### PR TITLE
Code for prompt monitoring of DoubleMu3_PFMET50 PFMHT60 path

### DIFF
--- a/Alignment/APEEstimation/macros/writeAPEsInASCII.C
+++ b/Alignment/APEEstimation/macros/writeAPEsInASCII.C
@@ -1,0 +1,196 @@
+////////////////////////////////////////////////////////////////////////////////////////
+///
+///  Write APEs in ASCII-file format
+///
+///  The ASCII file contains one row per module, where the first column
+///  lists the module id and the following 21 columns the diagonal and
+///  lower elements x11,x21,x22,x31,x32,x33,0... of the 6x6 covariance
+///  matrix, where the upper 3x3 sub-matrix contains the position APEs.
+///  The elements are stored in units of cm^2.
+///
+///
+///  Before first usage, create 'TrackerTree' that maps DetIDs with tracker
+///  structures by doing:
+///    cd $CMSSW_BASE/src/Alignment/TrackerAlignment
+///    mkdir hists
+///    cd test
+///    cmsRun trackerTreeGenerator_cfg.py
+///
+///
+///  This format is understood as input by
+///  Alignment/CommonAlignmentAlgorithm/python/ApeSettingAlgorithm_cfi.py
+///
+////////////////////////////////////////////////////////////////////////////////////////
+
+#include <exception>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+#include "TFile.h"
+#include "TString.h"
+#include "TTree.h"
+
+
+// APEs in mum, local [x,y,z]
+std::vector<double> apesBPXLayer1(3,0.);
+std::vector<double> apesBPXLayer2(3,0.);
+std::vector<double> apesBPXLayer3(3,0.);
+std::vector<double> apesBPXLayer4(3,0.);
+std::vector<double> apesFPX(3,0.);
+std::vector<double> apesTIB(3,0.);
+std::vector<double> apesTOB(3,0.);
+std::vector<double> apesTID(3,0.);
+std::vector<double> apesTEC(3,0.);
+
+const TString trackerTreeFileName = "../../TrackerAlignment/hists/TrackerTree.root";
+
+
+// Transform APE into covariance elements in cm^{2} units
+std::vector<double> transformIntoCovarianceMatrixElements(const std::vector<double>& apes) {
+  std::vector<double> cov(21,0.);
+  cov[0] = apes[0]*apes[0]*1E-8;
+  cov[2] = apes[1]*apes[1]*1E-8;
+  cov[5] = apes[2]*apes[2]*1E-8;
+
+  return cov;
+}
+
+
+void scaleAPEs(std::vector<double>& apes, const double scale) {
+  for(std::vector<double>::iterator it = apes.begin();
+      it != apes.end(); ++it) {
+    *it = (*it)*scale;
+  }
+}
+
+
+void writeAPEsInASCII(const TString& outName="ape.txt") {
+  // set APEs (in mum) for different subdetectors
+  apesBPXLayer1[0] = 500;
+  apesBPXLayer1[1] = 500;
+  apesBPXLayer1[2] = 500;
+  apesBPXLayer2[0] = 10;
+  apesBPXLayer2[1] = 40;
+  apesBPXLayer2[2] = 10;
+  apesBPXLayer3[0] = 10;
+  apesBPXLayer3[1] = 10;
+  apesBPXLayer3[2] = 10;
+  apesBPXLayer4[0] = 10;
+  apesBPXLayer4[1] = 10;
+  apesBPXLayer4[2] = 10;
+  
+  apesFPX[0] = 10;
+  apesFPX[1] = 10;
+  apesFPX[2] = 10;
+  
+  apesTIB[0] = 10;
+  apesTIB[1] = 10;
+  apesTIB[2] = 10;
+  
+  apesTOB[0] = 10;
+  apesTOB[1] = 10;
+  apesTOB[2] = 10;
+  
+  apesTID[0] = 20;
+  apesTID[1] = 20;
+  apesTID[2] = 20;
+  
+  apesTEC[0] = 20;
+  apesTEC[1] = 20;
+  apesTEC[2] = 20;
+
+  // scale APEs by
+  const double scale = 1.;
+  std::cout << "Scaling APEs by " << scale << std::endl;
+  scaleAPEs(apesBPXLayer1,scale);
+  scaleAPEs(apesBPXLayer2,scale);
+  scaleAPEs(apesBPXLayer3,scale);
+  scaleAPEs(apesBPXLayer4,scale);
+  scaleAPEs(apesFPX,scale);
+  scaleAPEs(apesTIB,scale);
+  scaleAPEs(apesTOB,scale);
+  scaleAPEs(apesTID,scale);
+  scaleAPEs(apesTEC,scale);
+
+  // transform into covariance elements
+  const std::vector<double> covBPXLayer1 = transformIntoCovarianceMatrixElements(apesBPXLayer1);
+  const std::vector<double> covBPXLayer2 = transformIntoCovarianceMatrixElements(apesBPXLayer2);
+  const std::vector<double> covBPXLayer3 = transformIntoCovarianceMatrixElements(apesBPXLayer3);
+  const std::vector<double> covBPXLayer4 = transformIntoCovarianceMatrixElements(apesBPXLayer4);
+  const std::vector<double> covFPX = transformIntoCovarianceMatrixElements(apesFPX);
+  const std::vector<double> covTIB = transformIntoCovarianceMatrixElements(apesTIB);
+  const std::vector<double> covTOB = transformIntoCovarianceMatrixElements(apesTOB);
+  const std::vector<double> covTID = transformIntoCovarianceMatrixElements(apesTID);
+  const std::vector<double> covTEC = transformIntoCovarianceMatrixElements(apesTEC);
+    
+  // open file with tracker-geometry info
+  TFile file(trackerTreeFileName,"READ");
+  if( !file.IsOpen() ) {
+    std::cerr << "\n\nERROR opening file '" << trackerTreeFileName << "'\n" << std::endl;
+    throw std::exception();
+  }
+
+  // get tree with geometry info
+  TTree* tree = 0;
+  const TString treeName = "TrackerTreeGenerator/TrackerTree/TrackerTree";
+  file.GetObject(treeName,tree);
+  if( tree == 0 ) {
+    std::cerr << "\n\nERROR reading tree '" << treeName << "' from file '" << trackerTreeFileName << "'\n" << std::endl;
+    throw std::exception();
+  }
+  
+  // tree variables
+  unsigned int theRawId = 0;
+  unsigned int theSubdetId = 0;
+  unsigned int theLayerId = 0;
+  tree->SetBranchAddress("RawId",&theRawId);
+  tree->SetBranchAddress("SubdetId",&theSubdetId);
+  tree->SetBranchAddress("Layer",&theLayerId);
+
+  // open the output file
+  std::ofstream apeSaveFile(outName.Data());
+
+  for(int iE = 0; iE < tree->GetEntries(); ++iE) {
+    tree->GetEntry(iE);
+    
+    // Set the APE according to the subdetector.
+    // The subdetector encoding in tree
+    // BPIX: 1
+    // FPIX: 2
+    // TIB:  3
+    // TID:  4
+    // TOB:  5
+    // TEC:  6
+    const std::vector<double>* cov = 0;
+    if(      theSubdetId == 1 ) {
+      if(      theLayerId == 1 ) cov = &covBPXLayer1;
+      else if( theLayerId == 2 ) cov = &covBPXLayer2;
+      else if( theLayerId == 3 ) cov = &covBPXLayer3;
+      else                       cov = &covBPXLayer4;
+    }
+    else if( theSubdetId == 2 ) cov = &covFPX;
+    else if( theSubdetId == 3 ) cov = &covTIB;
+    else if( theSubdetId == 4 ) cov = &covTID;
+    else if( theSubdetId == 5 ) cov = &covTOB;
+    else if( theSubdetId == 6 ) cov = &covTEC;
+    
+    // write APE to ASCII file
+    apeSaveFile << theRawId;
+    for(std::vector<double>::const_iterator it = cov->begin();
+	it != cov->end(); ++it) {
+      apeSaveFile << "  " << *it;
+    }
+    apeSaveFile << std::endl;
+
+  } // end of loop over tree (=modules)
+
+  apeSaveFile.close();
+  delete tree;
+  file.Close();
+  
+  std::cout << "Wrote APEs to '" << outName << "'" << std::endl;
+}
+
+
+

--- a/Alignment/APEEstimation/test/createTrackerAlignmentErrorExtendedRcd_cfg.py
+++ b/Alignment/APEEstimation/test/createTrackerAlignmentErrorExtendedRcd_cfg.py
@@ -1,0 +1,167 @@
+########################################################################################
+###
+###  Read and write APEs to and from database and ASCII files
+###
+###  The ASCII file contains one row per module, where the first column
+###  lists the module id and the following 21 columns the diagonal and
+###  lower elements x11,x21,x22,x31,x32,x33,0... of the 6x6 covariance
+###  matrix, where the upper 3x3 sub-matrix contains the position APEs.
+###  The elements are stored in units of cm^2.
+###
+########################################################################################
+
+
+
+###### Steering parameters #############################################################
+
+### specify the input APE
+#
+GT = "auto:phase1_2017_design"
+#
+# read the APE from database or from ASCII
+# True  : from database
+# False : from ASCII
+readAPEFromDB = False
+
+### specify APE input from database (only relevant if 'readAPEFromDB=True')
+#
+# specify run (to get proper IOV in IOV dependent databases)
+# for data payload only, "1" for MC
+readDBRun = 1
+#
+# False : APE from GT,
+# True  : APE from es_prefer statement
+readDBOverwriteGT = False
+#
+# info for es_prefer to overwrite APE info in GT
+# (only relevant if 'readDBOverwriteGT=True')
+readDBConnect = "frontier://FrontierProd/CMS_CONDITIONS"
+readDBTag     = "TrackerAlignmentErrorsExtended_Upgrade2017_design_v0"
+
+### specify APE input from ASCII (only relevant if 'readAPEFromDB=False')
+#
+# file name (relative to $CMSSW_BASE/src)
+readASCIIFile = "Alignment/APEEstimation/macros/ape.txt"
+#
+
+### specify APE output to ASCII file
+#
+saveAPEtoASCII = True
+saveASCIIFile = "apeDump.txt"
+
+### specify APE output to database file
+#
+saveAPEtoDB = True
+saveAPEFile = "APE_BPX-L1-Scenario_v0.db"
+saveAPETag  = "APEs"
+
+
+
+###### Main script #####################################################################
+
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("APEtoASCIIDump")
+
+# Load the conditions
+process.load('Configuration.Geometry.GeometryRecoDB_cff')
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag,GT)
+print "Using Global Tag:", process.GlobalTag.globaltag._value
+if readAPEFromDB and readDBOverwriteGT:
+    print "Overwriting APE payload with "+readDBTag
+    process.GlobalTag.toGet.append(
+        cms.PSet(
+            record = cms.string("TrackerAlignmentErrorExtendedRcd"),
+            tag = cms.string(readDBTag)
+            )
+        )
+
+
+### setup the alignmnet producer to read the APEs and dump them
+process.load("Alignment.CommonAlignmentProducer.AlignmentProducer_cff")
+from Alignment.CommonAlignmentAlgorithm.ApeSettingAlgorithm_cfi import ApeSettingAlgorithm
+#
+# general settings
+process.AlignmentProducer.algoConfig = ApeSettingAlgorithm.clone()
+process.AlignmentProducer.algoConfig.setComposites       = False
+process.AlignmentProducer.algoConfig.saveComposites      = False
+process.AlignmentProducer.algoConfig.readLocalNotGlobal  = False
+process.AlignmentProducer.algoConfig.readFullLocalMatrix = True
+process.AlignmentProducer.algoConfig.saveLocalNotGlobal  = False
+#
+# define how APEs are read: either from DB or from ASCII
+process.AlignmentProducer.applyDbAlignment            = readAPEFromDB
+process.AlignmentProducer.checkDbAlignmentValidity    = False # enable reading from tags with several IOVs
+process.AlignmentProducer.algoConfig.readApeFromASCII = not readAPEFromDB
+process.AlignmentProducer.algoConfig.apeASCIIReadFile = cms.FileInPath(readASCIIFile)
+#
+# define how APEs are written
+process.AlignmentProducer.saveApeToDB                 = saveAPEtoDB
+process.AlignmentProducer.algoConfig.saveApeToASCII   = saveAPEtoASCII
+process.AlignmentProducer.algoConfig.apeASCIISaveFile = saveASCIIFile
+
+
+### specify the output database file
+from CondCore.CondDB.CondDB_cfi import CondDB
+process.PoolDBOutputService = cms.Service(
+    "PoolDBOutputService",
+    CondDB.clone(connect = cms.string("sqlite_file:"+saveAPEFile)),
+    timetype = cms.untracked.string("runnumber"),
+    toPut = cms.VPSet(
+        cms.PSet(
+            record = cms.string("TrackerAlignmentErrorExtendedRcd"),
+            tag = cms.string(saveAPETag)
+            ),
+        )
+    )
+
+     
+process.MessageLogger = cms.Service(
+    "MessageLogger",
+    statistics = cms.untracked.vstring('cout', 'alignment'),
+    categories = cms.untracked.vstring('Alignment'),
+    cout = cms.untracked.PSet(
+        threshold = cms.untracked.string('DEBUG'),
+        noLineBreaks = cms.untracked.bool(True)
+        ),
+    alignment = cms.untracked.PSet(
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+            ),
+        noLineBreaks = cms.untracked.bool(True),
+        DEBUG = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+            ),
+        WARNING = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+            ),
+        ERROR = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+            ),
+        threshold = cms.untracked.string('INFO'),
+        Alignment = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+            )
+        ),
+    destinations = cms.untracked.vstring(
+        'cout',  ## .log automatically
+        'alignment')
+    )
+
+
+### speficy the source
+# 
+# process an empty source
+process.source = cms.Source(
+    "EmptySource",
+    firstRun = cms.untracked.uint32(readDBRun)
+    )
+#
+# need to run over 1 event
+# NB: will print an "MSG-e" saying no events to process. This can be ignored.
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+# We do not even need a path - producer is called anyway...

--- a/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalTrg_cff.py
+++ b/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalTrg_cff.py
@@ -4,6 +4,7 @@ import HLTrigger.HLTfilters.hltHighLevel_cfi
 ecalTrgHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
 #    eventSetupPathsKey='AlCa_EcalPhiSym*', # this is the HLT path that can be used                                                                                                          
      eventSetupPathsKey='EcalTrg',
+     throw = cms.bool( False ),
 )
 
 seqALCARECOEcalTrg = cms.Sequence(ecalTrgHLT)

--- a/CondCore/CondDB/src/IOVSchema.cc
+++ b/CondCore/CondDB/src/IOVSchema.cc
@@ -226,10 +226,15 @@ namespace cond {
 	q1.addCondition<INSERTION_TIME>( snapshotTime,"<=" );
       }
       q1.addCondition<SINCE>( end, "<=");
+      q1.addOrderClause<SINCE>();
+      q1.addOrderClause<INSERTION_TIME>( false );
+      size_t initialSize = iovs.size();
       for( auto row: q1 ){
-        iovs.push_back( row );
+	// starting from the second iov in the array, skip the rows with older timestamp
+	if( iovs.size()-initialSize && std::get<0>(iovs.back()) == std::get<0>(row) ) continue;
+	iovs.push_back( row );
       }
-      return iovs.size();
+      return iovs.size()-initialSize;
     }
 
     void IOV::Table::insertOne( const std::string& tag, 

--- a/Configuration/PyReleaseValidation/python/MatrixRunner.py
+++ b/Configuration/PyReleaseValidation/python/MatrixRunner.py
@@ -1,6 +1,4 @@
-
 import os, sys, time
-import random
 
 from Configuration.PyReleaseValidation.WorkFlow import WorkFlow
 from Configuration.PyReleaseValidation.WorkFlowRunner import WorkFlowRunner
@@ -56,8 +54,7 @@ class MatrixRunner(object):
             
     	    # make sure we don't run more than the allowed number of threads:
     	    while self.activeThreads() >= self.maxThreads:
-    	        time.sleep(10)
-                continue
+                time.sleep(1)
     	    
     	    print '\nPreparing to run %s %s' % (wf.numId, item)
             sys.stdout.flush()
@@ -65,7 +62,7 @@ class MatrixRunner(object):
     	    self.threadList.append(current)
     	    current.start()
             if not dryRun:
-                time.sleep(random.randint(1,5)) # try to avoid race cond by sleeping random amount of time [1,5] sec
+                time.sleep(0.5) # try to avoid race cond by sleeping 0.5 sec
 
     	# wait until all threads are finished
         while self.activeThreads() > 0:

--- a/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
+++ b/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
@@ -155,8 +155,9 @@ class WorkFlowRunner(Thread):
                 cmd+=closeCmd(istep,self.wf.nameId)            
                 retStep = 0
                 if istep>self.maxSteps:
-                   p = Popen("echo 'step%s:%s' >> %s/wf_steps.txt" % (istep, cmd, self.wfDir), shell=True)
-                   os.waitpid(p.pid, 0)[1]
+                   wf_stats = open("%s/wf_steps.txt" % self.wfDir,"a")
+                   wf_stats.write('step%s:%s\n' % (istep, cmd))
+                   wf_stats.close()
                 else: retStep = self.doCmd(cmd)
             
             self.retStep.append(retStep)

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1963,7 +1963,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
 
     upgradeStepDict['HARVESTFullGlobal'][k] = merge([{'-s': 'HARVESTING:@phase2Validation+@phase2+@miniAODValidation+@miniAODDQM'}, upgradeStepDict['HARVESTFull'][k]])
 
-    upgradeStepDict['ALCAFull'][k] = {'-s':'ALCA:TkAlMuonIsolated+TkAlMinBias+MuAlOverlaps+EcalESAlign+TkAlZMuMu+HcalCalHBHEMuonFilter+TkAlUpsilonMuMu+TkAlJpsiMuMu',
+    upgradeStepDict['ALCAFull'][k] = {'-s':'ALCA:TkAlMuonIsolated+TkAlMinBias+MuAlOverlaps+EcalESAlign+TkAlZMuMu+HcalCalHBHEMuonFilter+TkAlUpsilonMuMu+TkAlJpsiMuMu+SiStripCalMinBias',
                                       '--conditions':gt,
                                       '--datatier':'ALCARECO',
                                       '-n':'10',

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -19,6 +19,7 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 
+#include "DataFormats/Provenance/interface/EventRange.h"
 #include "DataFormats/CTPPSDigi/interface/TotemVFATStatus.h"
 #include "DataFormats/CTPPSDigi/interface/TotemFEDInfo.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
@@ -39,7 +40,7 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
   public:
     CTPPSDiamondDQMSource( const edm::ParameterSet& );
     virtual ~CTPPSDiamondDQMSource();
-  
+
   protected:
     void dqmBeginRun( const edm::Run&, const edm::EventSetup& ) override;
     void bookHistograms( DQMStore::IBooker&, const edm::Run&, const edm::EventSetup& ) override;
@@ -53,6 +54,7 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
     static const double SEC_PER_LUMI_SECTION;                   // Number of seconds per lumisection: used to compute hit rates in Hz
     static const int CHANNEL_OF_VFAT_CLOCK;                     // Channel ID of the VFAT that contains clock data
     static const double DISPLAY_RESOLUTION_FOR_HITS_MM;         // Bin width of histograms showing hits and tracks (in mm)
+    static const double INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
     static const double HPTDC_BIN_WIDTH_NS;                        // ns per HPTDC bin
     static const int CTPPS_NUM_OF_ARMS;
     static const int CTPPS_DIAMOND_STATION_ID;
@@ -73,6 +75,9 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
 
     bool excludeMultipleHits_;
     double minimumStripAngleForTomography_;
+    double maximumStripAngleForTomography_;
+    std::vector< std::pair<edm::EventRange, int> > runParameters_;
+    int centralOOT_;
     unsigned int verbosity_;
 
     /// plots related to the whole system
@@ -85,27 +90,29 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
     };
 
     GlobalPlots globalPlot_;
-    
+
     /// plots related to one Diamond detector package
     struct PotPlots
     {
-      MonitorElement* activity_per_bx = NULL, *activity_per_bx_short = NULL;
-      MonitorElement* activity_per_bx_plus1 = NULL, *activity_per_bx_short_plus1 = NULL;
-      MonitorElement* activity_per_bx_minus1 = NULL, *activity_per_bx_short_minus1 = NULL;
-      MonitorElement* activity_per_fedbx = NULL, *activity_per_fedbx_short = NULL;
+      MonitorElement* activity_per_bx = NULL;
+      MonitorElement* activity_per_bx_plus1 = NULL;
+      MonitorElement* activity_per_bx_minus1 = NULL;
 
       MonitorElement* hitDistribution2d = NULL;
       MonitorElement* hitDistribution2dOOT = NULL;
+      MonitorElement* hitDistribution2dOOT_le = NULL;
+      MonitorElement* hitDistribution2dOOT_te = NULL;
       MonitorElement* activePlanes = NULL;
 
       MonitorElement* trackDistribution = NULL;
       MonitorElement* trackDistributionOOT = NULL;
 
-      MonitorElement* stripTomographyAllFar = NULL, *stripTomographyAllNear = NULL;
-      MonitorElement* stripTomographyAllFar_plus1 = NULL, *stripTomographyAllNear_plus1 = NULL;
-      MonitorElement* stripTomographyAllFar_minus1 = NULL, *stripTomographyAllNear_minus1 = NULL;
+      MonitorElement* stripTomographyAllFar = NULL;
+      MonitorElement* stripTomographyAllFar_plus1 = NULL;
+      MonitorElement* stripTomographyAllFar_minus1 = NULL;
 
-      MonitorElement* leadingEdgeCumulativePot = NULL, *timeOverThresholdCumulativePot = NULL, *leadingTrailingCorrelationPot = NULL;
+      MonitorElement* leadingEdgeCumulative_both = NULL, *leadingEdgeCumulative_le = NULL;
+      MonitorElement* timeOverThresholdCumulativePot = NULL, *leadingTrailingCorrelationPot = NULL;
       MonitorElement* leadingWithoutTrailingCumulativePot = NULL;
 
       MonitorElement* ECCheck = NULL;
@@ -130,10 +137,8 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
       MonitorElement* digiProfileCumulativePerPlane = NULL;
       MonitorElement* hitProfile = NULL;
       MonitorElement* hit_multiplicity = NULL;
-      MonitorElement* threshold_voltage = NULL;
 
       MonitorElement* stripTomography_far = NULL;
-      MonitorElement* stripTomography_near = NULL;
 
       PlanePlots() {}
       PlanePlots( DQMStore::IBooker& ibooker, unsigned int id );
@@ -144,14 +149,16 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
     /// plots related to one Diamond channel
     struct ChannelPlots
     {
+      MonitorElement* activity_per_bx = NULL;
+      MonitorElement* activity_per_bx_plus1 = NULL;
+      MonitorElement* activity_per_bx_minus1 = NULL;
+
       MonitorElement* HPTDCErrorFlags = NULL;
-      MonitorElement* LeadingEdgeCumulativePerChannel = NULL;
+      MonitorElement* leadingEdgeCumulative_both = NULL, *leadingEdgeCumulative_le = NULL;
       MonitorElement* TimeOverThresholdCumulativePerChannel = NULL;
       MonitorElement* LeadingTrailingCorrelationPerChannel = NULL;
       MonitorElement* leadingWithoutTrailing = NULL;
-      MonitorElement* efficiency = NULL;
       MonitorElement* stripTomography_far = NULL;
-      MonitorElement* stripTomography_near = NULL;
       MonitorElement* hit_rate = NULL;
       MonitorElement* ECCheckPerChannel = NULL;
       unsigned long hitsCounterPerLumisection;
@@ -169,6 +176,7 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
 const double    CTPPSDiamondDQMSource::SEC_PER_LUMI_SECTION = 23.31;
 const int       CTPPSDiamondDQMSource::CHANNEL_OF_VFAT_CLOCK = 30;
 const double    CTPPSDiamondDQMSource::DISPLAY_RESOLUTION_FOR_HITS_MM = 0.1;
+const double    CTPPSDiamondDQMSource::INV_DISPLAY_RESOLUTION_FOR_HITS_MM = 1./DISPLAY_RESOLUTION_FOR_HITS_MM;
 const double    CTPPSDiamondDQMSource::HPTDC_BIN_WIDTH_NS = 25./1024;
 const int       CTPPSDiamondDQMSource::CTPPS_NUM_OF_ARMS = 2;
 const int       CTPPSDiamondDQMSource::CTPPS_DIAMOND_STATION_ID = 1;
@@ -209,36 +217,26 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
   CTPPSDiamondDetId( id ).rpName( title, CTPPSDiamondDetId::nFull );
 
   activity_per_bx = ibooker.book1D( "activity per BX", title+" activity per BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_bx_short = ibooker.book1D( "activity per BX (short)", title+" activity per BX (short);Event.BX", 102, -1.5, 100. + 0.5 );
-
   activity_per_bx_plus1 = ibooker.book1D( "activity per BX OOT +1", title+" activity per BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_bx_short_plus1 = ibooker.book1D( "activity per BX OOT +1 (short)", title+" activity per BX OOT +1 (short);Event.BX", 102, -1.5, 100. + 0.5 );
-
   activity_per_bx_minus1 = ibooker.book1D( "activity per BX OOT -1", title+" activity per BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_bx_short_minus1 = ibooker.book1D( "activity per BX OOT -1 (short)", title+" activity per BX OOT -1 (short);Event.BX", 102, -1.5, 100. + 0.5 );
 
-  activity_per_fedbx = ibooker.book1D( "activity per FED BX", title+" activity per FED BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_fedbx_short = ibooker.book1D( "activity per FED BX (short)", title+" activity per FED BX (short);Event.BX", 102, -1.5, 100. + 0.5 );
-
-  hitDistribution2d = ibooker.book2D( "hits in planes", title+" hits in planes;plane number;x (mm)", 10, -0.5, 4.5, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
-  hitDistribution2dOOT= ibooker.book2D( "hits with OOT in planes", title+" hits with OOT in planes;plane number + 0.25 OOT;x (mm)", 17, -0.25, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitDistribution2d = ibooker.book2D( "hits in planes", title+" hits in planes;plane number;x (mm)", 10, -0.5, 4.5, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitDistribution2dOOT= ibooker.book2D( "hits with OOT in planes", title+" hits with OOT in planes;plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitDistribution2dOOT_le= ibooker.book2D( "hits with OOT in planes (le only)", title+" hits with OOT in planes (le only);plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitDistribution2dOOT_te= ibooker.book2D( "hits with OOT in planes (te only)", title+" hits with OOT in planes (te only);plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   activePlanes = ibooker.book1D( "active planes", title+" active planes;number of active planes", 6, -0.5, 5.5 );
 
-  trackDistribution = ibooker.book1D( "tracks", title+" tracks;x (mm)", 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
-  trackDistributionOOT = ibooker.book2D( "tracks with OOT", title+" tracks with OOT;plane number;x (mm)", 9, -0.5, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  trackDistribution = ibooker.book1D( "tracks", title+" tracks;x (mm)", 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  trackDistributionOOT = ibooker.book2D( "tracks with OOT", title+" tracks with OOT;plane number;x (mm)", 9, -0.5, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
 
-  stripTomographyAllFar = ibooker.book2D( "tomography all far", title+" tomography with strips far (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
-  stripTomographyAllNear = ibooker.book2D( "tomography all near", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
+  stripTomographyAllFar = ibooker.book2D( "tomography all far", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
+  stripTomographyAllFar_plus1 = ibooker.book2D( "tomography all far OOT +1", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
+  stripTomographyAllFar_minus1 = ibooker.book2D( "tomography all far OOT -1", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
 
-  stripTomographyAllFar_plus1 = ibooker.book2D( "tomography all far OOT +1", title+" tomography with strips far (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
-  stripTomographyAllNear_plus1 = ibooker.book2D( "tomography all near OOT +1", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
-
-  stripTomographyAllFar_minus1 = ibooker.book2D( "tomography all far OOT -1", title+" tomography with strips far (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
-  stripTomographyAllNear_minus1 = ibooker.book2D( "tomography all near OOT -1", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );  
-
-  leadingEdgeCumulativePot = ibooker.book1D( "leading edge", title+" leading edge;leading edge (ns)", 125, -25, 100 );
-  timeOverThresholdCumulativePot = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 100, -50, 50 );
-  leadingTrailingCorrelationPot = ibooker.book2D( "leading trailing correlation", title+" leading trailing correlation;leading edge (ns);trailing edge (ns)", 201, -100, 100, 201, -100, 100 );
+  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge (le and te); leading edge (ns)", 125, 0, 125 );
+  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge (le only); leading edge (ns)", 125, 0, 125 );
+  timeOverThresholdCumulativePot = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 100, -100, 100 );
+  leadingTrailingCorrelationPot = ibooker.book2D( "leading trailing correlation", title+" leading trailing correlation;leading edge (ns);trailing edge (ns)", 100, 0, 100, 100, 0, 100 );
 
   leadingWithoutTrailingCumulativePot = ibooker.book1D( "leading edges without trailing", title+" leading edges without trailing;leading edges without trailing", 4, 0.5, 4.5 );
   leadingWithoutTrailingCumulativePot->getTH1F()->GetXaxis()->SetBinLabel( 1, "Nothing" );
@@ -255,10 +253,10 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
 
 
   ibooker.setCurrentFolder( path+"/clock/" );
-  clock_Digi1_le = ibooker.book1D( "clock1 leading edge", title+" clock1;leading edge (ns)", 1000, 0, 100 );
-  clock_Digi1_te = ibooker.book1D( "clock1 trailing edge", title+" clock1;trailing edge (ns)", 1000, 0, 100 );
-  clock_Digi3_le = ibooker.book1D( "clock3 leading edge", title+" clock3;leading edge (ns)", 1000, 0, 100 );
-  clock_Digi3_te = ibooker.book1D( "clock3 trailing edge", title+" clock3;trailing edge (ns)", 1000, 0, 100 );
+  clock_Digi1_le = ibooker.book1D( "clock1 leading edge", title+" clock1;leading edge (ns)", 125, 0, 125 );
+  clock_Digi1_te = ibooker.book1D( "clock1 trailing edge", title+" clock1;trailing edge (ns)", 125, 0, 125 );
+  clock_Digi3_le = ibooker.book1D( "clock3 leading edge", title+" clock3;leading edge (ns)", 1000, 0, 125 );
+  clock_Digi3_te = ibooker.book1D( "clock3 trailing edge", title+" clock3;trailing edge (ns)", 125, 0, 125 );
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -272,13 +270,10 @@ CTPPSDiamondDQMSource::PlanePlots::PlanePlots( DQMStore::IBooker& ibooker, unsig
   CTPPSDiamondDetId( id ).planeName( title, CTPPSDiamondDetId::nFull );
 
   digiProfileCumulativePerPlane = ibooker.book1D( "digi profile", title+" digi profile; ch number", 12, -0.5, 11.5 );
-  hitProfile = ibooker.book1D( "hit profile", title+" hit profile;x (mm)", 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitProfile = ibooker.book1D( "hit profile", title+" hit profile;x (mm)", 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   hit_multiplicity = ibooker.book1D( "channels per plane", title+" channels per plane; ch per plane", 13, -0.5, 12.5 );
 
-  threshold_voltage = ibooker.book2D( "threshold I2C", title+" threshold I2C; channel; value", 12, -0.5, 11.5, 512, 0, 512 );
-
-  stripTomography_far = ibooker.book2D( "tomography far", title+" tomography with strips far;x + 50 OOT (mm);y (mm)", 50, 0, 50, 150, -50, 100 );
-  stripTomography_near = ibooker.book2D( "tomography near", title+" tomography with strips near;x + 50 OOT (mm);y (mm)", 50, 0, 50, 150, -50, 100 );
+  stripTomography_far = ibooker.book2D( "tomography far", title+" tomography with strips far;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -297,21 +292,25 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, u
   leadingWithoutTrailing->getTH1F()->GetXaxis()->SetBinLabel( 3, "Trailer only" );
   leadingWithoutTrailing->getTH1F()->GetXaxis()->SetBinLabel( 4, "Full" );
 
+  activity_per_bx = ibooker.book1D( "activity per BX", title+" activity per BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
+  activity_per_bx_plus1 = ibooker.book1D( "activity per BX OOT +1", title+" activity per BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
+  activity_per_bx_minus1 = ibooker.book1D( "activity per BX OOT -1", title+" activity per BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
+
   HPTDCErrorFlags = ibooker.book1D( "hptdc_Errors", title+" HPTDC Errors", 16, -0.5, 16.5 );
   for ( unsigned short error_index=1; error_index<16; ++error_index )
     HPTDCErrorFlags->getTH1F()->GetXaxis()->SetBinLabel( error_index, HPTDCErrorFlags::getHPTDCErrorName( error_index-1 ).c_str() );
   HPTDCErrorFlags->getTH1F()->GetXaxis()->SetBinLabel( 16, "MH" );
 
-  LeadingEdgeCumulativePerChannel = ibooker.book1D( "leading edge", title+" leading edge; leading edge (ns)", 200, -100, 100 );
-  TimeOverThresholdCumulativePerChannel = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 200, -100, 100 );
-  LeadingTrailingCorrelationPerChannel = ibooker.book2D( "leading trailing correlation", title+" leading trailing correlation;leading edge (ns);trailing edge (ns)", 200, -100, 100, 200, -100, 100 );
+  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge; leading edge (ns)", 100, 0, 200 );
+  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge; leading edge (ns)", 200, 0, 200 );
+  TimeOverThresholdCumulativePerChannel = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 100, -100, 100 );
+  LeadingTrailingCorrelationPerChannel = ibooker.book2D( "leading trailing correlation", title+" leading trailing correlation;leading edge (ns);trailing edge (ns)", 100, 0, 100, 100, 0, 100 );
 
   ECCheckPerChannel = ibooker.book1D("optorxEC(8bit) - vfatEC vs optorxEC", title+" EC Error;optorxEC-vfatEC", 512, -256, 256 );
 
-  stripTomography_far = ibooker.book2D( "tomography far", "tomography with strips far;x + 50 OOT (mm);y (mm)", 200, -50, 150, 150, -50, 100 );
-  stripTomography_near = ibooker.book2D( "tomography near", "tomography with strips near;x + 50 OOT (mm);y (mm)", 200, -50, 150, 150, -50, 100 );
-  
-  hit_rate = ibooker.book1D( "hit rate", title+"hit rate;rate (Hz)", 1000, 0, 100 );
+  stripTomography_far = ibooker.book2D( "tomography far", "tomography with strips far;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
+
+  hit_rate = ibooker.book1D( "hit rate", title+"hit rate;rate (Hz)", 10, 0, 100 );
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -325,9 +324,15 @@ CTPPSDiamondDQMSource::CTPPSDiamondDQMSource( const edm::ParameterSet& ps ) :
   tokenFEDInfo_     ( consumes< std::vector<TotemFEDInfo> >                ( ps.getParameter<edm::InputTag>( "tagFEDInfo" ) ) ),
   excludeMultipleHits_           ( ps.getParameter<bool>( "excludeMultipleHits" ) ),
   minimumStripAngleForTomography_( ps.getParameter<double>( "minimumStripAngleForTomography" ) ),
+  maximumStripAngleForTomography_( ps.getParameter<double>( "maximumStripAngleForTomography" ) ),
+  centralOOT_( -999 ),
   verbosity_                     ( ps.getUntrackedParameter<unsigned int>( "verbosity", 0 ) ),
   EC_difference_56_( -500 ), EC_difference_45_( -500 )
-{}
+{
+  for ( const auto& pset : ps.getParameter< std::vector<edm::ParameterSet> >( "offsetsOOT" ) ) {
+    runParameters_.emplace_back( std::make_pair( pset.getParameter<edm::EventRange>( "validityRange" ), pset.getParameter<int>( "centralOOT" ) ) );
+  }
+}
 
 //----------------------------------------------------------------------------------------------------
 
@@ -337,8 +342,16 @@ CTPPSDiamondDQMSource::~CTPPSDiamondDQMSource()
 //----------------------------------------------------------------------------------------------------
 
 void
-CTPPSDiamondDQMSource::dqmBeginRun( const edm::Run&, const edm::EventSetup& )
-{}
+CTPPSDiamondDQMSource::dqmBeginRun( const edm::Run& iRun, const edm::EventSetup& )
+{
+  centralOOT_ = -999;
+  for ( const auto& oot : runParameters_ ) {
+    if ( edm::contains( oot.first, edm::EventID( iRun.run(), 0, 1 ) ) ) {
+      centralOOT_ = oot.second; break;
+    }
+  }
+}
+
 
 //----------------------------------------------------------------------------------------------------
 
@@ -347,7 +360,7 @@ CTPPSDiamondDQMSource::bookHistograms( DQMStore::IBooker& ibooker, const edm::Ru
 {
   ibooker.cd();
   ibooker.setCurrentFolder( "CTPPS" );
-  
+
   globalPlot_= GlobalPlots( ibooker );
 
   for ( unsigned short arm = 0; arm < CTPPS_NUM_OF_ARMS; ++arm ) {
@@ -423,11 +436,13 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
   //------------------------------
   // RP Plots
   //------------------------------  
-  
+
+  //   if (event.bunchCrossing() > 100) return;
+
   //------------------------------
   // Correlation Plots
   //------------------------------
-  
+
   for ( const auto& ds1 : *stripTracks ) {
     for ( const auto& tr1 : ds1 ) {
       if ( ! tr1.isValid() )  continue;
@@ -456,7 +471,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       for ( const auto& ds2 : *diamondLocalTracks ) {
         for ( const auto& tr2 : ds2 ) {
           if ( ! tr2.isValid() ) continue;
-          if ( tr2.getOOTIndex() != 1 ) continue;
+          if ( centralOOT_ != -999 && tr2.getOOTIndex() != centralOOT_ ) continue;
           if ( excludeMultipleHits_ && tr2.getMultipleHits() > 0 ) continue;
 
           CTPPSDetId diamId2( ds2.detId() );
@@ -474,7 +489,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
     for ( const auto& tr1 : ds1 ) {
       if ( ! tr1.isValid() ) continue;
       if ( excludeMultipleHits_ && tr1.getMultipleHits() > 0 ) continue;
-      if ( tr1.getOOTIndex() != 1 ) continue;
+      if ( centralOOT_ != -999 && tr1.getOOTIndex() != centralOOT_ ) continue;
 
       CTPPSDetId diamId1( ds1.detId() );
       unsigned int arm1 = diamId1.arm();
@@ -485,7 +500,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         for ( const auto& tr2 : ds2 ) {
           if ( ! tr2.isValid() ) continue;
           if ( excludeMultipleHits_ && tr2.getMultipleHits() > 0 ) continue;
-          if ( tr2.getOOTIndex() != 1 ) continue;
+          if ( centralOOT_ != -999 && tr2.getOOTIndex() != centralOOT_ ) continue;
 
           CTPPSDetId diamId2( ds2.detId() );
           unsigned int arm2 = diamId2.arm();
@@ -504,22 +519,13 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
     for ( const auto& digi : digis ) {
       detId_pot.setPlane( 0 );
       detId_pot.setChannel( 0 );
+      if ( detId.channel() == CHANNEL_OF_VFAT_CLOCK ) continue;
       if ( potPlots_.find( detId_pot ) == potPlots_.end() ) continue;
       //Leading without trailing investigation
       if      ( digi.getLeadingEdge() == 0 && digi.getTrailingEdge() == 0 ) potPlots_[detId_pot].leadingWithoutTrailingCumulativePot->Fill( 1 );
       else if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() == 0 ) potPlots_[detId_pot].leadingWithoutTrailingCumulativePot->Fill( 2 );
       else if ( digi.getLeadingEdge() == 0 && digi.getTrailingEdge() != 0 ) potPlots_[detId_pot].leadingWithoutTrailingCumulativePot->Fill( 3 );
       else if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() != 0 ) potPlots_[detId_pot].leadingWithoutTrailingCumulativePot->Fill( 4 );
-
-      if ( digi.getLeadingEdge() != 0 ) {
-        // FED BX monitoring (for MINIDAQ)
-        for ( const auto& fit : *fedInfo ) {
-          if ( ( detId.arm() == 1 && fit.getFEDId() == CTPPS_FED_ID_56 ) || ( detId.arm() == 0 && fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
-            potPlots_[detId_pot].activity_per_fedbx->Fill( fit.getBX() );
-            potPlots_[detId_pot].activity_per_fedbx_short->Fill( fit.getBX() );
-          }
-        }
-      }
 
       // HPTDC Errors
       const HPTDCErrorFlags hptdcErrors = digi.getHPTDCErrorFlags();
@@ -546,20 +552,22 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_56_ ) && ( static_cast<uint8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
             EC_difference_56_ = static_cast<int>( optorx.getLV1() & 0xFF )-( static_cast<unsigned int>( status.getEC() ) & 0xFF );
           if ( EC_difference_56_ != 1 && EC_difference_56_ != -500 && EC_difference_56_ < 128 && EC_difference_56_ > -128 )
-            if (verbosity_) edm::LogProblem("CTPPSDiamondDQMSource")  << "FED " << CTPPS_FED_ID_56 << ": ECError at EV: 0x"<< std::hex << optorx.getLV1()
-                                                                      << "\t\tVFAT EC: 0x"<< static_cast<unsigned int>( status.getEC() )
-                                                                      << "\twith ID: " << std::dec << detId
-                                                                      << "\tdiff: " <<  EC_difference_56_;
+            if (verbosity_)
+              edm::LogProblem("CTPPSDiamondDQMSource")  << "FED " << CTPPS_FED_ID_56 << ": ECError at EV: 0x"<< std::hex << optorx.getLV1()
+                << "\t\tVFAT EC: 0x"<< static_cast<unsigned int>( status.getEC() )
+                << "\twith ID: " << std::dec << detId
+                << "\tdiff: " <<  EC_difference_56_;
         }
         else if ( detId.arm() == 0 && optorx.getFEDId()== CTPPS_FED_ID_45 ) {
           potPlots_[detId_pot].ECCheck->Fill((int)((optorx.getLV1()& 0xFF)-status.getEC()) & 0xFF);
           if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_45_ ) && ( static_cast<uint8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
             EC_difference_45_ = static_cast<int>( optorx.getLV1() & 0xFF )-( static_cast<unsigned int>( status.getEC() ) & 0xFF );
           if ( EC_difference_45_ != 1 && EC_difference_45_ != -500 && EC_difference_45_ < 128 && EC_difference_45_ > -128 )
-            if (verbosity_) edm::LogProblem("CTPPSDiamondDQMSource")  << "FED " << CTPPS_FED_ID_45 << ": ECError at EV: 0x"<< std::hex << optorx.getLV1()
-                                                                      << "\t\tVFAT EC: 0x"<< static_cast<unsigned int>( status.getEC() )
-                                                                      << "\twith ID: " << std::dec << detId
-                                                                      << "\tdiff: " <<  EC_difference_45_;
+            if (verbosity_)
+              edm::LogProblem("CTPPSDiamondDQMSource")  << "FED " << CTPPS_FED_ID_45 << ": ECError at EV: 0x"<< std::hex << optorx.getLV1()
+                << "\t\tVFAT EC: 0x"<< static_cast<unsigned int>( status.getEC() )
+                << "\twith ID: " << std::dec << detId
+                << "\tdiff: " <<  EC_difference_45_;
         }
       }
     }
@@ -582,48 +590,76 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
 
       float UFSDShift = 0.0;
       if ( rechit.getYWidth() < 3 ) UFSDShift = 0.5;  // Display trick for UFSD that have 2 pixels with same X
-        
-      TH2F *hitHistoTmp = potPlots_[detId_pot].hitDistribution2d->getTH2F();
-      TAxis *hitHistoTmpYAxis = hitHistoTmp->GetYaxis();
-      int startBin = hitHistoTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
-      int numOfBins = rechit.getXWidth()/DISPLAY_RESOLUTION_FOR_HITS_MM;
-      for ( int i=0; i<numOfBins; ++i) {
-        hitHistoTmp->Fill( detId.plane(), hitHistoTmpYAxis->GetBinCenter(startBin+i) + UFSDShift );
-      }
-      
-      TH2F *hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT->getTH2F();
-      TAxis *hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
-      startBin = hitHistoOOTTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
-      numOfBins = rechit.getXWidth()/DISPLAY_RESOLUTION_FOR_HITS_MM;
-      for ( int i=0; i<numOfBins; ++i) {
-        hitHistoOOTTmp->Fill( detId.plane() + 0.25 * rechit.getOOTIndex(), hitHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
+
+      if ( rechit.getToT() != 0 && centralOOT_ != -999 && rechit.getOOTIndex() == centralOOT_ ) {
+        TH2F *hitHistoTmp = potPlots_[detId_pot].hitDistribution2d->getTH2F();
+        TAxis *hitHistoTmpYAxis = hitHistoTmp->GetYaxis();
+        int startBin = hitHistoTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
+        int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
+        for ( int i=0; i<numOfBins; ++i) {
+          hitHistoTmp->Fill( detId.plane(), hitHistoTmpYAxis->GetBinCenter(startBin+i) + UFSDShift );
+        }
       }
 
-      potPlots_[detId_pot].leadingEdgeCumulativePot->Fill( rechit.getT() + 25*rechit.getOOTIndex() );
-      potPlots_[detId_pot].timeOverThresholdCumulativePot->Fill( rechit.getToT() );
-      potPlots_[detId_pot].leadingTrailingCorrelationPot->Fill( rechit.getT()+ 25*rechit.getOOTIndex() , rechit.getT() + rechit.getToT() + 25*rechit.getOOTIndex()  );
+      if ( rechit.getToT() != 0 ) {
+        // Both
+        potPlots_[detId_pot].leadingEdgeCumulative_both->Fill( rechit.getT() + 25*rechit.getOOTIndex() );
+        potPlots_[detId_pot].timeOverThresholdCumulativePot->Fill( rechit.getToT() );
 
-      switch ( rechit.getOOTIndex() ) {
-        case 0: {
-          potPlots_[detId_pot].activity_per_bx_minus1->Fill( event.bunchCrossing() );
-          potPlots_[detId_pot].activity_per_bx_short_minus1->Fill( event.bunchCrossing() );
-        } break;
-        case 1: {
-          potPlots_[detId_pot].activity_per_bx->Fill( event.bunchCrossing() );
-          potPlots_[detId_pot].activity_per_bx_short->Fill( event.bunchCrossing() );
-        } break;
-        case 2: {
-          potPlots_[detId_pot].activity_per_bx_plus1->Fill( event.bunchCrossing() );
-          potPlots_[detId_pot].activity_per_bx_short_plus1->Fill( event.bunchCrossing() );
-        } break;
-      }      
+        TH2F *hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT->getTH2F();
+        TAxis *hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
+        int startBin = hitHistoOOTTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
+        int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
+        for ( int i=0; i<numOfBins; ++i) {
+          hitHistoOOTTmp->Fill( detId.plane() + 0.1 * rechit.getOOTIndex(), hitHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
+        }
+      }
+      else {
+        if ( rechit.getT() == 0 ) {
+          // Only trailing
+          TH2F *hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT_te->getTH2F();
+          TAxis *hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
+          int startBin = hitHistoOOTTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
+          int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
+          for ( int i=0; i<numOfBins; ++i) {
+            hitHistoOOTTmp->Fill( detId.plane() + 0.1 * rechit.getOOTIndex(), hitHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
+          }
+        }
+        else {
+          // Only leading
+          potPlots_[detId_pot].leadingEdgeCumulative_le->Fill( rechit.getT() + 25*rechit.getOOTIndex() );
+
+          TH2F *hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT_le->getTH2F();
+          TAxis *hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
+          int startBin = hitHistoOOTTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
+          int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
+          for ( int i=0; i<numOfBins; ++i) {
+            hitHistoOOTTmp->Fill( detId.plane() + 0.1 * rechit.getOOTIndex(), hitHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
+          }
+        }
+      }
+
+      if ( rechit.getToT() != 0 ) {
+        switch ( rechit.getOOTIndex() - ( ( centralOOT_ != -999 ) ? centralOOT_ : 0 ) ) {
+          case -1:
+            potPlots_[detId_pot].activity_per_bx_minus1->Fill( event.bunchCrossing() );
+            break;
+          case 0:
+            potPlots_[detId_pot].activity_per_bx->Fill( event.bunchCrossing() );
+            break;
+          case 1:
+            potPlots_[detId_pot].activity_per_bx_plus1->Fill( event.bunchCrossing() );
+            break;
+        }
+
+      } // End if (complete hits)
     }
   }
-  
+
   for ( const auto& plt : potPlots_ ) {
     plt.second.activePlanes->Fill( planes[plt.first].size() );
   }
-  
+
   // Using CTPPSDiamondLocalTrack
   for ( const auto& tracks : *diamondLocalTracks ) {
     CTPPSDiamondDetId detId_pot( tracks.detId() );
@@ -639,22 +675,22 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       TH2F *trackHistoOOTTmp = potPlots_[detId_pot].trackDistributionOOT->getTH2F();
       TAxis *trackHistoOOTTmpYAxis = trackHistoOOTTmp->GetYaxis();
       int startBin = trackHistoOOTTmpYAxis->FindBin( track.getX0() - track.getX0Sigma() );
-      int numOfBins = 2*track.getX0Sigma()/DISPLAY_RESOLUTION_FOR_HITS_MM;
+      int numOfBins = 2*track.getX0Sigma()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
       for ( int i=0; i<numOfBins; ++i) {
         trackHistoOOTTmp->Fill( track.getOOTIndex(), trackHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
       }
-      
-      if ( track.getOOTIndex() == 1 ) {
+
+      if ( centralOOT_ != -999 && track.getOOTIndex() == centralOOT_ ) {
         TH1F *trackHistoInTimeTmp = potPlots_[detId_pot].trackDistribution->getTH1F();
         int startBin = trackHistoInTimeTmp->FindBin( track.getX0() - track.getX0Sigma() );
-        int numOfBins = 2*track.getX0Sigma()/DISPLAY_RESOLUTION_FOR_HITS_MM;
+        int numOfBins = 2*track.getX0Sigma()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for ( int i=0; i<numOfBins; ++i) {
           trackHistoInTimeTmp->Fill( trackHistoInTimeTmp->GetBinCenter(startBin+i) );
         }
       }
     }
   }
-  
+
   // Tomography of diamonds using strips
   for ( const auto& rechits : *diamondRecHits ) {
     CTPPSDiamondDetId detId_pot( rechits.detId() );
@@ -664,6 +700,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
 
     for ( const auto& rechit : rechits ) {
       if ( excludeMultipleHits_ && rechit.getMultipleHits() > 0 ) continue;
+      if ( rechit.getToT() == 0 ) continue;
       if ( !stripTracks.isValid() ) continue;
       if ( potPlots_.find( detId_pot ) == potPlots_.end() ) continue;
 
@@ -672,30 +709,18 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         for ( const auto& striplt : ds ) {
           if ( !striplt.isValid() ) continue;
           if ( stripId.arm() != detId_pot.arm() ) continue;
-          if ( striplt.getTx() > minimumStripAngleForTomography_ || striplt.getTy() > minimumStripAngleForTomography_) continue; 
+          if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
+          if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
           if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
-            switch ( rechit.getOOTIndex() ) {
+            switch ( rechit.getOOTIndex() - ( ( centralOOT_ != -999 ) ? centralOOT_ : 0 ) ) {
+              case -1: {
+                potPlots_[detId_pot].stripTomographyAllFar_minus1->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
+              } break;
               case 0: {
-                potPlots_[detId_pot].stripTomographyAllFar_minus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+                potPlots_[detId_pot].stripTomographyAllFar->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
               } break;
               case 1: {
-                potPlots_[detId_pot].stripTomographyAllFar->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
-              } break;
-              case 2: {
-                potPlots_[detId_pot].stripTomographyAllFar_plus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
-              } break;
-            }
-          }
-          else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
-            switch ( rechit.getOOTIndex() ) {
-              case 0: {
-                potPlots_[detId_pot].stripTomographyAllNear_minus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
-              } break;
-              case 1: {
-                potPlots_[detId_pot].stripTomographyAllNear->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
-              } break;
-              case 2: {
-                potPlots_[detId_pot].stripTomographyAllNear_plus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+                potPlots_[detId_pot].stripTomographyAllFar_plus1->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
               } break;
             }
           }
@@ -740,9 +765,8 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
     CTPPSDiamondDetId detId_plane( digis.detId() );
     for ( const auto& digi : digis ) {
       detId_plane.setChannel( 0 );
+      if ( detId.channel() == CHANNEL_OF_VFAT_CLOCK ) continue;
       if ( planePlots_.find( detId_plane ) == planePlots_.end() ) continue;
-
-      planePlots_[detId_plane].threshold_voltage->Fill( detId.channel(), digi.getThresholdVoltage() );
 
       if ( digi.getLeadingEdge() != 0 ) {
         planePlots_[detId_plane].digiProfileCumulativePerPlane->Fill( detId.channel() );
@@ -755,19 +779,22 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
   for ( const auto& plt : channelsPerPlane ) {
     planePlots_[plt.first].hit_multiplicity->Fill( plt.second );
   }
-  
+
   // Using CTPPSDiamondRecHit
   for ( const auto& rechits : *diamondRecHits ) {
     CTPPSDiamondDetId detId_plane( rechits.detId() );
     detId_plane.setChannel( 0 );
     for ( const auto& rechit : rechits ) {
       if ( excludeMultipleHits_ && rechit.getMultipleHits() > 0 ) continue;
+      if ( rechit.getToT() == 0 ) continue;
       if ( planePlots_.find( detId_plane ) != planePlots_.end() ) {
-        TH1F *hitHistoTmp = planePlots_[detId_plane].hitProfile->getTH1F();
-        int startBin = hitHistoTmp->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
-        int numOfBins = rechit.getXWidth()/DISPLAY_RESOLUTION_FOR_HITS_MM;
-        for ( int i=0; i<numOfBins; ++i) {
-          if ( rechit.getOOTIndex() == 1 ) hitHistoTmp->Fill( hitHistoTmp->GetBinCenter(startBin+i) );
+        if ( centralOOT_ != -999 && rechit.getOOTIndex() == centralOOT_ ) {
+          TH1F *hitHistoTmp = planePlots_[detId_plane].hitProfile->getTH1F();
+          int startBin = hitHistoTmp->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
+          int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
+          for ( int i=0; i<numOfBins; ++i) {
+            hitHistoTmp->Fill( hitHistoTmp->GetBinCenter(startBin+i) );
+          }
         }
       }
     }
@@ -779,20 +806,19 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
     detId_plane.setChannel( 0 );
     for ( const auto& rechit : rechits ) {
       if ( excludeMultipleHits_ && rechit.getMultipleHits() > 0 ) continue;
+      if ( rechit.getToT() == 0 ) continue;
       if ( !stripTracks.isValid() ) continue;
       if (planePlots_.find(detId_plane) == planePlots_.end()) continue;
-      
+
       for ( const auto& ds : *stripTracks ) {
         const CTPPSDetId stripId(ds.detId());
         for ( const auto& striplt : ds ) {
           if (! striplt.isValid()) continue;
           if ( stripId.arm() != detId_plane.arm() ) continue;
-          if ( striplt.getTx() > minimumStripAngleForTomography_ || striplt.getTy() > minimumStripAngleForTomography_ ) continue;
+          if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
+          if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
           if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
-            planePlots_[detId_plane].stripTomography_far->Fill( striplt.getX0(), striplt.getY0() + 50*rechit.getOOTIndex() );
-          }
-          else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
-            planePlots_[detId_plane].stripTomography_near->Fill( striplt.getX0(), striplt.getY0() + 50*rechit.getOOTIndex() );
+            planePlots_[detId_plane].stripTomography_far->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - ( ( centralOOT_ != -999 ) ? centralOOT_ : 0 ) +1), striplt.getY0() );
           }
         }
       }
@@ -821,6 +847,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
   for ( const auto& digis : *diamondDigis ) {
     const CTPPSDiamondDetId detId( digis.detId() );
     for ( const auto& digi : digis ) {
+      if ( detId.channel() == CHANNEL_OF_VFAT_CLOCK ) continue;
       if ( channelPlots_.find( detId ) != channelPlots_.end() ) {
         // HPTDC Errors
         const HPTDCErrorFlags hptdcErrors = digi.getHPTDCErrorFlags();
@@ -836,21 +863,39 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       }
     }
   }
-  
+
   // Using CTPPSDiamondRecHit
   for ( const auto& rechits : *diamondRecHits ) {
     CTPPSDiamondDetId detId( rechits.detId() );
     for ( const auto& rechit : rechits ) {
       if ( excludeMultipleHits_ && rechit.getMultipleHits() > 0 ) continue;
       if ( channelPlots_.find( detId ) != channelPlots_.end() ) {
-        channelPlots_[detId].LeadingEdgeCumulativePerChannel->Fill( rechit.getT() + 25*rechit.getOOTIndex() );
-        channelPlots_[detId].TimeOverThresholdCumulativePerChannel->Fill( rechit.getToT() );
+        if ( rechit.getToT() != 0 ) {
+          channelPlots_[detId].leadingEdgeCumulative_both->Fill( rechit.getT() + 25*rechit.getOOTIndex() );
+          channelPlots_[detId].TimeOverThresholdCumulativePerChannel->Fill( rechit.getToT() );
+        }
+        else if ( rechit.getT() != 0 ) channelPlots_[detId].leadingEdgeCumulative_le->Fill( rechit.getT() + 25*rechit.getOOTIndex() );
         channelPlots_[detId].LeadingTrailingCorrelationPerChannel->Fill( rechit.getT() + 25*rechit.getOOTIndex(), rechit.getT() + 25*rechit.getOOTIndex() + rechit.getToT() );
         ++(channelPlots_[detId].hitsCounterPerLumisection);
       }
+
+      if ( rechit.getToT() != 0 ) {
+        switch ( rechit.getOOTIndex() - ( ( centralOOT_ != -999 ) ? centralOOT_ : 0 ) ) {
+          case -1: {
+            channelPlots_[detId].activity_per_bx_minus1->Fill( event.bunchCrossing() );
+          } break;
+          case 0: {
+            channelPlots_[detId].activity_per_bx->Fill( event.bunchCrossing() );
+          } break;
+          case 1: {
+            channelPlots_[detId].activity_per_bx_plus1->Fill( event.bunchCrossing() );
+          } break;
+        }
+      }
     }
+
   }
-  
+
   // Tomography of diamonds using strips
   for ( const auto& rechits : *diamondRecHits ) {
     const CTPPSDiamondDetId detId( rechits.detId() );
@@ -863,19 +908,16 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
             CTPPSDetId stripId(ds.detId());
             if ( !striplt.isValid() ) continue;
             if ( stripId.arm() != detId.arm() ) continue;
-            if ( striplt.getTx() > minimumStripAngleForTomography_ || striplt.getTy() > minimumStripAngleForTomography_ ) continue;
+            if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
+            if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
             if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
-              channelPlots_[detId].stripTomography_far->Fill( striplt.getX0(), striplt.getY0() + 50*( rechit.getOOTIndex()-1 ) );
-            }
-            else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
-              channelPlots_[detId].stripTomography_near->Fill( striplt.getX0(), striplt.getY0() + 50*( rechit.getOOTIndex()-1 ) );
+              channelPlots_[detId].stripTomography_far->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - ( ( centralOOT_ != -999 ) ? centralOOT_ : 0 ) +1), striplt.getY0() );
             }
           }
         }
       }
     }
   }
-  
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -73,6 +73,7 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
 
     bool excludeMultipleHits_;
     double minimumStripAngleForTomography_;
+    double maximumStripAngleForTomography_;
     int centralOOT_;
     unsigned int verbosity_;
 
@@ -93,9 +94,9 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
       MonitorElement* activity_per_bx = NULL;
       MonitorElement* activity_per_bx_plus1 = NULL;
       MonitorElement* activity_per_bx_minus1 = NULL;
-      MonitorElement* activity_per_fedbx = NULL;
-      MonitorElement* activity_per_fedbx_plus1 = NULL;
-      MonitorElement* activity_per_fedbx_minus1 = NULL;
+//       MonitorElement* activity_per_fedbx = NULL;
+//       MonitorElement* activity_per_fedbx_plus1 = NULL;
+//       MonitorElement* activity_per_fedbx_minus1 = NULL;
 
       MonitorElement* hitDistribution2d = NULL;
       MonitorElement* hitDistribution2dOOT = NULL;
@@ -106,9 +107,12 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
       MonitorElement* trackDistribution = NULL;
       MonitorElement* trackDistributionOOT = NULL;
 
-      MonitorElement* stripTomographyAllFar = NULL, *stripTomographyAllNear = NULL;
-      MonitorElement* stripTomographyAllFar_plus1 = NULL, *stripTomographyAllNear_plus1 = NULL;
-      MonitorElement* stripTomographyAllFar_minus1 = NULL, *stripTomographyAllNear_minus1 = NULL;
+      MonitorElement* stripTomographyAllFar = NULL;
+      MonitorElement* stripTomographyAllFar_plus1 = NULL;
+      MonitorElement* stripTomographyAllFar_minus1 = NULL;
+//       MonitorElement* stripTomographyAllNear = NULL;
+//       MonitorElement* stripTomographyAllNear_plus1 = NULL;
+//       MonitorElement* stripTomographyAllNear_minus1 = NULL;
 
       MonitorElement* leadingEdgeCumulative_both = NULL, *leadingEdgeCumulative_le = NULL;
       MonitorElement* timeOverThresholdCumulativePot = NULL, *leadingTrailingCorrelationPot = NULL;
@@ -136,10 +140,10 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
       MonitorElement* digiProfileCumulativePerPlane = NULL;
       MonitorElement* hitProfile = NULL;
       MonitorElement* hit_multiplicity = NULL;
-      MonitorElement* threshold_voltage = NULL;
+//       MonitorElement* threshold_voltage = NULL;
 
       MonitorElement* stripTomography_far = NULL;
-      MonitorElement* stripTomography_near = NULL;
+//       MonitorElement* stripTomography_near = NULL;
 
       PlanePlots() {}
       PlanePlots( DQMStore::IBooker& ibooker, unsigned int id );
@@ -153,18 +157,18 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
       MonitorElement* activity_per_bx = NULL;
       MonitorElement* activity_per_bx_plus1 = NULL;
       MonitorElement* activity_per_bx_minus1 = NULL;
-      MonitorElement* activity_per_fedbx = NULL;
-      MonitorElement* activity_per_fedbx_plus1 = NULL;
-      MonitorElement* activity_per_fedbx_minus1 = NULL;
+//       MonitorElement* activity_per_fedbx = NULL;
+//       MonitorElement* activity_per_fedbx_plus1 = NULL;
+//       MonitorElement* activity_per_fedbx_minus1 = NULL;
       
       MonitorElement* HPTDCErrorFlags = NULL;
       MonitorElement* leadingEdgeCumulative_both = NULL, *leadingEdgeCumulative_le = NULL;
       MonitorElement* TimeOverThresholdCumulativePerChannel = NULL;
       MonitorElement* LeadingTrailingCorrelationPerChannel = NULL;
       MonitorElement* leadingWithoutTrailing = NULL;
-      MonitorElement* efficiency = NULL;
+//       MonitorElement* efficiency = NULL;
       MonitorElement* stripTomography_far = NULL;
-      MonitorElement* stripTomography_near = NULL;
+//       MonitorElement* stripTomography_near = NULL;
       MonitorElement* hit_rate = NULL;
       MonitorElement* ECCheckPerChannel = NULL;
       unsigned long hitsCounterPerLumisection;
@@ -224,9 +228,9 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
   activity_per_bx = ibooker.book1D( "activity per BX", title+" activity per BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
   activity_per_bx_plus1 = ibooker.book1D( "activity per BX OOT +1", title+" activity per BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
   activity_per_bx_minus1 = ibooker.book1D( "activity per BX OOT -1", title+" activity per BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_fedbx = ibooker.book1D( "activity per FED BX", title+" activity per FED BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_fedbx_plus1 = ibooker.book1D( "activity per FED BX OOT +1", title+" activity per FED BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_fedbx_minus1 = ibooker.book1D( "activity per FED BX OOT -1", title+" activity per FED BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
+//   activity_per_fedbx = ibooker.book1D( "activity per FED BX", title+" activity per FED BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
+//   activity_per_fedbx_plus1 = ibooker.book1D( "activity per FED BX OOT +1", title+" activity per FED BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
+//   activity_per_fedbx_minus1 = ibooker.book1D( "activity per FED BX OOT -1", title+" activity per FED BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
 
   hitDistribution2d = ibooker.book2D( "hits in planes", title+" hits in planes;plane number;x (mm)", 10, -0.5, 4.5, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   hitDistribution2dOOT= ibooker.book2D( "hits with OOT in planes", title+" hits with OOT in planes;plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
@@ -238,13 +242,13 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
   trackDistributionOOT = ibooker.book2D( "tracks with OOT", title+" tracks with OOT;plane number;x (mm)", 9, -0.5, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
 
   stripTomographyAllFar = ibooker.book2D( "tomography all far", title+" tomography with strips far (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
-  stripTomographyAllNear = ibooker.book2D( "tomography all near", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
+//   stripTomographyAllNear = ibooker.book2D( "tomography all near", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
 
   stripTomographyAllFar_plus1 = ibooker.book2D( "tomography all far OOT +1", title+" tomography with strips far (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
-  stripTomographyAllNear_plus1 = ibooker.book2D( "tomography all near OOT +1", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
+//   stripTomographyAllNear_plus1 = ibooker.book2D( "tomography all near OOT +1", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
 
   stripTomographyAllFar_minus1 = ibooker.book2D( "tomography all far OOT -1", title+" tomography with strips far (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
-  stripTomographyAllNear_minus1 = ibooker.book2D( "tomography all near OOT -1", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );  
+//   stripTomographyAllNear_minus1 = ibooker.book2D( "tomography all near OOT -1", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );  
 
   leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge (le and te); leading edge (ns)", 300, -100, 200 );
   leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge (le only); leading edge (ns)", 300, -100, 200 );
@@ -267,9 +271,9 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
 
   ibooker.setCurrentFolder( path+"/clock/" );
   clock_Digi1_le = ibooker.book1D( "clock1 leading edge", title+" clock1;leading edge (ns)", 1000, 0, 100 );
-  clock_Digi1_te = ibooker.book1D( "clock1 trailing edge", title+" clock1;trailing edge (ns)", 1000, 0, 100 );
-  clock_Digi3_le = ibooker.book1D( "clock3 leading edge", title+" clock3;leading edge (ns)", 1000, 0, 100 );
-  clock_Digi3_te = ibooker.book1D( "clock3 trailing edge", title+" clock3;trailing edge (ns)", 1000, 0, 100 );
+  clock_Digi1_te = ibooker.book1D( "clock1 trailing edge", title+" clock1;trailing edge (ns)", 100, 0, 100 );
+  clock_Digi3_le = ibooker.book1D( "clock3 leading edge", title+" clock3;leading edge (ns)", 5000, 0, 100 );
+  clock_Digi3_te = ibooker.book1D( "clock3 trailing edge", title+" clock3;trailing edge (ns)", 100, 0, 100 );
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -286,10 +290,10 @@ CTPPSDiamondDQMSource::PlanePlots::PlanePlots( DQMStore::IBooker& ibooker, unsig
   hitProfile = ibooker.book1D( "hit profile", title+" hit profile;x (mm)", 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   hit_multiplicity = ibooker.book1D( "channels per plane", title+" channels per plane; ch per plane", 13, -0.5, 12.5 );
 
-  threshold_voltage = ibooker.book2D( "threshold I2C", title+" threshold I2C; channel; value", 12, -0.5, 11.5, 512, 0, 512 );
+//   threshold_voltage = ibooker.book2D( "threshold I2C", title+" threshold I2C; channel; value", 12, -0.5, 11.5, 512, 0, 512 );
 
   stripTomography_far = ibooker.book2D( "tomography far", title+" tomography with strips far;x + 50 OOT (mm);y (mm)", 50, 0, 50, 150, -50, 100 );
-  stripTomography_near = ibooker.book2D( "tomography near", title+" tomography with strips near;x + 50 OOT (mm);y (mm)", 50, 0, 50, 150, -50, 100 );
+//   stripTomography_near = ibooker.book2D( "tomography near", title+" tomography with strips near;x + 50 OOT (mm);y (mm)", 50, 0, 50, 150, -50, 100 );
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -311,9 +315,9 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, u
   activity_per_bx = ibooker.book1D( "activity per BX", title+" activity per BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
   activity_per_bx_plus1 = ibooker.book1D( "activity per BX OOT +1", title+" activity per BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
   activity_per_bx_minus1 = ibooker.book1D( "activity per BX OOT -1", title+" activity per BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_fedbx = ibooker.book1D( "activity per FED BX", title+" activity per FED BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_fedbx_plus1 = ibooker.book1D( "activity per FED BX OOT +1", title+" activity per FED BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_fedbx_minus1 = ibooker.book1D( "activity per FED BX OOT -1", title+" activity per FED BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
+//   activity_per_fedbx = ibooker.book1D( "activity per FED BX", title+" activity per FED BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
+//   activity_per_fedbx_plus1 = ibooker.book1D( "activity per FED BX OOT +1", title+" activity per FED BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
+//   activity_per_fedbx_minus1 = ibooker.book1D( "activity per FED BX OOT -1", title+" activity per FED BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
   
   
   HPTDCErrorFlags = ibooker.book1D( "hptdc_Errors", title+" HPTDC Errors", 16, -0.5, 16.5 );
@@ -329,7 +333,7 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, u
   ECCheckPerChannel = ibooker.book1D("optorxEC(8bit) - vfatEC vs optorxEC", title+" EC Error;optorxEC-vfatEC", 512, -256, 256 );
 
   stripTomography_far = ibooker.book2D( "tomography far", "tomography with strips far;x + 50 OOT (mm);y (mm)", 200, -50, 150, 150, -50, 100 );
-  stripTomography_near = ibooker.book2D( "tomography near", "tomography with strips near;x + 50 OOT (mm);y (mm)", 200, -50, 150, 150, -50, 100 );
+//   stripTomography_near = ibooker.book2D( "tomography near", "tomography with strips near;x + 50 OOT (mm);y (mm)", 200, -50, 150, 150, -50, 100 );
   
   hit_rate = ibooker.book1D( "hit rate", title+"hit rate;rate (Hz)", 1000, 0, 100 );
 }
@@ -345,6 +349,7 @@ CTPPSDiamondDQMSource::CTPPSDiamondDQMSource( const edm::ParameterSet& ps ) :
   tokenFEDInfo_     ( consumes< std::vector<TotemFEDInfo> >                ( ps.getParameter<edm::InputTag>( "tagFEDInfo" ) ) ),
   excludeMultipleHits_           ( ps.getParameter<bool>( "excludeMultipleHits" ) ),
   minimumStripAngleForTomography_( ps.getParameter<double>( "minimumStripAngleForTomography" ) ),
+  maximumStripAngleForTomography_( ps.getParameter<double>( "maximumStripAngleForTomography" ) ),
   centralOOT_( ps.getParameter<int>( "centralOOT" ) ),
   verbosity_                     ( ps.getUntrackedParameter<unsigned int>( "verbosity", 0 ) ),
   EC_difference_56_( -500 ), EC_difference_45_( -500 )
@@ -455,7 +460,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
 //           }
 //         }
 //   
-//   if (event.bunchCrossing() > 100) return;
+  if (event.bunchCrossing() > 100) return;
   
   
   //------------------------------
@@ -669,22 +674,22 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
             break;
         }      
         
-        // FED BX monitoring (for MINIDAQ)
-        for ( const auto& fit : *fedInfo ) {
-          if ( ( detId.arm() == 1 && fit.getFEDId() == CTPPS_FED_ID_56 ) || ( detId.arm() == 0 && fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
-            switch ( rechit.getOOTIndex() - centralOOT_ ) {
-              case -1: 
-                potPlots_[detId_pot].activity_per_fedbx_minus1->Fill( fit.getBX() );
-                break;
-              case 0: 
-                potPlots_[detId_pot].activity_per_fedbx->Fill( fit.getBX() );
-                break;
-              case 1: 
-                potPlots_[detId_pot].activity_per_fedbx_plus1->Fill( fit.getBX() );
-                break;
-            }
-          }
-        }
+//         // FED BX monitoring (for MINIDAQ)
+//         for ( const auto& fit : *fedInfo ) {
+//           if ( ( detId.arm() == 1 && fit.getFEDId() == CTPPS_FED_ID_56 ) || ( detId.arm() == 0 && fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
+//             switch ( rechit.getOOTIndex() - centralOOT_ ) {
+//               case -1: 
+//                 potPlots_[detId_pot].activity_per_fedbx_minus1->Fill( fit.getBX() );
+//                 break;
+//               case 0: 
+//                 potPlots_[detId_pot].activity_per_fedbx->Fill( fit.getBX() );
+//                 break;
+//               case 1: 
+//                 potPlots_[detId_pot].activity_per_fedbx_plus1->Fill( fit.getBX() );
+//                 break;
+//             }
+//           }
+//         }
       } // End if (complete hits)
     }
   }
@@ -742,7 +747,8 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         for ( const auto& striplt : ds ) {
           if ( !striplt.isValid() ) continue;
           if ( stripId.arm() != detId_pot.arm() ) continue;
-          if ( striplt.getTx() > minimumStripAngleForTomography_ || striplt.getTy() > minimumStripAngleForTomography_) continue; 
+          if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
+          if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
           if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
             switch ( rechit.getOOTIndex() - centralOOT_ ) {
               case -1: {
@@ -756,19 +762,19 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
               } break;
             }
           }
-          else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
-            switch ( rechit.getOOTIndex() - centralOOT_ ) {
-              case -1: {
-                potPlots_[detId_pot].stripTomographyAllNear_minus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
-              } break;
-              case 0: {
-                potPlots_[detId_pot].stripTomographyAllNear->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
-              } break;
-              case 1: {
-                potPlots_[detId_pot].stripTomographyAllNear_plus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
-              } break;
-            }
-          }
+//           else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
+//             switch ( rechit.getOOTIndex() - centralOOT_ ) {
+//               case -1: {
+//                 potPlots_[detId_pot].stripTomographyAllNear_minus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+//               } break;
+//               case 0: {
+//                 potPlots_[detId_pot].stripTomographyAllNear->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+//               } break;
+//               case 1: {
+//                 potPlots_[detId_pot].stripTomographyAllNear_plus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+//               } break;
+//             }
+//           }
         }
       }
     }
@@ -813,7 +819,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       if ( detId.channel() == CHANNEL_OF_VFAT_CLOCK ) continue;
       if ( planePlots_.find( detId_plane ) == planePlots_.end() ) continue;
 
-      planePlots_[detId_plane].threshold_voltage->Fill( detId.channel(), digi.getThresholdVoltage() );
+//       planePlots_[detId_plane].threshold_voltage->Fill( detId.channel(), digi.getThresholdVoltage() );
 
       if ( digi.getLeadingEdge() != 0 ) {
         planePlots_[detId_plane].digiProfileCumulativePerPlane->Fill( detId.channel() );
@@ -862,13 +868,14 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         for ( const auto& striplt : ds ) {
           if (! striplt.isValid()) continue;
           if ( stripId.arm() != detId_plane.arm() ) continue;
-          if ( striplt.getTx() > minimumStripAngleForTomography_ || striplt.getTy() > minimumStripAngleForTomography_ ) continue;
+          if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
+          if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
           if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
             planePlots_[detId_plane].stripTomography_far->Fill( striplt.getX0(), striplt.getY0() + 50*(rechit.getOOTIndex() - centralOOT_ +1) );
           }
-          else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
-            planePlots_[detId_plane].stripTomography_near->Fill( striplt.getX0(), striplt.getY0() + 50*(rechit.getOOTIndex() - centralOOT_ +1) );
-          }
+//           else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
+//             planePlots_[detId_plane].stripTomography_near->Fill( striplt.getX0(), striplt.getY0() + 50*(rechit.getOOTIndex() - centralOOT_ +1) );
+//           }
         }
       }
     }
@@ -911,14 +918,14 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         else if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() != 0 ) channelPlots_[detId].leadingWithoutTrailing->Fill( 4 );
       }
             
-      // FED BX monitoring (for MINIDAQ)
-      for ( const auto& fit : *fedInfo ) {
-        if ( ( detId.arm() == 1 && fit.getFEDId() == CTPPS_FED_ID_56 ) || ( detId.arm() == 0 && fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
-          if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() != 0 ) {
-            channelPlots_[detId].activity_per_fedbx->Fill( fit.getBX() );
-          }
-        }
-      }
+//       // FED BX monitoring (for MINIDAQ)
+//       for ( const auto& fit : *fedInfo ) {
+//         if ( ( detId.arm() == 1 && fit.getFEDId() == CTPPS_FED_ID_56 ) || ( detId.arm() == 0 && fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
+//           if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() != 0 ) {
+//             channelPlots_[detId].activity_per_fedbx->Fill( fit.getBX() );
+//           }
+//         }
+//       }
     }
   }
   
@@ -949,22 +956,22 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
             channelPlots_[detId].activity_per_bx_plus1->Fill( event.bunchCrossing() );
           } break;
         }
-        // FED BX monitoring (for MINIDAQ)
-        for ( const auto& fit : *fedInfo ) {
-          if ( ( detId.arm() == 1 && fit.getFEDId() == CTPPS_FED_ID_56 ) || ( detId.arm() == 0 && fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
-            switch ( rechit.getOOTIndex() - centralOOT_ ) {
-              case -1: {
-                channelPlots_[detId].activity_per_fedbx_minus1->Fill( fit.getBX() );
-              } break;
-              case 0: {
-                channelPlots_[detId].activity_per_fedbx->Fill( fit.getBX() );
-              } break;
-              case 1: {
-                channelPlots_[detId].activity_per_fedbx_plus1->Fill( fit.getBX() );
-              } break;
-            }
-          }
-        }
+//         // FED BX monitoring (for MINIDAQ)
+//         for ( const auto& fit : *fedInfo ) {
+//           if ( ( detId.arm() == 1 && fit.getFEDId() == CTPPS_FED_ID_56 ) || ( detId.arm() == 0 && fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
+//             switch ( rechit.getOOTIndex() - centralOOT_ ) {
+//               case -1: {
+//                 channelPlots_[detId].activity_per_fedbx_minus1->Fill( fit.getBX() );
+//               } break;
+//               case 0: {
+//                 channelPlots_[detId].activity_per_fedbx->Fill( fit.getBX() );
+//               } break;
+//               case 1: {
+//                 channelPlots_[detId].activity_per_fedbx_plus1->Fill( fit.getBX() );
+//               } break;
+//             }
+//           }
+//         }
       }
     }
     
@@ -982,13 +989,14 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
             CTPPSDetId stripId(ds.detId());
             if ( !striplt.isValid() ) continue;
             if ( stripId.arm() != detId.arm() ) continue;
-            if ( striplt.getTx() > minimumStripAngleForTomography_ || striplt.getTy() > minimumStripAngleForTomography_ ) continue;
+            if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
+            if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
             if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
               channelPlots_[detId].stripTomography_far->Fill( striplt.getX0(), striplt.getY0() + 50*( rechit.getOOTIndex() - centralOOT_ +1 ) );
             }
-            else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
-              channelPlots_[detId].stripTomography_near->Fill( striplt.getX0(), striplt.getY0() + 50*( rechit.getOOTIndex() - centralOOT_ +1 ) );
-            }
+//             else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
+//               channelPlots_[detId].stripTomography_near->Fill( striplt.getX0(), striplt.getY0() + 50*( rechit.getOOTIndex() - centralOOT_ +1 ) );
+//             }
           }
         }
       }

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -39,7 +39,7 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
   public:
     CTPPSDiamondDQMSource( const edm::ParameterSet& );
     virtual ~CTPPSDiamondDQMSource();
-  
+
   protected:
     void dqmBeginRun( const edm::Run&, const edm::EventSetup& ) override;
     void bookHistograms( DQMStore::IBooker&, const edm::Run&, const edm::EventSetup& ) override;
@@ -87,16 +87,13 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
     };
 
     GlobalPlots globalPlot_;
-    
+
     /// plots related to one Diamond detector package
     struct PotPlots
     {
       MonitorElement* activity_per_bx = NULL;
       MonitorElement* activity_per_bx_plus1 = NULL;
       MonitorElement* activity_per_bx_minus1 = NULL;
-//       MonitorElement* activity_per_fedbx = NULL;
-//       MonitorElement* activity_per_fedbx_plus1 = NULL;
-//       MonitorElement* activity_per_fedbx_minus1 = NULL;
 
       MonitorElement* hitDistribution2d = NULL;
       MonitorElement* hitDistribution2dOOT = NULL;
@@ -110,9 +107,6 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
       MonitorElement* stripTomographyAllFar = NULL;
       MonitorElement* stripTomographyAllFar_plus1 = NULL;
       MonitorElement* stripTomographyAllFar_minus1 = NULL;
-//       MonitorElement* stripTomographyAllNear = NULL;
-//       MonitorElement* stripTomographyAllNear_plus1 = NULL;
-//       MonitorElement* stripTomographyAllNear_minus1 = NULL;
 
       MonitorElement* leadingEdgeCumulative_both = NULL, *leadingEdgeCumulative_le = NULL;
       MonitorElement* timeOverThresholdCumulativePot = NULL, *leadingTrailingCorrelationPot = NULL;
@@ -140,10 +134,8 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
       MonitorElement* digiProfileCumulativePerPlane = NULL;
       MonitorElement* hitProfile = NULL;
       MonitorElement* hit_multiplicity = NULL;
-//       MonitorElement* threshold_voltage = NULL;
 
       MonitorElement* stripTomography_far = NULL;
-//       MonitorElement* stripTomography_near = NULL;
 
       PlanePlots() {}
       PlanePlots( DQMStore::IBooker& ibooker, unsigned int id );
@@ -157,18 +149,13 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
       MonitorElement* activity_per_bx = NULL;
       MonitorElement* activity_per_bx_plus1 = NULL;
       MonitorElement* activity_per_bx_minus1 = NULL;
-//       MonitorElement* activity_per_fedbx = NULL;
-//       MonitorElement* activity_per_fedbx_plus1 = NULL;
-//       MonitorElement* activity_per_fedbx_minus1 = NULL;
-      
+
       MonitorElement* HPTDCErrorFlags = NULL;
       MonitorElement* leadingEdgeCumulative_both = NULL, *leadingEdgeCumulative_le = NULL;
       MonitorElement* TimeOverThresholdCumulativePerChannel = NULL;
       MonitorElement* LeadingTrailingCorrelationPerChannel = NULL;
       MonitorElement* leadingWithoutTrailing = NULL;
-//       MonitorElement* efficiency = NULL;
       MonitorElement* stripTomography_far = NULL;
-//       MonitorElement* stripTomography_near = NULL;
       MonitorElement* hit_rate = NULL;
       MonitorElement* ECCheckPerChannel = NULL;
       unsigned long hitsCounterPerLumisection;
@@ -228,9 +215,6 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
   activity_per_bx = ibooker.book1D( "activity per BX", title+" activity per BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
   activity_per_bx_plus1 = ibooker.book1D( "activity per BX OOT +1", title+" activity per BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
   activity_per_bx_minus1 = ibooker.book1D( "activity per BX OOT -1", title+" activity per BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-//   activity_per_fedbx = ibooker.book1D( "activity per FED BX", title+" activity per FED BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
-//   activity_per_fedbx_plus1 = ibooker.book1D( "activity per FED BX OOT +1", title+" activity per FED BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-//   activity_per_fedbx_minus1 = ibooker.book1D( "activity per FED BX OOT -1", title+" activity per FED BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
 
   hitDistribution2d = ibooker.book2D( "hits in planes", title+" hits in planes;plane number;x (mm)", 10, -0.5, 4.5, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   hitDistribution2dOOT= ibooker.book2D( "hits with OOT in planes", title+" hits with OOT in planes;plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
@@ -242,13 +226,8 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
   trackDistributionOOT = ibooker.book2D( "tracks with OOT", title+" tracks with OOT;plane number;x (mm)", 9, -0.5, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
 
   stripTomographyAllFar = ibooker.book2D( "tomography all far", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
-//   stripTomographyAllNear = ibooker.book2D( "tomography all near", title+" tomography with strips near (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
-
   stripTomographyAllFar_plus1 = ibooker.book2D( "tomography all far OOT +1", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
-//   stripTomographyAllNear_plus1 = ibooker.book2D( "tomography all near OOT +1", title+" tomography with strips near (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
-
   stripTomographyAllFar_minus1 = ibooker.book2D( "tomography all far OOT -1", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
-//   stripTomographyAllNear_minus1 = ibooker.book2D( "tomography all near OOT -1", title+" tomography with strips near (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 ); 
 
   leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge (le and te); leading edge (ns)", 125, 0, 125 );
   leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge (le only); leading edge (ns)", 125, 0, 125 );
@@ -290,10 +269,7 @@ CTPPSDiamondDQMSource::PlanePlots::PlanePlots( DQMStore::IBooker& ibooker, unsig
   hitProfile = ibooker.book1D( "hit profile", title+" hit profile;x (mm)", 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   hit_multiplicity = ibooker.book1D( "channels per plane", title+" channels per plane; ch per plane", 13, -0.5, 12.5 );
 
-//   threshold_voltage = ibooker.book2D( "threshold I2C", title+" threshold I2C; channel; value", 12, -0.5, 11.5, 512, 0, 512 );
-
   stripTomography_far = ibooker.book2D( "tomography far", title+" tomography with strips far;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
-//   stripTomography_near = ibooker.book2D( "tomography near", title+" tomography with strips near;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -315,11 +291,7 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, u
   activity_per_bx = ibooker.book1D( "activity per BX", title+" activity per BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
   activity_per_bx_plus1 = ibooker.book1D( "activity per BX OOT +1", title+" activity per BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
   activity_per_bx_minus1 = ibooker.book1D( "activity per BX OOT -1", title+" activity per BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-//   activity_per_fedbx = ibooker.book1D( "activity per FED BX", title+" activity per FED BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
-//   activity_per_fedbx_plus1 = ibooker.book1D( "activity per FED BX OOT +1", title+" activity per FED BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-//   activity_per_fedbx_minus1 = ibooker.book1D( "activity per FED BX OOT -1", title+" activity per FED BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  
-  
+
   HPTDCErrorFlags = ibooker.book1D( "hptdc_Errors", title+" HPTDC Errors", 16, -0.5, 16.5 );
   for ( unsigned short error_index=1; error_index<16; ++error_index )
     HPTDCErrorFlags->getTH1F()->GetXaxis()->SetBinLabel( error_index, HPTDCErrorFlags::getHPTDCErrorName( error_index-1 ).c_str() );
@@ -333,8 +305,7 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, u
   ECCheckPerChannel = ibooker.book1D("optorxEC(8bit) - vfatEC vs optorxEC", title+" EC Error;optorxEC-vfatEC", 512, -256, 256 );
 
   stripTomography_far = ibooker.book2D( "tomography far", "tomography with strips far;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
-//   stripTomography_near = ibooker.book2D( "tomography near", "tomography with strips near;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
-  
+
   hit_rate = ibooker.book1D( "hit rate", title+"hit rate;rate (Hz)", 10, 0, 100 );
 }
 
@@ -350,7 +321,7 @@ CTPPSDiamondDQMSource::CTPPSDiamondDQMSource( const edm::ParameterSet& ps ) :
   excludeMultipleHits_           ( ps.getParameter<bool>( "excludeMultipleHits" ) ),
   minimumStripAngleForTomography_( ps.getParameter<double>( "minimumStripAngleForTomography" ) ),
   maximumStripAngleForTomography_( ps.getParameter<double>( "maximumStripAngleForTomography" ) ),
-  centralOOT_( ps.getParameter<int>( "centralOOT" ) ),
+  centralOOT_                    ( ps.getParameter<int>( "centralOOT" ) ),
   verbosity_                     ( ps.getUntrackedParameter<unsigned int>( "verbosity", 0 ) ),
   EC_difference_56_( -500 ), EC_difference_45_( -500 )
 {}
@@ -373,7 +344,7 @@ CTPPSDiamondDQMSource::bookHistograms( DQMStore::IBooker& ibooker, const edm::Ru
 {
   ibooker.cd();
   ibooker.setCurrentFolder( "CTPPS" );
-  
+
   globalPlot_= GlobalPlots( ibooker );
 
   for ( unsigned short arm = 0; arm < CTPPS_NUM_OF_ARMS; ++arm ) {
@@ -450,13 +421,13 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
   // RP Plots
   //------------------------------  
 
-//   if (event.bunchCrossing() > 100) return;
-  
-  
+  //   if (event.bunchCrossing() > 100) return;
+
+
   //------------------------------
   // Correlation Plots
   //------------------------------
-  
+
   for ( const auto& ds1 : *stripTracks ) {
     for ( const auto& tr1 : ds1 ) {
       if ( ! tr1.isValid() )  continue;
@@ -566,20 +537,22 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_56_ ) && ( static_cast<uint8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
             EC_difference_56_ = static_cast<int>( optorx.getLV1() & 0xFF )-( static_cast<unsigned int>( status.getEC() ) & 0xFF );
           if ( EC_difference_56_ != 1 && EC_difference_56_ != -500 && EC_difference_56_ < 128 && EC_difference_56_ > -128 )
-            if (verbosity_) edm::LogProblem("CTPPSDiamondDQMSource")  << "FED " << CTPPS_FED_ID_56 << ": ECError at EV: 0x"<< std::hex << optorx.getLV1()
-                                                                      << "\t\tVFAT EC: 0x"<< static_cast<unsigned int>( status.getEC() )
-                                                                      << "\twith ID: " << std::dec << detId
-                                                                      << "\tdiff: " <<  EC_difference_56_;
+            if (verbosity_)
+              edm::LogProblem("CTPPSDiamondDQMSource")  << "FED " << CTPPS_FED_ID_56 << ": ECError at EV: 0x"<< std::hex << optorx.getLV1()
+                << "\t\tVFAT EC: 0x"<< static_cast<unsigned int>( status.getEC() )
+                << "\twith ID: " << std::dec << detId
+                << "\tdiff: " <<  EC_difference_56_;
         }
         else if ( detId.arm() == 0 && optorx.getFEDId()== CTPPS_FED_ID_45 ) {
           potPlots_[detId_pot].ECCheck->Fill((int)((optorx.getLV1()& 0xFF)-status.getEC()) & 0xFF);
           if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_45_ ) && ( static_cast<uint8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
             EC_difference_45_ = static_cast<int>( optorx.getLV1() & 0xFF )-( static_cast<unsigned int>( status.getEC() ) & 0xFF );
           if ( EC_difference_45_ != 1 && EC_difference_45_ != -500 && EC_difference_45_ < 128 && EC_difference_45_ > -128 )
-            if (verbosity_) edm::LogProblem("CTPPSDiamondDQMSource")  << "FED " << CTPPS_FED_ID_45 << ": ECError at EV: 0x"<< std::hex << optorx.getLV1()
-                                                                      << "\t\tVFAT EC: 0x"<< static_cast<unsigned int>( status.getEC() )
-                                                                      << "\twith ID: " << std::dec << detId
-                                                                      << "\tdiff: " <<  EC_difference_45_;
+            if (verbosity_)
+              edm::LogProblem("CTPPSDiamondDQMSource")  << "FED " << CTPPS_FED_ID_45 << ": ECError at EV: 0x"<< std::hex << optorx.getLV1()
+                << "\t\tVFAT EC: 0x"<< static_cast<unsigned int>( status.getEC() )
+                << "\twith ID: " << std::dec << detId
+                << "\tdiff: " <<  EC_difference_45_;
         }
       }
     }
@@ -602,7 +575,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
 
       float UFSDShift = 0.0;
       if ( rechit.getYWidth() < 3 ) UFSDShift = 0.5;  // Display trick for UFSD that have 2 pixels with same X
-        
+
       if ( rechit.getToT() != 0 && rechit.getOOTIndex() == centralOOT_ ) {
         TH2F *hitHistoTmp = potPlots_[detId_pot].hitDistribution2d->getTH2F();
         TAxis *hitHistoTmpYAxis = hitHistoTmp->GetYaxis();
@@ -612,7 +585,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           hitHistoTmp->Fill( detId.plane(), hitHistoTmpYAxis->GetBinCenter(startBin+i) + UFSDShift );
         }
       }
-      
+
       if ( rechit.getToT() != 0 ) {
         // Both
         potPlots_[detId_pot].leadingEdgeCumulative_both->Fill( rechit.getT() + 25*rechit.getOOTIndex() );
@@ -640,7 +613,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         else {
           // Only leading
           potPlots_[detId_pot].leadingEdgeCumulative_le->Fill( rechit.getT() + 25*rechit.getOOTIndex() );
-          
+
           TH2F *hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT_le->getTH2F();
           TAxis *hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
           int startBin = hitHistoOOTTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
@@ -650,7 +623,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           }
         }
       }
-      
+
       if ( rechit.getToT() != 0 ) {
         switch ( rechit.getOOTIndex() - centralOOT_ ) {
           case -1:
@@ -663,31 +636,15 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
             potPlots_[detId_pot].activity_per_bx_plus1->Fill( event.bunchCrossing() );
             break;
         }      
-        
-//         // FED BX monitoring (for MINIDAQ)
-//         for ( const auto& fit : *fedInfo ) {
-//           if ( ( detId.arm() == 1 && fit.getFEDId() == CTPPS_FED_ID_56 ) || ( detId.arm() == 0 && fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
-//             switch ( rechit.getOOTIndex() - centralOOT_ ) {
-//               case -1: 
-//                 potPlots_[detId_pot].activity_per_fedbx_minus1->Fill( fit.getBX() );
-//                 break;
-//               case 0: 
-//                 potPlots_[detId_pot].activity_per_fedbx->Fill( fit.getBX() );
-//                 break;
-//               case 1: 
-//                 potPlots_[detId_pot].activity_per_fedbx_plus1->Fill( fit.getBX() );
-//                 break;
-//             }
-//           }
-//         }
+
       } // End if (complete hits)
     }
   }
-  
+
   for ( const auto& plt : potPlots_ ) {
     plt.second.activePlanes->Fill( planes[plt.first].size() );
   }
-  
+
   // Using CTPPSDiamondLocalTrack
   for ( const auto& tracks : *diamondLocalTracks ) {
     CTPPSDiamondDetId detId_pot( tracks.detId() );
@@ -707,7 +664,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       for ( int i=0; i<numOfBins; ++i) {
         trackHistoOOTTmp->Fill( track.getOOTIndex(), trackHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
       }
-      
+
       if ( track.getOOTIndex() == centralOOT_ ) {
         TH1F *trackHistoInTimeTmp = potPlots_[detId_pot].trackDistribution->getTH1F();
         int startBin = trackHistoInTimeTmp->FindBin( track.getX0() - track.getX0Sigma() );
@@ -718,7 +675,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       }
     }
   }
-  
+
   // Tomography of diamonds using strips
   for ( const auto& rechits : *diamondRecHits ) {
     CTPPSDiamondDetId detId_pot( rechits.detId() );
@@ -752,19 +709,6 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
               } break;
             }
           }
-//           else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
-//             switch ( rechit.getOOTIndex() - centralOOT_ ) {
-//               case -1: {
-//                 potPlots_[detId_pot].stripTomographyAllNear_minus1->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
-//               } break;
-//               case 0: {
-//                 potPlots_[detId_pot].stripTomographyAllNear->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
-//               } break;
-//               case 1: {
-//                 potPlots_[detId_pot].stripTomographyAllNear_plus1->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
-//               } break;
-//             }
-//           }
         }
       }
     }
@@ -809,8 +753,6 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       if ( detId.channel() == CHANNEL_OF_VFAT_CLOCK ) continue;
       if ( planePlots_.find( detId_plane ) == planePlots_.end() ) continue;
 
-//       planePlots_[detId_plane].threshold_voltage->Fill( detId.channel(), digi.getThresholdVoltage() );
-
       if ( digi.getLeadingEdge() != 0 ) {
         planePlots_[detId_plane].digiProfileCumulativePerPlane->Fill( detId.channel() );
         if ( channelsPerPlane.find(detId_plane) != channelsPerPlane.end() ) channelsPerPlane[detId_plane]++;
@@ -822,7 +764,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
   for ( const auto& plt : channelsPerPlane ) {
     planePlots_[plt.first].hit_multiplicity->Fill( plt.second );
   }
-  
+
   // Using CTPPSDiamondRecHit
   for ( const auto& rechits : *diamondRecHits ) {
     CTPPSDiamondDetId detId_plane( rechits.detId() );
@@ -852,7 +794,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       if ( rechit.getToT() == 0 ) continue;
       if ( !stripTracks.isValid() ) continue;
       if (planePlots_.find(detId_plane) == planePlots_.end()) continue;
-      
+
       for ( const auto& ds : *stripTracks ) {
         const CTPPSDetId stripId(ds.detId());
         for ( const auto& striplt : ds ) {
@@ -863,9 +805,6 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
             planePlots_[detId_plane].stripTomography_far->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - centralOOT_ +1), striplt.getY0() );
           }
-//           else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
-//             planePlots_[detId_plane].stripTomography_near->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - centralOOT_ +1), striplt.getY0() );
-//           }
         }
       }
     }
@@ -907,18 +846,9 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         else if ( digi.getLeadingEdge() == 0 && digi.getTrailingEdge() != 0 ) channelPlots_[detId].leadingWithoutTrailing->Fill( 3 );
         else if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() != 0 ) channelPlots_[detId].leadingWithoutTrailing->Fill( 4 );
       }
-            
-//       // FED BX monitoring (for MINIDAQ)
-//       for ( const auto& fit : *fedInfo ) {
-//         if ( ( detId.arm() == 1 && fit.getFEDId() == CTPPS_FED_ID_56 ) || ( detId.arm() == 0 && fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
-//           if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() != 0 ) {
-//             channelPlots_[detId].activity_per_fedbx->Fill( fit.getBX() );
-//           }
-//         }
-//       }
     }
   }
-  
+
   // Using CTPPSDiamondRecHit
   for ( const auto& rechits : *diamondRecHits ) {
     CTPPSDiamondDetId detId( rechits.detId() );
@@ -933,7 +863,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         channelPlots_[detId].LeadingTrailingCorrelationPerChannel->Fill( rechit.getT() + 25*rechit.getOOTIndex(), rechit.getT() + 25*rechit.getOOTIndex() + rechit.getToT() );
         ++(channelPlots_[detId].hitsCounterPerLumisection);
       }
-    
+
       if ( rechit.getToT() != 0 ) {
         switch ( rechit.getOOTIndex() - centralOOT_ ) {
           case -1: {
@@ -946,27 +876,11 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
             channelPlots_[detId].activity_per_bx_plus1->Fill( event.bunchCrossing() );
           } break;
         }
-//         // FED BX monitoring (for MINIDAQ)
-//         for ( const auto& fit : *fedInfo ) {
-//           if ( ( detId.arm() == 1 && fit.getFEDId() == CTPPS_FED_ID_56 ) || ( detId.arm() == 0 && fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
-//             switch ( rechit.getOOTIndex() - centralOOT_ ) {
-//               case -1: {
-//                 channelPlots_[detId].activity_per_fedbx_minus1->Fill( fit.getBX() );
-//               } break;
-//               case 0: {
-//                 channelPlots_[detId].activity_per_fedbx->Fill( fit.getBX() );
-//               } break;
-//               case 1: {
-//                 channelPlots_[detId].activity_per_fedbx_plus1->Fill( fit.getBX() );
-//               } break;
-//             }
-//           }
-//         }
       }
     }
-    
+
   }
-  
+
   // Tomography of diamonds using strips
   for ( const auto& rechits : *diamondRecHits ) {
     const CTPPSDiamondDetId detId( rechits.detId() );
@@ -984,15 +898,11 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
             if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
               channelPlots_[detId].stripTomography_far->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - centralOOT_ +1), striplt.getY0() );
             }
-//             else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
-//               channelPlots_[detId].stripTomography_near->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - centralOOT_ +1), striplt.getY0() );
-//             }
           }
         }
       }
     }
   }
-  
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -632,10 +632,10 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           case 0:
             potPlots_[detId_pot].activity_per_bx->Fill( event.bunchCrossing() );
             break;
-          case 1: 
+          case 1:
             potPlots_[detId_pot].activity_per_bx_plus1->Fill( event.bunchCrossing() );
             break;
-        }      
+        }
 
       } // End if (complete hits)
     }

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -54,6 +54,7 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
     static const double SEC_PER_LUMI_SECTION;                   // Number of seconds per lumisection: used to compute hit rates in Hz
     static const int CHANNEL_OF_VFAT_CLOCK;                     // Channel ID of the VFAT that contains clock data
     static const double DISPLAY_RESOLUTION_FOR_HITS_MM;         // Bin width of histograms showing hits and tracks (in mm)
+    static const double INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
     static const double HPTDC_BIN_WIDTH_NS;                        // ns per HPTDC bin
     static const int CTPPS_NUM_OF_ARMS;
     static const int CTPPS_DIAMOND_STATION_ID;
@@ -175,6 +176,7 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
 const double    CTPPSDiamondDQMSource::SEC_PER_LUMI_SECTION = 23.31;
 const int       CTPPSDiamondDQMSource::CHANNEL_OF_VFAT_CLOCK = 30;
 const double    CTPPSDiamondDQMSource::DISPLAY_RESOLUTION_FOR_HITS_MM = 0.1;
+const double    CTPPSDiamondDQMSource::INV_DISPLAY_RESOLUTION_FOR_HITS_MM = 1./DISPLAY_RESOLUTION_FOR_HITS_MM;
 const double    CTPPSDiamondDQMSource::HPTDC_BIN_WIDTH_NS = 25./1024;
 const int       CTPPSDiamondDQMSource::CTPPS_NUM_OF_ARMS = 2;
 const int       CTPPSDiamondDQMSource::CTPPS_DIAMOND_STATION_ID = 1;
@@ -218,14 +220,14 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
   activity_per_bx_plus1 = ibooker.book1D( "activity per BX OOT +1", title+" activity per BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
   activity_per_bx_minus1 = ibooker.book1D( "activity per BX OOT -1", title+" activity per BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
 
-  hitDistribution2d = ibooker.book2D( "hits in planes", title+" hits in planes;plane number;x (mm)", 10, -0.5, 4.5, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
-  hitDistribution2dOOT= ibooker.book2D( "hits with OOT in planes", title+" hits with OOT in planes;plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
-  hitDistribution2dOOT_le= ibooker.book2D( "hits with OOT in planes (le only)", title+" hits with OOT in planes (le only);plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
-  hitDistribution2dOOT_te= ibooker.book2D( "hits with OOT in planes (te only)", title+" hits with OOT in planes (te only);plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitDistribution2d = ibooker.book2D( "hits in planes", title+" hits in planes;plane number;x (mm)", 10, -0.5, 4.5, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitDistribution2dOOT= ibooker.book2D( "hits with OOT in planes", title+" hits with OOT in planes;plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitDistribution2dOOT_le= ibooker.book2D( "hits with OOT in planes (le only)", title+" hits with OOT in planes (le only);plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitDistribution2dOOT_te= ibooker.book2D( "hits with OOT in planes (te only)", title+" hits with OOT in planes (te only);plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   activePlanes = ibooker.book1D( "active planes", title+" active planes;number of active planes", 6, -0.5, 5.5 );
 
-  trackDistribution = ibooker.book1D( "tracks", title+" tracks;x (mm)", 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
-  trackDistributionOOT = ibooker.book2D( "tracks with OOT", title+" tracks with OOT;plane number;x (mm)", 9, -0.5, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  trackDistribution = ibooker.book1D( "tracks", title+" tracks;x (mm)", 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  trackDistributionOOT = ibooker.book2D( "tracks with OOT", title+" tracks with OOT;plane number;x (mm)", 9, -0.5, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
 
   stripTomographyAllFar = ibooker.book2D( "tomography all far", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
   stripTomographyAllFar_plus1 = ibooker.book2D( "tomography all far OOT +1", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
@@ -268,7 +270,7 @@ CTPPSDiamondDQMSource::PlanePlots::PlanePlots( DQMStore::IBooker& ibooker, unsig
   CTPPSDiamondDetId( id ).planeName( title, CTPPSDiamondDetId::nFull );
 
   digiProfileCumulativePerPlane = ibooker.book1D( "digi profile", title+" digi profile; ch number", 12, -0.5, 11.5 );
-  hitProfile = ibooker.book1D( "hit profile", title+" hit profile;x (mm)", 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitProfile = ibooker.book1D( "hit profile", title+" hit profile;x (mm)", 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   hit_multiplicity = ibooker.book1D( "channels per plane", title+" channels per plane; ch per plane", 13, -0.5, 12.5 );
 
   stripTomography_far = ibooker.book2D( "tomography far", title+" tomography with strips far;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
@@ -593,7 +595,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         TH2F *hitHistoTmp = potPlots_[detId_pot].hitDistribution2d->getTH2F();
         TAxis *hitHistoTmpYAxis = hitHistoTmp->GetYaxis();
         int startBin = hitHistoTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
-        int numOfBins = rechit.getXWidth()/DISPLAY_RESOLUTION_FOR_HITS_MM;
+        int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for ( int i=0; i<numOfBins; ++i) {
           hitHistoTmp->Fill( detId.plane(), hitHistoTmpYAxis->GetBinCenter(startBin+i) + UFSDShift );
         }
@@ -607,7 +609,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         TH2F *hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT->getTH2F();
         TAxis *hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
         int startBin = hitHistoOOTTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
-        int numOfBins = rechit.getXWidth()/DISPLAY_RESOLUTION_FOR_HITS_MM;
+        int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for ( int i=0; i<numOfBins; ++i) {
           hitHistoOOTTmp->Fill( detId.plane() + 0.1 * rechit.getOOTIndex(), hitHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
         }
@@ -618,7 +620,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           TH2F *hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT_te->getTH2F();
           TAxis *hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
           int startBin = hitHistoOOTTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
-          int numOfBins = rechit.getXWidth()/DISPLAY_RESOLUTION_FOR_HITS_MM;
+          int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
           for ( int i=0; i<numOfBins; ++i) {
             hitHistoOOTTmp->Fill( detId.plane() + 0.1 * rechit.getOOTIndex(), hitHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
           }
@@ -630,7 +632,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           TH2F *hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT_le->getTH2F();
           TAxis *hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
           int startBin = hitHistoOOTTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
-          int numOfBins = rechit.getXWidth()/DISPLAY_RESOLUTION_FOR_HITS_MM;
+          int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
           for ( int i=0; i<numOfBins; ++i) {
             hitHistoOOTTmp->Fill( detId.plane() + 0.1 * rechit.getOOTIndex(), hitHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
           }
@@ -673,7 +675,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       TH2F *trackHistoOOTTmp = potPlots_[detId_pot].trackDistributionOOT->getTH2F();
       TAxis *trackHistoOOTTmpYAxis = trackHistoOOTTmp->GetYaxis();
       int startBin = trackHistoOOTTmpYAxis->FindBin( track.getX0() - track.getX0Sigma() );
-      int numOfBins = 2*track.getX0Sigma()/DISPLAY_RESOLUTION_FOR_HITS_MM;
+      int numOfBins = 2*track.getX0Sigma()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
       for ( int i=0; i<numOfBins; ++i) {
         trackHistoOOTTmp->Fill( track.getOOTIndex(), trackHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
       }
@@ -681,7 +683,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       if ( centralOOT_ != -999 && track.getOOTIndex() == centralOOT_ ) {
         TH1F *trackHistoInTimeTmp = potPlots_[detId_pot].trackDistribution->getTH1F();
         int startBin = trackHistoInTimeTmp->FindBin( track.getX0() - track.getX0Sigma() );
-        int numOfBins = 2*track.getX0Sigma()/DISPLAY_RESOLUTION_FOR_HITS_MM;
+        int numOfBins = 2*track.getX0Sigma()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for ( int i=0; i<numOfBins; ++i) {
           trackHistoInTimeTmp->Fill( trackHistoInTimeTmp->GetBinCenter(startBin+i) );
         }
@@ -789,7 +791,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         if ( centralOOT_ != -999 && rechit.getOOTIndex() == centralOOT_ ) {
           TH1F *hitHistoTmp = planePlots_[detId_plane].hitProfile->getTH1F();
           int startBin = hitHistoTmp->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
-          int numOfBins = rechit.getXWidth()/DISPLAY_RESOLUTION_FOR_HITS_MM;
+          int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
           for ( int i=0; i<numOfBins; ++i) {
             hitHistoTmp->Fill( hitHistoTmp->GetBinCenter(startBin+i) );
           }

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -241,18 +241,18 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
   trackDistribution = ibooker.book1D( "tracks", title+" tracks;x (mm)", 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   trackDistributionOOT = ibooker.book2D( "tracks with OOT", title+" tracks with OOT;plane number;x (mm)", 9, -0.5, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
 
-  stripTomographyAllFar = ibooker.book2D( "tomography all far", title+" tomography with strips far (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
-//   stripTomographyAllNear = ibooker.book2D( "tomography all near", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
+  stripTomographyAllFar = ibooker.book2D( "tomography all far", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
+//   stripTomographyAllNear = ibooker.book2D( "tomography all near", title+" tomography with strips near (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
 
-  stripTomographyAllFar_plus1 = ibooker.book2D( "tomography all far OOT +1", title+" tomography with strips far (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
-//   stripTomographyAllNear_plus1 = ibooker.book2D( "tomography all near OOT +1", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
+  stripTomographyAllFar_plus1 = ibooker.book2D( "tomography all far OOT +1", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
+//   stripTomographyAllNear_plus1 = ibooker.book2D( "tomography all near OOT +1", title+" tomography with strips near (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
 
-  stripTomographyAllFar_minus1 = ibooker.book2D( "tomography all far OOT -1", title+" tomography with strips far (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
-//   stripTomographyAllNear_minus1 = ibooker.book2D( "tomography all near OOT -1", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );  
+  stripTomographyAllFar_minus1 = ibooker.book2D( "tomography all far OOT -1", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
+//   stripTomographyAllNear_minus1 = ibooker.book2D( "tomography all near OOT -1", title+" tomography with strips near (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 ); 
 
-  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge (le and te); leading edge (ns)", 300, -100, 200 );
-  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge (le only); leading edge (ns)", 300, -100, 200 );
-  timeOverThresholdCumulativePot = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 100, -50, 50 );
+  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge (le and te); leading edge (ns)", 125, 0, 125 );
+  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge (le only); leading edge (ns)", 125, 0, 125 );
+  timeOverThresholdCumulativePot = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 100, -100, 100 );
   leadingTrailingCorrelationPot = ibooker.book2D( "leading trailing correlation", title+" leading trailing correlation;leading edge (ns);trailing edge (ns)", 100, 0, 100, 100, 0, 100 );
 
   leadingWithoutTrailingCumulativePot = ibooker.book1D( "leading edges without trailing", title+" leading edges without trailing;leading edges without trailing", 4, 0.5, 4.5 );
@@ -270,10 +270,10 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
 
 
   ibooker.setCurrentFolder( path+"/clock/" );
-  clock_Digi1_le = ibooker.book1D( "clock1 leading edge", title+" clock1;leading edge (ns)", 1000, 0, 100 );
-  clock_Digi1_te = ibooker.book1D( "clock1 trailing edge", title+" clock1;trailing edge (ns)", 100, 0, 100 );
-  clock_Digi3_le = ibooker.book1D( "clock3 leading edge", title+" clock3;leading edge (ns)", 5000, 0, 100 );
-  clock_Digi3_te = ibooker.book1D( "clock3 trailing edge", title+" clock3;trailing edge (ns)", 100, 0, 100 );
+  clock_Digi1_le = ibooker.book1D( "clock1 leading edge", title+" clock1;leading edge (ns)", 125, 0, 125 );
+  clock_Digi1_te = ibooker.book1D( "clock1 trailing edge", title+" clock1;trailing edge (ns)", 125, 0, 125 );
+  clock_Digi3_le = ibooker.book1D( "clock3 leading edge", title+" clock3;leading edge (ns)", 1000, 0, 125 );
+  clock_Digi3_te = ibooker.book1D( "clock3 trailing edge", title+" clock3;trailing edge (ns)", 125, 0, 125 );
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -292,8 +292,8 @@ CTPPSDiamondDQMSource::PlanePlots::PlanePlots( DQMStore::IBooker& ibooker, unsig
 
 //   threshold_voltage = ibooker.book2D( "threshold I2C", title+" threshold I2C; channel; value", 12, -0.5, 11.5, 512, 0, 512 );
 
-  stripTomography_far = ibooker.book2D( "tomography far", title+" tomography with strips far;x + 50 OOT (mm);y (mm)", 50, 0, 50, 150, -50, 100 );
-//   stripTomography_near = ibooker.book2D( "tomography near", title+" tomography with strips near;x + 50 OOT (mm);y (mm)", 50, 0, 50, 150, -50, 100 );
+  stripTomography_far = ibooker.book2D( "tomography far", title+" tomography with strips far;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
+//   stripTomography_near = ibooker.book2D( "tomography near", title+" tomography with strips near;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -325,17 +325,17 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, u
     HPTDCErrorFlags->getTH1F()->GetXaxis()->SetBinLabel( error_index, HPTDCErrorFlags::getHPTDCErrorName( error_index-1 ).c_str() );
   HPTDCErrorFlags->getTH1F()->GetXaxis()->SetBinLabel( 16, "MH" );
 
-  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge; leading edge (ns)", 300, -100, 200 );
-  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge; leading edge (ns)", 300, -100, 200 );
-  TimeOverThresholdCumulativePerChannel = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 200, -100, 100 );
+  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge; leading edge (ns)", 100, 0, 200 );
+  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge; leading edge (ns)", 200, 0, 200 );
+  TimeOverThresholdCumulativePerChannel = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 100, -100, 100 );
   LeadingTrailingCorrelationPerChannel = ibooker.book2D( "leading trailing correlation", title+" leading trailing correlation;leading edge (ns);trailing edge (ns)", 100, 0, 100, 100, 0, 100 );
 
   ECCheckPerChannel = ibooker.book1D("optorxEC(8bit) - vfatEC vs optorxEC", title+" EC Error;optorxEC-vfatEC", 512, -256, 256 );
 
-  stripTomography_far = ibooker.book2D( "tomography far", "tomography with strips far;x + 50 OOT (mm);y (mm)", 200, -50, 150, 150, -50, 100 );
-//   stripTomography_near = ibooker.book2D( "tomography near", "tomography with strips near;x + 50 OOT (mm);y (mm)", 200, -50, 150, 150, -50, 100 );
+  stripTomography_far = ibooker.book2D( "tomography far", "tomography with strips far;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
+//   stripTomography_near = ibooker.book2D( "tomography near", "tomography with strips near;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
   
-  hit_rate = ibooker.book1D( "hit rate", title+"hit rate;rate (Hz)", 1000, 0, 100 );
+  hit_rate = ibooker.book1D( "hit rate", title+"hit rate;rate (Hz)", 10, 0, 100 );
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -449,18 +449,8 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
   //------------------------------
   // RP Plots
   //------------------------------  
-  
-    // FED BX monitoring (for MINIDAQ)
-//       for ( const auto& fit : *fedInfo ) {
-// //         std::cout<<"FED BX pre "<< fit.getBX()  <<std::endl;
-//         if ( ( fit.getFEDId() == CTPPS_FED_ID_56 ) || ( fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
-//           if ( (int) fit.getBX() > 100 ) return;
-// //           if ( (int) fit.getBX() > 990 and (int) fit.getBX() < 1100 ) return;
-// //           if ( (int) fit.getBX() < 775 or (int) fit.getBX() > 815 ) return;
-//           }
-//         }
-//   
-  if (event.bunchCrossing() > 100) return;
+
+//   if (event.bunchCrossing() > 100) return;
   
   
   //------------------------------
@@ -752,26 +742,26 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
             switch ( rechit.getOOTIndex() - centralOOT_ ) {
               case -1: {
-                potPlots_[detId_pot].stripTomographyAllFar_minus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+                potPlots_[detId_pot].stripTomographyAllFar_minus1->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
               } break;
               case 0: {
-                potPlots_[detId_pot].stripTomographyAllFar->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+                potPlots_[detId_pot].stripTomographyAllFar->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
               } break;
               case 1: {
-                potPlots_[detId_pot].stripTomographyAllFar_plus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+                potPlots_[detId_pot].stripTomographyAllFar_plus1->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
               } break;
             }
           }
 //           else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
 //             switch ( rechit.getOOTIndex() - centralOOT_ ) {
 //               case -1: {
-//                 potPlots_[detId_pot].stripTomographyAllNear_minus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+//                 potPlots_[detId_pot].stripTomographyAllNear_minus1->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
 //               } break;
 //               case 0: {
-//                 potPlots_[detId_pot].stripTomographyAllNear->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+//                 potPlots_[detId_pot].stripTomographyAllNear->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
 //               } break;
 //               case 1: {
-//                 potPlots_[detId_pot].stripTomographyAllNear_plus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+//                 potPlots_[detId_pot].stripTomographyAllNear_plus1->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
 //               } break;
 //             }
 //           }
@@ -871,10 +861,10 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
           if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
           if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
-            planePlots_[detId_plane].stripTomography_far->Fill( striplt.getX0(), striplt.getY0() + 50*(rechit.getOOTIndex() - centralOOT_ +1) );
+            planePlots_[detId_plane].stripTomography_far->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - centralOOT_ +1), striplt.getY0() );
           }
 //           else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
-//             planePlots_[detId_plane].stripTomography_near->Fill( striplt.getX0(), striplt.getY0() + 50*(rechit.getOOTIndex() - centralOOT_ +1) );
+//             planePlots_[detId_plane].stripTomography_near->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - centralOOT_ +1), striplt.getY0() );
 //           }
         }
       }
@@ -992,10 +982,10 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
             if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
             if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
             if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
-              channelPlots_[detId].stripTomography_far->Fill( striplt.getX0(), striplt.getY0() + 50*( rechit.getOOTIndex() - centralOOT_ +1 ) );
+              channelPlots_[detId].stripTomography_far->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - centralOOT_ +1), striplt.getY0() );
             }
 //             else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
-//               channelPlots_[detId].stripTomography_near->Fill( striplt.getX0(), striplt.getY0() + 50*( rechit.getOOTIndex() - centralOOT_ +1 ) );
+//               channelPlots_[detId].stripTomography_near->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - centralOOT_ +1), striplt.getY0() );
 //             }
           }
         }

--- a/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
@@ -9,7 +9,21 @@ ctppsDiamondDQMSource = cms.EDAnalyzer("CTPPSDiamondDQMSource",
     tagLocalTrack = cms.InputTag("totemRPLocalTrackFitter"),
     
     excludeMultipleHits = cms.bool(True),
-    minimumStripAngleForTomography = cms.double(1e-3),
+    minimumStripAngleForTomography = cms.double(0),
+    maximumStripAngleForTomography = cms.double(1),
+
+    offsetsOOT = cms.VPSet( # cut on the OOT bin for physics hits
+        # 2016, after TS2
+        cms.PSet(
+            validityRange = cms.EventRange("1:min - 292520:max"),
+            centralOOT = cms.int32(1),
+        ),
+        # 2017
+        cms.PSet(
+            validityRange = cms.EventRange("292521:min - 999999999:max"),
+            centralOOT = cms.int32(3),
+        ),
+    ),
   
     verbosity = cms.untracked.uint32(10),
 )

--- a/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
@@ -9,7 +9,8 @@ ctppsDiamondDQMSource = cms.EDAnalyzer("CTPPSDiamondDQMSource",
     tagLocalTrack = cms.InputTag("totemRPLocalTrackFitter"),
     
     excludeMultipleHits = cms.bool(True),
-    minimumStripAngleForTomography = cms.double(1e-3),
+    minimumStripAngleForTomography = cms.double(1),
+    centralOOT = cms.int32(2),
   
     verbosity = cms.untracked.uint32(10),
 )

--- a/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
@@ -16,7 +16,7 @@ ctppsDiamondDQMSource = cms.EDAnalyzer("CTPPSDiamondDQMSource",
         # 2016, after TS2
         cms.PSet(
             validityRange = cms.EventRange("1:min - 292520:max"),
-            centralOOT = cms.int32(-1),
+            centralOOT = cms.int32(-999), # no cut on OOT index
         ),
         # 2017
         cms.PSet(

--- a/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
@@ -9,8 +9,9 @@ ctppsDiamondDQMSource = cms.EDAnalyzer("CTPPSDiamondDQMSource",
     tagLocalTrack = cms.InputTag("totemRPLocalTrackFitter"),
     
     excludeMultipleHits = cms.bool(True),
-    minimumStripAngleForTomography = cms.double(1),
-    centralOOT = cms.int32(2),
+    minimumStripAngleForTomography = cms.double(0),
+    maximumStripAngleForTomography = cms.double(1),
+    centralOOT = cms.int32(3),
   
     verbosity = cms.untracked.uint32(10),
 )

--- a/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
@@ -11,7 +11,19 @@ ctppsDiamondDQMSource = cms.EDAnalyzer("CTPPSDiamondDQMSource",
     excludeMultipleHits = cms.bool(True),
     minimumStripAngleForTomography = cms.double(0),
     maximumStripAngleForTomography = cms.double(1),
-    centralOOT = cms.int32(3),
+
+    offsetsOOT = cms.VPSet(
+        # 2016, after TS2
+        cms.PSet(
+            validityRange = cms.EventRange("1:min - 292520:max"),
+            centralOOT = cms.int32(-1),
+        ),
+        # 2017
+        cms.PSet(
+            validityRange = cms.EventRange("292521:min - 999999999:max"),
+            centralOOT = cms.int32(3),
+        ),
+    ),
   
     verbosity = cms.untracked.uint32(10),
 )

--- a/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
@@ -12,11 +12,11 @@ ctppsDiamondDQMSource = cms.EDAnalyzer("CTPPSDiamondDQMSource",
     minimumStripAngleForTomography = cms.double(0),
     maximumStripAngleForTomography = cms.double(1),
 
-    offsetsOOT = cms.VPSet(
+    offsetsOOT = cms.VPSet( # cut on the OOT bin for physics hits
         # 2016, after TS2
         cms.PSet(
             validityRange = cms.EventRange("1:min - 292520:max"),
-            centralOOT = cms.int32(-999), # no cut on OOT index
+            centralOOT = cms.int32(1),
         ),
         # 2017
         cms.PSet(

--- a/DQM/CTPPS/test/diamond_dqm_test_cfg.py
+++ b/DQM/CTPPS/test/diamond_dqm_test_cfg.py
@@ -26,7 +26,8 @@ process.dqmSaver.tag = "CTPPS"
 process.source = cms.Source("NewEventStreamFileReader",
   fileNames = cms.untracked.vstring(
     #'file:/afs/cern.ch/user/j/jkaspar/public/run273062_ls0001-2_stream.root'
-    '/store/t0streamer/Data/Physics/000/294/737/run294737_ls0011_streamPhysics_StorageManager.dat',
+    #'/store/t0streamer/Data/Physics/000/294/737/run294737_ls0011_streamPhysics_StorageManager.dat',
+    '/store/t0streamer/Minidaq/A/000/295/626/run295626_ls0001_streamA_StorageManager.dat',
   )
 )
 

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -340,7 +340,7 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
         process.load("RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi")
         process.recopixelvertexing = cms.Sequence(process.pixelTracksSequence + process.pixelVertices)
         process.pixelTracksTrackingRegions.RegionPSet.originRadius = 0.4
-        process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 3
+        process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 6
         process.pixelTracksTrackingRegions.RegionPSet.originXPos = 0.08
         process.pixelTracksTrackingRegions.RegionPSet.originYPos = -0.03
         process.pixelTracksTrackingRegions.RegionPSet.originZPos = 1.

--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -132,7 +132,7 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     process.recopixelvertexing = cms.Sequence(process.pixelTracksSequence + process.pixelVertices)
     process.pixelVertices.TkFilterParameters.minPt = cms.double(0.9)
     process.pixelTracksTrackingRegions.RegionPSet.originRadius = 0.4
-    process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 3
+    process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 6
     process.pixelTracksTrackingRegions.RegionPSet.originXPos = 0.08
     process.pixelTracksTrackingRegions.RegionPSet.originYPos = -0.03
     process.pixelTracksTrackingRegions.RegionPSet.originZPos = 1.

--- a/DQMOffline/Trigger/plugins/SOSMonitor.cc
+++ b/DQMOffline/Trigger/plugins/SOSMonitor.cc
@@ -1,0 +1,323 @@
+#include "DQMOffline/Trigger/plugins/SOSMonitor.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+
+#include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
+
+#include "TLorentzVector.h"
+
+
+// -----------------------------
+//  constructors and destructor
+// -----------------------------
+
+SOSMonitor::SOSMonitor( const edm::ParameterSet& iConfig ) : 
+  folderName_             ( iConfig.getParameter<std::string>("FolderName") )
+  , metToken_             ( consumes<reco::PFMETCollection>      (iConfig.getParameter<edm::InputTag>("met")       ) )   
+  , jetToken_             ( mayConsume<reco::PFJetCollection>      (iConfig.getParameter<edm::InputTag>("jets")      ) )   
+  , eleToken_             ( mayConsume<reco::GsfElectronCollection>(iConfig.getParameter<edm::InputTag>("electrons") ) )   
+  , muoToken_             ( mayConsume<reco::MuonCollection>       (iConfig.getParameter<edm::InputTag>("muons")     ) )   
+  , sos_variable_binning_ ( iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("sosBinning") )
+  , sos_binning_          ( getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("sosPSet")    ) )
+  , ls_binning_           ( getHistoLSPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("lsPSet")     ) )
+  , num_SOSTriggerEventFlag_(new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("numGenericTriggerEventPSet"),consumesCollector(), *this))
+  , den_SOSTriggerEventFlag_(new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("denGenericTriggerEventPSet"),consumesCollector(), *this))
+  , metSelection_ ( iConfig.getParameter<std::string>("metSelection") )
+  , jetSelection_ ( iConfig.getParameter<std::string>("jetSelection") )
+  , eleSelection_ ( iConfig.getParameter<std::string>("eleSelection") )
+  , muoSelection_ ( iConfig.getParameter<std::string>("muoSelection") )
+  , njets_      ( iConfig.getParameter<int>("njets" )      )
+  , nelectrons_ ( iConfig.getParameter<int>("nelectrons" ) )
+  , nmuons_     ( iConfig.getParameter<int>("nmuons" )     )
+  , turn_on_    (iConfig.getParameter<std::string>("turn_on"))
+  , met_pt_cut_ (iConfig.getParameter<int>("met_pt_cut"))
+  , mu2_pt_cut_ (iConfig.getParameter<int>("mu2_pt_cut"))
+  , HTdefinition_ ( iConfig.getParameter<std::string>("HTdefinition") )
+  , HTcut_     ( iConfig.getParameter<double>("HTcut" ))
+  , invMassUppercut_ (iConfig.getParameter<double>("invMassUppercut"))
+  , invMassLowercut_ (iConfig.getParameter<double>("invMassLowercut"))
+  , opsign_ (iConfig.getParameter<bool>("opsign"))
+  , MHTdefinition_ ( iConfig.getParameter<std::string>("MHTdefinition") )
+  , MHTcut_     ( iConfig.getParameter<double>("MHTcut" )     )
+
+{
+
+}
+
+SOSMonitor::~SOSMonitor()
+{
+  if (num_SOSTriggerEventFlag_) delete num_SOSTriggerEventFlag_;
+  if (den_SOSTriggerEventFlag_) delete den_SOSTriggerEventFlag_;
+}
+
+SOSbinning SOSMonitor::getHistoPSet(edm::ParameterSet pset)
+{
+  return SOSbinning{
+    pset.getParameter<int32_t>("nbins"),
+      pset.getParameter<double>("xmin"),
+      pset.getParameter<double>("xmax"),
+      };
+}
+
+SOSbinning SOSMonitor::getHistoLSPSet(edm::ParameterSet pset)
+{
+  return SOSbinning{
+    pset.getParameter<int32_t>("nbins"),
+      0.,
+      double(pset.getParameter<int32_t>("nbins"))
+      };
+}
+
+void SOSMonitor::setTitle(MON& mon, std::string titleX, std::string titleY)
+{
+  mon.numerator->setAxisTitle(titleX,1);
+  mon.numerator->setAxisTitle(titleY,2);
+  mon.denominator->setAxisTitle(titleX,1);
+  mon.denominator->setAxisTitle(titleY,2);
+
+}
+
+void SOSMonitor::bookME(DQMStore::IBooker &ibooker, MON& mon, const std::string& histname, const std::string& histtitle, int nbins, double min, double max)
+{
+  mon.numerator   = ibooker.book1D(histname+"_numerator",   histtitle+" (numerator)",   nbins, min, max);
+  mon.denominator = ibooker.book1D(histname+"_denominator", histtitle+" (denominator)", nbins, min, max);
+}
+void SOSMonitor::bookME(DQMStore::IBooker &ibooker, MON& mon, const std::string& histname, const std::string& histtitle, const std::vector<double>& binning)
+{
+  int nbins = binning.size()-1;
+  std::vector<float> fbinning(binning.begin(),binning.end());
+  float* arr = &fbinning[0];
+  mon.numerator   = ibooker.book1D(histname+"_numerator",   histtitle+" (numerator)",   nbins, arr);
+  mon.denominator = ibooker.book1D(histname+"_denominator", histtitle+" (denominator)", nbins, arr);
+}
+void SOSMonitor::bookME(DQMStore::IBooker &ibooker, MON& mon, const std::string& histname, const std::string& histtitle, int nbinsX, double xmin, double xmax, double ymin, double ymax)
+{
+  mon.numerator   = ibooker.bookProfile(histname+"_numerator",   histtitle+" (numerator)",   nbinsX, xmin, xmax, ymin, ymax);
+  mon.denominator = ibooker.bookProfile(histname+"_denominator", histtitle+" (denominator)", nbinsX, xmin, xmax, ymin, ymax);
+}
+void SOSMonitor::bookME(DQMStore::IBooker &ibooker, MON& mon, const std::string& histname, const std::string& histtitle, int nbinsX, double xmin, double xmax, int nbinsY, double ymin, double ymax)
+{
+  mon.numerator   = ibooker.book2D(histname+"_numerator",   histtitle+" (numerator)",   nbinsX, xmin, xmax, nbinsY, ymin, ymax);
+  mon.denominator = ibooker.book2D(histname+"_denominator", histtitle+" (denominator)", nbinsX, xmin, xmax, nbinsY, ymin, ymax);
+}
+void SOSMonitor::bookME(DQMStore::IBooker &ibooker, MON& mon, const std::string& histname, const std::string& histtitle, const std::vector<double>& binningX, const std::vector<double>& binningY)
+{
+  int nbinsX = binningX.size()-1;
+  std::vector<float> fbinningX(binningX.begin(),binningX.end());
+  float* arrX = &fbinningX[0];
+  int nbinsY = binningY.size()-1;
+  std::vector<float> fbinningY(binningY.begin(),binningY.end());
+  float* arrY = &fbinningY[0];
+
+  mon.numerator   = ibooker.book2D(histname+"_numerator",   histtitle+" (numerator)",   nbinsX, arrX, nbinsY, arrY);
+  mon.denominator = ibooker.book2D(histname+"_denominator", histtitle+" (denominator)", nbinsX, arrX, nbinsY, arrY);
+}
+
+void SOSMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
+				 edm::Run const        & iRun,
+				 edm::EventSetup const & iSetup) 
+{  
+  
+  std::string histname, histtitle, histtitle2;
+
+  std::string currentFolder = folderName_ ;
+  ibooker.setCurrentFolder(currentFolder.c_str());
+  if (turn_on_=="met") histtitle2="PFMET ";
+  else histtitle2="Pt(mu2)";
+  histname = turn_on_ ; histtitle=histtitle2;
+  bookME(ibooker,sosMON_,histname,histtitle,sos_binning_.nbins,sos_binning_.xmin, sos_binning_.xmax);
+  setTitle(sosMON_,histtitle2+"[GeV]","events / [GeV]");
+
+  histname = turn_on_+"_variable"; histtitle=histtitle2;
+  bookME(ibooker,sosMON_variableBinning_,histname,histtitle,sos_variable_binning_);
+  setTitle(sosMON_variableBinning_,histtitle2+"[GeV]","events / [GeV]");
+
+  histname = turn_on_+"VsLS"; histtitle = histtitle2+"vs LS";
+  bookME(ibooker,sosVsLS_,histname,histtitle,ls_binning_.nbins, ls_binning_.xmin, ls_binning_.xmax,sos_binning_.xmin, sos_binning_.xmax);
+  setTitle(sosVsLS_,"LS",histtitle2+"[GeV]");
+
+   histname = turn_on_+"_Phi"; histtitle = histtitle2+"phi";
+  bookME(ibooker,sosPhiMON_,histname,histtitle, phi_binning_.nbins, phi_binning_.xmin, phi_binning_.xmax);
+  setTitle(sosPhiMON_,histtitle2+"#phi","events / 0.1 rad");
+  
+histname = turn_on_+"_PhiEta"; histtitle = histtitle2+"phiEta";
+  bookME(ibooker,sosPhiEtaMON_,histname,histtitle, phi_binning_.nbins, phi_binning_.xmin, phi_binning_.xmax,eta_binning_.nbins,eta_binning_.xmin,eta_binning_.xmax);
+  setTitle(sosPhiEtaMON_,histtitle2+" #phi",histtitle2+" #eta");
+  
+ histname = turn_on_+"ht" ; histtitle=turn_on_+"ht";
+  bookME(ibooker,sosHTMON_,histname,histtitle,sos_binning_.nbins,sos_binning_.xmin, sos_binning_.xmax);
+  setTitle(sosHTMON_,"HT [GeV]","events / [GeV]");
+
+
+  // Initialize the GenericTriggerEventFlag
+  if ( num_SOSTriggerEventFlag_ && num_SOSTriggerEventFlag_->on() ) num_SOSTriggerEventFlag_->initRun( iRun, iSetup );
+  if ( den_SOSTriggerEventFlag_ && den_SOSTriggerEventFlag_->on() ) den_SOSTriggerEventFlag_->initRun( iRun, iSetup );
+
+}
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "TLorentzVector.h"
+#include "TVector3.h"
+void SOSMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup)  {
+
+  // Filter out events if Trigger Filtering is requested
+  if (den_SOSTriggerEventFlag_->on() && ! den_SOSTriggerEventFlag_->accept( iEvent, iSetup) ) return;
+
+  edm::Handle<reco::PFMETCollection> metHandle;
+  iEvent.getByToken( metToken_, metHandle );
+  reco::PFMET pfmet = metHandle->front();
+  if ( ! metSelection_( pfmet ) ) return;
+  
+  float met = pfmet.pt();
+  float phi = pfmet.phi();
+  
+double eventHT = 0.;
+  TVector3 eventMHT;
+  eventMHT.SetPtEtaPhi(0,0,0); 
+ edm::Handle<reco::PFJetCollection> jetHandle;
+  iEvent.getByToken( jetToken_, jetHandle );
+  std::vector<reco::PFJet> jets;
+  if ( jetHandle->size() < njets_ ) return;
+  for ( auto const & j : *jetHandle ) {
+    if ( jetSelection_( j ) ) jets.push_back(j);
+     if ( HTdefinition_ ( j ) ){
+          eventHT += j.pt();
+      }
+      TVector3 temp;
+      temp.SetPtEtaPhi(0,0,0);
+     if ( MHTdefinition_ ( j ) ){
+       temp.SetPtEtaPhi(j.pt(),j.eta(),j.phi());
+      }
+     eventMHT +=temp; 
+  }
+  if ( jets.size() < njets_ ) return;
+   if (eventHT < HTcut_) return;
+  if (MHTcut_>0 && eventMHT.Pt()<MHTcut_) return;  
+
+//float ht=0;
+ 
+ 
+  edm::Handle<reco::GsfElectronCollection> eleHandle;
+  iEvent.getByToken( eleToken_, eleHandle );
+  std::vector<reco::GsfElectron> electrons;
+  if ( eleHandle->size() < nelectrons_ ) return;
+  for ( auto const & e : *eleHandle ) {
+    if ( eleSelection_( e ) ) electrons.push_back(e);
+  }
+  if ( electrons.size() < nelectrons_ ) return;
+  
+
+  edm::Handle<reco::MuonCollection> muoHandle;
+  iEvent.getByToken( muoToken_, muoHandle );
+  if ( muoHandle->size() < nmuons_ ) return;
+  std::vector<reco::Muon> muons;
+  for ( auto const & m : *muoHandle ) {
+    if ( muoSelection_( m ) ) muons.push_back(m);
+  }
+  if ( muons.size() < nmuons_ ) return;
+if (nmuons_!=2) return;
+TLorentzVector mu1,mu2;
+mu1.SetPtEtaPhiM(muons[0].pt(),muons[0].eta(),muons[0].phi(),0.1);
+mu2.SetPtEtaPhiM(muons[1].pt(),muons[1].eta(),muons[1].phi(),0.1);
+sign=muons.at(0).charge()*muons.at(1).charge();
+ if ((mu1+mu2).M()>invMassUppercut_ || (mu1+mu2).M()<invMassLowercut_) return;
+if (muons[0].pt()<mu2_pt_cut_ || muons[1].pt()<mu2_pt_cut_) return;
+if (met<met_pt_cut_) return;
+if (opsign_ && sign==1) return;
+  
+
+// filling histograms (denominator)  
+  float var=met,var_eta=0,var_phi=phi; 
+  if (turn_on_=="met"){ var=met; var_eta=0; var_phi=phi;}
+  else{ var=muons[1].pt(); var_eta=muons[1].eta(); var_phi=muons[1].phi();}
+  sosMON_.denominator -> Fill(var);
+  sosMON_variableBinning_.denominator -> Fill(var);
+  sosPhiEtaMON_.denominator -> Fill(var_phi,var_eta);
+  sosPhiMON_.denominator -> Fill(var_phi);
+  sosHTMON_.denominator->Fill(eventHT);
+  int ls = iEvent.id().luminosityBlock();
+  sosVsLS_.denominator -> Fill(ls, var);
+  
+  // applying selection for numerator
+  if (num_SOSTriggerEventFlag_->on() && ! num_SOSTriggerEventFlag_->accept( iEvent, iSetup) ) return;
+
+  // filling histograms (num_genTriggerEventFlag_)  
+  sosMON_.numerator -> Fill(var);
+  sosMON_variableBinning_.numerator -> Fill(var);
+  sosPhiEtaMON_.numerator -> Fill(var_phi,var_eta);
+  sosPhiMON_.numerator -> Fill(var_phi);
+  sosVsLS_.numerator -> Fill(ls, var);
+  sosHTMON_.numerator->Fill(eventHT);
+ }
+
+void SOSMonitor::fillHistoPSetDescription(edm::ParameterSetDescription & pset)
+{
+  pset.add<int>   ( "nbins");
+  pset.add<double>( "xmin" );
+  pset.add<double>( "xmax" );
+}
+
+void SOSMonitor::fillHistoLSPSetDescription(edm::ParameterSetDescription & pset)
+{
+  pset.add<int>   ( "nbins", 2500);
+}
+
+void SOSMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
+{
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>  ( "FolderName", "HLT/SOS" );
+
+  desc.add<edm::InputTag>( "met",      edm::InputTag("pfMet") );
+  desc.add<edm::InputTag>( "jets",     edm::InputTag("ak4PFJetsCHS") );
+  desc.add<edm::InputTag>( "electrons",edm::InputTag("gedGsfElectrons") );
+  desc.add<edm::InputTag>( "muons",    edm::InputTag("muons") );
+  desc.add<std::string>("metSelection", "pt > 0");
+  desc.add<std::string>("jetSelection", "pt > 0 & abs(eta)<2.4");
+  desc.add<std::string>("eleSelection", "pt > 0 & abs(eta)<2.4");
+  desc.add<std::string>("muoSelection", "pt > 0 & abs(eta)<2.4");
+  desc.add<int>("njets",      0);
+  desc.add<int>("nelectrons", 0);
+  desc.add<int>("nmuons",     0);
+  desc.add<std::string>("turn_on","met");
+  desc.add<int>("met_pt_cut",0);
+  desc.add<int>("mu2_pt_cut",0);
+   desc.add<std::string>("HTdefinition", "pt > 0");
+ desc.add<double>("HTcut", 0);
+   desc.add<double>("invMassUppercut",-1.0);
+  desc.add<double>("invMassLowercut",-1.0);
+  desc.add<bool>("opsign",false);
+  desc.add<std::string>("MHTdefinition", "pt > 0");
+  desc.add<double>("MHTcut", -1);
+
+  edm::ParameterSetDescription genericTriggerEventPSet;
+ 
+  genericTriggerEventPSet.add<edm::InputTag>("dcsInputTag", edm::InputTag("scalersRawToDigi") );
+  genericTriggerEventPSet.add<edm::InputTag>("hltInputTag", edm::InputTag("TriggerResults::HLT") );
+  genericTriggerEventPSet.add<std::vector<std::string> >("hltPaths",{});
+
+  desc.add<edm::ParameterSetDescription>("numGenericTriggerEventPSet", genericTriggerEventPSet);
+  desc.add<edm::ParameterSetDescription>("denGenericTriggerEventPSet", genericTriggerEventPSet);
+
+  edm::ParameterSetDescription histoPSet;
+  edm::ParameterSetDescription sosPSet;
+  fillHistoPSetDescription(sosPSet);
+  histoPSet.add<edm::ParameterSetDescription>("sosPSet", sosPSet);
+  std::vector<double> bins = {0.,20.,40.,60.,80.,90.,100.,110.,120.,130.,140.,150.,160.,170.,180.,190.,200.,220.,240.,260.,280.,300.,350.,400.,450.,1000.};
+  histoPSet.add<std::vector<double> >("sosBinning", bins);
+
+  edm::ParameterSetDescription lsPSet;
+  fillHistoLSPSetDescription(lsPSet);
+  histoPSet.add<edm::ParameterSetDescription>("lsPSet", lsPSet);
+
+  desc.add<edm::ParameterSetDescription>("histoPSet",histoPSet);
+
+  descriptions.add("sosMonitoring", desc);
+}
+
+// Define this as a plug-in
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(SOSMonitor);

--- a/DQMOffline/Trigger/plugins/SOSMonitor.h
+++ b/DQMOffline/Trigger/plugins/SOSMonitor.h
@@ -1,0 +1,136 @@
+#ifndef SOSMONITOR_H
+#define SOSMONITOR_H
+
+#include <string>
+#include <vector>
+#include <map>
+
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
+
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+//DataFormats
+#include "DataFormats/METReco/interface/PFMET.h"
+#include "DataFormats/METReco/interface/PFMETCollection.h"
+
+#include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/JetReco/interface/PFJetCollection.h"
+#include "DataFormats/JetReco/interface/CaloJet.h"
+#include "DataFormats/JetReco/interface/CaloJetCollection.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
+
+class GenericTriggerEventFlag;
+
+struct SOSbinning {
+  int nbins;
+  double xmin;
+  double xmax;
+};
+
+struct MON {
+  MonitorElement* numerator;
+  MonitorElement* denominator;
+};
+//
+// class declaration
+//
+
+class SOSMonitor : public DQMEDAnalyzer 
+{
+public:
+  SOSMonitor( const edm::ParameterSet& );
+  ~SOSMonitor();
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillHistoPSetDescription(edm::ParameterSetDescription & pset);
+  static void fillHistoLSPSetDescription(edm::ParameterSetDescription & pset);
+
+protected:
+
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void bookME(DQMStore::IBooker &, MON& me, const std::string& histname, const std::string& histtitle, int nbins, double xmin, double xmax);
+  void bookME(DQMStore::IBooker &, MON& me, const std::string& histname, const std::string& histtitle, const std::vector<double>& binningX);
+  void bookME(DQMStore::IBooker &, MON& me, const std::string& histname, const std::string& histtitle, int nbinsX, double xmin, double xmax, double ymin, double ymax);
+  void bookME(DQMStore::IBooker &, MON& me, const std::string& histname, const std::string& histtitle, int nbinsX, double xmin, double xmax, int nbinsY, double ymin, double ymax);
+  void bookME(DQMStore::IBooker &, MON& me, const std::string& histname, const std::string& histtitle, const std::vector<double>& binningX, const std::vector<double>& binningY);
+  void setTitle(MON& me, std::string titleX, std::string titleY);
+
+  void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
+
+private:
+  static SOSbinning getHistoPSet    (edm::ParameterSet pset);
+  static SOSbinning getHistoLSPSet  (edm::ParameterSet pset);
+
+  std::string folderName_;
+  std::string histoSuffix_;
+
+  edm::EDGetTokenT<reco::PFMETCollection>       metToken_;
+  edm::EDGetTokenT<reco::PFJetCollection>       jetToken_;
+  edm::EDGetTokenT<reco::GsfElectronCollection> eleToken_;
+  edm::EDGetTokenT<reco::MuonCollection>        muoToken_;
+
+  std::vector<double> sos_variable_binning_;
+  SOSbinning           sos_binning_;
+  SOSbinning           ls_binning_;
+
+  MON sosMON_;
+  MON sosMON_variableBinning_;
+  MON sosVsLS_;
+  MON sosPhiEtaMON_;
+  MON sosPhiMON_;
+  MON sosHTMON_;
+
+
+  GenericTriggerEventFlag* num_SOSTriggerEventFlag_;
+  GenericTriggerEventFlag* den_SOSTriggerEventFlag_;
+
+  StringCutObjectSelector<reco::MET,true>         metSelection_;
+  StringCutObjectSelector<reco::PFJet,true   >    jetSelection_;
+  StringCutObjectSelector<reco::GsfElectron,true> eleSelection_;
+  StringCutObjectSelector<reco::Muon,true>        muoSelection_;
+  unsigned int njets_;
+  unsigned int nelectrons_;
+  unsigned int nmuons_;
+  std::string turn_on_;
+  int met_pt_cut_;
+  float mu2_pt_cut_;
+  StringCutObjectSelector<reco::PFJet,true   >    HTdefinition_;
+  double HTcut_;
+  double invMassUppercut_;
+  double invMassLowercut_;
+  bool opsign_;
+  StringCutObjectSelector<reco::PFJet,true   >    MHTdefinition_;
+  double MHTcut_;
+  int   sign;
+
+
+  double sosMAX_PHI = 3.2;
+int sosN_PHI = 64;
+SOSbinning phi_binning_{
+  sosN_PHI, -sosMAX_PHI, sosMAX_PHI
+};
+double sosMAX_ETA = 2.1;
+int sosN_ETA = 64;
+SOSbinning eta_binning_{
+ sosN_ETA,-sosMAX_ETA,sosMAX_ETA
+};
+};
+
+#endif // SOSMONITOR_H

--- a/DQMOffline/Trigger/python/SoftOSMonitor_cff.py
+++ b/DQMOffline/Trigger/python/SoftOSMonitor_cff.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.SoftOSMonitor_cfi import hltSOSmonitoring
+
+# HLT_PFMETNoMu90_PFMHTNoMu90_IDTight
+DoubleMu3_PFMET50_DZ_PFMHT60_METmonitoring = hltSOSmonitoring.clone()
+DoubleMu3_PFMET50_DZ_PFMHT60_METmonitoring.FolderName = cms.string('HLT/SOS/MET/')
+DoubleMu3_PFMET50_DZ_PFMHT60_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu3_PFMET50_DZ_PFMHT60_v1")
+DoubleMu3_PFMET50_DZ_PFMHT60_METmonitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v7")
+DoubleMu3_PFMET50_DZ_PFMHT60_METmonitoring.turn_on = cms.string("met")
+DoubleMu3_PFMET50_DZ_PFMHT60_METmonitoring.mu2_pt_cut = cms.int32(20)
+
+DoubleMu3_PFMET50_DZ_PFMHT60_MUmonitoring = hltSOSmonitoring.clone()
+DoubleMu3_PFMET50_DZ_PFMHT60_MUmonitoring.FolderName = cms.string('HLT/SOS/MU/')
+DoubleMu3_PFMET50_DZ_PFMHT60_MUmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu3_PFMET50_DZ_PFMHT60_v1")
+DoubleMu3_PFMET50_DZ_PFMHT60_MUmonitoring.turn_on = cms.string("mu")
+DoubleMu3_PFMET50_DZ_PFMHT60_MUmonitoring.met_pt_cut = cms.int32(200)
+DoubleMu3_PFMET50_DZ_PFMHT60_MUmonitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET140_PFMHT140_IDTight_v9")
+
+
+
+susHLTSOSmonitoring = cms.Sequence(
+ DoubleMu3_PFMET50_DZ_PFMHT60_MUmonitoring+
+DoubleMu3_PFMET50_DZ_PFMHT60_METmonitoring
+ 
+)
+

--- a/DQMOffline/Trigger/python/SoftOSMonitor_cff.py
+++ b/DQMOffline/Trigger/python/SoftOSMonitor_cff.py
@@ -5,17 +5,17 @@ from DQMOffline.Trigger.SoftOSMonitor_cfi import hltSOSmonitoring
 # HLT_PFMETNoMu90_PFMHTNoMu90_IDTight
 DoubleMu3_PFMET50_DZ_PFMHT60_METmonitoring = hltSOSmonitoring.clone()
 DoubleMu3_PFMET50_DZ_PFMHT60_METmonitoring.FolderName = cms.string('HLT/SOS/MET/')
-DoubleMu3_PFMET50_DZ_PFMHT60_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu3_PFMET50_DZ_PFMHT60_v1")
-DoubleMu3_PFMET50_DZ_PFMHT60_METmonitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v7")
+DoubleMu3_PFMET50_DZ_PFMHT60_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu3_PFMET50_DZ_PFMHT60_v*")
+DoubleMu3_PFMET50_DZ_PFMHT60_METmonitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*")
 DoubleMu3_PFMET50_DZ_PFMHT60_METmonitoring.turn_on = cms.string("met")
 DoubleMu3_PFMET50_DZ_PFMHT60_METmonitoring.mu2_pt_cut = cms.int32(20)
 
 DoubleMu3_PFMET50_DZ_PFMHT60_MUmonitoring = hltSOSmonitoring.clone()
 DoubleMu3_PFMET50_DZ_PFMHT60_MUmonitoring.FolderName = cms.string('HLT/SOS/MU/')
-DoubleMu3_PFMET50_DZ_PFMHT60_MUmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu3_PFMET50_DZ_PFMHT60_v1")
+DoubleMu3_PFMET50_DZ_PFMHT60_MUmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu3_PFMET50_DZ_PFMHT60_v*")
 DoubleMu3_PFMET50_DZ_PFMHT60_MUmonitoring.turn_on = cms.string("mu")
 DoubleMu3_PFMET50_DZ_PFMHT60_MUmonitoring.met_pt_cut = cms.int32(200)
-DoubleMu3_PFMET50_DZ_PFMHT60_MUmonitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET140_PFMHT140_IDTight_v9")
+DoubleMu3_PFMET50_DZ_PFMHT60_MUmonitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET140_PFMHT140_IDTight_v*")
 
 
 

--- a/DQMOffline/Trigger/python/SoftOSMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/SoftOSMonitor_cfi.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.sosMonitoring_cfi import sosMonitoring
+
+hltSOSmonitoring = sosMonitoring.clone()
+hltSOSmonitoring.FolderName = cms.string('HLT/SOS/PFMET/')
+hltSOSmonitoring.histoPSet.sosPSet = cms.PSet(
+  nbins = cms.int32 (  200  ),
+  xmin  = cms.double(   -0.5),
+  xmax  = cms.double(19999.5),
+)
+hltSOSmonitoring.met       = cms.InputTag("pfMetEI") # pfMet
+hltSOSmonitoring.jets      = cms.InputTag("pfJetsEI") # ak4PFJets, ak4PFJetsCHS
+hltSOSmonitoring.electrons = cms.InputTag("gedGsfElectrons") # while pfIsolatedElectronsEI are reco::PFCandidate !
+hltSOSmonitoring.muons     = cms.InputTag("muons") # while pfIsolatedMuonsEI are reco::PFCandidate !
+
+hltSOSmonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
+hltSOSmonitoring.numGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_DoubleMu3_PFMET50_DZ_PFMHT60_v1") # HLT_ZeroBias_v*
+hltSOSmonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
+hltSOSmonitoring.denGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v7")
+hltSOSmonitoring.denGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
+hltSOSmonitoring.turn_on= cms.string("met")
+hltSOSmonitoring.met_pt_cut=cms.int32(40)
+hltSOSmonitoring.mu2_pt_cut=cms.int32(3)

--- a/DQMOffline/Trigger/python/SusyMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/SusyMonitoring_Client_cff.py
@@ -1,4 +1,37 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+metSOSEfficiency = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/SUSY/SOS/MET/*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_met          'MET turnON;            PF MET [GeV]; efficiency'     met_numerator          met_denominator",
+ "efficPhi_met          'MET efficiency phi;            Phi[rad];efficiency'     met_Phi_numerator          met_Phi_denominator", 
+"effic_ht          'HT turnON;            HT [GeV]; efficiency'     metht_numerator          metht_denominator",  
+ ),
+efficiencyProfile = cms.untracked.vstring(
+        "effic_met_vs_LS 'MET efficiency vs LS; LS; PF MET efficiency' metVsLS_numerator metVsLS_denominator"
+),
+)
+
+
+
+muSOSEfficiency = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/SUSY/SOS/Muon/*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+  "effic_mu          'MU turnON;            PT(mu) [GeV]; efficiency'     mu_numerator          mu_denominator",
+ "efficPhiEta_mu          'MU efficiency phi-eta;            Phi[rad]; Eta'     mu_PhiEta_numerator          mu_PhiEta_denominator",
+    ),
+efficiencyProfile = cms.untracked.vstring(
+        "effic_mu_vs_LS 'MU efficiency vs LS; LS; PT(mu) efficiency' muVsLS_numerator muVsLS_denominator"
+),
+)
+
 
 susyClient = cms.Sequence(
+metSOSEfficiency
++muSOSEfficiency
 )

--- a/DQMOffline/Trigger/python/SusyMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SusyMonitoring_cff.py
@@ -1,7 +1,50 @@
 import FWCore.ParameterSet.Config as cms
+from DQMOffline.Trigger.SoftOSMonitor_cfi import hltSOSmonitoring
+
+double_soft_muon_muonpt = hltSOSmonitoring.clone()
+double_soft_muon_muonpt.FolderName   = cms.string('HLT/SUSY/SOS/Muon/')
+# Selections
+double_soft_muon_muonpt.nmuons           = cms.int32(2)
+double_soft_muon_muonpt.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_muonpt.HTcut            = cms.double(60)
+double_soft_muon_muonpt.metSelection     =cms.string('pt>150')
+double_soft_muon_muonpt.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_muonpt.MHTcut           = cms.double(150)
+double_soft_muon_muonpt.invMassUppercut  = cms.double(50)
+double_soft_muon_muonpt.invMassLowercut  = cms.double(10)
+double_soft_muon_muonpt.met_pt_cut=cms.int32(160)
+double_soft_muon_muonpt.turn_on=cms.string("mu")
+
+double_soft_muon_muonpt.histoPSet.sosPSet=cms.PSet(nbins=cms.int32(20), xmin=cms.double(0.0), xmax=cms.double(60) )
+
+double_soft_muon_muonpt.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoubleMu3_DZ_PFMET50_PFMHT60_v*')
+double_soft_muon_muonpt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFMET140_PFMHT140_v*')
+
+#met
+double_soft_muon_metpt = hltSOSmonitoring.clone()
+double_soft_muon_metpt.FolderName   = cms.string('HLT/SUSY/SOS/MET/')
+# Selections
+double_soft_muon_metpt.nmuons           = cms.int32(2)
+double_soft_muon_metpt.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_metpt.HTcut            = cms.double(60)
+double_soft_muon_metpt.muoSelection     =cms.string('pt>18 & abs(eta)<2.4')
+double_soft_muon_metpt.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_metpt.MHTcut           = cms.double(150)
+double_soft_muon_metpt.invMassUppercut       = cms.double(50)
+double_soft_muon_metpt.invMassLowercut       = cms.double(10)
+# Binning
+double_soft_muon_metpt.histoPSet.sosPSet   =cms.PSet(nbins=cms.int32(50),xmin=cms.double(50),xmax=cms.double(300) )
+# Triggers
+double_soft_muon_metpt.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoubleMu3_DZ_PFMET50_PFMHT60_v*')
+double_soft_muon_metpt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
+
 
 from DQMOffline.Trigger.RazorMonitor_cff import *
 
 susyMonitorHLT = cms.Sequence(
+
     susyHLTRazorMonitoring
++double_soft_muon_metpt
++double_soft_muon_muonpt
+
 )

--- a/L1Trigger/L1TGlobal/plugins/L1TExtCondProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TExtCondProducer.cc
@@ -3,7 +3,7 @@
 ///
 /// Description: Fill uGT external condition to allow testing stage 2 algos, e.g. Bptx
 ///
-/// 
+///
 /// \author: D. Puigh OSU
 ///
 
@@ -82,7 +82,7 @@ using namespace l1t;
     setBptxAND_ (iConfig.getParameter<bool>("setBptxAND")),
     setBptxPlus_ (iConfig.getParameter<bool>("setBptxPlus")),
     setBptxMinus_ (iConfig.getParameter<bool>("setBptxMinus")),
-    setBptxOR_ (iConfig.getParameter<bool>("setBptxOR")) 
+    setBptxOR_ (iConfig.getParameter<bool>("setBptxOR"))
   {
     // register what you produce
     produces<GlobalExtBlkBxCollection>();
@@ -112,18 +112,18 @@ using namespace l1t;
     // get / update the trigger menu from the EventSetup
     // local cache & check on cacheIdentifier
     unsigned long long l1GtMenuCacheID = iSetup.get<L1TUtmTriggerMenuRcd>().cacheIdentifier();
-    
+
     if (m_l1GtMenuCacheID != l1GtMenuCacheID) {
 
         edm::ESHandle<L1TUtmTriggerMenu> l1GtMenu;
         iSetup.get< L1TUtmTriggerMenuRcd>().get(l1GtMenu) ;
         const L1TUtmTriggerMenu* utml1GtMenu =  l1GtMenu.product();
-        
+
 	// Instantiate Parser
-        TriggerMenuParser gtParser = TriggerMenuParser();   
+        TriggerMenuParser gtParser = TriggerMenuParser();
 
 	std::map<std::string, unsigned int> extBitMap = gtParser.getExternalSignals(utml1GtMenu);
-	
+
 	m_l1GtMenuCacheID = l1GtMenuCacheID;
 	m_extBitMap = extBitMap;
     }
@@ -145,11 +145,23 @@ using namespace l1t;
     if( setBptxMinus_ && foundBptxMinus ) extCond_bx.setExternalDecision(m_extBitMap["BPTX_minus.v0"],true);
     if( setBptxOR_ && foundBptxOR ) extCond_bx.setExternalDecision(m_extBitMap["BPTX_plus_OR_minus.v0"],true);
 
+    //check for updated Bptx names as well
+    foundBptxAND = ( m_extBitMap.find("ZeroBias_BPTX_AND_VME")!=m_extBitMap.end() );
+    foundBptxPlus = ( m_extBitMap.find("BPTX_B1_VME")!=m_extBitMap.end() );
+    foundBptxMinus = ( m_extBitMap.find("BPTX_B2_VME")!=m_extBitMap.end() );
+    foundBptxOR = ( m_extBitMap.find("BPTX_OR_VME")!=m_extBitMap.end() );
+
+    // Fill in some external conditions for testing
+    if( setBptxAND_ && foundBptxAND ) extCond_bx.setExternalDecision(m_extBitMap["ZeroBias_BPTX_AND_VME"],true);
+    if( setBptxPlus_ && foundBptxPlus ) extCond_bx.setExternalDecision(m_extBitMap["BPTX_B1_VME"],true);
+    if( setBptxMinus_ && foundBptxMinus ) extCond_bx.setExternalDecision(m_extBitMap["BPTX_B2_VME"],true);
+    if( setBptxOR_ && foundBptxOR ) extCond_bx.setExternalDecision(m_extBitMap["BPTX_OR_VME"],true);
+
     // Fill Externals
     for( int iBx=bxFirst_; iBx<=bxLast_; iBx++ ){
       extCond->push_back(iBx, extCond_bx);
     }
-   
+
 
     iEvent.put(std::move(extCond));
 

--- a/L1Trigger/L1TGlobal/src/CorrCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrCondition.cc
@@ -159,6 +159,9 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
     CombinationsInCond cond0Comb;
     CombinationsInCond cond1Comb;
 
+    int cond0bx(0);
+    int cond1bx(0);
+
     switch (cond0Categ) {
         case CondMuon: {
             corrMuon = static_cast<const MuonTemplate*>(m_gtCond0);
@@ -169,6 +172,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
             reqObjResult = muCondition.condLastResult();
 
             cond0Comb = (muCondition.getCombinationsInCond());
+            cond0bx = (corrMuon->condRelativeBx());
             cndObjTypeVec[0] = (corrMuon->objectType())[0];
 
             if (m_verbosity ) {
@@ -189,6 +193,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
             reqObjResult = caloCondition.condLastResult();
 
             cond0Comb = (caloCondition.getCombinationsInCond());
+            cond0bx = (corrCalo->condRelativeBx());
             cndObjTypeVec[0] = (corrCalo->objectType())[0];
 
             if (m_verbosity) {
@@ -208,6 +213,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
             reqObjResult = eSumCondition.condLastResult();
 
             cond0Comb = (eSumCondition.getCombinationsInCond());
+            cond0bx = (corrEnergySum->condRelativeBx());
             cndObjTypeVec[0] = (corrEnergySum->objectType())[0];
 
             if (m_verbosity ) {
@@ -246,6 +252,8 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
             reqObjResult = muCondition.condLastResult();
 
             cond1Comb = (muCondition.getCombinationsInCond());
+            cond1bx = (corrMuon->condRelativeBx());
+
             cndObjTypeVec[1] = (corrMuon->objectType())[0];
 
             if (m_verbosity) {
@@ -265,6 +273,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
             reqObjResult = caloCondition.condLastResult();
 
             cond1Comb = (caloCondition.getCombinationsInCond());
+            cond1bx = (corrCalo->condRelativeBx());
             cndObjTypeVec[1] = (corrCalo->objectType())[0];
 
             if (m_verbosity ) {
@@ -285,6 +294,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
             reqObjResult = eSumCondition.condLastResult();
 
             cond1Comb = (eSumCondition.getCombinationsInCond());
+            cond1bx = (corrEnergySum->condRelativeBx());
             cndObjTypeVec[1] = (corrEnergySum->objectType())[0];
 
             if (m_verbosity) {
@@ -410,10 +420,10 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
             case CondMuon: {
 	        lutObj0 = "MU";
                 candMuVec = m_uGtB->getCandL1Mu();
-                phiIndex0 =  (candMuVec->at(bxEval,obj0Index))->hwPhiAtVtx(); //(*candMuVec)[obj0Index]->phiIndex();
-                etaIndex0 =  (candMuVec->at(bxEval,obj0Index))->hwEtaAtVtx();
-		etIndex0  =  (candMuVec->at(bxEval,obj0Index))->hwPt();
-		chrg0     =  (candMuVec->at(bxEval,obj0Index))->hwCharge();
+                phiIndex0 =  (candMuVec->at(cond0bx,obj0Index))->hwPhiAtVtx(); //(*candMuVec)[obj0Index]->phiIndex();
+                etaIndex0 =  (candMuVec->at(cond0bx,obj0Index))->hwEtaAtVtx();
+		etIndex0  =  (candMuVec->at(cond0bx,obj0Index))->hwPt();
+		chrg0     =  (candMuVec->at(cond0bx,obj0Index))->hwCharge();
 		int etaBin0 = etaIndex0;
 		if(etaBin0<0) etaBin0 = m_gtScales->getMUScales().etaBins.size() + etaBin0; //twos complement
 //		LogDebug("L1TGlobal") << "Muon phi" << phiIndex0 << " eta " << etaIndex0 << " etaBin0 = " << etaBin0  << " et " << etIndex0 << std::endl;
@@ -445,9 +455,9 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 	         case gtEG: {
 		    lutObj0 = "EG";
 		    candCaloVec = m_uGtB->getCandL1EG();
-		    phiIndex0 =  (candCaloVec->at(bxEval,obj0Index))->hwPhi();
-		    etaIndex0 =  (candCaloVec->at(bxEval,obj0Index))->hwEta();
-		    etIndex0  =  (candCaloVec->at(bxEval,obj0Index))->hwPt();
+		    phiIndex0 =  (candCaloVec->at(cond0bx,obj0Index))->hwPhi();
+		    etaIndex0 =  (candCaloVec->at(cond0bx,obj0Index))->hwEta();
+		    etIndex0  =  (candCaloVec->at(cond0bx,obj0Index))->hwPt();
 		    etaBin0   = etaIndex0;
 		    if(etaBin0<0) etaBin0 = m_gtScales->getEGScales().etaBins.size() + etaBin0;
 //		    LogDebug("L1TGlobal") << "EG0 phi" << phiIndex0 << " eta " << etaIndex0 << " etaBin0 = " << etaBin0 << " et " << etIndex0 << std::endl;
@@ -473,9 +483,9 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		 case gtJet: {
 		    lutObj0 = "JET";
 		    candCaloVec = m_uGtB->getCandL1Jet();
-		    phiIndex0 =  (candCaloVec->at(bxEval,obj0Index))->hwPhi();
-		    etaIndex0 =  (candCaloVec->at(bxEval,obj0Index))->hwEta();
-		    etIndex0  =  (candCaloVec->at(bxEval,obj0Index))->hwPt();
+		    phiIndex0 =  (candCaloVec->at(cond0bx,obj0Index))->hwPhi();
+		    etaIndex0 =  (candCaloVec->at(cond0bx,obj0Index))->hwEta();
+		    etIndex0  =  (candCaloVec->at(cond0bx,obj0Index))->hwPt();
 		    etaBin0 = etaIndex0;
 		    if(etaBin0<0) etaBin0 = m_gtScales->getJETScales().etaBins.size() + etaBin0;
 
@@ -499,9 +509,9 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		   break;
 		 case gtTau: {
 		    candCaloVec = m_uGtB->getCandL1Tau();
-		    phiIndex0 =  (candCaloVec->at(bxEval,obj0Index))->hwPhi();
-		    etaIndex0 =  (candCaloVec->at(bxEval,obj0Index))->hwEta();
-		    etIndex0  =  (candCaloVec->at(bxEval,obj0Index))->hwPt();
+		    phiIndex0 =  (candCaloVec->at(cond0bx,obj0Index))->hwPhi();
+		    etaIndex0 =  (candCaloVec->at(cond0bx,obj0Index))->hwEta();
+		    etIndex0  =  (candCaloVec->at(cond0bx,obj0Index))->hwPt();
 		    etaBin0 = etaIndex0;
 		    if(etaBin0<0) etaBin0 = m_gtScales->getTAUScales().etaBins.size() + etaBin0;
 
@@ -597,11 +607,11 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 
                 candEtSumVec = m_uGtB->getCandL1EtSum();
 
-                for( int iEtSum=0; iEtSum < (int)candEtSumVec->size(bxEval); iEtSum++) {
-		  if( (candEtSumVec->at(bxEval,iEtSum))->getType() == type ) {
-                    phiIndex0 =  (candEtSumVec->at(bxEval,iEtSum))->hwPhi();
-                    etaIndex0 =  (candEtSumVec->at(bxEval,iEtSum))->hwEta();
-		    etIndex0  =  (candEtSumVec->at(bxEval,iEtSum))->hwPt();
+                for( int iEtSum=0; iEtSum < (int)candEtSumVec->size(cond0bx); iEtSum++) {
+		  if( (candEtSumVec->at(cond0bx,iEtSum))->getType() == type ) {
+                    phiIndex0 =  (candEtSumVec->at(cond0bx,iEtSum))->hwPhi();
+                    etaIndex0 =  (candEtSumVec->at(cond0bx,iEtSum))->hwEta();
+		    etIndex0  =  (candEtSumVec->at(cond0bx,iEtSum))->hwPt();
 
 
 
@@ -705,10 +715,10 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
                 case CondMuon: {
 		   lutObj1 = "MU";
                    candMuVec = m_uGtB->getCandL1Mu();
-                   phiIndex1 =  (candMuVec->at(bxEval,obj1Index))->hwPhiAtVtx(); //(*candMuVec)[obj0Index]->phiIndex();
-                   etaIndex1 =  (candMuVec->at(bxEval,obj1Index))->hwEtaAtVtx();
-		   etIndex1  =  (candMuVec->at(bxEval,obj1Index))->hwPt();
-		   chrg1     =  (candMuVec->at(bxEval,obj1Index))->hwCharge();
+                   phiIndex1 =  (candMuVec->at(cond1bx,obj1Index))->hwPhiAtVtx(); //(*candMuVec)[obj0Index]->phiIndex();
+                   etaIndex1 =  (candMuVec->at(cond1bx,obj1Index))->hwEtaAtVtx();
+		   etIndex1  =  (candMuVec->at(cond1bx,obj1Index))->hwPt();
+		   chrg1     =  (candMuVec->at(cond1bx,obj1Index))->hwCharge();
 		   etaBin1 = etaIndex1;
 		   if(etaBin1<0) etaBin1 = m_gtScales->getMUScales().etaBins.size() + etaBin1;
 //		   LogDebug("L1TGlobal") << "Muon phi" << phiIndex1 << " eta " << etaIndex1 << " etaBin1 = " << etaBin1  << " et " << etIndex1 << std::endl;
@@ -735,9 +745,9 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
         	   switch(cndObjTypeVec[1]) {
 	             case gtEG: {
 			candCaloVec = m_uGtB->getCandL1EG();
-			phiIndex1 =  (candCaloVec->at(bxEval,obj1Index))->hwPhi();
-			etaIndex1 =  (candCaloVec->at(bxEval,obj1Index))->hwEta();
-			etIndex1  =  (candCaloVec->at(bxEval,obj1Index))->hwPt();
+			phiIndex1 =  (candCaloVec->at(cond1bx,obj1Index))->hwPhi();
+			etaIndex1 =  (candCaloVec->at(cond1bx,obj1Index))->hwEta();
+			etIndex1  =  (candCaloVec->at(cond1bx,obj1Index))->hwPt();
 			etaBin1   =   etaIndex1;
 			if(etaBin1<0) etaBin1 = m_gtScales->getEGScales().etaBins.size() + etaBin1;
 
@@ -761,9 +771,9 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		       break;
 		     case gtJet: {
 			candCaloVec = m_uGtB->getCandL1Jet();
-			phiIndex1 =  (candCaloVec->at(bxEval,obj1Index))->hwPhi();
-			etaIndex1 =  (candCaloVec->at(bxEval,obj1Index))->hwEta();
-			etIndex1  =  (candCaloVec->at(bxEval,obj1Index))->hwPt();
+			phiIndex1 =  (candCaloVec->at(cond1bx,obj1Index))->hwPhi();
+			etaIndex1 =  (candCaloVec->at(cond1bx,obj1Index))->hwEta();
+			etIndex1  =  (candCaloVec->at(cond1bx,obj1Index))->hwPt();
 			etaBin1 = etaIndex1;
 			if(etaBin1<0) etaBin1 = m_gtScales->getJETScales().etaBins.size() + etaBin1;
 
@@ -789,9 +799,9 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 		       break;
 		     case gtTau: {
 			candCaloVec = m_uGtB->getCandL1Tau();
-			phiIndex1 =  (candCaloVec->at(bxEval,obj1Index))->hwPhi();
-			etaIndex1 =  (candCaloVec->at(bxEval,obj1Index))->hwEta();
-			etIndex1  =  (candCaloVec->at(bxEval,obj1Index))->hwPt();
+			phiIndex1 =  (candCaloVec->at(cond1bx,obj1Index))->hwPhi();
+			etaIndex1 =  (candCaloVec->at(cond1bx,obj1Index))->hwEta();
+			etIndex1  =  (candCaloVec->at(cond1bx,obj1Index))->hwPt();
 			etaBin1 = etaIndex1;
 			if(etaBin1<0) etaBin1 = m_gtScales->getTAUScales().etaBins.size() + etaBin1;
 
@@ -890,12 +900,12 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 
 		   candEtSumVec = m_uGtB->getCandL1EtSum();
 
-		   LogDebug("L1TGlobal") << "obj " << lutObj1 << " Vector Size " << candEtSumVec->size(bxEval) << std::endl;
-                   for( int iEtSum=0; iEtSum < (int)candEtSumVec->size(bxEval); iEtSum++) {
-		     if( (candEtSumVec->at(bxEval,iEtSum))->getType() == type ) {
-                       phiIndex1 =  (candEtSumVec->at(bxEval,iEtSum))->hwPhi();
-                       etaIndex1 =  (candEtSumVec->at(bxEval,iEtSum))->hwEta();
-		       etIndex1  =  (candEtSumVec->at(bxEval,iEtSum))->hwPt();
+		   LogDebug("L1TGlobal") << "obj " << lutObj1 << " Vector Size " << candEtSumVec->size(cond1bx) << std::endl;
+                   for( int iEtSum=0; iEtSum < (int)candEtSumVec->size(cond1bx); iEtSum++) {
+		     if( (candEtSumVec->at(cond1bx,iEtSum))->getType() == type ) {
+                       phiIndex1 =  (candEtSumVec->at(cond1bx,iEtSum))->hwPhi();
+                       etaIndex1 =  (candEtSumVec->at(cond1bx,iEtSum))->hwEta();
+		       etIndex1  =  (candEtSumVec->at(cond1bx,iEtSum))->hwPt();
 
 		       // Determine Floating Pt numbers for floating point caluclation
 

--- a/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondition.cc
@@ -203,6 +203,10 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
     CombinationsInCond cond1Comb;
     CombinationsInCond cond2Comb;
 
+    int cond0bx(0);
+    int cond1bx(0);
+    int cond2bx(0);
+
     switch (cond0Categ) {
         case CondMuon: {
             corrMuon = static_cast<const MuonTemplate*>(m_gtCond0);
@@ -213,6 +217,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             reqObjResult = muCondition.condLastResult();
 
             cond0Comb = (muCondition.getCombinationsInCond());
+            cond0bx = (corrMuon->condRelativeBx());
+
             cndObjTypeVec[0] = (corrMuon->objectType())[0];
 
             if (m_verbosity ) {
@@ -233,6 +239,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             reqObjResult = caloCondition.condLastResult();
 
             cond0Comb = (caloCondition.getCombinationsInCond());
+            cond0bx = (corrCalo->condRelativeBx());
+
             cndObjTypeVec[0] = (corrCalo->objectType())[0];
 
             if (m_verbosity) {
@@ -252,6 +260,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             reqObjResult = eSumCondition.condLastResult();
 
             cond0Comb = (eSumCondition.getCombinationsInCond());
+            cond0bx = (corrEnergySum->condRelativeBx());
+
             cndObjTypeVec[0] = (corrEnergySum->objectType())[0];
 
             if (m_verbosity ) {
@@ -290,6 +300,7 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             reqObjResult = muCondition.condLastResult();
 
             cond1Comb = (muCondition.getCombinationsInCond());
+            cond1bx = (corrMuon->condRelativeBx());
             cndObjTypeVec[1] = (corrMuon->objectType())[0];
 
             if (m_verbosity) {
@@ -309,6 +320,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             reqObjResult = caloCondition.condLastResult();
 
             cond1Comb = (caloCondition.getCombinationsInCond());
+            cond1bx = (corrCalo->condRelativeBx());
+
             cndObjTypeVec[1] = (corrCalo->objectType())[0];
 
             if (m_verbosity ) {
@@ -329,6 +342,7 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             reqObjResult = eSumCondition.condLastResult();
 
             cond1Comb = (eSumCondition.getCombinationsInCond());
+            cond1bx = (corrEnergySum->condRelativeBx());
             cndObjTypeVec[1] = (corrEnergySum->objectType())[0];
 
             if (m_verbosity) {
@@ -369,6 +383,7 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             reqObjResult = muCondition.condLastResult();
 
             cond2Comb = (muCondition.getCombinationsInCond());
+            cond2bx = (corrMuon->condRelativeBx());
             cndObjTypeVec[2] = (corrMuon->objectType())[0];
 
             if (m_verbosity) {
@@ -388,6 +403,7 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             reqObjResult = caloCondition.condLastResult();
 
             cond2Comb = (caloCondition.getCombinationsInCond());
+            cond2bx = (corrCalo->condRelativeBx());
             cndObjTypeVec[2] = (corrCalo->objectType())[0];
 
             if (m_verbosity ) {
@@ -408,6 +424,7 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             reqObjResult = eSumCondition.condLastResult();
 
             cond2Comb = (eSumCondition.getCombinationsInCond());
+            cond2bx = (corrEnergySum->condRelativeBx());
             cndObjTypeVec[2] = (corrEnergySum->objectType())[0];
 
             if (m_verbosity) {
@@ -552,10 +569,10 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
         case CondMuon: {
           lutObj0 = "MU";
           candMuVec = m_uGtB->getCandL1Mu();
-          phiIndex0 =  (candMuVec->at(bxEval,obj0Index))->hwPhi(); //(*candMuVec)[obj0Index]->phiIndex();
-          etaIndex0 =  (candMuVec->at(bxEval,obj0Index))->hwEta();
-          etIndex0  =  (candMuVec->at(bxEval,obj0Index))->hwPt();
-          chrg0     =  (candMuVec->at(bxEval,obj0Index))->hwCharge();
+          phiIndex0 =  (candMuVec->at(cond0bx,obj0Index))->hwPhi(); //(*candMuVec)[obj0Index]->phiIndex();
+          etaIndex0 =  (candMuVec->at(cond0bx,obj0Index))->hwEta();
+          etIndex0  =  (candMuVec->at(cond0bx,obj0Index))->hwPt();
+          chrg0     =  (candMuVec->at(cond0bx,obj0Index))->hwCharge();
           int etaBin0 = etaIndex0;
           if(etaBin0<0) etaBin0 = m_gtScales->getMUScales().etaBins.size() + etaBin0; //twos complement
           //		LogDebug("L1TGlobal") << "Muon phi" << phiIndex0 << " eta " << etaIndex0 << " etaBin0 = " << etaBin0  << " et " << etIndex0 << std::endl;
@@ -587,9 +604,9 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
               case gtEG: {
                 lutObj0 = "EG";
                 candCaloVec = m_uGtB->getCandL1EG();
-                phiIndex0 =  (candCaloVec->at(bxEval,obj0Index))->hwPhi();
-                etaIndex0 =  (candCaloVec->at(bxEval,obj0Index))->hwEta();
-                etIndex0  =  (candCaloVec->at(bxEval,obj0Index))->hwPt();
+                phiIndex0 =  (candCaloVec->at(cond0bx,obj0Index))->hwPhi();
+                etaIndex0 =  (candCaloVec->at(cond0bx,obj0Index))->hwEta();
+                etIndex0  =  (candCaloVec->at(cond0bx,obj0Index))->hwPt();
                 etaBin0   = etaIndex0;
                 if(etaBin0<0) etaBin0 = m_gtScales->getEGScales().etaBins.size() + etaBin0;
                 //		    LogDebug("L1TGlobal") << "EG0 phi" << phiIndex0 << " eta " << etaIndex0 << " etaBin0 = " << etaBin0 << " et " << etIndex0 << std::endl;
@@ -615,9 +632,9 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
               case gtJet: {
                 lutObj0 = "JET";
                 candCaloVec = m_uGtB->getCandL1Jet();
-                phiIndex0 =  (candCaloVec->at(bxEval,obj0Index))->hwPhi();
-                etaIndex0 =  (candCaloVec->at(bxEval,obj0Index))->hwEta();
-                etIndex0  =  (candCaloVec->at(bxEval,obj0Index))->hwPt();
+                phiIndex0 =  (candCaloVec->at(cond0bx,obj0Index))->hwPhi();
+                etaIndex0 =  (candCaloVec->at(cond0bx,obj0Index))->hwEta();
+                etIndex0  =  (candCaloVec->at(cond0bx,obj0Index))->hwPt();
                 etaBin0 = etaIndex0;
                 if(etaBin0<0) etaBin0 = m_gtScales->getJETScales().etaBins.size() + etaBin0;
 
@@ -641,9 +658,9 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
                 break;
               case gtTau: {
                 candCaloVec = m_uGtB->getCandL1Tau();
-                phiIndex0 =  (candCaloVec->at(bxEval,obj0Index))->hwPhi();
-                etaIndex0 =  (candCaloVec->at(bxEval,obj0Index))->hwEta();
-                etIndex0  =  (candCaloVec->at(bxEval,obj0Index))->hwPt();
+                phiIndex0 =  (candCaloVec->at(cond0bx,obj0Index))->hwPhi();
+                etaIndex0 =  (candCaloVec->at(cond0bx,obj0Index))->hwEta();
+                etIndex0  =  (candCaloVec->at(cond0bx,obj0Index))->hwPt();
                 etaBin0 = etaIndex0;
                 if(etaBin0<0) etaBin0 = m_gtScales->getTAUScales().etaBins.size() + etaBin0;
 
@@ -746,11 +763,11 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
 
             candEtSumVec = m_uGtB->getCandL1EtSum();
 
-            for( int iEtSum=0; iEtSum < (int)candEtSumVec->size(bxEval); iEtSum++) {
-              if( (candEtSumVec->at(bxEval,iEtSum))->getType() == type ) {
-                phiIndex0 =  (candEtSumVec->at(bxEval,iEtSum))->hwPhi();
-                etaIndex0 =  (candEtSumVec->at(bxEval,iEtSum))->hwEta();
-                etIndex0  =  (candEtSumVec->at(bxEval,iEtSum))->hwPt();
+            for( int iEtSum=0; iEtSum < (int)candEtSumVec->size(cond0bx); iEtSum++) {
+              if( (candEtSumVec->at(cond0bx,iEtSum))->getType() == type ) {
+                phiIndex0 =  (candEtSumVec->at(cond0bx,iEtSum))->hwPhi();
+                etaIndex0 =  (candEtSumVec->at(cond0bx,iEtSum))->hwEta();
+                etIndex0  =  (candEtSumVec->at(cond0bx,iEtSum))->hwPt();
 
                 //  Get the floating point numbers
                 if(cndObjTypeVec[0] == gtETM ) {
@@ -853,8 +870,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
 
               lutObj2 = "MU";
               candMuVec = m_uGtB->getCandL1Mu();
-              phiIndex2 =  (candMuVec->at(bxEval,obj2Index))->hwPhi(); //(*candMuVec)[obj2Index]->phiIndex();
-              etaIndex2 =  (candMuVec->at(bxEval,obj2Index))->hwEta();
+              phiIndex2 =  (candMuVec->at(cond2bx,obj2Index))->hwPhi(); //(*candMuVec)[obj2Index]->phiIndex();
+              etaIndex2 =  (candMuVec->at(cond2bx,obj2Index))->hwEta();
               int etaBin2 = etaIndex2;
               if(etaBin2<0) etaBin2 = m_gtScales->getMUScales().etaBins.size() + etaBin2; //twos complement
               //LogDebug("L1TGlobal") << "Muon phi" << phiIndex2 << " eta " << etaIndex2 << " etaBin2 = " << etaBin2  << " et " << etIndex2 << std::endl;
@@ -877,8 +894,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
                 case gtEG: {
                   lutObj2 = "EG";
                   candCaloVec = m_uGtB->getCandL1EG();
-                  phiIndex2 =  (candCaloVec->at(bxEval,obj2Index))->hwPhi();
-                  etaIndex2 =  (candCaloVec->at(bxEval,obj2Index))->hwEta();
+                  phiIndex2 =  (candCaloVec->at(cond2bx,obj2Index))->hwPhi();
+                  etaIndex2 =  (candCaloVec->at(cond2bx,obj2Index))->hwEta();
                   if(etaBin2<0) etaBin2 = m_gtScales->getEGScales().etaBins.size() + etaBin2;
                   //LogDebug("L1TGlobal") << "EG0 phi" << phiIndex2 << " eta " << etaIndex2 << " etaBin2 = " << etaBin2 << " et " << etIndex2 << std::endl;
 
@@ -893,8 +910,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
                 case gtJet: {
                   lutObj2 = "JET";
                   candCaloVec = m_uGtB->getCandL1Jet();
-                  phiIndex2 =  (candCaloVec->at(bxEval,obj2Index))->hwPhi();
-                  etaIndex2 =  (candCaloVec->at(bxEval,obj2Index))->hwEta();
+                  phiIndex2 =  (candCaloVec->at(cond2bx,obj2Index))->hwPhi();
+                  etaIndex2 =  (candCaloVec->at(cond2bx,obj2Index))->hwEta();
                   etaBin2 = etaIndex2;
                   if(etaBin2<0) etaBin2 = m_gtScales->getJETScales().etaBins.size() + etaBin2;
 
@@ -909,8 +926,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
                 case gtTau: {
 
                   candCaloVec = m_uGtB->getCandL1Tau();
-                  phiIndex2 =  (candCaloVec->at(bxEval,obj2Index))->hwPhi();
-                  etaIndex2 =  (candCaloVec->at(bxEval,obj2Index))->hwEta();
+                  phiIndex2 =  (candCaloVec->at(cond2bx,obj2Index))->hwPhi();
+                  etaIndex2 =  (candCaloVec->at(cond2bx,obj2Index))->hwEta();
                   if(etaBin2<0) etaBin2 = m_gtScales->getTAUScales().etaBins.size() + etaBin2;
 
                   // Determine Floating Pt numbers for floating point caluclation
@@ -995,10 +1012,10 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
 
               candEtSumVec = m_uGtB->getCandL1EtSum();
 
-              for( int iEtSum=0; iEtSum < (int)candEtSumVec->size(bxEval); iEtSum++) {
-                if( (candEtSumVec->at(bxEval,iEtSum))->getType() == type ) {
-                  phiIndex2 =  (candEtSumVec->at(bxEval,iEtSum))->hwPhi();
-                  etaIndex2 =  (candEtSumVec->at(bxEval,iEtSum))->hwEta();
+              for( int iEtSum=0; iEtSum < (int)candEtSumVec->size(cond2bx); iEtSum++) {
+                if( (candEtSumVec->at(cond2bx,iEtSum))->getType() == type ) {
+                  phiIndex2 =  (candEtSumVec->at(cond2bx,iEtSum))->hwPhi();
+                  etaIndex2 =  (candEtSumVec->at(cond2bx,iEtSum))->hwEta();
 
                   //  Get the floating point numbers
                   if(cndObjTypeVec[2] == gtETM ) {
@@ -1218,10 +1235,10 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
               case CondMuon: {
                 lutObj1 = "MU";
                 candMuVec = m_uGtB->getCandL1Mu();
-                phiIndex1 =  (candMuVec->at(bxEval,obj1Index))->hwPhi(); //(*candMuVec)[obj0Index]->phiIndex();
-                etaIndex1 =  (candMuVec->at(bxEval,obj1Index))->hwEta();
-                etIndex1  =  (candMuVec->at(bxEval,obj1Index))->hwPt();
-                chrg1     =  (candMuVec->at(bxEval,obj1Index))->hwCharge();
+                phiIndex1 =  (candMuVec->at(cond1bx,obj1Index))->hwPhi(); //(*candMuVec)[obj0Index]->phiIndex();
+                etaIndex1 =  (candMuVec->at(cond1bx,obj1Index))->hwEta();
+                etIndex1  =  (candMuVec->at(cond1bx,obj1Index))->hwPt();
+                chrg1     =  (candMuVec->at(cond1bx,obj1Index))->hwCharge();
                 etaBin1 = etaIndex1;
                 if(etaBin1<0) etaBin1 = m_gtScales->getMUScales().etaBins.size() + etaBin1;
                 //		   LogDebug("L1TGlobal") << "Muon phi" << phiIndex1 << " eta " << etaIndex1 << " etaBin1 = " << etaBin1  << " et " << etIndex1 << std::endl;
@@ -1252,9 +1269,9 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
                   case gtEG: {
 
                     candCaloVec = m_uGtB->getCandL1EG();
-                    phiIndex1 =  (candCaloVec->at(bxEval,obj1Index))->hwPhi();
-                    etaIndex1 =  (candCaloVec->at(bxEval,obj1Index))->hwEta();
-                    etIndex1  =  (candCaloVec->at(bxEval,obj1Index))->hwPt();
+                    phiIndex1 =  (candCaloVec->at(cond1bx,obj1Index))->hwPhi();
+                    etaIndex1 =  (candCaloVec->at(cond1bx,obj1Index))->hwEta();
+                    etIndex1  =  (candCaloVec->at(cond1bx,obj1Index))->hwPt();
                     etaBin1   =   etaIndex1;
                     if(etaBin1<0) etaBin1 = m_gtScales->getEGScales().etaBins.size() + etaBin1;
 
@@ -1279,9 +1296,9 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
 
                   case gtJet: {
                     candCaloVec = m_uGtB->getCandL1Jet();
-                    phiIndex1 =  (candCaloVec->at(bxEval,obj1Index))->hwPhi();
-                    etaIndex1 =  (candCaloVec->at(bxEval,obj1Index))->hwEta();
-                    etIndex1  =  (candCaloVec->at(bxEval,obj1Index))->hwPt();
+                    phiIndex1 =  (candCaloVec->at(cond1bx,obj1Index))->hwPhi();
+                    etaIndex1 =  (candCaloVec->at(cond1bx,obj1Index))->hwEta();
+                    etIndex1  =  (candCaloVec->at(cond1bx,obj1Index))->hwPt();
                     etaBin1 = etaIndex1;
                     if(etaBin1<0) etaBin1 = m_gtScales->getJETScales().etaBins.size() + etaBin1;
                     etBin1 = etIndex1;
@@ -1297,8 +1314,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
                     std::pair<double, double> binEdges = m_gtScales->getJETScales().phiBins.at(phiIndex1);
                     phi1Phy = 0.5*(binEdges.second + binEdges.first);
                     binEdges = m_gtScales->getJETScales().etaBins.at(etaBin1);
-                    eta1Phy = 0.5*(binEdges.second + binEdges.first);		
-                    
+                    eta1Phy = 0.5*(binEdges.second + binEdges.first);
+
                     binEdges = m_gtScales->getJETScales().etBins.at(etBin1);
                     et1Phy = 0.5*(binEdges.second + binEdges.first);
                     lutObj1 = "JET";
@@ -1307,9 +1324,9 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
 
                   case gtTau: {
                     candCaloVec = m_uGtB->getCandL1Tau();
-                    phiIndex1 =  (candCaloVec->at(bxEval,obj1Index))->hwPhi();
-                    etaIndex1 =  (candCaloVec->at(bxEval,obj1Index))->hwEta();
-                    etIndex1  =  (candCaloVec->at(bxEval,obj1Index))->hwPt();
+                    phiIndex1 =  (candCaloVec->at(cond1bx,obj1Index))->hwPhi();
+                    etaIndex1 =  (candCaloVec->at(cond1bx,obj1Index))->hwEta();
+                    etIndex1  =  (candCaloVec->at(cond1bx,obj1Index))->hwPt();
                     etaBin1 = etaIndex1;
                     if(etaBin1<0) etaBin1 = m_gtScales->getTAUScales().etaBins.size() + etaBin1;
                     etBin1 = etIndex1;
@@ -1416,12 +1433,12 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
 
                 candEtSumVec = m_uGtB->getCandL1EtSum();
 
-                LogDebug("L1TGlobal") << "obj " << lutObj1 << " Vector Size " << candEtSumVec->size(bxEval) << std::endl;
-                for( int iEtSum=0; iEtSum < (int)candEtSumVec->size(bxEval); iEtSum++) {
-                  if( (candEtSumVec->at(bxEval,iEtSum))->getType() == type ) {
-                    phiIndex1 =  (candEtSumVec->at(bxEval,iEtSum))->hwPhi();
-                    etaIndex1 =  (candEtSumVec->at(bxEval,iEtSum))->hwEta();
-                    etIndex1  =  (candEtSumVec->at(bxEval,iEtSum))->hwPt();
+                LogDebug("L1TGlobal") << "obj " << lutObj1 << " Vector Size " << candEtSumVec->size(cond1bx) << std::endl;
+                for( int iEtSum=0; iEtSum < (int)candEtSumVec->size(cond1bx); iEtSum++) {
+                  if( (candEtSumVec->at(cond1bx,iEtSum))->getType() == type ) {
+                    phiIndex1 =  (candEtSumVec->at(cond1bx,iEtSum))->hwPhi();
+                    etaIndex1 =  (candEtSumVec->at(cond1bx,iEtSum))->hwEta();
+                    etIndex1  =  (candEtSumVec->at(cond1bx,iEtSum))->hwPt();
 
                     // Determine Floating Pt numbers for floating point caluclation
 
@@ -1518,8 +1535,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
                 case CondMuon: {
                   lutObj2 = "MU";
                   candMuVec = m_uGtB->getCandL1Mu();
-                  phiIndex2 =  (candMuVec->at(bxEval,obj2Index))->hwPhi(); //(*candMuVec)[obj2Index]->phiIndex();
-                  etaIndex2 =  (candMuVec->at(bxEval,obj2Index))->hwEta();
+                  phiIndex2 =  (candMuVec->at(cond2bx,obj2Index))->hwPhi(); //(*candMuVec)[obj2Index]->phiIndex();
+                  etaIndex2 =  (candMuVec->at(cond2bx,obj2Index))->hwEta();
                 	int etaBin2 = etaIndex2;
                 	if(etaBin2<0) etaBin2 = m_gtScales->getMUScales().etaBins.size() + etaBin2; //twos complement
                   //LogDebug("L1TGlobal") << "Muon phi" << phiIndex2 << " eta " << etaIndex2 << " etaBin2 = " << etaBin2  << " et " << etIndex2 << std::endl;
@@ -1542,8 +1559,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
                     case gtEG: {
                       lutObj2 = "EG";
                       candCaloVec = m_uGtB->getCandL1EG();
-                      phiIndex2 =  (candCaloVec->at(bxEval,obj2Index))->hwPhi();
-                      etaIndex2 =  (candCaloVec->at(bxEval,obj2Index))->hwEta();
+                      phiIndex2 =  (candCaloVec->at(cond2bx,obj2Index))->hwPhi();
+                      etaIndex2 =  (candCaloVec->at(cond2bx,obj2Index))->hwEta();
                       if(etaBin2<0) etaBin2 = m_gtScales->getEGScales().etaBins.size() + etaBin2;
                       //LogDebug("L1TGlobal") << "EG0 phi" << phiIndex2 << " eta " << etaIndex2 << " etaBin2 = " << etaBin2 << " et " << etIndex2 << std::endl;
 
@@ -1558,8 +1575,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
                     case gtJet: {
                       lutObj2 = "JET";
                       candCaloVec = m_uGtB->getCandL1Jet();
-                      phiIndex2 =  (candCaloVec->at(bxEval,obj2Index))->hwPhi();
-                      etaIndex2 =  (candCaloVec->at(bxEval,obj2Index))->hwEta();
+                      phiIndex2 =  (candCaloVec->at(cond2bx,obj2Index))->hwPhi();
+                      etaIndex2 =  (candCaloVec->at(cond2bx,obj2Index))->hwEta();
                       etaBin2 = etaIndex2;
                       if(etaBin2<0) etaBin2 = m_gtScales->getJETScales().etaBins.size() + etaBin2;
                       // Determine Floating Pt numbers for floating point caluclation
@@ -1571,8 +1588,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
                       break;
                     case gtTau: {
                       candCaloVec = m_uGtB->getCandL1Tau();
-                      phiIndex2 =  (candCaloVec->at(bxEval,obj2Index))->hwPhi();
-                      etaIndex2 =  (candCaloVec->at(bxEval,obj2Index))->hwEta();
+                      phiIndex2 =  (candCaloVec->at(cond2bx,obj2Index))->hwPhi();
+                      etaIndex2 =  (candCaloVec->at(cond2bx,obj2Index))->hwEta();
                       if(etaBin2<0) etaBin2 = m_gtScales->getTAUScales().etaBins.size() + etaBin2;
 
                       // Determine Floating Pt numbers for floating point caluclation
@@ -1656,10 +1673,10 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
 
                   candEtSumVec = m_uGtB->getCandL1EtSum();
 
-                  for( int iEtSum=0; iEtSum < (int)candEtSumVec->size(bxEval); iEtSum++) {
-                    if( (candEtSumVec->at(bxEval,iEtSum))->getType() == type ) {
-                      phiIndex2 =  (candEtSumVec->at(bxEval,iEtSum))->hwPhi();
-                      etaIndex2 =  (candEtSumVec->at(bxEval,iEtSum))->hwEta();
+                  for( int iEtSum=0; iEtSum < (int)candEtSumVec->size(cond2bx); iEtSum++) {
+                    if( (candEtSumVec->at(cond2bx,iEtSum))->getType() == type ) {
+                      phiIndex2 =  (candEtSumVec->at(cond2bx,iEtSum))->hwPhi();
+                      etaIndex2 =  (candEtSumVec->at(cond2bx,iEtSum))->hwEta();
 
                       //  Get the floating point numbers
                       if(cndObjTypeVec[2] == gtETM ) {

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -18,10 +18,9 @@ CTPPSDiamondRecHitProducerAlgorithm::CTPPSDiamondRecHitProducerAlgorithm( const 
 void
 CTPPSDiamondRecHitProducerAlgorithm::build( const TotemRPGeometry* geom, const edm::DetSetVector<CTPPSDiamondDigi>& input, edm::DetSetVector<CTPPSDiamondRecHit>& output )
 {
-  for ( edm::DetSetVector<CTPPSDiamondDigi>::const_iterator vec = input.begin(); vec != input.end(); ++vec )
-  {
+  for ( edm::DetSetVector<CTPPSDiamondDigi>::const_iterator vec = input.begin(); vec != input.end(); ++vec ) {
     const CTPPSDiamondDetId detid( vec->detId() );
-    
+
     if ( detid.channel() > 20 ) continue;              // VFAT-like information, to be ignored by CTPPSDiamondRecHitProducer
 
     const DetGeomDesc* det = geom->GetDetector( detid );
@@ -32,17 +31,19 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const TotemRPGeometry* geom, const e
 
     edm::DetSet<CTPPSDiamondRecHit>& rec_hits = output.find_or_insert( detid );
 
-    for ( edm::DetSet<CTPPSDiamondDigi>::const_iterator digi = vec->begin(); digi != vec->end(); ++digi )
-    {
-      const int t = digi->getLeadingEdge();
-      if ( t==0 ) { continue; }
+    for ( edm::DetSet<CTPPSDiamondDigi>::const_iterator digi = vec->begin(); digi != vec->end(); ++digi ) {
+      if ( digi->getLeadingEdge()==0 and digi->getTrailingEdge()==0 ) { continue; }
 
-      const int t0 = ( t-t_shift_ ) % 1024,
-                time_slice = ( t-t_shift_ ) / 1024;
+      const int t = digi->getLeadingEdge();
+      const int t0 = ( t-t_shift_ ) % 1024;
+      const int time_slice = ( t-t_shift_ ) / 1024;
+
+      int tot = 0;
+      if ( t!=0 && digi->getTrailingEdge()!=0 ) tot = ( (int) digi->getTrailingEdge() ) - t;
 
       rec_hits.push_back( CTPPSDiamondRecHit( x_pos, x_width, y_pos, y_width, // spatial information
                                               ( t0 * ts_to_ns_ ),
-                                              ( digi->getTrailingEdge()-t0 ) * ts_to_ns_,
+                                              ( tot * ts_to_ns_),
                                               time_slice,
                                               digi->getHPTDCErrorFlags(),
                                               digi->getMultipleHit() ) );

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -39,7 +39,7 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const TotemRPGeometry* geom, const e
       const int time_slice = ( t-t_shift_ ) / 1024;
 
       int tot = 0;
-      if ( i==0 && digi->getTrailingEdge()!=0 ) tot = ( (int) digi->getTrailingEdge() ) - t;
+      if ( t!=0 && digi->getTrailingEdge()!=0 ) tot = ( (int) digi->getTrailingEdge() ) - t;
 
       rec_hits.push_back( CTPPSDiamondRecHit( x_pos, x_width, y_pos, y_width, // spatial information
                                               ( t0 * ts_to_ns_ ),

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -18,10 +18,9 @@ CTPPSDiamondRecHitProducerAlgorithm::CTPPSDiamondRecHitProducerAlgorithm( const 
 void
 CTPPSDiamondRecHitProducerAlgorithm::build( const TotemRPGeometry* geom, const edm::DetSetVector<CTPPSDiamondDigi>& input, edm::DetSetVector<CTPPSDiamondRecHit>& output )
 {
-  for ( edm::DetSetVector<CTPPSDiamondDigi>::const_iterator vec = input.begin(); vec != input.end(); ++vec )
-  {
+  for ( edm::DetSetVector<CTPPSDiamondDigi>::const_iterator vec = input.begin(); vec != input.end(); ++vec ) {
     const CTPPSDiamondDetId detid( vec->detId() );
-    
+
     if ( detid.channel() > 20 ) continue;              // VFAT-like information, to be ignored by CTPPSDiamondRecHitProducer
 
     const DetGeomDesc* det = geom->GetDetector( detid );
@@ -32,16 +31,15 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const TotemRPGeometry* geom, const e
 
     edm::DetSet<CTPPSDiamondRecHit>& rec_hits = output.find_or_insert( detid );
 
-    for ( edm::DetSet<CTPPSDiamondDigi>::const_iterator digi = vec->begin(); digi != vec->end(); ++digi )
-    {
+    for ( edm::DetSet<CTPPSDiamondDigi>::const_iterator digi = vec->begin(); digi != vec->end(); ++digi ) {
       if ( digi->getLeadingEdge()==0 and digi->getTrailingEdge()==0 ) { continue; }
-      
+
       const int t = digi->getLeadingEdge();
       const int t0 = ( t-t_shift_ ) % 1024;
       const int time_slice = ( t-t_shift_ ) / 1024;
-                
+
       int tot = 0;
-      if (t!=0 and digi->getTrailingEdge()!=0) tot = ( (int) digi->getTrailingEdge() ) -t;
+      if ( i==0 && digi->getTrailingEdge()!=0 ) tot = ( (int) digi->getTrailingEdge() ) - t;
 
       rec_hits.push_back( CTPPSDiamondRecHit( x_pos, x_width, y_pos, y_width, // spatial information
                                               ( t0 * ts_to_ns_ ),

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -34,15 +34,18 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const TotemRPGeometry* geom, const e
 
     for ( edm::DetSet<CTPPSDiamondDigi>::const_iterator digi = vec->begin(); digi != vec->end(); ++digi )
     {
+      if ( digi->getLeadingEdge()==0 and digi->getTrailingEdge()==0 ) { continue; }
+      
       const int t = digi->getLeadingEdge();
-      if ( t==0 ) { continue; }
-
-      const int t0 = ( t-t_shift_ ) % 1024,
-                time_slice = ( t-t_shift_ ) / 1024;
+      const int t0 = ( t-t_shift_ ) % 1024;
+      const int time_slice = ( t-t_shift_ ) / 1024;
+                
+      int tot = 0;
+      if (t!=0 and digi->getTrailingEdge()!=0) tot = ( (int) digi->getTrailingEdge() ) -t;
 
       rec_hits.push_back( CTPPSDiamondRecHit( x_pos, x_width, y_pos, y_width, // spatial information
                                               ( t0 * ts_to_ns_ ),
-                                              ( digi->getTrailingEdge()-t0 ) * ts_to_ns_,
+                                              ( tot * ts_to_ns_),
                                               time_slice,
                                               digi->getHPTDCErrorFlags(),
                                               digi->getMultipleHit() ) );

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
@@ -10,29 +10,21 @@
 
 #include <vector>
 
-
+class TrackerTopology;
 
 class PixelFitterByHelixProjections final : public PixelFitterBase {
 public:
-  explicit PixelFitterByHelixProjections(const edm::EventSetup *es, const MagneticField *field);
+  explicit PixelFitterByHelixProjections(const edm::EventSetup *es, const MagneticField *field,
+                                         bool scaleErrorsForBPix1, float scaleFactor);
   virtual ~PixelFitterByHelixProjections() {}
   virtual std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits,
                                            const TrackingRegion& region) const override;
 
 private:
-  /* these are just static and local moved to local namespace in cc .... 
-   *
-  int charge(const std::vector<GlobalPoint> & points) const;
-  float cotTheta(const GlobalPoint& pinner, const GlobalPoint& pouter) const;
-  float phi(float xC, float yC, int charge) const;
-  float pt(float curvature) const;
-  float zip(float d0, float phi_p, float curv, 
-    const GlobalPoint& pinner, const GlobalPoint& pouter) const;
-  double errZip2(float apt, float eta) const;
-  double errTip2(float apt, float eta) const;
-  */
-private:
   const edm::EventSetup *theES;
   const MagneticField *theField;
+  const bool thescaleErrorsForBPix1;
+  const float thescaleFactor;
+  TrackerTopology const * theTopo=nullptr;
 };
 #endif

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelFitterByHelixProjectionsProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelFitterByHelixProjectionsProducer.cc
@@ -18,18 +18,24 @@
 
 class PixelFitterByHelixProjectionsProducer: public edm::global::EDProducer<> {
 public:
-  explicit PixelFitterByHelixProjectionsProducer(const edm::ParameterSet& iConfig) {
+  explicit PixelFitterByHelixProjectionsProducer(const edm::ParameterSet& iConfig)
+    : thescaleErrorsForBPix1(iConfig.getParameter<bool>("scaleErrorsForBPix1"))
+    , thescaleFactor(iConfig.getParameter<double>("scaleFactor"))  {
     produces<PixelFitter>();
   }
   ~PixelFitterByHelixProjectionsProducer() {}
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
-    descriptions.add("pixelFitterByHelixProjections", desc);
+    desc.add<bool>("scaleErrorsForBPix1", false);
+    desc.add<double>("scaleFactor", 0.65)->setComment("The default value was derived for phase1 pixel");
+    descriptions.add("pixelFitterByHelixProjectionsDefault", desc);
   }
 
 private:
   virtual void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+  const bool thescaleErrorsForBPix1;
+  const float thescaleFactor;
 };
 
 
@@ -37,7 +43,7 @@ void PixelFitterByHelixProjectionsProducer::produce(edm::StreamID, edm::Event& i
   edm::ESHandle<MagneticField> fieldESH;
   iSetup.get<IdealMagneticFieldRecord>().get(fieldESH);
 
-  auto impl = std::make_unique<PixelFitterByHelixProjections>(&iSetup, fieldESH.product());
+  auto impl = std::make_unique<PixelFitterByHelixProjections>(&iSetup, fieldESH.product(), thescaleErrorsForBPix1, thescaleFactor);
   auto prod = std::make_unique<PixelFitter>(std::move(impl));
   iEvent.put(std::move(prod));
 }

--- a/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_2017_cff.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_2017_cff.py
@@ -23,112 +23,39 @@ import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cf
 from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 
 # SEEDING LAYERS
-import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
-import RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff
 from RecoTracker.IterativeTracking.InitialStep_cff import initialStepSeedLayers, initialStepHitDoublets, initialStepHitQuadruplets
-from RecoTracker.IterativeTracking.HighPtTripletStep_cff import highPtTripletStepClusters, highPtTripletStepSeedLayers, highPtTripletStepHitDoublets, highPtTripletStepHitTriplets
 
 # TrackingRegion
 pixelTracksTrackingRegions = _globalTrackingRegion.clone()
 
 
 # Pixel Quadruplets Tracking
-pixelTracksQuadSeedLayers = initialStepSeedLayers.clone(
+pixelTracksSeedLayers = initialStepSeedLayers.clone(
     BPix = dict(HitProducer = "siPixelRecHitsPreSplitting"),
     FPix = dict(HitProducer = "siPixelRecHitsPreSplitting")
 )
 
-pixelTracksQuadHitDoublets = initialStepHitDoublets.clone(
+pixelTracksHitDoublets = initialStepHitDoublets.clone(
     clusterCheck = "",
-    seedingLayers = "pixelTracksQuadSeedLayers",
+    seedingLayers = "pixelTracksSeedLayers",
     trackingRegions = "pixelTracksTrackingRegions"
 )
 
-pixelTracksQuadHitQuadruplets = initialStepHitQuadruplets.clone(
-    doublets = "pixelTracksQuadHitDoublets",
+pixelTracksHitQuadruplets = initialStepHitQuadruplets.clone(
+    doublets = "pixelTracksHitDoublets",
     SeedComparitorPSet = dict(clusterShapeCacheSrc = 'siPixelClusterShapeCachePreSplitting')
 )
 
-pixelTracksQuad = _pixelTracks.clone(
-    SeedingHitSets = "pixelTracksQuadHitQuadruplets"
-)
-
-pixelTracksQuadSequence = cms.Sequence(
-    pixelTracksQuadSeedLayers +
-    pixelTracksQuadHitDoublets +
-    pixelTracksQuadHitQuadruplets +
-    pixelTracksQuad
-)
-
-# Pixel Triplets Tracking
-pixelTracksTripletSeedLayers = highPtTripletStepSeedLayers.clone(
-    BPix = dict(skipClusters = cms.InputTag('pixelTracksTripletClusters'), HitProducer = "siPixelRecHitsPreSplitting"),
-    FPix = dict(skipClusters = cms.InputTag('pixelTracksTripletClusters'), HitProducer = "siPixelRecHitsPreSplitting")
-)
-
-pixelTracksTripletClusters = highPtTripletStepClusters.clone(
-    trackClassifier = cms.InputTag( '','QualityMasks' ),
-    maxChi2 = cms.double( 3000.0 ),
-    trajectories = cms.InputTag( "pixelTracksQuad" ),
-    oldClusterRemovalInfo = cms.InputTag( "" ),
-    pixelClusters = cms.InputTag( "siPixelClustersPreSplitting" ),
-)
-
-pixelTracksTripletHitDoublets = highPtTripletStepHitDoublets.clone(
-    clusterCheck = "",
-    seedingLayers = "pixelTracksTripletSeedLayers",
-    trackingRegions = "pixelTracksTrackingRegions"
-)
-
-pixelTracksTripletHitTriplets = highPtTripletStepHitTriplets.clone(
-    doublets = "pixelTracksTripletHitDoublets",
-    SeedComparitorPSet = dict(clusterShapeCacheSrc = 'siPixelClusterShapeCachePreSplitting')
-)
-
-pixelTracksTriplet = _pixelTracks.clone(
-    SeedingHitSets = "pixelTracksTripletHitTriplets"
-)
-
-pixelTracksTripletSequence = cms.Sequence(
-    pixelTracksTripletClusters +
-    pixelTracksTripletSeedLayers +
-    pixelTracksTripletHitDoublets +
-    pixelTracksTripletHitTriplets +
-    pixelTracksTriplet
-)
-
-
-
-pixelTracks = cms.EDProducer( "TrackListMerger",
-                              ShareFrac = cms.double( 0.19 ),
-                              writeOnlyTrkQuals = cms.bool( False ),
-                              MinPT = cms.double( 0.05 ),
-                              allowFirstHitShare = cms.bool( True ),
-                              copyExtras = cms.untracked.bool( True ),
-                              Epsilon = cms.double( -0.001 ),
-                              selectedTrackQuals = cms.VInputTag( 'pixelTracksTriplet','pixelTracksQuad' ),
-                              indivShareFrac = cms.vdouble( 1.0, 1.0 ),
-                              MaxNormalizedChisq = cms.double( 1000.0 ),
-                              copyMVA = cms.bool( False ),
-                              FoundHitBonus = cms.double( 5.0 ),
-                              setsToMerge = cms.VPSet(
-                                  cms.PSet(  pQual = cms.bool( False ),
-                                             tLists = cms.vint32( 0, 1 )
-                                  )
-                              ),
-                              MinFound = cms.int32( 3 ),
-                              hasSelector = cms.vint32( 0, 0 ),
-                              TrackProducers = cms.VInputTag( 'pixelTracksTriplet','pixelTracksQuad' ),
-                              LostHitPenalty = cms.double( 20.0 ),
-                              newQuality = cms.string( "confirmed" ),
-                              trackAlgoPriorityOrder = cms.string("trackAlgoPriorityOrder")
+pixelTracks = _pixelTracks.clone(
+    SeedingHitSets = "pixelTracksHitQuadruplets"
 )
 
 pixelTracksSequence = cms.Sequence(
     pixelTracksTrackingRegions +
     pixelFitterByHelixProjections +
     pixelTrackFilterByKinematics +
-    pixelTracksQuadSequence +
-    pixelTracksTripletSequence +
+    pixelTracksSeedLayers +
+    pixelTracksHitDoublets +
+    pixelTracksHitQuadruplets +
     pixelTracks
 )

--- a/RecoPixelVertexing/PixelTrackFitting/python/pixelFitterByHelixProjections_cfi.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/pixelFitterByHelixProjections_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+
+from RecoPixelVertexing.PixelTrackFitting.pixelFitterByHelixProjectionsDefault_cfi import pixelFitterByHelixProjectionsDefault
+
+pixelFitterByHelixProjections = pixelFitterByHelixProjectionsDefault.clone()
+
+phase1Pixel.toModify( pixelFitterByHelixProjections, scaleErrorsForBPix1 = True)

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
@@ -30,6 +30,9 @@
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackErrorParam.h"
 #include "DataFormats/GeometryVector/interface/Pi.h"
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
 #include "CommonTools/Utils/interface/DynArray.h"
 
 using namespace std;
@@ -90,8 +93,18 @@ namespace {
   }
 }
   
-PixelFitterByHelixProjections::PixelFitterByHelixProjections(const edm::EventSetup *es, const MagneticField *field):
-  theES(es), theField(field) {}
+PixelFitterByHelixProjections::PixelFitterByHelixProjections(const edm::EventSetup *es,
+							     const MagneticField *field,
+                                                             bool scaleErrorsForBPix1,
+                                                             float scaleFactor):
+  theES(es), theField(field),
+  thescaleErrorsForBPix1(scaleErrorsForBPix1), thescaleFactor(scaleFactor)
+{
+  //Retrieve tracker topology from geometry
+  edm::ESHandle<TrackerTopology> tTopo;
+  es->get<TrackerTopologyRcd>().get(tTopo);
+  theTopo = tTopo.product();
+}
 
 std::unique_ptr<reco::Track> PixelFitterByHelixProjections::run(
     const std::vector<const TrackingRecHit * > & hits,
@@ -141,12 +154,23 @@ std::unique_ptr<reco::Track> PixelFitterByHelixProjections::run(
   float valEta = std::asinh(valCotTheta);
   float valZip = zip(valTip, valPhi, curvature, points[0],points[1]);
 
+  // Rescale down the error to take into accont the fact that the
+  // inner pixel barrel layer for PhaseI is closer to the interaction
+  // point. The effective scale factor has been derived by checking
+  // that the pulls of the pixelVertices derived from the pixelTracks
+  // have the correct mean and sigma.
+  float errFactor = 1.;
+  if ( thescaleErrorsForBPix1
+       && (hits[0]->geographicalId().subdetId() == PixelSubdetector::PixelBarrel) &&
+       (theTopo->pxbLayer(hits[0]->geographicalId()) == 1))
+	errFactor = thescaleFactor;
+
   PixelTrackErrorParam param(valEta, valPt);
-  float errValPt  = param.errPt();
-  float errValCot = param.errCot();
-  float errValTip = param.errTip();
-  float errValPhi = param.errPhi();
-  float errValZip = param.errZip();
+  float errValPt  = errFactor*param.errPt();
+  float errValCot = errFactor*param.errCot();
+  float errValTip = errFactor*param.errTip();
+  float errValPhi = errFactor*param.errPhi();
+  float errValZip = errFactor*param.errZip();
 
 
   float chi2 = 0;


### PR DESCRIPTION
This code is for prompt monitoring of doublemu3_pfmet50 path. the MET and muon leg efficiencies are derived. the code compiles and passes the runTheMatrix test in CMSSW 9_2_1.