### PR TITLE
Clang Check modernize-use-override

### DIFF
--- a/DetectorDescription/Core/interface/DDFilter.h
+++ b/DetectorDescription/Core/interface/DDFilter.h
@@ -27,7 +27,7 @@ public:
 class DDPassAllFilter : public DDFilter
 {
 public:
-  bool accept(const DDExpandedView &) const override final {
+  bool accept(const DDExpandedView &) const final {
     return true;
   }
 };
@@ -40,9 +40,9 @@ class DDSpecificsFilter : public DDFilter
 public:
   DDSpecificsFilter();
   
-  ~DDSpecificsFilter();
+  ~DDSpecificsFilter() override;
   
-  bool accept(const DDExpandedView &) const override final; 
+  bool accept(const DDExpandedView &) const final; 
 	      
   void setCriteria(const DDValue & nameVal, // name & value of a variable 
                    DDCompOp );
@@ -73,7 +73,7 @@ public:
     attribute_(iAttribute,"",0 )
     {}
 
-  bool accept(const DDExpandedView &) const override final; 
+  bool accept(const DDExpandedView &) const final; 
 
 private:
   DDValue attribute_;
@@ -86,7 +86,7 @@ public:
     value_(iValue)
     {}
 
-  bool accept(const DDExpandedView &) const override final; 
+  bool accept(const DDExpandedView &) const final; 
 
 private:
   DDValue value_;
@@ -100,7 +100,7 @@ public:
     f1_(std::move(iF1)),
     f2_(std::move(iF2)) {}
 
-  bool accept(const DDExpandedView & node) const override final {
+  bool accept(const DDExpandedView & node) const final {
     return f1_.accept(node) && f2_.accept(node);
   }
 private:

--- a/DetectorDescription/Core/interface/DDNumberingScheme.h
+++ b/DetectorDescription/Core/interface/DDNumberingScheme.h
@@ -57,28 +57,28 @@ public:
   typedef DDNumberingScheme::nav_type nav_type;
   DDDefaultNumberingScheme(const DDExpandedView & e);
   DDDefaultNumberingScheme(const DDFilteredView & f);
-  virtual ~DDDefaultNumberingScheme();
+  ~DDDefaultNumberingScheme() override;
   
   //! calculate the id of a given node
-  virtual int id(const DDExpandedView &) const;
+  int id(const DDExpandedView &) const override;
   
   //! calculate the id of a given node
-  virtual int id(const DDNumberingScheme::nav_type &) const;
+  int id(const DDNumberingScheme::nav_type &) const override;
   
   //! calculate the id of a given node
-  virtual int id(const DDFilteredView &) const;
+  int id(const DDFilteredView &) const override;
 
   //! calculate the node given an id
   /** 
     returns true, if a node was found. view then corresponds to this node.
   */  
-  virtual bool node(int id, DDExpandedView & view) const;
+  bool node(int id, DDExpandedView & view) const override;
 
   //! calculate the node given an id
   /** 
     returns true, if a node was found. view then corresponds to this node.
   */  
-  virtual bool node(int id, DDFilteredView & view) const;
+  bool node(int id, DDFilteredView & view) const override;
 
 protected:
   DDNumberingScheme::nav_type idToNavType(int id) const;

--- a/DetectorDescription/Core/interface/DDSpecifics.h
+++ b/DetectorDescription/Core/interface/DDSpecifics.h
@@ -70,7 +70,7 @@ public:
 	      const DDsvalues_type & svalues,
 	      bool doRegex=true);
   
-  ~DDSpecifics();
+  ~DDSpecifics() override;
   
   //! Gives a reference to the collection of part-selections
   const std::vector<DDPartSelection> & selection() const;

--- a/DetectorDescription/Core/plugins/DDAngular.h
+++ b/DetectorDescription/Core/plugins/DDAngular.h
@@ -16,15 +16,15 @@ class DDAngular : public DDAlgorithm
 {
 public:
   DDAngular( void );
-  virtual ~DDAngular( void );
+  ~DDAngular( void ) override;
 
   void initialize( const DDNumericArguments & nArgs,
                    const DDVectorArguments & vArgs,
                    const DDMapArguments & mArgs,
                    const DDStringArguments & sArgs,
-                   const DDStringVectorArguments & vsArgs );
+                   const DDStringVectorArguments & vsArgs ) override;
 
-  void execute( DDCompactView& cpv );
+  void execute( DDCompactView& cpv ) override;
 
 private:
 

--- a/DetectorDescription/Core/plugins/DDLinear.h
+++ b/DetectorDescription/Core/plugins/DDLinear.h
@@ -14,15 +14,15 @@ class DDLinear : public DDAlgorithm
 {
 public:
   DDLinear( void );
-  virtual ~DDLinear( void );
+  ~DDLinear( void ) override;
 
   void initialize( const DDNumericArguments & nArgs,
                    const DDVectorArguments & vArgs,
                    const DDMapArguments & mArgs,
                    const DDStringArguments & sArgs,
-                   const DDStringVectorArguments & vsArgs );
+                   const DDStringVectorArguments & vsArgs ) override;
 
-  void execute( DDCompactView& cpv );
+  void execute( DDCompactView& cpv ) override;
 
 private:
   int           m_n;              //Number of copies

--- a/DetectorDescription/Core/src/Box.h
+++ b/DetectorDescription/Core/src/Box.h
@@ -20,10 +20,10 @@ namespace DDI {
       p_.push_back(yHalf);
       p_.push_back(zHalf);
     }  
-    ~Box() { }
+    ~Box() override { }
     
-    double volume() const { return 8.*p_[0]*p_[1]*p_[2]; }
-    void stream(std::ostream & os) const;
+    double volume() const override { return 8.*p_[0]*p_[1]*p_[2]; }
+    void stream(std::ostream & os) const override;
   };
 
 }

--- a/DetectorDescription/Core/src/Cons.h
+++ b/DetectorDescription/Core/src/Cons.h
@@ -17,8 +17,8 @@ namespace DDI {
 	 double startPhi,
 	 double deltaPhi);
    
-    double volume() const ;
-    void stream(std::ostream &) const;	 
+    double volume() const override ;
+    void stream(std::ostream &) const override;	 
   };
 
 }

--- a/DetectorDescription/Core/src/CutTubs.h
+++ b/DetectorDescription/Core/src/CutTubs.h
@@ -16,9 +16,9 @@ namespace DDI {
 	    double lx, double ly, double lz,
 	    double tx, double ty, double tz);
     
-    double volume() const { return -1; }
+    double volume() const override { return -1; }
     
-    void stream(std::ostream & os) const;
+    void stream(std::ostream & os) const override;
    };
 }
 

--- a/DetectorDescription/Core/src/Ellipsoid.h
+++ b/DetectorDescription/Core/src/Ellipsoid.h
@@ -27,12 +27,12 @@ namespace DDI {
 	p_.push_back(zBottomCut);
 	p_.push_back(zTopCut);
       }  
-      ~Ellipsoid() { }
+      ~Ellipsoid() override { }
       
       /// Not as flexible and possibly less accurate than G4 volume.
-      double volume() const ;
+      double volume() const override ;
       double halfVol (double dz, double maxz) const;
-      void stream(std::ostream & os) const;
+      void stream(std::ostream & os) const override;
   };
   
 }

--- a/DetectorDescription/Core/src/EllipticalTube.h
+++ b/DetectorDescription/Core/src/EllipticalTube.h
@@ -20,11 +20,11 @@ namespace DDI {
       p_.push_back(ySemiAxis);
       p_.push_back(zHeight);
     }  
-    ~EllipticalTube() { }
+    ~EllipticalTube() override { }
 
     /// Not as flexible and possibly less accurate than G4 volume.
-    double volume() const ;
-    void stream(std::ostream & os) const;
+    double volume() const override ;
+    void stream(std::ostream & os) const override;
   };
 
 }

--- a/DetectorDescription/Core/src/ExtrudedPolygon.h
+++ b/DetectorDescription/Core/src/ExtrudedPolygon.h
@@ -21,8 +21,8 @@ namespace DDI {
 		     const std::vector<double> & zy,
 		     const std::vector<double> & zscale ); 
 
-    double volume() const;
-    void stream( std::ostream & ) const;
+    double volume() const override;
+    void stream( std::ostream & ) const override;
   };		  
 }
 #endif // DDI_ExtrudedPolygon_h

--- a/DetectorDescription/Core/src/Orb.h
+++ b/DetectorDescription/Core/src/Orb.h
@@ -18,10 +18,10 @@ namespace DDI {
     { 
       p_.push_back(rMax);
     }  
-    ~Orb() { }
+    ~Orb() override { }
     
-    double volume() const { return (4.*Geom::pi()*p_[0]*p_[0]*p_[0])/3.; }
-    void stream(std::ostream & os) const;
+    double volume() const override { return (4.*Geom::pi()*p_[0]*p_[0]*p_[0])/3.; }
+    void stream(std::ostream & os) const override;
   };
 
 }

--- a/DetectorDescription/Core/src/Parallelepiped.h
+++ b/DetectorDescription/Core/src/Parallelepiped.h
@@ -24,11 +24,11 @@ namespace DDI {
       p_.push_back(theta);
       p_.push_back(phi);
     }  
-    ~Parallelepiped() { }
+    ~Parallelepiped() override { }
 
     /// Not as flexible and possibly less accurate than G4 volume.
-    double volume() const ;
-    void stream(std::ostream & os) const;
+    double volume() const override ;
+    void stream(std::ostream & os) const override;
   };
 
 }

--- a/DetectorDescription/Core/src/Polycone.h
+++ b/DetectorDescription/Core/src/Polycone.h
@@ -20,8 +20,8 @@ namespace DDI {
                const std::vector<double> & z,
 	       const std::vector<double> & r);
     
-    double volume() const;
-    void stream(std::ostream &) const;  	       
+    double volume() const override;
+    void stream(std::ostream &) const override;  	       
   };		  
 }
 #endif // DDI_Polycone_h

--- a/DetectorDescription/Core/src/Polyhedra.h
+++ b/DetectorDescription/Core/src/Polyhedra.h
@@ -20,8 +20,8 @@ namespace DDI {
                const std::vector<double> & z,
 	       const std::vector<double> & r);
     
-    double volume() const;
-    void stream(std::ostream &) const;
+    double volume() const override;
+    void stream(std::ostream &) const override;
   	       
   };		  
 }

--- a/DetectorDescription/Core/src/PseudoTrap.h
+++ b/DetectorDescription/Core/src/PseudoTrap.h
@@ -24,11 +24,11 @@ namespace DDI {
        p_.push_back(minusZ);
      }
     
-    ~PseudoTrap(){ }
+    ~PseudoTrap() override{ }
     
-    double volume() const { return -1; }
+    double volume() const override { return -1; }
     
-    void stream(std::ostream & os) const;
+    void stream(std::ostream & os) const override;
   };
    
 }

--- a/DetectorDescription/Core/src/Reflection.h
+++ b/DetectorDescription/Core/src/Reflection.h
@@ -11,8 +11,8 @@ namespace DDI {
   {
   public:
     Reflection(const DDSolid & s);
-    double volume() const;
-    void stream(std::ostream &) const;
+    double volume() const override;
+    void stream(std::ostream &) const override;
     const DDSolid & solid() const { return s_; } 
   private:
     DDSolid s_;  

--- a/DetectorDescription/Core/src/Shapeless.h
+++ b/DetectorDescription/Core/src/Shapeless.h
@@ -10,8 +10,8 @@ namespace DDI {
   {
   public:
     Shapeless() : Solid(ddshapeless) { }
-    double volume() const { return 0; }
-    void stream(std::ostream & os) const 
+    double volume() const override { return 0; }
+    void stream(std::ostream & os) const override 
      { os << " shapeless"; }
   };
 }

--- a/DetectorDescription/Core/src/Sphere.h
+++ b/DetectorDescription/Core/src/Sphere.h
@@ -16,8 +16,8 @@ namespace DDI {
 	   double startZ,
 	   double deltaZ);
    
-    double volume() const ;
-    void stream(std::ostream &) const;	 
+    double volume() const override ;
+    void stream(std::ostream &) const override;	 
   };
 
 }

--- a/DetectorDescription/Core/src/Torus.h
+++ b/DetectorDescription/Core/src/Torus.h
@@ -16,9 +16,9 @@ namespace DDI {
 	  double pDPhi
 	  );
     
-    double volume() const;
+    double volume() const override;
     
-    void stream(std::ostream &) const;
+    void stream(std::ostream &) const override;
   };
 
 }

--- a/DetectorDescription/Core/src/Trap.h
+++ b/DetectorDescription/Core/src/Trap.h
@@ -17,9 +17,9 @@ namespace DDI {
          double pDy2, double pDx3, double pDx4,
          double pAlp2);
     
-    double volume() const;
+    double volume() const override;
     
-    void stream(std::ostream &) const;
+    void stream(std::ostream &) const override;
   };
 
 }

--- a/DetectorDescription/Core/src/TruncTubs.h
+++ b/DetectorDescription/Core/src/TruncTubs.h
@@ -17,9 +17,9 @@ namespace DDI {
 	      double cutAtDelta,
 	      bool cutInside);
     
-    double volume() const { return -1; }
+    double volume() const override { return -1; }
     
-    void stream(std::ostream & os) const;
+    void stream(std::ostream & os) const override;
    };
 }
 

--- a/DetectorDescription/Core/src/Tubs.h
+++ b/DetectorDescription/Core/src/Tubs.h
@@ -14,9 +14,9 @@ namespace DDI {
 	 double startPhi, 
 	 double deltaPhi);
 
-    double volume() const;
+    double volume() const override;
     
-    void stream(std::ostream &) const;
+    void stream(std::ostream &) const override;
   };  
 
 }

--- a/DetectorDescription/Core/test/DDFilter.cppunit.cc
+++ b/DetectorDescription/Core/test/DDFilter.cppunit.cc
@@ -24,8 +24,8 @@ class testDDFilter : public CppUnit::TestFixture {
   CPPUNIT_TEST(checkFilters);
   CPPUNIT_TEST_SUITE_END();
 public:
-  void setUp(){}
-  void tearDown() {}
+  void setUp() override{}
+  void tearDown() override {}
   void checkFilters();
 };
 

--- a/DetectorDescription/Core/test/DDIsValid.cppunit.cc
+++ b/DetectorDescription/Core/test/DDIsValid.cppunit.cc
@@ -160,8 +160,8 @@ class testDDIsValid : public CppUnit::TestFixture {
   CPPUNIT_TEST(checkAgaistOld);
   CPPUNIT_TEST_SUITE_END();
 public:
-  void setUp(){}
-  void tearDown() {}
+  void setUp() override{}
+  void tearDown() override {}
   void buildIt();
   void testloading();
   void checkAgaistOld();

--- a/DetectorDescription/Core/test/DDStrVector.cppunit.cc
+++ b/DetectorDescription/Core/test/DDStrVector.cppunit.cc
@@ -12,8 +12,8 @@ class testDDStrVector : public CppUnit::TestFixture {
   CPPUNIT_TEST(checkAgaistOld);
   CPPUNIT_TEST_SUITE_END();
 public:
-  void setUp(){}
-  void tearDown() {}
+  void setUp() override{}
+  void tearDown() override {}
   void buildIt();
   void testloading();
   void checkAgaistOld();

--- a/DetectorDescription/Core/test/Singleton_.cpp
+++ b/DetectorDescription/Core/test/Singleton_.cpp
@@ -24,7 +24,7 @@ class testSingleton : public CppUnit::TestFixture
   
 public:
 
-  void setUp( void ) 
+  void setUp( void ) override 
     {
       m_s = &DDI::Singleton<Dummy>::instance();
     }

--- a/DetectorDescription/OfflineDBLoader/plugins/OutputDDToDDL.cc
+++ b/DetectorDescription/OfflineDBLoader/plugins/OutputDDToDDL.cc
@@ -37,7 +37,7 @@ class OutputDDToDDL : public edm::one::EDAnalyzer<edm::one::WatchRuns>
 {
 public:
   explicit OutputDDToDDL( const edm::ParameterSet& iConfig );
-  ~OutputDDToDDL();
+  ~OutputDDToDDL() override;
 
   void beginJob() override {}
   void beginRun( edm::Run const& iEvent, edm::EventSetup const& ) override;

--- a/DetectorDescription/OfflineDBLoader/plugins/OutputMagneticFieldDDToDDL.cc
+++ b/DetectorDescription/OfflineDBLoader/plugins/OutputMagneticFieldDDToDDL.cc
@@ -35,7 +35,7 @@ class OutputMagneticFieldDDToDDL : public edm::one::EDAnalyzer<edm::one::WatchRu
 {
 public:
   explicit OutputMagneticFieldDDToDDL( const edm::ParameterSet& iConfig );
-  ~OutputMagneticFieldDDToDDL( void );
+  ~OutputMagneticFieldDDToDDL( void ) override;
   
   void beginJob() override {}
   void beginRun(edm::Run const& iEvent, edm::EventSetup const&) override;

--- a/DetectorDescription/Parser/interface/DDLSAX2ConfigHandler.h
+++ b/DetectorDescription/Parser/interface/DDLSAX2ConfigHandler.h
@@ -36,13 +36,13 @@ class DDLSAX2ConfigHandler : public DDLSAX2Handler
   //  Constructor and Destructor
   // -----------------------------------------------------------------------
   DDLSAX2ConfigHandler( DDCompactView& cpv);
-  ~DDLSAX2ConfigHandler();
+  ~DDLSAX2ConfigHandler() override;
 
   // -----------------------------------------------------------------------
   //  Handlers for the SAX ContentHandler interface
   // -----------------------------------------------------------------------
   void startElement(const XMLCh* const uri, const XMLCh* const localname
-		    , const XMLCh* const qname, const Attributes& attrs);
+		    , const XMLCh* const qname, const Attributes& attrs) override;
 
   const std::vector<std::string>& getFileNames() const;
   const std::vector<std::string>& getURLs() const;

--- a/DetectorDescription/Parser/interface/DDLSAX2ExpressionHandler.h
+++ b/DetectorDescription/Parser/interface/DDLSAX2ExpressionHandler.h
@@ -26,7 +26,7 @@ class DDLSAX2ExpressionHandler : public DDLSAX2FileHandler
  public:
 
   DDLSAX2ExpressionHandler(DDCompactView& cpv);
-  ~DDLSAX2ExpressionHandler();
+  ~DDLSAX2ExpressionHandler() override;
 
   void startElement(const XMLCh* const uri, const XMLCh* const localname,
 		    const XMLCh* const qname, const Attributes& attrs) override;

--- a/DetectorDescription/Parser/interface/DDLSAX2FileHandler.h
+++ b/DetectorDescription/Parser/interface/DDLSAX2FileHandler.h
@@ -36,7 +36,7 @@ class DDLSAX2FileHandler : public DDLSAX2Handler
  public:
   
   DDLSAX2FileHandler( DDCompactView& cpv );
-  ~DDLSAX2FileHandler();
+  ~DDLSAX2FileHandler() override;
 
   void init() ;
 

--- a/DetectorDescription/Parser/interface/DDLSAX2Handler.h
+++ b/DetectorDescription/Parser/interface/DDLSAX2Handler.h
@@ -31,7 +31,7 @@ class DDLSAX2Handler : public XERCES_CPP_NAMESPACE::DefaultHandler
   typedef XERCES_CPP_NAMESPACE::SAXParseException SAXParseException;
 
   DDLSAX2Handler();
-  ~DDLSAX2Handler();
+  ~DDLSAX2Handler() override;
 
   /// Get the count of elements processed so far.
   unsigned int getElementCount() const
@@ -63,21 +63,21 @@ class DDLSAX2Handler : public XERCES_CPP_NAMESPACE::DefaultHandler
   //  Handlers for the SAX ContentHandler interface
   // -----------------------------------------------------------------------
 
-  virtual void startElement(const XMLCh* const uri, const XMLCh* const localname,
+  void startElement(const XMLCh* const uri, const XMLCh* const localname,
 			    const XMLCh* const qname, const Attributes& attrs) override;
-  virtual void endElement(const XMLCh* const uri, const XMLCh* const localname,
+  void endElement(const XMLCh* const uri, const XMLCh* const localname,
 			  const XMLCh* const qname) override;
-  virtual void characters(const XMLCh* const chars, const XMLSize_t length) override;
-  virtual void comment (const XMLCh *const chars, const XMLSize_t length ) override;
-  virtual void ignorableWhitespace(const XMLCh* const chars, const XMLSize_t length) override;
-  virtual void resetDocument() override;
+  void characters(const XMLCh* const chars, const XMLSize_t length) override;
+  void comment (const XMLCh *const chars, const XMLSize_t length ) override;
+  void ignorableWhitespace(const XMLCh* const chars, const XMLSize_t length) override;
+  void resetDocument() override;
 
   // -----------------------------------------------------------------------
   //  Handlers for the SAX ErrorHandler interface
   // -----------------------------------------------------------------------
-  virtual void warning(const SAXParseException& exception) override;
-  virtual void error(const SAXParseException& exception) override;
-  virtual void fatalError(const SAXParseException& exception) override;
+  void warning(const SAXParseException& exception) override;
+  void error(const SAXParseException& exception) override;
+  void fatalError(const SAXParseException& exception) override;
   virtual void dumpStats(const std::string& fname);
   
  protected:

--- a/DetectorDescription/Parser/interface/FIPConfiguration.h
+++ b/DetectorDescription/Parser/interface/FIPConfiguration.h
@@ -29,31 +29,31 @@ class FIPConfiguration : public DDLDocumentProvider
  public:
 
   FIPConfiguration( DDCompactView& cpv);
-  virtual ~FIPConfiguration();
+  ~FIPConfiguration() override;
 
   /// Read in the configuration file.
-  int readConfig(const std::string& filename);
+  int readConfig(const std::string& filename) override;
 
   /// Read in the configuration file.
   int readConfig(const std::string& filename, bool fullPath);
 
   /// Return a list of files as a std::vector of strings.
-  virtual const std::vector < std::string >&  getFileList(void) const;
+  const std::vector < std::string >&  getFileList(void) const override;
 
   /// Return a list of urls as a std::vector of strings.
   /**
      This implementation does not provide a meaningful url list.
    **/
-  virtual const std::vector < std::string >&  getURLList(void) const;
+  const std::vector < std::string >&  getURLList(void) const override;
 
   /// Print out the list of files.
-  virtual void dumpFileList(void) const;
+  void dumpFileList(void) const override;
 
   /// Return whether Validation should be on or off and where the DDL SchemaLocation is.
-  virtual bool doValidation() const;
+  bool doValidation() const override;
 
   /// Return the designation for where to look for the schema.
-  std::string getSchemaLocation() const;
+  std::string getSchemaLocation() const override;
 
  private:
   DDLSAX2ConfigHandler configHandler_;

--- a/DetectorDescription/Parser/src/DDDividedBox.h
+++ b/DetectorDescription/Parser/src/DDDividedBox.h
@@ -20,10 +20,10 @@ class DDDividedBoxX final : public DDDividedGeometryObject
   
   DDDividedBoxX( const DDDivision& div, DDCompactView* cpv);
   
-  virtual double getMaxParameter() const override;
-  virtual DDTranslation makeDDTranslation( const int copyNo ) const override;
-  virtual DDRotation makeDDRotation( const int copyNo ) const override;
-  virtual DDLogicalPart makeDDLogicalPart(const int copyNo) const override;
+  double getMaxParameter() const override;
+  DDTranslation makeDDTranslation( const int copyNo ) const override;
+  DDRotation makeDDRotation( const int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart(const int copyNo) const override;
 };
 
 class DDDividedBoxY final : public DDDividedGeometryObject
@@ -32,10 +32,10 @@ class DDDividedBoxY final : public DDDividedGeometryObject
   
   DDDividedBoxY( const DDDivision& div, DDCompactView* cpv);
   
-  virtual double getMaxParameter() const override;
-  virtual DDTranslation makeDDTranslation( const int copyNo ) const override;
-  virtual DDRotation makeDDRotation( const int copyNo ) const override;
-  virtual DDLogicalPart makeDDLogicalPart(const int copyNo) const override;
+  double getMaxParameter() const override;
+  DDTranslation makeDDTranslation( const int copyNo ) const override;
+  DDRotation makeDDRotation( const int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart(const int copyNo) const override;
 };
 
 class DDDividedBoxZ final : public DDDividedGeometryObject
@@ -44,9 +44,9 @@ class DDDividedBoxZ final : public DDDividedGeometryObject
   
   DDDividedBoxZ( const DDDivision& div, DDCompactView* cpv);
   
-  virtual double getMaxParameter() const override;
-  virtual DDTranslation makeDDTranslation( const int copyNo ) const override;
-  virtual DDRotation makeDDRotation( const int copyNo ) const override;
-  virtual DDLogicalPart makeDDLogicalPart(const int copyNo) const override;
+  double getMaxParameter() const override;
+  DDTranslation makeDDTranslation( const int copyNo ) const override;
+  DDRotation makeDDRotation( const int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart(const int copyNo) const override;
 };
 #endif

--- a/DetectorDescription/Parser/src/DDDividedCons.h
+++ b/DetectorDescription/Parser/src/DDDividedCons.h
@@ -19,10 +19,10 @@ class DDDividedConsRho final : public DDDividedGeometryObject
   
   DDDividedConsRho( const DDDivision& div, DDCompactView* cpv );
 
-  virtual double getMaxParameter() const override;
-  virtual DDTranslation makeDDTranslation( const int copyNo ) const override;
-  virtual DDRotation makeDDRotation(const int copyNo ) const override;
-  virtual DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+  double getMaxParameter() const override;
+  DDTranslation makeDDTranslation( const int copyNo ) const override;
+  DDRotation makeDDRotation(const int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
 };
 
 class DDDividedConsPhi final : public DDDividedGeometryObject
@@ -31,10 +31,10 @@ class DDDividedConsPhi final : public DDDividedGeometryObject
   
   DDDividedConsPhi( const DDDivision& div, DDCompactView* cpv );
 
-  virtual double getMaxParameter() const override;
-  virtual DDTranslation makeDDTranslation( const int copyNo ) const override;
-  virtual DDRotation makeDDRotation(const int copyNo ) const override;
-  virtual DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+  double getMaxParameter() const override;
+  DDTranslation makeDDTranslation( const int copyNo ) const override;
+  DDRotation makeDDRotation(const int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
 };
 
 class DDDividedConsZ final : public DDDividedGeometryObject
@@ -43,10 +43,10 @@ class DDDividedConsZ final : public DDDividedGeometryObject
   
   DDDividedConsZ( const DDDivision& div, DDCompactView* cpv) ;
 
-  virtual double getMaxParameter() const override;
-  virtual DDTranslation makeDDTranslation( const int copyNo ) const override;
-  virtual DDRotation makeDDRotation(const int copyNo ) const override;
-  virtual DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+  double getMaxParameter() const override;
+  DDTranslation makeDDTranslation( const int copyNo ) const override;
+  DDRotation makeDDRotation(const int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
 };
 
 #endif

--- a/DetectorDescription/Parser/src/DDDividedPolycone.h
+++ b/DetectorDescription/Parser/src/DDDividedPolycone.h
@@ -23,11 +23,11 @@ class DDDividedPolyconeRho final : public DDDividedGeometryObject
   
   DDDividedPolyconeRho( const DDDivision& div, DDCompactView* cpv );
   
-  virtual void checkParametersValidity() override;
-  virtual double getMaxParameter() const override;
-  virtual DDTranslation makeDDTranslation( const int copyNo ) const override;
-  virtual DDRotation makeDDRotation(const int copyNo ) const override;
-  virtual DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+  void checkParametersValidity() override;
+  double getMaxParameter() const override;
+  DDTranslation makeDDTranslation( const int copyNo ) const override;
+  DDRotation makeDDRotation(const int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
 };
 
 class DDDividedPolyconePhi final : public DDDividedGeometryObject
@@ -36,11 +36,11 @@ class DDDividedPolyconePhi final : public DDDividedGeometryObject
   
   DDDividedPolyconePhi( const DDDivision& div, DDCompactView* cpv );
   
-  virtual void checkParametersValidity() override;
-  virtual double getMaxParameter() const override;
-  virtual DDTranslation makeDDTranslation( const int copyNo ) const override;
-  virtual DDRotation makeDDRotation(const int copyNo ) const override;
-  virtual DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+  void checkParametersValidity() override;
+  double getMaxParameter() const override;
+  DDTranslation makeDDTranslation( const int copyNo ) const override;
+  DDRotation makeDDRotation(const int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
 };
 
 class DDDividedPolyconeZ final : public DDDividedGeometryObject
@@ -49,11 +49,11 @@ class DDDividedPolyconeZ final : public DDDividedGeometryObject
   
   DDDividedPolyconeZ( const DDDivision& div, DDCompactView* cpv );
   
-  virtual void checkParametersValidity() override;
-  virtual double getMaxParameter() const override;
-  virtual DDTranslation makeDDTranslation( const int copyNo ) const override;
-  virtual DDRotation makeDDRotation( const int copyNo ) const override;
-  virtual DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+  void checkParametersValidity() override;
+  double getMaxParameter() const override;
+  DDTranslation makeDDTranslation( const int copyNo ) const override;
+  DDRotation makeDDRotation( const int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
 };
 
 #endif

--- a/DetectorDescription/Parser/src/DDDividedPolyhedra.h
+++ b/DetectorDescription/Parser/src/DDDividedPolyhedra.h
@@ -23,11 +23,11 @@ class DDDividedPolyhedraRho final : public DDDividedGeometryObject
   
   DDDividedPolyhedraRho( const DDDivision& div, DDCompactView* cpv );
   
-  virtual void checkParametersValidity() override;
-  virtual double getMaxParameter() const override;
-  virtual DDTranslation makeDDTranslation( const int copyNo ) const override;
-  virtual DDRotation makeDDRotation(const int copyNo ) const override;
-  virtual DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+  void checkParametersValidity() override;
+  double getMaxParameter() const override;
+  DDTranslation makeDDTranslation( const int copyNo ) const override;
+  DDRotation makeDDRotation(const int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
 };
 
 //---------------------------------------------------------------------
@@ -40,11 +40,11 @@ class DDDividedPolyhedraPhi final : public DDDividedGeometryObject
   
   DDDividedPolyhedraPhi( const DDDivision& div, DDCompactView* cpv );
 
-  virtual void checkParametersValidity() override;
-  virtual double getMaxParameter() const override;
-  virtual DDTranslation makeDDTranslation( const int copyNo ) const override;
-  virtual DDRotation makeDDRotation(const int copyNo ) const override;
-  virtual DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+  void checkParametersValidity() override;
+  double getMaxParameter() const override;
+  DDTranslation makeDDTranslation( const int copyNo ) const override;
+  DDRotation makeDDRotation(const int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
 };
 
 //---------------------------------------------------------------------
@@ -57,11 +57,11 @@ class DDDividedPolyhedraZ final : public DDDividedGeometryObject
 
   DDDividedPolyhedraZ( const DDDivision& div, DDCompactView* cpv );
 
-  virtual void checkParametersValidity() override;
-  virtual double getMaxParameter() const override;
-  virtual DDTranslation makeDDTranslation( const int copyNo ) const override;
-  virtual DDRotation makeDDRotation(const int copyNo ) const override;
-  virtual DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+  void checkParametersValidity() override;
+  double getMaxParameter() const override;
+  DDTranslation makeDDTranslation( const int copyNo ) const override;
+  DDRotation makeDDRotation(const int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
 };
 
 #endif

--- a/DetectorDescription/Parser/src/DDDividedTrd.h
+++ b/DetectorDescription/Parser/src/DDDividedTrd.h
@@ -18,11 +18,11 @@ class DDDividedTrdX final : public DDDividedGeometryObject
 
     DDDividedTrdX( const DDDivision& div, DDCompactView* cpv );
 
-    virtual void checkParametersValidity() override;
-    virtual double getMaxParameter() const override;
-    virtual DDTranslation makeDDTranslation( const int copyNo ) const override;
-    virtual DDRotation makeDDRotation(const int copyNo ) const override;
-    virtual DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+    void checkParametersValidity() override;
+    double getMaxParameter() const override;
+    DDTranslation makeDDTranslation( const int copyNo ) const override;
+    DDRotation makeDDRotation(const int copyNo ) const override;
+    DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
 };
 
 class DDDividedTrdY final : public DDDividedGeometryObject
@@ -31,11 +31,11 @@ class DDDividedTrdY final : public DDDividedGeometryObject
 
     DDDividedTrdY( const DDDivision& div, DDCompactView* cpv );
 
-    virtual void checkParametersValidity() override;
-    virtual double getMaxParameter() const override;
-    virtual DDTranslation makeDDTranslation( const int copyNo ) const override;
-    virtual DDRotation makeDDRotation(const int copyNo ) const override;
-    virtual DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+    void checkParametersValidity() override;
+    double getMaxParameter() const override;
+    DDTranslation makeDDTranslation( const int copyNo ) const override;
+    DDRotation makeDDRotation(const int copyNo ) const override;
+    DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
 };
 
 class DDDividedTrdZ final : public DDDividedGeometryObject
@@ -44,11 +44,11 @@ class DDDividedTrdZ final : public DDDividedGeometryObject
 
     DDDividedTrdZ( const DDDivision& div, DDCompactView* cpv );
 
-    virtual void checkParametersValidity() override;
-    virtual double getMaxParameter() const override;
-    virtual DDTranslation makeDDTranslation( const int copyNo ) const override;
-    virtual DDRotation makeDDRotation(const int copyNo ) const override;
-    virtual DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+    void checkParametersValidity() override;
+    double getMaxParameter() const override;
+    DDTranslation makeDDTranslation( const int copyNo ) const override;
+    DDRotation makeDDRotation(const int copyNo ) const override;
+    DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
 };
 
 #endif

--- a/DetectorDescription/Parser/src/DDDividedTubs.h
+++ b/DetectorDescription/Parser/src/DDDividedTubs.h
@@ -19,10 +19,10 @@ class DDDividedTubsRho final : public DDDividedGeometryObject
 
   DDDividedTubsRho( const DDDivision& div, DDCompactView* cpv );
 
-  virtual double getMaxParameter() const override;
-  virtual DDTranslation makeDDTranslation( const int copyNo ) const override;
-  virtual DDRotation makeDDRotation( const int copyNo ) const override;
-  virtual DDLogicalPart makeDDLogicalPart(const int copyNo ) const override;
+  double getMaxParameter() const override;
+  DDTranslation makeDDTranslation( const int copyNo ) const override;
+  DDRotation makeDDRotation( const int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart(const int copyNo ) const override;
 };
 
 class DDDividedTubsPhi final : public DDDividedGeometryObject
@@ -31,10 +31,10 @@ class DDDividedTubsPhi final : public DDDividedGeometryObject
 
   DDDividedTubsPhi( const DDDivision& div, DDCompactView* cpv );
   
-  virtual double getMaxParameter() const override;
-  virtual DDTranslation makeDDTranslation( const int copyNo ) const override;
-  virtual DDRotation makeDDRotation( const int copyNo ) const override;
-  virtual DDLogicalPart makeDDLogicalPart(const int copyNo ) const override;
+  double getMaxParameter() const override;
+  DDTranslation makeDDTranslation( const int copyNo ) const override;
+  DDRotation makeDDRotation( const int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart(const int copyNo ) const override;
 };
 
 class DDDividedTubsZ final : public DDDividedGeometryObject
@@ -43,10 +43,10 @@ class DDDividedTubsZ final : public DDDividedGeometryObject
 
   DDDividedTubsZ( const DDDivision& div, DDCompactView* cpv );
 
-  virtual double getMaxParameter() const override;
-  virtual DDTranslation makeDDTranslation( const int copyNo ) const override;
-  virtual DDRotation makeDDRotation( const int copyNo ) const override;
-  virtual DDLogicalPart makeDDLogicalPart(const int copyNo ) const override;
+  double getMaxParameter() const override;
+  DDTranslation makeDDTranslation( const int copyNo ) const override;
+  DDRotation makeDDRotation( const int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart(const int copyNo ) const override;
 };
 
 #endif

--- a/DetectorDescription/Parser/src/DDLCone.h
+++ b/DetectorDescription/Parser/src/DDLCone.h
@@ -30,7 +30,7 @@ class DDLCone final : public DDLSolid
 
   DDLCone( DDLElementRegistry* myreg );
 
-  virtual void processElement( const std::string& name, const std::string& nmspace, DDCompactView& cpv ) override; 
+  void processElement( const std::string& name, const std::string& nmspace, DDCompactView& cpv ) override; 
 };
 
 #endif

--- a/DetectorDescription/Parser/test/testDoc.cpp
+++ b/DetectorDescription/Parser/test/testDoc.cpp
@@ -33,25 +33,25 @@ class DDLTestDoc : public DDLDocumentProvider
 public:
 
   DDLTestDoc( void );
-  virtual ~DDLTestDoc();
+  ~DDLTestDoc() override;
 
   /// Return a list of files as a vector of strings.
-  virtual const std::vector < std::string >&  getFileList( void ) const;
+  const std::vector < std::string >&  getFileList( void ) const override;
 
   /// Return a list of urls as a vector of strings.
-  virtual const std::vector < std::string >&  getURLList( void ) const;
+  const std::vector < std::string >&  getURLList( void ) const override;
 
   /// Print out the list of files.
-  virtual void dumpFileList( void ) const;
+  void dumpFileList( void ) const override;
 
   /// Return whether Validation should be on or off and where the DDL SchemaLocation is.
-  virtual bool doValidation( void ) const;
+  bool doValidation( void ) const override;
 
   /// Return the designation for where to look for the schema.
-  std::string getSchemaLocation( void ) const;
+  std::string getSchemaLocation( void ) const override;
 
   /// ReadConfig
-  virtual int readConfig( const std::string& filename );
+  int readConfig( const std::string& filename ) override;
 
   void push_back( std::string fileName, std::string url = std::string( "./" ));
 

--- a/DetectorDescription/RegressionTest/bin/DOMCount.hpp
+++ b/DetectorDescription/RegressionTest/bin/DOMCount.hpp
@@ -42,7 +42,7 @@ public:
     //  Constructors and Destructor
     // -----------------------------------------------------------------------
     DOMCountErrorHandler();
-    ~DOMCountErrorHandler();
+    ~DOMCountErrorHandler() override;
 
 
     // -----------------------------------------------------------------------
@@ -54,7 +54,7 @@ public:
     // -----------------------------------------------------------------------
     //  Implementation of the DOM ErrorHandler interface
     // -----------------------------------------------------------------------
-    bool handleError(const DOMError& domError);
+    bool handleError(const DOMError& domError) override;
     void resetErrors();
 
 

--- a/DetectorDescription/RegressionTest/interface/DDHtmlFormatter.h
+++ b/DetectorDescription/RegressionTest/interface/DDHtmlFormatter.h
@@ -129,8 +129,8 @@ class DDHtmlLpDetails : public DDHtmlDetails
 {
 public: 
   DDHtmlLpDetails(const std::string & cat, const std::string & txt) : DDHtmlDetails(cat,txt) {}
-  bool details(std::ostream & os, const DDName &);
-  ns_type & names();
+  bool details(std::ostream & os, const DDName &) override;
+  ns_type & names() override;
   
 };
 
@@ -138,8 +138,8 @@ class DDHtmlMaDetails : public DDHtmlDetails
 {
 public: 
   DDHtmlMaDetails(const std::string & cat, const std::string & txt) : DDHtmlDetails(cat,txt) {}
-  bool details(std::ostream & os, const DDName &);
-  ns_type & names();
+  bool details(std::ostream & os, const DDName &) override;
+  ns_type & names() override;
   
 };
 
@@ -147,8 +147,8 @@ class DDHtmlSoDetails : public DDHtmlDetails
 {
 public: 
   DDHtmlSoDetails(const std::string & cat, const std::string & txt) : DDHtmlDetails(cat,txt) {}
-  bool details(std::ostream & os, const DDName &);
-  ns_type & names();
+  bool details(std::ostream & os, const DDName &) override;
+  ns_type & names() override;
   
 };
 
@@ -156,8 +156,8 @@ class DDHtmlRoDetails : public DDHtmlDetails
 {
 public: 
   DDHtmlRoDetails(const std::string & cat, const std::string & txt) : DDHtmlDetails(cat,txt) {}
-  bool details(std::ostream & os, const DDName &);
-  ns_type & names();
+  bool details(std::ostream & os, const DDName &) override;
+  ns_type & names() override;
   
 };
 
@@ -165,8 +165,8 @@ class DDHtmlSpDetails : public DDHtmlDetails
 {
 public: 
   DDHtmlSpDetails(const std::string & cat, const std::string & txt) : DDHtmlDetails(cat,txt) {}
-  bool details(std::ostream & os, const DDName &);
-  ns_type & names();
+  bool details(std::ostream & os, const DDName &) override;
+  ns_type & names() override;
   
 };
 

--- a/DetectorDescription/RegressionTest/plugins/CompareDDCompactViews.cc
+++ b/DetectorDescription/RegressionTest/plugins/CompareDDCompactViews.cc
@@ -14,7 +14,7 @@ class CompareDDCompactViews : public edm::one::EDAnalyzer<edm::one::WatchRuns>
 {
 public:
   explicit CompareDDCompactViews( const edm::ParameterSet& iConfig );
-  ~CompareDDCompactViews( void ) {}
+  ~CompareDDCompactViews( void ) override {}
   
   void beginJob() override {}
   void beginRun(edm::Run const& iEvent, edm::EventSetup const&) override;

--- a/DetectorDescription/RegressionTest/src/SaxToDom.h
+++ b/DetectorDescription/RegressionTest/src/SaxToDom.h
@@ -20,16 +20,16 @@ public:
   typedef XERCES_CPP_NAMESPACE::Attributes Attributes;
   typedef XERCES_CPP_NAMESPACE::SAXParseException SAXParseException;
   SaxToDom();
-  ~SaxToDom();
-  void startElement(const XMLCh* const uri, const XMLCh* const localname, const XMLCh* const qname, const Attributes& attrs);
+  ~SaxToDom() override;
+  void startElement(const XMLCh* const uri, const XMLCh* const localname, const XMLCh* const qname, const Attributes& attrs) override;
   //void startElement(const XMLCh* const name, AttributeList& attributes);
   void endElement(const XMLCh* const uri, 
                             const XMLCh* const name, 
-			       const XMLCh* const qname);
+			       const XMLCh* const qname) override;
   const TinyDom & dom() const;
 
   // errors
-  void error(const SAXParseException& e);
+  void error(const SAXParseException& e) override;
   
 private:
   std::vector<NodeName> parent_;

--- a/DetectorDescription/RegressionTest/src/SaxToDom2.h
+++ b/DetectorDescription/RegressionTest/src/SaxToDom2.h
@@ -23,16 +23,16 @@ public:
   typedef XERCES_CPP_NAMESPACE::Attributes Attributes;
   typedef XERCES_CPP_NAMESPACE::SAXParseException SAXParseException;
   SaxToDom2();
-  ~SaxToDom2();
-  void startElement(const XMLCh* const uri, const XMLCh* const localname, const XMLCh* const qname, const Attributes& attrs);
+  ~SaxToDom2() override;
+  void startElement(const XMLCh* const uri, const XMLCh* const localname, const XMLCh* const qname, const Attributes& attrs) override;
   //void startElement(const XMLCh* const name, AttributeList& attributes);
   void endElement(const XMLCh* const uri, 
                             const XMLCh* const name, 
-			       const XMLCh* const qname);
+			       const XMLCh* const qname) override;
   const TinyDom2 & dom() const;
 
   // errors
-  void error(const SAXParseException& e);
+  void error(const SAXParseException& e) override;
   
 private:
   std::vector<Node2> parent_;

--- a/DetectorDescription/RegressionTest/test/test_module.cc
+++ b/DetectorDescription/RegressionTest/test/test_module.cc
@@ -12,18 +12,18 @@ class DDTestAlgorithm : public DDAlgorithm
 {
 public:
   DDTestAlgorithm( void ) {}
-  virtual ~DDTestAlgorithm( void ){}
+  ~DDTestAlgorithm( void ) override{}
  
   void initialize( const DDNumericArguments &,
 		   const DDVectorArguments &,
 		   const DDMapArguments &,
 		   const DDStringArguments &,
-		   const DDStringVectorArguments & )
+		   const DDStringVectorArguments & ) override
   {
     std::cout << "DDTestAlgorithm::initialize\n";
   }
 
-  void execute( DDCompactView& ) {
+  void execute( DDCompactView& ) override {
     std::cout << "DDTestAlgorithm::execute\n";
   }
 };

--- a/DetectorDescription/RegressionTest/test/tutorial.cc
+++ b/DetectorDescription/RegressionTest/test/tutorial.cc
@@ -48,7 +48,7 @@ namespace {
     GroupFilter(std::vector< DDSpecificsFilter* >& filters):
       filters_(filters) {}
 
-    bool accept(const DDExpandedView &cv ) const override final {
+    bool accept(const DDExpandedView &cv ) const final {
       bool returnValue = true;
       for(auto f: filters_) {
         returnValue = returnValue and f->accept(cv);

--- a/Geometry/CMSCommonData/test/DDFilteredViewAnalyzer.cc
+++ b/Geometry/CMSCommonData/test/DDFilteredViewAnalyzer.cc
@@ -11,7 +11,7 @@ class DDFilteredViewAnalyzer : public edm::one::EDAnalyzer<> {
 public:
 
   explicit DDFilteredViewAnalyzer( const edm::ParameterSet& );
-  ~DDFilteredViewAnalyzer( void ) {}
+  ~DDFilteredViewAnalyzer( void ) override {}
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/CSCGeometry/interface/CSCChamber.h
+++ b/Geometry/CSCGeometry/interface/CSCChamber.h
@@ -29,23 +29,23 @@ public:
     setDetId(id);
   }
 
-  ~CSCChamber();
+  ~CSCChamber() override;
 
-  const GeomDetType& type() const { return *(specs()); }
+  const GeomDetType& type() const override { return *(specs()); }
 
   /// Get the (concrete) DetId.
   CSCDetId id() const { return geographicalId(); }
 
   // Which subdetector
-  virtual SubDetector subDetector() const {return GeomDetEnumerators::CSC;}
+  SubDetector subDetector() const override {return GeomDetEnumerators::CSC;}
 
   const CSCChamberSpecs* specs() const { return theChamberSpecs; }
 
   /// Return the layers in this chamber
-  virtual std::vector< const GeomDet* > components() const;
+  std::vector< const GeomDet* > components() const override;
 
   /// Return the layer with a given id in this chamber
-  virtual const GeomDet* component(DetId id) const;
+  const GeomDet* component(DetId id) const override;
 
 
   // Extension of the interface

--- a/Geometry/CSCGeometry/interface/CSCChamberSpecs.h
+++ b/Geometry/CSCGeometry/interface/CSCChamberSpecs.h
@@ -53,7 +53,7 @@ public:
 		  );
 
   /// Destructor
-  ~CSCChamberSpecs();
+  ~CSCChamberSpecs() override;
 
   /// Allow comparison of Specs objects
   bool operator!=( const CSCChamberSpecs& specs ) const;
@@ -63,7 +63,7 @@ public:
   //@@ But still there as of Aug-2007. So much for design.
 
   /// Returns StripTopology of the odd-layer, positive-z geometry
-  virtual const Topology& topology() const;
+  const Topology& topology() const override;
 
   /// Accessors for LayerGeometry's
   const CSCLayerGeometry* oddLayerGeometry( int iendcap ) const 

--- a/Geometry/CSCGeometry/interface/CSCGeometry.h
+++ b/Geometry/CSCGeometry/interface/CSCGeometry.h
@@ -42,30 +42,30 @@ class CSCGeometry : public TrackingGeometry {
   CSCGeometry( bool debugV, bool gangedstripsME1a_, bool onlywiresME1a_, bool realWireGeometry_, bool useCentreTIOffsets_ );
 
   /// Destructor
-  virtual ~CSCGeometry();
+  ~CSCGeometry() override;
 
   //---- Base class' interface
 
   // Return a vector of all det types
-  virtual const DetTypeContainer&  detTypes() const override;
+  const DetTypeContainer&  detTypes() const override;
 
   // Return a vector of all GeomDetUnit
-  virtual const DetUnitContainer& detUnits() const override;
+  const DetUnitContainer& detUnits() const override;
 
   // Return a vector of all GeomDet (including all GeomDetUnits)
-  virtual const DetContainer& dets() const override;
+  const DetContainer& dets() const override;
   
   // Return a vector of all GeomDetUnit DetIds
-  virtual const DetIdContainer&    detUnitIds() const override;
+  const DetIdContainer&    detUnitIds() const override;
 
   // Return a vector of all GeomDet DetIds (including those of GeomDetUnits)
-  virtual const DetIdContainer& detIds() const override;
+  const DetIdContainer& detIds() const override;
 
   // Return the pointer to the GeomDetUnit corresponding to a given DetId
-  virtual const GeomDetUnit* idToDetUnit(DetId) const override;
+  const GeomDetUnit* idToDetUnit(DetId) const override;
 
   // Return the pointer to the GeomDet corresponding to a given DetId
-  virtual const GeomDet* idToDet(DetId) const override;
+  const GeomDet* idToDet(DetId) const override;
 
   //---- Extension of the interface
 

--- a/Geometry/CSCGeometry/interface/CSCLayer.h
+++ b/Geometry/CSCGeometry/interface/CSCLayer.h
@@ -30,9 +30,9 @@ public:
     setDetId(id);
 }
 
-  const GeomDetType& type() const { return chamber()->type(); }
+  const GeomDetType& type() const override { return chamber()->type(); }
 
-  const Topology& topology() const { return *(geometry()->topology()); }
+  const Topology& topology() const override { return *(geometry()->topology()); }
 
 
   /**

--- a/Geometry/CSCGeometry/interface/CSCLayerGeometry.h
+++ b/Geometry/CSCGeometry/interface/CSCLayerGeometry.h
@@ -52,7 +52,7 @@ public:
 
   CSCLayerGeometry& operator=( const CSCLayerGeometry& );
 
-  virtual ~CSCLayerGeometry();
+  ~CSCLayerGeometry() override;
 
   /**
    * How many strips in layer
@@ -240,9 +240,9 @@ public:
    * There are three versions, to parallel those of the TrapezoidalPlaneBounds which
    * a naive user might otherwise employ.
    */
-  bool inside( const Local3DPoint&, const LocalError&, float scale=1.f ) const;
-  bool inside( const Local3DPoint& ) const;
-  bool inside( const Local2DPoint& ) const;
+  bool inside( const Local3DPoint&, const LocalError&, float scale=1.f ) const override;
+  bool inside( const Local3DPoint& ) const override;
+  bool inside( const Local2DPoint& ) const override;
 
   /**
    * Return estimate of the 2-dim point of intersection of a strip and a cluster of wires.
@@ -303,7 +303,7 @@ public:
   /**
    * Utility method to handle proper copying of the class
    */
-  virtual Bounds* clone() const { 
+  Bounds* clone() const override { 
     return new CSCLayerGeometry(*this);
   }
 

--- a/Geometry/CSCGeometry/interface/CSCStripTopology.h
+++ b/Geometry/CSCGeometry/interface/CSCStripTopology.h
@@ -40,7 +40,7 @@ public:
    */
   CSCStripTopology( int ns, float aw, float dh, float r, float aoff, float ymid );
 
-  virtual ~CSCStripTopology();
+  ~CSCStripTopology() override;
 
   /**
    * Return slope and intercept of straight line representing (centre-line of) a strip in 2-dim local coordinates.

--- a/Geometry/CSCGeometry/interface/CSCWireTopology.h
+++ b/Geometry/CSCGeometry/interface/CSCWireTopology.h
@@ -19,7 +19,7 @@ class CSCWireTopology : public WireTopology {
 
  public:
 
-  virtual ~CSCWireTopology();
+  ~CSCWireTopology() override;
   
   /**
    * Constructor from endcap muon CSC wire geometry specs
@@ -42,16 +42,16 @@ class CSCWireTopology : public WireTopology {
    * Topology interface, but not implemented for CSCWireTopology (yet!)
    */
 
-  virtual LocalPoint localPosition( const MeasurementPoint& ) const;
-  virtual LocalError localError( const MeasurementPoint&, const MeasurementError& ) const;
-  virtual MeasurementPoint measurementPosition( const LocalPoint&) const;
-  virtual MeasurementError measurementError( const LocalPoint&, const LocalError& ) const;
+  LocalPoint localPosition( const MeasurementPoint& ) const override;
+  LocalError localError( const MeasurementPoint&, const MeasurementError& ) const override;
+  MeasurementPoint measurementPosition( const LocalPoint&) const override;
+  MeasurementError measurementError( const LocalPoint&, const LocalError& ) const override;
 
   /**
    * 'channel' is wire group number from 1 to no. of groups.
    * Return 0 if out-of-range or in a dead region
    */
-  virtual int channel( const LocalPoint& p) const;
+  int channel( const LocalPoint& p) const override;
 
   /**
    * WireTopology interface
@@ -67,20 +67,20 @@ class CSCWireTopology : public WireTopology {
    * The wire pitch. This is the wire spacing but
    * old-timers like the word 'pitch'.
    */
-  float wirePitch() const {
+  float wirePitch() const override {
     return static_cast<float>(wireSpacing()); }
 
   /**
    * The angle of the wires w.r.t local x axis (in radians)
    */
-  float wireAngle() const { 
+  float wireAngle() const override { 
     return theWireGeometry->wireAngle(); }
 
   /**
    * The nearest (virtual) wire to a given LocalPoint.
    * Beware that this wire might not exist or be read out!
    */
-  int nearestWire(const LocalPoint& lp) const {
+  int nearestWire(const LocalPoint& lp) const override {
     return theWireGeometry->nearestWire( lp ); }
 
   /**
@@ -118,7 +118,7 @@ class CSCWireTopology : public WireTopology {
    * This is the number which would fill the region covered
    * by wires, assuming the constant wire spacing.
    */
-  int numberOfWires() const {
+  int numberOfWires() const override {
     return theWireGrouping->numberOfWires(); }
 
   /**

--- a/Geometry/CSCGeometry/interface/OffsetRadialStripTopology.h
+++ b/Geometry/CSCGeometry/interface/OffsetRadialStripTopology.h
@@ -25,7 +25,7 @@ public:
   OffsetRadialStripTopology( int numberOfStrips, float stripPhiPitch,
      float detectorHeight, float radialDistance, float stripOffset, float yCentre);
 
-  virtual ~OffsetRadialStripTopology(){};
+  ~OffsetRadialStripTopology() override{};
 
   /** Fraction of a strip offset of layer relative to
    *  symmetry axis (local y). (This is an _angular_ value)
@@ -34,7 +34,7 @@ public:
 
   /** LocalPoint for a given strip
    */
-  virtual LocalPoint localPosition(float strip) const {
+  LocalPoint localPosition(float strip) const override {
     // Pass through to base class since otherwise it is shadowed by the localPosition(const MP&).
     // Note that base class version is OK because it uses stripAngle() which is overridden in ORST!
     // Also note that xOfStrip from base class RST also works for ORST for the same reason.
@@ -58,12 +58,12 @@ public:
    * BEWARE! Neither coordinate may correspond to either local x or local y.<BR>
    * BEWARE! This involves ONLY strip-related measurements, not CSC wires!
    */
-  virtual LocalPoint localPosition(const MeasurementPoint&) const;
+  LocalPoint localPosition(const MeasurementPoint&) const override;
 
   /**
    * MeasurementPoint corresponding to given LocalPoint
    */
-  virtual MeasurementPoint measurementPosition( const LocalPoint& ) const;
+  MeasurementPoint measurementPosition( const LocalPoint& ) const override;
 
   /** Strip in which a given LocalPoint lies. This is a float which
    * represents the fractional strip position within the detector.<BR>
@@ -71,19 +71,19 @@ public:
    * detector or BELOW, and float(nstrips) if it falls at the extreme high
    * edge or ABOVE.
    */
-  virtual float strip(const LocalPoint&) const;
+  float strip(const LocalPoint&) const override;
 
   /**
    * Angle between strip and local y axis (measured clockwise from y axis)
    */
-  float stripAngle(float strip) const;
+  float stripAngle(float strip) const override;
 
   /**
    * Channel number corresponding to a strip or a LocalPoint.
    * Sometimes more than one strip is OR'ed into one channel.
    */
   virtual int channel(int strip) const = 0;
-  virtual int channel(const LocalPoint& lp) const = 0;
+  int channel(const LocalPoint& lp) const override = 0;
 
   friend std::ostream & operator<<(std::ostream &, const OffsetRadialStripTopology &);
 

--- a/Geometry/CSCGeometry/interface/WireTopology.h
+++ b/Geometry/CSCGeometry/interface/WireTopology.h
@@ -15,7 +15,7 @@
 
 class WireTopology : public Topology {
  public:
-  virtual ~WireTopology() {}
+  ~WireTopology() override {}
  
   /**
    * How many wires

--- a/Geometry/CSCGeometry/src/CSCGangedStripTopology.h
+++ b/Geometry/CSCGeometry/src/CSCGangedStripTopology.h
@@ -17,13 +17,13 @@ public:
   CSCGangedStripTopology(const CSCStripTopology & topology, int numberOfGangedStrips ) 
     : CSCStripTopology(topology), theNumberOfGangedStrips(numberOfGangedStrips) {}
 
-  ~CSCGangedStripTopology() {}
+  ~CSCGangedStripTopology() override {}
 
   /** 
    * Return channel corresponding to a LocalPoint.
    * (Count from 1)
    */
-  int channel(const LocalPoint& lp) const {
+  int channel(const LocalPoint& lp) const override {
     return (int) (CSCRadialStripTopology::strip(lp)) % theNumberOfGangedStrips + 1;
   }
 
@@ -31,7 +31,7 @@ public:
    * Return channel corresponding to a strip.
    * (Count from 1).
    */
-  int channel(int strip) const {
+  int channel(int strip) const override {
     while(strip > theNumberOfGangedStrips) strip -= theNumberOfGangedStrips;
     while(strip <= 0) strip += theNumberOfGangedStrips;
     return strip;
@@ -43,14 +43,14 @@ public:
    * If gcc could handle it, should be
    *   virtual CSCGangedStripTopology* clone() const
    */
-  CSCStripTopology* clone() const {
+  CSCStripTopology* clone() const override {
     return new CSCGangedStripTopology(*this);
   }
 
   /**
    * Implement CSCStripTopology interface for its op<<
    */
-  std::ostream& put ( std::ostream& os ) const {
+  std::ostream& put ( std::ostream& os ) const override {
     return os << "CSCGangedStripTopology";
   }
 

--- a/Geometry/CSCGeometry/src/CSCGangedWireGrouping.h
+++ b/Geometry/CSCGeometry/src/CSCGangedWireGrouping.h
@@ -22,7 +22,7 @@ class CSCGangedWireGrouping : public CSCWireGrouping {
   typedef std::vector<int> Container;
   typedef Container::const_iterator CIterator;
 
-  virtual ~CSCGangedWireGrouping() {}
+  ~CSCGangedWireGrouping() override {}
      
   /**
    * Constructor from endcap muon wire information parsed from DDD
@@ -37,24 +37,24 @@ class CSCGangedWireGrouping : public CSCWireGrouping {
    * This is the number which would fill the region covered
    * by wires, assuming the constant wire spacing.
    */
-  int numberOfWires() const {
+  int numberOfWires() const override {
     return theNumberOfWires; }
 
   /**
    * How many wire groups
    */
-  int numberOfWireGroups() const {
+  int numberOfWireGroups() const override {
     return theNumberOfGroups; }
 
   /**
    * How many wires in a wiregroup
    */
-  int numberOfWiresPerGroup( int wireGroup ) const;
+  int numberOfWiresPerGroup( int wireGroup ) const override;
 
   /**
    * Wire group containing a given wire
    */
-  int wireGroup( int wire ) const;
+  int wireGroup( int wire ) const override;
 
   /**
    * Middle of wire-group.
@@ -62,13 +62,13 @@ class CSCGangedWireGrouping : public CSCWireGrouping {
    * This is a pseudo-wire no. for a group with an even no. of wires.
    * Accordingly, it is non-integer.
    */
-  float middleWireOfGroup( int wireGroup ) const;
+  float middleWireOfGroup( int wireGroup ) const override;
 
   /**
    * Clone to handle correct copy of component objects referenced
    * by base class pointer.
    */
-  CSCWireGrouping* clone() const {
+  CSCWireGrouping* clone() const override {
     return new CSCGangedWireGrouping(*this);
   }
 

--- a/Geometry/CSCGeometry/src/CSCNonslantedWireGeometry.h
+++ b/Geometry/CSCGeometry/src/CSCNonslantedWireGeometry.h
@@ -15,7 +15,7 @@
 
 class CSCNonslantedWireGeometry : public CSCWireGeometry {
  public:
-  virtual ~CSCNonslantedWireGeometry() {}
+  ~CSCNonslantedWireGeometry() override {}
   
   /**
    * Constructor from wire spacing
@@ -27,13 +27,13 @@ class CSCNonslantedWireGeometry : public CSCWireGeometry {
   /**
    * The angle of the wires w.r.t local x axis (in radians)
    */
-  float wireAngle() const { return 0.; }
+  float wireAngle() const override { return 0.; }
 
   /**
    * The nearest (virtual) wire to a given LocalPoint.
    * Beware that this wire might not exist or be read out!
    */
-  int nearestWire(const LocalPoint& lp) const {
+  int nearestWire(const LocalPoint& lp) const override {
     return 1 + nint( (lp.y()-yOfFirstWire())/wireSpacing() ) ;
   }
 
@@ -41,7 +41,7 @@ class CSCNonslantedWireGeometry : public CSCWireGeometry {
    * Local y of a given wire 'number' (float) at given x
    * For nonslanted wires this y is independent of x.
    */
-  float yOfWire(float wire, float x=0.) const {
+  float yOfWire(float wire, float x=0.) const override {
     return yOfFirstWire() + (wire-1.)*wireSpacing();
   }
 
@@ -49,7 +49,7 @@ class CSCNonslantedWireGeometry : public CSCWireGeometry {
    * Clone to handle correct copy of component objects referenced
    * by base class pointer.
    */
-  CSCWireGeometry* clone() const {
+  CSCWireGeometry* clone() const override {
     return new CSCNonslantedWireGeometry(*this);
   }
 

--- a/Geometry/CSCGeometry/src/CSCSlantedWireGeometry.h
+++ b/Geometry/CSCGeometry/src/CSCSlantedWireGeometry.h
@@ -14,7 +14,7 @@
 
 class CSCSlantedWireGeometry : public CSCWireGeometry {
  public:
-  virtual ~CSCSlantedWireGeometry() {}
+  ~CSCSlantedWireGeometry() override {}
 
   /**
    * Constructor from wire spacing and wire angle
@@ -26,24 +26,24 @@ class CSCSlantedWireGeometry : public CSCWireGeometry {
   /**
    * The angle of the wires w.r.t local x axis (in radians)
    */
-  float wireAngle() const { return theWireAngle; }
+  float wireAngle() const override { return theWireAngle; }
 
   /**
    * The nearest (virtual) wire to a given LocalPoint.
    * Beware that this wire might not exist or be read out!
    */
-  int nearestWire(const LocalPoint& lp) const;
+  int nearestWire(const LocalPoint& lp) const override;
 
   /**
    * Local y of a given wire 'number' (float) at given x
    */
-  float yOfWire(float wire, float x=0.) const;
+  float yOfWire(float wire, float x=0.) const override;
 
   /**
    * Clone to handle correct copy of component objects referenced
    * by base class pointer.
    */
-  CSCWireGeometry* clone() const {
+  CSCWireGeometry* clone() const override {
     return new CSCSlantedWireGeometry(*this);
   }
 

--- a/Geometry/CSCGeometry/src/CSCUngangedStripTopology.h
+++ b/Geometry/CSCGeometry/src/CSCUngangedStripTopology.h
@@ -19,13 +19,13 @@ public:
     CSCStripTopology( numberOfStrips, stripPhiPitch, 
        detectorHeight, whereStripsMeet, stripOffset, yCentre ){}
 
-  ~CSCUngangedStripTopology(){}
+  ~CSCUngangedStripTopology() override{}
 
   /** 
    * Return channel corresponding to a LocalPoint.
    * (but we count from 1 whereas RST counts from 0.)
    */
-  int channel(const LocalPoint& lp) const {
+  int channel(const LocalPoint& lp) const override {
     return CSCRadialStripTopology::channel(lp) + 1;
   }
 
@@ -33,7 +33,7 @@ public:
    * Return channel corresponding to a strip.
    * (Count from 1).
    */
-  int channel(int strip) const {return strip;}
+  int channel(int strip) const override {return strip;}
 
   /**
    * Clone to handle correct copy of component objects referenced
@@ -41,14 +41,14 @@ public:
    * If gcc could handle it, should be
    *   virtual CSCUngangedStripTopology* clone() const
    */
-  CSCStripTopology* clone() const {
+  CSCStripTopology* clone() const override {
     return new CSCUngangedStripTopology(*this);
   }
 
   /**
    * Implement CSCStripTopology interface for its op<<
    */
-  std::ostream& put ( std::ostream& os ) const {
+  std::ostream& put ( std::ostream& os ) const override {
     return os << "CSCUngangedStripTopology";
   }
 };

--- a/Geometry/CSCGeometry/test/stubs/CSCGACwithB.cc
+++ b/Geometry/CSCGeometry/test/stubs/CSCGACwithB.cc
@@ -22,7 +22,7 @@ class CSCGACwithB : public edm::one::EDAnalyzer<> {
 public:
  
   explicit CSCGACwithB( const edm::ParameterSet& );
-  ~CSCGACwithB();
+  ~CSCGACwithB() override;
 
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;

--- a/Geometry/CSCGeometry/test/stubs/CSCGeometryAnalyzer.cc
+++ b/Geometry/CSCGeometry/test/stubs/CSCGeometryAnalyzer.cc
@@ -17,7 +17,7 @@ class CSCGeometryAnalyzer : public edm::one::EDAnalyzer<> {
 public:
  
   explicit CSCGeometryAnalyzer( const edm::ParameterSet& );
-  ~CSCGeometryAnalyzer();
+  ~CSCGeometryAnalyzer() override;
 
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;

--- a/Geometry/CSCGeometry/test/stubs/CSCGeometryAsChambers.cc
+++ b/Geometry/CSCGeometry/test/stubs/CSCGeometryAsChambers.cc
@@ -16,7 +16,7 @@ class CSCGeometryAsChambers : public edm::one::EDAnalyzer<> {
 public:
  
   explicit CSCGeometryAsChambers( const edm::ParameterSet& );
-  ~CSCGeometryAsChambers();
+  ~CSCGeometryAsChambers() override;
 
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;

--- a/Geometry/CSCGeometry/test/stubs/CSCGeometryAsLayers.cc
+++ b/Geometry/CSCGeometry/test/stubs/CSCGeometryAsLayers.cc
@@ -17,7 +17,7 @@ class CSCGeometryAsLayers : public edm::one::EDAnalyzer<> {
 public:
  
   explicit CSCGeometryAsLayers( const edm::ParameterSet& );
-  ~CSCGeometryAsLayers();
+  ~CSCGeometryAsLayers() override;
 
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;

--- a/Geometry/CSCGeometry/test/stubs/CSCGeometryOfStrips.cc
+++ b/Geometry/CSCGeometry/test/stubs/CSCGeometryOfStrips.cc
@@ -16,7 +16,7 @@ class CSCGeometryOfStrips : public edm::one::EDAnalyzer<> {
 public:
  
   explicit CSCGeometryOfStrips( const edm::ParameterSet& );
-  ~CSCGeometryOfStrips();
+  ~CSCGeometryOfStrips() override;
 
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;

--- a/Geometry/CSCGeometry/test/stubs/CSCGeometryOfWires.cc
+++ b/Geometry/CSCGeometry/test/stubs/CSCGeometryOfWires.cc
@@ -20,7 +20,7 @@ class CSCGeometryOfWires : public edm::one::EDAnalyzer<> {
 public:
  
   explicit CSCGeometryOfWires( const edm::ParameterSet& );
-  ~CSCGeometryOfWires();
+  ~CSCGeometryOfWires() override;
 
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;

--- a/Geometry/CSCGeometry/test/stubs/CSCLayerGeometryInside.cc
+++ b/Geometry/CSCGeometry/test/stubs/CSCLayerGeometryInside.cc
@@ -25,7 +25,7 @@ class CSCLayerGeometryInside : public edm::one::EDAnalyzer<edm::one::SharedResou
 public:
  
   explicit CSCLayerGeometryInside( const edm::ParameterSet& );
-  ~CSCLayerGeometryInside();
+  ~CSCLayerGeometryInside() override;
 
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;

--- a/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.h
+++ b/Geometry/CSCGeometryBuilder/plugins/CSCGeometryESModule.h
@@ -22,7 +22,7 @@ public:
   CSCGeometryESModule(const edm::ParameterSet& p);
 
   /// Destructor
-  virtual ~CSCGeometryESModule();
+  ~CSCGeometryESModule() override;
 
   /// Produce CSCGeometry
   std::shared_ptr<CSCGeometry> produce(const MuonGeometryRecord& record);

--- a/Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h
@@ -57,7 +57,7 @@ class CaloGeometryDBEP : public edm::ESProducer
 			  edm::es::Label( T::producerTag() ) ) ;//+std::string("TEST") ) ) ;
       }
 
-      virtual ~CaloGeometryDBEP<T,U>() {}
+      ~CaloGeometryDBEP<T,U>() override {}
     
       PtrType produceAligned( const typename T::AlignedRecord& iRecord ) 
       {

--- a/Geometry/CaloEventSetup/interface/CaloGeometryEP.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryEP.h
@@ -41,7 +41,7 @@ class CaloGeometryEP : public edm::ESProducer
 			  edm::es::Label( T::producerTag() ) ) ;
       }
 
-      virtual ~CaloGeometryEP<T>() {}
+      ~CaloGeometryEP<T>() override {}
       PtrType produceAligned( const typename T::AlignedRecord& iRecord ) 
       {
 	 const Alignments* alignPtr  ( 0 ) ;

--- a/Geometry/CaloEventSetup/plugins/CaloGeometryBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/CaloGeometryBuilder.h
@@ -43,7 +43,7 @@ class CaloGeometryBuilder : public edm::ESProducer
 
       CaloGeometryBuilder( const edm::ParameterSet& iConfig ) ;
 
-      virtual ~CaloGeometryBuilder() {} ;
+      ~CaloGeometryBuilder() override {} ;
 
       ReturnType produceAligned( const CaloGeometryRecord&  iRecord ) ;
 

--- a/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.h
@@ -35,7 +35,7 @@ class CaloTopologyBuilder : public edm::ESProducer
 {
    public:
       CaloTopologyBuilder( const edm::ParameterSet& iP );
-      ~CaloTopologyBuilder() ;
+      ~CaloTopologyBuilder() override ;
 
       typedef std::shared_ptr< CaloTopology > ReturnType;
 

--- a/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.h
@@ -40,7 +40,7 @@ namespace edm {
 class CaloTowerConstituentsMapBuilder : public edm::ESProducer {
 public:
   CaloTowerConstituentsMapBuilder(const edm::ParameterSet&);
-  ~CaloTowerConstituentsMapBuilder();
+  ~CaloTowerConstituentsMapBuilder() override;
 
   typedef std::unique_ptr<CaloTowerConstituentsMap> ReturnType;
 

--- a/Geometry/CaloEventSetup/plugins/EcalTrigTowerConstituentsMapBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/EcalTrigTowerConstituentsMapBuilder.h
@@ -36,7 +36,7 @@
 class EcalTrigTowerConstituentsMapBuilder : public edm::ESProducer {
    public:
   EcalTrigTowerConstituentsMapBuilder(const edm::ParameterSet&);
-  ~EcalTrigTowerConstituentsMapBuilder();
+  ~EcalTrigTowerConstituentsMapBuilder() override;
 
   typedef std::unique_ptr<EcalTrigTowerConstituentsMap> ReturnType;
 

--- a/Geometry/CaloEventSetup/plugins/FakeCaloAlignmentEP.cc
+++ b/Geometry/CaloEventSetup/plugins/FakeCaloAlignmentEP.cc
@@ -89,7 +89,7 @@ class FakeCaloAlignmentEP : public edm::ESProducer
 	 setWhatProduced( this, &FakeCaloAlignmentEP::produceCastorAliErr ) ;
       }
 
-      ~FakeCaloAlignmentEP() {}
+      ~FakeCaloAlignmentEP() override {}
 
 //-------------------------------------------------------------------
  

--- a/Geometry/CaloEventSetup/plugins/FastTimeTopologyBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/FastTimeTopologyBuilder.cc
@@ -42,7 +42,7 @@ class FastTimeTopologyBuilder : public edm::ESProducer {
 
 public:
   FastTimeTopologyBuilder( const edm::ParameterSet& iP );
-  ~FastTimeTopologyBuilder() ;
+  ~FastTimeTopologyBuilder() override ;
 
   typedef std::shared_ptr< FastTimeTopology > ReturnType;
 

--- a/Geometry/CaloEventSetup/plugins/HGCalTopologyBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/HGCalTopologyBuilder.cc
@@ -42,7 +42,7 @@ class HGCalTopologyBuilder : public edm::ESProducer {
 
 public:
   HGCalTopologyBuilder( const edm::ParameterSet& iP );
-  ~HGCalTopologyBuilder() ;
+  ~HGCalTopologyBuilder() override ;
 
   typedef std::shared_ptr< HGCalTopology > ReturnType;
 

--- a/Geometry/CaloEventSetup/plugins/TestCaloAlignmentEP.cc
+++ b/Geometry/CaloEventSetup/plugins/TestCaloAlignmentEP.cc
@@ -89,7 +89,7 @@ class TestCaloAlignmentEP : public edm::ESProducer
 	 setWhatProduced( this, &TestCaloAlignmentEP::produceCastorAliErr ) ;
       }
 
-      ~TestCaloAlignmentEP() {}
+      ~TestCaloAlignmentEP() override {}
 
 //-------------------------------------------------------------------
  

--- a/Geometry/CaloEventSetup/test/CaloAlignmentRcdRead.cc
+++ b/Geometry/CaloEventSetup/test/CaloAlignmentRcdRead.cc
@@ -19,7 +19,7 @@ public:
 
   explicit CaloAlignmentRcdRead( const edm::ParameterSet& /*iConfig*/ )
     :nEventCalls_(0) {}
-  ~CaloAlignmentRcdRead() {}
+  ~CaloAlignmentRcdRead() override {}
   
   template<typename T>
   void dumpAlignments(const edm::EventSetup& evtSetup);

--- a/Geometry/CaloEventSetup/test/CaloAlignmentRcdWrite.cc
+++ b/Geometry/CaloEventSetup/test/CaloAlignmentRcdWrite.cc
@@ -23,7 +23,7 @@ public:
 
   explicit CaloAlignmentRcdWrite(const edm::ParameterSet& /*iConfig*/)
     :nEventCalls_(0) {}
-  ~CaloAlignmentRcdWrite() {}
+  ~CaloAlignmentRcdWrite() override {}
   
   template<typename T>
   void writeAlignments(const edm::EventSetup& evtSetup);

--- a/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc
+++ b/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc
@@ -40,7 +40,7 @@ class CaloGeometryAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResourc
 public:
 
   explicit CaloGeometryAnalyzer( const edm::ParameterSet& );
-  ~CaloGeometryAnalyzer();
+  ~CaloGeometryAnalyzer() override;
   
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/CaloEventSetup/test/TestWriteESAlignments.cc
+++ b/Geometry/CaloEventSetup/test/TestWriteESAlignments.cc
@@ -16,7 +16,7 @@ public:
 
   explicit TestWriteESAlignments(const edm::ParameterSet& /*iConfig*/)
     : nEventCalls_(0) {}
-  ~TestWriteESAlignments() {}
+  ~TestWriteESAlignments() override {}
   
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/CaloEventSetup/test/dumpEcalTrigTowerMapping.cc
+++ b/Geometry/CaloEventSetup/test/dumpEcalTrigTowerMapping.cc
@@ -49,7 +49,7 @@
 class dumpEcalTrigTowerMapping : public edm::one::EDAnalyzer<> {
 public:
   explicit dumpEcalTrigTowerMapping( const edm::ParameterSet& );
-  ~dumpEcalTrigTowerMapping();
+  ~dumpEcalTrigTowerMapping() override;
     
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/CaloEventSetup/test/testEcalGetWindow.cc
+++ b/Geometry/CaloEventSetup/test/testEcalGetWindow.cc
@@ -51,7 +51,7 @@
 class testEcalGetWindow : public edm::one::EDAnalyzer<> {
 public:
   explicit testEcalGetWindow( const edm::ParameterSet& );
-  ~testEcalGetWindow();
+  ~testEcalGetWindow() override;
   
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/CaloGeometry/interface/FlatTrd.h
+++ b/Geometry/CaloGeometry/interface/FlatTrd.h
@@ -41,7 +41,7 @@ public:
   
   FlatTrd( const FlatTrd& tr, const Pt3D& local) ;
 
-  virtual ~FlatTrd() ;
+  ~FlatTrd() override ;
   
   virtual const GlobalPoint& getPosition() const { return m_global; }
   GlobalPoint getPosition( const Pt3D& local ) const;
@@ -55,7 +55,7 @@ public:
   // Return phiAxis azimuthal angle of axis of the crystal
   CCGFloat getPhiAxis() const ;
 
-  virtual void vocalCorners( Pt3DVec&        vec ,
+  void vocalCorners( Pt3DVec&        vec ,
                              const CCGFloat* pv  ,
                              Pt3D&           ref  ) const override;
   
@@ -69,11 +69,11 @@ public:
                             const CCGFloat* pv  ,
                             Pt3D&           ref  ) ;
   
-  virtual void getTransform( Tr3D& tr, Pt3DVec* lptr ) const override;
+  void getTransform( Tr3D& tr, Pt3DVec* lptr ) const override;
 
 private:
 
-  virtual void initCorners(CornersVec& ) override;
+  void initCorners(CornersVec& ) override;
   
   GlobalVector makeAxis( void );
   

--- a/Geometry/CaloGeometry/interface/IdealObliquePrism.h
+++ b/Geometry/CaloGeometry/interface/IdealObliquePrism.h
@@ -42,7 +42,7 @@ public:
 		     CornersMgr*        mgr       ,
 		     const CCGFloat*    parm       ) ;
 
-  virtual ~IdealObliquePrism() ;
+  ~IdealObliquePrism() override ;
 
   CCGFloat dEta() const ;
   CCGFloat dPhi() const ;
@@ -54,12 +54,12 @@ public:
 			    const CCGFloat* pv  ,
 			    Pt3D&           ref  ) ;
 
-  virtual void vocalCorners( Pt3DVec&        vec ,
+  void vocalCorners( Pt3DVec&        vec ,
 			     const CCGFloat* pv  ,
 			     Pt3D&           ref  ) const override;
 
 private:
-  virtual void initCorners(CornersVec&)  override;
+  void initCorners(CornersVec&)  override;
 
   static GlobalPoint etaPhiPerp( float eta, float phi, float perp ) ;
   static GlobalPoint etaPhiZ(float eta, float phi, float z) ;

--- a/Geometry/CaloGeometry/interface/IdealZPrism.h
+++ b/Geometry/CaloGeometry/interface/IdealZPrism.h
@@ -44,7 +44,7 @@ class IdealZPrism final : public CaloCellGeometry
 		   const CCGFloat*    parm       ,
 			  IdealZPrism::DEPTH depth) ;
       
-      virtual ~IdealZPrism() ;
+      ~IdealZPrism() override ;
       
       CCGFloat dEta() const ;
       CCGFloat dPhi() const ;
@@ -56,7 +56,7 @@ class IdealZPrism final : public CaloCellGeometry
 				const CCGFloat* pv  ,
 				Pt3D&           ref   ) ;
       
-      virtual void vocalCorners( Pt3DVec&        vec ,
+      void vocalCorners( Pt3DVec&        vec ,
 				 const CCGFloat* pv  ,
 				 Pt3D&           ref   ) const override;
 
@@ -68,7 +68,7 @@ class IdealZPrism final : public CaloCellGeometry
   
    private:
 
-      virtual void initCorners(CornersVec& ) override;
+      void initCorners(CornersVec& ) override;
       
       static GlobalPoint etaPhiR( float eta ,
 				  float phi ,

--- a/Geometry/CaloGeometry/interface/PreshowerStrip.h
+++ b/Geometry/CaloGeometry/interface/PreshowerStrip.h
@@ -40,14 +40,14 @@ public:
 		  const CCGFloat*    parm  ) :
     CaloCellGeometry ( po , mgr, parm ) {initSpan();}
 
-  virtual ~PreshowerStrip();
+  ~PreshowerStrip() override;
 
   CCGFloat dx() const { return param()[0] ; }
   CCGFloat dy() const { return param()[1] ; }
   CCGFloat dz() const { return param()[2] ; }
   CCGFloat tilt() const { return param()[3] ; }
 
-  virtual void vocalCorners( Pt3DVec&        vec ,
+  void vocalCorners( Pt3DVec&        vec ,
 			     const CCGFloat* pv  ,
 			     Pt3D&           ref  ) const override 
     { localCorners( vec, pv, ref ) ; }
@@ -56,10 +56,10 @@ public:
 			    const CCGFloat* pv  , 
 			    Pt3D&           ref  ) ;
 
-  virtual void getTransform( Tr3D& tr, Pt3DVec* /*lptr*/ ) const override
+  void getTransform( Tr3D& tr, Pt3DVec* /*lptr*/ ) const override
     { }
  private:
-  virtual void initCorners(CaloCellGeometry::CornersVec&) override;
+  void initCorners(CaloCellGeometry::CornersVec&) override;
 };
 
 std::ostream& operator<<( std::ostream& s , const PreshowerStrip& cell) ;

--- a/Geometry/CaloGeometry/interface/TruncatedPyramid.h
+++ b/Geometry/CaloGeometry/interface/TruncatedPyramid.h
@@ -39,7 +39,7 @@ public:
   TruncatedPyramid( const CornersVec& corn ,
 		    const CCGFloat*   par    ) ;
   
-  virtual ~TruncatedPyramid() ;
+  ~TruncatedPyramid() override ;
   
   const GlobalPoint getPosition( CCGFloat depth ) const ;
   
@@ -56,7 +56,7 @@ public:
 			     const Tr3D&                  tr ,
 			     std::vector<GlobalPoint>&    co   ) ;
   
-  virtual void vocalCorners( Pt3DVec&        vec ,
+  void vocalCorners( Pt3DVec&        vec ,
 			     const CCGFloat* pv  ,
 			     Pt3D&           ref  ) const override;
   
@@ -72,10 +72,10 @@ public:
 				const CCGFloat* pv  ,
 				Pt3D&           ref  ) ;
   
-  virtual void getTransform( Tr3D& tr, Pt3DVec* lptr ) const override;
+  void getTransform( Tr3D& tr, Pt3DVec* lptr ) const override;
   
 private:
-  virtual void initCorners(CornersVec&) override;
+  void initCorners(CornersVec&) override;
   
   GlobalVector makeAxis( void );
   

--- a/Geometry/CaloTopology/interface/CaloTowerTopology.h
+++ b/Geometry/CaloTopology/interface/CaloTowerTopology.h
@@ -15,22 +15,22 @@ public:
   /// standard constructor
   CaloTowerTopology(const HcalTopology * topology);
   /// virtual destructor
-  virtual ~CaloTowerTopology() { }
+  ~CaloTowerTopology() override { }
   /// is this detid present in the Topology?
-  virtual bool valid(const DetId& id) const;
+  bool valid(const DetId& id) const override;
   virtual bool validDetId(const CaloTowerDetId& id) const;
   /** Get the neighbors of the given cell in east direction*/
-  virtual std::vector<DetId> east(const DetId& id) const;
+  std::vector<DetId> east(const DetId& id) const override;
   /** Get the neighbors of the given cell in west direction*/
-  virtual std::vector<DetId> west(const DetId& id) const;
+  std::vector<DetId> west(const DetId& id) const override;
   /** Get the neighbors of the given cell in north direction*/
-  virtual std::vector<DetId> north(const DetId& id) const;
+  std::vector<DetId> north(const DetId& id) const override;
   /** Get the neighbors of the given cell in south direction*/
-  virtual std::vector<DetId> south(const DetId& id) const;
+  std::vector<DetId> south(const DetId& id) const override;
   /** Get the neighbors of the given cell in up direction (outward)*/
-  virtual std::vector<DetId> up(const DetId& id) const;
+  std::vector<DetId> up(const DetId& id) const override;
   /** Get the neighbors of the given cell in down direction (inward)*/
-  virtual std::vector<DetId> down(const DetId& id) const;
+  std::vector<DetId> down(const DetId& id) const override;
 
   //mimic accessors from HcalTopology, but with continuous ieta
   int firstHBRing() const {return firstHBRing_;}

--- a/Geometry/CaloTopology/interface/EcalBarrelHardcodedTopology.h
+++ b/Geometry/CaloTopology/interface/EcalBarrelHardcodedTopology.h
@@ -13,13 +13,13 @@ class EcalBarrelHardcodedTopology final : public CaloSubdetectorTopology
   /// create a new Topology
   EcalBarrelHardcodedTopology() {};
 
-  virtual ~EcalBarrelHardcodedTopology() {};
+  ~EcalBarrelHardcodedTopology() override {};
   
   /// move the Topology north (increment iphi)
-  virtual DetId  goNorth(const DetId& id) const {
+  DetId  goNorth(const DetId& id) const override {
     return incrementIphi(EBDetId(id));
   }
-  virtual std::vector<DetId> north(const DetId& id) const
+  std::vector<DetId> north(const DetId& id) const override
     { 
       EBDetId nextId=goNorth(id);
       std::vector<DetId> vNeighborsDetId;
@@ -29,10 +29,10 @@ class EcalBarrelHardcodedTopology final : public CaloSubdetectorTopology
     }
 
   /// move the Topology south (decrement iphi)
-  virtual DetId goSouth(const DetId& id) const {
+  DetId goSouth(const DetId& id) const override {
     return decrementIphi(EBDetId(id));
   }
-  virtual std::vector<DetId> south(const DetId& id) const
+  std::vector<DetId> south(const DetId& id) const override
     { 
       EBDetId nextId=goSouth(id);
       std::vector<DetId> vNeighborsDetId;
@@ -42,10 +42,10 @@ class EcalBarrelHardcodedTopology final : public CaloSubdetectorTopology
     }
 
   /// move the Topology east (negative ieta)
-  virtual DetId  goEast(const DetId& id) const {
+  DetId  goEast(const DetId& id) const override {
     return decrementIeta(EBDetId(id));
   }
-  virtual std::vector<DetId> east(const DetId& id) const
+  std::vector<DetId> east(const DetId& id) const override
     { 
       EBDetId nextId=goEast(id);
       std::vector<DetId> vNeighborsDetId;
@@ -55,10 +55,10 @@ class EcalBarrelHardcodedTopology final : public CaloSubdetectorTopology
     }
 
   /// move the Topology west (positive ieta)
-  virtual DetId  goWest(const DetId& id) const {
+  DetId  goWest(const DetId& id) const override {
     return incrementIeta(EBDetId(id));
   }
-  virtual std::vector<DetId> west(const DetId& id) const
+  std::vector<DetId> west(const DetId& id) const override
     { 
       EBDetId nextId=goWest(id);
       std::vector<DetId> vNeighborsDetId;
@@ -67,14 +67,14 @@ class EcalBarrelHardcodedTopology final : public CaloSubdetectorTopology
       return vNeighborsDetId;
     }
   
-  virtual std::vector<DetId> up(const DetId& /*id*/) const
+  std::vector<DetId> up(const DetId& /*id*/) const override
     {
       std::cout << "EcalBarrelHardcodedTopology::up() not yet implemented" << std::endl; 
       std::vector<DetId> vNeighborsDetId;
       return  vNeighborsDetId;
     }
   
-  virtual std::vector<DetId> down(const DetId& /*id*/) const
+  std::vector<DetId> down(const DetId& /*id*/) const override
     {
       std::cout << "EcalBarrelHardcodedTopology::down() not yet implemented" << std::endl; 
       std::vector<DetId> vNeighborsDetId;

--- a/Geometry/CaloTopology/interface/EcalBarrelTopology.h
+++ b/Geometry/CaloTopology/interface/EcalBarrelTopology.h
@@ -16,7 +16,7 @@ class EcalBarrelTopology final : public CaloSubdetectorTopology
   EcalBarrelTopology(): theGeom_(0) {};
 
   /// virtual destructor
-  virtual ~EcalBarrelTopology() { }  
+  ~EcalBarrelTopology() override { }  
 
   /// create a new Topology from geometry
   EcalBarrelTopology(edm::ESHandle<CaloGeometry> theGeom) : theGeom_(theGeom)
@@ -24,10 +24,10 @@ class EcalBarrelTopology final : public CaloSubdetectorTopology
     }
   
  /// move the Topology north (increment iphi)
-  virtual DetId  goNorth(const DetId& id) const {
+  DetId  goNorth(const DetId& id) const override {
     return incrementIphi(EBDetId(id));
   }
-  virtual std::vector<DetId> north(const DetId& id) const
+  std::vector<DetId> north(const DetId& id) const override
     { 
       EBDetId nextId=goNorth(id);
       std::vector<DetId> vNeighborsDetId;
@@ -37,10 +37,10 @@ class EcalBarrelTopology final : public CaloSubdetectorTopology
     }
 
   /// move the Topology south (decrement iphi)
-  virtual DetId goSouth(const DetId& id) const {
+  DetId goSouth(const DetId& id) const override {
     return decrementIphi(EBDetId(id));
   }
-  virtual std::vector<DetId> south(const DetId& id) const
+  std::vector<DetId> south(const DetId& id) const override
     { 
       EBDetId nextId=goSouth(id);
       std::vector<DetId> vNeighborsDetId;
@@ -50,10 +50,10 @@ class EcalBarrelTopology final : public CaloSubdetectorTopology
     }
 
   /// move the Topology east (negative ieta)
-  virtual DetId  goEast(const DetId& id) const {
+  DetId  goEast(const DetId& id) const override {
     return decrementIeta(EBDetId(id));
   }
-  virtual std::vector<DetId> east(const DetId& id) const
+  std::vector<DetId> east(const DetId& id) const override
     { 
       EBDetId nextId=goEast(id);
       std::vector<DetId> vNeighborsDetId;
@@ -63,10 +63,10 @@ class EcalBarrelTopology final : public CaloSubdetectorTopology
     }
 
   /// move the Topology west (positive ieta)
-  virtual DetId  goWest(const DetId& id) const {
+  DetId  goWest(const DetId& id) const override {
     return incrementIeta(EBDetId(id));
   }
-  virtual std::vector<DetId> west(const DetId& id) const
+  std::vector<DetId> west(const DetId& id) const override
     { 
       EBDetId nextId=goWest(id);
       std::vector<DetId> vNeighborsDetId;
@@ -76,14 +76,14 @@ class EcalBarrelTopology final : public CaloSubdetectorTopology
     }
   
   
-  virtual std::vector<DetId> up(const DetId& /*id*/) const
+  std::vector<DetId> up(const DetId& /*id*/) const override
     {
       std::cout << "EcalBarrelTopology::up() not yet implemented" << std::endl; 
       std::vector<DetId> vNeighborsDetId;
       return  vNeighborsDetId;
     }
   
-  virtual std::vector<DetId> down(const DetId& /*id*/) const
+  std::vector<DetId> down(const DetId& /*id*/) const override
     {
       std::cout << "EcalBarrelTopology::down() not yet implemented" << std::endl; 
       std::vector<DetId> vNeighborsDetId;

--- a/Geometry/CaloTopology/interface/EcalEndcapHardcodedTopology.h
+++ b/Geometry/CaloTopology/interface/EcalEndcapHardcodedTopology.h
@@ -13,13 +13,13 @@ class EcalEndcapHardcodedTopology final : public CaloSubdetectorTopology
   /// create a new Topology
   EcalEndcapHardcodedTopology() {};
 
-  virtual ~EcalEndcapHardcodedTopology() {};
+  ~EcalEndcapHardcodedTopology() override {};
   
    /// move the Topology north (increment iy)  
-  virtual DetId  goNorth(const DetId& id) const {
+  DetId  goNorth(const DetId& id) const override {
     return incrementIy(EEDetId(id));
   }
-  virtual std::vector<DetId> north(const DetId& id) const
+  std::vector<DetId> north(const DetId& id) const override
   { 
     EEDetId nextId= goNorth(id);
     std::vector<DetId> vNeighborsDetId;
@@ -29,10 +29,10 @@ class EcalEndcapHardcodedTopology final : public CaloSubdetectorTopology
   }
   
   /// move the Topology south (decrement iy)
-  virtual DetId goSouth(const DetId& id) const {
+  DetId goSouth(const DetId& id) const override {
     return decrementIy(EEDetId(id));
   }
-  virtual std::vector<DetId> south(const DetId& id) const
+  std::vector<DetId> south(const DetId& id) const override
   { 
     EEDetId nextId= goSouth(id);
     std::vector<DetId> vNeighborsDetId;
@@ -42,10 +42,10 @@ class EcalEndcapHardcodedTopology final : public CaloSubdetectorTopology
   }
   
   /// move the Topology east (positive ix)
-  virtual DetId  goEast(const DetId& id) const {
+  DetId  goEast(const DetId& id) const override {
     return incrementIx(EEDetId(id));
   }
-  virtual std::vector<DetId> east(const DetId& id) const
+  std::vector<DetId> east(const DetId& id) const override
   { 
     EEDetId nextId=goEast(id);
     std::vector<DetId> vNeighborsDetId;
@@ -55,10 +55,10 @@ class EcalEndcapHardcodedTopology final : public CaloSubdetectorTopology
   }
   
   /// move the Topology west (negative ix)
-  virtual DetId goWest(const DetId& id) const {
+  DetId goWest(const DetId& id) const override {
     return decrementIx(EEDetId(id));
   }
-  virtual std::vector<DetId> west(const DetId& id) const
+  std::vector<DetId> west(const DetId& id) const override
   { 
     EEDetId nextId=goWest(id);
     std::vector<DetId> vNeighborsDetId;
@@ -67,14 +67,14 @@ class EcalEndcapHardcodedTopology final : public CaloSubdetectorTopology
     return vNeighborsDetId;
   }
   
-  virtual std::vector<DetId> up(const DetId& /*id*/) const
+  std::vector<DetId> up(const DetId& /*id*/) const override
   {
     std::cout << "EcalEndcapHardcodedTopology::up() not yet implemented" << std::endl; 
     std::vector<DetId> vNeighborsDetId;
     return  vNeighborsDetId;
   }
   
-  virtual std::vector<DetId> down(const DetId& /*id*/) const
+  std::vector<DetId> down(const DetId& /*id*/) const override
   {
     std::cout << "EcalEndcapHardcodedTopology::down() not yet implemented" << std::endl; 
     std::vector<DetId> vNeighborsDetId;

--- a/Geometry/CaloTopology/interface/EcalEndcapTopology.h
+++ b/Geometry/CaloTopology/interface/EcalEndcapTopology.h
@@ -15,7 +15,7 @@ class EcalEndcapTopology final : public CaloSubdetectorTopology {
   EcalEndcapTopology() : theGeom_(0) {};
 
   /// virtual destructor
-  virtual ~EcalEndcapTopology() { }  
+  ~EcalEndcapTopology() override { }  
   
   /// create a new Topology from geometry
   EcalEndcapTopology(edm::ESHandle<CaloGeometry> theGeom) : theGeom_(theGeom)
@@ -23,10 +23,10 @@ class EcalEndcapTopology final : public CaloSubdetectorTopology {
     }
 
   /// move the Topology north (increment iy)  
-  virtual DetId  goNorth(const DetId& id) const {
+  DetId  goNorth(const DetId& id) const override {
     return incrementIy(EEDetId(id));
   }
-  virtual std::vector<DetId> north(const DetId& id) const
+  std::vector<DetId> north(const DetId& id) const override
     { 
       EEDetId nextId= goNorth(id);
       std::vector<DetId> vNeighborsDetId;
@@ -36,10 +36,10 @@ class EcalEndcapTopology final : public CaloSubdetectorTopology {
     }
 
   /// move the Topology south (decrement iy)
-  virtual DetId goSouth(const DetId& id) const {
+  DetId goSouth(const DetId& id) const override {
     return decrementIy(EEDetId(id));
   }
-  virtual std::vector<DetId> south(const DetId& id) const
+  std::vector<DetId> south(const DetId& id) const override
     { 
       EEDetId nextId= goSouth(id);
       std::vector<DetId> vNeighborsDetId;
@@ -49,10 +49,10 @@ class EcalEndcapTopology final : public CaloSubdetectorTopology {
     }
 
   /// move the Topology east (positive ix)
-  virtual DetId  goEast(const DetId& id) const {
+  DetId  goEast(const DetId& id) const override {
     return incrementIx(EEDetId(id));
   }
-  virtual std::vector<DetId> east(const DetId& id) const
+  std::vector<DetId> east(const DetId& id) const override
     { 
       EEDetId nextId=goEast(id);
       std::vector<DetId> vNeighborsDetId;
@@ -62,10 +62,10 @@ class EcalEndcapTopology final : public CaloSubdetectorTopology {
     }
 
   /// move the Topology west (negative ix)
-  virtual DetId goWest(const DetId& id) const {
+  DetId goWest(const DetId& id) const override {
     return decrementIx(EEDetId(id));
   }
-  virtual std::vector<DetId> west(const DetId& id) const
+  std::vector<DetId> west(const DetId& id) const override
     { 
       EEDetId nextId=goWest(id);
       std::vector<DetId> vNeighborsDetId;
@@ -74,14 +74,14 @@ class EcalEndcapTopology final : public CaloSubdetectorTopology {
       return vNeighborsDetId;
     }
   
-  virtual std::vector<DetId> up(const DetId& /*id*/) const
+  std::vector<DetId> up(const DetId& /*id*/) const override
     {
       std::cout << "EcalBarrelTopology::up() not yet implemented" << std::endl; 
       std::vector<DetId> vNeighborsDetId;
       return  vNeighborsDetId;
     }
   
-  virtual std::vector<DetId> down(const DetId& /*id*/) const
+  std::vector<DetId> down(const DetId& /*id*/) const override
     {
       std::cout << "EcalBarrelTopology::down() not yet implemented" << std::endl; 
       std::vector<DetId> vNeighborsDetId;

--- a/Geometry/CaloTopology/interface/EcalPreshowerTopology.h
+++ b/Geometry/CaloTopology/interface/EcalPreshowerTopology.h
@@ -15,7 +15,7 @@ class EcalPreshowerTopology final : public CaloSubdetectorTopology {
   EcalPreshowerTopology() : theGeom_(0) {};
 
   /// virtual destructor
-  virtual ~EcalPreshowerTopology() { }  
+  ~EcalPreshowerTopology() override { }  
   
   /// create a new Topology from geometry
   EcalPreshowerTopology(edm::ESHandle<CaloGeometry> theGeom) : theGeom_(theGeom)
@@ -24,10 +24,10 @@ class EcalPreshowerTopology final : public CaloSubdetectorTopology {
 
   
   /// move the Topology north (increment iy)  
-  virtual DetId  goNorth(const DetId& id) const {
+  DetId  goNorth(const DetId& id) const override {
     return incrementIy(ESDetId(id));
   }
-  virtual std::vector<DetId> north(const DetId& id) const
+  std::vector<DetId> north(const DetId& id) const override
     { 
       ESDetId nextId= goNorth(id);
       std::vector<DetId> vNeighborsDetId;
@@ -37,10 +37,10 @@ class EcalPreshowerTopology final : public CaloSubdetectorTopology {
     }
 
   /// move the Topology south (decrement iy)
-  virtual DetId goSouth(const DetId& id) const {
+  DetId goSouth(const DetId& id) const override {
     return decrementIy(ESDetId(id));
   }
-  virtual std::vector<DetId> south(const DetId& id) const
+  std::vector<DetId> south(const DetId& id) const override
     { 
       ESDetId nextId= goSouth(id);
       std::vector<DetId> vNeighborsDetId;
@@ -50,10 +50,10 @@ class EcalPreshowerTopology final : public CaloSubdetectorTopology {
     }
 
   /// move the Topology east (positive ix)
-  virtual DetId  goEast(const DetId& id) const {
+  DetId  goEast(const DetId& id) const override {
     return incrementIx(ESDetId(id));
   }
-  virtual std::vector<DetId> east(const DetId& id) const
+  std::vector<DetId> east(const DetId& id) const override
   { 
     ESDetId nextId=goEast(id);
     std::vector<DetId> vNeighborsDetId;
@@ -63,10 +63,10 @@ class EcalPreshowerTopology final : public CaloSubdetectorTopology {
   }
 
   /// move the Topology west (negative ix)
-  virtual DetId goWest(const DetId& id) const {
+  DetId goWest(const DetId& id) const override {
     return decrementIx(ESDetId(id));
   }
-  virtual std::vector<DetId> west(const DetId& id) const
+  std::vector<DetId> west(const DetId& id) const override
   { 
     ESDetId nextId=goWest(id);
     std::vector<DetId> vNeighborsDetId;
@@ -75,10 +75,10 @@ class EcalPreshowerTopology final : public CaloSubdetectorTopology {
     return vNeighborsDetId;
   }
   
-  virtual DetId goUp(const DetId& id) const {
+  DetId goUp(const DetId& id) const override {
     return incrementIz(ESDetId(id));
   }
-  virtual std::vector<DetId> up(const DetId& id) const
+  std::vector<DetId> up(const DetId& id) const override
   {
     ESDetId nextId=goUp(id);
     std::vector<DetId> vNeighborsDetId;
@@ -87,10 +87,10 @@ class EcalPreshowerTopology final : public CaloSubdetectorTopology {
     return  vNeighborsDetId;
   }
   
-  virtual DetId goDown(const DetId& id) const {
+  DetId goDown(const DetId& id) const override {
     return decrementIz(ESDetId(id));
   }
-  virtual std::vector<DetId> down(const DetId& id) const
+  std::vector<DetId> down(const DetId& id) const override
   {
     ESDetId nextId=goDown(id);
     std::vector<DetId> vNeighborsDetId;

--- a/Geometry/CaloTopology/interface/FastTimeTopology.h
+++ b/Geometry/CaloTopology/interface/FastTimeTopology.h
@@ -18,13 +18,13 @@ public:
 		   ForwardSubdetector subdet, int type);
 
   /// virtual destructor
-  virtual ~FastTimeTopology() { }  
+  ~FastTimeTopology() override { }  
 
   /// move the Topology north (increment iy)  
-  virtual DetId  goNorth(const DetId& id) const {
+  DetId  goNorth(const DetId& id) const override {
     return offsetBy(id,0,+1);
   }
-  virtual std::vector<DetId> north(const DetId& id) const { 
+  std::vector<DetId> north(const DetId& id) const override { 
     DetId nextId= goNorth(id);
     std::vector<DetId> vNeighborsDetId;
     if (! (nextId==DetId(0)))
@@ -33,10 +33,10 @@ public:
   }
 
   /// move the Topology south (decrement iy)
-  virtual DetId goSouth(const DetId& id) const {
+  DetId goSouth(const DetId& id) const override {
     return offsetBy(id,0,-1);
   }
-  virtual std::vector<DetId> south(const DetId& id) const { 
+  std::vector<DetId> south(const DetId& id) const override { 
     DetId nextId= goSouth(id);
     std::vector<DetId> vNeighborsDetId;
     if (! (nextId==DetId(0)))
@@ -45,10 +45,10 @@ public:
   }
 
   /// move the Topology east (positive ix)
-  virtual DetId  goEast(const DetId& id) const {
+  DetId  goEast(const DetId& id) const override {
     return offsetBy(id,+1,0);
   }
-  virtual std::vector<DetId> east(const DetId& id) const { 
+  std::vector<DetId> east(const DetId& id) const override { 
     DetId nextId=goEast(id);
     std::vector<DetId> vNeighborsDetId;
     if (! (nextId==DetId(0)))
@@ -57,10 +57,10 @@ public:
   }
 
   /// move the Topology west (negative ix)
-  virtual DetId goWest(const DetId& id) const {
+  DetId goWest(const DetId& id) const override {
     return offsetBy(id,-1,0);
   }
-  virtual std::vector<DetId> west(const DetId& id) const { 
+  std::vector<DetId> west(const DetId& id) const override { 
     DetId nextId=goWest(id);
     std::vector<DetId> vNeighborsDetId;
     if (! (nextId==DetId(0)))
@@ -68,23 +68,23 @@ public:
     return vNeighborsDetId;
   }
   
-  virtual std::vector<DetId> up(const DetId& id) const {
+  std::vector<DetId> up(const DetId& id) const override {
     std::vector<DetId> vNeighborsDetId;
     return vNeighborsDetId;
   }
   
-  virtual std::vector<DetId> down(const DetId& id) const {
+  std::vector<DetId> down(const DetId& id) const override {
     std::vector<DetId> vNeighborsDetId;
     return vNeighborsDetId;
   }
 
   ///Dense indexing
-  virtual uint32_t detId2denseId(const DetId& id) const;
-  virtual DetId    denseId2detId(uint32_t denseId) const;
+  uint32_t detId2denseId(const DetId& id) const override;
+  DetId    denseId2detId(uint32_t denseId) const override;
   virtual uint32_t detId2denseGeomId(const DetId& id) const;
 
   ///Is this a valid cell id
-  virtual bool valid(const DetId& id) const;
+  bool valid(const DetId& id) const override;
   bool validHashIndex(uint32_t ix) const {return (ix < kSizeForDenseIndexing);}
 
   unsigned int totalModules() const {return kSizeForDenseIndexing;}

--- a/Geometry/CaloTopology/interface/HGCalTopology.h
+++ b/Geometry/CaloTopology/interface/HGCalTopology.h
@@ -18,13 +18,13 @@ public:
   HGCalTopology(const HGCalDDDConstants& hdcons, ForwardSubdetector subdet, bool halfChamber);
 
   /// virtual destructor
-  virtual ~HGCalTopology() { }  
+  ~HGCalTopology() override { }  
 
   /// move the Topology north (increment iy)  
-  virtual DetId  goNorth(const DetId& id) const {
+  DetId  goNorth(const DetId& id) const override {
     return changeXY(id,0,+1);
   }
-  virtual std::vector<DetId> north(const DetId& id) const { 
+  std::vector<DetId> north(const DetId& id) const override { 
     DetId nextId= goNorth(id);
     std::vector<DetId> vNeighborsDetId;
     if (! (nextId==DetId(0)))
@@ -33,10 +33,10 @@ public:
   }
 
   /// move the Topology south (decrement iy)
-  virtual DetId goSouth(const DetId& id) const {
+  DetId goSouth(const DetId& id) const override {
     return changeXY(id,0,-1);
   }
-  virtual std::vector<DetId> south(const DetId& id) const { 
+  std::vector<DetId> south(const DetId& id) const override { 
     DetId nextId= goSouth(id);
     std::vector<DetId> vNeighborsDetId;
     if (! (nextId==DetId(0)))
@@ -45,10 +45,10 @@ public:
   }
 
   /// move the Topology east (positive ix)
-  virtual DetId  goEast(const DetId& id) const {
+  DetId  goEast(const DetId& id) const override {
     return changeXY(id,+1,0);
   }
-  virtual std::vector<DetId> east(const DetId& id) const { 
+  std::vector<DetId> east(const DetId& id) const override { 
     DetId nextId=goEast(id);
     std::vector<DetId> vNeighborsDetId;
     if (! (nextId==DetId(0)))
@@ -57,10 +57,10 @@ public:
   }
 
   /// move the Topology west (negative ix)
-  virtual DetId goWest(const DetId& id) const {
+  DetId goWest(const DetId& id) const override {
     return changeXY(id,-1,0);
   }
-  virtual std::vector<DetId> west(const DetId& id) const { 
+  std::vector<DetId> west(const DetId& id) const override { 
     DetId nextId=goWest(id);
     std::vector<DetId> vNeighborsDetId;
     if (! (nextId==DetId(0)))
@@ -68,7 +68,7 @@ public:
     return vNeighborsDetId;
   }
   
-  virtual std::vector<DetId> up(const DetId& id) const {
+  std::vector<DetId> up(const DetId& id) const override {
     DetId nextId=changeZ(id,+1);
     std::vector<DetId> vNeighborsDetId;
     if (! (nextId==DetId(0)))
@@ -76,7 +76,7 @@ public:
     return vNeighborsDetId;
   }
   
-  virtual std::vector<DetId> down(const DetId& id) const {
+  std::vector<DetId> down(const DetId& id) const override {
     DetId nextId=changeZ(id,-1);
     std::vector<DetId> vNeighborsDetId;
     if (! (nextId==DetId(0)))
@@ -88,12 +88,12 @@ public:
   HGCalGeometryMode::GeometryMode geomMode() const {return mode_;}
 
   ///Dense indexing
-  virtual uint32_t detId2denseId(const DetId& id) const;
-  virtual DetId denseId2detId(uint32_t denseId) const;
+  uint32_t detId2denseId(const DetId& id) const override;
+  DetId denseId2detId(uint32_t denseId) const override;
   virtual uint32_t detId2denseGeomId(const DetId& id) const;
 
   ///Is this a valid cell id
-  virtual bool valid(const DetId& id) const;
+  bool valid(const DetId& id) const override;
   bool validHashIndex(uint32_t ix) const {return (ix < kSizeForDenseIndexing);}
 
   unsigned int totalModules() const {return kSizeForDenseIndexing;}

--- a/Geometry/CaloTopology/interface/HcalTopology.h
+++ b/Geometry/CaloTopology/interface/HcalTopology.h
@@ -40,16 +40,16 @@ public:
   static std::string producerTag() { return "HCAL" ; }
 
   /// return a linear packed id
-  virtual unsigned int detId2denseId(const DetId& id) const;
+  unsigned int detId2denseId(const DetId& id) const override;
   /// return a linear packed id
-  virtual DetId denseId2detId(unsigned int /*denseid*/) const;
+  DetId denseId2detId(unsigned int /*denseid*/) const override;
   /// return a count of valid cells (for dense indexing use)
-  virtual unsigned int ncells() const;
+  unsigned int ncells() const override;
   /// return a version which identifies the given topology
-  virtual int topoVersion() const;
+  int topoVersion() const override;
 
   /** Is this a valid cell id? */
-  virtual bool valid(const DetId& id) const;
+  bool valid(const DetId& id) const override;
   /** Is this a valid cell id? */
   bool validHcal(const HcalDetId& id) const;
   bool validDetId(HcalSubdetector subdet, int ieta, int iphi, int depth) const;
@@ -59,17 +59,17 @@ public:
   /** Flag=0 for unmerged Id's; =1 for for merged Id's; =2 for either */
 
   /** Get the neighbors of the given cell in east direction*/
-  virtual std::vector<DetId> east(const DetId& id) const;
+  std::vector<DetId> east(const DetId& id) const override;
   /** Get the neighbors of the given cell in west direction*/
-  virtual std::vector<DetId> west(const DetId& id) const;
+  std::vector<DetId> west(const DetId& id) const override;
   /** Get the neighbors of the given cell in north direction*/
-  virtual std::vector<DetId> north(const DetId& id) const;
+  std::vector<DetId> north(const DetId& id) const override;
   /** Get the neighbors of the given cell in south direction*/
-  virtual std::vector<DetId> south(const DetId& id) const;
+  std::vector<DetId> south(const DetId& id) const override;
   /** Get the neighbors of the given cell in up direction (outward)*/
-  virtual std::vector<DetId> up(const DetId& id) const;
+  std::vector<DetId> up(const DetId& id) const override;
   /** Get the neighbors of the given cell in down direction (inward)*/
-  virtual std::vector<DetId> down(const DetId& id) const;
+  std::vector<DetId> down(const DetId& id) const override;
 
   /** Get the neighbors of the given cell with higher (signed) ieta */
   int incIEta(const HcalDetId& id, HcalDetId neighbors[2]) const;

--- a/Geometry/CaloTopology/test/CaloTowerTopologyTester.cc
+++ b/Geometry/CaloTopology/test/CaloTowerTopologyTester.cc
@@ -22,10 +22,10 @@
 class CaloTowerTopologyTester : public edm::EDAnalyzer {
 public:
   explicit CaloTowerTopologyTester(const edm::ParameterSet& );
-  ~CaloTowerTopologyTester();
+  ~CaloTowerTopologyTester() override;
 
   
-  virtual void analyze(const edm::Event&, const edm::EventSetup& );
+  void analyze(const edm::Event&, const edm::EventSetup& ) override;
   void doTest(const CaloTowerTopology& topology);
 
 private:

--- a/Geometry/CaloTopology/test/FastTimeTopologyTester.cc
+++ b/Geometry/CaloTopology/test/FastTimeTopologyTester.cc
@@ -22,10 +22,10 @@
 class FastTimeTopologyTester : public edm::EDAnalyzer {
 public:
   explicit FastTimeTopologyTester(const edm::ParameterSet& );
-  ~FastTimeTopologyTester();
+  ~FastTimeTopologyTester() override;
 
   
-  virtual void analyze(const edm::Event&, const edm::EventSetup& );
+  void analyze(const edm::Event&, const edm::EventSetup& ) override;
   void doTest(const FastTimeTopology& topology);
 
 private:

--- a/Geometry/CaloTopology/test/HGCalTopologyTester.cc
+++ b/Geometry/CaloTopology/test/HGCalTopologyTester.cc
@@ -22,10 +22,10 @@
 class HGCalTopologyTester : public edm::EDAnalyzer {
 public:
   explicit HGCalTopologyTester(const edm::ParameterSet& );
-  ~HGCalTopologyTester();
+  ~HGCalTopologyTester() override;
 
   
-  virtual void analyze(const edm::Event&, const edm::EventSetup& );
+  void analyze(const edm::Event&, const edm::EventSetup& ) override;
   void doTest(const HGCalTopology& topology);
 
 private:

--- a/Geometry/CaloTopology/test/HcalTopologyTester.cc
+++ b/Geometry/CaloTopology/test/HcalTopologyTester.cc
@@ -23,10 +23,10 @@
 class HcalTopologyTester : public edm::EDAnalyzer {
 public:
   explicit HcalTopologyTester(const edm::ParameterSet& );
-  ~HcalTopologyTester();
+  ~HcalTopologyTester() override;
 
   
-  virtual void analyze(const edm::Event&, const edm::EventSetup& );
+  void analyze(const edm::Event&, const edm::EventSetup& ) override;
   void doTest(const HcalTopology& topology);
 
 private:

--- a/Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h
+++ b/Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h
@@ -24,29 +24,29 @@ public:
     GlobalTrackingGeometry(std::vector<const TrackingGeometry*>& geos);
 
     /// Destructor
-    virtual ~GlobalTrackingGeometry();  
+    ~GlobalTrackingGeometry() override;  
 
     // Return a vector of all det types.
-    virtual const DetTypeContainer&  detTypes()         const;
+    const DetTypeContainer&  detTypes()         const override;
 
     // Returm a vector of all GeomDetUnit
-    virtual const DetUnitContainer&  detUnits()         const;
+    const DetUnitContainer&  detUnits()         const override;
 
     // Returm a vector of all GeomDet (including all GeomDetUnits)
-    virtual const DetContainer&      dets()             const;
+    const DetContainer&      dets()             const override;
 
     // Returm a vector of all GeomDetUnit DetIds
-    virtual const DetIdContainer&    detUnitIds()       const;
+    const DetIdContainer&    detUnitIds()       const override;
 
     // Returm a vector of all GeomDet DetIds (including those of GeomDetUnits)
-    virtual const DetIdContainer&    detIds()           const;
+    const DetIdContainer&    detIds()           const override;
 
     // Return the pointer to the GeomDetUnit corresponding to a given DetId
-    virtual const GeomDetUnit*       idToDetUnit(DetId) const;
+    const GeomDetUnit*       idToDetUnit(DetId) const override;
 
     // Return the pointer to the GeomDet corresponding to a given DetId
     // (valid also for GeomDetUnits)
-    virtual const GeomDet*           idToDet(DetId)     const; 
+    const GeomDet*           idToDet(DetId)     const override; 
         
     /// Return the pointer to the actual geometry for a given DetId
     const TrackingGeometry* slaveGeometry(DetId id) const;

--- a/Geometry/CommonDetUnit/interface/GluedGeomDet.h
+++ b/Geometry/CommonDetUnit/interface/GluedGeomDet.h
@@ -9,13 +9,13 @@ public:
 
   GluedGeomDet( BoundPlane* sp, const GeomDetUnit* monoDet,  const GeomDetUnit* stereoDet, const DetId gluedDetId);
   
-  virtual ~GluedGeomDet();
+  ~GluedGeomDet() override;
 
   bool isLeaf() const override { return false;}
-  virtual std::vector<const GeomDet*> components() const override;
+  std::vector<const GeomDet*> components() const override;
 
   // Which subdetector
-  virtual SubDetector subDetector() const override {return theMonoDet->subDetector();}
+  SubDetector subDetector() const override {return theMonoDet->subDetector();}
 
   const GeomDetUnit* monoDet() const { return theMonoDet;}
   const GeomDetUnit* stereoDet() const { return theStereoDet;}

--- a/Geometry/CommonDetUnit/src/GeomDet.cc
+++ b/Geometry/CommonDetUnit/src/GeomDet.cc
@@ -60,19 +60,19 @@ void GeomDet::setSurfaceDeformation(const SurfaceDeformation * /*deformation*/)
 
 namespace {
 struct DummyTopology final : public Topology {
-  virtual LocalPoint localPosition( const MeasurementPoint& ) const { return LocalPoint();}
-  virtual LocalError
-  localError( const MeasurementPoint&, const MeasurementError& ) const { return LocalError();}
-  virtual MeasurementPoint measurementPosition( const LocalPoint&) const { return MeasurementPoint();}
-  virtual MeasurementError
-  measurementError( const LocalPoint&, const LocalError& ) const { return MeasurementError();}
-  virtual int channel( const LocalPoint& p) const { return -1;}
+  LocalPoint localPosition( const MeasurementPoint& ) const override { return LocalPoint();}
+  LocalError
+  localError( const MeasurementPoint&, const MeasurementError& ) const override { return LocalError();}
+  MeasurementPoint measurementPosition( const LocalPoint&) const override { return MeasurementPoint();}
+  MeasurementError
+  measurementError( const LocalPoint&, const LocalError& ) const override { return MeasurementError();}
+  int channel( const LocalPoint& p) const override { return -1;}
 };
   const DummyTopology dummyTopology{};
 
 struct DummyGeomDetType final : public GeomDetType {
    DummyGeomDetType() : GeomDetType("", GeomDetEnumerators::invalidDet){}
-   const Topology& topology() const { return dummyTopology;}
+   const Topology& topology() const override { return dummyTopology;}
 };
   const DummyGeomDetType dummyGeomDetType{};
 }

--- a/Geometry/CommonDetUnit/test/testDetSort.cpp
+++ b/Geometry/CommonDetUnit/test/testDetSort.cpp
@@ -22,12 +22,12 @@ class MyDet : public GeomDet {
     GeomDet(new BoundPlane(pos,RotationType(),new RectangularPlaneBounds(0,0,0))){}
   
   virtual DetId geographicalId() const {return DetId();}
-  virtual std::vector< const GeomDet*> components() const {
+  std::vector< const GeomDet*> components() const override {
     return std::vector< const GeomDet*>();
   }
 
   /// Which subdetector
-  virtual SubDetector subDetector() const {return GeomDetEnumerators::DT;}
+  SubDetector subDetector() const override {return GeomDetEnumerators::DT;}
 
 };  
 

--- a/Geometry/CommonTopologies/interface/BowedSurfaceDeformation.h
+++ b/Geometry/CommonTopologies/interface/BowedSurfaceDeformation.h
@@ -27,10 +27,10 @@ class BowedSurfaceDeformation : public SurfaceDeformation
   /// between minParameterSize() and maxParameterSize()
   BowedSurfaceDeformation(const std::vector<double> &parameters);
 
-  virtual BowedSurfaceDeformation* clone() const;
+  BowedSurfaceDeformation* clone() const override;
 
   /// specific type, i.e. SurfaceDeformationFactory::kBowedSurface
-  virtual int type() const;
+  int type() const override;
 
   /// correction to add to local position depending on 
   /// - track parameters in local frame (from LocalTrajectoryParameters):
@@ -38,18 +38,18 @@ class BowedSurfaceDeformation : public SurfaceDeformation
   ///   * track angles   as LocalTrackAngles(dxdz, dydz)
   /// - length of surface (local y-coordinate)
   /// - width of surface (local x-coordinate)
-  virtual Local2DVector positionCorrection(const Local2DPoint &localPos,
+  Local2DVector positionCorrection(const Local2DPoint &localPos,
                                            const LocalTrackAngles &localAngles,
-                                           double length, double width) const;
+                                           double length, double width) const override;
 
   /// update information with parameters of 'other',
   /// false in case the type or some parameters do not match and thus
   /// the information cannot be used (then no changes are done),
   /// true if merge was successful
-  virtual bool add(const SurfaceDeformation &other);
+  bool add(const SurfaceDeformation &other) override;
   
   /// parameters, i.e. sagittae as given in the constructor
-  virtual std::vector<double> parameters() const;
+  std::vector<double> parameters() const override;
 
   /// minimum size of vector that is accepted by constructor from vector
   static unsigned int minParameterSize() { return 3;}

--- a/Geometry/CommonTopologies/interface/CSCRadialStripTopology.h
+++ b/Geometry/CommonTopologies/interface/CSCRadialStripTopology.h
@@ -47,7 +47,7 @@ class CSCRadialStripTopology : public RadialStripTopology {
   /** 
    * Destructor
    */
-  virtual ~CSCRadialStripTopology(){}
+  ~CSCRadialStripTopology() override{}
 
   // =========================================================
   // StripTopology interface - implement pure virtual methods
@@ -57,7 +57,7 @@ class CSCRadialStripTopology : public RadialStripTopology {
    * LocalPoint on x axis for given 'strip'
    * 'strip' is a float in units of the strip (angular) width
    */
-  virtual LocalPoint localPosition(float strip) const;
+  LocalPoint localPosition(float strip) const override;
 
   /** 
    * LocalPoint for a given MeasurementPoint <BR>
@@ -72,7 +72,7 @@ class CSCRadialStripTopology : public RadialStripTopology {
    * the fractional position along the strip (range -0.5 to +0.5).<BR>
    * BEWARE! The components are not Cartesian.<BR>
    */
-  virtual LocalPoint localPosition(const MeasurementPoint&) const;
+  LocalPoint localPosition(const MeasurementPoint&) const override;
 
   /** 
    * LocalError for a pure strip measurement, where 'strip'
@@ -80,14 +80,14 @@ class CSCRadialStripTopology : public RadialStripTopology {
    * stripErr2 is the sigma-squared. Both quantities are expressed in
    * units of theAngularWidth of a strip.
    */
-  virtual LocalError localError(float strip, float stripErr2) const;
+  LocalError localError(float strip, float stripErr2) const override;
 
   /** 
    * LocalError for a given MeasurementPoint with known MeasurementError.
    * This may be used in Kalman filtering and hence must allow possible
    * correlations between the components.
    */
-  virtual LocalError localError(const MeasurementPoint&, const MeasurementError&) const;
+  LocalError localError(const MeasurementPoint&, const MeasurementError&) const override;
 
   /** 
    * Strip in which a given LocalPoint lies. This is a float which
@@ -96,14 +96,14 @@ class CSCRadialStripTopology : public RadialStripTopology {
    * detector or BELOW, and float(nstrips) if it falls at the extreme high
    * edge or ABOVE.
    */
-  virtual float strip(const LocalPoint&) const;
+  float strip(const LocalPoint&) const override;
 
 
   /** 
    * Pitch (strip width) at a given LocalPoint. <BR>
    * BEWARE: are you sure you really want to call this for a RadialStripTopology?
    */
-  virtual float localPitch(const LocalPoint&) const;
+  float localPitch(const LocalPoint&) const override;
 
   /** 
    * Angle between strip and symmetry axis (=local y axis)
@@ -116,22 +116,22 @@ class CSCRadialStripTopology : public RadialStripTopology {
    * whereas values 1, 2, ... nstrips correspond to the upper phi edges of
    * the strips.
    */
-  virtual float stripAngle(float strip) const;
+  float stripAngle(float strip) const override;
 
   /** 
    * Total number of strips 
    */
-  virtual int nstrips() const { return theNumberOfStrips; }
+  int nstrips() const override { return theNumberOfStrips; }
 
   /** 
    * Height of detector (= length of long symmetry axis of the plane of strips).
    */
-  virtual float stripLength() const { return theDetHeight; }
+  float stripLength() const override { return theDetHeight; }
 
   /** 
    * Length of a strip passing through a given LocalPpoint
    */
-  virtual float localStripLength(const LocalPoint& ) const;
+  float localStripLength(const LocalPoint& ) const override;
 
 
   // =========================================================
@@ -139,9 +139,9 @@ class CSCRadialStripTopology : public RadialStripTopology {
   // StripTopology interface)
   // =========================================================
 
-  virtual MeasurementPoint measurementPosition( const LocalPoint& ) const;
+  MeasurementPoint measurementPosition( const LocalPoint& ) const override;
 
-  virtual MeasurementError measurementError( const LocalPoint&, const LocalError& ) const;
+  MeasurementError measurementError( const LocalPoint&, const LocalError& ) const override;
 
   /** 
    * Channel number corresponding to a given LocalPoint.<BR>
@@ -150,7 +150,7 @@ class CSCRadialStripTopology : public RadialStripTopology {
    * LocalPoints outside the detector strip plane will be considered
    * as contributing to the edge channels 0 or nstrips-1.
    */
-  virtual int channel( const LocalPoint& ) const;
+  int channel( const LocalPoint& ) const override;
 
 
   // =========================================================
@@ -160,36 +160,36 @@ class CSCRadialStripTopology : public RadialStripTopology {
   /** 
    * Angular width of a each strip
    */
-  float angularWidth() const { return theAngularWidth;}
+  float angularWidth() const override { return theAngularWidth;}
 
   /** 
    * Phi pitch of each strip (= angular width!)
    */
-  virtual float phiPitch(void) const { return angularWidth(); }
+  float phiPitch(void) const override { return angularWidth(); }
 
   /** 
    * Length of long symmetry axis of plane of strips
    */
-  float detHeight() const { return theDetHeight;}
+  float detHeight() const override { return theDetHeight;}
 
   /** 
    * y extent of strip plane
    */
-  float yExtentOfStripPlane() const { return theDetHeight; } // same as detHeight()
+  float yExtentOfStripPlane() const override { return theDetHeight; } // same as detHeight()
 
   /** 
    * Distance from the intersection of the projections of
    * the extreme edges of the two extreme strips to the symmetry
    * centre of the plane of strips. 
    */
-  float centreToIntersection() const { return theCentreToIntersection; }
+  float centreToIntersection() const override { return theCentreToIntersection; }
 
   /** 
    * (y) distance from intersection of the projections of the strips
    * to the local coordinate origin. Same as centreToIntersection()
    * if symmetry centre of strip plane coincides with local origin.
    */
-  float originToIntersection() const { return (theCentreToIntersection - yCentre); }
+  float originToIntersection() const override { return (theCentreToIntersection - yCentre); }
 
   /**
    * Convenience function to access azimuthal angle of extreme edge of first strip 
@@ -203,33 +203,33 @@ class CSCRadialStripTopology : public RadialStripTopology {
    * where (full angle) = nstrips() * angularWidth(). <BR>
    *
    */
-  float phiOfOneEdge() const { return thePhiOfOneEdge; }
+  float phiOfOneEdge() const override { return thePhiOfOneEdge; }
 
   /**
    * Local x where centre of strip intersects input local y <BR>
    * 'strip' should be in range 1 to nstrips() <BR>
    */
-  float xOfStrip(int strip, float y) const;
+  float xOfStrip(int strip, float y) const override;
  
    /**
    * Nearest strip to given LocalPoint
    */
-  virtual int nearestStrip(const LocalPoint&) const;
+  int nearestStrip(const LocalPoint&) const override;
 
   /** 
    * y axis orientation, 1 means detector width increases with local y
    */
-  float yAxisOrientation() const { return theYAxisOrientation; }
+  float yAxisOrientation() const override { return theYAxisOrientation; }
 
   /**
    * Offset in local y between midpoint of detector (strip plane) extent and local origin
    */
-  float yCentreOfStripPlane() const { return yCentre; }
+  float yCentreOfStripPlane() const override { return yCentre; }
 
   /**
    * Distance in local y from a hit to the point of intersection of projected strips
    */
-  float yDistanceToIntersection( float y ) const;
+  float yDistanceToIntersection( float y ) const override;
 
   friend std::ostream & operator<<(std::ostream&, const RadialStripTopology& );
 

--- a/Geometry/CommonTopologies/interface/PixelTopology.h
+++ b/Geometry/CommonTopologies/interface/PixelTopology.h
@@ -10,7 +10,7 @@
 class PixelTopology : public Topology {
  public:  
   ////explicit PixelTopology( DetType* d) : Topology(d) {}
-  virtual ~PixelTopology() {}
+  ~PixelTopology() override {}
   
   //  The following methods are moved to the base class (Topology)
   

--- a/Geometry/CommonTopologies/interface/RadialStripTopology.h
+++ b/Geometry/CommonTopologies/interface/RadialStripTopology.h
@@ -32,7 +32,7 @@ class RadialStripTopology : public StripTopology {
   /** 
    * Destructor
    */
-  virtual ~RadialStripTopology(){}
+  ~RadialStripTopology() override{}
 
   // =========================================================
   // StripTopology interface - implement pure virtual methods
@@ -42,7 +42,7 @@ class RadialStripTopology : public StripTopology {
    * LocalPoint on x axis for given 'strip'
    * 'strip' is a float in units of the strip (angular) width
    */
-  virtual LocalPoint localPosition(float strip) const=0;
+  LocalPoint localPosition(float strip) const override =0;
 
   using StripTopology::localPosition;
   /** 
@@ -58,7 +58,7 @@ class RadialStripTopology : public StripTopology {
    * the fractional position along the strip (range -0.5 to +0.5).<BR>
    * BEWARE! The components are not Cartesian.<BR>
    */
-  virtual LocalPoint localPosition(const MeasurementPoint&) const=0;
+  LocalPoint localPosition(const MeasurementPoint&) const override =0;
 
   using StripTopology::localError;
   /** 
@@ -67,14 +67,14 @@ class RadialStripTopology : public StripTopology {
    * stripErr2 is the sigma-squared. Both quantities are expressed in
    * units of theAngularWidth of a strip.
    */
-  virtual LocalError localError(float strip, float stripErr2) const=0;
+  LocalError localError(float strip, float stripErr2) const override =0;
 
   /** 
    * LocalError for a given MeasurementPoint with known MeasurementError.
    * This may be used in Kalman filtering and hence must allow possible
    * correlations between the components.
    */
-  virtual LocalError localError(const MeasurementPoint&, const MeasurementError&) const=0;
+  LocalError localError(const MeasurementPoint&, const MeasurementError&) const override =0;
 
   /** 
    * Strip in which a given LocalPoint lies. This is a float which
@@ -83,7 +83,7 @@ class RadialStripTopology : public StripTopology {
    * detector or BELOW, and float(nstrips) if it falls at the extreme high
    * edge or ABOVE.
    */
-  virtual float strip(const LocalPoint&) const=0;
+  float strip(const LocalPoint&) const override =0;
 
 
   /** 
@@ -92,13 +92,13 @@ class RadialStripTopology : public StripTopology {
    * not sensible for a RadialStripTopology since strip widths vary with local y.
    * Use localPitch(.) instead.
    */
-  virtual float pitch() const final;
+  float pitch() const final;
 
   /** 
    * Pitch (strip width) at a given LocalPoint. <BR>
    * BEWARE: are you sure you really want to call this for a RadialStripTopology?
    */
-  virtual float localPitch(const LocalPoint&) const=0;
+  float localPitch(const LocalPoint&) const override =0;
 
   /** 
    * Angle between strip and symmetry axis (=local y axis)
@@ -111,22 +111,22 @@ class RadialStripTopology : public StripTopology {
    * whereas values 1, 2, ... nstrips correspond to the upper phi edges of
    * the strips.
    */
-  virtual float stripAngle(float strip) const=0;
+  float stripAngle(float strip) const override =0;
 
   /** 
    * Total number of strips 
    */
-  virtual int nstrips() const=0;
+  int nstrips() const override =0;
 
   /** 
    * Height of detector (= length of long symmetry axis of the plane of strips).
    */
-  virtual float stripLength() const=0;
+  float stripLength() const override =0;
 
   /** 
    * Length of a strip passing through a given LocalPpoint
    */
-  virtual float localStripLength(const LocalPoint& ) const=0;
+  float localStripLength(const LocalPoint& ) const override =0;
 
 
   // =========================================================
@@ -134,9 +134,9 @@ class RadialStripTopology : public StripTopology {
   // StripTopology interface)
   // =========================================================
 
-  virtual MeasurementPoint measurementPosition( const LocalPoint& ) const=0;
+  MeasurementPoint measurementPosition( const LocalPoint& ) const override =0;
 
-  virtual MeasurementError measurementError( const LocalPoint&, const LocalError& ) const=0;
+  MeasurementError measurementError( const LocalPoint&, const LocalError& ) const override =0;
 
   /** 
    * Channel number corresponding to a given LocalPoint.<BR>
@@ -145,7 +145,7 @@ class RadialStripTopology : public StripTopology {
    * LocalPoints outside the detector strip plane will be considered
    * as contributing to the edge channels 0 or nstrips-1.
    */
-  virtual int channel( const LocalPoint& ) const=0;
+  int channel( const LocalPoint& ) const override =0;
 
 
   // =========================================================

--- a/Geometry/CommonTopologies/interface/RectangularStripTopology.h
+++ b/Geometry/CommonTopologies/interface/RectangularStripTopology.h
@@ -14,41 +14,41 @@ public:
   RectangularStripTopology(int nstrips, float pitch, float detlength);
 
   using StripTopology::localPosition;
-  virtual LocalPoint localPosition(float strip) const;
+  LocalPoint localPosition(float strip) const override;
 
-  virtual LocalPoint localPosition(const MeasurementPoint&) const;
+  LocalPoint localPosition(const MeasurementPoint&) const override;
 
   using StripTopology::localError; 
-  virtual LocalError 
-  localError(float strip, float stripErr2) const;
+  LocalError 
+  localError(float strip, float stripErr2) const override;
   
-  virtual LocalError 
-  localError(const MeasurementPoint&, const MeasurementError&) const;
+  LocalError 
+  localError(const MeasurementPoint&, const MeasurementError&) const override;
   
-  virtual float strip(const LocalPoint&) const;
+  float strip(const LocalPoint&) const override;
 
   // the number of strip span by the segment between the two points..
-  virtual float coveredStrips(const LocalPoint& lp1, const LocalPoint& lp2)  const ; 
+  float coveredStrips(const LocalPoint& lp1, const LocalPoint& lp2)  const override ; 
 
 
-  virtual MeasurementPoint measurementPosition(const LocalPoint&) const;
+  MeasurementPoint measurementPosition(const LocalPoint&) const override;
     
-  virtual MeasurementError 
-  measurementError(const LocalPoint&, const LocalError&) const;
+  MeasurementError 
+  measurementError(const LocalPoint&, const LocalError&) const override;
 
-  virtual int channel(const LocalPoint& lp) const {  return std::min(int(strip(lp)),theNumberOfStrips-1); }
+  int channel(const LocalPoint& lp) const override {  return std::min(int(strip(lp)),theNumberOfStrips-1); }
 
-  virtual float pitch() const { return thePitch; }
+  float pitch() const override { return thePitch; }
 
-  virtual float localPitch(const LocalPoint&) const { return thePitch;}
+  float localPitch(const LocalPoint&) const override { return thePitch;}
   
-  virtual float stripAngle(float strip) const {  return 0;}
+  float stripAngle(float strip) const override {  return 0;}
 
-  virtual int nstrips() const { return theNumberOfStrips;}
+  int nstrips() const override { return theNumberOfStrips;}
 
-  virtual float stripLength() const {return theStripLength;}
+  float stripLength() const override {return theStripLength;}
 
-  virtual float localStripLength(const LocalPoint& /*aLP*/) const {
+  float localStripLength(const LocalPoint& /*aLP*/) const override {
     return stripLength();
   }
 

--- a/Geometry/CommonTopologies/interface/StripTopology.h
+++ b/Geometry/CommonTopologies/interface/StripTopology.h
@@ -11,7 +11,7 @@
 class StripTopology : public Topology {
 public:
 
-  virtual ~StripTopology() {}
+  ~StripTopology() override {}
 
   // GF: I hate the stupid hiding feature of C++, see
   // http://www.parashift.com/c%2B%2B-faq-lite/strange-inheritance.html#faq-23.9

--- a/Geometry/CommonTopologies/interface/TkRadialStripTopology.h
+++ b/Geometry/CommonTopologies/interface/TkRadialStripTopology.h
@@ -47,7 +47,7 @@ class TkRadialStripTopology final : public RadialStripTopology {
   /** 
    * Destructor
    */
-  ~TkRadialStripTopology(){}
+  ~TkRadialStripTopology() override{}
 
   // =========================================================
   // StripTopology interface - implement pure methods
@@ -57,7 +57,7 @@ class TkRadialStripTopology final : public RadialStripTopology {
    * LocalPoint on x axis for given 'strip'
    * 'strip' is a float in units of the strip (angular) width
    */
-  LocalPoint localPosition(float strip) const;
+  LocalPoint localPosition(float strip) const override;
 
   /** 
    * LocalPoint for a given MeasurementPoint <BR>
@@ -72,7 +72,7 @@ class TkRadialStripTopology final : public RadialStripTopology {
    * the fractional position along the strip (range -0.5 to +0.5).<BR>
    * BEWARE! The components are not Cartesian.<BR>
    */
-  LocalPoint localPosition(const MeasurementPoint&) const;
+  LocalPoint localPosition(const MeasurementPoint&) const override;
 
   /** 
    * LocalError for a pure strip measurement, where 'strip'
@@ -80,14 +80,14 @@ class TkRadialStripTopology final : public RadialStripTopology {
    * stripErr2 is the sigma-squared. Both quantities are expressed in
    * units of theAngularWidth of a strip.
    */
-  LocalError localError(float strip, float stripErr2) const;
+  LocalError localError(float strip, float stripErr2) const override;
 
   /** 
    * LocalError for a given MeasurementPoint with known MeasurementError.
    * This may be used in Kalman filtering and hence must allow possible
    * correlations between the components.
    */
-  LocalError localError(const MeasurementPoint&, const MeasurementError&) const;
+  LocalError localError(const MeasurementPoint&, const MeasurementError&) const override;
 
   /** 
    * Strip in which a given LocalPoint lies. This is a float which
@@ -96,17 +96,17 @@ class TkRadialStripTopology final : public RadialStripTopology {
    * detector or BELOW, and float(nstrips) if it falls at the extreme high
    * edge or ABOVE.
    */
-  float strip(const LocalPoint&) const;
+  float strip(const LocalPoint&) const override;
 
   // the number of strip span by the segment between the two points..
-  float coveredStrips(const LocalPoint& lp1, const LocalPoint& lp2)  const ; 
+  float coveredStrips(const LocalPoint& lp1, const LocalPoint& lp2)  const override ; 
 
 
   /** 
    * Pitch (strip width) at a given LocalPoint. <BR>
    * BEWARE: are you sure you really want to call this for a RadialStripTopology?
    */
-  float localPitch(const LocalPoint&) const;
+  float localPitch(const LocalPoint&) const override;
 
   /** 
    * Angle between strip and symmetry axis (=local y axis)
@@ -119,23 +119,23 @@ class TkRadialStripTopology final : public RadialStripTopology {
    * whereas values 1, 2, ... nstrips correspond to the upper phi edges of
    * the strips.
    */
-  float stripAngle(float strip) const { return   yAxisOrientation() * (phiOfOneEdge() +  strip * angularWidth()) ;}
+  float stripAngle(float strip) const override { return   yAxisOrientation() * (phiOfOneEdge() +  strip * angularWidth()) ;}
 
 
   /** 
    * Total number of strips 
    */
-  int nstrips() const { return theNumberOfStrips; }
+  int nstrips() const override { return theNumberOfStrips; }
 
   /** 
    * Height of detector (= length of long symmetry axis of the plane of strips).
    */
-  float stripLength() const { return theDetHeight; }
+  float stripLength() const override { return theDetHeight; }
 
   /** 
    * Length of a strip passing through a given LocalPpoint
    */
-  float localStripLength(const LocalPoint& ) const;
+  float localStripLength(const LocalPoint& ) const override;
 
 
   // =========================================================
@@ -143,9 +143,9 @@ class TkRadialStripTopology final : public RadialStripTopology {
   // StripTopology interface)
   // =========================================================
 
-  MeasurementPoint measurementPosition( const LocalPoint& ) const;
+  MeasurementPoint measurementPosition( const LocalPoint& ) const override;
 
-  MeasurementError measurementError( const LocalPoint&, const LocalError& ) const;
+  MeasurementError measurementError( const LocalPoint&, const LocalError& ) const override;
 
   /** 
    * Channel number corresponding to a given LocalPoint.<BR>
@@ -154,7 +154,7 @@ class TkRadialStripTopology final : public RadialStripTopology {
    * LocalPoints outside the detector strip plane will be considered
    * as contributing to the edge channels 0 or nstrips-1.
    */
-  int channel( const LocalPoint& ) const;
+  int channel( const LocalPoint& ) const override;
 
 
   // =========================================================
@@ -164,36 +164,36 @@ class TkRadialStripTopology final : public RadialStripTopology {
   /** 
    * Angular width of a each strip
    */
-  float angularWidth() const { return theAngularWidth;}
+  float angularWidth() const override { return theAngularWidth;}
 
   /** 
    * Phi pitch of each strip (= angular width!)
    */
-  float phiPitch(void) const { return angularWidth(); }
+  float phiPitch(void) const override { return angularWidth(); }
 
   /** 
    * Length of long symmetry axis of plane of strips
    */
-  float detHeight() const { return theDetHeight;}
+  float detHeight() const override { return theDetHeight;}
 
   /** 
    * y extent of strip plane
    */
-  float yExtentOfStripPlane() const { return theDetHeight; } // same as detHeight()
+  float yExtentOfStripPlane() const override { return theDetHeight; } // same as detHeight()
 
   /** 
    * Distance from the intersection of the projections of
    * the extreme edges of the two extreme strips to the symmetry
    * centre of the plane of strips. 
    */
-  float centreToIntersection() const { return theCentreToIntersection; }
+  float centreToIntersection() const override { return theCentreToIntersection; }
 
   /** 
    * (y) distance from intersection of the projections of the strips
    * to the local coordinate origin. Same as centreToIntersection()
    * if symmetry centre of strip plane coincides with local origin.
    */
-  float originToIntersection() const { return (theCentreToIntersection - yCentre); }
+  float originToIntersection() const override { return (theCentreToIntersection - yCentre); }
 
   /**
    * Convenience function to access azimuthal angle of extreme edge of first strip 
@@ -207,33 +207,33 @@ class TkRadialStripTopology final : public RadialStripTopology {
    * where (full angle) = nstrips() * angularWidth(). <BR>
    *
    */
-  float phiOfOneEdge() const { return thePhiOfOneEdge; }
+  float phiOfOneEdge() const override { return thePhiOfOneEdge; }
 
   /**
    * Local x where centre of strip intersects input local y <BR>
    * 'strip' should be in range 1 to nstrips() <BR>
    */
-  float xOfStrip(int strip, float y) const;
+  float xOfStrip(int strip, float y) const override;
  
    /**
    * Nearest strip to given LocalPoint
    */
-  int nearestStrip(const LocalPoint&) const;
+  int nearestStrip(const LocalPoint&) const override;
 
   /** 
    * y axis orientation, 1 means detector width increases with local y
    */
-  float yAxisOrientation() const { return theYAxisOrientation; }
+  float yAxisOrientation() const override { return theYAxisOrientation; }
 
   /**
    * Offset in local y between midpoint of detector (strip plane) extent and local origin
    */
-  float yCentreOfStripPlane() const { return yCentre; }
+  float yCentreOfStripPlane() const override { return yCentre; }
 
   /**
    * Distance in local y from a hit to the point of intersection of projected strips
    */
-  float yDistanceToIntersection( float y ) const;
+  float yDistanceToIntersection( float y ) const override;
 
  private:
 

--- a/Geometry/CommonTopologies/interface/TrapezoidalStripTopology.h
+++ b/Geometry/CommonTopologies/interface/TrapezoidalStripTopology.h
@@ -34,39 +34,39 @@ public:
   TrapezoidalStripTopology(int nstrip, float pitch, float detheight,float r0, int yAx);
 
   using StripTopology::localPosition;
-  virtual LocalPoint localPosition(float strip) const;
+  LocalPoint localPosition(float strip) const override;
 
-  virtual LocalPoint localPosition(const MeasurementPoint&) const;
+  LocalPoint localPosition(const MeasurementPoint&) const override;
   
   using StripTopology::localError;
-  virtual LocalError 
-  localError(float strip, float stripErr2) const;
+  LocalError 
+  localError(float strip, float stripErr2) const override;
   
-  virtual LocalError 
-  localError(const MeasurementPoint&, const MeasurementError&) const;
+  LocalError 
+  localError(const MeasurementPoint&, const MeasurementError&) const override;
   
-  virtual float strip(const LocalPoint&) const;
+  float strip(const LocalPoint&) const override;
 
-  virtual MeasurementPoint measurementPosition(const LocalPoint&) const;
+  MeasurementPoint measurementPosition(const LocalPoint&) const override;
     
-  virtual MeasurementError 
-  measurementError(const LocalPoint&, const LocalError&) const;
+  MeasurementError 
+  measurementError(const LocalPoint&, const LocalError&) const override;
 
-  virtual int channel(const LocalPoint&) const;
+  int channel(const LocalPoint&) const override;
 
   /** Pitch in the middle of the DetUnit */
-  virtual float pitch() const; 
+  float pitch() const override; 
 
-  virtual float localPitch(const LocalPoint&) const;
+  float localPitch(const LocalPoint&) const override;
   
   /** angle between strip and symmetry axis */
-  virtual float stripAngle(float strip) const;
+  float stripAngle(float strip) const override;
 
-  virtual int nstrips() const; 
+  int nstrips() const override; 
 
   /// det heigth (strip length in the middle)
-  virtual float stripLength() const {return theDetHeight;}
-  virtual float localStripLength(const LocalPoint& aLP) const;
+  float stripLength() const override {return theDetHeight;}
+  float localStripLength(const LocalPoint& aLP) const override;
   
   /** radius of circle passing through the middle of the det
    *    with center at the crossing of the two sides.

--- a/Geometry/CommonTopologies/interface/TwoBowedSurfacesDeformation.h
+++ b/Geometry/CommonTopologies/interface/TwoBowedSurfacesDeformation.h
@@ -37,10 +37,10 @@ class TwoBowedSurfacesDeformation : public SurfaceDeformation
   /// - ySplit: y-value where surfaces are split
   TwoBowedSurfacesDeformation(const std::vector<double> &parameters);
 
-  virtual TwoBowedSurfacesDeformation* clone() const;
+  TwoBowedSurfacesDeformation* clone() const override;
 
   /// specific type, i.e. SurfaceDeformationFactory::kTwoBowedSurfaces
-  virtual int type() const;
+  int type() const override;
 
   /// correction to add to local position depending on 
   /// - track parameters in local frame (from LocalTrajectoryParameters):
@@ -48,18 +48,18 @@ class TwoBowedSurfacesDeformation : public SurfaceDeformation
   ///   * track angles   as LocalTrackAngles(dxdz, dydz)
   /// - length of surface (local y-coordinate)
   /// - width of surface (local x-coordinate)
-  virtual Local2DVector positionCorrection(const Local2DPoint &localPos,
+  Local2DVector positionCorrection(const Local2DPoint &localPos,
                                            const LocalTrackAngles &localAngles,
-                                           double length, double width) const;
+                                           double length, double width) const override;
 
   /// update information with parameters of 'other',
   /// false in case the type or some parameters do not match and thus
   /// the information cannot be used (then no changes are done),
   /// true if merge was successful
-  virtual bool add(const SurfaceDeformation &other);
+  bool add(const SurfaceDeformation &other) override;
   
   /// parameters - see constructor for meaning
-  virtual std::vector<double> parameters() const;
+  std::vector<double> parameters() const override;
 
   // the size
   static constexpr unsigned int parSize = 13; 

--- a/Geometry/CommonTopologies/test/ValidateRadial.cc
+++ b/Geometry/CommonTopologies/test/ValidateRadial.cc
@@ -15,7 +15,7 @@ class ValidateRadial : public edm::one::EDAnalyzer<>
 {
 public:
   ValidateRadial(const edm::ParameterSet&);
-  ~ValidateRadial();
+  ~ValidateRadial() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/DTGeometry/interface/DTChamber.h
+++ b/Geometry/DTGeometry/interface/DTChamber.h
@@ -28,13 +28,13 @@ class DTChamber : public GeomDet {
     DTChamber(DTChamberId id, const ReferenceCountingPointer<BoundPlane>& plane);
 
     /// Destructor
-    virtual ~DTChamber();
+    ~DTChamber() override;
 
     /// Return the DTChamberId of this chamber
     DTChamberId id() const;
 
     // Which subdetector
-    virtual SubDetector subDetector() const {return GeomDetEnumerators::DT;}
+    SubDetector subDetector() const override {return GeomDetEnumerators::DT;}
 
     /// equal if the id is the same
     bool operator==(const DTChamber& ch) const;
@@ -43,10 +43,10 @@ class DTChamber : public GeomDet {
     void add(DTSuperLayer* sl);
 
     /// Return the superlayers in the chamber
-    virtual std::vector< const GeomDet*> components() const;
+    std::vector< const GeomDet*> components() const override;
 
     /// Return the sub-component (SL or layer) with a given id in this chamber
-    virtual const GeomDet* component(DetId id) const;
+    const GeomDet* component(DetId id) const override;
 
     /// Return the superlayers in the chamber
     const std::vector< const DTSuperLayer*>& superLayers() const;

--- a/Geometry/DTGeometry/interface/DTGeometry.h
+++ b/Geometry/DTGeometry/interface/DTGeometry.h
@@ -31,30 +31,30 @@ class DTGeometry : public TrackingGeometry {
     DTGeometry();
 
     /// Destructor
-    virtual ~DTGeometry();
+    ~DTGeometry() override;
 
     //---- Base class' interface 
 
     // Return a vector of all det types
-    virtual const DetTypeContainer&  detTypes() const override;
+    const DetTypeContainer&  detTypes() const override;
 
     // Returm a vector of all GeomDetUnit
-    virtual const DetUnitContainer&  detUnits() const override;
+    const DetUnitContainer&  detUnits() const override;
 
     // Returm a vector of all GeomDet (including all GeomDetUnits)
-    virtual const DetContainer& dets() const override;
+    const DetContainer& dets() const override;
 
     // Returm a vector of all GeomDetUnit DetIds
-    virtual const DetIdContainer&    detUnitIds() const override;
+    const DetIdContainer&    detUnitIds() const override;
 
     // Returm a vector of all GeomDet DetIds (including those of GeomDetUnits)
-    virtual const DetIdContainer& detIds() const override;
+    const DetIdContainer& detIds() const override;
 
     // Return the pointer to the GeomDetUnit corresponding to a given DetId
-    virtual const GeomDetUnit* idToDetUnit(DetId) const override;
+    const GeomDetUnit* idToDetUnit(DetId) const override;
 
     // Return the pointer to the GeomDet corresponding to a given DetId
-    virtual const GeomDet* idToDet(DetId) const override;
+    const GeomDet* idToDet(DetId) const override;
 
 
     //---- Extension of the interface

--- a/Geometry/DTGeometry/interface/DTLayer.h
+++ b/Geometry/DTGeometry/interface/DTLayer.h
@@ -35,12 +35,12 @@ class DTLayer : public GeomDetUnit {
             const DTSuperLayer* sl=0) ;
 
 /* Destructor */ 
-    virtual ~DTLayer() ;
+    ~DTLayer() override ;
 
 /* Operations */ 
-    const Topology& topology() const;
+    const Topology& topology() const override;
 
-    const GeomDetType& type() const;
+    const GeomDetType& type() const override;
 
     const DTTopology& specificTopology() const;
 
@@ -59,7 +59,7 @@ class DTLayer : public GeomDetUnit {
     bool operator==(const DTLayer& l) const;
 
     /// A Layer has no components
-    virtual std::vector< const GeomDet*> components() const;
+    std::vector< const GeomDet*> components() const override;
 
   private:
     DTLayerId   theId;

--- a/Geometry/DTGeometry/interface/DTLayerType.h
+++ b/Geometry/DTGeometry/interface/DTLayerType.h
@@ -20,7 +20,7 @@ class DTLayerType : public GeomDetType {
     DTLayerType() ;
 
 /* Operations */ 
-    virtual const Topology& topology() const;
+    const Topology& topology() const override;
 };
 #endif // DTLAYERTYPE_H
 

--- a/Geometry/DTGeometry/interface/DTSuperLayer.h
+++ b/Geometry/DTGeometry/interface/DTSuperLayer.h
@@ -32,23 +32,23 @@ class DTSuperLayer : public GeomDet {
                  const DTChamber* ch=0);
 
 /* Destructor */ 
-    virtual ~DTSuperLayer() ;
+    ~DTSuperLayer() override ;
 
 /* Operations */ 
     /// Return the DetId of this SL
     DTSuperLayerId id() const;
 
     // Which subdetector
-    virtual SubDetector subDetector() const {return GeomDetEnumerators::DT;}
+    SubDetector subDetector() const override {return GeomDetEnumerators::DT;}
 
     /// True if id are the same
     bool operator==(const DTSuperLayer& sl) const ;
 
     /// Return the layers in the SL
-    virtual std::vector< const GeomDet*> components() const;
+    std::vector< const GeomDet*> components() const override;
 
     /// Return the layer with a given id in this SL
-    virtual const GeomDet* component(DetId id) const;
+    const GeomDet* component(DetId id) const override;
 
     /// Return the layers in the SL
     const std::vector< const DTLayer*>& layers() const;

--- a/Geometry/DTGeometry/interface/DTTopology.h
+++ b/Geometry/DTGeometry/interface/DTTopology.h
@@ -31,32 +31,32 @@ class DTTopology: public Topology {
   /// Constructor: number of first wire, total # of wires in the layer and their lenght
   DTTopology(int firstWire, int nChannels, float semilenght); 
 
-  virtual ~DTTopology() {}
+  ~DTTopology() override {}
   
   /// Conversion between measurement coordinates
   /// and local cartesian coordinates.
-  LocalPoint localPosition( const MeasurementPoint& ) const;
+  LocalPoint localPosition( const MeasurementPoint& ) const override;
 
   /// Conversion between measurement coordinates
   /// and local cartesian coordinates.
-  LocalError localError( const MeasurementPoint&, const MeasurementError& ) const;
+  LocalError localError( const MeasurementPoint&, const MeasurementError& ) const override;
 
   /// Conversion to the measurement frame.
   /// (Caveat: when converting the position of a rechit, there is no
   /// guarantee that the converted value can be interpreted as the cell
   /// where the hit belongs, see note on neighbouring cells in the class
   /// header.
-  MeasurementPoint measurementPosition( const LocalPoint&) const;
+  MeasurementPoint measurementPosition( const LocalPoint&) const override;
 
   /// Conversion to the measurement frame.
-  MeasurementError measurementError( const LocalPoint&, const LocalError& ) const;
+  MeasurementError measurementError( const LocalPoint&, const LocalError& ) const override;
 
   /// Return the wire number, starting from a LocalPoint.
   /// This method is deprecated: when converting the position of a rechit,
   /// there is no guarantee that the converted value can be
   /// interpreted as the cell where the hit belongs, see note on
   /// neighbouring cells in the class header.
-  int channel( const LocalPoint& p) const;
+  int channel( const LocalPoint& p) const override;
 
   /// Returns the x position in the layer of a given wire number.
   float wirePosition(int wireNumber) const;

--- a/Geometry/DTGeometry/test/DTGeometryAnalyzer.cc
+++ b/Geometry/DTGeometry/test/DTGeometryAnalyzer.cc
@@ -27,7 +27,7 @@ class DTGeometryAnalyzer : public edm::one::EDAnalyzer<>
 {
 public: 
   DTGeometryAnalyzer( const edm::ParameterSet& pset);
-  ~DTGeometryAnalyzer();
+  ~DTGeometryAnalyzer() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/DTGeometryBuilder/plugins/DTGeometryESModule.h
+++ b/Geometry/DTGeometryBuilder/plugins/DTGeometryESModule.h
@@ -23,7 +23,7 @@ public:
   DTGeometryESModule(const edm::ParameterSet & p);
 
   /// Destructor
-  virtual ~DTGeometryESModule();
+  ~DTGeometryESModule() override;
 
   /// Produce DTGeometry.
   std::shared_ptr<DTGeometry> produce(const MuonGeometryRecord& record);

--- a/Geometry/EcalAlgo/interface/EcalBarrelGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalBarrelGeometry.h
@@ -47,12 +47,12 @@ class EcalBarrelGeometry final : public CaloSubdetectorGeometry
 
       static std::string dbString() { return "PEcalBarrelRcd" ; }
 
-      virtual unsigned int numberOfShapes() const { return k_NumberOfShapes ; }
-      virtual unsigned int numberOfParametersPerShape() const { return k_NumberOfParametersPerShape ; }
+      unsigned int numberOfShapes() const override { return k_NumberOfShapes ; }
+      unsigned int numberOfParametersPerShape() const override { return k_NumberOfParametersPerShape ; }
 
       EcalBarrelGeometry() ;
   
-      virtual ~EcalBarrelGeometry();
+      ~EcalBarrelGeometry() override;
 
       int getNumXtalsPhiDirection()           const { return _nnxtalPhi ; }
 
@@ -73,10 +73,10 @@ class EcalBarrelGeometry final : public CaloSubdetectorGeometry
       const OrderedListOfEEDetId* getClosestEndcapCells( EBDetId id ) const ;
 
       // Get closest cell, etc...
-      virtual DetId getClosestCell( const GlobalPoint& r ) const ;
+      DetId getClosestCell( const GlobalPoint& r ) const override ;
 
-      virtual CaloSubdetectorGeometry::DetIdSet getCells( const GlobalPoint& r,
-							  double             dR ) const ;
+      CaloSubdetectorGeometry::DetIdSet getCells( const GlobalPoint& r,
+							  double             dR ) const override ;
 
       CCGFloat avgRadiusXYFrontFaceCenter() const ;
 
@@ -97,14 +97,14 @@ class EcalBarrelGeometry final : public CaloSubdetectorGeometry
 				unsigned int    i   ,
 				Pt3D&           ref   ) ;
 
-      virtual void newCell( const GlobalPoint& f1 ,
+      void newCell( const GlobalPoint& f1 ,
 			    const GlobalPoint& f2 ,
 			    const GlobalPoint& f3 ,
 			    const CCGFloat*    parm ,
-			    const DetId&       detId ) ;
+			    const DetId&       detId ) override ;
    protected:
 
-      virtual const CaloCellGeometry* cellGeomPtr( uint32_t index ) const ;
+      const CaloCellGeometry* cellGeomPtr( uint32_t index ) const override ;
 
    private:
 

--- a/Geometry/EcalAlgo/interface/EcalEndcapGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalEndcapGeometry.h
@@ -49,12 +49,12 @@ class EcalEndcapGeometry final: public CaloSubdetectorGeometry
 
       static std::string dbString() { return "PEcalEndcapRcd" ; }
 
-      virtual unsigned int numberOfShapes() const { return k_NumberOfShapes ; }
-      virtual unsigned int numberOfParametersPerShape() const { return k_NumberOfParametersPerShape ; }
+      unsigned int numberOfShapes() const override { return k_NumberOfShapes ; }
+      unsigned int numberOfParametersPerShape() const override { return k_NumberOfParametersPerShape ; }
 
       EcalEndcapGeometry() ;
   
-      virtual ~EcalEndcapGeometry();
+      ~EcalEndcapGeometry() override;
 
       int getNumberOfModules()          const { return _nnmods ; }
 
@@ -66,12 +66,12 @@ class EcalEndcapGeometry final: public CaloSubdetectorGeometry
 
       const OrderedListOfEBDetId* getClosestBarrelCells( EEDetId id ) const ;
       // Get closest cell, etc...
-      virtual DetId getClosestCell( const GlobalPoint& r ) const ;
+      DetId getClosestCell( const GlobalPoint& r ) const override ;
 
-      virtual CaloSubdetectorGeometry::DetIdSet getCells( const GlobalPoint& r,
-							  double             dR ) const ;
+      CaloSubdetectorGeometry::DetIdSet getCells( const GlobalPoint& r,
+							  double             dR ) const override ;
 
-      virtual void initializeParms() ;
+      void initializeParms() override ;
 
       CCGFloat avgAbsZFrontFaceCenter() const ; // average over both endcaps. Positive!
 
@@ -92,15 +92,15 @@ class EcalEndcapGeometry final: public CaloSubdetectorGeometry
 				unsigned int    i   ,
 				Pt3D&           ref   ) ;
 
-      virtual void newCell( const GlobalPoint& f1 ,
+      void newCell( const GlobalPoint& f1 ,
 			    const GlobalPoint& f2 ,
 			    const GlobalPoint& f3 ,
 			    const CCGFloat*    parm ,
-			    const DetId&       detId   ) ;
+			    const DetId&       detId   ) override ;
 
    protected:
 
-      virtual const CaloCellGeometry* cellGeomPtr( uint32_t index ) const ;
+      const CaloCellGeometry* cellGeomPtr( uint32_t index ) const override ;
 
    private:
 

--- a/Geometry/EcalAlgo/interface/EcalPreshowerGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalPreshowerGeometry.h
@@ -40,13 +40,13 @@ class EcalPreshowerGeometry final : public CaloSubdetectorGeometry
 
       static std::string dbString() { return "PEcalPreshowerRcd" ; }
 
-      virtual unsigned int numberOfShapes() const override { return k_NumberOfShapes ; }
-      virtual unsigned int numberOfParametersPerShape() const override { return k_NumberOfParametersPerShape ; }
+      unsigned int numberOfShapes() const override { return k_NumberOfShapes ; }
+      unsigned int numberOfParametersPerShape() const override { return k_NumberOfParametersPerShape ; }
 
       EcalPreshowerGeometry() ;
   
       /// The EcalPreshowerGeometry will delete all its cell geometries at destruction time
-      virtual ~EcalPreshowerGeometry();
+      ~EcalPreshowerGeometry() override;
 
       void setzPlanes( CCGFloat z1minus, 
 		       CCGFloat z2minus,
@@ -54,7 +54,7 @@ class EcalPreshowerGeometry final : public CaloSubdetectorGeometry
 		       CCGFloat z2plus ) ;
 
       // Get closest cell
-      virtual DetId getClosestCell( const GlobalPoint& r ) const override;
+      DetId getClosestCell( const GlobalPoint& r ) const override;
 
 
       // Get closest cell in arbitrary plane (1 or 2)
@@ -62,8 +62,8 @@ class EcalPreshowerGeometry final : public CaloSubdetectorGeometry
 					   int                plane   ) const ;
 
 
-      virtual void initializeParms() override;
-      virtual unsigned int numberOfTransformParms() const override { return 3 ; }
+      void initializeParms() override;
+      unsigned int numberOfTransformParms() const override { return 3 ; }
 
       static std::string hitString() { return "EcalHitsES" ; }
 
@@ -82,7 +82,7 @@ class EcalPreshowerGeometry final : public CaloSubdetectorGeometry
 				unsigned int    i   ,
 				Pt3D&           ref   ) ;
 
-      virtual void newCell( const GlobalPoint& f1 ,
+      void newCell( const GlobalPoint& f1 ,
 			    const GlobalPoint& f2 ,
 			    const GlobalPoint& f3 ,
 			    const CCGFloat*    parm ,

--- a/Geometry/EcalCommonData/interface/DDEcalAPDAlgo.h
+++ b/Geometry/EcalCommonData/interface/DDEcalAPDAlgo.h
@@ -17,14 +17,14 @@ public:
 
   //Constructor and Destructor
   DDEcalAPDAlgo();
-  virtual ~DDEcalAPDAlgo();
+  ~DDEcalAPDAlgo() override;
 
   void initialize(const DDNumericArguments      & nArgs,
 		  const DDVectorArguments       & vArgs,
 		  const DDMapArguments          & mArgs,
 		  const DDStringArguments       & sArgs,
-		  const DDStringVectorArguments & vsArgs);
-  void execute(DDCompactView& cpv);
+		  const DDStringVectorArguments & vsArgs) override;
+  void execute(DDCompactView& cpv) override;
 
 protected:
 

--- a/Geometry/EcalCommonData/interface/DDEcalBarrelAlgo.h
+++ b/Geometry/EcalCommonData/interface/DDEcalBarrelAlgo.h
@@ -31,14 +31,14 @@ class DDEcalBarrelAlgo : public DDAlgorithm {
 
       //Constructor and Destructor
       DDEcalBarrelAlgo();
-      virtual ~DDEcalBarrelAlgo();
+      ~DDEcalBarrelAlgo() override;
 
       void initialize(const DDNumericArguments      & nArgs,
 		      const DDVectorArguments       & vArgs,
 		      const DDMapArguments          & mArgs,
 		      const DDStringArguments       & sArgs,
-		      const DDStringVectorArguments & vsArgs);
-      void execute(DDCompactView& cpv);
+		      const DDStringVectorArguments & vsArgs) override;
+      void execute(DDCompactView& cpv) override;
 
       DDMaterial ddmat(  const std::string& s ) const ;
       DDName     ddname( const std::string& s ) const ;

--- a/Geometry/EcalCommonData/interface/DDEcalBarrelNewAlgo.h
+++ b/Geometry/EcalCommonData/interface/DDEcalBarrelNewAlgo.h
@@ -31,14 +31,14 @@ class DDEcalBarrelNewAlgo : public DDAlgorithm {
 
       //Constructor and Destructor
       DDEcalBarrelNewAlgo();
-      virtual ~DDEcalBarrelNewAlgo();
+      ~DDEcalBarrelNewAlgo() override;
 
       void initialize(const DDNumericArguments      & nArgs,
 		      const DDVectorArguments       & vArgs,
 		      const DDMapArguments          & mArgs,
 		      const DDStringArguments       & sArgs,
-		      const DDStringVectorArguments & vsArgs);
-      void execute(DDCompactView& cpv);
+		      const DDStringVectorArguments & vsArgs) override;
+      void execute(DDCompactView& cpv) override;
 
       DDMaterial ddmat(  const std::string& s ) const ;
       DDName     ddname( const std::string& s ) const ;

--- a/Geometry/EcalCommonData/interface/DDEcalEndcapAlgo.h
+++ b/Geometry/EcalCommonData/interface/DDEcalEndcapAlgo.h
@@ -32,14 +32,14 @@ class DDEcalEndcapAlgo : public DDAlgorithm {
 
       //Constructor and Destructor
       DDEcalEndcapAlgo();
-      virtual ~DDEcalEndcapAlgo();
+      ~DDEcalEndcapAlgo() override;
 
       void initialize(const DDNumericArguments      & nArgs,
 		      const DDVectorArguments       & vArgs,
 		      const DDMapArguments          & mArgs,
 		      const DDStringArguments       & sArgs,
-		      const DDStringVectorArguments & vsArgs);
-      void execute(DDCompactView& cpv);
+		      const DDStringVectorArguments & vsArgs) override;
+      void execute(DDCompactView& cpv) override;
 
       //  New methods for SC geometry
       void EEPositionCRs( const DDName&        pName,

--- a/Geometry/EcalCommonData/interface/DDEcalPreshowerAlgo.h
+++ b/Geometry/EcalCommonData/interface/DDEcalPreshowerAlgo.h
@@ -21,8 +21,8 @@ public:
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
-  void execute(DDCompactView& pos);
+		  const DDStringVectorArguments & vsArgs) override;
+  void execute(DDCompactView& pos) override;
 
 private:
 

--- a/Geometry/EcalCommonData/interface/ESTBNumberingScheme.h
+++ b/Geometry/EcalCommonData/interface/ESTBNumberingScheme.h
@@ -8,8 +8,8 @@ class ESTBNumberingScheme : public EcalNumberingScheme {
 public:
 
   ESTBNumberingScheme();
-  ~ESTBNumberingScheme();
-  virtual uint32_t getUnitID(const EcalBaseNumber& baseNumber) const ;
+  ~ESTBNumberingScheme() override;
+  uint32_t getUnitID(const EcalBaseNumber& baseNumber) const override ;
 
 private:
 

--- a/Geometry/EcalCommonData/interface/EcalBarrelNumberingScheme.h
+++ b/Geometry/EcalCommonData/interface/EcalBarrelNumberingScheme.h
@@ -10,8 +10,8 @@
 class EcalBarrelNumberingScheme : public EcalNumberingScheme {
  public:
   EcalBarrelNumberingScheme();
-  ~EcalBarrelNumberingScheme();
-  virtual uint32_t getUnitID(const EcalBaseNumber& baseNumber) const ;
+  ~EcalBarrelNumberingScheme() override;
+  uint32_t getUnitID(const EcalBaseNumber& baseNumber) const override ;
 };
 
 #endif

--- a/Geometry/EcalCommonData/interface/EcalEndcapNumberingScheme.h
+++ b/Geometry/EcalCommonData/interface/EcalEndcapNumberingScheme.h
@@ -11,8 +11,8 @@ class EcalEndcapNumberingScheme : public EcalNumberingScheme {
 
 public:
   EcalEndcapNumberingScheme();
-  ~EcalEndcapNumberingScheme();
-  virtual uint32_t getUnitID(const EcalBaseNumber& baseNumber) const ;
+  ~EcalEndcapNumberingScheme() override;
+  uint32_t getUnitID(const EcalBaseNumber& baseNumber) const override ;
 
 };
 

--- a/Geometry/EcalCommonData/interface/EcalNumberingScheme.h
+++ b/Geometry/EcalCommonData/interface/EcalNumberingScheme.h
@@ -15,7 +15,7 @@ class EcalNumberingScheme : public CaloNumberingScheme {
 
 public:
   EcalNumberingScheme();
-  virtual ~EcalNumberingScheme();
+  ~EcalNumberingScheme() override;
   virtual uint32_t getUnitID(const EcalBaseNumber& baseNumber) const = 0;
 
 };

--- a/Geometry/EcalCommonData/interface/EcalPreshowerNumberingScheme.h
+++ b/Geometry/EcalCommonData/interface/EcalPreshowerNumberingScheme.h
@@ -12,8 +12,8 @@ class EcalPreshowerNumberingScheme : public EcalNumberingScheme {
  public:
 
   EcalPreshowerNumberingScheme();
-  ~EcalPreshowerNumberingScheme();
-  virtual uint32_t getUnitID(const EcalBaseNumber& baseNumber) const ;
+  ~EcalPreshowerNumberingScheme() override;
+  uint32_t getUnitID(const EcalBaseNumber& baseNumber) const override ;
 
  private:
 

--- a/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.h
+++ b/Geometry/EcalMapping/plugins/EcalElectronicsMappingBuilder.h
@@ -34,7 +34,7 @@ class EcalElectronicsMappingBuilder : public edm::ESProducer
 {
  public:
   EcalElectronicsMappingBuilder(const edm::ParameterSet&);
-  ~EcalElectronicsMappingBuilder();
+  ~EcalElectronicsMappingBuilder() override;
   
   typedef std::unique_ptr<EcalElectronicsMapping> ReturnType;
   

--- a/Geometry/EcalTestBeam/interface/EcalHodoscopeNumberingScheme.h
+++ b/Geometry/EcalTestBeam/interface/EcalHodoscopeNumberingScheme.h
@@ -12,8 +12,8 @@ class EcalHodoscopeNumberingScheme : public EcalNumberingScheme {
  public:
 
   EcalHodoscopeNumberingScheme();
-  ~EcalHodoscopeNumberingScheme();
-  virtual uint32_t getUnitID(const EcalBaseNumber& baseNumber) const ;
+  ~EcalHodoscopeNumberingScheme() override;
+  uint32_t getUnitID(const EcalBaseNumber& baseNumber) const override ;
 
 private:
 

--- a/Geometry/EcalTestBeam/interface/EcalTBHodoscopeGeometry.h
+++ b/Geometry/EcalTestBeam/interface/EcalTBHodoscopeGeometry.h
@@ -18,13 +18,13 @@ class EcalTBHodoscopeGeometry : public CaloSubdetectorGeometry
       typedef CaloCellGeometry::Pt3DVec  Pt3DVec  ;
 
       EcalTBHodoscopeGeometry() ;
-      ~EcalTBHodoscopeGeometry() ;
+      ~EcalTBHodoscopeGeometry() override ;
 
-      virtual void newCell( const GlobalPoint& f1 ,
+      void newCell( const GlobalPoint& f1 ,
 			    const GlobalPoint& f2 ,
 			    const GlobalPoint& f3 ,
 			    const CCGFloat*    parm ,
-			    const DetId&       detId   ) ;
+			    const DetId&       detId   ) override ;
 
       static float getFibreLp( int plane, int fibre ) ;
       
@@ -38,7 +38,7 @@ class EcalTBHodoscopeGeometry : public CaloSubdetectorGeometry
 
    protected:
 
-      virtual const CaloCellGeometry* cellGeomPtr( uint32_t index ) const ;
+      const CaloCellGeometry* cellGeomPtr( uint32_t index ) const override ;
       
    private:
       

--- a/Geometry/EcalTestBeam/plugins/DDTBH4Algo.h
+++ b/Geometry/EcalTestBeam/plugins/DDTBH4Algo.h
@@ -16,15 +16,15 @@ class DDTBH4Algo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDTBH4Algo(); 
-  virtual ~DDTBH4Algo();
+  ~DDTBH4Algo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
       DDMaterial ddmat(  const std::string& s ) const ;
       DDName     ddname( const std::string& s ) const ;

--- a/Geometry/EcalTestBeam/plugins/EcalTBGeometryBuilder.h
+++ b/Geometry/EcalTestBeam/plugins/EcalTBGeometryBuilder.h
@@ -35,7 +35,7 @@
 class EcalTBGeometryBuilder : public edm::ESProducer {
    public:
   EcalTBGeometryBuilder(const edm::ParameterSet&);
-  ~EcalTBGeometryBuilder();
+  ~EcalTBGeometryBuilder() override;
 
   typedef std::unique_ptr<CaloGeometry> ReturnType;
 

--- a/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryEP.h
+++ b/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryEP.h
@@ -25,7 +25,7 @@ class EcalTBHodoscopeGeometryLoaderFromDDD;
 class EcalTBHodoscopeGeometryEP : public edm::ESProducer {
  public:
   EcalTBHodoscopeGeometryEP(const edm::ParameterSet&);
-  ~EcalTBHodoscopeGeometryEP();
+  ~EcalTBHodoscopeGeometryEP() override;
   
   typedef std::unique_ptr<CaloSubdetectorGeometry> ReturnType;
   

--- a/Geometry/EcalTestBeam/test/CrystalCenterDump.cc
+++ b/Geometry/EcalTestBeam/test/CrystalCenterDump.cc
@@ -44,7 +44,7 @@ class CrystalCenterDump : public edm::one::EDAnalyzer<>
 {
 public:
   explicit CrystalCenterDump( const edm::ParameterSet& );
-  ~CrystalCenterDump();
+  ~CrystalCenterDump() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/EcalTestBeam/test/EcalTBHodoscopeGeometryAnalyzer.cc
+++ b/Geometry/EcalTestBeam/test/EcalTBHodoscopeGeometryAnalyzer.cc
@@ -45,7 +45,7 @@ class EcalTBHodoscopeGeometryAnalyzer : public edm::one::EDAnalyzer<>
 {
 public:
   explicit EcalTBHodoscopeGeometryAnalyzer( const edm::ParameterSet& );
-  ~EcalTBHodoscopeGeometryAnalyzer();
+  ~EcalTBHodoscopeGeometryAnalyzer() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/EcalTestBeam/test/ee/CaloGeometryEPtest.h
+++ b/Geometry/EcalTestBeam/test/ee/CaloGeometryEPtest.h
@@ -40,7 +40,7 @@ class CaloGeometryEPtest : public edm::ESProducer
 			  edm::es::Label( T::producerTag() ) ) ;
       }
 
-      virtual ~CaloGeometryEPtest<T>() {}
+      ~CaloGeometryEPtest<T>() override {}
       PtrType produceAligned( const typename T::AlignedRecord& iRecord ) 
       {
 	 const Alignments* alignPtr  ( 0 ) ;

--- a/Geometry/EcalTestBeam/test/ee/SurveyToTransforms.cc
+++ b/Geometry/EcalTestBeam/test/ee/SurveyToTransforms.cc
@@ -27,7 +27,7 @@ using namespace CLHEP;
 class SurveyToTransforms : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   SurveyToTransforms( const edm::ParameterSet& );
-  ~SurveyToTransforms() {}
+  ~SurveyToTransforms() override {}
 
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;

--- a/Geometry/ForwardCommonData/plugins/DDBHMAngular.h
+++ b/Geometry/ForwardCommonData/plugins/DDBHMAngular.h
@@ -11,15 +11,15 @@ class DDBHMAngular : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDBHMAngular(); 
-  virtual ~DDBHMAngular();
+  ~DDBHMAngular() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/ForwardGeometry/interface/CastorGeometry.h
+++ b/Geometry/ForwardGeometry/interface/CastorGeometry.h
@@ -35,17 +35,17 @@ class CastorGeometry : public CaloSubdetectorGeometry
 
       static std::string dbString() { return "PCastorRcd" ; }
 
-      virtual unsigned int numberOfTransformParms() const { return 3 ; }
+      unsigned int numberOfTransformParms() const override { return 3 ; }
 
-      virtual unsigned int numberOfShapes() const { return k_NumberOfShapes ; }
-      virtual unsigned int numberOfParametersPerShape() const { return k_NumberOfParametersPerShape ; }
+      unsigned int numberOfShapes() const override { return k_NumberOfShapes ; }
+      unsigned int numberOfParametersPerShape() const override { return k_NumberOfParametersPerShape ; }
 
       CastorGeometry() ;
 
       explicit CastorGeometry(const CastorTopology * topology);
-      virtual ~CastorGeometry();
+      ~CastorGeometry() override;
 
-      virtual DetId getClosestCell(const GlobalPoint& r) const ;
+      DetId getClosestCell(const GlobalPoint& r) const override ;
 
       static std::string producerTag() { return "CASTOR" ; }
 
@@ -60,15 +60,15 @@ class CastorGeometry : public CaloSubdetectorGeometry
 				unsigned int    i  ,
 				Pt3D&           ref  ) ;
 
-      virtual void newCell( const GlobalPoint& f1 ,
+      void newCell( const GlobalPoint& f1 ,
 			    const GlobalPoint& f2 ,
 			    const GlobalPoint& f3 ,
 			    const CCGFloat*    parm,
-			    const DetId&       detId     ) ;
+			    const DetId&       detId     ) override ;
 
    protected:
 
-      virtual const CaloCellGeometry* cellGeomPtr( uint32_t index ) const ;
+      const CaloCellGeometry* cellGeomPtr( uint32_t index ) const override ;
 
 
 private:

--- a/Geometry/ForwardGeometry/interface/CastorTopology.h
+++ b/Geometry/ForwardGeometry/interface/CastorTopology.h
@@ -37,12 +37,12 @@ public:
   virtual std::vector<DetId> incModule(const DetId& id) const;
 
   //** I have to put this here since they inherit from CaloSubdetectorTopology
-  virtual std::vector<DetId> east(const DetId& id) const;
-  virtual std::vector<DetId> west(const DetId& id) const; 
-  virtual std::vector<DetId> north(const DetId& id) const;
-  virtual std::vector<DetId> south(const DetId& id) const;
-  virtual std::vector<DetId> up(const DetId& id) const;
-  virtual std::vector<DetId> down(const DetId& id) const;
+  std::vector<DetId> east(const DetId& id) const override;
+  std::vector<DetId> west(const DetId& id) const override; 
+  std::vector<DetId> north(const DetId& id) const override;
+  std::vector<DetId> south(const DetId& id) const override;
+  std::vector<DetId> up(const DetId& id) const override;
+  std::vector<DetId> down(const DetId& id) const override;
   
   // how many channels (deph) for a given section
   using CaloSubdetectorTopology::ncells;

--- a/Geometry/ForwardGeometry/interface/IdealCastorTrapezoid.h
+++ b/Geometry/ForwardGeometry/interface/IdealCastorTrapezoid.h
@@ -48,7 +48,7 @@ class IdealCastorTrapezoid: public CaloCellGeometry
 			    CornersMgr*          mgr     ,
 			    const CCGFloat*      parm        ) ;
 	 
-      virtual ~IdealCastorTrapezoid() ;
+      ~IdealCastorTrapezoid() override ;
 	 
       CCGFloat dxl() const ; 
       CCGFloat dxh() const ; 
@@ -63,7 +63,7 @@ class IdealCastorTrapezoid: public CaloCellGeometry
       CCGFloat dR()  const ;
 
       using CaloCellGeometry::vocalCorners;
-      virtual void vocalCorners( Pt3DVec&        vec ,
+      void vocalCorners( Pt3DVec&        vec ,
 				 const CCGFloat* pv  ,
 				 Pt3D&           ref  ) const override ;
 
@@ -71,7 +71,7 @@ class IdealCastorTrapezoid: public CaloCellGeometry
 				const CCGFloat* pv  , 
 				Pt3D&           ref   ) ;
    private:
-      virtual void initCorners(CornersVec& ) override;
+      void initCorners(CornersVec& ) override;
 
 
 };

--- a/Geometry/ForwardGeometry/interface/IdealZDCTrapezoid.h
+++ b/Geometry/ForwardGeometry/interface/IdealZDCTrapezoid.h
@@ -38,7 +38,7 @@ class IdealZDCTrapezoid: public CaloCellGeometry
 			       CornersMgr*  mgr       ,
 			 const CCGFloat*    parm        ) ;
 	 
-      virtual ~IdealZDCTrapezoid() ;
+      ~IdealZDCTrapezoid() override ;
 
       CCGFloat an() const ;
       CCGFloat dx() const ;
@@ -47,16 +47,16 @@ class IdealZDCTrapezoid: public CaloCellGeometry
       CCGFloat ta() const ;
       CCGFloat dt() const ;
 
-      virtual void vocalCorners( Pt3DVec&        vec ,
+      void vocalCorners( Pt3DVec&        vec ,
 				 const CCGFloat* pv  ,
-				 Pt3D&           ref  ) const ;
+				 Pt3D&           ref  ) const override ;
 
       static void localCorners( Pt3DVec&        vec ,
 				const CCGFloat* pv  , 
 				Pt3D&           ref  ) ;
     
    private:
-      void initCorners(CaloCellGeometry::CornersVec& );
+      void initCorners(CaloCellGeometry::CornersVec& ) override;
 
 
 };

--- a/Geometry/ForwardGeometry/interface/ZdcGeometry.h
+++ b/Geometry/ForwardGeometry/interface/ZdcGeometry.h
@@ -33,13 +33,13 @@ class ZdcGeometry : public CaloSubdetectorGeometry
 
       static std::string dbString() { return "PZdcRcd" ; }
 
-      virtual unsigned int numberOfShapes() const { return k_NumberOfShapes ; }
-      virtual unsigned int numberOfParametersPerShape() const { return k_NumberOfParametersPerShape ; }
+      unsigned int numberOfShapes() const override { return k_NumberOfShapes ; }
+      unsigned int numberOfParametersPerShape() const override { return k_NumberOfParametersPerShape ; }
 
       ZdcGeometry() ;
 
       explicit ZdcGeometry(const ZdcTopology * topology);
-      virtual ~ZdcGeometry();
+      ~ZdcGeometry() override;
   
 //      virtual DetId getClosestCell(const GlobalPoint& r) const ;
 
@@ -56,15 +56,15 @@ class ZdcGeometry : public CaloSubdetectorGeometry
 				unsigned int    i   ,
 				Pt3D&           ref   ) ;
 
-      virtual void newCell( const GlobalPoint& f1 ,
+      void newCell( const GlobalPoint& f1 ,
 			    const GlobalPoint& f2 ,
 			    const GlobalPoint& f3 ,
 			    const CCGFloat*    parm,
-			    const DetId&       detId     ) ;
+			    const DetId&       detId     ) override ;
 
    protected:
 
-      virtual const CaloCellGeometry* cellGeomPtr( uint32_t index ) const ;
+      const CaloCellGeometry* cellGeomPtr( uint32_t index ) const override ;
 					
    private:
 

--- a/Geometry/ForwardGeometry/interface/ZdcTopology.h
+++ b/Geometry/ForwardGeometry/interface/ZdcTopology.h
@@ -35,12 +35,12 @@ public:
   virtual std::vector<DetId> longitudinal(const DetId& id) const;
 
   //** I have to put this here since they inherit from CaloSubdetectorTopology
-  virtual std::vector<DetId> east(const DetId& id) const;
-  virtual std::vector<DetId> west(const DetId& id) const; 
-  virtual std::vector<DetId> north(const DetId& id) const;
-  virtual std::vector<DetId> south(const DetId& id) const;
-  virtual std::vector<DetId> up(const DetId& id) const;
-  virtual std::vector<DetId> down(const DetId& id) const;
+  std::vector<DetId> east(const DetId& id) const override;
+  std::vector<DetId> west(const DetId& id) const override; 
+  std::vector<DetId> north(const DetId& id) const override;
+  std::vector<DetId> south(const DetId& id) const override;
+  std::vector<DetId> up(const DetId& id) const override;
+  std::vector<DetId> down(const DetId& id) const override;
   
   
   // how many channels (deph) for a given section

--- a/Geometry/ForwardGeometry/plugins/CastorHardcodeGeometryEP.h
+++ b/Geometry/ForwardGeometry/plugins/CastorHardcodeGeometryEP.h
@@ -19,7 +19,7 @@
 class CastorHardcodeGeometryEP : public edm::ESProducer {
    public:
       CastorHardcodeGeometryEP(const edm::ParameterSet&);
-      ~CastorHardcodeGeometryEP();
+      ~CastorHardcodeGeometryEP() override;
 
       typedef std::unique_ptr<CaloSubdetectorGeometry> ReturnType;
 

--- a/Geometry/ForwardGeometry/plugins/ZdcHardcodeGeometryEP.h
+++ b/Geometry/ForwardGeometry/plugins/ZdcHardcodeGeometryEP.h
@@ -21,7 +21,7 @@ class ZdcHardcodeGeometryEP : public edm::ESProducer
 {
    public:
       ZdcHardcodeGeometryEP(const edm::ParameterSet&);
-      ~ZdcHardcodeGeometryEP();
+      ~ZdcHardcodeGeometryEP() override;
 
       typedef std::shared_ptr<CaloSubdetectorGeometry> ReturnType;
 

--- a/Geometry/GEMGeometry/interface/GEMChamber.h
+++ b/Geometry/GEMGeometry/interface/GEMChamber.h
@@ -22,13 +22,13 @@ public:
   GEMChamber(GEMDetId id, const ReferenceCountingPointer<BoundPlane>& plane);
 
   /// Destructor
-  virtual ~GEMChamber();
+  ~GEMChamber() override;
 
   /// Return the GEMDetId of this chamber
   GEMDetId id() const;
 
   // Which subdetector
-  virtual SubDetector subDetector() const {return GeomDetEnumerators::GEM;}
+  SubDetector subDetector() const override {return GeomDetEnumerators::GEM;}
 
   /// equal if the id is the same
   bool operator==(const GEMChamber& ch) const;
@@ -37,10 +37,10 @@ public:
   void add(GEMEtaPartition* roll);
 
   /// Return the rolls in the chamber
-  virtual std::vector<const GeomDet*> components() const;
+  std::vector<const GeomDet*> components() const override;
 
   /// Return the sub-component (roll) with a given id in this chamber
-  virtual const GeomDet* component(DetId id) const;
+  const GeomDet* component(DetId id) const override;
 
   /// Return the eta partition corresponding to the given id 
   const GEMEtaPartition* etaPartition(GEMDetId id) const;

--- a/Geometry/GEMGeometry/interface/GEMEtaPartition.h
+++ b/Geometry/GEMGeometry/interface/GEMEtaPartition.h
@@ -14,18 +14,18 @@ class GEMEtaPartition : public GeomDetUnit
 public:
   
   GEMEtaPartition(GEMDetId id, BoundPlane::BoundPlanePointer bp, GEMEtaPartitionSpecs* rrs);
-  ~GEMEtaPartition();
+  ~GEMEtaPartition() override;
 
   const GEMEtaPartitionSpecs* specs() const { return specs_; }
   GEMDetId id() const { return id_; }
 
-  const Topology& topology() const;
+  const Topology& topology() const override;
   const StripTopology& specificTopology() const;
 
   const Topology& padTopology() const;
   const StripTopology& specificPadTopology() const;
 
-  const GeomDetType& type() const; 
+  const GeomDetType& type() const override; 
  
   // strip-related methods:
 

--- a/Geometry/GEMGeometry/interface/GEMEtaPartitionSpecs.h
+++ b/Geometry/GEMGeometry/interface/GEMEtaPartitionSpecs.h
@@ -24,9 +24,9 @@ public:
 
   GEMEtaPartitionSpecs( SubDetector rss, const std::string& name, const GEMSpecs& pars);
 
-  ~GEMEtaPartitionSpecs();
+  ~GEMEtaPartitionSpecs() override;
 
-  const Topology& topology() const;
+  const Topology& topology() const override;
 
   const StripTopology& specificTopology() const;
 

--- a/Geometry/GEMGeometry/interface/GEMGeometry.h
+++ b/Geometry/GEMGeometry/interface/GEMGeometry.h
@@ -28,28 +28,28 @@ class GEMGeometry : public TrackingGeometry {
   GEMGeometry();
 
   /// Destructor
-  virtual ~GEMGeometry();
+  ~GEMGeometry() override;
 
   // Return a vector of all det types
-  virtual const DetTypeContainer&  detTypes() const override;
+  const DetTypeContainer&  detTypes() const override;
 
   // Return a vector of all GeomDetUnit
-  virtual const DetUnitContainer& detUnits() const override;
+  const DetUnitContainer& detUnits() const override;
 
   // Return a vector of all GeomDet
-  virtual const DetContainer& dets() const override;
+  const DetContainer& dets() const override;
   
   // Return a vector of all GeomDetUnit DetIds
-  virtual const DetIdContainer& detUnitIds() const override;
+  const DetIdContainer& detUnitIds() const override;
 
   // Return a vector of all GeomDet DetIds
-  virtual const DetIdContainer& detIds() const override;
+  const DetIdContainer& detIds() const override;
 
   // Return the pointer to the GeomDetUnit corresponding to a given DetId
-  virtual const GeomDetUnit* idToDetUnit(DetId) const override;
+  const GeomDetUnit* idToDetUnit(DetId) const override;
 
   // Return the pointer to the GeomDet corresponding to a given DetId
-  virtual const GeomDet* idToDet(DetId) const override;
+  const GeomDet* idToDet(DetId) const override;
 
 
   //---- Extension of the interface

--- a/Geometry/GEMGeometry/interface/GEMSuperChamber.h
+++ b/Geometry/GEMGeometry/interface/GEMSuperChamber.h
@@ -23,7 +23,7 @@ class GEMSuperChamber : public GeomDet
   GEMSuperChamber(GEMDetId id, const ReferenceCountingPointer<BoundPlane>& plane);
 
   /// destructor
-  ~GEMSuperChamber();
+  ~GEMSuperChamber() override;
 
   /// Return the GEMDetId of this super chamber
   GEMDetId id() const;
@@ -32,7 +32,7 @@ class GEMSuperChamber : public GeomDet
   const std::vector<GEMDetId>& ids() const;
 
   // Which subdetector
-  virtual SubDetector subDetector() const {return GeomDetEnumerators::GEM;}
+  SubDetector subDetector() const override {return GeomDetEnumerators::GEM;}
 
   /// equal if the id is the same
   bool operator==(const GEMSuperChamber& sch) const;
@@ -41,10 +41,10 @@ class GEMSuperChamber : public GeomDet
   void add(GEMChamber* ch);
   
   /// Return the chambers in the super chamber
-  virtual std::vector<const GeomDet*> components() const;
+  std::vector<const GeomDet*> components() const override;
 
   /// Return the sub-component (chamber) with a given id in this super chamber
-  virtual const GeomDet* component(DetId id) const;
+  const GeomDet* component(DetId id) const override;
 
   /// Return the chamber corresponding to the given id 
   const GEMChamber* chamber(GEMDetId id) const;

--- a/Geometry/GEMGeometry/interface/ME0Chamber.h
+++ b/Geometry/GEMGeometry/interface/ME0Chamber.h
@@ -13,13 +13,13 @@ public:
   ME0Chamber(ME0DetId id, const ReferenceCountingPointer<BoundPlane>& plane);
 
   /// Destructor
-  virtual ~ME0Chamber();
+  ~ME0Chamber() override;
 
   /// Return the ME0DetId of this chamber
   ME0DetId id() const;
 
   // Which subdetector
-  virtual SubDetector subDetector() const {return GeomDetEnumerators::ME0;}
+  SubDetector subDetector() const override {return GeomDetEnumerators::ME0;}
 
   /// equal if the id is the same
   bool operator==(const ME0Chamber& ch) const;
@@ -28,10 +28,10 @@ public:
   void add(ME0Layer* layer);
 
   /// Return the rolls in the chamber
-  virtual std::vector<const GeomDet*> components() const;
+  std::vector<const GeomDet*> components() const override;
 
   /// Return the sub-component (roll) with a given id in this chamber
-  virtual const GeomDet* component(DetId id) const;
+  const GeomDet* component(DetId id) const override;
 
   /// Return the layer corresponding to the given id 
   const ME0Layer* layer(ME0DetId id) const;

--- a/Geometry/GEMGeometry/interface/ME0EtaPartition.h
+++ b/Geometry/GEMGeometry/interface/ME0EtaPartition.h
@@ -15,18 +15,18 @@ class ME0EtaPartition : public GeomDetUnit
 public:
   
   ME0EtaPartition(ME0DetId id, BoundPlane::BoundPlanePointer bp, ME0EtaPartitionSpecs* rrs);
-  ~ME0EtaPartition();
+  ~ME0EtaPartition() override;
 
   const ME0EtaPartitionSpecs* specs() const { return specs_; }
   ME0DetId id() const { return id_; }
 
-  const Topology& topology() const;
+  const Topology& topology() const override;
   const StripTopology& specificTopology() const;
 
   const Topology& padTopology() const;
   const StripTopology& specificPadTopology() const;
 
-  const GeomDetType& type() const; 
+  const GeomDetType& type() const override; 
  
   /// Return the chamber this roll belongs to 
   //const ME0Chamber* chamber() const;

--- a/Geometry/GEMGeometry/interface/ME0EtaPartitionSpecs.h
+++ b/Geometry/GEMGeometry/interface/ME0EtaPartitionSpecs.h
@@ -24,9 +24,9 @@ public:
 
   ME0EtaPartitionSpecs( SubDetector rss, const std::string& name, const ME0Specs& pars);
 
-  ~ME0EtaPartitionSpecs();
+  ~ME0EtaPartitionSpecs() override;
 
-  const Topology& topology() const;
+  const Topology& topology() const override;
 
   const StripTopology& specificTopology() const;
 

--- a/Geometry/GEMGeometry/interface/ME0Geometry.h
+++ b/Geometry/GEMGeometry/interface/ME0Geometry.h
@@ -16,28 +16,28 @@ class ME0Geometry : public TrackingGeometry {
   ME0Geometry();
 
   /// Destructor
-  virtual ~ME0Geometry();
+  ~ME0Geometry() override;
 
   // Return a vector of all det types
-  virtual const DetTypeContainer&  detTypes() const;
+  const DetTypeContainer&  detTypes() const override;
 
   // Return a vector of all GeomDetUnit
-  virtual const DetUnitContainer& detUnits() const;
+  const DetUnitContainer& detUnits() const override;
 
   // Return a vector of all GeomDet
-  virtual const DetContainer& dets() const;
+  const DetContainer& dets() const override;
   
   // Return a vector of all GeomDetUnit DetIds
-  virtual const DetIdContainer& detUnitIds() const;
+  const DetIdContainer& detUnitIds() const override;
 
   // Return a vector of all GeomDet DetIds
-  virtual const DetIdContainer& detIds() const;
+  const DetIdContainer& detIds() const override;
 
   // Return the pointer to the GeomDetUnit corresponding to a given DetId
-  virtual const GeomDetUnit* idToDetUnit(DetId) const;
+  const GeomDetUnit* idToDetUnit(DetId) const override;
 
   // Return the pointer to the GeomDet corresponding to a given DetId
-  virtual const GeomDet* idToDet(DetId) const;
+  const GeomDet* idToDet(DetId) const override;
 
 
   //---- Extension of the interface

--- a/Geometry/GEMGeometry/interface/ME0Layer.h
+++ b/Geometry/GEMGeometry/interface/ME0Layer.h
@@ -12,13 +12,13 @@ public:
   ME0Layer(ME0DetId id, const ReferenceCountingPointer<BoundPlane>& plane);
 
   /// Destructor
-  virtual ~ME0Layer();
+  ~ME0Layer() override;
 
   /// Return the ME0DetId of this layer
   ME0DetId id() const;
 
   // Which subdetector
-  virtual SubDetector subDetector() const {return GeomDetEnumerators::ME0;}
+  SubDetector subDetector() const override {return GeomDetEnumerators::ME0;}
 
   /// equal if the id is the same
   bool operator==(const ME0Layer& ch) const;
@@ -27,10 +27,10 @@ public:
   void add(const ME0EtaPartition* roll);
 
   /// Return the rolls in the layer
-  virtual std::vector<const GeomDet*> components() const;
+  std::vector<const GeomDet*> components() const override;
 
   /// Return the sub-component (roll) with a given id in this layer
-  virtual const GeomDet* component(DetId id) const;
+  const GeomDet* component(DetId id) const override;
 
   /// Return the eta partition corresponding to the given id 
   const ME0EtaPartition* etaPartition(ME0DetId id) const;

--- a/Geometry/GEMGeometry/test/GEMGeometryAnalyzer.cc
+++ b/Geometry/GEMGeometry/test/GEMGeometryAnalyzer.cc
@@ -31,7 +31,7 @@ class GEMGeometryAnalyzer : public edm::one::EDAnalyzer<> {
 public: 
   GEMGeometryAnalyzer( const edm::ParameterSet& pset);
 
-  ~GEMGeometryAnalyzer();
+  ~GEMGeometryAnalyzer() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/GEMGeometry/test/ME0GeometryAnalyzer.cc
+++ b/Geometry/GEMGeometry/test/ME0GeometryAnalyzer.cc
@@ -30,7 +30,7 @@ class ME0GeometryAnalyzer : public edm::one::EDAnalyzer<>
 public: 
   ME0GeometryAnalyzer( const edm::ParameterSet& pset);
 
-  ~ME0GeometryAnalyzer();
+  ~ME0GeometryAnalyzer() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/GEMGeometry/test/ME0GeometryAnalyzer10EtaPart.cc
+++ b/Geometry/GEMGeometry/test/ME0GeometryAnalyzer10EtaPart.cc
@@ -30,7 +30,7 @@ class ME0GeometryAnalyzer10EtaPart : public edm::one::EDAnalyzer<>
 public: 
   ME0GeometryAnalyzer10EtaPart( const edm::ParameterSet& pset);
 
-  ~ME0GeometryAnalyzer10EtaPart();
+  ~ME0GeometryAnalyzer10EtaPart() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/GEMGeometryBuilder/plugins/GEMGeometryESModule.h
+++ b/Geometry/GEMGeometryBuilder/plugins/GEMGeometryESModule.h
@@ -22,7 +22,7 @@ class GEMGeometryESModule : public edm::ESProducer
   GEMGeometryESModule(const edm::ParameterSet & p);
   
   /// Destructor
-  virtual ~GEMGeometryESModule();
+  ~GEMGeometryESModule() override;
   
   /// Produce GEMGeometry.
   std::shared_ptr<GEMGeometry>  produce(const MuonGeometryRecord & record);

--- a/Geometry/GEMGeometryBuilder/plugins/ME0GeometryESModule.h
+++ b/Geometry/GEMGeometryBuilder/plugins/ME0GeometryESModule.h
@@ -22,7 +22,7 @@ class ME0GeometryESModule : public edm::ESProducer
   ME0GeometryESModule(const edm::ParameterSet & p);
 
   /// Destructor
-  virtual ~ME0GeometryESModule();
+  ~ME0GeometryESModule() override;
   
   /// Produce ME0Geometry.
   std::shared_ptr<ME0Geometry>  produce(const MuonGeometryRecord & record);

--- a/Geometry/GlobalTrackingGeometryBuilder/plugins/GlobalTrackingGeometryESProducer.h
+++ b/Geometry/GlobalTrackingGeometryBuilder/plugins/GlobalTrackingGeometryESProducer.h
@@ -24,7 +24,7 @@ public:
   GlobalTrackingGeometryESProducer(const edm::ParameterSet & p);
 
   /// Destructor
-  virtual ~GlobalTrackingGeometryESProducer();
+  ~GlobalTrackingGeometryESProducer() override;
 
   /// Produce GlobalTrackingGeometry
   std::shared_ptr<GlobalTrackingGeometry> produce(const GlobalTrackingGeometryRecord& record);

--- a/Geometry/GlobalTrackingGeometryBuilder/test/GlobalTrackingGeometryTest.cc
+++ b/Geometry/GlobalTrackingGeometryBuilder/test/GlobalTrackingGeometryTest.cc
@@ -31,7 +31,7 @@ class GlobalTrackingGeometryTest : public edm::one::EDAnalyzer<>
 public:
  
   explicit GlobalTrackingGeometryTest( const edm::ParameterSet& );
-  ~GlobalTrackingGeometryTest();
+  ~GlobalTrackingGeometryTest() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/HGCalCommonData/plugins/DDAHcalModuleAlgo.h
+++ b/Geometry/HGCalCommonData/plugins/DDAHcalModuleAlgo.h
@@ -13,14 +13,14 @@ class DDAHcalModuleAlgo : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDAHcalModuleAlgo(); //const std::string & name);
-  virtual ~DDAHcalModuleAlgo();
+  ~DDAHcalModuleAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
                   const DDVectorArguments & vArgs,
                   const DDMapArguments & mArgs,
                   const DDStringArguments & sArgs,
-                  const DDStringVectorArguments & vsArgs);
-  void execute(DDCompactView& cpv);
+                  const DDStringVectorArguments & vsArgs) override;
+  void execute(DDCompactView& cpv) override;
 
 protected:
 

--- a/Geometry/HGCalCommonData/plugins/DDHGCalEEAlgo.h
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalEEAlgo.h
@@ -12,7 +12,7 @@ class DDHGCalEEAlgo : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDHGCalEEAlgo(); //const std::string & name);
-  virtual ~DDHGCalEEAlgo();
+  ~DDHGCalEEAlgo() override;
   
   struct HGCalEEPar {
     double yh1, bl1, tl1, yh2, bl2, tl2, alp, theta, phi, xpos, ypos, zpos;
@@ -26,8 +26,8 @@ public:
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
-  void execute(DDCompactView& cpv);
+		  const DDStringVectorArguments & vsArgs) override;
+  void execute(DDCompactView& cpv) override;
 
 protected:
 

--- a/Geometry/HGCalCommonData/plugins/DDHGCalHEAlgo.h
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalHEAlgo.h
@@ -12,7 +12,7 @@ class DDHGCalHEAlgo : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDHGCalHEAlgo(); //const std::string & name);
-  virtual ~DDHGCalHEAlgo();
+  ~DDHGCalHEAlgo() override;
   
   struct HGCalHEPar {
     double yh1, bl1, tl1, yh2, bl2, tl2, alp, theta, phi, xpos, ypos, zpos;
@@ -26,8 +26,8 @@ public:
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
-  void execute(DDCompactView& cpv);
+		  const DDStringVectorArguments & vsArgs) override;
+  void execute(DDCompactView& cpv) override;
 
 protected:
 

--- a/Geometry/HGCalCommonData/plugins/DDHGCalModule.h
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalModule.h
@@ -13,14 +13,14 @@ class DDHGCalModule : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDHGCalModule(); //const std::string & name);
-  virtual ~DDHGCalModule();
+  ~DDHGCalModule() override;
   
   void initialize(const DDNumericArguments & nArgs,
                   const DDVectorArguments & vArgs,
                   const DDMapArguments & mArgs,
                   const DDStringArguments & sArgs,
-                  const DDStringVectorArguments & vsArgs);
-  void execute(DDCompactView& cpv);
+                  const DDStringVectorArguments & vsArgs) override;
+  void execute(DDCompactView& cpv) override;
 
 protected:
 

--- a/Geometry/HGCalCommonData/plugins/DDHGCalModuleAlgo.h
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalModuleAlgo.h
@@ -13,14 +13,14 @@ class DDHGCalModuleAlgo : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDHGCalModuleAlgo(); //const std::string & name);
-  virtual ~DDHGCalModuleAlgo();
+  ~DDHGCalModuleAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
                   const DDVectorArguments & vArgs,
                   const DDMapArguments & mArgs,
                   const DDStringArguments & sArgs,
-                  const DDStringVectorArguments & vsArgs);
-  void execute(DDCompactView& cpv);
+                  const DDStringVectorArguments & vsArgs) override;
+  void execute(DDCompactView& cpv) override;
 
 protected:
 

--- a/Geometry/HGCalCommonData/plugins/DDHGCalNoTaperEndcap.h
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalNoTaperEndcap.h
@@ -10,15 +10,15 @@ class DDHGCalNoTaperEndcap : public DDAlgorithm {
 
 public:
   DDHGCalNoTaperEndcap( void ); 
-  virtual ~DDHGCalNoTaperEndcap( void );
+  ~DDHGCalNoTaperEndcap( void ) override;
   
   void initialize( const DDNumericArguments & nArgs,
 		   const DDVectorArguments & vArgs,
 		   const DDMapArguments & mArgs,
 		   const DDStringArguments & sArgs,
-		   const DDStringVectorArguments & vsArgs );
+		   const DDStringVectorArguments & vsArgs ) override;
 
-  void execute( DDCompactView& cpv );
+  void execute( DDCompactView& cpv ) override;
 
 private:
 

--- a/Geometry/HGCalCommonData/plugins/DDHGCalTBModule.h
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalTBModule.h
@@ -13,14 +13,14 @@ class DDHGCalTBModule : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDHGCalTBModule(); //const std::string & name);
-  virtual ~DDHGCalTBModule();
+  ~DDHGCalTBModule() override;
   
   void initialize(const DDNumericArguments & nArgs,
                   const DDVectorArguments & vArgs,
                   const DDMapArguments & mArgs,
                   const DDStringArguments & sArgs,
-                  const DDStringVectorArguments & vsArgs);
-  void execute(DDCompactView& cpv);
+                  const DDStringVectorArguments & vsArgs) override;
+  void execute(DDCompactView& cpv) override;
 
 protected:
 

--- a/Geometry/HGCalCommonData/plugins/DDHGCalWafer.h
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalWafer.h
@@ -12,14 +12,14 @@ class DDHGCalWafer : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDHGCalWafer();
-  virtual ~DDHGCalWafer();
+  ~DDHGCalWafer() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
-  void execute(DDCompactView& cpv);
+		  const DDStringVectorArguments & vsArgs) override;
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/HGCalCommonData/plugins/DDHGCalWaferAlgo.h
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalWaferAlgo.h
@@ -12,14 +12,14 @@ class DDHGCalWaferAlgo : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDHGCalWaferAlgo();
-  virtual ~DDHGCalWaferAlgo();
+  ~DDHGCalWaferAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
-  void execute(DDCompactView& cpv);
+		  const DDStringVectorArguments & vsArgs) override;
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/HGCalCommonData/plugins/FastTimeNumberingInitialization.cc
+++ b/Geometry/HGCalCommonData/plugins/FastTimeNumberingInitialization.cc
@@ -40,7 +40,7 @@ class FastTimeNumberingInitialization : public edm::ESProducer {
 
 public:
   FastTimeNumberingInitialization(const edm::ParameterSet&);
-  ~FastTimeNumberingInitialization();
+  ~FastTimeNumberingInitialization() override;
 
   typedef std::shared_ptr<FastTimeDDDConstants> ReturnType;
 

--- a/Geometry/HGCalCommonData/plugins/FastTimeParametersESModule.cc
+++ b/Geometry/HGCalCommonData/plugins/FastTimeParametersESModule.cc
@@ -15,7 +15,7 @@
 class  FastTimeParametersESModule : public edm::ESProducer {
 public:
   FastTimeParametersESModule(const edm::ParameterSet &);
-  ~FastTimeParametersESModule(void);
+  ~FastTimeParametersESModule(void) override;
   
   typedef std::shared_ptr<FastTimeParameters> ReturnType;
 

--- a/Geometry/HGCalCommonData/plugins/HGCalNumberingInitialization.cc
+++ b/Geometry/HGCalCommonData/plugins/HGCalNumberingInitialization.cc
@@ -36,7 +36,7 @@ class HGCalNumberingInitialization : public edm::ESProducer {
 
 public:
   HGCalNumberingInitialization(const edm::ParameterSet&);
-  ~HGCalNumberingInitialization();
+  ~HGCalNumberingInitialization() override;
 
   typedef std::unique_ptr<HGCalDDDConstants> ReturnType;
 

--- a/Geometry/HGCalCommonData/plugins/HGCalParametersESModule.cc
+++ b/Geometry/HGCalCommonData/plugins/HGCalParametersESModule.cc
@@ -15,7 +15,7 @@
 class  HGCalParametersESModule : public edm::ESProducer {
 public:
   HGCalParametersESModule( const edm::ParameterSet & );
-  ~HGCalParametersESModule( void );
+  ~HGCalParametersESModule( void ) override;
   
   typedef std::shared_ptr<HGCalParameters> ReturnType;
   

--- a/Geometry/HGCalCommonData/test/FastTimeNumberingTester.cc
+++ b/Geometry/HGCalCommonData/test/FastTimeNumberingTester.cc
@@ -45,7 +45,7 @@
 class FastTimeNumberingTester : public edm::one::EDAnalyzer<> {
 public:
   explicit FastTimeNumberingTester( const edm::ParameterSet& );
-  ~FastTimeNumberingTester();
+  ~FastTimeNumberingTester() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/HGCalCommonData/test/HGCGeometryTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCGeometryTester.cc
@@ -43,7 +43,7 @@
 class HGCGeometryTester : public edm::one::EDAnalyzer<> {
 public:
   explicit HGCGeometryTester( const edm::ParameterSet& );
-  ~HGCGeometryTester();
+  ~HGCGeometryTester() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/HGCalCommonData/test/HGCalNumberingTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalNumberingTester.cc
@@ -44,7 +44,7 @@
 class HGCalNumberingTester : public edm::one::EDAnalyzer<> {
 public:
   explicit HGCalNumberingTester( const edm::ParameterSet& );
-  ~HGCalNumberingTester();
+  ~HGCalNumberingTester() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/HGCalCommonData/test/HGCalParametersAnalyzer.cc
+++ b/Geometry/HGCalCommonData/test/HGCalParametersAnalyzer.cc
@@ -13,7 +13,7 @@ class HGCalParametersAnalyzer : public edm::one::EDAnalyzer<>
 {
 public:
   explicit HGCalParametersAnalyzer( const edm::ParameterSet& ) {}
-  ~HGCalParametersAnalyzer() {}
+  ~HGCalParametersAnalyzer() override {}
   
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/HGCalGeometry/interface/FastTimeGeometry.h
+++ b/Geometry/HGCalGeometry/interface/FastTimeGeometry.h
@@ -46,23 +46,23 @@ public:
  
   FastTimeGeometry(const FastTimeTopology& topology) ;
   
-  virtual ~FastTimeGeometry();
+  ~FastTimeGeometry() override;
 
   void localCorners(Pt3DVec&        lc,
 		    const CCGFloat* pv, 
 		    unsigned int    i,
 		    Pt3D&           ref) ;
   
-  virtual void newCell(const GlobalPoint& f1 ,
+  void newCell(const GlobalPoint& f1 ,
 		       const GlobalPoint& f2 ,
 		       const GlobalPoint& f3 ,
 		       const CCGFloat*    parm ,
 		       const DetId&       detId) override;
   
   /// Get the cell geometry of a given detector id.  Should return false if not found.
-  virtual const CaloCellGeometry* getGeometry(const DetId& id) const override;
+  const CaloCellGeometry* getGeometry(const DetId& id) const override;
 
-  virtual void getSummary(CaloSubdetectorGeometry::TrVec&  trVector,
+  void getSummary(CaloSubdetectorGeometry::TrVec&  trVector,
 			  CaloSubdetectorGeometry::IVec&   iVector,
 			  CaloSubdetectorGeometry::DimVec& dimVector,
 			  CaloSubdetectorGeometry::IVec& dinsVector ) const override;
@@ -73,11 +73,11 @@ public:
   CornersVec getCorners(const DetId& id) const; 
 
   // avoid sorting set in base class  
-  virtual const std::vector<DetId>& getValidDetIds( DetId::Detector det = DetId::Detector(0), int subdet = 0) const override { return m_validIds; }
+  const std::vector<DetId>& getValidDetIds( DetId::Detector det = DetId::Detector(0), int subdet = 0) const override { return m_validIds; }
   const std::vector<DetId>& getValidGeomDetIds( void ) const { return m_validGeomIds; }
 					       
   // Get closest cell, etc...
-  virtual DetId getClosestCell(const GlobalPoint& r) const override;
+  DetId getClosestCell(const GlobalPoint& r) const override;
   
   /** \brief Get a list of all cells within a dR of the given cell
       
@@ -85,10 +85,10 @@ public:
       Cleverer implementations are suggested to use rough conversions between
       eta/phi and ieta/iphi and test on the boundaries.
   */
-  virtual DetIdSet getCells(const GlobalPoint& r, double dR) const override;
+  DetIdSet getCells(const GlobalPoint& r, double dR) const override;
   
   virtual void fillNamedParams (DDFilteredView fv);
-  virtual void initializeParms() override;
+  void initializeParms() override;
   
   static std::string producerTag() { return "FastTime" ; }
   std::string cellElement() const;
@@ -98,11 +98,11 @@ public:
      
 protected:
 
-  virtual unsigned int indexFor(const DetId& id) const override;
+  unsigned int indexFor(const DetId& id) const override;
   using CaloSubdetectorGeometry::sizeForDenseIndex;
   unsigned int sizeForDenseIndex() const;
   
-  virtual const CaloCellGeometry* cellGeomPtr( uint32_t index ) const override;
+  const CaloCellGeometry* cellGeomPtr( uint32_t index ) const override;
   
   void addValidID(const DetId& id);
   

--- a/Geometry/HGCalGeometry/interface/HGCalGeometry.h
+++ b/Geometry/HGCalGeometry/interface/HGCalGeometry.h
@@ -46,23 +46,23 @@ public:
  
   HGCalGeometry(const HGCalTopology& topology) ;
   
-  virtual ~HGCalGeometry();
+  ~HGCalGeometry() override;
 
   void localCorners( Pt3DVec&        lc  ,
 		     const CCGFloat* pv  , 
 		     unsigned int    i   ,
 		     Pt3D&           ref   ) ;
   
-  virtual void newCell( const GlobalPoint& f1 ,
+  void newCell( const GlobalPoint& f1 ,
 			const GlobalPoint& f2 ,
 			const GlobalPoint& f3 ,
 			const CCGFloat*    parm ,
 			const DetId&       detId ) override;
   
   /// Get the cell geometry of a given detector id.  Should return false if not found.
-  virtual const CaloCellGeometry* getGeometry( const DetId& id ) const override;
+  const CaloCellGeometry* getGeometry( const DetId& id ) const override;
 
-  virtual void getSummary( CaloSubdetectorGeometry::TrVec&  trVector,
+  void getSummary( CaloSubdetectorGeometry::TrVec&  trVector,
 			   CaloSubdetectorGeometry::IVec&   iVector,
 			   CaloSubdetectorGeometry::DimVec& dimVector,
 			   CaloSubdetectorGeometry::IVec& dinsVector ) const override;
@@ -73,11 +73,11 @@ public:
   CornersVec getCorners( const DetId& id ) const; 
 
   // avoid sorting set in base class  
-  virtual const std::vector<DetId>& getValidDetIds( DetId::Detector det = DetId::Detector(0), int subdet = 0) const override { return m_validIds; }
+  const std::vector<DetId>& getValidDetIds( DetId::Detector det = DetId::Detector(0), int subdet = 0) const override { return m_validIds; }
   const std::vector<DetId>& getValidGeomDetIds( void ) const { return m_validGeomIds; }
 					       
   // Get closest cell, etc...
-  virtual DetId getClosestCell( const GlobalPoint& r ) const override;
+  DetId getClosestCell( const GlobalPoint& r ) const override;
   
   /** \brief Get a list of all cells within a dR of the given cell
       
@@ -85,10 +85,10 @@ public:
       Cleverer implementations are suggested to use rough conversions between
       eta/phi and ieta/iphi and test on the boundaries.
   */
-  virtual DetIdSet getCells( const GlobalPoint& r, double dR ) const override;
+  DetIdSet getCells( const GlobalPoint& r, double dR ) const override;
   
   virtual void fillNamedParams (DDFilteredView fv);
-  virtual void initializeParms() override;
+  void initializeParms() override;
   
   static std::string producerTag() { return "HGCal" ; }
   std::string cellElement() const;
@@ -98,11 +98,11 @@ public:
      
 protected:
 
-  virtual unsigned int indexFor(const DetId& id) const override;
+  unsigned int indexFor(const DetId& id) const override;
   using CaloSubdetectorGeometry::sizeForDenseIndex;
   unsigned int sizeForDenseIndex() const;
   
-  virtual const CaloCellGeometry* cellGeomPtr( uint32_t index ) const override;
+  const CaloCellGeometry* cellGeomPtr( uint32_t index ) const override;
   
   void addValidID(const DetId& id);
   unsigned int getClosestCellIndex ( const GlobalPoint& r ) const;

--- a/Geometry/HGCalGeometry/plugins/FastTimeGeometryESProducer.cc
+++ b/Geometry/HGCalGeometry/plugins/FastTimeGeometryESProducer.cc
@@ -39,7 +39,7 @@ class FastTimeGeometryESProducer : public edm::ESProducer {
 
 public:
   FastTimeGeometryESProducer( const edm::ParameterSet& iP );
-  virtual ~FastTimeGeometryESProducer() ;
+  ~FastTimeGeometryESProducer() override ;
 
   typedef std::shared_ptr<FastTimeGeometry> ReturnType;
 

--- a/Geometry/HGCalGeometry/plugins/HGCalGeometryESProducer.cc
+++ b/Geometry/HGCalGeometry/plugins/HGCalGeometryESProducer.cc
@@ -39,7 +39,7 @@ class HGCalGeometryESProducer : public edm::ESProducer {
 
 public:
   HGCalGeometryESProducer( const edm::ParameterSet& iP );
-  virtual ~HGCalGeometryESProducer() ;
+  ~HGCalGeometryESProducer() override ;
 
   typedef std::shared_ptr<HGCalGeometry> ReturnType;
 

--- a/Geometry/HGCalGeometry/test/FastTimeGeometryTester.cc
+++ b/Geometry/HGCalGeometry/test/FastTimeGeometryTester.cc
@@ -21,7 +21,7 @@
 class FastTimeGeometryTester : public edm::one::EDAnalyzer<> {
 public:
   explicit FastTimeGeometryTester(const edm::ParameterSet& );
-  ~FastTimeGeometryTester();
+  ~FastTimeGeometryTester() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/HGCalGeometry/test/HGCalGeometryTester.cc
+++ b/Geometry/HGCalGeometry/test/HGCalGeometryTester.cc
@@ -22,7 +22,7 @@
 class HGCalGeometryTester : public edm::one::EDAnalyzer<> {
 public:
   explicit HGCalGeometryTester(const edm::ParameterSet& );
-  ~HGCalGeometryTester();
+  ~HGCalGeometryTester() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/HGCalGeometry/test/HGCalTestRecHitTool.cc
+++ b/Geometry/HGCalGeometry/test/HGCalTestRecHitTool.cc
@@ -28,7 +28,7 @@
 class HGCalTestRecHitTool : public edm::one::EDAnalyzer<> {
 public:
   explicit HGCalTestRecHitTool(const edm::ParameterSet& );
-  ~HGCalTestRecHitTool();
+  ~HGCalTestRecHitTool() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/HcalAlgo/plugins/DDHCalAngular.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalAngular.h
@@ -11,15 +11,15 @@ class DDHCalAngular : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDHCalAngular(); 
-  virtual ~DDHCalAngular();
+  ~DDHCalAngular() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/HcalAlgo/plugins/DDHCalBarrelAlgo.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalBarrelAlgo.h
@@ -11,7 +11,7 @@ class DDHCalBarrelAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDHCalBarrelAlgo(); //const std::string & name);
-  virtual ~DDHCalBarrelAlgo();
+  ~DDHCalBarrelAlgo() override;
   
   //Get Methods
   std::string getGenMaterial()                const {return genMaterial;}
@@ -80,9 +80,9 @@ class DDHCalBarrelAlgo : public DDAlgorithm {
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 protected:
 

--- a/Geometry/HcalAlgo/plugins/DDHCalEndcapAlgo.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalEndcapAlgo.h
@@ -11,7 +11,7 @@ class DDHCalEndcapAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDHCalEndcapAlgo(); //const std::string & name);
-  virtual ~DDHCalEndcapAlgo();
+  ~DDHCalEndcapAlgo() override;
   
   //Get Methods
   std::string getGenMat()                  const {return genMaterial;}
@@ -81,9 +81,9 @@ class DDHCalEndcapAlgo : public DDAlgorithm {
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 protected:
 

--- a/Geometry/HcalAlgo/plugins/DDHCalEndcapModuleAlgo.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalEndcapModuleAlgo.h
@@ -12,7 +12,7 @@ class DDHCalEndcapModuleAlgo : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDHCalEndcapModuleAlgo(); //const std::string & name);
-  virtual ~DDHCalEndcapModuleAlgo();
+  ~DDHCalEndcapModuleAlgo() override;
   
   struct HcalEndcapPar {
     double yh1, bl1, tl1, yh2, bl2, tl2, alp, theta, phi, xpos, ypos, zpos;
@@ -26,8 +26,8 @@ public:
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
-  void execute(DDCompactView& cpv);
+		  const DDStringVectorArguments & vsArgs) override;
+  void execute(DDCompactView& cpv) override;
 
 protected:
 

--- a/Geometry/HcalAlgo/plugins/DDHCalFibreBundle.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalFibreBundle.h
@@ -12,15 +12,15 @@ class DDHCalFibreBundle : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDHCalFibreBundle(); 
-  virtual ~DDHCalFibreBundle();
+  ~DDHCalFibreBundle() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/HcalAlgo/plugins/DDHCalForwardAlgo.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalForwardAlgo.h
@@ -11,15 +11,15 @@ class DDHCalForwardAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDHCalForwardAlgo(); //const std::string & name);
-  virtual ~DDHCalForwardAlgo();
+  ~DDHCalForwardAlgo() override;
 
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/HcalAlgo/plugins/DDHCalLinearXY.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalLinearXY.h
@@ -12,15 +12,15 @@ class DDHCalLinearXY : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDHCalLinearXY(); 
-  virtual ~DDHCalLinearXY();
+  ~DDHCalLinearXY() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/HcalAlgo/plugins/DDHCalTBCableAlgo.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalTBCableAlgo.h
@@ -11,15 +11,15 @@ class DDHCalTBCableAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDHCalTBCableAlgo(); //const std::string & name);
-  virtual ~DDHCalTBCableAlgo();
+  ~DDHCalTBCableAlgo() override;
 
   void initialize(const DDNumericArguments & nArgs,
 			  const DDVectorArguments & vArgs,
 			  const DDMapArguments & mArgs,
 			  const DDStringArguments & sArgs,
-			  const DDStringVectorArguments & vsArgs);
+			  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/HcalAlgo/plugins/DDHCalTBZposAlgo.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalTBZposAlgo.h
@@ -11,15 +11,15 @@ class DDHCalTBZposAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDHCalTBZposAlgo(); 
-  virtual ~DDHCalTBZposAlgo();
+  ~DDHCalTBZposAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/HcalAlgo/plugins/DDHCalTestBeamAlgo.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalTestBeamAlgo.h
@@ -11,15 +11,15 @@ class DDHCalTestBeamAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDHCalTestBeamAlgo(); 
-  virtual ~DDHCalTestBeamAlgo();
+  ~DDHCalTestBeamAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/HcalAlgo/plugins/DDHCalXtalAlgo.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalXtalAlgo.h
@@ -11,15 +11,15 @@ class DDHCalXtalAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDHCalXtalAlgo(); 
-  virtual ~DDHCalXtalAlgo();
+  ~DDHCalXtalAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/HcalCommonData/plugins/HcalDDDRecConstantsESMoudle.cc
+++ b/Geometry/HcalCommonData/plugins/HcalDDDRecConstantsESMoudle.cc
@@ -38,7 +38,7 @@ class HcalDDDRecConstantsESModule : public edm::ESProducer {
 
 public:
   HcalDDDRecConstantsESModule(const edm::ParameterSet&);
-  ~HcalDDDRecConstantsESModule();
+  ~HcalDDDRecConstantsESModule() override;
 
   typedef std::shared_ptr<HcalDDDRecConstants> ReturnType;
 

--- a/Geometry/HcalCommonData/plugins/HcalDDDSimConstantsESModule.cc
+++ b/Geometry/HcalCommonData/plugins/HcalDDDSimConstantsESModule.cc
@@ -34,7 +34,7 @@ class HcalDDDSimConstantsESModule : public edm::ESProducer {
 
 public:
   HcalDDDSimConstantsESModule(const edm::ParameterSet&);
-  ~HcalDDDSimConstantsESModule();
+  ~HcalDDDSimConstantsESModule() override;
 
   typedef std::shared_ptr<HcalDDDSimConstants> ReturnType;
 

--- a/Geometry/HcalCommonData/plugins/HcalParametersESModule.cc
+++ b/Geometry/HcalCommonData/plugins/HcalParametersESModule.cc
@@ -16,7 +16,7 @@
 class  HcalParametersESModule : public edm::ESProducer {
 public:
   HcalParametersESModule( const edm::ParameterSet & );
-  ~HcalParametersESModule( void );
+  ~HcalParametersESModule( void ) override;
   
   typedef std::shared_ptr<HcalParameters> ReturnType;
 

--- a/Geometry/HcalCommonData/test/HcalParametersAnalyzer.cc
+++ b/Geometry/HcalCommonData/test/HcalParametersAnalyzer.cc
@@ -9,7 +9,7 @@
 class HcalParametersAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit HcalParametersAnalyzer( const edm::ParameterSet& );
-  ~HcalParametersAnalyzer( void );
+  ~HcalParametersAnalyzer( void ) override;
   
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/HcalCommonData/test/HcalRecNumberingTester.cc
+++ b/Geometry/HcalCommonData/test/HcalRecNumberingTester.cc
@@ -43,7 +43,7 @@
 class HcalRecNumberingTester : public edm::one::EDAnalyzer<> {
 public:
   explicit HcalRecNumberingTester( const edm::ParameterSet& );
-  ~HcalRecNumberingTester();
+  ~HcalRecNumberingTester() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/HcalCommonData/test/HcalSimNumberingTester.cc
+++ b/Geometry/HcalCommonData/test/HcalSimNumberingTester.cc
@@ -42,7 +42,7 @@
 class HcalSimNumberingTester : public edm::one::EDAnalyzer<> {
 public:
   explicit HcalSimNumberingTester( const edm::ParameterSet& );
-  ~HcalSimNumberingTester();
+  ~HcalSimNumberingTester() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/HcalEventSetup/interface/CaloTowerTopologyEP.h
+++ b/Geometry/HcalEventSetup/interface/CaloTowerTopologyEP.h
@@ -27,7 +27,7 @@ class CaloTowerTopologyEP : public edm::ESProducer {
 
 public:
   CaloTowerTopologyEP(const edm::ParameterSet&);
-  ~CaloTowerTopologyEP();
+  ~CaloTowerTopologyEP() override;
 
   typedef std::shared_ptr<CaloTowerTopology> ReturnType;
 

--- a/Geometry/HcalEventSetup/interface/HcalAlignmentEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalAlignmentEP.h
@@ -28,7 +28,7 @@ public:
   typedef AlignTransform::Rotation    Rot ;
 
   HcalAlignmentEP(const edm::ParameterSet&);
-  ~HcalAlignmentEP();
+  ~HcalAlignmentEP() override;
 
 //-------------------------------------------------------------------
  

--- a/Geometry/HcalEventSetup/interface/HcalDDDGeometryEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalDDDGeometryEP.h
@@ -25,7 +25,7 @@ class HcalDDDGeometryEP : public edm::ESProducer {
 public:
 
   HcalDDDGeometryEP(const edm::ParameterSet&);
-  ~HcalDDDGeometryEP();
+  ~HcalDDDGeometryEP() override;
 
   typedef std::shared_ptr<CaloSubdetectorGeometry> ReturnType;
  

--- a/Geometry/HcalEventSetup/interface/HcalHardcodeGeometryEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalHardcodeGeometryEP.h
@@ -17,7 +17,7 @@ class HcalHardcodeGeometryEP : public edm::ESProducer {
 
 public:
   HcalHardcodeGeometryEP(const edm::ParameterSet&);
-  virtual ~HcalHardcodeGeometryEP();
+  ~HcalHardcodeGeometryEP() override;
 
   typedef std::shared_ptr<CaloSubdetectorGeometry> ReturnType;
 

--- a/Geometry/HcalEventSetup/interface/HcalTopologyIdealEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalTopologyIdealEP.h
@@ -26,7 +26,7 @@ class HcalTopologyIdealEP : public edm::ESProducer {
 
 public:
   HcalTopologyIdealEP(const edm::ParameterSet&);
-  ~HcalTopologyIdealEP();
+  ~HcalTopologyIdealEP() override;
 
   typedef std::shared_ptr<HcalTopology> ReturnType;
 

--- a/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.h
+++ b/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.h
@@ -23,7 +23,7 @@ class IdealGeometryRecord;
 class CaloTowerHardcodeGeometryEP : public edm::ESProducer {
 public:
   CaloTowerHardcodeGeometryEP(const edm::ParameterSet&);
-  ~CaloTowerHardcodeGeometryEP();
+  ~CaloTowerHardcodeGeometryEP() override;
 
   typedef std::unique_ptr<CaloSubdetectorGeometry> ReturnType;
 

--- a/Geometry/HcalEventSetup/test/HcalDDDGeometryAnalyzer.cc
+++ b/Geometry/HcalEventSetup/test/HcalDDDGeometryAnalyzer.cc
@@ -47,7 +47,7 @@ class HcalDDDGeometryAnalyzer : public edm::one::EDAnalyzer<>
 public:
 
   explicit HcalDDDGeometryAnalyzer( const edm::ParameterSet& );
-  ~HcalDDDGeometryAnalyzer();
+  ~HcalDDDGeometryAnalyzer() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/HcalTestBeamData/plugins/DDEcalPreshowerAlgoTB.h
+++ b/Geometry/HcalTestBeamData/plugins/DDEcalPreshowerAlgoTB.h
@@ -14,8 +14,8 @@ public:
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
-  void execute(DDCompactView& pos);
+		  const DDStringVectorArguments & vsArgs) override;
+  void execute(DDCompactView& pos) override;
 
 private:
   std::string getMaterial(unsigned int i)   const {return materials_[i];}

--- a/Geometry/HcalTowerAlgo/interface/CaloTowerGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/CaloTowerGeometry.h
@@ -36,13 +36,13 @@ class CaloTowerGeometry : public CaloSubdetectorGeometry
 
       static std::string dbString() { return "PCaloTowerRcd" ; }
 
-      virtual unsigned int numberOfShapes() const { return k_NumberOfShapes ; }
-      virtual unsigned int numberOfParametersPerShape() const { return k_NumberOfParametersPerShape ; }
+      unsigned int numberOfShapes() const override { return k_NumberOfShapes ; }
+      unsigned int numberOfParametersPerShape() const override { return k_NumberOfParametersPerShape ; }
       virtual unsigned int numberOfCellsForCorners() const { return k_NumberOfCellsForCorners ; }
 
 
       CaloTowerGeometry(const CaloTowerTopology *cttopo_);
-      virtual ~CaloTowerGeometry();  
+      ~CaloTowerGeometry() override;  
 
       static std::string producerTag() { return "TOWER" ; }
 
@@ -59,26 +59,26 @@ class CaloTowerGeometry : public CaloSubdetectorGeometry
 				unsigned int    i   ,
 				Pt3D&           ref   ) ;
 
-      virtual void newCell( const GlobalPoint& f1 ,
+      void newCell( const GlobalPoint& f1 ,
 			    const GlobalPoint& f2 ,
 			    const GlobalPoint& f3 ,
 			    const CCGFloat*    parm,
-			    const DetId&       detId     ) ;
+			    const DetId&       detId     ) override ;
 				
-      virtual const CaloCellGeometry* getGeometry( const DetId& id ) const {
+      const CaloCellGeometry* getGeometry( const DetId& id ) const override {
           return cellGeomPtr( cttopo->denseIndex(id) ) ;
       }
 
-  virtual void getSummary( CaloSubdetectorGeometry::TrVec&  trVector,
+  void getSummary( CaloSubdetectorGeometry::TrVec&  trVector,
 			   CaloSubdetectorGeometry::IVec&   iVector,
 			   CaloSubdetectorGeometry::DimVec& dimVector,
-			   CaloSubdetectorGeometry::IVec& dinsVector ) const ;
+			   CaloSubdetectorGeometry::IVec& dinsVector ) const override ;
 
    protected:
 
-      virtual const CaloCellGeometry* cellGeomPtr( uint32_t index ) const ;
-      virtual unsigned int indexFor(const DetId& id) const { return  cttopo->denseIndex(id); }
-      virtual unsigned int sizeForDenseIndex(const DetId& id) const { return cttopo->sizeForDenseIndexing(); }
+      const CaloCellGeometry* cellGeomPtr( uint32_t index ) const override ;
+      unsigned int indexFor(const DetId& id) const override { return  cttopo->denseIndex(id); }
+      unsigned int sizeForDenseIndex(const DetId& id) const override { return cttopo->sizeForDenseIndexing(); }
 
    private:
       const CaloTowerTopology* cttopo;

--- a/Geometry/HcalTowerAlgo/interface/HcalDDDGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalDDDGeometry.h
@@ -27,24 +27,24 @@ public:
 
   explicit HcalDDDGeometry(const HcalTopology& theTopo);
   /// The HcalDDDGeometry will delete all its cell geometries at destruction time
-  virtual ~HcalDDDGeometry();
+  ~HcalDDDGeometry() override;
   
-  virtual const std::vector<DetId>& getValidDetIds( DetId::Detector det    = DetId::Detector ( 0 ) , 
-						    int             subdet = 0   ) const;
+  const std::vector<DetId>& getValidDetIds( DetId::Detector det    = DetId::Detector ( 0 ) , 
+						    int             subdet = 0   ) const override;
 
-  virtual DetId getClosestCell(const GlobalPoint& r) const ;
+  DetId getClosestCell(const GlobalPoint& r) const override ;
 
   int insertCell (std::vector<HcalCellType> const & );
 
-  virtual void newCell( const GlobalPoint& f1 ,
+  void newCell( const GlobalPoint& f1 ,
 			const GlobalPoint& f2 ,
 			const GlobalPoint& f3 ,
 			const CCGFloat*    parm,
-			const DetId&       detId     ) ;
+			const DetId&       detId     ) override ;
 					
 protected:
 
-  virtual const CaloCellGeometry* cellGeomPtr( uint32_t index ) const ;
+  const CaloCellGeometry* cellGeomPtr( uint32_t index ) const override ;
 
 private:
 

--- a/Geometry/HcalTowerAlgo/interface/HcalGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalGeometry.h
@@ -40,21 +40,21 @@ public:
 
   static std::string dbString() { return "PHcalRcd" ; }
 
-  virtual unsigned int numberOfShapes() const { return m_topology.getNumberOfShapes() ; }
-  virtual unsigned int numberOfParametersPerShape() const { return k_NumberOfParametersPerShape ; }
+  unsigned int numberOfShapes() const override { return m_topology.getNumberOfShapes() ; }
+  unsigned int numberOfParametersPerShape() const override { return k_NumberOfParametersPerShape ; }
 
   explicit HcalGeometry(const HcalTopology& topology);
 
   /// The HcalGeometry will delete all its cell geometries at destruction time
-  virtual ~HcalGeometry();
+  ~HcalGeometry() override;
   
-  virtual const std::vector<DetId>& getValidDetIds(DetId::Detector det    = DetId::Detector ( 0 ), 
-						   int             subdet = 0 ) const;
+  const std::vector<DetId>& getValidDetIds(DetId::Detector det    = DetId::Detector ( 0 ), 
+						   int             subdet = 0 ) const override;
 
-  virtual DetId getClosestCell(const GlobalPoint& r) const ;
+  DetId getClosestCell(const GlobalPoint& r) const override ;
       
-  virtual CaloSubdetectorGeometry::DetIdSet getCells( const GlobalPoint& r,
-						      double             dR ) const ;
+  CaloSubdetectorGeometry::DetIdSet getCells( const GlobalPoint& r,
+						      double             dR ) const override ;
 
   GlobalPoint                   getPosition(const DetId& id) const;
   GlobalPoint                   getBackPosition(const DetId& id) const;
@@ -99,29 +99,29 @@ public:
 		     unsigned int    i   ,
 		     Pt3D&           ref   ) ;
   
-  virtual void newCell( const GlobalPoint& f1 ,
+  void newCell( const GlobalPoint& f1 ,
 			const GlobalPoint& f2 ,
 			const GlobalPoint& f3 ,
 			const CCGFloat*    parm,
-			const DetId&       detId     ) ;
+			const DetId&       detId     ) override ;
 
-  virtual const CaloCellGeometry* getGeometry( const DetId& id ) const {
+  const CaloCellGeometry* getGeometry( const DetId& id ) const override {
       return cellGeomPtr( m_topology.detId2denseId( id ) ) ;
   }
 
-  virtual void getSummary( CaloSubdetectorGeometry::TrVec&  trVector,
+  void getSummary( CaloSubdetectorGeometry::TrVec&  trVector,
 			   CaloSubdetectorGeometry::IVec&   iVector,
 			   CaloSubdetectorGeometry::DimVec& dimVector,
-			   CaloSubdetectorGeometry::IVec& dinsVector ) const ;
+			   CaloSubdetectorGeometry::IVec& dinsVector ) const override ;
 
   const HcalTopology& topology() const { return m_topology; }
 
 protected:
 
-  virtual const CaloCellGeometry* cellGeomPtr( unsigned int index ) const ;
+  const CaloCellGeometry* cellGeomPtr( unsigned int index ) const override ;
 
-  virtual unsigned int indexFor(const DetId& id) const { return  m_topology.detId2denseId(id); }
-  virtual unsigned int sizeForDenseIndex(const DetId& id) const { return m_topology.ncells(); }
+  unsigned int indexFor(const DetId& id) const override { return  m_topology.detId2denseId(id); }
+  unsigned int sizeForDenseIndex(const DetId& id) const override { return m_topology.ncells(); }
 
 private:
 

--- a/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.h
+++ b/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.h
@@ -15,7 +15,7 @@ class HcalTrigTowerGeometryESProducer : public edm::ESProducer
 {
 public:
   HcalTrigTowerGeometryESProducer( const edm::ParameterSet & conf );
-  virtual ~HcalTrigTowerGeometryESProducer( void );
+  ~HcalTrigTowerGeometryESProducer( void ) override;
 
   std::shared_ptr<HcalTrigTowerGeometry> produce( const CaloGeometryRecord & );
 

--- a/Geometry/HcalTowerAlgo/test/CaloTowerGeometryAnalyzer.cc
+++ b/Geometry/HcalTowerAlgo/test/CaloTowerGeometryAnalyzer.cc
@@ -45,7 +45,7 @@ class CaloTowerGeometryAnalyzer : public edm::one::EDAnalyzer<>
 {
 public:
   explicit CaloTowerGeometryAnalyzer( const edm::ParameterSet& );
-  ~CaloTowerGeometryAnalyzer( void );
+  ~CaloTowerGeometryAnalyzer( void ) override;
     
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/HcalTowerAlgo/test/HcalDetIdTester.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalDetIdTester.cc
@@ -14,7 +14,7 @@ class HcalDetIdTester : public edm::one::EDAnalyzer<> {
 
 public:
   explicit HcalDetIdTester( const edm::ParameterSet& );
-  ~HcalDetIdTester( void );
+  ~HcalDetIdTester( void ) override;
     
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryAnalyzer.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryAnalyzer.cc
@@ -15,7 +15,7 @@ class HcalGeometryAnalyzer : public edm::one::EDAnalyzer<> {
 
 public:
   explicit HcalGeometryAnalyzer( const edm::ParameterSet& );
-  ~HcalGeometryAnalyzer( void );
+  ~HcalGeometryAnalyzer( void ) override;
     
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryDetIdAnalyzer.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryDetIdAnalyzer.cc
@@ -13,7 +13,7 @@
 class HcalGeometryDetIdAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit HcalGeometryDetIdAnalyzer( const edm::ParameterSet& );
-  ~HcalGeometryDetIdAnalyzer( void );
+  ~HcalGeometryDetIdAnalyzer( void ) override;
     
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryDump.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryDump.cc
@@ -14,7 +14,7 @@ class HcalGeometryDump : public edm::one::EDAnalyzer<> {
 
 public:
   explicit HcalGeometryDump( const edm::ParameterSet& );
-  ~HcalGeometryDump( void );
+  ~HcalGeometryDump( void ) override;
     
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryPlan1Tester.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryPlan1Tester.cc
@@ -16,7 +16,7 @@ class HcalGeometryPlan1Tester : public edm::one::EDAnalyzer<> {
 
 public:
   explicit HcalGeometryPlan1Tester( const edm::ParameterSet& );
-  ~HcalGeometryPlan1Tester( void ) {}
+  ~HcalGeometryPlan1Tester( void ) override {}
     
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryTester.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryTester.cc
@@ -18,7 +18,7 @@ class HcalGeometryTester : public edm::one::EDAnalyzer<> {
 
 public:
   explicit HcalGeometryTester( const edm::ParameterSet& );
-  ~HcalGeometryTester( void ) {}
+  ~HcalGeometryTester( void ) override {}
     
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;

--- a/Geometry/MTCCTrackerCommonData/plugins/DDTIBLayerAlgo_MTCC.h
+++ b/Geometry/MTCCTrackerCommonData/plugins/DDTIBLayerAlgo_MTCC.h
@@ -11,15 +11,15 @@ class DDTIBLayerAlgo_MTCC : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDTIBLayerAlgo_MTCC(); 
-  virtual ~DDTIBLayerAlgo_MTCC();
+  ~DDTIBLayerAlgo_MTCC() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/MTCCTrackerCommonData/plugins/DDTIBRadCableAlgo_MTCC.h
+++ b/Geometry/MTCCTrackerCommonData/plugins/DDTIBRadCableAlgo_MTCC.h
@@ -11,15 +11,15 @@ class DDTIBRadCableAlgo_MTCC : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDTIBRadCableAlgo_MTCC(); 
-  virtual ~DDTIBRadCableAlgo_MTCC();
+  ~DDTIBRadCableAlgo_MTCC() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/MuonCommonData/plugins/DDGEMAngular.h
+++ b/Geometry/MuonCommonData/plugins/DDGEMAngular.h
@@ -11,15 +11,15 @@ class DDGEMAngular : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDGEMAngular(); 
-  virtual ~DDGEMAngular();
+  ~DDGEMAngular() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/MuonCommonData/plugins/DDMuonAngular.h
+++ b/Geometry/MuonCommonData/plugins/DDMuonAngular.h
@@ -11,15 +11,15 @@ class DDMuonAngular : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDMuonAngular(); 
-  virtual ~DDMuonAngular();
+  ~DDMuonAngular() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/MuonNumbering/interface/CSCNumberingScheme.h
+++ b/Geometry/MuonNumbering/interface/CSCNumberingScheme.h
@@ -21,9 +21,9 @@ class CSCNumberingScheme : public MuonNumberingScheme {
 
   CSCNumberingScheme( const MuonDDDConstants& muonConstants );
   CSCNumberingScheme( const DDCompactView& cpv );
-  ~CSCNumberingScheme(){};
+  ~CSCNumberingScheme() override{};
   
-  virtual int baseNumberToUnitNumber(const MuonBaseNumber&);
+  int baseNumberToUnitNumber(const MuonBaseNumber&) override;
   
  private:
 

--- a/Geometry/MuonNumbering/interface/DTNumberingScheme.h
+++ b/Geometry/MuonNumbering/interface/DTNumberingScheme.h
@@ -22,9 +22,9 @@ class DTNumberingScheme : public MuonNumberingScheme {
 
   DTNumberingScheme( const DDCompactView& cpv );
   DTNumberingScheme( const MuonDDDConstants& muonConstants );
-  ~DTNumberingScheme(){}
+  ~DTNumberingScheme() override{}
   
-  virtual int baseNumberToUnitNumber(const MuonBaseNumber& num);
+  int baseNumberToUnitNumber(const MuonBaseNumber& num) override;
 
   int getDetId(const MuonBaseNumber& num) const;
   

--- a/Geometry/MuonNumbering/interface/GEMNumberingScheme.h
+++ b/Geometry/MuonNumbering/interface/GEMNumberingScheme.h
@@ -14,9 +14,9 @@ public:
   GEMNumberingScheme( const DDCompactView& cpv );
   GEMNumberingScheme( const MuonDDDConstants& muonConstants );
 
-  virtual ~GEMNumberingScheme(){};
+  ~GEMNumberingScheme() override{};
   
-  virtual int baseNumberToUnitNumber(const MuonBaseNumber&);
+  int baseNumberToUnitNumber(const MuonBaseNumber&) override;
   
 private:
   void initMe ( const MuonDDDConstants& muonConstants );

--- a/Geometry/MuonNumbering/interface/ME0NumberingScheme.h
+++ b/Geometry/MuonNumbering/interface/ME0NumberingScheme.h
@@ -14,9 +14,9 @@ public:
   ME0NumberingScheme( const DDCompactView& cpv );
   ME0NumberingScheme( const MuonDDDConstants& muonConstants );
   
-  virtual ~ME0NumberingScheme(){};
+  ~ME0NumberingScheme() override{};
   
-  virtual int baseNumberToUnitNumber(const MuonBaseNumber&);
+  int baseNumberToUnitNumber(const MuonBaseNumber&) override;
   
 private:
   void initMe ( const MuonDDDConstants& muonConstants );

--- a/Geometry/MuonNumbering/interface/MuonSimHitNumberingScheme.h
+++ b/Geometry/MuonNumbering/interface/MuonSimHitNumberingScheme.h
@@ -23,9 +23,9 @@ class MuonSimHitNumberingScheme : public MuonNumberingScheme {
 
   MuonSimHitNumberingScheme(MuonSubDetector*, const DDCompactView& cpv);
   MuonSimHitNumberingScheme(MuonSubDetector*, const MuonDDDConstants& muonConstants);
-  ~MuonSimHitNumberingScheme();
+  ~MuonSimHitNumberingScheme() override;
   
-  virtual int baseNumberToUnitNumber(const MuonBaseNumber&);
+  int baseNumberToUnitNumber(const MuonBaseNumber&) override;
   
  private:
 

--- a/Geometry/MuonNumbering/interface/RPCNumberingScheme.h
+++ b/Geometry/MuonNumbering/interface/RPCNumberingScheme.h
@@ -22,9 +22,9 @@ class RPCNumberingScheme : public MuonNumberingScheme {
   RPCNumberingScheme( const DDCompactView& cpv );
   RPCNumberingScheme( const MuonDDDConstants& muonConstants );
 
-  virtual ~RPCNumberingScheme(){};
+  ~RPCNumberingScheme() override{};
   
-  virtual int baseNumberToUnitNumber(const MuonBaseNumber&);
+  int baseNumberToUnitNumber(const MuonBaseNumber&) override;
   
  private:
   void initMe ( const MuonDDDConstants& muonConstants );

--- a/Geometry/MuonNumbering/plugins/MuonNumberingInitialization.cc
+++ b/Geometry/MuonNumbering/plugins/MuonNumberingInitialization.cc
@@ -34,7 +34,7 @@ class MuonNumberingInitialization : public edm::ESProducer
 public:
   
   MuonNumberingInitialization( const edm::ParameterSet& );
-  ~MuonNumberingInitialization();
+  ~MuonNumberingInitialization() override;
 
   typedef std::unique_ptr<MuonDDDConstants> ReturnType;
 

--- a/Geometry/MuonNumbering/test/MuonNumberingTester.cc
+++ b/Geometry/MuonNumbering/test/MuonNumberingTester.cc
@@ -46,7 +46,7 @@ class MuonNumberingTester : public edm::one::EDAnalyzer<>
 {
 public:
   explicit MuonNumberingTester( const edm::ParameterSet& );
-  ~MuonNumberingTester();
+  ~MuonNumberingTester() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/RPCGeometry/interface/RPCChamber.h
+++ b/Geometry/RPCGeometry/interface/RPCChamber.h
@@ -21,13 +21,13 @@ public:
   /// Constructor
   RPCChamber(RPCDetId id, const ReferenceCountingPointer<BoundPlane>& plane);
   /// Destructor
-  virtual ~RPCChamber();
+  ~RPCChamber() override;
 
   /// Return the RPCChamberId of this chamber
   RPCDetId id() const;
 
   // Which subdetector
-  virtual SubDetector subDetector() const {return GeomDetEnumerators::RPCBarrel;}
+  SubDetector subDetector() const override {return GeomDetEnumerators::RPCBarrel;}
 
   /// equal if the id is the same
   bool operator==(const RPCChamber& ch) const;
@@ -36,10 +36,10 @@ public:
   void add(RPCRoll* rl);
 
   /// Return the rolls in the chamber
-  virtual std::vector< const GeomDet*> components() const;
+  std::vector< const GeomDet*> components() const override;
 
   /// Return the sub-component (roll) with a given id in this chamber
-  virtual const GeomDet* component(DetId id) const;
+  const GeomDet* component(DetId id) const override;
 
   /// Return the Roll corresponding to the given id 
   const RPCRoll* roll(RPCDetId id) const;

--- a/Geometry/RPCGeometry/interface/RPCGeometry.h
+++ b/Geometry/RPCGeometry/interface/RPCGeometry.h
@@ -26,28 +26,28 @@ class RPCGeometry : public TrackingGeometry {
   RPCGeometry();
 
   /// Destructor
-  virtual ~RPCGeometry();
+  ~RPCGeometry() override;
 
   // Return a vector of all det types
-  virtual const DetTypeContainer&  detTypes() const override;
+  const DetTypeContainer&  detTypes() const override;
 
   // Return a vector of all GeomDetUnit
-  virtual const DetUnitContainer& detUnits() const override;
+  const DetUnitContainer& detUnits() const override;
 
   // Return a vector of all GeomDet
-  virtual const DetContainer& dets() const override;
+  const DetContainer& dets() const override;
   
   // Return a vector of all GeomDetUnit DetIds
-  virtual const DetIdContainer& detUnitIds() const override;
+  const DetIdContainer& detUnitIds() const override;
 
   // Return a vector of all GeomDet DetIds
-  virtual const DetIdContainer& detIds() const override;
+  const DetIdContainer& detIds() const override;
 
   // Return the pointer to the GeomDetUnit corresponding to a given DetId
-  virtual const GeomDetUnit* idToDetUnit(DetId) const override;
+  const GeomDetUnit* idToDetUnit(DetId) const override;
 
   // Return the pointer to the GeomDet corresponding to a given DetId
-  virtual const GeomDet* idToDet(DetId) const override;
+  const GeomDet* idToDet(DetId) const override;
 
 
   //---- Extension of the interface

--- a/Geometry/RPCGeometry/interface/RPCRoll.h
+++ b/Geometry/RPCGeometry/interface/RPCRoll.h
@@ -14,12 +14,12 @@ class RPCRoll : public GeomDetUnit{
  public:
   
   RPCRoll(RPCDetId id, BoundPlane::BoundPlanePointer bp, RPCRollSpecs* rrs);
-  ~RPCRoll();
+  ~RPCRoll() override;
   const RPCRollSpecs* specs() const;
   RPCDetId id() const;
-  const Topology& topology() const;
+  const Topology& topology() const override;
   const StripTopology& specificTopology() const;
-  const GeomDetType& type() const; 
+  const GeomDetType& type() const override; 
  
   /// Return the chamber this roll belongs to 
   const RPCChamber* chamber() const;

--- a/Geometry/RPCGeometry/interface/RPCRollSpecs.h
+++ b/Geometry/RPCGeometry/interface/RPCRollSpecs.h
@@ -23,9 +23,9 @@ class RPCRollSpecs : public GeomDetType {
 
   RPCRollSpecs( SubDetector rss, const std::string& name, const RPCSpecs& pars);
 
-  ~RPCRollSpecs();
+  ~RPCRollSpecs() override;
 
-  const Topology& topology() const;
+  const Topology& topology() const override;
 
   const StripTopology& specificTopology() const;
 

--- a/Geometry/RPCGeometry/test/RPCCSC.cc
+++ b/Geometry/RPCGeometry/test/RPCCSC.cc
@@ -82,7 +82,7 @@ class RPCCSC : public edm::one::EDAnalyzer<>
 {
 public:
   explicit RPCCSC(const edm::ParameterSet&);
-  ~RPCCSC();
+  ~RPCCSC() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/RPCGeometry/test/RPCGEO.cc
+++ b/Geometry/RPCGeometry/test/RPCGEO.cc
@@ -46,7 +46,7 @@ class RPCGEO : public edm::one::EDAnalyzer<>
 {
 public:
   explicit RPCGEO(const edm::ParameterSet&);
-  ~RPCGEO();
+  ~RPCGEO() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/RPCGeometry/test/RPCGEO2.cc
+++ b/Geometry/RPCGeometry/test/RPCGEO2.cc
@@ -55,7 +55,7 @@ class RPCGEO2 : public edm::one::EDAnalyzer<>
 {
 public:
   explicit RPCGEO2(const edm::ParameterSet&);
-  ~RPCGEO2();
+  ~RPCGEO2() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/RPCGeometry/test/RPCGeometryAnalyzer.cc
+++ b/Geometry/RPCGeometry/test/RPCGeometryAnalyzer.cc
@@ -31,7 +31,7 @@ class RPCGeometryAnalyzer : public edm::one::EDAnalyzer<> {
  public: 
   RPCGeometryAnalyzer( const edm::ParameterSet& pset);
 
-  ~RPCGeometryAnalyzer();
+  ~RPCGeometryAnalyzer() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/RPCGeometry/test/RPCRadiiAnalyzer.cc
+++ b/Geometry/RPCGeometry/test/RPCRadiiAnalyzer.cc
@@ -33,7 +33,7 @@ class RPCRadiiAnalyzer : public edm::one::EDAnalyzer<> {
  public: 
   RPCRadiiAnalyzer( const edm::ParameterSet& pset);
 
-  ~RPCRadiiAnalyzer();
+  ~RPCRadiiAnalyzer() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/RPCGeometry/test/RPCSectorAnalyzer.cc
+++ b/Geometry/RPCGeometry/test/RPCSectorAnalyzer.cc
@@ -32,7 +32,7 @@ class RPCSectorAnalyzer : public edm::one::EDAnalyzer<> {
  public: 
   RPCSectorAnalyzer( const edm::ParameterSet& pset);
 
-  ~RPCSectorAnalyzer();
+  ~RPCSectorAnalyzer() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/RPCGeometryBuilder/plugins/RPCGeometryESModule.h
+++ b/Geometry/RPCGeometryBuilder/plugins/RPCGeometryESModule.h
@@ -20,7 +20,7 @@ public:
   RPCGeometryESModule(const edm::ParameterSet & p);
 
   /// Destructor
-  virtual ~RPCGeometryESModule();
+  ~RPCGeometryESModule() override;
 
   /// Produce RPCGeometry.
   std::shared_ptr<RPCGeometry>  produce(const MuonGeometryRecord & record);

--- a/Geometry/TrackerCommonData/plugins/DDCutTubsFromPoints.h
+++ b/Geometry/TrackerCommonData/plugins/DDCutTubsFromPoints.h
@@ -15,15 +15,15 @@ class DDCutTubsFromPoints : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDCutTubsFromPoints(); 
-  virtual ~DDCutTubsFromPoints();
+  ~DDCutTubsFromPoints() override;
   
   void initialize(const DDNumericArguments & nArgs,
                   const DDVectorArguments & vArgs,
                   const DDMapArguments & mArgs,
                   const DDStringArguments & sArgs,
-                  const DDStringVectorArguments & vsArgs);
+                  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
   struct Section {

--- a/Geometry/TrackerCommonData/plugins/DDPixBarLayerAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDPixBarLayerAlgo.h
@@ -11,15 +11,15 @@ class DDPixBarLayerAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDPixBarLayerAlgo(); 
-  virtual ~DDPixBarLayerAlgo();
+  ~DDPixBarLayerAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDPixBarLayerUpgradeAlgo.h
@@ -11,15 +11,15 @@ class DDPixBarLayerUpgradeAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDPixBarLayerUpgradeAlgo(); 
-  virtual ~DDPixBarLayerUpgradeAlgo();
+  ~DDPixBarLayerUpgradeAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDPixFwdBlades.h
+++ b/Geometry/TrackerCommonData/plugins/DDPixFwdBlades.h
@@ -68,7 +68,7 @@ public:
   // Constructors & Destructor :  --------------------------------------------------------
 
   DDPixFwdBlades(); 
-  virtual ~DDPixFwdBlades();
+  ~DDPixFwdBlades() override;
   
   // Initialization & Execution :  -------------------------------------------------------
   
@@ -76,9 +76,9 @@ public:
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
   
   // -------------------------------------------------------------------------------------
 

--- a/Geometry/TrackerCommonData/plugins/DDPixFwdDiskAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDPixFwdDiskAlgo.h
@@ -11,15 +11,15 @@ class DDPixFwdDiskAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDPixFwdDiskAlgo(); 
-  virtual ~DDPixFwdDiskAlgo();
+  ~DDPixFwdDiskAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDPixPhase1FwdDiskAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDPixPhase1FwdDiskAlgo.h
@@ -11,15 +11,15 @@ class DDPixPhase1FwdDiskAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDPixPhase1FwdDiskAlgo(); 
-  virtual ~DDPixPhase1FwdDiskAlgo();
+  ~DDPixPhase1FwdDiskAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTECAxialCableAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTECAxialCableAlgo.h
@@ -12,15 +12,15 @@ class DDTECAxialCableAlgo : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDTECAxialCableAlgo(); 
-  virtual ~DDTECAxialCableAlgo();
+  ~DDTECAxialCableAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTECCoolAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTECCoolAlgo.h
@@ -11,15 +11,15 @@ class DDTECCoolAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDTECCoolAlgo(); 
-  virtual ~DDTECCoolAlgo();
+  ~DDTECCoolAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
                   const DDVectorArguments & vArgs,
                   const DDMapArguments & mArgs,
                   const DDStringArguments & sArgs,
-                  const DDStringVectorArguments & vsArgs);
+                  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
   std::string              idNameSpace;    //Namespace of this and ALL parts

--- a/Geometry/TrackerCommonData/plugins/DDTECModuleAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTECModuleAlgo.h
@@ -12,15 +12,15 @@ class DDTECModuleAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDTECModuleAlgo(); 
-  virtual ~DDTECModuleAlgo();
+  ~DDTECModuleAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
                   const DDVectorArguments & vArgs,
                   const DDMapArguments & mArgs,
                   const DDStringArguments & sArgs,
-                  const DDStringVectorArguments & vsArgs);
+                  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
   //this positions  toPos in mother

--- a/Geometry/TrackerCommonData/plugins/DDTECOptoHybAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTECOptoHybAlgo.h
@@ -11,15 +11,15 @@ class DDTECOptoHybAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDTECOptoHybAlgo(); 
-  virtual ~DDTECOptoHybAlgo();
+  ~DDTECOptoHybAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
                   const DDVectorArguments & vArgs,
                   const DDMapArguments & mArgs,
                   const DDStringArguments & sArgs,
-                  const DDStringVectorArguments & vsArgs);
+                  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTECPhiAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTECPhiAlgo.h
@@ -12,15 +12,15 @@ class DDTECPhiAlgo : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDTECPhiAlgo(); 
-  virtual ~DDTECPhiAlgo();
+  ~DDTECPhiAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTECPhiAltAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTECPhiAltAlgo.h
@@ -12,15 +12,15 @@ class DDTECPhiAltAlgo : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDTECPhiAltAlgo(); 
-  virtual ~DDTECPhiAltAlgo();
+  ~DDTECPhiAltAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTIBLayerAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTIBLayerAlgo.h
@@ -11,15 +11,15 @@ class DDTIBLayerAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDTIBLayerAlgo(); 
-  virtual ~DDTIBLayerAlgo();
+  ~DDTIBLayerAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTIDAxialCableAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTIDAxialCableAlgo.h
@@ -12,15 +12,15 @@ class DDTIDAxialCableAlgo : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDTIDAxialCableAlgo(); 
-  virtual ~DDTIDAxialCableAlgo();
+  ~DDTIDAxialCableAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTIDModuleAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTIDModuleAlgo.h
@@ -11,15 +11,15 @@ class DDTIDModuleAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDTIDModuleAlgo(); 
-  virtual ~DDTIDModuleAlgo();
+  ~DDTIDModuleAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
                   const DDVectorArguments & vArgs,
                   const DDMapArguments & mArgs,
                   const DDStringArguments & sArgs,
-                  const DDStringVectorArguments & vsArgs);
+                  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTIDModulePosAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTIDModulePosAlgo.h
@@ -11,14 +11,14 @@ class DDTIDModulePosAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDTIDModulePosAlgo(); 
-  virtual ~DDTIDModulePosAlgo();
+  ~DDTIDModulePosAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
                   const DDVectorArguments & vArgs,
                   const DDMapArguments & mArgs,
                   const DDStringArguments & sArgs,
-                  const DDStringVectorArguments & vsArgs);
-  void execute(DDCompactView& cpv);
+                  const DDStringVectorArguments & vsArgs) override;
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTIDRingAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTIDRingAlgo.h
@@ -12,15 +12,15 @@ class DDTIDRingAlgo : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDTIDRingAlgo(); 
-  virtual ~DDTIDRingAlgo();
+  ~DDTIDRingAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTOBAxCableAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTOBAxCableAlgo.h
@@ -11,15 +11,15 @@ class DDTOBAxCableAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDTOBAxCableAlgo(); 
-  virtual ~DDTOBAxCableAlgo();
+  ~DDTOBAxCableAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTOBRadCableAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTOBRadCableAlgo.h
@@ -11,15 +11,15 @@ class DDTOBRadCableAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDTOBRadCableAlgo(); 
-  virtual ~DDTOBRadCableAlgo();
+  ~DDTOBRadCableAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTOBRodAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTOBRodAlgo.h
@@ -11,15 +11,15 @@ class DDTOBRodAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDTOBRodAlgo(); 
-  virtual ~DDTOBRodAlgo();
+  ~DDTOBRodAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTrackerAngular.h
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerAngular.h
@@ -12,15 +12,15 @@ class DDTrackerAngular : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDTrackerAngular(); 
-  virtual ~DDTrackerAngular();
+  ~DDTrackerAngular() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTrackerAngularV1.h
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerAngularV1.h
@@ -12,15 +12,15 @@ class DDTrackerAngularV1 : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDTrackerAngularV1(); 
-  virtual ~DDTrackerAngularV1();
+  ~DDTrackerAngularV1() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTrackerLinear.h
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerLinear.h
@@ -11,15 +11,15 @@ class DDTrackerLinear : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDTrackerLinear(); 
-  virtual ~DDTrackerLinear();
+  ~DDTrackerLinear() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTrackerLinearXY.h
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerLinearXY.h
@@ -11,15 +11,15 @@ class DDTrackerLinearXY : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDTrackerLinearXY(); 
-  virtual ~DDTrackerLinearXY();
+  ~DDTrackerLinearXY() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTrackerPhiAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerPhiAlgo.h
@@ -12,15 +12,15 @@ class DDTrackerPhiAlgo : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDTrackerPhiAlgo(); 
-  virtual ~DDTrackerPhiAlgo();
+  ~DDTrackerPhiAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTrackerPhiAltAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerPhiAltAlgo.h
@@ -12,15 +12,15 @@ class DDTrackerPhiAltAlgo : public DDAlgorithm {
 public:
   //Constructor and Destructor
   DDTrackerPhiAltAlgo(); 
-  virtual ~DDTrackerPhiAltAlgo();
+  ~DDTrackerPhiAltAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTrackerRingAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerRingAlgo.h
@@ -43,15 +43,15 @@ class DDTrackerRingAlgo : public DDAlgorithm {
 public:
   // Constructor and Destructor
   DDTrackerRingAlgo(); 
-  virtual ~DDTrackerRingAlgo();
+  ~DDTrackerRingAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTrackerXYZPosAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerXYZPosAlgo.h
@@ -11,15 +11,15 @@ class DDTrackerXYZPosAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDTrackerXYZPosAlgo(); 
-  virtual ~DDTrackerXYZPosAlgo();
+  ~DDTrackerXYZPosAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerCommonData/plugins/DDTrackerZPosAlgo.h
+++ b/Geometry/TrackerCommonData/plugins/DDTrackerZPosAlgo.h
@@ -11,15 +11,15 @@ class DDTrackerZPosAlgo : public DDAlgorithm {
  public:
   //Constructor and Destructor
   DDTrackerZPosAlgo(); 
-  virtual ~DDTrackerZPosAlgo();
+  ~DDTrackerZPosAlgo() override;
   
   void initialize(const DDNumericArguments & nArgs,
 		  const DDVectorArguments & vArgs,
 		  const DDMapArguments & mArgs,
 		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs);
+		  const DDStringVectorArguments & vsArgs) override;
 
-  void execute(DDCompactView& cpv);
+  void execute(DDCompactView& cpv) override;
 
 private:
 

--- a/Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h
+++ b/Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h
@@ -18,12 +18,12 @@ public:
     GeomDetType(name,det),
     theTopology(t){}
 
-  virtual ~PixelGeomDetType() {
+  ~PixelGeomDetType() override {
     delete theTopology;
   }
 
   // Access to topologies
-  virtual const  Topology& topology() const { return *theTopology;}
+  const  Topology& topology() const override { return *theTopology;}
 
 
   virtual const TopologyType& specificTopology() const  { return *theTopology;}

--- a/Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h
+++ b/Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h
@@ -25,10 +25,10 @@ public:
   /// the proxy topology (through topology() and specificTopology()) which includes
   /// corrections for the surface deformations, and once via the GeomDetType
   /// (through type().topology() and the like).
-  virtual const GeomDetType& type() const override;
+  const GeomDetType& type() const override;
   
   /// Returns a reference to the pixel proxy topology
-  virtual const Topology& topology() const override;
+  const Topology& topology() const override;
 
   /// NOTE (A.M.): The actual pointer to PixelGeomDetType is now a member of the
   /// proxy topology. As PixelGeomDetType has the actual topology as a pointer,
@@ -42,7 +42,7 @@ public:
   virtual const PixelTopology& specificTopology() const;
 
   /// Return pointer to surface deformation.
-  virtual const SurfaceDeformation * surfaceDeformation() const override { 
+  const SurfaceDeformation * surfaceDeformation() const override { 
     return theTopology->surfaceDeformation();
   }
 
@@ -51,7 +51,7 @@ public:
 private:
 
   /// set the SurfaceDeformation for this StripGeomDetUnit to proxy topology.
-  virtual void setSurfaceDeformation(const SurfaceDeformation * deformation) override;
+  void setSurfaceDeformation(const SurfaceDeformation * deformation) override;
 
   std::unique_ptr<ProxyPixelTopology> theTopology;
 };

--- a/Geometry/TrackerGeometryBuilder/interface/ProxyPixelTopology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/ProxyPixelTopology.h
@@ -30,66 +30,66 @@ public:
 
   ProxyPixelTopology( PixelGeomDetType const * type, Plane * bp );
 
-  virtual LocalPoint localPosition( const MeasurementPoint& ) const;
+  LocalPoint localPosition( const MeasurementPoint& ) const override;
   /// conversion taking also the predicted track state 
-  virtual LocalPoint localPosition( const MeasurementPoint& mp,
-				    const Topology::LocalTrackPred &trkPred ) const;
+  LocalPoint localPosition( const MeasurementPoint& mp,
+				    const Topology::LocalTrackPred &trkPred ) const override;
   
-  virtual LocalError localError( const MeasurementPoint&,
-                                 const MeasurementError& ) const;
+  LocalError localError( const MeasurementPoint&,
+                                 const MeasurementError& ) const override;
   /// conversion taking also the predicted track state
-  virtual LocalError localError( const MeasurementPoint& mp,
+  LocalError localError( const MeasurementPoint& mp,
 				 const MeasurementError& me,
-				 const Topology::LocalTrackPred &trkPred ) const;
+				 const Topology::LocalTrackPred &trkPred ) const override;
 
-  virtual MeasurementPoint measurementPosition( const LocalPoint & ) const;
-  virtual MeasurementPoint measurementPosition( const LocalPoint &lp, 
-						const Topology::LocalTrackAngles &dir ) const;
+  MeasurementPoint measurementPosition( const LocalPoint & ) const override;
+  MeasurementPoint measurementPosition( const LocalPoint &lp, 
+						const Topology::LocalTrackAngles &dir ) const override;
 
-  virtual MeasurementError measurementError( const LocalPoint &lp, const LocalError &le ) const;
-  virtual MeasurementError measurementError( const LocalPoint &lp, const LocalError &le,
-					     const Topology::LocalTrackAngles &dir ) const;
+  MeasurementError measurementError( const LocalPoint &lp, const LocalError &le ) const override;
+  MeasurementError measurementError( const LocalPoint &lp, const LocalError &le,
+					     const Topology::LocalTrackAngles &dir ) const override;
 
-  virtual int channel( const LocalPoint& ) const;
-  virtual int channel( const LocalPoint &lp, const Topology::LocalTrackAngles &dir ) const;
+  int channel( const LocalPoint& ) const override;
+  int channel( const LocalPoint &lp, const Topology::LocalTrackAngles &dir ) const override;
   
-  virtual std::pair<float,float> pixel( const LocalPoint& p) const;
+  std::pair<float,float> pixel( const LocalPoint& p) const override;
   /// conversion taking also the angle from the track state
-  virtual std::pair<float,float> pixel( const LocalPoint& p,
-					const Topology::LocalTrackAngles &ltp ) const; 
+  std::pair<float,float> pixel( const LocalPoint& p,
+					const Topology::LocalTrackAngles &ltp ) const override; 
   
-  virtual std::pair<float,float> pitch() const { return specificTopology().pitch(); }
-  virtual int nrows() const { return specificTopology().nrows(); }
-  virtual int ncolumns() const { return specificTopology().ncolumns(); }
-  virtual int rocsY() const { return specificTopology().rocsY(); } 	 
-  virtual int rocsX() const { return specificTopology().rocsX(); } 	 
-  virtual int rowsperroc() const { return specificTopology().rowsperroc(); } 	 
-  virtual int colsperroc() const { return specificTopology().colsperroc(); }
-  virtual float localX( const float mpX ) const;
-  virtual float localX( const float mpX, const Topology::LocalTrackPred &trkPred ) const;
-  virtual float localY( const float mpY ) const;
-  virtual float localY( const float mpY, const Topology::LocalTrackPred &trkPred ) const;
+  std::pair<float,float> pitch() const override { return specificTopology().pitch(); }
+  int nrows() const override { return specificTopology().nrows(); }
+  int ncolumns() const override { return specificTopology().ncolumns(); }
+  int rocsY() const override { return specificTopology().rocsY(); } 	 
+  int rocsX() const override { return specificTopology().rocsX(); } 	 
+  int rowsperroc() const override { return specificTopology().rowsperroc(); } 	 
+  int colsperroc() const override { return specificTopology().colsperroc(); }
+  float localX( const float mpX ) const override;
+  float localX( const float mpX, const Topology::LocalTrackPred &trkPred ) const override;
+  float localY( const float mpY ) const override;
+  float localY( const float mpY, const Topology::LocalTrackPred &trkPred ) const override;
 
-  virtual bool isItBigPixelInX(const int ixbin) const {
+  bool isItBigPixelInX(const int ixbin) const override {
     return specificTopology().isItBigPixelInX(ixbin);
   }
-  virtual bool isItBigPixelInY(const int iybin) const {
+  bool isItBigPixelInY(const int iybin) const override {
     return specificTopology().isItBigPixelInY(iybin);
   }
-  virtual bool containsBigPixelInX(int ixmin, int ixmax) const {
+  bool containsBigPixelInX(int ixmin, int ixmax) const override {
     return specificTopology().containsBigPixelInX(ixmin, ixmax);
   }
-  virtual bool containsBigPixelInY(int iymin, int iymax) const {
+  bool containsBigPixelInY(int iymin, int iymax) const override {
     return specificTopology().containsBigPixelInY(iymin, iymax);
   }
 
-  virtual bool isItEdgePixelInX(int ixbin) const {
+  bool isItEdgePixelInX(int ixbin) const override {
     return specificTopology().isItEdgePixelInX(ixbin);
   }
-  virtual bool isItEdgePixelInY(int iybin) const {
+  bool isItEdgePixelInY(int iybin) const override {
     return specificTopology().isItEdgePixelInY(iybin);
   }
-  virtual bool isItEdgePixel(int ixbin, int iybin) const {
+  bool isItEdgePixel(int ixbin, int iybin) const override {
     return specificTopology().isItEdgePixel(ixbin, iybin);
   }
 

--- a/Geometry/TrackerGeometryBuilder/interface/ProxyStripTopology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/ProxyStripTopology.h
@@ -34,57 +34,57 @@ public:
 
   ProxyStripTopology(StripGeomDetType const * type, Plane * bp);
 
-  virtual LocalPoint localPosition( const MeasurementPoint& mp ) const { return specificTopology().localPosition(mp);}
+  LocalPoint localPosition( const MeasurementPoint& mp ) const override { return specificTopology().localPosition(mp);}
   /// conversion taking also the predicted track state 
-  virtual LocalPoint localPosition( const MeasurementPoint& mp, const Topology::LocalTrackPred &trkPred ) const;
+  LocalPoint localPosition( const MeasurementPoint& mp, const Topology::LocalTrackPred &trkPred ) const override;
 
-  virtual LocalPoint localPosition( float strip ) const {return specificTopology().localPosition(strip);}
+  LocalPoint localPosition( float strip ) const override {return specificTopology().localPosition(strip);}
   /// conversion taking also the predicted track state
-  virtual LocalPoint localPosition( float strip, const Topology::LocalTrackPred &trkPred) const;
+  LocalPoint localPosition( float strip, const Topology::LocalTrackPred &trkPred) const override;
 
-  virtual LocalError localError( float strip, float stripErr2 ) const {return specificTopology().localError(strip, stripErr2);}
+  LocalError localError( float strip, float stripErr2 ) const override {return specificTopology().localError(strip, stripErr2);}
   /// conversion taking also the predicted track state
-  virtual LocalError localError( float strip, float stripErr2, const Topology::LocalTrackPred &trkPred) const;
+  LocalError localError( float strip, float stripErr2, const Topology::LocalTrackPred &trkPred) const override;
 
-  virtual LocalError localError( const MeasurementPoint& mp,
-				 const MeasurementError& me) const { return specificTopology().localError(mp, me);}
+  LocalError localError( const MeasurementPoint& mp,
+				 const MeasurementError& me) const override { return specificTopology().localError(mp, me);}
   /// conversion taking also the predicted track state
-  virtual LocalError localError( const MeasurementPoint& mp,
+  LocalError localError( const MeasurementPoint& mp,
 				 const MeasurementError& me,
-				 const Topology::LocalTrackPred &trkPred) const;
+				 const Topology::LocalTrackPred &trkPred) const override;
   
-  virtual MeasurementPoint measurementPosition( const LocalPoint& lp) const  {return specificTopology().measurementPosition(lp);}
-  virtual MeasurementPoint measurementPosition( const LocalPoint &lp, 
-						const Topology::LocalTrackAngles &dir) const;
+  MeasurementPoint measurementPosition( const LocalPoint& lp) const override  {return specificTopology().measurementPosition(lp);}
+  MeasurementPoint measurementPosition( const LocalPoint &lp, 
+						const Topology::LocalTrackAngles &dir) const override;
 
-  virtual MeasurementError measurementError( const LocalPoint& lp,
-					     const LocalError& le ) const { return specificTopology().measurementError(lp, le); }
-  virtual MeasurementError measurementError( const LocalPoint &lp, const LocalError &le,
-					     const Topology::LocalTrackAngles &dir) const;
+  MeasurementError measurementError( const LocalPoint& lp,
+					     const LocalError& le ) const override { return specificTopology().measurementError(lp, le); }
+  MeasurementError measurementError( const LocalPoint &lp, const LocalError &le,
+					     const Topology::LocalTrackAngles &dir) const override;
   
-  virtual int channel( const LocalPoint& lp) const {return specificTopology().channel(lp);}
-  virtual int channel( const LocalPoint &lp, const Topology::LocalTrackAngles &dir) const;
+  int channel( const LocalPoint& lp) const override {return specificTopology().channel(lp);}
+  int channel( const LocalPoint &lp, const Topology::LocalTrackAngles &dir) const override;
   
-  virtual float strip( const LocalPoint& lp) const { return specificTopology().strip(lp);}
+  float strip( const LocalPoint& lp) const override { return specificTopology().strip(lp);}
   /// conversion taking also the track state (LocalTrajectoryParameters)
-  virtual float strip( const LocalPoint& lp, const Topology::LocalTrackAngles &dir ) const;
+  float strip( const LocalPoint& lp, const Topology::LocalTrackAngles &dir ) const override;
 
-  virtual float coveredStrips(const LocalPoint& lp1, const LocalPoint& lp2)  const {
+  float coveredStrips(const LocalPoint& lp1, const LocalPoint& lp2)  const override {
     return specificTopology().coveredStrips(lp1,lp2);
   }
 
-  virtual float pitch() const { return specificTopology().pitch(); }
-  virtual float localPitch( const LocalPoint& lp) const { return specificTopology().localPitch(lp);}
+  float pitch() const override { return specificTopology().pitch(); }
+  float localPitch( const LocalPoint& lp) const override { return specificTopology().localPitch(lp);}
   /// conversion taking also the angle from the track state (LocalTrajectoryParameters)
-  virtual float localPitch( const LocalPoint& lp, const Topology::LocalTrackAngles &dir ) const;
+  float localPitch( const LocalPoint& lp, const Topology::LocalTrackAngles &dir ) const override;
   
-  virtual float stripAngle( float strip ) const { return specificTopology().stripAngle(strip);}
+  float stripAngle( float strip ) const override { return specificTopology().stripAngle(strip);}
 
-  virtual int nstrips() const {return specificTopology().nstrips();}
+  int nstrips() const override {return specificTopology().nstrips();}
   
-  virtual float stripLength() const {return specificTopology().stripLength();}
-  virtual float localStripLength(const LocalPoint& lp) const { return specificTopology().localStripLength(lp);}
-  virtual float localStripLength( const LocalPoint& lp, const Topology::LocalTrackAngles &dir ) const;
+  float stripLength() const override {return specificTopology().stripLength();}
+  float localStripLength(const LocalPoint& lp) const override { return specificTopology().localStripLength(lp);}
+  float localStripLength( const LocalPoint& lp, const Topology::LocalTrackAngles &dir ) const override;
   
   virtual const GeomDetType& type() const  { return *theType;}
   virtual StripGeomDetType const & specificType() const  { return *theType;}

--- a/Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h
@@ -77,31 +77,31 @@ public:
 
   // Topology interface, go from Masurement to Local corrdinates
   // pixel coordinates (mp) -> cm (LocalPoint)
-  virtual LocalPoint localPosition( const MeasurementPoint& mp ) const;
+  LocalPoint localPosition( const MeasurementPoint& mp ) const override;
 
   // Transform LocalPoint to Measurement. Call pixel().
-  virtual MeasurementPoint measurementPosition( const LocalPoint& lp ) 
-      const {
+  MeasurementPoint measurementPosition( const LocalPoint& lp ) 
+      const override {
     std::pair<float,float> p = pixel( lp );
     return MeasurementPoint( p.first, p.second );
   }
 
   // PixelTopology interface. 
   // Transform LocalPoint in cm to measurement in pitch units.
-  virtual std::pair<float,float> pixel( const LocalPoint& p ) const;
+  std::pair<float,float> pixel( const LocalPoint& p ) const override;
 
   // Errors
   // Error in local (cm) from the masurement errors
-  virtual LocalError localError( const MeasurementPoint&,
-				 const MeasurementError& ) const;
+  LocalError localError( const MeasurementPoint&,
+				 const MeasurementError& ) const override;
   // Errors in pitch units from localpoint error (in cm)
-  virtual MeasurementError measurementError( const LocalPoint&, 
-					     const LocalError& ) const;
+  MeasurementError measurementError( const LocalPoint&, 
+					     const LocalError& ) const override;
   
   //-------------------------------------------------------------
   // Transform LocalPoint to channel. Call pixel()
   //
-  virtual int channel( const LocalPoint& lp ) const {
+  int channel( const LocalPoint& lp ) const override {
     std::pair<float,float> p = pixel( lp );
     return PixelChannelIdentifier::pixelToChannel( int( p.first ), 
 						   int( p.second ));
@@ -110,17 +110,17 @@ public:
   //-------------------------------------------------------------
   // Transform measurement to local coordinates individually in each dimension
   //
-  virtual float localX( const float mpX ) const;
-  virtual float localY( const float mpY ) const;
+  float localX( const float mpX ) const override;
+  float localY( const float mpY ) const override;
 
   //-------------------------------------------------------------
   // Return the BIG pixel information for a given pixel
   //
-  virtual bool isItBigPixelInX( const int ixbin ) const {
+  bool isItBigPixelInX( const int ixbin ) const override {
     return (( m_upgradeGeometry )?(false):(( ixbin == 79 ) | ( ixbin == 80 )));
   } 
 
-  virtual bool isItBigPixelInY( const int iybin ) const {
+  bool isItBigPixelInY( const int iybin ) const override {
       if unlikely( m_upgradeGeometry ) return false;
       else {
 	int iybin0 = iybin%52;
@@ -133,10 +133,10 @@ public:
   //-------------------------------------------------------------
   // Return BIG pixel flag in a given pixel range
   //
-  bool containsBigPixelInX(int ixmin, int ixmax ) const {
+  bool containsBigPixelInX(int ixmin, int ixmax ) const override {
     return m_upgradeGeometry ? false :( (ixmin<=80) & (ixmax>=79) );
   }
-  bool containsBigPixelInY(int iymin, int iymax ) const {
+  bool containsBigPixelInY(int iymin, int iymax ) const override {
     return  m_upgradeGeometry ? false :
       ( isItBigPixelInY( iymin ) || isItBigPixelInY( iymax ) ||  (iymin/52) != (iymax/52) )
       ;  
@@ -146,43 +146,43 @@ public:
   //-------------------------------------------------------------
   // Check whether the pixel is at the edge of the module
   //
-  bool isItEdgePixelInX (int ixbin) const {
+  bool isItEdgePixelInX (int ixbin) const override {
     return ( (ixbin == 0) | (ixbin == (m_nrows-1)) );
   } 
-  bool isItEdgePixelInY (int iybin) const {
+  bool isItEdgePixelInY (int iybin) const override {
     return ( (iybin == 0) | (iybin == (m_ncols-1)) );
   } 
-  bool isItEdgePixel (int ixbin, int iybin) const {
+  bool isItEdgePixel (int ixbin, int iybin) const override {
     return ( isItEdgePixelInX( ixbin ) | isItEdgePixelInY( iybin ) );
   } 
 
   //------------------------------------------------------------------
   // Return pitch
-  virtual std::pair<float,float> pitch() const {
+  std::pair<float,float> pitch() const override {
     return std::pair<float,float>( float(m_pitchx), float(m_pitchy));
   }
   // Return number of rows
-  virtual int nrows() const {
+  int nrows() const override {
     return ( m_nrows );
   }
   // Return number of cols
-  virtual int ncolumns() const {
+  int ncolumns() const override {
     return ( m_ncols );
   }
   // mlw Return number of ROCS Y 	 
-  virtual int rocsY() const { 	 
+  int rocsY() const override { 	 
     return m_ROCS_Y; 	 
   } 	 
   // mlw Return number of ROCS X 	 
-  virtual int rocsX() const { 	 
+  int rocsX() const override { 	 
     return m_ROCS_X; 	 
   } 	 
   // mlw Return number of rows per roc 	 
-  virtual int rowsperroc() const { 	 
+  int rowsperroc() const override { 	 
     return m_ROWS_PER_ROC; 	 
   } 	 
   // mlw Return number of cols per roc 	 
-  virtual int colsperroc() const { 	 
+  int colsperroc() const override { 	 
     return m_COLS_PER_ROC; 	 
   }
   float xoffset() const {

--- a/Geometry/TrackerGeometryBuilder/interface/StackGeomDet.h
+++ b/Geometry/TrackerGeometryBuilder/interface/StackGeomDet.h
@@ -9,13 +9,13 @@ public:
 
   StackGeomDet( BoundPlane* sp, const GeomDetUnit* lowerDet,  const GeomDetUnit* upperDet, const DetId stackDetId);
   
-  virtual ~StackGeomDet();
+  ~StackGeomDet() override;
 
   bool isLeaf() const override { return false;}
-  virtual std::vector<const GeomDet*> components() const override;
+  std::vector<const GeomDet*> components() const override;
 
   // Which subdetector
-  virtual SubDetector subDetector() const override { return theLowerDet->subDetector(); };
+  SubDetector subDetector() const override { return theLowerDet->subDetector(); };
 
   const GeomDetUnit* lowerDet() const { return theLowerDet; };
   const GeomDetUnit* upperDet() const { return theUpperDet; };

--- a/Geometry/TrackerGeometryBuilder/interface/StripGeomDetType.h
+++ b/Geometry/TrackerGeometryBuilder/interface/StripGeomDetType.h
@@ -18,12 +18,12 @@ public:
   StripGeomDetType(TopologyType* t, std::string const & name,SubDetector& det,bool stereo) : GeomDetType(name,det),
     theTopology(t),theStereoFlag(stereo){}
 
-  virtual ~StripGeomDetType() {
+  ~StripGeomDetType() override {
     delete theTopology;
   }
 
   // Access to topologies
-  virtual const Topology&  topology() const { return *theTopology;}
+  const Topology&  topology() const override { return *theTopology;}
   
   virtual const  TopologyType& specificTopology() const { return *theTopology;}
 

--- a/Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h
+++ b/Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h
@@ -25,10 +25,10 @@ public:
   /// the proxy topology (through topology() and specificTopology()) which includes
   /// corrections for the surface deformations, and once via the GeomDetType
   /// (through type().topology() and the like).
-  virtual const GeomDetType& type() const override;
+  const GeomDetType& type() const override;
 
   /// Returns a reference to the strip proxy topology
-  virtual const Topology& topology() const override;
+  const Topology& topology() const override;
 
   /// NOTE (A.M.): The actual pointer to StripGeomDetType is now a member of the
   /// proxy topology. As StripGeomDetType has the actual topology as a pointer,
@@ -42,7 +42,7 @@ public:
   virtual const StripTopology& specificTopology() const;
 
   /// Return pointer to surface deformation.
-  virtual const SurfaceDeformation * surfaceDeformation() const override { 
+  const SurfaceDeformation * surfaceDeformation() const override { 
     return theTopology->surfaceDeformation();
   }
 
@@ -52,7 +52,7 @@ public:
 private:
 
   /// set the SurfaceDeformation for this StripGeomDetUnit to proxy topology.
-  virtual void setSurfaceDeformation(const SurfaceDeformation * deformation) override;
+  void setSurfaceDeformation(const SurfaceDeformation * deformation) override;
 
   std::unique_ptr<ProxyStripTopology> theTopology;
 };

--- a/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
+++ b/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
@@ -54,15 +54,15 @@ public:
       Ph2SS
    };
 
-  virtual ~TrackerGeometry() ;
+  ~TrackerGeometry() override ;
 
-  const DetTypeContainer&  detTypes()         const {return theDetTypes;}
-  const DetUnitContainer&  detUnits()         const {return theDetUnits;}
-  const DetContainer&      dets()             const {return theDets;}
-  const DetIdContainer&    detUnitIds()       const {return theDetUnitIds;}
-  const DetIdContainer&    detIds()           const { return theDetIds;}
-  const TrackerGeomDet*    idToDetUnit(DetId) const;
-  const TrackerGeomDet*    idToDet(DetId)     const;
+  const DetTypeContainer&  detTypes()         const override {return theDetTypes;}
+  const DetUnitContainer&  detUnits()         const override {return theDetUnits;}
+  const DetContainer&      dets()             const override {return theDets;}
+  const DetIdContainer&    detUnitIds()       const override {return theDetUnitIds;}
+  const DetIdContainer&    detIds()           const override { return theDetIds;}
+  const TrackerGeomDet*    idToDetUnit(DetId) const override;
+  const TrackerGeomDet*    idToDet(DetId)     const override;
 
   const GeomDetEnumerators::SubDetector geomDetSubDetector(int subdet) const;
   unsigned int numberOfLayers(int subdet) const;

--- a/Geometry/TrackerGeometryBuilder/plugins/TrackerDigiGeometryESModule.h
+++ b/Geometry/TrackerGeometryBuilder/plugins/TrackerDigiGeometryESModule.h
@@ -16,7 +16,7 @@ namespace edm {
 class  TrackerDigiGeometryESModule: public edm::ESProducer{
  public:
   TrackerDigiGeometryESModule(const edm::ParameterSet & p);
-  virtual ~TrackerDigiGeometryESModule(); 
+  ~TrackerDigiGeometryESModule() override; 
   std::shared_ptr<TrackerGeometry> produce(const TrackerDigiGeometryRecord &);
 
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);

--- a/Geometry/TrackerGeometryBuilder/plugins/TrackerParametersESModule.h
+++ b/Geometry/TrackerGeometryBuilder/plugins/TrackerParametersESModule.h
@@ -16,7 +16,7 @@ class  TrackerParametersESModule: public edm::ESProducer
 {
  public:
   TrackerParametersESModule( const edm::ParameterSet & );
-  ~TrackerParametersESModule( void );
+  ~TrackerParametersESModule( void ) override;
 
   typedef std::shared_ptr<PTrackerParameters> ReturnType;
 

--- a/Geometry/TrackerGeometryBuilder/test/GeoHierarchyTest.cc
+++ b/Geometry/TrackerGeometryBuilder/test/GeoHierarchyTest.cc
@@ -61,7 +61,7 @@ struct Print {
 class GeoHierarchy : public edm::one::EDAnalyzer<> {
 public:
   explicit GeoHierarchy( const edm::ParameterSet& );
-  ~GeoHierarchy();
+  ~GeoHierarchy() override;
   
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/TrackerGeometryBuilder/test/ModuleInfo.cc
+++ b/Geometry/TrackerGeometryBuilder/test/ModuleInfo.cc
@@ -62,7 +62,7 @@
 class ModuleInfo : public edm::one::EDAnalyzer<> {
 public:
   explicit ModuleInfo( const edm::ParameterSet& );
-  ~ModuleInfo();
+  ~ModuleInfo() override;
   
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/TrackerGeometryBuilder/test/TrackerDigiGeometryAnalyzer.cc
+++ b/Geometry/TrackerGeometryBuilder/test/TrackerDigiGeometryAnalyzer.cc
@@ -59,7 +59,7 @@ class TrackerDigiGeometryAnalyzer : public edm::one::EDAnalyzer<>
 {
 public:
       explicit TrackerDigiGeometryAnalyzer( const edm::ParameterSet& );
-      ~TrackerDigiGeometryAnalyzer();
+      ~TrackerDigiGeometryAnalyzer() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/TrackerGeometryBuilder/test/TrackerMapTool.cc
+++ b/Geometry/TrackerGeometryBuilder/test/TrackerMapTool.cc
@@ -55,7 +55,7 @@
 class TrackerMapTool : public edm::one::EDAnalyzer<> {
 public:
   explicit TrackerMapTool( const edm::ParameterSet& );
-  ~TrackerMapTool();
+  ~TrackerMapTool() override;
   
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/TrackerGeometryBuilder/test/TrackerParametersAnalyzer.cc
+++ b/Geometry/TrackerGeometryBuilder/test/TrackerParametersAnalyzer.cc
@@ -16,7 +16,7 @@ class TrackerParametersAnalyzer : public edm::one::EDAnalyzer<>
 {
 public:
   explicit TrackerParametersAnalyzer( const edm::ParameterSet& ) {}
-  ~TrackerParametersAnalyzer() {}
+  ~TrackerParametersAnalyzer() override {}
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/TrackerNumberingBuilder/bin/stubs/GeometricDetLoader.h
+++ b/Geometry/TrackerNumberingBuilder/bin/stubs/GeometricDetLoader.h
@@ -15,7 +15,7 @@ class GeometricDetLoader : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 
  public:
   explicit GeometricDetLoader( const edm::ParameterSet& iConfig );
-  ~GeometricDetLoader();
+  ~GeometricDetLoader() override;
 
   void beginJob() override {}
   void beginRun(edm::Run const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsDetConstruction.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsDetConstruction.h
@@ -8,7 +8,7 @@
  */
 class CmsDetConstruction : public CmsTrackerLevelBuilder {
  public:
-  void  buildComponent(DDFilteredView& , GeometricDet*, std::string);
+  void  buildComponent(DDFilteredView& , GeometricDet*, std::string) override;
  private:
   void buildDets(DDFilteredView& , GeometricDet* , std::string);
   void buildSmallDetsforGlued(DDFilteredView& , GeometricDet* , std::string);

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerBuilder.h
@@ -15,8 +15,8 @@ public:
 
 private:
 
-  virtual void sortNS( DDFilteredView& , GeometricDet* );
-  virtual void buildComponent( DDFilteredView& , GeometricDet*, std::string );
+  void sortNS( DDFilteredView& , GeometricDet* ) override;
+  void buildComponent( DDFilteredView& , GeometricDet*, std::string ) override;
 };
 
 #endif

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerDiskBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerDiskBuilder.h
@@ -12,8 +12,8 @@ class CmsTrackerDiskBuilder : public CmsTrackerLevelBuilder
 {
   
 private:
-  virtual void sortNS( DDFilteredView& , GeometricDet* );
-  virtual void buildComponent( DDFilteredView& , GeometricDet*, std::string );
+  void sortNS( DDFilteredView& , GeometricDet* ) override;
+  void buildComponent( DDFilteredView& , GeometricDet*, std::string ) override;
 
 };
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLadderBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLadderBuilder.h
@@ -11,8 +11,8 @@
 class CmsTrackerLadderBuilder : public CmsTrackerLevelBuilder {
   
  private:
-  virtual void sortNS(DDFilteredView& , GeometricDet*);
-  virtual void buildComponent(DDFilteredView& , GeometricDet*, std::string);
+  void sortNS(DDFilteredView& , GeometricDet*) override;
+  void buildComponent(DDFilteredView& , GeometricDet*, std::string) override;
 
 };
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLayerBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLayerBuilder.h
@@ -10,8 +10,8 @@
 class CmsTrackerLayerBuilder : public CmsTrackerLevelBuilder {
   
  private:
-  virtual void sortNS(DDFilteredView& , GeometricDet*);
-  virtual void buildComponent(DDFilteredView& , GeometricDet*, std::string);
+  void sortNS(DDFilteredView& , GeometricDet*) override;
+  void buildComponent(DDFilteredView& , GeometricDet*, std::string) override;
 
 };
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLevelBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLevelBuilder.h
@@ -14,8 +14,8 @@ typedef std::unary_function<const GeometricDet*, double> uFcn;
 
 class CmsTrackerLevelBuilder : public CmsTrackerAbstractConstruction {
 public:
-  virtual void build(DDFilteredView& , GeometricDet*, std::string);
-  virtual ~CmsTrackerLevelBuilder(){}
+  void build(DDFilteredView& , GeometricDet*, std::string) override;
+  ~CmsTrackerLevelBuilder() override{}
   
   
   struct subDetByType{

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTDiscBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTDiscBuilder.h
@@ -12,8 +12,8 @@ class CmsTrackerOTDiscBuilder : public CmsTrackerLevelBuilder
 {
   
 private:
-  virtual void sortNS( DDFilteredView& , GeometricDet* );
-  virtual void buildComponent( DDFilteredView& , GeometricDet*, std::string );
+  void sortNS( DDFilteredView& , GeometricDet* ) override;
+  void buildComponent( DDFilteredView& , GeometricDet*, std::string ) override;
   
 };
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTLayerBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTLayerBuilder.h
@@ -10,8 +10,8 @@
 class CmsTrackerOTLayerBuilder : public CmsTrackerLevelBuilder {
   
  private:
-  virtual void sortNS(DDFilteredView& , GeometricDet*);
-  virtual void buildComponent(DDFilteredView& , GeometricDet*, std::string);
+  void sortNS(DDFilteredView& , GeometricDet*) override;
+  void buildComponent(DDFilteredView& , GeometricDet*, std::string) override;
 
 };
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTRingBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerOTRingBuilder.h
@@ -10,8 +10,8 @@
 class CmsTrackerOTRingBuilder : public CmsTrackerLevelBuilder {
   
  private:
-  virtual void sortNS(DDFilteredView& , GeometricDet*);
-  virtual void buildComponent(DDFilteredView& , GeometricDet*, std::string);
+  void sortNS(DDFilteredView& , GeometricDet*) override;
+  void buildComponent(DDFilteredView& , GeometricDet*, std::string) override;
 
 };
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPanelBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPanelBuilder.h
@@ -10,8 +10,8 @@
 class CmsTrackerPanelBuilder : public CmsTrackerLevelBuilder {
   
  private:
-  virtual void sortNS(DDFilteredView& , GeometricDet*);
-  virtual void buildComponent(DDFilteredView& , GeometricDet*, std::string);
+  void sortNS(DDFilteredView& , GeometricDet*) override;
+  void buildComponent(DDFilteredView& , GeometricDet*, std::string) override;
 
 };
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPetalBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPetalBuilder.h
@@ -10,8 +10,8 @@
 class CmsTrackerPetalBuilder : public CmsTrackerLevelBuilder {
   
  private:
-  virtual void sortNS(DDFilteredView& , GeometricDet*);
-  virtual void buildComponent(DDFilteredView& , GeometricDet*, std::string);
+  void sortNS(DDFilteredView& , GeometricDet*) override;
+  void buildComponent(DDFilteredView& , GeometricDet*, std::string) override;
 
 };
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPhase1DiskBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPhase1DiskBuilder.h
@@ -12,8 +12,8 @@ class CmsTrackerPhase1DiskBuilder : public CmsTrackerLevelBuilder
 {
   
 private:
-  virtual void sortNS( DDFilteredView& , GeometricDet* );
-  virtual void buildComponent( DDFilteredView& , GeometricDet*, std::string );
+  void sortNS( DDFilteredView& , GeometricDet* ) override;
+  void buildComponent( DDFilteredView& , GeometricDet*, std::string ) override;
   
   static bool PhiSort(const GeometricDet* Panel1, const GeometricDet* Panel2);
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPhase2TPDiskBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPhase2TPDiskBuilder.h
@@ -12,8 +12,8 @@ class CmsTrackerPhase2TPDiskBuilder : public CmsTrackerLevelBuilder
 {
   
 private:
-  virtual void sortNS( DDFilteredView& , GeometricDet* );
-  virtual void buildComponent( DDFilteredView& , GeometricDet*, std::string );
+  void sortNS( DDFilteredView& , GeometricDet* ) override;
+  void buildComponent( DDFilteredView& , GeometricDet*, std::string ) override;
   
   static bool PhiSort(const GeometricDet* Panel1, const GeometricDet* Panel2);
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPixelPhase1EndcapBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPixelPhase1EndcapBuilder.h
@@ -14,8 +14,8 @@ public:
   CmsTrackerPixelPhase1EndcapBuilder();
   
 private:
-  virtual void sortNS( DDFilteredView& , GeometricDet* );
-  virtual void buildComponent( DDFilteredView& , GeometricDet*, std::string );
+  void sortNS( DDFilteredView& , GeometricDet* ) override;
+  void buildComponent( DDFilteredView& , GeometricDet*, std::string ) override;
 };
 
 #endif

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPixelPhase2DiskBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPixelPhase2DiskBuilder.h
@@ -12,8 +12,8 @@ class CmsTrackerPixelPhase2DiskBuilder : public CmsTrackerLevelBuilder
 {
   
 private:
-  virtual void sortNS( DDFilteredView& , GeometricDet* );
-  virtual void buildComponent( DDFilteredView& , GeometricDet*, std::string );
+  void sortNS( DDFilteredView& , GeometricDet* ) override;
+  void buildComponent( DDFilteredView& , GeometricDet*, std::string ) override;
   
 };
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPixelPhase2EndcapBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPixelPhase2EndcapBuilder.h
@@ -14,8 +14,8 @@ public:
   CmsTrackerPixelPhase2EndcapBuilder();
   
 private:
-  virtual void sortNS( DDFilteredView& , GeometricDet* );
-  virtual void buildComponent( DDFilteredView& , GeometricDet*, std::string );
+  void sortNS( DDFilteredView& , GeometricDet* ) override;
+  void buildComponent( DDFilteredView& , GeometricDet*, std::string ) override;
 };
 
 #endif

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPixelPhase2RingBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPixelPhase2RingBuilder.h
@@ -10,8 +10,8 @@
 class CmsTrackerPixelPhase2RingBuilder : public CmsTrackerLevelBuilder {
   
  private:
-  virtual void sortNS(DDFilteredView& , GeometricDet*);
-  virtual void buildComponent(DDFilteredView& , GeometricDet*, std::string);
+  void sortNS(DDFilteredView& , GeometricDet*) override;
+  void buildComponent(DDFilteredView& , GeometricDet*, std::string) override;
 
 };
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerRingBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerRingBuilder.h
@@ -10,8 +10,8 @@
 class CmsTrackerRingBuilder : public CmsTrackerLevelBuilder {
   
  private:
-  virtual void sortNS(DDFilteredView& , GeometricDet*);
-  virtual void buildComponent(DDFilteredView& , GeometricDet*, std::string);
+  void sortNS(DDFilteredView& , GeometricDet*) override;
+  void buildComponent(DDFilteredView& , GeometricDet*, std::string) override;
 
 };
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerRodBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerRodBuilder.h
@@ -10,8 +10,8 @@
 class CmsTrackerRodBuilder : public CmsTrackerLevelBuilder {
   
  private:
-  virtual void sortNS(DDFilteredView& , GeometricDet*);
-  virtual void buildComponent(DDFilteredView& , GeometricDet*, std::string);
+  void sortNS(DDFilteredView& , GeometricDet*) override;
+  void buildComponent(DDFilteredView& , GeometricDet*, std::string) override;
 
 };
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerStringBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerStringBuilder.h
@@ -10,8 +10,8 @@
 class CmsTrackerStringBuilder : public CmsTrackerLevelBuilder {
   
  private:
-  virtual void sortNS(DDFilteredView& , GeometricDet*);
-  virtual void buildComponent(DDFilteredView& , GeometricDet*, std::string);
+  void sortNS(DDFilteredView& , GeometricDet*) override;
+  void buildComponent(DDFilteredView& , GeometricDet*, std::string) override;
 
 };
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerSubStrctBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerSubStrctBuilder.h
@@ -14,8 +14,8 @@ public:
   CmsTrackerSubStrctBuilder();
   
 private:
-  virtual void sortNS( DDFilteredView& , GeometricDet* );
-  virtual void buildComponent( DDFilteredView& , GeometricDet*, std::string );
+  void sortNS( DDFilteredView& , GeometricDet* ) override;
+  void buildComponent( DDFilteredView& , GeometricDet*, std::string ) override;
 };
 
 #endif

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerWheelBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerWheelBuilder.h
@@ -11,8 +11,8 @@
 class CmsTrackerWheelBuilder : public CmsTrackerLevelBuilder {
   
  private:
-  virtual void sortNS(DDFilteredView& , GeometricDet*);
-  virtual void buildComponent(DDFilteredView& , GeometricDet*, std::string);
+  void sortNS(DDFilteredView& , GeometricDet*) override;
+  void buildComponent(DDFilteredView& , GeometricDet*, std::string) override;
 
 };
 

--- a/Geometry/TrackerNumberingBuilder/plugins/TrackerGeometricDetESModule.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/TrackerGeometricDetESModule.h
@@ -15,7 +15,7 @@ class TrackerGeometricDetESModule : public edm::ESProducer
 {
 public:
   TrackerGeometricDetESModule( const edm::ParameterSet & p );
-  virtual ~TrackerGeometricDetESModule( void ); 
+  ~TrackerGeometricDetESModule( void ) override; 
   std::unique_ptr<GeometricDet> produce( const IdealGeometryRecord & );
 
   static void fillDescriptions( edm::ConfigurationDescriptions & descriptions );

--- a/Geometry/TrackerNumberingBuilder/plugins/TrackerGeometricDetExtraESModule.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/TrackerGeometricDetExtraESModule.h
@@ -11,7 +11,7 @@ class  TrackerGeometricDetExtraESModule: public edm::ESProducer {
 
  public:
   TrackerGeometricDetExtraESModule(const edm::ParameterSet & p);
-  virtual ~TrackerGeometricDetExtraESModule(); 
+  ~TrackerGeometricDetExtraESModule() override; 
   std::shared_ptr<std::vector<GeometricDetExtra> > produce(const IdealGeometryRecord &);
 
  protected:

--- a/Geometry/TrackerNumberingBuilder/plugins/TrackerTopologyEP.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/TrackerTopologyEP.h
@@ -15,7 +15,7 @@ class TrackerTopologyEP : public edm::ESProducer
 {
 public:
   TrackerTopologyEP( const edm::ParameterSet & );
-  ~TrackerTopologyEP( void );
+  ~TrackerTopologyEP( void ) override;
 
   typedef std::shared_ptr<TrackerTopology> ReturnType;
 

--- a/Geometry/TrackerNumberingBuilder/test/GeometricDetAnalyzer.cc
+++ b/Geometry/TrackerNumberingBuilder/test/GeometricDetAnalyzer.cc
@@ -48,7 +48,7 @@
 class GeometricDetAnalyzer : public edm::one::EDAnalyzer<> {
    public:
       explicit GeometricDetAnalyzer( const edm::ParameterSet& );
-      ~GeometricDetAnalyzer();
+      ~GeometricDetAnalyzer() override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/TrackerNumberingBuilder/test/ModuleNumbering.cc
+++ b/Geometry/TrackerNumberingBuilder/test/ModuleNumbering.cc
@@ -69,7 +69,7 @@
 class ModuleNumbering : public edm::one::EDAnalyzer<> {
 public:
   explicit ModuleNumbering( const edm::ParameterSet& );
-  ~ModuleNumbering();
+  ~ModuleNumbering() override;
   
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/TrackerNumberingBuilder/test/TrackerTopologyAnalyzer.cc
+++ b/Geometry/TrackerNumberingBuilder/test/TrackerTopologyAnalyzer.cc
@@ -17,7 +17,7 @@
 class TrackerTopologyAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit TrackerTopologyAnalyzer( const edm::ParameterSet& ) {};
-  ~TrackerTopologyAnalyzer() {};
+  ~TrackerTopologyAnalyzer() override {};
   
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;

--- a/Geometry/VeryForwardGeometryBuilder/plugins/GeometryInfoModule.cc
+++ b/Geometry/VeryForwardGeometryBuilder/plugins/GeometryInfoModule.cc
@@ -31,7 +31,7 @@ class GeometryInfoModule : public edm::one::EDAnalyzer<>
 {
   public:
     explicit GeometryInfoModule(const edm::ParameterSet&);
-    ~GeometryInfoModule();
+    ~GeometryInfoModule() override;
 
     struct MeanRPData
     {
@@ -70,8 +70,8 @@ class GeometryInfoModule : public edm::one::EDAnalyzer<>
     edm::ESWatcher<VeryForwardMisalignedGeometryRecord> watcherMisalignedGeometry;
 
     virtual void beginRun(edm::Run const&, edm::EventSetup const&);
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
-    virtual void endJob();
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
+    void endJob() override;
 
     void PrintGeometry(const TotemRPGeometry &, const edm::Event&);
 };

--- a/Geometry/VeryForwardGeometryBuilder/plugins/TotemRPGeometryESModule.cc
+++ b/Geometry/VeryForwardGeometryBuilder/plugins/TotemRPGeometryESModule.cc
@@ -53,7 +53,7 @@ class  TotemRPGeometryESModule : public edm::ESProducer
 {
   public:
     TotemRPGeometryESModule(const edm::ParameterSet &p);
-    virtual ~TotemRPGeometryESModule(); 
+    ~TotemRPGeometryESModule() override; 
 
     std::unique_ptr<DetGeomDesc> produceIdealGD(const IdealGeometryRecord &);
 

--- a/Geometry/VeryForwardGeometryBuilder/plugins/TotemRPIncludeAlignments.cc
+++ b/Geometry/VeryForwardGeometryBuilder/plugins/TotemRPIncludeAlignments.cc
@@ -35,7 +35,7 @@ class  TotemRPIncludeAlignments : public edm::ESProducer, public edm::EventSetup
 {
   public:
     TotemRPIncludeAlignments(const edm::ParameterSet &p);
-    virtual ~TotemRPIncludeAlignments(); 
+    ~TotemRPIncludeAlignments() override; 
 
     std::unique_ptr<RPAlignmentCorrectionsData> produceMeasured(const RPMeasuredAlignmentRecord &);
     std::unique_ptr<RPAlignmentCorrectionsData> produceReal(const RPRealAlignmentRecord &);
@@ -46,7 +46,7 @@ class  TotemRPIncludeAlignments : public edm::ESProducer, public edm::EventSetup
     RPAlignmentCorrectionsDataSequence acsMeasured, acsReal, acsMisaligned;
     RPAlignmentCorrectionsData acMeasured, acReal, acMisaligned;
 
-    virtual void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue&, edm::ValidityInterval&);
+    void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue&, edm::ValidityInterval&) override;
 
     /// merges an array of sequences to one
     RPAlignmentCorrectionsDataSequence Merge(const std::vector<RPAlignmentCorrectionsDataSequence>) const;

--- a/GeometryReaders/XMLIdealGeometryESSource/interface/GeometryConfiguration.h
+++ b/GeometryReaders/XMLIdealGeometryESSource/interface/GeometryConfiguration.h
@@ -22,29 +22,29 @@ class GeometryConfiguration: public DDLDocumentProvider {
  public:
   GeometryConfiguration( const edm::ParameterSet & p );
 
-  virtual ~GeometryConfiguration();
+  ~GeometryConfiguration() override;
 
   /// Print out the list of files.
-  virtual void dumpFileList(void) const;
+  void dumpFileList(void) const override;
 
   /// Return a list of files as a vector of strings.
-  virtual const std::vector < std::string >  & getFileList(void) const;
+  const std::vector < std::string >  & getFileList(void) const override;
 
   /// Return a list of urls as a vector of strings.
   /**
      The EDM should not allow URLs because of provenance.
      This vector will always be empty.
    **/
-  virtual const std::vector < std::string >  & getURLList(void) const;
+  const std::vector < std::string >  & getURLList(void) const override;
  
   /// Return a flag whether to do xml validation or not.
-  virtual bool doValidation() const;
+  bool doValidation() const override;
 
   /// Return the Schema Location.
-  virtual std::string getSchemaLocation() const;
+  std::string getSchemaLocation() const override;
 
   /// Reads in a configuration file and parses it
-  int readConfig(const std::string& filename);
+  int readConfig(const std::string& filename) override;
 
  protected:
 

--- a/GeometryReaders/XMLIdealGeometryESSource/interface/XMLIdealGeometryESSource.h
+++ b/GeometryReaders/XMLIdealGeometryESSource/interface/XMLIdealGeometryESSource.h
@@ -18,13 +18,13 @@ class XMLIdealGeometryESSource : public edm::ESProducer,
 {
 public:
     XMLIdealGeometryESSource(const edm::ParameterSet & p);
-    virtual ~XMLIdealGeometryESSource(); 
+    ~XMLIdealGeometryESSource() override; 
     std::unique_ptr<DDCompactView> produceGeom(const IdealGeometryRecord &);
     std::unique_ptr<DDCompactView> produceMagField(const IdealMagneticFieldRecord &);
     std::unique_ptr<DDCompactView> produce();
 protected:
-    virtual void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
-				const edm::IOVSyncValue &,edm::ValidityInterval &);
+    void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+				const edm::IOVSyncValue &,edm::ValidityInterval &) override;
 private:
     XMLIdealGeometryESSource(const XMLIdealGeometryESSource &);
     const XMLIdealGeometryESSource & operator=(const XMLIdealGeometryESSource &);

--- a/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealGeometryESProducer.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealGeometryESProducer.cc
@@ -50,7 +50,7 @@
 class XMLIdealGeometryESProducer : public edm::ESProducer {
 public:
   XMLIdealGeometryESProducer(const edm::ParameterSet&);
-  ~XMLIdealGeometryESProducer();
+  ~XMLIdealGeometryESProducer() override;
   
   typedef std::unique_ptr<DDCompactView> ReturnType;
   

--- a/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealMagneticFieldGeometryESProducer.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealMagneticFieldGeometryESProducer.cc
@@ -26,7 +26,7 @@ class XMLIdealMagneticFieldGeometryESProducer : public edm::ESProducer
 {
 public:
   XMLIdealMagneticFieldGeometryESProducer( const edm::ParameterSet& );
-  ~XMLIdealMagneticFieldGeometryESProducer();
+  ~XMLIdealMagneticFieldGeometryESProducer() override;
   
   typedef std::unique_ptr<DDCompactView> ReturnType;
   

--- a/GeometryReaders/XMLIdealGeometryESSource/test/ExtractXMLFile.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/test/ExtractXMLFile.cc
@@ -46,7 +46,7 @@
 class ExtractXMLFile : public edm::one::EDAnalyzer<> {
 public:
   explicit ExtractXMLFile( const edm::ParameterSet& );
-  ~ExtractXMLFile();
+  ~ExtractXMLFile() override;
 
   void beginJob() override {} 
   void analyze(edm::Event const&, edm::EventSetup const&) override;

--- a/GeometryReaders/XMLIdealGeometryESSource/test/PerfectGeometryAnalyzer.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/test/PerfectGeometryAnalyzer.cc
@@ -43,7 +43,7 @@
 class PerfectGeometryAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit PerfectGeometryAnalyzer( const edm::ParameterSet& );
-  ~PerfectGeometryAnalyzer();
+  ~PerfectGeometryAnalyzer() override;
 
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;

--- a/GeometryReaders/XMLIdealGeometryESSource/test/TestCompareDDDumpFiles.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/test/TestCompareDDDumpFiles.cc
@@ -34,7 +34,7 @@
 class TestCompareDDDumpFiles : public edm::one::EDAnalyzer<> {
 public:
   explicit TestCompareDDDumpFiles( const edm::ParameterSet& );
-  ~TestCompareDDDumpFiles();
+  ~TestCompareDDDumpFiles() override;
 
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;

--- a/GeometryReaders/XMLIdealGeometryESSource/test/TestCompareDDSpecsDumpFiles.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/test/TestCompareDDSpecsDumpFiles.cc
@@ -28,7 +28,7 @@ class TestCompareDDSpecsDumpFiles
 {
 public:
   explicit TestCompareDDSpecsDumpFiles( const edm::ParameterSet& );
-  ~TestCompareDDSpecsDumpFiles( void );
+  ~TestCompareDDSpecsDumpFiles( void ) override;
   
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;

--- a/GeometryReaders/XMLIdealGeometryESSource/test/TestIdealGeometryESProducer.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/test/TestIdealGeometryESProducer.cc
@@ -43,7 +43,7 @@
 class TestIdealGeometryESProducer : public edm::one::EDAnalyzer<> {
 public:
   explicit TestIdealGeometryESProducer( const edm::ParameterSet& );
-  ~TestIdealGeometryESProducer();
+  ~TestIdealGeometryESProducer() override;
 
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;

--- a/GeometryReaders/XMLIdealGeometryESSource/test/TestSpecParAnalyzer.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/test/TestSpecParAnalyzer.cc
@@ -41,7 +41,7 @@
 class TestSpecParAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit TestSpecParAnalyzer( const edm::ParameterSet& );
-  ~TestSpecParAnalyzer();
+  ~TestSpecParAnalyzer() override;
 
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;


### PR DESCRIPTION
Geometry part from @davidlange6 https://github.com/cms-sw/cmssw/pull/19529

Note, I agree with clang that _override_ would be superfluous in declarations where _final_, but not virtual, occurs. Still, the latter declaration expresses the intent a lot clearer and should definitely be preferred.