### PR TITLE
[92X] update conditions for unit test

### DIFF
--- a/Alignment/OfflineValidation/test/test_all_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_cfg.py
@@ -69,7 +69,7 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 ####################################################################
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_realistic', '')
 
 if allFromGT:
      print ">>>>>>>>>> testPVValidation_cfg.py: msg%-i: All is taken from GT"
@@ -82,7 +82,7 @@ else:
                                              connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
                                              timetype = cms.string("runnumber"),
                                              toGet = cms.VPSet(cms.PSet(record = cms.string('TrackerAlignmentRcd'),
-                                                                        tag = cms.string('TrackerAlignment_2015StartupPessimisticScenario_mc')
+                                                                        tag = cms.string('TrackerAlignment_Upgrade2017_design_v4')
                                                                         )
                                                                )
                                              )


### PR DESCRIPTION
backport of #19507

This resolves the same issue as in master branch:

> After https://github.com/kmcdermo/cmssw/commit/96d3942ed305266ec45f92e02ea58f04bffc5e36the list of files picked up by the unit test via:
> 
> ```python
> from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpGENSIMRECO
> ```
> points to a phase-I MC sample, hence breaking the unit test: [example of log file](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc630/CMSSW_9_2_X_2017-07-06-2300/unitTestLogs/Alignment/OfflineValidation).
> This commit restores the previous behavior.