### PR TITLE
L1T uGT - Parsing of LUTS, Remove unnecessary Warning messages

### DIFF
--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -367,8 +367,8 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
 	  } else if(condition.getType() == esConditionType::Externals      )
 	  {
              parseExternal(condition,chipNr);
-	     	    
-          }      
+
+          }
           else if(condition.getType() == esConditionType::SingleEgammaOvRm  ||
 		  condition.getType() == esConditionType::DoubleEgammaOvRm  ||
 		  condition.getType() == esConditionType::TripleEgammaOvRm  ||
@@ -397,7 +397,7 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
 	        << "QuadJetOvRm" << std::endl
                 << "The above conditions types OvRm are not implemented yet in the parser. Please remove alogrithms that use this type of condtion from L1T Menu!" << std::endl;
 
-          } 
+          }
           //parse CorrelationWithOverlapRemoval
           else if(condition.getType() == esConditionType::CaloCaloCorrelationOvRm  ||
                   condition.getType() == esConditionType::InvariantMassOvRm  ||
@@ -782,6 +782,9 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
     parsePt_LUTS(scaleMap, "Mass" ,"MU",  precisions["PRECISION-EG-MU-MassPt"] );
     parsePt_LUTS(scaleMap, "Mass" ,"JET", precisions["PRECISION-EG-JET-MassPt"] );
     parsePt_LUTS(scaleMap, "Mass" ,"TAU", precisions["PRECISION-EG-TAU-MassPt"] );
+    parsePt_LUTS(scaleMap, "Mass" ,"ETM", precisions["PRECISION-EG-ETM-MassPt"] );
+    parsePt_LUTS(scaleMap, "Mass" ,"ETMHF", precisions["PRECISION-EG-ETMHF-MassPt"] );
+    parsePt_LUTS(scaleMap, "Mass" ,"HTM", precisions["PRECISION-EG-HTM-MassPt"] );
 
     // Now the Pt LUTs  for TBPT calculation (??? CCLA following what was done for MASS pt LUTs for now ??)
     // ---------------
@@ -789,6 +792,9 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
     parsePt_LUTS(scaleMap,"TwoBody" ,"MU",  precisions["PRECISION-EG-MU-TwoBodyPt"] );
     parsePt_LUTS(scaleMap,"TwoBody" ,"JET", precisions["PRECISION-EG-JET-TwoBodyPt"] );
     parsePt_LUTS(scaleMap,"TwoBody" ,"TAU", precisions["PRECISION-EG-TAU-TwoBodyPt"] );
+    parsePt_LUTS(scaleMap,"TwoBody" ,"ETM", precisions["PRECISION-EG-ETM-TwoBodyPt"] );
+    parsePt_LUTS(scaleMap,"TwoBody" ,"ETMHF", precisions["PRECISION-EG-ETMHF-TwoBodyPt"] );
+    parsePt_LUTS(scaleMap,"TwoBody" ,"HTM", precisions["PRECISION-EG-HTM-TwoBodyPt"] );
 
 
 

--- a/L1Trigger/L1TGlobal/src/CorrCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrCondition.cc
@@ -1222,10 +1222,15 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
                   long long cosDeltaPhiLUT = m_gtScales->getLUT_DeltaPhi_Cos(lutName,deltaPhiFW);
 		  unsigned int precCosLUT = m_gtScales->getPrec_DeltaPhi_Cos(lutName);
 
-                  long long coshDeltaEtaLUT = m_gtScales->getLUT_DeltaEta_Cosh(lutName,deltaEtaFW);
-		  unsigned int precCoshLUT = m_gtScales->getPrec_DeltaEta_Cosh(lutName);
-		  if(precCoshLUT - precCosLUT != 0) LogDebug("L1TGlobal") << "Warning: Cos and Cosh LUTs on different Precision" << std::endl;
-		  if (corrPar.corrCutType & 0x10) coshDeltaEtaLUT=1*pow(10,precCosLUT);
+		  long long coshDeltaEtaLUT;
+		  if (corrPar.corrCutType & 0x10) {
+		    coshDeltaEtaLUT=1*pow(10,precCosLUT);
+		  }else{
+		    coshDeltaEtaLUT = m_gtScales->getLUT_DeltaEta_Cosh(lutName,deltaEtaFW);
+		    unsigned int precCoshLUT = m_gtScales->getPrec_DeltaEta_Cosh(lutName);
+		    if(precCoshLUT - precCosLUT != 0) LogDebug("L1TGlobal") << "Warning: Cos and Cosh LUTs on different Precision" << std::endl;
+		  }
+		  // if (corrPar.corrCutType & 0x10) coshDeltaEtaLUT=1*pow(10,precCosLUT);
 
 		  std::string lutName = lutObj0;
 		  lutName += "-ET";

--- a/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondition.cc
@@ -1297,8 +1297,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
                     std::pair<double, double> binEdges = m_gtScales->getJETScales().phiBins.at(phiIndex1);
                     phi1Phy = 0.5*(binEdges.second + binEdges.first);
                     binEdges = m_gtScales->getJETScales().etaBins.at(etaBin1);
-                    eta1Phy = 0.5*(binEdges.second + binEdges.first);		
-                    
+                    eta1Phy = 0.5*(binEdges.second + binEdges.first);
+
                     binEdges = m_gtScales->getJETScales().etBins.at(etBin1);
                     et1Phy = 0.5*(binEdges.second + binEdges.first);
                     lutObj1 = "JET";
@@ -2105,10 +2105,14 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             long long cosDeltaPhiLUT = m_gtScales->getLUT_DeltaPhi_Cos(lutName,deltaPhiFW);
             unsigned int precCosLUT = m_gtScales->getPrec_DeltaPhi_Cos(lutName);
 
-            long long coshDeltaEtaLUT = m_gtScales->getLUT_DeltaEta_Cosh(lutName,deltaEtaFW);
-            unsigned int precCoshLUT = m_gtScales->getPrec_DeltaEta_Cosh(lutName);
-            if(precCoshLUT - precCosLUT != 0) LogDebug("L1TGlobal") << "Warning: Cos and Cosh LUTs on different Precision" << std::endl;
-            if (corrPar.corrCutType & 0x10) coshDeltaEtaLUT=1*pow(10,precCosLUT);
+	    long long coshDeltaEtaLUT;
+	    if (corrPar.corrCutType & 0x10) {
+	      coshDeltaEtaLUT=1*pow(10,precCosLUT);
+	    }else{
+	      coshDeltaEtaLUT = m_gtScales->getLUT_DeltaEta_Cosh(lutName,deltaEtaFW);
+	      unsigned int precCoshLUT = m_gtScales->getPrec_DeltaEta_Cosh(lutName);
+	      if(precCoshLUT - precCosLUT != 0) LogDebug("L1TGlobal") << "Warning: Cos and Cosh LUTs on different Precision" << std::endl;
+	    }
 
             std::string lutName = lutObj0;
             lutName += "-ET";


### PR DESCRIPTION
- Add parsing of LUTS for ETM, ETMHF, and HTM mass and two body pT algorithms.
- Needed to get rid of unnecessary Warning messages when
running uGT emulator in HLT with L1T Menu contiaing M_T algorithms,
trying to deploy online. 

Please merge soon. 