### PR TITLE
dqm based on topmonitoring code for DoubleMu3_DZ_PFMET50_PFMHT60 path

### DIFF
--- a/DQMOffline/Trigger/plugins/TopMonitor.cc
+++ b/DQMOffline/Trigger/plugins/TopMonitor.cc
@@ -30,6 +30,10 @@ TopMonitor::TopMonitor( const edm::ParameterSet& iConfig ) :
   , DR_binning_           ( getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("DRPSet")    ) )
   // Marina
   , csv_binning_          ( getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet> ("csvPSet")))
+  //george
+  , invMass_mumu_binning_  ( getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet> ("invMassPSet")))
+  , MHT_binning_           ( getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("MHTPSet")    ) )
+ 
   , met_variable_binning_ ( iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("metBinning") )
   , HT_variable_binning_ ( iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("HTBinning") )
   , jetPt_variable_binning_ ( iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetPtBinning") )
@@ -48,6 +52,8 @@ TopMonitor::TopMonitor( const edm::ParameterSet& iConfig ) :
   , phi_variable_binning_2D_ ( iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("phiBinning2D") )
   , num_genTriggerEventFlag_(new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("numGenericTriggerEventPSet"),consumesCollector(), *this))
   , den_genTriggerEventFlag_(new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("denGenericTriggerEventPSet"),consumesCollector(), *this))
+ 
+   
   , metSelection_ ( iConfig.getParameter<std::string>("metSelection") )
   , jetSelection_ ( iConfig.getParameter<std::string>("jetSelection") )
   , eleSelection_ ( iConfig.getParameter<std::string>("eleSelection") )
@@ -64,7 +70,14 @@ TopMonitor::TopMonitor( const edm::ParameterSet& iConfig ) :
   , nbjets_    ( iConfig.getParameter<unsigned int>("nbjets"))
   , workingpoint_(iConfig.getParameter<double>("workingpoint"))
   //Suvankar
-  , usePVcuts_ ( iConfig.getParameter<bool>("applyleptonPVcuts")    )
+  , usePVcuts_ ( iConfig.getParameter<bool>("applyleptonPVcuts") )
+     //george  
+  , invMassUppercut_ (iConfig.getParameter<double>("invMassUppercut"))
+   , invMassLowercut_ (iConfig.getParameter<double>("invMassLowercut"))
+   , opsign_ (iConfig.getParameter<bool>("opsign"))
+   , MHTdefinition_ ( iConfig.getParameter<std::string>("MHTdefinition") )
+   , MHTcut_     ( iConfig.getParameter<double>("MHTcut" )     )
+   
 {
 
     METME empty;
@@ -99,6 +112,9 @@ TopMonitor::TopMonitor( const edm::ParameterSet& iConfig ) :
     mu1Eta_mu2Eta_ = empty;
     elePt_muPt_ = empty;
     eleEta_muEta_ = empty;
+    //george
+    invMass_mumu_=empty;
+    eventMHT_=empty;    
 
     //BTV
     DeltaR_jet_Mu_ = empty;
@@ -285,6 +301,10 @@ void TopMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
       histname = "mu1Eta_mu2Eta"; histtitle = "muon-1 #eta vs muon-2 #eta";
       bookME(ibooker,mu1Eta_mu2Eta_,histname,histtitle, muEta_variable_binning_2D_, muEta_variable_binning_2D_);      
       setMETitle(mu1Eta_mu2Eta_,"muon-1 #eta","muon-2 #eta");
+      //george
+     histname = "invMass"; histtitle = "M mu1 mu2";
+     bookME(ibooker,invMass_mumu_,histname,histtitle, invMass_mumu_binning_.nbins,invMass_mumu_binning_.xmin,invMass_mumu_binning_.xmax);      
+      setMETitle(invMass_mumu_,"M(mu1,mu2) [GeV]","events");
   }
 
   if ( (njets_ > 0) && (nmuons_ > 0)){
@@ -498,6 +518,12 @@ void TopMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
   bookME(ibooker,elePt_eventHT_,histname,histtitle, elePt_variable_binning_2D_, HT_variable_binning_2D_);
   setMETitle(elePt_eventHT_,"leading electron pt","event HT");
 
+  //george
+  histname = "eventMHT"; histtitle = "event MHT";
+  bookME(ibooker,eventMHT_,histname,histtitle, MHT_binning_.nbins,MHT_binning_.xmin, MHT_binning_.xmax);
+  setMETitle(eventMHT_," event MHT [GeV]","events");
+ 
+
 
   // Initialize the GenericTriggerEventFlag
   if ( num_genTriggerEventFlag_ && num_genTriggerEventFlag_->on() ) num_genTriggerEventFlag_->initRun( iRun, iSetup );
@@ -512,9 +538,13 @@ void TopMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
 //Suvankar
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+//george
+#include "TLorentzVector.h"
+#include "TVector3.h"
 
 void TopMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup)  {
-
+  mll=-2;
+  sign=0;
   // Filter out events if Trigger Filtering is requested
   if (den_genTriggerEventFlag_->on() && ! den_genTriggerEventFlag_->accept( iEvent, iSetup) ) return;
 
@@ -574,7 +604,22 @@ void TopMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
   }
   if ( muons.size() < nmuons_ ) return;
 
+    //george
+
+  if (nmuons_>1){
+    TLorentzVector mu1,mu2;
+    mu1.SetPtEtaPhiM(muons.at(0).pt(),muons.at(0).eta(),muons.at(0).phi(),0.1);
+    mu2.SetPtEtaPhiM(muons.at(1).pt(),muons.at(1).eta(),muons.at(1).phi(),0.1);
+    mll=(mu1+mu2).M();
+    sign=muons.at(0).charge()*muons.at(1).charge();
+    }
+  if (nmuons_>1 && invMassUppercut_>-1 &&  invMassLowercut_>-1 && (mll>invMassUppercut_ || mll<invMassLowercut_)) return;
+ if (nmuons_>1 && opsign_ && sign==1) return;  
+
+  //cout<<" mll="<<mll<<"  invMasscut_="<<invMasscut_<<endl;
   double eventHT = 0.;
+  TVector3 eventMHT;
+  eventMHT.SetPtEtaPhi(0,0,0);
 
   edm::Handle<reco::PFJetCollection> jetHandle;
   iEvent.getByToken( jetToken_, jetHandle );
@@ -588,6 +633,12 @@ void TopMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
       if ( HTdefinition_ ( j ) ){
           eventHT += j.pt();
       }
+      TVector3 temp;
+      temp.SetPtEtaPhi(0,0,0);
+     if ( MHTdefinition_ ( j ) ){
+       temp.SetPtEtaPhi(j.pt(),j.eta(),j.phi());
+      } 
+     eventMHT +=temp;
       if ( jetSelection_( j ) ){
           bool isJetOverlappedWithLepton = false;
           if(nmuons_>0){
@@ -615,6 +666,7 @@ void TopMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
   if ( jets.size() < njets_ ) return;
 
   if (eventHT < HTcut_) return;
+  if (MHTcut_>0 && eventMHT.Pt()<MHTcut_) return;
 
   // Marina
   edm::Handle<reco::JetTagCollection> bjetHandle;
@@ -639,12 +691,15 @@ void TopMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
 
   if (bjets.size() < nbjets_ ) return;  
 
+  
+
   // filling histograms (denominator)  
   metME_.denominator -> Fill(met);
   metME_variableBinning_.denominator -> Fill(met);
   metPhiME_.denominator -> Fill(phi);
   eventHT_.denominator -> Fill(eventHT);
   eventHT_variableBinning_.denominator -> Fill(eventHT);
+  eventMHT_.denominator -> Fill(eventMHT.Pt());
 
   int ls = iEvent.id().luminosityBlock();
   metVsLS_.denominator -> Fill(ls, met);
@@ -657,16 +712,19 @@ void TopMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
   // Marina
   bjetMulti_.denominator -> Fill(bjets.size());
 
-  if (nmuons_ > 0){
+  if (nmuons_ > 0){  
       muVsLS_.denominator -> Fill(ls, muons.at(0).pt());
-      if (nmuons_>1) {
+      if (nmuons_>1) {	
           mu1Pt_mu2Pt_.denominator->Fill(muons.at(0).pt(),muons.at(1).pt());
           mu1Eta_mu2Eta_.denominator->Fill(muons.at(0).eta(),muons.at(1).eta());
+          invMass_mumu_.denominator->Fill(mll);
       }
       if(njets_>0){
           DeltaR_jet_Mu_.denominator -> Fill (deltaR(jets.at(0),muons.at(0)));
       }
   }
+     
+
   if (njets_ > 0)      jetVsLS_.denominator -> Fill(ls, jets.at(0).pt());
   if (nelectrons_ > 0) {
       eleVsLS_.denominator -> Fill(ls, electrons.at(0).pt());
@@ -752,12 +810,15 @@ void TopMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
   htVsLS_.numerator -> Fill(ls, eventHT);
   eventHT_.numerator -> Fill(eventHT);
   eventHT_variableBinning_.numerator -> Fill(eventHT);
+  eventMHT_.numerator -> Fill(eventMHT.Pt());
+
 
   if (nmuons_ > 0){
       muVsLS_.numerator -> Fill(ls, muons.at(0).pt());
       if (nmuons_>1) {
           mu1Pt_mu2Pt_.numerator->Fill(muons.at(0).pt(),muons.at(1).pt());
           mu1Eta_mu2Eta_.numerator->Fill(muons.at(0).eta(),muons.at(1).eta());
+          invMass_mumu_.numerator->Fill(mll);
       }
       if(njets_>0){
           DeltaR_jet_Mu_.numerator -> Fill (deltaR(jets.at(0),muons.at(0)));
@@ -790,6 +851,7 @@ void TopMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
   
   for (unsigned int iMu=0; iMu<muons.size(); ++iMu){
       if (iMu>=nmuons_) break;
+     
       muPhi_.at(iMu).numerator  -> Fill(muons.at(iMu).phi());
       muEta_.at(iMu).numerator  -> Fill(muons.at(iMu).eta());
       muPt_.at(iMu).numerator   -> Fill(muons.at(iMu).pt() );
@@ -846,9 +908,9 @@ void TopMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
 
 void TopMonitor::fillHistoPSetDescription(edm::ParameterSetDescription & pset)
 {
-  pset.add<unsigned int>   ( "nbins");
-  pset.add<double>( "xmin" );
-  pset.add<double>( "xmax" );
+  pset.add<unsigned int>   ( "nbins",40);
+  pset.add<double>( "xmin",0 );
+  pset.add<double>( "xmax",100 );
 }
 
 void TopMonitor::fillHistoLSPSetDescription(edm::ParameterSetDescription & pset)
@@ -887,6 +949,12 @@ void TopMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
   desc.add<double>("workingpoint",     0.8484); // medium CSV
   //Suvankar
   desc.add<bool>("applyleptonPVcuts", false);
+  //george
+  desc.add<double>("invMassUppercut",-1.0);
+  desc.add<double>("invMassLowercut",-1.0);
+  desc.add<bool>("opsign",false);
+  desc.add<std::string>("MHTdefinition", "pt > 0");
+  desc.add<double>("MHTcut", -1);
 
   edm::ParameterSetDescription genericTriggerEventPSet;
   genericTriggerEventPSet.add<bool>("andOr");
@@ -914,6 +982,9 @@ void TopMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
   edm::ParameterSetDescription DRPSet;
   // Marina
   edm::ParameterSetDescription csvPSet;
+  //george
+ edm::ParameterSetDescription invMassPSet;
+ edm::ParameterSetDescription MHTPSet;
   fillHistoPSetDescription(metPSet);
   fillHistoPSetDescription(phiPSet);
   fillHistoPSetDescription(ptPSet);
@@ -922,6 +993,9 @@ void TopMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
   fillHistoPSetDescription(DRPSet);
   // Marina
   fillHistoPSetDescription(csvPSet);
+  //george
+  fillHistoPSetDescription(MHTPSet);
+  fillHistoPSetDescription(invMassPSet);  
   histoPSet.add<edm::ParameterSetDescription>("metPSet", metPSet);
   histoPSet.add<edm::ParameterSetDescription>("etaPSet", etaPSet);
   histoPSet.add<edm::ParameterSetDescription>("phiPSet", phiPSet);
@@ -930,6 +1004,11 @@ void TopMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
   histoPSet.add<edm::ParameterSetDescription>("DRPSet", DRPSet);
   // Marina
   histoPSet.add<edm::ParameterSetDescription>("csvPSet", csvPSet);
+  //george
+  histoPSet.add<edm::ParameterSetDescription>("invMassPSet", invMassPSet);
+  histoPSet.add<edm::ParameterSetDescription>("MHTPSet", MHTPSet);
+ 
+
   std::vector<double> bins = {0.,20.,40.,60.,80.,90.,100.,110.,120.,130.,140.,150.,160.,170.,180.,190.,200.,220.,240.,260.,280.,300.,350.,400.,450.,1000.};
   std::vector<double> eta_bins = {-3.,-2.5,-2.,-1.5,-1.,-.5,0.,.5,1.,1.5,2.,2.5,3.};
   histoPSet.add<std::vector<double> >("metBinning", bins);
@@ -940,6 +1019,7 @@ void TopMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
   histoPSet.add<std::vector<double> >("jetEtaBinning", eta_bins);
   histoPSet.add<std::vector<double> >("eleEtaBinning", eta_bins);
   histoPSet.add<std::vector<double> >("muEtaBinning", eta_bins);
+ 
 
   std::vector<double> bins_2D = {0.,40.,80.,100.,120.,140.,160.,180.,200.,240.,280.,350.,450.,1000.};
   std::vector<double> eta_bins_2D = {-3.,-2.,-1.,0.,1.,2.,3.};

--- a/DQMOffline/Trigger/plugins/TopMonitor.cc
+++ b/DQMOffline/Trigger/plugins/TopMonitor.cc
@@ -42,6 +42,10 @@ TopMonitor::TopMonitor( const edm::ParameterSet& iConfig ) :
   , jetEta_variable_binning_ ( iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetEtaBinning") )
   , muEta_variable_binning_ ( iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("muEtaBinning") )
   , eleEta_variable_binning_ ( iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("eleEtaBinning") )
+
+ //george
+ , invMass_mumu_variable_binning_ ( iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("invMassVariableBinning") )
+ , MHT_variable_binning_ ( iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("MHTVariableBinning") )
   , HT_variable_binning_2D_ ( iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("HTBinning2D") )
   , jetPt_variable_binning_2D_ ( iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetPtBinning2D") )
   , muPt_variable_binning_2D_ ( iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("muPtBinning2D") )
@@ -115,6 +119,10 @@ TopMonitor::TopMonitor( const edm::ParameterSet& iConfig ) :
     //george
     invMass_mumu_=empty;
     eventMHT_=empty;    
+    invMass_mumu_variableBinning_=empty;
+    eventMHT_variableBinning_=empty;
+
+
 
     //BTV
     DeltaR_jet_Mu_ = empty;
@@ -305,6 +313,9 @@ void TopMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
      histname = "invMass"; histtitle = "M mu1 mu2";
      bookME(ibooker,invMass_mumu_,histname,histtitle, invMass_mumu_binning_.nbins,invMass_mumu_binning_.xmin,invMass_mumu_binning_.xmax);      
       setMETitle(invMass_mumu_,"M(mu1,mu2) [GeV]","events");
+     histname = "invMass_variable"; histtitle = "M mu1 mu2 variable";
+     bookME(ibooker,invMass_mumu_variableBinning_,histname,histtitle,invMass_mumu_variable_binning_);
+     setMETitle(invMass_mumu_variableBinning_,"M(mu1,mu2) [GeV]","events / [GeV]");
   }
 
   if ( (njets_ > 0) && (nmuons_ > 0)){
@@ -522,7 +533,11 @@ void TopMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
   histname = "eventMHT"; histtitle = "event MHT";
   bookME(ibooker,eventMHT_,histname,histtitle, MHT_binning_.nbins,MHT_binning_.xmin, MHT_binning_.xmax);
   setMETitle(eventMHT_," event MHT [GeV]","events");
- 
+ histname = "eventMHT_variable"; histtitle = "event MHT variable";
+     bookME(ibooker,eventMHT_variableBinning_,histname,histtitle,MHT_variable_binning_);
+     setMETitle(eventMHT_variableBinning_,"event MHT [GeV]","events / [GeV]"); 
+
+
 
 
   // Initialize the GenericTriggerEventFlag
@@ -608,8 +623,8 @@ void TopMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
 
   if (nmuons_>1){
     TLorentzVector mu1,mu2;
-    mu1.SetPtEtaPhiM(muons.at(0).pt(),muons.at(0).eta(),muons.at(0).phi(),0.1);
-    mu2.SetPtEtaPhiM(muons.at(1).pt(),muons.at(1).eta(),muons.at(1).phi(),0.1);
+    mu1.SetPtEtaPhiM(muons.at(0).pt(),muons.at(0).eta(),muons.at(0).phi(),0.105);
+    mu2.SetPtEtaPhiM(muons.at(1).pt(),muons.at(1).eta(),muons.at(1).phi(),0.105);
     mll=(mu1+mu2).M();
     sign=muons.at(0).charge()*muons.at(1).charge();
     }
@@ -699,7 +714,9 @@ void TopMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
   metPhiME_.denominator -> Fill(phi);
   eventHT_.denominator -> Fill(eventHT);
   eventHT_variableBinning_.denominator -> Fill(eventHT);
+//george
   eventMHT_.denominator -> Fill(eventMHT.Pt());
+  eventMHT_variableBinning_.denominator -> Fill(eventMHT.Pt());
 
   int ls = iEvent.id().luminosityBlock();
   metVsLS_.denominator -> Fill(ls, met);
@@ -718,6 +735,7 @@ void TopMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
           mu1Pt_mu2Pt_.denominator->Fill(muons.at(0).pt(),muons.at(1).pt());
           mu1Eta_mu2Eta_.denominator->Fill(muons.at(0).eta(),muons.at(1).eta());
           invMass_mumu_.denominator->Fill(mll);
+          invMass_mumu_variableBinning_.denominator->Fill(mll);
       }
       if(njets_>0){
           DeltaR_jet_Mu_.denominator -> Fill (deltaR(jets.at(0),muons.at(0)));
@@ -811,6 +829,7 @@ void TopMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
   eventHT_.numerator -> Fill(eventHT);
   eventHT_variableBinning_.numerator -> Fill(eventHT);
   eventMHT_.numerator -> Fill(eventMHT.Pt());
+  eventMHT_variableBinning_.numerator -> Fill(eventMHT.Pt());
 
 
   if (nmuons_ > 0){
@@ -819,6 +838,7 @@ void TopMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
           mu1Pt_mu2Pt_.numerator->Fill(muons.at(0).pt(),muons.at(1).pt());
           mu1Eta_mu2Eta_.numerator->Fill(muons.at(0).eta(),muons.at(1).eta());
           invMass_mumu_.numerator->Fill(mll);
+          invMass_mumu_variableBinning_.numerator->Fill(mll);
       }
       if(njets_>0){
           DeltaR_jet_Mu_.numerator -> Fill (deltaR(jets.at(0),muons.at(0)));
@@ -1019,6 +1039,10 @@ void TopMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
   histoPSet.add<std::vector<double> >("jetEtaBinning", eta_bins);
   histoPSet.add<std::vector<double> >("eleEtaBinning", eta_bins);
   histoPSet.add<std::vector<double> >("muEtaBinning", eta_bins);
+//george
+histoPSet.add<std::vector<double> >("invMassVariableBinning", bins);
+  histoPSet.add<std::vector<double> >("MHTVariableBinning", bins);
+
  
 
   std::vector<double> bins_2D = {0.,40.,80.,100.,120.,140.,160.,180.,200.,240.,280.,350.,450.,1000.};

--- a/DQMOffline/Trigger/plugins/TopMonitor.h
+++ b/DQMOffline/Trigger/plugins/TopMonitor.h
@@ -62,6 +62,7 @@ struct PVcut {
   double dz;
 };
 
+
 //
 // class declaration
 //
@@ -123,6 +124,10 @@ private:
   MEbinning           DR_binning_;
   // Marina
   MEbinning           csv_binning_;
+  //george
+   MEbinning           invMass_mumu_binning_;
+   MEbinning           MHT_binning_;
+
 
   std::vector<double> met_variable_binning_;
   std::vector<double> HT_variable_binning_;
@@ -171,6 +176,9 @@ private:
   METME mu1Eta_mu2Eta_;
   METME elePt_muPt_;
   METME eleEta_muEta_;
+  //george
+  METME invMass_mumu_;
+  METME eventMHT_;  
 
   //BTV
   METME DeltaR_jet_Mu_;
@@ -220,6 +228,7 @@ private:
 
   METME eventHT_;
   METME eventHT_variableBinning_;
+  
 
   std::unique_ptr<GenericTriggerEventFlag> num_genTriggerEventFlag_;
   std::unique_ptr<GenericTriggerEventFlag> den_genTriggerEventFlag_;
@@ -229,6 +238,7 @@ private:
   StringCutObjectSelector<reco::GsfElectron,true> eleSelection_;
   StringCutObjectSelector<reco::Muon,true>        muoSelection_;
   StringCutObjectSelector<reco::PFJet,true   >    HTdefinition_;
+  
   //Suvankar
   StringCutObjectSelector<reco::Vertex,true>      vtxSelection_;
   
@@ -246,6 +256,18 @@ unsigned int njets_;
   //Suvankar
   PVcut  lepPVcuts_;
   bool usePVcuts_;
+
+  //george
+  double invMassUppercut_;
+  double invMassLowercut_;
+  bool opsign_;
+  StringCutObjectSelector<reco::PFJet,true   >    MHTdefinition_;
+  double MHTcut_;
+  double mll;
+  int   sign;
+  
+
+
   
 };
 

--- a/DQMOffline/Trigger/plugins/TopMonitor.h
+++ b/DQMOffline/Trigger/plugins/TopMonitor.h
@@ -137,6 +137,9 @@ private:
   std::vector<double> jetEta_variable_binning_;
   std::vector<double> muEta_variable_binning_;
   std::vector<double> eleEta_variable_binning_;
+   //george
+  std::vector<double> invMass_mumu_variable_binning_;
+  std::vector<double> MHT_variable_binning_;
 
   std::vector<double> HT_variable_binning_2D_;
   std::vector<double> jetPt_variable_binning_2D_;
@@ -179,6 +182,8 @@ private:
   //george
   METME invMass_mumu_;
   METME eventMHT_;  
+  METME invMass_mumu_variableBinning_;
+  METME eventMHT_variableBinning_;
 
   //BTV
   METME DeltaR_jet_Mu_;

--- a/DQMOffline/Trigger/python/SusyMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/SusyMonitoring_Client_cff.py
@@ -1,4 +1,63 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+
+
+#george
+double_soft_muon_muonpt_efficiency = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/SUSY/SOS/Muon/*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages 
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+
+    "effic_muPt_1       'efficiency vs muon pt; muon pt [GeV]; efficiency' muPt_1_numerator       muPt_1_variableBinning_denominator",
+   "effic_muEta_1       'efficiency vs muon eta; muon eta ; efficiency' muEta_1_variableBinning_numerator       muEta_1_variableBinning_denominator",
+     "effic_muPhi_1       'efficiency vs muon phi; muon phi ; efficiency' muPhi_1_numerator       muPhi_1_denominator",
+
+     "effic_muPt_2       'efficiency vs muon pt; muon pt [GeV]; efficiency' muPt_2_variableBinning_numerator       muPt_2_variableBinning_denominator",
+      "effic_muEta_2       'efficiency vs muon eta; muon eta ; efficiency' muEta_2_variableBinning_numerator       muEta_2_variableBinning_denominator",
+      "effic_muPhi_2       'efficiency vs muon phi; muon phi ; efficiency' muPhi_2_numerator       muPhi_2_denominator",
+
+       "effic_mu1mu2Pt       'efficiency vs mu1mu2 Pt; mu1 Pt [GeV]; mu2 Pt [GeV]' mu1Pt_mu2Pt_numerator   mu1Pt_mu2Pt_denominator",
+       "effic_mu1mu2Eta       'efficiency vs mu1mu2 Eta; mu1 Eta ; mu2 Eta' mu1Eta_mu2Eta_numerator   mu1Eta_mu2Eta_denominator",
+
+        ),
+)
+
+double_soft_muon_metpt_efficiency = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/SUSY/SOS/MET/*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages 
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+      "effic_MET       'efficiency vs met pt; met [GeV]; efficiency' met_numerator       met_denominator",
+
+        ),
+)
+
+double_soft_muon_mll_efficiency = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/SUSY/SOS/Mll/*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages 
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+      "effic_Mll       'efficiency vs inv.mass; Mll [GeV]; efficiency' invMass_numerator       invMass_denominator",
+
+        ),
+)
+
+double_soft_muon_mhtpt_efficiency = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/SUSY/SOS/MHT/*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages 
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+      "effic_MHT       'efficiency vs MHT; met [GeV]; efficiency' eventMHT_numerator       eventMHT_denominator",
+
+        ),
+)
 
 susyClient = cms.Sequence(
+double_soft_muon_muonpt_efficiency
++double_soft_muon_metpt_efficiency
++double_soft_muon_mll_efficiency
++double_soft_muon_mhtpt_efficiency
+
 )

--- a/DQMOffline/Trigger/python/SusyMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/SusyMonitoring_Client_cff.py
@@ -40,6 +40,7 @@ double_soft_muon_mll_efficiency = DQMEDHarvester("DQMGenericClient",
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
       "effic_Mll       'efficiency vs inv.mass; Mll [GeV]; efficiency' invMass_numerator       invMass_denominator",
+     "effic_Mll_variableBinning       'efficiency vs inv.mass; Mll [GeV]; efficiency' invMass_variable_numerator       invMass_variable_denominator",
 
         ),
 )
@@ -50,14 +51,61 @@ double_soft_muon_mhtpt_efficiency = DQMEDHarvester("DQMGenericClient",
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
       "effic_MHT       'efficiency vs MHT; met [GeV]; efficiency' eventMHT_numerator       eventMHT_denominator",
+    "effic_MHT_variableBinning       'efficiency vs MHT; met [GeV]; efficiency' eventMHT_variable_numerator       eventMHT_variable_denominator",
 
         ),
 )
+#backup1
+double_soft_muon_backup_70_metpt_efficiency = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/SUSY/SOS/backup70/MET/*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages 
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+      "effic_MET       'efficiency vs met pt; met [GeV]; efficiency' met_numerator       met_denominator",
+
+        ),
+)
+double_soft_muon_backup_70_mhtpt_efficiency = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/SUSY/SOS/backup70/MHT/*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages 
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+      "effic_MHT       'efficiency vs MHT; met [GeV]; efficiency' eventMHT_numerator       eventMHT_denominator",
+    "effic_MHT_variableBinning       'efficiency vs MHT; met [GeV]; efficiency' eventMHT_variable_numerator       eventMHT_variable_denominator",
+
+        ),
+)
+
+#backup1
+double_soft_muon_backup_90_metpt_efficiency = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/SUSY/SOS/backup90/MET/*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages 
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+      "effic_MET       'efficiency vs met pt; met [GeV]; efficiency' met_numerator       met_denominator",
+
+        ),
+)
+double_soft_muon_backup_90_mhtpt_efficiency = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/SUSY/SOS/backup90/MHT/*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages 
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+      "effic_MHT       'efficiency vs MHT; met [GeV]; efficiency' eventMHT_numerator       eventMHT_denominator",
+    "effic_MHT_variableBinning       'efficiency vs MHT; met [GeV]; efficiency' eventMHT_variable_numerator       eventMHT_variable_denominator",
+
+        ),
+)
+
+
 
 susyClient = cms.Sequence(
 double_soft_muon_muonpt_efficiency
 +double_soft_muon_metpt_efficiency
 +double_soft_muon_mll_efficiency
 +double_soft_muon_mhtpt_efficiency
-
++double_soft_muon_backup_70_metpt_efficiency
++double_soft_muon_backup_70_mhtpt_efficiency
++double_soft_muon_backup_90_metpt_efficiency
++double_soft_muon_backup_90_mhtpt_efficiency
 )

--- a/DQMOffline/Trigger/python/SusyMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SusyMonitoring_cff.py
@@ -56,10 +56,11 @@ double_soft_muon_mll.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
 double_soft_muon_mll.MHTcut            = cms.double(150)
 double_soft_muon_mll.metSelection      = cms.string('pt>150')
 # Binning
+double_soft_muon_mll.histoPSet.invMassVariableBinning      =cms.vdouble(8,12,15,20,25,30,35,40,45,47,50,60)
 
 # Triggers
 double_soft_muon_mll.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoubleMu3_DZ_PFMET50_PFMHT60_v*')
-double_soft_muon_mll.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_TripleMu_10_5_5_DZ_v*')
+double_soft_muon_mll.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Dimuon12_Upsilon_eta1p5_v*')
 
 #mht
 double_soft_muon_mhtpt = hltTOPmonitoring.clone()
@@ -74,12 +75,87 @@ double_soft_muon_mhtpt.metSelection     = cms.string('pt>150')
 double_soft_muon_mhtpt.invMassUppercut       = cms.double(50)
 double_soft_muon_mhtpt.invMassLowercut       = cms.double(10)
 # Binning
+double_soft_muon_mhtpt.histoPSet.MHTVariableBinning      =cms.vdouble(50,60,70,80,90,100,110,120,130,150,200,300)
 
 # Triggers
 double_soft_muon_mhtpt.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoubleMu3_DZ_PFMET50_PFMHT60_v*')
 double_soft_muon_mhtpt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
 
+#backup1
+#met
+double_soft_muon_backup_70_metpt = hltTOPmonitoring.clone()
+double_soft_muon_backup_70_metpt.FolderName   = cms.string('HLT/SUSY/SOS/Baclup70/MET/')
+# Selections
+double_soft_muon_backup_70_metpt.nmuons           = cms.uint32(2)
+double_soft_muon_backup_70_metpt.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_backup_70_metpt.HTcut            = cms.double(60)
+double_soft_muon_backup_70_metpt.muoSelection     =cms.string('pt>18 & abs(eta)<2.4')
+double_soft_muon_backup_70_metpt.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_backup_70_metpt.MHTcut           = cms.double(150)
+double_soft_muon_backup_70_metpt.invMassUppercut       = cms.double(50)
+double_soft_muon_backup_70_metpt.invMassLowercut       = cms.double(10)
+# Binning
+double_soft_muon_backup_70_metpt.histoPSet.metPSet   =cms.PSet(nbins=cms.uint32(50),xmin=cms.double(50),xmax=cms.double(300) )
+# Triggers
+double_soft_muon_backup_70_metpt.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoubleMu3_DZ_PFMET70_PFMHT70_v*')
+double_soft_muon_backup_70_metpt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
 
+#mht
+double_soft_muon_backup_70_mhtpt = hltTOPmonitoring.clone()
+double_soft_muon_backup_70_mhtpt.FolderName   = cms.string('HLT/SUSY/SOS/backup70/MHT/')
+# Selections
+double_soft_muon_backup_70_mhtpt.nmuons           = cms.uint32(2)
+double_soft_muon_backup_70_mhtpt.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_backup_70_mhtpt.HTcut            = cms.double(60)
+double_soft_muon_backup_70_mhtpt.muoSelection     =cms.string('pt>18 & abs(eta)<2.0')
+double_soft_muon_backup_70_mhtpt.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_backup_70_mhtpt.metSelection     = cms.string('pt>150')
+double_soft_muon_backup_70_mhtpt.invMassUppercut       = cms.double(50)
+double_soft_muon_backup_70_mhtpt.invMassLowercut       = cms.double(10)
+# Binning
+double_soft_muon_backup_70_mhtpt.histoPSet.MHTVariableBinning      =cms.vdouble(50,60,70,80,90,100,110,120,130,150,200,300)
+
+# Triggers
+double_soft_muon_backup_70_mhtpt.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoubleMu3_DZ_PFMET70_PFMHT70_v*')
+double_soft_muon_backup_70_mhtpt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
+
+#backup2
+#met
+double_soft_muon_backup_90_metpt = hltTOPmonitoring.clone()
+double_soft_muon_backup_90_metpt.FolderName   = cms.string('HLT/SUSY/SOS/Baclup90/MET/')
+# Selections
+double_soft_muon_backup_90_metpt.nmuons           = cms.uint32(2)
+double_soft_muon_backup_90_metpt.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_backup_90_metpt.HTcut            = cms.double(60)
+double_soft_muon_backup_90_metpt.muoSelection     =cms.string('pt>18 & abs(eta)<2.4')
+double_soft_muon_backup_90_metpt.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_backup_90_metpt.MHTcut           = cms.double(150)
+double_soft_muon_backup_90_metpt.invMassUppercut       = cms.double(50)
+double_soft_muon_backup_90_metpt.invMassLowercut       = cms.double(10)
+# Binning
+double_soft_muon_backup_90_metpt.histoPSet.metPSet   =cms.PSet(nbins=cms.uint32(50),xmin=cms.double(50),xmax=cms.double(300) )
+# Triggers
+double_soft_muon_backup_90_metpt.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoubleMu3_DZ_PFMET90_PFMHT90_v*')
+double_soft_muon_backup_90_metpt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
+
+#mht
+double_soft_muon_backup_90_mhtpt = hltTOPmonitoring.clone()
+double_soft_muon_backup_90_mhtpt.FolderName   = cms.string('HLT/SUSY/SOS/backup90/MHT/')
+# Selections
+double_soft_muon_backup_90_mhtpt.nmuons           = cms.uint32(2)
+double_soft_muon_backup_90_mhtpt.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_backup_90_mhtpt.HTcut            = cms.double(60)
+double_soft_muon_backup_90_mhtpt.muoSelection     =cms.string('pt>18 & abs(eta)<2.0')
+double_soft_muon_backup_90_mhtpt.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_backup_90_mhtpt.metSelection     = cms.string('pt>150')
+double_soft_muon_backup_90_mhtpt.invMassUppercut       = cms.double(50)
+double_soft_muon_backup_90_mhtpt.invMassLowercut       = cms.double(10)
+# Binning
+double_soft_muon_backup_90_mhtpt.histoPSet.MHTVariableBinning      =cms.vdouble(50,60,70,80,90,100,110,120,130,150,200,300)
+
+# Triggers
+double_soft_muon_backup_90_mhtpt.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoubleMu3_DZ_PFMET90_PFMHT90_v*')
+double_soft_muon_backup_90_mhtpt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
 
 susyMonitorHLT = cms.Sequence(
     susyHLTRazorMonitoring
@@ -87,4 +163,8 @@ susyMonitorHLT = cms.Sequence(
 +double_soft_muon_metpt
 +double_soft_muon_mhtpt
 +double_soft_muon_mll
++double_soft_muon_backup_70_metpt
++double_soft_muon_backup_70_mhtpt
++double_soft_muon_backup_90_metpt
++double_soft_muon_backup_90_mhtpt
 )

--- a/DQMOffline/Trigger/python/SusyMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SusyMonitoring_cff.py
@@ -2,6 +2,89 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.RazorMonitor_cff import *
 
+
+from DQMOffline.Trigger.TopMonitor_cfi import hltTOPmonitoring
+
+
+#george
+#muon
+double_soft_muon_muonpt = hltTOPmonitoring.clone()
+double_soft_muon_muonpt.FolderName   = cms.string('HLT/SUSY/SOS/Muon/')
+# Selections
+double_soft_muon_muonpt.nmuons           = cms.uint32(2)
+double_soft_muon_muonpt.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_muonpt.HTcut            = cms.double(60)
+double_soft_muon_muonpt.metSelection     =cms.string('pt>150')
+double_soft_muon_muonpt.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_muonpt.MHTcut           = cms.double(150)
+double_soft_muon_muonpt.invMassUppercut  = cms.double(50)
+double_soft_muon_muonpt.invMassLowercut  = cms.double(10)
+# Binning
+double_soft_muon_muonpt.histoPSet.muPtBinning      =cms.vdouble(0,2,5,7,10,12,15,17,20,25,30,50)
+double_soft_muon_muonpt.histoPSet.muPtBinning2D    =cms.vdouble(0,2,5,7,10,12,15,17,20,25,30,50)
+# Triggers
+double_soft_muon_muonpt.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoubleMu3_DZ_PFMET50_PFMHT60_v*')
+double_soft_muon_muonpt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFMET140_PFMHT140_v*')
+
+#met
+double_soft_muon_metpt = hltTOPmonitoring.clone()
+double_soft_muon_metpt.FolderName   = cms.string('HLT/SUSY/SOS/MET/')
+# Selections
+double_soft_muon_metpt.nmuons           = cms.uint32(2)
+double_soft_muon_metpt.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_metpt.HTcut            = cms.double(60)
+double_soft_muon_metpt.muoSelection     =cms.string('pt>18 & abs(eta)<2.4')
+double_soft_muon_metpt.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_metpt.MHTcut           = cms.double(150)
+double_soft_muon_metpt.invMassUppercut       = cms.double(50)
+double_soft_muon_metpt.invMassLowercut       = cms.double(10)
+# Binning
+double_soft_muon_metpt.histoPSet.metPSet   =cms.PSet(nbins=cms.uint32(50),xmin=cms.double(50),xmax=cms.double(300) )
+# Triggers
+double_soft_muon_metpt.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoubleMu3_DZ_PFMET50_PFMHT60_v*')
+double_soft_muon_metpt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
+
+#inv Mass
+double_soft_muon_mll = hltTOPmonitoring.clone()
+double_soft_muon_mll.FolderName   = cms.string('HLT/SUSY/SOS/Mll/')
+# Selections
+double_soft_muon_mll.nmuons           = cms.uint32(2)
+double_soft_muon_mll.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_mll.HTcut            = cms.double(60)
+double_soft_muon_mll.muoSelection     =cms.string('pt>10 & abs(eta)<2.4')
+double_soft_muon_mll.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_mll.MHTcut            = cms.double(150)
+double_soft_muon_mll.metSelection      = cms.string('pt>150')
+# Binning
+
+# Triggers
+double_soft_muon_mll.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoubleMu3_DZ_PFMET50_PFMHT60_v*')
+double_soft_muon_mll.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_TripleMu_10_5_5_DZ_v*')
+
+#mht
+double_soft_muon_mhtpt = hltTOPmonitoring.clone()
+double_soft_muon_mhtpt.FolderName   = cms.string('HLT/SUSY/SOS/MHT/')
+# Selections
+double_soft_muon_mhtpt.nmuons           = cms.uint32(2)
+double_soft_muon_mhtpt.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_mhtpt.HTcut            = cms.double(60)
+double_soft_muon_mhtpt.muoSelection     =cms.string('pt>18 & abs(eta)<2.0')
+double_soft_muon_mhtpt.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
+double_soft_muon_mhtpt.metSelection     = cms.string('pt>150')
+double_soft_muon_mhtpt.invMassUppercut       = cms.double(50)
+double_soft_muon_mhtpt.invMassLowercut       = cms.double(10)
+# Binning
+
+# Triggers
+double_soft_muon_mhtpt.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoubleMu3_DZ_PFMET50_PFMHT60_v*')
+double_soft_muon_mhtpt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
+
+
+
 susyMonitorHLT = cms.Sequence(
     susyHLTRazorMonitoring
++double_soft_muon_muonpt
++double_soft_muon_metpt
++double_soft_muon_mhtpt
++double_soft_muon_mll
 )

--- a/DQMOffline/Trigger/python/TopMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/TopMonitor_cfi.py
@@ -48,6 +48,18 @@ hltTOPmonitoring.leptonPVcuts = cms.PSet(
   dxy = cms.double(   9999.   ),
   dz  = cms.double(   9999.   ),
 )
+#george
+hltTOPmonitoring.histoPSet.invMassPSet = cms.PSet(
+  nbins = cms.uint32( 40 ),
+  xmin  = cms.double( 0.0 ),
+  xmax  = cms.double( 80.0  ),
+)
+#hltTOPmonitoring.histoPSet.MHTPSet = cms.PSet(
+#  nbins = cms.uint32(   80  ),
+#  xmin  = cms.double(   60   ),
+#  xmax  = cms.double(  300  ),
+#)
+
 
 #MET and HT binning
 hltTOPmonitoring.histoPSet.metBinning = cms.vdouble(0,20,40,60,80,100,125,150,175,200)
@@ -102,4 +114,9 @@ hltTOPmonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 24, 25,
 hltTOPmonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
 hltTOPmonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
 hltTOPmonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(0)
-
+#george
+hltTOPmonitoring.MHTdefinition = cms.string('pt>30 & abs(eta)<2.5')
+hltTOPmonitoring.MHTcut = cms.double(-1)
+hltTOPmonitoring.invMassUppercut=cms.double(-1.0)
+hltTOPmonitoring.invMassLowercut=cms.double(-1.0)
+hltTOPmonitoring.opsign=cms.bool(False)


### PR DESCRIPTION
DQM code for monitoring the HLT_DoubleMu3_DZ_PFMET50_PFMHT60 path. The code is based on the topMonitoring. It modifies and introduces PFMHT and Mll cuts.  