### PR TITLE
Fix crash from exception handling

### DIFF
--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -195,11 +195,6 @@ namespace edm {
     /// Tell the OutputModule that is must end the current file.
     void doCloseFile();
 
-    /// Tell the OutputModule to open an output file, if one is not
-    /// already open.
-    void maybeOpenFile();
-
-
     // Do the end-of-file tasks; this is only called internally, after
     // the appropriate tests have been done.
     virtual void reallyCloseFile();
@@ -225,8 +220,6 @@ namespace edm {
     virtual void respondToCloseInputFile(FileBlock const&) {}
 
     virtual bool isFileOpen() const { return true; }
-
-    virtual void reallyOpenFile() {}
 
     void keepThisBranch(BranchDescription const& desc,
                         std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc,

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -180,9 +180,6 @@ namespace edm {
     // Call closeFile() on all OutputModules.
     void closeOutputFiles();
 
-    // Call openNewFileIfNeeded() on all OutputModules
-    void openNewOutputFilesIfNeeded();
-
     // Call openFiles() on all OutputModules
     void openOutputFiles(FileBlock& fb);
 

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -133,13 +133,6 @@ namespace edm {
       for_all(subProcesses_, [](auto& subProcess) { subProcess.closeOutputFiles(); });
     }
 
-    // Call openNewFileIfNeeded() on all OutputModules
-    void openNewOutputFilesIfNeeded() {
-      ServiceRegistry::Operate operate(serviceToken_);
-      schedule_->openNewOutputFilesIfNeeded();
-      for_all(subProcesses_, [](auto& subProcess) { subProcess.openNewOutputFilesIfNeeded(); });
-    }
-
     // Call openFiles() on all OutputModules
     void openOutputFiles(FileBlock& fb) {
       ServiceRegistry::Operate operate(serviceToken_);

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -215,10 +215,6 @@ namespace edm {
       /// Tell the OutputModule that is must end the current file.
       void doCloseFile();
       
-      /// Tell the OutputModule to open an output file, if one is not
-      /// already open.
-      void maybeOpenFile();
-      
       void registerProductsAndCallbacks(OutputModuleBase const*, ProductRegistry const*) {}
 
       bool prePrefetchSelection(StreamID id, EventPrincipal const&, ModuleCallingContext const*);
@@ -238,7 +234,6 @@ namespace edm {
       virtual void writeRun(RunForOutput const&) = 0;
       virtual void openFile(FileBlock const&) {}
       virtual bool isFileOpen() const { return true; }
-      virtual void reallyOpenFile() {}
       
       virtual void preallocStreams(unsigned int){}
       virtual void doBeginStream_(StreamID){}

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -209,10 +209,6 @@ namespace edm {
       /// Tell the OutputModule that is must end the current file.
       void doCloseFile();
       
-      /// Tell the OutputModule to open an output file, if one is not
-      /// already open.
-      void maybeOpenFile();
-      
       void registerProductsAndCallbacks(OutputModuleBase const*, ProductRegistry const*) {}
 
       bool prePrefetchSelection(StreamID id, EventPrincipal const&, ModuleCallingContext const*);
@@ -234,7 +230,6 @@ namespace edm {
       virtual void writeRun(RunForOutput const&) = 0;
       virtual void openFile(FileBlock const&) {}
       virtual bool isFileOpen() const { return true; }
-      virtual void reallyOpenFile() {}
       
       virtual void doBeginRun_(RunForOutput const&){}
       virtual void doEndRun_(RunForOutput const& ){}

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -341,10 +341,6 @@ namespace edm {
     respondToCloseInputFile(fb);
   }
 
-  void OutputModule::maybeOpenFile() {
-    if(!isFileOpen()) reallyOpenFile();
-  }
-
   void OutputModule::doCloseFile() {
     if(isFileOpen()) {
       reallyCloseFile();

--- a/FWCore/Framework/src/OutputModuleCommunicator.h
+++ b/FWCore/Framework/src/OutputModuleCommunicator.h
@@ -45,8 +45,6 @@ namespace edm {
     ///\return true if output module wishes to close its file
     virtual bool shouldWeCloseFile() const = 0;
     
-    virtual void openNewFileIfNeeded() = 0;
-    
     ///\return true if no event filtering is applied to OutputModule
     virtual bool wantAllEvents() const = 0;
     

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.cc
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.cc
@@ -28,12 +28,6 @@ namespace edm {
 
   template<typename T>
   void
-  OutputModuleCommunicatorT<T>::openNewFileIfNeeded() {
-    module().maybeOpenFile();
-  }
-
-  template<typename T>
-  void
   OutputModuleCommunicatorT<T>::openFile(edm::FileBlock const& fb) {
     module().doOpenFile(fb);
   }

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.h
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.h
@@ -34,8 +34,6 @@ namespace edm {
     ///\return true if output module wishes to close its file
     virtual bool shouldWeCloseFile() const override;
     
-    virtual void openNewFileIfNeeded() override;
-    
     ///\return true if no event filtering is applied to OutputModule
     virtual bool wantAllEvents() const override;
     

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -983,11 +983,6 @@ namespace edm {
     for_all(all_output_communicators_, std::bind(&OutputModuleCommunicator::closeFile, _1));
   }
 
-  void Schedule::openNewOutputFilesIfNeeded() {
-    using std::placeholders::_1;
-    for_all(all_output_communicators_, std::bind(&OutputModuleCommunicator::openNewFileIfNeeded, _1));
-  }
-
   void Schedule::openOutputFiles(FileBlock& fb) {
     using std::placeholders::_1;
     for_all(all_output_communicators_, std::bind(&OutputModuleCommunicator::openFile, _1, std::cref(fb)));

--- a/FWCore/Framework/src/TransitionProcessors.icc
+++ b/FWCore/Framework/src/TransitionProcessors.icc
@@ -352,8 +352,8 @@ private:
     iEP.openOutputFiles();
   }
   
-  RunsInFileProcessor runs_;
   std::unique_ptr<FileResources> filesOpen_;
+  RunsInFileProcessor runs_;
   bool doNotMerge_;
 };
 

--- a/FWCore/Framework/src/global/OutputModuleBase.cc
+++ b/FWCore/Framework/src/global/OutputModuleBase.cc
@@ -309,10 +309,6 @@ namespace edm {
       doRespondToCloseInputFile_(fb);
     }
         
-    void OutputModuleBase::maybeOpenFile() {
-      if(!isFileOpen()) reallyOpenFile();
-    }
-    
     void OutputModuleBase::doCloseFile() {
       if(isFileOpen()) {
         reallyCloseFile();

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -317,10 +317,6 @@ namespace edm {
       doRespondToCloseInputFile_(fb);
     }
     
-    void OutputModuleBase::maybeOpenFile() {
-      if(!isFileOpen()) reallyOpenFile();
-    }
-    
     void OutputModuleBase::doCloseFile() {
       if(isFileOpen()) {
         reallyCloseFile();

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -140,7 +140,7 @@ namespace edm {
     virtual void writeLuminosityBlock(LuminosityBlockForOutput const& lb) override;
     virtual void writeRun(RunForOutput const& r) override;
     virtual bool isFileOpen() const override;
-    virtual void reallyOpenFile() override;
+    void reallyOpenFile();
     virtual void reallyCloseFile() override;
     virtual void beginJob() override;
 


### PR DESCRIPTION
The framework was giving the wrong order of operations to the OutputModules in the case of an exception. The OutputModules were told to close their output files before being told to write the LuminosityBlock.

This should fix the crashes seen in the IB RelVals.