### PR TITLE
Update Vcal Calibration (backport of PR #19181 in 92X)

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -173,6 +173,24 @@ def customiseFor19098(process):
 		if hasattr(producer, "infinitesimalPt"): del producer.infinitesimalPt
 	return process
 
+def customiseFor19181_pixel_phase0(process):
+    for producer in producers_by_type(process, "SiPixelClusterProducer"):
+        producer.VCaltoElectronGain_L1 = cms.int32(65)
+        producer.VCaltoElectronOffset_L1 = cms.int32(-414)
+        producer.ClusterThreshold    = cms.int32(4000)
+        producer.ClusterThreshold_L1 = cms.int32(4000)
+    return process
+
+def customiseFor19181_pixel_phase1(process):
+    for producer in producers_by_type(process, "SiPixelClusterProducer"):
+        producer.VCaltoElectronGain    = cms.int32(47)
+        producer.VCaltoElectronGain_L1 = cms.int32(50)
+        producer.VCaltoElectronOffset    = cms.int32(-60)
+        producer.VCaltoElectronOffset_L1 = cms.int32(-670)
+        producer.ClusterThreshold    = cms.int32(4000)
+        producer.ClusterThreshold_L1 = cms.int32(2000)
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -188,5 +206,10 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     process = customiseFor18429(process)
     process = customiseFor18559(process)
     process = customiseFor19098(process)
+
+    if (menuType == "GRun2016"):
+        process = customiseFor19181_pixel_phase0(process)
+    else:
+        process = customiseFor19181_pixel_phase1(process)
 
     return process

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelClusterizerBase.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelClusterizerBase.h
@@ -5,6 +5,7 @@
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h"
 #include <vector>
 
@@ -52,11 +53,13 @@ public:
 
   virtual void clusterizeDetUnit( const edm::DetSet<PixelDigi> & input,	
 				  const PixelGeomDetUnit * pixDet,
+				  const TrackerTopology* tTopo,
 				  const std::vector<short>& badChannels,
 				  edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) = 0;
 
   virtual void clusterizeDetUnit( const edmNew::DetSet<SiPixelCluster> & input,
                                   const PixelGeomDetUnit * pixDet,
+				  const TrackerTopology* tTopo,
                                   const std::vector<short>& badChannels,
                                   edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) = 0;
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -27,7 +27,6 @@
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 //#include "Geometry/CommonTopologies/RectangularPixelTopology.h"
-#include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
 
 // STL
 #include <stack>
@@ -47,9 +46,12 @@ PixelThresholdClusterizer::PixelThresholdClusterizer
     // Get thresholds in electrons
     thePixelThreshold( conf.getParameter<int>("ChannelThreshold") ),
     theSeedThreshold( conf.getParameter<int>("SeedThreshold") ),
-    theClusterThreshold( conf.getParameter<double>("ClusterThreshold") ),
+    theClusterThreshold( conf.getParameter<int>("ClusterThreshold") ),
+    theClusterThreshold_L1( conf.getParameter<int>("ClusterThreshold_L1") ),
     theConversionFactor( conf.getParameter<int>("VCaltoElectronGain") ),
+    theConversionFactor_L1( conf.getParameter<int>("VCaltoElectronGain_L1") ),
     theOffset( conf.getParameter<int>("VCaltoElectronOffset") ),
+    theOffset_L1( conf.getParameter<int>("VCaltoElectronOffset_L1") ),
     theStackADC_( conf.exists("AdcFullScaleStack") ? conf.getParameter<int>("AdcFullScaleStack") : 255 ),
     theFirstStack_( conf.exists("FirstStackLayer") ? conf.getParameter<int>("FirstStackLayer") : 5 ),
     theElectronPerADCGain_( conf.exists("ElectronPerADCGain") ? conf.getParameter<double>("ElectronPerADCGain") : 135. ),
@@ -62,6 +64,28 @@ PixelThresholdClusterizer::PixelThresholdClusterizer
 }
 /////////////////////////////////////////////////////////////////////////////
 PixelThresholdClusterizer::~PixelThresholdClusterizer() {}
+
+
+// Configuration descriptions
+void
+PixelThresholdClusterizer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // siPixelClusters
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("siPixelDigis"));
+  desc.add<int>("ChannelThreshold", 1000);
+  desc.addUntracked<bool>("MissCalibrate", true);
+  desc.add<bool>("SplitClusters", false);
+  desc.add<int>("VCaltoElectronGain", 65);
+  desc.add<int>("VCaltoElectronGain_L1", 65);
+  desc.add<int>("VCaltoElectronOffset", -414);
+  desc.add<int>("VCaltoElectronOffset_L1", -414);
+  desc.add<std::string>("payloadType", "Offline");
+  desc.add<int>("SeedThreshold", 1000);
+  desc.add<int>("ClusterThreshold_L1", 4000);
+  desc.add<int>("ClusterThreshold", 4000);
+  desc.add<int>("maxNumberOfClusters", -1);
+  descriptions.add("siPixelClusters", desc);
+}
 
 //----------------------------------------------------------------------------
 //!  Prepare the Clusterizer to work on a particular DetUnit.  Re-init the
@@ -104,6 +128,7 @@ bool PixelThresholdClusterizer::setup(const PixelGeomDetUnit * pixDet)
 template<typename T>
 void PixelThresholdClusterizer::clusterizeDetUnitT( const T & input,
 						   const PixelGeomDetUnit * pixDet,
+						   const TrackerTopology* tTopo,
 						   const std::vector<short>& badChannels,
                                                    edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) {
   
@@ -118,6 +143,11 @@ void PixelThresholdClusterizer::clusterizeDetUnitT( const T & input,
     return;
   
   detid_ = input.detId();
+  
+  // Set separate cluster threshold for L1 (needed for phase1)
+  auto clusterThreshold = theClusterThreshold;
+  layer_ = (DetId(detid_).subdetId()==1) ? tTopo->pxbLayer(detid_) : 0;
+  if (layer_==1) clusterThreshold = theClusterThreshold_L1;
   
   //  Copy PixelDigis to the buffer array; select the seed pixels
   //  on the way, and store them in theSeeds.
@@ -138,7 +168,7 @@ void PixelThresholdClusterizer::clusterizeDetUnitT( const T & input,
 	  
 	  //  Check if the cluster is above threshold  
 	  // (TO DO: one is signed, other unsigned, gcc warns...)
-	  if ( cluster.charge() >= theClusterThreshold) 
+	  if ( cluster.charge() >= clusterThreshold) 
 	    {
 	      // std::cout << "putting in this cluster " << i << " " << cluster.charge() << " " << cluster.pixelADC().size() << endl;
               // sort by row (x)
@@ -203,16 +233,19 @@ void PixelThresholdClusterizer::copy_to_buffer( DigiIterator begin, DigiIterator
   int electron[end-begin];
   memset(electron, 0, sizeof(electron));
   if ( doMissCalibrate ) {
-    (*theSiPixelGainCalibrationService_).calibrate(detid_,begin,end,theConversionFactor, theOffset,electron);
+    if (layer_==1) {
+      (*theSiPixelGainCalibrationService_).calibrate(detid_,begin,end,theConversionFactor_L1, theOffset_L1,electron);
+    } else {
+      (*theSiPixelGainCalibrationService_).calibrate(detid_,begin,end,theConversionFactor,    theOffset,  electron);
+    }
   } else {
-    int layer = (DetId(detid_).subdetId()==1) ? PXBDetId(detid_).layer() : 0;
     int i=0;
     for(DigiIterator di = begin; di != end; ++di) {
       auto adc = di->adc();
       const float gain = theElectronPerADCGain_; // default: 1 ADC = 135 electrons
       const float pedestal = 0.; //
       electron[i] = int(adc * gain + pedestal);
-      if (layer>=theFirstStack_) {
+      if (layer_>=theFirstStack_) {
 	if (theStackADC_==1&&adc==1) {
 	  electron[i] = int(255*135); // Arbitrarily use overflow value.
 	}
@@ -273,8 +306,6 @@ void PixelThresholdClusterizer::copy_to_buffer( ClusterIterator begin, ClusterIt
 int PixelThresholdClusterizer::calibrate(int adc, int col, int row) 
 {
   int electrons = 0;
-  int layer= 0;
-  if (DetId(detid_).subdetId()==1){ layer = PXBDetId(detid_).layer();}
 
   if ( doMissCalibrate ) 
     {
@@ -315,7 +346,11 @@ int PixelThresholdClusterizer::calibrate(int adc, int col, int row)
 	  //const float p3 = 113.0; 
 	  //float vcal = ( atanh( (adc-p3)/p2) + p1)/p0;
 	  
-	  electrons = int( vcal * theConversionFactor + theOffset); 
+	  if (layer_==1) {
+	    electrons = int( vcal * theConversionFactor_L1 + theOffset_L1); 
+	  } else {
+	    electrons = int( vcal * theConversionFactor + theOffset); 
+	  }
 	}
     }
   else 
@@ -324,7 +359,7 @@ int PixelThresholdClusterizer::calibrate(int adc, int col, int row)
       const float gain = theElectronPerADCGain_; // default: 1 ADC = 135 electrons
       const float pedestal = 0.; //
       electrons = int(adc * gain + pedestal);
-      if (layer>=theFirstStack_) {
+      if (layer_>=theFirstStack_) {
 	if (theStackADC_==1&&adc==1)
 	  {
 	    electrons = int(255*135); // Arbitrarily use overflow value.
@@ -427,6 +462,10 @@ PixelThresholdClusterizer::make_cluster( const SiPixelCluster::PixelPos& pix,
   
   if (dead_flag && doSplitClusters) 
     {
+      // Set separate cluster threshold for L1 (needed for phase1)
+      auto clusterThreshold = theClusterThreshold;
+      if (layer_==1) clusterThreshold = theClusterThreshold_L1;
+      
       //Set the first cluster equal to the existing cluster.
       SiPixelCluster first_cluster = cluster;
       bool have_second_cluster = false;
@@ -440,8 +479,8 @@ PixelThresholdClusterizer::make_cluster( const SiPixelCluster::PixelPos& pix,
 	  SiPixelCluster second_cluster = make_cluster(deadpix, output);
 	  
 	  //If both clusters would normally have been found by the clusterizer, put them into output
-	  if ( second_cluster.charge() >= theClusterThreshold && 
-	       first_cluster.charge() >= theClusterThreshold )
+	  if ( second_cluster.charge() >= clusterThreshold && 
+	       first_cluster.charge() >= clusterThreshold )
 	    {
 	      output.push_back( second_cluster );
 	      have_second_cluster = true;	
@@ -460,7 +499,7 @@ PixelThresholdClusterizer::make_cluster( const SiPixelCluster::PixelPos& pix,
 	}
       
       //Remember to also add the first cluster if we added the second one.
-      if ( first_cluster.charge() >= theClusterThreshold && have_second_cluster) 
+      if ( first_cluster.charge() >= clusterThreshold && have_second_cluster) 
 	{
 	  output.push_back( first_cluster );
           std::push_heap(output.begin(),output.end(),[](SiPixelCluster const & cl1,SiPixelCluster const & cl2) { return cl1.minPixelRow() < cl2.minPixelRow();});

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
@@ -50,6 +50,9 @@
 // Parameter Set:
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
 #include <vector>
 
 
@@ -62,18 +65,23 @@ class dso_hidden PixelThresholdClusterizer final : public PixelClusterizerBase {
   // Full I/O in DetSet
   void clusterizeDetUnit( const edm::DetSet<PixelDigi> & input,	
 				  const PixelGeomDetUnit * pixDet,
+				  const TrackerTopology* tTopo,
 				  const std::vector<short>& badChannels,
-				  edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) { clusterizeDetUnitT(input, pixDet, badChannels, output); }
+				  edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) { clusterizeDetUnitT(input, pixDet, tTopo, badChannels, output); }
   void clusterizeDetUnit( const edmNew::DetSet<SiPixelCluster> & input,
                           const PixelGeomDetUnit * pixDet,
+                          const TrackerTopology* tTopo,
                           const std::vector<short>& badChannels,
-                          edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) { clusterizeDetUnitT(input, pixDet, badChannels, output); }
+                          edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) { clusterizeDetUnitT(input, pixDet, tTopo, badChannels, output); }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
  private:
 
   template<typename T>
   void clusterizeDetUnitT( const T & input,
                            const PixelGeomDetUnit * pixDet,
+			   const TrackerTopology* tTopo,
                            const std::vector<short>& badChannels,
                            edmNew::DetSetVector<SiPixelCluster>::FastFiller& output);
 
@@ -88,11 +96,14 @@ class dso_hidden PixelThresholdClusterizer final : public PixelClusterizerBase {
   float theSeedThresholdInNoiseUnits;     // Pixel cluster seed in units of noise
   float theClusterThresholdInNoiseUnits;  // Cluster threshold in units of noise
 
-  const int   thePixelThreshold;  // Pixel threshold in electrons
-  const int   theSeedThreshold;   // Seed threshold in electrons
-  const float theClusterThreshold;  // Cluster threshold in electrons
-  const int   theConversionFactor;  // adc to electron conversion factor
-  const int   theOffset;            // adc to electron conversion offset
+  const int thePixelThreshold;  // Pixel threshold in electrons
+  const int theSeedThreshold;   // Seed threshold in electrons
+  const int theClusterThreshold;    // Cluster threshold in electrons
+  const int theClusterThreshold_L1; // Cluster threshold in electrons for Layer 1
+  const int theConversionFactor;    // adc to electron conversion factor
+  const int theConversionFactor_L1; // adc to electron conversion factor for Layer 1
+  const int theOffset;              // adc to electron conversion offset
+  const int theOffset_L1;           // adc to electron conversion offset for Layer 1
 
   const int   theStackADC_;          // The maximum ADC count for the stack layers
   const int   theFirstStack_;        // The index of the first stack layer
@@ -102,6 +113,7 @@ class dso_hidden PixelThresholdClusterizer final : public PixelClusterizerBase {
   int  theNumOfRows;
   int  theNumOfCols;
   uint32_t detid_;
+  int layer_;
   bool dead_flag;
   const bool doMissCalibrate; // Use calibration or not
   const bool doSplitClusters;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
@@ -103,6 +103,10 @@
     edm::ESHandle<TrackerGeometry> geom;
     es.get<TrackerDigiGeometryRecord>().get( geom );
 
+    edm::ESHandle<TrackerTopology> trackerTopologyHandle;
+    es.get<TrackerTopologyRcd>().get(trackerTopologyHandle);
+    tTopo_ = trackerTopologyHandle.product();
+
     // Step B: create the final output collection
     auto output = std::make_unique< SiPixelClusterCollectionNew>();
     //FIXME: put a reserve() here
@@ -185,7 +189,7 @@
       // Produce clusters for this DetUnit and store them in 
       // a DetSet
       edmNew::DetSetVector<SiPixelCluster>::FastFiller spc(output, DSViter->detId());
-      clusterizer_->clusterizeDetUnit(*DSViter, pixDet, badChannels, spc);
+      clusterizer_->clusterizeDetUnit(*DSViter, pixDet, tTopo_, badChannels, spc);
       if ( spc.empty() ) {
         spc.abort();
       } else {

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
@@ -38,7 +38,7 @@
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
-
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -74,6 +74,7 @@
     const std::string clusterMode_;         // user's choice of the clusterizer
     PixelClusterizerBase * clusterizer_;    // what we got (for now, one ptr to base class)
     bool readyToCluster_;                   // needed clusterizers valid => good to go!
+    const TrackerTopology* tTopo_;          // needed to get correct layer number
 
     //! Optional limit on the total number of clusters
     const int32_t maxTotalClusters_;

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -9,8 +9,10 @@ siPixelClusters = cms.EDProducer("SiPixelClusterProducer",
     ChannelThreshold = cms.int32(1000),
     MissCalibrate = cms.untracked.bool(True),
     SplitClusters = cms.bool(False),
-    VCaltoElectronGain = cms.int32(65),
-    VCaltoElectronOffset = cms.int32(-414),  
+    VCaltoElectronGain    = cms.int32(65),
+    VCaltoElectronGain_L1 = cms.int32(65),
+    VCaltoElectronOffset    = cms.int32(-414),  
+    VCaltoElectronOffset_L1 = cms.int32(-414),  
     # **************************************
     # ****  payLoadType Options         ****
     # ****  HLT - column granularity    ****
@@ -18,11 +20,22 @@ siPixelClusters = cms.EDProducer("SiPixelClusterProducer",
     # **************************************
     payloadType = cms.string('Offline'),
     SeedThreshold = cms.int32(1000),
-    ClusterThreshold = cms.double(4000.0),
+    ClusterThreshold    = cms.int32(4000),
+    ClusterThreshold_L1 = cms.int32(4000),
     # **************************************
     maxNumberOfClusters = cms.int32(-1), # -1 means no limit.
 )
 
+# phase1 pixel
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(siPixelClusters,
+  VCaltoElectronGain      = cms.int32(47),   # L2-4: 47 +- 4.7
+  VCaltoElectronGain_L1   = cms.int32(50),   # L1:   49.6 +- 2.6
+  VCaltoElectronOffset    = cms.int32(-60),  # L2-4: -60 +- 130
+  VCaltoElectronOffset_L1 = cms.int32(-670), # L1:   -670 +- 220
+  ChannelThreshold        = cms.int32(250),
+  ClusterThreshold_L1     = cms.int32(2000)
+)
 
 # Need these until phase2 pixel templates are used
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
@@ -29,6 +29,11 @@ def _modifyPixelDigitizerForPhase1Pixel( digitizer ) :
     digitizer.BPix_SignalResponse_p1 = cms.double(0.711)
     digitizer.BPix_SignalResponse_p2 = cms.double(203.)
     digitizer.BPix_SignalResponse_p3 = cms.double(148.)
+    # gains and offsets are ints in the Clusterizer, so round to the same value
+    digitizer.ElectronsPerVcal           = cms.double(47)   # L2-4: 47  +- 4.7
+    digitizer.ElectronsPerVcal_L1        = cms.double(50)   # L1:   49.6 +- 2.6
+    digitizer.ElectronsPerVcal_Offset    = cms.double(-60)  # L2-4: -60 +- 130
+    digitizer.ElectronsPerVcal_L1_Offset = cms.double(-670) # L1:   -670 +- 220
 
 
 SiPixelSimBlock = cms.PSet(
@@ -59,7 +64,9 @@ SiPixelSimBlock = cms.PSet(
     BPix_SignalResponse_p2 = cms.double(97.4),
     BPix_SignalResponse_p3 = cms.double(126.5),
     ElectronsPerVcal = cms.double(65.5),
+    ElectronsPerVcal_L1 = cms.double(65.5),
     ElectronsPerVcal_Offset = cms.double(-414.0),
+    ElectronsPerVcal_L1_Offset = cms.double(-414.0),
     ElectronPerAdc = cms.double(135.0),
     TofUpperCut = cms.double(12.5),
     AdcFullScale = cms.int32(255),

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -322,8 +322,10 @@ class SiPixelDigitizerAlgorithm  {
     const double theThresholdSmearing_BPix;
     const double theThresholdSmearing_BPix_L1;
 
-    const double electronsPerVCAL;          // for electrons - VCAL conversion
-    const double electronsPerVCAL_Offset;   // in misscalibrate()
+    const float electronsPerVCAL;          // for electrons - VCAL conversion
+    const float electronsPerVCAL_Offset;   // in misscalibrate()
+    const float electronsPerVCAL_L1;       // same for Layer 1
+    const float electronsPerVCAL_L1_Offset;// same for Layer 1
 
     const float theTofLowerCut;             // Cut on the particle TOF
     const float theTofUpperCut;             // Cut on the particle TOF
@@ -415,7 +417,7 @@ class SiPixelDigitizerAlgorithm  {
     
     // access to the gain calibration payloads in the db. Only gets initialized if check_dead_pixels_ is set to true.
     const std::unique_ptr<SiPixelGainCalibrationOfflineSimService> theSiPixelGainCalibrationService_;    
-    float missCalibrate(uint32_t detID, const PixelGeomDetUnit* pixdet, int col, int row, float amp) const;  
+    float missCalibrate(uint32_t detID, const TrackerTopology *tTopo, const PixelGeomDetUnit* pixdet, int col, int row, float amp) const;  
     LocalVector DriftDirection(const PixelGeomDetUnit* pixdet,
                                const GlobalVector& bfield,
                                const DetId& detId) const;


### PR DESCRIPTION
Contents of this PR:

    Update VCal to electron unit for the phase 1 detector using eras (gains and offsets)
    Allow separate values for layer 1
    Lower the cluster threshold for Layer 1
(see full description in the original PR merged in 93X PR #19181 )
Work done by  @jkarancs 
Adding @veszpv  @tsusa