### PR TITLE
Fix cluster-to-TrackingParticle associations for duplicate entries

### DIFF
--- a/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h
+++ b/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h
@@ -34,7 +34,12 @@ public:
     checkMappedProductID(tp);
     map_.emplace_back(cluster, tp);
   }
-  void sort() { std::sort(map_.begin(), map_.end(), compare); }
+  void sortAndUnique() {
+    std::sort(map_.begin(), map_.end(), compareSort);
+    auto last = std::unique(map_.begin(), map_.end());
+    map_.erase(last, map_.end());
+    map_.shrink_to_fit();
+  }
   void swap(ClusterTPAssociation& other) {
     map_.swap(other.map_);
     mappedProductId_.swap(other.mappedProductId_);
@@ -61,6 +66,12 @@ public:
 private:
   static bool compare(const value_type& i, const value_type& j) {
     return i.first.rawIndex() > j.first.rawIndex();
+  }
+
+  static bool compareSort(const value_type& i, const value_type& j) {
+    // For sorting compare also TrackingParticle keys in order to
+    // remove duplicate matches
+    return compare(i, j) || (i.first.rawIndex() == j.first.rawIndex() && i.second.key() > j.second.key());
   }
 
   map_type map_;

--- a/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
+++ b/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
@@ -238,7 +238,7 @@ void ClusterTPAssociationProducer::produce(edm::StreamID, edm::Event& iEvent, co
     }
 
   }
-  clusterTPList->sort();
+  clusterTPList->sortAndUnique();
   iEvent.put(std::move(clusterTPList));
 }
 


### PR DESCRIPTION
I noticed the `ClusterTPAssociation` can contain multiple associations from a cluster to a single TrackingParticle. This can happen despite of `ClusterTPAssociationProducer` already having already a logic for adding only one entry for each cluster-to-SimTrack association. But electron TrackingParticles can consist of multiple SimTracks, and therefore the existing logic is not enough. I decided to enhance the sort comparison function and use `std::unique` at the end as that's likely faster than doing any additional existence checks before the insertion, especially given that it does not happen very often.

While e.g. the track-to-TrackingParticle association (i.e. `QuickTrackAssociatorByHits`) is not affected, some other analyses may be affected because of the duplicated entries. E.g. here is one affected piece from standard workflows (FYI @smoortga)
https://github.com/cms-sw/cmssw/blob/master/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.cc#L218-L246
(this PR provides a bug fix and in all cases the number of clusters / TrackingParticle should decrease)

Tested in CMSSW_9_1_0_pre3, expecting changes in the BDHadron monitoring.

@rovere @VinInn 