### PR TITLE
clang check boost-use-to-string

### DIFF
--- a/CalibTracker/SiStripLorentzAngle/src/LA_Filler.cc
+++ b/CalibTracker/SiStripLorentzAngle/src/LA_Filler.cc
@@ -74,12 +74,12 @@ granularity(const SiStripDetId detid, const float tthetaL, const Long64_t TFE_in
   gran += subdetLabel(detid);
   if(byLayer_)  gran *= layerLabel(detid);
   if(byModule_) gran *= moduleLabel(detid);
-  if(localYbin_) gran += (localy < 0 ? "_yM":"_yP") + boost::lexical_cast<std::string>(abs((int)(localy/localYbin_+(localy<0?-1:0))));
-  if(stripsPerBin_) gran += "_strip"+boost::lexical_cast<std::string>((unsigned)((0.5+((apvstrip/64)?(127-apvstrip):apvstrip)/stripsPerBin_)*stripsPerBin_) );
+  if(localYbin_) gran += (localy < 0 ? "_yM":"_yP") + std::to_string(abs((int)(localy/localYbin_+(localy<0?-1:0))));
+  if(stripsPerBin_) gran += "_strip"+std::to_string((unsigned)((0.5+((apvstrip/64)?(127-apvstrip):apvstrip)/stripsPerBin_)*stripsPerBin_) );
   if(ensembleBins_) {
-    gran+= "_ensembleBin"+boost::lexical_cast<std::string>((int)(ensembleBins_*(tthetaL-ensembleLow_)/(ensembleUp_-ensembleLow_)));
+    gran+= "_ensembleBin"+std::to_string((int)(ensembleBins_*(tthetaL-ensembleLow_)/(ensembleUp_-ensembleLow_)));
     gran+= "";
-    if(ensembleSize_) gran*= "_sample"+boost::lexical_cast<std::string>(TFE_index % ensembleSize_);
+    if(ensembleSize_) gran*= "_sample"+std::to_string(TFE_index % ensembleSize_);
   }
   return gran;
 }
@@ -87,9 +87,9 @@ granularity(const SiStripDetId detid, const float tthetaL, const Long64_t TFE_in
 std::string LA_Filler_Fitter::
 subdetLabel(const SiStripDetId detid) { return detid.subDetector()==SiStripDetId::TOB? "TOB" : "TIB";}
 std::string LA_Filler_Fitter::
-moduleLabel(const SiStripDetId detid) { return subdetLabel(detid) + "_module"+boost::lexical_cast<std::string>(detid());}
+moduleLabel(const SiStripDetId detid) { return subdetLabel(detid) + "_module"+std::to_string(detid());}
 std::string LA_Filler_Fitter::
 layerLabel(const SiStripDetId detid) {
   unsigned layer = detid.subDetector() == SiStripDetId::TOB ? TOBDetId(detid()).layer() : TIBDetId(detid()).layer();
-  return subdetLabel(detid)+"_layer"+boost::lexical_cast<std::string>(layer)+(detid.stereo()?"s":"a");
+  return subdetLabel(detid)+"_layer"+std::to_string(layer)+(detid.stereo()?"s":"a");
 }

--- a/CondCore/CondDB/interface/KeyList.h
+++ b/CondCore/CondDB/interface/KeyList.h
@@ -46,7 +46,7 @@ namespace cond {
 	    m_objects[n] = deserialize<T>( i->second.first, i->second.second.first, i->second.second.second );
 	    m_data.erase( n );
 	  } else {
-	    throwException( "Payload for index "+boost::lexical_cast<std::string>(n)+" has not been found.",
+	    throwException( "Payload for index "+std::to_string(n)+" has not been found.",
 			    "KeyList::get");
 	  }
 	}

--- a/CondCore/CondDB/src/IOVSchema.h
+++ b/CondCore/CondDB/src/IOVSchema.h
@@ -91,7 +91,7 @@ namespace cond {
 	  return "MIN("+SINCE::fullyQualifiedName()+")";	  
 	} 
 	static std::string group(){
-	  std::string sgroupSize = boost::lexical_cast<std::string>( cond::time::SINCE_GROUP_SIZE);
+	  std::string sgroupSize = std::to_string(cond::time::SINCE_GROUP_SIZE);
 	  return "CAST("+SINCE::fullyQualifiedName()+"/"+sgroupSize+" AS INT )*"+sgroupSize;
 	}
       };

--- a/CondCore/Utilities/bin/conddb_edit_tag.cpp
+++ b/CondCore/Utilities/bin/conddb_edit_tag.cpp
@@ -127,7 +127,7 @@ int cond::EditTagUtilities::execute(){
 
   if( hasOptionValue("endOfValidity") ){
     cond::Time_t endOfValidity = getOptionValue<cond::Time_t>("endOfValidity");
-    changes.insert(std::make_pair("endOfValidity",std::make_pair(boost::lexical_cast<std::string>(editor.endOfValidity()),boost::lexical_cast<std::string>(endOfValidity))));
+    changes.insert(std::make_pair("endOfValidity",std::make_pair(std::to_string(editor.endOfValidity()),std::to_string(endOfValidity))));
     editor.setEndOfValidity( endOfValidity );
     change = true;
   }

--- a/CondCore/Utilities/bin/conddb_test_gt_load.cpp
+++ b/CondCore/Utilities/bin/conddb_test_gt_load.cpp
@@ -188,7 +188,7 @@ bool cond::UntypedPayloadProxy::get( cond::Time_t targetTime, bool debug ){
     m_session.transaction().start();
 
     auto iIov = m_iov.find( targetTime );
-    if(iIov == m_iov.end() ) cond::throwException(std::string("Tag ")+m_iov.tag()+": No iov available for the target time:"+boost::lexical_cast<std::string>(targetTime),"UntypedPayloadProxy::get");
+    if(iIov == m_iov.end() ) cond::throwException(std::string("Tag ")+m_iov.tag()+": No iov available for the target time:"+std::to_string(targetTime),"UntypedPayloadProxy::get");
     m_data->current = *iIov;
     event <<"For target time "<<targetTime<<" got a valid since:"<<m_data->current.since<<" from group ["<<m_iov.loadedGroup().first<<" - "<<m_iov.loadedGroup().second<<"]"; 
 

--- a/CondCore/Utilities/bin/conddb_test_gt_perf.cpp
+++ b/CondCore/Utilities/bin/conddb_test_gt_perf.cpp
@@ -180,7 +180,7 @@ bool cond::UntypedPayloadProxy::get( cond::Time_t targetTime, bool debug ){
     if( debug )std::cout <<" Searching tag "<<m_iov.tag()<<" for a valid payload for time="<<targetTime<<std::endl;
     m_session.transaction().start();
     auto iIov = m_iov.find( targetTime );
-    if(iIov == m_iov.end() ) cond::throwException(std::string("Tag ")+m_iov.tag()+": No iov available for the target time:"+boost::lexical_cast<std::string>(targetTime),"UntypedPayloadProxy::get");
+    if(iIov == m_iov.end() ) cond::throwException(std::string("Tag ")+m_iov.tag()+": No iov available for the target time:"+std::to_string(targetTime),"UntypedPayloadProxy::get");
     m_data->current = *iIov;
 
     std::string payloadType(""); 

--- a/CondCore/Utilities/interface/PayloadInspector.h
+++ b/CondCore/Utilities/interface/PayloadInspector.h
@@ -314,7 +314,7 @@ namespace cond {
 	      lumiIndex++;
 	    }
 	    ind =  rind + (lumiIndex/lumiSize); 
-            label = boost::lexical_cast<std::string>( run )+" : "+boost::lexical_cast<std::string>( lumi );
+            label = std::to_string(run )+" : "+std::to_string(lumi );
 	    currentRun = run;
 	  } else {
 	    ind++;
@@ -323,7 +323,7 @@ namespace cond {
 	      boost::posix_time::ptime t = cond::time::to_boost( since );
 	      label = boost::posix_time::to_simple_string( t );
 	    } else {
-	      label = boost::lexical_cast<std::string>( since );
+	      label = std::to_string(since );
 	    } 
 	  }
 	  std::shared_ptr<PayloadType> payload = Base::fetchPayload( std::get<1>(iov) );
@@ -365,7 +365,7 @@ namespace cond {
           if(  Base::tagTimeType()==cond::lumiid ||  Base::tagTimeType()==cond::runnumber){
             unsigned int nlumi = since & 0xFFFFFFFF;
 	    if( Base::tagTimeType()==cond::lumiid ) since = since >> 32;
-            label = boost::lexical_cast<std::string>( since );
+            label = std::to_string(since );
 	    auto it = runInfo.find( since );
 	    if ( it == runInfo.end() ){
 	      // this should never happen...
@@ -375,7 +375,7 @@ namespace cond {
 	    // add the lumi sections...
 	    if(  Base::tagTimeType()==cond::lumiid ){
 	      time += boost::posix_time::seconds( cond::time::SECONDS_PER_LUMI*nlumi );
-              label += (" : "+boost::lexical_cast<std::string>( nlumi ) );
+              label += (" : "+std::to_string(nlumi ) );
 	    }
 	  } else if (  Base::tagTimeType()==cond::timestamp ){
 	    time = cond::time::to_boost( since );

--- a/CondFormats/Serialization/interface/eos/portable_archive_exception.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_archive_exception.hpp
@@ -66,7 +66,7 @@ namespace eos {
 			: boost::archive::archive_exception(other_exception) 
 			, msg("requested integer size exceeds type size: ")
 		{
-			msg += boost::lexical_cast<std::string, int>(invalid_size);
+			msg += std::to_string(invalid_size);
 		}
 
 		//! negative number in unsigned type

--- a/DQM/HLTEvF/plugins/TriggerBxVsOrbitMonitor.cc
+++ b/DQM/HLTEvF/plugins/TriggerBxVsOrbitMonitor.cc
@@ -173,7 +173,7 @@ void TriggerBxVsOrbitMonitor::bookHistograms(DQMStore::IBooker & booker, edm::Ru
     m_orbit_bx_all->SetCanExtend(TH1::kAllAxes);
     
     for (unsigned int i = 0; i < nLS; ++i) {
-      std::string iname = boost::lexical_cast<std::string>(i);
+      std::string iname = std::to_string(i);
       m_orbit_bx_all_byLS.at(i) = booker.book2D("OrbitVsBX_LS"+iname, "OrbitVsBX_LS"+iname, nBX, float(m_minBX)-0.5, float(m_maxBX)+0.5, s_orbit_range+1, -0.5, float(s_orbit_range)+0.5)->getTH2F();
       m_orbit_bx_all_byLS.at(i)->GetXaxis()->SetTitle("BX");
       m_orbit_bx_all_byLS.at(i)->GetYaxis()->SetTitle("orbit");

--- a/DQM/HcalCommon/src/DQTask.cc
+++ b/DQM/HcalCommon/src/DQTask.cc
@@ -191,7 +191,7 @@ namespace hcaldqm
 			int cval = (int)((HcalDCCHeader const*)(fd.data()))->getCalibType();
 			if (cval>7)
 				_logger.warn("Unexpected Calib Type in FED " + 
-					boost::lexical_cast<std::string>(i));
+					std::to_string(i));
 			types[cval]++;
 		}
 		for (int i=FED_uTCA_MIN; i<=FED_uTCA_MAX; i++)
@@ -205,7 +205,7 @@ namespace hcaldqm
 			int cval = (int)((HcalDCCHeader const*)(fd.data()))->getCalibType();
 			if (cval>7)
 				_logger.warn("Unexpected Calib Type in FED " + 
-					boost::lexical_cast<std::string>(i));
+					std::to_string(i));
 			types[cval]++;
 		}
 
@@ -220,7 +220,7 @@ namespace hcaldqm
 		}
 		if (max!=(FED_VME_NUM+(FED_uTCA_MAX-FED_uTCA_MIN+1)-badFEDs))
 			_logger.warn("Conflicting Calibration Types found. Assigning " +
-				boost::lexical_cast<std::string>(calibType));
+				std::to_string(calibType));
 
 		return calibType;
 	}

--- a/DQM/L1TMonitor/src/L1ExtraDQM.cc
+++ b/DQM/L1TMonitor/src/L1ExtraDQM.cc
@@ -930,8 +930,8 @@ void L1ExtraDQM::L1ExtraMonElement<CollectionType>::bookhistograms(
 
         for (int iCount = 0; iCount < l1extra::L1HFRings::kNumRings; ++iCount) {
 
-            histName = l1ExtraObject + "_Count_" + boost::lexical_cast<std::string>(iCount);
-            histTitle = l1ExtraObject + ": count " + boost::lexical_cast<std::string>(iCount);
+            histName = l1ExtraObject + "_Count_" + std::to_string(iCount);
+            histTitle = l1ExtraObject + ": count " + std::to_string(iCount);
             xAxisTitle = l1ExtraObject;
             yAxisTitle = "Entries";
 
@@ -1018,8 +1018,8 @@ void L1ExtraDQM::L1ExtraMonElement<CollectionType>::bookhistograms(
 
         for (int iCount = 0; iCount < l1extra::L1HFRings::kNumRings; ++iCount) {
 
-            histName = l1ExtraObject + "_Count_" + boost::lexical_cast<std::string>(iCount);
-            histTitle = l1ExtraObject + ": count " + boost::lexical_cast<std::string>(iCount);
+            histName = l1ExtraObject + "_Count_" + std::to_string(iCount);
+            histTitle = l1ExtraObject + ": count " + std::to_string(iCount);
             xAxisTitle = l1ExtraObject;
             yAxisTitle = "Entries";
 

--- a/DQMOffline/CalibTracker/plugins/SiStripBadComponentsDQMServiceReader.cc
+++ b/DQMOffline/CalibTracker/plugins/SiStripBadComponentsDQMServiceReader.cc
@@ -125,7 +125,7 @@ string SiStripBadComponentsDQMServiceReader::detIdToString(const DetId & detid, 
       break;
     }
   }
-  std::string name( detector + "\t" + boost::lexical_cast<string>(layer) + "\t" + boost::lexical_cast<string>(stereo) + "\t" );
+  std::string name( detector + "\t" + std::to_string(layer) + "\t" + std::to_string(stereo) + "\t" );
   if( side == 1 ) {
     name += "-";
   }

--- a/DQMOffline/CalibTracker/plugins/SiStripNoisesDQMService.cc
+++ b/DQMOffline/CalibTracker/plugins/SiStripNoisesDQMService.cc
@@ -65,7 +65,7 @@ void SiStripNoisesDQMService::readNoises()
 
 
     MonitorElement * mE = 0;
-    std::string MEname("CMSubNoisePerStrip__det__"+boost::lexical_cast<string>(it->first));
+    std::string MEname("CMSubNoisePerStrip__det__"+std::to_string(it->first));
     for( std::vector<MonitorElement*>::const_iterator MEit = MEs.begin();
          MEit != MEs.end(); ++MEit ) {
       if( (*MEit)->getName() == MEname ) {

--- a/DQMOffline/CalibTracker/plugins/SiStripPedestalsDQMService.cc
+++ b/DQMOffline/CalibTracker/plugins/SiStripPedestalsDQMService.cc
@@ -66,7 +66,7 @@ void SiStripPedestalsDQMService::readPedestals()
 
 
     MonitorElement * mE = 0;
-    std::string MEname("PedsPerStrip__det__"+boost::lexical_cast<string>(it->first));
+    std::string MEname("PedsPerStrip__det__"+std::to_string(it->first));
     for( std::vector<MonitorElement*>::const_iterator MEit = MEs.begin();
          MEit != MEs.end(); ++MEit ) {
       if( (*MEit)->getName() == MEname ) {

--- a/Geometry/CommonTopologies/test/ValidateRadial.cc
+++ b/Geometry/CommonTopologies/test/ValidateRadial.cc
@@ -127,10 +127,10 @@ test_topology(const TkRadialStripTopology* t, unsigned i) {
   std::cout << "\nCSC\n" << oldt << std::endl;
 
 
-  TProfile prof(("se2limit1"+boost::lexical_cast<std::string>(i)).c_str(),
+  TProfile prof(("se2limit1"+std::to_string(i)).c_str(),
 		"Precision Limit of recoverable strip error (1st order);strip;strip error",
 		t->nstrips()/8,0,t->nstrips());
-  TProfile prof2(("se2limit2"+boost::lexical_cast<std::string>(i)).c_str(),
+  TProfile prof2(("se2limit2"+std::to_string(i)).c_str(),
 		 "Precision Limit of recoverable strip error (2nd order);strip;strip error",
 		 t->nstrips()/8,0,t->nstrips());
   for(float strip = 0; strip<t->nstrips(); strip+=0.5) {

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtTrigReport.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtTrigReport.cc
@@ -648,7 +648,7 @@ void L1GtTrigReport::analyze(const edm::Event& iEvent, const edm::EventSetup& ev
 
             //std::string ttName = itAlgo->first;
             //int ttBitNumber = ( itAlgo->second ).algoBitNumber();
-            std::string ttName = boost::lexical_cast<std::string>(iTechTrig);
+            std::string ttName = std::to_string(iTechTrig);
             int ttBitNumber = iTechTrig;
 
             int prescaleFactor = prescaleFactorsTechTrig.at(ttBitNumber);

--- a/MagneticField/Engine/test/testMagneticField.cc
+++ b/MagneticField/Engine/test/testMagneticField.cc
@@ -369,7 +369,7 @@ void testMagneticField::compareSectorTables(string file1) {
     string::size_type ss = file2.rfind("/s"); // last  occurence of "-"
     string ssec = "/s";
     if (sector2<10) ssec+="0";
-    ssec+=boost::lexical_cast<string>(sector2);
+    ssec+=std::to_string(sector2);
     file2.replace(ss,4,ssec);
  
     vector<GlobalPoint>  p1, p2;
@@ -384,7 +384,7 @@ void testMagneticField::compareSectorTables(string file1) {
     string binTable = "/data/n/namapane/MagneticField/120812/grid_120812_3_8t_v7_large"; 
     binTable+=ssec;
     binTable+="_";
-    string sVolNo = boost::lexical_cast<string>(volNo);
+    string sVolNo = std::to_string(volNo);
     binTable+=sVolNo[0];
     binTable+="/grid.";
     binTable+=sVolNo;

--- a/MagneticField/GeomBuilder/plugins/VolumeBasedMagneticFieldESProducerFromDB.cc
+++ b/MagneticField/GeomBuilder/plugins/VolumeBasedMagneticFieldESProducerFromDB.cc
@@ -132,7 +132,7 @@ std::unique_ptr<MagneticField> VolumeBasedMagneticFieldESProducerFromDB::produce
     // Build the geomeytry (DDDCompactView) from the DB blob
     // (code taken from GeometryReaders/XMLIdealGeometryESSource/src/XMLIdealMagneticFieldGeometryESProducer.cc) 
     edm::ESTransientHandle<FileBlob> gdd;
-    iRecord.getRecord<MFGeometryFileRcd>().get( boost::lexical_cast<string>(conf->geometryVersion), gdd );
+    iRecord.getRecord<MFGeometryFileRcd>().get( std::to_string(conf->geometryVersion), gdd );
     
     DDName ddName("cmsMagneticField:MAGF");
     DDLogicalPart rootNode(ddName);

--- a/MagneticField/GeomBuilder/src/volumeHandle.cc
+++ b/MagneticField/GeomBuilder/src/volumeHandle.cc
@@ -466,7 +466,7 @@ void MagGeoBuilderFromDDD::volumeHandle::printUniqueNames(handles::const_iterato
     for (handles::const_iterator i = begin; 
 	 i != end; ++i){
       if (uniq) names.push_back((*i)->name);
-      else names.push_back((*i)->name+":"+boost::lexical_cast<string>((*i)->copyno));
+      else names.push_back((*i)->name+":"+std::to_string((*i)->copyno));
     }
      
     sort(names.begin(),names.end());

--- a/OnlineDB/EcalCondDB/src/RunCrystalErrorsDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunCrystalErrorsDat.cc
@@ -59,7 +59,7 @@ void RunCrystalErrorsDat::writeDB(const EcalLogicID* ecid, const RunCrystalError
   try {
     m_writeStmt->setInt(1, iovID);
     m_writeStmt->setInt(2, logicID);
-    m_writeStmt->setString(3, ( boost::lexical_cast<std::string>(item->getErrorBits()) ).c_str());
+    m_writeStmt->setString(3, ( std::to_string(item->getErrorBits()) ).c_str());
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
     throw(std::runtime_error("RunCrystalErrorsDat::writeDB():  "+e.getMessage()));

--- a/OnlineDB/EcalCondDB/src/RunMemChErrorsDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunMemChErrorsDat.cc
@@ -60,7 +60,7 @@ void RunMemChErrorsDat::writeDB(const EcalLogicID* ecid, const RunMemChErrorsDat
   try {
     m_writeStmt->setInt(1, iovID);
     m_writeStmt->setInt(2, logicID);
-    m_writeStmt->setString(3, ( boost::lexical_cast<std::string>(item->getErrorBits()) ).c_str());
+    m_writeStmt->setString(3, ( std::to_string(item->getErrorBits()) ).c_str());
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
     throw(std::runtime_error("RunMemChErrorsDat::writeDB():  "+e.getMessage()));

--- a/OnlineDB/EcalCondDB/src/RunMemTTErrorsDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunMemTTErrorsDat.cc
@@ -61,7 +61,7 @@ void RunMemTTErrorsDat::writeDB(const EcalLogicID* ecid, const RunMemTTErrorsDat
   try {
     m_writeStmt->setInt(1, iovID);
     m_writeStmt->setInt(2, logicID);
-    m_writeStmt->setString(3, ( boost::lexical_cast<std::string>(item->getErrorBits()) ).c_str());
+    m_writeStmt->setString(3, ( std::to_string(item->getErrorBits()) ).c_str());
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
     throw(std::runtime_error("RunMemTTErrorsDat::writeDB():  "+e.getMessage()));

--- a/OnlineDB/EcalCondDB/src/RunPNErrorsDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunPNErrorsDat.cc
@@ -61,7 +61,7 @@ void RunPNErrorsDat::writeDB(const EcalLogicID* ecid, const RunPNErrorsDat* item
   try {
     m_writeStmt->setInt(1, iovID);
     m_writeStmt->setInt(2, logicID);
-    m_writeStmt->setString(3, ( boost::lexical_cast<std::string>(item->getErrorBits()) ).c_str());
+    m_writeStmt->setString(3, ( std::to_string(item->getErrorBits()) ).c_str());
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
     throw(std::runtime_error("RunPNErrorsDat::writeDB():  "+e.getMessage()));

--- a/OnlineDB/EcalCondDB/src/RunTTErrorsDat.cc
+++ b/OnlineDB/EcalCondDB/src/RunTTErrorsDat.cc
@@ -61,7 +61,7 @@ void RunTTErrorsDat::writeDB(const EcalLogicID* ecid, const RunTTErrorsDat* item
   try {
     m_writeStmt->setInt(1, iovID);
     m_writeStmt->setInt(2, logicID);
-    m_writeStmt->setString(3, ( boost::lexical_cast<std::string>(item->getErrorBits()) ).c_str());
+    m_writeStmt->setString(3, ( std::to_string(item->getErrorBits()) ).c_str());
     m_writeStmt->executeUpdate();
   } catch (SQLException &e) {
     throw(std::runtime_error("RunTTErrorsDat::writeDB():  "+e.getMessage()));


### PR DESCRIPTION
for comment about what clang-tidy does to CMSSW (and likely big and not mergeable - this is what clang-tidy check boost-use-to-string does on the tip of CMSSW_9_3_X as of a few days ago