### PR TITLE
clang check misc-uniqueptr-reset-release

### DIFF
--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
@@ -56,7 +56,7 @@ namespace edm {
         m_runSummaries.resize(1);
         m_lumiSummaries.resize(1);
         typename T::GlobalCache const* dummy=nullptr;
-        m_global.reset( impl::makeGlobal<T>(iPSet,dummy).release());
+        m_global = impl::makeGlobal<T>(iPSet,dummy);
       }
       ~EDAnalyzerAdaptor() {
       }

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
@@ -47,7 +47,7 @@ namespace edm {
         m_runSummaries.resize(1);
         m_lumiSummaries.resize(1);
         typename T::GlobalCache const* dummy=nullptr;
-        m_global.reset( impl::makeGlobal<T>(iPSet,dummy).release());
+        m_global = impl::makeGlobal<T>(iPSet,dummy);
       }
       ~ProducingModuleAdaptor() {
       }

--- a/GeneratorInterface/Core/interface/HadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/HadronizerFilter.h
@@ -257,8 +257,8 @@ namespace edm
       ++naccept;
       
       //keep the LAST accepted event (which is equivalent to choosing randomly from the accepted events)
-      finalEvent.reset(event.release());
-      finalGenEventInfo.reset(genEventInfo.release());
+      finalEvent = std::move(event);
+      finalGenEventInfo = std::move(genEventInfo);
       
     }
     

--- a/RecoTauTag/RecoTau/plugins/PATTauDiscriminantCutMultiplexer.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauDiscriminantCutMultiplexer.cc
@@ -200,7 +200,7 @@ void PATTauDiscriminantCutMultiplexer::beginEvent(const edm::Event& evt, const e
 	mvaOutput_normalization_ = loadObjectFromFile<TFormula>(*inputFile, mvaOutputNormalizationName_);
       } else {
 	auto temp = loadTFormulaFromDB(es, mvaOutputNormalizationName_, Form("%s_mvaOutput_normalization", moduleLabel_.data()), verbosity_);
-	mvaOutput_normalization_.reset(temp.release());
+	mvaOutput_normalization_ = std::move(temp);
       }
     }
     for ( DiscriminantCutMap::iterator cut = cuts_.begin();

--- a/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantCutMultiplexer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantCutMultiplexer.cc
@@ -204,7 +204,7 @@ void RecoTauDiscriminantCutMultiplexer::beginEvent(const edm::Event& evt, const 
 	mvaOutput_normalization_ = loadObjectFromFile<TFormula>(*inputFile, mvaOutputNormalizationName_);
       } else {
 	auto temp = loadTFormulaFromDB(es, mvaOutputNormalizationName_, Form("%s_mvaOutput_normalization", moduleLabel_.data()), verbosity_);
-	mvaOutput_normalization_.reset(temp.release());
+	mvaOutput_normalization_ = std::move(temp);
       }
     }
     for ( DiscriminantCutMap::iterator cut = cuts_.begin();


### PR DESCRIPTION
for comment about what clang-tidy does to CMSSW (and likely big and not mergeable - this is what clang-tidy check misc-uniqueptr-reset-release does on the tip of CMSSW_9_3_X as of a few days ago