### PR TITLE
clang check modernize-replace-auto-ptr

### DIFF
--- a/Alignment/CommonAlignment/src/AlignableModifier.cc
+++ b/Alignment/CommonAlignment/src/AlignableModifier.cc
@@ -379,7 +379,7 @@ void AlignableModifier
   }
   
   // auto_ptr has exception safe delete (in contrast to bare pointer)
-  const std::auto_ptr<SurfaceDeformation> surfDef
+  const std::unique_ptr<SurfaceDeformation> surfDef
     (SurfaceDeformationFactory::create(deformType, rndDeformation));
   
   alignable->addSurfaceDeformation(surfDef.get(), true); // true to propagate down

--- a/Alignment/OfflineValidation/plugins/EopTreeWriter.cc
+++ b/Alignment/OfflineValidation/plugins/EopTreeWriter.cc
@@ -142,7 +142,7 @@ EopTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 //      geo->getSubdetectorGeometry(DetId::Calo, CaloTowerDetId::SubdetId);
 
    // temporary collection of EB+EE recHits
-   std::auto_ptr<EcalRecHitCollection> tmpEcalRecHitCollection(new EcalRecHitCollection);
+   std::unique_ptr<EcalRecHitCollection> tmpEcalRecHitCollection(new EcalRecHitCollection);
    std::vector<edm::InputTag> ecalLabels_;
 
    edm::Handle<EcalRecHitCollection> tmpEc;

--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -191,7 +191,7 @@ private:
     template <typename T> TH1* make(const char* name,const char* title,int nBinX,double minBinX,double maxBinX,int nBinY,double minBinY,double maxBinY);
     template <typename T> TH1* make(const char* name,const char* title,int nBinX,double minBinX,double maxBinX,double minBinY,double maxBinY);  // at present not used
     
-    std::auto_ptr<TFileDirectory> tfd;
+    std::unique_ptr<TFileDirectory> tfd;
     std::string directoryString;
     const bool dqmMode;
     DQMStore* theDbe;

--- a/Alignment/ReferenceTrajectories/plugins/CombinedTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/CombinedTrajectoryFactory.cc
@@ -61,7 +61,7 @@ CombinedTrajectoryFactory::CombinedTrajectoryFactory( const edm::ParameterSet & 
   for ( itFactoryName = factoryNames.begin(); itFactoryName != factoryNames.end(); ++itFactoryName )
   {
     // auto_ptr to avoid missing a delete due to throw...
-    std::auto_ptr<TObjArray> namePset(TString((*itFactoryName).c_str()).Tokenize(","));
+    std::unique_ptr<TObjArray> namePset(TString((*itFactoryName).c_str()).Tokenize(","));
     if (namePset->GetEntriesFast() != 2) {
       throw cms::Exception("BadConfig") << "@SUB=CombinedTrajectoryFactory"
                                         << "TrajectoryFactoryNames must contain 2 comma "

--- a/Alignment/ReferenceTrajectories/src/ReferenceTrajectory.cc
+++ b/Alignment/ReferenceTrajectories/src/ReferenceTrajectory.cc
@@ -117,7 +117,7 @@ bool ReferenceTrajectory::construct(const TrajectoryStateOnSurface &refTsos,
 
   const SurfaceSide surfaceSide = this->surfaceSide(propDir_);
   // auto_ptr to avoid memory leaks in case of not reaching delete at end of method:
-  std::auto_ptr<MaterialEffectsUpdator> aMaterialEffectsUpdator
+  std::unique_ptr<MaterialEffectsUpdator> aMaterialEffectsUpdator
     (this->createUpdator(materialEffects_, mass_));
   if (!aMaterialEffectsUpdator.get()) return false; // empty auto_ptr
 

--- a/CalibCalorimetry/CaloTPG/plugins/CaloTPGTranscoderULUTs.cc
+++ b/CalibCalorimetry/CaloTPG/plugins/CaloTPGTranscoderULUTs.cc
@@ -19,6 +19,7 @@
 
 // system include files
 #include <memory>
+#include <utility>
 
 // user include files
 
@@ -161,9 +162,9 @@ CaloTPGTranscoderULUTs::produce(const CaloTPGRecord& iRecord)
    HcalLutMetadata fullLut{ *lutMetadata };
    fullLut.setTopo(htopo.product());
 
-   std::auto_ptr<CaloTPGTranscoderULUT> pTCoder(new CaloTPGTranscoderULUT(file1, file2));
+   std::unique_ptr<CaloTPGTranscoderULUT> pTCoder(new CaloTPGTranscoderULUT(file1, file2));
    pTCoder->setup(fullLut, *theTrigTowerGeometry, NCTScaleShift, RCTScaleShift);
-   return std::auto_ptr<CaloTPGTranscoder>( pTCoder );
+   return std::unique_ptr<CaloTPGTranscoder>( std::move(pTCoder) );
 }
 
 //define this as a plug-in

--- a/CalibCalorimetry/EcalLaserSorting/interface/LaserSorter.h
+++ b/CalibCalorimetry/EcalLaserSorting/interface/LaserSorter.h
@@ -85,7 +85,7 @@ private:
   private:
     int fedId_;
     edm::LuminosityBlockNumber_t startingLumiBlock_;
-    std::auto_ptr<std::ofstream> out_;
+    std::unique_ptr<std::ofstream> out_;
     std::string tmpFileName_;
     std::string finalFileName_;
     const static std::string emptyString_;

--- a/CalibCalorimetry/EcalLaserSorting/interface/WatcherStreamFileReader.h
+++ b/CalibCalorimetry/EcalLaserSorting/interface/WatcherStreamFileReader.h
@@ -60,7 +60,7 @@ private:
   
   /** Cached input file stream
    */
-  std::auto_ptr<edm::StreamerInputFile> streamerInputFile_;
+  std::unique_ptr<edm::StreamerInputFile> streamerInputFile_;
 
   std::string fileName_;
 

--- a/CalibCalorimetry/EcalLaserSorting/src/WatcherStreamFileReader.cc
+++ b/CalibCalorimetry/EcalLaserSorting/src/WatcherStreamFileReader.cc
@@ -394,7 +394,7 @@ edm::StreamerInputFile* WatcherStreamFileReader::getInputFile(){
 	cout << "[WatcherSource " << now() << "]" 
 	     << " Opening file " << fileName_ << "\n" << flush;
 	streamerInputFile_
-	  = auto_ptr<edm::StreamerInputFile>(new edm::StreamerInputFile(fileName_));
+	  = unique_ptr<edm::StreamerInputFile>(new edm::StreamerInputFile(fileName_));
 
 	ofstream f(".watcherfile");
 	f << fileName_;	

--- a/CalibCalorimetry/HcalAlgos/test/HcalPulseContainmentTest.cpp
+++ b/CalibCalorimetry/HcalAlgos/test/HcalPulseContainmentTest.cpp
@@ -4,8 +4,8 @@
 int main() {
   float fixedphase_ns = 6.0;
   float max_fracerror = 0.02;
-  std::auto_ptr<HcalPulseContainmentManager> manager;
-  manager = std::auto_ptr<HcalPulseContainmentManager>( new HcalPulseContainmentManager(max_fracerror));
+  std::unique_ptr<HcalPulseContainmentManager> manager;
+  manager = std::unique_ptr<HcalPulseContainmentManager>( new HcalPulseContainmentManager(max_fracerror));
 
   HcalDetId hb1(HcalBarrel, 1, 1, 1);
   HcalDetId he1(HcalEndcap, 17, 1, 1);

--- a/CalibTracker/SiStripDCS/interface/SiStripCoralIface.h
+++ b/CalibTracker/SiStripDCS/interface/SiStripCoralIface.h
@@ -37,7 +37,7 @@ class SiStripCoralIface
   std::string m_authPath;
   std::map<std::string,unsigned int> m_id_map;
   cond::persistency::Session m_session;
-  std::auto_ptr<cond::persistency::TransactionScope> m_transaction;
+  std::unique_ptr<cond::persistency::TransactionScope> m_transaction;
   // cond::CoralTransaction* m_coraldb;
   // cond::Connection* con;
 

--- a/CalibTracker/SiStripDCS/interface/SiStripDetVOffBuilder.h
+++ b/CalibTracker/SiStripDCS/interface/SiStripDetVOffBuilder.h
@@ -170,7 +170,7 @@ class SiStripDetVOffBuilder
   void setPayloadStats(const uint32_t afterV, const uint32_t numAdded, const uint32_t numRemoved);
   std::pair<int, int> extractDetIdVector(const unsigned int i, SiStripDetVOff * modV, DetIdListTimeAndStatus & detIdStruct);
 
-  std::auto_ptr<SiStripCoralIface> coralInterface;
+  std::unique_ptr<SiStripCoralIface> coralInterface;
 
 };
 #endif

--- a/CalibTracker/SiStripDCS/src/SiStripCoralIface.cc
+++ b/CalibTracker/SiStripDCS/src/SiStripCoralIface.cc
@@ -51,7 +51,7 @@ void  SiStripCoralIface::initialize() {
 void SiStripCoralIface::doQuery(std::string queryType, const coral::TimeStamp& startTime, const coral::TimeStamp& endTime, std::vector<coral::TimeStamp> &vec_changedate, 
 				std::vector<float> &vec_actualValue, std::vector<std::string> &vec_dpname)
 {
-  std::auto_ptr<coral::IQuery> query( m_session.coralSession().schema(std::string("CMS_TRK_DCS_PVSS_COND")).newQuery());
+  std::unique_ptr<coral::IQuery> query( m_session.coralSession().schema(std::string("CMS_TRK_DCS_PVSS_COND")).newQuery());
   std::string condition;
 
   LogTrace("SiStripCoralIface") << "[SiStripCoralIface::" << __func__ << "] table to be accessed: " << queryType;
@@ -118,7 +118,7 @@ void SiStripCoralIface::doQuery(std::string queryType, const coral::TimeStamp& s
 void SiStripCoralIface::doSettingsQuery(const coral::TimeStamp& startTime, const coral::TimeStamp& endTime, std::vector<coral::TimeStamp> &vec_changedate,
 					std::vector<float> &vec_settings, std::vector<std::string> &vec_dpname, std::vector<uint32_t> &vec_dpid) 
 {
-  std::auto_ptr<coral::IQuery> query( m_session.coralSession().schema(std::string("CMS_TRK_DCS_PVSS_COND")).newQuery());
+  std::unique_ptr<coral::IQuery> query( m_session.coralSession().schema(std::string("CMS_TRK_DCS_PVSS_COND")).newQuery());
   query->addToOutputList("FWCAENCHANNEL.CHANGE_DATE","CHANGE_DATE");
   query->addToOutputList("FWCAENCHANNEL.SETTINGS_V0","VSET");
   query->addToOutputList("FWCAENCHANNEL.DPID","DPID");
@@ -157,7 +157,7 @@ void SiStripCoralIface::doSettingsQuery(const coral::TimeStamp& startTime, const
 
 void SiStripCoralIface::doNameQuery(std::vector<std::string> &vec_dpname, std::vector<uint32_t> &vec_dpid) 
 {
-  std::auto_ptr<coral::IQuery> query( m_session.coralSession().schema(std::string("CMS_TRK_DCS_PVSS_COND")).newQuery());
+  std::unique_ptr<coral::IQuery> query( m_session.coralSession().schema(std::string("CMS_TRK_DCS_PVSS_COND")).newQuery());
   query->addToOutputList("DP_NAME2ID.DPNAME","DPNAME");
   query->addToOutputList("DP_NAME2ID.ID","DPID");
   query->addToTableList("DP_NAME2ID");

--- a/Calibration/EcalCalibAlgos/src/Pi0FixedMassWindowCalibration.cc
+++ b/Calibration/EcalCalibAlgos/src/Pi0FixedMassWindowCalibration.cc
@@ -389,7 +389,7 @@ Pi0FixedMassWindowCalibration::duringLoop(const edm::Event& event,
   }
 
   //Put clustershapes in event, but retain a Handle on them.
-  std::auto_ptr<reco::ClusterShapeCollection> clustersshapes_p_recalib(new reco::ClusterShapeCollection);
+  std::unique_ptr<reco::ClusterShapeCollection> clustersshapes_p_recalib(new reco::ClusterShapeCollection);
   clustersshapes_p_recalib->assign(ClusVec_recalib.begin(), ClusVec_recalib.end());
 
   cout<<"[Pi0FixedMassWindowCalibration][recalibration] Basic Cluster collection size: "<<clusters_recalib.size()<<endl;

--- a/CaloOnlineTools/EcalTools/plugins/EcalPulseShapeGrapher.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalPulseShapeGrapher.cc
@@ -116,7 +116,7 @@ EcalPulseShapeGrapher::analyze(const edm::Event& iEvent, const edm::EventSetup& 
    iEvent.getByLabel(EEDigis_, EEdigis);
    //cout << "event: " << eventNum << " digi collection size: " << digis->size() << endl;
 
-   auto_ptr<EcalElectronicsMapping> ecalElectronicsMap(new EcalElectronicsMapping);
+   unique_ptr<EcalElectronicsMapping> ecalElectronicsMap(new EcalElectronicsMapping);
 
    // Loop over the hits
    for(EcalUncalibratedRecHitCollection::const_iterator hitItr = EBHits->begin(); hitItr != EBHits->end(); ++hitItr)

--- a/CommonTools/CandUtils/interface/NamedCandCombinerBase.h
+++ b/CommonTools/CandUtils/interface/NamedCandCombinerBase.h
@@ -26,25 +26,25 @@ public:
   /// destructor
   virtual ~NamedCandCombinerBase();
   /// return all selected candidate pairs
-  std::auto_ptr<reco::NamedCompositeCandidateCollection> 
+  std::unique_ptr<reco::NamedCompositeCandidateCollection> 
   combine(const std::vector<reco::CandidatePtrVector> &, string_coll const &) const;
   /// return all selected candidate pairs
-  std::auto_ptr<reco::NamedCompositeCandidateCollection> 
+  std::unique_ptr<reco::NamedCompositeCandidateCollection> 
   combine(const reco::CandidatePtrVector &, 
 	  string_coll const &) const;
   /// return all selected candidate pairs
-  std::auto_ptr<reco::NamedCompositeCandidateCollection> 
+  std::unique_ptr<reco::NamedCompositeCandidateCollection> 
   combine(const reco::CandidatePtrVector &, 
 	  const reco::CandidatePtrVector &, 
 	  string_coll const &) const;
   /// return all selected candidate pairs
-  std::auto_ptr<reco::NamedCompositeCandidateCollection> 
+  std::unique_ptr<reco::NamedCompositeCandidateCollection> 
   combine(const reco::CandidatePtrVector &, 
 	  const reco::CandidatePtrVector &, 
 	  const reco::CandidatePtrVector &, 
 	  string_coll const &) const;
   /// return all selected candidate pairs
-  std::auto_ptr<reco::NamedCompositeCandidateCollection> 
+  std::unique_ptr<reco::NamedCompositeCandidateCollection> 
   combine(const reco::CandidatePtrVector &, 
 	  const reco::CandidatePtrVector &, 
 	  const reco::CandidatePtrVector &, 
@@ -69,7 +69,7 @@ private:
 	       string_coll const & names,
 	       std::vector<reco::CandidatePtrVector>::const_iterator begin,
 	       std::vector<reco::CandidatePtrVector>::const_iterator end,
-	       std::auto_ptr<reco::NamedCompositeCandidateCollection> & comps
+	       std::unique_ptr<reco::NamedCompositeCandidateCollection> & comps
 	       ) const;
   /// select a candidate
   virtual bool select(const reco::Candidate &) const = 0;

--- a/CommonTools/CandUtils/interface/cloneDecayTree.h
+++ b/CommonTools/CandUtils/interface/cloneDecayTree.h
@@ -3,6 +3,6 @@
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include <memory>
 
-std::auto_ptr<reco::Candidate> cloneDecayTree( const reco::Candidate & );
+std::unique_ptr<reco::Candidate> cloneDecayTree( const reco::Candidate & );
 
 #endif

--- a/CommonTools/CandUtils/interface/makeCompositeCandidate.h
+++ b/CommonTools/CandUtils/interface/makeCompositeCandidate.h
@@ -6,45 +6,45 @@
 #include <memory>
 
 namespace helpers {
-  struct CompositeCandidateMaker {
-    CompositeCandidateMaker(std::auto_ptr<reco::CompositeCandidate> cmp) :
-      cmp_( cmp ) {
+  struct std::move(CompositeCandidateMaker) {
+    CompositeCandidateMaker(std::unique_ptr<reco::CompositeCandidate> cmp) :
+      cmp_( std::move(cmp) ) {
     }
     void addDaughter(const reco::Candidate & dau) {
       cmp_->addDaughter( dau );
     }
     template<typename S>
-    std::auto_ptr<reco::Candidate> operator[]( const S & setup ) {
+    std::unique_ptr<reco::Candidate> operator[]( const S & setup ) {
       setup.set( * cmp_ );
       return release();
     }
   private:
-    std::auto_ptr<reco::CompositeCandidate> cmp_;
-    std::auto_ptr<reco::Candidate> release() {
-      std::auto_ptr<reco::Candidate> ret( cmp_.get() );
+    std::unique_ptr<reco::CompositeCandidate> cmp_;
+    std::unique_ptr<reco::Candidate> release() {
+      std::unique_ptr<reco::Candidate> ret( cmp_.get() );
       cmp_.release();
-      return ret;
+      return std::move(ret);
     }
   };
 
-  struct CompositePtrCandidateMaker {
-    CompositePtrCandidateMaker(std::auto_ptr<reco::CompositePtrCandidate> cmp) :
-      cmp_( cmp ) {
+  struct std::move(CompositePtrCandidateMaker) {
+    CompositePtrCandidateMaker(std::unique_ptr<reco::CompositePtrCandidate> cmp) :
+      cmp_( std::move(cmp) ) {
     }
     void addDaughter(const reco::CandidatePtr & dau) {
       cmp_->addDaughter( dau );
     }
     template<typename S>
-    std::auto_ptr<reco::Candidate> operator[]( const S & setup ) {
+    std::unique_ptr<reco::Candidate> operator[]( const S & setup ) {
       setup.set( * cmp_ );
       return release();
     }
   private:
-    std::auto_ptr<reco::CompositePtrCandidate> cmp_;
-    std::auto_ptr<reco::Candidate> release() {
-      std::auto_ptr<reco::Candidate> ret( cmp_.get() );
+    std::unique_ptr<reco::CompositePtrCandidate> cmp_;
+    std::unique_ptr<reco::Candidate> release() {
+      std::unique_ptr<reco::Candidate> ret( cmp_.get() );
       cmp_.release();
-      return ret;
+      return std::move(ret);
     }
   };
 }
@@ -75,7 +75,7 @@ helpers::CompositeCandidateMaker
 makeCompositeCandidate(const typename C::const_iterator & begin, 
 		       const typename C::const_iterator & end) {
   helpers::CompositeCandidateMaker 
-    cmp(std::auto_ptr<reco::CompositeCandidate>(new reco::CompositeCandidate) );
+    cmp(std::unique_ptr<reco::CompositeCandidate>(new reco::CompositeCandidate) );
   for(typename C::const_iterator i = begin; i != end; ++ i) 
     cmp.addDaughter(* i);
   return cmp;
@@ -101,7 +101,7 @@ helpers::CompositeCandidateMaker
 makeCompositeCandidateWithRefsToMaster(const typename C::const_iterator & begin, 
 				       const typename C::const_iterator & end) {
   helpers::CompositeCandidateMaker 
-    cmp(std::auto_ptr<reco::CompositeCandidate>(new reco::CompositeCandidate));
+    cmp(std::unique_ptr<reco::CompositeCandidate>(new reco::CompositeCandidate));
   for(typename C::const_iterator i = begin; i != end; ++ i) 
     cmp.addDaughter(ShallowCloneCandidate(CandidateBaseRef(* i)));
   return cmp;

--- a/CommonTools/CandUtils/interface/makeNamedCompositeCandidate.h
+++ b/CommonTools/CandUtils/interface/makeNamedCompositeCandidate.h
@@ -6,24 +6,24 @@
 #include <string>
 
 namespace helpers {
-  struct NamedCompositeCandidateMaker {
-    NamedCompositeCandidateMaker( std::auto_ptr<reco::NamedCompositeCandidate> cmp ) :
-      cmp_( cmp ) {
+  struct std::move(NamedCompositeCandidateMaker) {
+    NamedCompositeCandidateMaker( std::unique_ptr<reco::NamedCompositeCandidate> cmp ) :
+      cmp_( std::move(cmp) ) {
     }
     void addDaughter( const reco::Candidate & dau, std::string name ) {
       cmp_->addDaughter( dau, name );
     }
     template<typename S>
-    std::auto_ptr<reco::Candidate> operator[]( const S & setup ) {
+    std::unique_ptr<reco::Candidate> operator[]( const S & setup ) {
       setup.set( * cmp_ );
       return release();
     }
   private:
-    std::auto_ptr<reco::NamedCompositeCandidate> cmp_;
-    std::auto_ptr<reco::Candidate> release() {
-      std::auto_ptr<reco::Candidate> ret( cmp_.get() );
+    std::unique_ptr<reco::NamedCompositeCandidate> cmp_;
+    std::unique_ptr<reco::Candidate> release() {
+      std::unique_ptr<reco::Candidate> ret( cmp_.get() );
       cmp_.release();
-      return ret;
+      return std::move(ret);
     }
   };
 }
@@ -56,7 +56,7 @@ makeNamedCompositeCandidate( const typename C::const_iterator & begin,
 			     const std::vector<std::string>::const_iterator sbegin,
 			     const std::vector<std::string>::const_iterator send ) {
   helpers::NamedCompositeCandidateMaker 
-    cmp( std::auto_ptr<reco::NamedCompositeCandidate>( new reco::NamedCompositeCandidate ) );
+    cmp( std::unique_ptr<reco::NamedCompositeCandidate>( new reco::NamedCompositeCandidate ) );
   std::vector<std::string>::const_iterator si = sbegin;
   for( typename C::const_iterator i = begin; i != end && si != send; ++ i, ++si ) 
     cmp.addDaughter( * i, * si );
@@ -85,7 +85,7 @@ makeNamedCompositeCandidateWithRefsToMaster( const typename C::const_iterator & 
 			     const std::vector<std::string>::const_iterator sbegin,
 			     const std::vector<std::string>::const_iterator send ) {
   helpers::NamedCompositeCandidateMaker 
-    cmp( std::auto_ptr<reco::NamedCompositeCandidate>( new reco::NamedCompositeCandidate ) );
+    cmp( std::unique_ptr<reco::NamedCompositeCandidate>( new reco::NamedCompositeCandidate ) );
   std::vector<std::string>::const_iterator si = sbegin;
   for( typename C::const_iterator i = begin; i != end && si != send; ++ i, ++ si ) 
     cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( * i ) ), * si );

--- a/CommonTools/CandUtils/src/NamedCandCombinerBase.cc
+++ b/CommonTools/CandUtils/src/NamedCandCombinerBase.cc
@@ -52,7 +52,7 @@ void NamedCandCombinerBase::combine(NamedCompositeCandidate & cmp, const Candida
   setup(cmp);
 }
 
-auto_ptr<NamedCompositeCandidateCollection> 
+unique_ptr<NamedCompositeCandidateCollection> 
 NamedCandCombinerBase::combine(const vector<CandidatePtrVector> & src,
 			       string_coll const & names) const {
   size_t srcSize = src.size();
@@ -65,7 +65,7 @@ NamedCandCombinerBase::combine(const vector<CandidatePtrVector> & src,
     throw edm::Exception(edm::errors::Configuration)
       << "NamedCandCombiner: need to add 2 names, but size is " << names.size();
   
-  auto_ptr<NamedCompositeCandidateCollection> comps(new NamedCompositeCandidateCollection);
+  unique_ptr<NamedCompositeCandidateCollection> comps(new NamedCompositeCandidateCollection);
   if(srcSize == 2) {
     CandidatePtrVector src1 = src[0], src2 = src[1];
     if(src1 == src2) {
@@ -103,10 +103,10 @@ NamedCandCombinerBase::combine(const vector<CandidatePtrVector> & src,
     combine(0, stack, qStack, names, src.begin(), src.end(), comps);
   }
 
-  return comps;
+  return std::move(comps);
 }
 
-auto_ptr<NamedCompositeCandidateCollection> 
+unique_ptr<NamedCompositeCandidateCollection> 
 NamedCandCombinerBase::combine(const CandidatePtrVector & src, string_coll const & names) const {
   if(checkCharge_ && dauCharge_.size() != 2)
     throw edm::Exception(edm::errors::Configuration) 
@@ -117,7 +117,7 @@ NamedCandCombinerBase::combine(const CandidatePtrVector & src, string_coll const
     throw edm::Exception(edm::errors::Configuration)
       << "NamedCandCombiner: need to add 2 names, but size is " << names.size();
 
-  auto_ptr<NamedCompositeCandidateCollection> comps(new NamedCompositeCandidateCollection);
+  unique_ptr<NamedCompositeCandidateCollection> comps(new NamedCompositeCandidateCollection);
   const int n = src.size();
   for(int i1 = 0; i1 < n; ++i1) {
     const Candidate & c1 = *(src[i1]);
@@ -132,10 +132,10 @@ NamedCandCombinerBase::combine(const CandidatePtrVector & src, string_coll const
     } 
   }
 
-  return comps;
+  return std::move(comps);
 }
 
-auto_ptr<NamedCompositeCandidateCollection> 
+unique_ptr<NamedCompositeCandidateCollection> 
 NamedCandCombinerBase::combine(const CandidatePtrVector & src1, const CandidatePtrVector & src2, string_coll const & names) const {
   vector<CandidatePtrVector> src;
   src.push_back(src1);
@@ -143,7 +143,7 @@ NamedCandCombinerBase::combine(const CandidatePtrVector & src1, const CandidateP
   return combine(src, names);
 }
 
-auto_ptr<NamedCompositeCandidateCollection> 
+unique_ptr<NamedCompositeCandidateCollection> 
 NamedCandCombinerBase::combine(const CandidatePtrVector & src1, const CandidatePtrVector & src2, const CandidatePtrVector & src3, 
 			       string_coll const & names) const {
   vector<CandidatePtrVector> src;
@@ -153,7 +153,7 @@ NamedCandCombinerBase::combine(const CandidatePtrVector & src1, const CandidateP
   return combine(src, names);
 }
 
-auto_ptr<NamedCompositeCandidateCollection> 
+unique_ptr<NamedCompositeCandidateCollection> 
 NamedCandCombinerBase::combine(const CandidatePtrVector & src1, const CandidatePtrVector & src2, 
 			       const CandidatePtrVector & src3, const CandidatePtrVector & src4, 
 			       string_coll const & names) const {
@@ -169,7 +169,7 @@ void NamedCandCombinerBase::combine(size_t collectionIndex, CandStack & stack, C
 				    string_coll const & names,
 				    vector<CandidatePtrVector>::const_iterator collBegin,
 				    vector<CandidatePtrVector>::const_iterator collEnd,
-				    auto_ptr<NamedCompositeCandidateCollection> & comps) const {
+				    unique_ptr<NamedCompositeCandidateCollection> & comps) const {
   if(collBegin == collEnd) {
     static const int undetermined = 0, sameDecay = 1, conjDecay = -1, wrongDecay = 2;
     int decayType = undetermined;

--- a/CommonTools/CandUtils/src/cloneDecayTree.cc
+++ b/CommonTools/CandUtils/src/cloneDecayTree.cc
@@ -1,16 +1,18 @@
+#include <utility>
+
 #include "CommonTools/CandUtils/interface/cloneDecayTree.h"
 #include "DataFormats/Candidate/interface/CompositeCandidate.h"
 using namespace std;
 using namespace reco;
 
-auto_ptr<Candidate> cloneDecayTree(const Candidate & c) {
+unique_ptr<Candidate> cloneDecayTree(const Candidate & c) {
   size_t n = c.numberOfDaughters();
-  if (n == 1) return auto_ptr<Candidate>(c.clone());
+  if (n == 1) return unique_ptr<Candidate>(c.clone());
   // pass a particle, not a candidate, to avoid cloning daughters 
   const Candidate &p = c;
   CompositeCandidate * cmp(new CompositeCandidate(p));
-  auto_ptr<Candidate> cmpPtr(cmp);
+  unique_ptr<Candidate> cmpPtr(cmp);
   for(size_t i = 0; i < n; ++ i)
     cmp->addDaughter(cloneDecayTree(* c.daughter(i)));
-  return cmpPtr;
+  return std::move(cmpPtr);
 }

--- a/CommonTools/CandUtils/src/makeCompositeCandidate.cc
+++ b/CommonTools/CandUtils/src/makeCompositeCandidate.cc
@@ -1,9 +1,11 @@
+#include <utility>
+
 #include "CommonTools/CandUtils/interface/makeCompositeCandidate.h"
 using namespace reco;
 using namespace std;
 
 helpers::CompositeCandidateMaker makeCompositeCandidate( const Candidate & c1, const Candidate & c2 ) {
-  helpers::CompositeCandidateMaker cmp( auto_ptr<CompositeCandidate>( new CompositeCandidate ) );
+  helpers::CompositeCandidateMaker cmp( unique_ptr<CompositeCandidate>( new CompositeCandidate ) );
   cmp.addDaughter( c1 );
   cmp.addDaughter( c2 );
   return cmp;
@@ -11,7 +13,7 @@ helpers::CompositeCandidateMaker makeCompositeCandidate( const Candidate & c1, c
 
 helpers::CompositeCandidateMaker makeCompositeCandidate( const Candidate & c1, const Candidate & c2, 
 							 const Candidate & c3 ) {
-  helpers::CompositeCandidateMaker cmp( auto_ptr<CompositeCandidate>( new CompositeCandidate ) );
+  helpers::CompositeCandidateMaker cmp( unique_ptr<CompositeCandidate>( new CompositeCandidate ) );
   cmp.addDaughter( c1 );
   cmp.addDaughter( c2 );
   cmp.addDaughter( c3 );
@@ -20,7 +22,7 @@ helpers::CompositeCandidateMaker makeCompositeCandidate( const Candidate & c1, c
 
 helpers::CompositeCandidateMaker makeCompositeCandidate( const Candidate & c1, const Candidate & c2, 
 							 const Candidate & c3,const Candidate & c4 ) {
-  helpers::CompositeCandidateMaker cmp( auto_ptr<CompositeCandidate>( new CompositeCandidate ) );
+  helpers::CompositeCandidateMaker cmp( unique_ptr<CompositeCandidate>( new CompositeCandidate ) );
   cmp.addDaughter( c1 );
   cmp.addDaughter( c2 );
   cmp.addDaughter( c3 );
@@ -31,7 +33,7 @@ helpers::CompositeCandidateMaker makeCompositeCandidate( const Candidate & c1, c
 helpers::CompositeCandidateMaker 
 makeCompositeCandidateWithRefsToMaster( const reco::CandidateRef & c1, 
 					const reco::CandidateRef & c2 ) {
-  helpers::CompositeCandidateMaker cmp( auto_ptr<CompositeCandidate>( new CompositeCandidate ) );
+  helpers::CompositeCandidateMaker cmp( unique_ptr<CompositeCandidate>( new CompositeCandidate ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c1 ) ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c2 ) ) );
   return cmp;
@@ -41,7 +43,7 @@ helpers::CompositeCandidateMaker
 makeCompositeCandidateWithRefsToMaster( const reco::CandidateRef & c1, 
 					const reco::CandidateRef & c2,
 					const reco::CandidateRef & c3 ) {
-  helpers::CompositeCandidateMaker cmp( auto_ptr<CompositeCandidate>( new CompositeCandidate ) );
+  helpers::CompositeCandidateMaker cmp( unique_ptr<CompositeCandidate>( new CompositeCandidate ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c1 ) ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c2 ) ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c3 ) ) );
@@ -53,7 +55,7 @@ makeCompositeCandidateWithRefsToMaster( const reco::CandidateRef & c1,
 					const reco::CandidateRef & c2,
 					const reco::CandidateRef & c3,
 					const reco::CandidateRef & c4 ) {
-  helpers::CompositeCandidateMaker cmp( auto_ptr<CompositeCandidate>( new CompositeCandidate ) );
+  helpers::CompositeCandidateMaker cmp( unique_ptr<CompositeCandidate>( new CompositeCandidate ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c1 ) ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c2 ) ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c3 ) ) );
@@ -62,7 +64,7 @@ makeCompositeCandidateWithRefsToMaster( const reco::CandidateRef & c1,
 }
 
 helpers::CompositePtrCandidateMaker makeCompositePtrCandidate( const CandidatePtr & c1, const CandidatePtr & c2 ) {
-  helpers::CompositePtrCandidateMaker cmp( auto_ptr<CompositePtrCandidate>( new CompositePtrCandidate ) );
+  helpers::CompositePtrCandidateMaker cmp( unique_ptr<CompositePtrCandidate>( new CompositePtrCandidate ) );
   cmp.addDaughter( c1 );
   cmp.addDaughter( c2 );
   return cmp;
@@ -70,7 +72,7 @@ helpers::CompositePtrCandidateMaker makeCompositePtrCandidate( const CandidatePt
 
 helpers::CompositePtrCandidateMaker makeCompositePtrCandidate( const CandidatePtr & c1, const CandidatePtr & c2, 
 							       const CandidatePtr & c3 ) {
-  helpers::CompositePtrCandidateMaker cmp( auto_ptr<CompositePtrCandidate>( new CompositePtrCandidate ) );
+  helpers::CompositePtrCandidateMaker cmp( unique_ptr<CompositePtrCandidate>( new CompositePtrCandidate ) );
   cmp.addDaughter( c1 );
   cmp.addDaughter( c2 );
   cmp.addDaughter( c3 );
@@ -79,7 +81,7 @@ helpers::CompositePtrCandidateMaker makeCompositePtrCandidate( const CandidatePt
 
 helpers::CompositePtrCandidateMaker makeCompositePtrCandidate( const CandidatePtr & c1, const CandidatePtr & c2, 
 							       const CandidatePtr & c3, const CandidatePtr & c4 ) {
-  helpers::CompositePtrCandidateMaker cmp( auto_ptr<CompositePtrCandidate>( new CompositePtrCandidate ) );
+  helpers::CompositePtrCandidateMaker cmp( unique_ptr<CompositePtrCandidate>( new CompositePtrCandidate ) );
   cmp.addDaughter( c1 );
   cmp.addDaughter( c2 );
   cmp.addDaughter( c3 );

--- a/CommonTools/CandUtils/src/makeNamedCompositeCandidate.cc
+++ b/CommonTools/CandUtils/src/makeNamedCompositeCandidate.cc
@@ -1,10 +1,12 @@
+#include <utility>
+
 #include "CommonTools/CandUtils/interface/makeNamedCompositeCandidate.h"
 using namespace reco;
 using namespace std;
 
 helpers::NamedCompositeCandidateMaker makeNamedCompositeCandidate( const Candidate & c1 , std::string s1, 
 								   const Candidate & c2 , std::string s2 ) {
-  helpers::NamedCompositeCandidateMaker cmp( auto_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
+  helpers::NamedCompositeCandidateMaker cmp( unique_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
   cmp.addDaughter( c1, s1 );
   cmp.addDaughter( c2, s2 );
   return cmp;
@@ -13,7 +15,7 @@ helpers::NamedCompositeCandidateMaker makeNamedCompositeCandidate( const Candida
 helpers::NamedCompositeCandidateMaker makeNamedCompositeCandidate( const Candidate & c1, std::string s1,
 								   const Candidate & c2, std::string s2, 
 								   const Candidate & c3, std::string s3 ) {
-  helpers::NamedCompositeCandidateMaker cmp( auto_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
+  helpers::NamedCompositeCandidateMaker cmp( unique_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
   cmp.addDaughter( c1, s1 );
   cmp.addDaughter( c2, s2 );
   cmp.addDaughter( c3, s3 );
@@ -24,7 +26,7 @@ helpers::NamedCompositeCandidateMaker makeNamedCompositeCandidate( const Candida
 								   const Candidate & c2, std::string s2, 
 								   const Candidate & c3, std::string s3,
 								   const Candidate & c4, std::string s4  ) {
-  helpers::NamedCompositeCandidateMaker cmp( auto_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
+  helpers::NamedCompositeCandidateMaker cmp( unique_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
   cmp.addDaughter( c1, s1 );
   cmp.addDaughter( c2, s2 );
   cmp.addDaughter( c3, s3 );
@@ -35,7 +37,7 @@ helpers::NamedCompositeCandidateMaker makeNamedCompositeCandidate( const Candida
 helpers::NamedCompositeCandidateMaker 
 makeNamedCompositeCandidateWithRefsToMaster( const reco::CandidateRef & c1 , std::string s1, 
 					     const reco::CandidateRef & c2 , std::string s2 ) {
-  helpers::NamedCompositeCandidateMaker cmp( auto_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
+  helpers::NamedCompositeCandidateMaker cmp( unique_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c1 ) ), s1 );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c2 ) ), s2 );
   return cmp;
@@ -45,7 +47,7 @@ helpers::NamedCompositeCandidateMaker
 makeNamedCompositeCandidateWithRefsToMaster( const reco::CandidateRef & c1, std::string s1, 
 					     const reco::CandidateRef & c2, std::string s2,
 					     const reco::CandidateRef & c3, std::string s3 ) {
-  helpers::NamedCompositeCandidateMaker cmp( auto_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
+  helpers::NamedCompositeCandidateMaker cmp( unique_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c1 ) ), s1 );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c2 ) ), s2 );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c3 ) ), s3 );
@@ -57,7 +59,7 @@ makeNamedCompositeCandidateWithRefsToMaster( const reco::CandidateRef & c1, std:
 					     const reco::CandidateRef & c2, std::string s2,
 					     const reco::CandidateRef & c3, std::string s3,
 					     const reco::CandidateRef & c4, std::string s4  ) {
-  helpers::NamedCompositeCandidateMaker cmp( auto_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
+  helpers::NamedCompositeCandidateMaker cmp( unique_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c1 ) ), s1 );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c2 ) ), s2 );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c3 ) ), s3 );

--- a/CommonTools/CandUtils/test/testMakeCompositeCandidate.cc
+++ b/CommonTools/CandUtils/test/testMakeCompositeCandidate.cc
@@ -1,5 +1,7 @@
 // $Id: testMakeCompositeCandidate.cc,v 1.1 2009/02/26 09:17:35 llista Exp $
 #include <cppunit/extensions/HelperMacros.h>
+
+#include <utility>
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
 #include "CommonTools/CandUtils/interface/makeCompositeCandidate.h"
 #include "CommonTools/CandUtils/interface/AddFourMomenta.h"
@@ -32,7 +34,7 @@ void testMakeCompositeCandidate::checkAll() {
   test::DummyCandidate t1( p1, q1 );
   test::DummyCandidate t2( p2, q2 );
 
-  auto_ptr<Candidate> cmp = makeCompositeCandidate( t1, t2 )[ AddFourMomenta() ];  
+  unique_ptr<Candidate> cmp = makeCompositeCandidate( t1, t2 )[ AddFourMomenta() ];  
   CPPUNIT_ASSERT( cmp->numberOfDaughters() == 2 );
   const reco::Candidate * d[ 2 ];
   d[ 0 ] = cmp->daughter( 0 );
@@ -52,6 +54,6 @@ void testMakeCompositeCandidate::checkAll() {
   CPPUNIT_ASSERT( fabs(cmp->eta() - ptot.eta()) < epsilon );
   CPPUNIT_ASSERT( fabs(cmp->phi() - ptot.phi()) < epsilon );
 
-  auto_ptr<Candidate> cmp3 = makeCompositeCandidate( t1, t2, t1 )[ AddFourMomenta() ];  
-  auto_ptr<Candidate> cmp4 = makeCompositeCandidate( t1, t2, t1, t2 )[ AddFourMomenta() ];  
+  unique_ptr<Candidate> cmp3 = makeCompositeCandidate( t1, t2, t1 )[ AddFourMomenta() ];  
+  unique_ptr<Candidate> cmp4 = makeCompositeCandidate( t1, t2, t1, t2 )[ AddFourMomenta() ];  
 }

--- a/CommonTools/CandUtils/test/testMakeCompositePtrCandidate.cc
+++ b/CommonTools/CandUtils/test/testMakeCompositePtrCandidate.cc
@@ -5,6 +5,7 @@
 #include "CommonTools/CandUtils/interface/AddFourMomenta.h"
 #include "DataFormats/Common/interface/OrphanHandle.h"
 #include <iostream>
+#include <utility>
 using namespace reco;
 using namespace std;
 
@@ -41,7 +42,7 @@ void testMakePtrCompositeCandidate::checkAll() {
   dcol.push_back(t2);
   edm::OrphanHandle<test::DummyCandidateCollection> handle(&dcol, pid);
   reco::CandidatePtr ptr1(handle, 0), ptr2(handle, 1);
-  auto_ptr<Candidate> cmp = makeCompositePtrCandidate(ptr1, ptr2)[ AddFourMomenta() ];  
+  unique_ptr<Candidate> cmp = makeCompositePtrCandidate(ptr1, ptr2)[ AddFourMomenta() ];  
   CPPUNIT_ASSERT(cmp->numberOfDaughters() == 2);
   const reco::Candidate * d[2];
   const Candidate & cmp2 = *cmp;
@@ -64,6 +65,6 @@ void testMakePtrCompositeCandidate::checkAll() {
   CPPUNIT_ASSERT( fabs(cmp->eta() - ptot.eta()) < epsilon );
   CPPUNIT_ASSERT( fabs(cmp->phi() - ptot.phi()) < epsilon );
 
-  auto_ptr<Candidate> cmp3 = makeCompositePtrCandidate(ptr1, ptr2, ptr1)[ AddFourMomenta() ];  
-  auto_ptr<Candidate> cmp4 = makeCompositePtrCandidate(ptr1, ptr2, ptr1, ptr2)[ AddFourMomenta() ];  
+  unique_ptr<Candidate> cmp3 = makeCompositePtrCandidate(ptr1, ptr2, ptr1)[ AddFourMomenta() ];  
+  unique_ptr<Candidate> cmp4 = makeCompositePtrCandidate(ptr1, ptr2, ptr1, ptr2)[ AddFourMomenta() ];  
 }

--- a/CommonTools/RecoUtils/interface/PFCand_AssoMapAlgos.h
+++ b/CommonTools/RecoUtils/interface/PFCand_AssoMapAlgos.h
@@ -48,10 +48,10 @@ class PFCand_AssoMapAlgos : public PF_PU_AssoMapAlgos  {
    void GetInputCollections(edm::Event&, const edm::EventSetup&);
 
    //create the pf candidate to vertex association map
-   std::auto_ptr<PFCandToVertexAssMap> CreatePFCandToVertexMap(edm::Handle<reco::PFCandidateCollection>, const edm::EventSetup&);
+   std::unique_ptr<PFCandToVertexAssMap> CreatePFCandToVertexMap(edm::Handle<reco::PFCandidateCollection>, const edm::EventSetup&);
 
    //create the vertex to pf candidate association map
-   std::auto_ptr<VertexToPFCandAssMap> CreateVertexToPFCandMap(edm::Handle<reco::PFCandidateCollection>, const edm::EventSetup&);
+   std::unique_ptr<VertexToPFCandAssMap> CreateVertexToPFCandMap(edm::Handle<reco::PFCandidateCollection>, const edm::EventSetup&);
 
    //function to sort the vertices in the AssociationMap by the sum of (pT - pT_Error)**2
    std::unique_ptr<PFCandToVertexAssMap> SortPFCandAssociationMap(PFCandToVertexAssMap*,

--- a/CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h
+++ b/CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h
@@ -94,10 +94,10 @@ class PF_PU_AssoMapAlgos{
    virtual void GetInputCollections(edm::Event&, const edm::EventSetup&);
 
    //create the track to vertex association map
-   std::auto_ptr<TrackToVertexAssMap> CreateTrackToVertexMap(edm::Handle<reco::TrackCollection>, const edm::EventSetup&);
+   std::unique_ptr<TrackToVertexAssMap> CreateTrackToVertexMap(edm::Handle<reco::TrackCollection>, const edm::EventSetup&);
 
    //create the vertex to track association map
-   std::auto_ptr<VertexToTrackAssMap> CreateVertexToTrackMap(edm::Handle<reco::TrackCollection>, const edm::EventSetup&);
+   std::unique_ptr<VertexToTrackAssMap> CreateVertexToTrackMap(edm::Handle<reco::TrackCollection>, const edm::EventSetup&);
 
    //function to sort the vertices in the AssociationMap by the sum of (pT - pT_Error)**2
    std::unique_ptr<TrackToVertexAssMap> SortAssociationMap(TrackToVertexAssMap*);
@@ -133,7 +133,7 @@ class PF_PU_AssoMapAlgos{
    static double dR(const math::XYZPoint&, const math::XYZVector&, edm::Handle<reco::BeamSpot>);
 
    //function to filter the conversion collection
-   static std::auto_ptr<reco::ConversionCollection> GetCleanedConversions(edm::Handle<reco::ConversionCollection>,
+   static std::unique_ptr<reco::ConversionCollection> GetCleanedConversions(edm::Handle<reco::ConversionCollection>,
                                                                           edm::Handle<reco::BeamSpot>, bool);
 
    //function to find out if the track comes from a gamma conversion
@@ -144,10 +144,10 @@ class PF_PU_AssoMapAlgos{
 				               edm::Handle<reco::BeamSpot>, std::vector<reco::VertexRef>*, double);
 
    //function to filter the Kshort collection
-   static std::auto_ptr<reco::VertexCompositeCandidateCollection> GetCleanedKshort(edm::Handle<reco::VertexCompositeCandidateCollection>, edm::Handle<reco::BeamSpot>, bool);
+   static std::unique_ptr<reco::VertexCompositeCandidateCollection> GetCleanedKshort(edm::Handle<reco::VertexCompositeCandidateCollection>, edm::Handle<reco::BeamSpot>, bool);
 
    //function to filter the Lambda collection
-   static std::auto_ptr<reco::VertexCompositeCandidateCollection> GetCleanedLambda(edm::Handle<reco::VertexCompositeCandidateCollection>, edm::Handle<reco::BeamSpot>, bool);
+   static std::unique_ptr<reco::VertexCompositeCandidateCollection> GetCleanedLambda(edm::Handle<reco::VertexCompositeCandidateCollection>, edm::Handle<reco::BeamSpot>, bool);
 
    //function to find out if the track comes from a V0 decay
    static bool ComesFromV0Decay(const reco::TrackRef, const reco::VertexCompositeCandidateCollection&,
@@ -158,7 +158,7 @@ class PF_PU_AssoMapAlgos{
 				       edm::Handle<reco::BeamSpot>, std::vector<reco::VertexRef>*, double);
 
    //function to filter the nuclear interaction collection
-   static std::auto_ptr<reco::PFDisplacedVertexCollection> GetCleanedNI(edm::Handle<reco::PFDisplacedVertexCollection>, edm::Handle<reco::BeamSpot>, bool);
+   static std::unique_ptr<reco::PFDisplacedVertexCollection> GetCleanedNI(edm::Handle<reco::PFDisplacedVertexCollection>, edm::Handle<reco::BeamSpot>, bool);
 
    //function to find out if the track comes from a nuclear interaction
    static bool ComesFromNI(const reco::TrackRef, const reco::PFDisplacedVertexCollection&, reco::PFDisplacedVertex*);
@@ -188,19 +188,19 @@ class PF_PU_AssoMapAlgos{
 
    edm::EDGetTokenT<reco::ConversionCollection> ConversionsCollectionToken_;
    edm::Handle<reco::ConversionCollection> convCollH;
-   std::auto_ptr<reco::ConversionCollection> cleanedConvCollP;
+   std::unique_ptr<reco::ConversionCollection> cleanedConvCollP;
 
    edm::EDGetTokenT<reco::VertexCompositeCandidateCollection> KshortCollectionToken_;
    edm::Handle<reco::VertexCompositeCandidateCollection> vertCompCandCollKshortH;
-   std::auto_ptr<reco::VertexCompositeCandidateCollection> cleanedKshortCollP;
+   std::unique_ptr<reco::VertexCompositeCandidateCollection> cleanedKshortCollP;
 
    edm::EDGetTokenT<reco::VertexCompositeCandidateCollection> LambdaCollectionToken_;
    edm::Handle<reco::VertexCompositeCandidateCollection> vertCompCandCollLambdaH;
-   std::auto_ptr<reco::VertexCompositeCandidateCollection> cleanedLambdaCollP;
+   std::unique_ptr<reco::VertexCompositeCandidateCollection> cleanedLambdaCollP;
 
    edm::EDGetTokenT<reco::PFDisplacedVertexCollection> NIVertexCollectionToken_;
    edm::Handle<reco::PFDisplacedVertexCollection> displVertexCollH;
-   std::auto_ptr<reco::PFDisplacedVertexCollection> cleanedNICollP;
+   std::unique_ptr<reco::PFDisplacedVertexCollection> cleanedNICollP;
 
    int input_FinalAssociation_;
 

--- a/CommonTools/RecoUtils/src/PFCand_AssoMapAlgos.cc
+++ b/CommonTools/RecoUtils/src/PFCand_AssoMapAlgos.cc
@@ -1,4 +1,6 @@
 
+#include <utility>
+
 #include "CommonTools/RecoUtils/interface/PFCand_AssoMapAlgos.h"
 
 #include "TrackingTools/IPTools/interface/IPTools.h"
@@ -46,11 +48,11 @@ PFCand_AssoMapAlgos::GetInputCollections(edm::Event& iEvent, const edm::EventSet
 /* create the pf candidate to vertex association map                                 */
 /*************************************************************************************/
 
-std::auto_ptr<PFCandToVertexAssMap>
+std::unique_ptr<PFCandToVertexAssMap>
 PFCand_AssoMapAlgos::CreatePFCandToVertexMap(edm::Handle<reco::PFCandidateCollection> pfCandH, const edm::EventSetup& iSetup)
 {
 
-        auto_ptr<PFCandToVertexAssMap> pfcand2vertex(new PFCandToVertexAssMap(vtxcollH, pfCandH));
+        unique_ptr<PFCandToVertexAssMap> pfcand2vertex(new PFCandToVertexAssMap(vtxcollH, pfCandH));
 
 	int num_vertices = vtxcollH->size();
 	if ( num_vertices < input_MaxNumAssociations_) input_MaxNumAssociations_ = num_vertices;
@@ -104,7 +106,7 @@ PFCand_AssoMapAlgos::CreatePFCandToVertexMap(edm::Handle<reco::PFCandidateCollec
 	  delete vtxColl_help;
        	}
 
-	return pfcand2vertex;
+	return std::move(pfcand2vertex);
 
 }
 
@@ -112,11 +114,11 @@ PFCand_AssoMapAlgos::CreatePFCandToVertexMap(edm::Handle<reco::PFCandidateCollec
 /* create the vertex to pf candidate association map                                 */
 /*************************************************************************************/
 
-std::auto_ptr<VertexToPFCandAssMap>
+std::unique_ptr<VertexToPFCandAssMap>
 PFCand_AssoMapAlgos::CreateVertexToPFCandMap(edm::Handle<reco::PFCandidateCollection> pfCandH, const edm::EventSetup& iSetup)
 {
 
-  	auto_ptr<VertexToPFCandAssMap> vertex2pfcand(new VertexToPFCandAssMap(pfCandH, vtxcollH));
+  	unique_ptr<VertexToPFCandAssMap> vertex2pfcand(new VertexToPFCandAssMap(pfCandH, vtxcollH));
 
 	int num_vertices = vtxcollH->size();
 	if ( num_vertices < input_MaxNumAssociations_) input_MaxNumAssociations_ = num_vertices;
@@ -170,7 +172,7 @@ PFCand_AssoMapAlgos::CreateVertexToPFCandMap(edm::Handle<reco::PFCandidateCollec
 	  delete vtxColl_help;
        	}
 
-	return vertex2pfcand;
+	return std::move(vertex2pfcand);
 }
 
 /*************************************************************************************/

--- a/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
+++ b/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
@@ -1,4 +1,6 @@
 
+#include <utility>
+
 #include "CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -106,11 +108,11 @@ PF_PU_AssoMapAlgos::GetInputCollections(edm::Event& iEvent, const edm::EventSetu
 /*************************************************************************************/
 /* create the track to vertex association map                                        */
 /*************************************************************************************/
-std::auto_ptr<TrackToVertexAssMap>
+std::unique_ptr<TrackToVertexAssMap>
 PF_PU_AssoMapAlgos::CreateTrackToVertexMap(edm::Handle<reco::TrackCollection> trkcollH, const edm::EventSetup& iSetup)
 {
 
-	auto_ptr<TrackToVertexAssMap> track2vertex(new TrackToVertexAssMap(vtxcollH, trkcollH));
+	unique_ptr<TrackToVertexAssMap> track2vertex(new TrackToVertexAssMap(vtxcollH, trkcollH));
 
 	int num_vertices = vtxcollH->size();
 	if ( num_vertices < input_MaxNumAssociations_) input_MaxNumAssociations_ = num_vertices;
@@ -150,7 +152,7 @@ PF_PU_AssoMapAlgos::CreateTrackToVertexMap(edm::Handle<reco::TrackCollection> tr
 
   	}
 
-	return track2vertex;
+	return std::move(track2vertex);
 
 }
 
@@ -158,11 +160,11 @@ PF_PU_AssoMapAlgos::CreateTrackToVertexMap(edm::Handle<reco::TrackCollection> tr
 /* create the vertex to track association map                                        */
 /*************************************************************************************/
 
-std::auto_ptr<VertexToTrackAssMap>
+std::unique_ptr<VertexToTrackAssMap>
 PF_PU_AssoMapAlgos::CreateVertexToTrackMap(edm::Handle<reco::TrackCollection> trkcollH, const edm::EventSetup& iSetup)
 {
 
-  	auto_ptr<VertexToTrackAssMap> vertex2track(new VertexToTrackAssMap(trkcollH, vtxcollH));
+  	unique_ptr<VertexToTrackAssMap> vertex2track(new VertexToTrackAssMap(trkcollH, vtxcollH));
 
 	int num_vertices = vtxcollH->size();
 	if ( num_vertices < input_MaxNumAssociations_) input_MaxNumAssociations_ = num_vertices;
@@ -201,7 +203,7 @@ PF_PU_AssoMapAlgos::CreateVertexToTrackMap(edm::Handle<reco::TrackCollection> tr
 
 	}
 
-	return vertex2track;
+	return std::move(vertex2track);
 
 }
 
@@ -438,10 +440,10 @@ PF_PU_AssoMapAlgos::dR(const math::XYZPoint& vtx_pos, const math::XYZVector& vtx
 /* function to filter the conversion collection                                      */
 /*************************************************************************************/
 
-auto_ptr<ConversionCollection>
+unique_ptr<ConversionCollection>
 PF_PU_AssoMapAlgos::GetCleanedConversions(edm::Handle<reco::ConversionCollection> convCollH, Handle<BeamSpot> bsH, bool cleanedColl)
 {
-     	auto_ptr<ConversionCollection> cleanedConvColl(new ConversionCollection() );
+     	unique_ptr<ConversionCollection> cleanedConvColl(new ConversionCollection() );
 
 	for (unsigned int convcoll_idx=0; convcoll_idx<convCollH->size(); convcoll_idx++){
 
@@ -461,7 +463,7 @@ PF_PU_AssoMapAlgos::GetCleanedConversions(edm::Handle<reco::ConversionCollection
 
 	}
 
-  	return cleanedConvColl;
+  	return std::move(cleanedConvColl);
 
 }
 
@@ -517,11 +519,11 @@ PF_PU_AssoMapAlgos::FindConversionVertex(const reco::TrackRef trackref, const re
 /* function to filter the Kshort collection                                          */
 /*************************************************************************************/
 
-auto_ptr<VertexCompositeCandidateCollection>
+unique_ptr<VertexCompositeCandidateCollection>
 PF_PU_AssoMapAlgos::GetCleanedKshort(Handle<VertexCompositeCandidateCollection> KshortsH, Handle<BeamSpot> bsH, bool cleanedColl)
 {
 
-     	auto_ptr<VertexCompositeCandidateCollection> cleanedKaonColl(new VertexCompositeCandidateCollection() );
+     	unique_ptr<VertexCompositeCandidateCollection> cleanedKaonColl(new VertexCompositeCandidateCollection() );
 
 	for (unsigned int kscoll_idx=0; kscoll_idx<KshortsH->size(); kscoll_idx++){
 
@@ -559,18 +561,18 @@ PF_PU_AssoMapAlgos::GetCleanedKshort(Handle<VertexCompositeCandidateCollection> 
 
 	}
 
-	return cleanedKaonColl;
+	return std::move(cleanedKaonColl);
 }
 
 /*************************************************************************************/
 /* function to filter the Lambda collection                                          */
 /*************************************************************************************/
 
-auto_ptr<VertexCompositeCandidateCollection>
+unique_ptr<VertexCompositeCandidateCollection>
 PF_PU_AssoMapAlgos::GetCleanedLambda(Handle<VertexCompositeCandidateCollection> LambdasH, Handle<BeamSpot> bsH, bool cleanedColl)
 {
 
-     	auto_ptr<VertexCompositeCandidateCollection> cleanedLambdaColl(new VertexCompositeCandidateCollection() );
+     	unique_ptr<VertexCompositeCandidateCollection> cleanedLambdaColl(new VertexCompositeCandidateCollection() );
 
 	for (unsigned int lambdacoll_idx=0; lambdacoll_idx<LambdasH->size(); lambdacoll_idx++){
 
@@ -608,7 +610,7 @@ PF_PU_AssoMapAlgos::GetCleanedLambda(Handle<VertexCompositeCandidateCollection> 
 
 	}
 
-	return cleanedLambdaColl;
+	return std::move(cleanedLambdaColl);
 }
 
 /*************************************************************************************/
@@ -686,11 +688,11 @@ PF_PU_AssoMapAlgos::FindV0Vertex(const TrackRef trackref, const VertexCompositeC
 /* function to filter the nuclear interaction collection                             */
 /*************************************************************************************/
 
-auto_ptr<PFDisplacedVertexCollection>
+unique_ptr<PFDisplacedVertexCollection>
 PF_PU_AssoMapAlgos::GetCleanedNI(Handle<PFDisplacedVertexCollection> NuclIntH, Handle<BeamSpot> bsH, bool cleanedColl)
 {
 
-     	auto_ptr<PFDisplacedVertexCollection> cleanedNIColl(new PFDisplacedVertexCollection() );
+     	unique_ptr<PFDisplacedVertexCollection> cleanedNIColl(new PFDisplacedVertexCollection() );
 
 	for (PFDisplacedVertexCollection::const_iterator niref=NuclIntH->begin(); niref!=NuclIntH->end(); niref++){
 
@@ -726,7 +728,7 @@ PF_PU_AssoMapAlgos::GetCleanedNI(Handle<PFDisplacedVertexCollection> NuclIntH, H
 
 	}
 
-	return cleanedNIColl;
+	return std::move(cleanedNIColl);
 }
 
 /*************************************************************************************/

--- a/CondCore/CondDB/src/CredentialStore.cc
+++ b/CondCore/CondDB/src/CredentialStore.cc
@@ -211,7 +211,7 @@ namespace cond {
   };
 
   bool selectPrincipal( coral::ISchema& schema, const std::string& principal, PrincipalData& destination ){
-    std::auto_ptr<coral::IQuery> query(schema.tableHandle(COND_AUTHENTICATION_TABLE).newQuery());
+    std::unique_ptr<coral::IQuery> query(schema.tableHandle(COND_AUTHENTICATION_TABLE).newQuery());
     coral::AttributeList readBuff;
     readBuff.extend<int>(PRINCIPAL_ID_COL);
     readBuff.extend<std::string>(VERIFICATION_COL);
@@ -256,7 +256,7 @@ namespace cond {
 
   bool selectConnection( coral::ISchema& schema, const std::string& connectionLabel, CredentialData& destination ){
     
-    std::auto_ptr<coral::IQuery> query(schema.tableHandle(COND_CREDENTIAL_TABLE).newQuery());
+    std::unique_ptr<coral::IQuery> query(schema.tableHandle(COND_CREDENTIAL_TABLE).newQuery());
     coral::AttributeList readBuff;
     readBuff.extend<int>( CONNECTION_ID_COL );
     readBuff.extend<std::string>( USERNAME_COL );
@@ -299,7 +299,7 @@ namespace cond {
   };
 
   bool selectAuthorization( coral::ISchema& schema, int principalId, const std::string& role, const std::string& connectionString, AuthorizationData& destination ){
-    std::auto_ptr<coral::IQuery> query(schema.tableHandle(COND_AUTHORIZATION_TABLE).newQuery());
+    std::unique_ptr<coral::IQuery> query(schema.tableHandle(COND_AUTHORIZATION_TABLE).newQuery());
     coral::AttributeList readBuff;
     readBuff.extend<int>(AUTH_ID_COL);
     readBuff.extend<int>(C_ID_COL);
@@ -355,7 +355,7 @@ void cond::CredentialStore::closeSession( bool commit ){
 
 bool getNextSequenceValue( coral::ISchema& schema, const std::string& sequenceName, int& value ){
   bool ret = false;
-  std::auto_ptr< coral::IQuery > query( schema.tableHandle( SEQUENCE_TABLE_NAME ).newQuery() );
+  std::unique_ptr< coral::IQuery > query( schema.tableHandle( SEQUENCE_TABLE_NAME ).newQuery() );
   query->limitReturnedRows( 1, 0 );
   query->addToOutputList( SEQUENCE_VALUE_COL );
   query->defineOutputType( SEQUENCE_VALUE_COL, coral::AttributeSpecification::typeNameForType<int>() );
@@ -484,7 +484,7 @@ void cond::CredentialStore::startSession( bool readMode ){
     }
     
     // first find the credentials for WRITING in the security tables
-    std::auto_ptr<coral::IQuery> query(schema.newQuery());
+    std::unique_ptr<coral::IQuery> query(schema.newQuery());
     query->addToTableList(COND_AUTHORIZATION_TABLE, "AUTHO");
     query->addToTableList(COND_CREDENTIAL_TABLE, "CREDS");
     coral::AttributeList readBuff;
@@ -1168,7 +1168,7 @@ bool cond::CredentialStore::selectForUser( coral_bridge::AuthenticationCredentia
 
   auth::Cipher cipher( m_principalKey );
 
-  std::auto_ptr<coral::IQuery> query(schema.newQuery());
+  std::unique_ptr<coral::IQuery> query(schema.newQuery());
   query->addToTableList(COND_AUTHORIZATION_TABLE, "AUTHO");
   query->addToTableList(COND_CREDENTIAL_TABLE, "CREDS");
   coral::AttributeList readBuff;
@@ -1259,7 +1259,7 @@ bool cond::CredentialStore::listPrincipals( std::vector<std::string>& destinatio
   session.start( true  );
   coral::ISchema& schema = m_session->nominalSchema();
 
-  std::auto_ptr<coral::IQuery> query(schema.tableHandle(COND_AUTHENTICATION_TABLE).newQuery());
+  std::unique_ptr<coral::IQuery> query(schema.tableHandle(COND_AUTHENTICATION_TABLE).newQuery());
   coral::AttributeList readBuff;
   readBuff.extend<std::string>(PRINCIPAL_NAME_COL);
   query->defineOutput(readBuff);
@@ -1281,7 +1281,7 @@ bool cond::CredentialStore::listConnections( std::map<std::string,std::pair<std:
   session.start( true  );
   coral::ISchema& schema = m_session->nominalSchema();
 
-  std::auto_ptr<coral::IQuery> query(schema.tableHandle(COND_CREDENTIAL_TABLE).newQuery());
+  std::unique_ptr<coral::IQuery> query(schema.tableHandle(COND_CREDENTIAL_TABLE).newQuery());
   coral::AttributeList readBuff;
   readBuff.extend<std::string>( CONNECTION_LABEL_COL );
   readBuff.extend<std::string>( USERNAME_COL );
@@ -1327,7 +1327,7 @@ bool cond::CredentialStore::selectPermissions( const std::string& principalName,
   CSScopedSession session( *this );
   session.start( true  );
   coral::ISchema& schema = m_session->nominalSchema();
-  std::auto_ptr<coral::IQuery> query(schema.newQuery());
+  std::unique_ptr<coral::IQuery> query(schema.newQuery());
   query->addToTableList(COND_AUTHENTICATION_TABLE, "AUTHE");
   query->addToTableList(COND_AUTHORIZATION_TABLE, "AUTHO");
   query->addToTableList(COND_CREDENTIAL_TABLE, "CREDS");
@@ -1385,7 +1385,7 @@ bool cond::CredentialStore::exportAll( coral_bridge::AuthenticationCredentialSet
   CSScopedSession session( *this );
   session.start( true  );
   coral::ISchema& schema = m_session->nominalSchema();
-  std::auto_ptr<coral::IQuery> query(schema.newQuery());
+  std::unique_ptr<coral::IQuery> query(schema.newQuery());
   query->addToTableList(COND_AUTHORIZATION_TABLE, "AUTHO");
   query->addToTableList(COND_CREDENTIAL_TABLE, "CREDS");
   coral::AttributeList readBuff;

--- a/CondFormats/HcalObjects/interface/StorableDoubleMap.h
+++ b/CondFormats/HcalObjects/interface/StorableDoubleMap.h
@@ -16,7 +16,7 @@ public:
     inline ~StorableDoubleMap() {clear();}
 
     inline void add(const std::string& name, const std::string& category,
-                    std::auto_ptr<T> ptr)
+                    std::unique_ptr<T> ptr)
         {delete data_[category][name]; data_[category][name] = ptr.release();}
 
     void clear();

--- a/CondTools/BTau/src/BTagCalibrationReader.cc
+++ b/CondTools/BTau/src/BTagCalibrationReader.cc
@@ -64,7 +64,7 @@ BTagCalibrationReader::BTagCalibrationReaderImpl::BTagCalibrationReaderImpl(
             << "Every otherSysType should only be given once. Duplicate: "
             << ost;
     }
-    otherSysTypeReaders_[ost] = std::auto_ptr<BTagCalibrationReaderImpl>(
+    otherSysTypeReaders_[ost] = std::unique_ptr<BTagCalibrationReaderImpl>(
         new BTagCalibrationReaderImpl(op, ost)
     );
   }

--- a/CondTools/BeamSpot/plugins/BeamSpotRcdReader.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotRcdReader.cc
@@ -77,7 +77,7 @@ class BeamSpotRcdReader : public edm::one::EDAnalyzer<edm::one::SharedResources>
 
       // ----------member data ---------------------------
       edm::ESWatcher<BeamSpotObjectsRcd> watcher_;
-      std::auto_ptr<std::ofstream> output_;
+      std::unique_ptr<std::ofstream> output_;
 };
 
 //

--- a/CondTools/DT/src/DTHVStatusHandler.cc
+++ b/CondTools/DT/src/DTHVStatusHandler.cc
@@ -291,7 +291,7 @@ void DTHVStatusHandler::getChannelMap() {
     std::cout << "retrieve aliases table..." << std::endl;
     coral::ITable& hvalTable =
       buff_session.nominalSchema().tableHandle( "HVALIASES" );
-    std::auto_ptr<coral::IQuery> hvalQuery( hvalTable.newQuery() );
+    std::unique_ptr<coral::IQuery> hvalQuery( hvalTable.newQuery() );
     hvalQuery->addToOutputList( "DETID" );
     hvalQuery->addToOutputList(  "DPID" );
     coral::ICursor& hvalCursor = hvalQuery->execute();
@@ -323,7 +323,7 @@ void DTHVStatusHandler::getLayerSplit() {
   coral::ITable& lsplTable =
     util_session.nominalSchema().tableHandle( "DT_HV_LAYER_SPLIT" );
   std::cout << "         layer split table got..." << std::endl;
-  std::auto_ptr<coral::IQuery> lsplQuery( lsplTable.newQuery() );
+  std::unique_ptr<coral::IQuery> lsplQuery( lsplTable.newQuery() );
   coral::AttributeList versionBindVariableList;
   versionBindVariableList.extend( "version", typeid(std::string) );
   versionBindVariableList["version"].data<std::string>() = mapVersion;
@@ -371,7 +371,7 @@ void DTHVStatusHandler::getChannelSplit() {
   int sl_p;
   coral::ITable& csplTable =
     util_session.nominalSchema().tableHandle( "DT_HV_CHANNEL_SPLIT" );
-  std::auto_ptr<coral::IQuery> csplQuery( csplTable.newQuery() );
+  std::unique_ptr<coral::IQuery> csplQuery( csplTable.newQuery() );
   coral::AttributeList versionBindVariableList;
   versionBindVariableList.extend( "version", typeid(std::string) );
   versionBindVariableList["version"].data<std::string>() = splitVersion;
@@ -448,7 +448,7 @@ void DTHVStatusHandler::dumpHVAliases() {
   std::map<int,std::string> idMap;
   coral::ITable& dpidTable =
     omds_session.nominalSchema().tableHandle( "DP_NAME2ID" );
-  std::auto_ptr<coral::IQuery> dpidQuery( dpidTable.newQuery() );
+  std::unique_ptr<coral::IQuery> dpidQuery( dpidTable.newQuery() );
   dpidQuery->addToOutputList( "ID" );
   dpidQuery->addToOutputList( "DPNAME" );
   coral::ICursor& dpidCursor = dpidQuery->execute();
@@ -465,7 +465,7 @@ void DTHVStatusHandler::dumpHVAliases() {
   std::map<std::string,std::string> cnMap;
   coral::ITable& nameTable =
     omds_session.nominalSchema().tableHandle( "ALIASES" );
-  std::auto_ptr<coral::IQuery> nameQuery( nameTable.newQuery() );
+  std::unique_ptr<coral::IQuery> nameQuery( nameTable.newQuery() );
   nameQuery->addToOutputList( "DPE_NAME" );
   nameQuery->addToOutputList( "ALIAS" );
   coral::ICursor& nameCursor = nameQuery->execute();
@@ -715,7 +715,7 @@ int DTHVStatusHandler::recoverSnapshot() {
   std::cout << "retrieve snapshot table..." << std::endl;
   coral::ITable& hvssTable =
          buff_session.nominalSchema().tableHandle( "HVSNAPSHOT" );
-  std::auto_ptr<coral::IQuery> hvssQuery( hvssTable.newQuery() );
+  std::unique_ptr<coral::IQuery> hvssQuery( hvssTable.newQuery() );
   hvssQuery->addToOutputList( "TIME" );
   hvssQuery->addToOutputList( "WHEEL" );
   hvssQuery->addToOutputList( "STATION" );
@@ -871,7 +871,7 @@ int DTHVStatusHandler::checkForPeriod( cond::Time_t condSince,
 
   coral::ITable& fwccTable =
     omds_session.nominalSchema().tableHandle( "FWCAENCHANNEL" );
-  std::auto_ptr<coral::IQuery> fwccQuery( fwccTable.newQuery() );
+  std::unique_ptr<coral::IQuery> fwccQuery( fwccTable.newQuery() );
   fwccQuery->addToOutputList( "DPID"          );
   fwccQuery->addToOutputList( "CHANGE_DATE"   );
   fwccQuery->addToOutputList( "ACTUAL_VMON"   );

--- a/CondTools/DT/src/DTKeyedConfigHandler.cc
+++ b/CondTools/DT/src/DTKeyedConfigHandler.cc
@@ -135,7 +135,7 @@ void DTKeyedConfigHandler::getNewObjects() {
   std::map<int,std::vector<DTConfigKey>*> rhcMap;
   coral::ITable& runHistoryTable =
     isession->nominalSchema().tableHandle( "RUNHISTORY" );
-  std::auto_ptr<coral::IQuery>
+  std::unique_ptr<coral::IQuery>
     runHistoryQuery( runHistoryTable.newQuery() );
   runHistoryQuery->addToOutputList( "RUN" );
   runHistoryQuery->addToOutputList( "RHID" );
@@ -172,7 +172,7 @@ void DTKeyedConfigHandler::getNewObjects() {
   std::map<int,DTCCBId> ccbMap;
   coral::ITable& ccbMapTable =
     isession->nominalSchema().tableHandle( "CCBMAP" );
-  std::auto_ptr<coral::IQuery>
+  std::unique_ptr<coral::IQuery>
     ccbMapQuery( ccbMapTable.newQuery() );
   ccbMapQuery->addToOutputList( "CCBID" );
   ccbMapQuery->addToOutputList( "WHEEL" );
@@ -196,7 +196,7 @@ void DTKeyedConfigHandler::getNewObjects() {
   std::cout << "retrieve brick types" << std::endl;
   std::map<int,int> bktMap;
   coral::AttributeList emptyBindVariableList;
-  std::auto_ptr<coral::IQuery>
+  std::unique_ptr<coral::IQuery>
          brickTypeQuery( isession->nominalSchema().newQuery() );
   brickTypeQuery->addToTableList( "CFGBRICKS" );
   brickTypeQuery->addToTableList( "BRKT2CSETT" );
@@ -221,7 +221,7 @@ void DTKeyedConfigHandler::getNewObjects() {
   std::map<int,int> cfgMap;
   coral::ITable& rhcRelTable =
     isession->nominalSchema().tableHandle( "RHRELATIONS" );
-  std::auto_ptr<coral::IQuery>
+  std::unique_ptr<coral::IQuery>
     rhcRelQuery( rhcRelTable.newQuery() );
   rhcRelQuery->addToOutputList( "RHID" );
   rhcRelQuery->addToOutputList( "CONFKEY" );
@@ -254,7 +254,7 @@ void DTKeyedConfigHandler::getNewObjects() {
   std::map<int,int> cckMap;
   coral::ITable& ccbRelTable =
     isession->nominalSchema().tableHandle( "CCBRELATIONS" );
-  std::auto_ptr<coral::IQuery>
+  std::unique_ptr<coral::IQuery>
     ccbRelQuery( ccbRelTable.newQuery() );
   ccbRelQuery->addToOutputList( "CONFKEY" );
   ccbRelQuery->addToOutputList( "CCBID" );
@@ -295,7 +295,7 @@ void DTKeyedConfigHandler::getNewObjects() {
   std::map<int,std::vector<int>*> brkMap;
   coral::ITable& confBrickTable =
     isession->nominalSchema().tableHandle( "CFG2BRKREL" );
-  std::auto_ptr<coral::IQuery>
+  std::unique_ptr<coral::IQuery>
     confBrickQuery( confBrickTable.newQuery() );
   confBrickQuery->addToOutputList( "CONFID" );
   confBrickQuery->addToOutputList( "BRKID"  );
@@ -453,7 +453,7 @@ void DTKeyedConfigHandler::chkConfigList() {
   std::map<int,bool> activeConfigMap;
   coral::ITable& fullConfigTable =
     isession->nominalSchema().tableHandle( "CONFIGSETS" );
-  std::auto_ptr<coral::IQuery>
+  std::unique_ptr<coral::IQuery>
     fullConfigQuery( fullConfigTable.newQuery() );
   fullConfigQuery->addToOutputList( "CONFKEY" );
   fullConfigQuery->addToOutputList( "NAME" );
@@ -474,7 +474,7 @@ void DTKeyedConfigHandler::chkConfigList() {
   std::map<int,bool> activeCCBCfgMap;
   coral::ITable& fullCCBCfgTable =
     isession->nominalSchema().tableHandle( "CCBRELATIONS" );
-  std::auto_ptr<coral::IQuery>
+  std::unique_ptr<coral::IQuery>
     fullCCBCfgQuery( fullCCBCfgTable.newQuery() );
   fullCCBCfgQuery->addToOutputList( "CONFKEY" );
   fullCCBCfgQuery->addToOutputList( "CONFCCBKEY" );
@@ -498,7 +498,7 @@ void DTKeyedConfigHandler::chkConfigList() {
   std::map<int,bool> activeCfgBrkMap;
   coral::ITable& ccbConfBrkTable =
     isession->nominalSchema().tableHandle( "CFG2BRKREL" );
-  std::auto_ptr<coral::IQuery>
+  std::unique_ptr<coral::IQuery>
     ccbConfBrickQuery( ccbConfBrkTable.newQuery() );
   ccbConfBrickQuery->addToOutputList( "CONFID" );
   ccbConfBrickQuery->addToOutputList( "BRKID" );
@@ -522,7 +522,7 @@ void DTKeyedConfigHandler::chkConfigList() {
 
   coral::ITable& brickConfigTable =
     isession->nominalSchema().tableHandle( "CFGBRICKS" );
-  std::auto_ptr<coral::IQuery>
+  std::unique_ptr<coral::IQuery>
     brickConfigQuery( brickConfigTable.newQuery() );
   brickConfigQuery->addToOutputList( "BRKID" );
   brickConfigQuery->addToOutputList( "BRKNAME" );
@@ -571,7 +571,7 @@ void DTKeyedConfigHandler::chkConfigList() {
     coral::AttributeList bindVariableList;
     bindVariableList.extend( "brickId", typeid(int) );
     bindVariableList["brickId"].data<int>() = brickConfigId;
-    std::auto_ptr<coral::IQuery>
+    std::unique_ptr<coral::IQuery>
            brickDataQuery( isession->nominalSchema().newQuery() );
     brickDataQuery->addToTableList( "CFGRELATIONS" );
     brickDataQuery->addToTableList( "CONFIGCMDS" );

--- a/CondTools/DT/src/DTUserKeyedConfigHandler.cc
+++ b/CondTools/DT/src/DTUserKeyedConfigHandler.cc
@@ -137,7 +137,7 @@ void DTUserKeyedConfigHandler::getNewObjects() {
   std::map<int,DTCCBId> ccbMap;
   coral::ITable& ccbMapTable =
     isession->nominalSchema().tableHandle( "CCBMAP" );
-  std::auto_ptr<coral::IQuery>
+  std::unique_ptr<coral::IQuery>
     ccbMapQuery( ccbMapTable.newQuery() );
   ccbMapQuery->addToOutputList( "CCBID" );
   ccbMapQuery->addToOutputList( "WHEEL" );
@@ -161,7 +161,7 @@ void DTUserKeyedConfigHandler::getNewObjects() {
   std::cout << "retrieve brick types" << std::endl;
   std::map<int,int> bktMap;
   coral::AttributeList emptyBindVariableList;
-  std::auto_ptr<coral::IQuery>
+  std::unique_ptr<coral::IQuery>
          brickTypeQuery( isession->nominalSchema().newQuery() );
   brickTypeQuery->addToTableList( "CFGBRICKS" );
   brickTypeQuery->addToTableList( "BRKT2CSETT" );
@@ -186,7 +186,7 @@ void DTUserKeyedConfigHandler::getNewObjects() {
   std::map<int,int> cckMap;
   coral::ITable& ccbRelTable =
     isession->nominalSchema().tableHandle( "CCBRELATIONS" );
-  std::auto_ptr<coral::IQuery>
+  std::unique_ptr<coral::IQuery>
     ccbRelQuery( ccbRelTable.newQuery() );
   ccbRelQuery->addToOutputList( "CONFKEY" );
   ccbRelQuery->addToOutputList( "CCBID" );
@@ -224,7 +224,7 @@ void DTUserKeyedConfigHandler::getNewObjects() {
   std::map<int,std::vector<int>*> brkMap;
   coral::ITable& confBrickTable =
     isession->nominalSchema().tableHandle( "CFG2BRKREL" );
-  std::auto_ptr<coral::IQuery>
+  std::unique_ptr<coral::IQuery>
     confBrickQuery( confBrickTable.newQuery() );
   confBrickQuery->addToOutputList( "CONFID" );
   confBrickQuery->addToOutputList( "BRKID"  );
@@ -340,7 +340,7 @@ void DTUserKeyedConfigHandler::chkConfigList(
 
   coral::ITable& brickConfigTable =
     isession->nominalSchema().tableHandle( "CFGBRICKS" );
-  std::auto_ptr<coral::IQuery>
+  std::unique_ptr<coral::IQuery>
     brickConfigQuery( brickConfigTable.newQuery() );
   brickConfigQuery->addToOutputList( "BRKID" );
   brickConfigQuery->addToOutputList( "BRKNAME" );
@@ -388,7 +388,7 @@ void DTUserKeyedConfigHandler::chkConfigList(
     coral::AttributeList bindVariableList;
     bindVariableList.extend( "brickId", typeid(int) );
     bindVariableList["brickId"].data<int>() = brickConfigId;
-    std::auto_ptr<coral::IQuery>
+    std::unique_ptr<coral::IQuery>
            brickDataQuery( isession->nominalSchema().newQuery() );
     brickDataQuery->addToTableList( "CFGRELATIONS" );
     brickDataQuery->addToTableList( "CONFIGCMDS" );

--- a/CondTools/Ecal/src/EcalMappingElectronicsHandler.cc
+++ b/CondTools/Ecal/src/EcalMappingElectronicsHandler.cc
@@ -29,7 +29,7 @@ void EcalMappingElectronicsHandler::getNewObjects()
 
   std::cout << "------- Ecal - > getNewObjects\n";
   EcalMappingElectronics *payload = new EcalMappingElectronics ;
-  std::auto_ptr<EcalMappingElectronics> mapping = std::auto_ptr<EcalMappingElectronics>( new EcalMappingElectronics() );
+  std::unique_ptr<EcalMappingElectronics> mapping = std::unique_ptr<EcalMappingElectronics>( new EcalMappingElectronics() );
   //Filling map reading from file 
   edm::LogInfo("EcalMappingElectronicsHandler") << "Reading mapping from file " << edm::FileInPath(txtFileSource_).fullPath().c_str() ;
   

--- a/CondTools/HLT/src/AlCaRecoTriggerBitsRcdRead.cc
+++ b/CondTools/HLT/src/AlCaRecoTriggerBitsRcdRead.cc
@@ -62,7 +62,7 @@ private:
   edm::RunNumber_t firstRun_; 
   edm::RunNumber_t lastRun_;
   AlCaRecoTriggerBits lastTriggerBits_;
-  std::auto_ptr<std::ofstream> output_;
+  std::unique_ptr<std::ofstream> output_;
 };
 
 ///////////////////////////////////////////////////////////////////////

--- a/CondTools/Hcal/plugins/BufferedBoostIODBWriter.cc
+++ b/CondTools/Hcal/plugins/BufferedBoostIODBWriter.cc
@@ -45,7 +45,7 @@ BufferedBoostIODBWriter::BufferedBoostIODBWriter(const edm::ParameterSet& ps)
 void BufferedBoostIODBWriter::analyze(const edm::Event& iEvent,
                                       const edm::EventSetup& iSetup)
 {
-    std::auto_ptr<OOTPileupCorrectionBuffer> fcp;
+    std::unique_ptr<OOTPileupCorrectionBuffer> fcp;
 
     {
         std::ifstream input(inputFile.c_str(), std::ios_base::binary);
@@ -59,7 +59,7 @@ void BufferedBoostIODBWriter::analyze(const edm::Event& iEvent,
                 << "Failed to stat file \"" << inputFile << '"' << std::endl;
 
         const std::size_t len = st.st_size;
-        fcp = std::auto_ptr<OOTPileupCorrectionBuffer>(
+        fcp = std::unique_ptr<OOTPileupCorrectionBuffer>(
             new OOTPileupCorrectionBuffer(len));
         assert(fcp->length() == len);
         if (len)

--- a/CondTools/L1Trigger/src/DataWriter.cc
+++ b/CondTools/L1Trigger/src/DataWriter.cc
@@ -20,7 +20,7 @@ DataWriter::writePayload( const edm::EventSetup& setup,
 			  const std::string& recordType )
 {
   WriterFactory* factory = WriterFactory::get();
-  std::auto_ptr<WriterProxy> writer(factory->create( recordType + "@Writer" )) ;
+  std::unique_ptr<WriterProxy> writer(factory->create( recordType + "@Writer" )) ;
   if( writer.get() == 0 )
     {
       throw cond::Exception( "DataWriter: could not create WriterProxy with name "

--- a/CondTools/L1TriggerExt/src/DataWriterExt.cc
+++ b/CondTools/L1TriggerExt/src/DataWriterExt.cc
@@ -20,7 +20,7 @@ DataWriterExt::writePayload( const edm::EventSetup& setup,
 			  const std::string& recordType )
 {
   WriterFactory* factory = WriterFactory::get();
-  std::auto_ptr<WriterProxy> writer(factory->create( recordType + "@Writer" )) ;
+  std::unique_ptr<WriterProxy> writer(factory->create( recordType + "@Writer" )) ;
   if( writer.get() == 0 )
     {
       throw cond::Exception( "DataWriter: could not create WriterProxy with name "

--- a/CondTools/RPC/src/RPCDCCLinkMapHandler.cc
+++ b/CondTools/RPC/src/RPCDCCLinkMapHandler.cc
@@ -50,7 +50,7 @@ void RPCDCCLinkMapHandler::getNewObjects()
     edm::LogInfo("RPCDCCLinkMapHandler") << "Started Input Transaction";
     input_session->transaction().start(true); // readOnly
 
-    std::auto_ptr<coral::IQuery> query(input_session->schema("CMS_RPC_CONF").newQuery());
+    std::unique_ptr<coral::IQuery> query(input_session->schema("CMS_RPC_CONF").newQuery());
     query->addToTableList("DCCBOARD");
     query->addToTableList("TRIGGERBOARD");
     query->addToTableList("BOARDBOARDCONN");

--- a/CondTools/RPC/src/RPCLBLinkMapHandler.cc
+++ b/CondTools/RPC/src/RPCLBLinkMapHandler.cc
@@ -108,7 +108,7 @@ void RPCLBLinkMapHandler::getNewObjects()
     edm::LogInfo("RPCDCCLinkMapHandler") << "Started Input Transaction";
     input_session->transaction().start(true); // readOnly
 
-    std::auto_ptr<coral::IQuery> query(input_session->schema("CMS_RPC_CONF").newQuery());
+    std::unique_ptr<coral::IQuery> query(input_session->schema("CMS_RPC_CONF").newQuery());
     query->addToTableList("BOARD");
     query->addToTableList("CHAMBERSTRIP");
     query->addToTableList("CHAMBERLOCATION");

--- a/DQM/EcalMonitorDbModule/plugins/EcalCondDBReader.cc
+++ b/DQM/EcalMonitorDbModule/plugins/EcalCondDBReader.cc
@@ -56,17 +56,17 @@ EcalCondDBReader::EcalCondDBReader(edm::ParameterSet const& _ps) :
   std::string userName(_ps.getUntrackedParameter<std::string>("userName"));
   std::string password(_ps.getUntrackedParameter<std::string>("password"));
 
-  std::auto_ptr<EcalCondDBInterface> db(0);
+  std::unique_ptr<EcalCondDBInterface> db(0);
 
   if(verbosity_ > 0) edm::LogInfo("EcalDQM") << "Establishing DB connection";
 
   try{
-    db = std::auto_ptr<EcalCondDBInterface>(new EcalCondDBInterface(DBName, userName, password));
+    db = std::unique_ptr<EcalCondDBInterface>(new EcalCondDBInterface(DBName, userName, password));
   }
   catch(std::runtime_error& re){
     if(hostName != ""){
       try{
-        db = std::auto_ptr<EcalCondDBInterface>(new EcalCondDBInterface(hostName, DBName, userName, password, hostPort));
+        db = std::unique_ptr<EcalCondDBInterface>(new EcalCondDBInterface(hostName, DBName, userName, password, hostPort));
       }
       catch(std::runtime_error& re2){
         throw cms::Exception("DBError") << re2.what();

--- a/DQM/EcalMonitorDbModule/plugins/EcalCondDBWriter.cc
+++ b/DQM/EcalMonitorDbModule/plugins/EcalCondDBWriter.cc
@@ -50,7 +50,7 @@ EcalCondDBWriter::EcalCondDBWriter(edm::ParameterSet const& _ps) :
     if(verbosity_ > 1) edm::LogInfo("EcalDQM") << " " << fileName;
 
     TPRegexp pat("DQM_V[0-9]+(?:|_[0-9a-zA-Z]+)_R([0-9]+)");
-    std::auto_ptr<TObjArray> matches(pat.MatchS(fileName.c_str()));
+    std::unique_ptr<TObjArray> matches(pat.MatchS(fileName.c_str()));
     if(matches->GetEntries() == 0)
       throw cms::Exception("Configuration") << "Input file " << fileName << " is not an DQM output";
 
@@ -68,17 +68,17 @@ EcalCondDBWriter::EcalCondDBWriter(edm::ParameterSet const& _ps) :
   std::string userName(_ps.getUntrackedParameter<std::string>("userName"));
   std::string password(_ps.getUntrackedParameter<std::string>("password"));
 
-  std::auto_ptr<EcalCondDBInterface> db(0);
+  std::unique_ptr<EcalCondDBInterface> db(0);
 
   if(verbosity_ > 0) edm::LogInfo("EcalDQM") << "Establishing DB connection";
 
   try{
-    db = std::auto_ptr<EcalCondDBInterface>(new EcalCondDBInterface(DBName, userName, password));
+    db = std::unique_ptr<EcalCondDBInterface>(new EcalCondDBInterface(DBName, userName, password));
   }
   catch(std::runtime_error& re){
     if(hostName != ""){
       try{
-        db = std::auto_ptr<EcalCondDBInterface>(new EcalCondDBInterface(hostName, DBName, userName, password, hostPort));
+        db = std::unique_ptr<EcalCondDBInterface>(new EcalCondDBInterface(hostName, DBName, userName, password, hostPort));
       }
       catch(std::runtime_error& re2){
         throw cms::Exception("DBError") << re2.what();

--- a/DQM/SiStripCommissioningClients/interface/CommissioningHistograms.h
+++ b/DQM/SiStripCommissioningClients/interface/CommissioningHistograms.h
@@ -139,7 +139,7 @@ class CommissioningHistograms {
 
  protected:
 
-  std::auto_ptr<Factory> factory_;
+  std::unique_ptr<Factory> factory_;
   
  private:
   

--- a/DQM/SiStripCommissioningClients/interface/DaqScopeModeHistograms.h
+++ b/DQM/SiStripCommissioningClients/interface/DaqScopeModeHistograms.h
@@ -30,7 +30,7 @@ class DaqScopeModeHistograms : public CommissioningHistograms {
   
   std::map<uint32_t,DaqScopeModeAnalysis> data_;
   
-  std::auto_ptr<Factory> factory_;
+  std::unique_ptr<Factory> factory_;
   
 };
 

--- a/DQM/SiStripCommissioningClients/interface/FedCablingHistograms.h
+++ b/DQM/SiStripCommissioningClients/interface/FedCablingHistograms.h
@@ -34,7 +34,7 @@ class FedCablingHistograms : virtual public CommissioningHistograms {
   
   Analyses data_;
   
-  std::auto_ptr<Factory> factory_;
+  std::unique_ptr<Factory> factory_;
 
 };
 

--- a/DQM/SiStripCommissioningClients/interface/FedTimingHistograms.h
+++ b/DQM/SiStripCommissioningClients/interface/FedTimingHistograms.h
@@ -28,7 +28,7 @@ class FedTimingHistograms : public CommissioningHistograms {
 
   std::map<uint32_t,FedTimingAnalysis> data_;
 
-  std::auto_ptr<Factory> factory_;
+  std::unique_ptr<Factory> factory_;
   
   const float optimumSamplingPoint_;
   float minDelay_;

--- a/DQM/SiStripCommissioningClients/src/ApvTimingHistograms.cc
+++ b/DQM/SiStripCommissioningClients/src/ApvTimingHistograms.cc
@@ -21,7 +21,7 @@ ApvTimingHistograms::ApvTimingHistograms( const edm::ParameterSet& pset,
                              bei,
                              sistrip::APV_TIMING )
 {
-  factory_ = auto_ptr<ApvTimingSummaryFactory>( new ApvTimingSummaryFactory );
+  factory_ = unique_ptr<ApvTimingSummaryFactory>( new ApvTimingSummaryFactory );
   LogTrace(mlDqmClient_) 
     << "[ApvTimingHistograms::" << __func__ << "]"
     << " Constructing object...";

--- a/DQM/SiStripCommissioningClients/src/CalibrationHistograms.cc
+++ b/DQM/SiStripCommissioningClients/src/CalibrationHistograms.cc
@@ -30,7 +30,7 @@ CalibrationHistograms::CalibrationHistograms( const edm::ParameterSet& pset,
        << "[CalibrationHistograms::" << __func__ << "]"
        << " Constructing object...";
   std::string temp = std::string(sistrip::collate_) + "/" + sistrip::root_;
-  factory_ = auto_ptr<CalibrationSummaryFactory>( new CalibrationSummaryFactory );
+  factory_ = unique_ptr<CalibrationSummaryFactory>( new CalibrationSummaryFactory );
   MonitorElement* calchanElement = bei->get(temp + "/calchan");
   if(calchanElement) {
     calchan_ = calchanElement->getIntValue();

--- a/DQM/SiStripCommissioningClients/src/FastFedCablingHistograms.cc
+++ b/DQM/SiStripCommissioningClients/src/FastFedCablingHistograms.cc
@@ -21,7 +21,7 @@ FastFedCablingHistograms::FastFedCablingHistograms( const edm::ParameterSet& pse
                              bei,
                              sistrip::FAST_CABLING )
 {
-  factory_ = auto_ptr<FastFedCablingSummaryFactory>( new FastFedCablingSummaryFactory );
+  factory_ = unique_ptr<FastFedCablingSummaryFactory>( new FastFedCablingSummaryFactory );
   LogTrace(mlDqmClient_) 
     << "[FastFedCablingHistograms::" << __func__ << "]"
     << " Constructing object...";

--- a/DQM/SiStripCommissioningClients/src/NoiseHistograms.cc
+++ b/DQM/SiStripCommissioningClients/src/NoiseHistograms.cc
@@ -21,7 +21,7 @@ NoiseHistograms::NoiseHistograms( const edm::ParameterSet& pset,
                              bei,
                              sistrip::NOISE )
 {
-  factory_ = auto_ptr<NoiseSummaryFactory>( new NoiseSummaryFactory );
+  factory_ = unique_ptr<NoiseSummaryFactory>( new NoiseSummaryFactory );
   LogTrace(mlDqmClient_) 
     << "[NoiseHistograms::" << __func__ << "]"
     << " Constructing object...";

--- a/DQM/SiStripCommissioningClients/src/OptoScanHistograms.cc
+++ b/DQM/SiStripCommissioningClients/src/OptoScanHistograms.cc
@@ -21,7 +21,7 @@ OptoScanHistograms::OptoScanHistograms( const edm::ParameterSet& pset,
                              bei,
                              sistrip::OPTO_SCAN )
 {
-  factory_ = auto_ptr<OptoScanSummaryFactory>( new OptoScanSummaryFactory );
+  factory_ = unique_ptr<OptoScanSummaryFactory>( new OptoScanSummaryFactory );
   LogTrace(mlDqmClient_) 
     << "[OptoScanHistograms::" << __func__ << "]"
     << " Constructing object...";

--- a/DQM/SiStripCommissioningClients/src/PedestalsHistograms.cc
+++ b/DQM/SiStripCommissioningClients/src/PedestalsHistograms.cc
@@ -21,7 +21,7 @@ PedestalsHistograms::PedestalsHistograms( const edm::ParameterSet& pset,
                              bei,
                              sistrip::PEDESTALS )
 {
-  factory_ = auto_ptr<PedestalsSummaryFactory>( new PedestalsSummaryFactory );
+  factory_ = unique_ptr<PedestalsSummaryFactory>( new PedestalsSummaryFactory );
   LogTrace(mlDqmClient_) 
     << "[PedestalsHistograms::" << __func__ << "]"
     << " Constructing object...";

--- a/DQM/SiStripCommissioningClients/src/PedsFullNoiseHistograms.cc
+++ b/DQM/SiStripCommissioningClients/src/PedsFullNoiseHistograms.cc
@@ -21,7 +21,7 @@ PedsFullNoiseHistograms::PedsFullNoiseHistograms( const edm::ParameterSet& pset,
                              bei,
                              sistrip::PEDS_FULL_NOISE )
 {
-  factory_ = auto_ptr<PedsFullNoiseSummaryFactory>( new PedsFullNoiseSummaryFactory );
+  factory_ = unique_ptr<PedsFullNoiseSummaryFactory>( new PedsFullNoiseSummaryFactory );
   LogTrace(mlDqmClient_) 
     << "[PedsFullNoiseHistograms::" << __func__ << "]"
     << " Constructing object...";

--- a/DQM/SiStripCommissioningClients/src/PedsOnlyHistograms.cc
+++ b/DQM/SiStripCommissioningClients/src/PedsOnlyHistograms.cc
@@ -21,7 +21,7 @@ PedsOnlyHistograms::PedsOnlyHistograms( const edm::ParameterSet& pset,
                              bei,
                              sistrip::PEDS_ONLY )
 {
-  factory_ = auto_ptr<PedsOnlySummaryFactory>( new PedsOnlySummaryFactory );
+  factory_ = unique_ptr<PedsOnlySummaryFactory>( new PedsOnlySummaryFactory );
   LogTrace(mlDqmClient_) 
     << "[PedsOnlyHistograms::" << __func__ << "]"
     << " Constructing object...";

--- a/DQM/SiStripCommissioningClients/src/SamplingHistograms.cc
+++ b/DQM/SiStripCommissioningClients/src/SamplingHistograms.cc
@@ -27,7 +27,7 @@ SamplingHistograms::SamplingHistograms( const edm::ParameterSet& pset,
   LogTrace(mlDqmClient_) 
        << "[SamplingHistograms::" << __func__ << "]"
        << " Constructing object...";
-  factory_ = auto_ptr<SamplingSummaryFactory>( new SamplingSummaryFactory );
+  factory_ = unique_ptr<SamplingSummaryFactory>( new SamplingSummaryFactory );
   // retreive the latency code from the root file
   std::string dataPath = std::string(sistrip::collate_) + "/" + sistrip::root_ + "/latencyCode";
   MonitorElement* codeElement = bei->get(dataPath);

--- a/DQM/SiStripCommissioningClients/src/VpspScanHistograms.cc
+++ b/DQM/SiStripCommissioningClients/src/VpspScanHistograms.cc
@@ -21,7 +21,7 @@ VpspScanHistograms::VpspScanHistograms( const edm::ParameterSet& pset,
                              bei,
                              sistrip::VPSP_SCAN )
 {
-  factory_ = auto_ptr<VpspScanSummaryFactory>( new VpspScanSummaryFactory );
+  factory_ = unique_ptr<VpspScanSummaryFactory>( new VpspScanSummaryFactory );
   LogTrace(mlDqmClient_) 
     << "[VpspScanHistograms::" << __func__ << "]"
     << " Constructing object...";

--- a/DQM/SiStripCommissioningSources/src/NoiseTask.cc
+++ b/DQM/SiStripCommissioningSources/src/NoiseTask.cc
@@ -66,8 +66,8 @@ void NoiseTask::book()
   LogTrace( mlDqmSource_) << "[NoiseTask::" << __func__ << "]";
 
   // CACHING
-  static std::auto_ptr<SiStripPedestals> pDBPedestals;
-  static std::auto_ptr<SiStripNoises>    pDBNoises;
+  static std::unique_ptr<SiStripPedestals> pDBPedestals;
+  static std::unique_ptr<SiStripNoises>    pDBNoises;
   
   const uint16_t nBINS = 256;
   

--- a/DQM/SiStripMonitorHardware/src/FEDErrors.cc
+++ b/DQM/SiStripMonitorHardware/src/FEDErrors.cc
@@ -235,7 +235,7 @@ bool FEDErrors::fillFatalFEDErrors(const FEDRawData& aFedData,
 				   const unsigned int aPrintDebug)
 {
 
-  std::auto_ptr<const sistrip::FEDBufferBase> bufferBase;
+  std::unique_ptr<const sistrip::FEDBufferBase> bufferBase;
   try {
     bufferBase.reset(new sistrip::FEDBufferBase(aFedData.data(),aFedData.size()));
   } catch (const cms::Exception& e) {
@@ -347,7 +347,7 @@ bool FEDErrors::fillFEDErrors(const FEDRawData& aFedData,
   if (!fillFatalFEDErrors(aFedData,aPrintDebug)) return false;
 
   //need to construct full object to go any further
-  std::auto_ptr<const sistrip::FEDBuffer> buffer;
+  std::unique_ptr<const sistrip::FEDBuffer> buffer;
   buffer.reset(new sistrip::FEDBuffer(aFedData.data(),aFedData.size(),true));
 
   //fill remaining unpackerFEDcheck

--- a/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
@@ -229,7 +229,7 @@ SiStripCMMonitorPlugin::analyze(const edm::Event& iEvent,
       continue;
     }
 
-    std::auto_ptr<const sistrip::FEDBuffer> buffer;
+    std::unique_ptr<const sistrip::FEDBuffer> buffer;
 
     if (!lFedErrors.fillFatalFEDErrors(fedData,0)) {
       continue;

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDDataCheck.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDDataCheck.cc
@@ -224,7 +224,7 @@ SiStripFEDCheckPlugin::analyze(const edm::Event& iEvent, const edm::EventSetup& 
     bool hasFatalErrors = false;
     float rateNonFatal = 0;
 
-    std::auto_ptr<const sistrip::FEDBuffer> buffer;
+    std::unique_ptr<const sistrip::FEDBuffer> buffer;
 
     if (!lFedErrors.fillFatalFEDErrors(fedData,0)) {
       hasFatalErrors = true;

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyIdentifyRuns.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyIdentifyRuns.cc
@@ -121,7 +121,7 @@ namespace sistrip {
 	if ( !input.data() ||!input.size() ) continue;
           
 	//construct FEDBuffer
-	std::auto_ptr<sistrip::FEDSpyBuffer> buffer;
+	std::unique_ptr<sistrip::FEDSpyBuffer> buffer;
 	try {
 	  buffer.reset(new sistrip::FEDSpyBuffer(input.data(),input.size()));
 	} catch (const cms::Exception& e) { 

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyUnpacker.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyUnpacker.cc
@@ -124,7 +124,7 @@ namespace sistrip {
       auto conns = cabling.fedConnections(lFedId);
           
       //construct FEDBuffer
-      std::auto_ptr<sistrip::FEDSpyBuffer> buffer;
+      std::unique_ptr<sistrip::FEDSpyBuffer> buffer;
       try {
 	buffer.reset(new sistrip::FEDSpyBuffer(input.data(),input.size()));
 	if (!buffer->doChecks() && !allowIncompleteEvents_) {
@@ -208,7 +208,7 @@ namespace sistrip {
     *aRunRef = lRef;
 
     //create DSV to return
-    std::auto_ptr<RawDigis> pResult = dsvFiller.createDetSetVector();
+    std::unique_ptr<RawDigis> pResult = dsvFiller.createDetSetVector();
     pDigis->swap(*pResult);
 
   } // end of SpyUnpacker::createDigis method.

--- a/DQMOffline/RecoB/src/MVAJetTagPlotter.cc
+++ b/DQMOffline/RecoB/src/MVAJetTagPlotter.cc
@@ -1,6 +1,7 @@
 #include <sstream>
 
 #include <boost/bind.hpp>
+#include <utility>
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"

--- a/DQMOffline/RecoB/src/TagInfoPlotterFactory.cc
+++ b/DQMOffline/RecoB/src/TagInfoPlotterFactory.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "DQMOffline/RecoB/interface/TagInfoPlotterFactory.h"
 #include "DQMOffline/RecoB/interface/TrackCountingTagPlotter.h"
 #include "DQMOffline/RecoB/interface/TrackProbabilityTagPlotter.h"

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -2688,7 +2688,7 @@ DQMStore::save(const std::string &filename,
   f.cd();
 
   // Construct a regular expression from the pattern string.
-  std::auto_ptr<lat::Regexp> rxpat;
+  std::unique_ptr<lat::Regexp> rxpat;
   if (! pattern.empty())
     rxpat.reset(new lat::Regexp(pattern.c_str()));
 
@@ -2942,7 +2942,7 @@ DQMStore::readDirectory(TFile *file,
   std::list<TObject *> delayed;
   while ((key = (TKey *) next()))
   {
-    std::auto_ptr<TObject> obj(key->ReadObj());
+    std::unique_ptr<TObject> obj(key->ReadObj());
     if (dynamic_cast<TDirectory *>(obj.get()))
     {
       std::string subdir;
@@ -3057,7 +3057,7 @@ DQMStore::readFile(const std::string &filename,
   if (verbose_)
     std::cout << "DQMStore::readFile: reading from file '" << filename << "'\n";
 
-  std::auto_ptr<TFile> f;
+  std::unique_ptr<TFile> f;
 
   try
   {

--- a/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
@@ -198,7 +198,7 @@ private:
   void finishEndFile();
   std::string m_fileName;
   std::string m_logicalFileName;
-  std::auto_ptr<TFile> m_file;
+  std::unique_ptr<TFile> m_file;
   std::vector<boost::shared_ptr<TreeHelperBase> > m_treeHelpers;
 
   unsigned int m_run;
@@ -325,7 +325,7 @@ DQMRootOutputModule::openFile(edm::FileBlock const&)
 {
   //NOTE: I need to also set the I/O performance settings
 
-  m_file = std::auto_ptr<TFile>(new TFile(m_fileName.c_str(),"RECREATE",
+  m_file = std::unique_ptr<TFile>(new TFile(m_fileName.c_str(),"RECREATE",
                                 "1" //This is the file format version number
                                 ));
 

--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -11,6 +11,7 @@
 //
 
 // system include files
+#include <utility>
 #include <vector>
 #include <string>
 #include <map>
@@ -387,7 +388,7 @@ class DQMRootSource : public edm::InputSource
       std::list<unsigned int>::iterator m_nextIndexItr;
       std::list<unsigned int>::iterator m_presentIndexItr;
       std::vector<RunLumiToRange> m_runlumiToRange;
-      std::auto_ptr<TFile> m_file;
+      std::unique_ptr<TFile> m_file;
       std::vector<TTree*> m_trees;
       std::vector<boost::shared_ptr<TreeReaderBase> > m_treeReaders;
       
@@ -794,9 +795,9 @@ DQMRootSource::setupFile(unsigned int iIndex)
   logFileAction("  Initiating request to open file ", m_catalog.fileNames()[iIndex].c_str());
   m_presentlyOpenFileIndex = iIndex;
   m_file.reset();
-  std::auto_ptr<TFile> newFile;
+  std::unique_ptr<TFile> newFile;
   try {
-    newFile = std::auto_ptr<TFile>(TFile::Open(m_catalog.fileNames()[iIndex].c_str()));
+    newFile = std::unique_ptr<TFile>(TFile::Open(m_catalog.fileNames()[iIndex].c_str()));
   } catch(cms::Exception const& e) {
     if(!m_skipBadFiles) {
       edm::Exception ex(edm::errors::FileOpenError,"",e);
@@ -835,7 +836,7 @@ DQMRootSource::setupFile(unsigned int iIndex)
     }
     else {return 0;}
   }
-  m_file = newFile; //passed all tests so now we want to use this file
+  m_file = std::move(newFile); //passed all tests so now we want to use this file
   TTree* parameterSetTree = dynamic_cast<TTree*>(metaDir->Get(kParameterSetTree));
   assert(0!=parameterSetTree);
 

--- a/DataFormats/Candidate/test/testCandidate.cc
+++ b/DataFormats/Candidate/test/testCandidate.cc
@@ -66,7 +66,7 @@ void testCandidate::checkAll() {
 
   reco::Particle::Charge q( 1 );
   int x = 123, y0 = 111, y1 = 222;
-  std::auto_ptr<reco::Candidate> c( new test::DummyCandidate1( p, q, x, y0, y1 ) );
+  std::unique_ptr<reco::Candidate> c( new test::DummyCandidate1( p, q, x, y0, y1 ) );
   CPPUNIT_ASSERT( c->charge() == q );
   CPPUNIT_ASSERT( (c->p4() - p).M2() < 1.e-4 );
   CPPUNIT_ASSERT( c->numberOfDaughters() == 0 );

--- a/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.h
+++ b/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.h
@@ -55,7 +55,7 @@ private:
   bool silent_;
   bool usenominalOrbitMessageTime_;
   int expectedOrbitMessageTime_;
-  std::auto_ptr<HcalElectronicsMap> myEMap;
+  std::unique_ptr<HcalElectronicsMap> myEMap;
   edm::EDGetTokenT<FEDRawDataCollection> tok_input_;
   edm::ParameterSet zdcemap;
 };

--- a/EventFilter/EcalTBRawToDigi/test/stubs/EcalMatacqHist.cc
+++ b/EventFilter/EcalTBRawToDigi/test/stubs/EcalMatacqHist.cc
@@ -17,7 +17,7 @@ EcalMatacqHist::EcalMatacqHist(const edm::ParameterSet& ps):
   hTTrigMin = ps.getUntrackedParameter<double>("hTTrigMin", 0.);
   hTTrigMax = ps.getUntrackedParameter<double>("hTTrigMax", 2000.);
   TDirectory* dsave = gDirectory;
-  outFile = std::auto_ptr<TFile> (new TFile(outFileName.c_str(), "RECREATE"));
+  outFile = std::unique_ptr<TFile> (new TFile(outFileName.c_str(), "RECREATE"));
   if(outFile->IsZombie()){
     std::cout << "EcalMatacqHist: Failed to create file " << outFileName
 	 << " No histogram will be created.\n";

--- a/EventFilter/EcalTBRawToDigi/test/stubs/EcalMatacqHist.h
+++ b/EventFilter/EcalTBRawToDigi/test/stubs/EcalMatacqHist.h
@@ -42,7 +42,7 @@ private:
   int iEvent;
   double hTTrigMin;
   double hTTrigMax;
-  std::auto_ptr<TFile> outFile;
+  std::unique_ptr<TFile> outFile;
   std::vector<TProfile> profiles;
   //profile->MATACQ CH ID map
   std::vector<int> profChId;

--- a/EventFilter/L1TRawToDigi/src/Block.cc
+++ b/EventFilter/L1TRawToDigi/src/Block.cc
@@ -44,7 +44,7 @@ namespace l1t {
    {
       if (end_ - data_ < getHeaderSize()) {
          LogDebug("L1T") << "Reached end of payload";
-         return std::auto_ptr<Block>();
+         return std::unique_ptr<Block>();
       }
 
       if (data_[0] == 0xffffffff) {
@@ -59,7 +59,7 @@ namespace l1t {
          edm::LogError("L1T")
             << "Expecting a block size of " << header.getSize()
             << " but only " << (end_ - data_) << " words remaining";
-         return std::auto_ptr<Block>();
+         return std::unique_ptr<Block>();
       }
 
       LogTrace("L1T") << "Creating block with size " << header.getSize();
@@ -147,7 +147,7 @@ namespace l1t {
   MTF7Payload::getBlock()
   {
     if (end_ - data_ < 2)
-      return std::auto_ptr<Block>(0);
+      return std::unique_ptr<Block>(0);
     
     const uint16_t * data16 = reinterpret_cast<const uint16_t*>(data_);
     const uint16_t * end16 = reinterpret_cast<const uint16_t*>(end_);
@@ -170,7 +170,7 @@ namespace l1t {
     
     if (not valid(pattern)) {
       edm::LogWarning("L1T") << "MTF7 block with unrecognized id 0x" << std::hex << pattern;
-      return std::auto_ptr<Block>(0);
+      return std::unique_ptr<Block>(0);
     }
     
     data_ += (i + 1) * 2;

--- a/EventFilter/SiStripRawToDigi/interface/SiStripDetSetVectorFiller.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripDetSetVectorFiller.h
@@ -22,7 +22,7 @@ namespace sistrip {
     
     void newChannel(const uint32_t key, const uint16_t firstItem = 0);
     void addItem(const T& item);
-    std::auto_ptr< edm::DetSetVector<T> > createDetSetVector();
+    std::unique_ptr< edm::DetSetVector<T> > createDetSetVector();
   private:
     struct ChannelRegistryItem
     {
@@ -95,7 +95,7 @@ namespace sistrip {
       }
       iReg = jReg;
     }
-    return typename std::auto_ptr< edm::DetSetVector<T> >( new edm::DetSetVector<T>(sorted_and_merged, true) );
+    return typename std::unique_ptr< edm::DetSetVector<T> >( new edm::DetSetVector<T>(sorted_and_merged, true) );
   }
   
   typedef DetSetVectorFiller<SiStripRawDigi,false> RawDigiDetSetVectorFiller;

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
@@ -74,7 +74,7 @@ namespace sistrip {
       void findChannels();
       inline uint8_t getCorrectPacketCode() const { return packetCode(legacyUnpacker_); }
       uint16_t calculateFEUnitLength(const uint8_t internalFEUnitNumber) const;
-      std::auto_ptr<FEDFEHeader> feHeader_;
+      std::unique_ptr<FEDFEHeader> feHeader_;
       const uint8_t* payloadPointer_;
       uint16_t payloadLength_;
       uint8_t validChannels_;

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
@@ -407,11 +407,11 @@ namespace sistrip {
     {
     public:
       //factory function: allocates new FEDFEHeader derrivative of appropriate type
-      static std::auto_ptr<FEDFEHeader> newFEHeader(const FEDHeaderType headerType, const uint8_t* headerBuffer);
+      static std::unique_ptr<FEDFEHeader> newFEHeader(const FEDHeaderType headerType, const uint8_t* headerBuffer);
       //used by digi2Raw
-      static std::auto_ptr<FEDFEHeader> newFEHeader(const FEDHeaderType headerType);
+      static std::unique_ptr<FEDFEHeader> newFEHeader(const FEDHeaderType headerType);
       //create a buffer to use with digi2Raw
-      static std::auto_ptr<FEDFEHeader> newFEFakeHeader(const FEDHeaderType headerType);
+      static std::unique_ptr<FEDFEHeader> newFEFakeHeader(const FEDHeaderType headerType);
       virtual ~FEDFEHeader();
       //the length of the header
       virtual size_t lengthInBytes() const = 0;
@@ -1011,39 +1011,39 @@ namespace sistrip {
 
   //FEDFEHeader
 
-  inline std::auto_ptr<FEDFEHeader> FEDFEHeader::newFEHeader(const FEDHeaderType headerType, const uint8_t* headerBuffer)
+  inline std::unique_ptr<FEDFEHeader> FEDFEHeader::newFEHeader(const FEDHeaderType headerType, const uint8_t* headerBuffer)
     {
       switch (headerType) {
       case HEADER_TYPE_FULL_DEBUG:
-        return std::auto_ptr<FEDFEHeader>(new FEDFullDebugHeader(headerBuffer));
+        return std::unique_ptr<FEDFEHeader>(new FEDFullDebugHeader(headerBuffer));
       case HEADER_TYPE_APV_ERROR:
-        return std::auto_ptr<FEDFEHeader>(new FEDAPVErrorHeader(headerBuffer));
+        return std::unique_ptr<FEDFEHeader>(new FEDAPVErrorHeader(headerBuffer));
       default:
-        return std::auto_ptr<FEDFEHeader>();
+        return std::unique_ptr<FEDFEHeader>();
       }
     }
   
-  inline std::auto_ptr<FEDFEHeader> FEDFEHeader::newFEHeader(const FEDHeaderType headerType)
+  inline std::unique_ptr<FEDFEHeader> FEDFEHeader::newFEHeader(const FEDHeaderType headerType)
     {
       switch (headerType) {
       case HEADER_TYPE_FULL_DEBUG:
-        return std::auto_ptr<FEDFEHeader>(new FEDFullDebugHeader());
+        return std::unique_ptr<FEDFEHeader>(new FEDFullDebugHeader());
       case HEADER_TYPE_APV_ERROR:
-        return std::auto_ptr<FEDFEHeader>(new FEDAPVErrorHeader());
+        return std::unique_ptr<FEDFEHeader>(new FEDAPVErrorHeader());
       default:
-        return std::auto_ptr<FEDFEHeader>();
+        return std::unique_ptr<FEDFEHeader>();
       }
     }
   
-  inline std::auto_ptr<FEDFEHeader> FEDFEHeader::newFEFakeHeader(const FEDHeaderType headerType)
+  inline std::unique_ptr<FEDFEHeader> FEDFEHeader::newFEFakeHeader(const FEDHeaderType headerType)
     {
       switch (headerType) {
       case HEADER_TYPE_FULL_DEBUG:
-        return std::auto_ptr<FEDFEHeader>(new FEDFullDebugHeader);
+        return std::unique_ptr<FEDFEHeader>(new FEDFullDebugHeader);
       case HEADER_TYPE_APV_ERROR:
-        return std::auto_ptr<FEDFEHeader>(new FEDAPVErrorHeader);
+        return std::unique_ptr<FEDFEHeader>(new FEDAPVErrorHeader);
       default:
-        return std::auto_ptr<FEDFEHeader>();
+        return std::unique_ptr<FEDFEHeader>();
       }
     }
   

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferGenerator.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferGenerator.h
@@ -163,7 +163,7 @@ namespace sistrip {
       FEDDAQHeader defaultDAQHeader_;
       FEDDAQTrailer defaultDAQTrailer_;
       TrackerSpecialHeader defaultTrackerSpecialHeader_;
-      std::auto_ptr<FEDFEHeader> defaultFEHeader_;
+      std::unique_ptr<FEDFEHeader> defaultFEHeader_;
       std::vector<bool> feUnitsEnabled_;
       std::vector<bool> channelsEnabled_;
     };

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -177,7 +177,7 @@ namespace sistrip {
       }
       
       // construct FEDBuffer
-      std::auto_ptr<sistrip::FEDBuffer> buffer;
+      std::unique_ptr<sistrip::FEDBuffer> buffer;
       try {
         buffer.reset(new sistrip::FEDBuffer(input.data(),input.size()));
         buffer->setLegacyMode(legacy_);

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
@@ -18,7 +18,7 @@ namespace sistrip {
       feHeader_ = FEDFEHeader::newFEHeader(headerType(),getPointerToDataAfterTrackerSpecialHeader());
       payloadPointer_ = getPointerToDataAfterTrackerSpecialHeader()+feHeader_->lengthInBytes();
     } else {
-      feHeader_ = std::auto_ptr<FEDFEHeader>();
+      feHeader_ = std::unique_ptr<FEDFEHeader>();
       payloadPointer_ = getPointerToDataAfterTrackerSpecialHeader();
       if (!allowBadBuffer) {
 	std::ostringstream ss;

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferGenerator.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferGenerator.cc
@@ -450,7 +450,7 @@ namespace sistrip {
   {
     //deal with disabled FE units and channels properly (FE enables, status bits)
     TrackerSpecialHeader tkSpecialHeader(defaultTrackerSpecialHeader_);
-    std::auto_ptr<FEDFEHeader> fedFeHeader(defaultFEHeader_->clone());
+    std::unique_ptr<FEDFEHeader> fedFeHeader(defaultFEHeader_->clone());
     for (uint8_t iFE = 0; iFE < FEUNITS_PER_FED; iFE++) {
       const bool enabled = feUnitsEnabled_[iFE];
       tkSpecialHeader.setFEEnableForFEUnit(iFE,enabled);

--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.h
@@ -72,7 +72,7 @@ class RawEventFileWriterForBU
   jsoncollector::DataPointDefinition eorJsonDef_;
   bool writtenJSDs_=false;
 
-  std::auto_ptr<std::ofstream> ost_;
+  std::unique_ptr<std::ofstream> ost_;
   std::string fileName_;
   std::string destinationDir_;
 

--- a/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
@@ -46,7 +46,7 @@ class RawEventOutputModuleForBU : public edm::one::OutputModule<edm::one::WatchR
   virtual void beginLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
   virtual void endLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
 
-  std::auto_ptr<Consumer> templateConsumer_;
+  std::unique_ptr<Consumer> templateConsumer_;
   std::string label_;
   std::string instance_;
   edm::EDGetTokenT<FEDRawDataCollection> token_;

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -48,7 +48,7 @@ namespace evf {
     virtual void endLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
 
   private:
-    std::auto_ptr<Consumer> c_;
+    std::unique_ptr<Consumer> c_;
     std::string stream_label_;
     boost::filesystem::path openDatFilePath_;
     boost::filesystem::path openDatChecksumFilePath_;

--- a/FastSimulation/ParticleDecay/interface/PythiaDecays.h
+++ b/FastSimulation/ParticleDecay/interface/PythiaDecays.h
@@ -36,7 +36,7 @@ class PythiaDecays
  private:
 
   DaughterParticleList theList;
-  std::auto_ptr<Pythia8::Pythia>   decayer; 
+  std::unique_ptr<Pythia8::Pythia>   decayer; 
   std::unique_ptr<gen::P8RndmEngine> p8RndmEngine;
 };
 #endif

--- a/Fireworks/Core/bin/cmsShow.cc
+++ b/Fireworks/Core/bin/cmsShow.cc
@@ -91,7 +91,7 @@ void run_app(TApplication &app, int argc, char **argv)
    edm::MessageLoggerQ::setMLscribe_ptr(std::shared_ptr<edm::service::AbstractMLscribe>(std::make_shared<SilentMLscribe>()));
    edm::MessageDrop::instance()->messageLoggerScribeIsRunning = edm::MLSCRIBE_RUNNING_INDICATOR;
    //---------------------
-   std::auto_ptr<CmsShowMain> pMain( new CmsShowMain(argc,argv) );
+   std::unique_ptr<CmsShowMain> pMain( new CmsShowMain(argc,argv) );
 
    // Avoid haing root handling various associated to an error and install 
    // back the default ones.

--- a/Fireworks/Core/interface/CmsShowCommon.h
+++ b/Fireworks/Core/interface/CmsShowCommon.h
@@ -103,7 +103,7 @@ protected:
    TGLColorSet         m_lightColorSet;
    TGLColorSet         m_darkColorSet;
  
-   std::auto_ptr<FWViewEnergyScale>  m_energyScale;
+   std::unique_ptr<FWViewEnergyScale>  m_energyScale;
 
 
 private:

--- a/Fireworks/Core/interface/CmsShowMainBase.h
+++ b/Fireworks/Core/interface/CmsShowMainBase.h
@@ -146,18 +146,18 @@ protected:
 private:
    // The base class is responsible for the destruction of fwlite / FF
    // agnostic managers.
-   std::auto_ptr<FWModelChangeManager>   m_changeManager;
-   std::auto_ptr<FWColorManager>         m_colorManager;
-   std::auto_ptr<FWConfigurationManager> m_configurationManager;
-   std::auto_ptr<FWEventItemsManager>    m_eiManager;
-   std::auto_ptr<FWGUIManager>           m_guiManager;
-   std::auto_ptr<FWSelectionManager>     m_selectionManager;
-   std::auto_ptr<CmsShowTaskExecutor>    m_startupTasks;
-   std::auto_ptr<FWViewManagerManager>   m_viewManager;
+   std::unique_ptr<FWModelChangeManager>   m_changeManager;
+   std::unique_ptr<FWColorManager>         m_colorManager;
+   std::unique_ptr<FWConfigurationManager> m_configurationManager;
+   std::unique_ptr<FWEventItemsManager>    m_eiManager;
+   std::unique_ptr<FWGUIManager>           m_guiManager;
+   std::unique_ptr<FWSelectionManager>     m_selectionManager;
+   std::unique_ptr<CmsShowTaskExecutor>    m_startupTasks;
+   std::unique_ptr<FWViewManagerManager>   m_viewManager;
 
   
 
-   std::auto_ptr<SignalTimer>                 m_autoLoadTimer;
+   std::unique_ptr<SignalTimer>                 m_autoLoadTimer;
    
    // These are actually set by the concrete implementation via the setup 
    // method.

--- a/Fireworks/Core/interface/FWEveView.h
+++ b/Fireworks/Core/interface/FWEveView.h
@@ -146,8 +146,8 @@ private:
    FWBoolParameter   m_useGlobalEnergyScale;
 
    std::shared_ptr<FWViewContextMenuHandlerGL>   m_viewContextMenu;
-   std::auto_ptr<FWViewContext> m_viewContext;
-   std::auto_ptr<FWViewEnergyScale> m_localEnergyScale;
+   std::unique_ptr<FWViewContext> m_viewContext;
+   std::unique_ptr<FWViewEnergyScale> m_localEnergyScale;
 
    mutable FWViewEnergyScaleEditor* m_viewEnergyScaleEditor;
 };

--- a/Fireworks/Core/interface/FWGUIManager.h
+++ b/Fireworks/Core/interface/FWGUIManager.h
@@ -280,7 +280,7 @@ private:
 
    sigc::connection   m_modelChangeConn;
 
-   std::auto_ptr<CmsShowTaskExecutor> m_tasks;
+   std::unique_ptr<CmsShowTaskExecutor> m_tasks;
     std::vector<FWViewBase*> m_regionViews;
    int m_WMOffsetX, m_WMOffsetY, m_WMDecorH;
 };

--- a/Fireworks/Core/interface/FWXMLConfigParser.h
+++ b/Fireworks/Core/interface/FWXMLConfigParser.h
@@ -186,7 +186,7 @@ debug_config_state_machine(const char *where, const std::string &tag, int state)
 private:
    std::vector<std::pair<std::string, FWConfiguration *> > m_configs;
    enum STATES                                             m_state;
-   std::auto_ptr<FWConfiguration>                          m_first;
+   std::unique_ptr<FWConfiguration>                          m_first;
    //   unsigned int                                            m_currentConfigVersion;
    std::string                                             m_currentConfigName;
 };

--- a/Fireworks/Core/src/CmsShowMain.cc
+++ b/Fireworks/Core/src/CmsShowMain.cc
@@ -559,7 +559,7 @@ void
 CmsShowMain::openDataViaURL()
 {
    if (m_searchFiles.get() == 0) {
-      m_searchFiles = std::auto_ptr<CmsShowSearchFiles>(new CmsShowSearchFiles("",
+      m_searchFiles = std::unique_ptr<CmsShowSearchFiles>(new CmsShowSearchFiles("",
                                                                                "Open Remote Data Files",
                                                                                guiManager()->getMainFrame(),
                                                                                500, 400));
@@ -738,7 +738,7 @@ CmsShowMain::setLoadedAnyInputFileAfterStartup()
 void
 CmsShowMain::setupSocket(unsigned int iSocket)
 {
-   m_monitor = std::auto_ptr<TMonitor>(new TMonitor);
+   m_monitor = std::unique_ptr<TMonitor>(new TMonitor);
    TServerSocket* server = new TServerSocket(iSocket,kTRUE);
    if (server->GetErrorCode())
    {

--- a/Fireworks/Core/src/CmsShowMain.h
+++ b/Fireworks/Core/src/CmsShowMain.h
@@ -112,25 +112,25 @@ private:
    void checkLiveMode();
 
    // ---------- member data --------------------------------
-   std::auto_ptr<CmsShowNavigator>           m_navigator;
-   std::auto_ptr<FWLiteJobMetadataManager>   m_metadataManager;
-   std::auto_ptr<fireworks::Context>         m_context;
+   std::unique_ptr<CmsShowNavigator>           m_navigator;
+   std::unique_ptr<FWLiteJobMetadataManager>   m_metadataManager;
+   std::unique_ptr<fireworks::Context>         m_context;
 
    std::vector<std::string> m_inputFiles;
    bool                     m_loadedAnyInputFile;
    const TFile             *m_openFile;
 
-   std::auto_ptr<CmsShowSearchFiles>  m_searchFiles;
+   std::unique_ptr<CmsShowSearchFiles>  m_searchFiles;
 
    // live options
    bool                         m_live;
-   std::auto_ptr<SignalTimer>   m_liveTimer;
+   std::unique_ptr<SignalTimer>   m_liveTimer;
    int                          m_liveTimeout;
    UInt_t                       m_lastXEventSerial;
 
    bool                         m_noVersionCheck;
 
-   std::auto_ptr<TMonitor> m_monitor;
+   std::unique_ptr<TMonitor> m_monitor;
 };
 
 #endif

--- a/Fireworks/Core/src/FWConfigurationManager.cc
+++ b/Fireworks/Core/src/FWConfigurationManager.cc
@@ -159,7 +159,7 @@ FWConfigurationManager::readFromOldFile(const std::string& iName) const
       message += iName;
       throw std::runtime_error(message.c_str());
    }
-   std::auto_ptr<FWConfiguration> config( reinterpret_cast<FWConfiguration*>(lConfig) );
+   std::unique_ptr<FWConfiguration> config( reinterpret_cast<FWConfiguration*>(lConfig) );
 
    setFrom( *config);
 }

--- a/Fireworks/Core/src/FWFileEntry.cc
+++ b/Fireworks/Core/src/FWFileEntry.cc
@@ -322,7 +322,7 @@ void FWFileEntry::runFilter(Filter* filter, const FWEventItemsManager* eiMng)
 
    {
       TObjArray* branches = m_eventTree->GetListOfBranches();
-      std::auto_ptr<TIterator> pIt( branches->MakeIterator());
+      std::unique_ptr<TIterator> pIt( branches->MakeIterator());
       while (TObject* branchObj = pIt->Next())
       {
          TBranch* b = dynamic_cast<TBranch*> (branchObj);

--- a/Fireworks/Core/src/FWGUIValidatingTextEntry.cc
+++ b/Fireworks/Core/src/FWGUIValidatingTextEntry.cc
@@ -195,7 +195,7 @@ FWGUIValidatingTextEntry::showOptions() {
                                       0, GetHeight(), ax, ay, wdummy);
 
       //Wait to change focus for when the popup has already openned
-      std::auto_ptr<TTimer> timer( new ChangeFocusTimer(m_list->GetContainer()) );
+      std::unique_ptr<TTimer> timer( new ChangeFocusTimer(m_list->GetContainer()) );
       timer->TurnOn();
       //NOTE: this call has its own internal GUI event loop and will not return
       // until the popup has been shut down

--- a/Fireworks/Core/src/FWJobMetadataManager.cc
+++ b/Fireworks/Core/src/FWJobMetadataManager.cc
@@ -22,7 +22,7 @@ FWJobMetadataManager::~FWJobMetadataManager()
 void
 FWJobMetadataManager::update(FWJobMetadataUpdateRequest *request)
 {
-   std::auto_ptr<FWJobMetadataUpdateRequest> ptr(request);
+   std::unique_ptr<FWJobMetadataUpdateRequest> ptr(request);
    if (doUpdate(request))
       metadataChanged_();
 }

--- a/Fireworks/Core/test/unittest_fwconfiguration.cc
+++ b/Fireworks/Core/test/unittest_fwconfiguration.cc
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE( fwconfiguration )
    FWConfiguration::streamTo(std::cout, topConfig, "top");
 
    //Test manager
-   std::auto_ptr<Conf> pConf(new Conf() );
+   std::unique_ptr<Conf> pConf(new Conf() );
    
    FWConfigurationManager confMgr;
    confMgr.add("first", pConf.get() );

--- a/Fireworks/FWInterface/interface/FWFFLooper.h
+++ b/Fireworks/FWInterface/interface/FWFFLooper.h
@@ -86,9 +86,9 @@ private:
    void loadDefaultGeometryFile( void );
 
    edm::Service<FWFFHelper>            m_appHelper;
-   std::auto_ptr<FWFFNavigator>        m_navigator;
-   std::auto_ptr<FWFFMetadataManager>  m_metadataManager;
-   std::auto_ptr<fireworks::Context>   m_context;
+   std::unique_ptr<FWFFNavigator>        m_navigator;
+   std::unique_ptr<FWFFMetadataManager>  m_metadataManager;
+   std::unique_ptr<fireworks::Context>   m_context;
 
    TEveManager  *m_EveManager;
    TRint        *m_Rint;

--- a/Fireworks/FWInterface/interface/FWFFService.h
+++ b/Fireworks/FWInterface/interface/FWFFService.h
@@ -66,9 +66,9 @@ private:
 
    // ---------- member data --------------------------------
    
-   std::auto_ptr<FWFFNavigator>        m_navigator;
-   std::auto_ptr<FWFFMetadataManager>  m_metadataManager;
-   std::auto_ptr<fireworks::Context>   m_context;
+   std::unique_ptr<FWFFNavigator>        m_navigator;
+   std::unique_ptr<FWFFMetadataManager>  m_metadataManager;
+   std::unique_ptr<fireworks::Context>   m_context;
 
    FWFFHelper    m_appHelper;
    TEveManager  *m_EveManager;

--- a/Fireworks/Geometry/src/TGeoFromDddService.cc
+++ b/Fireworks/Geometry/src/TGeoFromDddService.cc
@@ -437,13 +437,13 @@ TGeoFromDddService::createShape(const std::string& iName,
 	       displacement = pt.halfZ() + delta;
 	       startPhi = 90. - openingAngle/deg/2.;
 	    }
-	    std::auto_ptr<TGeoShape> trap( new TGeoTrd2(pt.name().name().c_str(),
+	    std::unique_ptr<TGeoShape> trap( new TGeoTrd2(pt.name().name().c_str(),
 							pt.x1()/cm,
 							pt.x2()/cm,
 							pt.y1()/cm,
 							pt.y2()/cm,
 							pt.halfZ()/cm) );
-	    std::auto_ptr<TGeoShape> tubs( new TGeoTubeSeg(pt.name().name().c_str(),
+	    std::unique_ptr<TGeoShape> tubs( new TGeoTubeSeg(pt.name().name().c_str(),
 							   0.,
 							   r/cm,
 							   h/cm,
@@ -468,9 +468,9 @@ TGeoFromDddService::createShape(const std::string& iName,
 	       throw cms::Exception("GeomConvert") <<"conversion to DDBooleanSolid failed";
 	    }
 	    
-	    std::auto_ptr<TGeoShape> left( createShape(boolSolid.solidA().name().fullname(),
+	    std::unique_ptr<TGeoShape> left( createShape(boolSolid.solidA().name().fullname(),
 						       boolSolid.solidA()) );
-	    std::auto_ptr<TGeoShape> right( createShape(boolSolid.solidB().name().fullname(),
+	    std::unique_ptr<TGeoShape> right( createShape(boolSolid.solidB().name().fullname(),
 							boolSolid.solidB()));
 	    if( 0 != left.get() &&
 		0 != right.get() ) {
@@ -491,9 +491,9 @@ TGeoFromDddService::createShape(const std::string& iName,
 	       throw cms::Exception("GeomConvert") <<"conversion to DDBooleanSolid failed";
 	    }
 	    
-	    std::auto_ptr<TGeoShape> left( createShape(boolSolid.solidA().name().fullname(),
+	    std::unique_ptr<TGeoShape> left( createShape(boolSolid.solidA().name().fullname(),
 						       boolSolid.solidA()) );
-	    std::auto_ptr<TGeoShape> right( createShape(boolSolid.solidB().name().fullname(),
+	    std::unique_ptr<TGeoShape> right( createShape(boolSolid.solidB().name().fullname(),
 							boolSolid.solidB()));
 	    //DEBUGGING
 	    //break;
@@ -516,9 +516,9 @@ TGeoFromDddService::createShape(const std::string& iName,
 	       throw cms::Exception("GeomConvert") <<"conversion to DDBooleanSolid failed";
 	    }
 	    
-	    std::auto_ptr<TGeoShape> left( createShape(boolSolid.solidA().name().fullname(),
+	    std::unique_ptr<TGeoShape> left( createShape(boolSolid.solidA().name().fullname(),
 						       boolSolid.solidA()) );
-	    std::auto_ptr<TGeoShape> right( createShape(boolSolid.solidB().name().fullname(),
+	    std::unique_ptr<TGeoShape> right( createShape(boolSolid.solidB().name().fullname(),
 							boolSolid.solidB()));
 	    if( 0 != left.get() &&
 		0 != right.get() ) {

--- a/Fireworks/Geometry/src/TGeoMgrFromDdd.cc
+++ b/Fireworks/Geometry/src/TGeoMgrFromDdd.cc
@@ -419,14 +419,14 @@ TGeoMgrFromDdd::createShape(const std::string& iName,
 	      throw cms::Exception( "Check parameters of the PseudoTrap! name=" + pt.name().name());   
 	    }
 
-	    std::auto_ptr<TGeoShape> trap( new TGeoTrd2( pt.name().name().c_str(),
+	    std::unique_ptr<TGeoShape> trap( new TGeoTrd2( pt.name().name().c_str(),
 							 pt.x1()/cm,
 							 pt.x2()/cm,
 							 pt.y1()/cm,
 							 pt.y2()/cm,
 							 pt.halfZ()/cm ));
 	      
-	    std::auto_ptr<TGeoShape> tubs( new TGeoTubeSeg( pt.name().name().c_str(),
+	    std::unique_ptr<TGeoShape> tubs( new TGeoTubeSeg( pt.name().name().c_str(),
 							    0.,
 							    std::abs(r)/cm, // radius cannot be negative!!!
 							    h/cm,
@@ -446,7 +446,7 @@ TGeoMgrFromDdd::createShape(const std::string& iName,
 	    }
 	    else
 	    {
- 	      std::auto_ptr<TGeoShape> box( new TGeoBBox( 1.1*x/cm, 1.1*h/cm, sqrt(r*r-x*x)/cm ));
+ 	      std::unique_ptr<TGeoShape> box( new TGeoBBox( 1.1*x/cm, 1.1*h/cm, sqrt(r*r-x*x)/cm ));
 	      
 	      TGeoSubtraction* sub = new TGeoSubtraction( tubs.release(),
 							  box.release(),
@@ -456,7 +456,7 @@ TGeoMgrFromDdd::createShape(const std::string& iName,
 											  0.,
 											  0. )));
 	      
-	      std::auto_ptr<TGeoShape> tubicCap( new TGeoCompositeShape( iName.c_str(), sub ));
+	      std::unique_ptr<TGeoShape> tubicCap( new TGeoCompositeShape( iName.c_str(), sub ));
 						
 	      TGeoUnion* boolS = new TGeoUnion( trap.release(),
 						tubicCap.release(),
@@ -490,9 +490,9 @@ TGeoMgrFromDdd::createShape(const std::string& iName,
 	       throw cms::Exception("GeomConvert") <<"conversion to DDBooleanSolid failed";
 	    }
 	    
-	    std::auto_ptr<TGeoShape> left( createShape(boolSolid.solidA().name().fullname(),
+	    std::unique_ptr<TGeoShape> left( createShape(boolSolid.solidA().name().fullname(),
 						       boolSolid.solidA()) );
-	    std::auto_ptr<TGeoShape> right( createShape(boolSolid.solidB().name().fullname(),
+	    std::unique_ptr<TGeoShape> right( createShape(boolSolid.solidB().name().fullname(),
 							boolSolid.solidB()));
 	    if( 0 != left.get() &&
 		0 != right.get() ) {
@@ -545,7 +545,7 @@ TGeoMgrFromDdd::createShape(const std::string& iName,
 	    double R( cutAtDelta );
 	    
 	    // Note: startPhi is always 0.0
-	    std::auto_ptr<TGeoShape> tubs( new TGeoTubeSeg( name.c_str(), rIn/cm, rOut/cm, zHalf/cm, startPhi, deltaPhi/deg ));
+	    std::unique_ptr<TGeoShape> tubs( new TGeoTubeSeg( name.c_str(), rIn/cm, rOut/cm, zHalf/cm, startPhi, deltaPhi/deg ));
 
 	    double boxX( rOut ), boxY( rOut ); // exaggerate dimensions - does not matter, it's subtracted!
 	    
@@ -573,7 +573,7 @@ TGeoMgrFromDdd::createShape(const std::string& iName,
 	    {
 	      xBox = - ( boxX / sin( fabs( alpha )) - r );
 	    }
-	    std::auto_ptr<TGeoShape> box( new TGeoBBox( name.c_str(), boxX/cm, boxZ/cm, boxY/cm ));
+	    std::unique_ptr<TGeoShape> box( new TGeoBBox( name.c_str(), boxX/cm, boxZ/cm, boxY/cm ));
 
 	    TGeoTranslation trans( xBox/cm, 0., 0.);
 
@@ -592,9 +592,9 @@ TGeoMgrFromDdd::createShape(const std::string& iName,
 	       throw cms::Exception("GeomConvert") <<"conversion to DDBooleanSolid failed";
 	    }
 	    
-	    std::auto_ptr<TGeoShape> left( createShape(boolSolid.solidA().name().fullname(),
+	    std::unique_ptr<TGeoShape> left( createShape(boolSolid.solidA().name().fullname(),
 						       boolSolid.solidA()) );
-	    std::auto_ptr<TGeoShape> right( createShape(boolSolid.solidB().name().fullname(),
+	    std::unique_ptr<TGeoShape> right( createShape(boolSolid.solidB().name().fullname(),
 							boolSolid.solidB()));
 	    //DEBUGGING
 	    //break;
@@ -617,9 +617,9 @@ TGeoMgrFromDdd::createShape(const std::string& iName,
 	       throw cms::Exception("GeomConvert") <<"conversion to DDBooleanSolid failed";
 	    }
 	    
-	    std::auto_ptr<TGeoShape> left( createShape(boolSolid.solidA().name().fullname(),
+	    std::unique_ptr<TGeoShape> left( createShape(boolSolid.solidA().name().fullname(),
 						       boolSolid.solidA()) );
-	    std::auto_ptr<TGeoShape> right( createShape(boolSolid.solidB().name().fullname(),
+	    std::unique_ptr<TGeoShape> right( createShape(boolSolid.solidB().name().fullname(),
 							boolSolid.solidB()));
 	    if( 0 != left.get() &&
 		0 != right.get() ) {

--- a/Fireworks/Muons/src/FWMuonBuilder.cc
+++ b/Fireworks/Muons/src/FWMuonBuilder.cc
@@ -73,7 +73,7 @@ void addMatchInformation( const reco::Muon* muon,
   const std::vector<reco::MuonChamberMatch>& matches = muon->matches();
    
   //need to use auto_ptr since the segmentSet may not be passed to muonList
-  std::auto_ptr<TEveStraightLineSet> segmentSet( new TEveStraightLineSet );
+  std::unique_ptr<TEveStraightLineSet> segmentSet( new TEveStraightLineSet );
   // FIXME: This should be set elsewhere.
   segmentSet->SetLineWidth( 4 );
 

--- a/GeneratorInterface/AMPTInterface/plugins/plugin.cc
+++ b/GeneratorInterface/AMPTInterface/plugins/plugin.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "GeneratorInterface/AMPTInterface/interface/AMPTGeneratorFilter.h"
 

--- a/GeneratorInterface/AMPTInterface/src/AMPTGeneratorFilter.cc
+++ b/GeneratorInterface/AMPTInterface/src/AMPTGeneratorFilter.cc
@@ -1,4 +1,6 @@
 
 
+#include <utility>
+
 #include "GeneratorInterface/AMPTInterface/interface/AMPTHadronizer.h"
 

--- a/GeneratorInterface/AMPTInterface/src/AMPTHadronizer.cc
+++ b/GeneratorInterface/AMPTInterface/src/AMPTHadronizer.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <cmath>
+#include <utility>
 
 #include "boost/lexical_cast.hpp"
 

--- a/GeneratorInterface/CascadeInterface/plugins/Cascade2GeneratorFilter.cc
+++ b/GeneratorInterface/CascadeInterface/plugins/Cascade2GeneratorFilter.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "GeneratorInterface/Core/interface/GeneratorFilter.h"
 #include "GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h"
 #include "Cascade2Hadronizer.h"

--- a/GeneratorInterface/CascadeInterface/plugins/Cascade2Hadronizer.cc
+++ b/GeneratorInterface/CascadeInterface/plugins/Cascade2Hadronizer.cc
@@ -1,5 +1,7 @@
 #include "GeneratorInterface/CascadeInterface/plugins/Cascade2Hadronizer.h"
 
+#include <utility>
+
 #include "HepMC/GenEvent.h" 
 #include "HepMC/PdfInfo.h"
 #include "HepMC/PythiaWrapper6_4.h"  

--- a/GeneratorInterface/Core/interface/BaseHadronizer.h
+++ b/GeneratorInterface/Core/interface/BaseHadronizer.h
@@ -83,8 +83,8 @@ namespace gen {
 
   protected:
     GenRunInfoProduct& runInfo() { return genRunInfo_; }
-    std::auto_ptr<HepMC::GenEvent>& event() { return genEvent_; }
-    std::auto_ptr<GenEventInfoProduct>& eventInfo() { return genEventInfo_; }
+    std::unique_ptr<HepMC::GenEvent>& event() { return genEvent_; }
+    std::unique_ptr<GenEventInfoProduct>& eventInfo() { return genEventInfo_; }
 
     lhef::LHEEvent* lheEvent() { return lheEvent_.get(); }
     lhef::LHERunInfo *lheRunInfo() { return lheRunInfo_.get(); }
@@ -98,11 +98,11 @@ namespace gen {
     virtual std::vector<std::string> const& doSharedResources() const { return theSharedResources; }
 
     GenRunInfoProduct                   genRunInfo_;
-    std::auto_ptr<HepMC::GenEvent>      genEvent_;
-    std::auto_ptr<GenEventInfoProduct>  genEventInfo_;
+    std::unique_ptr<HepMC::GenEvent>      genEvent_;
+    std::unique_ptr<GenEventInfoProduct>  genEventInfo_;
 
     boost::shared_ptr<lhef::LHERunInfo> lheRunInfo_;
-    std::auto_ptr<lhef::LHEEvent>       lheEvent_;
+    std::unique_ptr<lhef::LHEEvent>       lheEvent_;
 
     edm::Event                          *edmEvent_;
 

--- a/GeneratorInterface/Core/src/BaseHadronizer.cc
+++ b/GeneratorInterface/Core/src/BaseHadronizer.cc
@@ -3,6 +3,7 @@
 #include "FWCore/ParameterSet/interface/Registry.h"
 
 #include <random>
+#include <utility>
 #include <sys/wait.h>
 
 namespace gen {

--- a/GeneratorInterface/ExhumeInterface/plugins/ExhumeGeneratorFilter.cc
+++ b/GeneratorInterface/ExhumeInterface/plugins/ExhumeGeneratorFilter.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "GeneratorInterface/Core/interface/GeneratorFilter.h"
 #include "GeneratorInterface/ExhumeInterface/interface/ExhumeHadronizer.h"
 #include "GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h"

--- a/GeneratorInterface/ExhumeInterface/src/ExhumeHadronizer.cc
+++ b/GeneratorInterface/ExhumeInterface/src/ExhumeHadronizer.cc
@@ -23,6 +23,7 @@
 
 #include <string>
 #include <sstream>
+#include <utility>
 
 HepMC::IO_HEPEVT conv;
 

--- a/GeneratorInterface/ExternalDecays/src/ExternalDecayDriver.cc
+++ b/GeneratorInterface/ExternalDecays/src/ExternalDecayDriver.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h"
 
 #include "GeneratorInterface/Core/interface/FortranInstance.h"

--- a/GeneratorInterface/Herwig6Interface/plugins/Herwig6Hadronizer.cc
+++ b/GeneratorInterface/Herwig6Interface/plugins/Herwig6Hadronizer.cc
@@ -1,6 +1,7 @@
 #include <cstring>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 #include <memory>
 #include <map>

--- a/GeneratorInterface/Herwig6Interface/src/fastjetfortran_madfks.cc
+++ b/GeneratorInterface/Herwig6Interface/src/fastjetfortran_madfks.cc
@@ -40,9 +40,9 @@ FASTJET_BEGIN_NAMESPACE      // defined in fastjet/internal/base.hh
 /// structures and means to transfer fortran <-> C++
 namespace fwrapper {
   vector<PseudoJet> input_particles, jets;
-  auto_ptr<JetDefinition::Plugin> plugin;
+  unique_ptr<JetDefinition::Plugin> plugin;
   JetDefinition jet_def;
-  auto_ptr<ClusterSequence> cs;
+  unique_ptr<ClusterSequence> cs;
 
   /// helper routine to transfer fortran input particles into 
   void transfer_input_particles(const double * p, const int & npart) {

--- a/GeneratorInterface/HijingInterface/plugins/plugin.cc
+++ b/GeneratorInterface/HijingInterface/plugins/plugin.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "GeneratorInterface/HijingInterface/interface/HijingGeneratorFilter.h"
 

--- a/GeneratorInterface/HijingInterface/src/HijingGeneratorFilter.cc
+++ b/GeneratorInterface/HijingInterface/src/HijingGeneratorFilter.cc
@@ -1,4 +1,6 @@
 
 
+#include <utility>
+
 #include "GeneratorInterface/HijingInterface/interface/HijingHadronizer.h"
 

--- a/GeneratorInterface/HijingInterface/src/HijingHadronizer.cc
+++ b/GeneratorInterface/HijingInterface/src/HijingHadronizer.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <cmath>
+#include <utility>
 
 #include "boost/lexical_cast.hpp"
 

--- a/GeneratorInterface/Hydjet2Interface/plugins/Hydjet2GeneratorFilter.cc
+++ b/GeneratorInterface/Hydjet2Interface/plugins/Hydjet2GeneratorFilter.cc
@@ -1,6 +1,8 @@
 //
 //
 
+#include <utility>
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "GeneratorInterface/Hydjet2Interface/interface/Hydjet2GeneratorFilter.h"
 

--- a/GeneratorInterface/Hydjet2Interface/src/Hydjet2Hadronizer.cc
+++ b/GeneratorInterface/Hydjet2Interface/src/Hydjet2Hadronizer.cc
@@ -52,6 +52,7 @@
 #include <iostream> 
 #include <fstream>
 #include <cmath>
+#include <utility>
 #include "boost/lexical_cast.hpp"
 
 #include "FWCore/Concurrency/interface/SharedResourceNames.h"

--- a/GeneratorInterface/HydjetInterface/plugins/plugin.cc
+++ b/GeneratorInterface/HydjetInterface/plugins/plugin.cc
@@ -1,6 +1,8 @@
 //
 //
 
+#include <utility>
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "GeneratorInterface/HydjetInterface/interface/HydjetGeneratorFilter.h"
 using gen::HydjetGeneratorFilter;

--- a/GeneratorInterface/HydjetInterface/src/HydjetGeneratorFilter.cc
+++ b/GeneratorInterface/HydjetInterface/src/HydjetGeneratorFilter.cc
@@ -1,4 +1,6 @@
 
 
+#include <utility>
+
 #include "GeneratorInterface/HydjetInterface/interface/HydjetHadronizer.h"
 

--- a/GeneratorInterface/HydjetInterface/src/HydjetHadronizer.cc
+++ b/GeneratorInterface/HydjetInterface/src/HydjetHadronizer.cc
@@ -12,6 +12,7 @@
 
 #include <iostream>
 #include <cmath>
+#include <utility>
 
 #include "boost/lexical_cast.hpp"
 

--- a/GeneratorInterface/LHEInterface/interface/LHEEvent.h
+++ b/GeneratorInterface/LHEInterface/interface/LHEEvent.h
@@ -47,7 +47,7 @@ class LHEEvent {
 	const int getReadAttempts() { return readAttemptCounter; }
 
 	void addWeight(const WGT& wgt) { weights_.push_back(wgt); }
-	void setPDF(std::auto_ptr<PDF> pdf) { this->pdf = pdf; }
+	void setPDF(std::unique_ptr<PDF> pdf) { this->pdf = std::move(pdf); }
 
 	double originalXWGTUP() const { return originalXWGTUP_; }
 	const std::vector<WGT>& weights() const { return weights_; }
@@ -74,7 +74,7 @@ class LHEEvent {
 	void fillPdfInfo(HepMC::PdfInfo *info) const;
 	void fillEventInfo(HepMC::GenEvent *hepmc) const;
 
-	std::auto_ptr<HepMC::GenEvent> asHepMCEvent() const;
+	std::unique_ptr<HepMC::GenEvent> asHepMCEvent() const;
 
 	static const HepMC::GenVertex *findSignalVertex(
 			const HepMC::GenEvent *event, bool status3 = true);
@@ -88,7 +88,7 @@ class LHEEvent {
 	const boost::shared_ptr<LHERunInfo>	runInfo;
 
 	HEPEUP					hepeup;
-	std::auto_ptr<PDF>			pdf;
+	std::unique_ptr<PDF>			pdf;
 	std::vector<WGT>	          	weights_;
 	std::vector<std::string>		comments;
 	bool					counted;

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -20,6 +20,7 @@ Implementation:
 // system include files
 #include <cstdio>
 #include <memory>
+#include <utility>
 #include <vector>
 #include <string>
 #include <fstream>
@@ -190,7 +191,7 @@ ExternalLHEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   iEvent.put(std::move(product));
 
   if (runInfo) {
-    std::auto_ptr<LHERunInfoProduct> product(new LHERunInfoProduct(*runInfo->getHEPRUP()));
+    std::unique_ptr<LHERunInfoProduct> product(new LHERunInfoProduct(*runInfo->getHEPRUP()));
     std::for_each(runInfo->getHeaders().begin(),
                   runInfo->getHeaders().end(),
                   boost::bind(&LHERunInfoProduct::addHeader,
@@ -204,7 +205,7 @@ ExternalLHEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       runInfoProducts.front().mergeProduct(*product);
       if (!wasMerged) {
         runInfoProducts.pop_front();
-        runInfoProducts.push_front(product);
+        runInfoProducts.push_front(std::move(product));
         wasMerged = true;
       }
     }

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.cc
@@ -6,6 +6,7 @@
 
 #include <boost/bind.hpp>
 #include <boost/ptr_container/ptr_deque.hpp>
+#include <utility>
 
 #include "FWCore/Framework/interface/InputSourceMacros.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -80,7 +81,7 @@ void LHESource::nextEvent()
 		runInfoLast = runInfoThis;
 	}
 	if (runInfo) {
-		std::auto_ptr<LHERunInfoProduct> product(
+		std::unique_ptr<LHERunInfoProduct> product(
 				new LHERunInfoProduct(*runInfo->getHEPRUP()));
 		std::for_each(runInfo->getHeaders().begin(),
 		              runInfo->getHeaders().end(),
@@ -96,7 +97,7 @@ void LHESource::nextEvent()
 		  if (runInfoProducts.front().mergeProduct(*product)) {
 			if (!wasMerged) {
 				runInfoProducts.pop_front();
-				runInfoProducts.push_front(product);
+				runInfoProducts.push_front(std::move(product));
 				wasMerged = true;
 			}
 		  } else {

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.h
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.h
@@ -46,7 +46,7 @@ class LHERunInfoProduct;
 
 	void nextEvent();
 
-	std::auto_ptr<lhef::LHEReader>		reader;
+	std::unique_ptr<lhef::LHEReader>		reader;
 
 	boost::shared_ptr<lhef::LHERunInfo>	runInfoLast;
 	boost::shared_ptr<lhef::LHERunInfo>	runInfo;

--- a/GeneratorInterface/LHEInterface/src/LHEEvent.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEEvent.cc
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <cstring>
 #include <string>
+#include <utility>
 #include <vector>
 #include <memory>
 #include <cmath>
@@ -254,9 +255,9 @@ void LHEEvent::fillEventInfo(HepMC::GenEvent *event) const
 	event->set_alphaQCD(hepeup.AQCDUP);
 }
 
-std::auto_ptr<HepMC::GenEvent> LHEEvent::asHepMCEvent() const
+std::unique_ptr<HepMC::GenEvent> LHEEvent::asHepMCEvent() const
 {
-	std::auto_ptr<HepMC::GenEvent> hepmc(new HepMC::GenEvent);
+	std::unique_ptr<HepMC::GenEvent> hepmc(new HepMC::GenEvent);
 
 	hepmc->set_signal_process_id(hepeup.IDPRUP);
 	hepmc->set_event_scale(hepeup.SCALUP);
@@ -270,7 +271,7 @@ std::auto_ptr<HepMC::GenEvent> LHEEvent::asHepMCEvent() const
 		edm::LogWarning("Generator|LHEInterface")
 			<< "Les Houches Event does not contain any partons. "
 			<< "Not much to convert." ;
-		return hepmc;
+		return std::move(hepmc);
 	}
 
 	// stores (pointers to) converted particles
@@ -381,7 +382,7 @@ std::auto_ptr<HepMC::GenEvent> LHEEvent::asHepMCEvent() const
 			const_cast<HepMC::GenVertex*>(
 				findSignalVertex(hepmc.get(), false)));
 
-	return hepmc;
+	return std::move(hepmc);
 }
 
 HepMC::GenParticle *LHEEvent::makeHepMCParticle(unsigned int i) const

--- a/GeneratorInterface/LHEInterface/src/LHEReader.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEReader.cc
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <cstring>
 #include <string>
+#include <utility>
 #include <vector>
 #include <cstdio>
 
@@ -70,7 +71,7 @@ class LHEReader::FileSource : public LHEReader::Source {
 	{ return new XMLDocument(fileStream, handler); }
 
     private:
-	std::auto_ptr<StorageWrap>	fileStream;
+	std::unique_ptr<StorageWrap>	fileStream;
 };
 
 class LHEReader::StringSource : public LHEReader::Source {
@@ -92,7 +93,7 @@ class LHEReader::StringSource : public LHEReader::Source {
 	{ return new XMLDocument(fileStream, handler); }
 
     private:
-  std::auto_ptr<std::istream>	fileStream;
+  std::unique_ptr<std::istream>	fileStream;
 };
 
 class LHEReader::XMLHandler : public XMLDocument::Handler {

--- a/GeneratorInterface/LHEInterface/src/LHERunInfo.cc
+++ b/GeneratorInterface/LHEInterface/src/LHERunInfo.cc
@@ -3,6 +3,7 @@
 #include <iomanip>
 #include <string>
 #include <cctype>
+#include <utility>
 #include <vector>
 #include <memory>
 #include <cmath>
@@ -507,9 +508,9 @@ static std::vector<std::string> domToLines(const DOMNode *node)
 	DOMImplementation *impl =
 		DOMImplementationRegistry::getDOMImplementation(
 							XMLUniStr("Core"));
-	std::auto_ptr<DOMLSSerializer> writer(((DOMImplementationLS*)(impl))->createLSSerializer());
+	std::unique_ptr<DOMLSSerializer> writer(((DOMImplementationLS*)(impl))->createLSSerializer());
 
-	std::auto_ptr<DOMLSOutput> outputDesc(((DOMImplementationLS*)impl)->createLSOutput());
+	std::unique_ptr<DOMLSOutput> outputDesc(((DOMImplementationLS*)impl)->createLSOutput());
  	assert(outputDesc.get());
 	outputDesc->setEncoding(XMLUniStr("UTF-8"));
 	
@@ -612,7 +613,7 @@ const DOMNode *LHERunInfo::Header::getXMLNode() const
 		parser.setCreateEntityReferenceNodes(false);
 
 		try {
-			std::auto_ptr<CBInputStream::Reader> reader(
+			std::unique_ptr<CBInputStream::Reader> reader(
 						new HeaderReader(this));
 			CBInputSource source(reader);
 			parser.parse(source);

--- a/GeneratorInterface/LHEInterface/src/XMLUtils.cc
+++ b/GeneratorInterface/LHEInterface/src/XMLUtils.cc
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 #include <cstring>
 
@@ -54,7 +55,7 @@ XMLDocument::XercesPlatform::~XercesPlatform()
 		cms::concurrency::xercesTerminate();
 }
 
-XMLDocument::XMLDocument(std::auto_ptr<std::istream> &in, Handler &handler) :
+XMLDocument::XMLDocument(std::unique_ptr<std::istream> &in, Handler &handler) :
 	platform(new XercesPlatform()),
 	source(new STLInputSource(in)),
 	parser(XMLReaderFactory::createXMLReader()),
@@ -63,7 +64,7 @@ XMLDocument::XMLDocument(std::auto_ptr<std::istream> &in, Handler &handler) :
 	init(handler);
 }
 
-XMLDocument::XMLDocument(std::auto_ptr<StorageWrap> &in, Handler &handler) :
+XMLDocument::XMLDocument(std::unique_ptr<StorageWrap> &in, Handler &handler) :
 	platform(new XercesPlatform()),
 	source(new StorageInputSource(in)),
 	parser(XMLReaderFactory::createXMLReader()),

--- a/GeneratorInterface/LHEInterface/src/XMLUtils.h
+++ b/GeneratorInterface/LHEInterface/src/XMLUtils.h
@@ -37,8 +37,8 @@ class XMLDocument {
     public:
 	class Handler : public XERCES_CPP_NAMESPACE_QUALIFIER DefaultHandler {};
 
-	XMLDocument(std::auto_ptr<std::istream> &in, Handler &handler);
-	XMLDocument(std::auto_ptr<StorageWrap> &in, Handler &handler);
+	XMLDocument(std::unique_ptr<std::istream> &in, Handler &handler);
+	XMLDocument(std::unique_ptr<StorageWrap> &in, Handler &handler);
 	virtual ~XMLDocument();
 
 	bool parse();
@@ -59,10 +59,10 @@ class XMLDocument {
 
 	void init(Handler &handler);
 
-	std::auto_ptr<XercesPlatform>					platform;
+	std::unique_ptr<XercesPlatform>					platform;
 
-	std::auto_ptr<XERCES_CPP_NAMESPACE_QUALIFIER InputSource>	source;
-	std::auto_ptr<XERCES_CPP_NAMESPACE_QUALIFIER SAX2XMLReader>	parser;
+	std::unique_ptr<XERCES_CPP_NAMESPACE_QUALIFIER InputSource>	source;
+	std::unique_ptr<XERCES_CPP_NAMESPACE_QUALIFIER SAX2XMLReader>	parser;
 
 	XERCES_CPP_NAMESPACE_QUALIFIER XMLPScanToken			token;
 
@@ -115,14 +115,14 @@ class XMLInputSourceWrapper :
     public:
 	typedef typename T::Stream_t Stream_t;
 
-	XMLInputSourceWrapper(std::auto_ptr<Stream_t> &obj) : obj(obj) {}
+	XMLInputSourceWrapper(std::unique_ptr<Stream_t> &obj) : obj(std::move(obj)) {}
 	virtual ~XMLInputSourceWrapper() {}
 
 	virtual XERCES_CPP_NAMESPACE_QUALIFIER BinInputStream* makeStream() const
 	{ return new T(*obj); }
 
     private:
-	std::auto_ptr<Stream_t>	obj;
+	std::unique_ptr<Stream_t>	obj;
 };
 
 class CBInputStream : public XERCES_CPP_NAMESPACE_QUALIFIER BinInputStream {

--- a/GeneratorInterface/MCatNLOInterface/plugins/MCatNLOSource.cc
+++ b/GeneratorInterface/MCatNLOInterface/plugins/MCatNLOSource.cc
@@ -6,6 +6,7 @@
 #include <memory>
 
 #include <boost/bind.hpp>
+#include <utility>
 
 #include "FWCore/Framework/interface/InputSourceMacros.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/GeneratorInterface/PartonShowerVeto/interface/JetMatching.h
+++ b/GeneratorInterface/PartonShowerVeto/interface/JetMatching.h
@@ -82,7 +82,7 @@ class JetMatching {
 	const std::vector<JetPartonMatch> &getMatchSummary() const
 	{ return matchSummary; }
 */
-	static std::auto_ptr<JetMatching> create(
+	static std::unique_ptr<JetMatching> create(
 					const edm::ParameterSet &params);
 
     protected:

--- a/GeneratorInterface/PartonShowerVeto/src/JetMatching.cc
+++ b/GeneratorInterface/PartonShowerVeto/src/JetMatching.cc
@@ -2,6 +2,7 @@
 #include <memory>
 
 #include <boost/shared_ptr.hpp>
+#include <utility>
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -44,11 +45,11 @@ std::set<std::string> JetMatching::capabilities() const
 	return result;
 }
 
-std::auto_ptr<JetMatching> JetMatching::create(const edm::ParameterSet &params)
+std::unique_ptr<JetMatching> JetMatching::create(const edm::ParameterSet &params)
 {
 	std::string scheme = params.getParameter<std::string>("scheme");
 
-	std::auto_ptr<JetMatching> matching;
+	std::unique_ptr<JetMatching> matching;
 
 	if (scheme == "Madgraph")
 	{
@@ -74,7 +75,7 @@ std::auto_ptr<JetMatching> JetMatching::create(const edm::ParameterSet &params)
 			   " for parton-shower matching is still in progress."
 			<< std::endl;
 
-	return matching;
+	return std::move(matching);
 }
 
 } // namespace gen

--- a/GeneratorInterface/PartonShowerVeto/src/JetMatchingAlpgen.cc
+++ b/GeneratorInterface/PartonShowerVeto/src/JetMatchingAlpgen.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <cstring>
+#include <utility>
 #include <vector>
 #include <memory>
 #include <string>

--- a/GeneratorInterface/PartonShowerVeto/src/JetMatchingMGFastJet.cc
+++ b/GeneratorInterface/PartonShowerVeto/src/JetMatchingMGFastJet.cc
@@ -9,6 +9,7 @@
 
 #include <boost/shared_ptr.hpp>
 #include <boost/algorithm/string/trim.hpp>
+#include <utility>
 
 
 namespace gen

--- a/GeneratorInterface/PartonShowerVeto/src/JetMatchingMadgraph.cc
+++ b/GeneratorInterface/PartonShowerVeto/src/JetMatchingMadgraph.cc
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <iostream>
 #include <sstream>
+#include <utility>
 #include <vector>
 #include <memory>
 #include <cstring>

--- a/GeneratorInterface/PomwigInterface/plugins/PomwigGeneratorFilter.cc
+++ b/GeneratorInterface/PomwigInterface/plugins/PomwigGeneratorFilter.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "GeneratorInterface/Core/interface/GeneratorFilter.h"
 #include "GeneratorInterface/PomwigInterface/interface/PomwigHadronizer.h"
 #include "GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h"

--- a/GeneratorInterface/PomwigInterface/src/PomwigHadronizer.cc
+++ b/GeneratorInterface/PomwigInterface/src/PomwigHadronizer.cc
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 #include <memory>
 #include <map>

--- a/GeneratorInterface/PyquenInterface/plugins/plugin.cc
+++ b/GeneratorInterface/PyquenInterface/plugins/plugin.cc
@@ -1,6 +1,8 @@
 //
 //
 
+#include <utility>
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 //#include "GeneratorInterface/PyquenInterface/interface/PyquenSource.h"
 //#include "GeneratorInterface/PyquenInterface/interface/PyquenProducer.h"

--- a/GeneratorInterface/PyquenInterface/src/PyquenGeneratorFilter.cc
+++ b/GeneratorInterface/PyquenInterface/src/PyquenGeneratorFilter.cc
@@ -1,4 +1,6 @@
 
 
+#include <utility>
+
 #include "GeneratorInterface/PyquenInterface/interface/PyquenHadronizer.h"
 

--- a/GeneratorInterface/PyquenInterface/src/PyquenHadronizer.cc
+++ b/GeneratorInterface/PyquenInterface/src/PyquenHadronizer.cc
@@ -6,6 +6,7 @@
 
 #include <iostream>
 #include <ctime>
+#include <utility>
 
 #include "GeneratorInterface/PyquenInterface/interface/PyquenHadronizer.h"
 

--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6GeneratorFilter.cc
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6GeneratorFilter.cc
@@ -1,5 +1,7 @@
 // -*- C++ -*-
 
+#include <utility>
+
 #include "GeneratorInterface/Core/interface/GeneratorFilter.h"
 #include "GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h"
 #include "Pythia6Hadronizer.h"

--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6Hadronizer.cc
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6Hadronizer.cc
@@ -33,6 +33,7 @@ HepMC::IO_HEPEVT conv;
 #include "GeneratorInterface/Pythia6Interface/interface/Pythia6Declarations.h"
 
 #include <iomanip>
+#include <utility>
 
 namespace gen
 {

--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6HadronizerFilter.cc
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6HadronizerFilter.cc
@@ -1,5 +1,7 @@
 // -*- C++ -*-
 
+#include <utility>
+
 #include "GeneratorInterface/Core/interface/HadronizerFilter.h"
 #include "GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h"
 #include "Pythia6Hadronizer.h"

--- a/GeneratorInterface/Pythia8Interface/interface/Py8InterfaceBase.h
+++ b/GeneratorInterface/Pythia8Interface/interface/Py8InterfaceBase.h
@@ -43,8 +43,8 @@ namespace gen {
 
       protected:
          
-	 std::auto_ptr<Pythia8::Pythia> fMasterGen;
-	 std::auto_ptr<Pythia8::Pythia> fDecayer;
+	 std::unique_ptr<Pythia8::Pythia> fMasterGen;
+	 std::unique_ptr<Pythia8::Pythia> fDecayer;
 	 HepMC::Pythia8ToHepMC          toHepMC;
 // 	 ParameterCollector	        fParameters;
          edm::ParameterSet	        fParameters;
@@ -58,7 +58,7 @@ namespace gen {
          // EvtGen plugin
          //
          bool useEvtGen;
-         std::auto_ptr<EvtGenDecays> evtgenDecays;
+         std::unique_ptr<EvtGenDecays> evtgenDecays;
          std::string evtgenDecFile;
          std::string evtgenPdlFile;
          std::vector<std::string> evtgenUserFiles;

--- a/GeneratorInterface/Pythia8Interface/plugins/JetMatchingHook.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/JetMatchingHook.cc
@@ -7,6 +7,7 @@
 
 //#include "HepMC/HEPEVT_Wrapper.h"
 #include <cassert>
+#include <utility>
 
 #include "GeneratorInterface/Pythia8Interface/plugins/Py8toJetInput.h"
 

--- a/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.cc
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <string>
 #include <memory>
+#include <utility>
 #include <assert.h>
 
 #include "GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.h"

--- a/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
@@ -1,4 +1,6 @@
 
+#include <utility>
+
 #include "GeneratorInterface/Core/interface/GeneratorFilter.h"
 #include "GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h"
 

--- a/GeneratorInterface/Pythia8Interface/plugins/Py8JetGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8JetGun.cc
@@ -1,4 +1,6 @@
 
+#include <utility>
+
 #include "GeneratorInterface/Core/interface/GeneratorFilter.h"
 #include "GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h"
 

--- a/GeneratorInterface/Pythia8Interface/plugins/Py8PtGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8PtGun.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "GeneratorInterface/Core/interface/GeneratorFilter.h"
 #include "GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h"
 

--- a/GeneratorInterface/Pythia8Interface/plugins/Py8toJetInput.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8toJetInput.cc
@@ -248,6 +248,7 @@ int Py8toJetInput::getAncestor( int pos, const Event& fullEvent, const Event& wo
 
 #include "HepMC/HEPEVT_Wrapper.h"
 #include <cassert>
+#include <utility>
 
 const std::vector<fastjet::PseudoJet> 
 Py8toJetInputHEPEVT::fillJetAlgoInput( const Event& event, const Event& workEvent, 

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -3,6 +3,7 @@
 #include <string>
 #include <memory>
 #include <stdint.h>
+#include <utility>
 #include <vector>
 
 #include "HepMC/GenEvent.h"
@@ -101,7 +102,7 @@ class Pythia8Hadronizer : public Py8InterfaceBase {
     double       comEnergy;
 
     std::string LHEInputFileName;
-    std::auto_ptr<LHAupLesHouches>  lhaUP;
+    std::unique_ptr<LHAupLesHouches>  lhaUP;
 
     enum { PP, PPbar, ElectronPositron };
     int  fInitialState ; // pp, ppbar, or e-e+
@@ -110,34 +111,34 @@ class Pythia8Hadronizer : public Py8InterfaceBase {
     double fBeam2PZ;
 
     //helper class to allow multiple user hooks simultaneously
-    std::auto_ptr<MultiUserHook> fMultiUserHook;
+    std::unique_ptr<MultiUserHook> fMultiUserHook;
     
     // Reweight user hooks
     //
-    std::auto_ptr<UserHooks> fReweightUserHook;
-    std::auto_ptr<UserHooks> fReweightRapUserHook;  
-    std::auto_ptr<UserHooks> fReweightPtHatRapUserHook;
+    std::unique_ptr<UserHooks> fReweightUserHook;
+    std::unique_ptr<UserHooks> fReweightRapUserHook;  
+    std::unique_ptr<UserHooks> fReweightPtHatRapUserHook;
         
     // PS matching prototype
     //
-    std::auto_ptr<JetMatchingHook> fJetMatchingHook;
-    std::auto_ptr<Pythia8::JetMatchingMadgraph> fJetMatchingPy8InternalHook;
-    std::auto_ptr<Pythia8::amcnlo_unitarised_interface> fMergingHook;
+    std::unique_ptr<JetMatchingHook> fJetMatchingHook;
+    std::unique_ptr<Pythia8::JetMatchingMadgraph> fJetMatchingPy8InternalHook;
+    std::unique_ptr<Pythia8::amcnlo_unitarised_interface> fMergingHook;
     
     // Emission Veto Hooks
     //
-    std::auto_ptr<PowhegHooks> fEmissionVetoHook;
-    std::auto_ptr<EmissionVetoHook1> fEmissionVetoHook1;
+    std::unique_ptr<PowhegHooks> fEmissionVetoHook;
+    std::unique_ptr<EmissionVetoHook1> fEmissionVetoHook1;
     
     // Resonance scale hook
-    std::auto_ptr<PowhegResHook> fPowhegResHook;
-    std::auto_ptr<PowhegHooksBB4L> fPowhegHooksBB4L;
+    std::unique_ptr<PowhegResHook> fPowhegResHook;
+    std::unique_ptr<PowhegHooksBB4L> fPowhegHooksBB4L;
     
     //resonance decay filter hook
-    std::auto_ptr<ResonanceDecayFilterHook> fResonanceDecayFilterHook;
+    std::unique_ptr<ResonanceDecayFilterHook> fResonanceDecayFilterHook;
  
     //PT filter hook
-    std::auto_ptr<PTFilterHook> fPTFilterHook;
+    std::unique_ptr<PTFilterHook> fPTFilterHook;
    
     int  EV1_nFinal;
     bool EV1_vetoOn;

--- a/GeneratorInterface/Pythia8Interface/src/Py8GunBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8GunBase.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "GeneratorInterface/Pythia8Interface/interface/Py8GunBase.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Concurrency/interface/SharedResourceNames.h"

--- a/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "GeneratorInterface/Pythia8Interface/interface/Py8InterfaceBase.h"
 
 #include "FWCore/Utilities/interface/Exception.h"

--- a/GeneratorInterface/ReggeGribovPartonMCInterface/plugins/plugin.cc
+++ b/GeneratorInterface/ReggeGribovPartonMCInterface/plugins/plugin.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "GeneratorInterface/ReggeGribovPartonMCInterface/interface/ReggeGribovPartonMCGeneratorFilter.h"
 

--- a/GeneratorInterface/ReggeGribovPartonMCInterface/src/ReggeGribovPartonMCGeneratorFilter.cc
+++ b/GeneratorInterface/ReggeGribovPartonMCInterface/src/ReggeGribovPartonMCGeneratorFilter.cc
@@ -1,1 +1,3 @@
+#include <utility>
+
 #include "GeneratorInterface/ReggeGribovPartonMCInterface/interface/ReggeGribovPartonMC.h"

--- a/GeneratorInterface/ReggeGribovPartonMCInterface/src/ReggeGribovPartonMCHadronizer.cc
+++ b/GeneratorInterface/ReggeGribovPartonMCInterface/src/ReggeGribovPartonMCHadronizer.cc
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <cmath>
 #include <string>
+#include <utility>
 
 #include "GeneratorInterface/ReggeGribovPartonMCInterface/interface/ReggeGribovPartonMCHadronizer.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"

--- a/GeneratorInterface/SherpaInterface/src/SherpaHadronizer.cc
+++ b/GeneratorInterface/SherpaInterface/src/SherpaHadronizer.cc
@@ -4,6 +4,7 @@
 #include <string>
 #include <memory>
 #include <stdint.h>
+#include <utility>
 #include <vector>
 
 

--- a/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
+++ b/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
@@ -1,6 +1,7 @@
 /* this is the code for the new Tauola++ */
 
 #include <iostream>
+#include <utility>
 
 #include "GeneratorInterface/TauolaInterface/interface/TauolappInterface.h"
 

--- a/GeneratorInterface/TauolaInterface/plugins/Tauolapp/module.cc
+++ b/GeneratorInterface/TauolaInterface/plugins/Tauolapp/module.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "GeneratorInterface/TauolaInterface/interface/TauolaFactory.h"

--- a/GeneratorInterface/TauolaInterface/src/TauolaFactory.cc
+++ b/GeneratorInterface/TauolaInterface/src/TauolaFactory.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "GeneratorInterface/TauolaInterface/interface/TauolaFactory.h"
 EDM_REGISTER_PLUGINFACTORY(TauolaFactory,"TauolaFactory");
 

--- a/GeneratorInterface/TauolaInterface/src/TauolaInterfaceBase.cc
+++ b/GeneratorInterface/TauolaInterface/src/TauolaInterfaceBase.cc
@@ -1,1 +1,3 @@
+#include <utility>
+
 #include "GeneratorInterface/TauolaInterface/interface/TauolaInterfaceBase.h"

--- a/Geometry/CaloGeometry/interface/CaloVGeometryLoader.h
+++ b/Geometry/CaloGeometry/interface/CaloVGeometryLoader.h
@@ -15,7 +15,7 @@ class CaloVGeometryLoader
    public:
       virtual ~CaloVGeometryLoader() = default;
       /// Load the subdetector geometry for the specified det and subdet
-      virtual std::auto_ptr<CaloSubdetectorGeometry> 
+      virtual std::unique_ptr<CaloSubdetectorGeometry> 
                      load( DetId::Detector det, int subdet ) = 0;
 };
 

--- a/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.cc
+++ b/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.cc
@@ -14,22 +14,23 @@
 typedef CaloCellGeometry::CCGFloat CCGFloat ;
 
 #include <iostream>
+#include <utility>
 #include <vector>
 #include <memory>
 
-std::auto_ptr<CaloSubdetectorGeometry> 
+std::unique_ptr<CaloSubdetectorGeometry> 
 EcalTBHodoscopeGeometryLoaderFromDDD::load( const DDCompactView* cpv ) 
 {
    std::cout << "[EcalTBHodoscopeGeometryLoaderFromDDD]:: start the construction of EcalTBHodoscope" << std::endl;
 
-   std::auto_ptr<CaloSubdetectorGeometry> ebg
+   std::unique_ptr<CaloSubdetectorGeometry> ebg
       ( new EcalTBHodoscopeGeometry() ) ;
 
    makeGeometry( cpv, ebg.get() ) ;
 
    std::cout << "[EcalTBHodoscopeGeometryLoaderFromDDD]:: Returning EcalTBHodoscopeGeometry" << std::endl;
 
-   return ebg;
+   return std::move(ebg);
 }
 
 void 

--- a/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.h
+++ b/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.h
@@ -28,7 +28,7 @@ class EcalTBHodoscopeGeometryLoaderFromDDD
 
       virtual ~EcalTBHodoscopeGeometryLoaderFromDDD() {} ;
 
-      std::auto_ptr<CaloSubdetectorGeometry> load( const DDCompactView* cpv ) ;
+      std::unique_ptr<CaloSubdetectorGeometry> load( const DDCompactView* cpv ) ;
 
    private:
 

--- a/Geometry/ForwardGeometry/interface/CastorHardcodeGeometryLoader.h
+++ b/Geometry/ForwardGeometry/interface/CastorHardcodeGeometryLoader.h
@@ -15,8 +15,8 @@ public:
   explicit CastorHardcodeGeometryLoader(const CastorTopology& ht);
   virtual ~CastorHardcodeGeometryLoader() { delete theTopology ; };
   
-  virtual std::auto_ptr<CaloSubdetectorGeometry> load(DetId::Detector det, int subdet);
-  std::auto_ptr<CaloSubdetectorGeometry> load();
+  virtual std::unique_ptr<CaloSubdetectorGeometry> load(DetId::Detector det, int subdet);
+  std::unique_ptr<CaloSubdetectorGeometry> load();
   
 private:
   void init();

--- a/Geometry/ForwardGeometry/src/CastorHardcodeGeometryLoader.cc
+++ b/Geometry/ForwardGeometry/src/CastorHardcodeGeometryLoader.cc
@@ -5,6 +5,7 @@
 #include "Geometry/ForwardGeometry/src/CastorGeometryData.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <algorithm>
+#include <utility>
 
 typedef CaloCellGeometry::CCGFloat CCGFloat ;
 
@@ -32,27 +33,27 @@ void CastorHardcodeGeometryLoader::init()
    theHADSectiondZ = 1212.;
 }
 
-std::auto_ptr<CaloSubdetectorGeometry> 
+std::unique_ptr<CaloSubdetectorGeometry> 
 CastorHardcodeGeometryLoader::load( DetId::Detector /*det*/, 
 				    int             subdet)
 {
-   std::auto_ptr<CaloSubdetectorGeometry> hg(new CastorGeometry( extTopology ));
+   std::unique_ptr<CaloSubdetectorGeometry> hg(new CastorGeometry( extTopology ));
    if( subdet == HcalCastorDetId::SubdetectorId )
    {
       fill( HcalCastorDetId::EM,  hg.get() ) ;
       fill( HcalCastorDetId::HAD, hg.get() ) ;
    }
-   return hg;
+   return std::move(hg);
 }
 
-std::auto_ptr<CaloSubdetectorGeometry> 
+std::unique_ptr<CaloSubdetectorGeometry> 
 CastorHardcodeGeometryLoader::load() 
 {
-   std::auto_ptr<CaloSubdetectorGeometry> hg
+   std::unique_ptr<CaloSubdetectorGeometry> hg
       ( new CastorGeometry( extTopology ) ) ;
    fill( HcalCastorDetId::EM,  hg.get() ) ;
    fill( HcalCastorDetId::HAD, hg.get() ) ;
-   return hg;
+   return std::move(hg);
 }
 
 void 

--- a/Geometry/HcalTowerAlgo/interface/CaloTowerHardcodeGeometryLoader.h
+++ b/Geometry/HcalTowerAlgo/interface/CaloTowerHardcodeGeometryLoader.h
@@ -14,7 +14,7 @@
   */
 class CaloTowerHardcodeGeometryLoader {
 public:
-  std::auto_ptr<CaloSubdetectorGeometry> load(const CaloTowerTopology *limits, const HcalTopology *hcaltopo, const HcalDDDRecConstants* hcons);
+  std::unique_ptr<CaloSubdetectorGeometry> load(const CaloTowerTopology *limits, const HcalTopology *hcaltopo, const HcalDDDRecConstants* hcons);
 private:
   void makeCell(uint32_t din, CaloSubdetectorGeometry* geom) const;
   const CaloTowerTopology *m_limits;

--- a/Geometry/HcalTowerAlgo/src/CaloTowerHardcodeGeometryLoader.cc
+++ b/Geometry/HcalTowerAlgo/src/CaloTowerHardcodeGeometryLoader.cc
@@ -11,7 +11,7 @@
 
 typedef CaloCellGeometry::CCGFloat CCGFloat ;
 
-std::auto_ptr<CaloSubdetectorGeometry> CaloTowerHardcodeGeometryLoader::load(const CaloTowerTopology *limits, const HcalTopology *hcaltopo, const HcalDDDRecConstants* hcons) {
+std::unique_ptr<CaloSubdetectorGeometry> CaloTowerHardcodeGeometryLoader::load(const CaloTowerTopology *limits, const HcalTopology *hcaltopo, const HcalDDDRecConstants* hcons) {
 
   m_limits = limits;
   m_hcaltopo = hcaltopo;
@@ -43,7 +43,7 @@ std::auto_ptr<CaloSubdetectorGeometry> CaloTowerHardcodeGeometryLoader::load(con
     makeCell(din, geom);
   }
   edm::LogInfo("Geometry") << "CaloTowersHardcodeGeometry made " << m_limits->sizeForDenseIndexing() << " towers.";
-  return std::auto_ptr<CaloSubdetectorGeometry>(geom); 
+  return std::unique_ptr<CaloSubdetectorGeometry>(geom); 
 }
 
 void

--- a/Geometry/MuonNumbering/plugins/MuonNumberingInitialization.cc
+++ b/Geometry/MuonNumbering/plugins/MuonNumberingInitialization.cc
@@ -65,7 +65,7 @@ MuonNumberingInitialization::produce(const MuonNumberingRecord& iRecord)
     edm::LogError( "MuonNumberingInitialization" ) << "MuonNumberingInitialization::produceMuonDDDConstants has NOT been initialized!";
     throw;
   }
-  return std::auto_ptr<MuonDDDConstants> ( muonDDDConst_ ) ;
+  return std::unique_ptr<MuonDDDConstants> ( muonDDDConst_ ) ;
 }
 
 void

--- a/IORawData/CaloPatterns/src/HcalPatternXMLParser.cc
+++ b/IORawData/CaloPatterns/src/HcalPatternXMLParser.cc
@@ -10,7 +10,7 @@ XERCES_CPP_NAMESPACE_USE
 
 class HcalPatternXMLParserImpl {
 public:
-  std::auto_ptr<SAX2XMLReader> parser;
+  std::unique_ptr<SAX2XMLReader> parser;
 };
 
 HcalPatternXMLParser::HcalPatternXMLParser() {
@@ -153,7 +153,7 @@ void HcalPatternXMLParser::parse(const std::string& xmlDocument, std::map<std::s
     try {
       if (m_parser==0) {
 	m_parser=new HcalPatternXMLParserImpl();
-	m_parser->parser=std::auto_ptr<xercesc::SAX2XMLReader>(xercesc::XMLReaderFactory::createXMLReader());
+	m_parser->parser=std::unique_ptr<xercesc::SAX2XMLReader>(xercesc::XMLReaderFactory::createXMLReader());
       }
 	 
       MemBufInputSource src((const unsigned char*)xmlDocument.c_str(), xmlDocument.length(),"hcal::PatternReader");

--- a/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectorDBWriter.cc
+++ b/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectorDBWriter.cc
@@ -65,7 +65,7 @@ FFTJetCorrectorDBWriter::FFTJetCorrectorDBWriter(const edm::ParameterSet& ps)
 void FFTJetCorrectorDBWriter::analyze(const edm::Event& iEvent,
                                       const edm::EventSetup& iSetup)
 {
-    std::auto_ptr<FFTJetCorrectorParameters> fcp;
+    std::unique_ptr<FFTJetCorrectorParameters> fcp;
 
     {
         std::ifstream input(inputFile.c_str(), std::ios_base::binary);
@@ -79,7 +79,7 @@ void FFTJetCorrectorDBWriter::analyze(const edm::Event& iEvent,
                 << "Failed to stat file \"" << inputFile << '"' << std::endl;
 
         const std::size_t len = st.st_size;
-        fcp = std::auto_ptr<FFTJetCorrectorParameters>(
+        fcp = std::unique_ptr<FFTJetCorrectorParameters>(
             new FFTJetCorrectorParameters(len));
         assert(fcp->length() == len);
         if (len)

--- a/JetMETCorrections/Objects/src/ChainedJetCorrector.cc
+++ b/JetMETCorrections/Objects/src/ChainedJetCorrector.cc
@@ -22,7 +22,7 @@ double ChainedJetCorrector::correction (const LorentzVector& fJet) const
 /// apply correction using Jet information only
 double ChainedJetCorrector::correction (const reco::Jet& fJet) const
 {
-  std::auto_ptr<reco::Jet> jet (dynamic_cast<reco::Jet*> (fJet.clone ()));
+  std::unique_ptr<reco::Jet> jet (dynamic_cast<reco::Jet*> (fJet.clone ()));
   double result = 1;
   for (size_t i = 0; i < mCorrectors.size (); ++i) {
     double scale = mCorrectors[i]->correction (*jet);
@@ -37,7 +37,7 @@ double ChainedJetCorrector::correction (const reco::Jet& fJet,
 					const edm::Event& fEvent,
 					const edm::EventSetup& fSetup) const
 {
-  std::auto_ptr<reco::Jet> jet (dynamic_cast<reco::Jet*> (fJet.clone ()));
+  std::unique_ptr<reco::Jet> jet (dynamic_cast<reco::Jet*> (fJet.clone ()));
   double result = 1;
   for (size_t i = 0; i < mCorrectors.size (); ++i) {
     double scale = mCorrectors[i]->correction (*jet, fEvent, fSetup);
@@ -52,7 +52,7 @@ double ChainedJetCorrector::correction (const reco::Jet& fJet,
 					const edm::Event& fEvent,
 					const edm::EventSetup& fSetup) const
 {
-  std::auto_ptr<reco::Jet> jet (dynamic_cast<reco::Jet*> (fJet.clone ()));
+  std::unique_ptr<reco::Jet> jet (dynamic_cast<reco::Jet*> (fJet.clone ()));
   double result = 1;
   for (size_t i = 0; i < mCorrectors.size (); ++i) {
     double scale = mCorrectors[i]->correction (*jet, fJetRef, fEvent, fSetup);

--- a/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtPatternGenerator.h
+++ b/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtPatternGenerator.h
@@ -96,7 +96,7 @@ private:
     std::vector<uint32_t> m_columnDefaults;
     bool m_debug;
 
-    std::auto_ptr<L1GtPatternWriter> m_writer;
+    std::unique_ptr<L1GtPatternWriter> m_writer;
 };
 
 #endif /*GlobalTriggerAnalyzer_L1GtPatternGenerator_h*/

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtPatternGenerator.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtPatternGenerator.cc
@@ -285,7 +285,7 @@ void L1GtPatternGenerator::beginJob()
     edm::LogError("L1GtPatternGenerator") <<  "Failed to open output file " << m_fileName;
   }
 
-  m_writer = std::auto_ptr<L1GtPatternWriter>(new L1GtPatternWriter(m_fileStream, m_header, m_footer, m_columnNames, m_columnLengths, m_columnDefaults, m_bx, m_debug));
+  m_writer = std::unique_ptr<L1GtPatternWriter>(new L1GtPatternWriter(m_fileStream, m_header, m_footer, m_columnNames, m_columnLengths, m_columnDefaults, m_bx, m_debug));
 }
 
 /** Method called once each job just after ending the event loop.

--- a/MagneticField/ParametrizedEngine/interface/ParametrizedMagneticFieldFactory.h
+++ b/MagneticField/ParametrizedEngine/interface/ParametrizedMagneticFieldFactory.h
@@ -35,11 +35,11 @@ class ParametrizedMagneticFieldFactory {
   friend class magneticfield::VolumeBasedMagneticFieldESProducerFromDB;
 
   // Get map configured from pset (deprecated)
-  std::auto_ptr<MagneticField>
+  std::unique_ptr<MagneticField>
   static get(std::string version, const edm::ParameterSet& parameters);
   
   // Get map configured from type name and numerical parameters
-  std::auto_ptr<MagneticField>
+  std::unique_ptr<MagneticField>
   static get(std::string version, std::vector<double> parameters);
 
 };

--- a/MagneticField/ParametrizedEngine/src/ParametrizedMagneticFieldFactory.cc
+++ b/MagneticField/ParametrizedEngine/src/ParametrizedMagneticFieldFactory.cc
@@ -6,6 +6,8 @@
 #include <MagneticField/ParametrizedEngine/interface/ParametrizedMagneticFieldFactory.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 
+#include <utility>
+
 #include "MagneticField/UniformEngine/interface/UniformMagneticField.h"
 #include "OAEParametrizedMagneticField.h"
 #include "ParabolicParametrizedMagneticField.h"
@@ -19,17 +21,17 @@ using namespace edm;
 ParametrizedMagneticFieldFactory::ParametrizedMagneticFieldFactory(){}
 
 // Legacy interface, deprecated
-std::auto_ptr<MagneticField>
+std::unique_ptr<MagneticField>
 ParametrizedMagneticFieldFactory::get(string version, const ParameterSet& parameters) {
 
   if (version=="OAE_1103l_071212") {
     // V. Karimaki's off-axis expansion fitted to v1103l TOSCA computation
-    std::auto_ptr<MagneticField> result( new OAEParametrizedMagneticField(parameters));
-    return result;
+    std::unique_ptr<MagneticField> result( new OAEParametrizedMagneticField(parameters));
+    return std::move(result);
   } else if (version=="PolyFit2D") {
     // V. Maroussov polynomial fit to mapping data
-    std::auto_ptr<MagneticField> result( new PolyFit2DParametrizedMagneticField(parameters));
-    return result;
+    std::unique_ptr<MagneticField> result( new PolyFit2DParametrizedMagneticField(parameters));
+    return std::move(result);
   } else if (version=="PolyFit3D") {
     // V. Maroussov polynomial fit to mapping data
     throw cms::Exception("InvalidParameter")<<"PolyFit3D is not supported anymore";
@@ -37,42 +39,42 @@ ParametrizedMagneticFieldFactory::get(string version, const ParameterSet& parame
     // FIXME implement configurable parameters to be passed to ctor
 //   vector<double> params =  parameters.getParameter<vdouble>("parameters");
 //   std::auto_ptr<MagneticField> result( new ParabolicParametrizedMagneticField(params));
-    std::auto_ptr<MagneticField> result( new ParabolicParametrizedMagneticField());
-    return result;
+    std::unique_ptr<MagneticField> result( new ParabolicParametrizedMagneticField());
+    return std::move(result);
   }  else {
     throw cms::Exception("InvalidParameter")<<"Invalid parametrization version " << version;
   }
-  return std::auto_ptr<MagneticField>(0); //make compiler happy
+  return std::unique_ptr<MagneticField>(0); //make compiler happy
 }
 
 
 // New interface
-std::auto_ptr<MagneticField>
+std::unique_ptr<MagneticField>
 ParametrizedMagneticFieldFactory::get(string version, vector<double> parameters) {
 
   if (version=="Uniform") {
     if (parameters.size()!=1) throw cms::Exception("InvalidParameter") << "Incorrect parameters (" << parameters.size()<< ")`for " << version ;
-     std::auto_ptr<MagneticField> result(new UniformMagneticField(parameters[0]));
-    return result;
+     std::unique_ptr<MagneticField> result(new UniformMagneticField(parameters[0]));
+    return std::move(result);
   } else if (version=="OAE_1103l_071212") {
     // V. Karimaki's off-axis expansion fitted to v1103l TOSCA computation
     if (parameters.size()!=1) throw cms::Exception("InvalidParameter") << "Incorrect parameters (" << parameters.size()<< ")`for " << version ;
-    std::auto_ptr<MagneticField> result( new OAEParametrizedMagneticField(parameters[0]));
-    return result;
+    std::unique_ptr<MagneticField> result( new OAEParametrizedMagneticField(parameters[0]));
+    return std::move(result);
   } else if (version=="PolyFit2D") {
     // V. Maroussov polynomial fit to mapping data
     if (parameters.size()!=1) throw cms::Exception("InvalidParameter") << "Incorrect parameters (" << parameters.size()<< ")`for " << version ;
-    std::auto_ptr<MagneticField> result( new PolyFit2DParametrizedMagneticField(parameters[0]));
-    return result;
+    std::unique_ptr<MagneticField> result( new PolyFit2DParametrizedMagneticField(parameters[0]));
+    return std::move(result);
   } else if (version=="PolyFit3D") {
     // V. Maroussov polynomial fit to mapping data
     throw cms::Exception("InvalidParameter")<<"PolyFit3D is not supported anymore";
   } else if (version=="Parabolic"){
     if (parameters.size()!=4) throw cms::Exception("InvalidParameter") << "Incorrect parameters (" << parameters.size()<< ")`for " << version ;
-    std::auto_ptr<MagneticField> result( new ParabolicParametrizedMagneticField(parameters));
-    return result;
+    std::unique_ptr<MagneticField> result( new ParabolicParametrizedMagneticField(parameters));
+    return std::move(result);
   }  else {
     throw cms::Exception("InvalidParameter")<<"Invalid parametrization version " << version;
   }
-  return std::auto_ptr<MagneticField>(0); //make compiler happy
+  return std::unique_ptr<MagneticField>(0); //make compiler happy
 }

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/DBWriter.h
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/DBWriter.h
@@ -20,5 +20,5 @@ private:
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
   virtual void endJob() {};
 
-  std::auto_ptr<BaseFunction> corrector_;
+  std::unique_ptr<BaseFunction> corrector_;
 };

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/Histograms.h
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/Histograms.h
@@ -2270,8 +2270,8 @@ class HMassResolutionVSPart : public Histograms
  protected:
   std::map<TString, TH1*> mapHisto_;
   TString nameSuffix_[2];
-  std::auto_ptr<HDelta> muMinus;
-  std::auto_ptr<HDelta> muPlus;
+  std::unique_ptr<HDelta> muMinus;
+  std::unique_ptr<HDelta> muPlus;
 };
 
 #endif

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFit.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFit.cc
@@ -309,7 +309,7 @@ class MuScleFit: public edm::EDLooper, MuScleFitBase
   edm::InputTag puInfoSrc_;
   edm::InputTag vertexSrc_;
 
-  std::auto_ptr<MuScleFitMuonSelector> muonSelector_;
+  std::unique_ptr<MuScleFitMuonSelector> muonSelector_;
 };
 
 template<typename T>

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitFilter.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitFilter.cc
@@ -122,7 +122,7 @@ bool MuScleFitFilter::filter(edm::Event& event, const edm::EventSetup& iSetup) {
 
   // Get the RecTrack and the RecMuon collection from the event
   // ----------------------------------------------------------
-  std::auto_ptr<reco::MuonCollection> muons(new reco::MuonCollection());
+  std::unique_ptr<reco::MuonCollection> muons(new reco::MuonCollection());
 
   if (debug) std::cout << "Looking for muons of the right kind" << std::endl;
 

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitUtils.h
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitUtils.h
@@ -79,7 +79,7 @@ public:
   static double invDimuonMass( const lorentzVector & mu1, const lorentzVector & mu2 );
   static double massResolution( const lorentzVector & mu1, const lorentzVector & mu2 );
   static double massResolution( const lorentzVector & mu1, const lorentzVector & mu2, const std::vector<double> & parval );
-  static double massResolution( const lorentzVector & mu1, const lorentzVector & mu2, std::auto_ptr<double> parval );
+  static double massResolution( const lorentzVector & mu1, const lorentzVector & mu2, std::unique_ptr<double> parval );
   static double massResolution( const lorentzVector & mu1, const lorentzVector & mu2, double* parval );
   static double massResolution( const lorentzVector& mu1, const lorentzVector& mu2, const ResolutionFunction & resolFunc );
 

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/TestCorrection.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/TestCorrection.cc
@@ -123,9 +123,9 @@ private:
 
   int eventCounter_;
 
-  std::auto_ptr<MomentumScaleCorrector> corrector_;
-  std::auto_ptr<ResolutionFunction> resolution_;
-  std::auto_ptr<BackgroundFunction> background_;
+  std::unique_ptr<MomentumScaleCorrector> corrector_;
+  std::unique_ptr<ResolutionFunction> resolution_;
+  std::unique_ptr<BackgroundFunction> background_;
 
   edm::EDGetTokenT<reco::MuonCollection> glbMuonsToken_;
   edm::EDGetTokenT<reco::TrackCollection> saMuonsToken_;

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/TestResolution.h
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/TestResolution.h
@@ -91,7 +91,7 @@ private:
 
   int eventCounter_;
 
-  std::auto_ptr<ResolutionFunction> resolutionFunction_;
+  std::unique_ptr<ResolutionFunction> resolutionFunction_;
 };
 
 #endif // TESTRESOLUTION_HH

--- a/OnlineDB/EcalCondDB/bin/cmsecal_write_offline_det_id.cpp
+++ b/OnlineDB/EcalCondDB/bin/cmsecal_write_offline_det_id.cpp
@@ -208,7 +208,7 @@ public:
   }
 
 private:
-  std::auto_ptr<coral::ISessionProxy> m_proxy;
+  std::unique_ptr<coral::ISessionProxy> m_proxy;
 };
 
 

--- a/PhysicsTools/CandUtils/interface/NamedCandCombinerBase.h
+++ b/PhysicsTools/CandUtils/interface/NamedCandCombinerBase.h
@@ -26,25 +26,25 @@ public:
   /// destructor
   virtual ~NamedCandCombinerBase();
   /// return all selected candidate pairs
-  std::auto_ptr<reco::NamedCompositeCandidateCollection> 
+  std::unique_ptr<reco::NamedCompositeCandidateCollection> 
   combine(const std::vector<reco::CandidatePtrVector> &, string_coll const &) const;
   /// return all selected candidate pairs
-  std::auto_ptr<reco::NamedCompositeCandidateCollection> 
+  std::unique_ptr<reco::NamedCompositeCandidateCollection> 
   combine(const reco::CandidatePtrVector &, 
 	  string_coll const &) const;
   /// return all selected candidate pairs
-  std::auto_ptr<reco::NamedCompositeCandidateCollection> 
+  std::unique_ptr<reco::NamedCompositeCandidateCollection> 
   combine(const reco::CandidatePtrVector &, 
 	  const reco::CandidatePtrVector &, 
 	  string_coll const &) const;
   /// return all selected candidate pairs
-  std::auto_ptr<reco::NamedCompositeCandidateCollection> 
+  std::unique_ptr<reco::NamedCompositeCandidateCollection> 
   combine(const reco::CandidatePtrVector &, 
 	  const reco::CandidatePtrVector &, 
 	  const reco::CandidatePtrVector &, 
 	  string_coll const &) const;
   /// return all selected candidate pairs
-  std::auto_ptr<reco::NamedCompositeCandidateCollection> 
+  std::unique_ptr<reco::NamedCompositeCandidateCollection> 
   combine(const reco::CandidatePtrVector &, 
 	  const reco::CandidatePtrVector &, 
 	  const reco::CandidatePtrVector &, 
@@ -69,7 +69,7 @@ private:
 	       string_coll const & names,
 	       std::vector<reco::CandidatePtrVector>::const_iterator begin,
 	       std::vector<reco::CandidatePtrVector>::const_iterator end,
-	       std::auto_ptr<reco::NamedCompositeCandidateCollection> & comps
+	       std::unique_ptr<reco::NamedCompositeCandidateCollection> & comps
 	       ) const;
   /// select a candidate
   virtual bool select(const reco::Candidate &) const = 0;

--- a/PhysicsTools/CandUtils/interface/cloneDecayTree.h
+++ b/PhysicsTools/CandUtils/interface/cloneDecayTree.h
@@ -3,6 +3,6 @@
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include <memory>
 
-std::auto_ptr<reco::Candidate> cloneDecayTree( const reco::Candidate & );
+std::unique_ptr<reco::Candidate> cloneDecayTree( const reco::Candidate & );
 
 #endif

--- a/PhysicsTools/CandUtils/interface/makeCompositeCandidate.h
+++ b/PhysicsTools/CandUtils/interface/makeCompositeCandidate.h
@@ -5,24 +5,24 @@
 #include <memory>
 
 namespace helpers {
-  struct CompositeCandidateMaker {
-    CompositeCandidateMaker( std::auto_ptr<reco::CompositeCandidate> cmp ) :
-      cmp_( cmp ) {
+  struct std::move(CompositeCandidateMaker) {
+    CompositeCandidateMaker( std::unique_ptr<reco::CompositeCandidate> cmp ) :
+      cmp_( std::move(cmp) ) {
     }
     void addDaughter( const reco::Candidate & dau ) {
       cmp_->addDaughter( dau );
     }
     template<typename S>
-    std::auto_ptr<reco::Candidate> operator[]( const S & setup ) {
+    std::unique_ptr<reco::Candidate> operator[]( const S & setup ) {
       setup.set( * cmp_ );
       return release();
     }
   private:
-    std::auto_ptr<reco::CompositeCandidate> cmp_;
-    std::auto_ptr<reco::Candidate> release() {
-      std::auto_ptr<reco::Candidate> ret( cmp_.get() );
+    std::unique_ptr<reco::CompositeCandidate> cmp_;
+    std::unique_ptr<reco::Candidate> release() {
+      std::unique_ptr<reco::Candidate> ret( cmp_.get() );
       cmp_.release();
-      return ret;
+      return std::move(ret);
     }
   };
 }
@@ -53,7 +53,7 @@ helpers::CompositeCandidateMaker
 makeCompositeCandidate( const typename C::const_iterator & begin, 
 			const typename C::const_iterator & end ) {
   helpers::CompositeCandidateMaker 
-    cmp( std::auto_ptr<reco::CompositeCandidate>( new reco::CompositeCandidate ) );
+    cmp( std::unique_ptr<reco::CompositeCandidate>( new reco::CompositeCandidate ) );
   for( typename C::const_iterator i = begin; i != end; ++ i ) 
     cmp.addDaughter( * i );
   return cmp;
@@ -79,7 +79,7 @@ helpers::CompositeCandidateMaker
 makeCompositeCandidateWithRefsToMaster( const typename C::const_iterator & begin, 
 					const typename C::const_iterator & end ) {
   helpers::CompositeCandidateMaker 
-    cmp( std::auto_ptr<reco::CompositeCandidate>( new reco::CompositeCandidate ) );
+    cmp( std::unique_ptr<reco::CompositeCandidate>( new reco::CompositeCandidate ) );
   for( typename C::const_iterator i = begin; i != end; ++ i ) 
     cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( * i ) ) );
   return cmp;

--- a/PhysicsTools/CandUtils/interface/makeNamedCompositeCandidate.h
+++ b/PhysicsTools/CandUtils/interface/makeNamedCompositeCandidate.h
@@ -6,24 +6,24 @@
 #include <string>
 
 namespace helpers {
-  struct NamedCompositeCandidateMaker {
-    NamedCompositeCandidateMaker( std::auto_ptr<reco::NamedCompositeCandidate> cmp ) :
-      cmp_( cmp ) {
+  struct std::move(NamedCompositeCandidateMaker) {
+    NamedCompositeCandidateMaker( std::unique_ptr<reco::NamedCompositeCandidate> cmp ) :
+      cmp_( std::move(cmp) ) {
     }
     void addDaughter( const reco::Candidate & dau, std::string name ) {
       cmp_->addDaughter( dau, name );
     }
     template<typename S>
-    std::auto_ptr<reco::Candidate> operator[]( const S & setup ) {
+    std::unique_ptr<reco::Candidate> operator[]( const S & setup ) {
       setup.set( * cmp_ );
       return release();
     }
   private:
-    std::auto_ptr<reco::NamedCompositeCandidate> cmp_;
-    std::auto_ptr<reco::Candidate> release() {
-      std::auto_ptr<reco::Candidate> ret( cmp_.get() );
+    std::unique_ptr<reco::NamedCompositeCandidate> cmp_;
+    std::unique_ptr<reco::Candidate> release() {
+      std::unique_ptr<reco::Candidate> ret( cmp_.get() );
       cmp_.release();
-      return ret;
+      return std::move(ret);
     }
   };
 }
@@ -56,7 +56,7 @@ makeNamedCompositeCandidate( const typename C::const_iterator & begin,
 			     const std::vector<std::string>::const_iterator sbegin,
 			     const std::vector<std::string>::const_iterator send ) {
   helpers::NamedCompositeCandidateMaker 
-    cmp( std::auto_ptr<reco::NamedCompositeCandidate>( new reco::NamedCompositeCandidate ) );
+    cmp( std::unique_ptr<reco::NamedCompositeCandidate>( new reco::NamedCompositeCandidate ) );
   std::vector<std::string>::const_iterator si = sbegin;
   for( typename C::const_iterator i = begin; i != end && si != send; ++ i, ++si ) 
     cmp.addDaughter( * i, * si );
@@ -85,7 +85,7 @@ makeNamedCompositeCandidateWithRefsToMaster( const typename C::const_iterator & 
 			     const std::vector<std::string>::const_iterator sbegin,
 			     const std::vector<std::string>::const_iterator send ) {
   helpers::NamedCompositeCandidateMaker 
-    cmp( std::auto_ptr<reco::NamedCompositeCandidate>( new reco::NamedCompositeCandidate ) );
+    cmp( std::unique_ptr<reco::NamedCompositeCandidate>( new reco::NamedCompositeCandidate ) );
   std::vector<std::string>::const_iterator si = sbegin;
   for( typename C::const_iterator i = begin; i != end && si != send; ++ i, ++ si ) 
     cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( * i ) ), * si );

--- a/PhysicsTools/CandUtils/src/NamedCandCombinerBase.cc
+++ b/PhysicsTools/CandUtils/src/NamedCandCombinerBase.cc
@@ -52,7 +52,7 @@ void NamedCandCombinerBase::combine(NamedCompositeCandidate & cmp, const Candida
   setup(cmp);
 }
 
-auto_ptr<NamedCompositeCandidateCollection> 
+unique_ptr<NamedCompositeCandidateCollection> 
 NamedCandCombinerBase::combine(const vector<CandidatePtrVector> & src,
 			       string_coll const & names) const {
   size_t srcSize = src.size();
@@ -65,7 +65,7 @@ NamedCandCombinerBase::combine(const vector<CandidatePtrVector> & src,
     throw edm::Exception(edm::errors::Configuration)
       << "NamedCandCombiner: need to add 2 names, but size is " << names.size();
   
-  auto_ptr<NamedCompositeCandidateCollection> comps(new NamedCompositeCandidateCollection);
+  unique_ptr<NamedCompositeCandidateCollection> comps(new NamedCompositeCandidateCollection);
   if(srcSize == 2) {
     CandidatePtrVector src1 = src[0], src2 = src[1];
     if(src1 == src2) {
@@ -103,10 +103,10 @@ NamedCandCombinerBase::combine(const vector<CandidatePtrVector> & src,
     combine(0, stack, qStack, names, src.begin(), src.end(), comps);
   }
 
-  return comps;
+  return std::move(comps);
 }
 
-auto_ptr<NamedCompositeCandidateCollection> 
+unique_ptr<NamedCompositeCandidateCollection> 
 NamedCandCombinerBase::combine(const CandidatePtrVector & src, string_coll const & names) const {
   if(checkCharge_ && dauCharge_.size() != 2)
     throw edm::Exception(edm::errors::Configuration) 
@@ -117,7 +117,7 @@ NamedCandCombinerBase::combine(const CandidatePtrVector & src, string_coll const
     throw edm::Exception(edm::errors::Configuration)
       << "NamedCandCombiner: need to add 2 names, but size is " << names.size();
 
-  auto_ptr<NamedCompositeCandidateCollection> comps(new NamedCompositeCandidateCollection);
+  unique_ptr<NamedCompositeCandidateCollection> comps(new NamedCompositeCandidateCollection);
   const int n = src.size();
   for(int i1 = 0; i1 < n; ++i1) {
     const Candidate & c1 = *(src[i1]);
@@ -132,10 +132,10 @@ NamedCandCombinerBase::combine(const CandidatePtrVector & src, string_coll const
     } 
   }
 
-  return comps;
+  return std::move(comps);
 }
 
-auto_ptr<NamedCompositeCandidateCollection> 
+unique_ptr<NamedCompositeCandidateCollection> 
 NamedCandCombinerBase::combine(const CandidatePtrVector & src1, const CandidatePtrVector & src2, string_coll const & names) const {
   vector<CandidatePtrVector> src;
   src.push_back(src1);
@@ -143,7 +143,7 @@ NamedCandCombinerBase::combine(const CandidatePtrVector & src1, const CandidateP
   return combine(src, names);
 }
 
-auto_ptr<NamedCompositeCandidateCollection> 
+unique_ptr<NamedCompositeCandidateCollection> 
 NamedCandCombinerBase::combine(const CandidatePtrVector & src1, const CandidatePtrVector & src2, const CandidatePtrVector & src3, 
 			       string_coll const & names) const {
   vector<CandidatePtrVector> src;
@@ -153,7 +153,7 @@ NamedCandCombinerBase::combine(const CandidatePtrVector & src1, const CandidateP
   return combine(src, names);
 }
 
-auto_ptr<NamedCompositeCandidateCollection> 
+unique_ptr<NamedCompositeCandidateCollection> 
 NamedCandCombinerBase::combine(const CandidatePtrVector & src1, const CandidatePtrVector & src2, 
 			       const CandidatePtrVector & src3, const CandidatePtrVector & src4, 
 			       string_coll const & names) const {
@@ -169,7 +169,7 @@ void NamedCandCombinerBase::combine(size_t collectionIndex, CandStack & stack, C
 				    string_coll const & names,
 				    vector<CandidatePtrVector>::const_iterator collBegin,
 				    vector<CandidatePtrVector>::const_iterator collEnd,
-				    auto_ptr<NamedCompositeCandidateCollection> & comps) const {
+				    unique_ptr<NamedCompositeCandidateCollection> & comps) const {
   if(collBegin == collEnd) {
     static const int undetermined = 0, sameDecay = 1, conjDecay = -1, wrongDecay = 2;
     int decayType = undetermined;

--- a/PhysicsTools/CandUtils/src/cloneDecayTree.cc
+++ b/PhysicsTools/CandUtils/src/cloneDecayTree.cc
@@ -1,16 +1,18 @@
+#include <utility>
+
 #include "PhysicsTools/CandUtils/interface/cloneDecayTree.h"
 #include "DataFormats/Candidate/interface/CompositeCandidate.h"
 using namespace std;
 using namespace reco;
 
-auto_ptr<Candidate> cloneDecayTree(const Candidate & c) {
+unique_ptr<Candidate> cloneDecayTree(const Candidate & c) {
   size_t n = c.numberOfDaughters();
-  if (n == 1) return auto_ptr<Candidate>(c.clone());
+  if (n == 1) return unique_ptr<Candidate>(c.clone());
   // pass a particle, not a candidate, to avoid cloning daughters 
   const Candidate &p = c;
   CompositeCandidate * cmp(new CompositeCandidate(p));
-  auto_ptr<Candidate> cmpPtr(cmp);
+  unique_ptr<Candidate> cmpPtr(cmp);
   for(size_t i = 0; i < n; ++ i)
     cmp->addDaughter(cloneDecayTree(* c.daughter(i)));
-  return cmpPtr;
+  return std::move(cmpPtr);
 }

--- a/PhysicsTools/CandUtils/src/makeCompositeCandidate.cc
+++ b/PhysicsTools/CandUtils/src/makeCompositeCandidate.cc
@@ -1,9 +1,11 @@
+#include <utility>
+
 #include "PhysicsTools/CandUtils/interface/makeCompositeCandidate.h"
 using namespace reco;
 using namespace std;
 
 helpers::CompositeCandidateMaker makeCompositeCandidate( const Candidate & c1, const Candidate & c2 ) {
-  helpers::CompositeCandidateMaker cmp( auto_ptr<CompositeCandidate>( new CompositeCandidate ) );
+  helpers::CompositeCandidateMaker cmp( unique_ptr<CompositeCandidate>( new CompositeCandidate ) );
   cmp.addDaughter( c1 );
   cmp.addDaughter( c2 );
   return cmp;
@@ -11,7 +13,7 @@ helpers::CompositeCandidateMaker makeCompositeCandidate( const Candidate & c1, c
 
 helpers::CompositeCandidateMaker makeCompositeCandidate( const Candidate & c1, const Candidate & c2, 
 							 const Candidate & c3 ) {
-  helpers::CompositeCandidateMaker cmp( auto_ptr<CompositeCandidate>( new CompositeCandidate ) );
+  helpers::CompositeCandidateMaker cmp( unique_ptr<CompositeCandidate>( new CompositeCandidate ) );
   cmp.addDaughter( c1 );
   cmp.addDaughter( c2 );
   cmp.addDaughter( c3 );
@@ -20,7 +22,7 @@ helpers::CompositeCandidateMaker makeCompositeCandidate( const Candidate & c1, c
 
 helpers::CompositeCandidateMaker makeCompositeCandidate( const Candidate & c1, const Candidate & c2, 
 							 const Candidate & c3,const Candidate & c4 ) {
-  helpers::CompositeCandidateMaker cmp( auto_ptr<CompositeCandidate>( new CompositeCandidate ) );
+  helpers::CompositeCandidateMaker cmp( unique_ptr<CompositeCandidate>( new CompositeCandidate ) );
   cmp.addDaughter( c1 );
   cmp.addDaughter( c2 );
   cmp.addDaughter( c3 );
@@ -31,7 +33,7 @@ helpers::CompositeCandidateMaker makeCompositeCandidate( const Candidate & c1, c
 helpers::CompositeCandidateMaker 
 makeCompositeCandidateWithRefsToMaster( const reco::CandidateRef & c1, 
 					const reco::CandidateRef & c2 ) {
-  helpers::CompositeCandidateMaker cmp( auto_ptr<CompositeCandidate>( new CompositeCandidate ) );
+  helpers::CompositeCandidateMaker cmp( unique_ptr<CompositeCandidate>( new CompositeCandidate ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c1 ) ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c2 ) ) );
   return cmp;
@@ -41,7 +43,7 @@ helpers::CompositeCandidateMaker
 makeCompositeCandidateWithRefsToMaster( const reco::CandidateRef & c1, 
 					const reco::CandidateRef & c2,
 					const reco::CandidateRef & c3 ) {
-  helpers::CompositeCandidateMaker cmp( auto_ptr<CompositeCandidate>( new CompositeCandidate ) );
+  helpers::CompositeCandidateMaker cmp( unique_ptr<CompositeCandidate>( new CompositeCandidate ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c1 ) ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c2 ) ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c3 ) ) );
@@ -53,7 +55,7 @@ makeCompositeCandidateWithRefsToMaster( const reco::CandidateRef & c1,
 					const reco::CandidateRef & c2,
 					const reco::CandidateRef & c3,
 					const reco::CandidateRef & c4 ) {
-  helpers::CompositeCandidateMaker cmp( auto_ptr<CompositeCandidate>( new CompositeCandidate ) );
+  helpers::CompositeCandidateMaker cmp( unique_ptr<CompositeCandidate>( new CompositeCandidate ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c1 ) ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c2 ) ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c3 ) ) );

--- a/PhysicsTools/CandUtils/src/makeNamedCompositeCandidate.cc
+++ b/PhysicsTools/CandUtils/src/makeNamedCompositeCandidate.cc
@@ -1,10 +1,12 @@
+#include <utility>
+
 #include "PhysicsTools/CandUtils/interface/makeNamedCompositeCandidate.h"
 using namespace reco;
 using namespace std;
 
 helpers::NamedCompositeCandidateMaker makeNamedCompositeCandidate( const Candidate & c1 , std::string s1, 
 								   const Candidate & c2 , std::string s2 ) {
-  helpers::NamedCompositeCandidateMaker cmp( auto_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
+  helpers::NamedCompositeCandidateMaker cmp( unique_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
   cmp.addDaughter( c1, s1 );
   cmp.addDaughter( c2, s2 );
   return cmp;
@@ -13,7 +15,7 @@ helpers::NamedCompositeCandidateMaker makeNamedCompositeCandidate( const Candida
 helpers::NamedCompositeCandidateMaker makeNamedCompositeCandidate( const Candidate & c1, std::string s1,
 								   const Candidate & c2, std::string s2, 
 								   const Candidate & c3, std::string s3 ) {
-  helpers::NamedCompositeCandidateMaker cmp( auto_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
+  helpers::NamedCompositeCandidateMaker cmp( unique_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
   cmp.addDaughter( c1, s1 );
   cmp.addDaughter( c2, s2 );
   cmp.addDaughter( c3, s3 );
@@ -24,7 +26,7 @@ helpers::NamedCompositeCandidateMaker makeNamedCompositeCandidate( const Candida
 								   const Candidate & c2, std::string s2, 
 								   const Candidate & c3, std::string s3,
 								   const Candidate & c4, std::string s4  ) {
-  helpers::NamedCompositeCandidateMaker cmp( auto_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
+  helpers::NamedCompositeCandidateMaker cmp( unique_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
   cmp.addDaughter( c1, s1 );
   cmp.addDaughter( c2, s2 );
   cmp.addDaughter( c3, s3 );
@@ -35,7 +37,7 @@ helpers::NamedCompositeCandidateMaker makeNamedCompositeCandidate( const Candida
 helpers::NamedCompositeCandidateMaker 
 makeNamedCompositeCandidateWithRefsToMaster( const reco::CandidateRef & c1 , std::string s1, 
 					     const reco::CandidateRef & c2 , std::string s2 ) {
-  helpers::NamedCompositeCandidateMaker cmp( auto_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
+  helpers::NamedCompositeCandidateMaker cmp( unique_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c1 ) ), s1 );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c2 ) ), s2 );
   return cmp;
@@ -45,7 +47,7 @@ helpers::NamedCompositeCandidateMaker
 makeNamedCompositeCandidateWithRefsToMaster( const reco::CandidateRef & c1, std::string s1, 
 					     const reco::CandidateRef & c2, std::string s2,
 					     const reco::CandidateRef & c3, std::string s3 ) {
-  helpers::NamedCompositeCandidateMaker cmp( auto_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
+  helpers::NamedCompositeCandidateMaker cmp( unique_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c1 ) ), s1 );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c2 ) ), s2 );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c3 ) ), s3 );
@@ -57,7 +59,7 @@ makeNamedCompositeCandidateWithRefsToMaster( const reco::CandidateRef & c1, std:
 					     const reco::CandidateRef & c2, std::string s2,
 					     const reco::CandidateRef & c3, std::string s3,
 					     const reco::CandidateRef & c4, std::string s4  ) {
-  helpers::NamedCompositeCandidateMaker cmp( auto_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
+  helpers::NamedCompositeCandidateMaker cmp( unique_ptr<NamedCompositeCandidate>( new NamedCompositeCandidate ) );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c1 ) ), s1 );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c2 ) ), s2 );
   cmp.addDaughter( ShallowCloneCandidate( CandidateBaseRef( c3 ) ), s3 );

--- a/PhysicsTools/CandUtils/test/testMakeCompositeCandidate.cc
+++ b/PhysicsTools/CandUtils/test/testMakeCompositeCandidate.cc
@@ -1,4 +1,6 @@
 #include <cppunit/extensions/HelperMacros.h>
+
+#include <utility>
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
 #include "PhysicsTools/CandUtils/interface/makeCompositeCandidate.h"
 #include "PhysicsTools/CandUtils/interface/AddFourMomenta.h"
@@ -32,7 +34,7 @@ void testMakeCompositeCandidate::checkAll() {
   test::DummyCandidate t1( p1, q1 );
   test::DummyCandidate t2( p2, q2 );
 
-  auto_ptr<Candidate> cmp = makeCompositeCandidate( t1, t2 )[ AddFourMomenta() ];  
+  unique_ptr<Candidate> cmp = makeCompositeCandidate( t1, t2 )[ AddFourMomenta() ];  
   CPPUNIT_ASSERT( cmp->numberOfDaughters() == 2 );
   const reco::Candidate * d[ 2 ];
   d[ 0 ] = cmp->daughter( 0 );
@@ -48,6 +50,6 @@ void testMakeCompositeCandidate::checkAll() {
   CPPUNIT_ASSERT( fabs(d[1]->p4().phi() - p2.phi()) < epsilon );
 
 
-  auto_ptr<Candidate> cmp3 = makeCompositeCandidate( t1, t2, t1 )[ AddFourMomenta() ];  
-  auto_ptr<Candidate> cmp4 = makeCompositeCandidate( t1, t2, t1, t2 )[ AddFourMomenta() ];  
+  unique_ptr<Candidate> cmp3 = makeCompositeCandidate( t1, t2, t1 )[ AddFourMomenta() ];  
+  unique_ptr<Candidate> cmp4 = makeCompositeCandidate( t1, t2, t1, t2 )[ AddFourMomenta() ];  
 }

--- a/PhysicsTools/CondLiteIO/plugins/FWLiteESSource.cc
+++ b/PhysicsTools/CondLiteIO/plugins/FWLiteESSource.cc
@@ -127,7 +127,7 @@ private:
    virtual void delaySettingRecords() override;
    
    // ---------- member data --------------------------------
-   std::auto_ptr<TFile> m_file;
+   std::unique_ptr<TFile> m_file;
    fwlite::EventSetup m_es;
    std::map<edm::eventsetup::EventSetupRecordKey, fwlite::RecordID> m_keyToID;
    

--- a/PhysicsTools/MVAComputer/bin/mvaConvertTMVAWeights.cpp
+++ b/PhysicsTools/MVAComputer/bin/mvaConvertTMVAWeights.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 #include <cstddef>
 #include <cstring>
@@ -35,7 +36,7 @@ static std::size_t getStreamSize(std::ifstream &in)
 static Calibration::VarProcessor*
 getCalibration(const std::string &file, const std::vector<std::string> &names)
 {
-	std::auto_ptr<Calibration::ProcExternal> calib(
+	std::unique_ptr<Calibration::ProcExternal> calib(
 					new Calibration::ProcExternal);
 
 	std::ifstream in(file.c_str(), std::ios::binary | std::ios::in);
@@ -113,7 +114,7 @@ int main(int argc, char **argv)
 		names.push_back(argv[i]);
 
 	try {
-		std::auto_ptr<Calibration::VarProcessor> proc(
+		std::unique_ptr<Calibration::VarProcessor> proc(
 					getCalibration(argv[1], names));
 
 		BitSet inputVars(names.size());

--- a/PhysicsTools/MVAComputer/bin/mvaExtractPDFs.cpp
+++ b/PhysicsTools/MVAComputer/bin/mvaExtractPDFs.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 #include <map>
 

--- a/PhysicsTools/MVAComputer/interface/MVAComputer.h
+++ b/PhysicsTools/MVAComputer/interface/MVAComputer.h
@@ -121,13 +121,13 @@ class MVAComputer {
 			processor(processor), nOutput(nOutput) {}
 
 		inline Processor(const Processor &orig)
-		{ processor = orig.processor; nOutput = orig.nOutput; }
+		{ processor = std::move(orig.processor); nOutput = orig.nOutput; }
 
 		inline Processor &operator = (const Processor &orig)
-		{ processor = orig.processor; nOutput = orig.nOutput; return *this; }
+		{ processor = std::move(orig.processor); nOutput = orig.nOutput; return *this; }
 
 		/// owned variable processor instance
-		mutable std::auto_ptr<VarProcessor>	processor;
+		mutable std::unique_ptr<VarProcessor>	processor;
 
 		/// number of output variables
 		unsigned int				nOutput;
@@ -199,7 +199,7 @@ class MVAComputer {
 	unsigned int		output;
 
 	/// in case calibration object is owned by the MVAComputer
-	std::auto_ptr<Calibration::MVAComputer> owned;
+	std::unique_ptr<Calibration::MVAComputer> owned;
 };
 
 } // namespace PhysicsTools

--- a/PhysicsTools/MVAComputer/interface/MVAComputerCache.h
+++ b/PhysicsTools/MVAComputer/interface/MVAComputerCache.h
@@ -78,14 +78,14 @@ class MVAComputerCache {
 	MVAComputer *get() { return computer.get(); }
 	const MVAComputer *get() const { return computer.get(); }
 
-	std::auto_ptr<MVAComputer> release();
+	std::unique_ptr<MVAComputer> release();
 
 	void reset() { computer.reset(); }
 
     private:
 	Calibration::MVAComputerContainer::CacheId	containerCacheId;
 	Calibration::MVAComputer::CacheId		computerCacheId;
-	std::auto_ptr<MVAComputer>			computer;
+	std::unique_ptr<MVAComputer>			computer;
 };
 
 } // namespace PhysicsTools

--- a/PhysicsTools/MVAComputer/plugins/module.cc
+++ b/PhysicsTools/MVAComputer/plugins/module.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/SourceFactory.h"
 

--- a/PhysicsTools/MVAComputer/src/MVAComputer.cc
+++ b/PhysicsTools/MVAComputer/src/MVAComputer.cc
@@ -5,6 +5,7 @@
 #include <iterator>
 #include <cstddef>
 #include <cstring>
+#include <utility>
 #include <vector>
 #include <set>
 
@@ -266,7 +267,7 @@ Calibration::MVAComputer *MVAComputer::readCalibration(std::istream &is)
 			static_cast<const void*>(buf.c_str())), kFALSE);
 	buffer.InitMap();
 
-	std::auto_ptr<Calibration::MVAComputer> calib(
+	std::unique_ptr<Calibration::MVAComputer> calib(
 					new Calibration::MVAComputer());
 	buffer.StreamObject(static_cast<void*>(calib.get()), rootClass);
 

--- a/PhysicsTools/MVAComputer/src/MVAComputerCache.cc
+++ b/PhysicsTools/MVAComputer/src/MVAComputerCache.cc
@@ -1,4 +1,5 @@
 #include <memory>
+#include <utility>
 
 #include "PhysicsTools/MVAComputer/interface/Calibration.h"
 #include "PhysicsTools/MVAComputer/interface/MVAComputer.h"
@@ -59,11 +60,11 @@ bool MVAComputerCache::update(
 	return true;
 }
 
-std::auto_ptr<MVAComputer> MVAComputerCache::release()
+std::unique_ptr<MVAComputer> MVAComputerCache::release()
 {
 	computerCacheId = Calibration::MVAComputer::CacheId();
 	containerCacheId = Calibration::MVAComputerContainer::CacheId();
-	return computer;
+	return std::move(computer);
 }
 
 } // namespace PhysicsTools

--- a/PhysicsTools/MVAComputer/src/MVAComputerESSourceBase.cc
+++ b/PhysicsTools/MVAComputer/src/MVAComputerESSourceBase.cc
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <string>
 #include <memory>
+#include <utility>
 #include <vector>
 #include <map>
 
@@ -48,7 +49,7 @@ MVAComputerESSourceBase::produce() const
 
 	for(LabelFileMap::const_iterator iter = mvaCalibrations.begin();
 	    iter != mvaCalibrations.end(); iter++) {
-		std::auto_ptr<Calibration::MVAComputer> calibration(
+		std::unique_ptr<Calibration::MVAComputer> calibration(
 			MVAComputer::readCalibration(iter->second.c_str()));
 
 		container->add(iter->first) = *calibration;

--- a/PhysicsTools/MVAComputer/src/ProcLikelihood.cc
+++ b/PhysicsTools/MVAComputer/src/ProcLikelihood.cc
@@ -84,14 +84,14 @@ class ProcLikelihood : public VarProcessor {
 		SigBkg(const Calibration::ProcLikelihood::SigBkg &calib)
 		{
 			if (calib.useSplines) {
-				signal = std::auto_ptr<PDF>(
+				signal = std::unique_ptr<PDF>(
 					new SplinePDF(&calib.signal));
-				background = std::auto_ptr<PDF>(
+				background = std::unique_ptr<PDF>(
 					new SplinePDF(&calib.background));
 			} else {
-				signal = std::auto_ptr<PDF>(
+				signal = std::unique_ptr<PDF>(
 					new HistogramPDF(&calib.signal));
-				background = std::auto_ptr<PDF>(
+				background = std::unique_ptr<PDF>(
 					new HistogramPDF(&calib.background));
 			}
 			double norm = (calib.signal.numberOfBins() +
@@ -100,8 +100,8 @@ class ProcLikelihood : public VarProcessor {
 			background->norm = norm;
 		}
 
-		std::auto_ptr<PDF>	signal;
-		std::auto_ptr<PDF>	background;
+		std::unique_ptr<PDF>	signal;
+		std::unique_ptr<PDF>	background;
 	};
 
 	int findPDFs(ValueIterator iter, unsigned int n,

--- a/PhysicsTools/MVAComputer/test/testMVAComputer.cppunit.cc
+++ b/PhysicsTools/MVAComputer/test/testMVAComputer.cppunit.cc
@@ -240,3 +240,4 @@ testMVAComputer::foreachTest()
 }
 
 #include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
+#include <utility>

--- a/PhysicsTools/MVAComputer/test/testMVAComputerEvaluate.cc
+++ b/PhysicsTools/MVAComputer/test/testMVAComputerEvaluate.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <utility>
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"

--- a/PhysicsTools/MVAComputer/test/testReadMVAComputerCondDB.cc
+++ b/PhysicsTools/MVAComputer/test/testReadMVAComputerCondDB.cc
@@ -1,6 +1,7 @@
 #include <sys/time.h>
 #include <stdint.h>
 #include <iostream>
+#include <utility>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"

--- a/PhysicsTools/MVAComputer/test/testWriteMVAComputerCondDB.cc
+++ b/PhysicsTools/MVAComputer/test/testWriteMVAComputerCondDB.cc
@@ -7,6 +7,7 @@
 // ***************************************************************************
 
 #include <iostream>
+#include <utility>
 #include <vector>
 #include <iterator>
 #include <algorithm>

--- a/PhysicsTools/MVATrainer/bin/mvaTreeComputer.cpp
+++ b/PhysicsTools/MVATrainer/bin/mvaTreeComputer.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <string>
 #include <memory>
+#include <utility>
 
 #include <TString.h>
 #include <TBranch.h>

--- a/PhysicsTools/MVATrainer/bin/mvaTreeTrainer.cpp
+++ b/PhysicsTools/MVATrainer/bin/mvaTreeTrainer.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <string>
 #include <memory>
+#include <utility>
 
 #include <TString.h>
 #include <TFile.h>

--- a/PhysicsTools/MVATrainer/plugins/ProcMLP.cc
+++ b/PhysicsTools/MVATrainer/plugins/ProcMLP.cc
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <cstddef>
 #include <cstring>
+#include <utility>
 #include <vector>
 #include <memory>
 #include <cmath>
@@ -63,7 +64,7 @@ class ProcMLP : public TrainProcessor {
 	unsigned int		steps;
 	unsigned int		count, row;
 	double			weightSum;
-	std::auto_ptr<MLP>	mlp;
+	std::unique_ptr<MLP>	mlp;
 	std::vector<double>	vars;
 	std::vector<double>	targets;
 	bool			needCleanup;
@@ -148,7 +149,7 @@ Calibration::VarProcessor *ProcMLP::getCalibration() const
 {
 	Calibration::ProcMLP *calib = new Calibration::ProcMLP;
 
-	std::auto_ptr<MLP> mlp(new MLP(getInputs().size() - (boost >= 0 ? 1 : 0),
+	std::unique_ptr<MLP> mlp(new MLP(getInputs().size() - (boost >= 0 ? 1 : 0),
 	                               getOutputs().size(), layout));
 	mlp->load(trainer->trainFileName(this, "txt"));
 
@@ -207,7 +208,7 @@ void ProcMLP::trainBegin()
 		break;
 	    case ITER_TRAIN:
 		try {
-			mlp = std::auto_ptr<MLP>(
+			mlp = std::unique_ptr<MLP>(
 					new MLP(getInputs().size() - (boost >= 0 ? 1 : 0),
 					getOutputs().size(), layout));
 			mlp->init(count);

--- a/PhysicsTools/MVATrainer/plugins/ProcTMVA.cc
+++ b/PhysicsTools/MVATrainer/plugins/ProcTMVA.cc
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstring>
 #include <cstdio>
+#include <utility>
 #include <vector>
 #include <memory>
 
@@ -92,7 +93,7 @@ class ProcTMVA : public TrainProcessor {
 
 	std::vector<Method>		methods;
 	std::vector<std::string>	names;
-	std::auto_ptr<TFile>		file;
+	std::unique_ptr<TFile>		file;
 	TTree				*treeSig, *treeBkg;
 	Double_t			weight;
 	std::vector<Double_t>		vars;
@@ -271,7 +272,7 @@ void ProcTMVA::trainBegin()
 	if (iteration == ITER_EXPORT) {
 		ROOTContextSentinel ctx;
 
-		file = std::auto_ptr<TFile>(TFile::Open(
+		file = std::unique_ptr<TFile>(TFile::Open(
 			trainer->trainFileName(this, "root",
 			                       "input").c_str(),
 			"RECREATE"));
@@ -333,7 +334,7 @@ void ProcTMVA::runTMVATrainer()
 			   "No signal (" << nSignal << ") or background ("
 			<< nBackground << ") events!" << std::endl;
 
-	std::auto_ptr<TFile> file(TFile::Open(
+	std::unique_ptr<TFile> file(TFile::Open(
 		trainer->trainFileName(this, "root", "output").c_str(),
 		"RECREATE"));
 	if (!file.get())
@@ -391,7 +392,7 @@ void ProcTMVA::trainEnd()
 
 			file->Close();
 			file.reset();
-			file = std::auto_ptr<TFile>(TFile::Open(
+			file = std::unique_ptr<TFile>(TFile::Open(
 				trainer->trainFileName(this, "root",
 				                       "input").c_str()));
 			if (!file.get())

--- a/PhysicsTools/MVATrainer/plugins/module.cc
+++ b/PhysicsTools/MVATrainer/plugins/module.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/LooperFactory.h"
 #include "PhysicsTools/MVAComputer/interface/MVAComputerRecord.h"

--- a/PhysicsTools/MVATrainer/src/MVATrainer.cc
+++ b/PhysicsTools/MVATrainer/src/MVATrainer.cc
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <cstdio>
 #include <string>
+#include <utility>
 #include <vector>
 #include <memory>
 #include <map>

--- a/PhysicsTools/MVATrainer/src/MVATrainerContainerSave.cc
+++ b/PhysicsTools/MVATrainer/src/MVATrainerContainerSave.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <memory>
+#include <utility>
 #include <vector>
 #include <string>
 

--- a/PhysicsTools/MVATrainer/src/MVATrainerFileSave.cc
+++ b/PhysicsTools/MVATrainer/src/MVATrainerFileSave.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <memory>
+#include <utility>
 #include <vector>
 #include <string>
 

--- a/PhysicsTools/MVATrainer/src/MVATrainerLooper.cc
+++ b/PhysicsTools/MVATrainer/src/MVATrainerLooper.cc
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <string>
 #include <memory>
+#include <utility>
 
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/EDMException.h"

--- a/PhysicsTools/MVATrainer/src/MVATrainerSave.cc
+++ b/PhysicsTools/MVATrainer/src/MVATrainerSave.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <memory>
+#include <utility>
 #include <vector>
 #include <string>
 

--- a/PhysicsTools/MVATrainer/src/ProcCategory.cc
+++ b/PhysicsTools/MVATrainer/src/ProcCategory.cc
@@ -2,6 +2,7 @@
 #include <iterator>
 #include <iostream>
 #include <cstring>
+#include <utility>
 #include <vector>
 #include <string>
 #include <set>

--- a/PhysicsTools/MVATrainer/src/ProcClassed.cc
+++ b/PhysicsTools/MVATrainer/src/ProcClassed.cc
@@ -2,6 +2,7 @@
 #include <iterator>
 #include <iostream>
 #include <cstring>
+#include <utility>
 #include <vector>
 #include <string>
 #include <set>

--- a/PhysicsTools/MVATrainer/src/ProcCount.cc
+++ b/PhysicsTools/MVATrainer/src/ProcCount.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <utility>
 #include <vector>
 #include <string>
 

--- a/PhysicsTools/MVATrainer/src/ProcForeach.cc
+++ b/PhysicsTools/MVATrainer/src/ProcForeach.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <utility>
 #include <vector>
 #include <string>
 

--- a/PhysicsTools/MVATrainer/src/ProcLikelihood.cc
+++ b/PhysicsTools/MVATrainer/src/ProcLikelihood.cc
@@ -3,6 +3,7 @@
 #include <numeric>
 #include <iomanip>
 #include <cstring>
+#include <utility>
 #include <vector>
 #include <string>
 #include <memory>

--- a/PhysicsTools/MVATrainer/src/ProcLinear.cc
+++ b/PhysicsTools/MVATrainer/src/ProcLinear.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <utility>
 #include <vector>
 #include <memory>
 

--- a/PhysicsTools/MVATrainer/src/ProcMatrix.cc
+++ b/PhysicsTools/MVATrainer/src/ProcMatrix.cc
@@ -1,4 +1,5 @@
 #include <cstring>
+#include <utility>
 #include <vector>
 #include <memory>
 

--- a/PhysicsTools/MVATrainer/src/ProcMultiply.cc
+++ b/PhysicsTools/MVATrainer/src/ProcMultiply.cc
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <iostream>
 #include <cstring>
+#include <utility>
 #include <vector>
 #include <string>
 #include <set>

--- a/PhysicsTools/MVATrainer/src/ProcNormalize.cc
+++ b/PhysicsTools/MVATrainer/src/ProcNormalize.cc
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <iomanip>
 #include <cstring>
+#include <utility>
 #include <vector>
 #include <string>
 #include <memory>

--- a/PhysicsTools/MVATrainer/src/ProcOptional.cc
+++ b/PhysicsTools/MVATrainer/src/ProcOptional.cc
@@ -2,6 +2,7 @@
 #include <iterator>
 #include <iostream>
 #include <cstring>
+#include <utility>
 #include <vector>
 #include <string>
 

--- a/PhysicsTools/MVATrainer/src/ProcSort.cc
+++ b/PhysicsTools/MVATrainer/src/ProcSort.cc
@@ -2,6 +2,7 @@
 #include <iterator>
 #include <iostream>
 #include <cstring>
+#include <utility>
 #include <vector>
 #include <string>
 #include <set>

--- a/PhysicsTools/MVATrainer/src/ProcSplitter.cc
+++ b/PhysicsTools/MVATrainer/src/ProcSplitter.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <utility>
 #include <vector>
 #include <string>
 

--- a/PhysicsTools/MVATrainer/src/TrainProcessor.cc
+++ b/PhysicsTools/MVATrainer/src/TrainProcessor.cc
@@ -1,5 +1,6 @@
 #include <limits>
 #include <string>
+#include <utility>
 
 #include <TH1.h>
 

--- a/PhysicsTools/MVATrainer/src/TreeSaver.cc
+++ b/PhysicsTools/MVATrainer/src/TreeSaver.cc
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstring>
 #include <cstdio>
+#include <utility>
 #include <vector>
 #include <memory>
 

--- a/PhysicsTools/MVATrainer/src/TreeTrainer.cc
+++ b/PhysicsTools/MVATrainer/src/TreeTrainer.cc
@@ -1,6 +1,7 @@
 #include <functional>
 #include <algorithm>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <TString.h>

--- a/PhysicsTools/MVATrainer/test/testMVATrainer.cpp
+++ b/PhysicsTools/MVATrainer/test/testMVATrainer.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <fstream>
 #include <memory>
+#include <utility>
 #include <vector>
 #include <string>
 #include <cstdlib>

--- a/PhysicsTools/MVATrainer/test/testMVATrainerLooper.cc
+++ b/PhysicsTools/MVATrainer/test/testMVATrainerLooper.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <memory>
+#include <utility>
 
 #include <TRandom.h>
 

--- a/PhysicsTools/Utilities/interface/Expression.h
+++ b/PhysicsTools/Utilities/interface/Expression.h
@@ -33,7 +33,7 @@ namespace funct {
    inline double operator()() const { return (*_f)(); }
    inline std::ostream& print(std::ostream& cout) const { return _f->print(cout); }
  private:
-   std::auto_ptr<AbsExpression> _f;
+   std::unique_ptr<AbsExpression> _f;
  };
 
  inline std::ostream& operator<<(std::ostream& cout, const Expression& e) { 
@@ -64,7 +64,7 @@ namespace funct {
    inline FunctExpression& operator=(const FunctExpression& e) { _f.reset(e._f->clone()); return *this; }
    inline double operator()(double x) const { return (*_f)(x); }
  private:
-   std::auto_ptr<AbsFunctExpression> _f;
+   std::unique_ptr<AbsFunctExpression> _f;
  };
 
 }

--- a/PhysicsTools/Utilities/interface/NumericalIntegration.h
+++ b/PhysicsTools/Utilities/interface/NumericalIntegration.h
@@ -146,7 +146,7 @@ namespace funct {
     ROOT::Math::IntegrationOneDim::Type type_;
     double absTol_, relTol_;
     unsigned int size_, rule_;
-    mutable std::auto_ptr<ROOT::Math::Integrator> integrator_;
+    mutable std::unique_ptr<ROOT::Math::Integrator> integrator_;
   };    
 }
 

--- a/PhysicsTools/Utilities/interface/RootMinuit.h
+++ b/PhysicsTools/Utilities/interface/RootMinuit.h
@@ -181,7 +181,7 @@ namespace fit {
     std::map<std::string, size_t> parIndices_;
     bool initialized_;
     double minValue_;
-    std::auto_ptr<TMinuit> minuit_;
+    std::unique_ptr<TMinuit> minuit_;
     std::vector<boost::shared_ptr<double> > pars_;
     static std::vector<boost::shared_ptr<double> > *fPars_;
     bool verbose_;

--- a/RecoBTag/ImpactParameter/plugins/IPProducer.h
+++ b/RecoBTag/ImpactParameter/plugins/IPProducer.h
@@ -151,7 +151,7 @@ class IPProducer : public edm::stream::EDProducer<> {
     bool m_computeProbabilities;
     bool m_computeGhostTrack;
     double m_ghostTrackPriorDeltaR;
-    std::auto_ptr<HistogramProbabilityEstimator> m_probabilityEstimator;
+    std::unique_ptr<HistogramProbabilityEstimator> m_probabilityEstimator;
     unsigned long long  m_calibrationCacheId2D; 
     unsigned long long  m_calibrationCacheId3D;
     bool m_useDB;
@@ -310,7 +310,7 @@ IPProducer<Container,Base,Helper>::produce(edm::Event& iEvent, const edm::EventS
 //	std::cout <<"SIZE: " << transientTracks.size() << std::endl;
      GlobalVector direction(jetMomentum.x(), jetMomentum.y(), jetMomentum.z());
 
-     std::auto_ptr<reco::GhostTrack> ghostTrack;
+     std::unique_ptr<reco::GhostTrack> ghostTrack;
      reco::TrackRef ghostTrackRef;
      if (m_computeGhostTrack) {
        reco::GhostTrackFitter fitter;

--- a/RecoBTag/PerformanceDB/plugins/BTagPerformaceRootProducerFromSQLITE.cc
+++ b/RecoBTag/PerformanceDB/plugins/BTagPerformaceRootProducerFromSQLITE.cc
@@ -64,7 +64,7 @@ class BTagPerformaceRootProducerFromSQLITE : public edm::EDAnalyzer {
       // ----------member data ---------------------------
   std::vector<std::string>  names_;
   edm::ESWatcher<BTagPerformanceRecord> recWatcher_;
-  std::auto_ptr<fwlite::RecordWriter> writer_;
+  std::unique_ptr<fwlite::RecordWriter> writer_;
   edm::IOVSyncValue lastValue_;
 };
 
@@ -106,7 +106,7 @@ BTagPerformaceRootProducerFromSQLITE::analyze(const edm::Event& iEvent, const ed
     if(! writer_.get()) {
       edm::Service<TFileService> fs ;
       TFile * f = &(fs->file());
-      writer_ = std::auto_ptr<fwlite::RecordWriter>(new fwlite::RecordWriter(r.key().name(), f ));
+      writer_ = std::unique_ptr<fwlite::RecordWriter>(new fwlite::RecordWriter(r.key().name(), f ));
     }
     lastValue_ = r.validityInterval().last();
 

--- a/RecoBTag/SecondaryVertex/plugins/JetTagESProducers.cc
+++ b/RecoBTag/SecondaryVertex/plugins/JetTagESProducers.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -640,8 +640,8 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 	}
 	// ------------------------------------ SV clustering END ----------------------------------------------
 
-	std::auto_ptr<ConfigurableVertexReconstructor> vertexReco;
-	std::auto_ptr<GhostTrackVertexFinder> vertexRecoGT;
+	std::unique_ptr<ConfigurableVertexReconstructor> vertexReco;
+	std::unique_ptr<GhostTrackVertexFinder> vertexRecoGT;
 	if (useGhostTrack)
 		vertexRecoGT.reset(new GhostTrackVertexFinder(
 			vtxRecoPSet.getParameter<double>("maxFitChi2"),
@@ -706,7 +706,7 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 
 		std::vector<TransientTrack> fitTracks;
 		std::vector<GhostTrackState> gtStates;
-		std::auto_ptr<GhostTrackPrediction> gtPred;
+		std::unique_ptr<GhostTrackPrediction> gtPred;
 		if (useGhostTrack)
 			gtPred.reset(new GhostTrackPrediction(
 						*iterJets->ghostTrack()));
@@ -753,7 +753,7 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 			}
 		}
 
-		std::auto_ptr<GhostTrack> ghostTrack;
+		std::unique_ptr<GhostTrack> ghostTrack;
 		if (useGhostTrack)
 			ghostTrack.reset(new GhostTrack(
 				GhostTrackPrediction(

--- a/RecoBTau/JetTagComputer/interface/GenericMVAComputerCache.h
+++ b/RecoBTau/JetTagComputer/interface/GenericMVAComputerCache.h
@@ -28,7 +28,7 @@ class GenericMVAComputerCache {
 		~IndividualComputer();
 
 		std::string						label;
-		std::auto_ptr<GenericMVAComputer>			computer;
+		std::unique_ptr<GenericMVAComputer>			computer;
 		PhysicsTools::Calibration::MVAComputer::CacheId		cacheId;
 	};
 

--- a/RecoBTau/JetTagComputer/interface/GenericMVAJetTagComputer.h
+++ b/RecoBTau/JetTagComputer/interface/GenericMVAJetTagComputer.h
@@ -28,7 +28,7 @@ class GenericMVAJetTagComputer : public JetTagComputer {
 	taggingVariables(const TagInfoHelper &info) const;
 
     private:
-	std::auto_ptr<TagInfoMVACategorySelector> categorySelector_;
+	std::unique_ptr<TagInfoMVACategorySelector> categorySelector_;
 	GenericMVAComputerCache computerCache_;
         std::string recordLabel_;
 };

--- a/RecoBTau/JetTagComputer/plugins/GenericMVAJetTagESProducer.cc
+++ b/RecoBTau/JetTagComputer/plugins/GenericMVAJetTagESProducer.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "FWCore/Framework/interface/ModuleFactory.h"
 
 #include "RecoBTau/JetTagComputer/interface/JetTagComputerESProducer.h"

--- a/RecoBTau/JetTagComputer/src/GenericMVAComputer.cc
+++ b/RecoBTau/JetTagComputer/src/GenericMVAComputer.cc
@@ -1,3 +1,4 @@
+#include <utility>
 #include <vector>
 
 #include "DataFormats/BTauReco/interface/TaggingVariable.h"

--- a/RecoBTau/JetTagComputer/src/GenericMVAComputerCache.cc
+++ b/RecoBTau/JetTagComputer/src/GenericMVAComputerCache.cc
@@ -1,4 +1,5 @@
 #include <string>
+#include <utility>
 #include <vector>
 #include <memory>
 
@@ -107,7 +108,7 @@ bool GenericMVAComputerCache::update(const MVAComputerContainer *calib)
 			continue;
 
 		// instantiate new MVAComputer with uptodate calibration
-		iter->computer = std::auto_ptr<GenericMVAComputer>(
+		iter->computer = std::unique_ptr<GenericMVAComputer>(
 					new GenericMVAComputer(computerCalib));
 
 		iter->cacheId = computerCalib->getCacheId();

--- a/RecoBTau/JetTagComputer/src/GenericMVAJetTagComputer.cc
+++ b/RecoBTau/JetTagComputer/src/GenericMVAJetTagComputer.cc
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <string>
 #include <memory>
+#include <utility>
 
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -20,10 +21,10 @@ using namespace PhysicsTools;
 
 static std::vector<std::string>
 getCalibrationLabels(const edm::ParameterSet &params,
-                     std::auto_ptr<TagInfoMVACategorySelector> &selector)
+                     std::unique_ptr<TagInfoMVACategorySelector> &selector)
 {
 	if (params.getParameter<bool>("useCategories")) {
-		selector = std::auto_ptr<TagInfoMVACategorySelector>(
+		selector = std::unique_ptr<TagInfoMVACategorySelector>(
 				new TagInfoMVACategorySelector(params));
 
 		return selector->getCategoryLabels();

--- a/RecoEgamma/EgammaTools/plugins/PhotonConversionMVAComputerCondUtilities.cc
+++ b/RecoEgamma/EgammaTools/plugins/PhotonConversionMVAComputerCondUtilities.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/SourceFactory.h"
 

--- a/RecoJets/FFTJetAlgorithms/interface/LinInterpolatedTable1D.h
+++ b/RecoJets/FFTJetAlgorithms/interface/LinInterpolatedTable1D.h
@@ -82,7 +82,7 @@ namespace fftjetcms {
         // refer to the inverted table (note that left and right will
         // exchange places if the original table is decreasing).
         //
-        std::auto_ptr<LinInterpolatedTable1D> inverse(
+        std::unique_ptr<LinInterpolatedTable1D> inverse(
             unsigned npoints, bool leftExtrapolationLinear,
             bool rightExtrapolationLinear) const;
 

--- a/RecoJets/FFTJetAlgorithms/src/LinInterpolatedTable1D.cc
+++ b/RecoJets/FFTJetAlgorithms/src/LinInterpolatedTable1D.cc
@@ -43,12 +43,12 @@ namespace fftjetcms {
         return monotonous_;
     }
 
-    std::auto_ptr<LinInterpolatedTable1D> LinInterpolatedTable1D::inverse(
+    std::unique_ptr<LinInterpolatedTable1D> LinInterpolatedTable1D::inverse(
         const unsigned npoints, const bool leftExtrapolationLinear,
         const bool rightExtrapolationLinear) const
     {
         if (!isMonotonous())
-            return std::auto_ptr<LinInterpolatedTable1D>(NULL);
+            return std::unique_ptr<LinInterpolatedTable1D>(NULL);
 
         std::vector<std::pair<double,double> > points;
         points.reserve(npoints_);
@@ -68,7 +68,7 @@ namespace fftjetcms {
             points.push_back(std::pair<double,double>(data_[0], xmin_));
         }
 
-        return std::auto_ptr<LinInterpolatedTable1D>(
+        return std::unique_ptr<LinInterpolatedTable1D>(
             new LinInterpolatedTable1D(points, npoints,
                                        leftExtrapolationLinear,
                                        rightExtrapolationLinear));

--- a/RecoJets/FFTJetProducers/interface/FFTJetInterface.h
+++ b/RecoJets/FFTJetProducers/interface/FFTJetInterface.h
@@ -99,7 +99,7 @@ namespace fftjetcms {
     std::vector<unsigned> candidateIndex;
 
     // The energy discretization grid
-    std::auto_ptr<fftjet::Grid2d<fftjetcms::Real> > energyFlow;
+    std::unique_ptr<fftjet::Grid2d<fftjetcms::Real> > energyFlow;
 
     // The input handle for the collection of candidates
     edm::Handle<reco::CandidateView> inputCollection;

--- a/RecoJets/FFTJetProducers/interface/FFTJetParameterParser.h
+++ b/RecoJets/FFTJetProducers/interface/FFTJetParameterParser.h
@@ -24,57 +24,57 @@
 namespace fftjetcms {
     // Pseudo-constructors for various FFTJet classes using ParameterSet
     // objects as arguments
-    std::auto_ptr<fftjet::Grid2d<Real> >
+    std::unique_ptr<fftjet::Grid2d<Real> >
     fftjet_Grid2d_parser(const edm::ParameterSet& ps);
 
-    std::auto_ptr<fftjet::Functor1<bool,fftjet::Peak> >
+    std::unique_ptr<fftjet::Functor1<bool,fftjet::Peak> >
     fftjet_PeakSelector_parser(const edm::ParameterSet& ps);
 
-    std::auto_ptr<fftjet::ScaleSpaceKernel>
+    std::unique_ptr<fftjet::ScaleSpaceKernel>
     fftjet_MembershipFunction_parser(const edm::ParameterSet& ps);
 
-    std::auto_ptr<AbsBgFunctor>
+    std::unique_ptr<AbsBgFunctor>
     fftjet_BgFunctor_parser(const edm::ParameterSet& ps);
 
-    std::auto_ptr<std::vector<double> >
+    std::unique_ptr<std::vector<double> >
     fftjet_ScaleSet_parser(const edm::ParameterSet& ps);
 
-    std::auto_ptr<fftjet::ClusteringTreeSparsifier<fftjet::Peak,long> >
+    std::unique_ptr<fftjet::ClusteringTreeSparsifier<fftjet::Peak,long> >
     fftjet_ClusteringTreeSparsifier_parser(const edm::ParameterSet& ps);
 
-    std::auto_ptr<fftjet::AbsDistanceCalculator<fftjet::Peak> >
+    std::unique_ptr<fftjet::AbsDistanceCalculator<fftjet::Peak> >
     fftjet_DistanceCalculator_parser(const edm::ParameterSet& ps);
 
-    std::auto_ptr<fftjet::LinearInterpolator1d>
+    std::unique_ptr<fftjet::LinearInterpolator1d>
     fftjet_LinearInterpolator1d_parser(const edm::ParameterSet& ps);
 
-    std::auto_ptr<fftjet::LinearInterpolator2d>
+    std::unique_ptr<fftjet::LinearInterpolator2d>
     fftjet_LinearInterpolator2d_parser(const edm::ParameterSet& ps);
 
-    std::auto_ptr<fftjetcms::LinInterpolatedTable1D>
+    std::unique_ptr<fftjetcms::LinInterpolatedTable1D>
     fftjet_LinInterpolatedTable1D_parser(const edm::ParameterSet& ps);
 
-    std::auto_ptr<fftjet::Functor1<double,fftjet::Peak> >
+    std::unique_ptr<fftjet::Functor1<double,fftjet::Peak> >
     fftjet_PeakFunctor_parser(const edm::ParameterSet& ps);
 
-    std::auto_ptr<fftjet::Functor1<double,fftjet::RecombinedJet<VectorLike> > >
+    std::unique_ptr<fftjet::Functor1<double,fftjet::RecombinedJet<VectorLike> > >
     fftjet_JetFunctor_parser(const edm::ParameterSet& ps);
 
-    std::auto_ptr<fftjet::Functor2<double,
+    std::unique_ptr<fftjet::Functor2<double,
                                    fftjet::RecombinedJet<VectorLike>,
                                    fftjet::RecombinedJet<VectorLike> > >
     fftjet_JetDistance_parser(const edm::ParameterSet& ps);
 
-    std::auto_ptr<fftjet::Functor1<double,double> >
+    std::unique_ptr<fftjet::Functor1<double,double> >
     fftjet_Function_parser(const edm::ParameterSet& ps);
 
-    std::auto_ptr<AbsPileupCalculator>
+    std::unique_ptr<AbsPileupCalculator>
     fftjet_PileupCalculator_parser(const edm::ParameterSet& ps);
 
-    std::auto_ptr<fftjet::JetMagnitudeMapper2d<fftjet::Peak> >
+    std::unique_ptr<fftjet::JetMagnitudeMapper2d<fftjet::Peak> >
     fftjet_PeakMagnitudeMapper2d_parser(const edm::ParameterSet& ps);
 
-    std::auto_ptr<fftjet::JetMagnitudeMapper2d<fftjet::RecombinedJet<VectorLike> > >
+    std::unique_ptr<fftjet::JetMagnitudeMapper2d<fftjet::RecombinedJet<VectorLike> > >
     fftjet_JetMagnitudeMapper2d_parser(const edm::ParameterSet& ps);
 }
 

--- a/RecoJets/FFTJetProducers/plugins/FFTJetDijetFilter.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetDijetFilter.cc
@@ -95,10 +95,10 @@ private:
     bool insertCompleteEvent;
 
     // Distance calculator for the clustering tree
-    std::auto_ptr<fftjet::AbsDistanceCalculator<fftjet::Peak> > distanceCalc;
+    std::unique_ptr<fftjet::AbsDistanceCalculator<fftjet::Peak> > distanceCalc;
 
     // Scales used
-    std::auto_ptr<std::vector<double> > iniScales;
+    std::unique_ptr<std::vector<double> > iniScales;
 
     // The clustering trees
     ClusteringTree* clusteringTree;

--- a/RecoJets/FFTJetProducers/plugins/FFTJetEFlowSmoother.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetEFlowSmoother.cc
@@ -67,22 +67,22 @@ private:
     void buildKernelConvolver(const edm::ParameterSet&);
 
     // Storage for convolved energy flow
-    std::auto_ptr<fftjet::Grid2d<fftjetcms::Real> > convolvedFlow;
+    std::unique_ptr<fftjet::Grid2d<fftjetcms::Real> > convolvedFlow;
 
     // Filtering scales
-    std::auto_ptr<std::vector<double> > iniScales;
+    std::unique_ptr<std::vector<double> > iniScales;
 
     // The FFT engine(s)
-    std::auto_ptr<MyFFTEngine> engine;
-    std::auto_ptr<MyFFTEngine> anotherEngine;
+    std::unique_ptr<MyFFTEngine> engine;
+    std::unique_ptr<MyFFTEngine> anotherEngine;
 
     // The pattern recognition kernel(s)
-    std::auto_ptr<fftjet::AbsFrequencyKernel> kernel2d;
-    std::auto_ptr<fftjet::AbsFrequencyKernel1d> etaKernel;
-    std::auto_ptr<fftjet::AbsFrequencyKernel1d> phiKernel;
+    std::unique_ptr<fftjet::AbsFrequencyKernel> kernel2d;
+    std::unique_ptr<fftjet::AbsFrequencyKernel1d> etaKernel;
+    std::unique_ptr<fftjet::AbsFrequencyKernel1d> phiKernel;
 
     // The kernel convolver
-    std::auto_ptr<fftjet::AbsConvolverBase<Real> > convolver;
+    std::unique_ptr<fftjet::AbsConvolverBase<Real> > convolver;
 
     // The scale power to use for scaling Et
     double scalePower;
@@ -105,7 +105,7 @@ FFTJetEFlowSmoother::FFTJetEFlowSmoother(const edm::ParameterSet& ps)
     checkConfig(energyFlow, "invalid discretization grid");
 
     // Copy of the grid which will be used for convolutions
-    convolvedFlow = std::auto_ptr<fftjet::Grid2d<fftjetcms::Real> >(
+    convolvedFlow = std::unique_ptr<fftjet::Grid2d<fftjetcms::Real> >(
         new fftjet::Grid2d<fftjetcms::Real>(*energyFlow));
 
     // Build the initial set of pattern recognition scales
@@ -162,17 +162,17 @@ void FFTJetEFlowSmoother::buildKernelConvolver(const edm::ParameterSet& ps)
     if (use2dKernel)
     {
         // Build the FFT engine
-        engine = std::auto_ptr<MyFFTEngine>(
+        engine = std::unique_ptr<MyFFTEngine>(
             new MyFFTEngine(energyFlow->nEta(), energyFlow->nPhi()));
 
         // 2d kernel
-        kernel2d = std::auto_ptr<fftjet::AbsFrequencyKernel>(
+        kernel2d = std::unique_ptr<fftjet::AbsFrequencyKernel>(
             new fftjet::DiscreteGauss2d(
                 kernelEtaScale, kernelPhiScale,
                 energyFlow->nEta(), energyFlow->nPhi()));
 
         // 2d convolver
-        convolver = std::auto_ptr<fftjet::AbsConvolverBase<Real> >(
+        convolver = std::unique_ptr<fftjet::AbsConvolverBase<Real> >(
             new fftjet::FrequencyKernelConvolver<Real,Complex>(
                 engine.get(), kernel2d.get(),
                 convolverMinBin, convolverMaxBin));
@@ -180,20 +180,20 @@ void FFTJetEFlowSmoother::buildKernelConvolver(const edm::ParameterSet& ps)
     else
     {
         // Need separate FFT engines for eta and phi
-        engine = std::auto_ptr<MyFFTEngine>(
+        engine = std::unique_ptr<MyFFTEngine>(
             new MyFFTEngine(1, energyFlow->nEta()));
-        anotherEngine = std::auto_ptr<MyFFTEngine>(
+        anotherEngine = std::unique_ptr<MyFFTEngine>(
             new MyFFTEngine(1, energyFlow->nPhi()));
 
         // 1d kernels
-        etaKernel = std::auto_ptr<fftjet::AbsFrequencyKernel1d>(
+        etaKernel = std::unique_ptr<fftjet::AbsFrequencyKernel1d>(
             new fftjet::DiscreteGauss1d(kernelEtaScale, energyFlow->nEta()));
 
-        phiKernel = std::auto_ptr<fftjet::AbsFrequencyKernel1d>(
+        phiKernel = std::unique_ptr<fftjet::AbsFrequencyKernel1d>(
             new fftjet::DiscreteGauss1d(kernelPhiScale, energyFlow->nPhi()));
 
         // Sequential convolver
-        convolver = std::auto_ptr<fftjet::AbsConvolverBase<Real> >(
+        convolver = std::unique_ptr<fftjet::AbsConvolverBase<Real> >(
             new fftjet::FrequencySequentialConvolver<Real,Complex>(
                 engine.get(), anotherEngine.get(),
                 etaKernel.get(), phiKernel.get(),

--- a/RecoJets/FFTJetProducers/plugins/FFTJetPileupEstimator.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetPileupEstimator.cc
@@ -81,8 +81,8 @@ private:
     double ptToDensityFactor;
     unsigned filterNumber;
     std::vector<double> uncertaintyZones;
-    std::auto_ptr<fftjet::Functor1<double,double> > calibrationCurve;
-    std::auto_ptr<fftjet::Functor1<double,double> > uncertaintyCurve;
+    std::unique_ptr<fftjet::Functor1<double,double> > calibrationCurve;
+    std::unique_ptr<fftjet::Functor1<double,double> > uncertaintyCurve;
 
     // Alternative method to calibrate the pileup.
     // We will fetch three lookup tables from the database:

--- a/RecoJets/FFTJetProducers/plugins/FFTJetPileupProcessor.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetPileupProcessor.cc
@@ -72,19 +72,19 @@ private:
     void loadFlatteningFactors(const edm::EventSetup& iSetup);
 
     // The FFT engine
-    std::auto_ptr<MyFFTEngine> engine;
+    std::unique_ptr<MyFFTEngine> engine;
 
     // The pattern recognition kernel(s)
-    std::auto_ptr<fftjet::AbsFrequencyKernel> kernel2d;
+    std::unique_ptr<fftjet::AbsFrequencyKernel> kernel2d;
 
     // The kernel convolver
-    std::auto_ptr<fftjet::AbsConvolverBase<Real> > convolver;
+    std::unique_ptr<fftjet::AbsConvolverBase<Real> > convolver;
 
     // Storage for convolved energy flow
-    std::auto_ptr<fftjet::Grid2d<fftjetcms::Real> > convolvedFlow;
+    std::unique_ptr<fftjet::Grid2d<fftjetcms::Real> > convolvedFlow;
 
     // Filtering scales
-    std::auto_ptr<fftjet::EquidistantInLogSpace> filterScales;
+    std::unique_ptr<fftjet::EquidistantInLogSpace> filterScales;
 
     // Eta-dependent factors to use for flattening the distribution
     // _after_ the filtering
@@ -144,7 +144,7 @@ FFTJetPileupProcessor::FFTJetPileupProcessor(const edm::ParameterSet& ps)
     checkConfig(energyFlow, "invalid discretization grid");
 
     // Copy of the grid which will be used for convolutions
-    convolvedFlow = std::auto_ptr<fftjet::Grid2d<fftjetcms::Real> >(
+    convolvedFlow = std::unique_ptr<fftjet::Grid2d<fftjetcms::Real> >(
         new fftjet::Grid2d<fftjetcms::Real>(*energyFlow));
 
     // Make sure the size of flattening factors is appropriate
@@ -170,7 +170,7 @@ FFTJetPileupProcessor::FFTJetPileupProcessor(const edm::ParameterSet& ps)
         throw cms::Exception("FFTJetBadConfig")
             << "invalid filter scales" << std::endl;
 
-    filterScales = std::auto_ptr<fftjet::EquidistantInLogSpace>(
+    filterScales = std::unique_ptr<fftjet::EquidistantInLogSpace>(
         new fftjet::EquidistantInLogSpace(minScale, maxScale, nScales));
 
     percentileData.resize(nScales*nPercentiles);
@@ -200,17 +200,17 @@ void FFTJetPileupProcessor::buildKernelConvolver(const edm::ParameterSet& ps)
     kernelEtaScale *= (2.0*M_PI/(energyFlow->etaMax() - energyFlow->etaMin()));
 
     // Build the FFT engine
-    engine = std::auto_ptr<MyFFTEngine>(
+    engine = std::unique_ptr<MyFFTEngine>(
         new MyFFTEngine(energyFlow->nEta(), energyFlow->nPhi()));
 
     // 2d kernel
-    kernel2d = std::auto_ptr<fftjet::AbsFrequencyKernel>(
+    kernel2d = std::unique_ptr<fftjet::AbsFrequencyKernel>(
         new fftjet::DiscreteGauss2d(
             kernelEtaScale, kernelPhiScale,
             energyFlow->nEta(), energyFlow->nPhi()));
 
     // 2d convolver
-    convolver = std::auto_ptr<fftjet::AbsConvolverBase<Real> >(
+    convolver = std::unique_ptr<fftjet::AbsConvolverBase<Real> >(
         new fftjet::FrequencyKernelConvolver<Real,Complex>(
             engine.get(), kernel2d.get(),
             convolverMinBin, convolverMaxBin));

--- a/RecoJets/FFTJetProducers/plugins/FFTJetProducer.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetProducer.cc
@@ -423,7 +423,7 @@ void FFTJetProducer::buildGridAlg()
         throw cms::Exception("FFTJetBadConfig")
             << "Invalid grid recombination algorithm \""
             << recombinationAlgorithm << "\"" << std::endl;
-    gridAlg = std::auto_ptr<GridAlg>(
+    gridAlg = std::unique_ptr<GridAlg>(
         factory[recombinationAlgorithm]->create(
             jetMembershipFunction.get(),
             bgMembershipFunction.get(),
@@ -434,7 +434,7 @@ void FFTJetProducer::buildGridAlg()
 
 bool FFTJetProducer::loadEnergyFlow(
     const edm::Event& iEvent, 
-    std::auto_ptr<fftjet::Grid2d<fftjetcms::Real> >& flow)
+    std::unique_ptr<fftjet::Grid2d<fftjetcms::Real> >& flow)
 {
     edm::Handle<reco::DiscretizedEnergyFlow> input;
     iEvent.getByToken(input_energyflow_token_, input);
@@ -451,7 +451,7 @@ bool FFTJetProducer::loadEnergyFlow(
     if (rebuildGrid)
     {
         // We should not get here very often...
-        flow = std::auto_ptr<fftjet::Grid2d<Real> >(
+        flow = std::unique_ptr<fftjet::Grid2d<Real> >(
             new fftjet::Grid2d<Real>(
                 input->nEtaBins(), input->etaMin(), input->etaMax(),
                 input->nPhiBins(), input->phiBin0Edge(), input->title()));
@@ -864,7 +864,7 @@ void FFTJetProducer::produce(edm::Event& iEvent,
 }
 
 
-std::auto_ptr<fftjet::Functor1<bool,fftjet::Peak> >
+std::unique_ptr<fftjet::Functor1<bool,fftjet::Peak> >
 FFTJetProducer::parse_peakSelector(const edm::ParameterSet& ps)
 {
     return fftjet_PeakSelector_parser(
@@ -873,7 +873,7 @@ FFTJetProducer::parse_peakSelector(const edm::ParameterSet& ps)
 
 
 // Parser for the jet membership function
-std::auto_ptr<fftjet::ScaleSpaceKernel>
+std::unique_ptr<fftjet::ScaleSpaceKernel>
 FFTJetProducer::parse_jetMembershipFunction(const edm::ParameterSet& ps)
 {
     return fftjet_MembershipFunction_parser(
@@ -882,7 +882,7 @@ FFTJetProducer::parse_jetMembershipFunction(const edm::ParameterSet& ps)
 
 
 // Parser for the background membership function
-std::auto_ptr<AbsBgFunctor>
+std::unique_ptr<AbsBgFunctor>
 FFTJetProducer::parse_bgMembershipFunction(const edm::ParameterSet& ps)
 {
     return fftjet_BgFunctor_parser(
@@ -891,7 +891,7 @@ FFTJetProducer::parse_bgMembershipFunction(const edm::ParameterSet& ps)
 
 
 // Calculator for the recombination scale
-std::auto_ptr<fftjet::Functor1<double,fftjet::Peak> >
+std::unique_ptr<fftjet::Functor1<double,fftjet::Peak> >
 FFTJetProducer::parse_recoScaleCalcPeak(const edm::ParameterSet& ps)
 {
     return fftjet_PeakFunctor_parser(
@@ -900,7 +900,7 @@ FFTJetProducer::parse_recoScaleCalcPeak(const edm::ParameterSet& ps)
 
 
 // Pile-up density calculator
-std::auto_ptr<fftjetcms::AbsPileupCalculator>
+std::unique_ptr<fftjetcms::AbsPileupCalculator>
 FFTJetProducer::parse_pileupDensityCalc(const edm::ParameterSet& ps)
 {
     return fftjet_PileupCalculator_parser(
@@ -909,7 +909,7 @@ FFTJetProducer::parse_pileupDensityCalc(const edm::ParameterSet& ps)
 
 
 // Calculator for the recombination scale ratio
-std::auto_ptr<fftjet::Functor1<double,fftjet::Peak> >
+std::unique_ptr<fftjet::Functor1<double,fftjet::Peak> >
 FFTJetProducer::parse_recoScaleRatioCalcPeak(const edm::ParameterSet& ps)
 {
     return fftjet_PeakFunctor_parser(
@@ -918,7 +918,7 @@ FFTJetProducer::parse_recoScaleRatioCalcPeak(const edm::ParameterSet& ps)
 
 
 // Calculator for the membership function factor
-std::auto_ptr<fftjet::Functor1<double,fftjet::Peak> >
+std::unique_ptr<fftjet::Functor1<double,fftjet::Peak> >
 FFTJetProducer::parse_memberFactorCalcPeak(const edm::ParameterSet& ps)
 {
     return fftjet_PeakFunctor_parser(
@@ -926,7 +926,7 @@ FFTJetProducer::parse_memberFactorCalcPeak(const edm::ParameterSet& ps)
 }
 
 
-std::auto_ptr<fftjet::Functor1<double,FFTJetProducer::RecoFFTJet> >
+std::unique_ptr<fftjet::Functor1<double,FFTJetProducer::RecoFFTJet> >
 FFTJetProducer::parse_recoScaleCalcJet(const edm::ParameterSet& ps)
 {
     return fftjet_JetFunctor_parser(
@@ -934,7 +934,7 @@ FFTJetProducer::parse_recoScaleCalcJet(const edm::ParameterSet& ps)
 }
 
 
-std::auto_ptr<fftjet::Functor1<double,FFTJetProducer::RecoFFTJet> >
+std::unique_ptr<fftjet::Functor1<double,FFTJetProducer::RecoFFTJet> >
 FFTJetProducer::parse_recoScaleRatioCalcJet(const edm::ParameterSet& ps)
 {
     return fftjet_JetFunctor_parser(
@@ -942,7 +942,7 @@ FFTJetProducer::parse_recoScaleRatioCalcJet(const edm::ParameterSet& ps)
 }
 
 
-std::auto_ptr<fftjet::Functor1<double,FFTJetProducer::RecoFFTJet> >
+std::unique_ptr<fftjet::Functor1<double,FFTJetProducer::RecoFFTJet> >
 FFTJetProducer::parse_memberFactorCalcJet(const edm::ParameterSet& ps)
 {
     return fftjet_JetFunctor_parser(
@@ -950,7 +950,7 @@ FFTJetProducer::parse_memberFactorCalcJet(const edm::ParameterSet& ps)
 }
 
 
-std::auto_ptr<fftjet::Functor2<
+std::unique_ptr<fftjet::Functor2<
     double,FFTJetProducer::RecoFFTJet,FFTJetProducer::RecoFFTJet> >
 FFTJetProducer::parse_jetDistanceCalc(const edm::ParameterSet& ps)
 {
@@ -988,7 +988,7 @@ void FFTJetProducer::beginJob()
             throw cms::Exception("FFTJetBadConfig")
                 << "Invalid vector recombination algorithm \""
                 << recombinationAlgorithm << "\"" << std::endl;
-        recoAlg = std::auto_ptr<RecoAlg>(
+        recoAlg = std::unique_ptr<RecoAlg>(
             factory[recombinationAlgorithm]->create(
                 jetMembershipFunction.get(),
                 &VectorLike::Et, &VectorLike::Eta, &VectorLike::Phi,
@@ -1094,7 +1094,7 @@ void FFTJetProducer::setJetStatusBit(RecoFFTJet* jet,
 
 void FFTJetProducer::determinePileupDensityFromConfig(
     const edm::Event& iEvent, 
-    std::auto_ptr<fftjet::Grid2d<fftjetcms::Real> >& density)
+    std::unique_ptr<fftjet::Grid2d<fftjetcms::Real> >& density)
 {
     edm::Handle<reco::FFTJetPileupSummary> summary;
     iEvent.getByToken(input_pusummary_token_, summary);
@@ -1131,7 +1131,7 @@ void FFTJetProducer::determinePileupDensityFromConfig(
 
 void FFTJetProducer::determinePileupDensityFromDB(
     const edm::Event& iEvent, const edm::EventSetup& iSetup,
-    std::auto_ptr<fftjet::Grid2d<fftjetcms::Real> >& density)
+    std::unique_ptr<fftjet::Grid2d<fftjetcms::Real> >& density)
 {
     edm::ESHandle<FFTJetLookupTableSequence> h;
     StaticFFTJetLookupTableSequenceLoader::instance().load(

--- a/RecoJets/FFTJetProducers/plugins/FFTJetProducer.h
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetProducer.h
@@ -139,46 +139,46 @@ protected:
         std::vector<fftjet::Peak>* preclusters);
 
     // Parser for the peak selector
-    virtual std::auto_ptr<fftjet::Functor1<bool,fftjet::Peak> >
+    virtual std::unique_ptr<fftjet::Functor1<bool,fftjet::Peak> >
     parse_peakSelector(const edm::ParameterSet&);
 
     // Parser for the default jet membership function
-    virtual std::auto_ptr<fftjet::ScaleSpaceKernel>
+    virtual std::unique_ptr<fftjet::ScaleSpaceKernel>
     parse_jetMembershipFunction(const edm::ParameterSet&);
 
     // Parser for the background membership function
-    virtual std::auto_ptr<fftjetcms::AbsBgFunctor>
+    virtual std::unique_ptr<fftjetcms::AbsBgFunctor>
     parse_bgMembershipFunction(const edm::ParameterSet&);
 
     // Calculator for the recombination scale
-    virtual std::auto_ptr<fftjet::Functor1<double,fftjet::Peak> >
+    virtual std::unique_ptr<fftjet::Functor1<double,fftjet::Peak> >
     parse_recoScaleCalcPeak(const edm::ParameterSet&);
 
     // Calculator for the recombination scale ratio
-    virtual std::auto_ptr<fftjet::Functor1<double,fftjet::Peak> >
+    virtual std::unique_ptr<fftjet::Functor1<double,fftjet::Peak> >
     parse_recoScaleRatioCalcPeak(const edm::ParameterSet&);
 
     // Calculator for the membership function factor
-    virtual std::auto_ptr<fftjet::Functor1<double,fftjet::Peak> >
+    virtual std::unique_ptr<fftjet::Functor1<double,fftjet::Peak> >
     parse_memberFactorCalcPeak(const edm::ParameterSet&);
 
     // Similar calculators for the iterative algorithm
-    virtual std::auto_ptr<fftjet::Functor1<double,RecoFFTJet> >
+    virtual std::unique_ptr<fftjet::Functor1<double,RecoFFTJet> >
     parse_recoScaleCalcJet(const edm::ParameterSet&);
 
-    virtual std::auto_ptr<fftjet::Functor1<double,RecoFFTJet> >
+    virtual std::unique_ptr<fftjet::Functor1<double,RecoFFTJet> >
     parse_recoScaleRatioCalcJet(const edm::ParameterSet&);
 
-    virtual std::auto_ptr<fftjet::Functor1<double,RecoFFTJet> >
+    virtual std::unique_ptr<fftjet::Functor1<double,RecoFFTJet> >
     parse_memberFactorCalcJet(const edm::ParameterSet&);
 
     // Calculator of the distance between jets which is used to make
     // the decision about convergence of the iterative algorithm
-    virtual std::auto_ptr<fftjet::Functor2<double,RecoFFTJet,RecoFFTJet> >
+    virtual std::unique_ptr<fftjet::Functor2<double,RecoFFTJet,RecoFFTJet> >
     parse_jetDistanceCalc(const edm::ParameterSet&);
 
     // Pile-up density calculator
-    virtual std::auto_ptr<fftjetcms::AbsPileupCalculator>
+    virtual std::unique_ptr<fftjetcms::AbsPileupCalculator>
     parse_pileupDensityCalc(const edm::ParameterSet& ps);
 
     // The following function performs most of the precluster selection
@@ -208,7 +208,7 @@ private:
     // The following function tells us if the grid was rebuilt.
     bool loadEnergyFlow(
         const edm::Event& iEvent,
-        std::auto_ptr<fftjet::Grid2d<fftjetcms::Real> >& flow);
+        std::unique_ptr<fftjet::Grid2d<fftjetcms::Real> >& flow);
     void buildGridAlg();
     void prepareRecombinationScales();
     bool checkConvergence(const std::vector<RecoFFTJet>& previousIterResult,
@@ -229,12 +229,12 @@ private:
     // necessary.
     virtual void determinePileupDensityFromConfig(
         const edm::Event& iEvent,
-        std::auto_ptr<fftjet::Grid2d<fftjetcms::Real> >& density);
+        std::unique_ptr<fftjet::Grid2d<fftjetcms::Real> >& density);
 
     // Similar function for getting pile-up shape from the database
     virtual void determinePileupDensityFromDB(
         const edm::Event& iEvent, const edm::EventSetup& iSetup,
-        std::auto_ptr<fftjet::Grid2d<fftjetcms::Real> >& density);
+        std::unique_ptr<fftjet::Grid2d<fftjetcms::Real> >& density);
 
     // The following function builds the pile-up estimate
     // for each jet
@@ -341,38 +341,38 @@ private:
     bool loadPileupFromDB;
 
     // Scales used
-    std::auto_ptr<std::vector<double> > iniScales;
+    std::unique_ptr<std::vector<double> > iniScales;
 
     // The sparse clustering tree
     SparseTree sparseTree;
 
     // Peak selector for the peaks already in the tree
-    std::auto_ptr<fftjet::Functor1<bool,fftjet::Peak> > peakSelector;
+    std::unique_ptr<fftjet::Functor1<bool,fftjet::Peak> > peakSelector;
 
     // Recombination algorithms and related quantities
-    std::auto_ptr<RecoAlg> recoAlg;
-    std::auto_ptr<GridAlg> gridAlg;
-    std::auto_ptr<fftjet::ScaleSpaceKernel> jetMembershipFunction;
-    std::auto_ptr<fftjetcms::AbsBgFunctor> bgMembershipFunction;
+    std::unique_ptr<RecoAlg> recoAlg;
+    std::unique_ptr<GridAlg> gridAlg;
+    std::unique_ptr<fftjet::ScaleSpaceKernel> jetMembershipFunction;
+    std::unique_ptr<fftjetcms::AbsBgFunctor> bgMembershipFunction;
 
     // Calculator for the recombination scale
-    std::auto_ptr<fftjet::Functor1<double,fftjet::Peak> > recoScaleCalcPeak;
+    std::unique_ptr<fftjet::Functor1<double,fftjet::Peak> > recoScaleCalcPeak;
 
     // Calculator for the recombination scale ratio
-    std::auto_ptr<fftjet::Functor1<double,fftjet::Peak> >
+    std::unique_ptr<fftjet::Functor1<double,fftjet::Peak> >
     recoScaleRatioCalcPeak;
 
     // Calculator for the membership function factor
-    std::auto_ptr<fftjet::Functor1<double,fftjet::Peak> > memberFactorCalcPeak;
+    std::unique_ptr<fftjet::Functor1<double,fftjet::Peak> > memberFactorCalcPeak;
 
     // Similar calculators for the iterative algorithm
-    std::auto_ptr<fftjet::Functor1<double,RecoFFTJet> > recoScaleCalcJet;
-    std::auto_ptr<fftjet::Functor1<double,RecoFFTJet> > recoScaleRatioCalcJet;
-    std::auto_ptr<fftjet::Functor1<double,RecoFFTJet> > memberFactorCalcJet;
+    std::unique_ptr<fftjet::Functor1<double,RecoFFTJet> > recoScaleCalcJet;
+    std::unique_ptr<fftjet::Functor1<double,RecoFFTJet> > recoScaleRatioCalcJet;
+    std::unique_ptr<fftjet::Functor1<double,RecoFFTJet> > memberFactorCalcJet;
 
     // Calculator for the jet distance used to estimate convergence
     // of the iterative algorithm
-    std::auto_ptr<fftjet::Functor2<double,RecoFFTJet,RecoFFTJet> >
+    std::unique_ptr<fftjet::Functor2<double,RecoFFTJet,RecoFFTJet> >
     jetDistanceCalc;
 
     // Vector of selected tree nodes
@@ -412,10 +412,10 @@ private:
     // The pile-up transverse energy density discretization grid.
     // Note that this is _density_, not energy. To get energy, 
     // multiply by cell area.
-    std::auto_ptr<fftjet::Grid2d<fftjetcms::Real> > pileupEnergyFlow;
+    std::unique_ptr<fftjet::Grid2d<fftjetcms::Real> > pileupEnergyFlow;
 
     // The functor that calculates the pile-up density
-    std::auto_ptr<fftjetcms::AbsPileupCalculator> pileupDensityCalc;
+    std::unique_ptr<fftjetcms::AbsPileupCalculator> pileupDensityCalc;
 
     // Memory buffers related to pile-up subtraction
     std::vector<fftjet::AbsKernel2d*> memFcns2dVec;

--- a/RecoJets/FFTJetProducers/plugins/FFTJetTreeDump.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetTreeDump.cc
@@ -94,21 +94,21 @@ private:
     const double completeEventScale;
 
     // Distance calculator for the clustering tree
-    std::auto_ptr<fftjet::AbsDistanceCalculator<fftjet::Peak> > distanceCalc;
+    std::unique_ptr<fftjet::AbsDistanceCalculator<fftjet::Peak> > distanceCalc;
 
     // Scales used
-    std::auto_ptr<std::vector<double> > iniScales;
+    std::unique_ptr<std::vector<double> > iniScales;
 
     // The sparse clustering tree
     SparseTree sparseTree;
 
     // Functors which define OpenDX glyph size and color
-    std::auto_ptr<PeakProperty> glyphSize;
-    std::auto_ptr<PeakProperty> glyphColor;
+    std::unique_ptr<PeakProperty> glyphSize;
+    std::unique_ptr<PeakProperty> glyphColor;
 
     // OpenDX formatters
-    std::auto_ptr<DXFormatter> denseFormatter;
-    std::auto_ptr<SparseFormatter> sparseFormatter;
+    std::unique_ptr<DXFormatter> denseFormatter;
+    std::unique_ptr<SparseFormatter> sparseFormatter;
 
     unsigned counter;
 };
@@ -155,9 +155,9 @@ FFTJetTreeDump::FFTJetTreeDump(const edm::ParameterSet& ps)
     checkConfig(glyphColor, "invalid glyph color parameters");
 
     // Build the tree formatters
-    denseFormatter = std::auto_ptr<DXFormatter>(new DXFormatter(
+    denseFormatter = std::unique_ptr<DXFormatter>(new DXFormatter(
         glyphSize.get(), glyphColor.get(), etaMax));
-    sparseFormatter = std::auto_ptr<SparseFormatter>(new SparseFormatter(
+    sparseFormatter = std::unique_ptr<SparseFormatter>(new SparseFormatter(
         glyphSize.get(), glyphColor.get(), etaMax));
 
     // Build the clustering tree

--- a/RecoJets/FFTJetProducers/src/FFTJetParameterParser.cc
+++ b/RecoJets/FFTJetProducers/src/FFTJetParameterParser.cc
@@ -2,6 +2,7 @@
 #include <cstring>
 #include <string>
 #include <fstream>
+#include <utility>
 
 #include "RecoJets/FFTJetProducers/interface/FFTJetParameterParser.h"
 
@@ -128,10 +129,10 @@ static bool parse_jet_member_function(const char* fname,
 
 namespace fftjetcms {
 
-std::auto_ptr<fftjet::Grid2d<Real> >
+std::unique_ptr<fftjet::Grid2d<Real> >
 fftjet_Grid2d_parser(const edm::ParameterSet& ps)
 {
-    typedef std::auto_ptr<fftjet::Grid2d<Real> > return_type;
+    typedef std::unique_ptr<fftjet::Grid2d<Real> > return_type;
     fftjet::Grid2d<Real> *g = 0;
 
     // Check if the grid should be read from file
@@ -189,10 +190,10 @@ fftjet_Grid2d_parser(const edm::ParameterSet& ps)
 }
 
 
-std::auto_ptr<fftjet::Functor1<bool,fftjet::Peak> >
+std::unique_ptr<fftjet::Functor1<bool,fftjet::Peak> >
 fftjet_PeakSelector_parser(const edm::ParameterSet& ps)
 {
-    typedef std::auto_ptr<fftjet::Functor1<bool,fftjet::Peak> > return_type;
+    typedef std::unique_ptr<fftjet::Functor1<bool,fftjet::Peak> > return_type;
 
     const std::string peakselector_type = ps.getParameter<std::string>(
         "Class");
@@ -267,10 +268,10 @@ fftjet_PeakSelector_parser(const edm::ParameterSet& ps)
 }
 
 
-std::auto_ptr<fftjet::ScaleSpaceKernel>
+std::unique_ptr<fftjet::ScaleSpaceKernel>
 fftjet_MembershipFunction_parser(const edm::ParameterSet& ps)
 {
-    typedef std::auto_ptr<fftjet::ScaleSpaceKernel> return_type;
+    typedef std::unique_ptr<fftjet::ScaleSpaceKernel> return_type;
 
     const std::string MembershipFunction_type = ps.getParameter<std::string>(
         "Class");
@@ -397,13 +398,13 @@ fftjet_MembershipFunction_parser(const edm::ParameterSet& ps)
             throw cms::Exception("FFTJetBadConfig")
                 << "Bad number of kernel parameters" << std::endl;
 
-    return std::auto_ptr<fftjet::ScaleSpaceKernel>(
+    return std::unique_ptr<fftjet::ScaleSpaceKernel>(
         factory[MembershipFunction_type]->create(
             sx, sy, scalePower, kernelParameters));
 }
 
 
-std::auto_ptr<AbsBgFunctor>
+std::unique_ptr<AbsBgFunctor>
 fftjet_BgFunctor_parser(const edm::ParameterSet& ps)
 {
     const std::string bg_Membership_type = ps.getParameter<std::string>(
@@ -413,18 +414,18 @@ fftjet_BgFunctor_parser(const edm::ParameterSet& ps)
     {
         const double minWeight = ps.getParameter<double>("minWeight");
         const double prior = ps.getParameter<double>("prior");
-        return std::auto_ptr<AbsBgFunctor>(
+        return std::unique_ptr<AbsBgFunctor>(
             new fftjet::GaussianNoiseMembershipFcn(minWeight,prior));
     }
 
-    return std::auto_ptr<AbsBgFunctor>(NULL);
+    return std::unique_ptr<AbsBgFunctor>(NULL);
 }
 
 
-std::auto_ptr<std::vector<double> >
+std::unique_ptr<std::vector<double> >
 fftjet_ScaleSet_parser(const edm::ParameterSet& ps)
 {
-    typedef std::auto_ptr<std::vector<double> > return_type;
+    typedef std::unique_ptr<std::vector<double> > return_type;
 
     const std::string className = ps.getParameter<std::string>("Class");
 
@@ -468,17 +469,17 @@ fftjet_ScaleSet_parser(const edm::ParameterSet& ps)
                 if ((*scales)[i] == (*scales)[j])
                     return return_type(NULL);
 
-        return scales;
+        return std::move(scales);
     }
 
     return return_type(NULL);
 }
 
 
-std::auto_ptr<fftjet::ClusteringTreeSparsifier<fftjet::Peak,long> >
+std::unique_ptr<fftjet::ClusteringTreeSparsifier<fftjet::Peak,long> >
 fftjet_ClusteringTreeSparsifier_parser(const edm::ParameterSet& ps)
 {
-    typedef std::auto_ptr<fftjet::ClusteringTreeSparsifier<fftjet::Peak,long> > return_type;
+    typedef std::unique_ptr<fftjet::ClusteringTreeSparsifier<fftjet::Peak,long> > return_type;
 
     const int maxLevelNumber = ps.getParameter<int>("maxLevelNumber");
     const unsigned filterMask = ps.getParameter<unsigned>("filterMask");
@@ -498,10 +499,10 @@ fftjet_ClusteringTreeSparsifier_parser(const edm::ParameterSet& ps)
 }
 
 
-std::auto_ptr<fftjet::AbsDistanceCalculator<fftjet::Peak> >
+std::unique_ptr<fftjet::AbsDistanceCalculator<fftjet::Peak> >
 fftjet_DistanceCalculator_parser(const edm::ParameterSet& ps)
 {
-    typedef std::auto_ptr<fftjet::AbsDistanceCalculator<fftjet::Peak> > return_type;
+    typedef std::unique_ptr<fftjet::AbsDistanceCalculator<fftjet::Peak> > return_type;
 
     const std::string calc_type = ps.getParameter<std::string>("Class");
 
@@ -514,7 +515,7 @@ fftjet_DistanceCalculator_parser(const edm::ParameterSet& ps)
 
     if (!calc_type.compare("PeakEtaDependentDistance"))
     {
-        std::auto_ptr<fftjet::LinearInterpolator1d> interp = 
+        std::unique_ptr<fftjet::LinearInterpolator1d> interp = 
             fftjet_LinearInterpolator1d_parser(
                 ps.getParameter<edm::ParameterSet>("Interpolator"));
         const fftjet::LinearInterpolator1d* ip = interp.get();
@@ -537,7 +538,7 @@ fftjet_DistanceCalculator_parser(const edm::ParameterSet& ps)
 }
 
 
-std::auto_ptr<fftjetcms::LinInterpolatedTable1D>
+std::unique_ptr<fftjetcms::LinInterpolatedTable1D>
 fftjet_LinInterpolatedTable1D_parser(const edm::ParameterSet& ps)
 {
     const double xmin = ps.getParameter<double>("xmin");
@@ -549,16 +550,16 @@ fftjet_LinInterpolatedTable1D_parser(const edm::ParameterSet& ps)
     const std::vector<double> data(
         ps.getParameter<std::vector<double> >("data"));
     if (data.empty())
-        return std::auto_ptr<fftjetcms::LinInterpolatedTable1D>(NULL);
+        return std::unique_ptr<fftjetcms::LinInterpolatedTable1D>(NULL);
     else
-        return std::auto_ptr<fftjetcms::LinInterpolatedTable1D>(
+        return std::unique_ptr<fftjetcms::LinInterpolatedTable1D>(
             new fftjetcms::LinInterpolatedTable1D(
                 &data[0], data.size(), xmin, xmax,
                 leftExtrapolationLinear, rightExtrapolationLinear));
 }
 
 
-std::auto_ptr<fftjet::LinearInterpolator1d>
+std::unique_ptr<fftjet::LinearInterpolator1d>
 fftjet_LinearInterpolator1d_parser(const edm::ParameterSet& ps)
 {
     const double xmin = ps.getParameter<double>("xmin");
@@ -568,15 +569,15 @@ fftjet_LinearInterpolator1d_parser(const edm::ParameterSet& ps)
     const std::vector<double> data(
         ps.getParameter<std::vector<double> >("data"));
     if (data.empty())
-        return std::auto_ptr<fftjet::LinearInterpolator1d>(NULL);
+        return std::unique_ptr<fftjet::LinearInterpolator1d>(NULL);
     else
-        return std::auto_ptr<fftjet::LinearInterpolator1d>(
+        return std::unique_ptr<fftjet::LinearInterpolator1d>(
             new fftjet::LinearInterpolator1d(
                 &data[0], data.size(), xmin, xmax, flow, fhigh));
 }
 
 
-std::auto_ptr<fftjet::LinearInterpolator2d>
+std::unique_ptr<fftjet::LinearInterpolator2d>
 fftjet_LinearInterpolator2d_parser(const edm::ParameterSet& ps)
 {
     const std::string file = ps.getParameter<std::string>("file");
@@ -589,15 +590,15 @@ fftjet_LinearInterpolator2d_parser(const edm::ParameterSet& ps)
     if (!ip)
         throw cms::Exception("FFTJetBadConfig")
             << "Failed to read file " << file << std::endl;
-    return std::auto_ptr<fftjet::LinearInterpolator2d>(ip);
+    return std::unique_ptr<fftjet::LinearInterpolator2d>(ip);
 }
 
 
-std::auto_ptr<fftjet::Functor1<double,fftjet::Peak> >
+std::unique_ptr<fftjet::Functor1<double,fftjet::Peak> >
 fftjet_PeakFunctor_parser(const edm::ParameterSet& ps)
 {
     typedef fftjet::Functor1<double,fftjet::Peak> ptr_type;
-    typedef std::auto_ptr<ptr_type> return_type;
+    typedef std::unique_ptr<ptr_type> return_type;
 
     const std::string property_type = ps.getParameter<std::string>("Class");
 
@@ -611,7 +612,7 @@ fftjet_PeakFunctor_parser(const edm::ParameterSet& ps)
             return_type result = return_type(
                 new fftjet::LogProperty<fftjet::Peak>(wr, true));
             wrapped.release();
-            return result;
+            return std::move(result);
         }
     }
 
@@ -676,13 +677,13 @@ fftjet_PeakFunctor_parser(const edm::ParameterSet& ps)
             return_type result = return_type(
                 new MultiplyByConst<fftjet::Peak>(factor, ptr, true));
             function.release();
-            return result;
+            return std::move(result);
         }
     }
 
     if (!property_type.compare("CompositeFunctor"))
     {
-        std::auto_ptr<fftjet::Functor1<double,double> > fcn1 = 
+        std::unique_ptr<fftjet::Functor1<double,double> > fcn1 = 
             fftjet_Function_parser(
                 ps.getParameter<edm::ParameterSet>("function1"));
         return_type fcn2 = fftjet_PeakFunctor_parser(
@@ -695,7 +696,7 @@ fftjet_PeakFunctor_parser(const edm::ParameterSet& ps)
                 new CompositeFunctor<fftjet::Peak>(f1, f2, true));
             fcn1.release();
             fcn2.release();
-            return result;
+            return std::move(result);
         }
     }
 
@@ -713,13 +714,13 @@ fftjet_PeakFunctor_parser(const edm::ParameterSet& ps)
                 new ProductFunctor<fftjet::Peak>(f1, f2, true));
             fcn1.release();
             fcn2.release();
-            return result;
+            return std::move(result);
         }
     }
 
     if (!property_type.compare("MagnitudeDependent"))
     {
-        std::auto_ptr<fftjet::Functor1<double,double> > fcn1 = 
+        std::unique_ptr<fftjet::Functor1<double,double> > fcn1 = 
             fftjet_Function_parser(
                 ps.getParameter<edm::ParameterSet>("function"));
         fftjet::Functor1<double,double>* f1 = fcn1.get();
@@ -728,13 +729,13 @@ fftjet_PeakFunctor_parser(const edm::ParameterSet& ps)
             return_type result = return_type(
                 new MagnitudeDependent<fftjet::Peak>(f1, true));
             fcn1.release();
-            return result;
+            return std::move(result);
         }
     }
 
     if (!property_type.compare("PeakEtaDependent"))
     {
-        std::auto_ptr<fftjet::Functor1<double,double> > fcn1 = 
+        std::unique_ptr<fftjet::Functor1<double,double> > fcn1 = 
             fftjet_Function_parser(
                 ps.getParameter<edm::ParameterSet>("function"));
         fftjet::Functor1<double,double>* f1 = fcn1.get();
@@ -742,7 +743,7 @@ fftjet_PeakFunctor_parser(const edm::ParameterSet& ps)
         {
             return_type result = return_type(new PeakEtaDependent(f1, true));
             fcn1.release();
-            return result;
+            return std::move(result);
         }
     }
 
@@ -750,11 +751,11 @@ fftjet_PeakFunctor_parser(const edm::ParameterSet& ps)
 }
 
 
-std::auto_ptr<fftjet::Functor1<double,fftjet::RecombinedJet<VectorLike> > >
+std::unique_ptr<fftjet::Functor1<double,fftjet::RecombinedJet<VectorLike> > >
 fftjet_JetFunctor_parser(const edm::ParameterSet& ps)
 {
     typedef fftjet::Functor1<double,RecoFFTJet> ptr_type;
-    typedef std::auto_ptr<ptr_type> return_type;
+    typedef std::unique_ptr<ptr_type> return_type;
 
     const std::string property_type = ps.getParameter<std::string>("Class");
 
@@ -768,13 +769,13 @@ fftjet_JetFunctor_parser(const edm::ParameterSet& ps)
             return_type result = return_type(
                 new fftjet::LogProperty<RecoFFTJet>(wr, true));
             wrapped.release();
-            return result;
+            return std::move(result);
         }
     }
 
     if (!property_type.compare("JetEtaDependent"))
     {
-        std::auto_ptr<fftjet::Functor1<double,double> > fcn1 = 
+        std::unique_ptr<fftjet::Functor1<double,double> > fcn1 = 
             fftjet_Function_parser(
                 ps.getParameter<edm::ParameterSet>("function"));
         fftjet::Functor1<double,double>* f1 = fcn1.get();
@@ -782,7 +783,7 @@ fftjet_JetFunctor_parser(const edm::ParameterSet& ps)
         {
             return_type result = return_type(new JetEtaDependent(f1, true));
             fcn1.release();
-            return result;
+            return std::move(result);
         }
     }
 
@@ -821,13 +822,13 @@ fftjet_JetFunctor_parser(const edm::ParameterSet& ps)
             return_type result = return_type(
                 new MultiplyByConst<RecoFFTJet>(factor, ptr, true));
             function.release();
-            return result;
+            return std::move(result);
         }
     }
 
     if (!property_type.compare("CompositeFunctor"))
     {
-        std::auto_ptr<fftjet::Functor1<double,double> > fcn1 = 
+        std::unique_ptr<fftjet::Functor1<double,double> > fcn1 = 
             fftjet_Function_parser(
                 ps.getParameter<edm::ParameterSet>("function1"));
         return_type fcn2 = fftjet_JetFunctor_parser(
@@ -840,7 +841,7 @@ fftjet_JetFunctor_parser(const edm::ParameterSet& ps)
                 new CompositeFunctor<RecoFFTJet>(f1, f2, true));
             fcn1.release();
             fcn2.release();
-            return result;
+            return std::move(result);
         }
     }
 
@@ -858,13 +859,13 @@ fftjet_JetFunctor_parser(const edm::ParameterSet& ps)
                 new ProductFunctor<RecoFFTJet>(f1, f2, true));
             fcn1.release();
             fcn2.release();
-            return result;
+            return std::move(result);
         }
     }
 
     if (!property_type.compare("MagnitudeDependent"))
     {
-        std::auto_ptr<fftjet::Functor1<double,double> > fcn1 = 
+        std::unique_ptr<fftjet::Functor1<double,double> > fcn1 = 
             fftjet_Function_parser(
                 ps.getParameter<edm::ParameterSet>("function"));
         fftjet::Functor1<double,double>* f1 = fcn1.get();
@@ -873,7 +874,7 @@ fftjet_JetFunctor_parser(const edm::ParameterSet& ps)
             return_type result = return_type(
                 new MagnitudeDependent<RecoFFTJet>(f1, true));
             fcn1.release();
-            return result;
+            return std::move(result);
         }
     }
 
@@ -881,12 +882,12 @@ fftjet_JetFunctor_parser(const edm::ParameterSet& ps)
 }
 
 
-std::auto_ptr<fftjet::Functor2<double,
+std::unique_ptr<fftjet::Functor2<double,
                                fftjet::RecombinedJet<VectorLike>,
                                fftjet::RecombinedJet<VectorLike> > >
 fftjet_JetDistance_parser(const edm::ParameterSet& ps)
 {
-    typedef std::auto_ptr<fftjet::Functor2<
+    typedef std::unique_ptr<fftjet::Functor2<
         double,
         fftjet::RecombinedJet<VectorLike>,
         fftjet::RecombinedJet<VectorLike> > > return_type;
@@ -908,16 +909,16 @@ fftjet_JetDistance_parser(const edm::ParameterSet& ps)
 }
 
 
-std::auto_ptr<fftjet::Functor1<double,double> >
+std::unique_ptr<fftjet::Functor1<double,double> >
 fftjet_Function_parser(const edm::ParameterSet& ps)
 {
-    typedef std::auto_ptr<fftjet::Functor1<double,double> > return_type;
+    typedef std::unique_ptr<fftjet::Functor1<double,double> > return_type;
 
     const std::string fcn_type = ps.getParameter<std::string>("Class");
 
     if (!fcn_type.compare("LinearInterpolator1d"))
     {
-        std::auto_ptr<fftjet::LinearInterpolator1d> p = 
+        std::unique_ptr<fftjet::LinearInterpolator1d> p = 
             fftjet_LinearInterpolator1d_parser(ps);
         fftjet::LinearInterpolator1d* ptr = p.get();
         if (ptr)
@@ -929,7 +930,7 @@ fftjet_Function_parser(const edm::ParameterSet& ps)
 
     if (!fcn_type.compare("LinInterpolatedTable1D"))
     {
-        std::auto_ptr<fftjetcms::LinInterpolatedTable1D> p = 
+        std::unique_ptr<fftjetcms::LinInterpolatedTable1D> p = 
             fftjet_LinInterpolatedTable1D_parser(ps);
         fftjetcms::LinInterpolatedTable1D* ptr = p.get();
         if (ptr)
@@ -958,16 +959,16 @@ fftjet_Function_parser(const edm::ParameterSet& ps)
 }
 
 
-std::auto_ptr<AbsPileupCalculator>
+std::unique_ptr<AbsPileupCalculator>
 fftjet_PileupCalculator_parser(const edm::ParameterSet& ps)
 {
-    typedef std::auto_ptr<AbsPileupCalculator> return_type;
+    typedef std::unique_ptr<AbsPileupCalculator> return_type;
 
     const std::string fcn_type = ps.getParameter<std::string>("Class");
 
     if (!fcn_type.compare("EtaDependentPileup"))
     {
-        std::auto_ptr<fftjet::LinearInterpolator2d> interp = 
+        std::unique_ptr<fftjet::LinearInterpolator2d> interp = 
             fftjet_LinearInterpolator2d_parser(
                 ps.getParameter<edm::ParameterSet>("Interpolator2d"));
         const double inputRhoFactor = ps.getParameter<double>("inputRhoFactor");
@@ -983,7 +984,7 @@ fftjet_PileupCalculator_parser(const edm::ParameterSet& ps)
 
     if (!fcn_type.compare("PileupGrid2d"))
     {
-        std::auto_ptr<fftjet::Grid2d<Real> > grid = 
+        std::unique_ptr<fftjet::Grid2d<Real> > grid = 
 	    fftjet_Grid2d_parser(
 		ps.getParameter<edm::ParameterSet>("Grid2d"));
         const double rhoFactor = ps.getParameter<double>("rhoFactor");
@@ -999,10 +1000,10 @@ fftjet_PileupCalculator_parser(const edm::ParameterSet& ps)
 }
 
 
-std::auto_ptr<fftjet::JetMagnitudeMapper2d <fftjet::Peak> >
+std::unique_ptr<fftjet::JetMagnitudeMapper2d <fftjet::Peak> >
 fftjet_PeakMagnitudeMapper2d_parser (const edm::ParameterSet& ps)
 {
-    std::auto_ptr<fftjet::LinearInterpolator2d> responseCurve =
+    std::unique_ptr<fftjet::LinearInterpolator2d> responseCurve =
         fftjet_LinearInterpolator2d_parser(
             ps.getParameter<edm::ParameterSet>("responseCurve"));
 
@@ -1012,7 +1013,7 @@ fftjet_PeakMagnitudeMapper2d_parser (const edm::ParameterSet& ps)
     const double maxMagnitude = ps.getParameter<double>("maxMagnitude");
     const unsigned nMagPoints = ps.getParameter<unsigned>("nMagPoints");
 
-    return (std::auto_ptr<fftjet::JetMagnitudeMapper2d<fftjet::Peak> >
+    return (std::unique_ptr<fftjet::JetMagnitudeMapper2d<fftjet::Peak> >
              (new fftjet::JetMagnitudeMapper2d<fftjet::Peak>(
                   *responseCurve,
                   new fftjetcms::PeakAbsEta<fftjet::Peak>(),
@@ -1021,10 +1022,10 @@ fftjet_PeakMagnitudeMapper2d_parser (const edm::ParameterSet& ps)
 }
 
 
-std::auto_ptr<fftjet::JetMagnitudeMapper2d <fftjet::RecombinedJet<VectorLike> > >
+std::unique_ptr<fftjet::JetMagnitudeMapper2d <fftjet::RecombinedJet<VectorLike> > >
 fftjet_JetMagnitudeMapper2d_parser (const edm::ParameterSet& ps)
 {
-    std::auto_ptr<fftjet::LinearInterpolator2d> responseCurve =
+    std::unique_ptr<fftjet::LinearInterpolator2d> responseCurve =
         fftjet_LinearInterpolator2d_parser(
             ps.getParameter<edm::ParameterSet>("responseCurve"));
 
@@ -1034,7 +1035,7 @@ fftjet_JetMagnitudeMapper2d_parser (const edm::ParameterSet& ps)
     const double maxMagnitude = ps.getParameter<double>("maxMagnitude");
     const unsigned nMagPoints = ps.getParameter<unsigned>("nMagPoints");
 
-    return (std::auto_ptr<fftjet::JetMagnitudeMapper2d<RecoFFTJet> >
+    return (std::unique_ptr<fftjet::JetMagnitudeMapper2d<RecoFFTJet> >
             (new fftjet::JetMagnitudeMapper2d<RecoFFTJet>(
                  *responseCurve,
                  new fftjetcms::JetAbsEta<RecoFFTJet>(),

--- a/RecoJets/JetAlgorithms/src/Qjets.cc
+++ b/RecoJets/JetAlgorithms/src/Qjets.cc
@@ -97,7 +97,7 @@ void Qjets::Cluster(fastjet::ClusterSequence & cs){
   } 
 
   extras->_wij = omega;
-  cs.plugin_associate_extras(std::auto_ptr<fastjet::ClusterSequence::Extras>(extras));
+  cs.plugin_associate_extras(std::unique_ptr<fastjet::ClusterSequence::Extras>(extras));
 
   // merge remaining jets with beam
   int num_merged_final(0);

--- a/RecoJets/JetProducers/interface/ECFAdder.h
+++ b/RecoJets/JetProducers/interface/ECFAdder.h
@@ -26,7 +26,7 @@ class ECFAdder : public edm::stream::EDProducer<> {
     std::vector<std::string>               variables_;
     double                                 beta_ ;
 
-    std::vector<std::auto_ptr<fastjet::contrib::EnergyCorrelator> >  routine_; 
+    std::vector<std::unique_ptr<fastjet::contrib::EnergyCorrelator> >  routine_; 
 };
 
 #endif

--- a/RecoJets/JetProducers/interface/NjettinessAdder.h
+++ b/RecoJets/JetProducers/interface/NjettinessAdder.h
@@ -68,7 +68,7 @@ class NjettinessAdder : public edm::stream::EDProducer<> {
 
 
 
-    std::auto_ptr<fastjet::contrib::Njettiness>   routine_; 
+    std::unique_ptr<fastjet::contrib::Njettiness>   routine_; 
 
 };
 

--- a/RecoJets/JetProducers/plugins/CATopJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CATopJetProducer.cc
@@ -18,7 +18,7 @@ CATopJetProducer::CATopJetProducer(edm::ParameterSet const& conf):
 
 	if (tagAlgo_ == CA_TOPTAGGER ) {
 		
-		legacyCMSTopTagger_ = std::auto_ptr<CATopJetAlgorithm>(
+		legacyCMSTopTagger_ = std::unique_ptr<CATopJetAlgorithm>(
 			new CATopJetAlgorithm(src_,
 			conf.getParameter<bool>  ("verbose"),              
        			conf.getParameter<int>	("algorithm"),                  // 0 = KT, 1 = CA, 2 = anti-KT
@@ -41,14 +41,14 @@ CATopJetProducer::CATopJetProducer(edm::ParameterSet const& conf):
       		));
 	}
 	else if (tagAlgo_ == FJ_CMS_TOPTAG ) {
-		fjCMSTopTagger_ = std::auto_ptr<fastjet::CMSTopTagger>(
+		fjCMSTopTagger_ = std::unique_ptr<fastjet::CMSTopTagger>(
 			new fastjet::CMSTopTagger(conf.getParameter<double> ("ptFrac"),
 						  conf.getParameter<double> ("rFrac"),
 						  conf.getParameter<double> ("adjacencyParam"))
 		);
 	}
 	else if (tagAlgo_ == FJ_JHU_TOPTAG ) {
-		fjJHUTopTagger_ = std::auto_ptr<fastjet::JHTopTagger>(
+		fjJHUTopTagger_ = std::unique_ptr<fastjet::JHTopTagger>(
 			new fastjet::JHTopTagger(conf.getParameter<double>("ptFrac"),
 						 conf.getParameter<double>("deltaRCut"),
 						 conf.getParameter<double>("cosThetaWMax")
@@ -59,7 +59,7 @@ CATopJetProducer::CATopJetProducer(edm::ParameterSet const& conf):
 		
 		fastjet::JetDefinition::Plugin *plugin = new fastjet::SISConePlugin(0.6, 0.75);
 		fastjet::JetDefinition NsubJetDef(plugin);
-		fjNSUBTagger_ = std::auto_ptr<fastjet::RestFrameNSubjettinessTagger>(
+		fjNSUBTagger_ = std::unique_ptr<fastjet::RestFrameNSubjettinessTagger>(
 			new fastjet::RestFrameNSubjettinessTagger(NsubJetDef,
 								  conf.getParameter<double>("tau2Cut"),
 								  conf.getParameter<double>("cosThetaSCut"),

--- a/RecoJets/JetProducers/plugins/CATopJetProducer.h
+++ b/RecoJets/JetProducers/plugins/CATopJetProducer.h
@@ -88,10 +88,10 @@ namespace cms
     virtual void runAlgorithm( edm::Event& iEvent, const edm::EventSetup& iSetup );
 
   private:
-    std::auto_ptr<CATopJetAlgorithm>        legacyCMSTopTagger_;         /// The algorithm to do the work
-    std::auto_ptr<fastjet::CMSTopTagger>     fjCMSTopTagger_;    // The FastJet implementation of the CMS tagger
-    std::auto_ptr<fastjet::JHTopTagger>     fjJHUTopTagger_;
-    std::auto_ptr<fastjet::RestFrameNSubjettinessTagger>   fjNSUBTagger_;
+    std::unique_ptr<CATopJetAlgorithm>        legacyCMSTopTagger_;         /// The algorithm to do the work
+    std::unique_ptr<fastjet::CMSTopTagger>     fjCMSTopTagger_;    // The FastJet implementation of the CMS tagger
+    std::unique_ptr<fastjet::JHTopTagger>     fjJHUTopTagger_;
+    std::unique_ptr<fastjet::RestFrameNSubjettinessTagger>   fjNSUBTagger_;
 
 
 

--- a/RecoJets/JetProducers/plugins/ECFAdder.cc
+++ b/RecoJets/JetProducers/plugins/ECFAdder.cc
@@ -15,7 +15,7 @@ ECFAdder::ECFAdder(const edm::ParameterSet& iConfig) :
       ecfN_str << "ecf" << *n;
       variables_.push_back(ecfN_str.str());
       produces<edm::ValueMap<float> >(ecfN_str.str().c_str());
-      routine_.push_back(std::auto_ptr<fastjet::contrib::EnergyCorrelator> ( new fastjet::contrib::EnergyCorrelator( *n, beta_, fastjet::contrib::EnergyCorrelator::pt_R ) ));
+      routine_.push_back(std::unique_ptr<fastjet::contrib::EnergyCorrelator> ( new fastjet::contrib::EnergyCorrelator( *n, beta_, fastjet::contrib::EnergyCorrelator::pt_R ) ));
     }  
 }
 

--- a/RecoJets/JetProducers/plugins/HTTTopJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/HTTTopJetProducer.cc
@@ -103,7 +103,7 @@ HTTTopJetProducer::HTTTopJetProducer(edm::ParameterSet const& conf):
   // Signal to the VirtualJetProducer that we have to add HTT information
   fromHTTTopJetProducer_ = 1;
   
-  fjHEPTopTagger_ = std::auto_ptr<fastjet::HEPTopTaggerV2>(new fastjet::HEPTopTaggerV2(
+  fjHEPTopTagger_ = std::unique_ptr<fastjet::HEPTopTaggerV2>(new fastjet::HEPTopTaggerV2(
 										       optimalR_,
 										       qJets_,
 										       minSubjetPt_, 

--- a/RecoJets/JetProducers/plugins/HTTTopJetProducer.h
+++ b/RecoJets/JetProducers/plugins/HTTTopJetProducer.h
@@ -92,7 +92,7 @@ namespace cms
 
 
   private:
-    std::auto_ptr<fastjet::HEPTopTaggerV2>        fjHEPTopTagger_;
+    std::unique_ptr<fastjet::HEPTopTaggerV2>        fjHEPTopTagger_;
 
     // Below are all configurable options. 
     // Parenthesis indicates if this is enforced by the tagger itself or by the producer

--- a/RecoJets/JetProducers/plugins/NjettinessAdder.cc
+++ b/RecoJets/JetProducers/plugins/NjettinessAdder.cc
@@ -70,7 +70,7 @@ NjettinessAdder::NjettinessAdder(const edm::ParameterSet& iConfig) :
   case  MultiPass_Axes : axesDef = &multipass_axes; break;
   };
 
-  routine_ = std::auto_ptr<fastjet::contrib::Njettiness> ( new fastjet::contrib::Njettiness( *axesDef, *measureDef ) );
+  routine_ = std::unique_ptr<fastjet::contrib::Njettiness> ( new fastjet::contrib::Njettiness( *axesDef, *measureDef ) );
       
 }
 

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -154,7 +154,7 @@ VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig) {
 	minSeed_ 		= iConfig.getParameter<unsigned int>("minSeed");
 	verbosity_ 		= iConfig.getParameter<int>	("verbosity");
 
-	anomalousTowerDef_ = auto_ptr<AnomalousTower>(new AnomalousTower(iConfig));
+	anomalousTowerDef_ = unique_ptr<AnomalousTower>(new AnomalousTower(iConfig));
 
 	input_vertex_token_ = consumes<reco::VertexCollection>(srcPVs_);
 	input_candidateview_token_ = consumes<reco::CandidateView>(src_);

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.h
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.h
@@ -219,7 +219,7 @@ protected:
   bool                  fromHTTTopJetProducer_;   // for running the v2.0 HEPTopTagger
 
 private:
-  std::auto_ptr<AnomalousTower>   anomalousTowerDef_;  // anomalous tower definition
+  std::unique_ptr<AnomalousTower>   anomalousTowerDef_;  // anomalous tower definition
 
   // tokens for the data access
   edm::EDGetTokenT<reco::CandidateView> input_candidateview_token_;

--- a/RecoLocalTracker/SiStripClusterizer/interface/StripClusterizerAlgorithmFactory.h
+++ b/RecoLocalTracker/SiStripClusterizer/interface/StripClusterizerAlgorithmFactory.h
@@ -7,6 +7,6 @@ class StripClusterizerAlgorithm;
 
 class StripClusterizerAlgorithmFactory {
  public:
-  static std::auto_ptr<StripClusterizerAlgorithm> create(const edm::ParameterSet&);
+  static std::unique_ptr<StripClusterizerAlgorithm> create(const edm::ParameterSet&);
 };
 #endif

--- a/RecoLocalTracker/SiStripClusterizer/src/SiStripClusterInfo.cc
+++ b/RecoLocalTracker/SiStripClusterizer/src/SiStripClusterInfo.cc
@@ -158,7 +158,7 @@ reclusterize(const edm::ParameterSet& conf) const {
       ? static_cast<uint8_t>(charges[i] * gains[i])
       : charges[i];
 
-  std::auto_ptr<StripClusterizerAlgorithm> 
+  std::unique_ptr<StripClusterizerAlgorithm> 
     algorithm = StripClusterizerAlgorithmFactory::create(conf);
   algorithm->initialize(es);
   auto const & det = algorithm->stripByStripBegin( detId_ );

--- a/RecoLocalTracker/SiStripClusterizer/src/StripClusterizerAlgorithmFactory.cc
+++ b/RecoLocalTracker/SiStripClusterizer/src/StripClusterizerAlgorithmFactory.cc
@@ -5,12 +5,12 @@
 #include "RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h"
 #include "RecoLocalTracker/SiStripClusterizer/interface/ClusterChargeCut.h"
 
-std::auto_ptr<StripClusterizerAlgorithm> StripClusterizerAlgorithmFactory::
+std::unique_ptr<StripClusterizerAlgorithm> StripClusterizerAlgorithmFactory::
 create(const edm::ParameterSet& conf) {
   std::string algorithm = conf.getParameter<std::string>("Algorithm");
 
   if(algorithm == "ThreeThresholdAlgorithm") {
-    return std::auto_ptr<StripClusterizerAlgorithm>(
+    return std::unique_ptr<StripClusterizerAlgorithm>(
 	   new ThreeThresholdAlgorithm(
 	       conf.getParameter<double>("ChannelThreshold"),
 	       conf.getParameter<double>("SeedThreshold"),

--- a/RecoLocalTracker/SiStripClusterizer/test/StripByStripTestDriver.h
+++ b/RecoLocalTracker/SiStripClusterizer/test/StripByStripTestDriver.h
@@ -28,7 +28,7 @@ private:
   const bool hlt;
 
   //SiStripClusterizerFactory*               hltFactory;
-  std::auto_ptr<StripClusterizerAlgorithm> algorithm;
+  std::unique_ptr<StripClusterizerAlgorithm> algorithm;
 
 };
 #endif

--- a/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingAlgorithms.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingAlgorithms.h
@@ -26,19 +26,19 @@ class SiStripRawProcessingAlgorithms {
   inline std::map< uint16_t, std::map< uint16_t, int16_t> >& GetSmoothedPoints(){return restorer->GetSmoothedPoints();}
   inline const std::vector< std::pair<short,float> >& getAPVsCM(){return subtractorCMN->getAPVsCM();}
 
-  const std::auto_ptr<SiStripPedestalsSubtractor> subtractorPed;
-  const std::auto_ptr<SiStripCommonModeNoiseSubtractor> subtractorCMN;
-  const std::auto_ptr<SiStripFedZeroSuppression> suppressor;
-  const std::auto_ptr<SiStripAPVRestorer> restorer;
+  const std::unique_ptr<SiStripPedestalsSubtractor> subtractorPed;
+  const std::unique_ptr<SiStripCommonModeNoiseSubtractor> subtractorCMN;
+  const std::unique_ptr<SiStripFedZeroSuppression> suppressor;
+  const std::unique_ptr<SiStripAPVRestorer> restorer;
 
  private:
   const bool doAPVRestore;
   const bool useCMMeanMap;
 
-  SiStripRawProcessingAlgorithms(std::auto_ptr<SiStripPedestalsSubtractor> ped,
-				 std::auto_ptr<SiStripCommonModeNoiseSubtractor> cmn,
-				 std::auto_ptr<SiStripFedZeroSuppression> zs,
-                                 std::auto_ptr<SiStripAPVRestorer> res,
+  SiStripRawProcessingAlgorithms(std::unique_ptr<SiStripPedestalsSubtractor> ped,
+				 std::unique_ptr<SiStripCommonModeNoiseSubtractor> cmn,
+				 std::unique_ptr<SiStripFedZeroSuppression> zs,
+                                 std::unique_ptr<SiStripAPVRestorer> res,
 				 bool doAPVRest,
 				 bool useCMMap); 
    

--- a/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingFactory.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingFactory.h
@@ -14,12 +14,12 @@ class SiStripRawProcessingFactory {
 
  public:
   
-  static std::auto_ptr<SiStripRawProcessingAlgorithms> create(const edm::ParameterSet&);
+  static std::unique_ptr<SiStripRawProcessingAlgorithms> create(const edm::ParameterSet&);
 
-  static std::auto_ptr<SiStripFedZeroSuppression> create_Suppressor(const edm::ParameterSet&);
-  static std::auto_ptr<SiStripPedestalsSubtractor> create_SubtractorPed(const edm::ParameterSet&);
-  static std::auto_ptr<SiStripCommonModeNoiseSubtractor> create_SubtractorCMN(const edm::ParameterSet&);
-  static std::auto_ptr<SiStripAPVRestorer> create_Restorer( const edm::ParameterSet&);
+  static std::unique_ptr<SiStripFedZeroSuppression> create_Suppressor(const edm::ParameterSet&);
+  static std::unique_ptr<SiStripPedestalsSubtractor> create_SubtractorPed(const edm::ParameterSet&);
+  static std::unique_ptr<SiStripCommonModeNoiseSubtractor> create_SubtractorCMN(const edm::ParameterSet&);
+  static std::unique_ptr<SiStripAPVRestorer> create_Restorer( const edm::ParameterSet&);
   
   static bool create_doAPVRestorer(const edm::ParameterSet&);
   static bool create_useCMMeanMap(const edm::ParameterSet&);

--- a/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripBaselineAnalyzer.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripBaselineAnalyzer.cc
@@ -84,7 +84,7 @@ class SiStripBaselineAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedReso
       virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
       virtual void endJob() override ;
       
-	  std::auto_ptr<SiStripPedestalsSubtractor>   subtractorPed_;
+	  std::unique_ptr<SiStripPedestalsSubtractor>   subtractorPed_;
           edm::ESHandle<SiStripPedestals> pedestalsHandle;
           std::vector<int> pedestals;
           uint32_t peds_cache_id;

--- a/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.h
@@ -43,7 +43,7 @@ class SiStripZeroSuppression : public edm::stream::EDProducer<>
   std::vector< edm::DetSet<SiStripProcessedRawDigi> > output_apvcm; 
   std::vector< edm::DetSet<SiStripProcessedRawDigi> > output_baseline;
   std::vector< edm::DetSet<SiStripDigi> > output_baseline_points;
-  std::auto_ptr<SiStripRawProcessingAlgorithms> algorithms;
+  std::unique_ptr<SiStripRawProcessingAlgorithms> algorithms;
   typedef edm::EDGetTokenT< edm::DetSetVector<SiStripRawDigi> > token_t;
   typedef std::vector<token_t> token_v;
   typedef token_v::const_iterator token_iterator_t;

--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripRawProcessingAlgorithms.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripRawProcessingAlgorithms.cc
@@ -9,18 +9,19 @@
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
 #include "RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingFactory.h"
 #include <memory>
+#include <utility>
 
 
-SiStripRawProcessingAlgorithms::SiStripRawProcessingAlgorithms(std::auto_ptr<SiStripPedestalsSubtractor> ped,
-				 std::auto_ptr<SiStripCommonModeNoiseSubtractor> cmn,
-				 std::auto_ptr<SiStripFedZeroSuppression> zs,
-				 std::auto_ptr<SiStripAPVRestorer> res,
+SiStripRawProcessingAlgorithms::SiStripRawProcessingAlgorithms(std::unique_ptr<SiStripPedestalsSubtractor> ped,
+				 std::unique_ptr<SiStripCommonModeNoiseSubtractor> cmn,
+				 std::unique_ptr<SiStripFedZeroSuppression> zs,
+				 std::unique_ptr<SiStripAPVRestorer> res,
 				 bool doAPVRest,
 				 bool useCMMap)
-    :  subtractorPed(ped),
-       subtractorCMN(cmn),
-       suppressor(zs),
-       restorer(res),
+    :  subtractorPed(std::move(ped)),
+       subtractorCMN(std::move(cmn)),
+       suppressor(std::move(zs)),
+       restorer(std::move(res)),
        doAPVRestore(doAPVRest),
        useCMMeanMap(useCMMap)
     {}

--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripRawProcessingFactory.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripRawProcessingFactory.cc
@@ -11,9 +11,9 @@
 #include "RecoLocalTracker/SiStripZeroSuppression/interface/TT6CMNSubtractor.h"
 
 
-std::auto_ptr<SiStripRawProcessingAlgorithms> SiStripRawProcessingFactory::
+std::unique_ptr<SiStripRawProcessingAlgorithms> SiStripRawProcessingFactory::
 create(const edm::ParameterSet& conf) {
-  return std::auto_ptr<SiStripRawProcessingAlgorithms>(
+  return std::unique_ptr<SiStripRawProcessingAlgorithms>(
 	           new SiStripRawProcessingAlgorithms(
 						      create_SubtractorPed(conf),
 						      create_SubtractorCMN(conf),
@@ -33,63 +33,63 @@ bool SiStripRawProcessingFactory::create_useCMMeanMap(const edm::ParameterSet&co
    return useCMMeanMap; 
 }
 
-std::auto_ptr<SiStripPedestalsSubtractor> SiStripRawProcessingFactory::
+std::unique_ptr<SiStripPedestalsSubtractor> SiStripRawProcessingFactory::
 create_SubtractorPed(const edm::ParameterSet& conf) {
   bool fedMode = conf.getParameter<bool>("PedestalSubtractionFedMode");
-  return std::auto_ptr<SiStripPedestalsSubtractor>( new SiStripPedestalsSubtractor(fedMode) );
+  return std::unique_ptr<SiStripPedestalsSubtractor>( new SiStripPedestalsSubtractor(fedMode) );
 }
 
-std::auto_ptr<SiStripCommonModeNoiseSubtractor> SiStripRawProcessingFactory::
+std::unique_ptr<SiStripCommonModeNoiseSubtractor> SiStripRawProcessingFactory::
 create_SubtractorCMN(const edm::ParameterSet& conf) {
   std::string mode = conf.getParameter<std::string>("CommonModeNoiseSubtractionMode");
 
   if ( mode == "Median")
-    return std::auto_ptr<SiStripCommonModeNoiseSubtractor>( new MedianCMNSubtractor() );
+    return std::unique_ptr<SiStripCommonModeNoiseSubtractor>( new MedianCMNSubtractor() );
 
   if ( mode == "Percentile") {
     double percentile = conf.getParameter<double>("Percentile");
-    return std::auto_ptr<SiStripCommonModeNoiseSubtractor>( new PercentileCMNSubtractor(percentile) );
+    return std::unique_ptr<SiStripCommonModeNoiseSubtractor>( new PercentileCMNSubtractor(percentile) );
   }
 
   if ( mode == "IteratedMedian") {
     double cutToAvoidSignal = conf.getParameter<double>("CutToAvoidSignal");
     int iterations = conf.getParameter<int>("Iterations");
-    return std::auto_ptr<SiStripCommonModeNoiseSubtractor>( new IteratedMedianCMNSubtractor(cutToAvoidSignal,iterations) );
+    return std::unique_ptr<SiStripCommonModeNoiseSubtractor>( new IteratedMedianCMNSubtractor(cutToAvoidSignal,iterations) );
   }
 
   if ( mode == "FastLinear")
-    return std::auto_ptr<SiStripCommonModeNoiseSubtractor>( new FastLinearCMNSubtractor() );
+    return std::unique_ptr<SiStripCommonModeNoiseSubtractor>( new FastLinearCMNSubtractor() );
 
   if ( mode == "TT6") {
     double cutToAvoidSignal = conf.getParameter<double>("CutToAvoidSignal");
-    return std::auto_ptr<SiStripCommonModeNoiseSubtractor>( new TT6CMNSubtractor(cutToAvoidSignal) );
+    return std::unique_ptr<SiStripCommonModeNoiseSubtractor>( new TT6CMNSubtractor(cutToAvoidSignal) );
   }
   
   edm::LogError("SiStripRawProcessingFactory::create_SubtractorCMN")
     << "Unregistered Algorithm: "<<mode<<". Use one of {Median, Percentile, IteratedMedian, FastLinear, TT6}";
-  return std::auto_ptr<SiStripCommonModeNoiseSubtractor>( new MedianCMNSubtractor() );
+  return std::unique_ptr<SiStripCommonModeNoiseSubtractor>( new MedianCMNSubtractor() );
 }
 
-std::auto_ptr<SiStripFedZeroSuppression> SiStripRawProcessingFactory::
+std::unique_ptr<SiStripFedZeroSuppression> SiStripRawProcessingFactory::
 create_Suppressor(const edm::ParameterSet& conf) {
   uint32_t mode = conf.getParameter<uint32_t>("SiStripFedZeroSuppressionMode");
   bool trunc = conf.getParameter<bool>("TruncateInSuppressor");
   switch(mode) {
   case 1: case 2: case 3:  case 4:
-    return std::auto_ptr<SiStripFedZeroSuppression>( new SiStripFedZeroSuppression(mode,trunc));
+    return std::unique_ptr<SiStripFedZeroSuppression>( new SiStripFedZeroSuppression(mode,trunc));
   default:
     edm::LogError("SiStripRawProcessingFactory::createSuppressor")
       << "Unregistered mode: "<<mode<<". Use one of {1,2,3,4}.";
-    return std::auto_ptr<SiStripFedZeroSuppression>( new SiStripFedZeroSuppression(4,true));
+    return std::unique_ptr<SiStripFedZeroSuppression>( new SiStripFedZeroSuppression(4,true));
   }
 }
 
-std::auto_ptr<SiStripAPVRestorer> SiStripRawProcessingFactory::
+std::unique_ptr<SiStripAPVRestorer> SiStripRawProcessingFactory::
 create_Restorer( const edm::ParameterSet& conf) {
   if(!conf.exists("APVRestoreMode")) {
-    return std::auto_ptr<SiStripAPVRestorer>( 0 );
+    return std::unique_ptr<SiStripAPVRestorer>( 0 );
   } else {
-    return std::auto_ptr<SiStripAPVRestorer> (new SiStripAPVRestorer(conf));
+    return std::unique_ptr<SiStripAPVRestorer> (new SiStripAPVRestorer(conf));
   }
 }
 

--- a/RecoLuminosity/LumiProducer/plugins/Lumi2DB.cc
+++ b/RecoLuminosity/LumiProducer/plugins/Lumi2DB.cc
@@ -749,7 +749,7 @@ lumi::Lumi2DB::retrieveData( unsigned int runnumber){
     throw lumi::Exception(std::string("non-existing HLXData "),"retrieveData","Lumi2DB");
   }
   //hlxtree->Print();
-  std::auto_ptr<HCAL_HLX::LUMI_SECTION> localSection(new HCAL_HLX::LUMI_SECTION);
+  std::unique_ptr<HCAL_HLX::LUMI_SECTION> localSection(new HCAL_HLX::LUMI_SECTION);
   HCAL_HLX::LUMI_SECTION_HEADER* lumiheader = &(localSection->hdr);
   HCAL_HLX::LUMI_SUMMARY* lumisummary = &(localSection->lumiSummary);
   HCAL_HLX::LUMI_DETAIL* lumidetail = &(localSection->lumiDetail);
@@ -766,7 +766,7 @@ lumi::Lumi2DB::retrieveData( unsigned int runnumber){
   TTree *diptree= (TTree*)source->Get("DIPCombined");
   if(diptree){
     //throw lumi::Exception(std::string("non-existing DIPData "),"retrieveData","Lumi2DB");
-    std::auto_ptr<HCAL_HLX::DIP_COMBINED_DATA> dipdata(new HCAL_HLX::DIP_COMBINED_DATA);
+    std::unique_ptr<HCAL_HLX::DIP_COMBINED_DATA> dipdata(new HCAL_HLX::DIP_COMBINED_DATA);
     diptree->SetBranchAddress("DIPCombined.",&dipdata);
     size_t ndipentries=diptree->GetEntries();
     for(size_t i=0;i<ndipentries;++i){

--- a/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.cc
@@ -109,7 +109,7 @@ LumiCorrectionSource::servletTranslation(const std::string& servlet) const{
   std::string frontierConnect;
   std::string realconnect;
   cms::concurrency::xercesInitialize();  
-  std::auto_ptr< xercesc::XercesDOMParser > parser(new xercesc::XercesDOMParser);
+  std::unique_ptr< xercesc::XercesDOMParser > parser(new xercesc::XercesDOMParser);
   try{
     parser->setValidationScheme(xercesc::XercesDOMParser::Val_Auto);
     parser->setDoNamespaces(false);

--- a/RecoLuminosity/LumiProducer/plugins/LumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiProducer.cc
@@ -209,7 +209,7 @@ LumiProducer::servletTranslation(const std::string& servlet) const{
   std::string frontierConnect;
   std::string realconnect;
   cms::concurrency::xercesInitialize();  
-  std::auto_ptr< xercesc::XercesDOMParser > parser(new xercesc::XercesDOMParser);
+  std::unique_ptr< xercesc::XercesDOMParser > parser(new xercesc::XercesDOMParser);
   try{
     parser->setValidationScheme(xercesc::XercesDOMParser::Val_Auto);
     parser->setDoNamespaces(false);

--- a/RecoLuminosity/LumiProducer/src/LumiCorrectionParam.cc
+++ b/RecoLuminosity/LumiProducer/src/LumiCorrectionParam.cc
@@ -9,7 +9,7 @@ LumiCorrectionParam::LumiCorrectionParam(LumiCorrectionParam::LumiType lumitype)
 
 float 
 LumiCorrectionParam::getCorrection(float luminonorm)const{
-  std::auto_ptr<lumi::NormFunctor> ptr(lumi::NormFunctorPluginFactory::get()->create(m_corrfunc));
+  std::unique_ptr<lumi::NormFunctor> ptr(lumi::NormFunctorPluginFactory::get()->create(m_corrfunc));
   (*ptr).initialize(m_coeffmap,m_afterglows);
   float result=(*ptr).getCorrection(luminonorm,m_intglumi,m_ncollidingbx);
   return result;

--- a/RecoLuminosity/LumiProducer/test/cmmdLoadLumiDB.cpp
+++ b/RecoLuminosity/LumiProducer/test/cmmdLoadLumiDB.cpp
@@ -232,7 +232,7 @@ int main(int argc, char** argv){
   if(!without_lumi){
     std::cout<<"Loading lumi from "<<lumipath<<" to "<< destconnect <<" run "<<runnumber<<" with "<<lumipluginName<<std::endl;
     try{
-      std::auto_ptr<lumi::DataPipe> lumiptr(lumi::DataPipeFactory::get()->create(lumipluginName,destconnect));
+      std::unique_ptr<lumi::DataPipe> lumiptr(lumi::DataPipeFactory::get()->create(lumipluginName,destconnect));
       lumiptr->setAuthPath(authpath);
       lumiptr->setSource(lumipath);
       if(novalidate){
@@ -283,7 +283,7 @@ int main(int argc, char** argv){
   if(!without_runsummary){
     std::cout<<"Loading runsummary from "<<runinfodb<<" to "<<destconnect <<" run "<<runnumber<<" with "<<runsummarypluginName<<std::endl;
      try{
-	std::auto_ptr<lumi::DataPipe> runptr(lumi::DataPipeFactory::get()->create(runsummarypluginName,destconnect));
+	std::unique_ptr<lumi::DataPipe> runptr(lumi::DataPipeFactory::get()->create(runsummarypluginName,destconnect));
 	runptr->setSource(runinfodb);
 	runptr->setAuthPath(authpath);
 	if(!collision_only){
@@ -313,7 +313,7 @@ int main(int argc, char** argv){
   if(!without_hltconf){
     try{
       std::cout<<"Loading hlt conf from "<<hltconfdb<<" to "<<destconnect <<" run "<<runnumber<<" with "<<hltconfpluginName<<std::endl;
-      std::auto_ptr<lumi::DataPipe> confptr(lumi::DataPipeFactory::get()->create(hltconfpluginName,destconnect));
+      std::unique_ptr<lumi::DataPipe> confptr(lumi::DataPipeFactory::get()->create(hltconfpluginName,destconnect));
       confptr->setSource(hltconfdb);
       confptr->setAuthPath(authpath);
       startClock=clock();
@@ -337,7 +337,7 @@ int main(int argc, char** argv){
     try{
       if(!use_wbm){
 	std::cout<<"Loading trg from GT "<<trgdb<<" to "<<destconnect <<" run "<<runnumber<<" with "<<trgpluginName<<std::endl;
-	std::auto_ptr<lumi::DataPipe> trgptr(lumi::DataPipeFactory::get()->create(trgpluginName,destconnect));
+	std::unique_ptr<lumi::DataPipe> trgptr(lumi::DataPipeFactory::get()->create(trgpluginName,destconnect));
 	trgptr->setAuthPath(authpath);
 	trgptr->setSource(trgdb);
 	if(!schemav2_only){
@@ -351,7 +351,7 @@ int main(int argc, char** argv){
 	trgptr.release();
       }else{
 	std::cout<<"Loading trg from WBM "<<wbmdb<<" to "<<destconnect <<" run "<<runnumber<<" with "<<wbmpluginName<<std::endl;
-	std::auto_ptr<lumi::DataPipe> trgptr(lumi::DataPipeFactory::get()->create(wbmpluginName,destconnect));
+	std::unique_ptr<lumi::DataPipe> trgptr(lumi::DataPipeFactory::get()->create(wbmpluginName,destconnect));
 	trgptr->setAuthPath(authpath);
 	trgptr->setSource(wbmdb);
 	startClock=clock();
@@ -375,7 +375,7 @@ int main(int argc, char** argv){
   if(!without_hlt){
     std::cout<<"Loading hlt from Runinfo "<<runinfodb <<" to "<<destconnect<<" run "<<runnumber<<" with "<<hltpluginName<<std::endl;
     try{
-      std::auto_ptr<lumi::DataPipe> hltptr(lumi::DataPipeFactory::get()->create(hltpluginName,destconnect));
+      std::unique_ptr<lumi::DataPipe> hltptr(lumi::DataPipeFactory::get()->create(hltpluginName,destconnect));
       hltptr->setSource(runinfodb);
       hltptr->setAuthPath(authpath);
       if(!schemav2_only){

--- a/RecoLuminosity/LumiProducer/test/standaloneScanLumiRaw.cpp
+++ b/RecoLuminosity/LumiProducer/test/standaloneScanLumiRaw.cpp
@@ -92,7 +92,7 @@ int main(int argc, char** argv){
   TTree *diptree=(TTree*)myfile->Get("DIPCombined");
   
   if(diptree){
-    std::auto_ptr<HCAL_HLX::DIP_COMBINED_DATA> dipdata(new HCAL_HLX::DIP_COMBINED_DATA);
+    std::unique_ptr<HCAL_HLX::DIP_COMBINED_DATA> dipdata(new HCAL_HLX::DIP_COMBINED_DATA);
     diptree->SetBranchAddress("DIPCombined.",&dipdata);
     size_t ndipentries=diptree->GetEntries();
     unsigned int dipls=0;

--- a/RecoLuminosity/LumiProducer/test/testWrite2LumiDB.cpp
+++ b/RecoLuminosity/LumiProducer/test/testWrite2LumiDB.cpp
@@ -68,7 +68,7 @@ int main(int argc, char** argv){
   //fill trg data
   try{
     std::cout<<"fill out trg data"<<std::endl;
-    std::auto_ptr<lumi::DataPipe> trgptr(lumi::DataPipeFactory::get()->create("TRG2DB",con));
+    std::unique_ptr<lumi::DataPipe> trgptr(lumi::DataPipeFactory::get()->create("TRG2DB",con));
     trgptr->setAuthPath(authpath);
     //trgptr->setSource("oracle://cms_omds_lb/CMS_GT_MON");
     trgptr->setSource("oracle://cms_orcoff_prod/CMS_GT_MON");

--- a/RecoLuminosity/LumiProducer/test/testWriteHLTConf2LumiDB.cpp
+++ b/RecoLuminosity/LumiProducer/test/testWriteHLTConf2LumiDB.cpp
@@ -7,7 +7,7 @@ int main(){
   edmplugin::PluginManager::Config config;
   edmplugin::PluginManager::configure(edmplugin::standard::config());
   const std::string con("sqlite_file:pippo.db");
-  std::auto_ptr<lumi::DataPipe> ptr(lumi::DataPipeFactory::get()->create("HLTConfDummy2DB",con));
+  std::unique_ptr<lumi::DataPipe> ptr(lumi::DataPipeFactory::get()->create("HLTConfDummy2DB",con));
   unsigned int hltconfId=5678;
   ptr->retrieveData(hltconfId);
   return 0;

--- a/RecoLuminosity/LumiProducer/test/validation/populateDummy2LumiDB.cpp
+++ b/RecoLuminosity/LumiProducer/test/validation/populateDummy2LumiDB.cpp
@@ -15,30 +15,30 @@ int main(){
   unsigned int fakerunnumber=1234;
   //fill cmsrunsummary data
   std::cout<<"fill out runsummary data"<<std::endl;
-  std::auto_ptr<lumi::DataPipe> runptr(lumi::DataPipeFactory::get()->create("CMSRunSummaryDummy2DB",con));
+  std::unique_ptr<lumi::DataPipe> runptr(lumi::DataPipeFactory::get()->create("CMSRunSummaryDummy2DB",con));
   runptr->setAuthPath(authpath);
   runptr->retrieveData(fakerunnumber);
   
   //fill lhx data
-  std::auto_ptr<lumi::DataPipe> lumiptr(lumi::DataPipeFactory::get()->create("LumiDummy2DB",con));
+  std::unique_ptr<lumi::DataPipe> lumiptr(lumi::DataPipeFactory::get()->create("LumiDummy2DB",con));
   lumiptr->setAuthPath(authpath);
   lumiptr->retrieveData(fakerunnumber);
    
   //fill trg data
   std::cout<<"fill out trg data"<<std::endl;
-  std::auto_ptr<lumi::DataPipe> trgptr(lumi::DataPipeFactory::get()->create("TRGDummy2DB",con));
+  std::unique_ptr<lumi::DataPipe> trgptr(lumi::DataPipeFactory::get()->create("TRGDummy2DB",con));
   trgptr->setAuthPath(authpath);
   trgptr->retrieveData(fakerunnumber);
    
   //fill hlt conf data
   std::cout<<"fill out conf data"<<std::endl;
-  std::auto_ptr<lumi::DataPipe> confptr(lumi::DataPipeFactory::get()->create("HLTConfDummy2DB",con));
+  std::unique_ptr<lumi::DataPipe> confptr(lumi::DataPipeFactory::get()->create("HLTConfDummy2DB",con));
   confptr->setAuthPath(authpath);
   confptr->retrieveData(fakerunnumber);
   
   //fill hlt scaler data
   std::cout<<"fill out hlt data"<<std::endl;
-  std::auto_ptr<lumi::DataPipe> hltptr(lumi::DataPipeFactory::get()->create("HLTDummy2DB",con));
+  std::unique_ptr<lumi::DataPipe> hltptr(lumi::DataPipeFactory::get()->create("HLTDummy2DB",con));
   hltptr->setAuthPath(authpath);
   hltptr->retrieveData(fakerunnumber);
   return 0;

--- a/RecoParticleFlow/PFProducer/plugins/PFProducer.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFProducer.h
@@ -109,7 +109,7 @@ class PFProducer : public edm::stream::EDProducer<> {
   // std::vector<std::string> fToRead;
   
   /// particle flow algorithm
-  std::auto_ptr<PFAlgo>      pfAlgo_;
+  std::unique_ptr<PFAlgo>      pfAlgo_;
 
 };
 

--- a/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexCandidateFinder.h
+++ b/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexCandidateFinder.h
@@ -62,9 +62,9 @@ class PFDisplacedVertexCandidateFinder {
   
   
   /// \return auto_ptr to collection of DisplacedVertexCandidates
-  std::auto_ptr< reco::PFDisplacedVertexCandidateCollection > transferVertexCandidates() {return vertexCandidates_;}
+  std::unique_ptr< reco::PFDisplacedVertexCandidateCollection > transferVertexCandidates() {return std::move(vertexCandidates_);}
 
-  const std::auto_ptr< reco::PFDisplacedVertexCandidateCollection >& vertexCandidates() const 
+  const std::unique_ptr< reco::PFDisplacedVertexCandidateCollection >& vertexCandidates() const 
     {return vertexCandidates_;}
 
   /// -------- Main function which find vertices -------- ///
@@ -116,7 +116,7 @@ class PFDisplacedVertexCandidateFinder {
 
   /// -------- Members -------- ///
 
-  std::auto_ptr< reco::PFDisplacedVertexCandidateCollection > vertexCandidates_;
+  std::unique_ptr< reco::PFDisplacedVertexCandidateCollection > vertexCandidates_;
   
 
   /// The track refs

--- a/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexFinder.h
+++ b/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexFinder.h
@@ -107,9 +107,9 @@ class PFDisplacedVertexFinder {
   
   
   /// \return auto_ptr to collection of DisplacedVertices
-  std::auto_ptr< reco::PFDisplacedVertexCollection > transferDisplacedVertices() {return displacedVertices_;}
+  std::unique_ptr< reco::PFDisplacedVertexCollection > transferDisplacedVertices() {return std::move(displacedVertices_);}
 
-  const std::auto_ptr< reco::PFDisplacedVertexCollection >& displacedVertices() const {return displacedVertices_;}
+  const std::unique_ptr< reco::PFDisplacedVertexCollection >& displacedVertices() const {return displacedVertices_;}
 
 
 
@@ -154,7 +154,7 @@ class PFDisplacedVertexFinder {
   /// -------- Members -------- ///
 
   reco::PFDisplacedVertexCandidateCollection const*  displacedVertexCandidates_;
-  std::auto_ptr< reco::PFDisplacedVertexCollection >    displacedVertices_;
+  std::unique_ptr< reco::PFDisplacedVertexCollection >    displacedVertices_;
 
   /// -------- Parameters -------- ///
 

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.cc
@@ -13,6 +13,7 @@
 
 
 #include <set>
+#include <utility>
 
 using namespace std;
 using namespace edm;

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.cc
@@ -20,6 +20,7 @@
 #include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertexCandidateFwd.h"
 
 #include <set>
+#include <utility>
 
 using namespace std;
 using namespace edm;

--- a/RecoParticleFlow/PFTracking/plugins/modules.cc
+++ b/RecoParticleFlow/PFTracking/plugins/modules.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h"
 #include "RecoParticleFlow/PFTracking/interface/LightPFTrackProducer.h"

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "RecoParticleFlow/PFTracking/interface/PFDisplacedVertexCandidateFinder.h"
 
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
@@ -432,7 +434,7 @@ ostream& operator<<(std::ostream& out, const PFDisplacedVertexCandidateFinder& a
   }
 
 
-  const std::auto_ptr< reco::PFDisplacedVertexCandidateCollection >& vertexCandidates
+  const std::unique_ptr< reco::PFDisplacedVertexCandidateCollection >& vertexCandidates
     = a.vertexCandidates(); 
     
   if(!vertexCandidates.get() ) {

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "RecoParticleFlow/PFTracking/interface/PFDisplacedVertexFinder.h"
 #include "RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h"
 
@@ -795,7 +797,7 @@ std::ostream& operator<<(std::ostream& out, const PFDisplacedVertexFinder& a) {
       << " sigmacut = " << a.sigmacut_ << " T_ini = " 
       << a.t_ini_ << " ratio = " << a.ratio_ << endl << endl; 
 
-  const std::auto_ptr< reco::PFDisplacedVertexCollection >& displacedVertices_
+  const std::unique_ptr< reco::PFDisplacedVertexCollection >& displacedVertices_
     = a.displacedVertices(); 
 
 

--- a/RecoTauTag/RecoTau/interface/CombinatoricGenerator.h
+++ b/RecoTauTag/RecoTau/interface/CombinatoricGenerator.h
@@ -257,7 +257,7 @@ template<typename T>
 
     public:
 
-    typedef std::auto_ptr<CombinatoricIterator<T> > CombIterPtr;
+    typedef std::unique_ptr<CombinatoricIterator<T> > CombIterPtr;
     typedef CombinatoricIterator<T> iterator;
     typedef typename iterator::value_type::ValueIter combo_iterator;
 

--- a/RecoTauTag/RecoTau/interface/PFRecoTauChargedHadronPlugins.h
+++ b/RecoTauTag/RecoTau/interface/PFRecoTauChargedHadronPlugins.h
@@ -39,7 +39,7 @@ class PFRecoTauChargedHadronBuilderPlugin : public RecoTauEventHolderPlugin
   typedef boost::ptr_vector<PFRecoTauChargedHadron> ChargedHadronVector;
   // Storing the result in an auto ptr on function return allows
   // allows us to safely release the ptr_vector in the virtual function
-  typedef std::auto_ptr<ChargedHadronVector> return_type;
+  typedef std::unique_ptr<ChargedHadronVector> return_type;
   explicit PFRecoTauChargedHadronBuilderPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector &&iC)
     : RecoTauEventHolderPlugin(pset) 
   {}

--- a/RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h
@@ -56,7 +56,7 @@ class RecoTauBuilderPlugin : public RecoTauEventHolderPlugin
 {
  public:
   typedef boost::ptr_vector<reco::PFTau> output_type;
-  typedef std::auto_ptr<output_type> return_type;
+  typedef std::unique_ptr<output_type> return_type;
 
   explicit RecoTauBuilderPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector && iC)
     : RecoTauEventHolderPlugin(pset),

--- a/RecoTauTag/RecoTau/interface/RecoTauConstructor.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauConstructor.h
@@ -125,7 +125,7 @@ class RecoTauConstructor {
     }
 
     // Build and return the associated tau
-    std::auto_ptr<reco::PFTau> get(bool setupLeadingCandidates=true);
+    std::unique_ptr<reco::PFTau> get(bool setupLeadingCandidates=true);
 
     // Get the four vector of the signal objects added so far
     const reco::Candidate::LorentzVector& p4() const { return p4_; }
@@ -157,7 +157,7 @@ class RecoTauConstructor {
     PFCandidatePtr convertToPtr(const PFCandidateRef& pfRef) const;
 
     const edm::Handle<PFCandidateCollection>& pfCands_;
-    std::auto_ptr<reco::PFTau> tau_;
+    std::unique_ptr<reco::PFTau> tau_;
     CollectionMap collections_;
 
     // Keep sorted (by descending pt) collections

--- a/RecoTauTag/RecoTau/interface/RecoTauIsolationMasking.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauIsolationMasking.h
@@ -45,7 +45,7 @@ class RecoTauIsolationMasking {
     double hcalCone_;
     double maxSigmas_;
     double finalHcalCone_;
-    std::auto_ptr<PFEnergyResolution> resolutions_;
+    std::unique_ptr<PFEnergyResolution> resolutions_;
 };
 
 }}

--- a/RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h
@@ -36,7 +36,7 @@ class RecoTauPiZeroBuilderPlugin : public RecoTauEventHolderPlugin {
     typedef boost::ptr_vector<RecoTauPiZero> PiZeroVector;
     // Storing the result in an auto ptr on function return allows
     // allows us to safely release the ptr_vector in the virtual function
-    typedef std::auto_ptr<PiZeroVector> return_type;
+    typedef std::unique_ptr<PiZeroVector> return_type;
     explicit RecoTauPiZeroBuilderPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector &&iC):
         RecoTauEventHolderPlugin(pset) {}
     virtual ~RecoTauPiZeroBuilderPlugin() {}

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
@@ -31,6 +31,7 @@
 #include "RecoTauTag/RecoTau/interface/pfRecoTauChargedHadronAuxFunctions.h"
 
 #include <memory>
+#include <utility>
 
 namespace reco 
 { 
@@ -186,7 +187,7 @@ PFRecoTauChargedHadronFromPFCandidatePlugin::return_type PFRecoTauChargedHadronF
     PFRecoTauChargedHadron::PFRecoTauChargedHadronAlgorithm algo = PFRecoTauChargedHadron::kUndefined;
     if ( std::abs((*cand)->charge()) > 0.5 ) algo = PFRecoTauChargedHadron::kChargedPFCandidate;
     else algo = PFRecoTauChargedHadron::kPFNeutralHadron;
-    std::auto_ptr<PFRecoTauChargedHadron> chargedHadron(new PFRecoTauChargedHadron(**cand, algo));
+    std::unique_ptr<PFRecoTauChargedHadron> chargedHadron(new PFRecoTauChargedHadron(**cand, algo));
     if ( (*cand)->trackRef().isNonnull() ) chargedHadron->track_ = edm::refToPtr((*cand)->trackRef());
     else if ( (*cand)->muonRef().isNonnull() && (*cand)->muonRef()->innerTrack().isNonnull()  ) chargedHadron->track_ = edm::refToPtr((*cand)->muonRef()->innerTrack());
     else if ( (*cand)->muonRef().isNonnull() && (*cand)->muonRef()->globalTrack().isNonnull() ) chargedHadron->track_ = edm::refToPtr((*cand)->muonRef()->globalTrack());
@@ -246,7 +247,7 @@ PFRecoTauChargedHadronFromPFCandidatePlugin::return_type PFRecoTauChargedHadronF
     }
     // Update the vertex
     if ( chargedHadron->daughterPtr(0).isNonnull() ) chargedHadron->setVertex(chargedHadron->daughterPtr(0)->vertex());
-    output.push_back(chargedHadron);
+    output.push_back(std::move(chargedHadron));
   }
 
   return output.release();

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromTrackPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromTrackPlugin.cc
@@ -39,6 +39,7 @@
 #include <TMath.h>
 
 #include <memory>
+#include <utility>
 #include <math.h>
 
 namespace reco { namespace tau {
@@ -182,7 +183,7 @@ PFRecoTauChargedHadronFromTrackPlugin::return_type PFRecoTauChargedHadronFromTra
     reco::Vertex::Point vtx(0.,0.,0.);
     if ( vertexAssociator_.associatedVertex(jet).isNonnull() ) vtx = vertexAssociator_.associatedVertex(jet)->position();
 
-    std::auto_ptr<PFRecoTauChargedHadron> chargedHadron(new PFRecoTauChargedHadron(trackCharge_int, chargedPionP4, vtx, 0, true, PFRecoTauChargedHadron::kTrack));
+    std::unique_ptr<PFRecoTauChargedHadron> chargedHadron(new PFRecoTauChargedHadron(trackCharge_int, chargedPionP4, vtx, 0, true, PFRecoTauChargedHadron::kTrack));
     chargedHadron->track_ = edm::Ptr<reco::Track>(tracks, iTrack);
 
     // CV: Take code for propagating track to ECAL entrance 
@@ -251,7 +252,7 @@ PFRecoTauChargedHadronFromTrackPlugin::return_type PFRecoTauChargedHadronFromTra
       edm::LogPrint("TauChHFromTrack") << *chargedHadron;
     }
 
-    output.push_back(chargedHadron);
+    output.push_back(std::move(chargedHadron));
   }
 
   return output.release();

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
@@ -81,10 +81,10 @@ public:
   builderList builders_;
   rankerList rankers_;
 
-  std::auto_ptr<ChargedHadronPredicate> predicate_;
+  std::unique_ptr<ChargedHadronPredicate> predicate_;
 
   // output selector
-  std::auto_ptr<StringCutObjectSelector<reco::PFRecoTauChargedHadron> > outputSelector_;
+  std::unique_ptr<StringCutObjectSelector<reco::PFRecoTauChargedHadron> > outputSelector_;
 
   // flag to enable/disable debug print-out
   int verbosity_;
@@ -121,7 +121,7 @@ PFRecoTauChargedHadronProducer::PFRecoTauChargedHadronProducer(const edm::Parame
   }
 
   // build the sorting predicate
-  predicate_ = std::auto_ptr<ChargedHadronPredicate>(new ChargedHadronPredicate(rankers_));
+  predicate_ = std::unique_ptr<ChargedHadronPredicate>(new ChargedHadronPredicate(rankers_));
   
   // check if we want to apply a final output selection
   if ( cfg.exists("outputSelection") ) {
@@ -205,7 +205,7 @@ void PFRecoTauChargedHadronProducer::produce(edm::Event& evt, const edm::EventSe
     while ( uncleanedChargedHadrons.size() >= 1 ) {
       
       // get next best ChargedHadron candidate
-      std::auto_ptr<reco::PFRecoTauChargedHadron> nextChargedHadron(uncleanedChargedHadrons.pop_front().release());
+      std::unique_ptr<reco::PFRecoTauChargedHadron> nextChargedHadron(uncleanedChargedHadrons.pop_front().release());
       if ( verbosity_ ) {
 	edm::LogPrint("PFRecoTauChHProducer")<< "processing nextChargedHadron:" ;
 	edm::LogPrint("PFRecoTauChHProducer")<< (*nextChargedHadron);
@@ -284,7 +284,7 @@ void PFRecoTauChargedHadronProducer::produce(edm::Event& evt, const edm::EventSe
 	if ( verbosity_ ) {
 	  edm::LogPrint("PFRecoTauChHProducer")<< "--> removing non-unique neutral PFCandidates and reinserting nextChargedHadron in uncleaned collection." ;
 	}
-        uncleanedChargedHadrons.insert(insertionPoint, nextChargedHadron);
+        uncleanedChargedHadrons.insert(insertionPoint, std::move(nextChargedHadron));
       }
     }
 

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
@@ -214,13 +214,13 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
   std::string moduleLabel_;
 
   edm::ParameterSet qualityCutsPSet_;
-  std::auto_ptr<tau::RecoTauQualityCuts> qcuts_;
+  std::unique_ptr<tau::RecoTauQualityCuts> qcuts_;
 
   // Inverted QCut which selects tracks with bad DZ/trackWeight
-  std::auto_ptr<tau::RecoTauQualityCuts> pileupQcutsPUTrackSelection_;
-  std::auto_ptr<tau::RecoTauQualityCuts> pileupQcutsGeneralQCuts_;
+  std::unique_ptr<tau::RecoTauQualityCuts> pileupQcutsPUTrackSelection_;
+  std::unique_ptr<tau::RecoTauQualityCuts> pileupQcutsGeneralQCuts_;
   
-  std::auto_ptr<tau::RecoTauVertexAssociator> vertexAssociator_;
+  std::unique_ptr<tau::RecoTauVertexAssociator> vertexAssociator_;
   
   bool includeTracks_;
   bool includeGammas_;
@@ -275,7 +275,7 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
   std::vector<reco::PFCandidatePtr> chargedPFCandidatesInEvent_;
   // Size of cone used to collect PU tracks
   double deltaBetaCollectionCone_;
-  std::auto_ptr<TFormula> deltaBetaFormula_;
+  std::unique_ptr<TFormula> deltaBetaFormula_;
   double deltaBetaFactorThisEvent_;
   
   // Rho correction

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByNProngs.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByNProngs.cc
@@ -25,8 +25,8 @@ class PFRecoTauDiscriminationByNProngs : public PFTauDiscriminationProducerBase 
 	double discriminate(const reco::PFTauRef&) const override;
 
     private:
-	std::auto_ptr<tau::RecoTauQualityCuts> qcuts_;
-	std::auto_ptr<tau::RecoTauVertexAssociator> vertexAssociator_;
+	std::unique_ptr<tau::RecoTauQualityCuts> qcuts_;
+	std::unique_ptr<tau::RecoTauVertexAssociator> vertexAssociator_;
 
 	uint32_t minN,maxN;
 	bool booleanOutput;

--- a/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
@@ -95,8 +95,8 @@ class PFTauPrimaryVertexProducer final : public edm::stream::EDProducer<> {
   bool RemoveMuonTracks_;
   bool RemoveElectronTracks_;
   DiscCutPairVec discriminators_;
-  std::auto_ptr<StringCutObjectSelector<reco::PFTau> > cut_;
-  std::auto_ptr<tau::RecoTauVertexAssociator> vertexAssociator_;
+  std::unique_ptr<StringCutObjectSelector<reco::PFTau> > cut_;
+  std::unique_ptr<tau::RecoTauVertexAssociator> vertexAssociator_;
 };
 
 PFTauPrimaryVertexProducer::PFTauPrimaryVertexProducer(const edm::ParameterSet& iConfig):

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
@@ -1,3 +1,4 @@
+#include <utility>
 #include <vector>
 
 #include "RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h"
@@ -483,7 +484,7 @@ RecoTauBuilderCombinatoricPlugin::operator()(
             boost::make_filter_iterator(
               pfNeutralJunk, regionalJunk.end(), regionalJunk.end()));
 
-        std::auto_ptr<reco::PFTau> tauPtr = tau.get(true);
+        std::unique_ptr<reco::PFTau> tauPtr = tau.get(true);
 	
 	// Set event vertex position for tau
 	reco::VertexRef primaryVertexRef = primaryVertex(*tauPtr);
@@ -512,7 +513,7 @@ RecoTauBuilderCombinatoricPlugin::operator()(
 	//edm::LogPrint("RecoTauBuilderCombinatoricPlugin") << "bendCorrMass2 = " << sqrt(bendCorrMass2) << std::endl;
 	tauPtr->setBendCorrMass(sqrt(bendCorrMass2));
 
-        output.push_back(tauPtr);
+        output.push_back(std::move(tauPtr));
       }
     }
   }

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
@@ -8,6 +8,7 @@
  *
  */
 
+#include <utility>
 #include <vector>
 #include <algorithm>
 
@@ -455,7 +456,7 @@ RecoTauBuilderConePlugin::return_type RecoTauBuilderConePlugin::operator()(
   // Put our built tau in the output - 'false' indicates don't build the
   // leading candidates, we already did that explicitly above.
 
-  std::auto_ptr<reco::PFTau> tauPtr = tau.get(false);
+  std::unique_ptr<reco::PFTau> tauPtr = tau.get(false);
 
   // Set event vertex position for tau
   reco::VertexRef primaryVertexRef = primaryVertex(*tauPtr);
@@ -468,7 +469,7 @@ RecoTauBuilderConePlugin::return_type RecoTauBuilderConePlugin::operator()(
   		   minRelPhotonSumPt_insideSignalCone_
 		   );
 
-  output.push_back(tauPtr);
+  output.push_back(std::move(tauPtr));
   return output.release();
 }
 }}  // end namespace reco::tauk

--- a/RecoTauTag/RecoTau/plugins/RecoTauMVATransform.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauMVATransform.cc
@@ -11,6 +11,7 @@
 #include <boost/foreach.hpp>
 #include <boost/ptr_container/ptr_map.hpp>
 #include <memory>
+#include <utility>
 
 #include "RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h"
 #include "RecoTauTag/RecoTau/interface/PFTauDecayModeTools.h"
@@ -26,18 +27,18 @@
 namespace {
 
 // Build the transformation function from the PSet format
-std::auto_ptr<TGraph> buildTransform(const edm::ParameterSet &pset) {
+std::unique_ptr<TGraph> buildTransform(const edm::ParameterSet &pset) {
   double min = pset.getParameter<double>("min");
   double max = pset.getParameter<double>("max");
   const std::vector<double> &values =
       pset.getParameter<std::vector<double> >("transform");
   double stepSize = (max - min)/(values.size()-1);
-  std::auto_ptr<TGraph> output(new TGraph(values.size()));
+  std::unique_ptr<TGraph> output(new TGraph(values.size()));
   for (size_t step = 0; step < values.size(); ++step) {
     double x = min + step*stepSize;
     output->SetPoint(step, x, values[step]);
   }
-  return output;
+  return std::move(output);
 }
 
 }

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroCombinatoricPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroCombinatoricPlugin.cc
@@ -10,6 +10,7 @@
  */
 
 #include <algorithm>
+#include <utility>
 
 #include "RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h"
 #include "DataFormats/TauReco/interface/RecoTauPiZero.h"
@@ -79,7 +80,7 @@ RecoTauPiZeroCombinatoricPlugin::operator()(
   for (ComboGenerator::iterator combo = generator.begin();
       combo != generator.end(); ++combo) {
     const Candidate::LorentzVector totalP4;
-    std::auto_ptr<RecoTauPiZero> piZero(
+    std::unique_ptr<RecoTauPiZero> piZero(
         new RecoTauPiZero(0, totalP4, Candidate::Point(0, 0, 0),
                           111, 10001, true, RecoTauPiZero::kCombinatoric));
     // Add our daughters from this combination
@@ -94,7 +95,7 @@ RecoTauPiZeroCombinatoricPlugin::operator()(
 
     if ((maxMass_ < 0 || piZero->mass() < maxMass_) &&
         piZero->mass() > minMass_)
-      output.push_back(piZero);
+      output.push_back(std::move(piZero));
   }
   return output.release();
 }

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
@@ -59,11 +59,11 @@ class RecoTauPiZeroProducer : public edm::stream::EDProducer<> {
 
     builderList builders_;
     rankerList rankers_;
-    std::auto_ptr<PiZeroPredicate> predicate_;
+    std::unique_ptr<PiZeroPredicate> predicate_;
     double piZeroMass_;
 
     // Output selector
-    std::auto_ptr<StringCutObjectSelector<reco::RecoTauPiZero> >
+    std::unique_ptr<StringCutObjectSelector<reco::RecoTauPiZero> >
       outputSelector_;
 
     //consumes interface
@@ -109,7 +109,7 @@ RecoTauPiZeroProducer::RecoTauPiZeroProducer(const edm::ParameterSet& pset)
   }
 
   // Build the sorting predicate
-  predicate_ = std::auto_ptr<PiZeroPredicate>(new PiZeroPredicate(rankers_));
+  predicate_ = std::unique_ptr<PiZeroPredicate>(new PiZeroPredicate(rankers_));
 
   // Check if we want to apply a final output selection
   if (pset.exists("outputSelection")) {
@@ -179,7 +179,7 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es)
     std::set<reco::CandidatePtr> photonsInCleanCollection;
     while (dirtyPiZeros.size()) {
       // Pull our candidate pi zero from the front of the list
-      std::auto_ptr<reco::RecoTauPiZero> toAdd(
+      std::unique_ptr<reco::RecoTauPiZero> toAdd(
           dirtyPiZeros.pop_front().release());
       // If this doesn't pass our basic selection, discard it.
       if (!(*outputSelector_)(*toAdd)) {
@@ -216,7 +216,7 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es)
         // Put this pi zero back into the collection of sorted dirty pizeros
         PiZeroList::iterator insertionPoint = std::lower_bound(
             dirtyPiZeros.begin(), dirtyPiZeros.end(), *toAdd, *predicate_);
-        dirtyPiZeros.insert(insertionPoint, toAdd);
+        dirtyPiZeros.insert(insertionPoint, std::move(toAdd));
       }
     }
     // Apply the mass hypothesis if desired

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
@@ -11,6 +11,7 @@
  */
 #include <algorithm>
 #include <memory>
+#include <utility>
 
 #include "boost/bind.hpp"
 
@@ -117,7 +118,7 @@ RecoTauPiZeroStripPlugin::return_type RecoTauPiZeroStripPlugin::operator()(
     cands.pop_front();
 
     // Add a new candidate to our collection using this seed
-    std::auto_ptr<RecoTauPiZero> strip(new RecoTauPiZero(
+    std::unique_ptr<RecoTauPiZero> strip(new RecoTauPiZero(
             *seed, RecoTauPiZero::kStrips));
     strip->addDaughter(seed);
 
@@ -141,7 +142,7 @@ RecoTauPiZeroStripPlugin::return_type RecoTauPiZeroStripPlugin::operator()(
     // Update the vertex
     if (strip->daughterPtr(0).isNonnull())
       strip->setVertex(strip->daughterPtr(0)->vertex());
-    output.push_back(strip);
+    output.push_back(std::move(strip));
   }
 
   // Check if we want to combine our strips
@@ -167,7 +168,7 @@ RecoTauPiZeroStripPlugin::return_type RecoTauPiZeroStripPlugin::operator()(
         secondP4 = applyMassConstraint(secondP4, combinatoricStripMassHypo_);
         Candidate::LorentzVector totalP4 = firstP4 + secondP4;
         // Make our new combined strip
-        std::auto_ptr<RecoTauPiZero> combinedStrips(
+        std::unique_ptr<RecoTauPiZero> combinedStrips(
             new RecoTauPiZero(0, totalP4,
               Candidate::Point(0, 0, 0),
               //111, 10001, true, RecoTauPiZero::kCombinatoricStrips));
@@ -186,7 +187,7 @@ RecoTauPiZeroStripPlugin::return_type RecoTauPiZeroStripPlugin::operator()(
         if (combinedStrips->daughterPtr(0).isNonnull())
           combinedStrips->setVertex(combinedStrips->daughterPtr(0)->vertex());
         // Add to our collection of combined strips
-        stripCombinations.push_back(combinedStrips);
+        stripCombinations.push_back(std::move(combinedStrips));
       }
     }
     // When done doing all the combinations, add the combined strips to the

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <utility>
 
 #include "boost/bind.hpp"
 
@@ -250,7 +251,7 @@ RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(con
     seedCandIdsCurrentStrip.clear();
     addCandIdsCurrentStrip.clear();
 
-    std::auto_ptr<RecoTauPiZero> strip(new RecoTauPiZero(*seedCands[idxSeed], RecoTauPiZero::kStrips));
+    std::unique_ptr<RecoTauPiZero> strip(new RecoTauPiZero(*seedCands[idxSeed], RecoTauPiZero::kStrips));
     strip->addDaughter(seedCands[idxSeed]);
     seedCandIdsCurrentStrip.insert(idxSeed);
 
@@ -274,7 +275,7 @@ RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(con
 
       // Update the vertex
       if ( strip->daughterPtr(0).isNonnull() ) strip->setVertex(strip->daughterPtr(0)->vertex());
-      output.push_back(strip);
+      output.push_back(std::move(strip));
 
       // Mark daughters as being part of this strip
       markCandsInStrip(seedCandFlags, seedCandIdsCurrentStrip);
@@ -312,7 +313,7 @@ RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(con
         secondP4 = applyMassConstraint(secondP4, combinatoricStripMassHypo_);
         Candidate::LorentzVector totalP4 = firstP4 + secondP4;
         // Make our new combined strip
-        std::auto_ptr<RecoTauPiZero> combinedStrips(
+        std::unique_ptr<RecoTauPiZero> combinedStrips(
             new RecoTauPiZero(0, totalP4,
               Candidate::Point(0, 0, 0),
               //111, 10001, true, RecoTauPiZero::kCombinatoricStrips));
@@ -331,7 +332,7 @@ RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(con
         if ( combinedStrips->daughterPtr(0).isNonnull() )
           combinedStrips->setVertex(combinedStrips->daughterPtr(0)->vertex());
         // Add to our collection of combined strips
-        stripCombinations.push_back(combinedStrips);
+        stripCombinations.push_back(std::move(combinedStrips));
       }
     }
     // When done doing all the combinations, add the combined strips to the

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <utility>
 
 #include "boost/bind.hpp"
 
@@ -274,7 +275,7 @@ RecoTauPiZeroStripPlugin3::return_type RecoTauPiZeroStripPlugin3::operator()(con
     seedCandIdsCurrentStrip.clear();
     addCandIdsCurrentStrip.clear();
 
-    std::auto_ptr<RecoTauPiZero> strip(new RecoTauPiZero(*seedCands[idxSeed], RecoTauPiZero::kStrips));
+    std::unique_ptr<RecoTauPiZero> strip(new RecoTauPiZero(*seedCands[idxSeed], RecoTauPiZero::kStrips));
     strip->addDaughter(seedCands[idxSeed]);
     seedCandIdsCurrentStrip.insert(idxSeed);
 
@@ -298,7 +299,7 @@ RecoTauPiZeroStripPlugin3::return_type RecoTauPiZeroStripPlugin3::operator()(con
 
       // Update the vertex
       if ( strip->daughterPtr(0).isNonnull() ) strip->setVertex(strip->daughterPtr(0)->vertex());
-      output.push_back(strip);
+      output.push_back(std::move(strip));
 
       // Mark daughters as being part of this strip
       markCandsInStrip(seedCandFlags, seedCandIdsCurrentStrip);
@@ -336,7 +337,7 @@ RecoTauPiZeroStripPlugin3::return_type RecoTauPiZeroStripPlugin3::operator()(con
         secondP4 = applyMassConstraint(secondP4, combinatoricStripMassHypo_);
         Candidate::LorentzVector totalP4 = firstP4 + secondP4;
         // Make our new combined strip
-        std::auto_ptr<RecoTauPiZero> combinedStrips(
+        std::unique_ptr<RecoTauPiZero> combinedStrips(
             new RecoTauPiZero(0, totalP4,
               Candidate::Point(0, 0, 0),
               //111, 10001, true, RecoTauPiZero::kCombinatoricStrips));
@@ -355,7 +356,7 @@ RecoTauPiZeroStripPlugin3::return_type RecoTauPiZeroStripPlugin3::operator()(con
 	}
 
         // Add to our collection of combined strips
-        stripCombinations.push_back(combinedStrips);
+        stripCombinations.push_back(std::move(combinedStrips));
       }
     }
     // When done doing all the combinations, add the combined strips to the

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroTrivialPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroTrivialPlugin.cc
@@ -20,6 +20,7 @@
 #include "RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h"
 
 #include <boost/foreach.hpp>
+#include <utility>
 
 namespace reco { namespace tau {
 
@@ -44,11 +45,11 @@ RecoTauPiZeroBuilderPlugin::return_type RecoTauPiZeroTrivialPlugin::operator()(
   output.reserve(pfGammaCands.size());
 
   BOOST_FOREACH(const PFCandidatePtr& gamma, pfGammaCands) {
-    std::auto_ptr<RecoTauPiZero> piZero(new RecoTauPiZero(
+    std::unique_ptr<RecoTauPiZero> piZero(new RecoTauPiZero(
             0, (*gamma).p4(), (*gamma).vertex(), 22, 1000, true,
             RecoTauPiZero::kTrivial));
     piZero->addDaughter(gamma);
-    output.push_back(piZero);
+    output.push_back(std::move(piZero));
   }
   return output.release();
 }

--- a/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
@@ -71,7 +71,7 @@ class RecoTauProducer : public edm::stream::EDProducer<>
   BuilderList builders_;
   ModifierList modifiers_;
   // Optional selection on the output of the taus
-  std::auto_ptr<StringCutObjectSelector<reco::PFTau> > outputSelector_;
+  std::unique_ptr<StringCutObjectSelector<reco::PFTau> > outputSelector_;
   // Whether or not to add build a tau from a jet for which the builders
   // return no taus.  The tau will have no content, only the four vector of
   // the orginal jet.

--- a/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
@@ -9,6 +9,7 @@
 
 #include <boost/foreach.hpp>
 #include <boost/bind.hpp>
+#include <utility>
 
 namespace reco { namespace tau {
 
@@ -351,7 +352,7 @@ namespace
   }
 }
 
-std::auto_ptr<reco::PFTau> RecoTauConstructor::get(bool setupLeadingObjects) 
+std::unique_ptr<reco::PFTau> RecoTauConstructor::get(bool setupLeadingObjects) 
 {
   LogDebug("TauConstructorGet") << "Start getting" ;
 
@@ -444,6 +445,6 @@ std::auto_ptr<reco::PFTau> RecoTauConstructor::get(bool setupLeadingObjects)
     if(leadingGammaCand != getCollection(kSignal, kGamma)->end())
       tau_->setleadPFNeutralCand(*leadingGammaCand);
   }
-  return tau_;
+  return std::move(tau_);
 }
 }} // end namespace reco::tau

--- a/RecoTauTag/TauTagTools/plugins/PFTauSelectorDefinition.h
+++ b/RecoTauTag/TauTagTools/plugins/PFTauSelectorDefinition.h
@@ -90,7 +90,7 @@ struct PFTauSelectorDefinition {
  private:
   container selected_;
   DiscCutPairVec discriminators_;
-  std::auto_ptr<StringCutObjectSelector<reco::PFTau> > cut_;
+  std::unique_ptr<StringCutObjectSelector<reco::PFTau> > cut_;
 
 };
 

--- a/RecoTauTag/TauTagTools/plugins/TauMVACondUtilities.cc
+++ b/RecoTauTag/TauTagTools/plugins/TauMVACondUtilities.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/SourceFactory.h"
 #include "FWCore/Framework/interface/LooperFactory.h"

--- a/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.h
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.h
@@ -60,8 +60,8 @@ class TemplatedInclusiveVertexFinder : public edm::stream::EDProducer<> {
 	double 					fitterRatio;
 	bool 					useVertexFitter;
 	bool 					useVertexReco;
-	std::auto_ptr<VertexReconstructor>	vtxReco;
-	std::auto_ptr<TracksClusteringFromDisplacedSeed>	clusterizer;
+	std::unique_ptr<VertexReconstructor>	vtxReco;
+	std::unique_ptr<TracksClusteringFromDisplacedSeed>	clusterizer;
 
 };
 template <class InputContainer, class VTX>

--- a/RecoVertex/GhostTrackFitter/interface/AnnealingGhostTrackFitter.h
+++ b/RecoVertex/GhostTrackFitter/interface/AnnealingGhostTrackFitter.h
@@ -39,7 +39,7 @@ class AnnealingGhostTrackFitter : public SequentialGhostTrackFitter {
 			const GhostTrackPrediction &pred,
 			std::vector<GhostTrackState> &states);
 
-	std::auto_ptr<AnnealingSchedule>	annealing;
+	std::unique_ptr<AnnealingSchedule>	annealing;
 	bool					firstStep;
 };
 

--- a/RecoVertex/GhostTrackFitter/interface/GhostTrackFitter.h
+++ b/RecoVertex/GhostTrackFitter/interface/GhostTrackFitter.h
@@ -80,8 +80,8 @@ class GhostTrackFitter {
 	               const std::vector<GhostTrackState> &states) const;
 
     private:
-	std::auto_ptr<FitterImpl>		fitter;
-	std::auto_ptr<PredictionUpdater>	updater;
+	std::unique_ptr<FitterImpl>		fitter;
+	std::unique_ptr<PredictionUpdater>	updater;
 };
 
 }

--- a/RecoVertex/GhostTrackFitter/interface/GhostTrackVertexFinder.h
+++ b/RecoVertex/GhostTrackFitter/interface/GhostTrackVertexFinder.h
@@ -179,9 +179,9 @@ class GhostTrackVertexFinder { // : public VertexReconstructor
 	double	seccut_;
 	FitType	fitType_;
 
-	mutable std::auto_ptr<GhostTrackFitter>	ghostTrackFitter_;
-	mutable std::auto_ptr<VertexFitter<5> > primVertexFitter_;
-	mutable std::auto_ptr<VertexFitter<5> > secVertexFitter_;
+	mutable std::unique_ptr<GhostTrackFitter>	ghostTrackFitter_;
+	mutable std::unique_ptr<VertexFitter<5> > primVertexFitter_;
+	mutable std::unique_ptr<VertexFitter<5> > secVertexFitter_;
 };
 
 }

--- a/RecoVertex/GhostTrackFitter/interface/PositiveSideGhostTrackFitter.h
+++ b/RecoVertex/GhostTrackFitter/interface/PositiveSideGhostTrackFitter.h
@@ -37,7 +37,7 @@ class PositiveSideGhostTrackFitter : public GhostTrackFitter::FitterImpl {
 	{ return new PositiveSideGhostTrackFitter(*this); }
 
 	GlobalPoint					origin_;
-	std::auto_ptr<GhostTrackFitter::FitterImpl>	actualFitter_;
+	std::unique_ptr<GhostTrackFitter::FitterImpl>	actualFitter_;
 };
 
 }

--- a/RecoVertex/GhostTrackFitter/src/GhostTrackVertexFinder.cc
+++ b/RecoVertex/GhostTrackFitter/src/GhostTrackVertexFinder.cc
@@ -306,7 +306,7 @@ GhostTrackFitter &GhostTrackVertexFinder::ghostTrackFitter() const
 
 VertexFitter<5> &GhostTrackVertexFinder::vertexFitter(bool primary) const
 {
-	std::auto_ptr<VertexFitter<5> > *ptr =
+	std::unique_ptr<VertexFitter<5> > *ptr =
 			primary ? &primVertexFitter_ : &secVertexFitter_;
 	if (!ptr->get())
 		ptr->reset(new AdaptiveVertexFitter(

--- a/RecoVertex/KinematicFitPrimitives/src/KinematicRefittedTrackState.cc
+++ b/RecoVertex/KinematicFitPrimitives/src/KinematicRefittedTrackState.cc
@@ -64,7 +64,7 @@ TrajectoryStateOnSurface KinematicRefittedTrackState::trajectoryStateOnSurface(c
 TrajectoryStateOnSurface KinematicRefittedTrackState::trajectoryStateOnSurface(const Surface & surface, 
                                                    const Propagator & propagator) const
 {
- std::auto_ptr<Propagator> thePropagator( propagator.clone());
+ std::unique_ptr<Propagator> thePropagator( propagator.clone());
  thePropagator->setPropagationDirection(anyDirection);
  return thePropagator->propagate(freeTrajectoryState(), surface);
 }

--- a/RecoVertex/V0Producer/src/V0Fitter.cc
+++ b/RecoVertex/V0Producer/src/V0Fitter.cc
@@ -230,8 +230,8 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
          if (sqrt(negTkHitPosD2) < (distMagXY - sigmaDistMagXY*innerHitPosCut_)) continue;
       }
       
-      std::auto_ptr<TrajectoryStateClosestToPoint> trajPlus;
-      std::auto_ptr<TrajectoryStateClosestToPoint> trajMins;
+      std::unique_ptr<TrajectoryStateClosestToPoint> trajPlus;
+      std::unique_ptr<TrajectoryStateClosestToPoint> trajMins;
       std::vector<reco::TransientTrack> theRefTracks;
       if (theRecoVertex.hasRefittedTracks()) {
          theRefTracks = theRecoVertex.refittedTracks();

--- a/RecoVertex/VertexTools/src/PerigeeRefittedTrackState.cc
+++ b/RecoVertex/VertexTools/src/PerigeeRefittedTrackState.cc
@@ -39,7 +39,7 @@ TrajectoryStateOnSurface
 PerigeeRefittedTrackState::trajectoryStateOnSurface(const Surface & surface,
 				const Propagator & propagator) const
 {
-  std::auto_ptr<Propagator> thePropagator( propagator.clone());
+  std::unique_ptr<Propagator> thePropagator( propagator.clone());
   thePropagator->setPropagationDirection(anyDirection);
 
   TrajectoryStateOnSurface tsos = thePropagator->propagate(freeTrajectoryState(), surface);

--- a/SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimRawData.h
+++ b/SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimRawData.h
@@ -442,7 +442,7 @@ private:
 
   /** Selective readout simulator
    */
-  std::auto_ptr<EcalSelectiveReadout> esr_;
+  std::unique_ptr<EcalSelectiveReadout> esr_;
 
   /** Output file for trigger tower flags
    */

--- a/SimCalorimetry/EcalSelectiveReadoutAlgos/interface/EcalSelectiveReadoutSuppressor.h
+++ b/SimCalorimetry/EcalSelectiveReadoutAlgos/interface/EcalSelectiveReadoutSuppressor.h
@@ -224,7 +224,7 @@ public:
 
   /** Help class to comput selective readout flags. 
    */
-  std::auto_ptr<EcalSelectiveReadout> ecalSelectiveReadout;
+  std::unique_ptr<EcalSelectiveReadout> ecalSelectiveReadout;
 
   const EcalTrigTowerConstituentsMap * theTriggerMap;
      

--- a/SimCalorimetry/EcalSelectiveReadoutAlgos/src/EcalSelectiveReadoutSuppressor.cc
+++ b/SimCalorimetry/EcalSelectiveReadoutAlgos/src/EcalSelectiveReadoutSuppressor.cc
@@ -71,7 +71,7 @@ EcalSelectiveReadoutSuppressor::EcalSelectiveReadoutSuppressor(const edm::Parame
   adcToGeV = settings->eeDccAdcToGeV_;
   thrUnit[ENDCAP] = adcToGeV/4.; //unit=1/4th ADC count
   ecalSelectiveReadout
-    = auto_ptr<EcalSelectiveReadout>(new EcalSelectiveReadout(
+    = unique_ptr<EcalSelectiveReadout>(new EcalSelectiveReadout(
 							      settings->deltaEta_[0],
 							      settings->deltaPhi_[0]));
   const int eb = 0;

--- a/SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h
@@ -86,7 +86,7 @@ class GenEventInfoProduct {
 	double			alphaQCD_, alphaQED_;
 
 	// optional PDF info
-	std::auto_ptr<PDF>	pdf_;
+	std::unique_ptr<PDF>	pdf_;
 
 	// If event was produced in bis, this contains
 	// the values that were used to define which

--- a/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
@@ -98,7 +98,7 @@ class LHEEventProduct {
     private:
 	lhef::HEPEUP			hepeup_;
 	std::vector<std::string>	comments_;
-	std::auto_ptr<PDF>		pdf_;
+	std::unique_ptr<PDF>		pdf_;
 	std::vector<WGT>                weights_;
 	double                          originalXWGTUP_;
         std::vector<float>              scales_; //scale value used to exclude EWK-produced partons from matching

--- a/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
+++ b/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
@@ -63,7 +63,7 @@ private:
   int          side;
 
   /// Table of Cherenkov angle integrals vs photon momentum
-  std::auto_ptr<G4PhysicsOrderedFreeVector> chAngleIntegrals_;
+  std::unique_ptr<G4PhysicsOrderedFreeVector> chAngleIntegrals_;
   G4MaterialPropertiesTable*                materialPropertiesTable;
   // Histogramming
   TTree* ntuple_;

--- a/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
+++ b/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
@@ -522,7 +522,7 @@ bool DreamSD::setPbWO2MaterialProperties_( G4Material* aMaterial ) {
   // Calculate Cherenkov angle integrals: 
   // This is an ad-hoc solution (we hold it in the class, not in the material)
   chAngleIntegrals_ = 
-    std::auto_ptr<G4PhysicsOrderedFreeVector>( new G4PhysicsOrderedFreeVector() );
+    std::unique_ptr<G4PhysicsOrderedFreeVector>( new G4PhysicsOrderedFreeVector() );
 
   int index = 0;
   double currentRI = RefractiveIndex[index];

--- a/SimG4Core/Geometry/src/DDDWorld.cc
+++ b/SimG4Core/Geometry/src/DDDWorld.cc
@@ -15,7 +15,7 @@ DDDWorld::DDDWorld(const DDCompactView* cpv,
 		   SensitiveDetectorCatalog & catalog,
 		   bool check) {
 
-  std::auto_ptr<DDG4Builder> theBuilder(new DDG4Builder(cpv, check));
+  std::unique_ptr<DDG4Builder> theBuilder(new DDG4Builder(cpv, check));
 
   DDGeometryReturnType ret = theBuilder->BuildGeometry();
   G4LogicalVolume *    world = ret.logicalVolume();

--- a/SimG4Core/GeometryProducer/interface/GeometryProducer.h
+++ b/SimG4Core/GeometryProducer/interface/GeometryProducer.h
@@ -53,8 +53,8 @@ private:
     SimActivityRegistry m_registry;
     std::vector<std::shared_ptr<SimWatcher> > m_watchers;
     std::vector<std::shared_ptr<SimProducer> > m_producers;
-    std::auto_ptr<sim::FieldBuilder> m_fieldBuilder;
-    std::auto_ptr<SimTrackManager> m_trackManager;
+    std::unique_ptr<sim::FieldBuilder> m_fieldBuilder;
+    std::unique_ptr<SimTrackManager> m_trackManager;
     AttachSD * m_attach;
     std::vector<SensitiveTkDetector*> m_sensTkDets;
     std::vector<SensitiveCaloDetector*> m_sensCaloDets;

--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -134,7 +134,7 @@ void GeometryProducer::produce(edm::Event & e, const edm::EventSetup & es)
     {
        edm::LogInfo("GeometryProducer") << " instantiating sensitive detectors ";
        // instantiate and attach the sensitive detectors
-       m_trackManager = std::auto_ptr<SimTrackManager>(new SimTrackManager);
+       m_trackManager = std::unique_ptr<SimTrackManager>(new SimTrackManager);
        if (m_attach==0) m_attach = new AttachSD;
        {
            std::pair< std::vector<SensitiveTkDetector*>,

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
@@ -42,10 +42,10 @@ class SensitiveDetectorMaker : public SensitiveDetectorMakerBase
 			const edm::ParameterSet& p,
 			const SimTrackManager* m,
 			SimActivityRegistry& reg,
-			std::auto_ptr<SensitiveTkDetector>& oTK,
-			std::auto_ptr<SensitiveCaloDetector>& oCalo) const
+			std::unique_ptr<SensitiveTkDetector>& oTK,
+			std::unique_ptr<SensitiveCaloDetector>& oCalo) const
       {
-	std::auto_ptr<T> returnValue(new T(iname, cpv, clg, p, m));
+	std::unique_ptr<T> returnValue(new T(iname, cpv, clg, p, m));
 	SimActivityRegistryEnroller::enroll(reg, returnValue.get());
 
 	this->convertTo(returnValue.get(), oTK,oCalo);

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
@@ -47,8 +47,8 @@ class SensitiveDetectorMakerBase
 			const edm::ParameterSet& p,
 			const SimTrackManager* m,
 			SimActivityRegistry& reg,
-			std::auto_ptr<SensitiveTkDetector>& oTK,
-			std::auto_ptr<SensitiveCaloDetector>& oCalo) const =0;
+			std::unique_ptr<SensitiveTkDetector>& oTK,
+			std::unique_ptr<SensitiveCaloDetector>& oCalo) const =0;
       
       // ---------- static member functions --------------------
 
@@ -57,14 +57,14 @@ class SensitiveDetectorMakerBase
    protected:
       //used to identify which type of Sensitive Detector we have
       void convertTo( SensitiveTkDetector* iFrom, 
-		      std::auto_ptr<SensitiveTkDetector>& oTo,
-		      std::auto_ptr<SensitiveCaloDetector>&) const{
-	oTo= std::auto_ptr<SensitiveTkDetector>(iFrom);
+		      std::unique_ptr<SensitiveTkDetector>& oTo,
+		      std::unique_ptr<SensitiveCaloDetector>&) const{
+	oTo= std::unique_ptr<SensitiveTkDetector>(iFrom);
       }
       void convertTo( SensitiveCaloDetector* iFrom,
-		      std::auto_ptr<SensitiveTkDetector>&,
-		      std::auto_ptr<SensitiveCaloDetector>& oTo) const{
-	oTo=std::auto_ptr<SensitiveCaloDetector>(iFrom);
+		      std::unique_ptr<SensitiveTkDetector>&,
+		      std::unique_ptr<SensitiveCaloDetector>& oTo) const{
+	oTo=std::unique_ptr<SensitiveCaloDetector>(iFrom);
       }
 
    private:

--- a/SimG4Core/SensitiveDetector/src/AttachSD.cc
+++ b/SimG4Core/SensitiveDetector/src/AttachSD.cc
@@ -39,10 +39,10 @@ AttachSD::create(const DDDWorld & w,
     std::string className = clg.className(*it);
     //std::cout<<" trying to find something for "<<className<<" " <<*it<<std::endl;
     edm::LogInfo("SimG4CoreSensitiveDetector") << " AttachSD: trying to find something for " << className << " "  << *it ;
-    std::auto_ptr<SensitiveDetectorMakerBase> temp(
+    std::unique_ptr<SensitiveDetectorMakerBase> temp(
 						   SensitiveDetectorPluginFactory::get()->create(className) );
-    std::auto_ptr<SensitiveTkDetector> tkDet;
-    std::auto_ptr<SensitiveCaloDetector> caloDet;
+    std::unique_ptr<SensitiveTkDetector> tkDet;
+    std::unique_ptr<SensitiveCaloDetector> caloDet;
     temp->make(*it,cpv,clg,p,m,reg,tkDet,caloDet);
     if(tkDet.get()){
       detList.first.push_back(tkDet.get());

--- a/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingLHEProducer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingLHEProducer.cc
@@ -24,6 +24,7 @@
 #include <fstream>
 #include <string>
 #include <memory>
+#include <utility>
 #include "TLorentzVector.h"
 
 // user include files

--- a/TopQuarkAnalysis/TopEventProducers/interface/PseudoTopProducer.h
+++ b/TopQuarkAnalysis/TopEventProducers/interface/PseudoTopProducer.h
@@ -26,7 +26,7 @@ private:
 
   const reco::Candidate* getLast(const reco::Candidate* p);
   reco::GenParticleRef buildGenParticle(const reco::Candidate* p, reco::GenParticleRefProd& refHandle,
-                                        std::auto_ptr<reco::GenParticleCollection>& outColl) const;
+                                        std::unique_ptr<reco::GenParticleCollection>& outColl) const;
   typedef reco::Particle::LorentzVector LorentzVector;
 
 private:

--- a/TopQuarkAnalysis/TopEventProducers/src/PseudoTopProducer.cc
+++ b/TopQuarkAnalysis/TopEventProducers/src/PseudoTopProducer.cc
@@ -506,7 +506,7 @@ bool PseudoTopProducer::isBHadron(const unsigned int absPdgId) const
 }
 
 reco::GenParticleRef PseudoTopProducer::buildGenParticle(const reco::Candidate* p, reco::GenParticleRefProd& refHandle,
-                                                         std::auto_ptr<reco::GenParticleCollection>& outColl) const
+                                                         std::unique_ptr<reco::GenParticleCollection>& outColl) const
 {
   reco::GenParticle pOut(*dynamic_cast<const reco::GenParticle*>(p));
   pOut.clearMothers();

--- a/TopQuarkAnalysis/TopEventSelection/plugins/SealModule.cc
+++ b/TopQuarkAnalysis/TopEventSelection/plugins/SealModule.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "TopQuarkAnalysis/TopEventSelection/plugins/TtFullHadSignalSelMVAComputer.h"

--- a/TopQuarkAnalysis/TopEventSelection/plugins/TtFullHadSignalSelMVAComputer.cc
+++ b/TopQuarkAnalysis/TopEventSelection/plugins/TtFullHadSignalSelMVAComputer.cc
@@ -1,6 +1,8 @@
 #include "PhysicsTools/JetMCUtils/interface/combination.h"
 
 #include "TopQuarkAnalysis/TopEventSelection/plugins/TtFullHadSignalSelMVAComputer.h"
+
+#include <utility>
 #include "TopQuarkAnalysis/TopEventSelection/interface/TtFullHadSignalSelEval.h"
 
 #include "DataFormats/RecoCandidate/interface/RecoCandidate.h"

--- a/TopQuarkAnalysis/TopEventSelection/plugins/TtFullHadSignalSelMVATrainer.cc
+++ b/TopQuarkAnalysis/TopEventSelection/plugins/TtFullHadSignalSelMVATrainer.cc
@@ -1,5 +1,6 @@
 #include "TMath.h"
 #include <algorithm>
+#include <utility>
 
 #include "PhysicsTools/JetMCUtils/interface/combination.h"
 #include "PhysicsTools/MVATrainer/interface/HelperMacros.h"

--- a/TopQuarkAnalysis/TopEventSelection/plugins/TtSemiLepSignalSelMVAComputer.cc
+++ b/TopQuarkAnalysis/TopEventSelection/plugins/TtSemiLepSignalSelMVAComputer.cc
@@ -1,6 +1,8 @@
 #include "PhysicsTools/JetMCUtils/interface/combination.h"
 
 #include "TopQuarkAnalysis/TopEventSelection/plugins/TtSemiLepSignalSelMVAComputer.h"
+
+#include <utility>
 #include "TopQuarkAnalysis/TopEventSelection/interface/TtSemiLepSignalSelEval.h"
 
 #include "DataFormats/RecoCandidate/interface/RecoCandidate.h"

--- a/TopQuarkAnalysis/TopEventSelection/plugins/TtSemiLepSignalSelMVATrainer.cc
+++ b/TopQuarkAnalysis/TopEventSelection/plugins/TtSemiLepSignalSelMVATrainer.cc
@@ -1,5 +1,6 @@
 #include "TMath.h"
 #include <algorithm>
+#include <utility>
 
 #include "PhysicsTools/JetMCUtils/interface/combination.h"
 #include "PhysicsTools/MVATrainer/interface/HelperMacros.h"

--- a/TopQuarkAnalysis/TopJetCombination/plugins/SealModule.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/SealModule.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.h"

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.cc
@@ -2,6 +2,8 @@
 
 #include "TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.h"
 
+#include <utility>
+
 TtSemiLepJetCombMVAComputer::TtSemiLepJetCombMVAComputer(const edm::ParameterSet& cfg):
   lepsToken_    (consumes< edm::View<reco::RecoCandidate>>(cfg.getParameter<edm::InputTag>("leps"))),
   jetsToken_    (consumes< std::vector<pat::Jet> >(cfg.getParameter<edm::InputTag>("jets"))),

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVATrainer.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVATrainer.cc
@@ -1,5 +1,6 @@
 #include "TMath.h"
 #include <algorithm>
+#include <utility>
 
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/MET.h"

--- a/Validation/Mixing/src/GlobalTest.cc
+++ b/Validation/Mixing/src/GlobalTest.cc
@@ -153,7 +153,7 @@ GlobalTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   }
 
   // part id for each track
-  std::auto_ptr<MixCollection<SimTrack> > coltr(new MixCollection<SimTrack>(cf_track.product()));
+  std::unique_ptr<MixCollection<SimTrack> > coltr(new MixCollection<SimTrack>(cf_track.product()));
   MixCollection<SimTrack>::iterator cfitr;
   for (cfitr=coltr->begin(); cfitr!=coltr->end();cfitr++) {
     trackPartIdH_[cfitr.bunch()-minbunch_]->Fill(cfitr->type());
@@ -161,7 +161,7 @@ GlobalTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   // energy sum
   double sumE[10]={0.,0.,0.,0.,0.,0.,0.,0.,0.,0.};
-  std::auto_ptr<MixCollection<PCaloHit> > colecalb(new MixCollection<PCaloHit>(cf_calohitB.product()));
+  std::unique_ptr<MixCollection<PCaloHit> > colecalb(new MixCollection<PCaloHit>(cf_calohitB.product()));
   MixCollection<PCaloHit>::iterator cfiecalb;
   for (cfiecalb=colecalb->begin(); cfiecalb!=colecalb->end();cfiecalb++) {
     sumE[cfiecalb.bunch()-minbunch_]+=cfiecalb->energy();
@@ -172,7 +172,7 @@ GlobalTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     caloEnergyEBH_[i-minbunch_]->Fill(sumE[i-minbunch_]);
   }
   double sumEE[10]={0.,0.,0.,0.,0.,0.,0.,0.,0.,0.};
-  std::auto_ptr<MixCollection<PCaloHit> > colecale(new MixCollection<PCaloHit>(cf_calohitE.product()));
+  std::unique_ptr<MixCollection<PCaloHit> > colecale(new MixCollection<PCaloHit>(cf_calohitE.product()));
   MixCollection<PCaloHit>::iterator cfiecale;
   for (cfiecale=colecale->begin(); cfiecale!=colecale->end();cfiecale++) {
     sumEE[cfiecale.bunch()-minbunch_]+=cfiecale->energy();

--- a/Validation/Mixing/src/MixCollectionValidation.cc
+++ b/Validation/Mixing/src/MixCollectionValidation.cc
@@ -135,7 +135,7 @@ void MixCollectionValidation::analyze(const edm::Event& iEvent, const edm::Event
     gotHepMCProduct = iEvent.getByToken(crossingFrame_Hep_Token_, crossingFrame);
 
     if (gotHepMCProduct){
-      std::auto_ptr<MixCollection<HepMCProduct> >
+      std::unique_ptr<MixCollection<HepMCProduct> >
           hepMCProduct (new MixCollection<HepMCProduct>(crossingFrame.product ()));
       MixCollection<HepMCProduct>::MixItr hitItr;
 
@@ -149,7 +149,7 @@ void MixCollectionValidation::analyze(const edm::Event& iEvent, const edm::Event
     gotSimTrack = iEvent.getByToken(crossingFrame_SimTr_Token_,crossingFrame);
 
     if (gotSimTrack){
-      std::auto_ptr<MixCollection<SimTrack> >
+      std::unique_ptr<MixCollection<SimTrack> >
           simTracks (new MixCollection<SimTrack>(crossingFrame.product ()));
       MixCollection<SimTrack>::MixItr hitItr;
 
@@ -164,7 +164,7 @@ void MixCollectionValidation::analyze(const edm::Event& iEvent, const edm::Event
     gotSimVertex = iEvent.getByToken(crossingFrame_SimVtx_Token_, crossingFrame);
 
     if (gotSimVertex){
-      std::auto_ptr<MixCollection<SimVertex> >
+      std::unique_ptr<MixCollection<SimVertex> >
           simVerteces (new MixCollection<SimVertex>(crossingFrame.product ()));
       MixCollection<SimVertex>::MixItr hitItr;
 
@@ -181,7 +181,7 @@ void MixCollectionValidation::analyze(const edm::Event& iEvent, const edm::Event
       gotPSimHit = iEvent.getByToken(crossingFrame_PSimHit_Tokens_[i], crossingFrame);
 
       if (gotPSimHit){
-        std::auto_ptr<MixCollection<PSimHit> >
+        std::unique_ptr<MixCollection<PSimHit> >
             simHits (new MixCollection<PSimHit>(crossingFrame.product ()));
 
         MixCollection<PSimHit>::MixItr hitItr;
@@ -203,7 +203,7 @@ void MixCollectionValidation::analyze(const edm::Event& iEvent, const edm::Event
       gotPCaloHit = iEvent.getByToken(crossingFrame_PCaloHit_Tokens_[i], crossingFrame);
 
       if (gotPCaloHit){
-        std::auto_ptr<MixCollection<PCaloHit> >
+        std::unique_ptr<MixCollection<PCaloHit> >
             caloHits (new MixCollection<PCaloHit>(crossingFrame.product ()));
 
         MixCollection<PCaloHit>::MixItr hitItr;

--- a/Validation/Mixing/src/TestSuite.cc
+++ b/Validation/Mixing/src/TestSuite.cc
@@ -100,7 +100,7 @@ TestSuite::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   MonitorElement * trhistsig = dbe_->book1D(sighistotracks,"Bunchcrossings",maxbunch_-minbunch_+1,minbunch_,maxbunch_+1);
   MonitorElement * trindhist = dbe_->book1D(histotracksind,"Track to Vertex indices",100,0,500);
   MonitorElement * trindhistsig = dbe_->book1D(histotracksindsig,"Signal Track to Vertex indices",100,0,500);
-  std::auto_ptr<MixCollection<SimTrack> > col1(new MixCollection<SimTrack>(cf_track.product()));
+  std::unique_ptr<MixCollection<SimTrack> > col1(new MixCollection<SimTrack>(cf_track.product()));
   MixCollection<SimTrack>::iterator cfi1;
   for (cfi1=col1->begin(); cfi1!=col1->end();cfi1++) {
     if (cfi1.getTrigger()==0) {
@@ -123,7 +123,7 @@ TestSuite::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   MonitorElement * vtxhistsig = dbe_->book1D(sighistovertices,"Bunchcrossings",maxbunch_-minbunch_+1,minbunch_,maxbunch_+1);
   MonitorElement * vtxindhist = dbe_->book1D(histovertexindices,"Vertex to Track Indices",100,0,300);
   MonitorElement * vtxindhistsig = dbe_->book1D(histovertexindicessig,"Signal Vertex to Track Indices",100,0,300);
-  std::auto_ptr<MixCollection<SimVertex> > col2(new MixCollection<SimVertex>(cf_vertex.product()));
+  std::unique_ptr<MixCollection<SimVertex> > col2(new MixCollection<SimVertex>(cf_vertex.product()));
   MixCollection<SimVertex>::iterator cfi2;
   for (cfi2=col2->begin(); cfi2!=col2->end();cfi2++) {
     if (cfi2.getTrigger()==0) {
@@ -143,7 +143,7 @@ TestSuite::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   MonitorElement * tofhist = dbe_->book1D(tof,"TrackerHit_ToF",100,float(bsp*minbunch_),float(bsp*maxbunch_)+50.);
   sprintf(tof,"SignalTrackerHit_Tof_bcr_%d",bunchcr_);
   MonitorElement * tofhist_sig = dbe_->book1D(tof,"TrackerHit_ToF",100,float(bsp*minbunch_),float(bsp*maxbunch_)+50.);
-  std::auto_ptr<MixCollection<PSimHit> > colsh(new MixCollection<PSimHit>(cf_simhit.product()));
+  std::unique_ptr<MixCollection<PSimHit> > colsh(new MixCollection<PSimHit>(cf_simhit.product()));
   MixCollection<PSimHit>::iterator cfish;
   for (cfish=colsh->begin(); cfish!=colsh->end();cfish++) {
     if (cfish.getTrigger())  {
@@ -160,7 +160,7 @@ TestSuite::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   sprintf(tof,"SignalEcalEBHit_Tof_bcr_%d",bunchcr_);
   MonitorElement * tofecalhist_sig = dbe_->book1D(tof,"EcalEBHit_ToF",100,float(bsp*minbunch_),float(bsp*maxbunch_)+50.);
   //    std::string ecalsubdet("EcalHitsEB");
-  std::auto_ptr<MixCollection<PCaloHit> > colecal(new MixCollection<PCaloHit>(cf_calohitEcal.product()));
+  std::unique_ptr<MixCollection<PCaloHit> > colecal(new MixCollection<PCaloHit>(cf_calohitEcal.product()));
   MixCollection<PCaloHit>::iterator cfiecal;
   for (cfiecal=colecal->begin(); cfiecal!=colecal->end();cfiecal++) {
     if (cfiecal.getTrigger())    tofecalhist_sig->Fill(cfiecal->time());
@@ -173,7 +173,7 @@ TestSuite::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   sprintf(tof,"SignalHcalHit_Tof_bcr_%d",bunchcr_);
   MonitorElement * tofhcalhist_sig = dbe_->book1D(tof,"HcalHit_ToF",100,float(bsp*minbunch_),float(bsp*maxbunch_)+50.);
   //    std::string hcalsubdet("HcalHits");
-  std::auto_ptr<MixCollection<PCaloHit> > colhcal(new MixCollection<PCaloHit>(cf_calohitHcal.product()));
+  std::unique_ptr<MixCollection<PCaloHit> > colhcal(new MixCollection<PCaloHit>(cf_calohitHcal.product()));
   MixCollection<PCaloHit>::iterator cfihcal;
 
   for (cfihcal=colhcal->begin(); cfihcal!=colhcal->end();cfihcal++) {

--- a/Validation/RecoTau/plugins/dqmAuxFunctions.cc
+++ b/Validation/RecoTau/plugins/dqmAuxFunctions.cc
@@ -139,7 +139,7 @@ void dqmCopyRecursively(DQMStore& dqmStore, const std::string& inputDirectory, c
       continue;
     }
 
-    std::auto_ptr<TH1> clone(dynamic_cast<TH1*>(histogram->Clone()));
+    std::unique_ptr<TH1> clone(dynamic_cast<TH1*>(histogram->Clone()));
     clone->Scale(scaleFactor);
 
     dqmStore.setCurrentFolder(outputDirectory);   


### PR DESCRIPTION
for comment about what clang-tidy does to CMSSW (and likely big and not mergeable - this is what clang-tidy check modernize-replace-auto-ptr does on the tip of CMSSW_9_3_X as of a few days ago