### PR TITLE
clang check readability-static-definition-in-anonymous-namespace

### DIFF
--- a/Alignment/CommonAlignment/src/AlignableObjectId.cc
+++ b/Alignment/CommonAlignment/src/AlignableObjectId.cc
@@ -14,7 +14,7 @@ struct AlignableObjectId::entry {
 
 namespace {
 
-  static constexpr AlignableObjectId::entry entries_RunI[] {
+  constexpr AlignableObjectId::entry entries_RunI[] {
     {align::invalid         , "invalid"},
     {align::AlignableDetUnit, "DetUnit"},
     {align::AlignableDet    , "Det"},
@@ -80,7 +80,7 @@ namespace {
     {align::notfound, 0}
   };
 
-  static constexpr AlignableObjectId::entry entries_PhaseI[] {
+  constexpr AlignableObjectId::entry entries_PhaseI[] {
     {align::invalid         , "invalid"},
     {align::AlignableDetUnit, "DetUnit"},
     {align::AlignableDet    , "Det"},
@@ -146,7 +146,7 @@ namespace {
     {align::notfound, 0}
   };
 
-  static constexpr AlignableObjectId::entry entries_PhaseII[] {
+  constexpr AlignableObjectId::entry entries_PhaseII[] {
     {align::invalid         , "invalid"},
     {align::AlignableDetUnit, "DetUnit"},
     {align::AlignableDet    , "Det"},

--- a/Alignment/MuonAlignmentAlgorithms/src/MuonResiduals6DOFrphiFitter.cc
+++ b/Alignment/MuonAlignmentAlgorithms/src/MuonResiduals6DOFrphiFitter.cc
@@ -22,7 +22,7 @@ namespace
 
   //const CSCGeometry *cscGeometry;
   //static CSCDetId cscDetId;
-  static double csc_R;
+  double csc_R;
 
 
   double getResidual(double delta_x, double delta_y, double delta_z, 

--- a/CommonTools/Utils/src/FormulaEvaluator.cc
+++ b/CommonTools/Utils/src/FormulaEvaluator.cc
@@ -559,20 +559,20 @@ namespace {
     return info;
   }
 
-  static const std::string k_log("log");
-  static const std::string k_log10("log10");
-  static const std::string k_TMath__Log("TMath::Log");
+  const std::string k_log("log");
+  const std::string k_log10("log10");
+  const std::string k_TMath__Log("TMath::Log");
   double const kLog10Inv = 1./std::log(10.);
-  static const std::string k_exp("exp");
-  static const std::string k_pow("pow");
-  static const std::string k_TMath__Power("TMath::Power");
-  static const std::string k_max("max");
-  static const std::string k_min("min");
-  static const std::string k_TMath__Max("TMath::Max");
-  static const std::string k_TMath__Min("TMath::Min");
-  static const std::string k_TMath__Erf("TMath::Erf");
-  static const std::string k_erf("erf");
-  static const std::string k_TMath__Landau("TMath::Landau");
+  const std::string k_exp("exp");
+  const std::string k_pow("pow");
+  const std::string k_TMath__Power("TMath::Power");
+  const std::string k_max("max");
+  const std::string k_min("min");
+  const std::string k_TMath__Max("TMath::Max");
+  const std::string k_TMath__Min("TMath::Min");
+  const std::string k_TMath__Erf("TMath::Erf");
+  const std::string k_erf("erf");
+  const std::string k_TMath__Landau("TMath::Landau");
 
 
   EvaluatorInfo 
@@ -660,7 +660,7 @@ namespace {
     return info;
   };
 
-  static ExpressionFinder const s_expressionFinder;
+  ExpressionFinder const s_expressionFinder;
   
 }
 //

--- a/DataFormats/Math/src/FastMath.cc
+++ b/DataFormats/Math/src/FastMath.cc
@@ -24,6 +24,6 @@ namespace fastmath_details {
 	}
       }
     };
-    static Initatan initAtan;
+    Initatan initAtan;
   }
 }

--- a/DataFormats/MuonReco/src/EmulatedME0Segment.cc
+++ b/DataFormats/MuonReco/src/EmulatedME0Segment.cc
@@ -49,7 +49,7 @@ namespace{
 };
 
 namespace{
-  static const AlgebraicMatrix theProjectionMatrix = createStaticMatrix();
+  const AlgebraicMatrix theProjectionMatrix = createStaticMatrix();
 };
 
 AlgebraicMatrix EmulatedME0Segment::projectionMatrix() const {

--- a/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
+++ b/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
@@ -393,7 +393,7 @@ namespace {
           }
        };
   typedef tbb::concurrent_unordered_map<edm::ParameterSetID, std::vector<std::string>, key_hash> AllLabelsMap;
-  [[cms::thread_safe]] static AllLabelsMap allLabelsMap;
+  [[cms::thread_safe]] AllLabelsMap allLabelsMap;
 }
 
 std::vector<std::string>  const* TriggerObjectStandAlone::allLabels(edm::ParameterSetID const& psetid, const edm::EventBase &event,const edm::TriggerResults &res) const {

--- a/DataFormats/PatCandidates/src/VIDCutFlowResult.cc
+++ b/DataFormats/PatCandidates/src/VIDCutFlowResult.cc
@@ -2,7 +2,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 namespace {
-  static const std::string empty_str("");
+  const std::string empty_str("");
 }
 
 namespace vid {

--- a/FWCore/Common/src/EventBase.cc
+++ b/FWCore/Common/src/EventBase.cc
@@ -30,7 +30,7 @@ namespace {
       }
    };
    typedef tbb::concurrent_unordered_map<edm::ParameterSetID, edm::TriggerNames, key_hash> TriggerNamesMap;
-   [[cms::thread_safe]] static TriggerNamesMap triggerNamesMap;
+   [[cms::thread_safe]] TriggerNamesMap triggerNamesMap;
 }
 
 namespace edm

--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -149,9 +149,9 @@ namespace {
     kFatal
   };
 
-  static thread_local bool s_ignoreWarnings = false;
+  thread_local bool s_ignoreWarnings = false;
 
-  static bool s_ignoreEverything = false;
+  bool s_ignoreEverything = false;
 
   void RootErrorHandlerImpl(int level, char const* location, char const* message) {
 

--- a/FWCore/Utilities/src/typelookup.cc
+++ b/FWCore/Utilities/src/typelookup.cc
@@ -60,7 +60,7 @@ namespace {
    // for the strings are assigned at compile time via a macro call
    using TypeNameToValueMap = tbb::concurrent_unordered_map<const char*, const std::type_info*, StringHash, StringEqual>;
 
-   static TypeNameToValueMap& typeNameToValueMap() {
+   TypeNameToValueMap& typeNameToValueMap() {
       static TypeNameToValueMap s_map;
       return s_map;
    }

--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -78,7 +78,7 @@ void FWRecoGeometryESProducer::ADD_PIXEL_TOPOLOGY( unsigned int rawid, const Geo
   }                                                                     \
 
 namespace {
-  static const std::array<std::string,3> hgcal_geom_names =  { { "HGCalEESensitive",
+  const std::array<std::string,3> hgcal_geom_names =  { { "HGCalEESensitive",
                                                                  "HGCalHESiliconSensitive",
                                                                  "HGCalHEScintillatorSensitive" } };
 }

--- a/Fireworks/ParticleFlow/plugins/FWPFCandidateWithHitsProxyBuilder.cc
+++ b/Fireworks/ParticleFlow/plugins/FWPFCandidateWithHitsProxyBuilder.cc
@@ -22,7 +22,7 @@
 
 namespace
 {
-   const static std::string cname("particleFlowRecHitHCALUpgrade");
+   const std::string cname("particleFlowRecHitHCALUpgrade");
 
 void  addLineToLineSet(TEveStraightLineSet* ls, const float* p, int i1, int i2)
 {

--- a/GeneratorInterface/AlpgenInterface/src/AlpgenHeader.cc
+++ b/GeneratorInterface/AlpgenInterface/src/AlpgenHeader.cc
@@ -134,7 +134,7 @@ namespace {
     { return this->index == index; }
   } 
   
-  static const alpgenParameterNames[] = {
+  const alpgenParameterNames[] = {
     DEFINE_ALPGEN_PARAMETER(ih2),
     DEFINE_ALPGEN_PARAMETER(ebeam),
     DEFINE_ALPGEN_PARAMETER(ndns),

--- a/GeneratorInterface/Herwig6Interface/plugins/Herwig6Hadronizer.cc
+++ b/GeneratorInterface/Herwig6Interface/plugins/Herwig6Hadronizer.cc
@@ -51,20 +51,20 @@ extern "C" {
 
 // helpers
 namespace {
-	static inline bool call_hwmatch()
+	inline bool call_hwmatch()
 	{
 		int result;
 		hwmatch(&result);
 		return result;
 	}  
-	static inline bool call_hwmsct()
+	inline bool call_hwmsct()
 	{
 		int result;
 		hwmsct(&result);
 		return result;
 	}
 
-	static int pdgToHerwig(int ipdg, char *nwig)
+	int pdgToHerwig(int ipdg, char *nwig)
 	{
 		int iopt = 1;
 		int iwig = 0;
@@ -72,7 +72,7 @@ namespace {
 		return ipdg ? iwig : 0;
 	}
 
-	static bool markStable(int pdgId)
+	bool markStable(int pdgId)
 	{
 		char nwig[9] = "        ";
 		if (!pdgToHerwig(pdgId, nwig))

--- a/GeneratorInterface/PomwigInterface/src/PomwigHadronizer.cc
+++ b/GeneratorInterface/PomwigInterface/src/PomwigHadronizer.cc
@@ -47,14 +47,14 @@ extern "C" {
 
 // helpers
 namespace {
-	static inline bool call_hwmsct()
+	inline bool call_hwmsct()
 	{
 		int result;
 		hwmsct(&result);
 		return result;
 	}
 
-	static int pdgToHerwig(int ipdg, char *nwig)
+	int pdgToHerwig(int ipdg, char *nwig)
 	{
 		int iopt = 1;
 		int iwig = 0;
@@ -62,7 +62,7 @@ namespace {
 		return ipdg ? iwig : 0;
 	}
 
-	static bool markStable(int pdgId)
+	bool markStable(int pdgId)
 	{
 		char nwig[9] = "        ";
 		if (!pdgToHerwig(pdgId, nwig))

--- a/HLTrigger/Timer/test/chrono/src/x86_tsc.cc
+++ b/HLTrigger/Timer/test/chrono/src/x86_tsc.cc
@@ -152,7 +152,7 @@ uint64_t serialising_rdtsc_unimplemented(void)
 
 namespace {
 
-  static inline constexpr
+  inline constexpr
   unsigned int _(const char b[4]) {
     return * (unsigned int *)(b);
   }

--- a/PhysicsTools/MVAComputer/plugins/ProcTMVA.cc
+++ b/PhysicsTools/MVAComputer/plugins/ProcTMVA.cc
@@ -65,7 +65,7 @@ class ProcTMVA : public VarProcessor {
   TString   methodName_t;
 };
 
-static ProcTMVA::Registry registry("ProcTMVA");
+ProcTMVA::Registry registry("ProcTMVA");
 
 ProcTMVA::ProcTMVA(const char *name,
                    const Calibration::ProcExternal *calib,

--- a/PhysicsTools/MVAComputer/src/ProcCategory.cc
+++ b/PhysicsTools/MVAComputer/src/ProcCategory.cc
@@ -41,7 +41,7 @@ class ProcCategory : public VarProcessor {
 	const Calibration::ProcCategory	*calib;
 };
 
-static ProcCategory::Registry registry("ProcCategory");
+ProcCategory::Registry registry("ProcCategory");
 
 ProcCategory::ProcCategory(const char *name,
                            const Calibration::ProcCategory *calib,

--- a/PhysicsTools/MVAComputer/src/ProcClassed.cc
+++ b/PhysicsTools/MVAComputer/src/ProcClassed.cc
@@ -38,7 +38,7 @@ class ProcClassed : public VarProcessor {
 	unsigned int	nClasses;
 };
 
-static ProcClassed::Registry registry("ProcClassed");
+ProcClassed::Registry registry("ProcClassed");
 
 ProcClassed::ProcClassed(const char *name,
                          const Calibration::ProcClassed *calib,

--- a/PhysicsTools/MVAComputer/src/ProcCount.cc
+++ b/PhysicsTools/MVAComputer/src/ProcCount.cc
@@ -34,7 +34,7 @@ class ProcCount : public VarProcessor {
 	virtual void eval(ValueIterator iter, unsigned int n) const override;
 };
 
-static ProcCount::Registry registry("ProcCount");
+ProcCount::Registry registry("ProcCount");
 
 ProcCount::ProcCount(const char *name,
                           const Calibration::ProcCount *calib,

--- a/PhysicsTools/MVAComputer/src/ProcForeach.cc
+++ b/PhysicsTools/MVAComputer/src/ProcForeach.cc
@@ -60,7 +60,7 @@ class ProcForeach : public VarProcessor {
 	unsigned int		count;
 };
 
-static ProcForeach::Registry registry("ProcForeach");
+ProcForeach::Registry registry("ProcForeach");
 
 ProcForeach::ProcForeach(const char *name,
                          const Calibration::ProcForeach *calib,

--- a/PhysicsTools/MVAComputer/src/ProcLikelihood.cc
+++ b/PhysicsTools/MVAComputer/src/ProcLikelihood.cc
@@ -118,7 +118,7 @@ class ProcLikelihood : public VarProcessor {
 	unsigned int		nCategories;
 };
 
-static ProcLikelihood::Registry registry("ProcLikelihood");
+ProcLikelihood::Registry registry("ProcLikelihood");
 
 double ProcLikelihood::SplinePDF::eval(double value) const
 {

--- a/PhysicsTools/MVAComputer/src/ProcLinear.cc
+++ b/PhysicsTools/MVAComputer/src/ProcLinear.cc
@@ -41,7 +41,7 @@ class ProcLinear : public VarProcessor {
 	double			offset;
 };
 
-static ProcLinear::Registry registry("ProcLinear");
+ProcLinear::Registry registry("ProcLinear");
 
 ProcLinear::ProcLinear(const char *name,
                        const Calibration::ProcLinear *calib,

--- a/PhysicsTools/MVAComputer/src/ProcMLP.cc
+++ b/PhysicsTools/MVAComputer/src/ProcMLP.cc
@@ -61,7 +61,7 @@ class ProcMLP : public VarProcessor {
 	unsigned int		maxTmp;
 };
 
-static ProcMLP::Registry registry("ProcMLP");
+ProcMLP::Registry registry("ProcMLP");
 
 ProcMLP::Layer::Layer(const Calibration::ProcMLP::Layer &calib) :
 	inputs(calib.first.front().second.size()),

--- a/PhysicsTools/MVAComputer/src/ProcMatrix.cc
+++ b/PhysicsTools/MVAComputer/src/ProcMatrix.cc
@@ -60,7 +60,7 @@ class ProcMatrix : public VarProcessor {
 	Matrix	matrix;
 };
 
-static ProcMatrix::Registry registry("ProcMatrix");
+ProcMatrix::Registry registry("ProcMatrix");
 
 ProcMatrix::ProcMatrix(const char *name,
                        const Calibration::ProcMatrix *calib,

--- a/PhysicsTools/MVAComputer/src/ProcMultiply.cc
+++ b/PhysicsTools/MVAComputer/src/ProcMultiply.cc
@@ -47,7 +47,7 @@ class ProcMultiply : public VarProcessor {
 	std::vector<Config>			out;
 };
 
-static ProcMultiply::Registry registry("ProcMultiply");
+ProcMultiply::Registry registry("ProcMultiply");
 
 ProcMultiply::ProcMultiply(const char *name,
                        const Calibration::ProcMultiply *calib,

--- a/PhysicsTools/MVAComputer/src/ProcNormalize.cc
+++ b/PhysicsTools/MVAComputer/src/ProcNormalize.cc
@@ -64,7 +64,7 @@ class ProcNormalize : public VarProcessor {
 	unsigned int		nCategories;
 };
 
-static ProcNormalize::Registry registry("ProcNormalize");
+ProcNormalize::Registry registry("ProcNormalize");
 
 ProcNormalize::ProcNormalize(const char *name,
                              const Calibration::ProcNormalize *calib,

--- a/PhysicsTools/MVAComputer/src/ProcOptional.cc
+++ b/PhysicsTools/MVAComputer/src/ProcOptional.cc
@@ -39,7 +39,7 @@ class ProcOptional : public VarProcessor {
 	std::vector<double>	neutralPos;
 };
 
-static ProcOptional::Registry registry("ProcOptional");
+ProcOptional::Registry registry("ProcOptional");
 
 ProcOptional::ProcOptional(const char *name,
                           const Calibration::ProcOptional *calib,

--- a/PhysicsTools/MVAComputer/src/ProcSort.cc
+++ b/PhysicsTools/MVAComputer/src/ProcSort.cc
@@ -49,7 +49,7 @@ class ProcSort : public VarProcessor {
 	bool		descending;
 };
 
-static ProcSort::Registry registry("ProcSort");
+ProcSort::Registry registry("ProcSort");
 
 ProcSort::ProcSort(const char *name,
                    const Calibration::ProcSort *calib,

--- a/PhysicsTools/MVAComputer/src/ProcSplitter.cc
+++ b/PhysicsTools/MVAComputer/src/ProcSplitter.cc
@@ -40,7 +40,7 @@ class ProcSplitter : public VarProcessor {
 	unsigned int	count;
 };
 
-static ProcSplitter::Registry registry("ProcSplitter");
+ProcSplitter::Registry registry("ProcSplitter");
 
 ProcSplitter::ProcSplitter(const char *name,
                           const Calibration::ProcSplitter *calib,

--- a/PhysicsTools/MVATrainer/plugins/ProcMLP.cc
+++ b/PhysicsTools/MVATrainer/plugins/ProcMLP.cc
@@ -72,7 +72,7 @@ class ProcMLP : public TrainProcessor {
 	double			limiter;
 };
 
-static ProcMLP::Registry registry("ProcMLP");
+ProcMLP::Registry registry("ProcMLP");
 
 ProcMLP::ProcMLP(const char *name, const AtomicId *id,
                  MVATrainer *trainer) :

--- a/PhysicsTools/MVATrainer/plugins/ProcTMVA.cc
+++ b/PhysicsTools/MVATrainer/plugins/ProcTMVA.cc
@@ -104,7 +104,7 @@ class ProcTMVA : public TrainProcessor {
 	std::string			setupOptions;	// training/test tree TMVA setup options
 };
 
-static ProcTMVA::Registry registry("ProcTMVA");
+ProcTMVA::Registry registry("ProcTMVA");
 
 ProcTMVA::ProcTMVA(const char *name, const AtomicId *id,
                    MVATrainer *trainer) :
@@ -215,7 +215,7 @@ bool ProcTMVA::load()
 	return true;
 }
 
-static std::size_t getStreamSize(std::ifstream &in)
+std::size_t getStreamSize(std::ifstream &in)
 {
 	std::ifstream::pos_type begin = in.tellg();
 	in.seekg(0, std::ios::end);

--- a/PhysicsTools/MVATrainer/src/ProcCategory.cc
+++ b/PhysicsTools/MVATrainer/src/ProcCategory.cc
@@ -51,7 +51,7 @@ class ProcCategory : public TrainProcessor {
 	std::vector<BinLimits>	limits;
 };
 
-static ProcCategory::Registry registry("ProcCategory");
+ProcCategory::Registry registry("ProcCategory");
 
 ProcCategory::ProcCategory(const char *name, const AtomicId *id,
                            MVATrainer *trainer) :
@@ -63,7 +63,7 @@ ProcCategory::~ProcCategory()
 {
 }
 
-static void
+void
 fillRange(unsigned int n, int *matrix, unsigned int off,
           const unsigned int *strides,
           const std::pair<unsigned int, unsigned int> *ranges, int value)

--- a/PhysicsTools/MVATrainer/src/ProcClassed.cc
+++ b/PhysicsTools/MVATrainer/src/ProcClassed.cc
@@ -37,7 +37,7 @@ class ProcClassed : public TrainProcessor {
 	unsigned int	count;
 };
 
-static ProcClassed::Registry registry("ProcClassed");
+ProcClassed::Registry registry("ProcClassed");
 
 ProcClassed::ProcClassed(const char *name, const AtomicId *id,
                          MVATrainer *trainer) :

--- a/PhysicsTools/MVATrainer/src/ProcCount.cc
+++ b/PhysicsTools/MVATrainer/src/ProcCount.cc
@@ -32,7 +32,7 @@ class ProcCount : public TrainProcessor {
 	std::vector<double>	neutrals;
 };
 
-static ProcCount::Registry registry("ProcCount");
+ProcCount::Registry registry("ProcCount");
 
 ProcCount::ProcCount(const char *name, const AtomicId *id,
                              MVATrainer *trainer) :

--- a/PhysicsTools/MVATrainer/src/ProcForeach.cc
+++ b/PhysicsTools/MVATrainer/src/ProcForeach.cc
@@ -32,7 +32,7 @@ class ProcForeach : public TrainProcessor {
 	unsigned int	count;
 };
 
-static ProcForeach::Registry registry("ProcForeach");
+ProcForeach::Registry registry("ProcForeach");
 
 ProcForeach::ProcForeach(const char *name, const AtomicId *id,
                          MVATrainer *trainer) :

--- a/PhysicsTools/MVATrainer/src/ProcLikelihood.cc
+++ b/PhysicsTools/MVATrainer/src/ProcLikelihood.cc
@@ -83,7 +83,7 @@ class ProcLikelihood : public TrainProcessor {
 	Iteration		iteration;
 };
 
-static ProcLikelihood::Registry registry("ProcLikelihood");
+ProcLikelihood::Registry registry("ProcLikelihood");
 
 ProcLikelihood::ProcLikelihood(const char *name, const AtomicId *id,
                                MVATrainer *trainer) :
@@ -414,7 +414,7 @@ void ProcLikelihood::trainData(const std::vector<double> *values,
 	}
 }
 
-static void smoothArray(unsigned int n, double *values, unsigned int nTimes)
+void smoothArray(unsigned int n, double *values, unsigned int nTimes)
 {
 	for(unsigned int iter = 0; iter < nTimes; iter++) {
 		double hold = n > 0 ? values[0] : 0.0;
@@ -522,7 +522,7 @@ void ProcLikelihood::trainEnd()
 	}
 }
 
-static void xmlParsePDF(ProcLikelihood::PDF &pdf, DOMElement *elem)
+void xmlParsePDF(ProcLikelihood::PDF &pdf, DOMElement *elem)
 {
 	if (!elem ||
 	    std::strcmp(XMLSimpleStr(elem->getNodeName()), "pdf") != 0)
@@ -750,7 +750,7 @@ bool ProcLikelihood::load()
 	return true;
 }
 
-static DOMElement *xmlStorePDF(DOMDocument *doc,
+DOMElement *xmlStorePDF(DOMDocument *doc,
                                const ProcLikelihood::PDF &pdf)
 {
 	DOMElement *elem = doc->createElement(XMLUniStr("pdf"));

--- a/PhysicsTools/MVATrainer/src/ProcLinear.cc
+++ b/PhysicsTools/MVATrainer/src/ProcLinear.cc
@@ -53,7 +53,7 @@ class ProcLinear : public TrainProcessor {
 	double theoffset;
 };
 
-static ProcLinear::Registry registry("ProcLinear");
+ProcLinear::Registry registry("ProcLinear");
 
 ProcLinear::ProcLinear(const char *name, const AtomicId *id,
                              MVATrainer *trainer) :

--- a/PhysicsTools/MVATrainer/src/ProcMatrix.cc
+++ b/PhysicsTools/MVATrainer/src/ProcMatrix.cc
@@ -64,7 +64,7 @@ class ProcMatrix : public TrainProcessor {
 	bool				doRanking;
 };
 
-static ProcMatrix::Registry registry("ProcMatrix");
+ProcMatrix::Registry registry("ProcMatrix");
 
 ProcMatrix::ProcMatrix(const char *name, const AtomicId *id,
                              MVATrainer *trainer) :
@@ -316,7 +316,7 @@ void ProcMatrix::save()
 	xml.getRootNode()->appendChild(ls->save(doc));
 }
 
-static void maskLine(TMatrixDSym &m, unsigned int line)
+void maskLine(TMatrixDSym &m, unsigned int line)
 {
 	unsigned int n = m.GetNrows();
 	for(unsigned int i = 0; i < n; i++)
@@ -324,7 +324,7 @@ static void maskLine(TMatrixDSym &m, unsigned int line)
 	m(line, line) = 1.;
 }
 
-static void restoreLine(TMatrixDSym &m, TMatrixDSym &o, unsigned int line)
+void restoreLine(TMatrixDSym &m, TMatrixDSym &o, unsigned int line)
 {
 	unsigned int n = m.GetNrows();
 	for(unsigned int i = 0; i < n; i++) {
@@ -333,7 +333,7 @@ static void restoreLine(TMatrixDSym &m, TMatrixDSym &o, unsigned int line)
 	}
 }
 
-static double targetCorrelation(const TMatrixDSym &coeffs,
+double targetCorrelation(const TMatrixDSym &coeffs,
                                 const std::vector<bool> &use)
 {
 	unsigned int n = coeffs.GetNrows() - 2;

--- a/PhysicsTools/MVATrainer/src/ProcMultiply.cc
+++ b/PhysicsTools/MVATrainer/src/ProcMultiply.cc
@@ -40,7 +40,7 @@ class ProcMultiply : public TrainProcessor {
 	std::vector<Config>			config;
 };
 
-static ProcMultiply::Registry registry("ProcMultiply");
+ProcMultiply::Registry registry("ProcMultiply");
 
 ProcMultiply::ProcMultiply(const char *name, const AtomicId *id,
                            MVATrainer *trainer) :

--- a/PhysicsTools/MVATrainer/src/ProcNormalize.cc
+++ b/PhysicsTools/MVATrainer/src/ProcNormalize.cc
@@ -77,7 +77,7 @@ class ProcNormalize : public TrainProcessor {
 	unsigned int		nCategories;
 };
 
-static ProcNormalize::Registry registry("ProcNormalize");
+ProcNormalize::Registry registry("ProcNormalize");
 
 ProcNormalize::ProcNormalize(const char *name, const AtomicId *id,
                              MVATrainer *trainer) :
@@ -260,7 +260,7 @@ void ProcNormalize::trainData(const std::vector<double> *values,
 	}
 }
 
-static void smoothArray(unsigned int n, double *values, unsigned int nTimes)
+void smoothArray(unsigned int n, double *values, unsigned int nTimes)
 {
 	for(unsigned int iter = 0; iter < nTimes; iter++) {
 		double hold = n > 0 ? values[0] : 0.0;

--- a/PhysicsTools/MVATrainer/src/ProcOptional.cc
+++ b/PhysicsTools/MVATrainer/src/ProcOptional.cc
@@ -37,7 +37,7 @@ class ProcOptional : public TrainProcessor {
 	std::vector<double>	neutrals;
 };
 
-static ProcOptional::Registry registry("ProcOptional");
+ProcOptional::Registry registry("ProcOptional");
 
 ProcOptional::ProcOptional(const char *name, const AtomicId *id,
                              MVATrainer *trainer) :

--- a/PhysicsTools/MVATrainer/src/ProcSort.cc
+++ b/PhysicsTools/MVATrainer/src/ProcSort.cc
@@ -48,7 +48,7 @@ class ProcSort : public TrainProcessor {
 	bool		descending;
 };
 
-static ProcSort::Registry registry("ProcSort");
+ProcSort::Registry registry("ProcSort");
 
 ProcSort::ProcSort(const char *name, const AtomicId *id, MVATrainer *trainer) :
 	TrainProcessor(name, id, trainer)

--- a/PhysicsTools/MVATrainer/src/ProcSplitter.cc
+++ b/PhysicsTools/MVATrainer/src/ProcSplitter.cc
@@ -32,7 +32,7 @@ class ProcSplitter : public TrainProcessor {
 	unsigned int	count;
 };
 
-static ProcSplitter::Registry registry("ProcSplitter");
+ProcSplitter::Registry registry("ProcSplitter");
 
 ProcSplitter::ProcSplitter(const char *name, const AtomicId *id,
                            MVATrainer *trainer) :

--- a/PhysicsTools/MVATrainer/src/TreeSaver.cc
+++ b/PhysicsTools/MVATrainer/src/TreeSaver.cc
@@ -91,7 +91,7 @@ class TreeSaver : public TrainProcessor {
 	bool				flagsPassed, begun;
 };
 
-static TreeSaver::Registry registry("TreeSaver");
+TreeSaver::Registry registry("TreeSaver");
 
 TreeSaver::TreeSaver(const char *name, const AtomicId *id,
                    MVATrainer *trainer) :

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaTowerIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaTowerIsolation.cc
@@ -29,7 +29,7 @@ namespace {
     const CaloTowerCollection* oldTowers=nullptr;;
     uint32_t id15=0;
   };
-  thread_local static TLS tls;
+  thread_local TLS tls;
 }
 
 EgammaTowerIsolation::EgammaTowerIsolation (float extRadiusI,

--- a/RecoEgamma/EgammaTools/plugins/EGFull5x5ShowerShapeModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGFull5x5ShowerShapeModifier.cc
@@ -9,7 +9,7 @@
 
 namespace {
   const edm::EDGetTokenT<edm::ValueMap<float> > empty_token;
-  const static edm::InputTag empty_tag("");
+  const edm::InputTag empty_tag("");
 }
 
 #include <unordered_map>

--- a/RecoEgamma/EgammaTools/plugins/EGPfIsolationModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGPfIsolationModifier.cc
@@ -12,9 +12,9 @@
 
 namespace {
   const edm::EDGetTokenT<edm::ValueMap<float> > empty_token;
-  const static edm::InputTag empty_tag("");
+  const edm::InputTag empty_tag("");
 
-  const static std::array<std::string,7>  electron_vars = { { "sumChargedHadronPt",
+  const std::array<std::string,7>  electron_vars = { { "sumChargedHadronPt",
                                                               "sumNeutralHadronEt",
                                                               "sumPhotonEt",
                                                               "sumChargedParticlePt",
@@ -22,7 +22,7 @@ namespace {
                                                               "sumPhotonEtHighThreshold",
                                                               "sumPUPt" } };
   
-  const static std::array<std::string,9> photon_vars = { { "chargedHadronIso",
+  const std::array<std::string,9> photon_vars = { { "chargedHadronIso",
                                                            "chargedHadronIsoWrongVtx",
                                                            "neutralHadronIso",
                                                            "photonIso",

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronRegressionValueMapProducer.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronRegressionValueMapProducer.cc
@@ -27,9 +27,9 @@ namespace {
   
   enum reg_int_vars   { k_NIntVars   = 0 };
 
-  static const std::vector<std::string> float_var_names( { } );
+  const std::vector<std::string> float_var_names( { } );
   
-  static const std::vector<std::string> integer_var_names( { } );  
+  const std::vector<std::string> integer_var_names( { } );  
   
   inline void set_map_val( const reg_float_vars index, const float value,
                            std::unordered_map<std::string,float>& map) {

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonRegressionValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonRegressionValueMapProducer.cc
@@ -26,9 +26,9 @@ namespace {
   
   enum reg_int_vars   { k_NIntVars   = 0 };
 
-  static const std::vector<std::string> float_var_names( { } );
+  const std::vector<std::string> float_var_names( { } );
   
-  static const std::vector<std::string> integer_var_names( { } );
+  const std::vector<std::string> integer_var_names( { } );
 
   inline void set_map_val( const reg_float_vars index, const float value,
                            std::unordered_map<std::string,float>& map) {

--- a/RecoParticleFlow/PFSimProducer/plugins/EcalBarrelClusterFastTimer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/EcalBarrelClusterFastTimer.cc
@@ -58,7 +58,7 @@ private:
 DEFINE_FWK_MODULE(EcalBarrelClusterFastTimer);
 
 namespace {
-  static const std::string resolution("Resolution");
+  const std::string resolution("Resolution");
 
   constexpr float cm_per_ns = 29.9792458;
 

--- a/RecoTauTag/RecoTau/src/AntiElectronIDMVA5.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronIDMVA5.cc
@@ -1015,7 +1015,7 @@ namespace {
   return cPhi;
  }
      
-  static const std::array<double,18> cPhi = fill_cPhi();
+  const std::array<double,18> cPhi = fill_cPhi();
 
 }
 

--- a/RecoTauTag/RecoTau/src/AntiElectronIDMVA6.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronIDMVA6.cc
@@ -1261,7 +1261,7 @@ namespace {
   return cPhi;
  }
      
-  static const std::array<double,18> cPhi = fill_cPhi();
+  const std::array<double,18> cPhi = fill_cPhi();
 
 }
 

--- a/RecoVertex/GhostTrackFitter/src/GhostTrackState.cc
+++ b/RecoVertex/GhostTrackFitter/src/GhostTrackState.cc
@@ -22,7 +22,7 @@ namespace {
 
 	typedef SVector<double, 3> Vector3;
 
-	static inline Vector3 conv(const GlobalVector &vec)
+	inline Vector3 conv(const GlobalVector &vec)
 	{
 		Vector3 result;
 		result[0] = vec.x();

--- a/RecoVertex/GhostTrackFitter/src/GhostTrackVertexFinder.cc
+++ b/RecoVertex/GhostTrackFitter/src/GhostTrackVertexFinder.cc
@@ -75,7 +75,7 @@ namespace {
 		const TransientTrack &track;
 	};
 
-	static inline Vector3 conv(const GlobalVector &vec)
+	inline Vector3 conv(const GlobalVector &vec)
 	{
 		Vector3 result;
 		result[0] = vec.x();
@@ -84,7 +84,7 @@ namespace {
 		return result;
 	}
 
-	static inline double sqr(double arg) { return arg * arg; }
+	inline double sqr(double arg) { return arg * arg; }
 }
 
 struct GhostTrackVertexFinder::FinderInfo {

--- a/RecoVertex/GhostTrackFitter/src/SequentialGhostTrackFitter.cc
+++ b/RecoVertex/GhostTrackFitter/src/SequentialGhostTrackFitter.cc
@@ -8,7 +8,7 @@
 using namespace reco;
 
 namespace {
-	static inline double sqr(double arg) { return arg * arg; }
+	inline double sqr(double arg) { return arg * arg; }
 }
 
 SequentialGhostTrackFitter::SequentialGhostTrackFitter() :

--- a/RecoVertex/GhostTrackFitter/src/TrackGhostTrackState.cc
+++ b/RecoVertex/GhostTrackFitter/src/TrackGhostTrackState.cc
@@ -20,7 +20,7 @@
 using namespace reco;
 
 namespace {
-	static inline double sqr(double arg) { return arg * arg; }
+	inline double sqr(double arg) { return arg * arg; }
 
 	using namespace ROOT::Math;
 
@@ -31,7 +31,7 @@ namespace {
 	typedef SMatrix<double, 3, 3> Matrix33;
 	typedef SMatrix<double, 3, 6> Matrix36;
 
-	static inline Vector3 conv(const GlobalVector &vec)
+	inline Vector3 conv(const GlobalVector &vec)
 	{
 		Vector3 result;
 		result[0] = vec.x();

--- a/RecoVertex/GhostTrackFitter/src/VertexGhostTrackState.cc
+++ b/RecoVertex/GhostTrackFitter/src/VertexGhostTrackState.cc
@@ -25,7 +25,7 @@ namespace {
 	typedef SMatrix<double, 3, 3> Matrix33;
 	typedef SMatrix<double, 3, 6> Matrix36;
 
-	static inline Vector3 conv(const GlobalVector &vec)
+	inline Vector3 conv(const GlobalVector &vec)
 	{
 		Vector3 result;
 		result[0] = vec.x();

--- a/RecoVertex/KalmanVertexFit/src/SingleTrackVertexConstraint.cc
+++ b/RecoVertex/KalmanVertexFit/src/SingleTrackVertexConstraint.cc
@@ -11,8 +11,8 @@ namespace {
   // FIXME
   // hard-coded tracker bounds
   // workaround while waiting for Geometry service
-  static const float TrackerBoundsRadius = 112;
-  static const float TrackerBoundsHalfLength = 273.5;
+  const float TrackerBoundsRadius = 112;
+  const float TrackerBoundsHalfLength = 273.5;
   bool insideTrackerBounds(const GlobalPoint& point) {
     return ((point.transverse() < TrackerBoundsRadius)
         && (abs(point.z()) < TrackerBoundsHalfLength));

--- a/RecoVertex/VertexTools/src/SequentialVertexFitter.cc
+++ b/RecoVertex/VertexTools/src/SequentialVertexFitter.cc
@@ -10,8 +10,8 @@ namespace {
   // FIXME
   // hard-coded tracker bounds
   // workaround while waiting for Geometry service
-  static const float TrackerBoundsRadius = 112;
-  static const float TrackerBoundsHalfLength = 273.5;
+  const float TrackerBoundsRadius = 112;
+  const float TrackerBoundsHalfLength = 273.5;
   bool insideTrackerBounds(const GlobalPoint& point) {
     return ((point.transverse() < TrackerBoundsRadius)
         && (abs(point.z()) < TrackerBoundsHalfLength));

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -61,13 +61,13 @@
 
 // from https://hypernews.cern.ch/HyperNews/CMS/get/edmFramework/3302/2.html
 namespace {
-  static std::atomic<int> thread_counter{ 0 };
+  std::atomic<int> thread_counter{ 0 };
 
   int get_new_thread_index() { 
     return thread_counter++;
   }
 
-  static thread_local int s_thread_index = get_new_thread_index();
+  thread_local int s_thread_index = get_new_thread_index();
 
   int getThreadIndex() { return s_thread_index; }
 

--- a/SimG4Core/Geometry/src/DDG4SolidConverter.cc
+++ b/SimG4Core/Geometry/src/DDG4SolidConverter.cc
@@ -265,7 +265,7 @@ G4VSolid * DDG4SolidConverter::torus(const DDSolid & solid) {
 #include "G4ReflectedSolid.hh"
 
 namespace {
-  static const HepGeom::ReflectZ3D z_reflection;
+  const HepGeom::ReflectZ3D z_reflection;
 }
 
 G4VSolid * DDG4SolidConverter::reflected(const DDSolid & solid) {

--- a/SimG4Core/PhysicsLists/src/G4MonopoleTransportation.cc
+++ b/SimG4Core/PhysicsLists/src/G4MonopoleTransportation.cc
@@ -57,7 +57,7 @@ class G4VSensitiveDetector;
 // Constructor
 
 namespace {
-  static const G4TouchableHandle nullTouchableHandle;  // Points to (G4VTouchable*) 0
+  const G4TouchableHandle nullTouchableHandle;  // Points to (G4VTouchable*) 0
 }
 
 G4MonopoleTransportation::G4MonopoleTransportation(const G4Monopole* mpl,

--- a/SimTracker/TrackAssociation/plugins/TrackTimeValueMapProducer.cc
+++ b/SimTracker/TrackAssociation/plugins/TrackTimeValueMapProducer.cc
@@ -67,9 +67,9 @@ DEFINE_FWK_MODULE(TrackTimeValueMapProducer);
 
 namespace {
   constexpr float fakeBeamSpotTimeWidth = 0.175f; // ns
-  static const std::string generalTracksName("generalTracks");
-  static const std::string gsfTracksName("gsfTracks");
-  static const std::string resolution("Resolution");
+  const std::string generalTracksName("generalTracks");
+  const std::string gsfTracksName("gsfTracks");
+  const std::string resolution("Resolution");
 
   template<typename ParticleType, typename T>
   void writeValueMap(edm::Event &iEvent,

--- a/SimTracker/TrackHistory/src/TrackQuality.cc
+++ b/SimTracker/TrackHistory/src/TrackQuality.cc
@@ -37,7 +37,7 @@
 
 namespace
 {
-static const uint32_t NonMatchedTrackId = (uint32_t)-1;
+const uint32_t NonMatchedTrackId = (uint32_t)-1;
 
 struct MatchedHit
 {


### PR DESCRIPTION
for comment about what clang-tidy does to CMSSW (and likely big and not mergeable - this is what clang-tidy check readability-static-definition-in-anonymous-namespace does on the tip of CMSSW_9_3_X as of a few days ago