### PR TITLE
clang check readability-uniqueptr-delete-release

### DIFF
--- a/Alignment/Geners/src/WriteOnlyCatalog.cc
+++ b/Alignment/Geners/src/WriteOnlyCatalog.cc
@@ -33,7 +33,7 @@ namespace gs {
         }
         else
         {
-            delete lastEntry_.release();
+            lastEntry_ = nullptr;
             return 0ULL;
         }
     }


### PR DESCRIPTION
for comment about what clang-tidy does to CMSSW (and likely big and not mergeable - this is what clang-tidy check readability-uniqueptr-delete-release does on the tip of CMSSW_9_3_X as of a few days ago