### PR TITLE
Update pythia8 pt hat reweight user hook

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -115,6 +115,7 @@ class Pythia8Hadronizer : public Py8InterfaceBase {
     // Reweight user hooks
     //
     std::auto_ptr<UserHooks> fReweightUserHook;
+    std::auto_ptr<UserHooks> fReweightEmpUserHook;
     std::auto_ptr<UserHooks> fReweightRapUserHook;  
     std::auto_ptr<UserHooks> fReweightPtHatRapUserHook;
         
@@ -210,7 +211,27 @@ Pythia8Hadronizer::Pythia8Hadronizer(const edm::ParameterSet &params) :
   // Reweight user hook
   //
   if( params.exists( "reweightGen" ) )
-    fReweightUserHook.reset(new PtHatReweightUserHook());
+  {
+    edm::LogInfo("Pythia8Interface") << "Start setup for reweightGen";
+    edm::ParameterSet rgParams =
+       params.getParameter<edm::ParameterSet>("reweightGen");
+    fReweightUserHook.reset(
+       new PtHatReweightUserHook(rgParams.getParameter<double>("pTRef"),
+                                 rgParams.getParameter<double>("power"))
+       );
+    edm::LogInfo("Pythia8Interface") << "End setup for reweightGen";
+  }
+  if( params.exists( "reweightGenEmp" ) )
+  {
+    edm::LogInfo("Pythia8Interface") << "Start setup for reweightGenEmp";
+    edm::ParameterSet rgeParams =
+       params.getParameter<edm::ParameterSet>("reweightGenEmp");
+    fReweightEmpUserHook.reset(
+       new PtHatEmpReweightUserHook(rgeParams.getParameter<double>("pTHatMin"),
+                                    rgeParams.getParameter<double>("pTHatMax"))
+       );
+    edm::LogInfo("Pythia8Interface") << "End setup for reweightGenEmp";
+  }
   if( params.exists( "reweightGenRap" ) )
   {
     edm::LogInfo("Pythia8Interface") << "Start setup for reweightGenRap";
@@ -332,6 +353,7 @@ bool Pythia8Hadronizer::initializeForInternalPartons()
   fMultiUserHook.reset(new MultiUserHook);
   
   if(fReweightUserHook.get()) fMultiUserHook->addHook(fReweightUserHook.get());
+  if(fReweightEmpUserHook.get()) fMultiUserHook->addHook(fReweightEmpUserHook.get());
   if(fReweightRapUserHook.get()) fMultiUserHook->addHook(fReweightRapUserHook.get());
   if(fReweightPtHatRapUserHook.get()) fMultiUserHook->addHook(fReweightPtHatRapUserHook.get());
   if(fJetMatchingHook.get()) fMultiUserHook->addHook(fJetMatchingHook.get());
@@ -458,6 +480,7 @@ bool Pythia8Hadronizer::initializeForExternalPartons()
   fMultiUserHook.reset(new MultiUserHook);
   
   if(fReweightUserHook.get()) fMultiUserHook->addHook(fReweightUserHook.get());
+  if(fReweightEmpUserHook.get()) fMultiUserHook->addHook(fReweightEmpUserHook.get());
   if(fReweightRapUserHook.get()) fMultiUserHook->addHook(fReweightRapUserHook.get());
   if(fReweightPtHatRapUserHook.get()) fMultiUserHook->addHook(fReweightPtHatRapUserHook.get());
   if(fJetMatchingHook.get()) fMultiUserHook->addHook(fJetMatchingHook.get());

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -226,10 +226,7 @@ Pythia8Hadronizer::Pythia8Hadronizer(const edm::ParameterSet &params) :
     edm::LogInfo("Pythia8Interface") << "Start setup for reweightGenEmp";
     edm::ParameterSet rgeParams =
        params.getParameter<edm::ParameterSet>("reweightGenEmp");
-    fReweightEmpUserHook.reset(
-       new PtHatEmpReweightUserHook(rgeParams.getParameter<double>("pTHatMin"),
-                                    rgeParams.getParameter<double>("pTHatMax"))
-       );
+    fReweightEmpUserHook.reset(new PtHatEmpReweightUserHook());
     edm::LogInfo("Pythia8Interface") << "End setup for reweightGenEmp";
   }
   if( params.exists( "reweightGenRap" ) )

--- a/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
@@ -26,6 +26,36 @@ class PtHatReweightUserHook : public Pythia8::UserHooks
     double pt, power;
 };
 
+class PtHatEmpReweightUserHook : public Pythia8::UserHooks
+{
+  public:
+   PtHatEmpReweightUserHook(double _pTHatMin, double _pTHatMax) :
+      pTHatMin(_pTHatMin), pTHatMax(_pTHatMax) {
+      // Normalized to Event/fb-1
+      // sigma(938.385)==1
+      sigma = TF1("sigma", "(x<1000.)*(([0]*TMath::Log10(x-[1])**[2])+[3])+(x>=1000.)*(x<2132.)*([4]*TMath::Exp(-[5]*x))+(x>=2132)*([6]*TMath::Exp(-[7]*x))", pTHatMin, pTHatMax);
+      sigma.SetParameters(5.24127e+18,-4.37813e+01, -3.87024e+01,-9.83995e-01,1.18362e+02,5.32593e-03,5.83347e+01,4.99407e-03);
+    }
+    virtual ~PtHatEmpReweightUserHook() {}
+
+    virtual bool canBiasSelection() { return true; }
+
+    virtual double biasSelectionBy(const Pythia8::SigmaProcess* sigmaProcessPtr,
+                      const Pythia8::PhaseSpace* phaseSpacePtr, bool inEvent)
+    {
+      //the variable selBias of the base class should be used;
+      if ((sigmaProcessPtr->nFinal() == 2)) {
+         selBias = 1.0/sigma.Eval(phaseSpacePtr->pTHat());
+        return selBias;
+      }
+      selBias = 1.;
+      return selBias;
+    }
+
+  private:
+    double pTHatMin, pTHatMax;
+    TF1 sigma;
+};
 
 class RapReweightUserHook : public Pythia8::UserHooks
 {

--- a/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
@@ -32,9 +32,31 @@ class PtHatEmpReweightUserHook : public Pythia8::UserHooks
    PtHatEmpReweightUserHook(double _pTHatMin, double _pTHatMax) :
       pTHatMin(_pTHatMin), pTHatMax(_pTHatMax) {
       // Normalized to Event/fb-1
-      // sigma(938.385)==1
-      sigma = TF1("sigma", "(x<1000.)*(([0]*TMath::Log10(x-[1])**[2])+[3])+(x>=1000.)*(x<2132.)*([4]*TMath::Exp(-[5]*x))+(x>=2132)*([6]*TMath::Exp(-[7]*x))", pTHatMin, pTHatMax);
-      sigma.SetParameters(5.24127e+18,-4.37813e+01, -3.87024e+01,-9.83995e-01,1.18362e+02,5.32593e-03,5.83347e+01,4.99407e-03);
+      //Mikko
+      //sigma = TF1("sigma", "max(2.e-15,[0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1]))", pTHatMin, pTHatMax);
+      //Line
+      //sigma = TF1("sigma", "((x<=5500)*([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1])))+((x>5500)*(1.99851e-11+-3.07464e-15*x))", pTHatMin, pTHatMax);
+      //quartic function
+      //sigma = TF1("sigma", "((x<=5500)*([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1])))+((x>5500)*(-3.07464e-18*pow(x-5250,2)+(1.436e-12)+(2e-27*pow(x,4))))", pTHatMin, pTHatMax);
+      //sigmoid
+      //sigma = TF1("sigma", "((x<=5500)*([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1])))+((x>5500)*(3.07464e-12/(0.00001+(TMath::Exp(0.015*(x-5500))))))", pTHatMin, pTHatMax);
+      //sigma = TF1("sigma", "((x<=5500)*([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1])))+((x>5500)*(3.07464e-12/(1.0+(TMath::Exp(0.035*(x-5800.0))))))", pTHatMin, pTHatMax);
+      //sigma = TF1("sigma", "((x<=5500)*([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1])))+((x>5500)*(3.07464e-12/(1.0+(TMath::Exp(0.017*(x-5600.0))))))", pTHatMin, pTHatMax);
+      //sigma = TF1("sigma", "((x<=5500)*([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1])))+((x>5500)*(3.07464e-12/(0.5507+(TMath::Exp(0.016*(x-5550.0))))))", pTHatMin, pTHatMax);
+      //sigma = TF1("sigma", "((x<=5500)*([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1])))+((x>5500)*(3.07464e-12/(0.73713+(TMath::Exp(0.0167*(x-5580.0))))))", pTHatMin, pTHatMax);
+      //sigma = TF1("sigma", "((x<=5500)*([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1])))+((x>5500)*(3.07464e-12/(0.03624+(TMath::Exp(0.015*(x-5530.0))))))", pTHatMin, pTHatMax);
+      //sigma = TF1("sigma", "((x<=5500)*([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1])))+((x>5500)*(3.07464e-12/(1.0+(TMath::Exp(0.022*(x-5680.0))))))", pTHatMin, pTHatMax);
+      std::string fLT5500 = "([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1]))";
+      std::string f5500to5700 = "(3.07464e-12/(0.5507+(TMath::Exp(0.016*(x-5550.0)))))";
+      std::string f5700to5800 = "(3.07464e-12/(0.73713+(TMath::Exp(0.0167*(x-5580.0)))))";
+      std::string f5800to6000 = "(3.07464e-12/(1.0+(TMath::Exp(0.017*(x-5600.0)))))";
+      std::string f6000toInf = "(3.07464e-12/(1.0+(TMath::Exp(0.023*(x-5705.0)))))";
+      const char *fmt = "((x<=5500)*%s)+((x>5500)*(x<=5700)*%s)+((x>5700)*(x<=5800)*%s)+((x>5800)*(x<=6000)*%s)+((x>6000)*%s)";
+      int sz = std::snprintf(nullptr, 0, fmt, fLT5500.c_str(), f5500to5700.c_str(), f5700to5800.c_str(), f5800to6000.c_str(), f6000toInf.c_str());
+      std::vector<char> buf(sz + 1); // +1 for null terminator
+      std::snprintf(&buf[0], buf.size(), fmt, fLT5500.c_str(), f5500to5700.c_str(), f5700to5800.c_str(), f5800to6000.c_str(), f6000toInf.c_str());
+      sigma = TF1("sigma", &buf[0], pTHatMin, pTHatMax);
+      sigma.SetParameters(5.66875e+13,9.93446e+00,-3.96986e+00,-2.26690e-01,1.75926e-02);
     }
     virtual ~PtHatEmpReweightUserHook() {}
 

--- a/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
@@ -29,10 +29,10 @@ class PtHatReweightUserHook : public Pythia8::UserHooks
 class PtHatEmpReweightUserHook : public Pythia8::UserHooks
 {
   public:
-   PtHatEmpReweightUserHook(double _pTHatMin, double _pTHatMax) :
-      pTHatMin(_pTHatMin), pTHatMax(_pTHatMax) {
-      sigma = TF1("sigma", "([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/(13000.+[5]),[1]))*x", pTHatMin, pTHatMax);
-      sigma.SetParameters(5.35720e+13,1.09077e+01,-2.58981e+00,-5.15755e-01,5.59513e-02,3.5e+02);
+    PtHatEmpReweightUserHook()
+    {
+      p = {5.3571961909810e+13,1.0907678218282e+01,-2.5898069229451e+00,-5.1575514014931e-01,5.5951279807561e-02,3.5e+02};
+      sigma = [this](double x) -> double { return (p[0]*pow(x,p[2]+p[3]*log(0.01*x)+p[4]*pow(log(0.01*x),2))*pow(1-2*x/(13000.+p[5]),p[1]))*x; };
     }
     virtual ~PtHatEmpReweightUserHook() {}
 
@@ -43,7 +43,7 @@ class PtHatEmpReweightUserHook : public Pythia8::UserHooks
     {
       //the variable selBias of the base class should be used;
       if ((sigmaProcessPtr->nFinal() == 2)) {
-         selBias = 1.0/sigma.Eval(phaseSpacePtr->pTHat());
+        selBias = 1.0/sigma(phaseSpacePtr->pTHat());
         return selBias;
       }
       selBias = 1.;
@@ -51,8 +51,8 @@ class PtHatEmpReweightUserHook : public Pythia8::UserHooks
     }
 
   private:
-    double pTHatMin, pTHatMax;
-    TF1 sigma;
+    std::vector<double> p;
+    std::function<double(double)> sigma;
 };
 
 class RapReweightUserHook : public Pythia8::UserHooks

--- a/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
@@ -31,32 +31,8 @@ class PtHatEmpReweightUserHook : public Pythia8::UserHooks
   public:
    PtHatEmpReweightUserHook(double _pTHatMin, double _pTHatMax) :
       pTHatMin(_pTHatMin), pTHatMax(_pTHatMax) {
-      // Normalized to Event/fb-1
-      //Mikko
-      //sigma = TF1("sigma", "max(2.e-15,[0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1]))", pTHatMin, pTHatMax);
-      //Line
-      //sigma = TF1("sigma", "((x<=5500)*([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1])))+((x>5500)*(1.99851e-11+-3.07464e-15*x))", pTHatMin, pTHatMax);
-      //quartic function
-      //sigma = TF1("sigma", "((x<=5500)*([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1])))+((x>5500)*(-3.07464e-18*pow(x-5250,2)+(1.436e-12)+(2e-27*pow(x,4))))", pTHatMin, pTHatMax);
-      //sigmoid
-      //sigma = TF1("sigma", "((x<=5500)*([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1])))+((x>5500)*(3.07464e-12/(0.00001+(TMath::Exp(0.015*(x-5500))))))", pTHatMin, pTHatMax);
-      //sigma = TF1("sigma", "((x<=5500)*([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1])))+((x>5500)*(3.07464e-12/(1.0+(TMath::Exp(0.035*(x-5800.0))))))", pTHatMin, pTHatMax);
-      //sigma = TF1("sigma", "((x<=5500)*([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1])))+((x>5500)*(3.07464e-12/(1.0+(TMath::Exp(0.017*(x-5600.0))))))", pTHatMin, pTHatMax);
-      //sigma = TF1("sigma", "((x<=5500)*([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1])))+((x>5500)*(3.07464e-12/(0.5507+(TMath::Exp(0.016*(x-5550.0))))))", pTHatMin, pTHatMax);
-      //sigma = TF1("sigma", "((x<=5500)*([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1])))+((x>5500)*(3.07464e-12/(0.73713+(TMath::Exp(0.0167*(x-5580.0))))))", pTHatMin, pTHatMax);
-      //sigma = TF1("sigma", "((x<=5500)*([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1])))+((x>5500)*(3.07464e-12/(0.03624+(TMath::Exp(0.015*(x-5530.0))))))", pTHatMin, pTHatMax);
-      //sigma = TF1("sigma", "((x<=5500)*([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1])))+((x>5500)*(3.07464e-12/(1.0+(TMath::Exp(0.022*(x-5680.0))))))", pTHatMin, pTHatMax);
-      std::string fLT5500 = "([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/13000.,[1]))";
-      std::string f5500to5700 = "(3.07464e-12/(0.5507+(TMath::Exp(0.016*(x-5550.0)))))";
-      std::string f5700to5800 = "(3.07464e-12/(0.73713+(TMath::Exp(0.0167*(x-5580.0)))))";
-      std::string f5800to6000 = "(3.07464e-12/(1.0+(TMath::Exp(0.017*(x-5600.0)))))";
-      std::string f6000toInf = "(3.07464e-12/(1.0+(TMath::Exp(0.023*(x-5705.0)))))";
-      const char *fmt = "((x<=5500)*%s)+((x>5500)*(x<=5700)*%s)+((x>5700)*(x<=5800)*%s)+((x>5800)*(x<=6000)*%s)+((x>6000)*%s)";
-      int sz = std::snprintf(nullptr, 0, fmt, fLT5500.c_str(), f5500to5700.c_str(), f5700to5800.c_str(), f5800to6000.c_str(), f6000toInf.c_str());
-      std::vector<char> buf(sz + 1); // +1 for null terminator
-      std::snprintf(&buf[0], buf.size(), fmt, fLT5500.c_str(), f5500to5700.c_str(), f5700to5800.c_str(), f5800to6000.c_str(), f6000toInf.c_str());
-      sigma = TF1("sigma", &buf[0], pTHatMin, pTHatMax);
-      sigma.SetParameters(5.66875e+13,9.93446e+00,-3.96986e+00,-2.26690e-01,1.75926e-02);
+      sigma = TF1("sigma", "([0]*pow(x,[2]+[3]*log(0.01*x)+[4]*pow(log(0.01*x),2))*pow(1-2*x/(13000.+[5]),[1]))*x", pTHatMin, pTHatMax);
+      sigma.SetParameters(5.35720e+13,1.09077e+01,-2.58981e+00,-5.15755e-01,5.59513e-02,3.5e+02);
     }
     virtual ~PtHatEmpReweightUserHook() {}
 


### PR DESCRIPTION
This PR would provide a new UserHook to Pythia in order to generate a sample with a truly "flat" pThat spectrum. These types of samples are currently used by the JetMET group for jet energy calibrations, but currently we are using a sub-optimal configuration; the new method works much better. It is not foreseen that this PR will have any effect on other packages. This should simply add a new feature to the CMSSW-Pythia8 interface.

We would like to include this feature in CMSSW in time for the upcoming 2017 MC production campaign using CMSSW_9_3_0.