### PR TITLE
Better handling of special TDC values for QIE10/QIE11

### DIFF
--- a/DataFormats/HcalRecHit/interface/HcalSpecialTimes.h
+++ b/DataFormats/HcalRecHit/interface/HcalSpecialTimes.h
@@ -1,26 +1,72 @@
 #ifndef DataFormats_HcalRecHit_HcalSpecialTimes_h_
 #define DataFormats_HcalRecHit_HcalSpecialTimes_h_
 
+// This is an excerpt from QIE10/QIE11 TDC specifications (by T. Zimmerman):
+//
+// Special codes: Special code 62 is generated when the discriminator
+// starts high. Special code 63 is generated when the TDC discriminator
+// starts low and remains low (nothing happened). Special code 58 indicates
+// "Invalid Code". This can be caused by an SEU in the TDC encoder logic.
+// It can also happen in certain situations when the TDC is operated in
+// "Last Mode", as discussed above. Code 59 is generated if the either
+// of the Delay Locked Loops on the QIE10 (the Phase DLL or the TDC DLL)
+// are not locked. Code 60 is generated when the Phase DLL is unlocked
+// (but the TDC DLL is locked), and code 61 for the TDC DLL unlocked
+// (but the Phase DLL is locked). If either of the DLLs on the chip are
+// unlocked, this takes precedence over any TDC data that might be present,
+// and the appropriate DLL no-lock condition is reported.
+
 namespace HcalSpecialTimes
 {
     // Special value for the rise time used in case the QIE10/11 pulse
     // is always below the discriminator
     constexpr float UNKNOWN_T_UNDERSHOOT = -100.f;
 
+    // "Invalid Code" TDC value
+    constexpr float UNKNOWN_T_INVALID_CODE = -105.f;
+
     // Special value for the rise time used in case the QIE10/11 pulse
     // is always above the discriminator
     constexpr float UNKNOWN_T_OVERSHOOT = -110.f;
+
+    // Any of the codes indicating DLL failures
+    constexpr float UNKNOWN_T_DLL_FAILURE = -115.f;
 
     // Special value for the time to use in case the TDC info is
     // not available or not meaningful (e.g., for QIE8)
     constexpr float UNKNOWN_T_NOTDC = -120.f;
 
+    // Special value which indicates a possible bug in the dataframe
+    constexpr float UNKNOWN_T_INVALID_RANGE = -125.f;
+
     // Check if the given time represents one of the special values
     inline bool isSpecial(const float t)
     {
-        return t == UNKNOWN_T_UNDERSHOOT ||
-               t == UNKNOWN_T_OVERSHOOT ||
-               t == UNKNOWN_T_NOTDC;
+        return t <= UNKNOWN_T_UNDERSHOOT;
+    }
+
+    inline float getTDCTime(const int tdc)
+    {
+        constexpr float tdc_to_ns = 0.5f;
+
+        constexpr int six_bits_mask = 0x3f;
+        constexpr int tdc_code_overshoot = 62;
+        constexpr int tdc_code_undershoot = 63;
+        constexpr int tdc_code_invalid = 58;
+
+        float t = tdc_to_ns*tdc;
+        if (tdc > six_bits_mask || tdc < 0)
+            t = UNKNOWN_T_INVALID_RANGE;
+        else if (tdc == tdc_code_overshoot)
+            t = UNKNOWN_T_OVERSHOOT;
+        else if (tdc == tdc_code_undershoot)
+            t = UNKNOWN_T_UNDERSHOOT;
+        else if (tdc == tdc_code_invalid)
+            t = UNKNOWN_T_INVALID_CODE;
+        else if (tdc > tdc_code_invalid)
+            t = UNKNOWN_T_DLL_FAILURE;
+
+        return t;
     }
 }
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/HFSimpleTimeCheck.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HFSimpleTimeCheck.h
@@ -56,6 +56,7 @@ public:
                       const float energyWeights[2*HFAnodeStatus::N_POSSIBLE_STATES-1][2],
                       unsigned soiPhase, float timeShift,
                       float triseIfNoTDC, float tfallIfNoTDC,
+                      float minChargeForUndershoot, float minChargeForOvershoot,
                       bool rejectAllFailures = true);
 
     inline virtual ~HFSimpleTimeCheck() {}
@@ -71,6 +72,8 @@ public:
     inline float timeShift() const {return timeShift_;}
     inline float triseIfNoTDC() const {return triseIfNoTDC_;}
     inline float tfallIfNoTDC() const {return tfallIfNoTDC_;}
+    inline float minChargeForUndershoot() const {return minChargeForUndershoot_;}
+    inline float minChargeForOvershoot() const {return minChargeForOvershoot_;}
     inline bool rejectingAllFailures() const {return rejectAllFailures_;}
 
 protected:
@@ -87,6 +90,8 @@ private:
     float timeShift_;
     float triseIfNoTDC_;
     float tfallIfNoTDC_;
+    float minChargeForUndershoot_;
+    float minChargeForOvershoot_;
     bool rejectAllFailures_;
 };
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/parseHFPhase1AlgoDescription.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/parseHFPhase1AlgoDescription.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include "RecoLocalCalo/HcalRecAlgos/interface/AbsHFPhase1Algo.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 namespace edm {
     class ParameterSet;
@@ -17,5 +18,12 @@ namespace edm {
 //
 std::unique_ptr<AbsHFPhase1Algo>
 parseHFPhase1AlgoDescription(const edm::ParameterSet& ps);
+
+//
+// Parameter descriptions for "parseHFPhase1AlgoDescription".
+// Keep implementation of this function is sync with
+// "parseHFPhase1AlgoDescription".
+//
+edm::ParameterSetDescription fillDescriptionForParseHFPhase1AlgoDescription();
 
 #endif // RecoLocalCalo_HcalRecAlgos_parseHFPhase1AlgoDescription_h

--- a/RecoLocalCalo/HcalRecAlgos/src/HFFlexibleTimeCheck.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFFlexibleTimeCheck.cc
@@ -25,12 +25,14 @@ unsigned HFFlexibleTimeCheck::determineAnodeStatus(
         return HFAnodeStatus::OK;
     }
 
-    // Special handling of under/overshoot TDC values
+    // Special handling of under/overshoot TDC values, as well
+    // as of DLL failures
     float trise = anode.timeRising();
     if ((trise == HcalSpecialTimes::UNKNOWN_T_UNDERSHOOT &&
          charge < minChargeForUndershoot()) ||
         (trise == HcalSpecialTimes::UNKNOWN_T_OVERSHOOT &&
-         charge < minChargeForOvershoot()))
+         charge < minChargeForOvershoot()) ||
+        trise == HcalSpecialTimes::UNKNOWN_T_DLL_FAILURE)
     {
         *isTimingReliable = false;
         return HFAnodeStatus::OK;

--- a/RecoLocalCalo/HcalRecAlgos/src/HFFlexibleTimeCheck.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFFlexibleTimeCheck.cc
@@ -25,8 +25,18 @@ unsigned HFFlexibleTimeCheck::determineAnodeStatus(
         return HFAnodeStatus::OK;
     }
 
-    // Check if the rise time information is meaningful
+    // Special handling of under/overshoot TDC values
     float trise = anode.timeRising();
+    if ((trise == HcalSpecialTimes::UNKNOWN_T_UNDERSHOOT &&
+         charge < minChargeForUndershoot()) ||
+        (trise == HcalSpecialTimes::UNKNOWN_T_OVERSHOOT &&
+         charge < minChargeForOvershoot()))
+    {
+        *isTimingReliable = false;
+        return HFAnodeStatus::OK;
+    }
+
+    // Check if the rise time information is meaningful
     if (HcalSpecialTimes::isSpecial(trise))
         return HFAnodeStatus::FAILED_TIMING;
 

--- a/RecoLocalCalo/HcalRecAlgos/src/HFPreRecAlgo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFPreRecAlgo.cc
@@ -14,14 +14,6 @@ HFQIE10Info HFPreRecAlgo::reconstruct(const QIE10DataFrame& digi,
                                       const HcalCoder& coder,
                                       const HcalCalibrations& calib) const
 {
-    // Conversion from TDC to ns for the QIE10 chip
-    static const float qie10_tdc_to_ns = 0.5f;
-
-    // TDC values produced in case the pulse is always above/below
-    // the discriminator
-    static const int qie10_tdc_code_overshoot = 62;
-    static const int qie10_tdc_code_undershoot = 63;
-
     // Scrap the trailing edge time for now -- until the front-end
     // FPGA firmware is finalized and the description of the FPGA
     // output becomes available
@@ -69,13 +61,7 @@ HFQIE10Info HFPreRecAlgo::reconstruct(const QIE10DataFrame& digi,
         const int capid = s.capid();
         const float charge = cs[tsToUse] - calib.pedestal(capid);
         const float energy = charge*calib.respcorrgain(capid);
-
-        const int tdc = s.le_tdc();
-        float timeRising = qie10_tdc_to_ns*tdc;
-        if (tdc == qie10_tdc_code_overshoot)
-            timeRising = HcalSpecialTimes::UNKNOWN_T_OVERSHOOT;
-        else if (tdc == qie10_tdc_code_undershoot)
-            timeRising = HcalSpecialTimes::UNKNOWN_T_UNDERSHOOT;
+        const float timeRising = HcalSpecialTimes::getTDCTime(s.le_tdc());
 
         // Figure out the window in the raw data
         // that we want to store. This window will

--- a/RecoLocalCalo/HcalRecAlgos/src/HFSimpleTimeCheck.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFSimpleTimeCheck.cc
@@ -42,11 +42,15 @@ HFSimpleTimeCheck::HFSimpleTimeCheck(const std::pair<float,float> tlimits[2],
                                      const float i_timeShift,
                                      const float i_triseIfNoTDC,
                                      const float i_tfallIfNoTDC,
+                                     const float i_minChargeForUndershoot,
+                                     const float i_minChargeForOvershoot,
                                      const bool rejectAllFailures)
     : soiPhase_(i_soiPhase),
       timeShift_(i_timeShift),
       triseIfNoTDC_(i_triseIfNoTDC),
       tfallIfNoTDC_(i_tfallIfNoTDC),
+      minChargeForUndershoot_(i_minChargeForUndershoot),
+      minChargeForOvershoot_(i_minChargeForOvershoot),
       rejectAllFailures_(rejectAllFailures)
 {
     tlimits_[0] = tlimits[0];

--- a/RecoLocalCalo/HcalRecAlgos/src/parseHFPhase1AlgoDescription.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/parseHFPhase1AlgoDescription.cc
@@ -30,6 +30,12 @@ parseHFPhase1AlgoDescription(const edm::ParameterSet& ps)
         const bool rejectAllFailures =
             ps.getParameter<bool>("rejectAllFailures");
 
+        float minChargeForUndershoot = -10000.f, minChargeForOvershoot = -10000.f;
+        if (ps.existsAs<double>("minChargeForUndershoot"))
+            minChargeForUndershoot = ps.getParameter<double>("minChargeForUndershoot");
+        if (ps.existsAs<double>("minChargeForOvershoot"))
+            minChargeForOvershoot = ps.getParameter<double>("minChargeForOvershoot");
+
         float energyWeights[2*HFAnodeStatus::N_POSSIBLE_STATES-1][2];
         const unsigned sz = sizeof(energyWeights)/sizeof(energyWeights[0][0]);
 
@@ -66,11 +72,13 @@ parseHFPhase1AlgoDescription(const edm::ParameterSet& ps)
                 algo = std::unique_ptr<AbsHFPhase1Algo>(
                     new HFSimpleTimeCheck(tlimits, energyWeights, soiPhase,
                                           timeShift, triseIfNoTDC, tfallIfNoTDC,
+                                          minChargeForUndershoot, minChargeForOvershoot,
                                           rejectAllFailures));
             else
                 algo = std::unique_ptr<AbsHFPhase1Algo>(
                     new HFFlexibleTimeCheck(tlimits, energyWeights, soiPhase,
                                             timeShift, triseIfNoTDC, tfallIfNoTDC,
+                                            minChargeForUndershoot, minChargeForOvershoot,
                                             rejectAllFailures));
         }
     }

--- a/RecoLocalCalo/HcalRecAlgos/src/parseHFPhase1AlgoDescription.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/parseHFPhase1AlgoDescription.cc
@@ -29,12 +29,10 @@ parseHFPhase1AlgoDescription(const edm::ParameterSet& ps)
             ps.getParameter<double>("tfallIfNoTDC");
         const bool rejectAllFailures =
             ps.getParameter<bool>("rejectAllFailures");
-
-        float minChargeForUndershoot = -10000.f, minChargeForOvershoot = -10000.f;
-        if (ps.existsAs<double>("minChargeForUndershoot"))
-            minChargeForUndershoot = ps.getParameter<double>("minChargeForUndershoot");
-        if (ps.existsAs<double>("minChargeForOvershoot"))
-            minChargeForOvershoot = ps.getParameter<double>("minChargeForOvershoot");
+        const float minChargeForUndershoot =
+            ps.getParameter<double>("minChargeForUndershoot");
+        const float minChargeForOvershoot =
+            ps.getParameter<double>("minChargeForOvershoot");
 
         float energyWeights[2*HFAnodeStatus::N_POSSIBLE_STATES-1][2];
         const unsigned sz = sizeof(energyWeights)/sizeof(energyWeights[0][0]);
@@ -84,4 +82,25 @@ parseHFPhase1AlgoDescription(const edm::ParameterSet& ps)
     }
 
     return algo;
+}
+
+edm::ParameterSetDescription fillDescriptionForParseHFPhase1AlgoDescription()
+{
+    edm::ParameterSetDescription desc;
+
+    std::vector<double> allPass{-10000.0, 10000.0, -10000.0, 10000.0};
+    desc.add<std::vector<double> >("tlimits", allPass);
+    desc.add<std::vector<double> >("energyWeights");
+    desc.add<unsigned>("soiPhase", 1U);
+    desc.add<double>("timeShift", 0.0);
+    desc.add<double>("triseIfNoTDC", -100.0);
+    desc.add<double>("tfallIfNoTDC", -101.0);
+    desc.add<double>("minChargeForUndershoot", -10000.f);
+    desc.add<double>("minChargeForOvershoot", -10000.f);
+
+    desc.ifValue(edm::ParameterDescription<std::string>("Class", "HFSimpleTimeCheck", true),
+                 "HFSimpleTimeCheck" >> edm::ParameterDescription<bool>("rejectAllFailures", false) or
+                 "HFFlexibleTimeCheck" >> edm::ParameterDescription<bool>("rejectAllFailures", true));
+
+    return desc;
 }

--- a/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
@@ -52,6 +52,14 @@ hfreco = cms.EDProducer("HFPhase1Reconstructor",
         triseIfNoTDC = cms.double(-100.0),
         tfallIfNoTDC = cms.double(-101.0),
 
+        # Charge limits for special TDC values. If the anode charge is
+        # below such a limit, the anode will participate in the energy
+        # reconstruction even if its TDC undershoots/overshoots. These
+        # global limits are in addition to those per channel limits in
+        # the database (effectively, the larger limit is used).
+        minChargeForUndershoot = cms.double(-10000.0),
+        minChargeForOvershoot = cms.double(-10000.0),
+
         # Do not construct rechits with problems
         rejectAllFailures = cms.bool(True)
     ),

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -149,21 +149,7 @@ namespace {
 
     float getTDCTimeFromSample(const QIE11DataFrame::Sample& s)
     {
-        // Conversion from TDC to ns for the QIE11 chip
-        static const float qie11_tdc_to_ns = 0.5f;
-
-        // TDC values produced in case the pulse is always above/below
-        // the discriminator
-        static const int qie11_tdc_code_overshoot = 62;
-        static const int qie11_tdc_code_undershoot = 63;
-
-        const int tdc = s.tdc();
-        float t = qie11_tdc_to_ns*tdc;
-        if (tdc == qie11_tdc_code_overshoot)
-            t = HcalSpecialTimes::UNKNOWN_T_OVERSHOOT;
-        else if (tdc == qie11_tdc_code_undershoot)
-            t = HcalSpecialTimes::UNKNOWN_T_UNDERSHOOT;
-        return t;
+        return HcalSpecialTimes::getTDCTime(s.tdc());
     }
 
     float getTDCTimeFromSample(const HcalQIESample&)

--- a/RecoLocalCalo/HcalRecProducers/src/HFPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HFPhase1Reconstructor.cc
@@ -297,8 +297,8 @@ HFPhase1Reconstructor::fillDescriptions(edm::ConfigurationDescriptions& descript
     desc.add<bool>("setNoiseFlags");
     desc.add<bool>("useChannelQualityFromDB");
     desc.add<bool>("checkChannelQualityForDepth3and4");
+    desc.add<edm::ParameterSetDescription>("algorithm", fillDescriptionForParseHFPhase1AlgoDescription());
 
-    add_param_set(algorithm);
     add_param_set(S9S1stat);
     add_param_set(S8S1stat);
     add_param_set(PETstat);


### PR DESCRIPTION
Added more special codes for QIE10/QIE11 TDC values (upon reading the chip specification documents).

Added the capability to allow channels with undershoot/overshoot to participate in energy reco if their charge is below dedicated thresholds (currently the same for all channels).

This PR will not modify any MC relval results. Minor modifications for the data are possible because TDC special codes 58, 59, 60, and 61 were not taken into account in earlier code (these TDC codes are also supposed to be very rare).
