### PR TITLE
Fix TP ET emulation for ieta=16

### DIFF
--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -736,8 +736,6 @@ HcalTriggerPrimitiveAlgo::validUpgradeFG(const HcalTrigTowerDetId& id, int depth
       return false;
    if (id.ietaAbs() > LAST_FINEGRAIN_TOWER)
       return false;
-   if (id.ietaAbs() == HBHE_OVERLAP_TOWER and not upgrade_hb_)
-      return false;
    return true;
 }
 


### PR DESCRIPTION
The HCAL trigger primitive emulation currently omits contributions from HEP17 in the HB/HE overlap region of ieta=16 if there is no HBP17 contribution at the same (ieta, iphi). This PR fixes the issue.

The attached plots show the compressed ET in data versus emulation for ieta=16 before and after this fix for a run in which charge is injected into individual channels of HEP17 one at a time.

This PR should have no effect on data or MC samples that do not include an upgraded HE. For MC samples with an upgraded HE, the effect should still be essentially negligible; the fix is needed primarily to resolve spurious data vs. emulation discrepancies.

[run297917_ieta16_before_fix.pdf](https://github.com/cms-sw/cmssw/files/1138725/run297917_ieta16_before_fix.pdf)
[run297917_ieta16_after_fix.pdf](https://github.com/cms-sw/cmssw/files/1138727/run297917_ieta16_after_fix.pdf)
