### PR TITLE
ECAL PF thresholds for aging

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/aging.py
+++ b/SLHCUpgradeSimulations/Configuration/python/aging.py
@@ -130,6 +130,15 @@ def ageEcal(process,lumi,instLumi):
         ['EcalTPGLinearizationConstRcd','EcalTPGLinearizationConst_TL{:d}_upgrade_8deg_mc'],
     ]
 
+    # update PF thresholds, based on https://indico.cern.ch/event/653123/contributions/2659235/attachments/1491385/2318364/170711_upsg_ledovskoy.pdf
+    ecal_thresholds = {
+        300 : 0.103,
+        1000 : 0.175,
+        3000 : 0.435,
+        4500 : 0.707,
+    }
+    ecal_seed_multiplier = 2.5
+
     # try to get conditions
     if int(lumi) in ecal_lumis:
         if not hasattr(process.GlobalTag,'toGet'):
@@ -141,6 +150,15 @@ def ageEcal(process,lumi,instLumi):
                 connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
                 )
             )
+        if hasattr(process,"particleFlowClusterECALUncorrected"):
+            _seeds = process.particleFlowClusterECALUncorrected.seedFinder.thresholdsByDetector
+            for iseed in range(0,len(_seeds)):
+                if _seeds[iseed].detector.value()=="ECAL_BARREL":
+                    _seeds[iseed].seedingThreshold = cms.double(ecal_thresholds[int(lumi)]*ecal_seed_multiplier)
+            _clusters = process.particleFlowClusterECALUncorrected.initialClusteringStep.thresholdsByDetector
+            for icluster in range(0,len(_clusters)):
+                if _clusters[icluster].detector.value()=="ECAL_BARREL":
+                    _clusters[icluster].gatheringThreshold = cms.double(ecal_thresholds[int(lumi)])
         
     return process
 


### PR DESCRIPTION
We have observed an issue with egamma objects and jets in the Phase2 Barrel TDR production for aged samples. It was determined that too many ECAL noise hits were being kept in clusters (due to increased noise with the aging conditions).

We have determined a set of thresholds for the PF seeding and clustering to mitigate these issues, based on noise levels for each aging scenario: https://indico.cern.ch/event/653123/contributions/2659235/attachments/1491385/2318364/170711_upsg_ledovskoy.pdf.

This PR will be backported to 91X.