### PR TITLE
Add tau3mu HLT producer

### DIFF
--- a/HLTrigger/Muon/BuildFile.xml
+++ b/HLTrigger/Muon/BuildFile.xml
@@ -1,3 +1,4 @@
+<use   name="DataFormats/Candidate"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/HLTReco"/>
 <use   name="DataFormats/L1GlobalMuonTrigger"/>

--- a/HLTrigger/Muon/interface/HLTTriMuonIsolation.h
+++ b/HLTrigger/Muon/interface/HLTTriMuonIsolation.h
@@ -3,7 +3,6 @@
 
 #include <iostream>
 #include <string>
-#include <boost/range/irange.hpp>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"

--- a/HLTrigger/Muon/interface/HLTTriMuonIsolation.h
+++ b/HLTrigger/Muon/interface/HLTTriMuonIsolation.h
@@ -118,13 +118,13 @@ HLTTriMuonIsolation::produce(edm::StreamID sid, edm::Event & iEvent, edm::EventS
         // Create the 3-muon candidates
         // loop over L3/Trk muons and create all combinations
         auto AllMuCands_end = AllMuCands->end();
-        for (auto i = AllMuCands->begin(); i != AllMuCands_end; ++i) {
+        for (auto i = AllMuCands->begin(); i != AllMuCands_end-2; ++i) {
             // check that muon_i passes the previous filter
             bool passingPreviousFilter_1 = false;
             for (const auto & imu : PassedL3Muons){
                 if (reco::deltaR2(i->momentum(), imu->momentum()) < (MatchingConeSize_*MatchingConeSize_)) passingPreviousFilter_1 = true;
             }
-            for (auto j = i+1; j != AllMuCands_end; ++j) {
+            for (auto j = i+1; j != AllMuCands_end-1; ++j) {
                 // check that muon_j passes the previous filter
                 bool passingPreviousFilter_2 = false;
                 for (const auto & jmu : PassedL3Muons){
@@ -217,8 +217,8 @@ HLTTriMuonIsolation::produce(edm::StreamID sid, edm::Event & iEvent, edm::EventS
             }
             
             // apply the isolation cut
-            if ((std::max(0., sumPt) > (EnableAbsIso_ * ChargedAbsIsoCut_)) || 
-                (std::max(0., sumPt) > (EnableRelIso_ * ChargedRelIsoCut_ * itau.pt()))) continue;
+            if ((sumPt > (EnableAbsIso_ * ChargedAbsIsoCut_)) || 
+                (sumPt > (EnableRelIso_ * ChargedRelIsoCut_ * itau.pt()))) continue;
             
             SelectedTaus->push_back(itau); 
         }

--- a/HLTrigger/Muon/interface/HLTTriMuonIsolation.h
+++ b/HLTrigger/Muon/interface/HLTTriMuonIsolation.h
@@ -1,0 +1,230 @@
+#ifndef HLTrigger_Muon_HLTTriMuonIsolation_h
+#define HLTrigger_Muon_HLTTriMuonIsolation_h
+
+#include <iostream>
+#include <string>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Candidate/interface/CompositeCandidate.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
+
+
+class HLTTriMuonIsolation : public edm::global::EDProducer<> {
+    public:
+        explicit HLTTriMuonIsolation(const edm::ParameterSet& iConfig);
+        ~HLTTriMuonIsolation();
+        virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+        static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+        
+    private:
+        const edm::EDGetTokenT<reco::RecoChargedCandidateCollection> L3MuonsToken_        ;
+        const edm::EDGetTokenT<reco::RecoChargedCandidateCollection> AllMuonsToken_       ;
+        const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> L3DiMuonsFilterToken_;
+        const edm::EDGetTokenT<reco::TrackCollection>                IsoTracksToken_      ;
+
+        edm::Handle<reco::RecoChargedCandidateCollection> L3MuCands           ;
+        edm::Handle<trigger::TriggerFilterObjectWithRefs> L3DiMuonsFilterCands;
+        edm::Handle<reco::RecoChargedCandidateRef>        PassedL3Muons       ;
+        edm::Handle<reco::RecoChargedCandidateCollection> AllMuCands          ;
+        edm::Handle<reco::TrackCollection>                IsoTracks           ;
+
+        static bool ptComparer(const reco::RecoChargedCandidate mu_1, const reco::RecoChargedCandidate mu_2) { return mu_1.pt() > mu_2.pt(); }
+        
+        const double Muon1PtCut_      ;
+        const double Muon2PtCut_      ;
+        const double Muon3PtCut_      ;
+        const double TriMuonPtCut_    ;
+        const double TriMuonEtaCut_   ;
+        const double ChargedRelIsoCut_;
+        const double ChargedAbsIsoCut_;
+        const double IsoConeSize_     ;
+        const double MinTriMuonMass_  ;
+        const double MaxTriMuonMass_  ;
+        const int    TriMuonAbsCharge_;
+        const double MaxDZ_           ;
+        const bool   EnableRelIso_    ;
+        const bool   EnableAbsIso_    ;
+};
+
+HLTTriMuonIsolation::HLTTriMuonIsolation(const edm::ParameterSet& iConfig):
+    L3MuonsToken_        (consumes<reco::RecoChargedCandidateCollection> (iConfig.getParameter<edm::InputTag>("L3MuonsSrc"        ))),
+    AllMuonsToken_       (consumes<reco::RecoChargedCandidateCollection> (iConfig.getParameter<edm::InputTag>("AllMuonsSrc"       ))),
+    L3DiMuonsFilterToken_(consumes<trigger::TriggerFilterObjectWithRefs> (iConfig.getParameter<edm::InputTag>("L3DiMuonsFilterSrc"))),
+    IsoTracksToken_      (consumes<reco::TrackCollection>                (iConfig.getParameter<edm::InputTag>("IsoTracksSrc"      ))),
+    Muon1PtCut_                                                          (iConfig.getParameter<double>       ("Muon1PtCut"        )) ,
+    Muon2PtCut_                                                          (iConfig.getParameter<double>       ("Muon2PtCut"        )) ,
+    Muon3PtCut_                                                          (iConfig.getParameter<double>       ("Muon3PtCut"        )) ,
+    TriMuonPtCut_                                                        (iConfig.getParameter<double>       ("TriMuonPtCut"      )) ,
+    TriMuonEtaCut_                                                       (iConfig.getParameter<double>       ("TriMuonEtaCut"     )) ,
+    ChargedRelIsoCut_                                                    (iConfig.getParameter<double>       ("ChargedRelIsoCut"  )) ,
+    ChargedAbsIsoCut_                                                    (iConfig.getParameter<double>       ("ChargedAbsIsoCut"  )) ,
+    IsoConeSize_                                                         (iConfig.getParameter<double>       ("IsoConeSize"       )) ,
+    MinTriMuonMass_                                                      (iConfig.getParameter<double>       ("MinTriMuonMass"    )) ,
+    MaxTriMuonMass_                                                      (iConfig.getParameter<double>       ("MaxTriMuonMass"    )) , 
+    TriMuonAbsCharge_                                                    (iConfig.getParameter<int>          ("TriMuonAbsCharge"  )) ,
+    MaxDZ_                                                               (iConfig.getParameter<double>       ("MaxDZ"             )) , 
+    EnableRelIso_                                                        (iConfig.getParameter<bool>         ("EnableRelIso"      )) ,
+    EnableAbsIso_                                                        (iConfig.getParameter<bool>         ("EnableAbsIso"      )) 
+{
+    //register products
+    produces<reco::CompositeCandidateCollection>("Taus");
+    produces<reco::CompositeCandidateCollection>("SelectedTaus");
+}
+
+HLTTriMuonIsolation::~HLTTriMuonIsolation(){ }
+
+void
+HLTTriMuonIsolation::produce(edm::StreamID sid, edm::Event & iEvent, edm::EventSetup const & iSetup) const
+{
+    std::unique_ptr<reco::CompositeCandidateCollection> Taus        (new reco::CompositeCandidateCollection);
+    std::unique_ptr<reco::CompositeCandidateCollection> SelectedTaus(new reco::CompositeCandidateCollection);
+
+    // Get the L3 muon candidates
+    edm::Handle<reco::RecoChargedCandidateCollection> L3MuCands;
+    iEvent.getByToken(L3MuonsToken_, L3MuCands);
+
+    // Get the L3 muon candidates that passed the filter
+    edm::Handle<trigger::TriggerFilterObjectWithRefs> L3DiMuonsFilterCands;
+    iEvent.getByToken(L3DiMuonsFilterToken_, L3DiMuonsFilterCands);
+    
+    std::vector<reco::RecoChargedCandidateRef> PassedL3Muons;
+    L3DiMuonsFilterCands->getObjects(trigger::TriggerMuon, PassedL3Muons);
+  
+    // Get the Trk + L3 muon candidates (after merging)
+    edm::Handle<reco::RecoChargedCandidateCollection> AllMuCands;
+    iEvent.getByToken(AllMuonsToken_, AllMuCands);
+    
+    // Get iso tracks
+    edm::Handle<reco::TrackCollection> IsoTracks;
+    iEvent.getByToken(IsoTracksToken_, IsoTracks);
+          
+    if (AllMuCands->size() >= 3){
+        // Create the 3-muon candidates
+        // loop over L3/Trk muons and create all combinations
+        for (unsigned int i = 0; i != AllMuCands->size(); ++i){
+            const reco::TrackRef &tk_i = (*AllMuCands)[i].track();
+            for (unsigned int j = i+1; j != AllMuCands->size(); ++j){
+                const reco::TrackRef &tk_j = (*AllMuCands)[j].track();
+                for (unsigned int k = j+1; k != AllMuCands->size(); ++k){
+                    const reco::TrackRef &tk_k = (*AllMuCands)[k].track();
+
+                    int passingPreviousFilter_1 = 0;
+                    int passingPreviousFilter_2 = 0;
+                    int passingPreviousFilter_3 = 0;
+    
+                    for (std::vector<reco::RecoChargedCandidateRef>::const_iterator imu = PassedL3Muons.begin(); imu != PassedL3Muons.end(); ++imu){
+                        reco::TrackRef candTrkRef = (*imu)->get<reco::TrackRef>();
+                        if (reco::deltaR2(tk_i->momentum(), candTrkRef->momentum()) < (0.03*0.03)) passingPreviousFilter_1++;
+                        if (reco::deltaR2(tk_j->momentum(), candTrkRef->momentum()) < (0.03*0.03)) passingPreviousFilter_2++; 
+                        if (reco::deltaR2(tk_k->momentum(), candTrkRef->momentum()) < (0.03*0.03)) passingPreviousFilter_3++;
+                    }                    
+                    // at least two muons must have passed the previous di-muon filter
+                    if (((passingPreviousFilter_1 < 1) & (passingPreviousFilter_2 < 1)) ||
+                        ((passingPreviousFilter_1 < 1) & (passingPreviousFilter_3 < 1)) ||
+                        ((passingPreviousFilter_2 < 1) & (passingPreviousFilter_3 < 1))) continue;
+
+                    // Create a composite candidate to be a tau
+                    reco::CompositeCandidate Tau;
+
+                    // sort the muons by pt and add them to the tau
+                    reco::RecoChargedCandidateCollection Daughters;
+                    
+                    Daughters.push_back((*AllMuCands)[i]);
+                    Daughters.push_back((*AllMuCands)[j]);
+                    Daughters.push_back((*AllMuCands)[k]);
+                                                            
+                    std::sort(Daughters.begin(), Daughters.end(), ptComparer);
+
+                    Tau.addDaughter((Daughters)[0], "Muon_1");
+                    Tau.addDaughter((Daughters)[1], "Muon_2");
+                    Tau.addDaughter((Daughters)[2], "Muon_3");
+
+                    // start building the tau
+                    int                      charge   = Daughters[0].charge() + Daughters[1].charge() + Daughters[2].charge();
+                    math::XYZTLorentzVectorD taup4    = Daughters[0].p4()     + Daughters[1].p4()     + Daughters[2].p4()    ;
+                    int                      tauPdgId = charge > 0? 15 : -15;
+
+                    Tau.setP4(taup4);
+                    Tau.setCharge(charge);
+                    Tau.setPdgId(tauPdgId);
+                    Tau.setVertex((Daughters)[0].vertex()); // assign the leading muon vertex as tau vertex
+                                                            
+                    Taus->push_back(Tau);
+                }
+            }
+        }
+
+        // Loop over taus and further select
+        for (reco::CompositeCandidateCollection::const_iterator itau = Taus->begin(); itau != Taus->end(); ++itau){
+            if (    itau->pt()   < TriMuonPtCut_  ) continue;
+            if (    itau->mass() < MinTriMuonMass_) continue;
+            if (    itau->mass() > MaxTriMuonMass_) continue;
+            if (abs(itau->eta()) > TriMuonEtaCut_ ) continue;
+            if (itau->daughter(0)->pt() < Muon1PtCut_) continue;
+            if (itau->daughter(1)->pt() < Muon2PtCut_) continue;
+            if (itau->daughter(2)->pt() < Muon3PtCut_) continue;
+            if ((abs(itau->charge()) != TriMuonAbsCharge_) & (TriMuonAbsCharge_ >= 0)) continue;
+            if (abs(itau->daughter(0)->vz() - itau->vz()) > MaxDZ_) continue;
+            if (abs(itau->daughter(1)->vz() - itau->vz()) > MaxDZ_) continue;
+            if (abs(itau->daughter(2)->vz() - itau->vz()) > MaxDZ_) continue;
+            
+            double sumPt = -itau->pt(); // remove the candidate pt from the iso sum
+            
+            // compute iso sum pT
+            for (reco::TrackCollection::const_iterator itrk = IsoTracks->begin(); itrk != IsoTracks->end(); ++itrk){
+                if (reco::deltaR2(itrk->momentum(), itau->p4()) > IsoConeSize_*IsoConeSize_) continue;
+                if (abs(itrk->vz() - itau->vz()) > MaxDZ_) continue;
+                sumPt += itrk->pt();
+            }
+            
+            // apply the isolation cut
+            if ((std::max(0., sumPt) > (EnableAbsIso_ * ChargedAbsIsoCut_)) || 
+                (std::max(0., sumPt) > (EnableRelIso_ * ChargedRelIsoCut_ * itau->pt()))) continue;
+            
+            SelectedTaus->push_back(*itau); 
+        }
+    }
+            
+    // finally put the vector of 3-muon candidates in the event 
+    iEvent.put(std::move(Taus)        , "Taus"        );
+    iEvent.put(std::move(SelectedTaus), "SelectedTaus");
+}
+
+void
+HLTTriMuonIsolation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
+{
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("L3MuonsSrc"        , edm::InputTag("hltIterL3FromL2MuonCandidates"  ));
+  desc.add<edm::InputTag>("AllMuonsSrc"       , edm::InputTag("hltGlbTrkMuonCands"             ));
+  desc.add<edm::InputTag>("L3DiMuonsFilterSrc", edm::InputTag("hltDiMuonForTau3MuDzFiltered0p3"));
+  desc.add<edm::InputTag>("IsoTracksSrc"      , edm::InputTag("hltIter2L3FromL2MuonMerged"     ));
+  desc.add<double>("Muon1PtCut"      , 5.   );
+  desc.add<double>("Muon2PtCut"      , 3.   );
+  desc.add<double>("Muon3PtCut"      , 0.   );
+  desc.add<double>("TriMuonPtCut"    , 8.   );
+  desc.add<double>("TriMuonEtaCut"   , 2.5  );
+  desc.add<double>("ChargedAbsIsoCut", 3.0  );
+  desc.add<double>("ChargedRelIsoCut", 0.1  );
+  desc.add<double>("IsoConeSize"     , 0.5  );
+  desc.add<double>("MinTriMuonMass"  , 0.5  );
+  desc.add<double>("MaxTriMuonMass"  , 2.8  );
+  desc.add<int>   ("TriMuonAbsCharge", -1   );
+  desc.add<double>("MaxDZ"           , 0.3  );
+  desc.add<bool>  ("EnableRelIso"    , false);
+  desc.add<bool>  ("EnableAbsIso"    , true );
+  descriptions.add("hltTriMuonIsolationProducer",desc);
+}
+
+#endif

--- a/HLTrigger/Muon/src/SealModule.cc
+++ b/HLTrigger/Muon/src/SealModule.cc
@@ -45,3 +45,6 @@ DEFINE_FWK_MODULE(HLTL1MuonSelector);
 DEFINE_FWK_MODULE(HLTL1TMuonSelector);
 DEFINE_FWK_MODULE(HLTScoutingMuonProducer);
 DEFINE_FWK_MODULE(HLTL1MuonNoL2Selector);
+
+#include "HLTrigger/Muon/interface/HLTTriMuonIsolation.h"
+DEFINE_FWK_MODULE(HLTTriMuonIsolation);


### PR DESCRIPTION
Add new HLT producer that builds a `reco::CompositeCandidate` tau out of 3 muons.
Then it applies further selection, most notably tracker based isolation around the tau candidate.