### PR TITLE
[93X] Cleanup of Alignment PV Validation code

### DIFF
--- a/Alignment/CommonAlignment/plugins/FilterOutLowPt.cc
+++ b/Alignment/CommonAlignment/plugins/FilterOutLowPt.cc
@@ -86,15 +86,15 @@ bool FilterOutLowPt::filter( edm::Event& iEvent, const edm::EventSetup& iSetup)
   
   if(runControl_){
     if (debugOn){
-      for(unsigned int i=0;i<runControlNumbers_.size();i++){
-	edm::LogInfo("FilterOutLowPt")<<"run number:" <<iEvent.id().run()<<" keeping runs:"<<runControlNumbers_[i]<<std::endl;
+      for(unsigned int runControlNumber : runControlNumbers_){
+	edm::LogInfo("FilterOutLowPt")<<"run number:" <<iEvent.id().run()<<" keeping runs:"<<runControlNumber<<std::endl;
       }
     }
 
-    for(unsigned int j=0;j<runControlNumbers_.size();j++){
-      if(iEvent.eventAuxiliary().run() == runControlNumbers_[j]){ 
+    for(unsigned int runControlNumber : runControlNumbers_){
+      if(iEvent.eventAuxiliary().run() == runControlNumber){ 
 	if (debugOn){
-	  edm::LogInfo("FilterOutLowPt")<<"run number"<< runControlNumbers_[j] << " match!"<<std::endl;
+	  edm::LogInfo("FilterOutLowPt")<<"run number"<< runControlNumber << " match!"<<std::endl;
 	}
 	passesRunControl = true;
 	break;
@@ -172,8 +172,8 @@ void FilterOutLowPt::endJob(){
                     
   edm::LogVerbatim("FilterOutLowPt")<<"###################################### \n"
 				    <<"# Filter Summary events accepted by run";
-  for (std::map<unsigned int,std::pair<int,int> >::iterator it=eventsInRun_.begin(); it!=eventsInRun_.end(); ++it)			       
-    edm::LogVerbatim("FilterOutLowPt")<<"# run:" << it->first << " => events tested: " << (it->second).first << " | events passed: " << (it->second).second;  
+  for (auto & it : eventsInRun_)			       
+    edm::LogVerbatim("FilterOutLowPt")<<"# run:" << it.first << " => events tested: " << (it.second).first << " | events passed: " << (it.second).second;  
   edm::LogVerbatim("FilterOutLowPt")<<"###################################### \n";
 }
 

--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -496,7 +496,7 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
 
     fins[i]->cd("PVValidation/EventFeatures/");
 
-    if(fins[i]->GetListOfKeys()->Contains("PVValidation/EventFeatures/etaMax")){
+    if(gDirectory->GetListOfKeys()->Contains("etaMax")){
       gDirectory->GetObject("etaMax",theEtaHistos[i]);
       theEtaMax_[i]   = theEtaHistos[i]->GetBinContent(1);
     } else {

--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <iostream>
 #include <fstream>
+#include <cassert>
 #include <Riostream.h>
 #include "TFile.h"
 #include "TPaveStats.h"
@@ -528,27 +529,14 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
 	// DCA absolute residuals
 
 	fins[i]->cd("PVValidation/Abs_Transv_Phi_Residuals/");
-	
 	gDirectory->GetObject(Form("histo_dxy_phi_plot%i",j),dxyPhiResiduals[i][j]);
 	gDirectory->GetObject(Form("histo_dx_phi_plot%i",j),dxPhiResiduals[i][j]);
 	gDirectory->GetObject(Form("histo_dy_phi_plot%i",j),dyPhiResiduals[i][j]);
-	
-	/*
-	dxyPhiResiduals[i][j] = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_Phi_Residuals/histo_dxy_phi_plot%i",j));
-	dxPhiResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_Phi_Residuals/histo_dx_phi_plot%i",j));
-	dyPhiResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_Phi_Residuals/histo_dy_phi_plot%i",j));
-	*/
-	
+		
 	fins[i]->cd("PVValidation/Abs_Transv_Eta_Residuals/");
 	gDirectory->GetObject(Form("histo_dxy_eta_plot%i",j),dxyEtaResiduals[i][j]);
 	gDirectory->GetObject(Form("histo_dx_eta_plot%i",j),dxEtaResiduals[i][j]);
 	gDirectory->GetObject(Form("histo_dy_eta_plot%i",j),dyEtaResiduals[i][j]);
-
-	/*
-	dxyEtaResiduals[i][j] = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_Eta_Residuals/histo_dxy_eta_plot%i",j));
-	dxEtaResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_Eta_Residuals/histo_dx_eta_plot%i",j));				
-	dyEtaResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_Eta_Residuals/histo_dy_eta_plot%i",j));
-	*/
 
 	dzPhiResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Long_Phi_Residuals/histo_dz_phi_plot%i",j));
 	dzEtaResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Long_Eta_Residuals/histo_dz_eta_plot%i",j));
@@ -565,14 +553,6 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
 
 	  for(Int_t k=0;k<theNBINS[i];k++){
 	  
-	    /*
-	    dxyMapResiduals[i][j][k] = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_DoubleDiffResiduals/histo_dxy_eta_plot%i_phi_plot%i",j,k));	  
-	    dzMapResiduals[i][j][k]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_DoubleDiffResiduals/histo_dz_eta_plot%i_phi_plot%i",j,k));  
-	   
-	    dxyNormMapResiduals[i][j][k] = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_DoubleDiffResiduals/histo_norm_dxy_eta_plot%i_phi_plot%i",j,k));  
-	    dzNormMapResiduals[i][j][k]  = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_DoubleDiffResiduals/histo_norm_dz_eta_plot%i_phi_plot%i",j,k));
-	    */
-
 	    // absolute residuals
 	    fins[i]->cd("PVValidation/Abs_DoubleDiffResiduals/");
 	    gDirectory->GetObject(Form("histo_dxy_eta_plot%i_phi_plot%i",j,k),dxyMapResiduals[i][j][k]);
@@ -605,12 +585,14 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
 	  for(Int_t k=0;k<theNBINS[i];k++){
 
 	    // absolute residuals
-	    dxyMapResiduals[i][j][k] = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_DoubleDiffResiduals/histo_dxy_eta_plot%i_phi_plot%i",j,k));
-	    dzMapResiduals[i][j][k]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_DoubleDiffResiduals/histo_dz_eta_plot%i_phi_plot%i",j,k));  
+	    fins[i]->cd("PVValidation/Abs_DoubleDiffResiduals");
+	    gDirectory->GetObject(Form("PVValidation/Abs_DoubleDiffResiduals/histo_dxy_eta_plot%i_phi_plot%i",j,k),dxyMapResiduals[i][j][k]);
+	    gDirectory->GetObject(Form("PVValidation/Abs_DoubleDiffResiduals/histo_dz_eta_plot%i_phi_plot%i",j,k),dzMapResiduals[i][j][k]);  
 	    
 	    // normalized residuals
-	    dxyNormMapResiduals[i][j][k] = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_DoubleDiffResiduals/histo_norm_dxy_eta_plot%i_phi_plot%i",j,k));  
-	    dzNormMapResiduals[i][j][k]  = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_DoubleDiffResiduals/histo_norm_dz_eta_plot%i_phi_plot%i",j,k));
+	    fins[i]->cd("PVValidation/Norm_DoubleDiffResiduals");
+	    gDirectory->GetObject(Form("PVValidation/Norm_DoubleDiffResiduals/histo_norm_dxy_eta_plot%i_phi_plot%i",j,k),dxyNormMapResiduals[i][j][k]);  
+	    gDirectory->GetObject(Form("PVValidation/Norm_DoubleDiffResiduals/histo_norm_dz_eta_plot%i_phi_plot%i",j,k),dzNormMapResiduals[i][j][k]);
 	  }
 	} // if do2DMaps
       } 
@@ -2000,6 +1982,9 @@ params::measurement getMAD(TH1F *histo)
 std::pair<params::measurement, params::measurement  > fitResiduals(TH1 *hist,bool singleTime)
 //*************************************************************
 {
+  
+  assert(hist!=nullptr) ;
+
   if (hist->GetEntries() < 10){ 
     // std::cout<<"hist name: "<<hist->GetName() << std::endl;
     return std::make_pair(std::make_pair(0.,0.),std::make_pair(0.,0.));

--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -605,8 +605,8 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
       dxyPtResiduals[i][l]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_pT_Residuals/histo_dxy_pT_plot%i",l));
       dzPtResiduals[i][l]   = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Long_pT_Residuals/histo_dz_pT_plot%i",l));
 
-      dxyNormPtResiduals[i][l]  = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Transv_pT_Residuals/histo_normdxy_pT_plot%i",l));
-      dzNormPtResiduals[i][l]   = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Long_pT_Residuals/histo_normdz_pT_plot%i",l));
+      dxyNormPtResiduals[i][l]  = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Transv_pT_Residuals/histo_norm_dxy_pT_plot%i",l));
+      dzNormPtResiduals[i][l]   = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Long_pT_Residuals/histo_norm_dz_pT_plot%i",l));
     
     }
 

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -153,7 +153,7 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
   bool passesRunControl = false;
 
   if(runControl_){
-    for(unsigned int j=0;j<runControlNumbers_.size();j++){
+    for(const auto & j : runControlNumbers_){
       if(iEvent.eventAuxiliary().run() == runControlNumbers_[j]){ 
 	if (debug_){
 	  edm::LogInfo("PrimaryVertexValidation")<<" run number: "<<iEvent.eventAuxiliary().run()<<" keeping run:"<<runControlNumbers_[j];
@@ -235,7 +235,9 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
   
   edm::Handle<TrackCollection>  trackCollectionHandle;
   iEvent.getByToken(theTrackCollectionToken, trackCollectionHandle);
-  
+  if(!trackCollectionHandle.isValid()) return;
+  auto const & tracks = *trackCollectionHandle;
+
   //=======================================================
   // Retrieve offline vartex information (only for reco)
   //=======================================================
@@ -427,10 +429,8 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
   //======================================================
  
   std::vector<TransientTrack> t_tks;
-  unsigned int k = 0;   
-  for(TrackCollection::const_iterator track = trackCollectionHandle->begin(); track!= trackCollectionHandle->end(); ++track, ++k){
-  
-    TransientTrack tt = theB_->build(&(*track));  
+  for (const auto & track : tracks){
+    TransientTrack tt = theB_->build(&(track));  
     tt.setBeamSpot(beamSpot);
     t_tks.push_back(tt);
   
@@ -462,20 +462,21 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
   //======================================================
   // Starts loop on clusters 
   //======================================================
-
-  for (vector< vector<TransientTrack> >::const_iterator iclus = clusters.begin(); iclus != clusters.end(); iclus++) {
+  for (const auto & iclus : clusters){
 
     nTracksPerClus_=0;
 
-    unsigned int i = 0;   
-    for(vector<TransientTrack>::const_iterator theTTrack = iclus->begin(); theTTrack!= iclus->end(); ++theTTrack, ++i)
+    unsigned int i=0;
+    for(const auto & theTTrack : iclus)
       {
+	i++;
+
 	if ( nTracks_ >= nMaxtracks_ ) {
 	  edm::LogError("PrimaryVertexValidation")<<" Warning - Number of tracks: " << nTracks_ << " , greater than " << nMaxtracks_;
 	  continue;
 	}
 	
-	const Track & theTrack = theTTrack->track();
+	const Track & theTrack = theTTrack.track();
 
 	pt_[nTracks_]       = theTrack.pt();
 	p_[nTracks_]        = theTrack.p();
@@ -516,7 +517,7 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 	int nhitinBPIX = hits.numberOfValidPixelBarrelHits();
 	int nhitinFPIX = hits.numberOfValidPixelEndcapHits();
 	
-	for (trackingRecHit_iterator iHit = theTTrack->recHitsBegin(); iHit != theTTrack->recHitsEnd(); ++iHit) {
+	for (trackingRecHit_iterator iHit = theTTrack.recHitsBegin(); iHit != theTTrack.recHitsEnd(); ++iHit) {
 	  if((*iHit)->isValid()) {	
 	    
 	    if (this->isHit2D(**iHit)) {++nRecHit2D;}
@@ -538,7 +539,7 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 	//=======================================================  
 
 	bool pass = true;
-	if(askFirstLayerHit_) pass = this->hasFirstLayerPixelHits((*theTTrack));
+	if(askFirstLayerHit_) pass = this->hasFirstLayerPixelHits(theTTrack);
 	if (pass && (theTrack.pt() >=ptOfProbe_) && fabs(theTrack.eta()) <= etaOfProbe_){
 	  isGoodTrack_[nTracks_]=1;
 	}
@@ -549,14 +550,14 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 	
 	vector<TransientTrack> theFinalTracks;
 	theFinalTracks.clear();
-
-	for(vector<TransientTrack>::const_iterator tk = iclus->begin(); tk!= iclus->end(); ++tk){
 	  
-	  pass = this->hasFirstLayerPixelHits((*tk));
+	for (const auto & tk : iclus) {
+
+	  pass = this->hasFirstLayerPixelHits(tk);
 	  if (pass){
 	    if( tk == theTTrack ) continue;
 	    else {
-	      theFinalTracks.push_back((*tk));
+	      theFinalTracks.push_back(tk);
 	    }
 	  }
 	}
@@ -591,7 +592,7 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 	      const math::XYZPoint myVertex(theFittedVertex.position().x(),theFittedVertex.position().y(),theFittedVertex.position().z());
 
 	      const Vertex vertex = theFittedVertex;
-	      fillTrackHistos(hDA,"all",&(*theTTrack),vertex,beamSpot,fBfield_);
+	      fillTrackHistos(hDA,"all",&theTTrack,vertex,beamSpot,fBfield_);
 
 	      hasRecVertex_[nTracks_]    = 1;
 	      xUnbiasedVertex_[nTracks_] = theFittedVertex.position().x();
@@ -616,7 +617,7 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 
 	      GlobalPoint vert(theFittedVertex.position().x(),theFittedVertex.position().y(),theFittedVertex.position().z());
 
-	      //FreeTrajectoryState theTrackNearVertex = (*theTTrack).trajectoryStateClosestToPoint(vert).theState();
+	      //FreeTrajectoryState theTrackNearVertex = theTTrack.trajectoryStateClosestToPoint(vert).theState();
 	      //double dz_err = sqrt(theFittedVertex.positionError().czz() + theTrackNearVertex.cartesianError().position().czz());      
 	      //double dz_err = hypot(theTrack.dzError(),theFittedVertex.positionError().czz());
 	      
@@ -624,7 +625,7 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 
 
 	      // PV2D 
-	      std::pair<bool,Measurement1D> s_ip2dpv = signedTransverseImpactParameter(*theTTrack,
+	      std::pair<bool,Measurement1D> s_ip2dpv = signedTransverseImpactParameter(theTTrack,
 										       GlobalVector(theTrack.px(),
 												    theTrack.py(),
 												    theTrack.pz()),
@@ -634,7 +635,7 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 	      double s_ip2dpv_err  = s_ip2dpv.second.error();
 	      
 	      // PV3D
-	      std::pair<bool, Measurement1D> s_ip3dpv = signedImpactParameter3D(*theTTrack,		    
+	      std::pair<bool, Measurement1D> s_ip3dpv = signedImpactParameter3D(theTTrack,		    
 										GlobalVector(theTrack.px(),  
 											     theTrack.py(),  
 											     theTrack.pz()), 
@@ -644,12 +645,12 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 	      double s_ip3dpv_err  = s_ip3dpv.second.error();
 
 	      // PV3D absolute
-	      std::pair<bool,Measurement1D> ip3dpv = absoluteImpactParameter3D(*theTTrack,theFittedVertex);
+	      std::pair<bool,Measurement1D> ip3dpv = absoluteImpactParameter3D(theTTrack,theFittedVertex);
 	      double ip3d_corr = ip3dpv.second.value(); 
 	      double ip3d_err  = ip3dpv.second.error(); 
 	      
 	      // with respect to any specified vertex, such as primary vertex
-	      TrajectoryStateClosestToPoint traj = (*theTTrack).trajectoryStateClosestToPoint(vert);
+	      TrajectoryStateClosestToPoint traj = (theTTrack).trajectoryStateClosestToPoint(vert);
 
 	      GlobalPoint refPoint = traj.position();
 	      GlobalPoint cPToVtx  = traj.theState().position();
@@ -737,7 +738,7 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 	      // checks on the probe track quality
 	      if(trackpt >= ptOfProbe_ && fabs(tracketa)<= etaOfProbe_){
 
-		std::pair<bool,bool> pixelOcc = pixelHitsCheck((*theTTrack));
+		std::pair<bool,bool> pixelOcc = pixelHitsCheck((theTTrack));
 
 		/*
 		  if(pixelOcc.first == true)
@@ -751,7 +752,7 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 	
 		//std::cout<<"track passed"<<std::endl;
 	
-		fillTrackHistos(hDA,"sel",&(*theTTrack),vertex,beamSpot,fBfield_);
+		fillTrackHistos(hDA,"sel",&(theTTrack),vertex,beamSpot,fBfield_);
 
 		// probe checks
 		h_probePt_->Fill(theTrack.pt());
@@ -780,9 +781,9 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 		float dxysigmaRecoV = TMath::Sqrt(theTrack.d0Error()*theTrack.d0Error()+xErrOfflineVertex_*yErrOfflineVertex_);
 		float dzsigmaRecoV  = TMath::Sqrt(theTrack.dzError()*theTrack.dzError()+zErrOfflineVertex_*zErrOfflineVertex_);
 
-		double zTrack=(theTTrack->stateAtBeamLine().trackStateAtPCA()).position().z();
+		double zTrack=(theTTrack.stateAtBeamLine().trackStateAtPCA()).position().z();
 		double zVertex=theFittedVertex.position().z();
-		double tantheta=tan((theTTrack->stateAtBeamLine().trackStateAtPCA()).momentum().theta());
+		double tantheta=tan((theTTrack.stateAtBeamLine().trackStateAtPCA()).momentum().theta());
 
 		double dz2= pow(theTrack.dzError(),2)+wxy2_/pow(tantheta,2);
 		double restrkz   = zTrack-zVertex;
@@ -1096,7 +1097,7 @@ void PrimaryVertexValidation::beginJob()
 
   h_runFromConfig     = EventFeatures.make<TH1I>("h_runFromConfig","run number from config;;run number (from configuration)",
 						 runControlNumbers_.size(),0.,runControlNumbers_.size());
-  for(unsigned int r=0;r<runControlNumbers_.size();r++){
+  for(const auto & r : runControlNumbers_){
     h_runFromConfig->SetBinContent(r+1,runControlNumbers_[r]);
   }
   
@@ -1493,8 +1494,8 @@ void PrimaryVertexValidation::beginJob()
   TFileDirectory Mean2DMapsDir   = fs->mkdir("MeanMaps");
   TFileDirectory Width2DMapsDir  = fs->mkdir("WidthMaps");
 
-  Double_t highedge=nBins_-0.5;
-  Double_t lowedge=-0.5;
+  double highedge=nBins_-0.5;
+  double lowedge=-0.5;
 
   // means and widths from the fit
 
@@ -2228,10 +2229,10 @@ void PrimaryVertexValidation::SetVarToZero()
 }
 
 //*************************************************************
-std::pair<Double_t,Double_t> PrimaryVertexValidation::getMedian(TH1F *histo)
+std::pair<double,double> PrimaryVertexValidation::getMedian(TH1F *histo)
 //*************************************************************
 {
-  Double_t median = 999;
+  double median = 999;
   int nbins = histo->GetNbinsX();
 
   //extract median from histogram
@@ -2246,7 +2247,7 @@ std::pair<Double_t,Double_t> PrimaryVertexValidation::getMedian(TH1F *histo)
   delete[] x; x = 0;
   delete[] y; y = 0;  
 
-  std::pair<Double_t,Double_t> result;
+  std::pair<double,double> result;
   result = std::make_pair(median,median/TMath::Sqrt(histo->GetEntries()));
 
   return result;
@@ -2254,18 +2255,18 @@ std::pair<Double_t,Double_t> PrimaryVertexValidation::getMedian(TH1F *histo)
 }
 
 //*************************************************************
-std::pair<Double_t,Double_t> PrimaryVertexValidation::getMAD(TH1F *histo)
+std::pair<double,double> PrimaryVertexValidation::getMAD(TH1F *histo)
 //*************************************************************
 {
 
   int nbins = histo->GetNbinsX();
-  Double_t median = getMedian(histo).first;
-  Double_t x_lastBin = histo->GetBinLowEdge(nbins+1);
+  double median = getMedian(histo).first;
+  double x_lastBin = histo->GetBinLowEdge(nbins+1);
   const char *HistoName =histo->GetName();
   TString Finalname = Form("resMed%s",HistoName);
   TH1F *newHisto = new TH1F(Finalname,Finalname,nbins,0.,x_lastBin);
-  Double_t *residuals = new Double_t[nbins];
-  Double_t *weights = new Double_t[nbins];
+  double *residuals = new double[nbins];
+  double *weights = new double[nbins];
 
   for (int j = 0; j < nbins; j++) {
     residuals[j] = TMath::Abs(median - histo->GetBinCenter(j+1));
@@ -2273,13 +2274,13 @@ std::pair<Double_t,Double_t> PrimaryVertexValidation::getMAD(TH1F *histo)
     newHisto->Fill(residuals[j],weights[j]);
   }
   
-  Double_t theMAD = (getMedian(newHisto).first)*1.4826;
+  double theMAD = (getMedian(newHisto).first)*1.4826;
   
   delete[] residuals; residuals=0;
   delete[] weights; weights=0;
   newHisto->Delete("");
   
-  std::pair<Double_t,Double_t> result;
+  std::pair<double,double> result;
   result = std::make_pair(theMAD,theMAD/histo->GetEntries());
 
   return result;
@@ -2287,7 +2288,7 @@ std::pair<Double_t,Double_t> PrimaryVertexValidation::getMAD(TH1F *histo)
 }
 
 //*************************************************************
-std::pair<std::pair<Double_t,Double_t>, std::pair<Double_t,Double_t>  > PrimaryVertexValidation::fitResiduals(TH1 *hist)
+std::pair<std::pair<double,double>, std::pair<double,double>  > PrimaryVertexValidation::fitResiduals(TH1 *hist)
 //*************************************************************
 {
   //float fitResult(9999);
@@ -2317,13 +2318,13 @@ std::pair<std::pair<Double_t,Double_t>, std::pair<Double_t,Double_t>  > PrimaryV
   float res_mean_err  = func.GetParError(1);
   float res_width_err = func.GetParError(2);
 
-  std::pair<Double_t,Double_t> resultM;
-  std::pair<Double_t,Double_t> resultW;
+  std::pair<double,double> resultM;
+  std::pair<double,double> resultW;
 
   resultM = std::make_pair(res_mean,res_mean_err);
   resultW = std::make_pair(res_width,res_width_err);
 
-  std::pair<std::pair<Double_t,Double_t>, std::pair<Double_t,Double_t>  > result;
+  std::pair<std::pair<double,double>, std::pair<double,double>  > result;
   
   result = std::make_pair(resultM,resultW);
   return result;
@@ -2402,7 +2403,7 @@ void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,std::vector<T
   for(auto iterator = h.begin(); iterator != h.end(); iterator++) {
     
     unsigned int bin = std::distance(h.begin(),iterator)+1;
-    std::pair<std::pair<Double_t,Double_t>, std::pair<Double_t,Double_t>  > myFit = fitResiduals((*iterator));
+    std::pair<std::pair<double,double>, std::pair<double,double>  > myFit = fitResiduals((*iterator));
 
     switch(fitPar_)
       {
@@ -2606,8 +2607,8 @@ std::vector<TH1F*> PrimaryVertexValidation::bookResidualsHistogram(TFileDirector
 								   TString varType){
   TH1F::SetDefaultSumw2(kTRUE);
   
-  Double_t up   = 1000;
-  Double_t down = -up;
+  double up   = 1000;
+  double down = -up;
   
   if(resType.Contains("norm")){
     up = up*(1/100);

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -552,7 +552,11 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 
 	bool pass = true;
 	if(askFirstLayerHit_) pass = this->hasFirstLayerPixelHits(theTTrack);
-	if (pass && (theTrack.pt() >=ptOfProbe_) && fabs(theTrack.eta()) <= etaOfProbe_){
+	if (pass 
+	    && (theTrack.pt() >=ptOfProbe_) 
+	    && fabs(theTrack.eta()) <= etaOfProbe_ 
+	    && (theTrack.numberOfValidHits())>=nHitsOfProbe_
+	    && (theTrack.p()) >= pOfProbe_ ){
 	  isGoodTrack_[nTracks_]=1;
 	}
       
@@ -580,7 +584,7 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 	    edm::LogInfo("PrimaryVertexValidation")<<"Transient Track Collection size: "<<theFinalTracks.size();
 	  try{
 	      
-	    VertexFitter<5>* theFitter = new AdaptiveVertexFitter;
+	    auto theFitter = std::unique_ptr<VertexFitter<5> >( new AdaptiveVertexFitter());
 	    TransientVertex theFittedVertex = theFitter->vertex(theFinalTracks);
 
 	    //AdaptiveVertexFitter* theFitter = new AdaptiveVertexFitter;
@@ -956,7 +960,7 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 	      }// ends if debug_
 	    } // ends if the fitted vertex is Valid
 
-	    delete theFitter;
+	    //delete theFitter;
 
 	  }  catch ( cms::Exception& er ) {
 	    LogTrace("PrimaryVertexValidation")<<"caught std::exception "<<er.what()<<std::endl;

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -271,7 +271,7 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
   // skip events with no PV, this should not happen
   if( vsorted.size() == 0) return;
   // skip events failing vertex cut
-  if( fabs(vsorted[0].z()) > vertexZMax_ ) return; 
+  if( std::abs(vsorted[0].z()) > vertexZMax_ ) return; 
   
   if ( vsorted[0].isValid() ) {
     xOfflineVertex_ = (vsorted)[0].x();
@@ -554,7 +554,7 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 	if(askFirstLayerHit_) pass = this->hasFirstLayerPixelHits(theTTrack);
 	if (pass 
 	    && (theTrack.pt() >=ptOfProbe_) 
-	    && fabs(theTrack.eta()) <= etaOfProbe_ 
+	    && std::abs(theTrack.eta()) <= etaOfProbe_ 
 	    && (theTrack.numberOfValidHits())>=nHitsOfProbe_
 	    && (theTrack.p()) >= pOfProbe_ ){
 	  isGoodTrack_[nTracks_]=1;
@@ -757,7 +757,7 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 		if(debug_)
 		  edm::LogInfo("PrimaryVertexValidation")<<"ipTBin:"<<ipTBin<< " "<<mypT_bins_[ipTBin]<< " < pT < "<<mypT_bins_[ipTBin+1]<<std::endl;
 		
-		if( fabs(tracketa)<1.5 && (trackpt >= pTF && trackpt < pTL) ){
+		if( std::abs(tracketa)<1.5 && (trackpt >= pTF && trackpt < pTL) ){
 		  
 		  if(debug_)
 		    edm::LogInfo("PrimaryVertexValidation")<<"passes this cut: "<<mypT_bins_[ipTBin]<<std::endl;
@@ -766,7 +766,7 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 		  fillByIndex(h_norm_dxy_pT_,ipTBin,dxyFromMyVertex/s_ip2dpv_err);
 		  fillByIndex(h_norm_dz_pT_,ipTBin,dzFromMyVertex/dz_err);
 		  
-		  if(fabs(tracketa)<1.){
+		  if(std::abs(tracketa)<1.){
 		    
 		    if(debug_)
 		      edm::LogInfo("PrimaryVertexValidation")<<"passes tight eta cut: "<<mypT_bins_[ipTBin]<<std::endl;
@@ -780,7 +780,7 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 	      
 	      // checks on the probe track quality
 	      if(trackpt >= ptOfProbe_ 
-		 && fabs(tracketa)<= etaOfProbe_ 
+		 && std::abs(tracketa)<= etaOfProbe_ 
 		 && tracknhits>=nHitsOfProbe_
 		 && trackp >= pOfProbe_){
 
@@ -2463,7 +2463,7 @@ std::pair<double,double> PrimaryVertexValidation::getMAD(TH1F *histo)
   double *weights = new double[nbins];
 
   for (int j = 0; j < nbins; j++) {
-    residuals[j] = TMath::Abs(median - histo->GetBinCenter(j+1));
+    residuals[j] = std::abs(median - histo->GetBinCenter(j+1));
     weights[j]=histo->GetBinContent(j+1);
     newHisto->Fill(residuals[j],weights[j]);
   }
@@ -2732,8 +2732,8 @@ bool PrimaryVertexValidation::passesTrackCuts(const reco::Track & track, const r
    dzsigma = sqrt(track.dzError()*track.dzError()+vzErr*vzErr);
  
    if(track.quality(reco::TrackBase::qualityByName(qualityString_)) != 1)return false;
-   if(fabs(dxy/dxysigma) > dxyErrMax_) return false;
-   if(fabs(dz/dzsigma) > dzErrMax_) return false;
+   if(std::abs(dxy/dxysigma) > dxyErrMax_) return false;
+   if(std::abs(dz/dzsigma) > dzErrMax_) return false;
    if(track.ptError() / track.pt() > ptErrMax_) return false;
 
    return true;
@@ -2849,7 +2849,7 @@ void PrimaryVertexValidation::fillTrackHistos(std::map<std::string, TH1*> & h, c
   if (d0Error>0){
     fill(h,"logtresxy_"+ttype,log(d0Error/0.0001)/log(10.));
     fill(h,"tpullxy_"+ttype,d0/d0Error);
-    fill(h,"tlogDCAxy_"+ttype,log(fabs(d0/d0Error)));
+    fill(h,"tlogDCAxy_"+ttype,log(std::abs(d0/d0Error)));
     
   }
   //double z0=tt->track().vz();
@@ -2857,7 +2857,7 @@ void PrimaryVertexValidation::fillTrackHistos(std::map<std::string, TH1*> & h, c
   if(dzError>0){
     fill(h,"logtresz_"+ttype,log(dzError/0.0001)/log(10.));
     fill(h,"tpullz_"+ttype,dz/dzError);
-    fill(h,"tlogDCAz_"+ttype,log(fabs(dz/dzError)));
+    fill(h,"tlogDCAz_"+ttype,log(std::abs(dz/dzError)));
   }
   
   //
@@ -2891,7 +2891,7 @@ void PrimaryVertexValidation::fillTrackHistos(std::map<std::string, TH1*> & h, c
     double q=sqrt(1.-2.*kappa*D0);
     double s0=(x1*cos(tt->track().phi())+y1*sin(tt->track().phi()))/q;
     // double s1;
-    if (fabs(kappa*s0)>0.001){
+    if (std::abs(kappa*s0)>0.001){
       //s1=asin(kappa*s0)/kappa;
     }else{
       //double ks02=(kappa*s0)*(kappa*s0);

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -866,27 +866,6 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 		n_dxyVsEta->Fill(tracketa,dxyFromMyVertex/s_ip2dpv_err); 
 		n_dzVsEta->Fill(tracketa,z0/z0_error); 
 
-		if( ladder_num > 0 && module_num > 0 ) {
-		  
-		  fillByIndex(h_dxy_modZ_,module_num-1,dxyFromMyVertex*cmToum);
-		  fillByIndex(h_dz_modZ_,module_num-1,dzFromMyVertex*cmToum);	  
-		  fillByIndex(h_norm_dxy_modZ_,module_num-1,dxyFromMyVertex/s_ip2dpv_err);	  
-		  fillByIndex(h_norm_dz_modZ_,module_num-1,dzFromMyVertex/dz_err);	  
-		  
-		  fillByIndex(h_dxy_ladder_,ladder_num-1,dxyFromMyVertex*cmToum);	  
-
-		  if(L1BPixHitCount==1){
-		    fillByIndex(h_dxy_ladderNoOverlap_,ladder_num-1,dxyFromMyVertex*cmToum);	  
-		  } else {
-		    fillByIndex(h_dxy_ladderOverlap_,ladder_num-1,dxyFromMyVertex*cmToum);	  
-		  }
-
-		  fillByIndex(h_dz_ladder_,ladder_num-1,dzFromMyVertex*cmToum);	  
-		  fillByIndex(h_norm_dxy_ladder_,ladder_num-1,dxyFromMyVertex/s_ip2dpv_err);  
-		  fillByIndex(h_norm_dz_ladder_,ladder_num-1,dzFromMyVertex/dz_err);   
-		  
-		}
-
 		// filling the binned distributions
 		for(int i=0; i<nBins_; i++){
 		  
@@ -1336,41 +1315,6 @@ void PrimaryVertexValidation::beginJob()
   TFileDirectory NormLongpTCentralRes  = fs->mkdir("Norm_Long_pTCentral_Residuals"); 
   h_norm_dz_Central_pT_  = bookResidualsHistogram(NormLongpTCentralRes,nPtBins_,"norm_dz","pTCentral");   
 
-  // book residuals vs module number
-  
-  TFileDirectory AbsTransModZRes  = fs->mkdir("Abs_Transv_modZ_Residuals"); 
-  h_dxy_modZ_      = bookResidualsHistogram(AbsTransModZRes,8,"dxy","modZ");	       
-
-  TFileDirectory AbsLongModZRes   = fs->mkdir("Abs_Long_modZ_Residuals"); 
-  h_dz_modZ_       = bookResidualsHistogram(AbsLongModZRes,8,"dz","modZ");		       
-
-  TFileDirectory NormTransModZRes = fs->mkdir("Norm_Transv_modZ_Residuals"); 
-  h_norm_dxy_modZ_ = bookResidualsHistogram(NormTransModZRes,8,"norm_dxy","modZ");	       
-
-  TFileDirectory NormLongModZRes  = fs->mkdir("Norm_Long_modZ_Residuals"); 
-  h_norm_dz_modZ_  = bookResidualsHistogram(NormLongModZRes,8,"norm_dz","modZ");	       
-
-  // book residuals vs ladder
-               
-  TFileDirectory AbsTransLadderRes  = fs->mkdir("Abs_Transv_ladder_Residuals"); 
-  h_dxy_ladder_ = bookResidualsHistogram(AbsTransLadderRes,12,"dxy","ladder");
-
-  TFileDirectory AbsTransLadderResOverlap  = fs->mkdir("Abs_Transv_ladderOverlap_Residuals"); 
-  h_dxy_ladderOverlap_ = bookResidualsHistogram(AbsTransLadderResOverlap,12,"dxy","ladder");       
-
-  TFileDirectory AbsTransLadderResNoOverlap  = fs->mkdir("Abs_Transv_ladderNoOverlap_Residuals"); 
-  h_dxy_ladderNoOverlap_ = bookResidualsHistogram(AbsTransLadderResNoOverlap,12,"dxy","ladder");       
-
-  TFileDirectory AbsLongLadderRes   = fs->mkdir("Abs_Long_ladder_Residuals"); 
-  h_dz_ladder_  = bookResidualsHistogram(AbsLongLadderRes,12,"dz","ladder");	       
-
-  TFileDirectory NormTransLadderRes = fs->mkdir("Norm_Transv_ladder_Residuals"); 
-  h_norm_dxy_ladder_ = bookResidualsHistogram(NormTransLadderRes,12,"norm_dxy","ladder");  
-
-  TFileDirectory NormLongLadderRes  = fs->mkdir("Norm_Long_ladder_Residuals"); 
-  h_norm_dz_ladder_  = bookResidualsHistogram(NormLongLadderRes,12,"norm_dz","ladder");   
-
-
   // book residuals as function of phi and eta
 
   for ( int i=0; i<nBins_; ++i ) {
@@ -1733,72 +1677,6 @@ void PrimaryVertexValidation::beginJob()
   n_dzpTCentralWidthTrend  = WidthTrendsDir.make<TH1F>("norm_widths_dz_pTCentral",
 						       "width(d_{z}/#sigma_{d_{z}}) vs p_{T};p_{T}(|#eta|<1.) [GeV];width(d_{z}/#sigma_{d_{z}})",
 						       48,mypT_bins_); 
-
-  // means and widhts vs ladder and module number
-  
-  a_dxymodZMeanTrend  = MeanTrendsDir.make<TH1F> ("means_dxy_modZ",
-						  "#LT d_{xy} #GT vs modZ;module number (Z);#LT d_{xy} #GT [#mum]",
-						  8,0.,8.); 
-  
-  a_dxymodZWidthTrend = WidthTrendsDir.make<TH1F>("widths_dxy_modZ",
-						  "#sigma_{d_{xy}} vs modZ;module number (Z);#sigma_{d_{xy}} [#mum]",
-						  8,0.,8.);
-  
-  a_dzmodZMeanTrend   = MeanTrendsDir.make<TH1F> ("means_dz_modZ",
-						  "#LT d_{z} #GT vs modZ;module number (Z);#LT d_{z} #GT [#mum]",
-						  8,0.,8.); 
-  
-  a_dzmodZWidthTrend  = WidthTrendsDir.make<TH1F>("widths_dz_modZ",
-						  "#sigma_{d_{z}} vs modZ;module number (Z);#sigma_{d_{z}} [#mum]",
-						  8,0.,8.);
- 
-  a_dxyladderMeanTrend  = MeanTrendsDir.make<TH1F> ("means_dxy_ladder",
-						    "#LT d_{xy} #GT vs ladder;ladder number (#phi);#LT d_{xy} #GT [#mum]",
-						    12,0.,12.);
-  
-  a_dxyladderWidthTrend = WidthTrendsDir.make<TH1F>("widths_dxy_ladder",
-						    "#sigma_{d_{xy}} vs ladder;ladder number (#phi);#sigma_{d_{xy}} [#mum]",
-						    12,0.,12.);
-  
-  a_dzladderMeanTrend   = MeanTrendsDir.make<TH1F> ("means_dz_ladder",
-						    "#LT d_{z} #GT vs ladder;ladder number (#phi);#LT d_{z} #GT [#mum]"
-						    ,12,0.,12.); 
-  
-  a_dzladderWidthTrend  = WidthTrendsDir.make<TH1F>("widths_dz_ladder",
-						    "#sigma_{d_{z}} vs ladder;ladder number (#phi);#sigma_{d_{z}} [#mum]",
-						    12,0.,12.);
-  
-  n_dxymodZMeanTrend  = MeanTrendsDir.make<TH1F> ("norm_means_dxy_modZ",
-						  "#LT d_{xy}/#sigma_{d_{xy}} #GT vs modZ;module number (Z);#LT d_{xy}/#sigma_{d_{xy}} #GT",
-						  8,0.,8.);
-  
-  n_dxymodZWidthTrend = WidthTrendsDir.make<TH1F>("norm_widths_dxy_modZ",
-						  "width(d_{xy}/#sigma_{d_{xy}}) vs modZ;module number (Z); width(d_{xy}/#sigma_{d_{xy}})",
-						  8,0.,8.);
-  
-  n_dzmodZMeanTrend   = MeanTrendsDir.make<TH1F> ("norm_means_dz_modZ",
-						  "#LT d_{z}/#sigma_{d_{z}} #GT vs modZ;module number (Z);#LT d_{z}/#sigma_{d_{z}} #GT",
-						  8,0.,8.); 
-  
-  n_dzmodZWidthTrend  = WidthTrendsDir.make<TH1F>("norm_widths_dz_modZ",
-						  "width(d_{z}/#sigma_{d_{z}}) vs pT;module number (Z);width(d_{z}/#sigma_{d_{z}})",
-						  8,0.,8.);
-  
-  n_dxyladderMeanTrend  = MeanTrendsDir.make<TH1F> ("norm_means_dxy_ladder",
-						    "#LT d_{xy}/#sigma_{d_{xy}} #GT vs ladder;ladder number (#phi);#LT d_{xy}/#sigma_{d_{z}} #GT",
-						    12,0.,12.);
-  
-  n_dxyladderWidthTrend = WidthTrendsDir.make<TH1F>("norm_widths_dxy_ladder",
-						    "width(d_{xy}/#sigma_{d_{xy}}) vs ladder;ladder number (#phi);width(d_{xy}/#sigma_{d_{z}})",
-						    12,0.,12.);
-  
-  n_dzladderMeanTrend   = MeanTrendsDir.make<TH1F> ("norm_means_dz_ladder",
-						    "#LT d_{z}/#sigma_{d_{z}} #GT vs ladder;ladder number (#phi);#LT d_{z}/#sigma_{d_{z}} #GT",
-						    12,0.,12.);  
-  
-  n_dzladderWidthTrend  = WidthTrendsDir.make<TH1F>("norm_widths_dz_ladder",
-						    "width(d_{z}/#sigma_{d_{z}}) vs ladder;ladder number (#phi);width(d_{z}/#sigma_{d_{z}})",
-						    12,0.,12.); 
 
   // 2D maps
 
@@ -2274,28 +2152,6 @@ void PrimaryVertexValidation::endJob()
   fillTrendPlotByIndex(n_dxypTCentralWidthTrend,h_norm_dxy_Central_pT_,statmode::WIDTH);
   fillTrendPlotByIndex(n_dzpTCentralMeanTrend  ,h_norm_dz_Central_pT_ ,statmode::MEAN ); 
   fillTrendPlotByIndex(n_dzpTCentralWidthTrend ,h_norm_dz_Central_pT_ ,statmode::WIDTH);
-
-  // vs ladder and module number
-
-  fillTrendPlotByIndex(a_dxymodZMeanTrend   ,h_dxy_modZ_,statmode::MEAN);  
-  fillTrendPlotByIndex(a_dxymodZWidthTrend  ,h_dxy_modZ_,statmode::WIDTH);
-  fillTrendPlotByIndex(a_dzmodZMeanTrend    ,h_dz_modZ_,statmode::MEAN);   
-  fillTrendPlotByIndex(a_dzmodZWidthTrend   ,h_dz_modZ_,statmode::WIDTH);  
-  		       		      
-  fillTrendPlotByIndex(a_dxyladderMeanTrend ,h_dxy_ladder_,statmode::MEAN); 
-  fillTrendPlotByIndex(a_dxyladderWidthTrend,h_dxy_ladder_,statmode::WIDTH);
-  fillTrendPlotByIndex(a_dzladderMeanTrend  ,h_dz_ladder_,statmode::MEAN); 
-  fillTrendPlotByIndex(a_dzladderWidthTrend ,h_dz_ladder_,statmode::WIDTH);
-  		       		      
-  fillTrendPlotByIndex(n_dxymodZMeanTrend   ,h_norm_dxy_modZ_,statmode::MEAN); 
-  fillTrendPlotByIndex(n_dxymodZWidthTrend  ,h_norm_dxy_modZ_,statmode::WIDTH);
-  fillTrendPlotByIndex(n_dzmodZMeanTrend    ,h_norm_dz_modZ_,statmode::MEAN); 
-  fillTrendPlotByIndex(n_dzmodZWidthTrend   ,h_norm_dz_modZ_,statmode::WIDTH);
-  		       		      
-  fillTrendPlotByIndex(n_dxyladderMeanTrend ,h_norm_dxy_ladder_,statmode::MEAN); 
-  fillTrendPlotByIndex(n_dxyladderWidthTrend,h_norm_dxy_ladder_,statmode::WIDTH);
-  fillTrendPlotByIndex(n_dzladderMeanTrend  ,h_norm_dz_ladder_,statmode::MEAN); 
-  fillTrendPlotByIndex(n_dzladderWidthTrend ,h_norm_dz_ladder_,statmode::WIDTH);
 
   // medians and MADs	  
   

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -787,18 +787,16 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 
 		std::pair<bool,bool> pixelOcc = pixelHitsCheck((theTTrack));
 
-		/*
+		if(debug_){
 		  if(pixelOcc.first == true)
-		  std::cout<<"has BPIx hits"<<std::endl;
+		    edm::LogInfo("PrimaryVertexValidation")<<"has BPIx hits"<<std::endl;
 		  if(pixelOcc.second == true)
-		  std::cout<<"has FPix hits"<<std::endl;
-		*/		  
+		    edm::LogInfo("PrimaryVertexValidation")<<"has FPix hits"<<std::endl;
+		}		  
 
 		if(!doBPix_ && (pixelOcc.first == true))  continue;
 		if(!doFPix_ && (pixelOcc.second == true)) continue;
-	
-		//std::cout<<"track passed"<<std::endl;
-	
+		
 		fillTrackHistos(hDA,"sel",&(theTTrack),vertex,beamSpot,fBfield_);
 
 		// probe checks
@@ -1153,7 +1151,7 @@ void PrimaryVertexValidation::beginJob()
   h_nTracks           = EventFeatures.make<TH1F>("h_nTracks","number of tracks per event;n_{tracks}/event;n_{events}",300,-0.5,299.5);	     
   h_nClus             = EventFeatures.make<TH1F>("h_nClus","number of track clusters;n_{clusters}/event;n_{events}",50,-0.5,49.5);	     
   h_nOfflineVertices  = EventFeatures.make<TH1F>("h_nOfflineVertices","number of offline reconstructed vertices;n_{vertices}/event;n_{events}",50,-0.5,49.5);  
-  h_runNumber         = EventFeatures.make<TH1F>("h_runNumber","run number;run number;n_{events}",100000,150000.,250000.);	     
+  h_runNumber         = EventFeatures.make<TH1F>("h_runNumber","run number;run number;n_{events}",100000,250000.,350000.);	     
   h_xOfflineVertex    = EventFeatures.make<TH1F>("h_xOfflineVertex","x-coordinate of offline vertex;x_{vertex};n_{events}",100,-0.1,0.1);    
   h_yOfflineVertex    = EventFeatures.make<TH1F>("h_yOfflineVertex","y-coordinate of offline vertex;y_{vertex};n_{events}",100,-0.1,0.1);    
   h_zOfflineVertex    = EventFeatures.make<TH1F>("h_zOfflineVertex","z-coordinate of offline vertex;z_{vertex};n_{events}",100,-30.,30.);    
@@ -2435,7 +2433,7 @@ void PrimaryVertexValidation::fillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot
     } else if(var_.find("phi") != std::string::npos){
       trendPlot->GetXaxis()->SetBinLabel(i+1,phipositionString); 
     } else {
-      std::cout<<"PrimaryVertexValidation::fillTrendPlot() "<<var_<<" unknown track parameter!"<<std::endl;
+      edm::LogWarning("PrimaryVertexValidation")<<"fillTrendPlot() "<<var_<<" unknown track parameter!"<<std::endl;
     }
   }
 }

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -86,9 +86,9 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   bool isHit2D(const TrackingRecHit &hit) const;
   bool hasFirstLayerPixelHits(const reco::TransientTrack track);
   std::pair<bool,bool> pixelHitsCheck(const reco::TransientTrack track);
-  std::pair<Double_t,Double_t> getMedian(TH1F *histo);
-  std::pair<Double_t,Double_t> getMAD(TH1F *histo);
-  std::pair<std::pair<Double_t,Double_t>, std::pair<Double_t,Double_t> > fitResiduals(TH1 *hist);
+  std::pair<double,double> getMedian(TH1F *histo);
+  std::pair<double,double> getMAD(TH1F *histo);
+  std::pair<std::pair<double,double>, std::pair<double,double> > fitResiduals(TH1 *hist);
   void fillTrendPlot(TH1F* trendPlot, TH1F *residualsPlot[100], statmode::estimator fitPar_, TString var_);
   void fillTrendPlotByIndex(TH1F* trendPlot,std::vector<TH1F*>& h, statmode::estimator fitPar_); 
 

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -134,7 +134,9 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   bool    doBPix_;
   bool    doFPix_;
   double  ptOfProbe_;
+  double  pOfProbe_;
   double  etaOfProbe_;
+  double  nHitsOfProbe_;
   bool    isPhase1_;
   int nBins_;                 // actual number of histograms     
   std::vector<unsigned int> runControlNumbers_;
@@ -347,6 +349,28 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   TH1F* n_dzpTCentralMeanTrend;
   TH1F* n_dzpTCentralWidthTrend;
 
+  // --- trend as a function of the ladder/module number
+
+  TH1F* a_dxymodZMeanTrend;					     		
+  TH1F* a_dxymodZWidthTrend; 					      			
+  TH1F* a_dzmodZMeanTrend; 		       		      			
+  TH1F* a_dzmodZWidthTrend; 
+					       			
+  TH1F* a_dxyladderMeanTrend;  						 			
+  TH1F* a_dxyladderWidthTrend; 					        		       
+  TH1F* a_dzladderMeanTrend;   					        			
+  TH1F* a_dzladderWidthTrend;  
+						 		      
+  TH1F* n_dxymodZMeanTrend;   						 			
+  TH1F* n_dxymodZWidthTrend;  					        			
+  TH1F* n_dzmodZMeanTrend;   					        			
+  TH1F* n_dzmodZWidthTrend;  
+						 			
+  TH1F* n_dxyladderMeanTrend;  						 			
+  TH1F* n_dxyladderWidthTrend; 						 			
+  TH1F* n_dzladderMeanTrend;   						 			
+  TH1F* n_dzladderWidthTrend;  
+
   // ---- medians and MAD
 
   TH1F* a_dxyPhiMedianTrend;
@@ -547,6 +571,10 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   TH1F* h_probeHitsInBPIX_; 
   TH1F* h_probeHitsInFPIX_; 
 
+  TH1F* h_probeL1Ladder_;
+  TH1F* h_probeL1Module_;
+  TH1I* h_probeHasBPixL1Overlap_;  
+
   // check vertex
 
   TH1F* h_fitVtxNdof_;
@@ -575,6 +603,22 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   std::vector<TH1F*> h_dz_Central_pT_;
   std::vector<TH1F*> h_norm_dxy_Central_pT_;
   std::vector<TH1F*> h_norm_dz_Central_pT_;   
+
+  // histograms for the plots as function of module ladder and number
+
+  std::vector<TH1F*> h_dxy_modZ_;
+  std::vector<TH1F*> h_dz_modZ_;
+  std::vector<TH1F*> h_norm_dxy_modZ_;
+  std::vector<TH1F*> h_norm_dz_modZ_;
+
+  std::vector<TH1F*> h_dxy_ladder_;
+
+  std::vector<TH1F*> h_dxy_ladderOverlap_;
+  std::vector<TH1F*> h_dxy_ladderNoOverlap_;
+
+  std::vector<TH1F*> h_dz_ladder_;
+  std::vector<TH1F*> h_norm_dxy_ladder_;
+  std::vector<TH1F*> h_norm_dz_ladder_;   
 
 };
 

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -86,9 +86,9 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   bool isHit2D(const TrackingRecHit &hit) const;
   bool hasFirstLayerPixelHits(const reco::TransientTrack track);
   std::pair<bool,bool> pixelHitsCheck(const reco::TransientTrack track);
-  std::pair<double,double> getMedian(TH1F *histo);
-  std::pair<double,double> getMAD(TH1F *histo);
-  std::pair<std::pair<double,double>, std::pair<double,double> > fitResiduals(TH1 *hist);
+  Measurement1D getMedian(TH1F *histo);
+  Measurement1D getMAD(TH1F *histo);
+  std::pair<Measurement1D, Measurement1D > fitResiduals(TH1 *hist);
   void fillTrendPlot(TH1F* trendPlot, TH1F *residualsPlot[100], statmode::estimator fitPar_, TString var_);
   void fillTrendPlotByIndex(TH1F* trendPlot,std::vector<TH1F*>& h, statmode::estimator fitPar_); 
 

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -349,28 +349,6 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   TH1F* n_dzpTCentralMeanTrend;
   TH1F* n_dzpTCentralWidthTrend;
 
-  // --- trend as a function of the ladder/module number
-
-  TH1F* a_dxymodZMeanTrend;					     		
-  TH1F* a_dxymodZWidthTrend; 					      			
-  TH1F* a_dzmodZMeanTrend; 		       		      			
-  TH1F* a_dzmodZWidthTrend; 
-					       			
-  TH1F* a_dxyladderMeanTrend;  						 			
-  TH1F* a_dxyladderWidthTrend; 					        		       
-  TH1F* a_dzladderMeanTrend;   					        			
-  TH1F* a_dzladderWidthTrend;  
-						 		      
-  TH1F* n_dxymodZMeanTrend;   						 			
-  TH1F* n_dxymodZWidthTrend;  					        			
-  TH1F* n_dzmodZMeanTrend;   					        			
-  TH1F* n_dzmodZWidthTrend;  
-						 			
-  TH1F* n_dxyladderMeanTrend;  						 			
-  TH1F* n_dxyladderWidthTrend; 						 			
-  TH1F* n_dzladderMeanTrend;   						 			
-  TH1F* n_dzladderWidthTrend;  
-
   // ---- medians and MAD
 
   TH1F* a_dxyPhiMedianTrend;
@@ -603,22 +581,6 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   std::vector<TH1F*> h_dz_Central_pT_;
   std::vector<TH1F*> h_norm_dxy_Central_pT_;
   std::vector<TH1F*> h_norm_dz_Central_pT_;   
-
-  // histograms for the plots as function of module ladder and number
-
-  std::vector<TH1F*> h_dxy_modZ_;
-  std::vector<TH1F*> h_dz_modZ_;
-  std::vector<TH1F*> h_norm_dxy_modZ_;
-  std::vector<TH1F*> h_norm_dz_modZ_;
-
-  std::vector<TH1F*> h_dxy_ladder_;
-
-  std::vector<TH1F*> h_dxy_ladderOverlap_;
-  std::vector<TH1F*> h_dxy_ladderNoOverlap_;
-
-  std::vector<TH1F*> h_dz_ladder_;
-  std::vector<TH1F*> h_norm_dxy_ladder_;
-  std::vector<TH1F*> h_norm_dz_ladder_;   
 
 };
 

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -76,31 +76,31 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
 
  public:
   explicit PrimaryVertexValidation(const edm::ParameterSet&);
-  ~PrimaryVertexValidation();
+  ~PrimaryVertexValidation() override;
 
  private:
-  virtual void beginJob();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob();
+  virtual void beginJob() override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
   bool isBFieldConsistentWithMode(const edm::EventSetup& iSetup) const;
   bool isHit2D(const TrackingRecHit &hit) const;
-  bool hasFirstLayerPixelHits(const reco::TransientTrack track);
-  std::pair<bool,bool> pixelHitsCheck(const reco::TransientTrack track);
+  bool hasFirstLayerPixelHits(const reco::TransientTrack& track);
+  std::pair<bool,bool> pixelHitsCheck(const reco::TransientTrack& track);
   Measurement1D getMedian(TH1F *histo);
   Measurement1D getMAD(TH1F *histo);
   std::pair<Measurement1D, Measurement1D > fitResiduals(TH1 *hist);
-  void fillTrendPlot(TH1F* trendPlot, TH1F *residualsPlot[100], statmode::estimator fitPar_, TString var_);
+  void fillTrendPlot(TH1F* trendPlot, TH1F *residualsPlot[100], statmode::estimator fitPar_,const std::string& var_);
   void fillTrendPlotByIndex(TH1F* trendPlot,std::vector<TH1F*>& h, statmode::estimator fitPar_); 
 
   static bool vtxSort( const reco::Vertex &  a, const reco::Vertex & b );
-  bool passesTrackCuts(const reco::Track & track, const reco::Vertex & vertex,std::string qualityString_, double dxyErrMax_,double dzErrMax_, double ptErrMax_);
+  bool passesTrackCuts(const reco::Track & track, const reco::Vertex & vertex,const std::string& qualityString_, double dxyErrMax_,double dzErrMax_, double ptErrMax_);
 
-  std::vector<TH1F*> bookResidualsHistogram(TFileDirectory dir,unsigned int theNOfBins,TString resType,TString varType); 
-  std::map<std::string, TH1*> bookVertexHistograms(TFileDirectory dir);
+  std::vector<TH1F*> bookResidualsHistogram(const TFileDirectory& dir,unsigned int theNOfBins,std::string resType,const std::string& varType); 
+  std::map<std::string, TH1*> bookVertexHistograms(const TFileDirectory& dir);
   void fillTrackHistos(std::map<std::string, TH1*> & h, const std::string & ttype, const reco::TransientTrack *tt, const reco::Vertex & v,const reco::BeamSpot & beamSpot, double fBfield);
   void add(std::map<std::string, TH1*>& h, TH1* hist);
-  void fill(std::map<std::string, TH1*>& h, std::string s, double x);
-  void fill(std::map<std::string, TH1*>& h, std::string s, double x, double y);
+  void fill(std::map<std::string, TH1*>& h,const std::string& s, double x);
+  void fill(std::map<std::string, TH1*>& h,const std::string& s, double x, double y);
   void fillByIndex(std::vector<TH1F*>& h, unsigned int index, double x); 
   void fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100][100], statmode::estimator fitPar_);
   

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
@@ -23,7 +23,7 @@ if isMC:
      print ">>>>>>>>>> testPVValidation_cfg.py: msg%-i: This is simulation!"
      runboundary = 1
 else:
-     print ">>>>>>>>>> testPVValidation_cfg.py: msg%-i: This is real dATA!"
+     print ">>>>>>>>>> testPVValidation_cfg.py: msg%-i: This is real DATA!"
      if ('.oO[lumilist]Oo.'):
           print ">>>>>>>>>> testPVValidation_cfg.py: msg%-i: JSON filtering with: .oO[lumilist]Oo. "
           import FWCore.PythonUtilities.LumiList as LumiList

--- a/Alignment/OfflineValidation/test/submitAllJobs.py
+++ b/Alignment/OfflineValidation/test/submitAllJobs.py
@@ -334,8 +334,8 @@ class Job:
         fout.write("cd $LXBATCH_DIR \n") 
         fout.write("cmsRun "+os.path.join(self.cfg_dir,self.outputCfgName)+" \n")
         fout.write("ls -lh . \n")
-        fout.write("for RootOutputFile in $(ls *root ); do eos cp -f ${RootOutputFile}  ${OUT_DIR}/${RootOutputFile} ; done \n")
-        fout.write("for TxtOutputFile in $(ls *txt ); do eos cp -f ${TxtOutputFile}  ${OUT_DIR}/${TxtOutputFile} ; done \n")
+        fout.write("for RootOutputFile in $(ls *root ); do xrdcp -f ${RootOutputFile}  root://eoscms//eos/cms${OUT_DIR}/${RootOutputFile} ; done \n")
+        fout.write("for TxtOutputFile in $(ls *txt ); do xrdcp -f ${TxtOutputFile}  root://eoscms//eos/cms${OUT_DIR}/${TxtOutputFile} ; done \n")
 
         fout.close()
 
@@ -681,7 +681,7 @@ def main():
             aJob.createTheCfgFile(theSrcFiles)
             aJob.createTheLSFFile()
 
-            output_file_list1.append("eos cp "+aJob.getOutputFileName()+" /tmp/$USER/"+opts.taskname+" \n")
+            output_file_list1.append("xrdcp root://eoscms//eos/cms"+aJob.getOutputFileName()+" /tmp/$USER/"+opts.taskname+" \n")
             if jobN == 0:
                 output_file_list2.append("/tmp/$USER/"+opts.taskname+"/"+aJob.getOutputBaseName()+".root ")
             output_file_list2.append("/tmp/$USER/"+opts.taskname+"/"+os.path.split(aJob.getOutputFileName())[1]+" ")    
@@ -705,7 +705,9 @@ def main():
         fout.write("mkdir -p /tmp/$USER/"+opts.taskname+" \n")
         fout.writelines(output_file_list1)
         fout.writelines(output_file_list2)
-        fout.write("eos cp -f $FILE $OUT_DIR \n")
+        fout.write("\n")
+        fout.write("echo \"xrdcp -f $FILE root://eoscms//eos/cms$OUT_DIR\" \n")
+        fout.write("xrdcp -f root://eoscms//eos/cms$FILE $OUT_DIR \n")
         fout.write("echo \"Harvesting for complete; please find output at $OUT_DIR \" | mail -s \"Harvesting for" +opts.taskname +" compled\" $MAIL \n")
 
         os.system("chmod u+x "+hadd_script_file)

--- a/Alignment/OfflineValidation/test/test_all_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_cfg.py
@@ -95,7 +95,7 @@ else:
                                    connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
                                    timetype = cms.string("runnumber"),
                                    toGet = cms.VPSet(cms.PSet(record = cms.string('TrackerAlignmentErrorExtendedRcd'),
-                                                              tag = cms.string('TrackerAlignmentExtendedErrors_2015StartupPessimisticScenario_mc')
+                                                              tag = cms.string('TrackerAlignmentErrorsExtended_Upgrade2017_design_v0')
                                                               )
                                                      )
                                    )
@@ -109,7 +109,7 @@ else:
           process.trackerBows = cms.ESSource("PoolDBESSource",CondDBSetup,
                                              connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
                                              toGet = cms.VPSet(cms.PSet(record = cms.string('TrackerSurfaceDeformationRcd'),
-                                                                        tag = cms.string('TrackerSurfaceDeformations_2011Realistic_v2_mc')
+                                                                        tag = cms.string('TrackerSurfaceDeformations_zero')
                                                                         )
                                                                )
                                              )


### PR DESCRIPTION
  Greetings,
changes proposed in this PR are mostly technical / stylistical, aiming to clean up the code of the Alignment PrimaryVertexValidation tool, in view of a major refactoring / simplification in a subsequent PR. 
Features: 
   * use range based loops
   * use pre-existing CMSSW types instead of redefining non trivial types
   * use `unique_ptr` instead of bare pointers
   * remove ROOT types in favor of native C++ types
   * added histograms for Bpix ladder checks
   * minor fixes and typos in the configuration