### PR TITLE
Detector Description Clang Check modernize-loop-convert

### DIFF
--- a/DetectorDescription/Core/src/DDFilteredView.cc
+++ b/DetectorDescription/Core/src/DDFilteredView.cc
@@ -243,8 +243,8 @@ void DDFilteredView::print() {
        << "-------------------" << std::endl
        << "scope = " << epv_.scope_ << std::endl
        << "parents:" << std::endl;
-  for (unsigned int i=0; i<parents_.size(); ++i)
-    edm::LogInfo("DDFliteredView") << "  " << parents_[i] << std::endl;
+  for (const auto & parent : parents_)
+    edm::LogInfo("DDFliteredView") << "  " << parent << std::endl;
     
 }
 

--- a/DetectorDescription/Core/src/DDLogicalPart.cc
+++ b/DetectorDescription/Core/src/DDLogicalPart.cc
@@ -348,8 +348,7 @@ DDIsValid( const std::string & ns, const std::string & nm, std::vector<DDLogical
     for (LPNAMES::value_type::const_iterator it=bn; it != ed; ++it)
       if(aRegex.match(it->first)) candidates.push_back(it);
   }
-  for (int i=0; i<int(candidates.size()); ++i) {
-    LPNAMES::value_type::const_iterator it = candidates[i];
+  for (auto it : candidates) {
     //if (doit)  edm::LogInfo("DDLogicalPart") << "rgx: " << aName << ' ' << it->first << ' ' << doit << std::endl;
     std::vector<DDName>::size_type sz = it->second.size(); // no of 'compatible' namespaces
     if ( emptyNs && (sz==1) ) { // accept all logical parts in all the namespaces

--- a/DetectorDescription/Core/src/DDLogicalPart.cc
+++ b/DetectorDescription/Core/src/DDLogicalPart.cc
@@ -348,7 +348,7 @@ DDIsValid( const std::string & ns, const std::string & nm, std::vector<DDLogical
     for (LPNAMES::value_type::const_iterator it=bn; it != ed; ++it)
       if(aRegex.match(it->first)) candidates.push_back(it);
   }
-  for (auto it : candidates) {
+  for (const auto & it : candidates) {
     //if (doit)  edm::LogInfo("DDLogicalPart") << "rgx: " << aName << ' ' << it->first << ' ' << doit << std::endl;
     std::vector<DDName>::size_type sz = it->second.size(); // no of 'compatible' namespaces
     if ( emptyNs && (sz==1) ) { // accept all logical parts in all the namespaces

--- a/DetectorDescription/Core/src/DDsvalues.cc
+++ b/DetectorDescription/Core/src/DDsvalues.cc
@@ -56,7 +56,7 @@ std::ostream & operator<<(std::ostream & os , const DDsvalues_type & s)
 
 std::ostream & operator<<(std::ostream & os , const std::vector<const DDsvalues_type*> & v)
 {
-   for (auto i : v) {
+   for (const auto & i : v) {
      os << *i; // << std::endl;
    }
    

--- a/DetectorDescription/Core/src/DDsvalues.cc
+++ b/DetectorDescription/Core/src/DDsvalues.cc
@@ -56,8 +56,8 @@ std::ostream & operator<<(std::ostream & os , const DDsvalues_type & s)
 
 std::ostream & operator<<(std::ostream & os , const std::vector<const DDsvalues_type*> & v)
 {
-   for (unsigned int i=0; i<v.size() ; ++i) {
-     os << *(v[i]); // << std::endl;
+   for (auto i : v) {
+     os << *i; // << std::endl;
    }
    
    return os;

--- a/DetectorDescription/Parser/src/DDXMLElement.cc
+++ b/DetectorDescription/Parser/src/DDXMLElement.cc
@@ -219,11 +219,10 @@ void
 DDXMLElement::stream( std::ostream & os ) const
 {
   os << "Output of current element attributes:" << std::endl;
-  for (std::vector<DDXMLAttribute>::const_iterator itv = attributes_.begin();
-       itv != attributes_.end(); ++itv)
+  for (const auto & attribute : attributes_)
   {
-    for (DDXMLAttribute::const_iterator it = itv->begin(); 
-	 it != itv->end(); ++it)
+    for (DDXMLAttribute::const_iterator it = attribute.begin(); 
+	 it != attribute.end(); ++it)
       os << it->first <<  " = " << it->second << "\t";
     os << std::endl;
   }

--- a/DetectorDescription/Parser/src/FIPConfiguration.cc
+++ b/DetectorDescription/Parser/src/FIPConfiguration.cc
@@ -49,8 +49,8 @@ FIPConfiguration::dumpFileList(void) const
 {
   std::cout << "File List:" << std::endl;
   std::cout << "  number of files=" << files_.size() << std::endl;
-  for (std::vector<std::string>::const_iterator it = files_.begin(); it != files_.end(); ++it)
-    std::cout << *it << std::endl;
+  for (const auto & file : files_)
+    std::cout << file << std::endl;
 }
 
 //-----------------------------------------------------------------------

--- a/DetectorDescription/RegressionTest/test/const_dump.cpp
+++ b/DetectorDescription/RegressionTest/test/const_dump.cpp
@@ -75,8 +75,8 @@ int main(int argc, char *argv[])
 	std::cout << vit->toString() << std::endl;
 	const std::vector<double>& tv = *vit;
 	std::cout << "size: " << tv.size() << std::endl;
-	for (size_t i=0; i < tv.size(); ++i) {
-	  std::cout << tv[i] << "\t";
+	for (double i : tv) {
+	  std::cout << i << "\t";
 	}
 	std::cout << std::endl;
       }

--- a/DetectorDescription/RegressionTest/test/tutorial.cc
+++ b/DetectorDescription/RegressionTest/test/tutorial.cc
@@ -50,7 +50,7 @@ namespace {
 
     bool accept(const DDExpandedView &cv ) const override final {
       bool returnValue = true;
-      for(auto f: filters_) {
+      for(const auto & f : filters_) {
         returnValue = returnValue and f->accept(cv);
         if(not returnValue) {
           break;
@@ -504,7 +504,7 @@ void tutorial()
 	case 's':
 	  fv.print();
 	  std::cout << std::endl <<"specifics sets = " << v.size() << ":" << std::endl;
-	  for (auto & o : v) {
+	  for (const auto & o : v) {
 	    std::cout << *(o.first) 
 		      << " = " 
 		      << *(o.second) 
@@ -515,7 +515,7 @@ void tutorial()
 	  std::cout << merged << std::endl;
 	 
 	  std::cout << "specifics only at logicalPart:" << std::endl;
-	  for (auto & o : only) {
+	  for (const auto & o : only) {
 	    std::cout << *o << std::endl;
 	  }
 	  std::cout << std::endl;	 

--- a/DetectorDescription/RegressionTest/test/tutorial.cc
+++ b/DetectorDescription/RegressionTest/test/tutorial.cc
@@ -504,10 +504,10 @@ void tutorial()
 	case 's':
 	  fv.print();
 	  std::cout << std::endl <<"specifics sets = " << v.size() << ":" << std::endl;
-	  for (spectype::size_type o=0;o<v.size();++o) {
-	    std::cout << *(v[o].first) 
+	  for (auto & o : v) {
+	    std::cout << *(o.first) 
 		      << " = " 
-		      << *(v[o].second) 
+		      << *(o.second) 
 		      << std::endl;// << std::endl;
 	  }
 	  std::cout << std::endl;
@@ -515,8 +515,8 @@ void tutorial()
 	  std::cout << merged << std::endl;
 	 
 	  std::cout << "specifics only at logicalPart:" << std::endl;
-	  for (std::vector<const DDsvalues_type *>::size_type o=0;o<only.size();++o) {
-	    std::cout << *(only[o]) << std::endl;
+	  for (auto & o : only) {
+	    std::cout << *o << std::endl;
 	  }
 	  std::cout << std::endl;	 
 	  std::cout << "translation: " << fv.translation() << std::endl;


### PR DESCRIPTION
DetectorDescription part of @davidlange6's PR https://github.com/cms-sw/cmssw/pull/19649

Note, I added a second commit to correct the loops with a promise of not modifying the values:
from
```
for( auto it : vec )
```
to
```
for( const auto & it :vec )
```