### PR TITLE
fix unclosed boost_serialization tag problem, 92x version

### DIFF
--- a/CondCore/Utilities/python/cond2xml.py
+++ b/CondCore/Utilities/python/cond2xml.py
@@ -50,9 +50,10 @@ namespace { // Avoid cluttering the global namespace.
       // now we have the object in memory, convert it to xml in a string and return it
      
       std::ostringstream outBuffer;
+      {
       boost::archive::xml_oarchive xmlResult( outBuffer );
       xmlResult << boost::serialization::make_nvp( "cmsCondPayload", *payload );
-
+      }
       return outBuffer.str();
   }
 


### PR DESCRIPTION
Fix problem by which the boost_serialization tag would never be closed in xml files created by conddb dump