### PR TITLE
Phase2-hgx88 Add a new method to provide layer #'s for each subdetector

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -4,6 +4,7 @@
 #include <array>
 #include <cmath>
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 
 class CaloGeometry;
 class DetId;
@@ -29,7 +30,7 @@ namespace hgcal {
     std::float_t getSiThickness(const DetId&) const;
     std::float_t getRadiusToSide(const DetId&) const;
 
-    unsigned int getLayer(int type) const;
+    unsigned int getLayer(ForwardSubdetector type) const;
     unsigned int getLayer(const DetId&) const;
     unsigned int getLayerWithOffset(const DetId&) const;
     unsigned int getWafer(const DetId&) const;

--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -29,6 +29,7 @@ namespace hgcal {
     std::float_t getSiThickness(const DetId&) const;
     std::float_t getRadiusToSide(const DetId&) const;
 
+    unsigned int getLayer(int type) const;
     unsigned int getLayer(const DetId&) const;
     unsigned int getLayerWithOffset(const DetId&) const;
     unsigned int getWafer(const DetId&) const;

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -130,23 +130,32 @@ std::float_t RecHitTools::getRadiusToSide(const DetId& id) const {
 
 unsigned int RecHitTools::getLayer(const ForwardSubdetector type) const {
 
-  int layer(0);
-  if        (type == ForwardSubdetector::HGCEE) {
+  int layer;
+  switch (type) {
+  case(ForwardSubdetector::HGCEE): {
     auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
     layer       = (geomEE->topology().dddConstants()).layers(true);
-  } else if (type == ForwardSubdetector::HGCHEF) {
+    break;
+  }
+  case (ForwardSubdetector::HGCHEF): {
     auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
     layer       = (geomFH->topology().dddConstants()).layers(true);
-  } else if (type == ForwardSubdetector::HGCHEB) {
+    break;
+  } 
+  case (ForwardSubdetector::HGCHEB): {
     auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
     layer       = (geomBH->topology().dddConstants())->getMaxDepth(1);
-  } else if (type == ForwardSubdetector::ForwardEmpty) {
+    break;
+  } 
+  case (ForwardSubdetector::ForwardEmpty): {
     auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
     layer       = (geomEE->topology().dddConstants()).layers(true);
     auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
     layer      += (geomFH->topology().dddConstants()).layers(true);
     auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
     layer      += (geomBH->topology().dddConstants())->getMaxDepth(1);
+  }
+  default: layer = 0;
   }
   return (unsigned int)(layer);
 }

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -132,30 +132,27 @@ unsigned int RecHitTools::getLayer(const ForwardSubdetector type) const {
 
   int layer;
   switch (type) {
-  case(ForwardSubdetector::HGCEE): {
-    auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
-    layer       = (geomEE->topology().dddConstants()).layers(true);
-    break;
-  }
-  case (ForwardSubdetector::HGCHEF): {
-    auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
-    layer       = (geomFH->topology().dddConstants()).layers(true);
-    break;
-  } 
-  case (ForwardSubdetector::HGCHEB): {
-    auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
-    layer       = (geomBH->topology().dddConstants())->getMaxDepth(1);
-    break;
-  } 
-  case (ForwardSubdetector::ForwardEmpty): {
-    auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
-    layer       = (geomEE->topology().dddConstants()).layers(true);
-    auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
-    layer      += (geomFH->topology().dddConstants()).layers(true);
-    auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
-    layer      += (geomBH->topology().dddConstants())->getMaxDepth(1);
-  }
-  default: layer = 0;
+    case(ForwardSubdetector::HGCEE): {
+      auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
+      layer       = (geomEE->topology().dddConstants()).layers(true);
+    }
+    case (ForwardSubdetector::HGCHEF): {
+      auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
+      layer       = (geomFH->topology().dddConstants()).layers(true);
+    } 
+    case (ForwardSubdetector::HGCHEB): {
+      auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
+      layer       = (geomBH->topology().dddConstants())->getMaxDepth(1);
+    } 
+    case (ForwardSubdetector::ForwardEmpty): {
+      auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
+      layer       = (geomEE->topology().dddConstants()).layers(true);
+      auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
+      layer      += (geomFH->topology().dddConstants()).layers(true);
+      auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
+      layer      += (geomBH->topology().dddConstants())->getMaxDepth(1);
+    }
+    default: layer = 0;
   }
   return (unsigned int)(layer);
 }

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -135,14 +135,17 @@ unsigned int RecHitTools::getLayer(const ForwardSubdetector type) const {
     case(ForwardSubdetector::HGCEE): {
       auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
       layer       = (geomEE->topology().dddConstants()).layers(true);
+      break;
     }
     case (ForwardSubdetector::HGCHEF): {
       auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
       layer       = (geomFH->topology().dddConstants()).layers(true);
+      break;
     } 
     case (ForwardSubdetector::HGCHEB): {
       auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
       layer       = (geomBH->topology().dddConstants())->getMaxDepth(1);
+      break;
     } 
     case (ForwardSubdetector::ForwardEmpty): {
       auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
@@ -151,6 +154,7 @@ unsigned int RecHitTools::getLayer(const ForwardSubdetector type) const {
       layer      += (geomFH->topology().dddConstants()).layers(true);
       auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
       layer      += (geomBH->topology().dddConstants())->getMaxDepth(1);
+      break;
     }
     default: layer = 0;
   }

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -140,7 +140,7 @@ unsigned int RecHitTools::getLayer(const ForwardSubdetector type) const {
   } else if (type == ForwardSubdetector::HGCHEB) {
     auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
     layer       = (geomBH->topology().dddConstants())->getMaxDepth(1);
-  } else {
+  } else if (type == ForwardSubdetector::ForwardEmpty) {
     auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
     layer       = (geomEE->topology().dddConstants()).layers(true);
     auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
@@ -148,7 +148,7 @@ unsigned int RecHitTools::getLayer(const ForwardSubdetector type) const {
     auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
     layer      += (geomBH->topology().dddConstants())->getMaxDepth(1);
   }
-  return layer;
+  return (unsigned int)(layer);
 }
 
 unsigned int RecHitTools::getLayer(const DetId& id) const {

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -128,6 +128,29 @@ std::float_t RecHitTools::getRadiusToSide(const DetId& id) const {
   return size;
 }
 
+unsigned int RecHitTools::getLayer(const int type) const {
+
+  int layer(0);
+  if        (type == 1) {
+    auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
+    layer       = (geomEE->topology().dddConstants()).layers(true);
+  } else if (type == 2) {
+    auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
+    layer       = (geomFH->topology().dddConstants()).layers(true);
+  } else if (type == 3) {
+    auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
+    layer       = (geomBH->topology().dddConstants())->getMaxDepth(1);
+  } else {
+    auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
+    layer       = (geomEE->topology().dddConstants()).layers(true);
+    auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
+    layer      += (geomFH->topology().dddConstants()).layers(true);
+    auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
+    layer      += (geomBH->topology().dddConstants())->getMaxDepth(1);
+  }
+  return layer;
+}
+
 unsigned int RecHitTools::getLayer(const DetId& id) const {
   unsigned int layer = std::numeric_limits<unsigned int>::max();
   if( id.det() == DetId::Forward) {

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -128,16 +128,16 @@ std::float_t RecHitTools::getRadiusToSide(const DetId& id) const {
   return size;
 }
 
-unsigned int RecHitTools::getLayer(const int type) const {
+unsigned int RecHitTools::getLayer(const ForwardSubdetector type) const {
 
   int layer(0);
-  if        (type == 1) {
+  if        (type == ForwardSubdetector::HGCEE) {
     auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
     layer       = (geomEE->topology().dddConstants()).layers(true);
-  } else if (type == 2) {
+  } else if (type == ForwardSubdetector::HGCHEF) {
     auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
     layer       = (geomFH->topology().dddConstants()).layers(true);
-  } else if (type == 3) {
+  } else if (type == ForwardSubdetector::HGCHEB) {
     auto geomBH = static_cast<const HcalGeometry*>(geom_->getSubdetectorGeometry(DetId::Hcal,HcalSubdetector::HcalEndcap));
     layer       = (geomBH->topology().dddConstants())->getMaxDepth(1);
   } else {


### PR DESCRIPTION
getLayer(const ForwardSubdetector type) returns # of layers for EE (type=HGCEE), FH (type=HGCHEF), BH (type=HGCHEB) and all combined (type=none of the 3 mentioned)