### PR TITLE
Fix for cosmic workflow

### DIFF
--- a/DQM/SiPixelPhase1Config/test/qTests/mean_charge_qualitytest_config_cosmics.xml
+++ b/DQM/SiPixelPhase1Config/test/qTests/mean_charge_qualitytest_config_cosmics.xml
@@ -1,0 +1,135 @@
+<TESTCONFIGURATION>
+  <!-- QTESTS for MEAN CHARGE: -->
+
+  <!-- PXBARREL -->
+  <!-- PXLAYER 1 -->
+  <QTEST name="Yrange:PXLayer_1:mean_charge" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">20.</PARAM>
+    <PARAM name="ymax">100000.</PARAM>
+  </QTEST>
+  <!-- PXLAYER 2 -->  <!-- warn -->
+  <QTEST name="Yrange:PXLayer_2:mean_charge" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">20.</PARAM>
+    <PARAM name="ymax">100000.</PARAM>
+  </QTEST>
+  <!-- PXLAYER 3 --> <!-- error -->
+  <QTEST name="Yrange:PXLayer_3:mean_charge" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">20.</PARAM>
+    <PARAM name="ymax">100000.</PARAM>
+  </QTEST>
+  <!-- PXLAYER 4 --> <!-- pass -->
+  <QTEST name="Yrange:PXLayer_4:mean_charge" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">20.</PARAM>
+    <PARAM name="ymax">100000.</PARAM>
+  </QTEST>
+
+  <!-- PXFORWARD -->
+  <!-- PXRING 1 -->
+  <!-- PXDISK ±1 --> <!-- error -->
+  <QTEST name="Yrange:PXRing_1__PXDisk_±1:mean_charge" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">20.</PARAM>
+    <PARAM name="ymax">100000.</PARAM>
+  </QTEST>
+  <!-- PXDISK ±2 --> <!-- pass -->
+  <QTEST name="Yrange:PXRing_1__PXDisk_±2:mean_charge" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">20.</PARAM>
+    <PARAM name="ymax">100000.</PARAM>
+  </QTEST>
+  <!-- PXDISK ±3 -->
+  <QTEST name="Yrange:PXRing_1__PXDisk_±3:mean_charge" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">20.</PARAM>
+    <PARAM name="ymax">100000.</PARAM>
+  </QTEST>
+  <!-- PXRING 2 -->
+  <!-- PXDISK ±1 -->
+  <QTEST name="Yrange:PXRing_2__PXDisk_±1:mean_charge" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">20.</PARAM>
+    <PARAM name="ymax">100000.</PARAM>
+  </QTEST>
+  <!-- PXDISK ±2 -->
+  <QTEST name="Yrange:PXRing_2__PXDisk_±2:mean_charge" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">20.</PARAM>
+    <PARAM name="ymax">100000.</PARAM>
+  </QTEST>
+  <!-- PXDISK ±3 -->
+  <QTEST name="Yrange:PXRing_2__PXDisk_±3:mean_charge" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">20.</PARAM>
+    <PARAM name="ymax">100000.</PARAM>
+  </QTEST>
+
+
+  <!-- LINKS between Quality Tests and Monitoring Elements: -->
+  <!-- PXBARREL LINKS -->
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_charge_PXLayer_1">
+    <TestName activate="true">Yrange:PXLayer_1:mean_charge</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_charge_PXLayer_2">
+    <TestName activate="true">Yrange:PXLayer_2:mean_charge</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_charge_PXLayer_3">
+    <TestName activate="true">Yrange:PXLayer_3:mean_charge</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_charge_PXLayer_4">
+    <TestName activate="true">Yrange:PXLayer_4:mean_charge</TestName>
+  </LINK>
+
+  <!-- PXFORWARD LINKS -->
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_charge_PXDisk_*1">
+    <TestName activate="true">Yrange:PXRing_1__PXDisk_±1:mean_charge</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_charge_PXDisk_*2">
+    <TestName activate="true">Yrange:PXRing_1__PXDisk_±2:mean_charge</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_charge_PXDisk_*3">
+    <TestName activate="true">Yrange:PXRing_1__PXDisk_±3:mean_charge</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_charge_PXDisk_*1">
+    <TestName activate="true">Yrange:PXRing_2__PXDisk_±1:mean_charge</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_charge_PXDisk_*2">
+    <TestName activate="true">Yrange:PXRing_2__PXDisk_±2:mean_charge</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_charge_PXDisk_*3">
+    <TestName activate="true">Yrange:PXRing_2__PXDisk_±3:mean_charge</TestName>
+  </LINK>
+</TESTCONFIGURATION>

--- a/DQM/SiPixelPhase1Config/test/qTests/mean_num_digis_qualitytest_config_cosmics.xml
+++ b/DQM/SiPixelPhase1Config/test/qTests/mean_num_digis_qualitytest_config_cosmics.xml
@@ -1,0 +1,135 @@
+<TESTCONFIGURATION>
+  <!-- QTESTS for MEAN NUMBER OF DIGIS: -->
+
+  <!-- PXBARREL -->
+  <!-- PXLAYER 1 -->
+  <QTEST name="Yrange:PXLayer_1:mean_num_digis" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.01</PARAM>
+    <PARAM name="ymax">50.</PARAM>
+  </QTEST>
+  <!-- PXLAYER 2 -->  <!-- warn -->
+  <QTEST name="Yrange:PXLayer_2:mean_num_digis" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.01</PARAM>
+    <PARAM name="ymax">10.</PARAM>
+  </QTEST>
+  <!-- PXLAYER 3 --> <!-- error -->
+  <QTEST name="Yrange:PXLayer_3:mean_num_digis" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.01</PARAM>
+    <PARAM name="ymax">10.</PARAM>
+  </QTEST>
+  <!-- PXLAYER 4 --> <!-- pass -->
+  <QTEST name="Yrange:PXLayer_4:mean_num_digis" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.01</PARAM>
+    <PARAM name="ymax">10.</PARAM>
+  </QTEST>
+
+  <!-- PXFORWARD -->
+  <!-- PXRING 1 -->
+  <!-- PXDISK ±1 --> <!-- error -->
+  <QTEST name="Yrange:PXRing_1__PXDisk_±1:mean_num_digis" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.01</PARAM>
+    <PARAM name="ymax">10.</PARAM>
+  </QTEST>
+  <!-- PXDISK ±2 --> <!-- pass -->
+  <QTEST name="Yrange:PXRing_1__PXDisk_±2:mean_num_digis" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.01</PARAM>
+    <PARAM name="ymax">10.</PARAM>
+  </QTEST>
+  <!-- PXDISK ±3 -->
+  <QTEST name="Yrange:PXRing_1__PXDisk_±3:mean_num_digis" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.01</PARAM>
+    <PARAM name="ymax">10.</PARAM>
+  </QTEST>
+  <!-- PXRING 2 -->
+  <!-- PXDISK ±1 -->
+  <QTEST name="Yrange:PXRing_2__PXDisk_±1:mean_num_digis" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.01</PARAM>
+    <PARAM name="ymax">10.</PARAM>
+  </QTEST>
+  <!-- PXDISK ±2 -->
+  <QTEST name="Yrange:PXRing_2__PXDisk_±2:mean_num_digis" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.01</PARAM>
+    <PARAM name="ymax">10.</PARAM>
+  </QTEST>
+  <!-- PXDISK ±3 -->
+  <QTEST name="Yrange:PXRing_2__PXDisk_±3:mean_num_digis" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.01</PARAM>
+    <PARAM name="ymax">10.</PARAM>
+  </QTEST>
+
+
+  <!-- LINKS between Quality Tests and Monitoring Elements: -->
+  <!-- PXBARREL LINKS -->
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_num_digis_PXLayer_1">
+    <TestName activate="true">Yrange:PXLayer_1:mean_num_digis</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_num_digis_PXLayer_2">
+    <TestName activate="true">Yrange:PXLayer_2:mean_num_digis</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_num_digis_PXLayer_3">
+    <TestName activate="true">Yrange:PXLayer_3:mean_num_digis</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_num_digis_PXLayer_4">
+    <TestName activate="true">Yrange:PXLayer_4:mean_num_digis</TestName>
+  </LINK>
+
+  <!-- PXFORWARD LINKS -->
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_num_digis_PXDisk_*1">
+    <TestName activate="true">Yrange:PXRing_1__PXDisk_±1:mean_num_digis</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_num_digis_PXDisk_*2">
+    <TestName activate="true">Yrange:PXRing_1__PXDisk_±2:mean_num_digis</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_num_digis_PXDisk_*3">
+    <TestName activate="true">Yrange:PXRing_1__PXDisk_±3:mean_num_digis</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_num_digis_PXDisk_*1">
+    <TestName activate="true">Yrange:PXRing_2__PXDisk_±1:mean_num_digis</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_num_digis_PXDisk_*2">
+    <TestName activate="true">Yrange:PXRing_2__PXDisk_±2:mean_num_digis</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_num_digis_PXDisk_*3">
+    <TestName activate="true">Yrange:PXRing_2__PXDisk_±3:mean_num_digis</TestName>
+  </LINK>
+</TESTCONFIGURATION>

--- a/DQM/SiPixelPhase1Config/test/qTests/mean_size_qualitytest_config_cosmics.xml
+++ b/DQM/SiPixelPhase1Config/test/qTests/mean_size_qualitytest_config_cosmics.xml
@@ -1,0 +1,135 @@
+<TESTCONFIGURATION>
+  <!-- QTESTS for MEAN SIZE: -->
+
+  <!-- PXBARREL -->
+  <!-- PXLAYER 1 -->
+  <QTEST name="Yrange:PXLayer_1:mean_size" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.1</PARAM>
+    <PARAM name="ymax">20.</PARAM>
+  </QTEST>
+  <!-- PXLAYER 2 -->  <!-- warn -->
+  <QTEST name="Yrange:PXLayer_2:mean_size" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.1</PARAM>
+    <PARAM name="ymax">20.</PARAM>
+  </QTEST>
+  <!-- PXLAYER 3 --> <!-- error -->
+  <QTEST name="Yrange:PXLayer_3:mean_size" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.1</PARAM>
+    <PARAM name="ymax">20.</PARAM>
+  </QTEST>
+  <!-- PXLAYER 4 --> <!-- pass -->
+  <QTEST name="Yrange:PXLayer_4:mean_size" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.1</PARAM>
+    <PARAM name="ymax">20.</PARAM>
+  </QTEST>
+
+  <!-- PXFORWARD -->
+  <!-- PXRING 1 -->
+  <!-- PXDISK ±1 --> <!-- error -->
+  <QTEST name="Yrange:PXRing_1__PXDisk_±1:mean_size" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.1</PARAM>
+    <PARAM name="ymax">20.</PARAM>
+  </QTEST>
+  <!-- PXDISK ±2 --> <!-- pass -->
+  <QTEST name="Yrange:PXRing_1__PXDisk_±2:mean_size" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.1</PARAM>
+    <PARAM name="ymax">20.</PARAM>
+  </QTEST>
+  <!-- PXDISK ±3 -->
+  <QTEST name="Yrange:PXRing_1__PXDisk_±3:mean_size" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.1</PARAM>
+    <PARAM name="ymax">20.</PARAM>
+  </QTEST>
+  <!-- PXRING 2 -->
+  <!-- PXDISK ±1 -->
+  <QTEST name="Yrange:PXRing_2__PXDisk_±1:mean_size" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.1</PARAM>
+    <PARAM name="ymax">20.</PARAM>
+  </QTEST>
+  <!-- PXDISK ±2 -->
+  <QTEST name="Yrange:PXRing_2__PXDisk_±2:mean_size" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.1</PARAM>
+    <PARAM name="ymax">20.</PARAM>
+  </QTEST>
+  <!-- PXDISK ±3 -->
+  <QTEST name="Yrange:PXRing_2__PXDisk_±3:mean_size" activate="true">
+    <TYPE>ContentsYRange</TYPE>
+    <PARAM name="useEmptyBins">1</PARAM>
+    <PARAM name="error">0.2</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="ymin">0.1</PARAM>
+    <PARAM name="ymax">20.</PARAM>
+  </QTEST>
+
+
+  <!-- LINKS between Quality Tests and Monitoring Elements: -->
+  <!-- PXBARREL LINKS -->
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_size_PXLayer_1">
+    <TestName activate="true">Yrange:PXLayer_1:mean_size</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_size_PXLayer_2">
+    <TestName activate="true">Yrange:PXLayer_2:mean_size</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_size_PXLayer_3">
+    <TestName activate="true">Yrange:PXLayer_3:mean_size</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_size_PXLayer_4">
+    <TestName activate="true">Yrange:PXLayer_4:mean_size</TestName>
+  </LINK>
+
+  <!-- PXFORWARD LINKS -->
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_size_PXDisk_*1">
+    <TestName activate="true">Yrange:PXRing_1__PXDisk_±1:mean_size</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_size_PXDisk_*2">
+    <TestName activate="true">Yrange:PXRing_1__PXDisk_±2:mean_size</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_size_PXDisk_*3">
+    <TestName activate="true">Yrange:PXRing_1__PXDisk_±3:mean_size</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_size_PXDisk_*1">
+    <TestName activate="true">Yrange:PXRing_2__PXDisk_±1:mean_size</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_size_PXDisk_*2">
+    <TestName activate="true">Yrange:PXRing_2__PXDisk_±2:mean_size</TestName>
+  </LINK>
+  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_size_PXDisk_*3">
+    <TestName activate="true">Yrange:PXRing_2__PXDisk_±3:mean_size</TestName>
+  </LINK>
+</TESTCONFIGURATION>

--- a/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
@@ -11,6 +11,7 @@ from RecoTracker.SpecialSeedGenerators.CosmicSeedP5Pairs_cff import *
 from RecoTracker.SingleTrackPattern.CosmicTrackFinderP5_cff import *
 # Final Track Selector for CosmicTF
 from RecoTracker.FinalTrackSelectors.CosmicTFFinalTrackSelectorP5_cff import *
+from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
 
 #chi2 set to 40!!
 # CTF
@@ -67,7 +68,7 @@ trackerCosmics_TopBot = cms.Sequence((trackerlocalrecoTop*tracksP5Top)+(trackerl
 #dEdX reconstruction
 from RecoTracker.DeDx.dedxEstimators_Cosmics_cff import *
 # (SK) keep rstracks commented out in case of resurrection
-tracksP5 = cms.Sequence(cosmictracksP5*ctftracksP5*doAllCosmicdEdXEstimators)
+tracksP5 = cms.Sequence(cosmictracksP5*ctftracksP5*doAllCosmicdEdXEstimators*siPixelClusterShapeCache)
 tracksP5_wodEdX = tracksP5.copy()
 tracksP5_wodEdX.remove(doAllCosmicdEdXEstimators)
 


### PR DESCRIPTION
Adding siPixelClusterShapeCache to cosmic wf and reintroducing pixel quality tests removed recently ( #19447 )
tested with cosmic WF 7.2 