### PR TITLE
[93X] L1T Validation Module with GeneratorParticle Information: remove low pt objects and fill overflow in last bin

### DIFF
--- a/Validation/L1T/plugins/L1Validator.cc
+++ b/Validation/L1T/plugins/L1Validator.cc
@@ -123,6 +123,9 @@ void L1Validator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
      // eta within calorimeter acceptance 4.7
      if(fabs((&Genjet)->eta())>4.7) continue;
 
+     // only consider the gen jet with pt greater than 10 GeV
+     if((&Genjet)->pt()<10.0) continue;
+
      double minDR = 999.0;
 
      // match L1T object
@@ -147,6 +150,9 @@ void L1Validator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     int pdg = GenPart->pdgId(), status = GenPart->status();
 
     double minDR = 999.0;
+
+    // only consider the gen particle with pt greater than 10 GeV
+    if(GenPart->pt()<10.0) continue;
 
     /// select the final state (i.e status==1) muons (pdg==+/-13)
     if(status==1 && abs(pdg)==13){  //Muon

--- a/Validation/L1T/src/L1ValidatorHists.cc
+++ b/Validation/L1T/src/L1ValidatorHists.cc
@@ -57,26 +57,28 @@ void L1ValidatorHists::Book(DQMStore::IBooker &iBooker){
 }
 
 void L1ValidatorHists::Fill(int i, const reco::LeafCandidate *GenPart, const reco::LeafCandidate *L1Part){
+  double GenPartPt = GenPart->pt();
+  // fill the overflow in the last bin
+  if(GenPart->pt()>=160.0) GenPartPt = 159.0;
   if(L1Part==NULL) {
-     Eff_Pt_Denom[i]->Fill(GenPart->pt());
+     Eff_Pt_Denom[i]->Fill(GenPartPt);
      if(GenPart->pt()>10)Eff_Eta_Denom[i]->Fill(GenPart->eta());
-     TurnOn_15_Denom[i]->Fill(GenPart->pt());
-     TurnOn_30_Denom[i]->Fill(GenPart->pt());
+     TurnOn_15_Denom[i]->Fill(GenPartPt);
+     TurnOn_30_Denom[i]->Fill(GenPartPt);
   } else {
      double idR = reco::deltaR(GenPart->eta(), GenPart->phi(), L1Part->eta(), L1Part->phi());
      bool matched  = idR < 0.15;
-     Eff_Pt_Denom[i]->Fill(GenPart->pt());
+     Eff_Pt_Denom[i]->Fill(GenPartPt);
      if(GenPart->pt()>10)Eff_Eta_Denom[i]->Fill(GenPart->eta());
-     if(matched)Eff_Pt_Nomin[i]->Fill(GenPart->pt());
+     if(matched)Eff_Pt_Nomin[i]->Fill(GenPartPt);
      if(matched && GenPart->pt()>10)Eff_Eta_Nomin[i]->Fill(GenPart->eta());
-     TurnOn_15_Denom[i]->Fill(GenPart->pt());
-     TurnOn_30_Denom[i]->Fill(GenPart->pt());
-     if(L1Part->pt()>15 && matched) TurnOn_15_Nomin[i]->Fill(GenPart->pt());
-     if(L1Part->pt()>30 && matched) TurnOn_30_Nomin[i]->Fill(GenPart->pt());
+     TurnOn_15_Denom[i]->Fill(GenPartPt);
+     TurnOn_30_Denom[i]->Fill(GenPartPt);
+     if(L1Part->pt()>15 && matched) TurnOn_15_Nomin[i]->Fill(GenPartPt);
+     if(L1Part->pt()>30 && matched) TurnOn_30_Nomin[i]->Fill(GenPartPt);
      dR[i]->Fill(idR);
      dPt[i]->Fill( (L1Part->pt()-GenPart->pt()) / GenPart->pt() );
      dR_vs_Pt[i]->Fill(GenPart->pt(), idR);
-     dPt[i]->Fill( (L1Part->pt()-GenPart->pt()) / GenPart->pt() );
      dPt_vs_Pt[i]->Fill( GenPart->pt(),  (L1Part->pt()-GenPart->pt()) / GenPart->pt() );
   }
 }


### PR DESCRIPTION
This PR makes two updates in Validation/L1T package which is used to fill the L1TriggerVsGen histograms for L1T RelVal: 
    remove the low pt gen objects (i.e pt < 10GeV); 
    fill the overflow pt entries (i.e pt >160GeV) in the last pt bin 120-160 GeV.
The PR has been tested with "runTheMatrix.py -l limited -i all", no problem shows up.