### PR TITLE
remove errant Eras.py imports

### DIFF
--- a/DQM/HcalTasks/python/DigiTask.py
+++ b/DQM/HcalTasks/python/DigiTask.py
@@ -28,5 +28,5 @@ digiTask = cms.EDAnalyzer(
 	qie10InConditions = cms.untracked.bool(False),
 )
 
-from Configuration.StandardSequences.Eras import eras
-eras.run2_HF_2017.toModify(digiTask, qie10InConditions=cms.untracked.bool(True))
+from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
+run2_HF_2017.toModify(digiTask, qie10InConditions=cms.untracked.bool(True))

--- a/DQM/Physics/python/DQMPhysics_cff.py
+++ b/DQM/Physics/python/DQMPhysics_cff.py
@@ -41,10 +41,10 @@ phase1Pixel.toReplaceWith(dqmPhysics, dqmPhysics.copyAndExclude([ # FIXME
     ewkElecDQM,          # Excessive printouts because 2017 doesn't have HLT yet
     ewkMuLumiMonitorDQM, # Excessive printouts because 2017 doesn't have HLT yet
 ]))
-from Configuration.StandardSequences.Eras import eras
+from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 dqmPhysicspA  =  dqmPhysics.copy()
 dqmPhysicspA += CentralitypADQM
-eras.pA_2016.toReplaceWith(dqmPhysics, dqmPhysicspA)
+pA_2016.toReplaceWith(dqmPhysics, dqmPhysicspA)
 
 bphysicsOniaDQMHI = bphysicsOniaDQM.clone(vertex=cms.InputTag("hiSelectedVertex"))
 dqmPhysicsHI = cms.Sequence(bphysicsOniaDQMHI+CentralityDQM)

--- a/DQMOffline/Configuration/python/DQMOffline_Certification_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_Certification_cff.py
@@ -6,8 +6,6 @@ from DQMOffline.Configuration.DQMOffline_DAQ_cff import *
 from DQMOffline.Configuration.DQMOffline_DCS_cff import *
 from DQMOffline.Configuration.DQMOffline_CRT_cff import *
 
-from Configuration.StandardSequences.Eras import eras
-
 DQMOffline_Certification = cms.Sequence(daq_dqmoffline*dcs_dqmoffline*crt_dqmoffline)
 
 DQMCertCommon = cms.Sequence(siStripDaqInfo * sipixelDaqInfo * 

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
@@ -268,7 +268,6 @@ from DQMOffline.L1Trigger.L1TEGammaOffline_cfi import *
 l1tEGammaOfflineDQMEmu.stage2CaloLayer2EGammaSource=cms.InputTag("valCaloStage2Layer2Digis")
 from DQMOffline.L1Trigger.L1TEfficiencyMuons_Offline_cfi import *
 
-from Configuration.StandardSequences.Eras import eras
 from DQM.L1TMonitor.L1TStage2_cff import *
 from DQMOffline.L1Trigger.L1TriggerDqmOffline_SecondStep_cff import *
 from DQMOffline.L1Trigger.L1TEfficiencyHarvesting_cfi import *

--- a/L1Trigger/L1TNtuples/python/L1NtupleEMU_cff.py
+++ b/L1Trigger/L1TNtuples/python/L1NtupleEMU_cff.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
 from L1Trigger.L1TNtuples.l1CaloTowerTree_cfi import *
 from L1Trigger.L1TNtuples.l1UpgradeTfMuonTree_cfi import *
@@ -32,12 +31,14 @@ l1UpgradeEmuTree.sumToken = cms.untracked.InputTag("simCaloStage2Digis")
 l1uGTEmuTree = l1uGTTree.clone()
 l1uGTEmuTree.ugtToken = cms.InputTag("simGtStage2Digis")
 
-if eras.stage1L1Trigger.isChosen() or eras.Run2_25ns.isChosen():
-    l1UpgradeEMUTree.egToken = "simCaloStage1FinalDigis"
-    l1UpgradeEMUTree.tauTokens = cms.untracked.VInputTag("simCaloStage1FinalDigis:rlxTaus")
-    l1UpgradeEMUTree.jetToken = "simCaloStage1FinalDigis"
-    l1UpgradeEMUTree.muonToken = "simGtDigis"
-    l1UpgradeEMUTree.sumToken = "simCaloStage1FinalDigis"
+from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
+stage1L1Trigger.toModify(l1UpgradeEMUTree,
+    egToken = "simCaloStage1FinalDigis",
+    tauTokens = cms.untracked.VInputTag("simCaloStage1FinalDigis:rlxTaus"),
+    jetToken = "simCaloStage1FinalDigis",
+    muonToken = "simGtDigis",
+    sumToken = "simCaloStage1FinalDigis",
+)
 
 L1NtupleEMU = cms.Sequence(
   l1EventTree

--- a/RecoCTPPS/TotemRPLocal/python/ctppsLocalTrackLiteProducer_cfi.py
+++ b/RecoCTPPS/TotemRPLocal/python/ctppsLocalTrackLiteProducer_cfi.py
@@ -9,5 +9,5 @@ ctppsLocalTrackLiteProducer = cms.EDProducer("CTPPSLocalTrackLiteProducer",
 )
 
 # enable the module for CTPPS era(s)
-from Configuration.StandardSequences.Eras import eras
-eras.ctpps_2016.toModify(ctppsLocalTrackLiteProducer, doNothing=cms.bool(False))
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+ctpps_2016.toModify(ctppsLocalTrackLiteProducer, doNothing=cms.bool(False))


### PR DESCRIPTION
Modifiers should be implemented from their own cff files, not from `Configuration.StandardSequences.Eras` (to reduce unnecessary dependencies). See #14895.