### PR TITLE
Switch phase2 pixelPair tracking regions to first 5 firstStepPrimaryVertices

### DIFF
--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -78,7 +78,7 @@ _region_Phase1 = dict(
 )
 trackingPhase1.toModify(pixelPairStepTrackingRegions, RegionPSet=_region_Phase1)
 trackingPhase1QuadProp.toModify(pixelPairStepTrackingRegions, RegionPSet=_region_Phase1)
-trackingPhase2PU140.toModify(pixelPairStepTrackingRegions, RegionPSet=dict(ptMin = 0.6, useMultipleScattering=False))
+trackingPhase2PU140.toModify(pixelPairStepTrackingRegions, RegionPSet=_region_Phase1)
 
 # SEEDS
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer


### PR DESCRIPTION
As for phase1 in #19051, and as mentioned in RECO meeting on June 16
https://indico.cern.ch/event/645986/contributions/2623365/attachments/1478282/2290968/slides_reco_20170616.pdf

Here is an MTV for 1000 single muon events (thanks to @ebrondol!)
https://cms-tracking-validation.web.cern.ch/cms-tracking-validation/PR/CMSSW_9_3_0_pre1_PR19739/
More tests with ttbar (and pileup) will come after we get RelVal samples in 93X (they should be in the making).

Tested in 9_3_0_pre1, expecting changes only in phase2. Based on the phase1 experience, I'd expect the (signal) efficiency to stay the same, and the overall fake rate to decrease (especially in pixelPairStep).

@rovere @VinInn @ebrondol 