### PR TITLE
Adding inactive hit maps

### DIFF
--- a/DQM/SiPixelPhase1TrackEfficiency/interface/SiPixelPhase1TrackEfficiency.h
+++ b/DQM/SiPixelPhase1TrackEfficiency/interface/SiPixelPhase1TrackEfficiency.h
@@ -17,6 +17,7 @@ class SiPixelPhase1TrackEfficiency : public SiPixelPhase1Base {
   enum {
     VALID,
     MISSING,
+    INACTIVE,
     EFFICIENCY,
     VERTICES
   };
@@ -29,6 +30,9 @@ class SiPixelPhase1TrackEfficiency : public SiPixelPhase1Base {
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > clustersToken_;
   edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
   edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
+
+  bool applyVertexCut_;
+  
 };
 
 #endif

--- a/DQM/SiPixelPhase1TrackEfficiency/python/SiPixelPhase1TrackEfficiency_cfi.py
+++ b/DQM/SiPixelPhase1TrackEfficiency/python/SiPixelPhase1TrackEfficiency_cfi.py
@@ -25,7 +25,7 @@ SiPixelPhase1TrackEfficiencyValid = DefaultHistoTrack.clone(
 )
 
 SiPixelPhase1TrackEfficiencyInactive = DefaultHistoTrack.clone(
-  name = "missing",
+  name = "inactive",
   title = "Inactive Hits",
   xlabel = "inactive hits",
   dimensions = 0,

--- a/DQM/SiPixelPhase1TrackEfficiency/python/SiPixelPhase1TrackEfficiency_cfi.py
+++ b/DQM/SiPixelPhase1TrackEfficiency/python/SiPixelPhase1TrackEfficiency_cfi.py
@@ -11,7 +11,7 @@ SiPixelPhase1TrackEfficiencyValid = DefaultHistoTrack.clone(
 
   specs = VPSet(
     StandardSpecifications1D_Num,
-    StandardSpecification2DOccupancy,
+    StandardSpecification2DProfile_Num,
 
     Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
                              .reduce("COUNT")    
@@ -24,6 +24,27 @@ SiPixelPhase1TrackEfficiencyValid = DefaultHistoTrack.clone(
   )
 )
 
+SiPixelPhase1TrackEfficiencyInactive = DefaultHistoTrack.clone(
+  name = "missing",
+  title = "Inactive Hits",
+  xlabel = "inactive hits",
+  dimensions = 0,
+
+  specs = VPSet(
+    StandardSpecifications1D_Num,
+    StandardSpecification2DProfile_Num,
+
+    Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
+                             .reduce("COUNT")    
+                             .groupBy("PXBarrel/PXLayer")
+                             .save(nbins=100, xmin=0, xmax=100),
+    Specification().groupBy("PXForward/PXDisk/Event")
+                             .reduce("COUNT")    
+                             .groupBy("PXForward/PXDisk/")
+                             .save(nbins=100, xmin=0, xmax=100),
+  )
+)
+
 SiPixelPhase1TrackEfficiencyMissing = DefaultHistoTrack.clone(
   name = "missing",
   title = "Missing Hits",
@@ -32,7 +53,7 @@ SiPixelPhase1TrackEfficiencyMissing = DefaultHistoTrack.clone(
 
   specs = VPSet(
     StandardSpecifications1D_Num,
-    StandardSpecification2DOccupancy,
+    StandardSpecification2DProfile_Num,
 
     Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
                              .reduce("COUNT")    
@@ -79,6 +100,7 @@ SiPixelPhase1TrackEfficiencyVertices= DefaultHistoTrack.clone(
 SiPixelPhase1TrackEfficiencyConf = cms.VPSet(
   SiPixelPhase1TrackEfficiencyValid,
   SiPixelPhase1TrackEfficiencyMissing,
+  SiPixelPhase1TrackEfficiencyInactive,
   SiPixelPhase1TrackEfficiencyEfficiency,
   SiPixelPhase1TrackEfficiencyVertices
 )

--- a/DQM/SiPixelPhase1TrackEfficiency/src/SiPixelPhase1TrackEfficiency.cc
+++ b/DQM/SiPixelPhase1TrackEfficiency/src/SiPixelPhase1TrackEfficiency.cc
@@ -19,13 +19,15 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
-
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 SiPixelPhase1TrackEfficiency::SiPixelPhase1TrackEfficiency(const edm::ParameterSet& iConfig) :
   SiPixelPhase1Base(iConfig) 
 { 
   tracksToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
   vtxToken_ = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("primaryvertices"));
+  applyVertexCut_=iConfig.getUntrackedParameter<bool>("VertexCut",true);
+
 }
 
 void SiPixelPhase1TrackEfficiency::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -40,8 +42,10 @@ void SiPixelPhase1TrackEfficiency::analyze(const edm::Event& iEvent, const edm::
   iEvent.getByToken( vtxToken_, vertices);
 
   if (!vertices.isValid()) return;
+
   histo[VERTICES].fill(vertices->size(),DetId(0),&iEvent);
-  if (vertices->size() == 0) return;
+
+  if (applyVertexCut_ &&  vertices->size() == 0) return;
 
   // should be used for weird cuts
   //const auto primaryVertex = vertices->at(0); 
@@ -52,6 +56,9 @@ void SiPixelPhase1TrackEfficiency::analyze(const edm::Event& iEvent, const edm::
   if (!tracks.isValid()) return;
 
   for (auto const & track : *tracks) {
+
+    //this cut is needed to be consisten with residuals calculation
+    if (applyVertexCut_ && (track.pt() < 0.75 || std::abs( track.dxy(vertices->at(0).position()) ) > 5*track.dxyError())) continue; 
 
     bool isBpixtrack = false, isFpixtrack = false;
     int nStripHits = 0;
@@ -91,7 +98,8 @@ void SiPixelPhase1TrackEfficiency::analyze(const edm::Event& iEvent, const edm::
 
       bool isHitValid   = hit->getType()==TrackingRecHit::valid;
       bool isHitMissing = hit->getType()==TrackingRecHit::missing;
-      
+      bool isHitInactive = hit->getType()==TrackingRecHit::inactive;
+
       /*
       const SiPixelRecHit* pixhit = dynamic_cast<const SiPixelRecHit*>(hit);
       const PixelGeomDetUnit* geomdetunit = dynamic_cast<const PixelGeomDetUnit*> ( tracker->idToDet(id) );
@@ -119,10 +127,14 @@ void SiPixelPhase1TrackEfficiency::analyze(const edm::Event& iEvent, const edm::
         histo[MISSING].fill(id, &iEvent);
         histo[EFFICIENCY].fill(0, id, &iEvent);
       }
+      if (isHitInactive)   {
+        histo[INACTIVE].fill(id, &iEvent);
+      }
     }
   }
-histo[VALID  ].executePerEventHarvesting(&iEvent);
-histo[MISSING].executePerEventHarvesting(&iEvent);
+  histo[VALID   ].executePerEventHarvesting(&iEvent);
+  histo[MISSING ].executePerEventHarvesting(&iEvent);
+  histo[INACTIVE].executePerEventHarvesting(&iEvent);
 }
 
 DEFINE_FWK_MODULE(SiPixelPhase1TrackEfficiency);


### PR DESCRIPTION
- Added 2D maps of inactive hits for offline pixel tracks. 
- This is done on top of the changes from the PR #19428 