### PR TITLE
New Interface for E/gamma 2017 Pixel Matching : V2

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/TrajSeedMatcher.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/TrajSeedMatcher.h
@@ -76,31 +76,55 @@ namespace std{
 
 class TrajSeedMatcher {
 public:
-  class HitInfo {
+  class SCHitMatch {
   public:
-    HitInfo():detId_(0),
+    SCHitMatch():detId_(0),
 	      dRZ_(std::numeric_limits<float>::max()),
 	      dPhi_(std::numeric_limits<float>::max()),
-	      hit_(nullptr){}
-	      
-    HitInfo(const GlobalPoint& vtxPos,
+	      hit_(nullptr),
+	      et_(0),eta_(0),phi_(0),charge_(0),nrClus_(0){}
+
+    //does not set charge,et,nrclus
+    SCHitMatch(const GlobalPoint& vtxPos,
 	    const TrajectoryStateOnSurface& trajState,
-	    const TrackingRecHit& hit);
-    ~HitInfo()=default;
+	    const TrackingRecHit& hit
+	    );
+    ~SCHitMatch()=default;
+
+    void setExtra(float et, float eta, float phi, int charge, int nrClus){
+      et_=et;
+      eta_=eta;
+      phi_=phi;
+      charge_=charge;
+      nrClus_=nrClus;
+    }
     
     int subdetId()const{return detId_.subdetId();}
     DetId detId()const{return detId_;}
     float dRZ()const{return dRZ_;}
     float dPhi()const{return dPhi_;}
-    const GlobalPoint& pos()const{return pos_;}
+    const GlobalPoint& hitPos()const{return hitPos_;}
+    float et()const{return et_;}
+    float eta()const{return eta_;}
+    float phi()const{return phi_;}
+    int charge()const{return charge_;}
+    int nrClus()const{return nrClus_;}
     const TrackingRecHit* hit()const{return hit_;}
   private:
     DetId detId_;
-    GlobalPoint pos_;
+    GlobalPoint hitPos_;
     float dRZ_;
     float dPhi_;    
     const TrackingRecHit* hit_; //we do not own this
+    //extra quanities which are set later
+    float et_;
+    float eta_;
+    float phi_;
+    int charge_;
+    int nrClus_;
   };
+
+ 
 
   struct MatchInfo {
   public:
@@ -109,8 +133,8 @@ public:
     float dPhiPos,dPhiNeg;
     
     MatchInfo(const DetId& iDetId,
-	      float iDRZPos,float iDRZNeg,
-	      float iDPhiPos,float iDPhiNeg):
+	      float iDRZPos, float iDRZNeg,
+	      float iDPhiPos, float iDPhiNeg):
       detId(iDetId),dRZPos(iDRZPos),dRZNeg(iDRZNeg),
       dPhiPos(iDPhiPos),dPhiNeg(iDPhiNeg){}
   };
@@ -118,8 +142,8 @@ public:
   class SeedWithInfo {
   public:
     SeedWithInfo(const TrajectorySeed& seed,
-		 const std::vector<HitInfo>& posCharge,
-		 const std::vector<HitInfo>& negCharge,
+		 const std::vector<SCHitMatch>& posCharge,
+		 const std::vector<SCHitMatch>& negCharge,
 		 int nrValidLayers);
     ~SeedWithInfo()=default;
     
@@ -145,10 +169,17 @@ public:
 
   class MatchingCuts {
   public:
-    explicit MatchingCuts(const edm::ParameterSet& pset);
-    bool operator()(const HitInfo& hit,const float scEt,const float scEta)const;
+    MatchingCuts(){}
+    virtual ~MatchingCuts(){}
+    virtual bool operator()(const SCHitMatch& scHitMatch)const=0;
+  };
+
+  class MatchingCutsV1 : public MatchingCuts {
+  public:
+    explicit MatchingCutsV1(const edm::ParameterSet& pset);
+    bool operator()(const SCHitMatch& scHitMatch)const;
   private:
-    float getDRZCutValue(const float scEt,const float scEta)const;
+    float getDRZCutValue(const float scEt, const float scEta)const;
   private:
     const double dPhiMax_;
     const double dRZMax_;
@@ -156,6 +187,22 @@ public:
     const std::vector<double> dRZMaxLowEtEtaBins_; 
     const std::vector<double> dRZMaxLowEt_; 
   };
+
+  class MatchingCutsV2 : public MatchingCuts {
+  public:
+    explicit MatchingCutsV2(const edm::ParameterSet& pset);
+    bool operator()(const SCHitMatch& scHitMatch)const;
+  private:
+    size_t getBinNr(float eta)const;
+    float getCutValue(float et, float highEt, float highEtThres, float lowEtGrad)const{
+      return  highEt + std::min(0.f,et-highEtThres)*lowEtGrad;
+    }
+  private:
+    std::vector<double> dPhiHighEt_,dPhiHighEtThres_,dPhiLowEtGrad_;
+    std::vector<double> dRZHighEt_,dRZHighEtThres_,dRZLowEtGrad_;
+    std::vector<double> etaBins_;
+  };
+
 
 public:  
   explicit TrajSeedMatcher(const edm::ParameterSet& pset);
@@ -173,33 +220,40 @@ public:
   
 private:
   
-  std::vector<HitInfo> processSeed(const TrajectorySeed& seed, const GlobalPoint& candPos,
+  std::vector<SCHitMatch> processSeed(const TrajectorySeed& seed, const GlobalPoint& candPos,
 				   const GlobalPoint & vprim, const float energy, const int charge );
 
-  static float getZVtxFromExtrapolation(const GlobalPoint& primeVtxPos,const GlobalPoint& hitPos,
+  static float getZVtxFromExtrapolation(const GlobalPoint& primeVtxPos, const GlobalPoint& hitPos,
 					const GlobalPoint& candPos);
   
   bool passTrajPreSel(const GlobalPoint& hitPos,const GlobalPoint& candPos)const;
   
-  TrajSeedMatcher::HitInfo matchFirstHit(const TrajectorySeed& seed,
-					 const TrajectoryStateOnSurface& trajState,
-					 const GlobalPoint& vtxPos,
-					 const PropagatorWithMaterial& propagator);
-
-  TrajSeedMatcher::HitInfo match2ndToNthHit(const TrajectorySeed& seed,
-					    const FreeTrajectoryState& trajState,
-					    const size_t hitNr,	
-					    const GlobalPoint& prevHitPos,
+  TrajSeedMatcher::SCHitMatch matchFirstHit(const TrajectorySeed& seed,
+					    const TrajectoryStateOnSurface& trajState,
 					    const GlobalPoint& vtxPos,
 					    const PropagatorWithMaterial& propagator);
+
+  TrajSeedMatcher::SCHitMatch match2ndToNthHit(const TrajectorySeed& seed,
+					       const FreeTrajectoryState& trajState,
+					       const size_t hitNr,	
+					       const GlobalPoint& prevHitPos,
+					       const GlobalPoint& vtxPos,
+					       const PropagatorWithMaterial& propagator);
   
-  const TrajectoryStateOnSurface& getTrajStateFromVtx(const TrackingRecHit& hit,const TrajectoryStateOnSurface& initialState,const PropagatorWithMaterial& propagator);
-  const TrajectoryStateOnSurface& getTrajStateFromPoint(const TrackingRecHit& hit,const FreeTrajectoryState& initialState,const GlobalPoint& point,const PropagatorWithMaterial& propagator);
+  const TrajectoryStateOnSurface& getTrajStateFromVtx(const TrackingRecHit& hit,
+						      const TrajectoryStateOnSurface& initialState,
+						      const PropagatorWithMaterial& propagator);
+
+  const TrajectoryStateOnSurface& getTrajStateFromPoint(const TrackingRecHit& hit,
+							const FreeTrajectoryState& initialState,
+							const GlobalPoint& point,
+							const PropagatorWithMaterial& propagator);
 
   void clearCache();
 
-  bool passesMatchSel(const HitInfo& hit,const size_t hitNr,const float scEt,const float scEta)const;
-  int getNrValidLayersAlongTraj(const HitInfo& hit1,const HitInfo& hit2,
+  bool passesMatchSel(const SCHitMatch& hit, const size_t hitNr)const;
+
+  int getNrValidLayersAlongTraj(const SCHitMatch& hit1, const SCHitMatch& hit2,
 				const GlobalPoint& candPos,
 				const GlobalPoint & vprim, 
 				const float energy, const int charge);
@@ -226,7 +280,7 @@ private:
   std::string detLayerGeomLabel_;
 
   bool useRecoVertex_;
-  std::vector<MatchingCuts> matchingCuts_;
+  std::vector<std::unique_ptr<MatchingCuts> > matchingCuts_;
   
   //these two varibles determine how hits we require 
   //based on how many valid layers we had

--- a/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
@@ -30,11 +30,21 @@ TrajSeedMatcher::TrajSeedMatcher(const edm::ParameterSet& pset):
   detLayerGeomLabel_ = pset.getParameter<std::string>("detLayerGeom");
   const auto cutsPSets=pset.getParameter<std::vector<edm::ParameterSet> >("matchingCuts");
   for(const auto & cutPSet : cutsPSets){
-    matchingCuts_.push_back(MatchingCuts(cutPSet));
+    int version=cutPSet.getParameter<int>("version");
+    switch(version){
+    case 1:
+      matchingCuts_.emplace_back(std::make_unique<MatchingCutsV1>(cutPSet));
+      break;
+    case 2:
+      matchingCuts_.emplace_back(std::make_unique<MatchingCutsV2>(cutPSet));
+      break;
+    default:
+      throw cms::Exception("InvalidConfig") <<" Error TrajSeedMatcher::TrajSeedMatcher pixel match cuts version "<<version<<" not recognised"<<std::endl;
+    }
   }
  
   if(minNrHitsValidLayerBins_.size()+1!=minNrHits_.size()){  
-    throw cms::Exception("InvalidConfig")<<" minNrHitsValidLayerBins should be 1 less than minNrHits when its "<<minNrHitsValidLayerBins_.size()<<" vs "<<minNrHits_.size();
+    throw cms::Exception("InvalidConfig")<<" TrajSeedMatcher::TrajSeedMatcher minNrHitsValidLayerBins should be 1 less than minNrHits when its "<<minNrHitsValidLayerBins_.size()<<" vs "<<minNrHits_.size();
   }
 }
 
@@ -47,19 +57,31 @@ edm::ParameterSetDescription TrajSeedMatcher::makePSetDescription()
   desc.add<std::vector<int> >("minNrHitsValidLayerBins",{4});
   desc.add<std::vector<unsigned int> >("minNrHits",{2,3});
   
-
   edm::ParameterSetDescription cutsDesc;
-  cutsDesc.add<double>("dPhiMax",0.04);
-  cutsDesc.add<double>("dRZMax",0.09);
-  cutsDesc.add<double>("dRZMaxLowEtThres",20.);
-  cutsDesc.add<std::vector<double> >("dRZMaxLowEtEtaBins",std::vector<double>{1.,1.5});
-  cutsDesc.add<std::vector<double> >("dRZMaxLowEt",std::vector<double>{0.09,0.15,0.09});
+  auto cutDescCases = 
+    1 >> 
+    (edm::ParameterDescription<double>("dPhiMax",0.04,true) and
+     edm::ParameterDescription<double>("dRZMax",0.09,true) and
+     edm::ParameterDescription<double>("dRZMaxLowEtThres",20.,true) and
+     edm::ParameterDescription<std::vector<double> >("dRZMaxLowEtEtaBins",std::vector<double>{1.,1.5},true) and
+     edm::ParameterDescription<std::vector<double> >("dRZMaxLowEt",std::vector<double>{0.09,0.15,0.09},true)) or
+    2 >> 
+    (edm::ParameterDescription<std::vector<double> >("dPhiMaxHighEt",{0.003},true) and
+     edm::ParameterDescription<std::vector<double> >("dPhiMaxHighEtThres",{0.0},true) and
+     edm::ParameterDescription<std::vector<double> >("dPhiMaxLowEtGrad",{0.0},true) and
+     edm::ParameterDescription<std::vector<double> >("dRZMaxHighEt",{0.005},true) and
+     edm::ParameterDescription<std::vector<double> >("dRZMaxHighEtThres",{30},true) and
+     edm::ParameterDescription<std::vector<double> >("dRZMaxLowEtGrad",{-0.002},true) and
+     edm::ParameterDescription<std::vector<double> >("etaBins",{},true));
+  cutsDesc.ifValue(edm::ParameterDescription<int>("version",1,true), std::move(cutDescCases));
+
   edm::ParameterSet defaults;
   defaults.addParameter<double>("dPhiMax",0.04);
   defaults.addParameter<double>("dRZMax",0.09);
   defaults.addParameter<double>("dRZMaxLowEtThres",0.09);
   defaults.addParameter<std::vector<double> >("dRZMaxLowEtEtaBins",std::vector<double>{1.,1.5});
   defaults.addParameter<std::vector<double> >("dRZMaxLowEt",std::vector<double>{0.09,0.09,0.09});
+  defaults.addParameter<int>("version",1);
   desc.addVPSet("matchingCuts",cutsDesc,std::vector<edm::ParameterSet>{defaults,defaults,defaults});
   return desc;
 }
@@ -89,8 +111,8 @@ TrajSeedMatcher::compatibleSeeds(const TrajectorySeedCollection& seeds, const Gl
   
   std::vector<SeedWithInfo> matchedSeeds;
   for(const auto& seed : seeds) {
-    std::vector<HitInfo> matchedHitsNeg = processSeed(seed,candPos,vprim,energy,-1);
-    std::vector<HitInfo> matchedHitsPos = processSeed(seed,candPos,vprim,energy,+1);
+    std::vector<SCHitMatch> matchedHitsNeg = processSeed(seed,candPos,vprim,energy,-1);
+    std::vector<SCHitMatch> matchedHitsPos = processSeed(seed,candPos,vprim,energy,+1);
     int nrValidLayersPos = 0;
     int nrValidLayersNeg = 0;
     if(matchedHitsNeg.size()>=2){
@@ -128,9 +150,9 @@ TrajSeedMatcher::compatibleSeeds(const TrajectorySeedCollection& seeds, const Gl
 //checks if the hits of the seed match within requested selection
 //matched hits are required to be consecutive, as soon as hit isnt matched,
 //the function returns, it doesnt allow skipping hits
-std::vector<TrajSeedMatcher::HitInfo>
+std::vector<TrajSeedMatcher::SCHitMatch>
 TrajSeedMatcher::processSeed(const TrajectorySeed& seed, const GlobalPoint& candPos,
-			      const GlobalPoint & vprim, const float energy, const int charge )
+			     const GlobalPoint & vprim, const float energy, const int charge )
 {
   const float candEta = candPos.eta();
   const float candEt = energy*std::sin(candPos.theta());
@@ -140,24 +162,26 @@ TrajSeedMatcher::processSeed(const TrajectorySeed& seed, const GlobalPoint& cand
   TrajectoryStateOnSurface initialTrajState(trajStateFromVtx,*bpb(trajStateFromVtx.position(), 
 								  trajStateFromVtx.momentum()));
  
-  std::vector<HitInfo> matchedHits;
-  HitInfo firstHit = matchFirstHit(seed,initialTrajState,vprim,*backwardPropagator_);
-  if(passesMatchSel(firstHit,0,candEt,candEta)){
+  std::vector<SCHitMatch> matchedHits;
+  SCHitMatch firstHit = matchFirstHit(seed,initialTrajState,vprim,*backwardPropagator_);
+  firstHit.setExtra(candEt,candEta,candPos.phi(),charge,1);
+  if(passesMatchSel(firstHit,0)){
     matchedHits.push_back(firstHit);
 
     //now we can figure out the z vertex
-    double zVertex = useRecoVertex_ ? vprim.z() : getZVtxFromExtrapolation(vprim,firstHit.pos(),candPos);
+    double zVertex = useRecoVertex_ ? vprim.z() : getZVtxFromExtrapolation(vprim,firstHit.hitPos(),candPos);
     GlobalPoint vertex(vprim.x(),vprim.y(),zVertex);
     
-    FreeTrajectoryState firstHitFreeTraj = FTSFromVertexToPointFactory::get(*magField_, firstHit.pos(), 
+    FreeTrajectoryState firstHitFreeTraj = FTSFromVertexToPointFactory::get(*magField_, firstHit.hitPos(), 
 									    vertex, energy, charge) ;
  
-    GlobalPoint prevHitPos = firstHit.pos();
+    GlobalPoint prevHitPos = firstHit.hitPos();
     for(size_t hitNr=1;hitNr<matchingCuts_.size() && hitNr<seed.nHits();hitNr++){
-      HitInfo hit = match2ndToNthHit(seed,firstHitFreeTraj,hitNr,prevHitPos,vertex,*forwardPropagator_);
-      if(passesMatchSel(hit,hitNr,candEt,candEta)){
+      SCHitMatch hit = match2ndToNthHit(seed,firstHitFreeTraj,hitNr,prevHitPos,vertex,*forwardPropagator_);
+      hit.setExtra(candEt,candEta,candPos.phi(),charge,1);
+      if(passesMatchSel(hit,hitNr)){
 	matchedHits.push_back(hit);
-	prevHitPos = hit.pos();
+	prevHitPos = hit.hitPos();
       }else break;
     }
   }
@@ -165,8 +189,8 @@ TrajSeedMatcher::processSeed(const TrajectorySeed& seed, const GlobalPoint& cand
 }
 
 // compute the z vertex from the candidate position and the found pixel hit
-float TrajSeedMatcher::getZVtxFromExtrapolation(const GlobalPoint& primeVtxPos,const GlobalPoint& hitPos,
-						 const GlobalPoint& candPos)
+float TrajSeedMatcher::getZVtxFromExtrapolation(const GlobalPoint& primeVtxPos, const GlobalPoint& hitPos,
+						const GlobalPoint& candPos)
 {
   auto sq = [](float x){return x*x;};
   auto calRDiff = [sq](const GlobalPoint& p1,const GlobalPoint& p2){
@@ -177,7 +201,7 @@ float TrajSeedMatcher::getZVtxFromExtrapolation(const GlobalPoint& primeVtxPos,c
   return hitPos.z() - r1Diff*(candPos.z()-hitPos.z())/r2Diff;
 }
 
-bool TrajSeedMatcher::passTrajPreSel(const GlobalPoint& hitPos,const GlobalPoint& candPos)const
+bool TrajSeedMatcher::passTrajPreSel(const GlobalPoint& hitPos, const GlobalPoint& candPos)const
 {
   float dt = hitPos.x()*candPos.x()+hitPos.y()*candPos.y();
   if (dt<0) return false;
@@ -185,7 +209,9 @@ bool TrajSeedMatcher::passTrajPreSel(const GlobalPoint& hitPos,const GlobalPoint
   return true;
 }
 
-const TrajectoryStateOnSurface& TrajSeedMatcher::getTrajStateFromVtx(const TrackingRecHit& hit,const TrajectoryStateOnSurface& initialState,const PropagatorWithMaterial& propagator)
+const TrajectoryStateOnSurface& TrajSeedMatcher::getTrajStateFromVtx(const TrackingRecHit& hit,
+								     const TrajectoryStateOnSurface& initialState,
+								     const PropagatorWithMaterial& propagator)
 {
   auto& trajStateFromVtxCache = initialState.charge()==1 ? trajStateFromVtxPosChargeCache_ :
                                                            trajStateFromVtxNegChargeCache_;
@@ -200,7 +226,10 @@ const TrajectoryStateOnSurface& TrajSeedMatcher::getTrajStateFromVtx(const Track
   }
 }
 
-const TrajectoryStateOnSurface& TrajSeedMatcher::getTrajStateFromPoint(const TrackingRecHit& hit,const FreeTrajectoryState& initialState,const GlobalPoint& point,const PropagatorWithMaterial& propagator)
+const TrajectoryStateOnSurface& TrajSeedMatcher::getTrajStateFromPoint(const TrackingRecHit& hit,
+								       const FreeTrajectoryState& initialState,
+								       const GlobalPoint& point,
+								       const PropagatorWithMaterial& propagator)
 {
   
   auto& trajStateFromPointCache = initialState.charge()==1 ? trajStateFromPointPosChargeCache_ :
@@ -216,35 +245,39 @@ const TrajectoryStateOnSurface& TrajSeedMatcher::getTrajStateFromPoint(const Tra
   }
 }
 
-TrajSeedMatcher::HitInfo TrajSeedMatcher::matchFirstHit(const TrajectorySeed& seed,const TrajectoryStateOnSurface& initialState,const GlobalPoint& vtxPos,const PropagatorWithMaterial& propagator)
+TrajSeedMatcher::SCHitMatch TrajSeedMatcher::matchFirstHit(const TrajectorySeed& seed,
+							   const TrajectoryStateOnSurface& initialState,
+							   const GlobalPoint& vtxPos,
+							   const PropagatorWithMaterial& propagator)
 {
   const TrajectorySeed::range& hits = seed.recHits();
   auto hitIt = hits.first;
 
   if(hitIt->isValid()){
     const TrajectoryStateOnSurface& trajStateFromVtx = getTrajStateFromVtx(*hitIt,initialState,propagator);
-    if(trajStateFromVtx.isValid()) return HitInfo(vtxPos,trajStateFromVtx,*hitIt);  
+    if(trajStateFromVtx.isValid()) return SCHitMatch(vtxPos,trajStateFromVtx,*hitIt);  
   }
-  return HitInfo();
+  return SCHitMatch();
 }
 
-TrajSeedMatcher::HitInfo TrajSeedMatcher::match2ndToNthHit(const TrajectorySeed& seed,
-							     const FreeTrajectoryState& initialState,
-							     const size_t hitNr,
-							     const GlobalPoint& prevHitPos,
-							     const GlobalPoint& vtxPos,
-							     const PropagatorWithMaterial& propagator)
+TrajSeedMatcher::SCHitMatch TrajSeedMatcher::match2ndToNthHit(const TrajectorySeed& seed,
+							   const FreeTrajectoryState& initialState,
+							   const size_t hitNr,
+							   const GlobalPoint& prevHitPos,
+							   const GlobalPoint& vtxPos,
+							   const PropagatorWithMaterial& propagator)
 {
   const TrajectorySeed::range& hits = seed.recHits();
   auto hitIt = hits.first+hitNr;
   
   if(hitIt->isValid()){
     const TrajectoryStateOnSurface& trajState = getTrajStateFromPoint(*hitIt,initialState,prevHitPos,propagator);
+    
     if(trajState.isValid()){
-      return HitInfo(vtxPos,trajState,*hitIt);  
+      return SCHitMatch(vtxPos,trajState,*hitIt);  
     }
   }
-  return HitInfo();
+  return SCHitMatch();
   
 }
 
@@ -256,31 +289,30 @@ void TrajSeedMatcher::clearCache()
   trajStateFromPointNegChargeCache_.clear();
 }
 
-bool TrajSeedMatcher::passesMatchSel(const TrajSeedMatcher::HitInfo& hit,const size_t hitNr,float scEt,float scEta)const
+bool TrajSeedMatcher::passesMatchSel(const TrajSeedMatcher::SCHitMatch& hit, const size_t hitNr)const
 {
   if(hitNr<matchingCuts_.size()){
-    return matchingCuts_[hitNr](hit,scEt,scEta);
+    return (*matchingCuts_[hitNr])(hit);
   }else{
     throw cms::Exception("LogicError") <<" Error, attempting to apply selection to hit "<<hitNr<<" but only cuts for "<<matchingCuts_.size()<<" defined";
   }
-  
 }
 
-int TrajSeedMatcher::getNrValidLayersAlongTraj(const HitInfo& hit1,const HitInfo& hit2,
+int TrajSeedMatcher::getNrValidLayersAlongTraj(const SCHitMatch& hit1, const SCHitMatch& hit2,
 						const GlobalPoint& candPos,
 						const GlobalPoint & vprim, 
 						const float energy, const int charge)
 {
-  double zVertex = useRecoVertex_ ? vprim.z() : getZVtxFromExtrapolation(vprim,hit1.pos(),candPos);
+  double zVertex = useRecoVertex_ ? vprim.z() : getZVtxFromExtrapolation(vprim,hit1.hitPos(),candPos);
   GlobalPoint vertex(vprim.x(),vprim.y(),zVertex);
   
-  FreeTrajectoryState firstHitFreeTraj = FTSFromVertexToPointFactory::get(*magField_,hit1.pos(), 
+  FreeTrajectoryState firstHitFreeTraj = FTSFromVertexToPointFactory::get(*magField_,hit1.hitPos(), 
 									  vertex, energy, charge);
-  const TrajectoryStateOnSurface& secondHitTraj = getTrajStateFromPoint(*hit2.hit(),firstHitFreeTraj,hit1.pos(),*forwardPropagator_);
+  const TrajectoryStateOnSurface& secondHitTraj = getTrajStateFromPoint(*hit2.hit(),firstHitFreeTraj,hit1.hitPos(),*forwardPropagator_);
   return getNrValidLayersAlongTraj(hit2.hit()->geographicalId(),secondHitTraj); 
 }
 
-int TrajSeedMatcher::getNrValidLayersAlongTraj(const DetId& hitId,const TrajectoryStateOnSurface& hitTrajState)const
+int TrajSeedMatcher::getNrValidLayersAlongTraj(const DetId& hitId, const TrajectoryStateOnSurface& hitTrajState)const
 {
   
   const DetLayer* detLayer = detLayerGeom_->idToLayer(hitId);
@@ -308,8 +340,8 @@ int TrajSeedMatcher::getNrValidLayersAlongTraj(const DetId& hitId,const Trajecto
   return nrValidLayers;
 }
 						 
-bool TrajSeedMatcher::layerHasValidHits(const DetLayer& layer,const TrajectoryStateOnSurface& hitSurState,
-					 const Propagator& propToLayerFromState)const
+bool TrajSeedMatcher::layerHasValidHits(const DetLayer& layer, const TrajectoryStateOnSurface& hitSurState,
+					const Propagator& propToLayerFromState)const
 {
   //FIXME: do not hardcode with werid magic numbers stolen from ancient tracking code
   //its taken from https://cmssdt.cern.ch/dxr/CMSSW/source/RecoTracker/TrackProducer/interface/TrackProducerBase.icc#165
@@ -336,14 +368,15 @@ size_t TrajSeedMatcher::getNrHitsRequired(const int nrValidLayers)const
   
 }
 
-TrajSeedMatcher::HitInfo::HitInfo(const GlobalPoint& vtxPos,
-				   const TrajectoryStateOnSurface& trajState,
-				   const TrackingRecHit& hit):
+TrajSeedMatcher::SCHitMatch::SCHitMatch(const GlobalPoint& vtxPos,
+					const TrajectoryStateOnSurface& trajState,
+					const TrackingRecHit& hit):
   detId_(hit.geographicalId()),
-  pos_(hit.globalPosition()),
-  hit_(&hit)
+  hitPos_(hit.globalPosition()),
+  hit_(&hit),
+  et_(0),eta_(0),phi_(0),charge_(0),nrClus_(0)
 {
-  EleRelPointPair pointPair(pos_,trajState.globalParameters().position(),vtxPos);
+  EleRelPointPair pointPair(hitPos_,trajState.globalParameters().position(),vtxPos);
   dRZ_ = detId_.subdetId()==PixelSubdetector::PixelBarrel ? pointPair.dZ() : pointPair.dPerp();
   dPhi_ = pointPair.dPhi();
 }
@@ -351,8 +384,8 @@ TrajSeedMatcher::HitInfo::HitInfo(const GlobalPoint& vtxPos,
 
 TrajSeedMatcher::SeedWithInfo::
 SeedWithInfo(const TrajectorySeed& seed,
-	     const std::vector<HitInfo>& posCharge,
-	     const std::vector<HitInfo>& negCharge,
+	     const std::vector<SCHitMatch>& posCharge,
+	     const std::vector<SCHitMatch>& negCharge,
 	     int nrValidLayers):
   seed_(seed),nrValidLayers_(nrValidLayers)
 {
@@ -374,7 +407,7 @@ SeedWithInfo(const TrajectorySeed& seed,
   }
 }
 
-TrajSeedMatcher::MatchingCuts::MatchingCuts(const edm::ParameterSet& pset):
+TrajSeedMatcher::MatchingCutsV1::MatchingCutsV1(const edm::ParameterSet& pset):
   dPhiMax_(pset.getParameter<double>("dPhiMax")),
   dRZMax_(pset.getParameter<double>("dRZMax")),
   dRZMaxLowEtThres_(pset.getParameter<double>("dRZMaxLowEtThres")),
@@ -386,17 +419,17 @@ TrajSeedMatcher::MatchingCuts::MatchingCuts(const edm::ParameterSet& pset):
   }
 }
 
-bool TrajSeedMatcher::MatchingCuts::operator()(const TrajSeedMatcher::HitInfo& hit,const float scEt,const float scEta)const
+bool TrajSeedMatcher::MatchingCutsV1::operator()(const TrajSeedMatcher::SCHitMatch& scHitMatch)const
 {
-  if(dPhiMax_>=0 && std::abs(hit.dPhi()) > dPhiMax_) return false;
+  if(dPhiMax_>=0 && std::abs(scHitMatch.dPhi()) > dPhiMax_) return false;
   
-  const float dRZMax = getDRZCutValue(scEt,scEta);
-  if(dRZMax_>=0 && std::abs(hit.dRZ()) > dRZMax) return false;
+  const float dRZMax = getDRZCutValue(scHitMatch.et(),scHitMatch.eta());
+  if(dRZMax_>=0 && std::abs(scHitMatch.dRZ()) > dRZMax) return false;
 	       
   return true;
 }
 
-float TrajSeedMatcher::MatchingCuts::getDRZCutValue(const float scEt,const float scEta)const
+float TrajSeedMatcher::MatchingCutsV1::getDRZCutValue(const float scEt, const float scEta)const
 {
   if(scEt>=dRZMaxLowEtThres_) return dRZMax_;
   else{
@@ -407,3 +440,47 @@ float TrajSeedMatcher::MatchingCuts::getDRZCutValue(const float scEt,const float
     return dRZMaxLowEt_.back();
   }
 }
+
+TrajSeedMatcher::MatchingCutsV2::MatchingCutsV2(const edm::ParameterSet& pset):
+  dPhiHighEt_(pset.getParameter<std::vector<double> >("dPhiMaxHighEt")),
+  dPhiHighEtThres_(pset.getParameter<std::vector<double> >("dPhiMaxHighEtThres")),
+  dPhiLowEtGrad_(pset.getParameter<std::vector<double> >("dPhiMaxLowEtGrad")),
+  dRZHighEt_(pset.getParameter<std::vector<double> >("dRZMaxHighEt")),
+  dRZHighEtThres_(pset.getParameter<std::vector<double> >("dRZMaxHighEtThres")),
+  dRZLowEtGrad_(pset.getParameter<std::vector<double> >("dRZMaxLowEtGrad")),
+  etaBins_(pset.getParameter<std::vector<double> >("etaBins"))
+{
+  auto binSizeCheck = [](size_t sizeEtaBins,const std::vector<double>& vec,const std::string& name){
+    if(vec.size()!=sizeEtaBins+1){ 
+      throw cms::Exception("InvalidConfig")<<" when constructing TrajSeedMatcher::MatchingCutsV2 "<< name<<" has "<<vec.size()<<" bins, it should be equal to #bins of etaBins+1"<<sizeEtaBins+1;
+    }
+  };
+  binSizeCheck(etaBins_.size(),dPhiHighEt_,"dPhiMaxHighEt");
+  binSizeCheck(etaBins_.size(),dPhiHighEtThres_,"dPhiMaxHighEtThres");
+  binSizeCheck(etaBins_.size(),dPhiLowEtGrad_,"dPhiMaxLowEtGrad");
+  binSizeCheck(etaBins_.size(),dRZHighEt_,"dRZMaxHighEt");
+  binSizeCheck(etaBins_.size(),dRZHighEtThres_,"dRZMaxHighEtThres");
+  binSizeCheck(etaBins_.size(),dRZLowEtGrad_,"dRZMaxLowEtGrad");
+}
+
+bool TrajSeedMatcher::MatchingCutsV2::operator()(const TrajSeedMatcher::SCHitMatch& scHitMatch)const
+{
+  size_t binNr=getBinNr(scHitMatch.eta());
+  float dPhiMax = getCutValue(scHitMatch.et(),dPhiHighEt_[binNr],dPhiHighEtThres_[binNr],dPhiLowEtGrad_[binNr]); 
+  if(dPhiMax>=0 && std::abs(scHitMatch.dPhi()) > dPhiMax) return false;  
+  float dRZMax = getCutValue(scHitMatch.et(),dRZHighEt_[binNr],dRZHighEtThres_[binNr],dRZLowEtGrad_[binNr]);
+  if(dRZMax>=0 && std::abs(scHitMatch.dRZ()) > dRZMax) return false;
+  
+  return true;
+}
+
+//eta bins is exactly 1 smaller than the vectors which will be accessed by this bin nr
+size_t TrajSeedMatcher::MatchingCutsV2::getBinNr(float eta)const
+{
+  const float absEta = std::abs(eta);
+  for(size_t etaNr=0;etaNr<etaBins_.size();etaNr++){
+    if(absEta<etaBins_[etaNr]) return etaNr;
+  }
+  return etaBins_.size();
+}
+


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/19263

Dear All,

I missed that the master switched from 93X to 92X while the above PR was in progress. We are preping to use this feature online late next week (basically as soon as we are convinced the alignment is good enough to be able to use it). As such, could we back port this PR to a 92X release. 

Thanks and sorry for any hassle this causes.
Sam

@Martin-Grunewald as you may not see it as its RECO code but used exclusively in the HLT (for now, the plan is to use it reco eventually)
