### PR TITLE
Use constexpr to fix clang compilation

### DIFF
--- a/RecoBTau/JetTagComputer/interface/GenericMVAJetTagComputerWrapper.h
+++ b/RecoBTau/JetTagComputer/interface/GenericMVAJetTagComputerWrapper.h
@@ -32,7 +32,7 @@
 
 namespace btau_dummy {
 	struct Null {};
-	extern const char none[];
+	constexpr const char none[] = "";
 }
 
 // 4 named TagInfos


### PR DESCRIPTION
Clang needs the pointer to a char used as a template parameter
to be declared constexpr.