### PR TITLE
Change to include HLT Muon filtering on DT DQM Online

### DIFF
--- a/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
@@ -25,6 +25,8 @@ process.dqmEnv.subSystemFolder = 'DT'
 process.dqmSaver.tag = "DT"
 #-----------------------------
 
+#Enable HLT*Mu* filtering to monitor only on Muon events
+process.source.SelectEvents = cms.untracked.vstring("HLT*Mu*")
 
 # DT reco and DQM sequences
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")


### PR DESCRIPTION
Expected change: reduction of events considered on DT DQM Online, only events which fired HLT*Mu* paths hence less background/noise in plots