### PR TITLE
Changed z-window width for the vertex search

### DIFF
--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -132,7 +132,7 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     process.recopixelvertexing = cms.Sequence(process.pixelTracksSequence + process.pixelVertices)
     process.pixelVertices.TkFilterParameters.minPt = process.pixelTracksTrackingRegions.RegionPSet.ptMin
     process.pixelTracksTrackingRegions.RegionPSet.originRadius = 0.4
-    process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 6
+    process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 15
     process.pixelTracksTrackingRegions.RegionPSet.originXPos = 0.08
     process.pixelTracksTrackingRegions.RegionPSet.originYPos = -0.03
     process.pixelTracksTrackingRegions.RegionPSet.originZPos = 1


### PR DESCRIPTION
I changed the z-window width for the vertex search because the z distribution of the vertex z-position had sharp cuts both on the left and on right-hand sides.
- Mauro.