### PR TITLE
Embedding developments: New feature electron embedding and bugfixes

### DIFF
--- a/GeneratorInterface/Core/interface/EmbeddingHepMCFilter.h
+++ b/GeneratorInterface/Core/interface/EmbeddingHepMCFilter.h
@@ -17,7 +17,7 @@ class EmbeddingHepMCFilter : public BaseHepMCFilter{
         const int muonPDGID_ = 13;
         const int electron_neutrino_PDGID_ = 12;
         const int electronPDGID_ = 11;
-	const int ZPDGID_ = 23;
+        const int ZPDGID_ = 23;
         
         enum class TauDecayMode : int
         {
@@ -74,11 +74,10 @@ class EmbeddingHepMCFilter : public BaseHepMCFilter{
         
         std::vector<CutsContainer> cuts_;
         DecayChannel DecayChannel_;
-	
-	virtual void fill_cut(std::string cut_string, EmbeddingHepMCFilter::DecayChannel &dc, CutsContainer &cut);
-	virtual void fill_cuts(std::string cut_string, EmbeddingHepMCFilter::DecayChannel &dc);
-	
-	
+
+        virtual void fill_cut(std::string cut_string, EmbeddingHepMCFilter::DecayChannel &dc, CutsContainer &cut);
+        virtual void fill_cuts(std::string cut_string, EmbeddingHepMCFilter::DecayChannel &dc);
+
         virtual void decay_and_sump4Vis(HepMC::GenParticle* particle, reco::Candidate::LorentzVector &p4Vis);
         virtual void sort_by_convention(std::vector<reco::Candidate::LorentzVector> &p4VisPair);
         virtual bool apply_cuts(std::vector<reco::Candidate::LorentzVector> &p4VisPair);

--- a/GeneratorInterface/Core/src/EmbeddingHepMCFilter.cc
+++ b/GeneratorInterface/Core/src/EmbeddingHepMCFilter.cc
@@ -47,40 +47,46 @@ EmbeddingHepMCFilter::filter(const HepMC::GenEvent* evt)
     //Reset DecayChannel_ and p4VisPair_ at the beginning of each event.
     DecayChannel_.reset();
     std::vector<reco::Candidate::LorentzVector> p4VisPair_;
-    
+
     // Going through the particle list. Mother particles are allways before their children. 
     // One can stop the loop after the second tau is reached and processed.
     for ( HepMC::GenEvent::particle_const_iterator particle = evt->particles_begin(); particle != evt->particles_end(); ++particle )
     {
-	int mom_id = 0; // No particle available with PDG ID 0
-	if ((*particle)->production_vertex() != 0){ // search for the mom via the production_vertex
-	  if ((*particle)->production_vertex()->particles_in_const_begin() != (*particle)->production_vertex()->particles_in_const_end()){ 
-	    mom_id =  (*(*particle)->production_vertex()->particles_in_const_begin())->pdg_id(); // mom was found
-	  }
-	}
-	
-	if (std::abs((*particle)->pdg_id()) == tauonPDGID_  && mom_id == ZPDGID_)
-	{
-          reco::Candidate::LorentzVector p4Vis;
-          decay_and_sump4Vis((*particle), p4Vis); // recursive access to final states.
-          p4VisPair_.push_back(p4Vis);	  
+      int mom_id = 0; // No particle available with PDG ID 0
+      if ((*particle)->production_vertex() != 0){ // search for the mom via the production_vertex
+        if ((*particle)->production_vertex()->particles_in_const_begin() != (*particle)->production_vertex()->particles_in_const_end()){
+          mom_id =  (*(*particle)->production_vertex()->particles_in_const_begin())->pdg_id(); // mom was found
         }
-        else if (std::abs((*particle)->pdg_id()) == muonPDGID_  && mom_id == ZPDGID_) // Also handle the option when Z-> mumu
-	{
-          reco::Candidate::LorentzVector p4Vis = (reco::Candidate::LorentzVector) (*particle)->momentum();
-	  DecayChannel_.fill(TauDecayMode::Muon); // take the muon cuts
-          p4VisPair_.push_back(p4Vis);
-	}
+      }
+
+      if (std::abs((*particle)->pdg_id()) == tauonPDGID_  && mom_id == ZPDGID_) {
+        reco::Candidate::LorentzVector p4Vis;
+        decay_and_sump4Vis((*particle), p4Vis); // recursive access to final states.
+        p4VisPair_.push_back(p4Vis);	  
+      } else if (std::abs((*particle)->pdg_id()) == muonPDGID_  && mom_id == ZPDGID_) {// Also handle the option when Z-> mumu
+        reco::Candidate::LorentzVector p4Vis = (reco::Candidate::LorentzVector) (*particle)->momentum();
+        DecayChannel_.fill(TauDecayMode::Muon); // take the muon cuts
+        p4VisPair_.push_back(p4Vis);
+      } else if (std::abs((*particle)->pdg_id()) == electronPDGID_  && mom_id == ZPDGID_) {// Also handle the option when Z-> ee
+        reco::Candidate::LorentzVector p4Vis = (reco::Candidate::LorentzVector) (*particle)->momentum();
+        DecayChannel_.fill(TauDecayMode::Electron); // take the electron cuts
+        p4VisPair_.push_back(p4Vis);
+      }
 
     }
     // Putting DecayChannel_ in default convention:
     // For mixed decay channels use the Electron_Muon, Electron_Hadronic, Muon_Hadronic convention.
     // For symmetric decay channels (e.g. Muon_Muon) use Leading_Trailing convention with respect to Pt.
-    sort_by_convention(p4VisPair_);
-    edm::LogInfo("EmbeddingHepMCFilter") << "Quantities of the visible decay products:"
-    << "\tPt's: " << " 1st " << p4VisPair_[0].Pt() << ", 2nd " << p4VisPair_[1].Pt()
-    << "\tEta's: " << " 1st " << p4VisPair_[0].Eta() << ", 2nd " << p4VisPair_[1].Eta()
-    << " decay channel: " << return_mode(DecayChannel_.first)<< return_mode(DecayChannel_.second);
+    if (p4VisPair_.size() == 2) {
+      sort_by_convention(p4VisPair_);
+      edm::LogInfo("EmbeddingHepMCFilter") << "Quantities of the visible decay products:"
+      << "\tPt's: " << " 1st " << p4VisPair_[0].Pt() << ", 2nd " << p4VisPair_[1].Pt()
+      << "\tEta's: " << " 1st " << p4VisPair_[0].Eta() << ", 2nd " << p4VisPair_[1].Eta()
+      << " decay channel: " << return_mode(DecayChannel_.first)<< return_mode(DecayChannel_.second);
+    }
+    else {
+      edm::LogError("EmbeddingHepMCFilter") << "Size less non equal two";
+    }
     
     return apply_cuts(p4VisPair_);
 }
@@ -155,20 +161,20 @@ EmbeddingHepMCFilter::apply_cuts(std::vector<reco::Candidate::LorentzVector> &p4
 {     
     for (std::vector<CutsContainer>::const_iterator cut = cuts_.begin(); cut != cuts_.end(); ++cut)  
     {
-        if(DecayChannel_.first == cut->decaychannel.first && DecayChannel_.second ==  cut->decaychannel.second){ // First the match to the decay channel
-            edm::LogInfo("EmbeddingHepMCFilter") << "Cut pt1 = " << cut->pt1 << " pt2 = " << cut->pt2
-            << " abs(eta1) = " << cut->eta1 << " abs(eta2) = " << cut->eta2
-            << " decay channel: " << return_mode(cut->decaychannel.first)
-            << return_mode(cut->decaychannel.second);
-            
-	    if((cut->pt1 == -1. || (p4VisPair[0].Pt() > cut->pt1)) &&
-	       (cut->pt2 == -1. || (p4VisPair[1].Pt() > cut->pt2)) &&
-	       (cut->eta1 == -1.|| (std::abs(p4VisPair[0].Eta()) < cut->eta1)) &&
-	       (cut->eta2 == -1.|| (std::abs(p4VisPair[1].Eta()) < cut->eta2))){
-		  edm::LogInfo("EmbeddingHepMCFilter") << "This cut was passed (Stop here and take the event)";
-		  return true;
-	    }
-	}
+      if(DecayChannel_.first == cut->decaychannel.first && DecayChannel_.second ==  cut->decaychannel.second){ // First the match to the decay channel
+        edm::LogInfo("EmbeddingHepMCFilter") << "Cut pt1 = " << cut->pt1 << " pt2 = " << cut->pt2
+          << " abs(eta1) = " << cut->eta1 << " abs(eta2) = " << cut->eta2
+          << " decay channel: " << return_mode(cut->decaychannel.first)
+          << return_mode(cut->decaychannel.second);
+          
+        if((cut->pt1 == -1. || (p4VisPair[0].Pt() > cut->pt1)) &&
+           (cut->pt2 == -1. || (p4VisPair[1].Pt() > cut->pt2)) &&
+           (cut->eta1 == -1.|| (std::abs(p4VisPair[0].Eta()) < cut->eta1)) &&
+           (cut->eta2 == -1.|| (std::abs(p4VisPair[1].Eta()) < cut->eta2))){
+          edm::LogInfo("EmbeddingHepMCFilter") << "This cut was passed (Stop here and take the event)";
+          return true;
+        }
+      }
     }
     return false;
 }

--- a/TauAnalysis/MCEmbeddingTools/plugins/CollectionMerger.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/CollectionMerger.cc
@@ -46,7 +46,7 @@ void  CollectionMerger<T1,T2>::fill_output_obj_tracker(std::unique_ptr<MergeColl
 
     std::map<uint32_t, std::vector<BaseHit> >   output_map;
   // First merge the collections with the help of the output map
-  for (auto inputCollection : inputCollections){
+  for (auto const & inputCollection : inputCollections){
    for ( typename MergeCollection::const_iterator clustSet = inputCollection->begin(); clustSet!= inputCollection->end(); ++clustSet ) {
       DetId detIdObject( clustSet->detId() );
       for (typename edmNew::DetSet<BaseHit>::const_iterator clustIt = clustSet->begin(); clustIt != clustSet->end(); ++clustIt ) {
@@ -73,7 +73,7 @@ void  CollectionMerger<T1,T2>::fill_output_obj_calo(std::unique_ptr<MergeCollect
 {
   std::map<uint32_t, BaseHit >   output_map;
   // First merge the two collections again
-  for (auto inputCollection : inputCollections){
+  for (auto const & inputCollection : inputCollections){
     for ( typename MergeCollection::const_iterator recHit = inputCollection->begin(); recHit!= inputCollection->end(); ++recHit ) {
       DetId detIdObject( recHit->detid().rawId() );
       T2 *akt_calo_obj = &output_map[detIdObject.rawId()];
@@ -98,7 +98,7 @@ void  CollectionMerger<T1,T2>::fill_output_obj_muonchamber(std::unique_ptr<Merge
 {
   std::map<uint32_t, std::vector<BaseHit> >   output_map;
   // First merge the collections with the help of the output map
-  for (auto inputCollection : inputCollections){
+  for (auto const & inputCollection : inputCollections){
    for ( typename MergeCollection::const_iterator recHit = inputCollection->begin(); recHit!= inputCollection->end(); ++recHit ) {
       DetId detIdObject( recHit->geographicalId() );
       output_map[detIdObject].push_back(*recHit);

--- a/TauAnalysis/MCEmbeddingTools/plugins/CollectionMerger.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/CollectionMerger.cc
@@ -49,20 +49,20 @@ void  CollectionMerger<T1,T2>::fill_output_obj_tracker(std::unique_ptr<MergeColl
   for (auto inputCollection : inputCollections){
    for ( typename MergeCollection::const_iterator clustSet = inputCollection->begin(); clustSet!= inputCollection->end(); ++clustSet ) {
       DetId detIdObject( clustSet->detId() );
-      for (typename edmNew::DetSet<BaseHit>::const_iterator clustIt = clustSet->begin(); clustIt != clustSet->end(); ++clustIt ) { 	
-        output_map[detIdObject.rawId()].push_back(*clustIt);	
+      for (typename edmNew::DetSet<BaseHit>::const_iterator clustIt = clustSet->begin(); clustIt != clustSet->end(); ++clustIt ) {
+        output_map[detIdObject.rawId()].push_back(*clustIt);
        }
-    } 
+    }
   }
   // Now save it into the standard CMSSW format, with the standard Filler
   for (typename std::map<uint32_t, std::vector<BaseHit> >::const_iterator outHits = output_map.begin(); outHits != output_map.end(); ++outHits ) {
      DetId detIdObject(outHits->first);
      typename MergeCollection::FastFiller spc(*output, detIdObject);
-     for (auto Hit : outHits->second){ 
+     for (auto Hit : outHits->second){
        spc.push_back(Hit);
-     }     
-   } 
-  
+     }
+   }
+
 }
 
 
@@ -71,21 +71,21 @@ void  CollectionMerger<T1,T2>::fill_output_obj_tracker(std::unique_ptr<MergeColl
 template <typename T1, typename T2>
 void  CollectionMerger<T1,T2>::fill_output_obj_calo(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections)
 {
- std::map<uint32_t, BaseHit >   output_map;  
- // First merge the two collections again
- for (auto inputCollection : inputCollections){
-  for ( typename MergeCollection::const_iterator recHit = inputCollection->begin(); recHit!= inputCollection->end(); ++recHit ) {
-    DetId detIdObject( recHit->detid().rawId() );
-    T2 *akt_calo_obj = &output_map[detIdObject.rawId()];
-    float new_energy = akt_calo_obj->energy() + recHit->energy();
-    T2 newRecHit(*recHit);
-    newRecHit.setEnergy(new_energy);
-    *akt_calo_obj = newRecHit;
-  } 
+  std::map<uint32_t, BaseHit >   output_map;
+  // First merge the two collections again
+  for (auto inputCollection : inputCollections){
+    for ( typename MergeCollection::const_iterator recHit = inputCollection->begin(); recHit!= inputCollection->end(); ++recHit ) {
+      DetId detIdObject( recHit->detid().rawId() );
+      T2 *akt_calo_obj = &output_map[detIdObject.rawId()];
+      float new_energy = akt_calo_obj->energy() + recHit->energy();
+      T2 newRecHit(*recHit);
+      newRecHit.setEnergy(new_energy);
+      *akt_calo_obj = newRecHit;
+    }
+  }
   // Now save it into the standard CMSSW format
-    for (typename std::map<uint32_t, BaseHit >::const_iterator outHits = output_map.begin(); outHits != output_map.end(); ++outHits ) {
-      output->push_back(outHits->second);
-    }   
+  for (typename std::map<uint32_t, BaseHit >::const_iterator outHits = output_map.begin(); outHits != output_map.end(); ++outHits ) {
+    output->push_back(outHits->second);
   }
   output->sort(); //Do a sort for this collection
 }
@@ -100,14 +100,14 @@ void  CollectionMerger<T1,T2>::fill_output_obj_muonchamber(std::unique_ptr<Merge
   // First merge the collections with the help of the output map
   for (auto inputCollection : inputCollections){
    for ( typename MergeCollection::const_iterator recHit = inputCollection->begin(); recHit!= inputCollection->end(); ++recHit ) {
-      DetId detIdObject( recHit->geographicalId() );	
-      output_map[detIdObject].push_back(*recHit);	
+      DetId detIdObject( recHit->geographicalId() );
+      output_map[detIdObject].push_back(*recHit);
       }
-  } 
+  }
   // Now save it into the standard CMSSW format, with the standard Filler
   for (typename std::map<uint32_t, std::vector<BaseHit> >::const_iterator outHits = output_map.begin(); outHits != output_map.end(); ++outHits ) {
-        output->put((typename T1::id_iterator::value_type) outHits->first , outHits->second.begin(), outHits->second.end()); // The DTLayerId misses the automatic type cast 
-   }  
+        output->put((typename T1::id_iterator::value_type) outHits->first , outHits->second.begin(), outHits->second.end()); // The DTLayerId misses the automatic type cast
+   }
 }
 
 
@@ -126,7 +126,7 @@ template <>
 void  CollectionMerger<edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster>::fill_output_obj(std::unique_ptr<MergeCollection > & output, std::vector<edm::Handle<MergeCollection> > &inputCollections)
 {
  fill_output_obj_tracker(output,inputCollections,true);
- 
+
 }
 
 

--- a/TauAnalysis/MCEmbeddingTools/plugins/CollectionMerger.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/CollectionMerger.h
@@ -68,7 +68,7 @@ template <typename T1, typename T2>
 CollectionMerger<T1,T2>::CollectionMerger(const edm::ParameterSet& iConfig)
 {
   std::vector<edm::InputTag> inCollections =  iConfig.getParameter<std::vector<edm::InputTag> >("mergCollections");
-  for (auto inCollection : inCollections){
+  for (auto const & inCollection : inCollections){
     inputs_[inCollection.instance()].push_back(consumes<MergeCollection >(inCollection));  
   }
   for (auto toproduce : inputs_){

--- a/TauAnalysis/MCEmbeddingTools/python/EmbeddingLHEProducer_cfi.py
+++ b/TauAnalysis/MCEmbeddingTools/python/EmbeddingLHEProducer_cfi.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 externalLHEProducer = cms.EDProducer("EmbeddingLHEProducer",
     src = cms.InputTag("selectedMuonsForEmbedding","",""),
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices","","SELECT"),
-    switchToMuonEmbedding = cms.bool(False),
+    particleToEmbed = cms.int32(15),
     rotate180 = cms.bool(False),
     mirror = cms.bool(False),
     studyFSRmode = cms.untracked.string("reco")

--- a/TauAnalysis/MCEmbeddingTools/python/customisers.py
+++ b/TauAnalysis/MCEmbeddingTools/python/customisers.py
@@ -185,6 +185,8 @@ def keepSimulated():
 	ret_vstring.append("keep *_standAloneMuons_*_SIMembedding")
 	ret_vstring.append("keep *_glbTrackQual_*_SIMembedding")
 	ret_vstring.append("keep *_generator_*_SIMembedding")
+	ret_vstring.append("keep *_addPileupInfo_*_SIMembedding")
+	ret_vstring.append("keep *_slimmedAddPileupInfo_*_*")
 	return ret_vstring
 
 
@@ -204,7 +206,7 @@ def customiseLHE(process, changeProcessname=True,reselect=False):
 	process.schedule.insert(0,process.lheproduction)
 	
 	
-        process = customisoptions(process)
+	process = customisoptions(process)
 	return modify_outputModules(process,[keepSelected(dataTier),keepCleaned(), keepLHE()],["MINIAODoutput"])
 
 
@@ -253,9 +255,66 @@ def customiseGenerator_Reselect(process):
 def keepMerged(dataTier="SELECT"):
 	ret_vstring = cms.untracked.vstring()
 	ret_vstring.append("drop *_*_*_"+dataTier)
+	ret_vstring.append("keep *_prunedGenParticles_*_MERGE")
 	ret_vstring.append("keep *_generator_*_SIMembedding")
 	return ret_vstring
 
+
+def customiseKeepPrunedGenParticles(process,reselect=False):
+	if reselect:
+		dataTier="RESELECT"
+	else:
+		dataTier="SELECT"
+	
+	process.load('PhysicsTools.PatAlgos.slimming.genParticles_cff')
+	process.merge_step += process.prunedGenParticlesWithStatusOne
+	process.load('PhysicsTools.PatAlgos.slimming.prunedGenParticles_cfi')
+	process.merge_step += process.prunedGenParticles
+	process.load('PhysicsTools.PatAlgos.slimming.packedGenParticles_cfi')
+	process.merge_step += process.packedGenParticles
+	
+	process.load('PhysicsTools.PatAlgos.mcMatchLayer0.muonMatch_cfi')
+	process.merge_step += process.muonMatch
+	process.load('PhysicsTools.PatAlgos.mcMatchLayer0.electronMatch_cfi')
+	process.merge_step += process.electronMatch
+	process.load('PhysicsTools.PatAlgos.mcMatchLayer0.photonMatch_cfi')
+	process.merge_step += process.photonMatch
+	process.load('PhysicsTools.PatAlgos.mcMatchLayer0.tauMatch_cfi')
+	process.merge_step += process.tauMatch
+	process.load('PhysicsTools.JetMCAlgos.TauGenJets_cfi')
+	process.merge_step += process.tauGenJets
+	process.load('PhysicsTools.PatAlgos.mcMatchLayer0.jetFlavourId_cff')
+	process.merge_step += process.patJetPartons
+	process.load('PhysicsTools.PatAlgos.mcMatchLayer0.jetMatch_cfi')
+	process.merge_step += process.patJetPartonMatch
+	
+	process.muonMatch.matched = "prunedGenParticles"
+	process.electronMatch.matched = "prunedGenParticles"
+	process.electronMatch.src = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
+	process.photonMatch.matched = "prunedGenParticles"
+	process.photonMatch.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
+	process.tauMatch.matched = "prunedGenParticles"
+	process.tauGenJets.GenParticles = "prunedGenParticles"
+	##Boosted taus
+	#process.tauMatchBoosted.matched = "prunedGenParticles"
+	#process.tauGenJetsBoosted.GenParticles = "prunedGenParticles"
+	process.patJetPartons.particles = "prunedGenParticles"
+	process.patJetPartonMatch.matched = "prunedGenParticles"
+	process.patJetPartonMatch.mcStatus = [ 3, 23 ]
+	process.patJetGenJetMatch.matched = "slimmedGenJets"
+	process.patJetGenJetMatchAK8.matched =  "slimmedGenJetsAK8"
+	process.patMuons.embedGenMatch = False
+	process.patElectrons.embedGenMatch = False
+	process.patPhotons.embedGenMatch = False
+	process.patTaus.embedGenMatch = False
+	process.patTausBoosted.embedGenMatch = False
+	process.patJets.embedGenPartonMatch = False
+	#also jet flavour must be switched
+	process.patJetFlavourAssociation.rParam = 0.4
+	
+	process.schedule.insert(0,process.merge_step)
+	process = customisoptions(process)  
+	return modify_outputModules(process, [keepMerged(dataTier)])
 
 
 def customiseMerging(process, changeProcessname=True,reselect=False):
@@ -370,9 +429,15 @@ def customiseLHEandCleaning_Reselect(process):
 ################################ additionla Customizer ###########################
 
 def customisoptions(process):
-	if not hasattr(process, "options"): 
-	  process.options = cms.untracked.PSet()
-	process.options.emptyRunLumiMode = cms.untracked.string('doNotHandleEmptyRunsAndLumis')	
+	if not hasattr(process, "options"):
+		process.options = cms.untracked.PSet()
+	process.options.emptyRunLumiMode = cms.untracked.string('doNotHandleEmptyRunsAndLumis')
+	if not hasattr(process, "bunchSpacingProducer"):
+		process.bunchSpacingProducer = cms.EDProducer("BunchSpacingProducer")
+	process.bunchSpacingProducer.bunchSpacingOverride = cms.uint32(25)
+	process.bunchSpacingProducer.overrideBunchSpacing = cms.bool(True)
+	process.options.numberOfThreads = cms.untracked.uint32(1)
+	process.options.numberOfStreams = cms.untracked.uint32(0)
 	return process
 
 ############################### MC specific Customizer ###########################
@@ -382,43 +447,47 @@ def customiseFilterZToMuMu(process):
 	process.ZToMuMuFilter = cms.Path(process.dYToMuMuGenFilter)
 	process.schedule.insert(-1,process.ZToMuMuFilter)
 	return process
-      
-      
-      
+
+def customiseFilterTTbartoMuMu(process):
+	process.load("TauAnalysis.MCEmbeddingTools.TTbartoMuMuGenFilter_cfi")
+	process.MCFilter = cms.Path(process.TTbartoMuMuGenFilter)
+	return customiseMCFilter(process)
+
+def customiseMCFilter(process):
+	process.schedule.insert(-1,process.MCFilter)
+	outputModulesList = [key for key,value in process.outputModules.iteritems()]
+	for outputModule in outputModulesList:
+		outputModule = getattr(process, outputModule)
+		outputModule.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("MCFilter"))
+	return process
+
 def fix_input_tags(process, formodules = ["generalTracks","cscSegments","dt4DSegments","rpcRecHits"]):
-  def change_tags_process(test_input):
-    if isinstance(test_input, cms.InputTag):
-      if test_input.getModuleLabel() in formodules:
-	test_input.setProcessName(process._Process__name)
+	def change_tags_process(test_input):
+		if isinstance(test_input, cms.InputTag):
+			if test_input.getModuleLabel() in formodules:
+				test_input.setProcessName(process._Process__name)
 
-  def search_for_tags(pset):
-    if isinstance(pset, dict):
-      for key in pset:
-	if isinstance(pset[key], cms.VInputTag):
-	  for akt_inputTag in pset[key]:
-	    change_tags_process(akt_inputTag)
-	elif isinstance(pset[key], cms.PSet):
-	  search_for_tags(pset[key].__dict__)
-	elif isinstance(pset[key], cms.VPSet):
-	  for akt_pset in pset[key]:
-	    search_for_tags(akt_pset.__dict__)
-	else:
-	  change_tags_process(pset[key])
-    else:
-      print "must be python dict not a ",type(pset)
-    
-  for module in process.producers_():
-    search_for_tags(getattr(process, module).__dict__)
-  for module in process.filters_():
-    search_for_tags(getattr(process, module).__dict__)
-  for module in process.analyzers_():
-    search_for_tags(getattr(process, module).__dict__)
+	def search_for_tags(pset):
+		if isinstance(pset, dict):
+			for key in pset:
+				if isinstance(pset[key], cms.VInputTag):
+					for akt_inputTag in pset[key]:
+						change_tags_process(akt_inputTag)
+				elif isinstance(pset[key], cms.PSet):
+					search_for_tags(pset[key].__dict__)
+				elif isinstance(pset[key], cms.VPSet):
+					for akt_pset in pset[key]:
+						search_for_tags(akt_pset.__dict__)
+				else:
+					change_tags_process(pset[key])
+		else:
+			print "must be python dict not a ",type(pset)
+			
+	for module in process.producers_():
+		search_for_tags(getattr(process, module).__dict__)
+	for module in process.filters_():
+		search_for_tags(getattr(process, module).__dict__)
+	for module in process.analyzers_():
+		search_for_tags(getattr(process, module).__dict__)
 
-  return process
-      
-      
-      
-      
-      
-      
-      
+	return process


### PR DESCRIPTION
Presented in RECO AT 14.07.2017.

- New feature to enable electron embedding:
Boolean parameter switchToMuonEmbedding replaced by integer parameter particleToEmbed representing the PDGID of the particle to be embedded.

- Workaround to keep prunedGenParticles:
New customizer function to keep genParticle collections that are removed in the PAT step on data.

- Bugfix in EmbeddingLHEProducer:
Only tau-leptons were added to the LHE product. Now crosschecking with list of allowed particles.

- Bugfix in Merge Collections (found after presentation):
First merge the two collections, then save the new collection.

**Testcases:**
Clone the following repository into your CMSSW_9_2_3patch2 src folder:
`git clone https://github.com/perahrens/gc_configs_for_embedding.git`

It contains three test configuration folders:
1. ElEl_data_2017_CMSSW923p2_ElEmbedding
2. MuMu_data_2017_CMSSW923p2_MuEmbedding
3. MuTau_data_2017_CMSSW923p2_TauEmbedding
For testing purposes, you can copy a RAW testfile (/DoubleMuon/Run2017B-v1/RAW) with the name **test.root** into the respective folder and run:
`cmsRun selection.py`
`cmsRun lheprodandcleaning.py`
`cmsRun generator.py`
`cmsRun merging.py`
Final output will be a root file in MINIAOD format with the hybrid events.