### PR TITLE
Add displaced pT measurement to L1T::Muon object

### DIFF
--- a/DataFormats/L1Trigger/interface/Muon.h
+++ b/DataFormats/L1Trigger/interface/Muon.h
@@ -36,7 +36,8 @@ namespace l1t {
       int hwEtaAtVtx = 0,
       int hwPhiAtVtx = 0,
       double etaAtVtx = 0.,
-      double phiAtVtx = 0.);
+      double phiAtVtx = 0.,
+      double ptNoVtx = 0.);
     
     Muon( const PolarLorentzVector& p4,
       int pt=0,
@@ -56,7 +57,8 @@ namespace l1t {
       int hwEtaAtVtx = 0,
       int hwPhiAtVtx = 0,
       double etaAtVtx = 0.,
-      double phiAtVtx = 0.);
+      double phiAtVtx = 0.,
+      double ptNoVtx = 0.);
 
     ~Muon();    
 
@@ -78,6 +80,8 @@ namespace l1t {
 
     inline void setDebug(bool debug) { debug_ = debug; };
 
+    inline void setPtNoVtx(float ptNoVtx) { ptNoVtx_ = ptNoVtx; }
+
     // methods to retrieve values
     inline int hwCharge() const { return hwCharge_; };
     inline int hwChargeValid() const { return hwChargeValid_; };
@@ -95,6 +99,8 @@ namespace l1t {
     inline int hwRank() const { return hwRank_; };
 
     inline bool debug() const { return debug_; };
+
+    inline float getPtNoVtx() const { return ptNoVtx_; }
     
   private:
     
@@ -116,6 +122,9 @@ namespace l1t {
     int hwPhiAtVtx_;
     double etaAtVtx_;
     double phiAtVtx_;
+
+    // additional phase-2 members
+    float ptNoVtx_;
   };
   
 }

--- a/DataFormats/L1Trigger/src/Muon.cc
+++ b/DataFormats/L1Trigger/src/Muon.cc
@@ -14,7 +14,8 @@ l1t::Muon::Muon()
     hwEtaAtVtx_(0),
     hwPhiAtVtx_(0),
     etaAtVtx_(0.),
-    phiAtVtx_(0.)
+    phiAtVtx_(0.),
+    ptNoVtx_(0.)
 {
 
 }
@@ -37,7 +38,8 @@ l1t::Muon::Muon( const LorentzVector& p4,
     int hwEtaAtVtx,
     int hwPhiAtVtx,
     double etaAtVtx,
-    double phiAtVtx)
+    double phiAtVtx,
+    double ptNoVtx)
   : L1Candidate(p4, pt, eta, phi, qual, iso),
     hwCharge_(charge),
     hwChargeValid_(chargeValid),
@@ -51,7 +53,8 @@ l1t::Muon::Muon( const LorentzVector& p4,
     hwEtaAtVtx_(hwEtaAtVtx),
     hwPhiAtVtx_(hwPhiAtVtx),
     etaAtVtx_(etaAtVtx),
-    phiAtVtx_(phiAtVtx)
+    phiAtVtx_(phiAtVtx),
+    ptNoVtx_(ptNoVtx)
 {
   
 }
@@ -74,7 +77,8 @@ l1t::Muon::Muon( const PolarLorentzVector& p4,
     int hwEtaAtVtx,
     int hwPhiAtVtx,
     double etaAtVtx,
-    double phiAtVtx)
+    double phiAtVtx,
+    double ptNoVtx)
   : L1Candidate(p4, pt, eta, phi, qual, iso),
     hwCharge_(charge),
     hwChargeValid_(chargeValid),
@@ -88,7 +92,8 @@ l1t::Muon::Muon( const PolarLorentzVector& p4,
     hwEtaAtVtx_(hwEtaAtVtx),
     hwPhiAtVtx_(hwPhiAtVtx),
     etaAtVtx_(etaAtVtx),
-    phiAtVtx_(phiAtVtx)
+    phiAtVtx_(phiAtVtx),
+    ptNoVtx_(ptNoVtx)
 {
   
 }

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -80,7 +80,8 @@
   <class name="l1t::TauVectorRef"/>
   <class name="edm::Wrapper<l1t::TauVectorRef>"/>
 
-  <class name="l1t::Muon" ClassVersion="17">
+  <class name="l1t::Muon" ClassVersion="18">
+   <version ClassVersion="18" checksum="2526190802"/>
    <version ClassVersion="17" checksum="3946815604"/>
    <version ClassVersion="16" checksum="1302394108"/>
    <version ClassVersion="15" checksum="957467775"/>


### PR DESCRIPTION
An extra member `ptNoVtx` was added to the `L1T::Muon` object opening up the possibility to develop pT assignment algorithms for non-prompt L1 muons. The changes proposed does not affect the performance of the l1 trigger. The extra member `ptNoVtx` will only be filled in phase-2 scenarios where displaced muon triggers are enabled. It should not be used in Run-2 or Run-3 scenarios. The default value is 0.

@tahuang1991