### PR TITLE
update V0 selection for 2017

### DIFF
--- a/RecoVertex/V0Producer/python/generalV0Candidates_cfi.py
+++ b/RecoVertex/V0Producer/python/generalV0Candidates_cfi.py
@@ -30,7 +30,7 @@ generalV0Candidates = cms.EDProducer("V0Producer",
    # Track normalized Chi2 <
    tkChi2Cut = cms.double(10.),
    # Number of valid hits on track >=
-   tkNHitsCut = cms.int32(7),
+   tkNHitsCut = cms.int32(3),
    # Pt of track >
    tkPtCut = cms.double(0.35),
    # Track impact parameter significance >
@@ -39,22 +39,22 @@ generalV0Candidates = cms.EDProducer("V0Producer",
 
    # -- cuts on the vertex --
    # Vertex chi2 <
-   vtxChi2Cut = cms.double(15.),
+   vtxChi2Cut = cms.double(6.63),
    # XY decay distance significance >
-   vtxDecaySigXYCut = cms.double(10.),
+   vtxDecaySigXYCut = cms.double(15.),
    # XYZ decay distance significance >
    vtxDecaySigXYZCut = cms.double(-1.),
 
    # -- miscellaneous cuts --
    # POCA distance between tracks <
-   tkDCACut = cms.double(2.),
+   tkDCACut = cms.double(1.),
    # invariant mass of track pair - assuming both tracks are charged pions <
    mPiPiCut = cms.double(0.6),
    # check if either track has a hit radially inside the vertex position minus this number times the sigma of the vertex fit
    # note: Set this to -1 to disable this cut, which MUST be done if you want to run V0Producer on the AOD track collection!
    innerHitPosCut = cms.double(4.),
    # cos(angleXY) between x and p of V0 candidate >
-   cosThetaXYCut = cms.double(0.9998),
+   cosThetaXYCut = cms.double(0.998),
    # cos(angleXYZ) between x and p of V0 candidate >
    cosThetaXYZCut = cms.double(-2.),
 

--- a/RecoVertex/V0Producer/src/V0Fitter.cc
+++ b/RecoVertex/V0Producer/src/V0Fitter.cc
@@ -211,10 +211,12 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
       if (distMagXY/sigmaDistMagXY < vtxDecaySigXYCut_) continue;
 
       // 3D decay significance
-      SVector3 distVecXYZ(vtxPos.x()-referencePos.x(), vtxPos.y()-referencePos.y(), vtxPos.z()-referencePos.z());
-      double distMagXYZ = ROOT::Math::Mag(distVecXYZ);
-      double sigmaDistMagXYZ = sqrt(ROOT::Math::Similarity(totalCov, distVecXYZ)) / distMagXYZ;
-      if (distMagXYZ/sigmaDistMagXYZ < vtxDecaySigXYZCut_) continue;
+      if (vtxDecaySigXYZCut_ > 0.) {
+         SVector3 distVecXYZ(vtxPos.x()-referencePos.x(), vtxPos.y()-referencePos.y(), vtxPos.z()-referencePos.z());
+         double distMagXYZ = ROOT::Math::Mag(distVecXYZ);
+         double sigmaDistMagXYZ = sqrt(ROOT::Math::Similarity(totalCov, distVecXYZ)) / distMagXYZ;
+         if (distMagXYZ/sigmaDistMagXYZ < vtxDecaySigXYZCut_) continue;
+      }
 
       // make sure the vertex radius is within the inner track hit radius
       if (innerHitPosCut_ > 0. && positiveTrackRef->innerOk()) {
@@ -270,10 +272,12 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
       if (angleXY < cosThetaXYCut_) continue;
 
       // 3D pointing angle
-      double dz = theVtx.z()-referencePos.z();
-      double pz = totalP.z();
-      double angleXYZ = (dx*px+dy*py+dz*pz)/(sqrt(dx*dx+dy*dy+dz*dz)*sqrt(px*px+py*py+pz*pz));
-      if (angleXYZ < cosThetaXYZCut_) continue;
+      if (cosThetaXYZCut_ > -1.) {
+         double dz = theVtx.z()-referencePos.z();
+         double pz = totalP.z();
+         double angleXYZ = (dx*px+dy*py+dz*pz)/(sqrt(dx*dx+dy*dy+dz*dz)*sqrt(px*px+py*py+pz*pz));
+         if (angleXYZ < cosThetaXYZCut_) continue;
+      }
 
       // calculate total energy of V0 3 ways: assume it's a kShort, a Lambda, or a LambdaBar.
       double piPlusE = sqrt(positiveP.mag2() + piMassSquared);


### PR DESCRIPTION
1) change selection to improve efficiency for reconstruction for V0s from displaced vertices
2) change selection to improve signal / noise performance
3) two minor changes to remove unnecessary calculations when using default configuration

see attached slides for performance plots
[prV0_v2.pdf](https://github.com/cms-sw/cmssw/files/1153865/prV0_v2.pdf)
