### PR TITLE
Extra members in CSCCorrelatedLCTDigi to determine its original components

### DIFF
--- a/DataFormats/CSCDigi/BuildFile.xml
+++ b/DataFormats/CSCDigi/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/MuonDetId"/>
+<use   name="DataFormats/GEMDigi"/>
 
 <export>
   <lib   name="1"/>

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -11,6 +11,9 @@
 
 #include <cstdint>
 #include <iosfwd>
+#include "DataFormats/CSCDigi/interface/CSCALCTDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
+#include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
 
 class CSCCorrelatedLCTDigi 
 {
@@ -111,7 +114,28 @@ class CSCCorrelatedLCTDigi
   /// set cscID
   void setCSCID(unsigned int c) {cscID=c;}
 
- private:
+  /// SIMULATION ONLY ////
+  enum Type{CLCTALCT, // CLCT-centric
+	    ALCTCLCT, // ALCT-centric
+	    ALCTCLCTGEM, // ALCT-CLCT-1 GEM pad
+	    ALCTCLCT2GEM, // ALCT-CLCT-2 GEM pads in coincidence
+	    ALCT2GEM, // ALCT-2 GEM pads in coincidence
+	    CLCT2GEM  // CLCT-2 GEM pads in coincidence
+  };
+  
+  int getType() {return type_;}
+  void setType(int type) {type_ = type;}
+  
+  void setALCT(const CSCALCTDigi& alct) {alct_ = alct;}
+  void setCLCT(const CSCCLCTDigi& clct) {clct_ = clct;}
+  void setGEM1(const GEMPadDigi& gem) {gem1_ = gem;}
+  void setGEM2(const GEMPadDigi& gem) {gem2_ = gem;}
+  const CSCALCTDigi&  getALCT() {return alct_;}
+  const CSCCLCTDigi&  getCLCT() {return clct_;}
+  const GEMPadDigi&  getGEM1() {return gem1_;}
+  const GEMPadDigi&  getGEM2() {return gem2_;}
+
+private:
   uint16_t trknmb;
   uint16_t valid;
   uint16_t quality;
@@ -124,6 +148,14 @@ class CSCCorrelatedLCTDigi
   uint16_t bx0; 
   uint16_t syncErr;
   uint16_t cscID;
+
+  /// SIMULATION ONLY ////
+  int type_;
+
+  CSCALCTDigi alct_;
+  CSCCLCTDigi clct_;
+  GEMPadDigi gem1_;
+  GEMPadDigi gem2_;
 };
 
 std::ostream & operator<<(std::ostream & o, const CSCCorrelatedLCTDigi& digi);

--- a/DataFormats/CSCDigi/src/classes_def.xml
+++ b/DataFormats/CSCDigi/src/classes_def.xml
@@ -11,7 +11,8 @@
    <class name="CSCComparatorDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="656608282"/>
    </class>
-   <class name="CSCCorrelatedLCTDigi" ClassVersion="10">
+   <class name="CSCCorrelatedLCTDigi" ClassVersion="11">
+    <version ClassVersion="11" checksum="2118578151"/>
     <version ClassVersion="10" checksum="1301481852"/>
    </class>
    <class name="GEMCSCLCTDigi" ClassVersion="11">

--- a/DataFormats/L1CSCTrackFinder/src/classes_def.xml
+++ b/DataFormats/L1CSCTrackFinder/src/classes_def.xml
@@ -13,7 +13,8 @@
     <version ClassVersion="10" checksum="3445513287"/>
    </class>
 
-   <class name="csctf::TrackStub" ClassVersion="11">
+   <class name="csctf::TrackStub" ClassVersion="12">
+    <version ClassVersion="12" checksum="1100843423"/>
     <version ClassVersion="11" checksum="2137081572"/>
     <version ClassVersion="10" checksum="2767475416"/>
      <field name="thePhiBinning" transient="true"/>

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -558,7 +558,7 @@ void CSCMotherboard::correlateLCTs(CSCALCTDigi bestALCT,
   if ((alct_trig_enable  && bestALCT.isValid()) ||
       (clct_trig_enable  && bestCLCT.isValid()) ||
       (match_trig_enable && bestALCT.isValid() && bestCLCT.isValid())) {
-    CSCCorrelatedLCTDigi lct = constructLCTs(bestALCT, bestCLCT);
+    CSCCorrelatedLCTDigi lct = constructLCTs(bestALCT, bestCLCT, CSCCorrelatedLCTDigi::CLCTALCT);
     int bx = lct.getBX();
     if (bx >= 0 && bx < MAX_LCT_BINS) {
       firstLCT[bx] = lct;
@@ -576,7 +576,7 @@ void CSCMotherboard::correlateLCTs(CSCALCTDigi bestALCT,
       ((alct_trig_enable  && secondALCT.isValid()) ||
        (clct_trig_enable  && secondCLCT.isValid()) ||
        (match_trig_enable && secondALCT.isValid() && secondCLCT.isValid()))) {
-    CSCCorrelatedLCTDigi lct = constructLCTs(secondALCT, secondCLCT);
+    CSCCorrelatedLCTDigi lct = constructLCTs(secondALCT, secondCLCT, CSCCorrelatedLCTDigi::CLCTALCT);
     int bx = lct.getBX();
     if (bx >= 0 && bx < MAX_LCT_BINS) {
       secondLCT[bx] = lct;
@@ -594,7 +594,8 @@ void CSCMotherboard::correlateLCTs(CSCALCTDigi bestALCT,
 // This method calculates all the TMB words and then passes them to the
 // constructor of correlated LCTs.
 CSCCorrelatedLCTDigi CSCMotherboard::constructLCTs(const CSCALCTDigi& aLCT,
-                                                   const CSCCLCTDigi& cLCT) {
+                                                   const CSCCLCTDigi& cLCT,
+						   int type) {
   // CLCT pattern number
   unsigned int pattern = encodePattern(cLCT.getPattern(), cLCT.getStripType());
 
@@ -609,6 +610,9 @@ CSCCorrelatedLCTDigi CSCMotherboard::constructLCTs(const CSCALCTDigi& aLCT,
   CSCCorrelatedLCTDigi thisLCT(trknmb, 1, quality, aLCT.getKeyWG(),
                                cLCT.getKeyStrip(), pattern, cLCT.getBend(),
                                bx, 0, 0, 0, theTrigChamber);
+  thisLCT.setType(type);
+  thisLCT.setALCT(aLCT);
+  thisLCT.setCLCT(cLCT);
   return thisLCT;
 }
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
@@ -142,7 +142,8 @@ class CSCMotherboard
   void correlateLCTs(CSCALCTDigi bestALCT, CSCALCTDigi secondALCT,
 		     CSCCLCTDigi bestCLCT, CSCCLCTDigi secondCLCT);
   CSCCorrelatedLCTDigi constructLCTs(const CSCALCTDigi& aLCT,
-				     const CSCCLCTDigi& cLCT);
+				     const CSCCLCTDigi& cLCT, 
+				     int);
   unsigned int encodePattern(const int ptn, const int highPt);
   unsigned int findQuality(const CSCALCTDigi& aLCT, const CSCCLCTDigi& cLCT);
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
@@ -516,44 +516,6 @@ void CSCMotherboardME11::correlateLCTs(CSCALCTDigi bestALCT,
 				   CSCCLCTDigi bestCLCT,
 				   CSCCLCTDigi secondCLCT,
 				   CSCCorrelatedLCTDigi& lct1,
-				   CSCCorrelatedLCTDigi& lct2)
-{
-  bool anodeBestValid     = bestALCT.isValid();
-  bool anodeSecondValid   = secondALCT.isValid();
-  bool cathodeBestValid   = bestCLCT.isValid();
-  bool cathodeSecondValid = secondCLCT.isValid();
-
-  if (anodeBestValid && !anodeSecondValid)     secondALCT = bestALCT;
-  if (!anodeBestValid && anodeSecondValid)     bestALCT   = secondALCT;
-  if (cathodeBestValid && !cathodeSecondValid) secondCLCT = bestCLCT;
-  if (!cathodeBestValid && cathodeSecondValid) bestCLCT   = secondCLCT;
-
-  // ALCT-CLCT matching conditions are defined by "trig_enable" configuration
-  // parameters.
-  if ((alct_trig_enable  && bestALCT.isValid()) ||
-      (clct_trig_enable  && bestCLCT.isValid()) ||
-      (match_trig_enable && bestALCT.isValid() && bestCLCT.isValid()))
-  {
-    lct1 = constructLCTs(bestALCT, bestCLCT);
-    lct1.setTrknmb(1);
-  }
-
-  if (((secondALCT != bestALCT) || (secondCLCT != bestCLCT)) &&
-      ((alct_trig_enable  && secondALCT.isValid()) ||
-       (clct_trig_enable  && secondCLCT.isValid()) ||
-       (match_trig_enable && secondALCT.isValid() && secondCLCT.isValid())))
-  {
-    lct2 = constructLCTs(secondALCT, secondCLCT);
-    lct2.setTrknmb(2);
-  }
-}
-
-
-void CSCMotherboardME11::correlateLCTs(CSCALCTDigi bestALCT,
-				   CSCALCTDigi secondALCT,
-				   CSCCLCTDigi bestCLCT,
-				   CSCCLCTDigi secondCLCT,
-				   CSCCorrelatedLCTDigi& lct1,
 				   CSCCorrelatedLCTDigi& lct2,
                                    int me)
 {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
@@ -607,16 +607,16 @@ void CSCMotherboardME11::correlateLCTs(CSCALCTDigi bestALCT,
 
   switch (lut[code][0]) {
     case 11:
-      lct1 = constructLCTs(bestALCT, bestCLCT);
+      lct1 = constructLCTs(bestALCT, bestCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
       break;
     case 12:
-      lct1 = constructLCTs(bestALCT, secondCLCT);
+      lct1 = constructLCTs(bestALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
       break;
     case 21:
-      lct1 = constructLCTs(secondALCT, bestCLCT);
+      lct1 = constructLCTs(secondALCT, bestCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
       break;
     case 22:
-      lct1 = constructLCTs(secondALCT, secondCLCT);
+      lct1 = constructLCTs(secondALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
       break;
     default: return;  
   }
@@ -627,17 +627,17 @@ void CSCMotherboardME11::correlateLCTs(CSCALCTDigi bestALCT,
   switch (lut[code][1])
   {
     case 12:
-      lct2 = constructLCTs(bestALCT, secondCLCT);
+      lct2 = constructLCTs(bestALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
       lct2.setTrknmb(2);
       if (dbg) LogTrace("CSCMotherboardME11")<<"lct2: "<<lct2<<std::endl;
       return;
     case 21:
-      lct2 = constructLCTs(secondALCT, bestCLCT);
+      lct2 = constructLCTs(secondALCT, bestCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
       lct2.setTrknmb(2);
       if (dbg) LogTrace("CSCMotherboardME11")<<"lct2: "<<lct2<<std::endl;
       return;
     case 22:
-      lct2 = constructLCTs(secondALCT, secondCLCT);
+      lct2 = constructLCTs(secondALCT, secondCLCT, CSCCorrelatedLCTDigi::ALCTCLCT);
       lct2.setTrknmb(2);
       if (dbg) LogTrace("CSCMotherboardME11")<<"lct2: "<<lct2<<std::endl;
       return;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.h
@@ -87,10 +87,6 @@ class CSCMotherboardME11 : public CSCMotherboard
 
   void correlateLCTs(CSCALCTDigi bestALCT, CSCALCTDigi secondALCT,
 		     CSCCLCTDigi bestCLCT, CSCCLCTDigi secondCLCT,
-		     CSCCorrelatedLCTDigi& lct1, CSCCorrelatedLCTDigi& lct2);
-
-  void correlateLCTs(CSCALCTDigi bestALCT, CSCALCTDigi secondALCT,
-		     CSCCLCTDigi bestCLCT, CSCCLCTDigi secondCLCT,
 		     CSCCorrelatedLCTDigi& lct1, CSCCorrelatedLCTDigi& lct2, int me);
 
   std::vector<CSCALCTDigi> alctV;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
@@ -1316,7 +1316,9 @@ void CSCMotherboardME11GEM::correlateLCTsGEM(CSCALCTDigi bestALCT,
   {
     lct1 = constructLCTsGEM(bestALCT, gemPad, ME, useOldLCTDataFormat_);
     lct1.setTrknmb(1);
-    //    lct1.setGEMDPhi(0.0);
+    lct1.setALCT(bestALCT);
+    lct1.setGEM1(gemPad);
+    lct1.setType(CSCCorrelatedLCTDigi::ALCT2GEM);
   }
 
   if ((alct_trig_enable  and secondALCT.isValid()) or
@@ -1324,7 +1326,9 @@ void CSCMotherboardME11GEM::correlateLCTsGEM(CSCALCTDigi bestALCT,
   {
     lct2 = constructLCTsGEM(secondALCT, gemPad, ME, useOldLCTDataFormat_);
     lct2.setTrknmb(2);
-    //    lct2.setGEMDPhi(0.0);
+    lct2.setALCT(secondALCT);
+    lct2.setGEM1(gemPad);
+    lct2.setType(CSCCorrelatedLCTDigi::ALCT2GEM);
   }
 }
 
@@ -1346,6 +1350,9 @@ void CSCMotherboardME11GEM::correlateLCTsGEM(CSCCLCTDigi bestCLCT,
   {
     lct1 = constructLCTsGEM(bestCLCT, gemPad, roll, ME, useOldLCTDataFormat_);
     lct1.setTrknmb(1);
+    lct1.setCLCT(bestCLCT);
+    lct1.setGEM1(gemPad);
+    lct1.setType(CSCCorrelatedLCTDigi::CLCT2GEM);
   }
 
   if ((clct_trig_enable  and secondCLCT.isValid()) or
@@ -1353,6 +1360,9 @@ void CSCMotherboardME11GEM::correlateLCTsGEM(CSCCLCTDigi bestCLCT,
   {
     lct2 = constructLCTsGEM(secondCLCT, gemPad, roll, ME, useOldLCTDataFormat_);
     lct2.setTrknmb(2);
+    lct2.setCLCT(secondCLCT);
+    lct2.setGEM1(gemPad);
+    lct2.setType(CSCCorrelatedLCTDigi::CLCT2GEM);
   }
 }
 
@@ -1695,6 +1705,10 @@ CSCCorrelatedLCTDigi CSCMotherboardME11GEM::constructLCTsGEM(const CSCALCTDigi& 
   CSCCorrelatedLCTDigi thisLCT(trknmb, 1, quality, aLCT.getKeyWG(),
                                cLCT.getKeyStrip(), pattern, cLCT.getBend(),
                                bx, 0, 0, 0, theTrigChamber);
+  thisLCT.setALCT(aLCT);
+  thisLCT.setCLCT(cLCT);
+  if (hasPad)   thisLCT.setType(CSCCorrelatedLCTDigi::ALCTCLCTGEM);
+  if (hasCoPad) thisLCT.setType(CSCCorrelatedLCTDigi::ALCTCLCT2GEM);
   return thisLCT;
 }
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
@@ -1261,44 +1261,6 @@ bool CSCMotherboardME11GEM::doesALCTCrossCLCT(CSCALCTDigi &a, CSCCLCTDigi &c, in
   return false;
 }
 
-void CSCMotherboardME11GEM::correlateLCTs(CSCALCTDigi bestALCT,
-				   CSCALCTDigi secondALCT,
-				   CSCCLCTDigi bestCLCT,
-				   CSCCLCTDigi secondCLCT,
-				   CSCCorrelatedLCTDigi& lct1,
-				   CSCCorrelatedLCTDigi& lct2)
-{
-  bool anodeBestValid     = bestALCT.isValid();
-  bool anodeSecondValid   = secondALCT.isValid();
-  bool cathodeBestValid   = bestCLCT.isValid();
-  bool cathodeSecondValid = secondCLCT.isValid();
-
-  if (anodeBestValid and !anodeSecondValid)     secondALCT = bestALCT;
-  if (!anodeBestValid and anodeSecondValid)     bestALCT   = secondALCT;
-  if (cathodeBestValid and !cathodeSecondValid) secondCLCT = bestCLCT;
-  if (!cathodeBestValid and cathodeSecondValid) bestCLCT   = secondCLCT;
-
-  // ALCT-CLCT matching conditions are defined by "trig_enable" configuration
-  // parameters.
-  if ((alct_trig_enable  and bestALCT.isValid()) or
-      (clct_trig_enable  and bestCLCT.isValid()) or
-      (match_trig_enable and bestALCT.isValid() and bestCLCT.isValid()))
-  {
-    lct1 = constructLCTs(bestALCT, bestCLCT);
-    lct1.setTrknmb(1);
-  }
-
-  if (((secondALCT != bestALCT) or (secondCLCT != bestCLCT)) and
-      ((alct_trig_enable  and secondALCT.isValid()) or
-       (clct_trig_enable  and secondCLCT.isValid()) or
-       (match_trig_enable and secondALCT.isValid() and secondCLCT.isValid())))
-  {
-    lct2 = constructLCTs(secondALCT, secondCLCT);
-    lct2.setTrknmb(2);
-  }
-}
-
-
 void CSCMotherboardME11GEM::correlateLCTsGEM(CSCALCTDigi bestALCT,
 					  CSCALCTDigi secondALCT,
 					  GEMPadDigi gemPad,

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.h
@@ -114,10 +114,6 @@ class CSCMotherboardME11GEM : public CSCMotherboard
   CSCCorrelatedLCTDigi allLCTs1b[MAX_LCT_BINS][15][2];
   CSCCorrelatedLCTDigi allLCTs1a[MAX_LCT_BINS][15][2];
 
-  void correlateLCTs(CSCALCTDigi bestALCT, CSCALCTDigi secondALCT,
-		     CSCCLCTDigi bestCLCT, CSCCLCTDigi secondCLCT,
-		     CSCCorrelatedLCTDigi& lct1, CSCCorrelatedLCTDigi& lct2);
-
   void correlateLCTsGEM(CSCALCTDigi bestALCT, CSCALCTDigi secondALCT,
 			CSCCLCTDigi bestCLCT, CSCCLCTDigi secondCLCT,
 			CSCCorrelatedLCTDigi& lct1, CSCCorrelatedLCTDigi& lct2, int me,

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21GEM.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21GEM.cc
@@ -680,7 +680,9 @@ void CSCMotherboardME21GEM::correlateLCTsGEM(CSCALCTDigi bestALCT,
   {
     lct1 = constructLCTsGEM(bestALCT, gemPad, useOldLCTDataFormat_);
     lct1.setTrknmb(1);
-    // lct1.setGEMDPhi(0.0);
+    lct1.setALCT(bestALCT);
+    lct1.setGEM1(gemPad);
+    lct1.setType(CSCCorrelatedLCTDigi::ALCT2GEM);
   }
 
   if ((alct_trig_enable  and secondALCT.isValid()) or
@@ -688,7 +690,9 @@ void CSCMotherboardME21GEM::correlateLCTsGEM(CSCALCTDigi bestALCT,
   {
     lct2 = constructLCTsGEM(secondALCT, gemPad, useOldLCTDataFormat_);
     lct2.setTrknmb(2);
-    // lct2.setGEMDPhi(0.0);
+    lct2.setALCT(secondALCT);
+    lct2.setGEM1(gemPad);
+    lct2.setType(CSCCorrelatedLCTDigi::ALCT2GEM);
   }
 }
 
@@ -710,6 +714,9 @@ void CSCMotherboardME21GEM::correlateLCTsGEM(CSCCLCTDigi bestCLCT,
   {
     lct1 = constructLCTsGEM(bestCLCT, gemPad, roll, useOldLCTDataFormat_);
     lct1.setTrknmb(1);
+    lct1.setCLCT(bestCLCT);
+    lct1.setGEM1(gemPad);
+    lct1.setType(CSCCorrelatedLCTDigi::CLCT2GEM);
   }
 
   if ((clct_trig_enable  and secondCLCT.isValid()) or
@@ -717,6 +724,9 @@ void CSCMotherboardME21GEM::correlateLCTsGEM(CSCCLCTDigi bestCLCT,
     {
     lct2 = constructLCTsGEM(secondCLCT, gemPad, roll, useOldLCTDataFormat_);
     lct2.setTrknmb(2);
+    lct2.setCLCT(secondCLCT);
+    lct2.setGEM1(gemPad);
+    lct2.setType(CSCCorrelatedLCTDigi::CLCT2GEM);
   }
 }
 
@@ -822,6 +832,11 @@ CSCCorrelatedLCTDigi CSCMotherboardME21GEM::constructLCTsGEM(const CSCALCTDigi& 
   CSCCorrelatedLCTDigi thisLCT(trknmb, 1, quality, aLCT.getKeyWG(),
                                cLCT.getKeyStrip(), pattern, cLCT.getBend(),
                                bx, 0, 0, 0, theTrigChamber);
+  thisLCT.setALCT(aLCT);
+  thisLCT.setCLCT(cLCT);
+  if (hasPad)   thisLCT.setType(CSCCorrelatedLCTDigi::ALCTCLCTGEM);
+  if (hasCoPad) thisLCT.setType(CSCCorrelatedLCTDigi::ALCTCLCT2GEM);
+
   return thisLCT;
 }
 


### PR DESCRIPTION
When CSCCorrelatedLCTDigis are constructed, some information of the original CSCALCTDigi and CSCCLCTDigi gets lots. As a result is not easy to determine which ALCT and CLCT where involved in the LCT construction. In particular in Phase-2 scenarios where GEMPadDigis are combined with CSCALCTDigi and/or CSCCLCTDigi it becomes even more complicated to determine where the CSCCorrelatedLCTDigis came from. This pull request will make the task of debugging the emulator much easier.

I added a member `type_` which can be 
* CLCT-ALCT (classic case)
* ALCT-CLCT (upgrade case for MEX/1)
* ALCT-CLCT-1GEM (1 GEM pad)
* ALCT-CLCT-2GEM (GEM coincidence pad)
* ALCT-2GEM (substitute CLCT for GEM coincidence pad)
* CLCT-2GEM (substitute ALCT for GEM coincidence pad)

In addition I added members to get the original CSCALCTDigi, CSCCLCTDigi and GEMPadDigi. 

Finally I deleted two implementations of `constructLCTs`, one in CSCMotherBoardME11, one in CSCMotherBoardME11GEM. Both were unused in the algorithm.

@Dr15Jones Referring to the discussion on the Framework and Edm Development HN, I find this implementation much more straightforward and easier to implement. Which is why I opted not to use edm::Ref. 

@tahuang1991