### PR TITLE
Tau customization for Phase2

### DIFF
--- a/RecoTauTag/RecoTau/python/PFRecoTauQualityCuts_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauQualityCuts_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 
 # A set of quality cuts used for the PFTaus.  Note that the quality cuts are
 # different for the signal and isolation regions.  (Currently, only in Nhits)
@@ -51,3 +52,6 @@ PFTauQualityCuts = cms.PSet(
     ##leadingTrkOrPFCandOption = cms.string("minLeadTrackOrPFCand")
     ##leadingTrkOrPFCandOption = cms.string("firstTrack") #default behaviour until 710 (first track in the collection)
 )
+phase2_common.toModify(PFTauQualityCuts,
+                       isolationQualityCuts = dict( maxDeltaZ = cms.double(0.1) ) )
+                       

--- a/RecoTauTag/RecoTau/python/RecoTauPiZeroProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauPiZeroProducer_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 import RecoTauTag.RecoTau.RecoTauPiZeroBuilderPlugins_cfi as builders
 import RecoTauTag.RecoTau.RecoTauPiZeroQualityPlugins_cfi as ranking
 from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
-
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 
 ak4PFJetsLegacyHPSPiZeros = cms.EDProducer(
     "RecoTauPiZeroProducer",
@@ -21,7 +21,8 @@ ak4PFJetsLegacyHPSPiZeros = cms.EDProducer(
         ranking.isInStrip
     )
 )
-
+phase2_common.toModify(ak4PFJetsLegacyHPSPiZeros, 
+                       builders = cms.VPSet(builders.modStrips) )
 
 ak4PFJetsRecoTauGreedyPiZeros = ak4PFJetsLegacyHPSPiZeros.clone( 
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
@@ -70,5 +71,3 @@ ak4PFJetsLegacyTaNCPiZeros = ak4PFJetsLegacyHPSPiZeros.clone(
         ranking.legacyPFTauDecayModeSelection
     ),
 )
-
-


### PR DESCRIPTION
As  title says: it is customization for Phase2 upgrade studies at high-PU.  It consists of two modifications compared to the Run-2 baseline:  
* fixed strips (pi-zero candidates) a la Run-1 which protect against "fat strips" due to PU photons,
* tighter dz cut for charged isolation (0.2->0.1) to maintain its efficiency at high-PU.

The modifications do not affect standard workflows, while for Phase2 ones at high-PU a lower number of fake-taus (with e.g. QCD, ttbar samples) esp. at lower-Pt is expected. 

Some further details in slides here:  
* https://indico.cern.ch/event/650324/contributions/2645287/attachments/1485227/2305885/mbluj_TauId_Phase2_fixed_strip_27June2017.pdf 
* https://indico.cern.ch/event/652731/contributions/2656795/attachments/1492042/2319888/mbluj_TauId_Phase2_WPproposal_12July2017.pdf

Backport to 92X and 91X will follow shortly.
 