### PR TITLE
Tau customization for Phase2 (92X)

### DIFF
--- a/RecoTauTag/RecoTau/python/PFRecoTauQualityCuts_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauQualityCuts_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 
 # A set of quality cuts used for the PFTaus.  Note that the quality cuts are
 # different for the signal and isolation regions.  (Currently, only in Nhits)
@@ -51,3 +52,6 @@ PFTauQualityCuts = cms.PSet(
     ##leadingTrkOrPFCandOption = cms.string("minLeadTrackOrPFCand")
     ##leadingTrkOrPFCandOption = cms.string("firstTrack") #default behaviour until 710 (first track in the collection)
 )
+phase2_common.toModify(PFTauQualityCuts,
+                       isolationQualityCuts = dict( maxDeltaZ = cms.double(0.1) ) )
+                       

--- a/RecoTauTag/RecoTau/python/RecoTauPiZeroProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauPiZeroProducer_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 import RecoTauTag.RecoTau.RecoTauPiZeroBuilderPlugins_cfi as builders
 import RecoTauTag.RecoTau.RecoTauPiZeroQualityPlugins_cfi as ranking
 from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
-
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 
 ak4PFJetsLegacyHPSPiZeros = cms.EDProducer(
     "RecoTauPiZeroProducer",
@@ -21,7 +21,8 @@ ak4PFJetsLegacyHPSPiZeros = cms.EDProducer(
         ranking.isInStrip
     )
 )
-
+phase2_common.toModify(ak4PFJetsLegacyHPSPiZeros, 
+                       builders = cms.VPSet(builders.modStrips) )
 
 ak4PFJetsRecoTauGreedyPiZeros = ak4PFJetsLegacyHPSPiZeros.clone( 
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
@@ -70,5 +71,3 @@ ak4PFJetsLegacyTaNCPiZeros = ak4PFJetsLegacyHPSPiZeros.clone(
         ranking.legacyPFTauDecayModeSelection
     ),
 )
-
-


### PR DESCRIPTION
Tau customization for Phase2 studies: backport of #19788 to CMSSW_9_2_X release series. Please check original PR for details.
