### PR TITLE
Set the SOI for HCAL TP samples when packing.

### DIFF
--- a/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
+++ b/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
@@ -144,6 +144,8 @@ namespace TPHeaderSpec{
   static const int MASK_FLAVOR = 0x7;
   static const int OFFSET_HEADER_BIT = 15;
   static const int MASK_HEADER_BIT = 0x1;
+  static const int OFFSET_SOI_BIT = 14;
+  static const int MASK_SOI_BIT = 0x1;
 }
 
 namespace QIE8SampleSpec{
@@ -552,7 +554,7 @@ public:
       auto raw = qiedf->sample(iTS).raw();
       // Add SOI information
       if (iTS == qiedf->presamples())
-         raw |= 0x4000;
+         raw |= TPHeaderSpec::MASK_SOI_BIT << TPHeaderSpec::OFFSET_SOI_BIT;
       uhtrs[uhtrIndex].push_back(raw);
     }// end loop over dataframe words
   };

--- a/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
+++ b/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
@@ -549,7 +549,11 @@ public:
     // loop over words in dataframe
     for( int iTS = 0 ; iTS < qiedf->size() ; iTS++ ){
       // push data into uhtr data container
-      uhtrs[uhtrIndex].push_back(qiedf->sample(iTS).raw());
+      auto raw = qiedf->sample(iTS).raw();
+      // Add SOI information
+      if (iTS == qiedf->presamples())
+         raw |= 0x4000;
+      uhtrs[uhtrIndex].push_back(raw);
     }// end loop over dataframe words
   };
 


### PR DESCRIPTION
See title. The information is accessed on a per-sample basis when unpacking, but the raw samples in MC don't have the corresponding bit set. Set it when packing.