### PR TITLE
CTPPS: leading/trailing edges inversion in diamond unpacker

### DIFF
--- a/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
@@ -28,14 +28,14 @@ class DiamondVFATFrame : public VFATFrame
     /// get timing infromation
     uint32_t getLeadingEdgeTime() const
     {
-      uint32_t time = ((data[5]&0x1f)<<16)+data[6];
+      uint32_t time = ((data[7]&0x1f)<<16)+data[8];
       time = (time & 0xFFE7FFFF) << 2 | (time & 0x00180000) >> 19;    //HPTDC inperpolation bits are MSB but should be LSB.... ask HPTDC designers...
       return time;     
     }
 
     uint32_t getTrailingEdgeTime() const
     {
-      uint32_t time = ((data[7]&0x1f)<<16)+data[8];
+      uint32_t time = ((data[5]&0x1f)<<16)+data[6];
       time = (time & 0xFFE7FFFF) << 2 | (time & 0x00180000) >> 19;   //HPTDC inperpolation bits are MSB but should be LSB.... ask HPTDC designers...
       return time;
     }


### PR DESCRIPTION
This PR introduces the inversion of the leading and trailing edge words in the diamond raw-to-digi unpacker.

Partial backport of #19754 