### PR TITLE
Remove dependence on outdated eos client software

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_alisetup.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_alisetup.py
@@ -258,11 +258,10 @@ def create_mass_storage_directory(mps_dir_name, general_options):
 
     # set directory on eos
     mss_dir = general_options.get("massStorageDir",
-                                  "/store/caf/user/"+os.environ["USER"])
+                                  "/eos/cms/store/caf/user/"+os.environ["USER"])
     mss_dir = os.path.join(mss_dir, "MPproduction", mps_dir_name)
 
-    cmd = ["/afs/cern.ch/project/eos/installation/cms/bin/eos.select",
-           "mkdir", "-p", mss_dir]
+    cmd = ["mkdir", "-p", mss_dir]
 
     # create directory
     if not general_options.get("testMode", False):

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_check.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_check.py
@@ -20,10 +20,7 @@ lib = mpslib.jobdatabase()
 lib.read_db()
 
 # create a list of eos ls entries containing files on eos
-# previously 'cmsLs -l $mssDir' -> deprecated command. Removed in January 2016
-# the simple command "eos ls -l" doesn't work. Exact location of application must be specified.
-eos = '/afs/cern.ch/project/eos/installation/cms/bin/eos.select'
-command = eos+' ls -l '+lib.mssDir
+command = ' ls -l '+lib.mssDir
 eoslsoutput = subprocess.check_output(command, stderr=subprocess.STDOUT, shell=True).split('\n')
 
 # loop over FETCH jobs

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_monitormerge.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_monitormerge.py
@@ -33,13 +33,12 @@ for i in xrange(len(items)):
 	occurences.append(lib.JOBSP3.count(items[i]))
 
 # copy files from eos and combine root-files of each dataset with "hadd"
-eos = '/afs/cern.ch/project/eos/installation/cms/bin/eos.select'
 counter = 0
 for i in xrange(len(items)):
 	command  = 'hadd '
 	command += 'monitormerge_'+items[i]+'.root '	
 	for j in xrange(occurences[i]):
-		os.system(eos+' cp /eos/cms'+eosDir+'/millePedeMonitor%03d.root .' % (counter+j+1))
+		os.system('cp '+eosDir+'/millePedeMonitor%03d.root .' % (counter+j+1))
 		command += 'millePedeMonitor%03d.root ' % (counter+j+1)	
 	os.system(command)
 	for j in xrange(occurences[i]):

--- a/Alignment/MillePedeAlignmentAlgorithm/templates/mps_runMille_template.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/templates/mps_runMille_template.sh
@@ -6,10 +6,6 @@
 #
 # In the very beginning of this script, stager requests for the files will be added.
 
-EOS="/afs/cern.ch/project/eos/installation/cms/bin/eos.select"
-EOSPREFIX="root://eoscms//eos/cms"
-
-
 # these defaults will be overwritten by MPS
 RUNDIR=$HOME/scratch0/some/path
 MSSDIR=/castor/cern.ch/user/u/username/another/path
@@ -67,9 +63,9 @@ if [ "$MSSDIRPOOL" != "cmscafuser" ]; then
   rfcp millePedeMonitor*root $MSSDIR/millePedeMonitorISN.root
 else
   MSSCAFDIR=`echo $MSSDIR | perl -pe 's/\/castor\/cern.ch\/cms//gi'`
-  ${EOS} mkdir -p ${MSSCAFDIR}	# ensure the directory exists
-  echo "xrdcp -f milleBinaryISN.dat.gz ${EOSPREFIX}${MSSCAFDIR}/milleBinaryISN.dat.gz > /dev/null"
-  xrdcp -f milleBinaryISN.dat.gz    ${EOSPREFIX}${MSSCAFDIR}/milleBinaryISN.dat.gz  > /dev/null
-  xrdcp -f treeFile*root         ${EOSPREFIX}${MSSCAFDIR}/treeFileISN.root > /dev/null
-  xrdcp -f millePedeMonitor*root ${EOSPREFIX}${MSSCAFDIR}/millePedeMonitorISN.root > /dev/null
+  mkdir -p ${MSSCAFDIR}	# ensure the directory exists
+  echo "xrdcp -f milleBinaryISN.dat.gz ${MSSCAFDIR}/milleBinaryISN.dat.gz > /dev/null"
+  xrdcp -f milleBinaryISN.dat.gz    ${MSSCAFDIR}/milleBinaryISN.dat.gz  > /dev/null
+  xrdcp -f treeFile*root         ${MSSCAFDIR}/treeFileISN.root > /dev/null
+  xrdcp -f millePedeMonitor*root ${MSSCAFDIR}/millePedeMonitorISN.root > /dev/null
 fi

--- a/Alignment/MillePedeAlignmentAlgorithm/templates/mps_runPede_rfcp_template.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/templates/mps_runPede_rfcp_template.sh
@@ -7,9 +7,6 @@
 #temporary fix (?):
 #unset PYTHONHOME
 
-EOS="/afs/cern.ch/project/eos/installation/cms/bin/eos.select"
-EOSPREFIX="root://eoscms//eos/cms"
-
 cd ${CMSSW_BASE}/src
 eval `scramv1 runtime -sh`
 cd -
@@ -28,7 +25,7 @@ if [ "${MSSDIRPOOL}" != "cmscafuser" ]
 then
     :                           # do nothing
 else
-    TREEFILELIST=`${EOS} ls -l ${MSSDIR} | grep -i treeFile | grep -i root`
+    TREEFILELIST=`ls -l ${MSSDIR} | grep -i treeFile | grep -i root`
 fi
 if [[ -z "${TREEFILELIST}" ]]
 then
@@ -120,8 +117,8 @@ if [ "${MSSDIRPOOL}" != "cmscafuser" ]; then
   echo copytreefile rfcp ${MSSDIR}/treeFileISN.root ${BATCH_DIR} >> parallel-copy-commands.txt
 else
   MSSCAFDIR=`echo ${MSSDIR} | perl -pe 's/\/castor\/cern.ch\/cms//gi'`
-  echo untilSuccess xrdcp ${EOSPREFIX}${MSSCAFDIR}/milleBinaryISN.dat.gz milleBinaryISN.dat.gz >> parallel-copy-commands.txt
-  echo copytreefile xrdcp ${EOSPREFIX}${MSSCAFDIR}/treeFileISN.root treeFileISN.root >> parallel-copy-commands.txt
+  echo untilSuccess xrdcp ${MSSCAFDIR}/milleBinaryISN.dat.gz milleBinaryISN.dat.gz >> parallel-copy-commands.txt
+  echo copytreefile xrdcp ${MSSCAFDIR}/treeFileISN.root treeFileISN.root >> parallel-copy-commands.txt
 fi
 xargs -a stager_get-commands.txt -n 1 -P 10 -I {} bash -c '$@' _ {}
 xargs -a parallel-copy-commands.txt -n 1 -P 10 -I {} bash -c '$@' _ {}


### PR DESCRIPTION
Important fix: remove dependence on outdated eos client software. Uses /eos mount instead. This follows https://cern.service-now.com/service-portal/view-outage.do?n=OTG0037759