### PR TITLE
use StringFormat::value() instead of operator const std::string &()

### DIFF
--- a/DQMServices/Core/src/DQMNet.cc
+++ b/DQMServices/Core/src/DQMNet.cc
@@ -968,10 +968,10 @@ DQMNet::onPeerConnect(IOSelectEvent *ev)
     InetAddress myaddr = inet->sockname();
     p->peeraddr = StringFormat("%1:%2")
 		  .arg(peeraddr.hostname())
-		  .arg(peeraddr.port());
+		  .arg(peeraddr.port()).value();
     localaddr = StringFormat("%1:%2")
 		.arg(myaddr.hostname())
-		.arg(myaddr.port());
+		.arg(myaddr.port()).value();
   }
   else if (LocalSocket *local = dynamic_cast<LocalSocket *>(s))
   {
@@ -1349,7 +1349,7 @@ DQMNet::run(void)
 	  InetAddress myaddr = ((InetSocket *) s)->sockname();
 	  p->peeraddr = StringFormat("%1:%2")
 			.arg(peeraddr.hostname())
-			.arg(peeraddr.port());
+			.arg(peeraddr.port()).value();
 	  p->mask = IORead|IOWrite|IOUrgent;
 	  p->update = ap->update;
 	  p->automatic = ap;


### PR DESCRIPTION
For clang IBs we see link errors like 
```
DQMServices/Core/src/DQMNet.cc:(.text+0x32e7): undefined reference to `lat::StringFormat::operator std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&() const'
DQMServices/Core/src/DQMNet.cc:(.text+0x3487): undefined reference to `lat::StringFormat::operator std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&() const'
tmp/slc6_amd64_gcc630/src/DQMServices/Core/src/DQMServicesCore/DQMNet.o: In function `DQMNet::run()':
DQMServices/Core/src/DQMNet.cc:(.text+0x5157): undefined reference to `lat::StringFormat::operator std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&() const'
```
this PR uses ```const std::string & StringFormat::value()``` instead of implicit call to ```operator const std::string &()``` to avoid this error.