### PR TITLE
initialize variable in CondFormats/Serialization

### DIFF
--- a/CondFormats/Serialization/interface/Test.h
+++ b/CondFormats/Serialization/interface/Test.h
@@ -52,7 +52,7 @@ void testSerialization()
     // of non-POD types without user-provided default constructor
     // (since it would be uninitialized), so we always create
     // a non-const object.
-    T originalObject;
+    T originalObject{};
     const T & originalObjectRef = originalObject;
     {
         std::ofstream ofs(filename, std::ios::out | std::ios::binary);


### PR DESCRIPTION
See errors in #19645. I'm not sure this resolves them, but seems it should.