### PR TITLE
Phase2 - HGCal - Filtering PFRecHits based on SNR threshold

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
@@ -99,7 +99,7 @@ bool HGCalRecHitWorkerSimple::run(const edm::Event & evt, const HGCUncalibratedR
         hid = detid;
         thickness = ddds_[hid.subdetId() - 3]->waferTypeL(hid.wafer());
         sigmaNoiseGeV = 1e-3 * weights_[layer] * rcorr_[thickness]
-                    * hgcHEF_noise_fC_[thickness - 1] / hgcHEF_fCPerMIP_[thickness - 1];
+                    * hgcEE_noise_fC_[thickness - 1] / hgcEE_fCPerMIP_[thickness - 1];
         break;
     case HGCHEF:
         rechitMaker_->setADCToGeVConstant(float(hgchefUncalib2GeV_));

--- a/RecoParticleFlow/PFClusterProducer/BuildFile.xml
+++ b/RecoParticleFlow/PFClusterProducer/BuildFile.xml
@@ -11,6 +11,7 @@
 <use   name="RecoParticleFlow/PFClusterTools"/>
 <use   name="Calibration/Tools"/>
 <use   name="CalibCalorimetry/EcalTPGTools"/>
+<use   name="DataFormats/HGCRecHit"/>
 <use   name="vdt_headers"/>
 <use   name="rootmath"/>
 <use   name="root"/>

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -845,6 +845,7 @@ class PFRecHitQTestHGCalThresholdSNR: public PFRecHitQTestBase
 
         bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override
         {
+            std::cout << "found hit with energy " << rh.energy() << " SNR: " <<  rh.signalOverSigmaNoise() << std::endl;
             return rh.signalOverSigmaNoise() > thresholdSNR_;
         }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -845,8 +845,7 @@ class PFRecHitQTestHGCalThresholdSNR: public PFRecHitQTestBase
 
         bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override
         {
-            std::cout << "found hit with energy " << rh.energy() << " SNR: " <<  rh.signalOverSigmaNoise() << std::endl;
-            return rh.signalOverSigmaNoise() > thresholdSNR_;
+            return rh.signalOverSigmaNoise() >= thresholdSNR_;
         }
 
     protected:

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -792,4 +792,64 @@ class PFRecHitQTestThresholdInThicknessNormalizedMIPs : public PFRecHitQTestBase
     }
 };
 
+
+class PFRecHitQTestHGCalThresholdSNR: public PFRecHitQTestBase
+{
+    public:
+        PFRecHitQTestHGCalThresholdSNR() :
+                thresholdSNR_(0.)
+        {
+        }
+
+        PFRecHitQTestHGCalThresholdSNR(const edm::ParameterSet& iConfig) :
+                PFRecHitQTestBase(iConfig), thresholdSNR_(iConfig.getParameter<double>("thresholdSNR"))
+        {
+        }
+
+        void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override
+        {
+        }
+
+        bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override
+        {
+            throw cms::Exception("WrongDetector")
+                    << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
+            return false;
+        }
+        bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override
+        {
+            throw cms::Exception("WrongDetector")
+                    << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
+            return false;
+        }
+
+        bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override
+        {
+            throw cms::Exception("WrongDetector")
+                    << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
+            return false;
+        }
+        bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override
+        {
+            throw cms::Exception("WrongDetector")
+                    << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
+            return false;
+        }
+
+        bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override
+        {
+            throw cms::Exception("WrongDetector")
+                    << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
+            return false;
+        }
+
+        bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override
+        {
+            return rh.signalOverSigmaNoise() > thresholdSNR_;
+        }
+
+    protected:
+        const double thresholdSNR_;
+};
+
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/RecHitQualityTests.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/RecHitQualityTests.cc
@@ -17,3 +17,5 @@ DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestHCALThresholdVsDepth, "PFRe
 
 DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestThresholdInMIPs, "PFRecHitQTestThresholdInMIPs");
 DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestThresholdInThicknessNormalizedMIPs, "PFRecHitQTestThresholdInThicknessNormalizedMIPs");
+
+DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestHGCalThresholdSNR, "PFRecHitQTestHGCalThresholdSNR");

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGC_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGC_cfi.py
@@ -22,6 +22,8 @@ particleFlowRecHitHGC = cms.EDProducer("PFRecHitProducer",
              src  = cms.InputTag("HGCalRecHit:HGCEERecHits"),
              geometryInstance = cms.string("HGCalEESensitive"),
              qualityTests = cms.VPSet(
+# Enabling PFRecHitQTestHGCalThresholdSNR will filter out of the PFRecHits, all the HGCRecHits with energy not exceeding
+# 5 sigma noise                 
 #                 cms.PSet(
 #                     name = cms.string("PFRecHitQTestHGCalThresholdSNR"),
 #                     thresholdSNR = cms.double(5.0),
@@ -33,6 +35,8 @@ particleFlowRecHitHGC = cms.EDProducer("PFRecHitProducer",
              src  = cms.InputTag("HGCalRecHit:HGCHEFRecHits"),
              geometryInstance = cms.string("HGCalHESiliconSensitive"),
              qualityTests = cms.VPSet(
+# Enabling PFRecHitQTestHGCalThresholdSNR will filter out of the PFRecHits, all the HGCRecHits with energy not exceeding
+# 5 sigma noise                     
 #                 cms.PSet(
 #                     name = cms.string("PFRecHitQTestHGCalThresholdSNR"),
 #                     thresholdSNR = cms.double(5.0),
@@ -44,6 +48,8 @@ particleFlowRecHitHGC = cms.EDProducer("PFRecHitProducer",
              src  = cms.InputTag("HGCalRecHit:HGCHEBRecHits"),
              geometryInstance = cms.string(""),
              qualityTests = cms.VPSet(
+# Enabling PFRecHitQTestHGCalThresholdSNR will filter out of the PFRecHits, all the HGCRecHits with energy not exceeding
+# 5 sigma noise                     
 #                 cms.PSet(
 #                     name = cms.string("PFRecHitQTestHGCalThresholdSNR"),
 #                     thresholdSNR = cms.double(5.0),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGC_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGC_cfi.py
@@ -22,10 +22,10 @@ particleFlowRecHitHGC = cms.EDProducer("PFRecHitProducer",
              src  = cms.InputTag("HGCalRecHit:HGCEERecHits"),
              geometryInstance = cms.string("HGCalEESensitive"),
              qualityTests = cms.VPSet(
-                cms.PSet(
-                    name = cms.string("PFRecHitQTestHGCalThresholdSNR"),
-                    thresholdSNR = cms.double(5.0),
-                   ),
+#                 cms.PSet(
+#                     name = cms.string("PFRecHitQTestHGCalThresholdSNR"),
+#                     thresholdSNR = cms.double(5.0),
+#                    ),
                 )              
            ),
            cms.PSet(
@@ -33,10 +33,10 @@ particleFlowRecHitHGC = cms.EDProducer("PFRecHitProducer",
              src  = cms.InputTag("HGCalRecHit:HGCHEFRecHits"),
              geometryInstance = cms.string("HGCalHESiliconSensitive"),
              qualityTests = cms.VPSet(
-                cms.PSet(
-                    name = cms.string("PFRecHitQTestHGCalThresholdSNR"),
-                    thresholdSNR = cms.double(5.0),
-                   ),                 
+#                 cms.PSet(
+#                     name = cms.string("PFRecHitQTestHGCalThresholdSNR"),
+#                     thresholdSNR = cms.double(5.0),
+#                    ),                 
                 )
            ),
            cms.PSet(
@@ -44,10 +44,10 @@ particleFlowRecHitHGC = cms.EDProducer("PFRecHitProducer",
              src  = cms.InputTag("HGCalRecHit:HGCHEBRecHits"),
              geometryInstance = cms.string(""),
              qualityTests = cms.VPSet(
-                cms.PSet(
-                    name = cms.string("PFRecHitQTestHGCalThresholdSNR"),
-                    thresholdSNR = cms.double(5.0),
-                   ),                 
+#                 cms.PSet(
+#                     name = cms.string("PFRecHitQTestHGCalThresholdSNR"),
+#                     thresholdSNR = cms.double(5.0),
+#                    ),                 
                 )
            )
     )          

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGC_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGC_cfi.py
@@ -21,7 +21,11 @@ particleFlowRecHitHGC = cms.EDProducer("PFRecHitProducer",
              name = cms.string("PFHGCEERecHitCreator"),
              src  = cms.InputTag("HGCalRecHit:HGCEERecHits"),
              geometryInstance = cms.string("HGCalEESensitive"),
-             qualityTests = cms.VPSet(  
+             qualityTests = cms.VPSet(
+                 cms.PSet(
+                     name = cms.string("PFRecHitQTestHGCalThresholdSNR"),
+                     thresholdSNR = cms.double(5.0),
+                    ),
                 )              
            ),
            cms.PSet(
@@ -29,6 +33,10 @@ particleFlowRecHitHGC = cms.EDProducer("PFRecHitProducer",
              src  = cms.InputTag("HGCalRecHit:HGCHEFRecHits"),
              geometryInstance = cms.string("HGCalHESiliconSensitive"),
              qualityTests = cms.VPSet(
+                 cms.PSet(
+                     name = cms.string("PFRecHitQTestHGCalThresholdSNR"),
+                     thresholdSNR = cms.double(5.0),
+                    ),                 
                 )
            ),
            cms.PSet(
@@ -36,6 +44,10 @@ particleFlowRecHitHGC = cms.EDProducer("PFRecHitProducer",
              src  = cms.InputTag("HGCalRecHit:HGCHEBRecHits"),
              geometryInstance = cms.string(""),
              qualityTests = cms.VPSet(
+                 cms.PSet(
+                     name = cms.string("PFRecHitQTestHGCalThresholdSNR"),
+                     thresholdSNR = cms.double(5.0),
+                    ),                 
                 )
            )
     )          

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGC_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGC_cfi.py
@@ -22,10 +22,10 @@ particleFlowRecHitHGC = cms.EDProducer("PFRecHitProducer",
              src  = cms.InputTag("HGCalRecHit:HGCEERecHits"),
              geometryInstance = cms.string("HGCalEESensitive"),
              qualityTests = cms.VPSet(
-                 cms.PSet(
-                     name = cms.string("PFRecHitQTestHGCalThresholdSNR"),
-                     thresholdSNR = cms.double(5.0),
-                    ),
+                cms.PSet(
+                    name = cms.string("PFRecHitQTestHGCalThresholdSNR"),
+                    thresholdSNR = cms.double(5.0),
+                   ),
                 )              
            ),
            cms.PSet(
@@ -33,10 +33,10 @@ particleFlowRecHitHGC = cms.EDProducer("PFRecHitProducer",
              src  = cms.InputTag("HGCalRecHit:HGCHEFRecHits"),
              geometryInstance = cms.string("HGCalHESiliconSensitive"),
              qualityTests = cms.VPSet(
-                 cms.PSet(
-                     name = cms.string("PFRecHitQTestHGCalThresholdSNR"),
-                     thresholdSNR = cms.double(5.0),
-                    ),                 
+                cms.PSet(
+                    name = cms.string("PFRecHitQTestHGCalThresholdSNR"),
+                    thresholdSNR = cms.double(5.0),
+                   ),                 
                 )
            ),
            cms.PSet(
@@ -44,10 +44,10 @@ particleFlowRecHitHGC = cms.EDProducer("PFRecHitProducer",
              src  = cms.InputTag("HGCalRecHit:HGCHEBRecHits"),
              geometryInstance = cms.string(""),
              qualityTests = cms.VPSet(
-                 cms.PSet(
-                     name = cms.string("PFRecHitQTestHGCalThresholdSNR"),
-                     thresholdSNR = cms.double(5.0),
-                    ),                 
+                cms.PSet(
+                    name = cms.string("PFRecHitQTestHGCalThresholdSNR"),
+                    thresholdSNR = cms.double(5.0),
+                   ),                 
                 )
            )
     )          


### PR DESCRIPTION
This PR is another step towards making RealisticSimClusters more realistic. 

A HGCRecHit produces a PFRecHit if its energy is above 5 sigma noise. 
The quality test is disabled and can be enabled for testing purposes by uncommenting the code in py configuration.
It will be enabled when RealisticSimClusters will be activated.

@malgeri @rovere @cseez @kpedro88 @vandreev11