### PR TITLE
xml files containing updated summary plot limit + fix for cosmic [Backport combining #19447 and #19713] 

### DIFF
--- a/DQM/SiPixelPhase1Config/test/qTests/mean_adc_qualitytest_config.xml
+++ b/DQM/SiPixelPhase1Config/test/qTests/mean_adc_qualitytest_config.xml
@@ -2,134 +2,533 @@
   <!-- QTESTS for MEAN ADC: -->
 
   <!-- PXBARREL -->
-  <!-- PXLAYER 1 -->
-  <QTEST name="Yrange:PXLayer_1:mean_adc" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.50</PARAM>
-    <PARAM name="warning">0.90</PARAM>
-    <PARAM name="ymin">50.</PARAM>
-    <PARAM name="ymax">200.</PARAM>
-  </QTEST>
-  <!-- PXLAYER 2 -->  <!-- warn -->
-  <QTEST name="Yrange:PXLayer_2:mean_adc" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.</PARAM>
-    <PARAM name="warning">0.99</PARAM>
-    <PARAM name="ymin">50.</PARAM>
-    <PARAM name="ymax">200.</PARAM>
-  </QTEST>
-  <!-- PXLAYER 3 --> <!-- error -->
-  <QTEST name="Yrange:PXLayer_3:mean_adc" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.99</PARAM>
-    <PARAM name="warning">0.99</PARAM>
-    <PARAM name="ymin">50.</PARAM>
-    <PARAM name="ymax">200.</PARAM>
-  </QTEST>
-  <!-- PXLAYER 4 --> <!-- pass -->
-  <QTEST name="Yrange:PXLayer_4:mean_adc" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.</PARAM>
-    <PARAM name="warning">0.</PARAM>
-    <PARAM name="ymin">50.</PARAM>
-    <PARAM name="ymax">200.</PARAM>
-  </QTEST>
+    <!-- PXLAYER 1 -->
+    <QTEST name="Yrange:PXLayer_1__Shell_mI:mean_adc" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">120.</PARAM>
+      <PARAM name="ymax">160.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_1__Shell_mO:mean_adc" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">120.</PARAM>
+      <PARAM name="ymax">160.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_1__Shell_pI:mean_adc" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">120.</PARAM>
+      <PARAM name="ymax">160.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_1__Shell_pO:mean_adc" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">120.</PARAM>
+      <PARAM name="ymax">160.</PARAM>
+    </QTEST>
+
+    <!-- PXLAYER 2 -->
+    <QTEST name="Yrange:PXLayer_2__Shell_mI:mean_adc" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">80.</PARAM>
+      <PARAM name="ymax">120.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_2__Shell_mO:mean_adc" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">80.</PARAM>
+      <PARAM name="ymax">120.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_2__Shell_pI:mean_adc" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">80.</PARAM>
+      <PARAM name="ymax">110.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_2__Shell_pO:mean_adc" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">80.</PARAM>
+      <PARAM name="ymax">110.</PARAM>
+    </QTEST>
+
+    <!-- PXLAYER 3 -->
+    <QTEST name="Yrange:PXLayer_3__Shell_mI:mean_adc" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">80.</PARAM>
+      <PARAM name="ymax">110.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_3__Shell_mO:mean_adc" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">80.</PARAM>
+      <PARAM name="ymax">110.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_3__Shell_pI:mean_adc" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">80.</PARAM>
+      <PARAM name="ymax">110.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_3__Shell_pO:mean_adc" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">80.</PARAM>
+      <PARAM name="ymax">110.</PARAM>
+    </QTEST>
+
+    <!-- PXLAYER 4 -->
+    <QTEST name="Yrange:PXLayer_4__Shell_mI:mean_adc" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">80.</PARAM>
+      <PARAM name="ymax">110.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_4__Shell_mO:mean_adc" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">80.</PARAM>
+      <PARAM name="ymax">110.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_4__Shell_pI:mean_adc" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">80.</PARAM>
+      <PARAM name="ymax">110.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_4__Shell_pO:mean_adc" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">75.</PARAM>
+      <PARAM name="ymax">105.</PARAM>
+    </QTEST>
 
   <!-- PXFORWARD -->
-  <!-- PXRING 1 -->
-  <!-- PXDISK ±1 --> <!-- error -->
-  <QTEST name="Yrange:PXRing_1__PXDisk_±1:mean_adc" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.50</PARAM>
-    <PARAM name="warning">0.90</PARAM>
-    <PARAM name="ymin">50.</PARAM>
-    <PARAM name="ymax">200.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±2 --> <!-- pass -->
-  <QTEST name="Yrange:PXRing_1__PXDisk_±2:mean_adc" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.50</PARAM>
-    <PARAM name="warning">0.90</PARAM>
-    <PARAM name="ymin">50.</PARAM>
-    <PARAM name="ymax">200.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±3 -->
-  <QTEST name="Yrange:PXRing_1__PXDisk_±3:mean_adc" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.50</PARAM>
-    <PARAM name="warning">0.90</PARAM>
-    <PARAM name="ymin">50.</PARAM>
-    <PARAM name="ymax">200.</PARAM>
-  </QTEST>
-  <!-- PXRING 2 -->
-  <!-- PXDISK ±1 -->
-  <QTEST name="Yrange:PXRing_2__PXDisk_±1:mean_adc" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.50</PARAM>
-    <PARAM name="warning">0.90</PARAM>
-    <PARAM name="ymin">50.</PARAM>
-    <PARAM name="ymax">200.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±2 -->
-  <QTEST name="Yrange:PXRing_2__PXDisk_±2:mean_adc" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.50</PARAM>
-    <PARAM name="warning">0.90</PARAM>
-    <PARAM name="ymin">50.</PARAM>
-    <PARAM name="ymax">200.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±3 -->
-  <QTEST name="Yrange:PXRing_2__PXDisk_±3:mean_adc" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.50</PARAM>
-    <PARAM name="warning">0.90</PARAM>
-    <PARAM name="ymin">50.</PARAM>
-    <PARAM name="ymax">200.</PARAM>
-  </QTEST>
+    <!-- HCMI -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-1:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-2:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-3:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-1:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-2:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-3:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+    <!-- HCMO -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-1:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-2:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-3:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-1:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-2:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">85.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-3:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">85.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+    <!-- HCPI -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+1:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+2:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+3:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+1:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+2:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+3:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
+      </QTEST>
+
+    <!-- HCPO -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+1:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+2:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+3:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+1:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+2:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+3:mean_adc" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">110.</PARAM>
+      </QTEST>
 
 
-  <!-- LINKS between Quality Tests and Monitoring Elements: -->
-  <!-- PXBARREL LINKS -->
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_adc_PXLayer_1">
-    <TestName activate="true">Yrange:PXLayer_1:mean_adc</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_adc_PXLayer_2">
-    <TestName activate="true">Yrange:PXLayer_2:mean_adc</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_adc_PXLayer_3">
-    <TestName activate="true">Yrange:PXLayer_3:mean_adc</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_adc_PXLayer_4">
-    <TestName activate="true">Yrange:PXLayer_4:mean_adc</TestName>
-  </LINK>
+  <!-- LINKS between Quality Tests and Monitoring Elements -->
+    <!-- PXBARREL LINKS -->
+      <!-- PXLAYER 1 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_adc_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_mI:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_adc_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_mO:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_adc_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_pI:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_adc_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_pO:mean_adc</TestName>
+      </LINK>
+
+      <!-- PXLAYER 2 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_adc_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_mI:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_adc_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_mO:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_adc_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_pI:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_adc_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_pO:mean_adc</TestName>
+      </LINK>
+
+      <!-- PXLAYER 3 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_adc_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_mI:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_adc_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_mO:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_adc_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_pI:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_adc_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_pO:mean_adc</TestName>
+      </LINK>
+
+      <!-- PXLAYER 4 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_adc_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_mI:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_adc_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_mO:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_adc_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_pI:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_adc_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_pO:mean_adc</TestName>
+      </LINK>
 
   <!-- PXFORWARD LINKS -->
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_adc_PXDisk_*1">
-    <TestName activate="true">Yrange:PXRing_1__PXDisk_±1:mean_adc</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_adc_PXDisk_*2">
-    <TestName activate="true">Yrange:PXRing_1__PXDisk_±2:mean_adc</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_adc_PXDisk_*3">
-    <TestName activate="true">Yrange:PXRing_1__PXDisk_±3:mean_adc</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_adc_PXDisk_*1">
-    <TestName activate="true">Yrange:PXRing_2__PXDisk_±1:mean_adc</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_adc_PXDisk_*2">
-    <TestName activate="true">Yrange:PXRing_2__PXDisk_±2:mean_adc</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_adc_PXDisk_*3">
-    <TestName activate="true">Yrange:PXRing_2__PXDisk_±3:mean_adc</TestName>
-  </LINK>
+    <!-- HCMI -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_1/mean_adc_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-1:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_1/mean_adc_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-2:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_1/mean_adc_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-3:mean_adc</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_2/mean_adc_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-1:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_2/mean_adc_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-2:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_2/mean_adc_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-3:mean_adc</TestName>
+      </LINK>
+
+    <!-- HCMO -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_1/mean_adc_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-1:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_1/mean_adc_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-2:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_1/mean_adc_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-3:mean_adc</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_2/mean_adc_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-1:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_2/mean_adc_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-2:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_2/mean_adc_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-3:mean_adc</TestName>
+      </LINK>
+
+    <!-- HCPI -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_1/mean_adc_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+1:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_1/mean_adc_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+2:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_1/mean_adc_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+3:mean_adc</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_2/mean_adc_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+1:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_2/mean_adc_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+2:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_2/mean_adc_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+3:mean_adc</TestName>
+      </LINK>
+
+    <!-- HCPO -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_1/mean_adc_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+1:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_1/mean_adc_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+2:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_1/mean_adc_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+3:mean_adc</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_2/mean_adc_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+1:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_2/mean_adc_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+2:mean_adc</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_2/mean_adc_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+3:mean_adc</TestName>
+      </LINK>
+
 </TESTCONFIGURATION>

--- a/DQM/SiPixelPhase1Config/test/qTests/mean_charge_qualitytest_config.xml
+++ b/DQM/SiPixelPhase1Config/test/qTests/mean_charge_qualitytest_config.xml
@@ -2,134 +2,539 @@
   <!-- QTESTS for MEAN CHARGE: -->
 
   <!-- PXBARREL -->
-  <!-- PXLAYER 1 -->
-  <QTEST name="Yrange:PXLayer_1:mean_charge" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">20.</PARAM>
-    <PARAM name="ymax">100000.</PARAM>
-  </QTEST>
-  <!-- PXLAYER 2 -->  <!-- warn -->
-  <QTEST name="Yrange:PXLayer_2:mean_charge" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">20.</PARAM>
-    <PARAM name="ymax">100000.</PARAM>
-  </QTEST>
-  <!-- PXLAYER 3 --> <!-- error -->
-  <QTEST name="Yrange:PXLayer_3:mean_charge" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">20.</PARAM>
-    <PARAM name="ymax">100000.</PARAM>
-  </QTEST>
-  <!-- PXLAYER 4 --> <!-- pass -->
-  <QTEST name="Yrange:PXLayer_4:mean_charge" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">20.</PARAM>
-    <PARAM name="ymax">100000.</PARAM>
-  </QTEST>
+    <!-- PXLAYER 1 -->
+    <QTEST name="Yrange:PXLayer_1__Shell_mI:mean_charge" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">70000</PARAM>
+      <PARAM name="ymax">90000.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_1__Shell_mO:mean_charge" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">65000</PARAM>
+      <PARAM name="ymax">80000.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_1__Shell_pI:mean_charge" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">70000</PARAM>
+      <PARAM name="ymax">90000.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_1__Shell_pO:mean_charge" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">70000</PARAM>
+      <PARAM name="ymax">9000.</PARAM>
+    </QTEST>
+
+    <!-- PXLAYER 2 -->
+    <QTEST name="Yrange:PXLayer_2__Shell_mI:mean_charge" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">70000</PARAM>
+      <PARAM name="ymax">110000.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_2__Shell_mO:mean_charge" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">70000</PARAM>
+      <PARAM name="ymax">110000.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_2__Shell_pI:mean_charge" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">65000</PARAM>
+      <PARAM name="ymax">90000.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_2__Shell_pO:mean_charge" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">70000</PARAM>
+      <PARAM name="ymax">90000.</PARAM>
+    </QTEST>
+
+    <!-- PXLAYER 3 -->
+    <QTEST name="Yrange:PXLayer_3__Shell_mI:mean_charge" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">60000</PARAM>
+      <PARAM name="ymax">80000.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_3__Shell_mO:mean_charge" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">65000</PARAM>
+      <PARAM name="ymax">80000.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_3__Shell_pI:mean_charge" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">60000</PARAM>
+      <PARAM name="ymax">80000.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_3__Shell_pO:mean_charge" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">60000</PARAM>
+      <PARAM name="ymax">80000.</PARAM>
+    </QTEST>
+
+    <!-- PXLAYER 4 -->
+    <QTEST name="Yrange:PXLayer_4__Shell_mI:mean_charge" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">60000</PARAM>
+      <PARAM name="ymax">80000.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_4__Shell_mO:mean_charge" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">60000</PARAM>
+      <PARAM name="ymax">75000.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_4__Shell_pI:mean_charge" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">60000</PARAM>
+      <PARAM name="ymax">75000.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_4__Shell_pO:mean_charge" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">60000</PARAM>
+      <PARAM name="ymax">75000.</PARAM>
+    </QTEST>
 
   <!-- PXFORWARD -->
-  <!-- PXRING 1 -->
-  <!-- PXDISK ±1 --> <!-- error -->
-  <QTEST name="Yrange:PXRing_1__PXDisk_±1:mean_charge" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">20.</PARAM>
-    <PARAM name="ymax">100000.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±2 --> <!-- pass -->
-  <QTEST name="Yrange:PXRing_1__PXDisk_±2:mean_charge" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">20.</PARAM>
-    <PARAM name="ymax">100000.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±3 -->
-  <QTEST name="Yrange:PXRing_1__PXDisk_±3:mean_charge" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">20.</PARAM>
-    <PARAM name="ymax">100000.</PARAM>
-  </QTEST>
-  <!-- PXRING 2 -->
-  <!-- PXDISK ±1 -->
-  <QTEST name="Yrange:PXRing_2__PXDisk_±1:mean_charge" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">20.</PARAM>
-    <PARAM name="ymax">100000.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±2 -->
-  <QTEST name="Yrange:PXRing_2__PXDisk_±2:mean_charge" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">20.</PARAM>
-    <PARAM name="ymax">100000.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±3 -->
-  <QTEST name="Yrange:PXRing_2__PXDisk_±3:mean_charge" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">20.</PARAM>
-    <PARAM name="ymax">100000.</PARAM>
-  </QTEST>
+    <!-- HCMI -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-1:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">40000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-2:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">40000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-3:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">40000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-1:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">40000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-2:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">40000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-3:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">40000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
 
 
-  <!-- LINKS between Quality Tests and Monitoring Elements: -->
-  <!-- PXBARREL LINKS -->
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_charge_PXLayer_1">
-    <TestName activate="true">Yrange:PXLayer_1:mean_charge</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_charge_PXLayer_2">
-    <TestName activate="true">Yrange:PXLayer_2:mean_charge</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_charge_PXLayer_3">
-    <TestName activate="true">Yrange:PXLayer_3:mean_charge</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_charge_PXLayer_4">
-    <TestName activate="true">Yrange:PXLayer_4:mean_charge</TestName>
-  </LINK>
+    <!-- HCMO -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-1:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">40000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-2:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">40000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-3:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">40000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-1:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">45000</PARAM>
+        <PARAM name="ymax">60000.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-2:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">45000</PARAM>
+        <PARAM name="ymax">60000.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-3:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">40000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+    
+    <!-- HCPI -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+1:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">40000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+2:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">45000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+3:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">40000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+1:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">45000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+2:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">45000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+3:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">45000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+     
+    <!-- HCPO -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+1:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">40000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+2:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">40000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+3:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">40000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+1:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">45000</PARAM>
+        <PARAM name="ymax">60000.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+2:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">45000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+3:mean_charge" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">40000</PARAM>
+        <PARAM name="ymax">55000.</PARAM>
+      </QTEST>
+
+     
+  <!-- LINKS between Quality Tests and Monitoring Elements -->
+    <!-- PXBARREL LINKS -->
+      <!-- PXLAYER 1 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_charge_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_mI:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_charge_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_mO:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_charge_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_pI:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_charge_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_pO:mean_charge</TestName>
+      </LINK>
+
+      <!-- PXLAYER 2 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_charge_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_mI:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_charge_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_mO:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_charge_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_pI:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_charge_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_pO:mean_charge</TestName>
+      </LINK>
+
+      <!-- PXLAYER 3 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_charge_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_mI:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_charge_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_mO:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_charge_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_pI:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_charge_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_pO:mean_charge</TestName>
+      </LINK>
+
+      <!-- PXLAYER 4 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_charge_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_mI:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_charge_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_mO:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_charge_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_pI:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_charge_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_pO:mean_charge</TestName>
+      </LINK>
 
   <!-- PXFORWARD LINKS -->
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_charge_PXDisk_*1">
-    <TestName activate="true">Yrange:PXRing_1__PXDisk_±1:mean_charge</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_charge_PXDisk_*2">
-    <TestName activate="true">Yrange:PXRing_1__PXDisk_±2:mean_charge</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_charge_PXDisk_*3">
-    <TestName activate="true">Yrange:PXRing_1__PXDisk_±3:mean_charge</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_charge_PXDisk_*1">
-    <TestName activate="true">Yrange:PXRing_2__PXDisk_±1:mean_charge</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_charge_PXDisk_*2">
-    <TestName activate="true">Yrange:PXRing_2__PXDisk_±2:mean_charge</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_charge_PXDisk_*3">
-    <TestName activate="true">Yrange:PXRing_2__PXDisk_±3:mean_charge</TestName>
-  </LINK>
+    <!-- HCMI -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_1/mean_charge_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-1:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_1/mean_charge_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-2:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_1/mean_charge_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-3:mean_charge</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_2/mean_charge_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-1:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_2/mean_charge_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-2:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_2/mean_charge_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-3:mean_charge</TestName>
+      </LINK>
+
+     
+    <!-- HCMO -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_1/mean_charge_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-1:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_1/mean_charge_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-2:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_1/mean_charge_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-3:mean_charge</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_2/mean_charge_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-1:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_2/mean_charge_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-2:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_2/mean_charge_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-3:mean_charge</TestName>
+      </LINK>
+
+    
+    <!-- HCPI -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_1/mean_charge_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+1:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_1/mean_charge_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+2:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_1/mean_charge_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+3:mean_charge</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_2/mean_charge_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+1:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_2/mean_charge_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+2:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_2/mean_charge_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+3:mean_charge</TestName>
+      </LINK>
+
+     
+    <!-- HCPO -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_1/mean_charge_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+1:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_1/mean_charge_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+2:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_1/mean_charge_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+3:mean_charge</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_2/mean_charge_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+1:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_2/mean_charge_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+2:mean_charge</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_2/mean_charge_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+3:mean_charge</TestName>
+      </LINK>
+
 </TESTCONFIGURATION>

--- a/DQM/SiPixelPhase1Config/test/qTests/mean_num_clusters_qualitytest_config.xml
+++ b/DQM/SiPixelPhase1Config/test/qTests/mean_num_clusters_qualitytest_config.xml
@@ -2,134 +2,533 @@
   <!-- QTESTS for MEAN NUMBER OF CLUSTERS: -->
 
   <!-- PXBARREL -->
-  <!-- PXLAYER 1 -->
-  <QTEST name="Yrange:PXLayer_1:mean_num_clusters" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">3.</PARAM>
-  </QTEST>
-  <!-- PXLAYER 2 -->  <!-- warn -->
-  <QTEST name="Yrange:PXLayer_2:mean_num_clusters" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">3.</PARAM>
-  </QTEST>
-  <!-- PXLAYER 3 --> <!-- error -->
-  <QTEST name="Yrange:PXLayer_3:mean_num_clusters" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">3.</PARAM>
-  </QTEST>
-  <!-- PXLAYER 4 --> <!-- pass -->
-  <QTEST name="Yrange:PXLayer_4:mean_num_clusters" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">3.</PARAM>
-  </QTEST>
+    <!-- PXLAYER 1 -->
+    <QTEST name="Yrange:PXLayer_1__Shell_mI:mean_num_clusters" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">15.</PARAM>
+      <PARAM name="ymax">40.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_1__Shell_mO:mean_num_clusters" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">14.</PARAM>
+      <PARAM name="ymax">40.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_1__Shell_pI:mean_num_clusters" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">10.</PARAM>
+      <PARAM name="ymax">40.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_1__Shell_pO:mean_num_clusters" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">12.</PARAM>
+      <PARAM name="ymax">40.</PARAM>
+    </QTEST>
+
+    <!-- PXLAYER 2 -->
+    <QTEST name="Yrange:PXLayer_2__Shell_mI:mean_num_clusters" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">2.5</PARAM>
+      <PARAM name="ymax">15.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_2__Shell_mO:mean_num_clusters" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">3.</PARAM>
+      <PARAM name="ymax">15.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_2__Shell_pI:mean_num_clusters" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">4.</PARAM>
+      <PARAM name="ymax">16.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_2__Shell_pO:mean_num_clusters" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">4.</PARAM>
+      <PARAM name="ymax">16.</PARAM>
+    </QTEST>
+
+    <!-- PXLAYER 3 -->
+    <QTEST name="Yrange:PXLayer_3__Shell_mI:mean_num_clusters" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">2.</PARAM>
+      <PARAM name="ymax">10.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_3__Shell_mO:mean_num_clusters" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">2.5</PARAM>
+      <PARAM name="ymax">10.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_3__Shell_pI:mean_num_clusters" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">2.</PARAM>
+      <PARAM name="ymax">10.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_3__Shell_pO:mean_num_clusters" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">2.</PARAM>
+      <PARAM name="ymax">10.</PARAM>
+    </QTEST>
+
+    <!-- PXLAYER 4 -->
+    <QTEST name="Yrange:PXLayer_4__Shell_mI:mean_num_clusters" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">1.</PARAM>
+      <PARAM name="ymax">5.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_4__Shell_mO:mean_num_clusters" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">1.</PARAM>
+      <PARAM name="ymax">5.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_4__Shell_pI:mean_num_clusters" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">1.</PARAM>
+      <PARAM name="ymax">5.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_4__Shell_pO:mean_num_clusters" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">1.</PARAM>
+      <PARAM name="ymax">5.</PARAM>
+    </QTEST>
 
   <!-- PXFORWARD -->
-  <!-- PXRING 1 -->
-  <!-- PXDISK ±1 --> <!-- error -->
-  <QTEST name="Yrange:PXRing_1__PXDisk_±1:mean_num_clusters" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">3.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±2 --> <!-- pass -->
-  <QTEST name="Yrange:PXRing_1__PXDisk_±2:mean_num_clusters" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">3.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±3 -->
-  <QTEST name="Yrange:PXRing_1__PXDisk_±3:mean_num_clusters" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">3.</PARAM>
-  </QTEST>
-  <!-- PXRING 2 -->
-  <!-- PXDISK ±1 -->
-  <QTEST name="Yrange:PXRing_2__PXDisk_±1:mean_num_clusters" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">3.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±2 -->
-  <QTEST name="Yrange:PXRing_2__PXDisk_±2:mean_num_clusters" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">3.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±3 -->
-  <QTEST name="Yrange:PXRing_2__PXDisk_±3:mean_num_clusters" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">3.</PARAM>
-  </QTEST>
+    <!-- HCMI -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-1:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">20.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-2:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">20.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-3:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">5.</PARAM>
+        <PARAM name="ymax">20.</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-1:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymax">10.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-2:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymax">10.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-3:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymax">10.</PARAM>
+      </QTEST>
+
+    <!-- HCMO -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-1:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">20.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-2:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">7.</PARAM>
+        <PARAM name="ymax">20.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-3:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">7.</PARAM>
+        <PARAM name="ymax">20.</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-1:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymax">10.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-2:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymax">10.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-3:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymax">10.</PARAM>
+      </QTEST>
+
+    <!-- HCPI -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+1:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">20.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+2:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">2.</PARAM>
+        <PARAM name="ymax">20.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+3:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">20.</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+1:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymax">10.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+2:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymax">10.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+3:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymax">10.</PARAM>
+      </QTEST>
+
+    <!-- HCPO -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+1:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">20.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+2:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">2.</PARAM>
+        <PARAM name="ymax">20.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+3:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">20.</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+1:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymax">10.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+2:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymax">10.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+3:mean_num_clusters" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymax">10.</PARAM>
+      </QTEST>
 
 
-  <!-- LINKS between Quality Tests and Monitoring Elements: -->
-  <!-- PXBARREL LINKS -->
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_num_clusters_PXLayer_1">
-    <TestName activate="true">Yrange:PXLayer_1:mean_num_clusters</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_num_clusters_PXLayer_2">
-    <TestName activate="true">Yrange:PXLayer_2:mean_num_clusters</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_num_clusters_PXLayer_3">
-    <TestName activate="true">Yrange:PXLayer_3:mean_num_clusters</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_num_clusters_PXLayer_4">
-    <TestName activate="true">Yrange:PXLayer_4:mean_num_clusters</TestName>
-  </LINK>
+  <!-- LINKS between Quality Tests and Monitoring Elements -->
+    <!-- PXBARREL LINKS -->
+      <!-- PXLAYER 1 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_num_clusters_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_mI:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_num_clusters_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_mO:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_num_clusters_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_pI:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_num_clusters_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_pO:mean_num_clusters</TestName>
+      </LINK>
+
+      <!-- PXLAYER 2 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_num_clusters_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_mI:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_num_clusters_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_mO:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_num_clusters_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_pI:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_num_clusters_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_pO:mean_num_clusters</TestName>
+      </LINK>
+
+      <!-- PXLAYER 3 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_num_clusters_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_mI:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_num_clusters_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_mO:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_num_clusters_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_pI:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_num_clusters_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_pO:mean_num_clusters</TestName>
+      </LINK>
+
+      <!-- PXLAYER 4 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_num_clusters_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_mI:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_num_clusters_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_mO:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_num_clusters_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_pI:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_num_clusters_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_pO:mean_num_clusters</TestName>
+      </LINK>
 
   <!-- PXFORWARD LINKS -->
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_num_clusters_PXDisk_*1">
-    <TestName activate="true">Yrange:PXRing_1__PXDisk_±1:mean_num_clusters</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_num_clusters_PXDisk_*2">
-    <TestName activate="true">Yrange:PXRing_1__PXDisk_±2:mean_num_clusters</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_num_clusters_PXDisk_*3">
-    <TestName activate="true">Yrange:PXRing_1__PXDisk_±3:mean_num_clusters</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_num_clusters_PXDisk_*1">
-    <TestName activate="true">Yrange:PXRing_2__PXDisk_±1:mean_num_clusters</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_num_clusters_PXDisk_*2">
-    <TestName activate="true">Yrange:PXRing_2__PXDisk_±2:mean_num_clusters</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_num_clusters_PXDisk_*3">
-    <TestName activate="true">Yrange:PXRing_2__PXDisk_±3:mean_num_clusters</TestName>
-  </LINK>
+    <!-- HCMI -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_1/mean_num_clusters_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-1:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_1/mean_num_clusters_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-2:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_1/mean_num_clusters_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-3:mean_num_clusters</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_2/mean_num_clusters_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-1:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_2/mean_num_clusters_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-2:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_2/mean_num_clusters_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-3:mean_num_clusters</TestName>
+      </LINK>
+
+    <!-- HCMO -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_1/mean_num_clusters_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-1:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_1/mean_num_clusters_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-2:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_1/mean_num_clusters_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-3:mean_num_clusters</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_2/mean_num_clusters_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-1:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_2/mean_num_clusters_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-2:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_2/mean_num_clusters_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-3:mean_num_clusters</TestName>
+      </LINK>
+
+    <!-- HCPI -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_1/mean_num_clusters_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+1:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_1/mean_num_clusters_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+2:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_1/mean_num_clusters_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+3:mean_num_clusters</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_2/mean_num_clusters_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+1:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_2/mean_num_clusters_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+2:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_2/mean_num_clusters_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+3:mean_num_clusters</TestName>
+      </LINK>
+
+    <!-- HCPO -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_1/mean_num_clusters_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+1:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_1/mean_num_clusters_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+2:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_1/mean_num_clusters_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+3:mean_num_clusters</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_2/mean_num_clusters_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+1:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_2/mean_num_clusters_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+2:mean_num_clusters</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_2/mean_num_clusters_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+3:mean_num_clusters</TestName>
+      </LINK>
+
 </TESTCONFIGURATION>

--- a/DQM/SiPixelPhase1Config/test/qTests/mean_num_digis_qualitytest_config.xml
+++ b/DQM/SiPixelPhase1Config/test/qTests/mean_num_digis_qualitytest_config.xml
@@ -2,134 +2,533 @@
   <!-- QTESTS for MEAN NUMBER OF DIGIS: -->
 
   <!-- PXBARREL -->
-  <!-- PXLAYER 1 -->
-  <QTEST name="Yrange:PXLayer_1:mean_num_digis" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">50.</PARAM>
-  </QTEST>
-  <!-- PXLAYER 2 -->  <!-- warn -->
-  <QTEST name="Yrange:PXLayer_2:mean_num_digis" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">10.</PARAM>
-  </QTEST>
-  <!-- PXLAYER 3 --> <!-- error -->
-  <QTEST name="Yrange:PXLayer_3:mean_num_digis" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">10.</PARAM>
-  </QTEST>
-  <!-- PXLAYER 4 --> <!-- pass -->
-  <QTEST name="Yrange:PXLayer_4:mean_num_digis" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">10.</PARAM>
-  </QTEST>
+    <!-- PXLAYER 1 -->
+    <QTEST name="Yrange:PXLayer_1__Shell_mI:mean_num_digis" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">5.</PARAM>
+      <PARAM name="ymax">20.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_1__Shell_mO:mean_num_digis" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">50.</PARAM>
+      <PARAM name="ymax">150.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_1__Shell_pI:mean_num_digis" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">30.</PARAM>
+      <PARAM name="ymax">150.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_1__Shell_pO:mean_num_digis" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">45.</PARAM>
+      <PARAM name="ymax">150.</PARAM>
+    </QTEST>
+
+    <!-- PXLAYER 2 -->
+    <QTEST name="Yrange:PXLayer_2__Shell_mI:mean_num_digis" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">10.</PARAM>
+      <PARAM name="ymax">70.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_2__Shell_mO:mean_num_digis" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">15.</PARAM>
+      <PARAM name="ymax">70.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_2__Shell_pI:mean_num_digis" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">20.</PARAM>
+      <PARAM name="ymax">70.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_2__Shell_pO:mean_num_digis" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">20.</PARAM>
+      <PARAM name="ymax">70.</PARAM>
+    </QTEST>
+
+    <!-- PXLAYER 3 -->
+    <QTEST name="Yrange:PXLayer_3__Shell_mI:mean_num_digis" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">10.</PARAM>
+      <PARAM name="ymax">30.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_3__Shell_mO:mean_num_digis" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">10.</PARAM>
+      <PARAM name="ymax">30.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_3__Shell_pI:mean_num_digis" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">10.</PARAM>
+      <PARAM name="ymax">30.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_3__Shell_pO:mean_num_digis" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">10.</PARAM>
+      <PARAM name="ymax">30.</PARAM>
+    </QTEST>
+
+    <!-- PXLAYER 4 -->
+    <QTEST name="Yrange:PXLayer_4__Shell_mI:mean_num_digis" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">5.</PARAM>
+      <PARAM name="ymax">20.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_4__Shell_mO:mean_num_digis" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">5.</PARAM>
+      <PARAM name="ymax">20.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_4__Shell_pI:mean_num_digis" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">5.</PARAM>
+      <PARAM name="ymax">20.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_4__Shell_pO:mean_num_digis" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">5.</PARAM>
+      <PARAM name="ymax">20.</PARAM>
+    </QTEST>
 
   <!-- PXFORWARD -->
-  <!-- PXRING 1 -->
-  <!-- PXDISK ±1 --> <!-- error -->
-  <QTEST name="Yrange:PXRing_1__PXDisk_±1:mean_num_digis" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">10.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±2 --> <!-- pass -->
-  <QTEST name="Yrange:PXRing_1__PXDisk_±2:mean_num_digis" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">10.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±3 -->
-  <QTEST name="Yrange:PXRing_1__PXDisk_±3:mean_num_digis" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">10.</PARAM>
-  </QTEST>
-  <!-- PXRING 2 -->
-  <!-- PXDISK ±1 -->
-  <QTEST name="Yrange:PXRing_2__PXDisk_±1:mean_num_digis" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">10.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±2 -->
-  <QTEST name="Yrange:PXRing_2__PXDisk_±2:mean_num_digis" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">10.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±3 -->
-  <QTEST name="Yrange:PXRing_2__PXDisk_±3:mean_num_digis" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.01</PARAM>
-    <PARAM name="ymax">10.</PARAM>
-  </QTEST>
+    <!-- HCMI -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-1:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">10.</PARAM>
+        <PARAM name="ymax">70.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-2:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">10.</PARAM>
+        <PARAM name="ymax">70.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-3:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">15.</PARAM>
+        <PARAM name="ymax">70.</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-1:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">8.</PARAM>
+        <PARAM name="ymax">40.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-2:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">8.</PARAM>
+        <PARAM name="ymax">40.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-3:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">5.</PARAM>
+        <PARAM name="ymax">40.</PARAM>
+      </QTEST>
+
+    <!-- HCMO -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-1:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">10.</PARAM>
+        <PARAM name="ymax">70.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-2:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">25.</PARAM>
+        <PARAM name="ymax">70.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-3:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">25.</PARAM>
+        <PARAM name="ymax">70.</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-1:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">8.</PARAM>
+        <PARAM name="ymax">25.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-2:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">5.</PARAM>
+        <PARAM name="ymax">25.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-3:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">5.</PARAM>
+        <PARAM name="ymax">25.</PARAM>
+      </QTEST>
+
+    <!-- HCPI -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+1:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">10.</PARAM>
+        <PARAM name="ymax">100.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+2:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">20.</PARAM>
+        <PARAM name="ymax">100.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+3:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">25.</PARAM>
+        <PARAM name="ymax">100.</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+1:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">5.</PARAM>
+        <PARAM name="ymax">25.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+2:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">5.</PARAM>
+        <PARAM name="ymax">30.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+3:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">6.</PARAM>
+        <PARAM name="ymax">35.</PARAM>
+      </QTEST>
+
+    <!-- HCPO -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+1:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">10.</PARAM>
+        <PARAM name="ymax">75.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+2:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">5.</PARAM>
+        <PARAM name="ymax">75.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+3:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">10.</PARAM>
+        <PARAM name="ymax">75.</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+1:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">8.</PARAM>
+        <PARAM name="ymax">25.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+2:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">8.</PARAM>
+        <PARAM name="ymax">25.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+3:mean_num_digis" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">5.</PARAM>
+        <PARAM name="ymax">25.</PARAM>
+      </QTEST>
 
 
-  <!-- LINKS between Quality Tests and Monitoring Elements: -->
-  <!-- PXBARREL LINKS -->
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_num_digis_PXLayer_1">
-    <TestName activate="true">Yrange:PXLayer_1:mean_num_digis</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_num_digis_PXLayer_2">
-    <TestName activate="true">Yrange:PXLayer_2:mean_num_digis</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_num_digis_PXLayer_3">
-    <TestName activate="true">Yrange:PXLayer_3:mean_num_digis</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_num_digis_PXLayer_4">
-    <TestName activate="true">Yrange:PXLayer_4:mean_num_digis</TestName>
-  </LINK>
+  <!-- LINKS between Quality Tests and Monitoring Elements -->
+    <!-- PXBARREL LINKS -->
+      <!-- PXLAYER 1 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_num_digis_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_mI:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_num_digis_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_mO:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_num_digis_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_pI:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_num_digis_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_pO:mean_num_digis</TestName>
+      </LINK>
+
+      <!-- PXLAYER 2 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_num_digis_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_mI:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_num_digis_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_mO:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_num_digis_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_pI:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_num_digis_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_pO:mean_num_digis</TestName>
+      </LINK>
+
+      <!-- PXLAYER 3 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_num_digis_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_mI:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_num_digis_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_mO:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_num_digis_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_pI:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_num_digis_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_pO:mean_num_digis</TestName>
+      </LINK>
+
+      <!-- PXLAYER 4 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_num_digis_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_mI:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_num_digis_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_mO:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_num_digis_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_pI:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_num_digis_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_pO:mean_num_digis</TestName>
+      </LINK>
 
   <!-- PXFORWARD LINKS -->
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_num_digis_PXDisk_*1">
-    <TestName activate="true">Yrange:PXRing_1__PXDisk_±1:mean_num_digis</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_num_digis_PXDisk_*2">
-    <TestName activate="true">Yrange:PXRing_1__PXDisk_±2:mean_num_digis</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_num_digis_PXDisk_*3">
-    <TestName activate="true">Yrange:PXRing_1__PXDisk_±3:mean_num_digis</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_num_digis_PXDisk_*1">
-    <TestName activate="true">Yrange:PXRing_2__PXDisk_±1:mean_num_digis</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_num_digis_PXDisk_*2">
-    <TestName activate="true">Yrange:PXRing_2__PXDisk_±2:mean_num_digis</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_num_digis_PXDisk_*3">
-    <TestName activate="true">Yrange:PXRing_2__PXDisk_±3:mean_num_digis</TestName>
-  </LINK>
+    <!-- HCMI -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_1/mean_num_digis_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-1:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_1/mean_num_digis_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-2:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_1/mean_num_digis_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-3:mean_num_digis</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_2/mean_num_digis_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-1:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_2/mean_num_digis_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-2:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_2/mean_num_digis_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-3:mean_num_digis</TestName>
+      </LINK>
+
+    <!-- HCMO -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_1/mean_num_digis_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-1:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_1/mean_num_digis_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-2:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_1/mean_num_digis_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-3:mean_num_digis</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_2/mean_num_digis_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-1:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_2/mean_num_digis_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-2:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_2/mean_num_digis_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-3:mean_num_digis</TestName>
+      </LINK>
+
+    <!-- HCPI -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_1/mean_num_digis_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+1:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_1/mean_num_digis_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+2:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_1/mean_num_digis_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+3:mean_num_digis</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_2/mean_num_digis_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+1:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_2/mean_num_digis_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+2:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_2/mean_num_digis_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+3:mean_num_digis</TestName>
+      </LINK>
+
+    <!-- HCPO -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_1/mean_num_digis_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+1:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_1/mean_num_digis_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+2:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_1/mean_num_digis_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+3:mean_num_digis</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_2/mean_num_digis_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+1:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_2/mean_num_digis_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+2:mean_num_digis</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_2/mean_num_digis_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+3:mean_num_digis</TestName>
+      </LINK>
+
 </TESTCONFIGURATION>

--- a/DQM/SiPixelPhase1Config/test/qTests/mean_size_qualitytest_config.xml
+++ b/DQM/SiPixelPhase1Config/test/qTests/mean_size_qualitytest_config.xml
@@ -2,134 +2,533 @@
   <!-- QTESTS for MEAN SIZE: -->
 
   <!-- PXBARREL -->
-  <!-- PXLAYER 1 -->
-  <QTEST name="Yrange:PXLayer_1:mean_size" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.1</PARAM>
-    <PARAM name="ymax">20.</PARAM>
-  </QTEST>
-  <!-- PXLAYER 2 -->  <!-- warn -->
-  <QTEST name="Yrange:PXLayer_2:mean_size" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.1</PARAM>
-    <PARAM name="ymax">20.</PARAM>
-  </QTEST>
-  <!-- PXLAYER 3 --> <!-- error -->
-  <QTEST name="Yrange:PXLayer_3:mean_size" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.1</PARAM>
-    <PARAM name="ymax">20.</PARAM>
-  </QTEST>
-  <!-- PXLAYER 4 --> <!-- pass -->
-  <QTEST name="Yrange:PXLayer_4:mean_size" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.1</PARAM>
-    <PARAM name="ymax">20.</PARAM>
-  </QTEST>
+    <!-- PXLAYER 1 -->
+    <QTEST name="Yrange:PXLayer_1__Shell_mI:mean_size" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">3.5</PARAM>
+      <PARAM name="ymax">5.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_1__Shell_mO:mean_size" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">3.</PARAM>
+      <PARAM name="ymax">5.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_1__Shell_pI:mean_size" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">3.5</PARAM>
+      <PARAM name="ymax">5.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_1__Shell_pO:mean_size" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">3.5</PARAM>
+      <PARAM name="ymax">5.</PARAM>
+    </QTEST>
+
+    <!-- PXLAYER 2 -->
+    <QTEST name="Yrange:PXLayer_2__Shell_mI:mean_size" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">4.</PARAM>
+      <PARAM name="ymax">6.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_2__Shell_mO:mean_size" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">4.</PARAM>
+      <PARAM name="ymax">6.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_2__Shell_pI:mean_size" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">4.</PARAM>
+      <PARAM name="ymax">6.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_2__Shell_pO:mean_size" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">4.</PARAM>
+      <PARAM name="ymax">6.</PARAM>
+    </QTEST>
+
+    <!-- PXLAYER 3 -->
+    <QTEST name="Yrange:PXLayer_3__Shell_mI:mean_size" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">3.5</PARAM>
+      <PARAM name="ymax">5.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_3__Shell_mO:mean_size" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">4.</PARAM>
+      <PARAM name="ymax">5.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_3__Shell_pI:mean_size" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">4.</PARAM>
+      <PARAM name="ymax">5.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_3__Shell_pO:mean_size" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">3.5</PARAM>
+      <PARAM name="ymax">4.5</PARAM>
+    </QTEST>
+
+    <!-- PXLAYER 4 -->
+    <QTEST name="Yrange:PXLayer_4__Shell_mI:mean_size" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">3.5</PARAM>
+      <PARAM name="ymax">5.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_4__Shell_mO:mean_size" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">3.5</PARAM>
+      <PARAM name="ymax">4.5</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_4__Shell_pI:mean_size" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">3.5</PARAM>
+      <PARAM name="ymax">4.5</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_4__Shell_pO:mean_size" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">3.5</PARAM>
+      <PARAM name="ymax">4.5</PARAM>
+    </QTEST>
 
   <!-- PXFORWARD -->
-  <!-- PXRING 1 -->
-  <!-- PXDISK ±1 --> <!-- error -->
-  <QTEST name="Yrange:PXRing_1__PXDisk_±1:mean_size" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.1</PARAM>
-    <PARAM name="ymax">20.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±2 --> <!-- pass -->
-  <QTEST name="Yrange:PXRing_1__PXDisk_±2:mean_size" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.1</PARAM>
-    <PARAM name="ymax">20.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±3 -->
-  <QTEST name="Yrange:PXRing_1__PXDisk_±3:mean_size" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.1</PARAM>
-    <PARAM name="ymax">20.</PARAM>
-  </QTEST>
-  <!-- PXRING 2 -->
-  <!-- PXDISK ±1 -->
-  <QTEST name="Yrange:PXRing_2__PXDisk_±1:mean_size" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.1</PARAM>
-    <PARAM name="ymax">20.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±2 -->
-  <QTEST name="Yrange:PXRing_2__PXDisk_±2:mean_size" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.1</PARAM>
-    <PARAM name="ymax">20.</PARAM>
-  </QTEST>
-  <!-- PXDISK ±3 -->
-  <QTEST name="Yrange:PXRing_2__PXDisk_±3:mean_size" activate="true">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="useEmptyBins">1</PARAM>
-    <PARAM name="error">0.2</PARAM>
-    <PARAM name="warning">0.5</PARAM>
-    <PARAM name="ymin">0.1</PARAM>
-    <PARAM name="ymax">20.</PARAM>
-  </QTEST>
+    <!-- HCMI -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-1:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">4.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-2:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">4.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-3:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">2.5</PARAM>
+        <PARAM name="ymax">3.5</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-1:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">5.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-2:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">5.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-3:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">5.</PARAM>
+      </QTEST>
+
+    <!-- HCMO -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-1:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">4.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-2:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">2.5</PARAM>
+        <PARAM name="ymax">4</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-3:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">2.5</PARAM>
+        <PARAM name="ymax">4.</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-1:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.5</PARAM>
+        <PARAM name="ymax">4.5</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-2:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">4.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-3:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">4.</PARAM>
+      </QTEST>
+
+    <!-- HCPI -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+1:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">4.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+2:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">4.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+3:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">2.5</PARAM>
+        <PARAM name="ymax">3.5</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+1:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.3</PARAM>
+        <PARAM name="ymax">4.3</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+2:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.3</PARAM>
+        <PARAM name="ymax">4.3</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+3:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">4.</PARAM>
+      </QTEST>
+
+    <!-- HCPO -->
+      <!-- PXRING 1 --> 
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+1:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">4.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+2:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">4.</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+3:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">2.8</PARAM>
+        <PARAM name="ymax">3.8</PARAM>
+      </QTEST>
+
+      <!-- PXRING 2 --> 
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+1:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.5</PARAM>
+        <PARAM name="ymax">4.5</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+2:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.4</PARAM>
+        <PARAM name="ymax">4.4</PARAM>
+      </QTEST>
+
+      <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+3:mean_size" activate="true">
+        <TYPE>ContentsYRange</TYPE>
+        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="error">0.85</PARAM>
+        <PARAM name="warning">0.95</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">4.</PARAM>
+      </QTEST>
 
 
-  <!-- LINKS between Quality Tests and Monitoring Elements: -->
-  <!-- PXBARREL LINKS -->
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_size_PXLayer_1">
-    <TestName activate="true">Yrange:PXLayer_1:mean_size</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_size_PXLayer_2">
-    <TestName activate="true">Yrange:PXLayer_2:mean_size</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_size_PXLayer_3">
-    <TestName activate="true">Yrange:PXLayer_3:mean_size</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_*/mean_size_PXLayer_4">
-    <TestName activate="true">Yrange:PXLayer_4:mean_size</TestName>
-  </LINK>
+  <!-- LINKS between Quality Tests and Monitoring Elements -->
+    <!-- PXBARREL LINKS -->
+      <!-- PXLAYER 1 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_size_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_mI:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_size_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_mO:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_size_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_pI:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_size_PXLayer_1">
+        <TestName activate="true">Yrange:PXLayer_1__Shell_pO:mean_size</TestName>
+      </LINK>
+
+      <!-- PXLAYER 2 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_size_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_mI:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_size_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_mO:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_size_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_pI:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_size_PXLayer_2">
+        <TestName activate="true">Yrange:PXLayer_2__Shell_pO:mean_size</TestName>
+      </LINK>
+
+      <!-- PXLAYER 3 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_size_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_mI:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_size_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_mO:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_size_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_pI:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_size_PXLayer_3">
+        <TestName activate="true">Yrange:PXLayer_3__Shell_pO:mean_size</TestName>
+      </LINK>
+
+      <!-- PXLAYER 4 -->
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mI/mean_size_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_mI:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_mO/mean_size_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_mO:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pI/mean_size_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_pI:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXBarrel/Shell_pO/mean_size_PXLayer_4">
+        <TestName activate="true">Yrange:PXLayer_4__Shell_pO:mean_size</TestName>
+      </LINK>
 
   <!-- PXFORWARD LINKS -->
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_size_PXDisk_*1">
-    <TestName activate="true">Yrange:PXRing_1__PXDisk_±1:mean_size</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_size_PXDisk_*2">
-    <TestName activate="true">Yrange:PXRing_1__PXDisk_±2:mean_size</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_1/mean_size_PXDisk_*3">
-    <TestName activate="true">Yrange:PXRing_1__PXDisk_±3:mean_size</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_size_PXDisk_*1">
-    <TestName activate="true">Yrange:PXRing_2__PXDisk_±1:mean_size</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_size_PXDisk_*2">
-    <TestName activate="true">Yrange:PXRing_2__PXDisk_±2:mean_size</TestName>
-  </LINK>
-  <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_*/PXRing_2/mean_size_PXDisk_*3">
-    <TestName activate="true">Yrange:PXRing_2__PXDisk_±3:mean_size</TestName>
-  </LINK>
+    <!-- HCMI -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_1/mean_size_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-1:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_1/mean_size_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-2:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_1/mean_size_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-3:mean_size</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_2/mean_size_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-1:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_2/mean_size_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-2:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mI/PXRing_2/mean_size_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-3:mean_size</TestName>
+      </LINK>
+
+    <!-- HCMO -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_1/mean_size_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-1:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_1/mean_size_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-2:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_1/mean_size_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-3:mean_size</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_2/mean_size_PXDisk_-1">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-1:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_2/mean_size_PXDisk_-2">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-2:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_mO/PXRing_2/mean_size_PXDisk_-3">
+        <TestName activate="true">Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-3:mean_size</TestName>
+      </LINK>
+
+    <!-- HCPI -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_1/mean_size_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+1:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_1/mean_size_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+2:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_1/mean_size_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+3:mean_size</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_2/mean_size_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+1:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_2/mean_size_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+2:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pI/PXRing_2/mean_size_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+3:mean_size</TestName>
+      </LINK>
+
+    <!-- HCPO -->
+      <!-- PXRING 1 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_1/mean_size_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+1:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_1/mean_size_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+2:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_1/mean_size_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+3:mean_size</TestName>
+      </LINK>
+
+      <!-- PXRING 2 --> 
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_2/mean_size_PXDisk_+1">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+1:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_2/mean_size_PXDisk_+2">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+2:mean_size</TestName>
+      </LINK>
+      <LINK name="PixelPhase1/Phase1_MechanicalView/PXForward/HalfCylinder_pO/PXRing_2/mean_size_PXDisk_+3">
+        <TestName activate="true">Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+3:mean_size</TestName>
+      </LINK>
+
 </TESTCONFIGURATION>

--- a/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
@@ -11,6 +11,7 @@ from RecoTracker.SpecialSeedGenerators.CosmicSeedP5Pairs_cff import *
 from RecoTracker.SingleTrackPattern.CosmicTrackFinderP5_cff import *
 # Final Track Selector for CosmicTF
 from RecoTracker.FinalTrackSelectors.CosmicTFFinalTrackSelectorP5_cff import *
+from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
 
 #chi2 set to 40!!
 # CTF
@@ -67,7 +68,7 @@ trackerCosmics_TopBot = cms.Sequence((trackerlocalrecoTop*tracksP5Top)+(trackerl
 #dEdX reconstruction
 from RecoTracker.DeDx.dedxEstimators_Cosmics_cff import *
 # (SK) keep rstracks commented out in case of resurrection
-tracksP5 = cms.Sequence(cosmictracksP5*ctftracksP5*doAllCosmicdEdXEstimators)
+tracksP5 = cms.Sequence(cosmictracksP5*ctftracksP5*doAllCosmicdEdXEstimators*siPixelClusterShapeCache)
 tracksP5_wodEdX = tracksP5.copy()
 tracksP5_wodEdX.remove(doAllCosmicdEdXEstimators)
 


### PR DESCRIPTION
Greetings 
 xml files for the qTests for the DQM PixelPhase1 summary plots and fix for cosmic sequence 

this is the backport of #19447 and #19713 

I combined the two since #19713  is fixing #19447 - Those are already merged in 93X (and even part of 930_pre2) 
 @ckmackay FYI 