### PR TITLE
fix eos in alignment validation

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
@@ -52,7 +52,6 @@ scriptTemplate="""
 export LSFWORKDIR=`pwd -P`
 echo LSF working directory is $LSFWORKDIR
 source /afs/cern.ch/cms/caf/setup.sh
-eos='/afs/cern.ch/project/eos/installation/cms/bin/eos.select'
 export X509_USER_PROXY=.oO[scriptsdir]Oo./.user_proxy
 cd .oO[CMSSW_BASE]Oo./src
 export SCRAM_ARCH=.oO[SCRAM_ARCH]Oo.
@@ -60,7 +59,7 @@ eval `scramv1 ru -sh`
 #rfmkdir -p .oO[datadir]Oo. &>! /dev/null
 
 #remove possible result file from previous runs
-previous_results=$($eos ls /store/caf/user/$USER/.oO[eosdir]Oo.)
+previous_results=$(eos ls /store/caf/user/$USER/.oO[eosdir]Oo.)
 for file in ${previous_results}
 do
     if [ ${file} = /store/caf/user/$USER/.oO[eosdir]Oo./.oO[outputFile]Oo. ]
@@ -99,7 +98,7 @@ gzip -f LOGFILE_*_.oO[name]Oo..log
 find . -maxdepth 1 -name "LOGFILE*.oO[alignmentName]Oo.*" -print | xargs -I {} bash -c "rfcp {} .oO[logdir]Oo."
 
 #copy root files to eos
-$eos mkdir -p /store/caf/user/$USER/.oO[eosdir]Oo.
+eos mkdir -p /store/caf/user/$USER/.oO[eosdir]Oo.
 if [ .oO[parallelJobs]Oo. -eq 1 ]
 then
     root_files=$(ls --color=never -d *.oO[alignmentName]Oo.*.root)
@@ -216,7 +215,6 @@ process.seqTrackselRefit*.oO[ValidationSequence]Oo.)
 ######################################################################
 mergeTemplate="""
 #!/bin/bash
-eos='/afs/cern.ch/project/eos/installation/cms/bin/eos.select'
 CWD=`pwd -P`
 cd .oO[CMSSW_BASE]Oo./src
 export SCRAM_ARCH=.oO[SCRAM_ARCH]Oo.
@@ -237,7 +235,7 @@ echo "Working directory: $(pwd -P)"
 
 ###############################################################################
 # download root files from eos
-root_files=$($eos ls /store/caf/user/$USER/.oO[eosdir]Oo. \
+root_files=$(eos ls /store/caf/user/$USER/.oO[eosdir]Oo. \
              | grep ".root$" | grep -v "result.root$")
 #for file in ${root_files}
 #do
@@ -283,7 +281,7 @@ ls -al .oO[mergeParallelFilePrefixes]Oo. > .oO[datadir]Oo./log_rootfilelist.txt
 compareAlignmentsExecution="""
 #merge for .oO[validationId]Oo. if it does not exist or is not up-to-date
 echo -e "\n\nComparing validations"
-$eos mkdir -p /store/caf/user/$USER/.oO[eosdir]Oo./
+eos mkdir -p /store/caf/user/$USER/.oO[eosdir]Oo./
 cp .oO[Alignment/OfflineValidation]Oo./scripts/compareFileAges.C .
 root -x -q -b -l "compareFileAges.C(\\\"root://eoscms.cern.ch//eos/cms/store/caf/user/$USER/.oO[eosdir]Oo./.oO[validationId]Oo._result.root\\\", \\\".oO[compareStringsPlain]Oo.\\\")"
 comparisonNeeded=${?}

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
@@ -165,7 +165,6 @@ process.p = cms.Path(process.goodvertexSkim*
 PVValidationScriptTemplate="""
 #!/bin/bash 
 source /afs/cern.ch/cms/caf/setup.sh
-eos='/afs/cern.ch/project/eos/installation/cms/bin/eos.select'
 
 echo  -----------------------
 echo  Job started at `date`
@@ -200,7 +199,7 @@ fi
 
 ls -lh . 
 
-$eos mkdir -p /store/caf/user/$USER/.oO[eosdir]Oo./plots/
+eos mkdir -p /store/caf/user/$USER/.oO[eosdir]Oo./plots/
 for RootOutputFile in $(ls *root )
 do
     xrdcp -f ${RootOutputFile}  root://eoscms//eos/cms/store/caf/user/$USER/.oO[eosdir]Oo./

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/zMuMuValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/zMuMuValidationTemplates.py
@@ -200,7 +200,6 @@ process.p = cms.Path(
 zMuMuScriptTemplate="""
 #!/bin/bash
 source /afs/cern.ch/cms/caf/setup.sh
-eos='/afs/cern.ch/project/eos/installation/cms/bin/eos.select'
 
 echo  -----------------------
 echo  Job started at `date`
@@ -249,7 +248,7 @@ cp  .oO[MuonAnalysis/MomentumScaleCalibration]Oo./test/Macros/RooFit/MultiHistoO
 if [[ .oO[zmumureference]Oo. == *store* ]]; then xrdcp -f .oO[zmumureference]Oo. BiasCheck_Reference.root; else ln -fs .oO[zmumureference]Oo. ./BiasCheck_Reference.root; fi
 root -q -b -l MultiHistoOverlap_.oO[resonance]Oo..C
 
-$eos mkdir -p /store/caf/user/$USER/.oO[eosdir]Oo./plots/
+eos mkdir -p /store/caf/user/$USER/.oO[eosdir]Oo./plots/
 for RootOutputFile in $(ls *root )
 do
     xrdcp -f ${RootOutputFile}  root://eoscms//eos/cms/store/caf/user/$USER/.oO[eosdir]Oo./

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -303,7 +303,7 @@ def createMergeScript( path, validations ):
             for f in validation.getRepMap()["outputFiles"]:
                 longName = os.path.join("/store/caf/user/$USER/",
                                          validation.getRepMap()["eosdir"], f)
-                repMap["rmUnmerged"] += "    $eos rm "+longName+"\n"
+                repMap["rmUnmerged"] += "    eos rm "+longName+"\n"
     repMap["rmUnmerged"] += ("else\n"
                              "    echo -e \\n\"WARNING: Merging failed, unmerged"
                              " files won't be deleted.\\n"

--- a/Alignment/OfflineValidation/test/PVValidationSubmitter.csh
+++ b/Alignment/OfflineValidation/test/PVValidationSubmitter.csh
@@ -18,8 +18,6 @@ set inputsource=$1
 set taskname=$2
 set options=$3
 
-set eos='/afs/cern.ch/project/eos/installation/cms/bin/eos.select'
-
 echo "Submitting validation for file $inputsource with $options in task $taskname"
 
 source /afs/cern.ch/cms/caf/setup.csh
@@ -90,22 +88,22 @@ if(${options} != "--dryRun") then
  echo "Content of working directory is: "
  \ls -lrt
 
- set reply=`${eos} find -d /store/caf/user/$USER/Alignment/PVValidation/${taskname}`
+ set reply=`eos find -d /store/caf/user/$USER/Alignment/PVValidation/${taskname}`
  set word=`echo $reply |awk '{split($0,a," "); print a[1]}'`
 
  if(${word} == "") then
  echo "Creating folder $taskname"
-    ${eos} mkdir /store/caf/user/$USER/Alignment/PVValidation/${taskname} 
+    eos mkdir /store/caf/user/$USER/Alignment/PVValidation/${taskname} 
  else 
     echo "Sorry /store/caf/user/$USER/Alignment/PVValidation/${taskname} already exists!"
  endif
 
  if (! -d  ${CMSSW_DIR}/test/PVValResults) then
      mkdir ${CMSSW_DIR}/PVValResults
-     ${eos} cp -f ${outfile} /store/caf/user/$USER/Alignment/PVValidation/${taskname}
+     eos cp -f ${outfile} /store/caf/user/$USER/Alignment/PVValidation/${taskname}
      cp ${jobname}.out ${CMSSW_DIR}/PVValResults 
  else     
-     ${eos} cp -f ${outfile} /store/caf/user/$USER/Alignment/PVValidation/${taskname}
+     eos cp -f ${outfile} /store/caf/user/$USER/Alignment/PVValidation/${taskname}
      cp ${jobname}.out ${CMSSW_DIR}/PVValResults 
  endif
 endif

--- a/Alignment/OfflineValidation/test/submitAllJobs.py
+++ b/Alignment/OfflineValidation/test/submitAllJobs.py
@@ -25,8 +25,6 @@ CopyRights += '#      marco.musich@cern.ch      #\n'
 CopyRights += '#         December 2015          #\n'
 CopyRights += '##################################\n'
 
-eos = '/afs/cern.ch/project/eos/installation/cms/bin/eos.select'
-
 ##############################################
 def drawProgressBar(percent, barLen=40):
 ##############################################
@@ -151,12 +149,12 @@ def mkdir_eos(out_path):
         newpath=os.path.join(newpath,dir)
         # do not issue mkdir from very top of the tree
         if newpath.find('test_out') > 0:
-            p = subprocess.Popen([eos+" mkdir",newpath], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p = subprocess.Popen(["eos", "mkdir", newpath], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             (out, err) = p.communicate()
             p.wait()
 
     # now check that the directory exists
-    p = subprocess.Popen([eos+"ls",out_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(["eos", "ls", out_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (out, err) = p.communicate()
     p.wait()
     if p.returncode !=0:


### PR DESCRIPTION
backport of #19823

use /usr/bin/eos instead of the /afs/cern.ch/project/eos/installation which no longer exists.