### PR TITLE
CTPPS: updated diamond unpacker for post-TS1 conditions

### DIFF
--- a/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
@@ -28,14 +28,14 @@ class DiamondVFATFrame : public VFATFrame
     /// get timing infromation
     uint32_t getLeadingEdgeTime() const
     {
-      uint32_t time = ((data[5]&0x1f)<<16)+data[6];
+      uint32_t time = ((data[7]&0x1f)<<16)+data[8];
       time = (time & 0xFFE7FFFF) << 2 | (time & 0x00180000) >> 19;    //HPTDC inperpolation bits are MSB but should be LSB.... ask HPTDC designers...
       return time;     
     }
 
     uint32_t getTrailingEdgeTime() const
     {
-      uint32_t time = ((data[7]&0x1f)<<16)+data[8];
+      uint32_t time = ((data[5]&0x1f)<<16)+data[6];
       time = (time & 0xFFE7FFFF) << 2 | (time & 0x00180000) >> 19;   //HPTDC inperpolation bits are MSB but should be LSB.... ask HPTDC designers...
       return time;
     }

--- a/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
@@ -1,8 +1,11 @@
-/**********************************************************
+/****************************************************************************
 *
-* Seyed Mohsen Etesami (setesami@cern.ch)    
+* This is a part of the TOTEM offline software.
+* Authors:
+*   Seyed Mohsen Etesami (setesami@cern.ch)
+*   Nicola Minafra
 *
-**********************************************************/
+****************************************************************************/
 
 #ifndef EventFilter_CTPPSRawToDigi_DiamondVFATFrame
 #define EventFilter_CTPPSRawToDigi_DiamondVFATFrame

--- a/EventFilter/CTPPSRawToDigi/interface/RawDataUnpacker.h
+++ b/EventFilter/CTPPSRawToDigi/interface/RawDataUnpacker.h
@@ -20,43 +20,46 @@
 
 //----------------------------------------------------------------------------------------------------
 
-/// \brief Collection of code for unpacking of TOTEM raw-data.
-class RawDataUnpacker
+namespace ctpps
 {
-  public:
-    typedef uint64_t word;
+  /// \brief Collection of code for unpacking of TOTEM raw-data.
+  class RawDataUnpacker
+  {
+    public:
+      typedef uint64_t word;
 
-    /// VFAT transmission modes
-    enum { vmCluster = 0x80, vmRaw = 0x90, vmDiamondCompact = 0xB0 };
+      /// VFAT transmission modes
+      enum { vmCluster = 0x80, vmRaw = 0x90, vmDiamondCompact = 0xB0 };
 
-    // list of headers for all words encountered in diamond data frames
-    static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_2 = 0x7800;
-    static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_3 = 0x7000;
-    static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_5 = 0x6800;
-    static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_7 = 0x6000;
-    static constexpr unsigned int VFAT_HEADER_OF_EC = 0xC000;
+      // list of headers for all words encountered in diamond data frames
+      static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_2 = 0x7800;
+      static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_3 = 0x7000;
+      static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_5 = 0x6800;
+      static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_7 = 0x6000;
+      static constexpr unsigned int VFAT_HEADER_OF_EC = 0xC000;
 
-    RawDataUnpacker() {}
+      RawDataUnpacker() {}
     
-    RawDataUnpacker(const edm::ParameterSet &conf);
+      RawDataUnpacker(const edm::ParameterSet &conf);
 
-    /// Unpack data from FED with fedId into `coll' collection.
-    int Run(int fedId, const FEDRawData &data, std::vector<TotemFEDInfo> &fedInfoColl, SimpleVFATFrameCollection &coll) const;
+      /// Unpack data from FED with fedId into `coll' collection.
+      int Run(int fedId, const FEDRawData &data, std::vector<TotemFEDInfo> &fedInfoColl, SimpleVFATFrameCollection &coll) const;
 
-    /// Process one Opto-Rx (or LoneG) frame.
-    int ProcessOptoRxFrame(const word *buf, unsigned int frameSize, TotemFEDInfo &fedInfo, SimpleVFATFrameCollection *fc) const;
+      /// Process one Opto-Rx (or LoneG) frame.
+      int ProcessOptoRxFrame(const word *buf, unsigned int frameSize, TotemFEDInfo &fedInfo, SimpleVFATFrameCollection *fc) const;
 
-    /// Process one Opto-Rx frame in serial (old) format
-    int ProcessOptoRxFrameSerial(const word *buffer, unsigned int frameSize, SimpleVFATFrameCollection *fc) const;
+      /// Process one Opto-Rx frame in serial (old) format
+      int ProcessOptoRxFrameSerial(const word *buffer, unsigned int frameSize, SimpleVFATFrameCollection *fc) const;
 
-    /// Process one Opto-Rx frame in parallel (new) format
-    int ProcessOptoRxFrameParallel(const word *buffer, unsigned int frameSize, TotemFEDInfo &fedInfo, SimpleVFATFrameCollection *fc) const;
+      /// Process one Opto-Rx frame in parallel (new) format
+      int ProcessOptoRxFrameParallel(const word *buffer, unsigned int frameSize, TotemFEDInfo &fedInfo, SimpleVFATFrameCollection *fc) const;
 
-    /// Process data from one VFAT in parallel (new) format
-    int ProcessVFATDataParallel(const uint16_t *buf, unsigned int maxWords, unsigned int OptoRxId, SimpleVFATFrameCollection *fc) const;
+      /// Process data from one VFAT in parallel (new) format
+      int ProcessVFATDataParallel(const uint16_t *buf, unsigned int maxWords, unsigned int OptoRxId, SimpleVFATFrameCollection *fc) const;
 
-  private:
-    unsigned char verbosity;
-};
+    private:
+      unsigned char verbosity;
+  };
+}
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/interface/RawDataUnpacker.h
+++ b/EventFilter/CTPPSRawToDigi/interface/RawDataUnpacker.h
@@ -28,7 +28,13 @@ class RawDataUnpacker
 
     /// VFAT transmission modes
     enum { vmCluster = 0x80, vmRaw = 0x90, vmDiamondCompact = 0xB0 };
-    enum { VFAT_DIAMOND_HEADER_OF_WORD_2=0x7800, VFAT_DIAMOND_HEADER_OF_WORD_3=0x7000, VFAT_DIAMOND_HEADER_OF_WORD_5=0x6800, VFAT_DIAMOND_HEADER_OF_WORD_7=0x6000, VFAT_HEADER_OF_EC=0xC000 };
+
+    // list of headers for all words encountered in diamond data frames
+    static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_2 = 0x7800;
+    static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_3 = 0x7000;
+    static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_5 = 0x6800;
+    static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_7 = 0x6000;
+    static constexpr unsigned int VFAT_HEADER_OF_EC = 0xC000;
 
     RawDataUnpacker() {}
     

--- a/EventFilter/CTPPSRawToDigi/interface/RawDataUnpacker.h
+++ b/EventFilter/CTPPSRawToDigi/interface/RawDataUnpacker.h
@@ -53,7 +53,7 @@ class RawDataUnpacker
     int ProcessOptoRxFrameParallel(const word *buffer, unsigned int frameSize, TotemFEDInfo &fedInfo, SimpleVFATFrameCollection *fc) const;
 
     /// Process data from one VFAT in parallel (new) format
-    int ProcessVFATDataParallel(const uint16_t *buf, unsigned int OptoRxId, SimpleVFATFrameCollection *fc) const;
+    int ProcessVFATDataParallel(const uint16_t *buf, unsigned int maxWords, unsigned int OptoRxId, SimpleVFATFrameCollection *fc) const;
 
   private:
     unsigned char verbosity;

--- a/EventFilter/CTPPSRawToDigi/interface/RawDataUnpacker.h
+++ b/EventFilter/CTPPSRawToDigi/interface/RawDataUnpacker.h
@@ -26,7 +26,8 @@ class RawDataUnpacker
     typedef uint64_t word;
 
     /// VFAT transmission modes
-    enum { vmCluster = 0x80, vmRaw = 0x90 };
+    enum { vmCluster = 0x80, vmRaw = 0x90, vmDiamondCompact = 0xB0 };
+    enum {VFAT_DAIMOND_2=0x7800, VFAT_DAIMOND_3=0x7000, VFAT_DAIMOND_5=0x6800, VFAT_DAIMOND_7=0x6000};
 
     RawDataUnpacker() {}
     

--- a/EventFilter/CTPPSRawToDigi/interface/RawDataUnpacker.h
+++ b/EventFilter/CTPPSRawToDigi/interface/RawDataUnpacker.h
@@ -27,7 +27,7 @@ class RawDataUnpacker
 
     /// VFAT transmission modes
     enum { vmCluster = 0x80, vmRaw = 0x90, vmDiamondCompact = 0xB0 };
-    enum {VFAT_DAIMOND_2=0x7800, VFAT_DAIMOND_3=0x7000, VFAT_DAIMOND_5=0x6800, VFAT_DAIMOND_7=0x6000};
+    enum {VFAT_DIAMOND_HEADER_OF_WORD_2=0x7800, VFAT_DIAMOND_HEADER_OF_WORD_3=0x7000, VFAT_DIAMOND_HEADER_OF_WORD_5=0x6800, VFAT_DIAMOND_HEADER_OF_WORD_7=0x6000, VFAT_HEADER_OF_EC=0xC000};
 
     RawDataUnpacker() {}
     

--- a/EventFilter/CTPPSRawToDigi/interface/RawDataUnpacker.h
+++ b/EventFilter/CTPPSRawToDigi/interface/RawDataUnpacker.h
@@ -3,6 +3,7 @@
 * This is a part of the TOTEM offline software.
 * Authors: 
 *   Jan Kašpar (jan.kaspar@gmail.com)
+*   Nicola Minafra
 *
 ****************************************************************************/
 
@@ -27,7 +28,7 @@ class RawDataUnpacker
 
     /// VFAT transmission modes
     enum { vmCluster = 0x80, vmRaw = 0x90, vmDiamondCompact = 0xB0 };
-    enum {VFAT_DIAMOND_HEADER_OF_WORD_2=0x7800, VFAT_DIAMOND_HEADER_OF_WORD_3=0x7000, VFAT_DIAMOND_HEADER_OF_WORD_5=0x6800, VFAT_DIAMOND_HEADER_OF_WORD_7=0x6000, VFAT_HEADER_OF_EC=0xC000};
+    enum { VFAT_DIAMOND_HEADER_OF_WORD_2=0x7800, VFAT_DIAMOND_HEADER_OF_WORD_3=0x7000, VFAT_DIAMOND_HEADER_OF_WORD_5=0x6800, VFAT_DIAMOND_HEADER_OF_WORD_7=0x6000, VFAT_HEADER_OF_EC=0xC000 };
 
     RawDataUnpacker() {}
     

--- a/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
@@ -53,7 +53,7 @@ class TotemVFATRawToDigi : public edm::stream::EDProducer<>
 
     edm::EDGetTokenT<FEDRawDataCollection> fedDataToken;
 
-    RawDataUnpacker rawDataUnpacker;
+    ctpps::RawDataUnpacker rawDataUnpacker;
     RawToDigiConverter rawToDigiConverter;
 
     template <typename DigiType>

--- a/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
@@ -3,6 +3,7 @@
 * This is a part of TOTEM offline software.
 * Authors: 
 *   Jan Kašpar (jan.kaspar@gmail.com)
+*   Nicola Minafra
 *
 ****************************************************************************/
 
@@ -17,10 +18,9 @@ using namespace edm;
 
 //----------------------------------------------------------------------------------------------------
 
-RawDataUnpacker::RawDataUnpacker(const edm::ParameterSet &conf) :
-  verbosity(conf.getUntrackedParameter<unsigned int>("verbosity", 0))
-{
-}
+RawDataUnpacker::RawDataUnpacker(const edm::ParameterSet& iConfig) :
+  verbosity(iConfig.getUntrackedParameter<unsigned int>("verbosity", 0))
+{}
 
 //----------------------------------------------------------------------------------------------------
 
@@ -47,7 +47,6 @@ int RawDataUnpacker::ProcessOptoRxFrame(const word *buf, unsigned int frameSize,
   // get OptoRx metadata
   unsigned long long head = buf[0];
   unsigned long long foot = buf[frameSize-1];
-
 
   fedInfo.setHeader(head);
   fedInfo.setFooter(foot);
@@ -81,11 +80,11 @@ int RawDataUnpacker::ProcessOptoRxFrame(const word *buf, unsigned int frameSize,
   #endif
 
   // parallel or serial transmission?
-  if (FOV == 1)
+  if (FOV == 1) {
     return ProcessOptoRxFrameSerial(buf, frameSize, fc);
+  }
 
   if (FOV == 2 || FOV == 3) {
-//     std::cout<< "FOV: "<< FOV<<std::endl;
     return ProcessOptoRxFrameParallel(buf, frameSize, fedInfo, fc);
   }
 
@@ -395,19 +394,19 @@ int RawDataUnpacker::ProcessVFATDataParallel(const uint16_t *buf, unsigned int O
         continue;
       }
       switch ( buf[i] & 0xF800 ) {
-        case VFAT_DIAMOND_HEADER_OF_WORD_2:     // If Word 2 of the diamond VFAT frame is found
+        case VFAT_DIAMOND_HEADER_OF_WORD_2: // if Word 2 of the diamond VFAT frame is found
           fd[2] = buf[i];
           fd[1] = buf[i + 1];
           break;
-        case VFAT_DIAMOND_HEADER_OF_WORD_3:     // If Word 2 of the diamond VFAT frame is found
+        case VFAT_DIAMOND_HEADER_OF_WORD_3: // if Word 2 of the diamond VFAT frame is found
           fd[3] = buf[i];
           fd[4] = buf[i - 1];
           break;
-        case VFAT_DIAMOND_HEADER_OF_WORD_5:     // If Word 2 of the diamond VFAT frame is found
+        case VFAT_DIAMOND_HEADER_OF_WORD_5: // if Word 2 of the diamond VFAT frame is found
           fd[5] = buf[i];
           fd[6] = buf[i - 1];
           break;
-        case VFAT_DIAMOND_HEADER_OF_WORD_7:     // If Word 2 of the diamond VFAT frame is found
+        case VFAT_DIAMOND_HEADER_OF_WORD_7: // if Word 2 of the diamond VFAT frame is found
           fd[7] = buf[i];
           fd[8] = buf[i - 1];
           break;

--- a/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
@@ -80,12 +80,13 @@ int RawDataUnpacker::ProcessOptoRxFrame(const word *buf, unsigned int frameSize,
   #endif
 
   // parallel or serial transmission?
-  if (FOV == 1) {
-    return ProcessOptoRxFrameSerial(buf, frameSize, fc);
-  }
-
-  if (FOV == 2 || FOV == 3) {
-    return ProcessOptoRxFrameParallel(buf, frameSize, fedInfo, fc);
+  switch (FOV) {
+    case 1:
+      return ProcessOptoRxFrameSerial(buf, frameSize, fc);
+    case 2:
+    case 3:
+      return ProcessOptoRxFrameParallel(buf, frameSize, fedInfo, fc);
+    default: break;
   }
 
   if (verbosity)
@@ -266,24 +267,19 @@ int RawDataUnpacker::ProcessVFATDataParallel(const uint16_t *buf, unsigned int O
   unsigned int dataOffset = wordsProcessed;
 
   // find trailer
-  if (hFlag == vmCluster)
-  {
-    unsigned int nCl = 0;
-    while ( (buf[wordsProcessed + nCl] >> 12) != 0xF )
-      nCl++;
-
-    wordsProcessed += nCl;
-  }
-
-  if (hFlag == vmRaw)
-    wordsProcessed += 9;
-  
-  if (hFlag == vmDiamondCompact)
-  {
-    wordsProcessed--;
-    while ( (buf[wordsProcessed] & 0xFFF0)!= 0xF000 ) {
-      wordsProcessed++;
-    }
+  switch (hFlag) {
+    case vmCluster: {
+      unsigned int nCl = 0;
+      while ( (buf[wordsProcessed + nCl] >> 12) != 0xF ) nCl++;
+      wordsProcessed += nCl;
+    } break;
+    case vmRaw:
+      wordsProcessed += 9;
+      break;
+    case vmDiamondCompact: {
+      wordsProcessed--;
+      while ( (buf[wordsProcessed] & 0xFFF0)!= 0xF000 ) wordsProcessed++;
+    } break;
   }
 
   // process trailer

--- a/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
@@ -47,12 +47,7 @@ int RawDataUnpacker::ProcessOptoRxFrame(const word *buf, unsigned int frameSize,
   // get OptoRx metadata
   unsigned long long head = buf[0];
   unsigned long long foot = buf[frameSize-1];
-  
-//   std::cout.width(16);
-//   for (uint i=0; i<frameSize; i+=1) {
-//     std::cout<<"OptoRxFrame:      "<< (unsigned long long) buf[i] /*<< "    " << (uint) buf[i+1] << "    " << (uint) buf[i+2] << "    " << (uint) buf[i+3]*/ << std::endl;
-//   }
-//   std::cout<<"OptoRxFrame:      " << std::endl;
+
 
   fedInfo.setHeader(head);
   fedInfo.setFooter(foot);
@@ -219,7 +214,6 @@ int RawDataUnpacker::ProcessVFATDataParallel(const uint16_t *buf, unsigned int O
 {
   // start counting processed words
   unsigned int wordsProcessed = 1;
-//   bool verbosity=true;
 
   // padding word? skip it
   if (buf[0] == 0xFFFF)
@@ -289,11 +283,8 @@ int RawDataUnpacker::ProcessVFATDataParallel(const uint16_t *buf, unsigned int O
   {
     wordsProcessed--;
     while ( (buf[wordsProcessed] & 0xFFF0)!= 0xF000 ) {
-//       std::cout<<"DiamFrame ###       "<<wordsProcessed<<"   "<<std::hex<<(uint) buf[wordsProcessed]<<std::endl;
       wordsProcessed++;
     }
-
-//     std::cout<<"DiamFrame ### Word processed: "<<wordsProcessed<<"     "<<std::hex<<(uint) buf[wordsProcessed-1]<<std::endl;
   }
 
   // process trailer
@@ -426,8 +417,6 @@ int RawDataUnpacker::ProcessVFATDataParallel(const uint16_t *buf, unsigned int O
   // save frame to output
   f.setPresenceFlags(presenceFlags);
   fc->Insert(fp, f);
-
-//     f.Print();
 
   return wordsProcessed;
 }

--- a/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
@@ -385,24 +385,29 @@ int RawDataUnpacker::ProcessVFATDataParallel(const uint16_t *buf, unsigned int m
   if (hFlag == vmDiamondCompact)
   {
     for (unsigned int i = 1; (buf[i+1] & 0xFFF0)!= 0xF000; i++) {
-      if ( ( buf[i] & 0xF000 ) == VFAT_HEADER_OF_EC ) {     // If Event Couter word is found
+      if ( ( buf[i] & 0xF000 ) == VFAT_HEADER_OF_EC ) {
+        // Event Counter word is found
         fd[10] = buf[i];
         continue;
       }
       switch ( buf[i] & 0xF800 ) {
-        case VFAT_DIAMOND_HEADER_OF_WORD_2: // if Word 2 of the diamond VFAT frame is found
+        case VFAT_DIAMOND_HEADER_OF_WORD_2:
+          // word 2 of the diamond VFAT frame is found
           fd[2] = buf[i];
           fd[1] = buf[i + 1];
           break;
-        case VFAT_DIAMOND_HEADER_OF_WORD_3: // if Word 2 of the diamond VFAT frame is found
+        case VFAT_DIAMOND_HEADER_OF_WORD_3:
+          // word 3 of the diamond VFAT frame is found
           fd[3] = buf[i];
           fd[4] = buf[i - 1];
           break;
-        case VFAT_DIAMOND_HEADER_OF_WORD_5: // if Word 2 of the diamond VFAT frame is found
+        case VFAT_DIAMOND_HEADER_OF_WORD_5:
+          // word 5 of the diamond VFAT frame is found
           fd[5] = buf[i];
           fd[6] = buf[i - 1];
           break;
-        case VFAT_DIAMOND_HEADER_OF_WORD_7: // if Word 2 of the diamond VFAT frame is found
+        case VFAT_DIAMOND_HEADER_OF_WORD_7:
+          // word 7 of the diamond VFAT frame is found
           fd[7] = buf[i];
           fd[8] = buf[i - 1];
           break;

--- a/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
@@ -271,7 +271,7 @@ int RawDataUnpacker::ProcessVFATDataParallel(const uint16_t *buf, unsigned int m
   switch (hFlag) {
     case vmCluster: {
       unsigned int nCl = 0;
-      while ( (buf[wordsProcessed + nCl] >> 12) != 0xF && wordsProcessed+nCl<maxWords ) nCl++;
+      while ( (buf[wordsProcessed + nCl] >> 12) != 0xF && ( wordsProcessed + nCl < maxWords ) ) nCl++;
       wordsProcessed += nCl;
     } break;
     case vmRaw:
@@ -279,7 +279,7 @@ int RawDataUnpacker::ProcessVFATDataParallel(const uint16_t *buf, unsigned int m
       break;
     case vmDiamondCompact: {
       wordsProcessed--;
-      while ( (buf[wordsProcessed] & 0xFFF0)!= 0xF000 && wordsProcessed<maxWords ) wordsProcessed++;
+      while ( (buf[wordsProcessed] & 0xFFF0)!= 0xF000 && ( wordsProcessed < maxWords ) ) wordsProcessed++;
     } break;
   }
 
@@ -329,7 +329,7 @@ int RawDataUnpacker::ProcessVFATDataParallel(const uint16_t *buf, unsigned int m
   // get channel data - cluster mode
   if (hFlag == vmCluster)
   {
-    for (unsigned int nCl = 0; (buf[dataOffset + nCl] >> 12) != 0xF; ++nCl)
+    for (unsigned int nCl = 0; (buf[dataOffset + nCl] >> 12) != 0xF && ( dataOffset + nCl < maxWords ); ++nCl)
     {
       const uint16_t &w = buf[dataOffset + nCl];
       unsigned int upperBlock = w >> 8;
@@ -394,8 +394,8 @@ int RawDataUnpacker::ProcessVFATDataParallel(const uint16_t *buf, unsigned int m
       switch ( buf[i] & 0xF800 ) {
         case VFAT_DIAMOND_HEADER_OF_WORD_2:
           // word 2 of the diamond VFAT frame is found
-          fd[2] = buf[i];
           fd[1] = buf[i + 1];
+          fd[2] = buf[i];
           break;
         case VFAT_DIAMOND_HEADER_OF_WORD_3:
           // word 3 of the diamond VFAT frame is found

--- a/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
@@ -201,7 +201,7 @@ int RawDataUnpacker::ProcessOptoRxFrameParallel(const word *buf, unsigned int fr
   // process all VFAT data
   for (unsigned int offset = 0; offset < nWords;)
   {
-    unsigned int wordsProcessed = ProcessVFATDataParallel(payload + offset, OptoRxId, fc);
+    unsigned int wordsProcessed = ProcessVFATDataParallel(payload + offset, nWords, OptoRxId, fc);
     offset += wordsProcessed;
   }
 
@@ -210,7 +210,7 @@ int RawDataUnpacker::ProcessOptoRxFrameParallel(const word *buf, unsigned int fr
 
 //----------------------------------------------------------------------------------------------------
 
-int RawDataUnpacker::ProcessVFATDataParallel(const uint16_t *buf, unsigned int OptoRxId, SimpleVFATFrameCollection *fc) const
+int RawDataUnpacker::ProcessVFATDataParallel(const uint16_t *buf, unsigned int maxWords, unsigned int OptoRxId, SimpleVFATFrameCollection *fc) const
 {
   // start counting processed words
   unsigned int wordsProcessed = 1;
@@ -270,7 +270,7 @@ int RawDataUnpacker::ProcessVFATDataParallel(const uint16_t *buf, unsigned int O
   switch (hFlag) {
     case vmCluster: {
       unsigned int nCl = 0;
-      while ( (buf[wordsProcessed + nCl] >> 12) != 0xF ) nCl++;
+      while ( (buf[wordsProcessed + nCl] >> 12) != 0xF && wordsProcessed+nCl<maxWords ) nCl++;
       wordsProcessed += nCl;
     } break;
     case vmRaw:
@@ -278,7 +278,7 @@ int RawDataUnpacker::ProcessVFATDataParallel(const uint16_t *buf, unsigned int O
       break;
     case vmDiamondCompact: {
       wordsProcessed--;
-      while ( (buf[wordsProcessed] & 0xFFF0)!= 0xF000 ) wordsProcessed++;
+      while ( (buf[wordsProcessed] & 0xFFF0)!= 0xF000 && wordsProcessed<maxWords ) wordsProcessed++;
     } break;
   }
 

--- a/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
@@ -15,6 +15,7 @@
 
 using namespace std;
 using namespace edm;
+using namespace ctpps;
 
 //----------------------------------------------------------------------------------------------------
 

--- a/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
@@ -389,26 +389,30 @@ int RawDataUnpacker::ProcessVFATDataParallel(const uint16_t *buf, unsigned int O
   // get channel data for diamond compact mode
   if (hFlag == vmDiamondCompact)
   {
-    for (unsigned int i = 0; (buf[i+1] & 0xFFF0)!= 0xF000; i++) {
+    for (unsigned int i = 1; (buf[i+1] & 0xFFF0)!= 0xF000; i++) {
+      if ( ( buf[i] & 0xF000 ) == VFAT_HEADER_OF_EC ) {     // If Event Couter word is found
+        fd[10] = buf[i];
+        continue;
+      }
       switch ( buf[i] & 0xF800 ) {
-        case VFAT_DAIMOND_2:
-                                              fd[2] = buf[i];
-                                              fd[1] = buf[i + 1];
-                                              break;
-        case VFAT_DAIMOND_3:
-                                              fd[3] = buf[i];
-                                              fd[4] = buf[i - 1];
-                                              break;
-        case VFAT_DAIMOND_5:
-                                              fd[5] = buf[i];
-                                              fd[6] = buf[i - 1];
-                                              break;
-        case VFAT_DAIMOND_7:
-                                              fd[7] = buf[i];
-                                              fd[8] = buf[i - 1];
-                                              break;
+        case VFAT_DIAMOND_HEADER_OF_WORD_2:     // If Word 2 of the diamond VFAT frame is found
+          fd[2] = buf[i];
+          fd[1] = buf[i + 1];
+          break;
+        case VFAT_DIAMOND_HEADER_OF_WORD_3:     // If Word 2 of the diamond VFAT frame is found
+          fd[3] = buf[i];
+          fd[4] = buf[i - 1];
+          break;
+        case VFAT_DIAMOND_HEADER_OF_WORD_5:     // If Word 2 of the diamond VFAT frame is found
+          fd[5] = buf[i];
+          fd[6] = buf[i - 1];
+          break;
+        case VFAT_DIAMOND_HEADER_OF_WORD_7:     // If Word 2 of the diamond VFAT frame is found
+          fd[7] = buf[i];
+          fd[8] = buf[i - 1];
+          break;
         default:
-                                              break;
+          break;
       }
       presenceFlags |= 0x8;
     }

--- a/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
@@ -385,7 +385,7 @@ int RawDataUnpacker::ProcessVFATDataParallel(const uint16_t *buf, unsigned int m
   // get channel data for diamond compact mode
   if (hFlag == vmDiamondCompact)
   {
-    for (unsigned int i = 1; (buf[i+1] & 0xFFF0)!= 0xF000; i++) {
+    for (unsigned int i = 1; (buf[i+1] & 0xFFF0)!= 0xF000 && ( i+1 < maxWords ); i++) {
       if ( ( buf[i] & 0xF000 ) == VFAT_HEADER_OF_EC ) {
         // Event Counter word is found
         fd[10] = buf[i];

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -279,7 +279,6 @@ void RawToDigiConverter::Run(const VFATFrameCollection &coll, const TotemDAQMapp
 
     if (record.status.isOK())
     {
-      record.frame->Print();
       const VFATFrame *fr = record.frame;
       DiamondVFATFrame *diamondframeTmp = (DiamondVFATFrame*) fr;
       DiamondVFATFrame diamondframe(*diamondframeTmp);
@@ -291,9 +290,6 @@ void RawToDigiConverter::Run(const VFATFrameCollection &coll, const TotemDAQMapp
       DetSet<CTPPSDiamondDigi> &digiDetSet = digi.find_or_insert(detId);
       digiDetSet.push_back(CTPPSDiamondDigi(diamondframe.getLeadingEdgeTime(),diamondframe.getTrailingEdgeTime(),diamondframe.getThresholdVoltage(),diamondframe.getMultihit(),diamondframe.getHptdcErrorFlag()));
     }
-//     else {
-//       record.frame->Print();
-//     }
 
     // save status
     DetSet<TotemVFATStatus> &statusDetSet = status.find_or_insert(detId);

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -279,16 +279,21 @@ void RawToDigiConverter::Run(const VFATFrameCollection &coll, const TotemDAQMapp
 
     if (record.status.isOK())
     {
+      record.frame->Print();
       const VFATFrame *fr = record.frame;
-      DiamondVFATFrame *diamondframe = (DiamondVFATFrame*) fr;
+      DiamondVFATFrame *diamondframeTmp = (DiamondVFATFrame*) fr;
+      DiamondVFATFrame diamondframe(*diamondframeTmp);
 
       // update Event Counter in status
       record.status.setEC(record.frame->getEC() & 0xFF);
 
       // create the digi
       DetSet<CTPPSDiamondDigi> &digiDetSet = digi.find_or_insert(detId);
-      digiDetSet.push_back(CTPPSDiamondDigi(diamondframe->getLeadingEdgeTime(),diamondframe->getTrailingEdgeTime(),diamondframe->getThresholdVoltage(),diamondframe->getMultihit(),diamondframe->getHptdcErrorFlag()));
+      digiDetSet.push_back(CTPPSDiamondDigi(diamondframe.getLeadingEdgeTime(),diamondframe.getTrailingEdgeTime(),diamondframe.getThresholdVoltage(),diamondframe.getMultihit(),diamondframe.getHptdcErrorFlag()));
     }
+//     else {
+//       record.frame->Print();
+//     }
 
     // save status
     DetSet<TotemVFATStatus> &statusDetSet = status.find_or_insert(detId);

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -4,6 +4,8 @@
 * Authors:
 *   Jan Kašpar (jan.kaspar@gmail.com)
 *   Seyed Mohsen Etesami (setesami@cern.ch)
+*   Nicola Minafra
+*
 ****************************************************************************/
 
 #include "EventFilter/CTPPSRawToDigi/interface/RawToDigiConverter.h"

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -4,8 +4,6 @@
 * Authors:
 *   Jan Kašpar (jan.kaspar@gmail.com)
 *   Seyed Mohsen Etesami (setesami@cern.ch)
-*   Nicola Minafra
-*
 ****************************************************************************/
 
 #include "EventFilter/CTPPSRawToDigi/interface/RawToDigiConverter.h"
@@ -282,15 +280,14 @@ void RawToDigiConverter::Run(const VFATFrameCollection &coll, const TotemDAQMapp
     if (record.status.isOK())
     {
       const VFATFrame *fr = record.frame;
-      DiamondVFATFrame *diamondframeTmp = (DiamondVFATFrame*) fr;
-      DiamondVFATFrame diamondframe(*diamondframeTmp);
+      DiamondVFATFrame *diamondframe = (DiamondVFATFrame*) fr;
 
       // update Event Counter in status
       record.status.setEC(record.frame->getEC() & 0xFF);
 
       // create the digi
       DetSet<CTPPSDiamondDigi> &digiDetSet = digi.find_or_insert(detId);
-      digiDetSet.push_back(CTPPSDiamondDigi(diamondframe.getLeadingEdgeTime(),diamondframe.getTrailingEdgeTime(),diamondframe.getThresholdVoltage(),diamondframe.getMultihit(),diamondframe.getHptdcErrorFlag()));
+      digiDetSet.push_back(CTPPSDiamondDigi(diamondframe->getLeadingEdgeTime(),diamondframe->getTrailingEdgeTime(),diamondframe->getThresholdVoltage(),diamondframe->getMultihit(),diamondframe->getHptdcErrorFlag()));
     }
 
     // save status

--- a/EventFilter/CTPPSRawToDigi/test/TotemVFATFrameAnalyzer.cc
+++ b/EventFilter/CTPPSRawToDigi/test/TotemVFATFrameAnalyzer.cc
@@ -39,7 +39,7 @@ class TotemVFATFrameAnalyzer : public edm::global::EDAnalyzer<>
 
     edm::EDGetTokenT<FEDRawDataCollection> fedDataToken;
 
-    RawDataUnpacker rawDataUnpacker;
+    ctpps::RawDataUnpacker rawDataUnpacker;
 
     template <typename DigiType>
     void run(edm::Event&, const edm::EventSetup&);

--- a/EventFilter/CTPPSRawToDigi/test/test_diamonds_only_cfg.py
+++ b/EventFilter/CTPPSRawToDigi/test/test_diamonds_only_cfg.py
@@ -10,15 +10,14 @@ process.MessageLogger = cms.Service("MessageLogger",
 )
 
 # raw data source
-process.source = cms.Source("PoolSource",
+process.source = cms.Source("NewEventStreamFileReader",
   fileNames = cms.untracked.vstring(
-    #'file:/afs/cern.ch/user/j/jkaspar/public/run273062_ls0001-2_stream.root'
-    '/store/express/Run2016H/ExpressPhysics/FEVT/Express-v2/000/283/877/00000/4EE44B0E-2499-E611-A155-02163E011938.root'
+        '/store/t0streamer/Minidaq/A/000/298/442/run298442_ls0001_streamA_StorageManager.dat'
   )
 )
 
 process.maxEvents = cms.untracked.PSet(
-  input = cms.untracked.int32(100)
+  input = cms.untracked.int32(20)
 )
 
 # raw-to-digi conversion


### PR DESCRIPTION
backport of #19754 

This PR introduces a collection of critical (and *urgent*) SW changes for 2017 data-taking operations with the diamond detectors:
* new "lite" readout mode unpacking handled properly, allowing to run on high rate conditions (previously limited at ~80 kHz) ; this SW update is fully backward-compatible, but its integration on the Tier-0 is **critical** before the deployment of the new FED FW
* leading and trailing edges are inverted, following the investigation performed on the signal cable polarities ; this feature will be backported in all useful releases for the next re-reco of previously collected data.

The test in `EventFilter/CTPPSRawToDigi/test/test_diamonds_only_cfg.py` has been modified to allow to test the new unpacker on a miniDAQ run collected with this new readout mode.