### PR TITLE
[93X] Streamline Alignment PV Validation tool

### DIFF
--- a/Alignment/OfflineValidation/BuildFile.xml
+++ b/Alignment/OfflineValidation/BuildFile.xml
@@ -11,6 +11,7 @@
 
 <use   name="CLHEP"/>
 <use   name="rootmath"/>
+<use   name="rootgraphics"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/Alignment/OfflineValidation/BuildFile.xml
+++ b/Alignment/OfflineValidation/BuildFile.xml
@@ -11,7 +11,7 @@
 
 <use   name="CLHEP"/>
 <use   name="rootmath"/>
-<use   name="rootgraphics"/>
+<use   name="roothistmatrix"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/Alignment/OfflineValidation/interface/PVValidationHelpers.h
+++ b/Alignment/OfflineValidation/interface/PVValidationHelpers.h
@@ -4,8 +4,11 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <cassert>
 #include <utility>
 #include "TH1.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace PVValHelper {
 
@@ -53,6 +56,37 @@ namespace PVValHelper {
   struct histodetails{
     std::map<std::pair<residualType,plotVariable>,std::pair<float,float>> range;
     int histobins;
+    void setMap(residualType type,plotVariable plot,float low,float high){
+      assert(low<high);     
+      range[std::make_pair(type,plot)] = std::make_pair(low,high);
+    }
+
+    std::pair<float,float> getRange(residualType type,plotVariable plot){
+      if (range.find(std::make_pair(type,plot)) != range.end()) {
+	return range[std::make_pair(type,plot)];
+      } else {
+	edm::LogWarning("PVValidationHelpers") << "Trying to get range for non-existent combination "<< std::endl;
+	return std::make_pair(0.,0.);
+      }
+    }
+
+    float getLow(residualType type,plotVariable plot){
+      if (range.find(std::make_pair(type,plot)) != range.end()) {
+	return range[std::make_pair(type,plot)].first;
+      } else {
+	edm::LogWarning("PVValidationHelpers") << "Trying to get low end of range for non-existent combination "<< std::endl;
+	return 0.;
+      }
+    }
+
+    float getHigh(residualType type,plotVariable plot){
+      if (range.find(std::make_pair(type,plot)) != range.end()) {
+	return range[std::make_pair(type,plot)].second;
+      } else {
+	edm::LogWarning("PVValidationHelpers") << "Trying get high end of range for non-existent combination "<< std::endl;
+	return 0.;
+      }
+    }
   };
 
   // helper methods

--- a/Alignment/OfflineValidation/interface/PVValidationHelpers.h
+++ b/Alignment/OfflineValidation/interface/PVValidationHelpers.h
@@ -1,0 +1,76 @@
+#ifndef ALIGNMENT_OFFLINEVALIDATION_PVVALIDATIONHELPER_H
+#define ALIGNMENT_OFFLINEVALIDATION_PVVALIDATIONHELPER_H
+
+#include <string>
+#include <vector>
+#include <map>
+#include <utility>
+#include "TH1.h"
+
+namespace PVValHelper {
+
+  // helper data formats
+
+  enum estimator 
+    { MEAN   = 1,
+      WIDTH  = 2, 
+      MEDIAN = 3,
+      MAD    = 4,
+      UNKWN  = -1
+    };
+  
+  enum residualType 
+    { dxy = 1,
+      dx  = 2,
+      dy  = 3,
+      dz  = 4,
+      IP2D = 5,
+      resz = 6,
+      IP3D = 7,
+      d3D  = 8,
+      
+      norm_dxy = 9,
+      norm_dx  = 10,
+      norm_dy  = 11,
+      norm_dz  = 12,
+      norm_IP2D = 13,
+      norm_resz = 14,
+      norm_IP3D = 15,
+      norm_d3D  = 16,
+      END_OF_TYPES = 17,
+    };
+    
+  enum plotVariable
+    { phi    = 1,
+      eta    = 2,
+      pT     = 3,
+      pTCentral = 4,
+      ladder = 5,
+      modZ   = 6,
+      END_OF_PLOTS = 7,
+    };
+
+  struct histodetails{
+    std::map<std::pair<residualType,plotVariable>,std::pair<float,float>> range;
+    int histobins;
+  };
+
+  // helper methods
+  
+  void add(std::map<std::string,TH1*>& h, TH1* hist);
+  
+  void fill(std::map<std::string, TH1*>& h,const std::string& s, double x);
+  
+  void fill(std::map<std::string, TH1*>& h,const std::string& s, double x, double y);
+
+  void fillByIndex(std::vector<TH1F*>& h, unsigned int index, double x,std::string tag="");
+  
+  void shrinkHistVectorToFit(std::vector<TH1F*>&h, unsigned int desired_size);
+    
+  std::tuple<std::string,std::string,std::string> getTypeString (residualType type);  
+
+  std::tuple<std::string,std::string,std::string> getVarString (PVValHelper::plotVariable var);
+
+};
+
+#endif

--- a/Alignment/OfflineValidation/interface/PVValidationHelpers.h
+++ b/Alignment/OfflineValidation/interface/PVValidationHelpers.h
@@ -54,8 +54,11 @@ namespace PVValHelper {
     };
 
   struct histodetails{
-    std::map<std::pair<residualType,plotVariable>,std::pair<float,float>> range;
+
     int histobins;
+    std::map<std::pair<residualType,plotVariable>,std::pair<float,float>> range;
+    std::map<plotVariable,std::vector<float> > trendbins; 
+
     void setMap(residualType type,plotVariable plot,float low,float high){
       assert(low<high);     
       range[std::make_pair(type,plot)] = std::make_pair(low,high);
@@ -104,6 +107,8 @@ namespace PVValHelper {
   std::tuple<std::string,std::string,std::string> getTypeString (residualType type);  
 
   std::tuple<std::string,std::string,std::string> getVarString (PVValHelper::plotVariable var);
+
+  std::vector<float> generateBins(int n, float start, float range);
 
 };
 

--- a/Alignment/OfflineValidation/interface/PVValidationHelpers.h
+++ b/Alignment/OfflineValidation/interface/PVValidationHelpers.h
@@ -9,6 +9,7 @@
 #include "TH1.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1D.h"
 
 namespace PVValHelper {
 
@@ -92,6 +93,8 @@ namespace PVValHelper {
     }
   };
 
+  typedef std::tuple<std::string,std::string,std::string>  plotLabels;
+
   // helper methods
   
   void add(std::map<std::string,TH1*>& h, TH1* hist);
@@ -104,11 +107,17 @@ namespace PVValHelper {
   
   void shrinkHistVectorToFit(std::vector<TH1F*>&h, unsigned int desired_size);
     
-  std::tuple<std::string,std::string,std::string> getTypeString (residualType type);  
+  plotLabels getTypeString (residualType type);  
 
-  std::tuple<std::string,std::string,std::string> getVarString (PVValHelper::plotVariable var);
+  plotLabels getVarString (plotVariable var);
 
   std::vector<float> generateBins(int n, float start, float range);
+
+  Measurement1D getMedian(TH1F *histo);
+
+  Measurement1D getMAD(TH1F *histo);
+
+  std::pair<Measurement1D, Measurement1D> fitResiduals(TH1 *hist);
 
 };
 

--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -516,14 +516,14 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
 
     if(gDirectory->GetListOfKeys()->Contains("etaMax")){
       gDirectory->GetObject("etaMax",theEtaHistos[i]);
-      theEtaMax_[i]   = theEtaHistos[i]->GetBinContent(1);
+      theEtaMax_[i]   = theEtaHistos[i]->GetBinContent(1)/theEtaHistos[i]->GetEntries();
     } else {
       theEtaMax_[i]   = 2.5;
     }
     	
     if(gDirectory->GetListOfKeys()->Contains("nbins")){
       gDirectory->GetObject("nbins",thebinsHistos[i]);
-      theNBINS[i] = thebinsHistos[i]->GetBinContent(1);
+      theNBINS[i] = thebinsHistos[i]->GetBinContent(1)/thebinsHistos[i]->GetEntries();	  
       std::cout<<"File n. "<<i<<" has theNBINS["<<i<<"] = "<< theNBINS[i]<<std::endl;
     } else {
       theNBINS[i] = 48.;
@@ -532,7 +532,7 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
 
     if(gDirectory->GetListOfKeys()->Contains("nladders")){
       gDirectory->GetObject("nladders",theLaddersHistos[i]);
-      theLadders[i] = theLaddersHistos[i]->GetBinContent(1);
+      theLadders[i] = theLaddersHistos[i]->GetBinContent(1)/theLaddersHistos[i]->GetEntries();
       std::cout<<"File n. "<<i<<" has theNLadders["<<i<<"] = "<< theLadders[i]<<std::endl;
     } else {
       theLadders[i] = -1.;

--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -852,15 +852,15 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
 
     if(nLadders_>0){
 
-      dxyLadderMeanTrend[i]  = new TH1F(Form("means_dxy_ladder_%i",i),"#LT d_{xy} #GT vs L1 ladder;ladder number;#LT d_{xy} #GT [#mum]",theLadders[i],0.,theLadders[i]);
-      dxyLadderWidthTrend[i] = new TH1F(Form("widths_dxy_ladder_%i",i),"#sigma(d_{xy}) vs L1 ladder;ladder number;#sigma(d_{xy}) [#mum]",theLadders[i],0.,theLadders[i]);
-      dzLadderMeanTrend[i]   = new TH1F(Form("means_dz_ladder_%i",i),"#LT d_{z} #GT vs L1 ladder;ladder number;#LT d_{z} #GT [#mum]",theLadders[i],0.,theLadders[i]);  
-      dzLadderWidthTrend[i]  = new TH1F(Form("widths_dz_ladder_%i",i),"#sigma(d_{z}) vs L1 ladder;ladder number;#sigma(d_{z}) [#mum]",theLadders[i],0.,theLadders[i]);
+      dxyLadderMeanTrend[i]  = new TH1F(Form("means_dxy_ladder_%i",i),"#LT d_{xy} #GT vs Layer 1 ladder;ladder number;#LT d_{xy} #GT [#mum]",theLadders[i],0.,theLadders[i]);
+      dxyLadderWidthTrend[i] = new TH1F(Form("widths_dxy_ladder_%i",i),"#sigma(d_{xy}) vs Layer 1 ladder;ladder number;#sigma(d_{xy}) [#mum]",theLadders[i],0.,theLadders[i]);
+      dzLadderMeanTrend[i]   = new TH1F(Form("means_dz_ladder_%i",i),"#LT d_{z} #GT vs Layer 1 ladder;ladder number;#LT d_{z} #GT [#mum]",theLadders[i],0.,theLadders[i]);  
+      dzLadderWidthTrend[i]  = new TH1F(Form("widths_dz_ladder_%i",i),"#sigma(d_{z}) vs Layer 1 ladder;ladder number;#sigma(d_{z}) [#mum]",theLadders[i],0.,theLadders[i]);
       
-      dxyModZMeanTrend[i]    = new TH1F(Form("means_dxy_modZ_%i",i),"#LT d_{xy} #GT vs L1 module number;module number;#LT d_{xy} #GT [#mum]",8,0.,8.);
-      dxyModZWidthTrend[i]   = new TH1F(Form("widths_dxy_modZ_%i",i),"#sigma(d_{xy}) vs L1 module number;module number;#sigma(d_{xy}) [#mum]",8,0.,8.);
-      dzModZMeanTrend[i]     = new TH1F(Form("means_dz_modZ_%i",i),"#LT d_{z} #GT vs L1 module number;module number;#LT d_{z} #GT [#mum]",8,0.,8.);  
-      dzModZWidthTrend[i]    = new TH1F(Form("widths_dz_modZ_%i",i),"#sigma(d_{z}) vs L1 module number;module number;#sigma(d_{z}) [#mum]",8,0.,8.);
+      dxyModZMeanTrend[i]    = new TH1F(Form("means_dxy_modZ_%i",i),"#LT d_{xy} #GT vs Layer 1 module number;module number;#LT d_{xy} #GT [#mum]",8,0.,8.);
+      dxyModZWidthTrend[i]   = new TH1F(Form("widths_dxy_modZ_%i",i),"#sigma(d_{xy}) vs Layer 1 module number;module number;#sigma(d_{xy}) [#mum]",8,0.,8.);
+      dzModZMeanTrend[i]     = new TH1F(Form("means_dz_modZ_%i",i),"#LT d_{z} #GT vs Layer 1 module number;module number;#LT d_{z} #GT [#mum]",8,0.,8.);  
+      dzModZWidthTrend[i]    = new TH1F(Form("widths_dz_modZ_%i",i),"#sigma(d_{z}) vs Layer 1 module number;module number;#sigma(d_{z}) [#mum]",8,0.,8.);
 
     }
 
@@ -883,15 +883,15 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
 
     if(nLadders_>0){
     
-      dxyNormLadderMeanTrend[i]  = new TH1F(Form("means_dxyNorm_ladder_%i",i),"#LT d_{xy}/#sigma_{d_{xy}} #GT vs L1 ladder;ladder number;#LT d_{xy}/#sigma_{d_{xy}} #GT",theLadders[i],0.,theLadders[i]);
-      dxyNormLadderWidthTrend[i] = new TH1F(Form("widths_dxyNorm_ladder_%i",i),"#sigma(d_{xy}/#sigma_{d_{xy}}) vs L1 ladder;ladder number;#sigma(d_{xy}/#sigma_{d_{xy}})",theLadders[i],0.,theLadders[i]);
-      dzNormLadderMeanTrend[i]   = new TH1F(Form("means_dzNorm_ladder_%i",i),"#LT d_{z}/#sigma_{d_{z}} #GT vs L1 ladder;ladder number;#LT d_{z}/#sigma_{d_{z}} #GT",theLadders[i],0.,theLadders[i]);  
-      dzNormLadderWidthTrend[i]  = new TH1F(Form("widths_dzNorm_ladder_%i",i),"#sigma(d_{z}/#sigma_{d_{z}}) vs L1 ladder;ladder number;#sigma(d_{z}/#sigma_{d_{z}})",theLadders[i],0.,theLadders[i]);
+      dxyNormLadderMeanTrend[i]  = new TH1F(Form("means_dxyNorm_ladder_%i",i),"#LT d_{xy}/#sigma_{d_{xy}} #GT vs Layer 1 ladder;ladder number;#LT d_{xy}/#sigma_{d_{xy}} #GT",theLadders[i],0.,theLadders[i]);
+      dxyNormLadderWidthTrend[i] = new TH1F(Form("widths_dxyNorm_ladder_%i",i),"#sigma(d_{xy}/#sigma_{d_{xy}}) vs Layer 1 ladder;ladder number;#sigma(d_{xy}/#sigma_{d_{xy}})",theLadders[i],0.,theLadders[i]);
+      dzNormLadderMeanTrend[i]   = new TH1F(Form("means_dzNorm_ladder_%i",i),"#LT d_{z}/#sigma_{d_{z}} #GT vs Layer 1 ladder;ladder number;#LT d_{z}/#sigma_{d_{z}} #GT",theLadders[i],0.,theLadders[i]);  
+      dzNormLadderWidthTrend[i]  = new TH1F(Form("widths_dzNorm_ladder_%i",i),"#sigma(d_{z}/#sigma_{d_{z}}) vs Layer 1 ladder;ladder number;#sigma(d_{z}/#sigma_{d_{z}})",theLadders[i],0.,theLadders[i]);
       
-      dxyNormModZMeanTrend[i]    = new TH1F(Form("means_dxyNorm_modZ_%i",i),"#LT d_{xy}/#sigma_{d_{xy}} #GT vs L1 module number;module number;#LT d_{xy}/#sigma_{d_{xy}} #GT",8,0.,8.);
-      dxyNormModZWidthTrend[i]   = new TH1F(Form("widths_dxyNorm_modZ_%i",i),"#sigma(d_{xy}/#sigma_{d_{xy}}) vs L1 module number;module number;#sigma(d_{xy}/#sigma_{d_{xy}})",8,0.,8.);
-      dzNormModZMeanTrend[i]     = new TH1F(Form("means_dzNorm_modZ_%i",i),"#LT d_{z}/#sigma_{d_{z}} #GT vs L1 module number;module number;#LT d_{z}/#sigma_{d_{z}} #GT",8,0.,8.);  
-      dzNormModZWidthTrend[i]    = new TH1F(Form("widths_dzNorm_modZ_%i",i),"#sigma(d_{z}/#sigma_{d_{z}}) vs L1 module number;module number;#sigma(d_{z}/#sigma_{d_{z}})",8,0.,8.);
+      dxyNormModZMeanTrend[i]    = new TH1F(Form("means_dxyNorm_modZ_%i",i),"#LT d_{xy}/#sigma_{d_{xy}} #GT vs Layer 1 module number;module number;#LT d_{xy}/#sigma_{d_{xy}} #GT",8,0.,8.);
+      dxyNormModZWidthTrend[i]   = new TH1F(Form("widths_dxyNorm_modZ_%i",i),"#sigma(d_{xy}/#sigma_{d_{xy}}) vs Layer 1 module number;module number;#sigma(d_{xy}/#sigma_{d_{xy}})",8,0.,8.);
+      dzNormModZMeanTrend[i]     = new TH1F(Form("means_dzNorm_modZ_%i",i),"#LT d_{z}/#sigma_{d_{z}} #GT vs Layer 1 module number;module number;#LT d_{z}/#sigma_{d_{z}} #GT",8,0.,8.);  
+      dzNormModZWidthTrend[i]    = new TH1F(Form("widths_dzNorm_modZ_%i",i),"#sigma(d_{z}/#sigma_{d_{z}}) vs Layer 1 module number;module number;#sigma(d_{z}/#sigma_{d_{z}})",8,0.,8.);
 
     }
 
@@ -1289,13 +1289,13 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
   // Bias plots (ladders and module number)
 
   if(nLadders_>0){
-    TCanvas *BiasesCanvasL1 = new TCanvas("BiasCanvasL1","BiasCanvasL1",1200,1200);
-    arrangeBiasCanvas(BiasesCanvasL1,dxyLadderMeanTrend,dzLadderMeanTrend,dxyModZMeanTrend, dzModZMeanTrend,nFiles_,LegLabels,theDate,setAutoLimits);
+    TCanvas *BiasesCanvasLayer1 = new TCanvas("BiasCanvasLayer1","BiasCanvasLayer1",1200,1200);
+    arrangeBiasCanvas(BiasesCanvasLayer1,dxyLadderMeanTrend,dzLadderMeanTrend,dxyModZMeanTrend, dzModZMeanTrend,nFiles_,LegLabels,theDate,setAutoLimits);
     
-    BiasesCanvasL1->SaveAs("BiasesCanvasL1_"+theStrDate+theStrAlignment+".pdf");
-    BiasesCanvasL1->SaveAs("BiasesCanvasL1_"+theStrDate+theStrAlignment+".png");
+    BiasesCanvasLayer1->SaveAs("BiasesCanvasLayer1_"+theStrDate+theStrAlignment+".pdf");
+    BiasesCanvasLayer1->SaveAs("BiasesCanvasLayer1_"+theStrDate+theStrAlignment+".png");
 
-    delete BiasesCanvasL1;
+    delete BiasesCanvasLayer1;
   }
 
   TCanvas *dxyPhiBiasCanvas = new TCanvas("dxyPhiBiasCanvas","dxyPhiBiasCanvas",600,600);
@@ -1343,13 +1343,13 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
 
   if(nLadders_>0){
 
-    TCanvas *ResolutionsCanvasL1 = new TCanvas("ResolutionsCanvasL1","ResolutionsCanvasL1",1200,1200);
-    arrangeBiasCanvas(ResolutionsCanvasL1,dxyLadderWidthTrend,dzLadderWidthTrend,dxyModZWidthTrend,dzModZWidthTrend,nFiles_,LegLabels,theDate,setAutoLimits);
+    TCanvas *ResolutionsCanvasLayer1 = new TCanvas("ResolutionsCanvasLayer1","ResolutionsCanvasLayer1",1200,1200);
+    arrangeBiasCanvas(ResolutionsCanvasLayer1,dxyLadderWidthTrend,dzLadderWidthTrend,dxyModZWidthTrend,dzModZWidthTrend,nFiles_,LegLabels,theDate,setAutoLimits);
     
-    ResolutionsCanvasL1->SaveAs("ResolutionsCanvasL1_"+theStrDate+theStrAlignment+".pdf");
-    ResolutionsCanvasL1->SaveAs("ResolutionsCanvasL1_"+theStrDate+theStrAlignment+".png");
+    ResolutionsCanvasLayer1->SaveAs("ResolutionsCanvasLayer1_"+theStrDate+theStrAlignment+".pdf");
+    ResolutionsCanvasLayer1->SaveAs("ResolutionsCanvasLayer1_"+theStrDate+theStrAlignment+".png");
 
-    delete ResolutionsCanvasL1;
+    delete ResolutionsCanvasLayer1;
   }
 
   // Pull plots
@@ -1361,13 +1361,13 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
   PullsCanvas->SaveAs("PullsCanvas_"+theStrDate+theStrAlignment+".png");
 
   if(nLadders_>0){
-    TCanvas *PullsCanvasL1 = new TCanvas("PullsCanvasL1","PullsCanvasL1",1200,1200);
-    arrangeBiasCanvas(PullsCanvasL1,dxyNormLadderWidthTrend,dzNormLadderWidthTrend,dxyNormModZWidthTrend,dzNormModZWidthTrend,nFiles_,LegLabels,theDate,setAutoLimits);
+    TCanvas *PullsCanvasLayer1 = new TCanvas("PullsCanvasLayer1","PullsCanvasLayer1",1200,1200);
+    arrangeBiasCanvas(PullsCanvasLayer1,dxyNormLadderWidthTrend,dzNormLadderWidthTrend,dxyNormModZWidthTrend,dzNormModZWidthTrend,nFiles_,LegLabels,theDate,setAutoLimits);
     
-    PullsCanvasL1->SaveAs("PullsCanvasL1_"+theStrDate+theStrAlignment+".pdf");
-    PullsCanvasL1->SaveAs("PullsCanvasL1_"+theStrDate+theStrAlignment+".png");
+    PullsCanvasLayer1->SaveAs("PullsCanvasLayer1_"+theStrDate+theStrAlignment+".pdf");
+    PullsCanvasLayer1->SaveAs("PullsCanvasLayer1_"+theStrDate+theStrAlignment+".png");
 
-    delete PullsCanvasL1;
+    delete PullsCanvasLayer1;
   }
 
   // delete all news
@@ -1505,12 +1505,18 @@ void arrangeBiasCanvas(TCanvas *canv,TH1F* dxyPhiMeanTrend[100],TH1F* dzPhiMeanT
     }
 
     Double_t safeDelta=(absmax[k]-absmin[k])/8.;
+
+    // if(safeDelta<0.1*absmax[k]) safeDelta*=16;
+
     Double_t theExtreme=std::max(absmax[k],TMath::Abs(absmin[k]));
 
     for(Int_t i=0; i<nFiles; i++){
       if(i==0){
 
 	TString theTitle = dBiasTrend[k][i]->GetName();
+	
+	//std::cout << theTitle<< " --->" << safeDelta << std::endl;
+
 	// if the autoLimits are not set
 	if(!setAutoLimits){
 	  
@@ -1520,11 +1526,17 @@ void arrangeBiasCanvas(TCanvas *canv,TH1F* dxyPhiMeanTrend[100],TH1F* dzPhiMeanT
 	} else {
 	
 	  if(theTitle.Contains("width")){
+
+	    if(theTitle.Contains("Norm"))
+	      safeDelta = (theTitle.Contains("ladder")==true||theTitle.Contains("modZ")==true) ? 1.  : safeDelta; 
+	    else
+	      safeDelta = (theTitle.Contains("ladder")==true||theTitle.Contains("modZ")==true) ? 50. : safeDelta; 
+
 	    dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,theExtreme+(safeDelta/2.));
 	  } else {
 
 	    if( theTitle.Contains("Norm")){
-	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(std::min(-0.48,absmin[k]-safeDelta/2.),std::max(0.48,absmax[k]+safeDelta/2.));
+	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(std::min(-0.48,absmin[k]-(safeDelta/2.)),std::max(0.48,absmax[k]+(safeDelta/2.)));
 	    } else if ( theTitle.Contains("h_probe")) {
 	      TGaxis::SetMaxDigits(4);   
 	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,theExtreme+(safeDelta*2.));
@@ -1533,7 +1545,6 @@ void arrangeBiasCanvas(TCanvas *canv,TH1F* dxyPhiMeanTrend[100],TH1F* dzPhiMeanT
 	    } 
 	  }
 	}
-
 	dBiasTrend[k][i]->Draw("e1");
 	makeNewXAxis(dBiasTrend[k][i]);
 	Int_t nbins =  dBiasTrend[k][i]->GetNbinsX();
@@ -1561,7 +1572,9 @@ void arrangeBiasCanvas(TCanvas *canv,TH1F* dxyPhiMeanTrend[100],TH1F* dzPhiMeanT
 	theConst->Draw("PLsame");
 
       }
-      else dBiasTrend[k][i]->Draw("e1sames");
+      else { 
+	dBiasTrend[k][i]->Draw("e1sames");	
+      }
       if(k==0){
 	lego->AddEntry(dBiasTrend[k][i],LegLabels[i]);
       } 
@@ -1692,6 +1705,8 @@ void arrangeCanvas(TCanvas *canv,TH1F* meanplots[100],TH1F* widthplots[100],Int_
       if(TString(meanplots[i]->GetName()).Contains("pT")){
        	//meanplots[i]->Draw("HIST][same");
 	gPad->SetLogx();
+	gPad->SetGridx();
+	gPad->SetGridy();
       } else {
 	makeNewXAxis(meanplots[i]); 
       }
@@ -1759,16 +1774,17 @@ void arrangeCanvas(TCanvas *canv,TH1F* meanplots[100],TH1F* widthplots[100],Int_
 	}
 
 	widthplots[i]->Draw("e1");
-	//if(TString(widthplots[i]->GetName()).Contains("pT")){
-	//  widthplots[i]->Draw("HIST][same");
-	//	}
-
+	if(TString(widthplots[i]->GetName()).Contains("pT")){
+	  widthplots[i]->Draw("HIST][same");
+	  gPad->SetGridx();
+	  gPad->SetGridy();
+	} 
 	makeNewXAxis(widthplots[i]);
       } else {
 	widthplots[i]->Draw("e1sames");
-	//if(TString(widthplots[i]->GetName()).Contains("pT")){
-	//  widthplots[i]->Draw("HIST][same");
-	//	}
+	if(TString(widthplots[i]->GetName()).Contains("pT")){
+	  widthplots[i]->Draw("HIST][same");
+	}
       }
     }
     
@@ -3444,26 +3460,34 @@ params::measurement getTheRangeUser(TH1F* thePlot, Limits* lims)
 	  result = std::make_pair(-lims->get_dxyPhiNormMax().first,lims->get_dxyPhiNormMax().first);
 	} else if (theTitle.Contains("eta")){
 	  result = std::make_pair(-lims->get_dxyEtaNormMax().first,lims->get_dxyEtaNormMax().first);
+	} else {
+	  result = std::make_pair(-0.8,0.8);
 	}
       } else if(theTitle.Contains("dz")){
 	if(theTitle.Contains("phi")){
 	  result = std::make_pair(-lims->get_dzPhiNormMax().first,lims->get_dzPhiNormMax().first);
 	} else if (theTitle.Contains("eta")){
 	  result = std::make_pair(-lims->get_dzEtaNormMax().first,lims->get_dzEtaNormMax().first);
+	} else {
+	  result = std::make_pair(-0.8,0.8);
 	}
-      }
+      } 
     } else if (theTitle.Contains("widths")){
       if(theTitle.Contains("dxy") || theTitle.Contains("dx") || theTitle.Contains("dy")){
 	if(theTitle.Contains("phi")){
 	  result = std::make_pair(0.,lims->get_dxyPhiNormMax().second);
 	} else if (theTitle.Contains("eta")){
 	  result = std::make_pair(0.,lims->get_dxyEtaNormMax().second);
+	} else {
+	  result = std::make_pair(0.,2.);
 	}
       } else if(theTitle.Contains("dz")){	
 	if(theTitle.Contains("phi")){
 	  result = std::make_pair(0.,lims->get_dzPhiNormMax().second);
 	} else if (theTitle.Contains("eta")){
 	  result = std::make_pair(0.,lims->get_dzEtaNormMax().second);
+	} else {
+	  result = std::make_pair(0.,2.);
 	}
       }
     } 
@@ -3474,12 +3498,16 @@ params::measurement getTheRangeUser(TH1F* thePlot, Limits* lims)
 	  result = std::make_pair(-lims->get_dxyPhiMax().first,lims->get_dxyPhiMax().first);
 	} else if (theTitle.Contains("eta")){
 	  result = std::make_pair(-lims->get_dxyEtaMax().first,lims->get_dxyEtaMax().first);
+	} else {
+	  result = std::make_pair(-40.,40.);
 	}
       } else if(theTitle.Contains("dz")){
 	if(theTitle.Contains("phi")){
 	  result = std::make_pair(-lims->get_dzPhiMax().first,lims->get_dzPhiMax().first);
 	} else if (theTitle.Contains("eta")){
 	  result = std::make_pair(-lims->get_dzEtaMax().first,lims->get_dzEtaMax().first);
+	} else {
+	  result = std::make_pair(-80.,80.);
 	}
       }
     } else if (theTitle.Contains("widths")){
@@ -3488,12 +3516,16 @@ params::measurement getTheRangeUser(TH1F* thePlot, Limits* lims)
 	  result = std::make_pair(0.,lims->get_dxyPhiMax().second);
 	} else if (theTitle.Contains("eta")){
 	  result = std::make_pair(0.,lims->get_dxyEtaMax().second);
+	} else {
+	  result = std::make_pair(0.,150.);
 	}
       } else if(theTitle.Contains("dz")){	
 	if(theTitle.Contains("phi")){
 	  result = std::make_pair(0.,lims->get_dzPhiMax().second);
 	} else if (theTitle.Contains("eta")){
 	  result = std::make_pair(0.,lims->get_dzEtaMax().second);
+	}  else {
+	  result = std::make_pair(0.,300.);
 	}
       }
     }

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -1326,62 +1326,63 @@ void PrimaryVertexValidation::beginJob()
   // book residuals vs pT histograms
   
   TFileDirectory AbsTranspTRes  = fs->mkdir("Abs_Transv_pT_Residuals"); 
-  h_dxy_pT_      = bookResidualsHistogram(AbsTranspTRes,nPtBins_,"dxy","pT");	       
+  h_dxy_pT_      = bookResidualsHistogram(AbsTranspTRes,nPtBins_,pvparams::dxy,pvparams::pT);	       
 
   TFileDirectory AbsLongpTRes   = fs->mkdir("Abs_Long_pT_Residuals"); 
-  h_dz_pT_       = bookResidualsHistogram(AbsLongpTRes,nPtBins_,"dz","pT");		       
+  h_dz_pT_       = bookResidualsHistogram(AbsLongpTRes,nPtBins_,pvparams::dz,pvparams::pT);		       
 
   TFileDirectory NormTranspTRes = fs->mkdir("Norm_Transv_pT_Residuals"); 
-  h_norm_dxy_pT_ = bookResidualsHistogram(NormTranspTRes,nPtBins_,"norm_dxy","pT");	       
+  h_norm_dxy_pT_ = bookResidualsHistogram(NormTranspTRes,nPtBins_,pvparams::norm_dxy,pvparams::pT,true);	       
 
   TFileDirectory NormLongpTRes  = fs->mkdir("Norm_Long_pT_Residuals"); 
-  h_norm_dz_pT_  = bookResidualsHistogram(NormLongpTRes,nPtBins_,"norm_dz","pT");	       
+  h_norm_dz_pT_  = bookResidualsHistogram(NormLongpTRes,nPtBins_,pvparams::norm_dz,pvparams::pT,true);	       
 
   // book residuals vs pT histograms in central region (|eta|<1.0)
                
   TFileDirectory AbsTranspTCentralRes  = fs->mkdir("Abs_Transv_pTCentral_Residuals"); 
-  h_dxy_Central_pT_ = bookResidualsHistogram(AbsTranspTCentralRes,nPtBins_,"dxy","pTCentral");       
+  h_dxy_Central_pT_ = bookResidualsHistogram(AbsTranspTCentralRes,nPtBins_,pvparams::dxy,pvparams::pTCentral);       
 
   TFileDirectory AbsLongpTCentralRes   = fs->mkdir("Abs_Long_pTCentral_Residuals"); 
-  h_dz_Central_pT_  = bookResidualsHistogram(AbsLongpTCentralRes,nPtBins_,"dz","pTCentral");	       
+  h_dz_Central_pT_  = bookResidualsHistogram(AbsLongpTCentralRes,nPtBins_,pvparams::dz,pvparams::pTCentral);	       
 
   TFileDirectory NormTranspTCentralRes = fs->mkdir("Norm_Transv_pTCentral_Residuals"); 
-  h_norm_dxy_Central_pT_ = bookResidualsHistogram(NormTranspTCentralRes,nPtBins_,"norm_dxy","pTCentral");  
+  h_norm_dxy_Central_pT_ = bookResidualsHistogram(NormTranspTCentralRes,nPtBins_,pvparams::norm_dxy,pvparams::pTCentral,true);  
 
   TFileDirectory NormLongpTCentralRes  = fs->mkdir("Norm_Long_pTCentral_Residuals"); 
-  h_norm_dz_Central_pT_  = bookResidualsHistogram(NormLongpTCentralRes,nPtBins_,"norm_dz","pTCentral");   
+  h_norm_dz_Central_pT_  = bookResidualsHistogram(NormLongpTCentralRes,nPtBins_,pvparams::norm_dz,pvparams::pTCentral,true);   
 
   // book residuals vs module number
   
   TFileDirectory AbsTransModZRes  = fs->mkdir("Abs_Transv_modZ_Residuals"); 
-  h_dxy_modZ_      = bookResidualsHistogram(AbsTransModZRes,8,"dxy","modZ");	       
+  h_dxy_modZ_      = bookResidualsHistogram(AbsTransModZRes,8,pvparams::dxy,pvparams::modZ);	       
 
   TFileDirectory AbsLongModZRes   = fs->mkdir("Abs_Long_modZ_Residuals"); 
-  h_dz_modZ_       = bookResidualsHistogram(AbsLongModZRes,8,"dz","modZ");		       
+  h_dz_modZ_       = bookResidualsHistogram(AbsLongModZRes,8,pvparams::dz,pvparams::modZ);		       
 
   TFileDirectory NormTransModZRes = fs->mkdir("Norm_Transv_modZ_Residuals"); 
-  h_norm_dxy_modZ_ = bookResidualsHistogram(NormTransModZRes,8,"norm_dxy","modZ");	       
+  h_norm_dxy_modZ_ = bookResidualsHistogram(NormTransModZRes,8,pvparams::norm_dxy,pvparams::modZ,true);	       
 
   TFileDirectory NormLongModZRes  = fs->mkdir("Norm_Long_modZ_Residuals"); 
-  h_norm_dz_modZ_  = bookResidualsHistogram(NormLongModZRes,8,"norm_dz","modZ");	       
+  h_norm_dz_modZ_  = bookResidualsHistogram(NormLongModZRes,8,pvparams::norm_dz,pvparams::modZ,true);	       
 
   TFileDirectory AbsTransLadderRes  = fs->mkdir("Abs_Transv_ladder_Residuals"); 
-  h_dxy_ladder_ = bookResidualsHistogram(AbsTransLadderRes,nLadders_,"dxy","ladder");
+  h_dxy_ladder_ = bookResidualsHistogram(AbsTransLadderRes,nLadders_,pvparams::dxy,pvparams::ladder);
 
   TFileDirectory AbsTransLadderResOverlap  = fs->mkdir("Abs_Transv_ladderOverlap_Residuals"); 
-  h_dxy_ladderOverlap_ = bookResidualsHistogram(AbsTransLadderResOverlap,nLadders_,"dxy","ladder");       
+  h_dxy_ladderOverlap_ = bookResidualsHistogram(AbsTransLadderResOverlap,nLadders_,pvparams::dxy,pvparams::ladder);       
 
   TFileDirectory AbsTransLadderResNoOverlap  = fs->mkdir("Abs_Transv_ladderNoOverlap_Residuals"); 
-  h_dxy_ladderNoOverlap_ = bookResidualsHistogram(AbsTransLadderResNoOverlap,nLadders_,"dxy","ladder");       
+  h_dxy_ladderNoOverlap_ = bookResidualsHistogram(AbsTransLadderResNoOverlap,nLadders_,pvparams::dxy,pvparams::ladder);       
 
   TFileDirectory AbsLongLadderRes   = fs->mkdir("Abs_Long_ladder_Residuals"); 
-  h_dz_ladder_  = bookResidualsHistogram(AbsLongLadderRes,nLadders_,"dz","ladder");	       
+  h_dz_ladder_  = bookResidualsHistogram(AbsLongLadderRes,nLadders_,pvparams::dz,pvparams::ladder);	       
 
   TFileDirectory NormTransLadderRes = fs->mkdir("Norm_Transv_ladder_Residuals"); 
-  h_norm_dxy_ladder_ = bookResidualsHistogram(NormTransLadderRes,nLadders_,"norm_dxy","ladder");  
+  h_norm_dxy_ladder_ = bookResidualsHistogram(NormTransLadderRes,nLadders_,pvparams::norm_dxy,pvparams::ladder,true);  
 
   TFileDirectory NormLongLadderRes  = fs->mkdir("Norm_Long_ladder_Residuals"); 
-  h_norm_dz_ladder_  = bookResidualsHistogram(NormLongLadderRes,nLadders_,"norm_dz","ladder");   
+  h_norm_dz_ladder_  = bookResidualsHistogram(NormLongLadderRes,nLadders_,pvparams::norm_dz,pvparams::ladder,true);   
+
 
   // book residuals as function of phi and eta
 
@@ -2187,139 +2188,139 @@ void PrimaryVertexValidation::endJob()
 
   if(useTracksFromRecoVtx_){
 
-    fillTrendPlot(a_dxyPhiMeanBiasTrend ,a_dxyPhiBiasResiduals,statmode::MEAN,"phi");  
-    fillTrendPlot(a_dxyPhiWidthBiasTrend,a_dxyPhiBiasResiduals,statmode::WIDTH,"phi");
-    fillTrendPlot(a_dzPhiMeanBiasTrend  ,a_dzPhiBiasResiduals ,statmode::MEAN,"phi");   
-    fillTrendPlot(a_dzPhiWidthBiasTrend ,a_dzPhiBiasResiduals ,statmode::WIDTH,"phi");  
+    fillTrendPlot(a_dxyPhiMeanBiasTrend ,a_dxyPhiBiasResiduals,pvparams::MEAN,"phi");  
+    fillTrendPlot(a_dxyPhiWidthBiasTrend,a_dxyPhiBiasResiduals,pvparams::WIDTH,"phi");
+    fillTrendPlot(a_dzPhiMeanBiasTrend  ,a_dzPhiBiasResiduals ,pvparams::MEAN,"phi");   
+    fillTrendPlot(a_dzPhiWidthBiasTrend ,a_dzPhiBiasResiduals ,pvparams::WIDTH,"phi");  
     
-    fillTrendPlot(a_dxyEtaMeanBiasTrend ,a_dxyEtaBiasResiduals,statmode::MEAN,"eta"); 
-    fillTrendPlot(a_dxyEtaWidthBiasTrend,a_dxyEtaBiasResiduals,statmode::WIDTH,"eta");
-    fillTrendPlot(a_dzEtaMeanBiasTrend  ,a_dzEtaBiasResiduals ,statmode::MEAN,"eta"); 
-    fillTrendPlot(a_dzEtaWidthBiasTrend ,a_dzEtaBiasResiduals ,statmode::WIDTH,"eta");
+    fillTrendPlot(a_dxyEtaMeanBiasTrend ,a_dxyEtaBiasResiduals,pvparams::MEAN,"eta"); 
+    fillTrendPlot(a_dxyEtaWidthBiasTrend,a_dxyEtaBiasResiduals,pvparams::WIDTH,"eta");
+    fillTrendPlot(a_dzEtaMeanBiasTrend  ,a_dzEtaBiasResiduals ,pvparams::MEAN,"eta"); 
+    fillTrendPlot(a_dzEtaWidthBiasTrend ,a_dzEtaBiasResiduals ,pvparams::WIDTH,"eta");
     
-    fillTrendPlot(n_dxyPhiMeanBiasTrend ,n_dxyPhiBiasResiduals,statmode::MEAN,"phi"); 
-    fillTrendPlot(n_dxyPhiWidthBiasTrend,n_dxyPhiBiasResiduals,statmode::WIDTH,"phi");
-    fillTrendPlot(n_dzPhiMeanBiasTrend  ,n_dzPhiBiasResiduals ,statmode::MEAN,"phi"); 
-    fillTrendPlot(n_dzPhiWidthBiasTrend ,n_dzPhiBiasResiduals ,statmode::WIDTH,"phi");
+    fillTrendPlot(n_dxyPhiMeanBiasTrend ,n_dxyPhiBiasResiduals,pvparams::MEAN,"phi"); 
+    fillTrendPlot(n_dxyPhiWidthBiasTrend,n_dxyPhiBiasResiduals,pvparams::WIDTH,"phi");
+    fillTrendPlot(n_dzPhiMeanBiasTrend  ,n_dzPhiBiasResiduals ,pvparams::MEAN,"phi"); 
+    fillTrendPlot(n_dzPhiWidthBiasTrend ,n_dzPhiBiasResiduals ,pvparams::WIDTH,"phi");
     
-    fillTrendPlot(n_dxyEtaMeanBiasTrend ,n_dxyEtaBiasResiduals,statmode::MEAN,"eta"); 
-    fillTrendPlot(n_dxyEtaWidthBiasTrend,n_dxyEtaBiasResiduals,statmode::WIDTH,"eta");
-    fillTrendPlot(n_dzEtaMeanBiasTrend  ,n_dzEtaBiasResiduals ,statmode::MEAN,"eta"); 
-    fillTrendPlot(n_dzEtaWidthBiasTrend ,n_dzEtaBiasResiduals ,statmode::WIDTH,"eta");
+    fillTrendPlot(n_dxyEtaMeanBiasTrend ,n_dxyEtaBiasResiduals,pvparams::MEAN,"eta"); 
+    fillTrendPlot(n_dxyEtaWidthBiasTrend,n_dxyEtaBiasResiduals,pvparams::WIDTH,"eta");
+    fillTrendPlot(n_dzEtaMeanBiasTrend  ,n_dzEtaBiasResiduals ,pvparams::MEAN,"eta"); 
+    fillTrendPlot(n_dzEtaWidthBiasTrend ,n_dzEtaBiasResiduals ,pvparams::WIDTH,"eta");
     
     // medians and MADs	  
     
-    fillTrendPlot(a_dxyPhiMedianBiasTrend,a_dxyPhiBiasResiduals,statmode::MEDIAN,"phi");  
-    fillTrendPlot(a_dxyPhiMADBiasTrend   ,a_dxyPhiBiasResiduals,statmode::MAD,"phi"); 
-    fillTrendPlot(a_dzPhiMedianBiasTrend ,a_dzPhiBiasResiduals ,statmode::MEDIAN,"phi");  
-    fillTrendPlot(a_dzPhiMADBiasTrend    ,a_dzPhiBiasResiduals ,statmode::MAD,"phi"); 
+    fillTrendPlot(a_dxyPhiMedianBiasTrend,a_dxyPhiBiasResiduals,pvparams::MEDIAN,"phi");  
+    fillTrendPlot(a_dxyPhiMADBiasTrend   ,a_dxyPhiBiasResiduals,pvparams::MAD,"phi"); 
+    fillTrendPlot(a_dzPhiMedianBiasTrend ,a_dzPhiBiasResiduals ,pvparams::MEDIAN,"phi");  
+    fillTrendPlot(a_dzPhiMADBiasTrend    ,a_dzPhiBiasResiduals ,pvparams::MAD,"phi"); 
     
-    fillTrendPlot(a_dxyEtaMedianBiasTrend,a_dxyEtaBiasResiduals,statmode::MEDIAN,"eta");  
-    fillTrendPlot(a_dxyEtaMADBiasTrend   ,a_dxyEtaBiasResiduals,statmode::MAD,"eta"); 
-    fillTrendPlot(a_dzEtaMedianBiasTrend ,a_dzEtaBiasResiduals ,statmode::MEDIAN,"eta");  
-    fillTrendPlot(a_dzEtaMADBiasTrend    ,a_dzEtaBiasResiduals ,statmode::MAD,"eta"); 
+    fillTrendPlot(a_dxyEtaMedianBiasTrend,a_dxyEtaBiasResiduals,pvparams::MEDIAN,"eta");  
+    fillTrendPlot(a_dxyEtaMADBiasTrend   ,a_dxyEtaBiasResiduals,pvparams::MAD,"eta"); 
+    fillTrendPlot(a_dzEtaMedianBiasTrend ,a_dzEtaBiasResiduals ,pvparams::MEDIAN,"eta");  
+    fillTrendPlot(a_dzEtaMADBiasTrend    ,a_dzEtaBiasResiduals ,pvparams::MAD,"eta"); 
     
-    fillTrendPlot(n_dxyPhiMedianBiasTrend,n_dxyPhiBiasResiduals,statmode::MEDIAN,"phi");  
-    fillTrendPlot(n_dxyPhiMADBiasTrend   ,n_dxyPhiBiasResiduals,statmode::MAD,"phi"); 
-    fillTrendPlot(n_dzPhiMedianBiasTrend ,n_dzPhiBiasResiduals ,statmode::MEDIAN,"phi");  
-    fillTrendPlot(n_dzPhiMADBiasTrend    ,n_dzPhiBiasResiduals ,statmode::MAD,"phi"); 
+    fillTrendPlot(n_dxyPhiMedianBiasTrend,n_dxyPhiBiasResiduals,pvparams::MEDIAN,"phi");  
+    fillTrendPlot(n_dxyPhiMADBiasTrend   ,n_dxyPhiBiasResiduals,pvparams::MAD,"phi"); 
+    fillTrendPlot(n_dzPhiMedianBiasTrend ,n_dzPhiBiasResiduals ,pvparams::MEDIAN,"phi");  
+    fillTrendPlot(n_dzPhiMADBiasTrend    ,n_dzPhiBiasResiduals ,pvparams::MAD,"phi"); 
     
-    fillTrendPlot(n_dxyEtaMedianBiasTrend,n_dxyEtaBiasResiduals,statmode::MEDIAN,"eta");  
-    fillTrendPlot(n_dxyEtaMADBiasTrend   ,n_dxyEtaBiasResiduals,statmode::MAD,"eta"); 
-    fillTrendPlot(n_dzEtaMedianBiasTrend ,n_dzEtaBiasResiduals ,statmode::MEDIAN,"eta");  
-    fillTrendPlot(n_dzEtaMADBiasTrend    ,n_dzEtaBiasResiduals ,statmode::MAD,"eta"); 
+    fillTrendPlot(n_dxyEtaMedianBiasTrend,n_dxyEtaBiasResiduals,pvparams::MEDIAN,"eta");  
+    fillTrendPlot(n_dxyEtaMADBiasTrend   ,n_dxyEtaBiasResiduals,pvparams::MAD,"eta"); 
+    fillTrendPlot(n_dzEtaMedianBiasTrend ,n_dzEtaBiasResiduals ,pvparams::MEDIAN,"eta");  
+    fillTrendPlot(n_dzEtaMADBiasTrend    ,n_dzEtaBiasResiduals ,pvparams::MAD,"eta"); 
    
     // 2d Maps
 
-    fillMap(a_dxyMeanBiasMap ,a_dxyBiasResidualsMap,statmode::MEAN); 
-    fillMap(a_dxyWidthBiasMap,a_dxyBiasResidualsMap,statmode::WIDTH);
-    fillMap(a_dzMeanBiasMap  ,a_dzBiasResidualsMap,statmode::MEAN); 
-    fillMap(a_dzWidthBiasMap ,a_dzBiasResidualsMap,statmode::WIDTH);
+    fillMap(a_dxyMeanBiasMap ,a_dxyBiasResidualsMap,pvparams::MEAN); 
+    fillMap(a_dxyWidthBiasMap,a_dxyBiasResidualsMap,pvparams::WIDTH);
+    fillMap(a_dzMeanBiasMap  ,a_dzBiasResidualsMap,pvparams::MEAN); 
+    fillMap(a_dzWidthBiasMap ,a_dzBiasResidualsMap,pvparams::WIDTH);
 
-    fillMap(n_dxyMeanBiasMap ,n_dxyBiasResidualsMap,statmode::MEAN); 
-    fillMap(n_dxyWidthBiasMap,n_dxyBiasResidualsMap,statmode::WIDTH);
-    fillMap(n_dzMeanBiasMap  ,n_dzBiasResidualsMap,statmode::MEAN); 
-    fillMap(n_dzWidthBiasMap ,n_dzBiasResidualsMap,statmode::WIDTH);
+    fillMap(n_dxyMeanBiasMap ,n_dxyBiasResidualsMap,pvparams::MEAN); 
+    fillMap(n_dxyWidthBiasMap,n_dxyBiasResidualsMap,pvparams::WIDTH);
+    fillMap(n_dzMeanBiasMap  ,n_dzBiasResidualsMap,pvparams::MEAN); 
+    fillMap(n_dzWidthBiasMap ,n_dzBiasResidualsMap,pvparams::WIDTH);
    
   }
 
   // do profiles
 
-  fillTrendPlot(a_dxyPhiMeanTrend ,a_dxyPhiResiduals,statmode::MEAN,"phi");  
-  fillTrendPlot(a_dxyPhiWidthTrend,a_dxyPhiResiduals,statmode::WIDTH,"phi");
-  fillTrendPlot(a_dzPhiMeanTrend  ,a_dzPhiResiduals ,statmode::MEAN,"phi");   
-  fillTrendPlot(a_dzPhiWidthTrend ,a_dzPhiResiduals ,statmode::WIDTH,"phi");  
+  fillTrendPlot(a_dxyPhiMeanTrend ,a_dxyPhiResiduals,pvparams::MEAN,"phi");  
+  fillTrendPlot(a_dxyPhiWidthTrend,a_dxyPhiResiduals,pvparams::WIDTH,"phi");
+  fillTrendPlot(a_dzPhiMeanTrend  ,a_dzPhiResiduals ,pvparams::MEAN,"phi");   
+  fillTrendPlot(a_dzPhiWidthTrend ,a_dzPhiResiduals ,pvparams::WIDTH,"phi");  
   
-  fillTrendPlot(a_dxyEtaMeanTrend ,a_dxyEtaResiduals,statmode::MEAN,"eta"); 
-  fillTrendPlot(a_dxyEtaWidthTrend,a_dxyEtaResiduals,statmode::WIDTH,"eta");
-  fillTrendPlot(a_dzEtaMeanTrend  ,a_dzEtaResiduals ,statmode::MEAN,"eta"); 
-  fillTrendPlot(a_dzEtaWidthTrend ,a_dzEtaResiduals ,statmode::WIDTH,"eta");
+  fillTrendPlot(a_dxyEtaMeanTrend ,a_dxyEtaResiduals,pvparams::MEAN,"eta"); 
+  fillTrendPlot(a_dxyEtaWidthTrend,a_dxyEtaResiduals,pvparams::WIDTH,"eta");
+  fillTrendPlot(a_dzEtaMeanTrend  ,a_dzEtaResiduals ,pvparams::MEAN,"eta"); 
+  fillTrendPlot(a_dzEtaWidthTrend ,a_dzEtaResiduals ,pvparams::WIDTH,"eta");
   
-  fillTrendPlot(n_dxyPhiMeanTrend ,n_dxyPhiResiduals,statmode::MEAN,"phi"); 
-  fillTrendPlot(n_dxyPhiWidthTrend,n_dxyPhiResiduals,statmode::WIDTH,"phi");
-  fillTrendPlot(n_dzPhiMeanTrend  ,n_dzPhiResiduals ,statmode::MEAN,"phi"); 
-  fillTrendPlot(n_dzPhiWidthTrend ,n_dzPhiResiduals ,statmode::WIDTH,"phi");
+  fillTrendPlot(n_dxyPhiMeanTrend ,n_dxyPhiResiduals,pvparams::MEAN,"phi"); 
+  fillTrendPlot(n_dxyPhiWidthTrend,n_dxyPhiResiduals,pvparams::WIDTH,"phi");
+  fillTrendPlot(n_dzPhiMeanTrend  ,n_dzPhiResiduals ,pvparams::MEAN,"phi"); 
+  fillTrendPlot(n_dzPhiWidthTrend ,n_dzPhiResiduals ,pvparams::WIDTH,"phi");
   
-  fillTrendPlot(n_dxyEtaMeanTrend ,n_dxyEtaResiduals,statmode::MEAN,"eta"); 
-  fillTrendPlot(n_dxyEtaWidthTrend,n_dxyEtaResiduals,statmode::WIDTH,"eta");
-  fillTrendPlot(n_dzEtaMeanTrend  ,n_dzEtaResiduals ,statmode::MEAN,"eta"); 
-  fillTrendPlot(n_dzEtaWidthTrend ,n_dzEtaResiduals ,statmode::WIDTH,"eta");
+  fillTrendPlot(n_dxyEtaMeanTrend ,n_dxyEtaResiduals,pvparams::MEAN,"eta"); 
+  fillTrendPlot(n_dxyEtaWidthTrend,n_dxyEtaResiduals,pvparams::WIDTH,"eta");
+  fillTrendPlot(n_dzEtaMeanTrend  ,n_dzEtaResiduals ,pvparams::MEAN,"eta"); 
+  fillTrendPlot(n_dzEtaWidthTrend ,n_dzEtaResiduals ,pvparams::WIDTH,"eta");
     
   // vs transverse momentum
 
-  fillTrendPlotByIndex(a_dxypTMeanTrend ,h_dxy_pT_,statmode::MEAN );  
-  fillTrendPlotByIndex(a_dxypTWidthTrend,h_dxy_pT_,statmode::WIDTH);
-  fillTrendPlotByIndex(a_dzpTMeanTrend  ,h_dz_pT_ ,statmode::MEAN );   
-  fillTrendPlotByIndex(a_dzpTWidthTrend ,h_dz_pT_ ,statmode::WIDTH);  
+  fillTrendPlotByIndex(a_dxypTMeanTrend ,h_dxy_pT_,pvparams::MEAN );  
+  fillTrendPlotByIndex(a_dxypTWidthTrend,h_dxy_pT_,pvparams::WIDTH);
+  fillTrendPlotByIndex(a_dzpTMeanTrend  ,h_dz_pT_ ,pvparams::MEAN );   
+  fillTrendPlotByIndex(a_dzpTWidthTrend ,h_dz_pT_ ,pvparams::WIDTH);  
   
-  fillTrendPlotByIndex(a_dxypTCentralMeanTrend ,h_dxy_Central_pT_,statmode::MEAN ); 
-  fillTrendPlotByIndex(a_dxypTCentralWidthTrend,h_dxy_Central_pT_,statmode::WIDTH);
-  fillTrendPlotByIndex(a_dzpTCentralMeanTrend  ,h_dz_Central_pT_ ,statmode::MEAN ); 
-  fillTrendPlotByIndex(a_dzpTCentralWidthTrend ,h_dz_Central_pT_ ,statmode::WIDTH);
+  fillTrendPlotByIndex(a_dxypTCentralMeanTrend ,h_dxy_Central_pT_,pvparams::MEAN ); 
+  fillTrendPlotByIndex(a_dxypTCentralWidthTrend,h_dxy_Central_pT_,pvparams::WIDTH);
+  fillTrendPlotByIndex(a_dzpTCentralMeanTrend  ,h_dz_Central_pT_ ,pvparams::MEAN ); 
+  fillTrendPlotByIndex(a_dzpTCentralWidthTrend ,h_dz_Central_pT_ ,pvparams::WIDTH);
   
-  fillTrendPlotByIndex(n_dxypTMeanTrend ,h_norm_dxy_pT_,statmode::MEAN ); 
-  fillTrendPlotByIndex(n_dxypTWidthTrend,h_norm_dxy_pT_,statmode::WIDTH);
-  fillTrendPlotByIndex(n_dzpTMeanTrend  ,h_norm_dz_pT_ ,statmode::MEAN ); 
-  fillTrendPlotByIndex(n_dzpTWidthTrend ,h_norm_dz_pT_ ,statmode::WIDTH);
+  fillTrendPlotByIndex(n_dxypTMeanTrend ,h_norm_dxy_pT_,pvparams::MEAN ); 
+  fillTrendPlotByIndex(n_dxypTWidthTrend,h_norm_dxy_pT_,pvparams::WIDTH);
+  fillTrendPlotByIndex(n_dzpTMeanTrend  ,h_norm_dz_pT_ ,pvparams::MEAN ); 
+  fillTrendPlotByIndex(n_dzpTWidthTrend ,h_norm_dz_pT_ ,pvparams::WIDTH);
   
-  fillTrendPlotByIndex(n_dxypTCentralMeanTrend ,h_norm_dxy_Central_pT_,statmode::MEAN ); 
-  fillTrendPlotByIndex(n_dxypTCentralWidthTrend,h_norm_dxy_Central_pT_,statmode::WIDTH);
-  fillTrendPlotByIndex(n_dzpTCentralMeanTrend  ,h_norm_dz_Central_pT_ ,statmode::MEAN ); 
-  fillTrendPlotByIndex(n_dzpTCentralWidthTrend ,h_norm_dz_Central_pT_ ,statmode::WIDTH);
+  fillTrendPlotByIndex(n_dxypTCentralMeanTrend ,h_norm_dxy_Central_pT_,pvparams::MEAN ); 
+  fillTrendPlotByIndex(n_dxypTCentralWidthTrend,h_norm_dxy_Central_pT_,pvparams::WIDTH);
+  fillTrendPlotByIndex(n_dzpTCentralMeanTrend  ,h_norm_dz_Central_pT_ ,pvparams::MEAN ); 
+  fillTrendPlotByIndex(n_dzpTCentralWidthTrend ,h_norm_dz_Central_pT_ ,pvparams::WIDTH);
 
-  // medians and MADs	  
-  
-  fillTrendPlot(a_dxyPhiMedianTrend,a_dxyPhiResiduals,statmode::MEDIAN,"phi");  
-  fillTrendPlot(a_dxyPhiMADTrend   ,a_dxyPhiResiduals,statmode::MAD,"phi"); 
-  fillTrendPlot(a_dzPhiMedianTrend ,a_dzPhiResiduals ,statmode::MEDIAN,"phi");  
-  fillTrendPlot(a_dzPhiMADTrend    ,a_dzPhiResiduals ,statmode::MAD,"phi"); 
-  
-  fillTrendPlot(a_dxyEtaMedianTrend,a_dxyEtaResiduals,statmode::MEDIAN,"eta");  
-  fillTrendPlot(a_dxyEtaMADTrend   ,a_dxyEtaResiduals,statmode::MAD,"eta"); 
-  fillTrendPlot(a_dzEtaMedianTrend ,a_dzEtaResiduals ,statmode::MEDIAN,"eta");  
-  fillTrendPlot(a_dzEtaMADTrend    ,a_dzEtaResiduals ,statmode::MAD,"eta"); 
-  
-  fillTrendPlot(n_dxyPhiMedianTrend,n_dxyPhiResiduals,statmode::MEDIAN,"phi");  
-  fillTrendPlot(n_dxyPhiMADTrend   ,n_dxyPhiResiduals,statmode::MAD,"phi"); 
-  fillTrendPlot(n_dzPhiMedianTrend ,n_dzPhiResiduals ,statmode::MEDIAN,"phi");  
-  fillTrendPlot(n_dzPhiMADTrend    ,n_dzPhiResiduals ,statmode::MAD,"phi"); 
-  
-  fillTrendPlot(n_dxyEtaMedianTrend,n_dxyEtaResiduals,statmode::MEDIAN,"eta");  
-  fillTrendPlot(n_dxyEtaMADTrend   ,n_dxyEtaResiduals,statmode::MAD,"eta"); 
-  fillTrendPlot(n_dzEtaMedianTrend ,n_dzEtaResiduals ,statmode::MEDIAN,"eta");  
-  fillTrendPlot(n_dzEtaMADTrend    ,n_dzEtaResiduals ,statmode::MAD,"eta"); 
+  // vs ladder and module number
+
+  fillTrendPlotByIndex(a_dxymodZMeanTrend   ,h_dxy_modZ_,pvparams::MEAN);  
+  fillTrendPlotByIndex(a_dxymodZWidthTrend  ,h_dxy_modZ_,pvparams::WIDTH);
+  fillTrendPlotByIndex(a_dzmodZMeanTrend    ,h_dz_modZ_,pvparams::MEAN);   
+  fillTrendPlotByIndex(a_dzmodZWidthTrend   ,h_dz_modZ_,pvparams::WIDTH);  
+  		       		      
+  fillTrendPlotByIndex(a_dxyladderMeanTrend ,h_dxy_ladder_,pvparams::MEAN); 
+  fillTrendPlotByIndex(a_dxyladderWidthTrend,h_dxy_ladder_,pvparams::WIDTH);
+  fillTrendPlotByIndex(a_dzladderMeanTrend  ,h_dz_ladder_,pvparams::MEAN); 
+  fillTrendPlotByIndex(a_dzladderWidthTrend ,h_dz_ladder_,pvparams::WIDTH);
+  		       		      
+  fillTrendPlotByIndex(n_dxymodZMeanTrend   ,h_norm_dxy_modZ_,pvparams::MEAN); 
+  fillTrendPlotByIndex(n_dxymodZWidthTrend  ,h_norm_dxy_modZ_,pvparams::WIDTH);
+  fillTrendPlotByIndex(n_dzmodZMeanTrend    ,h_norm_dz_modZ_,pvparams::MEAN); 
+  fillTrendPlotByIndex(n_dzmodZWidthTrend   ,h_norm_dz_modZ_,pvparams::WIDTH);
+  		       		      
+  fillTrendPlotByIndex(n_dxyladderMeanTrend ,h_norm_dxy_ladder_,pvparams::MEAN); 
+  fillTrendPlotByIndex(n_dxyladderWidthTrend,h_norm_dxy_ladder_,pvparams::WIDTH);
+  fillTrendPlotByIndex(n_dzladderMeanTrend  ,h_norm_dz_ladder_,pvparams::MEAN); 
+  fillTrendPlotByIndex(n_dzladderWidthTrend ,h_norm_dz_ladder_,pvparams::WIDTH);
     
   // 2D Maps
 
-  fillMap(a_dxyMeanMap ,a_dxyResidualsMap,statmode::MEAN); 
-  fillMap(a_dxyWidthMap,a_dxyResidualsMap,statmode::WIDTH);
-  fillMap(a_dzMeanMap  ,a_dzResidualsMap,statmode::MEAN); 
-  fillMap(a_dzWidthMap ,a_dzResidualsMap,statmode::WIDTH);
+  fillMap(a_dxyMeanMap ,a_dxyResidualsMap,pvparams::MEAN); 
+  fillMap(a_dxyWidthMap,a_dxyResidualsMap,pvparams::WIDTH);
+  fillMap(a_dzMeanMap  ,a_dzResidualsMap,pvparams::MEAN); 
+  fillMap(a_dzWidthMap ,a_dzResidualsMap,pvparams::WIDTH);
   
-  fillMap(n_dxyMeanMap ,n_dxyResidualsMap,statmode::MEAN); 
-  fillMap(n_dxyWidthMap,n_dxyResidualsMap,statmode::WIDTH);
-  fillMap(n_dzMeanMap  ,n_dzResidualsMap,statmode::MEAN); 
-  fillMap(n_dzWidthMap ,n_dzResidualsMap,statmode::WIDTH);
+  fillMap(n_dxyMeanMap ,n_dxyResidualsMap,pvparams::MEAN); 
+  fillMap(n_dxyWidthMap,n_dxyResidualsMap,pvparams::WIDTH);
+  fillMap(n_dzMeanMap  ,n_dzResidualsMap,pvparams::MEAN); 
+  fillMap(n_dzWidthMap ,n_dzResidualsMap,pvparams::WIDTH);
 
 }
 
@@ -2509,6 +2510,7 @@ std::pair<Measurement1D, Measurement1D> PrimaryVertexValidation::fitResiduals(TH
 }
 
 //*************************************************************
+
 void PrimaryVertexValidation::fillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot[100], statmode::estimator fitPar_,const std::string& var_)
 //*************************************************************
 {
@@ -2526,7 +2528,7 @@ void PrimaryVertexValidation::fillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot
     
     switch(fitPar_)
       {
-      case statmode::MEAN:
+      case pvparams::MEAN:
 	{
 	  float mean_      = fitResiduals(residualsPlot[i]).first.value();
 	  float meanErr_   = fitResiduals(residualsPlot[i]).first.error();
@@ -2534,7 +2536,7 @@ void PrimaryVertexValidation::fillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot
 	  trendPlot->SetBinError(i+1,meanErr_);
 	  break;
 	} 
-      case statmode::WIDTH:
+      case pvparams::WIDTH:
 	{
 	  float width_     = fitResiduals(residualsPlot[i]).second.value();
 	  float widthErr_  = fitResiduals(residualsPlot[i]).second.error();
@@ -2542,7 +2544,7 @@ void PrimaryVertexValidation::fillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot
 	  trendPlot->SetBinError(i+1,widthErr_);
 	  break;
 	}
-      case statmode::MEDIAN:
+      case pvparams::MEDIAN:
 	{
 	  float median_    = getMedian(residualsPlot[i]).value();
 	  float medianErr_ = getMedian(residualsPlot[i]).error();
@@ -2550,7 +2552,7 @@ void PrimaryVertexValidation::fillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot
 	  trendPlot->SetBinError(i+1,medianErr_);
 	  break;
 	} 
-      case statmode::MAD:
+      case pvparams::MAD:
 	{
 	  float mad_       = getMAD(residualsPlot[i]).value(); 
 	  float madErr_    = getMAD(residualsPlot[i]).error();
@@ -2574,7 +2576,7 @@ void PrimaryVertexValidation::fillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot
 }
 
 //*************************************************************
-void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,std::vector<TH1F*>& h,  statmode::estimator fitPar_)
+void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,std::vector<TH1F*>& h,  pvparams::estimator fitPar_)
 //*************************************************************
 {  
 
@@ -2585,7 +2587,7 @@ void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,std::vector<T
 
     switch(fitPar_)
       {
-      case statmode::MEAN: 
+      case pvparams::MEAN: 
 	{   
 	  float mean_      = myFit.first.value();
 	  float meanErr_   = myFit.first.error();
@@ -2593,7 +2595,7 @@ void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,std::vector<T
 	  trendPlot->SetBinError(bin,meanErr_);
 	  break;
 	}
-      case statmode::WIDTH:
+      case pvparams::WIDTH:
 	{
 	  float width_     = myFit.second.value();
 	  float widthErr_  = myFit.second.error();
@@ -2601,7 +2603,7 @@ void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,std::vector<T
 	  trendPlot->SetBinError(bin,widthErr_);
 	  break;
 	}
-      case statmode::MEDIAN:
+      case pvparams::MEDIAN:
 	{
 	  float median_    = getMedian(*iterator).value();
 	  float medianErr_ = getMedian(*iterator).error();
@@ -2609,7 +2611,7 @@ void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,std::vector<T
 	  trendPlot->SetBinError(bin,medianErr_);
 	  break;
 	}
-      case statmode::MAD:
+      case pvparams::MAD:
 	{
 	  float mad_       = getMAD(*iterator).value(); 
 	  float madErr_    = getMAD(*iterator).error();
@@ -2625,7 +2627,7 @@ void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,std::vector<T
 }
 
 //*************************************************************
-void PrimaryVertexValidation::fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100][100],  statmode::estimator fitPar_)
+void PrimaryVertexValidation::fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100][100],  pvparams::estimator fitPar_)
 //*************************************************************
 {
  
@@ -2648,7 +2650,7 @@ void PrimaryVertexValidation::fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100
 
       switch (fitPar_)
 	{ 
-	case statmode::MEAN:
+	case pvparams::MEAN:
 	  {
 	    float mean_      = fitResiduals(residualsMapPlot[i][j]).first.value();
 	    float meanErr_   = fitResiduals(residualsMapPlot[i][j]).first.error();
@@ -2656,7 +2658,7 @@ void PrimaryVertexValidation::fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100
 	    trendMap->SetBinError(j+1,i+1,meanErr_);
 	    break;
 	  }
-	case statmode::WIDTH:
+	case pvparams::WIDTH:
 	  {
 	    float width_     = fitResiduals(residualsMapPlot[i][j]).second.value();
 	    float widthErr_  = fitResiduals(residualsMapPlot[i][j]).second.error();
@@ -2664,7 +2666,7 @@ void PrimaryVertexValidation::fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100
 	    trendMap->SetBinError(j+1,i+1,widthErr_);
 	    break;
 	  }     
-	case statmode::MEDIAN:
+	case pvparams::MEDIAN:
 	  {
 	    float median_    = getMedian(residualsMapPlot[i][j]).value();
 	    float medianErr_ = getMedian(residualsMapPlot[i][j]).error();
@@ -2672,7 +2674,7 @@ void PrimaryVertexValidation::fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100
 	    trendMap->SetBinError(j+1,i+1,medianErr_);
 	    break;
 	  }     
-	case statmode::MAD:
+	case pvparams::MAD:
 	  {
 	    float mad_       = getMAD(residualsMapPlot[i][j]).value(); 
 	    float madErr_    = getMAD(residualsMapPlot[i][j]).error();
@@ -2781,14 +2783,17 @@ std::map<std::string, TH1*> PrimaryVertexValidation::bookVertexHistograms(const 
 //*************************************************************
 std::vector<TH1F*> PrimaryVertexValidation::bookResidualsHistogram(const TFileDirectory& dir,
 								   unsigned int theNOfBins,
-								   std::string resType,
-								   const std::string& varType){
+								   pvparams::residualType resType,
+								   pvparams::plotVariable varType,
+								   bool isNormalized){
+
   TH1F::SetDefaultSumw2(kTRUE);
   
   double up   = 1000;
   double down = -up;
   
-  if(resType.find( "norm" ) != std::string::npos){
+
+  if(isNormalized){
     up = up*(1/100);
     down = down*(1/100);
   }
@@ -2796,18 +2801,17 @@ std::vector<TH1F*> PrimaryVertexValidation::bookResidualsHistogram(const TFileDi
   std::vector<TH1F*> h;
   h.reserve(theNOfBins);
 
-  
-
-  std::string auxResType = std::regex_replace(resType, std::regex("_"), "");
-
   if (theNOfBins==0) {
     edm::LogError("PrimaryVertexValidation") <<"bookResidualsHistogram() The number of bins cannot be identically 0" << std::endl;
     assert(false);
   }
+  
+  std::string s_resType = this->getTypeString(resType);
+  std::string s_varType = this->getVarString(varType);
       
   for(unsigned int i=0; i<theNOfBins;i++){
-    TH1F* htemp = dir.make<TH1F>(Form("histo_%s_%s_plot%i",resType.c_str(),varType.c_str(),i),
-				 Form("%s vs %s - bin %i;%s;tracks",auxResType.c_str(),varType.c_str(),i,auxResType.c_str()),
+    TH1F* htemp = dir.make<TH1F>(Form("histo_%s_%s_plot%i",s_resType.c_str(),s_varType.c_str(),i),
+				 Form("%s vs %s - bin %i;%s;tracks",s_resType.c_str(),s_varType.c_str(),i,s_resType.c_str()),
 				 500,down,up); 
     h.push_back(htemp);
   }
@@ -2977,6 +2981,108 @@ void PrimaryVertexValidation::shrinkHistVectorToFit(std::vector<TH1F*>&h, unsign
 //*************************************************************
 {
   h.erase(h.begin()+desired_size,h.end()); 
+}
+
+//*************************************************************
+std::string PrimaryVertexValidation::getTypeString (pvparams::residualType type)
+//*************************************************************
+{
+  std::string returnType = "";
+  switch(type)
+    {
+    // absoulte
+
+    case pvparams::dxy  :
+      returnType = "d_{xy}";
+      break;
+    case pvparams::dx   :
+      returnType = "d_{x}";
+      break;
+    case pvparams::dy   :
+      returnType = "d_{y}";
+      break;
+    case pvparams::dz   :
+      returnType = "d_{z}";
+      break;
+    case pvparams::IP2D :
+      returnType = "IP_{2D}";
+      break;
+    case pvparams::resz :
+      returnType = "z_{trk}-z_{vtx}";
+      break;
+    case pvparams::IP3D :
+      returnType = "IP_{3D}";
+      break;
+    case pvparams::d3D  : 
+      returnType = "d_{3D}";
+      break;
+
+    // normalized
+
+    case pvparams::norm_dxy  :
+      returnType = "d_{xy}/#sigma_{d_{xy}}";
+      break;
+    case pvparams::norm_dx   :
+      returnType = "d_{x}/#sigma_{d_{x}}";
+      break;
+    case pvparams::norm_dy   :
+      returnType = "d_{y}/#sigma_{d_{y}}";
+      break;
+    case pvparams::norm_dz   :
+      returnType = "d_{z}/#sigma_{d_{z}}";
+      break;
+    case pvparams::norm_IP2D :
+      returnType = "IP_{2D}/#sigma_{IP_{2D}}";
+      break;
+    case pvparams::norm_resz :
+      returnType = "z_{trk}-z_{vtx}/#sigma_{res_{z}}";
+      break;
+    case pvparams::norm_IP3D :
+      returnType = "IP_{3D}/#sigma_{IP_{3D}}";
+      break;
+    case pvparams::norm_d3D  : 
+      returnType = "d_{3D}/#sigma_{d_{3D}}";
+      break;
+
+    default:
+      edm::LogWarning("PrimaryVertexValidation:") <<" getTypeString() unknown residual type"<<type<<std::endl;
+    }
+
+  return returnType;
+  
+}
+
+//*************************************************************
+std::string PrimaryVertexValidation::getVarString (pvparams::plotVariable var)
+//*************************************************************
+{
+  std::string returnVar = "";
+  switch(var)
+    {
+    case pvparams::phi  :
+      returnVar = "#phi";
+      break;
+    case pvparams::eta   :
+      returnVar = "#eta";
+      break;
+    case pvparams::pT   :
+      returnVar = "p_{T}";
+      break;
+    case pvparams::pTCentral :
+      returnVar = "p_{T} |#eta|<1.";
+      break;
+    case pvparams::ladder   :
+      returnVar = "ladder number";
+      break;
+    case pvparams::modZ :
+      returnVar = "module number";
+      break;
+    default:
+      edm::LogWarning("PrimaryVertexValidation:") <<" getVarString() unknown plot variable"<<var<<std::endl;
+    }
+
+  return returnVar;
+  
 }
 
 

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -116,9 +116,24 @@ PrimaryVertexValidation::PrimaryVertexValidation(const edm::ParameterSet& iConfi
     // provide the vectorized version of the clusterizer, if supported by the build
   } else if(clusteringAlgorithm=="DA_vect") {
     theTrackClusterizer_ = new DAClusterizerInZ_vect(iConfig.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<edm::ParameterSet>("TkDAClusParameters"));
-  }else{
+  } else {
     throw VertexException("PrimaryVertexProducerAlgorithm: unknown clustering algorithm: " + clusteringAlgorithm);  
   }
+
+  theDetails_.histobins = 500;
+  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::phi)]       = 2000.; 
+  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::eta)]       = 3000.;
+  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::pT)]        = 1000.;
+  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::pTCentral)] = 1000.;
+  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::ladder)]    = 1000.;
+  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::modZ)]      = 1000.;
+
+  for (int plot_index = pvparams::phi; plot_index < pvparams::END_OF_PLOTS; plot_index++ ){
+    for (int res_index = pvparams::dx; res_index < pvparams::END_OF_TYPES; res_index++ ){
+      theDetails_.range[std::make_pair(static_cast<pvparams::residualType>(res_index),static_cast<pvparams::plotVariable>(plot_index))] = theDetails_.range[std::make_pair(pvparams::dxy,static_cast<pvparams::plotVariable>(plot_index))];
+    }
+  }
+
 }
    
 // Destructor
@@ -2789,13 +2804,13 @@ std::vector<TH1F*> PrimaryVertexValidation::bookResidualsHistogram(const TFileDi
 
   TH1F::SetDefaultSumw2(kTRUE);
   
-  double up   =  1000;
-  double down = -1000.;
+  double up   =  theDetails_.range[std::make_pair(resType,varType)];
+  double down =  up*-1;
   
 
   if(isNormalized){
-    up   =  10.;
-    down = -10.;
+    up   =  up/100.;
+    down = down/100.;
   }
   
   std::vector<TH1F*> h;
@@ -2816,7 +2831,7 @@ std::vector<TH1F*> PrimaryVertexValidation::bookResidualsHistogram(const TFileDi
   for(unsigned int i=0; i<theNOfBins;i++){
     TH1F* htemp = dir.make<TH1F>(Form("histo_%s_%s_plot%i",s_resType.c_str(),s_varType.c_str(),i),
 				 Form("%s vs %s - bin %i;%s %s;tracks",t_resType.c_str(),t_varType.c_str(),i,t_resType.c_str(),units.c_str()),
-				 500,down,up); 
+				 theDetails_.histobins,down,up); 
     h.push_back(htemp);
   }
   

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -93,9 +93,6 @@ PrimaryVertexValidation::PrimaryVertexValidation(const edm::ParameterSet& iConfi
   defaultRuns.push_back(0);
   runControlNumbers_ = iConfig.getUntrackedParameter<std::vector<unsigned int> >("runControlNumber",defaultRuns);
 
-  phiSect_ = (2*TMath::Pi())/nBins_;
-  etaSect_ = (2*etaOfProbe_)/nBins_;
-
   edm::InputTag TrackCollectionTag_ = iConfig.getParameter<edm::InputTag>("TrackCollectionTag");
   theTrackCollectionToken = consumes<reco::TrackCollection>(TrackCollectionTag_);
 
@@ -252,14 +249,14 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
     isPhase1_ = true;
     nLadders_ = 12;
                         
-    if(h_dxy_ladderOverlap_.size()!=12){
+    if(h_dxy_ladderOverlap_.size()!=nLadders_){
 
-      PVValHelper::shrinkHistVectorToFit(h_dxy_ladderOverlap_,12);
-      PVValHelper::shrinkHistVectorToFit(h_dxy_ladderNoOverlap_,12);
-      PVValHelper::shrinkHistVectorToFit(h_dxy_ladder_,12);	  
-      PVValHelper::shrinkHistVectorToFit(h_dz_ladder_,12);	  
-      PVValHelper::shrinkHistVectorToFit(h_norm_dxy_ladder_,12);  
-      PVValHelper::shrinkHistVectorToFit(h_norm_dz_ladder_,12);   
+      PVValHelper::shrinkHistVectorToFit(h_dxy_ladderOverlap_,nLadders_);
+      PVValHelper::shrinkHistVectorToFit(h_dxy_ladderNoOverlap_,nLadders_);
+      PVValHelper::shrinkHistVectorToFit(h_dxy_ladder_,nLadders_);	  
+      PVValHelper::shrinkHistVectorToFit(h_dz_ladder_,nLadders_);	  
+      PVValHelper::shrinkHistVectorToFit(h_norm_dxy_ladder_,nLadders_);  
+      PVValHelper::shrinkHistVectorToFit(h_norm_dz_ladder_,nLadders_);   
       
       if (debug_){
 	edm::LogInfo("PrimaryVertexValidation")<<"checking size:"<<h_dxy_ladder_.size()<<std::endl;
@@ -398,7 +395,7 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 	double dxy_err = (**itrk).dxyError();
 	double dz_err  = (**itrk).dzError();
 	
-	float trackphi = ((**itrk).phi())*(180/TMath::Pi());
+	float trackphi = ((**itrk).phi())*(180/M_PI);
 	float tracketa = (**itrk).eta();
 	
 	for(int i=0; i<nBins_; i++){
@@ -781,7 +778,7 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 	     	      
 	      // fill directly the histograms of residuals
 	      
-	      float trackphi = (theTrack.phi())*(180/TMath::Pi());
+	      float trackphi = (theTrack.phi())*(180./M_PI);
 	      float tracketa = theTrack.eta();
 	      float trackpt  = theTrack.pt();
 	      float trackp   = theTrack.p();
@@ -1001,8 +998,8 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 
 		    for(int j=0; j<nBins_; j++){
 
-		      float etaJ=-etaOfProbe_+j*etaSect_;
-		      float etaK=-etaOfProbe_+(j+1)*etaSect_;
+		      float etaJ = theDetails_.trendbins[PVValHelper::eta][j];
+		      float etaK = theDetails_.trendbins[PVValHelper::eta][j+1];
 
 		      if(tracketa >= etaJ && tracketa < etaK ){
 			a_dxyResidualsMap[i][j]->Fill(dxyFromMyVertex*cmToum); 
@@ -1529,16 +1526,16 @@ void PrimaryVertexValidation::beginJob()
   TFileDirectory BiasVsParameter = fs->mkdir("BiasVsParameter");
 
   a_dxyVsPhi = BiasVsParameter.make<TH2F>("h2_dxy_vs_phi","d_{xy} vs track #phi;track #phi [rad];track d_{xy}(PV) [#mum]",
-					  nBins_,-TMath::Pi(),TMath::Pi(),theDetails_.histobins,-dxymax_phi,dxymax_phi); 
+					  nBins_,-M_PI,M_PI,theDetails_.histobins,-dxymax_phi,dxymax_phi); 
  
   a_dzVsPhi  = BiasVsParameter.make<TH2F>("h2_dz_vs_phi","d_{z} vs track #phi;track #phi [rad];track d_{z}(PV) [#mum]",
-					  nBins_,-TMath::Pi(),TMath::Pi(),theDetails_.histobins,-dzmax_phi,dzmax_phi);   
+					  nBins_,-M_PI,M_PI,theDetails_.histobins,-dzmax_phi,dzmax_phi);   
                
   n_dxyVsPhi = BiasVsParameter.make<TH2F>("h2_n_dxy_vs_phi","d_{xy}/#sigma_{d_{xy}} vs track #phi;track #phi [rad];track d_{xy}(PV)/#sigma_{d_{xy}}",
-					  nBins_,-TMath::Pi(),TMath::Pi(),theDetails_.histobins,-dxymax_phi/100.,dxymax_phi/100.); 
+					  nBins_,-M_PI,M_PI,theDetails_.histobins,-dxymax_phi/100.,dxymax_phi/100.); 
   
   n_dzVsPhi  = BiasVsParameter.make<TH2F>("h2_n_dz_vs_phi","d_{z}/#sigma_{d_{z}} vs track #phi;track #phi [rad];track d_{z}(PV)/#sigma_{d_{z}}",
-					  nBins_,-TMath::Pi(),TMath::Pi(),theDetails_.histobins,-dzmax_phi/100.,dzmax_phi/100.);   
+					  nBins_,-M_PI,M_PI,theDetails_.histobins,-dzmax_phi/100.,dzmax_phi/100.);   
                
   a_dxyVsEta = BiasVsParameter.make<TH2F>("h2_dxy_vs_eta","d_{xy} vs track #eta;track #eta;track d_{xy}(PV) [#mum]",
 					  nBins_,-etaOfProbe_,etaOfProbe_,theDetails_.histobins,-dxymax_eta,dzmax_eta);
@@ -1628,7 +1625,6 @@ void PrimaryVertexValidation::beginJob()
 						 "width(d_{z}/#sigma_{d_{z}}) vs #eta sector;#eta (sector);width(d_{z}/#sigma_{d_{z}})",
 						 nBins_,lowedge,highedge);                        
   
-
   // means and widhts vs pT and pTCentral
   
   a_dxypTMeanTrend  = MeanTrendsDir.make<TH1F> ("means_dxy_pT",
@@ -1646,21 +1642,6 @@ void PrimaryVertexValidation::beginJob()
   a_dzpTWidthTrend  = WidthTrendsDir.make<TH1F>("widths_dz_pT","#sigma_{d_{z}} vs pT;p_{T} [GeV];#sigma_{d_{z}} [#mum]",
 						48,mypT_bins_);
   
-  a_dxypTCentralMeanTrend  = MeanTrendsDir.make<TH1F> ("means_dxy_pTCentral",
-						       "#LT d_{xy} #GT vs p_{T};p_{T}(|#eta|<1.) [GeV];#LT d_{xy} #GT [#mum]",
-						       48,mypT_bins_);
-  
-  a_dxypTCentralWidthTrend = WidthTrendsDir.make<TH1F>("widths_dxy_pTCentral",
-						       "#sigma_{d_{xy}} vs p_{T};p_{T}(|#eta|<1.) [GeV];#sigma_{d_{xy}} [#mum]",
-						       48,mypT_bins_);
-  
-  a_dzpTCentralMeanTrend   = MeanTrendsDir.make<TH1F> ("means_dz_pTCentral",
-						       "#LT d_{z} #GT vs p_{T};p_{T}(|#eta|<1.) [GeV];#LT d_{z} #GT [#mum]"
-						       ,48,mypT_bins_); 
-  
-  a_dzpTCentralWidthTrend  = WidthTrendsDir.make<TH1F>("widths_dz_pTCentral",
-						       "#sigma_{d_{z}} vs p_{T};p_{T}(|#eta|<1.) [GeV];#sigma_{d_{z}} [#mum]",
-						       48,mypT_bins_);
   
   n_dxypTMeanTrend  = MeanTrendsDir.make<TH1F> ("norm_means_dxy_pT",
 						"#LT d_{xy}/#sigma_{d_{xy}} #GT vs pT;p_{T} [GeV];#LT d_{xy}/#sigma_{d_{xy}} #GT",
@@ -1677,6 +1658,23 @@ void PrimaryVertexValidation::beginJob()
   n_dzpTWidthTrend  = WidthTrendsDir.make<TH1F>("norm_widths_dz_pT",
 						"width(d_{z}/#sigma_{d_{z}}) vs pT;p_{T} [GeV];width(d_{z}/#sigma_{d_{z}})",
 						48,mypT_bins_);
+
+
+  a_dxypTCentralMeanTrend  = MeanTrendsDir.make<TH1F> ("means_dxy_pTCentral",
+						       "#LT d_{xy} #GT vs p_{T};p_{T}(|#eta|<1.) [GeV];#LT d_{xy} #GT [#mum]",
+						       48,mypT_bins_);
+  
+  a_dxypTCentralWidthTrend = WidthTrendsDir.make<TH1F>("widths_dxy_pTCentral",
+						       "#sigma_{d_{xy}} vs p_{T};p_{T}(|#eta|<1.) [GeV];#sigma_{d_{xy}} [#mum]",
+						       48,mypT_bins_);
+  
+  a_dzpTCentralMeanTrend   = MeanTrendsDir.make<TH1F> ("means_dz_pTCentral",
+						       "#LT d_{z} #GT vs p_{T};p_{T}(|#eta|<1.) [GeV];#LT d_{z} #GT [#mum]"
+						       ,48,mypT_bins_); 
+  
+  a_dzpTCentralWidthTrend  = WidthTrendsDir.make<TH1F>("widths_dz_pTCentral",
+						       "#sigma_{d_{z}} vs p_{T};p_{T}(|#eta|<1.) [GeV];#sigma_{d_{z}} [#mum]",
+						       48,mypT_bins_);
   
   n_dxypTCentralMeanTrend  = MeanTrendsDir.make<TH1F> ("norm_means_dxy_pTCentral",
 						       "#LT d_{xy}/#sigma_{d_{xy}} #GT vs p_{T};p_{T}(|#eta|<1.) [GeV];#LT d_{xy}/#sigma_{d_{z}} #GT",
@@ -1832,15 +1830,15 @@ void PrimaryVertexValidation::beginJob()
     TFileDirectory NormDoubleDiffBiasRes  = fs->mkdir("Norm_DoubleDiffBiasResiduals");
     
     for ( int i=0; i<nBins_; ++i ) {
+         
+      float phiF = theDetails_.trendbins[PVValHelper::phi][i];
+      float phiL = theDetails_.trendbins[PVValHelper::phi][i+1];
       
-      float phiF = (-TMath::Pi()+i*phiSect_)*(180/TMath::Pi());
-      float phiL = (-TMath::Pi()+(i+1)*phiSect_)*(180/TMath::Pi());
-      
-      float etaF=-etaOfProbe_+i*etaSect_;
-      float etaL=-etaOfProbe_+(i+1)*etaSect_;
-       
       for ( int j=0; j<nBins_; ++j ) {
-	
+
+	float etaF = theDetails_.trendbins[PVValHelper::eta][j];
+	float etaL = theDetails_.trendbins[PVValHelper::eta][j+1];
+
 	a_dxyBiasResidualsMap[i][j] = AbsDoubleDiffBiasRes.make<TH1F>(Form("histo_dxy_eta_plot%i_phi_plot%i",i,j),
 								      Form("%.2f<#eta_{tk}<%.2f %.2f#circ<#varphi_{tk}<%.2f#circ;d_{xy} [#mum];tracks",etaF,etaL,phiF,phiL),
 								      theDetails_.histobins,-dzmax_eta,dzmax_eta);
@@ -2051,19 +2049,19 @@ void PrimaryVertexValidation::endJob()
   
   a_dxymodZMeanTrend  = MeanTrendsDir.make<TH1F> ("means_dxy_modZ",
 						  "#LT d_{xy} #GT vs modZ;module number (Z);#LT d_{xy} #GT [#mum]",
-						  8,0.,8.); 
+						  nModZ_,0.,nModZ_); 
   
   a_dxymodZWidthTrend = WidthTrendsDir.make<TH1F>("widths_dxy_modZ",
 						  "#sigma_{d_{xy}} vs modZ;module number (Z);#sigma_{d_{xy}} [#mum]",
-						  8,0.,8.);
+						  nModZ_,0.,nModZ_);
   
   a_dzmodZMeanTrend   = MeanTrendsDir.make<TH1F> ("means_dz_modZ",
 						  "#LT d_{z} #GT vs modZ;module number (Z);#LT d_{z} #GT [#mum]",
-						  8,0.,8.); 
+						  nModZ_,0.,nModZ_); 
   
   a_dzmodZWidthTrend  = WidthTrendsDir.make<TH1F>("widths_dz_modZ",
 						  "#sigma_{d_{z}} vs modZ;module number (Z);#sigma_{d_{z}} [#mum]",
-						  8,0.,8.);
+						  nModZ_,0.,nModZ_);
  
   a_dxyladderMeanTrend  = MeanTrendsDir.make<TH1F> ("means_dxy_ladder",
 						    "#LT d_{xy} #GT vs ladder;ladder number (#phi);#LT d_{xy} #GT [#mum]",
@@ -2083,19 +2081,19 @@ void PrimaryVertexValidation::endJob()
   
   n_dxymodZMeanTrend  = MeanTrendsDir.make<TH1F> ("norm_means_dxy_modZ",
 						  "#LT d_{xy}/#sigma_{d_{xy}} #GT vs modZ;module number (Z);#LT d_{xy}/#sigma_{d_{xy}} #GT",
-						  8,0.,8.);
+						  nModZ_,0.,nModZ_);
   
   n_dxymodZWidthTrend = WidthTrendsDir.make<TH1F>("norm_widths_dxy_modZ",
 						  "width(d_{xy}/#sigma_{d_{xy}}) vs modZ;module number (Z); width(d_{xy}/#sigma_{d_{xy}})",
-						  8,0.,8.);
+						  nModZ_,0.,nModZ_);
   
   n_dzmodZMeanTrend   = MeanTrendsDir.make<TH1F> ("norm_means_dz_modZ",
 						  "#LT d_{z}/#sigma_{d_{z}} #GT vs modZ;module number (Z);#LT d_{z}/#sigma_{d_{z}} #GT",
-						  8,0.,8.); 
+						  nModZ_,0.,nModZ_); 
   
   n_dzmodZWidthTrend  = WidthTrendsDir.make<TH1F>("norm_widths_dz_modZ",
 						  "width(d_{z}/#sigma_{d_{z}}) vs pT;module number (Z);width(d_{z}/#sigma_{d_{z}})",
-						  8,0.,8.);
+						  nModZ_,0.,nModZ_);
   
   n_dxyladderMeanTrend  = MeanTrendsDir.make<TH1F> ("norm_means_dxy_ladder",
 						    "#LT d_{xy}/#sigma_{d_{xy}} #GT vs ladder;ladder number (#phi);#LT d_{xy}/#sigma_{d_{z}} #GT",
@@ -2606,7 +2604,7 @@ std::map<std::string, TH1*> PrimaryVertexValidation::bookVertexHistograms(const 
   for(const auto & type : types){
     h["pseudorapidity_"+type] =dir.make <TH1F>(("rapidity_"+type).c_str(),"track pseudorapidity; track #eta; tracks",100,-3., 3.);
     h["z0_"+type] = dir.make<TH1F>(("z0_"+type).c_str(),"track z_{0};track z_{0} (cm);tracks",80,-40., 40.);
-    h["phi_"+type] = dir.make<TH1F>(("phi_"+type).c_str(),"track #phi; track #phi;tracks",80,-TMath::Pi(), TMath::Pi());
+    h["phi_"+type] = dir.make<TH1F>(("phi_"+type).c_str(),"track #phi; track #phi;tracks",80,-M_PI, M_PI);
     h["eta_"+type] = dir.make<TH1F>(("eta_"+type).c_str(),"track #eta; track #eta;tracks",80,-4., 4.);
     h["pt_"+type] = dir.make<TH1F>(("pt_"+type).c_str(),"track p_{T}; track p_{T} [GeV];tracks",100,0., 20.);
     h["p_"+type] = dir.make<TH1F>(("p_"+type).c_str(),"track p; track p [GeV];tracks",100,0., 20.);
@@ -2625,9 +2623,9 @@ std::map<std::string, TH1*> PrimaryVertexValidation::bookVertexHistograms(const 
     h["lvseta_"+type] = dir.make<TH2F>(("lvseta_"+type).c_str(),"cluster length vs #eta;track #eta;cluster length",60,-3., 3., 20, 0., 20);
     h["lvstanlambda_"+type] = dir.make<TH2F>(("lvstanlambda_"+type).c_str(),"cluster length vs tan #lambda; tan#lambda;cluster length",60,-6., 6., 20, 0., 20);
     h["restrkz_"+type] = dir.make<TH1F>(("restrkz_"+type).c_str(),"z-residuals (track vs vertex);res_{z} (cm);tracks", 200, -5., 5.);
-    h["restrkzvsphi_"+type] = dir.make<TH2F>(("restrkzvsphi_"+type).c_str(),"z-residuals (track - vertex) vs track #phi;track #phi;res_{z} (cm)", 12,-TMath::Pi(),TMath::Pi(),100, -0.5,0.5);
+    h["restrkzvsphi_"+type] = dir.make<TH2F>(("restrkzvsphi_"+type).c_str(),"z-residuals (track - vertex) vs track #phi;track #phi;res_{z} (cm)", 12,-M_PI,M_PI,100, -0.5,0.5);
     h["restrkzvseta_"+type] = dir.make<TH2F>(("restrkzvseta_"+type).c_str(),"z-residuals (track - vertex) vs track #eta;track #eta;res_{z} (cm)", 12,-3.,3.,200, -0.5,0.5);
-    h["pulltrkzvsphi_"+type] = dir.make<TH2F>(("pulltrkzvsphi_"+type).c_str(),"normalized z-residuals (track - vertex) vs track #phi;track #phi;res_{z}/#sigma_{res_{z}}", 12,-TMath::Pi(),TMath::Pi(),100, -5., 5.);
+    h["pulltrkzvsphi_"+type] = dir.make<TH2F>(("pulltrkzvsphi_"+type).c_str(),"normalized z-residuals (track - vertex) vs track #phi;track #phi;res_{z}/#sigma_{res_{z}}", 12,-M_PI,M_PI,100, -5., 5.);
     h["pulltrkzvseta_"+type] = dir.make<TH2F>(("pulltrkzvseta_"+type).c_str(),"normalized z-residuals (track - vertex) vs track #eta;track #eta;res_{z}/#sigma_{res_{z}}", 12,-3.,3.,100, -5., 5.);
     h["pulltrkz_"+type] = dir.make<TH1F>(("pulltrkz_"+type).c_str(),"normalized z-residuals (track vs vertex);res_{z}/#sigma_{res_{z}};tracks", 100, -5., 5.);
     h["sigmatrkz0_"+type] = dir.make<TH1F>(("sigmatrkz0_"+type).c_str(),"z-resolution (excluding beam);#sigma^{trk}_{z_{0}} (cm);tracks", 100, 0., 5.);

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -282,8 +282,9 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
   }
 
   if(h_etaMax->GetEntries()==0.){
-    h_etaMax->SetBinContent(1,etaOfProbe_);
-    h_nbins->SetBinContent(1,nBins_);
+    h_etaMax->SetBinContent(1.,etaOfProbe_);
+    h_nbins->SetBinContent(1.,nBins_);
+    h_nLadders->SetBinContent(1.,nLadders_);
   }
 
   //=======================================================
@@ -1253,6 +1254,7 @@ void PrimaryVertexValidation::beginJob()
 
   h_etaMax            = EventFeatures.make<TH1F>("etaMax","etaMax",1,-0.5,0.5);
   h_nbins             = EventFeatures.make<TH1F>("nbins","nbins",1,-0.5,0.5);
+  h_nLadders          = EventFeatures.make<TH1F>("nladders","n. ladders",1,-0.5,0.5);
 
   // probe track histograms
   TFileDirectory ProbeFeatures = fs->mkdir("ProbeTrackFeatures");

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -1285,13 +1285,13 @@ void PrimaryVertexValidation::beginJob()
 
   // initialize the residuals histograms 
 
-  float dxymax_phi = 2000; 
-  float dzmax_phi  = 2000; 
-  float dxymax_eta = 3000; 
-  float dzmax_eta  = 3000;
+  const float dxymax_phi = 2000; 
+  const float dzmax_phi  = 2000; 
+  const float dxymax_eta = 3000; 
+  const float dzmax_eta  = 3000;
 
-  float d3Dmax_phi = hypot(dxymax_phi,dzmax_phi);
-  float d3Dmax_eta = hypot(dxymax_eta,dzmax_eta);
+  const float d3Dmax_phi = hypot(dxymax_phi,dzmax_phi);
+  const float d3Dmax_eta = hypot(dxymax_eta,dzmax_eta);
 
   const int mybins_ = 500;
 

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -150,18 +150,19 @@ PrimaryVertexValidation::PrimaryVertexValidation(const edm::ParameterSet& iConfi
   theDetails_.trendbins[PVValHelper::phi] = PVValHelper::generateBins(nBins_+1,-TMath::Pi(),2*TMath::Pi());
   theDetails_.trendbins[PVValHelper::eta] = PVValHelper::generateBins(nBins_+1,-etaOfProbe_,2*etaOfProbe_);
 
-  std::cout << "etaBins: ";
-  for (auto ieta: theDetails_.trendbins[PVValHelper::eta]) {
-    std::cout << ieta << " ";
+  if(debug_){
+    edm::LogVerbatim("PrimaryVertexValidation") << "etaBins: ";
+    for (auto ieta: theDetails_.trendbins[PVValHelper::eta]) {
+      edm::LogVerbatim("PrimaryVertexValidation") << ieta << " ";
+    }
+    edm::LogVerbatim("PrimaryVertexValidation") << "\n";
+    
+    edm::LogVerbatim("PrimaryVertexValidation") << "phiBins: ";
+    for (auto iphi: theDetails_.trendbins[PVValHelper::phi]) {
+      edm::LogVerbatim("PrimaryVertexValidation") << iphi << " ";
+    }
+    edm::LogVerbatim("PrimaryVertexValidation") << "\n";
   }
-  std::cout << "\n";
-
-  std::cout << "phiBins: ";
-  for (auto iphi: theDetails_.trendbins[PVValHelper::phi]) {
-    std::cout << iphi << " ";
-  }
-  std::cout << "\n";
-
   
 }
    
@@ -1339,7 +1340,7 @@ void PrimaryVertexValidation::beginJob()
   const float dzmax_phi  = theDetails_.getHigh(PVValHelper::dz ,PVValHelper::eta); 
   const float dxymax_eta = theDetails_.getHigh(PVValHelper::dxy,PVValHelper::phi);
   const float dzmax_eta  = theDetails_.getHigh(PVValHelper::dz, PVValHelper::eta);
-  const float d3Dmax_phi = theDetails_.getHigh(PVValHelper::d3D,PVValHelper::phi);
+  //const float d3Dmax_phi = theDetails_.getHigh(PVValHelper::d3D,PVValHelper::phi);
   const float d3Dmax_eta = theDetails_.getHigh(PVValHelper::d3D,PVValHelper::eta);
 
   ///////////////////////////////////////////////////////////////////
@@ -1349,6 +1350,12 @@ void PrimaryVertexValidation::beginJob()
   //
   ///////////////////////////////////////////////////////////////////
 
+  //    _   _            _      _         ___        _    _           _    
+  //   /_\ | |__ ___ ___| |_  _| |_ ___  | _ \___ __(_)__| |_  _ __ _| |___
+  //  / _ \| '_ (_-</ _ \ | || |  _/ -_) |   / -_|_-< / _` | || / _` | (_-<
+  // /_/ \_\_.__/__/\___/_|\_,_|\__\___| |_|_\___/__/_\__,_|\_,_\__,_|_/__/
+  //
+  
   TFileDirectory AbsTransPhiRes  = fs->mkdir("Abs_Transv_Phi_Residuals");
   a_dxyPhiResiduals  = bookResidualsHistogram(AbsTransPhiRes,nBins_,PVValHelper::dxy,PVValHelper::phi);
   a_dxPhiResiduals   = bookResidualsHistogram(AbsTransPhiRes,nBins_,PVValHelper::dx,PVValHelper::phi);
@@ -1440,6 +1447,13 @@ void PrimaryVertexValidation::beginJob()
   TFileDirectory AbsLongModZRes   = fs->mkdir("Abs_Long_modZ_Residuals"); 
   h_dz_modZ_       = bookResidualsHistogram(AbsLongModZRes,8,PVValHelper::dz,PVValHelper::modZ);		       
 
+
+  //  _  _                    _ _           _   ___        _    _           _    
+  // | \| |___ _ _ _ __  __ _| (_)______ __| | | _ \___ __(_)__| |_  _ __ _| |___
+  // | .` / _ \ '_| '  \/ _` | | |_ / -_) _` | |   / -_|_-< / _` | || / _` | (_-<
+  // |_|\_\___/_| |_|_|_\__,_|_|_/__\___\__,_| |_|_\___/__/_\__,_|\_,_\__,_|_/__/
+  //
+  
   TFileDirectory NormTransModZRes = fs->mkdir("Norm_Transv_modZ_Residuals"); 
   h_norm_dxy_modZ_ = bookResidualsHistogram(NormTransModZRes,8,PVValHelper::norm_dxy,PVValHelper::modZ,true);	       
 
@@ -1474,155 +1488,7 @@ void PrimaryVertexValidation::beginJob()
     
     float etaF=-etaOfProbe_+i*etaSect_;
     float etaL=-etaOfProbe_+(i+1)*etaSect_;
-    
-    // dxy vs phi and eta
-     
-    //a_dxyPhiResiduals[i] = AbsTransPhiRes.make<TH1F>(Form("histo_dxy_phi_plot%i",i),
-    //						     Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{xy} [#mum];tracks",phiF,phiL),
-    //						     theDetails_.histobins,-dxymax_phi,dxymax_phi);
-    
-    // a_dxyEtaResiduals[i] = AbsTransEtaRes.make<TH1F>(Form("histo_dxy_eta_plot%i",i),
-    // 						     Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{xy} [#mum];tracks",etaF,etaL),
-    // 						     theDetails_.histobins,-dxymax_eta,dxymax_eta);
-
-    // // dx vs phi and eta
-     
-    // a_dxPhiResiduals[i] = AbsTransPhiRes.make<TH1F>(Form("histo_dx_phi_plot%i",i),
-    // 						    Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{x} [#mum];tracks",phiF,phiL),
-    // 						    theDetails_.histobins,-dxymax_phi,dxymax_phi);
-    
-    // a_dxEtaResiduals[i] = AbsTransEtaRes.make<TH1F>(Form("histo_dx_eta_plot%i",i),
-    // 						    Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{x} [#mum];tracks",etaF,etaL),
-    // 						    theDetails_.histobins,-dxymax_eta,dxymax_eta);
-
-
-    // // dy vs phi and eta
-     
-    // a_dyPhiResiduals[i] = AbsTransPhiRes.make<TH1F>(Form("histo_dy_phi_plot%i",i),
-    // 						    Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{y} [#mum];tracks",phiF,phiL),
-    // 						    theDetails_.histobins,-dxymax_phi,dxymax_phi);
-    
-    // a_dyEtaResiduals[i] = AbsTransEtaRes.make<TH1F>(Form("histo_dy_eta_plot%i",i),
-    // 						    Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{y} [#mum];tracks",etaF,etaL),
-    // 						    theDetails_.histobins,-dxymax_eta,dxymax_eta);
-    
-    // // IP2D vs phi and eta
-
-    // a_IP2DPhiResiduals[i] = AbsTransPhiRes.make<TH1F>(Form("histo_IP2D_phi_plot%i",i),
-    // 						     Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;IP_{2D} [#mum];tracks",phiF,phiL),
-    // 						     theDetails_.histobins,-dxymax_phi,dxymax_phi);
-    
-    // a_IP2DEtaResiduals[i] = AbsTransEtaRes.make<TH1F>(Form("histo_IP2D_eta_plot%i",i),
-    // 						     Form("%.2f<#eta^{probe}_{tk}<%.2f;IP_{2D} [#mum];tracks",etaF,etaL),
-    // 						     theDetails_.histobins,-dxymax_eta,dxymax_eta);
-
-    // // IP3D vs phi and eta
-
-    // a_IP3DPhiResiduals[i] = Abs3DPhiRes.make<TH1F>(Form("histo_IP3D_phi_plot%i",i),
-    // 						   Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;IP_{3D} [#mum];tracks",phiF,phiL),
-    // 						   theDetails_.histobins,-dxymax_phi,dxymax_phi);
-    
-    // a_IP3DEtaResiduals[i] = Abs3DEtaRes.make<TH1F>(Form("histo_IP3D_eta_plot%i",i),
-    // 						   Form("%.2f<#eta^{probe}_{tk}<%.2f;IP_{3D} [#mum];tracks",etaF,etaL),
-    // 						   theDetails_.histobins,-dxymax_eta,dxymax_eta);
-
-    // // dz vs phi and eta
-
-    // a_dzPhiResiduals[i]  = AbsLongPhiRes.make<TH1F>(Form("histo_dz_phi_plot%i",i),
-    // 						    Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{z} [#mum];tracks",phiF,phiL),
-    // 						    theDetails_.histobins,-dzmax_phi,dzmax_phi);
-    
-    // a_dzEtaResiduals[i]  = AbsLongEtaRes.make<TH1F>(Form("histo_dz_eta_plot%i",i),
-    // 						    Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{z} [#mum];tracks",etaF,etaL),
-    // 						    theDetails_.histobins,-dzmax_eta,dzmax_eta);
-
-
-    // // resz vs phi and eta
-
-    // a_reszPhiResiduals[i]  = AbsLongPhiRes.make<TH1F>(Form("histo_resz_phi_plot%i",i),
-    // 						    Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;z_{trk} - z_{vtx} [#mum];tracks",phiF,phiL),
-    // 						    theDetails_.histobins,-dzmax_phi,dzmax_phi);
-    
-    // a_reszEtaResiduals[i]  = AbsLongEtaRes.make<TH1F>(Form("histo_resz_eta_plot%i",i),
-    // 						    Form("%.2f<#eta^{probe}_{tk}<%.2f;z_{trk} - z_{vtx} [#mum];tracks",etaF,etaL),
-    // 						    theDetails_.histobins,-dzmax_eta,dzmax_eta);
-
-    // // d3D vs phi and eta
-
-    // a_d3DPhiResiduals[i] = Abs3DPhiRes.make<TH1F>(Form("histo_d3D_phi_plot%i",i),
-    // 						  Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{3D} [#mum];tracks",phiF,phiL),
-    // 						  theDetails_.histobins,0.,d3Dmax_phi);
-    
-    // a_d3DEtaResiduals[i] = Abs3DEtaRes.make<TH1F>(Form("histo_d3D_eta_plot%i",i),
-    // 						  Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{3D} [#mum];tracks",etaF,etaL),
-    // 						  theDetails_.histobins,0.,d3Dmax_eta);
-       
-    // //  _  _                    _ _           _   ___        _    _           _    
-    // // | \| |___ _ _ _ __  __ _| (_)______ __| | | _ \___ __(_)__| |_  _ __ _| |___
-    // // | .` / _ \ '_| '  \/ _` | | |_ / -_) _` | |   / -_|_-< / _` | || / _` | (_-<
-    // // |_|\_\___/_| |_|_|_\__,_|_|_/__\___\__,_| |_|_\___/__/_\__,_|\_,_\__,_|_/__/
-    // //
-                                                                             
-    // // normalized dxy vs eta and phi
-   				
-    // n_dxyPhiResiduals[i] = NormTransPhiRes.make<TH1F>(Form("histo_norm_dxy_phi_plot%i",i),
-    // 						      Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{xy}/#sigma_{d_{xy}};tracks",phiF,phiL),
-    // 						      theDetails_.histobins,-dxymax_phi/100.,dxymax_phi/100.);
-    
-    // n_dxyEtaResiduals[i] = NormTransEtaRes.make<TH1F>(Form("histo_norm_dxy_eta_plot%i",i),
-    // 						      Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{xy}/#sigma_{d_{xy}};tracks",etaF,etaL),
-    // 						      theDetails_.histobins,-dxymax_eta/100.,dxymax_eta/100.);
-    
-    // // normalized IP2d vs eta and phi
-    
-    // n_IP2DPhiResiduals[i] = NormTransPhiRes.make<TH1F>(Form("histo_norm_IP2D_phi_plot%i",i),
-    // 						       Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;IP_{2D}/#sigma_{IP_{2D}};tracks",phiF,phiL),
-    // 						       theDetails_.histobins,-dxymax_phi/100.,dxymax_phi/100.);
-    
-    // n_IP2DEtaResiduals[i] = NormTransEtaRes.make<TH1F>(Form("histo_norm_IP2D_eta_plot%i",i),
-    // 						       Form("%.2f<#eta^{probe}_{tk}<%.2f;IP_{2D}/#sigma_{IP_{2D}};tracks",etaF,etaL),
-    // 						       theDetails_.histobins,-dxymax_eta/100.,dxymax_eta/100.);
-    
-    // // normalized IP3d vs eta and phi
-    
-    // n_IP3DPhiResiduals[i] = Norm3DPhiRes.make<TH1F>(Form("histo_norm_IP3D_phi_plot%i",i),
-    // 						    Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;IP_{3D}/#sigma_{IP_{3D}};tracks",phiF,phiL),
-    // 						    theDetails_.histobins,-dxymax_phi/100.,dxymax_phi/100.);
-    
-    // n_IP3DEtaResiduals[i] = Norm3DEtaRes.make<TH1F>(Form("histo_norm_IP3D_eta_plot%i",i),
-    // 						    Form("%.2f<#eta^{probe}_{tk}<%.2f;IP_{3D}/#sigma_{IP_{3D}};tracks",etaF,etaL),
-    // 						    theDetails_.histobins,-dxymax_eta/100.,dxymax_eta/100.);
-
-    // // normalized dz vs phi and eta
-
-    // n_dzPhiResiduals[i]  = NormLongPhiRes.make<TH1F>(Form("histo_norm_dz_phi_plot%i",i),
-    // 						     Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{z}/#sigma_{d_{z}};tracks",phiF,phiL),
-    // 						     theDetails_.histobins,-dzmax_phi/100.,dzmax_phi/100.);
-    
-    // n_dzEtaResiduals[i]  = NormLongEtaRes.make<TH1F>(Form("histo_norm_dz_eta_plot%i",i),
-    // 						     Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{z}/#sigma_{d_{z}};tracks",etaF,etaL),
-    // 						     theDetails_.histobins,-dzmax_eta/100.,dzmax_eta/100.);
-
-    // // pull of resz
-
-    // n_reszPhiResiduals[i]  = NormLongPhiRes.make<TH1F>(Form("histo_norm_resz_phi_plot%i",i),
-    // 						     Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;(z_{trk}-z_{vtx})/#sigma_{res_{z}};tracks",phiF,phiL),
-    // 						     theDetails_.histobins,-dzmax_phi/100.,dzmax_phi/100.);
-    
-    // n_reszEtaResiduals[i]  = NormLongEtaRes.make<TH1F>(Form("histo_norm_resz_eta_plot%i",i),
-    // 						     Form("%.2f<#eta^{probe}_{tk}<%.2f;(z_{trk}-z_{vtx})/#sigma_{res_{z}};tracks",etaF,etaL),
-    // 						     theDetails_.histobins,-dzmax_eta/100.,dzmax_eta/100.);
-
-    // // normalized d3D vs phi and eta
-
-    // n_d3DPhiResiduals[i] = Norm3DPhiRes.make<TH1F>(Form("histo_norm_d3D_phi_plot%i",i),
-    // 						   Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{3D}/#sigma_{d_{3D}};tracks",phiF,phiL),
-    // 						   theDetails_.histobins,0.,d3Dmax_phi/100.);
-    
-    // n_d3DEtaResiduals[i] = Norm3DEtaRes.make<TH1F>(Form("histo_norm_d3D_eta_plot%i",i),
-    // 						   Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{3D}/#sigma_{d_{3D}};tracks",etaF,etaL),
-    // 						   theDetails_.histobins,0.,d3Dmax_eta/100.);
-
+                                                                                          
     //  ___           _    _     ___  _  __  __   ___        _    _           _    
     // |   \ ___ _  _| |__| |___|   \(_)/ _|/ _| | _ \___ __(_)__| |_  _ __ _| |___
     // | |) / _ \ || | '_ \ / -_) |) | |  _|  _| |   / -_|_-< / _` | || / _` | (_-<
@@ -1971,39 +1837,7 @@ void PrimaryVertexValidation::beginJob()
       
       float etaF=-etaOfProbe_+i*etaSect_;
       float etaL=-etaOfProbe_+(i+1)*etaSect_;
-      
-      // a_dxyPhiBiasResiduals[i] = AbsTransPhiBiasRes.make<TH1F>(Form("histo_dxy_phi_plot%i",i),
-      // 							       Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{xy} [#mum];tracks",phiF,phiL),
-      // 							       theDetails_.histobins,-dxymax_phi,dxymax_phi);
-
-      // a_dxyEtaBiasResiduals[i] = AbsTransEtaBiasRes.make<TH1F>(Form("histo_dxy_eta_plot%i",i),
-      // 							       Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{xy} [#mum];tracks",etaF,etaL),
-      // 							       theDetails_.histobins,-dxymax_eta,dxymax_eta);
-      
-      // a_dzPhiBiasResiduals[i]  = AbsLongPhiBiasRes.make<TH1F>(Form("histo_dz_phi_plot%i",i),
-      // 							      Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f #circ;d_{z} [#mum];tracks",phiF,phiL),
-      // 							      theDetails_.histobins,-dzmax_phi,dzmax_phi);
-
-      // a_dzEtaBiasResiduals[i]  = AbsLongEtaBiasRes.make<TH1F>(Form("histo_dz_eta_plot%i",i),
-      // 							      Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{z} [#mum];tracks",etaF,etaL),
-      // 							      theDetails_.histobins,-dzmax_eta,dzmax_eta);
-      
-      // n_dxyPhiBiasResiduals[i] = NormTransPhiBiasRes.make<TH1F>(Form("histo_norm_dxy_phi_plot%i",i),
-      // 								Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{xy}/#sigma_{d_{xy}};tracks",phiF,phiL),
-      // 								theDetails_.histobins,-dxymax_phi/100.,dxymax_phi/100.);
-
-      // n_dxyEtaBiasResiduals[i] = NormTransEtaBiasRes.make<TH1F>(Form("histo_norm_dxy_eta_plot%i",i),
-      // 								Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{xy}/#sigma_{d_{xy}};tracks",etaF,etaL),
-      // 								theDetails_.histobins,-dxymax_eta/100.,dxymax_eta/100.);
-      
-      // n_dzPhiBiasResiduals[i]  = NormLongPhiBiasRes.make<TH1F>(Form("histo_norm_dz_phi_plot%i",i),
-      // 							       Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{z}/#sigma_{d_{z}};tracks",phiF,phiL),
-      // 							       theDetails_.histobins,-dzmax_phi/100.,dzmax_phi/100.);
-
-      // n_dzEtaBiasResiduals[i]  = NormLongEtaBiasRes.make<TH1F>(Form("histo_norm_dz_eta_plot%i",i),
-      // 							       Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{z}/#sigma_{d_{z}};tracks",etaF,etaL),
-      // 							       theDetails_.histobins,-dzmax_eta/100.,dzmax_eta/100.);
-      
+       
       for ( int j=0; j<nBins_; ++j ) {
 	
 	a_dxyBiasResidualsMap[i][j] = AbsDoubleDiffBiasRes.make<TH1F>(Form("histo_dxy_eta_plot%i_phi_plot%i",i,j),

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -1640,28 +1640,28 @@ void PrimaryVertexValidation::beginJob()
   TFileDirectory BiasVsParameter = fs->mkdir("BiasVsParameter");
 
   a_dxyVsPhi = BiasVsParameter.make<TH2F>("h2_dxy_vs_phi","d_{xy} vs track #phi;track #phi [rad];track d_{xy}(PV) [#mum]",
-					  48,-TMath::Pi(),TMath::Pi(),mybins_,-dxymax_phi,dxymax_phi); 
+					  nBins_,-TMath::Pi(),TMath::Pi(),theDetails_.histobins,-dxymax_phi,dxymax_phi); 
  
   a_dzVsPhi  = BiasVsParameter.make<TH2F>("h2_dz_vs_phi","d_{z} vs track #phi;track #phi [rad];track d_{z}(PV) [#mum]",
-					  48,-TMath::Pi(),TMath::Pi(),mybins_,-dzmax_phi,dzmax_phi);   
+					  nBins_,-TMath::Pi(),TMath::Pi(),theDetails_.histobins,-dzmax_phi,dzmax_phi);   
                
   n_dxyVsPhi = BiasVsParameter.make<TH2F>("h2_n_dxy_vs_phi","d_{xy}/#sigma_{d_{xy}} vs track #phi;track #phi [rad];track d_{xy}(PV)/#sigma_{d_{xy}}",
-					  48,-TMath::Pi(),TMath::Pi(),mybins_,-dxymax_phi/100.,dxymax_phi/100.); 
+					  nBins_,-TMath::Pi(),TMath::Pi(),theDetails_.histobins,-dxymax_phi/100.,dxymax_phi/100.); 
   
   n_dzVsPhi  = BiasVsParameter.make<TH2F>("h2_n_dz_vs_phi","d_{z}/#sigma_{d_{z}} vs track #phi;track #phi [rad];track d_{z}(PV)/#sigma_{d_{z}}",
-					  48,-TMath::Pi(),TMath::Pi(),mybins_,-dzmax_phi/100.,dzmax_phi/100.);   
+					  nBins_,-TMath::Pi(),TMath::Pi(),theDetails_.histobins,-dzmax_phi/100.,dzmax_phi/100.);   
                
   a_dxyVsEta = BiasVsParameter.make<TH2F>("h2_dxy_vs_eta","d_{xy} vs track #eta;track #eta;track d_{xy}(PV) [#mum]",
-					  48,-etaOfProbe_,etaOfProbe_,mybins_,-dxymax_eta,dzmax_eta);
+					  nBins_,-etaOfProbe_,etaOfProbe_,theDetails_.histobins,-dxymax_eta,dzmax_eta);
   
   a_dzVsEta  = BiasVsParameter.make<TH2F>("h2_dz_vs_eta","d_{z} vs track #eta;track #eta;track d_{z}(PV) [#mum]",
-					  48,-etaOfProbe_,etaOfProbe_,mybins_,-dzmax_eta,dzmax_eta);   
+					  nBins_,-etaOfProbe_,etaOfProbe_,theDetails_.histobins,-dzmax_eta,dzmax_eta);   
                
   n_dxyVsEta = BiasVsParameter.make<TH2F>("h2_n_dxy_vs_eta","d_{xy}/#sigma_{d_{xy}} vs track #eta;track #eta;track d_{xy}(PV)/#sigma_{d_{xy}}",
-					  48,-etaOfProbe_,etaOfProbe_,mybins_,-dxymax_eta/100.,dxymax_eta/100.);  
+					  nBins_,-etaOfProbe_,etaOfProbe_,theDetails_.histobins,-dxymax_eta/100.,dxymax_eta/100.);  
 
   n_dzVsEta  = BiasVsParameter.make<TH2F>("h2_n_dz_vs_eta","d_{z}/#sigma_{d_{z}} vs track #eta;track #eta;track d_{z}(PV)/#sigma_{d_{z}}",
-					  48,-etaOfProbe_,etaOfProbe_,mybins_,-dzmax_eta/100.,dzmax_eta/100.);   
+					  nBins_,-etaOfProbe_,etaOfProbe_,theDetails_.histobins,-dzmax_eta/100.,dzmax_eta/100.);   
 
   MeanTrendsDir   = fs->mkdir("MeanTrends");
   WidthTrendsDir  = fs->mkdir("WidthTrends");
@@ -2591,7 +2591,6 @@ std::pair<Measurement1D, Measurement1D> PrimaryVertexValidation::fitResiduals(TH
 }
 
 //*************************************************************
-
 void PrimaryVertexValidation::fillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot[100], statmode::estimator fitPar_,const std::string& var_)
 //*************************************************************
 {
@@ -3054,7 +3053,7 @@ void PrimaryVertexValidation::fill(std::map<std::string, TH1*>& h,const std::str
 void PrimaryVertexValidation::fillByIndex(std::vector<TH1F*>& h, unsigned int index, double x,std::string tag)
 //*************************************************************
 {
-  //assert(!h.empty());
+  assert(!h.empty());
   if(index <= h.size()){
     h[index]->Fill(x);
   } else {

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -19,6 +19,7 @@
 #include <memory>
 #include <vector>
 #include <regex>
+#include <cassert>
 
 // user include files
 #include "Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h"
@@ -38,7 +39,6 @@
 
 // CMSSW includes
 #include "CondFormats/RunInfo/interface/RunInfo.h"
-#include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1D.h"
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -47,7 +47,6 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
@@ -89,7 +88,7 @@ PrimaryVertexValidation::PrimaryVertexValidation(const edm::ParameterSet& iConfi
   // initialize phase space boundaries
   
   usesResource(TFileService::kSharedResource);
-
+  
   std::vector<unsigned int> defaultRuns;
   defaultRuns.push_back(0);
   runControlNumbers_ = iConfig.getUntrackedParameter<std::vector<unsigned int> >("runControlNumber",defaultRuns);
@@ -205,13 +204,28 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
   if( (pDD->isThere(GeomDetEnumerators::P1PXB)) || 
       (pDD->isThere(GeomDetEnumerators::P1PXEC)) ) {
     isPhase1_ = true;
+    nLadders_ = 12;
+                        
+    if(h_dxy_ladderOverlap_.size()!=12){
+      shrinkHistVectorToFit(h_dxy_ladderOverlap_,12);
+      shrinkHistVectorToFit(h_dxy_ladderNoOverlap_,12);
+      shrinkHistVectorToFit(h_dxy_ladder_,12);	  
+      shrinkHistVectorToFit(h_dz_ladder_,12);	  
+      shrinkHistVectorToFit(h_norm_dxy_ladder_,12);  
+      shrinkHistVectorToFit(h_norm_dz_ladder_,12);   
+
+      std::cout<<"checking size:"<<h_dxy_ladder_.size()<<std::endl;
+
+    }
+
     if (debug_){
-      edm::LogInfo("PrimaryVertexValidation")<<" pixel phase1 setup ";
+      edm::LogInfo("PrimaryVertexValidation")<<" pixel phase1 setup, nLadders: "<<nLadders_;
     }
   } else {
     isPhase1_ = false;
+    nLadders_ = 20;
     if (debug_){
-      edm::LogInfo("PrimaryVertexValidation")<<" pixel phase0 setup ";
+      edm::LogInfo("PrimaryVertexValidation")<<" pixel phase0 setup, nLadders: "<<nLadders_;
     }
   }
 
@@ -747,7 +761,6 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 	      h_probeL1Module_->Fill(module_num);
 	      h_probeHasBPixL1Overlap_->Fill(L1BPixHitCount);
 
-	      
 	      // filling the pT-binned distributions
 
 	      for(int ipTBin=0; ipTBin<nPtBins_; ipTBin++){
@@ -864,6 +877,31 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 		a_dzVsEta->Fill(tracketa,z0*cmToum);  
 		n_dxyVsEta->Fill(tracketa,dxyFromMyVertex/s_ip2dpv_err); 
 		n_dzVsEta->Fill(tracketa,z0/z0_error); 
+
+		if( ladder_num > 0 && module_num > 0 ) {
+		  
+		  //std::cout<<" ladder_num"<<ladder_num <<" module_num"<<module_num <<std::endl;
+
+		  fillByIndex(h_dxy_modZ_,module_num-1,dxyFromMyVertex*cmToum);
+		  fillByIndex(h_dz_modZ_,module_num-1,dzFromMyVertex*cmToum);	  
+		  fillByIndex(h_norm_dxy_modZ_,module_num-1,dxyFromMyVertex/s_ip2dpv_err);	  
+		  fillByIndex(h_norm_dz_modZ_,module_num-1,dzFromMyVertex/dz_err);	  
+		  
+		  fillByIndex(h_dxy_ladder_,ladder_num-1,dxyFromMyVertex*cmToum);	  
+
+		  // std::cout<<"h_dxy_ladder size:" <<h_dxy_ladder_.size() << std::endl;
+
+		  if(L1BPixHitCount==1){
+		    fillByIndex(h_dxy_ladderNoOverlap_,ladder_num-1,dxyFromMyVertex*cmToum);	  
+		  } else {
+		    fillByIndex(h_dxy_ladderOverlap_,ladder_num-1,dxyFromMyVertex*cmToum);	  
+		  }
+
+		  fillByIndex(h_dz_ladder_,ladder_num-1,dzFromMyVertex*cmToum);	  
+		  fillByIndex(h_norm_dxy_ladder_,ladder_num-1,dxyFromMyVertex/s_ip2dpv_err);  
+		  fillByIndex(h_norm_dz_ladder_,ladder_num-1,dzFromMyVertex/dz_err);   
+		  
+		}
 
 		// filling the binned distributions
 		for(int i=0; i<nBins_; i++){
@@ -1048,7 +1086,6 @@ void PrimaryVertexValidation::beginJob()
   Nevt_    = 0;
   
   //  rootFile_ = new TFile(filename_.c_str(),"recreate");
-  edm::Service<TFileService> fs;
   rootTree_ = fs->make<TTree>("tree","PV Validation tree");
  
   // Track Paramters 
@@ -1213,7 +1250,7 @@ void PrimaryVertexValidation::beginJob()
   h_probeHitsInBPIX_ = ProbeFeatures.make<TH1F>("h_probeNRechitsBPIX","N_{hits} BPIX;N_{hits} BPIX;tracks",40,-0.5,39.5);
   h_probeHitsInFPIX_ = ProbeFeatures.make<TH1F>("h_probeNRechitsFPIX","N_{hits} FPIX;N_{hits} FPIX;tracks",40,-0.5,39.5);
 
-  h_probeL1Ladder_         = ProbeFeatures.make<TH1F>("h_probeL1Ladder","Ladder number (L1 hit); ladder number",14,-1.5,12.5); 
+  h_probeL1Ladder_         = ProbeFeatures.make<TH1F>("h_probeL1Ladder","Ladder number (L1 hit); ladder number",22,-1.5,20.5); 
   h_probeL1Module_         = ProbeFeatures.make<TH1F>("h_probeL1Module","Module number (L1 hit); module number",10,-1.5,8.5);
   h_probeHasBPixL1Overlap_ = ProbeFeatures.make<TH1I>("h_probeHasBPixL1Overlap","n. hits in L1;n. L1-BPix hits;tracks",5,0,5);
 
@@ -1313,6 +1350,38 @@ void PrimaryVertexValidation::beginJob()
 
   TFileDirectory NormLongpTCentralRes  = fs->mkdir("Norm_Long_pTCentral_Residuals"); 
   h_norm_dz_Central_pT_  = bookResidualsHistogram(NormLongpTCentralRes,nPtBins_,"norm_dz","pTCentral");   
+
+  // book residuals vs module number
+  
+  TFileDirectory AbsTransModZRes  = fs->mkdir("Abs_Transv_modZ_Residuals"); 
+  h_dxy_modZ_      = bookResidualsHistogram(AbsTransModZRes,8,"dxy","modZ");	       
+
+  TFileDirectory AbsLongModZRes   = fs->mkdir("Abs_Long_modZ_Residuals"); 
+  h_dz_modZ_       = bookResidualsHistogram(AbsLongModZRes,8,"dz","modZ");		       
+
+  TFileDirectory NormTransModZRes = fs->mkdir("Norm_Transv_modZ_Residuals"); 
+  h_norm_dxy_modZ_ = bookResidualsHistogram(NormTransModZRes,8,"norm_dxy","modZ");	       
+
+  TFileDirectory NormLongModZRes  = fs->mkdir("Norm_Long_modZ_Residuals"); 
+  h_norm_dz_modZ_  = bookResidualsHistogram(NormLongModZRes,8,"norm_dz","modZ");	       
+
+  TFileDirectory AbsTransLadderRes  = fs->mkdir("Abs_Transv_ladder_Residuals"); 
+  h_dxy_ladder_ = bookResidualsHistogram(AbsTransLadderRes,nLadders_,"dxy","ladder");
+
+  TFileDirectory AbsTransLadderResOverlap  = fs->mkdir("Abs_Transv_ladderOverlap_Residuals"); 
+  h_dxy_ladderOverlap_ = bookResidualsHistogram(AbsTransLadderResOverlap,nLadders_,"dxy","ladder");       
+
+  TFileDirectory AbsTransLadderResNoOverlap  = fs->mkdir("Abs_Transv_ladderNoOverlap_Residuals"); 
+  h_dxy_ladderNoOverlap_ = bookResidualsHistogram(AbsTransLadderResNoOverlap,nLadders_,"dxy","ladder");       
+
+  TFileDirectory AbsLongLadderRes   = fs->mkdir("Abs_Long_ladder_Residuals"); 
+  h_dz_ladder_  = bookResidualsHistogram(AbsLongLadderRes,nLadders_,"dz","ladder");	       
+
+  TFileDirectory NormTransLadderRes = fs->mkdir("Norm_Transv_ladder_Residuals"); 
+  h_norm_dxy_ladder_ = bookResidualsHistogram(NormTransLadderRes,nLadders_,"norm_dxy","ladder");  
+
+  TFileDirectory NormLongLadderRes  = fs->mkdir("Norm_Long_ladder_Residuals"); 
+  h_norm_dz_ladder_  = bookResidualsHistogram(NormLongLadderRes,nLadders_,"norm_dz","ladder");   
 
   // book residuals as function of phi and eta
 
@@ -1535,13 +1604,13 @@ void PrimaryVertexValidation::beginJob()
   n_dzVsEta  = BiasVsParameter.make<TH2F>("h2_n_dz_vs_eta","d_{z}/#sigma_{d_{z}} vs track #eta;track #eta;track d_{z}(PV)/#sigma_{d_{z}}",
 					  48,-etaOfProbe_,etaOfProbe_,mybins_,-dzmax_eta/100.,dzmax_eta/100.);   
 
-  TFileDirectory MeanTrendsDir   = fs->mkdir("MeanTrends");
-  TFileDirectory WidthTrendsDir  = fs->mkdir("WidthTrends");
-  TFileDirectory MedianTrendsDir = fs->mkdir("MedianTrends");
-  TFileDirectory MADTrendsDir    = fs->mkdir("MADTrends");
+  MeanTrendsDir   = fs->mkdir("MeanTrends");
+  WidthTrendsDir  = fs->mkdir("WidthTrends");
+  MedianTrendsDir = fs->mkdir("MedianTrends");
+  MADTrendsDir    = fs->mkdir("MADTrends");
 
-  TFileDirectory Mean2DMapsDir   = fs->mkdir("MeanMaps");
-  TFileDirectory Width2DMapsDir  = fs->mkdir("WidthMaps");
+  Mean2DMapsDir   = fs->mkdir("MeanMaps");
+  Width2DMapsDir  = fs->mkdir("WidthMaps");
 
   double highedge=nBins_-0.5;
   double lowedge=-0.5;
@@ -2049,6 +2118,72 @@ void PrimaryVertexValidation::endJob()
     <<"# PrimaryVertexValidation::endJob()\n" 
     <<"# Number of analyzed events: "<<Nevt_<<"\n"
     <<"######################################";
+
+  // means and widhts vs ladder and module number
+  
+  a_dxymodZMeanTrend  = MeanTrendsDir.make<TH1F> ("means_dxy_modZ",
+						  "#LT d_{xy} #GT vs modZ;module number (Z);#LT d_{xy} #GT [#mum]",
+						  8,0.,8.); 
+  
+  a_dxymodZWidthTrend = WidthTrendsDir.make<TH1F>("widths_dxy_modZ",
+						  "#sigma_{d_{xy}} vs modZ;module number (Z);#sigma_{d_{xy}} [#mum]",
+						  8,0.,8.);
+  
+  a_dzmodZMeanTrend   = MeanTrendsDir.make<TH1F> ("means_dz_modZ",
+						  "#LT d_{z} #GT vs modZ;module number (Z);#LT d_{z} #GT [#mum]",
+						  8,0.,8.); 
+  
+  a_dzmodZWidthTrend  = WidthTrendsDir.make<TH1F>("widths_dz_modZ",
+						  "#sigma_{d_{z}} vs modZ;module number (Z);#sigma_{d_{z}} [#mum]",
+						  8,0.,8.);
+ 
+  a_dxyladderMeanTrend  = MeanTrendsDir.make<TH1F> ("means_dxy_ladder",
+						    "#LT d_{xy} #GT vs ladder;ladder number (#phi);#LT d_{xy} #GT [#mum]",
+						    nLadders_,0.,nLadders_);
+  
+  a_dxyladderWidthTrend = WidthTrendsDir.make<TH1F>("widths_dxy_ladder",
+						    "#sigma_{d_{xy}} vs ladder;ladder number (#phi);#sigma_{d_{xy}} [#mum]",
+						    nLadders_,0.,nLadders_);
+  
+  a_dzladderMeanTrend   = MeanTrendsDir.make<TH1F> ("means_dz_ladder",
+						    "#LT d_{z} #GT vs ladder;ladder number (#phi);#LT d_{z} #GT [#mum]"
+						    ,nLadders_,0.,nLadders_); 
+  
+  a_dzladderWidthTrend  = WidthTrendsDir.make<TH1F>("widths_dz_ladder",
+						    "#sigma_{d_{z}} vs ladder;ladder number (#phi);#sigma_{d_{z}} [#mum]",
+						    nLadders_,0.,nLadders_);
+  
+  n_dxymodZMeanTrend  = MeanTrendsDir.make<TH1F> ("norm_means_dxy_modZ",
+						  "#LT d_{xy}/#sigma_{d_{xy}} #GT vs modZ;module number (Z);#LT d_{xy}/#sigma_{d_{xy}} #GT",
+						  8,0.,8.);
+  
+  n_dxymodZWidthTrend = WidthTrendsDir.make<TH1F>("norm_widths_dxy_modZ",
+						  "width(d_{xy}/#sigma_{d_{xy}}) vs modZ;module number (Z); width(d_{xy}/#sigma_{d_{xy}})",
+						  8,0.,8.);
+  
+  n_dzmodZMeanTrend   = MeanTrendsDir.make<TH1F> ("norm_means_dz_modZ",
+						  "#LT d_{z}/#sigma_{d_{z}} #GT vs modZ;module number (Z);#LT d_{z}/#sigma_{d_{z}} #GT",
+						  8,0.,8.); 
+  
+  n_dzmodZWidthTrend  = WidthTrendsDir.make<TH1F>("norm_widths_dz_modZ",
+						  "width(d_{z}/#sigma_{d_{z}}) vs pT;module number (Z);width(d_{z}/#sigma_{d_{z}})",
+						  8,0.,8.);
+  
+  n_dxyladderMeanTrend  = MeanTrendsDir.make<TH1F> ("norm_means_dxy_ladder",
+						    "#LT d_{xy}/#sigma_{d_{xy}} #GT vs ladder;ladder number (#phi);#LT d_{xy}/#sigma_{d_{z}} #GT",
+						    nLadders_,0.,nLadders_);
+  
+  n_dxyladderWidthTrend = WidthTrendsDir.make<TH1F>("norm_widths_dxy_ladder",
+						    "width(d_{xy}/#sigma_{d_{xy}}) vs ladder;ladder number (#phi);width(d_{xy}/#sigma_{d_{z}})",
+						    nLadders_,0.,nLadders_);
+  
+  n_dzladderMeanTrend   = MeanTrendsDir.make<TH1F> ("norm_means_dz_ladder",
+						    "#LT d_{z}/#sigma_{d_{z}} #GT vs ladder;ladder number (#phi);#LT d_{z}/#sigma_{d_{z}} #GT",
+						    nLadders_,0.,nLadders_);  
+  
+  n_dzladderWidthTrend  = WidthTrendsDir.make<TH1F>("norm_widths_dz_ladder",
+						    "width(d_{z}/#sigma_{d_{z}}) vs ladder;ladder number (#phi);width(d_{z}/#sigma_{d_{z}})",
+						    nLadders_,0.,nLadders_); 
 
   if(useTracksFromRecoVtx_){
 
@@ -2660,9 +2795,16 @@ std::vector<TH1F*> PrimaryVertexValidation::bookResidualsHistogram(const TFileDi
   
   std::vector<TH1F*> h;
   h.reserve(theNOfBins);
+
   
+
   std::string auxResType = std::regex_replace(resType, std::regex("_"), "");
-  
+
+  if (theNOfBins==0) {
+    edm::LogError("PrimaryVertexValidation") <<"bookResidualsHistogram() The number of bins cannot be identically 0" << std::endl;
+    assert(false);
+  }
+      
   for(unsigned int i=0; i<theNOfBins;i++){
     TH1F* htemp = dir.make<TH1F>(Form("histo_%s_%s_plot%i",resType.c_str(),varType.c_str(),i),
 				 Form("%s vs %s - bin %i;%s;tracks",auxResType.c_str(),varType.c_str(),i,auxResType.c_str()),
@@ -2825,10 +2967,20 @@ void PrimaryVertexValidation::fillByIndex(std::vector<TH1F*>& h, unsigned int in
   if(index <= h.size()){
     h[index]->Fill(x);
   } else {
-    edm::LogWarning("PrimaryVertexValidation") << "Trying to fill non-existing Histogram with index " << index << std::endl;
+    edm::LogWarning("PrimaryVertexValidation") << "Trying to fill non-existing Histogram with index " << index << " for array with size: "<<h.size()<< std::endl;
     return;
   }
 }
 
+//*************************************************************
+void PrimaryVertexValidation::shrinkHistVectorToFit(std::vector<TH1F*>&h, unsigned int desired_size)
+//*************************************************************
+{
+  h.erase(h.begin()+desired_size,h.end()); 
+}
+
+
 //define this as a plug-in
 DEFINE_FWK_MODULE(PrimaryVertexValidation);
+
+

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -121,23 +121,23 @@ PrimaryVertexValidation::PrimaryVertexValidation(const edm::ParameterSet& iConfi
   }
 
   theDetails_.histobins = 500;
-  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::phi)]       = std::make_pair(-2000.,2000.); 
-  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::eta)]       = std::make_pair(-3000.,3000.);
-  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::pT)]        = std::make_pair(-1000.,1000.);
-  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::pTCentral)] = std::make_pair(-1000.,1000.);
-  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::ladder)]    = std::make_pair(-1000.,1000.);
-  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::modZ)]      = std::make_pair(-1000.,1000.);
+  theDetails_.range[std::make_pair(PVValHelper::dxy,PVValHelper::phi)]       = std::make_pair(-2000.,2000.); 
+  theDetails_.range[std::make_pair(PVValHelper::dxy,PVValHelper::eta)]       = std::make_pair(-3000.,3000.);
+  theDetails_.range[std::make_pair(PVValHelper::dxy,PVValHelper::pT)]        = std::make_pair(-1000.,1000.);
+  theDetails_.range[std::make_pair(PVValHelper::dxy,PVValHelper::pTCentral)] = std::make_pair(-1000.,1000.);
+  theDetails_.range[std::make_pair(PVValHelper::dxy,PVValHelper::ladder)]    = std::make_pair(-1000.,1000.);
+  theDetails_.range[std::make_pair(PVValHelper::dxy,PVValHelper::modZ)]      = std::make_pair(-1000.,1000.);
 
-  for (int i = pvparams::phi; i < pvparams::END_OF_PLOTS; i++ ){
-    for (int j = pvparams::dx; j < pvparams::END_OF_TYPES; j++ ){
+  for (int i = PVValHelper::phi; i < PVValHelper::END_OF_PLOTS; i++ ){
+    for (int j = PVValHelper::dx; j < PVValHelper::END_OF_TYPES; j++ ){
 
-      auto res_index  = static_cast<pvparams::residualType>(i);
-      auto plot_index = static_cast<pvparams::plotVariable>(j);
+      auto res_index  = static_cast<PVValHelper::residualType>(i);
+      auto plot_index = static_cast<PVValHelper::plotVariable>(j);
 
-      if(res_index!=pvparams::d3D)
-	theDetails_.range[std::make_pair(res_index,plot_index)] = theDetails_.range[std::make_pair(pvparams::dxy,plot_index)];
+      if(res_index!=PVValHelper::d3D)
+	theDetails_.range[std::make_pair(res_index,plot_index)] = theDetails_.range[std::make_pair(PVValHelper::dxy,plot_index)];
       else
-	theDetails_.range[std::make_pair(res_index,plot_index)] = std::make_pair(0.,theDetails_.range[std::make_pair(pvparams::dxy,plot_index)].second);
+	theDetails_.range[std::make_pair(res_index,plot_index)] = std::make_pair(0.,theDetails_.range[std::make_pair(PVValHelper::dxy,plot_index)].second);
     }
   }
 
@@ -229,20 +229,23 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
     nLadders_ = 12;
                         
     if(h_dxy_ladderOverlap_.size()!=12){
-      shrinkHistVectorToFit(h_dxy_ladderOverlap_,12);
-      shrinkHistVectorToFit(h_dxy_ladderNoOverlap_,12);
-      shrinkHistVectorToFit(h_dxy_ladder_,12);	  
-      shrinkHistVectorToFit(h_dz_ladder_,12);	  
-      shrinkHistVectorToFit(h_norm_dxy_ladder_,12);  
-      shrinkHistVectorToFit(h_norm_dz_ladder_,12);   
 
-      std::cout<<"checking size:"<<h_dxy_ladder_.size()<<std::endl;
-
+      PVValHelper::shrinkHistVectorToFit(h_dxy_ladderOverlap_,12);
+      PVValHelper::shrinkHistVectorToFit(h_dxy_ladderNoOverlap_,12);
+      PVValHelper::shrinkHistVectorToFit(h_dxy_ladder_,12);	  
+      PVValHelper::shrinkHistVectorToFit(h_dz_ladder_,12);	  
+      PVValHelper::shrinkHistVectorToFit(h_norm_dxy_ladder_,12);  
+      PVValHelper::shrinkHistVectorToFit(h_norm_dz_ladder_,12);   
+      
+      if (debug_){
+	edm::LogInfo("PrimaryVertexValidation")<<"checking size:"<<h_dxy_ladder_.size()<<std::endl;
+      }
     }
 
     if (debug_){
       edm::LogInfo("PrimaryVertexValidation")<<" pixel phase1 setup, nLadders: "<<nLadders_;
     }
+    
   } else {
     isPhase1_ = false;
     nLadders_ = 20;
@@ -384,19 +387,19 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 	  
 	  if(tracketa >= etaF && tracketa < etaL ){
 
-	    a_dxyEtaBiasResiduals[i]->Fill(dxyRes*cmToum);
-	    a_dzEtaBiasResiduals[i]->Fill(dzRes*cmToum); 
-	    n_dxyEtaBiasResiduals[i]->Fill((dxyRes)/dxy_err);
-	    n_dzEtaBiasResiduals[i]->Fill((dzRes)/dz_err);
+	    PVValHelper::fillByIndex(a_dxyEtaBiasResiduals,i,dxyRes*cmToum);
+	    PVValHelper::fillByIndex(a_dzEtaBiasResiduals,i,dzRes*cmToum); 
+	    PVValHelper::fillByIndex(n_dxyEtaBiasResiduals,i,(dxyRes)/dxy_err);
+	    PVValHelper::fillByIndex(n_dzEtaBiasResiduals,i,(dzRes)/dz_err);
 
 	  }
 
 	  if(trackphi >= phiF && trackphi < phiL ){ 
 
-	    a_dxyPhiBiasResiduals[i]->Fill(dxyRes*cmToum);
-	    a_dzPhiBiasResiduals[i]->Fill(dzRes*cmToum); 
-	    n_dxyPhiBiasResiduals[i]->Fill((dxyRes)/dxy_err);
-	    n_dzPhiBiasResiduals[i]->Fill((dzRes)/dz_err); 
+	    PVValHelper::fillByIndex(a_dxyPhiBiasResiduals,i,dxyRes*cmToum);
+	    PVValHelper::fillByIndex(a_dzPhiBiasResiduals,i,dzRes*cmToum); 
+	    PVValHelper::fillByIndex(n_dxyPhiBiasResiduals,i,(dxyRes)/dxy_err);
+	    PVValHelper::fillByIndex(n_dzPhiBiasResiduals,i,(dzRes)/dz_err); 
 	    
 	    for(int j=0; j<nBins_; j++){
 	      
@@ -799,19 +802,19 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 		  
 		  if(debug_)
 		    edm::LogInfo("PrimaryVertexValidation")<<"passes this cut: "<<mypT_bins_[ipTBin]<<std::endl;
-		  fillByIndex(h_dxy_pT_,ipTBin,dxyFromMyVertex*cmToum);
-		  fillByIndex(h_dz_pT_,ipTBin,dzFromMyVertex*cmToum);
-		  fillByIndex(h_norm_dxy_pT_,ipTBin,dxyFromMyVertex/s_ip2dpv_err);
-		  fillByIndex(h_norm_dz_pT_,ipTBin,dzFromMyVertex/dz_err);
+		  PVValHelper::fillByIndex(h_dxy_pT_,ipTBin,dxyFromMyVertex*cmToum);
+		  PVValHelper::fillByIndex(h_dz_pT_,ipTBin,dzFromMyVertex*cmToum);
+		  PVValHelper::fillByIndex(h_norm_dxy_pT_,ipTBin,dxyFromMyVertex/s_ip2dpv_err);
+		  PVValHelper::fillByIndex(h_norm_dz_pT_,ipTBin,dzFromMyVertex/dz_err);
 		  
 		  if(std::abs(tracketa)<1.){
 		    
 		    if(debug_)
 		      edm::LogInfo("PrimaryVertexValidation")<<"passes tight eta cut: "<<mypT_bins_[ipTBin]<<std::endl;
-		    fillByIndex(h_dxy_Central_pT_,ipTBin,dxyFromMyVertex*cmToum);
-		    fillByIndex(h_dz_Central_pT_,ipTBin,dzFromMyVertex*cmToum);
-		    fillByIndex(h_norm_dxy_Central_pT_,ipTBin,dxyFromMyVertex/s_ip2dpv_err);
-		    fillByIndex(h_norm_dz_Central_pT_,ipTBin,dzFromMyVertex/dz_err);
+		    PVValHelper::fillByIndex(h_dxy_Central_pT_,ipTBin,dxyFromMyVertex*cmToum);
+		    PVValHelper::fillByIndex(h_dz_Central_pT_,ipTBin,dzFromMyVertex*cmToum);
+		    PVValHelper::fillByIndex(h_norm_dxy_Central_pT_,ipTBin,dxyFromMyVertex/s_ip2dpv_err);
+		    PVValHelper::fillByIndex(h_norm_dz_Central_pT_,ipTBin,dzFromMyVertex/dz_err);
 		  }
 		}
 	      }
@@ -904,26 +907,26 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 
 		if( ladder_num > 0 && module_num > 0 ) {
 		  
-		  //std::cout<<" ladder_num"<<ladder_num <<" module_num"<<module_num <<std::endl;
+		  LogDebug("PrimaryVertexValidation")<<" ladder_num"<<ladder_num <<" module_num"<<module_num <<std::endl;
 
-		  fillByIndex(h_dxy_modZ_,module_num-1,dxyFromMyVertex*cmToum);
-		  fillByIndex(h_dz_modZ_,module_num-1,dzFromMyVertex*cmToum);	  
-		  fillByIndex(h_norm_dxy_modZ_,module_num-1,dxyFromMyVertex/s_ip2dpv_err);	  
-		  fillByIndex(h_norm_dz_modZ_,module_num-1,dzFromMyVertex/dz_err);	  
+		  PVValHelper::fillByIndex(h_dxy_modZ_,module_num-1,dxyFromMyVertex*cmToum);
+		  PVValHelper::fillByIndex(h_dz_modZ_,module_num-1,dzFromMyVertex*cmToum);	  
+		  PVValHelper::fillByIndex(h_norm_dxy_modZ_,module_num-1,dxyFromMyVertex/s_ip2dpv_err);	  
+		  PVValHelper::fillByIndex(h_norm_dz_modZ_,module_num-1,dzFromMyVertex/dz_err);	  
 		  
-		  fillByIndex(h_dxy_ladder_,ladder_num-1,dxyFromMyVertex*cmToum);	  
+		  PVValHelper::fillByIndex(h_dxy_ladder_,ladder_num-1,dxyFromMyVertex*cmToum);	  
 
-		  // std::cout<<"h_dxy_ladder size:" <<h_dxy_ladder_.size() << std::endl;
+		  LogDebug("PrimaryVertexValidation")<<"h_dxy_ladder size:" <<h_dxy_ladder_.size() << std::endl;
 
 		  if(L1BPixHitCount==1){
-		    fillByIndex(h_dxy_ladderNoOverlap_,ladder_num-1,dxyFromMyVertex*cmToum);	  
+		    PVValHelper::fillByIndex(h_dxy_ladderNoOverlap_,ladder_num-1,dxyFromMyVertex*cmToum);	  
 		  } else {
-		    fillByIndex(h_dxy_ladderOverlap_,ladder_num-1,dxyFromMyVertex*cmToum);	  
+		    PVValHelper::fillByIndex(h_dxy_ladderOverlap_,ladder_num-1,dxyFromMyVertex*cmToum);	  
 		  }
 
-		  fillByIndex(h_dz_ladder_,ladder_num-1,dzFromMyVertex*cmToum);	  
-		  fillByIndex(h_norm_dxy_ladder_,ladder_num-1,dxyFromMyVertex/s_ip2dpv_err);  
-		  fillByIndex(h_norm_dz_ladder_,ladder_num-1,dzFromMyVertex/dz_err);   
+		  PVValHelper::fillByIndex(h_dz_ladder_,ladder_num-1,dzFromMyVertex*cmToum);	  
+		  PVValHelper::fillByIndex(h_norm_dxy_ladder_,ladder_num-1,dxyFromMyVertex/s_ip2dpv_err);  
+		  PVValHelper::fillByIndex(h_norm_dz_ladder_,ladder_num-1,dzFromMyVertex/dz_err);   
 		  
 		}
 
@@ -938,39 +941,39 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 
 		  if(tracketa >= etaF && tracketa < etaL ){
 
-		    fillByIndex(a_dxyEtaResiduals,i,dxyFromMyVertex*cmToum,"1");
-		    fillByIndex(a_dxEtaResiduals,i,my_dx*cmToum,"2");
-		    fillByIndex(a_dyEtaResiduals,i,my_dy*cmToum,"3");
-		    fillByIndex(a_dzEtaResiduals,i,dzFromMyVertex*cmToum,"4");   
-		    fillByIndex(n_dxyEtaResiduals,i,dxyFromMyVertex/s_ip2dpv_err,"5");
-		    fillByIndex(n_dzEtaResiduals,i,dzFromMyVertex/dz_err,"6");	    
-		    fillByIndex(a_IP2DEtaResiduals,i,s_ip2dpv_corr*cmToum,"7");
-		    fillByIndex(n_IP2DEtaResiduals,i,s_ip2dpv_corr/s_ip2dpv_err,"8");
-		    fillByIndex(a_reszEtaResiduals,i,restrkz*cmToum,"9");
-		    fillByIndex(n_reszEtaResiduals,i,pulltrkz,"10");
-		    fillByIndex(a_d3DEtaResiduals,i,ip3d_corr*cmToum,"11");   
-		    fillByIndex(n_d3DEtaResiduals,i,ip3d_corr/ip3d_err,"12");
-		    fillByIndex(a_IP3DEtaResiduals,i,s_ip3dpv_corr*cmToum,"13");
-		    fillByIndex(n_IP3DEtaResiduals,i,s_ip3dpv_corr/s_ip3dpv_err,"14");
+		    PVValHelper::fillByIndex(a_dxyEtaResiduals,i,dxyFromMyVertex*cmToum,"1");
+		    PVValHelper::fillByIndex(a_dxEtaResiduals,i,my_dx*cmToum,"2");
+		    PVValHelper::fillByIndex(a_dyEtaResiduals,i,my_dy*cmToum,"3");
+		    PVValHelper::fillByIndex(a_dzEtaResiduals,i,dzFromMyVertex*cmToum,"4");   
+		    PVValHelper::fillByIndex(n_dxyEtaResiduals,i,dxyFromMyVertex/s_ip2dpv_err,"5");
+		    PVValHelper::fillByIndex(n_dzEtaResiduals,i,dzFromMyVertex/dz_err,"6");	    
+		    PVValHelper::fillByIndex(a_IP2DEtaResiduals,i,s_ip2dpv_corr*cmToum,"7");
+		    PVValHelper::fillByIndex(n_IP2DEtaResiduals,i,s_ip2dpv_corr/s_ip2dpv_err,"8");
+		    PVValHelper::fillByIndex(a_reszEtaResiduals,i,restrkz*cmToum,"9");
+		    PVValHelper::fillByIndex(n_reszEtaResiduals,i,pulltrkz,"10");
+		    PVValHelper::fillByIndex(a_d3DEtaResiduals,i,ip3d_corr*cmToum,"11");   
+		    PVValHelper::fillByIndex(n_d3DEtaResiduals,i,ip3d_corr/ip3d_err,"12");
+		    PVValHelper::fillByIndex(a_IP3DEtaResiduals,i,s_ip3dpv_corr*cmToum,"13");
+		    PVValHelper::fillByIndex(n_IP3DEtaResiduals,i,s_ip3dpv_corr/s_ip3dpv_err,"14");
 
 		  }
 		  	  
 		  if(trackphi >= phiF && trackphi < phiL ){
 
-		    fillByIndex(a_dxyPhiResiduals,i,dxyFromMyVertex*cmToum,"15");
-		    fillByIndex(a_dxPhiResiduals,i,my_dx*cmToum,"16");
-		    fillByIndex(a_dyPhiResiduals,i,my_dy*cmToum,"17");
-		    fillByIndex(a_dzPhiResiduals,i,dzFromMyVertex*cmToum,"18"); 
-		    fillByIndex(n_dxyPhiResiduals,i,dxyFromMyVertex/s_ip2dpv_err,"19");
-		    fillByIndex(n_dzPhiResiduals,i,dzFromMyVertex/dz_err,"20"); 
-		    fillByIndex(a_IP2DPhiResiduals,i,s_ip2dpv_corr*cmToum,"21");
-		    fillByIndex(n_IP2DPhiResiduals,i,s_ip2dpv_corr/s_ip2dpv_err,"22"); 
-		    fillByIndex(a_reszPhiResiduals,i,restrkz*cmToum,"23");
-		    fillByIndex(n_reszPhiResiduals,i,pulltrkz,"24");
-		    fillByIndex(a_d3DPhiResiduals,i,ip3d_corr*cmToum,"25");   
-		    fillByIndex(n_d3DPhiResiduals,i,ip3d_corr/ip3d_err,"26");
-		    fillByIndex(a_IP3DPhiResiduals,i,s_ip3dpv_corr*cmToum,"27");
-		    fillByIndex(n_IP3DPhiResiduals,i,s_ip3dpv_corr/s_ip3dpv_err,"28");
+		    PVValHelper::fillByIndex(a_dxyPhiResiduals,i,dxyFromMyVertex*cmToum,"15");
+		    PVValHelper::fillByIndex(a_dxPhiResiduals,i,my_dx*cmToum,"16");
+		    PVValHelper::fillByIndex(a_dyPhiResiduals,i,my_dy*cmToum,"17");
+		    PVValHelper::fillByIndex(a_dzPhiResiduals,i,dzFromMyVertex*cmToum,"18"); 
+		    PVValHelper::fillByIndex(n_dxyPhiResiduals,i,dxyFromMyVertex/s_ip2dpv_err,"19");
+		    PVValHelper::fillByIndex(n_dzPhiResiduals,i,dzFromMyVertex/dz_err,"20"); 
+		    PVValHelper::fillByIndex(a_IP2DPhiResiduals,i,s_ip2dpv_corr*cmToum,"21");
+		    PVValHelper::fillByIndex(n_IP2DPhiResiduals,i,s_ip2dpv_corr/s_ip2dpv_err,"22"); 
+		    PVValHelper::fillByIndex(a_reszPhiResiduals,i,restrkz*cmToum,"23");
+		    PVValHelper::fillByIndex(n_reszPhiResiduals,i,pulltrkz,"24");
+		    PVValHelper::fillByIndex(a_d3DPhiResiduals,i,ip3d_corr*cmToum,"25");   
+		    PVValHelper::fillByIndex(n_d3DPhiResiduals,i,ip3d_corr/ip3d_err,"26");
+		    PVValHelper::fillByIndex(a_IP3DPhiResiduals,i,s_ip3dpv_corr*cmToum,"27");
+		    PVValHelper::fillByIndex(n_IP3DPhiResiduals,i,s_ip3dpv_corr/s_ip3dpv_err,"28");
 
 		    for(int j=0; j<nBins_; j++){
 
@@ -1328,56 +1331,56 @@ void PrimaryVertexValidation::beginJob()
   ///////////////////////////////////////////////////////////////////
 
   TFileDirectory AbsTransPhiRes  = fs->mkdir("Abs_Transv_Phi_Residuals");
-  a_dxyPhiResiduals  = bookResidualsHistogram(AbsTransPhiRes,nBins_,pvparams::dxy,pvparams::phi);
-  a_dxPhiResiduals   = bookResidualsHistogram(AbsTransPhiRes,nBins_,pvparams::dx,pvparams::phi);
-  a_dyPhiResiduals   = bookResidualsHistogram(AbsTransPhiRes,nBins_,pvparams::dy,pvparams::phi);  
-  a_IP2DPhiResiduals = bookResidualsHistogram(AbsTransPhiRes,nBins_,pvparams::IP2D,pvparams::phi);
+  a_dxyPhiResiduals  = bookResidualsHistogram(AbsTransPhiRes,nBins_,PVValHelper::dxy,PVValHelper::phi);
+  a_dxPhiResiduals   = bookResidualsHistogram(AbsTransPhiRes,nBins_,PVValHelper::dx,PVValHelper::phi);
+  a_dyPhiResiduals   = bookResidualsHistogram(AbsTransPhiRes,nBins_,PVValHelper::dy,PVValHelper::phi);  
+  a_IP2DPhiResiduals = bookResidualsHistogram(AbsTransPhiRes,nBins_,PVValHelper::IP2D,PVValHelper::phi);
 
   TFileDirectory AbsTransEtaRes  = fs->mkdir("Abs_Transv_Eta_Residuals");
-  a_dxyEtaResiduals  = bookResidualsHistogram(AbsTransEtaRes,nBins_,pvparams::dxy,pvparams::eta);
-  a_dxEtaResiduals   = bookResidualsHistogram(AbsTransEtaRes,nBins_,pvparams::dx,pvparams::eta);
-  a_dyEtaResiduals   = bookResidualsHistogram(AbsTransEtaRes,nBins_,pvparams::dy,pvparams::eta);
-  a_IP2DEtaResiduals = bookResidualsHistogram(AbsTransEtaRes,nBins_,pvparams::IP2D,pvparams::eta);
+  a_dxyEtaResiduals  = bookResidualsHistogram(AbsTransEtaRes,nBins_,PVValHelper::dxy,PVValHelper::eta);
+  a_dxEtaResiduals   = bookResidualsHistogram(AbsTransEtaRes,nBins_,PVValHelper::dx,PVValHelper::eta);
+  a_dyEtaResiduals   = bookResidualsHistogram(AbsTransEtaRes,nBins_,PVValHelper::dy,PVValHelper::eta);
+  a_IP2DEtaResiduals = bookResidualsHistogram(AbsTransEtaRes,nBins_,PVValHelper::IP2D,PVValHelper::eta);
 		 					  
   TFileDirectory AbsLongPhiRes   = fs->mkdir("Abs_Long_Phi_Residuals");
-  a_dzPhiResiduals   = bookResidualsHistogram(AbsLongPhiRes,nBins_,pvparams::dz,pvparams::phi);
-  a_reszPhiResiduals = bookResidualsHistogram(AbsLongPhiRes,nBins_,pvparams::resz,pvparams::phi);
+  a_dzPhiResiduals   = bookResidualsHistogram(AbsLongPhiRes,nBins_,PVValHelper::dz,PVValHelper::phi);
+  a_reszPhiResiduals = bookResidualsHistogram(AbsLongPhiRes,nBins_,PVValHelper::resz,PVValHelper::phi);
 
   TFileDirectory AbsLongEtaRes   = fs->mkdir("Abs_Long_Eta_Residuals");
-  a_dzEtaResiduals   = bookResidualsHistogram(AbsLongEtaRes,nBins_,pvparams::dz,pvparams::eta);
-  a_reszEtaResiduals = bookResidualsHistogram(AbsLongEtaRes,nBins_,pvparams::resz,pvparams::eta);
+  a_dzEtaResiduals   = bookResidualsHistogram(AbsLongEtaRes,nBins_,PVValHelper::dz,PVValHelper::eta);
+  a_reszEtaResiduals = bookResidualsHistogram(AbsLongEtaRes,nBins_,PVValHelper::resz,PVValHelper::eta);
 		 		  
   TFileDirectory Abs3DPhiRes     = fs->mkdir("Abs_3D_Phi_Residuals");
-  a_d3DPhiResiduals  = bookResidualsHistogram(Abs3DPhiRes,nBins_,pvparams::d3D,pvparams::phi);
-  a_IP3DPhiResiduals = bookResidualsHistogram(Abs3DPhiRes,nBins_,pvparams::IP3D,pvparams::phi);
+  a_d3DPhiResiduals  = bookResidualsHistogram(Abs3DPhiRes,nBins_,PVValHelper::d3D,PVValHelper::phi);
+  a_IP3DPhiResiduals = bookResidualsHistogram(Abs3DPhiRes,nBins_,PVValHelper::IP3D,PVValHelper::phi);
 
   TFileDirectory Abs3DEtaRes     = fs->mkdir("Abs_3D_Eta_Residuals");
-  a_d3DEtaResiduals  = bookResidualsHistogram(Abs3DEtaRes ,nBins_,pvparams::d3D,pvparams::eta);
-  a_IP3DEtaResiduals = bookResidualsHistogram(Abs3DEtaRes ,nBins_,pvparams::IP3D,pvparams::eta);
+  a_d3DEtaResiduals  = bookResidualsHistogram(Abs3DEtaRes ,nBins_,PVValHelper::d3D,PVValHelper::eta);
+  a_IP3DEtaResiduals = bookResidualsHistogram(Abs3DEtaRes ,nBins_,PVValHelper::IP3D,PVValHelper::eta);
 
   TFileDirectory NormTransPhiRes = fs->mkdir("Norm_Transv_Phi_Residuals");
-  n_dxyPhiResiduals  = bookResidualsHistogram(NormTransPhiRes,nBins_,pvparams::norm_dxy,pvparams::phi,true);
-  n_IP2DPhiResiduals = bookResidualsHistogram(NormTransPhiRes,nBins_,pvparams::norm_IP2D,pvparams::phi,true);
+  n_dxyPhiResiduals  = bookResidualsHistogram(NormTransPhiRes,nBins_,PVValHelper::norm_dxy,PVValHelper::phi,true);
+  n_IP2DPhiResiduals = bookResidualsHistogram(NormTransPhiRes,nBins_,PVValHelper::norm_IP2D,PVValHelper::phi,true);
 
   TFileDirectory NormTransEtaRes = fs->mkdir("Norm_Transv_Eta_Residuals");
-  n_dxyEtaResiduals  = bookResidualsHistogram(NormTransEtaRes,nBins_,pvparams::norm_dxy,pvparams::eta,true);
-  n_IP2DEtaResiduals = bookResidualsHistogram(NormTransEtaRes,nBins_,pvparams::norm_IP2D,pvparams::eta,true);
+  n_dxyEtaResiduals  = bookResidualsHistogram(NormTransEtaRes,nBins_,PVValHelper::norm_dxy,PVValHelper::eta,true);
+  n_IP2DEtaResiduals = bookResidualsHistogram(NormTransEtaRes,nBins_,PVValHelper::norm_IP2D,PVValHelper::eta,true);
 		 					  
   TFileDirectory NormLongPhiRes  = fs->mkdir("Norm_Long_Phi_Residuals");
-  n_dzPhiResiduals   = bookResidualsHistogram(NormLongPhiRes,nBins_,pvparams::norm_dz,pvparams::phi,true);
-  n_reszPhiResiduals = bookResidualsHistogram(NormLongPhiRes,nBins_,pvparams::norm_resz,pvparams::phi,true);
+  n_dzPhiResiduals   = bookResidualsHistogram(NormLongPhiRes,nBins_,PVValHelper::norm_dz,PVValHelper::phi,true);
+  n_reszPhiResiduals = bookResidualsHistogram(NormLongPhiRes,nBins_,PVValHelper::norm_resz,PVValHelper::phi,true);
 
   TFileDirectory NormLongEtaRes  = fs->mkdir("Norm_Long_Eta_Residuals");
-  n_dzEtaResiduals   = bookResidualsHistogram(NormLongEtaRes,nBins_,pvparams::norm_dz,pvparams::eta,true);
-  n_reszEtaResiduals = bookResidualsHistogram(NormLongEtaRes,nBins_,pvparams::norm_resz,pvparams::eta,true);
+  n_dzEtaResiduals   = bookResidualsHistogram(NormLongEtaRes,nBins_,PVValHelper::norm_dz,PVValHelper::eta,true);
+  n_reszEtaResiduals = bookResidualsHistogram(NormLongEtaRes,nBins_,PVValHelper::norm_resz,PVValHelper::eta,true);
 
   TFileDirectory Norm3DPhiRes    = fs->mkdir("Norm_3D_Phi_Residuals");
-  n_d3DPhiResiduals  = bookResidualsHistogram(Norm3DPhiRes,nBins_,pvparams::norm_d3D,pvparams::phi,true);
-  n_IP3DPhiResiduals = bookResidualsHistogram(Norm3DPhiRes,nBins_,pvparams::norm_IP3D,pvparams::phi,true);
+  n_d3DPhiResiduals  = bookResidualsHistogram(Norm3DPhiRes,nBins_,PVValHelper::norm_d3D,PVValHelper::phi,true);
+  n_IP3DPhiResiduals = bookResidualsHistogram(Norm3DPhiRes,nBins_,PVValHelper::norm_IP3D,PVValHelper::phi,true);
   
   TFileDirectory Norm3DEtaRes    = fs->mkdir("Norm_3D_Eta_Residuals");
-  n_d3DEtaResiduals  = bookResidualsHistogram(Norm3DEtaRes,nBins_,pvparams::norm_d3D,pvparams::eta,true);
-  n_IP3DEtaResiduals = bookResidualsHistogram(Norm3DEtaRes,nBins_,pvparams::norm_IP3D,pvparams::eta,true);
+  n_d3DEtaResiduals  = bookResidualsHistogram(Norm3DEtaRes,nBins_,PVValHelper::norm_d3D,PVValHelper::eta,true);
+  n_IP3DEtaResiduals = bookResidualsHistogram(Norm3DEtaRes,nBins_,PVValHelper::norm_IP3D,PVValHelper::eta,true);
 
   TFileDirectory AbsDoubleDiffRes   = fs->mkdir("Abs_DoubleDiffResiduals");
   TFileDirectory NormDoubleDiffRes  = fs->mkdir("Norm_DoubleDiffResiduals");
@@ -1385,62 +1388,62 @@ void PrimaryVertexValidation::beginJob()
   // book residuals vs pT histograms
   
   TFileDirectory AbsTranspTRes  = fs->mkdir("Abs_Transv_pT_Residuals"); 
-  h_dxy_pT_      = bookResidualsHistogram(AbsTranspTRes,nPtBins_,pvparams::dxy,pvparams::pT);	       
+  h_dxy_pT_      = bookResidualsHistogram(AbsTranspTRes,nPtBins_,PVValHelper::dxy,PVValHelper::pT);	       
 
   TFileDirectory AbsLongpTRes   = fs->mkdir("Abs_Long_pT_Residuals"); 
-  h_dz_pT_       = bookResidualsHistogram(AbsLongpTRes,nPtBins_,pvparams::dz,pvparams::pT);		       
+  h_dz_pT_       = bookResidualsHistogram(AbsLongpTRes,nPtBins_,PVValHelper::dz,PVValHelper::pT);		       
 
   TFileDirectory NormTranspTRes = fs->mkdir("Norm_Transv_pT_Residuals"); 
-  h_norm_dxy_pT_ = bookResidualsHistogram(NormTranspTRes,nPtBins_,pvparams::norm_dxy,pvparams::pT,true);	       
+  h_norm_dxy_pT_ = bookResidualsHistogram(NormTranspTRes,nPtBins_,PVValHelper::norm_dxy,PVValHelper::pT,true);	       
 
   TFileDirectory NormLongpTRes  = fs->mkdir("Norm_Long_pT_Residuals"); 
-  h_norm_dz_pT_  = bookResidualsHistogram(NormLongpTRes,nPtBins_,pvparams::norm_dz,pvparams::pT,true);	       
+  h_norm_dz_pT_  = bookResidualsHistogram(NormLongpTRes,nPtBins_,PVValHelper::norm_dz,PVValHelper::pT,true);	       
 
   // book residuals vs pT histograms in central region (|eta|<1.0)
                
   TFileDirectory AbsTranspTCentralRes  = fs->mkdir("Abs_Transv_pTCentral_Residuals"); 
-  h_dxy_Central_pT_ = bookResidualsHistogram(AbsTranspTCentralRes,nPtBins_,pvparams::dxy,pvparams::pTCentral);       
+  h_dxy_Central_pT_ = bookResidualsHistogram(AbsTranspTCentralRes,nPtBins_,PVValHelper::dxy,PVValHelper::pTCentral);       
 
   TFileDirectory AbsLongpTCentralRes   = fs->mkdir("Abs_Long_pTCentral_Residuals"); 
-  h_dz_Central_pT_  = bookResidualsHistogram(AbsLongpTCentralRes,nPtBins_,pvparams::dz,pvparams::pTCentral);	       
+  h_dz_Central_pT_  = bookResidualsHistogram(AbsLongpTCentralRes,nPtBins_,PVValHelper::dz,PVValHelper::pTCentral);	       
 
   TFileDirectory NormTranspTCentralRes = fs->mkdir("Norm_Transv_pTCentral_Residuals"); 
-  h_norm_dxy_Central_pT_ = bookResidualsHistogram(NormTranspTCentralRes,nPtBins_,pvparams::norm_dxy,pvparams::pTCentral,true);  
+  h_norm_dxy_Central_pT_ = bookResidualsHistogram(NormTranspTCentralRes,nPtBins_,PVValHelper::norm_dxy,PVValHelper::pTCentral,true);  
 
   TFileDirectory NormLongpTCentralRes  = fs->mkdir("Norm_Long_pTCentral_Residuals"); 
-  h_norm_dz_Central_pT_  = bookResidualsHistogram(NormLongpTCentralRes,nPtBins_,pvparams::norm_dz,pvparams::pTCentral,true);   
+  h_norm_dz_Central_pT_  = bookResidualsHistogram(NormLongpTCentralRes,nPtBins_,PVValHelper::norm_dz,PVValHelper::pTCentral,true);   
 
   // book residuals vs module number
   
   TFileDirectory AbsTransModZRes  = fs->mkdir("Abs_Transv_modZ_Residuals"); 
-  h_dxy_modZ_      = bookResidualsHistogram(AbsTransModZRes,8,pvparams::dxy,pvparams::modZ);	       
+  h_dxy_modZ_      = bookResidualsHistogram(AbsTransModZRes,8,PVValHelper::dxy,PVValHelper::modZ);	       
 
   TFileDirectory AbsLongModZRes   = fs->mkdir("Abs_Long_modZ_Residuals"); 
-  h_dz_modZ_       = bookResidualsHistogram(AbsLongModZRes,8,pvparams::dz,pvparams::modZ);		       
+  h_dz_modZ_       = bookResidualsHistogram(AbsLongModZRes,8,PVValHelper::dz,PVValHelper::modZ);		       
 
   TFileDirectory NormTransModZRes = fs->mkdir("Norm_Transv_modZ_Residuals"); 
-  h_norm_dxy_modZ_ = bookResidualsHistogram(NormTransModZRes,8,pvparams::norm_dxy,pvparams::modZ,true);	       
+  h_norm_dxy_modZ_ = bookResidualsHistogram(NormTransModZRes,8,PVValHelper::norm_dxy,PVValHelper::modZ,true);	       
 
   TFileDirectory NormLongModZRes  = fs->mkdir("Norm_Long_modZ_Residuals"); 
-  h_norm_dz_modZ_  = bookResidualsHistogram(NormLongModZRes,8,pvparams::norm_dz,pvparams::modZ,true);	       
+  h_norm_dz_modZ_  = bookResidualsHistogram(NormLongModZRes,8,PVValHelper::norm_dz,PVValHelper::modZ,true);	       
 
   TFileDirectory AbsTransLadderRes  = fs->mkdir("Abs_Transv_ladder_Residuals"); 
-  h_dxy_ladder_ = bookResidualsHistogram(AbsTransLadderRes,nLadders_,pvparams::dxy,pvparams::ladder);
+  h_dxy_ladder_ = bookResidualsHistogram(AbsTransLadderRes,nLadders_,PVValHelper::dxy,PVValHelper::ladder);
 
   TFileDirectory AbsTransLadderResOverlap  = fs->mkdir("Abs_Transv_ladderOverlap_Residuals"); 
-  h_dxy_ladderOverlap_ = bookResidualsHistogram(AbsTransLadderResOverlap,nLadders_,pvparams::dxy,pvparams::ladder);       
+  h_dxy_ladderOverlap_ = bookResidualsHistogram(AbsTransLadderResOverlap,nLadders_,PVValHelper::dxy,PVValHelper::ladder);       
 
   TFileDirectory AbsTransLadderResNoOverlap  = fs->mkdir("Abs_Transv_ladderNoOverlap_Residuals"); 
-  h_dxy_ladderNoOverlap_ = bookResidualsHistogram(AbsTransLadderResNoOverlap,nLadders_,pvparams::dxy,pvparams::ladder);       
+  h_dxy_ladderNoOverlap_ = bookResidualsHistogram(AbsTransLadderResNoOverlap,nLadders_,PVValHelper::dxy,PVValHelper::ladder);       
 
   TFileDirectory AbsLongLadderRes   = fs->mkdir("Abs_Long_ladder_Residuals"); 
-  h_dz_ladder_  = bookResidualsHistogram(AbsLongLadderRes,nLadders_,pvparams::dz,pvparams::ladder);	       
+  h_dz_ladder_  = bookResidualsHistogram(AbsLongLadderRes,nLadders_,PVValHelper::dz,PVValHelper::ladder);	       
 
   TFileDirectory NormTransLadderRes = fs->mkdir("Norm_Transv_ladder_Residuals"); 
-  h_norm_dxy_ladder_ = bookResidualsHistogram(NormTransLadderRes,nLadders_,pvparams::norm_dxy,pvparams::ladder,true);  
+  h_norm_dxy_ladder_ = bookResidualsHistogram(NormTransLadderRes,nLadders_,PVValHelper::norm_dxy,PVValHelper::ladder,true);  
 
   TFileDirectory NormLongLadderRes  = fs->mkdir("Norm_Long_ladder_Residuals"); 
-  h_norm_dz_ladder_  = bookResidualsHistogram(NormLongLadderRes,nLadders_,pvparams::norm_dz,pvparams::ladder,true);   
+  h_norm_dz_ladder_  = bookResidualsHistogram(NormLongLadderRes,nLadders_,PVValHelper::norm_dz,PVValHelper::ladder,true);   
 
 
   // book residuals as function of phi and eta
@@ -1916,16 +1919,28 @@ void PrimaryVertexValidation::beginJob()
   if (useTracksFromRecoVtx_){
 
     TFileDirectory AbsTransPhiBiasRes  = fs->mkdir("Abs_Transv_Phi_BiasResiduals");
+    a_dxyPhiBiasResiduals  = bookResidualsHistogram(AbsTransPhiBiasRes,nBins_,PVValHelper::dxy,PVValHelper::phi);
+
     TFileDirectory AbsTransEtaBiasRes  = fs->mkdir("Abs_Transv_Eta_BiasResiduals");
-    
+    a_dxyEtaBiasResiduals  = bookResidualsHistogram(AbsTransEtaBiasRes,nBins_,PVValHelper::dxy,PVValHelper::eta);
+
     TFileDirectory AbsLongPhiBiasRes   = fs->mkdir("Abs_Long_Phi_BiasResiduals");
+    a_dzPhiBiasResiduals  = bookResidualsHistogram(AbsLongPhiBiasRes,nBins_,PVValHelper::dz,PVValHelper::phi);
+						    
     TFileDirectory AbsLongEtaBiasRes   = fs->mkdir("Abs_Long_Eta_BiasResiduals");
+    a_dzEtaBiasResiduals  = bookResidualsHistogram(AbsLongEtaBiasRes,nBins_,PVValHelper::dz,PVValHelper::eta);
     
     TFileDirectory NormTransPhiBiasRes = fs->mkdir("Norm_Transv_Phi_BiasResiduals");
+    n_dxyPhiBiasResiduals  = bookResidualsHistogram(NormTransPhiBiasRes,nBins_,PVValHelper::dxy,PVValHelper::phi);
+    
     TFileDirectory NormTransEtaBiasRes = fs->mkdir("Norm_Transv_Eta_BiasResiduals");
+    n_dxyEtaBiasResiduals  = bookResidualsHistogram(NormTransEtaBiasRes,nBins_,PVValHelper::dxy,PVValHelper::eta);
     
     TFileDirectory NormLongPhiBiasRes  = fs->mkdir("Norm_Long_Phi_BiasResiduals");
+    n_dzPhiBiasResiduals  = bookResidualsHistogram(NormLongPhiBiasRes,nBins_,PVValHelper::dz,PVValHelper::phi);
+
     TFileDirectory NormLongEtaBiasRes  = fs->mkdir("Norm_Long_Eta_BiasResiduals");
+    n_dzEtaBiasResiduals  = bookResidualsHistogram(NormLongEtaBiasRes,nBins_,PVValHelper::dz,PVValHelper::eta);
     
     TFileDirectory AbsDoubleDiffBiasRes   = fs->mkdir("Abs_DoubleDiffBiasResiduals");
     TFileDirectory NormDoubleDiffBiasRes  = fs->mkdir("Norm_DoubleDiffBiasResiduals");
@@ -1938,37 +1953,37 @@ void PrimaryVertexValidation::beginJob()
       float etaF=-etaOfProbe_+i*etaSect_;
       float etaL=-etaOfProbe_+(i+1)*etaSect_;
       
-      a_dxyPhiBiasResiduals[i] = AbsTransPhiBiasRes.make<TH1F>(Form("histo_dxy_phi_plot%i",i),
-							       Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{xy} [#mum];tracks",phiF,phiL),
-							       mybins_,-dxymax_phi,dxymax_phi);
+      // a_dxyPhiBiasResiduals[i] = AbsTransPhiBiasRes.make<TH1F>(Form("histo_dxy_phi_plot%i",i),
+      // 							       Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{xy} [#mum];tracks",phiF,phiL),
+      // 							       mybins_,-dxymax_phi,dxymax_phi);
 
-      a_dxyEtaBiasResiduals[i] = AbsTransEtaBiasRes.make<TH1F>(Form("histo_dxy_eta_plot%i",i),
-							       Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{xy} [#mum];tracks",etaF,etaL),
-							       mybins_,-dxymax_eta,dxymax_eta);
+      // a_dxyEtaBiasResiduals[i] = AbsTransEtaBiasRes.make<TH1F>(Form("histo_dxy_eta_plot%i",i),
+      // 							       Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{xy} [#mum];tracks",etaF,etaL),
+      // 							       mybins_,-dxymax_eta,dxymax_eta);
       
-      a_dzPhiBiasResiduals[i]  = AbsLongPhiBiasRes.make<TH1F>(Form("histo_dz_phi_plot%i",i),
-							      Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f #circ;d_{z} [#mum];tracks",phiF,phiL),
-							      mybins_,-dzmax_phi,dzmax_phi);
+      // a_dzPhiBiasResiduals[i]  = AbsLongPhiBiasRes.make<TH1F>(Form("histo_dz_phi_plot%i",i),
+      // 							      Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f #circ;d_{z} [#mum];tracks",phiF,phiL),
+      // 							      mybins_,-dzmax_phi,dzmax_phi);
 
-      a_dzEtaBiasResiduals[i]  = AbsLongEtaBiasRes.make<TH1F>(Form("histo_dz_eta_plot%i",i),
-							      Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{z} [#mum];tracks",etaF,etaL),
-							      mybins_,-dzmax_eta,dzmax_eta);
+      // a_dzEtaBiasResiduals[i]  = AbsLongEtaBiasRes.make<TH1F>(Form("histo_dz_eta_plot%i",i),
+      // 							      Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{z} [#mum];tracks",etaF,etaL),
+      // 							      mybins_,-dzmax_eta,dzmax_eta);
       
-      n_dxyPhiBiasResiduals[i] = NormTransPhiBiasRes.make<TH1F>(Form("histo_norm_dxy_phi_plot%i",i),
-								Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{xy}/#sigma_{d_{xy}};tracks",phiF,phiL),
-								mybins_,-dxymax_phi/100.,dxymax_phi/100.);
+      // n_dxyPhiBiasResiduals[i] = NormTransPhiBiasRes.make<TH1F>(Form("histo_norm_dxy_phi_plot%i",i),
+      // 								Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{xy}/#sigma_{d_{xy}};tracks",phiF,phiL),
+      // 								mybins_,-dxymax_phi/100.,dxymax_phi/100.);
 
-      n_dxyEtaBiasResiduals[i] = NormTransEtaBiasRes.make<TH1F>(Form("histo_norm_dxy_eta_plot%i",i),
-								Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{xy}/#sigma_{d_{xy}};tracks",etaF,etaL),
-								mybins_,-dxymax_eta/100.,dxymax_eta/100.);
+      // n_dxyEtaBiasResiduals[i] = NormTransEtaBiasRes.make<TH1F>(Form("histo_norm_dxy_eta_plot%i",i),
+      // 								Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{xy}/#sigma_{d_{xy}};tracks",etaF,etaL),
+      // 								mybins_,-dxymax_eta/100.,dxymax_eta/100.);
       
-      n_dzPhiBiasResiduals[i]  = NormLongPhiBiasRes.make<TH1F>(Form("histo_norm_dz_phi_plot%i",i),
-							       Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{z}/#sigma_{d_{z}};tracks",phiF,phiL),
-							       mybins_,-dzmax_phi/100.,dzmax_phi/100.);
+      // n_dzPhiBiasResiduals[i]  = NormLongPhiBiasRes.make<TH1F>(Form("histo_norm_dz_phi_plot%i",i),
+      // 							       Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{z}/#sigma_{d_{z}};tracks",phiF,phiL),
+      // 							       mybins_,-dzmax_phi/100.,dzmax_phi/100.);
 
-      n_dzEtaBiasResiduals[i]  = NormLongEtaBiasRes.make<TH1F>(Form("histo_norm_dz_eta_plot%i",i),
-							       Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{z}/#sigma_{d_{z}};tracks",etaF,etaL),
-							       mybins_,-dzmax_eta/100.,dzmax_eta/100.);
+      // n_dzEtaBiasResiduals[i]  = NormLongEtaBiasRes.make<TH1F>(Form("histo_norm_dz_eta_plot%i",i),
+      // 							       Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{z}/#sigma_{d_{z}};tracks",etaF,etaL),
+      // 							       mybins_,-dzmax_eta/100.,dzmax_eta/100.);
       
       for ( int j=0; j<nBins_; ++j ) {
 	
@@ -2246,162 +2261,162 @@ void PrimaryVertexValidation::endJob()
 
   if(useTracksFromRecoVtx_){
 
-    fillTrendPlot(a_dxyPhiMeanBiasTrend ,a_dxyPhiBiasResiduals,pvparams::MEAN,"phi");  
-    fillTrendPlot(a_dxyPhiWidthBiasTrend,a_dxyPhiBiasResiduals,pvparams::WIDTH,"phi");
-    fillTrendPlot(a_dzPhiMeanBiasTrend  ,a_dzPhiBiasResiduals ,pvparams::MEAN,"phi");   
-    fillTrendPlot(a_dzPhiWidthBiasTrend ,a_dzPhiBiasResiduals ,pvparams::WIDTH,"phi");  
+    fillTrendPlotByIndex(a_dxyPhiMeanBiasTrend ,a_dxyPhiBiasResiduals,PVValHelper::MEAN);  
+    fillTrendPlotByIndex(a_dxyPhiWidthBiasTrend,a_dxyPhiBiasResiduals,PVValHelper::WIDTH);
+    fillTrendPlotByIndex(a_dzPhiMeanBiasTrend  ,a_dzPhiBiasResiduals ,PVValHelper::MEAN);   
+    fillTrendPlotByIndex(a_dzPhiWidthBiasTrend ,a_dzPhiBiasResiduals ,PVValHelper::WIDTH);  
     
-    fillTrendPlot(a_dxyEtaMeanBiasTrend ,a_dxyEtaBiasResiduals,pvparams::MEAN,"eta"); 
-    fillTrendPlot(a_dxyEtaWidthBiasTrend,a_dxyEtaBiasResiduals,pvparams::WIDTH,"eta");
-    fillTrendPlot(a_dzEtaMeanBiasTrend  ,a_dzEtaBiasResiduals ,pvparams::MEAN,"eta"); 
-    fillTrendPlot(a_dzEtaWidthBiasTrend ,a_dzEtaBiasResiduals ,pvparams::WIDTH,"eta");
+    fillTrendPlotByIndex(a_dxyEtaMeanBiasTrend ,a_dxyEtaBiasResiduals,PVValHelper::MEAN); 
+    fillTrendPlotByIndex(a_dxyEtaWidthBiasTrend,a_dxyEtaBiasResiduals,PVValHelper::WIDTH);
+    fillTrendPlotByIndex(a_dzEtaMeanBiasTrend  ,a_dzEtaBiasResiduals ,PVValHelper::MEAN); 
+    fillTrendPlotByIndex(a_dzEtaWidthBiasTrend ,a_dzEtaBiasResiduals ,PVValHelper::WIDTH);
     
-    fillTrendPlot(n_dxyPhiMeanBiasTrend ,n_dxyPhiBiasResiduals,pvparams::MEAN,"phi"); 
-    fillTrendPlot(n_dxyPhiWidthBiasTrend,n_dxyPhiBiasResiduals,pvparams::WIDTH,"phi");
-    fillTrendPlot(n_dzPhiMeanBiasTrend  ,n_dzPhiBiasResiduals ,pvparams::MEAN,"phi"); 
-    fillTrendPlot(n_dzPhiWidthBiasTrend ,n_dzPhiBiasResiduals ,pvparams::WIDTH,"phi");
+    fillTrendPlotByIndex(n_dxyPhiMeanBiasTrend ,n_dxyPhiBiasResiduals,PVValHelper::MEAN); 
+    fillTrendPlotByIndex(n_dxyPhiWidthBiasTrend,n_dxyPhiBiasResiduals,PVValHelper::WIDTH);
+    fillTrendPlotByIndex(n_dzPhiMeanBiasTrend  ,n_dzPhiBiasResiduals ,PVValHelper::MEAN); 
+    fillTrendPlotByIndex(n_dzPhiWidthBiasTrend ,n_dzPhiBiasResiduals ,PVValHelper::WIDTH);
     
-    fillTrendPlot(n_dxyEtaMeanBiasTrend ,n_dxyEtaBiasResiduals,pvparams::MEAN,"eta"); 
-    fillTrendPlot(n_dxyEtaWidthBiasTrend,n_dxyEtaBiasResiduals,pvparams::WIDTH,"eta");
-    fillTrendPlot(n_dzEtaMeanBiasTrend  ,n_dzEtaBiasResiduals ,pvparams::MEAN,"eta"); 
-    fillTrendPlot(n_dzEtaWidthBiasTrend ,n_dzEtaBiasResiduals ,pvparams::WIDTH,"eta");
+    fillTrendPlotByIndex(n_dxyEtaMeanBiasTrend ,n_dxyEtaBiasResiduals,PVValHelper::MEAN); 
+    fillTrendPlotByIndex(n_dxyEtaWidthBiasTrend,n_dxyEtaBiasResiduals,PVValHelper::WIDTH);
+    fillTrendPlotByIndex(n_dzEtaMeanBiasTrend  ,n_dzEtaBiasResiduals ,PVValHelper::MEAN); 
+    fillTrendPlotByIndex(n_dzEtaWidthBiasTrend ,n_dzEtaBiasResiduals ,PVValHelper::WIDTH);
     
     // medians and MADs	  
     
-    fillTrendPlot(a_dxyPhiMedianBiasTrend,a_dxyPhiBiasResiduals,pvparams::MEDIAN,"phi");  
-    fillTrendPlot(a_dxyPhiMADBiasTrend   ,a_dxyPhiBiasResiduals,pvparams::MAD,"phi"); 
-    fillTrendPlot(a_dzPhiMedianBiasTrend ,a_dzPhiBiasResiduals ,pvparams::MEDIAN,"phi");  
-    fillTrendPlot(a_dzPhiMADBiasTrend    ,a_dzPhiBiasResiduals ,pvparams::MAD,"phi"); 
+    fillTrendPlotByIndex(a_dxyPhiMedianBiasTrend,a_dxyPhiBiasResiduals,PVValHelper::MEDIAN);  
+    fillTrendPlotByIndex(a_dxyPhiMADBiasTrend   ,a_dxyPhiBiasResiduals,PVValHelper::MAD); 
+    fillTrendPlotByIndex(a_dzPhiMedianBiasTrend ,a_dzPhiBiasResiduals ,PVValHelper::MEDIAN);  
+    fillTrendPlotByIndex(a_dzPhiMADBiasTrend    ,a_dzPhiBiasResiduals ,PVValHelper::MAD); 
     
-    fillTrendPlot(a_dxyEtaMedianBiasTrend,a_dxyEtaBiasResiduals,pvparams::MEDIAN,"eta");  
-    fillTrendPlot(a_dxyEtaMADBiasTrend   ,a_dxyEtaBiasResiduals,pvparams::MAD,"eta"); 
-    fillTrendPlot(a_dzEtaMedianBiasTrend ,a_dzEtaBiasResiduals ,pvparams::MEDIAN,"eta");  
-    fillTrendPlot(a_dzEtaMADBiasTrend    ,a_dzEtaBiasResiduals ,pvparams::MAD,"eta"); 
+    fillTrendPlotByIndex(a_dxyEtaMedianBiasTrend,a_dxyEtaBiasResiduals,PVValHelper::MEDIAN);  
+    fillTrendPlotByIndex(a_dxyEtaMADBiasTrend   ,a_dxyEtaBiasResiduals,PVValHelper::MAD); 
+    fillTrendPlotByIndex(a_dzEtaMedianBiasTrend ,a_dzEtaBiasResiduals ,PVValHelper::MEDIAN);  
+    fillTrendPlotByIndex(a_dzEtaMADBiasTrend    ,a_dzEtaBiasResiduals ,PVValHelper::MAD); 
     
-    fillTrendPlot(n_dxyPhiMedianBiasTrend,n_dxyPhiBiasResiduals,pvparams::MEDIAN,"phi");  
-    fillTrendPlot(n_dxyPhiMADBiasTrend   ,n_dxyPhiBiasResiduals,pvparams::MAD,"phi"); 
-    fillTrendPlot(n_dzPhiMedianBiasTrend ,n_dzPhiBiasResiduals ,pvparams::MEDIAN,"phi");  
-    fillTrendPlot(n_dzPhiMADBiasTrend    ,n_dzPhiBiasResiduals ,pvparams::MAD,"phi"); 
+    fillTrendPlotByIndex(n_dxyPhiMedianBiasTrend,n_dxyPhiBiasResiduals,PVValHelper::MEDIAN);  
+    fillTrendPlotByIndex(n_dxyPhiMADBiasTrend   ,n_dxyPhiBiasResiduals,PVValHelper::MAD); 
+    fillTrendPlotByIndex(n_dzPhiMedianBiasTrend ,n_dzPhiBiasResiduals ,PVValHelper::MEDIAN);  
+    fillTrendPlotByIndex(n_dzPhiMADBiasTrend    ,n_dzPhiBiasResiduals ,PVValHelper::MAD); 
     
-    fillTrendPlot(n_dxyEtaMedianBiasTrend,n_dxyEtaBiasResiduals,pvparams::MEDIAN,"eta");  
-    fillTrendPlot(n_dxyEtaMADBiasTrend   ,n_dxyEtaBiasResiduals,pvparams::MAD,"eta"); 
-    fillTrendPlot(n_dzEtaMedianBiasTrend ,n_dzEtaBiasResiduals ,pvparams::MEDIAN,"eta");  
-    fillTrendPlot(n_dzEtaMADBiasTrend    ,n_dzEtaBiasResiduals ,pvparams::MAD,"eta"); 
+    fillTrendPlotByIndex(n_dxyEtaMedianBiasTrend,n_dxyEtaBiasResiduals,PVValHelper::MEDIAN);  
+    fillTrendPlotByIndex(n_dxyEtaMADBiasTrend   ,n_dxyEtaBiasResiduals,PVValHelper::MAD); 
+    fillTrendPlotByIndex(n_dzEtaMedianBiasTrend ,n_dzEtaBiasResiduals ,PVValHelper::MEDIAN);  
+    fillTrendPlotByIndex(n_dzEtaMADBiasTrend    ,n_dzEtaBiasResiduals ,PVValHelper::MAD); 
    
     // 2d Maps
 
-    fillMap(a_dxyMeanBiasMap ,a_dxyBiasResidualsMap,pvparams::MEAN); 
-    fillMap(a_dxyWidthBiasMap,a_dxyBiasResidualsMap,pvparams::WIDTH);
-    fillMap(a_dzMeanBiasMap  ,a_dzBiasResidualsMap,pvparams::MEAN); 
-    fillMap(a_dzWidthBiasMap ,a_dzBiasResidualsMap,pvparams::WIDTH);
+    fillMap(a_dxyMeanBiasMap ,a_dxyBiasResidualsMap,PVValHelper::MEAN); 
+    fillMap(a_dxyWidthBiasMap,a_dxyBiasResidualsMap,PVValHelper::WIDTH);
+    fillMap(a_dzMeanBiasMap  ,a_dzBiasResidualsMap,PVValHelper::MEAN); 
+    fillMap(a_dzWidthBiasMap ,a_dzBiasResidualsMap,PVValHelper::WIDTH);
 
-    fillMap(n_dxyMeanBiasMap ,n_dxyBiasResidualsMap,pvparams::MEAN); 
-    fillMap(n_dxyWidthBiasMap,n_dxyBiasResidualsMap,pvparams::WIDTH);
-    fillMap(n_dzMeanBiasMap  ,n_dzBiasResidualsMap,pvparams::MEAN); 
-    fillMap(n_dzWidthBiasMap ,n_dzBiasResidualsMap,pvparams::WIDTH);
+    fillMap(n_dxyMeanBiasMap ,n_dxyBiasResidualsMap,PVValHelper::MEAN); 
+    fillMap(n_dxyWidthBiasMap,n_dxyBiasResidualsMap,PVValHelper::WIDTH);
+    fillMap(n_dzMeanBiasMap  ,n_dzBiasResidualsMap,PVValHelper::MEAN); 
+    fillMap(n_dzWidthBiasMap ,n_dzBiasResidualsMap,PVValHelper::WIDTH);
    
   }
 
   // do profiles
 
-  fillTrendPlotByIndex(a_dxyPhiMeanTrend, a_dxyPhiResiduals,pvparams::MEAN);  
-  fillTrendPlotByIndex(a_dxyPhiWidthTrend,a_dxyPhiResiduals,pvparams::WIDTH);  
-  fillTrendPlotByIndex(a_dzPhiMeanTrend  ,a_dzPhiResiduals ,pvparams::MEAN);   
-  fillTrendPlotByIndex(a_dzPhiWidthTrend ,a_dzPhiResiduals ,pvparams::WIDTH);  
+  fillTrendPlotByIndex(a_dxyPhiMeanTrend, a_dxyPhiResiduals,PVValHelper::MEAN);  
+  fillTrendPlotByIndex(a_dxyPhiWidthTrend,a_dxyPhiResiduals,PVValHelper::WIDTH);  
+  fillTrendPlotByIndex(a_dzPhiMeanTrend  ,a_dzPhiResiduals ,PVValHelper::MEAN);   
+  fillTrendPlotByIndex(a_dzPhiWidthTrend ,a_dzPhiResiduals ,PVValHelper::WIDTH);  
   
-  fillTrendPlotByIndex(a_dxyEtaMeanTrend ,a_dxyEtaResiduals,pvparams::MEAN); 
-  fillTrendPlotByIndex(a_dxyEtaWidthTrend,a_dxyEtaResiduals,pvparams::WIDTH);
-  fillTrendPlotByIndex(a_dzEtaMeanTrend  ,a_dzEtaResiduals ,pvparams::MEAN); 
-  fillTrendPlotByIndex(a_dzEtaWidthTrend ,a_dzEtaResiduals ,pvparams::WIDTH);
+  fillTrendPlotByIndex(a_dxyEtaMeanTrend ,a_dxyEtaResiduals,PVValHelper::MEAN); 
+  fillTrendPlotByIndex(a_dxyEtaWidthTrend,a_dxyEtaResiduals,PVValHelper::WIDTH);
+  fillTrendPlotByIndex(a_dzEtaMeanTrend  ,a_dzEtaResiduals ,PVValHelper::MEAN); 
+  fillTrendPlotByIndex(a_dzEtaWidthTrend ,a_dzEtaResiduals ,PVValHelper::WIDTH);
   
-  fillTrendPlotByIndex(n_dxyPhiMeanTrend ,n_dxyPhiResiduals,pvparams::MEAN); 
-  fillTrendPlotByIndex(n_dxyPhiWidthTrend,n_dxyPhiResiduals,pvparams::WIDTH);
-  fillTrendPlotByIndex(n_dzPhiMeanTrend  ,n_dzPhiResiduals ,pvparams::MEAN); 
-  fillTrendPlotByIndex(n_dzPhiWidthTrend ,n_dzPhiResiduals ,pvparams::WIDTH);
+  fillTrendPlotByIndex(n_dxyPhiMeanTrend ,n_dxyPhiResiduals,PVValHelper::MEAN); 
+  fillTrendPlotByIndex(n_dxyPhiWidthTrend,n_dxyPhiResiduals,PVValHelper::WIDTH);
+  fillTrendPlotByIndex(n_dzPhiMeanTrend  ,n_dzPhiResiduals ,PVValHelper::MEAN); 
+  fillTrendPlotByIndex(n_dzPhiWidthTrend ,n_dzPhiResiduals ,PVValHelper::WIDTH);
   
-  fillTrendPlotByIndex(n_dxyEtaMeanTrend ,n_dxyEtaResiduals,pvparams::MEAN); 
-  fillTrendPlotByIndex(n_dxyEtaWidthTrend,n_dxyEtaResiduals,pvparams::WIDTH);
-  fillTrendPlotByIndex(n_dzEtaMeanTrend  ,n_dzEtaResiduals ,pvparams::MEAN); 
-  fillTrendPlotByIndex(n_dzEtaWidthTrend ,n_dzEtaResiduals ,pvparams::WIDTH);
+  fillTrendPlotByIndex(n_dxyEtaMeanTrend ,n_dxyEtaResiduals,PVValHelper::MEAN); 
+  fillTrendPlotByIndex(n_dxyEtaWidthTrend,n_dxyEtaResiduals,PVValHelper::WIDTH);
+  fillTrendPlotByIndex(n_dzEtaMeanTrend  ,n_dzEtaResiduals ,PVValHelper::MEAN); 
+  fillTrendPlotByIndex(n_dzEtaWidthTrend ,n_dzEtaResiduals ,PVValHelper::WIDTH);
     
   // vs transverse momentum
 
-  fillTrendPlotByIndex(a_dxypTMeanTrend ,h_dxy_pT_,pvparams::MEAN );  
-  fillTrendPlotByIndex(a_dxypTWidthTrend,h_dxy_pT_,pvparams::WIDTH);
-  fillTrendPlotByIndex(a_dzpTMeanTrend  ,h_dz_pT_ ,pvparams::MEAN );   
-  fillTrendPlotByIndex(a_dzpTWidthTrend ,h_dz_pT_ ,pvparams::WIDTH);  
+  fillTrendPlotByIndex(a_dxypTMeanTrend ,h_dxy_pT_,PVValHelper::MEAN );  
+  fillTrendPlotByIndex(a_dxypTWidthTrend,h_dxy_pT_,PVValHelper::WIDTH);
+  fillTrendPlotByIndex(a_dzpTMeanTrend  ,h_dz_pT_ ,PVValHelper::MEAN );   
+  fillTrendPlotByIndex(a_dzpTWidthTrend ,h_dz_pT_ ,PVValHelper::WIDTH);  
   
-  fillTrendPlotByIndex(a_dxypTCentralMeanTrend ,h_dxy_Central_pT_,pvparams::MEAN ); 
-  fillTrendPlotByIndex(a_dxypTCentralWidthTrend,h_dxy_Central_pT_,pvparams::WIDTH);
-  fillTrendPlotByIndex(a_dzpTCentralMeanTrend  ,h_dz_Central_pT_ ,pvparams::MEAN ); 
-  fillTrendPlotByIndex(a_dzpTCentralWidthTrend ,h_dz_Central_pT_ ,pvparams::WIDTH);
+  fillTrendPlotByIndex(a_dxypTCentralMeanTrend ,h_dxy_Central_pT_,PVValHelper::MEAN ); 
+  fillTrendPlotByIndex(a_dxypTCentralWidthTrend,h_dxy_Central_pT_,PVValHelper::WIDTH);
+  fillTrendPlotByIndex(a_dzpTCentralMeanTrend  ,h_dz_Central_pT_ ,PVValHelper::MEAN ); 
+  fillTrendPlotByIndex(a_dzpTCentralWidthTrend ,h_dz_Central_pT_ ,PVValHelper::WIDTH);
   
-  fillTrendPlotByIndex(n_dxypTMeanTrend ,h_norm_dxy_pT_,pvparams::MEAN ); 
-  fillTrendPlotByIndex(n_dxypTWidthTrend,h_norm_dxy_pT_,pvparams::WIDTH);
-  fillTrendPlotByIndex(n_dzpTMeanTrend  ,h_norm_dz_pT_ ,pvparams::MEAN ); 
-  fillTrendPlotByIndex(n_dzpTWidthTrend ,h_norm_dz_pT_ ,pvparams::WIDTH);
+  fillTrendPlotByIndex(n_dxypTMeanTrend ,h_norm_dxy_pT_,PVValHelper::MEAN ); 
+  fillTrendPlotByIndex(n_dxypTWidthTrend,h_norm_dxy_pT_,PVValHelper::WIDTH);
+  fillTrendPlotByIndex(n_dzpTMeanTrend  ,h_norm_dz_pT_ ,PVValHelper::MEAN ); 
+  fillTrendPlotByIndex(n_dzpTWidthTrend ,h_norm_dz_pT_ ,PVValHelper::WIDTH);
   
-  fillTrendPlotByIndex(n_dxypTCentralMeanTrend ,h_norm_dxy_Central_pT_,pvparams::MEAN ); 
-  fillTrendPlotByIndex(n_dxypTCentralWidthTrend,h_norm_dxy_Central_pT_,pvparams::WIDTH);
-  fillTrendPlotByIndex(n_dzpTCentralMeanTrend  ,h_norm_dz_Central_pT_ ,pvparams::MEAN ); 
-  fillTrendPlotByIndex(n_dzpTCentralWidthTrend ,h_norm_dz_Central_pT_ ,pvparams::WIDTH);
+  fillTrendPlotByIndex(n_dxypTCentralMeanTrend ,h_norm_dxy_Central_pT_,PVValHelper::MEAN ); 
+  fillTrendPlotByIndex(n_dxypTCentralWidthTrend,h_norm_dxy_Central_pT_,PVValHelper::WIDTH);
+  fillTrendPlotByIndex(n_dzpTCentralMeanTrend  ,h_norm_dz_Central_pT_ ,PVValHelper::MEAN ); 
+  fillTrendPlotByIndex(n_dzpTCentralWidthTrend ,h_norm_dz_Central_pT_ ,PVValHelper::WIDTH);
 
   // vs ladder and module number
 
-  fillTrendPlotByIndex(a_dxymodZMeanTrend   ,h_dxy_modZ_,pvparams::MEAN);  
-  fillTrendPlotByIndex(a_dxymodZWidthTrend  ,h_dxy_modZ_,pvparams::WIDTH);
-  fillTrendPlotByIndex(a_dzmodZMeanTrend    ,h_dz_modZ_,pvparams::MEAN);   
-  fillTrendPlotByIndex(a_dzmodZWidthTrend   ,h_dz_modZ_,pvparams::WIDTH);  
+  fillTrendPlotByIndex(a_dxymodZMeanTrend   ,h_dxy_modZ_,PVValHelper::MEAN);  
+  fillTrendPlotByIndex(a_dxymodZWidthTrend  ,h_dxy_modZ_,PVValHelper::WIDTH);
+  fillTrendPlotByIndex(a_dzmodZMeanTrend    ,h_dz_modZ_,PVValHelper::MEAN);   
+  fillTrendPlotByIndex(a_dzmodZWidthTrend   ,h_dz_modZ_,PVValHelper::WIDTH);  
   		       		      
-  fillTrendPlotByIndex(a_dxyladderMeanTrend ,h_dxy_ladder_,pvparams::MEAN); 
-  fillTrendPlotByIndex(a_dxyladderWidthTrend,h_dxy_ladder_,pvparams::WIDTH);
-  fillTrendPlotByIndex(a_dzladderMeanTrend  ,h_dz_ladder_,pvparams::MEAN); 
-  fillTrendPlotByIndex(a_dzladderWidthTrend ,h_dz_ladder_,pvparams::WIDTH);
+  fillTrendPlotByIndex(a_dxyladderMeanTrend ,h_dxy_ladder_,PVValHelper::MEAN); 
+  fillTrendPlotByIndex(a_dxyladderWidthTrend,h_dxy_ladder_,PVValHelper::WIDTH);
+  fillTrendPlotByIndex(a_dzladderMeanTrend  ,h_dz_ladder_,PVValHelper::MEAN); 
+  fillTrendPlotByIndex(a_dzladderWidthTrend ,h_dz_ladder_,PVValHelper::WIDTH);
   		       		      
-  fillTrendPlotByIndex(n_dxymodZMeanTrend   ,h_norm_dxy_modZ_,pvparams::MEAN); 
-  fillTrendPlotByIndex(n_dxymodZWidthTrend  ,h_norm_dxy_modZ_,pvparams::WIDTH);
-  fillTrendPlotByIndex(n_dzmodZMeanTrend    ,h_norm_dz_modZ_,pvparams::MEAN); 
-  fillTrendPlotByIndex(n_dzmodZWidthTrend   ,h_norm_dz_modZ_,pvparams::WIDTH);
+  fillTrendPlotByIndex(n_dxymodZMeanTrend   ,h_norm_dxy_modZ_,PVValHelper::MEAN); 
+  fillTrendPlotByIndex(n_dxymodZWidthTrend  ,h_norm_dxy_modZ_,PVValHelper::WIDTH);
+  fillTrendPlotByIndex(n_dzmodZMeanTrend    ,h_norm_dz_modZ_,PVValHelper::MEAN); 
+  fillTrendPlotByIndex(n_dzmodZWidthTrend   ,h_norm_dz_modZ_,PVValHelper::WIDTH);
   		       		      
-  fillTrendPlotByIndex(n_dxyladderMeanTrend ,h_norm_dxy_ladder_,pvparams::MEAN); 
-  fillTrendPlotByIndex(n_dxyladderWidthTrend,h_norm_dxy_ladder_,pvparams::WIDTH);
-  fillTrendPlotByIndex(n_dzladderMeanTrend  ,h_norm_dz_ladder_,pvparams::MEAN); 
-  fillTrendPlotByIndex(n_dzladderWidthTrend ,h_norm_dz_ladder_,pvparams::WIDTH);
+  fillTrendPlotByIndex(n_dxyladderMeanTrend ,h_norm_dxy_ladder_,PVValHelper::MEAN); 
+  fillTrendPlotByIndex(n_dxyladderWidthTrend,h_norm_dxy_ladder_,PVValHelper::WIDTH);
+  fillTrendPlotByIndex(n_dzladderMeanTrend  ,h_norm_dz_ladder_,PVValHelper::MEAN); 
+  fillTrendPlotByIndex(n_dzladderWidthTrend ,h_norm_dz_ladder_,PVValHelper::WIDTH);
 
   // medians and MADs	  
   
-  fillTrendPlotByIndex(a_dxyPhiMedianTrend,a_dxyPhiResiduals,pvparams::MEDIAN);
-  fillTrendPlotByIndex(a_dxyPhiMADTrend   ,a_dxyPhiResiduals,pvparams::MAD);   
+  fillTrendPlotByIndex(a_dxyPhiMedianTrend,a_dxyPhiResiduals,PVValHelper::MEDIAN);
+  fillTrendPlotByIndex(a_dxyPhiMADTrend   ,a_dxyPhiResiduals,PVValHelper::MAD);   
   
-  fillTrendPlotByIndex(a_dzPhiMedianTrend ,a_dzPhiResiduals ,pvparams::MEDIAN);  
-  fillTrendPlotByIndex(a_dzPhiMADTrend    ,a_dzPhiResiduals ,pvparams::MAD); 
+  fillTrendPlotByIndex(a_dzPhiMedianTrend ,a_dzPhiResiduals ,PVValHelper::MEDIAN);  
+  fillTrendPlotByIndex(a_dzPhiMADTrend    ,a_dzPhiResiduals ,PVValHelper::MAD); 
   
-  fillTrendPlotByIndex(a_dxyEtaMedianTrend,a_dxyEtaResiduals,pvparams::MEDIAN);  
-  fillTrendPlotByIndex(a_dxyEtaMADTrend   ,a_dxyEtaResiduals,pvparams::MAD); 
-  fillTrendPlotByIndex(a_dzEtaMedianTrend ,a_dzEtaResiduals ,pvparams::MEDIAN);  
-  fillTrendPlotByIndex(a_dzEtaMADTrend    ,a_dzEtaResiduals ,pvparams::MAD); 
+  fillTrendPlotByIndex(a_dxyEtaMedianTrend,a_dxyEtaResiduals,PVValHelper::MEDIAN);  
+  fillTrendPlotByIndex(a_dxyEtaMADTrend   ,a_dxyEtaResiduals,PVValHelper::MAD); 
+  fillTrendPlotByIndex(a_dzEtaMedianTrend ,a_dzEtaResiduals ,PVValHelper::MEDIAN);  
+  fillTrendPlotByIndex(a_dzEtaMADTrend    ,a_dzEtaResiduals ,PVValHelper::MAD); 
   
-  fillTrendPlotByIndex(n_dxyPhiMedianTrend,n_dxyPhiResiduals,pvparams::MEDIAN);  
-  fillTrendPlotByIndex(n_dxyPhiMADTrend   ,n_dxyPhiResiduals,pvparams::MAD); 
-  fillTrendPlotByIndex(n_dzPhiMedianTrend ,n_dzPhiResiduals ,pvparams::MEDIAN);  
-  fillTrendPlotByIndex(n_dzPhiMADTrend    ,n_dzPhiResiduals ,pvparams::MAD); 
+  fillTrendPlotByIndex(n_dxyPhiMedianTrend,n_dxyPhiResiduals,PVValHelper::MEDIAN);  
+  fillTrendPlotByIndex(n_dxyPhiMADTrend   ,n_dxyPhiResiduals,PVValHelper::MAD); 
+  fillTrendPlotByIndex(n_dzPhiMedianTrend ,n_dzPhiResiduals ,PVValHelper::MEDIAN);  
+  fillTrendPlotByIndex(n_dzPhiMADTrend    ,n_dzPhiResiduals ,PVValHelper::MAD); 
   
-  fillTrendPlotByIndex(n_dxyEtaMedianTrend,n_dxyEtaResiduals,pvparams::MEDIAN);  
-  fillTrendPlotByIndex(n_dxyEtaMADTrend   ,n_dxyEtaResiduals,pvparams::MAD); 
-  fillTrendPlotByIndex(n_dzEtaMedianTrend ,n_dzEtaResiduals ,pvparams::MEDIAN);  
-  fillTrendPlotByIndex(n_dzEtaMADTrend    ,n_dzEtaResiduals ,pvparams::MAD); 
+  fillTrendPlotByIndex(n_dxyEtaMedianTrend,n_dxyEtaResiduals,PVValHelper::MEDIAN);  
+  fillTrendPlotByIndex(n_dxyEtaMADTrend   ,n_dxyEtaResiduals,PVValHelper::MAD); 
+  fillTrendPlotByIndex(n_dzEtaMedianTrend ,n_dzEtaResiduals ,PVValHelper::MEDIAN);  
+  fillTrendPlotByIndex(n_dzEtaMADTrend    ,n_dzEtaResiduals ,PVValHelper::MAD); 
     
   // 2D Maps
 
-  fillMap(a_dxyMeanMap ,a_dxyResidualsMap,pvparams::MEAN); 
-  fillMap(a_dxyWidthMap,a_dxyResidualsMap,pvparams::WIDTH);
-  fillMap(a_dzMeanMap  ,a_dzResidualsMap,pvparams::MEAN); 
-  fillMap(a_dzWidthMap ,a_dzResidualsMap,pvparams::WIDTH);
+  fillMap(a_dxyMeanMap ,a_dxyResidualsMap,PVValHelper::MEAN); 
+  fillMap(a_dxyWidthMap,a_dxyResidualsMap,PVValHelper::WIDTH);
+  fillMap(a_dzMeanMap  ,a_dzResidualsMap,PVValHelper::MEAN); 
+  fillMap(a_dzWidthMap ,a_dzResidualsMap,PVValHelper::WIDTH);
   
-  fillMap(n_dxyMeanMap ,n_dxyResidualsMap,pvparams::MEAN); 
-  fillMap(n_dxyWidthMap,n_dxyResidualsMap,pvparams::WIDTH);
-  fillMap(n_dzMeanMap  ,n_dzResidualsMap,pvparams::MEAN); 
-  fillMap(n_dzWidthMap ,n_dzResidualsMap,pvparams::WIDTH);
+  fillMap(n_dxyMeanMap ,n_dxyResidualsMap,PVValHelper::MEAN); 
+  fillMap(n_dxyWidthMap,n_dxyResidualsMap,PVValHelper::WIDTH);
+  fillMap(n_dzMeanMap  ,n_dzResidualsMap,PVValHelper::MEAN); 
+  fillMap(n_dzWidthMap ,n_dzResidualsMap,PVValHelper::WIDTH);
 
 }
 
@@ -2591,7 +2606,7 @@ std::pair<Measurement1D, Measurement1D> PrimaryVertexValidation::fitResiduals(TH
 }
 
 //*************************************************************
-void PrimaryVertexValidation::fillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot[100], statmode::estimator fitPar_,const std::string& var_)
+void PrimaryVertexValidation::fillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot[100], PVValHelper::estimator fitPar_, const std::string& var_)
 //*************************************************************
 {
    
@@ -2608,7 +2623,7 @@ void PrimaryVertexValidation::fillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot
     
     switch(fitPar_)
       {
-      case pvparams::MEAN:
+      case PVValHelper::MEAN:
 	{
 	  float mean_      = fitResiduals(residualsPlot[i]).first.value();
 	  float meanErr_   = fitResiduals(residualsPlot[i]).first.error();
@@ -2616,7 +2631,7 @@ void PrimaryVertexValidation::fillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot
 	  trendPlot->SetBinError(i+1,meanErr_);
 	  break;
 	} 
-      case pvparams::WIDTH:
+      case PVValHelper::WIDTH:
 	{
 	  float width_     = fitResiduals(residualsPlot[i]).second.value();
 	  float widthErr_  = fitResiduals(residualsPlot[i]).second.error();
@@ -2624,7 +2639,7 @@ void PrimaryVertexValidation::fillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot
 	  trendPlot->SetBinError(i+1,widthErr_);
 	  break;
 	}
-      case pvparams::MEDIAN:
+      case PVValHelper::MEDIAN:
 	{
 	  float median_    = getMedian(residualsPlot[i]).value();
 	  float medianErr_ = getMedian(residualsPlot[i]).error();
@@ -2632,7 +2647,7 @@ void PrimaryVertexValidation::fillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot
 	  trendPlot->SetBinError(i+1,medianErr_);
 	  break;
 	} 
-      case pvparams::MAD:
+      case PVValHelper::MAD:
 	{
 	  float mad_       = getMAD(residualsPlot[i]).value(); 
 	  float madErr_    = getMAD(residualsPlot[i]).error();
@@ -2656,7 +2671,7 @@ void PrimaryVertexValidation::fillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot
 }
 
 //*************************************************************
-void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,std::vector<TH1F*>& h,  pvparams::estimator fitPar_)
+void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,std::vector<TH1F*>& h,  PVValHelper::estimator fitPar_)
 //*************************************************************
 {  
 
@@ -2667,7 +2682,7 @@ void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,std::vector<T
 
     switch(fitPar_)
       {
-      case pvparams::MEAN: 
+      case PVValHelper::MEAN: 
 	{   
 	  float mean_      = myFit.first.value();
 	  float meanErr_   = myFit.first.error();
@@ -2675,7 +2690,7 @@ void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,std::vector<T
 	  trendPlot->SetBinError(bin,meanErr_);
 	  break;
 	}
-      case pvparams::WIDTH:
+      case PVValHelper::WIDTH:
 	{
 	  float width_     = myFit.second.value();
 	  float widthErr_  = myFit.second.error();
@@ -2683,7 +2698,7 @@ void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,std::vector<T
 	  trendPlot->SetBinError(bin,widthErr_);
 	  break;
 	}
-      case pvparams::MEDIAN:
+      case PVValHelper::MEDIAN:
 	{
 	  float median_    = getMedian(*iterator).value();
 	  float medianErr_ = getMedian(*iterator).error();
@@ -2691,7 +2706,7 @@ void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,std::vector<T
 	  trendPlot->SetBinError(bin,medianErr_);
 	  break;
 	}
-      case pvparams::MAD:
+      case PVValHelper::MAD:
 	{
 	  float mad_       = getMAD(*iterator).value(); 
 	  float madErr_    = getMAD(*iterator).error();
@@ -2707,7 +2722,7 @@ void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,std::vector<T
 }
 
 //*************************************************************
-void PrimaryVertexValidation::fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100][100],  pvparams::estimator fitPar_)
+void PrimaryVertexValidation::fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100][100],  PVValHelper::estimator fitPar_)
 //*************************************************************
 {
  
@@ -2730,7 +2745,7 @@ void PrimaryVertexValidation::fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100
 
       switch (fitPar_)
 	{ 
-	case pvparams::MEAN:
+	case PVValHelper::MEAN:
 	  {
 	    float mean_      = fitResiduals(residualsMapPlot[i][j]).first.value();
 	    float meanErr_   = fitResiduals(residualsMapPlot[i][j]).first.error();
@@ -2738,7 +2753,7 @@ void PrimaryVertexValidation::fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100
 	    trendMap->SetBinError(j+1,i+1,meanErr_);
 	    break;
 	  }
-	case pvparams::WIDTH:
+	case PVValHelper::WIDTH:
 	  {
 	    float width_     = fitResiduals(residualsMapPlot[i][j]).second.value();
 	    float widthErr_  = fitResiduals(residualsMapPlot[i][j]).second.error();
@@ -2746,7 +2761,7 @@ void PrimaryVertexValidation::fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100
 	    trendMap->SetBinError(j+1,i+1,widthErr_);
 	    break;
 	  }     
-	case pvparams::MEDIAN:
+	case PVValHelper::MEDIAN:
 	  {
 	    float median_    = getMedian(residualsMapPlot[i][j]).value();
 	    float medianErr_ = getMedian(residualsMapPlot[i][j]).error();
@@ -2754,7 +2769,7 @@ void PrimaryVertexValidation::fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100
 	    trendMap->SetBinError(j+1,i+1,medianErr_);
 	    break;
 	  }     
-	case pvparams::MAD:
+	case PVValHelper::MAD:
 	  {
 	    float mad_       = getMAD(residualsMapPlot[i][j]).value(); 
 	    float madErr_    = getMAD(residualsMapPlot[i][j]).error();
@@ -2863,8 +2878,8 @@ std::map<std::string, TH1*> PrimaryVertexValidation::bookVertexHistograms(const 
 //*************************************************************
 std::vector<TH1F*> PrimaryVertexValidation::bookResidualsHistogram(const TFileDirectory& dir,
 								   unsigned int theNOfBins,
-								   pvparams::residualType resType,
-								   pvparams::plotVariable varType,
+								   PVValHelper::residualType resType,
+								   PVValHelper::plotVariable varType,
 								   bool isNormalized){
 
   TH1F::SetDefaultSumw2(kTRUE);
@@ -2887,12 +2902,12 @@ std::vector<TH1F*> PrimaryVertexValidation::bookResidualsHistogram(const TFileDi
     assert(false);
   }
   
-  std::string s_resType = std::get<0>(this->getTypeString(resType));
-  std::string s_varType = std::get<0>(this->getVarString(varType));
+  std::string s_resType = std::get<0>(PVValHelper::getTypeString(resType));
+  std::string s_varType = std::get<0>(PVValHelper::getVarString(varType));
       
-  std::string t_resType = std::get<1>(this->getTypeString(resType));
-  std::string t_varType = std::get<1>(this->getVarString(varType));
-  std::string units     = std::get<2>(this->getTypeString(resType));
+  std::string t_resType = std::get<1>(PVValHelper::getTypeString(resType));
+  std::string t_varType = std::get<1>(PVValHelper::getVarString(varType));
+  std::string units     = std::get<2>(PVValHelper::getTypeString(resType));
 
   for(unsigned int i=0; i<theNOfBins;i++){
     TH1F* htemp = dir.make<TH1F>(Form("histo_%s_%s_plot%i",s_resType.c_str(),s_varType.c_str(),i),
@@ -2912,39 +2927,39 @@ void PrimaryVertexValidation::fillTrackHistos(std::map<std::string, TH1*> & h, c
 
   using namespace reco;
 
-  fill(h,"pseudorapidity_"+ttype,tt->track().eta());
-  fill(h,"z0_"+ttype,tt->track().vz());
-  fill(h,"phi_"+ttype,tt->track().phi());
-  fill(h,"eta_"+ttype,tt->track().eta());
-  fill(h,"pt_"+ttype,tt->track().pt());
-  fill(h,"p_"+ttype,tt->track().p());
-  fill(h,"found_"+ttype,tt->track().found());
-  fill(h,"lost_"+ttype,tt->track().lost());
-  fill(h,"nchi2_"+ttype,tt->track().normalizedChi2());
-  fill(h,"rstart_"+ttype,(tt->track().innerPosition()).Rho());
+  PVValHelper::fill(h,"pseudorapidity_"+ttype,tt->track().eta());
+  PVValHelper::fill(h,"z0_"+ttype,tt->track().vz());
+  PVValHelper::fill(h,"phi_"+ttype,tt->track().phi());
+  PVValHelper::fill(h,"eta_"+ttype,tt->track().eta());
+  PVValHelper::fill(h,"pt_"+ttype,tt->track().pt());
+  PVValHelper::fill(h,"p_"+ttype,tt->track().p());
+  PVValHelper::fill(h,"found_"+ttype,tt->track().found());
+  PVValHelper::fill(h,"lost_"+ttype,tt->track().lost());
+  PVValHelper::fill(h,"nchi2_"+ttype,tt->track().normalizedChi2());
+  PVValHelper::fill(h,"rstart_"+ttype,(tt->track().innerPosition()).Rho());
   
   double d0Error=tt->track().d0Error();
   double d0=tt->track().dxy(beamSpot.position());
   double dz=tt->track().dz(beamSpot.position());
   if (d0Error>0){
-    fill(h,"logtresxy_"+ttype,log(d0Error/0.0001)/log(10.));
-    fill(h,"tpullxy_"+ttype,d0/d0Error);
-    fill(h,"tlogDCAxy_"+ttype,log(std::abs(d0/d0Error)));
+    PVValHelper::fill(h,"logtresxy_"+ttype,log(d0Error/0.0001)/log(10.));
+    PVValHelper::fill(h,"tpullxy_"+ttype,d0/d0Error);
+    PVValHelper::fill(h,"tlogDCAxy_"+ttype,log(std::abs(d0/d0Error)));
     
   }
   //double z0=tt->track().vz();
   double dzError=tt->track().dzError();
   if(dzError>0){
-    fill(h,"logtresz_"+ttype,log(dzError/0.0001)/log(10.));
-    fill(h,"tpullz_"+ttype,dz/dzError);
-    fill(h,"tlogDCAz_"+ttype,log(std::abs(dz/dzError)));
+    PVValHelper::fill(h,"logtresz_"+ttype,log(dzError/0.0001)/log(10.));
+    PVValHelper::fill(h,"tpullz_"+ttype,dz/dzError);
+    PVValHelper::fill(h,"tlogDCAz_"+ttype,log(std::abs(dz/dzError)));
   }
   
   //
   double wxy2_=pow(beamSpot.BeamWidthX(),2)+pow(beamSpot.BeamWidthY(),2);
 
-  fill(h,"sigmatrkz_"+ttype,sqrt(pow(tt->track().dzError(),2)+wxy2_/pow(tan(tt->track().theta()),2)));
-  fill(h,"sigmatrkz0_"+ttype,tt->track().dzError());
+  PVValHelper::fill(h,"sigmatrkz_"+ttype,sqrt(pow(tt->track().dzError(),2)+wxy2_/pow(tan(tt->track().theta()),2)));
+  PVValHelper::fill(h,"sigmatrkz0_"+ttype,tt->track().dzError());
   
   // track vs vertex
   if( v.isValid()){ // && (v.ndof()<10.)) {
@@ -2956,13 +2971,13 @@ void PrimaryVertexValidation::fillTrackHistos(std::map<std::string, TH1*> & h, c
     double tantheta=tan((tt->stateAtBeamLine().trackStateAtPCA()).momentum().theta());
     double dz2= pow(tt->track().dzError(),2)+wxy2_/pow(tantheta,2);
     
-    fill(h,"restrkz_"+ttype,z-v.position().z());
-    fill(h,"restrkzvsphi_"+ttype,tt->track().phi(), z-v.position().z());
-    fill(h,"restrkzvseta_"+ttype,tt->track().eta(), z-v.position().z());
-    fill(h,"pulltrkzvsphi_"+ttype,tt->track().phi(), (z-v.position().z())/sqrt(dz2));
-    fill(h,"pulltrkzvseta_"+ttype,tt->track().eta(), (z-v.position().z())/sqrt(dz2));
+    PVValHelper::fill(h,"restrkz_"+ttype,z-v.position().z());
+    PVValHelper::fill(h,"restrkzvsphi_"+ttype,tt->track().phi(), z-v.position().z());
+    PVValHelper::fill(h,"restrkzvseta_"+ttype,tt->track().eta(), z-v.position().z());
+    PVValHelper::fill(h,"pulltrkzvsphi_"+ttype,tt->track().phi(), (z-v.position().z())/sqrt(dz2));
+    PVValHelper::fill(h,"pulltrkzvseta_"+ttype,tt->track().eta(), (z-v.position().z())/sqrt(dz2));
     
-    fill(h,"pulltrkz_"+ttype,(z-v.position().z())/sqrt(dz2));
+    PVValHelper::fill(h,"pulltrkz_"+ttype,(z-v.position().z())/sqrt(dz2));
     
     double x1=tt->track().vx()-beamSpot.x0(); double y1=tt->track().vy()-beamSpot.y0();
     
@@ -2984,13 +2999,13 @@ void PrimaryVertexValidation::fillTrackHistos(std::map<std::string, TH1*> & h, c
   //
   
   // collect some info on hits and clusters
-  fill(h,"nbarrelLayers_"+ttype,tt->track().hitPattern().pixelBarrelLayersWithMeasurement());
-  fill(h,"nPxLayers_"+ttype,tt->track().hitPattern().pixelLayersWithMeasurement());
-  fill(h,"nSiLayers_"+ttype,tt->track().hitPattern().trackerLayersWithMeasurement());
-  fill(h,"expectedInner_"+ttype,tt->track().hitPattern().numberOfHits(HitPattern::MISSING_INNER_HITS));
-  fill(h,"expectedOuter_"+ttype,tt->track().hitPattern().numberOfHits(HitPattern::MISSING_OUTER_HITS));
-  fill(h,"trackAlgo_"+ttype,tt->track().algo());
-  fill(h,"trackQuality_"+ttype,tt->track().qualityMask());
+  PVValHelper::fill(h,"nbarrelLayers_"+ttype,tt->track().hitPattern().pixelBarrelLayersWithMeasurement());
+  PVValHelper::fill(h,"nPxLayers_"+ttype,tt->track().hitPattern().pixelLayersWithMeasurement());
+  PVValHelper::fill(h,"nSiLayers_"+ttype,tt->track().hitPattern().trackerLayersWithMeasurement());
+  PVValHelper::fill(h,"expectedInner_"+ttype,tt->track().hitPattern().numberOfHits(HitPattern::MISSING_INNER_HITS));
+  PVValHelper::fill(h,"expectedOuter_"+ttype,tt->track().hitPattern().numberOfHits(HitPattern::MISSING_OUTER_HITS));
+  PVValHelper::fill(h,"trackAlgo_"+ttype,tt->track().algo());
+  PVValHelper::fill(h,"trackQuality_"+ttype,tt->track().qualityMask());
   
   //
   int longesthit=0, nbarrel=0;
@@ -3005,172 +3020,19 @@ void PrimaryVertexValidation::fillTrackHistos(std::map<std::string, TH1*> & h, c
 	  nbarrel++;
 	  if (clust->sizeY()-longesthit>0) longesthit=clust->sizeY();
 	  if (clust->sizeY()>20.){
-	    fill(h,"lvseta_"+ttype,tt->track().eta(), 19.9);
-	    fill(h,"lvstanlambda_"+ttype,tan(tt->track().lambda()), 19.9);
+	    PVValHelper::fill(h,"lvseta_"+ttype,tt->track().eta(), 19.9);
+	    PVValHelper::fill(h,"lvstanlambda_"+ttype,tan(tt->track().lambda()), 19.9);
 	  }else{
-	    fill(h,"lvseta_"+ttype,tt->track().eta(), float(clust->sizeY()));
-	    fill(h,"lvstanlambda_"+ttype,tan(tt->track().lambda()), float(clust->sizeY()));
+	    PVValHelper::fill(h,"lvseta_"+ttype,tt->track().eta(), float(clust->sizeY()));
+	    PVValHelper::fill(h,"lvstanlambda_"+ttype,tan(tt->track().lambda()), float(clust->sizeY()));
 	  }
 	}
       }
     }
   }
-  fill(h,"nbarrelhits_"+ttype,float(nbarrel));
+  PVValHelper::fill(h,"nbarrelhits_"+ttype,float(nbarrel));
   //------------------------------------------------------------------- 
 }
-
-//*************************************************************
-void PrimaryVertexValidation::add(std::map<std::string, TH1*>& h, TH1* hist)
-//*************************************************************
-{ 
-  h[hist->GetName()]=hist; 
-  hist->StatOverflows(kTRUE);
-}
-
-//*************************************************************
-void PrimaryVertexValidation::fill(std::map<std::string, TH1*>& h,const std::string& s, double x)
-//*************************************************************
-{
-  if(h.count(s)==0){
-    edm::LogWarning("PrimaryVertexValidation") << "Trying to fill non-existing Histogram named " << s << std::endl;
-    return;
-  }
-  h[s]->Fill(x);
-}
-
-//*************************************************************
-void PrimaryVertexValidation::fill(std::map<std::string, TH1*>& h,const std::string& s, double x, double y)
-//*************************************************************
-{
-  if(h.count(s)==0){
-    edm::LogWarning("PrimaryVertexValidation") << "Trying to fill non-existing Histogram named " << s << std::endl;
-    return;
-  }
-  h[s]->Fill(x,y);
-}
-
-//*************************************************************
-void PrimaryVertexValidation::fillByIndex(std::vector<TH1F*>& h, unsigned int index, double x,std::string tag)
-//*************************************************************
-{
-  assert(!h.empty());
-  if(index <= h.size()){
-    h[index]->Fill(x);
-  } else {
-    edm::LogWarning("PrimaryVertexValidation") << "Trying to fill non-existing Histogram with index " << index << " for array with size: "<<h.size()<<" tag: "<< tag<< std::endl;
-    return;
-  }
-}
-
-//*************************************************************
-void PrimaryVertexValidation::shrinkHistVectorToFit(std::vector<TH1F*>&h, unsigned int desired_size)
-//*************************************************************
-{
-  h.erase(h.begin()+desired_size,h.end()); 
-}
-
-//*************************************************************
-std::tuple<std::string,std::string,std::string> PrimaryVertexValidation::getTypeString (pvparams::residualType type)
-//*************************************************************
-{
-  std::tuple<std::string,std::string,std::string> returnType;
-  switch(type)
-    {
-    // absoulte
-
-    case pvparams::dxy  :
-      returnType = std::make_tuple("dxy","d_{xy}","[#mum]");
-      break;
-    case pvparams::dx   :
-      returnType = std::make_tuple("dx","d_{x}","[#mum]");
-      break;
-    case pvparams::dy   :
-      returnType = std::make_tuple("dy","d_{y}","[#mum]");
-      break;
-    case pvparams::dz   :
-      returnType =  std::make_tuple("dz","d_{z}","[#mum]");
-      break;
-    case pvparams::IP2D :
-      returnType =  std::make_tuple("IP2D","IP_{2D}","[#mum]");
-      break;
-    case pvparams::resz :
-      returnType =  std::make_tuple("resz","z_{trk}-z_{vtx}","[#mum]");
-      break;
-    case pvparams::IP3D :
-      returnType =  std::make_tuple("IP3D","IP_{3D}","[#mum]");
-      break;
-    case pvparams::d3D  : 
-      returnType =  std::make_tuple("d3D","d_{3D}","[#mum]");
-      break;
-
-    // normalized
-
-    case pvparams::norm_dxy  :
-      returnType =  std::make_tuple("norm_dxy","d_{xy}/#sigma_{d_{xy}}","");
-      break;
-    case pvparams::norm_dx   :
-      returnType =  std::make_tuple("norm_dx","d_{x}/#sigma_{d_{x}}","");
-      break;
-    case pvparams::norm_dy   :
-      returnType =  std::make_tuple("norm_dy","d_{y}/#sigma_{d_{y}}","");
-      break;
-    case pvparams::norm_dz   :
-      returnType =  std::make_tuple("norm_dz","d_{z}/#sigma_{d_{z}}","");
-      break;
-    case pvparams::norm_IP2D :
-      returnType =  std::make_tuple("norm_IP2D","IP_{2D}/#sigma_{IP_{2D}}","");
-      break;
-    case pvparams::norm_resz :
-      returnType =  std::make_tuple("norm_resz","z_{trk}-z_{vtx}/#sigma_{res_{z}}","");
-      break;
-    case pvparams::norm_IP3D :
-      returnType =  std::make_tuple("norm_IP3D","IP_{3D}/#sigma_{IP_{3D}}","");
-      break;
-    case pvparams::norm_d3D  : 
-      returnType =  std::make_tuple("norm_d3D","d_{3D}/#sigma_{d_{3D}}","");
-      break;
-
-    default:
-      edm::LogWarning("PrimaryVertexValidation:") <<" getTypeString() unknown residual type"<<type<<std::endl;
-    }
-
-  return returnType;
-  
-}
-
-//*************************************************************
-std::tuple<std::string,std::string,std::string> PrimaryVertexValidation::getVarString (pvparams::plotVariable var)
-//*************************************************************
-{
-  std::tuple<std::string,std::string,std::string> returnVar;
-  switch(var)
-    {
-    case pvparams::phi  :
-      returnVar =  std::make_tuple("phi","#phi","[rad]");
-      break;
-    case pvparams::eta   :
-      returnVar =  std::make_tuple("eta","#eta","");
-      break;
-    case pvparams::pT   :
-      returnVar = std::make_tuple("pT","p_{T}","[GeV]");
-      break;
-    case pvparams::pTCentral :
-      returnVar = std::make_tuple("pTCentral","p_{T} |#eta|<1.","[GeV]");
-      break;
-    case pvparams::ladder   :
-      returnVar = std::make_tuple("ladder","ladder number","");
-      break;
-    case pvparams::modZ :
-      returnVar = std::make_tuple("modZ","module number","");
-      break;
-    default:
-      edm::LogWarning("PrimaryVertexValidation:") <<" getVarString() unknown plot variable"<<var<<std::endl;
-    }
-
-  return returnVar;
-  
-}
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(PrimaryVertexValidation);

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -121,16 +121,23 @@ PrimaryVertexValidation::PrimaryVertexValidation(const edm::ParameterSet& iConfi
   }
 
   theDetails_.histobins = 500;
-  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::phi)]       = 2000.; 
-  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::eta)]       = 3000.;
-  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::pT)]        = 1000.;
-  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::pTCentral)] = 1000.;
-  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::ladder)]    = 1000.;
-  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::modZ)]      = 1000.;
+  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::phi)]       = std::make_pair(-2000.,2000.); 
+  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::eta)]       = std::make_pair(-3000.,3000.);
+  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::pT)]        = std::make_pair(-1000.,1000.);
+  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::pTCentral)] = std::make_pair(-1000.,1000.);
+  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::ladder)]    = std::make_pair(-1000.,1000.);
+  theDetails_.range[std::make_pair(pvparams::dxy,pvparams::modZ)]      = std::make_pair(-1000.,1000.);
 
-  for (int plot_index = pvparams::phi; plot_index < pvparams::END_OF_PLOTS; plot_index++ ){
-    for (int res_index = pvparams::dx; res_index < pvparams::END_OF_TYPES; res_index++ ){
-      theDetails_.range[std::make_pair(static_cast<pvparams::residualType>(res_index),static_cast<pvparams::plotVariable>(plot_index))] = theDetails_.range[std::make_pair(pvparams::dxy,static_cast<pvparams::plotVariable>(plot_index))];
+  for (int i = pvparams::phi; i < pvparams::END_OF_PLOTS; i++ ){
+    for (int j = pvparams::dx; j < pvparams::END_OF_TYPES; j++ ){
+
+      auto res_index  = static_cast<pvparams::residualType>(i);
+      auto plot_index = static_cast<pvparams::plotVariable>(j);
+
+      if(res_index!=pvparams::d3D)
+	theDetails_.range[std::make_pair(res_index,plot_index)] = theDetails_.range[std::make_pair(pvparams::dxy,plot_index)];
+      else
+	theDetails_.range[std::make_pair(res_index,plot_index)] = std::make_pair(0.,theDetails_.range[std::make_pair(pvparams::dxy,plot_index)].second);
     }
   }
 
@@ -299,7 +306,9 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
   std::sort( vsorted.begin(), vsorted.end(), PrimaryVertexValidation::vtxSort );
   
   // skip events with no PV, this should not happen
+
   if( vsorted.empty()) return;
+
   // skip events failing vertex cut
   if( std::abs(vsorted[0].z()) > vertexZMax_ ) return; 
   
@@ -929,38 +938,39 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
 
 		  if(tracketa >= etaF && tracketa < etaL ){
 
-		    a_dxyEtaResiduals[i]->Fill(dxyFromMyVertex*cmToum);
-		    a_dxEtaResiduals[i]->Fill(my_dx*cmToum);
-		    a_dyEtaResiduals[i]->Fill(my_dy*cmToum);
-		    a_dzEtaResiduals[i]->Fill(dzFromMyVertex*cmToum);   
-		    n_dxyEtaResiduals[i]->Fill(dxyFromMyVertex/s_ip2dpv_err);
-		    n_dzEtaResiduals[i]->Fill(dzFromMyVertex/dz_err);	    
-		    a_IP2DEtaResiduals[i]->Fill(s_ip2dpv_corr*cmToum);
-		    n_IP2DEtaResiduals[i]->Fill(s_ip2dpv_corr/s_ip2dpv_err);
-		    a_reszEtaResiduals[i]->Fill(restrkz*cmToum);
-		    n_reszEtaResiduals[i]->Fill(pulltrkz);
-		    a_d3DEtaResiduals[i]->Fill(ip3d_corr*cmToum);   
-		    n_d3DEtaResiduals[i]->Fill(ip3d_corr/ip3d_err);
-		    a_IP3DEtaResiduals[i]->Fill(s_ip3dpv_corr*cmToum);
-		    n_IP3DEtaResiduals[i]->Fill(s_ip3dpv_corr/s_ip3dpv_err);
+		    fillByIndex(a_dxyEtaResiduals,i,dxyFromMyVertex*cmToum,"1");
+		    fillByIndex(a_dxEtaResiduals,i,my_dx*cmToum,"2");
+		    fillByIndex(a_dyEtaResiduals,i,my_dy*cmToum,"3");
+		    fillByIndex(a_dzEtaResiduals,i,dzFromMyVertex*cmToum,"4");   
+		    fillByIndex(n_dxyEtaResiduals,i,dxyFromMyVertex/s_ip2dpv_err,"5");
+		    fillByIndex(n_dzEtaResiduals,i,dzFromMyVertex/dz_err,"6");	    
+		    fillByIndex(a_IP2DEtaResiduals,i,s_ip2dpv_corr*cmToum,"7");
+		    fillByIndex(n_IP2DEtaResiduals,i,s_ip2dpv_corr/s_ip2dpv_err,"8");
+		    fillByIndex(a_reszEtaResiduals,i,restrkz*cmToum,"9");
+		    fillByIndex(n_reszEtaResiduals,i,pulltrkz,"10");
+		    fillByIndex(a_d3DEtaResiduals,i,ip3d_corr*cmToum,"11");   
+		    fillByIndex(n_d3DEtaResiduals,i,ip3d_corr/ip3d_err,"12");
+		    fillByIndex(a_IP3DEtaResiduals,i,s_ip3dpv_corr*cmToum,"13");
+		    fillByIndex(n_IP3DEtaResiduals,i,s_ip3dpv_corr/s_ip3dpv_err,"14");
 
 		  }
 		  	  
 		  if(trackphi >= phiF && trackphi < phiL ){
-		    a_dxyPhiResiduals[i]->Fill(dxyFromMyVertex*cmToum);
-		    a_dxPhiResiduals[i]->Fill(my_dx*cmToum);
-		    a_dyPhiResiduals[i]->Fill(my_dy*cmToum);
-		    a_dzPhiResiduals[i]->Fill(dzFromMyVertex*cmToum); 
-		    n_dxyPhiResiduals[i]->Fill(dxyFromMyVertex/s_ip2dpv_err);
-		    n_dzPhiResiduals[i]->Fill(dzFromMyVertex/dz_err); 
-		    a_IP2DPhiResiduals[i]->Fill(s_ip2dpv_corr*cmToum);
-		    n_IP2DPhiResiduals[i]->Fill(s_ip2dpv_corr/s_ip2dpv_err); 
-		    a_reszPhiResiduals[i]->Fill(restrkz*cmToum);
-		    n_reszPhiResiduals[i]->Fill(pulltrkz);
-		    a_d3DPhiResiduals[i]->Fill(ip3d_corr*cmToum);   
-		    n_d3DPhiResiduals[i]->Fill(ip3d_corr/ip3d_err);
-		    a_IP3DPhiResiduals[i]->Fill(s_ip3dpv_corr*cmToum);
-		    n_IP3DPhiResiduals[i]->Fill(s_ip3dpv_corr/s_ip3dpv_err);
+
+		    fillByIndex(a_dxyPhiResiduals,i,dxyFromMyVertex*cmToum,"15");
+		    fillByIndex(a_dxPhiResiduals,i,my_dx*cmToum,"16");
+		    fillByIndex(a_dyPhiResiduals,i,my_dy*cmToum,"17");
+		    fillByIndex(a_dzPhiResiduals,i,dzFromMyVertex*cmToum,"18"); 
+		    fillByIndex(n_dxyPhiResiduals,i,dxyFromMyVertex/s_ip2dpv_err,"19");
+		    fillByIndex(n_dzPhiResiduals,i,dzFromMyVertex/dz_err,"20"); 
+		    fillByIndex(a_IP2DPhiResiduals,i,s_ip2dpv_corr*cmToum,"21");
+		    fillByIndex(n_IP2DPhiResiduals,i,s_ip2dpv_corr/s_ip2dpv_err,"22"); 
+		    fillByIndex(a_reszPhiResiduals,i,restrkz*cmToum,"23");
+		    fillByIndex(n_reszPhiResiduals,i,pulltrkz,"24");
+		    fillByIndex(a_d3DPhiResiduals,i,ip3d_corr*cmToum,"25");   
+		    fillByIndex(n_d3DPhiResiduals,i,ip3d_corr/ip3d_err,"26");
+		    fillByIndex(a_IP3DPhiResiduals,i,s_ip3dpv_corr*cmToum,"27");
+		    fillByIndex(n_IP3DPhiResiduals,i,s_ip3dpv_corr/s_ip3dpv_err,"28");
 
 		    for(int j=0; j<nBins_; j++){
 
@@ -1318,22 +1328,56 @@ void PrimaryVertexValidation::beginJob()
   ///////////////////////////////////////////////////////////////////
 
   TFileDirectory AbsTransPhiRes  = fs->mkdir("Abs_Transv_Phi_Residuals");
+  a_dxyPhiResiduals  = bookResidualsHistogram(AbsTransPhiRes,nBins_,pvparams::dxy,pvparams::phi);
+  a_dxPhiResiduals   = bookResidualsHistogram(AbsTransPhiRes,nBins_,pvparams::dx,pvparams::phi);
+  a_dyPhiResiduals   = bookResidualsHistogram(AbsTransPhiRes,nBins_,pvparams::dy,pvparams::phi);  
+  a_IP2DPhiResiduals = bookResidualsHistogram(AbsTransPhiRes,nBins_,pvparams::IP2D,pvparams::phi);
+
   TFileDirectory AbsTransEtaRes  = fs->mkdir("Abs_Transv_Eta_Residuals");
+  a_dxyEtaResiduals  = bookResidualsHistogram(AbsTransEtaRes,nBins_,pvparams::dxy,pvparams::eta);
+  a_dxEtaResiduals   = bookResidualsHistogram(AbsTransEtaRes,nBins_,pvparams::dx,pvparams::eta);
+  a_dyEtaResiduals   = bookResidualsHistogram(AbsTransEtaRes,nBins_,pvparams::dy,pvparams::eta);
+  a_IP2DEtaResiduals = bookResidualsHistogram(AbsTransEtaRes,nBins_,pvparams::IP2D,pvparams::eta);
 		 					  
   TFileDirectory AbsLongPhiRes   = fs->mkdir("Abs_Long_Phi_Residuals");
+  a_dzPhiResiduals   = bookResidualsHistogram(AbsLongPhiRes,nBins_,pvparams::dz,pvparams::phi);
+  a_reszPhiResiduals = bookResidualsHistogram(AbsLongPhiRes,nBins_,pvparams::resz,pvparams::phi);
+
   TFileDirectory AbsLongEtaRes   = fs->mkdir("Abs_Long_Eta_Residuals");
+  a_dzEtaResiduals   = bookResidualsHistogram(AbsLongEtaRes,nBins_,pvparams::dz,pvparams::eta);
+  a_reszEtaResiduals = bookResidualsHistogram(AbsLongEtaRes,nBins_,pvparams::resz,pvparams::eta);
 		 		  
   TFileDirectory Abs3DPhiRes     = fs->mkdir("Abs_3D_Phi_Residuals");
+  a_d3DPhiResiduals  = bookResidualsHistogram(Abs3DPhiRes,nBins_,pvparams::d3D,pvparams::phi);
+  a_IP3DPhiResiduals = bookResidualsHistogram(Abs3DPhiRes,nBins_,pvparams::IP3D,pvparams::phi);
+
   TFileDirectory Abs3DEtaRes     = fs->mkdir("Abs_3D_Eta_Residuals");
+  a_d3DEtaResiduals  = bookResidualsHistogram(Abs3DEtaRes ,nBins_,pvparams::d3D,pvparams::eta);
+  a_IP3DEtaResiduals = bookResidualsHistogram(Abs3DEtaRes ,nBins_,pvparams::IP3D,pvparams::eta);
 
   TFileDirectory NormTransPhiRes = fs->mkdir("Norm_Transv_Phi_Residuals");
+  n_dxyPhiResiduals  = bookResidualsHistogram(NormTransPhiRes,nBins_,pvparams::norm_dxy,pvparams::phi,true);
+  n_IP2DPhiResiduals = bookResidualsHistogram(NormTransPhiRes,nBins_,pvparams::norm_IP2D,pvparams::phi,true);
+
   TFileDirectory NormTransEtaRes = fs->mkdir("Norm_Transv_Eta_Residuals");
+  n_dxyEtaResiduals  = bookResidualsHistogram(NormTransEtaRes,nBins_,pvparams::norm_dxy,pvparams::eta,true);
+  n_IP2DEtaResiduals = bookResidualsHistogram(NormTransEtaRes,nBins_,pvparams::norm_IP2D,pvparams::eta,true);
 		 					  
   TFileDirectory NormLongPhiRes  = fs->mkdir("Norm_Long_Phi_Residuals");
+  n_dzPhiResiduals   = bookResidualsHistogram(NormLongPhiRes,nBins_,pvparams::norm_dz,pvparams::phi,true);
+  n_reszPhiResiduals = bookResidualsHistogram(NormLongPhiRes,nBins_,pvparams::norm_resz,pvparams::phi,true);
+
   TFileDirectory NormLongEtaRes  = fs->mkdir("Norm_Long_Eta_Residuals");
+  n_dzEtaResiduals   = bookResidualsHistogram(NormLongEtaRes,nBins_,pvparams::norm_dz,pvparams::eta,true);
+  n_reszEtaResiduals = bookResidualsHistogram(NormLongEtaRes,nBins_,pvparams::norm_resz,pvparams::eta,true);
 
   TFileDirectory Norm3DPhiRes    = fs->mkdir("Norm_3D_Phi_Residuals");
+  n_d3DPhiResiduals  = bookResidualsHistogram(Norm3DPhiRes,nBins_,pvparams::norm_d3D,pvparams::phi,true);
+  n_IP3DPhiResiduals = bookResidualsHistogram(Norm3DPhiRes,nBins_,pvparams::norm_IP3D,pvparams::phi,true);
+  
   TFileDirectory Norm3DEtaRes    = fs->mkdir("Norm_3D_Eta_Residuals");
+  n_d3DEtaResiduals  = bookResidualsHistogram(Norm3DEtaRes,nBins_,pvparams::norm_d3D,pvparams::eta,true);
+  n_IP3DEtaResiduals = bookResidualsHistogram(Norm3DEtaRes,nBins_,pvparams::norm_IP3D,pvparams::eta,true);
 
   TFileDirectory AbsDoubleDiffRes   = fs->mkdir("Abs_DoubleDiffResiduals");
   TFileDirectory NormDoubleDiffRes  = fs->mkdir("Norm_DoubleDiffResiduals");
@@ -1411,152 +1455,151 @@ void PrimaryVertexValidation::beginJob()
     
     // dxy vs phi and eta
      
-    a_dxyPhiResiduals[i] = AbsTransPhiRes.make<TH1F>(Form("histo_dxy_phi_plot%i",i),
-						     Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{xy} [#mum];tracks",phiF,phiL),
-						     mybins_,-dxymax_phi,dxymax_phi);
+    //a_dxyPhiResiduals[i] = AbsTransPhiRes.make<TH1F>(Form("histo_dxy_phi_plot%i",i),
+    //						     Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{xy} [#mum];tracks",phiF,phiL),
+    //						     mybins_,-dxymax_phi,dxymax_phi);
     
-    a_dxyEtaResiduals[i] = AbsTransEtaRes.make<TH1F>(Form("histo_dxy_eta_plot%i",i),
-						     Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{xy} [#mum];tracks",etaF,etaL),
-						     mybins_,-dxymax_eta,dxymax_eta);
+    // a_dxyEtaResiduals[i] = AbsTransEtaRes.make<TH1F>(Form("histo_dxy_eta_plot%i",i),
+    // 						     Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{xy} [#mum];tracks",etaF,etaL),
+    // 						     mybins_,-dxymax_eta,dxymax_eta);
 
-
-    // dx vs phi and eta
+    // // dx vs phi and eta
      
-    a_dxPhiResiduals[i] = AbsTransPhiRes.make<TH1F>(Form("histo_dx_phi_plot%i",i),
-						    Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{x} [#mum];tracks",phiF,phiL),
-						    mybins_,-dxymax_phi,dxymax_phi);
+    // a_dxPhiResiduals[i] = AbsTransPhiRes.make<TH1F>(Form("histo_dx_phi_plot%i",i),
+    // 						    Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{x} [#mum];tracks",phiF,phiL),
+    // 						    mybins_,-dxymax_phi,dxymax_phi);
     
-    a_dxEtaResiduals[i] = AbsTransEtaRes.make<TH1F>(Form("histo_dx_eta_plot%i",i),
-						    Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{x} [#mum];tracks",etaF,etaL),
-						    mybins_,-dxymax_eta,dxymax_eta);
+    // a_dxEtaResiduals[i] = AbsTransEtaRes.make<TH1F>(Form("histo_dx_eta_plot%i",i),
+    // 						    Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{x} [#mum];tracks",etaF,etaL),
+    // 						    mybins_,-dxymax_eta,dxymax_eta);
 
 
-    // dy vs phi and eta
+    // // dy vs phi and eta
      
-    a_dyPhiResiduals[i] = AbsTransPhiRes.make<TH1F>(Form("histo_dy_phi_plot%i",i),
-						    Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{y} [#mum];tracks",phiF,phiL),
-						    mybins_,-dxymax_phi,dxymax_phi);
+    // a_dyPhiResiduals[i] = AbsTransPhiRes.make<TH1F>(Form("histo_dy_phi_plot%i",i),
+    // 						    Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{y} [#mum];tracks",phiF,phiL),
+    // 						    mybins_,-dxymax_phi,dxymax_phi);
     
-    a_dyEtaResiduals[i] = AbsTransEtaRes.make<TH1F>(Form("histo_dy_eta_plot%i",i),
-						    Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{y} [#mum];tracks",etaF,etaL),
-						    mybins_,-dxymax_eta,dxymax_eta);
+    // a_dyEtaResiduals[i] = AbsTransEtaRes.make<TH1F>(Form("histo_dy_eta_plot%i",i),
+    // 						    Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{y} [#mum];tracks",etaF,etaL),
+    // 						    mybins_,-dxymax_eta,dxymax_eta);
     
-    // IP2D vs phi and eta
+    // // IP2D vs phi and eta
 
-    a_IP2DPhiResiduals[i] = AbsTransPhiRes.make<TH1F>(Form("histo_IP2D_phi_plot%i",i),
-						     Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;IP_{2D} [#mum];tracks",phiF,phiL),
-						     mybins_,-dxymax_phi,dxymax_phi);
+    // a_IP2DPhiResiduals[i] = AbsTransPhiRes.make<TH1F>(Form("histo_IP2D_phi_plot%i",i),
+    // 						     Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;IP_{2D} [#mum];tracks",phiF,phiL),
+    // 						     mybins_,-dxymax_phi,dxymax_phi);
     
-    a_IP2DEtaResiduals[i] = AbsTransEtaRes.make<TH1F>(Form("histo_IP2D_eta_plot%i",i),
-						     Form("%.2f<#eta^{probe}_{tk}<%.2f;IP_{2D} [#mum];tracks",etaF,etaL),
-						     mybins_,-dxymax_eta,dxymax_eta);
+    // a_IP2DEtaResiduals[i] = AbsTransEtaRes.make<TH1F>(Form("histo_IP2D_eta_plot%i",i),
+    // 						     Form("%.2f<#eta^{probe}_{tk}<%.2f;IP_{2D} [#mum];tracks",etaF,etaL),
+    // 						     mybins_,-dxymax_eta,dxymax_eta);
 
-    // IP3D vs phi and eta
+    // // IP3D vs phi and eta
 
-    a_IP3DPhiResiduals[i] = Abs3DPhiRes.make<TH1F>(Form("histo_IP3D_phi_plot%i",i),
-						   Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;IP_{3D} [#mum];tracks",phiF,phiL),
-						   mybins_,-dxymax_phi,dxymax_phi);
+    // a_IP3DPhiResiduals[i] = Abs3DPhiRes.make<TH1F>(Form("histo_IP3D_phi_plot%i",i),
+    // 						   Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;IP_{3D} [#mum];tracks",phiF,phiL),
+    // 						   mybins_,-dxymax_phi,dxymax_phi);
     
-    a_IP3DEtaResiduals[i] = Abs3DEtaRes.make<TH1F>(Form("histo_IP3D_eta_plot%i",i),
-						   Form("%.2f<#eta^{probe}_{tk}<%.2f;IP_{3D} [#mum];tracks",etaF,etaL),
-						   mybins_,-dxymax_eta,dxymax_eta);
+    // a_IP3DEtaResiduals[i] = Abs3DEtaRes.make<TH1F>(Form("histo_IP3D_eta_plot%i",i),
+    // 						   Form("%.2f<#eta^{probe}_{tk}<%.2f;IP_{3D} [#mum];tracks",etaF,etaL),
+    // 						   mybins_,-dxymax_eta,dxymax_eta);
 
-    // dz vs phi and eta
+    // // dz vs phi and eta
 
-    a_dzPhiResiduals[i]  = AbsLongPhiRes.make<TH1F>(Form("histo_dz_phi_plot%i",i),
-						    Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{z} [#mum];tracks",phiF,phiL),
-						    mybins_,-dzmax_phi,dzmax_phi);
+    // a_dzPhiResiduals[i]  = AbsLongPhiRes.make<TH1F>(Form("histo_dz_phi_plot%i",i),
+    // 						    Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{z} [#mum];tracks",phiF,phiL),
+    // 						    mybins_,-dzmax_phi,dzmax_phi);
     
-    a_dzEtaResiduals[i]  = AbsLongEtaRes.make<TH1F>(Form("histo_dz_eta_plot%i",i),
-						    Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{z} [#mum];tracks",etaF,etaL),
-						    mybins_,-dzmax_eta,dzmax_eta);
+    // a_dzEtaResiduals[i]  = AbsLongEtaRes.make<TH1F>(Form("histo_dz_eta_plot%i",i),
+    // 						    Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{z} [#mum];tracks",etaF,etaL),
+    // 						    mybins_,-dzmax_eta,dzmax_eta);
 
 
-    // resz vs phi and eta
+    // // resz vs phi and eta
 
-    a_reszPhiResiduals[i]  = AbsLongPhiRes.make<TH1F>(Form("histo_resz_phi_plot%i",i),
-						    Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;z_{trk} - z_{vtx} [#mum];tracks",phiF,phiL),
-						    mybins_,-dzmax_phi,dzmax_phi);
+    // a_reszPhiResiduals[i]  = AbsLongPhiRes.make<TH1F>(Form("histo_resz_phi_plot%i",i),
+    // 						    Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;z_{trk} - z_{vtx} [#mum];tracks",phiF,phiL),
+    // 						    mybins_,-dzmax_phi,dzmax_phi);
     
-    a_reszEtaResiduals[i]  = AbsLongEtaRes.make<TH1F>(Form("histo_resz_eta_plot%i",i),
-						    Form("%.2f<#eta^{probe}_{tk}<%.2f;z_{trk} - z_{vtx} [#mum];tracks",etaF,etaL),
-						    mybins_,-dzmax_eta,dzmax_eta);
+    // a_reszEtaResiduals[i]  = AbsLongEtaRes.make<TH1F>(Form("histo_resz_eta_plot%i",i),
+    // 						    Form("%.2f<#eta^{probe}_{tk}<%.2f;z_{trk} - z_{vtx} [#mum];tracks",etaF,etaL),
+    // 						    mybins_,-dzmax_eta,dzmax_eta);
 
-    // d3D vs phi and eta
+    // // d3D vs phi and eta
 
-    a_d3DPhiResiduals[i] = Abs3DPhiRes.make<TH1F>(Form("histo_d3D_phi_plot%i",i),
-						  Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{3D} [#mum];tracks",phiF,phiL),
-						  mybins_,0.,d3Dmax_phi);
+    // a_d3DPhiResiduals[i] = Abs3DPhiRes.make<TH1F>(Form("histo_d3D_phi_plot%i",i),
+    // 						  Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{3D} [#mum];tracks",phiF,phiL),
+    // 						  mybins_,0.,d3Dmax_phi);
     
-    a_d3DEtaResiduals[i] = Abs3DEtaRes.make<TH1F>(Form("histo_d3D_eta_plot%i",i),
-						  Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{3D} [#mum];tracks",etaF,etaL),
-						  mybins_,0.,d3Dmax_eta);
+    // a_d3DEtaResiduals[i] = Abs3DEtaRes.make<TH1F>(Form("histo_d3D_eta_plot%i",i),
+    // 						  Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{3D} [#mum];tracks",etaF,etaL),
+    // 						  mybins_,0.,d3Dmax_eta);
        
-    //  _  _                    _ _           _   ___        _    _           _    
-    // | \| |___ _ _ _ __  __ _| (_)______ __| | | _ \___ __(_)__| |_  _ __ _| |___
-    // | .` / _ \ '_| '  \/ _` | | |_ / -_) _` | |   / -_|_-< / _` | || / _` | (_-<
-    // |_|\_\___/_| |_|_|_\__,_|_|_/__\___\__,_| |_|_\___/__/_\__,_|\_,_\__,_|_/__/
-    //
+    // //  _  _                    _ _           _   ___        _    _           _    
+    // // | \| |___ _ _ _ __  __ _| (_)______ __| | | _ \___ __(_)__| |_  _ __ _| |___
+    // // | .` / _ \ '_| '  \/ _` | | |_ / -_) _` | |   / -_|_-< / _` | || / _` | (_-<
+    // // |_|\_\___/_| |_|_|_\__,_|_|_/__\___\__,_| |_|_\___/__/_\__,_|\_,_\__,_|_/__/
+    // //
                                                                              
-    // normalized dxy vs eta and phi
+    // // normalized dxy vs eta and phi
    				
-    n_dxyPhiResiduals[i] = NormTransPhiRes.make<TH1F>(Form("histo_norm_dxy_phi_plot%i",i),
-						      Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{xy}/#sigma_{d_{xy}};tracks",phiF,phiL),
-						      mybins_,-dxymax_phi/100.,dxymax_phi/100.);
+    // n_dxyPhiResiduals[i] = NormTransPhiRes.make<TH1F>(Form("histo_norm_dxy_phi_plot%i",i),
+    // 						      Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{xy}/#sigma_{d_{xy}};tracks",phiF,phiL),
+    // 						      mybins_,-dxymax_phi/100.,dxymax_phi/100.);
     
-    n_dxyEtaResiduals[i] = NormTransEtaRes.make<TH1F>(Form("histo_norm_dxy_eta_plot%i",i),
-						      Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{xy}/#sigma_{d_{xy}};tracks",etaF,etaL),
-						      mybins_,-dxymax_eta/100.,dxymax_eta/100.);
+    // n_dxyEtaResiduals[i] = NormTransEtaRes.make<TH1F>(Form("histo_norm_dxy_eta_plot%i",i),
+    // 						      Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{xy}/#sigma_{d_{xy}};tracks",etaF,etaL),
+    // 						      mybins_,-dxymax_eta/100.,dxymax_eta/100.);
     
-    // normalized IP2d vs eta and phi
+    // // normalized IP2d vs eta and phi
     
-    n_IP2DPhiResiduals[i] = NormTransPhiRes.make<TH1F>(Form("histo_norm_IP2D_phi_plot%i",i),
-						       Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;IP_{2D}/#sigma_{IP_{2D}};tracks",phiF,phiL),
-						       mybins_,-dxymax_phi/100.,dxymax_phi/100.);
+    // n_IP2DPhiResiduals[i] = NormTransPhiRes.make<TH1F>(Form("histo_norm_IP2D_phi_plot%i",i),
+    // 						       Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;IP_{2D}/#sigma_{IP_{2D}};tracks",phiF,phiL),
+    // 						       mybins_,-dxymax_phi/100.,dxymax_phi/100.);
     
-    n_IP2DEtaResiduals[i] = NormTransEtaRes.make<TH1F>(Form("histo_norm_IP2D_eta_plot%i",i),
-						       Form("%.2f<#eta^{probe}_{tk}<%.2f;IP_{2D}/#sigma_{IP_{2D}};tracks",etaF,etaL),
-						       mybins_,-dxymax_eta/100.,dxymax_eta/100.);
+    // n_IP2DEtaResiduals[i] = NormTransEtaRes.make<TH1F>(Form("histo_norm_IP2D_eta_plot%i",i),
+    // 						       Form("%.2f<#eta^{probe}_{tk}<%.2f;IP_{2D}/#sigma_{IP_{2D}};tracks",etaF,etaL),
+    // 						       mybins_,-dxymax_eta/100.,dxymax_eta/100.);
     
-    // normalized IP3d vs eta and phi
+    // // normalized IP3d vs eta and phi
     
-    n_IP3DPhiResiduals[i] = Norm3DPhiRes.make<TH1F>(Form("histo_norm_IP3D_phi_plot%i",i),
-						    Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;IP_{3D}/#sigma_{IP_{3D}};tracks",phiF,phiL),
-						    mybins_,-dxymax_phi/100.,dxymax_phi/100.);
+    // n_IP3DPhiResiduals[i] = Norm3DPhiRes.make<TH1F>(Form("histo_norm_IP3D_phi_plot%i",i),
+    // 						    Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;IP_{3D}/#sigma_{IP_{3D}};tracks",phiF,phiL),
+    // 						    mybins_,-dxymax_phi/100.,dxymax_phi/100.);
     
-    n_IP3DEtaResiduals[i] = Norm3DEtaRes.make<TH1F>(Form("histo_norm_IP3D_eta_plot%i",i),
-						    Form("%.2f<#eta^{probe}_{tk}<%.2f;IP_{3D}/#sigma_{IP_{3D}};tracks",etaF,etaL),
-						    mybins_,-dxymax_eta/100.,dxymax_eta/100.);
+    // n_IP3DEtaResiduals[i] = Norm3DEtaRes.make<TH1F>(Form("histo_norm_IP3D_eta_plot%i",i),
+    // 						    Form("%.2f<#eta^{probe}_{tk}<%.2f;IP_{3D}/#sigma_{IP_{3D}};tracks",etaF,etaL),
+    // 						    mybins_,-dxymax_eta/100.,dxymax_eta/100.);
 
-    // normalized dz vs phi and eta
+    // // normalized dz vs phi and eta
 
-    n_dzPhiResiduals[i]  = NormLongPhiRes.make<TH1F>(Form("histo_norm_dz_phi_plot%i",i),
-						     Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{z}/#sigma_{d_{z}};tracks",phiF,phiL),
-						     mybins_,-dzmax_phi/100.,dzmax_phi/100.);
+    // n_dzPhiResiduals[i]  = NormLongPhiRes.make<TH1F>(Form("histo_norm_dz_phi_plot%i",i),
+    // 						     Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{z}/#sigma_{d_{z}};tracks",phiF,phiL),
+    // 						     mybins_,-dzmax_phi/100.,dzmax_phi/100.);
     
-    n_dzEtaResiduals[i]  = NormLongEtaRes.make<TH1F>(Form("histo_norm_dz_eta_plot%i",i),
-						     Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{z}/#sigma_{d_{z}};tracks",etaF,etaL),
-						     mybins_,-dzmax_eta/100.,dzmax_eta/100.);
+    // n_dzEtaResiduals[i]  = NormLongEtaRes.make<TH1F>(Form("histo_norm_dz_eta_plot%i",i),
+    // 						     Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{z}/#sigma_{d_{z}};tracks",etaF,etaL),
+    // 						     mybins_,-dzmax_eta/100.,dzmax_eta/100.);
 
-    // pull of resz
+    // // pull of resz
 
-    n_reszPhiResiduals[i]  = NormLongPhiRes.make<TH1F>(Form("histo_norm_resz_phi_plot%i",i),
-						     Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;(z_{trk}-z_{vtx})/#sigma_{res_{z}};tracks",phiF,phiL),
-						     mybins_,-dzmax_phi/100.,dzmax_phi/100.);
+    // n_reszPhiResiduals[i]  = NormLongPhiRes.make<TH1F>(Form("histo_norm_resz_phi_plot%i",i),
+    // 						     Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;(z_{trk}-z_{vtx})/#sigma_{res_{z}};tracks",phiF,phiL),
+    // 						     mybins_,-dzmax_phi/100.,dzmax_phi/100.);
     
-    n_reszEtaResiduals[i]  = NormLongEtaRes.make<TH1F>(Form("histo_norm_resz_eta_plot%i",i),
-						     Form("%.2f<#eta^{probe}_{tk}<%.2f;(z_{trk}-z_{vtx})/#sigma_{res_{z}};tracks",etaF,etaL),
-						     mybins_,-dzmax_eta/100.,dzmax_eta/100.);
+    // n_reszEtaResiduals[i]  = NormLongEtaRes.make<TH1F>(Form("histo_norm_resz_eta_plot%i",i),
+    // 						     Form("%.2f<#eta^{probe}_{tk}<%.2f;(z_{trk}-z_{vtx})/#sigma_{res_{z}};tracks",etaF,etaL),
+    // 						     mybins_,-dzmax_eta/100.,dzmax_eta/100.);
 
-    // normalized d3D vs phi and eta
+    // // normalized d3D vs phi and eta
 
-    n_d3DPhiResiduals[i] = Norm3DPhiRes.make<TH1F>(Form("histo_norm_d3D_phi_plot%i",i),
-						   Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{3D}/#sigma_{d_{3D}};tracks",phiF,phiL),
-						   mybins_,0.,d3Dmax_phi/100.);
+    // n_d3DPhiResiduals[i] = Norm3DPhiRes.make<TH1F>(Form("histo_norm_d3D_phi_plot%i",i),
+    // 						   Form("%.2f#circ<#varphi^{probe}_{tk}<%.2f#circ;d_{3D}/#sigma_{d_{3D}};tracks",phiF,phiL),
+    // 						   mybins_,0.,d3Dmax_phi/100.);
     
-    n_d3DEtaResiduals[i] = Norm3DEtaRes.make<TH1F>(Form("histo_norm_d3D_eta_plot%i",i),
-						   Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{3D}/#sigma_{d_{3D}};tracks",etaF,etaL),
-						   mybins_,0.,d3Dmax_eta/100.);
+    // n_d3DEtaResiduals[i] = Norm3DEtaRes.make<TH1F>(Form("histo_norm_d3D_eta_plot%i",i),
+    // 						   Form("%.2f<#eta^{probe}_{tk}<%.2f;d_{3D}/#sigma_{d_{3D}};tracks",etaF,etaL),
+    // 						   mybins_,0.,d3Dmax_eta/100.);
 
     //  ___           _    _     ___  _  __  __   ___        _    _           _    
     // |   \ ___ _  _| |__| |___|   \(_)/ _|/ _| | _ \___ __(_)__| |_  _ __ _| |___
@@ -2261,25 +2304,25 @@ void PrimaryVertexValidation::endJob()
 
   // do profiles
 
-  fillTrendPlot(a_dxyPhiMeanTrend ,a_dxyPhiResiduals,pvparams::MEAN,"phi");  
-  fillTrendPlot(a_dxyPhiWidthTrend,a_dxyPhiResiduals,pvparams::WIDTH,"phi");
-  fillTrendPlot(a_dzPhiMeanTrend  ,a_dzPhiResiduals ,pvparams::MEAN,"phi");   
-  fillTrendPlot(a_dzPhiWidthTrend ,a_dzPhiResiduals ,pvparams::WIDTH,"phi");  
+  fillTrendPlotByIndex(a_dxyPhiMeanTrend, a_dxyPhiResiduals,pvparams::MEAN);  
+  fillTrendPlotByIndex(a_dxyPhiWidthTrend,a_dxyPhiResiduals,pvparams::WIDTH);  
+  fillTrendPlotByIndex(a_dzPhiMeanTrend  ,a_dzPhiResiduals ,pvparams::MEAN);   
+  fillTrendPlotByIndex(a_dzPhiWidthTrend ,a_dzPhiResiduals ,pvparams::WIDTH);  
   
-  fillTrendPlot(a_dxyEtaMeanTrend ,a_dxyEtaResiduals,pvparams::MEAN,"eta"); 
-  fillTrendPlot(a_dxyEtaWidthTrend,a_dxyEtaResiduals,pvparams::WIDTH,"eta");
-  fillTrendPlot(a_dzEtaMeanTrend  ,a_dzEtaResiduals ,pvparams::MEAN,"eta"); 
-  fillTrendPlot(a_dzEtaWidthTrend ,a_dzEtaResiduals ,pvparams::WIDTH,"eta");
+  fillTrendPlotByIndex(a_dxyEtaMeanTrend ,a_dxyEtaResiduals,pvparams::MEAN); 
+  fillTrendPlotByIndex(a_dxyEtaWidthTrend,a_dxyEtaResiduals,pvparams::WIDTH);
+  fillTrendPlotByIndex(a_dzEtaMeanTrend  ,a_dzEtaResiduals ,pvparams::MEAN); 
+  fillTrendPlotByIndex(a_dzEtaWidthTrend ,a_dzEtaResiduals ,pvparams::WIDTH);
   
-  fillTrendPlot(n_dxyPhiMeanTrend ,n_dxyPhiResiduals,pvparams::MEAN,"phi"); 
-  fillTrendPlot(n_dxyPhiWidthTrend,n_dxyPhiResiduals,pvparams::WIDTH,"phi");
-  fillTrendPlot(n_dzPhiMeanTrend  ,n_dzPhiResiduals ,pvparams::MEAN,"phi"); 
-  fillTrendPlot(n_dzPhiWidthTrend ,n_dzPhiResiduals ,pvparams::WIDTH,"phi");
+  fillTrendPlotByIndex(n_dxyPhiMeanTrend ,n_dxyPhiResiduals,pvparams::MEAN); 
+  fillTrendPlotByIndex(n_dxyPhiWidthTrend,n_dxyPhiResiduals,pvparams::WIDTH);
+  fillTrendPlotByIndex(n_dzPhiMeanTrend  ,n_dzPhiResiduals ,pvparams::MEAN); 
+  fillTrendPlotByIndex(n_dzPhiWidthTrend ,n_dzPhiResiduals ,pvparams::WIDTH);
   
-  fillTrendPlot(n_dxyEtaMeanTrend ,n_dxyEtaResiduals,pvparams::MEAN,"eta"); 
-  fillTrendPlot(n_dxyEtaWidthTrend,n_dxyEtaResiduals,pvparams::WIDTH,"eta");
-  fillTrendPlot(n_dzEtaMeanTrend  ,n_dzEtaResiduals ,pvparams::MEAN,"eta"); 
-  fillTrendPlot(n_dzEtaWidthTrend ,n_dzEtaResiduals ,pvparams::WIDTH,"eta");
+  fillTrendPlotByIndex(n_dxyEtaMeanTrend ,n_dxyEtaResiduals,pvparams::MEAN); 
+  fillTrendPlotByIndex(n_dxyEtaWidthTrend,n_dxyEtaResiduals,pvparams::WIDTH);
+  fillTrendPlotByIndex(n_dzEtaMeanTrend  ,n_dzEtaResiduals ,pvparams::MEAN); 
+  fillTrendPlotByIndex(n_dzEtaWidthTrend ,n_dzEtaResiduals ,pvparams::WIDTH);
     
   // vs transverse momentum
 
@@ -2324,6 +2367,29 @@ void PrimaryVertexValidation::endJob()
   fillTrendPlotByIndex(n_dxyladderWidthTrend,h_norm_dxy_ladder_,pvparams::WIDTH);
   fillTrendPlotByIndex(n_dzladderMeanTrend  ,h_norm_dz_ladder_,pvparams::MEAN); 
   fillTrendPlotByIndex(n_dzladderWidthTrend ,h_norm_dz_ladder_,pvparams::WIDTH);
+
+  // medians and MADs	  
+  
+  fillTrendPlotByIndex(a_dxyPhiMedianTrend,a_dxyPhiResiduals,pvparams::MEDIAN);
+  fillTrendPlotByIndex(a_dxyPhiMADTrend   ,a_dxyPhiResiduals,pvparams::MAD);   
+  
+  fillTrendPlotByIndex(a_dzPhiMedianTrend ,a_dzPhiResiduals ,pvparams::MEDIAN);  
+  fillTrendPlotByIndex(a_dzPhiMADTrend    ,a_dzPhiResiduals ,pvparams::MAD); 
+  
+  fillTrendPlotByIndex(a_dxyEtaMedianTrend,a_dxyEtaResiduals,pvparams::MEDIAN);  
+  fillTrendPlotByIndex(a_dxyEtaMADTrend   ,a_dxyEtaResiduals,pvparams::MAD); 
+  fillTrendPlotByIndex(a_dzEtaMedianTrend ,a_dzEtaResiduals ,pvparams::MEDIAN);  
+  fillTrendPlotByIndex(a_dzEtaMADTrend    ,a_dzEtaResiduals ,pvparams::MAD); 
+  
+  fillTrendPlotByIndex(n_dxyPhiMedianTrend,n_dxyPhiResiduals,pvparams::MEDIAN);  
+  fillTrendPlotByIndex(n_dxyPhiMADTrend   ,n_dxyPhiResiduals,pvparams::MAD); 
+  fillTrendPlotByIndex(n_dzPhiMedianTrend ,n_dzPhiResiduals ,pvparams::MEDIAN);  
+  fillTrendPlotByIndex(n_dzPhiMADTrend    ,n_dzPhiResiduals ,pvparams::MAD); 
+  
+  fillTrendPlotByIndex(n_dxyEtaMedianTrend,n_dxyEtaResiduals,pvparams::MEDIAN);  
+  fillTrendPlotByIndex(n_dxyEtaMADTrend   ,n_dxyEtaResiduals,pvparams::MAD); 
+  fillTrendPlotByIndex(n_dzEtaMedianTrend ,n_dzEtaResiduals ,pvparams::MEDIAN);  
+  fillTrendPlotByIndex(n_dzEtaMADTrend    ,n_dzEtaResiduals ,pvparams::MAD); 
     
   // 2D Maps
 
@@ -2804,9 +2870,10 @@ std::vector<TH1F*> PrimaryVertexValidation::bookResidualsHistogram(const TFileDi
 
   TH1F::SetDefaultSumw2(kTRUE);
   
-  double up   =  theDetails_.range[std::make_pair(resType,varType)];
-  double down =  up*-1;
-  
+  auto hash = std::make_pair(resType,varType);
+
+  double down =  theDetails_.range[hash].first;
+  double up   =  theDetails_.range[hash].second;
 
   if(isNormalized){
     up   =  up/100.;
@@ -2984,13 +3051,14 @@ void PrimaryVertexValidation::fill(std::map<std::string, TH1*>& h,const std::str
 }
 
 //*************************************************************
-void PrimaryVertexValidation::fillByIndex(std::vector<TH1F*>& h, unsigned int index, double x)
+void PrimaryVertexValidation::fillByIndex(std::vector<TH1F*>& h, unsigned int index, double x,std::string tag)
 //*************************************************************
 {
+  //assert(!h.empty());
   if(index <= h.size()){
     h[index]->Fill(x);
   } else {
-    edm::LogWarning("PrimaryVertexValidation") << "Trying to fill non-existing Histogram with index " << index << " for array with size: "<<h.size()<< std::endl;
+    edm::LogWarning("PrimaryVertexValidation") << "Trying to fill non-existing Histogram with index " << index << " for array with size: "<<h.size()<<" tag: "<< tag<< std::endl;
     return;
   }
 }

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -147,6 +147,22 @@ PrimaryVertexValidation::PrimaryVertexValidation(const edm::ParameterSet& iConfi
     std::cout<<std::setw(10) << std::get<0>(PVValHelper::getTypeString(it.first.first)) << " "<< std::setw(10)<< std::get<0>(PVValHelper::getVarString(it.first.second)) << " (" << std::setw(5)<< it.second.first << ";" <<std::setw(5)<< it.second.second << ")"<<std::endl;
   }
 
+  theDetails_.trendbins[PVValHelper::phi] = PVValHelper::generateBins(nBins_+1,-TMath::Pi(),2*TMath::Pi());
+  theDetails_.trendbins[PVValHelper::eta] = PVValHelper::generateBins(nBins_+1,-etaOfProbe_,2*etaOfProbe_);
+
+  std::cout << "etaBins: ";
+  for (auto ieta: theDetails_.trendbins[PVValHelper::eta]) {
+    std::cout << ieta << " ";
+  }
+  std::cout << "\n";
+
+  std::cout << "phiBins: ";
+  for (auto iphi: theDetails_.trendbins[PVValHelper::phi]) {
+    std::cout << iphi << " ";
+  }
+  std::cout << "\n";
+
+  
 }
    
 // Destructor
@@ -2264,47 +2280,47 @@ void PrimaryVertexValidation::endJob()
 
   if(useTracksFromRecoVtx_){
 
-    fillTrendPlotByIndex(a_dxyPhiMeanBiasTrend ,a_dxyPhiBiasResiduals,PVValHelper::MEAN);  
-    fillTrendPlotByIndex(a_dxyPhiWidthBiasTrend,a_dxyPhiBiasResiduals,PVValHelper::WIDTH);
-    fillTrendPlotByIndex(a_dzPhiMeanBiasTrend  ,a_dzPhiBiasResiduals ,PVValHelper::MEAN);   
-    fillTrendPlotByIndex(a_dzPhiWidthBiasTrend ,a_dzPhiBiasResiduals ,PVValHelper::WIDTH);  
+    fillTrendPlotByIndex(a_dxyPhiMeanBiasTrend ,a_dxyPhiBiasResiduals,PVValHelper::MEAN,PVValHelper::phi);  
+    fillTrendPlotByIndex(a_dxyPhiWidthBiasTrend,a_dxyPhiBiasResiduals,PVValHelper::WIDTH,PVValHelper::phi);
+    fillTrendPlotByIndex(a_dzPhiMeanBiasTrend  ,a_dzPhiBiasResiduals ,PVValHelper::MEAN,PVValHelper::phi);   
+    fillTrendPlotByIndex(a_dzPhiWidthBiasTrend ,a_dzPhiBiasResiduals ,PVValHelper::WIDTH,PVValHelper::phi);  
     
-    fillTrendPlotByIndex(a_dxyEtaMeanBiasTrend ,a_dxyEtaBiasResiduals,PVValHelper::MEAN); 
-    fillTrendPlotByIndex(a_dxyEtaWidthBiasTrend,a_dxyEtaBiasResiduals,PVValHelper::WIDTH);
-    fillTrendPlotByIndex(a_dzEtaMeanBiasTrend  ,a_dzEtaBiasResiduals ,PVValHelper::MEAN); 
-    fillTrendPlotByIndex(a_dzEtaWidthBiasTrend ,a_dzEtaBiasResiduals ,PVValHelper::WIDTH);
+    fillTrendPlotByIndex(a_dxyEtaMeanBiasTrend ,a_dxyEtaBiasResiduals,PVValHelper::MEAN,PVValHelper::eta); 
+    fillTrendPlotByIndex(a_dxyEtaWidthBiasTrend,a_dxyEtaBiasResiduals,PVValHelper::WIDTH,PVValHelper::eta);
+    fillTrendPlotByIndex(a_dzEtaMeanBiasTrend  ,a_dzEtaBiasResiduals ,PVValHelper::MEAN,PVValHelper::eta); 
+    fillTrendPlotByIndex(a_dzEtaWidthBiasTrend ,a_dzEtaBiasResiduals ,PVValHelper::WIDTH,PVValHelper::eta);
     
-    fillTrendPlotByIndex(n_dxyPhiMeanBiasTrend ,n_dxyPhiBiasResiduals,PVValHelper::MEAN); 
-    fillTrendPlotByIndex(n_dxyPhiWidthBiasTrend,n_dxyPhiBiasResiduals,PVValHelper::WIDTH);
-    fillTrendPlotByIndex(n_dzPhiMeanBiasTrend  ,n_dzPhiBiasResiduals ,PVValHelper::MEAN); 
-    fillTrendPlotByIndex(n_dzPhiWidthBiasTrend ,n_dzPhiBiasResiduals ,PVValHelper::WIDTH);
+    fillTrendPlotByIndex(n_dxyPhiMeanBiasTrend ,n_dxyPhiBiasResiduals,PVValHelper::MEAN,PVValHelper::phi); 
+    fillTrendPlotByIndex(n_dxyPhiWidthBiasTrend,n_dxyPhiBiasResiduals,PVValHelper::WIDTH,PVValHelper::phi);
+    fillTrendPlotByIndex(n_dzPhiMeanBiasTrend  ,n_dzPhiBiasResiduals ,PVValHelper::MEAN,PVValHelper::phi); 
+    fillTrendPlotByIndex(n_dzPhiWidthBiasTrend ,n_dzPhiBiasResiduals ,PVValHelper::WIDTH,PVValHelper::phi);
     
-    fillTrendPlotByIndex(n_dxyEtaMeanBiasTrend ,n_dxyEtaBiasResiduals,PVValHelper::MEAN); 
-    fillTrendPlotByIndex(n_dxyEtaWidthBiasTrend,n_dxyEtaBiasResiduals,PVValHelper::WIDTH);
-    fillTrendPlotByIndex(n_dzEtaMeanBiasTrend  ,n_dzEtaBiasResiduals ,PVValHelper::MEAN); 
-    fillTrendPlotByIndex(n_dzEtaWidthBiasTrend ,n_dzEtaBiasResiduals ,PVValHelper::WIDTH);
+    fillTrendPlotByIndex(n_dxyEtaMeanBiasTrend ,n_dxyEtaBiasResiduals,PVValHelper::MEAN,PVValHelper::eta); 
+    fillTrendPlotByIndex(n_dxyEtaWidthBiasTrend,n_dxyEtaBiasResiduals,PVValHelper::WIDTH,PVValHelper::eta);
+    fillTrendPlotByIndex(n_dzEtaMeanBiasTrend  ,n_dzEtaBiasResiduals ,PVValHelper::MEAN,PVValHelper::eta); 
+    fillTrendPlotByIndex(n_dzEtaWidthBiasTrend ,n_dzEtaBiasResiduals ,PVValHelper::WIDTH,PVValHelper::eta);
     
     // medians and MADs	  
     
-    fillTrendPlotByIndex(a_dxyPhiMedianBiasTrend,a_dxyPhiBiasResiduals,PVValHelper::MEDIAN);  
-    fillTrendPlotByIndex(a_dxyPhiMADBiasTrend   ,a_dxyPhiBiasResiduals,PVValHelper::MAD); 
-    fillTrendPlotByIndex(a_dzPhiMedianBiasTrend ,a_dzPhiBiasResiduals ,PVValHelper::MEDIAN);  
-    fillTrendPlotByIndex(a_dzPhiMADBiasTrend    ,a_dzPhiBiasResiduals ,PVValHelper::MAD); 
+    fillTrendPlotByIndex(a_dxyPhiMedianBiasTrend,a_dxyPhiBiasResiduals,PVValHelper::MEDIAN,PVValHelper::phi);  
+    fillTrendPlotByIndex(a_dxyPhiMADBiasTrend   ,a_dxyPhiBiasResiduals,PVValHelper::MAD,PVValHelper::phi); 
+    fillTrendPlotByIndex(a_dzPhiMedianBiasTrend ,a_dzPhiBiasResiduals ,PVValHelper::MEDIAN,PVValHelper::phi);  
+    fillTrendPlotByIndex(a_dzPhiMADBiasTrend    ,a_dzPhiBiasResiduals ,PVValHelper::MAD,PVValHelper::phi); 
     
-    fillTrendPlotByIndex(a_dxyEtaMedianBiasTrend,a_dxyEtaBiasResiduals,PVValHelper::MEDIAN);  
-    fillTrendPlotByIndex(a_dxyEtaMADBiasTrend   ,a_dxyEtaBiasResiduals,PVValHelper::MAD); 
-    fillTrendPlotByIndex(a_dzEtaMedianBiasTrend ,a_dzEtaBiasResiduals ,PVValHelper::MEDIAN);  
-    fillTrendPlotByIndex(a_dzEtaMADBiasTrend    ,a_dzEtaBiasResiduals ,PVValHelper::MAD); 
+    fillTrendPlotByIndex(a_dxyEtaMedianBiasTrend,a_dxyEtaBiasResiduals,PVValHelper::MEDIAN,PVValHelper::eta);  
+    fillTrendPlotByIndex(a_dxyEtaMADBiasTrend   ,a_dxyEtaBiasResiduals,PVValHelper::MAD,PVValHelper::eta); 
+    fillTrendPlotByIndex(a_dzEtaMedianBiasTrend ,a_dzEtaBiasResiduals ,PVValHelper::MEDIAN,PVValHelper::eta);  
+    fillTrendPlotByIndex(a_dzEtaMADBiasTrend    ,a_dzEtaBiasResiduals ,PVValHelper::MAD,PVValHelper::eta); 
     
-    fillTrendPlotByIndex(n_dxyPhiMedianBiasTrend,n_dxyPhiBiasResiduals,PVValHelper::MEDIAN);  
-    fillTrendPlotByIndex(n_dxyPhiMADBiasTrend   ,n_dxyPhiBiasResiduals,PVValHelper::MAD); 
-    fillTrendPlotByIndex(n_dzPhiMedianBiasTrend ,n_dzPhiBiasResiduals ,PVValHelper::MEDIAN);  
-    fillTrendPlotByIndex(n_dzPhiMADBiasTrend    ,n_dzPhiBiasResiduals ,PVValHelper::MAD); 
+    fillTrendPlotByIndex(n_dxyPhiMedianBiasTrend,n_dxyPhiBiasResiduals,PVValHelper::MEDIAN,PVValHelper::phi);  
+    fillTrendPlotByIndex(n_dxyPhiMADBiasTrend   ,n_dxyPhiBiasResiduals,PVValHelper::MAD,PVValHelper::phi); 
+    fillTrendPlotByIndex(n_dzPhiMedianBiasTrend ,n_dzPhiBiasResiduals ,PVValHelper::MEDIAN,PVValHelper::phi);  
+    fillTrendPlotByIndex(n_dzPhiMADBiasTrend    ,n_dzPhiBiasResiduals ,PVValHelper::MAD,PVValHelper::phi); 
     
-    fillTrendPlotByIndex(n_dxyEtaMedianBiasTrend,n_dxyEtaBiasResiduals,PVValHelper::MEDIAN);  
-    fillTrendPlotByIndex(n_dxyEtaMADBiasTrend   ,n_dxyEtaBiasResiduals,PVValHelper::MAD); 
-    fillTrendPlotByIndex(n_dzEtaMedianBiasTrend ,n_dzEtaBiasResiduals ,PVValHelper::MEDIAN);  
-    fillTrendPlotByIndex(n_dzEtaMADBiasTrend    ,n_dzEtaBiasResiduals ,PVValHelper::MAD); 
+    fillTrendPlotByIndex(n_dxyEtaMedianBiasTrend,n_dxyEtaBiasResiduals,PVValHelper::MEDIAN,PVValHelper::eta);  
+    fillTrendPlotByIndex(n_dxyEtaMADBiasTrend   ,n_dxyEtaBiasResiduals,PVValHelper::MAD,PVValHelper::eta); 
+    fillTrendPlotByIndex(n_dzEtaMedianBiasTrend ,n_dzEtaBiasResiduals ,PVValHelper::MEDIAN,PVValHelper::eta);  
+    fillTrendPlotByIndex(n_dzEtaMADBiasTrend    ,n_dzEtaBiasResiduals ,PVValHelper::MAD,PVValHelper::eta); 
    
     // 2d Maps
 
@@ -2322,25 +2338,25 @@ void PrimaryVertexValidation::endJob()
 
   // do profiles
 
-  fillTrendPlotByIndex(a_dxyPhiMeanTrend, a_dxyPhiResiduals,PVValHelper::MEAN);  
-  fillTrendPlotByIndex(a_dxyPhiWidthTrend,a_dxyPhiResiduals,PVValHelper::WIDTH);  
-  fillTrendPlotByIndex(a_dzPhiMeanTrend  ,a_dzPhiResiduals ,PVValHelper::MEAN);   
-  fillTrendPlotByIndex(a_dzPhiWidthTrend ,a_dzPhiResiduals ,PVValHelper::WIDTH);  
+  fillTrendPlotByIndex(a_dxyPhiMeanTrend, a_dxyPhiResiduals,PVValHelper::MEAN,PVValHelper::phi);  
+  fillTrendPlotByIndex(a_dxyPhiWidthTrend,a_dxyPhiResiduals,PVValHelper::WIDTH,PVValHelper::phi);  
+  fillTrendPlotByIndex(a_dzPhiMeanTrend  ,a_dzPhiResiduals ,PVValHelper::MEAN,PVValHelper::phi);   
+  fillTrendPlotByIndex(a_dzPhiWidthTrend ,a_dzPhiResiduals ,PVValHelper::WIDTH,PVValHelper::phi);  
   
-  fillTrendPlotByIndex(a_dxyEtaMeanTrend ,a_dxyEtaResiduals,PVValHelper::MEAN); 
-  fillTrendPlotByIndex(a_dxyEtaWidthTrend,a_dxyEtaResiduals,PVValHelper::WIDTH);
-  fillTrendPlotByIndex(a_dzEtaMeanTrend  ,a_dzEtaResiduals ,PVValHelper::MEAN); 
-  fillTrendPlotByIndex(a_dzEtaWidthTrend ,a_dzEtaResiduals ,PVValHelper::WIDTH);
+  fillTrendPlotByIndex(a_dxyEtaMeanTrend ,a_dxyEtaResiduals,PVValHelper::MEAN,PVValHelper::eta); 
+  fillTrendPlotByIndex(a_dxyEtaWidthTrend,a_dxyEtaResiduals,PVValHelper::WIDTH,PVValHelper::eta);
+  fillTrendPlotByIndex(a_dzEtaMeanTrend  ,a_dzEtaResiduals ,PVValHelper::MEAN,PVValHelper::eta); 
+  fillTrendPlotByIndex(a_dzEtaWidthTrend ,a_dzEtaResiduals ,PVValHelper::WIDTH,PVValHelper::eta);
   
-  fillTrendPlotByIndex(n_dxyPhiMeanTrend ,n_dxyPhiResiduals,PVValHelper::MEAN); 
-  fillTrendPlotByIndex(n_dxyPhiWidthTrend,n_dxyPhiResiduals,PVValHelper::WIDTH);
-  fillTrendPlotByIndex(n_dzPhiMeanTrend  ,n_dzPhiResiduals ,PVValHelper::MEAN); 
+  fillTrendPlotByIndex(n_dxyPhiMeanTrend ,n_dxyPhiResiduals,PVValHelper::MEAN,PVValHelper::phi); 
+  fillTrendPlotByIndex(n_dxyPhiWidthTrend,n_dxyPhiResiduals,PVValHelper::WIDTH,PVValHelper::phi);
+  fillTrendPlotByIndex(n_dzPhiMeanTrend  ,n_dzPhiResiduals ,PVValHelper::MEAN,PVValHelper::phi); 
   fillTrendPlotByIndex(n_dzPhiWidthTrend ,n_dzPhiResiduals ,PVValHelper::WIDTH);
   
-  fillTrendPlotByIndex(n_dxyEtaMeanTrend ,n_dxyEtaResiduals,PVValHelper::MEAN); 
-  fillTrendPlotByIndex(n_dxyEtaWidthTrend,n_dxyEtaResiduals,PVValHelper::WIDTH);
-  fillTrendPlotByIndex(n_dzEtaMeanTrend  ,n_dzEtaResiduals ,PVValHelper::MEAN); 
-  fillTrendPlotByIndex(n_dzEtaWidthTrend ,n_dzEtaResiduals ,PVValHelper::WIDTH);
+  fillTrendPlotByIndex(n_dxyEtaMeanTrend ,n_dxyEtaResiduals,PVValHelper::MEAN,PVValHelper::eta); 
+  fillTrendPlotByIndex(n_dxyEtaWidthTrend,n_dxyEtaResiduals,PVValHelper::WIDTH,PVValHelper::eta);
+  fillTrendPlotByIndex(n_dzEtaMeanTrend  ,n_dzEtaResiduals ,PVValHelper::MEAN,PVValHelper::eta); 
+  fillTrendPlotByIndex(n_dzEtaWidthTrend ,n_dzEtaResiduals ,PVValHelper::WIDTH,PVValHelper::eta);
     
   // vs transverse momentum
 
@@ -2388,26 +2404,26 @@ void PrimaryVertexValidation::endJob()
 
   // medians and MADs	  
   
-  fillTrendPlotByIndex(a_dxyPhiMedianTrend,a_dxyPhiResiduals,PVValHelper::MEDIAN);
-  fillTrendPlotByIndex(a_dxyPhiMADTrend   ,a_dxyPhiResiduals,PVValHelper::MAD);   
+  fillTrendPlotByIndex(a_dxyPhiMedianTrend,a_dxyPhiResiduals,PVValHelper::MEDIAN,PVValHelper::phi);
+  fillTrendPlotByIndex(a_dxyPhiMADTrend   ,a_dxyPhiResiduals,PVValHelper::MAD,PVValHelper::phi);   
   
-  fillTrendPlotByIndex(a_dzPhiMedianTrend ,a_dzPhiResiduals ,PVValHelper::MEDIAN);  
-  fillTrendPlotByIndex(a_dzPhiMADTrend    ,a_dzPhiResiduals ,PVValHelper::MAD); 
+  fillTrendPlotByIndex(a_dzPhiMedianTrend ,a_dzPhiResiduals ,PVValHelper::MEDIAN,PVValHelper::phi);  
+  fillTrendPlotByIndex(a_dzPhiMADTrend    ,a_dzPhiResiduals ,PVValHelper::MAD,PVValHelper::phi); 
   
-  fillTrendPlotByIndex(a_dxyEtaMedianTrend,a_dxyEtaResiduals,PVValHelper::MEDIAN);  
-  fillTrendPlotByIndex(a_dxyEtaMADTrend   ,a_dxyEtaResiduals,PVValHelper::MAD); 
-  fillTrendPlotByIndex(a_dzEtaMedianTrend ,a_dzEtaResiduals ,PVValHelper::MEDIAN);  
-  fillTrendPlotByIndex(a_dzEtaMADTrend    ,a_dzEtaResiduals ,PVValHelper::MAD); 
+  fillTrendPlotByIndex(a_dxyEtaMedianTrend,a_dxyEtaResiduals,PVValHelper::MEDIAN,PVValHelper::eta);  
+  fillTrendPlotByIndex(a_dxyEtaMADTrend   ,a_dxyEtaResiduals,PVValHelper::MAD,PVValHelper::eta); 
+  fillTrendPlotByIndex(a_dzEtaMedianTrend ,a_dzEtaResiduals ,PVValHelper::MEDIAN,PVValHelper::eta);  
+  fillTrendPlotByIndex(a_dzEtaMADTrend    ,a_dzEtaResiduals ,PVValHelper::MAD,PVValHelper::eta); 
   
-  fillTrendPlotByIndex(n_dxyPhiMedianTrend,n_dxyPhiResiduals,PVValHelper::MEDIAN);  
-  fillTrendPlotByIndex(n_dxyPhiMADTrend   ,n_dxyPhiResiduals,PVValHelper::MAD); 
-  fillTrendPlotByIndex(n_dzPhiMedianTrend ,n_dzPhiResiduals ,PVValHelper::MEDIAN);  
-  fillTrendPlotByIndex(n_dzPhiMADTrend    ,n_dzPhiResiduals ,PVValHelper::MAD); 
+  fillTrendPlotByIndex(n_dxyPhiMedianTrend,n_dxyPhiResiduals,PVValHelper::MEDIAN,PVValHelper::phi);  
+  fillTrendPlotByIndex(n_dxyPhiMADTrend   ,n_dxyPhiResiduals,PVValHelper::MAD,PVValHelper::phi); 
+  fillTrendPlotByIndex(n_dzPhiMedianTrend ,n_dzPhiResiduals ,PVValHelper::MEDIAN,PVValHelper::phi);  
+  fillTrendPlotByIndex(n_dzPhiMADTrend    ,n_dzPhiResiduals ,PVValHelper::MAD,PVValHelper::phi); 
   
-  fillTrendPlotByIndex(n_dxyEtaMedianTrend,n_dxyEtaResiduals,PVValHelper::MEDIAN);  
-  fillTrendPlotByIndex(n_dxyEtaMADTrend   ,n_dxyEtaResiduals,PVValHelper::MAD); 
-  fillTrendPlotByIndex(n_dzEtaMedianTrend ,n_dzEtaResiduals ,PVValHelper::MEDIAN);  
-  fillTrendPlotByIndex(n_dzEtaMADTrend    ,n_dzEtaResiduals ,PVValHelper::MAD); 
+  fillTrendPlotByIndex(n_dxyEtaMedianTrend,n_dxyEtaResiduals,PVValHelper::MEDIAN,PVValHelper::eta);  
+  fillTrendPlotByIndex(n_dxyEtaMADTrend   ,n_dxyEtaResiduals,PVValHelper::MAD,PVValHelper::eta); 
+  fillTrendPlotByIndex(n_dzEtaMedianTrend ,n_dzEtaResiduals ,PVValHelper::MEDIAN,PVValHelper::eta);  
+  fillTrendPlotByIndex(n_dzEtaMADTrend    ,n_dzEtaResiduals ,PVValHelper::MAD,PVValHelper::eta); 
     
   // 2D Maps
 
@@ -2674,7 +2690,7 @@ void PrimaryVertexValidation::fillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot
 }
 
 //*************************************************************
-void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,std::vector<TH1F*>& h,  PVValHelper::estimator fitPar_)
+void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,std::vector<TH1F*>& h,  PVValHelper::estimator fitPar_, PVValHelper::plotVariable plotVar)
 //*************************************************************
 {  
 
@@ -2721,6 +2737,20 @@ void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,std::vector<T
 	edm::LogWarning("PrimaryVertexValidation")<<"fillTrendPlotByIndex() "<<fitPar_<<" unknown estimator!"<<std::endl;
 	break;
       }
+
+    char bincenter[129];
+    if(plotVar == PVValHelper::eta){
+      auto etaBins = theDetails_.trendbins[PVValHelper::eta];
+      sprintf(bincenter,"%.1f",(etaBins[bin-1]+etaBins[bin])/2.);      
+      trendPlot->GetXaxis()->SetBinLabel(bin,bincenter); 
+    } else if(plotVar == PVValHelper::phi){
+      auto phiBins = theDetails_.trendbins[PVValHelper::phi];
+      sprintf(bincenter,"%.1f",180.*(phiBins[bin-1]+phiBins[bin])/(2.*TMath::Pi()));
+      trendPlot->GetXaxis()->SetBinLabel(bin,bincenter); 
+    } else {
+      //edm::LogWarning("PrimaryVertexValidation")<<"fillTrendPlotByIndex() "<< plotVar <<" unknown track parameter!"<<std::endl;
+    }
+    
   }
 }
 
@@ -2913,8 +2943,13 @@ std::vector<TH1F*> PrimaryVertexValidation::bookResidualsHistogram(const TFileDi
   std::string units     = std::get<2>(PVValHelper::getTypeString(resType));
 
   for(unsigned int i=0; i<theNOfBins;i++){
+
+    TString title = (varType == PVValHelper::phi || varType == PVValHelper::eta) ? 	 
+      Form("%s vs %s - bin %i (%f < %s < %f);%s %s;tracks",t_resType.c_str(),t_varType.c_str(),i, theDetails_.trendbins[varType][i],t_varType.c_str(),theDetails_.trendbins[varType][i+1],t_resType.c_str(),units.c_str()) : Form("%s vs %s - bin %i;%s %s;tracks",t_resType.c_str(),t_varType.c_str(),i,t_resType.c_str(),units.c_str());
+
     TH1F* htemp = dir.make<TH1F>(Form("histo_%s_%s_plot%i",s_resType.c_str(),s_varType.c_str(),i),
-				 Form("%s vs %s - bin %i;%s %s;tracks",t_resType.c_str(),t_varType.c_str(),i,t_resType.c_str(),units.c_str()),
+				 //Form("%s vs %s - bin %i;%s %s;tracks",t_resType.c_str(),t_varType.c_str(),i,t_resType.c_str(),units.c_str()),
+				 title.Data(),
 				 theDetails_.histobins,down,up); 
     h.push_back(htemp);
   }

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -2789,13 +2789,13 @@ std::vector<TH1F*> PrimaryVertexValidation::bookResidualsHistogram(const TFileDi
 
   TH1F::SetDefaultSumw2(kTRUE);
   
-  double up   = 1000;
-  double down = -up;
+  double up   =  1000;
+  double down = -1000.;
   
 
   if(isNormalized){
-    up = up*(1/100);
-    down = down*(1/100);
+    up   =  10.;
+    down = -10.;
   }
   
   std::vector<TH1F*> h;
@@ -2806,12 +2806,16 @@ std::vector<TH1F*> PrimaryVertexValidation::bookResidualsHistogram(const TFileDi
     assert(false);
   }
   
-  std::string s_resType = this->getTypeString(resType);
-  std::string s_varType = this->getVarString(varType);
+  std::string s_resType = std::get<0>(this->getTypeString(resType));
+  std::string s_varType = std::get<0>(this->getVarString(varType));
       
+  std::string t_resType = std::get<1>(this->getTypeString(resType));
+  std::string t_varType = std::get<1>(this->getVarString(varType));
+  std::string units     = std::get<2>(this->getTypeString(resType));
+
   for(unsigned int i=0; i<theNOfBins;i++){
     TH1F* htemp = dir.make<TH1F>(Form("histo_%s_%s_plot%i",s_resType.c_str(),s_varType.c_str(),i),
-				 Form("%s vs %s - bin %i;%s;tracks",s_resType.c_str(),s_varType.c_str(),i,s_resType.c_str()),
+				 Form("%s vs %s - bin %i;%s %s;tracks",t_resType.c_str(),t_varType.c_str(),i,t_resType.c_str(),units.c_str()),
 				 500,down,up); 
     h.push_back(htemp);
   }
@@ -2984,64 +2988,64 @@ void PrimaryVertexValidation::shrinkHistVectorToFit(std::vector<TH1F*>&h, unsign
 }
 
 //*************************************************************
-std::string PrimaryVertexValidation::getTypeString (pvparams::residualType type)
+std::tuple<std::string,std::string,std::string> PrimaryVertexValidation::getTypeString (pvparams::residualType type)
 //*************************************************************
 {
-  std::string returnType = "";
+  std::tuple<std::string,std::string,std::string> returnType;
   switch(type)
     {
     // absoulte
 
     case pvparams::dxy  :
-      returnType = "d_{xy}";
+      returnType = std::make_tuple("dxy","d_{xy}","[#mum]");
       break;
     case pvparams::dx   :
-      returnType = "d_{x}";
+      returnType = std::make_tuple("dx","d_{x}","[#mum]");
       break;
     case pvparams::dy   :
-      returnType = "d_{y}";
+      returnType = std::make_tuple("dy","d_{y}","[#mum]");
       break;
     case pvparams::dz   :
-      returnType = "d_{z}";
+      returnType =  std::make_tuple("dz","d_{z}","[#mum]");
       break;
     case pvparams::IP2D :
-      returnType = "IP_{2D}";
+      returnType =  std::make_tuple("IP2D","IP_{2D}","[#mum]");
       break;
     case pvparams::resz :
-      returnType = "z_{trk}-z_{vtx}";
+      returnType =  std::make_tuple("resz","z_{trk}-z_{vtx}","[#mum]");
       break;
     case pvparams::IP3D :
-      returnType = "IP_{3D}";
+      returnType =  std::make_tuple("IP3D","IP_{3D}","[#mum]");
       break;
     case pvparams::d3D  : 
-      returnType = "d_{3D}";
+      returnType =  std::make_tuple("d3D","d_{3D}","[#mum]");
       break;
 
     // normalized
 
     case pvparams::norm_dxy  :
-      returnType = "d_{xy}/#sigma_{d_{xy}}";
+      returnType =  std::make_tuple("norm_dxy","d_{xy}/#sigma_{d_{xy}}","");
       break;
     case pvparams::norm_dx   :
-      returnType = "d_{x}/#sigma_{d_{x}}";
+      returnType =  std::make_tuple("norm_dx","d_{x}/#sigma_{d_{x}}","");
       break;
     case pvparams::norm_dy   :
-      returnType = "d_{y}/#sigma_{d_{y}}";
+      returnType =  std::make_tuple("norm_dy","d_{y}/#sigma_{d_{y}}","");
       break;
     case pvparams::norm_dz   :
-      returnType = "d_{z}/#sigma_{d_{z}}";
+      returnType =  std::make_tuple("norm_dz","d_{z}/#sigma_{d_{z}}","");
       break;
     case pvparams::norm_IP2D :
-      returnType = "IP_{2D}/#sigma_{IP_{2D}}";
+      returnType =  std::make_tuple("norm_IP2D","IP_{2D}/#sigma_{IP_{2D}}","");
       break;
     case pvparams::norm_resz :
-      returnType = "z_{trk}-z_{vtx}/#sigma_{res_{z}}";
+      returnType =  std::make_tuple("norm_resz","z_{trk}-z_{vtx}/#sigma_{res_{z}}","");
       break;
     case pvparams::norm_IP3D :
-      returnType = "IP_{3D}/#sigma_{IP_{3D}}";
+      returnType =  std::make_tuple("norm_IP3D","IP_{3D}/#sigma_{IP_{3D}}","");
       break;
     case pvparams::norm_d3D  : 
-      returnType = "d_{3D}/#sigma_{d_{3D}}";
+      returnType =  std::make_tuple("norm_d3D","d_{3D}/#sigma_{d_{3D}}","");
       break;
 
     default:
@@ -3053,29 +3057,29 @@ std::string PrimaryVertexValidation::getTypeString (pvparams::residualType type)
 }
 
 //*************************************************************
-std::string PrimaryVertexValidation::getVarString (pvparams::plotVariable var)
+std::tuple<std::string,std::string,std::string> PrimaryVertexValidation::getVarString (pvparams::plotVariable var)
 //*************************************************************
 {
-  std::string returnVar = "";
+  std::tuple<std::string,std::string,std::string> returnVar;
   switch(var)
     {
     case pvparams::phi  :
-      returnVar = "#phi";
+      returnVar =  std::make_tuple("phi","#phi","[rad]");
       break;
     case pvparams::eta   :
-      returnVar = "#eta";
+      returnVar =  std::make_tuple("eta","#eta","");
       break;
     case pvparams::pT   :
-      returnVar = "p_{T}";
+      returnVar = std::make_tuple("pT","p_{T}","[GeV]");
       break;
     case pvparams::pTCentral :
-      returnVar = "p_{T} |#eta|<1.";
+      returnVar = std::make_tuple("pTCentral","p_{T} |#eta|<1.","[GeV]");
       break;
     case pvparams::ladder   :
-      returnVar = "ladder number";
+      returnVar = std::make_tuple("ladder","ladder number","");
       break;
     case pvparams::modZ :
-      returnVar = "module number";
+      returnVar = std::make_tuple("modZ","module number","");
       break;
     default:
       edm::LogWarning("PrimaryVertexValidation:") <<" getVarString() unknown plot variable"<<var<<std::endl;

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -137,8 +137,8 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   void fill(std::map<std::string, TH1*>& h,const std::string& s, double x, double y);
   void fillByIndex(std::vector<TH1F*>& h, unsigned int index, double x); 
   void shrinkHistVectorToFit(std::vector<TH1F*>&h,unsigned int desired_size);
-  std::string getTypeString (pvparams::residualType type);
-  std::string getVarString (pvparams::plotVariable var);
+  std::tuple<std::string,std::string,std::string> getTypeString (pvparams::residualType type);
+  std::tuple<std::string,std::string,std::string> getVarString (pvparams::plotVariable var);
 
   void fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100][100], pvparams::estimator fitPar_);
   

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -16,6 +16,7 @@
 
 // CMSSW includes
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
@@ -102,6 +103,7 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   void fill(std::map<std::string, TH1*>& h,const std::string& s, double x);
   void fill(std::map<std::string, TH1*>& h,const std::string& s, double x, double y);
   void fillByIndex(std::vector<TH1F*>& h, unsigned int index, double x); 
+  void shrinkHistVectorToFit(std::vector<TH1F*>&h,unsigned int desired_size);
   void fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100][100], statmode::estimator fitPar_);
   
   inline double square(double x){
@@ -160,7 +162,9 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
 
   float phiSect_;
   float etaSect_;
-
+  int   nLadders_= 20;
+  int   nModZ_   =  8;
+  
   // pT binning as in paragraph 3.2 of CMS-PAS-TRK-10-005 (https://cds.cern.ch/record/1279383/files/TRK-10-005-pas.pdf)
 
   //                                      0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  24  25  26  27  28  29  30  31  32  33  34  35  36   37  38   39  40  41  42  43  44  45   46  47  48
@@ -242,6 +246,16 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
 
   int   hasRecVertex_[nMaxtracks_];
   int   isGoodTrack_[nMaxtracks_];
+
+  edm::Service<TFileService> fs;
+
+  TFileDirectory MeanTrendsDir;
+  TFileDirectory WidthTrendsDir; 
+  TFileDirectory MedianTrendsDir;
+  TFileDirectory MADTrendsDir;   
+  				
+  TFileDirectory Mean2DMapsDir;  
+  TFileDirectory Width2DMapsDir; 
 
   // histogram for max(eta)
   TH1F* h_etaMax;

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -83,7 +83,7 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   std::pair<Measurement1D, Measurement1D > fitResiduals(TH1 *hist);
 
   void fillTrendPlot(TH1F* trendPlot, TH1F *residualsPlot[100], PVValHelper::estimator fitPar_, const std::string& var_);
-  void fillTrendPlotByIndex(TH1F* trendPlot,std::vector<TH1F*>& h, PVValHelper::estimator fitPar_); 
+  void fillTrendPlotByIndex(TH1F* trendPlot,std::vector<TH1F*>& h, PVValHelper::estimator fitPar_,PVValHelper::plotVariable plotVar=PVValHelper::END_OF_PLOTS); 
 
   static bool vtxSort( const reco::Vertex &  a, const reco::Vertex & b );
   bool passesTrackCuts(const reco::Track & track, const reco::Vertex & vertex,const std::string& qualityString_, double dxyErrMax_,double dzErrMax_, double ptErrMax_);

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -102,7 +102,7 @@ namespace pvparams{
 
   struct histodetails
   {
-    std::map<std::pair<residualType,plotVariable>,float> range;
+    std::map<std::pair<residualType,plotVariable>,std::pair<float,float>> range;
     int histobins;
   };
 
@@ -142,9 +142,11 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
 
   void fillTrackHistos(std::map<std::string, TH1*> & h, const std::string & ttype, const reco::TransientTrack *tt, const reco::Vertex & v,const reco::BeamSpot & beamSpot, double fBfield);
   void add(std::map<std::string, TH1*>& h, TH1* hist);
+
   void fill(std::map<std::string, TH1*>& h,const std::string& s, double x);
   void fill(std::map<std::string, TH1*>& h,const std::string& s, double x, double y);
-  void fillByIndex(std::vector<TH1F*>& h, unsigned int index, double x); 
+  void fillByIndex(std::vector<TH1F*>& h, unsigned int index, double x,std::string tag=""); 
+
   void shrinkHistVectorToFit(std::vector<TH1F*>&h,unsigned int desired_size);
   std::tuple<std::string,std::string,std::string> getTypeString (pvparams::residualType type);
   std::tuple<std::string,std::string,std::string> getVarString (pvparams::plotVariable var);
@@ -313,49 +315,50 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   
   // absolute residuals
 
-  TH1F* a_dxyPhiResiduals[nMaxBins_];
-  TH1F* a_dxyEtaResiduals[nMaxBins_];
+  //TH1F* a_dxyPhiResiduals[nMaxBins_];
+  std::vector<TH1F*> a_dxyPhiResiduals;
+  std::vector<TH1F*> a_dxyEtaResiduals;
 
-  TH1F* a_dxPhiResiduals[nMaxBins_];
-  TH1F* a_dxEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> a_dxPhiResiduals;
+  std::vector<TH1F*> a_dxEtaResiduals;
 
-  TH1F* a_dyPhiResiduals[nMaxBins_];
-  TH1F* a_dyEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> a_dyPhiResiduals;
+  std::vector<TH1F*> a_dyEtaResiduals;
 
-  TH1F* a_dzPhiResiduals[nMaxBins_];
-  TH1F* a_dzEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> a_dzPhiResiduals;
+  std::vector<TH1F*> a_dzEtaResiduals;
   
-  TH1F* a_IP2DPhiResiduals[nMaxBins_];
-  TH1F* a_IP2DEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> a_IP2DPhiResiduals;
+  std::vector<TH1F*> a_IP2DEtaResiduals;
   
-  TH1F* a_IP3DPhiResiduals[nMaxBins_];
-  TH1F* a_IP3DEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> a_IP3DPhiResiduals;
+  std::vector<TH1F*> a_IP3DEtaResiduals;
 
-  TH1F* a_reszPhiResiduals[nMaxBins_];
-  TH1F* a_reszEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> a_reszPhiResiduals;
+  std::vector<TH1F*> a_reszEtaResiduals;
 
-  TH1F* a_d3DPhiResiduals[nMaxBins_];
-  TH1F* a_d3DEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> a_d3DPhiResiduals;
+  std::vector<TH1F*> a_d3DEtaResiduals;
 
   // normalized residuals
 
-  TH1F* n_dxyPhiResiduals[nMaxBins_];
-  TH1F* n_dxyEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> n_dxyPhiResiduals;
+  std::vector<TH1F*> n_dxyEtaResiduals;
   
-  TH1F* n_dzPhiResiduals[nMaxBins_];
-  TH1F* n_dzEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> n_dzPhiResiduals;
+  std::vector<TH1F*> n_dzEtaResiduals;
   
-  TH1F* n_IP2DPhiResiduals[nMaxBins_];
-  TH1F* n_IP2DEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> n_IP2DPhiResiduals;
+  std::vector<TH1F*> n_IP2DEtaResiduals;
   
-  TH1F* n_IP3DPhiResiduals[nMaxBins_];
-  TH1F* n_IP3DEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> n_IP3DPhiResiduals;
+  std::vector<TH1F*> n_IP3DEtaResiduals;
 
-  TH1F* n_reszPhiResiduals[nMaxBins_];
-  TH1F* n_reszEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> n_reszPhiResiduals;
+  std::vector<TH1F*> n_reszEtaResiduals;
 
-  TH1F* n_d3DPhiResiduals[nMaxBins_];
-  TH1F* n_d3DEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> n_d3DPhiResiduals;
+  std::vector<TH1F*> n_d3DEtaResiduals;
 
   // for the maps
 

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -59,13 +59,43 @@
 // residuals moments estimation 
 //
 
-namespace statmode{
+namespace pvparams{
+  
   enum estimator 
     { MEAN   = 1,
       WIDTH  = 2, 
       MEDIAN = 3,
       MAD    = 4,
       UNKWN  = -1
+    };
+  
+  enum residualType 
+    { dxy = 1,
+      dx  = 2,
+      dy  = 3,
+      dz  = 4,
+      IP2D = 5,
+      resz = 6,
+      IP3D = 7,
+      d3D  = 8,
+      
+      norm_dxy = 9,
+      norm_dx  = 10,
+      norm_dy  = 11,
+      norm_dz  = 12,
+      norm_IP2D = 13,
+      norm_resz = 14,
+      norm_IP3D = 15,
+      norm_d3D  = 16,
+    };
+    
+  enum plotVariable
+    { phi    = 1,
+      eta    = 2,
+      pT     = 3,
+      pTCentral = 4,
+      ladder = 5,
+      modZ   = 6,
     };
 }
 
@@ -90,21 +120,27 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   Measurement1D getMedian(TH1F *histo);
   Measurement1D getMAD(TH1F *histo);
   std::pair<Measurement1D, Measurement1D > fitResiduals(TH1 *hist);
+
   void fillTrendPlot(TH1F* trendPlot, TH1F *residualsPlot[100], statmode::estimator fitPar_,const std::string& var_);
   void fillTrendPlotByIndex(TH1F* trendPlot,std::vector<TH1F*>& h, statmode::estimator fitPar_); 
 
   static bool vtxSort( const reco::Vertex &  a, const reco::Vertex & b );
   bool passesTrackCuts(const reco::Track & track, const reco::Vertex & vertex,const std::string& qualityString_, double dxyErrMax_,double dzErrMax_, double ptErrMax_);
 
+
   std::vector<TH1F*> bookResidualsHistogram(const TFileDirectory& dir,unsigned int theNOfBins,std::string resType,const std::string& varType); 
   std::map<std::string, TH1*> bookVertexHistograms(const TFileDirectory& dir);
+
   void fillTrackHistos(std::map<std::string, TH1*> & h, const std::string & ttype, const reco::TransientTrack *tt, const reco::Vertex & v,const reco::BeamSpot & beamSpot, double fBfield);
   void add(std::map<std::string, TH1*>& h, TH1* hist);
   void fill(std::map<std::string, TH1*>& h,const std::string& s, double x);
   void fill(std::map<std::string, TH1*>& h,const std::string& s, double x, double y);
   void fillByIndex(std::vector<TH1F*>& h, unsigned int index, double x); 
   void shrinkHistVectorToFit(std::vector<TH1F*>&h,unsigned int desired_size);
-  void fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100][100], statmode::estimator fitPar_);
+  std::string getTypeString (pvparams::residualType type);
+  std::string getVarString (pvparams::plotVariable var);
+
+  void fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100][100], pvparams::estimator fitPar_);
   
   inline double square(double x){
     return x*x;

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -161,10 +161,8 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   static const int cmToum = 10000;
   static const int nPtBins_ = 48;
 
-  float phiSect_;
-  float etaSect_;
-  int   nLadders_= 20;
-  int   nModZ_   =  8;
+  unsigned int   nLadders_= 20;
+  unsigned int   nModZ_   =  8;
   
   // pT binning as in paragraph 3.2 of CMS-PAS-TRK-10-005 (https://cds.cern.ch/record/1279383/files/TRK-10-005-pas.pdf)
 

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -130,12 +130,11 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   Measurement1D getMAD(TH1F *histo);
   std::pair<Measurement1D, Measurement1D > fitResiduals(TH1 *hist);
 
-  void fillTrendPlot(TH1F* trendPlot, TH1F *residualsPlot[100], statmode::estimator fitPar_,const std::string& var_);
-  void fillTrendPlotByIndex(TH1F* trendPlot,std::vector<TH1F*>& h, statmode::estimator fitPar_); 
+  void fillTrendPlot(TH1F* trendPlot, TH1F *residualsPlot[100], pvparams::estimator fitPar_, const std::string& var_);
+  void fillTrendPlotByIndex(TH1F* trendPlot,std::vector<TH1F*>& h, pvparams::estimator fitPar_); 
 
   static bool vtxSort( const reco::Vertex &  a, const reco::Vertex & b );
   bool passesTrackCuts(const reco::Track & track, const reco::Vertex & vertex,const std::string& qualityString_, double dxyErrMax_,double dzErrMax_, double ptErrMax_);
-
 
   std::vector<TH1F*> bookResidualsHistogram(const TFileDirectory& dir,unsigned int theNOfBins,std::string resType,const std::string& varType); 
   std::map<std::string, TH1*> bookVertexHistograms(const TFileDirectory& dir);
@@ -315,7 +314,6 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   
   // absolute residuals
 
-  //TH1F* a_dxyPhiResiduals[nMaxBins_];
   std::vector<TH1F*> a_dxyPhiResiduals;
   std::vector<TH1F*> a_dxyEtaResiduals;
 
@@ -464,7 +462,8 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   TH2F* n_dxyWidthMap;
   TH2F* n_dzWidthMap;
 
-  // ---- directly histograms =================> biased residuals
+  // ---- directly histograms 
+  // biased residuals
   
   // absolute residuals
 
@@ -490,7 +489,7 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   TH1F* n_dxyBiasResidualsMap[nMaxBins_][nMaxBins_];  				 
   TH1F* n_dzBiasResidualsMap[nMaxBins_][nMaxBins_];
 
-  // ---- trends as function of phi
+  // ---- trends as function of phi / eta
   
   TH1F* a_dxyPhiMeanBiasTrend;
   TH1F* a_dxyPhiWidthBiasTrend;

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -53,60 +53,12 @@
 #include "TrackingTools/IPTools/interface/IPTools.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateClosestToPoint.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "Alignment/OfflineValidation/interface/PVValidationHelpers.h"
 
 //
 // ancyllary enum for 
 // residuals moments estimation 
 //
-
-namespace pvparams{
-  
-  enum estimator 
-    { MEAN   = 1,
-      WIDTH  = 2, 
-      MEDIAN = 3,
-      MAD    = 4,
-      UNKWN  = -1
-    };
-  
-  enum residualType 
-    { dxy = 1,
-      dx  = 2,
-      dy  = 3,
-      dz  = 4,
-      IP2D = 5,
-      resz = 6,
-      IP3D = 7,
-      d3D  = 8,
-      
-      norm_dxy = 9,
-      norm_dx  = 10,
-      norm_dy  = 11,
-      norm_dz  = 12,
-      norm_IP2D = 13,
-      norm_resz = 14,
-      norm_IP3D = 15,
-      norm_d3D  = 16,
-      END_OF_TYPES = 17,
-    };
-    
-  enum plotVariable
-    { phi    = 1,
-      eta    = 2,
-      pT     = 3,
-      pTCentral = 4,
-      ladder = 5,
-      modZ   = 6,
-      END_OF_PLOTS = 7,
-    };
-
-  struct histodetails
-  {
-    std::map<std::pair<residualType,plotVariable>,std::pair<float,float>> range;
-    int histobins;
-  };
-
-}
 
 //
 // class decleration
@@ -130,13 +82,13 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   Measurement1D getMAD(TH1F *histo);
   std::pair<Measurement1D, Measurement1D > fitResiduals(TH1 *hist);
 
-  void fillTrendPlot(TH1F* trendPlot, TH1F *residualsPlot[100], pvparams::estimator fitPar_, const std::string& var_);
-  void fillTrendPlotByIndex(TH1F* trendPlot,std::vector<TH1F*>& h, pvparams::estimator fitPar_); 
+  void fillTrendPlot(TH1F* trendPlot, TH1F *residualsPlot[100], PVValHelper::estimator fitPar_, const std::string& var_);
+  void fillTrendPlotByIndex(TH1F* trendPlot,std::vector<TH1F*>& h, PVValHelper::estimator fitPar_); 
 
   static bool vtxSort( const reco::Vertex &  a, const reco::Vertex & b );
   bool passesTrackCuts(const reco::Track & track, const reco::Vertex & vertex,const std::string& qualityString_, double dxyErrMax_,double dzErrMax_, double ptErrMax_);
 
-  std::vector<TH1F*> bookResidualsHistogram(const TFileDirectory& dir,unsigned int theNOfBins,std::string resType,const std::string& varType); 
+  std::vector<TH1F*> bookResidualsHistogram(TFileDirectory dir,unsigned int theNOfBins,PVValHelper::residualType resType,PVValHelper::plotVariable varType, bool isNormalized=false); 
   std::map<std::string, TH1*> bookVertexHistograms(const TFileDirectory& dir);
 
   void fillTrackHistos(std::map<std::string, TH1*> & h, const std::string & ttype, const reco::TransientTrack *tt, const reco::Vertex & v,const reco::BeamSpot & beamSpot, double fBfield);
@@ -147,10 +99,10 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   void fillByIndex(std::vector<TH1F*>& h, unsigned int index, double x,std::string tag=""); 
 
   void shrinkHistVectorToFit(std::vector<TH1F*>&h,unsigned int desired_size);
-  std::tuple<std::string,std::string,std::string> getTypeString (pvparams::residualType type);
-  std::tuple<std::string,std::string,std::string> getVarString (pvparams::plotVariable var);
+  std::tuple<std::string,std::string,std::string> getTypeString (PVValHelper::residualType type);
+  std::tuple<std::string,std::string,std::string> getVarString (PVValHelper::plotVariable var);
 
-  void fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100][100], pvparams::estimator fitPar_);
+  void fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100][100], PVValHelper::estimator fitPar_);
   
   inline double square(double x){
     return x*x;
@@ -172,7 +124,7 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   bool useTracksFromRecoVtx_; 
   
   // histogram details
-  pvparams::histodetails theDetails_;
+  PVValHelper::histodetails theDetails_;
   
   // requirements on the vertex
   double vertexZMax_;
@@ -461,25 +413,26 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
 
   TH2F* n_dxyWidthMap;
   TH2F* n_dzWidthMap;
-
+  
+  //
   // ---- directly histograms 
   // biased residuals
   
   // absolute residuals
 
-  TH1F* a_dxyPhiBiasResiduals[nMaxBins_];
-  TH1F* a_dxyEtaBiasResiduals[nMaxBins_];
+  std::vector<TH1F*> a_dxyPhiBiasResiduals;
+  std::vector<TH1F*> a_dxyEtaBiasResiduals;
   
-  TH1F* a_dzPhiBiasResiduals[nMaxBins_];
-  TH1F* a_dzEtaBiasResiduals[nMaxBins_];
+  std::vector<TH1F*> a_dzPhiBiasResiduals;
+  std::vector<TH1F*> a_dzEtaBiasResiduals;
   
   // normalized BiasResiduals
 
-  TH1F* n_dxyPhiBiasResiduals[nMaxBins_];
-  TH1F* n_dxyEtaBiasResiduals[nMaxBins_];
+  std::vector<TH1F*> n_dxyPhiBiasResiduals;
+  std::vector<TH1F*> n_dxyEtaBiasResiduals;
   
-  TH1F* n_dzPhiBiasResiduals[nMaxBins_];
-  TH1F* n_dzEtaBiasResiduals[nMaxBins_];
+  std::vector<TH1F*> n_dzPhiBiasResiduals;
+  std::vector<TH1F*> n_dzEtaBiasResiduals;
   
   // for the maps
 

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -88,7 +88,7 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   static bool vtxSort( const reco::Vertex &  a, const reco::Vertex & b );
   bool passesTrackCuts(const reco::Track & track, const reco::Vertex & vertex,const std::string& qualityString_, double dxyErrMax_,double dzErrMax_, double ptErrMax_);
 
-  std::vector<TH1F*> bookResidualsHistogram(TFileDirectory dir,unsigned int theNOfBins,PVValHelper::residualType resType,PVValHelper::plotVariable varType, bool isNormalized=false); 
+  std::vector<TH1F*> bookResidualsHistogram(const TFileDirectory& dir,unsigned int theNOfBins,PVValHelper::residualType resType,PVValHelper::plotVariable varType, bool isNormalized=false); 
   std::map<std::string, TH1*> bookVertexHistograms(const TFileDirectory& dir);
 
   void fillTrackHistos(std::map<std::string, TH1*> & h, const std::string & ttype, const reco::TransientTrack *tt, const reco::Vertex & v,const reco::BeamSpot & beamSpot, double fBfield);
@@ -363,6 +363,28 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   TH1F* n_dxypTCentralWidthTrend;
   TH1F* n_dzpTCentralMeanTrend;
   TH1F* n_dzpTCentralWidthTrend;
+
+  // --- trend as a function of the ladder/module number
+
+  TH1F* a_dxymodZMeanTrend;					     		
+  TH1F* a_dxymodZWidthTrend; 					      			
+  TH1F* a_dzmodZMeanTrend; 		       		      			
+  TH1F* a_dzmodZWidthTrend; 
+					       			
+  TH1F* a_dxyladderMeanTrend;  						 			
+  TH1F* a_dxyladderWidthTrend; 					        		       
+  TH1F* a_dzladderMeanTrend;   					        			
+  TH1F* a_dzladderWidthTrend;  
+						 		      
+  TH1F* n_dxymodZMeanTrend;   						 			
+  TH1F* n_dxymodZWidthTrend;  					        			
+  TH1F* n_dzmodZMeanTrend;   					        			
+  TH1F* n_dzmodZWidthTrend;  
+						 			
+  TH1F* n_dxyladderMeanTrend;  						 			
+  TH1F* n_dxyladderWidthTrend; 						 			
+  TH1F* n_dzladderMeanTrend;   						 			
+  TH1F* n_dzladderWidthTrend; 
 
   // ---- medians and MAD
 

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -256,9 +256,10 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   TFileDirectory Mean2DMapsDir;  
   TFileDirectory Width2DMapsDir; 
 
-  // histogram for max(eta)
+  // histogram for sanity check
   TH1F* h_etaMax;
   TH1F* h_nbins;
+  TH1F* h_nLadders;
 
   // ---- directly histograms // ===> unbiased residuals
   

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -596,6 +596,21 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   std::vector<TH1F*> h_norm_dxy_Central_pT_;
   std::vector<TH1F*> h_norm_dz_Central_pT_;   
 
+  // histograms for the plots as function of module ladder and number
+
+  std::vector<TH1F*> h_dxy_modZ_;
+  std::vector<TH1F*> h_dz_modZ_;
+  std::vector<TH1F*> h_norm_dxy_modZ_;
+  std::vector<TH1F*> h_norm_dz_modZ_;
+
+  std::vector<TH1F*> h_dxy_ladderOverlap_;
+  std::vector<TH1F*> h_dxy_ladderNoOverlap_;
+
+  std::vector<TH1F*> h_dxy_ladder_;
+  std::vector<TH1F*> h_dz_ladder_;
+  std::vector<TH1F*> h_norm_dxy_ladder_;
+  std::vector<TH1F*> h_norm_dz_ladder_;   
+
 };
 
 #endif

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -87,6 +87,7 @@ namespace pvparams{
       norm_resz = 14,
       norm_IP3D = 15,
       norm_d3D  = 16,
+      END_OF_TYPES = 17,
     };
     
   enum plotVariable
@@ -96,7 +97,15 @@ namespace pvparams{
       pTCentral = 4,
       ladder = 5,
       modZ   = 6,
+      END_OF_PLOTS = 7,
     };
+
+  struct histodetails
+  {
+    std::map<std::pair<residualType,plotVariable>,float> range;
+    int histobins;
+  };
+
 }
 
 //
@@ -160,6 +169,9 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   bool storeNtuple_;
   bool lightNtupleSwitch_;   // switch to keep only info for daily validation     
   bool useTracksFromRecoVtx_; 
+  
+  // histogram details
+  pvparams::histodetails theDetails_;
   
   // requirements on the vertex
   double vertexZMax_;

--- a/Alignment/OfflineValidation/src/PVValidationHelpers.cc
+++ b/Alignment/OfflineValidation/src/PVValidationHelpers.cc
@@ -1,0 +1,156 @@
+#include "Alignment/OfflineValidation/interface/PVValidationHelpers.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <cassert>
+//#include "TH1.h"
+
+//*************************************************************
+void PVValHelper::add(std::map<std::string, TH1*>& h, TH1* hist)
+//*************************************************************
+{ 
+  h[hist->GetName()]=hist; 
+  //hist->StatOverflows(kTRUE);
+}
+
+//*************************************************************
+void PVValHelper::fill(std::map<std::string, TH1*>& h,const std::string& s, double x)
+//*************************************************************
+{
+  if(h.count(s)==0){
+    edm::LogWarning("PVValidationHelpers") << "Trying to fill non-existing Histogram named " << s << std::endl;
+    return;
+  }
+  h[s]->Fill(x);
+}
+
+//*************************************************************
+void PVValHelper::fill(std::map<std::string, TH1*>& h,const std::string& s, double x, double y)
+//*************************************************************
+{
+  if(h.count(s)==0){
+    edm::LogWarning("PVValidationHelpers") << "Trying to fill non-existing Histogram named " << s << std::endl;
+    return;
+  }
+  h[s]->Fill(x,y);
+}
+
+//*************************************************************
+void PVValHelper::fillByIndex(std::vector<TH1F*>& h, unsigned int index, double x,std::string tag)
+//*************************************************************
+{
+  assert(!h.empty());
+  if(index <= h.size()){
+    h[index]->Fill(x);
+  } else {
+    edm::LogWarning("PVValidationHelpers") << "Trying to fill non-existing Histogram with index " << index << " for array with size: "<<h.size()<<" tag: "<< tag<< std::endl;
+    return;
+  }
+}
+
+//*************************************************************
+void PVValHelper::shrinkHistVectorToFit(std::vector<TH1F*>&h, unsigned int desired_size)
+//*************************************************************
+{
+  h.erase(h.begin()+desired_size,h.end()); 
+}
+
+//*************************************************************
+std::tuple<std::string,std::string,std::string> PVValHelper::getTypeString (PVValHelper::residualType type)
+//*************************************************************
+{
+  std::tuple<std::string,std::string,std::string> returnType;
+  switch(type)
+    {
+    // absoulte
+
+    case PVValHelper::dxy  :
+      returnType = std::make_tuple("dxy","d_{xy}","[#mum]");
+      break;
+    case PVValHelper::dx   :
+      returnType = std::make_tuple("dx","d_{x}","[#mum]");
+      break;
+    case PVValHelper::dy   :
+      returnType = std::make_tuple("dy","d_{y}","[#mum]");
+      break;
+    case PVValHelper::dz   :
+      returnType =  std::make_tuple("dz","d_{z}","[#mum]");
+      break;
+    case PVValHelper::IP2D :
+      returnType =  std::make_tuple("IP2D","IP_{2D}","[#mum]");
+      break;
+    case PVValHelper::resz :
+      returnType =  std::make_tuple("resz","z_{trk}-z_{vtx}","[#mum]");
+      break;
+    case PVValHelper::IP3D :
+      returnType =  std::make_tuple("IP3D","IP_{3D}","[#mum]");
+      break;
+    case PVValHelper::d3D  : 
+      returnType =  std::make_tuple("d3D","d_{3D}","[#mum]");
+      break;
+
+    // normalized
+
+    case PVValHelper::norm_dxy  :
+      returnType =  std::make_tuple("norm_dxy","d_{xy}/#sigma_{d_{xy}}","");
+      break;
+    case PVValHelper::norm_dx   :
+      returnType =  std::make_tuple("norm_dx","d_{x}/#sigma_{d_{x}}","");
+      break;
+    case PVValHelper::norm_dy   :
+      returnType =  std::make_tuple("norm_dy","d_{y}/#sigma_{d_{y}}","");
+      break;
+    case PVValHelper::norm_dz   :
+      returnType =  std::make_tuple("norm_dz","d_{z}/#sigma_{d_{z}}","");
+      break;
+    case PVValHelper::norm_IP2D :
+      returnType =  std::make_tuple("norm_IP2D","IP_{2D}/#sigma_{IP_{2D}}","");
+      break;
+    case PVValHelper::norm_resz :
+      returnType =  std::make_tuple("norm_resz","z_{trk}-z_{vtx}/#sigma_{res_{z}}","");
+      break;
+    case PVValHelper::norm_IP3D :
+      returnType =  std::make_tuple("norm_IP3D","IP_{3D}/#sigma_{IP_{3D}}","");
+      break;
+    case PVValHelper::norm_d3D  : 
+      returnType =  std::make_tuple("norm_d3D","d_{3D}/#sigma_{d_{3D}}","");
+      break;
+
+    default:
+      edm::LogWarning("PVValidationHelpers") <<" getTypeString() unknown residual type"<<type<<std::endl;
+    }
+
+  return returnType;
+  
+}
+
+//*************************************************************
+std::tuple<std::string,std::string,std::string> PVValHelper::getVarString (PVValHelper::plotVariable var)
+//*************************************************************
+{
+  std::tuple<std::string,std::string,std::string> returnVar;
+  switch(var)
+    {
+    case PVValHelper::phi  :
+      returnVar =  std::make_tuple("phi","#phi","[rad]");
+      break;
+    case PVValHelper::eta   :
+      returnVar =  std::make_tuple("eta","#eta","");
+      break;
+    case PVValHelper::pT   :
+      returnVar = std::make_tuple("pT","p_{T}","[GeV]");
+      break;
+    case PVValHelper::pTCentral :
+      returnVar = std::make_tuple("pTCentral","p_{T} |#eta|<1.","[GeV]");
+      break;
+    case PVValHelper::ladder   :
+      returnVar = std::make_tuple("ladder","ladder number","");
+      break;
+    case PVValHelper::modZ :
+      returnVar = std::make_tuple("modZ","module number","");
+      break;
+    default:
+      edm::LogWarning("PVValidationHelpers") <<" getVarString() unknown plot variable"<<var<<std::endl;
+    }
+
+  return returnVar;
+  
+}

--- a/Alignment/OfflineValidation/src/PVValidationHelpers.cc
+++ b/Alignment/OfflineValidation/src/PVValidationHelpers.cc
@@ -115,7 +115,7 @@ std::tuple<std::string,std::string,std::string> PVValHelper::getTypeString (PVVa
       break;
 
     default:
-      edm::LogWarning("PVValidationHelpers") <<" getTypeString() unknown residual type"<<type<<std::endl;
+      edm::LogWarning("PVValidationHelpers") <<" getTypeString() unknown residual type: "<<type<<std::endl;
     }
 
   return returnType;
@@ -148,7 +148,7 @@ std::tuple<std::string,std::string,std::string> PVValHelper::getVarString (PVVal
       returnVar = std::make_tuple("modZ","module number","");
       break;
     default:
-      edm::LogWarning("PVValidationHelpers") <<" getVarString() unknown plot variable"<<var<<std::endl;
+      edm::LogWarning("PVValidationHelpers") <<" getVarString() unknown plot variable: "<<var<<std::endl;
     }
 
   return returnVar;

--- a/Alignment/OfflineValidation/src/PVValidationHelpers.cc
+++ b/Alignment/OfflineValidation/src/PVValidationHelpers.cc
@@ -1,6 +1,9 @@
 #include "Alignment/OfflineValidation/interface/PVValidationHelpers.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <cassert>
+#include <numeric>
+#include <algorithm>
+#include <iostream>
 //#include "TH1.h"
 
 //*************************************************************
@@ -153,4 +156,25 @@ std::tuple<std::string,std::string,std::string> PVValHelper::getVarString (PVVal
 
   return returnVar;
   
+}
+
+//*************************************************************
+std::vector<float> PVValHelper::generateBins(int n, float start,float range)
+//*************************************************************
+{
+
+  std::vector<float> v(n);
+  float interval = range/(n-1);
+
+  //std::cout<<" interval:"<<interval<<std::endl;
+
+  std::iota(v.begin(),v.end(),1.);
+
+  for(float &a : v) { std::cout<< a << " ";  }
+  //std::cout<< "\n";
+
+  std::for_each(begin(v), end(v), [&](float& a) { a = start+((a-1)*interval); });
+
+  return v;
+
 }

--- a/Alignment/OfflineValidation/src/PVValidationHelpers.cc
+++ b/Alignment/OfflineValidation/src/PVValidationHelpers.cc
@@ -183,20 +183,12 @@ std::vector<float> PVValHelper::generateBins(int n, float start,float range)
 Measurement1D PVValHelper::getMedian(TH1F *histo)
 //*************************************************************
 {
-  double median = 999;
-  int nbins = histo->GetNbinsX();
-
-  //extract median from histogram
-  double *x = new double[nbins];
-  double *y = new double[nbins];
-  for (int j = 0; j < nbins; j++) {
-    x[j] = histo->GetBinCenter(j+1);
-    y[j] = histo->GetBinContent(j+1);
-  }
-  median = TMath::Median(nbins, x, y);
-  
-  delete[] x; x = nullptr;
-  delete[] y; y = nullptr;  
+  double median=0.;
+  double q = 0.5; // 0.5 quantile for "median"
+  // protect against empty histograms
+  if(histo->ComputeIntegral()!=0){
+    histo->GetQuantiles(1, &median, &q);
+  }  
 
   Measurement1D result(median,median/TMath::Sqrt(histo->GetEntries()));
 
@@ -213,14 +205,14 @@ Measurement1D PVValHelper::getMAD(TH1F *histo)
   double median = getMedian(histo).value();
   double x_lastBin = histo->GetBinLowEdge(nbins+1);
   const char *HistoName =histo->GetName();
-  TString Finalname = Form("resMed%s",HistoName);
-  TH1F *newHisto = new TH1F(Finalname,Finalname,nbins,0.,x_lastBin);
+  std::string Finalname = "resMed_";
+  Finalname.append(HistoName);
+  TH1F *newHisto = new TH1F(Finalname.c_str(),Finalname.c_str(),nbins,0.,x_lastBin);
   double *residuals = new double[nbins];
-  double *weights = new double[nbins];
+  const float *weights = histo->GetArray();
 
   for (int j = 0; j < nbins; j++) {
     residuals[j] = std::abs(median - histo->GetBinCenter(j+1));
-    weights[j]=histo->GetBinContent(j+1);
     newHisto->Fill(residuals[j],weights[j]);
   }
   

--- a/Alignment/OfflineValidation/src/PVValidationHelpers.cc
+++ b/Alignment/OfflineValidation/src/PVValidationHelpers.cc
@@ -183,21 +183,13 @@ std::vector<float> PVValHelper::generateBins(int n, float start,float range)
 Measurement1D PVValHelper::getMedian(TH1F *histo)
 //*************************************************************
 {
-  double median = 999;
-  int nbins = histo->GetNbinsX();
-
-  //extract median from histogram
-  double *x = new double[nbins];
-  double *y = new double[nbins];
-  for (int j = 0; j < nbins; j++) {
-    x[j] = histo->GetBinCenter(j+1);
-    y[j] = histo->GetBinContent(j+1);
-  }
-  median = TMath::Median(nbins, x, y);
+  double median=0.;
+  double q = 0.5; // 0.5 quantile for "median"
+  // protect against empty histograms
+  if(histo->Integral()!=0){
+    histo->GetQuantiles(1, &median, &q);
+  }  
   
-  delete[] x; x = nullptr;
-  delete[] y; y = nullptr;  
-
   Measurement1D result(median,median/TMath::Sqrt(histo->GetEntries()));
 
   return result;
@@ -213,21 +205,20 @@ Measurement1D PVValHelper::getMAD(TH1F *histo)
   double median = getMedian(histo).value();
   double x_lastBin = histo->GetBinLowEdge(nbins+1);
   const char *HistoName =histo->GetName();
-  TString Finalname = Form("resMed%s",HistoName);
-  TH1F *newHisto = new TH1F(Finalname,Finalname,nbins,0.,x_lastBin);
+  std::string Finalname = "resMed_";
+  Finalname.append(HistoName);
+  TH1F *newHisto = new TH1F(Finalname.c_str(),Finalname.c_str(),nbins,0.,x_lastBin);
   double *residuals = new double[nbins];
-  double *weights = new double[nbins];
+  const float *weights = histo->GetArray(); 
 
   for (int j = 0; j < nbins; j++) {
     residuals[j] = std::abs(median - histo->GetBinCenter(j+1));
-    weights[j]=histo->GetBinContent(j+1);
     newHisto->Fill(residuals[j],weights[j]);
   }
   
   double theMAD = (PVValHelper::getMedian(newHisto).value())*1.4826;
   
   delete[] residuals; residuals=nullptr;
-  delete[] weights; weights=nullptr;
   newHisto->Delete("");
   
   Measurement1D result(theMAD,theMAD/histo->GetEntries());

--- a/Alignment/OfflineValidation/src/PVValidationHelpers.cc
+++ b/Alignment/OfflineValidation/src/PVValidationHelpers.cc
@@ -165,12 +165,10 @@ std::vector<float> PVValHelper::generateBins(int n, float start,float range)
 
   std::vector<float> v(n);
   float interval = range/(n-1);
-
-  //std::cout<<" interval:"<<interval<<std::endl;
-
   std::iota(v.begin(),v.end(),1.);
 
-  for(float &a : v) { std::cout<< a << " ";  }
+  //std::cout<<" interval:"<<interval<<std::endl;
+  //for(float &a : v) { std::cout<< a << " ";  }
   //std::cout<< "\n";
 
   std::for_each(begin(v), end(v), [&](float& a) { a = start+((a-1)*interval); });


### PR DESCRIPTION
 Greetings,
this PR is meant to streamline and consolidate the PV tool:
   * possibly common methods are moved into an helper namespace;
   * make booking and filling of histograms uniform;
   * reduce duplications in the creation of the track variable bins (hardwiring all instances to a single `std::map` depending on the impact parameter type and track variables);
   * added profiles of the bias and resolution towards the BPix L1 ladder and module number (where useful in the startup pixel commissioning phase): this is supported also for the Phase-0 detector.
   * update the plotting macro according to the other changes. 