### PR TITLE
OnlineDQM : Tune L1T Muon QTs v2

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2MuonComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2MuonComp.h
@@ -33,6 +33,7 @@ class L1TStage2MuonComp : public DQMEDAnalyzer {
 
   enum variables {BXRANGEGOOD=1, BXRANGEBAD, NMUONGOOD, NMUONBAD, MUONALL, MUONGOOD, PTBAD, ETABAD, PHIBAD, ETAATVTXBAD, PHIATVTXBAD, CHARGEBAD, CHARGEVALBAD, QUALBAD, ISOBAD, IDXBAD};
   enum ratioVariables {RBXRANGE=1, RNMUON, RMUON, RPT, RETA, RPHI, RETAATVTX, RPHIATVTX, RCHARGE, RCHARGEVAL, RQUAL, RISO, RIDX};
+  bool incBin[RIDX+1];
 
   edm::EDGetTokenT<l1t::MuonBxCollection> muonToken1;
   edm::EDGetTokenT<l1t::MuonBxCollection> muonToken2;
@@ -40,6 +41,7 @@ class L1TStage2MuonComp : public DQMEDAnalyzer {
   std::string muonColl1Title;
   std::string muonColl2Title;
   std::string summaryTitle;
+  std::vector<int> ignoreBin;
   bool verbose;
 
   MonitorElement* summary;

--- a/DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h
@@ -34,6 +34,7 @@ class L1TStage2RegionalMuonCandComp : public DQMEDAnalyzer {
   enum variables {BXRANGEGOOD=1, BXRANGEBAD, NMUONGOOD, NMUONBAD, MUONALL, MUONGOOD, PTBAD, ETABAD, LOCALPHIBAD, SIGNBAD, SIGNVALBAD, QUALBAD, HFBAD, LINKBAD, PROCBAD, TFBAD, TRACKADDRBAD};
   enum ratioVariables {RBXRANGE=1, RNMUON, RMUON, RPT, RETA, RLOCALPHI, RSIGN, RSIGNVAL, RQUAL, RHF, RLINK, RPROC, RTF, RTRACKADDR};
   enum tfs {BMTFBIN=1, OMTFNEGBIN, OMTFPOSBIN, EMTFNEGBIN, EMTFPOSBIN};
+  bool incBin[RTRACKADDR+1];
 
   edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> muonToken1;
   edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> muonToken2;
@@ -42,6 +43,7 @@ class L1TStage2RegionalMuonCandComp : public DQMEDAnalyzer {
   std::string muonColl2Title;
   std::string summaryTitle;
   bool ignoreBadTrkAddr;
+  std::vector<int> ignoreBin;
   bool verbose;
 
   MonitorElement* summary;

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
@@ -80,6 +80,9 @@ l1tStage2uGMTZeroSupp = cms.EDAnalyzer(
 l1tStage2uGMTZeroSuppFatEvts = l1tStage2uGMTZeroSupp.clone()
 l1tStage2uGMTZeroSuppFatEvts.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/zeroSuppression/FatEvts")
 
+# List of bins to ignore
+ignoreBins = [1]
+
 # compares the unpacked BMTF output regional muon collection with the unpacked uGMT input regional muon collection from BMTF
 # only muons that do not match are filled in the histograms
 l1tStage2BmtfOutVsuGMTIn = cms.EDAnalyzer(
@@ -90,6 +93,7 @@ l1tStage2BmtfOutVsuGMTIn = cms.EDAnalyzer(
     regionalMuonCollection1Title = cms.untracked.string("BMTF output data"),
     regionalMuonCollection2Title = cms.untracked.string("uGMT input data from BMTF"),
     summaryTitle = cms.untracked.string("Summary of comparison between BMTF output muons and uGMT input muons from BMTF"),
+    ignoreBin = cms.untracked.vint32(ignoreBins),
     verbose = cms.untracked.bool(False),
 )
 

--- a/DQM/L1TMonitor/python/L1TdeStage2OMTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2OMTF_cfi.py
@@ -1,5 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
+# List of bins to ignore
+ignoreBins = [1, 14]
+
 # compares the unpacked uGMT input regional muon collection from OMTF to the emulated OMTF regional muon collection
 # only muons that do not match are filled in the histograms
 l1tdeStage2Omtf = cms.EDAnalyzer(
@@ -11,6 +14,7 @@ l1tdeStage2Omtf = cms.EDAnalyzer(
     regionalMuonCollection2Title = cms.untracked.string("OMTF emulator"),
     summaryTitle = cms.untracked.string("Summary of comparison between uGMT input muons from OMTF and OMTF emulator muons"),
     ignoreBadTrackAddress = cms.untracked.bool(True),
+    ignoreBin = cms.untracked.vint32(ignoreBins),
     verbose = cms.untracked.bool(False),
 )
 

--- a/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
@@ -8,6 +8,9 @@ emulatorModule = "valGmtStage2Digis"
 ugmtEmuDqmDir = "L1TEMU/L1TdeStage2uGMT"
 ugmtEmuImdMuDqmDir = ugmtEmuDqmDir+"/intermediate_muons"
 
+# List of bins to ignore
+ignoreBins = [7, 8, 12, 13]
+
 # fills histograms with all uGMT emulated muons
 # uGMT input muon histograms from track finders are not filled since they are identical to the data DQM plots
 from DQM.L1TMonitor.L1TStage2uGMT_cfi import *
@@ -77,30 +80,35 @@ l1tdeStage2uGMTIntermediateBMTF.muonCollection1 = cms.InputTag(unpackerModule, "
 l1tdeStage2uGMTIntermediateBMTF.muonCollection2 = cms.InputTag(emulatorModule, "imdMuonsBMTF")
 l1tdeStage2uGMTIntermediateBMTF.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/BMTF/data_vs_emulator_comparison")
 l1tdeStage2uGMTIntermediateBMTF.summaryTitle = cms.untracked.string("Summary of uGMT intermediate muon from BMTF comparison between unpacked and emulated")
+l1tdeStage2uGMTIntermediateBMTF.ignoreBin = cms.untracked.vint32(ignoreBins)
 
 l1tdeStage2uGMTIntermediateOMTFNeg = l1tdeStage2uGMTIntermediateBMTF.clone()
 l1tdeStage2uGMTIntermediateOMTFNeg.muonCollection1 = cms.InputTag(unpackerModule, "imdMuonsOMTFNeg")
 l1tdeStage2uGMTIntermediateOMTFNeg.muonCollection2 = cms.InputTag(emulatorModule, "imdMuonsOMTFNeg")
 l1tdeStage2uGMTIntermediateOMTFNeg.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/OMTF_neg/data_vs_emulator_comparison")
 l1tdeStage2uGMTIntermediateOMTFNeg.summaryTitle = cms.untracked.string("Summary of uGMT intermediate muon from OMTF- comparison between unpacked and emulated")
+l1tdeStage2uGMTIntermediateOMTFNeg.ignoreBin = cms.untracked.vint32(ignoreBins)
 
 l1tdeStage2uGMTIntermediateOMTFPos = l1tdeStage2uGMTIntermediateBMTF.clone()
 l1tdeStage2uGMTIntermediateOMTFPos.muonCollection1 = cms.InputTag(unpackerModule, "imdMuonsOMTFPos")
 l1tdeStage2uGMTIntermediateOMTFPos.muonCollection2 = cms.InputTag(emulatorModule, "imdMuonsOMTFPos")
 l1tdeStage2uGMTIntermediateOMTFPos.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/OMTF_pos/data_vs_emulator_comparison")
 l1tdeStage2uGMTIntermediateOMTFPos.summaryTitle = cms.untracked.string("Summary of uGMT intermediate muon from OMTF+ comparison between unpacked and emulated")
+l1tdeStage2uGMTIntermediateOMTFPos.ignoreBin = cms.untracked.vint32(ignoreBins)
 
 l1tdeStage2uGMTIntermediateEMTFNeg = l1tdeStage2uGMTIntermediateBMTF.clone()
 l1tdeStage2uGMTIntermediateEMTFNeg.muonCollection1 = cms.InputTag(unpackerModule, "imdMuonsEMTFNeg")
 l1tdeStage2uGMTIntermediateEMTFNeg.muonCollection2 = cms.InputTag(emulatorModule, "imdMuonsEMTFNeg")
 l1tdeStage2uGMTIntermediateEMTFNeg.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/EMTF_neg/data_vs_emulator_comparison")
 l1tdeStage2uGMTIntermediateEMTFNeg.summaryTitle = cms.untracked.string("Summary of uGMT intermediate muon from EMTF- comparison between unpacked and emulated")
+l1tdeStage2uGMTIntermediateEMTFNeg.ignoreBin = cms.untracked.vint32(ignoreBins)
 
 l1tdeStage2uGMTIntermediateEMTFPos = l1tdeStage2uGMTIntermediateBMTF.clone()
 l1tdeStage2uGMTIntermediateEMTFPos.muonCollection1 = cms.InputTag(unpackerModule, "imdMuonsEMTFPos")
 l1tdeStage2uGMTIntermediateEMTFPos.muonCollection2 = cms.InputTag(emulatorModule, "imdMuonsEMTFPos")
 l1tdeStage2uGMTIntermediateEMTFPos.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/EMTF_pos/data_vs_emulator_comparison")
 l1tdeStage2uGMTIntermediateEMTFPos.summaryTitle = cms.untracked.string("Summary of uGMT intermediate muon from EMTF+ comparison between unpacked and emulated")
+l1tdeStage2uGMTIntermediateEMTFPos.ignoreBin = cms.untracked.vint32(ignoreBins)
 
 # sequences
 l1tStage2uGMTEmulatorOnlineDQMSeq = cms.Sequence(

--- a/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
@@ -12,7 +12,7 @@ L1TStage2MuonComp::L1TStage2MuonComp(const edm::ParameterSet& ps)
       verbose(ps.getUntrackedParameter<bool>("verbose"))
 {
   // First include all bins
-  for (uint i = 1; i <= RIDX; i++) {
+  for (unsigned int i = 1; i <= RIDX; i++) {
     incBin[i] = true;
   }
   // Then check the list of bins to ignore
@@ -81,7 +81,7 @@ void L1TStage2MuonComp::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   errorSummaryNum->setBinLabel(RIDX, "index mismatch", 1);
 
   // Change the label for those bins that will be ignored
-  for (uint i = 1; i <= RIDX; i++) {
+  for (unsigned int i = 1; i <= RIDX; i++) {
     if (incBin[i]==false) {
       errorSummaryNum->setBinLabel(i, "Ignored", 1);
     }
@@ -239,67 +239,87 @@ void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
       bool muonSelMismatch = false; // Muon mismatches excluding ignored bins
       if (muonIt1->hwPt() != muonIt2->hwPt()) {
         muonMismatch = true;
-        if (incBin[RPT]) muonSelMismatch = true;
         summary->Fill(PTBAD);
-        if (incBin[RPT]) errorSummaryNum->Fill(RPT);
+        if (incBin[RPT]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RPT);
+        }
       }
       if (muonIt1->hwEta() != muonIt2->hwEta()) {
         muonMismatch = true;
-        if (incBin[RETA]) muonSelMismatch = true;
         summary->Fill(ETABAD);
-        if (incBin[RETA]) errorSummaryNum->Fill(RETA);
+        if (incBin[RETA]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RETA);
+        }
       }
       if (muonIt1->hwPhi() != muonIt2->hwPhi()) {
         muonMismatch = true;
-        if (incBin[RPHI]) muonSelMismatch = true;
         summary->Fill(PHIBAD);
-        if (incBin[RPHI]) errorSummaryNum->Fill(RPHI);
+        if (incBin[RPHI]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RPHI);
+        }
       }
       if (muonIt1->hwEtaAtVtx() != muonIt2->hwEtaAtVtx()) {
         muonMismatch = true;
-        if (incBin[RETAATVTX]) muonSelMismatch = true;
         summary->Fill(ETAATVTXBAD);
-        if (incBin[RETAATVTX]) errorSummaryNum->Fill(RETAATVTX);
+        if (incBin[RETAATVTX]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RETAATVTX);
+        }
       }
       if (muonIt1->hwPhiAtVtx() != muonIt2->hwPhiAtVtx()) {
         muonMismatch = true;
-        if (incBin[RPHIATVTX]) muonSelMismatch = true;
         summary->Fill(PHIATVTXBAD);
-        if (incBin[RPHIATVTX]) errorSummaryNum->Fill(RPHIATVTX);
+        if (incBin[RPHIATVTX]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RPHIATVTX);
+        }
       }
       if (muonIt1->hwCharge() != muonIt2->hwCharge()) {
         muonMismatch = true;
-        if (incBin[RCHARGE]) muonSelMismatch = true;
         summary->Fill(CHARGEBAD);
-        if (incBin[RCHARGE]) errorSummaryNum->Fill(RCHARGE);
+        if (incBin[RCHARGE]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RCHARGE);
+        }
       }
       if (muonIt1->hwChargeValid() != muonIt2->hwChargeValid()) {
         muonMismatch = true;
-        if (incBin[RCHARGEVAL]) muonSelMismatch = true;
         summary->Fill(CHARGEVALBAD);
-        if (incBin[RCHARGEVAL]) errorSummaryNum->Fill(RCHARGEVAL);
+        if (incBin[RCHARGEVAL]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RCHARGEVAL);
+        }
       }
       if (muonIt1->hwQual() != muonIt2->hwQual()) {
         muonMismatch = true;
-        if (incBin[RQUAL]) muonSelMismatch = true;
         summary->Fill(QUALBAD);
-        if (incBin[RQUAL]) errorSummaryNum->Fill(RQUAL);
+        if (incBin[RQUAL]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RQUAL);
+        }
       }
       if (muonIt1->hwIso() != muonIt2->hwIso()) {
         muonMismatch = true;
-        if (incBin[RISO]) muonSelMismatch = true;
         summary->Fill(ISOBAD);
-        if (incBin[RISO]) errorSummaryNum->Fill(RISO);
+        if (incBin[RISO]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RISO);
+        }
       }
       if (muonIt1->tfMuonIndex() != muonIt2->tfMuonIndex()) {
         muonMismatch = true;
-        if (incBin[RIDX]) muonSelMismatch = true;
         summary->Fill(IDXBAD);
-        if (incBin[RIDX]) errorSummaryNum->Fill(RIDX);
+        if (incBin[RIDX]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RIDX);
+        }
       }
 
-      if (muonSelMismatch) {
-        if (incBin[RMUON]) errorSummaryNum->Fill(RMUON);
+      if (incBin[RMUON] && muonSelMismatch) {
+        errorSummaryNum->Fill(RMUON);
       }
 
       if (muonMismatch) {

--- a/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
@@ -167,7 +167,7 @@ void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
   int bxRange2 = muonBxColl2->getLastBX() - muonBxColl2->getFirstBX() + 1;
   if (bxRange1 != bxRange2) {
     summary->Fill(BXRANGEBAD);
-    errorSummaryNum->Fill(RBXRANGE, incBin[RBXRANGE]);
+    if (incBin[RBXRANGE]) errorSummaryNum->Fill(RBXRANGE);
     int bx;
     for (bx = muonBxColl1->getFirstBX(); bx <= muonBxColl1->getLastBX(); ++bx) {
         muColl1BxRange->Fill(bx);
@@ -190,7 +190,7 @@ void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
     // check number of muons
     if (muonBxColl1->size(iBx) != muonBxColl2->size(iBx)) {
       summary->Fill(NMUONBAD);
-      errorSummaryNum->Fill(RNMUON, incBin[RNMUON]);
+      if (incBin[RNMUON]) errorSummaryNum->Fill(RNMUON);
       muColl1nMu->Fill(muonBxColl1->size(iBx));
       muColl2nMu->Fill(muonBxColl2->size(iBx));
 
@@ -239,67 +239,67 @@ void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
       bool muonSelMismatch = false; // Muon mismatches excluding ignored bins
       if (muonIt1->hwPt() != muonIt2->hwPt()) {
         muonMismatch = true;
-        muonSelMismatch = muonSelMismatch || incBin[RPT];
+        if (incBin[RPT]) muonSelMismatch = true;
         summary->Fill(PTBAD);
-        errorSummaryNum->Fill(RPT, incBin[RPT]);
+        if (incBin[RPT]) errorSummaryNum->Fill(RPT);
       }
       if (muonIt1->hwEta() != muonIt2->hwEta()) {
         muonMismatch = true;
-        muonSelMismatch = muonSelMismatch || incBin[RETA];
+        if (incBin[RETA]) muonSelMismatch = true;
         summary->Fill(ETABAD);
-        errorSummaryNum->Fill(RETA, incBin[RETA]);
+        if (incBin[RETA]) errorSummaryNum->Fill(RETA);
       }
       if (muonIt1->hwPhi() != muonIt2->hwPhi()) {
         muonMismatch = true;
-        muonSelMismatch = muonSelMismatch || incBin[RPHI];
+        if (incBin[RPHI]) muonSelMismatch = true;
         summary->Fill(PHIBAD);
-        errorSummaryNum->Fill(RPHI, incBin[RPHI]);
+        if (incBin[RPHI]) errorSummaryNum->Fill(RPHI);
       }
       if (muonIt1->hwEtaAtVtx() != muonIt2->hwEtaAtVtx()) {
         muonMismatch = true;
-        muonSelMismatch = muonSelMismatch || incBin[RETAATVTX];
+        if (incBin[RETAATVTX]) muonSelMismatch = true;
         summary->Fill(ETAATVTXBAD);
-        errorSummaryNum->Fill(RETAATVTX, incBin[RETAATVTX]);
+        if (incBin[RETAATVTX]) errorSummaryNum->Fill(RETAATVTX);
       }
       if (muonIt1->hwPhiAtVtx() != muonIt2->hwPhiAtVtx()) {
         muonMismatch = true;
-        muonSelMismatch = muonSelMismatch || incBin[RPHIATVTX];
+        if (incBin[RPHIATVTX]) muonSelMismatch = true;
         summary->Fill(PHIATVTXBAD);
-        errorSummaryNum->Fill(RPHIATVTX, incBin[RPHIATVTX]);
+        if (incBin[RPHIATVTX]) errorSummaryNum->Fill(RPHIATVTX);
       }
       if (muonIt1->hwCharge() != muonIt2->hwCharge()) {
         muonMismatch = true;
-        muonSelMismatch = muonSelMismatch || incBin[RCHARGE];
+        if (incBin[RCHARGE]) muonSelMismatch = true;
         summary->Fill(CHARGEBAD);
-        errorSummaryNum->Fill(RCHARGE, incBin[RCHARGE]);
+        if (incBin[RCHARGE]) errorSummaryNum->Fill(RCHARGE);
       }
       if (muonIt1->hwChargeValid() != muonIt2->hwChargeValid()) {
         muonMismatch = true;
-        muonSelMismatch = muonSelMismatch || incBin[RCHARGEVAL];
+        if (incBin[RCHARGEVAL]) muonSelMismatch = true;
         summary->Fill(CHARGEVALBAD);
-        errorSummaryNum->Fill(RCHARGEVAL, incBin[RCHARGEVAL]);
+        if (incBin[RCHARGEVAL]) errorSummaryNum->Fill(RCHARGEVAL);
       }
       if (muonIt1->hwQual() != muonIt2->hwQual()) {
         muonMismatch = true;
-        muonSelMismatch = muonSelMismatch || incBin[RQUAL];
+        if (incBin[RQUAL]) muonSelMismatch = true;
         summary->Fill(QUALBAD);
-        errorSummaryNum->Fill(RQUAL, incBin[RQUAL]);
+        if (incBin[RQUAL]) errorSummaryNum->Fill(RQUAL);
       }
       if (muonIt1->hwIso() != muonIt2->hwIso()) {
         muonMismatch = true;
-        muonSelMismatch = muonSelMismatch || incBin[RISO];
+        if (incBin[RISO]) muonSelMismatch = true;
         summary->Fill(ISOBAD);
-        errorSummaryNum->Fill(RISO, incBin[RISO]);
+        if (incBin[RISO]) errorSummaryNum->Fill(RISO);
       }
       if (muonIt1->tfMuonIndex() != muonIt2->tfMuonIndex()) {
         muonMismatch = true;
-        muonSelMismatch = muonSelMismatch || incBin[RIDX];
+        if (incBin[RIDX]) muonSelMismatch = true;
         summary->Fill(IDXBAD);
-        errorSummaryNum->Fill(RIDX, incBin[RIDX]);
+        if (incBin[RIDX]) errorSummaryNum->Fill(RIDX);
       }
 
       if (muonSelMismatch) {
-        errorSummaryNum->Fill(RMUON, incBin[RMUON]);
+        if (incBin[RMUON]) errorSummaryNum->Fill(RMUON);
       }
 
       if (muonMismatch) {

--- a/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
@@ -8,8 +8,19 @@ L1TStage2MuonComp::L1TStage2MuonComp(const edm::ParameterSet& ps)
       muonColl1Title(ps.getUntrackedParameter<std::string>("muonCollection1Title")),
       muonColl2Title(ps.getUntrackedParameter<std::string>("muonCollection2Title")),
       summaryTitle(ps.getUntrackedParameter<std::string>("summaryTitle")),
+      ignoreBin(ps.getUntrackedParameter<std::vector<int>>("ignoreBin")),
       verbose(ps.getUntrackedParameter<bool>("verbose"))
 {
+  // First include all bins
+  for (uint i = 1; i <= RIDX; i++) {
+    incBin[i] = true;
+  }
+  // Then check the list of bins to ignore
+  for (const auto& i : ignoreBin) {
+    if (i > 0 && i <= RIDX) {
+      incBin[i] = false;
+    }
+  }
 }
 
 L1TStage2MuonComp::~L1TStage2MuonComp() {}
@@ -22,6 +33,7 @@ void L1TStage2MuonComp::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.addUntracked<std::string>("muonCollection1Title", "Muon collection 1")->setComment("Histogram title for first collection.");
   desc.addUntracked<std::string>("muonCollection2Title", "Muon collection 2")->setComment("Histogram title for second collection.");
   desc.addUntracked<std::string>("summaryTitle", "Summary")->setComment("Title of summary histogram.");
+  desc.addUntracked<std::vector<int>>("ignoreBin", std::vector<int>())->setComment("List of bins to ignore");
   desc.addUntracked<bool>("verbose", false);
   descriptions.add("l1tStage2MuonComp", desc);
 }
@@ -67,6 +79,13 @@ void L1TStage2MuonComp::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   errorSummaryNum->setBinLabel(RQUAL, "quality mismatch", 1);
   errorSummaryNum->setBinLabel(RISO, "iso mismatch", 1);
   errorSummaryNum->setBinLabel(RIDX, "index mismatch", 1);
+
+  // Change the label for those bins that will be ignored
+  for (uint i = 1; i <= RIDX; i++) {
+    if (incBin[i]==false) {
+      errorSummaryNum->setBinLabel(i, "Ignored", 1);
+    }
+  }
 
   errorSummaryDen = ibooker.book1D("errorSummaryDen", "denominators", 13, 1, 14); // range to match bin numbering
   errorSummaryDen->setBinLabel(RBXRANGE, "# events", 1);
@@ -148,7 +167,7 @@ void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
   int bxRange2 = muonBxColl2->getLastBX() - muonBxColl2->getFirstBX() + 1;
   if (bxRange1 != bxRange2) {
     summary->Fill(BXRANGEBAD);
-    errorSummaryNum->Fill(RBXRANGE);
+    errorSummaryNum->Fill(RBXRANGE, incBin[RBXRANGE]);
     int bx;
     for (bx = muonBxColl1->getFirstBX(); bx <= muonBxColl1->getLastBX(); ++bx) {
         muColl1BxRange->Fill(bx);
@@ -171,7 +190,7 @@ void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
     // check number of muons
     if (muonBxColl1->size(iBx) != muonBxColl2->size(iBx)) {
       summary->Fill(NMUONBAD);
-      errorSummaryNum->Fill(RNMUON);
+      errorSummaryNum->Fill(RNMUON, incBin[RNMUON]);
       muColl1nMu->Fill(muonBxColl1->size(iBx));
       muColl2nMu->Fill(muonBxColl2->size(iBx));
 
@@ -216,60 +235,74 @@ void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
         errorSummaryDen->Fill(i);
       }
 
-      bool muonMismatch = false;
+      bool muonMismatch = false;    // All muon mismatches
+      bool muonSelMismatch = false; // Muon mismatches excluding ignored bins
       if (muonIt1->hwPt() != muonIt2->hwPt()) {
         muonMismatch = true;
+        muonSelMismatch = muonSelMismatch || incBin[RPT];
         summary->Fill(PTBAD);
-        errorSummaryNum->Fill(RPT);
+        errorSummaryNum->Fill(RPT, incBin[RPT]);
       }
       if (muonIt1->hwEta() != muonIt2->hwEta()) {
         muonMismatch = true;
+        muonSelMismatch = muonSelMismatch || incBin[RETA];
         summary->Fill(ETABAD);
-        errorSummaryNum->Fill(RETA);
+        errorSummaryNum->Fill(RETA, incBin[RETA]);
       }
       if (muonIt1->hwPhi() != muonIt2->hwPhi()) {
         muonMismatch = true;
+        muonSelMismatch = muonSelMismatch || incBin[RPHI];
         summary->Fill(PHIBAD);
-        errorSummaryNum->Fill(RPHI);
+        errorSummaryNum->Fill(RPHI, incBin[RPHI]);
       }
       if (muonIt1->hwEtaAtVtx() != muonIt2->hwEtaAtVtx()) {
         muonMismatch = true;
+        muonSelMismatch = muonSelMismatch || incBin[RETAATVTX];
         summary->Fill(ETAATVTXBAD);
-        errorSummaryNum->Fill(RETAATVTX);
+        errorSummaryNum->Fill(RETAATVTX, incBin[RETAATVTX]);
       }
       if (muonIt1->hwPhiAtVtx() != muonIt2->hwPhiAtVtx()) {
         muonMismatch = true;
+        muonSelMismatch = muonSelMismatch || incBin[RPHIATVTX];
         summary->Fill(PHIATVTXBAD);
-        errorSummaryNum->Fill(RPHIATVTX);
+        errorSummaryNum->Fill(RPHIATVTX, incBin[RPHIATVTX]);
       }
       if (muonIt1->hwCharge() != muonIt2->hwCharge()) {
         muonMismatch = true;
+        muonSelMismatch = muonSelMismatch || incBin[RCHARGE];
         summary->Fill(CHARGEBAD);
-        errorSummaryNum->Fill(RCHARGE);
+        errorSummaryNum->Fill(RCHARGE, incBin[RCHARGE]);
       }
       if (muonIt1->hwChargeValid() != muonIt2->hwChargeValid()) {
         muonMismatch = true;
+        muonSelMismatch = muonSelMismatch || incBin[RCHARGEVAL];
         summary->Fill(CHARGEVALBAD);
-        errorSummaryNum->Fill(RCHARGEVAL);
+        errorSummaryNum->Fill(RCHARGEVAL, incBin[RCHARGEVAL]);
       }
       if (muonIt1->hwQual() != muonIt2->hwQual()) {
         muonMismatch = true;
+        muonSelMismatch = muonSelMismatch || incBin[RQUAL];
         summary->Fill(QUALBAD);
-        errorSummaryNum->Fill(RQUAL);
+        errorSummaryNum->Fill(RQUAL, incBin[RQUAL]);
       }
       if (muonIt1->hwIso() != muonIt2->hwIso()) {
         muonMismatch = true;
+        muonSelMismatch = muonSelMismatch || incBin[RISO];
         summary->Fill(ISOBAD);
-        errorSummaryNum->Fill(RISO);
+        errorSummaryNum->Fill(RISO, incBin[RISO]);
       }
       if (muonIt1->tfMuonIndex() != muonIt2->tfMuonIndex()) {
         muonMismatch = true;
+        muonSelMismatch = muonSelMismatch || incBin[RIDX];
         summary->Fill(IDXBAD);
-        errorSummaryNum->Fill(RIDX);
+        errorSummaryNum->Fill(RIDX, incBin[RIDX]);
+      }
+
+      if (muonSelMismatch) {
+        errorSummaryNum->Fill(RMUON, incBin[RMUON]);
       }
 
       if (muonMismatch) {
-        errorSummaryNum->Fill(RMUON);
 
         muColl1hwPt->Fill(muonIt1->hwPt());
         muColl1hwEta->Fill(muonIt1->hwEta());

--- a/DQM/L1TMonitor/src/L1TStage2RegionalMuonCandComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2RegionalMuonCandComp.cc
@@ -13,7 +13,7 @@ L1TStage2RegionalMuonCandComp::L1TStage2RegionalMuonCandComp(const edm::Paramete
       verbose(ps.getUntrackedParameter<bool>("verbose"))
 {
   // First include all bins
-  for (uint i = 1; i <= RTRACKADDR; i++) {
+  for (unsigned int i = 1; i <= RTRACKADDR; i++) {
     incBin[i] = true;
   }
   // Then check the list of bins to ignore
@@ -90,7 +90,7 @@ void L1TStage2RegionalMuonCandComp::bookHistograms(DQMStore::IBooker& ibooker, c
   errorSummaryNum->setBinLabel(RTRACKADDR, "track address mismatch", 1);
 
   // Change the label for those bins that will be ignored
-  for (uint i = 1; i <= RTRACKADDR; i++) {
+  for (unsigned int i = 1; i <= RTRACKADDR; i++) {
     if (incBin[i]==false) {
       errorSummaryNum->setBinLabel(i, "Ignored", 1);
     }
@@ -288,57 +288,75 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
       bool muonSelMismatch = false; // Muon mismatches excluding ignored bins
       if (muonIt1->hwPt() != muonIt2->hwPt()) {
         muonMismatch = true;
-        if (incBin[RPT]) muonSelMismatch = true;
         summary->Fill(PTBAD);
-        if (incBin[RPT]) errorSummaryNum->Fill(RPT);
+        if (incBin[RPT]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RPT);
+        }
       }
       if (muonIt1->hwEta() != muonIt2->hwEta()) {
         muonMismatch = true;
-        if (incBin[RETA]) muonSelMismatch = true;
         summary->Fill(ETABAD);
-        if (incBin[RETA]) errorSummaryNum->Fill(RETA);
+        if (incBin[RETA]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RETA);
+        }
       }
       if (muonIt1->hwPhi() != muonIt2->hwPhi()) {
         muonMismatch = true;
-        if (incBin[RLOCALPHI]) muonSelMismatch = true;
         summary->Fill(LOCALPHIBAD);
-        if (incBin[RLOCALPHI]) errorSummaryNum->Fill(RLOCALPHI);
+        if (incBin[RLOCALPHI]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RLOCALPHI);
+        }
       }
       if (muonIt1->hwSign() != muonIt2->hwSign()) {
         muonMismatch = true;
-        if (incBin[RSIGN]) muonSelMismatch = true;
         summary->Fill(SIGNBAD);
-        if (incBin[RSIGN]) errorSummaryNum->Fill(RSIGN);
+        if (incBin[RSIGN]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RSIGN);
+        }
       }
       if (muonIt1->hwSignValid() != muonIt2->hwSignValid()) {
         muonMismatch = true;
-        if (incBin[RSIGNVAL]) muonSelMismatch = true;
         summary->Fill(SIGNVALBAD);
-        if (incBin[RSIGNVAL]) errorSummaryNum->Fill(RSIGNVAL);
+        if (incBin[RSIGNVAL]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RSIGNVAL);
+        }
       }
       if (muonIt1->hwQual() != muonIt2->hwQual()) {
         muonMismatch = true;
-        if (incBin[RQUAL]) muonSelMismatch = true;
         summary->Fill(QUALBAD);
-        if (incBin[RQUAL]) errorSummaryNum->Fill(RQUAL);
+        if (incBin[RQUAL]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RQUAL);
+        }
       }
       if (muonIt1->link() != muonIt2->link()) {
         muonMismatch = true;
-        if (incBin[RLINK]) muonSelMismatch = true;
         summary->Fill(LINKBAD);
-        if (incBin[RLINK]) errorSummaryNum->Fill(RLINK);
+        if (incBin[RLINK]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RLINK);
+        }
       }
       if (muonIt1->processor() != muonIt2->processor()) {
         muonMismatch = true;
-        if (incBin[RPROC]) muonSelMismatch = true;
         summary->Fill(PROCBAD);
-        if (incBin[RPROC]) errorSummaryNum->Fill(RPROC);
+        if (incBin[RPROC]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RPROC);
+        }
       }
       if (muonIt1->trackFinderType() != muonIt2->trackFinderType()) {
         muonMismatch = true;
-        if (incBin[RTF]) muonSelMismatch = true;
         summary->Fill(TFBAD);
-        if (incBin[RTF]) errorSummaryNum->Fill(RTF);
+        if (incBin[RTF]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RTF);
+        }
       }
       // check track address
       const std::map<int, int> muon1TrackAddr = muonIt1->trackAddress();
@@ -366,8 +384,8 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
         if (incBin[RTRACKADDR]) errorSummaryNum->Fill(RTRACKADDR);
       }
 
-      if (muonSelMismatch) {
-        if (incBin[RMUON]) errorSummaryNum->Fill(RMUON);
+      if (incBin[RMUON] && muonSelMismatch) {
+        errorSummaryNum->Fill(RMUON);
       }
 
       if (muonMismatch) {

--- a/DQM/L1TMonitor/src/L1TStage2RegionalMuonCandComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2RegionalMuonCandComp.cc
@@ -197,7 +197,7 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
   int bxRange2 = muonBxColl2->getLastBX() - muonBxColl2->getFirstBX() + 1;
   if (bxRange1 != bxRange2) {
     summary->Fill(BXRANGEBAD);
-    errorSummaryNum->Fill(RBXRANGE, incBin[RBXRANGE]);
+    if (incBin[RBXRANGE]) errorSummaryNum->Fill(RBXRANGE);
     int bx;
     for (bx = muonBxColl1->getFirstBX(); bx <= muonBxColl1->getLastBX(); ++bx) {
         muColl1BxRange->Fill(bx);
@@ -220,7 +220,7 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
     // check number of muons
     if (muonBxColl1->size(iBx) != muonBxColl2->size(iBx)) {
       summary->Fill(NMUONBAD);
-      errorSummaryNum->Fill(RNMUON, incBin[RNMUON]);
+      if (incBin[RNMUON]) errorSummaryNum->Fill(RNMUON);
       muColl1nMu->Fill(muonBxColl1->size(iBx));
       muColl2nMu->Fill(muonBxColl2->size(iBx));
 
@@ -288,57 +288,57 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
       bool muonSelMismatch = false; // Muon mismatches excluding ignored bins
       if (muonIt1->hwPt() != muonIt2->hwPt()) {
         muonMismatch = true;
-        muonSelMismatch = muonSelMismatch || incBin[RPT];
+        if (incBin[RPT]) muonSelMismatch = true;
         summary->Fill(PTBAD);
-        errorSummaryNum->Fill(RPT, incBin[RPT]);
+        if (incBin[RPT]) errorSummaryNum->Fill(RPT);
       }
       if (muonIt1->hwEta() != muonIt2->hwEta()) {
         muonMismatch = true;
-        muonSelMismatch = muonSelMismatch || incBin[RETA];
+        if (incBin[RETA]) muonSelMismatch = true;
         summary->Fill(ETABAD);
-        errorSummaryNum->Fill(RETA, incBin[RETA]);
+        if (incBin[RETA]) errorSummaryNum->Fill(RETA);
       }
       if (muonIt1->hwPhi() != muonIt2->hwPhi()) {
         muonMismatch = true;
-        muonSelMismatch = muonSelMismatch || incBin[RLOCALPHI];
+        if (incBin[RLOCALPHI]) muonSelMismatch = true;
         summary->Fill(LOCALPHIBAD);
-        errorSummaryNum->Fill(RLOCALPHI, incBin[RLOCALPHI]);
+        if (incBin[RLOCALPHI]) errorSummaryNum->Fill(RLOCALPHI);
       }
       if (muonIt1->hwSign() != muonIt2->hwSign()) {
         muonMismatch = true;
-        muonSelMismatch = muonSelMismatch || incBin[RSIGN];
+        if (incBin[RSIGN]) muonSelMismatch = true;
         summary->Fill(SIGNBAD);
-        errorSummaryNum->Fill(RSIGN, incBin[RSIGN]);
+        if (incBin[RSIGN]) errorSummaryNum->Fill(RSIGN);
       }
       if (muonIt1->hwSignValid() != muonIt2->hwSignValid()) {
         muonMismatch = true;
-        muonSelMismatch = muonSelMismatch || incBin[RSIGNVAL];
+        if (incBin[RSIGNVAL]) muonSelMismatch = true;
         summary->Fill(SIGNVALBAD);
-        errorSummaryNum->Fill(RSIGNVAL, incBin[RSIGNVAL]);
+        if (incBin[RSIGNVAL]) errorSummaryNum->Fill(RSIGNVAL);
       }
       if (muonIt1->hwQual() != muonIt2->hwQual()) {
         muonMismatch = true;
-        muonSelMismatch = muonSelMismatch || incBin[RQUAL];
+        if (incBin[RQUAL]) muonSelMismatch = true;
         summary->Fill(QUALBAD);
-        errorSummaryNum->Fill(RQUAL, incBin[RQUAL]);
+        if (incBin[RQUAL]) errorSummaryNum->Fill(RQUAL);
       }
       if (muonIt1->link() != muonIt2->link()) {
         muonMismatch = true;
-        muonSelMismatch = muonSelMismatch || incBin[RLINK];
+        if (incBin[RLINK]) muonSelMismatch = true;
         summary->Fill(LINKBAD);
-        errorSummaryNum->Fill(RLINK, incBin[RLINK]);
+        if (incBin[RLINK]) errorSummaryNum->Fill(RLINK);
       }
       if (muonIt1->processor() != muonIt2->processor()) {
         muonMismatch = true;
-        muonSelMismatch = muonSelMismatch || incBin[RPROC];
+        if (incBin[RPROC]) muonSelMismatch = true;
         summary->Fill(PROCBAD);
-        errorSummaryNum->Fill(RPROC, incBin[RPROC]);
+        if (incBin[RPROC]) errorSummaryNum->Fill(RPROC);
       }
       if (muonIt1->trackFinderType() != muonIt2->trackFinderType()) {
         muonMismatch = true;
-        muonSelMismatch = muonSelMismatch || incBin[RTF];
+        if (incBin[RTF]) muonSelMismatch = true;
         summary->Fill(TFBAD);
-        errorSummaryNum->Fill(RTF, incBin[RTF]);
+        if (incBin[RTF]) errorSummaryNum->Fill(RTF);
       }
       // check track address
       const std::map<int, int> muon1TrackAddr = muonIt1->trackAddress();
@@ -360,18 +360,17 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
       if (badTrackAddr) {
         if (!ignoreBadTrkAddr) {
           muonMismatch = true;
-          muonSelMismatch = muonSelMismatch || incBin[RTRACKADDR];
+          if (incBin[RTRACKADDR]) muonSelMismatch = true;
         }
         summary->Fill(TRACKADDRBAD);
-        errorSummaryNum->Fill(RTRACKADDR, incBin[RTRACKADDR]);
+        if (incBin[RTRACKADDR]) errorSummaryNum->Fill(RTRACKADDR);
       }
 
       if (muonSelMismatch) {
-        errorSummaryNum->Fill(RMUON, incBin[RMUON]);
+        if (incBin[RMUON]) errorSummaryNum->Fill(RMUON);
       }
 
       if (muonMismatch) {
-        errorSummaryNum->Fill(RMUON, incBin[RMUON]);
 
         muColl1hwPt->Fill(muonIt1->hwPt());
         muColl1hwEta->Fill(muonIt1->hwEta());

--- a/DQM/L1TMonitorClient/data/L1TStage2EMTFQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2EMTFQualityTests.xml
@@ -13,8 +13,8 @@
     <TYPE>NoisyChannel</TYPE>	
     <PARAM name="tolerance">20</PARAM>
     <PARAM name="neighbours">9</PARAM>
-    <PARAM name="error">0.996</PARAM>
-    <PARAM name="warning">0.999</PARAM>
+    <PARAM name="error">0.990</PARAM>
+    <PARAM name="warning">0.995</PARAM>
   </QTEST>
   
   <LINK name="*/L1TStage2EMTF/emtfHitOccupancy">
@@ -36,8 +36,8 @@
     <TYPE>NoisyChannel</TYPE>	
     <PARAM name="tolerance">10</PARAM>
     <PARAM name="neighbours">1</PARAM>
-    <PARAM name="error">0.996</PARAM>
-    <PARAM name="warning">0.999</PARAM>
+    <PARAM name="error">0.990</PARAM>
+    <PARAM name="warning">0.995</PARAM>
   </QTEST>
   
   <LINK name="*/L1TStage2EMTF/emtfTrackBX">

--- a/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
@@ -9,7 +9,7 @@
     <PARAM name="xmin">0</PARAM>
     <PARAM name="xmax">0</PARAM>
     <PARAM name="error">0.30</PARAM>
-    <PARAM name="warning">0.60</PARAM>
+    <PARAM name="warning">0.50</PARAM>
   </QTEST>
 
   <QTEST name="uGMT_MuonBXMeanAtBX0">
@@ -104,7 +104,7 @@
     <PARAM name="xmin">0</PARAM>
     <PARAM name="xmax">0</PARAM>
     <PARAM name="error">0.30</PARAM>
-    <PARAM name="warning">0.60</PARAM>
+    <PARAM name="warning">0.50</PARAM>
   </QTEST>
   <TestName activate="true">uGMTBMTFBXPeakAtBX0</TestName>
 
@@ -194,7 +194,7 @@
     <PARAM name="xmin">0</PARAM>
     <PARAM name="xmax">0</PARAM>
     <PARAM name="error">0.30</PARAM>
-    <PARAM name="warning">0.60</PARAM>
+    <PARAM name="warning">0.50</PARAM>
   </QTEST>
 
   <QTEST name="uGMT_OMTFBXMeanAtBX0">
@@ -319,7 +319,7 @@
     <PARAM name="xmin">0</PARAM>
     <PARAM name="xmax">0</PARAM>
     <PARAM name="error">0.30</PARAM>
-    <PARAM name="warning">0.60</PARAM>
+    <PARAM name="warning">0.50</PARAM>
   </QTEST>
 
   <QTEST name="uGMT_EMTFBXMeanAtBX0">

--- a/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
@@ -173,6 +173,11 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemDisable  = cms.uint32(0),
                         QualityTests = cms.VPSet(
                             cms.PSet(
+                                QualityTestName = cms.string("uGMT_MuonBXPeakAtBX0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonBX"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
                                 QualityTestName = cms.string("uGMT_MuonBXMeanAtBX0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonBX"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
@@ -198,6 +203,11 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestSummaryEnabled = cms.uint32(0)
                                 ),
                             cms.PSet(
+                                QualityTestName = cms.string("uGMT_BMTFBXPeakAtBX0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFInput/ugmtBMTFBX"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
                                 QualityTestName = cms.string("uGMT_BMTFBXMeanAtBX0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFInput/ugmtBMTFBX"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
@@ -215,6 +225,11 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                             cms.PSet(
                                 QualityTestName = cms.string("uGMT_BMTFhwSignUniform"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFInput/ugmtBMTFhwSign"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_OMTFBXPeakAtBX0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFBX"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
@@ -245,6 +260,11 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                             cms.PSet(
                                 QualityTestName = cms.string("uGMT_OMTFhwSignUniform"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFhwSign"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_EMTFBXPeakAtBX0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/EMTFInput/ugmtEMTFBX"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(

--- a/DQM/L1TMonitorClient/python/L1TStage2OMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2OMTFEmulatorClient_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+from DQM.L1TMonitor.L1TdeStage2OMTF_cfi import ignoreBins
 
 # RegionalMuonCands
 l1tStage2OMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
@@ -10,7 +11,7 @@ l1tStage2OMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     ratioTitle = cms.untracked.string('Summary of mismatch rates between OMTF muons and OMTF emulator muons'),
     yAxisTitle = cms.untracked.string('# mismatch / # total'),
     binomialErr = cms.untracked.bool(True),
-    ignoreBin = cms.untracked.vint32(1)
+    ignoreBin = cms.untracked.vint32(ignoreBins)
 )
 
 # sequences

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+from DQM.L1TMonitor.L1TStage2uGMT_cff import ignoreBins
 
 # directory path shortening
 ugmtDqmDir = 'L1T/L1TStage2uGMT'
@@ -56,7 +57,7 @@ l1tStage2BmtfOutVsuGMTInRatioClient.monitorDir = cms.untracked.string(ugmtDqmDir
 l1tStage2BmtfOutVsuGMTInRatioClient.inputNum = cms.untracked.string(ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistNumStr)
 l1tStage2BmtfOutVsuGMTInRatioClient.inputDen = cms.untracked.string(ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistDenStr)
 l1tStage2BmtfOutVsuGMTInRatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between BMTF output muons and uGMT input muons from BMTF')
-l1tStage2BmtfOutVsuGMTInRatioClient.ignoreBin = cms.untracked.vint32(1)
+l1tStage2BmtfOutVsuGMTInRatioClient.ignoreBin = cms.untracked.vint32(ignoreBins)
 
 l1tStage2EmtfOutVsuGMTInRatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
 l1tStage2EmtfOutVsuGMTInRatioClient.monitorDir = cms.untracked.string(ugmtDqmDir+'/EMTFoutput_vs_uGMTinput')

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+from DQM.L1TMonitor.L1TdeStage2uGMT_cff import ignoreBins
 
 # directories
 ugmtEmuDqmDir = "L1TEMU/L1TdeStage2uGMT"
@@ -27,35 +28,35 @@ l1tStage2uGMTEmulImdMuBMTFCompRatioClient.monitorDir = cms.untracked.string(ugmt
 l1tStage2uGMTEmulImdMuBMTFCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/BMTF/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuBMTFCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/BMTF/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuBMTFCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'BMTF')
-l1tStage2uGMTEmulImdMuBMTFCompRatioClient.ignoreBin = cms.untracked.vint32(7, 8, 12, 13)
+l1tStage2uGMTEmulImdMuBMTFCompRatioClient.ignoreBin = cms.untracked.vint32(ignoreBins)
 
 l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
 l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_neg/data_vs_emulator_comparison')
 l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_neg/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_neg/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'OMTF-')
-l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.ignoreBin = cms.untracked.vint32(7, 8, 12, 13)
+l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.ignoreBin = cms.untracked.vint32(ignoreBins)
 
 l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
 l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_pos/data_vs_emulator_comparison')
 l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_pos/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_pos/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'OMTF+')
-l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.ignoreBin = cms.untracked.vint32(7, 8, 12, 13)
+l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.ignoreBin = cms.untracked.vint32(ignoreBins)
 
 l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
 l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_neg/data_vs_emulator_comparison')
 l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_neg/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_neg/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'EMTF-')
-l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.ignoreBin = cms.untracked.vint32(7, 8, 12, 13)
+l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.ignoreBin = cms.untracked.vint32(ignoreBins)
 
 l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
 l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_pos/data_vs_emulator_comparison')
 l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_pos/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_pos/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'EMTF+')
-l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.ignoreBin = cms.untracked.vint32(7, 8, 12, 13)
+l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.ignoreBin = cms.untracked.vint32(ignoreBins)
 
 # sequences
 l1tStage2uGMTEmulatorClient = cms.Sequence(


### PR DESCRIPTION
Description:

This PR includes the following changes:

- Reduce the warning threshold of the L1T muon BX QTs from 60% to 50% for all TF, and also slightly reduce the threshold of the noisy channel QT for EMTF.

- Modify the modules that make the muon comparison plots ( L1TStage2RegionalMuonCandComp and  L1TStage2RegionalMuonCandComp )  to include the option of ignoring bins when making the muon mismatch plots, so that they don't take into account the ignored categories when summing up the total number of mismatch muons. The list of ignored bins is then properly propagated to the modules that compute the mismatch ratio plots.

- Include the PeakAtBX0 Quality Tests for muons in the L1T Summary plot
