### PR TITLE
add CosmicsSPLoose_UP17 to the short matrix to capture failures sooner than full IB

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -48,6 +48,7 @@ if __name__ == '__main__':
     #this can get out of here
     predefinedSet={
         'limited' : [5.1, #FastSim ttbar
+                     7.3, #CosmicsSPLoose_UP17
                      8, #BH/Cosmic MC
                      25, #MC ttbar
                      4.22, #cosmic data


### PR DESCRIPTION
we had a few failures in the 2017 cosmic wf in the past few weeks.
It seems like a good time to add it to the PR checkout steps.
