### PR TITLE
Update Pythia8 Flat Configuration Files 

### DIFF
--- a/Configuration/Generator/python/InclusiveppMuX_8TeV_TuneCUETP8M1_cfi.py
+++ b/Configuration/Generator/python/InclusiveppMuX_8TeV_TuneCUETP8M1_cfi.py
@@ -9,7 +9,10 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
                          filterEfficiency = cms.untracked.double(0.002305),
                          comEnergy = cms.double(8000.0),
                          crossSection = cms.untracked.double(51560000000.),
-                         reweightGen = cms.PSet(),
+                         reweightGen = cms.PSet(
+        pTRef = cms.double(15.0),
+        power = cms.double(4.5)
+        ),
                          PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
         pythia8CUEP8M1SettingsBlock,

--- a/Configuration/Generator/python/QCDForPF_13TeV_TuneCUETP8M1_cfi.py
+++ b/Configuration/Generator/python/QCDForPF_13TeV_TuneCUETP8M1_cfi.py
@@ -9,7 +9,10 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
                          filterEfficiency = cms.untracked.double(0.037),
                          crossSection = cms.untracked.double(74310000.),
                          comEnergy = cms.double(13000.0),  # center of mass energy in GeV
-                         reweightGen = cms.PSet(),
+                         reweightGen = cms.PSet(
+        pTRef = cms.double(15.0),
+        power = cms.double(4.5)
+        ),
                          PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
         pythia8CUEP8M1SettingsBlock,

--- a/Configuration/Generator/python/QCDForPF_14TeV_TuneCUETP8M1_cfi.py
+++ b/Configuration/Generator/python/QCDForPF_14TeV_TuneCUETP8M1_cfi.py
@@ -9,7 +9,10 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
                          filterEfficiency = cms.untracked.double(0.037),
                          crossSection = cms.untracked.double(74310000.),
                          comEnergy = cms.double(14000.0),  # center of mass energy in GeV
-                         reweightGen = cms.PSet(),
+                         reweightGen = cms.PSet(
+        pTRef = cms.double(15.0),
+        power = cms.double(4.5)
+        ),
                          PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
         pythia8CUEP8M1SettingsBlock,

--- a/Configuration/Generator/python/QCDForPF_8TeV_TuneCUETP8M1_cfi.py
+++ b/Configuration/Generator/python/QCDForPF_8TeV_TuneCUETP8M1_cfi.py
@@ -9,7 +9,10 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
                          filterEfficiency = cms.untracked.double(0.037),
                          crossSection = cms.untracked.double(74310000.),
                          comEnergy = cms.double(8000.0),  # center of mass energy in GeV
-                         reweightGen = cms.PSet(), 
+                         reweightGen = cms.PSet(
+        pTRef = cms.double(15.0),
+        power = cms.double(4.5)
+        ), 
                          PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
         pythia8CUEP8M1SettingsBlock,

--- a/Configuration/Generator/python/QCD_Pt-15To7000_TuneCUETP8M1_Flat_14TeV-pythia8_cff.py
+++ b/Configuration/Generator/python/QCD_Pt-15To7000_TuneCUETP8M1_Flat_14TeV-pythia8_cff.py
@@ -11,7 +11,10 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
         maxEventsToPrint = cms.untracked.int32(1),
         pythiaHepMCVerbosity = cms.untracked.bool(False),
         pythiaPylistVerbosity = cms.untracked.int32(1),
-        #reweightGen = cms.bool(True), #
+        #reweightGen = cms.bool(
+        #                pTRef = cms.double(15.0),
+        #                power = cms.double(4.5)
+        #                ), #
 
         PythiaParameters = cms.PSet(
                 pythia8CommonSettingsBlock,

--- a/GeneratorInterface/Pythia8Interface/test/pythia8ex2_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/pythia8ex2_cfg.py
@@ -14,7 +14,10 @@ process.generator = cms.EDFilter("Pythia8GeneratorFilter",
     comEnergy = cms.double(7000.),
     #PPbarInitialState = cms.PSet(),
     #SLHAFileForPythia8 = cms.string('Configuration/Generator/data/CSA07SUSYBSM_LM9p_sftsdkpyt_slha.out'),
-    #reweightGen = cms.PSet(),
+    #reweightGen = cms.PSet( # flat in pT
+    #   pTRef = cms.double(15.0),
+    #   power = cms.double(4.5)
+    #),
     #reweightGenRap = cms.PSet( # flat in eta
     #   yLabSigmaFunc = cms.string("15.44/pow(x,0.0253)-12.56"),
     #   yLabPower = cms.double(2.),


### PR DESCRIPTION
Update the Pythia8 configuration files which flatten the pThat distribution. This would bring the configuration files in line with #19668 and fix a problem with some runTheMatrix tests.