### PR TITLE
Fix pixel tracking configuration for trackingPhase1QuadProp workflows

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_cff.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_cff.py
@@ -26,7 +26,7 @@ from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgo
 from Configuration.Eras.Modifier_trackingLowPU_cff import trackingLowPU
 
 # SEEDING LAYERS
-from RecoTracker.IterativeTracking.InitialStep_cff import initialStepSeedLayers, initialStepHitDoublets, initialStepHitQuadruplets
+from RecoTracker.IterativeTracking.InitialStep_cff import initialStepSeedLayers, initialStepHitDoublets, _initialStepCAHitQuadruplets
 
 # TrackingRegion
 pixelTracksTrackingRegions = _globalTrackingRegion.clone()
@@ -45,7 +45,7 @@ pixelTracksHitDoublets = initialStepHitDoublets.clone(
     trackingRegions = "pixelTracksTrackingRegions"
 )
 
-pixelTracksHitQuadruplets = initialStepHitQuadruplets.clone(
+pixelTracksHitQuadruplets = _initialStepCAHitQuadruplets.clone(
     doublets = "pixelTracksHitDoublets",
     SeedComparitorPSet = dict(clusterShapeCacheSrc = 'siPixelClusterShapeCachePreSplitting')
 )

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -61,7 +61,7 @@ initialStepSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
     seedingHitSets = "initialStepHitTriplets",
 )
 from RecoPixelVertexing.PixelTriplets.caHitQuadrupletEDProducer_cfi import caHitQuadrupletEDProducer as _caHitQuadrupletEDProducer
-initialStepHitQuadruplets = _caHitQuadrupletEDProducer.clone(
+_initialStepCAHitQuadruplets = _caHitQuadrupletEDProducer.clone(
     doublets = "initialStepHitDoublets",
     extraHitRPhitolerance = initialStepHitTriplets.extraHitRPhitolerance,
     SeedComparitorPSet = initialStepHitTriplets.SeedComparitorPSet,
@@ -75,6 +75,7 @@ initialStepHitQuadruplets = _caHitQuadrupletEDProducer.clone(
     CAThetaCut = 0.0012,
     CAPhiCut = 0.2,
 )
+initialStepHitQuadruplets = _initialStepCAHitQuadruplets.clone()
 trackingPhase1.toModify(initialStepHitDoublets, layerPairs = [0,1,2]) # layer pairs (0,1), (1,2), (2,3)
 
 from RecoPixelVertexing.PixelTriplets.pixelQuadrupletEDProducer_cfi import pixelQuadrupletEDProducer as _pixelQuadrupletEDProducer


### PR DESCRIPTION
This PR fixes the breakage of workflows 10024.[45] caused by recent #19738 (even if we should phase these ones out in not-so-distant future).

Tested in CMSSW_9_3_X_2017-07-20-1100. Workflows 10024.[45] workflows run again, no other changes are expected.

@rovere @VinInn 