### PR TITLE
Add FEDRawDataCollection to RAWMINIAOD skim event content

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -806,6 +806,14 @@ RAWMINIAODEventContent.outputCommands.extend(RAWEventContent.outputCommands)
 RAWMINIAODEventContent.outputCommands.extend(MicroEventContent.outputCommands)
 RAWMINIAODSIMEventContent.outputCommands.extend(RAWEventContent.outputCommands)
 RAWMINIAODSIMEventContent.outputCommands.extend(MicroEventContentMC.outputCommands)
+RAWMINIAODEventContent.outputCommands.extend(cms.untracked.vstring(
+    'keep FEDRawDataCollection_rawDataCollector_*_*',
+    'keep FEDRawDataCollection_source_*_*'
+))
+RAWMINIAODSIMEventContent.outputCommands.extend(cms.untracked.vstring(
+    'keep FEDRawDataCollection_rawDataCollector_*_*',
+    'keep FEDRawDataCollection_source_*_*'
+))
 
 #
 #

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -802,10 +802,12 @@ RAWMINIAODSIMEventContent= cms.PSet(
     compressionLevel=cms.untracked.int32(4)
 )
 
-RAWMINIAODEventContent.outputCommands.extend(RAWEventContent.outputCommands)
 RAWMINIAODEventContent.outputCommands.extend(MicroEventContent.outputCommands)
-RAWMINIAODSIMEventContent.outputCommands.extend(RAWEventContent.outputCommands)
+RAWMINIAODEventContent.outputCommands.extend(L1TriggerRAW.outputCommands)
+RAWMINIAODEventContent.outputCommands.extend(HLTriggerRAW.outputCommands)
 RAWMINIAODSIMEventContent.outputCommands.extend(MicroEventContentMC.outputCommands)
+RAWMINIAODSIMEventContent.outputCommands.extend(L1TriggerRAW.outputCommands)
+RAWMINIAODSIMEventContent.outputCommands.extend(HLTriggerRAW.outputCommands)
 RAWMINIAODEventContent.outputCommands.extend(cms.untracked.vstring(
     'keep FEDRawDataCollection_rawDataCollector_*_*',
     'keep FEDRawDataCollection_source_*_*'


### PR DESCRIPTION
Adding FEDRawDataCollection to RAW+MINIAOD event content, which is used in the MuTau skim. 