### PR TITLE
Update ztee.py to limit default log size to 16mb.

### DIFF
--- a/DQMServices/StreamerIO/scripts/ztee.py
+++ b/DQMServices/StreamerIO/scripts/ztee.py
@@ -25,7 +25,7 @@ class GZipLog(object):
 
         self.file = open(log_file, "wb+")
         self.file_min_size = 2*1024*1024    # this amount of space we keep after truncating
-        self.file_max_size = 64*1024*1024   # we truncate if file gets bigger
+        self.file_max_size = 16*1024*1024   # we truncate if file gets bigger
 
         self.file_truncate_pos = None
         self.file_truncate_state = None


### PR DESCRIPTION
This script is used only in Online DQM.
16mb of *compressed* log is more than enough.

92x: https://github.com/cms-sw/cmssw/pull/19849