### PR TITLE
[93X] put back the scalers information in SiStrip ALCARECO gone missing in AfterAbortGap -> AAG

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasAAG_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasAAG_Output_cff.py
@@ -12,6 +12,8 @@ OutALCARECOSiStripCalMinBiasAAG_noDrop = cms.PSet(
         'keep DetIdedmEDCollection_siStripDigis_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
+        'keep LumiScalerss_scalersRawToDigi_*_*',
+        'keep DcsStatuss_scalersRawToDigi_*_*',
         'keep *_TriggerResults_*_*')
 )
 

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasHI_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasHI_Output_cff.py
@@ -12,6 +12,8 @@ OutALCARECOSiStripCalMinBias_noDrop = cms.PSet(
         'keep DetIdedmEDCollection_siStripDigis_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
+        'keep LumiScalerss_scalersRawToDigi_*_*',
+        'keep DcsStatuss_scalersRawToDigi_*_*',
         'keep *_TriggerResults_*_*')
 )
 


### PR DESCRIPTION
   Greetings,
the intent of PR is re-add the scalers information already introduced once in #17981 (in CMSSW_9_1_X and backported in 8_0_X via #18062) in the `ALCARECOSiStripCalMinBiasAfterAbortGap`, that unfortunately has gone lost in https://github.com/cms-sw/cmssw/pull/18753, during the AfterAbortGap -> AAG transition. 
As a reminder the increase in event size is of ~135b/evt. 
I profit of this PR to add the same info also in the producer for HI data-taking. 
Since making this information available at ALCARECO level is rather useful to tune the event thresholds for the calibration in multi-run harvesting mode, I'd appreciate fast integration.