### PR TITLE
Adding V3 Train E/gamma paths to the E/g HLT TnP DQM : 92X

### DIFF
--- a/DQMOffline/Trigger/python/EgammaMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/EgammaMonitoring_Client_cff.py
@@ -15,7 +15,7 @@ def makeEGEffHistDef(baseName,filterName):
             
 def makeAllEGEffHistDefs():
     baseNames=["eleWPTightTag","eleWPTightTag-HEP17","eleWPTightTag-HEM17"]
-    filterNames=["hltEle33CaloIdLMWPMS2Filter","hltDiEle33CaloIdLMWPMS2UnseededFilter","hltEG300erFilter","hltEG70HEFilter","hltDiEG70HEUnseededFilter","hltEG85HEFilter","hltDiEG85HEUnseededFilter","hltEG30EIso15HE30EcalIsoLastFilter","hltEG18EIso15HE30EcalIsoUnseededFilter","hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg1Filter","hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg2Filter","hltEle27WPTightGsfTrackIsoFilter","hltEle32noerWPTightGsfTrackIsoFilter","hltEle35noerWPTightGsfTrackIsoFilter","hltEle38noerWPTightGsfTrackIsoFilter","hltEle27L1DoubleEGWPTightGsfTrackIsoFilter","hltEle32L1DoubleEGWPTightGsfTrackIsoFilter","hltEG33L1EG26HEFilter","hltEG50HEFilter","hltEG75HEFilter","hltEG90HEFilter","hltEG120HEFilter","hltEG150HEFilter","hltEG175HEFilter","hltEG200HEFilter","hltSingleCaloJet500","hltSingleCaloJet550","hltEle28HighEtaSC20TrackIsoFilter","hltEle50CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle115CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle135CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle145CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle200CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle250CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle300CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle20WPLoose1GsfTrackIsoFilter","hltEle20erWPLoose1GsfTrackIsoFilter","hltEle20WPTightGsfTrackIsoFilter","hltEle27L1DoubleEGWPTightEcalIsoFilter","hltDiEle27L1DoubleEGWPTightEcalIsoFilter"
+    filterNames=["hltEle33CaloIdLMWPMS2Filter","hltDiEle33CaloIdLMWPMS2UnseededFilter","hltEG300erFilter","hltEG70HEFilter","hltDiEG70HEUnseededFilter","hltEG85HEFilter","hltDiEG85HEUnseededFilter","hltEG30EIso15HE30EcalIsoLastFilter","hltEG18EIso15HE30EcalIsoUnseededFilter","hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg1Filter","hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg2Filter","hltEle27WPTightGsfTrackIsoFilter","hltEle32noerWPTightGsfTrackIsoFilter","hltEle35noerWPTightGsfTrackIsoFilter","hltEle38noerWPTightGsfTrackIsoFilter","hltEle27L1DoubleEGWPTightGsfTrackIsoFilter","hltEle32L1DoubleEGWPTightGsfTrackIsoFilter","hltEG25L1EG18HEFilter","hltEG33L1EG26HEFilter","hltEG50HEFilter","hltEG75HEFilter","hltEG90HEFilter","hltEG120HEFilter","hltEG150HEFilter","hltEG175HEFilter","hltEG200HEFilter","hltSingleCaloJet500","hltSingleCaloJet550","hltEle28HighEtaSC20TrackIsoFilter","hltEle50CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle115CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle135CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle145CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle200CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle250CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle300CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle20WPLoose1GsfTrackIsoFilter","hltEle20erWPLoose1GsfTrackIsoFilter","hltEle20WPTightGsfTrackIsoFilter","hltEle27L1DoubleEGWPTightEcalIsoFilter","hltDiEle27L1DoubleEGWPTightEcalIsoFilter","hltEle27CaloIdLMWPMS2Filter","hltDiEle27CaloIdLMWPMS2UnseededFilter","hltEle25CaloIdLMWPMS2Filter","hltDiEle25CaloIdLMWPMS2UnseededFilter","hltEle27CaloIdLMWPMS2Filter","hltDiEle27CaloIdLMWPMS2UnseededFilter","hltEle37CaloIdLMWPMS2UnseededFilter","hltSingleEle35WPTightGsfL1EGMTTrackIsoFilter"
                  ]
     
     
@@ -25,8 +25,16 @@ def makeAllEGEffHistDefs():
         for filterName in filterNames:
             histDefs.extend(makeEGEffHistDef(baseName,filterName))
 
-    baseNames=["eleWPTightTagPhoProbe","eleWPTightTagPhoProbe-HEM17","eleWPTightTagPhoProbe-HEP17"]
+    baseNames=["eleWPTightTagPhoHighEtaProbe","eleWPTightTagPhoHighEtaProbe-HEM17","eleWPTightTagPhoHighEtaProbe-HEP17"]
     filterNames=["hltEle28HighEtaSC20Mass55Filter","hltEle28HighEtaSC20HcalIsoFilterUnseeded"]
+
+    for baseName in baseNames:
+        for filterName in filterNames:
+            histDefs.extend(makeEGEffHistDef(baseName,filterName))
+
+
+    baseNames=["eleWPTightTagPhoProbe","eleWPTightTagPhoProbe-HEM17","eleWPTightTagPhoProbe-HEP17"]
+    filterNames=["hltEG20CaloIdLV2ClusterShapeL1TripleEGFilter","hltTriEG20CaloIdLV2ClusterShapeUnseededFilter","hltEG20CaloIdLV2R9IdVLR9IdL1TripleEGFilter","hltTriEG20CaloIdLV2R9IdVLR9IdUnseededFilter","hltEG30CaloIdLV2ClusterShapeL1TripleEGFilter","hltEG10CaloIdLV2ClusterShapeUnseededFilter","hltDiEG30CaloIdLV2EtUnseededFilter","hltEG30CaloIdLV2R9IdVLR9IdL1TripleEGFilter","hltEG10CaloIdLV2R9IdVLR9IdUnseededFilter","hltDiEG30CaloIdLV2R9IdVLEtUnseededFilter","hltEG35CaloIdLV2R9IdVLR9IdL1TripleEGFilter","hltEG5CaloIdLV2R9IdVLR9IdUnseededFilter","hltDiEG35CaloIdLV2R9IdVLEtUnseededFilter"]
 
     for baseName in baseNames:
         for filterName in filterNames:

--- a/DQMOffline/Trigger/python/EgammaMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/EgammaMonitoring_cff.py
@@ -1,10 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
-from DQMOffline.Trigger.HLTEGTnPMonitor_cfi import egmGsfElectronIDsForDQM,egHLTDQMOfflineTnPSource,egmPhotonIDSequenceForDQM,egHLTElePhoDQMOfflineTnPSource,photonIDValueMapProducer,egmPhotonIDsForDQM
+from DQMOffline.Trigger.HLTEGTnPMonitor_cfi import egmGsfElectronIDsForDQM,egHLTDQMOfflineTnPSource,egmPhotonIDSequenceForDQM,egHLTElePhoDQMOfflineTnPSource,egHLTElePhoHighEtaDQMOfflineTnPSource,photonIDValueMapProducer,egmPhotonIDsForDQM
 
 egammaMonitorHLT = cms.Sequence(
     egmGsfElectronIDsForDQM*
     egHLTDQMOfflineTnPSource*
     egmPhotonIDSequenceForDQM*
-    egHLTElePhoDQMOfflineTnPSource
+    egHLTElePhoDQMOfflineTnPSource*
+    egHLTElePhoHighEtaDQMOfflineTnPSource
 )

--- a/DQMOffline/Trigger/python/HLTEGTnPMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/HLTEGTnPMonitor_cfi.py
@@ -82,8 +82,6 @@ tagAndProbeConfigEle27WPTight = cms.PSet(
   
     
     ) 
-
-
 tagAndProbeConfigEle27WPTightHEP17 = tagAndProbeConfigEle27WPTight.clone( 
     probeRangeCuts = cms.VPSet(
         hcalPosEtaCut,
@@ -95,18 +93,36 @@ tagAndProbeConfigEle27WPTightHEM17 = tagAndProbeConfigEle27WPTight.clone(
         hcalPhi17Cut,
 ))
 
+
 tagAndProbeElePhoConfigEle27WPTight = tagAndProbeConfigEle27WPTight.clone(
+    probeColl=cms.InputTag("gedPhotons"),
+    probeVIDCuts=cms.InputTag("cutBasedPhotonID-Spring16-V2p2-loose"),
+    minTagProbeDR=cms.double(0.1)
+)
+
+tagAndProbeElePhoConfigEle27WPTightHEP17 = tagAndProbeElePhoConfigEle27WPTight.clone(
+     probeRangeCuts = cms.VPSet(
+        hcalPosEtaCut,
+        hcalPhi17Cut,
+))
+tagAndProbeElePhoConfigEle27WPTightHEM17 = tagAndProbeElePhoConfigEle27WPTight.clone(
+     probeRangeCuts = cms.VPSet(
+        hcalNegEtaCut,
+        hcalPhi17Cut,
+))
+
+tagAndProbeElePhoHighEtaConfigEle27WPTight = tagAndProbeConfigEle27WPTight.clone(
     probeColl=cms.InputTag("gedPhotons"),
     probeVIDCuts=cms.InputTag("cutBasedPhotonID-Spring16-V2p2-loose"),
     probeRangeCuts = cms.VPSet(),
     minTagProbeDR=cms.double(0.1)
 )
-tagAndProbeElePhoConfigEle27WPTightHEP17 = tagAndProbeElePhoConfigEle27WPTight.clone(
+tagAndProbeElePhoHighEtaConfigEle27WPTightHEP17 = tagAndProbeElePhoHighEtaConfigEle27WPTight.clone(
      probeRangeCuts = cms.VPSet(
         ecalEndcapPosHighEtaCut,
         hcalPhi17Cut,
 ))
-tagAndProbeElePhoConfigEle27WPTightHEM17 = tagAndProbeElePhoConfigEle27WPTight.clone(
+tagAndProbeElePhoHighEtaConfigEle27WPTightHEM17 = tagAndProbeElePhoHighEtaConfigEle27WPTight.clone(
      probeRangeCuts = cms.VPSet(
         ecalEndcapPosHighEtaCut,
         hcalPhi17Cut,
@@ -313,7 +329,15 @@ egammaStdFiltersToMonitor= cms.VPSet(
         filterName = cms.string("hltEle32L1DoubleEGWPTightGsfTrackIsoFilter"),
         histTitle = cms.string(""),
         tagExtraFilter = cms.string(""),
+        ), 
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Photon25"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("28:99999")),),
+        filterName = cms.string("hltEG25L1EG18HEFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
         ),
+
     cms.PSet(
         folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Photon33"),
         rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("35:99999")),),
@@ -475,10 +499,68 @@ egammaStdFiltersToMonitor= cms.VPSet(
         histTitle = cms.string(""),
         tagExtraFilter = cms.string("hltEle27L1DoubleEGWPTightEcalIsoFilter"),
         ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_DoubleEle27_CaloIdL_MW"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("30:99999")),),
+        filterName = cms.string("hltEle27CaloIdLMWPMS2Filter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ), 
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_DoubleEle27_CaloIdL_MW"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("30:99999")),),
+        filterName = cms.string("hltDiEle27CaloIdLMWPMS2UnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltEle27CaloIdLMWPMS2Filter"),
+        ), 
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_DoubleEle25_CaloIdL_MW"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("28:99999")),),
+        filterName = cms.string("hltEle25CaloIdLMWPMS2Filter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ), 
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_DoubleEle25_CaloIdL_MW"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("28:99999")),),
+        filterName = cms.string("hltDiEle25CaloIdLMWPMS2UnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltEle25CaloIdLMWPMS2Filter"),
+        ),  
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele27_Ele37_CaloIdL_MW"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("30:99999")),),
+        filterName = cms.string("hltEle27CaloIdLMWPMS2Filter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+     cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele27_Ele37_CaloIdL_MW"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("30:99999")),),
+        filterName = cms.string("hltDiEle27CaloIdLMWPMS2UnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltEle27CaloIdLMWPMS2Filter"),
+        ),
+     cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele27_Ele37_CaloIdL_MW"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("40:99999")),),
+        filterName = cms.string("hltEle37CaloIdLMWPMS2UnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltEle27CaloIdLMWPMS2Filter"),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele35_WPTight_Gsf_L1EGMT"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("38:99999")),),
+        filterName = cms.string("hltSingleEle35WPTightGsfL1EGMTTrackIsoFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    
      )
 
+
   
-egammaPhoFiltersToMonitor= cms.VPSet(
+egammaPhoHighEtaFiltersToMonitor= cms.VPSet(
     cms.PSet(
         folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele28_HighEta_SC20_Mass55"),
         rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("22:99999")),
@@ -499,7 +581,110 @@ egammaPhoFiltersToMonitor= cms.VPSet(
         ),
   
 ) 
+egammaPhoFiltersToMonitor= cms.VPSet(
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_TriplePhoton_20_20_20_CaloIdLV2"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("25:99999")),),
+        filterName = cms.string("hltEG20CaloIdLV2ClusterShapeL1TripleEGFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ), 
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_TriplePhoton_20_20_20_CaloIdLV2"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("25:99999")),),
+        filterName = cms.string("hltTriEG20CaloIdLV2ClusterShapeUnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltEG20CaloIdLV2ClusterShapeL1TripleEGFilter"),
+        ), 
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_TriplePhoton_20_20_20_CaloIdLV2_R9IdVL"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("25:99999")),),
+        filterName = cms.string("hltEG20CaloIdLV2R9IdVLR9IdL1TripleEGFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ), 
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_TriplePhoton_20_20_20_CaloIdLV2_R9IdVL"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("25:99999")),),
+        filterName = cms.string("hltTriEG20CaloIdLV2R9IdVLR9IdUnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltEG20CaloIdLV2R9IdVLR9IdL1TripleEGFilter"),
+        ), 
+    #first seeded leg
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_TriplePhoton_30_30_10_CaloIdLV2"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("35:99999")),),
+        filterName = cms.string("hltEG30CaloIdLV2ClusterShapeL1TripleEGFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ), 
+    #second unseeded leg, 10 GeV 
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_TriplePhoton_30_30_10_CaloIdLV2"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("15:99999")),),
+        filterName = cms.string("hltEG10CaloIdLV2ClusterShapeUnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltEG30CaloIdLV2ClusterShapeL1TripleEGFilter"),
+        ), 
+    #second unseded leg, 30 GeV
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_TriplePhoton_30_30_10_CaloIdLV2"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("35:99999")),),
+        filterName = cms.string("hltDiEG30CaloIdLV2EtUnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltEG30CaloIdLV2ClusterShapeL1TripleEGFilter"),
+        ), 
+    #first seeded leg
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_TriplePhoton_30_30_10_CaloIdLV2_R9IdVL"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("35:99999")),),
+        filterName = cms.string("hltEG30CaloIdLV2R9IdVLR9IdL1TripleEGFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ), 
+    #second unseeded leg, 10 GeV
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_TriplePhoton_30_30_10_CaloIdLV2_R9IdVL"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("15:99999")),),
+        filterName = cms.string("hltEG10CaloIdLV2R9IdVLR9IdUnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltEG30CaloIdLV2R9IdVLR9IdL1TripleEGFilter"),
+                                     
+        ), 
+    #second unseeded leg, 30 GeV
+     cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_TriplePhoton_30_30_10_CaloIdLV2_R9IdVL"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("35:99999")),),
+        filterName = cms.string("hltDiEG30CaloIdLV2R9IdVLEtUnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltEG30CaloIdLV2R9IdVLR9IdL1TripleEGFilter"),
+        ), 
+    #first seeded leg
+     cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_TriplePhoton_35_35_5_CaloIdLV2_R9IdVL"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("38:99999")),),
+        filterName = cms.string("hltEG35CaloIdLV2R9IdVLR9IdL1TripleEGFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ), 
+    #second unseeded leg, 5 GeV
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_TriplePhoton_35_35_5_CaloIdLV2_R9IdVL"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("10:99999")),),
+        filterName = cms.string("hltEG5CaloIdLV2R9IdVLR9IdUnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltEG35CaloIdLV2R9IdVLR9IdL1TripleEGFilter"),
+        ), 
+    #second unseeded leg, 35 GeV
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_TriplePhoton_35_35_5_CaloIdLV2_R9IdVL"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("38:99999")),),
+        filterName = cms.string("hltDiEG35CaloIdLV2R9IdVLEtUnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltEG35CaloIdLV2R9IdVLR9IdL1TripleEGFilter"),
+        ), 
 
+) 
 egHLTDQMOfflineTnPSource = cms.EDAnalyzer("HLTEleTagAndProbeOfflineSource",
                                           tagAndProbeCollections = cms.VPSet(
         cms.PSet( 
@@ -524,29 +709,53 @@ egHLTDQMOfflineTnPSource = cms.EDAnalyzer("HLTEleTagAndProbeOfflineSource",
         )
                                          )
 
+egHLTElePhoHighEtaDQMOfflineTnPSource = cms.EDAnalyzer("HLTElePhoTagAndProbeOfflineSource",
+                                                       tagAndProbeCollections = cms.VPSet(
+        cms.PSet( 
+            tagAndProbeElePhoHighEtaConfigEle27WPTight,
+            histConfigs = egammaHighEtaHistConfigs,
+            baseHistName = cms.string("eleWPTightTagPhoHighEtaProbe_"),
+            filterConfigs = egammaPhoHighEtaFiltersToMonitor,
+        ),
+        cms.PSet(
+            tagAndProbeElePhoHighEtaConfigEle27WPTightHEM17,
+            histConfigs = egammaHighEtaHistConfigs,
+            baseHistName = cms.string("eleWPTightTagPhoHighEtaProbe-HEM17_"),
+            filterConfigs = egammaPhoHighEtaFiltersToMonitor,
+        ),
+        cms.PSet(
+            tagAndProbeElePhoHighEtaConfigEle27WPTightHEP17,
+            histConfigs = egammaHighEtaHistConfigs,
+            baseHistName = cms.string("eleWPTightTagPhoHighEtaProbe-HEP17_"),
+            filterConfigs = egammaPhoHighEtaFiltersToMonitor,
+        ),
+           
+        )
+                                                )
 egHLTElePhoDQMOfflineTnPSource = cms.EDAnalyzer("HLTElePhoTagAndProbeOfflineSource",
                                                 tagAndProbeCollections = cms.VPSet(
         cms.PSet( 
             tagAndProbeElePhoConfigEle27WPTight,
-            histConfigs = egammaHighEtaHistConfigs,
+            histConfigs = egammaStdHistConfigs,
             baseHistName = cms.string("eleWPTightTagPhoProbe_"),
             filterConfigs = egammaPhoFiltersToMonitor,
         ),
         cms.PSet(
             tagAndProbeElePhoConfigEle27WPTightHEM17,
-            histConfigs = egammaHighEtaHistConfigs,
+            histConfigs = egammaStdHistConfigs,
             baseHistName = cms.string("eleWPTightTagPhoProbe-HEM17_"),
             filterConfigs = egammaPhoFiltersToMonitor,
         ),
         cms.PSet(
             tagAndProbeElePhoConfigEle27WPTightHEP17,
-            histConfigs = egammaHighEtaHistConfigs,
+            histConfigs = egammaStdHistConfigs,
             baseHistName = cms.string("eleWPTightTagPhoProbe-HEP17_"),
             filterConfigs = egammaPhoFiltersToMonitor,
         ),
            
         )
-                                                )
+)
+
 
 from RecoEgamma.ElectronIdentification.egmGsfElectronIDs_cff import egmGsfElectronIDs
 


### PR DESCRIPTION
92X backport of https://github.com/cms-sw/cmssw/pull/19792

Adds V3 E/gamma paths to the E/g HLT TnP DQM
