### PR TITLE
VID update to handle isPOGApproved in a better way

### DIFF
--- a/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
@@ -50,17 +50,15 @@ class VersionedSelector : public Selector<T> {
  VersionedSelector(const edm::ParameterSet& conf) : 
   Selector<T>(),
   initialized_(false) { 
-    constexpr unsigned length = MD5_DIGEST_LENGTH;
-    edm::ParameterSet trackedPart = conf.trackedPart();
+
+    validateParamsAreTracked(conf);
+
     name_ = conf.getParameter<std::string>("idName");
-    memset(id_md5_,0,length*sizeof(unsigned char));
-    std::string tracked(trackedPart.dump()), untracked(conf.dump());   
-    if ( tracked != untracked ) {
-      throw cms::Exception("InvalidConfiguration")
-	<< "VersionedSelector does not allow untracked parameters"
-	<< " in the cutflow ParameterSet!";
-    }
+
     // now setup the md5 and cute accessor functions
+    constexpr unsigned length = MD5_DIGEST_LENGTH;
+    std::string tracked(conf.trackedPart().dump());
+    memset(id_md5_,0,length*sizeof(unsigned char));
     MD5((unsigned char*)tracked.c_str(), tracked.size(), id_md5_);
     char buf[32];
     for( unsigned i=0; i<MD5_DIGEST_LENGTH; ++i ){
@@ -157,6 +155,30 @@ class VersionedSelector : public Selector<T> {
 
   CINT_GUARD(void setConsumes(edm::ConsumesCollector));
 
+ private:
+  //here we check that the parameters of the VID cuts are tracked
+  //we allow exactly one parameter to be untracked "isPOGApproved"
+  //as if its tracked, its a pain for the md5Sums
+  //due to the mechanics of PSets, it was demined easier just to 
+  //create a new config which doesnt have an untracked isPOGApproved
+  //if isPOGApproved is tracked (if we decide to do that in the future), it keeps it
+  //see https://github.com/cms-sw/cmssw/issues/19799 for the discussion
+  static void validateParamsAreTracked(const edm::ParameterSet& conf){
+    edm::ParameterSet trackedPart = conf.trackedPart();
+    edm::ParameterSet confWithoutIsPOGApproved;
+    for(auto& paraName : conf.getParameterNames()){
+      if(paraName != "isPOGApproved") confWithoutIsPOGApproved.copyFrom(conf,paraName);
+      else if(conf.existsAs<bool>(paraName,true)) confWithoutIsPOGApproved.copyFrom(conf,paraName); //adding isPOGApproved if its a tracked bool
+    }
+    std::string tracked(conf.trackedPart().dump()), untracked(confWithoutIsPOGApproved.dump());   
+    if ( tracked != untracked ) {
+      throw cms::Exception("InvalidConfiguration")
+	<< "VersionedSelector does not allow untracked parameters"
+	<< " in the cutflow ParameterSet!";
+    }
+  }
+
+   
  protected:
   bool initialized_;
   std::vector<SHARED_PTR(candf::CandidateCut) > cuts_;

--- a/PhysicsTools/SelectorUtils/python/tools/vid_id_tools.py
+++ b/PhysicsTools/SelectorUtils/python/tools/vid_id_tools.py
@@ -14,13 +14,12 @@ def setupVIDSelection(vidproducer,cutflow):
     if not hasattr(cutflow,'cutFlow'):
         raise Exception('InvalidVIDCutFlow', 'The cutflow configuration provided is malformed and does not have a specific cutflow!')
     cutflow_md5 = central_id_registry.getMD5FromName(cutflow.idName)
-    isPOGApproved = cms.untracked.bool(False)
+    isPOGApproved = False
     if hasattr(cutflow,'isPOGApproved'):
-        isPOGApproved = cutflow.isPOGApproved
-        del cutflow.isPOGApproved
+        isPOGApproved = cutflow.isPOGApproved.value()
     vidproducer.physicsObjectIDs.append(
         cms.PSet( idDefinition = cutflow,
-                  isPOGApproved = isPOGApproved,
+                  isPOGApproved = cms.untracked.bool(isPOGApproved),
                   idMD5 = cms.string(cutflow_md5) )
     )    
 #    sys.stderr.write('Added ID \'%s\' to %s\n'%(cutflow.idName.value(),vidproducer.label()))


### PR DESCRIPTION
Dear All,

This PR fixes issue raised in https://github.com/cms-sw/cmssw/issues/19799

The short summary:
VID md5sums the tracked part of the pset's dump string of its id psets. Therefore isPOGApproved is easier if it's tracked as you have to redo the md5sum once you flip it. However it also forbids untracked parameters in its id psets. Therein lies the issue because isPOGApproved can neither be tracked or untracked now. 

To solve this issue, when setting up the VID module via a python function, VID deletes the isPOGApproved from the id pset and creates a new pset with the id, md5sum and id pset. The issue is when you do this twice, the second time isPOGApproved is missing from the id pset and therefore VID warns that its not approved.

To fix the issue, we now ignore isPOGApproved when checking there are no untracked parameters in the id pset. 

This should only affect the printing out of the warning about not being approved, there should be no other changes expected from this.

Note while I was doing this, I noticed that the md5sum checking is somewhat useless. It does not throw an exception if they differ and if you're running with info suppressed, you wont even see it.  It should be changed in my opinion to throw if there's a difference or at least throw if isPOGApproved is set. 

For testing, I had a fair number of xrootd issues with runTheMatrix and scramv1 b runtests so I can not guarantee they all pass. 



