### PR TITLE
Dijet Prompt DQM for JEC

### DIFF
--- a/DQMOffline/Trigger/plugins/DiJetMonitor.cc
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.cc
@@ -17,12 +17,10 @@ num_genTriggerEventFlag_ ( new GenericTriggerEventFlag(iConfig.getParameter<edm:
 {
   folderName_              = iConfig.getParameter<std::string>("FolderName"); 
   dijetSrc_                = mayConsume<reco::PFJetCollection>(iConfig.getParameter<edm::InputTag>("dijetSrc"));//jet 
-  dijetpT_variable_binning_= iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetptBinning");
+  
   dijetpt_binning_         = getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("dijetPSet")    );
   dijetptThr_binning_      = getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("dijetPtThrPSet")    );
-  ls_binning_              = getHistoLSPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("lsPSet")     );
-
-
+  
   ptcut_      = iConfig.getParameter<double>("ptcut" ); 
 
 }

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.cc
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.cc
@@ -259,13 +259,11 @@ void DiJetMonitor::fillDescriptions(edm::ConfigurationDescriptions & description
 //---- Additional DiJet offline selection------
 bool DiJetMonitor::dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id){
   bool passeta = false; //check that one of the jets in the barrel
-  if (abs(eta_1)< etacut_ || abs(eta_2) < etacut_ ) 
-    passeta=true;
+  if (abs(eta_1)< etacut_ || abs(eta_2) < etacut_ )  passeta=true;
   
   float delta_phi_1_2= (phi_1 - phi_2);
   bool other_cuts = false;//check that jets are back to back
-  if (abs(delta_phi_1_2) >= phicut_)
-    other_cuts=true;
+  if (abs(delta_phi_1_2) >= phicut_) other_cuts=true;
 
    if(fabs(eta_1)<etacut_ && fabs(eta_2)>etacut_) {
     tag_id = 0; 

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.cc
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.cc
@@ -15,113 +15,19 @@ DiJetMonitor::DiJetMonitor( const edm::ParameterSet& iConfig ):
 num_genTriggerEventFlag_ ( new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("numGenericTriggerEventPSet"),consumesCollector(), *this))
 ,den_genTriggerEventFlag_ ( new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("denGenericTriggerEventPSet"),consumesCollector(), *this))
 {
-  folderName_            = iConfig.getParameter<std::string>("FolderName"); 
-  dijetSrc_  = mayConsume<reco::PFJetCollection>(iConfig.getParameter<edm::InputTag>("dijetSrc"));//jet 
-  dijetpT_variable_binning_  = iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetptBinning");
-  dijetpt_binning_           = getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("dijetPSet")    );
+  folderName_              = iConfig.getParameter<std::string>("FolderName"); 
+  dijetSrc_                = mayConsume<reco::PFJetCollection>(iConfig.getParameter<edm::InputTag>("dijetSrc"));//jet 
+  dijetpT_variable_binning_= iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetptBinning");
+  dijetpt_binning_         = getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("dijetPSet")    );
   dijetptThr_binning_      = getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("dijetPtThrPSet")    );
-  ls_binning_            = getHistoLSPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("lsPSet")     );
+  ls_binning_              = getHistoLSPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("lsPSet")     );
 
 
   ptcut_      = iConfig.getParameter<double>("ptcut" ); 
   etacut_      = iConfig.getParameter<double>("etacut" ); // for DiJet Offline selection 
   phicut_      = iConfig.getParameter<double>("delphicut" ); // for DiJet Offline selection
 
-      jetpt1ME_.numerator = nullptr;
-      jetpt2ME_.numerator = nullptr;
-   jetptAvgaME_.numerator = nullptr;
-jetptAvgaThrME_.numerator = nullptr;
-   jetptAvgbME_.numerator = nullptr;
-    jetptTagME_.numerator = nullptr;
-    jetptPrbME_.numerator = nullptr;
-    jetptAsyME_.numerator = nullptr;
-   jetetaPrbME_.numerator = nullptr;
-   jetetaTagME_.numerator = nullptr;
-   jetphiPrbME_.numerator = nullptr;
-   jetAsyEtaME_.numerator = nullptr;
-   jetEtaPhiME_.numerator = nullptr;
-  
-      jetpt1ME_.denominator = nullptr;
-      jetpt2ME_.denominator = nullptr;
-   jetptAvgaME_.denominator = nullptr;
-jetptAvgaThrME_.denominator = nullptr;
-   jetptAvgbME_.denominator = nullptr;
-    jetptTagME_.denominator = nullptr;
-    jetptPrbME_.denominator = nullptr;
-    jetptAsyME_.denominator = nullptr;
-   jetetaPrbME_.denominator = nullptr;
-   jetetaTagME_.denominator = nullptr;
-   jetphiPrbME_.denominator = nullptr;
-   jetAsyEtaME_.denominator = nullptr;
-   jetEtaPhiME_.denominator = nullptr;
 }
-
-
-
-DiJetMonitor::~DiJetMonitor()
-{
-}
-
-DiJetMonitor::MEbinning DiJetMonitor::getHistoPSet(edm::ParameterSet pset)
-{
-  return DiJetMonitor::MEbinning{
-    pset.getParameter<unsigned int>("nbins"),
-      pset.getParameter<double>("xmin"),
-      pset.getParameter<double>("xmax"),
-      };
-}
-
-DiJetMonitor::MEbinning DiJetMonitor::getHistoLSPSet(edm::ParameterSet pset)
-{
-  return DiJetMonitor::MEbinning{
-    pset.getParameter<unsigned int>("nbins"),
-      0.,
-      double(pset.getParameter<unsigned int>("nbins"))
-      };
-}
-void DiJetMonitor::setMETitle(JetME& me, std::string titleX, std::string titleY)
-{
-  me.numerator->setAxisTitle(titleX,1);
-  me.numerator->setAxisTitle(titleY,2);
-  me.denominator->setAxisTitle(titleX,1);
-  me.denominator->setAxisTitle(titleY,2);
-}
-void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, JetME& me, std::string& histname, std::string& histtitle, unsigned int nbins, double min, double max)
-{
-  me.numerator   = ibooker.book1D(histname+"_numerator",   histtitle+" (numerator)",   nbins, min, max);
-  me.denominator = ibooker.book1D(histname+"_denominator", histtitle+" (denominator)", nbins, min, max);
-}
-void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, JetME& me, std::string& histname, std::string& histtitle, std::vector<double> binning)
-{
-  int nbins = binning.size()-1;
-  std::vector<float> fbinning(binning.begin(),binning.end());
-  float* arr = &fbinning[0];
-  me.numerator   = ibooker.book1D(histname+"_numerator",   histtitle+" (numerator)",   nbins, arr);
-  me.denominator = ibooker.book1D(histname+"_denominator", histtitle+" (denominator)", nbins, arr);
-}
-void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, JetME& me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax, double ymin, double ymax)
-{
-  me.numerator   = ibooker.bookProfile(histname+"_numerator",   histtitle+" (numerator)",   nbinsX, xmin, xmax, ymin, ymax);
-  me.denominator = ibooker.bookProfile(histname+"_denominator", histtitle+" (denominator)", nbinsX, xmin, xmax, ymin, ymax);
-}
-void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, JetME& me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax, int nbinsY, double ymin, double ymax)
-{
-  me.numerator   = ibooker.book2D(histname+"_numerator",   histtitle+" (numerator)",   nbinsX, xmin, xmax, nbinsY, ymin, ymax);
-  me.denominator = ibooker.book2D(histname+"_denominator", histtitle+" (denominator)", nbinsX, xmin, xmax, nbinsY, ymin, ymax);
-}
-void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, JetME& me, std::string& histname, std::string& histtitle, std::vector<double> binningX, std::vector<double> binningY)
-{
-  int nbinsX = binningX.size()-1;
-  std::vector<float> fbinningX(binningX.begin(),binningX.end());
-  float* arrX = &fbinningX[0];
-  int nbinsY = binningY.size()-1;
-  std::vector<float> fbinningY(binningY.begin(),binningY.end());
-  float* arrY = &fbinningY[0];
-
-  me.numerator   = ibooker.book2D(histname+"_numerator",   histtitle+" (numerator)",   nbinsX, arrX, nbinsY, arrY);
-  me.denominator = ibooker.book2D(histname+"_denominator", histtitle+" (denominator)", nbinsX, arrX, nbinsY, arrY);
-}
-
 
 void DiJetMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
 				 edm::Run const        & iRun,
@@ -270,7 +176,6 @@ void DiJetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSet
      jetpt2ME_.numerator -> Fill(pt_2);
   jetptAvgbME_.numerator -> Fill(pt_avg_b);
 
-    
     if(tag_id == 0 && probe_id == 1) {
       double pt_asy = (pt_2 - pt_1)/(pt_1 + pt_2);
       double pt_avg = (pt_1 + pt_2)*0.5;
@@ -302,18 +207,6 @@ void DiJetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSet
 
 }
 
-void DiJetMonitor::fillHistoPSetDescription(edm::ParameterSetDescription & pset)
-{
-  pset.add<unsigned int>   ( "nbins");
-  pset.add<double>( "xmin" );
-  pset.add<double>( "xmax" );
-}
-
-void DiJetMonitor::fillHistoLSPSetDescription(edm::ParameterSetDescription & pset)
-{
-  pset.add<unsigned int>   ( "nbins", 2500);
-}
-
 void DiJetMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
 {
   edm::ParameterSetDescription desc;
@@ -339,7 +232,6 @@ void DiJetMonitor::fillDescriptions(edm::ConfigurationDescriptions & description
   genericTriggerEventPSet.add<bool>("andOrHlt", true);
   genericTriggerEventPSet.add<edm::InputTag>("hltInputTag", edm::InputTag("TriggerResults::HLT") );
   genericTriggerEventPSet.add<std::vector<std::string> >("hltPaths",{});
-//  genericTriggerEventPSet.add<std::string>("hltDBKey","");
   genericTriggerEventPSet.add<bool>("errorReplyHlt",false);
   genericTriggerEventPSet.add<unsigned int>("verbosityLevel",1);
 
@@ -366,12 +258,12 @@ void DiJetMonitor::fillDescriptions(edm::ConfigurationDescriptions & description
 
 //---- Additional DiJet offline selection------
 bool DiJetMonitor::dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id){
-  bool passeta; //check that one of the jets in the barrel
+  bool passeta = false; //check that one of the jets in the barrel
   if (abs(eta_1)< etacut_ || abs(eta_2) < etacut_ ) 
     passeta=true;
   
   float delta_phi_1_2= (phi_1 - phi_2);
-  bool other_cuts;//check that jets are back to back
+  bool other_cuts = false;//check that jets are back to back
   if (abs(delta_phi_1_2) >= phicut_)
     other_cuts=true;
 

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.cc
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.cc
@@ -1,0 +1,373 @@
+#include "DQMOffline/Trigger/plugins/DiJetMonitor.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DQM/TrackingMonitor/interface/GetLumi.h"
+
+#include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
+
+
+// -----------------------------
+//  constructors and destructor
+// -----------------------------
+
+DiJetMonitor::DiJetMonitor( const edm::ParameterSet& iConfig ):
+num_genTriggerEventFlag_ ( new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("numGenericTriggerEventPSet"),consumesCollector(), *this))
+,den_genTriggerEventFlag_ ( new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("denGenericTriggerEventPSet"),consumesCollector(), *this))
+{
+  folderName_            = iConfig.getParameter<std::string>("FolderName"); 
+  dijetSrc_  = mayConsume<reco::PFJetCollection>(iConfig.getParameter<edm::InputTag>("dijetSrc"));//jet 
+  dijetpT_variable_binning_  = iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetptBinning");
+  dijetpT_binning           = getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("dijetPSet")    );
+  dijetptThr_binning_      = getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("dijetPtThrPSet")    );
+  ls_binning_            = getHistoLSPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("lsPSet")     );
+
+
+  ptcut_      = iConfig.getParameter<double>("ptcut" ); // for HLT DiJet 
+  isPFDiJetTrig    = iConfig.getParameter<bool>("ispfdijettrg" );
+  isCaloDiJetTrig  = iConfig.getParameter<bool>("iscalodijettrg" );
+
+  jetpt1ME_.histo = nullptr;
+  jetpt2ME_.histo = nullptr;
+  jetptAvgaME_.histo = nullptr;
+  jetptAvgbME_.histo = nullptr;
+  jetptTagME_.histo = nullptr;
+  jetptPrbME_.histo = nullptr;
+  jetptAsyME_.histo = nullptr;
+  jetetaPrbME_.histo = nullptr;
+  jetAsyEtaME_.histo = nullptr;
+}
+
+
+DiJetMonitor::~DiJetMonitor()
+{
+}
+
+DiJetMonitor::MEbinning DiJetMonitor::getHistoPSet(edm::ParameterSet pset)
+{
+  return DiJetMonitor::MEbinning{
+    pset.getParameter<unsigned int>("nbins"),
+      pset.getParameter<double>("xmin"),
+      pset.getParameter<double>("xmax"),
+      };
+}
+
+DiJetMonitor::MEbinning DiJetMonitor::getHistoLSPSet(edm::ParameterSet pset)
+{
+  return DiJetMonitor::MEbinning{
+    pset.getParameter<unsigned int>("nbins"),
+      0.,
+      double(pset.getParameter<unsigned int>("nbins"))
+      };
+}
+
+void DiJetMonitor::setMETitle(DiJetME& me, std::string titleX, std::string titleY)
+{
+  me.histo->setAxisTitle(titleX,1);
+  me.histo->setAxisTitle(titleY,2);
+}
+void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, DiJetME& me, std::string& histname, std::string& histtitle, unsigned int nbins, double min, double max)
+{
+  me.histo = ibooker.book1D(histname, histtitle, nbins, min, max);
+}
+void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, DiJetME& me, std::string& histname, std::string& histtitle, std::vector<double> binning)
+{
+  int nbins = binning.size()-1;
+  std::vector<float> fbinning(binning.begin(),binning.end());
+  float* arr = &fbinning[0];
+  me.histo = ibooker.book1D(histname, histtitle, nbins, arr);
+}
+void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, DiJetME& me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax, double ymin, double ymax)
+{
+  me.histo = ibooker.bookProfile(histname, histtitle, nbinsX, xmin, xmax, ymin, ymax);
+}
+void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, DiJetME& me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax, int nbinsY, double ymin, double ymax)
+{
+  me.histo = ibooker.book2D(histname, histtitle, nbinsX, xmin, xmax, nbinsY, ymin, ymax);
+}
+void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, DiJetME& me, std::string& histname, std::string& histtitle, std::vector<double> binningX, std::vector<double> binningY)
+{
+  int nbinsX = binningX.size()-1;
+  std::vector<float> fbinningX(binningX.begin(),binningX.end());
+  float* arrX = &fbinningX[0];
+  int nbinsY = binningY.size()-1;
+  std::vector<float> fbinningY(binningY.begin(),binningY.end());
+  float* arrY = &fbinningY[0];
+
+  me.histo = ibooker.book2D(histname, histtitle, nbinsX, arrX, nbinsY, arrY);
+}
+
+void DiJetMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
+				 edm::Run const        & iRun,
+				 edm::EventSetup const & iSetup) 
+{  
+  
+  std::string histname, histtitle;
+  std::string hist_obtag = "";
+  std::string histtitle_obtag = "";
+  std::string currentFolder = folderName_ ;
+  ibooker.setCurrentFolder(currentFolder.c_str());
+
+
+  histname = "pt_1"; histtitle = "leading Jet Pt";
+  bookME(ibooker,jetpt1ME_,histname,histtitle,dijetpT_binning.nbins,dijetpT_binning.xmin, dijetpT_binning.xmax);
+  setMETitle(jetpt1ME_,"Pt_1 [GeV]","events / [GeV]");
+
+  histname = "pt_2"; histtitle = "second leading Jet Pt";
+  bookME(ibooker,jetpt2ME_,histname,histtitle,dijetpT_binning.nbins,dijetpT_binning.xmin, dijetpT_binning.xmax);
+  setMETitle(jetpt2ME_,"Pt_2 [GeV]","events / [GeV]");
+
+  histname = "pt_avg_b"; histtitle = "Pt average before offline selection";
+  bookME(ibooker,jetptAvgbME_,histname,histtitle,dijetpT_binning.nbins,dijetpT_binning.xmin, dijetpT_binning.xmax);
+  setMETitle(jetptAvgbME_,"(pt_1 + pt_2)*0.5 [GeV]","events / [GeV]");
+
+  histname = "pt_avg_a"; histtitle = "Pt average after offline selection";
+  bookME(ibooker,jetptAvgaME_,histname,histtitle,dijetpT_binning.nbins,dijetpT_binning.xmin, dijetpT_binning.xmax);
+  setMETitle(jetptAvgaME_,"(pt_1 + pt_2)*0.5 [GeV]","events / [GeV]");
+
+  histname = "pt_tag"; histtitle = "Tag Jet Pt";
+  bookME(ibooker,jetptTagME_,histname,histtitle,dijetpT_binning.nbins,dijetpT_binning.xmin, dijetpT_binning.xmax);
+  setMETitle(jetptTagME_,"Pt_tag [GeV]","events / [GeV]");
+
+  histname = "pt_prb"; histtitle = "Probe Jet Pt";
+  bookME(ibooker,jetptPrbME_,histname,histtitle,dijetpT_binning.nbins,dijetpT_binning.xmin, dijetpT_binning.xmax);
+  setMETitle(jetptPrbME_,"Pt_prb [GeV]","events / [GeV]");
+
+  histname = "pt_asym"; histtitle = "Jet Pt Asymetry";
+  bookME(ibooker,jetptAsyME_,histname,histtitle,asy_binning_.nbins,asy_binning_.xmin, asy_binning_.xmax);
+  setMETitle(jetptAsyME_,"(pt_prb - pt_tag)/(pt_prb + pt_tag)","events");
+
+  histname = "eta_prb"; histtitle = "Probe Jet eta";
+  bookME(ibooker,jetetaPrbME_,histname,histtitle,dijet_eta_binning_.nbins,dijet_eta_binning_.xmin, dijet_eta_binning_.xmax);
+  setMETitle(jetetaPrbME_,"Eta_probe","events");
+
+  histname = "pt_Asym_VS_eta_prb"; histtitle = "Pt_Asym vs eta_ptb";
+  bookME(ibooker,jetAsyEtaME_,histname,histtitle,asy_binning_.nbins, asy_binning_.xmin, asy_binning_.xmax, dijet_eta_binning_.nbins, dijet_eta_binning_.xmin,dijet_eta_binning_.xmax);
+  setMETitle(jetAsyEtaME_,"(pt_prb - pt_tag)/(pt_prb + pt_tag)","Eta");
+
+  // Initialize the GenericTriggerEventFlag
+  // Initialize the GenericTriggerEventFlag
+  if ( num_genTriggerEventFlag_ && num_genTriggerEventFlag_->on() ) num_genTriggerEventFlag_->initRun( iRun, iSetup );
+  if ( den_genTriggerEventFlag_ && den_genTriggerEventFlag_->on() ) den_genTriggerEventFlag_->initRun( iRun, iSetup );
+
+}
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "DataFormats/Math/interface/deltaR.h" // For Delta R
+void DiJetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup)  {
+  // Filter out events if Trigger Filtering is requested
+  if (den_genTriggerEventFlag_->on() && ! den_genTriggerEventFlag_->accept( iEvent, iSetup) ) return;
+//  edm::Handle<reco::PFDiJetCollection> pfjetHandle;
+//  iEvent.getByToken( pfjetToken_, pfjetHandle );
+
+//  edm::Handle<reco::CaloDiJetCollection> calojetHandle;
+//  iEvent.getByToken( calojetToken_, calojetHandle );
+
+  int ls = iEvent.id().luminosityBlock();
+  v_jetpt.clear();
+  v_jeteta.clear();
+  v_jetphi.clear();
+
+//  edm::Handle< edm::View<reco::Jet> > offjets;
+  edm::Handle<reco::PFJetCollection > offjets;
+  iEvent.getByToken( dijetSrc_, offjets );
+  if (!offjets.isValid()){
+      edm::LogWarning("DiJetMonitor") << "DiJet handle not valid \n";
+      return;
+  }
+  for ( reco::PFJetCollection::const_iterator ibegin = offjets->begin(), iend = offjets->end(), ijet = ibegin; ijet != iend; ++ijet ) {
+    if (ijet->pt()< 20) {continue;}
+//    if (ijet->pt()< ptcut_) {continue;}
+    v_jetpt.push_back(ijet->pt()); 
+    v_jeteta.push_back(ijet->eta()); 
+    v_jetphi.push_back(ijet->phi()); 
+//    cout << " ijet->pt() (view ) : " << ijet->pt() << endl;
+  }
+
+  if (v_jetpt.size() < 2) {return;}
+//      edm::LogWarning("DiJetMonitor") << " v_jetps.size<2 is exist'  \n";
+  if (num_genTriggerEventFlag_->on() && ! num_genTriggerEventFlag_->accept( iEvent, iSetup) ) return; 
+//      edm::LogWarning("DiJetMonitor") << " events 'num_genTriggerEventFlag_->on'  \n";
+  double pt_1 = v_jetpt[0];
+  double eta_1 = v_jeteta[0];
+  double phi_1 = v_jetphi[0];
+
+  double pt_2 = v_jetpt[1];
+  double eta_2 = v_jeteta[1];
+  double phi_2 = v_jetphi[1];
+//    cout << " TriggerPassed !! pt_1,2 (view ) :  pt_1 = " << pt_1 << ", pt_2  = "<<pt_2<< endl;
+//    cout << " !!  pt_1,2 (view ) :  pt_1 = " << pt_1 << ", pt_2  = "<<pt_2<< endl;
+
+  jetpt1ME_.histo -> Fill(pt_1);
+  jetpt2ME_.histo -> Fill(pt_2);
+  double pt_avg_b = (pt_1 + pt_2)*0.5;
+  jetptAvgbME_.histo -> Fill(pt_avg_b);
+
+  int tag_id = -999, probe_id = -999;
+//_______Offline selection______//  
+  if( dijet_selection(eta_1, phi_1, eta_2, phi_2, pt_1, pt_2,tag_id, probe_id ) == false ) return;
+  
+  if(tag_id == 0 && probe_id == 1) {
+//    double pt_tag = pt_1;
+//    double pt_prb = pt_2;
+//    double eta_prb = eta_2;
+//    double pt_asy = (pt_prb - pt_tag)/(pt_tag + pt_prb);
+    double pt_asy = (pt_2 - pt_1)/(pt_1 + pt_2);
+//    double pt_avg = (pt_tag + pt_prb)*0.5;
+    double pt_avg = (pt_1 + pt_2)*0.5;
+   jetptAvgaME_.histo -> Fill(pt_avg);
+//   jetptTagME_.histo -> Fill(pt_tag);
+//   jetptPrbME_.histo -> Fill(pt_prb);
+   jetptTagME_.histo -> Fill(pt_1);
+   jetptPrbME_.histo -> Fill(pt_2);
+//   jetetaPrbME_.histo -> Fill(eta_prb);
+   jetetaPrbME_.histo -> Fill(eta_2);
+   jetptAsyME_.histo->Fill(pt_asy);
+//   jetetaPrbME_.histo -> Fill(eta_prb);
+//   jetAsyEtaME_.histo -> Fill(pt_asy,eta_prb);
+   jetetaPrbME_.histo -> Fill(eta_2);
+   jetAsyEtaME_.histo -> Fill(pt_asy,eta_2);
+  }
+  if(tag_id == 1 && probe_id == 0) {
+//    double pt_tag = pt_2;
+//    double pt_prb = pt_1;
+//    double eta_prb = eta_1;
+//    double pt_asy = (pt_prb - pt_tag)/(pt_tag + pt_prb);
+//    double pt_avg = (pt_tag + pt_prb)*0.5;
+    double pt_asy = (pt_1 - pt_2)/(pt_2 + pt_1);
+    double pt_avg = (pt_2 + pt_1)*0.5;
+   jetptAvgaME_.histo -> Fill(pt_avg);
+//   jetptTagME_.histo -> Fill(pt_tag);
+//   jetptPrbME_.histo -> Fill(pt_prb);
+   jetptTagME_.histo -> Fill(pt_2);
+   jetptPrbME_.histo -> Fill(pt_1);
+//   jetetaPrbME_.histo -> Fill(eta_prb);
+   jetetaPrbME_.histo -> Fill(eta_1);
+   jetptAsyME_.histo->Fill(pt_asy);
+//   jetetaPrbME_.histo -> Fill(eta_prb);
+//   jetAsyEtaME_.histo -> Fill(pt_asy,eta_prb);
+   jetetaPrbME_.histo -> Fill(eta_1);
+   jetAsyEtaME_.histo -> Fill(pt_asy,eta_1);
+  }
+}
+
+
+
+
+
+void DiJetMonitor::fillHistoPSetDescription(edm::ParameterSetDescription & pset)
+{
+  pset.add<unsigned int>   ( "nbins");
+  pset.add<double>( "xmin" );
+  pset.add<double>( "xmax" );
+}
+
+void DiJetMonitor::fillHistoLSPSetDescription(edm::ParameterSetDescription & pset)
+{
+  pset.add<unsigned int>   ( "nbins", 2500);
+}
+
+void DiJetMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
+{
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>  ( "FolderName", "HLT/Jet" );
+
+  desc.add<edm::InputTag>( "met",      edm::InputTag("pfMet") );
+  desc.add<edm::InputTag>( "pfjets",     edm::InputTag("ak4PFDiJetsCHS") );
+  desc.add<edm::InputTag>( "calojets",     edm::InputTag("ak4CaloDiJets") );
+  desc.add<edm::InputTag>( "dijetSrc",     edm::InputTag("ak4PFJetsCHS") );
+  desc.add<edm::InputTag>( "electrons",edm::InputTag("gedGsfElectrons") );
+  desc.add<edm::InputTag>( "muons",    edm::InputTag("muons") );
+  desc.add<int>("njets",      0);
+  desc.add<int>("nelectrons", 0);
+  desc.add<double>("ptcut",   20);
+  desc.add<bool>("ispfdijettrg",    true);
+  desc.add<bool>("iscalodijettrg",  false);
+
+  edm::ParameterSetDescription genericTriggerEventPSet;
+  genericTriggerEventPSet.add<bool>("andOr");
+  genericTriggerEventPSet.add<edm::InputTag>("dcsInputTag", edm::InputTag("scalersRawToDigi") );
+  genericTriggerEventPSet.add<std::vector<int> >("dcsPartitions",{});
+  genericTriggerEventPSet.add<bool>("andOrDcs", false);
+  genericTriggerEventPSet.add<bool>("errorReplyDcs", true);
+  genericTriggerEventPSet.add<std::string>("dbLabel","");
+  genericTriggerEventPSet.add<bool>("andOrHlt", true);
+  genericTriggerEventPSet.add<edm::InputTag>("hltInputTag", edm::InputTag("TriggerResults::HLT") );
+  genericTriggerEventPSet.add<std::vector<std::string> >("hltPaths",{});
+//  genericTriggerEventPSet.add<std::string>("hltDBKey","");
+  genericTriggerEventPSet.add<bool>("errorReplyHlt",false);
+  genericTriggerEventPSet.add<unsigned int>("verbosityLevel",1);
+
+  desc.add<edm::ParameterSetDescription>("numGenericTriggerEventPSet", genericTriggerEventPSet);
+  desc.add<edm::ParameterSetDescription>("denGenericTriggerEventPSet", genericTriggerEventPSet);
+
+  edm::ParameterSetDescription histoPSet;
+  edm::ParameterSetDescription dijetPSet;
+  edm::ParameterSetDescription dijetPtThrPSet;
+  fillHistoPSetDescription(dijetPSet);
+  fillHistoPSetDescription(dijetPtThrPSet);
+  histoPSet.add<edm::ParameterSetDescription>("dijetPSet", dijetPSet);  
+  histoPSet.add<edm::ParameterSetDescription>("dijetPtThrPSet", dijetPtThrPSet);  
+  std::vector<double> bins = {0.,20.,40.,60.,80.,90.,100.,110.,120.,130.,140.,150.,160.,170.,180.,190.,200.,220.,240.,260.,280.,300.,350.,400.,450.,1000.}; // DiJet pT Binning
+  histoPSet.add<std::vector<double> >("jetptBinning", bins);
+
+  edm::ParameterSetDescription lsPSet;
+  fillHistoLSPSetDescription(lsPSet);
+  histoPSet.add<edm::ParameterSetDescription>("lsPSet", lsPSet);
+
+  desc.add<edm::ParameterSetDescription>("histoPSet",histoPSet);
+
+  descriptions.add("dijetMonitoring", desc);
+}
+
+bool DiJetMonitor::isBarrel(double eta){
+  bool output = false;
+  if (fabs(eta)<=1.3) output=true;
+  return output;
+}
+//---- Additional DiJet offline selection------
+bool DiJetMonitor::dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id){
+  bool passeta; //check that one of the jets in the barrel
+  if (abs(eta_1)< 1.3 || abs(eta_2) < 1.3 ) 
+    passeta=true;
+  
+  float delta_phi_1_2= (phi_1 - phi_2);
+  bool other_cuts;//check that jets are back to back
+  if (abs(delta_phi_1_2) >= 2.7)
+    other_cuts=true;
+
+   if(fabs(eta_1)<1.3 && fabs(eta_2)>1.3) {
+    tag_id = 0; 
+    probe_id = 1;
+  }
+  else 
+    if(fabs(eta_2)<1.3 && fabs(eta_1)>1.3) {
+      tag_id = 1; 
+      probe_id = 0;
+    }
+    else 
+      if(fabs(eta_2)<1.3 && fabs(eta_1)<1.3){
+    int ran = rand();
+    int numb = ran % 2 + 1;
+       if(numb==1){
+         tag_id = 0; 
+         probe_id = 1;
+       }
+       if(numb==2){
+         tag_id = 1; 
+         probe_id = 0;
+       }
+     }
+  if (passeta && other_cuts)
+    return true;
+  else
+    return false;
+}
+
+//------------------------------------------------------------------------//
+// Define this as a plug-in
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(DiJetMonitor);

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.cc
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.cc
@@ -17,18 +17,45 @@ num_genTriggerEventFlag_ ( new GenericTriggerEventFlag(iConfig.getParameter<edm:
 {
   folderName_            = iConfig.getParameter<std::string>("FolderName"); 
   dijetSrc_  = mayConsume<reco::PFJetCollection>(iConfig.getParameter<edm::InputTag>("dijetSrc"));//jet 
-  dijetpT_binning           = getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("dijetPSet")    );
+  dijetpT_variable_binning_  = iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetptBinning");
+  dijetpt_binning_           = getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("dijetPSet")    );
+  dijetptThr_binning_      = getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("dijetPtThrPSet")    );
+  ls_binning_            = getHistoLSPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("lsPSet")     );
 
-  jetpt1ME_.histo = nullptr;
-  jetpt2ME_.histo = nullptr;
-  jetptAvgaME_.histo = nullptr;
-  jetptAvgbME_.histo = nullptr;
-  jetptTagME_.histo = nullptr;
-  jetptPrbME_.histo = nullptr;
-  jetptAsyME_.histo = nullptr;
-  jetetaPrbME_.histo = nullptr;
-  jetAsyEtaME_.histo = nullptr;
+
+  ptcut_      = iConfig.getParameter<double>("ptcut" ); 
+  etacut_      = iConfig.getParameter<double>("etacut" ); // for DiJet Offline selection 
+  phicut_      = iConfig.getParameter<double>("delphicut" ); // for DiJet Offline selection
+
+      jetpt1ME_.numerator = nullptr;
+      jetpt2ME_.numerator = nullptr;
+   jetptAvgaME_.numerator = nullptr;
+jetptAvgaThrME_.numerator = nullptr;
+   jetptAvgbME_.numerator = nullptr;
+    jetptTagME_.numerator = nullptr;
+    jetptPrbME_.numerator = nullptr;
+    jetptAsyME_.numerator = nullptr;
+   jetetaPrbME_.numerator = nullptr;
+   jetetaTagME_.numerator = nullptr;
+   jetphiPrbME_.numerator = nullptr;
+   jetAsyEtaME_.numerator = nullptr;
+   jetEtaPhiME_.numerator = nullptr;
+  
+      jetpt1ME_.denominator = nullptr;
+      jetpt2ME_.denominator = nullptr;
+   jetptAvgaME_.denominator = nullptr;
+jetptAvgaThrME_.denominator = nullptr;
+   jetptAvgbME_.denominator = nullptr;
+    jetptTagME_.denominator = nullptr;
+    jetptPrbME_.denominator = nullptr;
+    jetptAsyME_.denominator = nullptr;
+   jetetaPrbME_.denominator = nullptr;
+   jetetaTagME_.denominator = nullptr;
+   jetphiPrbME_.denominator = nullptr;
+   jetAsyEtaME_.denominator = nullptr;
+   jetEtaPhiME_.denominator = nullptr;
 }
+
 
 
 DiJetMonitor::~DiJetMonitor()
@@ -52,32 +79,37 @@ DiJetMonitor::MEbinning DiJetMonitor::getHistoLSPSet(edm::ParameterSet pset)
       double(pset.getParameter<unsigned int>("nbins"))
       };
 }
-
-void DiJetMonitor::setMETitle(DiJetME& me, std::string titleX, std::string titleY)
+void DiJetMonitor::setMETitle(JetME& me, std::string titleX, std::string titleY)
 {
-  me.histo->setAxisTitle(titleX,1);
-  me.histo->setAxisTitle(titleY,2);
+  me.numerator->setAxisTitle(titleX,1);
+  me.numerator->setAxisTitle(titleY,2);
+  me.denominator->setAxisTitle(titleX,1);
+  me.denominator->setAxisTitle(titleY,2);
 }
-void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, DiJetME& me, std::string& histname, std::string& histtitle, unsigned int nbins, double min, double max)
+void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, JetME& me, std::string& histname, std::string& histtitle, unsigned int nbins, double min, double max)
 {
-  me.histo = ibooker.book1D(histname, histtitle, nbins, min, max);
+  me.numerator   = ibooker.book1D(histname+"_numerator",   histtitle+" (numerator)",   nbins, min, max);
+  me.denominator = ibooker.book1D(histname+"_denominator", histtitle+" (denominator)", nbins, min, max);
 }
-void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, DiJetME& me, std::string& histname, std::string& histtitle, std::vector<double> binning)
+void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, JetME& me, std::string& histname, std::string& histtitle, std::vector<double> binning)
 {
   int nbins = binning.size()-1;
   std::vector<float> fbinning(binning.begin(),binning.end());
   float* arr = &fbinning[0];
-  me.histo = ibooker.book1D(histname, histtitle, nbins, arr);
+  me.numerator   = ibooker.book1D(histname+"_numerator",   histtitle+" (numerator)",   nbins, arr);
+  me.denominator = ibooker.book1D(histname+"_denominator", histtitle+" (denominator)", nbins, arr);
 }
-void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, DiJetME& me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax, double ymin, double ymax)
+void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, JetME& me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax, double ymin, double ymax)
 {
-  me.histo = ibooker.bookProfile(histname, histtitle, nbinsX, xmin, xmax, ymin, ymax);
+  me.numerator   = ibooker.bookProfile(histname+"_numerator",   histtitle+" (numerator)",   nbinsX, xmin, xmax, ymin, ymax);
+  me.denominator = ibooker.bookProfile(histname+"_denominator", histtitle+" (denominator)", nbinsX, xmin, xmax, ymin, ymax);
 }
-void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, DiJetME& me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax, int nbinsY, double ymin, double ymax)
+void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, JetME& me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax, int nbinsY, double ymin, double ymax)
 {
-  me.histo = ibooker.book2D(histname, histtitle, nbinsX, xmin, xmax, nbinsY, ymin, ymax);
+  me.numerator   = ibooker.book2D(histname+"_numerator",   histtitle+" (numerator)",   nbinsX, xmin, xmax, nbinsY, ymin, ymax);
+  me.denominator = ibooker.book2D(histname+"_denominator", histtitle+" (denominator)", nbinsX, xmin, xmax, nbinsY, ymin, ymax);
 }
-void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, DiJetME& me, std::string& histname, std::string& histtitle, std::vector<double> binningX, std::vector<double> binningY)
+void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, JetME& me, std::string& histname, std::string& histtitle, std::vector<double> binningX, std::vector<double> binningY)
 {
   int nbinsX = binningX.size()-1;
   std::vector<float> fbinningX(binningX.begin(),binningX.end());
@@ -86,8 +118,10 @@ void DiJetMonitor::bookME(DQMStore::IBooker &ibooker, DiJetME& me, std::string& 
   std::vector<float> fbinningY(binningY.begin(),binningY.end());
   float* arrY = &fbinningY[0];
 
-  me.histo = ibooker.book2D(histname, histtitle, nbinsX, arrX, nbinsY, arrY);
+  me.numerator   = ibooker.book2D(histname+"_numerator",   histtitle+" (numerator)",   nbinsX, arrX, nbinsY, arrY);
+  me.denominator = ibooker.book2D(histname+"_denominator", histtitle+" (denominator)", nbinsX, arrX, nbinsY, arrY);
 }
+
 
 void DiJetMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
 				 edm::Run const        & iRun,
@@ -95,47 +129,60 @@ void DiJetMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
 {  
   
   std::string histname, histtitle;
-  std::string hist_obtag = "";
-  std::string histtitle_obtag = "";
   std::string currentFolder = folderName_ ;
   ibooker.setCurrentFolder(currentFolder.c_str());
 
+  histname = "jetpt1"; histtitle = "leading Jet Pt";
+  bookME(ibooker,jetpt1ME_,histname,histtitle,dijetpt_binning_.nbins,dijetpt_binning_.xmin, dijetpt_binning_.xmax);
+  setMETitle(jetpt1ME_,"Pt_1 [GeV]","events");
 
-  histname = "pt_1"; histtitle = "leading Jet Pt";
-  bookME(ibooker,jetpt1ME_,histname,histtitle,dijetpT_binning.nbins,dijetpT_binning.xmin, dijetpT_binning.xmax);
-  setMETitle(jetpt1ME_,"Pt_1 [GeV]","events / [GeV]");
+  histname = "jetpt2"; histtitle = "second leading Jet Pt";
+  bookME(ibooker,jetpt2ME_,histname,histtitle,dijetpt_binning_.nbins,dijetpt_binning_.xmin, dijetpt_binning_.xmax);
+  setMETitle(jetpt2ME_,"Pt_2 [GeV]","events");
 
-  histname = "pt_2"; histtitle = "second leading Jet Pt";
-  bookME(ibooker,jetpt2ME_,histname,histtitle,dijetpT_binning.nbins,dijetpT_binning.xmin, dijetpT_binning.xmax);
-  setMETitle(jetpt2ME_,"Pt_2 [GeV]","events / [GeV]");
+  histname = "jetptAvgB"; histtitle = "Pt average before offline selection";
+  bookME(ibooker,jetptAvgbME_,histname,histtitle,dijetpt_binning_.nbins,dijetpt_binning_.xmin, dijetpt_binning_.xmax);
+  setMETitle(jetptAvgbME_,"(pt_1 + pt_2)*0.5 [GeV]","events");
 
-  histname = "pt_avg_b"; histtitle = "Pt average before offline selection";
-  bookME(ibooker,jetptAvgbME_,histname,histtitle,dijetpT_binning.nbins,dijetpT_binning.xmin, dijetpT_binning.xmax);
-  setMETitle(jetptAvgbME_,"(pt_1 + pt_2)*0.5 [GeV]","events / [GeV]");
+  histname = "jetptAvgA"; histtitle = "Pt average after offline selection";
+  bookME(ibooker,jetptAvgaME_,histname,histtitle,dijetpt_binning_.nbins,dijetpt_binning_.xmin, dijetpt_binning_.xmax);
+  setMETitle(jetptAvgaME_,"(pt_1 + pt_2)*0.5 [GeV]","events");
 
-  histname = "pt_avg_a"; histtitle = "Pt average after offline selection";
-  bookME(ibooker,jetptAvgaME_,histname,histtitle,dijetpT_binning.nbins,dijetpT_binning.xmin, dijetpT_binning.xmax);
-  setMETitle(jetptAvgaME_,"(pt_1 + pt_2)*0.5 [GeV]","events / [GeV]");
+  histname = "jetptAvgAThr"; histtitle = "Pt average after offline selection";
+  bookME(ibooker,jetptAvgaThrME_,histname,histtitle,dijetptThr_binning_.nbins,dijetptThr_binning_.xmin, dijetptThr_binning_.xmax);
+  setMETitle(jetptAvgaThrME_,"(pt_1 + pt_2)*0.5 [GeV]","events");
 
-  histname = "pt_tag"; histtitle = "Tag Jet Pt";
-  bookME(ibooker,jetptTagME_,histname,histtitle,dijetpT_binning.nbins,dijetpT_binning.xmin, dijetpT_binning.xmax);
-  setMETitle(jetptTagME_,"Pt_tag [GeV]","events / [GeV]");
+  histname = "jetptTag"; histtitle = "Tag Jet Pt";
+  bookME(ibooker,jetptTagME_,histname,histtitle,dijetpt_binning_.nbins,dijetpt_binning_.xmin, dijetpt_binning_.xmax);
+  setMETitle(jetptTagME_,"Pt_tag [GeV]","events ");
 
-  histname = "pt_prb"; histtitle = "Probe Jet Pt";
-  bookME(ibooker,jetptPrbME_,histname,histtitle,dijetpT_binning.nbins,dijetpT_binning.xmin, dijetpT_binning.xmax);
-  setMETitle(jetptPrbME_,"Pt_prb [GeV]","events / [GeV]");
+  histname = "jetptPrb"; histtitle = "Probe Jet Pt";
+  bookME(ibooker,jetptPrbME_,histname,histtitle,dijetpt_binning_.nbins,dijetpt_binning_.xmin,dijetpt_binning_.xmax);
+  setMETitle(jetptPrbME_,"Pt_prb [GeV]","events");
 
-  histname = "pt_asym"; histtitle = "Jet Pt Asymetry";
+  histname = "jetptAsym"; histtitle = "Jet Pt Asymetry";
   bookME(ibooker,jetptAsyME_,histname,histtitle,asy_binning_.nbins,asy_binning_.xmin, asy_binning_.xmax);
   setMETitle(jetptAsyME_,"(pt_prb - pt_tag)/(pt_prb + pt_tag)","events");
 
-  histname = "eta_prb"; histtitle = "Probe Jet eta";
+  histname = "jetetaPrb"; histtitle = "Probe Jet eta";
   bookME(ibooker,jetetaPrbME_,histname,histtitle,dijet_eta_binning_.nbins,dijet_eta_binning_.xmin, dijet_eta_binning_.xmax);
-  setMETitle(jetetaPrbME_,"Eta_probe","events");
+  setMETitle(jetetaPrbME_,"Eta_probe #eta","events");
 
-  histname = "pt_Asym_VS_eta_prb"; histtitle = "Pt_Asym vs eta_ptb";
+  histname = "jetetaTag"; histtitle = "Tag Jet eta";
+  bookME(ibooker,jetetaTagME_,histname,histtitle,dijet_eta_binning_.nbins,dijet_eta_binning_.xmin, dijet_eta_binning_.xmax);
+  setMETitle(jetetaTagME_,"Eta_tag #eta","events");
+
+  histname = "ptAsymVSetaPrb"; histtitle = "Pt_Asym vs eta_prb";
   bookME(ibooker,jetAsyEtaME_,histname,histtitle,asy_binning_.nbins, asy_binning_.xmin, asy_binning_.xmax, dijet_eta_binning_.nbins, dijet_eta_binning_.xmin,dijet_eta_binning_.xmax);
-  setMETitle(jetAsyEtaME_,"(pt_prb - pt_tag)/(pt_prb + pt_tag)","Eta_probe");
+  setMETitle(jetAsyEtaME_,"(pt_prb - pt_tag)/(pt_prb + pt_tag)","Eta_probe #eta");
+
+  histname = "etaPrbVSphiPrb"; histtitle = "eta_prb vs phi_prb";
+  bookME(ibooker,jetEtaPhiME_,histname,histtitle,dijet_eta_binning_.nbins, dijet_eta_binning_.xmin, dijet_eta_binning_.xmax, dijet_phi_binning_.nbins, dijet_phi_binning_.xmin,dijet_phi_binning_.xmax);
+  setMETitle(jetEtaPhiME_,"Eta_probe #eta","Phi_probe #phi");
+
+  histname = "jetphiPrb"; histtitle = "Probe Jet phi";
+  bookME(ibooker,jetphiPrbME_,histname,histtitle,dijet_phi_binning_.nbins,dijet_phi_binning_.xmin, dijet_phi_binning_.xmax);
+  setMETitle(jetphiPrbME_,"Phi_probe #phi","events");
 
   // Initialize the GenericTriggerEventFlag
   // Initialize the GenericTriggerEventFlag
@@ -152,11 +199,12 @@ void DiJetMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
 void DiJetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup)  {
   // Filter out events if Trigger Filtering is requested
   if (den_genTriggerEventFlag_->on() && ! den_genTriggerEventFlag_->accept( iEvent, iSetup) ) return;
-
+ 
   v_jetpt.clear();
   v_jeteta.clear();
   v_jetphi.clear();
 
+//  edm::Handle< edm::View<reco::Jet> > offjets;
   edm::Handle<reco::PFJetCollection > offjets;
   iEvent.getByToken( dijetSrc_, offjets );
   if (!offjets.isValid()){
@@ -164,60 +212,98 @@ void DiJetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSet
       return;
   }
   for ( reco::PFJetCollection::const_iterator ibegin = offjets->begin(), iend = offjets->end(), ijet = ibegin; ijet != iend; ++ijet ) {
-    if (ijet->pt()< 20) {continue;}
+    if (ijet->pt()< ptcut_) {continue;}
     v_jetpt.push_back(ijet->pt()); 
     v_jeteta.push_back(ijet->eta()); 
     v_jetphi.push_back(ijet->phi()); 
-//    cout << " ijet->pt() (view ) : " << ijet->pt() << endl;
   }
-
   if (v_jetpt.size() < 2) {return;}
-  if (num_genTriggerEventFlag_->on() && ! num_genTriggerEventFlag_->accept( iEvent, iSetup) ) return; 
-//      edm::LogWarning("DiJetMonitor") << " events 'num_genTriggerEventFlag_->on'  \n";
   double pt_1 = v_jetpt[0];
   double eta_1 = v_jeteta[0];
   double phi_1 = v_jetphi[0];
-
   double pt_2 = v_jetpt[1];
   double eta_2 = v_jeteta[1];
   double phi_2 = v_jetphi[1];
-
-  jetpt1ME_.histo -> Fill(pt_1);
-  jetpt2ME_.histo -> Fill(pt_2);
   double pt_avg_b = (pt_1 + pt_2)*0.5;
-  jetptAvgbME_.histo -> Fill(pt_avg_b);
-
   int tag_id = -999, probe_id = -999;
-//_______Offline selection______//  
-  if( dijet_selection(eta_1, phi_1, eta_2, phi_2, pt_1, pt_2,tag_id, probe_id ) == false ) return;
+
+     jetpt1ME_.denominator -> Fill(pt_1);
+     jetpt2ME_.denominator -> Fill(pt_2);
+  jetptAvgbME_.denominator -> Fill(pt_avg_b);
+
+  if( dijet_selection(eta_1, phi_1, eta_2, phi_2, pt_1, pt_2,tag_id, probe_id ) ){ 
   
-  if(tag_id == 0 && probe_id == 1) {
-    double pt_asy = (pt_2 - pt_1)/(pt_1 + pt_2);
-    double pt_avg = (pt_1 + pt_2)*0.5;
-   jetptAvgaME_.histo -> Fill(pt_avg);
-   jetptTagME_.histo -> Fill(pt_1);
-   jetptPrbME_.histo -> Fill(pt_2);
-   jetetaPrbME_.histo -> Fill(eta_2);
-   jetptAsyME_.histo->Fill(pt_asy);
-   jetetaPrbME_.histo -> Fill(eta_2);
-   jetAsyEtaME_.histo -> Fill(pt_asy,eta_2);
+    if(tag_id == 0 && probe_id == 1) {
+      double pt_asy = (pt_2 - pt_1)/(pt_1 + pt_2);
+      double pt_avg = (pt_1 + pt_2)*0.5;
+    jetptAvgaME_.denominator -> Fill(pt_avg);
+    jetptAvgaThrME_.denominator -> Fill(pt_avg);
+     jetptTagME_.denominator -> Fill(pt_1);
+     jetptPrbME_.denominator -> Fill(pt_2);
+    jetetaPrbME_.denominator -> Fill(eta_2);
+    jetetaTagME_.denominator -> Fill(eta_1);
+     jetptAsyME_.denominator ->Fill(pt_asy);
+    jetphiPrbME_.denominator -> Fill(phi_2);
+    jetAsyEtaME_.denominator -> Fill(pt_asy,eta_2);
+  jetEtaPhiME_.denominator -> Fill(eta_2,phi_2);
+    }
+    if(tag_id == 1 && probe_id == 0) {
+      double pt_asy = (pt_1 - pt_2)/(pt_2 + pt_1);
+      double pt_avg = (pt_2 + pt_1)*0.5;
+   jetptAvgaME_.denominator -> Fill(pt_avg);
+   jetptAvgaThrME_.denominator -> Fill(pt_avg);
+    jetptTagME_.denominator -> Fill(pt_2);
+    jetptPrbME_.denominator -> Fill(pt_1);
+   jetetaPrbME_.denominator -> Fill(eta_1);
+   jetetaTagME_.denominator -> Fill(eta_2);
+    jetptAsyME_.denominator->Fill(pt_asy);
+   jetphiPrbME_.denominator -> Fill(phi_1);
+   jetAsyEtaME_.denominator -> Fill(pt_asy,eta_1);
+   jetEtaPhiME_.denominator -> Fill(eta_1,phi_1);
+   }
+
   }
-  if(tag_id == 1 && probe_id == 0) {
-    double pt_asy = (pt_1 - pt_2)/(pt_2 + pt_1);
-    double pt_avg = (pt_2 + pt_1)*0.5;
-   jetptAvgaME_.histo -> Fill(pt_avg);
-   jetptTagME_.histo -> Fill(pt_2);
-   jetptPrbME_.histo -> Fill(pt_1);
-   jetetaPrbME_.histo -> Fill(eta_1);
-   jetptAsyME_.histo->Fill(pt_asy);
-   jetetaPrbME_.histo -> Fill(eta_1);
-   jetAsyEtaME_.histo -> Fill(pt_asy,eta_1);
-  }
+
+  if (num_genTriggerEventFlag_->on() && ! num_genTriggerEventFlag_->accept( iEvent, iSetup) ) return; 
+
+     jetpt1ME_.numerator -> Fill(pt_1);
+     jetpt2ME_.numerator -> Fill(pt_2);
+  jetptAvgbME_.numerator -> Fill(pt_avg_b);
+
+//_______Offline selection______//  
+// if( dijet_selection(eta_1, phi_1, eta_2, phi_2, pt_1, pt_2,tag_id, probe_id ) ) {
+    
+    if(tag_id == 0 && probe_id == 1) {
+      double pt_asy = (pt_2 - pt_1)/(pt_1 + pt_2);
+      double pt_avg = (pt_1 + pt_2)*0.5;
+    jetptAvgaME_.numerator -> Fill(pt_avg);
+    jetptAvgaThrME_.numerator -> Fill(pt_avg);
+     jetptTagME_.numerator -> Fill(pt_1);
+     jetptPrbME_.numerator -> Fill(pt_2);
+    jetetaPrbME_.numerator -> Fill(eta_2);
+    jetetaTagME_.numerator -> Fill(eta_1);
+     jetptAsyME_.numerator->Fill(pt_asy);
+    jetphiPrbME_.numerator -> Fill(phi_2);
+    jetAsyEtaME_.numerator -> Fill(pt_asy,eta_2);
+    jetEtaPhiME_.numerator -> Fill(eta_2,phi_2);
+    }
+    if(tag_id == 1 && probe_id == 0) {
+      double pt_asy = (pt_1 - pt_2)/(pt_2 + pt_1);
+      double pt_avg = (pt_2 + pt_1)*0.5;
+    jetptAvgaME_.numerator -> Fill(pt_avg);
+    jetptAvgaThrME_.numerator -> Fill(pt_avg);
+     jetptTagME_.numerator -> Fill(pt_2);
+     jetptPrbME_.numerator -> Fill(pt_1);
+    jetetaPrbME_.numerator -> Fill(eta_1);
+    jetetaTagME_.numerator -> Fill(eta_2);
+     jetptAsyME_.numerator->Fill(pt_asy);
+    jetphiPrbME_.numerator -> Fill(phi_1);
+    jetAsyEtaME_.numerator -> Fill(pt_asy,eta_1);
+    jetEtaPhiME_.numerator -> Fill(eta_1,phi_1);
+    }
+// }
+
 }
-
-
-
-
 
 void DiJetMonitor::fillHistoPSetDescription(edm::ParameterSetDescription & pset)
 {
@@ -234,9 +320,17 @@ void DiJetMonitor::fillHistoLSPSetDescription(edm::ParameterSetDescription & pse
 void DiJetMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
 {
   edm::ParameterSetDescription desc;
- desc.add<std::string>  ( "FolderName", "HLT/Jet" );
+  desc.add<std::string>  ( "FolderName", "HLT/JetMET" );
 
-  desc.add<edm::InputTag>( "dijetSrc",     edm::InputTag("ak4PFJetsCHS") );
+  desc.add<edm::InputTag>( "met",      edm::InputTag("pfMet") );
+  desc.add<edm::InputTag>( "dijetSrc",     edm::InputTag("ak4PFJets") );
+  desc.add<edm::InputTag>( "electrons",edm::InputTag("gedGsfElectrons") );
+  desc.add<edm::InputTag>( "muons",    edm::InputTag("muons") );
+  desc.add<int>("njets",      0);
+  desc.add<int>("nelectrons", 0);
+  desc.add<double>("ptcut",   20);
+  desc.add<double>("etacut",   1.7);   //using dijet offline selection
+  desc.add<double>("delphicut",   2.7);//using dijet offline selection
 
   edm::ParameterSetDescription genericTriggerEventPSet;
   genericTriggerEventPSet.add<bool>("andOr");
@@ -248,6 +342,7 @@ void DiJetMonitor::fillDescriptions(edm::ConfigurationDescriptions & description
   genericTriggerEventPSet.add<bool>("andOrHlt", true);
   genericTriggerEventPSet.add<edm::InputTag>("hltInputTag", edm::InputTag("TriggerResults::HLT") );
   genericTriggerEventPSet.add<std::vector<std::string> >("hltPaths",{});
+//  genericTriggerEventPSet.add<std::string>("hltDBKey","");
   genericTriggerEventPSet.add<bool>("errorReplyHlt",false);
   genericTriggerEventPSet.add<unsigned int>("verbosityLevel",1);
 
@@ -260,6 +355,9 @@ void DiJetMonitor::fillDescriptions(edm::ConfigurationDescriptions & description
   fillHistoPSetDescription(dijetPSet);
   fillHistoPSetDescription(dijetPtThrPSet);
   histoPSet.add<edm::ParameterSetDescription>("dijetPSet", dijetPSet);  
+  histoPSet.add<edm::ParameterSetDescription>("dijetPtThrPSet", dijetPtThrPSet);  
+  std::vector<double> bins = {0.,20.,40.,60.,80.,90.,100.,110.,120.,130.,140.,150.,160.,170.,180.,190.,200.,220.,240.,260.,280.,300.,350.,400.,450.,1000.}; // DiJet pT Binning
+  histoPSet.add<std::vector<double> >("jetptBinning", bins);
 
   edm::ParameterSetDescription lsPSet;
   fillHistoLSPSetDescription(lsPSet);
@@ -272,30 +370,30 @@ void DiJetMonitor::fillDescriptions(edm::ConfigurationDescriptions & description
 //---- Additional DiJet offline selection------
 bool DiJetMonitor::dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id){
   bool passeta; //check that one of the jets in the barrel
-  if (abs(eta_1)< 1.3 || abs(eta_2) < 1.3 ) 
+  if (abs(eta_1)< etacut_ || abs(eta_2) < etacut_ ) 
     passeta=true;
   
   float delta_phi_1_2= (phi_1 - phi_2);
   bool other_cuts;//check that jets are back to back
-  if (abs(delta_phi_1_2) >= 2.7)
+  if (abs(delta_phi_1_2) >= phicut_)
     other_cuts=true;
 
-   if(fabs(eta_1)<1.3 && fabs(eta_2)>1.3) {
+   if(fabs(eta_1)<etacut_ && fabs(eta_2)>etacut_) {
     tag_id = 0; 
     probe_id = 1;
   }
   else 
-    if(fabs(eta_2)<1.3 && fabs(eta_1)>1.3) {
+    if(fabs(eta_2)<etacut_ && fabs(eta_1)>etacut_) {
       tag_id = 1; 
       probe_id = 0;
     }
     else 
-      if(fabs(eta_2)<1.3 && fabs(eta_1)<1.3){
+      if(fabs(eta_2)<etacut_ && fabs(eta_1)<etacut_){
     int ran = rand();
     int numb = ran % 2 + 1;
        if(numb==1){
-         tag_id = 0; 
-         probe_id = 1;
+       tag_id = 0; 
+       probe_id = 1;
        }
        if(numb==2){
          tag_id = 1; 

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.cc
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.cc
@@ -270,8 +270,6 @@ void DiJetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSet
      jetpt2ME_.numerator -> Fill(pt_2);
   jetptAvgbME_.numerator -> Fill(pt_avg_b);
 
-//_______Offline selection______//  
-// if( dijet_selection(eta_1, phi_1, eta_2, phi_2, pt_1, pt_2,tag_id, probe_id ) ) {
     
     if(tag_id == 0 && probe_id == 1) {
       double pt_asy = (pt_2 - pt_1)/(pt_1 + pt_2);
@@ -301,7 +299,6 @@ void DiJetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSet
     jetAsyEtaME_.numerator -> Fill(pt_asy,eta_1);
     jetEtaPhiME_.numerator -> Fill(eta_1,phi_1);
     }
-// }
 
 }
 

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.cc
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.cc
@@ -24,8 +24,6 @@ num_genTriggerEventFlag_ ( new GenericTriggerEventFlag(iConfig.getParameter<edm:
 
 
   ptcut_      = iConfig.getParameter<double>("ptcut" ); 
-  etacut_      = iConfig.getParameter<double>("etacut" ); // for DiJet Offline selection 
-  phicut_      = iConfig.getParameter<double>("delphicut" ); // for DiJet Offline selection
 
 }
 
@@ -168,8 +166,6 @@ void DiJetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSet
    jetEtaPhiME_.denominator -> Fill(eta_1,phi_1);
    }
 
-  }
-
   if (num_genTriggerEventFlag_->on() && ! num_genTriggerEventFlag_->accept( iEvent, iSetup) ) return; 
 
      jetpt1ME_.numerator -> Fill(pt_1);
@@ -204,7 +200,7 @@ void DiJetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSet
     jetAsyEtaME_.numerator -> Fill(pt_asy,eta_1);
     jetEtaPhiME_.numerator -> Fill(eta_1,phi_1);
     }
-
+  }
 }
 
 void DiJetMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
@@ -219,8 +215,6 @@ void DiJetMonitor::fillDescriptions(edm::ConfigurationDescriptions & description
   desc.add<int>("njets",      0);
   desc.add<int>("nelectrons", 0);
   desc.add<double>("ptcut",   20);
-  desc.add<double>("etacut",   1.7);   //using dijet offline selection
-  desc.add<double>("delphicut",   2.7);//using dijet offline selection
 
   edm::ParameterSetDescription genericTriggerEventPSet;
   genericTriggerEventPSet.add<bool>("andOr");
@@ -258,6 +252,9 @@ void DiJetMonitor::fillDescriptions(edm::ConfigurationDescriptions & description
 
 //---- Additional DiJet offline selection------
 bool DiJetMonitor::dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id){
+  double etacut_ = 1.7;
+  double phicut_ = 2.7;
+	
   bool passeta = false; //check that one of the jets in the barrel
   if (abs(eta_1)< etacut_ || abs(eta_2) < etacut_ )  passeta=true;
   

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.cc
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.cc
@@ -63,27 +63,27 @@ void DiJetMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
   setMETitle(jetptPrbME_,"Pt_prb [GeV]","events");
 
   histname = "jetptAsym"; histtitle = "Jet Pt Asymetry";
-  bookME(ibooker,jetptAsyME_,histname,histtitle,asy_binning_.nbins,asy_binning_.xmin, asy_binning_.xmax);
+  bookME(ibooker,jetptAsyME_,histname,histtitle,asy_binning.nbins,asy_binning.xmin, asy_binning.xmax);
   setMETitle(jetptAsyME_,"(pt_prb - pt_tag)/(pt_prb + pt_tag)","events");
 
   histname = "jetetaPrb"; histtitle = "Probe Jet eta";
-  bookME(ibooker,jetetaPrbME_,histname,histtitle,dijet_eta_binning_.nbins,dijet_eta_binning_.xmin, dijet_eta_binning_.xmax);
+  bookME(ibooker,jetetaPrbME_,histname,histtitle,dijet_eta_binning.nbins,dijet_eta_binning.xmin, dijet_eta_binning.xmax);
   setMETitle(jetetaPrbME_,"Eta_probe #eta","events");
 
   histname = "jetetaTag"; histtitle = "Tag Jet eta";
-  bookME(ibooker,jetetaTagME_,histname,histtitle,dijet_eta_binning_.nbins,dijet_eta_binning_.xmin, dijet_eta_binning_.xmax);
+  bookME(ibooker,jetetaTagME_,histname,histtitle,dijet_eta_binning.nbins,dijet_eta_binning.xmin, dijet_eta_binning.xmax);
   setMETitle(jetetaTagME_,"Eta_tag #eta","events");
 
   histname = "ptAsymVSetaPrb"; histtitle = "Pt_Asym vs eta_prb";
-  bookME(ibooker,jetAsyEtaME_,histname,histtitle,asy_binning_.nbins, asy_binning_.xmin, asy_binning_.xmax, dijet_eta_binning_.nbins, dijet_eta_binning_.xmin,dijet_eta_binning_.xmax);
+  bookME(ibooker,jetAsyEtaME_,histname,histtitle,asy_binning.nbins, asy_binning.xmin, asy_binning.xmax, dijet_eta_binning.nbins, dijet_eta_binning.xmin,dijet_eta_binning.xmax);
   setMETitle(jetAsyEtaME_,"(pt_prb - pt_tag)/(pt_prb + pt_tag)","Eta_probe #eta");
 
   histname = "etaPrbVSphiPrb"; histtitle = "eta_prb vs phi_prb";
-  bookME(ibooker,jetEtaPhiME_,histname,histtitle,dijet_eta_binning_.nbins, dijet_eta_binning_.xmin, dijet_eta_binning_.xmax, dijet_phi_binning_.nbins, dijet_phi_binning_.xmin,dijet_phi_binning_.xmax);
+  bookME(ibooker,jetEtaPhiME_,histname,histtitle,dijet_eta_binning.nbins, dijet_eta_binning.xmin, dijet_eta_binning.xmax, dijet_phi_binning.nbins, dijet_phi_binning.xmin,dijet_phi_binning.xmax);
   setMETitle(jetEtaPhiME_,"Eta_probe #eta","Phi_probe #phi");
 
   histname = "jetphiPrb"; histtitle = "Probe Jet phi";
-  bookME(ibooker,jetphiPrbME_,histname,histtitle,dijet_phi_binning_.nbins,dijet_phi_binning_.xmin, dijet_phi_binning_.xmax);
+  bookME(ibooker,jetphiPrbME_,histname,histtitle,dijet_phi_binning.nbins,dijet_phi_binning.xmin, dijet_phi_binning.xmax);
   setMETitle(jetphiPrbME_,"Phi_probe #phi","events");
 
   // Initialize the GenericTriggerEventFlag
@@ -99,14 +99,19 @@ void DiJetMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "DataFormats/Math/interface/deltaR.h" // For Delta R
 void DiJetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup)  {
+  int Event = -999;
+  Event = iEvent.id().event();
   // Filter out events if Trigger Filtering is requested
   if (den_genTriggerEventFlag_->on() && ! den_genTriggerEventFlag_->accept( iEvent, iSetup) ) return;
  
+  std::vector<double> v_jetpt;
+  std::vector<double> v_jeteta;
+  std::vector<double> v_jetphi;
+	
   v_jetpt.clear();
   v_jeteta.clear();
   v_jetphi.clear();
 
-//  edm::Handle< edm::View<reco::Jet> > offjets;
   edm::Handle<reco::PFJetCollection > offjets;
   iEvent.getByToken( dijetSrc_, offjets );
   if (!offjets.isValid()){
@@ -129,74 +134,74 @@ void DiJetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSet
   double pt_avg_b = (pt_1 + pt_2)*0.5;
   int tag_id = -999, probe_id = -999;
 
-     jetpt1ME_.denominator -> Fill(pt_1);
-     jetpt2ME_.denominator -> Fill(pt_2);
+  jetpt1ME_.denominator    -> Fill(pt_1);
+  jetpt2ME_.denominator    -> Fill(pt_2);
   jetptAvgbME_.denominator -> Fill(pt_avg_b);
 
-  if( dijet_selection(eta_1, phi_1, eta_2, phi_2, pt_1, pt_2,tag_id, probe_id ) ){ 
+  if( dijet_selection(eta_1, phi_1, eta_2, phi_2, pt_1, pt_2,tag_id, probe_id,Event) ){ 
   
     if(tag_id == 0 && probe_id == 1) {
       double pt_asy = (pt_2 - pt_1)/(pt_1 + pt_2);
       double pt_avg = (pt_1 + pt_2)*0.5;
-    jetptAvgaME_.denominator -> Fill(pt_avg);
-    jetptAvgaThrME_.denominator -> Fill(pt_avg);
-     jetptTagME_.denominator -> Fill(pt_1);
-     jetptPrbME_.denominator -> Fill(pt_2);
-    jetetaPrbME_.denominator -> Fill(eta_2);
-    jetetaTagME_.denominator -> Fill(eta_1);
-     jetptAsyME_.denominator ->Fill(pt_asy);
-    jetphiPrbME_.denominator -> Fill(phi_2);
-    jetAsyEtaME_.denominator -> Fill(pt_asy,eta_2);
-  jetEtaPhiME_.denominator -> Fill(eta_2,phi_2);
+      jetptAvgaME_.denominator -> Fill(pt_avg);
+      jetptAvgaThrME_.denominator -> Fill(pt_avg);
+      jetptTagME_.denominator  -> Fill(pt_1);
+      jetptPrbME_.denominator  -> Fill(pt_2);
+      jetetaPrbME_.denominator -> Fill(eta_2);
+      jetetaTagME_.denominator -> Fill(eta_1);
+      jetptAsyME_.denominator  ->Fill(pt_asy);
+      jetphiPrbME_.denominator -> Fill(phi_2);
+      jetAsyEtaME_.denominator -> Fill(pt_asy,eta_2);
+      jetEtaPhiME_.denominator -> Fill(eta_2,phi_2);
     }
     if(tag_id == 1 && probe_id == 0) {
       double pt_asy = (pt_1 - pt_2)/(pt_2 + pt_1);
       double pt_avg = (pt_2 + pt_1)*0.5;
-   jetptAvgaME_.denominator -> Fill(pt_avg);
-   jetptAvgaThrME_.denominator -> Fill(pt_avg);
-    jetptTagME_.denominator -> Fill(pt_2);
-    jetptPrbME_.denominator -> Fill(pt_1);
-   jetetaPrbME_.denominator -> Fill(eta_1);
-   jetetaTagME_.denominator -> Fill(eta_2);
-    jetptAsyME_.denominator->Fill(pt_asy);
-   jetphiPrbME_.denominator -> Fill(phi_1);
-   jetAsyEtaME_.denominator -> Fill(pt_asy,eta_1);
-   jetEtaPhiME_.denominator -> Fill(eta_1,phi_1);
-   }
+      jetptAvgaME_.denominator -> Fill(pt_avg);
+      jetptAvgaThrME_.denominator -> Fill(pt_avg);
+      jetptTagME_.denominator  -> Fill(pt_2);
+      jetptPrbME_.denominator  -> Fill(pt_1);
+      jetetaPrbME_.denominator -> Fill(eta_1);
+      jetetaTagME_.denominator -> Fill(eta_2);
+      jetptAsyME_.denominator  ->Fill(pt_asy);
+      jetphiPrbME_.denominator -> Fill(phi_1);
+      jetAsyEtaME_.denominator -> Fill(pt_asy,eta_1);
+      jetEtaPhiME_.denominator -> Fill(eta_1,phi_1);
+    }
 
   if (num_genTriggerEventFlag_->on() && ! num_genTriggerEventFlag_->accept( iEvent, iSetup) ) return; 
 
-     jetpt1ME_.numerator -> Fill(pt_1);
-     jetpt2ME_.numerator -> Fill(pt_2);
-  jetptAvgbME_.numerator -> Fill(pt_avg_b);
+     jetpt1ME_.numerator   -> Fill(pt_1);
+     jetpt2ME_.numerator   -> Fill(pt_2);
+     jetptAvgbME_.numerator -> Fill(pt_avg_b);
 
     if(tag_id == 0 && probe_id == 1) {
       double pt_asy = (pt_2 - pt_1)/(pt_1 + pt_2);
       double pt_avg = (pt_1 + pt_2)*0.5;
-    jetptAvgaME_.numerator -> Fill(pt_avg);
-    jetptAvgaThrME_.numerator -> Fill(pt_avg);
-     jetptTagME_.numerator -> Fill(pt_1);
-     jetptPrbME_.numerator -> Fill(pt_2);
-    jetetaPrbME_.numerator -> Fill(eta_2);
-    jetetaTagME_.numerator -> Fill(eta_1);
-     jetptAsyME_.numerator->Fill(pt_asy);
-    jetphiPrbME_.numerator -> Fill(phi_2);
-    jetAsyEtaME_.numerator -> Fill(pt_asy,eta_2);
-    jetEtaPhiME_.numerator -> Fill(eta_2,phi_2);
+      jetptAvgaME_.numerator -> Fill(pt_avg);
+      jetptAvgaThrME_.numerator -> Fill(pt_avg);
+      jetptTagME_.numerator  -> Fill(pt_1);
+      jetptPrbME_.numerator  -> Fill(pt_2);
+      jetetaPrbME_.numerator -> Fill(eta_2);
+      jetetaTagME_.numerator -> Fill(eta_1);
+      jetptAsyME_.numerator  ->Fill(pt_asy);
+      jetphiPrbME_.numerator -> Fill(phi_2);
+      jetAsyEtaME_.numerator -> Fill(pt_asy,eta_2);
+      jetEtaPhiME_.numerator -> Fill(eta_2,phi_2);
     }
     if(tag_id == 1 && probe_id == 0) {
       double pt_asy = (pt_1 - pt_2)/(pt_2 + pt_1);
       double pt_avg = (pt_2 + pt_1)*0.5;
-    jetptAvgaME_.numerator -> Fill(pt_avg);
-    jetptAvgaThrME_.numerator -> Fill(pt_avg);
-     jetptTagME_.numerator -> Fill(pt_2);
-     jetptPrbME_.numerator -> Fill(pt_1);
-    jetetaPrbME_.numerator -> Fill(eta_1);
-    jetetaTagME_.numerator -> Fill(eta_2);
-     jetptAsyME_.numerator->Fill(pt_asy);
-    jetphiPrbME_.numerator -> Fill(phi_1);
-    jetAsyEtaME_.numerator -> Fill(pt_asy,eta_1);
-    jetEtaPhiME_.numerator -> Fill(eta_1,phi_1);
+      jetptAvgaME_.numerator -> Fill(pt_avg);
+      jetptAvgaThrME_.numerator -> Fill(pt_avg);
+      jetptTagME_.numerator  -> Fill(pt_2);
+      jetptPrbME_.numerator  -> Fill(pt_1);
+      jetetaPrbME_.numerator -> Fill(eta_1);
+      jetetaTagME_.numerator -> Fill(eta_2);
+      jetptAsyME_.numerator  ->Fill(pt_asy);
+      jetphiPrbME_.numerator -> Fill(phi_1);
+      jetAsyEtaME_.numerator -> Fill(pt_asy,eta_1);
+      jetEtaPhiME_.numerator -> Fill(eta_1,phi_1);
     }
   }
 }
@@ -249,39 +254,36 @@ void DiJetMonitor::fillDescriptions(edm::ConfigurationDescriptions & description
 }
 
 //---- Additional DiJet offline selection------
-bool DiJetMonitor::dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id){
-  double etacut_ = 1.7;
-  double phicut_ = 2.7;
+bool DiJetMonitor::dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id, int Event){
+  double etacut = 1.7;
+  double phicut = 2.7;
 	
-  bool passeta = false; //check that one of the jets in the barrel
-  if (abs(eta_1)< etacut_ || abs(eta_2) < etacut_ )  passeta=true;
-  
+  bool passeta = (std::abs(eta_1)< etacut || std::abs(eta_2) < etacut );//check that one of the jets in the barrel
+ 
   float delta_phi_1_2= (phi_1 - phi_2);
-  bool other_cuts = false;//check that jets are back to back
-  if (abs(delta_phi_1_2) >= phicut_) other_cuts=true;
+  bool other_cuts = (std::abs(delta_phi_1_2) >= phicut); //check that jets are back to back
 
-   if(fabs(eta_1)<etacut_ && fabs(eta_2)>etacut_) {
-    tag_id = 0; 
-    probe_id = 1;
+  if(std::abs(eta_1)<etacut && std::abs(eta_2)>etacut) {
+      tag_id = 0; 
+      probe_id = 1;
   }
   else 
-    if(fabs(eta_2)<etacut_ && fabs(eta_1)>etacut_) {
+  if(std::abs(eta_2)<etacut && std::abs(eta_1)>etacut) {
       tag_id = 1; 
       probe_id = 0;
-    }
-    else 
-      if(fabs(eta_2)<etacut_ && fabs(eta_1)<etacut_){
-    int ran = rand();
-    int numb = ran % 2 + 1;
-       if(numb==1){
-       tag_id = 0; 
-       probe_id = 1;
-       }
-       if(numb==2){
-         tag_id = 1; 
-         probe_id = 0;
-       }
-     }
+  }
+  else 
+  if(std::abs(eta_2)<etacut && std::abs(eta_1)<etacut){
+      int numb = Event % 2;
+      if(numb==0){
+        tag_id = 0; 
+        probe_id = 1;
+      }
+      if(numb==1){
+        tag_id = 1; 
+        probe_id = 0;
+      }
+  }
   if (passeta && other_cuts)
     return true;
   else

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.cc
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.cc
@@ -32,7 +32,7 @@ void DiJetMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
   
   std::string histname, histtitle;
   std::string currentFolder = folderName_ ;
-  ibooker.setCurrentFolder(currentFolder.c_str());
+  ibooker.setCurrentFolder(currentFolder);
 
   histname = "jetpt1"; histtitle = "leading Jet Pt";
   bookME(ibooker,jetpt1ME_,histname,histtitle,dijetpt_binning_.nbins,dijetpt_binning_.xmin, dijetpt_binning_.xmax);

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.h
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.h
@@ -42,8 +42,6 @@
 
 class GenericTriggerEventFlag;
 
-
-
 //
 // class declaration
 //

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.h
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.h
@@ -55,8 +55,9 @@ public:
     double xmax;
   };
 
-  struct DiJetME {
-    MonitorElement* histo= nullptr;
+  struct JetME {
+    MonitorElement* numerator = nullptr;
+    MonitorElement* denominator= nullptr;
   };
 
   DiJetMonitor( const edm::ParameterSet& );
@@ -68,18 +69,23 @@ public:
 protected:
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void bookME(DQMStore::IBooker &, DiJetME& me, std::string& histname, std::string& histtitle, unsigned int nbins, double xmin, double xmax);
-  void bookME(DQMStore::IBooker &, DiJetME& me, std::string& histname, std::string& histtitle, std::vector<double> binningX);
-  void bookME(DQMStore::IBooker &, DiJetME& me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax, double ymin, double ymax);
-  void bookME(DQMStore::IBooker &, DiJetME& me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax, int nbinsY, double ymin, double ymax);
-  void bookME(DQMStore::IBooker &, DiJetME& me, std::string& histname, std::string& histtitle, std::vector<double> binningX, std::vector<double> binningY);
-  void setMETitle(DiJetME& me, std::string titleX, std::string titleY);
+  void bookME(DQMStore::IBooker &, JetME& me, std::string& histname, std::string& histtitle, unsigned int nbins, double xmin, double xmax);
+  void bookME(DQMStore::IBooker &, JetME& me, std::string& histname, std::string& histtitle, std::vector<double> binningX);
+  void bookME(DQMStore::IBooker &, JetME& me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax, double ymin, double ymax);
+  void bookME(DQMStore::IBooker &, JetME& me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax, int nbinsY, double ymin, double ymax);
+  void bookME(DQMStore::IBooker &, JetME& me, std::string& histname, std::string& histtitle, std::vector<double> binningX, std::vector<double> binningY);
+  void setMETitle(JetME& me, std::string titleX, std::string titleY);
   void bookME(DQMStore::IBooker &, MonitorElement* me, std::string& histname, std::string& histtitle, int nbins, double xmin, double xmax);
   void bookME(DQMStore::IBooker &, MonitorElement* me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax,int nbinsY, double ymin, double ymax );
 
   void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
+  bool isBarrel(double eta);
   bool dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id);
 
+  //void FillME(std::vector<MonitorElement*> v_me,std::vector<double>v_pt, std::vector<double> v_phi); //Fill Histograms 
+  //void AutoNullPtr(DiJetME* a_me,const int len_); //Fill Histograms 
+//  void bookMESub(DQMStore::IBooker &,JetME* a_me,const int len_,std::string h_Name ,std::string h_Title, std::string h_subOptName, std::string h_subOptTitle ); //Fill Histograms 
+  //void FillME(JetME* a_me,double pt_, double phi_, double eta_, int ls_, std::string denu); //Fill Histograms 
 
 private:
   static MEbinning getHistoPSet    (edm::ParameterSet pset);
@@ -88,27 +94,54 @@ private:
   std::string folderName_;
   std::string histoSuffix_;
 
+  edm::EDGetTokenT<reco::PFMETCollection>       metToken_;
+  edm::EDGetTokenT<reco::PFJetCollection>       pfdijetToken_;// pfjet
+  edm::EDGetTokenT<reco::CaloJetCollection>     calodijetToken_;// calojet
+  edm::EDGetTokenT<reco::GsfElectronCollection> eleToken_;
+  edm::EDGetTokenT<reco::MuonCollection>        muoToken_;
+  //edm::InputTag        jetSrc_; // test for Jet
   edm::EDGetTokenT<reco::PFJetCollection>  dijetSrc_; // test for Jet
 
-  MEbinning           dijetpT_binning;
+  std::vector<double> dijetpT_variable_binning_;
+  MEbinning           dijetpt_binning_;
+  MEbinning           dijetptThr_binning_;
+  MEbinning           ls_binning_;
 
-   DiJetME jetpt1ME_;
-   DiJetME jetpt2ME_;
-   DiJetME jetptAvgaME_;
-   DiJetME jetptAvgbME_;
-   DiJetME jetptTagME_;
-   DiJetME jetptPrbME_;
-   DiJetME jetptAsyME_;
-   DiJetME jetetaPrbME_;
-   DiJetME jetAsyEtaME_;
+
+   JetME jetpt1ME_;
+   JetME jetpt2ME_;
+   JetME jetptAvgaME_;
+   JetME jetptAvgaThrME_;
+   JetME jetptAvgbME_;
+   JetME jetptTagME_;
+   JetME jetptPrbME_;
+   JetME jetptAsyME_;
+   JetME jetetaPrbME_;
+   JetME jetetaTagME_;
+   JetME jetphiPrbME_;
+   JetME jetAsyEtaME_;
+   JetME jetEtaPhiME_;
 
   std::unique_ptr<GenericTriggerEventFlag> num_genTriggerEventFlag_;
   std::unique_ptr<GenericTriggerEventFlag> den_genTriggerEventFlag_;
+
+  int nmuons_;
+  double ptcut_;
+  double etacut_;
+  double phicut_;
+  bool isPFDiJetTrig;
+  bool isCaloDiJetTrig;
 
   std::vector<double> v_jetpt;
   std::vector<double> v_jeteta;
   std::vector<double> v_jetphi;
 
+  // Define Phi Bin //
+  double DiJet_MAX_PHI = 3.2;
+  unsigned int DiJet_N_PHI = 64;
+  MEbinning dijet_phi_binning_{
+    DiJet_N_PHI, -DiJet_MAX_PHI, DiJet_MAX_PHI
+  };
   // Define Eta Bin //
   double DiJet_MAX_ETA = 5;
   unsigned int DiJet_N_ETA = 50;

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.h
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.h
@@ -18,6 +18,8 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
 
+#include "DQMOffline/Trigger/plugins/TriggerDQMBase.h"
+#include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
 //DataFormats
@@ -46,74 +48,47 @@ class GenericTriggerEventFlag;
 // class declaration
 //
 
-class DiJetMonitor : public DQMEDAnalyzer 
+class DiJetMonitor : public DQMEDAnalyzer  ,  public TriggerDQMBase
 {
 public:
-  struct MEbinning {
-    unsigned int nbins;
-    double xmin;
-    double xmax;
-  };
-
-  struct JetME {
-    MonitorElement* numerator = nullptr;
-    MonitorElement* denominator= nullptr;
-  };
-
   DiJetMonitor( const edm::ParameterSet& );
-  ~DiJetMonitor();
+  virtual ~DiJetMonitor() noexcept(true) {};
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  static void fillHistoPSetDescription(edm::ParameterSetDescription & pset);
-  static void fillHistoLSPSetDescription(edm::ParameterSetDescription & pset);
 
 protected:
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void bookME(DQMStore::IBooker &, JetME& me, std::string& histname, std::string& histtitle, unsigned int nbins, double xmin, double xmax);
-  void bookME(DQMStore::IBooker &, JetME& me, std::string& histname, std::string& histtitle, std::vector<double> binningX);
-  void bookME(DQMStore::IBooker &, JetME& me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax, double ymin, double ymax);
-  void bookME(DQMStore::IBooker &, JetME& me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax, int nbinsY, double ymin, double ymax);
-  void bookME(DQMStore::IBooker &, JetME& me, std::string& histname, std::string& histtitle, std::vector<double> binningX, std::vector<double> binningY);
-  void setMETitle(JetME& me, std::string titleX, std::string titleY);
-  void bookME(DQMStore::IBooker &, MonitorElement* me, std::string& histname, std::string& histtitle, int nbins, double xmin, double xmax);
-  void bookME(DQMStore::IBooker &, MonitorElement* me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax,int nbinsY, double ymin, double ymax );
-
   void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
   bool dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id);
 
 private:
-  static MEbinning getHistoPSet    (edm::ParameterSet pset);
-  static MEbinning getHistoLSPSet  (edm::ParameterSet pset);
 
   std::string folderName_;
   std::string histoSuffix_;
 
   edm::EDGetTokenT<reco::PFMETCollection>       metToken_;
-  edm::EDGetTokenT<reco::PFJetCollection>       pfdijetToken_;// pfjet
-  edm::EDGetTokenT<reco::CaloJetCollection>     calodijetToken_;// calojet
   edm::EDGetTokenT<reco::GsfElectronCollection> eleToken_;
   edm::EDGetTokenT<reco::MuonCollection>        muoToken_;
-  edm::EDGetTokenT<reco::PFJetCollection>  dijetSrc_;
+  edm::EDGetTokenT<reco::PFJetCollection>  dijetSrc_; // test for Jet
 
   std::vector<double> dijetpT_variable_binning_;
   MEbinning           dijetpt_binning_;
   MEbinning           dijetptThr_binning_;
   MEbinning           ls_binning_;
 
-
-   JetME jetpt1ME_;
-   JetME jetpt2ME_;
-   JetME jetptAvgaME_;
-   JetME jetptAvgaThrME_;
-   JetME jetptAvgbME_;
-   JetME jetptTagME_;
-   JetME jetptPrbME_;
-   JetME jetptAsyME_;
-   JetME jetetaPrbME_;
-   JetME jetetaTagME_;
-   JetME jetphiPrbME_;
-   JetME jetAsyEtaME_;
-   JetME jetEtaPhiME_;
+  ObjME jetpt1ME_;
+  ObjME jetpt2ME_;
+  ObjME jetptAvgaME_;
+  ObjME jetptAvgaThrME_;
+  ObjME jetptAvgbME_;
+  ObjME jetptTagME_;
+  ObjME jetptPrbME_;
+  ObjME jetptAsyME_;
+  ObjME jetetaPrbME_;
+  ObjME jetetaTagME_;
+  ObjME jetphiPrbME_;
+  ObjME jetAsyEtaME_;
+  ObjME jetEtaPhiME_;
 
   std::unique_ptr<GenericTriggerEventFlag> num_genTriggerEventFlag_;
   std::unique_ptr<GenericTriggerEventFlag> den_genTriggerEventFlag_;

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.h
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.h
@@ -1,0 +1,160 @@
+#ifndef JETMETMONITOR_H
+#define JETMETMONITOR_H
+
+#include <string>
+#include <vector>
+#include <map>
+
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
+
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+//DataFormats
+#include "DataFormats/METReco/interface/PFMET.h"
+#include "DataFormats/METReco/interface/PFMETCollection.h"
+
+#include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/JetReco/interface/PFJetCollection.h"
+#include "DataFormats/JetReco/interface/CaloJet.h"
+#include "DataFormats/JetReco/interface/CaloJetCollection.h"
+#include "DataFormats/JetReco/interface/GenJetCollection.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
+
+class GenericTriggerEventFlag;
+
+
+
+//
+// class declaration
+//
+
+class DiJetMonitor : public DQMEDAnalyzer 
+{
+public:
+  struct MEbinning {
+    unsigned int nbins;
+    double xmin;
+    double xmax;
+  };
+
+  struct DiJetME {
+    MonitorElement* numerator = nullptr;
+    MonitorElement* denominator= nullptr;
+    MonitorElement* histo= nullptr;
+  };
+
+  DiJetMonitor( const edm::ParameterSet& );
+  ~DiJetMonitor();
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillHistoPSetDescription(edm::ParameterSetDescription & pset);
+  static void fillHistoLSPSetDescription(edm::ParameterSetDescription & pset);
+
+protected:
+
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void bookME(DQMStore::IBooker &, DiJetME& me, std::string& histname, std::string& histtitle, unsigned int nbins, double xmin, double xmax);
+  void bookME(DQMStore::IBooker &, DiJetME& me, std::string& histname, std::string& histtitle, std::vector<double> binningX);
+  void bookME(DQMStore::IBooker &, DiJetME& me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax, double ymin, double ymax);
+  void bookME(DQMStore::IBooker &, DiJetME& me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax, int nbinsY, double ymin, double ymax);
+  void bookME(DQMStore::IBooker &, DiJetME& me, std::string& histname, std::string& histtitle, std::vector<double> binningX, std::vector<double> binningY);
+  void setMETitle(DiJetME& me, std::string titleX, std::string titleY);
+  void bookME(DQMStore::IBooker &, MonitorElement* me, std::string& histname, std::string& histtitle, int nbins, double xmin, double xmax);
+  void bookME(DQMStore::IBooker &, MonitorElement* me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax,int nbinsY, double ymin, double ymax );
+
+  void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
+  bool isBarrel(double eta);
+  bool dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id);
+
+  //void FillME(std::vector<MonitorElement*> v_me,std::vector<double>v_pt, std::vector<double> v_phi); //Fill Histograms 
+  //void AutoNullPtr(DiJetME* a_me,const int len_); //Fill Histograms 
+  void bookMESub(DQMStore::IBooker &,DiJetME* a_me,const int len_,std::string h_Name ,std::string h_Title, std::string h_subOptName, std::string h_subOptTitle ); //Fill Histograms 
+  void FillME(DiJetME* a_me,double pt_, double phi_, double eta_, int ls_, std::string denu); //Fill Histograms 
+
+private:
+  static MEbinning getHistoPSet    (edm::ParameterSet pset);
+  static MEbinning getHistoLSPSet  (edm::ParameterSet pset);
+
+  std::string folderName_;
+  std::string histoSuffix_;
+
+  edm::EDGetTokenT<reco::PFMETCollection>       metToken_;
+  edm::EDGetTokenT<reco::PFJetCollection>       pfdijetToken_;// pfjet
+  edm::EDGetTokenT<reco::CaloJetCollection>     calodijetToken_;// calojet
+  edm::EDGetTokenT<reco::GsfElectronCollection> eleToken_;
+  edm::EDGetTokenT<reco::MuonCollection>        muoToken_;
+  //edm::InputTag        jetSrc_; // test for Jet
+  edm::EDGetTokenT<reco::PFJetCollection>  dijetSrc_; // test for Jet
+
+  std::vector<double> dijetpT_variable_binning_;
+  MEbinning           dijetpT_binning;
+  MEbinning           dijetptThr_binning_;
+  MEbinning           ls_binning_;
+
+
+//  DiJetME a_ME[7];
+//  DiJetME a_ME_tag[7];
+//  DiJetME a_ME_prb[7];
+   DiJetME jetpt1ME_;
+   DiJetME jetpt2ME_;
+   DiJetME jetptAvgaME_;
+   DiJetME jetptAvgbME_;
+   DiJetME jetptTagME_;
+   DiJetME jetptPrbME_;
+   DiJetME jetptAsyME_;
+   DiJetME jetetaPrbME_;
+   DiJetME jetAsyEtaME_;
+// Add !!!!!!!!!!!!! more plot!!!!!!!!!!!
+
+  std::unique_ptr<GenericTriggerEventFlag> num_genTriggerEventFlag_;
+  std::unique_ptr<GenericTriggerEventFlag> den_genTriggerEventFlag_;
+
+  int nmuons_;
+  double ptcut_;
+  bool isPFDiJetTrig;
+  bool isCaloDiJetTrig;
+
+  std::vector<double> v_jetpt;
+  std::vector<double> v_jeteta;
+  std::vector<double> v_jetphi;
+
+  // Define Phi Bin //
+  double DiJet_MAX_PHI = 3.2;
+  unsigned int DiJet_N_PHI = 64;
+  MEbinning dijet_phi_binning_{
+    DiJet_N_PHI, -DiJet_MAX_PHI, DiJet_MAX_PHI
+  };
+  // Define Eta Bin //
+  double DiJet_MAX_ETA = 5;
+  unsigned int DiJet_N_ETA = 50;
+  MEbinning dijet_eta_binning_{
+    DiJet_N_ETA, -DiJet_MAX_ETA, DiJet_MAX_ETA
+  };
+
+  double MAX_asy = 1;
+  double MIN_asy = -1;
+  unsigned int N_asy = 100;
+  MEbinning asy_binning_{
+    N_asy, MIN_asy, MAX_asy
+  };
+
+};
+
+#endif // JETMETMONITOR_H

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.h
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.h
@@ -56,8 +56,6 @@ public:
   };
 
   struct DiJetME {
-    MonitorElement* numerator = nullptr;
-    MonitorElement* denominator= nullptr;
     MonitorElement* histo= nullptr;
   };
 
@@ -80,13 +78,8 @@ protected:
   void bookME(DQMStore::IBooker &, MonitorElement* me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax,int nbinsY, double ymin, double ymax );
 
   void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
-  bool isBarrel(double eta);
   bool dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id);
 
-  //void FillME(std::vector<MonitorElement*> v_me,std::vector<double>v_pt, std::vector<double> v_phi); //Fill Histograms 
-  //void AutoNullPtr(DiJetME* a_me,const int len_); //Fill Histograms 
-  void bookMESub(DQMStore::IBooker &,DiJetME* a_me,const int len_,std::string h_Name ,std::string h_Title, std::string h_subOptName, std::string h_subOptTitle ); //Fill Histograms 
-  void FillME(DiJetME* a_me,double pt_, double phi_, double eta_, int ls_, std::string denu); //Fill Histograms 
 
 private:
   static MEbinning getHistoPSet    (edm::ParameterSet pset);
@@ -95,23 +88,10 @@ private:
   std::string folderName_;
   std::string histoSuffix_;
 
-  edm::EDGetTokenT<reco::PFMETCollection>       metToken_;
-  edm::EDGetTokenT<reco::PFJetCollection>       pfdijetToken_;// pfjet
-  edm::EDGetTokenT<reco::CaloJetCollection>     calodijetToken_;// calojet
-  edm::EDGetTokenT<reco::GsfElectronCollection> eleToken_;
-  edm::EDGetTokenT<reco::MuonCollection>        muoToken_;
-  //edm::InputTag        jetSrc_; // test for Jet
   edm::EDGetTokenT<reco::PFJetCollection>  dijetSrc_; // test for Jet
 
-  std::vector<double> dijetpT_variable_binning_;
   MEbinning           dijetpT_binning;
-  MEbinning           dijetptThr_binning_;
-  MEbinning           ls_binning_;
 
-
-//  DiJetME a_ME[7];
-//  DiJetME a_ME_tag[7];
-//  DiJetME a_ME_prb[7];
    DiJetME jetpt1ME_;
    DiJetME jetpt2ME_;
    DiJetME jetptAvgaME_;
@@ -121,26 +101,14 @@ private:
    DiJetME jetptAsyME_;
    DiJetME jetetaPrbME_;
    DiJetME jetAsyEtaME_;
-// Add !!!!!!!!!!!!! more plot!!!!!!!!!!!
 
   std::unique_ptr<GenericTriggerEventFlag> num_genTriggerEventFlag_;
   std::unique_ptr<GenericTriggerEventFlag> den_genTriggerEventFlag_;
-
-  int nmuons_;
-  double ptcut_;
-  bool isPFDiJetTrig;
-  bool isCaloDiJetTrig;
 
   std::vector<double> v_jetpt;
   std::vector<double> v_jeteta;
   std::vector<double> v_jetphi;
 
-  // Define Phi Bin //
-  double DiJet_MAX_PHI = 3.2;
-  unsigned int DiJet_N_PHI = 64;
-  MEbinning dijet_phi_binning_{
-    DiJet_N_PHI, -DiJet_MAX_PHI, DiJet_MAX_PHI
-  };
   // Define Eta Bin //
   double DiJet_MAX_ETA = 5;
   unsigned int DiJet_N_ETA = 50;

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.h
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.h
@@ -79,13 +79,7 @@ protected:
   void bookME(DQMStore::IBooker &, MonitorElement* me, std::string& histname, std::string& histtitle, int nbinsX, double xmin, double xmax,int nbinsY, double ymin, double ymax );
 
   void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
-  bool isBarrel(double eta);
   bool dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id);
-
-  //void FillME(std::vector<MonitorElement*> v_me,std::vector<double>v_pt, std::vector<double> v_phi); //Fill Histograms 
-  //void AutoNullPtr(DiJetME* a_me,const int len_); //Fill Histograms 
-//  void bookMESub(DQMStore::IBooker &,JetME* a_me,const int len_,std::string h_Name ,std::string h_Title, std::string h_subOptName, std::string h_subOptTitle ); //Fill Histograms 
-  //void FillME(JetME* a_me,double pt_, double phi_, double eta_, int ls_, std::string denu); //Fill Histograms 
 
 private:
   static MEbinning getHistoPSet    (edm::ParameterSet pset);
@@ -99,8 +93,7 @@ private:
   edm::EDGetTokenT<reco::CaloJetCollection>     calodijetToken_;// calojet
   edm::EDGetTokenT<reco::GsfElectronCollection> eleToken_;
   edm::EDGetTokenT<reco::MuonCollection>        muoToken_;
-  //edm::InputTag        jetSrc_; // test for Jet
-  edm::EDGetTokenT<reco::PFJetCollection>  dijetSrc_; // test for Jet
+  edm::EDGetTokenT<reco::PFJetCollection>  dijetSrc_;
 
   std::vector<double> dijetpT_variable_binning_;
   MEbinning           dijetpt_binning_;
@@ -129,8 +122,6 @@ private:
   double ptcut_;
   double etacut_;
   double phicut_;
-  bool isPFDiJetTrig;
-  bool isCaloDiJetTrig;
 
   std::vector<double> v_jetpt;
   std::vector<double> v_jeteta;

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.h
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.h
@@ -69,10 +69,10 @@ private:
   edm::EDGetTokenT<reco::MuonCollection>        muoToken_;
   edm::EDGetTokenT<reco::PFJetCollection>  dijetSrc_; // test for Jet
 
-  std::vector<double> dijetpT_variable_binning_;
+
   MEbinning           dijetpt_binning_;
   MEbinning           dijetptThr_binning_;
-  MEbinning           ls_binning_;
+
 
   ObjME jetpt1ME_;
   ObjME jetpt2ME_;
@@ -93,8 +93,7 @@ private:
 
   int nmuons_;
   double ptcut_;
-  double etacut_;
-  double phicut_;
+
 
   std::vector<double> v_jetpt;
   std::vector<double> v_jeteta;

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.h
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.h
@@ -50,7 +50,7 @@ class DiJetMonitor : public DQMEDAnalyzer  ,  public TriggerDQMBase
 {
 public:
   DiJetMonitor( const edm::ParameterSet& );
-  ~DiJetMonitor() throw() override;
+  ~DiJetMonitor() throw() override {};
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 protected:

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.h
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.h
@@ -1,5 +1,5 @@
-#ifndef JETMETMONITOR_H
-#define JETMETMONITOR_H
+#ifndef DIJETMETMONITOR_H
+#define DIJETMETMONITOR_H
 
 #include <string>
 #include <vector>
@@ -57,7 +57,7 @@ protected:
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
-  bool dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id);
+  bool dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id, int Event);
 
 private:
 
@@ -94,31 +94,26 @@ private:
   int nmuons_;
   double ptcut_;
 
-
-  std::vector<double> v_jetpt;
-  std::vector<double> v_jeteta;
-  std::vector<double> v_jetphi;
-
   // Define Phi Bin //
-  double DiJet_MAX_PHI = 3.2;
+  const double DiJet_MAX_PHI = 3.2;
   unsigned int DiJet_N_PHI = 64;
-  MEbinning dijet_phi_binning_{
+  MEbinning dijet_phi_binning{
     DiJet_N_PHI, -DiJet_MAX_PHI, DiJet_MAX_PHI
   };
   // Define Eta Bin //
-  double DiJet_MAX_ETA = 5;
+  const double DiJet_MAX_ETA = 5;
   unsigned int DiJet_N_ETA = 50;
-  MEbinning dijet_eta_binning_{
+  MEbinning dijet_eta_binning{
     DiJet_N_ETA, -DiJet_MAX_ETA, DiJet_MAX_ETA
   };
 
-  double MAX_asy = 1;
-  double MIN_asy = -1;
+  const double MAX_asy = 1;
+  const double MIN_asy = -1;
   unsigned int N_asy = 100;
-  MEbinning asy_binning_{
+  MEbinning asy_binning{
     N_asy, MIN_asy, MAX_asy
   };
 
 };
 
-#endif // JETMETMONITOR_H
+#endif // DIJETMETMONITOR_H

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.h
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.h
@@ -50,7 +50,7 @@ class DiJetMonitor : public DQMEDAnalyzer  ,  public TriggerDQMBase
 {
 public:
   DiJetMonitor( const edm::ParameterSet& );
-  virtual ~DiJetMonitor() noexcept(true) {};
+  ~DiJetMonitor() throw() {};
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 protected:

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.h
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.h
@@ -50,7 +50,7 @@ class DiJetMonitor : public DQMEDAnalyzer  ,  public TriggerDQMBase
 {
 public:
   DiJetMonitor( const edm::ParameterSet& );
-  ~DiJetMonitor() throw() {};
+  ~DiJetMonitor() throw() override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 protected:

--- a/DQMOffline/Trigger/python/DQMOffline_HLT_Client_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_HLT_Client_cff.py
@@ -25,9 +25,12 @@ from DQMOffline.Trigger.B2GMonitoring_Client_cff import *
 from DQMOffline.Trigger.HiggsMonitoring_Client_cff import *
 from DQMOffline.Trigger.StandardModelMonitoring_Client_cff import *
 from DQMOffline.Trigger.TopMonitoring_Client_cff import *
+
 from DQMOffline.Trigger.BTaggingMonitoring_Client_cff import *
 from DQMOffline.Trigger.BPHMonitoring_Client_cff import *
 from DQMOffline.Trigger.JetMETPromptMonitoring_Client_cff import *
+from DQMOffline.Trigger.DiJetMonitor_Client_cff import *
+
 hltOfflineDQMClient = cms.Sequence(
 #    hltGeneralSeqClient *
     sipixelHarvesterHLTsequence *
@@ -49,6 +52,7 @@ hltOfflineDQMClient = cms.Sequence(
     topClient *
     btaggingClient *
     bphClient*
-    JetMetPromClient
+    JetMetPromClient *
+    dijetClient
     )
 

--- a/DQMOffline/Trigger/python/DiJetMonitor_Client_cff.py
+++ b/DQMOffline/Trigger/python/DiJetMonitor_Client_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+dijetEfficiency = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/JetMET/*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_dijetptAvgThr       'Jet Pt turnON;            DiJet_Pt_Avg [GeV]; efficiency'     jetptAvgAThr_numerator    jetptAvgAThr_denominator",
+        "effic_dijetphiPrb         'Jet efficiency vs #phi_probe; DiJet_Phi_probe #phi [rad]; efficiency'     jetphiPrb_numerator       jetphiPrb_denominator",
+        "effic_dijetetaPrb         'Jet efficiency vs #eta_probe; DiJet_Eta_probe #eta; efficiency'           jetetaPrb_numerator       jetetaPrb_denominator",
+        "effic_dijetetaTag         'Jet efficiency vs #eta_tag; DiJet_Eta_tag #eta; efficiency'           jetetaTag_numerator       jetetaTag_denominator"
+    )
+  
+)
+
+dijetClient = cms.Sequence(
+    dijetEfficiency
+)

--- a/DQMOffline/Trigger/python/DiJetMonitor_Client_cff.py
+++ b/DQMOffline/Trigger/python/DiJetMonitor_Client_cff.py
@@ -8,8 +8,7 @@ dijetEfficiency = DQMEDHarvester("DQMGenericClient",
     efficiency     = cms.vstring(
         "effic_dijetptAvgThr       'Jet Pt turnON;            DiJet_Pt_Avg [GeV]; efficiency'     jetptAvgAThr_numerator    jetptAvgAThr_denominator",
         "effic_dijetphiPrb         'Jet efficiency vs #phi_probe; DiJet_Phi_probe #phi [rad]; efficiency'     jetphiPrb_numerator       jetphiPrb_denominator",
-        "effic_dijetetaPrb         'Jet efficiency vs #eta_probe; DiJet_Eta_probe #eta; efficiency'           jetetaPrb_numerator       jetetaPrb_denominator",
-        "effic_dijetetaTag         'Jet efficiency vs #eta_tag; DiJet_Eta_tag #eta; efficiency'           jetetaTag_numerator       jetetaTag_denominator"
+        "effic_dijetetaPrb         'Jet efficiency vs #eta_probe; DiJet_Eta_probe #eta; efficiency'           jetetaPrb_numerator       jetetaPrb_denominator"
     )
   
 )

--- a/DQMOffline/Trigger/python/DiJetMonitor_cff.py
+++ b/DQMOffline/Trigger/python/DiJetMonitor_cff.py
@@ -5,72 +5,142 @@ from DQMOffline.Trigger.DiJetMonitor_cfi import DiPFjetAve40_Prommonitoring
 # DiPFjetAve60
 DiPFjetAve60_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
 DiPFjetAve60_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve60/')
+DiPFjetAve60_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  75 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  150.),
+)
 DiPFjetAve60_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve60_v*")
 
 # DiPFjetAve80
 DiPFjetAve80_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
 DiPFjetAve80_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve80/')
+DiPFjetAve80_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  100 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  200.),
+)
 DiPFjetAve80_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve80_v*")
 
 # DiPFjetAve140
 DiPFjetAve140_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
 DiPFjetAve140_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve140/')
+DiPFjetAve140_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  70 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  350.),
+)
 DiPFjetAve140_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve140_v*")
 
 # DiPFjetAve200
 DiPFjetAve200_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
 DiPFjetAve200_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve200/')
+DiPFjetAve200_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  50 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  500.),
+)
 DiPFjetAve200_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve200_v*")
 
 # DiPFjetAve260
 DiPFjetAve260_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
 DiPFjetAve260_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve260/')
+DiPFjetAve260_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  65 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  650.),
+)
 DiPFjetAve260_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve260_v*")
 
 # DiPFjetAve320
 DiPFjetAve320_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
 DiPFjetAve320_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve320/')
+DiPFjetAve320_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  80 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  800.),
+)
 DiPFjetAve320_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve320_v*")
 
 # DiPFjetAve400
 DiPFjetAve400_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
 DiPFjetAve400_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve400/')
+DiPFjetAve400_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  100 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  1000.),
+)
 DiPFjetAve400_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve400_v*")
 
 # DiPFjetAve500
 DiPFjetAve500_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
 DiPFjetAve500_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve500/')
+DiPFjetAve500_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  125),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(1250),
+)
 DiPFjetAve500_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve500_v*")
 
 # HLT_DiPFJetAve60_HFJEC
-DiPFJetAve60_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFJetAve60_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve60_HFJEC/')
-DiPFJetAve60_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve60_HFJEC_v*")
+DiPFjetAve60_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve60_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve60_HFJEC/')
+DiPFjetAve60_HFJEC_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  75 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  150.),
+)
+DiPFjetAve60_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve60_HFJEC_v*")
 
 # HLT_DiPFJetAve80_HFJEC
-DiPFJetAve80_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFJetAve80_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve80_HFJEC/')
-DiPFJetAve80_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve80_HFJEC_v*")
+DiPFjetAve80_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve80_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve80_HFJEC/')
+DiPFjetAve80_HFJEC_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  100 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  200.),
+)
+DiPFjetAve80_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve80_HFJEC_v*")
 
 # HLT_DiPFJetAve100_HFJEC
-DiPFJetAve100_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFJetAve100_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve100_HFJEC/')
-DiPFJetAve100_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve100_HFJEC_v*")
+DiPFjetAve100_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve100_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve100_HFJEC/')
+DiPFjetAve100_HFJEC_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  50 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  250.),
+)
+DiPFjetAve100_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve100_HFJEC_v*")
 
 # HLT_DiPFJetAve160_HFJEC
-DiPFJetAve160_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFJetAve160_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve160_HFJEC/')
-DiPFJetAve160_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve160_HFJEC_v*")
+DiPFjetAve160_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve160_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve160_HFJEC/')
+DiPFjetAve160_HFJEC_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  80 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  400.),
+)
+DiPFjetAve160_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve160_HFJEC_v*")
 
 # HLT_DiPFJetAve220_HFJEC
-DiPFJetAve220_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFJetAve220_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve220_HFJEC/')
-DiPFJetAve220_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve220_HFJEC_v*")
+DiPFjetAve220_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve220_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve220_HFJEC/')
+DiPFjetAve220_HFJEC_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  55 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  550.),
+)
+DiPFjetAve220_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve220_HFJEC_v*")
 
 # HLT_DiPFJetAve300_HFJEC
-DiPFJetAve300_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFJetAve300_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve300_HFJEC/')
-DiPFJetAve300_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve300_HFJEC_v*")
+DiPFjetAve300_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve300_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve300_HFJEC/')
+DiPFjetAve300_HFJEC_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  75 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  750.),
+)
+DiPFjetAve300_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve300_HFJEC_v*")
 
 HLTDiJetmonitoring = cms.Sequence(
     DiPFjetAve40_Prommonitoring
@@ -82,11 +152,11 @@ HLTDiJetmonitoring = cms.Sequence(
     *DiPFjetAve320_Prommonitoring
     *DiPFjetAve400_Prommonitoring
     *DiPFjetAve500_Prommonitoring
-    *DiPFJetAve60_HFJEC_Prommonitoring
-    *DiPFJetAve80_HFJEC_Prommonitoring
-    *DiPFJetAve100_HFJEC_Prommonitoring
-    *DiPFJetAve160_HFJEC_Prommonitoring
-    *DiPFJetAve220_HFJEC_Prommonitoring
-    *DiPFJetAve300_HFJEC_Prommonitoring
+    *DiPFjetAve60_HFJEC_Prommonitoring
+    *DiPFjetAve80_HFJEC_Prommonitoring
+    *DiPFjetAve100_HFJEC_Prommonitoring
+    *DiPFjetAve160_HFJEC_Prommonitoring
+    *DiPFjetAve220_HFJEC_Prommonitoring
+    *DiPFjetAve300_HFJEC_Prommonitoring
 )
 

--- a/DQMOffline/Trigger/python/DiJetMonitor_cff.py
+++ b/DQMOffline/Trigger/python/DiJetMonitor_cff.py
@@ -6,21 +6,11 @@ from DQMOffline.Trigger.DiJetMonitor_cfi import DiPFjetAve40_Prommonitoring
 DiPFjetAve60_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
 DiPFjetAve60_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve60/')
 DiPFjetAve60_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve60_v*")
-#DiPFjetAve60_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
-#  nbins = cms.uint32 (  60),
-#  xmin  = cms.double(   0.),
-#  xmax  = cms.double(1000),
-#)
 
 # DiPFjetAve80
 DiPFjetAve80_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
 DiPFjetAve80_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve80/')
 DiPFjetAve80_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve80_v*")
-#DiPFjetAve80_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
-#  nbins = cms.uint32 (  80),
-#  xmin  = cms.double(   0.),
-#  xmax  = cms.double(1000),
-#)
 
 # DiPFjetAve140
 DiPFjetAve140_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
@@ -81,22 +71,6 @@ DiPFJetAve220_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vst
 DiPFJetAve300_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
 DiPFJetAve300_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve300_HFJEC/')
 DiPFJetAve300_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve300_HFJEC_v*")
-#HLT_DiPFJetAve40
-#HLT_DiPFJetAve60
-#HLT_DiPFJetAve80
-#HLT_DiPFJetAve140
-#HLT_DiPFJetAve200
-#HLT_DiPFJetAve260
-#HLT_DiPFJetAve320
-#HLT_DiPFJetAve400
-#HLT_DiPFJetAve500
-#HLT_DiPFJetAve60_HFJEC
-#HLT_DiPFJetAve80_HFJEC
-#HLT_DiPFJetAve100_HFJEC
-#HLT_DiPFJetAve160_HFJEC
-#HLT_DiPFJetAve220_HFJEC
-#HLT_DiPFJetAve300_HFJEC
-
 
 HLTDiJetmonitoring = cms.Sequence(
     DiPFjetAve40_Prommonitoring

--- a/DQMOffline/Trigger/python/DiJetMonitor_cff.py
+++ b/DQMOffline/Trigger/python/DiJetMonitor_cff.py
@@ -1,0 +1,118 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.DiJetMonitor_cfi import DiPFjetAve40_Prommonitoring
+### HLT_DiJet Triggers ###
+# DiPFjetAve60
+DiPFjetAve60_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve60_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve60/')
+DiPFjetAve60_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve60_v*")
+#DiPFjetAve60_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+#  nbins = cms.uint32 (  60),
+#  xmin  = cms.double(   0.),
+#  xmax  = cms.double(1000),
+#)
+
+# DiPFjetAve80
+DiPFjetAve80_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve80_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve80/')
+DiPFjetAve80_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve80_v*")
+#DiPFjetAve80_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+#  nbins = cms.uint32 (  80),
+#  xmin  = cms.double(   0.),
+#  xmax  = cms.double(1000),
+#)
+
+# DiPFjetAve140
+DiPFjetAve140_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve140_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve140/')
+DiPFjetAve140_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve140_v*")
+
+# DiPFjetAve200
+DiPFjetAve200_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve200_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve200/')
+DiPFjetAve200_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve200_v*")
+
+# DiPFjetAve260
+DiPFjetAve260_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve260_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve260/')
+DiPFjetAve260_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve260_v*")
+
+# DiPFjetAve320
+DiPFjetAve320_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve320_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve320/')
+DiPFjetAve320_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve320_v*")
+
+# DiPFjetAve400
+DiPFjetAve400_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve400_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve400/')
+DiPFjetAve400_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve400_v*")
+
+# DiPFjetAve500
+DiPFjetAve500_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve500_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve500/')
+DiPFjetAve500_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve500_v*")
+
+# HLT_DiPFJetAve60_HFJEC
+DiPFJetAve60_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFJetAve60_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve60_HFJEC/')
+DiPFJetAve60_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve60_HFJEC_v*")
+
+# HLT_DiPFJetAve80_HFJEC
+DiPFJetAve80_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFJetAve80_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve80_HFJEC/')
+DiPFJetAve80_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve80_HFJEC_v*")
+
+# HLT_DiPFJetAve100_HFJEC
+DiPFJetAve100_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFJetAve100_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve100_HFJEC/')
+DiPFJetAve100_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve100_HFJEC_v*")
+
+# HLT_DiPFJetAve160_HFJEC
+DiPFJetAve160_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFJetAve160_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve160_HFJEC/')
+DiPFJetAve160_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve160_HFJEC_v*")
+
+# HLT_DiPFJetAve220_HFJEC
+DiPFJetAve220_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFJetAve220_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve220_HFJEC/')
+DiPFJetAve220_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve220_HFJEC_v*")
+
+# HLT_DiPFJetAve300_HFJEC
+DiPFJetAve300_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFJetAve300_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve300_HFJEC/')
+DiPFJetAve300_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve300_HFJEC_v*")
+#HLT_DiPFJetAve40
+#HLT_DiPFJetAve60
+#HLT_DiPFJetAve80
+#HLT_DiPFJetAve140
+#HLT_DiPFJetAve200
+#HLT_DiPFJetAve260
+#HLT_DiPFJetAve320
+#HLT_DiPFJetAve400
+#HLT_DiPFJetAve500
+#HLT_DiPFJetAve60_HFJEC
+#HLT_DiPFJetAve80_HFJEC
+#HLT_DiPFJetAve100_HFJEC
+#HLT_DiPFJetAve160_HFJEC
+#HLT_DiPFJetAve220_HFJEC
+#HLT_DiPFJetAve300_HFJEC
+
+
+HLTDiJetmonitoring = cms.Sequence(
+    DiPFjetAve40_Prommonitoring
+    *DiPFjetAve60_Prommonitoring
+    *DiPFjetAve80_Prommonitoring
+    *DiPFjetAve140_Prommonitoring
+    *DiPFjetAve200_Prommonitoring
+    *DiPFjetAve260_Prommonitoring
+    *DiPFjetAve320_Prommonitoring
+    *DiPFjetAve400_Prommonitoring
+    *DiPFjetAve500_Prommonitoring
+    *DiPFJetAve60_HFJEC_Prommonitoring
+    *DiPFJetAve80_HFJEC_Prommonitoring
+    *DiPFJetAve100_HFJEC_Prommonitoring
+    *DiPFJetAve160_HFJEC_Prommonitoring
+    *DiPFJetAve220_HFJEC_Prommonitoring
+    *DiPFJetAve300_HFJEC_Prommonitoring
+)
+

--- a/DQMOffline/Trigger/python/DiJetMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/DiJetMonitor_cfi.py
@@ -8,19 +8,7 @@ DiPFjetAve40_Prommonitoring.histoPSet.dijetPSet = cms.PSet(
   xmin  = cms.double(   0),
   xmax  = cms.double(1000.),
 )
-DiPFjetAve40_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  200 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(1000.),
-)
-DiPFjetAve40_Prommonitoring.met       = cms.InputTag("pfMetEI") # pfMet
-#DiPFjetAve40_Prommonitoring.pfjets    = cms.InputTag("ak4PFJets") # ak4PFJets, ak4PFJetsCHS
 DiPFjetAve40_Prommonitoring.dijetSrc  = cms.InputTag("ak4PFJets") # ak4PFJets, ak4PFJetsCHS
-DiPFjetAve40_Prommonitoring.electrons = cms.InputTag("gedGsfElectrons") # while pfIsolatedElectronsEI are reco::PFCandidate !
-DiPFjetAve40_Prommonitoring.muons     = cms.InputTag("muons") # while pfIsolatedMuonsEI are reco::PFCandidate !
-DiPFjetAve40_Prommonitoring.ptcut     = cms.double(20) # while pfIsolatedMuonsEI are reco::PFCandidate !
-DiPFjetAve40_Prommonitoring.ispfdijettrg = cms.bool(True) # is PFJet Trigge  ?
-DiPFjetAve40_Prommonitoring.iscalodijettrg = cms.bool(False) # is CaloJet Trigge  ?
 
 DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
 DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.dbLabel       = cms.string("JetMETDQMTrigger") # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !

--- a/DQMOffline/Trigger/python/DiJetMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/DiJetMonitor_cfi.py
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.dijetMonitoring_cfi import dijetMonitoring
+DiPFjetAve40_Prommonitoring = dijetMonitoring.clone()
+DiPFjetAve40_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve40/')
+DiPFjetAve40_Prommonitoring.histoPSet.dijetPSet = cms.PSet(
+  nbins = cms.uint32 (  200  ),
+  xmin  = cms.double(   0),
+  xmax  = cms.double(1000.),
+)
+DiPFjetAve40_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  200 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(1000.),
+)
+DiPFjetAve40_Prommonitoring.met       = cms.InputTag("pfMetEI") # pfMet
+#DiPFjetAve40_Prommonitoring.pfjets    = cms.InputTag("ak4PFJets") # ak4PFJets, ak4PFJetsCHS
+DiPFjetAve40_Prommonitoring.dijetSrc  = cms.InputTag("ak4PFJets") # ak4PFJets, ak4PFJetsCHS
+DiPFjetAve40_Prommonitoring.electrons = cms.InputTag("gedGsfElectrons") # while pfIsolatedElectronsEI are reco::PFCandidate !
+DiPFjetAve40_Prommonitoring.muons     = cms.InputTag("muons") # while pfIsolatedMuonsEI are reco::PFCandidate !
+DiPFjetAve40_Prommonitoring.ptcut     = cms.double(20) # while pfIsolatedMuonsEI are reco::PFCandidate !
+DiPFjetAve40_Prommonitoring.ispfdijettrg = cms.bool(True) # is PFJet Trigge  ?
+DiPFjetAve40_Prommonitoring.iscalodijettrg = cms.bool(False) # is CaloJet Trigge  ?
+
+DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
+DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.dbLabel       = cms.string("JetMETDQMTrigger") # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
+DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
+DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
+DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_DiPFJetAve40_v*") # HLT_ZeroBias_v*
+DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
+DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
+
+DiPFjetAve40_Prommonitoring.denGenericTriggerEventPSet.andOr         = cms.bool( False )
+DiPFjetAve40_Prommonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
+DiPFjetAve40_Prommonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29: pixel, we should add all other detectors !
+DiPFjetAve40_Prommonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
+DiPFjetAve40_Prommonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
+DiPFjetAve40_Prommonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
+

--- a/DQMOffline/Trigger/python/DiJetMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/DiJetMonitor_cfi.py
@@ -19,8 +19,6 @@ DiPFjetAve40_Prommonitoring.dijetSrc  = cms.InputTag("ak4PFJets") # ak4PFJets, a
 DiPFjetAve40_Prommonitoring.electrons = cms.InputTag("gedGsfElectrons") # while pfIsolatedElectronsEI are reco::PFCandidate !
 DiPFjetAve40_Prommonitoring.muons     = cms.InputTag("muons") # while pfIsolatedMuonsEI are reco::PFCandidate !
 DiPFjetAve40_Prommonitoring.ptcut     = cms.double(20) # while pfIsolatedMuonsEI are reco::PFCandidate !
-DiPFjetAve40_Prommonitoring.etacut     = cms.double(1.7) # Using dijet offline selection
-DiPFjetAve40_Prommonitoring.delphicut  = cms.double(2.7) # Using dijet offline selection
 
 DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
 DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.dbLabel       = cms.string("JetMETDQMTrigger") # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !

--- a/DQMOffline/Trigger/python/DiJetMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/DiJetMonitor_cfi.py
@@ -8,7 +8,19 @@ DiPFjetAve40_Prommonitoring.histoPSet.dijetPSet = cms.PSet(
   xmin  = cms.double(   0),
   xmax  = cms.double(1000.),
 )
+DiPFjetAve40_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  50 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(100.),
+)
+DiPFjetAve40_Prommonitoring.met       = cms.InputTag("pfMetEI") # pfMet
+#DiPFjetAve40_Prommonitoring.pfjets    = cms.InputTag("ak4PFJets") # ak4PFJets, ak4PFJetsCHS
 DiPFjetAve40_Prommonitoring.dijetSrc  = cms.InputTag("ak4PFJets") # ak4PFJets, ak4PFJetsCHS
+DiPFjetAve40_Prommonitoring.electrons = cms.InputTag("gedGsfElectrons") # while pfIsolatedElectronsEI are reco::PFCandidate !
+DiPFjetAve40_Prommonitoring.muons     = cms.InputTag("muons") # while pfIsolatedMuonsEI are reco::PFCandidate !
+DiPFjetAve40_Prommonitoring.ptcut     = cms.double(20) # while pfIsolatedMuonsEI are reco::PFCandidate !
+DiPFjetAve40_Prommonitoring.etacut     = cms.double(1.7) # Using dijet offline selection
+DiPFjetAve40_Prommonitoring.delphicut  = cms.double(2.7) # Using dijet offline selection
 
 DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
 DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.dbLabel       = cms.string("JetMETDQMTrigger") # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !

--- a/DQMOffline/Trigger/python/JetMETPromptMonitor_cff.py
+++ b/DQMOffline/Trigger/python/JetMETPromptMonitor_cff.py
@@ -1,7 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.JetMonitor_cff import *
+from DQMOffline.Trigger.DiJetMonitor_cff import *
 
 jetmetMonitorHLT = cms.Sequence(
     HLTJetmonitoring
+    *HLTDiJetmonitoring
 )


### PR DESCRIPTION
///Trigger Paths///
HLT_DiPFJetAve40
HLT_DiPFJetAve60
HLT_DiPFJetAve80
HLT_DiPFJetAve140
HLT_DiPFJetAve200
HLT_DiPFJetAve260
HLT_DiPFJetAve320
HLT_DiPFJetAve400
HLT_DiPFJetAve500
HLT_DiPFJetAve60_HFJEC
HLT_DiPFJetAve80_HFJEC
HLT_DiPFJetAve100_HFJEC
HLT_DiPFJetAve160_HFJEC
HLT_DiPFJetAve220_HFJEC
HLT_DiPFJetAve300_HFJEC

///Histograms///
pt_1 : pt of leading jet passed trigger and w/o offline selection
pt_2 : pt of second leading jet passed trigger and w/o offline selection
pt_avg_b : using (pt_1 + pt_2) * 0.5 , pt average before offline selection
pt_tag : tag jet passed trigger and offline selection satisfied with fabs(eta) < 1.3 
pt_prb : probe jet passed trigger and offline selection, satisfied with fabs(eta) > 1.3 among pt_1 and pt_2
(If both pt_1 and pt_2 are satisfied with fabs(eta) < 1.3, tag and probe are randomly selected.)
pt_asym : using (pt_prb - pt_tag)/(pt_tag + pt_prb), asymmetry of pt_tag and pt_prb
pt_avg_a : using (pt_tab + pt_prb) * 0.5 , pt average after offline selection
eta_prb : eta of probe jet
pt_Asym_VS_eta_prb : 2D historgram of pt_asym and eta_prb

Anastasia asked.
