### PR TITLE
Move layer1SecondStageLUT to uint vector

### DIFF
--- a/L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h
+++ b/L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h
@@ -437,8 +437,8 @@ namespace l1t {
     void setLayer1HCalScalePhiBins(const std::vector<unsigned> params) { pnode_[layer1HCal].uparams_ = params; }
     void setLayer1HFScalePhiBins(const std::vector<unsigned> params)   { pnode_[layer1HF  ].uparams_ = params; }
 
-    l1t::LUT* layer1HOverELUT() { return &pnode_[layer1HOverE].LUT_; }
-    void setLayer1HOverELUT(const l1t::LUT & lut) { pnode_[layer1HOverE].LUT_ = lut; }
+    std::vector<unsigned> layer1SecondStageLUT() { return pnode_[layer1HOverE].uparams_; }
+    void setLayer1SecondStageLUT(const std::vector<unsigned>& lut) { pnode_[layer1HOverE].uparams_ = lut; }
 
 
   private:

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsESProducer.cc
@@ -337,10 +337,9 @@ L1TCaloParamsESProducer::L1TCaloParamsESProducer(const edm::ParameterSet& conf)
   m_params_helper.setLayer1HCalScalePhiBins(conf.getParameter<std::vector<unsigned>>("layer1HCalScalePhiBins"));
   m_params_helper.setLayer1HFScalePhiBins  (conf.getParameter<std::vector<unsigned>>("layer1HFScalePhiBins"));
 
-  edm::FileInPath layer1HOverELUTFile = conf.getParameter<edm::FileInPath>("layer1HOverELUTFile");
-  std::ifstream layer1HOverELUTStream(layer1HOverELUTFile.fullPath());
-  std::shared_ptr<LUT> layer1HOverELUT( new LUT(layer1HOverELUTStream) );
-  m_params_helper.setLayer1HOverELUT(*layer1HOverELUT);
+  if (conf.existsAs<std::vector<unsigned>>("layer1SecondStageLUT")) {
+    m_params_helper.setLayer1SecondStageLUT(conf.getParameter<std::vector<unsigned>>("layer1SecondStageLUT"));
+  }
    
   m_params = (CaloParams)m_params_helper;
 

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloStage2ParamsESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloStage2ParamsESProducer.cc
@@ -343,6 +343,10 @@ L1TCaloStage2ParamsESProducer::L1TCaloStage2ParamsESProducer(const edm::Paramete
   m_params_helper.setLayer1HCalScalePhiBins(conf.exists("layer1HCalScalePhiBins") ? conf.getParameter<std::vector<unsigned>>("layer1HCalScalePhiBins") : std::vector<unsigned>(36,0));
   m_params_helper.setLayer1HFScalePhiBins  (conf.exists("layer1HFScalePhiBins") ? conf.getParameter<std::vector<unsigned>>("layer1HFScalePhiBins") : std::vector<unsigned>(36,0));
 
+  if (conf.existsAs<std::vector<unsigned>>("layer1SecondStageLUT")) {
+    m_params_helper.setLayer1SecondStageLUT(conf.getParameter<std::vector<unsigned>>("layer1SecondStageLUT"));
+  }
+
   m_params = (CaloParams)m_params_helper;
 }
 

--- a/L1TriggerConfig/L1TConfigProducers/src/CaloParamsHelperO2O.h
+++ b/L1TriggerConfig/L1TConfigProducers/src/CaloParamsHelperO2O.h
@@ -453,8 +453,8 @@ namespace l1t {
     void setLayer1HCalScalePhiBins(const std::vector<unsigned> params) { pnode_[layer1HCal].uparams_ = params; }
     void setLayer1HFScalePhiBins(const std::vector<unsigned> params)   { pnode_[layer1HF  ].uparams_ = params; }
 
-    l1t::LUT* layer1HOverELUT() { return &pnode_[layer1HOverE].LUT_; }
-    void setLayer1HOverELUT(const l1t::LUT & lut) { pnode_[layer1HOverE].LUT_ = lut; }
+    std::vector<unsigned> layer1SecondStageLUT() { return pnode_[layer1HOverE].uparams_; }
+    void setLayer1SecondStageLUT(const std::vector<unsigned>& lut) { pnode_[layer1HOverE].uparams_ = lut; }
 
 
   private:

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
@@ -69,7 +69,7 @@ std::map<std::string, l1t::Mask>& ) {
   if( conf.find("layer1HFScalePhiBins") != conf.end() )
       paramsHelper.setLayer1HFScalePhiBins  (conf["layer1HFScalePhiBins"]  .getVector<unsigned int>());
   if( conf.find("layer1SecondStageLUT") != conf.end() )
-      paramsHelper.setLayer1HOverELUT( l1t::convertToLUT( conf["layer1SecondStageLUT"]  .getVector<unsigned int>()) );
+      paramsHelper.setLayer1SecondStageLUT(conf["layer1SecondStageLUT"].getVector<unsigned int>() );
 
   return true;
 }


### PR DESCRIPTION
l1t::LUT does not support 32-bit wide data!
Cannot change l1t::LUT since it has already been persisted in the DB.

At present, the CaloLayer1 emulator has no knowledge of this parameter, so it is unaffected.

@kkotov no backport needed since P5 install is custom, right?