### PR TITLE
B-tag validation/offline DQM: fix efficiency plots on data & eta ranges

### DIFF
--- a/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.cc
+++ b/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.cc
@@ -29,9 +29,9 @@ BTagPerformanceAnalyzerOnData::BTagPerformanceAnalyzerOnData(const edm::Paramete
   jecMCToken = mayConsume<JetCorrector>(pSet.getParameter<edm::InputTag>( "JECsourceMC" ));
   jecDataToken = consumes<JetCorrector>(pSet.getParameter<edm::InputTag>( "JECsourceData" ));
   
-  if (etaRanges.size() == 0)
+  if (etaRanges.size() <= 1)
       etaRanges = { pSet.getParameter<double>("etaMin"), pSet.getParameter<double>("etaMax") };
-  if (ptRanges.size() == 0)
+  if (ptRanges.size() <= 1)
       ptRanges = { pSet.getParameter<double>("ptRecJetMin"), pSet.getParameter<double>("ptRecJetMax") };
   
   for (vector<edm::ParameterSet>::const_iterator iModule = moduleConfig.begin();
@@ -82,9 +82,9 @@ void BTagPerformanceAnalyzerOnData::bookHistograms(DQMStore::IBooker & ibook, ed
 
   // iterate over ranges:
   const int iEtaStart = -1                   ;  // this will be the inactive one
-  const int iEtaEnd   = etaRanges.size() - 1 ;
+  const int iEtaEnd   = etaRanges.size() > 2 ? etaRanges.size() - 1 : 0; // if there is only one bin defined, leave it as the inactive one
   const int iPtStart  = -1                   ;  // this will be the inactive one
-  const int iPtEnd    = ptRanges.size() - 1  ;
+  const int iPtEnd    = ptRanges.size() > 2 ? ptRanges.size() - 1 : 0; // if there is only one bin defined, leave it as the inactive one
   setTDRStyle();
 
   TagInfoPlotterFactory theFactory;

--- a/DQMOffline/RecoB/plugins/BTagPerformanceHarvester.cc
+++ b/DQMOffline/RecoB/plugins/BTagPerformanceHarvester.cc
@@ -32,6 +32,11 @@ BTagPerformanceHarvester::BTagPerformanceHarvester(const edm::ParameterSet& pSet
   } else
       mcPlots_ = 0;
 
+  if (etaRanges.size() <= 1)
+      etaRanges = { pSet.getParameter<double>("etaMin"), pSet.getParameter<double>("etaMax") };
+  if (ptRanges.size() <= 1)
+      ptRanges = { pSet.getParameter<double>("ptRecJetMin"), pSet.getParameter<double>("ptRecJetMax") };
+  
   for (vector<edm::ParameterSet>::const_iterator iModule = moduleConfig.begin();
        iModule != moduleConfig.end(); ++iModule) {
     const string& dataFormatType = iModule->exists("type") ?
@@ -96,9 +101,9 @@ void BTagPerformanceHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMStore::IG
 
   // iterate over ranges:
   const int iEtaStart = -1                  ;  // this will be the inactive one
-  const int iEtaEnd   = etaRanges.size() - 1;
+  const int iEtaEnd   = etaRanges.size() > 2 ? etaRanges.size() - 1 : 0; // if there is only one bin defined, leave it as the inactive one
   const int iPtStart  = -1                  ;  // this will be the inactive one
-  const int iPtEnd    = ptRanges.size() - 1 ;
+  const int iPtEnd    = ptRanges.size() > 2 ? ptRanges.size() - 1 : 0; // if there is only one bin defined, leave it as the inactive one
   setTDRStyle();
 
   TagInfoPlotterFactory theFactory;

--- a/DQMOffline/RecoB/python/bTagCommon_cff.py
+++ b/DQMOffline/RecoB/python/bTagCommon_cff.py
@@ -169,7 +169,7 @@ bTagCommonBlock = cms.PSet(
             folder = cms.string("Ctagger_CvsL"),
             doCTagPlots = cms.bool(True),
             differentialPlots = cms.bool(True),
-            discrCut = cms.double(-0.48)
+            discrCut = cms.double(-0.1)
         ),
         cms.PSet(
             cTagGenericAnalysisBlock,
@@ -177,7 +177,7 @@ bTagCommonBlock = cms.PSet(
             folder = cms.string("Ctagger_CvsB"),
             doCTagPlots = cms.bool(True),
             differentialPlots = cms.bool(True),
-            discrCut = cms.double(-0.17)
+            discrCut = cms.double(0.08)
         ),
         cms.PSet(
             cTagCorrelationAnalysisBlock,

--- a/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.cc
+++ b/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.cc
@@ -48,9 +48,9 @@ BTagPerformanceAnalyzerMC::BTagPerformanceAnalyzerMC(const edm::ParameterSet& pS
     default: electronPlots = false; muonPlots = false; tauPlots = false;
   }
 
-  if (etaRanges.size() == 0)
+  if (etaRanges.size() <= 1)
       etaRanges = { pSet.getParameter<double>("etaMin"), pSet.getParameter<double>("etaMax") };
-  if (ptRanges.size() == 0)
+  if (ptRanges.size() <= 1)
       ptRanges = { pSet.getParameter<double>("ptRecJetMin"), pSet.getParameter<double>("ptRecJetMax") };
   
   genToken = mayConsume<GenEventInfoProduct>(edm::InputTag("generator"));
@@ -111,9 +111,10 @@ void BTagPerformanceAnalyzerMC::bookHistograms(DQMStore::IBooker & ibook, edm::R
 
   // iterate over ranges:
   const int iEtaStart = -1                   ;  // this will be the inactive one
-  const int iEtaEnd   = etaRanges.size() - 1 ;
+  const int iEtaEnd   = etaRanges.size() > 2 ? etaRanges.size() - 1 : 0; // if there is only one bin defined, leave it as the inactive one
   const int iPtStart  = -1                   ;  // this will be the inactive one
-  const int iPtEnd    = ptRanges.size() - 1  ;
+  const int iPtEnd    = ptRanges.size() > 2 ? ptRanges.size() - 1 : 0; // if there is only one bin defined, leave it as the inactive one
+
   setTDRStyle();
 
   TagInfoPlotterFactory theFactory;


### PR DESCRIPTION
This fixes something I had forgotten to add in #18518 (see here: https://github.com/cms-btv-pog/cmssw/commit/b0ca7e2a27ddf07e848ab346e040e6bc964590e6#diff-414b5076390e1bdab7b5e40ddfbd0571R241), which resulted in the plots being correctly filled for MC but not for data.

It also fixes an older bug that only became apparent because of #18518: when no eta ranges are declared (as is the case for MC validation), the jet eta histogram range would be from 0 to 0 (here: https://github.com/cms-sw/cmssw/blob/master/DQMOffline/RecoB/src/JetTagPlotter.cc#L66), so the binning would be automatically defined by ROOT. In practice it seemed to always return a histogram filled between -2.5 and 2.5. However, this misbehaved when filling the new histograms, where a cut on the b-jet discriminator is applied: the "automatic" binning range would be more or less random, resulting in flawed comparisons during the software validation.