### PR TITLE
Fixing a BS Issue affecting the Egamma HLT

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/TrackingRegionsFromSuperClustersProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/TrackingRegionsFromSuperClustersProducer.h
@@ -249,28 +249,35 @@ GlobalPoint TrackingRegionsFromSuperClustersProducer::
 getVtxPos(const edm::Event& iEvent,double& deltaZVertex)const
 {
   if(useZInVertex_){
-    auto verticesHandle = getHandle(iEvent,verticesToken_);   
-    deltaZVertex = originHalfLength_;
-    const auto& pv = verticesHandle->front();
-    return GlobalPoint(pv.x(),pv.y(),pv.z());
-  }
-  
-  auto beamSpotHandle = getHandle(iEvent,beamSpotToken_);
-  const reco::BeamSpot::Point& bsPos = beamSpotHandle->position();
-  
-  if(useZInBeamspot_){
-    //as this is what has been done traditionally for e/gamma, others just use sigmaZ
-    const double bsSigmaZ = std::sqrt(beamSpotHandle->sigmaZ()*beamSpotHandle->sigmaZ() + 
-				      beamSpotHandle->sigmaZ0Error()*beamSpotHandle->sigmaZ0Error());
-    const double sigmaZ = std::max(bsSigmaZ,minBSDeltaZ_);
-    deltaZVertex = nrSigmaForBSDeltaZ_*sigmaZ;
-    
-    return GlobalPoint(bsPos.x(),bsPos.y(),bsPos.z());
+    auto verticesHandle = getHandle(iEvent,verticesToken_);
+    //we throw if the vertices are not there but if no vertex is 
+    //recoed in the event, we default to 0,0,defaultZ as the vertex
+    if(!verticesHandle->empty()){ 
+      deltaZVertex = originHalfLength_;
+      const auto& pv = verticesHandle->front();
+      return GlobalPoint(pv.x(),pv.y(),pv.z());
+    }else{
+      deltaZVertex = originHalfLength_;
+      return GlobalPoint(0,0,defaultZ_);
+    }
   }else{
-    deltaZVertex = originHalfLength_;
-    return GlobalPoint(bsPos.x(),bsPos.y(),defaultZ_); 
+
+    auto beamSpotHandle = getHandle(iEvent,beamSpotToken_);
+    const reco::BeamSpot::Point& bsPos = beamSpotHandle->position();
+    
+    if(useZInBeamspot_){
+      //as this is what has been done traditionally for e/gamma, others just use sigmaZ
+      const double bsSigmaZ = std::sqrt(beamSpotHandle->sigmaZ()*beamSpotHandle->sigmaZ() + 
+					beamSpotHandle->sigmaZ0Error()*beamSpotHandle->sigmaZ0Error());
+      const double sigmaZ = std::max(bsSigmaZ,minBSDeltaZ_);
+      deltaZVertex = nrSigmaForBSDeltaZ_*sigmaZ;
+    
+      return GlobalPoint(bsPos.x(),bsPos.y(),bsPos.z());
+    }else{
+      deltaZVertex = originHalfLength_;
+      return GlobalPoint(bsPos.x(),bsPos.y(),defaultZ_); 
+    }
   }
-  
   
 }
 


### PR DESCRIPTION
Dear All,

The online beamspot issues persist and this is impacting data taking efficiency for electrons. As such I have added more flexibility to the E/gamma code to deal with this. We now have various options available to us for tracking regions.

1) use the primary vertex +/- X (existing)
2) use the beamspot z +/-  N*sigmaZ  (the N being configurable is the new part, it was annoyingly hardcoded to 3
3) use X+/-Y , eg 0 +/-20cm (my favoured solution however there are currently timing issues)
4) use the beamspot z+/- N *sigmaZ where sigmaZ has a minimum allowed value, say 5cm

The TSG will decide which one we use, however having the options of all 4 are useful. 

We really need this online as soon as possible as we are losing efficiency in electron triggers in a nasty way which is impossible to detect using t&p. 

This code does not run at reco, it is HLT exclusive so far. It may well run in RECO in the future. 

Validation: 

- run on the DoubleEG dataset of 299480 (about a million events, also includes a triggers which do not use tracking)
   - when used with an existing config, no changes to unprescaled paths are observed which is what I was testing
- run on 100K Z->ee MC events (83X samples) with the online beamspot forced to have a too small deltaZ
   -  the fixes successfully recovered the efficiency 

Will run over data as soon possible but this is more the TSG, the MC tests show the code is functioning as expected. 

Passes the scramv1 b run tests and runTheMatrix.py -l limited -i all

@Martin-Grunewald 





