### PR TITLE
make edmPythonConfigToCppValidation work with everything in Modules.py

### DIFF
--- a/FWCore/ParameterSet/scripts/edmPythonConfigToCppValidation
+++ b/FWCore/ParameterSet/scripts/edmPythonConfigToCppValidation
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-from FWCore.ParameterSet.Modules import _Module
+from FWCore.ParameterSet.Modules import _TypedParameterizable
 from FWCore.ParameterSet.Mixins import _ValidatingParameterListBase
 import FWCore.ParameterSet.Config as cms
 
@@ -243,7 +243,7 @@ for item in config.iterkeys():
     if item.startswith('_'):
         continue
     
-    if isinstance(config[item], _Module):
+    if isinstance(config[item], _TypedParameterizable):
         modules[item] = config[item]
 
 if not modules:


### PR DESCRIPTION
The type check in `edmPythonConfigToCppValidation` is generalized to handle anything that inherits from `_TypedParameterizable`. The tool can now handle any type defined in [Modules.py](https://github.com/cms-sw/cmssw/blob/master/FWCore/ParameterSet/python/Modules.py).

Tested on a `Service` and an `ESSource`:
```
edmPythonConfigToCppValidation $CMSSW_RELEASE_BASE/src/DQMServices/Components/python/DQMFastTimerServiceClient_cfi.py
edmPythonConfigToCppValidation $CMSSW_RELEASE_BASE/src/CalibCalorimetry/HcalPlugins/python/HBHEDarkening_cff.py
```

Fulfills issue #18425.