### PR TITLE
Add getSkimDataTier method to Skims_cff

### DIFF
--- a/Configuration/StandardSequences/python/Skims_cff.py
+++ b/Configuration/StandardSequences/python/Skims_cff.py
@@ -23,6 +23,16 @@ def documentSkims():
     print 'possible cmsDriver options for skimming:'
     print 'SKIM:'+'+'.join(listOfOptions)
 
+def getSkimDataTier(skimname):
+    import Configuration.StandardSequences.Skims_cff as Skims
+
+    for skim in Skims.__dict__:
+        skimstream = getattr(Skims,skim)
+        if (not isinstance(skimstream,cms.FilteredStream)): continue
+
+        if skimname == skimstream['name']:
+            return skimstream['dataTier']
+    return None
 
 ### DPG skims ###
 from DPGAnalysis.Skims.Skims_DPG_cff import *


### PR DESCRIPTION
As requested by Dirk for T0 development, adding a method at Skims_cff to obtain the mapping between skim name and the corresponding data tier.