### PR TITLE
Fix MultiTrackValidator histograms vs. radius

### DIFF
--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -939,7 +939,7 @@ void MTVHistoProducerAlgoForTracker::fill_recoAssociated_simTrack_histos(int cou
   const auto nSim3DLayers = nSimPixelLayers + nSimStripMonoAndStereoLayers;
 
   const auto vertexTPwrtBS = vertexTP - bsPosition;
-  const auto vertxy = vertexTPwrtBS.r();
+  const auto vertxy = std::sqrt(vertexTPwrtBS.perp2());
   const auto vertz = vertexTPwrtBS.z();
 
   //efficiency vs. cut on MVA
@@ -1111,7 +1111,7 @@ void MTVHistoProducerAlgoForTracker::fill_generic_recoTrack_histos(int count,
   const auto nPixelLayers = track.hitPattern().pixelLayersWithMeasurement();
   const auto n3DLayers = nPixelLayers + track.hitPattern().numberOfValidStripLayersWithMonoAndStereo();
   const auto refPointWrtBS = track.referencePoint() - bsPosition;
-  const auto vertxy = refPointWrtBS.r();
+  const auto vertxy = std::sqrt(refPointWrtBS.perp2());
   const auto vertz = refPointWrtBS.z();
   const auto deltar = min(max(dR,h_recodr[count]->getTH1()->GetXaxis()->GetXmin()),h_recodr[count]->getTH1()->GetXaxis()->GetXmax());
   const auto chi2 = track.normalizedChi2();


### PR DESCRIPTION
This PR fixes a bug introduced in #19582, where the histograms vs. (transverse) radius were accidentally changed to the 3D radius instead of intended transverse 2D radius.

Tested in 9_3_0_pre2, expecting changes in MTV plots vs. radius.

@rovere @VinInn 