### PR TITLE
gcc7 compilation warning(s) fix(es) in CondFormats/Calibration

### DIFF
--- a/CondFormats/Calibration/interface/BlobComplex.h
+++ b/CondFormats/Calibration/interface/BlobComplex.h
@@ -7,7 +7,11 @@
 #include <utility>
 
 struct BlobComplexData {
-  BlobComplexData() {}
+  BlobComplexData(){
+    a = 0;
+    b = 0;
+  }
+
 
   void fill(unsigned int &serial);
   void print() const;
@@ -40,7 +44,10 @@ struct BlobComplexContent {
 };
 
 struct BlobComplexObjects {
-  BlobComplexObjects() {}
+  BlobComplexObjects() {
+    a = 0;
+    b = 0;
+  }
 
   void fill(unsigned int &serial);
   void print() const;


### PR DESCRIPTION
Fix for compilation warning(s) when compiling with gcc7 and more flags listed here:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-07-24-2300/CondFormats/Calibration