### PR TITLE
gcc7 compilation warnings fix in DPGAnalysis/SiStripTools pkg

### DIFF
--- a/DPGAnalysis/SiStripTools/bin/OccupancyPlotMacros.cc
+++ b/DPGAnalysis/SiStripTools/bin/OccupancyPlotMacros.cc
@@ -463,7 +463,7 @@ TCanvas* drawMap(const char* cname, const TH1* hval, const TProfile* averadius, 
       
   for(int i=1;i<hval->GetNbinsX();++i) {
 	
-    if(averadius->GetBinEntries(i)*avez->GetBinEntries(i)) {
+    if( (averadius->GetBinEntries(i)*avez->GetBinEntries(i)) != 0) {
       
       double dz = -1.;
       double dr = -1.;


### PR DESCRIPTION
Fix for compilation warning(s) when compiling with gcc7 and more flags listed here:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-07-24-2300/DPGAnalysis/SiStripTools