### PR TITLE
gcc7 compilation warning(s) fix(es) in ElectroWeakAnalysis/ZMuMu pkg

### DIFF
--- a/ElectroWeakAnalysis/ZMuMu/plugins/ZMuMuEfficiency.cc
+++ b/ElectroWeakAnalysis/ZMuMu/plugins/ZMuMuEfficiency.cc
@@ -537,7 +537,7 @@ bool ZMuMuEfficiency::check_ifZmumu(const Candidate * dauGen0, const Candidate *
   if (partId0==13 || partId1==13 || partId2==13) muminusFound=true;
   if (partId0==-13 || partId1==-13 || partId2==-13) muplusFound=true;
   if (partId0==23 || partId1==23 || partId2==23) ZFound=true;
-  return muplusFound*muminusFound*ZFound;
+  return ( muplusFound && muminusFound && ZFound );
 }
 
 float ZMuMuEfficiency::getParticlePt(const int ipart, const Candidate * dauGen0, const Candidate * dauGen1, const Candidate * dauGen2)

--- a/ElectroWeakAnalysis/ZMuMu/plugins/ZMuMuPerformances.cc
+++ b/ElectroWeakAnalysis/ZMuMu/plugins/ZMuMuPerformances.cc
@@ -1016,7 +1016,7 @@ bool ZMuMuPerformances::check_ifZmumu(const Candidate * dauGen0, const Candidate
   if (partId0==13 || partId1==13 || partId2==13) muminusFound=true;
   if (partId0==-13 || partId1==-13 || partId2==-13) muplusFound=true;
   if (partId0==23 || partId1==23 || partId2==23) ZFound=true;
-  return muplusFound*muminusFound*ZFound;
+  return (muplusFound && muminusFound && ZFound);
 }
 
 float ZMuMuPerformances::getParticlePt(const int ipart, const Candidate * dauGen0, const Candidate * dauGen1, const Candidate * dauGen2)

--- a/ElectroWeakAnalysis/ZMuMu/plugins/ZMuMu_MCanalyzer.cc
+++ b/ElectroWeakAnalysis/ZMuMu/plugins/ZMuMu_MCanalyzer.cc
@@ -431,7 +431,7 @@ bool ZMuMu_MCanalyzer::check_ifZmumu(const Candidate * dauGen0, const Candidate 
   if (partId0==13 || partId1==13 || partId2==13) muminusFound=true;
   if (partId0==-13 || partId1==-13 || partId2==-13) muplusFound=true;
   if (partId0==23 || partId1==23 || partId2==23) ZFound=true;
-  return muplusFound*muminusFound*ZFound;
+  return (muplusFound && muminusFound && ZFound);
 }
 
 float ZMuMu_MCanalyzer::getParticlePt(const int ipart, const Candidate * dauGen0, const Candidate * dauGen1, const Candidate * dauGen2)

--- a/ElectroWeakAnalysis/ZMuMu/plugins/ZMuMu_efficiencyAnalyzer.cc
+++ b/ElectroWeakAnalysis/ZMuMu/plugins/ZMuMu_efficiencyAnalyzer.cc
@@ -600,7 +600,7 @@ bool ZMuMu_efficiencyAnalyzer::check_ifZmumu(const Candidate * dauGen0, const Ca
   if (partId0==13 || partId1==13 || partId2==13) muminusFound=true;
   if (partId0==-13 || partId1==-13 || partId2==-13) muplusFound=true;
   if (partId0==23 || partId1==23 || partId2==23) ZFound=true;
-  return muplusFound*muminusFound*ZFound;
+  return (muplusFound && muminusFound && ZFound);
 }
 
 float ZMuMu_efficiencyAnalyzer::getParticlePt(const int ipart, const Candidate * dauGen0, const Candidate * dauGen1, const Candidate * dauGen2)

--- a/ElectroWeakAnalysis/ZMuMu/plugins/ZMuMu_vtxAnalyzer.cc
+++ b/ElectroWeakAnalysis/ZMuMu/plugins/ZMuMu_vtxAnalyzer.cc
@@ -445,7 +445,7 @@ bool ZMuMu_vtxAnalyzer::check_ifZmumu(const Candidate * dauGen0, const Candidate
   if (partId0==13 || partId1==13 || partId2==13) muminusFound=true;
   if (partId0==-13 || partId1==-13 || partId2==-13) muplusFound=true;
   if (partId0==23 || partId1==23 || partId2==23) ZFound=true;
-  return muplusFound*muminusFound*ZFound;
+  return  ( muplusFound && muminusFound && ZFound );
 }
 
 float ZMuMu_vtxAnalyzer::getParticlePt(const int ipart, const Candidate * dauGen0, const Candidate * dauGen1, const Candidate * dauGen2)


### PR DESCRIPTION
Fix for compilation warning(s) when compiling with gcc7 and more flags listed here:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-07-24-2300/ElectroWeakAnalysis/ZMuMu