### PR TITLE
gcc7 compilation warning(s) fix(es) in DataFormats/L1THGCal

### DIFF
--- a/DataFormats/L1THGCal/interface/HGCFETriggerDigi.h
+++ b/DataFormats/L1THGCal/interface/HGCFETriggerDigi.h
@@ -43,7 +43,9 @@ namespace l1t {
     typedef std::vector<bool> data_payload;
     typedef uint32_t key_type; 
 
-    HGCFETriggerDigi() : codec_((unsigned char)0xffff) {}
+    HGCFETriggerDigi() : codec_((unsigned char)0xffff) {
+      detid_ = 0;
+    }
     ~HGCFETriggerDigi() {}
     
     //detector id information


### PR DESCRIPTION
Fix for compilation warning(s) when compiling with gcc7 and more flags listed here:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-07-24-2300/L1Trigger/L1THGCal