### PR TITLE
gcc7 compilation warning(s) fix(es) in RecoGamma & RecoMuon

### DIFF
--- a/RecoMuon/TrackingTools/src/MuonTrackLoader.cc
+++ b/RecoMuon/TrackingTools/src/MuonTrackLoader.cc
@@ -202,7 +202,6 @@ MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
   reco::TrackRef::key_type trackUpdatedIndex = 0;
   
   reco::TrackExtraRef::key_type trackExtraIndex = 0;
-  TrackingRecHitRef::key_type recHitsIndex = 0;
   
   edm::Ref<reco::TrackCollection>::key_type iTkRef = 0;
   edm::Ref< std::vector<Trajectory> >::key_type iTjRef = 0;
@@ -541,10 +540,8 @@ MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
   event.getByToken(theBeamSpotToken,beamSpot);
 
   reco::TrackRef::key_type trackIndex = 0;
-  //  reco::TrackRef::key_type trackUpdatedIndex = 0;
   
   reco::TrackExtraRef::key_type trackExtraIndex = 0;
-  TrackingRecHitRef::key_type recHitsIndex = 0;
   
   edm::Ref<reco::TrackCollection>::key_type iTkRef = 0;
   edm::Ref< std::vector<Trajectory> >::key_type iTjRef = 0;


### PR DESCRIPTION
Fix for compilation warning(s) when compiling with gcc7 and more flags listed here:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-07-24-2300/RecoMuon/MuonIsolation
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-07-24-2300/RecoEgamma/EgammaIsolationAlgos
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-07-24-2300/RecoMuon/TrackingTools