### PR TITLE
gcc7 compilation warning(s) fix(es) in HLTrigger/Timer

### DIFF
--- a/HLTrigger/Timer/test/chrono/src/x86_tsc.cc
+++ b/HLTrigger/Timer/test/chrono/src/x86_tsc.cc
@@ -163,16 +163,19 @@ extern "C" {
 
   static uint64_t (*serialising_rdtsc_resolver(void))(void)
   {
+    
     if (not tsc_allowed())
       return serialising_rdtsc_unimplemented;
 
     if (has_rdtscp())
       // if available, use the RDTSCP instruction
       return serialising_rdtscp;
-
+    
+    unsigned eax=0, ebx=0, ecx=0, edx=0;
+    
     if (has_tsc()) {
       // if the TSC is available, chck the processor vendor
-      unsigned int eax, ebx, ecx, edx;
+      //unsigned int eax, ebx, ecx, edx;
       __get_cpuid(0x00, & eax, & ebx, & ecx, & edx);
       if (ebx == _("Genu") and edx == _("ineI") and ecx == _("ntel"))
         // for Intel processors, LFENCE can be used as a serialising instruction before RDTSC

--- a/HLTrigger/Timer/test/chrono/src/x86_tsc.cc
+++ b/HLTrigger/Timer/test/chrono/src/x86_tsc.cc
@@ -171,11 +171,9 @@ extern "C" {
       // if available, use the RDTSCP instruction
       return serialising_rdtscp;
     
-    unsigned eax=0, ebx=0, ecx=0, edx=0;
-    
     if (has_tsc()) {
       // if the TSC is available, chck the processor vendor
-      //unsigned int eax, ebx, ecx, edx;
+      unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
       __get_cpuid(0x00, & eax, & ebx, & ecx, & edx);
       if (ebx == _("Genu") and edx == _("ineI") and ecx == _("ntel"))
         // for Intel processors, LFENCE can be used as a serialising instruction before RDTSC


### PR DESCRIPTION
Fix for compilation warning(s) when compiling with gcc7 and more flags listed here:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-07-24-2300/HLTrigger/Timer