### PR TITLE
gcc7 compilation warning(s) fix(es) in FastSimulation/CaloGeometryTools

### DIFF
--- a/FastSimulation/CaloGeometryTools/interface/Crystal.h
+++ b/FastSimulation/CaloGeometryTools/interface/Crystal.h
@@ -29,7 +29,7 @@ class Crystal
   // side numbering
   //  enum CrystalSide{EAST=0,NORTH=1,WEST=2,SOUTH=3,FRONT=4,BACK=5};
   /// Empty constructor 
-  Crystal(){;};
+  Crystal(){number_ = 0;};
   /// constructor from DetId
   Crystal(const DetId&  cell,const BaseCrystal* bc=0);
 


### PR DESCRIPTION
Fix for compilation warning(s) when compiling with gcc7 and more flags listed here:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-07-24-2300/FastSimulation/CaloGeometryTools