### PR TITLE
gcc7 compilation warning(s) fix(es) in TopQuarkAnalysis/TopKinFitter

### DIFF
--- a/TopQuarkAnalysis/TopKinFitter/plugins/TtFullLepKinSolutionProducer.h
+++ b/TopQuarkAnalysis/TopKinFitter/plugins/TtFullLepKinSolutionProducer.h
@@ -218,7 +218,7 @@ void TtFullLepKinSolutionProducer::produce(edm::Event & evt, const edm::EventSet
   // Check if the leptons for the required Channel are available
   bool correctLeptons = ((electronsFound && eeChannel_) || (muonsFound && mumuChannel_) || (electronMuonFound && emuChannel_) );
   // Check for equally charged leptons if for wrong charge combinations is searched
-  if(isWrongCharge) correctLeptons *= searchWrongCharge_;
+  if(isWrongCharge) { correctLeptons = correctLeptons && searchWrongCharge_; }
 
   if(correctLeptons && METFound && jetsFound) {
 


### PR DESCRIPTION
Fix for compilation warning(s) when compiling with gcc7 and more flags listed here:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-07-24-2300/TopQuarkAnalysis/TopKinFitter