### PR TITLE
gcc7 compilation warning(s) fix(es) in SimMuon/MCTruth

### DIFF
--- a/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
+++ b/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
@@ -27,7 +27,7 @@ class MuonAssociatorByHits {
  public:
   
   MuonAssociatorByHits (const edm::ParameterSet& conf, edm::ConsumesCollector && iC);   
-  ~MuonAssociatorByHits();
+  virtual ~MuonAssociatorByHits();
   
   // Originally from TrackAssociatorBase from where this class used to inherit from
   reco::RecoToSimCollection associateRecoToSim(edm::Handle<edm::View<reco::Track> >& tCH,


### PR DESCRIPTION
Fix for compilation warning(s) when compiling with gcc7 and more flags listed here:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-07-24-2300/SimMuon/MCTruth