### PR TITLE
gcc7 compilation warning(s) fix(es) in SimG4CMS/Calo

### DIFF
--- a/SimG4CMS/Calo/src/HFGflash.cc
+++ b/SimG4CMS/Calo/src/HFGflash.cc
@@ -253,8 +253,8 @@ std::vector<HFGflash::Hit> HFGflash::gfParameterization(G4Step * aStep,bool & ok
 #ifdef DebugLog  
     LogDebug("HFShower") << " zInX0 = " << zInX0 << " spotBeta*zInX0 = " << spotBeta*zInX0;
 #endif
-    if ((!zInX0) || (!spotBeta*zInX0) || (zInX0 < 0.01) || 
-	(spotBeta*zInX0 < 0.00001) || (!zInX0*beta) || (zInX0*beta < 0.00001)) 
+    if ((!zInX0) || (! (spotBeta*zInX0 != 0) ) || (zInX0 < 0.01) || 
+	(spotBeta*zInX0 < 0.00001) || (! (zInX0*beta != 0) ) || (zInX0*beta < 0.00001)) 
       return hit;
 
     G4int nSpotsInStep = 0;


### PR DESCRIPTION
Fix for compilation warning(s) when compiling with gcc7 and more flags listed here:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-07-24-2300/SimG4CMS/Calo