### PR TITLE
gcc7 compilation warnings fix in RecoJets pkgs

### DIFF
--- a/RecoJets/FFTJetProducers/plugins/FFTJetEFlowSmoother.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetEFlowSmoother.cc
@@ -34,7 +34,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/Common/interface/View.h"
-#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
+#include <TH3F.h>
 
 // parameter parser header
 #include "RecoJets/FFTJetProducers/interface/FFTJetParameterParser.h"

--- a/RecoJets/JetAnalyzers/src/FFTJetImageRecorder.cc
+++ b/RecoJets/JetAnalyzers/src/FFTJetImageRecorder.cc
@@ -33,7 +33,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
+#include <TH3F.h>
 
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 

--- a/RecoJets/JetAnalyzers/src/FFTJetPileupAnalyzer.cc
+++ b/RecoJets/JetAnalyzers/src/FFTJetPileupAnalyzer.cc
@@ -31,7 +31,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
+#include <TH2D.h>
 #include "DataFormats/JetReco/interface/FFTJetPileupSummary.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"


### PR DESCRIPTION
Fixes for compilation warnings when compiling with gcc7 and more flags listed here:
https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/slc6_amd64_gcc700/www/mon/9.3-mon-23/CMSSW_9_3_X_2017-07-24-2300
packages 18 and 19 comp warnings