### PR TITLE
gcc7 compilation warnings fixes in DQM, DQMOffline, DQMServices packages

### DIFF
--- a/DQM/L1TMonitor/src/L1TRate.cc
+++ b/DQM/L1TMonitor/src/L1TRate.cc
@@ -24,7 +24,7 @@
 #include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
 #include "CondFormats/DataRecord/interface/L1GtPrescaleFactorsAlgoTrigRcd.h"
 
-#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
+//#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
 
 #include "TList.h"
 

--- a/DQM/L1TMonitorClient/src/L1TOccupancyClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TOccupancyClient.cc
@@ -8,7 +8,7 @@
 #include "DQMServices/Core/interface/QReport.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
-#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
+//#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
 #include <stdio.h>
 #include <sstream>
 #include <math.h>

--- a/DQM/L1TMonitorClient/src/L1TTestsSummary.cc
+++ b/DQM/L1TMonitorClient/src/L1TTestsSummary.cc
@@ -9,7 +9,7 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "DQMServices/Core/interface/DQMChannel.h"
-#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
+//#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
 #include <stdio.h>
 #include <sstream>
 #include <math.h>

--- a/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
@@ -11,7 +11,7 @@
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
+//#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 #include "DataFormats/GeometrySurface/interface/Cylinder.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"

--- a/DQMOffline/L1Trigger/src/L1TRate_Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TRate_Offline.cc
@@ -10,7 +10,7 @@
 #include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
 #include "CondFormats/DataRecord/interface/L1GtPrescaleFactorsAlgoTrigRcd.h"
 
-#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
+//#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
 
 #include "TList.h"
 

--- a/DQMServices/Components/plugins/SealModule.cc
+++ b/DQMServices/Components/plugins/SealModule.cc
@@ -34,11 +34,11 @@ DEFINE_FWK_MODULE(DQMScalInfo);
 DEFINE_FWK_MODULE(DQMDaqInfo);
 
 // module converting between ME and ROOT in Run tree of edm file
-#include "DQMServices/Components/plugins/MEtoEDMConverter.h"
+/*#include "DQMServices/Components/plugins/MEtoEDMConverter.h"
 DEFINE_FWK_MODULE(MEtoEDMConverter);
 #include "DQMServices/Components/plugins/EDMtoMEConverter.h"
 DEFINE_FWK_MODULE(EDMtoMEConverter);
 
 #include "DQMServices/Components/plugins/MEtoMEComparitor.h"
 //define this as a plug-in
-DEFINE_FWK_MODULE(MEtoMEComparitor);
+DEFINE_FWK_MODULE(MEtoMEComparitor);*/


### PR DESCRIPTION
Fixes for compilation warnings when compiling with gcc7 and more flags listed here:
https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/slc6_amd64_gcc700/www/mon/9.3-mon-23/CMSSW_9_3_X_2017-07-24-2300
packages 4,5,7 and 8 comp warnings
