### PR TITLE
pr93x-CaloSaturations-at-P5

### DIFF
--- a/L1Trigger/L1TCalorimeter/interface/CaloTools.h
+++ b/L1Trigger/L1TCalorimeter/interface/CaloTools.h
@@ -46,6 +46,17 @@ namespace l1t {
     static const int kNrTowers = ((kHFEnd-kHFBegin+1)*kHFNrPhi + kHBHEEnd*kHBHENrPhi )*2;
     static const int kNrHBHETowers = kHBHEEnd*kHBHENrPhi*2;
 
+    // These are the saturation codes sent from Layer 1 as the tower pT to Layer 2
+    // 509 = Layer 1 received saturated HCAL TP
+    // 510 = Layer 1 received saturated ECAL TP
+    // 511 = Layer 1 received both saturated ECAL & HCAL TPs
+    static const int kSatHcal = 509;
+    static const int kSatEcal = 510;
+    static const int kSatTower = 511;
+
+    // Jet saturation value
+    static const int kSatJet = 65535;
+
   public:
     enum SubDet{ECAL=0x1,HCAL=0x2,CALO=0x3}; //CALO is a short cut for ECAL|HCAL
 

--- a/L1Trigger/L1TCalorimeter/interface/Stage2Layer2JetAlgorithmFirmware.h
+++ b/L1Trigger/L1TCalorimeter/interface/Stage2Layer2JetAlgorithmFirmware.h
@@ -31,7 +31,7 @@ namespace l1t {
 
     void accuSort(std::vector<Jet> & jets);
 
-    void calibrate(std::vector<Jet> & jets, int calibThreshold);
+    void calibrate(std::vector<Jet> & jets, int calibThreshold, bool isAllJets);
 
     double calibFit(double, double*);
     double calibFitErr(double,double*);

--- a/L1Trigger/L1TCalorimeter/macros/compHwEmu.C
+++ b/L1Trigger/L1TCalorimeter/macros/compHwEmu.C
@@ -207,16 +207,25 @@ void compHwEmu (
   TH1D* hwMPSumEt = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/mpsumet/et");
   TH1D* emMPSumEt = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/mpsumet/et");
 
+  TH1D* hwMPSumEtSat = (TH1D*) new TH1D(*hwMPSumEt);
+  TH1D* emMPSumEtSat = (TH1D*) new TH1D(*emMPSumEt);
+
   // ETTHF
   TH1D* hwMPSumEtHF = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/mpsumethf/et");
   TH1D* emMPSumEtHF = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/mpsumethf/et");
 
-  /*
+  TH1D* hwMPSumEtHFSat = (TH1D*) new TH1D(*hwMPSumEtHF);
+  TH1D* emMPSumEtHFSat = (TH1D*) new TH1D(*emMPSumEtHF);
+
+ 
   // ETTEM
   TH1D* hwMPSumEtEM = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/mpsumetem/et");
   TH1D* emMPSumEtEM = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/mpsumetem/et");
-  */
-
+  
+   // ETTEM
+  TH1D* hwMPSumEtEMSat = (TH1D*) new TH1D(*hwMPSumEtEM);
+  TH1D* emMPSumEtEMSat = (TH1D*) new TH1D(*emMPSumEtEM);
+ 
   // ETx
   TH1D* hwMPSumEtx = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/mpsummetx/et");
   TH1D* emMPSumEtx = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/mpsummetx/et");
@@ -228,6 +237,11 @@ void compHwEmu (
   // ETxHF
   TH1D* hwMPSumEtxHF = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/mpsummetxhf/et");
   TH1D* emMPSumEtxHF = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/mpsummetxhf/et");
+
+  // ETx Sat
+  TH1D* hwMPSumEtxHFSat = (TH1D*) new TH1D(*hwMPSumEtxHF);
+  TH1D* emMPSumEtxHFSat = (TH1D*) new TH1D(*emMPSumEtxHF);
+  
 
   // ETy
   TH1D* hwMPSumEty = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/mpsummety/et");
@@ -241,29 +255,59 @@ void compHwEmu (
   TH1D* hwMPSumEtyHF = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/mpsummetyhf/et");
   TH1D* emMPSumEtyHF = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/mpsummetyhf/et");
 
+  // ETy Sat
+  TH1D* hwMPSumEtyHFSat = (TH1D*) new TH1D(*hwMPSumEtyHF);
+  TH1D* emMPSumEtyHFSat = (TH1D*) new TH1D(*emMPSumEtyHF);
+
   // HTT
   TH1D* hwMPSumHt = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/mpsumht/et");
   TH1D* emMPSumHt = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/mpsumht/et");
+
+  // HTT
+  TH1D* hwMPSumHtSat = (TH1D*) new TH1D(*hwMPSumHt);
+  TH1D* emMPSumHtSat = (TH1D*) new TH1D(*emMPSumHt);
 
   // HTTHF
   TH1D* hwMPSumHtHF = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/mpsumhthf/et");
   TH1D* emMPSumHtHF = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/mpsumhthf/et");
 
+  // HTT
+  TH1D* hwMPSumHtHFSat = (TH1D*) new TH1D(*hwMPSumHtHF);
+  TH1D* emMPSumHtHFSat = (TH1D*) new TH1D(*emMPSumHtHF);
+
   // HTx
   TH1D* hwMPSumHtx = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/mpsummhtx/et");
   TH1D* emMPSumHtx = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/mpsummhtx/et");
+
+  // HTx Sat
+  TH1D* hwMPSumHtxSat = (TH1D*) new TH1D(*hwMPSumHtx);
+  TH1D* emMPSumHtxSat = (TH1D*) new TH1D(*emMPSumHtx);
 
   // HTxHF
   TH1D* hwMPSumHtxHF = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/mpsummhtxhf/et");
   TH1D* emMPSumHtxHF = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/mpsummhtxhf/et");
 
+  // HTxHF Sat
+  TH1D* hwMPSumHtxHFSat = (TH1D*) new TH1D(*hwMPSumHtxHF);
+  TH1D* emMPSumHtxHFSat = (TH1D*) new TH1D(*emMPSumHtxHF);
+
+
   // HTy
   TH1D* hwMPSumHty = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/mpsummhty/et");
   TH1D* emMPSumHty = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/mpsummhty/et");
 
+  // HTy Sat
+  TH1D* hwMPSumHtySat = (TH1D*) new TH1D(*hwMPSumHty);
+  TH1D* emMPSumHtySat = (TH1D*) new TH1D(*emMPSumHty);
+
   // HTyHF
   TH1D* hwMPSumHtyHF = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/mpsummhtyhf/et");
   TH1D* emMPSumHtyHF = (TH1D*)inFileEm->Get("l1tStage2CaloAnalyzer/mpsummhtyhf/et");
+
+  // HTyHF Sat
+  TH1D* hwMPSumHtyHFSat = (TH1D*) new TH1D(*hwMPSumHtyHF);
+  TH1D* emMPSumHtyHFSat = (TH1D*) new TH1D(*emMPSumHtyHF);
+
   
   // HITowerCount
   TH1D* hwMPSumHITowerCount = (TH1D*)inFileHw->Get("l1tCaloStage2HwHistos/mpsumhitowercount/et");
@@ -503,7 +547,7 @@ void compHwEmu (
     // plot demux jet Et
     create_plot(
       hwJetEt, emJetEt, runNo, dataset,
-      "Jet iE_{T}", "DemuxJets/JetEt.pdf"
+      "Jet iE_{T}", "DemuxJets/JetEt.pdf",  1, 13, 0, 2500
       );
 
     // plot demux jet eta
@@ -536,23 +580,47 @@ void compHwEmu (
     // plot MP sum Et
     create_plot(
       hwMPSumEt, emMPSumEt, runNo, dataset,
-      "Sum iE_{T}", "MPSums/MPSumEt.pdf"
+      "Sum iE_{T}", "MPSums/MPSumEt.pdf", 1, 13, 0, 10000
       );
+
+     // plot MP sum Et
+    create_plot(
+      hwMPSumEtSat, emMPSumEtSat, runNo, dataset,
+      "Sum iE_{T}", "MPSums/MPSumEtSat.pdf", 1, 13, 0, 100000
+      );
+    
 
     // plot MP sum Et with HF
     create_plot(
       hwMPSumEtHF, emMPSumEtHF, runNo, dataset,
-      "Sum iE_{T}", "MPSums/MPSumEtHF.pdf"
+      "Sum iE_{T}", "MPSums/MPSumEtHF.pdf",  1, 13, 0, 10000
       );
 
-    /*
-    // plot MP sum ETTEM
+    // plot MP sum Et with HF
     create_plot(
-      hwMPSumEt, emMPSumEt, runNo, dataset,
-      "Jet iE_{T}", "MPSums/MPSumEt.pdf"
+      hwMPSumEtHFSat, emMPSumEtHFSat, runNo, dataset,
+      "Sum iE_{T}", "MPSums/MPSumEtHFSat.pdf", 1, 13, 0, 100000
       );
-    */
-  }
+
+    
+
+    
+    // plot MP sum ETEm
+    create_plot(
+      hwMPSumEtEM, emMPSumEtEM, runNo, dataset,
+      "Sum iE_{T}", "MPSums/MPSumEtEM.pdf", 1, 13, 0, 5000
+      );
+    
+     
+  
+
+  // plot MP sum ETTEM
+    create_plot(
+      hwMPSumEtEMSat, emMPSumEtEMSat, runNo, dataset,
+      "Sum iE_{T}", "MPSums/MPSumEtEMSat.pdf", 1, 13, 0, 100000
+      );
+    
+ 
 
   // plot MP sum Etx
   create_plot(
@@ -571,6 +639,13 @@ void compHwEmu (
     "Sum iE_{T,x}", "MPSums/MPSumEtxHF.pdf", 1, 13, -200000, 200000 
     );
 
+    // plot MP sum Etx with HF sat
+  create_plot(
+    hwMPSumEtxHFSat, emMPSumEtxHFSat, runNo, dataset,
+    "Sum iE_{T,x}", "MPSums/MPSumEtxHFSat.pdf", 1000, 13, -2200000000, 2200000000
+    );
+
+
   // plot MP sum Ety
   create_plot(
     hwMPSumEty, emMPSumEty, runNo, dataset, 
@@ -587,6 +662,13 @@ void compHwEmu (
     hwMPSumEtyHF, emMPSumEtyHF, runNo, dataset,
     "Sum iE_{T,y}", "MPSums/MPSumEtyHF.pdf", 1, 13, -200000, 200000
     );
+
+  // plot MP sum Ety with HF
+  create_plot(
+    hwMPSumEtyHFSat, emMPSumEtyHFSat, runNo, dataset,
+    "Sum iE_{T,y}", "MPSums/MPSumEtyHFSat.pdf",  1000, 13, -2200000000, 2200000000 
+    );
+  }
 
   if (presentationMode) {
     // plot MP sum Ht
@@ -624,6 +706,7 @@ void compHwEmu (
       hwMPSumHtyHF, emMPSumHtyHF, runNo, dataset,
       "Sum iH_{T,y}", "MPSums/MPSumHtyHF.pdf", 1, 13, -20000, 20000
       );
+
       // plot HI tower count
     create_plot(
       hwMPSumHITowerCount, emMPSumHITowerCount, runNo, dataset,
@@ -634,39 +717,79 @@ void compHwEmu (
     // plot MP sum Ht
     create_plot(
       hwMPSumHt, emMPSumHt, runNo, dataset,
-      "Sum iH_{T}", "MPSums/MPSumHt.pdf"
+      "Sum iH_{T}", "MPSums/MPSumHt.pdf", 1, 13, 0, 10000
       );
 
     // plot MP sum Ht (with HF)
     create_plot(
       hwMPSumHtHF, emMPSumHtHF, runNo, dataset,
-      "Sum iH_{T}", "MPSums/MPSumHtHF.pdf"
+      "Sum iH_{T}", "MPSums/MPSumHtHF.pdf", 1, 13, 0, 10000
       );
+
+
+      // plot MP sum Ht
+    create_plot(
+      hwMPSumHtSat, emMPSumHtSat, runNo, dataset,
+      "Sum iH_{T}", "MPSums/MPSumHtSat.pdf", 1, 13, 0, 100000
+      );
+
+    // plot MP sum Ht (with HF)
+    create_plot(
+      hwMPSumHtHFSat, emMPSumHtHFSat, runNo, dataset,
+      "Sum iH_{T}", "MPSums/MPSumHtHFSat.pdf", 1, 13, 0, 100000
+      );
+
 
 
     // plot MP sum Htx
     create_plot(
       hwMPSumHtx, emMPSumHtx, runNo, dataset,
-      "Sum iH_{T,x}", "MPSums/MPSumHtx.pdf"
+      "Sum iH_{T,x}", "MPSums/MPSumHtx.pdf", 1, 13, -200000, 200000
       );
 
     // plot MP sum Htx (with HF)
     create_plot(
       hwMPSumHtxHF, emMPSumHtxHF, runNo, dataset,
-      "Sum iH_{T,x}", "MPSums/MPSumHtxHF.pdf"
+      "Sum iH_{T,x}", "MPSums/MPSumHtxHF.pdf", 1, 13, -200000, 200000
+      );
+
+
+      // plot MP sum Htx (with HF) sat
+    create_plot(
+      hwMPSumHtxSat, emMPSumHtxSat, runNo, dataset,
+      "Sum iH_{T,x}", "MPSums/MPSumHtxSat.pdf", 1000, 13, -2200000000, 2200000000
+      );
+
+    // plot MP sum Htx (with HF) sat
+    create_plot(
+      hwMPSumHtxHFSat, emMPSumHtxHFSat, runNo, dataset,
+      "Sum iH_{T,x}", "MPSums/MPSumHtxHFSat.pdf", 1000, 13, -2200000000, 2200000000
       );
 
     // plot MP sum Hty
     create_plot(
       hwMPSumHty, emMPSumHty, runNo, dataset,
-      "Sum iH_{T,y}", "MPSums/MPSumHty.pdf"
+      "Sum iH_{T,y}", "MPSums/MPSumHty.pdf", 1, 13, -200000, 200000
       );
 
     // plot MP sum Hty (with HF)
     create_plot(
       hwMPSumHtyHF, emMPSumHtyHF, runNo, dataset,
-      "Sum iH_{T,y}", "MPSums/MPSumHtyHF.pdf"
+      "Sum iH_{T,y}", "MPSums/MPSumHtyHF.pdf", 1, 13, -200000, 200000
       );
+
+       // plot MP sum Hty sat
+    create_plot(
+      hwMPSumHtySat, emMPSumHtySat, runNo, dataset,
+      "Sum iH_{T,y}", "MPSums/MPSumHtySat.pdf", 1000, 13, -2200000000, 2200000000
+      );
+
+    // plot MP sum Hty (with HF) sat
+    create_plot(
+      hwMPSumHtyHFSat, emMPSumHtyHFSat, runNo, dataset,
+      "Sum iH_{T,y}", "MPSums/MPSumHtyHFSat.pdf", 1000, 13, -2200000000, 2200000000
+      );
+  
 
     // plot HI tower count
     create_plot(
@@ -706,14 +829,14 @@ void compHwEmu (
     create_plot(
       hwSumMet,
       emSumMet,
-      runNo, dataset, "iMET", "DemuxSums/DemSumMet.pdf", 5, 13, 0, 200
+      runNo, dataset, "iMET", "DemuxSums/DemSumMet.pdf", 5, 13, 0, 5000
       );
 
     // plot demux sum Met with HF
     create_plot(
       hwSumMetHF,
       emSumMetHF,
-      runNo, dataset, "iMET", "DemuxSums/DemSumMetHF.pdf", 5, 13, 0, 200
+      runNo, dataset, "iMET", "DemuxSums/DemSumMetHF.pdf", 5, 13, 0, 5000
       );
 
     // plot demux sum Met phi
@@ -776,14 +899,14 @@ void compHwEmu (
     create_plot(
       hwSumEt,
       emSumEt,
-      runNo, dataset, "iE_{T}", "DemuxSums/DemSumEt.pdf"
+      runNo, dataset, "iE_{T}", "DemuxSums/DemSumEt.pdf", 1, 13, 0, 5000
       );
 
     // plot demux sum EtEM
     create_plot(
       hwSumEtEM,
       emSumEtEM,
-      runNo, dataset, "iE_{T}", "DemuxSums/DemSumEtEM.pdf"
+      runNo, dataset, "iE_{T}", "DemuxSums/DemSumEtEM.pdf", 1, 13, 0, 5000
       );
 
     /*
@@ -799,14 +922,14 @@ void compHwEmu (
     create_plot(
       hwSumMetHF,
       emSumMetHF,
-      runNo, dataset, "iMET", "DemuxSums/DemSumMetHF.pdf"
+      runNo, dataset, "iMET", "DemuxSums/DemSumMetHF.pdf", 1, 13, 0, 5000
       );
 
     // plot demux sum Met
     create_plot(
       hwSumMet,
       emSumMet,
-      runNo, dataset, "iMET", "DemuxSums/DemSumMet.pdf"
+      runNo, dataset, "iMET", "DemuxSums/DemSumMet.pdf", 1, 13, 0, 5000
       );
 
     // plot demux sum Met phi
@@ -827,7 +950,7 @@ void compHwEmu (
     create_plot(
       hwSumHt,
       emSumHt,
-      runNo, dataset, "iH_{T}", "DemuxSums/DemSumHt.pdf"
+      runNo, dataset, "iH_{T}", "DemuxSums/DemSumHt.pdf", 1, 13, 0, 5000
       );
 
       // plot demux hi tower count
@@ -841,14 +964,14 @@ void compHwEmu (
     create_plot(
       hwSumMht,
       emSumMht,
-      runNo, dataset, "iMHT", "DemuxSums/DemSumMht.pdf"
+      runNo, dataset, "iMHT", "DemuxSums/DemSumMht.pdf", 1, 13, 1, 5000
       );
 
     // plot demux sum Mht (with HF)
     create_plot(
       hwSumMhtHF,
       emSumMhtHF,
-      runNo, dataset, "iMHT", "DemuxSums/DemSumMhtHF.pdf"
+      runNo, dataset, "iMHT", "DemuxSums/DemSumMhtHF.pdf", 1, 13, 1, 5000
       );
 
     // plot demux sum Mht phi
@@ -873,7 +996,7 @@ void compHwEmu (
   create_plot(
     hwMPEgEt,
     emMPEgEt,
-    runNo, dataset, "e/#gamma iE_{T}", "Egs/EgEt.pdf", 1, 13, 0, 1500
+    runNo, dataset, "e/#gamma iE_{T}", "Egs/EgEt.pdf", 1, 13, 0, 1000
     );
 
 // plot MP e/g eta
@@ -904,7 +1027,7 @@ void compHwEmu (
   create_plot(
     hwEgEt,
     emEgEt,
-    runNo, dataset, "e/#gamma iE_{T}", "DemuxEgs/EgEt.pdf", 1, 13, 0, 1500
+    runNo, dataset, "e/#gamma iE_{T}", "DemuxEgs/EgEt.pdf", 1, 13, 0, 1000
     );
 
 // plot demux e/g eta

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloAnalyzer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloAnalyzer.cc
@@ -679,10 +679,10 @@ namespace l1t {
         het_.insert( std::pair< ObjectType, TH1F* >(*itr, dirs_.at(*itr).make<TH1F>("et", "", 2200000, -2199999500, 2200000500) ));
       }
       else if (*itr==MPSumMHTx  || *itr==MPSumMHTxHF  || *itr==MPSumMHTy || *itr==MPSumMHTyHF ) {
-	het_.insert( std::pair< ObjectType, TH1F* >(*itr, dirs_.at(*itr).make<TH1F>("et", "", 2000, -199950, 200050) ));
+	het_.insert( std::pair< ObjectType, TH1F* >(*itr, dirs_.at(*itr).make<TH1F>("et", "",  2200000, -2199999500, 2200000500) ));
       }
       else if (*itr==SumET || *itr==SumETEm || *itr==MPSumETEm || *itr==MPSumET || *itr==MPSumETHF || *itr==SumHT || *itr==MPSumHT || *itr==MPSumHTHF ) {
-        het_.insert( std::pair< ObjectType, TH1F* >(*itr, dirs_.at(*itr).make<TH1F>("et", "", 350, -0.5, 6999.5) )); 
+        het_.insert( std::pair< ObjectType, TH1F* >(*itr, dirs_.at(*itr).make<TH1F>("et", "", 100000, -0.5, 99999.5) )); 
       }
       else if (*itr==MPMinBiasHFP0 ||
                *itr==MPMinBiasHFM0 ||

--- a/L1Trigger/L1TCalorimeter/python/customiseReEmulateCaloLayer2.py
+++ b/L1Trigger/L1TCalorimeter/python/customiseReEmulateCaloLayer2.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 def reEmulateLayer2(process):
 
     process.load('L1Trigger/L1TCalorimeter/simCaloStage2Digis_cfi')
-    process.load('L1Trigger.L1TCalorimeter.caloStage2Params_2017_v1_7_cfi')
+    process.load('L1Trigger.L1TCalorimeter.caloStage2Params_2017_v1_7_excl30_cfi')
 
     process.simCaloStage2Digis.towerToken = cms.InputTag("caloStage2Digis", "CaloTower")
     

--- a/L1Trigger/L1TCalorimeter/python/generateTowerEtThresholdLUT.py
+++ b/L1Trigger/L1TCalorimeter/python/generateTowerEtThresholdLUT.py
@@ -26,8 +26,8 @@ if not os.path.isdir(os.environ['LOCALRT'] + "/src/L1Trigger/L1TCalorimeter/data
           "Remember to do 'git add " + os.environ['LOCALRT'] + "L1Trigger/L1TCalorimeter/data' when committing the new LUT!")
     os.makedirs(os.environ['LOCALRT'] + "/src/L1Trigger/L1TCalorimeter/data")
 
-print "Creating tower Et threshold LUT with filename " + os.environ['LOCALRT'] + "/src/L1Trigger/L1TCalorimeter/data/lut_towEtThresh_2017v4.txt'"
-towEtThreshLUTFile = open(os.environ['LOCALRT']+"/src/L1Trigger/L1TCalorimeter/data/lut_towEtThresh_2017v4.txt", "w")
+print "Creating tower Et threshold LUT with filename " + os.environ['LOCALRT'] + "/src/L1Trigger/L1TCalorimeter/data/lut_towEtThresh_2017v6.txt'"
+towEtThreshLUTFile = open(os.environ['LOCALRT']+"/src/L1Trigger/L1TCalorimeter/data/lut_towEtThresh_2017v6.txt", "w")
 
 
 # write header info
@@ -58,17 +58,22 @@ printBins = ""
 
 for compNTT4 in compNTT4Range:
     for ieta in etaRange:
-        towEtThresh = int(round(float(towerAreas[ieta])*(1/(1+math.exp(-0.2*(ieta-5))))*(float(compNTT4)/10)))
+        if compNTT4 < 16:
+            towEtThresh = int(round(pow(float(towerAreas[ieta]),1.4)*(1/(1+math.exp(-0.07*(ieta))))*(pow(float(compNTT4),2)/100)))
+        else:
+            towEtThresh = int(round(pow(float(towerAreas[ieta]),1.4)*(1/(1+math.exp(-0.07*(ieta))))*(pow(float(16),2)/100)))
         if ieta > 28:
-            towEtThresh -= 4
-        if towEtThresh > 16:
-            towEtThresh = int(16)
+            towEtThresh -= 2
+        if towEtThresh > 12:
+            towEtThresh = int(12)
         if ieta < 13 or towEtThresh < 0:
             towEtThresh = 0
         if (addr % 64) == 0:
             printBins = "             # nTT4 = " + str(5*compNTT4) + "-" + str((5*compNTT4)+5) + " ieta = " + str(ieta)  
+        elif ieta>28:
+            printBins = "             # ieta = " + str(ieta+1)
         else:
-            printBins = ""
+            printBins = "             # ieta = " + str(ieta)
         towEtThreshLUTFile.write(
             str(addr) + " " + 
             str(towEtThresh) +

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxSumsAlgoFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2DemuxSumsAlgoFirmwareImp1.cc
@@ -29,88 +29,88 @@ l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::~Stage2Layer2DemuxSumsAlgoFirmwareIm
 void l1t::Stage2Layer2DemuxSumsAlgoFirmwareImp1::processEvent(const std::vector<l1t::EtSum> & inputSums,
                                                               std::vector<l1t::EtSum> & outputSums) {
 
-  int32_t et(0), etem(0), metx(0), mety(0), metxHF(0), metyHF(0), ht(0), mhtx(0), mhty(0), mhtxHF(0), mhtyHF(0), metPhi(0), metPhiHF(0), mhtPhi(0), mhtPhiHF(0);
-  uint32_t met(0), metHF(0), mht(0), mhtHF(0);
-  uint32_t mbp0(0), mbm0(0), mbp1(0), mbm1(0);
-  uint32_t ntow(0);
+  int et(0), etem(0), metx(0), mety(0), metxHF(0), metyHF(0), ht(0), mhtx(0), mhty(0), mhtxHF(0), mhtyHF(0), metPhi(0), metPhiHF(0), mhtPhi(0), mhtPhiHF(0);
+  unsigned int met(0), metHF(0), mht(0), mhtHF(0);
+  unsigned int mbp0(0), mbm0(0), mbp1(0), mbm1(0);
+  unsigned int ntow(0);
 
   bool metSat(0), metHFSat(0), mhtSat(0), mhtHFSat(0);
 
   // Add up the x, y and scalar components
-  for (std::vector<l1t::EtSum>::const_iterator eSum = inputSums.begin() ; eSum != inputSums.end() ; ++eSum )
-    {
-      switch (eSum->getType()) {
+  for (auto&& eSum : inputSums)
+  {
+      switch (eSum.getType()) {
 
       case l1t::EtSum::EtSumType::kTotalEt:
-        et += eSum->hwPt();
+        et += eSum.hwPt();
         break;
 
       case l1t::EtSum::EtSumType::kTotalEtEm:
-        etem += eSum->hwPt();
+        etem += eSum.hwPt();
         break;
 
       case l1t::EtSum::EtSumType::kTotalEtx:
-	if(eSum->hwPt()==0x7fffffff) metSat=true;
-        else metx += eSum->hwPt();
+	if(eSum.hwPt()==0x7fffffff) metSat=true;
+        else metx += eSum.hwPt();
         break;
 
       case l1t::EtSum::EtSumType::kTotalEty:
-	if(eSum->hwPt()==0x7fffffff) metSat=true;
-        else mety += eSum->hwPt();
+	if(eSum.hwPt()==0x7fffffff) metSat=true;
+        else mety += eSum.hwPt();
         break;
 
       case l1t::EtSum::EtSumType::kTotalHt:
-        ht += eSum->hwPt();
+        ht += eSum.hwPt();
         break;
 
       case l1t::EtSum::EtSumType::kTotalHtx:
-	if(eSum->hwPt()==0x7fffffff) mhtSat=true;
-        else mhtx += eSum->hwPt();
+	if(eSum.hwPt()==0x7fffffff) mhtSat=true;
+        else mhtx += eSum.hwPt();
 	break;
 
       case l1t::EtSum::EtSumType::kTotalHty:
-	if(eSum->hwPt()==0x7fffffff) mhtSat=true;
-	else mhty += eSum->hwPt();
+	if(eSum.hwPt()==0x7fffffff) mhtSat=true;
+	else mhty += eSum.hwPt();
         break;
 	
       case l1t::EtSum::EtSumType::kTotalEtxHF:
-	if(eSum->hwPt()==0x7fffffff) metHFSat=true;
-        else metxHF += eSum->hwPt();
+	if(eSum.hwPt()==0x7fffffff) metHFSat=true;
+        else metxHF += eSum.hwPt();
         break;
 	
       case l1t::EtSum::EtSumType::kTotalEtyHF:
-	if(eSum->hwPt()==0x7fffffff) metHFSat=true;
-        else metyHF += eSum->hwPt();
+	if(eSum.hwPt()==0x7fffffff) metHFSat=true;
+        else metyHF += eSum.hwPt();
         break;
 
       case l1t::EtSum::EtSumType::kTotalHtxHF:
-	if(eSum->hwPt()==0x7fffffff) mhtHFSat=true;
-	else mhtxHF += eSum->hwPt();
+	if(eSum.hwPt()==0x7fffffff) mhtHFSat=true;
+	else mhtxHF += eSum.hwPt();
         break;
 	
       case l1t::EtSum::EtSumType::kTotalHtyHF:
-	if(eSum->hwPt()==0x7fffffff) mhtHFSat=true;
-	else mhtyHF += eSum->hwPt();
+	if(eSum.hwPt()==0x7fffffff) mhtHFSat=true;
+	else mhtyHF += eSum.hwPt();
         break;
 
       case l1t::EtSum::EtSumType::kMinBiasHFP0:
-	mbp0 = eSum->hwPt();
+	mbp0 = eSum.hwPt();
 	break;
 
       case l1t::EtSum::EtSumType::kMinBiasHFM0:
-	mbm0 = eSum->hwPt();
+	mbm0 = eSum.hwPt();
 	break;
 
       case l1t::EtSum::EtSumType::kMinBiasHFP1:
-	mbp1 = eSum->hwPt();
+	mbp1 = eSum.hwPt();
 	break;
 
       case l1t::EtSum::EtSumType::kMinBiasHFM1:
-	mbm1 = eSum->hwPt();
+	mbm1 = eSum.hwPt();
 	break;
 
       case l1t::EtSum::EtSumType::kTowerCount:
-	ntow = eSum->hwPt();
+	ntow = eSum.hwPt();
 	break;
 
       default:

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EtSumAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EtSumAlgorithmFirmwareImp1.cc
@@ -49,7 +49,7 @@ void l1t::Stage2Layer2EtSumAlgorithmFirmwareImp1::processEvent(const std::vector
     int32_t etem(0);
     uint32_t mb0(0), mb1(0);
 
-    bool ecalSat(0), hcalSat(0);
+    bool ettSat(0), ettHFSat(0), ecalEtSat(0), metSat(0), metHFSat(0);
 
     for (unsigned absieta=1; absieta<=(uint)CaloTools::mpEta(CaloTools::kHFEnd); absieta++) {
 
@@ -108,44 +108,44 @@ void l1t::Stage2Layer2EtSumAlgorithmFirmwareImp1::processEvent(const std::vector
 
         l1t::CaloTower tower = l1t::CaloTools::getTower(towers, CaloTools::caloEta(ieta), iphi);
 
-	//ecal, hcal and tower saturation check
-	if(tower.hwPt()==509) hcalSat=true;
-	if(tower.hwPt()==510) ecalSat=true;
-	if(tower.hwPt()==511){
-	  hcalSat=true;
-	  ecalSat=true;
-	}
-
 
 	// MET without HF
 
-	if (tower.hwPt()>towEtMetThresh_ && CaloTools::mpEta(abs(tower.hwEta()))<=CaloTools::mpEta(metEtaMax_)) {
+	if (tower.hwPt()>towEtMetThresh_ && CaloTools::mpEta(abs(tower.hwEta()))<=CaloTools::mpEta(metEtaMax_) && !metSat) {
 
 	  // x- and -y coefficients are truncated by after multiplication of Et by trig coefficient.
 	  // The trig coefficients themselves take values [-1023,1023] and so were scaled by
 	  // 2^10 = 1024, which requires bitwise shift to the right of the final value by 10 bits.
 	  // This is accounted for at ouput of demux (see Stage2Layer2DemuxSumsAlgoFirmwareImp1.cc)
+	  if(tower.hwPt() == CaloTools::kSatHcal || tower.hwPt() == CaloTools::kSatEcal || tower.hwPt() == CaloTools::kSatTower) metSat=true;
 	  ringEx += (int32_t) (tower.hwPt() * CaloTools::cos_coeff[iphi - 1] );
 	  ringEy += (int32_t) (tower.hwPt() * CaloTools::sin_coeff[iphi - 1] );	    
 	}
 
 	// MET *with* HF
-	if (tower.hwPt()>towEtMetThresh_ && CaloTools::mpEta(abs(tower.hwEta()))<=CaloTools::mpEta(metEtaMaxHF_)) {
+	if (tower.hwPt()>towEtMetThresh_ && CaloTools::mpEta(abs(tower.hwEta()))<=CaloTools::mpEta(metEtaMaxHF_) && !metHFSat) {
+	  if(tower.hwPt() == CaloTools::kSatHcal || tower.hwPt() == CaloTools::kSatEcal || tower.hwPt() == CaloTools::kSatTower) metHFSat=true;
 	  ringExHF += (int32_t) (tower.hwPt() * CaloTools::cos_coeff[iphi - 1] );
 	  ringEyHF += (int32_t) (tower.hwPt() * CaloTools::sin_coeff[iphi - 1] );	    
 	}
 
 	// scalar sum
-	if (tower.hwPt()>towEtSumEtThresh_ && CaloTools::mpEta(abs(tower.hwEta()))<=CaloTools::mpEta(ettEtaMax_)) 
+	if (tower.hwPt()>towEtSumEtThresh_ && CaloTools::mpEta(abs(tower.hwEta()))<=CaloTools::mpEta(ettEtaMax_) && !ettSat){
+	  if(tower.hwPt() == CaloTools::kSatHcal || tower.hwPt() == CaloTools::kSatEcal || tower.hwPt() == CaloTools::kSatTower) ettSat=true;
 	  ringEt += tower.hwPt();
+	}
   
 	// scalar sum including HF
-	if (tower.hwPt()>towEtSumEtThresh_ && CaloTools::mpEta(abs(tower.hwEta()))<=CaloTools::mpEta(ettEtaMaxHF_)) 
+	if (tower.hwPt()>towEtSumEtThresh_ && CaloTools::mpEta(abs(tower.hwEta()))<=CaloTools::mpEta(ettEtaMaxHF_) && !ettHFSat) {
+	  if(tower.hwPt() == CaloTools::kSatHcal || tower.hwPt() == CaloTools::kSatEcal || tower.hwPt() == CaloTools::kSatTower) ettHFSat=true;
 	  ringEtHF += tower.hwPt();
-		
+	}
+	
         // scalar sum (EM)
-        if (tower.hwPt()>towEtEcalSumThresh_ && CaloTools::mpEta(abs(tower.hwEta()))<=ettEtaMax_)
+        if (tower.hwPt()>towEtEcalSumThresh_ && CaloTools::mpEta(abs(tower.hwEta()))<=CaloTools::mpEta(ettEtaMax_) && !ecalEtSat){
+	  if(tower.hwPt() == CaloTools::kSatEcal || tower.hwPt() == CaloTools::kSatTower) ecalEtSat=true;
           ringEtEm += tower.hwEtEm();
+	}
 
 	// count HF tower HCAL flags
 	if (CaloTools::mpEta(abs(tower.hwEta()))>=CaloTools::mpEta(CaloTools::kHFBegin) &&
@@ -179,17 +179,18 @@ void l1t::Stage2Layer2EtSumAlgorithmFirmwareImp1::processEvent(const std::vector
 
     // saturate energy sums if saturated TP/tower
 
-    if(ecalSat) etem = 0xffff;
-
-    if(ecalSat || hcalSat){
-      et = 0xffff;
+    if(ecalEtSat) etem = 0xffff;
+    if(ettSat) et = 0xffff;
+    if(ettHFSat) etHF = 0xffff;
+    if(metSat){ 
       ex = 0x7fffffff;
       ey = 0x7fffffff;
-      etHF = 0xffff;
+    }
+    if(metHFSat){
       exHF = 0x7fffffff;
       eyHF = 0x7fffffff;
     }
-
+    
     l1t::EtSum etSumTotalEt(p4,l1t::EtSum::EtSumType::kTotalEt,et,0,0,0);
     l1t::EtSum etSumEx(p4,l1t::EtSum::EtSumType::kTotalEtx,ex,0,0,0);
     l1t::EtSum etSumEy(p4,l1t::EtSum::EtSumType::kTotalEty,ey,0,0,0);

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EtSumAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EtSumAlgorithmFirmwareImp1.cc
@@ -32,26 +32,26 @@ l1t::Stage2Layer2EtSumAlgorithmFirmwareImp1::~Stage2Layer2EtSumAlgorithmFirmware
 void l1t::Stage2Layer2EtSumAlgorithmFirmwareImp1::processEvent(const std::vector<l1t::CaloTower> & towers,
                                                                std::vector<l1t::EtSum> & etsums) {
 
-  uint32_t ntowers(0);
+  unsigned int ntowers(0);
   math::XYZTLorentzVector p4;
   
   int nTT4 = CaloTools::calNrTowers(-1*params_->egPUSParam(1),
 				    params_->egPUSParam(1),
 				    1,72,towers,1+params_->pileUpTowerThreshold(),999,CaloTools::CALO);
-  uint compNTT4 = params_->egCompressShapesLUT()->data((0x1<<7)+(0x1<<8)+(0x1<<5)+nTT4);
+  unsigned int compNTT4 = params_->egCompressShapesLUT()->data((0x1<<7)+(0x1<<8)+(0x1<<5)+nTT4);
 
 
   // etaSide=1 is positive eta, etaSide=-1 is negative eta
   for (int etaSide=1; etaSide>=-1; etaSide-=2) {
 
-    int32_t ex(0), ey(0), et(0);
-    int32_t exHF(0), eyHF(0), etHF(0);
-    int32_t etem(0);
-    uint32_t mb0(0), mb1(0);
+    int ex(0), ey(0), et(0);
+    int exHF(0), eyHF(0), etHF(0);
+    int etem(0);
+    unsigned int mb0(0), mb1(0);
 
     bool ettSat(0), ettHFSat(0), ecalEtSat(0), metSat(0), metHFSat(0);
 
-    for (unsigned absieta=1; absieta<=(uint)CaloTools::mpEta(CaloTools::kHFEnd); absieta++) {
+    for (unsigned absieta=1; absieta<=(unsigned int)CaloTools::mpEta(CaloTools::kHFEnd); absieta++) {
 
       int ieta = etaSide * absieta;
       
@@ -61,7 +61,7 @@ void l1t::Stage2Layer2EtSumAlgorithmFirmwareImp1::processEvent(const std::vector
 
       if(!params_->etSumBypassMetPUS()){
 	if(params_->etSumMetPUSType() == "LUT"){
-	  uint towEtMetLUTAddr = (compNTT4<<6) | (abs(ieta));
+	  unsigned int towEtMetLUTAddr = (compNTT4<<6) | (abs(ieta));
 	  if(abs(ieta)<13) towEtMetLUTAddr = abs(ieta);
 	  towEtMetThresh_ = params_->etSumMetPUSLUT()->data(towEtMetLUTAddr);
 	} else {
@@ -74,7 +74,7 @@ void l1t::Stage2Layer2EtSumAlgorithmFirmwareImp1::processEvent(const std::vector
       
       if(!params_->etSumBypassEttPUS()){
 	if(params_->etSumEttPUSType() == "LUT"){
-	  uint towEtSumEtLUTAddr = (compNTT4<<6) | (abs(ieta));
+	  unsigned int towEtSumEtLUTAddr = (compNTT4<<6) | (abs(ieta));
 	  if(abs(ieta)<13) towEtSumEtLUTAddr = abs(ieta);
 	  towEtSumEtThresh_ = params_->etSumEttPUSLUT()->data(towEtSumEtLUTAddr);
 	} else {
@@ -87,7 +87,7 @@ void l1t::Stage2Layer2EtSumAlgorithmFirmwareImp1::processEvent(const std::vector
       
       if(!params_->etSumBypassEcalSumPUS()){
 	if(params_->etSumEcalSumPUSType() == "LUT"){
-	  uint towEtEcalSumLUTAddr = (compNTT4<<6) | (abs(ieta));
+	  unsigned int towEtEcalSumLUTAddr = (compNTT4<<6) | (abs(ieta));
 	  if(abs(ieta)<13) towEtEcalSumLUTAddr = abs(ieta);
 	  towEtEcalSumThresh_ = params_->etSumEcalSumPUSLUT()->data(towEtEcalSumLUTAddr);
 	} else {
@@ -98,11 +98,11 @@ void l1t::Stage2Layer2EtSumAlgorithmFirmwareImp1::processEvent(const std::vector
 	}
       }
       
-      int32_t ringEx(0), ringEy(0), ringEt(0);
-      int32_t ringExHF(0), ringEyHF(0), ringEtHF(0);
-      int32_t ringEtEm(0);
-      uint32_t ringMB0(0), ringMB1(0);
-      uint32_t ringNtowers(0);
+      int ringEx(0), ringEy(0), ringEt(0);
+      int ringExHF(0), ringEyHF(0), ringEtHF(0);
+      int ringEtEm(0);
+      unsigned int ringMB0(0), ringMB1(0);
+      unsigned int ringNtowers(0);
 
       for (int iphi=1; iphi<=CaloTools::kHBHENrPhi; iphi++) {
 
@@ -118,15 +118,15 @@ void l1t::Stage2Layer2EtSumAlgorithmFirmwareImp1::processEvent(const std::vector
 	  // 2^10 = 1024, which requires bitwise shift to the right of the final value by 10 bits.
 	  // This is accounted for at ouput of demux (see Stage2Layer2DemuxSumsAlgoFirmwareImp1.cc)
 	  if(tower.hwPt() == CaloTools::kSatHcal || tower.hwPt() == CaloTools::kSatEcal || tower.hwPt() == CaloTools::kSatTower) metSat=true;
-	  ringEx += (int32_t) (tower.hwPt() * CaloTools::cos_coeff[iphi - 1] );
-	  ringEy += (int32_t) (tower.hwPt() * CaloTools::sin_coeff[iphi - 1] );	    
+	  ringEx += (int) (tower.hwPt() * CaloTools::cos_coeff[iphi - 1] );
+	  ringEy += (int) (tower.hwPt() * CaloTools::sin_coeff[iphi - 1] );	    
 	}
 
 	// MET *with* HF
 	if (tower.hwPt()>towEtMetThresh_ && CaloTools::mpEta(abs(tower.hwEta()))<=CaloTools::mpEta(metEtaMaxHF_) && !metHFSat) {
 	  if(tower.hwPt() == CaloTools::kSatHcal || tower.hwPt() == CaloTools::kSatEcal || tower.hwPt() == CaloTools::kSatTower) metHFSat=true;
-	  ringExHF += (int32_t) (tower.hwPt() * CaloTools::cos_coeff[iphi - 1] );
-	  ringEyHF += (int32_t) (tower.hwPt() * CaloTools::sin_coeff[iphi - 1] );	    
+	  ringExHF += (int) (tower.hwPt() * CaloTools::cos_coeff[iphi - 1] );
+	  ringEyHF += (int) (tower.hwPt() * CaloTools::sin_coeff[iphi - 1] );	    
 	}
 
 	// scalar sum

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
@@ -57,7 +57,7 @@ void l1t::Stage2Layer2JetAlgorithmFirmwareImp1::processEvent(const std::vector<l
   create(towers, jets, alljets, params_->jetPUSType());
 
   // calibrate all jets
-  calibrate(alljets, 0); // pass all jets and the hw threshold above which to calibrate
+  calibrate(alljets, 0, true); // pass all jets and the hw threshold above which to calibrate
 
   // jets accumulated sort
   accuSort(jets);
@@ -172,7 +172,7 @@ void l1t::Stage2Layer2JetAlgorithmFirmwareImp1::create(const std::vector<l1t::Ca
 	    if (iEt<=0) continue;
 
 	    // if tower Et is saturated, saturate jet Et
-	    if (seedEt >= 509) iEt = 65535;
+	    if (seedEt == CaloTools::kSatHcal || seedEt == CaloTools::kSatEcal || seedEt == CaloTools::kSatTower) iEt = CaloTools::kSatJet;
 
 	    jet.setHwPt(iEt);
 	    jet.setRawEt( (short int) rawEt);
@@ -190,7 +190,7 @@ void l1t::Stage2Layer2JetAlgorithmFirmwareImp1::create(const std::vector<l1t::Ca
 	}
 
 	 // jet energy corrections
-	calibrate(jetsRing, 0); // pass the jet collection and the hw threshold above which to calibrate
+	calibrate(jetsRing, 0, false); // pass the jet collection and the hw threshold above which to calibrate
 
 	// sort these jets and keep top 6
 	start_ = jetsRing.begin();  
@@ -380,7 +380,7 @@ int l1t::Stage2Layer2JetAlgorithmFirmwareImp1::chunkyDonutPUEstimate(l1t::Jet & 
       const CaloTower& towPhiDown = CaloTools::getTower(towers, CaloTools::caloEta(towEta), iphiDown);
       towEt = towPhiDown.hwPt();
       ring[1] += towEt;
-            
+
     } 
     
     // do EtaUp
@@ -394,13 +394,10 @@ int l1t::Stage2Layer2JetAlgorithmFirmwareImp1::chunkyDonutPUEstimate(l1t::Jet & 
         const CaloTower& towEtaUp = CaloTools::getTower(towers, CaloTools::caloEta(ietaUp), towPhi);
         int towEt = towEtaUp.hwPt();
         ring[2] += towEt;
-      }else{
-        ring[2] = 0;
-        break;
       }
-      
-    } 
-    
+
+    }
+
     // do EtaDown
     for (int iphi=jetPhi-size+1; iphi<jetPhi+size; ++iphi) {
       
@@ -412,16 +409,13 @@ int l1t::Stage2Layer2JetAlgorithmFirmwareImp1::chunkyDonutPUEstimate(l1t::Jet & 
         const CaloTower& towEtaDown = CaloTools::getTower(towers, CaloTools::caloEta(ietaDown), towPhi);
         int towEt = towEtaDown.hwPt();
         ring[3] += towEt;
-      }else{
-        ring[3] = 0;
-        break;
       }
-      
+     
     }     
     
     
   }
-  
+    
   // for donut subtraction we only use the middle 2 (in energy) ring strips
   // std::sort(ring.begin(), ring.end(), std::greater<int>());
   // return ( ring[1]+ring[2] ); 
@@ -429,15 +423,15 @@ int l1t::Stage2Layer2JetAlgorithmFirmwareImp1::chunkyDonutPUEstimate(l1t::Jet & 
   // use lowest 3 strips as PU estimate
   std::sort( ring.begin(), ring.end() );
   
-  for(uint i=0; i<4; ++i)    jet.setPUDonutEt(i, (short int) ring[i]);
-    
+  for(uint i=0; i<4; ++i) jet.setPUDonutEt(i, (short int) ring[i]);
+
   return ( ring[0] + ring[1] + ring[2] );
   
 }
 
 
 
-void l1t::Stage2Layer2JetAlgorithmFirmwareImp1::calibrate(std::vector<l1t::Jet> & jets, int calibThreshold) {
+void l1t::Stage2Layer2JetAlgorithmFirmwareImp1::calibrate(std::vector<l1t::Jet> & jets, int calibThreshold, bool isAllJets) {
 
   if( params_->jetCalibrationType() == "function6PtParams22EtaBins" ){ //One eta bin per region
 
@@ -556,6 +550,9 @@ void l1t::Stage2Layer2JetAlgorithmFirmwareImp1::calibrate(std::vector<l1t::Jet> 
 
       //Check jet is above the calibration threshold, if not do nothing
       if(jet->hwPt() < calibThreshold) continue;
+      
+      //don't calibrate saturated jets for HT
+      if( isAllJets && (jet->hwPt() == CaloTools::kSatJet) ) continue;
 
       // In the firmware, we take bits 1 to 8 of the hwPt.
       // To avoid getting nonsense by only taking smaller bits,

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
@@ -423,7 +423,7 @@ int l1t::Stage2Layer2JetAlgorithmFirmwareImp1::chunkyDonutPUEstimate(l1t::Jet & 
   // use lowest 3 strips as PU estimate
   std::sort( ring.begin(), ring.end() );
   
-  for(uint i=0; i<4; ++i) jet.setPUDonutEt(i, (short int) ring[i]);
+  for(unsigned int i=0; i<4; ++i) jet.setPUDonutEt(i, (short int) ring[i]);
 
   return ( ring[0] + ring[1] + ring[2] );
   

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetSumAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetSumAlgorithmFirmwareImp1.cc
@@ -36,6 +36,8 @@ void l1t::Stage2Layer2JetSumAlgorithmFirmwareImp1::processEvent(const std::vecto
 
     int32_t hx(0), hy(0), ht(0);
     int32_t hxHF(0), hyHF(0), htHF(0);
+
+    bool satMht(0), satMhtHF(0), satHt(0), satHtHF(0);
   
     // loop over rings    
     for (unsigned absieta=1; absieta<=(uint)CaloTools::mpEta(CaloTools::kHFEnd); absieta++) {
@@ -66,19 +68,32 @@ void l1t::Stage2Layer2JetSumAlgorithmFirmwareImp1::processEvent(const std::vecto
 		  // (see Stage2Layer2DemuxSumsAlgoFirmwareImp1.cc)
 
 		if (thisJet.hwPt()>mhtJetThresholdHw_ && CaloTools::mpEta(abs(thisJet.hwEta()))<=CaloTools::mpEta(mhtEtaMax_)) {
-		  ringHx += (int32_t) (( thisJet.hwPt() * CaloTools::cos_coeff[iphi - 1] ) >> 4 );
-		  ringHy += (int32_t) (( thisJet.hwPt() * CaloTools::sin_coeff[iphi - 1] ) >> 4 );
+		  if(thisJet.hwPt()==CaloTools::kSatJet){
+		    satMht=true;
+		    satMhtHF=true;
+		  }else{
+		    ringHx += (int32_t) (( thisJet.hwPt() * CaloTools::cos_coeff[iphi - 1] ) >> 4 );
+		    ringHy += (int32_t) (( thisJet.hwPt() * CaloTools::sin_coeff[iphi - 1] ) >> 4 );
+		  }
 		}
 		if (thisJet.hwPt()>mhtJetThresholdHw_ && CaloTools::mpEta(abs(thisJet.hwEta()))<=CaloTools::mpEta(mhtEtaMaxHF_)) {
-		  ringHxHF += (int32_t) (( thisJet.hwPt() * CaloTools::cos_coeff[iphi - 1] ) >> 4 );
-		  ringHyHF += (int32_t) (( thisJet.hwPt() * CaloTools::sin_coeff[iphi - 1] ) >> 4 );
+		  if(thisJet.hwPt()==CaloTools::kSatJet) satMhtHF=true;
+		  else{
+		    ringHxHF += (int32_t) (( thisJet.hwPt() * CaloTools::cos_coeff[iphi - 1] ) >> 4 );
+		    ringHyHF += (int32_t) (( thisJet.hwPt() * CaloTools::sin_coeff[iphi - 1] ) >> 4 );
+		  }
 		}
 		
 		if (thisJet.hwPt()>httJetThresholdHw_ && CaloTools::mpEta(abs(thisJet.hwEta()))<=CaloTools::mpEta(httEtaMax_)) {
-		  ringHt += thisJet.hwPt();
+		  if(thisJet.hwPt()==CaloTools::kSatJet){
+		    satHt=true;
+		    satHtHF=true;
+		  }
+		  else ringHt += thisJet.hwPt();
 		}
 		if (thisJet.hwPt()>httJetThresholdHw_ && CaloTools::mpEta(abs(thisJet.hwEta()))<=CaloTools::mpEta(httEtaMaxHF_)) {
-		  ringHtHF += thisJet.hwPt();
+		  if(thisJet.hwPt()==CaloTools::kSatJet) satHtHF=true;
+		  else ringHtHF += thisJet.hwPt();
 		}
       }
 
@@ -92,9 +107,18 @@ void l1t::Stage2Layer2JetSumAlgorithmFirmwareImp1::processEvent(const std::vecto
 
     }
 
-    if(ht>65535) ht=65535; // ht saturation
-    
+    if(satHt) ht = 0xffff;
+    if(satHtHF) htHF = 0xffff;
 
+    if(satMht){ 
+      hx = 0x7fffffff;
+      hy = 0x7fffffff;
+    }
+    if(satMhtHF){
+      hxHF = 0x7fffffff;
+      hyHF = 0x7fffffff;
+    }
+    
     math::XYZTLorentzVector p4;
     
     l1t::EtSum htSumHt(p4,l1t::EtSum::EtSumType::kTotalHt,ht,0,0,0);

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetSumAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetSumAlgorithmFirmwareImp1.cc
@@ -34,18 +34,18 @@ void l1t::Stage2Layer2JetSumAlgorithmFirmwareImp1::processEvent(const std::vecto
   // etaSide=1 is positive eta, etaSide=-1 is negative eta
   for (int etaSide=1; etaSide>=-1; etaSide-=2) {
 
-    int32_t hx(0), hy(0), ht(0);
-    int32_t hxHF(0), hyHF(0), htHF(0);
+    int hx(0), hy(0), ht(0);
+    int hxHF(0), hyHF(0), htHF(0);
 
     bool satMht(0), satMhtHF(0), satHt(0), satHtHF(0);
   
     // loop over rings    
-    for (unsigned absieta=1; absieta<=(uint)CaloTools::mpEta(CaloTools::kHFEnd); absieta++) {
+    for (unsigned absieta=1; absieta<=(unsigned int)CaloTools::mpEta(CaloTools::kHFEnd); absieta++) {
 
       int ieta = etaSide * absieta;
 
-      int32_t ringHx(0), ringHy(0), ringHt(0); 
-      int32_t ringHxHF(0), ringHyHF(0), ringHtHF(0); 
+      int ringHx(0), ringHy(0), ringHt(0); 
+      int ringHxHF(0), ringHyHF(0), ringHtHF(0); 
       
       // loop over phi
       for (int iphi=1; iphi<=CaloTools::kHBHENrPhi; iphi++) {
@@ -72,15 +72,15 @@ void l1t::Stage2Layer2JetSumAlgorithmFirmwareImp1::processEvent(const std::vecto
 		    satMht=true;
 		    satMhtHF=true;
 		  }else{
-		    ringHx += (int32_t) (( thisJet.hwPt() * CaloTools::cos_coeff[iphi - 1] ) >> 4 );
-		    ringHy += (int32_t) (( thisJet.hwPt() * CaloTools::sin_coeff[iphi - 1] ) >> 4 );
+		    ringHx += (int) (( thisJet.hwPt() * CaloTools::cos_coeff[iphi - 1] ) >> 4 );
+		    ringHy += (int) (( thisJet.hwPt() * CaloTools::sin_coeff[iphi - 1] ) >> 4 );
 		  }
 		}
 		if (thisJet.hwPt()>mhtJetThresholdHw_ && CaloTools::mpEta(abs(thisJet.hwEta()))<=CaloTools::mpEta(mhtEtaMaxHF_)) {
 		  if(thisJet.hwPt()==CaloTools::kSatJet) satMhtHF=true;
 		  else{
-		    ringHxHF += (int32_t) (( thisJet.hwPt() * CaloTools::cos_coeff[iphi - 1] ) >> 4 );
-		    ringHyHF += (int32_t) (( thisJet.hwPt() * CaloTools::sin_coeff[iphi - 1] ) >> 4 );
+		    ringHxHF += (int) (( thisJet.hwPt() * CaloTools::cos_coeff[iphi - 1] ) >> 4 );
+		    ringHyHF += (int) (( thisJet.hwPt() * CaloTools::sin_coeff[iphi - 1] ) >> 4 );
 		  }
 		}
 		

--- a/L1Trigger/L1TCalorimeter/test/runEmulator-CaloStage2.py
+++ b/L1Trigger/L1TCalorimeter/test/runEmulator-CaloStage2.py
@@ -121,7 +121,7 @@ process.simCaloStage2Layer1Digis.ecalToken = cms.InputTag("ecalDigis:EcalTrigger
 process.simCaloStage2Layer1Digis.hcalToken = cms.InputTag("hcalDigis")
 
 # emulator ES
-process.load('L1Trigger.L1TCalorimeter.caloStage2Params_2017_v1_7_cfi')
+process.load('L1Trigger.L1TCalorimeter.caloStage2Params_2017_v1_8_2_updateHFSF_v6MET_cfi')
 
 # histograms
 process.load('L1Trigger.L1TCalorimeter.l1tStage2CaloAnalyzer_cfi')


### PR DESCRIPTION
pr93x CaloSaturations-at-P5

Small fixes to jets & sums saturation. 
- Now HT, MHT saturate in the same way as MET corresponding to fw
- Don't calibrate saturated jets for HT.
- Now use 0 instead of 111 as default MHT phi value when the MHT == 0.