### PR TITLE
Cleanup Geant4 sensitive detectors 

### DIFF
--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -54,8 +54,8 @@ public:
          edm::ParameterSet const & p, const SimTrackManager*,
 	 float timeSlice=1., bool ignoreTkID=false);
   virtual ~CaloSD();
-  virtual bool     ProcessHits(G4Step * step,G4TouchableHistory * tHistory);
-  virtual bool     ProcessHits(G4GFlashSpot*aSpot,G4TouchableHistory*);
+  virtual bool     ProcessHits(G4Step * step, G4TouchableHistory * tHistory);
+  virtual bool     ProcessHits(G4GFlashSpot*aSpot, G4TouchableHistory*);
   virtual double   getEnergyDeposit(G4Step* step); 
   virtual uint32_t setDetUnitId(G4Step* step)=0;
   
@@ -116,6 +116,7 @@ protected:
 
   CaloHitID                       currentID, previousID; 
   G4Track*                        theTrack;
+  G4TouchableHistory*             theTouchableHistory;
 
   G4StepPoint*                    preStepPoint; 
   float                           edepositEM, edepositHAD;
@@ -126,7 +127,7 @@ protected:
 
   const SimTrackManager*          m_trackManager;
   CaloG4Hit*                      currentHit;
-//  TimerProxy                    theHitTimer;
+  //  TimerProxy                    theHitTimer;
   bool                            runInit;
 
   bool                            corrTOFBeam, suppressHeavy;

--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -55,7 +55,7 @@ public:
 	 float timeSlice=1., bool ignoreTkID=false);
   virtual ~CaloSD();
   virtual bool     ProcessHits(G4Step * step, G4TouchableHistory * tHistory);
-  virtual bool     ProcessHits(G4GFlashSpot*aSpot, G4TouchableHistory*);
+  virtual bool     ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*);
   virtual double   getEnergyDeposit(G4Step* step); 
   virtual uint32_t setDetUnitId(G4Step* step)=0;
   

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -224,10 +224,10 @@ void CaloSD::EndOfEvent(G4HCofThisEvent* ) {
   
   cleanHitCollection();
   
+#ifdef DebugLog
   edm::LogInfo("CaloSim") << "CaloSD: EndofEvent entered with " << theHC->entries()
                           << " entries";
-
-  //  TimeMe("CaloSD:sortAndMergeHits",false);
+#endif
 }
 
 void CaloSD::clear() {} 

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -111,21 +111,21 @@ CaloSD::CaloSD(G4String name, const DDCompactView & cpv,
 }
 
 CaloSD::~CaloSD() { 
-  if (slave)           delete slave; 
-  if (theHC)           delete theHC;
-  if (meanResponse)    delete meanResponse;
+  delete slave; 
+  delete theHC;
+  delete meanResponse;
 }
 
 bool CaloSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
   
-  NaNTrap( aStep ) ;
-  
-  if (aStep == NULL) {
-    return true;
-  } else {
+  // do not make any computation withou energy deposition
+  if(aStep->GetTotalEnergyDeposit() > 0.) {
+
+    NaNTrap(aStep);
     if (getStepInfo(aStep)) {
-      if (hitExists() == false && edepositEM+edepositHAD>0.) 
+      if (hitExists() == false && edepositEM+edepositHAD>0.) {
         currentHit = createNewHit();
+      }
     }
   }
   return true;

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -123,22 +123,16 @@ CaloSD::~CaloSD() {
 
 bool CaloSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
   
-  // do not make any computation without energy deposition
-  if(aStep->GetTotalEnergyDeposit() > 0.) {
-
-    NaNTrap(aStep);
-    if (getStepInfo(aStep)) {
-      if (hitExists() == false && edepositEM+edepositHAD>0.) {
-        currentHit = createNewHit();
-      }
-    }
+  NaNTrap(aStep);
+  if(getStepInfo(aStep) && hitExists() == false && edepositEM+edepositHAD>0.f) {
+    currentHit = createNewHit();
   }
   return true;
 } 
 
 bool CaloSD::ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) { 
 
-  if (aSpot != NULL) {   
+  if (aSpot != nullptr) {   
     theTrack = const_cast<G4Track *>(aSpot->GetOriginatorTrack()->GetPrimaryTrack());
     G4int particleCode = theTrack->GetDefinition()->GetPDGEncoding();
     

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -260,19 +260,17 @@ bool CaloSD::getStepInfo(G4Step* aStep) {
     currentID.setID(unitID, time, primaryID, depth);
 
 #ifdef DebugLog
-    G4TouchableHistory* touch =(G4TouchableHistory*)(theTrack->GetTouchable());
     edm::LogInfo("CaloSim") << "CaloSD:: GetStepInfo for"
-			    << " PV "     << touch->GetVolume(0)->GetName()
-			    << " PVid = " << touch->GetReplicaNumber(0)
-			    << " MVid = " << touch->GetReplicaNumber(1)
+			    << " PV "     << theTouchableHistory->GetVolume(0)->GetName()
+			    << " PVid = " << theTouchableHistory->GetReplicaNumber(0)
+			    << " MVid = " << theTouchableHistory->GetReplicaNumber(1)
 			    << " Unit   " << currentID.unitID() 
 			    << " Edeposit = " << aStep->GetTotalEnergyDeposit();
   } else {
-    G4TouchableHistory* touch =(G4TouchableHistory*)(theTrack->GetTouchable());
     edm::LogInfo("CaloSim") << "CaloSD:: GetStepInfo for"
-			    << " PV "     << touch->GetVolume(0)->GetName()
-			    << " PVid = " << touch->GetReplicaNumber(0)
-			    << " MVid = " << touch->GetReplicaNumber(1)
+			    << " PV "     << theTouchableHistory->GetVolume(0)->GetName()
+			    << " PVid = " << theTouchableHistory->GetReplicaNumber(0)
+			    << " MVid = " << theTouchableHistory->GetReplicaNumber(1)
 			    << " Unit   " << std::hex << unitID << std::dec;
 #endif
   }
@@ -431,7 +429,7 @@ CaloG4Hit* CaloSD::createNewHit() {
     }
   }
   primIDSaved = currentID.trackID();
-  if (useMap) totalHits++;
+  if (useMap) ++totalHits;
   return aHit;
 }  
 

--- a/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
+++ b/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
@@ -63,7 +63,7 @@ private:
   int          side;
 
   /// Table of Cherenkov angle integrals vs photon momentum
-  std::auto_ptr<G4PhysicsOrderedFreeVector> chAngleIntegrals_;
+  std::unique_ptr<G4PhysicsOrderedFreeVector> chAngleIntegrals_;
   G4MaterialPropertiesTable*                materialPropertiesTable;
   // Histogramming
   TTree* ntuple_;

--- a/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
+++ b/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
@@ -522,7 +522,7 @@ bool DreamSD::setPbWO2MaterialProperties_( G4Material* aMaterial ) {
   // Calculate Cherenkov angle integrals: 
   // This is an ad-hoc solution (we hold it in the class, not in the material)
   chAngleIntegrals_ = 
-    std::auto_ptr<G4PhysicsOrderedFreeVector>( new G4PhysicsOrderedFreeVector() );
+    std::unique_ptr<G4PhysicsOrderedFreeVector>( new G4PhysicsOrderedFreeVector() );
 
   int index = 0;
   double currentRI = RefractiveIndex[index];

--- a/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
+++ b/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
@@ -521,8 +521,7 @@ bool DreamSD::setPbWO2MaterialProperties_( G4Material* aMaterial ) {
 
   // Calculate Cherenkov angle integrals: 
   // This is an ad-hoc solution (we hold it in the class, not in the material)
-  chAngleIntegrals_ = 
-    std::unique_ptr<G4PhysicsOrderedFreeVector>( new G4PhysicsOrderedFreeVector() );
+  chAngleIntegrals_ = std::make_unique<G4PhysicsOrderedFreeVector>();
 
   int index = 0;
   double currentRI = RefractiveIndex[index];

--- a/SimG4Core/Geometry/src/DDDWorld.cc
+++ b/SimG4Core/Geometry/src/DDDWorld.cc
@@ -15,7 +15,7 @@ DDDWorld::DDDWorld(const DDCompactView* cpv,
 		   SensitiveDetectorCatalog & catalog,
 		   bool check) {
 
-  std::auto_ptr<DDG4Builder> theBuilder(new DDG4Builder(cpv, check));
+  std::unique_ptr<DDG4Builder> theBuilder(new DDG4Builder(cpv, check));
 
   DDGeometryReturnType ret = theBuilder->BuildGeometry();
   G4LogicalVolume *    world = ret.logicalVolume();

--- a/SimG4Core/Geometry/src/DDDWorld.cc
+++ b/SimG4Core/Geometry/src/DDDWorld.cc
@@ -8,15 +8,12 @@
 #include "G4PVPlacement.hh"
 #include "G4TransportationManager.hh"
  
-using namespace edm;
-
 DDDWorld::DDDWorld(const DDCompactView* cpv, 
 		   G4LogicalVolumeToDDLogicalPartMap & map,
 		   SensitiveDetectorCatalog & catalog,
 		   bool check) {
 
-  std::unique_ptr<DDG4Builder> theBuilder(new DDG4Builder(cpv, check));
-
+  auto theBuilder = std::make_unique<DDG4Builder>(cpv, check);
   DDGeometryReturnType ret = theBuilder->BuildGeometry();
   G4LogicalVolume *    world = ret.logicalVolume();
 

--- a/SimG4Core/GeometryProducer/interface/GeometryProducer.h
+++ b/SimG4Core/GeometryProducer/interface/GeometryProducer.h
@@ -53,8 +53,8 @@ private:
     SimActivityRegistry m_registry;
     std::vector<std::shared_ptr<SimWatcher> > m_watchers;
     std::vector<std::shared_ptr<SimProducer> > m_producers;
-    std::auto_ptr<sim::FieldBuilder> m_fieldBuilder;
-    std::auto_ptr<SimTrackManager> m_trackManager;
+    std::unique_ptr<sim::FieldBuilder> m_fieldBuilder;
+    std::unique_ptr<SimTrackManager> m_trackManager;
     AttachSD * m_attach;
     std::vector<SensitiveTkDetector*> m_sensTkDets;
     std::vector<SensitiveCaloDetector*> m_sensCaloDets;

--- a/SimG4Core/GeometryProducer/interface/GeometryProducer.h
+++ b/SimG4Core/GeometryProducer/interface/GeometryProducer.h
@@ -55,7 +55,7 @@ private:
     std::vector<std::shared_ptr<SimProducer> > m_producers;
     std::unique_ptr<sim::FieldBuilder> m_fieldBuilder;
     std::unique_ptr<SimTrackManager> m_trackManager;
-    AttachSD * m_attach;
+    std::unique_ptr<AttachSD> m_attach;
     std::vector<SensitiveTkDetector*> m_sensTkDets;
     std::vector<SensitiveCaloDetector*> m_sensCaloDets;
     edm::ParameterSet m_p;

--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -63,8 +63,11 @@ GeometryProducer::GeometryProducer(edm::ParameterSet const & p) :
     m_pUseMagneticField(p.getParameter<bool>("UseMagneticField")),
     m_pField(p.getParameter<edm::ParameterSet>("MagneticField")), 
     m_pUseSensitiveDetectors(p.getParameter<bool>("UseSensitiveDetectors")),
-    m_attach(nullptr), m_p(p), m_firstRun ( true )
+    m_p(p), m_firstRun ( true )
 {
+    m_trackManager = std::unique_ptr<SimTrackManager>(new SimTrackManager);
+    m_attach = std::unique_ptr<AttachSD>(new AttachSD);
+
     //Look for an outside SimActivityRegistry
     //this is used by the visualization code
     edm::Service<SimActivityRegistry> otherRegistry;
@@ -75,7 +78,6 @@ GeometryProducer::GeometryProducer(edm::ParameterSet const & p) :
 
 GeometryProducer::~GeometryProducer() 
 { 
-  delete m_attach;
   delete m_kernel; 
 }
 
@@ -134,8 +136,6 @@ void GeometryProducer::produce(edm::Event & e, const edm::EventSetup & es)
     {
        edm::LogInfo("GeometryProducer") << " instantiating sensitive detectors ";
        // instantiate and attach the sensitive detectors
-       m_trackManager = std::unique_ptr<SimTrackManager>(new SimTrackManager);
-       if (m_attach == nullptr) m_attach = new AttachSD;
        {
            std::pair< std::vector<SensitiveTkDetector*>,
                std::vector<SensitiveCaloDetector*> > 

--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -134,7 +134,7 @@ void GeometryProducer::produce(edm::Event & e, const edm::EventSetup & es)
     {
        edm::LogInfo("GeometryProducer") << " instantiating sensitive detectors ";
        // instantiate and attach the sensitive detectors
-       m_trackManager = std::auto_ptr<SimTrackManager>(new SimTrackManager);
+       m_trackManager = std::unique_ptr<SimTrackManager>(new SimTrackManager);
        if (m_attach==0) m_attach = new AttachSD;
        {
            std::pair< std::vector<SensitiveTkDetector*>,

--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -135,7 +135,7 @@ void GeometryProducer::produce(edm::Event & e, const edm::EventSetup & es)
        edm::LogInfo("GeometryProducer") << " instantiating sensitive detectors ";
        // instantiate and attach the sensitive detectors
        m_trackManager = std::unique_ptr<SimTrackManager>(new SimTrackManager);
-       if (m_attach==0) m_attach = new AttachSD;
+       if (m_attach == nullptr) m_attach = new AttachSD;
        {
            std::pair< std::vector<SensitiveTkDetector*>,
                std::vector<SensitiveCaloDetector*> > 

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
@@ -47,8 +47,7 @@ public:
     std::vector<std::string> temp;
     temp.push_back(name);
     return temp;
-  }
-  
+  }  
   void NaNTrap( G4Step* step ) ;
     
 private:

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
@@ -34,14 +34,17 @@ public:
   virtual void AssignSD(const std::string & vname);
   virtual void EndOfEvent(G4HCofThisEvent * eventHC); 
   enum coordinates {WorldCoordinates, LocalCoordinates};
-  Local3DPoint InitialStepPosition(G4Step * s, coordinates);
-  Local3DPoint FinalStepPosition(G4Step * s, coordinates);
-  Local3DPoint ConvertToLocal3DPoint(const G4ThreeVector& point);    
-  std::string nameOfSD() { return name; }
+  Local3DPoint InitialStepPosition(G4Step * step, coordinates);
+  Local3DPoint FinalStepPosition(G4Step * step, coordinates);
+  inline Local3DPoint ConvertToLocal3DPoint(const G4ThreeVector& point)
+  {
+    return Local3DPoint(point.x(),point.y(),point.z());
+  }    
+  inline std::string& nameOfSD() { return name; }
   virtual std::vector<std::string> getNames() 
   {
     std::vector<std::string> temp;
-    temp.push_back(nameOfSD());
+    temp.push_back(name);
     return temp;
   }
   
@@ -49,7 +52,6 @@ public:
     
 private:
   std::string name;
-  G4Step * currentStep;
 };
 
 #endif

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
@@ -38,7 +38,8 @@ public:
   Local3DPoint FinalStepPosition(G4Step * step, coordinates);
   inline Local3DPoint ConvertToLocal3DPoint(const G4ThreeVector& point)
   {
-    return Local3DPoint(point.x(),point.y(),point.z());
+    Local3DPoint res(point.x(),point.y(),point.z());
+    return std::move(res);
   }    
   inline std::string& nameOfSD() { return name; }
   virtual std::vector<std::string> getNames() 

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
@@ -45,7 +45,7 @@ class SensitiveDetectorMaker : public SensitiveDetectorMakerBase
 			std::unique_ptr<SensitiveTkDetector>& oTK,
 			std::unique_ptr<SensitiveCaloDetector>& oCalo) const
       {
-	std::unique_ptr<T> returnValue(new T(iname, cpv, clg, p, m));
+        auto returnValue  = std::make_unique<T>(iname, cpv, clg, p, m);
 	SimActivityRegistryEnroller::enroll(reg, returnValue.get());
 
 	this->convertTo(returnValue.get(), oTK,oCalo);

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMaker.h
@@ -42,10 +42,10 @@ class SensitiveDetectorMaker : public SensitiveDetectorMakerBase
 			const edm::ParameterSet& p,
 			const SimTrackManager* m,
 			SimActivityRegistry& reg,
-			std::auto_ptr<SensitiveTkDetector>& oTK,
-			std::auto_ptr<SensitiveCaloDetector>& oCalo) const
+			std::unique_ptr<SensitiveTkDetector>& oTK,
+			std::unique_ptr<SensitiveCaloDetector>& oCalo) const
       {
-	std::auto_ptr<T> returnValue(new T(iname, cpv, clg, p, m));
+	std::unique_ptr<T> returnValue(new T(iname, cpv, clg, p, m));
 	SimActivityRegistryEnroller::enroll(reg, returnValue.get());
 
 	this->convertTo(returnValue.get(), oTK,oCalo);

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetectorMakerBase.h
@@ -47,8 +47,8 @@ class SensitiveDetectorMakerBase
 			const edm::ParameterSet& p,
 			const SimTrackManager* m,
 			SimActivityRegistry& reg,
-			std::auto_ptr<SensitiveTkDetector>& oTK,
-			std::auto_ptr<SensitiveCaloDetector>& oCalo) const =0;
+			std::unique_ptr<SensitiveTkDetector>& oTK,
+			std::unique_ptr<SensitiveCaloDetector>& oCalo) const =0;
       
       // ---------- static member functions --------------------
 
@@ -57,14 +57,14 @@ class SensitiveDetectorMakerBase
    protected:
       //used to identify which type of Sensitive Detector we have
       void convertTo( SensitiveTkDetector* iFrom, 
-		      std::auto_ptr<SensitiveTkDetector>& oTo,
-		      std::auto_ptr<SensitiveCaloDetector>&) const{
-	oTo= std::auto_ptr<SensitiveTkDetector>(iFrom);
+		      std::unique_ptr<SensitiveTkDetector>& oTo,
+		      std::unique_ptr<SensitiveCaloDetector>&) const{
+	oTo= std::unique_ptr<SensitiveTkDetector>(iFrom);
       }
       void convertTo( SensitiveCaloDetector* iFrom,
-		      std::auto_ptr<SensitiveTkDetector>&,
-		      std::auto_ptr<SensitiveCaloDetector>& oTo) const{
-	oTo=std::auto_ptr<SensitiveCaloDetector>(iFrom);
+		      std::unique_ptr<SensitiveTkDetector>&,
+		      std::unique_ptr<SensitiveCaloDetector>& oTo) const{
+	oTo=std::unique_ptr<SensitiveCaloDetector>(iFrom);
       }
 
    private:

--- a/SimG4Core/SensitiveDetector/src/AttachSD.cc
+++ b/SimG4Core/SensitiveDetector/src/AttachSD.cc
@@ -7,12 +7,10 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-using std::vector;
-using std::string;
-using std::cout;
-using std::endl;
-
-// #define DEBUG
+//using std::vector;
+//using std::string;
+//using std::cout;
+//using std::endl;
 
 AttachSD::AttachSD() {}
 
@@ -29,20 +27,18 @@ AttachSD::create(const DDDWorld & w,
 {
   std::pair< std::vector<SensitiveTkDetector *>,
     std::vector<SensitiveCaloDetector*> > detList;
-//#ifdef DEBUG
   //cout << " Initializing AttachSD " << endl;
   LogDebug("SimG4CoreSensitiveDetector") << " AttachSD: Initializing" ;
-//#endif
   const std::vector<std::string>& rouNames = clg.readoutNames();
   for (std::vector<std::string>::const_iterator it = rouNames.begin();
        it != rouNames.end(); it++) {
     std::string className = clg.className(*it);
     //std::cout<<" trying to find something for "<<className<<" " <<*it<<std::endl;
     edm::LogInfo("SimG4CoreSensitiveDetector") << " AttachSD: trying to find something for " << className << " "  << *it ;
-    std::auto_ptr<SensitiveDetectorMakerBase> temp(
+    std::unique_ptr<SensitiveDetectorMakerBase> temp(
 						   SensitiveDetectorPluginFactory::get()->create(className) );
-    std::auto_ptr<SensitiveTkDetector> tkDet;
-    std::auto_ptr<SensitiveCaloDetector> caloDet;
+    std::unique_ptr<SensitiveTkDetector> tkDet;
+    std::unique_ptr<SensitiveCaloDetector> caloDet;
     temp->make(*it,cpv,clg,p,m,reg,tkDet,caloDet);
     if(tkDet.get()){
       detList.first.push_back(tkDet.get());
@@ -52,10 +48,8 @@ AttachSD::create(const DDDWorld & w,
       detList.second.push_back(caloDet.get());
       caloDet.release();
     }
-//#ifdef DEBUG
     // cout << " AttachSD: created a " << className << " with name " << *it << endl;
     LogDebug("SimG4CoreSensitiveDetector") << " AttachSD: created a " << className << " with name " << *it ;
-    //#endif
   }      
   return detList;
 }

--- a/SimG4Core/SensitiveDetector/src/AttachSD.cc
+++ b/SimG4Core/SensitiveDetector/src/AttachSD.cc
@@ -1,4 +1,3 @@
-//#include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorFactoryByName.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorPluginFactory.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetector.h"
 #include "SimG4Core/SensitiveDetector/interface/AttachSD.h"
@@ -6,11 +5,6 @@
 #include <vector>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-//using std::vector;
-//using std::string;
-//using std::cout;
-//using std::endl;
 
 AttachSD::AttachSD() {}
 

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -12,9 +12,9 @@
 #include "G4TouchableHistory.hh"
 
 SensitiveDetector::SensitiveDetector(std::string & iname, 
-				     const DDCompactView & cpv,
-				     const SensitiveDetectorCatalog & clg,
-				     edm::ParameterSet const & p) :
+                                     const DDCompactView & cpv,
+                                     const SensitiveDetectorCatalog & clg,
+                                     edm::ParameterSet const & p) :
   G4VSensitiveDetector(iname), name(iname) {}
 
 SensitiveDetector::~SensitiveDetector() {}
@@ -40,17 +40,17 @@ Local3DPoint SensitiveDetector::InitialStepPosition(G4Step * step, coordinates c
   G4StepPoint * preStepPoint = step->GetPreStepPoint();
   return (cc == WorldCoordinates) ? ConvertToLocal3DPoint(preStepPoint->GetPosition())
     : ConvertToLocal3DPoint(preStepPoint->GetTouchable()->GetHistory()
-			    ->GetTopTransform().TransformPoint(preStepPoint->GetPosition()));
+                            ->GetTopTransform().TransformPoint(preStepPoint->GetPosition()));
 }
 
 Local3DPoint SensitiveDetector::FinalStepPosition(G4Step * step, coordinates cc)
 {
   // transformation is defined pre-step
-  G4StepPoint * preStepPoint = step->GetPostStepPoint();
+  G4StepPoint * preStepPoint = step->GetPreStepPoint();
   G4StepPoint * postStepPoint = step->GetPostStepPoint();
   return (cc == WorldCoordinates) ? ConvertToLocal3DPoint(postStepPoint->GetPosition())
     : ConvertToLocal3DPoint(preStepPoint->GetTouchable()->GetHistory()
-			    ->GetTopTransform().TransformPoint(postStepPoint->GetPosition()));
+                            ->GetTopTransform().TransformPoint(postStepPoint->GetPosition()));
 }
 
 void SensitiveDetector::NaNTrap( G4Step* aStep )
@@ -63,9 +63,9 @@ void SensitiveDetector::NaNTrap( G4Step* aStep )
     {
       G4VPhysicalVolume* pCurrentVol = CurrentTrk->GetVolume() ;
       G4String NameOfVol = ( pCurrentVol != nullptr ) ? pCurrentVol->GetName() 
-	: "CorruptedVolumeInfo" ;
+        : "CorruptedVolumeInfo";
       throw SimG4Exception("SimG4CoreSensitiveDetector: Corrupted Event - NaN detected (position) in volume " 
-			   + NameOfVol);
+                           + NameOfVol);
     }
 
     xyz = CurrentTrk->GetMomentum().x() + CurrentTrk->GetMomentum().y() + CurrentTrk->GetMomentum().z();
@@ -73,7 +73,7 @@ void SensitiveDetector::NaNTrap( G4Step* aStep )
     {
       G4VPhysicalVolume* pCurrentVol = CurrentTrk->GetVolume() ;
       G4String NameOfVol = ( pCurrentVol != nullptr ) ? pCurrentVol->GetName() 
-	: "CorruptedVolumeInfo" ;
+        : "CorruptedVolumeInfo";
       throw SimG4Exception("SimG4CoreSensitiveDetector: Corrupted Event - NaN detected (3-momentum) in volume "
                            + NameOfVol);
     }

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -9,7 +9,7 @@
 #include "SimG4Core/Notification/interface/SimG4Exception.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 
-using std::string;
+//using std::string;
 
 SensitiveDetector::SensitiveDetector(std::string & iname, 
 				     const DDCompactView & cpv,

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -79,48 +79,34 @@ void SensitiveDetector::NaNTrap( G4Step* aStep )
 
     if ( aStep == nullptr ) return ;
     
-    G4Track* CurrentTrk = aStep->GetTrack() ;
-    G4ThreeVector CurrentPos = CurrentTrk->GetPosition() ;
-    G4ThreeVector CurrentMom = CurrentTrk->GetMomentum() ;
-    G4VPhysicalVolume* pCurrentVol = CurrentTrk->GetVolume() ;
-    G4String NameOfVol ;
-    if ( pCurrentVol != nullptr )
-    {
-       NameOfVol = pCurrentVol->GetName() ;
-    }
-    else
-    {
-       NameOfVol = "CorruptedVolumeInfo" ;
-    }
-    
-    // for simplicity... maybe edm::isNotFinite() will work on the 
-    // 3-vector directly...
+    G4Track* CurrentTrk = aStep->GetTrack();
 
-    double xyz[3] ;
-    xyz[0] = CurrentPos.x() ;
-    xyz[1] = CurrentPos.y() ;
-    xyz[2] = CurrentPos.z() ;
+    double xyz[3];
+    xyz[0] = CurrentTrk->GetPosition().x();
+    xyz[1] = CurrentTrk->GetPosition().y();
+    xyz[2] = CurrentTrk->GetPosition().z();
     
     //
     // this is another trick to check on a NaN, maybe it's even CPU-faster...
     // but ler's stick to system function edm::isNotFinite(...) for now
     //
-    // if ( !(xyz[0]==xyz[0]) || !(xyz[1]==xyz[1]) || !(xyz[2]==xyz[2]) )
-    if( edm::isNotFinite(xyz[0]+xyz[1]+xyz[2]) != 0 )
+    if( edm::isNotFinite(xyz[0]+xyz[1]+xyz[2]))
     {
+      G4VPhysicalVolume* pCurrentVol = CurrentTrk->GetVolume() ;
+      G4String NameOfVol = ( pCurrentVol != nullptr ) ? pCurrentVol->GetName() 
+	: "CorruptedVolumeInfo" ;
       throw SimG4Exception( "SimG4CoreSensitiveDetector: Corrupted Event - NaN detected (position) in volume " + NameOfVol);
     }
 
-    xyz[0] = CurrentMom.x() ;
-    xyz[1] = CurrentMom.y() ;
-    xyz[2] = CurrentMom.z() ;
-    if ( !(xyz[0]==xyz[0]) || !(xyz[1]==xyz[1]) || !(xyz[2]==xyz[2]) ||
-         edm::isNotFinite(xyz[0]) != 0 || edm::isNotFinite(xyz[1]) != 0 || 
-	 edm::isNotFinite(xyz[2]) != 0 )
+    xyz[0] = CurrentTrk->GetMomentum().x();
+    xyz[1] = CurrentTrk->GetMomentum().y();
+    xyz[2] = CurrentTrk->GetMomentum().z();
+    if( edm::isNotFinite(xyz[0]+xyz[1]+xyz[2]))
     {
+      G4VPhysicalVolume* pCurrentVol = CurrentTrk->GetVolume() ;
+      G4String NameOfVol = ( pCurrentVol != nullptr ) ? pCurrentVol->GetName() 
+	: "CorruptedVolumeInfo" ;
       throw SimG4Exception( "SimG4CoreSensitiveDetector: Corrupted Event - NaN detected (3-momentum) in volume " + NameOfVol);
     }
-
    return;
-
 }

--- a/Validation/Geometry/test/TrackerMaterialBudgetComparison.C
+++ b/Validation/Geometry/test/TrackerMaterialBudgetComparison.C
@@ -52,8 +52,8 @@ TProfile* prof_x0_str_ELE_new;
 TProfile* prof_x0_str_OTH_new;
 TProfile* prof_x0_str_AIR_new;
 
-TProfile* prof2d_x0_det_total_old;
-TProfile* prof2d_x0_det_total_new;
+TProfile2D* prof2d_x0_det_total_old;
+TProfile2D* prof2d_x0_det_total_new;
 
 //
 unsigned int iFirst = 1;


### PR DESCRIPTION
Substituted remaining auto_ptr by unique_ptr.

Proper initialised CaloSD with nullptr and all local members.

Removed not necessary computations in the beginning of produce(..) method, simplified computations in SensitiveDetector class by using directly G4 methods.

Should bring a small CPU performance improvement and no change in results.