### PR TITLE
gcc7 warning fix: move anonymous::CheckBinLabels in to MEtoEDM class

### DIFF
--- a/DQM/L1TMonitor/src/L1TRate.cc
+++ b/DQM/L1TMonitor/src/L1TRate.cc
@@ -24,8 +24,6 @@
 #include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
 #include "CondFormats/DataRecord/interface/L1GtPrescaleFactorsAlgoTrigRcd.h"
 
-#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
-
 #include "TList.h"
 
 using namespace edm;

--- a/DQM/L1TMonitorClient/src/L1TOccupancyClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TOccupancyClient.cc
@@ -8,7 +8,6 @@
 #include "DQMServices/Core/interface/QReport.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
-#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
 #include <stdio.h>
 #include <sstream>
 #include <math.h>

--- a/DQM/L1TMonitorClient/src/L1TTestsSummary.cc
+++ b/DQM/L1TMonitorClient/src/L1TTestsSummary.cc
@@ -9,7 +9,6 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "DQMServices/Core/interface/DQMChannel.h"
-#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
 #include <stdio.h>
 #include <sstream>
 #include <math.h>

--- a/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
@@ -11,7 +11,6 @@
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 #include "DataFormats/GeometrySurface/interface/Cylinder.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"

--- a/DQMOffline/L1Trigger/src/L1TRate_Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TRate_Offline.cc
@@ -10,8 +10,6 @@
 #include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
 #include "CondFormats/DataRecord/interface/L1GtPrescaleFactorsAlgoTrigRcd.h"
 
-#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
-
 #include "TList.h"
 
 using namespace edm;

--- a/DQMServices/Components/plugins/MEtoEDMConverter.cc
+++ b/DQMServices/Components/plugins/MEtoEDMConverter.cc
@@ -13,6 +13,7 @@
 #include "classlib/utils/StringList.h"
 #include "classlib/utils/StringOps.h"
 #include "DataFormats/Histograms/interface/DQMToken.h"
+#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
 
 using namespace lat;
 

--- a/DQMServices/Components/plugins/MEtoEDMConverter.h
+++ b/DQMServices/Components/plugins/MEtoEDMConverter.h
@@ -28,9 +28,6 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 
-// data format
-#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
-
 // helper files
 #include <iostream>
 #include <stdlib.h>

--- a/DQMServices/Components/plugins/MEtoMEComparitor.cc
+++ b/DQMServices/Components/plugins/MEtoMEComparitor.cc
@@ -22,6 +22,7 @@
 #include "classlib/utils/StringList.h"
 #include "classlib/utils/StringOps.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
+#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
 
 MEtoMEComparitor::MEtoMEComparitor(const edm::ParameterSet& iConfig)
 

--- a/DQMServices/Components/plugins/MEtoMEComparitor.h
+++ b/DQMServices/Components/plugins/MEtoMEComparitor.h
@@ -33,7 +33,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DQMServices/Core/interface/DQMStore.h"

--- a/DataFormats/Histograms/interface/MEtoEDMFormat.h
+++ b/DataFormats/Histograms/interface/MEtoEDMFormat.h
@@ -33,35 +33,6 @@
 
 #define METOEDMFORMAT_DEBUG 0
 
-namespace {
-  //utility function to check the consistency of the axis labels
-  //taken from TH1::CheckBinLabels
-  bool CheckBinLabels(const TAxis* a1, const TAxis * a2)
-  {
-    // check that axis have same labels
-    THashList *l1 = (const_cast<TAxis*>(a1))->GetLabels();
-    THashList *l2 = (const_cast<TAxis*>(a2))->GetLabels();
-    
-    if (!l1 && !l2 )
-      return true;
-    if (!l1 ||  !l2 ) {
-      return false;
-    }
-    // check now labels sizes  are the same
-    if (l1->GetSize() != l2->GetSize() ) {
-      return false;
-    }
-    for (int i = 1; i <= a1->GetNbins(); ++i) {
-      TString label1 = a1->GetBinLabel(i);
-      TString label2 = a2->GetBinLabel(i);
-      if (label1 != label2) {
-	return false;
-      }
-    }
-    return true;
-  }
-}
-
 template <class T>
 class MEtoEDM
 {
@@ -96,6 +67,31 @@ class MEtoEDM
 
   const MEtoEdmObjectVector & getMEtoEdmObject() const
     { return MEtoEdmObject; }
+
+  bool CheckBinLabels(const TAxis* a1, const TAxis * a2)
+  {
+    // check that axis have same labels
+    THashList *l1 = (const_cast<TAxis*>(a1))->GetLabels();
+    THashList *l2 = (const_cast<TAxis*>(a2))->GetLabels();
+
+    if (!l1 && !l2 )
+      return true;
+    if (!l1 ||  !l2 ) {
+      return false;
+    }
+    // check now labels sizes  are the same
+    if (l1->GetSize() != l2->GetSize() ) {
+      return false;
+    }
+    for (int i = 1; i <= a1->GetNbins(); ++i) {
+      TString label1 = a1->GetBinLabel(i);
+      TString label2 = a2->GetBinLabel(i);
+      if (label1 != label2) {
+	return false;
+      }
+    }
+    return true;
+  }
 
   bool mergeProduct(const MEtoEDM<T> &newMEtoEDM) {
     const MEtoEdmObjectVector &newMEtoEDMObject = newMEtoEDM.getMEtoEdmObject();


### PR DESCRIPTION
- move anonymous::CheckBinLabels in to MEtoEDM which is only user of this function
- cleanup unnecessary include statements