### PR TITLE
Bug fix pat::TriggerObjectStandAlone

### DIFF
--- a/DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h
+++ b/DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h
@@ -100,11 +100,16 @@ namespace pat {
       /// Constructors from Lorentz-vectors and (optional) PDG ID
       TriggerObjectStandAlone( const reco::Particle::LorentzVector & vec, int id = 0 );
       TriggerObjectStandAlone( const reco::Particle::PolarLorentzVector & vec, int id = 0 );
+      TriggerObjectStandAlone( const TriggerObjectStandAlone& ) = default;
 
       /// Destructor
       virtual ~TriggerObjectStandAlone() {};
 
       /// Methods
+
+      TriggerObjectStandAlone copy() const {
+        return *this;
+      }
 
       /// Adds a new HLT filter label
       void addFilterLabel( const std::string & filterLabel ) { addFilterOrCondition( filterLabel ); };

--- a/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
+++ b/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
@@ -5,6 +5,7 @@
 #include "FWCore/Common/interface/TriggerNames.h"
 
 #include <boost/algorithm/string.hpp>
+#include <tbb/concurrent_unordered_map.h>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/PatCandidates/interface/libminifloat.h"
 
@@ -12,7 +13,6 @@
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/Registry.h"
 
 using namespace pat;
 
@@ -406,10 +406,10 @@ std::vector<std::string>  const* TriggerObjectStandAlone::allLabels(edm::Paramet
          return &iter->second;
       }
 
-      auto   triggerNames= event.triggerNames(res); //this also ensure that the registry is filled
-      edm::pset::Registry* psetRegistry = edm::pset::Registry::instance();
-      edm::ParameterSet const* pset=0;
-      if (0!=(pset=psetRegistry->getMapped(psetid ))) {
+      auto   triggerNames= event.triggerNames(res); 
+      edm::ParameterSet const* pset=nullptr;
+      //getting the ParameterSet from the event ensures that the registry is filled
+      if (nullptr!=(pset=event.parameterSet(psetid ))) {
    	using namespace std;
 	using namespace edm;
    	using namespace trigger;


### PR DESCRIPTION
The pat::TriggerObjectStandAlone was directly calling the ParameterSet registry assuming that a
previous call would fill the registry. That assumption was incorrect. Now the class calls the method
EventBase::parameterSet which will do the necessary up dating of the registry behind the scenes.