### PR TITLE
Enable HLT DQM for MET plus Track EXO triggers

### DIFF
--- a/DQMOffline/Trigger/python/ExoticaMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/ExoticaMonitoring_cff.py
@@ -13,7 +13,7 @@ exoticaMonitorHLT = cms.Sequence(
   + exoHLTNoBPTXmonitoring
   + exoHLTPhotonmonitoring
   + exoHLTHTmonitoring
-# + exoHLTMETplusTrackMonitoring    # disabled pending the review of METplusTrackMonitor.cc
+  + exoHLTMETplusTrackMonitoring
   + exoHLTMuonmonitoring
   + exoHLTDisplacedJetmonitoring
 )


### PR DESCRIPTION
Re-enable the HLT DQM developed at #19490, which is currently disabled pending a review of the METplusTrackMonitor.h / .cc code.