### PR TITLE
fix HLT customize for "Pixel cluster shape: new calibration for Phase1 and Phase2" #19824

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -27,7 +27,8 @@ def customiseFor19029(process):
 
 def customiseFor19824(process) :
     for producer in esproducers_by_type(process, "ClusterShapeHitFilterESProducer"):
-        producer.PixelShapeFileL1= cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShapePhase1_all.par')
+         producer.PixelShapeFile   = cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShapePhase1_all.par')
+         producer.PixelShapeFileL1 = cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShapePhase1_all.par')
     return process
 
 


### PR DESCRIPTION
now is ok

went undetected due to absence of poisoning for data

136.781_RunDoubleEG2017B+RunDoubleEG2017B+HLTDR2_2017+RECODR2_2017reHLT_skimDoubleEG_Prompt+HARVEST2017 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Fri Jul 28 14:50:28 2017-date Fri Jul 28 14:39:26 2017; exit: 0 0 0 0
1 1 1 1 tests passed, 0 0 0 0 failed
