### PR TITLE
uGMT fixes for intermediate muons - 93x

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
@@ -77,18 +77,20 @@ namespace l1t {
       {
          UnpackerMap res;
 
-         // input muons
+         // MP7 input link numbers are represented by even numbers starting from 0 (iLink=link*2)
+         // input muons on links 36-71
          auto gmt_in_unp = UnpackerFactory::get()->make("stage2::RegionalMuonGMTUnpacker");
          for (int iLink = 72; iLink < 144; iLink += 2)
             res[iLink] = gmt_in_unp;
 
-         // internal muons
+         // MP7 output link numbers are represented by odd numbers (oLink=link*2+1)
+         // internal muons on links 24-31
          auto gmt_imd_unp = static_pointer_cast<l1t::stage2::IntermediateMuonUnpacker>(UnpackerFactory::get()->make("stage2::IntermediateMuonUnpacker"));
          gmt_imd_unp->setAlgoVersion(fw);
          for (int oLink = 49; oLink < 65; oLink += 2)
             res[oLink] = gmt_imd_unp;
 
-         // output muons (6 copies)
+         // output muons on links 0-23 (6 copies on 4 links each)
          std::array<std::shared_ptr<l1t::stage2::MuonUnpacker>, 6> gmt_out_unps;
          int i = 0;
          for (auto gmt_out_unp:gmt_out_unps) {

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
@@ -85,7 +85,7 @@ namespace l1t {
          // internal muons
          auto gmt_imd_unp = static_pointer_cast<l1t::stage2::IntermediateMuonUnpacker>(UnpackerFactory::get()->make("stage2::IntermediateMuonUnpacker"));
          gmt_imd_unp->setAlgoVersion(fw);
-         for (int oLink = 49; oLink < 63; oLink += 2)
+         for (int oLink = 49; oLink < 65; oLink += 2)
             res[oLink] = gmt_imd_unp;
 
          // output muons (6 copies)

--- a/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
@@ -416,7 +416,7 @@ L1TMuonProducer::addMuonsToCollections(MicroGMTConfiguration::InterMuonList& col
     math::PtEtaPhiMLorentzVector vec{(mu->hwPt()-1)*0.5, mu->hwEta()*0.010875, mu->hwGlobalPhi()*0.010908, 0.0};
     int outMuQual = MicroGMTConfiguration::setOutputMuonQuality(mu->hwQual(), mu->trackFinderType(), mu->hwHF());
     // set tfMuonIndex and iso to 0 like in the FW
-    Muon outMu{vec, mu->hwPt(), mu->hwEta(), mu->hwGlobalPhi(), outMuQual, mu->hwSign(), mu->hwSignValid(), -1, 0, 0, true, 0, mu->hwDPhi(), mu->hwDEta(), mu->hwRank()};
+    Muon outMu{vec, mu->hwPt(), mu->hwEta(), mu->hwGlobalPhi(), outMuQual, mu->hwSign(), mu->hwSignValid(), 0, 0, 0, true, 0, mu->hwDPhi(), mu->hwDEta(), mu->hwRank()};
     if (mu->hwSignValid()) {
       outMu.setCharge(1 - 2 * mu->hwSign());
     } else {


### PR DESCRIPTION
Two fixes for the uGMT intermediate muons used by the DQM.

- Add missing link to the unpacker to get all intermediates from EMTF-.
- Set the isolation variable of the emulator to the same value as the unpacker (0).