### PR TITLE
gcc7 warning fix: increase size to avoid memory override

### DIFF
--- a/SimG4CMS/Calo/test/HFPMTHitAnalyzer.cc
+++ b/SimG4CMS/Calo/test/HFPMTHitAnalyzer.cc
@@ -41,7 +41,7 @@ HFPMTHitAnalyzer::~HFPMTHitAnalyzer() {}
 void HFPMTHitAnalyzer::beginJob() {
 
   event_no = 0;
-  char name[20], title[120], sub[10];
+  char name[20], title[120], sub[11];
 
   edm::Service<TFileService> fs;
   if ( !fs.isAvailable() )


### PR DESCRIPTION
this should fix the warning
```
SimG4CMS/Calo/test/HFPMTHitAnalyzer.cc:72:30: warning: 'void* __builtin_memcpy(void*, const void*, long unsigned int)' writing 11 bytes into a region of size 10 overflows the destination [-Wstringop-overflow=]
      if      (i == 0) sprintf (sub, "(Absorber)");
```
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-07-27-2300/SimG4CMS/Calo