### PR TITLE
gcc7 compilation warning(s) fix(es) in DQM/EcalMonitorDbModule

### DIFF
--- a/DQM/EcalMonitorDbModule/interface/MonitorXMLParser.h
+++ b/DQM/EcalMonitorDbModule/interface/MonitorXMLParser.h
@@ -99,7 +99,7 @@ public:
   }
 
 
-  ~TagNames() throw(){
+  ~TagNames() noexcept(false){
     
     try{
 


### PR DESCRIPTION
Fix for compilation warning(s) when compiling with gcc7 and more flags listed here:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-07-24-2300/DQM/EcalMonitorDbModule