### PR TITLE
Fixed StorageAccount token creation

### DIFF
--- a/Utilities/StorageFactory/src/StorageAccount.cc
+++ b/Utilities/StorageFactory/src/StorageAccount.cc
@@ -61,10 +61,9 @@ StorageAccount::StorageClassToken StorageAccount::tokenForStorageClassName( std:
   }
   int value = s_nextTokenValue++;
   
-  auto ret = s_nameToToken.insert(std::make_pair(iName, value));
+  s_nameToToken.insert(std::make_pair(iName, value));
   
-  //don't use value since another thread may have beaten us to here
-  return StorageClassToken(ret.second);
+  return StorageClassToken(value);
 }
 
 const std::string& StorageAccount::nameForToken( StorageClassToken iToken) {


### PR DESCRIPTION
The way tokens were assigned values was flawed such that only the values of 0 or 1 were possible and were assigned to multiple names. 
The problem was the return value of 'tbb::concurrent_unordered_map::insert' was mis-interpreted and the bool value which denotes if the item had already been inserted was used as the token value instead of the unique value assigned.