### PR TITLE
new beamhlt dqm client for 93X (identical with 92X)

### DIFF
--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -39,8 +39,8 @@ process.hltTriggerTypeFilter = cms.EDFilter("HLTTriggerTypeFilter",
 # DQM Live Environment
 #-----------------------------
 process.load("DQM.Integration.config.environment_cfi")
-process.dqmEnv.subSystemFolder = 'BeamMonitorHLT'
-process.dqmSaver.tag           = 'BeamMonitorHLT'
+process.dqmEnv.subSystemFolder = 'TrackingBeamspotStream'
+process.dqmSaver.tag           = 'TrackingBeamspotStream'
 
 #-----------------------------
 # BeamMonitor
@@ -59,14 +59,14 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 # Change Beam Monitor variables
 if process.dqmRunConfig.type.value() is "production":
   process.dqmBeamMonitor.BeamFitter.WriteAscii = True
-  process.dqmBeamMonitor.BeamFitter.AsciiFileName = '/nfshome0/yumiceva/BeamMonitorDQM/BeamFitResults.txt'
+  process.dqmBeamMonitor.BeamFitter.AsciiFileName = '/nfshome0/yumiceva/BeamMonitorDQM/BeamFitResultsHLT.txt'
   process.dqmBeamMonitor.BeamFitter.WriteDIPAscii = True
-  process.dqmBeamMonitor.BeamFitter.DIPFileName = '/nfshome0/dqmpro/BeamMonitorDQM/BeamFitResults.txt'
+  process.dqmBeamMonitor.BeamFitter.DIPFileName = '/nfshome0/dqmpro/BeamMonitorDQM/BeamFitResultsHLT.txt'
 else:
   process.dqmBeamMonitor.BeamFitter.WriteAscii = False
-  process.dqmBeamMonitor.BeamFitter.AsciiFileName = '/nfshome0/yumiceva/BeamMonitorDQM/BeamFitResults.txt'
+  process.dqmBeamMonitor.BeamFitter.AsciiFileName = '/nfshome0/yumiceva/BeamMonitorDQM/BeamFitResultsHLT.txt'
   process.dqmBeamMonitor.BeamFitter.WriteDIPAscii = True
-  process.dqmBeamMonitor.BeamFitter.DIPFileName = '/nfshome0/dqmdev/BeamMonitorDQM/BeamFitResults.txt'
+  process.dqmBeamMonitor.BeamFitter.DIPFileName = '/nfshome0/dqmdev/BeamMonitorDQM/BeamFitResultsHLT.txt'
 
 process.dqmcommon = cms.Sequence(process.dqmEnv
                                * process.dqmSaver)
@@ -92,7 +92,7 @@ if (process.runType.getRunType() == process.runType.pp_run or
 
     process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
 
-    process.dqmBeamMonitor.monitorName = 'BeamMonitorHLT'
+    process.dqmBeamMonitor.monitorName = 'trackingbeamspotstream'
 
     process.dqmBeamMonitor.OnlineMode = True              
 

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -39,8 +39,8 @@ process.hltTriggerTypeFilter = cms.EDFilter("HLTTriggerTypeFilter",
 # DQM Live Environment
 #-----------------------------
 process.load("DQM.Integration.config.environment_cfi")
-process.dqmEnv.subSystemFolder = 'TrackingBeamspotStream'
-process.dqmSaver.tag           = 'TrackingBeamspotStream'
+process.dqmEnv.subSystemFolder = 'TrackingHLTBeamspotStream'
+process.dqmSaver.tag           = 'TrackingHLTBeamspotStream'
 
 #-----------------------------
 # BeamMonitor
@@ -92,7 +92,7 @@ if (process.runType.getRunType() == process.runType.pp_run or
 
     process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
 
-    process.dqmBeamMonitor.monitorName = 'trackingbeamspotstream'
+    process.dqmBeamMonitor.monitorName = 'TrackingHLTBeamspotStream'
 
     process.dqmBeamMonitor.OnlineMode = True              
 

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -1,0 +1,125 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+
+process = cms.Process("BeamMonitor", eras.Run2_2017)
+
+# Message logger
+#process.load("FWCore.MessageLogger.MessageLogger_cfi")
+#process.MessageLogger = cms.Service("MessageLogger",
+#    debugModules = cms.untracked.vstring('*'),
+#    cerr = cms.untracked.PSet(
+#        FwkReport = cms.untracked.PSet(
+#            optionalPSet = cms.untracked.bool(True),
+#            reportEvery = cms.untracked.int32(1000),
+#            limit = cms.untracked.int32(999999)
+#        )
+#    ),
+#    destinations = cms.untracked.vstring('cerr'),
+#)
+
+# Common part for PP and H.I Running
+#-----------------------------
+# for live online DQM in P5
+process.load("DQM.Integration.config.inputsource_cfi")
+# for testing in lxplus
+#process.load("DQM.Integration.config.fileinputsource_cfi")
+
+# new stream label
+process.source.streamLabel = cms.untracked.string('streamDQMOnlineBeamspot')
+
+#--------------------------
+# HLT Filter
+# 0=random, 1=physics, 2=calibration, 3=technical
+#--------------------------
+process.hltTriggerTypeFilter = cms.EDFilter("HLTTriggerTypeFilter",
+    SelectedTriggerType = cms.int32(1)
+)
+
+#-----------------------------
+# DQM Live Environment
+#-----------------------------
+process.load("DQM.Integration.config.environment_cfi")
+process.dqmEnv.subSystemFolder = 'BeamMonitorHLT'
+process.dqmSaver.tag           = 'BeamMonitorHLT'
+
+#-----------------------------
+# BeamMonitor
+#-----------------------------
+process.load("DQM.BeamMonitor.BeamMonitor_cff")
+
+#---------------
+# Calibration
+#---------------
+# Condition for P5 cluster
+process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
+# Condition for lxplus: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+
+# Change Beam Monitor variables
+if process.dqmRunConfig.type.value() is "production":
+  process.dqmBeamMonitor.BeamFitter.WriteAscii = True
+  process.dqmBeamMonitor.BeamFitter.AsciiFileName = '/nfshome0/yumiceva/BeamMonitorDQM/BeamFitResults.txt'
+  process.dqmBeamMonitor.BeamFitter.WriteDIPAscii = True
+  process.dqmBeamMonitor.BeamFitter.DIPFileName = '/nfshome0/dqmpro/BeamMonitorDQM/BeamFitResults.txt'
+else:
+  process.dqmBeamMonitor.BeamFitter.WriteAscii = False
+  process.dqmBeamMonitor.BeamFitter.AsciiFileName = '/nfshome0/yumiceva/BeamMonitorDQM/BeamFitResults.txt'
+  process.dqmBeamMonitor.BeamFitter.WriteDIPAscii = True
+  process.dqmBeamMonitor.BeamFitter.DIPFileName = '/nfshome0/dqmdev/BeamMonitorDQM/BeamFitResults.txt'
+
+process.dqmcommon = cms.Sequence(process.dqmEnv
+                               * process.dqmSaver)
+
+process.monitor = cms.Sequence(process.dqmBeamMonitor)
+
+#-----------------------------------------------------------
+# process customizations included here
+from DQM.Integration.config.online_customizations_cfi import *
+process = customise(process)
+
+#--------------------------
+# Proton-Proton Stuff
+#--------------------------
+
+if (process.runType.getRunType() == process.runType.pp_run or
+    process.runType.getRunType() == process.runType.pp_run_stage1 or
+    process.runType.getRunType() == process.runType.cosmic_run or
+    process.runType.getRunType() == process.runType.cosmic_run_stage1 or 
+    process.runType.getRunType() == process.runType.hpu_run):
+
+    print "[beamhlt_dqm_sourceclient-live_cfg]:: Running pp"
+
+    process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
+
+    process.dqmBeamMonitor.monitorName = 'BeamMonitorHLT'
+
+    process.dqmBeamMonitor.OnlineMode = True              
+
+    process.dqmBeamMonitor.resetEveryNLumi   = 5
+    process.dqmBeamMonitor.resetPVEveryNLumi = 5
+
+    process.dqmBeamMonitor.PVFitter.minNrVerticesForFit = 20
+    process.dqmBeamMonitor.PVFitter.minVertexNdf        = 10
+  
+    # some inputs to BeamMonitor
+    process.dqmBeamMonitor.BeamFitter.TrackCollection = 'hltPFMuonMerging'
+    process.dqmBeamMonitor.primaryVertex              = 'hltVerticesPFFilter'
+    process.dqmBeamMonitor.PVFitter.VertexCollection  = 'hltVerticesPFFilter'
+
+    # keep checking this with new release expected close to 1
+    process.dqmBeamMonitor.PVFitter.errorScale = 0.95
+
+    #TriggerName for selecting pv for DIP publication, NO wildcard needed here
+    #it will pick all triggers which has these strings in theri name
+    process.dqmBeamMonitor.jetTrigger = cms.untracked.vstring(
+        "HLT_HT300_Beamspot", "HLT_HT300_Beamspot")
+#        "HLT_PAZeroBias_v", "HLT_ZeroBias_v", "HLT_QuadJet")
+
+    process.dqmBeamMonitor.hltResults = cms.InputTag("TriggerResults","","HLT")
+
+    process.p = cms.Path( process.hltTriggerTypeFilter
+                        * process.dqmcommon
+                        * process.offlineBeamSpot
+                        * process.monitor )
+


### PR DESCRIPTION
New beamhlt_dqm_sourceclient-live_cfg.py.

It uses the stream is streamDQMOnlineBeamspot and consumes the objects from
HLT: tracks are hltPFMuonMerging, vertices are hltVerticesPFFilter. Since HLT
provides no digis, only dqmBeamMonitor runs. The client is a much slimmed-down
version of the original beam_dqm_sourceclient-live_cfg.py.

There is a new DQM folder called BeaMonitorHLT, the client outputs folders Fit
and PrimaryVertex.

The client was tested on run several runs for proper functioning and timing
(4-5 per fits at the end of blocks with 10 LSs).

For further info please check:
https://twiki.cern.ch/twiki/bin/view/CMS/OnlineBeamSpot#23_June_2017_check_the_new_DQMOn