### PR TITLE
Restrict GEM/ME0 cluster size and max N clusters

### DIFF
--- a/SimMuon/GEMDigitizer/src/GEMPadDigiClusterProducer.cc
+++ b/SimMuon/GEMDigitizer/src/GEMPadDigiClusterProducer.cc
@@ -54,7 +54,7 @@ void GEMPadDigiClusterProducer::produce(edm::Event& e, const edm::EventSetup& ev
 
 
 void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection &det_pads,
-					      GEMPadDigiClusterCollection &out_clusters)
+                                              GEMPadDigiClusterCollection &out_clusters)
 {
   // construct clusters
   for (const auto& ch: geometry_->chambers()) {

--- a/SimMuon/GEMDigitizer/src/GEMPadDigiClusterProducer.cc
+++ b/SimMuon/GEMDigitizer/src/GEMPadDigiClusterProducer.cc
@@ -96,9 +96,11 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection &det_pa
     } // end of partition loop
 
     // cluster selection: pick first maxClusters_ for now
-    for (unsigned iCluster = 0; iCluster < maxClusters_; ++iCluster){
-      const auto& p(proto_clusters[iCluster]);
+    unsigned int iCluster=0;
+    for (const auto& p: proto_clusters){
       out_clusters.insertDigi(GEMDetId(p.first), p.second);
+      iCluster++;
+      if (iCluster>maxClusters_) break;
     }
   } // end of chamber loop
 }

--- a/SimMuon/GEMDigitizer/src/GEMPadDigiClusterProducer.cc
+++ b/SimMuon/GEMDigitizer/src/GEMPadDigiClusterProducer.cc
@@ -96,11 +96,11 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection &det_pa
     } // end of partition loop
 
     // cluster selection: pick first maxClusters_ for now
-    unsigned int iCluster=0;
-    for (const auto& p: proto_clusters){
-      out_clusters.insertDigi(GEMDetId(p.first), p.second);
-      iCluster++;
-      if (iCluster>maxClusters_) break;
+    unsigned loopMax=std::min(maxClusters_,unsigned(proto_clusters.size()));
+    for ( unsigned int i=0; i<loopMax; i++) {
+      const auto& detid(proto_clusters[i].first);
+      const auto& cluster(proto_clusters[i].second);
+      out_clusters.insertDigi(detid, cluster);
     }
   } // end of chamber loop
 }

--- a/SimMuon/GEMDigitizer/src/GEMPadDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/GEMPadDigiProducer.cc
@@ -52,7 +52,7 @@ void GEMPadDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetu
 
 void GEMPadDigiProducer::buildPads(const GEMDigiCollection &det_digis, GEMPadDigiCollection &out_pads) const
 {
-  auto etaPartitions = geometry_->etaPartitions();
+  const auto& etaPartitions = geometry_->etaPartitions();
   for(const auto& p: etaPartitions)
   {
     // set of <pad, bx> pairs, sorted first by pad then by bx

--- a/SimMuon/GEMDigitizer/src/GEMPadDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/GEMPadDigiProducer.cc
@@ -52,13 +52,12 @@ void GEMPadDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetu
 
 void GEMPadDigiProducer::buildPads(const GEMDigiCollection &det_digis, GEMPadDigiCollection &out_pads) const
 {
-  const auto& etaPartitions = geometry_->etaPartitions();
-  for(const auto& p: etaPartitions)
+  for(const auto& p: geometry_->etaPartitions())
   {
     // set of <pad, bx> pairs, sorted first by pad then by bx
     std::set<std::pair<int, int> > proto_pads;
-  
-    // walk over digis in this partition, 
+
+    // walk over digis in this partition,
     // and stuff them into a set of unique pads (equivalent of OR operation)
     auto digis = det_digis.get(p->id());
     for (auto d = digis.first; d != digis.second; ++d)
@@ -66,10 +65,10 @@ void GEMPadDigiProducer::buildPads(const GEMDigiCollection &det_digis, GEMPadDig
       int pad_num = 1 + static_cast<int>( p->padOfStrip(d->strip()) );
       proto_pads.emplace(pad_num, d->bx());
     }
-  
+
     // in the future, do some dead-time handling
     // emulateDeadTime(proto_pads)
-  
+
     // fill the output collections
     for (const auto& d: proto_pads)
     {

--- a/SimMuon/GEMDigitizer/src/ME0PadDigiClusterProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PadDigiClusterProducer.cc
@@ -53,7 +53,8 @@ void ME0PadDigiClusterProducer::produce(edm::Event& e, const edm::EventSetup& ev
 }
 
 
-void ME0PadDigiClusterProducer::buildClusters(const ME0PadDigiCollection &det_pads, ME0PadDigiClusterCollection &out_clusters)
+void ME0PadDigiClusterProducer::buildClusters(const ME0PadDigiCollection &det_pads,
+                                              ME0PadDigiClusterCollection &out_clusters)
 {
   // construct clusters
   for (const auto& ch: geometry_->chambers()) {

--- a/SimMuon/GEMDigitizer/src/ME0PadDigiClusterProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PadDigiClusterProducer.cc
@@ -96,9 +96,11 @@ void ME0PadDigiClusterProducer::buildClusters(const ME0PadDigiCollection &det_pa
     } // end of partition loop
 
     // cluster selection: pick first maxClusters_ for now
-    for (unsigned iCluster = 0; iCluster < maxClusters_; ++iCluster){
-      const auto& p(proto_clusters[iCluster]);
+    unsigned int iCluster=0;
+    for (const auto& p: proto_clusters){
       out_clusters.insertDigi(ME0DetId(p.first), p.second);
+      iCluster++;
+      if (iCluster>maxClusters_) break;
     }
   } // end of chamber loop
 }

--- a/SimMuon/GEMDigitizer/src/ME0PadDigiClusterProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PadDigiClusterProducer.cc
@@ -96,11 +96,11 @@ void ME0PadDigiClusterProducer::buildClusters(const ME0PadDigiCollection &det_pa
     } // end of partition loop
 
     // cluster selection: pick first maxClusters_ for now
-    unsigned int iCluster=0;
-    for (const auto& p: proto_clusters){
-      out_clusters.insertDigi(ME0DetId(p.first), p.second);
-      iCluster++;
-      if (iCluster>maxClusters_) break;
+    unsigned loopMax=std::min(maxClusters_,unsigned(proto_clusters.size()));
+    for ( unsigned int i=0; i<loopMax; i++) {
+      const auto& detid(proto_clusters[i].first);
+      const auto& cluster(proto_clusters[i].second);
+      out_clusters.insertDigi(detid, cluster);
     }
   } // end of chamber loop
 }

--- a/SimMuon/GEMDigitizer/src/ME0PadDigiClusterProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PadDigiClusterProducer.cc
@@ -57,7 +57,7 @@ void ME0PadDigiClusterProducer::buildClusters(const ME0PadDigiCollection &det_pa
                                               ME0PadDigiClusterCollection &out_clusters)
 {
   // construct clusters
-  for (const auto& ch: geometry_->chambers()) {
+  for (const auto& ch: geometry_->layers()) {
 
     // proto collection
     std::vector<std::pair<ME0DetId, ME0PadDigiCluster> > proto_clusters;

--- a/SimMuon/GEMDigitizer/src/ME0PadDigiClusterProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PadDigiClusterProducer.cc
@@ -55,7 +55,12 @@ void ME0PadDigiClusterProducer::produce(edm::Event& e, const edm::EventSetup& ev
 
 void ME0PadDigiClusterProducer::buildClusters(const ME0PadDigiCollection &det_pads, ME0PadDigiClusterCollection &out_clusters)
 {
+  // construct clusters
   for (const auto& ch: geometry_->chambers()) {
+
+    // proto collection
+    std::vector<std::pair<ME0DetId, ME0PadDigiCluster> > proto_clusters;
+
     for (const auto& part: ch->etaPartitions()) {
       auto pads = det_pads.get(part->id());
       std::vector<uint16_t> cl;
@@ -65,22 +70,34 @@ void ME0PadDigiClusterProducer::buildClusters(const ME0PadDigiCollection &det_pa
           cl.push_back((*d).pad());
         }
         else {
-          if ((*d).bx() == startBX and (*d).pad() == cl.back() + 1) {
+          if ((*d).bx() == startBX and // same bunch crossing
+              (*d).pad() == cl.back() + 1 // pad difference is 1
+              and cl.size()<maxClusterSize_) { // max 8 in cluster
             cl.push_back((*d).pad());
           }
           else {
+            // put the current cluster in the proto collection
             ME0PadDigiCluster pad_cluster(cl, startBX);
-            out_clusters.insertDigi(part->id(), pad_cluster);
+            proto_clusters.emplace_back(part->id(), pad_cluster);
+
+            // start a new cluster
             cl.clear();
             cl.push_back((*d).pad());
           }
         }
         startBX = (*d).bx();
       }
+      // put the last cluster in the proto collection
       if (pads.first != pads.second){
         ME0PadDigiCluster pad_cluster(cl, startBX);
-        out_clusters.insertDigi(part->id(), pad_cluster);
+        proto_clusters.emplace_back(part->id(), pad_cluster);
       }
+    } // end of partition loop
+
+    // cluster selection: pick first maxClusters_ for now
+    for (unsigned iCluster = 0; iCluster < maxClusters_; ++iCluster){
+      const auto& p(proto_clusters[iCluster]);
+      out_clusters.insertDigi(ME0DetId(p.first), p.second);
     }
-  }
+  } // end of chamber loop
 }

--- a/SimMuon/GEMDigitizer/src/ME0PadDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PadDigiProducer.cc
@@ -51,8 +51,7 @@ void ME0PadDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetu
 
 void ME0PadDigiProducer::buildPads(const ME0DigiCollection &det_digis, ME0PadDigiCollection &out_pads) const
 {
-  const auto& etaPartitions = geometry_->etaPartitions();
-  for(const auto& p: etaPartitions)
+  for(const auto& p: geometry_->etaPartitions())
   {
     // set of <pad, bx> pairs, sorted first by pad then by bx
     std::set<std::pair<int, int> > proto_pads;

--- a/SimMuon/GEMDigitizer/src/ME0PadDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PadDigiProducer.cc
@@ -51,7 +51,7 @@ void ME0PadDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetu
 
 void ME0PadDigiProducer::buildPads(const ME0DigiCollection &det_digis, ME0PadDigiCollection &out_pads) const
 {
-  auto etaPartitions = geometry_->etaPartitions();
+  const auto& etaPartitions = geometry_->etaPartitions();
   for(const auto& p: etaPartitions)
   {
     // set of <pad, bx> pairs, sorted first by pad then by bx


### PR DESCRIPTION
GEM/ME0 cluster size is restricted to `maxClusterSize_` and max number of clusters to `maxClusters_`.  By default both parameters are set to 8 as specified in the GEM TDR and Muon Upgrade TDR.  Both GEM chambers (`GEMChamber`) and ME0 chambers (`ME0Layer`) are designed to send out max 8 clusters of 8 neighboring trigger pads. In case there are more than 8 clusters, the algorithm selects the first 8. The cluster selection procedure is expected to be optimized later.