### PR TITLE
PixelPhase Validation bin reduction and protection against memory leak.

### DIFF
--- a/Validation/SiPixelPhase1DigisV/python/SiPixelPhase1DigisV_cfi.py
+++ b/Validation/SiPixelPhase1DigisV/python/SiPixelPhase1DigisV_cfi.py
@@ -11,12 +11,13 @@ SiPixelPhase1DigisADC = DefaultHisto.clone(
   range_nbins = 300,
   topFolderName = "PixelPhase1V/Digis",
   specs = VPSet(
-    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
-    Specification().groupBy("PXForward/PXDisk/PXModuleName").save()
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save(),
+    StandardSpecification2DProfile,
   )
 )
 
-SiPixelPhase1DigisNdigis = DefaultHistoDigiCluster.clone(
+SiPixelPhase1DigisNdigis = DefaultHisto.clone(
   name = "digis", # 'Count of' added automatically
   title = "Digis",
   xlabel = "Number of Digis",
@@ -46,8 +47,9 @@ SiPixelPhase1DigisRows = DefaultHisto.clone(
   range_nbins = 200,
   topFolderName = "PixelPhase1V/Digis",
   specs = VPSet(
-    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
-    Specification().groupBy("PXForward/PXDisk/PXModuleName").save()
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save(),
+    StandardSpecification2DProfile,
   )
 )
 
@@ -60,8 +62,9 @@ SiPixelPhase1DigisColumns = DefaultHisto.clone(
   range_nbins = 300,
   topFolderName = "PixelPhase1V/Digis",
   specs = VPSet(
-    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
-    Specification().groupBy("PXForward/PXDisk/PXModuleName").save()
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save(),
+    StandardSpecification2DProfile,
  )
 )
 

--- a/Validation/SiPixelPhase1HitsV/interface/SiPixelPhase1HitsV.h
+++ b/Validation/SiPixelPhase1HitsV/interface/SiPixelPhase1HitsV.h
@@ -20,10 +20,7 @@ namespace reco {
 
 class SiPixelPhase1HitsV : public SiPixelPhase1Base {
   enum {
-    TOF_ETA,
-    TOF_PHI,
     TOF_R,
-    TOF_Z,
     ELOSS,
     ENTRY_EXIT_X,
     ENTRY_EXIT_Y,

--- a/Validation/SiPixelPhase1HitsV/python/SiPixelPhase1HitsV_cfi.py
+++ b/Validation/SiPixelPhase1HitsV/python/SiPixelPhase1HitsV_cfi.py
@@ -2,46 +2,13 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
 
-SiPixelPhase1HitsTofEta = DefaultHisto.clone(
-  name = "tof_eta",
-  title = "Time of flight vs #eta",
-  range_min = -4.0, range_max = 4.0, range_nbins = 5000,
-  range_y_min = -100, range_y_max = 100, range_y_nbins = 200,
-  xlabel = "#eta", ylabel = "Time of flight",
-  topFolderName = "PixelPhase1V/Hits",
-  dimensions = 2,
-  specs = VPSet(
-    Specification().groupBy("").save(),
-  )
-)
-
-SiPixelPhase1HitsTofPhi = SiPixelPhase1HitsTofEta.clone(
-  name = "tof_phi",
-  title = "Time of flight vs #phi",
-  range_min = -3.5, range_max = 3.5, range_nbins = 5000,
-  xlabel = "#phi",
-  dimensions = 2,
-  specs = VPSet(
-    Specification().groupBy("").save(),
-  )
-)  
-
-SiPixelPhase1HitsTofR = SiPixelPhase1HitsTofEta.clone(
+SiPixelPhase1HitsTofR = DefaultHisto.clone(
   name = "tof_r",
   title = "Time of flight vs r",
-  range_min = 0, range_max = 60, range_nbins = 5000,
-  xlabel = "r",
-  dimensions = 2,
-  specs = VPSet(
-    Specification().groupBy("").save(),
-  )
-)
-
-SiPixelPhase1HitsTofZ = SiPixelPhase1HitsTofEta.clone(
-  name = "tof_z",
-  title = "Time of flight vs z",
-  range_min = -60, range_max = 60, range_nbins = 5000,
-  xlabel = "z",
+  range_min = 0, range_max = 60, range_nbins = 500,
+  range_y_min = 0.0, range_y_max = 100.0, range_y_nbins = 100,
+  xlabel = "r", ylabel = "Time of flight",
+  topFolderName = "PixelPhase1V/Hits",
   dimensions = 2,
   specs = VPSet(
     Specification().groupBy("").save(),
@@ -56,8 +23,9 @@ SiPixelPhase1HitsEnergyLoss = DefaultHisto.clone(
   dimensions = 1,
   topFolderName = "PixelPhase1V/Hits",
   specs = VPSet(
-   Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
-   Specification().groupBy("PXForward/PXDisk/PXModuleName").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save(),
+    StandardSpecification2DProfile,
   )
 )
 
@@ -69,8 +37,9 @@ SiPixelPhase1HitsEntryExitX = DefaultHisto.clone(
   dimensions = 1,
   topFolderName = "PixelPhase1V/Hits",
   specs = VPSet(
-    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
-    Specification().groupBy("PXForward/PXDisk/PXModuleName").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save(),
+    StandardSpecification2DProfile,
   )
 )
 
@@ -96,8 +65,9 @@ SiPixelPhase1HitsPosX = DefaultHisto.clone(
   dimensions = 1,
   topFolderName = "PixelPhase1V/Hits",
   specs = VPSet(
-    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
-    Specification().groupBy("PXForward/PXDisk/PXModuleName").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save(),
+    StandardSpecification2DProfile,
   )
 )
 
@@ -141,10 +111,7 @@ SiPixelPhase1HitsEfficiencyTrack = DefaultHistoTrack.clone(
 )
 
 SiPixelPhase1HitsConf = cms.VPSet(
-  SiPixelPhase1HitsTofEta,
-  SiPixelPhase1HitsTofPhi,
   SiPixelPhase1HitsTofR,
-  SiPixelPhase1HitsTofZ,
   SiPixelPhase1HitsEnergyLoss,
   SiPixelPhase1HitsEntryExitX,
   SiPixelPhase1HitsEntryExitY,

--- a/Validation/SiPixelPhase1HitsV/python/SiPixelPhase1HitsV_cfi.py
+++ b/Validation/SiPixelPhase1HitsV/python/SiPixelPhase1HitsV_cfi.py
@@ -5,7 +5,7 @@ from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
 SiPixelPhase1HitsTofR = DefaultHisto.clone(
   name = "tof_r",
   title = "Time of flight vs r",
-  range_min = 0, range_max = 60, range_nbins = 500,
+  range_min = 0, range_max = 60, range_nbins = 2500,
   range_y_min = 0.0, range_y_max = 100.0, range_y_nbins = 100,
   xlabel = "r", ylabel = "Time of flight",
   topFolderName = "PixelPhase1V/Hits",

--- a/Validation/SiPixelPhase1HitsV/src/SiPixelPhase1HitsV.cc
+++ b/Validation/SiPixelPhase1HitsV/src/SiPixelPhase1HitsV.cc
@@ -9,6 +9,7 @@
 
 #include "Validation/SiPixelPhase1HitsV/interface/SiPixelPhase1HitsV.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
@@ -66,10 +67,7 @@ void SiPixelPhase1HitsV::analyze(const edm::Event& iEvent, const edm::EventSetup
     GlobalPoint gpos=det->toGlobal(it->localPosition());
 
     float tof = it->timeOfFlight();
-    float globalEta = gpos.eta();
-    float globalPhi = gpos.phi();
     float globalR = gpos.mag();
-    float globalZ = gpos.z();
 
     float energyLoss = it->energyLoss();
 
@@ -83,10 +81,7 @@ void SiPixelPhase1HitsV::analyze(const edm::Event& iEvent, const edm::EventSetup
     float localPhi = it->localPosition().phi();
     float localEta = it->localPosition().eta();
 
-    histo[TOF_ETA].fill(globalEta, tof, id, &iEvent);
-    histo[TOF_PHI].fill(globalPhi, tof, id, &iEvent);
     histo[TOF_R].fill(globalR, tof, id, &iEvent);
-    histo[TOF_Z].fill(globalZ, tof, id, &iEvent);
     histo[ELOSS].fill(energyLoss, id, &iEvent);
     histo[ENTRY_EXIT_X].fill(entryExitX, id, &iEvent);
     histo[ENTRY_EXIT_Y].fill(entryExitY, id, &iEvent);
@@ -104,10 +99,7 @@ void SiPixelPhase1HitsV::analyze(const edm::Event& iEvent, const edm::EventSetup
     GlobalPoint gpos=det->toGlobal(it->localPosition());
 
     float tof = it->timeOfFlight();
-    float globalEta = gpos.eta();
-    float globalPhi = gpos.phi();
     float globalR = gpos.mag();
-    float globalZ = gpos.z();
 
     float energyLoss = it->energyLoss();
 
@@ -121,10 +113,7 @@ void SiPixelPhase1HitsV::analyze(const edm::Event& iEvent, const edm::EventSetup
     float localPhi = it->localPosition().phi();
     float localEta = it->localPosition().eta();
 
-    histo[TOF_ETA].fill(globalEta, tof, id, &iEvent);
-    histo[TOF_PHI].fill(globalPhi, tof, id, &iEvent);
     histo[TOF_R].fill(globalR, tof, id, &iEvent);
-    histo[TOF_Z].fill(globalZ, tof, id, &iEvent);
     histo[ELOSS].fill(energyLoss, id, &iEvent);
     histo[ENTRY_EXIT_X].fill(entryExitX, id, &iEvent);
     histo[ENTRY_EXIT_Y].fill(entryExitY, id, &iEvent);
@@ -143,10 +132,7 @@ void SiPixelPhase1HitsV::analyze(const edm::Event& iEvent, const edm::EventSetup
     GlobalPoint gpos=det->toGlobal(it->localPosition());
 
     float tof = it->timeOfFlight();
-    float globalEta = gpos.eta();
-    float globalPhi = gpos.phi();
     float globalR = gpos.mag();
-    float globalZ = gpos.z();
 
     float energyLoss = it->energyLoss();
 
@@ -160,10 +146,7 @@ void SiPixelPhase1HitsV::analyze(const edm::Event& iEvent, const edm::EventSetup
     float localPhi = it->localPosition().phi();
     float localEta = it->localPosition().eta();
 
-    histo[TOF_ETA].fill(globalEta, tof, id, &iEvent);
-    histo[TOF_PHI].fill(globalPhi, tof, id, &iEvent);
     histo[TOF_R].fill(globalR, tof, id, &iEvent);
-    histo[TOF_Z].fill(globalZ, tof, id, &iEvent);
     histo[ELOSS].fill(energyLoss, id, &iEvent);
     histo[ENTRY_EXIT_X].fill(entryExitX, id, &iEvent);
     histo[ENTRY_EXIT_Y].fill(entryExitY, id, &iEvent);
@@ -182,10 +165,7 @@ void SiPixelPhase1HitsV::analyze(const edm::Event& iEvent, const edm::EventSetup
     GlobalPoint gpos=det->toGlobal(it->localPosition());
 
     float tof = it->timeOfFlight();
-    float globalEta = gpos.eta();
-    float globalPhi = gpos.phi();
     float globalR = gpos.mag();
-    float globalZ = gpos.z();
 
     float energyLoss = it->energyLoss();
 
@@ -199,10 +179,7 @@ void SiPixelPhase1HitsV::analyze(const edm::Event& iEvent, const edm::EventSetup
     float localPhi = it->localPosition().phi();
     float localEta = it->localPosition().eta();
 
-    histo[TOF_ETA].fill(globalEta, tof, id, &iEvent);
-    histo[TOF_PHI].fill(globalPhi, tof, id, &iEvent);
     histo[TOF_R].fill(globalR, tof, id, &iEvent);
-    histo[TOF_Z].fill(globalZ, tof, id, &iEvent);
     histo[ELOSS].fill(energyLoss, id, &iEvent);
     histo[ENTRY_EXIT_X].fill(entryExitX, id, &iEvent);
     histo[ENTRY_EXIT_Y].fill(entryExitY, id, &iEvent);
@@ -225,9 +202,10 @@ void SiPixelPhase1HitsV::analyze(const edm::Event& iEvent, const edm::EventSetup
 
   edm::Handle<reco::TrackToTrackingParticleAssociator> theHitsAssociator;
   iEvent.getByToken(trackAssociatorByHitsToken_,theHitsAssociator);
-  if ( theHitsAssociator.isValid() ) {
-    associatorByHits = theHitsAssociator.product();
+  if ( ! theHitsAssociator.isValid() ) {
+    throw cms::Exception ("NO VALID HIT ASSOCIATOR");
   }
+  associatorByHits = theHitsAssociator.product();
 
   if ( TPCollectionH.isValid() && trackCollectionH.isValid() ) {
     reco::RecoToSimCollection p = associatorByHits->associateRecoToSim(trackCollectionH,TPCollectionH);

--- a/Validation/SiPixelPhase1RecHitsV/python/SiPixelPhase1RecHitsV_cfi.py
+++ b/Validation/SiPixelPhase1RecHitsV/python/SiPixelPhase1RecHitsV_cfi.py
@@ -14,6 +14,7 @@ SiPixelPhase1RecHitsInTimeEvents = DefaultHisto.clone(
     Specification().groupBy("PXForward").save(),
     Specification().groupBy("PXBarrel/PXLayer").save(),
     Specification().groupBy("PXForward/PXDisk").save(),
+    StandardSpecification2DProfile,
   )
 )
 
@@ -29,6 +30,7 @@ SiPixelPhase1RecHitsOutTimeEvents = DefaultHisto.clone(
     Specification().groupBy("PXForward").save(),
     Specification().groupBy("PXBarrel/PXLayer").save(),
     Specification().groupBy("PXForward/PXDisk").save(),
+    StandardSpecification2DProfile,
   )
 )
 
@@ -43,6 +45,7 @@ SiPixelPhase1RecHitsNSimHits = DefaultHisto.clone(
   specs = VPSet(
     Specification().groupBy("PXBarrel/PXLayer").save(),
     Specification().groupBy("PXForward/PXDisk").save(),
+    StandardSpecification2DProfile,
   )
 )
 
@@ -58,8 +61,7 @@ SiPixelPhase1RecHitsPosX = DefaultHisto.clone(
     Specification().groupBy("PXForward").save(),
     Specification().groupBy("PXBarrel/PXLayer").save(),
     Specification().groupBy("PXForward/PXDisk").save(),
-    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
-    Specification().groupBy("PXForward/PXDisk/PXModuleName").save(),
+    StandardSpecification2DProfile,
   )
 )
 
@@ -80,8 +82,9 @@ SiPixelPhase1RecHitsResX = DefaultHisto.clone(
   specs = VPSet(
     Specification().groupBy("PXBarrel").save(),
     Specification().groupBy("PXForward").save(),
-    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
-    Specification().groupBy("PXForward/PXDisk/PXModuleName").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save(),
+    StandardSpecification2DProfile,
   )
 )
 
@@ -102,6 +105,7 @@ SiPixelPhase1RecHitsErrorX = DefaultHisto.clone(
     Specification().groupBy("").save(),
     Specification().groupBy("PXBarrel/PXLayer").save(),
     Specification().groupBy("PXForward/PXDisk").save(),
+    StandardSpecification2DProfile,
   )
 )
 
@@ -121,8 +125,7 @@ SiPixelPhase1RecHitsPullX = DefaultHisto.clone(
   specs = VPSet(
     Specification().groupBy("PXBarrel/PXLayer").save(),
     Specification().groupBy("PXForward/PXDisk").save(),
-    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
-    Specification().groupBy("PXForward/PXDisk/PXModuleName").save(),
+    StandardSpecification2DProfile,
   )
 )
 

--- a/Validation/SiPixelPhase1TrackClustersV/python/SiPixelPhase1TrackClustersV_cfi.py
+++ b/Validation/SiPixelPhase1TrackClustersV/python/SiPixelPhase1TrackClustersV_cfi.py
@@ -9,8 +9,9 @@ SiPixelPhase1TrackClustersCharge = DefaultHisto.clone(
   xlabel = "Charge size (in ke)",
   topFolderName = "PixelPhase1V/Clusters",
   specs = VPSet(
-    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
-    Specification().groupBy("PXForward/PXDisk/PXModuleName").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save(),
+    StandardSpecification2DProfile,
   )
 )
 
@@ -21,8 +22,9 @@ SiPixelPhase1TrackClustersSizeX = DefaultHisto.clone(
   xlabel = "Cluster size (in pixels)",
   topFolderName = "PixelPhase1V/Clusters",
   specs = VPSet(
-    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
-    Specification().groupBy("PXForward/PXDisk/PXModuleName").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save(),
+    StandardSpecification2DProfile,
   )
 )
 
@@ -33,8 +35,9 @@ SiPixelPhase1TrackClustersSizeY = DefaultHisto.clone(
   xlabel = "Cluster size (in pixels)",
   topFolderName = "PixelPhase1V/Clusters",
   specs = VPSet(
-    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
-    Specification().groupBy("PXForward/PXDisk/PXModuleName").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save(),
+    StandardSpecification2DProfile,
   )
 )
 


### PR DESCRIPTION
Updated plots: 
- Removed module level plots and replaced them with 1D plots per layer/disk, significantly reducing the number of bins used. 
- Maps per module per ladder/blade now exist where appropriate to provide module information information without significantly increasing the budget akin to the old 1D module level plots.
- Removed ToF plots deemed not as useful as ToF vs r (i.e. ToF vs eta/phi/z) and removed negative axis range (which was originally present due to copying the range used by the old pixel) as PSimHits do not have negative ToFs (unlike SimHits).

Added memory leak protection:
- PR https://github.com/cms-sw/cmssw/pull/19889 for Run 3 workflows exposed lack of check to ensure that `associatorByHits ` does exist , which was raised in https://github.com/cms-sw/cmssw/pull/19811#issuecomment-317524701 . A check and exception message has been added to ensure that the program terminates safely, does not experience a memory leak and 
- This does not resolve the non-existence of `associatorByHits ` in the Run 3 workflow. It is believed that the case has been identified. @kpedro88 and @davidcarbonis are working on this and a separate PR is planned to be opened to resolve this.

Other outstanding issues:
- The random differences noted in https://github.com/cms-sw/cmssw/pull/19811#issuecomment-316617004 in "PixelPhase1V/Run summary/TrackingParticle" between unrelated PRs, have not been forgotten but still need to be understood.

@davidlange6: I shall provide bin info shortly.

@fioriNTU will be interested in this.
