### PR TITLE
92x L1T uGT fix disagreement fw/emul OOT dcorrelations algorithms

### DIFF
--- a/L1Trigger/L1TGlobal/src/CorrCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrCondition.cc
@@ -705,10 +705,11 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 	    //If we are dealing with the same object type avoid the two legs
 	    // either being the same object
 	    if( cndObjTypeVec[0] == cndObjTypeVec[1] &&
-	               obj0Index == obj1Index ) {
+		obj0Index == obj1Index &&
+		cond0bx == cond1bx) {
 
-		       LogDebug("L1TGlobal") << "Corr Condition looking at same leg...skip" << std::endl;
-		       continue;
+	      LogDebug("L1TGlobal") << "Corr Condition looking at same leg...skip" << std::endl;
+	      continue;
 	    }
 
             switch (cond1Categ) {

--- a/L1Trigger/L1TGlobal/src/CorrCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrCondition.cc
@@ -172,7 +172,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
             reqObjResult = muCondition.condLastResult();
 
             cond0Comb = (muCondition.getCombinationsInCond());
-            cond0bx = (corrMuon->condRelativeBx());
+            cond0bx = bxEval + (corrMuon->condRelativeBx());
             cndObjTypeVec[0] = (corrMuon->objectType())[0];
 
             if (m_verbosity ) {
@@ -193,7 +193,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
             reqObjResult = caloCondition.condLastResult();
 
             cond0Comb = (caloCondition.getCombinationsInCond());
-            cond0bx = (corrCalo->condRelativeBx());
+            cond0bx = bxEval + (corrCalo->condRelativeBx());
             cndObjTypeVec[0] = (corrCalo->objectType())[0];
 
             if (m_verbosity) {
@@ -213,7 +213,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
             reqObjResult = eSumCondition.condLastResult();
 
             cond0Comb = (eSumCondition.getCombinationsInCond());
-            cond0bx = (corrEnergySum->condRelativeBx());
+            cond0bx = bxEval + (corrEnergySum->condRelativeBx());
             cndObjTypeVec[0] = (corrEnergySum->objectType())[0];
 
             if (m_verbosity ) {
@@ -252,7 +252,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
             reqObjResult = muCondition.condLastResult();
 
             cond1Comb = (muCondition.getCombinationsInCond());
-            cond1bx = (corrMuon->condRelativeBx());
+            cond1bx = bxEval + (corrMuon->condRelativeBx());
 
             cndObjTypeVec[1] = (corrMuon->objectType())[0];
 
@@ -273,7 +273,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
             reqObjResult = caloCondition.condLastResult();
 
             cond1Comb = (caloCondition.getCombinationsInCond());
-            cond1bx = (corrCalo->condRelativeBx());
+            cond1bx = bxEval + (corrCalo->condRelativeBx());
             cndObjTypeVec[1] = (corrCalo->objectType())[0];
 
             if (m_verbosity ) {
@@ -294,7 +294,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
             reqObjResult = eSumCondition.condLastResult();
 
             cond1Comb = (eSumCondition.getCombinationsInCond());
-            cond1bx = (corrEnergySum->condRelativeBx());
+            cond1bx = bxEval + (corrEnergySum->condRelativeBx());
             cndObjTypeVec[1] = (corrEnergySum->objectType())[0];
 
             if (m_verbosity) {
@@ -419,7 +419,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
         switch (cond0Categ) {
             case CondMuon: {
 	        lutObj0 = "MU";
-                candMuVec = m_uGtB->getCandL1Mu();
+		candMuVec = m_uGtB->getCandL1Mu();
                 phiIndex0 =  (candMuVec->at(cond0bx,obj0Index))->hwPhiAtVtx(); //(*candMuVec)[obj0Index]->phiIndex();
                 etaIndex0 =  (candMuVec->at(cond0bx,obj0Index))->hwEtaAtVtx();
 		etIndex0  =  (candMuVec->at(cond0bx,obj0Index))->hwPt();

--- a/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondition.cc
@@ -1225,7 +1225,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
               //If we are dealing with the same object type avoid the two legs
               // either being the same object
               if( cndObjTypeVec[0] == cndObjTypeVec[1] &&
-                obj0Index == obj1Index ) {
+		  obj0Index == obj1Index &&
+		  cond0bx == cond1bx) {
 
                 LogDebug("L1TGlobal") << "Corr Condition looking at same leg...skip" << std::endl;
                 continue;

--- a/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondition.cc
@@ -217,7 +217,7 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             reqObjResult = muCondition.condLastResult();
 
             cond0Comb = (muCondition.getCombinationsInCond());
-            cond0bx = (corrMuon->condRelativeBx());
+            cond0bx = bxEval + (corrMuon->condRelativeBx());
 
             cndObjTypeVec[0] = (corrMuon->objectType())[0];
 
@@ -239,7 +239,7 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             reqObjResult = caloCondition.condLastResult();
 
             cond0Comb = (caloCondition.getCombinationsInCond());
-            cond0bx = (corrCalo->condRelativeBx());
+            cond0bx = bxEval + (corrCalo->condRelativeBx());
 
             cndObjTypeVec[0] = (corrCalo->objectType())[0];
 
@@ -260,7 +260,7 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             reqObjResult = eSumCondition.condLastResult();
 
             cond0Comb = (eSumCondition.getCombinationsInCond());
-            cond0bx = (corrEnergySum->condRelativeBx());
+            cond0bx = bxEval + (corrEnergySum->condRelativeBx());
 
             cndObjTypeVec[0] = (corrEnergySum->objectType())[0];
 
@@ -300,7 +300,7 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             reqObjResult = muCondition.condLastResult();
 
             cond1Comb = (muCondition.getCombinationsInCond());
-            cond1bx = (corrMuon->condRelativeBx());
+            cond1bx = bxEval + (corrMuon->condRelativeBx());
             cndObjTypeVec[1] = (corrMuon->objectType())[0];
 
             if (m_verbosity) {
@@ -320,7 +320,7 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             reqObjResult = caloCondition.condLastResult();
 
             cond1Comb = (caloCondition.getCombinationsInCond());
-            cond1bx = (corrCalo->condRelativeBx());
+            cond1bx = bxEval + (corrCalo->condRelativeBx());
 
             cndObjTypeVec[1] = (corrCalo->objectType())[0];
 
@@ -342,7 +342,7 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             reqObjResult = eSumCondition.condLastResult();
 
             cond1Comb = (eSumCondition.getCombinationsInCond());
-            cond1bx = (corrEnergySum->condRelativeBx());
+            cond1bx = bxEval + (corrEnergySum->condRelativeBx());
             cndObjTypeVec[1] = (corrEnergySum->objectType())[0];
 
             if (m_verbosity) {
@@ -383,7 +383,7 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             reqObjResult = muCondition.condLastResult();
 
             cond2Comb = (muCondition.getCombinationsInCond());
-            cond2bx = (corrMuon->condRelativeBx());
+            cond2bx = bxEval + (corrMuon->condRelativeBx());
             cndObjTypeVec[2] = (corrMuon->objectType())[0];
 
             if (m_verbosity) {
@@ -403,7 +403,7 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             reqObjResult = caloCondition.condLastResult();
 
             cond2Comb = (caloCondition.getCombinationsInCond());
-            cond2bx = (corrCalo->condRelativeBx());
+            cond2bx = bxEval + (corrCalo->condRelativeBx());
             cndObjTypeVec[2] = (corrCalo->objectType())[0];
 
             if (m_verbosity ) {
@@ -424,7 +424,7 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             reqObjResult = eSumCondition.condLastResult();
 
             cond2Comb = (eSumCondition.getCombinationsInCond());
-            cond2bx = (corrEnergySum->condRelativeBx());
+            cond2bx = bxEval + (corrEnergySum->condRelativeBx());
             cndObjTypeVec[2] = (corrEnergySum->objectType())[0];
 
             if (m_verbosity) {


### PR DESCRIPTION
PR 92x (backport of #19994) needed for data taking.
- fix disagreement fw/emul OOT correlations algorithms (CDC algos in the L1T menu).
The fix is to have emulator correctly check BX for conditions.

Without this fix, the event are not accepted by L1T CDC algo when fw/emul disagree (large percentage).
Please merge for next data taking release if possible. 