### PR TITLE
gcc7 compilation warning(s) fix(es) in L1Trigger/GlobalTriggerAnalyzer

### DIFF
--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtBeamModeFilter.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtBeamModeFilter.cc
@@ -181,7 +181,7 @@ bool L1GtBeamModeFilter::filter(edm::Event& iEvent,
     //
 
     if (m_invertResult) {
-        filterResult = ~filterResult;
+        filterResult = !filterResult;
     }
 
     return filterResult;


### PR DESCRIPTION
Fining compiler warning listed here
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-07-31-1200/L1Trigger/GlobalTriggerAnalyzer