### PR TITLE
Avoid NaNs in SimClustering

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/Cluster3DPCACalculator.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Cluster3DPCACalculator.cc
@@ -87,9 +87,12 @@ calculateAndSetPositionActual(reco::PFCluster& cluster) {
     const double rh_fraction = rhf.fraction();
     rh_energy = refhit->energy()*rh_fraction;
     if( edm::isNotFinite(rh_energy) ) {
-      throw cms::Exception("PFClusterAlgo")
-	<<"rechit " << refhit->detId() << " has a NaN energy... " 
-	<< "The input of the particle flow clustering seems to be corrupted.";
+//temporarily changed exception to warning
+//      throw cms::Exception("PFClusterAlgo")
+      edm::LogWarning("PFClusterAlgo")
+      <<"rechit " << refhit->detId() << " has a NaN energy... " 
+      << "The input of the particle flow clustering seems to be corrupted.";
+      continue;
     }    
     pcavars[0] = refhit->position().x();
     pcavars[1] = refhit->position().y();

--- a/SimGeneral/CaloAnalysis/plugins/BuildFile.xml
+++ b/SimGeneral/CaloAnalysis/plugins/BuildFile.xml
@@ -24,6 +24,7 @@
 <use   name="Geometry/Records"/>
 <use   name="Geometry/HGCalGeometry"/>
 <use   name="Geometry/HcalTowerAlgo"/>
+<use   name="Geometry/HcalCommonData"/>
 <library   file="*.cc" name="SimGeneralCaloAnalysisPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/SimGeneral/CaloAnalysis/plugins/BuildFile.xml
+++ b/SimGeneral/CaloAnalysis/plugins/BuildFile.xml
@@ -21,6 +21,7 @@
 <use   name="SimGeneral/MixingModule"/>
 <use   name="SimDataFormats/CaloTest"/>
 <use   name="DataFormats/ForwardDetId"/>
+<use   name="DataFormats/HcalDetId"/>
 <use   name="Geometry/Records"/>
 <use   name="Geometry/HGCalGeometry"/>
 <use   name="Geometry/HcalTowerAlgo"/>

--- a/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
+++ b/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
@@ -149,7 +149,7 @@ void CaloTruthAccumulator::finalizeEvent( edm::Event& event, edm::EventSetup con
       const float totalenergy = m_detIdToTotalSimEnergy[hAndE.first];
       float fraction = 0.;
       if(totalenergy>0) fraction = hAndE.second/totalenergy;
-      else edm::LogWarning("CaloTruthAccumulator") << "TotalSimEnergy for hAndE.first is 0! The fraction for this hit cannot be computed.";
+      else edm::LogWarning("CaloTruthAccumulator") << "TotalSimEnergy for hit " << hAndE.first << " is 0! The fraction for this hit cannot be computed.";
       sc.addRecHitAndFraction(hAndE.first,fraction);
     }
   }

--- a/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
+++ b/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
@@ -30,6 +30,7 @@
 
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/HcalCommonData/interface/HcalHitRelabeller.h"
 
 #include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
@@ -429,13 +430,7 @@ template<class T> void CaloTruthAccumulator::fillSimHits( std::vector<std::pair<
       DetId id(0);
       const uint32_t simId = simHit.id();
       if( isHcal ) {
-	int subdet, z, depth0, eta0, phi0, lay;
-	HcalTestNumbering::unpackHcalIndex(simId, subdet, z, depth0, eta0, phi0, lay);
-	int sign = (z==0) ? (-1):(1);
-	HcalDDDRecConstants::HcalID tempid = hcddd_->getHCID(subdet, sign*eta0, phi0, lay, depth0);
-	if (subdet==int(HcalEndcap)) {
-	  id = HcalDetId(HcalEndcap,sign*tempid.eta,tempid.phi,tempid.depth);    
-	}
+        id = HcalHitRelabeller::relabel(simId, hcddd_);
       } else {
 	int subdet, layer, cell, sec, subsec, zp;
 	HGCalTestNumbering::unpackHexagonIndex(simId, subdet, zp, layer, sec, subsec, cell); 

--- a/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
+++ b/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
@@ -5,6 +5,7 @@
 #include "SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.h"
 
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "SimDataFormats/CaloTest/interface/HGCalTestNumbering.h"
 #include "DataFormats/HcalDetId/interface/HcalTestNumbering.h"
 #include "SimDataFormats/Vertex/interface/SimVertex.h"
@@ -430,7 +431,8 @@ template<class T> void CaloTruthAccumulator::fillSimHits( std::vector<std::pair<
       DetId id(0);
       const uint32_t simId = simHit.id();
       if( isHcal ) {
-        id = HcalHitRelabeller::relabel(simId, hcddd_);
+        HcalDetId hid = HcalHitRelabeller::relabel(simId, hcddd_);
+        if(hid.subdet()==HcalEndcap) id = hid;
       } else {
 	int subdet, layer, cell, sec, subsec, zp;
 	HGCalTestNumbering::unpackHexagonIndex(simId, subdet, zp, layer, sec, subsec, cell); 

--- a/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
+++ b/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
@@ -146,7 +146,10 @@ void CaloTruthAccumulator::finalizeEvent( edm::Event& event, edm::EventSetup con
     auto hitsAndEnergies = sc.hits_and_fractions();
     sc.clearHitsAndFractions();
     for( auto& hAndE : hitsAndEnergies ) {
-      const float fraction = hAndE.second/m_detIdToTotalSimEnergy[hAndE.first];
+      const float totalenergy = m_detIdToTotalSimEnergy[hAndE.first];
+      float fraction = 0.;
+      if(totalenergy>0) fraction = hAndE.second/totalenergy;
+      else edm::LogWarning("CaloTruthAccumulator") << "TotalSimEnergy for hAndE.first is 0! The fraction for this hit cannot be computed.";
       sc.addRecHitAndFraction(hAndE.first,fraction);
     }
   }


### PR DESCRIPTION
Some Phase 2 TDR production workflows encountered SimClusters with NaN fractions for certain hits.

I found the likely culprit in `CaloTruthAccumulator` that could make NaN values, and added a protection. I also changed the exception in `Cluster3DPCACalculator` to a warning, so the jobs can still run in case there's another problem that I missed. (These NaNs happen very rarely and are almost impossible to reproduce given we're running 200PU w/ 4 threads.)

This PR will be backported to 91X.

attn: @lgray 