### PR TITLE
gcc7 compilation warning(s) fix SimG4Core/Application

### DIFF
--- a/SimG4Core/Application/src/ElectronLimiter.cc
+++ b/SimG4Core/Application/src/ElectronLimiter.cc
@@ -18,7 +18,7 @@ ElectronLimiter::ElectronLimiter(const edm::ParameterSet & p)
   // set Process Sub Type
   SetProcessSubType(static_cast<int>(STEP_LIMITER));
 
-  minStepLimit = p.getParameter<double>("MinStepLimit")*mm;
+  minStepLimit = p.getParameter<double>("MinStepLimit")*mm > 0;
   rangeCheckFlag = false;
   fieldCheckFlag = false;
   killTrack = false;


### PR DESCRIPTION
Fining compiler warning listed here
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-07-31-1200/SimG4Core/Application