### PR TITLE
Modify CaloLayer1 emulator to properly handle saturation in all cases

### DIFF
--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
@@ -99,6 +99,7 @@ private:
   bool verbose;
   bool unpackHcalMask;
   bool unpackEcalMask;
+  int  fwVersion;
 
   UCTLayer1 *layer1;
 
@@ -131,13 +132,13 @@ L1TCaloLayer1::L1TCaloLayer1(const edm::ParameterSet& iConfig) :
   useHFLUT(iConfig.getParameter<bool>("useHFLUT")),
   verbose(iConfig.getParameter<bool>("verbose")), 
   unpackHcalMask(iConfig.getParameter<bool>("unpackHcalMask")),
-  unpackEcalMask(iConfig.getParameter<bool>("unpackEcalMask"))
+  unpackEcalMask(iConfig.getParameter<bool>("unpackEcalMask")),
+  fwVersion(iConfig.getParameter<int>("firmwareVersion"))
 {
   produces<CaloTowerBxCollection>();
   produces<L1CaloRegionCollection>();
 
   // See UCTLayer1.hh for firmware version definitions
-  int fwVersion = iConfig.getParameter<int>("firmwareVersion");
   layer1 = new UCTLayer1(fwVersion);
 
   vector<UCTCrate*> crates = layer1->getCrates();
@@ -309,7 +310,7 @@ L1TCaloLayer1::endJob() {
 void
 L1TCaloLayer1::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup)
 {
-  if(!L1TCaloLayer1FetchLUTs(iSetup, ecalLUT, hcalLUT, hfLUT, ePhiMap, hPhiMap, hfPhiMap, useLSB, useCalib, useECALLUT, useHCALLUT, useHFLUT)) {
+  if(!L1TCaloLayer1FetchLUTs(iSetup, ecalLUT, hcalLUT, hfLUT, ePhiMap, hPhiMap, hfPhiMap, useLSB, useCalib, useECALLUT, useHCALLUT, useHFLUT, fwVersion)) {
     LOG_ERROR << "L1TCaloLayer1::beginRun: failed to fetch LUTS - using unity" << std::endl;
     std::array< std::array< std::array<uint32_t, nEtBins>, nCalSideBins >, nCalEtaBins> eCalLayer1EtaSideEtArray;
     std::array< std::array< std::array<uint32_t, nEtBins>, nCalSideBins >, nCalEtaBins> hCalLayer1EtaSideEtArray;

--- a/L1Trigger/L1TCaloLayer1/python/simCaloStage2Layer1Digis_cfi.py
+++ b/L1Trigger/L1TCaloLayer1/python/simCaloStage2Layer1Digis_cfi.py
@@ -18,5 +18,5 @@ simCaloStage2Layer1Digis = cms.EDProducer(
     unpackEcalMask = cms.bool(False),
     unpackHcalMask = cms.bool(False),
     # See UCTLayer1.hh for firmware version
-    firmwareVersion = cms.int32(1),
+    firmwareVersion = cms.int32(3),
     )

--- a/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.hh
+++ b/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.hh
@@ -18,6 +18,7 @@ bool L1TCaloLayer1FetchLUTs(const edm::EventSetup& iSetup,
 			    bool useCalib = true,
 			    bool useECALLUT = true,
 			    bool useHCALLUT = true,
-                            bool useHFLUT = true);
+                            bool useHFLUT = true,
+                            int fwVersion = 0);
 
 #endif

--- a/L1Trigger/L1TCaloLayer1/src/UCTLayer1.hh
+++ b/L1Trigger/L1TCaloLayer1/src/UCTLayer1.hh
@@ -16,6 +16,10 @@ public:
   // Default (0): initial version for 2016 running
   // 1: Update to include saturated tower codes to layer 2
   //    (put online at run >= 275908: http://cmsonline.cern.ch/cms-elog/931059)
+  // 2: Update for all-LUT processing, initially no change in behavior
+  //    (put online at run >= 291173: http://cmsonline.cern.ch/cms-elog/973914)
+  // 3: Update to handle saturation codes HF (and do division in LUT, and consider HBHE saturation before decompression)
+  //    (put online at run >= ?: )
   //
   UCTLayer1(int fwv=0);
 


### PR DESCRIPTION
Backport of #20000
Necessary (at least) for online DQM data-emulator comparisons