### PR TITLE
DetectorDescription Clang Crash Bug Fix

### DIFF
--- a/DetectorDescription/Core/interface/DDTransform.h
+++ b/DetectorDescription/Core/interface/DDTransform.h
@@ -16,6 +16,9 @@ std::ostream & operator<<(std::ostream &, const DDRotation &);
 DDRotation DDrot(const DDName & name,
                  DDRotationMatrix * rot);
 
+DDRotation * DDrotPtr(const DDName & name,
+		      DDRotationMatrix * rot);
+
 //! Definition of a uniquely identifiable rotation matrix named by DDName \a name in the GEANT3 style
 /** DDrot() returns a reference-object DDRotation representing the rotation matrix.
 */
@@ -65,6 +68,7 @@ class DDRotation : public DDBase<DDName,DDRotationMatrix*>
 {
   friend std::ostream & operator<<(std::ostream &, const DDRotation &);
   friend DDRotation DDrot(const DDName &, DDRotationMatrix *);
+  friend DDRotation* DDrotPtr(const DDName &, DDRotationMatrix *);
   friend DDRotation DDrotReflect(const DDName&,double,double,double,double,double,double);
   friend DDRotation DDanonymousRot(DDRotationMatrix*);
 public:

--- a/DetectorDescription/Core/interface/DDTransform.h
+++ b/DetectorDescription/Core/interface/DDTransform.h
@@ -16,8 +16,8 @@ std::ostream & operator<<(std::ostream &, const DDRotation &);
 DDRotation DDrot(const DDName & name,
                  DDRotationMatrix * rot);
 
-DDRotation * DDrotPtr(const DDName & name,
-		      DDRotationMatrix * rot);
+std::unique_ptr<DDRotation> DDrotPtr(const DDName & name,
+				     DDRotationMatrix * rot);
 
 //! Definition of a uniquely identifiable rotation matrix named by DDName \a name in the GEANT3 style
 /** DDrot() returns a reference-object DDRotation representing the rotation matrix.
@@ -68,7 +68,7 @@ class DDRotation : public DDBase<DDName,DDRotationMatrix*>
 {
   friend std::ostream & operator<<(std::ostream &, const DDRotation &);
   friend DDRotation DDrot(const DDName &, DDRotationMatrix *);
-  friend DDRotation* DDrotPtr(const DDName &, DDRotationMatrix *);
+  friend std::unique_ptr<DDRotation> DDrotPtr(const DDName &, DDRotationMatrix *);
   friend DDRotation DDrotReflect(const DDName&,double,double,double,double,double,double);
   friend DDRotation DDanonymousRot(DDRotationMatrix*);
 public:

--- a/DetectorDescription/Core/src/DDRotation.cc
+++ b/DetectorDescription/Core/src/DDRotation.cc
@@ -53,7 +53,7 @@ DDRotation::DDRotation() : DDBase<DDName,DDRotationMatrix*>()
   char buf[64];
   snprintf(buf, 64, "%s%i", baseName, countBlank++);
   prep_ = StoreT::instance().create(DDName(buf,baseName), new DDRotationMatrix );
-  //  std::cout << "making a BLANK " << buf << " named rotation, " << prep_->second << std::endl;
+  // std::cout << "making a BLANK " << buf << " named rotation, " << prep_->second << std::endl;
 }
 
 
@@ -79,7 +79,7 @@ DDRotation::DDRotation(DDRotationMatrix * rot)
   char buf[64];
   snprintf(buf, 64, "DdNoNa%i", countNN++);
   prep_ = StoreT::instance().create(DDName(buf, "DdNoNa"), rot);
-  //  std::cout << "making a NO-NAME " << buf << " named rotation, " << prep_->second << std::endl;
+  // std::cout << "making a NO-NAME " << buf << " named rotation, " << prep_->second << std::endl;
 }
 
 // void DDRotation::clear()
@@ -91,6 +91,12 @@ DDRotation DDrot(const DDName & ddname, DDRotationMatrix * rot)
 {
    // memory of rot goes sto DDRotationImpl!!
    return DDRotation(ddname, rot);
+}
+
+DDRotation* DDrotPtr(const DDName & ddname, DDRotationMatrix * rot)
+{
+   // memory of rot goes sto DDRotationImpl!!
+   return new DDRotation(ddname, rot);
 }
  
 // makes sure that the DDRotationMatrix constructed is right-handed and orthogonal.

--- a/DetectorDescription/Core/src/DDRotation.cc
+++ b/DetectorDescription/Core/src/DDRotation.cc
@@ -93,10 +93,10 @@ DDRotation DDrot(const DDName & ddname, DDRotationMatrix * rot)
    return DDRotation(ddname, rot);
 }
 
-DDRotation* DDrotPtr(const DDName & ddname, DDRotationMatrix * rot)
+std::unique_ptr<DDRotation> DDrotPtr(const DDName & ddname, DDRotationMatrix * rot)
 {
    // memory of rot goes sto DDRotationImpl!!
-   return new DDRotation(ddname, rot);
+  return std::make_unique<DDRotation>(ddname, rot);
 }
  
 // makes sure that the DDRotationMatrix constructed is right-handed and orthogonal.

--- a/DetectorDescription/Parser/src/DDLPosPart.cc
+++ b/DetectorDescription/Parser/src/DDLPosPart.cc
@@ -93,17 +93,13 @@ DDLPosPart::processElement( const std::string& name, const std::string& nmspace,
   DDRotation* myDDRotation;
   // if rotation is named ...
   if ( rotn.name() != "" && rotn.ns() != "" ) {
-    DDRotation temp(rotn);
-    myDDRotation = &temp;
+    myDDRotation = new DDRotation(rotn);
   } else { 
     // rotn is not assigned a name anywhere therefore the DDPos assumes the identity matrix.
-    DDRotation temp(DDName(std::string("identity"),std::string("generatedForDDD")));
-    myDDRotation = &temp;
+    myDDRotation = new DDRotation(DDName(std::string("identity"),std::string("generatedForDDD")));
     // if the identity is not yet defined, then...
     if ( !myDDRotation->isValid() ) {
-      DDRotationMatrix* dmr = new DDRotationMatrix;
-      temp = DDrot(DDName(std::string("identity"),std::string("generatedForDDD")), dmr );
-      myDDRotation = &temp;
+      myDDRotation = DDrotPtr(DDName(std::string("identity"),std::string("generatedForDDD")), new DDRotationMatrix );
     }
   }
 

--- a/DetectorDescription/Parser/src/DDLPosPart.cc
+++ b/DetectorDescription/Parser/src/DDLPosPart.cc
@@ -90,13 +90,13 @@ DDLPosPart::processElement( const std::string& name, const std::string& nmspace,
     z = ev.eval(nmspace, atts.find("z")->second);
   }
 
-  DDRotation* myDDRotation;
+  std::unique_ptr<DDRotation> myDDRotation;
   // if rotation is named ...
   if ( rotn.name() != "" && rotn.ns() != "" ) {
-    myDDRotation = new DDRotation(rotn);
+    myDDRotation = std::make_unique<DDRotation>(rotn);
   } else { 
     // rotn is not assigned a name anywhere therefore the DDPos assumes the identity matrix.
-    myDDRotation = new DDRotation(DDName(std::string("identity"),std::string("generatedForDDD")));
+    myDDRotation = std::make_unique<DDRotation>(DDName(std::string("identity"),std::string("generatedForDDD")));
     // if the identity is not yet defined, then...
     if ( !myDDRotation->isValid() ) {
       myDDRotation = DDrotPtr(DDName(std::string("identity"),std::string("generatedForDDD")), new DDRotationMatrix );


### PR DESCRIPTION
* Avoid using temporary references which are cleaned up by clang meticulously

@Dr15Jones and @smuzaffar - FYI
