### PR TITLE
 Minor bug fix in hltGetConfiguration - 93X

### DIFF
--- a/HLTrigger/Configuration/python/Tools/confdb.py
+++ b/HLTrigger/Configuration/python/Tools/confdb.py
@@ -530,41 +530,15 @@ from HLTrigger.Configuration.CustomConfigs import L1REPACK
     quote = '[\'\"]'
     self.data = re.compile(r'^(process\s*=\s*cms\.Process\(\s*' + quote + r')\w+(' + quote + r'\s*\).*)$', re.MULTILINE).sub(r'\1%s\2' % self.config.name, self.data, 1)
 
-    # the following was stolen and adapted from HLTrigger.Configuration.customL1THLT_Options
-    self.data += """
-# adapt HLT modules to the correct process name
-if 'hltTrigReport' in %%(dict)s:
-    %%(process)s.hltTrigReport.HLTriggerResults                    = cms.InputTag( 'TriggerResults', '', '%(name)s' )
-
-if 'hltPreExpressCosmicsOutputSmart' in %%(dict)s:
-    %%(process)s.hltPreExpressCosmicsOutputSmart.hltResults = cms.InputTag( 'TriggerResults', '', '%(name)s' )
-
-if 'hltPreExpressOutputSmart' in %%(dict)s:
-    %%(process)s.hltPreExpressOutputSmart.hltResults        = cms.InputTag( 'TriggerResults', '', '%(name)s' )
-
-if 'hltPreDQMForHIOutputSmart' in %%(dict)s:
-    %%(process)s.hltPreDQMForHIOutputSmart.hltResults       = cms.InputTag( 'TriggerResults', '', '%(name)s' )
-
-if 'hltPreDQMForPPOutputSmart' in %%(dict)s:
-    %%(process)s.hltPreDQMForPPOutputSmart.hltResults       = cms.InputTag( 'TriggerResults', '', '%(name)s' )
-
-if 'hltPreHLTDQMResultsOutputSmart' in %%(dict)s:
-    %%(process)s.hltPreHLTDQMResultsOutputSmart.hltResults  = cms.InputTag( 'TriggerResults', '', '%(name)s' )
-
-if 'hltPreHLTDQMOutputSmart' in %%(dict)s:
-    %%(process)s.hltPreHLTDQMOutputSmart.hltResults         = cms.InputTag( 'TriggerResults', '', '%(name)s' )
-
-if 'hltPreHLTMONOutputSmart' in %%(dict)s:
-    %%(process)s.hltPreHLTMONOutputSmart.hltResults         = cms.InputTag( 'TriggerResults', '', '%(name)s' )
-
-if 'hltDQMHLTScalers' in %%(dict)s:
-    %%(process)s.hltDQMHLTScalers.triggerResults                   = cms.InputTag( 'TriggerResults', '', '%(name)s' )
-    %%(process)s.hltDQMHLTScalers.processname                      = '%(name)s'
-
-if 'hltDQML1SeedLogicScalers' in %%(dict)s:
-    %%(process)s.hltDQML1SeedLogicScalers.processname              = '%(name)s'
-""" % self.config.__dict__
-
+    # when --setup option is used, remove possible errors from PrescaleService due to missing HLT paths.
+    if self.config.setup: self.data += """
+# avoid PrescaleService error due to missing HLT paths
+if 'PrescaleService' in process.__dict__:
+    for pset in reversed(process.PrescaleService.prescaleTable):
+        if not hasattr(process,pset.pathName.value()):
+            process.PrescaleService.prescaleTable.remove(pset)
+"""
+    
 
   def updateMessageLogger(self):
     # request summary informations from the MessageLogger


### PR DESCRIPTION
This PR solve the following bug related to '--setup' option:
`hltGetConfiguration /users/gennai/PFMET_MHT_Cleaned/V6  --full --offline --data --process MYHLT --globaltag 92X_upgrade2017_realistic_v7  --no-output --max-events -1 --setup /dev/CMSSW_9_2_0/GRun  --input /store/relval/CMSSW_9_2_7/RelValTTbar_13/GEN-SIM-DIGI-RAW/PU25ns_92X_upgrade2017_realistic_v7-v1/00000/028A4997-C570-E711-8116-0CC47A7AB7A0.root --l1-emulator uGT  --l1 L1Menu_Collisions2017_v2_m6_full_xml  > hlt.py &`

It give the error
```
----- Begin Fatal Exception 01-Aug-2017 15:43:52 CEST-----------------------
An exception of category 'PrescaleServiceConfigError' occurred while
   [0] Calling beginJob
Exception Message:
 Path 'AlCa_EcalPhiSym_v8' is unknown or does not contain any HLTPrescaler!
----- End Fatal Exception ------------------------------------------------- 

```

This has been fixed removing all PSets in PrescaleService pointing to missing HLT paths.

This PR removes also a customization part that is obsolete since we are using '@currentProcess' in HLT menu (see CMSHLT-1466) 

PR 93X: #20003 