### PR TITLE
rearranging some plots saving bins

### DIFF
--- a/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
@@ -40,7 +40,7 @@ PerLadder = cms.PSet(enabled = cms.bool(True)) # histos per ladder, profiles
 PerLayer2D = cms.PSet(enabled = cms.bool(True)) # 2D maps/profiles of layers
 PerLayer1D = cms.PSet(enabled = cms.bool(True)) # normal histos per layer
 PerReadout = cms.PSet(enabled = cms.bool(True)) # "Readout view", also for initial timing
-OverlayCurvesForTiming= cms.PSet(enabled = cms.bool(True)) #switch to overlay digi/clusters curves for timing scan
+OverlayCurvesForTiming= cms.PSet(enabled = cms.bool(False)) #switch to overlay digi/clusters curves for timing scan
 
 # Default histogram configuration. This is _not_ used automatically, but you
 # can import and pass this (or clones of it) in the plugin config.

--- a/DQM/SiPixelPhase1RecHits/python/SiPixelPhase1RecHits_cfi.py
+++ b/DQM/SiPixelPhase1RecHits/python/SiPixelPhase1RecHits_cfi.py
@@ -18,10 +18,10 @@ SiPixelPhase1RecHitsNRecHits = DefaultHistoTrack.clone(
 )
 
 SiPixelPhase1RecHitsClustX = DefaultHistoTrack.clone(
-  name = "rechitsize_x",
-  title = "X size of RecHit clusters",
+  name = "clustersize_x",
+  title = "Cluster Size X (OnTrack)",
   range_min = 0, range_max = 50, range_nbins = 50,
-  xlabel = "RecHit X-Size",
+  xlabel = "size[pixels]",
   dimensions = 1,
   specs = VPSet(
     StandardSpecification2DProfile
@@ -29,9 +29,9 @@ SiPixelPhase1RecHitsClustX = DefaultHistoTrack.clone(
 )
 
 SiPixelPhase1RecHitsClustY = SiPixelPhase1RecHitsClustX.clone(
-  name = "rechitsize_y",
-  title = "Y size of RecHit clusters",
-  xlabel = "RecHit Y-Size"
+  name = "clustersize_y",
+  title = "Cluster Size Y (OnTrack)",
+  xlabel = "size[pixels]"
 )
 
 SiPixelPhase1RecHitsErrorX = DefaultHistoTrack.clone(
@@ -75,7 +75,23 @@ SiPixelPhase1RecHitsProb = DefaultHistoTrack.clone(
   range_min = -10, range_max = 1, range_nbins = 50,
   dimensions = 1,
   specs = VPSet(
-    StandardSpecifications1D
+
+        Specification().groupBy("PXBarrel/PXLayer").saveAll(),
+        Specification().groupBy("PXForward/PXDisk").saveAll(),
+        StandardSpecification2DProfile,
+    
+        Specification().groupBy("PXBarrel/PXLayer/Lumisection")
+                       .reduce("MEAN")
+                       .groupBy("PXBarrel/PXLayer", "EXTEND_X")
+                       .save(),
+
+        Specification().groupBy("PXForward/PXDisk/Lumisection")
+                       .reduce("MEAN")
+                       .groupBy("PXForward/PXDisk", "EXTEND_X")
+                       .save(),
+
+        Specification(PerLayer1D).groupBy("PXBarrel/Shell/PXLayer").save(),
+        Specification(PerLayer1D).groupBy("PXForward/HalfCylinder/PXRing/PXDisk").save()
   )
 )
 

--- a/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
+++ b/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
@@ -5,35 +5,21 @@ from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
 SiPixelPhase1TrackClustersOnTrackCharge = DefaultHistoTrack.clone(
   name = "charge",
   title = "Corrected Cluster Charge (OnTrack)",
-  range_min = 0, range_max = 200e3, range_nbins = 100,
+  range_min = 0, range_max = 150e3, range_nbins = 100,
   xlabel = "Charge (electrons)",
 
   specs = VPSet(
-    Specification().groupBy("PXBarrel/PXLayer").saveAll(),
-    Specification().groupBy("PXForward/PXDisk").saveAll(),
-    StandardSpecification2DProfile,#what is below is only for the timing client
-
+    StandardSpecifications1D,    
+    StandardSpecification2DProfile,
+    
+    #what is below is only for the timing client    
     Specification(OverlayCurvesForTiming).groupBy("PXBarrel/OnlineBlock")
          .groupBy("PXBarrel", "EXTEND_Y")
          .save(),
     Specification(OverlayCurvesForTiming).groupBy("PXForward/OnlineBlock")
-          .groupBy("PXForward", "EXTEND_Y")
-          .save(),
-    
-    Specification().groupBy("PXBarrel/PXLayer/Lumisection")
-                   .reduce("MEAN")
-                   .groupBy("PXBarrel/PXLayer", "EXTEND_X")
-                   .save(),
+         .groupBy("PXForward", "EXTEND_Y")
+         .save(),
 
-    Specification().groupBy("PXForward/PXDisk/Lumisection")
-                   .reduce("MEAN")
-                   .groupBy("PXForward/PXDisk", "EXTEND_X")
-                   .save(),
-
-    Specification(PerLayer1D).groupBy("PXBarrel/Shell/PXLayer").save(),
-    Specification(PerLayer1D).groupBy("PXForward/HalfCylinder/PXRing/PXDisk").save(),
-
-    
     Specification(OverlayCurvesForTiming).groupBy("PXForward/PXDisk/OnlineBlock") # per-layer with history for online
                    .groupBy("PXForward/PXDisk", "EXTEND_Y")
                    .save(),
@@ -50,23 +36,8 @@ SiPixelPhase1TrackClustersOnTrackSize = DefaultHistoTrack.clone(
   xlabel = "size[pixels]",
 
   specs = VPSet(
-    Specification().groupBy("PXBarrel/PXLayer").saveAll(),
-    Specification().groupBy("PXForward/PXDisk").saveAll(),
-    StandardSpecification2DProfile,
-
-    Specification().groupBy("PXBarrel/PXLayer/Lumisection")
-                   .reduce("MEAN")
-                   .groupBy("PXBarrel/PXLayer", "EXTEND_X")
-                   .save(),
-
-    Specification().groupBy("PXForward/PXDisk/Lumisection")
-                   .reduce("MEAN")
-                   .groupBy("PXForward/PXDisk", "EXTEND_X")
-                   .save(),
-
-    Specification(PerLayer1D).groupBy("PXBarrel/Shell/PXLayer").save(),
-    Specification(PerLayer1D).groupBy("PXForward/HalfCylinder/PXRing/PXDisk").save()
-
+        StandardSpecifications1D,    
+        StandardSpecification2DProfile
   )
 )
 
@@ -101,7 +72,7 @@ SiPixelPhase1TrackClustersOnTrackShape = DefaultHistoTrack.clone(
 
 SiPixelPhase1TrackClustersOnTrackNClusters = DefaultHistoTrack.clone(
   name = "clusters_ontrack",
-  title = "Clusters_onTrack",
+  title = "Clusters_onTrack (valid hits)",
   range_min = 0, range_max = 30, range_nbins = 30,
   xlabel = "clusters",
   dimensions = 0,
@@ -237,6 +208,7 @@ SiPixelPhase1ClustersSizeVsEtaOnTrackOuter = DefaultHistoTrack.clone(
     Specification().groupBy("PXBarrel/PXLayer").save()
   )
 )
+
 SiPixelPhase1ClustersSizeVsEtaOnTrackInner = SiPixelPhase1ClustersSizeVsEtaOnTrackOuter.clone(
   name = "sizeyvseta_on_track_inner",
   title = "Cluster Size along Beamline vs. Track #eta (OnTrack) inner ladders",
@@ -251,10 +223,12 @@ SiPixelPhase1TrackClustersOnTrackSizeYOuter = SiPixelPhase1ClustersSizeVsEtaOnTr
   ylabel = "length [pixels]",
   range_min = 0, range_max  = 30, range_nbins   = 60
 )
+
 SiPixelPhase1TrackClustersOnTrackSizeYInner = SiPixelPhase1TrackClustersOnTrackSizeYOuter.clone(
   name = "sizey_on_track_inner",
   title = "Cluster Size along Beamline vs. prediction (OnTrack) inner ladders",
 )
+
 SiPixelPhase1TrackClustersOnTrackSizeYF = SiPixelPhase1TrackClustersOnTrackSizeYOuter.clone(
   name = "sizey_on_track_forward",
   title = "Cluster Size ortogonal to Beamline vs. prediction (OnTrack) forward",
@@ -273,10 +247,12 @@ SiPixelPhase1TrackClustersOnTrackSizeXOuter = SiPixelPhase1TrackClustersOnTrackS
   range_y_min =  0, range_y_max = 8, range_y_nbins = 8
 
 )
+
 SiPixelPhase1TrackClustersOnTrackSizeXInner = SiPixelPhase1TrackClustersOnTrackSizeXOuter.clone(
   name = "sizex_on_track_inner",
   title = "Cluster Size along radial vs. prediction (OnTrack) inner ladders",
 )
+
 SiPixelPhase1TrackClustersOnTrackSizeXF = SiPixelPhase1TrackClustersOnTrackSizeYF.clone(
   name = "sizex_on_track_forward",
   title = "Cluster Size radial vs. prediction (OnTrack) forward",
@@ -292,10 +268,12 @@ SiPixelPhase1TrackClustersOnTrackSizeXYOuter = SiPixelPhase1TrackClustersOnTrack
   range_min = 0, range_max  = 20, range_nbins   = 20,
   range_y_min = 0, range_y_max = 10, range_y_nbins = 10 
 )
+
 SiPixelPhase1TrackClustersOnTrackSizeXYInner = SiPixelPhase1TrackClustersOnTrackSizeXYOuter.clone(
  name = "sizexy_on_track_inner",
  title = "Cluster Size x vs y (OnTrack) inner ladders"
 )
+
 SiPixelPhase1TrackClustersOnTrackSizeXYF = SiPixelPhase1TrackClustersOnTrackSizeYF.clone(
   name = "sizexy_on_track_forward",
   title = "Cluster Size x vs y (OnTrack) forward",
@@ -306,9 +284,6 @@ SiPixelPhase1TrackClustersOnTrackSizeXYF = SiPixelPhase1TrackClustersOnTrackSize
 
 )
 
-
-
-
 SiPixelPhase1TrackClustersOnTrackChargeOuter = DefaultHistoTrack.clone(
   name = "chargeOuter",
   title = "Corrected Cluster Charge (OnTrack) outer ladders",
@@ -318,7 +293,8 @@ SiPixelPhase1TrackClustersOnTrackChargeOuter = DefaultHistoTrack.clone(
   specs = VPSet(
     Specification().groupBy("PXBarrel/PXLayer").save()
   )
-)  
+)
+  
 SiPixelPhase1TrackClustersOnTrackChargeInner = SiPixelPhase1TrackClustersOnTrackChargeOuter.clone(
   name = "chargeInner",
   title = "Corrected Cluster Charge (OnTrack) inner ladders"
@@ -334,11 +310,11 @@ SiPixelPhase1TrackClustersOnTrackShapeOuter = DefaultHistoTrack.clone(
     Specification().groupBy("PXBarrel/PXLayer").save()
   )
 )
+
 SiPixelPhase1TrackClustersOnTrackShapeInner = SiPixelPhase1TrackClustersOnTrackShapeOuter.clone(
   name = "shapeFilterInner",
   title = "Shape filter (OnTrack) Inner Ladders",
 )
-
 
 # copy this in the enum
 SiPixelPhase1TrackClustersConf = cms.VPSet(
@@ -371,8 +347,6 @@ SiPixelPhase1TrackClustersConf = cms.VPSet(
   SiPixelPhase1TrackClustersOnTrackSizeXYInner,
   SiPixelPhase1TrackClustersOnTrackSizeXYF
 )
-
-
 
 SiPixelPhase1TrackClustersAnalyzer = cms.EDAnalyzer("SiPixelPhase1TrackClusters",
         clusters = cms.InputTag("siPixelClusters"),

--- a/DQM/SiPixelPhase1TrackEfficiency/python/SiPixelPhase1TrackEfficiency_cfi.py
+++ b/DQM/SiPixelPhase1TrackEfficiency/python/SiPixelPhase1TrackEfficiency_cfi.py
@@ -11,7 +11,7 @@ SiPixelPhase1TrackEfficiencyValid = DefaultHistoTrack.clone(
 
   specs = VPSet(
     StandardSpecifications1D_Num,
-    StandardSpecification2DProfile_Num,
+    #StandardSpecification2DProfile_Num, #for this we have the on track clusters map (i.e the same thing)
 
     Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
                              .reduce("COUNT")    
@@ -31,7 +31,6 @@ SiPixelPhase1TrackEfficiencyInactive = DefaultHistoTrack.clone(
   dimensions = 0,
 
   specs = VPSet(
-    StandardSpecifications1D_Num,
     StandardSpecification2DProfile_Num,
 
     Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk

--- a/DQM/SiPixelPhase1TrackResiduals/python/SiPixelPhase1TrackResiduals_cfi.py
+++ b/DQM/SiPixelPhase1TrackResiduals/python/SiPixelPhase1TrackResiduals_cfi.py
@@ -10,7 +10,22 @@ SiPixelPhase1TrackResidualsResidualsX = DefaultHistoTrack.clone(
   dimensions = 1,
   specs = VPSet(
     StandardSpecification2DProfile,
-    StandardSpecifications1D
+    Specification().groupBy("PXBarrel/PXLayer").saveAll(),
+    Specification().groupBy("PXForward/PXDisk").saveAll(),
+    StandardSpecification2DProfile,
+    
+    Specification().groupBy("PXBarrel/PXLayer/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel/PXLayer", "EXTEND_X")
+                   .save(),
+
+    Specification().groupBy("PXForward/PXDisk/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXDisk", "EXTEND_X")
+                   .save(),
+
+    Specification(PerLayer1D).groupBy("PXBarrel/Shell/PXLayer").save(),
+    Specification(PerLayer1D).groupBy("PXForward/HalfCylinder/PXRing/PXDisk").save()
   )
 )
 


### PR DESCRIPTION
This PR rearrange some plots in the Phase 1 DQM, basically what is done is to switch the roles of residuals and cluster probability plots with cluster charge and size plots (much more important to monitor the detector). Since the first pair of plots have a number of bins or 150 and 50 respectively, while the cluster charge and size have 100 and 30 respectively, we have gain in number of bins.

Additionally few plots produced in the TrackEfficiency plugin are completely removed