### PR TITLE
EMTF 2017 PR #5 - DQM

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2EMTF.h
+++ b/DQM/L1TMonitor/interface/L1TStage2EMTF.h
@@ -9,8 +9,8 @@
 #include "DQMServices/Core/interface/MonitorElement.h"
 
 #include "DataFormats/L1TMuon/interface/EMTFDaqOut.h"
-#include "DataFormats/L1TMuon/interface/EMTFHit2016.h"
-#include "DataFormats/L1TMuon/interface/EMTFTrack2016.h"
+#include "DataFormats/L1TMuon/interface/EMTFHit.h"
+#include "DataFormats/L1TMuon/interface/EMTFTrack.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
 
 
@@ -31,24 +31,30 @@ class L1TStage2EMTF : public DQMEDAnalyzer {
  private:
 
   edm::EDGetTokenT<l1t::EMTFDaqOutCollection> daqToken;
-  edm::EDGetTokenT<l1t::EMTFHit2016Collection> hitToken;
-  edm::EDGetTokenT<l1t::EMTFTrack2016Collection> trackToken;
+  edm::EDGetTokenT<l1t::EMTFHitCollection> hitToken;
+  edm::EDGetTokenT<l1t::EMTFTrackCollection> trackToken;
   edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> muonToken;
   std::string monitorDir;
   bool verbose;
 
   MonitorElement* emtfErrors;
+  MonitorElement* mpcLinkErrors;
+  MonitorElement* mpcLinkGood;
 
-  MonitorElement* emtfHitBX;
-  MonitorElement* emtfHitStrip[18];
-  MonitorElement* emtfHitWire[18];
-  MonitorElement* emtfChamberStrip[18];
-  MonitorElement* emtfChamberWire[18];
-  MonitorElement* emtfHitOccupancy;
+  MonitorElement* cscLCTBX;
+  MonitorElement* cscLCTStrip[20];
+  MonitorElement* cscLCTWire[20];
+  MonitorElement* cscChamberStrip[20];
+  MonitorElement* cscChamberWire[20];
+  MonitorElement* cscLCTOccupancy;
+  MonitorElement* cscLCTTiming[5];
+  MonitorElement* cscLCTTimingFrac[4];
   
   MonitorElement* emtfnTracks;
   MonitorElement* emtfTracknHits;
   MonitorElement* emtfTrackBX;
+  MonitorElement* emtfTrackBXVsCSCLCT[3];
+  MonitorElement* emtfTrackBXVsRPCHit[3];
   MonitorElement* emtfTrackPt;
   MonitorElement* emtfTrackEta;
   MonitorElement* emtfTrackPhi;
@@ -63,6 +69,17 @@ class L1TStage2EMTF : public DQMEDAnalyzer {
   MonitorElement* emtfMuonhwEta;
   MonitorElement* emtfMuonhwPhi;
   MonitorElement* emtfMuonhwQual;
+
+  MonitorElement* rpcHitBX;
+  MonitorElement* rpcHitOccupancy;
+  MonitorElement* rpcHitTiming[5];
+  MonitorElement* rpcHitTimingFrac[4];
+  MonitorElement* rpcHitPhi[12];
+  MonitorElement* rpcHitTheta[12];
+  MonitorElement* rpcChamberPhi[12];
+  MonitorElement* rpcChamberTheta[12];
+  
+  MonitorElement* rpcHitTimingInTrack;
 };
 
 #endif

--- a/DQM/L1TMonitor/src/L1TStage2EMTF.cc
+++ b/DQM/L1TMonitor/src/L1TStage2EMTF.cc
@@ -1,13 +1,16 @@
 #include <string>
 #include <vector>
+#include <iostream>
+#include <map>
 
 #include "DQM/L1TMonitor/interface/L1TStage2EMTF.h"
 
+const double PI = 3.14159265358979323846;
 
 L1TStage2EMTF::L1TStage2EMTF(const edm::ParameterSet& ps)
     : daqToken(consumes<l1t::EMTFDaqOutCollection>(ps.getParameter<edm::InputTag>("emtfSource"))),
-      hitToken(consumes<l1t::EMTFHit2016Collection>(ps.getParameter<edm::InputTag>("emtfSource"))),
-      trackToken(consumes<l1t::EMTFTrack2016Collection>(ps.getParameter<edm::InputTag>("emtfSource"))),
+      hitToken(consumes<l1t::EMTFHitCollection>(ps.getParameter<edm::InputTag>("emtfSource"))),
+      trackToken(consumes<l1t::EMTFTrackCollection>(ps.getParameter<edm::InputTag>("emtfSource"))),
       muonToken(consumes<l1t::RegionalMuonCandBxCollection>(ps.getParameter<edm::InputTag>("emtfSource"))),
       monitorDir(ps.getUntrackedParameter<std::string>("monitorDir", "")),
       verbose(ps.getUntrackedParameter<bool>("verbose", false)) {}
@@ -19,111 +22,109 @@ void L1TStage2EMTF::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) {}
 void L1TStage2EMTF::beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) {}
 
 void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) {
-
+  
+  // Monitor Dir
   ibooker.setCurrentFolder(monitorDir);
-
+  
+  std::vector<std::string> binNamesErrors = {"Corruptions","Synch. Err.","Synch. Mod.","BX Mismatch","Time Misalign","FMM != Ready"};
+  
   // DAQ Output Monitor Elements
   emtfErrors = ibooker.book1D("emtfErrors", "EMTF Errors", 6, 0, 6);
   emtfErrors->setAxisTitle("Error Type (Corruptions Not Implemented)", 1);
   emtfErrors->setAxisTitle("Number of Errors", 2);
-  emtfErrors->setBinLabel(1, "Corruptions", 1);
-  emtfErrors->setBinLabel(2, "Synch. Err.", 1);
-  emtfErrors->setBinLabel(3, "Synch. Mod.", 1);
-  emtfErrors->setBinLabel(4, "BX Mismatch", 1);
-  emtfErrors->setBinLabel(5, "Time Misalign.", 1);
-  emtfErrors->setBinLabel(6, "FMM != Ready", 1);
+  for (unsigned int bin = 0; bin < binNamesErrors.size(); ++bin) { 
+    emtfErrors->setBinLabel(bin+1, binNamesErrors[bin], 1);
+  }
 
-  // Hit (LCT) Monitor Elements
-  int n_xbins;
+  // CSC LCT Monitor Elements
+  int nChambs, nWires, nStrips;  // Number of chambers, wiregroups, and halfstrips in each station/ring pair
   std::string name, label;
-  std::vector<std::string> suffix_name = {"42", "41", "32", "31", "22", "21", "13", "12", "11"};
-  std::vector<std::string> suffix_label = {"4/2", "4/1", "3/2", "3/1", " 2/2", "2/1", "1/3", "1/2", "1/1"};
+  std::array<std::string, 10> suffix_name{{"42", "41", "32", "31", "22", "21", "13", "12", "11b", "11a"}};
+  std::array<std::string, 10> suffix_label{{"4/2", "4/1", "3/2", "3/1", " 2/2", "2/1", "1/3", "1/2", "1/1b", "1/1a"}};
+  std::array<std::string, 12> binNames{{"ME-N", "ME-4", "ME-3", "ME-2", "ME-1b", "ME-1a", "ME+1a", "ME+1b", "ME+2", "ME+3", "ME+4", "ME+N"}};
 
-  emtfHitBX = ibooker.book2D("emtfHitBX", "EMTF Hit BX", 8, -3, 5, 18, 0, 18);
-  emtfHitBX->setAxisTitle("BX", 1);
-  for (int xbin = 1, xbin_label = -3; xbin <= 8; ++xbin, ++xbin_label) {
-    emtfHitBX->setBinLabel(xbin, std::to_string(xbin_label), 1);
+  cscLCTBX = ibooker.book2D("cscLCTBX", "CSC LCT BX", 7, -3, 4, 20, 0, 20);
+  cscLCTBX->setAxisTitle("BX", 1);
+  for (int xbin = 1, xbin_label = -3; xbin <= 7; ++xbin, ++xbin_label) {
+    cscLCTBX->setBinLabel(xbin, std::to_string(xbin_label), 1);
   }
-  for (int ybin = 1; ybin <= 9; ++ybin) {
-    emtfHitBX->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
-    emtfHitBX->setBinLabel(19 - ybin, "ME+" + suffix_label[ybin - 1], 2);
+  for (int ybin = 1; ybin <= 10; ++ybin) {
+    cscLCTBX->setBinLabel(ybin, "ME-" + suffix_label[ybin - 1], 2);
+    cscLCTBX->setBinLabel(21 - ybin, "ME+" + suffix_label[ybin - 1], 2);
   }
-
-  for (int hist = 0, i = 0; hist < 18; ++hist, i = hist % 9) {
-
-    if (hist < 9) {
-      name = "MENeg" + suffix_name[i];
-      label = "ME-" + suffix_label[i];
-    } else {
-      name = "MEPos" + suffix_name[8 - i];
-      label = "ME+" + suffix_label[8 - i];
-    }
-
-    if (hist < 6 || hist > 11) {
-      n_xbins = (i % 2) ? 18 : 36;
-    } else {
-      n_xbins = 36;
-    }
-
-    emtfHitStrip[hist] = ibooker.book1D("emtfHitStrip" + name, "EMTF Halfstrip " + label, 256, 0, 256);
-    emtfHitStrip[hist]->setAxisTitle("Cathode Halfstrip, " + label, 1);
-
-    emtfHitWire[hist] = ibooker.book1D("emtfHitWire" + name, "EMTF Wiregroup " + label, 128, 0, 128);
-    emtfHitWire[hist]->setAxisTitle("Anode Wiregroup, " + label, 1);
-
-    emtfChamberStrip[hist] = ibooker.book2D("emtfChamberStrip" + name, "EMTF Halfstrip " + label, n_xbins, 1, 1+n_xbins, 256, 0, 256);
-    emtfChamberStrip[hist]->setAxisTitle("Chamber, " + label, 1);
-    emtfChamberStrip[hist]->setAxisTitle("Cathode Halfstrip", 2);
-
-    emtfChamberWire[hist] = ibooker.book2D("emtfChamberWire" + name, "EMTF Wiregroup " + label, n_xbins, 1, 1+n_xbins, 128, 0, 128);
-    emtfChamberWire[hist]->setAxisTitle("Chamber, " + label, 1);
-    emtfChamberWire[hist]->setAxisTitle("Anode Wiregroup", 2);
-
-    for (int bin = 1; bin <= n_xbins; ++bin) {
-      emtfChamberStrip[hist]->setBinLabel(bin, std::to_string(bin), 1);
-      emtfChamberWire[hist]->setBinLabel(bin, std::to_string(bin), 1);
-    }
+  
+  cscLCTOccupancy = ibooker.book2D("cscLCTOccupancy", "CSC Chamber Occupancy", 54, 1, 55, 12, -6, 6);
+  cscLCTOccupancy->setAxisTitle("Sector (CSCID 1-9 Unlabelled)", 1);
+  for (int xbin = 1; xbin < 7; ++xbin) {
+    cscLCTOccupancy->setBinLabel(xbin * 9 - 8, std::to_string(xbin), 1);
+  }
+  for (unsigned int ybin = 0; ybin < binNames.size(); ++ybin) {
+    cscLCTOccupancy->setBinLabel(ybin+1, binNames[ybin], 2);
+  }
+  
+  mpcLinkErrors = ibooker.book2D("mpcLinkErrors", "MPC Link Errors", 54, 1, 55, 12, -6, 6);
+  mpcLinkErrors->setAxisTitle("Sector (CSCID 1-9 Unlabelled)", 1);
+  for (int xbin = 1; xbin < 7; ++xbin) {
+    mpcLinkErrors->setBinLabel(xbin * 9 - 8, std::to_string(xbin), 1);
+  }
+  for (unsigned int ybin = 0; ybin < binNames.size(); ++ybin) {
+    mpcLinkErrors->setBinLabel(ybin+1, binNames[ybin], 2);
   }
 
-  emtfHitOccupancy = ibooker.book2D("emtfHitOccupancy", "EMTF Chamber Occupancy", 54, 1, 55, 10, -5, 5);
-  emtfHitOccupancy->setAxisTitle("Sector (CSCID 1-9 Unlabelled)", 1);
-  for (int bin = 1; bin <= 46; bin += 9) {
-    emtfHitOccupancy->setBinLabel(bin, std::to_string(bin % 8), 1);
+  mpcLinkGood = ibooker.book2D("mpcLinkGood", "MPC Good Links", 54, 1, 55, 12, -6, 6);
+  mpcLinkGood->setAxisTitle("Sector (CSCID 1-9 Unlabelled)", 1);
+  for (int xbin = 1; xbin < 7; ++xbin) {
+    mpcLinkGood->setBinLabel(xbin * 9 - 8, std::to_string(xbin), 1);
   }
-  emtfHitOccupancy->setBinLabel(1, "ME-4", 2);
-  emtfHitOccupancy->setBinLabel(2, "ME-3", 2);
-  emtfHitOccupancy->setBinLabel(3, "ME-2", 2);
-  emtfHitOccupancy->setBinLabel(4, "ME-1b", 2);
-  emtfHitOccupancy->setBinLabel(5, "ME-1a", 2);
-  emtfHitOccupancy->setBinLabel(6, "ME+1a", 2);
-  emtfHitOccupancy->setBinLabel(7, "ME+1b", 2);
-  emtfHitOccupancy->setBinLabel(8, "ME+2", 2);
-  emtfHitOccupancy->setBinLabel(9, "ME+3", 2);
-  emtfHitOccupancy->setBinLabel(10, "ME+4", 2);
+  for (unsigned int ybin = 0; ybin < binNames.size(); ++ybin) {
+    mpcLinkGood->setBinLabel(ybin+1, binNames[ybin], 2);
+  }
+
+  // RPC Monitor Elements
+  std::array<std::string, 6> rpc_name{{"43", "42", "33", "32", "22", "12"}};
+  std::array<std::string, 6> rpc_label{{"4/3", "4/2", "3/3", "3/2", "2/2", "1/2"}};
+
+  rpcHitBX = ibooker.book2D("rpcHitBX", "RPC Hit BX", 7, -3, 4, 12, 0, 12);
+  rpcHitBX->setAxisTitle("BX", 1);
+  for (int xbin = 1, xbin_label = -3; xbin <= 7; ++xbin, ++xbin_label) {
+    rpcHitBX->setBinLabel(xbin, std::to_string(xbin_label), 1);
+  }
+  for (int ybin = 1; ybin <= 6; ++ybin) {
+    rpcHitBX->setBinLabel(ybin, "RE-" + rpc_label[ybin - 1], 2);
+    rpcHitBX->setBinLabel(13 - ybin, "RE+" + rpc_label[ybin - 1], 2);
+  }
+  
+  rpcHitOccupancy = ibooker.book2D("rpcHitOccupancy", "RPC Chamber Occupancy", 36, 1, 37, 12, 0, 12);
+  rpcHitOccupancy->setAxisTitle("Sector", 1);
+  for (int bin = 1; bin < 7; ++bin) {
+    rpcHitOccupancy->setBinLabel(bin*6 - 5, std::to_string(bin), 1);
+    rpcHitOccupancy->setBinLabel(bin, "RE-" + rpc_label[bin - 1], 2);
+    rpcHitOccupancy->setBinLabel(13 - bin, "RE+" + rpc_label[bin - 1],2);
+  }  
 
   // Track Monitor Elements
   emtfnTracks = ibooker.book1D("emtfnTracks", "Number of EMTF Tracks per Event", 11, 0, 11);
-  for (int bin = 1; bin <= 10; ++bin) {
-    emtfnTracks->setBinLabel(bin, std::to_string(bin - 1), 1);
+  for (int xbin = 1; xbin <= 10; ++xbin) {
+    emtfnTracks->setBinLabel(xbin, std::to_string(xbin - 1), 1);
   }
   emtfnTracks->setBinLabel(11, "Overflow", 1);
 
   emtfTracknHits = ibooker.book1D("emtfTracknHits", "Number of Hits per EMTF Track", 5, 0, 5);
-  for (int bin = 1; bin <= 5; ++bin) {
-    emtfTracknHits->setBinLabel(bin, std::to_string(bin - 1), 1);
+  for (int xbin = 1; xbin <= 5; ++xbin) {
+    emtfTracknHits->setBinLabel(xbin, std::to_string(xbin - 1), 1);
   }
 
-  emtfTrackBX = ibooker.book2D("emtfTrackBX", "EMTF Track Bunch Crossing", 12, -6, 6, 8, -3, 5);
+  emtfTrackBX = ibooker.book2D("emtfTrackBX", "EMTF Track Bunch Crossing", 12, -6, 6, 7, -3, 4);
   emtfTrackBX->setAxisTitle("Sector (Endcap)", 1);
-  for (int i = 0; i < 6; ++i) {
-    emtfTrackBX->setBinLabel(i + 1, std::to_string(6 - i) + " (-)", 1);
-    emtfTrackBX->setBinLabel(12 - i, std::to_string(6 - i) + " (+)", 1);
+  for (int xbin = 0; xbin < 6; ++xbin) {
+    emtfTrackBX->setBinLabel(xbin + 1, std::to_string(6 - xbin) + " (-)", 1);
+    emtfTrackBX->setBinLabel(12 - xbin, std::to_string(6 - xbin) + " (+)", 1);
   }
   emtfTrackBX->setAxisTitle("Track BX", 2);
-  for (int bin = 1, i = -3; bin <= 8; ++bin, ++i) {
-    emtfTrackBX->setBinLabel(bin, std::to_string(i), 2);
+  for (int ybin = 1, i = -3; ybin <= 7; ++ybin, ++i) {
+    emtfTrackBX->setBinLabel(ybin, std::to_string(i), 2);
   }
-
+  
   emtfTrackPt = ibooker.book1D("emtfTrackPt", "EMTF Track p_{T}", 256, 1, 257);
   emtfTrackPt->setAxisTitle("Track p_{T} [GeV]", 1);
 
@@ -134,7 +135,7 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   emtfTrackPhi->setAxisTitle("Track #phi", 1);
 
   emtfTrackPhiHighQuality = ibooker.book1D("emtfTrackPhiHighQuality", "EMTF High Quality #phi", 126, -3.15, 3.15);
-  emtfTrackPhiHighQuality->setAxisTitle("Track #phi (High Quality)", 1);
+  emtfTrackPhiHighQuality->setAxisTitle("Track #phi (Quality #geq 12)", 1);
 
   emtfTrackOccupancy = ibooker.book2D("emtfTrackOccupancy", "EMTF Track Occupancy", 100, -2.5, 2.5, 126, -3.15, 3.15);
   emtfTrackOccupancy->setAxisTitle("#eta", 1);
@@ -157,13 +158,168 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
     emtfTrackQualityVsMode->setBinLabel(bin, std::to_string(bin - 1), 2);
   }
 
-  // Regional Muon Candidate Monitor Elements
+  // CSC Input
+  ibooker.setCurrentFolder(monitorDir + "/CSCInput");
+
+  for (int hist = 0, i = 0; hist < 20; ++hist, i = hist % 10) {
+
+    if (hist < 10) {
+      name = "MENeg" + suffix_name[i];
+      label = "ME-" + suffix_label[i];
+    } else {
+      name = "MEPos" + suffix_name[9 - i];
+      label = "ME+" + suffix_label[9 - i];
+    }
+
+    if (hist < 6 || hist > 13) {
+      nChambs = (i % 2) ? 18 : 36;
+    } else {
+      nChambs = 36;
+    }
+    
+    std::array<int, 10> wiregroups{{64, 96, 64, 96, 64, 112, 32, 64, 48, 48}};
+    std::array<int, 10> halfstrips{{160, 160, 160, 160, 160, 160, 128, 160, 128, 96}};
+    
+    if (hist < 10) {
+      nWires  = wiregroups[hist];
+      nStrips = halfstrips[hist];
+    } else {
+      nWires  = wiregroups[19 - hist];
+      nStrips = halfstrips[19 - hist];
+    }
+
+    cscLCTStrip[hist] = ibooker.book1D("cscLCTStrip" + name, "CSC Halfstrip " + label, nStrips, 0, nStrips);
+    cscLCTStrip[hist]->setAxisTitle("Cathode Halfstrip, " + label, 1);
+
+    cscLCTWire[hist] = ibooker.book1D("cscLCTWire" + name, "CSC Wiregroup " + label, nWires, 0, nWires);
+    cscLCTWire[hist]->setAxisTitle("Anode Wiregroup, " + label, 1);
+
+    cscChamberStrip[hist] = ibooker.book2D("cscChamberStrip" + name, "CSC Halfstrip " + label, nChambs, 1, 1+nChambs, nStrips, 0, nStrips);
+    cscChamberStrip[hist]->setAxisTitle("Chamber, " + label, 1);
+    cscChamberStrip[hist]->setAxisTitle("Cathode Halfstrip", 2);
+
+    cscChamberWire[hist] = ibooker.book2D("cscChamberWire" + name, "CSC Wiregroup " + label, nChambs, 1, 1+nChambs, nWires, 0, nWires);
+    cscChamberWire[hist]->setAxisTitle("Chamber, " + label, 1);
+    cscChamberWire[hist]->setAxisTitle("Anode Wiregroup", 2);
+    
+    for (int bin = 1; bin <= nChambs; ++bin) {
+      cscChamberStrip[hist]->setBinLabel(bin, std::to_string(bin), 1);
+      cscChamberWire[hist]->setBinLabel(bin, std::to_string(bin), 1);
+    }
+  }
+
+  // RPC Input
+  ibooker.setCurrentFolder(monitorDir + "/RPCInput");
+
+  for (int hist = 0, i = 0; hist < 12; ++hist, i = hist % 6) {
+    if (hist < 6) {
+      name = "RENeg" + rpc_name[i];
+      label = "RE-" + rpc_label[i];
+    } else {
+      name = "REPos" + rpc_name[5 - i];
+      label = "RE+" + rpc_label[5 - i];
+    }
+    rpcHitPhi[hist] = ibooker.book1D("rpcHitPhi" + name, "RPC Hit Phi " + label, 1250, 0, 1250);
+    rpcHitPhi[hist]->setAxisTitle("#phi", 1);
+    rpcHitTheta[hist] = ibooker.book1D("rpcHitTheta" + name, "RPC Hit Theta " + label, 32, 0, 32);
+    rpcHitTheta[hist]->setAxisTitle("#theta", 1);
+    rpcChamberPhi[hist] = ibooker.book2D("rpcChamberPhi" + name, "RPC Chamber Phi " + label, 36, 1, 37, 1250, 0, 1250);
+    rpcChamberPhi[hist]->setAxisTitle("Chamber", 1);
+    rpcChamberPhi[hist]->setAxisTitle("#phi", 2);
+    rpcChamberTheta[hist] = ibooker.book2D("rpcChamberTheta" + name, "RPC Chamber Theta " + label, 36, 1, 37, 32, 0, 32);
+    rpcChamberTheta[hist]->setAxisTitle("Chamber", 1);
+    rpcChamberTheta[hist]->setAxisTitle("#theta", 2);
+    for (int xbin = 1; xbin < 37; ++xbin) {
+      rpcChamberPhi[hist]->setBinLabel(xbin, std::to_string(xbin), 1);
+      rpcChamberTheta[hist]->setBinLabel(xbin, std::to_string(xbin), 1);
+    }
+  }
+
+  // CSC LCT and RPC Hit Timing
+  ibooker.setCurrentFolder(monitorDir + "/Timing");
+  
+  std::array<std::string, 5> nameBX{{"BXNeg1","BXPos1","BXNeg2","BXPos2","BX0"}};
+  std::array<std::string, 5> labelBX{{"BX -1","BX +1","BX -2","BX +2","BX 0"}};
+
+  for (int hist = 0;  hist < 5; ++hist) {
+
+    cscLCTTiming[hist] = ibooker.book2D("cscLCTTiming" + nameBX[hist], "CSC Chamber Occupancy " + labelBX[hist], 54, 1, 55, 12, -6, 6);
+    cscLCTTiming[hist]->setAxisTitle("Sector (CSCID 1-9 Unlabelled)", 1);
+    for (int xbin = 1; xbin < 7; ++xbin) {
+      cscLCTTiming[hist]->setBinLabel(xbin * 9 - 8, std::to_string(xbin), 1);
+    }
+    for (unsigned int ybin = 0; ybin < binNames.size(); ++ybin) {
+      cscLCTTiming[hist]->setBinLabel(ybin+1, binNames[ybin], 2);
+    }
+    
+    rpcHitTiming[hist] = ibooker.book2D("rpcHitTiming" + nameBX[hist], "RPC Chamber Occupancy " + labelBX[hist], 36, 1, 37, 12, 0, 12);
+    rpcHitTiming[hist]->setAxisTitle("Sector", 1);
+    for (int bin = 1; bin < 7; ++bin) {
+      rpcHitTiming[hist]->setBinLabel(bin*6 - 5, std::to_string(bin), 1);
+      rpcHitTiming[hist]->setBinLabel(bin, "RE-" + rpc_label[bin - 1], 2);
+      rpcHitTiming[hist]->setBinLabel(13 - bin, "RE+" + rpc_label[bin - 1],2);
+    }
+  
+    if (hist == 4) continue; // Don't book for BX = 0
+  
+    cscLCTTimingFrac[hist] = ibooker.book2D("cscLCTTimingFrac" + nameBX[hist], "CSC Chamber Fraction in " + labelBX[hist], 54, 1, 55, 12, -6, 6);
+    cscLCTTimingFrac[hist]->setAxisTitle("Sector (CSCID 1-9 Unlabelled)", 1);
+    for (int xbin = 1; xbin < 7; ++xbin) {
+      cscLCTTimingFrac[hist]->setBinLabel(xbin * 9 - 8, std::to_string(xbin), 1);
+    }
+    for (unsigned int ybin = 0; ybin < binNames.size(); ++ybin) {
+      cscLCTTimingFrac[hist]->setBinLabel(ybin+1, binNames[ybin], 2);
+    }
+    
+    rpcHitTimingFrac[hist] = ibooker.book2D("rpcHitTimingFrac" + nameBX[hist], "RPC Chamber Fraction in " + labelBX[hist], 36, 1, 37, 12, 0, 12);
+    rpcHitTimingFrac[hist]->setAxisTitle("Sector", 1);
+    for (int bin = 1; bin < 7; ++bin) {
+      rpcHitTimingFrac[hist]->setBinLabel(bin*6 - 5, std::to_string(bin), 1);
+      rpcHitTimingFrac[hist]->setBinLabel(bin, "RE-" + rpc_label[bin - 1], 2);
+      rpcHitTimingFrac[hist]->setBinLabel(13 - bin, "RE+" + rpc_label[bin - 1],2);
+    }
+  }
+      
+  rpcHitTimingInTrack = ibooker.book2D("rpcHitTimingInTrack", "RPC Hit Timing (in Track)", 7, -3, 4, 12, 0, 12);
+  rpcHitTimingInTrack->setAxisTitle("BX", 1);
+  for (int xbin = 1, xbin_label = -3; xbin <= 7; ++xbin, ++xbin_label) {
+    rpcHitTimingInTrack->setBinLabel(xbin, std::to_string(xbin_label), 1);
+  }
+  for (int ybin = 1; ybin <= 6; ++ybin) {
+    rpcHitTimingInTrack->setBinLabel(ybin, "RE-" + rpc_label[ybin - 1], 2);
+    rpcHitTimingInTrack->setBinLabel(13 - ybin, "RE+" + rpc_label[ybin - 1], 2);
+  }
+  
+  std::array<std::string, 3> nameNumStation{{"4Station","3Station","2Station"}};
+  std::array<std::string, 3> labelNumStation{{"4 Station Track","3 Station Track","2 Station Track"}};
+    
+  for (int hist = 0; hist < 3; ++hist) {
+    emtfTrackBXVsCSCLCT[hist] = ibooker.book2D("emtfTrackBXVsCSCLCT" + nameNumStation[hist], 
+					       "EMTF " + labelNumStation[hist] + " BX vs CSC LCT BX", 7, -3, 4, 7, -3, 4);
+    emtfTrackBXVsCSCLCT[hist]->setAxisTitle("LCT BX", 1);
+    emtfTrackBXVsCSCLCT[hist]->setAxisTitle("Track BX", 2);
+    for (int bin = 1, bin_label = -3; bin <= 7; ++bin, ++bin_label) {
+      emtfTrackBXVsCSCLCT[hist]->setBinLabel(bin, std::to_string(bin_label), 1);
+      emtfTrackBXVsCSCLCT[hist]->setBinLabel(bin, std::to_string(bin_label), 2);
+    }
+    emtfTrackBXVsRPCHit[hist] = ibooker.book2D("emtfTrackBXVsRPCHit" + nameNumStation[hist], 
+					       "EMTF " + labelNumStation[hist] + " BX vs RPC Hit BX", 7, -3, 4, 7, -3, 4);
+    emtfTrackBXVsRPCHit[hist]->setAxisTitle("LCT BX", 1);
+    emtfTrackBXVsRPCHit[hist]->setAxisTitle("Track BX", 2);
+    for (int bin = 1, bin_label = -3; bin <= 7; ++bin, ++bin_label) {
+      emtfTrackBXVsRPCHit[hist]->setBinLabel(bin, std::to_string(bin_label), 1);
+      emtfTrackBXVsRPCHit[hist]->setBinLabel(bin, std::to_string(bin_label), 2);
+    }
+  }
+
+  // Muon Cand
   ibooker.setCurrentFolder(monitorDir + "/MuonCand");
 
+  // Regional Muon Candidate Monitor Elements
   emtfMuonBX = ibooker.book1D("emtfMuonBX", "EMTF Muon Cand BX", 7, -3, 4);
   emtfMuonBX->setAxisTitle("BX", 1);
-  for (int bin = 1, bin_label = -3; bin <= 7; ++bin, ++bin_label) {
-    emtfMuonBX->setBinLabel(bin, std::to_string(bin_label), 1);
+  for (int xbin = 1, bin_label = -3; xbin <= 7; ++xbin, ++bin_label) {
+    emtfMuonBX->setBinLabel(xbin, std::to_string(bin_label), 1);
   }
 
   emtfMuonhwPt = ibooker.book1D("emtfMuonhwPt", "EMTF Muon Cand p_{T}", 512, 0, 512);
@@ -172,13 +328,13 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   emtfMuonhwEta = ibooker.book1D("emtfMuonhwEta", "EMTF Muon Cand #eta", 460, -230, 230);
   emtfMuonhwEta->setAxisTitle("Hardware #eta", 1);
 
-  emtfMuonhwPhi = ibooker.book1D("emtfMuonhwPhi", "EMTF Muon Cand #phi", 125, -20, 105);
+  emtfMuonhwPhi = ibooker.book1D("emtfMuonhwPhi", "EMTF Muon Cand #phi", 145, -40, 105);
   emtfMuonhwPhi->setAxisTitle("Hardware #phi", 1);
 
   emtfMuonhwQual = ibooker.book1D("emtfMuonhwQual", "EMTF Muon Cand Quality", 16, 0, 16);
   emtfMuonhwQual->setAxisTitle("Quality", 1);
-  for (int bin = 1; bin <= 16; ++bin) {
-    emtfMuonhwQual->setBinLabel(bin, std::to_string(bin - 1), 1);
+  for (int xbin = 1; xbin <= 16; ++xbin) {
+    emtfMuonhwQual->setBinLabel(xbin, std::to_string(xbin - 1), 1);
   }
 }
 
@@ -189,118 +345,265 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
   // DAQ Output
   edm::Handle<l1t::EMTFDaqOutCollection> DaqOutCollection;
   e.getByToken(daqToken, DaqOutCollection);
-
+  
   for (std::vector<l1t::EMTFDaqOut>::const_iterator DaqOut = DaqOutCollection->begin(); DaqOut != DaqOutCollection->end(); ++DaqOut) {
     const l1t::emtf::MECollection* MECollection = DaqOut->PtrMECollection();
     for (std::vector<l1t::emtf::ME>::const_iterator ME = MECollection->begin(); ME != MECollection->end(); ++ME) {
-      if (ME->SE()) emtfErrors->Fill(1);
-      if (ME->SM()) emtfErrors->Fill(2);
+      if (ME->SE())  emtfErrors->Fill(1);
+      if (ME->SM())  emtfErrors->Fill(2);
       if (ME->BXE()) emtfErrors->Fill(3);
-      if (ME->AF()) emtfErrors->Fill(4);
+      if (ME->AF())  emtfErrors->Fill(4);
     }
 
     const l1t::emtf::EventHeader* EventHeader = DaqOut->PtrEventHeader();
     if (!EventHeader->Rdy()) emtfErrors->Fill(5);
-  }
-
-  // Hits (LCTs)
-  edm::Handle<l1t::EMTFHit2016Collection> HitCollection;
-  e.getByToken(hitToken, HitCollection);
-
-  for (std::vector<l1t::EMTFHit2016>::const_iterator Hit = HitCollection->begin(); Hit != HitCollection->end(); ++Hit) {
-    int endcap = Hit->Endcap();
-    int sector = Hit->Sector();
-    int station = Hit->Station();
-    int ring = Hit->Ring();
-    int cscid = Hit->CSC_ID();
-    int chamber = Hit->Chamber();
-    int strip = Hit->Strip();
-    int wire = Hit->Wire();
-
-    int hist_index = 0;
-    int cscid_offset = (sector - 1) * 9;
-
-    // The following logic determines the index of the monitor element
-    // to which a hit belongs, exploiting the symmetry of the endcaps.
-    if (station == 1) {
-      if (ring == 1 || ring == 4) {
-        hist_index = 8;
-      } else if (ring == 2) {
-        hist_index = 7;
-      } else if (ring == 3) {
-        hist_index = 6;
-      }
-    } else if (ring == 1) {
-      if (station == 2) {
-        hist_index = 5;
-      } else if (station == 3) {
-        hist_index = 3;
-      } else if (station == 4) {
-        hist_index = 1;
-      }
-    } else if (ring == 2) {
-      if (station == 2) {
-        hist_index = 4;
-      } else if (station == 3) {
-        hist_index = 2;
-      } else if (station == 4) {
-        hist_index = 0;
+    
+    // Fill MPC input link errors
+    int offset = (EventHeader->Sector() - 1) * 9;
+    int endcap = EventHeader->Endcap();
+    l1t::emtf::Counters CO = DaqOut->GetCounters();
+    std::array<std::array<int,9>,5> counters {{
+      {{CO.ME1a_1(), CO.ME1a_2(), CO.ME1a_3(), CO.ME1a_4(), CO.ME1a_5(), CO.ME1a_6(), CO.ME1a_7(), CO.ME1a_8(), CO.ME1a_9()}},
+      {{CO.ME1b_1(), CO.ME1b_2(), CO.ME1b_3(), CO.ME1b_4(), CO.ME1b_5(), CO.ME1b_6(), CO.ME1b_7(), CO.ME1b_8(), CO.ME1b_9()}},
+      {{CO.ME2_1(), CO.ME2_2(), CO.ME2_3(), CO.ME2_4(), CO.ME2_5(), CO.ME2_6(), CO.ME2_7(), CO.ME2_8(), CO.ME2_9()}},
+      {{CO.ME3_1(), CO.ME3_2(), CO.ME3_3(), CO.ME3_4(), CO.ME3_5(), CO.ME3_6(), CO.ME3_7(), CO.ME3_8(), CO.ME3_9()}},
+      {{CO.ME4_1(), CO.ME4_2(), CO.ME4_3(), CO.ME4_4(), CO.ME4_5(), CO.ME4_6(), CO.ME4_7(), CO.ME4_8(), CO.ME4_9()}}
+      }};
+    for (int i = 0; i < 5; i++) {
+      for (int j = 0; j < 9; j++) {
+        if (counters.at(i).at(j) != 0) mpcLinkErrors->Fill(j + 1 + offset, endcap * (i + 0.5), counters.at(i).at(j));
+        else mpcLinkGood->Fill(j + 1 + offset, endcap * (i  + 0.5));
       }
     }
+    if (CO.ME1n_3() == 1) mpcLinkErrors->Fill(1 + offset, endcap * 5.5);
+    if (CO.ME1n_6() == 1) mpcLinkErrors->Fill(2 + offset, endcap * 5.5);
+    if (CO.ME1n_9() == 1) mpcLinkErrors->Fill(3 + offset, endcap * 5.5);
+    if (CO.ME2n_3() == 1) mpcLinkErrors->Fill(4 + offset, endcap * 5.5);
+    if (CO.ME2n_9() == 1) mpcLinkErrors->Fill(5 + offset, endcap * 5.5);
+    if (CO.ME3n_3() == 1) mpcLinkErrors->Fill(6 + offset, endcap * 5.5);
+    if (CO.ME3n_9() == 1) mpcLinkErrors->Fill(7 + offset, endcap * 5.5);
+    if (CO.ME4n_3() == 1) mpcLinkErrors->Fill(8 + offset, endcap * 5.5);
+    if (CO.ME4n_9() == 1) mpcLinkErrors->Fill(9 + offset, endcap * 5.5);
+    if (CO.ME1n_3() == 0) mpcLinkGood->Fill(1 + offset, endcap * 5.5);
+    if (CO.ME1n_6() == 0) mpcLinkGood->Fill(2 + offset, endcap * 5.5);
+    if (CO.ME1n_9() == 0) mpcLinkGood->Fill(3 + offset, endcap * 5.5);
+    if (CO.ME2n_3() == 0) mpcLinkGood->Fill(4 + offset, endcap * 5.5);
+    if (CO.ME2n_9() == 0) mpcLinkGood->Fill(5 + offset, endcap * 5.5);
+    if (CO.ME3n_3() == 0) mpcLinkGood->Fill(6 + offset, endcap * 5.5);
+    if (CO.ME3n_9() == 0) mpcLinkGood->Fill(7 + offset, endcap * 5.5);
+    if (CO.ME4n_3() == 0) mpcLinkGood->Fill(8 + offset, endcap * 5.5);
+    if (CO.ME4n_9() == 0) mpcLinkGood->Fill(9 + offset, endcap * 5.5);
+  }
 
-    if (endcap > 0) hist_index = 17 - hist_index;
+  // Hits (CSC LCTs and RPC hits)
+  edm::Handle<l1t::EMTFHitCollection> HitCollection;
+  e.getByToken(hitToken, HitCollection);
+  
+  // Maps CSC station and ring to the monitor element index and uses symmetry of the endcaps    
+  std::map<std::pair<int,int>,int> histIndexCSC = { {{1,4}, 9}, {{1,1}, 8}, {{1,2}, 7}, {{1,3}, 6},
+						    {{2,1}, 5}, {{2,2}, 4}, 
+						    {{3,1}, 3}, {{3,2}, 2},
+						    {{4,1}, 1}, {{4,2}, 0} };
+  
+  // Maps RPC staion and ring to the monitor element index and uses symmetry of the endcaps
+  std::map<std::pair<int, int>, int> histIndexRPC = { {{4,3}, 0}, {{4,2}, 1}, {{3,3}, 2}, {{3,2}, 3}, {{2,2}, 4}, {{1,2}, 5} };
 
-    emtfHitBX->Fill(Hit->BX(), hist_index);
-
-    emtfHitStrip[hist_index]->Fill(strip);
-    emtfHitWire[hist_index]->Fill(wire);
-
-    emtfChamberStrip[hist_index]->Fill(chamber, strip);
-    emtfChamberWire[hist_index]->Fill(chamber, wire);
-
-    if (Hit->Subsector() == 1) {
-      emtfHitOccupancy->Fill(cscid + cscid_offset, endcap * (station - 0.5));
-    } else {
-      emtfHitOccupancy->Fill(cscid + cscid_offset, endcap * (station + 0.5));
+  for (std::vector<l1t::EMTFHit>::const_iterator Hit = HitCollection->begin(); Hit != HitCollection->end(); ++Hit) {
+    int endcap  = Hit->Endcap();
+    int sector  = Hit->Sector();
+    int station = Hit->Station();
+    int ring    = Hit->Ring();
+    int cscid   = Hit->CSC_ID();
+    int chamber = Hit->Chamber();
+    int strip   = Hit->Strip();
+    int wire    = Hit->Wire();
+    int cscid_offset = (sector - 1) * 9;
+    
+    int hist_index = 0;
+    hist_index = histIndexCSC[{station,ring}];    
+    if (endcap > 0) hist_index = 19 - hist_index;
+    if (ring == 4 && strip >= 128) strip -= 128;
+    
+    if (Hit->Is_CSC() == true) {
+      cscLCTBX->Fill(Hit->BX(), hist_index);
+      if (Hit->Neighbor() == false) {
+        cscLCTStrip[hist_index]->Fill(strip);
+        cscLCTWire[hist_index]->Fill(wire);
+        cscChamberStrip[hist_index]->Fill(chamber, strip);
+        cscChamberWire[hist_index]->Fill(chamber, wire);
+        if (Hit->Subsector() == 1) {
+          cscLCTOccupancy->Fill(cscid + cscid_offset, endcap * (station - 0.5));
+        } else {
+          cscLCTOccupancy->Fill(cscid + cscid_offset, endcap * (station + 0.5));
+        }
+      } else {
+	// Map neighbor chambers to "fake" CSC IDs: 1/3 --> 1, 1/6 --> 2, 1/9 --> 3, 2/3 --> 4, 2/9 --> 5, etc.
+	int cscid_n = (station == 1 ? (cscid / 3) : (station * 2) + ((cscid - 3) / 6) );
+        cscLCTOccupancy->Fill(cscid_n + cscid_offset, endcap * 5.5);
+      }
+    }
+   
+    if (Hit->Is_RPC() == true) {
+      hist_index = histIndexRPC[{station,ring}];
+      if (endcap > 0) hist_index = 11 - hist_index;
+      
+      rpcHitBX->Fill(Hit->BX(), hist_index);
+      
+      if (Hit->Neighbor() == false) {
+        rpcHitPhi[hist_index]->Fill(Hit->Phi_fp() / 4);
+        rpcHitTheta[hist_index]->Fill(Hit->Theta_fp() / 4);
+        rpcChamberPhi[hist_index]->Fill(chamber, Hit->Phi_fp() / 4);
+        rpcChamberTheta[hist_index]->Fill(chamber, Hit->Theta_fp() / 4);
+        rpcHitOccupancy->Fill((Hit->Sector_RPC() - 1) * 6 + Hit->Subsector(), hist_index + 0.5);
+      }
     }
   }
 
   // Tracks
-  edm::Handle<l1t::EMTFTrack2016Collection> TrackCollection;
+  edm::Handle<l1t::EMTFTrackCollection> TrackCollection;
   e.getByToken(trackToken, TrackCollection);
 
   int nTracks = TrackCollection->size();
 
-  if (nTracks <= 10) {
-    emtfnTracks->Fill(nTracks);
-  } else {
-    emtfnTracks->Fill(10);
-  }
-
-  for (std::vector<l1t::EMTFTrack2016>::const_iterator Track = TrackCollection->begin(); Track != TrackCollection->end(); ++Track) {
+  emtfnTracks->Fill(std::min(nTracks, emtfnTracks->getTH2F()->GetNbinsX() - 1));
+  
+  for (std::vector<l1t::EMTFTrack>::const_iterator Track = TrackCollection->begin(); Track != TrackCollection->end(); ++Track) {
     int endcap = Track->Endcap();
     int sector = Track->Sector();
     float eta = Track->Eta();
-    float phi_glob_rad = Track->Phi_glob_rad();
+    float phi_glob_rad = Track->Phi_glob() * PI / 180.;
     int mode = Track->Mode();
-    int quality = Track->Quality();
-
-    emtfTracknHits->Fill(Track->NumHits());
+    int quality = Track->GMT_quality();
+    int numHits = Track->NumHits();
+    int modeNeighbor = Track->Mode_neighbor();
+    
+    emtfTracknHits->Fill(numHits);
     emtfTrackBX->Fill(endcap * (sector - 0.5), Track->BX());
     emtfTrackPt->Fill(Track->Pt());
     emtfTrackEta->Fill(eta);
-    emtfTrackPhi->Fill(phi_glob_rad);
+    
     emtfTrackOccupancy->Fill(eta, phi_glob_rad);
     emtfTrackMode->Fill(mode);
     emtfTrackQuality->Fill(quality);
     emtfTrackQualityVsMode->Fill(mode, quality);
-    if (mode == 15) emtfTrackPhiHighQuality->Fill(phi_glob_rad);
-   }
+    
+    // Only plot if there are <= 1 neighbor hits in the track to avoid spikes at sector boundaries
+    if (modeNeighbor < 2 || modeNeighbor == 4 || modeNeighbor == 8) {
+      emtfTrackPhi->Fill(phi_glob_rad);
+      if (quality >= 12) {
+        emtfTrackPhiHighQuality->Fill(phi_glob_rad);
+      }
+    }
+    
+    ////////////////////////////////////////////////////
+    ///  Begin block for CSC LCT and RPC hit timing  ///
+    ////////////////////////////////////////////////////
+    { 
+      // LCT and RPC Timing
+      if (numHits < 2 || numHits > 4) continue;
+      l1t::EMTFHitCollection tmp_hits = Track->Hits();
+      int numHitsInTrack_BX0 = 0;
+      unsigned int hist_index = 4 - numHits;
+    
+      for (int iHit = 0; iHit < numHits; ++iHit) {
+        int trackHit_BX = Track->Hits().at(iHit).BX();
+	if (Track->Hits().at(iHit).Is_CSC() == true) {	  
+	  emtfTrackBXVsCSCLCT[hist_index]->Fill(trackHit_BX, Track->BX());
+	}
+	else if (Track->Hits().at(iHit).Is_RPC() == true) { 
+	  emtfTrackBXVsRPCHit[hist_index]->Fill(trackHit_BX, Track->BX());
+	}
+      }
 
+      // Select well-timed tracks: >= 3 hits, with <= 1 in BX != 0
+      if (numHits < 3) continue;
+      for (int iHit = 0; iHit < numHits; ++iHit) {
+	if (Track->Hits().at(iHit).BX() == 0)
+	  numHitsInTrack_BX0++;
+      }
+      if (numHitsInTrack_BX0 < numHits - 1) continue;
+      
+      for (int iHit = 0; iHit < numHits; ++iHit) {
+ 	l1t::EMTFHit tmpHit = Track->Hits().at(iHit);
+	
+	int trackhitBX   = tmpHit.BX();
+	int cscid        = tmpHit.CSC_ID();
+	int ring         = tmpHit.Ring();
+	int station      = tmpHit.Station();
+	int sector       = tmpHit.Sector();
+	int subsector    = tmpHit.Subsector();
+	int cscid_offset = (sector - 1) * 9;
+	int neighbor     = tmpHit.Neighbor();
+	int endcap       = tmpHit.Endcap();	
+	int chamber      = tmpHit.Chamber();
+      	
+	int hist_index = 0; 
+	// Maps CSC BX from -2 to 2 to monitor element cscLCTTIming
+	std::map<int, int> histIndexBX = {{0, 4}, {-1, 0}, {1, 1}, {-2, 2}, {2, 3}};
+	
+	if (tmpHit.Is_CSC() == true) {
+	  if (neighbor == false) {
+	    if (subsector == 1) {
+	      cscLCTTiming[histIndexBX.at(trackhitBX)]->Fill(cscid + cscid_offset, endcap * (station - 0.5));
+	    }
+	    else {
+	      cscLCTTiming[histIndexBX.at(trackhitBX)]->Fill(cscid + cscid_offset, endcap * (station + 0.5));
+	    }
+	  }
+	  else {
+	    // Map neighbor chambers to "fake" CSC IDs: 1/3 --> 1, 1/6 --> 2, 1/9 --> 3, 2/3 --> 4, 2/9 --> 5, etc.
+	    int cscid_n = (station == 1 ? (cscid / 3) : (station * 2) + ((cscid - 3) / 6) );
+	    cscLCTTiming[histIndexBX[trackhitBX]]->Fill(cscid_n + cscid_offset, endcap * 5.5);
+	  }
+	
+	  // Fill RPC timing with matched CSC LCTs
+	  if (trackhitBX == 0 && ring == 2) {
+	    for (std::vector<l1t::EMTFHit>::const_iterator Hit = HitCollection->begin(); Hit != HitCollection->end(); ++Hit) {
+	      if (Hit->Is_RPC() == true && neighbor == false) {
+		if (std::abs(Track->Eta() - Hit->Eta()) < 0.1) {
+		  if (Hit->Endcap() == endcap && Hit->Station() == station && Hit->Chamber() == chamber) {		    
+
+		    hist_index = histIndexRPC[{ Hit->Station(), Hit->Ring() }];
+		    if (Hit->Endcap() > 0) hist_index = 11 - hist_index;
+		    rpcHitTimingInTrack->Fill(Hit->BX(), hist_index + 0.5);
+		    rpcHitTiming[histIndexBX[trackhitBX]]->Fill((Hit->Sector_RPC() - 1) * 6 + Hit->Subsector(), hist_index + 0.5);
+		    
+		  }
+		}
+	      } 
+	    } // End loop: for (std::vector<l1t::EMTFHit>::const_iterator Hit = HitCollection->begin(); Hit != HitCollection->end(); ++Hit)
+	  } // End conditional: if (trackhitBX == 0 && ring == 2)
+	} // End conditional: if (tmpHit.Is_CSC() == true)
+	
+	// Maps RPC station and ring to monitor element index
+	std::map<std::pair<int, int>, int> histIndexRPC = { {{4,3}, 0}, {{4,2}, 1}, {{3,3}, 2}, {{3,2}, 3}, {{2,2}, 4}, {{1,2}, 5}};
+	
+	if (tmpHit.Is_RPC() == true && neighbor == false) {
+	  hist_index = histIndexRPC.at({station, ring});
+	  if (endcap > 0) hist_index = 11 - hist_index;
+	
+	  rpcHitTimingInTrack->Fill(tmpHit.BX(), hist_index + 0.5);
+	  rpcHitTiming[histIndexBX[trackhitBX]]->Fill((tmpHit.Sector_RPC() - 1) * 6 + subsector, hist_index + 0.5);
+	} // End conditional: if (tmpHit.Is_RPC() == true && neighbor == false)
+
+      } // End loop: for (int iHit = 0; iHit < numHits; ++iHit)
+    } 
+    //////////////////////////////////////////////////
+    ///  End block for CSC LCT and RPC hit timing  ///
+    //////////////////////////////////////////////////
+    
+  } // End loop: for (std::vector<l1t::EMTFTrack>::const_iterator Track = TrackCollection->begin(); Track != TrackCollection->end(); ++Track)
+  
+  // CSC LCT and RPC Hit Timing Efficieny
+  for (int hist_index = 0; hist_index < 4; ++hist_index) {
+    cscLCTTimingFrac[hist_index]->getTH2F()->Divide(cscLCTTiming[hist_index]->getTH2F(), cscLCTTiming[4]->getTH2F());
+    rpcHitTimingFrac[hist_index]->getTH2F()->Divide(rpcHitTiming[hist_index]->getTH2F(), rpcHitTiming[4]->getTH2F());
+  }
+  
   // Regional Muon Candidates
   edm::Handle<l1t::RegionalMuonCandBxCollection> MuonBxCollection;
   e.getByToken(muonToken, MuonBxCollection);
-
+  
   for (int itBX = MuonBxCollection->getFirstBX(); itBX <= MuonBxCollection->getLastBX(); ++itBX) {
     for (l1t::RegionalMuonCandBxCollection::const_iterator Muon = MuonBxCollection->begin(itBX); Muon != MuonBxCollection->end(itBX); ++Muon) {
       emtfMuonBX->Fill(itBX);
@@ -311,4 +614,3 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
     }
   }
 }
-

--- a/DQM/L1TMonitor/src/L1TStage2EMTF.cc
+++ b/DQM/L1TMonitor/src/L1TStage2EMTF.cc
@@ -418,11 +418,11 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
     int cscid_offset = (sector - 1) * 9;
     
     int hist_index = 0;
-    hist_index = histIndexCSC.at( {station, ring} );
-    if (endcap > 0) hist_index = 19 - hist_index;
     if (ring == 4 && strip >= 128) strip -= 128;
     
     if (Hit->Is_CSC() == true) {
+      hist_index = histIndexCSC.at( {station, ring} );
+      if (endcap > 0) hist_index = 19 - hist_index;
       cscLCTBX->Fill(Hit->BX(), hist_index);
       if (Hit->Neighbor() == false) {
         cscLCTStrip[hist_index]->Fill(strip);

--- a/DQM/L1TMonitor/src/L1TStage2EMTF.cc
+++ b/DQM/L1TMonitor/src/L1TStage2EMTF.cc
@@ -465,7 +465,7 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
   int nTracks = TrackCollection->size();
 
-  emtfnTracks->Fill(std::min(nTracks, emtfnTracks->getTH2F()->GetNbinsX() - 1));
+  emtfnTracks->Fill(std::min(nTracks, emtfnTracks->getTH1F()->GetNbinsX() - 1));
   
   for (std::vector<l1t::EMTFTrack>::const_iterator Track = TrackCollection->begin(); Track != TrackCollection->end(); ++Track) {
     int endcap = Track->Endcap();

--- a/DQM/L1TMonitor/src/L1TStage2EMTF.cc
+++ b/DQM/L1TMonitor/src/L1TStage2EMTF.cc
@@ -5,8 +5,6 @@
 
 #include "DQM/L1TMonitor/interface/L1TStage2EMTF.h"
 
-const double PI = 3.14159265358979323846;
-
 L1TStage2EMTF::L1TStage2EMTF(const edm::ParameterSet& ps)
     : daqToken(consumes<l1t::EMTFDaqOutCollection>(ps.getParameter<edm::InputTag>("emtfSource"))),
       hitToken(consumes<l1t::EMTFHitCollection>(ps.getParameter<edm::InputTag>("emtfSource"))),
@@ -26,7 +24,7 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   // Monitor Dir
   ibooker.setCurrentFolder(monitorDir);
   
-  std::vector<std::string> binNamesErrors = {"Corruptions","Synch. Err.","Synch. Mod.","BX Mismatch","Time Misalign","FMM != Ready"};
+  const std::array<std::string, 6> binNamesErrors{{"Corruptions","Synch. Err.","Synch. Mod.","BX Mismatch","Time Misalign","FMM != Ready"}};
   
   // DAQ Output Monitor Elements
   emtfErrors = ibooker.book1D("emtfErrors", "EMTF Errors", 6, 0, 6);
@@ -39,9 +37,9 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   // CSC LCT Monitor Elements
   int nChambs, nWires, nStrips;  // Number of chambers, wiregroups, and halfstrips in each station/ring pair
   std::string name, label;
-  std::array<std::string, 10> suffix_name{{"42", "41", "32", "31", "22", "21", "13", "12", "11b", "11a"}};
-  std::array<std::string, 10> suffix_label{{"4/2", "4/1", "3/2", "3/1", " 2/2", "2/1", "1/3", "1/2", "1/1b", "1/1a"}};
-  std::array<std::string, 12> binNames{{"ME-N", "ME-4", "ME-3", "ME-2", "ME-1b", "ME-1a", "ME+1a", "ME+1b", "ME+2", "ME+3", "ME+4", "ME+N"}};
+  const std::array<std::string, 10> suffix_name{{"42", "41", "32", "31", "22", "21", "13", "12", "11b", "11a"}};
+  const std::array<std::string, 10> suffix_label{{"4/2", "4/1", "3/2", "3/1", " 2/2", "2/1", "1/3", "1/2", "1/1b", "1/1a"}};
+  const std::array<std::string, 12> binNames{{"ME-N", "ME-4", "ME-3", "ME-2", "ME-1b", "ME-1a", "ME+1a", "ME+1b", "ME+2", "ME+3", "ME+4", "ME+N"}};
 
   cscLCTBX = ibooker.book2D("cscLCTBX", "CSC LCT BX", 7, -3, 4, 20, 0, 20);
   cscLCTBX->setAxisTitle("BX", 1);
@@ -81,8 +79,8 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   }
 
   // RPC Monitor Elements
-  std::array<std::string, 6> rpc_name{{"43", "42", "33", "32", "22", "12"}};
-  std::array<std::string, 6> rpc_label{{"4/3", "4/2", "3/3", "3/2", "2/2", "1/2"}};
+  const std::array<std::string, 6> rpc_name{{"43", "42", "33", "32", "22", "12"}};
+  const std::array<std::string, 6> rpc_label{{"4/3", "4/2", "3/3", "3/2", "2/2", "1/2"}};
 
   rpcHitBX = ibooker.book2D("rpcHitBX", "RPC Hit BX", 7, -3, 4, 12, 0, 12);
   rpcHitBX->setAxisTitle("BX", 1);
@@ -177,8 +175,8 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
       nChambs = 36;
     }
     
-    std::array<int, 10> wiregroups{{64, 96, 64, 96, 64, 112, 32, 64, 48, 48}};
-    std::array<int, 10> halfstrips{{160, 160, 160, 160, 160, 160, 128, 160, 128, 96}};
+    const std::array<int, 10> wiregroups{{64, 96, 64, 96, 64, 112, 32, 64, 48, 48}};
+    const std::array<int, 10> halfstrips{{160, 160, 160, 160, 160, 160, 128, 160, 128, 96}};
     
     if (hist < 10) {
       nWires  = wiregroups[hist];
@@ -238,8 +236,8 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   // CSC LCT and RPC Hit Timing
   ibooker.setCurrentFolder(monitorDir + "/Timing");
   
-  std::array<std::string, 5> nameBX{{"BXNeg1","BXPos1","BXNeg2","BXPos2","BX0"}};
-  std::array<std::string, 5> labelBX{{"BX -1","BX +1","BX -2","BX +2","BX 0"}};
+  const std::array<std::string, 5> nameBX{{"BXNeg1","BXPos1","BXNeg2","BXPos2","BX0"}};
+  const std::array<std::string, 5> labelBX{{"BX -1","BX +1","BX -2","BX +2","BX 0"}};
 
   for (int hist = 0;  hist < 5; ++hist) {
 
@@ -290,8 +288,8 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
     rpcHitTimingInTrack->setBinLabel(13 - ybin, "RE+" + rpc_label[ybin - 1], 2);
   }
   
-  std::array<std::string, 3> nameNumStation{{"4Station","3Station","2Station"}};
-  std::array<std::string, 3> labelNumStation{{"4 Station Track","3 Station Track","2 Station Track"}};
+  const std::array<std::string, 3> nameNumStation{{"4Station","3Station","2Station"}};
+  const std::array<std::string, 3> labelNumStation{{"4 Station Track","3 Station Track","2 Station Track"}};
     
   for (int hist = 0; hist < 3; ++hist) {
     emtfTrackBXVsCSCLCT[hist] = ibooker.book2D("emtfTrackBXVsCSCLCT" + nameNumStation[hist], 
@@ -346,9 +344,9 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
   edm::Handle<l1t::EMTFDaqOutCollection> DaqOutCollection;
   e.getByToken(daqToken, DaqOutCollection);
   
-  for (std::vector<l1t::EMTFDaqOut>::const_iterator DaqOut = DaqOutCollection->begin(); DaqOut != DaqOutCollection->end(); ++DaqOut) {
+  for (auto DaqOut = DaqOutCollection->begin(); DaqOut != DaqOutCollection->end(); ++DaqOut ) {
     const l1t::emtf::MECollection* MECollection = DaqOut->PtrMECollection();
-    for (std::vector<l1t::emtf::ME>::const_iterator ME = MECollection->begin(); ME != MECollection->end(); ++ME) {
+    for (auto ME = MECollection->begin(); ME != MECollection->end(); ++ME ) {
       if (ME->SE())  emtfErrors->Fill(1);
       if (ME->SM())  emtfErrors->Fill(2);
       if (ME->BXE()) emtfErrors->Fill(3);
@@ -362,7 +360,7 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
     int offset = (EventHeader->Sector() - 1) * 9;
     int endcap = EventHeader->Endcap();
     l1t::emtf::Counters CO = DaqOut->GetCounters();
-    std::array<std::array<int,9>,5> counters {{
+    const std::array<std::array<int,9>,5> counters {{
       {{CO.ME1a_1(), CO.ME1a_2(), CO.ME1a_3(), CO.ME1a_4(), CO.ME1a_5(), CO.ME1a_6(), CO.ME1a_7(), CO.ME1a_8(), CO.ME1a_9()}},
       {{CO.ME1b_1(), CO.ME1b_2(), CO.ME1b_3(), CO.ME1b_4(), CO.ME1b_5(), CO.ME1b_6(), CO.ME1b_7(), CO.ME1b_8(), CO.ME1b_9()}},
       {{CO.ME2_1(), CO.ME2_2(), CO.ME2_3(), CO.ME2_4(), CO.ME2_5(), CO.ME2_6(), CO.ME2_7(), CO.ME2_8(), CO.ME2_9()}},
@@ -400,15 +398,15 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
   e.getByToken(hitToken, HitCollection);
   
   // Maps CSC station and ring to the monitor element index and uses symmetry of the endcaps    
-  std::map<std::pair<int,int>,int> histIndexCSC = { {{1,4}, 9}, {{1,1}, 8}, {{1,2}, 7}, {{1,3}, 6},
-						    {{2,1}, 5}, {{2,2}, 4}, 
-						    {{3,1}, 3}, {{3,2}, 2},
-						    {{4,1}, 1}, {{4,2}, 0} };
+  const std::map<std::pair<int,int>,int> histIndexCSC = { {{1,4}, 9}, {{1,1}, 8}, {{1,2}, 7}, {{1,3}, 6},
+							  {{2,1}, 5}, {{2,2}, 4}, 
+							  {{3,1}, 3}, {{3,2}, 2},
+							  {{4,1}, 1}, {{4,2}, 0} };
   
   // Maps RPC staion and ring to the monitor element index and uses symmetry of the endcaps
-  std::map<std::pair<int, int>, int> histIndexRPC = { {{4,3}, 0}, {{4,2}, 1}, {{3,3}, 2}, {{3,2}, 3}, {{2,2}, 4}, {{1,2}, 5} };
+  const std::map<std::pair<int, int>, int> histIndexRPC = { {{4,3}, 0}, {{4,2}, 1}, {{3,3}, 2}, {{3,2}, 3}, {{2,2}, 4}, {{1,2}, 5} };
 
-  for (std::vector<l1t::EMTFHit>::const_iterator Hit = HitCollection->begin(); Hit != HitCollection->end(); ++Hit) {
+  for (auto Hit = HitCollection->begin(); Hit != HitCollection->end(); ++Hit) {
     int endcap  = Hit->Endcap();
     int sector  = Hit->Sector();
     int station = Hit->Station();
@@ -420,7 +418,7 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
     int cscid_offset = (sector - 1) * 9;
     
     int hist_index = 0;
-    hist_index = histIndexCSC[{station,ring}];    
+    hist_index = histIndexCSC.at( {station, ring} );
     if (endcap > 0) hist_index = 19 - hist_index;
     if (ring == 4 && strip >= 128) strip -= 128;
     
@@ -444,7 +442,7 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
     }
    
     if (Hit->Is_RPC() == true) {
-      hist_index = histIndexRPC[{station,ring}];
+      hist_index = histIndexRPC.at( {station, ring} );
       if (endcap > 0) hist_index = 11 - hist_index;
       
       rpcHitBX->Fill(Hit->BX(), hist_index);
@@ -467,11 +465,11 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
   emtfnTracks->Fill(std::min(nTracks, emtfnTracks->getTH1F()->GetNbinsX() - 1));
   
-  for (std::vector<l1t::EMTFTrack>::const_iterator Track = TrackCollection->begin(); Track != TrackCollection->end(); ++Track) {
+  for (auto Track = TrackCollection->begin(); Track != TrackCollection->end(); ++Track) {
     int endcap = Track->Endcap();
     int sector = Track->Sector();
     float eta = Track->Eta();
-    float phi_glob_rad = Track->Phi_glob() * PI / 180.;
+    float phi_glob_rad = Track->Phi_glob() * M_PI / 180.;
     int mode = Track->Mode();
     int quality = Track->GMT_quality();
     int numHits = Track->NumHits();
@@ -505,86 +503,85 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
       int numHitsInTrack_BX0 = 0;
       unsigned int hist_index = 4 - numHits;
     
-      for (int iHit = 0; iHit < numHits; ++iHit) {
-        int trackHit_BX = Track->Hits().at(iHit).BX();
-	if (Track->Hits().at(iHit).Is_CSC() == true) {	  
-	  emtfTrackBXVsCSCLCT[hist_index]->Fill(trackHit_BX, Track->BX());
+      for (const auto & iTrkHit: Track->Hits()) { 
+	if (iTrkHit.Is_CSC() == true) {	  
+	  emtfTrackBXVsCSCLCT[hist_index]->Fill(iTrkHit.BX(), Track->BX());
 	}
-	else if (Track->Hits().at(iHit).Is_RPC() == true) { 
-	  emtfTrackBXVsRPCHit[hist_index]->Fill(trackHit_BX, Track->BX());
+	else if (iTrkHit.Is_RPC() == true) { 
+	  emtfTrackBXVsRPCHit[hist_index]->Fill(iTrkHit.BX(), Track->BX());
 	}
       }
 
       // Select well-timed tracks: >= 3 hits, with <= 1 in BX != 0
       if (numHits < 3) continue;
-      for (int iHit = 0; iHit < numHits; ++iHit) {
-	if (Track->Hits().at(iHit).BX() == 0)
+      for (const auto & jTrkHit: Track->Hits()) { 
+	if (jTrkHit.BX() == 0)
 	  numHitsInTrack_BX0++;
       }
       if (numHitsInTrack_BX0 < numHits - 1) continue;
       
-      for (int iHit = 0; iHit < numHits; ++iHit) {
- 	l1t::EMTFHit tmpHit = Track->Hits().at(iHit);
+      for (const auto & TrkHit: Track->Hits()) { 
 	
-	int trackhitBX   = tmpHit.BX();
-	int cscid        = tmpHit.CSC_ID();
-	int ring         = tmpHit.Ring();
-	int station      = tmpHit.Station();
-	int sector       = tmpHit.Sector();
-	int subsector    = tmpHit.Subsector();
+	int trackHitBX   = TrkHit.BX();
+	int cscid        = TrkHit.CSC_ID();
+	int ring         = TrkHit.Ring();
+	int station      = TrkHit.Station();
+	int sector       = TrkHit.Sector();
+	int subsector    = TrkHit.Subsector();
 	int cscid_offset = (sector - 1) * 9;
-	int neighbor     = tmpHit.Neighbor();
-	int endcap       = tmpHit.Endcap();	
-	int chamber      = tmpHit.Chamber();
+	int neighbor     = TrkHit.Neighbor();
+	int endcap       = TrkHit.Endcap();	
+	int chamber      = TrkHit.Chamber();
       	
 	int hist_index = 0; 
 	// Maps CSC BX from -2 to 2 to monitor element cscLCTTIming
-	std::map<int, int> histIndexBX = {{0, 4}, {-1, 0}, {1, 1}, {-2, 2}, {2, 3}};
+	const std::map<int, int> histIndexBX = {{0, 4}, {-1, 0}, {1, 1}, {-2, 2}, {2, 3}};
+	if (std::abs(trackHitBX) > 2) continue; // Should never happen, but just to be safe ...
 	
-	if (tmpHit.Is_CSC() == true) {
+	if (TrkHit.Is_CSC() == true) {
 	  if (neighbor == false) {
 	    if (subsector == 1) {
-	      cscLCTTiming[histIndexBX.at(trackhitBX)]->Fill(cscid + cscid_offset, endcap * (station - 0.5));
+	      cscLCTTiming[histIndexBX.at(trackHitBX)]->Fill(cscid + cscid_offset, endcap * (station - 0.5));
 	    }
 	    else {
-	      cscLCTTiming[histIndexBX.at(trackhitBX)]->Fill(cscid + cscid_offset, endcap * (station + 0.5));
+	      cscLCTTiming[histIndexBX.at(trackHitBX)]->Fill(cscid + cscid_offset, endcap * (station + 0.5));
 	    }
 	  }
 	  else {
 	    // Map neighbor chambers to "fake" CSC IDs: 1/3 --> 1, 1/6 --> 2, 1/9 --> 3, 2/3 --> 4, 2/9 --> 5, etc.
 	    int cscid_n = (station == 1 ? (cscid / 3) : (station * 2) + ((cscid - 3) / 6) );
-	    cscLCTTiming[histIndexBX[trackhitBX]]->Fill(cscid_n + cscid_offset, endcap * 5.5);
+	    cscLCTTiming[histIndexBX.at(trackHitBX)]->Fill(cscid_n + cscid_offset, endcap * 5.5);
 	  }
 	
 	  // Fill RPC timing with matched CSC LCTs
-	  if (trackhitBX == 0 && ring == 2) {
-	    for (std::vector<l1t::EMTFHit>::const_iterator Hit = HitCollection->begin(); Hit != HitCollection->end(); ++Hit) {
-	      if (Hit->Is_RPC() == true && neighbor == false) {
-		if (std::abs(Track->Eta() - Hit->Eta()) < 0.1) {
-		  if (Hit->Endcap() == endcap && Hit->Station() == station && Hit->Chamber() == chamber) {		    
+	  if (trackHitBX == 0 && ring == 2) {
+	    for (auto Hit = HitCollection->begin(); Hit != HitCollection->end(); ++Hit) {
+	      if ( Hit->Is_RPC() == false || neighbor == true ) continue;
+	      if ( std::abs(Track->Eta() - Hit->Eta()) > 0.1  ) continue;
+	      if ( Hit->Endcap()  != endcap  || 
+		   Hit->Station() != station ||
+		   Hit->Chamber() != chamber ) continue;
+	      if ( std::abs(Hit->BX()) > 2   ) continue;
 
-		    hist_index = histIndexRPC[{ Hit->Station(), Hit->Ring() }];
-		    if (Hit->Endcap() > 0) hist_index = 11 - hist_index;
-		    rpcHitTimingInTrack->Fill(Hit->BX(), hist_index + 0.5);
-		    rpcHitTiming[histIndexBX.at(Hit->BX())]->Fill((Hit->Sector_RPC() - 1) * 6 + Hit->Subsector(), hist_index + 0.5);
+	      hist_index = histIndexRPC.at( {Hit->Station(), Hit->Ring()} );
+	      if (Hit->Endcap() > 0) hist_index = 11 - hist_index;
+	      rpcHitTimingInTrack->Fill(Hit->BX(), hist_index + 0.5);
+	      rpcHitTiming[histIndexBX.at(Hit->BX())]->Fill((Hit->Sector_RPC() - 1) * 6 + Hit->Subsector(), hist_index + 0.5);
 		    
-		  }
-		}
-	      } 
-	    } // End loop: for (std::vector<l1t::EMTFHit>::const_iterator Hit = HitCollection->begin(); Hit != HitCollection->end(); ++Hit)
-	  } // End conditional: if (trackhitBX == 0 && ring == 2)
-	} // End conditional: if (tmpHit.Is_CSC() == true)
+	    } // End loop: for (auto Hit = HitCollection->begin(); Hit != HitCollection->end(); ++Hit)
+	  } // End conditional: if (trackHitBX == 0 && ring == 2)
+	} // End conditional: if (TrkHit.Is_CSC() == true)
 	
 	// Maps RPC station and ring to monitor element index
-	std::map<std::pair<int, int>, int> histIndexRPC = { {{4,3}, 0}, {{4,2}, 1}, {{3,3}, 2}, {{3,2}, 3}, {{2,2}, 4}, {{1,2}, 5}};
+	const std::map<std::pair<int, int>, int> histIndexRPC = { {{4,3}, 0}, {{4,2}, 1}, {{3,3}, 2}, {{3,2}, 3}, {{2,2}, 4}, {{1,2}, 5}};
 	
-	if (tmpHit.Is_RPC() == true && neighbor == false) {
-	  hist_index = histIndexRPC.at({station, ring});
+	if (TrkHit.Is_RPC() == true && neighbor == false) {
+	  hist_index = histIndexRPC.at( {station, ring} );
 	  if (endcap > 0) hist_index = 11 - hist_index;
 	
-	  rpcHitTimingInTrack->Fill(trackhitBX, hist_index + 0.5);
-	  rpcHitTiming[histIndexBX.at(trackhitBX)]->Fill((tmpHit.Sector_RPC() - 1) * 6 + subsector, hist_index + 0.5);
-	} // End conditional: if (tmpHit.Is_RPC() == true && neighbor == false)
+	  rpcHitTimingInTrack->Fill(trackHitBX, hist_index + 0.5);
+	  rpcHitTiming[histIndexBX.at(trackHitBX)]->Fill((TrkHit.Sector_RPC() - 1) * 6 + subsector, hist_index + 0.5);
+	} // End conditional: if (TrkHit.Is_RPC() == true && neighbor == false)
 
       } // End loop: for (int iHit = 0; iHit < numHits; ++iHit)
     } 
@@ -592,7 +589,7 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
     ///  End block for CSC LCT and RPC hit timing  ///
     //////////////////////////////////////////////////
     
-  } // End loop: for (std::vector<l1t::EMTFTrack>::const_iterator Track = TrackCollection->begin(); Track != TrackCollection->end(); ++Track)
+  } // End loop: for (auto Track = TrackCollection->begin(); Track != TrackCollection->end(); ++Track)
   
   // CSC LCT and RPC Hit Timing Efficieny
   for (int hist_index = 0; hist_index < 4; ++hist_index) {

--- a/DQM/L1TMonitor/src/L1TStage2EMTF.cc
+++ b/DQM/L1TMonitor/src/L1TStage2EMTF.cc
@@ -566,7 +566,7 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
 		    hist_index = histIndexRPC[{ Hit->Station(), Hit->Ring() }];
 		    if (Hit->Endcap() > 0) hist_index = 11 - hist_index;
 		    rpcHitTimingInTrack->Fill(Hit->BX(), hist_index + 0.5);
-		    rpcHitTiming[histIndexBX[trackhitBX]]->Fill((Hit->Sector_RPC() - 1) * 6 + Hit->Subsector(), hist_index + 0.5);
+		    rpcHitTiming[histIndexBX.at(Hit->BX())]->Fill((Hit->Sector_RPC() - 1) * 6 + Hit->Subsector(), hist_index + 0.5);
 		    
 		  }
 		}
@@ -582,8 +582,8 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
 	  hist_index = histIndexRPC.at({station, ring});
 	  if (endcap > 0) hist_index = 11 - hist_index;
 	
-	  rpcHitTimingInTrack->Fill(tmpHit.BX(), hist_index + 0.5);
-	  rpcHitTiming[histIndexBX[trackhitBX]]->Fill((tmpHit.Sector_RPC() - 1) * 6 + subsector, hist_index + 0.5);
+	  rpcHitTimingInTrack->Fill(trackhitBX, hist_index + 0.5);
+	  rpcHitTiming[histIndexBX.at(trackhitBX)]->Fill((tmpHit.Sector_RPC() - 1) * 6 + subsector, hist_index + 0.5);
 	} // End conditional: if (tmpHit.Is_RPC() == true && neighbor == false)
 
       } // End loop: for (int iHit = 0; iHit < numHits; ++iHit)

--- a/DQM/L1TMonitorClient/data/L1TStage2EMTFQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2EMTFQualityTests.xml
@@ -2,14 +2,14 @@
 
   <!-- EMTF Hit Occupancy -->
 
-  <QTEST name="EMTF_HitOccupancyDeadChamber">
+  <QTEST name="EMTF_LCTOccupancyDeadChamber">
     <TYPE>DeadChannel</TYPE>	
     <PARAM name="threshold">0</PARAM>
     <PARAM name="error">0.60</PARAM>
     <PARAM name="warning">0.80</PARAM>
   </QTEST>
 
-  <QTEST name="EMTF_HitOccupancyNoisyChamber">
+  <QTEST name="EMTF_LCTOccupancyNoisyChamber">
     <TYPE>NoisyChannel</TYPE>	
     <PARAM name="tolerance">20</PARAM>
     <PARAM name="neighbours">9</PARAM>
@@ -17,9 +17,9 @@
     <PARAM name="warning">0.999</PARAM>
   </QTEST>
   
-  <LINK name="*/L1TStage2EMTF/emtfHitOccupancy">
-      <TestName activate="true">EMTF_HitOccupancyDeadChamber</TestName>
-      <TestName activate="true">EMTF_HitOccupancyNoisyChamber</TestName>
+  <LINK name="*/L1TStage2EMTF/cscLCTOccupancy">
+      <TestName activate="true">EMTF_LCTOccupancyDeadChamber</TestName>
+      <TestName activate="true">EMTF_LCTOccupancyNoisyChamber</TestName>
   </LINK>
 
   <!-- EMTF Track BX -->

--- a/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
@@ -146,13 +146,13 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemDisable  = cms.uint32(0),
                         QualityTests = cms.VPSet(
                             cms.PSet(
-                                QualityTestName = cms.string("EMTF_HitOccupancyDeadChambe"),
-                                QualityTestHist = cms.string("L1T/L1TStage2EMTF/emtfHitOccupancy"),
+                                QualityTestName = cms.string("EMTF_LCTOccupancyDeadChambe"),
+                                QualityTestHist = cms.string("L1T/L1TStage2EMTF/cscLCTOccupancy"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("EMTF_HitOccupancyNoisyChamber"),
-                                QualityTestHist = cms.string("L1T/L1TStage2EMTF/emtfHitOccupancy"),
+                                QualityTestName = cms.string("EMTF_LCTOccupancyNoisyChamber"),
+                                QualityTestHist = cms.string("L1T/L1TStage2EMTF/cscLCTOccupancy"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.cc
@@ -10,8 +10,6 @@ namespace l1t {
       event_.put(std::move(EMTFDaqOuts_));
       event_.put(std::move(EMTFHits_));
       event_.put(std::move(EMTFTracks_));
-      event_.put(std::move(EMTFHit2016s_));
-      event_.put(std::move(EMTFTrack2016s_));
       event_.put(std::move(EMTFLCTs_));
     }
   }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.h
@@ -9,8 +9,6 @@
 #include "DataFormats/L1TMuon/interface/EMTFDaqOut.h"
 #include "DataFormats/L1TMuon/interface/EMTFHit.h"
 #include "DataFormats/L1TMuon/interface/EMTFTrack.h"
-#include "DataFormats/L1TMuon/interface/EMTFHit2016.h"
-#include "DataFormats/L1TMuon/interface/EMTFTrack2016.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
 
 #include "EventFilter/L1TRawToDigi/interface/UnpackerCollections.h"
@@ -25,8 +23,6 @@ namespace l1t {
 	EMTFDaqOuts_(new EMTFDaqOutCollection()),
 	EMTFHits_(new EMTFHitCollection()),
 	EMTFTracks_(new EMTFTrackCollection()),
-	EMTFHit2016s_(new EMTFHit2016Collection()),
-	EMTFTrack2016s_(new EMTFTrack2016Collection()),
 	EMTFLCTs_(new CSCCorrelatedLCTDigiCollection())
 	  {};
       
@@ -37,8 +33,6 @@ namespace l1t {
       inline EMTFDaqOutCollection* getEMTFDaqOuts() { return EMTFDaqOuts_.get(); }
       inline EMTFHitCollection*    getEMTFHits()    { return EMTFHits_.get();    }       
       inline EMTFTrackCollection*  getEMTFTracks()  { return EMTFTracks_.get();  }       
-      inline EMTFHit2016Collection*    getEMTFHit2016s()    { return EMTFHit2016s_.get();    }       
-      inline EMTFTrack2016Collection*  getEMTFTrack2016s()  { return EMTFTrack2016s_.get();  }       
       inline CSCCorrelatedLCTDigiCollection* getEMTFLCTs() { return EMTFLCTs_.get(); }
       
     private:
@@ -47,8 +41,6 @@ namespace l1t {
       std::unique_ptr<EMTFDaqOutCollection>         EMTFDaqOuts_;
       std::unique_ptr<EMTFHitCollection>            EMTFHits_;
       std::unique_ptr<EMTFTrackCollection>          EMTFTracks_;
-      std::unique_ptr<EMTFHit2016Collection>            EMTFHit2016s_;
-      std::unique_ptr<EMTFTrack2016Collection>          EMTFTrack2016s_;
       std::unique_ptr<CSCCorrelatedLCTDigiCollection> EMTFLCTs_;
       
     };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.cc
@@ -47,8 +47,6 @@ namespace l1t {
          prod.produces<EMTFDaqOutCollection>();
          prod.produces<EMTFHitCollection>();
          prod.produces<EMTFTrackCollection>();
-         prod.produces<EMTFHit2016Collection>();
-         prod.produces<EMTFTrack2016Collection>();
          prod.produces<CSCCorrelatedLCTDigiCollection>();
       }
 

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.cc
@@ -15,8 +15,6 @@ namespace l1t {
       EMTFDaqOutToken_ = cc.consumes<EMTFDaqOutCollection>(tag);
       EMTFHitToken_ = cc.consumes<EMTFHitCollection>(tag);
       EMTFTrackToken_ = cc.consumes<EMTFTrackCollection>(tag);
-      EMTFHit2016Token_ = cc.consumes<EMTFHit2016Collection>(tag);
-      EMTFTrack2016Token_ = cc.consumes<EMTFTrack2016Collection>(tag);
       EMTFLCTToken_ = cc.consumes<CSCCorrelatedLCTDigiCollection>(tag);   
     }
   }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.h
@@ -6,8 +6,6 @@
 #include "DataFormats/L1TMuon/interface/EMTFDaqOut.h"
 #include "DataFormats/L1TMuon/interface/EMTFHit.h"
 #include "DataFormats/L1TMuon/interface/EMTFTrack.h"
-#include "DataFormats/L1TMuon/interface/EMTFHit2016.h"
-#include "DataFormats/L1TMuon/interface/EMTFTrack2016.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
 
 #include "EventFilter/L1TRawToDigi/interface/PackerTokens.h"
@@ -22,8 +20,6 @@ namespace l1t {
       inline const edm::EDGetTokenT<EMTFDaqOutCollection>& getEMTFDaqOutToken() const { return EMTFDaqOutToken_; }
       inline const edm::EDGetTokenT<EMTFHitCollection>& getEMTFHitToken() const { return EMTFHitToken_; }
       inline const edm::EDGetTokenT<EMTFTrackCollection>& getEMTFTrackToken() const { return EMTFTrackToken_; }
-      inline const edm::EDGetTokenT<EMTFHit2016Collection>& getEMTFHit2016Token() const { return EMTFHit2016Token_; }
-      inline const edm::EDGetTokenT<EMTFTrack2016Collection>& getEMTFTrack2016Token() const { return EMTFTrack2016Token_; }
       inline const edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection>& getEMTFLCTToken() const { return EMTFLCTToken_; }
       
     private:
@@ -32,8 +28,6 @@ namespace l1t {
       edm::EDGetTokenT<EMTFDaqOutCollection> EMTFDaqOutToken_;
       edm::EDGetTokenT<EMTFHitCollection> EMTFHitToken_;
       edm::EDGetTokenT<EMTFTrackCollection> EMTFTrackToken_;
-      edm::EDGetTokenT<EMTFHit2016Collection> EMTFHit2016Token_;
-      edm::EDGetTokenT<EMTFTrack2016Collection> EMTFTrack2016Token_;
       edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> EMTFLCTToken_;
       
     };


### PR DESCRIPTION
Part 3 (really) of set of PRs following PR #19741 and #19743
PR #19744 is no longer necessary
PR #19928 (CondDB and O2O) will have to be revisited later
Big emulator PR yet to come

Updated EMTF DQM with several improvements:
  * RPC monitoring plots (using updated unpacker)
  * MPC link monitoring (using updated unpacker)
  * CSC LCT and RPC hit timing plots
  * Many low-level plots moved to subfolders; main plots in main directory

Since the DQM is the only consumer of the unpacked "EMTFHit" and "EMTFTrack" collections, removed "EMTFHit2016" and "EMTFTrack2016" products from the unpacker.
