### PR TITLE
Fixed step limit definition

### DIFF
--- a/SimG4Core/Application/interface/ElectronLimiter.h
+++ b/SimG4Core/Application/interface/ElectronLimiter.h
@@ -43,7 +43,7 @@ private:
 
   const G4ParticleDefinition* particle;
 
-  G4bool minStepLimit;
+  G4double minStepLimit;
 
   G4bool rangeCheckFlag;
   G4bool fieldCheckFlag;


### PR DESCRIPTION
It is a real bug discovered by gcc7 compiler, due to the bug the code was useless and was not used. This PR is created instead of #19999