### PR TITLE
HGCal - Remove ghost detids

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
@@ -54,7 +54,11 @@ HGCalRecHitWorkerSimple::HGCalRecHitWorkerSimple(const edm::ParameterSet&ps) :
     hgcHEF_noise_fC_ = ps.getParameter < std::vector<double> > ("HGCHEF_noise_fC");
     hgcHEB_noise_MIP_ = ps.getParameter<double>("HGCHEB_noise_MIP");
 
-
+    // don't produce rechit if detid is a ghost one
+    GhostDetIdPosMin_ = ps.getParameter<int>("GhostDetIdPosMin");
+    GhostDetIdPosMax_ = ps.getParameter<int>("GhostDetIdPosMax");
+    GhostDetIdNegMin_ = ps.getParameter<int>("GhostDetIdNegMin");
+    GhostDetIdNegMax_ = ps.getParameter<int>("GhostDetIdNegMax");
 }
 
 void HGCalRecHitWorkerSimple::set(const edm::EventSetup& es)
@@ -87,6 +91,10 @@ bool HGCalRecHitWorkerSimple::run(const edm::Event & evt, const HGCUncalibratedR
         HGCRecHitCollection & result)
 {
     DetId detid = uncalibRH.id();
+// don't produce rechit if detid is a ghost one
+    if((detid < GhostDetIdPosMax_ +1  and GhostDetIdPosMin_-1 < detid ) or (detid < GhostDetIdNegMax_+1  and GhostDetIdNegMin_-1 < detid ) )
+        return false;
+
     int thickness = -1;
     float sigmaNoiseGeV = 0.f;
     unsigned int layer = tools_->getLayerWithOffset(detid);

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
@@ -55,10 +55,8 @@ HGCalRecHitWorkerSimple::HGCalRecHitWorkerSimple(const edm::ParameterSet&ps) :
     hgcHEB_noise_MIP_ = ps.getParameter<double>("HGCHEB_noise_MIP");
 
     // don't produce rechit if detid is a ghost one
-    GhostDetIdPosMin_ = ps.getParameter<int>("GhostDetIdPosMin");
-    GhostDetIdPosMax_ = ps.getParameter<int>("GhostDetIdPosMax");
-    GhostDetIdNegMin_ = ps.getParameter<int>("GhostDetIdNegMin");
-    GhostDetIdNegMax_ = ps.getParameter<int>("GhostDetIdNegMax");
+    rangeMatch_ = ps.getParameter<uint32_t>("rangeMatch");
+    rangeMask_  = ps.getParameter<uint32_t>("rangeMask");
 }
 
 void HGCalRecHitWorkerSimple::set(const edm::EventSetup& es)
@@ -92,7 +90,8 @@ bool HGCalRecHitWorkerSimple::run(const edm::Event & evt, const HGCUncalibratedR
 {
     DetId detid = uncalibRH.id();
 // don't produce rechit if detid is a ghost one
-    if((detid < GhostDetIdPosMax_ +1  and GhostDetIdPosMin_-1 < detid ) or (detid < GhostDetIdNegMax_+1  and GhostDetIdNegMin_-1 < detid ) )
+
+    if((detid & rangeMask_) == rangeMatch_)
         return false;
 
     int thickness = -1;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.h
@@ -47,6 +47,11 @@ class HGCalRecHitWorkerSimple : public HGCalRecHitWorkerBaseClass {
   std::vector<int> v_DB_reco_flags_;
   bool killDeadChannels_;
 
+  uint32_t GhostDetIdPosMin_;
+  uint32_t GhostDetIdPosMax_;
+  uint32_t GhostDetIdNegMin_;
+  uint32_t GhostDetIdNegMax_;
+
   std::vector<double> rcorr_;
   std::vector<float> weights_;
   std::unique_ptr<HGCalRecHitSimpleAlgo> rechitMaker_;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.h
@@ -47,10 +47,8 @@ class HGCalRecHitWorkerSimple : public HGCalRecHitWorkerBaseClass {
   std::vector<int> v_DB_reco_flags_;
   bool killDeadChannels_;
 
-  uint32_t GhostDetIdPosMin_;
-  uint32_t GhostDetIdPosMax_;
-  uint32_t GhostDetIdNegMin_;
-  uint32_t GhostDetIdNegMax_;
+  uint32_t rangeMatch_;
+  uint32_t rangeMask_;
 
   std::vector<double> rcorr_;
   std::vector<float> weights_;

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
@@ -75,6 +75,13 @@ HGCalRecHit = cms.EDProducer(
     HGCHEF_fCPerMIP = HGCalUncalibRecHit.HGCHEFConfig.fCPerMIP,
     HGCHEB_keV2DIGI = hgchebackDigitizer.digiCfg.keV2MIP,
     HGCHEB_isSiFE   = HGCalUncalibRecHit.HGCHEBConfig.isSiFE,
+    # don't produce rechit if detid is a ghost one
+    # smallest and largest ghost detid on positive side
+    GhostDetIdPosMin = 1162362881,
+    GhostDetIdPosMax = 1162362952,
+    # smallest and largest ghost detid on negative side
+    GhostDetIdNegMin = 1161838593,
+    GhostDetIdNegMax = 1161838664,
 
     # EM Scale calibrations
     layerWeights = dEdX_weights,

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
@@ -76,7 +76,6 @@ HGCalRecHit = cms.EDProducer(
     HGCHEB_keV2DIGI = hgchebackDigitizer.digiCfg.keV2MIP,
     HGCHEB_isSiFE   = HGCalUncalibRecHit.HGCHEBConfig.isSiFE,
     # don't produce rechit if detid is a ghost one
-    # smallest and largest ghost detid on positive side
     rangeMask = cms.uint32(4294442496),
     rangeMatch = cms.uint32(1161838592),
 

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
@@ -77,11 +77,9 @@ HGCalRecHit = cms.EDProducer(
     HGCHEB_isSiFE   = HGCalUncalibRecHit.HGCHEBConfig.isSiFE,
     # don't produce rechit if detid is a ghost one
     # smallest and largest ghost detid on positive side
-    GhostDetIdPosMin = 1162362881,
-    GhostDetIdPosMax = 1162362952,
-    # smallest and largest ghost detid on negative side
-    GhostDetIdNegMin = 1161838593,
-    GhostDetIdNegMax = 1161838664,
+    rangeMask = cms.uint32(4294442496),
+    rangeMatch = cms.uint32(1161838592),
+
 
     # EM Scale calibrations
     layerWeights = dEdX_weights,


### PR DESCRIPTION
This PR is a fix for a hopefully temporary bug in the geometry.
In the geometry we have some hidden, ghost detIds that should not exist. 
You can find the list here: www.cern.ch/felice.pantaleo/ghosts.txt
