### PR TITLE
Wait in destructor of SerialTaskQueue

### DIFF
--- a/FWCore/Concurrency/interface/SerialTaskQueue.h
+++ b/FWCore/Concurrency/interface/SerialTaskQueue.h
@@ -70,6 +70,8 @@ namespace edm {
       m_pauseCount{0}
       {  }
       
+      ~SerialTaskQueue();
+      
       // ---------- const member functions ---------------------
       /// Checks to see if the queue has been paused.
       /**\return true if the queue is paused

--- a/FWCore/Concurrency/src/SerialTaskQueue.cc
+++ b/FWCore/Concurrency/src/SerialTaskQueue.cc
@@ -23,6 +23,16 @@ using namespace edm;
 //
 // member functions
 //
+SerialTaskQueue::~SerialTaskQueue()
+{
+  //be certain all tasks have completed
+  bool isEmpty = m_tasks.empty();
+  bool isTaskChosen = m_taskChosen;
+  if ( (not isEmpty and not isPaused()) or isTaskChosen) {
+    pushAndWait([]() {return;});
+  }
+}
+
 bool
 SerialTaskQueue::resume() {
   if(0==--m_pauseCount) {


### PR DESCRIPTION
Do a 'pushAndWait' in the destructor of the SerialTaskQueue if there are outstanding tasks being processed. This avoids a possible crash caused if the task tries to talk back to the deleted SerialTaskQueue.
This problem was pointed out by valgrind.