### PR TITLE
Memory reduction of the Cluster Charge Histogram used in SiStrip gain calibration

### DIFF
--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -208,7 +208,8 @@ private:
         MonitorElement* MPV_Vs_PhiTECthin;                       /*!< MPV vs Phi for TEC thin planes */
         MonitorElement* MPV_Vs_PhiTECthick;                      /*!< MPV vs Phi for TID tick planes */
 
-        MonitorElement* NoMPV;                                   /*!< R,Z map of missing APV calibration */
+        MonitorElement* NoMPVmasked;                             /*!< R,Z map of missing APV calibration (masked modules)*/
+        MonitorElement* NoMPVfit;                                /*!< R,Z map of missing APV calibration (no fit) */
 
         MonitorElement* Gains;                                   /*!< distribution of gain factors */
         MonitorElement* MPVs;                                    /*!< distribution of MPVs */
@@ -479,7 +480,25 @@ void SiStripGainFromCalibTree::bookDQMHistos(const char* dqm_dir, const char* ta
 
     int elepos = (m_harvestingMode && AlgoMode=="PCL")? Harvest : statCollectionFromMode(tag);
 
-    Charge_Vs_Index[elepos]           = dbe->book2S(cvi.c_str()     , cvi.c_str()     , 88625, 0   , 88624,2000,0,4000);
+    //setting up the bin array for the Charge_Vs_Index histogram
+    float* binXarray = new float[NStripAPVs+1];
+    for(int a=0;a<=NStripAPVs;a++){
+       binXarray[a] = (float)a;
+    }
+ 
+    float* binYarray = new float[688];
+    double p0 = 5.445;
+    double p1 = 0.002113;
+    double p2 = 69.01576;
+    double y = 0.;
+    for(int b=0;b<687;b++) {
+       binYarray[b] = y;
+       if(y<=902.) y = y + 2.;
+       else y = ( p0 - log(exp(p0-p1*y) - p2*p1)) / p1;
+    }
+    binYarray[687] = 4000.;
+
+    Charge_Vs_Index[elepos]           = dbe->book2S(cvi.c_str()     , cvi.c_str()     , NStripAPVs, binXarray, 687, binYarray);
     //Charge_Vs_Index_Absolute[elepos]  = dbe->book2S(cviA.c_str()    , cviA.c_str()    , 88625, 0   , 88624,1000,0,4000);
     Charge_Vs_PathlengthTIB[elepos]   = dbe->book2S(cvpTIB.c_str()  , cvpTIB.c_str()  , 20   , 0.3 , 1.3  , 250,0,2000);
     Charge_Vs_PathlengthTOB[elepos]   = dbe->book2S(cvpTOB.c_str()  , cvpTOB.c_str()  , 20   , 0.3 , 1.3  , 250,0,2000);
@@ -531,6 +550,9 @@ void SiStripGainFromCalibTree::bookDQMHistos(const char* dqm_dir, const char* ta
         Charge_4[elepos].push_back( APVGain::APVmon(id,side,plane,monitor) );
     }
 
+    delete[] binXarray;
+    delete[] binYarray;
+
     //Book validation histograms
     if (m_harvestingMode) {
         int   MPVbin = 300;
@@ -551,7 +573,8 @@ void SiStripGainFromCalibTree::bookDQMHistos(const char* dqm_dir, const char* ta
         MPV_Vs_PhiTECthin  = dbe->book2DD("MPV_vs_PhiTEC1","MPV vs Phi TEC-thin" , 50, -3.4, 3.4, MPVbin, MPVmin, MPVmax);
         MPV_Vs_PhiTECthick = dbe->book2DD("MPV_vs_PhiTEC2","MPV vs Phi TEC-thick", 50, -3.4, 3.4, MPVbin, MPVmin, MPVmax);
 
-        NoMPV          = dbe->book2DD("NoMPV"         ,"NoMPV"         ,350, -350, 350, 240, 0, 120);
+        NoMPVfit           = dbe->book2DD("NoMPVfit"      ,"Modules with bad Landau Fit",350, -350, 350, 240, 0, 120);
+        NoMPVmasked        = dbe->book2DD("NoMPVmasked"   ,"Masked Modules"             ,350, -350, 350, 240, 0, 120);
 
         Gains          = dbe->book1DD("Gains"         ,"Gains"             ,                300, 0, 2);
         MPVs           = dbe->book1DD("MPVs"          ,"MPVs"              ,                MPVbin, MPVmin, MPVmax);
@@ -969,7 +992,7 @@ SiStripGainFromCalibTree::algoEndJob() {
 		algoAnalyzeTheTree();
 	}else if(m_harvestingMode){
 		NClusterStrip = (Charge_Vs_Index[Harvest])->getTH2S()->Integral(0,NStripAPVs+1, 0, 99999 );
-		NClusterPixel = (Charge_Vs_Index[Harvest])->getTH2S()->Integral(NStripAPVs+2, NStripAPVs+NPixelDets+2, 0, 99999 );
+		//NClusterPixel = (Charge_Vs_Index[Harvest])->getTH2S()->Integral(NStripAPVs+2, NStripAPVs+NPixelDets+2, 0, 99999 );
 	}
 
 	// Now that we have the full statistics we can extract the information of the 2D histograms
@@ -1121,7 +1144,10 @@ void SiStripGainFromCalibTree::processEvent() {
 			if(Validation)     {ClusterChargeOverPath/=(*gainused)[i];}
 			if(OldGainRemoving){ClusterChargeOverPath*=(*gainused)[i];}
 		}
-		//(Charge_Vs_Index_Absolute[elepos])->Fill(APV->Index,Charge);   
+
+                // keep pixel cluster charge processing until here
+		if(APV->SubDet<=2) continue;
+
 		(Charge_Vs_Index[elepos])         ->Fill(APV->Index,ClusterChargeOverPath);
 
 
@@ -1358,8 +1384,9 @@ void SiStripGainFromCalibTree::qualityMonitor() {
         }
 
 
-        if (FitMPV<0.) {  // No fit of MPV
-            NoMPV->Fill(z,R);
+        if (FitMPV<=0.) {  // No fit of MPV
+            if (APV->isMasked) NoMPVmasked->Fill(z,R);
+            else               NoMPVfit->Fill(z,R);
 
         } else {          // Fit of MPV
             if(FitMPV>0.) Gains->Fill(Gain);
@@ -1482,19 +1509,19 @@ void SiStripGainFromCalibTree::storeOnTree(TFileService* tfs)
 	FILE* Gains = stdout;
 	fprintf(Gains,"NEvents   = %i\n",NEvent);
 	fprintf(Gains,"NTracks   = %i\n",NTrack);
-	fprintf(Gains,"NClustersPixel = %i\n",NClusterPixel);
+	//fprintf(Gains,"NClustersPixel = %i\n",NClusterPixel);
 	fprintf(Gains,"NClustersStrip = %i\n",NClusterStrip);
-	fprintf(Gains,"Number of Pixel Dets = %lu\n",static_cast<unsigned long>(NPixelDets));
+	//fprintf(Gains,"Number of Pixel Dets = %lu\n",static_cast<unsigned long>(NPixelDets));
 	fprintf(Gains,"Number of Strip APVs = %lu\n",static_cast<unsigned long>(NStripAPVs));
 	fprintf(Gains,"GoodFits = %i BadFits = %i ratio = %f%%   (MASKED=%i)\n",GOOD,BAD,(100.0*GOOD)/(GOOD+BAD), MASKED);
 
 	Gains=fopen(OutputGains.c_str(),"w");
 	fprintf(Gains,"NEvents   = %i\n",NEvent);
 	fprintf(Gains,"NTracks   = %i\n",NTrack);
-	fprintf(Gains,"NClustersPixel = %i\n",NClusterPixel);
+	//fprintf(Gains,"NClustersPixel = %i\n",NClusterPixel);
 	fprintf(Gains,"NClustersStrip = %i\n",NClusterStrip);
 	fprintf(Gains,"Number of Strip APVs = %lu\n",static_cast<unsigned long>(NStripAPVs));
-	fprintf(Gains,"Number of Pixel Dets = %lu\n",static_cast<unsigned long>(NPixelDets));
+	//fprintf(Gains,"Number of Pixel Dets = %lu\n",static_cast<unsigned long>(NPixelDets));
 	fprintf(Gains,"GoodFits = %i BadFits = %i ratio = %f%%   (MASKED=%i)\n",GOOD,BAD,(100.0*GOOD)/(GOOD+BAD), MASKED);
 
         int elepos = statCollectionFromMode(m_calibrationMode.c_str());

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -501,11 +501,11 @@ void SiStripGainFromCalibTree::bookDQMHistos(const char* dqm_dir, const char* ta
     double p2 = 69.01576;
     double y = 0.;
     for(int b=0;b<687;b++) {
-       binYarray.at(b) = y;
+       binYarray[b] = y;
        if(y<=902.) y = y + 2.;
        else y = ( p0 - log(exp(p0-p1*y) - p2*p1)) / p1;
     }
-    binYarray.at(687) = 4000.;
+    binYarray[687] = 4000.;
 
     Charge_Vs_Index[elepos]           = dbe->book2S(cvi.c_str()     , cvi.c_str()     , NStripAPVs, &binXarray[0], 687, binYarray.data());
     //Charge_Vs_Index_Absolute[elepos]  = dbe->book2S(cviA.c_str()    , cviA.c_str()    , 88625, 0   , 88624,1000,0,4000);

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -82,6 +82,7 @@
 #include "CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h"
 
 #include <unordered_map>
+#include <array>
 
 
 
@@ -480,25 +481,33 @@ void SiStripGainFromCalibTree::bookDQMHistos(const char* dqm_dir, const char* ta
 
     int elepos = (m_harvestingMode && AlgoMode=="PCL")? Harvest : statCollectionFromMode(tag);
 
-    //setting up the bin array for the Charge_Vs_Index histogram
-    float* binXarray = new float[NStripAPVs+1];
+    // The cluster charge is stored by exploiting a non uniform binning in order 
+    // reduce the histogram memory size. The bin width is relaxed with a falling
+    // exponential function and the bin boundaries are stored in the binYarray. 
+    // The binXarray is used to provide as many bins as the APVs.
+    //
+    // More details about this implementations are here:
+    // https://indico.cern.ch/event/649344/contributions/2672267/attachments/1498323/2332518/OptimizeChHisto.pdf
+
+    std::vector<float> binXarray;
+    binXarray.reserve( NStripAPVs+1 );
     for(int a=0;a<=NStripAPVs;a++){
-       binXarray[a] = (float)a;
+       binXarray.push_back( (float)a );
     }
  
-    float* binYarray = new float[688];
+    std::array<float,688> binYarray;
     double p0 = 5.445;
     double p1 = 0.002113;
     double p2 = 69.01576;
     double y = 0.;
     for(int b=0;b<687;b++) {
-       binYarray[b] = y;
+       binYarray.at(b) = y;
        if(y<=902.) y = y + 2.;
        else y = ( p0 - log(exp(p0-p1*y) - p2*p1)) / p1;
     }
-    binYarray[687] = 4000.;
+    binYarray.at(687) = 4000.;
 
-    Charge_Vs_Index[elepos]           = dbe->book2S(cvi.c_str()     , cvi.c_str()     , NStripAPVs, binXarray, 687, binYarray);
+    Charge_Vs_Index[elepos]           = dbe->book2S(cvi.c_str()     , cvi.c_str()     , NStripAPVs, &binXarray[0], 687, binYarray.data());
     //Charge_Vs_Index_Absolute[elepos]  = dbe->book2S(cviA.c_str()    , cviA.c_str()    , 88625, 0   , 88624,1000,0,4000);
     Charge_Vs_PathlengthTIB[elepos]   = dbe->book2S(cvpTIB.c_str()  , cvpTIB.c_str()  , 20   , 0.3 , 1.3  , 250,0,2000);
     Charge_Vs_PathlengthTOB[elepos]   = dbe->book2S(cvpTOB.c_str()  , cvpTOB.c_str()  , 20   , 0.3 , 1.3  , 250,0,2000);
@@ -549,9 +558,6 @@ void SiStripGainFromCalibTree::bookDQMHistos(const char* dqm_dir, const char* ta
         int plane = APVGain::subdetectorPlane((hnames[i]).first);
         Charge_4[elepos].push_back( APVGain::APVmon(id,side,plane,monitor) );
     }
-
-    delete[] binXarray;
-    delete[] binYarray;
 
     //Book validation histograms
     if (m_harvestingMode) {

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
@@ -186,7 +186,8 @@ SiStripGainsPCLHarvester::gainQualityMonitor(DQMStore::IBooker& ibooker_, const 
   MonitorElement* MPV_Vs_PhiTECthin  = ibooker_.book2DD("MPVvsPhiTEC1","MPV vs Phi TEC-thin ",50,-3.4,3.4,MPVbin,MPVmin,MPVmax);
   MonitorElement* MPV_Vs_PhiTECthick = ibooker_.book2DD("MPVvsPhiTEC2","MPV vs Phi TEC-thick",50,-3.4,3.4,MPVbin,MPVmin,MPVmax);
 
-  MonitorElement* NoMPV              = ibooker_.book2DD("NoMPV"         ,"NoMPV"         ,350, -350, 350, 240, 0, 120);
+  MonitorElement* NoMPVfit           = ibooker_.book2DD("NoMPVfit"    ,"Modules with bad Landau Fit",350, -350, 350, 240, 0, 120);
+  MonitorElement* NoMPVmasked        = ibooker_.book2DD("NoMPVmasked" ,"Masked Modules"             ,350, -350, 350, 240, 0, 120);
 
   MonitorElement* Gains              = ibooker_.book1DD("Gains"         ,"Gains"            , 300, 0, 2);
   MonitorElement* MPVs               = ibooker_.book1DD("MPVs"          ,"MPVs"             , MPVbin,MPVmin,MPVmax);
@@ -262,8 +263,9 @@ SiStripGainsPCLHarvester::gainQualityMonitor(DQMStore::IBooker& ibooker_, const 
     }
     
 
-    if (FitMPV<0.) {  // No fit of MPV
-       NoMPV->Fill(z,R);
+    if (FitMPV<=0.) {  // No fit of MPV
+       if (APV->isMasked) NoMPVmasked->Fill(z,R);
+       else               NoMPVfit->Fill(z,R);
 
     } else {          // Fit of MPV
        if(FitMPV>0.) Gains->Fill(Gain);

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
@@ -537,11 +537,11 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
   double p2 = 69.01576;
   double y = 0.;
   for(int b=0;b<687;b++) {
-     binYarray.at(b) = y;
+     binYarray[b] = y;
      if(y<=902.) y = y + 2.;
      else y = ( p0 - log(exp(p0-p1*y) - p2*p1)) / p1;
   }
-  binYarray.at(687) = 4000.;
+  binYarray[687] = 4000.;
   
   Charge_Vs_Index[elepos]           = ibooker.book2S(cvi.c_str()     , cvi.c_str()     , NStripAPVs, &binXarray[0], 687, binYarray.data());
   Charge_Vs_PathlengthTIB[elepos]   = ibooker.book2S(cvpTIB.c_str()  , cvpTIB.c_str()  , 20   , 0.3 , 1.3  , 250,0,2000);

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -1242,6 +1242,24 @@ DQMStore::book2D(const std::string &name, const std::string &title,
                                      nchX, xbinsize, nchY, ybinsize));
 }
 
+/// Book 2S variable bin histogram.
+MonitorElement *
+DQMStore::book2S(const char *name, const char *title,
+                 int nchX, const float *xbinsize, int nchY, const float *ybinsize)
+{
+  return book2S(pwd_, name, new TH2S(name, title,
+                                     nchX, xbinsize, nchY, ybinsize));
+}
+
+/// Book 2S variable bin histogram.
+MonitorElement *
+DQMStore::book2S(const std::string &name, const std::string &title,
+                 int nchX, const float *xbinsize, int nchY, const float *ybinsize)
+{
+  return book2S(pwd_, name, new TH2S(name.c_str(), title.c_str(),
+                                     nchX, xbinsize, nchY, ybinsize));
+}
+
 /// Book 2D histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book2D(const char *name, TH2F *source)


### PR DESCRIPTION
This pull requests implements the code needed to reduce the number of bins of the cluster charge histogram. The implementation requires to book a TH2S histogram with variable bin size, which was incidentally not supported by the DQMStore. The fix for this is delivered within the pull request under the  DQMservice package.

The motivation of this change has been already presented here
https://indico.cern.ch/event/649344/contributions/2672267/attachments/1498323/2332518/OptimizeChHisto.pdf

