### PR TITLE
more realistic cylinder of origin, halflength = 12cm, centered, 93X

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -338,10 +338,10 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
         #pixel  track/vertices reco
         process.load("RecoPixelVertexing.Configuration.RecoPixelVertexing_cff")
         process.pixelTracksTrackingRegions.RegionPSet.originRadius = 0.4
-        process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 6
+        process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 12
         process.pixelTracksTrackingRegions.RegionPSet.originXPos = 0.08
         process.pixelTracksTrackingRegions.RegionPSet.originYPos = -0.03
-        process.pixelTracksTrackingRegions.RegionPSet.originZPos = 1.
+        process.pixelTracksTrackingRegions.RegionPSet.originZPos = 0.
         process.pixelVertices.TkFilterParameters.minPt = process.pixelTracksTrackingRegions.RegionPSet.ptMin
 
         process.dqmBeamMonitor.PVFitter.errorScale = 1.22 #keep checking this with new release expected close to 1.2


### PR DESCRIPTION
All infos are listed at
[https://twiki.cern.ch/twiki/bin/view/CMS/OnlineBeamSpot#31_July_2017_check_if_origin_Hal](url)

Motivation: Proposal for a BS-related bug fix in EGamma paths￼ (Sam Harper)
Point to improve on: https://github.com/cms-sw/cmssw/blob/CMSSW_9_2_X/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py#L343￼
Results: checked run #300157￼ distribution of z position of the primary vertex fits vs originHalfLength, by modifying L343 in beam_dqm_sourceclient-live_cfg.py using first 5000 events in the run. 
(open the figures below in a new tab to get a larger figure) 
(blue arrows indicate the present working point of originHalfLength = 6 cm)

Conclusions:
online beamspot so far kind of worked with originHalfLength = 6 cm thanks to badly pointing low pt tracks or built-in tolerances; but in any case it clearly gives narrower sigmaZ than offline, and it affects e.g. hlt electrons.
the opening of originHalfLength results in a more symmetric and better gaussian-shaped primary vertex distribution with the price of a slightly increasing running time
based on the timing vs number of vertices plot (a sort of performance summary) I am proposing to set the working point to originHalfLength = 12 cm and also to re-center with originZPos = 0 cm