### PR TITLE
gcc7 compilation warning fix in RecoEgamma/EgammaIsolationAlgo pkg

### DIFF
--- a/RecoEgamma/EgammaIsolationAlgos/plugins/isolation_cones/ElectronPFIsolationWithConeVeto.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/isolation_cones/ElectronPFIsolationWithConeVeto.cc
@@ -94,11 +94,11 @@ isInIsolationCone(const reco::CandidatePtr& physob,
 	  break;
 	}
       }      
-      result *= ( is_vertex_allowed );
+      result = result && ( is_vertex_allowed );
     }
-    result *= deltar2 > vetoConeSize2 && deltar2 < _coneSize2 ;
+    result = result && ( deltar2 > vetoConeSize2 && deltar2 < _coneSize2 );
   } else if ( aspf.isNonnull() && aspf.get() ) {    
-    result *= deltar2 > vetoConeSize2 && deltar2 < _coneSize2;
+    result = result && ( deltar2 > vetoConeSize2 && deltar2 < _coneSize2 );
   } else {
     throw cms::Exception("InvalidIsolationInput")
       << "The supplied candidate to be used as isolation "


### PR DESCRIPTION
Fining compiler warning listed here
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-07-31-1200/RecoEgamma/EgammaIsolationAlgos