### PR TITLE
gcc7 compilation warning fix in RecoMuon/MuonIsolation package

### DIFF
--- a/RecoMuon/MuonIsolation/plugins/MuonPFIsolationWithConeVeto.cc
+++ b/RecoMuon/MuonIsolation/plugins/MuonPFIsolationWithConeVeto.cc
@@ -59,11 +59,11 @@ bool MuonPFIsolationWithConeVeto::isInIsolationCone(const reco::CandidatePtr& ph
           break;
         }
       }
-      result *= ( is_vertex_allowed );
+      result = result && ( is_vertex_allowed );
     }
-    result *= aspacked->pt() > _vetoThreshold && deltar2 > _vetoConeSize2 && deltar2 < _coneSize2 ;
+    result = result &&( aspacked->pt() > _vetoThreshold && deltar2 > _vetoConeSize2 && deltar2 < _coneSize2 );
   } else if ( aspf.isNonnull() && aspf.get() ) {
-    result *= aspf->pt() > _vetoThreshold && deltar2 > _vetoConeSize2 && deltar2 < _coneSize2 ;
+    result = result && ( aspf->pt() > _vetoThreshold && deltar2 > _vetoConeSize2 && deltar2 < _coneSize2 );
   } else {
     throw cms::Exception("InvalidIsolationInput")
       << "The supplied candidate to be used as isolation "


### PR DESCRIPTION
Fining compiler warning listed here
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-07-31-1200/RecoMuon/MuonIsolation