### PR TITLE
gcc7 compilation warning fix in EventFilter/CSCTFRawToDigi

### DIFF
--- a/EventFilter/CSCTFRawToDigi/src/CSCTFEvent.cc
+++ b/EventFilter/CSCTFRawToDigi/src/CSCTFEvent.cc
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <stdexcept>
 
-unsigned int CSCTFEvent::unpack(const unsigned short *buf, unsigned int length) throw() {
+unsigned int CSCTFEvent::unpack(const unsigned short *buf, unsigned int length) {
 	// Clean up
 	nRecords = 0;
 	bzero(sp,sizeof(sp));

--- a/EventFilter/CSCTFRawToDigi/src/CSCTFEvent.h
+++ b/EventFilter/CSCTFRawToDigi/src/CSCTFEvent.h
@@ -29,7 +29,7 @@ public:
         return retval;
     }
 
-	unsigned int unpack(const unsigned short *buf, unsigned int length) throw() ;
+	unsigned int unpack(const unsigned short *buf, unsigned int length);
 
 	CSCTFEvent(void){}
 };


### PR DESCRIPTION
Fining compiler warning listed here
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-07-31-1200/EventFilter/CSCTFRawToDigi