### PR TITLE
Fix mixing workflows that use playback

### DIFF
--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -409,7 +409,7 @@ namespace edm {
     }
     else{ // have to read PU information from playback info
       for (int bunchIdx = minBunch_; bunchIdx <= maxBunch_; ++bunchIdx) {
-
+	bunchCrossingList.push_back(bunchIdx);
 	for (size_t readSrcIdx=0; readSrcIdx<maxNbSources_; ++readSrcIdx) {
                                                                       
 	  if(oldFormatPlayback) {
@@ -418,12 +418,16 @@ namespace edm {
 	    if(readSrcIdx == 0) {
 	      PileupList.push_back(numberOfEvents);
 	      TrueNumInteractions_.push_back(numberOfEvents);
+	      numInteractionList.push_back(numberOfEvents);
+	      TrueInteractionList.push_back(numberOfEvents);
 	    }
 	  } else {
 	    size_t numberOfEvents = playbackInfo_H->getNumberOfEvents(bunchIdx, readSrcIdx);
 	    if(readSrcIdx == 0) {
 	      PileupList.push_back(numberOfEvents);
 	      TrueNumInteractions_.push_back(numberOfEvents);
+	      numInteractionList.push_back(numberOfEvents);
+	      TrueInteractionList.push_back(numberOfEvents);
 	    }
 	  }
 	}


### PR DESCRIPTION
Back in 81X, PR #15436 caused the heavy-ion embedding workflows that use the playback mechanism to stop giving sensible results.  
The symptom was that the primary vertex stopped being reconstructed, defaulting instead to the beamspot. 
For 80X, we simply reverted the corresponding PR with PR #18528

This PR fixes the issue in the master.  This can be seen by running wf 301 and scanning thru the PVs with FWLite as follows:
Events->Scan("recoVertexs_hiSelectedVertex__RECO.obj.position_.fCoordinates.fZ")
With this PR you will see distinct z-vertex values. 

@mdhildreth :  Can you have a look?




