### PR TITLE
Make L1TMuon offline DQM histogram binning configurable from config file

### DIFF
--- a/DQMOffline/L1Trigger/interface/L1TMuonDQMOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TMuonDQMOffline.h
@@ -138,7 +138,6 @@ class L1TMuonDQMOffline : public DQMEDAnalyzer {
         void getProbeMuons(edm::Handle<edm::TriggerResults> & trigResults,edm::Handle<trigger::TriggerEvent> & trigEvent);
 
     private:
-        bool  m_verbose;
         HLTConfigProvider m_hltConfig;
 
         edm::ESHandle<MagneticField> m_BField;
@@ -160,6 +159,7 @@ class L1TMuonDQMOffline : public DQMEDAnalyzer {
         BXVector<l1t::Muon>  m_L1tL1tMuons;
 
         // config params
+        bool  m_verbose;
         std::string m_HistFolder;
         std::vector<int> m_GmtPtCuts;
         edm::EDGetTokenT<reco::MuonCollection> m_MuonInputTag;
@@ -170,6 +170,10 @@ class L1TMuonDQMOffline : public DQMEDAnalyzer {
         std::string m_trigProcess;
         edm::EDGetTokenT<edm::TriggerResults> m_trigProcess_token;
         std::vector<std::string> m_trigNames;
+        std::vector<double> m_effVsPtBins;
+        std::vector<double> m_effVsPhiBins;
+        std::vector<double> m_effVsEtaBins;
+
         std::vector<int> m_trigIndices;
 
         float m_MaxMuonEta;

--- a/DQMOffline/L1Trigger/python/L1TMuonDQMOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TMuonDQMOffline_cfi.py
@@ -1,6 +1,29 @@
 import FWCore.ParameterSet.Config as cms
+import math
 
 muonEfficiencyThresholds = [16, 20, 25]
+
+# define binning for efficiency plots
+# pt
+effVsPtBins = range(0, 50, 2)
+effVsPtBins += range(50, 70, 5)
+effVsPtBins += range(70, 100, 10)
+effVsPtBins += range(100, 200, 25)
+effVsPtBins += range(200, 300, 50)
+effVsPtBins += range(300, 500, 100)
+effVsPtBins.append(500)
+
+# phi
+nPhiBins = 24
+phiMin = -math.pi
+phiMax = math.pi
+effVsPhiBins = [i*(phiMax-phiMin)/nPhiBins + phiMin for i in range(nPhiBins+1)]
+
+# eta
+nEtaBins = 50
+etaMin = -2.5
+etaMax = 2.5
+effVsEtaBins = [i*(etaMax-etaMin)/nEtaBins + etaMin for i in range(nEtaBins+1)]
 
 l1tMuonDQMOffline = cms.EDAnalyzer("L1TMuonDQMOffline",
     histFolder = cms.untracked.string('L1T/L1TMuon'),
@@ -23,6 +46,10 @@ l1tMuonDQMOffline = cms.EDAnalyzer("L1TMuonDQMOffline",
     trigInputTag       = cms.untracked.InputTag("hltTriggerSummaryAOD", "", "HLT"),
     trigProcess        = cms.untracked.string("HLT"),
     trigProcess_token  = cms.untracked.InputTag("TriggerResults","","HLT"),
+
+    efficiencyVsPtBins = cms.untracked.vdouble(effVsPtBins),
+    efficiencyVsPhiBins = cms.untracked.vdouble(effVsPhiBins),
+    efficiencyVsEtaBins = cms.untracked.vdouble(effVsEtaBins),
 
     verbose   = cms.untracked.bool(False)
 )

--- a/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
@@ -103,22 +103,23 @@ FreeTrajectoryState MuonGmtPair::freeTrajStateMuon(TrackRef track)
 }
 
 //__________DQM_base_class_______________________________________________
-L1TMuonDQMOffline::L1TMuonDQMOffline(const ParameterSet & ps){
-    m_verbose = ps.getUntrackedParameter<bool>("verbose");
+L1TMuonDQMOffline::L1TMuonDQMOffline(const ParameterSet & ps) :
+    m_verbose(ps.getUntrackedParameter<bool>("verbose")),
+    m_HistFolder(ps.getUntrackedParameter<string>("histFolder")),
+    m_GmtPtCuts(ps.getUntrackedParameter< vector<int> >("gmtPtCuts")),
+    m_MuonInputTag(consumes<reco::MuonCollection>(ps.getUntrackedParameter<InputTag>("muonInputTag"))),
+    m_GmtInputTag(consumes<l1t::MuonBxCollection>(ps.getUntrackedParameter<InputTag>("gmtInputTag"))),
+    m_VtxInputTag(consumes<VertexCollection>(ps.getUntrackedParameter<InputTag>("vtxInputTag"))),
+    m_BsInputTag(consumes<BeamSpot>(ps.getUntrackedParameter<InputTag>("bsInputTag"))),
+    m_trigInputTag(consumes<trigger::TriggerEvent>(ps.getUntrackedParameter<InputTag>("trigInputTag"))),
+    m_trigProcess(ps.getUntrackedParameter<string>("trigProcess")),
+    m_trigProcess_token(consumes<edm::TriggerResults>(ps.getUntrackedParameter<InputTag>("trigProcess_token"))),
+    m_trigNames(ps.getUntrackedParameter<vector<string> >("triggerNames")),
+    m_effVsPtBins(ps.getUntrackedParameter<std::vector<double>>("efficiencyVsPtBins")),
+    m_effVsPhiBins(ps.getUntrackedParameter<std::vector<double>>("efficiencyVsPhiBins")),
+    m_effVsEtaBins(ps.getUntrackedParameter<std::vector<double>>("efficiencyVsEtaBins"))
+{
     if (m_verbose) cout << "[L1TMuonDQMOffline:] ____________ Storage initialization ____________ " << endl;
-
-    // Initializing config params
-    m_HistFolder  = ps.getUntrackedParameter<string>("histFolder");
-    m_GmtPtCuts = ps.getUntrackedParameter< vector<int> >("gmtPtCuts");
-    m_MuonInputTag =  consumes<reco::MuonCollection>(ps.getUntrackedParameter<InputTag>("muonInputTag"));
-    m_GmtInputTag  =  consumes<l1t::MuonBxCollection>(ps.getUntrackedParameter<InputTag>("gmtInputTag"));
-    m_VtxInputTag =  consumes<VertexCollection>(ps.getUntrackedParameter<InputTag>("vtxInputTag"));
-    m_BsInputTag  =  consumes<BeamSpot>(ps.getUntrackedParameter<InputTag>("bsInputTag"));
-    m_trigInputTag = consumes<trigger::TriggerEvent>(ps.getUntrackedParameter<InputTag>("trigInputTag"));
-    m_trigProcess  = ps.getUntrackedParameter<string>("trigProcess");
-    m_trigProcess_token  = consumes<edm::TriggerResults>(ps.getUntrackedParameter<InputTag>("trigProcess_token"));
-    m_trigNames    = ps.getUntrackedParameter<vector<string> >("triggerNames");
-
     // CB do we need them from cfi?
     m_MaxMuonEta   = 2.4;
     m_MaxGmtMuonDR = 0.7;
@@ -334,76 +335,86 @@ void L1TMuonDQMOffline::bookEfficiencyHistos(DQMStore::IBooker &ibooker, int ptC
     string ptTag = ptCutToTag.str();
 
     ibooker.setCurrentFolder(m_HistFolder+"/numerators_and_denominators");
-    float xbins[33] = {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 55, 60, 65, 70, 80, 90, 100};
+
+    std::vector<float> effVsPtBins(m_effVsPtBins.begin(), m_effVsPtBins.end());
+    int nEffVsPtBins = effVsPtBins.size() - 1;
+    float* ptBinsArray = &(effVsPtBins[0]);
 
     string name1 = "EffvsPt_" + ptTag + "_Den";
-    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(),name1.c_str(),32,xbins);
+    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(), name1.c_str(), nEffVsPtBins, ptBinsArray);
     string name2 = "EffvsPt_" + ptTag + "_Num";
-    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(),name2.c_str(),32,xbins);
+    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(), name2.c_str(), nEffVsPtBins, ptBinsArray);
 
     name1 = "EffvsPt_OPEN_" + ptTag + "_Den";
-    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(),name1.c_str(),32,xbins);
+    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(), name1.c_str(), nEffVsPtBins, ptBinsArray);
     name2 = "EffvsPt_OPEN_" + ptTag + "_Num";
-    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(),name2.c_str(),32,xbins);
+    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(), name2.c_str(), nEffVsPtBins, ptBinsArray);
 
     name1 = "EffvsPt_DOUBLE_" + ptTag + "_Den";
-    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(),name1.c_str(),32, xbins);
+    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(), name1.c_str(), nEffVsPtBins, ptBinsArray);
     name2 = "EffvsPt_DOUBLE_" + ptTag + "_Num";
-    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(),name2.c_str(),32, xbins);
+    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(), name2.c_str(), nEffVsPtBins, ptBinsArray);
 
     name1 = "EffvsPt_SINGLE_" + ptTag + "_Den";
-    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(),name1.c_str(),32,xbins);
+    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(), name1.c_str(), nEffVsPtBins, ptBinsArray);
     name2 = "EffvsPt_SINGLE_" + ptTag + "_Num";
-    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(),name2.c_str(),32,xbins);
+    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(), name2.c_str(), nEffVsPtBins, ptBinsArray);
 
 ////////////////////////////////////////////////
 
+    std::vector<float> effVsPhiBins(m_effVsPhiBins.begin(), m_effVsPhiBins.end());
+    int nEffVsPhiBins = effVsPhiBins.size() - 1;
+    float* phiBinsArray = &(effVsPhiBins[0]);
+
+    std::vector<float> effVsEtaBins(m_effVsEtaBins.begin(), m_effVsEtaBins.end());
+    int nEffVsEtaBins = effVsEtaBins.size() - 1;
+    float* etaBinsArray = &(effVsEtaBins[0]);
+
     name1 = "EffvsPhi_" + ptTag + "_Den";
-    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(),name1.c_str(),24,-TMath::Pi(),TMath::Pi());
+    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(), name1.c_str(), nEffVsPhiBins, phiBinsArray);
     name2 = "EffvsPhi_" + ptTag + "_Num";
-    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(),name2.c_str(),24,-TMath::Pi(),TMath::Pi());
+    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(), name2.c_str(), nEffVsPhiBins, phiBinsArray);
 
     name1 = "EffvsEta_" + ptTag + "_Den";
-    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(),name1.c_str(),50,-2.5,2.5);
+    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(), name1.c_str(), nEffVsEtaBins, etaBinsArray);
     name2 = "EffvsEta_" + ptTag + "_Num";
-    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(),name2.c_str(),50,-2.5,2.5);
+    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(), name2.c_str(), nEffVsEtaBins, etaBinsArray);
 
 //////////////////////////////////////////////
 
     name1 = "EffvsPhi_OPEN_" + ptTag + "_Den";
-    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(),name1.c_str(),24,-TMath::Pi(),TMath::Pi());
+    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(), name1.c_str(), nEffVsPhiBins, phiBinsArray);
     name2 = "EffvsPhi_OPEN_" + ptTag + "_Num";
-    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(),name2.c_str(),24,-TMath::Pi(),TMath::Pi());
+    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(), name2.c_str(), nEffVsPhiBins, phiBinsArray);
 
     name1 = "EffvsEta_OPEN_" + ptTag + "_Den";
-    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(),name1.c_str(),50,-2.5,2.5);
+    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(), name1.c_str(), nEffVsEtaBins, etaBinsArray);
     name2 = "EffvsEta_OPEN_" + ptTag + "_Num";
-    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(),name2.c_str(),50,-2.5,2.5);
+    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(), name2.c_str(), nEffVsEtaBins, etaBinsArray);
 
 //////////////////////////////////////////////
 
     name1 = "EffvsPhi_DOUBLE_" + ptTag + "_Den";
-    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(),name1.c_str(),24,-TMath::Pi(),TMath::Pi());
+    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(), name1.c_str(), nEffVsPhiBins, phiBinsArray);
     name2 = "EffvsPhi_DOUBLE_" + ptTag + "_Num";
-    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(),name2.c_str(),24,-TMath::Pi(),TMath::Pi());
+    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(), name2.c_str(), nEffVsPhiBins, phiBinsArray);
 
     name1 = "EffvsEta_DOUBLE_" + ptTag + "_Den";
-    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(),name1.c_str(),50,-2.5,2.5);
+    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(), name1.c_str(), nEffVsEtaBins, etaBinsArray);
     name2 = "EffvsEta_DOUBLE_" + ptTag + "_Num";
-    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(),name2.c_str(),50,-2.5,2.5);
+    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(), name2.c_str(), nEffVsEtaBins, etaBinsArray);
 
 //////////////////////////////////////////////
 
     name1 = "EffvsPhi_SINGLE_" + ptTag + "_Den";
-    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(),name1.c_str(),24,-TMath::Pi(),TMath::Pi());
+    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(), name1.c_str(), nEffVsPhiBins, phiBinsArray);
     name2 = "EffvsPhi_SINGLE_" + ptTag + "_Num";
-    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(),name2.c_str(),24,-TMath::Pi(),TMath::Pi());
-
+    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(), name2.c_str(), nEffVsPhiBins, phiBinsArray);
 
     name1 = "EffvsEta_SINGLE_" + ptTag + "_Den";
-    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(),name1.c_str(),50,-2.5,2.5);
+    m_EfficiencyHistos[ptCut][name1] = ibooker.book1D(name1.c_str(), name1.c_str(), nEffVsEtaBins, etaBinsArray);
     name2 = "EffvsEta_SINGLE_" + ptTag + "_Num";
-    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(),name2.c_str(),50,-2.5,2.5);
+    m_EfficiencyHistos[ptCut][name2] = ibooker.book1D(name2.c_str(), name2.c_str(), nEffVsEtaBins, etaBinsArray);
 }
 
 //_____________________________________________________________________


### PR DESCRIPTION
Makes the binning of the histograms for the efficiency calculation configurable from the python config file.

This also fixes a crash that appeared after the PR #19441 was merged. It seems that the TH1::Divide function used in the harvesting step cannot mix TH1s with the binning defined by an minimum and maximum value with TH1s with the binning defined by an array (https://root-forum.cern.ch/t/attempt-to-divide-histograms-with-different-bin-limits/17624).
All L1TMuon MonitorElements are now booked with arrays for the binning.

The reason that this crash was not found in the matrix tests is that the @common DQM workflow, which seems to be used at the T0, is not executed in any test as far as I could see.