### PR TITLE
fix upgrade input tags for HCAL TPs w/ premixing

### DIFF
--- a/Configuration/StandardSequences/python/DataMixerDataOnData_cff.py
+++ b/Configuration/StandardSequences/python/DataMixerDataOnData_cff.py
@@ -42,6 +42,7 @@ DMHcalTTPDigis = simHcalTTPDigis.clone()
 
 # Re-define inputs to point at DataMixer output
 DMHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag(cms.InputTag('mixData'),cms.InputTag('mixData'))
+DMHcalTriggerPrimitiveDigis.inputUpgradeLabel = cms.VInputTag(cms.InputTag('mixData:HBHEQIE11DigiCollection'),cms.InputTag('mixData:HFQIE10DigiCollection'))
 DMHcalDigis.digiLabel = cms.string("mixData")
 DMHcalTTPDigis.HFDigiCollection = cms.InputTag("mixData")
 

--- a/Configuration/StandardSequences/python/DataMixerDataOnSim_cff.py
+++ b/Configuration/StandardSequences/python/DataMixerDataOnSim_cff.py
@@ -42,6 +42,7 @@ DMHcalTTPDigis = simHcalTTPDigis.clone()
 
 # Re-define inputs to point at DataMixer output
 DMHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag(cms.InputTag('mixData'),cms.InputTag('mixData'))
+DMHcalTriggerPrimitiveDigis.inputUpgradeLabel = cms.VInputTag(cms.InputTag('mixData:HBHEQIE11DigiCollection'),cms.InputTag('mixData:HFQIE10DigiCollection'))
 DMHcalDigis.digiLabel = cms.string("mixData")
 DMHcalTTPDigis.HFDigiCollection = cms.InputTag("mixData")
 

--- a/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
+++ b/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
@@ -42,6 +42,7 @@ DMHcalTTPDigis = simHcalTTPDigis.clone()
 
 # Re-define inputs to point at DataMixer output
 DMHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag(cms.InputTag('mixData'),cms.InputTag('mixData'))
+DMHcalTriggerPrimitiveDigis.inputUpgradeLabel = cms.VInputTag(cms.InputTag('mixData:HBHEQIE11DigiCollection'),cms.InputTag('mixData:HFQIE10DigiCollection'))
 DMHcalDigis.digiLabel = cms.string('mixData')
 DMHcalTTPDigis.HFDigiCollection = cms.InputTag("mixData")
 

--- a/Configuration/StandardSequences/python/DataMixerSimOnSim_cff.py
+++ b/Configuration/StandardSequences/python/DataMixerSimOnSim_cff.py
@@ -42,6 +42,7 @@ DMHcalTTPDigis = simHcalTTPDigis.clone()
 
 # Re-define inputs to point at DataMixer output
 DMHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag(cms.InputTag('mixData'),cms.InputTag('mixData'))
+DMHcalTriggerPrimitiveDigis.inputUpgradeLabel = cms.VInputTag(cms.InputTag('mixData:HBHEQIE11DigiCollection'),cms.InputTag('mixData:HFQIE10DigiCollection'))
 DMHcalDigis.digiLabel = cms.string("mixData")
 DMHcalTTPDigis.HFDigiCollection = cms.InputTag("mixData")
 


### PR DESCRIPTION
Fixes the problem observed in premixing relvals (see [here](https://indico.cern.ch/event/656058/contributions/2672562/attachments/1499922/2335536/RelVal930pre2.pdf#page=6)).

The wrong HCAL upgrade digi collections were being given to the trigger primitive producer. This actually caused the TP collection to be entirely empty. It is filled properly with this PR.

attn: @mdhildreth 