### PR TITLE
Add first hit from HitPattern in PackedCandidates with high level track details (92X version)

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -33,9 +33,8 @@ namespace pat {
     typedef math::XYZVector Vector;
 
     typedef unsigned int index;
-
     /// default constructor
-    PackedCandidate() :
+    PackedCandidate() : 
       packedPt_(0), packedEta_(0),
       packedPhi_(0), packedM_(0),
       packedDxy_(0), packedDz_(0), packedDPhi_(0), packedDEta_(0),packedDTrkPt_(0),
@@ -48,7 +47,7 @@ namespace pat {
       p4_(new PolarLorentzVector(0,0,0,0)), p4c_( new LorentzVector(0,0,0,0)), 
       vertex_(new Point(0,0,0)), dphi_(0), deta_(0), dtrkpt_(0),track_(nullptr), pdgId_(0),
       qualityFlags_(0), pvRefKey_(reco::VertexRef::invalidKey()),
-      m_(nullptr), packedHits_(0), packedLayers_(0), normalizedChi2_(0),covarianceVersion_(0),covarianceSchema_(0) { }
+      m_(nullptr), packedHits_(0), packedLayers_(0), normalizedChi2_(0),covarianceVersion_(0),covarianceSchema_(0),firstHit_(0) { }
 
     explicit PackedCandidate( const reco::Candidate & c,
                               const reco::VertexRefProd &pvRefProd,
@@ -60,7 +59,7 @@ namespace pat {
       dphi_(0), deta_(0), dtrkpt_(0),
       track_(nullptr), pdgId_(c.pdgId()), qualityFlags_(0), pvRefProd_(pvRefProd),
       pvRefKey_(pvRefKey),m_(nullptr), packedHits_(0), packedLayers_(0),
-      normalizedChi2_(0),covarianceVersion_(0), covarianceSchema_(0) {
+      normalizedChi2_(0),covarianceVersion_(0), covarianceSchema_(0),firstHit_(0) {
       packBoth();
     }
 
@@ -77,7 +76,7 @@ namespace pat {
       dtrkpt_(std::abs(trkPt-p4_.load()->pt())>=kMinDTrkPtToStore_ ? trkPt-p4_.load()->pt() : 0.),
       track_(nullptr), pdgId_(pdgId),
       qualityFlags_(0), pvRefProd_(pvRefProd), pvRefKey_(pvRefKey),
-      m_(nullptr),packedHits_(0), packedLayers_(0),normalizedChi2_(0),covarianceVersion_(0),covarianceSchema_(0) {
+      m_(nullptr),packedHits_(0), packedLayers_(0),normalizedChi2_(0),covarianceVersion_(0),covarianceSchema_(0),firstHit_(0) {
       packBoth();
     }
 
@@ -94,7 +93,7 @@ namespace pat {
       dtrkpt_(std::abs(trkPt-p4_.load()->pt())>=kMinDTrkPtToStore_ ? trkPt-p4_.load()->pt() : 0.),
       track_(nullptr), pdgId_(pdgId), qualityFlags_(0),
       pvRefProd_(pvRefProd), pvRefKey_(pvRefKey),
-      m_(nullptr),packedHits_(0),packedLayers_(0),normalizedChi2_(0),covarianceVersion_(0),covarianceSchema_(0)  {
+      m_(nullptr),packedHits_(0),packedLayers_(0),normalizedChi2_(0),covarianceVersion_(0),covarianceSchema_(0),firstHit_(0)  {
       packBoth();
     }
 
@@ -119,7 +118,7 @@ namespace pat {
       pvRefProd_(iOther.pvRefProd_),pvRefKey_(iOther.pvRefKey_),
       m_(iOther.m_? new reco::TrackBase::CovarianceMatrix(*iOther.m_) : nullptr),
       packedHits_(iOther.packedHits_),packedLayers_(iOther.packedLayers_),  normalizedChi2_(iOther.normalizedChi2_),
-      covarianceVersion_(iOther.covarianceVersion_), covarianceSchema_(iOther.covarianceSchema_)  {
+      covarianceVersion_(iOther.covarianceVersion_), covarianceSchema_(iOther.covarianceSchema_),firstHit_(iOther.firstHit_)  {
       }
 
     PackedCandidate( PackedCandidate&& iOther) :
@@ -142,7 +141,7 @@ namespace pat {
       pvRefProd_(std::move(iOther.pvRefProd_)),pvRefKey_(iOther.pvRefKey_),
       m_( iOther.m_.exchange(nullptr)),
       packedHits_(iOther.packedHits_), packedLayers_(iOther.packedLayers_),normalizedChi2_(iOther.normalizedChi2_),
-      covarianceVersion_(iOther.covarianceVersion_), covarianceSchema_(iOther.covarianceSchema_) {
+      covarianceVersion_(iOther.covarianceVersion_), covarianceSchema_(iOther.covarianceSchema_),firstHit_(iOther.firstHit_)  {
       }
 
 
@@ -217,6 +216,7 @@ namespace pat {
       normalizedChi2_=iOther.normalizedChi2_;
       covarianceVersion_=iOther.covarianceVersion_;
       covarianceSchema_=iOther.covarianceSchema_;
+      firstHit_=iOther.firstHit_;
       return *this;
     }
 
@@ -258,6 +258,7 @@ namespace pat {
       normalizedChi2_=iOther.normalizedChi2_;
       covarianceVersion_=iOther.covarianceVersion_;
       covarianceSchema_=iOther.covarianceSchema_;
+      firstHit_=iOther.firstHit_;
       return *this;
     }
 
@@ -524,6 +525,13 @@ namespace pat {
         qualityFlags_ = (qualityFlags_ & ~lostInnerHitsMask) | ((lost << lostInnerHitsShift) & lostInnerHitsMask); 
     }
 
+    /// Set first hit from HitPattern
+    void setFirstHit(uint32_t hitFromHitPattern) {
+	firstHit_=hitFromHitPattern;
+    }
+    /// Return first hit from HitPattern for tracks with high level details
+    uint32_t firstHit() const { return	firstHit_;}
+
     void setMuonID(bool isStandAlone, bool isGlobal) {
         int16_t muonFlags = isStandAlone | (2*isGlobal);
         qualityFlags_ = (qualityFlags_ & ~muonFlagsMask) | ((muonFlags << muonFlagsShift) & muonFlagsMask);
@@ -716,6 +724,8 @@ namespace pat {
         lostInnerHitsMask = 0x30, lostInnerHitsShift=4,
         muonFlagsMask = 0x0600, muonFlagsShift=9
     };
+  public:
+    uint32_t firstHit_;
   };
 
   typedef std::vector<pat::PackedCandidate> PackedCandidateCollection;

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -526,11 +526,11 @@ namespace pat {
     }
 
     /// Set first hit from HitPattern
-    void setFirstHit(uint32_t hitFromHitPattern) {
-	firstHit_=hitFromHitPattern;
+    void setFirstHit(uint16_t pattern) {
+	firstHit_=pattern;
     }
     /// Return first hit from HitPattern for tracks with high level details
-    uint32_t firstHit() const { return	firstHit_;}
+    uint16_t firstHit() const { return	firstHit_;}
 
     void setMuonID(bool isStandAlone, bool isGlobal) {
         int16_t muonFlags = isStandAlone | (2*isGlobal);
@@ -725,7 +725,7 @@ namespace pat {
         muonFlagsMask = 0x0600, muonFlagsShift=9
     };
   public:
-    uint32_t firstHit_;
+    uint16_t firstHit_;
   };
 
   typedef std::vector<pat::PackedCandidate> PackedCandidateCollection;

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -165,9 +165,17 @@ void pat::PackedCandidate::unpackTrk() const {
     LostInnerHits innerLost = lostInnerHits();
     
     auto track = std::make_unique<reco::Track>(normalizedChi2_*ndof,ndof,*vertex_,math::XYZVector(p3.x(),p3.y(),p3.z()),charge(),*(m_.load()),reco::TrackBase::undefAlgorithm,reco::TrackBase::loose);
-    
-    track->appendHitPattern(firstHit_,TrackingRecHit::valid);
-    int i=1; // we added already one hit in the line above
+    int i=0;
+    if ( firstHit_ == 0) { 
+	   if(innerLost == validHitInFirstPixelBarrelLayer){
+	      track->appendTrackerHitPattern(PixelSubdetector::PixelBarrel, 1, 0, TrackingRecHit::valid); 		
+	      i=1;
+	   } 
+
+    } else {
+	   track->appendHitPattern(firstHit_,TrackingRecHit::valid);
+	   i=1;
+    }
 
     // add hits to match the number of laters and validHitInFirstPixelBarrelLayer
     if(innerLost == validHitInFirstPixelBarrelLayer){

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -304,7 +304,7 @@
    <version ClassVersion="3" checksum="3320406063"/>
   </class>
   <class name="pat::PackedCandidate" ClassVersion="31">
-   <version ClassVersion="31" checksum="3956419701"/>
+   <version ClassVersion="31" checksum="1248040002"/>
    <version ClassVersion="30" checksum="3338823671"/>
    <version ClassVersion="29" checksum="649303924"/>
    <version ClassVersion="28" checksum="1956349111"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -303,7 +303,8 @@
   <class name="pat::PackedCandidate::PackedCovariance" ClassVersion="3">
    <version ClassVersion="3" checksum="3320406063"/>
   </class>
-  <class name="pat::PackedCandidate" ClassVersion="30">
+  <class name="pat::PackedCandidate" ClassVersion="31">
+   <version ClassVersion="31" checksum="3956419701"/>
    <version ClassVersion="30" checksum="3338823671"/>
    <version ClassVersion="29" checksum="649303924"/>
    <version ClassVersion="28" checksum="1956349111"/>

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -236,6 +236,7 @@ public:
     bool appendHit(const TrackingRecHit &hit, const TrackerTopology& ttopo);
     bool appendHit(const TrackingRecHitRef &ref, const TrackerTopology& ttopo);
     bool appendHit(const DetId &id, TrackingRecHit::Type hitType, const TrackerTopology& ttopo);
+    bool appendHit(const uint16_t pattern, TrackingRecHit::Type hitType);
 
     /**
      * This is meant to be used only in cases where the an
@@ -463,7 +464,6 @@ private:
     bool insertExpectedInnerHit(const uint16_t pattern);
     bool insertExpectedOuterHit(const uint16_t pattern);
     void insertHit(const uint16_t pattern);
-    bool appendHit(const uint16_t pattern, TrackingRecHit::Type hitType);
 
     uint16_t getHitPatternByAbsoluteIndex(int position) const;
 

--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -335,12 +335,13 @@ public:
     bool appendHitPattern(const DetId &id, TrackingRecHit::Type hitType, const TrackerTopology& ttopo);
 
     /**
-     * This is meant to be used only in cases where the an
+     * These are meant to be used only in cases where the an
      * already-packed hit information is re-interpreted in terms of
      * HitPattern (i.e. MiniAOD PackedCandidate, and the IO rule for
      * reading old versions of HitPattern)
      */
     bool appendTrackerHitPattern(uint16_t subdet, uint16_t layer, uint16_t stereo, TrackingRecHit::Type hitType);
+    bool appendHitPattern(const uint16_t pattern, TrackingRecHit::Type hitType);
 
     /**
      * This is meant to be used only in cases where the an
@@ -459,6 +460,10 @@ inline bool TrackBase::appendHitPattern(const TrackingRecHit &hit, const Tracker
 
 inline bool TrackBase::appendTrackerHitPattern(uint16_t subdet, uint16_t layer, uint16_t stereo, TrackingRecHit::Type hitType) {
     return hitPattern_.appendTrackerHit(subdet, layer, stereo, hitType);
+}
+
+inline bool TrackBase::appendHitPattern(uint16_t pattern, TrackingRecHit::Type hitType) {
+    return hitPattern_.appendHit(pattern, hitType);
 }
 
 inline bool TrackBase::appendMuonHitPattern(const DetId& id, TrackingRecHit::Type hitType) {

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -266,6 +266,8 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
 	     whiteList.find(ic)!=whiteList.end() || 
              (cand.trackRef().isNonnull() &&  whiteListTk.find(cand.trackRef())!=whiteListTk.end())
 	    ) {
+	   outPtrP->back().setFirstHit(ctrack->hitPattern().getHitPattern(reco::HitPattern::TRACK_HITS, 0));
+
             if(abs(outPtrP->back().pdgId())==22) {outPtrP->back().setTrackProperties(*ctrack,covariancePackingSchemas_[4],covarianceVersion_);}
             else { 
                 if( ctrack->hitPattern().numberOfValidPixelHits() >0) { outPtrP->back().setTrackProperties(*ctrack,covariancePackingSchemas_[0],covarianceVersion_);} //high quality 

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -266,14 +266,16 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
 	     whiteList.find(ic)!=whiteList.end() || 
              (cand.trackRef().isNonnull() &&  whiteListTk.find(cand.trackRef())!=whiteListTk.end())
 	    ) {
-	   outPtrP->back().setFirstHit(ctrack->hitPattern().getHitPattern(reco::HitPattern::TRACK_HITS, 0));
-
-            if(abs(outPtrP->back().pdgId())==22) {outPtrP->back().setTrackProperties(*ctrack,covariancePackingSchemas_[4],covarianceVersion_);}
-            else { 
-                if( ctrack->hitPattern().numberOfValidPixelHits() >0) { outPtrP->back().setTrackProperties(*ctrack,covariancePackingSchemas_[0],covarianceVersion_);} //high quality 
-                  else {  outPtrP->back().setTrackProperties(*ctrack,covariancePackingSchemas_[1],covarianceVersion_);} 
-             }
-            
+	      outPtrP->back().setFirstHit(ctrack->hitPattern().getHitPattern(reco::HitPattern::TRACK_HITS, 0));
+              if(abs(outPtrP->back().pdgId())==22) {
+                  outPtrP->back().setTrackProperties(*ctrack,covariancePackingSchemas_[4],covarianceVersion_);
+	      } else { 
+                  if( ctrack->hitPattern().numberOfValidPixelHits() >0) {
+		      outPtrP->back().setTrackProperties(*ctrack,covariancePackingSchemas_[0],covarianceVersion_); //high quality 
+		  }  else { 
+		      outPtrP->back().setTrackProperties(*ctrack,covariancePackingSchemas_[1],covarianceVersion_);
+		  } 
+              }            
             //outPtrP->back().setTrackProperties(*ctrack,tsos.curvilinearError());
           } else {
             if(outPtrP->back().pt() > 0.5 ){ 


### PR DESCRIPTION
This adds the first hit layer/substructure information for PackedCandidates passing the high level track details (i.e.> 0.95GeV at the moment)
It also removes the storage of case the lostHits = -1 (validHitInFirstPixelBarrelLayer) as the information is redundant (at least for tracks where the first hit is in PXB1, perhaps not true for some loopers... )

The size increase should be ~ 60-100 bytes/event

@gpetruc

same as #19509 