### PR TITLE
attempt to fix SiStrip DQM reproducibility issue: allign members common to root and full c++

### DIFF
--- a/DPGAnalysis/SiStripTools/interface/Multiplicities.h
+++ b/DPGAnalysis/SiStripTools/interface/Multiplicities.h
@@ -43,12 +43,12 @@ class ClusterSummarySingleMultiplicity {
   int mult() const;
 
  private:
-#ifndef __ROOTCLING__
-  edm::EDGetTokenT<ClusterSummary> m_collection;
-#endif
   ClusterSummary::CMSTracker m_subdetenum;
   ClusterSummary::VariablePlacement m_varenum;
   int m_mult;
+#ifndef __ROOTCLING__
+  edm::EDGetTokenT<ClusterSummary> m_collection;
+#endif
 
 };
 
@@ -70,43 +70,40 @@ class SingleMultiplicity {
 
  private:
 
-#ifndef __ROOTCLING__
-  edm::EDGetTokenT<T> m_collection;
-#endif
   int m_modthr;
   bool m_useQuality;
   std::string m_qualityLabel;
   int m_mult;
+#ifndef __ROOTCLING__
+  edm::EDGetTokenT<T> m_collection;
+#endif
 };
 
 template <class T>
 SingleMultiplicity<T>::SingleMultiplicity():
-  //  mult(0),
-#ifndef __ROOTCLING__
-m_collection(),
-#endif
     m_modthr(-1), m_useQuality(false),  m_qualityLabel(),
-  m_mult(0)
+    m_mult(0)
+#ifndef __ROOTCLING__
+    ,m_collection()
+#endif
 { }
 
 #ifndef __ROOTCLING__
 template <class T>
 SingleMultiplicity<T>::SingleMultiplicity(const edm::ParameterSet& iConfig,edm::ConsumesCollector&& iC):
-  //  mult(0),
-m_collection(iC.consumes<T>(iConfig.getParameter<edm::InputTag>("collectionName"))),
   m_modthr(iConfig.getUntrackedParameter<int>("moduleThreshold")),
   m_useQuality(iConfig.getUntrackedParameter<bool>("useQuality",false)),
   m_qualityLabel(iConfig.getUntrackedParameter<std::string>("qualityLabel","")),
-  m_mult(0)
+  m_mult(0),
+  m_collection(iC.consumes<T>(iConfig.getParameter<edm::InputTag>("collectionName")))
 { }
 template <class T>
 SingleMultiplicity<T>::SingleMultiplicity(const edm::ParameterSet& iConfig,edm::ConsumesCollector& iC):
-  //  mult(0),
-m_collection(iC.consumes<T>(iConfig.getParameter<edm::InputTag>("collectionName"))),
   m_modthr(iConfig.getUntrackedParameter<int>("moduleThreshold")),
   m_useQuality(iConfig.getUntrackedParameter<bool>("useQuality",false)),
   m_qualityLabel(iConfig.getUntrackedParameter<std::string>("qualityLabel","")),
-  m_mult(0)
+  m_mult(0),
+  m_collection(iC.consumes<T>(iConfig.getParameter<edm::InputTag>("collectionName")))
 { }
 #endif
 
@@ -116,7 +113,6 @@ void
 SingleMultiplicity<T>::getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
   m_mult = 0;
-  //  mult = 0;
 
   edm::ESHandle<SiStripQuality> qualityHandle;
    if( m_useQuality) {
@@ -156,8 +152,6 @@ template <class T1, class T2>
     void getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup);
     int mult1() const;
     int mult2() const;
-    //    int mult1;
-    //    int mult2;
 
  private:
 
@@ -168,20 +162,17 @@ template <class T1, class T2>
 
 template <class T1, class T2>
   MultiplicityPair<T1,T2>::MultiplicityPair():
-    //    mult1(0),mult2(0),
     m_multiplicity1(),  m_multiplicity2()
 { }
 
 #ifndef __ROOTCLING__
 template <class T1, class T2>
       MultiplicityPair<T1,T2>::MultiplicityPair(const edm::ParameterSet& iConfig,edm::ConsumesCollector&& iC):
-    //    mult1(0),mult2(0),
   m_multiplicity1(iConfig.getParameter<edm::ParameterSet>("firstMultiplicityConfig"),iC),
     m_multiplicity2(iConfig.getParameter<edm::ParameterSet>("secondMultiplicityConfig"),iC)
 { }
 template <class T1, class T2>
       MultiplicityPair<T1,T2>::MultiplicityPair(const edm::ParameterSet& iConfig,edm::ConsumesCollector& iC):
-    //    mult1(0),mult2(0),
   m_multiplicity1(iConfig.getParameter<edm::ParameterSet>("firstMultiplicityConfig"),iC),
     m_multiplicity2(iConfig.getParameter<edm::ParameterSet>("secondMultiplicityConfig"),iC)
 { }
@@ -194,8 +185,6 @@ template <class T1, class T2>
   m_multiplicity1.getEvent(iEvent,iSetup);
   m_multiplicity2.getEvent(iEvent,iSetup);
 
-  //  mult1=m_multiplicity1.mult;
-  //  mult2=m_multiplicity2.mult;
 
 }
 

--- a/DPGAnalysis/SiStripTools/src/Multiplicities.cc
+++ b/DPGAnalysis/SiStripTools/src/Multiplicities.cc
@@ -1,18 +1,18 @@
 #include "DPGAnalysis/SiStripTools/interface/Multiplicities.h"
 
 ClusterSummarySingleMultiplicity::ClusterSummarySingleMultiplicity():
-  m_collection(),m_subdetenum(ClusterSummary::STRIP),m_varenum(ClusterSummary::NCLUSTERS),m_mult(0) { }
+  m_subdetenum(ClusterSummary::STRIP),m_varenum(ClusterSummary::NCLUSTERS),m_mult(0),m_collection() { }
 
 ClusterSummarySingleMultiplicity::ClusterSummarySingleMultiplicity(const edm::ParameterSet& iConfig,edm::ConsumesCollector&& iC):
-  m_collection(iC.consumes<ClusterSummary>(iConfig.getParameter<edm::InputTag>("clusterSummaryCollection"))),
   m_subdetenum((ClusterSummary::CMSTracker)iConfig.getParameter<int>("subDetEnum")),m_varenum((ClusterSummary::VariablePlacement)iConfig.getParameter<int>("varEnum")),
-  m_mult(0)
+  m_mult(0),
+  m_collection(iC.consumes<ClusterSummary>(iConfig.getParameter<edm::InputTag>("clusterSummaryCollection")))
 {}
 
 ClusterSummarySingleMultiplicity::ClusterSummarySingleMultiplicity(const edm::ParameterSet& iConfig,edm::ConsumesCollector& iC):
-  m_collection(iC.consumes<ClusterSummary>(iConfig.getParameter<edm::InputTag>("clusterSummaryCollection"))),
   m_subdetenum((ClusterSummary::CMSTracker)iConfig.getParameter<int>("subDetEnum")),m_varenum((ClusterSummary::VariablePlacement)iConfig.getParameter<int>("varEnum")),
-  m_mult(0)
+  m_mult(0),
+  m_collection(iC.consumes<ClusterSummary>(iConfig.getParameter<edm::InputTag>("clusterSummaryCollection")))
 {}
 
 void ClusterSummarySingleMultiplicity::getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) {


### PR DESCRIPTION
DPGAnalysis/SiStripTools/interface/Multiplicities.h has different class data member content depending on the compilation mode (used for dictionary generation or for execution in algorithms at run time). This PR makes the layout for common data members to be the same.
This should hopefully resolve https://its.cern.ch/jira/browse/CMSTRACK-151

This is meant to solve the following problem
We frequently have SiStrip DQM plots coming and going altogether in ```AlCaReco/Run summary/SiStrip/MechanicalView``` folder.
These are produced by SiStripCalZeroBiasMonitorCluster, which is running in pathALCARECOSiStripCalZeroBias right after LargeSiStripClusterEvents.
The reason for empty plots is that an otherwise the same setup can have this module running when needed or not running at all by simply rerunning cmsRun with the same config.

The most direct reason for SiStripCalZeroBiasMonitorCluster to be on/off is that LargeSiStripClusterEvents filter can be on or off (while other modules preceding in the path appear to give consistently reproducible results).

I was not able to get a setup that leads to a reproducible bad behavior to be able to confirm from first principles where the problem is.
The only meaningful reason that I could see for this behavior was in this duality of the data layout in SingleMultiplicity class.
Note that the problem did not show up at noticeable level until December 9 2016,
even though the relevant change in the member data layout happened in 2014 in #3094.
Most likely the appearance of the issue is related to #16821 merged Dec 5.

The evidence of a fix to the problem is based on rerunning [extended] short matrix several times and on different machines to have better sampling using CMSSW_9_3_0_pre3 as the baseline. 
- the baseline setup has workflows with differences corresponding to SiStripCalZeroBiasMonitorCluster going off
- the baseline+this PR has no workflows with differences corresponding to SiStripCalZeroBiasMonitorCluster going off
- comparisons of baseline with "baseline+thisPR" show workflows where the baseline histograms are empty (SiStripCalZeroBiasMonitorCluster is off) while they are filled in "baseline+thisPR", which is the expected behavior of the fix.


A better solution is to properly decouple classes defined in DPGAnalysis/SiStripTools/interface/Multiplicities.h to be data formats and update the logic of ByMultiplicityEventFilter.
This will also remove the self-aware data product violation  mentioned already in https://github.com/cms-sw/cmssw/pull/16821#issuecomment-263988601
