### PR TITLE
Updated muon mc classifier

### DIFF
--- a/MuonAnalysis/MuonAssociators/plugins/MuonMCClassifier.cc
+++ b/MuonAnalysis/MuonAssociators/plugins/MuonMCClassifier.cc
@@ -70,10 +70,10 @@
 class MuonMCClassifier : public edm::EDProducer {
     public:
         explicit MuonMCClassifier(const edm::ParameterSet&);
-        ~MuonMCClassifier();
+        ~MuonMCClassifier() override;
 
     private:
-        virtual void produce(edm::Event&, const edm::EventSetup&) override;
+        void produce(edm::Event&, const edm::EventSetup&) override;
         /// The RECO objects
         edm::EDGetTokenT<edm::View<reco::Muon> > muonsToken_;
 

--- a/MuonAnalysis/MuonAssociators/plugins/MuonMCClassifier.cc
+++ b/MuonAnalysis/MuonAssociators/plugins/MuonMCClassifier.cc
@@ -7,7 +7,7 @@
 
 
  CLASSIFICATION: For each RECO Muon, match to SIM particle, and then:
-  - If the SIM is not a Muon, label as Punchthrough (1)
+  - If the SIM is not a Muon, label as Punchthrough (1) except if it is an electron or positron (11)
   - If the SIM is a Muon, then look at it's provenance.
      A) the SIM muon is also a GEN muon, whose parent is NOT A HADRON AND NOT A TAU
         -> classify as "primary" (4).
@@ -26,9 +26,9 @@
 
 */
 //
-// Original Author:  Nov 16 16:12 (lxplus231.cern.ch)
+// Original Author:  G.Petrucciani and G.Abbiendi
 //         Created:  Sun Nov 16 16:14:09 CET 2008
-//
+//         revised:  3/Aug/2017
 //
 
 
@@ -54,6 +54,7 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
 
 #include "SimDataFormats/Associations/interface/MuonToTrackingParticleAssociator.h"
 #include "SimTracker/Records/interface/TrackAssociatorRecord.h"
@@ -88,7 +89,8 @@ class MuonMCClassifier : public edm::EDProducer {
         edm::EDGetTokenT<TrackingParticleCollection> trackingParticlesToken_;
 
         /// The Associations
-        std::string associatorLabel_;
+        edm::InputTag associatorLabel_;
+        edm::EDGetTokenT<reco::MuonToTrackingParticleAssociator> muAssocToken_;
 
         /// Cylinder to use to decide if a decay is early or late
         double decayRho_, decayAbsZ_;
@@ -125,22 +127,25 @@ class MuonMCClassifier : public edm::EDProducer {
                            const edm::Handle<reco::GenParticleCollection> & genParticles) const ;
 };
 
+
 MuonMCClassifier::MuonMCClassifier(const edm::ParameterSet &iConfig) :
     muonsToken_(consumes<edm::View<reco::Muon> >(iConfig.getParameter<edm::InputTag>("muons"))),
     hasMuonCut_(iConfig.existsAs<std::string>("muonPreselection")),
     muonCut_(hasMuonCut_ ? iConfig.getParameter<std::string>("muonPreselection") : ""),
     trackingParticlesToken_(consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("trackingParticles"))),
-    associatorLabel_(iConfig.getParameter< std::string >("associatorLabel")),
+    muAssocToken_(consumes<reco::MuonToTrackingParticleAssociator>(iConfig.getParameter<edm::InputTag>("associatorLabel"))),
     decayRho_(iConfig.getParameter<double>("decayRho")),
     decayAbsZ_(iConfig.getParameter<double>("decayAbsZ")),
     linkToGenParticles_(iConfig.getParameter<bool>("linkToGenParticles")),
     genParticles_(linkToGenParticles_ ? iConfig.getParameter<edm::InputTag>("genParticles") : edm::InputTag("NONE"))
+
 {
     std::string trackType = iConfig.getParameter< std::string >("trackType");
     if (trackType == "inner") trackType_ = reco::InnerTk;
     else if (trackType == "outer") trackType_ = reco::OuterTk;
     else if (trackType == "global") trackType_ = reco::GlobalTk;
     else if (trackType == "segments") trackType_ = reco::Segments;
+    else if (trackType == "glb_or_trk") trackType_ = reco::GlbOrTrk;
     else throw cms::Exception("Configuration") << "Track type '" << trackType << "' not supported.\n";
     if (linkToGenParticles_) {
       genParticlesToken_ = consumes<reco::GenParticleCollection>(genParticles_);
@@ -150,6 +155,7 @@ MuonMCClassifier::MuonMCClassifier(const edm::ParameterSet &iConfig) :
     produces<edm::ValueMap<int> >("ext");
     produces<edm::ValueMap<int> >("flav");
     produces<edm::ValueMap<int> >("hitsPdgId");
+    produces<edm::ValueMap<int> >("G4processType"); // Geant process producing the particle
     produces<edm::ValueMap<int> >("momPdgId");
     produces<edm::ValueMap<int> >("momFlav");
     produces<edm::ValueMap<int> >("momStatus");
@@ -157,6 +163,12 @@ MuonMCClassifier::MuonMCClassifier(const edm::ParameterSet &iConfig) :
     produces<edm::ValueMap<int> >("gmomFlav");
     produces<edm::ValueMap<int> >("hmomFlav"); // heaviest mother flavour
     produces<edm::ValueMap<int> >("tpId");
+    produces<edm::ValueMap<int> >("tpEv");
+    produces<edm::ValueMap<int> >("tpBx");    
+    produces<edm::ValueMap<float> >("signp");
+    produces<edm::ValueMap<float> >("pt");
+    produces<edm::ValueMap<float> >("eta");
+    produces<edm::ValueMap<float> >("phi");
     produces<edm::ValueMap<float> >("prodRho");
     produces<edm::ValueMap<float> >("prodZ");
     produces<edm::ValueMap<float> >("momRho");
@@ -176,8 +188,6 @@ MuonMCClassifier::~MuonMCClassifier()
 void
 MuonMCClassifier::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-    edm::LogVerbatim("MuonMCClassifier") <<"\n sono in MuonMCClassifier !";
-
     edm::Handle<edm::View<reco::Muon> > muons;
     iEvent.getByToken(muonsToken_, muons);
 
@@ -190,7 +200,7 @@ MuonMCClassifier::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     }
 
     edm::Handle<reco::MuonToTrackingParticleAssociator> associatorBase;
-    iEvent.getByLabel(associatorLabel_, associatorBase);
+    iEvent.getByToken(muAssocToken_, associatorBase);
     const reco::MuonToTrackingParticleAssociator * assoByHits = associatorBase.product();
 
     reco::MuonToSimCollection recSimColl;
@@ -240,9 +250,10 @@ MuonMCClassifier::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     edm::LogVerbatim("MuonMCClassifier") <<"\n There are "<<nmu<<" reco::Muons.";
 
     std::vector<int> classif(nmu, 0), ext(nmu, 0);
-    std::vector<int> hitsPdgId(nmu, 0), momPdgId(nmu, 0), gmomPdgId(nmu, 0), momStatus(nmu, 0);
-    std::vector<int> flav(nmu, 0),      momFlav(nmu, 0),  gmomFlav(nmu, 0), hmomFlav(nmu, 0);
-    std::vector<int> tpId(nmu, -1);
+    std::vector<int> hitsPdgId(nmu, 0), G4processType(nmu, 0), momPdgId(nmu, 0), gmomPdgId(nmu, 0), momStatus(nmu, 0);
+    std::vector<int> flav(nmu, 0), momFlav(nmu, 0), gmomFlav(nmu, 0), hmomFlav(nmu, 0);
+    std::vector<int> tpId(nmu, -1), tpBx(nmu, 999), tpEv(nmu, 999);
+    std::vector<float> signp(nmu, 0.0), pt(nmu, 0.0), eta(nmu, -99.), phi(nmu, -99.);
     std::vector<float> prodRho(nmu, 0.0), prodZ(nmu, 0.0), momRho(nmu, 0.0), momZ(nmu, 0.0);
     std::vector<float> tpAssoQuality(nmu, -1);
 
@@ -251,20 +262,20 @@ MuonMCClassifier::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     std::vector<int> muToPrimary(nmu, -1), muToSecondary(nmu, -1); // map from input into (index) in output, -1 for null
     if (linkToGenParticles_) secondaries.reset(new reco::GenParticleCollection());
 
-    for(size_t i = 0; i < nmu; ++i) {
-        edm::LogVerbatim("MuonMCClassifier") <<"\n reco::Muons # "<<i;
+    // loop on reco muons
+    for(size_t i = 0; i < nmu; ++i) {    
         edm::RefToBase<reco::Muon> mu = muons->refAt(i);
         if (hasMuonCut_ && (std::find(selMuons.begin(), selMuons.end(), mu) == selMuons.end()) ) {
-            edm::LogVerbatim("MuonMCClassifier") <<"\t muon didn't pass the selection. classified as -99 and skipped";
+	  LogTrace("MuonMCClassifier") <<"\n reco::Muon # "<<i<<"didn't pass the selection. classified as -99 and skipped";
             classif[i] = -99; continue;
-        }
+        } 
+	else edm::LogVerbatim("MuonMCClassifier") <<"\n reco::Muon # "<<i;
 
         TrackingParticleRef        tp;
         edm::RefToBase<reco::Muon> muMatchBack;
         r2s_it match = recSimColl.find(mu);
         s2r_it matchback;
         if (match != recSimColl.end()) {
-            edm::LogVerbatim("MuonMCClassifier") <<"\t RtS matched Ok...";
             // match->second is vector, front is first element, first is the ref (second would be the quality)
             tp = match->second.front().first;
             tpId[i]          = tp.isNonnull() ? tp.key() : -1; // we check, even if null refs should not appear here at all
@@ -280,7 +291,6 @@ MuonMCClassifier::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
             // perform a second attempt, matching with the standalone muon
             r2s_it matchSta = UpdSTA_recSimColl.find(mu);
             if (matchSta != UpdSTA_recSimColl.end()) {
-                edm::LogVerbatim("MuonMCClassifier") <<"\t RtS matched Ok... from the UpdSTA_recSimColl ";
                 tp    = matchSta->second.front().first;
                 tpId[i]          = tp.isNonnull() ? tp.key() : -1; // we check, even if null refs should not appear here at all
                 tpAssoQuality[i] = matchSta->second.front().second;
@@ -291,61 +301,132 @@ MuonMCClassifier::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
                     edm::LogWarning("MuonMCClassifier") << "\n***WARNING:  This I do NOT understand: why no match back in UpdSTA? *** \n";
                 }
             }
-        }
+        } else {
+            edm::LogVerbatim("MuonMCClassifier") <<"\t No matching TrackingParticle is found ";
+	}
+
         if (tp.isNonnull()) {
             bool isGhost = muMatchBack != mu;
-            if (isGhost) edm::LogVerbatim("MuonMCClassifier") <<"\t This seems a GHOST ! classif[i] will be < 0";
+            if (isGhost) edm::LogVerbatim("MuonMCClassifier") <<"\t *** This seems a Duplicate muon ! classif[i] will be < 0 ***";
+
+	    // identify signal and pileup TP
+	    tpBx[i]      = tp->eventId().bunchCrossing();
+	    tpEv[i]      = tp->eventId().event();
 
             hitsPdgId[i] = tp->pdgId();
             prodRho[i]   = tp->vertex().Rho();
             prodZ[i]     = tp->vertex().Z();
-	    edm::LogVerbatim("MuonMCClassifier") <<"\t TP pdgId = "<<hitsPdgId[i] << ", vertex rho = " << prodRho[i] << ", z = " << prodZ[i];
+
+	    // added info on GEANT process producing the TrackingParticle
+	    std::vector<SimVertex> G4Vs = tp->parentVertex()->g4Vertices();
+	    G4processType[i] = G4Vs[0].processType();
+
+	    signp[i] = tp->charge() * tp->p();
+	    pt[i]    = tp->pt();
+	    eta[i]   = tp->eta();
+	    phi[i]   = tp->phi();
 
             // Try to extract mother and grand mother of this muon.
             // Unfortunately, SIM and GEN histories require diffent code :-(
             if (!tp->genParticles().empty()) { // Muon is in GEN
-                reco::GenParticleRef genp   = tp->genParticles()[0];
-                reco::GenParticleRef genMom = genp->numberOfMothers() > 0 ? genp->motherRef() : reco::GenParticleRef();
-                if (genMom.isNonnull()) {
-                    momPdgId[i]  = genMom->pdgId();
-                    momStatus[i] = genMom->status();
-                    momRho[i] = genMom->vertex().Rho(); momZ[i] = genMom->vz();
-                    edm::LogVerbatim("MuonMCClassifier") << "\t Particle pdgId = "<<hitsPdgId[i] << " produced at rho = " << prodRho[i] << ", z = " << prodZ[i] << ", has GEN mother pdgId = " << momPdgId[i];
-                    reco::GenParticleRef genGMom = genMom->numberOfMothers() > 0 ? genMom->motherRef() : reco::GenParticleRef();
-                    if (genGMom.isNonnull()) {
-                        gmomPdgId[i] = genGMom->pdgId();
-                        edm::LogVerbatim("MuonMCClassifier") << "\t\t mother prod. vertex rho = " << momRho[i] << ", z = " << momZ[i] << ", grand-mom pdgId = " << gmomPdgId[i];
-                    }
-                    // in this case, we might want to know the heaviest mom flavour
-                    for (reco::GenParticleRef nMom = genMom;
-                         nMom.isNonnull() && std::abs(nMom->pdgId()) >= 100; // stop when we're no longer looking at hadrons or mesons
-                         nMom = nMom->numberOfMothers() > 0 ? nMom->motherRef() : reco::GenParticleRef()) {
-                        int flav = flavour(nMom->pdgId());
-                        if (hmomFlav[i] < flav) hmomFlav[i] = flav;
-                        edm::LogVerbatim("MuonMCClassifier") << "\t\t backtracking flavour: mom pdgId = "<<nMom->pdgId()<< ", flavour = " << flav << ", heaviest so far = " << hmomFlav[i];
-                    }
-                }
+	      reco::GenParticleRef genp   = tp->genParticles()[0];
+	      reco::GenParticleRef genMom = genp->numberOfMothers() > 0 ? genp->motherRef() : reco::GenParticleRef();
+	      reco::GenParticleRef mMom = genMom;
+	      
+	      if (genMom.isNonnull()) {
+		if (genMom->pdgId() != tp->pdgId()) {
+		  momPdgId[i]  = genMom->pdgId();
+		  momStatus[i] = genMom->status();
+		  momRho[i] = genMom->vertex().Rho(); 
+		  momZ[i] = genMom->vz();
+		}
+		else {
+		  // if mother has the same identity look backwards for the real mother (it may happen in radiative decays) 
+		  int jm = 0;
+		  while (mMom->pdgId() == tp->pdgId()) {
+		    jm++;
+
+		    if (mMom->numberOfMothers() > 0) {
+		      mMom = mMom->motherRef();
+		    }
+		    LogTrace("MuonMCClassifier") 
+		      << "\t\t backtracking mother "<<jm<<", pdgId = "<<mMom->pdgId()<<", status= " <<mMom->status();
+		  }
+		  genMom = mMom; // redefine genMom
+		  momPdgId[i]  = genMom->pdgId();
+		  momStatus[i] = genMom->status();
+		  momRho[i] = genMom->vertex().Rho(); 
+		  momZ[i] = genMom->vz();
+		}
+		edm::LogVerbatim("MuonMCClassifier") 
+		  << "\t Particle pdgId = "<<hitsPdgId[i] << ", (Event,Bx) = "<< "(" <<tpEv[i]<<","<<tpBx[i]<<")"
+		  <<"\n\t   q*p = "<<signp[i]<<", pT = "<<pt[i]<<", eta = "<<eta[i]<<", phi = "<<phi[i]
+		  << "\n\t   produced at vertex rho = " << prodRho[i] << ", z = " << prodZ[i] 
+		  << ", (GEANT4 process = "<< G4processType[i]<<")"
+		  << "\n\t   has GEN mother pdgId = " << momPdgId[i] << " (status = "<<momStatus[i] << ")";
+		
+		reco::GenParticleRef genGMom = genMom->numberOfMothers() > 0 ? genMom->motherRef() : reco::GenParticleRef();
+	      
+		if (genGMom.isNonnull()) {
+		  gmomPdgId[i] = genGMom->pdgId();
+		  edm::LogVerbatim("MuonMCClassifier") << "\t\t mother prod. vertex rho = " << momRho[i] << ", z = " << momZ[i] 
+						       << ", grand-mom pdgId = " << gmomPdgId[i];
+		}
+		// in this case, we might want to know the heaviest mom flavour
+		for (reco::GenParticleRef nMom = genMom;
+                     nMom.isNonnull() && std::abs(nMom->pdgId()) >= 100; // stop when we're no longer looking at hadrons or mesons
+		     nMom = nMom->numberOfMothers() > 0 ? nMom->motherRef() : reco::GenParticleRef()) {
+		  int flav = flavour(nMom->pdgId());
+		  if (hmomFlav[i] < flav) hmomFlav[i] = flav;
+		  edm::LogVerbatim("MuonMCClassifier") 
+		    << "\t\t backtracking flavour: mom pdgId = "<<nMom->pdgId()
+		    << ", flavour = " << flav << ", heaviest so far = " << hmomFlav[i];
+		}
+	      }    //      if (genMom.isNonnull())
+
+	      else {   // mother is null ??
+		edm::LogWarning("MuonMCClassifier") 
+		  << "\t GenParticle with pdgId = "<<hitsPdgId[i] << ", (Event,Bx) = "<< "(" <<tpEv[i]<<","<<tpBx[i]<<")"
+		  <<"\n\t   q*p = "<<signp[i]<<", pT = "<<pt[i]<<", eta = "<<eta[i]<<", phi = "<<phi[i]
+		  << "\n\t   produced at vertex rho = " << prodRho[i] << ", z = " << prodZ[i] 
+		  << ", (GEANT4 process = "<< G4processType[i]<<")"
+		  <<"\n\t   has NO mother!";
+	      }
+	      
             } else { // Muon is in SIM Only
                 TrackingParticleRef simMom = getTpMother(tp);
                 if (simMom.isNonnull()) {
                     momPdgId[i] = simMom->pdgId();
                     momRho[i] = simMom->vertex().Rho();
                     momZ[i]   = simMom->vertex().Z();
-                    edm::LogVerbatim("MuonMCClassifier") << "\t Particle pdgId = "<<hitsPdgId[i] << " produced at rho = " << prodRho[i] << ", z = " << prodZ[i] <<
-                                                            ", has SIM mother pdgId = " << momPdgId[i] << " produced at rho = " << simMom->vertex().Rho() << ", z = " << simMom->vertex().Z();
+                    edm::LogVerbatim("MuonMCClassifier") 
+		      << "\t Particle pdgId = "<<hitsPdgId[i] << ", (Event,Bx) = "<< "(" <<tpEv[i]<<","<<tpBx[i]<<")"
+		      <<"\n\t   q*p = "<<signp[i]<<", pT = "<<pt[i]<<", eta = "<<eta[i]<<", phi = "<<phi[i]
+		      << "\n\t   produced at vertex rho = " << prodRho[i] << ", z = " << prodZ[i] 
+		      << ", (GEANT4 process = "<< G4processType[i]<<")"
+		      <<"\n\t   has SIM mother pdgId = " << momPdgId[i] 
+		      << " produced at rho = " << simMom->vertex().Rho() << ", z = " << simMom->vertex().Z();
+
                     if (!simMom->genParticles().empty()) {
-                        momStatus[i] = simMom->genParticles()[0]->status();
-                        reco::GenParticleRef genGMom = (simMom->genParticles()[0]->numberOfMothers() > 0 ? simMom->genParticles()[0]->motherRef() : reco::GenParticleRef());
-                        if (genGMom.isNonnull()) gmomPdgId[i] = genGMom->pdgId();
-                        edm::LogVerbatim("MuonMCClassifier") << "\t\t SIM mother is in GEN (status " << momStatus[i] << "), grand-mom id = " << gmomPdgId[i];
-                    } else {
-                        momStatus[i] = -1;
-                        TrackingParticleRef simGMom = getTpMother(simMom);
-                        if (simGMom.isNonnull()) gmomPdgId[i] = simGMom->pdgId();
-                        edm::LogVerbatim("MuonMCClassifier") << "\t\t SIM mother is in SIM only, grand-mom id = " << gmomPdgId[i];
+		      momStatus[i] = simMom->genParticles()[0]->status();
+		      reco::GenParticleRef genGMom = (simMom->genParticles()[0]->numberOfMothers() > 0 ? simMom->genParticles()[0]->motherRef() : reco::GenParticleRef());
+		      if (genGMom.isNonnull()) gmomPdgId[i] = genGMom->pdgId();
+		      edm::LogVerbatim("MuonMCClassifier") 
+			<< "\t\t SIM mother is in GEN (status " << momStatus[i] << "), grand-mom id = " << gmomPdgId[i];
+                    } 
+		    else {
+		      momStatus[i] = -1;
+		      TrackingParticleRef simGMom = getTpMother(simMom);
+		      if (simGMom.isNonnull()) gmomPdgId[i] = simGMom->pdgId();
+		      edm::LogVerbatim("MuonMCClassifier") << "\t\t SIM mother is in SIM only, grand-mom id = " << gmomPdgId[i];
                     }
                 } else {
-                  edm::LogVerbatim("MuonMCClassifier") << "\t Particle pdgId = "<<hitsPdgId[i] << " produced at rho = " << prodRho[i] << ", z = " << prodZ[i] << ", has NO mother!";
+                  edm::LogVerbatim("MuonMCClassifier") 
+		      << "\t Particle pdgId = "<<hitsPdgId[i] << ", (Event,Bx) = "<< "(" <<tpEv[i]<<","<<tpBx[i]<<")"
+		      <<"\n\t   q*p = "<<signp[i]<<", pT = "<<pt[i]<<", eta = "<<eta[i]<<", phi = "<<phi[i]
+		      << "\n\t   produced at vertex rho = " << prodRho[i] << ", z = " << prodZ[i] 
+		      << ", (GEANT4 process = "<< G4processType[i]<<")"
+		      <<"\n\t   has NO mother!";
                 }
             }
             momFlav[i]  = flavour(momPdgId[i]);
@@ -353,25 +434,33 @@ MuonMCClassifier::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
             // Check first IF this is a muon at all
             if (abs(tp->pdgId()) != 13) {
+	      if (abs(tp->pdgId()) == 11) {
+                classif[i] = isGhost ? -11 : 11;
+                ext[i]     = isGhost ? -11 : 11;
+                edm::LogVerbatim("MuonMCClassifier") <<"\t This is electron/positron. classif[i] = " << classif[i];
+	      }
+	      else {
                 classif[i] = isGhost ? -1 : 1;
                 ext[i]     = isGhost ? -1 : 1;
                 edm::LogVerbatim("MuonMCClassifier") <<"\t This is not a muon. Sorry. classif[i] = " << classif[i];
-                continue;
+	      }
+
+	      continue;
             }
 
             // Is this SIM muon also a GEN muon, with a mother?
             if (!tp->genParticles().empty() && (momPdgId[i] != 0)) {
                 if (abs(momPdgId[i]) < 100 && (abs(momPdgId[i]) != 15)) {
                     classif[i] = isGhost ? -4 : 4;
-                    flav[i] = (abs(momPdgId[i]) == 15 ? 15 : 13);
+		    flav[i] = 13;
+                    ext[i]  = 10;
                     edm::LogVerbatim("MuonMCClassifier") <<"\t This seems PRIMARY MUON ! classif[i] = " << classif[i];
-                    ext[i] = 10;
                 } else if (momFlav[i] == 4 || momFlav[i] == 5 || momFlav[i] == 15) {
                     classif[i] = isGhost ? -3 : 3;
                     flav[i]    = momFlav[i];
                     if (momFlav[i] == 15)      ext[i] = 9; // tau->mu
                     else if (momFlav[i] == 5)  ext[i] = 8; // b->mu
-                    else if (hmomFlav[i] == 5) ext[i] = 7; // b->c->mu
+                    else if (hmomFlav[i] == 5) ext[i] = 7; // b->c->mu or b->tau->mu
                     else                       ext[i] = 6; // c->mu
                     edm::LogVerbatim("MuonMCClassifier") <<"\t This seems HEAVY FLAVOUR ! classif[i] = " << classif[i];
                 } else {
@@ -412,20 +501,27 @@ MuonMCClassifier::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
                 }
             }
             edm::LogVerbatim("MuonMCClassifier") <<"\t Extended classification code = " << ext[i];
-	}
-    }
+	}  // if (tp.isNonnull())
+    } // end loop on reco muons 
 
     writeValueMap(iEvent, muons, classif,   "");
     writeValueMap(iEvent, muons, ext,       "ext");
     writeValueMap(iEvent, muons, flav,      "flav");
     writeValueMap(iEvent, muons, tpId,      "tpId");
+    writeValueMap(iEvent, muons, tpBx,      "tpBx");
+    writeValueMap(iEvent, muons, tpEv,      "tpEv");
     writeValueMap(iEvent, muons, hitsPdgId, "hitsPdgId");
+    writeValueMap(iEvent, muons, G4processType, "G4processType");
     writeValueMap(iEvent, muons, momPdgId,  "momPdgId");
     writeValueMap(iEvent, muons, momStatus, "momStatus");
     writeValueMap(iEvent, muons, momFlav,   "momFlav");
     writeValueMap(iEvent, muons, gmomPdgId, "gmomPdgId");
     writeValueMap(iEvent, muons, gmomFlav,  "gmomFlav");
     writeValueMap(iEvent, muons, hmomFlav,  "hmomFlav");
+    writeValueMap(iEvent, muons, signp,     "signp");
+    writeValueMap(iEvent, muons, pt,        "pt");
+    writeValueMap(iEvent, muons, eta,       "eta");
+    writeValueMap(iEvent, muons, phi,       "phi");
     writeValueMap(iEvent, muons, prodRho,   "prodRho");
     writeValueMap(iEvent, muons, prodZ,     "prodZ");
     writeValueMap(iEvent, muons, momRho,    "momRho");
@@ -445,12 +541,13 @@ MuonMCClassifier::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         iEvent.put(std::move(outPri), "toPrimaries");
         iEvent.put(std::move(outSec), "toSecondaries");
     }
+
 }
 
 template<typename T>
 void
 MuonMCClassifier::writeValueMap(edm::Event &iEvent,
-        const edm::Handle<edm::View<reco::Muon> > & handle,
+	const edm::Handle<edm::View<reco::Muon> > & handle,
         const std::vector<T> & values,
         const std::string    & label) const
 {

--- a/MuonAnalysis/MuonAssociators/plugins/MuonMCClassifier.cc
+++ b/MuonAnalysis/MuonAssociators/plugins/MuonMCClassifier.cc
@@ -318,7 +318,7 @@ MuonMCClassifier::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
             prodZ[i]     = tp->vertex().Z();
 
 	    // added info on GEANT process producing the TrackingParticle
-	    std::vector<SimVertex> G4Vs = tp->parentVertex()->g4Vertices();
+	    const std::vector<SimVertex> & G4Vs = tp->parentVertex()->g4Vertices();
 	    G4processType[i] = G4Vs[0].processType();
 
 	    signp[i] = tp->charge() * tp->p();

--- a/MuonAnalysis/MuonAssociators/python/muonClassificationByHitsTP_cfi.py
+++ b/MuonAnalysis/MuonAssociators/python/muonClassificationByHitsTP_cfi.py
@@ -1,31 +1,13 @@
 ### Add MC classification by hits
-
-from SimGeneral.MixingModule.mixNoPU_cfi import *
-
-trackingParticlesNoSimHits = mix.clone(
-    digitizers = cms.PSet(
-        mergedtruth = theDigitizersValid.mergedtruth.clone(
-            simHitCollections = cms.PSet(
-                pixel = cms.VInputTag(),
-                tracker = cms.VInputTag(),
-                muon = cms.VInputTag(),
-            )
-        ),
-    ),
-    mixObjects = cms.PSet(
-        mixHepMC    = mix.mixObjects.mixHepMC.clone(),
-        mixVertices = mix.mixObjects.mixVertices.clone(),
-        mixTracks   = mix.mixObjects.mixTracks.clone(),
-    ),
-)
-
+### Note: this cfi needs TrackingParticle collection from the Event
+ 
 from SimMuon.MCTruth.muonAssociatorByHitsNoSimHitsHelper_cfi import * 
 
 classByHitsTM = cms.EDProducer("MuonMCClassifier",
     muons = cms.InputTag("muons"),
     muonPreselection = cms.string("muonID('TrackerMuonArbitrated')"), # definition of "duplicates" depends on the preselection
     trackType = cms.string("segments"),  # 'inner','outer','global','segments','glb_or_trk'
-    trackingParticles = cms.InputTag("trackingParticlesNoSimHits","MergedTrackTruth"),         
+    trackingParticles = cms.InputTag("mix","MergedTrackTruth"), # default TrackingParticle collection (should exist in the Event)      
     associatorLabel   = cms.InputTag("muonAssociatorByHitsNoSimHitsHelper"),
     decayRho  = cms.double(200), # to classify differently decay muons included in ppMuX
     decayAbsZ = cms.double(400), # and decay muons that could not be in ppMuX
@@ -50,7 +32,6 @@ classByHitsGlbOrTrk = classByHitsTM.clone(
 
 
 muonClassificationByHits = cms.Sequence(
-    trackingParticlesNoSimHits +
     muonAssociatorByHitsNoSimHitsHelper +
     ( 
 #      classByHitsTM      +

--- a/MuonAnalysis/MuonAssociators/python/patMuonsWithTrigger_cff.py
+++ b/MuonAnalysis/MuonAssociators/python/patMuonsWithTrigger_cff.py
@@ -1,12 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
-##    __  __       _          ____   _  _____   __  __                       
-##   |  \/  | __ _| | _____  |  _ \ / \|_   _| |  \/  |_   _  ___  _ __  ___ 
+##    __  __       _          ____   _  _____   __  __
+##   |  \/  | __ _| | _____  |  _ \ / \|_   _| |  \/  |_   _  ___  _ __  ___
 ##   | |\/| |/ _` | |/ / _ \ | |_) / _ \ | |   | |\/| | | | |/ _ \| '_ \/ __|
 ##   | |  | | (_| |   <  __/ |  __/ ___ \| |   | |  | | |_| | (_) | | | \__ \
 ##   |_|  |_|\__,_|_|\_\___| |_| /_/   \_\_|   |_|  |_|\__,_|\___/|_| |_|___/
-##                                                                           
-##   
+##
+##
 ### ==== Make PAT Muons ====
 import PhysicsTools.PatAlgos.producersLayer1.muonProducer_cfi
 patMuonsWithoutTrigger = PhysicsTools.PatAlgos.producersLayer1.muonProducer_cfi.patMuons.clone(
@@ -22,7 +22,7 @@ patMuonsWithoutTrigger = PhysicsTools.PatAlgos.producersLayer1.muonProducer_cfi.
     # then switch off some features we don't need
     #addTeVRefits = False, ## <<--- this doesn't work. PAT bug ??
     embedPickyMuon = False,
-    embedTpfmsMuon = False, 
+    embedTpfmsMuon = False,
     userIsolation = cms.PSet(),   # no extra isolation beyond what's in reco::Muon itself
     isoDeposits = cms.PSet(), # no heavy isodeposits
     addGenMatch = False,       # no mc: T&P doesn't take it from here anyway.
@@ -33,13 +33,13 @@ patMuonsWithoutTrigger.userData.userFloats.src  = []
 patMuonsWithoutTrigger.userData.userCands.src   = []
 patMuonsWithoutTrigger.userData.userClasses.src = []
 
-##    __  __       _       _       ____      ___        __  _     _ 
+##    __  __       _       _       ____      ___        __  _     _
 ##   |  \/  | __ _| |_ ___| |__   |  _ \    / \ \      / / | |   / |
 ##   | |\/| |/ _` | __/ __| '_ \  | |_) |  / _ \ \ /\ / /  | |   | |
 ##   | |  | | (_| | || (__| | | | |  _ <  / ___ \ V  V /   | |___| |
 ##   |_|  |_|\__,_|\__\___|_| |_| |_| \_\/_/   \_\_/\_/    |_____|_|
-##                                                                  
-##   
+##
+##
 from MuonAnalysis.MuonAssociators.muonL1Match_cfi import muonL1Match as muonL1Info
 
 ## Define a generic function, so that it can be used with existing PAT Muons
@@ -48,13 +48,13 @@ def addL1UserData(patMuonProducer, l1ModuleLabel = "muonL1Info"):
     patMuonProducer.userData.userInts.src += [
         cms.InputTag(l1ModuleLabel, "quality"), # will be -999 in case of no match
     ]
-    patMuonProducer.userData.userFloats.src += [  
+    patMuonProducer.userData.userFloats.src += [
         cms.InputTag(l1ModuleLabel, "deltaR"),  # will be 999 in case of no match
     ]
-    patMuonProducer.userData.userFloats.src += [  
+    patMuonProducer.userData.userFloats.src += [
         cms.InputTag(l1ModuleLabel, "deltaPhi"),  # will be 999 in case of no match
     ]
-    patMuonProducer.userData.userInts.src += [  
+    patMuonProducer.userData.userInts.src += [
         cms.InputTag(l1ModuleLabel, "bx"),  # will be -999 in case of no match
     ]
     patMuonProducer.userData.userCands.src += [
@@ -64,25 +64,25 @@ def addL1UserData(patMuonProducer, l1ModuleLabel = "muonL1Info"):
 ## Do it for this collection of pat Muons
 addL1UserData(patMuonsWithoutTrigger, "muonL1Info")
 
-##    __  __       _       _       _   _ _   _____ 
+##    __  __       _       _       _   _ _   _____
 ##   |  \/  | __ _| |_ ___| |__   | | | | | |_   _|
-##   | |\/| |/ _` | __/ __| '_ \  | |_| | |   | |  
-##   | |  | | (_| | || (__| | | | |  _  | |___| |  
-##   |_|  |_|\__,_|\__\___|_| |_| |_| |_|_____|_|  
-##                                                 
-##   
+##   | |\/| |/ _` | __/ __| '_ \  | |_| | |   | |
+##   | |  | | (_| | || (__| | | | |  _  | |___| |
+##   |_|  |_|\__,_|\__\___|_| |_| |_| |_|_____|_|
+##
+##
 
 ### ==== Unpack trigger, and match ====
 from PhysicsTools.PatAlgos.triggerLayer1.triggerProducer_cfi import patTrigger as patTriggerFull
 patTriggerFull.onlyStandAlone = True
 patTrigger = cms.EDProducer("TriggerObjectFilterByCollection",
     src = cms.InputTag("patTriggerFull"),
-    collections = cms.vstring("hltL1extraParticles", "hltGmtStage2Digis", "hltL2MuonCandidates", "hltL3MuonCandidates", "hltHighPtTkMuonCands", "hltGlbTrkMuonCands", "hltMuTrackJpsiCtfTrackCands", "hltMuTrackJpsiEffCtfTrackCands", "hltMuTkMuJpsiTrackerMuonCands","hltTracksIter"),
+    collections = cms.vstring("hltL1extraParticles", "hltGmtStage2Digis", "hltL2MuonCandidates", "hltIterL3MuonCandidates","hltIterL3FromL2MuonCandidates","hltHighPtTkMuonCands", "hltGlbTrkMuonCands", "hltMuTrackJpsiCtfTrackCands", "hltMuTrackJpsiEffCtfTrackCands", "hltMuTkMuJpsiTrackerMuonCands","hltTracksIter"),
 )
 #patTrigger = cms.EDFilter("PATTriggerObjectStandAloneSelector",
 #    src = cms.InputTag("patTriggerFull"),
-#    cut = cms.string('coll("hltL1extraParticles") || coll("hltL2MuonCandidates") || coll("hltL3MuonCandidates") || coll("hltGlbTrkMuonCands") || coll("hltMuTrackJpsiCtfTrackCands") || coll("hltMuTrackJpsiEffCtfTrackCands") || coll("hltMuTkMuJpsiTrackerMuonCands")'),
-#) 
+#    cut = cms.string('coll("hltL1extraParticles") || coll("hltL2MuonCandidates") || coll("hltIterL3MuonCandidates") || coll("hltGlbTrkMuonCands") || coll("hltMuTrackJpsiCtfTrackCands") || coll("hltMuTrackJpsiEffCtfTrackCands") || coll("hltMuTkMuJpsiTrackerMuonCands")'),
+#)
 
 ### ==== Then perform a match for all HLT triggers of interest
 muonTriggerMatchHLT = cms.EDProducer( "PATTriggerMatcherDRDPtLessByR",
@@ -111,19 +111,21 @@ muonMatchL1 = muonHLTL1Match.clone(
 ### Single Mu L1
 muonMatchHLTL1 = muonMatchL1.clone(matchedCuts = cms.string('coll("hltL1extraParticles")'))
 muonMatchHLTL2 = muonTriggerMatchHLT.clone(matchedCuts = cms.string('coll("hltL2MuonCandidates")'), maxDeltaR = 0.3, maxDPtRel = 10.0)  #maxDeltaR Changed accordingly to Zoltan tuning. It was: 1.2
-muonMatchHLTL3 = muonTriggerMatchHLT.clone(matchedCuts = cms.string('coll("hltL3MuonCandidates")'), maxDeltaR = 0.1, maxDPtRel = 10.0)  #maxDeltaR Changed accordingly to Zoltan tuning. It was: 0.5
+muonMatchHLTL3 = muonTriggerMatchHLT.clone(matchedCuts = cms.string('coll("hltIterL3MuonCandidates")'), maxDeltaR = 0.1, maxDPtRel = 10.0)  #maxDeltaR Changed accordingly to Zoltan tuning. It was: 0.5
 muonMatchHLTL3T = muonTriggerMatchHLT.clone(matchedCuts = cms.string('coll("hltGlbTrkMuonCands")'),  maxDeltaR = 0.1, maxDPtRel = 10.0)  #maxDeltaR Changed accordingly to Zoltan tuning. It was: 0.5
+muonMatchHLTL3fromL2 = muonTriggerMatchHLT.clone(matchedCuts = cms.string('coll("hltIterL3FromL2MuonCandidates")'),  maxDeltaR = 0.1, maxDPtRel = 10.0)  #maxDeltaR Changed accordingly to Zoltan tuning. It was: 0.5
 muonMatchHLTTkMu =  muonTriggerMatchHLT.clone(matchedCuts = cms.string('coll("hltHighPtTkMuonCands")'),  maxDeltaR = 0.1, maxDPtRel = 10.0)  #maxDeltaR Changed accordingly to Zoltan tuning. It was: 0.5
-muonMatchHLTCtfTrack  = muonTriggerMatchHLT.clone(matchedCuts = cms.string('coll("hltMuTrackJpsiCtfTrackCands")'),    maxDeltaR = 0.1, maxDPtRel = 10.0)  #maxDeltaR Changed accordingly to Zoltan tuning. 
-muonMatchHLTCtfTrack2 = muonTriggerMatchHLT.clone(matchedCuts = cms.string('coll("hltMuTrackJpsiEffCtfTrackCands")'), maxDeltaR = 0.1, maxDPtRel = 10.0)  #maxDeltaR Changed accordingly to Zoltan tuning. 
-muonMatchHLTTrackMu  = muonTriggerMatchHLT.clone(matchedCuts = cms.string('coll("hltMuTkMuJpsiTrackerMuonCands")'), maxDeltaR = 0.1, maxDPtRel = 10.0) #maxDeltaR Changed accordingly to Zoltan tuning. 
-muonMatchHLTTrackIt  = muonTriggerMatchHLT.clone(matchedCuts = cms.string('coll("hltTracksIter")'), maxDeltaR = 0.1, maxDPtRel = 1.0) #maxDeltaR Changed accordingly to Zoltan tuning. 
+muonMatchHLTCtfTrack  = muonTriggerMatchHLT.clone(matchedCuts = cms.string('coll("hltMuTrackJpsiCtfTrackCands")'),    maxDeltaR = 0.1, maxDPtRel = 10.0)  #maxDeltaR Changed accordingly to Zoltan tuning.
+muonMatchHLTCtfTrack2 = muonTriggerMatchHLT.clone(matchedCuts = cms.string('coll("hltMuTrackJpsiEffCtfTrackCands")'), maxDeltaR = 0.1, maxDPtRel = 10.0)  #maxDeltaR Changed accordingly to Zoltan tuning.
+muonMatchHLTTrackMu  = muonTriggerMatchHLT.clone(matchedCuts = cms.string('coll("hltMuTkMuJpsiTrackerMuonCands")'), maxDeltaR = 0.1, maxDPtRel = 10.0) #maxDeltaR Changed accordingly to Zoltan tuning.
+muonMatchHLTTrackIt  = muonTriggerMatchHLT.clone(matchedCuts = cms.string('coll("hltTracksIter")'), maxDeltaR = 0.1, maxDPtRel = 1.0) #maxDeltaR Changed accordingly to Zoltan tuning.
 
 patTriggerMatchers1Mu = cms.Sequence(
       #muonMatchHLTL1 +   # keep off by default, since it is slow and usually not needed
       muonMatchHLTL2 +
       muonMatchHLTL3 +
       muonMatchHLTL3T +
+      muonMatchHLTL3fromL2 +
       muonMatchHLTTkMu
 )
 patTriggerMatchers1MuInputTags = [
@@ -132,6 +134,7 @@ patTriggerMatchers1MuInputTags = [
     cms.InputTag('muonMatchHLTL2'),
     cms.InputTag('muonMatchHLTL3'),
     cms.InputTag('muonMatchHLTL3T'),
+    cms.InputTag('muonMatchHLTL3fromL2'),
     cms.InputTag('muonMatchHLTTkMu'),
 ]
 
@@ -159,7 +162,7 @@ patMuonsWithTrigger.matches += patTriggerMatchers2MuInputTags
 
 ## ==== Trigger Sequence ====
 patTriggerMatching = cms.Sequence(
-    patTriggerFull * patTrigger * 
+    patTriggerFull * patTrigger *
     patTriggerMatchers1Mu *
     patTriggerMatchers2Mu *
     patMuonsWithTrigger
@@ -178,6 +181,7 @@ def switchOffAmbiguityResolution(process):
     process.muonMatchHLTL1.resolveAmbiguities = False
     process.muonMatchHLTL2.resolveAmbiguities = False
     process.muonMatchHLTL3.resolveAmbiguities = False
+    process.muonMatchHLTL3fromL2.resolveAmbiguities = False
     process.muonMatchHLTTkMu.resolveAmbiguities  = False
     process.muonMatchHLTCtfTrack.resolveAmbiguities = False
     process.muonMatchHLTTrackMu.resolveAmbiguities  = False
@@ -206,7 +210,7 @@ def useExistingPATMuons(process, newPatMuonTag, addL1Info=False):
 def addPreselection(process, cut):
     "Add a preselection cut to the muons before matching (might be relevant, due to ambiguity resolution in trigger matching!"
     process.patMuonsWithoutTriggerUnfiltered = process.patMuonsWithoutTrigger.clone()
-    process.globalReplace('patMuonsWithoutTrigger', cms.EDFilter("PATMuonSelector", src = cms.InputTag('patMuonsWithoutTriggerUnfiltered'), cut = cms.string(cut))) 
+    process.globalReplace('patMuonsWithoutTrigger', cms.EDFilter("PATMuonSelector", src = cms.InputTag('patMuonsWithoutTriggerUnfiltered'), cut = cms.string(cut)))
     process.patMuonsWithTriggerSequence.replace(process.patMuonsWithoutTrigger, process.patMuonsWithoutTriggerUnfiltered * process.patMuonsWithoutTrigger)
 
 def addMCinfo(process):
@@ -237,25 +241,24 @@ def useL1MatchingWindowForSinglets(process):
 
 
 def useL1Stage2Candidates(process):
-    if hasattr(process, 'muonL1Info'): 
-        # l1PhiOffest might need a second look 
+    if hasattr(process, 'muonL1Info'):
+        # l1PhiOffest might need a second look
         # barrel seems not to requre it, whereas encaps do
         # anyhow the effect is of the order of 0.02
-        #process.muonL1Info.l1PhiOffset = cms.double() 
+        #process.muonL1Info.l1PhiOffset = cms.double()
         process.muonL1Info.useMB2InOverlap = cms.bool(True)
         process.muonL1Info.useStage2L1 = cms.bool(True)
         process.muonL1Info.preselection = cms.string("")
         process.muonL1Info.matched = cms.InputTag("gmtStage2Digis:Muon:")
 
 def appendL1MatchingAlgo(process, algo = "quality"):
-    if hasattr(process, 'muonL1Info'): 
-        newMuonL1Info = process.muonL1Info.clone(sortBy = cms.string(algo), 
-                                                         sortByQuality  = cms.bool(algo == "quality"), 
-                                                         sortByDeltaPhi = cms.bool(algo == "deltaEta"), 
-                                                         sortByDeltaEta = cms.bool(algo == "deltaPhi"), 
-                                                         sortByPt       = cms.bool(algo == "pt"), 
+    if hasattr(process, 'muonL1Info'):
+        newMuonL1Info = process.muonL1Info.clone(sortBy = cms.string(algo),
+                                                         sortByQuality  = cms.bool(algo == "quality"),
+                                                         sortByDeltaPhi = cms.bool(algo == "deltaEta"),
+                                                         sortByDeltaEta = cms.bool(algo == "deltaPhi"),
+                                                         sortByPt       = cms.bool(algo == "pt"),
                                                          maxDeltaR  = cms.double(0.3))
         setattr(process, "muonL1Info" + algo.title(), newMuonL1Info)
         process.patMuonsWithTriggerSequence.replace(process.muonL1Info, process.muonL1Info + getattr(process, 'muonL1Info' + algo.title()))
         addL1UserData(patMuonsWithoutTrigger, "muonL1Info" + algo.title())
-

--- a/MuonAnalysis/MuonAssociators/test/MuonMCClassifier/testClassByHitsTP_cfg.py
+++ b/MuonAnalysis/MuonAssociators/test/MuonMCClassifier/testClassByHitsTP_cfg.py
@@ -1,0 +1,150 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.StandardSequences.Eras import eras
+
+process = cms.Process('MuonClassif',eras.Phase2)
+
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('SimGeneral.MixingModule.mix_POISSON_average_cfi')
+
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+
+process.source = cms.Source("PoolSource",
+ fileNames = cms.untracked.vstring(
+'/store/relval/CMSSW_9_1_1/RelValZMM_14/GEN-SIM-RECO/PU25ns_91X_upgrade2023_realistic_v1_D17PU200-v1/10000/003FC7CB-EB3F-E711-92D1-0025905A6076.root'
+ ),
+ secondaryFileNames = cms.untracked.vstring(
+ )
+)
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )    
+
+process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load("Configuration.StandardSequences.Reconstruction_cff")
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
+
+## ==== PAT used to parse the muon selection
+process.load("MuonAnalysis.MuonAssociators.patMuonsWithTrigger_cff")
+from MuonAnalysis.MuonAssociators.patMuonsWithTrigger_cff import *
+
+## ==== Classification by Hits
+process.load("MuonAnalysis.MuonAssociators.muonClassificationByHitsTP_cfi")
+#
+from MuonAnalysis.MuonAssociators.muonClassificationByHitsTP_cfi import addUserData as addClassByHits
+addClassByHits(process.patMuonsWithoutTrigger, extraInfo=True)
+
+# Output definition
+process.MYoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    fileName = cms.untracked.string('ZMMpu25ns-UPG2023_test.root'),
+    splitLevel = cms.untracked.int32(0)
+)
+
+process.MuonClassifier = cms.Path(
+    process.muonClassificationByHits
+)
+
+process.MYoutput_step = cms.EndPath(process.MYoutput)
+
+process.schedule = cms.Schedule(
+   process.MuonClassifier, 
+   process.MYoutput_step
+)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from SimGeneral.MixingModule.fullMixCustomize_cff
+from SimGeneral.MixingModule.fullMixCustomize_cff import setCrossingFrameOn 
+
+#call to customisation function setCrossingFrameOn imported from SimGeneral.MixingModule.fullMixCustomize_cff
+process = setCrossingFrameOn(process)
+
+# End of customisation functions
+#do not add changes to your config after this point (unless you know what you are doing)
+from FWCore.ParameterSet.Utilities import convertToUnscheduled
+process=convertToUnscheduled(process)
+
+# customisation of the process.
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion
+
+######
+process.MessageLogger.categories = cms.untracked.vstring('MuonToTrackingParticleAssociatorEDProducer',
+'MuonToTrackingParticleAssociatorByHits','MuonAssociatorByHitsHelper','MuonToTrackingParticleAssociatorByHitsImpl',
+'TrackerMuonHitExtractor','MuonMCClassifier',
+'FwkJob','FwkReport','FwkSummary','Root_NoDictionary')
+
+process.MessageLogger.cerr = cms.untracked.PSet(
+    noTimeStamps = cms.untracked.bool(True),
+
+    threshold = cms.untracked.string('WARNING'),
+
+    MuonToTrackingParticleAssociatorEDProducer = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    ),
+    MuonToTrackingParticleAssociatorByHits = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    ),
+    MuonToTrackingParticleAssociatorByHitsImpl = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    ),
+    MuonAssociatorByHitsHelper = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    ),
+    TrackerMuonHitExtractor = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    )
+)
+
+process.MessageLogger.cout = cms.untracked.PSet(
+    noTimeStamps = cms.untracked.bool(True),
+    threshold = cms.untracked.string('INFO'),
+
+    default = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    ),
+    MuonToTrackingParticleAssociatorEDProducer = cms.untracked.PSet(
+        limit = cms.untracked.int32(10000000)
+    ),
+    MuonToTrackingParticleAssociatorByHits = cms.untracked.PSet(
+        limit = cms.untracked.int32(10000000)
+    ),
+    MuonToTrackingParticleAssociatorByHitsImpl = cms.untracked.PSet(
+        limit = cms.untracked.int32(10000000)
+    ),
+    MuonAssociatorByHitsHelper = cms.untracked.PSet(
+        limit = cms.untracked.int32(10000000)
+    ),
+    TrackerMuonHitExtractor = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    ),
+    MuonMCClassifier = cms.untracked.PSet(
+        limit = cms.untracked.int32(10000000)
+    ),
+    FwkReport = cms.untracked.PSet(
+        reportEvery = cms.untracked.int32(1),
+        limit = cms.untracked.int32(10000000)
+    ),
+    FwkSummary = cms.untracked.PSet(
+        reportEvery = cms.untracked.int32(1),
+        limit = cms.untracked.int32(10000000)
+    ),
+    FwkJob = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    ),
+    Root_NoDictionary = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    )
+)

--- a/MuonAnalysis/MuonAssociators/test/MuonMCClassifier/testClassByHitsTP_cfg.py
+++ b/MuonAnalysis/MuonAssociators/test/MuonMCClassifier/testClassByHitsTP_cfg.py
@@ -20,7 +20,7 @@ process.source = cms.Source("PoolSource",
  )
 )
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )    
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(5) )    
 
 process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
@@ -40,23 +40,19 @@ process.load("MuonAnalysis.MuonAssociators.muonClassificationByHitsTP_cfi")
 from MuonAnalysis.MuonAssociators.muonClassificationByHitsTP_cfi import addUserData as addClassByHits
 addClassByHits(process.patMuonsWithoutTrigger, extraInfo=True)
 
-# Output definition
-process.MYoutput = cms.OutputModule("PoolOutputModule",
+# test output
+process.output = cms.OutputModule("PoolOutputModule",
     eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
-    fileName = cms.untracked.string('ZMMpu25ns-UPG2023_test.root'),
+    fileName = cms.untracked.string('output_test.root'),
     splitLevel = cms.untracked.int32(0)
 )
 
-process.MuonClassifier = cms.Path(
-    process.muonClassificationByHits
-)
+process.muonClassifier = cms.Path(process.muonClassificationByHits)
 
-process.MYoutput_step = cms.EndPath(process.MYoutput)
+process.output_step = cms.EndPath(process.output)
 
-process.schedule = cms.Schedule(
-   process.MuonClassifier, 
-   process.MYoutput_step
-)
+process.schedule = cms.Schedule(process.muonClassifier)
+
 
 # customisation of the process.
 
@@ -65,20 +61,6 @@ from SimGeneral.MixingModule.fullMixCustomize_cff import setCrossingFrameOn
 
 #call to customisation function setCrossingFrameOn imported from SimGeneral.MixingModule.fullMixCustomize_cff
 process = setCrossingFrameOn(process)
-
-# End of customisation functions
-#do not add changes to your config after this point (unless you know what you are doing)
-from FWCore.ParameterSet.Utilities import convertToUnscheduled
-process=convertToUnscheduled(process)
-
-# customisation of the process.
-
-# Customisation from command line
-
-# Add early deletion of temporary data products to reduce peak memory need
-from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
-process = customiseEarlyDelete(process)
-# End adding early deletion
 
 ######
 process.MessageLogger.categories = cms.untracked.vstring('MuonToTrackingParticleAssociatorEDProducer',

--- a/SimDataFormats/Associations/interface/MuonTrackType.h
+++ b/SimDataFormats/Associations/interface/MuonTrackType.h
@@ -24,7 +24,7 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 
 namespace reco {
-    enum MuonTrackType { InnerTk, OuterTk, GlobalTk, Segments };
+    enum MuonTrackType { InnerTk, OuterTk, GlobalTk, Segments, GlbOrTrk };
 
     struct RefToBaseSort { 
       template<typename T> bool operator()(const edm::RefToBase<T> &r1, const edm::RefToBase<T> &r2) const { 

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.cc
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.cc
@@ -29,8 +29,8 @@
 // constructors and destructor
 //
 MuonToTrackingParticleAssociatorByHitsImpl::MuonToTrackingParticleAssociatorByHitsImpl(TrackerMuonHitExtractor const& iHitExtractor,
-MuonAssociatorByHitsHelper::Resources const& iResources,
-                                                                                             MuonAssociatorByHitsHelper const* iHelper):
+									    MuonAssociatorByHitsHelper::Resources const& iResources,
+										          MuonAssociatorByHitsHelper const* iHelper):
   m_hitExtractor(&iHitExtractor),
   m_resources(iResources),
   m_helper(iHelper)
@@ -54,24 +54,29 @@ MuonToTrackingParticleAssociatorByHitsImpl::associateMuons(reco::MuonToSimCollec
     /// PART 1: Fill MuonToSimAssociatorByHits::TrackHitsCollection
     MuonAssociatorByHitsHelper::TrackHitsCollection muonHitRefs;
     edm::OwnVector<TrackingRecHit> allTMRecHits;  // this I will fill in only for tracker muon hits from segments
+
+    std::vector<edm::OwnVector<TrackingRecHit> > TMRecHits; // used for case GlbOrTrk
+    edm::OwnVector<TrackingRecHit> noTM;
+
     switch (type) {
+        
         case reco::InnerTk: 
             for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
                 edm::RefToBase<reco::Muon> mur = *it;
                 if (mur->track().isNonnull()) { 
                     muonHitRefs.push_back(std::make_pair(mur->track()->recHitsBegin(), mur->track()->recHitsEnd()));
                 } else {
-                    muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
+		  muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
                 }
             }
-            break;
+	    break;
         case reco::OuterTk: 
             for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
                 edm::RefToBase<reco::Muon> mur = *it;
                 if (mur->outerTrack().isNonnull()) { 
                     muonHitRefs.push_back(std::make_pair(mur->outerTrack()->recHitsBegin(), mur->outerTrack()->recHitsEnd()));
                 } else {
-                    muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
+		  muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
                 }
             }
             break;
@@ -81,8 +86,8 @@ MuonToTrackingParticleAssociatorByHitsImpl::associateMuons(reco::MuonToSimCollec
                 if (mur->globalTrack().isNonnull()) { 
                     muonHitRefs.push_back(std::make_pair(mur->globalTrack()->recHitsBegin(), mur->globalTrack()->recHitsEnd()));
                 } else {
-                    muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
-               }
+		  muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
+		}
             }
             break;
         case reco::Segments: {
@@ -110,6 +115,63 @@ MuonToTrackingParticleAssociatorByHitsImpl::associateMuons(reco::MuonToSimCollec
                 
             }
             break;
+        case reco::GlbOrTrk: {
+	   edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl") 
+	     <<"\n"<<"There are "<<muons.size()<<" selected reco::Muons.";
+
+	   int isel = 0;
+	   for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
+	     edm::RefToBase<reco::Muon> mur = *it;
+
+	    edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl") 
+	      <<" #"<<isel<<", reco::Muon key = " <<mur.key()
+	      <<", q*p = "<<mur->charge()*mur->p()<<", pT = "<<mur->pt()<<", eta = "<<mur->eta()<<", phi = "<<mur->phi();
+
+	     // Global muon with valid muon hits
+	     if (mur->isGlobalMuon() && mur->globalTrack()->hitPattern().numberOfValidMuonHits()>0) {
+	       edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl") 
+		 <<"\t this is a Global Muon with valid muon hits";
+	       muonHitRefs.push_back(std::make_pair(mur->globalTrack()->recHitsBegin(), mur->globalTrack()->recHitsEnd()));
+	     }
+
+	     // Tracker Muon
+	     else if (mur->isTrackerMuon()) {
+	       edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl") 
+		 <<"\t this is a Tracker Muon";
+	       edm::OwnVector<TrackingRecHit> TMvec;
+
+	       std::vector<const TrackingRecHit *> hits = m_hitExtractor->getMuonHits(*mur); 
+	       for (std::vector<const TrackingRecHit *>::const_iterator ith = hits.begin(), edh = hits.end(); ith != edh; ++ith) {
+		 TMvec.push_back(**ith);
+	       }
+	       
+	       TMRecHits.push_back(TMvec);
+	       
+	       muonHitRefs.push_back(std::make_pair(TMRecHits.rbegin()->data().begin(), TMRecHits.rbegin()->data().end()));
+	     }
+
+	     // Standalone muon or Global without valid muon hits
+	     else if (mur->outerTrack().isNonnull()) {
+	       edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl") 
+		 <<"\t this is a Standalone muon";
+	       muonHitRefs.push_back(std::make_pair(mur->outerTrack()->recHitsBegin(), mur->outerTrack()->recHitsEnd()));
+	     }
+
+	     else {
+	       edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl") 
+		 <<"\t what muon is this ?";
+	       edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl") 
+		 <<"isMuon : "<<mur->isMuon()<<", isPFMuon : "<<mur->isPFMuon()<<", isTrackerMuon : "<<mur->isTrackerMuon()
+		 <<", isStandAloneMuon : "<<mur->isStandAloneMuon()<<", isGlobalMuon : "<<mur->isGlobalMuon()
+		 <<", isRPCMuon : "<<mur->isRPCMuon()<<", isGEMMuon : "<<mur->isGEMMuon()<<", isME0Muon : "<<mur->isME0Muon();
+	       muonHitRefs.push_back(std::make_pair(noTM.data().end(), noTM.data().end()));
+	     }
+	     
+	     isel++;
+	   } // loop on muons
+	   
+        }
+	break;
     }
 
     /// PART 2: call the association routines 

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
@@ -114,26 +114,28 @@ namespace {
  
     if (crossingframe) {
       std:: unique_ptr<MixCollection<SimTrack> > SimTk( new MixCollection<SimTrack>(simtracksXF_.product()) );
-      edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")<<"\n"<<"CrossingFrame<SimTrack> collection with InputTag = "<<simtracksXFTag
-                                              <<" has size = "<<SimTk->size();
+      edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+	<<"\n"<<"CrossingFrame<SimTrack> collection with InputTag = "<<simtracksXFTag<<" has size = "<<SimTk->size();
       int k = 0;
       for (MixCollection<SimTrack>::MixItr ITER=SimTk->begin(); ITER!=SimTk->end(); ITER++, k++) {
         edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
           <<"SimTrack "<<k
           <<" - Id:"<<ITER->trackId()<<"/Evt:("<<ITER->eventId().event()<<","<<ITER->eventId().bunchCrossing()<<")"
-          <<" pdgId = "<<ITER->type()<<", q = "<<ITER->charge()<<", p = "<<ITER->momentum().P()
+          <<", q = "<<ITER->charge()<<", p = "<<ITER->momentum().P()
           <<", pT = "<<ITER->momentum().Pt()<<", eta = "<<ITER->momentum().Eta()<<", phi = "<<ITER->momentum().Phi()
-          <<"\n * "<<*ITER <<endl;
+	  <<"\n\t pdgId = "<<ITER->type()<<", Vertex index = "<<ITER->vertIndex()
+	  <<", Gen Particle index = "<< (ITER->genpartIndex()>0 ? ITER->genpartIndex()-1 : ITER->genpartIndex()) <<endl;
       }
 
       std::unique_ptr<MixCollection<SimVertex> > SimVtx( new MixCollection<SimVertex>(simvertsXF_.product()) );
-      edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")<<"\n"<<"CrossingFrame<SimVertex> collection with InputTag = "<<simtracksXFTag
-                                              <<" has size = "<<SimVtx->size();
+      edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+	<<"\n"<<"CrossingFrame<SimVertex> collection with InputTag = "<<simtracksXFTag<<" has size = "<<SimVtx->size();
       int kv = 0;
       for (MixCollection<SimVertex>::MixItr VITER=SimVtx->begin(); VITER!=SimVtx->end(); VITER++, kv++){
         edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
           <<"SimVertex "<<kv
-          << " : "<< *VITER <<endl;
+	  <<" - Id:"<<VITER->vertexId()<<", position = "<<VITER->position()<<", parent SimTrack Id = "<<VITER->parentIndex()
+	  <<", processType = "<<VITER->processType();
       }
     }
     else {
@@ -145,9 +147,10 @@ namespace {
         edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
           <<"SimTrack "<<k
           <<" - Id:"<<ITER->trackId()<<"/Evt:("<<ITER->eventId().event()<<","<<ITER->eventId().bunchCrossing()<<")"
-          <<" pdgId = "<<ITER->type()<<", q = "<<ITER->charge()<<", p = "<<ITER->momentum().P()
+          <<", q = "<<ITER->charge()<<", p = "<<ITER->momentum().P()
           <<", pT = "<<ITER->momentum().Pt()<<", eta = "<<ITER->momentum().Eta()<<", phi = "<<ITER->momentum().Phi()
-          <<"\n * "<<*ITER <<endl;
+	  <<"\n\t pdgId = "<<ITER->type()<<", Vertex index = "<<ITER->vertIndex()
+	  <<", Gen Particle index = "<< (ITER->genpartIndex()>0 ? ITER->genpartIndex()-1 : ITER->genpartIndex()) <<endl;
       }
       const edm::SimVertexContainer simVC = *(simverts_.product());
       edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")<<"\n"<<"SimVertex collection with InputTag = "<<"g4SimHits"
@@ -156,7 +159,8 @@ namespace {
       for (edm::SimVertexContainer::const_iterator VITER=simVC.begin(); VITER!=simVC.end(); VITER++, kv++){
         edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
           <<"SimVertex "<<kv
-          << " : "<< *VITER <<endl;
+	  <<" - Id:"<<VITER->vertexId()<<", position = "<<VITER->position()<<", parent SimTrack Id = "<<VITER->parentIndex()
+	  <<", processType = "<<VITER->processType();
       }
     }
 

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
@@ -177,7 +177,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
 private:
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
   
   // ----------member data ---------------------------
   edm::ParameterSet const config_;

--- a/SimMuon/MCTruth/python/muonAssociatorByHitsNoSimHitsHelper_cfi.py
+++ b/SimMuon/MCTruth/python/muonAssociatorByHitsNoSimHitsHelper_cfi.py
@@ -13,13 +13,20 @@ muonAssociatorByHitsNoSimHitsHelper.RPCsimhitsTag = ""
 muonAssociatorByHitsNoSimHitsHelper.GEMsimhitsTag = ""
 muonAssociatorByHitsNoSimHitsHelper.DTsimhitsTag  = ""
 
-### The following is useful when running only on RECO
+### The following was used when running only on RECO
 # don't normalize on the total number of hits (which is unknown, if I don't have simHits)
-muonAssociatorByHitsNoSimHitsHelper.AbsoluteNumberOfHits_muon = True
-muonAssociatorByHitsNoSimHitsHelper.AbsoluteNumberOfHits_track = True
+#muonAssociatorByHitsNoSimHitsHelper.AbsoluteNumberOfHits_muon = True
+#muonAssociatorByHitsNoSimHitsHelper.AbsoluteNumberOfHits_track = True
+#
+### currently this is dealt with in the code itself (MuonAssociatorByHitsHelper.cc) 
+### to allow ranking the simToReco matches according to the number of shared hits: 
+### this is relevant for the definition of duplicates
+   
 # use only muon system
 muonAssociatorByHitsNoSimHitsHelper.UseTracker = False
 
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+run3_GEM.toModify( muonAssociatorByHitsNoSimHitsHelper, useGEMs = cms.bool(True) )
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify( muonAssociatorByHitsNoSimHitsHelper, usePhase2Tracker = cms.bool(True) )
 phase2_tracker.toModify( muonAssociatorByHitsNoSimHitsHelper, pixelSimLinkSrc = "simSiPixelDigis:Pixel" )
-phase2_tracker.toModify( muonAssociatorByHitsNoSimHitsHelper, stripSimLinkSrc = "simSiPixelDigis:Tracker" )

--- a/SimMuon/MCTruth/src/MuonAssociatorByHitsHelper.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHitsHelper.cc
@@ -613,9 +613,14 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices( const TrackHitsCollection
 
         // Handle the case of TrackingParticles that don't have PSimHits inside, e.g. because they were made on RECOSIM only.
         if (trpart->numberOfHits()==0) {
-            // FIXME this can be made better, counting the digiSimLinks associated to this TP, but perhaps it's not worth it
-            n_tracker_recounted_simhits = tracker_nshared;
-            n_muon_simhits = muon_nshared;
+	  // FIXME this can be made better, counting the digiSimLinks associated to this TP, but perhaps it's not worth it
+	  //n_tracker_recounted_simhits = tracker_nshared;
+	  //n_muon_simhits = muon_nshared;
+	  // ---> on RECOSIM when the AbsoluteNumberOfHits_muon=True this always obtains quality=1, 
+	  //      hence no sorting is possible in case of duplicate matchings
+	  // ---> reset these variables to 1 so to keep the number of shared hits as ranking criterion
+	  n_tracker_recounted_simhits = 1;
+	  n_muon_simhits = 1;
         }	
 	n_global_simhits = n_tracker_recounted_simhits + n_muon_simhits;
 

--- a/SimMuon/MCTruth/src/MuonAssociatorByHitsHelper.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHitsHelper.cc
@@ -940,6 +940,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds
 	      <<"\n\t this TrackingRecHit is a DTRecSegment4D with "
 	      <<componentHits.size()<<" hits (phi:"<<phiHits.size()<<", z:"<<zHits.size()<<")";
 	    
+	    SimTrackIds.clear();
 	    std::vector<SimHitIdpr> i_SimTrackIds;
 	    int i_compHit = 0;
 	    for (std::vector<const TrackingRecHit *>::const_iterator ithit =componentHits.begin(); 
@@ -1041,6 +1042,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds
 	    if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper")
 	      <<"\n\t this TrackingRecHit is a CSCSegment with "<<componentHits.size()<<" hits";
 	    
+	    SimTrackIds.clear();
 	    std::vector<SimHitIdpr> i_SimTrackIds;
 	    int i_compHit = 0;
 	    for (std::vector<const TrackingRecHit *>::const_iterator ithit =componentHits.begin(); 
@@ -1168,6 +1170,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds
 	    if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper")
 	      <<"\n\t this TrackingRecHit is a GEMSegment with "<<componentHits.size()<<" hits";
 	    
+	    SimTrackIds.clear();
 	    std::vector<SimHitIdpr> i_SimTrackIds;
 	    int i_compHit = 0;
 
@@ -1211,7 +1214,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds
 		i_hitlog = i_hitlog + write_matched_simtracks(i_SimTrackIds);
 		edm::LogVerbatim("MuonAssociatorByHitsHelper") << i_hitlog;
 	      }
-	      
+
 	      SimTrackIds.insert(SimTrackIds.end(),i_SimTrackIds.begin(),i_SimTrackIds.end());
 	    }	    
 	  }  // if (gemsegment)	  
@@ -1220,7 +1223,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds
       }
       else if (printRtS) edm::LogVerbatim("MuonAssociatorByHitsHelper")
 			   <<"TrackingRecHit "<<iloop<<"  *** WARNING *** Unexpected Hit from Detector = "<<det;
-    }
+    } // end if (det == DetId::Muon && UseMuon)
     else continue;
     
     hitlog = hitlog + write_matched_simtracks(SimTrackIds);

--- a/SimMuon/MCTruth/src/TrackerMuonHitExtractor.cc
+++ b/SimMuon/MCTruth/src/TrackerMuonHitExtractor.cc
@@ -106,8 +106,10 @@ TrackerMuonHitExtractor::getMuonHits(const reco::Muon &mu) const {
 	int endcap, /*station, */ ring, chamber;
 	
 	edm::LogVerbatim("TrackerMuonHitExtractor") <<"Number of chambers: "<<mu.matches().size()
-					      <<", arbitrated: "<<mu.numberOfMatches(reco::Muon::SegmentAndTrackArbitration);
+					      <<", arbitrated: "<<mu.numberOfMatches(reco::Muon::SegmentAndTrackArbitration)
+					      <<", tot (no arbitration): "<<mu.numberOfMatches(reco::Muon::NoArbitration);
 	unsigned int index_chamber = 0;
+	int n_segments_noArb = 0;
 	
 	for(std::vector<reco::MuonChamberMatch>::const_iterator chamberMatch = mu.matches().begin();
 	    chamberMatch != mu.matches().end(); ++chamberMatch, index_chamber++) {
@@ -135,6 +137,7 @@ TrackerMuonHitExtractor::getMuonHits(const reco::Muon &mu) const {
 	  
 	  chamberStr << ", Number of segments: "<<chamberMatch->segmentMatches.size();
 	  edm::LogVerbatim("TrackerMuonHitExtractor") << chamberStr.str();
+	  n_segments_noArb = n_segments_noArb + chamberMatch->segmentMatches.size();
 
 	  unsigned int index_segment = 0;
 	  
@@ -165,6 +168,7 @@ TrackerMuonHitExtractor::getMuonHits(const reco::Muon &mu) const {
 		<<"\n\t  Local Position (X,Y)=("<<segmentX<<","<<segmentY<<") +/- ("<<segmentXerr<<","<<segmentYerr<<"), " 
 		<<"\n\t  Local Direction (dXdZ,dYdZ)=("<<segmentdXdZ<<","<<segmentdYdZ<<") +/- ("<<segmentdXdZerr<<","<<segmentdYdZerr<<")"; 
 	      
+	      // with the following line the DT segments failing standard arbitration are skipped 
 	      if (!segment_arbitrated_Ok) continue;
 
               if (segmentDT.get() != 0) {
@@ -198,6 +202,7 @@ TrackerMuonHitExtractor::getMuonHits(const reco::Muon &mu) const {
 		<<"\n\t  Local Position (X,Y)=("<<segmentX<<","<<segmentY<<") +/- ("<<segmentXerr<<","<<segmentYerr<<"), " 
 		<<"\n\t  Local Direction (dXdZ,dYdZ)=("<<segmentdXdZ<<","<<segmentdYdZ<<") +/- ("<<segmentdXdZerr<<","<<segmentdYdZerr<<")"; 
 	      
+	      // with the following line the CSC segments failing standard arbitration are skipped 
 	      if (!segment_arbitrated_Ok) continue;
 
               if (segmentCSC.get() != 0) {
@@ -215,6 +220,8 @@ TrackerMuonHitExtractor::getMuonHits(const reco::Muon &mu) const {
 	    
 	  } // loop on vector<MuonSegmentMatch>	  
 	}  // loop on vector<MuonChamberMatch>	
+
+	edm::LogVerbatim("TrackerMuonHitExtractor")<<"\n N. matched Segments before arbitration = "<<n_segments_noArb;
 
         return ret;
 }

--- a/SimMuon/MCTruth/src/TrackerMuonHitExtractor.cc
+++ b/SimMuon/MCTruth/src/TrackerMuonHitExtractor.cc
@@ -171,7 +171,7 @@ TrackerMuonHitExtractor::getMuonHits(const reco::Muon &mu) const {
 	      // with the following line the DT segments failing standard arbitration are skipped 
 	      if (!segment_arbitrated_Ok) continue;
 
-              if (segmentDT.get() != 0) {
+              if (segmentDT.get() != nullptr) {
 		const DTRecSegment4D* segment = segmentDT.get();
 		
 		edm::LogVerbatim("TrackerMuonHitExtractor")<<"\t ===> MATCHING with DT segment with index = "<<segmentDT.key();
@@ -205,7 +205,7 @@ TrackerMuonHitExtractor::getMuonHits(const reco::Muon &mu) const {
 	      // with the following line the CSC segments failing standard arbitration are skipped 
 	      if (!segment_arbitrated_Ok) continue;
 
-              if (segmentCSC.get() != 0) {
+              if (segmentCSC.get() != nullptr) {
 		const CSCSegment* segment = segmentCSC.get();
 		
 		edm::LogVerbatim("TrackerMuonHitExtractor")<<"\t ===> MATCHING with CSC segment with index = "<<segmentCSC.key();


### PR DESCRIPTION
This is an update of the MC truth association tools for muons.
The association of reco::Muons has been updated to allow the association of (Global || Tracker) muons. The MuonMCClassifier has been updated and few bugs have been fixed.
The tools can be used to assess the performance of Muon ID and have been employed for the Particle-Flow performance paper (PRF-14-001).
The new code was initially developed in that context (in 7_4_X) and extensively tested there.
Now it has been ported to CMSSW_9_3_X and tested on MC events with "RelVal"-like content.
An example is provided, running on Phase2 events having the TrackingParticles in the event content:
 MuonAnalysis/MuonAssociators/test/MuonMCClassifier/testClassByHitsTP_cfg.py

This PR is relevant for performance studies (e.g. Phase2 Muon TDR) and in general for developments in the muon ID validation.

@calabria 
