### PR TITLE
[93X] make cut on number of tracks in Strip Hit Efficiency code configurable

### DIFF
--- a/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
+++ b/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
@@ -65,7 +65,9 @@ class HitEff : public edm::EDAnalyzer {
   
   bool addLumi_;
   bool addCommonMode_;
-
+  bool cutOnTracks_;
+  unsigned int trackMultiplicityCut_;
+  
   const edm::EDGetTokenT< reco::TrackCollection > combinatorialTracks_token_;
   const edm::EDGetTokenT< std::vector<Trajectory> > trajectories_token_;
   const edm::EDGetTokenT< edmNew::DetSetVector<SiStripCluster> > clusters_token_;

--- a/CalibTracker/SiStripHitEfficiency/python/SiStripHitEff_cff.py
+++ b/CalibTracker/SiStripHitEfficiency/python/SiStripHitEff_cff.py
@@ -17,7 +17,11 @@ anEff = cms.EDAnalyzer("HitEff",
                        lumiScalers = cms.InputTag("scalersRawToDigi"),
                        addLumi = cms.untracked.bool(False),
                        commonMode = cms.InputTag("siStripDigis", "CommonMode"),
-                       addCommonMode = cms.untracked.bool(False)
+                       addCommonMode = cms.untracked.bool(False),
+                       # do not cut on the total number of tracks
+                       cutOnTracks = cms.untracked.bool(False),
+                       # compatibility
+                       trackMultiplicity = cms.untracked.int(100)
                        )
 
 hiteff = cms.Sequence( anEff )

--- a/CalibTracker/SiStripHitEfficiency/python/SiStripHitEff_cff.py
+++ b/CalibTracker/SiStripHitEfficiency/python/SiStripHitEff_cff.py
@@ -19,7 +19,7 @@ anEff = cms.EDAnalyzer("HitEff",
                        commonMode = cms.InputTag("siStripDigis", "CommonMode"),
                        addCommonMode = cms.untracked.bool(False),
                        # do not cut on the total number of tracks
-                       cutOnTracks = cms.untracked.bool(False),
+                       cutOnTracks = cms.untracked.bool(True),
                        # compatibility
                        trackMultiplicity = cms.untracked.int(100)
                        )

--- a/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
@@ -85,6 +85,8 @@ HitEff::HitEff(const edm::ParameterSet& conf) :
   DEBUG = conf_.getParameter<bool>("Debug");
   addLumi_ = conf_.getUntrackedParameter<bool>("addLumi", false);
   addCommonMode_ = conf_.getUntrackedParameter<bool>("addCommonMode", false);
+  cutOnTracks_ = conf_.getUntrackedParameter<bool>("cutOnTracks", false);
+  trackMultiplicityCut_ = conf.getUntrackedParameter<unsigned int>("trackMultiplicity",100);
 }
 
 // Virtual destructor needed.
@@ -272,7 +274,8 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
   const   reco::TrackCollection *tracksCKF=trackCollectionCKF.product();
   if (DEBUG)  cout << "number ckf tracks found = " << tracksCKF->size() << endl;
   //if (tracksCKF->size() == 1 ){
-  if (tracksCKF->size() > 0 && tracksCKF->size()<100) {
+  if (tracksCKF->size() > 0) {
+    if( cutOnTracks_ && (tracksCKF->size() > trackMultiplicityCut_) ) return;
     if (DEBUG)    cout << "starting checking good event with < 100 tracks" << endl;
 
     EventTrackCKF++;  

--- a/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
@@ -275,8 +275,8 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
   if (DEBUG)  cout << "number ckf tracks found = " << tracksCKF->size() << endl;
   //if (tracksCKF->size() == 1 ){
   if (tracksCKF->size() > 0) {
-    if( cutOnTracks_ && (tracksCKF->size() > trackMultiplicityCut_) ) return;
-    if (DEBUG)    cout << "starting checking good event with < 100 tracks" << endl;
+    if( cutOnTracks_ && (tracksCKF->size() >= trackMultiplicityCut_) ) return;
+    if( DEBUG && cutOnTracks_ ) cout << "starting checking good event with < "<< trackMultiplicityCut_ <<" tracks" << endl;
 
     EventTrackCKF++;  
 


### PR DESCRIPTION
Update module which is used to ntuplize Hit Efficiency trees, to allow events with > 100 reconstructed tracks in it to enter the computation. 
For the time being the cut is set to yield the same trees as before. 