### PR TITLE
Upgrade of the SingleModuleOccupancy script

### DIFF
--- a/DQM/SiStripMonitorClient/bin/moduleOccupancyTrend.cc
+++ b/DQM/SiStripMonitorClient/bin/moduleOccupancyTrend.cc
@@ -24,6 +24,14 @@ int main(int argc, char *argv[]) {
   filelist= argv[1];
   modulelist= argv[2];
 
+  int stripmin = 999;
+  int stripmax = 999;
+
+  if (argv[3] && argv[4]){
+    stripmin=atoi(argv[3]);
+    stripmax=atoi(argv[4]);
+  }
+
   std::string detid;
   std::string hn;
 
@@ -106,7 +114,9 @@ int main(int argc, char *argv[]) {
 
       if (hn.find("Summary")==std::string::npos) histo->Scale(1/EvtNum);
 
-      double numberPerEvent= histo->Integral();
+      double numberPerEvent;
+      if (stripmin==999 && stripmax==999) numberPerEvent=histo->Integral();
+      else numberPerEvent=histo->Integral(stripmin,stripmax);
 
       
       if (max<=histo->GetBinContent(histo->GetMaximumBin())) max=histo->GetBinContent(histo->GetMaximumBin());
@@ -116,9 +126,6 @@ int main(int argc, char *argv[]) {
       histo->SetMarkerStyle(9);
       histo->SetMarkerColor(k+1);
            
-      
-      
-
       trend->SetBinContent(k+1,numberPerEvent);
       trend->GetXaxis()->SetBinLabel(k+1,runNum.c_str());
 

--- a/DQM/SiStripMonitorClient/scripts/moduleOccupancyTrend.sh
+++ b/DQM/SiStripMonitorClient/scripts/moduleOccupancyTrend.sh
@@ -29,9 +29,10 @@ done
 
 echo "Summary" >> modulefile
 
-moduleOccupancyTrend rootfilestmp.txt modulefile
+moduleOccupancyTrend rootfilestmp.txt modulefile $7 $8
 
 rm modulefile
+rm rootfilestmp.txt
 
 cd -
 


### PR DESCRIPTION
With this PR the SingleModuleOccupancy trends can be done in a selected range of strips instead that for the full module only.

This script is used on demand by the Tracker Offline shifters/experts, there is really nothing to be tested.