### PR TITLE
pr92x L1T fix EMTF Unpacker RPC Bit Range

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
@@ -32,7 +32,7 @@ namespace l1t {
 	if(GetHexBits(RPCb, 15, 15) != 0) { errors += 1; edm::LogError("L1T|EMTF") << "Format identifier bits in RPCb are incorrect"; }
 	if(GetHexBits(RPCc, 12, 13) != 0) { errors += 1; edm::LogError("L1T|EMTF") << "Format identifier bits in RPCc are incorrect"; }
 	if(GetHexBits(RPCc, 15, 15) != 1) { errors += 1; edm::LogError("L1T|EMTF") << "Format identifier bits in RPCc are incorrect"; }
-	if(GetHexBits(RPCd, 3, 15)  != 0) { errors += 1; edm::LogError("L1T|EMTF") << "Format identifier bits in RPCd are incorrect"; }
+	if(GetHexBits(RPCd, 4, 15)  != 0) { errors += 1; edm::LogError("L1T|EMTF") << "Format identifier bits in RPCd are incorrect"; }
 
 	return errors;
 	


### PR DESCRIPTION
92x L1T EMTF Unpacker RPC Bit Range
No need for 93x PR (see below).

This will remove numerous printouts from L1T, currently appearing at Tier0 when processing 2017 data.
```
%MSG-e EMTF:  L1TRawToDigi:emtfStage2Digis 15-Jul-2017 14:50:46 CEST  Run: 298853 Event: 29487742
Format identifier bits in RPCd are incorrect
%MSG
```

Description:
In 92x, we are still using 2016 EMTF unpacker. 
This fixes that EMTF unpacker to use the correct bit-range (4 to 15) when checking for unpacking RPC input data.

In 2017 data,  the bit range (4 to 15) is used in the fw at P5.  In 2016 data, the bit range {3 to 15) was used. So this fix will work on 2016 data as well. 

There is no need for 93x PR as this fix is already included in the  L1T EMTF 2017 emulator/unpacker
migration in CMSSW, and has already been merged in 93x. See here: 
https://github.com/cms-sw/cmssw/blob/CMSSW_9_3_X/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc#L65
