### PR TITLE
Added fragment corrected Ecal depth

### DIFF
--- a/SimG4Core/Application/python/EcalDepthCorrection_cff.py
+++ b/SimG4Core/Application/python/EcalDepthCorrection_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+def customise(process):
+
+  # fragment allowing to simulate correct Ecal hit depth 
+
+  if hasattr(process,'g4SimHits'):
+    process.g4SimHits.ECalSD.IgnoreDepthCorr = cms.bool(False)
+
+    return(process)

--- a/SimG4Core/Application/python/EcalDepthCorrection_cff.py
+++ b/SimG4Core/Application/python/EcalDepthCorrection_cff.py
@@ -2,9 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 def customiseEcalSD(process):
 
-  # fragment allowing to simulate correct Ecal hit depth 
-
-  if hasattr(process,'g4SimHits'):
+    # fragment allowing to simulate correct Ecal hit depth 
     process.g4SimHits.ECalSD.IgnoreDepthCorr = cms.bool(False)
 
     return(process)

--- a/SimG4Core/Application/python/EcalDepthCorrection_cff.py
+++ b/SimG4Core/Application/python/EcalDepthCorrection_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-def customise(process):
+def customiseEcalSD(process):
 
   # fragment allowing to simulate correct Ecal hit depth 
 


### PR DESCRIPTION
This python fragment may enables fixed Ecal computation of distance from a hit position to APD, which is provided in #19625.

This PR should be tested together with #19625. 