### PR TITLE
Fix for ECAL saturation in the tail of the pulse

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -340,7 +340,7 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
             << "! something wrong with EcalTimeCalibConstants in your DB? ";
 	}
 
-        int lastSampleBeforeSaturation = -1;
+        int lastSampleBeforeSaturation = -2;
         for(unsigned int iSample = 0; iSample < EcalDataFrame::MAXSAMPLES; iSample++) {
           if ( ((EcalDataFrame)(*itdg)).sample(iSample).gainId() == 0 ) {
             lastSampleBeforeSaturation=iSample-1;
@@ -356,7 +356,7 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
             uncalibRecHit.setFlagBit( EcalUncalibratedRecHit::kSaturated );
 	    // do not propagate the default chi2 = -1 value to the calib rechit (mapped to 64), set it to 0 when saturation
             uncalibRecHit.setChi2(0);
-        } else if ( lastSampleBeforeSaturation >= 0 ) { // saturation on other samples: cannot extrapolate from the fourth one
+        } else if ( lastSampleBeforeSaturation >= -1 ) { // saturation on other samples: cannot extrapolate from the fourth one
             int gainId = ((EcalDataFrame)(*itdg)).sample(5).gainId();
             if (gainId==0) gainId=3;
             auto pedestal = pedVec[gainId-1];

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -207,7 +207,7 @@ double EcalUncalibRecHitWorkerMultiFit::timeCorrection(
   double theCorrection = 0;
 
   // sanity check for arrays
-  if (amplitudeBins.size() == 0) {
+  if (amplitudeBins.empty()) {
     edm::LogError("EcalRecHitError")
         << "timeCorrAmplitudeBins is empty, forcing no time bias corrections.";
 
@@ -294,12 +294,12 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
         // intelligence for recHit computation
         float offsetTime = 0;
         
-        const EcalPedestals::Item * aped = 0;
-        const EcalMGPAGainRatio * aGain = 0;
-        const EcalXtalGroupId * gid = 0;
-        const EcalPulseShapes::Item * aPulse = 0;
-        const EcalPulseCovariances::Item * aPulseCov = 0;
-
+        const EcalPedestals::Item * aped = nullptr;
+        const EcalMGPAGainRatio * aGain = nullptr;
+        const EcalXtalGroupId * gid = nullptr;
+        const EcalPulseShapes::Item * aPulse = nullptr;
+        const EcalPulseCovariances::Item * aPulseCov = nullptr;
+ 
         if (barrel) {
             unsigned int hashedIndex = EBDetId(detid).hashedIndex();
             aped       = &peds->barrel(hashedIndex);

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -340,16 +340,23 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
             << "! something wrong with EcalTimeCalibConstants in your DB? ";
 	}
 
-        // === amplitude computation ===
-        int leadingSample = ((EcalDataFrame)(*itdg)).lastUnsaturatedSample();
+        int lastSampleBeforeSaturation = -1;
+        for(unsigned int iSample = 0; iSample < EcalDataFrame::MAXSAMPLES; iSample++) {
+          if ( ((EcalDataFrame)(*itdg)).sample(iSample).gainId() == 0 ) {
+            lastSampleBeforeSaturation=iSample-1;
+            break;
+          }
+        }
 
-        if ( leadingSample == 4 ) { // saturation on the expected max sample
+        // === amplitude computation ===
+
+        if ( lastSampleBeforeSaturation == 4 ) { // saturation on the expected max sample
             result.emplace_back((*itdg).id(), 4095*12, 0, 0, 0);
             auto & uncalibRecHit = result.back();
             uncalibRecHit.setFlagBit( EcalUncalibratedRecHit::kSaturated );
 	    // do not propagate the default chi2 = -1 value to the calib rechit (mapped to 64), set it to 0 when saturation
             uncalibRecHit.setChi2(0);
-        } else if ( leadingSample >= 0 ) { // saturation on other samples: cannot extrapolate from the fourth one
+        } else if ( lastSampleBeforeSaturation >= 0 ) { // saturation on other samples: cannot extrapolate from the fourth one
             int gainId = ((EcalDataFrame)(*itdg)).sample(5).gainId();
             if (gainId==0) gainId=3;
             auto pedestal = pedVec[gainId-1];

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -42,7 +42,7 @@ class EcalUncalibRecHitWorkerMultiFit final : public EcalUncalibRecHitWorkerBase
         public:
                 EcalUncalibRecHitWorkerMultiFit(const edm::ParameterSet&, edm::ConsumesCollector& c);
 		EcalUncalibRecHitWorkerMultiFit() {};
-                virtual ~EcalUncalibRecHitWorkerMultiFit() {};
+                ~EcalUncalibRecHitWorkerMultiFit() override {};
         private:
                 void set(const edm::EventSetup& es) override;
                 void set(const edm::Event& evt) override;


### PR DESCRIPTION
This PR fixes the handling of cases where the saturation was happening in the tail of the pulse shape, instead of the neighbours of the max sample.
In these cases, due to a wrong behavior of EcalDataFrame.lastUnsaturatedSample(), if the saturation happened in the last samples of the tail:

- the rechit was not flagged as "kSaturated" (so propagated to clusters)
- the multifit reconstruction was used
- the multifit had internally a protection against this, throwing a warning and setting the amplitude of the sample to the maximum value, but still attempting to fit. 

With this PR the multifit is not called if any of the sample is saturated, and the last saturated sample is set to the one before the first happening of the saturation.

This fixes the occurrences of the warnings seen by @gennai at HLT.
In the meanwhile we investigate within ECAL about the implementation of EcalDataFrame.lastUnsaturatedSample() and eventually will fix it (or remove, since it is not used elsewhere in CMSSW).

@bendavid @amassiro @crovelli @paramatti

Same change as done for the 92X branch, in PR #20059 