### PR TITLE
GTUpdates_MagFieldMap_SiPixelQuality_CSC_ChannelStatus_HadPFUpdate_ESInterCalib

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -38,13 +38,13 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '93X_dataRun2_HLTHI_frozen_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '93X_upgrade2017_design_IdealBS_v0',
+    'phase1_2017_design'       :  '93X_mc2017_design_IdealBS_v0',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '93X_upgrade2017_realistic_v0',
+    'phase1_2017_realistic'    : '93X_mc2017_realistic_v0',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '93X_upgrade2017cosmics_realistic_deco_v0',
+    'phase1_2017_cosmics'      : '93X_mc2017cosmics_realistic_deco_v0',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '93X_upgrade2017cosmics_realistic_peak_v0',
+    'phase1_2017_cosmics_peak' : '93X_mc2017cosmics_realistic_peak_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '93X_upgrade2018_design_IdealBS_v0',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -38,13 +38,13 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '93X_dataRun2_HLTHI_frozen_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '93X_mc2017_design_IdealBS_v0',
+    'phase1_2017_design'       :  '93X_mc2017_design_IdealBS_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '93X_mc2017_realistic_v0',
+    'phase1_2017_realistic'    : '93X_mc2017_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '93X_mc2017cosmics_realistic_deco_v0',
+    'phase1_2017_cosmics'      : '93X_mc2017cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '93X_mc2017cosmics_realistic_peak_v0',
+    'phase1_2017_cosmics_peak' : '93X_mc2017cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '93X_upgrade2018_design_IdealBS_v0',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,59 +2,59 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '92X_mcRun1_design_v2',
+    'run1_design'       :   '93X_mcRun1_design_v0',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '92X_mcRun1_realistic_v2',
+    'run1_mc'           :   '93X_mcRun1_realistic_v0',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '92X_mcRun1_HeavyIon_v2',
+    'run1_mc_hi'        :   '93X_mcRun1_HeavyIon_v0',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '92X_mcRun1_pA_v2',
+    'run1_mc_pa'        :   '93X_mcRun1_pA_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '92X_mcRun2_design_v2',
+    'run2_design'       :   '93X_mcRun2_design_v0',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '92X_mcRun2_startup_v2',
+    'run2_mc_50ns'      :   '93X_mcRun2_startup_v0',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '92X_mcRun2_asymptotic_v2',
+    'run2_mc'           :   '93X_mcRun2_asymptotic_v0',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '92X_mcRun2cosmics_startup_deco_v2',
+    'run2_mc_cosmics'   :   '93X_mcRun2cosmics_startup_deco_v0',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '92X_mcRun2_HeavyIon_v2',
+    'run2_mc_hi'        :   '93X_mcRun2_HeavyIon_v0',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '92X_mcRun2_pA_v2',
+    'run2_mc_pa'        :   '93X_mcRun2_pA_v0',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '92X_dataRun2_v5',
+    'run1_data'         :   '93X_dataRun2_v0',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '92X_dataRun2_v5',
+    'run2_data'         :   '93X_dataRun2_v0',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '92X_dataRun2_relval_v6',
+    'run2_data_relval'  :   '93X_dataRun2_relval_v0',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '92X_dataRun2_PromptLike_v5',
+    'run2_data_promptlike' : '93X_dataRun2_PromptLike_v0',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '92X_dataRun2_HLT_frozen_v6',
+    'run1_hlt'          :   '93X_dataRun2_HLT_frozen_v0',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '92X_dataRun2_HLT_frozen_v6',
+    'run2_hlt'          :   '93X_dataRun2_HLT_frozen_v0',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '92X_dataRun2_HLT_relval_v7',
+    'run2_hlt_relval'   :   '93X_dataRun2_HLT_relval_v0',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '92X_dataRun2_HLTHI_frozen_v6',
+    'run2_hlt_hi'       :   '93X_dataRun2_HLTHI_frozen_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '92X_upgrade2017_design_IdealBS_v10',
+    'phase1_2017_design'       :  '93X_upgrade2017_design_IdealBS_v0',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '92X_upgrade2017_realistic_v10',
+    'phase1_2017_realistic'    : '93X_upgrade2017_realistic_v0',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '92X_upgrade2017cosmics_realistic_deco_v10',
+    'phase1_2017_cosmics'      : '93X_upgrade2017cosmics_realistic_deco_v0',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '92X_upgrade2017cosmics_realistic_peak_v10',
+    'phase1_2017_cosmics_peak' : '93X_upgrade2017cosmics_realistic_peak_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '92X_upgrade2018_design_IdealBS_v7',
+    'phase1_2018_design'       : '93X_upgrade2018_design_IdealBS_v0',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '92X_upgrade2018_realistic_v8',
+    'phase1_2018_realistic'    : '93X_upgrade2018_realistic_v0',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '92X_upgrade2018cosmics_realistic_deco_v8',
+    'phase1_2018_cosmics'      :   '93X_upgrade2018cosmics_realistic_deco_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '92X_upgrade2023_realistic_v2'
+    'phase2_realistic'         : '93X_upgrade2023_realistic_v0'
 }
 
 aliases = {


### PR DESCRIPTION
# Summary of changes in Global Tags 
 
## RunI simulation 
 
   * **RunI Heavy Ions scenario** : [93X_mcRun1_HeavyIon_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun1_HeavyIon_v0) as [92X_mcRun1_HeavyIon_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_mcRun1_HeavyIon_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mcRun1_HeavyIon_v0/92X_mcRun1_HeavyIon_v2): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html

   * **RunI Ideal scenario** : [93X_mcRun1_design_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun1_design_v0) as [92X_mcRun1_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_mcRun1_design_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mcRun1_design_v0/92X_mcRun1_design_v2): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html

   * **RunI Proton-Lead scenario** : [93X_mcRun1_pA_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun1_pA_v0) as [92X_mcRun1_pA_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_mcRun1_pA_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mcRun1_pA_v0/92X_mcRun1_pA_v2): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html

   * **RunI Realistic scenario** : [93X_mcRun1_realistic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun1_realistic_v0) as [92X_mcRun1_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_mcRun1_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mcRun1_realistic_v0/92X_mcRun1_realistic_v2): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html

## RunII simulation 
 
   * **RunII Asymptotic scenario** : [93X_mcRun2_asymptotic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_asymptotic_v0) as [92X_mcRun2_asymptotic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_mcRun2_asymptotic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mcRun2_asymptotic_v0/92X_mcRun2_asymptotic_v2): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html

   * **RunII CRAFT scenario** : [93X_mcRun2cosmics_startup_deco_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2cosmics_startup_deco_v0) as [92X_mcRun2cosmics_startup_deco_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_mcRun2cosmics_startup_deco_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mcRun2cosmics_startup_deco_v0/92X_mcRun2cosmics_startup_deco_v2): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html

   * **RunII Heavy Ions scenario** : [93X_mcRun2_HeavyIon_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_HeavyIon_v0) as [92X_mcRun2_HeavyIon_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_mcRun2_HeavyIon_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mcRun2_HeavyIon_v0/92X_mcRun2_HeavyIon_v2): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html

   * **RunII Ideal scenario** : [93X_mcRun2_design_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_design_v0) as [92X_mcRun2_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_mcRun2_design_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mcRun2_design_v0/92X_mcRun2_design_v2): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html

   * **RunII Proton-Lead scenario** : [93X_mcRun2_pA_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_pA_v0) as [92X_mcRun2_pA_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_mcRun2_pA_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mcRun2_pA_v0/92X_mcRun2_pA_v2): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html

   * **RunII Startup scenario** : [93X_mcRun2_startup_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_startup_v0) as [92X_mcRun2_startup_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_mcRun2_startup_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mcRun2_startup_v0/92X_mcRun2_startup_v2): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html

## MC 2017

   * **MC 2017 cosmics peak scenario** : [93X_mc2017cosmics_realistic_peak_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mc2017cosmics_realistic_peak_v0) as [92X_upgrade2017cosmics_realistic_peak_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2017cosmics_realistic_peak_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mc2017cosmics_realistic_peak_v0/92X_upgrade2017cosmics_realistic_peak_v10): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html
      * update of CSC bad chambers : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3137.html
      * update of pixel channel quality : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3080.html
      * update of ES intercalib : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3100.html

   * **MC 2017 cosmics scenario** : [93X_mc2017cosmics_realistic_deco_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mc2017cosmics_realistic_deco_v0) as [92X_upgrade2017cosmics_realistic_deco_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2017cosmics_realistic_deco_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mc2017cosmics_realistic_deco_v0/92X_upgrade2017cosmics_realistic_deco_v10): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html
      * update of CSC bad chambers : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3137.html
      * update of pixel channel quality : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3080.html
      * update of ES intercalib : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3100.html

   * **MC 2017 design scenario** : [93X_mc2017_design_IdealBS_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mc2017_design_IdealBS_v0) as [92X_upgrade2017_design_IdealBS_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2017_design_IdealBS_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mc2017_design_IdealBS_v0/92X_upgrade2017_design_IdealBS_v10): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html
      * update of ES intercalib : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3100.html

   * **MC 2017 realistic scenario** : [93X_mc2017_realistic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mc2017_realistic_v0) as [92X_upgrade2017_realistic_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2017_realistic_v10) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mc2017_realistic_v0/92X_upgrade2017_realistic_v10): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html
      * update of CSC bad chambers : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3137.html
      * update of pixel channel quality : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3080.html
      * update of ES intercalib : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3100.html

## Upgrade 
 
   * **PhaseII realistic scenario** : [93X_upgrade2023_realistic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_upgrade2023_realistic_v0) as [92X_upgrade2023_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2023_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_upgrade2023_realistic_v0/92X_upgrade2023_realistic_v2): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html

   * **PhaseI 2018 cosmics scenario** : [93X_upgrade2018cosmics_realistic_deco_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_upgrade2018cosmics_realistic_deco_v0) as [92X_upgrade2018cosmics_realistic_deco_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2018cosmics_realistic_deco_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_upgrade2018cosmics_realistic_deco_v0/92X_upgrade2018cosmics_realistic_deco_v8): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html
      * update of pixel channel quality : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3080.html

   * **PhaseI 2018 design scenario** : [93X_upgrade2018_design_IdealBS_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_upgrade2018_design_IdealBS_v0) as [92X_upgrade2018_design_IdealBS_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2018_design_IdealBS_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_upgrade2018_design_IdealBS_v0/92X_upgrade2018_design_IdealBS_v7): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html

   * **PhaseI 2018 realistic scenario** : [93X_upgrade2018_realistic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_upgrade2018_realistic_v0) as [92X_upgrade2018_realistic_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2018_realistic_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_upgrade2018_realistic_v0/92X_upgrade2018_realistic_v8): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html
      * update of pixel channel quality : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3080.html

## RunI and RunII data 
 
   * **RunII HLTHI processing** : [93X_dataRun2_HLTHI_frozen_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_dataRun2_HLTHI_frozen_v0) as [92X_dataRun2_HLTHI_frozen_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_dataRun2_HLTHI_frozen_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_dataRun2_HLTHI_frozen_v0/92X_dataRun2_HLTHI_frozen_v6): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html

   * **RunII HLT relval processing** : [93X_dataRun2_HLT_relval_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_dataRun2_HLT_relval_v0) as [92X_dataRun2_HLT_relval_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_dataRun2_HLT_relval_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_dataRun2_HLT_relval_v0/92X_dataRun2_HLT_relval_v7): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html

   * **RunI - RunII Offline processing** : [93X_dataRun2_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_dataRun2_v0) as [92X_dataRun2_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_dataRun2_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_dataRun2_v0/92X_dataRun2_v5): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html

   * **RunII Offline relval processing** : [93X_dataRun2_relval_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_dataRun2_relval_v0) as [92X_dataRun2_relval_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_dataRun2_relval_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_dataRun2_relval_v0/92X_dataRun2_relval_v6): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html

   * **RunII Prompt processing** : [93X_dataRun2_PromptLike_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_dataRun2_PromptLike_v0) as [92X_dataRun2_PromptLike_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_dataRun2_PromptLike_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_dataRun2_PromptLike_v0/92X_dataRun2_PromptLike_v5): 
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/
      * update of hadronic PF corrections : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3132.html

   * **RunI - RunII HLT processing** : [93X_dataRun2_HLT_frozen_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_dataRun2_HLT_frozen_v0) as [92X_dataRun2_HLT_frozen_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_dataRun2_HLT_frozen_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_dataRun2_HLT_frozen_v0/92X_dataRun2_HLT_frozen_v6): 
      * removal of offline PF hadronic and EGM corrections
      * update of magnetic field maps : https://indico.cern.ch/event/646984/contributions/2631576/