### PR TITLE
Updating GT for online (v7) and express (v6)

### DIFF
--- a/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
@@ -7,7 +7,7 @@ from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
 # https://cmsweb.cern.ch/t0wmadatasvc/prod/express_config
 # would tell you.
 GlobalTag.connect = cms.string("frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierProd)(serverurl=http://localhost:8000/FrontierProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_CONDITIONS")
-GlobalTag.globaltag = "92X_dataRun2_Express_v6"
+GlobalTag.globaltag = "92X_dataRun2_Express_v7"
 
 # ===== auto -> Automatically get the GT string from current Tier0 configuration via a Tier0Das call.
 #       This needs a valid proxy to access the cern.ch network from the .cms one.
@@ -147,7 +147,7 @@ if auto:
     if 'http_proxy' in os.environ:
         proxyurl = os.environ[ 'http_proxy' ]
     t0 = Tier0Handler( tier0Url, 5, 5, 5, proxyurl, False )
-    
+
     try:
         # Get the express GT from Tie0 DataService API
         GlobalTag.globaltag = cms.string( t0.getGlobalTag( 'express_config' ) )
@@ -157,3 +157,5 @@ if auto:
         print "Error in querying the Tier0 DataService"
         print error
         print "Falling back to the default value of the express GT: \"%s\"" % ( GlobalTag.globaltag.value(), )
+else:
+    print "Using hardcoded GT: \"%s\"" % GlobalTag.globaltag.value()

--- a/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
@@ -1,15 +1,17 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import * 
+from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
 
 # Default Express GT: it is the GT that will be used in case we are not able
 # to retrieve the one used at Tier0.
-# It should be kept in synch with Express processing at Tier0.
+# It should be kept in synch with Express processing at Tier0: what the url
+# https://cmsweb.cern.ch/t0wmadatasvc/prod/express_config
+# would tell you.
 GlobalTag.connect = cms.string("frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierProd)(serverurl=http://localhost:8000/FrontierProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_CONDITIONS")
-GlobalTag.globaltag = "92X_dataRun2_Express_v2"
+GlobalTag.globaltag = "92X_dataRun2_Express_v6"
 
 # ===== auto -> Automatically get the GT string from current Tier0 configuration via a Tier0Das call.
 #       This needs a valid proxy to access the cern.ch network from the .cms one.
-# 
+#
 auto=False
 
 # The implementation of the class is reused from the condition upload service.

--- a/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
@@ -1,3 +1,3 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import * 
-GlobalTag.globaltag = "92X_dataRun2_HLT_v4"
+from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
+GlobalTag.globaltag = "92X_dataRun2_HLT_v7"


### PR DESCRIPTION
PR for backport to 9_2_8

GT 92X_dataRun2_HLT_v7, to be used for online DQM CMSSW >= 9_2_7 

Also fixed some trailing spaces, updated the express GT and added some documentation.