### PR TITLE
HCALDQM: Fix missing HF in hcalcalib

### DIFF
--- a/DQM/HcalTasks/plugins/PedestalTask.cc
+++ b/DQM/HcalTasks/plugins/PedestalTask.cc
@@ -947,8 +947,8 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps):
 		if (did.subdet() != HcalForward) {
 			continue;
 		}
-		int digiSizeToUse = floor(digi.samples()/constants::CAPS_NUM)*
-			constants::CAPS_NUM-1;
+		// HF has 3 samples in global, so impossible to make divisible by 4
+		int digiSizeToUse = (digi.samples() >= 4 ? floor(digi.samples()/constants::CAPS_NUM)*constants::CAPS_NUM-1 : digi.samples());
 		nHF++;
 		for (int i=0; i<digiSizeToUse; i++)
 		{


### PR DESCRIPTION
HF was missing from hcalcalib PedestalTask plots due to the rounding of nsamples down to a multiple of four (to sample the capids evenly) -- this doesn't work for 3 samples, which gets rounded down to zero. This fix has PedestalTask use all samples for HF if nsamples<4. 