### PR TITLE
for neutral long-live exotic particles: only send their daughters to Geant4

### DIFF
--- a/SimG4Core/Generators/BuildFile.xml
+++ b/SimG4Core/Generators/BuildFile.xml
@@ -5,6 +5,7 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="SimDataFormats/GeneratorProducts"/>
 <use   name="boost"/>
+<use   name="heppdt"/>
 <use   name="geant4core"/>
 <use   name="rootmath"/>
 <use   name="expat"/>

--- a/SimG4Core/Generators/interface/Generator.h
+++ b/SimG4Core/Generators/interface/Generator.h
@@ -33,7 +33,7 @@ public:
 private:
 
   bool particlePassesPrimaryCuts(const G4ThreeVector& p) const;
-  bool isExotic(HepMC::GenParticle* p) const;
+  bool isExoticCharged(HepMC::GenParticle* p) const;
   void particleAssignDaughters(G4PrimaryParticle * p, HepMC::GenParticle * hp, 
 			       double length);
   void setGenId(G4PrimaryParticle* p, int id) const 


### PR DESCRIPTION
See referebce: https://indico.cern.ch/event/568875/contributions/2397935/attachments/1459125/2253274/Marshall_MC4BSM_2017.05.13.pdf