### PR TITLE
[92X] Cleanup and Streamline Alignment PV Validation tool 

### DIFF
--- a/Alignment/CommonAlignment/plugins/FilterOutLowPt.cc
+++ b/Alignment/CommonAlignment/plugins/FilterOutLowPt.cc
@@ -86,15 +86,15 @@ bool FilterOutLowPt::filter( edm::Event& iEvent, const edm::EventSetup& iSetup)
   
   if(runControl_){
     if (debugOn){
-      for(unsigned int i=0;i<runControlNumbers_.size();i++){
-	edm::LogInfo("FilterOutLowPt")<<"run number:" <<iEvent.id().run()<<" keeping runs:"<<runControlNumbers_[i]<<std::endl;
+      for(unsigned int runControlNumber : runControlNumbers_){
+	edm::LogInfo("FilterOutLowPt")<<"run number:" <<iEvent.id().run()<<" keeping runs:"<<runControlNumber<<std::endl;
       }
     }
 
-    for(unsigned int j=0;j<runControlNumbers_.size();j++){
-      if(iEvent.eventAuxiliary().run() == runControlNumbers_[j]){ 
+    for(unsigned int runControlNumber : runControlNumbers_){
+      if(iEvent.eventAuxiliary().run() == runControlNumber){ 
 	if (debugOn){
-	  edm::LogInfo("FilterOutLowPt")<<"run number"<< runControlNumbers_[j] << " match!"<<std::endl;
+	  edm::LogInfo("FilterOutLowPt")<<"run number"<< runControlNumber << " match!"<<std::endl;
 	}
 	passesRunControl = true;
 	break;
@@ -172,8 +172,8 @@ void FilterOutLowPt::endJob(){
                     
   edm::LogVerbatim("FilterOutLowPt")<<"###################################### \n"
 				    <<"# Filter Summary events accepted by run";
-  for (std::map<unsigned int,std::pair<int,int> >::iterator it=eventsInRun_.begin(); it!=eventsInRun_.end(); ++it)			       
-    edm::LogVerbatim("FilterOutLowPt")<<"# run:" << it->first << " => events tested: " << (it->second).first << " | events passed: " << (it->second).second;  
+  for (auto & it : eventsInRun_)			       
+    edm::LogVerbatim("FilterOutLowPt")<<"# run:" << it.first << " => events tested: " << (it.second).first << " | events passed: " << (it.second).second;  
   edm::LogVerbatim("FilterOutLowPt")<<"###################################### \n";
 }
 

--- a/Alignment/OfflineValidation/BuildFile.xml
+++ b/Alignment/OfflineValidation/BuildFile.xml
@@ -11,6 +11,7 @@
 
 <use   name="CLHEP"/>
 <use   name="rootmath"/>
+<use   name="rootgraphics"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/Alignment/OfflineValidation/BuildFile.xml
+++ b/Alignment/OfflineValidation/BuildFile.xml
@@ -11,7 +11,7 @@
 
 <use   name="CLHEP"/>
 <use   name="rootmath"/>
-<use   name="rootgraphics"/>
+<use   name="roothistmatrix"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/Alignment/OfflineValidation/interface/PVValidationHelpers.h
+++ b/Alignment/OfflineValidation/interface/PVValidationHelpers.h
@@ -1,0 +1,124 @@
+#ifndef ALIGNMENT_OFFLINEVALIDATION_PVVALIDATIONHELPER_H
+#define ALIGNMENT_OFFLINEVALIDATION_PVVALIDATIONHELPER_H
+
+#include <string>
+#include <vector>
+#include <map>
+#include <cassert>
+#include <utility>
+#include "TH1.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1D.h"
+
+namespace PVValHelper {
+
+  // helper data formats
+
+  enum estimator 
+    { MEAN   = 1,
+      WIDTH  = 2, 
+      MEDIAN = 3,
+      MAD    = 4,
+      UNKWN  = -1
+    };
+  
+  enum residualType 
+    { dxy = 1,
+      dx  = 2,
+      dy  = 3,
+      dz  = 4,
+      IP2D = 5,
+      resz = 6,
+      IP3D = 7,
+      d3D  = 8,
+      
+      norm_dxy = 9,
+      norm_dx  = 10,
+      norm_dy  = 11,
+      norm_dz  = 12,
+      norm_IP2D = 13,
+      norm_resz = 14,
+      norm_IP3D = 15,
+      norm_d3D  = 16,
+      END_OF_TYPES = 17,
+    };
+    
+  enum plotVariable
+    { phi    = 1,
+      eta    = 2,
+      pT     = 3,
+      pTCentral = 4,
+      ladder = 5,
+      modZ   = 6,
+      END_OF_PLOTS = 7,
+    };
+
+  struct histodetails{
+
+    int histobins;
+    std::map<std::pair<residualType,plotVariable>,std::pair<float,float>> range;
+    std::map<plotVariable,std::vector<float> > trendbins; 
+
+    void setMap(residualType type,plotVariable plot,float low,float high){
+      assert(low<high);     
+      range[std::make_pair(type,plot)] = std::make_pair(low,high);
+    }
+
+    std::pair<float,float> getRange(residualType type,plotVariable plot){
+      if (range.find(std::make_pair(type,plot)) != range.end()) {
+	return range[std::make_pair(type,plot)];
+      } else {
+	edm::LogWarning("PVValidationHelpers") << "Trying to get range for non-existent combination "<< std::endl;
+	return std::make_pair(0.,0.);
+      }
+    }
+
+    float getLow(residualType type,plotVariable plot){
+      if (range.find(std::make_pair(type,plot)) != range.end()) {
+	return range[std::make_pair(type,plot)].first;
+      } else {
+	edm::LogWarning("PVValidationHelpers") << "Trying to get low end of range for non-existent combination "<< std::endl;
+	return 0.;
+      }
+    }
+
+    float getHigh(residualType type,plotVariable plot){
+      if (range.find(std::make_pair(type,plot)) != range.end()) {
+	return range[std::make_pair(type,plot)].second;
+      } else {
+	edm::LogWarning("PVValidationHelpers") << "Trying get high end of range for non-existent combination "<< std::endl;
+	return 0.;
+      }
+    }
+  };
+
+  typedef std::tuple<std::string,std::string,std::string>  plotLabels;
+
+  // helper methods
+  
+  void add(std::map<std::string,TH1*>& h, TH1* hist);
+  
+  void fill(std::map<std::string, TH1*>& h,const std::string& s, double x);
+  
+  void fill(std::map<std::string, TH1*>& h,const std::string& s, double x, double y);
+
+  void fillByIndex(std::vector<TH1F*>& h, unsigned int index, double x,std::string tag="");
+  
+  void shrinkHistVectorToFit(std::vector<TH1F*>&h, unsigned int desired_size);
+    
+  plotLabels getTypeString (residualType type);  
+
+  plotLabels getVarString (plotVariable var);
+
+  std::vector<float> generateBins(int n, float start, float range);
+
+  Measurement1D getMedian(TH1F *histo);
+
+  Measurement1D getMAD(TH1F *histo);
+
+  std::pair<Measurement1D, Measurement1D> fitResiduals(TH1 *hist);
+
+};
+
+#endif

--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <iostream>
 #include <fstream>
+#include <cassert>
 #include <Riostream.h>
 #include "TFile.h"
 #include "TPaveStats.h"
@@ -291,7 +292,8 @@ void setStyle();
 
 ofstream outfile("FittedDeltaZ.txt");
 
-Int_t nBins_  = 48;
+Int_t nBins_     = 48;
+Int_t nLadders_  = 20;
 const Int_t nPtBins_ = 48;
 Float_t _boundMin   = -0.5;
 Float_t _boundSx    = (nBins_/4.)-0.5;
@@ -478,11 +480,27 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
   TH1F* dzPtResiduals[nFiles_][nPtBins_];
   TH1F* dxyPtResiduals[nFiles_][nPtBins_];
 
+  // dca residuals vs module number/ladder
+  TH1F* dzNormLadderResiduals[nFiles_][nLadders_];
+  TH1F* dxyNormLadderResiduals[nFiles_][nLadders_];
+  
+  TH1F* dzLadderResiduals[nFiles_][nLadders_];
+  TH1F* dxyLadderResiduals[nFiles_][nLadders_];
+
+  TH1F* dzNormModZResiduals[nFiles_][8];
+  TH1F* dxyNormModZResiduals[nFiles_][8];
+  
+  TH1F* dzModZResiduals[nFiles_][8];
+  TH1F* dxyModZResiduals[nFiles_][8];
+
   // for sanity checks
   TH1F* theEtaHistos[nFiles_];
   TH1F* thebinsHistos[nFiles_];
+  TH1F* theLaddersHistos[nFiles_];
+
   double theEtaMax_[nFiles_];
   double theNBINS[nFiles_];
+  double theLadders[nFiles_];
 
   TTimeStamp initialization_done;
 
@@ -496,7 +514,7 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
 
     fins[i]->cd("PVValidation/EventFeatures/");
 
-    if(fins[i]->GetListOfKeys()->Contains("PVValidation/EventFeatures/etaMax")){
+    if(gDirectory->GetListOfKeys()->Contains("etaMax")){
       gDirectory->GetObject("etaMax",theEtaHistos[i]);
       theEtaMax_[i]   = theEtaHistos[i]->GetBinContent(1);
     } else {
@@ -510,6 +528,15 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
     } else {
       theNBINS[i] = 48.;
       std::cout<<"File n. "<<i<<" getting the default n. of bins: "<< theNBINS[i]<<std::endl;
+    }
+
+    if(gDirectory->GetListOfKeys()->Contains("nladders")){
+      gDirectory->GetObject("nladders",theLaddersHistos[i]);
+      theLadders[i] = theLaddersHistos[i]->GetBinContent(1);
+      std::cout<<"File n. "<<i<<" has theNLadders["<<i<<"] = "<< theLadders[i]<<std::endl;
+    } else {
+      theLadders[i] = -1.;
+      std::cout<<"File n. "<<i<<" getting the default n. ladders: "<< theLadders[i]<<std::endl;
     }
 
     // get the non-differential residuals plots
@@ -528,27 +555,14 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
 	// DCA absolute residuals
 
 	fins[i]->cd("PVValidation/Abs_Transv_Phi_Residuals/");
-	
 	gDirectory->GetObject(Form("histo_dxy_phi_plot%i",j),dxyPhiResiduals[i][j]);
 	gDirectory->GetObject(Form("histo_dx_phi_plot%i",j),dxPhiResiduals[i][j]);
 	gDirectory->GetObject(Form("histo_dy_phi_plot%i",j),dyPhiResiduals[i][j]);
-	
-	/*
-	dxyPhiResiduals[i][j] = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_Phi_Residuals/histo_dxy_phi_plot%i",j));
-	dxPhiResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_Phi_Residuals/histo_dx_phi_plot%i",j));
-	dyPhiResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_Phi_Residuals/histo_dy_phi_plot%i",j));
-	*/
-	
+		
 	fins[i]->cd("PVValidation/Abs_Transv_Eta_Residuals/");
 	gDirectory->GetObject(Form("histo_dxy_eta_plot%i",j),dxyEtaResiduals[i][j]);
 	gDirectory->GetObject(Form("histo_dx_eta_plot%i",j),dxEtaResiduals[i][j]);
 	gDirectory->GetObject(Form("histo_dy_eta_plot%i",j),dyEtaResiduals[i][j]);
-
-	/*
-	dxyEtaResiduals[i][j] = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_Eta_Residuals/histo_dxy_eta_plot%i",j));
-	dxEtaResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_Eta_Residuals/histo_dx_eta_plot%i",j));				
-	dyEtaResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_Eta_Residuals/histo_dy_eta_plot%i",j));
-	*/
 
 	dzPhiResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Long_Phi_Residuals/histo_dz_phi_plot%i",j));
 	dzEtaResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Long_Eta_Residuals/histo_dz_eta_plot%i",j));
@@ -565,14 +579,6 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
 
 	  for(Int_t k=0;k<theNBINS[i];k++){
 	  
-	    /*
-	    dxyMapResiduals[i][j][k] = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_DoubleDiffResiduals/histo_dxy_eta_plot%i_phi_plot%i",j,k));	  
-	    dzMapResiduals[i][j][k]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_DoubleDiffResiduals/histo_dz_eta_plot%i_phi_plot%i",j,k));  
-	   
-	    dxyNormMapResiduals[i][j][k] = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_DoubleDiffResiduals/histo_norm_dxy_eta_plot%i_phi_plot%i",j,k));  
-	    dzNormMapResiduals[i][j][k]  = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_DoubleDiffResiduals/histo_norm_dz_eta_plot%i_phi_plot%i",j,k));
-	    */
-
 	    // absolute residuals
 	    fins[i]->cd("PVValidation/Abs_DoubleDiffResiduals/");
 	    gDirectory->GetObject(Form("histo_dxy_eta_plot%i_phi_plot%i",j,k),dxyMapResiduals[i][j][k]);
@@ -605,12 +611,14 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
 	  for(Int_t k=0;k<theNBINS[i];k++){
 
 	    // absolute residuals
-	    dxyMapResiduals[i][j][k] = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_DoubleDiffResiduals/histo_dxy_eta_plot%i_phi_plot%i",j,k));
-	    dzMapResiduals[i][j][k]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_DoubleDiffResiduals/histo_dz_eta_plot%i_phi_plot%i",j,k));  
+	    fins[i]->cd("PVValidation/Abs_DoubleDiffResiduals");
+	    gDirectory->GetObject(Form("PVValidation/Abs_DoubleDiffResiduals/histo_dxy_eta_plot%i_phi_plot%i",j,k),dxyMapResiduals[i][j][k]);
+	    gDirectory->GetObject(Form("PVValidation/Abs_DoubleDiffResiduals/histo_dz_eta_plot%i_phi_plot%i",j,k),dzMapResiduals[i][j][k]);  
 	    
 	    // normalized residuals
-	    dxyNormMapResiduals[i][j][k] = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_DoubleDiffResiduals/histo_norm_dxy_eta_plot%i_phi_plot%i",j,k));  
-	    dzNormMapResiduals[i][j][k]  = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_DoubleDiffResiduals/histo_norm_dz_eta_plot%i_phi_plot%i",j,k));
+	    fins[i]->cd("PVValidation/Norm_DoubleDiffResiduals");
+	    gDirectory->GetObject(Form("PVValidation/Norm_DoubleDiffResiduals/histo_norm_dxy_eta_plot%i_phi_plot%i",j,k),dxyNormMapResiduals[i][j][k]);  
+	    gDirectory->GetObject(Form("PVValidation/Norm_DoubleDiffResiduals/histo_norm_dz_eta_plot%i_phi_plot%i",j,k),dzNormMapResiduals[i][j][k]);
 	  }
 	} // if do2DMaps
       } 
@@ -623,9 +631,34 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
       dxyPtResiduals[i][l]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_pT_Residuals/histo_dxy_pT_plot%i",l));
       dzPtResiduals[i][l]   = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Long_pT_Residuals/histo_dz_pT_plot%i",l));
 
-      dxyNormPtResiduals[i][l]  = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Transv_pT_Residuals/histo_normdxy_pT_plot%i",l));
-      dzNormPtResiduals[i][l]   = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Long_pT_Residuals/histo_normdz_pT_plot%i",l));
+      dxyNormPtResiduals[i][l]  = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Transv_pT_Residuals/histo_norm_dxy_pT_plot%i",l));
+      dzNormPtResiduals[i][l]   = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Long_pT_Residuals/histo_norm_dz_pT_plot%i",l));
     
+    }
+
+    // residuals vs module number / ladder
+
+    if(theLadders[i]>0) {
+
+      for (Int_t iLadder=0;iLadder<theLadders[i];iLadder++){
+	
+	dzNormLadderResiduals[i][iLadder]  =  (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Long_ladder_Residuals/histo_norm_dz_ladder_plot%i",iLadder));
+	dxyNormLadderResiduals[i][iLadder] =  (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Transv_ladder_Residuals/histo_norm_dxy_ladder_plot%i",iLadder));
+	
+	dzLadderResiduals[i][iLadder]      =  (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Long_ladder_Residuals/histo_dz_ladder_plot%i",iLadder));
+	dxyLadderResiduals[i][iLadder]     =  (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_ladderNoOverlap_Residuals/histo_dxy_ladder_plot%i",iLadder));
+	
+      }
+      
+      for (Int_t iMod=0;iMod<8;iMod++){
+	
+	dzNormModZResiduals[i][iMod]  =  (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Long_modZ_Residuals/histo_norm_dz_modZ_plot%i",iMod));
+	dxyNormModZResiduals[i][iMod] =  (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Transv_modZ_Residuals/histo_norm_dxy_modZ_plot%i",iMod));
+	
+	dzModZResiduals[i][iMod]      =  (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Long_modZ_Residuals/histo_dz_modZ_plot%i",iMod));
+	dxyModZResiduals[i][iMod]     =  (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_modZ_Residuals/histo_dxy_modZ_plot%i",iMod));
+	
+      }
     }
 
     // close the files after retrieving them
@@ -668,6 +701,20 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
     std::cout<<"======================================================"<<std::endl;
   }
 
+  // checks if the geometries are consistent to produce the ladder plots
+  if(check(theLadders,nFiles_)){
+    std::cout<<"======================================================"<<std::endl;
+    std::cout<<"FitPVResiduals::FitPVResiduals(): the number of ladders is different"<<std::endl;
+    std::cout<<"won't do the ladder analysis..."<<std::endl;
+    std::cout<<"======================================================"<<std::endl;
+    nLadders_ = -1;
+  } else {
+    nLadders_ = theLadders[0];
+    std::cout<<"======================================================"<<std::endl;
+    std::cout<<"FitPVResiduals::FitPVResiduals(): the number of ladders is: "<< nLadders_ << std::endl;
+    std::cout<<"======================================================"<<std::endl;
+  }
+
   Double_t highedge=nBins_-0.5;
   Double_t lowedge=-0.5;
   
@@ -703,6 +750,18 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
   TH1F* dzPtMeanTrend[nFiles_];   
   TH1F* dzPtWidthTrend[nFiles_]; 
 
+  // vs ladder and module number
+
+  TH1F* dxyLadderMeanTrend[nFiles_];  
+  TH1F* dxyLadderWidthTrend[nFiles_]; 
+  TH1F* dzLadderMeanTrend[nFiles_];   
+  TH1F* dzLadderWidthTrend[nFiles_]; 
+
+  TH1F* dxyModZMeanTrend[nFiles_];  
+  TH1F* dxyModZWidthTrend[nFiles_]; 
+  TH1F* dzModZMeanTrend[nFiles_];   
+  TH1F* dzModZWidthTrend[nFiles_]; 
+
   // DCA normalized
 
   TH1F* dxyNormPhiMeanTrend[nFiles_];  
@@ -719,6 +778,16 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
   TH1F* dxyNormPtWidthTrend[nFiles_]; 
   TH1F* dzNormPtMeanTrend[nFiles_];   
   TH1F* dzNormPtWidthTrend[nFiles_];  
+
+  TH1F* dxyNormLadderMeanTrend[nFiles_];  
+  TH1F* dxyNormLadderWidthTrend[nFiles_]; 
+  TH1F* dzNormLadderMeanTrend[nFiles_];   
+  TH1F* dzNormLadderWidthTrend[nFiles_]; 
+
+  TH1F* dxyNormModZMeanTrend[nFiles_];  
+  TH1F* dxyNormModZWidthTrend[nFiles_]; 
+  TH1F* dzNormModZMeanTrend[nFiles_];   
+  TH1F* dzNormModZWidthTrend[nFiles_];
 
   // 2D maps
 
@@ -776,27 +845,55 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
     dzEtaMeanTrend[i]   = new TH1F(Form("means_dz_eta_%i",i),"#LT d_{z} #GT vs #eta sector;track #eta;#LT d_{z} #GT [#mum]",nBins_,lowedge,highedge); 
     dzEtaWidthTrend[i]  = new TH1F(Form("widths_dz_eta_%i",i),"#sigma(d_{xy}) vs #eta sector;track #eta;#sigma(d_{z}) [#mum]",nBins_,lowedge,highedge);
 
-    dxyPtMeanTrend[i]  = new TH1F(Form("means_dxy_pT_%i",i),"#LT d_{xy} #GT vs p_{T} sector;track p_{T} [GeV];#LT d_{xy} #GT [#mum]",nPtBins_,mypT_bins);
-    dxyPtWidthTrend[i] = new TH1F(Form("widths_dxy_pT_%i",i),"#sigma(d_{xy}) vs p_{T} sector;track p_{T} [GeV];#sigma(d_{xy}) [#mum]",nPtBins_,mypT_bins);
-    dzPtMeanTrend[i]   = new TH1F(Form("means_dz_pT_%i",i),"#LT d_{z} #GT vs p_{T} sector;track p_{T} [GeV];#LT d_{z} #GT [#mum]",nPtBins_,mypT_bins); 
-    dzPtWidthTrend[i]  = new TH1F(Form("widths_dz_pT_%i",i),"#sigma(d_{xy}) vs p_{T} sector;track p_{T} [GeV];#sigma(d_{z}) [#mum]",nPtBins_,mypT_bins);
+    dxyPtMeanTrend[i]   = new TH1F(Form("means_dxy_pT_%i",i),"#LT d_{xy} #GT vs p_{T} sector;track p_{T} [GeV];#LT d_{xy} #GT [#mum]",nPtBins_,mypT_bins);
+    dxyPtWidthTrend[i]  = new TH1F(Form("widths_dxy_pT_%i",i),"#sigma(d_{xy}) vs p_{T} sector;track p_{T} [GeV];#sigma(d_{xy}) [#mum]",nPtBins_,mypT_bins);
+    dzPtMeanTrend[i]    = new TH1F(Form("means_dz_pT_%i",i),"#LT d_{z} #GT vs p_{T} sector;track p_{T} [GeV];#LT d_{z} #GT [#mum]",nPtBins_,mypT_bins); 
+    dzPtWidthTrend[i]   = new TH1F(Form("widths_dz_pT_%i",i),"#sigma(d_{z}) vs p_{T} sector;track p_{T} [GeV];#sigma(d_{z}) [#mum]",nPtBins_,mypT_bins);
+
+    if(nLadders_>0){
+
+      dxyLadderMeanTrend[i]  = new TH1F(Form("means_dxy_ladder_%i",i),"#LT d_{xy} #GT vs Layer 1 ladder;ladder number;#LT d_{xy} #GT [#mum]",theLadders[i],0.,theLadders[i]);
+      dxyLadderWidthTrend[i] = new TH1F(Form("widths_dxy_ladder_%i",i),"#sigma(d_{xy}) vs Layer 1 ladder;ladder number;#sigma(d_{xy}) [#mum]",theLadders[i],0.,theLadders[i]);
+      dzLadderMeanTrend[i]   = new TH1F(Form("means_dz_ladder_%i",i),"#LT d_{z} #GT vs Layer 1 ladder;ladder number;#LT d_{z} #GT [#mum]",theLadders[i],0.,theLadders[i]);  
+      dzLadderWidthTrend[i]  = new TH1F(Form("widths_dz_ladder_%i",i),"#sigma(d_{z}) vs Layer 1 ladder;ladder number;#sigma(d_{z}) [#mum]",theLadders[i],0.,theLadders[i]);
+      
+      dxyModZMeanTrend[i]    = new TH1F(Form("means_dxy_modZ_%i",i),"#LT d_{xy} #GT vs Layer 1 module number;module number;#LT d_{xy} #GT [#mum]",8,0.,8.);
+      dxyModZWidthTrend[i]   = new TH1F(Form("widths_dxy_modZ_%i",i),"#sigma(d_{xy}) vs Layer 1 module number;module number;#sigma(d_{xy}) [#mum]",8,0.,8.);
+      dzModZMeanTrend[i]     = new TH1F(Form("means_dz_modZ_%i",i),"#LT d_{z} #GT vs Layer 1 module number;module number;#LT d_{z} #GT [#mum]",8,0.,8.);  
+      dzModZWidthTrend[i]    = new TH1F(Form("widths_dz_modZ_%i",i),"#sigma(d_{z}) vs Layer 1 module number;module number;#sigma(d_{z}) [#mum]",8,0.,8.);
+
+    }
 
     // DCA normalized trend plots
 
-    dxyNormPhiMeanTrend[i] = new TH1F(Form("means_dxyNorm_phi_%i",i),"#LT d_{xy}/#sigma_{d_{xy}} #GT vs #phi sector;track #phi [rad];#LT d_{xy}/#sigma_{d_{xy}} #GT [#mum]",nBins_,lowedge,highedge); 
-    dxyNormPhiWidthTrend[i]= new TH1F(Form("widths_dxyNorm_phi_%i",i),"#sigma(d_{xy}/#sigma_{d_{xy}}) vs #phi sector;track #phi [rad];#sigma(d_{xy}/#sigma_{d_{xy}}) [#mum]",nBins_,lowedge,highedge);
-    dzNormPhiMeanTrend[i]  = new TH1F(Form("means_dzNorm_phi_%i",i),"#LT d_{z}/#sigma_{d_{z}} #GT vs #phi sector;track #phi [rad];#LT d_{z}/#sigma_{d_{z}} #GT [#mum]",nBins_,lowedge,highedge); 
-    dzNormPhiWidthTrend[i] = new TH1F(Form("widths_dzNorm_phi_%i",i),"#sigma(d_{z}/#sigma_{d_{z}}) vs #phi sector;track #phi [rad];#sigma(d_{z}/#sigma_{d_{z}}) [#mum]",nBins_,lowedge,highedge);
+    dxyNormPhiMeanTrend[i] = new TH1F(Form("means_dxyNorm_phi_%i",i),"#LT d_{xy}/#sigma_{d_{xy}} #GT vs #phi sector;track #phi [rad];#LT d_{xy}/#sigma_{d_{xy}} #GT",nBins_,lowedge,highedge); 
+    dxyNormPhiWidthTrend[i]= new TH1F(Form("widths_dxyNorm_phi_%i",i),"#sigma(d_{xy}/#sigma_{d_{xy}}) vs #phi sector;track #phi [rad];#sigma(d_{xy}/#sigma_{d_{xy}})",nBins_,lowedge,highedge);
+    dzNormPhiMeanTrend[i]  = new TH1F(Form("means_dzNorm_phi_%i",i),"#LT d_{z}/#sigma_{d_{z}} #GT vs #phi sector;track #phi [rad];#LT d_{z}/#sigma_{d_{z}} #GT",nBins_,lowedge,highedge); 
+    dzNormPhiWidthTrend[i] = new TH1F(Form("widths_dzNorm_phi_%i",i),"#sigma(d_{z}/#sigma_{d_{z}}) vs #phi sector;track #phi [rad];#sigma(d_{z}/#sigma_{d_{z}})",nBins_,lowedge,highedge);
     
-    dxyNormEtaMeanTrend[i] = new TH1F(Form("means_dxyNorm_eta_%i",i),"#LT d_{xy}/#sigma_{d_{xy}} #GT vs #eta sector;track #eta;#LT d_{xy}/#sigma_{d_{xy}} #GT [#mum]",nBins_,lowedge,highedge);
-    dxyNormEtaWidthTrend[i]= new TH1F(Form("widths_dxyNorm_eta_%i",i),"#sigma(d_{xy}/#sigma_{d_{xy}}) vs #eta sector;track #eta;#sigma(d_{xy}/#sigma_{d_{xy}}) [#mum]",nBins_,lowedge,highedge);
-    dzNormEtaMeanTrend[i]  = new TH1F(Form("means_dzNorm_eta_%i",i),"#LT d_{z}/#sigma_{d_{z}} #GT vs #eta sector;track #eta;#LT d_{z}/#sigma_{d_{z}} #GT [#mum]",nBins_,lowedge,highedge); 
-    dzNormEtaWidthTrend[i] = new TH1F(Form("widths_dzNorm_eta_%i",i),"#sigma(d_{z}/#sigma_{d_{z}}) vs #eta sector;track #eta;#sigma(d_{z}/#sigma_{d_{z}}) [#mum]",nBins_,lowedge,highedge);
+    dxyNormEtaMeanTrend[i] = new TH1F(Form("means_dxyNorm_eta_%i",i),"#LT d_{xy}/#sigma_{d_{xy}} #GT vs #eta sector;track #eta;#LT d_{xy}/#sigma_{d_{xy}} #GT",nBins_,lowedge,highedge);
+    dxyNormEtaWidthTrend[i]= new TH1F(Form("widths_dxyNorm_eta_%i",i),"#sigma(d_{xy}/#sigma_{d_{xy}}) vs #eta sector;track #eta;#sigma(d_{xy}/#sigma_{d_{xy}})",nBins_,lowedge,highedge);
+    dzNormEtaMeanTrend[i]  = new TH1F(Form("means_dzNorm_eta_%i",i),"#LT d_{z}/#sigma_{d_{z}} #GT vs #eta sector;track #eta;#LT d_{z}/#sigma_{d_{z}} #GT",nBins_,lowedge,highedge); 
+    dzNormEtaWidthTrend[i] = new TH1F(Form("widths_dzNorm_eta_%i",i),"#sigma(d_{z}/#sigma_{d_{z}}) vs #eta sector;track #eta;#sigma(d_{z}/#sigma_{d_{z}})",nBins_,lowedge,highedge);
     
-    dxyNormPtMeanTrend[i] = new TH1F(Form("means_dxyNorm_pT_%i",i),"#LT d_{xy}/#sigma_{d_{xy}} #GT vs p_{T} sector;track p_{T} [GeV];#LT d_{xy}/#sigma_{d_{xy}} #GT [#mum]",nPtBins_,mypT_bins);
-    dxyNormPtWidthTrend[i]= new TH1F(Form("widths_dxyNorm_pT_%i",i),"#sigma(d_{xy}/#sigma_{d_{xy}}) vs p_{T} sector;track p_{T} [GeV];#sigma(d_{xy}/#sigma_{d_{xy}}) [#mum]",nPtBins_,mypT_bins);
-    dzNormPtMeanTrend[i]  = new TH1F(Form("means_dzNorm_pT_%i",i),"#LT d_{z}/#sigma_{d_{z}} #GT vs p_{T} sector;track p_{T} [GeV];#LT d_{z}/#sigma_{d_{z}} #GT [#mum]",nPtBins_,mypT_bins); 
-    dzNormPtWidthTrend[i] = new TH1F(Form("widths_dzNorm_pT_%i",i),"#sigma(d_{z}/#sigma_{d_{z}}) vs p_{T} sector;track p_{T} [GeV];#sigma(d_{z}/#sigma_{d_{z}}) [#mum]",nPtBins_,mypT_bins);
+    dxyNormPtMeanTrend[i] = new TH1F(Form("means_dxyNorm_pT_%i",i),"#LT d_{xy}/#sigma_{d_{xy}} #GT vs p_{T} sector;track p_{T} [GeV];#LT d_{xy}/#sigma_{d_{xy}} #GT",nPtBins_,mypT_bins);
+    dxyNormPtWidthTrend[i]= new TH1F(Form("widths_dxyNorm_pT_%i",i),"#sigma(d_{xy}/#sigma_{d_{xy}}) vs p_{T} sector;track p_{T} [GeV];#sigma(d_{xy}/#sigma_{d_{xy}})",nPtBins_,mypT_bins);
+    dzNormPtMeanTrend[i]  = new TH1F(Form("means_dzNorm_pT_%i",i),"#LT d_{z}/#sigma_{d_{z}} #GT vs p_{T} sector;track p_{T} [GeV];#LT d_{z}/#sigma_{d_{z}} #GT",nPtBins_,mypT_bins); 
+    dzNormPtWidthTrend[i] = new TH1F(Form("widths_dzNorm_pT_%i",i),"#sigma(d_{z}/#sigma_{d_{z}}) vs p_{T} sector;track p_{T} [GeV];#sigma(d_{z}/#sigma_{d_{z}})",nPtBins_,mypT_bins);
+
+    if(nLadders_>0){
+    
+      dxyNormLadderMeanTrend[i]  = new TH1F(Form("means_dxyNorm_ladder_%i",i),"#LT d_{xy}/#sigma_{d_{xy}} #GT vs Layer 1 ladder;ladder number;#LT d_{xy}/#sigma_{d_{xy}} #GT",theLadders[i],0.,theLadders[i]);
+      dxyNormLadderWidthTrend[i] = new TH1F(Form("widths_dxyNorm_ladder_%i",i),"#sigma(d_{xy}/#sigma_{d_{xy}}) vs Layer 1 ladder;ladder number;#sigma(d_{xy}/#sigma_{d_{xy}})",theLadders[i],0.,theLadders[i]);
+      dzNormLadderMeanTrend[i]   = new TH1F(Form("means_dzNorm_ladder_%i",i),"#LT d_{z}/#sigma_{d_{z}} #GT vs Layer 1 ladder;ladder number;#LT d_{z}/#sigma_{d_{z}} #GT",theLadders[i],0.,theLadders[i]);  
+      dzNormLadderWidthTrend[i]  = new TH1F(Form("widths_dzNorm_ladder_%i",i),"#sigma(d_{z}/#sigma_{d_{z}}) vs Layer 1 ladder;ladder number;#sigma(d_{z}/#sigma_{d_{z}})",theLadders[i],0.,theLadders[i]);
+      
+      dxyNormModZMeanTrend[i]    = new TH1F(Form("means_dxyNorm_modZ_%i",i),"#LT d_{xy}/#sigma_{d_{xy}} #GT vs Layer 1 module number;module number;#LT d_{xy}/#sigma_{d_{xy}} #GT",8,0.,8.);
+      dxyNormModZWidthTrend[i]   = new TH1F(Form("widths_dxyNorm_modZ_%i",i),"#sigma(d_{xy}/#sigma_{d_{xy}}) vs Layer 1 module number;module number;#sigma(d_{xy}/#sigma_{d_{xy}})",8,0.,8.);
+      dzNormModZMeanTrend[i]     = new TH1F(Form("means_dzNorm_modZ_%i",i),"#LT d_{z}/#sigma_{d_{z}} #GT vs Layer 1 module number;module number;#LT d_{z}/#sigma_{d_{z}} #GT",8,0.,8.);  
+      dzNormModZWidthTrend[i]    = new TH1F(Form("widths_dzNorm_modZ_%i",i),"#sigma(d_{z}/#sigma_{d_{z}}) vs Layer 1 module number;module number;#sigma(d_{z}/#sigma_{d_{z}})",8,0.,8.);
+
+    }
 
     // 2D maps
     dxyMeanMap[i]      = new TH2F(Form("means_dxy_map_%i",i), "#LT d_{xy} #GT map;track #eta;track #phi [rad];#LT d_{xy} #GT [#mum]",nBins_,lowedge,highedge,nBins_,lowedge,highedge);		       
@@ -846,6 +943,18 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
     FillTrendPlot(dzPtMeanTrend[i]  ,dzPtResiduals[i] ,params::MEAN,"pT",nPtBins_); 
     FillTrendPlot(dzPtWidthTrend[i] ,dzPtResiduals[i] ,params::WIDTH,"pT",nPtBins_);
 
+    if(nLadders_>0){
+      FillTrendPlot(dxyLadderMeanTrend[i] ,dxyLadderResiduals[i],params::MEAN,"else",nLadders_); 
+      FillTrendPlot(dxyLadderWidthTrend[i],dxyLadderResiduals[i],params::WIDTH,"else",nLadders_);
+      FillTrendPlot(dzLadderMeanTrend[i]  ,dzLadderResiduals[i] ,params::MEAN,"else",nLadders_); 
+      FillTrendPlot(dzLadderWidthTrend[i] ,dzLadderResiduals[i] ,params::WIDTH,"else",nLadders_);
+      
+      FillTrendPlot(dxyModZMeanTrend[i] ,dxyModZResiduals[i],params::MEAN,"else",8); 
+      FillTrendPlot(dxyModZWidthTrend[i],dxyModZResiduals[i],params::WIDTH,"else",8);
+      FillTrendPlot(dzModZMeanTrend[i]  ,dzModZResiduals[i] ,params::MEAN,"else",8); 
+      FillTrendPlot(dzModZWidthTrend[i] ,dzModZResiduals[i] ,params::WIDTH,"else",8);
+    }
+
     MakeNiceTrendPlotStyle(dxyPhiMeanTrend[i],colors[i],markers[i]);
     MakeNiceTrendPlotStyle(dxyPhiWidthTrend[i],colors[i],markers[i]);
     MakeNiceTrendPlotStyle(dxPhiMeanTrend[i],colors[i],markers[i]);
@@ -869,6 +978,18 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
     MakeNiceTrendPlotStyle(dzPtMeanTrend[i],colors[i],markers[i]);
     MakeNiceTrendPlotStyle(dzPtWidthTrend[i],colors[i],markers[i]);
 
+    if(nLadders_>0){
+      MakeNiceTrendPlotStyle(dxyLadderMeanTrend[i],colors[i],markers[i]); 
+      MakeNiceTrendPlotStyle(dxyLadderWidthTrend[i],colors[i],markers[i]);
+      MakeNiceTrendPlotStyle(dzLadderMeanTrend[i],colors[i],markers[i]);  
+      MakeNiceTrendPlotStyle(dzLadderWidthTrend[i],colors[i],markers[i]); 
+      
+      MakeNiceTrendPlotStyle(dxyModZMeanTrend[i] ,colors[i],markers[i]);
+      MakeNiceTrendPlotStyle(dxyModZWidthTrend[i],colors[i],markers[i]);
+      MakeNiceTrendPlotStyle(dzModZMeanTrend[i]  ,colors[i],markers[i]);
+      MakeNiceTrendPlotStyle(dzModZWidthTrend[i] ,colors[i],markers[i]);
+    }      
+
     // DCA normalized
 
     FillTrendPlot(dxyNormPhiMeanTrend[i] ,dxyNormPhiResiduals[i],params::MEAN,"phi",nBins_);  
@@ -885,6 +1006,18 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
     FillTrendPlot(dxyNormPtWidthTrend[i],dxyNormPtResiduals[i],params::WIDTH,"pT",nPtBins_);       
     FillTrendPlot(dzNormPtMeanTrend[i]  ,dzNormPtResiduals[i] ,params::MEAN,"pT",nPtBins_);       
     FillTrendPlot(dzNormPtWidthTrend[i] ,dzNormPtResiduals[i] ,params::WIDTH,"pT",nPtBins_);
+    
+    if(nLadders_>0){
+      FillTrendPlot(dxyNormLadderMeanTrend[i] ,dxyNormLadderResiduals[i],params::MEAN,"else",nLadders_); 
+      FillTrendPlot(dxyNormLadderWidthTrend[i],dxyNormLadderResiduals[i],params::WIDTH,"else",nLadders_);
+      FillTrendPlot(dzNormLadderMeanTrend[i]  ,dzNormLadderResiduals[i] ,params::MEAN,"else",nLadders_); 
+      FillTrendPlot(dzNormLadderWidthTrend[i] ,dzNormLadderResiduals[i] ,params::WIDTH,"else",nLadders_);
+      
+      FillTrendPlot(dxyNormModZMeanTrend[i] ,dxyNormModZResiduals[i],params::MEAN,"else",8); 
+      FillTrendPlot(dxyNormModZWidthTrend[i],dxyNormModZResiduals[i],params::WIDTH,"else",8);
+      FillTrendPlot(dzNormModZMeanTrend[i]  ,dzNormModZResiduals[i] ,params::MEAN,"else",8); 
+      FillTrendPlot(dzNormModZWidthTrend[i] ,dzNormModZResiduals[i] ,params::WIDTH,"else",8);
+    }      
 
     MakeNiceTrendPlotStyle(dxyNormPhiMeanTrend[i],colors[i],markers[i]);
     MakeNiceTrendPlotStyle(dxyNormPhiWidthTrend[i],colors[i],markers[i]);
@@ -901,6 +1034,18 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
     MakeNiceTrendPlotStyle(dzNormPtMeanTrend[i],colors[i],markers[i]);
     MakeNiceTrendPlotStyle(dzNormPtWidthTrend[i],colors[i],markers[i]);
     
+    if(nLadders_>0){
+      MakeNiceTrendPlotStyle(dxyNormLadderMeanTrend[i],colors[i],markers[i]); 
+      MakeNiceTrendPlotStyle(dxyNormLadderWidthTrend[i],colors[i],markers[i]);
+      MakeNiceTrendPlotStyle(dzNormLadderMeanTrend[i],colors[i],markers[i]);  
+      MakeNiceTrendPlotStyle(dzNormLadderWidthTrend[i],colors[i],markers[i]); 
+      
+      MakeNiceTrendPlotStyle(dxyNormModZMeanTrend[i] ,colors[i],markers[i]);
+      MakeNiceTrendPlotStyle(dxyNormModZWidthTrend[i],colors[i],markers[i]);
+      MakeNiceTrendPlotStyle(dzNormModZMeanTrend[i]  ,colors[i],markers[i]);
+      MakeNiceTrendPlotStyle(dzNormModZWidthTrend[i] ,colors[i],markers[i]);
+    }
+
     // maps
 
     //TTimeStamp filling1D_done;
@@ -1039,6 +1184,15 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
   dzEtaTrend->SaveAs("dzEtaTrend_"+theStrDate+theStrAlignment+".pdf");
   dzEtaTrend->SaveAs("dzEtaTrend_"+theStrDate+theStrAlignment+".png");
 
+  if(nLadders_>0){
+    TCanvas *dxyLadderTrend = new TCanvas("dxyLadderTrend","dxyLadderTrend",600,600);
+    arrangeCanvas(dxyLadderTrend,dxyLadderMeanTrend,dxyLadderWidthTrend,nFiles_,LegLabels,theDate,true,setAutoLimits);
+    
+    dxyLadderTrend->SaveAs("dxyLadderTrend_"+theStrDate+theStrAlignment+".pdf");
+    dxyLadderTrend->SaveAs("dxyLadderTrend_"+theStrDate+theStrAlignment+".png");
+    dxyLadderTrend->SaveAs("dxyLadderTrend_"+theStrDate+theStrAlignment+".root");
+  }    
+
   // fit dz vs phi
   TCanvas *dzPhiTrendFit = new TCanvas("dzPhiTrendFit","dzPhiTrendFit",1200,600);
   arrangeFitCanvas(dzPhiTrendFit,dzPhiMeanTrend,nFiles_,LegLabels,theDate);
@@ -1132,6 +1286,18 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
   BiasesCanvasXY->SaveAs("BiasesCanvasXY_"+theStrDate+theStrAlignment+".pdf");
   BiasesCanvasXY->SaveAs("BiasesCanvasXY_"+theStrDate+theStrAlignment+".png");
 
+  // Bias plots (ladders and module number)
+
+  if(nLadders_>0){
+    TCanvas *BiasesCanvasLayer1 = new TCanvas("BiasCanvasLayer1","BiasCanvasLayer1",1200,1200);
+    arrangeBiasCanvas(BiasesCanvasLayer1,dxyLadderMeanTrend,dzLadderMeanTrend,dxyModZMeanTrend, dzModZMeanTrend,nFiles_,LegLabels,theDate,setAutoLimits);
+    
+    BiasesCanvasLayer1->SaveAs("BiasesCanvasLayer1_"+theStrDate+theStrAlignment+".pdf");
+    BiasesCanvasLayer1->SaveAs("BiasesCanvasLayer1_"+theStrDate+theStrAlignment+".png");
+
+    delete BiasesCanvasLayer1;
+  }
+
   TCanvas *dxyPhiBiasCanvas = new TCanvas("dxyPhiBiasCanvas","dxyPhiBiasCanvas",600,600);
   TCanvas *dxyEtaBiasCanvas = new TCanvas("dxyEtaBiasCanvas","dxyEtaBiasCanvas",600,600);
   TCanvas *dzPhiBiasCanvas  = new TCanvas("dzPhiBiasCanvas","dzPhiBiasCanvas",600,600);
@@ -1175,6 +1341,17 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
   ResolutionsCanvasXY->SaveAs("ResolutionsCanvasXY_"+theStrDate+theStrAlignment+".pdf");
   ResolutionsCanvasXY->SaveAs("ResolutionsCanvasXY_"+theStrDate+theStrAlignment+".png");
 
+  if(nLadders_>0){
+
+    TCanvas *ResolutionsCanvasLayer1 = new TCanvas("ResolutionsCanvasLayer1","ResolutionsCanvasLayer1",1200,1200);
+    arrangeBiasCanvas(ResolutionsCanvasLayer1,dxyLadderWidthTrend,dzLadderWidthTrend,dxyModZWidthTrend,dzModZWidthTrend,nFiles_,LegLabels,theDate,setAutoLimits);
+    
+    ResolutionsCanvasLayer1->SaveAs("ResolutionsCanvasLayer1_"+theStrDate+theStrAlignment+".pdf");
+    ResolutionsCanvasLayer1->SaveAs("ResolutionsCanvasLayer1_"+theStrDate+theStrAlignment+".png");
+
+    delete ResolutionsCanvasLayer1;
+  }
+
   // Pull plots
 
   TCanvas *PullsCanvas = new TCanvas("PullsCanvas","PullsCanvas",1200,1200);
@@ -1182,6 +1359,16 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
   
   PullsCanvas->SaveAs("PullsCanvas_"+theStrDate+theStrAlignment+".pdf");
   PullsCanvas->SaveAs("PullsCanvas_"+theStrDate+theStrAlignment+".png");
+
+  if(nLadders_>0){
+    TCanvas *PullsCanvasLayer1 = new TCanvas("PullsCanvasLayer1","PullsCanvasLayer1",1200,1200);
+    arrangeBiasCanvas(PullsCanvasLayer1,dxyNormLadderWidthTrend,dzNormLadderWidthTrend,dxyNormModZWidthTrend,dzNormModZWidthTrend,nFiles_,LegLabels,theDate,setAutoLimits);
+    
+    PullsCanvasLayer1->SaveAs("PullsCanvasLayer1_"+theStrDate+theStrAlignment+".pdf");
+    PullsCanvasLayer1->SaveAs("PullsCanvasLayer1_"+theStrDate+theStrAlignment+".png");
+
+    delete PullsCanvasLayer1;
+  }
 
   // delete all news
   delete ResolutionsCanvas;
@@ -1318,12 +1505,18 @@ void arrangeBiasCanvas(TCanvas *canv,TH1F* dxyPhiMeanTrend[100],TH1F* dzPhiMeanT
     }
 
     Double_t safeDelta=(absmax[k]-absmin[k])/8.;
+
+    // if(safeDelta<0.1*absmax[k]) safeDelta*=16;
+
     Double_t theExtreme=std::max(absmax[k],TMath::Abs(absmin[k]));
 
     for(Int_t i=0; i<nFiles; i++){
       if(i==0){
 
 	TString theTitle = dBiasTrend[k][i]->GetName();
+	
+	//std::cout << theTitle<< " --->" << safeDelta << std::endl;
+
 	// if the autoLimits are not set
 	if(!setAutoLimits){
 	  
@@ -1333,11 +1526,17 @@ void arrangeBiasCanvas(TCanvas *canv,TH1F* dxyPhiMeanTrend[100],TH1F* dzPhiMeanT
 	} else {
 	
 	  if(theTitle.Contains("width")){
+
+	    if(theTitle.Contains("Norm"))
+	      safeDelta = (theTitle.Contains("ladder")==true||theTitle.Contains("modZ")==true) ? 1.  : safeDelta; 
+	    else
+	      safeDelta = (theTitle.Contains("ladder")==true||theTitle.Contains("modZ")==true) ? 50. : safeDelta; 
+
 	    dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,theExtreme+(safeDelta/2.));
 	  } else {
 
 	    if( theTitle.Contains("Norm")){
-	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(std::min(-0.48,absmin[k]-safeDelta/2.),std::max(0.48,absmax[k]+safeDelta/2.));
+	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(std::min(-0.48,absmin[k]-(safeDelta/2.)),std::max(0.48,absmax[k]+(safeDelta/2.)));
 	    } else if ( theTitle.Contains("h_probe")) {
 	      TGaxis::SetMaxDigits(4);   
 	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,theExtreme+(safeDelta*2.));
@@ -1346,7 +1545,6 @@ void arrangeBiasCanvas(TCanvas *canv,TH1F* dxyPhiMeanTrend[100],TH1F* dzPhiMeanT
 	    } 
 	  }
 	}
-
 	dBiasTrend[k][i]->Draw("e1");
 	makeNewXAxis(dBiasTrend[k][i]);
 	Int_t nbins =  dBiasTrend[k][i]->GetNbinsX();
@@ -1374,7 +1572,9 @@ void arrangeBiasCanvas(TCanvas *canv,TH1F* dxyPhiMeanTrend[100],TH1F* dzPhiMeanT
 	theConst->Draw("PLsame");
 
       }
-      else dBiasTrend[k][i]->Draw("e1sames");
+      else { 
+	dBiasTrend[k][i]->Draw("e1sames");	
+      }
       if(k==0){
 	lego->AddEntry(dBiasTrend[k][i],LegLabels[i]);
       } 
@@ -1503,9 +1703,13 @@ void arrangeCanvas(TCanvas *canv,TH1F* meanplots[100],TH1F* widthplots[100],Int_
       
       meanplots[i]->Draw("e1");
       if(TString(meanplots[i]->GetName()).Contains("pT")){
-	meanplots[i]->Draw("HIST][same");
+       	//meanplots[i]->Draw("HIST][same");
+	gPad->SetLogx();
+	gPad->SetGridx();
+	gPad->SetGridy();
+      } else {
+	makeNewXAxis(meanplots[i]); 
       }
-      makeNewXAxis(meanplots[i]); 
 
       if(onlyBias){
 	canv->cd();
@@ -1519,9 +1723,9 @@ void arrangeCanvas(TCanvas *canv,TH1F* meanplots[100],TH1F* widthplots[100],Int_
       }
     }
     else meanplots[i]->Draw("e1sames");
-    if(TString(meanplots[i]->GetName()).Contains("pT")){
-      meanplots[i]->Draw("HIST][same");
-    }
+    //if(TString(meanplots[i]->GetName()).Contains("pT")){
+    //  meanplots[i]->Draw("HIST][same");
+    // }
 
     lego->AddEntry(meanplots[i],LegLabels[i]); 
   }  
@@ -1572,8 +1776,9 @@ void arrangeCanvas(TCanvas *canv,TH1F* meanplots[100],TH1F* widthplots[100],Int_
 	widthplots[i]->Draw("e1");
 	if(TString(widthplots[i]->GetName()).Contains("pT")){
 	  widthplots[i]->Draw("HIST][same");
-	}
-
+	  gPad->SetGridx();
+	  gPad->SetGridy();
+	} 
 	makeNewXAxis(widthplots[i]);
       } else {
 	widthplots[i]->Draw("e1sames");
@@ -2000,6 +2205,9 @@ params::measurement getMAD(TH1F *histo)
 std::pair<params::measurement, params::measurement  > fitResiduals(TH1 *hist,bool singleTime)
 //*************************************************************
 {
+  
+  assert(hist!=nullptr) ;
+
   if (hist->GetEntries() < 10){ 
     // std::cout<<"hist name: "<<hist->GetName() << std::endl;
     return std::make_pair(std::make_pair(0.,0.),std::make_pair(0.,0.));
@@ -3030,6 +3238,12 @@ void makeNewXAxis (TH1F *h)
     axmin = 0;
     axmax = 19.99;
     ndiv = 510;
+  } else if (myTitle.Contains("ladder")) {
+    axmin = 0.5;
+    axmax = 12.5;
+  } else if (myTitle.Contains("modZ")) {
+    axmin = 0.5;
+    axmax = 8.5;
   } else if (myTitle.Contains("h_probe")){
     ndiv = 505;
     axmin = h->GetXaxis()->GetXmin();
@@ -3105,7 +3319,6 @@ void makeNewPairOfAxes (TH2F *h)
 				   axmin,
 				   axmax,                          
 				   ndivx,"-SDH");
-
 
   TGaxis *newYaxisR = new TGaxis(gPad->GetUxmin(),gPad->GetUymin(),
 				 gPad->GetUxmin(),gPad->GetUymax(),
@@ -3247,26 +3460,34 @@ params::measurement getTheRangeUser(TH1F* thePlot, Limits* lims)
 	  result = std::make_pair(-lims->get_dxyPhiNormMax().first,lims->get_dxyPhiNormMax().first);
 	} else if (theTitle.Contains("eta")){
 	  result = std::make_pair(-lims->get_dxyEtaNormMax().first,lims->get_dxyEtaNormMax().first);
+	} else {
+	  result = std::make_pair(-0.8,0.8);
 	}
       } else if(theTitle.Contains("dz")){
 	if(theTitle.Contains("phi")){
 	  result = std::make_pair(-lims->get_dzPhiNormMax().first,lims->get_dzPhiNormMax().first);
 	} else if (theTitle.Contains("eta")){
 	  result = std::make_pair(-lims->get_dzEtaNormMax().first,lims->get_dzEtaNormMax().first);
+	} else {
+	  result = std::make_pair(-0.8,0.8);
 	}
-      }
+      } 
     } else if (theTitle.Contains("widths")){
       if(theTitle.Contains("dxy") || theTitle.Contains("dx") || theTitle.Contains("dy")){
 	if(theTitle.Contains("phi")){
 	  result = std::make_pair(0.,lims->get_dxyPhiNormMax().second);
 	} else if (theTitle.Contains("eta")){
 	  result = std::make_pair(0.,lims->get_dxyEtaNormMax().second);
+	} else {
+	  result = std::make_pair(0.,2.);
 	}
       } else if(theTitle.Contains("dz")){	
 	if(theTitle.Contains("phi")){
 	  result = std::make_pair(0.,lims->get_dzPhiNormMax().second);
 	} else if (theTitle.Contains("eta")){
 	  result = std::make_pair(0.,lims->get_dzEtaNormMax().second);
+	} else {
+	  result = std::make_pair(0.,2.);
 	}
       }
     } 
@@ -3277,12 +3498,16 @@ params::measurement getTheRangeUser(TH1F* thePlot, Limits* lims)
 	  result = std::make_pair(-lims->get_dxyPhiMax().first,lims->get_dxyPhiMax().first);
 	} else if (theTitle.Contains("eta")){
 	  result = std::make_pair(-lims->get_dxyEtaMax().first,lims->get_dxyEtaMax().first);
+	} else {
+	  result = std::make_pair(-40.,40.);
 	}
       } else if(theTitle.Contains("dz")){
 	if(theTitle.Contains("phi")){
 	  result = std::make_pair(-lims->get_dzPhiMax().first,lims->get_dzPhiMax().first);
 	} else if (theTitle.Contains("eta")){
 	  result = std::make_pair(-lims->get_dzEtaMax().first,lims->get_dzEtaMax().first);
+	} else {
+	  result = std::make_pair(-80.,80.);
 	}
       }
     } else if (theTitle.Contains("widths")){
@@ -3291,12 +3516,16 @@ params::measurement getTheRangeUser(TH1F* thePlot, Limits* lims)
 	  result = std::make_pair(0.,lims->get_dxyPhiMax().second);
 	} else if (theTitle.Contains("eta")){
 	  result = std::make_pair(0.,lims->get_dxyEtaMax().second);
+	} else {
+	  result = std::make_pair(0.,150.);
 	}
       } else if(theTitle.Contains("dz")){	
 	if(theTitle.Contains("phi")){
 	  result = std::make_pair(0.,lims->get_dzPhiMax().second);
 	} else if (theTitle.Contains("eta")){
 	  result = std::make_pair(0.,lims->get_dzEtaMax().second);
+	}  else {
+	  result = std::make_pair(0.,300.);
 	}
       }
     }

--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -516,14 +516,14 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
 
     if(gDirectory->GetListOfKeys()->Contains("etaMax")){
       gDirectory->GetObject("etaMax",theEtaHistos[i]);
-      theEtaMax_[i]   = theEtaHistos[i]->GetBinContent(1);
+      theEtaMax_[i]   = theEtaHistos[i]->GetBinContent(1)/theEtaHistos[i]->GetEntries();
     } else {
       theEtaMax_[i]   = 2.5;
     }
     	
     if(gDirectory->GetListOfKeys()->Contains("nbins")){
       gDirectory->GetObject("nbins",thebinsHistos[i]);
-      theNBINS[i] = thebinsHistos[i]->GetBinContent(1);
+      theNBINS[i] = thebinsHistos[i]->GetBinContent(1)/thebinsHistos[i]->GetEntries();	  
       std::cout<<"File n. "<<i<<" has theNBINS["<<i<<"] = "<< theNBINS[i]<<std::endl;
     } else {
       theNBINS[i] = 48.;
@@ -532,7 +532,7 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
 
     if(gDirectory->GetListOfKeys()->Contains("nladders")){
       gDirectory->GetObject("nladders",theLaddersHistos[i]);
-      theLadders[i] = theLaddersHistos[i]->GetBinContent(1);
+      theLadders[i] = theLaddersHistos[i]->GetBinContent(1)/theLaddersHistos[i]->GetEntries();
       std::cout<<"File n. "<<i<<" has theNLadders["<<i<<"] = "<< theLadders[i]<<std::endl;
     } else {
       theLadders[i] = -1.;

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -16,6 +16,7 @@
 
 // CMSSW includes
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
@@ -52,21 +53,12 @@
 #include "TrackingTools/IPTools/interface/IPTools.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateClosestToPoint.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "Alignment/OfflineValidation/interface/PVValidationHelpers.h"
 
 //
 // ancyllary enum for 
 // residuals moments estimation 
 //
-
-namespace statmode{
-  enum estimator 
-    { MEAN   = 1,
-      WIDTH  = 2, 
-      MEDIAN = 3,
-      MAD    = 4,
-      UNKWN  = -1
-    };
-}
 
 //
 // class decleration
@@ -76,33 +68,41 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
 
  public:
   explicit PrimaryVertexValidation(const edm::ParameterSet&);
-  ~PrimaryVertexValidation();
+  ~PrimaryVertexValidation() override;
 
  private:
-  virtual void beginJob();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob();
+  virtual void beginJob() override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
   bool isBFieldConsistentWithMode(const edm::EventSetup& iSetup) const;
   bool isHit2D(const TrackingRecHit &hit) const;
-  bool hasFirstLayerPixelHits(const reco::TransientTrack track);
-  std::pair<bool,bool> pixelHitsCheck(const reco::TransientTrack track);
-  std::pair<Double_t,Double_t> getMedian(TH1F *histo);
-  std::pair<Double_t,Double_t> getMAD(TH1F *histo);
-  std::pair<std::pair<Double_t,Double_t>, std::pair<Double_t,Double_t> > fitResiduals(TH1 *hist);
-  void fillTrendPlot(TH1F* trendPlot, TH1F *residualsPlot[100], statmode::estimator fitPar_, TString var_);
-  void fillTrendPlotByIndex(TH1F* trendPlot,std::vector<TH1F*>& h, statmode::estimator fitPar_); 
+  bool hasFirstLayerPixelHits(const reco::TransientTrack& track);
+  std::pair<bool,bool> pixelHitsCheck(const reco::TransientTrack& track);
+  Measurement1D getMedian(TH1F *histo);
+  Measurement1D getMAD(TH1F *histo);
+  std::pair<Measurement1D, Measurement1D > fitResiduals(TH1 *hist);
+
+  void fillTrendPlot(TH1F* trendPlot, TH1F *residualsPlot[100], PVValHelper::estimator fitPar_, const std::string& var_);
+  void fillTrendPlotByIndex(TH1F* trendPlot,std::vector<TH1F*>& h, PVValHelper::estimator fitPar_,PVValHelper::plotVariable plotVar=PVValHelper::END_OF_PLOTS); 
 
   static bool vtxSort( const reco::Vertex &  a, const reco::Vertex & b );
-  bool passesTrackCuts(const reco::Track & track, const reco::Vertex & vertex,std::string qualityString_, double dxyErrMax_,double dzErrMax_, double ptErrMax_);
+  bool passesTrackCuts(const reco::Track & track, const reco::Vertex & vertex,const std::string& qualityString_, double dxyErrMax_,double dzErrMax_, double ptErrMax_);
 
-  std::vector<TH1F*> bookResidualsHistogram(TFileDirectory dir,unsigned int theNOfBins,TString resType,TString varType); 
-  std::map<std::string, TH1*> bookVertexHistograms(TFileDirectory dir);
+  std::vector<TH1F*> bookResidualsHistogram(const TFileDirectory& dir,unsigned int theNOfBins,PVValHelper::residualType resType,PVValHelper::plotVariable varType, bool isNormalized=false); 
+  std::map<std::string, TH1*> bookVertexHistograms(const TFileDirectory& dir);
+
   void fillTrackHistos(std::map<std::string, TH1*> & h, const std::string & ttype, const reco::TransientTrack *tt, const reco::Vertex & v,const reco::BeamSpot & beamSpot, double fBfield);
   void add(std::map<std::string, TH1*>& h, TH1* hist);
-  void fill(std::map<std::string, TH1*>& h, std::string s, double x);
-  void fill(std::map<std::string, TH1*>& h, std::string s, double x, double y);
-  void fillByIndex(std::vector<TH1F*>& h, unsigned int index, double x); 
-  void fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100][100], statmode::estimator fitPar_);
+
+  void fill(std::map<std::string, TH1*>& h,const std::string& s, double x);
+  void fill(std::map<std::string, TH1*>& h,const std::string& s, double x, double y);
+  void fillByIndex(std::vector<TH1F*>& h, unsigned int index, double x,std::string tag=""); 
+
+  void shrinkHistVectorToFit(std::vector<TH1F*>&h,unsigned int desired_size);
+  std::tuple<std::string,std::string,std::string> getTypeString (PVValHelper::residualType type);
+  std::tuple<std::string,std::string,std::string> getVarString (PVValHelper::plotVariable var);
+
+  void fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100][100], PVValHelper::estimator fitPar_);
   
   inline double square(double x){
     return x*x;
@@ -123,6 +123,9 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   bool lightNtupleSwitch_;   // switch to keep only info for daily validation     
   bool useTracksFromRecoVtx_; 
   
+  // histogram details
+  PVValHelper::histodetails theDetails_;
+  
   // requirements on the vertex
   double vertexZMax_;
 
@@ -134,7 +137,9 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   bool    doBPix_;
   bool    doFPix_;
   double  ptOfProbe_;
+  double  pOfProbe_;
   double  etaOfProbe_;
+  double  nHitsOfProbe_;
   bool    isPhase1_;
   int nBins_;                 // actual number of histograms     
   std::vector<unsigned int> runControlNumbers_;
@@ -156,9 +161,9 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   static const int cmToum = 10000;
   static const int nPtBins_ = 48;
 
-  float phiSect_;
-  float etaSect_;
-
+  unsigned int   nLadders_= 20;
+  unsigned int   nModZ_   =  8;
+  
   // pT binning as in paragraph 3.2 of CMS-PAS-TRK-10-005 (https://cds.cern.ch/record/1279383/files/TRK-10-005-pas.pdf)
 
   //                                      0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  24  25  26  27  28  29  30  31  32  33  34  35  36   37  38   39  40  41  42  43  44  45   46  47  48
@@ -241,57 +246,68 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   int   hasRecVertex_[nMaxtracks_];
   int   isGoodTrack_[nMaxtracks_];
 
-  // histogram for max(eta)
+  edm::Service<TFileService> fs;
+
+  TFileDirectory MeanTrendsDir;
+  TFileDirectory WidthTrendsDir; 
+  TFileDirectory MedianTrendsDir;
+  TFileDirectory MADTrendsDir;   
+  				
+  TFileDirectory Mean2DMapsDir;  
+  TFileDirectory Width2DMapsDir; 
+
+  // histogram for sanity check
   TH1F* h_etaMax;
   TH1F* h_nbins;
+  TH1F* h_nLadders;
 
   // ---- directly histograms // ===> unbiased residuals
   
   // absolute residuals
 
-  TH1F* a_dxyPhiResiduals[nMaxBins_];
-  TH1F* a_dxyEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> a_dxyPhiResiduals;
+  std::vector<TH1F*> a_dxyEtaResiduals;
 
-  TH1F* a_dxPhiResiduals[nMaxBins_];
-  TH1F* a_dxEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> a_dxPhiResiduals;
+  std::vector<TH1F*> a_dxEtaResiduals;
 
-  TH1F* a_dyPhiResiduals[nMaxBins_];
-  TH1F* a_dyEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> a_dyPhiResiduals;
+  std::vector<TH1F*> a_dyEtaResiduals;
 
-  TH1F* a_dzPhiResiduals[nMaxBins_];
-  TH1F* a_dzEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> a_dzPhiResiduals;
+  std::vector<TH1F*> a_dzEtaResiduals;
   
-  TH1F* a_IP2DPhiResiduals[nMaxBins_];
-  TH1F* a_IP2DEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> a_IP2DPhiResiduals;
+  std::vector<TH1F*> a_IP2DEtaResiduals;
   
-  TH1F* a_IP3DPhiResiduals[nMaxBins_];
-  TH1F* a_IP3DEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> a_IP3DPhiResiduals;
+  std::vector<TH1F*> a_IP3DEtaResiduals;
 
-  TH1F* a_reszPhiResiduals[nMaxBins_];
-  TH1F* a_reszEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> a_reszPhiResiduals;
+  std::vector<TH1F*> a_reszEtaResiduals;
 
-  TH1F* a_d3DPhiResiduals[nMaxBins_];
-  TH1F* a_d3DEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> a_d3DPhiResiduals;
+  std::vector<TH1F*> a_d3DEtaResiduals;
 
   // normalized residuals
 
-  TH1F* n_dxyPhiResiduals[nMaxBins_];
-  TH1F* n_dxyEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> n_dxyPhiResiduals;
+  std::vector<TH1F*> n_dxyEtaResiduals;
   
-  TH1F* n_dzPhiResiduals[nMaxBins_];
-  TH1F* n_dzEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> n_dzPhiResiduals;
+  std::vector<TH1F*> n_dzEtaResiduals;
   
-  TH1F* n_IP2DPhiResiduals[nMaxBins_];
-  TH1F* n_IP2DEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> n_IP2DPhiResiduals;
+  std::vector<TH1F*> n_IP2DEtaResiduals;
   
-  TH1F* n_IP3DPhiResiduals[nMaxBins_];
-  TH1F* n_IP3DEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> n_IP3DPhiResiduals;
+  std::vector<TH1F*> n_IP3DEtaResiduals;
 
-  TH1F* n_reszPhiResiduals[nMaxBins_];
-  TH1F* n_reszEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> n_reszPhiResiduals;
+  std::vector<TH1F*> n_reszEtaResiduals;
 
-  TH1F* n_d3DPhiResiduals[nMaxBins_];
-  TH1F* n_d3DEtaResiduals[nMaxBins_];
+  std::vector<TH1F*> n_d3DPhiResiduals;
+  std::vector<TH1F*> n_d3DEtaResiduals;
 
   // for the maps
 
@@ -347,6 +363,28 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   TH1F* n_dzpTCentralMeanTrend;
   TH1F* n_dzpTCentralWidthTrend;
 
+  // --- trend as a function of the ladder/module number
+
+  TH1F* a_dxymodZMeanTrend;					     		
+  TH1F* a_dxymodZWidthTrend; 					      			
+  TH1F* a_dzmodZMeanTrend; 		       		      			
+  TH1F* a_dzmodZWidthTrend; 
+					       			
+  TH1F* a_dxyladderMeanTrend;  						 			
+  TH1F* a_dxyladderWidthTrend; 					        		       
+  TH1F* a_dzladderMeanTrend;   					        			
+  TH1F* a_dzladderWidthTrend;  
+						 		      
+  TH1F* n_dxymodZMeanTrend;   						 			
+  TH1F* n_dxymodZWidthTrend;  					        			
+  TH1F* n_dzmodZMeanTrend;   					        			
+  TH1F* n_dzmodZWidthTrend;  
+						 			
+  TH1F* n_dxyladderMeanTrend;  						 			
+  TH1F* n_dxyladderWidthTrend; 						 			
+  TH1F* n_dzladderMeanTrend;   						 			
+  TH1F* n_dzladderWidthTrend; 
+
   // ---- medians and MAD
 
   TH1F* a_dxyPhiMedianTrend;
@@ -396,24 +434,26 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
 
   TH2F* n_dxyWidthMap;
   TH2F* n_dzWidthMap;
-
-  // ---- directly histograms =================> biased residuals
+  
+  //
+  // ---- directly histograms 
+  // biased residuals
   
   // absolute residuals
 
-  TH1F* a_dxyPhiBiasResiduals[nMaxBins_];
-  TH1F* a_dxyEtaBiasResiduals[nMaxBins_];
+  std::vector<TH1F*> a_dxyPhiBiasResiduals;
+  std::vector<TH1F*> a_dxyEtaBiasResiduals;
   
-  TH1F* a_dzPhiBiasResiduals[nMaxBins_];
-  TH1F* a_dzEtaBiasResiduals[nMaxBins_];
+  std::vector<TH1F*> a_dzPhiBiasResiduals;
+  std::vector<TH1F*> a_dzEtaBiasResiduals;
   
   // normalized BiasResiduals
 
-  TH1F* n_dxyPhiBiasResiduals[nMaxBins_];
-  TH1F* n_dxyEtaBiasResiduals[nMaxBins_];
+  std::vector<TH1F*> n_dxyPhiBiasResiduals;
+  std::vector<TH1F*> n_dxyEtaBiasResiduals;
   
-  TH1F* n_dzPhiBiasResiduals[nMaxBins_];
-  TH1F* n_dzEtaBiasResiduals[nMaxBins_];
+  std::vector<TH1F*> n_dzPhiBiasResiduals;
+  std::vector<TH1F*> n_dzEtaBiasResiduals;
   
   // for the maps
 
@@ -423,7 +463,7 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   TH1F* n_dxyBiasResidualsMap[nMaxBins_][nMaxBins_];  				 
   TH1F* n_dzBiasResidualsMap[nMaxBins_][nMaxBins_];
 
-  // ---- trends as function of phi
+  // ---- trends as function of phi / eta
   
   TH1F* a_dxyPhiMeanBiasTrend;
   TH1F* a_dxyPhiWidthBiasTrend;
@@ -547,6 +587,10 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   TH1F* h_probeHitsInBPIX_; 
   TH1F* h_probeHitsInFPIX_; 
 
+  TH1F* h_probeL1Ladder_;
+  TH1F* h_probeL1Module_;
+  TH1I* h_probeHasBPixL1Overlap_;  
+
   // check vertex
 
   TH1F* h_fitVtxNdof_;
@@ -575,6 +619,21 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   std::vector<TH1F*> h_dz_Central_pT_;
   std::vector<TH1F*> h_norm_dxy_Central_pT_;
   std::vector<TH1F*> h_norm_dz_Central_pT_;   
+
+  // histograms for the plots as function of module ladder and number
+
+  std::vector<TH1F*> h_dxy_modZ_;
+  std::vector<TH1F*> h_dz_modZ_;
+  std::vector<TH1F*> h_norm_dxy_modZ_;
+  std::vector<TH1F*> h_norm_dz_modZ_;
+
+  std::vector<TH1F*> h_dxy_ladderOverlap_;
+  std::vector<TH1F*> h_dxy_ladderNoOverlap_;
+
+  std::vector<TH1F*> h_dxy_ladder_;
+  std::vector<TH1F*> h_dz_ladder_;
+  std::vector<TH1F*> h_norm_dxy_ladder_;
+  std::vector<TH1F*> h_norm_dz_ladder_;   
 
 };
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
@@ -23,7 +23,7 @@ if isMC:
      print ">>>>>>>>>> testPVValidation_cfg.py: msg%-i: This is simulation!"
      runboundary = 1
 else:
-     print ">>>>>>>>>> testPVValidation_cfg.py: msg%-i: This is real dATA!"
+     print ">>>>>>>>>> testPVValidation_cfg.py: msg%-i: This is real DATA!"
      if ('.oO[lumilist]Oo.'):
           print ">>>>>>>>>> testPVValidation_cfg.py: msg%-i: JSON filtering with: .oO[lumilist]Oo. "
           import FWCore.PythonUtilities.LumiList as LumiList

--- a/Alignment/OfflineValidation/src/PVValidationHelpers.cc
+++ b/Alignment/OfflineValidation/src/PVValidationHelpers.cc
@@ -1,0 +1,276 @@
+#include "Alignment/OfflineValidation/interface/PVValidationHelpers.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <cassert>
+#include <numeric>
+#include <algorithm>
+#include <iostream>
+#include "TMath.h"
+#include "TH1.h"
+#include "TF1.h"
+
+//*************************************************************
+void PVValHelper::add(std::map<std::string, TH1*>& h, TH1* hist)
+//*************************************************************
+{ 
+  h[hist->GetName()]=hist; 
+  hist->StatOverflows(kTRUE);
+}
+
+//*************************************************************
+void PVValHelper::fill(std::map<std::string, TH1*>& h,const std::string& s, double x)
+//*************************************************************
+{
+  if(h.count(s)==0){
+    edm::LogWarning("PVValidationHelpers") << "Trying to fill non-existing Histogram named " << s << std::endl;
+    return;
+  }
+  h[s]->Fill(x);
+}
+
+//*************************************************************
+void PVValHelper::fill(std::map<std::string, TH1*>& h,const std::string& s, double x, double y)
+//*************************************************************
+{
+  if(h.count(s)==0){
+    edm::LogWarning("PVValidationHelpers") << "Trying to fill non-existing Histogram named " << s << std::endl;
+    return;
+  }
+  h[s]->Fill(x,y);
+}
+
+//*************************************************************
+void PVValHelper::fillByIndex(std::vector<TH1F*>& h, unsigned int index, double x,std::string tag)
+//*************************************************************
+{
+  assert(!h.empty());
+  if(index <= h.size()){
+    h[index]->Fill(x);
+  } else {
+    edm::LogWarning("PVValidationHelpers") << "Trying to fill non-existing Histogram with index " << index << " for array with size: "<<h.size()<<" tag: "<< tag<< std::endl;
+    return;
+  }
+}
+
+//*************************************************************
+void PVValHelper::shrinkHistVectorToFit(std::vector<TH1F*>&h, unsigned int desired_size)
+//*************************************************************
+{
+  h.erase(h.begin()+desired_size,h.end()); 
+}
+
+//*************************************************************
+PVValHelper::plotLabels PVValHelper::getTypeString (PVValHelper::residualType type)
+//*************************************************************
+{
+  PVValHelper::plotLabels returnType;
+  switch(type)
+    {
+    // absoulte
+
+    case PVValHelper::dxy  :
+      returnType = std::make_tuple("dxy","d_{xy}","[#mum]");
+      break;
+    case PVValHelper::dx   :
+      returnType = std::make_tuple("dx","d_{x}","[#mum]");
+      break;
+    case PVValHelper::dy   :
+      returnType = std::make_tuple("dy","d_{y}","[#mum]");
+      break;
+    case PVValHelper::dz   :
+      returnType =  std::make_tuple("dz","d_{z}","[#mum]");
+      break;
+    case PVValHelper::IP2D :
+      returnType =  std::make_tuple("IP2D","IP_{2D}","[#mum]");
+      break;
+    case PVValHelper::resz :
+      returnType =  std::make_tuple("resz","z_{trk}-z_{vtx}","[#mum]");
+      break;
+    case PVValHelper::IP3D :
+      returnType =  std::make_tuple("IP3D","IP_{3D}","[#mum]");
+      break;
+    case PVValHelper::d3D  : 
+      returnType =  std::make_tuple("d3D","d_{3D}","[#mum]");
+      break;
+
+    // normalized
+
+    case PVValHelper::norm_dxy  :
+      returnType =  std::make_tuple("norm_dxy","d_{xy}/#sigma_{d_{xy}}","");
+      break;
+    case PVValHelper::norm_dx   :
+      returnType =  std::make_tuple("norm_dx","d_{x}/#sigma_{d_{x}}","");
+      break;
+    case PVValHelper::norm_dy   :
+      returnType =  std::make_tuple("norm_dy","d_{y}/#sigma_{d_{y}}","");
+      break;
+    case PVValHelper::norm_dz   :
+      returnType =  std::make_tuple("norm_dz","d_{z}/#sigma_{d_{z}}","");
+      break;
+    case PVValHelper::norm_IP2D :
+      returnType =  std::make_tuple("norm_IP2D","IP_{2D}/#sigma_{IP_{2D}}","");
+      break;
+    case PVValHelper::norm_resz :
+      returnType =  std::make_tuple("norm_resz","z_{trk}-z_{vtx}/#sigma_{res_{z}}","");
+      break;
+    case PVValHelper::norm_IP3D :
+      returnType =  std::make_tuple("norm_IP3D","IP_{3D}/#sigma_{IP_{3D}}","");
+      break;
+    case PVValHelper::norm_d3D  : 
+      returnType =  std::make_tuple("norm_d3D","d_{3D}/#sigma_{d_{3D}}","");
+      break;
+
+    default:
+      edm::LogWarning("PVValidationHelpers") <<" getTypeString() unknown residual type: "<<type<<std::endl;
+    }
+
+  return returnType;
+  
+}
+
+//*************************************************************
+PVValHelper::plotLabels PVValHelper::getVarString (PVValHelper::plotVariable var)
+//*************************************************************
+{
+  PVValHelper::plotLabels returnVar;
+  switch(var)
+    {
+    case PVValHelper::phi  :
+      returnVar =  std::make_tuple("phi","#phi","[rad]");
+      break;
+    case PVValHelper::eta   :
+      returnVar =  std::make_tuple("eta","#eta","");
+      break;
+    case PVValHelper::pT   :
+      returnVar = std::make_tuple("pT","p_{T}","[GeV]");
+      break;
+    case PVValHelper::pTCentral :
+      returnVar = std::make_tuple("pTCentral","p_{T} |#eta|<1.","[GeV]");
+      break;
+    case PVValHelper::ladder   :
+      returnVar = std::make_tuple("ladder","ladder number","");
+      break;
+    case PVValHelper::modZ :
+      returnVar = std::make_tuple("modZ","module number","");
+      break;
+    default:
+      edm::LogWarning("PVValidationHelpers") <<" getVarString() unknown plot variable: "<<var<<std::endl;
+    }
+
+  return returnVar;
+  
+}
+
+//*************************************************************
+std::vector<float> PVValHelper::generateBins(int n, float start,float range)
+//*************************************************************
+{
+
+  std::vector<float> v(n);
+  float interval = range/(n-1);
+  std::iota(v.begin(),v.end(),1.);
+
+  //std::cout<<" interval:"<<interval<<std::endl;
+  //for(float &a : v) { std::cout<< a << " ";  }
+  //std::cout<< "\n";
+
+  std::for_each(begin(v), end(v), [&](float& a) { a = start+((a-1)*interval); });
+
+  return v;
+
+}
+
+//*************************************************************
+Measurement1D PVValHelper::getMedian(TH1F *histo)
+//*************************************************************
+{
+  double median = 999;
+  int nbins = histo->GetNbinsX();
+
+  //extract median from histogram
+  double *x = new double[nbins];
+  double *y = new double[nbins];
+  for (int j = 0; j < nbins; j++) {
+    x[j] = histo->GetBinCenter(j+1);
+    y[j] = histo->GetBinContent(j+1);
+  }
+  median = TMath::Median(nbins, x, y);
+  
+  delete[] x; x = nullptr;
+  delete[] y; y = nullptr;  
+
+  Measurement1D result(median,median/TMath::Sqrt(histo->GetEntries()));
+
+  return result;
+
+}
+
+//*************************************************************
+Measurement1D PVValHelper::getMAD(TH1F *histo)
+//*************************************************************
+{
+
+  int nbins = histo->GetNbinsX();
+  double median = getMedian(histo).value();
+  double x_lastBin = histo->GetBinLowEdge(nbins+1);
+  const char *HistoName =histo->GetName();
+  TString Finalname = Form("resMed%s",HistoName);
+  TH1F *newHisto = new TH1F(Finalname,Finalname,nbins,0.,x_lastBin);
+  double *residuals = new double[nbins];
+  double *weights = new double[nbins];
+
+  for (int j = 0; j < nbins; j++) {
+    residuals[j] = std::abs(median - histo->GetBinCenter(j+1));
+    weights[j]=histo->GetBinContent(j+1);
+    newHisto->Fill(residuals[j],weights[j]);
+  }
+  
+  double theMAD = (PVValHelper::getMedian(newHisto).value())*1.4826;
+  
+  delete[] residuals; residuals=nullptr;
+  delete[] weights; weights=nullptr;
+  newHisto->Delete("");
+  
+  Measurement1D result(theMAD,theMAD/histo->GetEntries());
+  return result;
+}
+
+
+//*************************************************************
+std::pair<Measurement1D, Measurement1D> PVValHelper::fitResiduals(TH1 *hist)
+//*************************************************************
+{
+  //float fitResult(9999);
+  //if (hist->GetEntries() < 20) return ;
+  
+  float mean  = hist->GetMean();
+  float sigma = hist->GetRMS();
+  
+  TF1 func("tmp", "gaus", mean - 1.5*sigma, mean + 1.5*sigma); 
+  if (0 == hist->Fit(&func,"QNR")) { // N: do not blow up file by storing fit!
+    mean  = func.GetParameter(1);
+    sigma = func.GetParameter(2);
+    // second fit: three sigma of first fit around mean of first fit
+    func.SetRange(mean - 2*sigma, mean + 2*sigma);
+      // I: integral gives more correct results if binning is too wide
+      // L: Likelihood can treat empty bins correctly (if hist not weighted...)
+    if (0 == hist->Fit(&func, "Q0LR")) {
+      if (hist->GetFunction(func.GetName())) { // Take care that it is later on drawn:
+	hist->GetFunction(func.GetName())->ResetBit(TF1::kNotDraw);
+      }
+    }
+  }
+
+  float res_mean  = func.GetParameter(1);
+  float res_width = func.GetParameter(2);
+  
+  float res_mean_err  = func.GetParError(1);
+  float res_width_err = func.GetParError(2);
+
+  Measurement1D resultM(res_mean,res_mean_err);
+  Measurement1D resultW(res_width,res_width_err);
+
+  std::pair<Measurement1D, Measurement1D> result;
+  
+  result = std::make_pair(resultM,resultW);
+  return result;
+}

--- a/Alignment/OfflineValidation/src/PVValidationHelpers.cc
+++ b/Alignment/OfflineValidation/src/PVValidationHelpers.cc
@@ -183,21 +183,13 @@ std::vector<float> PVValHelper::generateBins(int n, float start,float range)
 Measurement1D PVValHelper::getMedian(TH1F *histo)
 //*************************************************************
 {
-  double median = 999;
-  int nbins = histo->GetNbinsX();
-
-  //extract median from histogram
-  double *x = new double[nbins];
-  double *y = new double[nbins];
-  for (int j = 0; j < nbins; j++) {
-    x[j] = histo->GetBinCenter(j+1);
-    y[j] = histo->GetBinContent(j+1);
-  }
-  median = TMath::Median(nbins, x, y);
+  double median=0.;
+  double q = 0.5; // 0.5 quantile for "median"
+  // protect against empty histograms
+  if(histo->Integral()!=0){
+    histo->GetQuantiles(1, &median, &q);
+  }  
   
-  delete[] x; x = nullptr;
-  delete[] y; y = nullptr;  
-
   Measurement1D result(median,median/TMath::Sqrt(histo->GetEntries()));
 
   return result;
@@ -213,21 +205,20 @@ Measurement1D PVValHelper::getMAD(TH1F *histo)
   double median = getMedian(histo).value();
   double x_lastBin = histo->GetBinLowEdge(nbins+1);
   const char *HistoName =histo->GetName();
-  TString Finalname = Form("resMed%s",HistoName);
-  TH1F *newHisto = new TH1F(Finalname,Finalname,nbins,0.,x_lastBin);
+  std::string Finalname = "resMed_";
+  Finalname.append(HistoName);
+  TH1F *newHisto = new TH1F(Finalname.c_str(),Finalname.c_str(),nbins,0.,x_lastBin);
   double *residuals = new double[nbins];
-  double *weights = new double[nbins];
+  const float *weights = histo->GetArray(); 
 
   for (int j = 0; j < nbins; j++) {
     residuals[j] = std::abs(median - histo->GetBinCenter(j+1));
-    weights[j]=histo->GetBinContent(j+1);
     newHisto->Fill(residuals[j],weights[j]);
   }
   
   double theMAD = (PVValHelper::getMedian(newHisto).value())*1.4826;
   
   delete[] residuals; residuals=nullptr;
-  delete[] weights; weights=nullptr;
   newHisto->Delete("");
   
   Measurement1D result(theMAD,theMAD/histo->GetEntries());

--- a/Alignment/OfflineValidation/test/submitAllJobs.py
+++ b/Alignment/OfflineValidation/test/submitAllJobs.py
@@ -334,8 +334,8 @@ class Job:
         fout.write("cd $LXBATCH_DIR \n") 
         fout.write("cmsRun "+os.path.join(self.cfg_dir,self.outputCfgName)+" \n")
         fout.write("ls -lh . \n")
-        fout.write("for RootOutputFile in $(ls *root ); do eos cp -f ${RootOutputFile}  ${OUT_DIR}/${RootOutputFile} ; done \n")
-        fout.write("for TxtOutputFile in $(ls *txt ); do eos cp -f ${TxtOutputFile}  ${OUT_DIR}/${TxtOutputFile} ; done \n")
+        fout.write("for RootOutputFile in $(ls *root ); do xrdcp -f ${RootOutputFile}  root://eoscms//eos/cms${OUT_DIR}/${RootOutputFile} ; done \n")
+        fout.write("for TxtOutputFile in $(ls *txt ); do xrdcp -f ${TxtOutputFile}  root://eoscms//eos/cms${OUT_DIR}/${TxtOutputFile} ; done \n")
 
         fout.close()
 
@@ -681,7 +681,7 @@ def main():
             aJob.createTheCfgFile(theSrcFiles)
             aJob.createTheLSFFile()
 
-            output_file_list1.append("eos cp "+aJob.getOutputFileName()+" /tmp/$USER/"+opts.taskname+" \n")
+            output_file_list1.append("xrdcp root://eoscms//eos/cms"+aJob.getOutputFileName()+" /tmp/$USER/"+opts.taskname+" \n")
             if jobN == 0:
                 output_file_list2.append("/tmp/$USER/"+opts.taskname+"/"+aJob.getOutputBaseName()+".root ")
             output_file_list2.append("/tmp/$USER/"+opts.taskname+"/"+os.path.split(aJob.getOutputFileName())[1]+" ")    
@@ -705,7 +705,9 @@ def main():
         fout.write("mkdir -p /tmp/$USER/"+opts.taskname+" \n")
         fout.writelines(output_file_list1)
         fout.writelines(output_file_list2)
-        fout.write("eos cp -f $FILE $OUT_DIR \n")
+        fout.write("\n")
+        fout.write("echo \"xrdcp -f $FILE root://eoscms//eos/cms$OUT_DIR\" \n")
+        fout.write("xrdcp -f root://eoscms//eos/cms$FILE $OUT_DIR \n")
         fout.write("echo \"Harvesting for complete; please find output at $OUT_DIR \" | mail -s \"Harvesting for" +opts.taskname +" compled\" $MAIL \n")
 
         os.system("chmod u+x "+hadd_script_file)

--- a/Alignment/OfflineValidation/test/test_all_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_cfg.py
@@ -95,7 +95,7 @@ else:
                                    connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
                                    timetype = cms.string("runnumber"),
                                    toGet = cms.VPSet(cms.PSet(record = cms.string('TrackerAlignmentErrorExtendedRcd'),
-                                                              tag = cms.string('TrackerAlignmentExtendedErrors_2015StartupPessimisticScenario_mc')
+                                                              tag = cms.string('TrackerAlignmentErrorsExtended_Upgrade2017_design_v0')
                                                               )
                                                      )
                                    )
@@ -109,7 +109,7 @@ else:
           process.trackerBows = cms.ESSource("PoolDBESSource",CondDBSetup,
                                              connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
                                              toGet = cms.VPSet(cms.PSet(record = cms.string('TrackerSurfaceDeformationRcd'),
-                                                                        tag = cms.string('TrackerSurfaceDeformations_2011Realistic_v2_mc')
+                                                                        tag = cms.string('TrackerSurfaceDeformations_zero')
                                                                         )
                                                                )
                                              )


### PR DESCRIPTION
backport of #19704 and #19839 

Summary of aggregated features:
   * use range based loops
   * use pre-existing CMSSW types instead of redefining non trivial types
   * use `unique_ptr` instead of bare pointers
   * remove ROOT types in favor of native C++ types
   * added histograms for Bpix ladder checks
   * minor fixes and typos in the configuration
   * possibly common methods are moved into an helper namespace;
   * make booking and filling of histograms uniform;
   * reduce duplications in the creation of the track variable bins (hardwiring all instances to a single `std::map` depending on the impact parameter type and track variables);
   * added profiles of the bias and resolution towards the BPix L1 ladder and module number (where useful in the startup pixel commissioning phase): this is supported also for the Phase-0 detector.
   * update the plotting macro according to the other changes. 

would be nice to have it included in release for analysis of the alignment campaign on the 2017 V1 MC samples. 
