### PR TITLE
[93X] Adding the DQMEventInfo module to the SiStrip Bad components harvesting

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/AlcaSiStripQualityHarvester_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/AlcaSiStripQualityHarvester_cff.py
@@ -9,5 +9,9 @@ EDMtoMEConvertSiStrip.runInputTag = cms.InputTag("MEtoEDMConvertSiStrip","MEtoED
 
 DQMStore = cms.Service("DQMStore")
 
-ALCAHARVESTSiStripQuality = cms.Sequence(EDMtoMEConvertSiStrip + alcaSiStripQualityHarvester)
+dqmEnvSiStripQuality = cms.EDAnalyzer("DQMEventInfo",
+                                      subSystemFolder = cms.untracked.string('AlCaReco'),  
+                                      )
+
+ALCAHARVESTSiStripQuality = cms.Sequence(EDMtoMEConvertSiStrip + alcaSiStripQualityHarvester + dqmEnvSiStripQuality)
 #ALCAHARVESTSiStripQuality = cms.Sequence(EDMtoMEConvertSiStrip + dqmSaver)


### PR DESCRIPTION
Greetings,
this PR aims to provide to the harvested ALCAPROMPT files for the SiStrip bad components flavour the necessary input histograms to show the run/ LS / start time info to be displayed in the DQM GUI header, as it is done for the standard DQM - in the same spirit of https://github.com/cms-sw/cmssw/pull/19385