### PR TITLE
added .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,44 @@
+---
+Checks:
+  -*
+  ,boost-use-to-string
+  ,misc-string-compare
+  ,misc-uniqueptr-reset-release
+  ,modernize-deprecated-headers
+  ,modernize-make-shared
+  ,modernize-use-bool-literals
+  ,modernize-use-equals-delete
+  ,modernize-use-nullptr
+  ,modernize-use-override
+  ,performance-unnecessary-copy-initialization
+  ,readability-container-size-empty
+  ,readability-redundant-string-cstr
+  ,readability-static-definition-in-anonymous-namespace
+  ,readability-uniqueptr-delete-release
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+User:            muzaffar
+CheckOptions:    
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+...
+


### PR DESCRIPTION
 cling-tidy configuration files added with following checks enabled by default
 - boost-use-to-string
 - misc-string-compare
 - misc-uniqueptr-reset-release
 - modernize-deprecated-headers
 - modernize-make-shared
 - modernize-use-bool-literals
 - modernize-use-equals-delete
 - modernize-use-nullptr
 - modernize-use-override
 - performance-unnecessary-copy-initialization
 - readability-container-size-empty
 - readability-redundant-string-cstr
 - readability-static-definition-in-anonymous-namespace
 - readability-uniqueptr-delete-release

FYI, @davidlange6 @fwyzard 
