### PR TITLE
fix for Beam Spot txt file mess-up

### DIFF
--- a/Calibration/TkAlCaRecoProducers/plugins/AlcaBeamSpotHarvester.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/AlcaBeamSpotHarvester.cc
@@ -77,7 +77,6 @@ void AlcaBeamSpotHarvester::endRun(const edm::Run& iRun, const edm::EventSetup&)
   std::ofstream outFile;
   outFile.open(outTxt.c_str());
 
-
   if(poolDbService.isAvailable() ) {
     for(AlcaBeamSpotManager::bsMap_iterator it=beamSpotMap.begin(); it!=beamSpotMap.end();it++){
       BeamSpotObjects *aBeamSpot = new BeamSpotObjects();
@@ -190,6 +189,9 @@ void AlcaBeamSpotHarvester::endRun(const edm::Run& iRun, const edm::EventSetup&)
 
 
   }
+
+  outFile.close();
+
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/Calibration/TkAlCaRecoProducers/plugins/AlcaBeamSpotHarvester.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/AlcaBeamSpotHarvester.cc
@@ -74,6 +74,9 @@ void AlcaBeamSpotHarvester::endRun(const edm::Run& iRun, const edm::EventSetup&)
 //  cond::ExportIOVUtilities utilities;
 
   std::string outTxt = Form("%s_Run%d.txt", outTxtFileName_.c_str(), iRun.id().run());
+  std::ofstream outFile;
+  outFile.open(outTxt.c_str());
+
 
   if(poolDbService.isAvailable() ) {
     for(AlcaBeamSpotManager::bsMap_iterator it=beamSpotMap.begin(); it!=beamSpotMap.end();it++){
@@ -146,7 +149,7 @@ void AlcaBeamSpotHarvester::endRun(const edm::Run& iRun, const edm::EventSetup&)
 	  //poolDbService->createNewIOV<BeamSpotObjects>(aBeamSpot, poolDbService->currentTime(), poolDbService->endOfTime(),"BeamSpotObjectsRcd");
 	  poolDbService->writeOne<BeamSpotObjects>(aBeamSpot, thisIOV, outputrecordName_);
           if (dumpTxt_ && beamSpotOutputBase_ == "lumibased"){
-              beamspot::dumpBeamSpotTxt(outTxt, false, currentBS);
+              beamspot::dumpBeamSpotTxt(outFile, currentBS);
           }    
       } 
       else {
@@ -155,7 +158,7 @@ void AlcaBeamSpotHarvester::endRun(const edm::Run& iRun, const edm::EventSetup&)
         //poolDbService->appendSinceTime<BeamSpotObjects>(aBeamSpot, poolDbService->currentTime(),"BeamSpotObjectsRcd");
 	poolDbService->writeOne<BeamSpotObjects>(aBeamSpot, thisIOV, outputrecordName_);
         if (dumpTxt_ && beamSpotOutputBase_ == "lumibased"){
-            beamspot::dumpBeamSpotTxt(outTxt, true, currentBS);
+            beamspot::dumpBeamSpotTxt(outFile, currentBS);
         }
       }
 

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2Txt.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2Txt.h
@@ -17,7 +17,7 @@ namespace beamspot {
       std::time_t    reftime[2]        ;
   };
  
-  void dumpBeamSpotTxt(std::ofstream & outFile, bool append, BeamSpotContainer const& bsContainer){
+  void dumpBeamSpotTxt(std::ofstream & outFile, BeamSpotContainer const& bsContainer){
 
     outFile << "Runnumber "            << bsContainer.run                                                 << std::endl;
     outFile << "BeginTimeOfFit "       << bsContainer.beginTimeOfFit << " "   << bsContainer.reftime[0]   << std::endl;

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2Txt.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2Txt.h
@@ -17,15 +17,8 @@ namespace beamspot {
       std::time_t    reftime[2]        ;
   };
  
-  void dumpBeamSpotTxt(std::string const& fileName, bool append, BeamSpotContainer const& bsContainer){
+  void dumpBeamSpotTxt(std::ofstream & outFile, bool append, BeamSpotContainer const& bsContainer){
 
-    std::ofstream outFile;
-  
-    if (!append)
-      outFile.open(fileName.c_str());
-    else
-      outFile.open(fileName.c_str(), std::ios::app);
-  
     outFile << "Runnumber "            << bsContainer.run                                                 << std::endl;
     outFile << "BeginTimeOfFit "       << bsContainer.beginTimeOfFit << " "   << bsContainer.reftime[0]   << std::endl;
     outFile << "EndTimeOfFit "         << bsContainer.endTimeOfFit   << " "   << bsContainer.reftime[1]   << std::endl;
@@ -51,8 +44,7 @@ namespace beamspot {
     outFile << "EmittanceX "           << bsContainer.beamspot.emittanceX()                               << std::endl;
     outFile << "EmittanceY "           << bsContainer.beamspot.emittanceY()                               << std::endl;
     outFile << "BetaStar "             << bsContainer.beamspot.betaStar()                                 << std::endl;
-  
-    outFile.close();
+
   }
 
 } // end namespace beamspot

--- a/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
@@ -684,7 +684,7 @@ void BeamFitter::dumpTxtFile(std::string & fileName, bool append){
     currentBS.endLumiOfFit   = fendLumiOfFit  ;
     std::copy(freftime, freftime+2, currentBS.reftime);
           
-    if (outFile.is_open()) beamspot::dumpBeamSpotTxt(outFile, currentBS);
+    beamspot::dumpBeamSpotTxt(outFile, currentBS);
         
     //write here Pv info for DIP only: This added only if append is false, which happen for DIP only :)
   if(!append){

--- a/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
@@ -684,7 +684,7 @@ void BeamFitter::dumpTxtFile(std::string & fileName, bool append){
     currentBS.endLumiOfFit   = fendLumiOfFit  ;
     std::copy(freftime, freftime+2, currentBS.reftime);
           
-    if (outFile.is_open()) beamspot::dumpBeamSpotTxt(outFile, append, currentBS);
+    if (outFile.is_open()) beamspot::dumpBeamSpotTxt(outFile, currentBS);
         
     //write here Pv info for DIP only: This added only if append is false, which happen for DIP only :)
   if(!append){

--- a/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
@@ -684,7 +684,7 @@ void BeamFitter::dumpTxtFile(std::string & fileName, bool append){
     currentBS.endLumiOfFit   = fendLumiOfFit  ;
     std::copy(freftime, freftime+2, currentBS.reftime);
           
-    beamspot::dumpBeamSpotTxt(fileName, append, currentBS);
+    if (outFile.is_open()) beamspot::dumpBeamSpotTxt(outFile, append, currentBS);
         
     //write here Pv info for DIP only: This added only if append is false, which happen for DIP only :)
   if(!append){
@@ -697,7 +697,7 @@ void BeamFitter::dumpTxtFile(std::string & fileName, bool append){
     outFile << "nPV "<< (int)ForDIPPV_[6] << std::endl;
    }//writeDIPPVInfo_
   }//else end  here
-
+  
   outFile.close();
 }
 


### PR DESCRIPTION
Fix needed to restore the appropriate txt format needed by, in cascade, if I understand correctly: DIP, WBM, scalers, HLT.

It heals a simultaneous attempt to write in the same `/nfshome0/dqmpro/BeamMonitorDQM/BeamFitResults.txt `
file.

@vanbesien @arunhep @sarafiorendi @sikler