### PR TITLE
Fixing missing seeds affecting Electron EcalDriven Efficiency

### DIFF
--- a/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
@@ -246,7 +246,12 @@ _seedCollections_Phase1 = [
     'pixelLessStepSeeds',
     'tripletElectronSeeds',
     'pixelPairElectronSeeds',
-    'stripPairElectronSeeds'
+    'stripPairElectronSeeds',
+    'lowPtTripletStepSeeds',
+    'lowPtQuadStepSeeds',
+    'detachedTripletStepSeeds',
+    'detachedQuadStepSeeds',
+    'pixelPairStepSeeds'
 ]
 trackingPhase1.toModify(newCombinedSeeds, seedCollections = _seedCollections_Phase1)
 trackingPhase1QuadProp.toModify(newCombinedSeeds, seedCollections = _seedCollections_Phase1)


### PR DESCRIPTION
Dear All,

The efficiency of an electron to be ECAL driven has been low by 7-10% in 2017 data and this is one of the show stopping issues for the data re-reco. A reminder, electrons can be tracker driven (seeded by tracks) or ecal driven (seeded by pixel hits matched to the supercluster's trajectory). The tracker driven electrons were fine but there were issues with the ecal driven electrons

The issue has now been identified and was discussed today in the e/gamma meeting:
https://indico.cern.ch/event/604940/contributions/2686772/attachments/1506133/2347059/ecalDrivenFix.pdf

To summarise, E/gamma wants to have as input all sensible doublet combinations. This is done by pixelPairElectronSeeds but importantly it is cleaned for previously made pixel seeds, ie a cluster cant be considered for pixelPairElectronSeeds if it was used for a previous seed collection.  A final seed collection, newCombinedSeeds is made out of these seeds and all the previously made pixel seeds for which it was cleaned. This is presumably to reduce timing and is a sensible approach. Unfortunately for phase1 pixels, a rather key set of seeds, pixelPairSeeds, were removed from newCombinedSeeds. 

To summarise the summary:  [the chap guessed wrong](https://github.com/cms-sw/cmssw/blob/master/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py#L37)

I have added them back along with all other seeds which are involved in the cleaning. This covers most of the inefficiency but there remains a 0.5% effect compared to just making the doublets directly without cleaning. I will continue to have a look at this but things are very much improved already so I think its important to have into the release asap.

To do:
I want to re-reco all of the DoubleEG dataset of 299480 just to check there are no adverse effects from this (I only re-recoed the failing ecal driven electrons). I expect this to complete tomorrow, grid willing. 

Also this potentially impacts timing. What is the recommended benchmark job to evaluate this impact? 

Finally this wasnt supposed to be in the MC but given the fix, its weird it isnt there, to be investigated. 






