### PR TITLE
disable ZS mark and pass for 2017 data. it affects pre-TS1 data only.

### DIFF
--- a/RecoLocalCalo/HcalRecProducers/python/hfprereco_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/hfprereco_cfi.py
@@ -33,7 +33,7 @@ import FWCore.ParameterSet.Config as cms
 #
 hfprereco = cms.EDProducer("HFPreReconstructor",
     digiLabel = cms.InputTag("hcalDigis"),
-    dropZSmarkedPassed = cms.bool(True),
+    dropZSmarkedPassed = cms.bool(False),
     tsFromDB = cms.bool(False),
     sumAllTimeSlices = cms.bool(False),
     forceSOI = cms.int32(-1),


### PR DESCRIPTION
earlier this year we realized that there was an effective ZS applied at reco level for HF which was coming from the MarkAndPass flag being set in the RAW data. that flag is now unset and the HF is read and reconstructed in full readout for real starting from TS1. However, in order to recover the wanted non-suppressed behaviour in HF for the early 2017 data in the upcoming re-recos, we would like to merge this change.