### PR TITLE
CTPPS Pixel unpacker patch (backport)

### DIFF
--- a/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
@@ -148,6 +148,12 @@ void CTPPSPixelDataFormatter::interpretRawData(  bool& errorsInEvent, int fedId,
     int dcol = (ww >> m_DCOL_shift) & m_DCOL_mask;
     int pxid = (ww >> m_PXID_shift) & m_PXID_mask;
 
+    if(dcol<0||dcol>=26||pxid<2||pxid>161){
+      edm::LogError("CTPPSPixelDataFormatter")<< " unphysical dcol and/or pxid "  << " nllink=" << nlink 
+					      << " nroc="<< nroc << " adc=" << adc << " dcol=" << dcol << " pxid=" << pxid;
+      continue;
+    }
+
     std::pair<int,int> rocPixel;
     std::pair<int,int> modPixel;
 

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
@@ -22,6 +22,10 @@ namespace {
   constexpr int m_DCOL_bits = 5;
   constexpr int m_PXID_bits = 8;
   constexpr int m_ADC_bits  = 8;
+  constexpr int min_Dcol = 0;
+  constexpr int max_Dcol = 25;
+  constexpr int min_Pixid = 2;
+  constexpr int max_Pixid = 161;
 }
 
 CTPPSPixelDataFormatter::CTPPSPixelDataFormatter(std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo> const &mapping)  :  theWordCounter(0), mapping_(mapping)
@@ -148,7 +152,7 @@ void CTPPSPixelDataFormatter::interpretRawData(  bool& errorsInEvent, int fedId,
     int dcol = (ww >> m_DCOL_shift) & m_DCOL_mask;
     int pxid = (ww >> m_PXID_shift) & m_PXID_mask;
 
-    if(dcol<0||dcol>=26||pxid<2||pxid>161){
+    if(dcol<min_Dcol || dcol>max_Dcol || pxid<min_Pixid || pxid>max_Pixid){
       edm::LogError("CTPPSPixelDataFormatter")<< " unphysical dcol and/or pxid "  << " nllink=" << nlink 
 					      << " nroc="<< nroc << " adc=" << adc << " dcol=" << dcol << " pxid=" << pxid;
       continue;


### PR DESCRIPTION
adding small patch in the unpacker to prevent corrupted row/col from making the jobs crash (as in PR #20120 )