### PR TITLE
HGC Energy calibration for realistic simclusters

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h
@@ -245,7 +245,7 @@ bool stdsimplemove(DetId& cell,
     neighbours = barrelTopo.getNeighbours(ebDetId,dir);
 
     // first try to move according to the standard navigation
-    if(neighbours.size()>0 && !neighbours[0].null()) {
+    if(!neighbours.empty() && !neighbours[0].null()) {
       cell = neighbours[0];
       return true;
     }
@@ -276,7 +276,7 @@ bool stdsimplemove(DetId& cell,
 
     neighbours= endcapTopo.getNeighbours(eeDetId,dir);
 
-    if(neighbours.size()>0 && !neighbours[0].null()) {
+    if(!neighbours.empty() && !neighbours[0].null()) {
       cell = neighbours[0];
       return true;
     }

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
@@ -128,7 +128,7 @@ class PFEcalEndcapRecHitCreator :  public  PFRecHitCreatorBase {
     int iDccChan = EcalElecId.towerId();
     const bool ignoreSingle = true;
     const std::vector<EcalScDetId> id = elecMap_->getEcalScDetId(iDCC, iDccChan, ignoreSingle);
-    return id.size()>0?id[0]:EcalScDetId();
+    return !id.empty()?id[0]:EcalScDetId();
   }
 
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreatorMaxSample.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreatorMaxSample.h
@@ -159,7 +159,7 @@ class PFHBHERecHitCreatorMaxSample :  public  PFRecHitCreatorBase {
 
 	}	    
 
-	if (hitEnergies.size()==0)
+	if (hitEnergies.empty())
 	  continue;
 
 	int depth = detid.depth();

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
@@ -105,7 +105,7 @@ class PFHFRecHitCreator final :  public  PFRecHitCreatorBase {
       }
       //Sort by DetID the collection
       DetIDSorter sorter;
-      if (tmpOut.size()>0)
+      if (!tmpOut.empty())
 	std::sort(tmpOut.begin(),tmpOut.end(),sorter); 
 
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericTopoClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericTopoClusterizer.cc
@@ -37,7 +37,7 @@ buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
     if( !rechitMask[seed] || !seedable[seed] || used[seed] ) continue;    
     temp.reset();
     buildTopoCluster(input,rechitMask,seed,used,temp);
-    if( temp.recHitFractions().size() ) output.push_back(temp);
+    if( !temp.recHitFractions().empty() ) output.push_back(temp);
   }
 }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
@@ -51,7 +51,7 @@ public:
       conf.getParameter<edm::InputTag>("inputPS");
     _inputPS = consumes<reco::PFClusterCollection>( inputPS );
 
-    const edm::ParameterSet corConf = conf.getParameterSet("energyCorrector");
+    const edm::ParameterSet& corConf = conf.getParameterSet("energyCorrector");
     _corrector.reset(new PFClusterEMEnergyCorrector(corConf,consumesCollector()));
 
     produces<reco::PFCluster::EEtoPSAssociation>();

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/GenericSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/GenericSimClusterMapper.cc
@@ -56,7 +56,7 @@ buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
 	seed = ref;
       }
     }    
-    if( back.hitsAndFractions().size() != 0 ) {
+    if( !back.hitsAndFractions().empty() ) {
       back.setSeed(seed->detId());
       back.setEnergy(energy);   
       back.setCorrectedEnergy(energy);

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -25,19 +25,26 @@
 #endif
 
 namespace {
+
+inline
+bool isPi0(int pdgId)
+{
+    return pdgId == 111;
+}
+
 inline
 bool isEGamma(int pdgId)
 {
     pdgId = std::abs(pdgId);
-    return (pdgId == 11) or (pdgId == 22) or (pdgId == 111);
+    return (pdgId == 11) or (pdgId == 22);
 }
 
 inline
 bool isHadron(int pdgId)
 {
     pdgId = std::abs(pdgId) % 10000;
-    return (pdgId > 100 and pdgId < 900) or
-           (pdgId > 1000 and pdgId < 9000);
+    return ((pdgId > 100 and pdgId < 900) or
+           (pdgId > 1000 and pdgId < 9000));
 }
 }
 
@@ -115,7 +122,7 @@ void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCo
             auto abseta = std::abs(simClusters[ic].eta());
             if ((abseta >= calibMinEta_) and (abseta <= calibMaxEta_)) //protecting range
             {
-                if (isEGamma(pdgId) and !egammaCalib_.empty())
+                if ((isEGamma(pdgId) or isPi0(pdgId)) and !egammaCalib_.empty())
                 {
                     unsigned int etabin = std::floor(
                             ((abseta - calibMinEta_) * egammaCalib_.size())
@@ -123,7 +130,7 @@ void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCo
 
                     energyCorrection = egammaCalib_[etabin];
                 }
-                else if (isHadron(pdgId) && !hadronCalib_.empty()) // this function is expensive.. should we treat as hadron everything which is not egamma?
+                else if (isHadron(pdgId) and !(isPi0(pdgId)) and !hadronCalib_.empty()) // this function is expensive.. should we treat as hadron everything which is not egamma?
                 {
                     unsigned int etabin = std::floor(
                             ((abseta - calibMinEta_) * hadronCalib_.size())

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -29,7 +29,7 @@ inline
 bool isEGamma(int pdgId)
 {
     pdgId = std::abs(pdgId);
-    return (pdgId == 11) or (pdgId == 22);
+    return (pdgId == 11) or (pdgId == 22) or (pdgId == 111);
 }
 
 inline

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -31,6 +31,7 @@ bool isEGamma(int pdgId)
     pdgId = std::abs(pdgId);
     return (pdgId == 11) or (pdgId == 22);
 }
+
 inline
 bool isHadron(int pdgId)
 {
@@ -38,11 +39,7 @@ bool isHadron(int pdgId)
     return (pdgId > 100 and pdgId < 900) or
            (pdgId > 1000 and pdgId < 9000);
 }
-
-
 }
-
-
 
 void RealisticSimClusterMapper::updateEvent(const edm::Event& ev)
 {
@@ -52,7 +49,6 @@ void RealisticSimClusterMapper::updateEvent(const edm::Event& ev)
 void RealisticSimClusterMapper::update(const edm::EventSetup& es)
 {
     rhtools_.getEventSetup(es);
-
 }
 
 void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
@@ -153,7 +149,7 @@ void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCo
                 }
             }
         }
-        if (back.hitsAndFractions().size() != 0)
+        if (!back.hitsAndFractions().empty())
         {
             back.setSeed(seed->detId());
             back.setEnergy(realisticClusters[ic].getEnergy());

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.h
@@ -20,16 +20,21 @@ class RealisticSimClusterMapper : public InitialClusteringStepBase {
     exclusiveFraction_(conf.getParameter<double>("exclusiveFraction")),
     maxDistanceFilter_(conf.getParameter<bool>("maxDistanceFilter")),
     maxDistance_(conf.getParameter<double>("maxDistance")),
-    useMCFractionsForExclEnergy_(conf.getParameter<bool>("useMCFractionsForExclEnergy"))
+    useMCFractionsForExclEnergy_(conf.getParameter<bool>("useMCFractionsForExclEnergy")),
+    calibMinEta_(conf.getParameter<double>("calibMinEta")),
+    calibMaxEta_(conf.getParameter<double>("calibMaxEta"))
     {
       simClusterToken_ = sumes.consumes<SimClusterCollection>(conf.getParameter<edm::InputTag>("simClusterSrc"));
+      hadronCalib_ = conf.getParameter < std::vector<double> > ("hadronCalib");
+      egammaCalib_ = conf.getParameter < std::vector<double> > ("egammaCalib");
     }
-  virtual ~RealisticSimClusterMapper() {}
+
+  ~RealisticSimClusterMapper() override {}
   RealisticSimClusterMapper(const RealisticSimClusterMapper&) = delete;
   RealisticSimClusterMapper& operator=(const RealisticSimClusterMapper&) = delete;
 
-  virtual void updateEvent(const edm::Event&) override final;
-  virtual void update(const edm::EventSetup&) override final;
+  void updateEvent(const edm::Event&) final;
+  void update(const edm::EventSetup&) final;
 
   void buildClusters(const edm::Handle<reco::PFRecHitCollection>&,
 		     const std::vector<bool>&,
@@ -43,6 +48,11 @@ class RealisticSimClusterMapper : public InitialClusteringStepBase {
   const bool maxDistanceFilter_ = false;
   const float maxDistance_ = 10.f;
   const bool useMCFractionsForExclEnergy_ = false;
+  const float calibMinEta_ = 1.4;
+  const float calibMaxEta_ = 3.0;
+  std::vector<double> hadronCalib_;
+  std::vector<double> egammaCalib_;
+
   edm::EDGetTokenT<SimClusterCollection> simClusterToken_;
   edm::Handle<SimClusterCollection> simClusterH_;
   

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-
+from RecoParticleFlow.PFClusterProducer.particleFlowRealisticSimClusterHGCCalibrations_cfi import *
 #### PF CLUSTER HGCal ####
 
 #cleaning (none for now)
@@ -23,6 +23,10 @@ _simClusterMapper_HGCal = cms.PSet(
     useMCFractionsForExclEnergy = cms.bool(False),    
     thresholdsByDetector = cms.VPSet(
     ),
+    hadronCalib = hadronCorrections,
+    egammaCalib = egammaCorrections, 
+    calibMinEta = minEtaCorrection, 
+    calibMaxEta = maxEtaCorrection,                                   
     simClusterSrc = cms.InputTag("mix:MergedCaloTruth")
 )
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRealisticSimClusterHGCCalibrations_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRealisticSimClusterHGCCalibrations_cfi.py
@@ -2,5 +2,5 @@ import FWCore.ParameterSet.Config as cms
 
 minEtaCorrection = cms.double(1.4)
 maxEtaCorrection = cms.double(3.0)
-hadronCorrections = cms.vdouble(1.15, 1.15, 1.14, 1.14, 1.15, 1.17, 1.20, 1.20)  
+hadronCorrections = cms.vdouble(1.16, 1.10, 1.08, 1.08, 1.09, 1.11, 1.14, 1.26)  
 egammaCorrections = cms.vdouble(1.00, 1.00, 1.00, 1.00, 1.02, 1.03, 1.03, 1.03)  

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRealisticSimClusterHGCCalibrations_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRealisticSimClusterHGCCalibrations_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+minEtaCorrection = cms.double(1.4)
+maxEtaCorrection = cms.double(3.0)
+hadronCorrections = cms.vdouble(1.15, 1.15, 1.14, 1.14, 1.15, 1.17, 1.20, 1.20)  
+egammaCorrections = cms.vdouble(1.00, 1.00, 1.00, 1.00, 1.02, 1.03, 1.03, 1.03)  


### PR DESCRIPTION
This PR applies energy corrections for realistic simclusters so that 50GeV pions and photons with 5GeV energy have response 1.

https://indico.cern.ch/event/658375/contributions/2686991/attachments/1506366/2349119/HGCAL_RealisticSimClustersAndCalibration.pdf

