### PR TITLE
DetectorDescription Clang readability-avoid-const-params-in-decls

### DIFF
--- a/DetectorDescription/Core/src/Division.h
+++ b/DetectorDescription/Core/src/Division.h
@@ -1,5 +1,5 @@
-#ifndef DDI_Division_h
-#define DDI_Division_h
+#ifndef DETECTOR_DESCRIPTION_CORE_DDI_DIVISION_H
+#define DETECTOR_DESCRIPTION_CORE_DDI_DIVISION_H
 
 #include <iostream>
 #include <map>
@@ -13,24 +13,24 @@ namespace DDI {
   class Division {
     
   public:
-    Division(const DDLogicalPart & parent,
-	     const DDAxes axis,
-	     const int nReplicas,
-	     const double width,
-	     const double offset );
+    Division( const DDLogicalPart & parent,
+	      DDAxes axis,
+	      int nReplicas,
+	      double width,
+	      double offset );
       
       
     // Constructor with number of divisions 
-    Division(const DDLogicalPart & parent,
-	     const DDAxes axis,
-	     const int nReplicas,
-	     const double offset );
+    Division( const DDLogicalPart & parent,
+	      DDAxes axis,
+	      int nReplicas,
+	      double offset );
       
     // Constructor with width
-    Division(const DDLogicalPart & parent,
-	     const DDAxes axis,
-	     const double width,
-	     const double offset );
+    Division( const DDLogicalPart & parent,
+	      DDAxes axis,
+	      double width,
+	      double offset );
       
     DDAxes axis() const;
     int nReplicas() const;
@@ -48,4 +48,5 @@ namespace DDI {
       
   };
 }
+
 #endif

--- a/DetectorDescription/Parser/interface/DDLSAX2ConfigHandler.h
+++ b/DetectorDescription/Parser/interface/DDLSAX2ConfigHandler.h
@@ -1,19 +1,12 @@
-#ifndef DDL_SAX2ConfigHandler_H
-#define DDL_SAX2ConfigHandler_H
+#ifndef DETECTOR_DESCRIPTION_PARSER_DDL_SAX2_CONFIG_HANDLER_H
+#define DETECTOR_DESCRIPTION_PARSER_DDL_SAX2_CONFIG_HANDLER_H
 
-// ---------------------------------------------------------------------------
-//  Includes
-// ---------------------------------------------------------------------------
 #include "DetectorDescription/Parser/interface/DDLSAX2Handler.h"
-
-// DDCore parts
 #include "DetectorDescription/Core/interface/DDName.h"
 #include "DetectorDescription/Core/interface/DDCompactView.h"
 
 #include <vector>
 #include <string>
-
-// Xerces C++ dependencies
 #include <xercesc/sax2/Attributes.hpp>
 
 /// DDLSAX2ConfigHandler is the handler for the configuration file.
@@ -32,17 +25,14 @@ class DDLSAX2ConfigHandler : public DDLSAX2Handler
 
  public:
 
-  // -----------------------------------------------------------------------
-  //  Constructor and Destructor
-  // -----------------------------------------------------------------------
   DDLSAX2ConfigHandler( DDCompactView& cpv);
   ~DDLSAX2ConfigHandler() override;
 
   // -----------------------------------------------------------------------
   //  Handlers for the SAX ContentHandler interface
   // -----------------------------------------------------------------------
-  void startElement(const XMLCh* const uri, const XMLCh* const localname
-		    , const XMLCh* const qname, const Attributes& attrs) override;
+  void startElement( const XMLCh* uri, const XMLCh* localname,
+		     const XMLCh* qname, const Attributes& attrs) override;
 
   const std::vector<std::string>& getFileNames() const;
   const std::vector<std::string>& getURLs() const;
@@ -55,7 +45,6 @@ class DDLSAX2ConfigHandler : public DDLSAX2Handler
   std::vector<std::string> urls_;
   std::string schemaLocation_;
   DDCompactView& cpv_;
-
 };
 
 #endif

--- a/DetectorDescription/Parser/interface/DDLSAX2ExpressionHandler.h
+++ b/DetectorDescription/Parser/interface/DDLSAX2ExpressionHandler.h
@@ -1,5 +1,5 @@
-#ifndef DETECTORDESCRIPTION_PARSER_DDLSAX2EXPRESSIONHANDLER_H
-#define DETECTORDESCRIPTION_PARSER_DDLSAX2EXPRESSIONHANDLER_H
+#ifndef DETECTOR_DESCRIPTION_PARSER_DDL_SAX2_EXPRESSION_HANDLER_H
+#define DETECTOR_DESCRIPTION_PARSER_DDL_SAX2_EXPRESSION_HANDLER_H
 
 #include <xercesc/sax2/Attributes.hpp>
 #include <string>
@@ -28,11 +28,11 @@ class DDLSAX2ExpressionHandler : public DDLSAX2FileHandler
   DDLSAX2ExpressionHandler(DDCompactView& cpv);
   ~DDLSAX2ExpressionHandler() override;
 
-  void startElement(const XMLCh* const uri, const XMLCh* const localname,
-		    const XMLCh* const qname, const Attributes& attrs) override;
+  void startElement( const XMLCh* uri, const XMLCh* localname,
+		     const XMLCh* qname, const Attributes& attrs) override;
   
-  void endElement(const XMLCh* const uri, const XMLCh* const localname,
-		  const XMLCh* const qname) override;
+  void endElement( const XMLCh* uri, const XMLCh* localname,
+		   const XMLCh* qname) override;
 };
 
 #endif

--- a/DetectorDescription/Parser/interface/DDLSAX2FileHandler.h
+++ b/DetectorDescription/Parser/interface/DDLSAX2FileHandler.h
@@ -1,11 +1,11 @@
-#ifndef DETECTORDESCRIPTION_PARSER_DDL_SAX2FILEHANDLER_H
-#define DETECTORDESCRIPTION_PARSER_DDL_SAX2FILEHANDLER_H
+#ifndef DETECTOR_DESCRIPTION_PARSER_DDL_SAX2_FILE_HANDLER_H
+#define DETECTOR_DESCRIPTION_PARSER_DDL_SAX2_FILE_HANDLER_H
 
-#include <stddef.h>
-#include <xercesc/sax2/Attributes.hpp>
+#include <cstddef>
 #include <map>
 #include <string>
 #include <vector>
+#include <xercesc/sax2/Attributes.hpp>
 
 #include "DetectorDescription/Core/interface/DDCompactView.h"
 #include "DetectorDescription/Core/interface/DDName.h"
@@ -44,12 +44,12 @@ class DDLSAX2FileHandler : public DDLSAX2Handler
   //  Handlers for the SAX ContentHandler interface
   // -----------------------------------------------------------------------
   
-  void startElement(const XMLCh* const uri, const XMLCh* const localname,
-		    const XMLCh* const qname, const Attributes& attrs) override;
-  void endElement(const XMLCh* const uri, const XMLCh* const localname,
-		  const XMLCh* const qname) override;
-  void characters (const XMLCh *const chars, const XMLSize_t length) override;
-  void comment (const XMLCh *const chars, const XMLSize_t length ) override;
+  void startElement( const XMLCh* uri, const XMLCh* localname,
+		     const XMLCh* qname, const Attributes& attrs) override;
+  void endElement( const XMLCh* uri, const XMLCh* localname,
+		   const XMLCh* qname) override;
+  void characters( const XMLCh* chars, XMLSize_t length) override;
+  void comment( const XMLCh* chars, XMLSize_t length ) override;
   
  private:
   virtual const std::string& parent() const;

--- a/DetectorDescription/Parser/interface/DDLSAX2Handler.h
+++ b/DetectorDescription/Parser/interface/DDLSAX2Handler.h
@@ -1,5 +1,5 @@
-#ifndef DETECTORDESCRIPTION_PARSER_DDLSAX2HANDLER_H
-#define DETECTORDESCRIPTION_PARSER_DDLSAX2HANDLER_H
+#ifndef DETECTOR_DESCRIPTION_PARSER_DDL_SAX2_HANDLER_H
+#define DETECTOR_DESCRIPTION_PARSER_DDL_SAX2_HANDLER_H
 
 #include <xercesc/sax2/Attributes.hpp>
 #include <xercesc/sax2/DefaultHandler.hpp>
@@ -27,8 +27,8 @@
 class DDLSAX2Handler : public XERCES_CPP_NAMESPACE::DefaultHandler
 {
  public:
-  typedef XERCES_CPP_NAMESPACE::Attributes Attributes;
-  typedef XERCES_CPP_NAMESPACE::SAXParseException SAXParseException;
+  using Attributes = XERCES_CPP_NAMESPACE::Attributes;
+  using SAXParseException = XERCES_CPP_NAMESPACE::SAXParseException;
 
   DDLSAX2Handler();
   ~DDLSAX2Handler() override;
@@ -63,13 +63,13 @@ class DDLSAX2Handler : public XERCES_CPP_NAMESPACE::DefaultHandler
   //  Handlers for the SAX ContentHandler interface
   // -----------------------------------------------------------------------
 
-  void startElement(const XMLCh* const uri, const XMLCh* const localname,
-			    const XMLCh* const qname, const Attributes& attrs) override;
-  void endElement(const XMLCh* const uri, const XMLCh* const localname,
-			  const XMLCh* const qname) override;
-  void characters(const XMLCh* const chars, const XMLSize_t length) override;
-  void comment (const XMLCh *const chars, const XMLSize_t length ) override;
-  void ignorableWhitespace(const XMLCh* const chars, const XMLSize_t length) override;
+  void startElement( const XMLCh* uri, const XMLCh* localname,
+		     const XMLCh* qname, const Attributes& attrs ) override;
+  void endElement( const XMLCh* uri, const XMLCh* localname,
+		   const XMLCh* qname ) override;
+  void characters( const XMLCh* chars, XMLSize_t length ) override;
+  void comment( const XMLCh* chars, XMLSize_t length ) override;
+  void ignorableWhitespace( const XMLCh* chars, XMLSize_t length ) override;
   void resetDocument() override;
 
   // -----------------------------------------------------------------------

--- a/DetectorDescription/Parser/src/DDDividedBox.h
+++ b/DetectorDescription/Parser/src/DDDividedBox.h
@@ -1,10 +1,5 @@
-#ifndef DD_DividedBox_H
-#define DD_DividedBox_H
-
-//
-// ********************************************************************
-// 25.04.04 - M. Case ddd-ize G4ParametarisationBox*
-// ********************************************************************
+#ifndef DETECTOR_DESCRIPTION_PARSER_DD_DIVIDED_BOX_H
+#define DETECTOR_DESCRIPTION_PARSER_DD_DIVIDED_BOX_H
 
 #include "DDDividedGeometryObject.h"
 #include "DetectorDescription/Core/interface/DDTranslation.h"
@@ -21,9 +16,9 @@ class DDDividedBoxX final : public DDDividedGeometryObject
   DDDividedBoxX( const DDDivision& div, DDCompactView* cpv);
   
   double getMaxParameter() const override;
-  DDTranslation makeDDTranslation( const int copyNo ) const override;
-  DDRotation makeDDRotation( const int copyNo ) const override;
-  DDLogicalPart makeDDLogicalPart(const int copyNo) const override;
+  DDTranslation makeDDTranslation( int copyNo ) const override;
+  DDRotation makeDDRotation( int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( int copyNo) const override;
 };
 
 class DDDividedBoxY final : public DDDividedGeometryObject
@@ -33,9 +28,9 @@ class DDDividedBoxY final : public DDDividedGeometryObject
   DDDividedBoxY( const DDDivision& div, DDCompactView* cpv);
   
   double getMaxParameter() const override;
-  DDTranslation makeDDTranslation( const int copyNo ) const override;
-  DDRotation makeDDRotation( const int copyNo ) const override;
-  DDLogicalPart makeDDLogicalPart(const int copyNo) const override;
+  DDTranslation makeDDTranslation( int copyNo ) const override;
+  DDRotation makeDDRotation( int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( int copyNo) const override;
 };
 
 class DDDividedBoxZ final : public DDDividedGeometryObject
@@ -45,8 +40,9 @@ class DDDividedBoxZ final : public DDDividedGeometryObject
   DDDividedBoxZ( const DDDivision& div, DDCompactView* cpv);
   
   double getMaxParameter() const override;
-  DDTranslation makeDDTranslation( const int copyNo ) const override;
-  DDRotation makeDDRotation( const int copyNo ) const override;
-  DDLogicalPart makeDDLogicalPart(const int copyNo) const override;
+  DDTranslation makeDDTranslation( int copyNo ) const override;
+  DDRotation makeDDRotation( int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( int copyNo) const override;
 };
+
 #endif

--- a/DetectorDescription/Parser/src/DDDividedCons.h
+++ b/DetectorDescription/Parser/src/DDDividedCons.h
@@ -1,9 +1,5 @@
-#ifndef DD_DividedCons_H
-#define DD_DividedCons_H
-//
-// ********************************************************************
-// 25.04.04 - M. Case ddd-ize G4ParameterisationCons*
-// ********************************************************************
+#ifndef DETECTOR_DESCRIPTION_PARSER_DD_DIVIDED_CONS_H
+#define DETECTOR_DESCRIPTION_PARSER_DD_DIVIDED_CONS_H
 
 #include "DDDividedGeometryObject.h"
 #include "DetectorDescription/Core/interface/DDTranslation.h"
@@ -20,9 +16,9 @@ class DDDividedConsRho final : public DDDividedGeometryObject
   DDDividedConsRho( const DDDivision& div, DDCompactView* cpv );
 
   double getMaxParameter() const override;
-  DDTranslation makeDDTranslation( const int copyNo ) const override;
-  DDRotation makeDDRotation(const int copyNo ) const override;
-  DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+  DDTranslation makeDDTranslation( int copyNo ) const override;
+  DDRotation makeDDRotation( int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( int copyNo ) const override;
 };
 
 class DDDividedConsPhi final : public DDDividedGeometryObject
@@ -32,9 +28,9 @@ class DDDividedConsPhi final : public DDDividedGeometryObject
   DDDividedConsPhi( const DDDivision& div, DDCompactView* cpv );
 
   double getMaxParameter() const override;
-  DDTranslation makeDDTranslation( const int copyNo ) const override;
-  DDRotation makeDDRotation(const int copyNo ) const override;
-  DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+  DDTranslation makeDDTranslation( int copyNo ) const override;
+  DDRotation makeDDRotation( int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( int copyNo ) const override;
 };
 
 class DDDividedConsZ final : public DDDividedGeometryObject
@@ -44,9 +40,9 @@ class DDDividedConsZ final : public DDDividedGeometryObject
   DDDividedConsZ( const DDDivision& div, DDCompactView* cpv) ;
 
   double getMaxParameter() const override;
-  DDTranslation makeDDTranslation( const int copyNo ) const override;
-  DDRotation makeDDRotation(const int copyNo ) const override;
-  DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+  DDTranslation makeDDTranslation( int copyNo ) const override;
+  DDRotation makeDDRotation( int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( int copyNo ) const override;
 };
 
 #endif

--- a/DetectorDescription/Parser/src/DDDividedGeometryObject.h
+++ b/DetectorDescription/Parser/src/DDDividedGeometryObject.h
@@ -1,10 +1,5 @@
-#ifndef DD_DividedGeometryObject_H
-#define DD_DividedGeometryObject_H
-//
-// ********************************************************************
-// 25.04.04 - M.Case ported algorithm from G4VDivisionParameterisation.hh. to 
-//            DDD version
-//---------------------------------------------------------------------
+#ifndef DETECTOR_DESCRIPTION_PARSER_DD_DIVIDED_GEOMETRY_OBJECT_H
+#define DETECTOR_DESCRIPTION_PARSER_DD_DIVIDED_GEOMETRY_OBJECT_H
 
 #include <string>
 
@@ -30,9 +25,9 @@ public:
   
   virtual ~DDDividedGeometryObject( void ) = default; // inline
   
-  virtual DDTranslation makeDDTranslation( const int copyNo ) const;
-  virtual DDRotation    makeDDRotation   ( const int copyNo ) const;
-  virtual DDLogicalPart makeDDLogicalPart( const int copyNo ) const;
+  virtual DDTranslation makeDDTranslation( int copyNo ) const;
+  virtual DDRotation    makeDDRotation   ( int copyNo ) const;
+  virtual DDLogicalPart makeDDLogicalPart( int copyNo ) const;
 
   virtual const std::string& getType( void ) const;
 

--- a/DetectorDescription/Parser/src/DDDividedPolycone.h
+++ b/DetectorDescription/Parser/src/DDDividedPolycone.h
@@ -1,9 +1,5 @@
-#ifndef DD_DividedPolycone_H
-#define DD_DividedPolycone_H
-//
-// ********************************************************************
-// 25.04.04 - M. Case ddd-ize G4ParameterisationPolycone*
-//---------------------------------------------------------------------
+#ifndef DETECTOR_DESCRIPTION_PARSER_DD_DIVIDED_POLYCONE_H
+#define DETECTOR_DESCRIPTION_PARSER_DD_DIVIDED_POLYCONE_H
 
 #include "DDDividedGeometryObject.h"
 #include "DetectorDescription/Core/interface/DDTranslation.h"
@@ -13,10 +9,6 @@ class DDCompactView;
 class DDLogicalPart;
 class DDRotation;
 
-//---------------------------------------------------------------------
-// Class DDDividedPolycone
-//---------------------------------------------------------------------
-
 class DDDividedPolyconeRho final : public DDDividedGeometryObject
 { 
  public:
@@ -25,9 +17,9 @@ class DDDividedPolyconeRho final : public DDDividedGeometryObject
   
   void checkParametersValidity() override;
   double getMaxParameter() const override;
-  DDTranslation makeDDTranslation( const int copyNo ) const override;
-  DDRotation makeDDRotation(const int copyNo ) const override;
-  DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+  DDTranslation makeDDTranslation( int copyNo ) const override;
+  DDRotation makeDDRotation( int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( int copyNo ) const override;
 };
 
 class DDDividedPolyconePhi final : public DDDividedGeometryObject
@@ -38,9 +30,9 @@ class DDDividedPolyconePhi final : public DDDividedGeometryObject
   
   void checkParametersValidity() override;
   double getMaxParameter() const override;
-  DDTranslation makeDDTranslation( const int copyNo ) const override;
-  DDRotation makeDDRotation(const int copyNo ) const override;
-  DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+  DDTranslation makeDDTranslation( int copyNo ) const override;
+  DDRotation makeDDRotation( int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( int copyNo ) const override;
 };
 
 class DDDividedPolyconeZ final : public DDDividedGeometryObject
@@ -51,9 +43,9 @@ class DDDividedPolyconeZ final : public DDDividedGeometryObject
   
   void checkParametersValidity() override;
   double getMaxParameter() const override;
-  DDTranslation makeDDTranslation( const int copyNo ) const override;
-  DDRotation makeDDRotation( const int copyNo ) const override;
-  DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+  DDTranslation makeDDTranslation( int copyNo ) const override;
+  DDRotation makeDDRotation( int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( int copyNo ) const override;
 };
 
 #endif

--- a/DetectorDescription/Parser/src/DDDividedPolyhedra.h
+++ b/DetectorDescription/Parser/src/DDDividedPolyhedra.h
@@ -1,9 +1,5 @@
-#ifndef DDDividedPolyhedra_H
-#define DDDividedPolyhedra_H
-//
-// ********************************************************************
-// 25.04.04 - M. Case ddd-ize G4ParameterisationPolyhedra*
-//---------------------------------------------------------------------
+#ifndef DETECTOR_DESCRIPTION_PARSER_DD_DIVIDED_POLYHEDRA_H
+#define DETECTOR_DESCRIPTION_PARSER_DD_DIVIDED_POLYHEDRA_H
 
 #include "DDDividedGeometryObject.h"
 #include "DetectorDescription/Core/interface/DDTranslation.h"
@@ -13,10 +9,6 @@ class DDCompactView;
 class DDLogicalPart;
 class DDRotation;
 
-//---------------------------------------------------------------------
-// Class DDDividedPolyhedraRho
-//---------------------------------------------------------------------
-
 class DDDividedPolyhedraRho final : public DDDividedGeometryObject
 { 
  public:  
@@ -25,14 +17,10 @@ class DDDividedPolyhedraRho final : public DDDividedGeometryObject
   
   void checkParametersValidity() override;
   double getMaxParameter() const override;
-  DDTranslation makeDDTranslation( const int copyNo ) const override;
-  DDRotation makeDDRotation(const int copyNo ) const override;
-  DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+  DDTranslation makeDDTranslation( int copyNo ) const override;
+  DDRotation makeDDRotation( int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( int copyNo ) const override;
 };
-
-//---------------------------------------------------------------------
-// Class DDDividedPolyhedraPhi
-//---------------------------------------------------------------------
 
 class DDDividedPolyhedraPhi final : public DDDividedGeometryObject
 { 
@@ -42,14 +30,10 @@ class DDDividedPolyhedraPhi final : public DDDividedGeometryObject
 
   void checkParametersValidity() override;
   double getMaxParameter() const override;
-  DDTranslation makeDDTranslation( const int copyNo ) const override;
-  DDRotation makeDDRotation(const int copyNo ) const override;
-  DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+  DDTranslation makeDDTranslation( int copyNo ) const override;
+  DDRotation makeDDRotation( int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( int copyNo ) const override;
 };
-
-//---------------------------------------------------------------------
-// Class DDDividedPolyhedraZ
-//---------------------------------------------------------------------
 
 class DDDividedPolyhedraZ final : public DDDividedGeometryObject
 { 
@@ -59,9 +43,9 @@ class DDDividedPolyhedraZ final : public DDDividedGeometryObject
 
   void checkParametersValidity() override;
   double getMaxParameter() const override;
-  DDTranslation makeDDTranslation( const int copyNo ) const override;
-  DDRotation makeDDRotation(const int copyNo ) const override;
-  DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+  DDTranslation makeDDTranslation( int copyNo ) const override;
+  DDRotation makeDDRotation( int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( int copyNo ) const override;
 };
 
 #endif

--- a/DetectorDescription/Parser/src/DDDividedTrd.h
+++ b/DetectorDescription/Parser/src/DDDividedTrd.h
@@ -1,8 +1,5 @@
-#ifndef DDDividedTrd_H
-#define DDDividedTrd_H//
-// ********************************************************************
-// 25.04.04 - M. Case ddd-ize G4ParameterisationTrd*
-// ********************************************************************
+#ifndef DETECTOR_DESCRIPTION_PARSER_DD_DIVIDED_TRD_H
+#define DETECTOR_DESCRIPTION_PARSER_DD_DIVIDED_TRD_H
 
 #include "DDDividedGeometryObject.h"
 #include "DetectorDescription/Core/interface/DDTranslation.h"
@@ -14,41 +11,41 @@ class DDRotation;
 
 class DDDividedTrdX final : public DDDividedGeometryObject
 { 
-  public:
-
-    DDDividedTrdX( const DDDivision& div, DDCompactView* cpv );
-
-    void checkParametersValidity() override;
-    double getMaxParameter() const override;
-    DDTranslation makeDDTranslation( const int copyNo ) const override;
-    DDRotation makeDDRotation(const int copyNo ) const override;
-    DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+ public:
+  
+  DDDividedTrdX( const DDDivision& div, DDCompactView* cpv );
+  
+  void checkParametersValidity() override;
+  double getMaxParameter() const override;
+  DDTranslation makeDDTranslation( int copyNo ) const override;
+  DDRotation makeDDRotation( int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( int copyNo ) const override;
 };
 
 class DDDividedTrdY final : public DDDividedGeometryObject
 { 
-  public:
-
-    DDDividedTrdY( const DDDivision& div, DDCompactView* cpv );
-
-    void checkParametersValidity() override;
-    double getMaxParameter() const override;
-    DDTranslation makeDDTranslation( const int copyNo ) const override;
-    DDRotation makeDDRotation(const int copyNo ) const override;
-    DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+ public:
+  
+  DDDividedTrdY( const DDDivision& div, DDCompactView* cpv );
+  
+  void checkParametersValidity() override;
+  double getMaxParameter() const override;
+  DDTranslation makeDDTranslation( int copyNo ) const override;
+  DDRotation makeDDRotation( int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( int copyNo ) const override;
 };
 
 class DDDividedTrdZ final : public DDDividedGeometryObject
 {
-  public:
+ public:
 
-    DDDividedTrdZ( const DDDivision& div, DDCompactView* cpv );
-
-    void checkParametersValidity() override;
-    double getMaxParameter() const override;
-    DDTranslation makeDDTranslation( const int copyNo ) const override;
-    DDRotation makeDDRotation(const int copyNo ) const override;
-    DDLogicalPart makeDDLogicalPart( const int copyNo ) const override;
+  DDDividedTrdZ( const DDDivision& div, DDCompactView* cpv );
+  
+  void checkParametersValidity() override;
+  double getMaxParameter() const override;
+  DDTranslation makeDDTranslation( int copyNo ) const override;
+  DDRotation makeDDRotation( int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( int copyNo ) const override;
 };
 
 #endif

--- a/DetectorDescription/Parser/src/DDDividedTubs.h
+++ b/DetectorDescription/Parser/src/DDDividedTubs.h
@@ -1,9 +1,5 @@
-#ifndef DD_DividedTubs_H
-#define DD_DividedTubs_H
-//
-// ********************************************************************
-// 25.04.04 - M. Case ddd-ize  G4ParameterisationTubs*
-// ********************************************************************
+#ifndef DETECTOR_DESCRIPTION_PARSER_DD_DIVIDED_TUBS_H
+#define DETECTOR_DESCRIPTION_PARSER_DD_DIVIDED_TUBS_H
 
 #include "DDDividedGeometryObject.h"
 #include "DetectorDescription/Core/interface/DDTranslation.h"
@@ -18,11 +14,11 @@ class DDDividedTubsRho final : public DDDividedGeometryObject
  public:
 
   DDDividedTubsRho( const DDDivision& div, DDCompactView* cpv );
-
+  
   double getMaxParameter() const override;
-  DDTranslation makeDDTranslation( const int copyNo ) const override;
-  DDRotation makeDDRotation( const int copyNo ) const override;
-  DDLogicalPart makeDDLogicalPart(const int copyNo ) const override;
+  DDTranslation makeDDTranslation( int copyNo ) const override;
+  DDRotation makeDDRotation( int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( int copyNo ) const override;
 };
 
 class DDDividedTubsPhi final : public DDDividedGeometryObject
@@ -32,9 +28,9 @@ class DDDividedTubsPhi final : public DDDividedGeometryObject
   DDDividedTubsPhi( const DDDivision& div, DDCompactView* cpv );
   
   double getMaxParameter() const override;
-  DDTranslation makeDDTranslation( const int copyNo ) const override;
-  DDRotation makeDDRotation( const int copyNo ) const override;
-  DDLogicalPart makeDDLogicalPart(const int copyNo ) const override;
+  DDTranslation makeDDTranslation( int copyNo ) const override;
+  DDRotation makeDDRotation( int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( int copyNo ) const override;
 };
 
 class DDDividedTubsZ final : public DDDividedGeometryObject
@@ -44,9 +40,9 @@ class DDDividedTubsZ final : public DDDividedGeometryObject
   DDDividedTubsZ( const DDDivision& div, DDCompactView* cpv );
 
   double getMaxParameter() const override;
-  DDTranslation makeDDTranslation( const int copyNo ) const override;
-  DDRotation makeDDRotation( const int copyNo ) const override;
-  DDLogicalPart makeDDLogicalPart(const int copyNo ) const override;
+  DDTranslation makeDDTranslation( int copyNo ) const override;
+  DDRotation makeDDRotation( int copyNo ) const override;
+  DDLogicalPart makeDDLogicalPart( int copyNo ) const override;
 };
 
 #endif

--- a/DetectorDescription/RegressionTest/src/SaxToDom.h
+++ b/DetectorDescription/RegressionTest/src/SaxToDom.h
@@ -1,5 +1,5 @@
-#ifndef x_SaxToDom_h
-#define x_SaxToDom_h
+#ifndef DETECTOR_DESCRIPTION_REGRESSION_TEST_SAXTODOM_H
+#define DETECTOR_DESCRIPTION_REGRESSION_TEST_SAXTODOM_H
 
 #include <xercesc/util/XercesDefs.hpp>
 #include <map>
@@ -17,15 +17,14 @@
 class SaxToDom : public XERCES_CPP_NAMESPACE::DefaultHandler
 {
 public:
-  typedef XERCES_CPP_NAMESPACE::Attributes Attributes;
-  typedef XERCES_CPP_NAMESPACE::SAXParseException SAXParseException;
+  using Attributes = XERCES_CPP_NAMESPACE::Attributes;
+  using SAXParseException = XERCES_CPP_NAMESPACE::SAXParseException;
   SaxToDom();
   ~SaxToDom() override;
-  void startElement(const XMLCh* const uri, const XMLCh* const localname, const XMLCh* const qname, const Attributes& attrs) override;
-  //void startElement(const XMLCh* const name, AttributeList& attributes);
-  void endElement(const XMLCh* const uri, 
-                            const XMLCh* const name, 
-			       const XMLCh* const qname) override;
+  void startElement(const XMLCh* uri, const XMLCh* localname, const XMLCh* qname, const Attributes& attrs) override;
+  void endElement(const XMLCh* uri, 
+		  const XMLCh* name, 
+		  const XMLCh* qname) override;
   const TinyDom & dom() const;
 
   // errors

--- a/DetectorDescription/RegressionTest/src/SaxToDom2.h
+++ b/DetectorDescription/RegressionTest/src/SaxToDom2.h
@@ -1,5 +1,5 @@
-#ifndef x_SaxToDom2_h
-#define x_SaxToDom2_h
+#ifndef DETECTOR_DESCRIPTION_REGRESSION_TEST_SAXTODOM2_H
+#define DETECTOR_DESCRIPTION_REGRESSION_TEST_SAXTODOM2_H
 
 #include <xercesc/util/XercesDefs.hpp>
 #include <map>
@@ -20,15 +20,14 @@ class SaxToDom2 : public XERCES_CPP_NAMESPACE::DefaultHandler
 {
 
 public:
-  typedef XERCES_CPP_NAMESPACE::Attributes Attributes;
-  typedef XERCES_CPP_NAMESPACE::SAXParseException SAXParseException;
+  using Attributes = XERCES_CPP_NAMESPACE::Attributes;
+  using SAXParseException = XERCES_CPP_NAMESPACE::SAXParseException;
   SaxToDom2();
   ~SaxToDom2() override;
-  void startElement(const XMLCh* const uri, const XMLCh* const localname, const XMLCh* const qname, const Attributes& attrs) override;
-  //void startElement(const XMLCh* const name, AttributeList& attributes);
-  void endElement(const XMLCh* const uri, 
-                            const XMLCh* const name, 
-			       const XMLCh* const qname) override;
+  void startElement(const XMLCh* uri, const XMLCh* localname, const XMLCh* qname, const Attributes& attrs) override;
+  void endElement(const XMLCh* uri,
+		  const XMLCh* name, 
+		  const XMLCh* qname) override;
   const TinyDom2 & dom() const;
 
   // errors


### PR DESCRIPTION
* DetectorDescription part of @davidlange6's https://github.com/cms-sw/cmssw/pull/19660

* Other cleanups