### PR TITLE
Run2-hcx142 Make codes compatible with current HCAL geometry

### DIFF
--- a/Calibration/HcalIsolatedTrackReco/interface/EcalIsolatedParticleCandidateProducer.h
+++ b/Calibration/HcalIsolatedTrackReco/interface/EcalIsolatedParticleCandidateProducer.h
@@ -2,14 +2,12 @@
 #define Calibration_EcalIsolatedParticleCandidateProducer_h
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
@@ -18,30 +16,27 @@
 // class decleration
 //
 
-class EcalIsolatedParticleCandidateProducer : public edm::EDProducer {
-   public:
-      explicit EcalIsolatedParticleCandidateProducer(const edm::ParameterSet&);
-      ~EcalIsolatedParticleCandidateProducer();
+class EcalIsolatedParticleCandidateProducer : public edm::global::EDProducer<> {
+public:
+  explicit EcalIsolatedParticleCandidateProducer(const edm::ParameterSet&);
+  ~EcalIsolatedParticleCandidateProducer();
 
-   private:
+private:
+  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  virtual void beginJob() override;
+  virtual void endJob() override;
 
-    const CaloGeometry* geo;
+  double InConeSize_;
+  double OutConeSize_;
+  double hitCountEthr_;
+  double hitEthr_;
 
-    double InConeSize_;
-    double OutConeSize_;
-    double hitCountEthr_;
-    double hitEthr_;
-
-    edm::EDGetTokenT<l1extra::L1JetParticleCollection> tok_l1tau_;
-    edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tok_hlt_;
-    edm::EDGetTokenT<EcalRecHitCollection> tok_EB_;
-    edm::EDGetTokenT<EcalRecHitCollection> tok_EE_;
-
-      virtual void beginJob() ;
-      virtual void produce(edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+  edm::EDGetTokenT<l1extra::L1JetParticleCollection> tok_l1tau_;
+  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tok_hlt_;
+  edm::EDGetTokenT<EcalRecHitCollection> tok_EB_;
+  edm::EDGetTokenT<EcalRecHitCollection> tok_EE_;
       
-      // ----------member data ---------------------------
+  // ----------member data ---------------------------
 };
 
 #endif

--- a/Calibration/HcalIsolatedTrackReco/interface/EcalIsolatedParticleCandidateProducer.h
+++ b/Calibration/HcalIsolatedTrackReco/interface/EcalIsolatedParticleCandidateProducer.h
@@ -22,9 +22,9 @@ public:
   ~EcalIsolatedParticleCandidateProducer();
 
 private:
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-  virtual void beginJob() override;
-  virtual void endJob() override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void beginJob() override;
+  void endJob() override;
 
   double InConeSize_;
   double OutConeSize_;

--- a/Calibration/HcalIsolatedTrackReco/src/EcalIsolatedParticleCandidateProducer.cc
+++ b/Calibration/HcalIsolatedTrackReco/src/EcalIsolatedParticleCandidateProducer.cc
@@ -28,14 +28,11 @@
 
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/DetId/interface/DetId.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloTopology/interface/EcalBarrelTopology.h"
-
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 #include "Calibration/HcalIsolatedTrackReco/interface/EcalIsolatedParticleCandidateProducer.h"
-
-
-
 
 EcalIsolatedParticleCandidateProducer::EcalIsolatedParticleCandidateProducer(const edm::ParameterSet& conf)
 {
@@ -69,19 +66,18 @@ EcalIsolatedParticleCandidateProducer::~EcalIsolatedParticleCandidateProducer()
 
 // ------------ method called to produce the data  ------------
 void 
-EcalIsolatedParticleCandidateProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+EcalIsolatedParticleCandidateProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
 
 //  std::cout<<"get tau"<<std::endl;
 
   edm::Handle<l1extra::L1JetParticleCollection> l1Taus;
   iEvent.getByToken(tok_l1tau_,l1Taus);
-
+  
 //  std::cout<<"get geom"<<std::endl;
 
   edm::ESHandle<CaloGeometry> pG;
   iSetup.get<CaloGeometryRecord>().get(pG);
-  geo = pG.product();
+  const CaloGeometry* geo = pG.product();
 
 //  std::cout<<" get ec rechit"<<std::endl;
 

--- a/Calibration/HcalIsolatedTrackReco/src/EcalIsolatedParticleCandidateProducer.cc
+++ b/Calibration/HcalIsolatedTrackReco/src/EcalIsolatedParticleCandidateProducer.cc
@@ -135,7 +135,7 @@ EcalIsolatedParticleCandidateProducer::produce(edm::StreamID, edm::Event& iEvent
 //	std::cout<<" loops over rechits"<<std::endl;
     for (EcalRecHitCollection::const_iterator eItr=ecalEB->begin(); eItr!=ecalEB->end(); eItr++) {
       double phiD, R;
-      GlobalPoint pos = geo->getPosition(eItr->detid());
+      const GlobalPoint& pos = geo->getPosition(eItr->detid());
       double phihit = pos.phi();
       double etahit = pos.eta();
       phiD=fabs(phihit-tit->phi());
@@ -160,7 +160,7 @@ EcalIsolatedParticleCandidateProducer::produce(edm::StreamID, edm::Event& iEvent
     
     for (EcalRecHitCollection::const_iterator eItr=ecalEE->begin(); eItr!=ecalEE->end(); eItr++)  {
       double phiD, R;
-      GlobalPoint pos = geo->getPosition(eItr->detid());
+      const GlobalPoint& pos = geo->getPosition(eItr->detid());
       double phihit = pos.phi();
       double etahit = pos.eta();
       phiD=fabs(phihit-tit->phi());

--- a/Calibration/HcalIsolatedTrackReco/src/EcalIsolatedParticleCandidateProducer.cc
+++ b/Calibration/HcalIsolatedTrackReco/src/EcalIsolatedParticleCandidateProducer.cc
@@ -18,6 +18,7 @@
 
 
 // system include files
+#include <cmath>
 #include <memory>
 
 // user include files
@@ -70,38 +71,36 @@ EcalIsolatedParticleCandidateProducer::~EcalIsolatedParticleCandidateProducer()
 void 
 EcalIsolatedParticleCandidateProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
- 
-  using namespace edm;
 
 //  std::cout<<"get tau"<<std::endl;
 
-  Handle<l1extra::L1JetParticleCollection> l1Taus;
+  edm::Handle<l1extra::L1JetParticleCollection> l1Taus;
   iEvent.getByToken(tok_l1tau_,l1Taus);
 
 //  std::cout<<"get geom"<<std::endl;
 
-  ESHandle<CaloGeometry> pG;
+  edm::ESHandle<CaloGeometry> pG;
   iSetup.get<CaloGeometryRecord>().get(pG);
   geo = pG.product();
 
 //  std::cout<<" get ec rechit"<<std::endl;
 
-  Handle<EcalRecHitCollection> ecalEB;
+  edm::Handle<EcalRecHitCollection> ecalEB;
   iEvent.getByToken(tok_EB_,ecalEB);
 
-  Handle<EcalRecHitCollection> ecalEE;
+  edm::Handle<EcalRecHitCollection> ecalEE;
   iEvent.getByToken(tok_EE_,ecalEE);
 
 //  std::cout<<"get l1 trig obj"<<std::endl;
 
-  Handle<trigger::TriggerFilterObjectWithRefs> l1trigobj;
+  edm::Handle<trigger::TriggerFilterObjectWithRefs> l1trigobj;
   iEvent.getByToken(tok_hlt_, l1trigobj);
 
-  std::vector< edm::Ref<l1extra::L1JetParticleCollection> > l1tauobjref;
-  std::vector< edm::Ref<l1extra::L1JetParticleCollection> > l1jetobjref;
-
-  l1trigobj->getObjects(trigger::TriggerL1TauJet, l1tauobjref);
-  l1trigobj->getObjects(trigger::TriggerL1CenJet, l1jetobjref);
+  std::vector< edm::Ref<l1t::TauBxCollection> > l1tauobjref;
+  std::vector< edm::Ref<l1t::JetBxCollection> > l1jetobjref;
+  
+  l1trigobj->getObjects(trigger::TriggerL1Tau, l1tauobjref);
+  l1trigobj->getObjects(trigger::TriggerL1Jet, l1jetobjref);
    
   double ptTriggered=-10;
   double etaTriggered=-100;
@@ -109,101 +108,86 @@ EcalIsolatedParticleCandidateProducer::produce(edm::Event& iEvent, const edm::Ev
 
 //  std::cout<<"find highest pT triggered obj"<<std::endl;
 
-  for (unsigned int p=0; p<l1tauobjref.size(); p++)
-        {
-        if (l1tauobjref[p]->pt()>ptTriggered)
-                {
-                ptTriggered=l1tauobjref[p]->pt();
-                phiTriggered=l1tauobjref[p]->phi();
-                etaTriggered=l1tauobjref[p]->eta();
-                }
-        }
-  for (unsigned int p=0; p<l1jetobjref.size(); p++)
-        {
-        if (l1jetobjref[p]->pt()>ptTriggered)
-                {
-                ptTriggered=l1jetobjref[p]->pt();
-                phiTriggered=l1jetobjref[p]->phi();
-                etaTriggered=l1jetobjref[p]->eta();
-                }
-        }
+  for (unsigned int p=0; p<l1tauobjref.size(); p++) {
+    if (l1tauobjref[p]->pt()>ptTriggered) {
+      ptTriggered=l1tauobjref[p]->pt();
+      phiTriggered=l1tauobjref[p]->phi();
+      etaTriggered=l1tauobjref[p]->eta();
+    }
+  }
+  for (unsigned int p=0; p<l1jetobjref.size(); p++) {
+    if (l1jetobjref[p]->pt()>ptTriggered) {
+      ptTriggered=l1jetobjref[p]->pt();
+      phiTriggered=l1jetobjref[p]->phi();
+      etaTriggered=l1jetobjref[p]->eta();
+    }
+  }
 
   auto iptcCollection = std::make_unique<reco::IsolatedPixelTrackCandidateCollection>();
 
 //  std::cout<<"loop over l1taus"<<std::endl;
 
-  for (l1extra::L1JetParticleCollection::const_iterator tit=l1Taus->begin(); tit!=l1Taus->end(); tit++)
-	{
-	double dphi=fabs(tit->phi()-phiTriggered);
-	if (dphi>3.1415926535) dphi=2*3.1415926535-dphi;
-	double Rseed=sqrt(pow(etaTriggered-tit->eta(),2)+dphi*dphi);
-	if (Rseed<1.2) continue;
-	int nhitOut=0;
-	int nhitIn=0;
-	double OutEnergy=0;
-	double InEnergy=0;
+  for (l1extra::L1JetParticleCollection::const_iterator tit=l1Taus->begin(); tit!=l1Taus->end(); tit++) {
+    double dphi=fabs(tit->phi()-phiTriggered);
+    if (dphi>M_PI) dphi=2*M_PI-dphi;
+    double Rseed=sqrt(pow(etaTriggered-tit->eta(),2)+dphi*dphi);
+    if (Rseed<1.2) continue;
+    int nhitOut=0;
+    int nhitIn=0;
+    double OutEnergy=0;
+    double InEnergy=0;
 //	std::cout<<" loops over rechits"<<std::endl;
-	for (EcalRecHitCollection::const_iterator eItr=ecalEB->begin(); eItr!=ecalEB->end(); eItr++)
-		{
-		double phiD, R;
-                GlobalPoint pos = geo->getPosition(eItr->detid());
-                double phihit = pos.phi();
-                double etahit = pos.eta();
-                phiD=fabs(phihit-tit->phi());
-                if (phiD>3.1415926535) phiD=2*3.1415926535-phiD;
-                R=sqrt(pow(etahit-tit->eta(),2)+phiD*phiD);
+    for (EcalRecHitCollection::const_iterator eItr=ecalEB->begin(); eItr!=ecalEB->end(); eItr++) {
+      double phiD, R;
+      GlobalPoint pos = geo->getPosition(eItr->detid());
+      double phihit = pos.phi();
+      double etahit = pos.eta();
+      phiD=fabs(phihit-tit->phi());
+      if (phiD>M_PI) phiD=2*M_PI-phiD;
+      R=sqrt(pow(etahit-tit->eta(),2)+phiD*phiD);
                 
-		if (R<OutConeSize_&&R>InConeSize_&&eItr->energy()>hitCountEthr_)
-                	{
-                  	nhitOut++;
-                	}
-		if (R<InConeSize_&&eItr->energy()>hitCountEthr_)
-                        {
-                        nhitIn++;
-                        }
+      if (R<OutConeSize_&&R>InConeSize_&&eItr->energy()>hitCountEthr_) {
+	nhitOut++;
+      }
+      if (R<InConeSize_&&eItr->energy()>hitCountEthr_)                 {
+	nhitIn++;
+      }
 
-		if (R<OutConeSize_&&R>InConeSize_&&eItr->energy()>hitEthr_)
-                        {
-                        OutEnergy+=eItr->energy();
-                        }
-                if (R<InConeSize_&&eItr->energy()>hitEthr_)
-                        {
-                        InEnergy+=eItr->energy();
-                        }
+      if (R<OutConeSize_&&R>InConeSize_&&eItr->energy()>hitEthr_)      {
+	OutEnergy+=eItr->energy();
+      }
+      if (R<InConeSize_&&eItr->energy()>hitEthr_)                      {
+	InEnergy+=eItr->energy();
+      }
 
-                }
+    }
+    
+    for (EcalRecHitCollection::const_iterator eItr=ecalEE->begin(); eItr!=ecalEE->end(); eItr++)  {
+      double phiD, R;
+      GlobalPoint pos = geo->getPosition(eItr->detid());
+      double phihit = pos.phi();
+      double etahit = pos.eta();
+      phiD=fabs(phihit-tit->phi());
+      if (phiD>M_PI) phiD=2*M_PI-phiD;
+      R=sqrt(pow(etahit-tit->eta(),2)+phiD*phiD);
+      if (R<OutConeSize_&&R>InConeSize_&&eItr->energy()>hitCountEthr_)  {
+	nhitOut++;
+      }
+      if (R<InConeSize_&&eItr->energy()>hitCountEthr_)                  {
+	nhitIn++;
+      }
+      if (R<OutConeSize_&&R>InConeSize_&&eItr->energy()>hitEthr_)       {
+	OutEnergy+=eItr->energy();
+      }
+      if (R<InConeSize_&&eItr->energy()>hitEthr_)                       {
+	InEnergy+=eItr->energy();
+      }
 
-	for (EcalRecHitCollection::const_iterator eItr=ecalEE->begin(); eItr!=ecalEE->end(); eItr++)
-                {
-                double phiD, R;
-                GlobalPoint pos = geo->getPosition(eItr->detid());
-                double phihit = pos.phi();
-                double etahit = pos.eta();
-                phiD=fabs(phihit-tit->phi());
-                if (phiD>3.1415926535) phiD=2*3.1415926535-phiD;
-                R=sqrt(pow(etahit-tit->eta(),2)+phiD*phiD);
-                if (R<OutConeSize_&&R>InConeSize_&&eItr->energy()>hitCountEthr_)
-                        {
-                        nhitOut++;
-                        }
-                if (R<InConeSize_&&eItr->energy()>hitCountEthr_)
-                        {
-                        nhitIn++;
-                        }
-		if (R<OutConeSize_&&R>InConeSize_&&eItr->energy()>hitEthr_)
-                        {
-                        OutEnergy+=eItr->energy();
-                        }
-                if (R<InConeSize_&&eItr->energy()>hitEthr_)
-                        {
-                        InEnergy+=eItr->energy();
-                        }
-
-                }
+    }
 //	std::cout<<"create and push_back candidate"<<std::endl;
-	reco::IsolatedPixelTrackCandidate newca(l1extra::L1JetParticleRef(l1Taus,tit-l1Taus->begin()), InEnergy, OutEnergy, nhitIn, nhitOut);
-        iptcCollection->push_back(newca);	
-	}
+    reco::IsolatedPixelTrackCandidate newca(l1extra::L1JetParticleRef(l1Taus,tit-l1Taus->begin()), InEnergy, OutEnergy, nhitIn, nhitOut);
+    iptcCollection->push_back(newca);	
+  }
 
 
   

--- a/Calibration/IsolatedParticles/BuildFile.xml
+++ b/Calibration/IsolatedParticles/BuildFile.xml
@@ -27,11 +27,12 @@
 <use   name="SimTracker/TrackerHitAssociation"/>
 <use   name="SimGeneral/HepPDTRecord"/>
 <use   name="Geometry/CaloGeometry"/>
-<use   name="Geometry/CommonDetUnit"/>
-<use   name="Geometry/TrackerGeometryBuilder"/>
-<use   name="Geometry/EcalAlgo"/>
 <use   name="Geometry/CaloTopology"/>
+<use   name="Geometry/CommonDetUnit"/>
+<use   name="Geometry/EcalAlgo"/>
+<use   name="Geometry/HcalTowerAlgo"/>
 <use   name="Geometry/Records"/>
+<use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="RecoLocalCalo/EcalRecAlgos"/>
 <use   name="TrackingTools/TrajectoryState"/>
 <use   name="TrackingTools/GeomPropagators"/>

--- a/Calibration/IsolatedParticles/interface/CaloSimInfo.icc
+++ b/Calibration/IsolatedParticles/interface/CaloSimInfo.icc
@@ -307,7 +307,7 @@ namespace spr{
         std::cout << " " << matchedId[it];
       std::cout << std::endl;
     }
-    if (matchedId.size() > 0) {
+    if (!matchedId.empty()) {
       typename T::const_iterator ihit;
       for (ihit=hits->begin(); ihit!=hits->end(); ihit++) {
 
@@ -348,7 +348,7 @@ namespace spr{
         std::cout << " " << matchedId[it];
       std::cout << std::endl;
     }
-    if (matchedId.size() > 0) {
+    if (!matchedId.empty()) {
       typename T::const_iterator ihit;
       for (ihit=hitsEB->begin(); ihit!=hitsEB->end(); ihit++) {
 

--- a/Calibration/IsolatedParticles/src/CaloSimInfo.cc
+++ b/Calibration/IsolatedParticles/src/CaloSimInfo.cc
@@ -1,7 +1,9 @@
+#include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 #include "Calibration/IsolatedParticles/interface/CaloConstants.h"
 #include "Calibration/IsolatedParticles/interface/CaloSimInfo.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 
 #include "CLHEP/Units/PhysicalConstants.h"
 #include "CLHEP/Units/SystemOfUnits.h"
@@ -14,13 +16,16 @@ namespace spr{
 
   double timeOfFlight(DetId id, const CaloGeometry* geo, bool debug) {
 
-    double R   = geo->getPosition(id).mag();
+    GlobalPoint point = (id.det() == DetId::Hcal) ? 
+      ((HcalGeometry*)(geo->getSubdetectorGeometry(id)))->getPosition(id) : 
+      geo->getPosition(id);
+    double R   = point.mag();
     double tmp = R/CLHEP::c_light/CLHEP::ns;
 #ifdef EDM_ML_DEBUG
     if (debug) {
       DetId::Detector det = id.det();
       int subdet   = id.subdetId();
-      double eta   = geo->getPosition(id).eta();
+      double eta   = point.eta();
       double theta = 2.0*atan(exp(-std::abs(eta)));
       double dist  = 0;
       if (det == DetId::Ecal) {

--- a/Calibration/IsolatedParticles/src/FindCaloHitCone.cc
+++ b/Calibration/IsolatedParticles/src/FindCaloHitCone.cc
@@ -2,6 +2,7 @@
 #include "Calibration/IsolatedParticles/interface/FindCaloHitCone.h"
 #include "Calibration/IsolatedParticles/interface/FindDistCone.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 #include <iostream>
 
 namespace spr {
@@ -92,7 +93,8 @@ namespace spr {
     for (HBHERecHitCollection::const_iterator j=hits->begin(); 
 	 j!=hits->end(); j++) {   
       DetId detId(j->id());
-      const GlobalPoint rechitPoint = geo->getPosition(detId);
+      const GlobalPoint rechitPoint = 
+	((HcalGeometry*)(geo->getSubdetectorGeometry(detId)))->getPosition(detId);
       if (spr::getDistInPlaneTrackDir(hpoint1, trackMom, rechitPoint, debug) < dR) hit.push_back(j);
     }  
     return hit;
@@ -105,7 +107,9 @@ namespace spr {
     edm::PCaloHitContainer::const_iterator ihit;
     for (ihit=hits->begin(); ihit!=hits->end(); ihit++) {
       DetId detId(ihit->id());
-      const GlobalPoint rechitPoint = geo->getPosition(detId);
+      const GlobalPoint rechitPoint = (detId.det() == DetId::Hcal) ? 
+	((HcalGeometry*)(geo->getSubdetectorGeometry(detId)))->getPosition(detId) : 
+	geo->getPosition(detId);
       if (spr::getDistInPlaneTrackDir(hpoint1, trackMom, rechitPoint, debug) < dR) {
 	hit.push_back(ihit);
       }

--- a/Calibration/IsolatedParticles/src/FindCaloHitCone.cc
+++ b/Calibration/IsolatedParticles/src/FindCaloHitCone.cc
@@ -20,11 +20,11 @@ namespace spr {
     
       if (j->id().subdetId() == EcalEndcap) {
 	EEDetId EEid = EEDetId(j->id());
-	const GlobalPoint rechitPoint = geo->getPosition(EEid);
+	const GlobalPoint & rechitPoint = geo->getPosition(EEid);
 	if (spr::getDistInPlaneTrackDir(point1, trackMom, rechitPoint, debug) < dR) keepHit = true;
       } else if (j->id().subdetId() == EcalBarrel) {
 	EBDetId EBid = EBDetId(j->id());
-	const GlobalPoint rechitPoint = geo->getPosition(EBid);
+	const GlobalPoint & rechitPoint = geo->getPosition(EBid);
 	if (spr::getDistInPlaneTrackDir(point1, trackMom, rechitPoint, debug) < dR) keepHit = true;
       }
 
@@ -52,7 +52,7 @@ namespace spr {
 	bool keepHit = false;
 	if (j->id().subdetId() == EcalBarrel) {
 	  EBDetId EBid = EBDetId(j->id());
-	  const GlobalPoint rechitPoint = geo->getPosition(EBid);
+	  const GlobalPoint & rechitPoint = geo->getPosition(EBid);
 	  if (spr::getDistInPlaneTrackDir(point1, trackMom, rechitPoint, debug) < dR) keepHit = true;
 	} else {
 	  std::cout << "PROBLEM : Endcap RecHits in Barrel Collection!?" 
@@ -71,7 +71,7 @@ namespace spr {
       
 	if (j->id().subdetId() == EcalEndcap) {
 	  EEDetId EEid = EEDetId(j->id());
-	  const GlobalPoint rechitPoint = geo->getPosition(EEid);
+	  const GlobalPoint & rechitPoint = geo->getPosition(EEid);
 	  if (spr::getDistInPlaneTrackDir(point1, trackMom, rechitPoint, debug) < dR) keepHit = true;
 	} else {
 	  std::cout << "PROBLEM : Barrel RecHits in Endcap Collection!?" 

--- a/Calibration/IsolatedParticles/src/FindDistCone.cc
+++ b/Calibration/IsolatedParticles/src/FindDistCone.cc
@@ -1,5 +1,6 @@
 #include "Calibration/IsolatedParticles/interface/CaloConstants.h"
 #include "Calibration/IsolatedParticles/interface/FindDistCone.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 
 #include <iostream>
 
@@ -190,12 +191,15 @@ namespace spr {
 
   GlobalPoint getGpos(const CaloGeometry* geo,HBHERecHitCollection::const_iterator hit, bool) {
     DetId detId(hit->id());
-    return geo->getPosition(detId);
+    return ((HcalGeometry*)(geo->getSubdetectorGeometry(detId)))->getPosition(detId);
   }
 
   GlobalPoint getGpos(const CaloGeometry* geo,edm::PCaloHitContainer::const_iterator hit, bool) {
     DetId detId(hit->id());
-    return geo->getPosition(detId);
+    GlobalPoint point = (detId.det() == DetId::Hcal) ? 
+      ((HcalGeometry*)(geo->getSubdetectorGeometry(detId)))->getPosition(detId) : 
+      geo->getPosition(detId);
+    return point;
   }
 
   GlobalPoint getGpos(const CaloGeometry* geo, EcalRecHitCollection::const_iterator hit, bool) {

--- a/Calibration/IsolatedParticles/src/MatrixHCALDetIds.cc
+++ b/Calibration/IsolatedParticles/src/MatrixHCALDetIds.cc
@@ -3,6 +3,7 @@
 #include "Calibration/IsolatedParticles/interface/MatrixHCALDetIds.h"
 #include "Calibration/IsolatedParticles/interface/FindDistCone.h"
 #include "Calibration/IsolatedParticles/interface/DebugInfo.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 
 #include<algorithm>
 #include<iostream>
@@ -50,7 +51,7 @@ namespace spr{
 				   bool debug) {
  
     HcalDetId   hcdet = HcalDetId(det);
-    GlobalPoint core  = geo->getPosition(hcdet);
+    GlobalPoint core  = ((HcalGeometry*)(geo->getSubdetectorGeometry(hcdet)))->getPosition(hcdet);
     std::vector<DetId> dets, vdetx;
     dets.push_back(det);
     int ietaphi = (int)(dR/15.0)+1;
@@ -58,7 +59,7 @@ namespace spr{
 						  ietaphi, includeHO, debug);
     for (unsigned int i=0; i<vdets.size(); ++i) {
       HcalDetId   hcdet  = HcalDetId(vdets[i]);
-      GlobalPoint rpoint = geo->getPosition(hcdet);
+      GlobalPoint rpoint = ((HcalGeometry*)(geo->getSubdetectorGeometry(hcdet)))->getPosition(hcdet);
       if (spr::getDistInPlaneTrackDir(core, trackMom, rpoint) < dR) {
 	vdetx.push_back(vdets[i]);
       }

--- a/Calibration/IsolatedParticles/src/MatrixHCALDetIds.cc
+++ b/Calibration/IsolatedParticles/src/MatrixHCALDetIds.cc
@@ -411,7 +411,7 @@ namespace spr{
       HcalDetId vdet = dets[i1];
       for (int idepth = 0; idepth < 3; idepth++) {
         std::vector<DetId> vUpDetId = topology->up(vdet);
-        if (vUpDetId.size() != 0) {
+        if (!vUpDetId.empty()) {
           if (includeHO || vUpDetId[0].subdetId() != (int)(HcalOuter)) {
             int n = std::count(vdets.begin(),vdets.end(),vUpDetId[0]);
             if (n == 0) {


### PR DESCRIPTION
The codes used for isolated charged particle in calibration or in the HLT makes use of HCAL geometry which needs updating because of Plan 1 version of HCAL (old access method would not work).