### PR TITLE
Make vertex filters rubust to L3Muon duplicates - 92X backport

### DIFF
--- a/HLTrigger/btau/src/HLTDisplacedmumuFilter.cc
+++ b/HLTrigger/btau/src/HLTDisplacedmumuFilter.cc
@@ -146,7 +146,7 @@ bool HLTDisplacedmumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
 	    if(tkRef == vertextkRef1) {cand1 = cand; iFoundRefs++;}
 	    if(tkRef == vertextkRef2) {cand2 = cand; iFoundRefs++;}
 	  }
-	  if(iFoundRefs != 2) throw cms::Exception("BadLogic") << "HLTDisplacedmumuFilter: ERROR: the Jpsi vertex must have exactly two muons by definition."  << std::endl;
+	  if(iFoundRefs < 2) throw cms::Exception("BadLogic") << "HLTDisplacedmumuFilter: ERROR: the Jpsi vertex must have exactly two muons by definition."  << std::endl;
 	
           // calculate two-track transverse momentum
           math::XYZVector pperp(cand1->px() + cand2->px(),

--- a/HLTrigger/btau/src/HLTDisplacedmumuFilter.cc
+++ b/HLTrigger/btau/src/HLTDisplacedmumuFilter.cc
@@ -1,4 +1,4 @@
-#include <iostream>
+1;4205;0c#include <iostream>
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -146,7 +146,7 @@ bool HLTDisplacedmumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
 	    if(tkRef == vertextkRef1) {cand1 = cand; iFoundRefs++;}
 	    if(tkRef == vertextkRef2) {cand2 = cand; iFoundRefs++;}
 	  }
-	  if(iFoundRefs < 2) throw cms::Exception("BadLogic") << "HLTDisplacedmumuFilter: ERROR: the Jpsi vertex must have exactly two muons by definition."  << std::endl;
+	  if(iFoundRefs < 2) throw cms::Exception("BadLogic") << "HLTDisplacedmumuFilter: ERROR: the muons matched with the Jpsi vertex tracks should be at least two by definition."  << std::endl;
 	
           // calculate two-track transverse momentum
           math::XYZVector pperp(cand1->px() + cand2->px(),

--- a/HLTrigger/btau/src/HLTDisplacedmumuFilter.cc
+++ b/HLTrigger/btau/src/HLTDisplacedmumuFilter.cc
@@ -154,7 +154,7 @@ bool HLTDisplacedmumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
         			  0.);
 
 
-	  reco::Vertex::Point vpoint=displacedVertex.position();
+	  const reco::Vertex::Point& vpoint=displacedVertex.position();
 	  //translate to global point, should be improved
 	  GlobalPoint secondaryVertex (vpoint.x(), vpoint.y(), vpoint.z());
 

--- a/HLTrigger/btau/src/HLTDisplacedmumuFilter.cc
+++ b/HLTrigger/btau/src/HLTDisplacedmumuFilter.cc
@@ -1,4 +1,4 @@
-1;4205;0c#include <iostream>
+#include <iostream>
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"

--- a/HLTrigger/btau/src/HLTDisplacedmumuFilter.h
+++ b/HLTrigger/btau/src/HLTDisplacedmumuFilter.h
@@ -13,11 +13,11 @@ class HLTDisplacedmumuFilter : public HLTFilter {
 
   public:
     explicit HLTDisplacedmumuFilter(const edm::ParameterSet&);
-    ~HLTDisplacedmumuFilter();
+    ~HLTDisplacedmumuFilter() override;
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);	
-    virtual void beginJob() override ;
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
-    virtual void endJob() override ;
+    void beginJob() override ;
+    bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+    void endJob() override ;
 
   private:
     bool fastAccept_;

--- a/HLTrigger/btau/src/HLTDisplacedmumumuFilter.cc
+++ b/HLTrigger/btau/src/HLTDisplacedmumumuFilter.cc
@@ -161,7 +161,7 @@ bool HLTDisplacedmumumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSet
         			  0.);
 
 
-	  reco::Vertex::Point vpoint=displacedVertex.position();
+	  const reco::Vertex::Point& vpoint=displacedVertex.position();
 	  //translate to global point, should be improved
 	  GlobalPoint secondaryVertex (vpoint.x(), vpoint.y(), vpoint.z());
 

--- a/HLTrigger/btau/src/HLTDisplacedmumumuFilter.cc
+++ b/HLTrigger/btau/src/HLTDisplacedmumumuFilter.cc
@@ -153,7 +153,7 @@ bool HLTDisplacedmumumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSet
 	    if(tkRef == vertextkRef2) {cand2 = cand; iFoundRefs++;}
 	    if(tkRef == vertextkRef3) {cand3 = cand; iFoundRefs++;}
 	  }
-	  if(iFoundRefs != 3) throw cms::Exception("BadLogic") << "HLTDisplacedmumumuFilter: ERROR: the Jpsi vertex must have exactly two muons by definition."  << std::endl;
+	  if(iFoundRefs < 3) throw cms::Exception("BadLogic") << "HLTDisplacedmumumuFilter: ERROR: the Jpsi vertex must have exactly two muons by definition."  << std::endl;
 
           // calculate two-track transverse momentum
           math::XYZVector pperp(cand1->px() + cand2->px() + cand3->px(),

--- a/HLTrigger/btau/src/HLTDisplacedmumumuFilter.cc
+++ b/HLTrigger/btau/src/HLTDisplacedmumumuFilter.cc
@@ -153,7 +153,7 @@ bool HLTDisplacedmumumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSet
 	    if(tkRef == vertextkRef2) {cand2 = cand; iFoundRefs++;}
 	    if(tkRef == vertextkRef3) {cand3 = cand; iFoundRefs++;}
 	  }
-	  if(iFoundRefs < 3) throw cms::Exception("BadLogic") << "HLTDisplacedmumumuFilter: ERROR: the Jpsi vertex must have exactly two muons by definition."  << std::endl;
+	  if(iFoundRefs < 3) throw cms::Exception("BadLogic") << "HLTDisplacedmumumuFilter: ERROR: the muons matched with the Jpsi vertex tracks should be at least three by definition."  << std::endl;
 
           // calculate two-track transverse momentum
           math::XYZVector pperp(cand1->px() + cand2->px() + cand3->px(),

--- a/HLTrigger/btau/src/HLTDisplacedmumumuFilter.h
+++ b/HLTrigger/btau/src/HLTDisplacedmumumuFilter.h
@@ -13,11 +13,11 @@ class HLTDisplacedmumumuFilter : public HLTFilter {
 
   public:
     explicit HLTDisplacedmumumuFilter(const edm::ParameterSet&);
-    ~HLTDisplacedmumumuFilter();
+    ~HLTDisplacedmumumuFilter() override;
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    virtual void beginJob() override ;
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
-    virtual void endJob() override ;
+    void beginJob() override ;
+    bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+    void endJob() override ;
 
   private:
     bool fastAccept_;

--- a/HLTrigger/btau/src/HLTDisplacedtktkFilter.cc
+++ b/HLTrigger/btau/src/HLTDisplacedtktkFilter.cc
@@ -151,7 +151,7 @@ bool HLTDisplacedtktkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
 	    if(tkRef == vertextkRef2) {cand2 = cand; iFoundRefs++;}
 	  }
 	  
-	  if(iFoundRefs != 2){
+	  if(iFoundRefs < 2){
             edm::LogError("HLTDisplacedtktkFilter") << "HLTDisplacedtktkFilter: ERROR: the Jpsi vertex must have exactly two tracks by definition."  << std::endl;
             return false;
           } 	

--- a/HLTrigger/btau/src/HLTDisplacedtktkFilter.cc
+++ b/HLTrigger/btau/src/HLTDisplacedtktkFilter.cc
@@ -152,7 +152,7 @@ bool HLTDisplacedtktkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
 	  }
 	  
 	  if(iFoundRefs < 2){
-            edm::LogError("HLTDisplacedtktkFilter") << "HLTDisplacedtktkFilter: ERROR: the Jpsi vertex must have exactly two tracks by definition."  << std::endl;
+            edm::LogError("HLTDisplacedtktkFilter") << "HLTDisplacedtktkFilter: ERROR: the tracks matched with the Jpsi vertex tracks should be at least two by definition."  << std::endl;
             return false;
           } 	
           // calculate two-track transverse momentum

--- a/HLTrigger/btau/src/HLTDisplacedtktkFilter.cc
+++ b/HLTrigger/btau/src/HLTDisplacedtktkFilter.cc
@@ -161,7 +161,7 @@ bool HLTDisplacedtktkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
         			  0.);
 
 
-	  reco::Vertex::Point vpoint=displacedVertex.position();
+	  const reco::Vertex::Point& vpoint=displacedVertex.position();
 	  //translate to global point, should be improved
 	  GlobalPoint secondaryVertex (vpoint.x(), vpoint.y(), vpoint.z());
 

--- a/HLTrigger/btau/src/HLTDisplacedtktkFilter.h
+++ b/HLTrigger/btau/src/HLTDisplacedtktkFilter.h
@@ -13,11 +13,11 @@ class HLTDisplacedtktkFilter : public HLTFilter {
 
   public:
     explicit HLTDisplacedtktkFilter(const edm::ParameterSet&);
-    ~HLTDisplacedtktkFilter();
+    ~HLTDisplacedtktkFilter() override;
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);	
-    virtual void beginJob() override ;
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
-    virtual void endJob() override ;
+    void beginJob() override ;
+    bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+    void endJob() override ;
 
   private:
     bool fastAccept_;


### PR DESCRIPTION
Backport of #20136 

As spotted by FOG[1], these three filters are giving error any time in the hltIterL3MuonCandidates collection is present a duplicated objects. Some details are given in this[2] JIRA.

Since in presence of duplicates the filters will treat them correctly, the error message is restricted to the cases when the L3Muons matched to the two vertexing tracks are less then 2.

[1]
https://groups.cern.ch/group/cms-hlt/Lists/Archive/Flat.aspx?RootFolder=%2Fgroup%2Fcms%2Dhlt%2FLists%2FArchive%2FHLTDisplacedmumuFilter%20error%20in%20recent%20runs&FolderCTID=0x012002005CF9F426540B9C4D8205911CC3985E98
[2]
https://its.cern.ch/jira/browse/CMSMUONS-23