### PR TITLE
[93X] fix configuration of Strip hit efficiency tree and add tree producer to unit tests

### DIFF
--- a/CalibTracker/SiStripCommon/test/testProduceCalibrationTree_cfg.py
+++ b/CalibTracker/SiStripCommon/test/testProduceCalibrationTree_cfg.py
@@ -1,0 +1,138 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpGENSIMRECO
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+###################################################################
+# Setup 'standard' options
+###################################################################
+options = VarParsing.VarParsing()
+
+options.register('conditionGT',
+                 "auto:phase1_2017_realistic",
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "condition global tag for the job (\"auto:phase1_2017_realistic\" is default)")
+
+options.register('conditionOverwrite',
+                 "",
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "configuration to overwrite the condition into the GT (\"\" is default)")
+
+options.register('inputCollection',
+                 "generalTracks",
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "collections to be used for input (\"generalTracks\" is default)")
+
+options.register('inputFiles',
+                 filesRelValTTbarPileUpGENSIMRECO,
+                 VarParsing.VarParsing.multiplicity.list,
+                 VarParsing.VarParsing.varType.string,
+                 "file to process")
+
+options.register('outputFile',
+                 "calibTreeTest.root",
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "name for the output root file (\"calibTreeTest.root\" is default)")
+
+options.register('maxEvents',
+                 -1,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "number of events to process (\"-1\" for all)")
+
+options.parseArguments()
+
+print "conditionGT       : ", options.conditionGT
+print "conditionOverwrite: ", options.conditionOverwrite
+print "inputCollection   : ", options.inputCollection
+print "maxEvents         : ", options.maxEvents
+print "outputFile        : ", options.outputFile
+print "inputFiles        : ", options.inputFiles
+
+process = cms.Process('CALIB')
+process.load('CalibTracker.Configuration.setupCalibrationTree_cff')
+process.load('Configuration/StandardSequences/MagneticField_cff')
+process.load('Configuration.Geometry.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, options.conditionGT, options.conditionOverwrite)
+
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.StandardSequences.Services_cff')
+process.add_( cms.Service( "TFileService",
+                           fileName = cms.string( options.outputFile ),
+                           closeFileFast = cms.untracked.bool(True)  ) )
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxEvents) )
+
+#import runs
+process.source = cms.Source (
+    "PoolSource",
+    fileNames = cms.untracked.vstring(options.inputFiles[0])
+    )
+
+process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+process.MessageLogger.cerr.FwkReport.reportEvery = 10000
+
+#definition of input collection
+process.CalibrationTracks.src = cms.InputTag( options.inputCollection )
+process.shallowTracks.Tracks  = cms.InputTag( options.inputCollection )
+#process.shallowGainCalibrationAllBunch   = 'ALCARECOSiStripCalMinBias' #cms.InputTag( options.inputCollection )
+#process.shallowGainCalibrationAllBunch0T = 'ALCARECOSiStripCalMinBias' #cms.InputTag( options.inputCollection )
+
+# BSCNoBeamHalo selection (Not to use for Cosmic Runs) --- OUTDATED!!!
+## process.load('L1TriggerConfig.L1GtConfigProducers.L1GtTriggerMaskTechTrigConfig_cff')
+## process.load('HLTrigger/HLTfilters/hltLevel1GTSeed_cfi')
+
+## process.L1T1=process.hltLevel1GTSeed.clone()
+## process.L1T1.L1TechTriggerSeeding = cms.bool(True)
+## process.L1T1.L1SeedsLogicalExpression = cms.string('(40 OR 41) AND NOT (36 OR 37 OR 38 OR 39)')
+
+#process.TkCalPath = cms.Path(process.L1T1*process.TkCalFullSequence)
+process.TkCalPath_StdBunch   = cms.Path(process.TkCalSeq_StdBunch)
+process.TkCalPath_StdBunch0T = cms.Path(process.TkCalSeq_StdBunch0T)
+process.TkCalPath_IsoMuon    = cms.Path(process.TkCalSeq_IsoMuon)
+process.TkCalPath_IsoMuon0T  = cms.Path(process.TkCalSeq_IsoMuon0T)
+process.TkCalPath_AagBunch   = cms.Path(process.TkCalSeq_AagBunch)
+process.TkCalPath_AagBunch0T = cms.Path(process.TkCalSeq_AagBunch0T)
+
+process.schedule = cms.Schedule( process.TkCalPath_StdBunch, 
+                                 process.TkCalPath_StdBunch0T,
+                                 #process.TkCalPath_IsoMuon,         # no After Abort Gap in MC
+                                 #process.TkCalPath_IsoMuon0T,
+                                 #process.TkCalPath_AagBunch,
+                                 #process.TkCalPath_AagBunch0T,
+                                 )
+
+process.options = cms.untracked.PSet(
+    Rethrow = cms.untracked.vstring('OtherCMS', 
+        'StdException', 
+        'Unknown', 
+        'BadAlloc', 
+        'BadExceptionType', 
+        'ProductNotFound', 
+        'DictionaryNotFound', 
+        'InsertFailure', 
+        'Configuration', 
+        'LogicError', 
+        'UnimplementedFeature', 
+        'InvalidReference', 
+        'NullPointerError', 
+        'NoProductSpecified', 
+        'EventTimeout', 
+        'EventCorruption', 
+        'ScheduleExecutionFailure', 
+        'EventProcessorFailure', 
+        'FileInPathError', 
+        'FileOpenError', 
+        'FileReadError', 
+        'FatalRootError', 
+        'MismatchedInputFiles', 
+        'ProductDoesNotSupportViews', 
+        'ProductDoesNotSupportPtr', 
+        'NotFound')
+    )

--- a/CalibTracker/SiStripCommon/test/test_all.sh
+++ b/CalibTracker/SiStripCommon/test/test_all.sh
@@ -4,3 +4,4 @@ function die { echo $1: status $2 ; exit $2; }
 
 echo "TESTING CalibTracker/SiStripCommon ..."
 cmsRun ${LOCAL_TEST_DIR}/test_all_cfg.py || die "Failure running test_CalibTrackerSiStripCommon_cfg.py" $? 
+cmsRun ${LOCAL_TEST_DIR}/testProduceCalibrationTree_cfg.py maxEvents=1 || die "Failure running produceCalibrationTree_template_cfg.py" $?

--- a/CalibTracker/SiStripHitEfficiency/python/SiStripHitEff_cff.py
+++ b/CalibTracker/SiStripHitEfficiency/python/SiStripHitEff_cff.py
@@ -21,7 +21,7 @@ anEff = cms.EDAnalyzer("HitEff",
                        # do not cut on the total number of tracks
                        cutOnTracks = cms.untracked.bool(True),
                        # compatibility
-                       trackMultiplicity = cms.untracked.int(100)
+                       trackMultiplicity = cms.untracked.uint32(100)
                        )
 
 hiteff = cms.Sequence( anEff )


### PR DESCRIPTION
Fixes a mistake in the Strip Hit efficiency tree configuration introduced in #20052 and adds a unit test to avoid such mistakes to happen again unnoticed. 