### PR TITLE
Allow a boost on particles in PythiaMomDauFilter, PythiaFilter and PythiaFilterMultiMother

### DIFF
--- a/GeneratorInterface/GenFilters/interface/MCFilterZboostHelper.h
+++ b/GeneratorInterface/GenFilters/interface/MCFilterZboostHelper.h
@@ -1,0 +1,16 @@
+#ifndef MCFilterZboostHelper_h
+#define MCFilterZboostHelper_h
+
+#include "HepMC/SimpleVector.h"
+
+namespace HepMC {
+   class FourVector;
+}
+
+namespace MCFilterZboostHelper{
+
+HepMC::FourVector zboost(const HepMC::FourVector&, double);
+
+}
+
+#endif

--- a/GeneratorInterface/GenFilters/interface/MCParticlePairFilter.h
+++ b/GeneratorInterface/GenFilters/interface/MCParticlePairFilter.h
@@ -38,9 +38,6 @@
 namespace edm {
   class HepMCProduct;
 }
-namespace HepMC {
-   class FourVector;
-}
 
 class MCParticlePairFilter : public edm::EDFilter {
    public:
@@ -52,7 +49,6 @@ class MCParticlePairFilter : public edm::EDFilter {
    private:
       // ----------memeber function----------------------
        int charge(const int& Id);
-       HepMC::FourVector zboost(const HepMC::FourVector&);
 
       // ----------member data ---------------------------
       

--- a/GeneratorInterface/GenFilters/interface/MCSingleParticleFilter.h
+++ b/GeneratorInterface/GenFilters/interface/MCSingleParticleFilter.h
@@ -38,9 +38,6 @@
 namespace edm {
   class HepMCProduct;
 }
-namespace HepMC {
-   class FourVector;
-}
 
 class MCSingleParticleFilter : public edm::EDFilter {
    public:
@@ -51,8 +48,6 @@ class MCSingleParticleFilter : public edm::EDFilter {
       virtual bool filter(edm::Event&, const edm::EventSetup&);
    private:
       // ----------memeber function----------------------
-       HepMC::FourVector zboost(const HepMC::FourVector&);
-
       // ----------member data ---------------------------
       
        edm::EDGetTokenT<edm::HepMCProduct> token_;

--- a/GeneratorInterface/GenFilters/interface/MCSmartSingleParticleFilter.h
+++ b/GeneratorInterface/GenFilters/interface/MCSmartSingleParticleFilter.h
@@ -35,9 +35,6 @@
 namespace edm {
   class HepMCProduct;
 }
-namespace HepMC {
-   class FourVector;
-}
 
 class MCSmartSingleParticleFilter : public edm::EDFilter {
    public:
@@ -48,7 +45,6 @@ class MCSmartSingleParticleFilter : public edm::EDFilter {
       virtual bool filter(edm::Event&, const edm::EventSetup&);
    private:
       // ----------memeber function----------------------
-       HepMC::FourVector zboost(const HepMC::FourVector&);
 
       // ----------member data ---------------------------
       

--- a/GeneratorInterface/GenFilters/interface/PythiaFilter.h
+++ b/GeneratorInterface/GenFilters/interface/PythiaFilter.h
@@ -31,8 +31,6 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "HepMC/SimpleVector.h"
-
 //
 // class decleration
 //
@@ -52,9 +50,6 @@ class PythiaFilter : public edm::EDFilter {
 
       virtual bool filter(edm::Event&, const edm::EventSetup&);
    private:
-      // ----------member function -----------------------
-       HepMC::FourVector zboost(const HepMC::FourVector&);
-
       // ----------member data ---------------------------
       
        edm::EDGetTokenT<edm::HepMCProduct> token_;

--- a/GeneratorInterface/GenFilters/interface/PythiaFilter.h
+++ b/GeneratorInterface/GenFilters/interface/PythiaFilter.h
@@ -39,6 +39,10 @@ namespace edm {
   class HepMCProduct;
 }
 
+namespace HepMC {
+   class FourVector;
+}
+
 class PythiaFilter : public edm::EDFilter {
    public:
       explicit PythiaFilter(const edm::ParameterSet&);
@@ -47,6 +51,9 @@ class PythiaFilter : public edm::EDFilter {
 
       virtual bool filter(edm::Event&, const edm::EventSetup&);
    private:
+      // ----------member function -----------------------
+       HepMC::FourVector zboost(const HepMC::FourVector&);
+
       // ----------member data ---------------------------
       
        edm::EDGetTokenT<edm::HepMCProduct> token_;
@@ -67,5 +74,7 @@ class PythiaFilter : public edm::EDFilter {
        int status; 
        int motherID;   
        int processID;    
+
+       double betaBoost;
 };
 #endif

--- a/GeneratorInterface/GenFilters/interface/PythiaFilter.h
+++ b/GeneratorInterface/GenFilters/interface/PythiaFilter.h
@@ -38,10 +38,6 @@ namespace edm {
   class HepMCProduct;
 }
 
-namespace HepMC {
-   class FourVector;
-}
-
 class PythiaFilter : public edm::EDFilter {
    public:
       explicit PythiaFilter(const edm::ParameterSet&);

--- a/GeneratorInterface/GenFilters/interface/PythiaFilter.h
+++ b/GeneratorInterface/GenFilters/interface/PythiaFilter.h
@@ -41,10 +41,10 @@ namespace edm {
 class PythiaFilter : public edm::EDFilter {
    public:
       explicit PythiaFilter(const edm::ParameterSet&);
-      ~PythiaFilter();
+      ~PythiaFilter() override;
 
 
-      virtual bool filter(edm::Event&, const edm::EventSetup&);
+      bool filter(edm::Event&, const edm::EventSetup&) override;
    private:
       // ----------member data ---------------------------
       

--- a/GeneratorInterface/GenFilters/interface/PythiaFilter.h
+++ b/GeneratorInterface/GenFilters/interface/PythiaFilter.h
@@ -31,6 +31,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "HepMC/SimpleVector.h"
 
 //
 // class decleration

--- a/GeneratorInterface/GenFilters/interface/PythiaFilterMultiMother.h
+++ b/GeneratorInterface/GenFilters/interface/PythiaFilterMultiMother.h
@@ -14,17 +14,11 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "HepMC/SimpleVector.h"
-
 //
 // class decleration
 //
 namespace edm {
   class HepMCProduct;
-}
-
-namespace HepMC {
-   class FourVector;
 }
 
 class PythiaFilterMultiMother : public edm::EDFilter {
@@ -35,9 +29,6 @@ class PythiaFilterMultiMother : public edm::EDFilter {
 
       virtual bool filter(edm::Event&, const edm::EventSetup&);
    private:
-     // ----------member function ----------------------- 
-     HepMC::FourVector zboost(const HepMC::FourVector&);
-
      // ----------member data ---------------------------
 
        edm::EDGetTokenT<edm::HepMCProduct> token_;

--- a/GeneratorInterface/GenFilters/interface/PythiaFilterMultiMother.h
+++ b/GeneratorInterface/GenFilters/interface/PythiaFilterMultiMother.h
@@ -24,10 +24,10 @@ namespace edm {
 class PythiaFilterMultiMother : public edm::EDFilter {
    public:
       explicit PythiaFilterMultiMother(const edm::ParameterSet&);
-      ~PythiaFilterMultiMother();
+      ~PythiaFilterMultiMother() override;
 
 
-      virtual bool filter(edm::Event&, const edm::EventSetup&);
+      bool filter(edm::Event&, const edm::EventSetup&) override;
    private:
      // ----------member data ---------------------------
 

--- a/GeneratorInterface/GenFilters/interface/PythiaFilterMultiMother.h
+++ b/GeneratorInterface/GenFilters/interface/PythiaFilterMultiMother.h
@@ -14,6 +14,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "HepMC/SimpleVector.h"
 
 //
 // class decleration

--- a/GeneratorInterface/GenFilters/interface/PythiaFilterMultiMother.h
+++ b/GeneratorInterface/GenFilters/interface/PythiaFilterMultiMother.h
@@ -22,6 +22,10 @@ namespace edm {
   class HepMCProduct;
 }
 
+namespace HepMC {
+   class FourVector;
+}
+
 class PythiaFilterMultiMother : public edm::EDFilter {
    public:
       explicit PythiaFilterMultiMother(const edm::ParameterSet&);
@@ -30,7 +34,10 @@ class PythiaFilterMultiMother : public edm::EDFilter {
 
       virtual bool filter(edm::Event&, const edm::EventSetup&);
    private:
-      // ----------member data ---------------------------
+     // ----------member function ----------------------- 
+     HepMC::FourVector zboost(const HepMC::FourVector&);
+
+     // ----------member data ---------------------------
 
        edm::EDGetTokenT<edm::HepMCProduct> token_;
        int particleID;
@@ -50,5 +57,7 @@ class PythiaFilterMultiMother : public edm::EDFilter {
        int status;
        std::vector<int> motherIDs;
        int processID;
+
+       double betaBoost;
 };
 #endif

--- a/GeneratorInterface/GenFilters/interface/PythiaMomDauFilter.h
+++ b/GeneratorInterface/GenFilters/interface/PythiaMomDauFilter.h
@@ -33,14 +33,8 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "HepMC/SimpleVector.h"
-
 namespace edm {
       class HepMCProduct;
-}
-
-namespace HepMC {
-   class FourVector;
 }
 
 //
@@ -55,10 +49,6 @@ class PythiaMomDauFilter : public edm::EDFilter {
 
       virtual bool filter(edm::Event&, const edm::EventSetup&);
    private:
-      // ----------memeber function----------------------
-
-       HepMC::FourVector zboost(const HepMC::FourVector&);
-
       // ----------member data ---------------------------
       
       edm::EDGetTokenT<edm::HepMCProduct> label_;

--- a/GeneratorInterface/GenFilters/interface/PythiaMomDauFilter.h
+++ b/GeneratorInterface/GenFilters/interface/PythiaMomDauFilter.h
@@ -33,6 +33,8 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "HepMC/SimpleVector.h"
+
 namespace edm {
       class HepMCProduct;
 }

--- a/GeneratorInterface/GenFilters/interface/PythiaMomDauFilter.h
+++ b/GeneratorInterface/GenFilters/interface/PythiaMomDauFilter.h
@@ -20,9 +20,7 @@
 //
 //
 
-namespace edm {
-    class HepMCProduct;
-}
+
 // system include files
 #include <memory>
 
@@ -35,6 +33,13 @@ namespace edm {
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+namespace edm {
+      class HepMCProduct;
+}
+
+namespace HepMC {
+   class FourVector;
+}
 
 //
 // class decleration
@@ -50,9 +55,11 @@ class PythiaMomDauFilter : public edm::EDFilter {
    private:
       // ----------memeber function----------------------
 
+       HepMC::FourVector zboost(const HepMC::FourVector&);
+
       // ----------member data ---------------------------
       
-       edm::EDGetTokenT<edm::HepMCProduct> label_;
+      edm::EDGetTokenT<edm::HepMCProduct> label_;
        std::vector<int> dauIDs;
        std::vector<int> desIDs;
        int particleID;
@@ -68,6 +75,7 @@ class PythiaMomDauFilter : public edm::EDFilter {
        double mom_maxptcut;
        double mom_minetacut;
        double mom_maxetacut;
+       double betaBoost;
 };
 #define PYCOMP pycomp_
 extern "C" {

--- a/GeneratorInterface/GenFilters/interface/PythiaMomDauFilter.h
+++ b/GeneratorInterface/GenFilters/interface/PythiaMomDauFilter.h
@@ -44,10 +44,10 @@ namespace edm {
 class PythiaMomDauFilter : public edm::EDFilter {
    public:
       explicit PythiaMomDauFilter(const edm::ParameterSet&);
-      ~PythiaMomDauFilter();
+      ~PythiaMomDauFilter() override;
 
 
-      virtual bool filter(edm::Event&, const edm::EventSetup&);
+      bool filter(edm::Event&, const edm::EventSetup&) override;
    private:
       // ----------member data ---------------------------
       

--- a/GeneratorInterface/GenFilters/src/MCFilterZboostHelper.cc
+++ b/GeneratorInterface/GenFilters/src/MCFilterZboostHelper.cc
@@ -1,0 +1,11 @@
+#include "GeneratorInterface/GenFilters/interface/MCFilterZboostHelper.h"
+
+HepMC::FourVector MCFilterZboostHelper::zboost(const HepMC::FourVector& mom, double betaBoost) {
+   //Boost this Lorentz vector (from TLorentzVector::Boost)
+   double b2 = betaBoost*betaBoost;
+   double gamma = 1.0 / sqrt(1.0 - b2);
+   double bp = betaBoost*mom.pz();
+   double gamma2 = b2 > 0 ? (gamma - 1.0)/b2 : 0.0;
+
+   return HepMC::FourVector(mom.px(), mom.py(), mom.pz() + gamma2*bp*betaBoost + gamma*betaBoost*mom.e(), gamma*(mom.e()+bp));
+}

--- a/GeneratorInterface/GenFilters/src/MCParticlePairFilter.cc
+++ b/GeneratorInterface/GenFilters/src/MCParticlePairFilter.cc
@@ -2,6 +2,7 @@
 //-ap #include "Configuration/CSA06Skimming/interface/MCParticlePairFilter.h"
 
 #include "GeneratorInterface/GenFilters/interface/MCParticlePairFilter.h"
+#include "GeneratorInterface/GenFilters/interface/MCFilterZboostHelper.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include <iostream>
@@ -126,7 +127,7 @@ bool MCParticlePairFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSe
        }
      }
      if(gottypeAID) {
-       HepMC::FourVector mom = zboost((*p)->momentum());
+       HepMC::FourVector mom = MCFilterZboostHelper::zboost((*p)->momentum(),betaBoost);
        if ( mom.perp() > ptMin[0] && mom.rho() > pMin[0] && mom.eta() > etaMin[0] 
 	    && mom.eta() < etaMax[0] && ((*p)->status() == status[0] || status[0] == 0)) { 
 	 // passed A type conditions ...
@@ -156,7 +157,7 @@ bool MCParticlePairFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSe
 	   charge1 = charge((*p)->pdg_id());
 	   //totmomentum = momentum1 + typeBpassed[i]->momentum();
 	   //invmass = totmomentum.m();
-      HepMC::FourVector mom_i = zboost(typeBpassed[i]->momentum());
+      HepMC::FourVector mom_i = MCFilterZboostHelper::zboost(typeBpassed[i]->momentum(),betaBoost);
 	   tot_x += mom_i.px();
 	   tot_y += mom_i.py();
 	   tot_z += mom_i.pz();
@@ -198,7 +199,7 @@ bool MCParticlePairFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSe
        }
      }
      if(gottypeBID) {
-       HepMC::FourVector mom = zboost((*p)->momentum());
+       HepMC::FourVector mom = MCFilterZboostHelper::zboost((*p)->momentum(),betaBoost);
        if ( mom.perp() > ptMin[1] && mom.rho() > pMin[1] && mom.eta() > etaMin[1] 
 	    && mom.eta() < etaMax[1] && ((*p)->status() == status[1] || status[1] == 0)) { 
 	 // passed B type conditions ...
@@ -229,7 +230,7 @@ bool MCParticlePairFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSe
 	     charge1 = charge((*p)->pdg_id());
 	     //totmomentum = momentum1 + typeApassed[i]->momentum();
         //invmass = totmomentum.m();
-        HepMC::FourVector mom_i = zboost(mom_i);
+        HepMC::FourVector mom_i = MCFilterZboostHelper::zboost(mom_i,betaBoost);
 	     tot_x += mom_i.px();
 	     tot_y += mom_i.py();
 	     tot_z += mom_i.pz();
@@ -338,14 +339,4 @@ int MCParticlePairFilter::charge(const int& Id){
 
   // cout << hepchg<< endl;
   return hepchg;
-}
-
-HepMC::FourVector MCParticlePairFilter::zboost(const HepMC::FourVector& mom) {
-   //Boost this Lorentz vector (from TLorentzVector::Boost)
-   double b2 = betaBoost*betaBoost;
-   double gamma = 1.0 / sqrt(1.0 - b2);
-   double bp = betaBoost*mom.pz();
-   double gamma2 = b2 > 0 ? (gamma - 1.0)/b2 : 0.0;
-
-   return HepMC::FourVector(mom.px(), mom.py(), mom.pz() + gamma2*bp*betaBoost + gamma*betaBoost*mom.e(), gamma*(mom.e()+bp));
 }

--- a/GeneratorInterface/GenFilters/src/MCSingleParticleFilter.cc
+++ b/GeneratorInterface/GenFilters/src/MCSingleParticleFilter.cc
@@ -1,5 +1,6 @@
 
 #include "GeneratorInterface/GenFilters/interface/MCSingleParticleFilter.h"
+#include "GeneratorInterface/GenFilters/interface/MCFilterZboostHelper.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include <iostream>
@@ -102,7 +103,7 @@ bool MCSingleParticleFilter::filter(edm::Event& iEvent, const edm::EventSetup& i
 	 if ( (*p)->momentum().perp() > ptMin[i]
 	      && ((*p)->status() == status[i] || status[i] == 0)) {
 
-           HepMC::FourVector mom = zboost((*p)->momentum());
+           HepMC::FourVector mom = MCFilterZboostHelper::zboost((*p)->momentum(),betaBoost);
            if ( mom.eta() > etaMin[i] && mom.eta() < etaMax[i] ) {
              accepted = true;
            }
@@ -118,15 +119,3 @@ bool MCSingleParticleFilter::filter(edm::Event& iEvent, const edm::EventSetup& i
    if (accepted){ return true; } else {return false;}
    
 }
-
-
-HepMC::FourVector MCSingleParticleFilter::zboost(const HepMC::FourVector& mom) {
-   //Boost this Lorentz vector (from TLorentzVector::Boost)
-   double b2 = betaBoost*betaBoost;
-   double gamma = 1.0 / sqrt(1.0 - b2);
-   double bp = betaBoost*mom.pz();
-   double gamma2 = b2 > 0 ? (gamma - 1.0)/b2 : 0.0;
-
-   return HepMC::FourVector(mom.px(), mom.py(), mom.pz() + gamma2*bp*betaBoost + gamma*betaBoost*mom.e(), gamma*(mom.e()+bp));
-}
-

--- a/GeneratorInterface/GenFilters/src/MCSmartSingleParticleFilter.cc
+++ b/GeneratorInterface/GenFilters/src/MCSmartSingleParticleFilter.cc
@@ -1,5 +1,6 @@
 
 #include "GeneratorInterface/GenFilters/interface/MCSmartSingleParticleFilter.h"
+#include "GeneratorInterface/GenFilters/interface/MCFilterZboostHelper.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include <iostream>
@@ -158,7 +159,7 @@ bool MCSmartSingleParticleFilter::filter(edm::Event& iEvent, const edm::EventSet
 	 if ( (*p)->momentum().perp() > ptMin[i]
               && ((*p)->status() == status[i] || status[i] == 0))  {
 
-           HepMC::FourVector mom = zboost((*p)->momentum());
+           HepMC::FourVector mom = MCFilterZboostHelper::zboost((*p)->momentum(),betaBoost);
            if ( mom.rho() > pMin[i]
                 && mom.eta() > etaMin[i] && mom.eta() < etaMax[i]) {
 
@@ -188,15 +189,3 @@ bool MCSmartSingleParticleFilter::filter(edm::Event& iEvent, const edm::EventSet
    if (accepted){ return true; } else {return false;}
 
 }
-
-
-HepMC::FourVector MCSmartSingleParticleFilter::zboost(const HepMC::FourVector& mom) {
-   //Boost this Lorentz vector (from TLorentzVector::Boost)
-   double b2 = betaBoost*betaBoost;
-   double gamma = 1.0 / sqrt(1.0 - b2);
-   double bp = betaBoost*mom.pz();
-   double gamma2 = b2 > 0 ? (gamma - 1.0)/b2 : 0.0;
-
-   return HepMC::FourVector(mom.px(), mom.py(), mom.pz() + gamma2*bp*betaBoost + gamma*betaBoost*mom.e(), gamma*(mom.e()+bp));
-}
-

--- a/GeneratorInterface/GenFilters/src/PythiaFilter.cc
+++ b/GeneratorInterface/GenFilters/src/PythiaFilter.cc
@@ -23,7 +23,8 @@ minphicut(iConfig.getUntrackedParameter("MinPhi", -3.5)),
 maxphicut(iConfig.getUntrackedParameter("MaxPhi", 3.5)),
 status(iConfig.getUntrackedParameter("Status", 0)),
 motherID(iConfig.getUntrackedParameter("MotherID", 0)),
-processID(iConfig.getUntrackedParameter("ProcessID", 0))
+processID(iConfig.getUntrackedParameter("ProcessID", 0)),
+betaBoost(iConfig.getUntrackedParameter("BetaBoost",0.))
 {
    //now do what ever initialization is needed
 
@@ -57,20 +58,20 @@ bool PythiaFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
      
      for ( HepMC::GenEvent::particle_const_iterator p = myGenEvent->particles_begin();
 	   p != myGenEvent->particles_end(); ++p ) {
-       
-       rapidity = 0.5*log( ((*p)->momentum().e()+(*p)->momentum().pz()) / ((*p)->momentum().e()-(*p)->momentum().pz()) );
+       HepMC::FourVector mom = zboost((*p)->momentum());
+       rapidity = 0.5*log( (mom.e()+mom.pz()) / (mom.e()-mom.pz()) );
        
        if ( abs((*p)->pdg_id()) == particleID 
-	    && (*p)->momentum().rho() > minpcut 
-	    && (*p)->momentum().rho() < maxpcut
-	    && (*p)->momentum().perp() > minptcut 
-	    && (*p)->momentum().perp() < maxptcut
-	    && (*p)->momentum().eta() > minetacut
-	    && (*p)->momentum().eta() < maxetacut 
+	    && mom.rho() > minpcut 
+	    && mom.rho() < maxpcut
+	    && mom.perp() > minptcut 
+	    && mom.perp() < maxptcut
+	    && mom.eta() > minetacut
+	    && mom.eta() < maxetacut 
 	    && rapidity > minrapcut
 	    && rapidity < maxrapcut 
-	    && (*p)->momentum().phi() > minphicut
-	    && (*p)->momentum().phi() < maxphicut ) {
+	    && mom.phi() > minphicut
+	    && mom.phi() < maxphicut ) {
 	 
          
 	 
@@ -122,3 +123,12 @@ bool PythiaFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 }
 
+HepMC::FourVector PythiaFilter::zboost(const HepMC::FourVector& mom) {
+   //Boost this Lorentz vector (from TLorentzVector::Boost)
+   double b2 = betaBoost*betaBoost;
+   double gamma = 1.0 / sqrt(1.0 - b2);
+   double bp = betaBoost*mom.pz();
+   double gamma2 = b2 > 0 ? (gamma - 1.0)/b2 : 0.0;
+
+   return HepMC::FourVector(mom.px(), mom.py(), mom.pz() + gamma2*bp*betaBoost + gamma*betaBoost*mom.e(), gamma*(mom.e()+bp));
+}

--- a/GeneratorInterface/GenFilters/src/PythiaFilter.cc
+++ b/GeneratorInterface/GenFilters/src/PythiaFilter.cc
@@ -64,14 +64,14 @@ bool PythiaFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
        if ( abs((*p)->pdg_id()) == particleID 
 	    && mom.rho() > minpcut 
 	    && mom.rho() < maxpcut
-	    && mom.perp() > minptcut 
-	    && mom.perp() < maxptcut
+	    && (*p)->momentum().perp() > minptcut 
+	    && (*p)->momentum().perp() < maxptcut
 	    && mom.eta() > minetacut
 	    && mom.eta() < maxetacut 
 	    && rapidity > minrapcut
 	    && rapidity < maxrapcut 
-	    && mom.phi() > minphicut
-	    && mom.phi() < maxphicut ) {
+	    && (*p)->momentum().phi() > minphicut
+	    && (*p)->momentum().phi() < maxphicut ) {
 	 
          
 	 

--- a/GeneratorInterface/GenFilters/src/PythiaFilter.cc
+++ b/GeneratorInterface/GenFilters/src/PythiaFilter.cc
@@ -1,5 +1,6 @@
 
 #include "GeneratorInterface/GenFilters/interface/PythiaFilter.h"
+#include "GeneratorInterface/GenFilters/interface/MCFilterZboostHelper.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include <iostream>
@@ -58,7 +59,7 @@ bool PythiaFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
      
      for ( HepMC::GenEvent::particle_const_iterator p = myGenEvent->particles_begin();
 	   p != myGenEvent->particles_end(); ++p ) {
-       HepMC::FourVector mom = zboost((*p)->momentum());
+       HepMC::FourVector mom = MCFilterZboostHelper::zboost((*p)->momentum(),betaBoost);
        rapidity = 0.5*log( (mom.e()+mom.pz()) / (mom.e()-mom.pz()) );
        
        if ( abs((*p)->pdg_id()) == particleID 
@@ -121,14 +122,4 @@ bool PythiaFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
    if (accepted){
    return true; } else {return false;}
 
-}
-
-HepMC::FourVector PythiaFilter::zboost(const HepMC::FourVector& mom) {
-   //Boost this Lorentz vector (from TLorentzVector::Boost)
-   double b2 = betaBoost*betaBoost;
-   double gamma = 1.0 / sqrt(1.0 - b2);
-   double bp = betaBoost*mom.pz();
-   double gamma2 = b2 > 0 ? (gamma - 1.0)/b2 : 0.0;
-
-   return HepMC::FourVector(mom.px(), mom.py(), mom.pz() + gamma2*bp*betaBoost + gamma*betaBoost*mom.e(), gamma*(mom.e()+bp));
 }

--- a/GeneratorInterface/GenFilters/src/PythiaFilterMultiMother.cc
+++ b/GeneratorInterface/GenFilters/src/PythiaFilterMultiMother.cc
@@ -64,14 +64,14 @@ bool PythiaFilterMultiMother::filter(edm::Event& iEvent, const edm::EventSetup& 
        if ( abs((*p)->pdg_id()) == particleID
 	    && mom.rho() > minpcut
 	    && mom.rho() < maxpcut
-	    && mom.perp() > minptcut
-	    && mom.perp() < maxptcut
+	    && (*p)->momentum().perp() > minptcut
+	    && (*p)->momentum().perp() < maxptcut
 	    && mom.eta() > minetacut
 	    && mom.eta() < maxetacut
 	    && rapidity > minrapcut
 	    && rapidity < maxrapcut
-	    && mom.phi() > minphicut
-	    && mom.phi() < maxphicut ) {
+	    && (*p)->momentum().phi() > minphicut
+	    && (*p)->momentum().phi() < maxphicut ) {
 
 
 	 for(std::vector<int>::const_iterator motherID = motherIDs.begin(); motherID != motherIDs.end(); ++motherID) {

--- a/GeneratorInterface/GenFilters/src/PythiaFilterMultiMother.cc
+++ b/GeneratorInterface/GenFilters/src/PythiaFilterMultiMother.cc
@@ -23,7 +23,8 @@ minphicut(iConfig.getUntrackedParameter("MinPhi", -3.5)),
 maxphicut(iConfig.getUntrackedParameter("MaxPhi", 3.5)),
 status(iConfig.getUntrackedParameter("Status", 0)),
 motherIDs(iConfig.getUntrackedParameter("MotherIDs", std::vector<int>{0})),
-processID(iConfig.getUntrackedParameter("ProcessID", 0))
+processID(iConfig.getUntrackedParameter("ProcessID", 0)),
+betaBoost(iConfig.getUntrackedParameter("BetaBoost",0.))
 {
    //now do what ever initialization is needed
 
@@ -57,20 +58,20 @@ bool PythiaFilterMultiMother::filter(edm::Event& iEvent, const edm::EventSetup& 
 
      for ( HepMC::GenEvent::particle_const_iterator p = myGenEvent->particles_begin();
 	   p != myGenEvent->particles_end(); ++p ) {
-
-       rapidity = 0.5*log( ((*p)->momentum().e()+(*p)->momentum().pz()) / ((*p)->momentum().e()-(*p)->momentum().pz()) );
+       HepMC::FourVector mom = zboost((*p)->momentum());
+       rapidity = 0.5*log( (mom.e()+mom.pz()) / (mom.e()-mom.pz()) );
 
        if ( abs((*p)->pdg_id()) == particleID
-	    && (*p)->momentum().rho() > minpcut
-	    && (*p)->momentum().rho() < maxpcut
-	    && (*p)->momentum().perp() > minptcut
-	    && (*p)->momentum().perp() < maxptcut
-	    && (*p)->momentum().eta() > minetacut
-	    && (*p)->momentum().eta() < maxetacut
+	    && mom.rho() > minpcut
+	    && mom.rho() < maxpcut
+	    && mom.perp() > minptcut
+	    && mom.perp() < maxptcut
+	    && mom.eta() > minetacut
+	    && mom.eta() < maxetacut
 	    && rapidity > minrapcut
 	    && rapidity < maxrapcut
-	    && (*p)->momentum().phi() > minphicut
-	    && (*p)->momentum().phi() < maxphicut ) {
+	    && mom.phi() > minphicut
+	    && mom.phi() < maxphicut ) {
 
 
 	 for(std::vector<int>::const_iterator motherID = motherIDs.begin(); motherID != motherIDs.end(); ++motherID) {
@@ -121,4 +122,14 @@ bool PythiaFilterMultiMother::filter(edm::Event& iEvent, const edm::EventSetup& 
    if (accepted){
    return true; } else {return false;}
 
+}
+
+HepMC::FourVector MCParticlePairFilter::zboost(const HepMC::FourVector& mom) {
+   //Boost this Lorentz vector (from TLorentzVector::Boost)
+   double b2 = betaBoost*betaBoost;
+   double gamma = 1.0 / sqrt(1.0 - b2);
+   double bp = betaBoost*mom.pz();
+   double gamma2 = b2 > 0 ? (gamma - 1.0)/b2 : 0.0;
+
+   return HepMC::FourVector(mom.px(), mom.py(), mom.pz() + gamma2*bp*betaBoost + gamma*betaBoost*mom.e(), gamma*(mom.e()+bp));
 }

--- a/GeneratorInterface/GenFilters/src/PythiaFilterMultiMother.cc
+++ b/GeneratorInterface/GenFilters/src/PythiaFilterMultiMother.cc
@@ -124,7 +124,7 @@ bool PythiaFilterMultiMother::filter(edm::Event& iEvent, const edm::EventSetup& 
 
 }
 
-HepMC::FourVector MCParticlePairFilter::zboost(const HepMC::FourVector& mom) {
+HepMC::FourVector PythiaFilterMultiMother::zboost(const HepMC::FourVector& mom) {
    //Boost this Lorentz vector (from TLorentzVector::Boost)
    double b2 = betaBoost*betaBoost;
    double gamma = 1.0 / sqrt(1.0 - b2);

--- a/GeneratorInterface/GenFilters/src/PythiaFilterMultiMother.cc
+++ b/GeneratorInterface/GenFilters/src/PythiaFilterMultiMother.cc
@@ -1,5 +1,6 @@
 
 #include "GeneratorInterface/GenFilters/interface/PythiaFilterMultiMother.h"
+#include "GeneratorInterface/GenFilters/interface/MCFilterZboostHelper.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include <iostream>
@@ -58,7 +59,7 @@ bool PythiaFilterMultiMother::filter(edm::Event& iEvent, const edm::EventSetup& 
 
      for ( HepMC::GenEvent::particle_const_iterator p = myGenEvent->particles_begin();
 	   p != myGenEvent->particles_end(); ++p ) {
-       HepMC::FourVector mom = zboost((*p)->momentum());
+       HepMC::FourVector mom = MCFilterZboostHelper::zboost((*p)->momentum(),betaBoost);
        rapidity = 0.5*log( (mom.e()+mom.pz()) / (mom.e()-mom.pz()) );
 
        if ( abs((*p)->pdg_id()) == particleID
@@ -122,14 +123,4 @@ bool PythiaFilterMultiMother::filter(edm::Event& iEvent, const edm::EventSetup& 
    if (accepted){
    return true; } else {return false;}
 
-}
-
-HepMC::FourVector PythiaFilterMultiMother::zboost(const HepMC::FourVector& mom) {
-   //Boost this Lorentz vector (from TLorentzVector::Boost)
-   double b2 = betaBoost*betaBoost;
-   double gamma = 1.0 / sqrt(1.0 - b2);
-   double bp = betaBoost*mom.pz();
-   double gamma2 = b2 > 0 ? (gamma - 1.0)/b2 : 0.0;
-
-   return HepMC::FourVector(mom.px(), mom.py(), mom.pz() + gamma2*bp*betaBoost + gamma*betaBoost*mom.e(), gamma*(mom.e()+bp));
 }

--- a/GeneratorInterface/GenFilters/src/PythiaMomDauFilter.cc
+++ b/GeneratorInterface/GenFilters/src/PythiaMomDauFilter.cc
@@ -1,6 +1,6 @@
 
 #include "GeneratorInterface/GenFilters/interface/PythiaMomDauFilter.h"
-
+#include "GeneratorInterface/GenFilters/interface/MCFilterZboostHelper.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "HepMC/PythiaWrapper6_4.h"
@@ -68,7 +68,7 @@ bool PythiaMomDauFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
  for ( HepMC::GenEvent::particle_const_iterator p = myGenEvent->particles_begin();  p != myGenEvent->particles_end(); ++p ) {
      
   if( (*p)->pdg_id() != particleID ) continue ;
-  HepMC::FourVector mom = zboost((*p)->momentum());
+  HepMC::FourVector mom = MCFilterZboostHelper::zboost((*p)->momentum(),betaBoost);
   if( (*p)->momentum().perp() >  mom_minptcut  && (*p)->momentum().perp() <  mom_maxptcut  && mom.eta()  >  mom_minetacut &&  mom.eta()  <  mom_maxetacut ){ 
    mom_accepted = true;
    ndauac = 0;
@@ -88,7 +88,7 @@ bool PythiaMomDauFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
         ++ndes;        
         for( unsigned int i=0; i<desIDs.size(); ++i) {
          if( (*des)->pdg_id() != desIDs[i] ) continue ;
-         HepMC::FourVector dau_i = zboost((*des)->momentum());
+         HepMC::FourVector dau_i = MCFilterZboostHelper::zboost((*des)->momentum(),betaBoost);
          if( (*des)->momentum().perp() >  minptcut  && (*des)->momentum().perp() <  maxptcut  && dau_i.eta()  >  minetacut &&  dau_i.eta()  <  maxetacut ) {
           ++ndesac;
           break;
@@ -113,7 +113,7 @@ bool PythiaMomDauFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
      for ( HepMC::GenEvent::particle_const_iterator p = myGenEvent->particles_begin(); p != myGenEvent->particles_end(); ++p ) {
        
        if( (*p)->pdg_id() != -particleID ) continue ;
-       HepMC::FourVector mom = zboost((*p)->momentum());
+       HepMC::FourVector mom = MCFilterZboostHelper::zboost((*p)->momentum(),betaBoost);
        if( (*p)->momentum().perp() >  mom_minptcut  && (*p)->momentum().perp() <  mom_maxptcut  &&  mom.eta()  >  mom_minetacut && mom.eta()  <  mom_maxetacut ){ 
        mom_accepted = true;
        ndauac = 0;
@@ -145,7 +145,7 @@ bool PythiaMomDauFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
 	     int has_antipart = pydat2.kchg[3-1][pythiaCode-1];
 	     if( has_antipart == 0 ) IDanti = desIDs[i];
 	     if( (*des)->pdg_id() != IDanti ) continue ;
-             HepMC::FourVector dau_i = zboost((*des)->momentum());
+             HepMC::FourVector dau_i = MCFilterZboostHelper::zboost((*des)->momentum(),betaBoost);
 	     if(   (*des)->momentum().perp() >  minptcut  && (*des)->momentum().perp() <  maxptcut  &&  dau_i.eta()  >  minetacut && dau_i.eta()  <  maxetacut ) {
 	       ++ndesac;
 	       break;
@@ -167,14 +167,4 @@ bool PythiaMomDauFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
    if (accepted){
    return true; } else {return false;}
 
-}
-
-HepMC::FourVector PythiaMomDauFilter::zboost(const HepMC::FourVector& mom) {
-   //Boost this Lorentz vector (from TLorentzVector::Boost)
-   double b2 = betaBoost*betaBoost;
-   double gamma = 1.0 / sqrt(1.0 - b2);
-   double bp = betaBoost*mom.pz();
-   double gamma2 = b2 > 0 ? (gamma - 1.0)/b2 : 0.0;
-
-   return HepMC::FourVector(mom.px(), mom.py(), mom.pz() + gamma2*bp*betaBoost + gamma*betaBoost*mom.e(), gamma*(mom.e()+bp));
 }

--- a/GeneratorInterface/GenFilters/src/PythiaMomDauFilter.cc
+++ b/GeneratorInterface/GenFilters/src/PythiaMomDauFilter.cc
@@ -69,7 +69,7 @@ bool PythiaMomDauFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
      
   if( (*p)->pdg_id() != particleID ) continue ;
   HepMC::FourVector mom = zboost((*p)->momentum());
-  if( mom.perp() >  mom_minptcut  && mom.perp() <  mom_maxptcut  && mom.eta()  >  mom_minetacut &&  mom.eta()  <  mom_maxetacut ){ 
+  if( (*p)->momentum().perp() >  mom_minptcut  && (*p)->momentum().perp() <  mom_maxptcut  && mom.eta()  >  mom_minetacut &&  mom.eta()  <  mom_maxetacut ){ 
    mom_accepted = true;
    ndauac = 0;
    ndau   = 0;
@@ -89,7 +89,7 @@ bool PythiaMomDauFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
         for( unsigned int i=0; i<desIDs.size(); ++i) {
          if( (*des)->pdg_id() != desIDs[i] ) continue ;
          HepMC::FourVector dau_i = zboost((*des)->momentum());
-         if( dau_i.perp() >  minptcut  && dau_i.perp() <  maxptcut  && dau_i.eta()  >  minetacut &&  dau_i.eta()  <  maxetacut ) {
+         if( (*des)->momentum().perp() >  minptcut  && (*des)->momentum().perp() <  maxptcut  && dau_i.eta()  >  minetacut &&  dau_i.eta()  <  maxetacut ) {
           ++ndesac;
           break;
 	  } 
@@ -114,7 +114,7 @@ bool PythiaMomDauFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
        
        if( (*p)->pdg_id() != -particleID ) continue ;
        HepMC::FourVector mom = zboost((*p)->momentum());
-       if( mom.perp() >  mom_minptcut  && mom.perp() <  mom_maxptcut  &&  mom.eta()  >  mom_minetacut && mom.eta()  <  mom_maxetacut ){ 
+       if( (*p)->momentum().perp() >  mom_minptcut  && (*p)->momentum().perp() <  mom_maxptcut  &&  mom.eta()  >  mom_minetacut && mom.eta()  <  mom_maxetacut ){ 
        mom_accepted = true;
        ndauac = 0;
        ndau = 0;
@@ -146,7 +146,7 @@ bool PythiaMomDauFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
 	     if( has_antipart == 0 ) IDanti = desIDs[i];
 	     if( (*des)->pdg_id() != IDanti ) continue ;
              HepMC::FourVector dau_i = zboost((*des)->momentum());
-	     if(   dau_i.perp() >  minptcut  && dau_i.perp() <  maxptcut  &&  dau_i.eta()  >  minetacut && dau_i.eta()  <  maxetacut ) {
+	     if(   (*des)->momentum().perp() >  minptcut  && (*des)->momentum().perp() <  maxptcut  &&  dau_i.eta()  >  minetacut && dau_i.eta()  <  maxetacut ) {
 	       ++ndesac;
 	       break;
 	     } 

--- a/GeneratorInterface/GenFilters/src/PythiaMomDauFilter.cc
+++ b/GeneratorInterface/GenFilters/src/PythiaMomDauFilter.cc
@@ -12,19 +12,20 @@ using namespace std;
 
 PythiaMomDauFilter::PythiaMomDauFilter(const edm::ParameterSet& iConfig) :
 label_(consumes<edm::HepMCProduct>(edm::InputTag(iConfig.getUntrackedParameter("moduleLabel",std::string("generator")),"unsmeared"))),
-particleID(iConfig.getUntrackedParameter("ParticleID", 0)),
-daughterID(iConfig.getUntrackedParameter("DaughterID", 0)),
-chargeconju(iConfig.getUntrackedParameter("ChargeConjugation", true)),
-ndaughters(iConfig.getUntrackedParameter("NumberDaughters", 0)),
-ndescendants(iConfig.getUntrackedParameter("NumberDescendants", 0)),
-minptcut(iConfig.getUntrackedParameter("MinPt", 0.)),
-maxptcut(iConfig.getUntrackedParameter("MaxPt", 14000.)),
-minetacut(iConfig.getUntrackedParameter("MinEta", -10.)),
-maxetacut(iConfig.getUntrackedParameter("MaxEta", 10.)),
-mom_minptcut(iConfig.getUntrackedParameter("MomMinPt", 0.)),
-mom_maxptcut(iConfig.getUntrackedParameter("MomMaxPt", 14000.)),
-mom_minetacut(iConfig.getUntrackedParameter("MomMinEta", -10.)),
-mom_maxetacut(iConfig.getUntrackedParameter("MomMaxEta", 10.))
+particleID(iConfig.getUntrackedParameter<int>("ParticleID", 0)),
+daughterID(iConfig.getUntrackedParameter<int>("DaughterID", 0)),
+chargeconju(iConfig.getUntrackedParameter<bool>("ChargeConjugation", true)),
+ndaughters(iConfig.getUntrackedParameter<int>("NumberDaughters", 0)),
+ndescendants(iConfig.getUntrackedParameter<int>("NumberDescendants", 0)),
+minptcut(iConfig.getUntrackedParameter<double>("MinPt", 0.)),
+maxptcut(iConfig.getUntrackedParameter<double>("MaxPt", 14000.)),
+minetacut(iConfig.getUntrackedParameter<double>("MinEta", -10.)),
+maxetacut(iConfig.getUntrackedParameter<double>("MaxEta", 10.)),
+mom_minptcut(iConfig.getUntrackedParameter<double>("MomMinPt", 0.)),
+mom_maxptcut(iConfig.getUntrackedParameter<double>("MomMaxPt", 14000.)),
+mom_minetacut(iConfig.getUntrackedParameter<double>("MomMinEta", -10.)),
+mom_maxetacut(iConfig.getUntrackedParameter<double>("MomMaxEta", 10.)),
+betaBoost(iConfig.getUntrackedParameter("BetaBoost",0.))
 {
    //now do what ever initialization is needed
    vector<int> defdauID;
@@ -67,7 +68,8 @@ bool PythiaMomDauFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
  for ( HepMC::GenEvent::particle_const_iterator p = myGenEvent->particles_begin();  p != myGenEvent->particles_end(); ++p ) {
      
   if( (*p)->pdg_id() != particleID ) continue ;
-  if( (*p)->momentum().perp() >  mom_minptcut  && (*p)->momentum().perp() <  mom_maxptcut  && (*p)->momentum().eta()  >  mom_minetacut &&  (*p)->momentum().eta()  <  mom_maxetacut ){ 
+  HepMC::FourVector mom = zboost((*p)->momentum());
+  if( mom.perp() >  mom_minptcut  && mom.perp() <  mom_maxptcut  && mom.eta()  >  mom_minetacut &&  mom.eta()  <  mom_maxetacut ){ 
    mom_accepted = true;
    ndauac = 0;
    ndau   = 0;
@@ -86,7 +88,8 @@ bool PythiaMomDauFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
         ++ndes;        
         for( unsigned int i=0; i<desIDs.size(); ++i) {
          if( (*des)->pdg_id() != desIDs[i] ) continue ;
-         if( (*des)->momentum().perp() >  minptcut  && (*des)->momentum().perp() <  maxptcut  && (*des)->momentum().eta()  >  minetacut &&  (*des)->momentum().eta()  <  maxetacut ) {
+         HepMC::FourVector dau_i = zboost((*des)->momentum());
+         if( dau_i.perp() >  minptcut  && dau_i.perp() <  maxptcut  && dau_i.eta()  >  minetacut &&  dau_i.eta()  <  maxetacut ) {
           ++ndesac;
           break;
 	  } 
@@ -110,7 +113,8 @@ bool PythiaMomDauFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
      for ( HepMC::GenEvent::particle_const_iterator p = myGenEvent->particles_begin(); p != myGenEvent->particles_end(); ++p ) {
        
        if( (*p)->pdg_id() != -particleID ) continue ;
-       if( (*p)->momentum().perp() >  mom_minptcut  && (*p)->momentum().perp() <  mom_maxptcut  &&  (*p)->momentum().eta()  >  mom_minetacut && (*p)->momentum().eta()  <  mom_maxetacut ){ 
+       HepMC::FourVector mom = zboost((*p)->momentum());
+       if( mom.perp() >  mom_minptcut  && mom.perp() <  mom_maxptcut  &&  mom.eta()  >  mom_minetacut && mom.eta()  <  mom_maxetacut ){ 
        mom_accepted = true;
        ndauac = 0;
        ndau = 0;
@@ -141,7 +145,8 @@ bool PythiaMomDauFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
 	     int has_antipart = pydat2.kchg[3-1][pythiaCode-1];
 	     if( has_antipart == 0 ) IDanti = desIDs[i];
 	     if( (*des)->pdg_id() != IDanti ) continue ;
-	     if(   (*des)->momentum().perp() >  minptcut  && (*des)->momentum().perp() <  maxptcut  &&  (*des)->momentum().eta()  >  minetacut && (*des)->momentum().eta()  <  maxetacut ) {
+             HepMC::FourVector dau_i = zboost((*des)->momentum());
+	     if(   dau_i.perp() >  minptcut  && dau_i.perp() <  maxptcut  &&  dau_i.eta()  >  minetacut && dau_i.eta()  <  maxetacut ) {
 	       ++ndesac;
 	       break;
 	     } 
@@ -162,4 +167,14 @@ bool PythiaMomDauFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
    if (accepted){
    return true; } else {return false;}
 
+}
+
+HepMC::FourVector PythiaMomDauFilter::zboost(const HepMC::FourVector& mom) {
+   //Boost this Lorentz vector (from TLorentzVector::Boost)
+   double b2 = betaBoost*betaBoost;
+   double gamma = 1.0 / sqrt(1.0 - b2);
+   double bp = betaBoost*mom.pz();
+   double gamma2 = b2 > 0 ? (gamma - 1.0)/b2 : 0.0;
+
+   return HepMC::FourVector(mom.px(), mom.py(), mom.pz() + gamma2*bp*betaBoost + gamma*betaBoost*mom.e(), gamma*(mom.e()+bp));
 }


### PR DESCRIPTION
This change is needed to be able to apply generator-level cuts on momenta in the laboratory frame, instead of the centre of mass frame, in the case of boosted MC production (for proton-lead).
This PR follows the same strategy as #16425 and #18532

@kurtejung and @mandrenguyen are aware of this PR.