### PR TITLE
Add per-site Xrootd statistics to the HTCondor monitoring.

### DIFF
--- a/FWCore/Framework/src/defaultCmsRunServices.cc
+++ b/FWCore/Framework/src/defaultCmsRunServices.cc
@@ -23,7 +23,8 @@ namespace edm {
                                               "AdaptorConfig",
                                               "SiteLocalConfigService",
                                               "StatisticsSenderService",
-                                              "CondorStatusService"};
+                                              "CondorStatusService",
+                                              "XrdAdaptor::XrdStatisticsService"};
 
       return returnValue;
    }

--- a/FWCore/Services/plugins/BuildFile.xml
+++ b/FWCore/Services/plugins/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="FWCore/Services"/>
 <use   name="Utilities/StorageFactory"/>
+<use   name="Utilities/XrdAdaptor"/>
 <use   name="boost"/>
 <use   name="gcc-atomic"/>
 <library   file="*.cc" name="FWCoreServicesPlugins">

--- a/FWCore/Services/plugins/CondorStatusUpdater.cc
+++ b/FWCore/Services/plugins/CondorStatusUpdater.cc
@@ -445,8 +445,8 @@ CondorStatusService::updateChirpImpl(const std::string &key_suffix, const std::s
     argv.push_back(set_job_attr.c_str());
     argv.push_back(key.c_str());
     argv.push_back(value.c_str());
-    argv.push_back(NULL);
-    int status = posix_spawnp(&pid, "condor_chirp", &file_actions, NULL, const_cast<char* const*>(&argv[0]), environ);
+    argv.push_back(nullptr);
+    int status = posix_spawnp(&pid, "condor_chirp", &file_actions, nullptr, const_cast<char* const*>(&argv[0]), environ);
     close(devnull_fd);
     posix_spawn_file_actions_destroy(&file_actions);
     if (status)

--- a/Utilities/StorageFactory/interface/IOBuffer.h
+++ b/Utilities/StorageFactory/interface/IOBuffer.h
@@ -22,7 +22,7 @@ private:
 /** Construct a null I/O buffer.  */
 inline
 IOBuffer::IOBuffer (void)
-  : m_data (0),
+  : m_data (nullptr),
     m_length (0)
 {}
 

--- a/Utilities/StorageFactory/interface/IOPosBuffer.h
+++ b/Utilities/StorageFactory/interface/IOPosBuffer.h
@@ -29,7 +29,7 @@ private:
 inline
 IOPosBuffer::IOPosBuffer (void)
   : m_offset (0),
-    m_data (0),
+    m_data (nullptr),
     m_length (0)
 {}
 

--- a/Utilities/StorageFactory/interface/IOTypes.h
+++ b/Utilities/StorageFactory/interface/IOTypes.h
@@ -1,8 +1,8 @@
 #ifndef STORAGE_FACTORY_IO_TYPES_H
 # define STORAGE_FACTORY_IO_TYPES_H
 
-# include <stdint.h>
-# include <stdlib.h>
+# include <cstdint>
+# include <cstdlib>
 
 /** Invalid channel descriptor constant.  */
 #define EDM_IOFD_INVALID -1

--- a/Utilities/StorageFactory/interface/Storage.h
+++ b/Utilities/StorageFactory/interface/Storage.h
@@ -23,7 +23,7 @@ public:
   enum Relative { SET, CURRENT, END };
 
   Storage (void);
-  virtual ~Storage (void);
+  ~Storage (void) override;
 
   using IOInput::read;
   using IOInput::readv;

--- a/Utilities/StorageFactory/interface/StorageAccount.h
+++ b/Utilities/StorageFactory/interface/StorageAccount.h
@@ -1,7 +1,7 @@
 #ifndef STORAGE_FACTORY_STORAGE_ACCOUNT_H
 # define STORAGE_FACTORY_STORAGE_ACCOUNT_H
 
-# include <stdint.h>
+# include <cstdint>
 # include <string>
 # include <chrono>
 # include <atomic>

--- a/Utilities/XrdAdaptor/src/QualityMetric.h
+++ b/Utilities/XrdAdaptor/src/QualityMetric.h
@@ -1,7 +1,7 @@
 #ifndef Utilities_XrdAdaptor_QualityMetric_h
 #define Utilities_XrdAdaptor_QualityMetric_h
 
-#include <time.h>
+#include <ctime>
 
 #include <mutex>
 #include <memory>

--- a/Utilities/XrdAdaptor/src/XrdRequest.h
+++ b/Utilities/XrdAdaptor/src/XrdRequest.h
@@ -44,7 +44,7 @@ public:
           m_iolist(iolist),
           m_manager(manager)
     {
-        if (m_iolist->size() && !m_size)
+        if (!m_iolist->empty() && !m_size)
         {
             for (IOPosBuffer const & buf : *m_iolist)
             {
@@ -58,7 +58,7 @@ public:
         m_stats = stats;
     }
 
-    virtual ~ClientRequest();
+    ~ClientRequest() override;
 
     std::future<IOSize> get_future()
     {
@@ -68,7 +68,7 @@ public:
     /**
      * Handle the response from the Xrootd server.
      */
-    virtual void HandleResponse(XrdCl::XRootDStatus *status, XrdCl::AnyObject *response) override;
+    void HandleResponse(XrdCl::XRootDStatus *status, XrdCl::AnyObject *response) override;
 
     IOSize getSize() const {return m_size;}
 

--- a/Utilities/XrdAdaptor/src/XrdStatistics.cc
+++ b/Utilities/XrdAdaptor/src/XrdStatistics.cc
@@ -44,14 +44,15 @@ void XrdStatisticsService::postEndJob()
     }
 }
 
-std::map<std::string, XrdStatisticsService::CondorIOStats>
+std::vector<std::pair<std::string, XrdStatisticsService::CondorIOStats>>
 XrdStatisticsService::condorUpdate()
 {
-    std::map<std::string, XrdStatisticsService::CondorIOStats> result;
+    std::vector<std::pair<std::string, XrdStatisticsService::CondorIOStats>> result;
     XrdSiteStatisticsInformation *instance = XrdSiteStatisticsInformation::getInstance();
     if (!instance) {return result;}
 
     std::lock_guard<std::mutex> lock(instance->m_mutex);
+    result.reserve(instance->m_sites.size());
     for (auto& stats : instance->m_sites)
     {
         CondorIOStats cs;
@@ -59,7 +60,7 @@ XrdStatisticsService::condorUpdate()
         if (!ss) continue;
         cs.bytesRead = ss->getTotalBytes();
         cs.transferTime = ss->getTotalReadTime();
-        result[ss->site()] = cs;
+        result.emplace_back(ss->site(), cs);
     }
     return result;
 }

--- a/Utilities/XrdAdaptor/src/XrdStatistics.cc
+++ b/Utilities/XrdAdaptor/src/XrdStatistics.cc
@@ -19,12 +19,12 @@ std::atomic<XrdSiteStatisticsInformation*> XrdSiteStatisticsInformation::m_insta
 
 XrdStatisticsService::XrdStatisticsService(const edm::ParameterSet &iPS, edm::ActivityRegistry &iRegistry)
 {
+    XrdSiteStatisticsInformation::createInstance();
+
     if (iPS.getUntrackedParameter<bool>("reportToFJR", false))
     {
-        XrdSiteStatisticsInformation::createInstance();
+        iRegistry.watchPostEndJob(this, &XrdStatisticsService::postEndJob);
     }
-
-    iRegistry.watchPostEndJob(this, &XrdStatisticsService::postEndJob);
 }
 
 
@@ -42,6 +42,26 @@ void XrdStatisticsService::postEndJob()
         stats->recomputeProperties(props);
         reportSvc->reportPerformanceForModule(stats->site(), "XrdSiteStatistics", props);
     }
+}
+
+std::map<std::string, XrdStatisticsService::CondorIOStats>
+XrdStatisticsService::condorUpdate()
+{
+    std::map<std::string, XrdStatisticsService::CondorIOStats> result;
+    XrdSiteStatisticsInformation *instance = XrdSiteStatisticsInformation::getInstance();
+    if (!instance) {return result;}
+
+    std::lock_guard<std::mutex> lock(instance->m_mutex);
+    for (auto& stats : instance->m_sites)
+    {
+        CondorIOStats cs;
+        std::shared_ptr<XrdSiteStatistics> ss = get_underlying_safe(stats);
+        if (!ss) continue;
+        cs.bytesRead = ss->getTotalBytes();
+        cs.transferTime = ss->getTotalReadTime();
+        result[ss->site()] = cs;
+    }
+    return result;
 }
 
 
@@ -171,10 +191,10 @@ XrdReadStatistics::XrdReadStatistics(std::shared_ptr<XrdSiteStatistics> parent, 
 }
 
 
-float
+uint64_t
 XrdReadStatistics::elapsedNS() const
 {
     std::chrono::time_point<std::chrono::high_resolution_clock> end = std::chrono::high_resolution_clock::now();
-    return static_cast<int>(std::chrono::duration_cast<std::chrono::nanoseconds>(end-m_start).count());
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(end-m_start).count();
 }
 

--- a/Utilities/XrdAdaptor/src/XrdStatistics.h
+++ b/Utilities/XrdAdaptor/src/XrdStatistics.h
@@ -16,6 +16,11 @@ namespace edm
     class ParameterSet;
     class ActivityRegistry;
     class ConfigurationDescriptions;
+
+    namespace service
+    {
+        class CondorStatusService;
+    }
 }
 
 namespace XrdAdaptor
@@ -41,8 +46,16 @@ public:
 
     void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
-private:
+    struct CondorIOStats {
+      uint64_t bytesRead{0};
+      std::chrono::nanoseconds transferTime{0};
+    };
 
+    // Provide an update of per-site transfer statistics to the CondorStatusService.
+    // Returns a mapping of "site name" to transfer statistics.  The "site name" is
+    // as self-identified by the Xrootd host; may not necessarily match up with the
+    // "CMS site name".
+    std::map<std::string, CondorIOStats> condorUpdate();
 };
 
 class XrdSiteStatisticsInformation
@@ -81,6 +94,9 @@ public:
 
     void finishRead(XrdReadStatistics const &);
 
+    uint64_t getTotalBytes() const {return m_readvSize + m_readSize;}
+    std::chrono::nanoseconds getTotalReadTime() {return std::chrono::nanoseconds(m_readvNS) + std::chrono::nanoseconds(m_readNS);}
+
 private:
     const std::string m_site = "Unknown";
 
@@ -105,7 +121,7 @@ public:
 private:
     XrdReadStatistics(std::shared_ptr<XrdSiteStatistics> parent, IOSize size, size_t count);
 
-    float elapsedNS() const;
+    uint64_t elapsedNS() const;
     int readCount() const {return m_count;}
     int size() const {return m_size;}
 

--- a/Utilities/XrdAdaptor/src/XrdStatistics.h
+++ b/Utilities/XrdAdaptor/src/XrdStatistics.h
@@ -55,7 +55,7 @@ public:
     // Returns a mapping of "site name" to transfer statistics.  The "site name" is
     // as self-identified by the Xrootd host; may not necessarily match up with the
     // "CMS site name".
-    std::map<std::string, CondorIOStats> condorUpdate();
+    std::vector<std::pair<std::string, CondorIOStats>> condorUpdate();
 };
 
 class XrdSiteStatisticsInformation


### PR DESCRIPTION
Per popular demand, this will allow us to see per-site bytes read and read time, aggregated by site (as identified by the remote server; may be different from the CMS site name).

@osschar 