### PR TITLE
Secondary source statistics (v2)

### DIFF
--- a/FWCore/Services/plugins/CondorStatusUpdater.cc
+++ b/FWCore/Services/plugins/CondorStatusUpdater.cc
@@ -452,8 +452,8 @@ CondorStatusService::updateChirpImpl(const std::string &key_suffix, const std::s
     argv.push_back(set_job_attr.c_str());
     argv.push_back(key.c_str());
     argv.push_back(value.c_str());
-    argv.push_back(NULL);
-    int status = posix_spawnp(&pid, "condor_chirp", &file_actions, NULL, const_cast<char* const*>(&argv[0]), environ);
+    argv.push_back(nullptr);
+    int status = posix_spawnp(&pid, "condor_chirp", &file_actions, nullptr, const_cast<char* const*>(&argv[0]), environ);
     close(devnull_fd);
     posix_spawn_file_actions_destroy(&file_actions);
     if (status)

--- a/IOPool/Input/src/InputFile.cc
+++ b/IOPool/Input/src/InputFile.cc
@@ -40,7 +40,7 @@ namespace edm {
           label = StorageAccount::OpenLabel::SecondarySource;
           break;
         default:
-          label = StorageAccount::OpenLabel::None;
+          label = StorageAccount::OpenLabel::Aggregate;
           assert(true);
       }
       // Sets a label for statistics collection; it is a thread-local that is unset when the

--- a/IOPool/Input/src/InputFile.cc
+++ b/IOPool/Input/src/InputFile.cc
@@ -10,6 +10,7 @@ Holder for an input TFile.
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/ExceptionPropagate.h"
 #include "FWCore/Utilities/interface/TimeOfDay.h"
+#include "Utilities/StorageFactory/interface/StorageAccount.h"
 
 #include <exception>
 #include <iomanip>
@@ -27,6 +28,21 @@ namespace edm {
       // it was registered in.  Fixes issue #15524.
       TDirectory::TContext contextEraser;
 
+      std::string label;
+      switch (inputType) {
+        case InputType::Primary:
+          label = "primary";
+          break;
+        case InputType::SecondaryFile:
+          label = "secondaryfile";
+          break;
+        case InputType::SecondarySource:
+          label = "secondarysource";
+      }
+      // Sets a label for statistics collection; it is a thread-local that is unset when the
+      // `token` object falls out of scope.  Only used if the plugin selected by TFile
+      // is from CMSSW.
+      auto token = StorageAccount::setLabel(label);
       file_ = std::unique_ptr<TFile>(TFile::Open(fileName)); // propagate_const<T> has no reset() function
     }
     std::exception_ptr e = edm::threadLocalException::getException();

--- a/IOPool/Input/src/InputFile.cc
+++ b/IOPool/Input/src/InputFile.cc
@@ -28,21 +28,25 @@ namespace edm {
       // it was registered in.  Fixes issue #15524.
       TDirectory::TContext contextEraser;
 
-      std::string label;
+      StorageAccount::OpenLabel label;
       switch (inputType) {
         case InputType::Primary:
-          label = "primary";
+          label = StorageAccount::OpenLabel::Primary;
           break;
         case InputType::SecondaryFile:
-          label = "secondaryfile";
+          label = StorageAccount::OpenLabel::SecondaryFile;
           break;
         case InputType::SecondarySource:
-          label = "secondarysource";
+          label = StorageAccount::OpenLabel::SecondarySource;
+          break;
+        default:
+          label = StorageAccount::OpenLabel::None;
+          assert(true);
       }
       // Sets a label for statistics collection; it is a thread-local that is unset when the
       // `token` object falls out of scope.  Only used if the plugin selected by TFile
       // is from CMSSW.
-      auto token = StorageAccount::setLabel(label);
+      auto token = StorageAccount::setContextLabel(label);
       file_ = std::unique_ptr<TFile>(TFile::Open(fileName)); // propagate_const<T> has no reset() function
     }
     std::exception_ptr e = edm::threadLocalException::getException();

--- a/IOPool/Input/src/InputFile.h
+++ b/IOPool/Input/src/InputFile.h
@@ -45,7 +45,7 @@ namespace edm {
 
     TObject* Get(char const* name) {return file_->Get(name);}
     TFileCacheRead* GetCacheRead() const {return file_->GetCacheRead();}
-    void SetCacheRead(TFileCacheRead* tfcr) {file_->SetCacheRead(tfcr, NULL, TFile::kDoNotDisconnect);}
+    void SetCacheRead(TFileCacheRead* tfcr) {file_->SetCacheRead(tfcr, nullptr, TFile::kDoNotDisconnect);}
     void logFileAction(char const* msg, char const* fileName) const;
   private:
     edm::propagate_const<std::unique_ptr<TFile>> file_;

--- a/IOPool/TFileAdaptor/interface/TStorageFactoryFile.h
+++ b/IOPool/TFileAdaptor/interface/TStorageFactoryFile.h
@@ -32,22 +32,22 @@ public:
   TStorageFactoryFile(const char *name, Option_t *option = "",
                       const char *ftitle = "", Int_t compress = 1);
 
-  ~TStorageFactoryFile(void);
+  ~TStorageFactoryFile(void) override;
 
-  virtual Bool_t	ReadBuffer(char *buf, Int_t len);
-  virtual Bool_t	ReadBuffer(char *buf, Long64_t pos, Int_t len);
-  virtual Bool_t	ReadBufferAsync(Long64_t off, Int_t len);
-  virtual Bool_t	ReadBuffers(char *buf,  Long64_t *pos, Int_t *len, Int_t nbuf);
-  virtual Bool_t	WriteBuffer(const char *buf, Int_t len);
+  Bool_t	ReadBuffer(char *buf, Int_t len) override;
+  Bool_t	ReadBuffer(char *buf, Long64_t pos, Int_t len) override;
+  Bool_t	ReadBufferAsync(Long64_t off, Int_t len) override;
+  Bool_t	ReadBuffers(char *buf,  Long64_t *pos, Int_t *len, Int_t nbuf) override;
+  Bool_t	WriteBuffer(const char *buf, Int_t len) override;
 
-  void			ResetErrno(void) const;
+  void			ResetErrno(void) const override;
 
 protected:
-  virtual Int_t		SysOpen(const char *pathname, Int_t flags, UInt_t mode);
-  virtual Int_t		SysClose(Int_t fd);
-  virtual Long64_t	SysSeek(Int_t fd, Long64_t offset, Int_t whence);
-  virtual Int_t		SysStat(Int_t fd, Long_t *id, Long64_t *size, Long_t *flags, Long_t *modtime);
-  virtual Int_t		SysSync(Int_t fd);
+  Int_t		SysOpen(const char *pathname, Int_t flags, UInt_t mode) override;
+  Int_t		SysClose(Int_t fd) override;
+  Long64_t	SysSeek(Int_t fd, Long64_t offset, Int_t whence) override;
+  Int_t		SysStat(Int_t fd, Long_t *id, Long64_t *size, Long_t *flags, Long_t *modtime) override;
+  Int_t		SysSync(Int_t fd) override;
 
 private:
   void                  Initialize(const char *name, Option_t *option = "");

--- a/IOPool/TFileAdaptor/interface/TStorageFactoryFile.h
+++ b/IOPool/TFileAdaptor/interface/TStorageFactoryFile.h
@@ -6,8 +6,9 @@
 
 # include "TFile.h"
 
-# include "Utilities/StorageFactory/interface/IOPosBuffer.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
+#include "Utilities/StorageFactory/interface/IOPosBuffer.h"
+#include "Utilities/StorageFactory/interface/StorageAccount.h"
 
 
 class Storage;
@@ -58,6 +59,7 @@ private:
   TStorageFactoryFile(void);
 
   edm::propagate_const<std::unique_ptr<Storage>> storage_; //< Real underlying storage
+  StorageAccount::StorageClassToken token_; //< Token for accounting purposes.
 };
 
 #endif // TFILE_ADAPTOR_TSTORAGE_FACTORY_FILE_H

--- a/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
+++ b/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
@@ -11,7 +11,7 @@
 #include "TSystem.h"
 #include "TROOT.h"
 #include "TEnv.h"
-#include <errno.h>
+#include <cerrno>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -70,20 +70,20 @@ public:
 #endif
 
 ClassImp(TStorageFactoryFile)
-static StorageAccount::Counter *s_statsCtor = 0;
-static StorageAccount::Counter *s_statsOpen = 0;
-static StorageAccount::Counter *s_statsClose = 0;
-static StorageAccount::Counter *s_statsFlush = 0;
-static StorageAccount::Counter *s_statsStat = 0;
-static StorageAccount::Counter *s_statsSeek = 0;
-static StorageAccount::Counter *s_statsRead = 0;
-static StorageAccount::Counter *s_statsCRead = 0;
-static StorageAccount::Counter *s_statsCPrefetch = 0;
-static StorageAccount::Counter *s_statsARead = 0;
-static StorageAccount::Counter *s_statsXRead = 0;
-static StorageAccount::Counter *s_statsWrite = 0;
-static StorageAccount::Counter *s_statsCWrite = 0;
-static StorageAccount::Counter *s_statsXWrite = 0;
+static StorageAccount::Counter *s_statsCtor = nullptr;
+static StorageAccount::Counter *s_statsOpen = nullptr;
+static StorageAccount::Counter *s_statsClose = nullptr;
+static StorageAccount::Counter *s_statsFlush = nullptr;
+static StorageAccount::Counter *s_statsStat = nullptr;
+static StorageAccount::Counter *s_statsSeek = nullptr;
+static StorageAccount::Counter *s_statsRead = nullptr;
+static StorageAccount::Counter *s_statsCRead = nullptr;
+static StorageAccount::Counter *s_statsCPrefetch = nullptr;
+static StorageAccount::Counter *s_statsARead = nullptr;
+static StorageAccount::Counter *s_statsXRead = nullptr;
+static StorageAccount::Counter *s_statsWrite = nullptr;
+static StorageAccount::Counter *s_statsCWrite = nullptr;
+static StorageAccount::Counter *s_statsXWrite = nullptr;
 
 
 static inline StorageAccount::Counter &
@@ -280,7 +280,7 @@ TStorageFactoryFile::ReadBuffer(char *buf, Int_t len)
                                  ? storageCounter(s_statsCPrefetch, StorageAccount::Operation::readPrefetchToCache, token_)
                                  : storageCounter(s_statsCRead, StorageAccount::Operation::readViaCache, token_));
 
-    Int_t st = ReadBufferViaCache(async ? 0 : buf, len);
+    Int_t st = ReadBufferViaCache(async ? nullptr : buf, len);
 
     if (st == 2) {
       Error("ReadBuffer","ReadBufferViaCache failed. Asked to read nBytes: %d from offset: %lld with file size: %lld",len, here, GetSize());
@@ -351,7 +351,7 @@ TStorageFactoryFile::ReadBufferAsync(Long64_t off, Int_t len)
     ;
   }
 
-  IOPosBuffer iov(off, (void *) 0, len ? len : PREFETCH_PROBE_LENGTH);
+  IOPosBuffer iov(off, (void *) nullptr, len ? len : PREFETCH_PROBE_LENGTH);
   if (storage_->prefetch(&iov, 1))
   {
     stats.tick(len);
@@ -461,7 +461,7 @@ TStorageFactoryFile::ReadBuffers(char *buf, Long64_t *pos, Int_t *len, Int_t nbu
   // optimization itself.
 
   // Read from underlying storage.
-  void* const nobuf = 0;
+  void* const nobuf = nullptr;
   Int_t total = 0;
   std::vector<IOPosBuffer> iov;
   iov.reserve(nbuf);

--- a/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
+++ b/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
@@ -89,7 +89,7 @@ static StorageAccount::Counter *s_statsXWrite = 0;
 static inline StorageAccount::Counter &
 storageCounter(StorageAccount::Counter *&c, StorageAccount::Operation operation)
 {
-  static const auto token = StorageAccount::tokenForStorageClassName("tstoragefile");
+  static const auto token = StorageAccount::tokenForStorageClassNameUsingContext("tstoragefile");
   if (! c) c = &StorageAccount::counter(token, operation);
   return *c;
 }

--- a/Utilities/StorageFactory/interface/File.h
+++ b/Utilities/StorageFactory/interface/File.h
@@ -15,7 +15,7 @@ public:
   File (IOFD fd, bool autoclose = true);
   File (const char *name, int flags = IOFlags::OpenRead, int perms = 0666);
   File (const std::string &name, int flags = IOFlags::OpenRead, int perms = 0666);
-  ~File (void);
+  ~File (void) override;
   // implicit copy constructor
   // implicit assignment operator
 
@@ -39,22 +39,22 @@ public:
   using Storage::writev;
   using Storage::position;
 
-  virtual bool		prefetch (const IOPosBuffer *what, IOSize n);
-  virtual IOSize	read (void *into, IOSize n);
-  virtual IOSize	read (void *into, IOSize n, IOOffset pos);
-  virtual IOSize	readv (IOBuffer *into, IOSize length);
+  bool		prefetch (const IOPosBuffer *what, IOSize n) override;
+  IOSize	read (void *into, IOSize n) override;
+  IOSize	read (void *into, IOSize n, IOOffset pos) override;
+  IOSize	readv (IOBuffer *into, IOSize length) override;
 
-  virtual IOSize	write (const void *from, IOSize n);
-  virtual IOSize	write (const void *from, IOSize n, IOOffset pos);
-  virtual IOSize	writev (const IOBuffer *from, IOSize length);
+  IOSize	write (const void *from, IOSize n) override;
+  IOSize	write (const void *from, IOSize n, IOOffset pos) override;
+  IOSize	writev (const IOBuffer *from, IOSize length) override;
 
-  virtual IOOffset	size (void) const;
-  virtual IOOffset	position (IOOffset offset, Relative whence = SET);
+  IOOffset	size (void) const override;
+  IOOffset	position (IOOffset offset, Relative whence = SET) override;
 
-  virtual void		resize (IOOffset size);
+  void		resize (IOOffset size) override;
 
-  virtual void		flush (void);
-  virtual void		close (void);
+  void		flush (void) override;
+  void		close (void) override;
   virtual void		abort (void);
 
   virtual void		setAutoClose (bool closeit);
@@ -69,7 +69,7 @@ private:
   static IOFD		sysduplicate (IOFD fd);
   static void		sysopen (const char *name, int flags, int perms,
 				 IOFD &newfd, unsigned &newflags);
-  static bool		sysclose (IOFD fd, int *error = 0);
+  static bool		sysclose (IOFD fd, int *error = nullptr);
 
   unsigned		m_flags;
 };

--- a/Utilities/StorageFactory/interface/IOBuffer.h
+++ b/Utilities/StorageFactory/interface/IOBuffer.h
@@ -22,7 +22,7 @@ private:
 /** Construct a null I/O buffer.  */
 inline
 IOBuffer::IOBuffer (void)
-  : m_data (0),
+  : m_data (nullptr),
     m_length (0)
 {}
 

--- a/Utilities/StorageFactory/interface/IOChannel.h
+++ b/Utilities/StorageFactory/interface/IOChannel.h
@@ -10,18 +10,18 @@ class IOChannel : public virtual IOInput, public virtual IOOutput
 {
 public:
   IOChannel (IOFD fd = EDM_IOFD_INVALID);
-  virtual ~IOChannel (void);
+  ~IOChannel (void) override;
   // implicit copy constructor
   // implicit assignment operator
 
   using IOInput::read;
   using IOOutput::write;
   
-  virtual IOSize	read (void *into, IOSize n);
-  virtual IOSize	readv (IOBuffer *into, IOSize buffers);
+  IOSize	read (void *into, IOSize n) override;
+  IOSize	readv (IOBuffer *into, IOSize buffers) override;
 
-  virtual IOSize	write (const void *from, IOSize n);
-  virtual IOSize	writev (const IOBuffer *from, IOSize buffers);
+  IOSize	write (const void *from, IOSize n) override;
+  IOSize	writev (const IOBuffer *from, IOSize buffers) override;
 
   virtual IOFD		fd (void) const;
   virtual void		fd (IOFD value); // FIXME: dangerous?
@@ -33,7 +33,7 @@ public:
 
 protected:
   // System implementation
-  bool			sysclose (IOFD fd, int *error = 0);
+  bool			sysclose (IOFD fd, int *error = nullptr);
 
 private:
   IOFD			m_fd;		/*< System file descriptor. */

--- a/Utilities/StorageFactory/interface/IOPosBuffer.h
+++ b/Utilities/StorageFactory/interface/IOPosBuffer.h
@@ -29,7 +29,7 @@ private:
 inline
 IOPosBuffer::IOPosBuffer (void)
   : m_offset (0),
-    m_data (0),
+    m_data (nullptr),
     m_length (0)
 {}
 

--- a/Utilities/StorageFactory/interface/IOTypes.h
+++ b/Utilities/StorageFactory/interface/IOTypes.h
@@ -1,8 +1,8 @@
 #ifndef STORAGE_FACTORY_IO_TYPES_H
 # define STORAGE_FACTORY_IO_TYPES_H
 
-# include <stdint.h>
-# include <stdlib.h>
+# include <cstdint>
+# include <cstdlib>
 
 /** Invalid channel descriptor constant.  */
 #define EDM_IOFD_INVALID -1

--- a/Utilities/StorageFactory/interface/LocalCacheFile.h
+++ b/Utilities/StorageFactory/interface/LocalCacheFile.h
@@ -13,25 +13,25 @@ class LocalCacheFile : public Storage
 {
 public:
   LocalCacheFile (std::unique_ptr<Storage> base, const std::string &tmpdir = "");
-  ~LocalCacheFile (void);
+  ~LocalCacheFile (void) override;
 
   using Storage::read;
   using Storage::write;
 
-  virtual bool		prefetch (const IOPosBuffer *what, IOSize n);
-  virtual IOSize	read (void *into, IOSize n);
-  virtual IOSize	read (void *into, IOSize n, IOOffset pos);
-  virtual IOSize	readv (IOBuffer *into, IOSize n);
-  virtual IOSize	readv (IOPosBuffer *into, IOSize n);
-  virtual IOSize	write (const void *from, IOSize n);
-  virtual IOSize	write (const void *from, IOSize n, IOOffset pos);
-  virtual IOSize	writev (const IOBuffer *from, IOSize n);
-  virtual IOSize	writev (const IOPosBuffer *from, IOSize n);
+  bool		prefetch (const IOPosBuffer *what, IOSize n) override;
+  IOSize	read (void *into, IOSize n) override;
+  IOSize	read (void *into, IOSize n, IOOffset pos) override;
+  IOSize	readv (IOBuffer *into, IOSize n) override;
+  IOSize	readv (IOPosBuffer *into, IOSize n) override;
+  IOSize	write (const void *from, IOSize n) override;
+  IOSize	write (const void *from, IOSize n, IOOffset pos) override;
+  IOSize	writev (const IOBuffer *from, IOSize n) override;
+  IOSize	writev (const IOPosBuffer *from, IOSize n) override;
 
-  virtual IOOffset	position (IOOffset offset, Relative whence = SET);
-  virtual void		resize (IOOffset size);
-  virtual void		flush (void);
-  virtual void		close (void);
+  IOOffset	position (IOOffset offset, Relative whence = SET) override;
+  void		resize (IOOffset size) override;
+  void		flush (void) override;
+  void		close (void) override;
 
 private:
   void			cache (IOOffset start, IOOffset end);

--- a/Utilities/StorageFactory/interface/Storage.h
+++ b/Utilities/StorageFactory/interface/Storage.h
@@ -23,7 +23,7 @@ public:
   enum Relative { SET, CURRENT, END };
 
   Storage (void);
-  virtual ~Storage (void);
+  ~Storage (void) override;
 
   using IOInput::read;
   using IOInput::readv;

--- a/Utilities/StorageFactory/interface/StorageAccount.h
+++ b/Utilities/StorageFactory/interface/StorageAccount.h
@@ -1,7 +1,7 @@
 #ifndef STORAGE_FACTORY_STORAGE_ACCOUNT_H
 # define STORAGE_FACTORY_STORAGE_ACCOUNT_H
 
-# include <stdint.h>
+# include <cstdint>
 # include <string>
 # include <chrono>
 # include <atomic>

--- a/Utilities/StorageFactory/interface/StorageAccount.h
+++ b/Utilities/StorageFactory/interface/StorageAccount.h
@@ -11,7 +11,9 @@
 
 class StorageAccount {
 public:
-  
+
+  // NOTE: if you add any new items to this enum, additionally add them to
+  // the static `allOperations`, initialized in StorageAccount.cc.  
   enum class Operation {
     check,
     close,
@@ -36,7 +38,7 @@ public:
     writeViaCache,
     writev
   };
-  static const std::array<Operation, 2> allOperations;
+  static const std::array<Operation, 22> allOperations;
   
   struct Counter {
     Counter():

--- a/Utilities/StorageFactory/interface/StorageAccount.h
+++ b/Utilities/StorageFactory/interface/StorageAccount.h
@@ -211,7 +211,7 @@ public:
   static StorageClassToken tokenForStorageClassName(std::string const& iName, OpenLabel iLabel);
   static const std::pair<OpenLabel, std::string>& nameForToken( StorageClassToken);
   
-  static StorageStats& summary(void);
+  static const StorageStats& summary(void);
   static std::string         summaryText(bool banner=false);
   static void                fillSummary(std::map<std::string, std::string> &summary);
   static Counter&            counter (StorageClassToken token,

--- a/Utilities/StorageFactory/interface/StorageAccount.h
+++ b/Utilities/StorageFactory/interface/StorageAccount.h
@@ -157,7 +157,7 @@ public:
   };
 
   enum class OpenLabel {
-    None,
+    Aggregate,
     Primary,
     SecondaryFile,
     SecondarySource

--- a/Utilities/StorageFactory/interface/StorageAccount.h
+++ b/Utilities/StorageFactory/interface/StorageAccount.h
@@ -36,6 +36,7 @@ public:
     writeViaCache,
     writev
   };
+  static const std::array<Operation, 2> allOperations;
   
   struct Counter {
     Counter():
@@ -83,13 +84,49 @@ public:
     std::atomic<double>   timeTotal;
     std::atomic<double>   timeMin;
     std::atomic<double>   timeMax;
-    
-    static void addTo(std::atomic<double>& iAtomic, double iToAdd) {
-      double oldValue = iAtomic.load();
+
+    template<typename T>
+    static void combineAtomics(std::atomic<double> & iAtomic, double iToAdd) {
+      double oldValue = iAtomic;
       double newValue = oldValue + iToAdd;
       while( not iAtomic.compare_exchange_weak(oldValue, newValue)) {
-        newValue = oldValue+iToAdd;
+        newValue = T()(oldValue, iToAdd);
       }
+    }
+
+    static void addTo(std::atomic<double> &lhs, double rhs) {
+      combineAtomics<std::plus<double>>(lhs, rhs);
+    }
+
+    struct minObj {
+      double operator()(double a, double b) {return a+b;}
+    };
+    static void minTo(std::atomic<double> &lhs, double rhs) {
+      combineAtomics<minObj>(lhs, rhs);
+    }
+
+    struct maxObj {
+      double operator()(double a, double b) {return a+b;}
+    };
+    static void maxTo(std::atomic<double> &lhs, double rhs) {
+      combineAtomics<maxObj>(lhs, rhs);
+    }
+
+    // Combine the contents of `this` with another counter; returns a reference
+    // to this object.
+    // NOTE: I was tempted to call this "operator+=", but timeMin/timeMax
+    // aren't actually added...
+    Counter & aggregate(const Counter &other) {
+      attempts += other.attempts;
+      successes += other.successes;
+      amount += other.amount;
+      addTo(amount_square, other.amount_square);
+      vector_count += other.vector_count;
+      vector_square += other.vector_square;
+      addTo(timeTotal, other.timeTotal);
+      minTo(timeMin, other.timeMin);
+      maxTo(timeMax, other.timeMax);
+      return *this;
     }
   };
 
@@ -116,21 +153,61 @@ public:
     int m_value;
     
   };
-  
+
+  /**
+   * The `OpenLabelToken` provides callers of TFile::Open the ability to
+   * retrieve a separate set of statistics in the FrameworkJobReport (and
+   * other statistics services) for IO.  Usage looks like this:
+   *
+   * ```cpp
+   * TFile *file = nullptr;
+   * {
+   *   OpenLabelToken label = StorageAccount::setLabel("MixingModule");
+   *   file = TFile::Open("url://foo/bar");
+   * }
+   * ```
+   *
+   * Any IO activity associated with `file` above will get a separate
+   * aggregation in CMSSW statistics.  This allows, for example, bytes
+   * read from the mixing module to be differentiated from the primary source.
+   */
+  class OpenLabelToken {
+  friend class StorageAccount;
+
+  public:
+    OpenLabelToken(OpenLabelToken const&) = delete;
+    OpenLabelToken(OpenLabelToken &&) = default;
+    ~OpenLabelToken() {m_label = "";}
+
+  private:
+    OpenLabelToken(const std::string &label) {
+      m_label = label;
+    }
+
+    static const std::string &getLabel() {return m_label;}
+
+    static thread_local std::string m_label;
+  };
+
+  static OpenLabelToken setLabel(const std::string &label) {return OpenLabelToken(label);}
+  static const std::string &getLabel() {return OpenLabelToken::getLabel();}
+
   typedef tbb::concurrent_unordered_map<int, Counter> OperationStats;
   typedef tbb::concurrent_unordered_map<int, OperationStats > StorageStats;
 
   static char const* operationName(Operation operation);
   static StorageClassToken tokenForStorageClassName( std::string const& iName);
-  static const std::string& nameForToken( StorageClassToken);
+  static const std::pair<std::string, std::string>& nameForToken( StorageClassToken);
   
-  static const StorageStats& summary(void);
+  static StorageStats& summary(void);
   static std::string         summaryText(bool banner=false);
   static void                fillSummary(std::map<std::string, std::string> &summary);
   static Counter&            counter (StorageClassToken token,
                                       Operation operation);
 
 private:
+  static void aggregateStatistics();
+
   static StorageStats m_stats;
 
 };

--- a/Utilities/StorageFactory/interface/StorageAccountProxy.h
+++ b/Utilities/StorageFactory/interface/StorageAccountProxy.h
@@ -19,25 +19,25 @@ class StorageAccountProxy : public Storage
 {
 public:
   StorageAccountProxy (const std::string &storageClass, std::unique_ptr<Storage> baseStorage);
-  ~StorageAccountProxy (void);
+  ~StorageAccountProxy (void) override;
 
   using Storage::read;
   using Storage::write;
 
-  virtual bool		prefetch (const IOPosBuffer *what, IOSize n);
-  virtual IOSize	read (void *into, IOSize n);
-  virtual IOSize	read (void *into, IOSize n, IOOffset pos);
-  virtual IOSize	readv (IOBuffer *into, IOSize n);
-  virtual IOSize	readv (IOPosBuffer *into, IOSize n);
-  virtual IOSize	write (const void *from, IOSize n);
-  virtual IOSize	write (const void *from, IOSize n, IOOffset pos);
-  virtual IOSize	writev (const IOBuffer *from, IOSize n);
-  virtual IOSize	writev (const IOPosBuffer *from, IOSize n);
+  bool		prefetch (const IOPosBuffer *what, IOSize n) override;
+  IOSize	read (void *into, IOSize n) override;
+  IOSize	read (void *into, IOSize n, IOOffset pos) override;
+  IOSize	readv (IOBuffer *into, IOSize n) override;
+  IOSize	readv (IOPosBuffer *into, IOSize n) override;
+  IOSize	write (const void *from, IOSize n) override;
+  IOSize	write (const void *from, IOSize n, IOOffset pos) override;
+  IOSize	writev (const IOBuffer *from, IOSize n) override;
+  IOSize	writev (const IOPosBuffer *from, IOSize n) override;
 
-  virtual IOOffset	position (IOOffset offset, Relative whence = SET);
-  virtual void		resize (IOOffset size);
-  virtual void		flush (void);
-  virtual void		close (void);
+  IOOffset	position (IOOffset offset, Relative whence = SET) override;
+  void		resize (IOOffset size) override;
+  void		flush (void) override;
+  void		close (void) override;
 
 protected:
   void releaseStorage() {get_underlying_safe(m_baseStorage).release();}

--- a/Utilities/StorageFactory/interface/StorageFactory.h
+++ b/Utilities/StorageFactory/interface/StorageFactory.h
@@ -60,7 +60,7 @@ public:
   std::unique_ptr<Storage>	open (const std::string &url,
 	    	      int mode = IOFlags::OpenRead) const;
   bool		check (const std::string &url,
-	    	       IOOffset *size = 0) const;
+	    	       IOOffset *size = nullptr) const;
 
   std::unique_ptr<Storage>	wrapNonLocalFile (std::unique_ptr<Storage> s,
 				  const std::string &proto,

--- a/Utilities/StorageFactory/interface/StorageMaker.h
+++ b/Utilities/StorageFactory/interface/StorageMaker.h
@@ -39,7 +39,7 @@ public:
   virtual bool		check (const std::string &proto,
 			       const std::string &path,
              const AuxSettings& aux,
-			       IOOffset *size = 0) const;
+			       IOOffset *size = nullptr) const;
 };
 
 #endif // STORAGE_FACTORY_STORAGE_MAKER_H

--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -56,7 +56,7 @@ StatisticsSenderService::FileStatistics::fillUDP(std::ostringstream &os) {
   ssize_t read_vector_square = 0;
   ssize_t read_vector_count_sum = 0;
   ssize_t read_vector_count_square = 0;
-  auto token = StorageAccount::tokenForStorageClassName("tstoragefile", StorageAccount::OpenLabel::None);
+  auto token = StorageAccount::tokenForStorageClassName("tstoragefile", StorageAccount::OpenLabel::Aggregate);
   for (StorageAccount::StorageStats::const_iterator i = stats.begin (); i != stats.end(); ++i) {
     if (i->first == token.value()) {
       continue;

--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -56,7 +56,7 @@ StatisticsSenderService::FileStatistics::fillUDP(std::ostringstream &os) {
   ssize_t read_vector_square = 0;
   ssize_t read_vector_count_sum = 0;
   ssize_t read_vector_count_square = 0;
-  auto token = StorageAccount::tokenForStorageClassName("tstoragefile");
+  auto token = StorageAccount::tokenForStorageClassName("tstoragefile", StorageAccount::OpenLabel::None);
   for (StorageAccount::StorageStats::const_iterator i = stats.begin (); i != stats.end(); ++i) {
     if (i->first == token.value()) {
       continue;

--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -42,7 +42,7 @@ StatisticsSenderService::FileStatistics::FileStatistics() :
   m_read_vector_square(0),
   m_read_vector_count_sum(0),
   m_read_vector_count_square(0),
-  m_start_time(time(NULL))
+  m_start_time(time(nullptr))
 {}
 
 void
@@ -106,7 +106,7 @@ StatisticsSenderService::FileStatistics::fillUDP(std::ostringstream &os) {
   UPDATE_AND_OUTPUT_STATISTIC(read_vector_bytes)
 
   os << "\"start_time\":" << m_start_time << ", ";
-  m_start_time = time(NULL);
+  m_start_time = time(nullptr);
   // NOTE: last entry doesn't have the trailing comma.
   os << "\"end_time\":" << m_start_time;
 }
@@ -179,7 +179,7 @@ StatisticsSenderService::filePreCloseEvent(std::string const& lfn, bool usedFall
   }
 
   std::set<std::string> const * info = pSLC->statisticsInfo();
-  if (info && info->size() && (m_userdn != "unknown") && (
+  if (info && !info->empty() && (m_userdn != "unknown") && (
       (info->find("dn") == info->end()) ||
       (info->find("nodn") != info->end()))
      )
@@ -293,7 +293,7 @@ static X509 * findEEC(STACK_OF(X509) * certstack) {
   char *subject = nullptr;
   X509 *x509cert = sk_X509_value(certstack, idx);
   for (; x509cert && idx>0; idx--) {
-    subject = X509_NAME_oneline(X509_get_subject_name(x509cert),0,0);
+    subject = X509_NAME_oneline(X509_get_subject_name(x509cert),nullptr,0);
     if (subject && priorsubject && (strncmp(subject, priorsubject, strlen(subject)) != 0)) {
       break;
     }
@@ -347,7 +347,7 @@ getX509SubjectFromFile(const std::string &filename, std::string &result) {
       x509cert = findEEC(certs);
     }
     if (x509cert) {
-      subject = X509_NAME_oneline(X509_get_subject_name(x509cert),0,0);
+      subject = X509_NAME_oneline(X509_get_subject_name(x509cert),nullptr,0);
     }
     // Note we do not free x509cert directly, as it's still owned by the certs stack.
     if (certs) {

--- a/Utilities/StorageFactory/src/StorageAccount.cc
+++ b/Utilities/StorageFactory/src/StorageAccount.cc
@@ -146,20 +146,21 @@ StorageAccount::summaryText (bool banner /*=false*/) {
   std::ostringstream os;
   if (banner)
     os << "stats: class/operation/attempts/successes/amount/time-total/time-min/time-max\n";
-  for (auto i = s_nameToToken.begin (); i != s_nameToToken.end(); ++i) {
-    auto const& opStats = m_stats[i->second];
-    for (auto j = opStats.begin (); j != opStats.end (); ++j, first = false) {
-      if (i->first.first != OpenLabel::Aggregate) continue;
-      if (j->second.attempts == 0) continue;
+  for (const auto &i : s_nameToToken) {
+    auto const& opStats = m_stats[i.second];
+    for (const auto &j : opStats) {
+      if (i.first.first != OpenLabel::Aggregate) continue;
+      if (j.second.attempts == 0) continue;
       os << (first ? "" : "; ")
-         << (i->first.second) << '/'
-         << kOperationNames[j->first] << '='
-         << j->second.attempts << '/'
-         << j->second.successes << '/'
-         << (static_cast<double>(j->second.amount) / 1024 / 1024) << "MB/"
-         << (static_cast<double>(j->second.timeTotal) / 1000 / 1000) << "ms/"
-         << (static_cast<double>(j->second.timeMin) / 1000 / 1000) << "ms/"
-         << (static_cast<double>(j->second.timeMax) / 1000 / 1000) << "ms";
+         << (i.first.second) << '/'
+         << kOperationNames[j.first] << '='
+         << j.second.attempts << '/'
+         << j.second.successes << '/'
+         << (static_cast<double>(j.second.amount) / 1024 / 1024) << "MB/"
+         << (static_cast<double>(j.second.timeTotal) / 1000 / 1000) << "ms/"
+         << (static_cast<double>(j.second.timeMin) / 1000 / 1000) << "ms/"
+         << (static_cast<double>(j.second.timeMax) / 1000 / 1000) << "ms";
+      first = false;
     }
   }
   return os.str ();
@@ -171,23 +172,23 @@ StorageAccount::fillSummary(std::map<std::string, std::string>& summary) {
 
   int const oneM = 1000 * 1000;
   int const oneMeg = 1024 * 1024;
-  for (auto i = s_nameToToken.begin (); i != s_nameToToken.end(); ++i) {
-    auto const& opStats = m_stats[i->second];
-    for (auto j = opStats.begin(); j != opStats.end(); ++j) {
+  for (const auto &i : s_nameToToken) {
+    auto const& opStats = m_stats[i.second];
+    for (const auto &j : opStats) {
       std::ostringstream os;
-      if (j->second.attempts == 0) continue;
-      if (i->first.first == OpenLabel::Aggregate) {
-        os << "Timing-" << i->first.second << "-" << kOperationNames[j->first] << "-";
+      if (j.second.attempts == 0) continue;
+      if (i.first.first == OpenLabel::Aggregate) {
+        os << "Timing-" << i.first.second << "-" << kOperationNames[j.first] << "-";
       } else {
-        os << "Timing-" << kLabelNames[static_cast<int>(i->first.first)]
-           << "-" << i->first.second << "-" << kOperationNames[j->first] << "-";
+        os << "Timing-" << kLabelNames[static_cast<int>(i.first.first)]
+           << "-" << i.first.second << "-" << kOperationNames[j.first] << "-";
       }
-      summary.insert(std::make_pair(os.str() + "numOperations", i2str(j->second.attempts)));
-      summary.insert(std::make_pair(os.str() + "numSuccessfulOperations", i2str(j->second.successes)));
-      summary.insert(std::make_pair(os.str() + "totalMegabytes", d2str(static_cast<double>(j->second.amount) / oneMeg)));
-      summary.insert(std::make_pair(os.str() + "totalMsecs", d2str(static_cast<double>(j->second.timeTotal) / oneM)));
-      summary.insert(std::make_pair(os.str() + "minMsecs", d2str(static_cast<double>(j->second.timeMin) / oneM)));
-      summary.insert(std::make_pair(os.str() + "maxMsecs", d2str(static_cast<double>(j->second.timeMax) / oneM)));
+      summary.insert(std::make_pair(os.str() + "numOperations", i2str(j.second.attempts)));
+      summary.insert(std::make_pair(os.str() + "numSuccessfulOperations", i2str(j.second.successes)));
+      summary.insert(std::make_pair(os.str() + "totalMegabytes", d2str(static_cast<double>(j.second.amount) / oneMeg)));
+      summary.insert(std::make_pair(os.str() + "totalMsecs", d2str(static_cast<double>(j.second.timeTotal) / oneM)));
+      summary.insert(std::make_pair(os.str() + "minMsecs", d2str(static_cast<double>(j.second.timeMin) / oneM)));
+      summary.insert(std::make_pair(os.str() + "maxMsecs", d2str(static_cast<double>(j.second.timeMax) / oneM)));
     }
   }
 }

--- a/Utilities/StorageFactory/src/StorageAccount.cc
+++ b/Utilities/StorageFactory/src/StorageAccount.cc
@@ -167,7 +167,7 @@ StorageAccount::fillSummary(std::map<std::string, std::string>& summary) {
   }
 }
 
-StorageAccount::StorageStats&
+const StorageAccount::StorageStats&
 StorageAccount::summary (void) {
   aggregateStatistics();
   return m_stats;

--- a/Utilities/StorageFactory/src/StorageAccount.cc
+++ b/Utilities/StorageFactory/src/StorageAccount.cc
@@ -72,7 +72,7 @@ const std::array<StorageAccount::Operation, 22> StorageAccount::allOperations{ {
   Operation::writev
 } };
 
-thread_local StorageAccount::OpenLabel StorageAccount::OpenLabelToken::s_label{OpenLabel::None};
+thread_local StorageAccount::OpenLabel StorageAccount::OpenLabelToken::s_label{OpenLabel::Aggregate};
 
 static std::string i2str(int i) {
   std::ostringstream t;
@@ -93,7 +93,7 @@ void StorageAccount::aggregateStatistics() {
     protocols.insert(item.first.second);
   }
   for (auto const &protocol : protocols) {
-    auto token = tokenForStorageClassName(protocol, OpenLabel::None);
+    auto token = tokenForStorageClassName(protocol, OpenLabel::Aggregate);
     OperationStats protocol_stats;
     for (auto &item : m_stats) {
       if (item.first == token.value()) {
@@ -149,7 +149,7 @@ StorageAccount::summaryText (bool banner /*=false*/) {
   for (auto i = s_nameToToken.begin (); i != s_nameToToken.end(); ++i) {
     auto const& opStats = m_stats[i->second];
     for (auto j = opStats.begin (); j != opStats.end (); ++j, first = false) {
-      if (i->first.first != OpenLabel::None) continue;
+      if (i->first.first != OpenLabel::Aggregate) continue;
       if (j->second.attempts == 0) continue;
       os << (first ? "" : "; ")
          << (i->first.second) << '/'
@@ -176,7 +176,7 @@ StorageAccount::fillSummary(std::map<std::string, std::string>& summary) {
     for (auto j = opStats.begin(); j != opStats.end(); ++j) {
       std::ostringstream os;
       if (j->second.attempts == 0) continue;
-      if (i->first.first == OpenLabel::None) {
+      if (i->first.first == OpenLabel::Aggregate) {
         os << "Timing-" << i->first.second << "-" << kOperationNames[j->first] << "-";
       } else {
         os << "Timing-" << kLabelNames[static_cast<int>(i->first.first)]

--- a/Utilities/StorageFactory/src/StorageAccount.cc
+++ b/Utilities/StorageFactory/src/StorageAccount.cc
@@ -47,7 +47,30 @@ namespace {
 
 StorageAccount::StorageStats StorageAccount::m_stats;
 
-const std::array<StorageAccount::Operation, 2> StorageAccount::allOperations{ {Operation::check, Operation::close} };
+const std::array<StorageAccount::Operation, 22> StorageAccount::allOperations{ {
+  Operation::check,
+  Operation::close,
+  Operation::construct,
+  Operation::destruct,
+  Operation::flush,
+  Operation::open,
+  Operation::position,
+  Operation::prefetch,
+  Operation::read,
+  Operation::readActual,
+  Operation::readAsync,
+  Operation::readPrefetchToCache,
+  Operation::readViaCache,
+  Operation::readv,
+  Operation::resize,
+  Operation::seek,
+  Operation::stagein,
+  Operation::stat,
+  Operation::write,
+  Operation::writeActual,
+  Operation::writeViaCache,
+  Operation::writev
+} };
 
 thread_local StorageAccount::OpenLabel StorageAccount::OpenLabelToken::s_label{OpenLabel::None};
 
@@ -127,6 +150,7 @@ StorageAccount::summaryText (bool banner /*=false*/) {
     auto const& opStats = m_stats[i->second];
     for (auto j = opStats.begin (); j != opStats.end (); ++j, first = false) {
       if (i->first.first != OpenLabel::None) continue;
+      if (j->second.attempts == 0) continue;
       os << (first ? "" : "; ")
          << (i->first.second) << '/'
          << kOperationNames[j->first] << '='
@@ -151,6 +175,7 @@ StorageAccount::fillSummary(std::map<std::string, std::string>& summary) {
     auto const& opStats = m_stats[i->second];
     for (auto j = opStats.begin(); j != opStats.end(); ++j) {
       std::ostringstream os;
+      if (j->second.attempts == 0) continue;
       if (i->first.first == OpenLabel::None) {
         os << "Timing-" << i->first.second << "-" << kOperationNames[j->first] << "-";
       } else {

--- a/Utilities/StorageFactory/src/StorageAccountProxy.cc
+++ b/Utilities/StorageFactory/src/StorageAccountProxy.cc
@@ -3,7 +3,7 @@
 StorageAccountProxy::StorageAccountProxy (const std::string &storageClass,
                                           std::unique_ptr<Storage> baseStorage)
   : m_baseStorage (std::move(baseStorage)),
-    m_token(StorageAccount::tokenForStorageClassName(storageClass)),
+    m_token(StorageAccount::tokenForStorageClassNameUsingContext(storageClass)),
     m_statsRead (StorageAccount::counter (m_token, StorageAccount::Operation::read)),
     m_statsReadV (StorageAccount::counter (m_token, StorageAccount::Operation::readv)),
     m_statsWrite (StorageAccount::counter (m_token, StorageAccount::Operation::write)),

--- a/Utilities/StorageFactory/src/StorageFactory.cc
+++ b/Utilities/StorageFactory/src/StorageFactory.cc
@@ -177,7 +177,7 @@ StorageFactory::open (const std::string &url, int mode /* = IOFlags::OpenRead */
   if (StorageMaker *maker = getMaker (url, protocol, rest))
   {
     if (m_accounting) {
-        auto token = StorageAccount::tokenForStorageClassName(protocol);
+        auto token = StorageAccount::tokenForStorageClassNameUsingContext(protocol);
         stats.reset(new StorageAccount::Stamp(StorageAccount::counter (token, StorageAccount::Operation::open)));
     }
     try
@@ -218,7 +218,7 @@ StorageFactory::stagein (const std::string &url) const
   if (StorageMaker *maker = getMaker (url, protocol, rest))
   {
     if (m_accounting) {
-      auto token = StorageAccount::tokenForStorageClassName(protocol);
+      auto token = StorageAccount::tokenForStorageClassNameUsingContext(protocol);
       stats.reset(new StorageAccount::Stamp(StorageAccount::counter (token, StorageAccount::Operation::stagein)));
     }
     try
@@ -246,7 +246,7 @@ StorageFactory::check (const std::string &url, IOOffset *size /* = 0 */) const
   if (StorageMaker *maker = getMaker (url, protocol, rest))
   {
     if (m_accounting) {
-      auto token = StorageAccount::tokenForStorageClassName(protocol);
+      auto token = StorageAccount::tokenForStorageClassNameUsingContext(protocol);
       stats.reset(new StorageAccount::Stamp(StorageAccount::counter (token, StorageAccount::Operation::check)));
     }
     try


### PR DESCRIPTION
This breaks out the FJR information (and corresponding HTCondor statistics) for the secondary source versus all sources.

The intent is to provide insight for amount of input data for PileUp-vs-Primary in various DIGI-RECO workflows.

This is a cleaned-up version of #20107; I believe I got all the review comments addressed from that PR.