### PR TITLE
PixelFed25 error propagation to tracking

### DIFF
--- a/CondFormats/SiPixelObjects/src/SiPixelFrameConverter.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFrameConverter.cc
@@ -38,7 +38,7 @@ PixelROC const * SiPixelFrameConverter::toRoc(int link, int roc) const {
     stm << "Map shows no fed="<<theFedId
         <<", link="<< link
         <<", roc="<< roc;
-    LogDebug("SiPixelFrameConverter") << stm.str();
+    edm::LogWarning("SiPixelFrameConverter") << stm.str();
   }
   return rocp;
 }

--- a/DataFormats/SiPixelDetId/interface/PixelFEDChannel.h
+++ b/DataFormats/SiPixelDetId/interface/PixelFEDChannel.h
@@ -1,0 +1,17 @@
+#ifndef SiPixelDetId_PixelFEDChannel_H
+#define SiPixelDetId_PixelFEDChannel_H
+
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+
+struct PixelFEDChannel {
+  unsigned int fed, link, roc_first, roc_last;
+};
+
+inline bool operator<( const PixelFEDChannel& one, const PixelFEDChannel& other) {
+  if (one.fed == other.fed) return one.link<other.link;
+  return one.fed < other.fed;
+}
+
+typedef edmNew::DetSetVector<PixelFEDChannel> PixelFEDChannelCollection;
+
+#endif

--- a/DataFormats/SiPixelDetId/src/classes.h
+++ b/DataFormats/SiPixelDetId/src/classes.h
@@ -2,3 +2,25 @@
 #include <boost/cstdint.hpp> 
 #include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
 
+#include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
+#include "DataFormats/Common/interface/EDCollection.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+
+namespace DataFormats_PixelFEDChannel {
+  struct dictionary {
+    std::vector<PixelFEDChannel> vFC_;
+    edm::EDCollection<PixelFEDChannel> edcFC_;
+    edmNew::DetSet<PixelFEDChannel> dsFC_;
+    std::vector<edmNew::DetSet<PixelFEDChannel> > vdsFC_;
+    edmNew::DetSetVector<PixelFEDChannel> dsvFC_;
+    PixelFEDChannelCollection FCc_;
+
+    edm::Wrapper<std::vector<PixelFEDChannel> > vFCw_;
+    edm::Wrapper<edm::EDCollection<PixelFEDChannel> > edcFCw_;
+    edm::Wrapper<edmNew::DetSet<PixelFEDChannel> > dsFCw_;
+    edm::Wrapper<std::vector<edmNew::DetSet<PixelFEDChannel> > > vdsFCw_;
+    edm::Wrapper<edmNew::DetSetVector<PixelFEDChannel> > dsvFCw_;
+    edm::Wrapper<PixelFEDChannelCollection> FCcw_;
+  };
+}

--- a/DataFormats/SiPixelDetId/src/classes_def.xml
+++ b/DataFormats/SiPixelDetId/src/classes_def.xml
@@ -7,4 +7,17 @@
    <version ClassVersion="11" checksum="1218239916"/>
    <version ClassVersion="10" checksum="64579558"/>
   </class>
+  <class name="PixelFEDChannel" ClassVersion="3">
+   <version ClassVersion="3" checksum="2591256255"/>
+  </class>
+  <class name="std::vector<PixelFEDChannel>"/>
+  <class name="edm::EDCollection<PixelFEDChannel>"/>
+  <class name="edmNew::DetSet<PixelFEDChannel>"/>
+  <class name="std::vector<edmNew::DetSet<PixelFEDChannel> >"/>
+  <class name="edmNew::DetSetVector<PixelFEDChannel>"/>
+  <class name="edm::Wrapper<std::vector<PixelFEDChannel> >"/>
+  <class name="edm::Wrapper<edm::EDCollection<PixelFEDChannel> >"/>
+  <class name="edm::Wrapper<edmNew::DetSet<PixelFEDChannel> >"/>
+  <class name="edm::Wrapper<std::vector<edmNew::DetSet<PixelFEDChannel> > >"/>
+  <class name="edm::Wrapper<edmNew::DetSetVector<PixelFEDChannel> >"/>
 </lcgdict>

--- a/DataFormats/SiPixelRawData/src/SiPixelRawDataError.cc
+++ b/DataFormats/SiPixelRawData/src/SiPixelRawDataError.cc
@@ -56,7 +56,7 @@ fedId_ = fedId;
 void SiPixelRawDataError::setMessage() {
   switch (errorType_) {
     case(25) : {
-     errorMessage_ = "Error: ROC=25";
+     errorMessage_ = "Error: Disabled FED channel (ROC=25)";
      break;
    }
    case(26) : {

--- a/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
@@ -14,6 +14,7 @@
 class FEDRawData;
 
 class SiPixelFrameConverter;
+class SiPixelFedCabling;
 
 class ErrorChecker {
 
@@ -37,6 +38,7 @@ public:
   bool checkTrailer(bool& errorsInEvent, int fedId, int nWords, const Word64* trailer, Errors& errors);
 
   bool checkROC(bool& errorsInEvent, int fedId, const SiPixelFrameConverter* converter, 
+		const SiPixelFedCabling* theCablingTree,
 		Word32& errorWord, Errors& errors);
 
 

--- a/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
+++ b/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
@@ -107,6 +107,8 @@ private:
   int maxROCIndex;
   bool phase1;
 
+  friend class SiPixelRawToDigi;
+
   int checkError(const Word32& data) const;
 
   int digi2word(  cms_uint32_t detId, const PixelDigi& digi,

--- a/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
+++ b/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
@@ -109,7 +109,6 @@ private:
   int maxROCIndex;
   bool phase1;
 
-  friend class SiPixelRawToDigi;
 
   int checkError(const Word32& data) const;
 

--- a/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
+++ b/EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h
@@ -82,6 +82,8 @@ public:
 
   void formatRawData( unsigned int lvl1_ID, RawData & fedRawData, const Digis & digis);
 
+  cms_uint32_t linkId(cms_uint32_t word32) { return (word32 >> LINK_shift) & LINK_mask; }
+
 private:
   mutable int theDigiCounter;
   mutable int theWordCounter;

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
@@ -4,6 +4,7 @@
 // enabled by: process.siPixelDigis.UseQualityInfo = True (BY DEFAULT NOT USED)
 // 20-10-2010 Andrew York (Tennessee)
 // Jan 2016 Tamas Almos Vami (Tav) (Wigner RCP) -- Cabling Map label option
+// Jul 2017 Viktor Veszpremi -- added PixelFEDChannel
 
 #include "SiPixelRawToDigi.h"
 
@@ -31,6 +32,7 @@
 
 #include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
 
+#include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
 #include "EventFilter/SiPixelRawToDigi/interface/PixelUnpackingRegions.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
@@ -67,6 +69,7 @@ SiPixelRawToDigi::SiPixelRawToDigi( const edm::ParameterSet& conf )
     produces< edm::DetSetVector<SiPixelRawDataError> >();
     produces<DetIdCollection>();
     produces<DetIdCollection>("UserErrorModules");
+    produces<edmNew::DetSetVector<PixelFEDChannel> >();
   }
 
   // regions
@@ -191,6 +194,7 @@ void SiPixelRawToDigi::produce( edm::Event& ev,
   auto errorcollection = std::make_unique<edm::DetSetVector<SiPixelRawDataError>>();
   auto tkerror_detidcollection = std::make_unique<DetIdCollection>();
   auto usererror_detidcollection = std::make_unique<DetIdCollection>();
+  auto disabled_channelcollection = std::make_unique<edmNew::DetSetVector<PixelFEDChannel> >();
 
   //PixelDataFormatter formatter(cabling_.get()); // phase 0 only
   PixelDataFormatter formatter(cabling_.get(), usePhase1); // for phase 1 & 0
@@ -241,30 +245,58 @@ void SiPixelRawToDigi::produce( edm::Event& ev,
 	  // in the configurable error list in the job option cfi.
 	  // Code needs to be here, because there can be a set of errors for each 
 	  // entry in the for loop over PixelDataFormatter::Errors
-	  if(!tkerrorlist.empty() || !usererrorlist.empty()){
-	    DetId errorDetId(errordetid);
-	    edm::DetSet<SiPixelRawDataError>::const_iterator itPixelError=errorDetSet.begin();
-            for(; itPixelError!=errorDetSet.end(); ++itPixelError){
-              // fill list of detIds to be turned off by tracking
-              if(!tkerrorlist.empty()) {
-	        std::vector<int>::iterator it_find = find(tkerrorlist.begin(), tkerrorlist.end(), itPixelError->getType());
-	        if(it_find != tkerrorlist.end()){
-		  tkerror_detidcollection->push_back(errordetid);
-	        }
+	  edm::DetSet<SiPixelRawDataError>::const_iterator itPixelError=errorDetSet.begin();
+	  std::vector<PixelFEDChannel> disabledChannelsDetSet;
+
+	  for(; itPixelError!=errorDetSet.end(); ++itPixelError){
+	    // For the time being, we extend the error handling functionality with ErrorType 25
+	    // In the future, we should sort out how the usage of tkerrorlist can be generalized
+	    if (itPixelError->getType()==25) {
+	      assert(itPixelError->getFedId()==fedId);
+	      const sipixelobjects::PixelFEDCabling* fed = cabling_->fed(fedId);
+	      if (fed) {
+		cms_uint32_t linkId = (itPixelError->getWord32() >> formatter.LINK_shift) & formatter.LINK_mask;
+		const sipixelobjects::PixelFEDLink* link = fed->link(linkId);
+		if (link) {
+		  // The "offline" 0..15 numbering is fixed by definition, also, the FrameConversion depends on it
+		  // in contrast, the ROC-in-channel numbering is determined by hardware --> better to use the "offline" scheme
+		  PixelFEDChannel ch = {fed->id(), linkId, 25, 0};
+		  for (unsigned int iRoc=1; iRoc<=link->numberOfROCs(); iRoc++) {
+		    const sipixelobjects::PixelROC * roc = link->roc(iRoc);
+		    if (roc->idInDetUnit()<ch.roc_first) ch.roc_first=roc->idInDetUnit();
+		    if (roc->idInDetUnit()>ch.roc_last) ch.roc_last=roc->idInDetUnit();
+		  }
+		  disabledChannelsDetSet.push_back(ch);
+		}
 	      }
-              // fill list of detIds with errors to be studied
-              if(!usererrorlist.empty()) {
-	        std::vector<int>::iterator it_find = find(usererrorlist.begin(), usererrorlist.end(), itPixelError->getType());
-	        if(it_find != usererrorlist.end()){
-		  usererror_detidcollection->push_back(errordetid);
-	        }
+	    } else {
+	      // fill list of detIds to be turned off by tracking
+	      if(!tkerrorlist.empty()) {
+		std::vector<int>::iterator it_find = find(tkerrorlist.begin(), tkerrorlist.end(), itPixelError->getType());
+		if(it_find != tkerrorlist.end()){
+		  tkerror_detidcollection->push_back(errordetid);
+		}
 	      }
 	    }
+
+	    // fill list of detIds with errors to be studied
+	    if(!usererrorlist.empty()) {
+	      std::vector<int>::iterator it_find = find(usererrorlist.begin(), usererrorlist.end(), itPixelError->getType());
+	      if(it_find != usererrorlist.end()){
+		usererror_detidcollection->push_back(errordetid);
+	      }
+	    }
+
+	  } // loop on DetSet of errors
+
+	  if (disabledChannelsDetSet.size()>0) {
+	    disabled_channelcollection->insert(errordetid, disabledChannelsDetSet.data(), disabledChannelsDetSet.size());
 	  }
-	}
-      }
-    }
-  }
+
+	} // if error assigned to a real DetId
+      } // loop on errors in event for this FED
+    } // if errors to be included in the event
+  } // loop on FED data to be unpacked
 
   if(includeErrors) {
     edm::DetSet<SiPixelRawDataError>& errorDetSet = errorcollection->find_or_insert(dummydetid);
@@ -289,5 +321,6 @@ void SiPixelRawToDigi::produce( edm::Event& ev,
     ev.put(std::move(errorcollection));
     ev.put(std::move(tkerror_detidcollection));
     ev.put(std::move(usererror_detidcollection), "UserErrorModules");
+    ev.put(std::move(disabled_channelcollection));
   }
 }

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
@@ -99,7 +99,7 @@ SiPixelRawToDigi::SiPixelRawToDigi( const edm::ParameterSet& conf )
   usePhase1 = false;
   if (config_.exists("UsePhase1")) {
     usePhase1 = config_.getParameter<bool> ("UsePhase1");
-    if(usePhase1) edm::LogInfo("SiPixelRawToDigi")  << " Use pilot blade data (FED 40)";
+    if(usePhase1) edm::LogInfo("SiPixelRawToDigi")  << " Using phase1";
   }
   //CablingMap could have a label //Tav
   cablingMapLabel = config_.getParameter<std::string> ("CablingMapLabel");

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
@@ -245,17 +245,17 @@ void SiPixelRawToDigi::produce( edm::Event& ev,
 	  // in the configurable error list in the job option cfi.
 	  // Code needs to be here, because there can be a set of errors for each 
 	  // entry in the for loop over PixelDataFormatter::Errors
-	  edm::DetSet<SiPixelRawDataError>::const_iterator itPixelError=errorDetSet.begin();
+
 	  std::vector<PixelFEDChannel> disabledChannelsDetSet;
 
-	  for(; itPixelError!=errorDetSet.end(); ++itPixelError){
+	  for (auto const& aPixelError : errorDetSet) {
 	    // For the time being, we extend the error handling functionality with ErrorType 25
 	    // In the future, we should sort out how the usage of tkerrorlist can be generalized
-	    if (itPixelError->getType()==25) {
-	      assert(itPixelError->getFedId()==fedId);
+	    if (aPixelError.getType()==25) {
+	      assert(aPixelError.getFedId()==fedId);
 	      const sipixelobjects::PixelFEDCabling* fed = cabling_->fed(fedId);
 	      if (fed) {
-		cms_uint32_t linkId = (itPixelError->getWord32() >> formatter.LINK_shift) & formatter.LINK_mask;
+		cms_uint32_t linkId = formatter.linkId(aPixelError.getWord32());
 		const sipixelobjects::PixelFEDLink* link = fed->link(linkId);
 		if (link) {
 		  // The "offline" 0..15 numbering is fixed by definition, also, the FrameConversion depends on it
@@ -272,7 +272,7 @@ void SiPixelRawToDigi::produce( edm::Event& ev,
 	    } else {
 	      // fill list of detIds to be turned off by tracking
 	      if(!tkerrorlist.empty()) {
-		std::vector<int>::iterator it_find = find(tkerrorlist.begin(), tkerrorlist.end(), itPixelError->getType());
+		std::vector<int>::iterator it_find = find(tkerrorlist.begin(), tkerrorlist.end(), aPixelError.getType());
 		if(it_find != tkerrorlist.end()){
 		  tkerror_detidcollection->push_back(errordetid);
 		}
@@ -281,7 +281,7 @@ void SiPixelRawToDigi::produce( edm::Event& ev,
 
 	    // fill list of detIds with errors to be studied
 	    if(!usererrorlist.empty()) {
-	      std::vector<int>::iterator it_find = find(usererrorlist.begin(), usererrorlist.end(), itPixelError->getType());
+	      std::vector<int>::iterator it_find = find(usererrorlist.begin(), usererrorlist.end(), aPixelError.getType());
 	      if(it_find != usererrorlist.end()){
 		usererror_detidcollection->push_back(errordetid);
 	      }

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.cc
@@ -44,9 +44,9 @@ using namespace std;
 // -----------------------------------------------------------------------------
 SiPixelRawToDigi::SiPixelRawToDigi( const edm::ParameterSet& conf ) 
   : config_(conf), 
-    badPixelInfo_(0),
-    regions_(0),
-    hCPU(0), hDigi(0)
+    badPixelInfo_(nullptr),
+    regions_(nullptr),
+    hCPU(nullptr), hDigi(nullptr)
 {
 
   includeErrors = config_.getParameter<bool>("IncludeErrors");
@@ -74,7 +74,7 @@ SiPixelRawToDigi::SiPixelRawToDigi( const edm::ParameterSet& conf )
 
   // regions
   if (config_.exists("Regions")) {
-    if(config_.getParameter<edm::ParameterSet>("Regions").getParameterNames().size() > 0)
+    if(!config_.getParameter<edm::ParameterSet>("Regions").getParameterNames().empty())
     {
       regions_ = new PixelUnpackingRegions(config_, consumesCollector());
     }
@@ -289,7 +289,7 @@ void SiPixelRawToDigi::produce( edm::Event& ev,
 
 	  } // loop on DetSet of errors
 
-	  if (disabledChannelsDetSet.size()>0) {
+	  if (!disabledChannelsDetSet.empty()) {
 	    disabled_channelcollection->insert(errordetid, disabledChannelsDetSet.data(), disabledChannelsDetSet.size());
 	  }
 

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
@@ -30,12 +30,12 @@ public:
   explicit SiPixelRawToDigi( const edm::ParameterSet& );
 
   /// dtor
-  virtual ~SiPixelRawToDigi();
+  ~SiPixelRawToDigi() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   /// get data, convert to digis attach againe to Event
-  virtual void produce( edm::Event&, const edm::EventSetup& ) override;
+  void produce( edm::Event&, const edm::EventSetup& ) override;
 
 private:
 

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
@@ -22,6 +22,7 @@ class SiPixelFedCabling;
 class SiPixelQuality;
 class TH1D;
 class PixelUnpackingRegions;
+class PixelDisabledFEDChannel;
 
 class SiPixelRawToDigi : public edm::stream::EDProducer<> {
 public:

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
@@ -22,7 +22,6 @@ class SiPixelFedCabling;
 class SiPixelQuality;
 class TH1D;
 class PixelUnpackingRegions;
-class PixelDisabledFEDChannel;
 
 class SiPixelRawToDigi : public edm::stream::EDProducer<> {
 public:

--- a/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
+++ b/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
@@ -183,7 +183,7 @@ void PixelDataFormatter::interpretRawData(bool& errorsInEvent, int fedId, const 
 
     if ( (nlink!=link) | (nroc!=roc) ) {  // new roc
       link = nlink; roc=nroc;
-      skipROC = likely(roc<maxROCIndex) ? false : !errorcheck.checkROC(errorsInEvent, fedId, &converter, ww, errors);
+      skipROC = likely(roc<maxROCIndex) ? false : !errorcheck.checkROC(errorsInEvent, fedId, &converter, theCablingTree, ww, errors);
       if (skipROC) continue;
       rocp = converter.toRoc(link,roc);
       if unlikely(!rocp) {

--- a/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
+++ b/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
@@ -55,7 +55,7 @@ namespace {
 }
 
 PixelDataFormatter::PixelDataFormatter( const SiPixelFedCabling* map, bool phase)
-  : theDigiCounter(0), theWordCounter(0), theCablingTree(map), badPixelInfo(0), modulesToUnpack(0), phase1(phase)
+  : theDigiCounter(0), theWordCounter(0), theCablingTree(map), badPixelInfo(nullptr), modulesToUnpack(nullptr), phase1(phase)
 {
   int s32 = sizeof(Word32);
   int s64 = sizeof(Word64);

--- a/RecoLocalTracker/Configuration/python/RecoLocalTracker_EventContent_cff.py
+++ b/RecoLocalTracker/Configuration/python/RecoLocalTracker_EventContent_cff.py
@@ -5,6 +5,7 @@ RecoLocalTrackerFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring(
     'keep DetIdedmEDCollection_siStripDigis_*_*',
     'keep DetIdedmEDCollection_siPixelDigis_*_*',
+    'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*',
     'keep *_siPixelClusters_*_*', 
     'keep *_siStripClusters_*_*',
     'keep *_clusterSummaryProducer_*_*')
@@ -14,6 +15,7 @@ RecoLocalTrackerRECO = cms.PSet(
     outputCommands = cms.untracked.vstring(
     'keep DetIdedmEDCollection_siStripDigis_*_*',
     'keep DetIdedmEDCollection_siPixelDigis_*_*',
+    'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*',
     'keep *_siPixelClusters_*_*', 
     'keep *_siStripClusters_*_*',
     'keep ClusterSummary_clusterSummaryProducer_*_*')

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.cc
@@ -128,19 +128,19 @@ MeasurementTrackerEventProducer::updatePixels( const edm::Event& event, PxMeasur
       for (const auto& disabledChannels: *pixelFEDChannelCollectionHandle) {	
 	PxMeasurementDetSet::BadFEDChannelPositions positions;
 	for(const auto& ch: disabledChannels) {
-	  const sipixelobjects::PixelROC *roc_first=NULL, *roc_last=NULL;
+	  const sipixelobjects::PixelROC *roc_first=nullptr, *roc_last=nullptr;
 	  sipixelobjects::CablingPathToDetUnit path = {ch.fed, ch.link, 0};
 	  // PixelFEDChannelCollection addresses the ROCs by their 'idInDetUnit' (from 0 to 15), ROCs also know their on 'idInDetUnit',
 	  // however the cabling map uses a numbering [1,numberOfROCs], see sipixelobjects::PixelFEDLink::roc(unsigned int id), not necessarily sorted in the same direction.
 	  // PixelFEDChannelCollection MUST be filled such that ch.roc_first (ch.roc_last) correspond to the lowest (highest) 'idInDetUnit' in the channel
 	  for (path.roc=1; path.roc<=(ch.roc_last-ch.roc_first)+1; path.roc++) {
 	    const sipixelobjects::PixelROC *roc = cablingMap->findItem(path);
-	    if (roc==NULL) continue;
+	    if (roc==nullptr) continue;
 	    assert(roc->rawId()==disabledChannels.detId());
 	    if (roc->idInDetUnit()==ch.roc_first) roc_first=roc;
 	    if (roc->idInDetUnit()==ch.roc_last) roc_last=roc;
 	  }
-	  if (roc_first==NULL || roc_last==NULL) { 
+	  if (roc_first==nullptr || roc_last==nullptr) { 
 	    edm::LogError("PixelFEDChannelCollection")<<"Do not find either roc_first or roc_last in the cabling map."; 
 	    continue; 
 	  }
@@ -155,7 +155,7 @@ MeasurementTrackerEventProducer::updatePixels( const edm::Event& event, PxMeasur
 	  LocalPoint ur(std::max(lp1.x(), lp2.x()), std::max(lp1.y(), lp2.y()), std::max(lp1.z(), lp2.z()));	  
 	  positions.push_back(std::make_pair(ll, ur));
 	} // loop on channels
-	if (positions.size()) {
+	if (!positions.empty()) {
 	  i=thePxDets.find(disabledChannels.detId(),i);
 	  assert(i!=thePxDets.size() && thePxDets.id(i)==disabledChannels.detId());
 	  thePxDets.addBadFEDChannelPositions(i, positions);

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.h
@@ -10,6 +10,8 @@
 #include "RecoTracker/MeasurementDet/src/TkMeasurementDetSet.h"
 #include "DataFormats/Common/interface/ContainerMask.h"
 #include "DataFormats/DetId/interface/DetIdCollection.h"
+#include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
 
 class dso_hidden MeasurementTrackerEventProducer final : public edm::stream::EDProducer<> {
 public:
@@ -19,7 +21,8 @@ private:
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
 protected:
-      void updatePixels( const edm::Event&, PxMeasurementDetSet & thePxDets, std::vector<bool> & pixelClustersToSkip ) const;
+      void updatePixels( const edm::Event&, PxMeasurementDetSet & thePxDets, std::vector<bool> & pixelClustersToSkip, 
+			 const TrackerGeometry& trackerGeom, const SiPixelFedCablingMap& cablingMap) const;
       void updateStrips( const edm::Event&, StMeasurementDetSet & theStDets, std::vector<bool> & stripClustersToSkip ) const;
       void updatePhase2OT( const edm::Event&, Phase2OTMeasurementDetSet & thePh2OTDets ) const;
       //FIXME:: going to be updated soon
@@ -36,6 +39,8 @@ protected:
       edm::EDGetTokenT<edm::ContainerMask<edmNew::DetSetVector<SiStripCluster>>> theStripClusterMask;
 
       std::vector<edm::EDGetTokenT<DetIdCollection>>      theInactivePixelDetectorLabels;
+      std::vector<edm::EDGetTokenT<PixelFEDChannelCollection> > theBadPixelFEDChannelsLabels;
+      std::string pixelCablingMapLabel_;
       std::vector<edm::EDGetTokenT<DetIdCollection>>      theInactiveStripDetectorLabels;
 
       bool selfUpdateSkipClusters_;

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.h
@@ -22,7 +22,7 @@ private:
 
 protected:
       void updatePixels( const edm::Event&, PxMeasurementDetSet & thePxDets, std::vector<bool> & pixelClustersToSkip, 
-			 const TrackerGeometry& trackerGeom, const SiPixelFedCablingMap& cablingMap) const;
+			 const TrackerGeometry& trackerGeom, const edm::EventSetup& iSetup) const;
       void updateStrips( const edm::Event&, StMeasurementDetSet & theStDets, std::vector<bool> & stripClustersToSkip ) const;
       void updatePhase2OT( const edm::Event&, Phase2OTMeasurementDetSet & thePh2OTDets ) const;
       //FIXME:: going to be updated soon

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.h
@@ -16,9 +16,9 @@
 class dso_hidden MeasurementTrackerEventProducer final : public edm::stream::EDProducer<> {
 public:
       explicit MeasurementTrackerEventProducer(const edm::ParameterSet &iConfig) ;
-      ~MeasurementTrackerEventProducer() {}
+      ~MeasurementTrackerEventProducer() override {}
 private:
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
 
 protected:
       void updatePixels( const edm::Event&, PxMeasurementDetSet & thePxDets, std::vector<bool> & pixelClustersToSkip, 

--- a/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
@@ -151,7 +151,9 @@ TkPixelMeasurementDet::compHits( const TrajectoryStateOnSurface& ts, const Measu
 
 bool
 TkPixelMeasurementDet::hasBadComponents( const TrajectoryStateOnSurface &tsos, const MeasurementTrackerEvent & data ) const {
-    if (badRocPositions_.empty()) return false;
+  auto badFEDChannelPositions=getBadFEDChannelPositions(data);
+  if (badRocPositions_.empty() && badFEDChannelPositions==NULL) return false;
+
     auto lp = tsos.localPosition();
     auto le = tsos.localError().positionError();
     for (auto const & broc : badRocPositions_) {
@@ -160,5 +162,17 @@ TkPixelMeasurementDet::hasBadComponents( const TrajectoryStateOnSurface &tsos, c
       if ( (dx<=0.f) & (dy<=0.f) ) return true;
       if ( (dx*dx < 9.f*le.xx()) && (dy*dy< 9.f*le.yy()) ) return true;
     }
+
+  if (badFEDChannelPositions==NULL) return false;
+  float dx = 3.*std::sqrt(le.xx()) + theRocWidth, dy = 3.*std::sqrt(le.yy()) + theRocHeight;
+  for (auto p : *badFEDChannelPositions) {
+    if ( lp.x() > (p.first.x()-dx) &&
+	 lp.x() < (p.second.x()+dx) &&
+	 lp.y() > (p.first.y()-dy) &&
+	 lp.y() < (p.second.y()+dy) ) {
+      return true;
+    }
+  }
+
     return false;
 }

--- a/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
@@ -20,7 +20,7 @@ TkPixelMeasurementDet::TkPixelMeasurementDet( const GeomDet* gdet,
     MeasurementDet (gdet),
     theDetConditions(&conditions)
   {
-    if ( dynamic_cast<const PixelGeomDetUnit*>(gdet) == 0) {
+    if ( dynamic_cast<const PixelGeomDetUnit*>(gdet) == nullptr) {
       throw MeasurementDetException( "TkPixelMeasurementDet constructed with a GeomDet which is not a PixelGeomDetUnit");
     }
   }
@@ -96,8 +96,8 @@ TkPixelMeasurementDet::compHits( const TrajectoryStateOnSurface& ts, const Measu
   RecHitContainer result;
   if (isEmpty(data.pixelData())== true ) return result;
   if (isActive(data) == false) return result;
-  const SiPixelCluster* begin=0;
-  if (0 != data.pixelData().handle()->data().size()) {
+  const SiPixelCluster* begin=nullptr;
+  if (!data.pixelData().handle()->data().empty()) {
      begin = &(data.pixelData().handle()->data().front());
   }
   const detset & detSet = data.pixelData().detSet(index());
@@ -163,7 +163,7 @@ TkPixelMeasurementDet::hasBadComponents( const TrajectoryStateOnSurface &tsos, c
       if ( (dx*dx < 9.f*le.xx()) && (dy*dy< 9.f*le.yy()) ) return true;
     }
 
-  if (badFEDChannelPositions==NULL) return false;
+  if (badFEDChannelPositions==nullptr) return false;
   float dx = 3.f*std::sqrt(le.xx()) + theRocWidth, dy = 3.f*std::sqrt(le.yy()) + theRocHeight;
   for (auto const& p : *badFEDChannelPositions) {
     if ( lp.x() > (p.first.x()-dx) &&

--- a/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
@@ -152,7 +152,7 @@ TkPixelMeasurementDet::compHits( const TrajectoryStateOnSurface& ts, const Measu
 bool
 TkPixelMeasurementDet::hasBadComponents( const TrajectoryStateOnSurface &tsos, const MeasurementTrackerEvent & data ) const {
   auto badFEDChannelPositions=getBadFEDChannelPositions(data);
-  if (badRocPositions_.empty() && badFEDChannelPositions==NULL) return false;
+  if (badRocPositions_.empty() && badFEDChannelPositions==nullptr) return false;
 
     auto lp = tsos.localPosition();
     auto le = tsos.localError().positionError();
@@ -164,8 +164,8 @@ TkPixelMeasurementDet::hasBadComponents( const TrajectoryStateOnSurface &tsos, c
     }
 
   if (badFEDChannelPositions==NULL) return false;
-  float dx = 3.*std::sqrt(le.xx()) + theRocWidth, dy = 3.*std::sqrt(le.yy()) + theRocHeight;
-  for (auto p : *badFEDChannelPositions) {
+  float dx = 3.f*std::sqrt(le.xx()) + theRocWidth, dy = 3.f*std::sqrt(le.yy()) + theRocHeight;
+  for (auto const& p : *badFEDChannelPositions) {
     if ( lp.x() > (p.first.x()-dx) &&
 	 lp.x() < (p.second.x()+dx) &&
 	 lp.y() > (p.first.y()-dy) &&

--- a/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.h
@@ -78,6 +78,10 @@ public:
   /** \brief Clear the list of bad ROCs */
   void clearBadRocPositions() { badRocPositions_.clear(); }
 
+  const PxMeasurementDetSet::BadFEDChannelPositions* getBadFEDChannelPositions(const MeasurementTrackerEvent & data) const {
+    return data.pixelData().getBadFEDChannelPositions(index());
+  }
+
   int index() const { return index_; }
   void setIndex(int i) { index_ = i; }
 

--- a/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.h
@@ -34,10 +34,10 @@ public:
   void setEmpty(PxMeasurementDetSet & data) { data.setEmpty(index());  }
   bool isEmpty(const PxMeasurementDetSet & data) const {return data.empty(index());}
 
-  virtual ~TkPixelMeasurementDet() { }
+  ~TkPixelMeasurementDet() override { }
 
   // all hits
-  virtual RecHitContainer recHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & dat) const override;
+  RecHitContainer recHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & dat) const override;
 
   // only hits compatible with tsos 
   RecHitContainer compHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & dat, float xl, float yl ) const;
@@ -45,16 +45,16 @@ public:
 
 
  // simple hits
-  virtual bool recHits(SimpleHitContainer & result,  
-		       const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator&, const MeasurementTrackerEvent & data) const {
+  bool recHits(SimpleHitContainer & result,  
+		       const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator&, const MeasurementTrackerEvent & data) const override {
     assert("not implemented for Pixel yet"==nullptr);
   }
 
  
 
-  virtual bool measurements( const TrajectoryStateOnSurface& stateOnThisDet,
+  bool measurements( const TrajectoryStateOnSurface& stateOnThisDet,
 			    const MeasurementEstimator& est, const MeasurementTrackerEvent & dat,
-			    TempMeasurements & result) const;
+			    TempMeasurements & result) const override;
 
 
   const PixelGeomDetUnit& specificGeomDet() const {return static_cast<PixelGeomDetUnit const &>(fastGeomDet());}
@@ -69,9 +69,9 @@ public:
              This per-event flag is cleared by any call to 'update' or 'setEmpty'  */
   void setActiveThisEvent(PxMeasurementDetSet & data, bool active) const { data.setActiveThisEvent(index(), active); }
   /** \brief Is this module active in reconstruction? It must be both 'setActiveThisEvent' and 'setActive'. */
-  bool isActive(const MeasurementTrackerEvent & data) const { return data.pixelData().isActive(index()); }
+  bool isActive(const MeasurementTrackerEvent & data) const override { return data.pixelData().isActive(index()); }
 
-  bool hasBadComponents( const TrajectoryStateOnSurface &tsos, const MeasurementTrackerEvent & dat ) const ; 
+  bool hasBadComponents( const TrajectoryStateOnSurface &tsos, const MeasurementTrackerEvent & dat ) const override ; 
 
   /** \brief Sets the list of bad ROCs, identified by the positions of their centers in the local coordinate frame*/
   void setBadRocPositions(std::vector< LocalPoint > & positions) { badRocPositions_.swap(positions); }

--- a/RecoTracker/MeasurementDet/python/MeasurementTrackerEventProducer_cfi.py
+++ b/RecoTracker/MeasurementDet/python/MeasurementTrackerEventProducer_cfi.py
@@ -10,6 +10,8 @@ MeasurementTrackerEvent = cms.EDProducer("MeasurementTrackerEventProducer",
 
     # One or more DetIdCollections of modules to mask on the fly for a given event
     inactivePixelDetectorLabels = cms.VInputTag(cms.InputTag('siPixelDigis')),
+    badPixelFEDChannelCollectionLabels = cms.VInputTag(cms.InputTag('siPixelDigis')),
+    pixelCablingMapLabel = cms.string(''),
     inactiveStripDetectorLabels = cms.VInputTag(cms.InputTag('siStripDigis')),
     switchOffPixelsIfEmpty = cms.bool(True), # let's keep it like this, for cosmics                                    
 )

--- a/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.h
+++ b/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.h
@@ -337,12 +337,14 @@ class PxMeasurementDetSet {
 public:
   typedef edm::Ref<edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster> SiPixelClusterRef;
   typedef edmNew::DetSet<SiPixelCluster> PixelDetSet;
+  typedef std::vector<std::pair<LocalPoint,LocalPoint> > BadFEDChannelPositions;
 
   PxMeasurementDetSet(const PxMeasurementConditionSet &cond) : 
     conditionSet_(&cond),
     detSet_(cond.nDet()),
     empty_(cond.nDet(), true),
-    activeThisEvent_(cond.nDet(), true)  {}
+    activeThisEvent_(cond.nDet(), true),
+    badFEDChannelPositionsSet_(cond.nDet()) {}
 
   const PxMeasurementConditionSet & conditions() const { return *conditionSet_; } 
 
@@ -361,16 +363,27 @@ public:
   bool empty(int i) const { return empty_[i];}  
   bool isActive(int i) const { return activeThisEvent_[i] && conditions().isActiveThisPeriod(i); }
 
-  void setEmpty(int i) {empty_[i] = true; activeThisEvent_[i] = true; }
+  void setEmpty(int i) {empty_[i] = true; activeThisEvent_[i] = true; badFEDChannelPositionsSet_[i].reset(); }
   
   void setEmpty() {
     std::fill(empty_.begin(),empty_.end(),true);
     std::fill(activeThisEvent_.begin(), activeThisEvent_.end(),true);
+    std::fill(badFEDChannelPositionsSet_.begin(), badFEDChannelPositionsSet_.end(), nullptr);
   }
   void setActiveThisEvent(bool active) {
     std::fill(activeThisEvent_.begin(), activeThisEvent_.end(),active);
   }
   
+  const BadFEDChannelPositions* getBadFEDChannelPositions(int i) const { return badFEDChannelPositionsSet_[i].get(); }
+  void addBadFEDChannelPositions(int i, BadFEDChannelPositions& positions) { 
+    if (badFEDChannelPositionsSet_[i]==nullptr) {
+      badFEDChannelPositionsSet_[i]=std::make_unique<BadFEDChannelPositions>(positions);
+      return;
+    }
+    badFEDChannelPositionsSet_[i]->insert(badFEDChannelPositionsSet_[i]->end(), positions.begin(), positions.end());
+  }
+  void clearBadFEDChannelPositions() { badFEDChannelPositionsSet_.clear(); }
+
   /** \brief Turn on/off the module for reconstruction for one events.
       This per-event flag is cleared by any call to 'update' or 'setEmpty'  */
   void setActiveThisEvent(int i, bool active) { activeThisEvent_[i] = active;  if (!active) empty_[i] = true; }
@@ -389,6 +402,7 @@ private:
   std::vector<PixelDetSet> detSet_;
   std::vector<bool> empty_;
   std::vector<bool> activeThisEvent_;
+  std::vector<std::unique_ptr<BadFEDChannelPositions> > badFEDChannelPositionsSet_;
 };
 
 //FIXME:just temporary solution for phase2 OT that works!

--- a/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.h
+++ b/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.h
@@ -382,7 +382,6 @@ public:
     }
     badFEDChannelPositionsSet_[i]->insert(badFEDChannelPositionsSet_[i]->end(), positions.begin(), positions.end());
   }
-  void clearBadFEDChannelPositions() { badFEDChannelPositionsSet_.clear(); }
 
   /** \brief Turn on/off the module for reconstruction for one events.
       This per-event flag is cleared by any call to 'update' or 'setEmpty'  */


### PR DESCRIPTION
Following changes are explained in the commits and in this presentation where validation plots also shown: https://indico.cern.ch/event/658331/#48-inactive-pixel-roc-propagat
