### PR TITLE
make MonitorElement::getTH...() methods return a smart pointer that locks around all method invocations

### DIFF
--- a/DQMServices/Core/interface/MonitorElement.h
+++ b/DQMServices/Core/interface/MonitorElement.h
@@ -25,13 +25,15 @@
 # include <stdint.h>
 
 #include <mutex>
-#include "locking_ptr.h"
 
 # ifndef DQM_ROOT_METHODS
 #  define DQM_ROOT_METHODS 1
 # endif
 
 class QCriterion;
+
+template <typename T>
+class locking_ptr;
 
 // tag for a special constructor, see below
 struct MonitorElementNoCloneTag {};
@@ -68,6 +70,8 @@ public:
 
   typedef std::vector<QReport>::const_iterator QReportIterator;
 
+  typedef std::recursive_mutex  LockType;
+
 private:
   DQMNet::CoreObject    data_;       //< Core object information.
   Scalar                scalar_;     //< Current scalar value.
@@ -77,7 +81,7 @@ private:
   std::vector<QReport>  qreports_;   //< QReports associated to this object.
 
   mutable
-  std::recursive_mutex  mutex_;      //< Avoid concurrent access to the underlying ROOT objects.
+  LockType              mutex_;      //< Avoid concurrent access to the underlying ROOT objects.
 
   MonitorElement *initialise(Kind kind);
   MonitorElement *initialise(Kind kind, TH1 *rootobj);
@@ -399,5 +403,7 @@ public:
   const uint32_t streamId(void) const {return data_.streamId;}
   const uint32_t moduleId(void) const {return data_.moduleId;}
 };
+
+#include "locking_ptr.h"
 
 #endif // DQMSERVICES_CORE_MONITOR_ELEMENT_H

--- a/DQMServices/Core/interface/MonitorElement.h
+++ b/DQMServices/Core/interface/MonitorElement.h
@@ -1,5 +1,5 @@
 #ifndef DQMSERVICES_CORE_MONITOR_ELEMENT_H
-# define DQMSERVICES_CORE_MONITOR_ELEMENT_H
+#define DQMSERVICES_CORE_MONITOR_ELEMENT_H
 
 # include "DQMServices/Core/interface/DQMNet.h"
 # include "DQMServices/Core/interface/QReport.h"
@@ -23,6 +23,9 @@
 # include <iomanip>
 # include <cassert>
 # include <stdint.h>
+
+#include <mutex>
+#include "locking_ptr.h"
 
 # ifndef DQM_ROOT_METHODS
 #  define DQM_ROOT_METHODS 1
@@ -72,6 +75,9 @@ private:
   TH1                   *reference_; //< Current ROOT reference object.
   TH1                   *refvalue_;  //< Soft reference if any.
   std::vector<QReport>  qreports_;   //< QReports associated to this object.
+
+  mutable
+  std::recursive_mutex  mutex_;      //< Avoid concurrent access to the underlying ROOT objects.
 
   MonitorElement *initialise(Kind kind);
   MonitorElement *initialise(Kind kind, TH1 *rootobj);
@@ -335,17 +341,17 @@ private:
   void updateQReportStats(void);
 
 public:
-  TObject *getRootObject(void) const;
-  TH1 *getTH1(void) const;
-  TH1F *getTH1F(void) const;
-  TH1S *getTH1S(void) const;
-  TH1D *getTH1D(void) const;
-  TH2F *getTH2F(void) const;
-  TH2S *getTH2S(void) const;
-  TH2D *getTH2D(void) const;
-  TH3F *getTH3F(void) const;
-  TProfile *getTProfile(void) const;
-  TProfile2D *getTProfile2D(void) const;
+  locking_ptr<TObject> getRootObject(void) const;
+  locking_ptr<TH1> getTH1(void) const;
+  locking_ptr<TH1F> getTH1F(void) const;
+  locking_ptr<TH1S> getTH1S(void) const;
+  locking_ptr<TH1D> getTH1D(void) const;
+  locking_ptr<TH2F> getTH2F(void) const;
+  locking_ptr<TH2S> getTH2S(void) const;
+  locking_ptr<TH2D> getTH2D(void) const;
+  locking_ptr<TH3F> getTH3F(void) const;
+  locking_ptr<TProfile> getTProfile(void) const;
+  locking_ptr<TProfile2D> getTProfile2D(void) const;
 
   TObject *getRefRootObject(void) const;
   TH1 *getRefTH1(void) const;

--- a/DQMServices/Core/interface/QTest.h
+++ b/DQMServices/Core/interface/QTest.h
@@ -366,7 +366,7 @@ public:
 protected:
   /// get average for bin under consideration
   /// (see description of method setNumNeighbors)
-  double getAverage(int bin, const TH1 *h) const;
+  double getAverage(int bin, locking_ptr<TH1> const& h) const;
 
   float tolerance_;        /*< tolerance for considering a channel noisy */
   unsigned numNeighbors_;  /*< # of neighboring channels for calculating average to be used

--- a/DQMServices/Core/interface/locking_ptr.h
+++ b/DQMServices/Core/interface/locking_ptr.h
@@ -1,0 +1,136 @@
+#ifndef locking_ptr_h
+#define locking_ptr_h
+
+#include <memory>
+
+namespace detail {
+
+  class lock_base
+  {
+  public:
+    lock_base() = default;
+    virtual ~lock_base() = default;
+
+    virtual void lock() const = 0;
+    virtual void unlock() const = 0;
+  };
+
+  template <typename L>
+  class lock_impl : public lock_base
+  {
+  public:
+    lock_impl<L>(L & lock) :
+      lock_(lock)
+    { }
+
+    void lock() const final
+    {
+      lock_.lock();
+    }
+
+    void unlock() const final
+    {
+      lock_.unlock();
+    }
+
+  private:
+    L & lock_;
+  };
+
+
+  template <typename T>
+  class locking_ptr_impl
+  {
+  public:
+    locking_ptr_impl<T>(T * object, lock_base * lock) :
+      object_(object),
+      lock_(lock)
+    {
+      lock_->lock();
+    }
+
+    ~locking_ptr_impl<T>()
+    {
+      lock_->unlock();
+    }
+
+    T * operator->() {
+      return object_;
+    }
+
+    const T * operator->() const {
+      return object_;
+    }
+
+  protected:
+    T * object_;
+    lock_base * lock_;
+  };
+
+} // detail
+
+template <typename T>
+class locking_ptr
+{
+public:
+  locking_ptr<T>() :
+    object_(nullptr),
+    lock_()
+  { }
+
+  template <typename L>
+  locking_ptr<T>(T * object, L & lock) :
+    object_(object),
+    lock_(std::make_shared<detail::lock_impl<L>>(lock))
+  { }
+
+  locking_ptr<T>(locking_ptr<T> const& other) :
+    object_(other.object_),
+    lock_(other.lock_)
+  { }
+
+  template <typename U>
+  locking_ptr<T>(locking_ptr<U> const& other) :
+    object_(other.object_),
+    lock_(other.lock_)
+  { }
+
+  ~locking_ptr<T>()
+  { }
+
+  detail::locking_ptr_impl<T> operator->() {
+    return detail::locking_ptr_impl<T>(object_, lock_.get());
+  }
+
+  detail::locking_ptr_impl<const T> operator->() const {
+    return detail::locking_ptr_impl<const T>(object_, lock_.get());
+  }
+
+  explicit operator bool() const noexcept {
+    return (object_ != nullptr);
+  }
+
+protected:
+  T * object_;
+  std::shared_ptr<detail::lock_base> lock_;
+
+private:
+  template <typename U>
+  friend class locking_ptr;
+};
+
+
+template <typename T, typename L>
+locking_ptr<T> make_locking(T * object, L & lock)
+{
+  return locking_ptr<T>(object, lock);
+}
+
+template <typename T, typename L>
+const locking_ptr<const T> make_locking(const T * object, L & lock)
+{
+  return locking_ptr<const T>(object, lock);
+}
+
+
+#endif // ! locking_ptr_h

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -405,14 +405,14 @@ void DQMStore::mergeAndResetMEsRunSummaryCache(uint32_t run,
 	{
 	  if(me->getTH1()->CanExtendAllAxes() && i->getTH1()->CanExtendAllAxes()) {
 	    TList list;
-	    list.Add(i->getTH1());
+	    list.Add(i->getTH1().operator->().operator->());
 	    if( -1 == me->getTH1()->Merge(&list)) {
 	      std::cout << "mergeAndResetMEsRunSummaryCache: Failed to merge DQM element "<<me->getFullname();
 	    }
 	  }
 	  else {
             if (i->getTH1()->GetEntries())
-	      me->getTH1()->Add(i->getTH1());
+	      me->getTH1()->Add(i->getTH1().operator->().operator->());
           }
 	}
     } else {
@@ -475,14 +475,14 @@ void DQMStore::mergeAndResetMEsLuminositySummaryCache(uint32_t run,
 	{
 	  if(me->getTH1()->CanExtendAllAxes() && i->getTH1()->CanExtendAllAxes()) {
 	    TList list;
-	    list.Add(i->getTH1());
+	    list.Add(i->getTH1().operator->().operator->());
 	    if( -1 == me->getTH1()->Merge(&list)) {
 	      std::cout << "mergeAndResetMEsLuminositySummaryCache: Failed to merge DQM element "<<me->getFullname();
 	    }
 	  }
 	  else {
             if (i->getTH1()->GetEntries())
-	      me->getTH1()->Add(i->getTH1());
+	      me->getTH1()->Add(i->getTH1().operator->().operator->());
           }
 	}
     } else {
@@ -1652,8 +1652,8 @@ DQMStore::collateProfile(MonitorElement *me, TProfile *h, unsigned verbose)
 {
   if (checkBinningMatches(me,h,verbose))
   {
-    TProfile *meh = me->getTProfile();
-    me->addProfiles(h, meh, meh, 1, 1);
+    auto meh = me->getTProfile();
+    me->addProfiles(h, meh.operator->().operator->(), meh.operator->().operator->(), 1, 1);
   }
 }
 
@@ -1662,8 +1662,8 @@ DQMStore::collateProfile2D(MonitorElement *me, TProfile2D *h, unsigned verbose)
 {
   if (checkBinningMatches(me,h,verbose))
   {
-    TProfile2D *meh = me->getTProfile2D();
-    me->addProfiles(h, meh, meh, 1, 1);
+    auto meh = me->getTProfile2D();
+    me->addProfiles(h, meh.operator->().operator->(), meh.operator->().operator->(), 1, 1);
   }
 }
 

--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -201,8 +201,9 @@ MonitorElement::MonitorElement(const MonitorElement &x, MonitorElementNoCloneTag
 MonitorElement::MonitorElement(const MonitorElement &x)
   : MonitorElement::MonitorElement(x, MonitorElementNoCloneTag())
 {
-  std::lock_guard<std::recursive_mutex> lock1(mutex_);
-  std::lock_guard<std::recursive_mutex> lock2(x.mutex_);
+  std::lock(mutex_, x.mutex_);
+  std::lock_guard<std::recursive_mutex> lock1(mutex_, std::adopt_lock);
+  std::lock_guard<std::recursive_mutex> lock2(x.mutex_, std::adopt_lock);
 
   if (x.object_)
     object_ = static_cast<TH1 *>(x.object_->Clone());
@@ -211,17 +212,18 @@ MonitorElement::MonitorElement(const MonitorElement &x)
     refvalue_ = static_cast<TH1 *>(x.refvalue_->Clone());
 }
 
-MonitorElement::MonitorElement(MonitorElement &&o)
-  : MonitorElement::MonitorElement(o, MonitorElementNoCloneTag())
+MonitorElement::MonitorElement(MonitorElement &&x)
+  : MonitorElement::MonitorElement(x, MonitorElementNoCloneTag())
 {
-  std::lock_guard<std::recursive_mutex> lock1(mutex_);
-  std::lock_guard<std::recursive_mutex> lock2(o.mutex_);
+  std::lock(mutex_, x.mutex_);
+  std::lock_guard<std::recursive_mutex> lock1(mutex_, std::adopt_lock);
+  std::lock_guard<std::recursive_mutex> lock2(x.mutex_, std::adopt_lock);
 
-  object_ = o.object_;
-  refvalue_ = o.refvalue_;
+  object_ = x.object_;
+  refvalue_ = x.refvalue_;
 
-  o.object_ = nullptr;
-  o.refvalue_ = nullptr;
+  x.object_ = nullptr;
+  x.refvalue_ = nullptr;
 }
 
 MonitorElement::~MonitorElement(void)

--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -68,7 +68,7 @@ MonitorElement *
 MonitorElement::initialise(Kind kind, TH1 *rootobj)
 {
   initialise(kind);
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  std::lock_guard<LockType> lock(mutex_);
   switch (kind)
   {
   case DQM_KIND_TH1F:
@@ -202,8 +202,8 @@ MonitorElement::MonitorElement(const MonitorElement &x)
   : MonitorElement::MonitorElement(x, MonitorElementNoCloneTag())
 {
   std::lock(mutex_, x.mutex_);
-  std::lock_guard<std::recursive_mutex> lock1(mutex_, std::adopt_lock);
-  std::lock_guard<std::recursive_mutex> lock2(x.mutex_, std::adopt_lock);
+  std::lock_guard<LockType> lock1(mutex_, std::adopt_lock);
+  std::lock_guard<LockType> lock2(x.mutex_, std::adopt_lock);
 
   if (x.object_)
     object_ = static_cast<TH1 *>(x.object_->Clone());
@@ -216,8 +216,8 @@ MonitorElement::MonitorElement(MonitorElement &&x)
   : MonitorElement::MonitorElement(x, MonitorElementNoCloneTag())
 {
   std::lock(mutex_, x.mutex_);
-  std::lock_guard<std::recursive_mutex> lock1(mutex_, std::adopt_lock);
-  std::lock_guard<std::recursive_mutex> lock2(x.mutex_, std::adopt_lock);
+  std::lock_guard<LockType> lock1(mutex_, std::adopt_lock);
+  std::lock_guard<LockType> lock2(x.mutex_, std::adopt_lock);
 
   object_ = x.object_;
   refvalue_ = x.refvalue_;
@@ -240,7 +240,7 @@ MonitorElement::CheckBinLabels(const TAxis* a1, const TAxis * a2)
   // check that axis have same labels
   THashList *l1 = (const_cast<TAxis*>(a1))->GetLabels();
   THashList *l2 = (const_cast<TAxis*>(a2))->GetLabels();
-  
+
   if (!l1 && !l2 )
     return true;
   if (!l1 ||  !l2 ) {
@@ -275,7 +275,7 @@ MonitorElement::Fill(std::string &value)
 void
 MonitorElement::Fill(double x)
 {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  std::lock_guard<LockType> lock(mutex_);
   update();
   if (kind() == DQM_KIND_INT)
     scalar_.num = static_cast<int64_t>(x);
@@ -298,7 +298,7 @@ MonitorElement::Fill(double x)
 void
 MonitorElement::doFill(int64_t x)
 {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  std::lock_guard<LockType> lock(mutex_);
   update();
   if (kind() == DQM_KIND_INT)
     scalar_.num = static_cast<int64_t>(x);
@@ -321,7 +321,7 @@ MonitorElement::doFill(int64_t x)
 void
 MonitorElement::Fill(double x, double yw)
 {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  std::lock_guard<LockType> lock(mutex_);
   update();
   if (kind() == DQM_KIND_TH1F)
     accessRootObject(__PRETTY_FUNCTION__, 1)
@@ -354,7 +354,7 @@ MonitorElement::Fill(double x, double yw)
 void
 MonitorElement::ShiftFillLast(double y, double ye, int xscale)
 {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  std::lock_guard<LockType> lock(mutex_);
   update();
   if (kind() == DQM_KIND_TH1F
       || kind() == DQM_KIND_TH1S
@@ -1035,7 +1035,7 @@ MonitorElement::getAxis(const char *func, int axis) const
 void
 MonitorElement::softReset(void)
 {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  std::lock_guard<LockType> lock(mutex_);
   update();
 
   // Create the reference object the first time this is called.
@@ -1176,7 +1176,7 @@ MonitorElement::softReset(void)
 void
 MonitorElement::disableSoftReset(void)
 {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  std::lock_guard<LockType> lock(mutex_);
 
   if (refvalue_)
   {

--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -201,9 +201,7 @@ MonitorElement::MonitorElement(const MonitorElement &x, MonitorElementNoCloneTag
 MonitorElement::MonitorElement(const MonitorElement &x)
   : MonitorElement::MonitorElement(x, MonitorElementNoCloneTag())
 {
-  std::lock(mutex_, x.mutex_);
-  std::lock_guard<LockType> lock1(mutex_, std::adopt_lock);
-  std::lock_guard<LockType> lock2(x.mutex_, std::adopt_lock);
+  std::lock_guard<LockType> lock(x.mutex_);
 
   if (x.object_)
     object_ = static_cast<TH1 *>(x.object_->Clone());
@@ -215,9 +213,7 @@ MonitorElement::MonitorElement(const MonitorElement &x)
 MonitorElement::MonitorElement(MonitorElement &&x)
   : MonitorElement::MonitorElement(x, MonitorElementNoCloneTag())
 {
-  std::lock(mutex_, x.mutex_);
-  std::lock_guard<LockType> lock1(mutex_, std::adopt_lock);
-  std::lock_guard<LockType> lock2(x.mutex_, std::adopt_lock);
+  std::lock_guard<LockType> lock(x.mutex_);
 
   object_ = x.object_;
   refvalue_ = x.refvalue_;

--- a/DQMServices/Core/src/QTest.cc
+++ b/DQMServices/Core/src/QTest.cc
@@ -45,7 +45,7 @@ float Comp2RefEqualH::runTest(const MonitorElement*me)
     return -1;
   if (!me->getRootObject() || !me->getRefRootObject()) 
     return -1;
-  TH1* h=0; //initialize histogram pointer
+  locking_ptr<TH1> h;   // initialize histogram pointer
   TH1* ref_=0;
   
   if (verbose_>1) 
@@ -166,7 +166,7 @@ float Comp2RefChi2::runTest(const MonitorElement *me)
     return -1;
   if (!me->getRootObject() || !me->getRefRootObject()) 
     return -1;
-  TH1* h=0;
+  locking_ptr<TH1> h;
   TH1* ref_=0;
  
   if (verbose_>1) 
@@ -298,7 +298,7 @@ float Comp2Ref2DChi2::runTest(const MonitorElement *me)
   if (minEntries_ != 0 && me->getEntries() < minEntries_)
     return -1;
 
-  TH2* h=0;
+  locking_ptr<TH2> h;
   TH2* ref_=0;
  
   if (verbose_>1) 
@@ -399,7 +399,7 @@ float Comp2RefKolmogorov::runTest(const MonitorElement *me)
     return -1;
   if (!me->getRootObject() || !me->getRefRootObject()) 
     return -1;
-  TH1* h=0;
+  locking_ptr<TH1> h;
   TH1* ref_=0;
 
   if (verbose_>1) 
@@ -583,7 +583,7 @@ float ContentsXRange::runTest(const MonitorElement*me)
     return -1;
   if (!me->getRootObject()) 
     return -1;
-  TH1* h=0; 
+  locking_ptr<TH1> h; 
 
   if (verbose_>1) 
     std::cout << "QTest:" << getAlgoName() << "::runTest called on " 
@@ -653,7 +653,7 @@ float ContentsYRange::runTest(const MonitorElement*me)
     return -1;
   if (!me->getRootObject()) 
     return -1;
-  TH1* h=0; 
+  locking_ptr<TH1> h; 
 
   if (verbose_>1) 
     std::cout << "QTest:" << getAlgoName() << "::runTest called on " 
@@ -731,8 +731,8 @@ float DeadChannel::runTest(const MonitorElement*me)
     return -1;
   if (!me->getRootObject()) 
     return -1;
-  TH1* h1=0;
-  TH2* h2=0;//initialize histogram pointers
+  locking_ptr<TH1> h1;
+  locking_ptr<TH2> h2;  // initialize histogram pointers
 
   if (verbose_>1) 
     std::cout << "QTest:" << getAlgoName() << "::runTest called on " 
@@ -779,7 +779,7 @@ float DeadChannel::runTest(const MonitorElement*me)
   int fail = 0; // number of failed channels
 
   //--------- do the quality test for 1D histo ---------------//
-  if (h1 != NULL)  
+  if (h1)  
   {
     if (!rangeInitialized_ || !h1->GetXaxis() ) 
       return 1; // all bins are accepted if no initialization
@@ -807,7 +807,7 @@ float DeadChannel::runTest(const MonitorElement*me)
   //----------------------------------------------------------//
  
   //--------- do the quality test for 2D -------------------//
-  else if (h2 !=NULL )
+  else if (h2)
   {
     int ncx = h2->GetXaxis()->GetNbins(); // get X bins
     int ncy = h2->GetYaxis()->GetNbins(); // get Y bins
@@ -852,7 +852,7 @@ float NoisyChannel::runTest(const MonitorElement *me)
     return -1;
   if (!me->getRootObject()) 
     return -1; 
-  TH1* h=0;//initialize histogram pointer
+  locking_ptr<TH1> h;   // initialize histogram pointer
 
   if (verbose_>1) 
     std::cout << "QTest:" << getAlgoName() << "::runTest called on " 
@@ -941,7 +941,7 @@ float NoisyChannel::runTest(const MonitorElement *me)
 
 // get average for bin under consideration
 // (see description of method setNumNeighbors)
-double NoisyChannel::getAverage(int bin, const TH1 *h) const
+double NoisyChannel::getAverage(int bin, locking_ptr<TH1> const& h) const
 {
   /// do NOT use underflow bin
   int first = 1;
@@ -977,7 +977,7 @@ float ContentsWithinExpected::runTest(const MonitorElement*me)
     return -1;
   if (!me->getRootObject()) 
     return -1;
-  TH1* h=0; //initialize histogram pointer
+  locking_ptr<TH1> h;   // initialize histogram pointer
 
   if (verbose_>1) 
     std::cout << "QTest:" << getAlgoName() << "::runTest called on " 
@@ -1251,7 +1251,7 @@ float MeanWithinExpected::runTest(const MonitorElement *me )
     return -1;
   if (!me->getRootObject()) 
     return -1;
-  TH1* h=0;
+  locking_ptr<TH1> h;
    
   if (verbose_>1) 
     std::cout << "QTest:" << getAlgoName() << "::runTest called on " 
@@ -1370,7 +1370,7 @@ float CompareToMedian::runTest(const MonitorElement *me){
     return -1;
   if (!me->getRootObject())
     return -1;
-  TH1* h=0;
+  locking_ptr<TH1> h;
 
   if (verbose_>1){
     std::cout << "QTest:" << getAlgoName() << "::runTest called on "
@@ -1498,8 +1498,8 @@ float CompareLastFilledBin::runTest(const MonitorElement *me){
     return -1;
   if (!me->getRootObject())
     return -1;
-  TH1* h1=0;
-  TH2* h2=0;
+  locking_ptr<TH1> h1;
+  locking_ptr<TH2> h2;
   if (verbose_>1){
     std::cout << "QTest:" << getAlgoName() << "::runTest called on "
               << me-> getFullname() << "\n";
@@ -1525,13 +1525,13 @@ float CompareLastFilledBin::runTest(const MonitorElement *me){
   float lastBinVal; 
 
   //--------- do the quality test for 1D histo ---------------// 
-  if (h1 != NULL) 
+  if (h1) 
   { 
     lastBinX = h1->FindLastBinAbove(_average,1);
     lastBinVal = h1->GetBinContent(lastBinX);
     if (h1->GetEntries() == 0 || lastBinVal < 0) return 1;
   } 
-  else if (h2 != NULL) 
+  else if (h2) 
   {   
     
     lastBinX = h2->FindLastBinAbove(_average,1);
@@ -1559,7 +1559,7 @@ float CheckVariance::runTest(const MonitorElement*me)
     return -1;
   if (!me->getRootObject())
     return -1;
-  TH1* h=0;
+  locking_ptr<TH1> h;
 
   if (verbose_>1)
     std::cout << "QTest:" << getAlgoName() << "::runTest called on "


### PR DESCRIPTION
Currently the `MonitorElement` uses a `recursive_mutex` to lock the underlying ROOT objects, because many methods need to call other methods.

TODO
  - extend the interface of the `MonitorElement` class so that the `public` methods should always acquire lock, while the `private` methods do not;
  - change from `std::recursive_mutex` to the `std::mutex` type
  - let the `DQMService` use the non-locking methods when it knows from the context that it has exclusive access
