### PR TITLE
Move @relval2017 default to HLT V2.2 (92X)

### DIFF
--- a/Configuration/HLT/python/autoHLT.py
+++ b/Configuration/HLT/python/autoHLT.py
@@ -8,6 +8,6 @@ autoHLT = {
   'relval50ns' : 'Fake',
   'relval25ns' : 'Fake1',
   'relval2016' : 'Fake2',
-  'relval2017' : '2e34v21',
+  'relval2017' : '2e34v22',
   'test'       : 'GRun',
 }


### PR DESCRIPTION
Move @relval2017 default to HLT V2.2 (92X)
Based on CMSSW_9_2_9
