### PR TITLE
B2G DQM for dilepton paths

### DIFF
--- a/DQMOffline/Trigger/python/B2GMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/B2GMonitoring_Client_cff.py
@@ -21,7 +21,39 @@ b2gjetEfficiency = cms.EDProducer("DQMGenericClient",
     ),
 )
 
+b2gEfficiency_ElMu = cms.EDProducer("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/B2GHLTOffline/Dileptonic/Dimuon/CrossTriggers"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
+                                      
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_muPt_1       'efficiency vs leading muon pt; muon pt [GeV]; efficiency' muPt_1_numerator       muPt_1_denominator",
+        "effic_muEta_1       'efficiency vs leading muon eta; muon eta ; efficiency' muEta_1_numerator       muEta_1_denominator",
+        "effic_muPhi_1       'efficiency vs leading muon phi; muon phi ; efficiency' muPhi_1_numerator       muPhi_1_denominator",
+        "effic_elePt_1       'efficiency vs electron pt; electron pt [GeV]; efficiency' elePt_1_numerator       elePt_1_denominator",
+        "effic_eleEta_1       'efficiency vs electron eta; electron eta ; efficiency' eleEta_1_numerator       eleEta_1_denominator",
+        "effic_elePhi_1       'efficiency vs electron phi; electron phi ; efficiency' elePhi_1_numerator       elePhi_1_denominator",
+    ),
+)
+
+b2gEfficiency_diMu = cms.EDProducer("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/B2GHLTOffline/Dileptonic/Dimuon/"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
+                                      
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_muPt_1       'efficiency vs leading muon pt; muon pt [GeV]; efficiency' muPt_1_numerator       muPt_1_denominator",
+        "effic_muEta_1       'efficiency vs leading muon eta; muon eta ; efficiency' muEta_1_numerator       muEta_1_denominator",
+        "effic_muPhi_1       'efficiency vs leading muon phi; muon phi ; efficiency' muPhi_1_numerator       muPhi_1_denominator",
+        "effic_muPt_2       'efficiency vs sub-leading muon pt; muon pt [GeV]; efficiency' muPt_2_numerator       muPt_2_denominator",
+        "effic_muEta_2       'efficiency vs sub-leading muon eta; muon eta ; efficiency' muEta_2_numerator       muEta_2_denominator",
+        "effic_muPhi_2       'efficiency vs sub-leading muon phi; muon phi ; efficiency' muPhi_2_numerator       muPhi_2_denominator",
+    ),
+)
+
 b2gClient = cms.Sequence(
     b2gjetEfficiency
+    + b2gEfficiency_ElMu
+    + b2gEfficiency_diMu
 )
 

--- a/DQMOffline/Trigger/python/B2GMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/B2GMonitoring_cff.py
@@ -3,6 +3,8 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.JetMonitor_cfi import hltJetMETmonitoring
 from DQMOffline.Trigger.HTMonitor_cfi import hltHTmonitoring
 from DQMOffline.Trigger.B2GTnPMonitor_cfi import B2GegmGsfElectronIDsForDQM,B2GegHLTDQMOfflineTnPSource
+from DQMOffline.Trigger.topDiLeptonHLTEventDQM_cfi import topDiLeptonHLTOfflineDQM
+
 
 # B2G triggers:
 #HLT_AK8PFHT750_TrimMass50_v*
@@ -62,6 +64,23 @@ AK8PFJet420_TrimMass30_PromptMonitoring.FolderName = cms.string('HLT/B2GMonitor/
 AK8PFJet420_TrimMass30_PromptMonitoring.ptcut = cms.double(420)
 AK8PFJet420_TrimMass30_PromptMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJet420_TrimMass30_v*")
 
+
+b2gDileptonHLTOfflineDQM = topDiLeptonHLTOfflineDQM.clone()
+b2gDileptonHLTOfflineDQM.setup.directory = cms.string('HLT/B2GHLTOffline/Dileptonic/CrossTriggers')
+b2gDileptonHLTOfflineDQM.setup.triggerExtras.pathsELECMU = cms.vstring(['HLT_Mu37_Ele27_CaloIdL_MW_v','HLT_Mu27_Ele37_CaloIdL_MW_v'])
+b2gDileptonHLTOfflineDQM.setup.triggerExtras.pathsDIMUON = cms.vstring([''])
+b2gDileptonHLTOfflineDQM.setup.triggerExtras.pathsDIELEC = cms.vstring([''])
+b2gDileptonHLTOfflineDQM.preselection.trigger.select = cms.vstring(['HLT_Mu37_Ele27_CaloIdL_MW_v','HLT_Mu27_Ele37_CaloIdL_MW_v'])
+
+b2gDimuonHLTOfflineDQM = topDiLeptonHLTOfflineDQM.clone()
+b2gDimuonHLTOfflineDQM.setup.directory = cms.string('HLT/B2GHLTOffline/Dileptonic/Dimuon')
+b2gDimuonHLTOfflineDQM.setup.triggerExtras.pathsELECMU = cms.vstring([''])
+b2gDimuonHLTOfflineDQM.setup.triggerExtras.pathsDIMUON = cms.vstring(['HLT_Mu37_TkMu27_v'])
+b2gDimuonHLTOfflineDQM.setup.triggerExtras.pathsDIELEC = cms.vstring([''])
+b2gDimuonHLTOfflineDQM.preselection.trigger.select = cms.vstring(['HLT_Mu37_TkMu27'])
+
+
+
 b2gMonitorHLT = cms.Sequence(
     AK8PFHT750_TrimMass50_HTmonitoring +
     AK8PFHT800_TrimMass50_HTmonitoring + 
@@ -72,5 +91,7 @@ b2gMonitorHLT = cms.Sequence(
     AK8PFJet400_TrimMass30_PromptMonitoring + 
     AK8PFJet420_TrimMass30_PromptMonitoring +
     B2GegmGsfElectronIDsForDQM*
-    B2GegHLTDQMOfflineTnPSource
+    B2GegHLTDQMOfflineTnPSource*
+    b2gDileptonHLTOfflineDQM*
+    b2gDimuonHLTOfflineDQM
 )


### PR DESCRIPTION
These are the (hopefully) final B2G paths that needed monitoring to be included in the menus. These are dilepton paths monitored primarily by B2G for the X5/3 analysis. They are designed to monitor:

HLT_Mu37_Ele27_CaloIdL_MW_v
HLT_Mu27_Ele37_CaloIdL_MW_v
HLT_Mu37_TkMu27_v
