### PR TITLE
updating the E/gamma HLT TnP DQM to have muon tags

### DIFF
--- a/DQMOffline/Trigger/plugins/HLTDQMMuonSelector.cc
+++ b/DQMOffline/Trigger/plugins/HLTDQMMuonSelector.cc
@@ -1,0 +1,126 @@
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/MuonReco/interface/MuonSelectors.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
+
+class HLTDQMMuonSelector : public edm::stream::EDProducer<> {
+public:
+  explicit HLTDQMMuonSelector(const edm::ParameterSet& config);
+  void produce(edm::Event&, edm::EventSetup const&)override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+private:
+
+  enum class MuonSelectionType {
+    Tight,Medium,Loose,Soft,HighPt
+  };
+  
+  static MuonSelectionType convertToEnum(const std::string& val);
+  bool passMuonSel(const reco::Muon& muon,const reco::Vertex& vertex)const;
+  
+
+  edm::EDGetTokenT<reco::MuonCollection> muonToken_;
+  edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
+  StringCutObjectSelector<reco::Muon,true> selection_;
+  
+  MuonSelectionType muonSelType_;
+  
+  
+};
+
+
+HLTDQMMuonSelector::HLTDQMMuonSelector(const edm::ParameterSet& config):
+  muonToken_(consumes<reco::MuonCollection>(config.getParameter<edm::InputTag>("objs"))),
+  vtxToken_(consumes<reco::VertexCollection>(config.getParameter<edm::InputTag>("vertices"))),
+  selection_(config.getParameter<std::string>("selection")),
+  muonSelType_(convertToEnum(config.getParameter<std::string>("muonSelectionType")))
+{ 
+  produces<edm::ValueMap<bool> >(); 
+}
+
+void HLTDQMMuonSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+{
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("objs", edm::InputTag("muons"));
+  desc.add<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"));
+  desc.add<std::string>("selection","et > 5");
+  desc.add<std::string>("muonSelectionType","tight");
+  descriptions.add("hltDQMMuonSelector", desc);
+}
+
+
+void HLTDQMMuonSelector::produce(edm::Event& event,const edm::EventSetup& setup)
+{
+  edm::Handle<reco::MuonCollection> muonHandle;
+  event.getByToken(muonToken_,muonHandle);
+  
+  edm::Handle<reco::VertexCollection> vtxHandle;
+  event.getByToken(vtxToken_,vtxHandle);
+  
+  if(!muonHandle.isValid()) return;
+  
+  std::vector<bool> selResults;
+  for(auto& muon : *muonHandle){
+    if(vtxHandle.isValid() && !vtxHandle->empty()){
+      selResults.push_back(passMuonSel(muon,vtxHandle->front()) && selection_(muon));
+    }else{
+      selResults.push_back(false);
+    }
+  }
+  auto valMap = std::make_unique<edm::ValueMap<bool> >();
+  edm::ValueMap<bool>::Filler filler(*valMap);
+  filler.insert(muonHandle, selResults.begin(), selResults.end());
+  filler.fill();
+  event.put(std::move(valMap));
+}
+	       
+HLTDQMMuonSelector::MuonSelectionType HLTDQMMuonSelector::convertToEnum(const std::string& val)
+{
+  const std::vector<std::pair<std::string,MuonSelectionType> > strsToEnums = {
+    {"tight",MuonSelectionType::Tight},
+    {"medium",MuonSelectionType::Medium},
+    {"loose",MuonSelectionType::Loose},
+    {"soft",MuonSelectionType::Soft},
+    {"highpt",MuonSelectionType::HighPt}
+  };
+  for(const auto& strEnumPair : strsToEnums){
+    if(val==strEnumPair.first) return strEnumPair.second;
+  }
+  std::ostringstream validEnums;
+  for(const auto& strEnumPair : strsToEnums) validEnums <<strEnumPair.first<<" ";
+  throw cms::Exception("InvalidConfig") << "invalid muonSelectionType "<<val<<", allowed values are "<<validEnums.str();
+}
+
+bool HLTDQMMuonSelector::passMuonSel(const reco::Muon& muon,const reco::Vertex& vertex)const
+{
+  switch(muonSelType_){
+  case MuonSelectionType::Tight:
+    return muon::isTightMuon(muon,vertex);
+  case MuonSelectionType::Medium:
+    return muon::isMediumMuon(muon);
+  case MuonSelectionType::Loose:
+    return muon::isLooseMuon(muon);
+  case MuonSelectionType::Soft:
+    return muon::isSoftMuon(muon,vertex);
+  case MuonSelectionType::HighPt:
+    return muon::isHighPtMuon(muon,vertex);
+  default:
+    edm::LogError("HLTDQMMuonSelector")<<" inconsistent code, an option has been added to MuonSelectionType without updating HLTDQMMuonSelector::passMuonSel";
+    return false;
+  }
+
+}
+  
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(HLTDQMMuonSelector);

--- a/DQMOffline/Trigger/plugins/HLTDQMMuonSelector.cc
+++ b/DQMOffline/Trigger/plugins/HLTDQMMuonSelector.cc
@@ -23,7 +23,7 @@ public:
 private:
 
   enum class MuonSelectionType {
-    Tight,Medium,Loose,Soft,HighPt
+    Tight,Medium,Loose,Soft,HighPt,None
   };
   
   static MuonSelectionType convertToEnum(const std::string& val);
@@ -92,7 +92,8 @@ HLTDQMMuonSelector::MuonSelectionType HLTDQMMuonSelector::convertToEnum(const st
     {"medium",MuonSelectionType::Medium},
     {"loose",MuonSelectionType::Loose},
     {"soft",MuonSelectionType::Soft},
-    {"highpt",MuonSelectionType::HighPt}
+    {"highpt",MuonSelectionType::HighPt},
+    {"none",MuonSelectionType::None}
   };
   for(const auto& strEnumPair : strsToEnums){
     if(val==strEnumPair.first) return strEnumPair.second;
@@ -115,6 +116,8 @@ bool HLTDQMMuonSelector::passMuonSel(const reco::Muon& muon,const reco::Vertex& 
     return muon::isSoftMuon(muon,vertex);
   case MuonSelectionType::HighPt:
     return muon::isHighPtMuon(muon,vertex);
+  case MuonSelectionType::None:
+    return true;
   default:
     edm::LogError("HLTDQMMuonSelector")<<" inconsistent code, an option has been added to MuonSelectionType without updating HLTDQMMuonSelector::passMuonSel";
     return false;

--- a/DQMOffline/Trigger/plugins/HLTTagAndProbeOfflineSource.cc
+++ b/DQMOffline/Trigger/plugins/HLTTagAndProbeOfflineSource.cc
@@ -98,10 +98,12 @@ using HLTEleTagAndProbeOfflineSource = HLTTagAndProbeOfflineSource<reco::GsfElec
 using HLTPhoTagAndProbeOfflineSource = HLTTagAndProbeOfflineSource<reco::Photon,reco::PhotonCollection>;
 using HLTElePhoTagAndProbeOfflineSource = HLTTagAndProbeOfflineSource<reco::GsfElectron,reco::GsfElectronCollection,reco::Photon,reco::PhotonCollection>;
 using HLTMuEleTagAndProbeOfflineSource = HLTTagAndProbeOfflineSource<reco::Muon,reco::MuonCollection,reco::GsfElectron,reco::GsfElectronCollection>;
+using HLTMuPhoTagAndProbeOfflineSource = HLTTagAndProbeOfflineSource<reco::Muon,reco::MuonCollection,reco::Photon,reco::PhotonCollection>;
 using HLTMuTagAndProbeOfflineSource = HLTTagAndProbeOfflineSource<reco::Muon,reco::MuonCollection>;
 DEFINE_FWK_MODULE(HLTEleTagAndProbeOfflineSource);
 DEFINE_FWK_MODULE(HLTPhoTagAndProbeOfflineSource);
 DEFINE_FWK_MODULE(HLTElePhoTagAndProbeOfflineSource);
 DEFINE_FWK_MODULE(HLTMuEleTagAndProbeOfflineSource);
+DEFINE_FWK_MODULE(HLTMuPhoTagAndProbeOfflineSource);
 DEFINE_FWK_MODULE(HLTMuTagAndProbeOfflineSource);
 

--- a/DQMOffline/Trigger/python/EgammaMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/EgammaMonitoring_Client_cff.py
@@ -15,7 +15,7 @@ def makeEGEffHistDef(baseName,filterName):
             
 def makeAllEGEffHistDefs():
     baseNames=["eleWPTightTag","eleWPTightTag-HEP17","eleWPTightTag-HEM17"]
-    filterNames=["hltEle33CaloIdLMWPMS2Filter","hltDiEle33CaloIdLMWPMS2UnseededFilter","hltEG300erFilter","hltEG70HEFilter","hltDiEG70HEUnseededFilter","hltEG85HEFilter","hltDiEG85HEUnseededFilter","hltEG30EIso15HE30EcalIsoLastFilter","hltEG18EIso15HE30EcalIsoUnseededFilter","hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg1Filter","hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg2Filter","hltEle27WPTightGsfTrackIsoFilter","hltEle32noerWPTightGsfTrackIsoFilter","hltEle35noerWPTightGsfTrackIsoFilter","hltEle38noerWPTightGsfTrackIsoFilter","hltEle27L1DoubleEGWPTightGsfTrackIsoFilter","hltEle32L1DoubleEGWPTightGsfTrackIsoFilter","hltEG25L1EG18HEFilter","hltEG33L1EG26HEFilter","hltEG50HEFilter","hltEG75HEFilter","hltEG90HEFilter","hltEG120HEFilter","hltEG150HEFilter","hltEG175HEFilter","hltEG200HEFilter","hltSingleCaloJet500","hltSingleCaloJet550","hltEle28HighEtaSC20TrackIsoFilter","hltEle50CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle115CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle135CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle145CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle200CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle250CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle300CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle20WPLoose1GsfTrackIsoFilter","hltEle20erWPLoose1GsfTrackIsoFilter","hltEle20WPTightGsfTrackIsoFilter","hltEle27L1DoubleEGWPTightEcalIsoFilter","hltDiEle27L1DoubleEGWPTightEcalIsoFilter","hltEle27CaloIdLMWPMS2Filter","hltDiEle27CaloIdLMWPMS2UnseededFilter","hltEle25CaloIdLMWPMS2Filter","hltDiEle25CaloIdLMWPMS2UnseededFilter","hltEle27CaloIdLMWPMS2Filter","hltDiEle27CaloIdLMWPMS2UnseededFilter","hltEle37CaloIdLMWPMS2UnseededFilter","hltSingleEle35WPTightGsfL1EGMTTrackIsoFilter"
+    filterNames=["hltEle33CaloIdLMWPMS2Filter","hltDiEle33CaloIdLMWPMS2UnseededFilter","hltEG300erFilter","hltEG70HEFilter","hltDiEG70HEUnseededFilter","hltEG85HEFilter","hltDiEG85HEUnseededFilter","hltEG30EIso15HE30EcalIsoLastFilter","hltEG18EIso15HE30EcalIsoUnseededFilter","hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg1Filter","hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg2Filter","hltEle27WPTightGsfTrackIsoFilter","hltEle32WPTightGsfTrackIsoFilter","hltEle35noerWPTightGsfTrackIsoFilter","hltEle38noerWPTightGsfTrackIsoFilter","hltEle27L1DoubleEGWPTightGsfTrackIsoFilter","hltEle32L1DoubleEGWPTightGsfTrackIsoFilter","hltEG25L1EG18HEFilter","hltEG33L1EG26HEFilter","hltEG50HEFilter","hltEG75HEFilter","hltEG90HEFilter","hltEG120HEFilter","hltEG150HEFilter","hltEG175HEFilter","hltEG200HEFilter","hltSingleCaloJet500","hltSingleCaloJet550","hltEle28HighEtaSC20TrackIsoFilter","hltEle50CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle115CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle135CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle145CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle200CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle250CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle300CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle20WPLoose1GsfTrackIsoFilter","hltEle20erWPLoose1GsfTrackIsoFilter","hltEle20WPTightGsfTrackIsoFilter","hltEle27L1DoubleEGWPTightEcalIsoFilter","hltDiEle27L1DoubleEGWPTightEcalIsoFilter","hltEle27CaloIdLMWPMS2Filter","hltDiEle27CaloIdLMWPMS2UnseededFilter","hltEle25CaloIdLMWPMS2Filter","hltDiEle25CaloIdLMWPMS2UnseededFilter","hltEle27CaloIdLMWPMS2Filter","hltDiEle27CaloIdLMWPMS2UnseededFilter","hltEle37CaloIdLMWPMS2UnseededFilter","hltSingleEle35WPTightGsfL1EGMTTrackIsoFilter"
                  ]
     
     
@@ -40,6 +40,19 @@ def makeAllEGEffHistDefs():
         for filterName in filterNames:
             histDefs.extend(makeEGEffHistDef(baseName,filterName))
     
+    baseNames=["muonIsoMuTagPhoProbe","muonIsoMuTagPhoProbe-HEM17","muonIsoMuTagPhoProbe-HEP17"]
+    filterNames=["hltMu12DiEG20HEUnseededFilter"]
+
+    for baseName in baseNames:
+        for filterName in filterNames:
+            histDefs.extend(makeEGEffHistDef(baseName,filterName))
+
+    baseNames=["muonIsoMuTagEleProbe","muonIsoMuTagEleProbe-HEM17","muonIsoMuTagEleProbe-HEP17"]
+    filterNames=["hltMu12DiEG20HEUnseededFilter","hltEle27CaloIdLMWPMS2UnseededFilter","hltEle37CaloIdLMWPMS2UnseededFilter","hltEle33CaloIdLMWPMS2Filter","hltEle32WPTightGsfTrackIsoFilter","hltEle32L1DoubleEGWPTightGsfTrackIsoFilter"]
+    for baseName in baseNames:
+        for filterName in filterNames:
+            histDefs.extend(makeEGEffHistDef(baseName,filterName))
+
 #    print histDefs
     return histDefs
 

--- a/DQMOffline/Trigger/python/EgammaMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/EgammaMonitoring_cff.py
@@ -1,11 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
-from DQMOffline.Trigger.HLTEGTnPMonitor_cfi import egmGsfElectronIDsForDQM,egHLTDQMOfflineTnPSource,egmPhotonIDSequenceForDQM,egHLTElePhoDQMOfflineTnPSource,egHLTElePhoHighEtaDQMOfflineTnPSource,photonIDValueMapProducer,egmPhotonIDsForDQM
+from DQMOffline.Trigger.HLTEGTnPMonitor_cfi import egmGsfElectronIDsForDQM,egHLTDQMOfflineTnPSource,egmPhotonIDSequenceForDQM,egHLTElePhoDQMOfflineTnPSource,egHLTElePhoHighEtaDQMOfflineTnPSource,photonIDValueMapProducer,egmPhotonIDsForDQM,egHLTMuonPhoDQMOfflineTnPSource,egmDQMSelectedMuons,egmMuonIDSequenceForDQM,egHLTMuonEleDQMOfflineTnPSource
 
 egammaMonitorHLT = cms.Sequence(
     egmGsfElectronIDsForDQM*
     egHLTDQMOfflineTnPSource*
     egmPhotonIDSequenceForDQM*
     egHLTElePhoDQMOfflineTnPSource*
-    egHLTElePhoHighEtaDQMOfflineTnPSource
+    egHLTElePhoHighEtaDQMOfflineTnPSource*
+    egmMuonIDSequenceForDQM*
+    egHLTMuonEleDQMOfflineTnPSource*
+    egHLTMuonPhoDQMOfflineTnPSource
+    
 )

--- a/DQMOffline/Trigger/python/HLTEGTnPMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/HLTEGTnPMonitor_cfi.py
@@ -49,7 +49,10 @@ hcalPhi17Cut = cms.PSet(
     allowedRanges=cms.vstring("-0.87:-0.52"),
     )
 
-
+muonEtaCut=cms.PSet(
+    rangeVar=cms.string("eta"),
+    allowedRanges=cms.vstring("-2.4:2.4")
+    )
 tagAndProbeConfigEle27WPTight = cms.PSet(
     trigEvent = cms.InputTag("hltTriggerSummaryAOD","","HLT"),
     tagColl = cms.InputTag("gedGsfElectrons"),
@@ -65,7 +68,7 @@ tagAndProbeConfigEle27WPTight = cms.PSet(
         ),
     #it is intended that these are the filters of the triggers listed for sampleTrigRequirements
     tagFilters = cms.vstring("hltEle27WPTightGsfTrackIsoFilter",
-                             "hltEle32noerWPTightGsfTrackIsoFilter"
+                             "hltEle32WPTightGsfTrackIsoFilter"
                              "hltEle35noerWPTightGsfTrackIsoFilter"
                              "hltEle38noerWPTightGsfTrackIsoFilter"
                              "hltEle27L1DoubleEGWPTightGsfTrackIsoFilter",
@@ -127,6 +130,62 @@ tagAndProbeElePhoHighEtaConfigEle27WPTightHEM17 = tagAndProbeElePhoHighEtaConfig
         ecalEndcapPosHighEtaCut,
         hcalPhi17Cut,
 ))
+
+
+tagAndProbeMuonEleConfigIsoMu = cms.PSet(
+    trigEvent = cms.InputTag("hltTriggerSummaryAOD","","HLT"),
+    tagColl = cms.InputTag("muons"),
+    probeColl = cms.InputTag("gedGsfElectrons"),
+    tagVIDCuts = cms.InputTag("egmDQMSelectedMuons"),
+    probeVIDCuts = cms.InputTag("egmGsfElectronIDsForDQM:cutBasedElectronID-Summer16-80X-V1-tight"),
+    sampleTrigRequirements = cms.PSet(
+        hltInputTag = cms.InputTag("TriggerResults","","HLT"),
+        hltPaths = cms.vstring("HLT_IsoMu27_v*")
+                               
+        ),
+    #it is intended that these are the filters of the triggers listed for sampleTrigRequirements
+    tagFilters = cms.vstring("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07"),
+    tagFiltersORed = cms.bool(True),
+    tagRangeCuts = cms.VPSet(muonEtaCut),
+    probeFilters = cms.vstring(),
+    probeFiltersORed = cms.bool(False),
+    probeRangeCuts = cms.VPSet(ecalBarrelAndEndcapEtaCut),
+    minTagProbeDR = cms.double(0.4),
+    minMass = cms.double(-1),
+    maxMass = cms.double(-1),
+    requireOpSign = cms.bool(False),
+    )
+
+tagAndProbeMuonEleConfigIsoMuHEP17 = tagAndProbeMuonEleConfigIsoMu.clone(
+    probeRangeCuts = cms.VPSet(
+        hcalPosEtaCut,
+        hcalPhi17Cut,
+        )
+    )
+tagAndProbeMuonEleConfigIsoMuHEM17 = tagAndProbeMuonEleConfigIsoMu.clone(
+    probeRangeCuts = cms.VPSet(
+        hcalNegEtaCut,
+        hcalPhi17Cut,
+        )
+    )
+
+tagAndProbeMuonPhoConfigIsoMu = tagAndProbeMuonEleConfigIsoMu.clone(
+    probeColl=cms.InputTag("gedPhotons"),
+    probeVIDCuts=cms.InputTag("cutBasedPhotonID-Spring16-V2p2-loose"),
+)
+tagAndProbeMuonPhoConfigIsoMuHEP17 = tagAndProbeMuonPhoConfigIsoMu.clone(
+    probeRangeCuts = cms.VPSet(
+        hcalPosEtaCut,
+        hcalPhi17Cut,
+        )
+    )
+tagAndProbeMuonPhoConfigIsoMuHEM17 = tagAndProbeMuonPhoConfigIsoMu.clone(
+    probeRangeCuts = cms.VPSet(
+        hcalNegEtaCut,
+        hcalPhi17Cut,
+        )
+    )
+
 
 egammaStdHistConfigs = cms.VPSet(
     cms.PSet(
@@ -298,7 +357,7 @@ egammaStdFiltersToMonitor= cms.VPSet(
     cms.PSet(
         folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele32_WPTight_Gsf"),
         rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("35:99999")),),
-        filterName = cms.string("hltEle32noerWPTightGsfTrackIsoFilter"),
+        filterName = cms.string("hltEle32WPTightGsfTrackIsoFilter"),
         histTitle = cms.string(""),
         tagExtraFilter = cms.string(""),
         ),
@@ -685,6 +744,63 @@ egammaPhoFiltersToMonitor= cms.VPSet(
         ), 
 
 ) 
+
+
+egammaMuPhoFiltersToMonitor= cms.VPSet(
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Mu12_DoublePhoton20"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("25:99999")),),
+        filterName = cms.string("hltMu12DiEG20HEUnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltL3fL1sMu12Diphoton20L1f0L2f8QL3Filtered12"),
+        ), 
+)
+
+egammaMuEleFiltersToMonitor= cms.VPSet(
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Mu12_DoublePhoton20"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("25:99999")),),
+        filterName = cms.string("hltMu12DiEG20HEUnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltL3fL1sMu12Diphoton20L1f0L2f8QL3Filtered12"),
+        ), 
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Mu37_Ele27_CaloIdL_MW"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("30:99999")),),
+        filterName = cms.string("hltEle27CaloIdLMWPMS2UnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltL3fL1sMu16orMu25L1f0L2f10QL3Filtered37Q"),
+        ), 
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Mu27_Ele37_CaloIdL_MW"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("42:99999")),),
+        filterName = cms.string("hltEle37CaloIdLMWPMS2UnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltL3fL1sMu16orMu25L1f0L2f10QL3Filtered27Q"),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_DoubleEle33_CaloIdL_MW"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("40:99999")),),
+        filterName = cms.string("hltEle33CaloIdLMWPMS2Filter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele32_WPTight_Gsf"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("35:99999")),),
+        filterName = cms.string("hltEle32WPTightGsfTrackIsoFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele32_WPTight_Gsf_L1DoubleEG"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("35:99999")),),
+        filterName = cms.string("hltEle32L1DoubleEGWPTightGsfTrackIsoFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+)
+
 egHLTDQMOfflineTnPSource = cms.EDAnalyzer("HLTEleTagAndProbeOfflineSource",
                                           tagAndProbeCollections = cms.VPSet(
         cms.PSet( 
@@ -707,7 +823,7 @@ egHLTDQMOfflineTnPSource = cms.EDAnalyzer("HLTEleTagAndProbeOfflineSource",
         ),
            
         )
-                                         )
+)
 
 egHLTElePhoHighEtaDQMOfflineTnPSource = cms.EDAnalyzer("HLTElePhoTagAndProbeOfflineSource",
                                                        tagAndProbeCollections = cms.VPSet(
@@ -756,6 +872,53 @@ egHLTElePhoDQMOfflineTnPSource = cms.EDAnalyzer("HLTElePhoTagAndProbeOfflineSour
         )
 )
 
+egHLTMuonEleDQMOfflineTnPSource = cms.EDAnalyzer("HLTMuEleTagAndProbeOfflineSource",
+                                                 tagAndProbeCollections = cms.VPSet(
+        cms.PSet( 
+            tagAndProbeMuonEleConfigIsoMu,
+            histConfigs = egammaStdHistConfigs,
+            baseHistName = cms.string("muonIsoMuTagEleProbe_"),
+            filterConfigs = egammaMuEleFiltersToMonitor,
+        ),
+        cms.PSet(
+            tagAndProbeMuonEleConfigIsoMuHEM17,
+            histConfigs = egammaStdHistConfigs,
+            baseHistName = cms.string("muonIsoMuTagEleProbe-HEM17_"),
+            filterConfigs = egammaMuEleFiltersToMonitor,
+        ),
+        cms.PSet(
+            tagAndProbeMuonPhoConfigIsoMuHEP17,
+            histConfigs = egammaStdHistConfigs,
+            baseHistName = cms.string("muonIsoMuTagEleProbe-HEP17_"),
+            filterConfigs = egammaMuEleFiltersToMonitor,
+        ),
+           
+        )
+)
+egHLTMuonPhoDQMOfflineTnPSource = cms.EDAnalyzer("HLTMuPhoTagAndProbeOfflineSource",
+                                                 tagAndProbeCollections = cms.VPSet(
+        cms.PSet( 
+            tagAndProbeMuonPhoConfigIsoMu,
+            histConfigs = egammaStdHistConfigs,
+            baseHistName = cms.string("muonIsoMuTagPhoProbe_"),
+            filterConfigs = egammaMuPhoFiltersToMonitor,
+        ),
+        cms.PSet(
+            tagAndProbeMuonPhoConfigIsoMuHEM17,
+            histConfigs = egammaStdHistConfigs,
+            baseHistName = cms.string("muonIsoMuTagPhoProbe-HEM17_"),
+            filterConfigs = egammaMuPhoFiltersToMonitor,
+        ),
+        cms.PSet(
+            tagAndProbeMuonPhoConfigIsoMuHEP17,
+            histConfigs = egammaStdHistConfigs,
+            baseHistName = cms.string("muonIsoMuTagPhoProbe-HEP17_"),
+            filterConfigs = egammaMuPhoFiltersToMonitor,
+        ),
+           
+        )
+)
+
 
 from RecoEgamma.ElectronIdentification.egmGsfElectronIDs_cff import egmGsfElectronIDs
 
@@ -791,3 +954,11 @@ for id_module_name in my_id_modules:
             setupVIDSelection(egmPhotonIDsForDQM,item)
 egmPhotonIDSequenceForDQM = cms.Sequence(photonIDValueMapProducer*
                                          egmPhotonIDsForDQM)
+
+egmDQMSelectedMuons = cms.EDProducer("HLTDQMMuonSelector",
+                                     objs=cms.InputTag("muons"),
+                                     vertices=cms.InputTag("offlinePrimaryVertices"),
+                                     selection=cms.string("pt > 20"),
+                                     muonSelectionType=cms.string("tight")
+                                     )
+egmMuonIDSequenceForDQM = cms.Sequence(egmDQMSelectedMuons)

--- a/DQMOffline/Trigger/python/HLTEGTnPMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/HLTEGTnPMonitor_cfi.py
@@ -4,7 +4,10 @@ import FWCore.ParameterSet.Config as cms
 
 etBinsStd=cms.vdouble(5,10,12.5,15,17.5,20,22.5,25,30,35,40,45,50,60,80,100,150,200,250,300,350,400)
 scEtaBinsStd = cms.vdouble(-2.5,-2.4,-2.3,-2.2,-2.1,-2.0,-1.9,-1.8,-1.7,-1.566,-1.4442,-1.3,-1.2,-1.1,-1.0,-0.9,-0.8,-0.7,-0.6,-0.5,-0.4,-0.3,-0.2,-0.1,0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1,1.1,1.2,1.3,1.4442,1.566,1.7,1.8,1.9,2.0,2.1,2.2,2.3,2.4,2.5)
+scEtaBinsHEP17 = cms.vdouble(1.3,1.4442,1.566,1.7,1.8,1.9,2.0,2.1,2.2,2.3,2.4,2.5)
+scEtaBinsHEM17 = cms.vdouble(-2.5,-2.4,-2.3,-2.2,-2.1,-2.0,-1.9,-1.8,-1.7,-1.566,-1.4442,-1.3)
 phiBinsStd = cms.vdouble(-3.32,-2.97,-2.62,-2.27,-1.92,-1.57,-1.22,-0.87,-0.52,-0.18,0.18,0.52,0.87,1.22,1.57,1.92,2.27,2.62,2.97,3.32)
+phiBinsHE17 = cms.vdouble(-0.87,-0.80,-0.73,-0.66,-0.59,-0.52)
 
 etRangeCut= cms.PSet(
     rangeVar=cms.string("et"),
@@ -234,6 +237,53 @@ egammaStdHistConfigs = cms.VPSet(
         ),
     
     )
+
+egammaHEP17HistConfigs = cms.VPSet(
+    cms.PSet(
+        histType=cms.string("1D"),
+        vsVar=cms.string("et"),
+        nameSuffex=cms.string("_vsEt"),
+        rangeCuts=cms.VPSet(),
+        binLowEdges=etBinsStd,
+        ),
+    cms.PSet(
+        histType=cms.string("1D"),
+        vsVar=cms.string("scEta"),
+        nameSuffex=cms.string("_vsSCEta"),
+        rangeCuts=cms.VPSet(),
+        binLowEdges=scEtaBinsHEP17,
+        ),
+    cms.PSet(
+        histType=cms.string("1D"),
+        vsVar=cms.string("phi"),
+        nameSuffex=cms.string("_vsPhi"),
+        rangeCuts=cms.VPSet(),
+        binLowEdges=phiBinsHE17,
+    )
+)
+egammaHEM17HistConfigs = cms.VPSet(
+    cms.PSet(
+        histType=cms.string("1D"),
+        vsVar=cms.string("et"),
+        nameSuffex=cms.string("_vsEt"),
+        rangeCuts=cms.VPSet(),
+        binLowEdges=etBinsStd,
+        ),
+    cms.PSet(
+        histType=cms.string("1D"),
+        vsVar=cms.string("scEta"),
+        nameSuffex=cms.string("_vsSCEta"),
+        rangeCuts=cms.VPSet(),
+        binLowEdges=scEtaBinsHEM17,
+        ),
+    cms.PSet(
+        histType=cms.string("1D"),
+        vsVar=cms.string("phi"),
+        nameSuffex=cms.string("_vsPhi"),
+        rangeCuts=cms.VPSet(),
+        binLowEdges=phiBinsHE17,
+    )
+)
 egammaHighEtaHistConfigs = cms.VPSet(
     cms.PSet(
         histType=cms.string("1D"),
@@ -811,13 +861,13 @@ egHLTDQMOfflineTnPSource = cms.EDAnalyzer("HLTEleTagAndProbeOfflineSource",
         ),
         cms.PSet(
             tagAndProbeConfigEle27WPTightHEM17,
-            histConfigs = egammaStdHistConfigs,
+            histConfigs = egammaHEM17HistConfigs,
             baseHistName = cms.string("eleWPTightTag-HEM17_"),
             filterConfigs = egammaStdFiltersToMonitor,
         ),
         cms.PSet(
             tagAndProbeConfigEle27WPTightHEP17,
-            histConfigs = egammaStdHistConfigs,
+            histConfigs = egammaHEP17HistConfigs,
             baseHistName = cms.string("eleWPTightTag-HEP17_"),
             filterConfigs = egammaStdFiltersToMonitor,
         ),
@@ -858,13 +908,13 @@ egHLTElePhoDQMOfflineTnPSource = cms.EDAnalyzer("HLTElePhoTagAndProbeOfflineSour
         ),
         cms.PSet(
             tagAndProbeElePhoConfigEle27WPTightHEM17,
-            histConfigs = egammaStdHistConfigs,
+            histConfigs = egammaHEM17HistConfigs,
             baseHistName = cms.string("eleWPTightTagPhoProbe-HEM17_"),
             filterConfigs = egammaPhoFiltersToMonitor,
         ),
         cms.PSet(
             tagAndProbeElePhoConfigEle27WPTightHEP17,
-            histConfigs = egammaStdHistConfigs,
+            histConfigs = egammaHEM17HistConfigs,
             baseHistName = cms.string("eleWPTightTagPhoProbe-HEP17_"),
             filterConfigs = egammaPhoFiltersToMonitor,
         ),
@@ -882,13 +932,13 @@ egHLTMuonEleDQMOfflineTnPSource = cms.EDAnalyzer("HLTMuEleTagAndProbeOfflineSour
         ),
         cms.PSet(
             tagAndProbeMuonEleConfigIsoMuHEM17,
-            histConfigs = egammaStdHistConfigs,
+            histConfigs = egammaHEM17HistConfigs,
             baseHistName = cms.string("muonIsoMuTagEleProbe-HEM17_"),
             filterConfigs = egammaMuEleFiltersToMonitor,
         ),
         cms.PSet(
             tagAndProbeMuonPhoConfigIsoMuHEP17,
-            histConfigs = egammaStdHistConfigs,
+            histConfigs = egammaHEP17HistConfigs,
             baseHistName = cms.string("muonIsoMuTagEleProbe-HEP17_"),
             filterConfigs = egammaMuEleFiltersToMonitor,
         ),
@@ -905,13 +955,13 @@ egHLTMuonPhoDQMOfflineTnPSource = cms.EDAnalyzer("HLTMuPhoTagAndProbeOfflineSour
         ),
         cms.PSet(
             tagAndProbeMuonPhoConfigIsoMuHEM17,
-            histConfigs = egammaStdHistConfigs,
+            histConfigs = egammaHEM17HistConfigs,
             baseHistName = cms.string("muonIsoMuTagPhoProbe-HEM17_"),
             filterConfigs = egammaMuPhoFiltersToMonitor,
         ),
         cms.PSet(
             tagAndProbeMuonPhoConfigIsoMuHEP17,
-            histConfigs = egammaStdHistConfigs,
+            histConfigs = egammaHEP17HistConfigs,
             baseHistName = cms.string("muonIsoMuTagPhoProbe-HEP17_"),
             filterConfigs = egammaMuPhoFiltersToMonitor,
         ),


### PR DESCRIPTION
Dear All,

This update of the E/gamma HLT TnP DQM package now allows triggers to be monitored by muon tags, adding further cross trigger monitoring. It is also enabled for a few select electron triggers to be able to monitor e/gamma problems that may impact the tag & probe in a correlated way (online beamspot issues immediately jump to mind there)

As well as adding DQM plots where the tag is a muon, this update also fixes the newly introduced for V3 HLT_Ele32_WPTight_Gsf filters which were slightly miss named. 

The new filters have been tested on ttbar lepton relval sample and the  results are below, showing the filters run and are filled. The full listing is at
https://sharper.web.cern.ch/sharper/cms/trig/2017/Aug14th_muDQM/

HLT_Ele32_WPTight_Gsf:
ele tag:
https://sharper.web.cern.ch/sharper/cms/trig/2017/Aug14th_muDQM/eleWPTightTag_HLT_Ele32_WPTight_Gsf_hltEle32WPTightGsfTrackIsoFilter.gif
muon tag:
https://sharper.web.cern.ch/sharper/cms/trig/2017/Aug14th_muDQM/muonIsoMuTagEleProbe_HLT_Ele32_WPTight_Gsf_hltEle32WPTightGsfTrackIsoFilter.gif

HLT_Ele32_WPTight_Gsf_L1DoubleEG:
https://sharper.web.cern.ch/sharper/cms/trig/2017/Aug14th_muDQM/muonIsoMuTagEleProbe_HLT_Ele32_WPTight_Gsf_L1DoubleEG_hltEle32L1DoubleEGWPTightGsfTrackIsoFilter.gif

HLT_DoubleEle33_CaloIdL_MW:
https://sharper.web.cern.ch/sharper/cms/trig/2017/Aug14th_muDQM/muonIsoMuTagEleProbe_HLT_DoubleEle33_CaloIdL_MW_hltEle33CaloIdLMWPMS2Filter.gif

HLT_Mu12_DoublePhoton20:
with photon probe:
https://sharper.web.cern.ch/sharper/cms/trig/2017/Aug14th_muDQM/muonIsoMuTagPhoProbe_HLT_Mu12_DoublePhoton20_hltMu12DiEG20HEUnseededFilter.gif
with electron probe
https://sharper.web.cern.ch/sharper/cms/trig/2017/Aug14th_muDQM/muonIsoMuTagEleProbe_HLT_Mu12_DoublePhoton20_hltMu12DiEG20HEUnseededFilter.gif

HLT_Mu27_Ele37_CaloIdL_MW:
https://sharper.web.cern.ch/sharper/cms/trig/2017/Aug14th_muDQM/muonIsoMuTagEleProbe_HLT_Mu27_Ele37_CaloIdL_MW_hltEle37CaloIdLMWPMS2UnseededFilter.gif

HLT_Mu37_Ele27_CaloIdL_MW:
https://sharper.web.cern.ch/sharper/cms/trig/2017/Aug14th_muDQM/muonIsoMuTagEleProbe_HLT_Mu37_Ele27_CaloIdL_MW_hltEle27CaloIdLMWPMS2UnseededFilter.gif








