### PR TITLE
Allowing HF anodes with special TDC values to participate in energy reco

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/parseHFPhase1AlgoDescription.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/parseHFPhase1AlgoDescription.cc
@@ -95,8 +95,8 @@ edm::ParameterSetDescription fillDescriptionForParseHFPhase1AlgoDescription()
     desc.add<double>("timeShift", 0.0);
     desc.add<double>("triseIfNoTDC", -100.0);
     desc.add<double>("tfallIfNoTDC", -101.0);
-    desc.add<double>("minChargeForUndershoot", -10000.f);
-    desc.add<double>("minChargeForOvershoot", -10000.f);
+    desc.add<double>("minChargeForUndershoot", 1.0e10);
+    desc.add<double>("minChargeForOvershoot", 1.0e10);
 
     desc.ifValue(edm::ParameterDescription<std::string>("Class", "HFSimpleTimeCheck", true),
                  "HFSimpleTimeCheck" >> edm::ParameterDescription<bool>("rejectAllFailures", false, true) or

--- a/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
@@ -57,8 +57,8 @@ hfreco = cms.EDProducer("HFPhase1Reconstructor",
         # reconstruction even if its TDC undershoots/overshoots. These
         # global limits are in addition to those per channel limits in
         # the database (effectively, the larger limit is used).
-        minChargeForUndershoot = cms.double(-10000.0),
-        minChargeForOvershoot = cms.double(-10000.0),
+        minChargeForUndershoot = cms.double(1.0e10),
+        minChargeForOvershoot = cms.double(1.0e10),
 
         # Do not construct rechits with problems
         rejectAllFailures = cms.bool(True)


### PR DESCRIPTION
This change will allow the HF anodes with QIE10 "undershoot" and
"overshoot" TDC codes (63 and 62) to participate in the rechit energy
reconstruction. The study leading to this adjustment is described
in the following talks:

https://indico.cern.ch/event/649519/contributions/2641896/attachments/1495616/2326893/20170719_Jae_HCALPSG_TDC6263.pdf

https://indico.cern.ch/event/652743/contributions/2656951/attachments/1506347/2347457/20170809_Jae_HCALPSG_TDC6263.pdf

Here is a brief summary of issues:

-- The energy collected by the anode with "undershoot" is only weakly
correlated with the energy collected by its neighbor anode. Therefore,
discarding the anode with "undershoot" (and multiplying the energy of
the neighbor by 2) would normally lead to incorrect energy determination.

-- It is believed that the "overshoot" condition is most likely caused
by pile-up rather than by particle hitting the PMT window and
migrating the pulse to the previous time slice. The anodes with
"overshoot" do exhibit substantial correlation with their neighbors,
so it is judged that the effect of pile-up is small and can be
neglected.

This PR will not modify any relval results for MC. Minor changes are
expected for data.
