### PR TITLE
Geant4 sensitive detectors cleanup 2

### DIFF
--- a/SimG4CMS/Calo/interface/CaloG4Hit.h
+++ b/SimG4CMS/Calo/interface/CaloG4Hit.h
@@ -35,15 +35,15 @@ class CaloG4Hit : public G4VHit {
 public:
   
   CaloG4Hit();
-  virtual ~CaloG4Hit();
+  ~CaloG4Hit() override;
   CaloG4Hit(const CaloG4Hit &right);
   const CaloG4Hit& operator=(const CaloG4Hit &right);
   bool operator==(const CaloG4Hit &){return false;}
   inline void * operator new(size_t);
   inline void   operator delete(void * CaloG4Hit);
 
-  void         Draw(){}
-  void         Print();
+  void         Draw() override{}
+  void         Print() override;
   
 public:
   

--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -49,7 +49,7 @@ class CaloSD : public SensitiveCaloDetector,
 
 public:    
   
-  CaloSD(std::string aSDname, const DDCompactView & cpv,
+  CaloSD(const std::string& aSDname, const DDCompactView & cpv,
          const SensitiveDetectorCatalog & clg,
          edm::ParameterSet const & p, const SimTrackManager*,
 	 float timeSlice=1., bool ignoreTkID=false);

--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -53,19 +53,19 @@ public:
          const SensitiveDetectorCatalog & clg,
          edm::ParameterSet const & p, const SimTrackManager*,
 	 float timeSlice=1., bool ignoreTkID=false);
-  virtual ~CaloSD();
-  virtual bool     ProcessHits(G4Step * step, G4TouchableHistory * tHistory);
-  virtual bool     ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*);
+  ~CaloSD() override;
+  bool     ProcessHits(G4Step * step, G4TouchableHistory * tHistory) override;
+  bool     ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) override;
   virtual double   getEnergyDeposit(G4Step* step); 
-  virtual uint32_t setDetUnitId(G4Step* step)=0;
+  //uint32_t setDetUnitId(G4Step* step) override =0;
   
-  virtual void     Initialize(G4HCofThisEvent * HCE);
-  virtual void     EndOfEvent(G4HCofThisEvent * eventHC);
-  virtual void     clear();
-  virtual void     DrawAll();
-  virtual void     PrintAll();
+  void     Initialize(G4HCofThisEvent * HCE) override;
+  void     EndOfEvent(G4HCofThisEvent * eventHC) override;
+  void     clear() override;
+  void     DrawAll() override;
+  void     PrintAll() override;
 
-  void             fillHits(edm::PCaloHitContainer&, std::string&);
+  void     fillHits(edm::PCaloHitContainer&, std::string&) override ;
 
 protected:
 
@@ -80,12 +80,12 @@ protected:
   double           getAttenuation(G4Step* aStep, double birk1, double birk2,
                                   double birk3);
 
-  virtual void     update(const BeginOfRun *);
-  virtual void     update(const BeginOfEvent *);
-  virtual void     update(const BeginOfTrack * trk);
-  virtual void     update(const EndOfTrack * trk);
-  virtual void     update(const ::EndOfEvent *);
-  virtual void     clearHits();
+  void     update(const BeginOfRun *) override;
+  void     update(const BeginOfEvent *) override;
+  void     update(const BeginOfTrack * trk) override;
+  void     update(const EndOfTrack * trk) override;
+  void     update(const ::EndOfEvent *) override;
+  void     clearHits() override ;
   virtual void     initRun();
   virtual bool     filterHit(CaloG4Hit*, double);
 

--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -98,7 +98,6 @@ private:
 
   void             storeHit(CaloG4Hit*);
   bool             saveHit(CaloG4Hit*);
-  void             summarize();
   void             cleanHitCollection();
 
 protected:

--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -49,7 +49,7 @@ class CaloSD : public SensitiveCaloDetector,
 
 public:    
   
-  CaloSD(G4String  aSDname, const DDCompactView & cpv,
+  CaloSD(std::string aSDname, const DDCompactView & cpv,
          const SensitiveDetectorCatalog & clg,
          edm::ParameterSet const & p, const SimTrackManager*,
 	 float timeSlice=1., bool ignoreTkID=false);
@@ -65,7 +65,7 @@ public:
   virtual void     DrawAll();
   virtual void     PrintAll();
 
-  void             fillHits(edm::PCaloHitContainer&,std::string n);
+  void             fillHits(edm::PCaloHitContainer&, std::string&);
 
 protected:
 
@@ -116,7 +116,7 @@ protected:
 
   CaloHitID                       currentID, previousID; 
   G4Track*                        theTrack;
-  G4TouchableHistory*             theTouchableHistory;
+  G4LogicalVolume*                theLogicalVolume;
 
   G4StepPoint*                    preStepPoint; 
   float                           edepositEM, edepositHAD;

--- a/SimG4CMS/Calo/interface/ECalSD.h
+++ b/SimG4CMS/Calo/interface/ECalSD.h
@@ -33,14 +33,14 @@ public:
 
   ECalSD(std::string, const DDCompactView &, const SensitiveDetectorCatalog &,
 	 edm::ParameterSet const & p, const SimTrackManager*);
-  virtual ~ECalSD();
-  virtual double                    getEnergyDeposit(G4Step*);
+  ~ECalSD() override;
+  double                    getEnergyDeposit(G4Step*) override;
   virtual uint16_t                  getRadiationLength(G4Step *);
   virtual uint16_t                  getLayerIDForTimeSim(G4Step *);
-  virtual uint32_t                  setDetUnitId(G4Step*);
+  uint32_t                  setDetUnitId(G4Step*) override ;
   void                              setNumberingScheme(EcalNumberingScheme*);
-  virtual int                       getTrackID(G4Track*);
-  virtual uint16_t                  getDepth(G4Step*);
+  int                       getTrackID(G4Track*) override;
+  uint16_t                  getDepth(G4Step*) override;
 
 private:    
   void                              initMap(const G4String&, const DDCompactView &);

--- a/SimG4CMS/Calo/interface/ECalSD.h
+++ b/SimG4CMS/Calo/interface/ECalSD.h
@@ -31,7 +31,7 @@ class ECalSD : public CaloSD {
 
 public:    
 
-  ECalSD(std::string, const DDCompactView &, const SensitiveDetectorCatalog &,
+  ECalSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	 edm::ParameterSet const & p, const SimTrackManager*);
   ~ECalSD() override;
   double                    getEnergyDeposit(G4Step*) override;

--- a/SimG4CMS/Calo/interface/ECalSD.h
+++ b/SimG4CMS/Calo/interface/ECalSD.h
@@ -31,7 +31,7 @@ class ECalSD : public CaloSD {
 
 public:    
 
-  ECalSD(G4String, const DDCompactView &, const SensitiveDetectorCatalog &,
+  ECalSD(std::string, const DDCompactView &, const SensitiveDetectorCatalog &,
 	 edm::ParameterSet const & p, const SimTrackManager*);
   virtual ~ECalSD();
   virtual double                    getEnergyDeposit(G4Step*);
@@ -43,12 +43,12 @@ public:
   virtual uint16_t                  getDepth(G4Step*);
 
 private:    
-  void                              initMap(G4String, const DDCompactView &);
-  double                            curve_LY(G4Step*); 
-  double                            crystalLength(G4LogicalVolume*);
-  double                            crystalDepth(G4LogicalVolume*, const G4ThreeVector&);
+  void                              initMap(const G4String&, const DDCompactView &);
+  double                            curve_LY(); 
+  double                            crystalLength();
+  double                            crystalDepth();
   void                              getBaseNumber(const G4Step*); 
-  double                            getBirkL3(G4Step*);
+  double                            getBirkL3(const G4Step*);
   std::vector<double>               getDDDArray(const std::string&,
 						const DDsvalues_type&);
   std::vector<std::string>          getStringArray(const std::string&,
@@ -66,6 +66,7 @@ private:
   EcalBaseNumber                    theBaseNumber;
   EnergyResolutionVsLumi            ageing;
   bool                              ageingWithSlopeLY;
+  G4ThreeVector                     localPoint;
 #ifdef plotDebug
   TH2F                             *g2L_[4];
 #endif

--- a/SimG4CMS/Calo/interface/EnergyResolutionVsLumi.h
+++ b/SimG4CMS/Calo/interface/EnergyResolutionVsLumi.h
@@ -7,10 +7,10 @@
 #include <string>
 #include <map>
 
-#include <time.h>
-#include <stdio.h>
+#include <ctime>
+#include <cstdio>
 
-#include <math.h>
+#include <cmath>
 
 #include "SimG4CMS/Calo/interface/EvolutionECAL.h"
 #include "DataFormats/DetId/interface/DetId.h"

--- a/SimG4CMS/Calo/interface/EvolutionECAL.h
+++ b/SimG4CMS/Calo/interface/EvolutionECAL.h
@@ -7,10 +7,10 @@
 #include <string>
 #include <map>
 
-#include <time.h>
-#include <stdio.h>
+#include <ctime>
+#include <cstdio>
 
-#include <math.h>
+#include <cmath>
 #include "TF1.h"
 #include "TH1F.h"
 #include "TMath.h"

--- a/SimG4CMS/Calo/interface/HCalSD.h
+++ b/SimG4CMS/Calo/interface/HCalSD.h
@@ -39,17 +39,17 @@ public:
 
   HCalSD(std::string , const DDCompactView &, const SensitiveDetectorCatalog &,
          edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~HCalSD();
-  virtual bool                  ProcessHits(G4Step * , G4TouchableHistory * );
-  virtual double                getEnergyDeposit(G4Step* );
-  virtual uint32_t              setDetUnitId(G4Step* step);
+  ~HCalSD() override;
+  bool                  ProcessHits(G4Step * , G4TouchableHistory * ) override;
+  double                getEnergyDeposit(G4Step* ) override;
+  uint32_t              setDetUnitId(G4Step* step) override ;
   void                          setNumberingScheme(HcalNumberingScheme* );
 
 protected:
 
-  virtual void                  update(const BeginOfJob *);
-  virtual void                  initRun();
-  virtual bool                  filterHit(CaloG4Hit*, double);
+  void                  update(const BeginOfJob *) override;
+  void                  initRun() override;
+  bool                  filterHit(CaloG4Hit*, double) override;
 
 private:    
 

--- a/SimG4CMS/Calo/interface/HCalSD.h
+++ b/SimG4CMS/Calo/interface/HCalSD.h
@@ -37,7 +37,7 @@ class HCalSD : public CaloSD, public Observer<const BeginOfJob *> {
 
 public:    
 
-  HCalSD(std::string , const DDCompactView &, const SensitiveDetectorCatalog &,
+  HCalSD(const std::string& , const DDCompactView &, const SensitiveDetectorCatalog &,
          edm::ParameterSet const &, const SimTrackManager*);
   ~HCalSD() override;
   bool                  ProcessHits(G4Step * , G4TouchableHistory * ) override;

--- a/SimG4CMS/Calo/interface/HCalSD.h
+++ b/SimG4CMS/Calo/interface/HCalSD.h
@@ -37,7 +37,7 @@ class HCalSD : public CaloSD, public Observer<const BeginOfJob *> {
 
 public:    
 
-  HCalSD(G4String , const DDCompactView &, const SensitiveDetectorCatalog &,
+  HCalSD(std::string , const DDCompactView &, const SensitiveDetectorCatalog &,
          edm::ParameterSet const &, const SimTrackManager*);
   virtual ~HCalSD();
   virtual bool                  ProcessHits(G4Step * , G4TouchableHistory * );
@@ -58,26 +58,26 @@ private:
   std::vector<double>           getDDDArray(const std::string&, 
                                             const DDsvalues_type&);
   std::vector<G4String>         getNames(DDFilteredView&);
-  bool                          isItHF(G4Step *);
-  bool                          isItHF(G4String);
+  bool                          isItHF(const G4Step *);
+  bool                          isItHF(const G4String&);
   bool                          isItFibre(G4LogicalVolume*);
-  bool                          isItFibre(G4String);
+  bool                          isItFibre(const G4String&);
   bool                          isItPMT(G4LogicalVolume*);
   bool                          isItStraightBundle(G4LogicalVolume*);
   bool                          isItConicalBundle(G4LogicalVolume*);
   bool                          isItScintillator(G4Material*);
-  bool                          isItinFidVolume (G4ThreeVector&);
+  bool                          isItinFidVolume (const G4ThreeVector&);
   void                          getFromLibrary(G4Step * step, double weight);
   void                          hitForFibre(G4Step * step, double weight);
   void                          getFromParam(G4Step * step, double weight);
   void                          getHitPMT(G4Step * step);
   void                          getHitFibreBundle(G4Step * step, bool type);
-  int                           setTrackID(G4Step * step);
-  void                          readWeightFromFile(std::string);
+  int                           setTrackID(const G4Step * step);
+  void                          readWeightFromFile(const std::string&);
   double                        layerWeight(int, const G4ThreeVector&, int, int);
-  void                          plotProfile(G4Step* step, const G4ThreeVector& pos, 
+  void                          plotProfile(const G4Step* step, const G4ThreeVector& pos, 
                                             double edep, double time, int id);
-  void                          plotHF(G4ThreeVector& pos, bool emType);
+  void                          plotHF(const G4ThreeVector& pos, bool emType);
   void                          modifyDepth(HcalNumberingFromDDD::HcalID& id);
 
   HcalDDDSimConstants*          hcalConstants;

--- a/SimG4CMS/Calo/interface/HFFibre.h
+++ b/SimG4CMS/Calo/interface/HFFibre.h
@@ -22,7 +22,7 @@ class HFFibre {
 public:
   
   //Constructor and Destructor
-  HFFibre(std::string & name, const DDCompactView & cpv,
+  HFFibre(const std::string & name, const DDCompactView & cpv,
 	  edm::ParameterSet const & p);
   ~HFFibre();
 

--- a/SimG4CMS/Calo/interface/HFShower.h
+++ b/SimG4CMS/Calo/interface/HFShower.h
@@ -23,7 +23,7 @@ class HFShower {
 
 public:    
 
-  HFShower(std::string & name, const DDCompactView & cpv, 
+  HFShower(const std::string & name, const DDCompactView & cpv, 
 	   edm::ParameterSet const & p, int chk=0);
   virtual ~HFShower();
 

--- a/SimG4CMS/Calo/interface/HFShowerFibreBundle.h
+++ b/SimG4CMS/Calo/interface/HFShowerFibreBundle.h
@@ -21,7 +21,7 @@ class HFShowerFibreBundle {
 
 public:    
 
-  HFShowerFibreBundle(std::string & name, const DDCompactView & cpv, 
+  HFShowerFibreBundle(const std::string & name, const DDCompactView & cpv, 
 		      edm::ParameterSet const & p);
   virtual ~HFShowerFibreBundle();
   double                getHits(G4Step * aStep, bool type);

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -31,7 +31,7 @@ class HFShowerLibrary {
 public:
   
   //Constructor and Destructor
-  HFShowerLibrary(std::string & name, const DDCompactView & cpv,
+  HFShowerLibrary(const std::string & name, const DDCompactView & cpv,
 		  edm::ParameterSet const & p);
   ~HFShowerLibrary();
 

--- a/SimG4CMS/Calo/interface/HFShowerPMT.h
+++ b/SimG4CMS/Calo/interface/HFShowerPMT.h
@@ -21,7 +21,7 @@ class HFShowerPMT {
 
 public:    
 
-  HFShowerPMT(std::string & name, const DDCompactView & cpv, 
+  HFShowerPMT(const std::string & name, const DDCompactView & cpv, 
 	      edm::ParameterSet const & p);
   virtual ~HFShowerPMT();
   double                getHits(G4Step * aStep);

--- a/SimG4CMS/Calo/interface/HFShowerParam.h
+++ b/SimG4CMS/Calo/interface/HFShowerParam.h
@@ -28,7 +28,7 @@ class HFShowerParam {
 
 public:    
 
-  HFShowerParam(std::string & name, const DDCompactView & cpv, 
+  HFShowerParam(const std::string & name, const DDCompactView & cpv, 
 		edm::ParameterSet const & p);
   virtual ~HFShowerParam();
 

--- a/SimG4CMS/Calo/interface/HcalNumberingScheme.h
+++ b/SimG4CMS/Calo/interface/HcalNumberingScheme.h
@@ -14,7 +14,7 @@ class HcalNumberingScheme : public CaloNumberingScheme {
 
 public:
   HcalNumberingScheme();
-  virtual ~HcalNumberingScheme();
+  ~HcalNumberingScheme() override;
   virtual uint32_t getUnitID(const HcalNumberingFromDDD::HcalID& id);
 
 };

--- a/SimG4CMS/Calo/interface/HcalTestNumberingScheme.h
+++ b/SimG4CMS/Calo/interface/HcalTestNumberingScheme.h
@@ -12,8 +12,8 @@ class HcalTestNumberingScheme : public HcalNumberingScheme {
 
 public:
   HcalTestNumberingScheme(bool forTB);
-  virtual ~HcalTestNumberingScheme();
-  virtual uint32_t getUnitID(const HcalNumberingFromDDD::HcalID& id);
+  ~HcalTestNumberingScheme() override;
+  uint32_t getUnitID(const HcalNumberingFromDDD::HcalID& id) override;
   static uint32_t  packHcalIndex(int det, int z, int depth, int eta,
                                  int phi, int lay);
   static void      unpackHcalIndex(const uint32_t & idx, int& det, int& z, 

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -374,7 +374,7 @@ CaloG4Hit* CaloSD::createNewHit() {
 #endif  
   
   CaloG4Hit* aHit;
-  if (reusehit.size() > 0) {
+  if (!reusehit.empty()) {
     aHit = reusehit[0];
     aHit->setEM(0.);
     aHit->setHadr(0.);
@@ -413,7 +413,7 @@ CaloG4Hit* CaloSD::createNewHit() {
     edm::LogInfo("CaloSim") << "CaloSD : TrackwithHistory pointer for " 
 			    << currentID.trackID() << " is " << trkh;
 #endif
-    if (trkh != NULL) {
+    if (trkh != nullptr) {
       etrack = sqrt(trkh->momentum().Mag2());
       if (etrack >= energyCut) {
         trkh->save();
@@ -503,7 +503,7 @@ void CaloSD::update(const EndOfTrack * trk) {
   if (trkI) lastTrackID = trkI->getIDonCaloSurface();
   if (id == lastTrackID) {
     const TrackContainer * trksForThisEvent = m_trackManager->trackContainer();
-    if (trksForThisEvent != NULL) {
+    if (trksForThisEvent != nullptr) {
       int it = (int)(trksForThisEvent->size()) - 1;
       if (it >= 0) {
         TrackWithHistory * trkH = (*trksForThisEvent)[it];
@@ -680,7 +680,7 @@ void CaloSD::cleanHitCollection() {
 #endif
   
   selIndex.reserve(theHC->entries()-cleanIndex);
-  if ( reusehit.size() == 0 ) reusehit.reserve(theHC->entries()-cleanIndex); 
+  if ( reusehit.empty() ) reusehit.reserve(theHC->entries()-cleanIndex); 
 
   // if no map used, merge before hits to have the save situation as a map
   if ( !useMap ) {

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -21,7 +21,7 @@
 
 // #define DebugLog
 
-CaloSD::CaloSD(std::string iname, const DDCompactView & cpv,
+CaloSD::CaloSD(const std::string& iname, const DDCompactView & cpv,
         const SensitiveDetectorCatalog & clg,
         edm::ParameterSet const & p, const SimTrackManager* manager,
         float timeSliceUnit, bool ignoreTkID) : 

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -289,14 +289,14 @@ G4ThreeVector CaloSD::setToLocal(const G4ThreeVector& global, const G4VTouchable
 
   G4ThreeVector localPoint = touch->GetHistory()->GetTopTransform().TransformPoint(global);
   
-  return localPoint;  
+  return std::move(localPoint);  
 }
 
 G4ThreeVector CaloSD::setToGlobal(const G4ThreeVector& local, const G4VTouchable* touch) {
 
   G4ThreeVector globalPoint = touch->GetHistory()->GetTopTransform().Inverse().TransformPoint(local);
   
-  return globalPoint;  
+  return std::move(globalPoint);  
 }
 
 G4bool CaloSD::hitExists() {
@@ -538,7 +538,6 @@ void CaloSD::update(const ::EndOfEvent * ) {
                           << " hits recorded with " << wrong 
                           << " track IDs not given properly and "
                           << totalHits-count << " hits not passing cuts";
-  summarize();
 
   tkMap.erase (tkMap.begin(), tkMap.end());
 }
@@ -649,8 +648,6 @@ bool CaloSD::saveHit(CaloG4Hit* aHit) {
 #endif
   return ok;
 }
-
-void CaloSD::summarize() {}
 
 void CaloSD::update(const BeginOfTrack * trk) {
   int primary = -1;

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -21,18 +21,18 @@
 
 // #define DebugLog
 
-CaloSD::CaloSD(G4String name, const DDCompactView & cpv,
+CaloSD::CaloSD(std::string iname, const DDCompactView & cpv,
         const SensitiveDetectorCatalog & clg,
         edm::ParameterSet const & p, const SimTrackManager* manager,
         float timeSliceUnit, bool ignoreTkID) : 
-  SensitiveCaloDetector(name, cpv, clg, p),
-  G4VGFlashSensitiveDetector(), theTrack(nullptr), theTouchableHistory(nullptr),
+  SensitiveCaloDetector(iname, cpv, clg, p),
+  G4VGFlashSensitiveDetector(), theTrack(nullptr), theLogicalVolume(nullptr),
   preStepPoint(nullptr), eminHit(0.0), eminHitD(0.0), m_trackManager(manager), 
   currentHit(nullptr), runInit(false), timeSlice(timeSliceUnit), 
   ignoreTrackID(ignoreTkID), hcID(-1), theHC(nullptr), meanResponse(nullptr) {
 
   //Add Hcal Sentitive Detector Names
-  collectionName.insert(name);
+  collectionName.insert((G4String)iname);
 
   // initialisation
   incidentEnergy = edepositEM = edepositHAD = 0.0f;
@@ -61,7 +61,7 @@ CaloSD::CaloSD(G4String name, const DDCompactView & cpv,
 
   SetVerboseLevel(verbn);
   for (unsigned int k=0; k<hcn.size(); ++k) {
-    if (name == (G4String)(hcn[k])) {
+    if (iname == hcn[k]) {
       if (k < eminHits.size()) eminHit = eminHits[k]*MeV;
       if (k < eminHitX.size()) eminHitD= eminHitX[k]*MeV;
       if (k < tmaxHits.size()) tmaxHit = tmaxHits[k]*ns;
@@ -72,15 +72,11 @@ CaloSD::CaloSD(G4String name, const DDCompactView & cpv,
 #ifdef DebugLog
   LogDebug("CaloSim") << "***************************************************" 
                       << "\n"
-                      << "*                                                 *" 
-                      << "\n"
                       << "* Constructing a CaloSD  with name " << GetName()
-                      << "\n"
-                      << "*                                                 *" 
                       << "\n"
                       << "***************************************************";
 #endif
-  slave      = new CaloSlaveSD(name);
+  slave      = new CaloSlaveSD(iname);
   currentID  = CaloHitID(timeSlice, ignoreTrackID);
   previousID = CaloHitID(timeSlice, ignoreTrackID);
   
@@ -92,7 +88,7 @@ CaloSD::CaloSD(G4String name, const DDCompactView & cpv,
   //
   // Now attach the right detectors (LogicalVolumes) to me
   //
-  const std::vector<std::string>& lvNames = clg.logicalNames(name);
+  const std::vector<std::string>& lvNames = clg.logicalNames(iname);
   this->Register();
   for (std::vector<std::string>::const_iterator it=lvNames.begin(); it !=lvNames.end(); ++it) {
     this->AssignSD(*it);
@@ -121,10 +117,9 @@ CaloSD::~CaloSD() {
   delete meanResponse;
 }
 
-bool CaloSD::ProcessHits(G4Step * aStep, G4TouchableHistory * tHistory) {
+bool CaloSD::ProcessHits(G4Step * aStep, G4TouchableHistory *) {
   
   NaNTrap(aStep);
-  theTouchableHistory = tHistory;
   if(getStepInfo(aStep) && !hitExists() && edepositEM+edepositHAD>0.f) {
     currentHit = createNewHit();
   }
@@ -241,14 +236,15 @@ void CaloSD::PrintAll() {
   theHC->PrintAllHits();
 } 
 
-void CaloSD::fillHits(edm::PCaloHitContainer& c, std::string n) {
-  if (slave->name() == n) c=slave->hits();
+void CaloSD::fillHits(edm::PCaloHitContainer& cont, std::string& hitname) {
+  if (slave->name() == hitname) { cont = slave->hits(); }
   slave->Clean();
 }
 
 bool CaloSD::getStepInfo(G4Step* aStep) {  
 
   preStepPoint = aStep->GetPreStepPoint(); 
+  theLogicalVolume = preStepPoint->GetPhysicalVolume()->GetLogicalVolume();
   theTrack     = aStep->GetTrack();   
   
   unsigned int unitID= setDetUnitId(aStep);

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -38,13 +38,13 @@ bool any(const std::vector<T> & v, const T &what) {
   return std::find(v.begin(), v.end(), what) != v.end();
 }
 
-ECalSD::ECalSD(G4String name, const DDCompactView & cpv,
+ECalSD::ECalSD(std::string name, const DDCompactView & cpv,
 	       const SensitiveDetectorCatalog & clg,
 	       edm::ParameterSet const & p, const SimTrackManager* manager) : 
   CaloSD(name, cpv, clg, p, manager, 
 	 (float)(p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("TimeSliceUnit")),
 	 p.getParameter<edm::ParameterSet>("ECalSD").getParameter<bool>("IgnoreTrackID")), 
-  numberingScheme(0){
+  numberingScheme(0), localPoint(0.,0.,0.) {
 
   //   static SimpleConfigurable<bool>   on1(false,  "ECalSD:UseBirkLaw");
   //   static SimpleConfigurable<double> bk1(0.00463,"ECalSD:BirkC1");
@@ -78,7 +78,6 @@ ECalSD::ECalSD(G4String name, const DDCompactView & cpv,
   if(ageingWithSlopeLY) ageing.setLumies(p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("DelivLuminosity"),
 					 p.getParameter<edm::ParameterSet>("ECalSD").getParameter<double>("InstLuminosity"));
 
-  //Material list for HB/HE/HO sensitive detectors
   std::string attribute = "ReadOutName";
   DDSpecificsMatchesValueFilter filter{DDValue(attribute,name,0)};
   DDFilteredView fv(cpv,filter);
@@ -172,47 +171,47 @@ ECalSD::~ECalSD() {
 
 double ECalSD::getEnergyDeposit(G4Step * aStep) {
   
-  if (aStep == NULL) {
-    return 0;
-  } else {
-    preStepPoint        = aStep->GetPreStepPoint();
-    G4Track* theTrack   = aStep->GetTrack();
-    double wt2  = theTrack->GetWeight();
-    G4String nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
+  double edep = aStep->GetTotalEnergyDeposit();
+  if(edep <= 0.0) { return 0.0; }
 
-    // take into account light collection curve for crystals
-    double weight = 1.;
-    if (suppressHeavy) {
-      TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
-      if (trkInfo) {
-	int pdg = theTrack->GetDefinition()->GetPDGEncoding();
-	if (!(trkInfo->isPrimary())) { // Only secondary particles
-	  double ke = theTrack->GetKineticEnergy()/MeV;
-	  if (((pdg/1000000000 == 1 && ((pdg/10000)%100) > 0 &&
-		((pdg/10)%100) > 0)) && (ke<kmaxIon)) weight = 0;
-	  if ((pdg == 2212) && (ke < kmaxProton))     weight = 0;
-	  if ((pdg == 2112) && (ke < kmaxNeutron))    weight = 0;
+  localPoint = setToLocal(preStepPoint->GetPosition(),
+			  preStepPoint->GetTouchable());
+  double wt2  = theTrack->GetWeight();
+
+  // take into account light collection curve for crystals
+  double weight = 1.;
+  if (suppressHeavy) {
+    TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
+    if (trkInfo) {
+      int pdg = theTrack->GetDefinition()->GetPDGEncoding();
+      if (!(trkInfo->isPrimary())) { // Only secondary particles
+	double ke = theTrack->GetKineticEnergy()/MeV;
+	if (((pdg/1000000000 == 1 && ((pdg/10000)%100) > 0 &&
+	      ((pdg/10)%100) > 0)) && (ke<kmaxIon)) weight = 0;
+	if ((pdg == 2212) && (ke < kmaxProton))     weight = 0;
+	if ((pdg == 2112) && (ke < kmaxNeutron))    weight = 0;
 #ifdef EDM_ML_DEBUG
-	  if (weight == 0) 
-	    edm::LogInfo("EcalSim") << "Ignore Track " << theTrack->GetTrackID()
-				    << " Type " << theTrack->GetDefinition()->GetParticleName()
-				    << " Kinetic Energy " << ke << " MeV";
+	if (weight == 0) 
+	  edm::LogInfo("EcalSim") << "Ignore Track " << theTrack->GetTrackID()
+				  << " Type " << theTrack->GetDefinition()->GetParticleName()
+				  << " Kinetic Energy " << ke << " MeV";
 #endif
-	}
       }
     }
-    G4LogicalVolume* lv   = aStep->GetPreStepPoint()->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-    if (useWeight && !any(noWeight,lv)) {
-      weight *= curve_LY(aStep);
-      if (useBirk) {
-	if (useBirkL3) weight *= getBirkL3(aStep);
-	else           weight *= getAttenuation(aStep, birk1, birk2, birk3);
-      }
+  }
+
+  if (useWeight && !any(noWeight,theLogicalVolume)) {
+    weight *= curve_LY();
+    if (useBirk) {
+      if (useBirkL3) weight *= getBirkL3(aStep);
+      else           weight *= getAttenuation(aStep, birk1, birk2, birk3);
     }
-    double wt1  = getResponseWt(theTrack);
-    double edep = aStep->GetTotalEnergyDeposit()*weight*wt1;
-    /*
+  }
+  double wt1  = getResponseWt(theTrack);
+  edep *= weight*wt1;
+  /*
     if(wt2 != 1.0) { 
+      G4String nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
       edm::LogInfo("EcalSim") << "ECalSD:: " << nameVolume
 			      <<" LightWeight= " <<weight << " wt1= " <<wt1
 			      << "  wt2= " << wt2 << "  "
@@ -231,16 +230,15 @@ double ECalSD::getEnergyDeposit(G4Step * aStep) {
 				<< " Id=" << theTrack->GetTrackID()
 				<< " IdP=" << theTrack->GetParentID();
     }
-    */
-    if(wt2 > 0.0) { edep *= wt2; }
+  */
+  if(wt2 > 0.0) { edep *= wt2; }
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("EcalSim") << "ECalSD:: " << nameVolume
-			    << " Light Collection Efficiency " << weight << ":"
-			    << wt1 << " Weighted Energy Deposit " << edep/MeV 
-			    << " MeV";
+  edm::LogInfo("EcalSim") << "ECalSD:: " << preStepPoint->GetPhysicalVolume()->GetName()
+			  << " Light Collection Efficiency " << weight << ":"
+			  << wt1 << " Weighted Energy Deposit " << edep/MeV 
+			  << " MeV";
 #endif
-    return edep;
-  } 
+  return edep;
 }
 
 int ECalSD::getTrackID(G4Track* aTrack) {
@@ -248,10 +246,9 @@ int ECalSD::getTrackID(G4Track* aTrack) {
   int  primaryID(0);
   bool flag(false);
   if (storeTrack) {
-    G4LogicalVolume* lv  = preStepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-    if (any(useDepth1,lv)) {
+    if (any(useDepth1,theLogicalVolume)) {
       flag = true;
-    } else if (any(useDepth2,lv)) {
+    } else if (any(useDepth2,theLogicalVolume)) {
       flag = true;
     }
   }
@@ -265,10 +262,10 @@ int ECalSD::getTrackID(G4Track* aTrack) {
 }
 
 uint16_t ECalSD::getDepth(G4Step * aStep) {
-  G4LogicalVolume* lv   = aStep->GetPreStepPoint()->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-  uint16_t depth  = any(useDepth1,lv) ? 1 : (any(useDepth2,lv) ? 2 : 0);
+
+  uint16_t depth  = any(useDepth1,theLogicalVolume) ? 1 : (any(useDepth2,theLogicalVolume) ? 2 : 0);
   if (storeRL) {
-    auto ite        = xtalLMap.find(lv);
+    auto ite        = xtalLMap.find(theLogicalVolume);
     uint16_t depth1 = (ite == xtalLMap.end()) ? 0 : (((ite->second) >= 0) ? 0 :
 						     PCaloHit::kEcalDepthRefz);
     uint16_t depth2 = getRadiationLength(aStep);
@@ -288,60 +285,46 @@ uint16_t ECalSD::getDepth(G4Step * aStep) {
 uint16_t ECalSD::getRadiationLength(G4Step * aStep) {
   
   uint16_t thisX0 = 0;
-  if (aStep != NULL) {
-    G4StepPoint* hitPoint = aStep->GetPreStepPoint();
-    G4LogicalVolume* lv   = hitPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("EcalSim") << lv->GetName() << " useWight " << useWeight;
+  edm::LogInfo("EcalSim") << theLogicalVolume->GetName() << " useWight " << useWeight;
 #endif
-    if (useWeight) {
-      G4ThreeVector  localPoint = setToLocal(hitPoint->GetPosition(),
-					     hitPoint->GetTouchable());
-      double radl     = hitPoint->GetMaterial()->GetRadlen();
-      double depth    = crystalDepth(lv,localPoint);
-      thisX0 = (uint16_t)floor(scaleRL*depth/radl);
+  if (useWeight) {
+    posGlobal = preStepPoint->GetPosition();
+    double radl = preStepPoint->GetMaterial()->GetRadlen();
+    double depth  = crystalDepth();
+    thisX0 = (uint16_t)floor(scaleRL*depth/radl);
 #ifdef plotDebug
-      std::string lvname = lv->GetName();
-      int k1 = (lvname.find("EFRY")!=std::string::npos) ? 2 : 0;
-      int k2 = (lvname.find("refl")!=std::string::npos) ? 1 : 0;
-      int kk = k1+k2;
-      double rz = (k1 == 0) ? (hitPoint->GetPosition()).rho() : 
-	std::abs((hitPoint->GetPosition()).z());
-      edm::LogVerbatim("EcalSim") << lvname << " # " << k1 << ":" << k2 << ":" 
-				  << kk << " rz " << rz << " D " << thisX0;
-      g2L_[kk]->Fill(rz,thisX0);
+    std::string lvname = theLogicalVolume->GetName();
+    int k1 = (lvname.find("EFRY")!=std::string::npos) ? 2 : 0;
+    int k2 = (lvname.find("refl")!=std::string::npos) ? 1 : 0;
+    int kk = k1+k2;
+    double rz = (k1 == 0) ? posGlobal.rho() : std::abs(posGlobal.z());
+    edm::LogVerbatim("EcalSim") << lvname << " # " << k1 << ":" << k2 << ":" 
+				<< kk << " rz " << rz << " D " << thisX0;
+    g2L_[kk]->Fill(rz,thisX0);
 #endif
 #ifdef EDM_ML_DEBUG
-      double crlength = crystalLength(lv);
-      edm::LogVerbatim("EcalSim") << lv->GetName() << " Global " 
-				  << hitPoint->GetPosition() << ":" 
-				  << (hitPoint->GetPosition()).rho() 
-				  << " Local " << localPoint 
-				  << " Crystal Length " << crlength 
-				  << " Radl " << radl << " DetZ " << detz 
-				  << " Index " << thisX0 
-				  << " : " << getLayerIDForTimeSim(aStep);
+    double crlength = crystalLength();
+    edm::LogVerbatim("EcalSim") << theLogicalVolume->GetName() << " Global " 
+				<< posGlobal << ":" << posGlobal.rho() 
+				<< " Local " << localPoint 
+				<< " Crystal Length " << crlength 
+				<< " Radl " << radl << " DetZ " << detz 
+				<< " Index " << thisX0 
+				<< " : " << getLayerIDForTimeSim(aStep);
 #endif
-    } 
   }
   return thisX0;
 }
 
 uint16_t ECalSD::getLayerIDForTimeSim(G4Step * aStep) 
 {
-  float    layerSize = 1*cm; //layer size in cm
+  const float layerSize = (float)(1*cm); //layer size in cm
   if (!isEB && !isEE)  return 0;
 
-  if (aStep != NULL ) {
-    G4StepPoint* hitPoint = aStep->GetPreStepPoint();
-    G4LogicalVolume* lv   = hitPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-    G4ThreeVector  localPoint = setToLocal(hitPoint->GetPosition(),
-					   hitPoint->GetTouchable());
-    double detz     = crystalDepth(lv,localPoint);
-    if (detz<0) detz= 0;
-    return (int)detz/layerSize;
-  }
-  return 0;
+  double detz = crystalDepth();
+  detz = std::max(detz, 0.0);
+  return (int)detz/layerSize;
 }
 
 uint32_t ECalSD::setDetUnitId(G4Step * aStep) { 
@@ -363,7 +346,7 @@ void ECalSD::setNumberingScheme(EcalNumberingScheme* scheme) {
 }
 
 
-void ECalSD::initMap(G4String sd, const DDCompactView & cpv) {
+void ECalSD::initMap(const G4String& sd, const DDCompactView & cpv) {
 
   G4String attribute = "ReadOutName";
   DDSpecificsMatchesValueFilter filter{DDValue(attribute,sd,0)};
@@ -482,17 +465,11 @@ void ECalSD::initMap(G4String sd, const DDCompactView & cpv) {
 #endif
 }
 
-double ECalSD::curve_LY(G4Step* aStep) {
-
-  G4StepPoint*     stepPoint = aStep->GetPreStepPoint();
-  G4LogicalVolume* lv        = stepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
+double ECalSD::curve_LY() {
 
   double weight = 1.;
-  G4ThreeVector  localPoint = setToLocal(stepPoint->GetPosition(),
-					 stepPoint->GetTouchable());
-
-  double crlength = crystalLength(lv);
-  double depth    = crystalDepth(lv,localPoint);
+  double crlength = crystalLength();
+  double depth    = crystalDepth();
 
   if (ageingWithSlopeLY) {
     //position along the crystal in mm from 0 to 230 (in EB)
@@ -506,7 +483,7 @@ double ECalSD::curve_LY(G4Step* aStep) {
     } else {
       edm::LogWarning("EcalSim") << "ECalSD: light coll curve : wrong distance "
 				 << "to APD " << dapd << " crlength = " 
-				 << crlength <<" crystal name = " <<lv->GetName()
+				 << crlength <<" crystal name = " <<theLogicalVolume->GetName()
 				 << " z of localPoint = " << localPoint.z() 
 				 << " take weight = " << weight;
     }
@@ -514,20 +491,18 @@ double ECalSD::curve_LY(G4Step* aStep) {
   return weight;
 }
 
-double ECalSD::crystalLength(G4LogicalVolume* lv) {
+double ECalSD::crystalLength() {
 
-  auto ite = xtalLMap.find(lv);
+  auto ite = xtalLMap.find(theLogicalVolume);
   double length = (ite == xtalLMap.end()) ? 230.0 : std::abs(ite->second);
   return length;
 }
 
-double ECalSD::crystalDepth(G4LogicalVolume* lv, 
-			    const G4ThreeVector& localPoint) {
+double ECalSD::crystalDepth() {
 
-  auto ite = xtalLMap.find(lv);
+  auto ite = xtalLMap.find(theLogicalVolume);
   double depth = (ite == xtalLMap.end()) ? 0 :
     (std::abs(0.5*(ite->second)+localPoint.z()));
-//  (0.5*std::abs(ite->second)+localPoint.z());
   return depth;
 }
 
@@ -551,18 +526,18 @@ void ECalSD::getBaseNumber(const G4Step* aStep) {
 
 }
 
-double ECalSD::getBirkL3(G4Step* aStep) {
+double ECalSD::getBirkL3(const G4Step* aStep) {
 
   double weight = 1.;
-  double charge = aStep->GetPreStepPoint()->GetCharge();
+  double charge = preStepPoint->GetCharge();
 
   if (charge != 0. && aStep->GetStepLength() > 0) {
-    G4Material* mat = aStep->GetPreStepPoint()->GetMaterial();
+    G4Material* mat = preStepPoint->GetMaterial();
     double density = mat->GetDensity();
     double dedx    = aStep->GetTotalEnergyDeposit()/aStep->GetStepLength();
     double rkb     = birk1/density;
     if (dedx > 0) {
-      weight         = 1. - birkSlope*log(rkb*dedx);
+      weight = 1. - birkSlope*std::log(rkb*dedx);
       if (weight < birkCut) weight = birkCut;
       else if (weight > 1.) weight = 1.;
     }

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -38,7 +38,7 @@ bool any(const std::vector<T> & v, const T &what) {
   return std::find(v.begin(), v.end(), what) != v.end();
 }
 
-ECalSD::ECalSD(std::string name, const DDCompactView & cpv,
+ECalSD::ECalSD(const std::string& name, const DDCompactView & cpv,
 	       const SensitiveDetectorCatalog & clg,
 	       edm::ParameterSet const & p, const SimTrackManager* manager) : 
   CaloSD(name, cpv, clg, p, manager, 

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -47,9 +47,9 @@ HCalSD::HCalSD(std::string name, const DDCompactView & cpv,
   CaloSD(name, cpv, clg, p, manager,
          (float)(p.getParameter<edm::ParameterSet>("HCalSD").getParameter<double>("TimeSliceUnit")),
          p.getParameter<edm::ParameterSet>("HCalSD").getParameter<bool>("IgnoreTrackID")), 
-  hcalConstants(0), numberingFromDDD(0), numberingScheme(0), showerLibrary(0), 
-  hfshower(0), showerParam(0), showerPMT(0), showerBundle(0), m_HBDarkening(nullptr), m_HEDarkening(nullptr),
-  m_HFDarkening(nullptr), hcalTestNS_(0), depth_(1) {
+  hcalConstants(nullptr), numberingFromDDD(nullptr), numberingScheme(nullptr), showerLibrary(nullptr), 
+  hfshower(nullptr), showerParam(nullptr), showerPMT(nullptr), showerBundle(nullptr), m_HBDarkening(nullptr), m_HEDarkening(nullptr),
+  m_HFDarkening(nullptr), hcalTestNS_(nullptr), depth_(1) {
 
   //static SimpleConfigurable<double> bk1(0.013, "HCalSD:BirkC1");
   //static SimpleConfigurable<double> bk2(0.0568,"HCalSD:BirkC2");
@@ -147,7 +147,7 @@ HCalSD::HCalSD(std::string name, const DDCompactView & cpv,
 			    << " elements";
     for (unsigned int i=0; i < hfNames.size(); ++i) {
       G4String namv = hfNames[i];
-      lv            = 0;
+      lv            = nullptr;
       for(lvcite=lvs->begin(); lvcite!=lvs->end(); lvcite++) 
 	if((*lvcite)->GetName()==namv) {
 	  lv = (*lvcite);
@@ -170,7 +170,7 @@ HCalSD::HCalSD(std::string name, const DDCompactView & cpv,
                             << " = " << value << ":";
     for (unsigned int i=0; i<fibreNames.size(); ++i) {
       G4String namv = fibreNames[i];
-      lv            = 0;
+      lv            = nullptr;
       for (lvcite = lvs->begin(); lvcite != lvs->end(); ++lvcite) {
         if ((*lvcite)->GetName() == namv) {
           lv = (*lvcite);
@@ -192,7 +192,7 @@ HCalSD::HCalSD(std::string name, const DDCompactView & cpv,
 			    << " entries";
     for (unsigned int i=0; i<pmtNames.size(); ++i)  {
       G4String namv = pmtNames[i];
-      lv            = 0;
+      lv            = nullptr;
       for (lvcite = lvs->begin(); lvcite != lvs->end(); ++lvcite) 
         if ((*lvcite)->GetName() == namv) {
 	  lv = (*lvcite);
@@ -202,7 +202,7 @@ HCalSD::HCalSD(std::string name, const DDCompactView & cpv,
       edm::LogInfo("HcalSim") << "HCalSD:  (" << i << ") " << pmtNames[i]
                               << " LV " << pmtLV[i];
     }
-    if (pmtNames.size() > 0) showerPMT = new HFShowerPMT (name, cpv, p);
+    if (!pmtNames.empty()) showerPMT = new HFShowerPMT (name, cpv, p);
   
     // HF Fibre bundles
     value     = "HFFibreBundleStraight";
@@ -214,7 +214,7 @@ HCalSD::HCalSD(std::string name, const DDCompactView & cpv,
                             << " entries";
     for (unsigned int i=0; i<fibreNames.size(); ++i) {
       G4String namv = fibreNames[i];
-      lv            = 0;
+      lv            = nullptr;
       for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++) 
         if ((*lvcite)->GetName() == namv) {
 	  lv = (*lvcite);
@@ -235,7 +235,7 @@ HCalSD::HCalSD(std::string name, const DDCompactView & cpv,
 			    << " entries";
     for (unsigned int i=0; i<fibreNames.size(); ++i) {
       G4String namv = fibreNames[i];
-      lv            = 0;
+      lv            = nullptr;
       for (lvcite = lvs->begin(); lvcite != lvs->end(); ++lvcite) 
 	if ((*lvcite)->GetName() == namv) {
 	  lv = (*lvcite);
@@ -245,7 +245,7 @@ HCalSD::HCalSD(std::string name, const DDCompactView & cpv,
       edm::LogInfo("HcalSim") << "HCalSD:  (" << i << ") " << fibreNames[i]
                               << " LV " << fibre2LV[i];
     }
-    if (fibre1LV.size() > 0 || fibre2LV.size() > 0) 
+    if (!fibre1LV.empty() || !fibre2LV.empty()) 
       showerBundle = new HFShowerFibreBundle (name, cpv, p);
   }
 
@@ -295,8 +295,8 @@ HCalSD::HCalSD(std::string name, const DDCompactView & cpv,
   
   if (useLayerWt) readWeightFromFile(file);
 
-  for (int i=0;  i<9; ++i) hit_[i] = time_[i]= dist_[i] = 0;
-  hzvem = hzvhad = 0;
+  for (int i=0;  i<9; ++i) hit_[i] = time_[i]= dist_[i] = nullptr;
+  hzvem = hzvhad = nullptr;
 
   if (agingFlagHF) m_HFDarkening.reset(new HFDarkening(m_HC.getParameter<edm::ParameterSet>("HFDarkeningParameterBlock")));
 #ifdef plotDebug
@@ -544,7 +544,7 @@ uint32_t HCalSD::setDetUnitId(G4Step * aStep) {
 
   G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();
-  G4ThreeVector hitPoint    = preStepPoint->GetPosition();
+  const G4ThreeVector& hitPoint    = preStepPoint->GetPosition();
 
   int depth = (touch->GetReplicaNumber(0))%10 + 1;
   int lay   = (touch->GetReplicaNumber(0)/10)%100 + 1;
@@ -554,7 +554,7 @@ uint32_t HCalSD::setDetUnitId(G4Step * aStep) {
 }
 
 void HCalSD::setNumberingScheme(HcalNumberingScheme * scheme) {
-  if (scheme != 0) {
+  if (scheme != nullptr) {
     edm::LogInfo("HcalSim") << "HCalSD: updates numbering scheme for " << GetName();
     if (numberingScheme) delete numberingScheme;
     numberingScheme = scheme;
@@ -862,7 +862,7 @@ void HCalSD::hitForFibre (G4Step* aStep, double weight) { // if not ParamShower
 			  << " of " << preStepPoint->GetKineticEnergy()/GeV 
 			  << " GeV in detector type " << det;
 #endif
-  if (hits.size() > 0) {
+  if (!hits.empty()) {
     for (unsigned int i=0; i<hits.size(); ++i) {
       G4ThreeVector hitPoint = hits[i].position;
       if (isItinFidVolume (hitPoint)) {
@@ -1161,24 +1161,24 @@ void HCalSD::plotProfile(const G4Step* aStep,const G4ThreeVector& global, double
                       << " Local " << local << " depth " << depth << " ID " 
 		      << id << " EDEP " << edep << " Time " << time;
 #endif
-  if (hit_[idx]  != 0) hit_[idx]->Fill(edep);
-  if (time_[idx] != 0) time_[idx]->Fill(time,edep);
-  if (dist_[idx] != 0) dist_[idx]->Fill(depth,edep);
+  if (hit_[idx]  != nullptr) hit_[idx]->Fill(edep);
+  if (time_[idx] != nullptr) time_[idx]->Fill(time,edep);
+  if (dist_[idx] != nullptr) dist_[idx]->Fill(depth,edep);
   int jd = 2*idx + id - 7;
   if (jd >= 0 && jd < 4) {
     jd += 5;
-    if (hit_[jd]  != 0) hit_[jd]->Fill(edep);
-    if (time_[jd] != 0) time_[jd]->Fill(time,edep);
-    if (dist_[jd] != 0) dist_[jd]->Fill(depth,edep);
+    if (hit_[jd]  != nullptr) hit_[jd]->Fill(edep);
+    if (time_[jd] != nullptr) time_[jd]->Fill(time,edep);
+    if (dist_[jd] != nullptr) dist_[jd]->Fill(depth,edep);
   }
 }
 
 void HCalSD::plotHF(const G4ThreeVector& hitPoint, bool emType) {
   double zv  = std::abs(hitPoint.z()) - gpar[4];
   if (emType) {
-    if (hzvem  != 0) hzvem->Fill(zv);
+    if (hzvem  != nullptr) hzvem->Fill(zv);
   } else {
-    if (hzvhad != 0) hzvhad->Fill(zv);
+    if (hzvhad != nullptr) hzvhad->Fill(zv);
   }
 }
 

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -41,7 +41,7 @@
 //#define EDM_ML_DEBUG
 //#define plotDebug
 
-HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
+HCalSD::HCalSD(std::string name, const DDCompactView & cpv,
                const SensitiveDetectorCatalog & clg,
                edm::ParameterSet const & p, const SimTrackManager* manager) : 
   CaloSD(name, cpv, clg, p, manager,
@@ -87,11 +87,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
 #ifdef EDM_ML_DEBUG
   LogDebug("HcalSim") << "***************************************************" 
                       << "\n"
-                      << "*                                                 *"
-                      << "\n"
                       << "* Constructing a HCalSD  with name " << name << "\n"
-                      << "*                                                 *"
-                      << "\n"
                       << "***************************************************";
 #endif
   edm::LogInfo("HcalSim") << "HCalSD:: Use of HF code is set to " << useHF
@@ -358,109 +354,106 @@ bool HCalSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 
   NaNTrap( aStep ) ;
   
-  if (aStep == NULL) {
-    return true;
-  } else {
-    depth_ = (aStep->GetPreStepPoint()->GetTouchable()->GetReplicaNumber(0))%10;
-    G4LogicalVolume* lv =
-      aStep->GetPreStepPoint()->GetPhysicalVolume()->GetLogicalVolume();
-    G4String nameVolume = lv->GetName();
-    if (isItHF(aStep)) {
-      G4int parCode = aStep->GetTrack()->GetDefinition()->GetPDGEncoding();
-      double weight(1.0);
-      if (m_HFDarkening) {
-	G4ThreeVector hitPoint = aStep->GetPreStepPoint()->GetPosition();
-	double r = hitPoint.perp()/CLHEP::cm;
-	double z = std::abs(hitPoint.z())/CLHEP::cm;
-	double dose_acquired = 0.;
-  if (z>=HFDarkening::lowZLimit && z <= HFDarkening::upperZLimit) {
-    unsigned int hfZLayer = (int)((z - HFDarkening::lowZLimit)/5);
-    if (hfZLayer >= HFDarkening::upperZLimit) hfZLayer = (HFDarkening::upperZLimit-1);
-	  float normalized_lumi = m_HFDarkening->int_lumi(deliveredLumi);
-    for (int i = hfZLayer; i != HFDarkening::numberOfZLayers; ++i) {
-	    dose_acquired = m_HFDarkening->dose(i,r);
-	    weight *= m_HFDarkening->degradation(normalized_lumi*dose_acquired);
-	  }
+  depth_ = (aStep->GetPreStepPoint()->GetTouchable()->GetReplicaNumber(0))%10;
+  G4LogicalVolume* lv =
+    aStep->GetPreStepPoint()->GetPhysicalVolume()->GetLogicalVolume();
+  G4String nameVolume = lv->GetName();
+  if (isItHF(aStep)) {
+    G4int parCode = aStep->GetTrack()->GetDefinition()->GetPDGEncoding();
+    double weight(1.0);
+    if (m_HFDarkening) {
+      G4ThreeVector hitPoint = aStep->GetPreStepPoint()->GetPosition();
+      double r = hitPoint.perp()/CLHEP::cm;
+      double z = std::abs(hitPoint.z())/CLHEP::cm;
+      double dose_acquired = 0.;
+      if (z>=HFDarkening::lowZLimit && z <= HFDarkening::upperZLimit) {
+	unsigned int hfZLayer = (int)((z - HFDarkening::lowZLimit)/5);
+	if (hfZLayer >= HFDarkening::upperZLimit) hfZLayer = (HFDarkening::upperZLimit-1);
+	float normalized_lumi = m_HFDarkening->int_lumi(deliveredLumi);
+	for (int i = hfZLayer; i != HFDarkening::numberOfZLayers; ++i) {
+	  dose_acquired = m_HFDarkening->dose(i,r);
+	  weight *= m_HFDarkening->degradation(normalized_lumi*dose_acquired);
 	}
-#ifdef EDM_ML_DEBUG
-	LogDebug("HcalSim") << "HCalSD: HFLumiDarkening at r = " << r 
-			    << ", z = " << z << " Dose " << dose_acquired 
-			    << " weight " << weight;
-#endif
       }
-      if (useParam) {
 #ifdef EDM_ML_DEBUG
-        LogDebug("HcalSim") << "HCalSD: " << getNumberOfHits()
-			    << " hits from parametrization in " << nameVolume 
-			    << " for Track " << aStep->GetTrack()->GetTrackID()
-			    <<" (" << aStep->GetTrack()->GetDefinition()->GetParticleName() 
-			    <<")";
+      LogDebug("HcalSim") << "HCalSD: HFLumiDarkening at r = " << r 
+			  << ", z = " << z << " Dose " << dose_acquired 
+			  << " weight " << weight;
 #endif
-        getFromParam(aStep, weight);
+    }
+    if (useParam) {
 #ifdef EDM_ML_DEBUG
-        LogDebug("HcalSim") << "HCalSD: " << getNumberOfHits() 
-			    << " hits afterParamS*";
+      LogDebug("HcalSim") << "HCalSD: " << getNumberOfHits()
+			  << " hits from parametrization in " << nameVolume 
+			  << " for Track " << aStep->GetTrack()->GetTrackID()
+			  <<" (" << aStep->GetTrack()->GetDefinition()->GetParticleName() 
+			  <<")";
+#endif
+      getFromParam(aStep, weight);
+#ifdef EDM_ML_DEBUG
+      LogDebug("HcalSim") << "HCalSD: " << getNumberOfHits() 
+			  << " hits afterParamS*";
 #endif 
-      } else {
-        bool notaMuon = true;
-        if (parCode == mupPDG || parCode == mumPDG ) notaMuon = false;
-        if (useShowerLibrary && notaMuon) {
-#ifdef EDM_ML_DEBUG
-          LogDebug("HcalSim") << "HCalSD: Starts shower library from " 
-                              << nameVolume << " for Track " 
-                              << aStep->GetTrack()->GetTrackID() << " ("
-                              << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
-#endif
-          getFromLibrary(aStep, weight);
-        } else if (isItFibre(lv)) {
-#ifdef EDM_ML_DEBUG
-          LogDebug("HcalSim") << "HCalSD: Hit at Fibre in " << nameVolume 
-                              << " for Track " 
-                              << aStep->GetTrack()->GetTrackID() <<" ("
-                              << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
-#endif
-          hitForFibre(aStep, weight);
-        }
-      }
-    } else if (isItPMT(lv)) {
-#ifdef EDM_ML_DEBUG
-      LogDebug("HcalSim") << "HCalSD: Hit from PMT parametrization from " 
-                          <<  nameVolume << " for Track " 
-                          << aStep->GetTrack()->GetTrackID() << " ("
-                          << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
-#endif
-      if (usePMTHit && showerPMT) getHitPMT(aStep);
-    } else if (isItStraightBundle(lv) || isItConicalBundle(lv)) {
-#ifdef EDM_ML_DEBUG
-      LogDebug("HcalSim") << "HCalSD: Hit from FibreBundle from "
-                          << nameVolume << " for Track " 
-                          << aStep->GetTrack()->GetTrackID() << " ("
-                          << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
-#endif
-      if (useFibreBundle && showerBundle) 
-	getHitFibreBundle(aStep, isItConicalBundle(lv));
     } else {
+      bool notaMuon = true;
+      if (parCode == mupPDG || parCode == mumPDG ) notaMuon = false;
+      if (useShowerLibrary && notaMuon) {
 #ifdef EDM_ML_DEBUG
-      LogDebug("HcalSim") << "HCalSD: Hit from standard path from " 
-                          <<  nameVolume << " for Track " 
-                          << aStep->GetTrack()->GetTrackID() << " ("
-                          << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
+	LogDebug("HcalSim") << "HCalSD: Starts shower library from " 
+			    << nameVolume << " for Track " 
+			    << aStep->GetTrack()->GetTrackID() << " ("
+			    << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
 #endif
-      if (getStepInfo(aStep)) {
-#ifdef plotDebug
-        if (edepositEM+edepositHAD > 0)
-          plotProfile(aStep, aStep->GetPreStepPoint()->GetPosition(),
-                      edepositEM+edepositHAD,aStep->GetPostStepPoint()->GetGlobalTime(),0);
+	getFromLibrary(aStep, weight);
+      } else if (isItFibre(lv)) {
+#ifdef EDM_ML_DEBUG
+	LogDebug("HcalSim") << "HCalSD: Hit at Fibre in " << nameVolume 
+			    << " for Track " 
+			    << aStep->GetTrack()->GetTrackID() <<" ("
+			    << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
 #endif
-        if (hitExists() == false && edepositEM+edepositHAD>0.) currentHit = createNewHit();
+	hitForFibre(aStep, weight);
       }
     }
-    return true;
+  } else if (isItPMT(lv)) {
+#ifdef EDM_ML_DEBUG
+    LogDebug("HcalSim") << "HCalSD: Hit from PMT parametrization from " 
+			<<  nameVolume << " for Track " 
+			<< aStep->GetTrack()->GetTrackID() << " ("
+			<< aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
+#endif
+    if (usePMTHit && showerPMT) getHitPMT(aStep);
+  } else if (isItStraightBundle(lv) || isItConicalBundle(lv)) {
+#ifdef EDM_ML_DEBUG
+    LogDebug("HcalSim") << "HCalSD: Hit from FibreBundle from "
+			<< nameVolume << " for Track " 
+			<< aStep->GetTrack()->GetTrackID() << " ("
+			<< aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
+#endif
+    if (useFibreBundle && showerBundle) 
+      getHitFibreBundle(aStep, isItConicalBundle(lv));
+  } else {
+#ifdef EDM_ML_DEBUG
+    LogDebug("HcalSim") << "HCalSD: Hit from standard path from " 
+			<<  nameVolume << " for Track " 
+			<< aStep->GetTrack()->GetTrackID() << " ("
+			<< aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
+#endif
+    if (getStepInfo(aStep)) {
+#ifdef plotDebug
+      if (edepositEM+edepositHAD > 0)
+	plotProfile(aStep, aStep->GetPreStepPoint()->GetPosition(),
+		    edepositEM+edepositHAD,aStep->GetPostStepPoint()->GetGlobalTime(),0);
+#endif
+      if (hitExists() == false && edepositEM+edepositHAD>0.) currentHit = createNewHit();
+    }
   }
+  return true;
 } 
 
 double HCalSD::getEnergyDeposit(G4Step* aStep) {
   double destep = aStep->GetTotalEnergyDeposit();
+  if(destep <= 0.0) { return 0.0; }
   double weight = 1;
   G4Track* theTrack = aStep->GetTrack();
 
@@ -542,9 +535,9 @@ double HCalSD::getEnergyDeposit(G4Step* aStep) {
                           << " weight " << weight0 << " " << weight << " " << wt1 
 			  << " " << wt2; 
 #endif
-  double edep = weight*wt1*destep;
-  if (wt2 > 0.0) { edep *= wt2; }
-  return edep;
+  destep *= weight*wt1;
+  if (wt2 > 0.0) { destep *= wt2; }
+  return destep;
 }
 
 uint32_t HCalSD::setDetUnitId(G4Step * aStep) { 
@@ -710,7 +703,7 @@ std::vector<G4String> HCalSD::getNames(DDFilteredView& fv) {
   return tmp;
 }
 
-bool HCalSD::isItHF(G4Step * aStep) {
+bool HCalSD::isItHF(const G4Step * aStep) {
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   int levels = (touch->GetHistoryDepth()) + 1;
   for (unsigned int it=0; it < hfNames.size(); ++it) {
@@ -722,9 +715,9 @@ bool HCalSD::isItHF(G4Step * aStep) {
   return false;
 }
 
-bool HCalSD::isItHF (G4String name) {
+bool HCalSD::isItHF (const G4String& nameV) {
   std::vector<G4String>::const_iterator it = hfNames.begin();
-  for (; it != hfNames.end(); ++it) if (name == *it) return true;
+  for (; it != hfNames.end(); ++it) if (nameV == *it) return true;
   return false;
 }
 
@@ -734,9 +727,9 @@ bool HCalSD::isItFibre (G4LogicalVolume* lv) {
   return false;
 }
 
-bool HCalSD::isItFibre (G4String name) {
+bool HCalSD::isItFibre (const G4String& nameV) {
   std::vector<G4String>::const_iterator it = fibreNames.begin();
-  for (; it != fibreNames.end(); ++it) if (name == *it) return true;
+  for (; it != fibreNames.end(); ++it) if (nameV == *it) return true;
   return false;
 }
 
@@ -764,7 +757,7 @@ bool HCalSD::isItScintillator (G4Material* mat) {
   return false;
 }
 
-bool HCalSD::isItinFidVolume (G4ThreeVector& hitPoint) {
+bool HCalSD::isItinFidVolume (const G4ThreeVector& hitPoint) {
   bool flag = true;
   if (applyFidCut) {
     int npmt = HFFibreFiducial:: PMTNumber(hitPoint);
@@ -1065,7 +1058,7 @@ void HCalSD::getHitFibreBundle (G4Step* aStep, bool type) {
   } // non-zero energy deposit
 }
 
-int HCalSD::setTrackID (G4Step* aStep) {
+int HCalSD::setTrackID (const G4Step* aStep) {
   theTrack     = aStep->GetTrack();
 
   double etrack = preStepPoint->GetKineticEnergy();
@@ -1085,7 +1078,7 @@ int HCalSD::setTrackID (G4Step* aStep) {
   return primaryID;
 }
 
-void HCalSD::readWeightFromFile(std::string fName) {
+void HCalSD::readWeightFromFile(const std::string& fName) {
 
   std::ifstream infile;
   int entry=0;
@@ -1133,7 +1126,7 @@ double HCalSD::layerWeight(int det, const G4ThreeVector& pos, int depth, int lay
   return wt;
 }
 
-void HCalSD::plotProfile(G4Step* aStep,const G4ThreeVector& global, double edep,
+void HCalSD::plotProfile(const G4Step* aStep,const G4ThreeVector& global, double edep,
                          double time, int id) { 
 
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
@@ -1180,7 +1173,7 @@ void HCalSD::plotProfile(G4Step* aStep,const G4ThreeVector& global, double edep,
   }
 }
 
-void HCalSD::plotHF(G4ThreeVector& hitPoint, bool emType) {
+void HCalSD::plotHF(const G4ThreeVector& hitPoint, bool emType) {
   double zv  = std::abs(hitPoint.z()) - gpar[4];
   if (emType) {
     if (hzvem  != 0) hzvem->Fill(zv);

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -41,7 +41,7 @@
 //#define EDM_ML_DEBUG
 //#define plotDebug
 
-HCalSD::HCalSD(std::string name, const DDCompactView & cpv,
+HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
                const SensitiveDetectorCatalog & clg,
                edm::ParameterSet const & p, const SimTrackManager* manager) : 
   CaloSD(name, cpv, clg, p, manager,

--- a/SimG4CMS/Calo/src/HFFibre.cc
+++ b/SimG4CMS/Calo/src/HFFibre.cc
@@ -16,7 +16,7 @@
 
 //#define DebugLog
 
-HFFibre::HFFibre(std::string & name, const DDCompactView & cpv, 
+HFFibre::HFFibre(const std::string & name, const DDCompactView & cpv, 
 		 edm::ParameterSet const & p) {
 
   edm::ParameterSet m_HF = p.getParameter<edm::ParameterSet>("HFShower");

--- a/SimG4CMS/Calo/src/HFShower.cc
+++ b/SimG4CMS/Calo/src/HFShower.cc
@@ -23,9 +23,9 @@
 
 #include<iostream>
 
-HFShower::HFShower(std::string & name, const DDCompactView & cpv, 
-		   edm::ParameterSet const & p, int chk) : cherenkov(0),
-                                                           fibre(0),
+HFShower::HFShower(const std::string & name, const DDCompactView & cpv, 
+		   edm::ParameterSet const & p, int chk) : cherenkov(nullptr),
+                                                           fibre(nullptr),
                                                            chkFibre(chk) {
 
   edm::ParameterSet m_HF = p.getParameter<edm::ParameterSet>("HFShower");
@@ -73,11 +73,11 @@ std::vector<HFShower::Hit> HFShower::getHits(G4Step * aStep, double weight) {
   double dose     = 0.;
   int    npeDose  = 0;
 
-  G4ThreeVector momentumDir = aParticle->GetMomentumDirection();
+  const G4ThreeVector& momentumDir = aParticle->GetMomentumDirection();
   G4ParticleDefinition *particleDef = aTrack->GetDefinition();
      
   G4StepPoint * preStepPoint = aStep->GetPreStepPoint();
-  G4ThreeVector globalPos    = preStepPoint->GetPosition();
+  const G4ThreeVector& globalPos    = preStepPoint->GetPosition();
   G4String      name         = preStepPoint->GetTouchable()->GetSolid(0)->GetName();
   //double        zv           = std::abs(globalPos.z()) - gpar[4] - 0.5*gpar[1];
   double        zv           = std::abs(globalPos.z()) - gpar[4];
@@ -207,11 +207,11 @@ std::vector<HFShower::Hit> HFShower::getHits(G4Step * aStep,
   double dose     = 0.;
   int    npeDose  = 0;
 
-  G4ThreeVector momentumDir = aParticle->GetMomentumDirection();
+  const G4ThreeVector& momentumDir = aParticle->GetMomentumDirection();
   G4ParticleDefinition *particleDef = aTrack->GetDefinition();
      
   G4StepPoint * preStepPoint = aStep->GetPreStepPoint();
-  G4ThreeVector globalPos    = preStepPoint->GetPosition();
+  const G4ThreeVector& globalPos    = preStepPoint->GetPosition();
   G4String      name         = preStepPoint->GetTouchable()->GetSolid(0)->GetName();
   //double        zv           = std::abs(globalPos.z()) - gpar[4] - 0.5*gpar[1];
   //double        zv           = std::abs(globalPos.z()) - gpar[4];
@@ -340,11 +340,11 @@ std::vector<HFShower::Hit> HFShower::getHits(G4Step * aStep, bool forLibrary) {
   double dose     = 0.;
   int    npeDose  = 0;
 
-  G4ThreeVector momentumDir = aParticle->GetMomentumDirection();
+  const G4ThreeVector& momentumDir = aParticle->GetMomentumDirection();
   G4ParticleDefinition *particleDef = aTrack->GetDefinition();
 
   G4StepPoint * preStepPoint = aStep->GetPreStepPoint();
-  G4ThreeVector globalPos    = preStepPoint->GetPosition();
+  const G4ThreeVector& globalPos    = preStepPoint->GetPosition();
   G4String      name         = preStepPoint->GetTouchable()->GetSolid(0)->GetName();
   double        zv           = std::abs(globalPos.z()) - gpar[4] - 0.5*gpar[1];
   G4ThreeVector localPos     = G4ThreeVector(globalPos.x(),globalPos.y(), zv);

--- a/SimG4CMS/Calo/src/HFShowerFibreBundle.cc
+++ b/SimG4CMS/Calo/src/HFShowerFibreBundle.cc
@@ -19,7 +19,7 @@
 
 //#define DebugLog
 
-HFShowerFibreBundle::HFShowerFibreBundle(std::string & name, 
+HFShowerFibreBundle::HFShowerFibreBundle(const std::string & name, 
 					 const DDCompactView & cpv,
 					 edm::ParameterSet const & p) {
 

--- a/SimG4CMS/Calo/src/HFShowerLibrary.cc
+++ b/SimG4CMS/Calo/src/HFShowerLibrary.cc
@@ -21,10 +21,10 @@
 
 //#define DebugLog
 
-HFShowerLibrary::HFShowerLibrary(std::string & name, const DDCompactView & cpv,
-				 edm::ParameterSet const & p) : fibre(0),hf(0),
-								emBranch(0),
-								hadBranch(0),
+HFShowerLibrary::HFShowerLibrary(const std::string & name, const DDCompactView & cpv,
+				 edm::ParameterSet const & p) : fibre(nullptr),hf(nullptr),
+								emBranch(nullptr),
+								hadBranch(nullptr),
 								npe(0) {
   
 
@@ -58,11 +58,11 @@ HFShowerLibrary::HFShowerLibrary(std::string & name, const DDCompactView & cpv,
   }
 
   newForm = (branchEvInfo == "");
-  TTree* event(0);
+  TTree* event(nullptr);
   if (newForm) event = (TTree *) hf ->Get("HFSimHits");
   else         event = (TTree *) hf ->Get("Events");
   if (event) {
-    TBranch *evtInfo(0);
+    TBranch *evtInfo(nullptr);
     if (!newForm) {
       std::string info = branchEvInfo + branchPost;
       evtInfo          = event->GetBranch(info.c_str());
@@ -127,7 +127,7 @@ HFShowerLibrary::HFShowerLibrary(std::string & name, const DDCompactView & cpv,
 HFShowerLibrary::~HFShowerLibrary() {
   if (hf)     hf->Close();
   if (fibre)  delete   fibre;
-  fibre  = 0;
+  fibre  = nullptr;
   if (photo)  delete photo;
 }
 

--- a/SimG4CMS/Calo/src/HFShowerPMT.cc
+++ b/SimG4CMS/Calo/src/HFShowerPMT.cc
@@ -19,8 +19,8 @@
 
 //#define DebugLog
 
-HFShowerPMT::HFShowerPMT(std::string & name, const DDCompactView & cpv,
-			 edm::ParameterSet const & p) : cherenkov(0) {
+HFShowerPMT::HFShowerPMT(const std::string & name, const DDCompactView & cpv,
+			 edm::ParameterSet const & p) : cherenkov(nullptr) {
 
   edm::ParameterSet m_HF  = p.getParameter<edm::ParameterSet>("HFShowerPMT");
   pePerGeV                = m_HF.getParameter<double>("PEPerGeVPMT");

--- a/SimG4CMS/Calo/src/HFShowerParam.cc
+++ b/SimG4CMS/Calo/src/HFShowerParam.cc
@@ -27,9 +27,9 @@
 //#define plotDebug
 //#define mkdebug
 
-HFShowerParam::HFShowerParam(std::string & name, const DDCompactView & cpv,
-                             edm::ParameterSet const & p) : showerLibrary(0), 
-                                                            fibre(0), gflash(0),
+HFShowerParam::HFShowerParam(const std::string & name, const DDCompactView & cpv,
+                             edm::ParameterSet const & p) : showerLibrary(nullptr), 
+                                                            fibre(nullptr), gflash(nullptr),
                                                             fillHisto(false) { 
   edm::ParameterSet m_HF  = p.getParameter<edm::ParameterSet>("HFShower");
   pePerGeV                = m_HF.getParameter<double>("PEPerGeV");
@@ -118,7 +118,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(G4Step * aStep,
 						       double weight) {
   G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
   G4Track *     track    = aStep->GetTrack();   
-  G4ThreeVector hitPoint = preStepPoint->GetPosition();   
+  const G4ThreeVector& hitPoint = preStepPoint->GetPosition();   
   G4int         particleCode = track->GetDefinition()->GetPDGEncoding();
   double        zv = std::abs(hitPoint.z()) - gpar[4] - 0.5*gpar[1];
   G4ThreeVector localPoint = G4ThreeVector(hitPoint.x(),hitPoint.y(),zv);

--- a/SimG4Core/Application/interface/EventAction.h
+++ b/SimG4Core/Application/interface/EventAction.h
@@ -30,10 +30,10 @@ public:
     explicit EventAction(const edm::ParameterSet& ps,
 			 SimRunInterface*, SimTrackManager*,
 			 CMSSteppingVerbose*);
-    virtual ~EventAction();
+    ~EventAction() override;
 
-    virtual void BeginOfEventAction(const G4Event * evt);
-    virtual void EndOfEventAction(const G4Event * evt);
+    void BeginOfEventAction(const G4Event * evt) override;
+    void EndOfEventAction(const G4Event * evt) override;
 
     void abortEvent();
 

--- a/SimG4Core/Notification/interface/Signaler.h
+++ b/SimG4Core/Notification/interface/Signaler.h
@@ -39,7 +39,7 @@ namespace sim_act {
       public:
 	 typedef Observer<const T*>* slot_type; 
 	 Signaler() {}
-	 virtual ~Signaler() {}
+	 ~Signaler() override {}
 	 
 	 // ---------- const member functions ---------------------
 	 void operator()(const T* iSignal) const {
@@ -65,12 +65,12 @@ namespace sim_act {
 	    observers_.push_back(&iObs);
 	 }
 
+	 Signaler(const Signaler&) = delete; // stop default
+	 
+	 const Signaler& operator=(const Signaler&) = delete; // stop default
+	 
       private:
-	 Signaler(const Signaler&); // stop default
-	 
-	 const Signaler& operator=(const Signaler&); // stop default
-	 
-	 void update(const T* iData) {
+	 void update(const T* iData) override {
 	    this->operator()(iData);
 	 }
 	 // ---------- member data --------------------------------

--- a/SimG4Core/Notification/interface/SimG4Exception.h
+++ b/SimG4Core/Notification/interface/SimG4Exception.h
@@ -14,8 +14,8 @@ class SimG4Exception : public std::exception
 {
 public:
     SimG4Exception(const std::string & message) : error_(message) {}
-    virtual ~SimG4Exception() throw() {}
-    virtual const char * what () const throw() { return error_.c_str(); }
+    ~SimG4Exception() throw() override {}
+    const char * what () const throw() override { return error_.c_str(); }
 private:
     std::string error_;    
 };

--- a/SimG4Core/Notification/interface/TrackInformation.h
+++ b/SimG4Core/Notification/interface/TrackInformation.h
@@ -8,7 +8,7 @@
 class TrackInformation : public G4VUserTrackInformation {
 
 public:
-  virtual ~TrackInformation() {}
+  ~TrackInformation() override {}
   inline void * operator new(size_t);
   inline void   operator delete(void * TrackInformation);
 
@@ -58,7 +58,7 @@ public:
   void setCastorHitPID(const int pid) { hasCastorHit_=true; castorHitPID_ = pid; }
   int getCastorHitPID() const { return castorHitPID_; }
 
-  virtual void Print() const;
+  void Print() const override;
 private:
   bool   storeTrack_;    
   bool   isPrimary_;

--- a/SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h
@@ -10,11 +10,11 @@
 class SensitiveCaloDetector : public SensitiveDetector
 {
 public:
-    SensitiveCaloDetector(std::string & iname, const DDCompactView & cpv,
-			  const SensitiveDetectorCatalog & clg,
-			  edm::ParameterSet const & p) :
-      SensitiveDetector(iname,cpv,clg,p) {}
-    virtual void fillHits(edm::PCaloHitContainer &, std::string name = 0) = 0;
+  SensitiveCaloDetector(std::string & iname, const DDCompactView & cpv,
+			const SensitiveDetectorCatalog & clg,
+			edm::ParameterSet const & p) :
+  SensitiveDetector(iname,cpv,clg,p) {}
+  virtual void fillHits(edm::PCaloHitContainer &, std::string& hitnam) {};
 };
 
 #endif

--- a/SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h
@@ -10,7 +10,7 @@
 class SensitiveCaloDetector : public SensitiveDetector
 {
 public:
-  SensitiveCaloDetector(std::string & iname, const DDCompactView & cpv,
+  SensitiveCaloDetector(const std::string & iname, const DDCompactView & cpv,
 			const SensitiveDetectorCatalog & clg,
 			edm::ParameterSet const & p) :
   SensitiveDetector(iname,cpv,clg,p) {}

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
@@ -10,7 +10,6 @@
 
 #include "G4VSensitiveDetector.hh"
 
-#include <boost/cstdint.hpp>
 #include <string>
 
 class G4Step;

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
@@ -26,15 +26,17 @@ public:
 			     edm::ParameterSet const & p);
   ~SensitiveDetector() override;
   void Initialize(G4HCofThisEvent * eventHC) override;
-  virtual void clearHits();
-  G4bool ProcessHits(G4Step * step ,G4TouchableHistory * tHistory) override;
+  virtual void clearHits() = 0;
+  G4bool ProcessHits(G4Step * step ,G4TouchableHistory * tHistory) override = 0;
   virtual uint32_t setDetUnitId(G4Step * step) = 0;
   void Register();
   void AssignSD(const std::string & vname);
   void EndOfEvent(G4HCofThisEvent * eventHC) override; 
+
   enum coordinates {WorldCoordinates, LocalCoordinates};
   Local3DPoint InitialStepPosition(const G4Step * step, coordinates);
   Local3DPoint FinalStepPosition(const G4Step * step, coordinates);
+
   inline Local3DPoint ConvertToLocal3DPoint(const G4ThreeVector& point)
   {
     Local3DPoint res(point.x(),point.y(),point.z());
@@ -42,13 +44,6 @@ public:
   }    
   inline std::string& nameOfSD() { return name; }
   virtual std::vector<std::string> getNames();
-  /*
-  {
-    std::vector<std::string> temp;
-    temp.push_back(name);
-    return temp;
-  } 
-  */ 
   void NaNTrap( G4Step* step ) ;
     
 private:

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
@@ -24,29 +24,31 @@ public:
   explicit SensitiveDetector(std::string & iname, const DDCompactView & cpv,
 			     const SensitiveDetectorCatalog & ,
 			     edm::ParameterSet const & p);
-  virtual ~SensitiveDetector();
-  virtual void Initialize(G4HCofThisEvent * eventHC);
-  virtual void clearHits() = 0;
-  virtual G4bool ProcessHits(G4Step * step ,G4TouchableHistory * tHistory) = 0;
+  ~SensitiveDetector() override;
+  void Initialize(G4HCofThisEvent * eventHC) override;
+  virtual void clearHits();
+  G4bool ProcessHits(G4Step * step ,G4TouchableHistory * tHistory) override;
   virtual uint32_t setDetUnitId(G4Step * step) = 0;
   void Register();
-  virtual void AssignSD(const std::string & vname);
-  virtual void EndOfEvent(G4HCofThisEvent * eventHC); 
+  void AssignSD(const std::string & vname);
+  void EndOfEvent(G4HCofThisEvent * eventHC) override; 
   enum coordinates {WorldCoordinates, LocalCoordinates};
-  Local3DPoint InitialStepPosition(G4Step * step, coordinates);
-  Local3DPoint FinalStepPosition(G4Step * step, coordinates);
+  Local3DPoint InitialStepPosition(const G4Step * step, coordinates);
+  Local3DPoint FinalStepPosition(const G4Step * step, coordinates);
   inline Local3DPoint ConvertToLocal3DPoint(const G4ThreeVector& point)
   {
     Local3DPoint res(point.x(),point.y(),point.z());
     return std::move(res);
   }    
   inline std::string& nameOfSD() { return name; }
-  virtual std::vector<std::string> getNames() 
+  virtual std::vector<std::string> getNames();
+  /*
   {
     std::vector<std::string> temp;
     temp.push_back(name);
     return temp;
-  }  
+  } 
+  */ 
   void NaNTrap( G4Step* step ) ;
     
 private:

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
@@ -21,7 +21,7 @@ class DDCompactView;
 class SensitiveDetector : public G4VSensitiveDetector
 {
 public:
-  explicit SensitiveDetector(std::string & iname, const DDCompactView & cpv,
+  explicit SensitiveDetector(const std::string & iname, const DDCompactView & cpv,
 			     const SensitiveDetectorCatalog & ,
 			     edm::ParameterSet const & p);
   ~SensitiveDetector() override;

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -11,11 +11,11 @@
 
 #include "G4TouchableHistory.hh"
 
-SensitiveDetector::SensitiveDetector(std::string & iname, 
+SensitiveDetector::SensitiveDetector(const std::string & iname, 
                                      const DDCompactView & cpv,
                                      const SensitiveDetectorCatalog & clg,
                                      edm::ParameterSet const & p) :
-  G4VSensitiveDetector((G4String)iname), name(iname) {}
+  G4VSensitiveDetector(iname), name(iname) {}
 
 SensitiveDetector::~SensitiveDetector() {}
 

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -15,7 +15,7 @@ SensitiveDetector::SensitiveDetector(std::string & iname,
                                      const DDCompactView & cpv,
                                      const SensitiveDetectorCatalog & clg,
                                      edm::ParameterSet const & p) :
-  G4VSensitiveDetector(iname), name(iname) {}
+  G4VSensitiveDetector((G4String)iname), name(iname) {}
 
 SensitiveDetector::~SensitiveDetector() {}
 

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -84,7 +84,5 @@ void SensitiveDetector::NaNTrap( G4Step* aStep )
 
 std::vector<std::string> SensitiveDetector::getNames()
 {
-  std::vector<std::string> temp;
-  temp.push_back(name);
-  return std::move(temp);
+  return std::vector<std::string>(1, name);
 }  

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -29,13 +29,14 @@ void SensitiveDetector::Register()
 
 void SensitiveDetector::AssignSD(const std::string & vname)
 {
-  G4LogicalVolume* v = G4LogicalVolumeStore::GetInstance()->GetVolume(vname, true);
+  G4LogicalVolume* v = 
+    G4LogicalVolumeStore::GetInstance()->GetVolume((G4String)vname, true);
   if (v) { v->SetSensitiveDetector(this); }
 }
 
 void SensitiveDetector::EndOfEvent(G4HCofThisEvent * eventHC) {}
 
-Local3DPoint SensitiveDetector::InitialStepPosition(G4Step * step, coordinates cc)
+Local3DPoint SensitiveDetector::InitialStepPosition(const G4Step * step, coordinates cc)
 {
   G4StepPoint * preStepPoint = step->GetPreStepPoint();
   return (cc == WorldCoordinates) ? ConvertToLocal3DPoint(preStepPoint->GetPosition())
@@ -43,7 +44,7 @@ Local3DPoint SensitiveDetector::InitialStepPosition(G4Step * step, coordinates c
                             ->GetTopTransform().TransformPoint(preStepPoint->GetPosition()));
 }
 
-Local3DPoint SensitiveDetector::FinalStepPosition(G4Step * step, coordinates cc)
+Local3DPoint SensitiveDetector::FinalStepPosition(const G4Step * step, coordinates cc)
 {
   // transformation is defined pre-step
   G4StepPoint * preStepPoint = step->GetPreStepPoint();
@@ -80,3 +81,10 @@ void SensitiveDetector::NaNTrap( G4Step* aStep )
   }
   return;
 }
+
+std::vector<std::string> SensitiveDetector::getNames()
+{
+  std::vector<std::string> temp;
+  temp.push_back(name);
+  return std::move(temp);
+}  


### PR DESCRIPTION
Cleanup of main Sensitive detectors classes for calorimeters:
1) removed variables shadowing
2) reduce number of repeated computations
3) reduced computations when energy deposition zero
4) use of const pointers to G4 objects in private methods
5) after code checker applied extra files and modifications were added

Estimated speed-up of the SIM step ~1%, results should be identical.