### PR TITLE
Fix seeding layers in MultiTrackValidator for conversion and GSF tracks

### DIFF
--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -35,6 +35,11 @@ for _eraName, _postfix, _era in _cfg.allEras():
     locals()["_seedProducers"+_postfix] = _seedProd + _cfg.seedProducers(_postfix)
     locals()["_trackProducers"+_postfix] = _trackProd + _cfg.trackProducers(_postfix)
 
+    if _eraName != "trackingPhase2PU140":
+        locals()["_electronSeedProducers"+_postfix] = ["tripletElectronSeeds", "pixelPairElectronSeeds", "stripPairElectronSeeds"]
+    else:
+        locals()["_electronSeedProducers"+_postfix] = ["tripletElectronSeeds"]
+
 _removeForFastSimSeedProducers =["initialStepSeedsPreSplitting",
                                  "jetCoreRegionalStepSeeds",
                                  "muonSeededSeedsInOut",
@@ -175,11 +180,9 @@ def _setForEra(module, eraName, era, **kwargs):
         era.toModify(module, **kwargs)
 
 # Seeding layer sets
-def _getSeedingLayers(seedProducers):
-    import RecoTracker.IterativeTracking.iterativeTk_cff as _iterativeTk_cff
-
+def _getSeedingLayers(seedProducers, config):
     def _findSeedingLayers(name):
-        prod = getattr(_iterativeTk_cff, name)
+        prod = getattr(config, name)
         if hasattr(prod, "triplets"):
             if hasattr(prod, "layerList"): # merger
                 return prod.layerList.refToPSet_.value()
@@ -190,7 +193,7 @@ def _getSeedingLayers(seedProducers):
 
     seedingLayersMerged = []
     for seedName in seedProducers:
-        seedProd = getattr(_iterativeTk_cff, seedName)
+        seedProd = getattr(config, seedName)
         if hasattr(seedProd, "OrderedHitsFactoryPSet"):
             if hasattr(seedProd, "SeedMergerPSet"):
                 seedingLayersName = seedProd.SeedMergerPSet.layerList.refToPSet_.value()
@@ -201,13 +204,23 @@ def _getSeedingLayers(seedProducers):
         else:
             continue
 
-        seedingLayers = getattr(_iterativeTk_cff, seedingLayersName).layerList.value()
+        seedingLayers = getattr(config, seedingLayersName).layerList.value()
         for layerSet in seedingLayers:
             if layerSet not in seedingLayersMerged:
                 seedingLayersMerged.append(layerSet)
     return seedingLayersMerged
+import RecoTracker.IterativeTracking.iterativeTk_cff as _iterativeTk_cff
+import RecoTracker.IterativeTracking.ElectronSeeds_cff as _ElectronSeeds_cff
 for _eraName, _postfix, _era in _relevantEras:
-    locals()["_seedingLayerSets"+_postfix] = _getSeedingLayers(locals()["_seedProducers"+_postfix])
+    _stdLayers = _getSeedingLayers(locals()["_seedProducers"+_postfix], _iterativeTk_cff)
+    _eleLayers = []
+    for _layer in _getSeedingLayers(locals()["_electronSeedProducers"+_postfix], _ElectronSeeds_cff):
+        if _layer not in _stdLayers:
+            _eleLayers.append(_layer)
+
+    locals()["_seedingLayerSets"+_postfix] = _stdLayers
+    locals()["_seedingLayerSetsForElectrons"+_postfix] = _eleLayers
+
 
 # MVA selectors
 def _getMVASelectors(postfix):
@@ -463,6 +476,8 @@ trackValidatorConversion = trackValidator.clone(
     doPVAssociationPlots = False,
     calculateDrSingleCollection = False,
 )
+from RecoTracker.ConversionSeedGenerators.ConversionStep_cff import convLayerPairs as _convLayerPairs
+trackValidatorConversion.histoProducerAlgoBlock.seedingLayerSets = _convLayerPairs.layerList.value()
 # relax lip and tip
 for n in ["Eta", "Phi", "Pt", "VTXR", "VTXZ"]:
     pset = getattr(trackValidatorConversion.histoProducerAlgoBlock, "TpSelectorForEfficiencyVs"+n)
@@ -475,6 +490,11 @@ trackValidatorGsfTracks = trackValidatorConversion.clone(
     label = ["electronGsfTracks"],
     label_tp_effic = "trackingParticlesElectron",
 )
+# add the additional seeding layers from ElectronSeeds
+for _eraName, _postfix, _era in _relevantEras:
+    _setForEra(trackValidatorGsfTracks.histoProducerAlgoBlock, _eraName, _era, seedingLayerSets=trackValidator.histoProducerAlgoBlock.seedingLayerSets.value()+locals()["_seedingLayerSetsForElectrons"+_postfix])
+
+
 
 # for B-hadrons
 trackValidatorBHadron = trackValidator.clone(

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -477,7 +477,17 @@ trackValidatorConversion = trackValidator.clone(
     calculateDrSingleCollection = False,
 )
 from RecoTracker.ConversionSeedGenerators.ConversionStep_cff import convLayerPairs as _convLayerPairs
-trackValidatorConversion.histoProducerAlgoBlock.seedingLayerSets = _convLayerPairs.layerList.value()
+def _uniqueFirstLayers(layerList):
+    firstLayers = [layerSet.split("+")[0] for layerSet in layerList]
+    ret = []
+    for l in firstLayers:
+        if not l in ret:
+            ret.append(l)
+    return ret
+# PhotonConversionTrajectorySeedProducerFromSingleLeg keeps only the
+# first hit of the pairs in the seed, bookkeeping those is the best we
+# can do without major further development
+trackValidatorConversion.histoProducerAlgoBlock.seedingLayerSets = _uniqueFirstLayers(_convLayerPairs.layerList.value())
 # relax lip and tip
 for n in ["Eta", "Phi", "Pt", "VTXR", "VTXZ"]:
     pset = getattr(trackValidatorConversion.histoProducerAlgoBlock, "TpSelectorForEfficiencyVs"+n)

--- a/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
+++ b/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
@@ -45,6 +45,7 @@ def main(opts):
             "allTPEffic": limitProcessing,
             "fromPV": limitProcessing,
             "fromPVAllTP": limitProcessing,
+            "tpPtLess09": limitProcessing,
             "seeding": limitProcessing,
             "building": limitProcessing,
         }
@@ -56,6 +57,7 @@ def main(opts):
             "allTPEffic": ignore,
             "fromPV": ignore,
             "fromPVAllTP": ignore,
+            "tpPtLess09": limitRelVal,
             "seeding": ignore,
         }
 

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -1591,9 +1591,11 @@ unsigned int MTVHistoProducerAlgoForTracker::getSeedingLayerSetBin(const reco::T
 
     // This is an ugly assumption, but a generic solution would
     // require significantly more effort
-    // The "if hit is strip mono or not" is checked only for the last hit
+    // The "if hit is strip mono or not" is checked only for the last
+    // hit and only if nhits is 3, because the "mono-only" definition
+    // is only used by strip triplet seeds
     bool isStripMono = false;
-    if(i == nhits-1 && subdetStrip) {
+    if(nhits == 3 && i == nhits-1 && subdetStrip) {
       isStripMono = trackerHitRTTI::isSingle(*iHit);
     }
     searchId[i] = SeedingLayerId(SeedingLayerSetsBuilder::SeedingLayerId(subdet, side, ttopo.layer(detId)), isStripMono);

--- a/Validation/RecoTrack/test/trackingCompare.py
+++ b/Validation/RecoTrack/test/trackingCompare.py
@@ -49,6 +49,7 @@ ignore = lambda algo, quality: False # ignore everything
 # produced for it
 limitSubFolders = {
     "":            limit,  # The default set (signal TrackingParticles for efficiency, all TrackingParticles for fakes)
+    "tpPtLess09":  limit,  # Efficiency for TrackingParticles with pT < 0.9 GeV
     "allTPEffic":  ignore, # Efficiency with all TrackingParticles
     "fromPV":      limit,  # Tracks from PV, signal TrackingParticles for efficiency and fakes
     "fromPVAllTP": limit,  # Tracks from PV, all TrackingParticles for fakes


### PR DESCRIPTION
The seeding layers used for conversion and GSF tracks differ from the seeding layers of iterative tracking, but this was not taken into account in tracking validation configuration. This PR sets the seeding layers correctly for both conversion and GSF tracks.

Only caveat is that `PhotonConversionTrajectorySeedProducerFromSingleLeg` only puts the first hit of the pair into the `TrajectorySeed` (https://github.com/cms-sw/cmssw/blob/7d6f190a9a22b134851a160272dc06c46c1a5063/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversion1Leg.cc#L167), so therefore the first layer of the pair is the only information we can deduce afterwards (without significant additional development).

Tested in 9_3_0_pre2, expecting changes in rates/tracks vs. seeding layer sets in conversion and GSF MTV instances because of different binning and now actually filling also bins other than "Other/Unknown".

@rovere @VinInn 