### PR TITLE
Run2-hcx144 Correct the active length calculation and its usage

### DIFF
--- a/Calibration/HcalCalibAlgos/plugins/HcalHBHEMuonAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalHBHEMuonAnalyzer.cc
@@ -821,17 +821,25 @@ double HcalHBHEMuonAnalyzer::activeLength(const DetId& id_) {
   HcalDetId id(id_);
   int ieta = id.ietaAbs();
   int depth= id.depth();
+  int zside= id.zside();
+  int iphi = id.iphi();
   double lx(0);
   if (id.subdet() == HcalBarrel) {
     for (unsigned int i=0; i<actHB.size(); ++i) {
-      if (ieta == actHB[i].ieta && depth == actHB[i].depth) {
+      if ((ieta == actHB[i].ieta) && (depth == actHB[i].depth) && 
+	  (zside == actHB[i].zside) && 
+	  (std::find(actHB[i].iphis.begin(),actHB[i].iphis.end(),iphi) !=
+	   actHB[i].iphis.end())) {
 	lx = actHB[i].thick;
 	break;
       }
     }
   } else {
     for (unsigned int i=0; i<actHE.size(); ++i) {
-      if (ieta == actHE[i].ieta && depth == actHE[i].depth) {
+      if ((ieta == actHE[i].ieta) && (depth == actHE[i].depth) && 
+	  (zside == actHE[i].zside) && 
+	  (std::find(actHE[i].iphis.begin(),actHE[i].iphis.end(),iphi) !=
+	   actHE[i].iphis.end())) {
 	lx = actHE[i].thick;
 	break;
       }

--- a/Calibration/HcalCalibAlgos/plugins/HcalHBHEMuonAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalHBHEMuonAnalyzer.cc
@@ -71,10 +71,10 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void beginJob() override;
-  virtual void analyze(edm::Event const&, edm::EventSetup const&) override;
-  virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  virtual void endRun(edm::Run const&, edm::EventSetup const&) override {}
+  void beginJob() override;
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override {}
   virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
   virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
   void   clearVectors();

--- a/Calibration/HcalCalibAlgos/plugins/HcalHBHEMuonAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalHBHEMuonAnalyzer.cc
@@ -67,7 +67,6 @@ class HcalHBHEMuonAnalyzer :  public edm::one::EDAnalyzer<edm::one::WatchRuns,ed
 
 public:
   explicit HcalHBHEMuonAnalyzer(const edm::ParameterSet&);
-  ~HcalHBHEMuonAnalyzer();
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -136,7 +135,7 @@ private:
   unsigned int              runNumber_, eventNumber_ , lumiNumber_, bxNumber_;
 };
 
-HcalHBHEMuonAnalyzer::HcalHBHEMuonAnalyzer(const edm::ParameterSet& iConfig) : hdc(0) {
+HcalHBHEMuonAnalyzer::HcalHBHEMuonAnalyzer(const edm::ParameterSet& iConfig) : hdc(nullptr) {
   
   usesResource(TFileService::kSharedResource);
   //now do what ever initialization is needed
@@ -182,11 +181,6 @@ HcalHBHEMuonAnalyzer::HcalHBHEMuonAnalyzer(const edm::ParameterSet& iConfig) : h
 				   << "\n            " << labelHBHERecHit_
 				   << "\n            " << edm::InputTag(modnam,labelMuon_,procnm);
   }
-}
-
-HcalHBHEMuonAnalyzer::~HcalHBHEMuonAnalyzer() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //

--- a/Geometry/HcalCommonData/BuildFile.xml
+++ b/Geometry/HcalCommonData/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="DetectorDescription/Core"/>
 <use   name="DataFormats/HcalDetId"/>
+<use   name="clhep"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/Geometry/HcalCommonData/interface/HcalDDDRecConstants.h
+++ b/Geometry/HcalCommonData/interface/HcalDDDRecConstants.h
@@ -58,7 +58,7 @@ public:
                                                  nPhi(nfi), rMin(r1), rMax(r2) {}
   };
 
-  std::vector<std::pair<double,double> > getConstHBHE(const int type) const {
+  std::vector<std::pair<double,double> > getConstHBHE(int type) const {
     if      (type == 0) return gconsHB;
     else if (type == 1) return gconsHE;
     else {std::vector<std::pair<double,double> > gcons; return gcons;}
@@ -70,11 +70,11 @@ public:
 					  const int zside) const {return hcons.getDepthEta16(det,iphi,zside);}
   std::vector<HcalEtaBin>   getEtaBins(int itype) const;
   std::pair<double,double>  getEtaPhi(int subdet, int ieta, int iphi) const;
-  std::pair<int,int>        getEtaRange(const int i) const
+  std::pair<int,int>        getEtaRange(int i) const
     {return std::pair<int,int>(iEtaMin[i],iEtaMax[i]);}
   const std::vector<double> &      getEtaTable()   const {return etaTable;}
   const std::vector<double> &      getEtaTableHF() const {return hpar->etaTableHF;}
-  std::pair<double,double>  getEtaLimit(const int i) const 
+  std::pair<double,double>  getEtaLimit(int i) const 
     {return std::pair<double,double>(etaTable[i],etaTable[i+1]);}
   HcalID                    getHCID(int subdet, int ieta, int iphi, int lay,
 				    int idepth) const;
@@ -88,10 +88,10 @@ public:
   int                       getMinDepth(int itype, int ieta,
 					int iphi, int zside) const;
   int                       getNEta() const {return hpar->etagroup.size();}
-  int                       getNoff(const int i) const {return hpar->noff[i];}
-  int                       getNPhi(const int type) const {return nPhiBins[type];}
-  double                    getPhiBin(const int i) const {return phibin[i];}
-  double                    getPhiOff(const int i) const {return hpar->phioff[i];}
+  int                       getNoff(int i) const {return hpar->noff[i];}
+  int                       getNPhi(int type) const {return nPhiBins[type];}
+  double                    getPhiBin(int i) const {return phibin[i];}
+  double                    getPhiOff(int i) const {return hpar->phioff[i];}
   const std::vector<double> &      getPhiOffs()    const {return hpar->phioff;}
   std::vector<std::pair<int,double> > getPhis(int subdet, int ieta) const;
   const std::vector<double> &      getPhiTable()   const {return phibin;}

--- a/Geometry/HcalCommonData/interface/HcalDDDRecConstants.h
+++ b/Geometry/HcalCommonData/interface/HcalDDDRecConstants.h
@@ -44,6 +44,7 @@ public:
   struct HcalActiveLength {
     int    ieta, depth, zside, stype;
     double eta, thick;
+    std::vector<int> iphis;
     HcalActiveLength(int ie=0, int d=0, int z=0, int s=0, double et=0, 
 		     double t=0) : ieta(ie), depth(d), zside(z), stype(s),
                                    eta(et), thick(t) {}
@@ -78,9 +79,9 @@ public:
   HcalID                    getHCID(int subdet, int ieta, int iphi, int lay,
 				    int idepth) const;
   std::vector<HFCellParameters>    getHFCellParameters() const;
-  void                      getLayerDepth(int ieta, std::map<int,int>& layers) const;
-  int                       getLayerFront(int det, int eta, int phi, int depth) const;
-  double                    getLayer0Wt(int det, int phi, int zside) const {return hcons.getLayer0Wt(det,phi,zside);}
+  void                      getLayerDepth(const int ieta, std::map<int,int>& layers) const;
+  int                       getLayerFront(const int det, const int eta, const int phi, const int depth) const;
+  double                    getLayer0Wt(const int det, const int phi, const int zside) const {return hcons.getLayer0Wt(det,phi,zside);}
   int                       getMaxDepth(const int type) const {return maxDepth[type];}
   int                       getMaxDepth(int itype, int ieta,
 					int iphi, int zside) const;

--- a/Geometry/HcalCommonData/interface/HcalDDDRecConstants.h
+++ b/Geometry/HcalCommonData/interface/HcalDDDRecConstants.h
@@ -58,49 +58,51 @@ public:
                                                  nPhi(nfi), rMin(r1), rMax(r2) {}
   };
 
-  std::vector<std::pair<double,double> > getConstHBHE(int type) const {
+  std::vector<std::pair<double,double> > getConstHBHE(const int& type) const {
     if      (type == 0) return gconsHB;
     else if (type == 1) return gconsHE;
     else {std::vector<std::pair<double,double> > gcons; return gcons;}
   }
-  std::vector<int>          getDepth(int det, int phi, 
-				     int zside, unsigned int eta) const;
-  std::vector<int>          getDepth(unsigned int eta, bool extra) const;
-  int                       getDepthEta16(const int det, const int iphi, 
-					  const int zside) const {return hcons.getDepthEta16(det,iphi,zside);}
-  std::vector<HcalEtaBin>   getEtaBins(int itype) const;
-  std::pair<double,double>  getEtaPhi(int subdet, int ieta, int iphi) const;
-  std::pair<int,int>        getEtaRange(int i) const
+  std::vector<int>          getDepth(const int& det, const int& phi, 
+				     const int& zside, const unsigned int& eta) const;
+  std::vector<int>          getDepth(const unsigned int& eta, const bool& extra) const;
+  int                       getDepthEta16(const int& det, const int& iphi, 
+					  const int& zside) const {return hcons.getDepthEta16(det,iphi,zside);}
+  std::vector<HcalEtaBin>   getEtaBins(const int& itype) const;
+  std::pair<double,double>  getEtaPhi(const int& subdet, const int& ieta, const int& iphi) const;
+  std::pair<int,int>        getEtaRange(const int& i) const
     {return std::pair<int,int>(iEtaMin[i],iEtaMax[i]);}
   const std::vector<double> &      getEtaTable()   const {return etaTable;}
   const std::vector<double> &      getEtaTableHF() const {return hpar->etaTableHF;}
-  std::pair<double,double>  getEtaLimit(int i) const 
+  std::pair<double,double>  getEtaLimit(const int& i) const 
     {return std::pair<double,double>(etaTable[i],etaTable[i+1]);}
-  HcalID                    getHCID(int subdet, int ieta, int iphi, int lay,
-				    int idepth) const;
+  HcalID                    getHCID(int subdet, int ieta, int iphi, int lay, int idepth) const;
   std::vector<HFCellParameters>    getHFCellParameters() const;
-  void                      getLayerDepth(const int ieta, std::map<int,int>& layers) const;
-  int                       getLayerFront(const int det, const int eta, const int phi, const int depth) const;
-  double                    getLayer0Wt(const int det, const int phi, const int zside) const {return hcons.getLayer0Wt(det,phi,zside);}
-  int                       getMaxDepth(const int type) const {return maxDepth[type];}
-  int                       getMaxDepth(int itype, int ieta,
-					int iphi, int zside) const;
-  int                       getMinDepth(int itype, int ieta,
-					int iphi, int zside) const;
+  void                      getLayerDepth(const int& ieta, std::map<int,int>& layers) const;
+  int                       getLayerFront(const int& det, const int& eta, const int& phi,
+					  const int& depth) const;
+  double                    getLayer0Wt(const int& det, const int& phi,
+					const int& zside) const {return hcons.getLayer0Wt(det,phi,zside);}
+  int                       getMaxDepth(const int& type) const {return maxDepth[type];}
+  int                       getMaxDepth(const int& itype, const int& ieta,
+					const int& iphi,  const int& zside) const;
+  int                       getMinDepth(const int& itype, const int& ieta,
+					const int& iphi,  const int& zside) const;
   int                       getNEta() const {return hpar->etagroup.size();}
-  int                       getNoff(int i) const {return hpar->noff[i];}
-  int                       getNPhi(int type) const {return nPhiBins[type];}
-  double                    getPhiBin(int i) const {return phibin[i];}
-  double                    getPhiOff(int i) const {return hpar->phioff[i];}
+  int                       getNoff(const int& i) const {return hpar->noff[i];}
+  int                       getNPhi(const int& type) const {return nPhiBins[type];}
+  double                    getPhiBin(const int& i) const {return phibin[i];}
+  double                    getPhiOff(const int& i) const {return hpar->phioff[i];}
   const std::vector<double> &      getPhiOffs()    const {return hpar->phioff;}
-  std::vector<std::pair<int,double> > getPhis(int subdet, int ieta) const;
+  std::vector<std::pair<int,double> > getPhis(const int& subdet, const int& ieta) const;
   const std::vector<double> &      getPhiTable()   const {return phibin;}
   const std::vector<double> &      getPhiTableHF() const {return hpar->phitable;}
   int                       getPhiZOne(std::vector<std::pair<int,int> >& phiz) const;
-  double                    getRZ(int subdet, int ieta, int depth) const;
-  double                    getRZ(int subdet, int ieta, int iphi, int depth) const;
-  double                    getRZ(int subdet, int layer) const;
-  std::vector<HcalActiveLength>    getThickActive(int type) const;
+  double                    getRZ(const int& subdet, const int& ieta, const int& depth) const;
+  double                    getRZ(const int& subdet, const int& ieta, const int& iphi,
+				  const int& depth) const;
+  double                    getRZ(const int& subdet, const int& layer) const;
+  std::vector<HcalActiveLength>    getThickActive(const int& type) const;
   int                       getTopoMode() const {return ((hpar->topologyMode)&0xFF);}
   int                       getTriggerMode() const {return (((hpar->topologyMode)>>8)&0xFF);}
   std::vector<HcalCellType> HcalCellTypes(HcalSubdetector) const;

--- a/Geometry/HcalCommonData/interface/HcalDDDSimConstants.h
+++ b/Geometry/HcalCommonData/interface/HcalDDDSimConstants.h
@@ -51,16 +51,17 @@ public:
   const std::vector<double> &  getEtaTableHF() const {return hpar->etaTableHF;}
   const std::vector<double> &  getGparHF() const {return hpar->gparHF;}
   const std::vector<HcalDetId> & getIdHF2QIE() const {return idHF2QIE;}
-  double                    getLayer0Wt(int det, int phi, 
-					int zside) const;
-  int                       getFrontLayer(int det, int eta) const;
-  int                       getLayerFront(int det, int eta, 
-					  int phi, int zside,
-					  int depth) const;
-  int                       getLayerBack(int det, int eta, 
-					 int phi, int zside,
-					 int depth) const;
-  int                       getLayerMax(int eta, int depth) const;
+  double                    getLayer0Wt(const int det, const int phi, 
+					const int zside) const;
+  int                       getFrontLayer(const int det, const int eta) const;
+  int                       getLastLayer(const int det, const int eta) const;
+  int                       getLayerFront(const int det, const int eta, 
+					  const int phi, const int zside,
+					  const int depth) const;
+  int                       getLayerBack(const int det, const int eta, 
+					 const int phi, const int zside,
+					 const int depth) const;
+  int                       getLayerMax(const int eta, const int depth) const;
   int                       getMaxDepth(const int type) const {return maxDepth[type];}
   int                       getMaxDepth(int det, int eta, 
 					int phi, int zside,
@@ -130,6 +131,8 @@ private:
   int                 depthEta29[2]; // maximum depth index for ieta=29
   int                 layFHB[2]; // first layers in HB (normal, special 16)
   int                 layFHE[3]; // first layers in HE (normal, special 16, 18)
+  int                 layBHB[3]; // last layers in HB (normal, special 15, 16)
+  int                 layBHE[3]; // last layers in HE (normal, special 16, 17|18)
   bool                isBH_;         // if HE is BH
   std::vector<HcalDetId> idHF2QIE;   // DetId's of HF modules with 2 QIE's
   std::pair<int,int>  depthMaxDf_, depthMaxSp_; // (subdet,maximum depth) default,special

--- a/Geometry/HcalCommonData/interface/HcalDDDSimConstants.h
+++ b/Geometry/HcalCommonData/interface/HcalDDDSimConstants.h
@@ -132,7 +132,7 @@ private:
   int                 layFHB[2]; // first layers in HB (normal, special 16)
   int                 layFHE[3]; // first layers in HE (normal, special 16, 18)
   int                 layBHB[3]; // last layers in HB (normal, special 15, 16)
-  int                 layBHE[3]; // last layers in HE (normal, special 16, 17|18)
+  int                 layBHE[4]; // last layers in HE (normal, special 16, 17, 18)
   bool                isBH_;         // if HE is BH
   std::vector<HcalDetId> idHF2QIE;   // DetId's of HF modules with 2 QIE's
   std::pair<int,int>  depthMaxDf_, depthMaxSp_; // (subdet,maximum depth) default,special

--- a/Geometry/HcalCommonData/interface/HcalDDDSimConstants.h
+++ b/Geometry/HcalCommonData/interface/HcalDDDSimConstants.h
@@ -28,80 +28,80 @@ public:
   HcalDDDSimConstants(const HcalParameters* hp);
   ~HcalDDDSimConstants();
 
-  HcalCellType::HcalCell    cell(int det, int zside, 
-				 int depth, int etaR, 
-				 int iphi) const;
-  int                       findDepth(int det, int eta, 
-				      int phi, int zside,
-				      int lay) const;
-  unsigned int              findLayer(int layer, const std::vector<HcalParameters::LayerItem>& layerGroup) const;
-  std::vector<std::pair<double,double> > getConstHBHE(int type) const;
-  int                       getDepthEta16(int det, int phi, 
-					  int zside) const;
-  int                       getDepthEta16M(int det) const;
-  int                       getDepthEta29(int phi, int zside, int i) const;
-  int                       getDepthEta29M(int i, bool planOne) const;
-  std::pair<int,double>     getDetEta(double eta, int depth);
-  int                       getEta(int det, int lay, double hetaR);
-  std::pair<int,int>        getEtaDepth(int det, int etaR, int phi,
-					int zside, int depth, int lay);
-  double                    getEtaHO(double& etaR, double& x, double& y, 
-				     double& z) const;
-  std::pair<int,int>        getiEtaRange(const int i) const {return std::pair<int,int>(hpar->etaMin[i],hpar->etaMax[i]);}
+  HcalCellType::HcalCell    cell(const int& det,  const int& zside, const int& depth,
+				 const int& etaR, const int& iphi) const;
+  int                       findDepth(const int& det,   const int& eta, const int& phi,
+				      const int& zside, const int& lay) const;
+  unsigned int              findLayer(const int& layer, const std::vector<HcalParameters::LayerItem>& layerGroup) const;
+  std::vector<std::pair<double,double> > getConstHBHE(const int& type) const;
+  int                       getDepthEta16(const int& det, const int& phi, 
+					  const int& zside) const;
+  int                       getDepthEta16M(const int& det) const;
+  int                       getDepthEta29(const int& phi, const int& zside, const int& i) const;
+  int                       getDepthEta29M(const int& i, const bool& planOne) const;
+  std::pair<int,double>     getDetEta(const double& eta, const int& depth);
+  int                       getEta(const int& det, const int& lay, const double& hetaR);
+  std::pair<int,int>        getEtaDepth(const int& det, int etaR, const int& phi,
+					const int& zside, int depth, const int& lay);
+  double                    getEtaHO(const double& etaR, const double& x, const double& y, 
+				     const double& z) const;
+  std::pair<int,int>        getiEtaRange(const int& i) const {return std::pair<int,int>(hpar->etaMin[i],hpar->etaMax[i]);}
   const std::vector<double> &  getEtaTableHF() const {return hpar->etaTableHF;}
   const std::vector<double> &  getGparHF() const {return hpar->gparHF;}
   const std::vector<HcalDetId> & getIdHF2QIE() const {return idHF2QIE;}
-  double                    getLayer0Wt(const int det, const int phi, 
-					const int zside) const;
-  int                       getFrontLayer(const int det, const int eta) const;
-  int                       getLastLayer(const int det, const int eta) const;
-  int                       getLayerFront(const int det, const int eta, 
-					  const int phi, const int zside,
-					  const int depth) const;
-  int                       getLayerBack(const int det, const int eta, 
-					 const int phi, const int zside,
-					 const int depth) const;
-  int                       getLayerMax(const int eta, const int depth) const;
-  int                       getMaxDepth(const int type) const {return maxDepth[type];}
-  int                       getMaxDepth(int det, int eta, 
-					int phi, int zside,
-					bool partialOnly) const;
-  std::pair<int,int>        getMaxDepthDet(const int i) const {return ((i==1) ? depthMaxDf_ : depthMaxSp_);}
-  int                       getMinDepth(int det, int eta, 
-					int phi, int zside,
-					bool partialOnly) const;
-  std::pair<int,int>        getModHalfHBHE(int type) const;
-  std::pair<double,double>  getPhiCons(int det, int ieta) const;
-  std::vector<std::pair<int,double> > getPhis(int subdet, int ieta) const;
+  double                    getLayer0Wt(const int& det, const int& phi, 
+					const int& zside) const;
+  int                       getFrontLayer(const int& det, const int& eta) const;
+  int                       getLastLayer(const int& det, const int& eta) const;
+  int                       getLayerFront(const int& det, const int& eta, 
+					  const int& phi, const int& zside,
+					  const int& depth) const;
+  int                       getLayerBack(const int& det, const int& eta, 
+					 const int& phi, const int& zside,
+					 const int& depth) const;
+  int                       getLayerMax(const int& eta, const int& depth) const;
+  int                       getMaxDepth(const int& type) const {return maxDepth[type];}
+  int                       getMaxDepth(const int& det, const int& eta, 
+					const int& phi, const int& zside,
+					const bool& partialOnly) const;
+  std::pair<int,int>        getMaxDepthDet(const int& i) const {return ((i==1) ? depthMaxDf_ : depthMaxSp_);}
+  int                       getMinDepth(const int& det, const int& eta, 
+					const int& phi, const int& zside,
+					const bool& partialOnly) const;
+  std::pair<int,int>        getModHalfHBHE(const int& type) const;
+  std::pair<double,double>  getPhiCons(const int& det, const int& ieta) const;
+  std::vector<std::pair<int,double> > getPhis(const int& subdet, const int& ieta) const;
   const std::vector<double> &  getPhiTableHF() const {return hpar->phitable;}
   const std::vector<double> &  getRTableHF()   const {return hpar->rTable;}
   std::vector<HcalCellType> HcalCellTypes()    const;
-  std::vector<HcalCellType> HcalCellTypes(HcalSubdetector, int ieta=-1,
+  std::vector<HcalCellType> HcalCellTypes(const HcalSubdetector&, int ieta=-1,
 					  int depth=-1) const;
   bool                      isBH() const {return isBH_;}
   const HcalLayerDepthMap*  ldMap() const {return &ldmap_;}
-  int                       maxHFDepth(int ieta, int iphi) const;
-  unsigned int              numberOfCells(HcalSubdetector) const;
-  int                       phiNumber(int phi, int unit) const;
+  int                       maxHFDepth(const int& ieta, const int& iphi) const;
+  unsigned int              numberOfCells(const HcalSubdetector&) const;
+  int                       phiNumber(const int& phi, const int& unit) const;
   void                      printTiles() const;
-  int                       unitPhi(int det, int etaR) const;
-  int                       unitPhi(double dphi) const; 
+  int                       unitPhi(const int& det, const int& etaR) const;
+  int                       unitPhi(const double& dphi) const; 
        
 private:
+
+  static const int          nDepthMax=9;
+  static const int          maxLayer_=18;
+  static const int          maxLayerHB_=16;
+
   void                      initialize();
-  double                    deltaEta(int det, int eta, 
-				     int depth) const;
-  double                    getEta(int det, int etaR,
-				   int zside, int depth=1) const;
-  double                    getEta(double r, double z) const;
-  int                       getShift(HcalSubdetector subdet, 
-				     int depth) const;
-  double                    getGain (HcalSubdetector subdet, 
-				     int depth) const;
-  void                      printTileHB(int eta, int phi,
-					int zside, int depth) const;
-  void                      printTileHE(int eta, int phi, 
-					int zside, int depth) const;
+  double                    deltaEta(const int& det, const int& eta, const int& depth) const;
+  double                    getEta(const int& det, const int& etaR,
+				   const int& zside, int depth=1) const;
+  double                    getEta(const double& r, const double& z) const;
+  int                       getShift(const HcalSubdetector& subdet, const int& depth) const;
+  double                    getGain (const HcalSubdetector& subdet, const int& depth) const;
+  void                      printTileHB(const int& eta,   const int& phi,
+					const int& zside, const int& depth) const;
+  void                      printTileHE(const int& eta,   const int& phi, 
+					const int& zside, const int& depth) const;
   unsigned int              layerGroupSize(int eta) const;
   unsigned int              layerGroup(int eta, int i) const;
   unsigned int              layerGroup(int det, int eta,
@@ -110,10 +110,6 @@ private:
 
   const HcalParameters* hpar;
   HcalLayerDepthMap     ldmap_;
-
-  static const int    nDepthMax=9;
-  static const int    maxLayer_=18;
-  static const int    maxLayerHB_=16;
 
   std::vector<int>    maxDepth; // Maximum depths in HB/HE/HF/HO
   int                 nEta;     // Number of bins in eta for HB and HE

--- a/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
@@ -26,8 +26,8 @@ HcalDDDRecConstants::~HcalDDDRecConstants() {
 #endif
 }
 
-std::vector<int> HcalDDDRecConstants::getDepth(const unsigned int eta,
-					       const bool extra) const {
+std::vector<int> HcalDDDRecConstants::getDepth(unsigned int eta,
+					       bool extra) const {
 
   if (!extra) {
     std::vector<HcalParameters::LayerItem>::const_iterator last = hpar->layerGroupEtaRec.begin();
@@ -47,7 +47,8 @@ std::vector<int> HcalDDDRecConstants::getDepth(const unsigned int eta,
   }
 }
 
-std::vector<int> HcalDDDRecConstants::getDepth(const int det, const int phi, const int zside, const unsigned int eta) const {
+std::vector<int> HcalDDDRecConstants::getDepth(int det, int phi, int zside, 
+					       unsigned int eta) const {
   std::map<int,int> layers;
   hcons.ldMap()->getLayerDepth(det, eta+1, phi, zside, layers);
   if (layers.empty()) {
@@ -61,7 +62,7 @@ std::vector<int> HcalDDDRecConstants::getDepth(const int det, const int phi, con
 }
 
 std::vector<HcalDDDRecConstants::HcalEtaBin> 
-HcalDDDRecConstants::getEtaBins(const int itype) const {
+HcalDDDRecConstants::getEtaBins(int itype) const {
 
   std::vector<HcalDDDRecConstants::HcalEtaBin> bins;
   unsigned int     type     = (itype == 0) ? 0 : 1;
@@ -270,8 +271,7 @@ HcalDDDRecConstants::getHFCellParameters() const {
   return cells;
 }
 
-void HcalDDDRecConstants::getLayerDepth(const int ieta, 
-					std::map<int,int>& layers) const {
+void HcalDDDRecConstants::getLayerDepth(int ieta, std::map<int,int>& layers) const {
 
   layers.clear();
   for (unsigned int l=0; l<layerGroupSize(ieta-1); ++l) {
@@ -287,8 +287,8 @@ void HcalDDDRecConstants::getLayerDepth(const int ieta,
 #endif
 }
 
-int HcalDDDRecConstants::getLayerFront(const int idet, const int ieta,
-				       const int iphi, const int depth) const {
+int HcalDDDRecConstants::getLayerFront(int idet, int ieta,
+				       int iphi, int depth) const {
   int subdet = (idet == 1) ? 1 : 2;
   int zside  = (ieta > 0) ? 1 : -1;
   int eta    = zside*ieta;
@@ -315,8 +315,8 @@ int HcalDDDRecConstants::getLayerFront(const int idet, const int ieta,
   return layFront;
 }
 
-int HcalDDDRecConstants::getMaxDepth (const int itype, const int ieta,
-				      const int iphi, const int zside) const {
+int HcalDDDRecConstants::getMaxDepth (int itype, int ieta,
+				      int iphi,  int zside) const {
   
   unsigned int type  = (itype == 0) ? 0 : 1;
   int lmax = hcons.getMaxDepth(type+1, ieta, iphi, zside, true);
@@ -337,8 +337,8 @@ int HcalDDDRecConstants::getMaxDepth (const int itype, const int ieta,
   return lmax;
 }
 
-int HcalDDDRecConstants::getMinDepth (const int itype, const int ieta,
-				      const int iphi, const int zside) const {
+int HcalDDDRecConstants::getMinDepth (int itype, int ieta,
+				      int iphi,  int zside) const {
 
   int lmin = hcons.getMinDepth(itype+1, ieta, iphi, zside, true);
   if (lmin < 0) {
@@ -441,7 +441,7 @@ double HcalDDDRecConstants::getRZ(int subdet, int layer) const {
 
  	
 std::vector<HcalDDDRecConstants::HcalActiveLength> 
-HcalDDDRecConstants::getThickActive(const int type) const {
+HcalDDDRecConstants::getThickActive(int type) const {
 
   std::vector<HcalDDDRecConstants::HcalActiveLength> actives;
   std::vector<HcalDDDRecConstants::HcalEtaBin> bins = getEtaBins(type);
@@ -1028,7 +1028,7 @@ void HcalDDDRecConstants::initialize(void) {
 
 }
 
-unsigned int HcalDDDRecConstants::layerGroupSize(const int eta) const {
+unsigned int HcalDDDRecConstants::layerGroupSize(int eta) const {
   unsigned int k = 0;
   for (auto const & it : hpar->layerGroupEtaRec) {
     if (it.layer == (unsigned int)(eta + 1)) {
@@ -1040,8 +1040,7 @@ unsigned int HcalDDDRecConstants::layerGroupSize(const int eta) const {
   return k;
 }
 
-unsigned int HcalDDDRecConstants::layerGroup(const int eta, 
-					     const int i) const {
+unsigned int HcalDDDRecConstants::layerGroup(int eta, int i) const {
   unsigned int k = 0;
   for (auto const & it :  hpar->layerGroupEtaRec) {
     if (it.layer == (unsigned int)(eta + 1))  {

--- a/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
@@ -26,8 +26,8 @@ HcalDDDRecConstants::~HcalDDDRecConstants() {
 #endif
 }
 
-std::vector<int> HcalDDDRecConstants::getDepth(unsigned int eta,
-					       bool extra) const {
+std::vector<int> HcalDDDRecConstants::getDepth(const unsigned int& eta,
+					       const bool& extra) const {
 
   if (!extra) {
     std::vector<HcalParameters::LayerItem>::const_iterator last = hpar->layerGroupEtaRec.begin();
@@ -47,8 +47,8 @@ std::vector<int> HcalDDDRecConstants::getDepth(unsigned int eta,
   }
 }
 
-std::vector<int> HcalDDDRecConstants::getDepth(int det, int phi, int zside, 
-					       unsigned int eta) const {
+std::vector<int> HcalDDDRecConstants::getDepth(const int& det, const int& phi, const int& zside, 
+					       const unsigned int& eta) const {
   std::map<int,int> layers;
   hcons.ldMap()->getLayerDepth(det, eta+1, phi, zside, layers);
   if (layers.empty()) {
@@ -62,7 +62,7 @@ std::vector<int> HcalDDDRecConstants::getDepth(int det, int phi, int zside,
 }
 
 std::vector<HcalDDDRecConstants::HcalEtaBin> 
-HcalDDDRecConstants::getEtaBins(int itype) const {
+HcalDDDRecConstants::getEtaBins(const int& itype) const {
 
   std::vector<HcalDDDRecConstants::HcalEtaBin> bins;
   unsigned int     type     = (itype == 0) ? 0 : 1;
@@ -132,7 +132,7 @@ HcalDDDRecConstants::getEtaBins(int itype) const {
 }
 
 std::pair<double,double> 
-HcalDDDRecConstants::getEtaPhi(int subdet, int ieta, int iphi) const {
+HcalDDDRecConstants::getEtaPhi(const int& subdet, const int& ieta, const int& iphi) const {
   int ietaAbs = (ieta > 0) ? ieta : -ieta;
   double eta(0), phi(0);
   if ((subdet == static_cast<int>(HcalBarrel)) || 
@@ -271,7 +271,7 @@ HcalDDDRecConstants::getHFCellParameters() const {
   return cells;
 }
 
-void HcalDDDRecConstants::getLayerDepth(int ieta, std::map<int,int>& layers) const {
+void HcalDDDRecConstants::getLayerDepth(const int& ieta, std::map<int,int>& layers) const {
 
   layers.clear();
   for (unsigned int l=0; l<layerGroupSize(ieta-1); ++l) {
@@ -287,8 +287,8 @@ void HcalDDDRecConstants::getLayerDepth(int ieta, std::map<int,int>& layers) con
 #endif
 }
 
-int HcalDDDRecConstants::getLayerFront(int idet, int ieta,
-				       int iphi, int depth) const {
+int HcalDDDRecConstants::getLayerFront(const int& idet, const int& ieta,
+				       const int& iphi, const int& depth) const {
   int subdet = (idet == 1) ? 1 : 2;
   int zside  = (ieta > 0) ? 1 : -1;
   int eta    = zside*ieta;
@@ -315,8 +315,8 @@ int HcalDDDRecConstants::getLayerFront(int idet, int ieta,
   return layFront;
 }
 
-int HcalDDDRecConstants::getMaxDepth (int itype, int ieta,
-				      int iphi,  int zside) const {
+int HcalDDDRecConstants::getMaxDepth (const int& itype, const int& ieta,
+				      const int& iphi,  const int& zside) const {
   
   unsigned int type  = (itype == 0) ? 0 : 1;
   int lmax = hcons.getMaxDepth(type+1, ieta, iphi, zside, true);
@@ -337,8 +337,8 @@ int HcalDDDRecConstants::getMaxDepth (int itype, int ieta,
   return lmax;
 }
 
-int HcalDDDRecConstants::getMinDepth (int itype, int ieta,
-				      int iphi,  int zside) const {
+int HcalDDDRecConstants::getMinDepth (const int& itype, const int& ieta,
+				      const int& iphi,  const int& zside) const {
 
   int lmin = hcons.getMinDepth(itype+1, ieta, iphi, zside, true);
   if (lmin < 0) {
@@ -360,7 +360,7 @@ int HcalDDDRecConstants::getMinDepth (int itype, int ieta,
 }
 
 std::vector<std::pair<int,double> >
-HcalDDDRecConstants::getPhis(int subdet, int ieta) const {
+HcalDDDRecConstants::getPhis(const int& subdet, const int& ieta) const {
 
   std::vector<std::pair<int,double> > phis;
   int ietaAbs = (ieta > 0) ? ieta : -ieta;
@@ -407,13 +407,14 @@ int HcalDDDRecConstants::getPhiZOne(std::vector<std::pair<int,int>>& phiz) const
   return subdet;
 }
 
-double HcalDDDRecConstants::getRZ(int subdet, int ieta, int depth) const {
+double HcalDDDRecConstants::getRZ(const int& subdet, const int& ieta, 
+				  const int& depth) const {
 
   return getRZ(subdet, ieta, 1, depth);
 }
 
-double HcalDDDRecConstants::getRZ(int subdet, int ieta, int iphi,
-				  int depth) const {
+double HcalDDDRecConstants::getRZ(const int& subdet, const int& ieta, const int& iphi,
+				  const int& depth) const {
   int    layf  = getLayerFront(subdet,ieta,iphi,depth);
   double rz    = (layf < 0) ? 0.0 : 
     ((subdet == static_cast<int>(HcalBarrel)) ? (gconsHB[layf].first) :
@@ -426,7 +427,7 @@ double HcalDDDRecConstants::getRZ(int subdet, int ieta, int iphi,
   return rz;
 }
 
-double HcalDDDRecConstants::getRZ(int subdet, int layer) const {
+double HcalDDDRecConstants::getRZ(const int& subdet, const int& layer) const {
 
   double rz(0);
   if (layer > 0 && layer <= (int)(layerGroupSize(0)))
@@ -441,7 +442,7 @@ double HcalDDDRecConstants::getRZ(int subdet, int layer) const {
 
  	
 std::vector<HcalDDDRecConstants::HcalActiveLength> 
-HcalDDDRecConstants::getThickActive(int type) const {
+HcalDDDRecConstants::getThickActive(const int& type) const {
 
   std::vector<HcalDDDRecConstants::HcalActiveLength> actives;
   std::vector<HcalDDDRecConstants::HcalEtaBin> bins = getEtaBins(type);

--- a/Geometry/HcalCommonData/src/HcalDDDSimConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDSimConstants.cc
@@ -329,12 +329,12 @@ int HcalDDDSimConstants::getFrontLayer(const int det, const int eta) const {
 
   int lay=0;
   if (det == 1) {
-    if      (eta == 16 || eta == -16) lay = layFHB[1];
-    else                              lay = layFHB[0];
+    if      (std::abs(eta) == 16) lay = layFHB[1];
+    else                          lay = layFHB[0];
   } else {
-    if      (eta == 16 || eta == -16) lay = layFHE[1];
-    else if (eta == 18 || eta == -18) lay = layFHE[2];
-    else                              lay = layFHE[0];
+    if      (std::abs(eta) == 16) lay = layFHE[1];
+    else if (std::abs(eta) == 18) lay = layFHE[2];
+    else                          lay = layFHE[0];
   }
   return lay;
 }
@@ -343,14 +343,14 @@ int HcalDDDSimConstants::getLastLayer(const int det, const int eta) const {
 
   int lay=0;
   if (det == 1) {
-    if      (eta == 15 || eta == -15) lay = layBHB[1];
-    else if (eta == 16 || eta == -16) lay = layBHB[2];
-    else                              lay = layBHB[0];
+    if      (std::abs(eta) == 15) lay = layBHB[1];
+    else if (std::abs(eta) == 16) lay = layBHB[2];
+    else                          lay = layBHB[0];
   } else {
-    if      (eta == 16 || eta == -16) lay = layBHE[1];
-    else if (eta == 17 || eta == -17) lay = layBHE[2];
-    else if (eta == 18 || eta == -18) lay = layBHE[3];
-    else                              lay = layBHE[0];
+    if      (std::abs(eta) == 16) lay = layBHE[1];
+    else if (std::abs(eta) == 17) lay = layBHE[2];
+    else if (std::abs(eta) == 18) lay = layBHE[3];
+    else                          lay = layBHE[0];
   }
   return lay;
 }

--- a/Geometry/HcalCommonData/src/HcalDDDSimConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDSimConstants.cc
@@ -348,8 +348,8 @@ int HcalDDDSimConstants::getLastLayer(const int det, const int eta) const {
     else                              lay = layBHB[0];
   } else {
     if      (eta == 16 || eta == -16) lay = layBHE[1];
-    else if (eta == 17 || eta == -17 || 
-	     eta == 18 || eta == -18) lay = layBHE[2];
+    else if (eta == 17 || eta == -17) lay = layBHE[2];
+    else if (eta == 18 || eta == -18) lay = layBHE[3];
     else                              lay = layBHE[0];
   }
   return lay;
@@ -880,7 +880,7 @@ void HcalDDDSimConstants::initialize( void ) {
   layFHB[0] = 0;  layFHB[1] = 1;
   layBHB[0] = 16; layBHB[1] = 15; layBHB[2] = 8;
   layFHE[0] = 1;  layFHE[1] = 4;  layFHE[2] = 0;
-  layBHE[0] = 18; layBHE[1] = 9;  layBHE[2] = 14;
+  layBHE[0] = 18; layBHE[1] = 9;  layBHE[2] = 14; layBHE[3] = 16;
   depthMaxSp_ = std::pair<int,int>(0,0);
   int noffk(noffsize+5);
   if ((int)(hpar->noff.size()) > (noffsize+5)) {
@@ -928,9 +928,9 @@ void HcalDDDSimConstants::initialize( void ) {
 	  for (int i=0; i<2; ++i) layFHB[i] = hpar->noff[noffm+i+1];
 	  for (int i=0; i<3; ++i) layFHE[i] = hpar->noff[noffm+i+3];
 	}
-	if (ndnext > 10 && (int)(hpar->noff.size()) >= noffm+ndnext) {
+	if (ndnext > 11 && (int)(hpar->noff.size()) >= noffm+ndnext) {
 	  for (int i=0; i<3; ++i) layBHB[i] = hpar->noff[noffm+i+6];
-	  for (int i=0; i<3; ++i) layBHE[i] = hpar->noff[noffm+i+9];
+	  for (int i=0; i<4; ++i) layBHE[i] = hpar->noff[noffm+i+9];
 	}
       }
     }
@@ -941,7 +941,8 @@ void HcalDDDSimConstants::initialize( void ) {
 	    << ":" << layFHE[2] << std::endl;
   std::cout << "Last Layer Definition for HB: " << layBHB[0] << ":" 
 	    << layBHB[1] << ":" << layBHB[2] << " and for HE: " << layBHE[0] 
-	    << ":" << layBHE[1] << ":" << layBHE[2] << std::endl;
+	    << ":" << layBHE[1] << ":" << layBHE[2] << ":" << layBHE[3]
+	    << std::endl;
 #endif
   if (depthMaxSp_.first == 0) {
     depthMaxSp_ = depthMaxDf_ = std::pair<int,int>(2,maxDepth[1]);

--- a/Geometry/HcalCommonData/src/HcalDDDSimConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDSimConstants.cc
@@ -28,9 +28,9 @@ HcalDDDSimConstants::~HcalDDDSimConstants() {
 #endif
 }
 
-HcalCellType::HcalCell HcalDDDSimConstants::cell(const int idet, const int zside, 
-						 const int depth, const int etaR,
-						 const int iphi) const {
+HcalCellType::HcalCell HcalDDDSimConstants::cell(const int& idet,  const int& zside, 
+						 const int& depth, const int& etaR,
+						 const int& iphi) const {
 
   double etaMn = hpar->etaMin[0];
   double etaMx = hpar->etaMax[0];
@@ -120,15 +120,15 @@ HcalCellType::HcalCell HcalDDDSimConstants::cell(const int idet, const int zside
   return tmp;
 }
 
-int HcalDDDSimConstants::findDepth(const int det, const int eta, 
-				   const int phi, const int zside,
-				   const int lay) const {
+int HcalDDDSimConstants::findDepth(const int& det, const int& eta, 
+				   const int& phi, const int& zside,
+				   const int& lay) const {
 
   int depth = (ldmap_.isValid(det,phi,zside)) ? ldmap_.getDepth(det,eta,phi,zside,lay) : -1;
   return depth;
 }
 
-unsigned int HcalDDDSimConstants::findLayer(const int layer, const std::vector<HcalParameters::LayerItem>& layerGroup) const {
+unsigned int HcalDDDSimConstants::findLayer(const int& layer, const std::vector<HcalParameters::LayerItem>& layerGroup) const {
   
   unsigned int id = layerGroup.size();
   for (unsigned int i = 0; i < layerGroup.size(); i++) {
@@ -140,7 +140,7 @@ unsigned int HcalDDDSimConstants::findLayer(const int layer, const std::vector<H
   return id;
 }
 
-std::vector<std::pair<double,double> > HcalDDDSimConstants::getConstHBHE(const int type) const {
+std::vector<std::pair<double,double> > HcalDDDSimConstants::getConstHBHE(const int& type) const {
 
   std::vector<std::pair<double,double> > gcons;
   if (type == 0) {
@@ -155,8 +155,8 @@ std::vector<std::pair<double,double> > HcalDDDSimConstants::getConstHBHE(const i
   return gcons;
 }
 
-int HcalDDDSimConstants::getDepthEta16(const int det, const int phi, 
-				       const int zside) const {
+int HcalDDDSimConstants::getDepthEta16(const int& det, const int& phi, 
+				       const int& zside) const {
 
   int depth = ldmap_.getDepth16(det,phi,zside);
   if (depth < 0) depth = (det == 2) ? depthEta16[1] : depthEta16[0];
@@ -166,7 +166,7 @@ int HcalDDDSimConstants::getDepthEta16(const int det, const int phi,
   return depth;
 }
 
-int HcalDDDSimConstants::getDepthEta16M(const int det) const {
+int HcalDDDSimConstants::getDepthEta16M(const int& det) const {
   int depth = (det == 2) ? depthEta16[1] : depthEta16[0];
   std::vector<int> phis;
   int detsp = ldmap_.validDet(phis);
@@ -180,16 +180,16 @@ int HcalDDDSimConstants::getDepthEta16M(const int det) const {
   return depth;
 }
 
-int HcalDDDSimConstants::getDepthEta29(const int phi, const int zside, 
-				       const int i) const {
+int HcalDDDSimConstants::getDepthEta29(const int& phi, const int& zside, 
+				       const int& i) const {
 
   int depth = (i == 0) ? ldmap_.getMaxDepthLastHE(2,phi,zside) : -1;
   if (depth < 0) depth = (i == 1) ? depthEta29[1] : depthEta29[0];
   return depth;
 }
 
-int HcalDDDSimConstants::getDepthEta29M(const int i, 
-					const bool planOne) const {
+int HcalDDDSimConstants::getDepthEta29M(const int& i, 
+					const bool& planOne) const {
   int depth = (i == 1) ? depthEta29[1] : depthEta29[0];
   if (i == 0 && planOne) {
     std::vector<int> phis;
@@ -204,8 +204,8 @@ int HcalDDDSimConstants::getDepthEta29M(const int i,
   return depth;
 }
 
-std::pair<int,double> HcalDDDSimConstants::getDetEta(const double eta, 
-						     const int depth) {
+std::pair<int,double> HcalDDDSimConstants::getDetEta(const double& eta, 
+						     const int& depth) {
 
   int    hsubdet(0), ieta(0);
   double etaR(0);
@@ -229,8 +229,8 @@ std::pair<int,double> HcalDDDSimConstants::getDetEta(const double eta,
   return std::pair<int,double>(hsubdet,etaR);
 }
 
-int HcalDDDSimConstants::getEta(const int det, const int lay, 
-				const double hetaR) {
+int HcalDDDSimConstants::getEta(const int& det, const int& lay, 
+				const double& hetaR) {
 
   int    ieta(0);
   if (det == static_cast<int>(HcalForward)) { // Forward HCal
@@ -253,9 +253,9 @@ int HcalDDDSimConstants::getEta(const int det, const int lay,
   return ieta;
 }
 
-std::pair<int,int> HcalDDDSimConstants::getEtaDepth(const int det, int etaR, 
-						    int phi, int zside, 
-						    int depth, int lay) {
+std::pair<int,int> HcalDDDSimConstants::getEtaDepth(const int& det, int etaR, 
+						    const int& phi, const int& zside, 
+						    int depth, const int& lay) {
 
 #ifdef EDM_ML_DEBUG
   std::cout << "HcalDDDEsimConstants:getEtaDepth: I/P " << det << ":" << etaR
@@ -299,8 +299,8 @@ std::pair<int,int> HcalDDDSimConstants::getEtaDepth(const int det, int etaR,
   return std::pair<int,int>(etaR,depth);
 }
 
-double HcalDDDSimConstants::getEtaHO(double& etaR, double& x, double& y, 
-				     double& z) const {
+double HcalDDDSimConstants::getEtaHO(const double& etaR, const double& x, const double& y, 
+				     const double& z) const {
 
   if (hpar->zHO.size() > 4) {
     double eta  = fabs(etaR);
@@ -325,7 +325,7 @@ double HcalDDDSimConstants::getEtaHO(double& etaR, double& x, double& y,
   }
 }
 
-int HcalDDDSimConstants::getFrontLayer(const int det, const int eta) const {
+int HcalDDDSimConstants::getFrontLayer(const int& det, const int& eta) const {
 
   int lay=0;
   if (det == 1) {
@@ -339,7 +339,7 @@ int HcalDDDSimConstants::getFrontLayer(const int det, const int eta) const {
   return lay;
 }
 
-int HcalDDDSimConstants::getLastLayer(const int det, const int eta) const {
+int HcalDDDSimConstants::getLastLayer(const int& det, const int& eta) const {
 
   int lay=0;
   if (det == 1) {
@@ -355,17 +355,17 @@ int HcalDDDSimConstants::getLastLayer(const int det, const int eta) const {
   return lay;
 }
 
-double HcalDDDSimConstants::getLayer0Wt(const int det, const int phi, 
-					const int zside) const {
+double HcalDDDSimConstants::getLayer0Wt(const int& det, const int& phi, 
+					const int& zside) const {
 
   double wt = ldmap_.getLayer0Wt(det, phi, zside);
   if (wt < 0) wt = (det == 2) ? hpar->Layer0Wt[1] :  hpar->Layer0Wt[0];
   return wt;
 }
 
-int HcalDDDSimConstants::getLayerFront(const int det, const int eta, 
-				       const int phi, const int zside,
-				       const int depth) const {
+int HcalDDDSimConstants::getLayerFront(const int& det, const int& eta, 
+				       const int& phi, const int& zside,
+				       const int& depth) const {
 
   int layer = ldmap_.getLayerFront(det, eta, phi, zside, depth);
   if (layer < 0) {
@@ -383,9 +383,9 @@ int HcalDDDSimConstants::getLayerFront(const int det, const int eta,
   return layer;
 }
 
-int HcalDDDSimConstants::getLayerBack(const int det, const int eta, 
-				      const int phi, const int zside,
-				      const int depth) const {
+int HcalDDDSimConstants::getLayerBack(const int& det, const int& eta, 
+				      const int& phi, const int& zside,
+				      const int& depth) const {
 
   int layer = ldmap_.getLayerBack(det, eta, phi, zside, depth);
   if (layer < 0) {
@@ -398,15 +398,15 @@ int HcalDDDSimConstants::getLayerBack(const int det, const int eta,
   return layer;
 }
 
-int HcalDDDSimConstants::getLayerMax(const int eta, const int depth) const {
+int HcalDDDSimConstants::getLayerMax(const int& eta, const int& depth) const {
 
   int layermx =  ((eta < hpar->etaMin[1]) && depth-1 < maxDepth[0]) ? maxLayerHB_+1 : (int)layerGroupSize(eta-1);
   return layermx;
 }
 
-int HcalDDDSimConstants::getMaxDepth(const int det, const int eta, 
-				     const int phi, const int zside,
-				     const bool partialDetOnly) const {
+int HcalDDDSimConstants::getMaxDepth(const int& det, const int& eta, 
+				     const int& phi, const int& zside,
+				     const bool& partialDetOnly) const {
 
   int dmax(-1);
   if (partialDetOnly) {
@@ -432,9 +432,9 @@ int HcalDDDSimConstants::getMaxDepth(const int det, const int eta,
   return dmax;
 }
 
-int HcalDDDSimConstants::getMinDepth(const int det, const int eta, 
-				     const int phi, const int zside,
-				     const bool partialDetOnly) const {
+int HcalDDDSimConstants::getMinDepth(const int& det, const int& eta, 
+				     const int& phi, const int& zside,
+				     const bool& partialDetOnly) const {
 
   int lmin(-1);
   if (partialDetOnly) {
@@ -460,7 +460,7 @@ int HcalDDDSimConstants::getMinDepth(const int det, const int eta,
   return lmin;
 }
 
-std::pair<int,int> HcalDDDSimConstants::getModHalfHBHE(const int type) const {
+std::pair<int,int> HcalDDDSimConstants::getModHalfHBHE(const int& type) const {
 
   if (type == 0) {
     return std::pair<int,int>(nmodHB,nzHB);
@@ -469,8 +469,8 @@ std::pair<int,int> HcalDDDSimConstants::getModHalfHBHE(const int type) const {
   }
 }
 
-std::pair<double,double> HcalDDDSimConstants::getPhiCons(const int det, 
-							 const int ieta) const {
+std::pair<double,double> HcalDDDSimConstants::getPhiCons(const int& det, 
+							 const int& ieta) const {
   
   double fioff(0), fibin(0);
   if (det == static_cast<int>(HcalForward)) { // Forward HCal
@@ -491,7 +491,7 @@ std::pair<double,double> HcalDDDSimConstants::getPhiCons(const int det,
 }
 
 std::vector<std::pair<int,double> >
-HcalDDDSimConstants::getPhis(const int subdet, const int ieta) const {
+HcalDDDSimConstants::getPhis(const int& subdet, const int& ieta) const {
 
   std::vector<std::pair<int,double> > phis;
   int ietaAbs = (ieta > 0) ? ieta : -ieta;
@@ -553,7 +553,8 @@ std::vector<HcalCellType> HcalDDDSimConstants::HcalCellTypes() const{
   return cellTypes;
 }
 
-std::vector<HcalCellType> HcalDDDSimConstants::HcalCellTypes(const HcalSubdetector subdet, const int ieta, const int depthl) const {
+std::vector<HcalCellType> HcalDDDSimConstants::HcalCellTypes(const HcalSubdetector& subdet, 
+							     int ieta, int depthl) const {
 
   std::vector<HcalCellType> cellTypes;
   if (subdet == HcalForward) {
@@ -652,7 +653,7 @@ std::vector<HcalCellType> HcalDDDSimConstants::HcalCellTypes(const HcalSubdetect
   return cellTypes;
 }
 
-int HcalDDDSimConstants::maxHFDepth(const int eta, const int iphi) const {
+int HcalDDDSimConstants::maxHFDepth(const int& eta, const int& iphi) const {
   int mxdepth = maxDepth[2];
   if (!idHF2QIE.empty()) {
     bool ok(false);
@@ -666,7 +667,7 @@ int HcalDDDSimConstants::maxHFDepth(const int eta, const int iphi) const {
   return mxdepth;
 }
 
-unsigned int HcalDDDSimConstants::numberOfCells(const HcalSubdetector subdet) const{
+unsigned int HcalDDDSimConstants::numberOfCells(const HcalSubdetector& subdet) const{
 
   unsigned int num = 0;
   std::vector<HcalCellType> cellTypes = HcalCellTypes(subdet);
@@ -681,7 +682,7 @@ unsigned int HcalDDDSimConstants::numberOfCells(const HcalSubdetector subdet) co
   return num;
 }
 
-int HcalDDDSimConstants::phiNumber(const int phi, const int units) const {
+int HcalDDDSimConstants::phiNumber(const int& phi, const int& units) const {
 
   int iphi_skip = phi;
   if      (units==2) iphi_skip  = (phi-1)*2+1;
@@ -727,13 +728,13 @@ void HcalDDDSimConstants::printTiles() const {
   }
 }
 
-int HcalDDDSimConstants::unitPhi(const int det, const int etaR) const {
+int HcalDDDSimConstants::unitPhi(const int& det, const int& etaR) const {
 
   double dphi = (det == static_cast<int>(HcalForward)) ? hpar->phitable[etaR-hpar->etaMin[2]] : hpar->phibin[etaR-1];
   return unitPhi(dphi);
 }
 
-int HcalDDDSimConstants::unitPhi(const double dphi) const {
+int HcalDDDSimConstants::unitPhi(const double& dphi) const {
 
   const double fiveDegInRad = 2*M_PI/72;
   int units = int(dphi/fiveDegInRad+0.5);
@@ -961,8 +962,8 @@ void HcalDDDSimConstants::initialize( void ) {
 #endif
 }
 
-double HcalDDDSimConstants::deltaEta(const int det, const int etaR,
-				     const int depth) const {
+double HcalDDDSimConstants::deltaEta(const int& det, const int& etaR,
+				     const int& depth) const {
 
   double tmp = 0;
   if (det == static_cast<int>(HcalForward)) {
@@ -1000,8 +1001,8 @@ double HcalDDDSimConstants::deltaEta(const int det, const int etaR,
   return tmp;
 }
 
-double HcalDDDSimConstants::getEta(const int det, const int etaR,
-				   const int zside, const int depth) const {
+double HcalDDDSimConstants::getEta(const int& det,   const int& etaR,
+				   const int& zside, int depth) const {
 
   double tmp = 0;
   if (det == static_cast<int>(HcalForward)) {
@@ -1040,7 +1041,7 @@ double HcalDDDSimConstants::getEta(const int det, const int etaR,
   return tmp;
 }
  
-double HcalDDDSimConstants::getEta(const double r, const double z) const {
+double HcalDDDSimConstants::getEta(const double& r, const double& z) const {
 
   double tmp = 0;
   if (z != 0) tmp = -log(tan(0.5*atan(r/z)));
@@ -1051,8 +1052,8 @@ double HcalDDDSimConstants::getEta(const double r, const double z) const {
   return tmp;
 }
 
-int HcalDDDSimConstants::getShift(const HcalSubdetector subdet,
-				  const int depth) const {
+int HcalDDDSimConstants::getShift(const HcalSubdetector& subdet,
+				  const int& depth) const {
 
   int shift;
   switch(subdet) {
@@ -1072,8 +1073,8 @@ int HcalDDDSimConstants::getShift(const HcalSubdetector subdet,
   return shift;
 }
 
-double HcalDDDSimConstants::getGain(const HcalSubdetector subdet, 
-				    const int depth) const {
+double HcalDDDSimConstants::getGain(const HcalSubdetector& subdet, 
+				    const int& depth) const {
 
   double gain;
   switch(subdet) {
@@ -1093,8 +1094,8 @@ double HcalDDDSimConstants::getGain(const HcalSubdetector subdet,
   return gain;
 }
 
-void HcalDDDSimConstants::printTileHB(const int eta, const int phi,
-				      const int zside, const int depth) const {
+void HcalDDDSimConstants::printTileHB(const int& eta,   const int& phi,
+				      const int& zside, const int& depth) const {
   edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants::printTileHB for eta " 
 			       << eta << " and depth " << depth;
   
@@ -1129,8 +1130,8 @@ void HcalDDDSimConstants::printTileHB(const int eta, const int phi,
   }
 }
 
-void HcalDDDSimConstants::printTileHE(const int eta, const int phi,
-				      const int zside, const int depth) const {
+void HcalDDDSimConstants::printTileHE(const int& eta,   const int& phi,
+				      const int& zside, const int& depth) const {
 
   double etaL   = hpar->etaTable[eta-1];
   double thetaL = 2.*atan(exp(-etaL));
@@ -1192,7 +1193,7 @@ void HcalDDDSimConstants::printTileHE(const int eta, const int phi,
   }
 }
 
-unsigned int HcalDDDSimConstants::layerGroupSize(const int eta) const {
+unsigned int HcalDDDSimConstants::layerGroupSize(int eta) const {
   unsigned int k = 0;
   for (auto const & it : hpar->layerGroupEtaSim) {
     if (it.layer == (unsigned int)(eta + 1)) {
@@ -1204,8 +1205,7 @@ unsigned int HcalDDDSimConstants::layerGroupSize(const int eta) const {
   return k;
 }
 
-unsigned int HcalDDDSimConstants::layerGroup(const int eta, 
-					     const int i) const {
+unsigned int HcalDDDSimConstants::layerGroup(int eta, int i) const {
   unsigned int k = 0;
   for (auto const & it :  hpar->layerGroupEtaSim) {
     if (it.layer == (unsigned int)(eta + 1)) {
@@ -1217,9 +1217,9 @@ unsigned int HcalDDDSimConstants::layerGroup(const int eta,
   return k;
 }
  
-unsigned int HcalDDDSimConstants::layerGroup(const int det, const int eta,
-					     const int phi, const int zside,
-					     const int lay) const {
+unsigned int HcalDDDSimConstants::layerGroup(int det, int eta,
+					     int phi, int zside,
+					     int lay) const {
 
   int depth0 = findDepth(det,eta,phi,zside,lay);
   unsigned int depth = (depth0 > 0) ? (unsigned int)(depth0) : layerGroup(eta-1,lay);


### PR DESCRIPTION
Active length in scintillator is used for MIP calculation. 