### PR TITLE
[backport from 93x to 92x] Dijet Prompt DQM for JEC (#19873)

### DIFF
--- a/DQMOffline/Trigger/plugins/DiJetMonitor.cc
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.cc
@@ -1,0 +1,299 @@
+#include "DQMOffline/Trigger/plugins/DiJetMonitor.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DQM/TrackingMonitor/interface/GetLumi.h"
+
+#include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
+
+
+// -----------------------------
+//  constructors and destructor
+// -----------------------------
+
+DiJetMonitor::DiJetMonitor( const edm::ParameterSet& iConfig ):
+num_genTriggerEventFlag_ ( new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("numGenericTriggerEventPSet"),consumesCollector(), *this))
+,den_genTriggerEventFlag_ ( new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("denGenericTriggerEventPSet"),consumesCollector(), *this))
+{
+  folderName_              = iConfig.getParameter<std::string>("FolderName"); 
+  dijetSrc_                = mayConsume<reco::PFJetCollection>(iConfig.getParameter<edm::InputTag>("dijetSrc"));//jet 
+  dijetpT_variable_binning_= iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetptBinning");
+  dijetpt_binning_         = getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("dijetPSet")    );
+  dijetptThr_binning_      = getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("dijetPtThrPSet")    );
+  ls_binning_              = getHistoLSPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("lsPSet")     );
+
+
+  ptcut_      = iConfig.getParameter<double>("ptcut" ); 
+  etacut_      = iConfig.getParameter<double>("etacut" ); // for DiJet Offline selection 
+  phicut_      = iConfig.getParameter<double>("delphicut" ); // for DiJet Offline selection
+
+}
+
+void DiJetMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
+				 edm::Run const        & iRun,
+				 edm::EventSetup const & iSetup) 
+{  
+  
+  std::string histname, histtitle;
+  std::string currentFolder = folderName_ ;
+  ibooker.setCurrentFolder(currentFolder.c_str());
+
+  histname = "jetpt1"; histtitle = "leading Jet Pt";
+  bookME(ibooker,jetpt1ME_,histname,histtitle,dijetpt_binning_.nbins,dijetpt_binning_.xmin, dijetpt_binning_.xmax);
+  setMETitle(jetpt1ME_,"Pt_1 [GeV]","events");
+
+  histname = "jetpt2"; histtitle = "second leading Jet Pt";
+  bookME(ibooker,jetpt2ME_,histname,histtitle,dijetpt_binning_.nbins,dijetpt_binning_.xmin, dijetpt_binning_.xmax);
+  setMETitle(jetpt2ME_,"Pt_2 [GeV]","events");
+
+  histname = "jetptAvgB"; histtitle = "Pt average before offline selection";
+  bookME(ibooker,jetptAvgbME_,histname,histtitle,dijetpt_binning_.nbins,dijetpt_binning_.xmin, dijetpt_binning_.xmax);
+  setMETitle(jetptAvgbME_,"(pt_1 + pt_2)*0.5 [GeV]","events");
+
+  histname = "jetptAvgA"; histtitle = "Pt average after offline selection";
+  bookME(ibooker,jetptAvgaME_,histname,histtitle,dijetpt_binning_.nbins,dijetpt_binning_.xmin, dijetpt_binning_.xmax);
+  setMETitle(jetptAvgaME_,"(pt_1 + pt_2)*0.5 [GeV]","events");
+
+  histname = "jetptAvgAThr"; histtitle = "Pt average after offline selection";
+  bookME(ibooker,jetptAvgaThrME_,histname,histtitle,dijetptThr_binning_.nbins,dijetptThr_binning_.xmin, dijetptThr_binning_.xmax);
+  setMETitle(jetptAvgaThrME_,"(pt_1 + pt_2)*0.5 [GeV]","events");
+
+  histname = "jetptTag"; histtitle = "Tag Jet Pt";
+  bookME(ibooker,jetptTagME_,histname,histtitle,dijetpt_binning_.nbins,dijetpt_binning_.xmin, dijetpt_binning_.xmax);
+  setMETitle(jetptTagME_,"Pt_tag [GeV]","events ");
+
+  histname = "jetptPrb"; histtitle = "Probe Jet Pt";
+  bookME(ibooker,jetptPrbME_,histname,histtitle,dijetpt_binning_.nbins,dijetpt_binning_.xmin,dijetpt_binning_.xmax);
+  setMETitle(jetptPrbME_,"Pt_prb [GeV]","events");
+
+  histname = "jetptAsym"; histtitle = "Jet Pt Asymetry";
+  bookME(ibooker,jetptAsyME_,histname,histtitle,asy_binning_.nbins,asy_binning_.xmin, asy_binning_.xmax);
+  setMETitle(jetptAsyME_,"(pt_prb - pt_tag)/(pt_prb + pt_tag)","events");
+
+  histname = "jetetaPrb"; histtitle = "Probe Jet eta";
+  bookME(ibooker,jetetaPrbME_,histname,histtitle,dijet_eta_binning_.nbins,dijet_eta_binning_.xmin, dijet_eta_binning_.xmax);
+  setMETitle(jetetaPrbME_,"Eta_probe #eta","events");
+
+  histname = "jetetaTag"; histtitle = "Tag Jet eta";
+  bookME(ibooker,jetetaTagME_,histname,histtitle,dijet_eta_binning_.nbins,dijet_eta_binning_.xmin, dijet_eta_binning_.xmax);
+  setMETitle(jetetaTagME_,"Eta_tag #eta","events");
+
+  histname = "ptAsymVSetaPrb"; histtitle = "Pt_Asym vs eta_prb";
+  bookME(ibooker,jetAsyEtaME_,histname,histtitle,asy_binning_.nbins, asy_binning_.xmin, asy_binning_.xmax, dijet_eta_binning_.nbins, dijet_eta_binning_.xmin,dijet_eta_binning_.xmax);
+  setMETitle(jetAsyEtaME_,"(pt_prb - pt_tag)/(pt_prb + pt_tag)","Eta_probe #eta");
+
+  histname = "etaPrbVSphiPrb"; histtitle = "eta_prb vs phi_prb";
+  bookME(ibooker,jetEtaPhiME_,histname,histtitle,dijet_eta_binning_.nbins, dijet_eta_binning_.xmin, dijet_eta_binning_.xmax, dijet_phi_binning_.nbins, dijet_phi_binning_.xmin,dijet_phi_binning_.xmax);
+  setMETitle(jetEtaPhiME_,"Eta_probe #eta","Phi_probe #phi");
+
+  histname = "jetphiPrb"; histtitle = "Probe Jet phi";
+  bookME(ibooker,jetphiPrbME_,histname,histtitle,dijet_phi_binning_.nbins,dijet_phi_binning_.xmin, dijet_phi_binning_.xmax);
+  setMETitle(jetphiPrbME_,"Phi_probe #phi","events");
+
+  // Initialize the GenericTriggerEventFlag
+  // Initialize the GenericTriggerEventFlag
+  if ( num_genTriggerEventFlag_ && num_genTriggerEventFlag_->on() ) num_genTriggerEventFlag_->initRun( iRun, iSetup );
+  if ( den_genTriggerEventFlag_ && den_genTriggerEventFlag_->on() ) den_genTriggerEventFlag_->initRun( iRun, iSetup );
+
+}
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "DataFormats/Math/interface/deltaR.h" // For Delta R
+void DiJetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup)  {
+  // Filter out events if Trigger Filtering is requested
+  if (den_genTriggerEventFlag_->on() && ! den_genTriggerEventFlag_->accept( iEvent, iSetup) ) return;
+ 
+  v_jetpt.clear();
+  v_jeteta.clear();
+  v_jetphi.clear();
+
+//  edm::Handle< edm::View<reco::Jet> > offjets;
+  edm::Handle<reco::PFJetCollection > offjets;
+  iEvent.getByToken( dijetSrc_, offjets );
+  if (!offjets.isValid()){
+      edm::LogWarning("DiJetMonitor") << "DiJet handle not valid \n";
+      return;
+  }
+  for ( reco::PFJetCollection::const_iterator ibegin = offjets->begin(), iend = offjets->end(), ijet = ibegin; ijet != iend; ++ijet ) {
+    if (ijet->pt()< ptcut_) {continue;}
+    v_jetpt.push_back(ijet->pt()); 
+    v_jeteta.push_back(ijet->eta()); 
+    v_jetphi.push_back(ijet->phi()); 
+  }
+  if (v_jetpt.size() < 2) {return;}
+  double pt_1 = v_jetpt[0];
+  double eta_1 = v_jeteta[0];
+  double phi_1 = v_jetphi[0];
+  double pt_2 = v_jetpt[1];
+  double eta_2 = v_jeteta[1];
+  double phi_2 = v_jetphi[1];
+  double pt_avg_b = (pt_1 + pt_2)*0.5;
+  int tag_id = -999, probe_id = -999;
+
+     jetpt1ME_.denominator -> Fill(pt_1);
+     jetpt2ME_.denominator -> Fill(pt_2);
+  jetptAvgbME_.denominator -> Fill(pt_avg_b);
+
+  if( dijet_selection(eta_1, phi_1, eta_2, phi_2, pt_1, pt_2,tag_id, probe_id ) ){ 
+  
+    if(tag_id == 0 && probe_id == 1) {
+      double pt_asy = (pt_2 - pt_1)/(pt_1 + pt_2);
+      double pt_avg = (pt_1 + pt_2)*0.5;
+    jetptAvgaME_.denominator -> Fill(pt_avg);
+    jetptAvgaThrME_.denominator -> Fill(pt_avg);
+     jetptTagME_.denominator -> Fill(pt_1);
+     jetptPrbME_.denominator -> Fill(pt_2);
+    jetetaPrbME_.denominator -> Fill(eta_2);
+    jetetaTagME_.denominator -> Fill(eta_1);
+     jetptAsyME_.denominator ->Fill(pt_asy);
+    jetphiPrbME_.denominator -> Fill(phi_2);
+    jetAsyEtaME_.denominator -> Fill(pt_asy,eta_2);
+  jetEtaPhiME_.denominator -> Fill(eta_2,phi_2);
+    }
+    if(tag_id == 1 && probe_id == 0) {
+      double pt_asy = (pt_1 - pt_2)/(pt_2 + pt_1);
+      double pt_avg = (pt_2 + pt_1)*0.5;
+   jetptAvgaME_.denominator -> Fill(pt_avg);
+   jetptAvgaThrME_.denominator -> Fill(pt_avg);
+    jetptTagME_.denominator -> Fill(pt_2);
+    jetptPrbME_.denominator -> Fill(pt_1);
+   jetetaPrbME_.denominator -> Fill(eta_1);
+   jetetaTagME_.denominator -> Fill(eta_2);
+    jetptAsyME_.denominator->Fill(pt_asy);
+   jetphiPrbME_.denominator -> Fill(phi_1);
+   jetAsyEtaME_.denominator -> Fill(pt_asy,eta_1);
+   jetEtaPhiME_.denominator -> Fill(eta_1,phi_1);
+   }
+
+  }
+
+  if (num_genTriggerEventFlag_->on() && ! num_genTriggerEventFlag_->accept( iEvent, iSetup) ) return; 
+
+     jetpt1ME_.numerator -> Fill(pt_1);
+     jetpt2ME_.numerator -> Fill(pt_2);
+  jetptAvgbME_.numerator -> Fill(pt_avg_b);
+
+    if(tag_id == 0 && probe_id == 1) {
+      double pt_asy = (pt_2 - pt_1)/(pt_1 + pt_2);
+      double pt_avg = (pt_1 + pt_2)*0.5;
+    jetptAvgaME_.numerator -> Fill(pt_avg);
+    jetptAvgaThrME_.numerator -> Fill(pt_avg);
+     jetptTagME_.numerator -> Fill(pt_1);
+     jetptPrbME_.numerator -> Fill(pt_2);
+    jetetaPrbME_.numerator -> Fill(eta_2);
+    jetetaTagME_.numerator -> Fill(eta_1);
+     jetptAsyME_.numerator->Fill(pt_asy);
+    jetphiPrbME_.numerator -> Fill(phi_2);
+    jetAsyEtaME_.numerator -> Fill(pt_asy,eta_2);
+    jetEtaPhiME_.numerator -> Fill(eta_2,phi_2);
+    }
+    if(tag_id == 1 && probe_id == 0) {
+      double pt_asy = (pt_1 - pt_2)/(pt_2 + pt_1);
+      double pt_avg = (pt_2 + pt_1)*0.5;
+    jetptAvgaME_.numerator -> Fill(pt_avg);
+    jetptAvgaThrME_.numerator -> Fill(pt_avg);
+     jetptTagME_.numerator -> Fill(pt_2);
+     jetptPrbME_.numerator -> Fill(pt_1);
+    jetetaPrbME_.numerator -> Fill(eta_1);
+    jetetaTagME_.numerator -> Fill(eta_2);
+     jetptAsyME_.numerator->Fill(pt_asy);
+    jetphiPrbME_.numerator -> Fill(phi_1);
+    jetAsyEtaME_.numerator -> Fill(pt_asy,eta_1);
+    jetEtaPhiME_.numerator -> Fill(eta_1,phi_1);
+    }
+
+}
+
+void DiJetMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
+{
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>  ( "FolderName", "HLT/JetMET" );
+
+  desc.add<edm::InputTag>( "met",      edm::InputTag("pfMet") );
+  desc.add<edm::InputTag>( "dijetSrc",     edm::InputTag("ak4PFJets") );
+  desc.add<edm::InputTag>( "electrons",edm::InputTag("gedGsfElectrons") );
+  desc.add<edm::InputTag>( "muons",    edm::InputTag("muons") );
+  desc.add<int>("njets",      0);
+  desc.add<int>("nelectrons", 0);
+  desc.add<double>("ptcut",   20);
+  desc.add<double>("etacut",   1.7);   //using dijet offline selection
+  desc.add<double>("delphicut",   2.7);//using dijet offline selection
+
+  edm::ParameterSetDescription genericTriggerEventPSet;
+  genericTriggerEventPSet.add<bool>("andOr");
+  genericTriggerEventPSet.add<edm::InputTag>("dcsInputTag", edm::InputTag("scalersRawToDigi") );
+  genericTriggerEventPSet.add<std::vector<int> >("dcsPartitions",{});
+  genericTriggerEventPSet.add<bool>("andOrDcs", false);
+  genericTriggerEventPSet.add<bool>("errorReplyDcs", true);
+  genericTriggerEventPSet.add<std::string>("dbLabel","");
+  genericTriggerEventPSet.add<bool>("andOrHlt", true);
+  genericTriggerEventPSet.add<edm::InputTag>("hltInputTag", edm::InputTag("TriggerResults::HLT") );
+  genericTriggerEventPSet.add<std::vector<std::string> >("hltPaths",{});
+  genericTriggerEventPSet.add<bool>("errorReplyHlt",false);
+  genericTriggerEventPSet.add<unsigned int>("verbosityLevel",1);
+
+  desc.add<edm::ParameterSetDescription>("numGenericTriggerEventPSet", genericTriggerEventPSet);
+  desc.add<edm::ParameterSetDescription>("denGenericTriggerEventPSet", genericTriggerEventPSet);
+
+  edm::ParameterSetDescription histoPSet;
+  edm::ParameterSetDescription dijetPSet;
+  edm::ParameterSetDescription dijetPtThrPSet;
+  fillHistoPSetDescription(dijetPSet);
+  fillHistoPSetDescription(dijetPtThrPSet);
+  histoPSet.add<edm::ParameterSetDescription>("dijetPSet", dijetPSet);  
+  histoPSet.add<edm::ParameterSetDescription>("dijetPtThrPSet", dijetPtThrPSet);  
+  std::vector<double> bins = {0.,20.,40.,60.,80.,90.,100.,110.,120.,130.,140.,150.,160.,170.,180.,190.,200.,220.,240.,260.,280.,300.,350.,400.,450.,1000.}; // DiJet pT Binning
+  histoPSet.add<std::vector<double> >("jetptBinning", bins);
+
+  edm::ParameterSetDescription lsPSet;
+  fillHistoLSPSetDescription(lsPSet);
+  histoPSet.add<edm::ParameterSetDescription>("lsPSet", lsPSet);
+  desc.add<edm::ParameterSetDescription>("histoPSet",histoPSet);
+
+  descriptions.add("dijetMonitoring", desc);
+}
+
+//---- Additional DiJet offline selection------
+bool DiJetMonitor::dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id){
+  bool passeta = false; //check that one of the jets in the barrel
+  if (abs(eta_1)< etacut_ || abs(eta_2) < etacut_ )  passeta=true;
+  
+  float delta_phi_1_2= (phi_1 - phi_2);
+  bool other_cuts = false;//check that jets are back to back
+  if (abs(delta_phi_1_2) >= phicut_)  other_cuts=true;
+
+   if(fabs(eta_1)<etacut_ && fabs(eta_2)>etacut_) {
+    tag_id = 0; 
+    probe_id = 1;
+  }
+  else 
+    if(fabs(eta_2)<etacut_ && fabs(eta_1)>etacut_) {
+      tag_id = 1; 
+      probe_id = 0;
+    }
+    else 
+      if(fabs(eta_2)<etacut_ && fabs(eta_1)<etacut_){
+    int ran = rand();
+    int numb = ran % 2 + 1;
+       if(numb==1){
+       tag_id = 0; 
+       probe_id = 1;
+       }
+       if(numb==2){
+         tag_id = 1; 
+         probe_id = 0;
+       }
+     }
+  if (passeta && other_cuts)
+    return true;
+  else
+    return false;
+}
+
+//------------------------------------------------------------------------//
+// Define this as a plug-in
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(DiJetMonitor);

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.cc
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.cc
@@ -17,15 +17,11 @@ num_genTriggerEventFlag_ ( new GenericTriggerEventFlag(iConfig.getParameter<edm:
 {
   folderName_              = iConfig.getParameter<std::string>("FolderName"); 
   dijetSrc_                = mayConsume<reco::PFJetCollection>(iConfig.getParameter<edm::InputTag>("dijetSrc"));//jet 
-  dijetpT_variable_binning_= iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetptBinning");
   dijetpt_binning_         = getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("dijetPSet")    );
   dijetptThr_binning_      = getHistoPSet   (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("dijetPtThrPSet")    );
-  ls_binning_              = getHistoLSPSet (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>   ("lsPSet")     );
 
 
   ptcut_      = iConfig.getParameter<double>("ptcut" ); 
-  etacut_      = iConfig.getParameter<double>("etacut" ); // for DiJet Offline selection 
-  phicut_      = iConfig.getParameter<double>("delphicut" ); // for DiJet Offline selection
 
 }
 
@@ -168,8 +164,6 @@ void DiJetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSet
    jetEtaPhiME_.denominator -> Fill(eta_1,phi_1);
    }
 
-  }
-
   if (num_genTriggerEventFlag_->on() && ! num_genTriggerEventFlag_->accept( iEvent, iSetup) ) return; 
 
      jetpt1ME_.numerator -> Fill(pt_1);
@@ -204,7 +198,7 @@ void DiJetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSet
     jetAsyEtaME_.numerator -> Fill(pt_asy,eta_1);
     jetEtaPhiME_.numerator -> Fill(eta_1,phi_1);
     }
-
+  }
 }
 
 void DiJetMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
@@ -219,8 +213,6 @@ void DiJetMonitor::fillDescriptions(edm::ConfigurationDescriptions & description
   desc.add<int>("njets",      0);
   desc.add<int>("nelectrons", 0);
   desc.add<double>("ptcut",   20);
-  desc.add<double>("etacut",   1.7);   //using dijet offline selection
-  desc.add<double>("delphicut",   2.7);//using dijet offline selection
 
   edm::ParameterSetDescription genericTriggerEventPSet;
   genericTriggerEventPSet.add<bool>("andOr");
@@ -258,6 +250,10 @@ void DiJetMonitor::fillDescriptions(edm::ConfigurationDescriptions & description
 
 //---- Additional DiJet offline selection------
 bool DiJetMonitor::dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id){
+  
+  double etacut_ = 1.7;
+  double phicut_ = 2.7;
+  
   bool passeta = false; //check that one of the jets in the barrel
   if (abs(eta_1)< etacut_ || abs(eta_2) < etacut_ )  passeta=true;
   

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.cc
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.cc
@@ -32,7 +32,7 @@ void DiJetMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
   
   std::string histname, histtitle;
   std::string currentFolder = folderName_ ;
-  ibooker.setCurrentFolder(currentFolder.c_str());
+  ibooker.setCurrentFolder(currentFolder);
 
   histname = "jetpt1"; histtitle = "leading Jet Pt";
   bookME(ibooker,jetpt1ME_,histname,histtitle,dijetpt_binning_.nbins,dijetpt_binning_.xmin, dijetpt_binning_.xmax);
@@ -63,27 +63,27 @@ void DiJetMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
   setMETitle(jetptPrbME_,"Pt_prb [GeV]","events");
 
   histname = "jetptAsym"; histtitle = "Jet Pt Asymetry";
-  bookME(ibooker,jetptAsyME_,histname,histtitle,asy_binning_.nbins,asy_binning_.xmin, asy_binning_.xmax);
+  bookME(ibooker,jetptAsyME_,histname,histtitle,asy_binning.nbins,asy_binning.xmin, asy_binning.xmax);
   setMETitle(jetptAsyME_,"(pt_prb - pt_tag)/(pt_prb + pt_tag)","events");
 
   histname = "jetetaPrb"; histtitle = "Probe Jet eta";
-  bookME(ibooker,jetetaPrbME_,histname,histtitle,dijet_eta_binning_.nbins,dijet_eta_binning_.xmin, dijet_eta_binning_.xmax);
+  bookME(ibooker,jetetaPrbME_,histname,histtitle,dijet_eta_binning.nbins,dijet_eta_binning.xmin, dijet_eta_binning.xmax);
   setMETitle(jetetaPrbME_,"Eta_probe #eta","events");
 
   histname = "jetetaTag"; histtitle = "Tag Jet eta";
-  bookME(ibooker,jetetaTagME_,histname,histtitle,dijet_eta_binning_.nbins,dijet_eta_binning_.xmin, dijet_eta_binning_.xmax);
+  bookME(ibooker,jetetaTagME_,histname,histtitle,dijet_eta_binning.nbins,dijet_eta_binning.xmin, dijet_eta_binning.xmax);
   setMETitle(jetetaTagME_,"Eta_tag #eta","events");
 
   histname = "ptAsymVSetaPrb"; histtitle = "Pt_Asym vs eta_prb";
-  bookME(ibooker,jetAsyEtaME_,histname,histtitle,asy_binning_.nbins, asy_binning_.xmin, asy_binning_.xmax, dijet_eta_binning_.nbins, dijet_eta_binning_.xmin,dijet_eta_binning_.xmax);
+  bookME(ibooker,jetAsyEtaME_,histname,histtitle,asy_binning.nbins, asy_binning.xmin, asy_binning.xmax, dijet_eta_binning.nbins, dijet_eta_binning.xmin,dijet_eta_binning.xmax);
   setMETitle(jetAsyEtaME_,"(pt_prb - pt_tag)/(pt_prb + pt_tag)","Eta_probe #eta");
 
   histname = "etaPrbVSphiPrb"; histtitle = "eta_prb vs phi_prb";
-  bookME(ibooker,jetEtaPhiME_,histname,histtitle,dijet_eta_binning_.nbins, dijet_eta_binning_.xmin, dijet_eta_binning_.xmax, dijet_phi_binning_.nbins, dijet_phi_binning_.xmin,dijet_phi_binning_.xmax);
+  bookME(ibooker,jetEtaPhiME_,histname,histtitle,dijet_eta_binning.nbins, dijet_eta_binning.xmin, dijet_eta_binning.xmax, dijet_phi_binning.nbins, dijet_phi_binning.xmin,dijet_phi_binning.xmax);
   setMETitle(jetEtaPhiME_,"Eta_probe #eta","Phi_probe #phi");
 
   histname = "jetphiPrb"; histtitle = "Probe Jet phi";
-  bookME(ibooker,jetphiPrbME_,histname,histtitle,dijet_phi_binning_.nbins,dijet_phi_binning_.xmin, dijet_phi_binning_.xmax);
+  bookME(ibooker,jetphiPrbME_,histname,histtitle,dijet_phi_binning.nbins,dijet_phi_binning.xmin, dijet_phi_binning.xmax);
   setMETitle(jetphiPrbME_,"Phi_probe #phi","events");
 
   // Initialize the GenericTriggerEventFlag
@@ -99,8 +99,15 @@ void DiJetMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "DataFormats/Math/interface/deltaR.h" // For Delta R
 void DiJetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup)  {
+  int Event = -999;
+  Event = iEvent.id().event();
   // Filter out events if Trigger Filtering is requested
   if (den_genTriggerEventFlag_->on() && ! den_genTriggerEventFlag_->accept( iEvent, iSetup) ) return;
+
+
+  std::vector<double> v_jetpt;
+  std::vector<double> v_jeteta;
+  std::vector<double> v_jetphi;
  
   v_jetpt.clear();
   v_jeteta.clear();
@@ -120,83 +127,83 @@ void DiJetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSet
     v_jetphi.push_back(ijet->phi()); 
   }
   if (v_jetpt.size() < 2) {return;}
-  double pt_1 = v_jetpt[0];
+  double pt_1  = v_jetpt[0];
   double eta_1 = v_jeteta[0];
   double phi_1 = v_jetphi[0];
-  double pt_2 = v_jetpt[1];
+  double pt_2  = v_jetpt[1];
   double eta_2 = v_jeteta[1];
   double phi_2 = v_jetphi[1];
   double pt_avg_b = (pt_1 + pt_2)*0.5;
   int tag_id = -999, probe_id = -999;
 
-     jetpt1ME_.denominator -> Fill(pt_1);
-     jetpt2ME_.denominator -> Fill(pt_2);
+  jetpt1ME_.denominator    -> Fill(pt_1);
+  jetpt2ME_.denominator    -> Fill(pt_2);
   jetptAvgbME_.denominator -> Fill(pt_avg_b);
 
-  if( dijet_selection(eta_1, phi_1, eta_2, phi_2, pt_1, pt_2,tag_id, probe_id ) ){ 
+  if( dijet_selection(eta_1, phi_1, eta_2, phi_2, pt_1, pt_2,tag_id, probe_id, Event ) ){ 
   
     if(tag_id == 0 && probe_id == 1) {
       double pt_asy = (pt_2 - pt_1)/(pt_1 + pt_2);
       double pt_avg = (pt_1 + pt_2)*0.5;
-    jetptAvgaME_.denominator -> Fill(pt_avg);
-    jetptAvgaThrME_.denominator -> Fill(pt_avg);
-     jetptTagME_.denominator -> Fill(pt_1);
-     jetptPrbME_.denominator -> Fill(pt_2);
-    jetetaPrbME_.denominator -> Fill(eta_2);
-    jetetaTagME_.denominator -> Fill(eta_1);
-     jetptAsyME_.denominator ->Fill(pt_asy);
-    jetphiPrbME_.denominator -> Fill(phi_2);
-    jetAsyEtaME_.denominator -> Fill(pt_asy,eta_2);
-  jetEtaPhiME_.denominator -> Fill(eta_2,phi_2);
+      jetptAvgaME_.denominator -> Fill(pt_avg);
+      jetptAvgaThrME_.denominator -> Fill(pt_avg);
+      jetptTagME_.denominator  -> Fill(pt_1);
+      jetptPrbME_.denominator  -> Fill(pt_2);
+      jetetaPrbME_.denominator -> Fill(eta_2);
+      jetetaTagME_.denominator -> Fill(eta_1);
+      jetptAsyME_.denominator  ->Fill(pt_asy);
+      jetphiPrbME_.denominator -> Fill(phi_2);
+      jetAsyEtaME_.denominator -> Fill(pt_asy,eta_2);
+      jetEtaPhiME_.denominator -> Fill(eta_2,phi_2);
     }
     if(tag_id == 1 && probe_id == 0) {
       double pt_asy = (pt_1 - pt_2)/(pt_2 + pt_1);
       double pt_avg = (pt_2 + pt_1)*0.5;
-   jetptAvgaME_.denominator -> Fill(pt_avg);
-   jetptAvgaThrME_.denominator -> Fill(pt_avg);
-    jetptTagME_.denominator -> Fill(pt_2);
-    jetptPrbME_.denominator -> Fill(pt_1);
-   jetetaPrbME_.denominator -> Fill(eta_1);
-   jetetaTagME_.denominator -> Fill(eta_2);
-    jetptAsyME_.denominator->Fill(pt_asy);
-   jetphiPrbME_.denominator -> Fill(phi_1);
-   jetAsyEtaME_.denominator -> Fill(pt_asy,eta_1);
-   jetEtaPhiME_.denominator -> Fill(eta_1,phi_1);
-   }
+      jetptAvgaME_.denominator -> Fill(pt_avg);
+      jetptAvgaThrME_.denominator -> Fill(pt_avg);
+      jetptTagME_.denominator  -> Fill(pt_2);
+      jetptPrbME_.denominator  -> Fill(pt_1);
+      jetetaPrbME_.denominator -> Fill(eta_1);
+      jetetaTagME_.denominator -> Fill(eta_2);
+      jetptAsyME_.denominator  ->Fill(pt_asy);
+      jetphiPrbME_.denominator -> Fill(phi_1);
+      jetAsyEtaME_.denominator -> Fill(pt_asy,eta_1);
+      jetEtaPhiME_.denominator -> Fill(eta_1,phi_1);
+    }
 
   if (num_genTriggerEventFlag_->on() && ! num_genTriggerEventFlag_->accept( iEvent, iSetup) ) return; 
 
-     jetpt1ME_.numerator -> Fill(pt_1);
-     jetpt2ME_.numerator -> Fill(pt_2);
-  jetptAvgbME_.numerator -> Fill(pt_avg_b);
+    jetpt1ME_.numerator    -> Fill(pt_1);
+    jetpt2ME_.numerator    -> Fill(pt_2);
+    jetptAvgbME_.numerator -> Fill(pt_avg_b);
 
     if(tag_id == 0 && probe_id == 1) {
       double pt_asy = (pt_2 - pt_1)/(pt_1 + pt_2);
       double pt_avg = (pt_1 + pt_2)*0.5;
-    jetptAvgaME_.numerator -> Fill(pt_avg);
-    jetptAvgaThrME_.numerator -> Fill(pt_avg);
-     jetptTagME_.numerator -> Fill(pt_1);
-     jetptPrbME_.numerator -> Fill(pt_2);
-    jetetaPrbME_.numerator -> Fill(eta_2);
-    jetetaTagME_.numerator -> Fill(eta_1);
-     jetptAsyME_.numerator->Fill(pt_asy);
-    jetphiPrbME_.numerator -> Fill(phi_2);
-    jetAsyEtaME_.numerator -> Fill(pt_asy,eta_2);
-    jetEtaPhiME_.numerator -> Fill(eta_2,phi_2);
+      jetptAvgaME_.numerator -> Fill(pt_avg);
+      jetptAvgaThrME_.numerator -> Fill(pt_avg);
+      jetptTagME_.numerator  -> Fill(pt_1);
+      jetptPrbME_.numerator  -> Fill(pt_2);
+      jetetaPrbME_.numerator -> Fill(eta_2);
+      jetetaTagME_.numerator -> Fill(eta_1);
+      jetptAsyME_.numerator  ->Fill(pt_asy);
+      jetphiPrbME_.numerator -> Fill(phi_2);
+      jetAsyEtaME_.numerator -> Fill(pt_asy,eta_2);
+      jetEtaPhiME_.numerator -> Fill(eta_2,phi_2);
     }
     if(tag_id == 1 && probe_id == 0) {
       double pt_asy = (pt_1 - pt_2)/(pt_2 + pt_1);
       double pt_avg = (pt_2 + pt_1)*0.5;
-    jetptAvgaME_.numerator -> Fill(pt_avg);
-    jetptAvgaThrME_.numerator -> Fill(pt_avg);
-     jetptTagME_.numerator -> Fill(pt_2);
-     jetptPrbME_.numerator -> Fill(pt_1);
-    jetetaPrbME_.numerator -> Fill(eta_1);
-    jetetaTagME_.numerator -> Fill(eta_2);
-     jetptAsyME_.numerator->Fill(pt_asy);
-    jetphiPrbME_.numerator -> Fill(phi_1);
-    jetAsyEtaME_.numerator -> Fill(pt_asy,eta_1);
-    jetEtaPhiME_.numerator -> Fill(eta_1,phi_1);
+      jetptAvgaME_.numerator -> Fill(pt_avg);
+      jetptAvgaThrME_.numerator -> Fill(pt_avg);
+      jetptTagME_.numerator  -> Fill(pt_2);
+      jetptPrbME_.numerator  -> Fill(pt_1);
+      jetetaPrbME_.numerator -> Fill(eta_1);
+      jetetaTagME_.numerator -> Fill(eta_2);
+      jetptAsyME_.numerator->Fill(pt_asy);
+      jetphiPrbME_.numerator -> Fill(phi_1);
+      jetAsyEtaME_.numerator -> Fill(pt_asy,eta_1);
+      jetEtaPhiME_.numerator -> Fill(eta_1,phi_1);
     }
   }
 }
@@ -249,41 +256,39 @@ void DiJetMonitor::fillDescriptions(edm::ConfigurationDescriptions & description
 }
 
 //---- Additional DiJet offline selection------
-bool DiJetMonitor::dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id){
+bool DiJetMonitor::dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id, int Event){
   
-  double etacut_ = 1.7;
-  double phicut_ = 2.7;
+  double etacut = 1.7;
+  double phicut = 2.7;
   
   bool passeta = false; //check that one of the jets in the barrel
-  if (abs(eta_1)< etacut_ || abs(eta_2) < etacut_ )  passeta=true;
+  if (std::abs(eta_1)< etacut || std::abs(eta_2) < etacut )  passeta=true;
   
   float delta_phi_1_2= (phi_1 - phi_2);
-  bool other_cuts = false;//check that jets are back to back
-  if (abs(delta_phi_1_2) >= phicut_)  other_cuts=true;
+  bool other_cuts = (std::abs(delta_phi_1_2) >= phicut); //check that jets are back to back
 
-   if(fabs(eta_1)<etacut_ && fabs(eta_2)>etacut_) {
-    tag_id = 0; 
-    probe_id = 1;
-  }
-  else 
-    if(fabs(eta_2)<etacut_ && fabs(eta_1)>etacut_) {
+   if(std::abs(eta_1)<etacut && std::abs(eta_2)>etacut) {
+      tag_id = 0; 
+      probe_id = 1;
+   }
+   else 
+   if(std::abs(eta_2)<etacut && std::abs(eta_1)>etacut) {
       tag_id = 1; 
       probe_id = 0;
-    }
-    else 
-      if(fabs(eta_2)<etacut_ && fabs(eta_1)<etacut_){
-    int ran = rand();
-    int numb = ran % 2 + 1;
-       if(numb==1){
-       tag_id = 0; 
-       probe_id = 1;
-       }
-       if(numb==2){
+   }
+   else 
+   if(std::abs(eta_2)<etacut && std::abs(eta_1)<etacut){
+      int numb = Event % 2;
+      if(numb==0){
+         tag_id = 0; 
+         probe_id = 1;
+      }
+      if(numb==1){
          tag_id = 1; 
          probe_id = 0;
-       }
-     }
-  if (passeta && other_cuts)
+      }
+   }
+   if (passeta && other_cuts)
     return true;
   else
     return false;

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.h
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.h
@@ -1,0 +1,127 @@
+#ifndef JETMETMONITOR_H
+#define JETMETMONITOR_H
+
+#include <string>
+#include <vector>
+#include <map>
+
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
+
+#include "DQMOffline/Trigger/plugins/TriggerDQMBase.h"
+#include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+//DataFormats
+#include "DataFormats/METReco/interface/PFMET.h"
+#include "DataFormats/METReco/interface/PFMETCollection.h"
+
+#include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/JetReco/interface/PFJetCollection.h"
+#include "DataFormats/JetReco/interface/CaloJet.h"
+#include "DataFormats/JetReco/interface/CaloJetCollection.h"
+#include "DataFormats/JetReco/interface/GenJetCollection.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
+
+class GenericTriggerEventFlag;
+
+
+
+//
+// class declaration
+//
+
+class DiJetMonitor : public DQMEDAnalyzer  ,  public TriggerDQMBase
+{
+public:
+  DiJetMonitor( const edm::ParameterSet& );
+  virtual ~DiJetMonitor() noexcept(true) {};
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+
+protected:
+
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
+  bool dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id);
+
+private:
+
+  std::string folderName_;
+  std::string histoSuffix_;
+
+  edm::EDGetTokenT<reco::PFMETCollection>       metToken_;
+  edm::EDGetTokenT<reco::GsfElectronCollection> eleToken_;
+  edm::EDGetTokenT<reco::MuonCollection>        muoToken_;
+  edm::EDGetTokenT<reco::PFJetCollection>  dijetSrc_; // test for Jet
+
+  std::vector<double> dijetpT_variable_binning_;
+  MEbinning           dijetpt_binning_;
+  MEbinning           dijetptThr_binning_;
+  MEbinning           ls_binning_;
+
+  ObjME jetpt1ME_;
+  ObjME jetpt2ME_;
+  ObjME jetptAvgaME_;
+  ObjME jetptAvgaThrME_;
+  ObjME jetptAvgbME_;
+  ObjME jetptTagME_;
+  ObjME jetptPrbME_;
+  ObjME jetptAsyME_;
+  ObjME jetetaPrbME_;
+  ObjME jetetaTagME_;
+  ObjME jetphiPrbME_;
+  ObjME jetAsyEtaME_;
+  ObjME jetEtaPhiME_;
+
+  std::unique_ptr<GenericTriggerEventFlag> num_genTriggerEventFlag_;
+  std::unique_ptr<GenericTriggerEventFlag> den_genTriggerEventFlag_;
+
+  int nmuons_;
+  double ptcut_;
+  double etacut_;
+  double phicut_;
+
+  std::vector<double> v_jetpt;
+  std::vector<double> v_jeteta;
+  std::vector<double> v_jetphi;
+
+  // Define Phi Bin //
+  double DiJet_MAX_PHI = 3.2;
+  unsigned int DiJet_N_PHI = 64;
+  MEbinning dijet_phi_binning_{
+    DiJet_N_PHI, -DiJet_MAX_PHI, DiJet_MAX_PHI
+  };
+  // Define Eta Bin //
+  double DiJet_MAX_ETA = 5;
+  unsigned int DiJet_N_ETA = 50;
+  MEbinning dijet_eta_binning_{
+    DiJet_N_ETA, -DiJet_MAX_ETA, DiJet_MAX_ETA
+  };
+
+  double MAX_asy = 1;
+  double MIN_asy = -1;
+  unsigned int N_asy = 100;
+  MEbinning asy_binning_{
+    N_asy, MIN_asy, MAX_asy
+  };
+
+};
+
+#endif // JETMETMONITOR_H

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.h
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.h
@@ -71,10 +71,8 @@ private:
   edm::EDGetTokenT<reco::MuonCollection>        muoToken_;
   edm::EDGetTokenT<reco::PFJetCollection>  dijetSrc_; // test for Jet
 
-  std::vector<double> dijetpT_variable_binning_;
   MEbinning           dijetpt_binning_;
   MEbinning           dijetptThr_binning_;
-  MEbinning           ls_binning_;
 
   ObjME jetpt1ME_;
   ObjME jetpt2ME_;
@@ -95,8 +93,6 @@ private:
 
   int nmuons_;
   double ptcut_;
-  double etacut_;
-  double phicut_;
 
   std::vector<double> v_jetpt;
   std::vector<double> v_jeteta;

--- a/DQMOffline/Trigger/plugins/DiJetMonitor.h
+++ b/DQMOffline/Trigger/plugins/DiJetMonitor.h
@@ -1,5 +1,5 @@
-#ifndef JETMETMONITOR_H
-#define JETMETMONITOR_H
+#ifndef DIJETMONITOR_H
+#define DIJETMONITOR_H
 
 #include <string>
 #include <vector>
@@ -52,14 +52,14 @@ class DiJetMonitor : public DQMEDAnalyzer  ,  public TriggerDQMBase
 {
 public:
   DiJetMonitor( const edm::ParameterSet& );
-  virtual ~DiJetMonitor() noexcept(true) {};
+  ~DiJetMonitor() throw() override {};
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 protected:
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
-  bool dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id);
+  bool dijet_selection(double eta_1, double phi_1, double eta_2, double phi_2, double pt_1, double pt_2, int &tag_id, int &probe_id, int Event);
 
 private:
 
@@ -94,27 +94,24 @@ private:
   int nmuons_;
   double ptcut_;
 
-  std::vector<double> v_jetpt;
-  std::vector<double> v_jeteta;
-  std::vector<double> v_jetphi;
 
   // Define Phi Bin //
-  double DiJet_MAX_PHI = 3.2;
+  const double DiJet_MAX_PHI = 3.2;
   unsigned int DiJet_N_PHI = 64;
-  MEbinning dijet_phi_binning_{
+  MEbinning dijet_phi_binning{
     DiJet_N_PHI, -DiJet_MAX_PHI, DiJet_MAX_PHI
   };
   // Define Eta Bin //
-  double DiJet_MAX_ETA = 5;
+  const double DiJet_MAX_ETA = 5;
   unsigned int DiJet_N_ETA = 50;
-  MEbinning dijet_eta_binning_{
+  MEbinning dijet_eta_binning{
     DiJet_N_ETA, -DiJet_MAX_ETA, DiJet_MAX_ETA
   };
 
-  double MAX_asy = 1;
-  double MIN_asy = -1;
+  const double MAX_asy = 1;
+  const double MIN_asy = -1;
   unsigned int N_asy = 100;
-  MEbinning asy_binning_{
+  MEbinning asy_binning{
     N_asy, MIN_asy, MAX_asy
   };
 

--- a/DQMOffline/Trigger/plugins/TriggerDQMBase.cc
+++ b/DQMOffline/Trigger/plugins/TriggerDQMBase.cc
@@ -1,0 +1,76 @@
+#include "DQMOffline/Trigger/plugins/TriggerDQMBase.h"
+
+void TriggerDQMBase::setMETitle(ObjME& me, const std::string& titleX, const std::string& titleY)
+{
+  me.numerator->setAxisTitle(titleX,1);
+  me.numerator->setAxisTitle(titleY,2);
+  me.denominator->setAxisTitle(titleX,1);
+  me.denominator->setAxisTitle(titleY,2);
+
+}
+
+void TriggerDQMBase::bookME(DQMStore::IBooker &ibooker, ObjME& me, const std::string& histname, const std::string& histtitle, unsigned nbins, double min, double max)
+{
+  me.numerator   = ibooker.book1D(histname+"_numerator",   histtitle+" (numerator)",   nbins, min, max);
+  me.denominator = ibooker.book1D(histname+"_denominator", histtitle+" (denominator)", nbins, min, max);
+}
+void TriggerDQMBase::bookME(DQMStore::IBooker &ibooker, ObjME& me, const std::string& histname, const std::string& histtitle, const std::vector<double>& binning)
+{
+  unsigned nbins = binning.size()-1;
+  std::vector<float> fbinning(binning.begin(),binning.end());
+  float* arr = &fbinning[0];
+  me.numerator   = ibooker.book1D(histname+"_numerator",   histtitle+" (numerator)",   nbins, arr);
+  me.denominator = ibooker.book1D(histname+"_denominator", histtitle+" (denominator)", nbins, arr);
+}
+void TriggerDQMBase::bookME(DQMStore::IBooker &ibooker, ObjME& me, const std::string& histname, const std::string& histtitle, unsigned nbinsX, double xmin, double xmax, double ymin, double ymax)
+{
+  me.numerator   = ibooker.bookProfile(histname+"_numerator",   histtitle+" (numerator)",   nbinsX, xmin, xmax, ymin, ymax);
+  me.denominator = ibooker.bookProfile(histname+"_denominator", histtitle+" (denominator)", nbinsX, xmin, xmax, ymin, ymax);
+}
+void TriggerDQMBase::bookME(DQMStore::IBooker &ibooker, ObjME& me, const std::string& histname, const std::string& histtitle, unsigned nbinsX, double xmin, double xmax, unsigned nbinsY, double ymin, double ymax)
+{
+  me.numerator   = ibooker.book2D(histname+"_numerator",   histtitle+" (numerator)",   nbinsX, xmin, xmax, nbinsY, ymin, ymax);
+  me.denominator = ibooker.book2D(histname+"_denominator", histtitle+" (denominator)", nbinsX, xmin, xmax, nbinsY, ymin, ymax);
+}
+void TriggerDQMBase::bookME(DQMStore::IBooker &ibooker, ObjME& me, const std::string& histname, const std::string& histtitle, const std::vector<double>& binningX, const std::vector<double>& binningY)
+{
+  unsigned nbinsX = binningX.size()-1;
+  std::vector<float> fbinningX(binningX.begin(),binningX.end());
+  float* arrX = &fbinningX[0];
+  unsigned nbinsY = binningY.size()-1;
+  std::vector<float> fbinningY(binningY.begin(),binningY.end());
+  float* arrY = &fbinningY[0];
+
+  me.numerator   = ibooker.book2D(histname+"_numerator",   histtitle+" (numerator)",   nbinsX, arrX, nbinsY, arrY);
+  me.denominator = ibooker.book2D(histname+"_denominator", histtitle+" (denominator)", nbinsX, arrX, nbinsY, arrY);
+}
+
+void TriggerDQMBase::fillHistoPSetDescription(edm::ParameterSetDescription & pset)
+{
+  pset.add<unsigned>   ( "nbins");
+  pset.add<double>( "xmin" );
+  pset.add<double>( "xmax" );
+}
+
+void TriggerDQMBase::fillHistoLSPSetDescription(edm::ParameterSetDescription & pset)
+{
+  pset.add<unsigned>   ( "nbins", 2500);
+}
+
+TriggerDQMBase::MEbinning TriggerDQMBase::getHistoPSet(const edm::ParameterSet& pset)
+{
+  return TriggerDQMBase::MEbinning{
+    pset.getParameter<uint32_t>("nbins"),
+      pset.getParameter<double>("xmin"),
+      pset.getParameter<double>("xmax"),
+      };
+}
+
+TriggerDQMBase::MEbinning TriggerDQMBase::getHistoLSPSet(const edm::ParameterSet& pset)
+{
+  return TriggerDQMBase::MEbinning{
+    pset.getParameter<uint32_t>("nbins"),
+      0.,
+      double(pset.getParameter<uint32_t>("nbins"))
+      };
+}

--- a/DQMOffline/Trigger/plugins/TriggerDQMBase.h
+++ b/DQMOffline/Trigger/plugins/TriggerDQMBase.h
@@ -1,0 +1,42 @@
+#ifndef DQMOffline_Trigger_TriggerDQMBase_H
+#define DQMOffline_Trigger_TriggerDQMBase_H
+
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+class TriggerDQMBase
+{
+ public:
+  TriggerDQMBase()= default;;  
+  virtual ~TriggerDQMBase()= default;;
+
+  struct MEbinning {
+    unsigned nbins;
+    double xmin;
+    double xmax;
+  };
+  
+  struct ObjME {
+    MonitorElement* numerator = nullptr;
+    MonitorElement* denominator = nullptr;
+  };
+
+  static void fillHistoPSetDescription(edm::ParameterSetDescription & pset);
+  static void fillHistoLSPSetDescription(edm::ParameterSetDescription & pset);
+  static MEbinning getHistoPSet    (const edm::ParameterSet& pset);
+  static MEbinning getHistoLSPSet  (const edm::ParameterSet& pset);
+
+ protected:
+  void bookME(DQMStore::IBooker &, ObjME& me, const std::string& histname, const std::string& histtitle, unsigned nbins, double xmin, double xmax);
+  void bookME(DQMStore::IBooker &, ObjME& me, const std::string& histname, const std::string& histtitle, const std::vector<double>& binningX);
+  void bookME(DQMStore::IBooker &, ObjME& me, const std::string& histname, const std::string& histtitle, unsigned nbinsX, double xmin, double xmax, double ymin, double ymax);
+  void bookME(DQMStore::IBooker &, ObjME& me, const std::string& histname, const std::string& histtitle, unsigned nbinsX, double xmin, double xmax, unsigned nbinsY, double ymin, double ymax);
+  void bookME(DQMStore::IBooker &, ObjME& me, const std::string& histname, const std::string& histtitle, const std::vector<double>& binningX, const std::vector<double>& binningY);
+  void setMETitle(ObjME& me, const std::string& titleX, const std::string& titleY);
+
+ private:
+
+};//class
+
+#endif //DQMOffline_Trigger_TriggerDQMBase_H

--- a/DQMOffline/Trigger/python/DQMOffline_HLT_Client_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_HLT_Client_cff.py
@@ -28,6 +28,7 @@ from DQMOffline.Trigger.TopMonitoring_Client_cff import *
 
 from DQMOffline.Trigger.BTaggingMonitoring_Client_cff import *
 from DQMOffline.Trigger.BPHMonitoring_Client_cff import *
+from DQMOffline.Trigger.DiJetMonitor_Client_cff import * 
 hltOfflineDQMClient = cms.Sequence(
 #    hltGeneralSeqClient *
     sipixelHarvesterHLTsequence *
@@ -48,6 +49,7 @@ hltOfflineDQMClient = cms.Sequence(
     smpClient *
     topClient *
     btaggingClient *
-    bphClient
+    bphClient*
+    dijetClient
     )
 

--- a/DQMOffline/Trigger/python/DiJetMonitor_Client_cff.py
+++ b/DQMOffline/Trigger/python/DiJetMonitor_Client_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+dijetEfficiency = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/JetMET/*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_dijetptAvgThr       'Jet Pt turnON;            DiJet_Pt_Avg [GeV]; efficiency'     jetptAvgAThr_numerator    jetptAvgAThr_denominator",
+        "effic_dijetphiPrb         'Jet efficiency vs #phi_probe; DiJet_Phi_probe #phi [rad]; efficiency'     jetphiPrb_numerator       jetphiPrb_denominator",
+        "effic_dijetetaPrb         'Jet efficiency vs #eta_probe; DiJet_Eta_probe #eta; efficiency'           jetetaPrb_numerator       jetetaPrb_denominator",
+        "effic_dijetetaTag         'Jet efficiency vs #eta_tag; DiJet_Eta_tag #eta; efficiency'           jetetaTag_numerator       jetetaTag_denominator"
+    )
+  
+)
+
+dijetClient = cms.Sequence(
+    dijetEfficiency
+)

--- a/DQMOffline/Trigger/python/DiJetMonitor_Client_cff.py
+++ b/DQMOffline/Trigger/python/DiJetMonitor_Client_cff.py
@@ -8,8 +8,7 @@ dijetEfficiency = DQMEDHarvester("DQMGenericClient",
     efficiency     = cms.vstring(
         "effic_dijetptAvgThr       'Jet Pt turnON;            DiJet_Pt_Avg [GeV]; efficiency'     jetptAvgAThr_numerator    jetptAvgAThr_denominator",
         "effic_dijetphiPrb         'Jet efficiency vs #phi_probe; DiJet_Phi_probe #phi [rad]; efficiency'     jetphiPrb_numerator       jetphiPrb_denominator",
-        "effic_dijetetaPrb         'Jet efficiency vs #eta_probe; DiJet_Eta_probe #eta; efficiency'           jetetaPrb_numerator       jetetaPrb_denominator",
-        "effic_dijetetaTag         'Jet efficiency vs #eta_tag; DiJet_Eta_tag #eta; efficiency'           jetetaTag_numerator       jetetaTag_denominator"
+        "effic_dijetetaPrb         'Jet efficiency vs #eta_probe; DiJet_Eta_probe #eta; efficiency'           jetetaPrb_numerator       jetetaPrb_denominator"
     )
   
 )

--- a/DQMOffline/Trigger/python/DiJetMonitor_cff.py
+++ b/DQMOffline/Trigger/python/DiJetMonitor_cff.py
@@ -1,0 +1,162 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.DiJetMonitor_cfi import DiPFjetAve40_Prommonitoring
+### HLT_DiJet Triggers ###
+# DiPFjetAve60
+DiPFjetAve60_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve60_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve60/')
+DiPFjetAve60_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  75 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  150.),
+)
+DiPFjetAve60_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve60_v*")
+
+# DiPFjetAve80
+DiPFjetAve80_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve80_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve80/')
+DiPFjetAve80_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  100 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  200.),
+)
+DiPFjetAve80_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve80_v*")
+
+# DiPFjetAve140
+DiPFjetAve140_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve140_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve140/')
+DiPFjetAve140_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  70 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  350.),
+)
+DiPFjetAve140_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve140_v*")
+
+# DiPFjetAve200
+DiPFjetAve200_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve200_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve200/')
+DiPFjetAve200_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  50 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  500.),
+)
+DiPFjetAve200_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve200_v*")
+
+# DiPFjetAve260
+DiPFjetAve260_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve260_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve260/')
+DiPFjetAve260_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  65 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  650.),
+)
+DiPFjetAve260_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve260_v*")
+
+# DiPFjetAve320
+DiPFjetAve320_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve320_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve320/')
+DiPFjetAve320_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  80 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  800.),
+)
+DiPFjetAve320_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve320_v*")
+
+# DiPFjetAve400
+DiPFjetAve400_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve400_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve400/')
+DiPFjetAve400_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  100 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  1000.),
+)
+DiPFjetAve400_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve400_v*")
+
+# DiPFjetAve500
+DiPFjetAve500_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve500_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve500/')
+DiPFjetAve500_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  125),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(1250),
+)
+DiPFjetAve500_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve500_v*")
+
+# HLT_DiPFJetAve60_HFJEC
+DiPFjetAve60_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve60_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve60_HFJEC/')
+DiPFjetAve60_HFJEC_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  75 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  150.),
+)
+DiPFjetAve60_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve60_HFJEC_v*")
+
+# HLT_DiPFJetAve80_HFJEC
+DiPFjetAve80_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve80_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve80_HFJEC/')
+DiPFjetAve80_HFJEC_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  100 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  200.),
+)
+DiPFjetAve80_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve80_HFJEC_v*")
+
+# HLT_DiPFJetAve100_HFJEC
+DiPFjetAve100_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve100_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve100_HFJEC/')
+DiPFjetAve100_HFJEC_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  50 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  250.),
+)
+DiPFjetAve100_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve100_HFJEC_v*")
+
+# HLT_DiPFJetAve160_HFJEC
+DiPFjetAve160_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve160_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve160_HFJEC/')
+DiPFjetAve160_HFJEC_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  80 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  400.),
+)
+DiPFjetAve160_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve160_HFJEC_v*")
+
+# HLT_DiPFJetAve220_HFJEC
+DiPFjetAve220_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve220_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve220_HFJEC/')
+DiPFjetAve220_HFJEC_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  55 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  550.),
+)
+DiPFjetAve220_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve220_HFJEC_v*")
+
+# HLT_DiPFJetAve300_HFJEC
+DiPFjetAve300_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
+DiPFjetAve300_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve300_HFJEC/')
+DiPFjetAve300_HFJEC_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  75 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(  750.),
+)
+DiPFjetAve300_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve300_HFJEC_v*")
+
+HLTDiJetmonitoring = cms.Sequence(
+    DiPFjetAve40_Prommonitoring
+    *DiPFjetAve60_Prommonitoring
+    *DiPFjetAve80_Prommonitoring
+    *DiPFjetAve140_Prommonitoring
+    *DiPFjetAve200_Prommonitoring
+    *DiPFjetAve260_Prommonitoring
+    *DiPFjetAve320_Prommonitoring
+    *DiPFjetAve400_Prommonitoring
+    *DiPFjetAve500_Prommonitoring
+    *DiPFjetAve60_HFJEC_Prommonitoring
+    *DiPFjetAve80_HFJEC_Prommonitoring
+    *DiPFjetAve100_HFJEC_Prommonitoring
+    *DiPFjetAve160_HFJEC_Prommonitoring
+    *DiPFjetAve220_HFJEC_Prommonitoring
+    *DiPFjetAve300_HFJEC_Prommonitoring
+)
+

--- a/DQMOffline/Trigger/python/DiJetMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/DiJetMonitor_cfi.py
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.dijetMonitoring_cfi import dijetMonitoring
+DiPFjetAve40_Prommonitoring = dijetMonitoring.clone()
+DiPFjetAve40_Prommonitoring.FolderName = cms.string('HLT/JetMET/HLT_DiPFJetAve40/')
+DiPFjetAve40_Prommonitoring.histoPSet.dijetPSet = cms.PSet(
+  nbins = cms.uint32 (  200  ),
+  xmin  = cms.double(   0),
+  xmax  = cms.double(1000.),
+)
+DiPFjetAve40_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
+  nbins = cms.uint32 (  50 ),
+  xmin  = cms.double(   0.),
+  xmax  = cms.double(100.),
+)
+DiPFjetAve40_Prommonitoring.met       = cms.InputTag("pfMetEI") # pfMet
+#DiPFjetAve40_Prommonitoring.pfjets    = cms.InputTag("ak4PFJets") # ak4PFJets, ak4PFJetsCHS
+DiPFjetAve40_Prommonitoring.dijetSrc  = cms.InputTag("ak4PFJets") # ak4PFJets, ak4PFJetsCHS
+DiPFjetAve40_Prommonitoring.electrons = cms.InputTag("gedGsfElectrons") # while pfIsolatedElectronsEI are reco::PFCandidate !
+DiPFjetAve40_Prommonitoring.muons     = cms.InputTag("muons") # while pfIsolatedMuonsEI are reco::PFCandidate !
+DiPFjetAve40_Prommonitoring.ptcut     = cms.double(20) # while pfIsolatedMuonsEI are reco::PFCandidate !
+DiPFjetAve40_Prommonitoring.etacut     = cms.double(1.7) # Using dijet offline selection
+DiPFjetAve40_Prommonitoring.delphicut  = cms.double(2.7) # Using dijet offline selection
+
+DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
+DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.dbLabel       = cms.string("JetMETDQMTrigger") # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
+DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
+DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
+DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_DiPFJetAve40_v*") # HLT_ZeroBias_v*
+DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
+DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
+
+DiPFjetAve40_Prommonitoring.denGenericTriggerEventPSet.andOr         = cms.bool( False )
+DiPFjetAve40_Prommonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
+DiPFjetAve40_Prommonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29: pixel, we should add all other detectors !
+DiPFjetAve40_Prommonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
+DiPFjetAve40_Prommonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
+DiPFjetAve40_Prommonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
+

--- a/DQMOffline/Trigger/python/DiJetMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/DiJetMonitor_cfi.py
@@ -19,8 +19,6 @@ DiPFjetAve40_Prommonitoring.dijetSrc  = cms.InputTag("ak4PFJets") # ak4PFJets, a
 DiPFjetAve40_Prommonitoring.electrons = cms.InputTag("gedGsfElectrons") # while pfIsolatedElectronsEI are reco::PFCandidate !
 DiPFjetAve40_Prommonitoring.muons     = cms.InputTag("muons") # while pfIsolatedMuonsEI are reco::PFCandidate !
 DiPFjetAve40_Prommonitoring.ptcut     = cms.double(20) # while pfIsolatedMuonsEI are reco::PFCandidate !
-DiPFjetAve40_Prommonitoring.etacut     = cms.double(1.7) # Using dijet offline selection
-DiPFjetAve40_Prommonitoring.delphicut  = cms.double(2.7) # Using dijet offline selection
 
 DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
 DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.dbLabel       = cms.string("JetMETDQMTrigger") # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !

--- a/DQMOffline/Trigger/python/JetMETPromptMonitor_cff.py
+++ b/DQMOffline/Trigger/python/JetMETPromptMonitor_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.JetMonitor_cff import *
+from DQMOffline.Trigger.DiJetMonitor_cff import * 
+jetmetMonitorHLT = cms.Sequence(
+    HLTJetmonitoring *
+    HLTDiJetmonitoring
+)


### PR DESCRIPTION
///Trigger Paths///
HLT_DiPFJetAve40
HLT_DiPFJetAve60
HLT_DiPFJetAve80
HLT_DiPFJetAve140
HLT_DiPFJetAve200
HLT_DiPFJetAve260
HLT_DiPFJetAve320
HLT_DiPFJetAve400
HLT_DiPFJetAve500
HLT_DiPFJetAve60_HFJEC
HLT_DiPFJetAve80_HFJEC
HLT_DiPFJetAve100_HFJEC
HLT_DiPFJetAve160_HFJEC
HLT_DiPFJetAve220_HFJEC
HLT_DiPFJetAve300_HFJEC

///Histograms///
jetpt1 : pt of leading jet passed trigger and w/o offline selection
jetpt2 : pt of second leading jet passed trigger and w/o offline selection
jetptAvgB : Fill using (pt_1 + pt_2) * 0.5 , pt average before offline selection
jetptAvgA: Fill using (pt_1 + pt_2) * 0.5 , pt average after offline selection
jetptAvgAThr : Fill using (pt_1 + pt_2) * 0.5 , pt average after offline selection using dijetPtThrPSet
jetptTag : tag jet passed trigger and offline selection satisfied with fabs(eta) < 1.3
jetptPrb : probe jet passed trigger and offline selection, satisfied with fabs(eta) > 1.3 among pt_1 and pt_2
(If both pt_1 and pt_2 are satisfied with fabs(eta) < 1.3, tag and probe are randomly selected.)
jetptAsym : using (pt_prb - pt_tag)/(pt_tag + pt_prb), asymmetry of pt_tag and pt_prb
jetetaPrb : eta of probe jet
jetetaTag : eta of tag jet
ptAsymVSetaPrb : 2D historgram of pt_asym and eta_prb
etaPrbVSphiPrb : 2D historgram of eta_prb and phi_prb
jetphiPrb : phi of probe jet