### PR TITLE
LogErrorHarvester depends on  EDProducers

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -2212,6 +2212,14 @@ class ConfigBuilder(object):
 
 	self.pythonCfgCode += self.addCustomiseCmdLine()
 
+        if hasattr(self.process,"logErrorHarvester"):
+                #configure logErrorHarvester to wait for same EDProducers to finish as the OutputModules
+                self.pythonCfgCode +="\n#Have logErrorHarvester wait for the same EDProducers to finish as those providing data for the OutputModule\n"
+                self.pythonCfgCode +="from FWCore.Modules.logErrorHarvester_cff import customiseLogErrorHarvesterUsingOutputCommands\n"
+                self.pythonCfgCode +="process = customiseLogErrorHarvesterUsingOutputCommands(process)\n"
+                from FWCore.Modules.logErrorHarvester_cff import customiseLogErrorHarvesterUsingOutputCommands
+                self.process = customiseLogErrorHarvesterUsingOutputCommands(self.process)
+
         # Temporary hack to put the early delete customization after
         # everything else
         #

--- a/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
@@ -71,6 +71,11 @@ reconstructionCosmics         = cms.Sequence(localReconstructionCosmics*
                                              metrecoCosmics*
                                              egammaCosmics*
                                              logErrorHarvester)
+#logErrorHarvester should only wait for items produced in the reconstructionCosmics sequence
+_modulesInReconstruction = list()
+reconstructionCosmics.visit(cms.ModuleNamesFromGlobalsVisitor(globals(),_modulesInReconstruction))
+logErrorHarvester.includeModules = cms.untracked.vstring(set(_modulesInReconstruction))
+
 reconstructionCosmics_HcalNZS = cms.Sequence(localReconstructionCosmics_HcalNZS*
                                              beamhaloTracksSeq*
                                              jetsCosmics*

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -131,6 +131,11 @@ from FWCore.Modules.logErrorHarvester_cfi import *
 # "Export" Section
 reconstruction         = cms.Sequence(localreco*globalreco*highlevelreco*logErrorHarvester)
 
+#logErrorHarvester should only wait for items produced in the reconstruction sequence
+_modulesInReconstruction = list()
+reconstruction.visit(cms.ModuleNamesFromGlobalsVisitor(globals(),_modulesInReconstruction))
+logErrorHarvester.includeModules = cms.untracked.vstring(set(_modulesInReconstruction))
+
 reconstruction_trackingOnly = cms.Sequence(localreco*globalreco_tracking)
 
 #need a fully expanded sequence copy

--- a/Configuration/StandardSequences/python/earlyDeleteSettings_cff.py
+++ b/Configuration/StandardSequences/python/earlyDeleteSettings_cff.py
@@ -52,6 +52,15 @@ def customiseEarlyDelete(process):
             branchSet.add(branch)
     process.options.canDeleteEarly.extend(list(branchSet))
 
+    # LogErrorHarvester should not wait for deleted items
+    for prod in process.producers_().itervalues():
+        if prod.type_() == "LogErrorHarvester":
+            if not hasattr(prod,'excludeModules'):
+                prod.excludeModules = cms.untracked.vstring()
+            t = prod.excludeModules.value()
+            t.extend([b.split('_')[1] for b in branchSet])
+            prod.excludeModules = t
+
     # Find the consumers
     producers=[]
     branchesList=[]

--- a/FWCore/Modules/BuildFile.xml
+++ b/FWCore/Modules/BuildFile.xml
@@ -3,5 +3,7 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/Sources"/>
+<use   name="FWCore/Utilities"/>
+<use   name="DataFormats/Common"/>
 <use   name="boost"/>
 <flags   EDM_PLUGIN="1"/>

--- a/FWCore/Modules/python/logErrorHarvester_cff.py
+++ b/FWCore/Modules/python/logErrorHarvester_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+from FWCore.Modules.logErrorHarvester_cfi import logErrorHarvester
+
+def customiseLogErrorHarvesterUsingOutputCommands(process):
+    if not hasattr(process,'logErrorHarvester'):
+        return process
+
+    modulesFromOutput = set()
+    for o in process.outputModules_().itervalues():
+        if not hasattr(o,"outputCommands"):
+            continue
+        for ln in o.outputCommands.value():
+            if -1 != ln.find("keep"):
+                s = ln.split("_")
+                if len(s)>1:
+                    if s[1].find("*")==-1 and s[1] != 'logErrorHarvester':
+                        modulesFromOutput.add(s[1])
+    process.logErrorHarvester.includeModules =cms.untracked.vstring(*modulesFromOutput)
+    return process

--- a/FWCore/Modules/python/logErrorHarvester_cff.py
+++ b/FWCore/Modules/python/logErrorHarvester_cff.py
@@ -2,18 +2,39 @@ import FWCore.ParameterSet.Config as cms
 from FWCore.Modules.logErrorHarvester_cfi import logErrorHarvester
 
 def customiseLogErrorHarvesterUsingOutputCommands(process):
-    if not hasattr(process,'logErrorHarvester'):
+    logName = 'logErrorHarvester'
+    if not hasattr(process,logName):
         return process
 
-    modulesFromOutput = set()
+    modulesFromAllOutput = set()
+    onlyOneOutput = (len(process.outputModules_()) == 1)
     for o in process.outputModules_().itervalues():
         if not hasattr(o,"outputCommands"):
+            continue
+        modulesFromOutput = set()
+        storesLogs = False
+        if (not onlyOneOutput) and hasattr(o,"SelectEvents") and hasattr(o.SelectEvents,"SelectEvents") and o.SelectEvents.SelectEvents:
+            #if the output module is skimming events, we do not want to force running of 
+            # unscheduled modules
             continue
         for ln in o.outputCommands.value():
             if -1 != ln.find("keep"):
                 s = ln.split("_")
                 if len(s)>1:
-                    if s[1].find("*")==-1 and s[1] != 'logErrorHarvester':
-                        modulesFromOutput.add(s[1])
-    process.logErrorHarvester.includeModules =cms.untracked.vstring(*modulesFromOutput)
+                    if s[1].find("*")==-1:
+                        if s[1] != logName:
+                            modulesFromOutput.add(s[1])
+                        else:
+                            storesLogs = True
+        if storesLogs:
+            modulesFromAllOutput =modulesFromAllOutput.union(modulesFromOutput)
+    if hasattr(process.logErrorHarvester,"includeModules"):
+        #need to exclude items from includeModules which are not being stored
+        includeMods = set(process.logErrorHarvester.includeModules)
+        toExclude = includeMods.difference(modulesFromAllOutput)
+        if hasattr(process.logErrorHarvester,"excludeModules"):
+            toExclude = toExclude.union(set(process.logErrorHarvester.excludeModules.value()))
+        process.logErrorHarvester.excludeModules = cms.untracked.vstring(*toExclude)
+    else:
+        process.logErrorHarvester.includeModules = cms.untracked.vstring(*modulesFromAllOutput)
     return process

--- a/FWCore/Modules/src/LogErrorHarvester.cc
+++ b/FWCore/Modules/src/LogErrorHarvester.cc
@@ -23,9 +23,14 @@
 #include "FWCore/MessageLogger/interface/LoggedErrorsSummary.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "DataFormats/Common/interface/EndPathStatus.h"
+#include "DataFormats/Common/interface/PathStatus.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
 
 // system include files
 #include <memory>
+#include <unordered_set>
+#include <string>
 
 //
 // class decleration
@@ -41,10 +46,42 @@ namespace edm {
     void beginJob() override;
     void produce(StreamID, Event&, EventSetup const&) const override;
     void endJob() override;
+    
   };
 
-  LogErrorHarvester::LogErrorHarvester(ParameterSet const&) {
+  LogErrorHarvester::LogErrorHarvester(ParameterSet const& iPSet) {
+    
     produces<std::vector<ErrorSummaryEntry>>();
+
+    const edm::TypeID endPathStatusType{typeid(edm::EndPathStatus)};
+    const edm::TypeID pathStatusType{typeid(edm::PathStatus)};
+    const edm::TypeID triggerResultsType{typeid(edm::TriggerResults)};
+
+    auto const& ignore = iPSet.getUntrackedParameter<std::vector<std::string>>("excludeModules");
+    const std::unordered_set<std::string> excludedModules(ignore.begin(),ignore.end());
+
+    auto const& includeM = iPSet.getUntrackedParameter<std::vector<std::string>>("includeModules");
+    const std::unordered_set<std::string> includeModules(includeM.begin(),includeM.end());
+
+    //Need to be sure to run only after all other EDProducers have run
+    callWhenNewProductsRegistered([this,
+                                   endPathStatusType,pathStatusType,triggerResultsType,
+                                   excludedModules, includeModules](edm::BranchDescription const& iBD) 
+    {
+      if((iBD.branchType() == edm::InEvent and moduleDescription().processName() == iBD.processName()) and 
+         ( (not includeModules.empty() and
+            includeModules.end() != includeModules.find(iBD.moduleLabel())) or
+           (iBD.unwrappedTypeID() != endPathStatusType and
+            iBD.unwrappedTypeID() != pathStatusType and
+            iBD.unwrappedTypeID() != triggerResultsType))) {
+        if(excludedModules.end() == excludedModules.find(iBD.moduleLabel())) {
+          consumes(edm::TypeToGet{iBD.unwrappedTypeID(),edm::PRODUCT_TYPE},
+                   edm::InputTag{iBD.moduleLabel(),
+                                 iBD.productInstanceName(),
+                                 iBD.processName()});
+        }
+      }
+    });
   }
 
   void
@@ -74,6 +111,8 @@ namespace edm {
   void
   LogErrorHarvester::fillDescriptions(ConfigurationDescriptions& descriptions) {
     ParameterSetDescription desc;
+    desc.addUntracked<std::vector<std::string>>("excludeModules",std::vector<std::string>{})->setComment("List of module labels to exclude from consumes.");
+    desc.addUntracked<std::vector<std::string>>("includeModules",std::vector<std::string>{})->setComment("List of the only module labels to include in consumes. The empty list will include all.");
     descriptions.add("logErrorHarvester", desc);
   }
 }

--- a/FWCore/Modules/src/LogErrorHarvester.cc
+++ b/FWCore/Modules/src/LogErrorHarvester.cc
@@ -69,8 +69,8 @@ namespace edm {
                                    excludedModules, includeModules](edm::BranchDescription const& iBD) 
     {
       if((iBD.branchType() == edm::InEvent and moduleDescription().processName() == iBD.processName()) and 
-         ( (not includeModules.empty() and
-            includeModules.end() != includeModules.find(iBD.moduleLabel())) or
+         ( (includeModules.empty() or
+            includeModules.end() != includeModules.find(iBD.moduleLabel())) and
            (iBD.unwrappedTypeID() != endPathStatusType and
             iBD.unwrappedTypeID() != pathStatusType and
             iBD.unwrappedTypeID() != triggerResultsType))) {

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -14,7 +14,7 @@ from Modules import *
 from Modules import _Module
 from SequenceTypes import *
 from SequenceTypes import _ModuleSequenceType, _Sequenceable  #extend needs it
-from SequenceVisitors import PathValidator, EndPathValidator, ScheduleTaskValidator, NodeVisitor, CompositeVisitor
+from SequenceVisitors import PathValidator, EndPathValidator, ScheduleTaskValidator, NodeVisitor, CompositeVisitor, ModuleNamesFromGlobalsVisitor
 import DictTypes
 
 from ExceptionHandling import *

--- a/FWCore/ParameterSet/python/SequenceVisitors.py
+++ b/FWCore/ParameterSet/python/SequenceVisitors.py
@@ -103,6 +103,19 @@ class CompositeVisitor(object):
         #self._node.leave(visitee)
         self._decorated.leave(visitee)
 
+class ModuleNamesFromGlobalsVisitor(object):
+    """Fill a list with the names of Event module types in a sequence. The names are determined
+    by using globals() to lookup the variable names assigned to the modules. This
+    allows the determination of the labels before the modules have been attached to a Process."""
+    def __init__(self,globals_,l):
+        self._moduleToName = { v[1]:v[0] for v in globals_.iteritems() if isinstance(v[1],_Module) }
+        self._names =l
+    def enter(self,node):
+        if isinstance(node,_Module):
+            self._names.append(self._moduleToName[node])
+    def leave(self,node):
+        return
+
 if __name__=="__main__":
     import unittest
     class TestModuleCommand(unittest.TestCase):


### PR DESCRIPTION
In order to capture all MessageLogger messages from all EDProducers in the job, the LogErrorHarvester says it 'consumes' all data from those EDProducers.