### PR TITLE
Cleanup suggested by scram b code-checks

### DIFF
--- a/FWCore/ParameterSet/interface/ANDGroupDescription.h
+++ b/FWCore/ParameterSet/interface/ANDGroupDescription.h
@@ -29,43 +29,43 @@ namespace edm {
     ANDGroupDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
                         std::unique_ptr<ParameterDescriptionNode> node_right);
 
-    virtual ParameterDescriptionNode* clone() const {
+    ParameterDescriptionNode* clone() const override {
       return new ANDGroupDescription(*this);
     }
 
   private:
 
-    virtual void checkAndGetLabelsAndTypes_(std::set<std::string> & usedLabels,
-                                            std::set<ParameterTypes> & parameterTypes,
-                                            std::set<ParameterTypes> & wildcardTypes) const;
+    void checkAndGetLabelsAndTypes_(std::set<std::string> & usedLabels,
+                                    std::set<ParameterTypes> & parameterTypes,
+                                    std::set<ParameterTypes> & wildcardTypes) const override;
 
-    virtual void validate_(ParameterSet & pset,
-                           std::set<std::string> & validatedLabels,
-                           bool optional) const;
+    void validate_(ParameterSet & pset,
+                   std::set<std::string> & validatedLabels,
+                   bool optional) const override;
 
-    virtual void writeCfi_(std::ostream & os,
-                           bool & startWithComma,
-                           int indentation,
-                           bool & wroteSomething) const;
+    void writeCfi_(std::ostream & os,
+                   bool & startWithComma,
+                   int indentation,
+                   bool & wroteSomething) const override;
 
-    virtual void print_(std::ostream & os,
-                        bool optional,
-                        bool writeToCfi,
-                        DocFormatHelper & dfh) const;
+    void print_(std::ostream & os,
+                bool optional,
+                bool writeToCfi,
+                DocFormatHelper & dfh) const override;
 
-    virtual bool hasNestedContent_() const {
+    bool hasNestedContent_() const override {
       return true;
     }
 
-    virtual void printNestedContent_(std::ostream & os,
-                                     bool optional,
-                                     DocFormatHelper & dfh) const;
+    void printNestedContent_(std::ostream & os,
+                             bool optional,
+                             DocFormatHelper & dfh) const override;
 
-    virtual bool exists_(ParameterSet const& pset) const;
+    bool exists_(ParameterSet const& pset) const override;
 
-    virtual bool partiallyExists_(ParameterSet const& pset) const;
+    bool partiallyExists_(ParameterSet const& pset) const override;
 
-    virtual int howManyXORSubNodesExist_(ParameterSet const& pset) const;
+    int howManyXORSubNodesExist_(ParameterSet const& pset) const override;
 
 
     void throwIfDuplicateLabels(std::set<std::string> const& labelsLeft,

--- a/FWCore/ParameterSet/interface/AllowedLabelsDescription.h
+++ b/FWCore/ParameterSet/interface/AllowedLabelsDescription.h
@@ -34,15 +34,15 @@ namespace edm {
     {
     }
 
-    virtual ParameterDescriptionNode* clone() const {
+    ParameterDescriptionNode* clone() const override {
       return new AllowedLabelsDescription(*this);
     }
 
   private:
 
-    virtual void validateAllowedLabel_(std::string const& allowedLabel,
-                                       ParameterSet & pset,
-                                       std::set<std::string> & validatedLabels) const {
+    void validateAllowedLabel_(std::string const& allowedLabel,
+                               ParameterSet & pset,
+                               std::set<std::string> & validatedLabels) const override {
       if (pset.existsAs<T>(allowedLabel, isTracked())) {
         validatedLabels.insert(allowedLabel);
       }
@@ -67,17 +67,17 @@ namespace edm {
                              ParameterSetDescription const& value,
                              bool isTracked);
 
-    virtual ParameterDescriptionNode* clone() const;
+    ParameterDescriptionNode* clone() const override;
 
   private:
 
-    virtual void printNestedContent_(std::ostream & os,
-                                     bool optional,
-                                     DocFormatHelper & helper) const;
+    void printNestedContent_(std::ostream & os,
+                             bool optional,
+                             DocFormatHelper & helper) const override;
 
-    virtual void validateAllowedLabel_(std::string const& allowedLabel,
-                                       ParameterSet & pset,
-                                       std::set<std::string> & validatedLabels) const;
+    void validateAllowedLabel_(std::string const& allowedLabel,
+                               ParameterSet & pset,
+                               std::set<std::string> & validatedLabels) const override;
 
     value_ptr<ParameterSetDescription> psetDesc_;
   };
@@ -100,17 +100,17 @@ namespace edm {
                              ParameterSetDescription const& value,
                              bool isTracked);
 
-    virtual ParameterDescriptionNode* clone() const;
+    ParameterDescriptionNode* clone() const override;
 
   private:
 
-    virtual void printNestedContent_(std::ostream & os,
-                                     bool optional,
-                                     DocFormatHelper & helper) const;
+    void printNestedContent_(std::ostream & os,
+                             bool optional,
+                             DocFormatHelper & helper) const override;
 
-    virtual void validateAllowedLabel_(std::string const& allowedLabel,
-                                       ParameterSet & pset,
-                                       std::set<std::string> & validatedLabels) const;
+    void validateAllowedLabel_(std::string const& allowedLabel,
+                               ParameterSet & pset,
+                               std::set<std::string> & validatedLabels) const override;
 
     value_ptr<ParameterSetDescription> psetDesc_;
   };

--- a/FWCore/ParameterSet/interface/AllowedLabelsDescriptionBase.h
+++ b/FWCore/ParameterSet/interface/AllowedLabelsDescriptionBase.h
@@ -16,7 +16,7 @@ namespace edm {
   class AllowedLabelsDescriptionBase : public ParameterDescriptionNode {
   public:
 
-    virtual ~AllowedLabelsDescriptionBase();
+    ~AllowedLabelsDescriptionBase() override;
 
     ParameterTypes type() const { return type_; }
     bool isTracked() const { return isTracked_; }
@@ -33,36 +33,36 @@ namespace edm {
 
   private:
 
-    virtual void checkAndGetLabelsAndTypes_(std::set<std::string> & usedLabels,
-                                            std::set<ParameterTypes> & parameterTypes,
-                                            std::set<ParameterTypes> & wildcardTypes) const;
+    void checkAndGetLabelsAndTypes_(std::set<std::string> & usedLabels,
+                                    std::set<ParameterTypes> & parameterTypes,
+                                    std::set<ParameterTypes> & wildcardTypes) const override;
 
-    virtual void validate_(ParameterSet & pset,
-                           std::set<std::string> & validatedLabels,
-                           bool optional) const;
+    void validate_(ParameterSet & pset,
+                   std::set<std::string> & validatedLabels,
+                   bool optional) const override;
 
-    virtual void writeCfi_(std::ostream & os,
-                           bool & startWithComma,
-                           int indentation,
-                           bool & wroteSomething) const;
+    void writeCfi_(std::ostream & os,
+                   bool & startWithComma,
+                   int indentation,
+                   bool & wroteSomething) const override;
 
 
-    virtual void print_(std::ostream & os,
-                        bool optional,
-                        bool writeToCfi,
-                        DocFormatHelper & dfh) const;
+    void print_(std::ostream & os,
+                bool optional,
+                bool writeToCfi,
+                DocFormatHelper & dfh) const override;
 
-    virtual bool hasNestedContent_() const;
+    bool hasNestedContent_() const override;
 
-    virtual void printNestedContent_(std::ostream & os,
-                                     bool optional,
-                                     DocFormatHelper & dfh) const;
+    void printNestedContent_(std::ostream & os,
+                             bool optional,
+                             DocFormatHelper & dfh) const override;
 
-    virtual bool exists_(ParameterSet const& pset) const;
+    bool exists_(ParameterSet const& pset) const override;
 
-    virtual bool partiallyExists_(ParameterSet const& pset) const;
+    bool partiallyExists_(ParameterSet const& pset) const override;
 
-    virtual int howManyXORSubNodesExist_(ParameterSet const& pset) const;
+    int howManyXORSubNodesExist_(ParameterSet const& pset) const override;
 
     virtual void validateAllowedLabel_(std::string const& allowedLabel,
                                        ParameterSet & pset,

--- a/FWCore/ParameterSet/interface/EmptyGroupDescription.h
+++ b/FWCore/ParameterSet/interface/EmptyGroupDescription.h
@@ -16,35 +16,35 @@ namespace edm {
   public:
     EmptyGroupDescription();
 
-    virtual ParameterDescriptionNode* clone() const {
+    ParameterDescriptionNode* clone() const override {
       return new EmptyGroupDescription(*this);
     }
 
   private:
 
-    virtual void checkAndGetLabelsAndTypes_(std::set<std::string> & usedLabels,
-                                            std::set<ParameterTypes> & parameterTypes,
-                                            std::set<ParameterTypes> & wildcardTypes) const;
+    void checkAndGetLabelsAndTypes_(std::set<std::string> & usedLabels,
+                                    std::set<ParameterTypes> & parameterTypes,
+                                    std::set<ParameterTypes> & wildcardTypes) const override;
 
-    virtual void validate_(ParameterSet & pset,
-                           std::set<std::string> & validatedLabels,
-                           bool optional) const;
+    void validate_(ParameterSet & pset,
+                   std::set<std::string> & validatedLabels,
+                   bool optional) const override;
 
-    virtual void writeCfi_(std::ostream & os,
-                           bool & startWithComma,
-                           int indentation,
-                           bool & wroteSomething) const;
+    void writeCfi_(std::ostream & os,
+                   bool & startWithComma,
+                   int indentation,
+                   bool & wroteSomething) const override;
 
-    virtual void print_(std::ostream & os,
-                        bool optional,
-                        bool writeToCfi,
-                        DocFormatHelper & dfh) const;
+    void print_(std::ostream & os,
+                bool optional,
+                bool writeToCfi,
+                DocFormatHelper & dfh) const override;
 
-    virtual bool exists_(ParameterSet const& pset) const;
+    bool exists_(ParameterSet const& pset) const override;
 
-    virtual bool partiallyExists_(ParameterSet const& pset) const;
+    bool partiallyExists_(ParameterSet const& pset) const override;
 
-    virtual int howManyXORSubNodesExist_(ParameterSet const& pset) const;
+    int howManyXORSubNodesExist_(ParameterSet const& pset) const override;
   };
 }
 #endif

--- a/FWCore/ParameterSet/interface/IfExistsDescription.h
+++ b/FWCore/ParameterSet/interface/IfExistsDescription.h
@@ -29,43 +29,43 @@ namespace edm {
     IfExistsDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
                         std::unique_ptr<ParameterDescriptionNode> node_right);
 
-    virtual ParameterDescriptionNode* clone() const {
+    ParameterDescriptionNode* clone() const override {
       return new IfExistsDescription(*this);
     }
 
   private:
 
-    virtual void checkAndGetLabelsAndTypes_(std::set<std::string> & usedLabels,
-                                            std::set<ParameterTypes> & parameterTypes,
-                                            std::set<ParameterTypes> & wildcardTypes) const;
+    void checkAndGetLabelsAndTypes_(std::set<std::string> & usedLabels,
+                                    std::set<ParameterTypes> & parameterTypes,
+                                    std::set<ParameterTypes> & wildcardTypes) const override;
 
-    virtual void validate_(ParameterSet & pset,
-                           std::set<std::string> & validatedLabels,
-                           bool optional) const;
+    void validate_(ParameterSet & pset,
+                   std::set<std::string> & validatedLabels,
+                   bool optional) const override;
 
-    virtual void writeCfi_(std::ostream & os,
-                           bool & startWithComma,
-                           int indentation,
-                           bool & wroteSomething) const;
+    void writeCfi_(std::ostream & os,
+                   bool & startWithComma,
+                   int indentation,
+                   bool & wroteSomething) const override;
 
-    virtual void print_(std::ostream & os,
-                        bool optional,
-                        bool writeToCfi,
-                        DocFormatHelper & dfh) const;
+    void print_(std::ostream & os,
+                bool optional,
+                bool writeToCfi,
+                DocFormatHelper & dfh) const override;
 
-    virtual bool hasNestedContent_() const {
+    bool hasNestedContent_() const override {
       return true;
     }
 
-    virtual void printNestedContent_(std::ostream & os,
-                                     bool optional,
-                                     DocFormatHelper & dfh) const;
+    void printNestedContent_(std::ostream & os,
+                             bool optional,
+                             DocFormatHelper & dfh) const override;
 
-    virtual bool exists_(ParameterSet const& pset) const;
+    bool exists_(ParameterSet const& pset) const override;
 
-    virtual bool partiallyExists_(ParameterSet const& pset) const;
+    bool partiallyExists_(ParameterSet const& pset) const override;
 
-    virtual int howManyXORSubNodesExist_(ParameterSet const& pset) const;
+    int howManyXORSubNodesExist_(ParameterSet const& pset) const override;
 
     void throwIfDuplicateLabels(std::set<std::string> const& labelsLeft,
                                 std::set<std::string> const& labelsRight) const;

--- a/FWCore/ParameterSet/interface/ORGroupDescription.h
+++ b/FWCore/ParameterSet/interface/ORGroupDescription.h
@@ -29,43 +29,43 @@ namespace edm {
     ORGroupDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
                        std::unique_ptr<ParameterDescriptionNode> node_right);
 
-    virtual ParameterDescriptionNode* clone() const {
+    ParameterDescriptionNode* clone() const override {
       return new ORGroupDescription(*this);
     }
 
   private:
 
-    virtual void checkAndGetLabelsAndTypes_(std::set<std::string> & usedLabels,
-                                            std::set<ParameterTypes> & parameterTypes,
-                                            std::set<ParameterTypes> & wildcardTypes) const;
+    void checkAndGetLabelsAndTypes_(std::set<std::string> & usedLabels,
+                                    std::set<ParameterTypes> & parameterTypes,
+                                    std::set<ParameterTypes> & wildcardTypes) const override;
 
-    virtual void validate_(ParameterSet & pset,
-                           std::set<std::string> & validatedLabels,
-                           bool optional) const;
+    void validate_(ParameterSet & pset,
+                   std::set<std::string> & validatedLabels,
+                   bool optional) const override;
 
-    virtual void writeCfi_(std::ostream & os,
-                           bool & startWithComma,
-                           int indentation,
-                           bool & wroteSomething) const;
+    void writeCfi_(std::ostream & os,
+                   bool & startWithComma,
+                   int indentation,
+                   bool & wroteSomething) const override;
 
-    virtual void print_(std::ostream & os,
-                        bool optional,
-                        bool writeToCfi,
-                        DocFormatHelper & dfh) const;
+    void print_(std::ostream & os,
+                bool optional,
+                bool writeToCfi,
+                DocFormatHelper & dfh) const override;
 
-    virtual bool hasNestedContent_() const {
+    bool hasNestedContent_() const override {
       return true;
     }
 
-    virtual void printNestedContent_(std::ostream & os,
-                                     bool optional,
-                                     DocFormatHelper & dfh) const;
+    void printNestedContent_(std::ostream & os,
+                             bool optional,
+                             DocFormatHelper & dfh) const override;
 
-    virtual bool exists_(ParameterSet const& pset) const;
+    bool exists_(ParameterSet const& pset) const override;
 
-    virtual bool partiallyExists_(ParameterSet const& pset) const;
+    bool partiallyExists_(ParameterSet const& pset) const override;
 
-    virtual int howManyXORSubNodesExist_(ParameterSet const& pset) const;
+    int howManyXORSubNodesExist_(ParameterSet const& pset) const override;
 
     void throwIfDuplicateLabels(std::set<std::string> const& labelsLeft,
                                 std::set<std::string> const& labelsRight) const;

--- a/FWCore/ParameterSet/interface/ParameterDescription.h
+++ b/FWCore/ParameterSet/interface/ParameterDescription.h
@@ -160,9 +160,9 @@ namespace edm {
       value_() {
     }
 
-    virtual ~ParameterDescription() { }
+    ~ParameterDescription() override { }
 
-    virtual ParameterDescriptionNode* clone() const {
+    ParameterDescriptionNode* clone() const override {
       return new ParameterDescription(*this);
     }
 
@@ -170,28 +170,28 @@ namespace edm {
 
   private:
 
-    virtual bool exists_(ParameterSet const& pset) const {
+    bool exists_(ParameterSet const& pset) const override {
       return pset.existsAs<T>(label(), isTracked());
     }
 
-    virtual bool hasNestedContent_() const {
+    bool hasNestedContent_() const override {
       if (!hasDefault()) return false;
       return writeParameterValue::hasNestedContent(value_);
     }
 
-    virtual void writeCfi_(std::ostream& os, int indentation) const {
+    void writeCfi_(std::ostream& os, int indentation) const override {
       writeParameterValue::writeValue(os, indentation, value_, writeParameterValue::CFI);
     }
 
-    virtual void writeDoc_(std::ostream& os, int indentation) const {
+    void writeDoc_(std::ostream& os, int indentation) const override {
       writeParameterValue::writeValue(os, indentation, value_, writeParameterValue::DOC);
     }
 
-    virtual bool exists_(ParameterSet const& pset, bool isTracked) const {
+    bool exists_(ParameterSet const& pset, bool isTracked) const override {
       return pset.existsAs<T>(label(), isTracked);
     }
 
-    virtual void insertDefault_(ParameterSet& pset) const {
+    void insertDefault_(ParameterSet& pset) const override {
       if (isTracked()) {
         pset.addParameter(label(), value_);
       }
@@ -218,40 +218,40 @@ namespace edm {
                          bool isTracked,
                          Comment const& iComment = Comment());
 
-    virtual ~ParameterDescription();
+    ~ParameterDescription() override;
 
-    virtual ParameterSetDescription const* parameterSetDescription() const;
-    virtual ParameterSetDescription * parameterSetDescription();
+    ParameterSetDescription const* parameterSetDescription() const override;
+    ParameterSetDescription * parameterSetDescription() override;
 
-    virtual ParameterDescriptionNode* clone() const {
+    ParameterDescriptionNode* clone() const override {
       return new ParameterDescription(*this);
     }
 
   private:
 
-    virtual void validate_(ParameterSet& pset,
-                           std::set<std::string>& validatedLabels,
-                           bool optional) const;
+    void validate_(ParameterSet& pset,
+                   std::set<std::string>& validatedLabels,
+                   bool optional) const override;
 
-    virtual void printDefault_(std::ostream& os,
-                                 bool writeToCfi,
-                                 DocFormatHelper& dfh) const;
+    void printDefault_(std::ostream& os,
+                       bool writeToCfi,
+                       DocFormatHelper& dfh) const override;
 
-    virtual bool hasNestedContent_() const;
+    bool hasNestedContent_() const override;
 
-    virtual void printNestedContent_(std::ostream& os,
-                                     bool optional,
-                                     DocFormatHelper& dfh) const;
+    void printNestedContent_(std::ostream& os,
+                             bool optional,
+                             DocFormatHelper& dfh) const override;
 
-    virtual bool exists_(ParameterSet const& pset) const;
+    bool exists_(ParameterSet const& pset) const override;
 
-    virtual void writeCfi_(std::ostream& os, int indentation) const;
+    void writeCfi_(std::ostream& os, int indentation) const override;
 
-    virtual void writeDoc_(std::ostream& os, int indentation) const;
+    void writeDoc_(std::ostream& os, int indentation) const override;
 
-    virtual bool exists_(ParameterSet const& pset, bool isTracked) const;
+    bool exists_(ParameterSet const& pset, bool isTracked) const override;
 
-    virtual void insertDefault_(ParameterSet& pset) const;
+    void insertDefault_(ParameterSet& pset) const override;
 
     value_ptr<ParameterSetDescription> psetDesc_;
   };
@@ -283,12 +283,12 @@ namespace edm {
                          bool isTracked,
                          Comment const& iComment = Comment());
 
-    virtual ~ParameterDescription();
+    ~ParameterDescription() override;
 
-    virtual ParameterSetDescription const* parameterSetDescription() const;
-    virtual ParameterSetDescription * parameterSetDescription();
+    ParameterSetDescription const* parameterSetDescription() const override;
+    ParameterSetDescription * parameterSetDescription() override;
 
-    virtual ParameterDescriptionNode* clone() const {
+    ParameterDescriptionNode* clone() const override {
       return new ParameterDescription(*this);
     }
 
@@ -296,29 +296,29 @@ namespace edm {
 
   private:
 
-    virtual void validate_(ParameterSet& pset,
-                           std::set<std::string>& validatedLabels,
-                           bool optional) const;
+    void validate_(ParameterSet& pset,
+                   std::set<std::string>& validatedLabels,
+                   bool optional) const override;
 
-    virtual void printDefault_(std::ostream& os,
-                               bool writeToCfi,
-                               DocFormatHelper& dfh) const;
+    void printDefault_(std::ostream& os,
+                       bool writeToCfi,
+                       DocFormatHelper& dfh) const override;
 
-    virtual bool hasNestedContent_() const;
+    bool hasNestedContent_() const override;
 
-    virtual void printNestedContent_(std::ostream& os,
-                                     bool optional,
-                                     DocFormatHelper& dfh) const;
+    void printNestedContent_(std::ostream& os,
+                             bool optional,
+                             DocFormatHelper& dfh) const override;
 
-    virtual bool exists_(ParameterSet const& pset) const;
+    bool exists_(ParameterSet const& pset) const override;
 
-    virtual void writeCfi_(std::ostream& os, int indentation) const;
+    void writeCfi_(std::ostream& os, int indentation) const override;
 
-    virtual void writeDoc_(std::ostream& os, int indentation) const;
+    void writeDoc_(std::ostream& os, int indentation) const override;
 
-    virtual bool exists_(ParameterSet const& pset, bool isTracked) const;
+    bool exists_(ParameterSet const& pset, bool isTracked) const override;
 
-    virtual void insertDefault_(ParameterSet& pset) const;
+    void insertDefault_(ParameterSet& pset) const override;
 
     static void writeOneElementToCfi(ParameterSet const& pset,
                                      std::ostream& os,

--- a/FWCore/ParameterSet/interface/ParameterDescriptionBase.h
+++ b/FWCore/ParameterSet/interface/ParameterDescriptionBase.h
@@ -33,15 +33,15 @@ namespace edm {
   class ParameterDescriptionBase : public ParameterDescriptionNode 
   {
   public:
-    virtual ~ParameterDescriptionBase();
+    ~ParameterDescriptionBase() override;
 
     std::string const& label() const { return label_; }
     ParameterTypes type() const { return type_; }
     bool isTracked() const { return isTracked_; }
     bool hasDefault() const { return hasDefault_; }
 
-    virtual ParameterSetDescription const* parameterSetDescription() const { return 0; }
-    virtual ParameterSetDescription * parameterSetDescription() { return 0; }
+    virtual ParameterSetDescription const* parameterSetDescription() const { return nullptr; }
+    virtual ParameterSetDescription * parameterSetDescription() { return nullptr; }
 
   protected:
     void throwParameterWrongTrackiness() const;
@@ -64,39 +64,39 @@ namespace edm {
 
   private:
 
-    virtual void checkAndGetLabelsAndTypes_(std::set<std::string> & usedLabels,
-                                            std::set<ParameterTypes> & parameterTypes,
-                                            std::set<ParameterTypes> & wildcardTypes) const;
+    void checkAndGetLabelsAndTypes_(std::set<std::string> & usedLabels,
+                                    std::set<ParameterTypes> & parameterTypes,
+                                    std::set<ParameterTypes> & wildcardTypes) const override;
 
-    virtual void validate_(ParameterSet & pset,
-                           std::set<std::string> & validatedLabels,
-                           bool optional) const;
+    void validate_(ParameterSet & pset,
+                   std::set<std::string> & validatedLabels,
+                   bool optional) const override;
 
-    virtual void writeCfi_(std::ostream & os,
-                           bool & startWithComma,
-                           int indentation,
-                           bool & wroteSomething) const;
+    void writeCfi_(std::ostream & os,
+                   bool & startWithComma,
+                   int indentation,
+                   bool & wroteSomething) const override;
 
-    virtual bool partiallyExists_(ParameterSet const& pset) const;
+    bool partiallyExists_(ParameterSet const& pset) const override;
 
-    virtual int howManyXORSubNodesExist_(ParameterSet const& pset) const;
+    int howManyXORSubNodesExist_(ParameterSet const& pset) const override;
 
     virtual void writeCfi_(std::ostream & os, int indentation) const = 0;
 
     virtual void writeDoc_(std::ostream & os, int indentation) const = 0;
 
-    virtual void print_(std::ostream & os,
-                        bool optional,
-                        bool writeToCfi,
-                        DocFormatHelper & dfh) const;
+    void print_(std::ostream & os,
+                bool optional,
+                bool writeToCfi,
+                DocFormatHelper & dfh) const override;
 
     virtual void printDefault_(std::ostream & os,
-                                 bool writeToCfi,
-                                 DocFormatHelper & dfh) const;
+                               bool writeToCfi,
+                               DocFormatHelper & dfh) const;
 
-    virtual void printNestedContent_(std::ostream & os,
-                                     bool optional,
-                                     DocFormatHelper & dfh) const;
+    void printNestedContent_(std::ostream & os,
+                             bool optional,
+                             DocFormatHelper & dfh) const override;
 
     using ParameterDescriptionNode::exists_;
     virtual bool exists_(ParameterSet const& pset, bool isTracked) const = 0;

--- a/FWCore/ParameterSet/interface/ParameterSetDescriptionFiller.h
+++ b/FWCore/ParameterSet/interface/ParameterSetDescriptionFiller.h
@@ -35,16 +35,16 @@ namespace edm {
   public:
     ParameterSetDescriptionFiller() {}
 
-    virtual void fill(ConfigurationDescriptions & descriptions) const {
+    void fill(ConfigurationDescriptions & descriptions) const override {
       T::fillDescriptions(descriptions);
       T::prevalidate(descriptions);
     }
 
-    virtual const std::string& baseType() const {
+    const std::string& baseType() const override {
       return T::baseType();
     }
 
-    virtual const std::string& extendedBaseType() const {
+    const std::string& extendedBaseType() const override {
       const T* type = nullptr;
       return ParameterSetDescriptionFillerBase::extendedBaseType(type);
     }
@@ -130,7 +130,7 @@ namespace edm {
 
     // If T has a fillDescriptions function then just call that, otherwise
     // put in an "unknown description" as a default.
-    virtual void fill(ConfigurationDescriptions & descriptions) const {
+    void fill(ConfigurationDescriptions & descriptions) const override {
       std::conditional_t<edm::fillDetails::has_fillDescriptions_function<T>::value,
                          edm::fillDetails::DoFillDescriptions<T>,
                          edm::fillDetails::DoFillAsUnknown<T>> fill_descriptions;
@@ -140,11 +140,11 @@ namespace edm {
       //prevalidateService(descriptions);
     }
 
-    virtual const std::string& baseType() const {
+    const std::string& baseType() const override {
       return kBaseForService;
     }
 
-    virtual const std::string& extendedBaseType() const {
+    const std::string& extendedBaseType() const override {
       return kEmpty;
     }
 
@@ -162,7 +162,7 @@ namespace edm {
 
     // If T has a fillDescriptions function then just call that, otherwise
     // put in an "unknown description" as a default.
-    virtual void fill(ConfigurationDescriptions & descriptions) const {
+    void fill(ConfigurationDescriptions & descriptions) const override {
       std::conditional_t<edm::fillDetails::has_fillDescriptions_function<T>::value,
                          edm::fillDetails::DoFillDescriptions<T>,
                          edm::fillDetails::DoFillAsUnknown<T>> fill_descriptions;
@@ -174,11 +174,11 @@ namespace edm {
       prevalidate(descriptions);
     }
 
-    virtual const std::string& baseType() const {
+    const std::string& baseType() const override {
       return kBaseForESSource;
     }
 
-    virtual const std::string& extendedBaseType() const {
+    const std::string& extendedBaseType() const override {
       return kEmpty;
     }
 
@@ -195,7 +195,7 @@ namespace edm {
 
     // If T has a fillDescriptions function then just call that, otherwise
     // put in an "unknown description" as a default.
-    virtual void fill(ConfigurationDescriptions & descriptions) const {
+    void fill(ConfigurationDescriptions & descriptions) const override {
       std::conditional_t<edm::fillDetails::has_fillDescriptions_function<T>::value,
                          edm::fillDetails::DoFillDescriptions<T>,
                          edm::fillDetails::DoFillAsUnknown<T>> fill_descriptions;
@@ -207,11 +207,11 @@ namespace edm {
       prevalidate(descriptions);
     }
 
-    virtual const std::string& baseType() const {
+    const std::string& baseType() const override {
       return kBaseForESProducer;
     }
 
-    virtual const std::string& extendedBaseType() const {
+    const std::string& extendedBaseType() const override {
       return kEmpty;
     }
 

--- a/FWCore/ParameterSet/interface/ParameterSwitch.h
+++ b/FWCore/ParameterSet/interface/ParameterSwitch.h
@@ -38,24 +38,24 @@ namespace edm {
       }
     }
 
-    virtual ParameterDescriptionNode* clone() const {
+    ParameterDescriptionNode* clone() const override {
       return new ParameterSwitch(*this);
     }
 
   private:
 
-    virtual void checkAndGetLabelsAndTypes_(std::set<std::string> & usedLabels,
-                                            std::set<ParameterTypes> & parameterTypes,
-                                            std::set<ParameterTypes> & wildcardTypes) const {
+    void checkAndGetLabelsAndTypes_(std::set<std::string> & usedLabels,
+                                    std::set<ParameterTypes> & parameterTypes,
+                                    std::set<ParameterTypes> & wildcardTypes) const override {
 
       std::set<std::string> caseLabels;
       std::set<ParameterTypes> caseParameterTypes;
       std::set<ParameterTypes> caseWildcardTypes;
       for_all(cases_, std::bind(&ParameterSwitch::checkCaseLabels,
-                                  std::placeholders::_1,
-                                  std::ref(caseLabels),
-                                  std::ref(caseParameterTypes),
-                                  std::ref(caseWildcardTypes)));
+                                std::placeholders::_1,
+                                std::ref(caseLabels),
+                                std::ref(caseParameterTypes),
+                                std::ref(caseWildcardTypes)));
 
       insertAndCheckLabels(switch_.label(),
                            usedLabels,
@@ -72,9 +72,9 @@ namespace edm {
       }
     }
 
-    virtual void validate_(ParameterSet & pset,
-                           std::set<std::string> & validatedLabels,
-                           bool optional) const {
+    void validate_(ParameterSet & pset,
+                   std::set<std::string> & validatedLabels,
+                   bool optional) const override {
 
       switch_.validate(pset, validatedLabels, optional);
       if (switch_.exists(pset)) {
@@ -109,10 +109,10 @@ namespace edm {
       }
     }
 
-    virtual void writeCfi_(std::ostream & os,
-                          bool & startWithComma,
-                          int indentation,
-                          bool & wroteSomething) const {
+    void writeCfi_(std::ostream & os,
+                   bool & startWithComma,
+                   int indentation,
+                   bool & wroteSomething) const override {
       switch_.writeCfi(os, startWithComma, indentation, wroteSomething);
 
       typename CaseMap::const_iterator selectedCase = cases_.find(switch_.getDefaultValue());
@@ -121,27 +121,27 @@ namespace edm {
       }
     }
 
-    virtual void print_(std::ostream & os,
-                        bool optional,
-                        bool writeToCfi,
-                        DocFormatHelper & dfh) const {
+    void print_(std::ostream & os,
+                bool optional,
+                bool writeToCfi,
+                DocFormatHelper & dfh) const override {
       printBase(os, optional, writeToCfi, dfh, switch_.label(), switch_.isTracked(), parameterTypeEnumToString(switch_.type()));
     }
 
-    virtual void printNestedContent_(std::ostream & os,
-                                     bool optional,
-                                     DocFormatHelper & dfh) const {
+    void printNestedContent_(std::ostream & os,
+                             bool optional,
+                             DocFormatHelper & dfh) const override {
 
       DocFormatHelper new_dfh(dfh);
       printNestedContentBase(os, dfh, new_dfh, switch_.label());
 
       switch_.print(os, optional, true, new_dfh);
       for_all(cases_, std::bind(&ParameterSwitchBase::printCaseT<T>,
-                                  std::placeholders::_1,
-                                  std::ref(os),
-                                  optional,
-                                  std::ref(new_dfh),
-                                  std::cref(switch_.label())));
+                                std::placeholders::_1,
+                                std::ref(os),
+                                optional,
+                                std::ref(new_dfh),
+                                std::cref(switch_.label())));
 
       new_dfh.setPass(1);
       new_dfh.setCounter(0);
@@ -168,7 +168,7 @@ namespace edm {
                                   std::cref(switch_.label())));
     }
 
-    virtual bool exists_(ParameterSet const& pset) const { return switch_.exists(pset); }
+    bool exists_(ParameterSet const& pset) const override { return switch_.exists(pset); }
 
     static void checkCaseLabels(std::pair<T, edm::value_ptr<ParameterDescriptionNode> > const& thePair,
                                 std::set<std::string> & labels,

--- a/FWCore/ParameterSet/interface/ParameterSwitchBase.h
+++ b/FWCore/ParameterSet/interface/ParameterSwitchBase.h
@@ -15,7 +15,7 @@ namespace edm {
 
   class ParameterSwitchBase : public ParameterDescriptionNode {
   public:
-    virtual ~ParameterSwitchBase();
+    ~ParameterSwitchBase() override;
 
   protected:
     void insertAndCheckLabels(std::string const& switchLabel,
@@ -23,10 +23,10 @@ namespace edm {
                               std::set<std::string> & labels) const;
 
     void insertAndCheckTypes(ParameterTypes switchType,
-                      std::set<ParameterTypes> const& caseParameterTypes,
-                      std::set<ParameterTypes> const& caseWildcardTypes,
-                      std::set<ParameterTypes> & parameterTypes,
-		      std::set<ParameterTypes> & wildcardTypes) const;
+                             std::set<ParameterTypes> const& caseParameterTypes,
+                             std::set<ParameterTypes> const& caseWildcardTypes,
+                             std::set<ParameterTypes> & parameterTypes,
+                             std::set<ParameterTypes> & wildcardTypes) const;
 
     void throwDuplicateCaseValues(std::string const& switchLabel) const;
 
@@ -42,7 +42,7 @@ namespace edm {
                    bool isTracked,
                    std::string const& typeString) const;
 
-    virtual bool hasNestedContent_() const;
+    bool hasNestedContent_() const override;
 
     void printNestedContentBase(std::ostream & os,
                                 DocFormatHelper & dfh,
@@ -78,9 +78,9 @@ namespace edm {
                           DocFormatHelper & dfh,
                           std::string const& switchLabel);
 
-    virtual bool partiallyExists_(ParameterSet const& pset) const;
+    bool partiallyExists_(ParameterSet const& pset) const override;
 
-    virtual int howManyXORSubNodesExist_(ParameterSet const& pset) const;
+    int howManyXORSubNodesExist_(ParameterSet const& pset) const override;
 
   };
 }

--- a/FWCore/ParameterSet/interface/ParameterWildcard.h
+++ b/FWCore/ParameterSet/interface/ParameterWildcard.h
@@ -33,30 +33,30 @@ namespace edm {
       throwIfInvalidPattern(pattern);
     }
 
-    virtual ~ParameterWildcard() { }
+    ~ParameterWildcard() override { }
 
-    virtual ParameterDescriptionNode* clone() const {
+    ParameterDescriptionNode* clone() const override {
       return new ParameterWildcard(*this);
     }
 
   private:
    
-    virtual void validate_(ParameterSet & pset,
-                           std::set<std::string> & validatedLabels,
-                           bool optional) const {
+    void validate_(ParameterSet & pset,
+                   std::set<std::string> & validatedLabels,
+                   bool optional) const override {
 
       std::vector<std::string> parameterNames  = pset.getParameterNamesForType<T>(isTracked());
       validateMatchingNames(parameterNames, validatedLabels, optional);
 
     }
 
-    virtual bool exists_(ParameterSet const& pset) const {
+    bool exists_(ParameterSet const& pset) const override {
 
       if (criteria() == RequireZeroOrMore) return true;
 
       std::vector<std::string> parameterNames  = pset.getParameterNamesForType<T>(isTracked());
 
-      if (criteria() == RequireAtLeastOne) return parameterNames.size() >= 1U;
+      if (criteria() == RequireAtLeastOne) return !parameterNames.empty();
       return parameterNames.size() == 1U;
     }
 
@@ -76,23 +76,23 @@ namespace edm {
     ParameterWildcard(char const* pattern, WildcardValidationCriteria criteria, bool isTracked,
                       ParameterSetDescription const& desc);
 
-    virtual ~ParameterWildcard();
+    ~ParameterWildcard() override;
 
-    virtual ParameterDescriptionNode* clone() const;
+    ParameterDescriptionNode* clone() const override;
 
   private:
    
-    virtual void validate_(ParameterSet & pset,
-                           std::set<std::string> & validatedLabels,
-                           bool optional) const;
+    void validate_(ParameterSet & pset,
+                   std::set<std::string> & validatedLabels,
+                   bool optional) const override;
 
-    virtual bool hasNestedContent_() const;
+    bool hasNestedContent_() const override;
 
-    virtual void printNestedContent_(std::ostream & os,
-                                     bool optional,
-                                     DocFormatHelper & helper) const;
+    void printNestedContent_(std::ostream & os,
+                             bool optional,
+                             DocFormatHelper & helper) const override;
 
-    virtual bool exists_(ParameterSet const& pset) const;
+    bool exists_(ParameterSet const& pset) const override;
 
     void validateDescription(std::string const& parameterName, ParameterSet & pset) const;
 
@@ -112,23 +112,23 @@ namespace edm {
     ParameterWildcard(char const* pattern, WildcardValidationCriteria criteria, bool isTracked,
                       ParameterSetDescription const& desc);
 
-    virtual ~ParameterWildcard();
+    ~ParameterWildcard() override;
 
-    virtual ParameterDescriptionNode* clone() const;
+    ParameterDescriptionNode* clone() const override;
 
   private:
    
-    virtual void validate_(ParameterSet & pset,
-                           std::set<std::string> & validatedLabels,
-                           bool optional) const;
+    void validate_(ParameterSet & pset,
+                   std::set<std::string> & validatedLabels,
+                   bool optional) const override;
 
-    virtual bool hasNestedContent_() const;
+    bool hasNestedContent_() const override;
 
-    virtual void printNestedContent_(std::ostream & os,
-                                     bool optional,
-                                     DocFormatHelper & dfh) const;
+    void printNestedContent_(std::ostream & os,
+                             bool optional,
+                             DocFormatHelper & dfh) const override;
 
-    virtual bool exists_(ParameterSet const& pset) const;
+    bool exists_(ParameterSet const& pset) const override;
 
     void validatePSetVector(std::string const& parameterName, ParameterSet & pset) const;
 

--- a/FWCore/ParameterSet/interface/ParameterWildcardBase.h
+++ b/FWCore/ParameterSet/interface/ParameterWildcardBase.h
@@ -24,7 +24,7 @@ namespace edm {
   class ParameterWildcardBase : public ParameterDescriptionNode 
   {
   public:
-    virtual ~ParameterWildcardBase();
+    ~ParameterWildcardBase() override;
 
     ParameterTypes type() const { return type_; }
     bool isTracked() const { return isTracked_; }
@@ -45,23 +45,23 @@ namespace edm {
 
   private:
 
-    virtual void checkAndGetLabelsAndTypes_(std::set<std::string> & usedLabels,
-                                            std::set<ParameterTypes> & parameterTypes,
-                                            std::set<ParameterTypes> & wildcardTypes) const;
+    void checkAndGetLabelsAndTypes_(std::set<std::string> & usedLabels,
+                                    std::set<ParameterTypes> & parameterTypes,
+                                    std::set<ParameterTypes> & wildcardTypes) const override;
 
-    virtual void writeCfi_(std::ostream & os,
-                           bool & startWithComma,
-                           int indentation,
-                           bool & wroteSomething) const;
+    void writeCfi_(std::ostream & os,
+                   bool & startWithComma,
+                   int indentation,
+                   bool & wroteSomething) const override;
 
-    virtual void print_(std::ostream & os,
-                        bool optional,
-                        bool writeToCfi,
-                        DocFormatHelper & dfh) const;
+    void print_(std::ostream & os,
+                bool optional,
+                bool writeToCfi,
+                DocFormatHelper & dfh) const override;
 
-    virtual bool partiallyExists_(ParameterSet const& pset) const;
+    bool partiallyExists_(ParameterSet const& pset) const override;
 
-    virtual int howManyXORSubNodesExist_(ParameterSet const& pset) const;
+    int howManyXORSubNodesExist_(ParameterSet const& pset) const override;
 
     ParameterTypes type_;
     bool isTracked_;

--- a/FWCore/ParameterSet/interface/XORGroupDescription.h
+++ b/FWCore/ParameterSet/interface/XORGroupDescription.h
@@ -29,43 +29,43 @@ namespace edm {
     XORGroupDescription(std::unique_ptr<ParameterDescriptionNode> node_left,
                         std::unique_ptr<ParameterDescriptionNode> node_right);
 
-    virtual ParameterDescriptionNode* clone() const {
+    ParameterDescriptionNode* clone() const override {
       return new XORGroupDescription(*this);
     }
 
   private:
 
-    virtual void checkAndGetLabelsAndTypes_(std::set<std::string> & usedLabels,
-                                            std::set<ParameterTypes> & parameterTypes,
-                                            std::set<ParameterTypes> & wildcardTypes) const;
+    void checkAndGetLabelsAndTypes_(std::set<std::string> & usedLabels,
+                                    std::set<ParameterTypes> & parameterTypes,
+                                    std::set<ParameterTypes> & wildcardTypes) const override;
 
-    virtual void validate_(ParameterSet & pset,
-                           std::set<std::string> & validatedLabels,
-                           bool optional) const;
+    void validate_(ParameterSet & pset,
+                   std::set<std::string> & validatedLabels,
+                   bool optional) const override;
 
-    virtual void writeCfi_(std::ostream & os,
-                           bool & startWithComma,
-                           int indentation,
-                           bool & wroteSomething) const;
+    void writeCfi_(std::ostream & os,
+                   bool & startWithComma,
+                   int indentation,
+                   bool & wroteSomething) const override;
 
-    virtual void print_(std::ostream & os,
-                        bool optional,
-                        bool writeToCfi,
-                        DocFormatHelper & dfh) const;
+    void print_(std::ostream & os,
+                bool optional,
+                bool writeToCfi,
+                DocFormatHelper & dfh) const override;
 
-    virtual bool hasNestedContent_() const {
+    bool hasNestedContent_() const override {
       return true;
     }
 
-    virtual void printNestedContent_(std::ostream & os,
-                                     bool optional,
-                                     DocFormatHelper & dfh) const;
+    void printNestedContent_(std::ostream & os,
+                             bool optional,
+                             DocFormatHelper & dfh) const override;
 
-    virtual bool exists_(ParameterSet const& pset) const;
+    bool exists_(ParameterSet const& pset) const override;
 
-    virtual bool partiallyExists_(ParameterSet const& pset) const;
+    bool partiallyExists_(ParameterSet const& pset) const override;
 
-    virtual int howManyXORSubNodesExist_(ParameterSet const& pset) const;
+    int howManyXORSubNodesExist_(ParameterSet const& pset) const override;
 
     void throwMoreThanOneParameter() const;
     void throwAfterValidation() const;

--- a/FWCore/ParameterSet/src/ParameterDescription.cc
+++ b/FWCore/ParameterSet/src/ParameterDescription.cc
@@ -324,11 +324,11 @@ namespace edm {
     if(partOfDefaultOfVPSet_) subsectionOffset = 1;
 
     if(hasDefault()) {
-      if(vPset_.size() == 0U) os << "The default VPSet is empty.\n";
+      if(vPset_.empty()) os << "The default VPSet is empty.\n";
       else if(vPset_.size() == 1U) os << "The default VPSet has 1 element.\n";
       else os << "The default VPSet has " << vPset_.size() << " elements.\n";
 
-      if(vPset_.size() > 0U) {
+      if(!vPset_.empty()) {
         for(unsigned i = 0; i < vPset_.size(); ++i) {
           printSpaces(os, indentation + DocFormatHelper::offsetSectionContent());
           os << "[" << (i) << "]: see Section " << dfh.section()
@@ -487,7 +487,7 @@ namespace edm {
         std::string resultLessPrecision = s.str();
 
         if(resultLessPrecision.size() < result.size() - 2) {
-          double test = std::strtod(resultLessPrecision.c_str(), 0);
+          double test = std::strtod(resultLessPrecision.c_str(), nullptr);
           if(test == value) {
             result = resultLessPrecision;
           }
@@ -645,11 +645,11 @@ namespace edm {
       std::ios_base::fmtflags ff = os.flags(std::ios_base::dec);
       char oldFill = os.fill();
       os.width(0);
-      if(value_.size() == 0U && format == DOC) {
+      if(value_.empty() && format == DOC) {
         os << "empty";
       } else if(value_.size() == 1U && format == CFI) {
         writeValueInVector<T>(os, value_[0], format);
-      } else if(value_.size() >= 1U) {
+      } else if(!value_.empty()) {
         if(format == DOC) os << "(vector size = " << value_.size() << ")";
         if(format == CFI and value_.size() > 255U) os << " *(";
         os.fill(' ');


### PR DESCRIPTION
Replaced virtual with override where appropriate, use nullptr
instead of 0, and use empty instead of size.

Needed to manually fix the indentation in multiple places, the
rest of the changes were automated.