### PR TITLE
fix ECAL constantTerm for PhaseII (fw port for 93)

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/aging.py
+++ b/SLHCUpgradeSimulations/Configuration/python/aging.py
@@ -123,8 +123,8 @@ def ageEcal(process,lumi,instLumi):
    # available conditions
     ecal_lumis = [300,1000,3000,4500]
     ecal_conditions = [
-        ['EcalIntercalibConstantsRcd','EcalIntercalibConstants_TL{:d}_upgrade_8deg_mc'],
-        ['EcalIntercalibConstantsMCRcd','EcalIntercalibConstantsMC_TL{:d}_upgrade_8deg_mc'],
+        ['EcalIntercalibConstantsRcd','EcalIntercalibConstants_TL{:d}_upgrade_8deg_v2_mc'],
+        ['EcalIntercalibConstantsMCRcd','EcalIntercalibConstantsMC_TL{:d}_upgrade_8deg_v2_mc'],
         ['EcalLaserAPDPNRatiosRcd','EcalLaserAPDPNRatios_TL{:d}_upgrade_8deg_mc'],
         ['EcalPedestalsRcd','EcalPedestals_TL{:d}_upgradeTIA_8deg_mc'],
         ['EcalTPGLinearizationConstRcd','EcalTPGLinearizationConst_TL{:d}_upgrade_8deg_mc'],


### PR DESCRIPTION
**FW port of**:  https://github.com/cms-sw/cmssw/pull/20193

the ECAL resolution constant term needs to be fixed for the imminent re-production of samples targeting Barrel Calorimeter TDR, by amending for these two records:

```
     EcalIntercalibConstantsRcd 
     EcalIntercalibConstantsMCRcd

```

the tags _v2 (see below) which are selected via the ageing custom function.
All other ingredients of the condition-driven ageing scenarios need to stay the same.

@kpedro88 @amassiro @arunhep @lpernie @cerminar 