### PR TITLE
Fixes to TrackCollectionMerger

### DIFF
--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionMerger.cc
@@ -283,19 +283,16 @@ namespace {
       producer(srcColls[i],selId);
       assert(producer.selTracks_->size()==nsel);
       assert(tid.size()==nsel-isel);
-      if(doMerging) { // override these only if the merging was run
-        auto k=0U;
-        for (;isel<nsel;++isel) {
-          auto & otk = (*producer.selTracks_)[isel];
-          otk.setQualityMask((*pquals)[isel]);
+      auto k=0U;
+      for (;isel<nsel;++isel) {
+        auto & otk = (*producer.selTracks_)[isel];
+        otk.setQualityMask((*pquals)[isel]);       // needed also without merging
+        if(doMerging) {
           otk.setOriginalAlgorithm(oriAlgo[tid[k]]);
           otk.setAlgoMask(algoMask[tid[k++]]);
         }
-        assert(tid.size()==k);
       }
-      else {
-        isel = nsel; // update the internal bookkeeping
-      }
+      if(doMerging) assert(tid.size()==k);
     }
 
     assert(producer.selTracks_->size()==pmvas->size());

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionMerger.cc
@@ -129,7 +129,8 @@ namespace {
 
 
     unsigned char qualMask = ~0;
-    if (m_minQuality!=reco::TrackBase::undefQuality) qualMask = 1<<m_minQuality; 
+    const bool acceptAll = m_minQuality==reco::TrackBase::undefQuality;
+    if (!acceptAll) qualMask = 1<<m_minQuality;
     
     
     // load tracks
@@ -147,7 +148,7 @@ namespace {
       edm::Handle<QualityMaskCollection> hqual;
       evt.getByToken(srcQuals[i], hqual);
       for (auto j=0U; j<size; ++j) {
-	if (! (qualMask&(* hqual)[j]) ) continue;
+	if (! (acceptAll || (qualMask&(* hqual)[j]) ) ) continue;
 	mvas[k]=(*hmva)[j];
 	quals[k] = (*hqual)[j];
 	tkInds[k]=j;


### PR DESCRIPTION
This PR makes two changes to `TrackCollectionMerger` that do not affect the default behaviour:
* Fix a bug in the "concatenation mode" (introduced in #19635) that caused the quality mask to disappear from the resulting tracks
* If `minQuality` is set to `undefQuality`, select all input tracks
   * Currently the default is `loose`, and if one passes `undefQuality`, the result is still effectively `loose`. In principle any bit set in quality mask would be enough, but in practice this means `loose` (so there is no mechanism to select also those tracks whose quality mask is empty).

Tested in 9_3_0_pre3, no changes expected in standard workflows.

@rovere @VinInn 