### PR TITLE
Add muon filter sequence

### DIFF
--- a/SimMuon/MCTruth/plugins/SimMuFilter.cc
+++ b/SimMuon/MCTruth/plugins/SimMuFilter.cc
@@ -8,13 +8,13 @@ class SimMuFilter : public edm::stream::EDFilter<>
  public:
 
    explicit SimMuFilter(const edm::ParameterSet&);
-   ~SimMuFilter();
+   ~SimMuFilter() override;
 
  private:
 
    virtual void beginJob();
    virtual void endJob();
-   virtual bool filter(edm::Event&, const edm::EventSetup&);
+   bool filter(edm::Event&, const edm::EventSetup&) override;
    
  private:
    

--- a/SimMuon/MCTruth/plugins/SimMuFilter.cc
+++ b/SimMuon/MCTruth/plugins/SimMuFilter.cc
@@ -27,6 +27,8 @@ class SimMuFilter : public edm::stream::EDFilter<>
    edm::Handle<edm::PSimHitContainer> simHitsMuonRPCHandle;
    edm::Handle<edm::PSimHitContainer> simHitsMuonCSCHandle;
    edm::Handle<edm::PSimHitContainer> simHitsMuonDTHandle;
+   
+   int nMuSel_;
 };
 
 SimMuFilter::SimMuFilter(const edm::ParameterSet& iConfig)
@@ -35,6 +37,7 @@ SimMuFilter::SimMuFilter(const edm::ParameterSet& iConfig)
    simHitsMuonRPCToken_ = consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("simHitsMuonRPCInput"));
    simHitsMuonCSCToken_ = consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("simHitsMuonCSCInput"));
    simHitsMuonDTToken_ = consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("simHitsMuonDTInput"));
+   nMuSel_             = iConfig.getParameter<int>("nMuSel");
 }
 
 SimMuFilter::~SimMuFilter()
@@ -54,7 +57,7 @@ bool SimMuFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
    
    int nTracks = simTracks.size();
 
-   bool pass = 0;
+   int nPass = 0;
    
    for(int it=0;it<nTracks;it++)
      {
@@ -91,10 +94,10 @@ bool SimMuFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	     nSimHitDT++;
 	  }
 	
-	if( nSimHitRPC+nSimHitCSC+nSimHitDT > 0 ) pass = 1;
-     }
-
-   return pass;
+	if( nSimHitRPC+nSimHitCSC+nSimHitDT > 0 ) nPass++;
+     }   
+   
+   return (nPass >= nMuSel_);
 }
 
 void SimMuFilter::beginJob()

--- a/SimMuon/MCTruth/python/SimMuFiltDouble_cff.py
+++ b/SimMuon/MCTruth/python/SimMuFiltDouble_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from SimMuon.MCTruth.SimMuFilter_cfi import SimMuFilter
 
-SimMuFilter.nMuSel = 2
+SimDoubleMuFilter = SimMuFilter.clone()
+SimDoubleMuFilter.nMuSel = 2
 
-SimMuFiltSeq = cms.Sequence(SimMuFilter)
+SimMuFiltSeq = cms.Sequence(SimDoubleMuFilter)

--- a/SimMuon/MCTruth/python/SimMuFiltDouble_cff.py
+++ b/SimMuon/MCTruth/python/SimMuFiltDouble_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from SimMuon.MCTruth.SimMuFilter_cfi import SimMuFilter
+
+SimMuFilter.nMuSel = 2
+
+SimMuFiltSeq = cms.Sequence(SimMuFilter)

--- a/SimMuon/MCTruth/python/SimMuFiltSingle_cff.py
+++ b/SimMuon/MCTruth/python/SimMuFiltSingle_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from SimMuon.MCTruth.SimMuFilter_cfi import SimMuFilter
+
+SimMuFilter.nMuSel = 1
+
+SimMuFiltSeq = cms.Sequence(SimMuFilter)

--- a/SimMuon/MCTruth/python/SimMuFiltSingle_cff.py
+++ b/SimMuon/MCTruth/python/SimMuFiltSingle_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from SimMuon.MCTruth.SimMuFilter_cfi import SimMuFilter
 
-SimMuFilter.nMuSel = 1
+SimSingleMuFilter = SimMuFilter.clone()
+SimSingleMuFilter.nMuSel = 1
 
-SimMuFiltSeq = cms.Sequence(SimMuFilter)
+SimMuFiltSeq = cms.Sequence(SimSingleMuFilter)

--- a/SimMuon/MCTruth/python/SimMuFilter_cfi.py
+++ b/SimMuon/MCTruth/python/SimMuFilter_cfi.py
@@ -5,7 +5,6 @@ SimMuFilter = cms.EDFilter('SimMuFilter',
               simTracksInput = cms.InputTag("g4SimHits","","SIM"),
               simHitsMuonRPCInput = cms.InputTag("g4SimHits","MuonRPCHits","SIM"),
               simHitsMuonCSCInput = cms.InputTag("g4SimHits","MuonCSCHits","SIM"),
-              simHitsMuonDTInput = cms.InputTag("g4SimHits","MuonDTHits","SIM")
+              simHitsMuonDTInput = cms.InputTag("g4SimHits","MuonDTHits","SIM"),
+              nMuSel = cms.int32(1)
 )
-
-SimMuFiltSeq = cms.Sequence(SimMuFilter)

--- a/SimMuon/MCTruth/python/SimMuFilter_cfi.py
+++ b/SimMuon/MCTruth/python/SimMuFilter_cfi.py
@@ -8,3 +8,4 @@ SimMuFilter = cms.EDFilter('SimMuFilter',
               simHitsMuonDTInput = cms.InputTag("g4SimHits","MuonDTHits","SIM")
 )
 
+SimMuFiltSeq = cms.Sequence(SimMuFilter)


### PR DESCRIPTION
This PR represents a small update to the SIM muon filter implementation (#16849) to make it also available as a sequence. This allows one to use it directly in cmsDriver sequences for official MC production. 