### PR TITLE
Modified delay for LS timeout in online DQM

### DIFF
--- a/DQM/Integration/python/config/inputsource_cfi.py
+++ b/DQM/Integration/python/config/inputsource_cfi.py
@@ -53,7 +53,7 @@ runType.setRunType(options.runkey.strip())
 
 if not options.inputFiles:
     # Input source
-    nextLumiTimeoutMillis = 90000
+    nextLumiTimeoutMillis = 240000
     endOfRunKills = True
     
     if options.scanOnce:


### PR DESCRIPTION
Modified delay for LS timeout in online DQM to 4 mins.

Reasoning behind: http://cmsonline.cern.ch/cms-elog/1004988