### PR TITLE
fix collection names for premixing

### DIFF
--- a/Configuration/StandardSequences/python/DigiToRawDM_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRawDM_cff.py
@@ -43,5 +43,6 @@ run2_HCAL_2017.toModify( hcalRawDatauHTR,
     HFqie8 = cms.InputTag("DMHcalDigis"),
     QIE10 = cms.InputTag("DMHcalDigis","HFQIE10DigiCollection"),
     QIE11 = cms.InputTag("DMHcalDigis","HBHEQIE11DigiCollection"),
+    TP = cms.InputTag("DMHcalTriggerPrimitiveDigis"),
 )
 

--- a/Validation/HcalDigis/python/HcalDigisParam_cfi.py
+++ b/Validation/HcalDigis/python/HcalDigisParam_cfi.py
@@ -11,7 +11,7 @@ hcaldigisAnalyzer = cms.EDAnalyzer("HcalDigisValidation",
     mc		= cms.untracked.string('yes'),
     simHits     = cms.untracked.InputTag("g4SimHits","HcalHits"),
     emulTPs     = cms.InputTag("emulDigis"),
-    dataTPs     = cms.InputTag("simHcalTriggerPrimitiveDigis"),
+    dataTPs     = cms.InputTag("hcalDigis"),
     TestNumber  = cms.bool(False),
     hep17       = cms.bool(False)
 )


### PR DESCRIPTION
this PR fixes:
- the name of the TP collection being packed into the rawDataCollection when the data mixing is used.
- the name of the TP collection used in the validation code.