### PR TITLE
[93X] Offline DQM extensions for L1T EGamma (calo layer 2) and fixes

### DIFF
--- a/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
@@ -39,16 +39,16 @@ class L1TEGammaOffline: public DQMEDAnalyzer {
 public:
 
   L1TEGammaOffline(const edm::ParameterSet& ps);
-  virtual ~L1TEGammaOffline();
+  ~L1TEGammaOffline() override;
 
 protected:
 
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
-  void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup) override;
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
 
 private:
   bool passesLooseEleId(reco::GsfElectron const& electron) const;

--- a/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
@@ -83,6 +83,8 @@ private:
 
   std::vector<double> electronEfficiencyThresholds_;
   std::vector<double> electronEfficiencyBins_;
+  double probeToL1Offset_;
+  std::vector<double>deepInspectionElectronThresholds_;
 
   std::vector<double> photonEfficiencyThresholds_;
   std::vector<double> photonEfficiencyBins_;
@@ -122,12 +124,22 @@ private:
   std::map<double, MonitorElement*> h_efficiencyElectronET_EB_pass_;
   std::map<double, MonitorElement*> h_efficiencyElectronET_EE_pass_;
   std::map<double, MonitorElement*> h_efficiencyElectronET_EB_EE_pass_;
+  std::map<double, MonitorElement*> h_efficiencyElectronPhi_vs_Eta_pass_;
+  // for deep inspection only
+  std::map<double, MonitorElement*> h_efficiencyElectronEta_pass_;
+  std::map<double, MonitorElement*> h_efficiencyElectronPhi_pass_;
+  std::map<double, MonitorElement*> h_efficiencyElectronNVertex_pass_;
 
   // we could drop the map here, but L1TEfficiency_Harvesting expects
   // identical names except for the suffix
   std::map<double, MonitorElement*> h_efficiencyElectronET_EB_total_;
   std::map<double, MonitorElement*> h_efficiencyElectronET_EE_total_;
   std::map<double, MonitorElement*> h_efficiencyElectronET_EB_EE_total_;
+  std::map<double, MonitorElement*> h_efficiencyElectronPhi_vs_Eta_total_;
+  // for deep inspection only
+  std::map<double, MonitorElement*> h_efficiencyElectronEta_total_;
+  std::map<double, MonitorElement*> h_efficiencyElectronPhi_total_;
+  std::map<double, MonitorElement*> h_efficiencyElectronNVertex_total_;
 
   // photons
   MonitorElement* h_L1EGammaETvsPhotonET_EB_;

--- a/DQMOffline/L1Trigger/interface/L1TEfficiencyHarvesting.h
+++ b/DQMOffline/L1Trigger/interface/L1TEfficiencyHarvesting.h
@@ -62,7 +62,6 @@ private:
   std::string denominatorSuffix_;
 
   MonitorElement* h_efficiency_;
-
 };
 
 typedef std::vector<L1TEfficiencyPlotHandler> L1TEfficiencyPlotHandlerCollection;

--- a/DQMOffline/L1Trigger/interface/L1TEfficiencyHarvesting.h
+++ b/DQMOffline/L1Trigger/interface/L1TEfficiencyHarvesting.h
@@ -75,11 +75,11 @@ class L1TEfficiencyHarvesting: public DQMEDHarvester {
 public:
 
   L1TEfficiencyHarvesting(const edm::ParameterSet& ps);   // Constructor
-  virtual ~L1TEfficiencyHarvesting();                     // Destructor
+  ~L1TEfficiencyHarvesting() override;                     // Destructor
 
 protected:
 
-  virtual void dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) override;
+  void dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) override;
   virtual void dqmEndLuminosityBlock(DQMStore::IGetter &igetter, edm::LuminosityBlock const& lumiBlock,
       edm::EventSetup const& c);
 

--- a/DQMOffline/L1Trigger/python/L1TEGammaEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaEfficiency_cfi.py
@@ -6,10 +6,15 @@ variables = {
     'photon': L1TEGammaOffline_cfi.photonEfficiencyThresholds,
 }
 
+deepInspectionThresholds = {
+    'electron': L1TEGammaOffline_cfi.deepInspectionElectronThresholds,
+    'photon': [],
+}
+
 plots = {
     'electron': [
         "efficiencyElectronET_EB", "efficiencyElectronET_EE",
-        "efficiencyElectronET_EB_EE"
+        "efficiencyElectronET_EB_EE", "efficiencyElectronPhi_vs_Eta",
     ],
     'photon': [
         "efficiencyPhotonET_EB", "efficiencyPhotonET_EE",
@@ -17,10 +22,24 @@ plots = {
     ]
 }
 
+deepInspectionPlots = {
+    'electron': [
+        'efficiencyElectronEta', 'efficiencyElectronPhi',
+        'efficiencyElectronNVertex'
+    ],
+    'photon': [],
+}
+
 allEfficiencyPlots = []
 add_plot = allEfficiencyPlots.append
 for variable, thresholds in variables.iteritems():
     for plot in plots[variable]:
+        for threshold in thresholds:
+            plotName = '{0}_threshold_{1}'.format(plot, threshold)
+            add_plot(plotName)
+
+for variable, thresholds in deepInspectionThresholds.iteritems():
+    for plot in deepInspectionPlots[variable]:
         for threshold in thresholds:
             plotName = '{0}_threshold_{1}'.format(plot, threshold)
             add_plot(plotName)

--- a/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
@@ -8,7 +8,14 @@ electronEfficiencyBins.extend(list(xrange(42, 45, 3)))
 electronEfficiencyBins.extend(list(xrange(45, 50, 5)))
 electronEfficiencyBins.extend(list(xrange(50, 70, 10)))
 electronEfficiencyBins.extend(list(xrange(70, 100, 30)))
-print electronEfficiencyBins
+
+# additional efficiency vs eta, phi and # vertices plots will
+# be created for the following probe electron pT thresholds
+deepInspectionElectronThresholds = [48, 50]
+
+# offset for 2D efficiency plots, uses
+# electronEfficiencyBins + probeToL1Offset (GeV)
+probeToL1Offset = 10
 
 # just copy for now
 photonEfficiencyThresholds = electronEfficiencyThresholds
@@ -30,13 +37,14 @@ l1tEGammaOfflineDQM = cms.EDAnalyzer(
     TriggerFilter=cms.InputTag('hltEle27WP80TrackIsoFilter', '', 'HLT'),
     TriggerPath=cms.string('HLT_Ele27_WP80_v13'),
 
-
     stage2CaloLayer2EGammaSource=cms.InputTag("caloStage2Digis", "EGamma"),
 
     histFolder=cms.string('L1T/L1TEGamma'),
 
     electronEfficiencyThresholds=cms.vdouble(electronEfficiencyThresholds),
     electronEfficiencyBins=cms.vdouble(electronEfficiencyBins),
+    probeToL1Offset=cms.double(probeToL1Offset),
+    deepInspectionElectronThresholds=cms.vdouble([48, 50]),
 
     photonEfficiencyThresholds=cms.vdouble(photonEfficiencyThresholds),
     photonEfficiencyBins=cms.vdouble(photonEfficiencyBins),

--- a/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
@@ -1,12 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
-electronEfficiencyThresholds = [36, 68, 128, 176]
+electronEfficiencyThresholds = [34, 36, 38, 40, 42]
 
 electronEfficiencyBins = []
-electronEfficiencyBins.extend(list(xrange(0, 120, 10)))
-electronEfficiencyBins.extend(list(xrange(120, 180, 20)))
-electronEfficiencyBins.extend(list(xrange(180, 300, 40)))
-electronEfficiencyBins.extend(list(xrange(300, 400, 100)))
+electronEfficiencyBins.extend(list(xrange(2, 42, 2)))
+electronEfficiencyBins.extend(list(xrange(42, 45, 3)))
+electronEfficiencyBins.extend(list(xrange(45, 50, 5)))
+electronEfficiencyBins.extend(list(xrange(50, 70, 10)))
+electronEfficiencyBins.extend(list(xrange(70, 100, 30)))
+print electronEfficiencyBins
 
 # just copy for now
 photonEfficiencyThresholds = electronEfficiencyThresholds
@@ -35,7 +37,7 @@ l1tEGammaOfflineDQM = cms.EDAnalyzer(
 
     electronEfficiencyThresholds=cms.vdouble(electronEfficiencyThresholds),
     electronEfficiencyBins=cms.vdouble(electronEfficiencyBins),
-    
+
     photonEfficiencyThresholds=cms.vdouble(photonEfficiencyThresholds),
     photonEfficiencyBins=cms.vdouble(photonEfficiencyBins),
 )

--- a/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
@@ -7,7 +7,7 @@ electronEfficiencyBins.extend(list(xrange(2, 42, 2)))
 electronEfficiencyBins.extend(list(xrange(42, 45, 3)))
 electronEfficiencyBins.extend(list(xrange(45, 50, 5)))
 electronEfficiencyBins.extend(list(xrange(50, 70, 10)))
-electronEfficiencyBins.extend(list(xrange(70, 100, 30)))
+electronEfficiencyBins.extend(list(xrange(70, 101, 30)))
 
 # additional efficiency vs eta, phi and # vertices plots will
 # be created for the following probe electron pT thresholds

--- a/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Offline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Offline_cfi.py
@@ -10,14 +10,14 @@ jetEfficiencyBins = []
 jetEfficiencyBins.extend(list(xrange(0, 120, 10)))
 jetEfficiencyBins.extend(list(xrange(120, 180, 20)))
 jetEfficiencyBins.extend(list(xrange(180, 300, 40)))
-jetEfficiencyBins.extend(list(xrange(300, 400, 100)))
+jetEfficiencyBins.extend(list(xrange(300, 401, 100)))
 
 metEfficiencyBins = []
 metEfficiencyBins.extend(list(xrange(0, 40, 4)))
 metEfficiencyBins.extend(list(xrange(40, 70, 2)))
 metEfficiencyBins.extend(list(xrange(70, 100, 5)))
 metEfficiencyBins.extend(list(xrange(100, 160, 10)))
-metEfficiencyBins.extend(list(xrange(160, 260, 20)))
+metEfficiencyBins.extend(list(xrange(160, 261, 20)))
 
 mhtEfficiencyBins = []
 mhtEfficiencyBins.extend(list(xrange(30, 50, 1)))
@@ -25,20 +25,20 @@ mhtEfficiencyBins.extend(list(xrange(50, 80, 5)))
 mhtEfficiencyBins.extend(list(xrange(80, 140, 10)))
 mhtEfficiencyBins.extend(list(xrange(140, 200, 15)))
 mhtEfficiencyBins.extend(list(xrange(200, 300, 20)))
-mhtEfficiencyBins.extend(list(xrange(300, 400, 50)))
+mhtEfficiencyBins.extend(list(xrange(300, 401, 50)))
 
 ettEfficiencyBins = []
 ettEfficiencyBins.extend(list(xrange(0, 30, 30)))
 ettEfficiencyBins.extend(list(xrange(30, 50, 10)))
 ettEfficiencyBins.extend(list(xrange(50, 90, 5)))
-ettEfficiencyBins.extend(list(xrange(90, 140, 2)))
+ettEfficiencyBins.extend(list(xrange(90, 141, 2)))
 
 httEfficiencyBins = []
 httEfficiencyBins.extend(list(xrange(0, 100, 5)))
 httEfficiencyBins.extend(list(xrange(100, 200, 10)))
 httEfficiencyBins.extend(list(xrange(200, 400, 20)))
 httEfficiencyBins.extend(list(xrange(400, 500, 50)))
-httEfficiencyBins.extend(list(xrange(500, 600, 10)))
+httEfficiencyBins.extend(list(xrange(500, 601, 10)))
 
 l1tStage2CaloLayer2OfflineDQM = cms.EDAnalyzer(
     "L1TStage2CaloLayer2Offline",

--- a/DQMOffline/L1Trigger/python/L1TTauOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TTauOffline_cfi.py
@@ -6,12 +6,12 @@ tauEfficiencyBins = []
 tauEfficiencyBins.extend(list(xrange(0, 120, 1)))
 tauEfficiencyBins.extend(list(xrange(120, 180, 20)))
 tauEfficiencyBins.extend(list(xrange(180, 300, 40)))
-tauEfficiencyBins.extend(list(xrange(300, 400, 100)))
+tauEfficiencyBins.extend(list(xrange(300, 401, 100)))
 
 l1tTauOfflineDQM = cms.EDAnalyzer(
     "L1TTauOffline",
     verbose   = cms.untracked.bool(False),
-    
+
     muonInputTag = cms.untracked.InputTag("muons"),
     tauInputTag = cms.untracked.InputTag("hpsPFTauProducer"),
     metInputTag = cms.untracked.InputTag("pfMet"),
@@ -31,7 +31,7 @@ l1tTauOfflineDQM = cms.EDAnalyzer(
 
     tauEfficiencyThresholds=cms.vint32(tauEfficiencyThresholds),
     tauEfficiencyBins=cms.vdouble(tauEfficiencyBins),
-    
+
 )
 
 l1tTauOfflineDQMEmu = l1tTauOfflineDQM.clone(

--- a/DQMOffline/L1Trigger/src/L1TEGammaOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TEGammaOffline.cc
@@ -11,10 +11,10 @@
 
 #include <iostream>
 #include <iomanip>
-#include <stdio.h>
+#include <cstdio>
 #include <string>
 #include <sstream>
-#include <math.h>
+#include <cmath>
 #include <algorithm>
 
 //
@@ -117,7 +117,7 @@ void L1TEGammaOffline::fillElectrons(edm::Event const& e, const unsigned int nVe
     edm::LogError("L1TEGammaOffline") << "invalid collection: GSF electrons " << std::endl;
     return;
   }
-  if (gsfElectrons->size() == 0) {
+  if (gsfElectrons->empty()) {
     LogDebug("L1TEGammaOffline") << "empty collection: GSF electrons " << std::endl;
     return;
   }
@@ -390,7 +390,7 @@ void L1TEGammaOffline::fillPhotons(edm::Event const& e, const unsigned int nVert
     return;
   }
 
-  if(photons->size() ==0){
+  if(photons->empty()){
     LogDebug("L1TEGammaOffline") << "No photons found in event." << std::endl;
     return;
   }
@@ -509,7 +509,7 @@ void L1TEGammaOffline::endRun(edm::Run const& run, edm::EventSetup const& eSetup
 void L1TEGammaOffline::bookElectronHistos(DQMStore::IBooker & ibooker)
 {
   ibooker.cd();
-  ibooker.setCurrentFolder(histFolder_.c_str());
+  ibooker.setCurrentFolder(histFolder_);
   h_nVertex_ = ibooker.book1D("nVertex", "Number of event vertices in collection", 40, -0.5, 39.5);
   h_tagAndProbeMass_ = ibooker.book1D("tagAndProbeMass", "Invariant mass of tag & probe pair", 100, 40, 140);
   // electron reco vs L1
@@ -561,7 +561,7 @@ void L1TEGammaOffline::bookElectronHistos(DQMStore::IBooker & ibooker)
       "electron #eta resolution  (EB); (L1 EGamma #eta - GSF Electron #eta)/GSF Electron #eta; events", 120, -0.3, 0.3);
 
   // electron turn-ons
-  ibooker.setCurrentFolder(efficiencyFolder_.c_str());
+  ibooker.setCurrentFolder(efficiencyFolder_);
   std::vector<float> electronBins(electronEfficiencyBins_.begin(), electronEfficiencyBins_.end());
   int nBins = electronBins.size() - 1;
   float* electronBinArray = &(electronBins[0]);
@@ -627,7 +627,7 @@ void L1TEGammaOffline::bookElectronHistos(DQMStore::IBooker & ibooker)
 void L1TEGammaOffline::bookPhotonHistos(DQMStore::IBooker & ibooker)
 {
   ibooker.cd();
-  ibooker.setCurrentFolder(histFolder_.c_str());
+  ibooker.setCurrentFolder(histFolder_);
   h_L1EGammaETvsPhotonET_EB_ = ibooker.book2D("L1EGammaETvsPhotonET_EB",
       "L1 EGamma E_{T} vs  Photon E_{T} (EB);  Photon E_{T} (GeV); L1 EGamma E_{T} (GeV)", 300, 0, 300, 300, 0, 300);
   h_L1EGammaETvsPhotonET_EE_ = ibooker.book2D("L1EGammaETvsPhotonET_EE",
@@ -670,7 +670,7 @@ void L1TEGammaOffline::bookPhotonHistos(DQMStore::IBooker & ibooker)
       "photon #eta resolution  (EB); (L1 EGamma #eta -  Photon #eta)/ Photon #eta; events", 120, -0.3, 0.3);
 
   // photon turn-ons
-  ibooker.setCurrentFolder(efficiencyFolder_.c_str());
+  ibooker.setCurrentFolder(efficiencyFolder_);
   std::vector<float> photonBins(photonEfficiencyBins_.begin(), photonEfficiencyBins_.end());
   int nBins = photonBins.size() - 1;
   float* photonBinArray = &(photonBins[0]);

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -295,7 +295,7 @@ void L1TStage2CaloLayer2Offline::fillJets(edm::Event const& e, const unsigned in
 //	}
 
   if (!foundMatch) {
-    edm::LogError("L1TStage2CaloLayer2Offline") << "Could not find a matching L1 Jet " << std::endl;
+    edm::LogWarning("L1TStage2CaloLayer2Offline") << "Could not find a matching L1 Jet " << std::endl;
     return;
   }
 

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -262,7 +262,7 @@ void L1TStage2CaloLayer2Offline::fillJets(edm::Event const& e, const unsigned in
     return;
   }
 
-  if (caloJets->size() == 0) {
+  if (caloJets->empty()) {
     LogDebug("L1TStage2CaloLayer2Offline") << "no calo jets found" << std::endl;
     return;
   }
@@ -416,7 +416,7 @@ void L1TStage2CaloLayer2Offline::bookHistos(DQMStore::IBooker & ibooker)
 void L1TStage2CaloLayer2Offline::bookEnergySumHistos(DQMStore::IBooker & ibooker)
 {
   ibooker.cd();
-  ibooker.setCurrentFolder(histFolder_.c_str());
+  ibooker.setCurrentFolder(histFolder_);
 
   h_nVertex_ = ibooker.book1D("nVertex", "Number of event vertices in collection", 40, -0.5, 39.5);
 
@@ -470,7 +470,7 @@ void L1TStage2CaloLayer2Offline::bookEnergySumHistos(DQMStore::IBooker & ibooker
       "MET #phi resolution; (L1 MHT #phi - reco MHT #phi)/reco MHT #phi; events", 120, -0.3, 0.3);
 
   // energy sum turn ons
-  ibooker.setCurrentFolder(efficiencyFolder_.c_str());
+  ibooker.setCurrentFolder(efficiencyFolder_);
 
   std::vector<float> metBins(metEfficiencyBins_.begin(), metEfficiencyBins_.end());
   std::vector<float> mhtBins(mhtEfficiencyBins_.begin(), mhtEfficiencyBins_.end());
@@ -514,7 +514,7 @@ void L1TStage2CaloLayer2Offline::bookEnergySumHistos(DQMStore::IBooker & ibooker
 void L1TStage2CaloLayer2Offline::bookJetHistos(DQMStore::IBooker & ibooker)
 {
   ibooker.cd();
-  ibooker.setCurrentFolder(histFolder_.c_str());
+  ibooker.setCurrentFolder(histFolder_);
   // jets control plots (monitor beyond the limits of the 2D histograms)
   h_controlPlots_[ControlPlots::L1JetET] = ibooker.book1D("L1JetET", "L1 Jet E_{T}; L1 Jet E_{T} (GeV); events", 500, 0,
       5e3);
@@ -570,7 +570,7 @@ void L1TStage2CaloLayer2Offline::bookJetHistos(DQMStore::IBooker & ibooker)
       "jet #eta resolution  (HB); (L1 Jet #eta - Offline Jet #eta)/Offline Jet #eta; events", 120, -0.3, 0.3);
 
   // jet turn-ons
-  ibooker.setCurrentFolder(efficiencyFolder_.c_str());
+  ibooker.setCurrentFolder(efficiencyFolder_);
   std::vector<float> jetBins(jetEfficiencyBins_.begin(), jetEfficiencyBins_.end());
   int nBins = jetBins.size() - 1;
   float* jetBinArray = &(jetBins[0]);

--- a/DQMOffline/L1Trigger/test/runDQMOffline_step2_L1TStage2CaloLayer2_cfg.py
+++ b/DQMOffline/L1Trigger/test/runDQMOffline_step2_L1TStage2CaloLayer2_cfg.py
@@ -1,4 +1,11 @@
 import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
+
+
+options = VarParsing('analysis')
+options.setDefault(
+    'inputFiles', ['L1TOffline_L1TStage2CaloLayer2_job1_RAW2DIGI_RECO_DQM.root'])
+options.parseArguments()
 
 process = cms.Process('HARVESTING')
 
@@ -39,7 +46,7 @@ process.maxEvents = cms.untracked.PSet(
 process.source = cms.Source(
     "DQMRootSource",
     fileNames=cms.untracked.vstring(
-        "file:L1TOffline_L1TStage2CaloLayer2_job1_RAW2DIGI_RECO_DQM.root")
+        "file:{0}".format(options.inputFiles[0]))
 )
 
 
@@ -52,7 +59,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:mc', '')  # for MC
 process.myHarvesting = cms.Path(process.DQMExampleStep2)
 process.myEff = cms.Path(
     process.l1tStage2CaloLayer2Efficiency * process.l1tStage2CaloLayer2EmuDiff +
-    process. l1tEGammaEfficiency * process.l1tEGammaEmuDiff + 
+    process. l1tEGammaEfficiency * process.l1tEGammaEmuDiff +
     process. l1tTauEfficiency * process.l1tTauEmuDiff
 )
 process.myTest = cms.Path(process.DQMExample_qTester)


### PR DESCRIPTION
This PR implements the features requested in Jira ticket [CMSLITDPG-171](https://its.cern.ch/jira/browse/CMSLITDPG-171):
 - changes to the electron thresholds
 - additional histograms for all electron probes
 - additional histograms for a subset of electron probes

In addition, this PR includes
 - fixes for the last bins for the efficiency histograms in L1T EGamma, Jets, Sums and Taus (last bin was ommited)
 - L1TEfficiency harvesting can now handle 2D histograms (needed for ticket)
 - changed `edm::LogError` to `edm::LogWarning` for the message regarding a missing matched L1T jet

