### PR TITLE
Urgent bugfix for miniaod covariance

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -694,6 +694,7 @@ namespace pat {
     //static std::atomic<CovarianceParameterization*> covarianceParameterization_;
     static std::once_flag covariance_load_flag;
     const CovarianceParameterization & covarianceParameterization() const {
+	if (!hasTrackDetails()) throw edm::Exception(edm::errors::InvalidReference, "Trying to access covariance matrix for a PackedCandidate for which it's not available. Check hasTrackDetails() before!\n");
 	std::call_once(covariance_load_flag,[](int v) { covarianceParameterization_.load(v); } ,covarianceVersion_ );
         if(covarianceParameterization_.loadedVersion() != covarianceVersion_ )
         {

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -354,6 +354,10 @@
     <![CDATA[delete track_.exchange(nullptr);
     ]]>
   </ioread>
+  <ioread sourceClass="pat::PackedCandidate"  version="[1-]" targetClass="pat::PackedCandidate" source="" target="m_">
+    <![CDATA[delete m_.exchange(nullptr);
+    ]]>
+  </ioread>
   <ioread sourceClass="pat::PackedCandidate" source="uint16_t packedCovarianceDxyDxy_; uint16_t packedCovarianceDxyDz_; uint16_t packedCovarianceDzDz_;   int8_t packedCovarianceDlambdaDz_; int8_t packedCovarianceDphiDxy_;  int8_t packedCovarianceDptDpt_; int8_t packedCovarianceDetaDeta_;  int8_t packedCovarianceDphiDphi_ " version="[-28]" targetClass="pat::PackedCandidate"
    target="packedCovariance_" embed="false" >
    <![CDATA[

--- a/DataFormats/PatCandidates/test/testPackedCandidate.cc
+++ b/DataFormats/PatCandidates/test/testPackedCandidate.cc
@@ -100,9 +100,13 @@ testPackedCandidate::testPackUnpack() {
   CPPUNIT_ASSERT(tolerance(pc.vertex().X(),v.X(), 0.001));
   CPPUNIT_ASSERT(tolerance(pc.vertex().Y(),v.Y(), 0.001));
   CPPUNIT_ASSERT(tolerance(pc.vertex().Z(),v.Z(), 0.01));  
-  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().pt(),trkPt,0.001));
-  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().eta(),trkEta,0.001));
-  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().phi(),trkPhi,0.001));
+//AR : this cannot be called unless track details are set
+//  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().pt(),trkPt,0.001));
+//  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().eta(),trkEta,0.001));
+//  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().phi(),trkPhi,0.001));
+  CPPUNIT_ASSERT(tolerance(pc.ptTrk(),trkPt,0.001));
+  CPPUNIT_ASSERT(tolerance(pc.etaAtVtx(),trkEta,0.001));
+  CPPUNIT_ASSERT(tolerance(pc.phiAtVtx(),trkPhi,0.001));
 }
 
 void testPackedCandidate::testSimulateReadFromRoot() {
@@ -131,6 +135,7 @@ void testPackedCandidate::testSimulateReadFromRoot() {
   delete pc.p4c_.exchange(nullptr);
   delete pc.vertex_.exchange(nullptr);
   delete pc.track_.exchange(nullptr);
+  delete pc.m_.exchange(nullptr);
 
   CPPUNIT_ASSERT(tolerance(pc.polarP4().Pt(),plv.Pt(),0.001) );
   CPPUNIT_ASSERT(tolerance(pc.polarP4().Eta(),plv.Eta(),0.001) );
@@ -143,9 +148,13 @@ void testPackedCandidate::testSimulateReadFromRoot() {
   CPPUNIT_ASSERT(tolerance(pc.vertex().X(),v.X(), 0.001));
   CPPUNIT_ASSERT(tolerance(pc.vertex().Y(),v.Y(), 0.001));
   CPPUNIT_ASSERT(tolerance(pc.vertex().Z(),v.Z(), 0.01));
-  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().pt(),trkPt,0.001));
-  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().eta(),trkEta,0.001));
-  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().phi(),trkPhi,0.001));
+//AR : this cannot be called unless track details are set
+//  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().pt(),trkPt,0.001));
+//  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().eta(),trkEta,0.001));
+//  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().phi(),trkPhi,0.001));
+  CPPUNIT_ASSERT(tolerance(pc.ptTrk(),trkPt,0.001));
+  CPPUNIT_ASSERT(tolerance(pc.etaAtVtx(),trkEta,0.001));
+  CPPUNIT_ASSERT(tolerance(pc.phiAtVtx(),trkPhi,0.001));
   
 }
 


### PR DESCRIPTION
Covariance information in miniaod 9XY is broken due to uninit data member when reading back from disk.
IOREAD added.

This PR also introduce a better exception when the user attempt to unpack tracks of candidates for which there are no track details

93X PR will follow in few minutes