### PR TITLE
More dE/dx info in AOD

### DIFF
--- a/RecoTracker/DeDx/interface/ASmirnovDeDxDiscriminator.h
+++ b/RecoTracker/DeDx/interface/ASmirnovDeDxDiscriminator.h
@@ -12,14 +12,14 @@ public:
    meVperADCStrip      = iConfig.getParameter<double>("MeVperADCStrip"); //currently needed until the map on the database are redone
    Reccord             = iConfig.getParameter<std::string>  ("Reccord");
    ProbabilityMode     = iConfig.getParameter<std::string>  ("ProbabilityMode");
-   Prob_ChargePath     = NULL;
+   Prob_ChargePath     = nullptr;
  }
 
- virtual void beginRun(edm::Run const& run, const edm::EventSetup& iSetup){
+ void beginRun(edm::Run const& run, const edm::EventSetup& iSetup) override{
     DeDxTools::buildDiscrimMap(run, iSetup, Reccord,  ProbabilityMode, Prob_ChargePath);
  }
 
- virtual std::pair<float,float> dedx(const reco::DeDxHitCollection& Hits){
+ std::pair<float,float> dedx(const reco::DeDxHitCollection& Hits) override{
     std::vector<float> vect_probs;
     for(size_t i = 0; i< Hits.size(); i ++){
        float path   = Hits[i].pathLength() * 10.0;  //x10 in order to be compatible with the map content

--- a/RecoTracker/DeDx/interface/BTagLikeDeDxDiscriminator.h
+++ b/RecoTracker/DeDx/interface/BTagLikeDeDxDiscriminator.h
@@ -12,14 +12,14 @@ public:
    meVperADCStrip      = iConfig.getParameter<double>("MeVperADCStrip"); //currently needed until the map on the database are redone
    Reccord             = iConfig.getParameter<std::string>  ("Reccord");
    ProbabilityMode     = iConfig.getParameter<std::string>  ("ProbabilityMode");
-   Prob_ChargePath     = NULL;
+   Prob_ChargePath     = nullptr;
  }
 
- virtual void beginRun(edm::Run const& run, const edm::EventSetup& iSetup){
+ void beginRun(edm::Run const& run, const edm::EventSetup& iSetup) override{
     DeDxTools::buildDiscrimMap(run, iSetup, Reccord,  ProbabilityMode, Prob_ChargePath);
  }
 
- virtual std::pair<float,float> dedx(const reco::DeDxHitCollection& Hits){
+ std::pair<float,float> dedx(const reco::DeDxHitCollection& Hits) override{
     std::vector<float> vect_probs;
     for(size_t i = 0; i< Hits.size(); i ++){
        float path   = Hits[i].pathLength() * 10.0;  //x10 in order to be compatible with the map content

--- a/RecoTracker/DeDx/interface/GenericAverageDeDxEstimator.h
+++ b/RecoTracker/DeDx/interface/GenericAverageDeDxEstimator.h
@@ -12,7 +12,7 @@ public:
     m_expo = iConfig.getParameter<double>("exponent");
  }
 
- virtual std::pair<float,float> dedx(const reco::DeDxHitCollection& Hits) {
+ std::pair<float,float> dedx(const reco::DeDxHitCollection& Hits) override {
     float result=0;
     size_t n = Hits.size();
     for(size_t i = 0; i< n; i ++){

--- a/RecoTracker/DeDx/interface/GenericTruncatedAverageDeDxEstimator.h
+++ b/RecoTracker/DeDx/interface/GenericTruncatedAverageDeDxEstimator.h
@@ -1,0 +1,32 @@
+#ifndef RecoTrackerDeDx_GenericTruncatedAverageDeDxEstimator_h
+#define RecoTrackerDeDx_GenericTruncatedAverageDeDxEstimator_h
+
+#include "RecoTracker/DeDx/interface/BaseDeDxEstimator.h"
+#include "RecoTracker/DeDx/interface/DeDxTools.h"
+#include "DataFormats/TrackReco/interface/DeDxHit.h"
+#include <numeric>
+
+class GenericTruncatedAverageDeDxEstimator: public BaseDeDxEstimator
+{
+public: 
+ GenericTruncatedAverageDeDxEstimator(const edm::ParameterSet& iConfig){
+    m_fraction = iConfig.getParameter<double>("fraction");
+    m_expo = iConfig.getParameter<double>("exponent");
+ }
+
+ virtual std::pair<float,float> dedx(const reco::DeDxHitCollection& Hits){
+    int nTrunc = int( Hits.size()*m_fraction);
+    double sumdedx = 0;
+    for(size_t i=0;i + nTrunc <  Hits.size() ; i++){
+       sumdedx+=pow(Hits[i].charge(),m_expo);
+    } 
+   double avrdedx = (Hits.size()) ? pow(sumdedx/(Hits.size()-nTrunc),1.0/m_expo) :0.0;
+   return  std::make_pair(avrdedx,-1);
+ } 
+
+private:
+ float m_fraction, m_expo;
+
+};
+
+#endif

--- a/RecoTracker/DeDx/interface/GenericTruncatedAverageDeDxEstimator.h
+++ b/RecoTracker/DeDx/interface/GenericTruncatedAverageDeDxEstimator.h
@@ -15,12 +15,17 @@ public:
  }
 
  virtual std::pair<float,float> dedx(const reco::DeDxHitCollection& Hits){
-    int nTrunc = int( Hits.size()*m_fraction);
+    int first = 0, last = Hits.size();
+    if (m_fraction > 0) { // truncate high charge ones
+       last -= int(Hits.size()*m_fraction); 
+    } else {
+       first += int(Hits.size()*(-m_fraction)); 
+    }
     double sumdedx = 0;
-    for(size_t i=0;i + nTrunc <  Hits.size() ; i++){
+    for(int i = first; i < last; i++){
        sumdedx+=pow(Hits[i].charge(),m_expo);
     } 
-   double avrdedx = (Hits.size()) ? pow(sumdedx/(Hits.size()-nTrunc),1.0/m_expo) :0.0;
+   double avrdedx = (last-first) ? pow(sumdedx/(last-first),1.0/m_expo) :0.0;
    return  std::make_pair(avrdedx,-1);
  } 
 

--- a/RecoTracker/DeDx/interface/GenericTruncatedAverageDeDxEstimator.h
+++ b/RecoTracker/DeDx/interface/GenericTruncatedAverageDeDxEstimator.h
@@ -14,7 +14,7 @@ public:
     m_expo = iConfig.getParameter<double>("exponent");
  }
 
- virtual std::pair<float,float> dedx(const reco::DeDxHitCollection& Hits){
+ std::pair<float,float> dedx(const reco::DeDxHitCollection& Hits) override{
     int first = 0, last = Hits.size();
     if (m_fraction > 0) { // truncate high charge ones
        last -= int(Hits.size()*m_fraction); 

--- a/RecoTracker/DeDx/interface/MedianDeDxEstimator.h
+++ b/RecoTracker/DeDx/interface/MedianDeDxEstimator.h
@@ -11,8 +11,8 @@ public:
  MedianDeDxEstimator(const edm::ParameterSet& iConfig){
  }
 
- virtual std::pair<float,float> dedx(const reco::DeDxHitCollection & Hits){
-    if(Hits.size()==0)return std::make_pair(-1,-1);
+ std::pair<float,float> dedx(const reco::DeDxHitCollection & Hits) override{
+    if(Hits.empty())return std::make_pair(-1,-1);
     return std::make_pair(Hits[Hits.size()/2].charge(),-1); 
  } 
 };

--- a/RecoTracker/DeDx/interface/ProductDeDxDiscriminator.h
+++ b/RecoTracker/DeDx/interface/ProductDeDxDiscriminator.h
@@ -12,14 +12,14 @@ public:
    meVperADCStrip      = iConfig.getParameter<double>("MeVperADCStrip"); //currently needed until the map on the database are redone
    Reccord             = iConfig.getParameter<std::string>  ("Reccord");
    ProbabilityMode     = iConfig.getParameter<std::string>  ("ProbabilityMode");
-   Prob_ChargePath     = NULL;
+   Prob_ChargePath     = nullptr;
  }
 
- virtual void beginRun(edm::Run const& run, const edm::EventSetup& iSetup){
+ void beginRun(edm::Run const& run, const edm::EventSetup& iSetup) override{
     DeDxTools::buildDiscrimMap(run, iSetup, Reccord,  ProbabilityMode, Prob_ChargePath);
  }
 
- virtual std::pair<float,float> dedx(const reco::DeDxHitCollection& Hits){
+ std::pair<float,float> dedx(const reco::DeDxHitCollection& Hits) override{
     std::vector<float> vect_probs;
     for(size_t i = 0; i< Hits.size(); i ++){
        float path   = Hits[i].pathLength() * 10.0;  //x10 in order to be compatible with the map content

--- a/RecoTracker/DeDx/interface/SmirnovDeDxDiscriminator.h
+++ b/RecoTracker/DeDx/interface/SmirnovDeDxDiscriminator.h
@@ -12,14 +12,14 @@ public:
    meVperADCStrip      = iConfig.getParameter<double>("MeVperADCStrip"); //currently needed until the map on the database are redone
    Reccord             = iConfig.getParameter<std::string>  ("Reccord");
    ProbabilityMode     = iConfig.getParameter<std::string>  ("ProbabilityMode");
-   Prob_ChargePath     = NULL;
+   Prob_ChargePath     = nullptr;
  }
 
- virtual void beginRun(edm::Run const& run, const edm::EventSetup& iSetup){
+ void beginRun(edm::Run const& run, const edm::EventSetup& iSetup) override{
     DeDxTools::buildDiscrimMap(run, iSetup, Reccord,  ProbabilityMode, Prob_ChargePath);
  }
 
- virtual std::pair<float,float> dedx(const reco::DeDxHitCollection& Hits){
+ std::pair<float,float> dedx(const reco::DeDxHitCollection& Hits) override{
     std::vector<float> vect_probs;
     for(size_t i = 0; i< Hits.size(); i ++){
        float path   = Hits[i].pathLength() * 10.0;  //x10 in order to be compatible with the map content

--- a/RecoTracker/DeDx/interface/TruncatedAverageDeDxEstimator.h
+++ b/RecoTracker/DeDx/interface/TruncatedAverageDeDxEstimator.h
@@ -13,7 +13,7 @@ public:
     m_fraction = iConfig.getParameter<double>("fraction");
  }
 
- virtual std::pair<float,float> dedx(const reco::DeDxHitCollection& Hits){
+ std::pair<float,float> dedx(const reco::DeDxHitCollection& Hits) override{
     int nTrunc = int( Hits.size()*m_fraction);
     double sumdedx = 0;
     for(size_t i=0;i + nTrunc <  Hits.size() ; i++){

--- a/RecoTracker/DeDx/interface/UnbinnedFitDeDxEstimator.h
+++ b/RecoTracker/DeDx/interface/UnbinnedFitDeDxEstimator.h
@@ -19,14 +19,14 @@ class UnbinnedFitDeDxEstimator: public BaseDeDxEstimator
     fitter.setFunction((f1 = new TF1("myLandau","TMath::Landau(x,[0],[1],1)",0,255)));
   }
   
-  virtual ~UnbinnedFitDeDxEstimator() {
+  ~UnbinnedFitDeDxEstimator() override {
     // clean up everything
     delete f1;
   }
  
-  virtual std::pair<float,float> dedx(const reco::DeDxHitCollection & Hits){
+  std::pair<float,float> dedx(const reco::DeDxHitCollection & Hits) override{
     // if there is no hit, returns invalid.
-    if(Hits.size()==0) return std::make_pair(-1,-1);
+    if(Hits.empty()) return std::make_pair(-1,-1);
     // sets the initial parameters
     f1->SetParameters(3.0 , 0.3);
     // fills a temporary array and performs the fit

--- a/RecoTracker/DeDx/interface/UnbinnedLikelihoodFit.h
+++ b/RecoTracker/DeDx/interface/UnbinnedLikelihoodFit.h
@@ -3,7 +3,7 @@
 #include <TObject.h>
 #include <TF1.h>
 #include <TVirtualFitter.h>
-#include <stdint.h>
+#include <cstdint>
 
 // a class to perform a likelihood fit
 // Author: Christophe Delaere
@@ -26,7 +26,7 @@ class UnbinnedLikelihoodFit : public TObject
   public:
     // Constructor and destructor
     UnbinnedLikelihoodFit();
-    ~UnbinnedLikelihoodFit();
+    ~UnbinnedLikelihoodFit() override;
 
     // Set the data for the fit: a set of measurements
     void setData(uint32_t n, double* x);
@@ -46,8 +46,8 @@ class UnbinnedLikelihoodFit : public TObject
     TF1* getFunction() const { return function_; }
     double getParameterValue(uint32_t i) { return function_ ? function_->GetParameter(i) : 0; }
     double getParameterError(uint32_t i) { return function_ ? function_->GetParError(i)  : 0; }
-    double* getParameterValues() { return function_ ? function_->GetParameters() : NULL; }
-    const double* getParameterErrors() { return function_ ? function_->GetParErrors()  : NULL; }
+    double* getParameterValues() { return function_ ? function_->GetParameters() : nullptr; }
+    const double* getParameterErrors() { return function_ ? function_->GetParErrors()  : nullptr; }
   
   private:
     // input data

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
@@ -93,7 +93,7 @@ DeDxEstimatorProducer::~DeDxEstimatorProducer()
 void  DeDxEstimatorProducer::beginRun(edm::Run const& run, const edm::EventSetup& iSetup)
 {
    iSetup.get<TrackerDigiGeometryRecord>().get( tkGeom );
-   if(useCalibration && calibGains.size()==0){
+   if(useCalibration && calibGains.empty()){
       m_off = tkGeom->offsetDU(GeomDetEnumerators::PixelBarrel); //index start at the first pixel
 
       DeDxTools::makeCalibrationMap(m_calibrationPath, *tkGeom, calibGains, m_off);

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
@@ -57,6 +57,7 @@ DeDxEstimatorProducer::DeDxEstimatorProducer(const edm::ParameterSet& iConfig)
    if     (estimatorName == "median")              m_estimator = new MedianDeDxEstimator(iConfig);
    else if(estimatorName == "generic")             m_estimator = new GenericAverageDeDxEstimator  (iConfig);
    else if(estimatorName == "truncated")           m_estimator = new TruncatedAverageDeDxEstimator(iConfig);
+   else if(estimatorName == "genericTruncated")    m_estimator = new GenericTruncatedAverageDeDxEstimator(iConfig);
    else if(estimatorName == "unbinnedFit")         m_estimator = new UnbinnedFitDeDxEstimator(iConfig);
    else if(estimatorName == "productDiscrim")      m_estimator = new ProductDeDxDiscriminator(iConfig);
    else if(estimatorName == "btagDiscrim")         m_estimator = new BTagLikeDeDxDiscriminator(iConfig);

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.h
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.h
@@ -26,6 +26,7 @@
 #include "RecoTracker/DeDx/interface/BaseDeDxEstimator.h"
 #include "RecoTracker/DeDx/interface/GenericAverageDeDxEstimator.h"
 #include "RecoTracker/DeDx/interface/TruncatedAverageDeDxEstimator.h"
+#include "RecoTracker/DeDx/interface/GenericTruncatedAverageDeDxEstimator.h"
 #include "RecoTracker/DeDx/interface/MedianDeDxEstimator.h"
 #include "RecoTracker/DeDx/interface/UnbinnedFitDeDxEstimator.h"
 #include "RecoTracker/DeDx/interface/ProductDeDxDiscriminator.h"

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.h
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.h
@@ -75,6 +75,8 @@ private:
 
   std::vector< std::vector<float> > calibGains; 
   unsigned int m_off;
+
+  edm::ESHandle<TrackerGeometry> tkGeom;
 };
 
 #endif

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.h
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.h
@@ -48,12 +48,12 @@
 class DeDxEstimatorProducer : public edm::stream::EDProducer<> {
 public:
   explicit DeDxEstimatorProducer(const edm::ParameterSet&);
-  ~DeDxEstimatorProducer();
+  ~DeDxEstimatorProducer() override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) override;
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void beginRun(edm::Run const& run, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
   void   makeCalibrationMap(const TrackerGeometry& tkGeom);
   void   processHit(const TrackingRecHit * recHit, float trackMomentum, float& cosine, reco::DeDxHitCollection& dedxHits, int& NClusterSaturating);

--- a/RecoTracker/DeDx/plugins/DeDxHitInfoProducer.cc
+++ b/RecoTracker/DeDx/plugins/DeDxHitInfoProducer.cc
@@ -58,7 +58,7 @@ DeDxHitInfoProducer::~DeDxHitInfoProducer(){}
 void  DeDxHitInfoProducer::beginRun(edm::Run const& run, const edm::EventSetup& iSetup)
 {
    iSetup.get<TrackerDigiGeometryRecord>().get( tkGeom );
-   if(useCalibration && calibGains.size()==0){
+   if(useCalibration && calibGains.empty()){
       m_off = tkGeom->offsetDU(GeomDetEnumerators::PixelBarrel); //index start at the first pixel
 
       DeDxTools::makeCalibrationMap(m_calibrationPath, *tkGeom, calibGains, m_off);

--- a/RecoTracker/DeDx/plugins/DeDxHitInfoProducer.h
+++ b/RecoTracker/DeDx/plugins/DeDxHitInfoProducer.h
@@ -34,11 +34,11 @@
 class DeDxHitInfoProducer : public edm::stream::EDProducer<> {
 public:
   explicit DeDxHitInfoProducer(const edm::ParameterSet&);
-  ~DeDxHitInfoProducer();
+  ~DeDxHitInfoProducer() override;
 
 private:
-  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) override;
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void beginRun(edm::Run const& run, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
   void   makeCalibrationMap(const TrackerGeometry& tkGeom);
   void   processHit(const TrackingRecHit* recHit, const float trackMomentum, const float cosine, reco::DeDxHitInfo& hitDeDxInfo,  const LocalPoint& hitLocalPos);

--- a/RecoTracker/DeDx/plugins/DeDxHitInfoProducer.h
+++ b/RecoTracker/DeDx/plugins/DeDxHitInfoProducer.h
@@ -69,6 +69,15 @@ private:
   unsigned int m_off;
 
   edm::ESHandle<TrackerGeometry> tkGeom;
+
+  uint64_t xorshift128p(uint64_t state[2]) {
+      uint64_t x = state[0];
+      uint64_t const y = state[1];
+      state[0] = y;
+      x ^= x << 23; // a
+      state[1] = x ^ y ^ (x >> 17) ^ (y >> 26); // b, c
+      return state[1] + y;
+  }
 };
 
 #endif

--- a/RecoTracker/DeDx/plugins/DeDxHitInfoProducer.h
+++ b/RecoTracker/DeDx/plugins/DeDxHitInfoProducer.h
@@ -25,6 +25,7 @@
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 
 #include "DataFormats/TrackReco/interface/DeDxHitInfo.h"
+#include "RecoTracker/DeDx/interface/GenericTruncatedAverageDeDxEstimator.h"
 
 //
 // class declaration
@@ -53,11 +54,16 @@ private:
 
   const unsigned int minTrackHits;
   const float        minTrackPt;
+  const float        minTrackPtPrescale;
   const float        maxTrackEta;
 
   const std::string                       m_calibrationPath;
   const bool                              useCalibration;
   const bool                              shapetest;
+
+  const unsigned int lowPtTracksPrescalePass, lowPtTracksPrescaleFail;
+  GenericTruncatedAverageDeDxEstimator lowPtTracksEstimator;
+  const float lowPtTracksDeDxThreshold;
 
   std::vector< std::vector<float> > calibGains; 
   unsigned int m_off;

--- a/RecoTracker/DeDx/plugins/DeDxHitInfoProducer.h
+++ b/RecoTracker/DeDx/plugins/DeDxHitInfoProducer.h
@@ -61,6 +61,8 @@ private:
 
   std::vector< std::vector<float> > calibGains; 
   unsigned int m_off;
+
+  edm::ESHandle<TrackerGeometry> tkGeom;
 };
 
 #endif

--- a/RecoTracker/DeDx/plugins/HLTDeDxFilter.h
+++ b/RecoTracker/DeDx/plugins/HLTDeDxFilter.h
@@ -23,9 +23,9 @@ class HLTDeDxFilter : public HLTFilter {
 
    public:
       explicit HLTDeDxFilter(const edm::ParameterSet&);
-      ~HLTDeDxFilter();
+      ~HLTDeDxFilter() override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+      bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
 
    private:
       bool saveTags_;              // whether to save this tag

--- a/RecoTracker/DeDx/python/dedxEstimators_cff.py
+++ b/RecoTracker/DeDx/python/dedxEstimators_cff.py
@@ -5,6 +5,7 @@ dedxHitInfo = cms.EDProducer("DeDxHitInfoProducer",
 
     minTrackHits       = cms.uint32(0),
     minTrackPt         = cms.double(10),
+    minTrackPtPrescale = cms.double(0.5), # minimal pT for prescaled low pT tracks
     maxTrackEta        = cms.double(5.0),
 
     useStrip           = cms.bool(True),
@@ -15,6 +16,14 @@ dedxHitInfo = cms.EDProducer("DeDxHitInfoProducer",
     useCalibration     = cms.bool(False),
     calibrationPath    = cms.string("file:Gains.root"),
     shapeTest          = cms.bool(True),
+
+    lowPtTracksPrescalePass = cms.uint32(50),   # prescale factor for low pt tracks above the dEdx cut
+    lowPtTracksPrescaleFail = cms.uint32(2000), # prescale factor for low pt tracks below the dEdx cut
+    lowPtTracksEstimatorParameters = cms.PSet( # generalized truncated average
+        fraction = cms.double(0.15),
+        exponent = cms.double(-2.0),
+    ),
+    lowPtTracksDeDxThreshold = cms.double(3.5), # threshold on tracks
 )
 
 dedxHarmonic2 = cms.EDProducer("DeDxEstimatorProducer",

--- a/RecoTracker/DeDx/python/dedxEstimators_cff.py
+++ b/RecoTracker/DeDx/python/dedxEstimators_cff.py
@@ -39,6 +39,13 @@ dedxHarmonic2 = cms.EDProducer("DeDxEstimatorProducer",
 
 dedxPixelHarmonic2 = dedxHarmonic2.clone(UseStrip = False, UsePixel = True)
 
+dedxPixelAndStripHarmonic2T085 = dedxHarmonic2.clone(
+        UseStrip = True, UsePixel = True,
+        estimator = 'genericTruncated',
+        fraction  = 0.15, # Drop the lowest 15% of hits
+        exponent  = -2.0, # Harmonic02
+)
+
 dedxTruncated40 = dedxHarmonic2.clone()
 dedxTruncated40.estimator =  cms.string('truncated')
 
@@ -60,4 +67,4 @@ dedxDiscrimSmi.estimator = cms.string('smirnovDiscrim')
 dedxDiscrimASmi         = dedxHarmonic2.clone()
 dedxDiscrimASmi.estimator = cms.string('asmirnovDiscrim')
 
-doAlldEdXEstimators = cms.Sequence(dedxTruncated40 + dedxHarmonic2 + dedxPixelHarmonic2 + dedxHitInfo)
+doAlldEdXEstimators = cms.Sequence(dedxTruncated40 + dedxHarmonic2 + dedxPixelHarmonic2 + dedxPixelAndStripHarmonic2T085 + dedxHitInfo)

--- a/RecoTracker/DeDx/python/dedxEstimators_cff.py
+++ b/RecoTracker/DeDx/python/dedxEstimators_cff.py
@@ -17,10 +17,10 @@ dedxHitInfo = cms.EDProducer("DeDxHitInfoProducer",
     calibrationPath    = cms.string("file:Gains.root"),
     shapeTest          = cms.bool(True),
 
-    lowPtTracksPrescalePass = cms.uint32(50),   # prescale factor for low pt tracks above the dEdx cut
+    lowPtTracksPrescalePass = cms.uint32(100),   # prescale factor for low pt tracks above the dEdx cut
     lowPtTracksPrescaleFail = cms.uint32(2000), # prescale factor for low pt tracks below the dEdx cut
     lowPtTracksEstimatorParameters = cms.PSet( # generalized truncated average
-        fraction = cms.double(0.15),
+        fraction = cms.double(-0.15), # negative = throw away the 15% with lowest charge
         exponent = cms.double(-2.0),
     ),
     lowPtTracksDeDxThreshold = cms.double(3.5), # threshold on tracks
@@ -51,7 +51,7 @@ dedxPixelHarmonic2 = dedxHarmonic2.clone(UseStrip = False, UsePixel = True)
 dedxPixelAndStripHarmonic2T085 = dedxHarmonic2.clone(
         UseStrip = True, UsePixel = True,
         estimator = 'genericTruncated',
-        fraction  = 0.15, # Drop the lowest 15% of hits
+        fraction  = -0.15, # Drop the lowest 15% of hits
         exponent  = -2.0, # Harmonic02
 )
 

--- a/RecoTracker/DeDx/src/DeDxTools.cc
+++ b/RecoTracker/DeDx/src/DeDxTools.cc
@@ -310,7 +310,7 @@ bool IsSpanningOver2APV(unsigned int FirstStrip, unsigned int ClusterSize)
 
 bool IsFarFromBorder(const TrajectoryStateOnSurface& trajState, const GeomDetUnit* it)
 {
-  if (dynamic_cast<const StripGeomDetUnit*>(it)==0 && dynamic_cast<const PixelGeomDetUnit*>(it)==0) {
+  if (dynamic_cast<const StripGeomDetUnit*>(it)==nullptr && dynamic_cast<const PixelGeomDetUnit*>(it)==nullptr) {
      edm::LogInfo("DeDxTools::IsFarFromBorder") << "this detID doesn't seem to belong to the Tracker" << std::endl;
      return false;
   }
@@ -322,20 +322,12 @@ bool IsFarFromBorder(const TrajectoryStateOnSurface& trajState, const GeomDetUni
   const TrapezoidalPlaneBounds* trapezoidalBounds( dynamic_cast<const TrapezoidalPlaneBounds*>(&(plane.bounds())));
   const RectangularPlaneBounds* rectangularBounds( dynamic_cast<const RectangularPlaneBounds*>(&(plane.bounds())));
 
+  if (!trapezoidalBounds && !rectangularBounds) return false;
+
   double DistFromBorder = 1.0;
   //double HalfWidth      = it->surface().bounds().width()  /2.0;
-  double HalfLength     = it->surface().bounds().length() /2.0;
-
-  if(trapezoidalBounds)
-  {
-      std::array<const float, 4> const & parameters = (*trapezoidalBounds).parameters();
-     HalfLength     = parameters[3];
-     //double t       = (HalfLength + HitLocalPos.y()) / (2*HalfLength) ;
-     //HalfWidth      = parameters[0] + (parameters[1]-parameters[0]) * t;
-  }else if(rectangularBounds){
-     //HalfWidth      = it->surface().bounds().width()  /2.0;
-     HalfLength     = it->surface().bounds().length() /2.0;
-  }else{return false;}
+  double HalfLength     = trapezoidalBounds ? (*trapezoidalBounds).parameters()[3] 
+                                            : it->surface().bounds().length() /2.0;
 
 //  if (fabs(HitLocalPos.x())+HitLocalError.xx() >= (HalfWidth  - DistFromBorder) ) return false;//Don't think is really necessary
   if (fabs(HitLocalPos.y())+HitLocalError.yy() >= (HalfLength - DistFromBorder) ) return false;

--- a/RecoTracker/DeDx/src/UnbinnedLikelihoodFit.cc
+++ b/RecoTracker/DeDx/src/UnbinnedLikelihoodFit.cc
@@ -30,8 +30,8 @@ void UnbinnedLL(Int_t&, Double_t*, Double_t &val, Double_t *par, Int_t) {
 UnbinnedLikelihoodFit::UnbinnedLikelihoodFit() {
   nparameters_ = 0;
   datasize_ = 0;
-  x_ = NULL;
-  min = NULL;
+  x_ = nullptr;
+  min = nullptr;
   tolerance_ = 0.01;
   maxIterations_ = 1000;
 }


### PR DESCRIPTION
Save prescaled  dE/dx hit information for low pt tracks, to allow calibration on AOD
It also declares the producer for I<sub>h</sub> as in EXO-16-036 but I didn't add it to the event content yet.

Presentation: https://indico.cern.ch/event/660773/
I checked also the rates of tracks from the JetHT PD in the recent run [300575](https://cmswbm.cern.ch/cmsdb/servlet/RunSummary?RUN=300575), where before prescaling I see ~10 tracks/event in region A (pt > 10), 85 tracks/event in region B (low pt, high dE/dx) and ~550 tracks/event in region C (low pt, low dEdx)

I can also push in this PR the changes from code-checks and the static analyzer for the RecoTracker/DeDx package, but I didn't want to mix that with the content-related changes.
Those changes are in [this diff](https://github.com/gpetruc/cmssw/compare/more_dedx...dedx_codecleanup)

@arizzi @jozzez1 
