### PR TITLE
update of autoCond to include L1Menu_Collisions2017_v3_m6_xml in 8 GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -39,23 +39,23 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '92X_dataRun2_HLTHI_frozen_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '92X_upgrade2017_design_IdealBS_v10',
+    'phase1_2017_design'       :  '92X_upgrade2017_design_IdealBS_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '92X_upgrade2017_realistic_v10',
+    'phase1_2017_realistic'    : '92X_upgrade2017_realistic_v11',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '92X_upgrade2017cosmics_realistic_deco_v10',
+    'phase1_2017_cosmics'      : '92X_upgrade2017cosmics_realistic_deco_v11',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '92X_upgrade2017cosmics_realistic_peak_v10',
+    'phase1_2017_cosmics_peak' : '92X_upgrade2017cosmics_realistic_peak_v11',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '92X_upgrade2018_design_IdealBS_v7',
+    'phase1_2018_design'       : '92X_upgrade2018_design_IdealBS_v8',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '92X_upgrade2018_realistic_v8',
+    'phase1_2018_realistic'    : '92X_upgrade2018_realistic_v9',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '92X_upgrade2018cosmics_realistic_deco_v8',
+    'phase1_2018_cosmics'      :   '92X_upgrade2018cosmics_realistic_deco_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '92X_upgrade2023_realistic_v2'
+    'phase2_realistic'         : '92X_upgrade2023_realistic_v3'
 }
 
 aliases = {


### PR DESCRIPTION
PR to master that includes a single change to autocond.py
8 GTs have been changes in such a way that now we use the L1T menu V3.
Deatails in:
https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3001/2/1.html
Backport of: https://github.com/cms-sw/cmssw/pull/20238