### PR TITLE
option to use deterministic event-based seed in SmearedJetProducer (for MT) [80X]

### DIFF
--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -154,7 +154,7 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
             desc.add<std::int32_t>("variation", 0);
             desc.add<std::uint32_t>("seed", 37428479);
             desc.add<bool>("skipGenMatching", false);
-            desc.add<bool>("useDeterministicSeed", false);
+            desc.add<bool>("useDeterministicSeed", true);
             desc.addUntracked<bool>("debug", false);
 
             auto source =

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -200,8 +200,8 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
                     unsigned int runNum_uint = static_cast <unsigned int> (event.id().run());
                     unsigned int lumiNum_uint = static_cast <unsigned int> (event.id().luminosityBlock());
                     unsigned int evNum_uint = static_cast <unsigned int> (event.id().event());
-                    unsigned int jet0pt = uint32_t(jets.empty() ? 0 : jets[0].pt()/0.01);
-                    std::uint32_t seed = jet0pt + (lumiNum_uint<<10) + (runNum_uint<<20) + evNum_uint;
+                    unsigned int jet0eta = uint32_t(jets.empty() ? 0 : jets[0].eta()/0.01);
+                    std::uint32_t seed = jet0eta + (lumiNum_uint<<10) + (runNum_uint<<20) + evNum_uint;
                     m_random_generator.seed(seed);
                 }
             }

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -185,6 +185,8 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
             JME::JetResolution resolution;
             JME::JetResolutionScaleFactor resolution_sf;
 
+            const JetCollection& jets = *jets_collection;
+
             if (m_enabled) {
                 if (m_use_txt_files) {
                     resolution = *m_resolution_from_file;
@@ -196,13 +198,13 @@ class SmearedJetProducerT : public edm::stream::EDProducer<> {
 
                 if(m_useDeterministicSeed) {
                     unsigned int runNum_uint = static_cast <unsigned int> (event.id().run());
-                    unsigned int evNum_uint = static_cast <unsigned int> (event.id().event()); 
-                    std::uint32_t seed = runNum_uint + 4*evNum_uint;
+                    unsigned int lumiNum_uint = static_cast <unsigned int> (event.id().luminosityBlock());
+                    unsigned int evNum_uint = static_cast <unsigned int> (event.id().event());
+                    unsigned int jet0pt = uint32_t(jets.empty() ? 0 : jets[0].pt()/0.01);
+                    std::uint32_t seed = jet0pt + (lumiNum_uint<<10) + (runNum_uint<<20) + evNum_uint;
                     m_random_generator.seed(seed);
                 }
             }
-
-            const JetCollection& jets = *jets_collection;
 
             if (m_genJetMatcher)
                 m_genJetMatcher->getTokens(event);

--- a/PhysicsTools/PatUtils/python/patPFMETCorrections_cff.py
+++ b/PhysicsTools/PatUtils/python/patPFMETCorrections_cff.py
@@ -134,6 +134,7 @@ patSmearedJets = cms.EDProducer("SmearedPATJetProducer",
     variation = cms.int32(0),  # If not specified, default to 0
 
     seed = cms.uint32(37428479),  # If not specified, default to 37428479
+    useDeterministicSeed = cms.bool(True),
 
     debug = cms.untracked.bool(False)
 )


### PR DESCRIPTION
backport of #20240