### PR TITLE
Modifier for high-lumi CSC L1 local trigger algorithms

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2018_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_cff.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
 from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
+from Configuration.Eras.Modifier_run2_CSC_2018_cff import run2_CSC_2018
 
-Run2_2018 = Run2_2017.copyAndExclude([run2_HEPlan1_2017])
+Run2_2018 = cms.ModifierChain(Run2_2017.copyAndExclude([run2_HEPlan1_2017]), run2_CSC_2018)
 
 

--- a/Configuration/Eras/python/Modifier_run2_CSC_2018_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_CSC_2018_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run2_CSC_2018 = cms.Modifier()

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -39,6 +39,7 @@ class Eras (object):
                            'run2_HF_2017', 'run2_HCAL_2017', 'run2_HEPlan1_2017',
                            'run3_HB', 'run3_common',
                            'phase1Pixel', 'run3_GEM', 'run2_GEM_2017', 'run2_GEM_2017_MCTest',
+                           'run2_CSC_2018',
                            'phase2_common', 'phase2_tracker',
                            'phase2_hgcal', 'phase2_muon', 'phase2_timing',
                            'phase2_timing_layer','phase2_hcal',
@@ -76,7 +77,7 @@ class Eras (object):
             if type(value)==Modifier:
                 nmod=nmod+1
                 if details: self.inspectModifier(value,details)
-        print '   ',nmod,'modifiers defined' 
+        print '   ',nmod,'modifiers defined'
 
     def inspect(self,name=None,onlyChosen=False,details=True):
         if name==None:
@@ -94,9 +95,9 @@ class Eras (object):
             if name is not None and name==e:
                 self.inspectEra(e,details)
             if name is None:
-                if not onlyChosen or getattr(self,e).isChosen(): 
+                if not onlyChosen or getattr(self,e).isChosen():
                     self.inspectEra(e,details)
-        
+
 eras=Eras()
 
 


### PR DESCRIPTION
During the 2018 data taking period the CSC L1 local trigger algorithms for the ME1/1 motherboard, ALCT mezzanine board and DCFEB will be tested and brought (partially) online. This modifier will enable us to switch on the essential upgrades in `L1Trigger/CSCTriggerPrimitives` to cope with higher instantaneous luminosity.