### PR TITLE
Modifications to Timing vs BX plot for ECAL

### DIFF
--- a/DQM/EcalMonitorTasks/interface/TimingTask.h
+++ b/DQM/EcalMonitorTasks/interface/TimingTask.h
@@ -19,22 +19,19 @@ namespace ecaldqm {
     void runOnRecHits(EcalRecHitCollection const&, Collections);
     void runOnUncalibRecHits(EcalUncalibratedRecHitCollection const&);
 
-    enum Constants {
-      nBXBins = 15
-    };
-
   private:
     void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
     void beginEvent(edm::Event const&, edm::EventSetup const&) override;
     void setParams(edm::ParameterSet const&) override;
 
-    std::array<int,nBXBins+1> bxBinEdges_;
+    std::vector<int> bxBinEdges_;
     double bxBin_;
 
     float chi2ThresholdEB_;
     float chi2ThresholdEE_;
     float energyThresholdEB_;
     float energyThresholdEE_;
+    float timingVsBXThreshold_;
 
     MESet* meTimeMapByLS;
   };

--- a/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
@@ -1,23 +1,26 @@
 import FWCore.ParameterSet.Config as cms
 
-bxBins = [
-    "1",
-    "271",
-    "541",
-    "892",
-    "1162",
-    "1432",
-    "1783",
-    "2053",
-    "2323",
-    "2674",
-    "2944",
-    "3214",
-    "3446",
-    "3490",
-    "3491",
-    "3565"
-]
+bxBins = [1]
+
+bxStepSizes = [9, 50, 100, 300]
+bxMaxVals = [101, 1501, 2401, 3601]
+runningMinVal = 1
+
+for stepCounter in range(len(bxStepSizes)):
+    runningMinVal = bxBins[-1]
+    bxStepSize = bxStepSizes[stepCounter]
+    bxMaxVal = bxMaxVals[stepCounter]
+    bxBins += list(range(runningMinVal + bxStepSize, bxMaxVal, bxStepSize))
+
+bxBinLabels = [str(bxBins[0])]
+for bxBinCounter in range(0, -1+len(bxBins)):
+    bxBinLabels += [str(1+bxBins[bxBinCounter]) + "-->" + str(bxBins[bxBinCounter+1])]
+
+nBXBins = len(bxBins)
+
+bxBinsFine = [i for i in range(1, 3601)]
+bxBinLabelsFine = [str(i) if (i%100 == 0) else "" for i in range(1, 3601)]
+nBXBinsFine = len(bxBinsFine)
 
 EaxisEdges = []
 for i in range(50) :
@@ -27,15 +30,19 @@ chi2ThresholdEE = 50.
 chi2ThresholdEB = 16.
 energyThresholdEE = 3.
 energyThresholdEB = 1.
+timingVsBXThreshold = 2.02
 timeWindow = 12.5
 summaryTimeWindow = 7.
 
 ecalTimingTask = cms.untracked.PSet(
     params = cms.untracked.PSet(
+        bxBins = cms.untracked.vint32(bxBins),
+        bxBinsFine = cms.untracked.vint32(bxBinsFine),
         chi2ThresholdEE = cms.untracked.double(chi2ThresholdEE),
         chi2ThresholdEB = cms.untracked.double(chi2ThresholdEB),
         energyThresholdEE = cms.untracked.double(energyThresholdEE),
-        energyThresholdEB = cms.untracked.double(energyThresholdEB)
+        energyThresholdEB = cms.untracked.double(energyThresholdEB),
+        timingVsBXThreshold = cms.untracked.double(timingVsBXThreshold)
     ),
     MEs = cms.untracked.PSet(
         TimeMap = cms.untracked.PSet(
@@ -121,22 +128,39 @@ ecalTimingTask = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/%(prefix)sTMT timing vs amplitude %(sm)s'),
             description = cms.untracked.string('Correlation between hit timing and energy. Only hits with GOOD or OUT_OF_TIME reconstruction flags are used.')
         ),
-        TimingVsBX = cms.untracked.PSet(
-            path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/%(prefix)sTMT Timing vs BX%(suffix)s'),
+        BarrelTimingVsBX = cms.untracked.PSet(
+            path = cms.untracked.string('EcalBarrel/EBTimingTask/EBTMT Timing vs BX'),
             kind = cms.untracked.string('TProfile'),
-            otype = cms.untracked.string('Ecal3P'),
+            otype = cms.untracked.string('EB'),
             xaxis = cms.untracked.PSet(
-                high = cms.untracked.double(16.0),
-                nbins = cms.untracked.int32(16),
+                high = cms.untracked.double(1.0*nBXBins),
+                nbins = cms.untracked.int32(nBXBins),
                 low = cms.untracked.double(0.0),
                 title = cms.untracked.string('bunch crossing'),
-                labels = cms.untracked.vstring(bxBins)
+                labels = cms.untracked.vstring(bxBinLabels)
             ),
             yaxis = cms.untracked.PSet(
                 title = cms.untracked.string('Timing (ns)')
             ),
             btype = cms.untracked.string('User'),
-            description = cms.untracked.string('Average hit timing in the partition as a function of BX number.')
+            description = cms.untracked.string('Average hit timing in the barrel as a function of BX number.')
+        ),
+        BarrelTimingVsBXFineBinned = cms.untracked.PSet(
+            path = cms.untracked.string('EcalBarrel/EBTimingTask/EBTMT Timing vs Finely Binned BX'),
+            kind = cms.untracked.string('TProfile'),
+            otype = cms.untracked.string('EB'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(1.0*nBXBinsFine),
+                nbins = cms.untracked.int32(nBXBinsFine),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('bunch crossing'),
+                labels = cms.untracked.vstring(bxBinLabelsFine)
+            ),
+            yaxis = cms.untracked.PSet(
+                title = cms.untracked.string('Timing (ns)')
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Average hit timing in the barrel as a finely-binned function of BX number.')
         ),
         TimeAmpBXm = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),

--- a/DQM/EcalMonitorTasks/src/TimingTask.cc
+++ b/DQM/EcalMonitorTasks/src/TimingTask.cc
@@ -13,12 +13,13 @@ namespace ecaldqm
 {
   TimingTask::TimingTask() :
     DQWorkerTask(),
-    bxBinEdges_{ {1, 271, 541, 892, 1162, 1432, 1783, 2053, 2323, 2674, 2944, 3214, 3446, 3490, 3491, 3565} },
+    bxBinEdges_(),
     bxBin_(0.),
     chi2ThresholdEB_(0.),
     chi2ThresholdEE_(0.),
     energyThresholdEB_(0.),
     energyThresholdEE_(0.),
+    timingVsBXThreshold_(0.),
     meTimeMapByLS(0)
   {
   }
@@ -26,10 +27,12 @@ namespace ecaldqm
   void
   TimingTask::setParams(edm::ParameterSet const& _params)
   {
+    bxBinEdges_ = onlineMode_? _params.getUntrackedParameter<std::vector<int> >("bxBins"): _params.getUntrackedParameter<std::vector<int> >("bxBinsFine");
     chi2ThresholdEB_   = _params.getUntrackedParameter<double>("chi2ThresholdEB");
     chi2ThresholdEE_   = _params.getUntrackedParameter<double>("chi2ThresholdEE");
     energyThresholdEB_ = _params.getUntrackedParameter<double>("energyThresholdEB");
     energyThresholdEE_ = _params.getUntrackedParameter<double>("energyThresholdEE");
+    timingVsBXThreshold_ = _params.getUntrackedParameter<double>("timingVsBXThreshold");
   }
 
   bool
@@ -62,7 +65,7 @@ namespace ecaldqm
   TimingTask::beginEvent(edm::Event const& _evt, edm::EventSetup const&  _es)
   {
     using namespace std;
-    int* pBin(std::upper_bound(bxBinEdges_.begin(), bxBinEdges_.end(), _evt.bunchCrossing()));
+    std::vector<int>::iterator pBin = std::upper_bound(bxBinEdges_.begin(), bxBinEdges_.end(), _evt.bunchCrossing());
     bxBin_ = static_cast<int>(pBin - bxBinEdges_.begin()) - 0.5;
   }
 
@@ -71,7 +74,7 @@ namespace ecaldqm
   {
     MESet& meTimeAmp(MEs_.at("TimeAmp"));
     MESet& meTimeAmpAll(MEs_.at("TimeAmpAll"));
-    MESet& meTimingVsBX(MEs_.at("TimingVsBX"));
+    MESet& meTimingVsBX(onlineMode_? MEs_.at("BarrelTimingVsBX"): MEs_.at("BarrelTimingVsBXFineBinned"));
     MESet& meTimeAll(MEs_.at("TimeAll"));
     MESet& meTimeAllMap(MEs_.at("TimeAllMap"));
     MESet& meTimeMap(MEs_.at("TimeMap")); // contains cumulative run stats => not suitable for Trend plots
@@ -108,7 +111,7 @@ namespace ecaldqm
                     meTimeAmp.fill(id, energy, time);
                     meTimeAmpAll.fill(id, energy, time);
 
-                    meTimingVsBX.fill(signedSubdet, bxBin_, time);
+                    if (energy > timingVsBXThreshold_ && signedSubdet == EcalBarrel) meTimingVsBX.fill(bxBin_, time);
 
                     if(energy > threshold){
                       meTimeAll.fill(id, time);

--- a/DQM/EcalMonitorTasks/src/TimingTask.cc
+++ b/DQM/EcalMonitorTasks/src/TimingTask.cc
@@ -20,7 +20,7 @@ namespace ecaldqm
     energyThresholdEB_(0.),
     energyThresholdEE_(0.),
     timingVsBXThreshold_(0.),
-    meTimeMapByLS(0)
+    meTimeMapByLS(nullptr)
   {
   }
 


### PR DESCRIPTION
Fill Timing vs BX plot with a much finer binning for offline DQM (where we have more statistics), to make it more useful for non-ECAL people. For online DQM we modify the current binning to make it more useful to ECAL experts.

Link to PR for P5 production version: https://github.com/cms-sw/cmssw/pull/20256

Link to corresponding P5 DQM GUI Deployment PR: https://github.com/dmwm/deployment/pull/531
