### PR TITLE
FIX in GBL reference trajectories: add missing initialisations

### DIFF
--- a/Alignment/ReferenceTrajectories/src/TwoBodyDecayTrajectory.cc
+++ b/Alignment/ReferenceTrajectories/src/TwoBodyDecayTrajectory.cc
@@ -123,6 +123,7 @@ bool TwoBodyDecayTrajectory::construct(const TwoBodyDecayTrajectoryState& state,
                                          trajectory2.gblInput().front().second*tbdToLocal2));
     // add virtual mass measurement
     theGblExtDerivatives.resize(1,nTbd);
+    theGblExtDerivatives.setZero();
     theGblExtDerivatives(0,TwoBodyDecayParameters::mass) = 1.0;
     theGblExtMeasurements.resize(1);
     theGblExtMeasurements(0) = state.primaryMass() - state.decayParameters()[TwoBodyDecayParameters::mass];


### PR DESCRIPTION
Adds missing matrix initialisations to the EIGEN matrices.
This was not needed in previous implementation of GBL based on ROOT TMatrix
(ROOT presets matrices to 0., EIGEN not).

Fix provided by @ckleinw