### PR TITLE
FIX in GBL reference trajectories: add missing initialisations

### DIFF
--- a/Alignment/ReferenceTrajectories/src/GblTrajectory.cc
+++ b/Alignment/ReferenceTrajectories/src/GblTrajectory.cc
@@ -603,6 +603,7 @@ namespace gbl {
 
     int nOffset = aPoint.getOffset();
 
+    anIndex = {};
     aJacobian.setZero();
     if (nOffset < 0) // need interpolation
       {
@@ -697,6 +698,7 @@ namespace gbl {
 
     int nOffset = aPoint.getOffset();
 
+    anIndex = {};
     aJacobian.setZero();
 
     Matrix2d prevW, prevWJ, nextW, nextWJ;
@@ -1077,6 +1079,7 @@ namespace gbl {
             if (measDim > 2) {
               matPDer = matP * matDer;
             } else { // 'shortcut' for position measurements
+              matPDer.setZero();
               matPDer.block<2, 5>(3, 0) = matP.block<2, 2>(3, 3)
                 * matDer.block<2, 5>(3, 0);
             }
@@ -1084,6 +1087,7 @@ namespace gbl {
             if (numInnerTrans > 0) {
               // transform for external parameters
               proDer.resize(measDim, Eigen::NoChange);
+              proDer.setZero();
               // match parameters
               unsigned int ifirst = 0;
               unsigned int ilabel = 0;
@@ -1151,6 +1155,7 @@ namespace gbl {
             if (numInnerTrans > 0) {
               // transform for external parameters
               proDer.resize(nDim, Eigen::NoChange);
+              proDer.setZero();
               // match parameters
               unsigned int ifirst = 0;
               unsigned int ilabel = 0;

--- a/Alignment/ReferenceTrajectories/src/TwoBodyDecayTrajectory.cc
+++ b/Alignment/ReferenceTrajectories/src/TwoBodyDecayTrajectory.cc
@@ -123,6 +123,7 @@ bool TwoBodyDecayTrajectory::construct(const TwoBodyDecayTrajectoryState& state,
                                          trajectory2.gblInput().front().second*tbdToLocal2));
     // add virtual mass measurement
     theGblExtDerivatives.resize(1,nTbd);
+    theGblExtDerivatives.setZero();
     theGblExtDerivatives(0,TwoBodyDecayParameters::mass) = 1.0;
     theGblExtMeasurements.resize(1);
     theGblExtMeasurements(0) = state.primaryMass() - state.decayParameters()[TwoBodyDecayParameters::mass];


### PR DESCRIPTION
Backport of #20262

Adds missing matrix initialisations to the EIGEN matrices.
This was not needed in previous implementation of GBL based on ROOT TMatrix
(ROOT presets matrices to 0., EIGEN not).

Fix provided by @ckleinw 
 