### PR TITLE
Fix HCAL TP validation & packing w/ premixing

### DIFF
--- a/Configuration/StandardSequences/python/DigiToRawDM_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRawDM_cff.py
@@ -20,6 +20,7 @@ hcalRawDataVME.HBHE = cms.untracked.InputTag("DMHcalDigis")
 hcalRawDataVME.HF = cms.untracked.InputTag("DMHcalDigis")
 hcalRawDataVME.HO = cms.untracked.InputTag("DMHcalDigis") 
 hcalRawDataVME.ZDC = cms.untracked.InputTag("mixData")
+hcalRawDataVME.TRIG = cms.untracked.InputTag("DMHcalTriggerPrimitiveDigis")
 #
 cscpacker.wireDigiTag = cms.InputTag("mixData","MuonCSCWireDigisDM")
 cscpacker.stripDigiTag = cms.InputTag("mixData","MuonCSCStripDigisDM")
@@ -37,11 +38,13 @@ from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify( hcalRawDataVME,
     HBHE = cms.untracked.InputTag(""),
     HF = cms.untracked.InputTag(""),
+    TRIG = cms.untracked.InputTag(""),
 )
 run2_HCAL_2017.toModify( hcalRawDatauHTR,
     HBHEqie8 = cms.InputTag("DMHcalDigis"),
     HFqie8 = cms.InputTag("DMHcalDigis"),
     QIE10 = cms.InputTag("DMHcalDigis","HFQIE10DigiCollection"),
     QIE11 = cms.InputTag("DMHcalDigis","HBHEQIE11DigiCollection"),
+    TP = cms.InputTag("DMHcalTriggerPrimitiveDigis"),
 )
 

--- a/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
+++ b/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
@@ -15,6 +15,7 @@ SimCalorimetryFEVTDEBUG = cms.PSet(
         'keep *_mixData_HcalSamples_*',
         'keep *_mix_HcalHits_*',
         'keep *_mixData_HcalHits_*',
+        'keep *_DMHcalTriggerPrimitiveDigis_*_*',
     )
 )
 SimCalorimetryRAW = cms.PSet(

--- a/SimGeneral/DataMixingModule/python/customiseForPremixingInput.py
+++ b/SimGeneral/DataMixingModule/python/customiseForPremixingInput.py
@@ -18,6 +18,8 @@ def customiseForPreMixingInput(process):
         replaceInputTag(tag, "simSiPixelDigis", "mixData:PixelDigiSimLink")
     def replaceStripDigiSimLink(tag):
         replaceInputTag(tag, "simSiStripDigis", "mixData:StripDigiSimLink")
+    def replaceHcalTp(tag):
+        replaceInputTag(tag, "simHcalTriggerPrimitiveDigis", "DMHcalTriggerPrimitiveDigis")
 
     for label, producer in process.producers_().iteritems():
         if producer.type_() == "ClusterTPAssociationProducer":
@@ -60,6 +62,8 @@ def customiseForPreMixingInput(process):
         if analyzer.type_() == "SiStripRecHitsValid":
             replacePixelDigiSimLink(analyzer.pixelSimLinkSrc)
             replaceStripDigiSimLink(analyzer.stripSimLinkSrc)
+        if analyzer.type_() == "HcalDigisValidation":
+            replaceHcalTp(analyzer.dataTPs)
 
 
 


### PR DESCRIPTION
Followup to #20221 with a more complete solution.
1. TPs from premixing are now included in the packer for both current and old workflows.
2. TPs from premixing are now included in the event content.
3. The HCAL validation sequences that use the simulated TPs are customized to use the proper tag for premixing workflows.

attn: @deguio @hatakeyamak @abdoulline @christopheralanwest @matz-e 