### PR TITLE
Fix unit test, uninitialized variable could cause infinite wait

### DIFF
--- a/FWCore/Integration/test/WaitingThreadIntProducer.cc
+++ b/FWCore/Integration/test/WaitingThreadIntProducer.cc
@@ -40,7 +40,9 @@ namespace {
                   unsigned int iSecondsToWait):
     m_perStream(iNumberOfStreams),
     m_minNumStreamsBeforeDoingWork(iMinNumberOfStreamsBeforeDoingWork),
-    m_secondsToWait(iSecondsToWait){}
+    m_secondsToWait(iSecondsToWait),
+    m_shouldStop(false),
+    m_drainQueue(false) {}
     void start();
     void stop();
     


### PR DESCRIPTION
If m_shouldStop is initialized to false the server stops prematurely and the producer's produce methods will wait forever for their data to get processed.
