### PR TITLE
Updated DQM after front-end optimization

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -39,15 +39,15 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
 {
   public:
     CTPPSDiamondDQMSource( const edm::ParameterSet& );
-    virtual ~CTPPSDiamondDQMSource();
+    ~CTPPSDiamondDQMSource() override;
 
   protected:
     void dqmBeginRun( const edm::Run&, const edm::EventSetup& ) override;
     void bookHistograms( DQMStore::IBooker&, const edm::Run&, const edm::EventSetup& ) override;
-    void analyze( const edm::Event&, const edm::EventSetup& );
-    void beginLuminosityBlock( const edm::LuminosityBlock&, const edm::EventSetup& );
-    void endLuminosityBlock( const edm::LuminosityBlock&, const edm::EventSetup& );
-    void endRun( const edm::Run&, const edm::EventSetup& );
+    void analyze( const edm::Event&, const edm::EventSetup& ) override;
+    void beginLuminosityBlock( const edm::LuminosityBlock&, const edm::EventSetup& ) override;
+    void endLuminosityBlock( const edm::LuminosityBlock&, const edm::EventSetup& ) override;
+    void endRun( const edm::Run&, const edm::EventSetup& ) override;
 
   private:
     // Constants
@@ -573,7 +573,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       for ( const auto& optorx : *fedInfo ) {
         if ( detId.arm() == 1 && optorx.getFEDId() == CTPPS_FED_ID_56 ) {
           potPlots_[detId_pot].ECCheck->Fill((int)((optorx.getLV1()& 0xFF)-((unsigned int) status.getEC() & 0xFF)) & 0xFF);
-          if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_56_ ) && ( static_cast<unsigned int8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
+          if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_56_ ) && ( static_cast<uint8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
             EC_difference_56_ = static_cast<int>( optorx.getLV1() & 0xFF )-( static_cast<unsigned int>( status.getEC() ) & 0xFF );
           if ( EC_difference_56_ != 1 && EC_difference_56_ != -500 && EC_difference_56_ < 128 && EC_difference_56_ > -128 )
             if (verbosity_)
@@ -584,7 +584,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         }
         else if ( detId.arm() == 0 && optorx.getFEDId()== CTPPS_FED_ID_45 ) {
           potPlots_[detId_pot].ECCheck->Fill((int)((optorx.getLV1()& 0xFF)-status.getEC()) & 0xFF);
-          if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_45_ ) && ( static_cast<unsigned int8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
+          if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_45_ ) && ( static_cast<uint8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
             EC_difference_45_ = static_cast<int>( optorx.getLV1() & 0xFF )-( static_cast<unsigned int>( status.getEC() ) & 0xFF );
           if ( EC_difference_45_ != 1 && EC_difference_45_ != -500 && EC_difference_45_ < 128 && EC_difference_45_ > -128 )
             if (verbosity_)

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -83,7 +83,7 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
     /// plots related to the whole system
     struct GlobalPlots
     {
-      MonitorElement* h_trackCorr_hor = NULL;
+      MonitorElement* h_trackCorr_hor = nullptr;
 
       GlobalPlots() {}
       GlobalPlots( DQMStore::IBooker& ibooker );
@@ -94,36 +94,41 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
     /// plots related to one Diamond detector package
     struct PotPlots
     {
-      MonitorElement* activity_per_bx = NULL;
-      MonitorElement* activity_per_bx_plus1 = NULL;
-      MonitorElement* activity_per_bx_minus1 = NULL;
+      MonitorElement* activity_per_bx_0_25 = nullptr;
+      MonitorElement* activity_per_bx_25_50 = nullptr;
+      MonitorElement* activity_per_bx_50_75 = nullptr;
+      std::vector< MonitorElement* > activity_per_bx;
 
-      MonitorElement* hitDistribution2d = NULL;
-      MonitorElement* hitDistribution2dOOT = NULL;
-      MonitorElement* hitDistribution2dOOT_le = NULL;
-      MonitorElement* hitDistribution2dOOT_te = NULL;
-      MonitorElement* activePlanes = NULL;
+      MonitorElement* hitDistribution2d = nullptr;
+      MonitorElement* hitDistribution2d_lumisection = nullptr;
+      MonitorElement* hitDistribution2dOOT = nullptr;
+      MonitorElement* hitDistribution2dOOT_le = nullptr;
+      MonitorElement* activePlanes = nullptr, *activePlanesInclusive = nullptr;
 
-      MonitorElement* trackDistribution = NULL;
-      MonitorElement* trackDistributionOOT = NULL;
+      MonitorElement* trackDistribution = nullptr;
+      MonitorElement* trackDistributionOOT = nullptr;
 
-      MonitorElement* stripTomographyAllFar = NULL;
-      MonitorElement* stripTomographyAllFar_plus1 = NULL;
-      MonitorElement* stripTomographyAllFar_minus1 = NULL;
+      MonitorElement* stripTomographyAllFar_0_25 = nullptr;
+      MonitorElement* stripTomographyAllFar_25_50 = nullptr;
+      MonitorElement* stripTomographyAllFar_50_75 = nullptr;
+      std::vector< MonitorElement* > stripTomographyAllFar;
 
-      MonitorElement* leadingEdgeCumulative_both = NULL, *leadingEdgeCumulative_le = NULL;
-      MonitorElement* timeOverThresholdCumulativePot = NULL, *leadingTrailingCorrelationPot = NULL;
-      MonitorElement* leadingWithoutTrailingCumulativePot = NULL;
+      MonitorElement* leadingEdgeCumulative_both = nullptr, *leadingEdgeCumulative_le = nullptr, *trailingEdgeCumulative_te = nullptr;
+      MonitorElement* timeOverThresholdCumulativePot = nullptr, *leadingTrailingCorrelationPot = nullptr;
+      MonitorElement* leadingWithoutTrailingCumulativePot = nullptr;
 
-      MonitorElement* ECCheck = NULL;
+      MonitorElement* ECCheck = nullptr;
 
-      MonitorElement* HPTDCErrorFlags_cumulative = NULL;
+      MonitorElement* HPTDCErrorFlags_cumulative = nullptr;
+      MonitorElement* MHComprensive = nullptr;
 
-      MonitorElement* clock_Digi1_le = NULL;
-      MonitorElement* clock_Digi1_te = NULL;
-      MonitorElement* clock_Digi3_le = NULL;
-      MonitorElement* clock_Digi3_te = NULL;
+      MonitorElement* clock_Digi1_le = nullptr;
+      MonitorElement* clock_Digi1_te = nullptr;
+      MonitorElement* clock_Digi3_le = nullptr;
+      MonitorElement* clock_Digi3_te = nullptr;
 
+      unsigned int HitCounter, MHCounter, LeadingOnlyCounter, TrailingOnlyCounter, CompleteCounter;
+      
       PotPlots() {};
       PotPlots( DQMStore::IBooker& ibooker, unsigned int id );
     };
@@ -134,11 +139,11 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
     /// plots related to one Diamond plane
     struct PlanePlots
     {
-      MonitorElement* digiProfileCumulativePerPlane = NULL;
-      MonitorElement* hitProfile = NULL;
-      MonitorElement* hit_multiplicity = NULL;
+      MonitorElement* digiProfileCumulativePerPlane = nullptr;
+      MonitorElement* hitProfile = nullptr;
+      MonitorElement* hit_multiplicity = nullptr;
 
-      MonitorElement* stripTomography_far = NULL;
+      MonitorElement* stripTomography_far = nullptr;
 
       PlanePlots() {}
       PlanePlots( DQMStore::IBooker& ibooker, unsigned int id );
@@ -149,19 +154,22 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
     /// plots related to one Diamond channel
     struct ChannelPlots
     {
-      MonitorElement* activity_per_bx = NULL;
-      MonitorElement* activity_per_bx_plus1 = NULL;
-      MonitorElement* activity_per_bx_minus1 = NULL;
+      MonitorElement* activity_per_bx_0_25 = nullptr;
+      MonitorElement* activity_per_bx_25_50 = nullptr;
+      MonitorElement* activity_per_bx_50_75 = nullptr;
+      std::vector< MonitorElement* > activity_per_bx;
 
-      MonitorElement* HPTDCErrorFlags = NULL;
-      MonitorElement* leadingEdgeCumulative_both = NULL, *leadingEdgeCumulative_le = NULL;
-      MonitorElement* TimeOverThresholdCumulativePerChannel = NULL;
-      MonitorElement* LeadingTrailingCorrelationPerChannel = NULL;
-      MonitorElement* leadingWithoutTrailing = NULL;
-      MonitorElement* stripTomography_far = NULL;
-      MonitorElement* hit_rate = NULL;
-      MonitorElement* ECCheckPerChannel = NULL;
+      MonitorElement* HPTDCErrorFlags = nullptr;
+      MonitorElement* leadingEdgeCumulative_both = nullptr, *leadingEdgeCumulative_le = nullptr, *trailingEdgeCumulative_te = nullptr;
+      MonitorElement* TimeOverThresholdCumulativePerChannel = nullptr;
+      MonitorElement* LeadingTrailingCorrelationPerChannel = nullptr;
+      MonitorElement* leadingWithoutTrailing = nullptr;
+      MonitorElement* stripTomography_far = nullptr;
+      MonitorElement* hit_rate = nullptr;
+      MonitorElement* ECCheckPerChannel = nullptr;
       unsigned long hitsCounterPerLumisection;
+      
+      unsigned int HitCounter, MHCounter, LeadingOnlyCounter, TrailingOnlyCounter, CompleteCounter;
 
       ChannelPlots() : hitsCounterPerLumisection( 0 ) {}
       ChannelPlots( DQMStore::IBooker &ibooker, unsigned int id );
@@ -208,7 +216,7 @@ CTPPSDiamondDQMSource::GlobalPlots::GlobalPlots( DQMStore::IBooker& ibooker )
 //----------------------------------------------------------------------------------------------------
 
 
-CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned int id )
+CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned int id ): HitCounter(0), MHCounter(0), LeadingOnlyCounter(0), TrailingOnlyCounter(0), CompleteCounter(0)
 {
   std::string path, title;
   CTPPSDiamondDetId( id ).rpName( path, CTPPSDiamondDetId::nPath );
@@ -216,47 +224,55 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
 
   CTPPSDiamondDetId( id ).rpName( title, CTPPSDiamondDetId::nFull );
 
-  activity_per_bx = ibooker.book1D( "activity per BX", title+" activity per BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_bx_plus1 = ibooker.book1D( "activity per BX OOT +1", title+" activity per BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_bx_minus1 = ibooker.book1D( "activity per BX OOT -1", title+" activity per BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
+  activity_per_bx_0_25 = ibooker.book1D( "activity per BX 0 25", title+" Activity per BX 0 - 25 ns;Event.BX", 3600, -1.5, 3598. + 0.5 );
+  activity_per_bx.emplace_back(activity_per_bx_0_25);
+  activity_per_bx_25_50 = ibooker.book1D( "activity per BX 25 50", title+" Activity per BX 25 - 50 ns;Event.BX", 3600, -1.5, 3598. + 0.5 );
+  activity_per_bx.emplace_back(activity_per_bx_25_50);
+  activity_per_bx_50_75 = ibooker.book1D( "activity per BX 50 75", title+" Activity per BX 50 - 75 ns;Event.BX", 3600, -1.5, 3598. + 0.5 );
+  activity_per_bx.emplace_back(activity_per_bx_50_75);
 
   hitDistribution2d = ibooker.book2D( "hits in planes", title+" hits in planes;plane number;x (mm)", 10, -0.5, 4.5, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
-  hitDistribution2dOOT= ibooker.book2D( "hits with OOT in planes", title+" hits with OOT in planes;plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
-  hitDistribution2dOOT_le= ibooker.book2D( "hits with OOT in planes (le only)", title+" hits with OOT in planes (le only);plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
-  hitDistribution2dOOT_te= ibooker.book2D( "hits with OOT in planes (te only)", title+" hits with OOT in planes (te only);plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
-  activePlanes = ibooker.book1D( "active planes", title+" active planes;number of active planes", 6, -0.5, 5.5 );
+  hitDistribution2d_lumisection = ibooker.book2D( "hits in planes lumisection", title+" hits in planes in the last lumisection;plane number;x (mm)", 10, -0.5, 4.5, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitDistribution2dOOT= ibooker.book2D( "hits with OOT in planes", title+" hits with OOT in planes;plane number + 0.25 OOT;x (mm)", 17, -0.25, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitDistribution2dOOT_le= ibooker.book2D( "hits with OOT in planes (le only)", title+" hits with OOT in planes (le only);plane number + 0.25 OOT;x (mm)", 17, -0.25, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  activePlanes = ibooker.book1D( "active planes", title+" active planes (per event);number of active planes", 6, -0.5, 5.5 );
+  activePlanesInclusive = ibooker.book1D( "active planes inclusive", title+" active planes, MH and le only included (per event);number of active planes", 6, -0.5, 5.5 );
 
   trackDistribution = ibooker.book1D( "tracks", title+" tracks;x (mm)", 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   trackDistributionOOT = ibooker.book2D( "tracks with OOT", title+" tracks with OOT;plane number;x (mm)", 9, -0.5, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
 
-  stripTomographyAllFar = ibooker.book2D( "tomography all far", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
-  stripTomographyAllFar_plus1 = ibooker.book2D( "tomography all far OOT +1", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
-  stripTomographyAllFar_minus1 = ibooker.book2D( "tomography all far OOT -1", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
+  stripTomographyAllFar_0_25 = ibooker.book2D( "tomography all far 0 25", title+" tomography with strips far 0 - 25 ns (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 12, -2, 10 );
+  stripTomographyAllFar.emplace_back(stripTomographyAllFar_0_25);
+  stripTomographyAllFar_25_50 = ibooker.book2D( "tomography all far 25 50", title+" tomography with strips far 25 - 50 ns (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 12, -2, 10 );
+  stripTomographyAllFar.emplace_back(stripTomographyAllFar_25_50);
+  stripTomographyAllFar_50_75 = ibooker.book2D( "tomography all far 50 75", title+" tomography with strips far 50 - 75 ns (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 12, -2, 10 );
+  stripTomographyAllFar.emplace_back(stripTomographyAllFar_50_75);
 
   leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge (le and te); leading edge (ns)", 125, 0, 125 );
   leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge (le only); leading edge (ns)", 125, 0, 125 );
-  timeOverThresholdCumulativePot = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 100, -100, 100 );
-  leadingTrailingCorrelationPot = ibooker.book2D( "leading trailing correlation", title+" leading trailing correlation;leading edge (ns);trailing edge (ns)", 100, 0, 100, 100, 0, 100 );
+  trailingEdgeCumulative_te = ibooker.book1D( "trailing edge (te only)", title+" trailing edge (te only); trailing edge (ns)", 125, 0, 125 );
+  timeOverThresholdCumulativePot = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 250, -25, 100 );
+  leadingTrailingCorrelationPot = ibooker.book2D( "leading trailing correlation", title+" leading trailing correlation;leading edge (ns);trailing edge (ns)", 75, 0, 75, 75, 0, 75 );
 
-  leadingWithoutTrailingCumulativePot = ibooker.book1D( "leading edges without trailing", title+" leading edges without trailing;leading edges without trailing", 4, 0.5, 4.5 );
-  leadingWithoutTrailingCumulativePot->getTH1F()->GetXaxis()->SetBinLabel( 1, "Nothing" );
-  leadingWithoutTrailingCumulativePot->getTH1F()->GetXaxis()->SetBinLabel( 2, "Leading only" );
-  leadingWithoutTrailingCumulativePot->getTH1F()->GetXaxis()->SetBinLabel( 3, "Trailing only" );
-  leadingWithoutTrailingCumulativePot->getTH1F()->GetXaxis()->SetBinLabel( 4, "Both" );
+  leadingWithoutTrailingCumulativePot = ibooker.book1D( "event category", title+" leading edges without trailing;;%", 3, 0.5, 3.5 );
+  leadingWithoutTrailingCumulativePot->getTH1F()->GetXaxis()->SetBinLabel( 1, "Leading only" );
+  leadingWithoutTrailingCumulativePot->getTH1F()->GetXaxis()->SetBinLabel( 2, "Trailing only" );
+  leadingWithoutTrailingCumulativePot->getTH1F()->GetXaxis()->SetBinLabel( 3, "Both" );
 
-  ECCheck = ibooker.book1D( "optorxEC(8bit) - vfatEC", title+" EC Error;optorxEC-vfatEC", 512, -256, 256 );
+  ECCheck = ibooker.book1D( "optorxEC(8bit) - vfatEC", title+" EC Error;optorxEC-vfatEC", 128, -64, 64 );
 
   HPTDCErrorFlags_cumulative = ibooker.book1D( "HPTDC Errors", title+" HPTDC Errors", 16, -0.5, 16.5 );
   for ( unsigned short error_index=1; error_index<16; ++error_index ) 
     HPTDCErrorFlags_cumulative->getTH1F()->GetXaxis()->SetBinLabel( error_index, HPTDCErrorFlags::getHPTDCErrorName( error_index-1 ).c_str() );
-  HPTDCErrorFlags_cumulative->getTH1F()->GetXaxis()->SetBinLabel( 16, "MH" );
+  HPTDCErrorFlags_cumulative->getTH1F()->GetXaxis()->SetBinLabel( 16, "MH  (%)" );
 
+  MHComprensive = ibooker.book2D( "MH in channels", title+" MH (%) in channels;plane number;ch number", 10, -0.5, 4.5, 14, -1, 13 );
 
   ibooker.setCurrentFolder( path+"/clock/" );
-  clock_Digi1_le = ibooker.book1D( "clock1 leading edge", title+" clock1;leading edge (ns)", 125, 0, 125 );
-  clock_Digi1_te = ibooker.book1D( "clock1 trailing edge", title+" clock1;trailing edge (ns)", 125, 0, 125 );
-  clock_Digi3_le = ibooker.book1D( "clock3 leading edge", title+" clock3;leading edge (ns)", 1000, 0, 125 );
-  clock_Digi3_te = ibooker.book1D( "clock3 trailing edge", title+" clock3;trailing edge (ns)", 125, 0, 125 );
+  clock_Digi1_le = ibooker.book1D( "clock1 leading edge", title+" clock1;leading edge (ns)", 1250, 0, 125 );
+  clock_Digi1_te = ibooker.book1D( "clock1 trailing edge", title+" clock1;trailing edge (ns)", 75, 0, 75 );
+  clock_Digi3_le = ibooker.book1D( "clock3 leading edge", title+" clock3;leading edge (ns)", 1250, 0, 125 );
+  clock_Digi3_te = ibooker.book1D( "clock3 trailing edge", title+" clock3;trailing edge (ns)", 75, 0, 75 );
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -273,12 +289,12 @@ CTPPSDiamondDQMSource::PlanePlots::PlanePlots( DQMStore::IBooker& ibooker, unsig
   hitProfile = ibooker.book1D( "hit profile", title+" hit profile;x (mm)", 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   hit_multiplicity = ibooker.book1D( "channels per plane", title+" channels per plane; ch per plane", 13, -0.5, 12.5 );
 
-  stripTomography_far = ibooker.book2D( "tomography far", title+" tomography with strips far;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
+  stripTomography_far = ibooker.book2D( "tomography far", title+" tomography with strips far;x + 25 OOT (mm);y (mm)", 50, 0, 50, 12, -2, 10 );
 }
 
 //----------------------------------------------------------------------------------------------------
 
-CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, unsigned int id ) : hitsCounterPerLumisection(0)
+CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, unsigned int id ) : hitsCounterPerLumisection(0), HitCounter(0), MHCounter(0), LeadingOnlyCounter(0), TrailingOnlyCounter(0), CompleteCounter(0)
 {
   std::string path, title;
   CTPPSDiamondDetId( id ).channelName( path, CTPPSDiamondDetId::nPath );
@@ -286,31 +302,34 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, u
 
   CTPPSDiamondDetId( id ).channelName( title, CTPPSDiamondDetId::nFull );
 
-  leadingWithoutTrailing = ibooker.book1D( "Leading Edges Without Trailing", title+" leading edges without trailing", 4, 0.5, 4.5 );
-  leadingWithoutTrailing->getTH1F()->GetXaxis()->SetBinLabel( 1, "Nothing" );
-  leadingWithoutTrailing->getTH1F()->GetXaxis()->SetBinLabel( 2, "Leading only" );
-  leadingWithoutTrailing->getTH1F()->GetXaxis()->SetBinLabel( 3, "Trailer only" );
-  leadingWithoutTrailing->getTH1F()->GetXaxis()->SetBinLabel( 4, "Full" );
+  leadingWithoutTrailing = ibooker.book1D( "event category", title+" Event Category;;%", 3, 0.5, 3.5 );
+  leadingWithoutTrailing->getTH1F()->GetXaxis()->SetBinLabel( 1, "Leading only" );
+  leadingWithoutTrailing->getTH1F()->GetXaxis()->SetBinLabel( 2, "Trailing only" );
+  leadingWithoutTrailing->getTH1F()->GetXaxis()->SetBinLabel( 3, "Full" );
 
-  activity_per_bx = ibooker.book1D( "activity per BX", title+" activity per BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_bx_plus1 = ibooker.book1D( "activity per BX OOT +1", title+" activity per BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_bx_minus1 = ibooker.book1D( "activity per BX OOT -1", title+" activity per BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
+  activity_per_bx_0_25 = ibooker.book1D( "activity per BX 0 25", title+" Activity per BX 0 - 25 ns;Event.BX", 1000, -1.5, 998. + 0.5 );
+  activity_per_bx.emplace_back(activity_per_bx_0_25);
+  activity_per_bx_25_50 = ibooker.book1D( "activity per BX 25 50", title+" Activity per BX 25 - 50 ns;Event.BX", 1000, -1.5, 998. + 0.5 );
+  activity_per_bx.emplace_back(activity_per_bx_25_50);
+  activity_per_bx_50_75 = ibooker.book1D( "activity per BX 50 75", title+" Activity per BX 50 - 75 ns;Event.BX", 1000, -1.5, 998. + 0.5 );
+  activity_per_bx.emplace_back(activity_per_bx_50_75);
 
   HPTDCErrorFlags = ibooker.book1D( "hptdc_Errors", title+" HPTDC Errors", 16, -0.5, 16.5 );
   for ( unsigned short error_index=1; error_index<16; ++error_index )
     HPTDCErrorFlags->getTH1F()->GetXaxis()->SetBinLabel( error_index, HPTDCErrorFlags::getHPTDCErrorName( error_index-1 ).c_str() );
-  HPTDCErrorFlags->getTH1F()->GetXaxis()->SetBinLabel( 16, "MH" );
+  HPTDCErrorFlags->getTH1F()->GetXaxis()->SetBinLabel( 16, "MH  (%)" );
 
-  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge; leading edge (ns)", 100, 0, 200 );
-  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge; leading edge (ns)", 200, 0, 200 );
-  TimeOverThresholdCumulativePerChannel = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 100, -100, 100 );
-  LeadingTrailingCorrelationPerChannel = ibooker.book2D( "leading trailing correlation", title+" leading trailing correlation;leading edge (ns);trailing edge (ns)", 100, 0, 100, 100, 0, 100 );
+  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge; leading edge (ns)", 125, 0, 125 );
+  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge; leading edge (ns)", 125, 0, 125 );
+  trailingEdgeCumulative_te = ibooker.book1D( "trailing edge (te only)", title+" trailing edge (te only); trailing edge (ns)", 125, 0, 125 );
+  TimeOverThresholdCumulativePerChannel = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 75, -25, 50 );
+  LeadingTrailingCorrelationPerChannel = ibooker.book2D( "leading trailing correlation", title+" leading trailing correlation;leading edge (ns);trailing edge (ns)", 75, 0, 75, 75, 0, 75 );
 
-  ECCheckPerChannel = ibooker.book1D("optorxEC(8bit) - vfatEC vs optorxEC", title+" EC Error;optorxEC-vfatEC", 512, -256, 256 );
+  ECCheckPerChannel = ibooker.book1D("optorxEC(8bit) - vfatEC vs optorxEC", title+" EC Error;optorxEC-vfatEC", 128, -64, 64 );
 
-  stripTomography_far = ibooker.book2D( "tomography far", "tomography with strips far;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
+  stripTomography_far = ibooker.book2D( "tomography far", "tomography with strips far;x + 25 OOT (mm);y (mm)", 50, 0, 50, 12, -2, 10 );
 
-  hit_rate = ibooker.book1D( "hit rate", title+"hit rate;rate (Hz)", 10, 0, 100 );
+  hit_rate = ibooker.book1D( "hit rate", title+"hit rate;rate (Hz)", 40, 0, 20);
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -383,12 +402,8 @@ CTPPSDiamondDQMSource::bookHistograms( DQMStore::IBooker& ibooker, const edm::Ru
 void
 CTPPSDiamondDQMSource::beginLuminosityBlock( const edm::LuminosityBlock&, const edm::EventSetup& ) 
 {
-  for ( auto& plot : channelPlots_ ) {
-    if ( plot.second.hitsCounterPerLumisection != 0 ) {
-      plot.second.hit_rate->Fill( (double) plot.second.hitsCounterPerLumisection / SEC_PER_LUMI_SECTION );
-    }
-    plot.second.hitsCounterPerLumisection = 0;
-  }
+  for ( auto& plot : potPlots_ ) 
+    plot.second.hitDistribution2d_lumisection->Reset();
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -436,8 +451,6 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
   //------------------------------
   // RP Plots
   //------------------------------  
-
-  //   if (event.bunchCrossing() > 100) return;
 
   //------------------------------
   // Correlation Plots
@@ -522,16 +535,27 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       if ( detId.channel() == CHANNEL_OF_VFAT_CLOCK ) continue;
       if ( potPlots_.find( detId_pot ) == potPlots_.end() ) continue;
       //Leading without trailing investigation
-      if      ( digi.getLeadingEdge() == 0 && digi.getTrailingEdge() == 0 ) potPlots_[detId_pot].leadingWithoutTrailingCumulativePot->Fill( 1 );
-      else if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() == 0 ) potPlots_[detId_pot].leadingWithoutTrailingCumulativePot->Fill( 2 );
-      else if ( digi.getLeadingEdge() == 0 && digi.getTrailingEdge() != 0 ) potPlots_[detId_pot].leadingWithoutTrailingCumulativePot->Fill( 3 );
-      else if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() != 0 ) potPlots_[detId_pot].leadingWithoutTrailingCumulativePot->Fill( 4 );
-
+      if ( digi.getLeadingEdge() != 0 || digi.getTrailingEdge() != 0 ) {
+        ++(potPlots_[detId_pot].HitCounter);
+        if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() == 0 ) {
+          ++(potPlots_[detId_pot].LeadingOnlyCounter);
+          potPlots_[detId_pot].leadingEdgeCumulative_le->Fill( HPTDC_BIN_WIDTH_NS * digi.getLeadingEdge() );
+        }
+        if ( digi.getLeadingEdge() == 0 && digi.getTrailingEdge() != 0 ) {
+          ++(potPlots_[detId_pot].TrailingOnlyCounter);
+          potPlots_[detId_pot].trailingEdgeCumulative_te->Fill( HPTDC_BIN_WIDTH_NS * digi.getTrailingEdge() );
+        }
+        if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() != 0 ) {
+          ++(potPlots_[detId_pot].CompleteCounter);
+          potPlots_[detId_pot].leadingTrailingCorrelationPot->Fill( HPTDC_BIN_WIDTH_NS * digi.getLeadingEdge(), HPTDC_BIN_WIDTH_NS * digi.getTrailingEdge() );
+        }
+      }      
+      
       // HPTDC Errors
       const HPTDCErrorFlags hptdcErrors = digi.getHPTDCErrorFlags();
       for ( unsigned short hptdcErrorIndex = 1; hptdcErrorIndex < 16; ++hptdcErrorIndex )
         if ( hptdcErrors.getErrorId( hptdcErrorIndex-1 ) ) potPlots_[detId_pot].HPTDCErrorFlags_cumulative->Fill( hptdcErrorIndex );
-      if ( digi.getMultipleHit() ) potPlots_[detId_pot].HPTDCErrorFlags_cumulative->Fill( 16 );
+      if ( digi.getMultipleHit() ) ++(potPlots_[detId_pot].MHCounter);
     }
   }
 
@@ -549,7 +573,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       for ( const auto& optorx : *fedInfo ) {
         if ( detId.arm() == 1 && optorx.getFEDId() == CTPPS_FED_ID_56 ) {
           potPlots_[detId_pot].ECCheck->Fill((int)((optorx.getLV1()& 0xFF)-((unsigned int) status.getEC() & 0xFF)) & 0xFF);
-          if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_56_ ) && ( static_cast<uint8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
+          if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_56_ ) && ( static_cast<unsigned int8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
             EC_difference_56_ = static_cast<int>( optorx.getLV1() & 0xFF )-( static_cast<unsigned int>( status.getEC() ) & 0xFF );
           if ( EC_difference_56_ != 1 && EC_difference_56_ != -500 && EC_difference_56_ < 128 && EC_difference_56_ > -128 )
             if (verbosity_)
@@ -560,7 +584,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         }
         else if ( detId.arm() == 0 && optorx.getFEDId()== CTPPS_FED_ID_45 ) {
           potPlots_[detId_pot].ECCheck->Fill((int)((optorx.getLV1()& 0xFF)-status.getEC()) & 0xFF);
-          if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_45_ ) && ( static_cast<uint8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
+          if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_45_ ) && ( static_cast<unsigned int8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
             EC_difference_45_ = static_cast<int>( optorx.getLV1() & 0xFF )-( static_cast<unsigned int>( status.getEC() ) & 0xFF );
           if ( EC_difference_45_ != 1 && EC_difference_45_ != -500 && EC_difference_45_ < 128 && EC_difference_45_ > -128 )
             if (verbosity_)
@@ -575,6 +599,8 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
 
   // Using CTPPSDiamondRecHit
   std::unordered_map<unsigned int, std::set<unsigned int> > planes;
+  std::unordered_map<unsigned int, std::set<unsigned int> > planes_inclusive;
+  
 
   for ( const auto& rechits : *diamondRecHits ) {
     CTPPSDiamondDetId detId_pot( rechits.detId() );
@@ -583,8 +609,10 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
     const CTPPSDiamondDetId detId( rechits.detId() );
 
     for ( const auto& rechit : rechits ) {
+      planes_inclusive[detId_pot].insert( detId.plane() );
       if ( excludeMultipleHits_ && rechit.getMultipleHits() > 0 ) continue;
-      planes[detId_pot].insert( detId.plane() );
+      if ( rechit.getToT() != 0 && centralOOT_ != -999 && rechit.getOOTIndex() == centralOOT_ )
+        planes[detId_pot].insert( detId.plane() );
 
       if ( potPlots_.find( detId_pot ) == potPlots_.end() ) continue;
 
@@ -597,8 +625,17 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         int startBin = hitHistoTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
         int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for ( int i=0; i<numOfBins; ++i) {
-          hitHistoTmp->Fill( detId.plane(), hitHistoTmpYAxis->GetBinCenter(startBin+i) + UFSDShift );
+          hitHistoTmp->Fill( detId.plane() + UFSDShift, hitHistoTmpYAxis->GetBinCenter(startBin+i) );
         }
+        
+        hitHistoTmp = potPlots_[detId_pot].hitDistribution2d_lumisection->getTH2F();
+        hitHistoTmpYAxis = hitHistoTmp->GetYaxis();
+        startBin = hitHistoTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
+        numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
+        for ( int i=0; i<numOfBins; ++i) {
+          hitHistoTmp->Fill( detId.plane() + UFSDShift, hitHistoTmpYAxis->GetBinCenter(startBin+i) );
+        }
+        
       }
 
       if ( rechit.getToT() != 0 ) {
@@ -611,53 +648,29 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         int startBin = hitHistoOOTTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
         int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for ( int i=0; i<numOfBins; ++i) {
-          hitHistoOOTTmp->Fill( detId.plane() + 0.1 * rechit.getOOTIndex(), hitHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
+          hitHistoOOTTmp->Fill( detId.plane() + 0.2 * rechit.getOOTIndex(), hitHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
         }
       }
       else {
-        if ( rechit.getT() == 0 ) {
-          // Only trailing
-          TH2F *hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT_te->getTH2F();
-          TAxis *hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
-          int startBin = hitHistoOOTTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
-          int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
-          for ( int i=0; i<numOfBins; ++i) {
-            hitHistoOOTTmp->Fill( detId.plane() + 0.1 * rechit.getOOTIndex(), hitHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
-          }
-        }
-        else {
+        if ( rechit.getT() != 0 ) {
           // Only leading
-          potPlots_[detId_pot].leadingEdgeCumulative_le->Fill( rechit.getT() + 25*rechit.getOOTIndex() );
-
           TH2F *hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT_le->getTH2F();
           TAxis *hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
           int startBin = hitHistoOOTTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
           int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
           for ( int i=0; i<numOfBins; ++i) {
-            hitHistoOOTTmp->Fill( detId.plane() + 0.1 * rechit.getOOTIndex(), hitHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
+            hitHistoOOTTmp->Fill( detId.plane() + 0.2 * rechit.getOOTIndex(), hitHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
           }
         }
       }
-
-      if ( rechit.getToT() != 0 ) {
-        switch ( rechit.getOOTIndex() - ( ( centralOOT_ != -999 ) ? centralOOT_ : 0 ) ) {
-          case -1:
-            potPlots_[detId_pot].activity_per_bx_minus1->Fill( event.bunchCrossing() );
-            break;
-          case 0:
-            potPlots_[detId_pot].activity_per_bx->Fill( event.bunchCrossing() );
-            break;
-          case 1:
-            potPlots_[detId_pot].activity_per_bx_plus1->Fill( event.bunchCrossing() );
-            break;
-        }
-
-      } // End if (complete hits)
+      if ( (unsigned int) rechit.getOOTIndex() < potPlots_[detId_pot].activity_per_bx.size() )
+        potPlots_[detId_pot].activity_per_bx.at( rechit.getOOTIndex() )->Fill( event.bunchCrossing() );
     }
   }
 
   for ( const auto& plt : potPlots_ ) {
     plt.second.activePlanes->Fill( planes[plt.first].size() );
+    plt.second.activePlanesInclusive->Fill( planes_inclusive[plt.first].size() );
   }
 
   // Using CTPPSDiamondLocalTrack
@@ -712,17 +725,8 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
           if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
           if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
-            switch ( rechit.getOOTIndex() - ( ( centralOOT_ != -999 ) ? centralOOT_ : 0 ) ) {
-              case -1: {
-                potPlots_[detId_pot].stripTomographyAllFar_minus1->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
-              } break;
-              case 0: {
-                potPlots_[detId_pot].stripTomographyAllFar->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
-              } break;
-              case 1: {
-                potPlots_[detId_pot].stripTomographyAllFar_plus1->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
-              } break;
-            }
+            if ( (unsigned int) rechit.getOOTIndex() < potPlots_[detId_pot].stripTomographyAllFar.size() )
+              potPlots_[detId_pot].stripTomographyAllFar.at( rechit.getOOTIndex() )->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
           }
         }
       }
@@ -818,7 +822,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
           if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
           if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
-            planePlots_[detId_plane].stripTomography_far->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - ( ( centralOOT_ != -999 ) ? centralOOT_ : 0 ) +1), striplt.getY0() );
+            planePlots_[detId_plane].stripTomography_far->Fill( striplt.getX0() + 25*rechit.getOOTIndex() , striplt.getY0() );
           }
         }
       }
@@ -853,13 +857,24 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         const HPTDCErrorFlags hptdcErrors = digi.getHPTDCErrorFlags();
         for ( unsigned short hptdcErrorIndex = 1; hptdcErrorIndex < 16; ++hptdcErrorIndex )
           if ( hptdcErrors.getErrorId( hptdcErrorIndex-1 ) ) channelPlots_[detId].HPTDCErrorFlags->Fill( hptdcErrorIndex );
-        if ( digi.getMultipleHit() ) channelPlots_[detId].HPTDCErrorFlags->Fill( 16 );
+        if ( digi.getMultipleHit() ) ++(channelPlots_[detId].MHCounter);
 
         // Check dropped trailing edges
-        if      ( digi.getLeadingEdge() == 0 && digi.getTrailingEdge() == 0 ) channelPlots_[detId].leadingWithoutTrailing->Fill( 1 );
-        else if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() == 0 ) channelPlots_[detId].leadingWithoutTrailing->Fill( 2 );
-        else if ( digi.getLeadingEdge() == 0 && digi.getTrailingEdge() != 0 ) channelPlots_[detId].leadingWithoutTrailing->Fill( 3 );
-        else if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() != 0 ) channelPlots_[detId].leadingWithoutTrailing->Fill( 4 );
+        if ( digi.getLeadingEdge() != 0 || digi.getTrailingEdge() != 0 ) {
+          ++(channelPlots_[detId].HitCounter);
+          if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() == 0 ) {
+            ++(channelPlots_[detId].LeadingOnlyCounter);
+            channelPlots_[detId].leadingEdgeCumulative_le->Fill( HPTDC_BIN_WIDTH_NS * digi.getLeadingEdge() );
+          }
+          if ( digi.getLeadingEdge() == 0 && digi.getTrailingEdge() != 0 ) {
+            ++(channelPlots_[detId].TrailingOnlyCounter);
+            channelPlots_[detId].trailingEdgeCumulative_te->Fill( HPTDC_BIN_WIDTH_NS * digi.getTrailingEdge() );
+          }
+          if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() != 0 ) {
+            ++(channelPlots_[detId].CompleteCounter);
+            channelPlots_[detId].LeadingTrailingCorrelationPerChannel->Fill( HPTDC_BIN_WIDTH_NS * digi.getLeadingEdge(), HPTDC_BIN_WIDTH_NS * digi.getTrailingEdge() );
+          }
+        }
       }
     }
   }
@@ -874,24 +889,11 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           channelPlots_[detId].leadingEdgeCumulative_both->Fill( rechit.getT() + 25*rechit.getOOTIndex() );
           channelPlots_[detId].TimeOverThresholdCumulativePerChannel->Fill( rechit.getToT() );
         }
-        else if ( rechit.getT() != 0 ) channelPlots_[detId].leadingEdgeCumulative_le->Fill( rechit.getT() + 25*rechit.getOOTIndex() );
-        channelPlots_[detId].LeadingTrailingCorrelationPerChannel->Fill( rechit.getT() + 25*rechit.getOOTIndex(), rechit.getT() + 25*rechit.getOOTIndex() + rechit.getToT() );
         ++(channelPlots_[detId].hitsCounterPerLumisection);
       }
 
-      if ( rechit.getToT() != 0 ) {
-        switch ( rechit.getOOTIndex() - ( ( centralOOT_ != -999 ) ? centralOOT_ : 0 ) ) {
-          case -1: {
-            channelPlots_[detId].activity_per_bx_minus1->Fill( event.bunchCrossing() );
-          } break;
-          case 0: {
-            channelPlots_[detId].activity_per_bx->Fill( event.bunchCrossing() );
-          } break;
-          case 1: {
-            channelPlots_[detId].activity_per_bx_plus1->Fill( event.bunchCrossing() );
-          } break;
-        }
-      }
+      if ( (unsigned int) rechit.getOOTIndex() < channelPlots_[detId].activity_per_bx.size() )
+        channelPlots_[detId].activity_per_bx.at( rechit.getOOTIndex() )->Fill( event.bunchCrossing() );
     }
 
   }
@@ -911,7 +913,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
             if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
             if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
             if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
-              channelPlots_[detId].stripTomography_far->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - ( ( centralOOT_ != -999 ) ? centralOOT_ : 0 ) +1), striplt.getY0() );
+              channelPlots_[detId].stripTomography_far->Fill( striplt.getX0() + 25*rechit.getOOTIndex(), striplt.getY0() );
             }
           }
         }
@@ -924,7 +926,41 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
 
 void
 CTPPSDiamondDQMSource::endLuminosityBlock( const edm::LuminosityBlock&, const edm::EventSetup& ) 
-{}
+{
+  for ( auto& plot : channelPlots_ ) {
+    if ( plot.second.hitsCounterPerLumisection != 0 ) {
+      plot.second.hit_rate->Fill( (double) plot.second.hitsCounterPerLumisection / SEC_PER_LUMI_SECTION );
+    }
+    plot.second.hitsCounterPerLumisection = 0;
+    
+    double HundredOverHitCounter = .0; 
+    if ( plot.second.HitCounter != 0 )
+      HundredOverHitCounter = 100. / plot.second.HitCounter;
+    plot.second.HPTDCErrorFlags->setBinContent( 16, HundredOverHitCounter * plot.second.MHCounter );
+    plot.second.leadingWithoutTrailing->setBinContent(1, HundredOverHitCounter * plot.second.LeadingOnlyCounter ); 
+    plot.second.leadingWithoutTrailing->setBinContent(2, HundredOverHitCounter * plot.second.TrailingOnlyCounter ); 
+    plot.second.leadingWithoutTrailing->setBinContent(3, HundredOverHitCounter * plot.second.CompleteCounter );
+  }
+    
+  for ( auto& plot : potPlots_ ) {
+    double HundredOverHitCounterPot = 100. / plot.second.HitCounter;
+    plot.second.HPTDCErrorFlags_cumulative->setBinContent( 16, HundredOverHitCounterPot * plot.second.MHCounter );
+    plot.second.leadingWithoutTrailingCumulativePot->setBinContent(1, HundredOverHitCounterPot * plot.second.LeadingOnlyCounter ); 
+    plot.second.leadingWithoutTrailingCumulativePot->setBinContent(2, HundredOverHitCounterPot * plot.second.TrailingOnlyCounter ); 
+    plot.second.leadingWithoutTrailingCumulativePot->setBinContent(3, HundredOverHitCounterPot * plot.second.CompleteCounter ); 
+    
+    plot.second.MHComprensive->Reset();
+    CTPPSDiamondDetId rpId(plot.first);
+    for ( auto& chPlot : channelPlots_ ) {
+      CTPPSDiamondDetId chId(chPlot.first);
+      if ( chId.arm() == rpId.arm() && chId.rp() == rpId.rp() ) {
+       plot.second.MHComprensive->Fill(chId.plane(), chId.channel(), chPlot.second.HPTDCErrorFlags->getBinContent( 16 ) );
+      }
+    }
+    
+  }
+  
+}
 
 //----------------------------------------------------------------------------------------------------
 

--- a/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
@@ -20,8 +20,18 @@ ctppsDiamondDQMSource = cms.EDAnalyzer("CTPPSDiamondDQMSource",
         ),
         # 2017
         cms.PSet(
-            validityRange = cms.EventRange("292521:min - 999999999:max"),
+            validityRange = cms.EventRange("292521:min - 301417:max"),
             centralOOT = cms.int32(3),
+        ),
+        # 2017, after channel delays corrections
+        cms.PSet(
+            validityRange = cms.EventRange("301418:min - 301517:max"),
+            centralOOT = cms.int32(1),
+        ),
+        # 2017, after channel delays corrections
+        cms.PSet(
+            validityRange = cms.EventRange("301518:min - 9999999:max"),
+            centralOOT = cms.int32(0),
         ),
     ),
   


### PR DESCRIPTION
This PR updates the DQM according to the latest hardware configuration.

The front-end chip (HPTDC) configuration has been optimized during the commissioning of the detector.
The main modification was the introduction of a delay (digital) for the different channels to temporally align them. This allows a better visualization of the online data: for instance all peaks in the leading edge plots are aligned.
Therefore, it was possible to reduce the acquisition window from 5 clock cycle down to 2. Drastically reducing the possibility of 2 hits in the same event.
Out of those 5 time slices, the one synchronized with the trigger (centralOOT) was moved from 4 to 1 and then to 0 (first acquired slice).
Some parameters require the modification of the DQM code; moreover, the readability of some plots has been improved (showing percentage instead of absolute values) and some new plots have been introduced, as the hit map in the last lumisection to immediately spot problems with the detectors.

Also, code has been improved (switch case removed, NULL -> nullptr, histogram binning optimized).

Finally, this code is compatible with the upcoming geometry update (UFSD implementation).

Note about urgency: current version of the DQM is enough to understand if the detector is working, but not enough to show its performance online.