### PR TITLE
DetectorDescription Clang tidy code-checks-all

### DIFF
--- a/DetectorDescription/Core/interface/DDComparator.h
+++ b/DetectorDescription/Core/interface/DDComparator.h
@@ -1,5 +1,5 @@
-#ifndef DDComparator_h
-#define DDComparator_h
+#ifndef DETECTOR_DESCRIPTION_CORE_DD_COMPARATOR_H
+#define DETECTOR_DESCRIPTION_CORE_DD_COMPARATOR_H
 
 #include <vector>
 
@@ -13,11 +13,12 @@
 /**
   This is a function-object.
 */
-class DDCompareEqual // : public binary_function<DDGeoHistory,DDPartSelection,bool> 
+class DDCompareEqual
 {
 public:
-  DDCompareEqual(const DDGeoHistory & h, const DDPartSelection & s)
-    : hist_(h), 
+  
+ DDCompareEqual(const DDGeoHistory & h, const DDPartSelection & s)
+   : hist_(h), 
     partsel_(s), 
     hMax_(h.size()), 
     hIndex_(0), 
@@ -28,9 +29,9 @@ public:
     absResult_(hMax_>0 && sMax_>0 ) 
     { 
       // it makes only sense to compare if both std::vectors have at least one entry each.
-        //std::cout << std::endl << std::endl << "COMPARATOR CREATED" << std::endl << std::endl;
-      //DCOUT('U', "Comparator():\n  hist=" << h << "\n  PartSel=" << s);
     }
+
+  DDCompareEqual() = delete;  
 
   bool operator() (const DDGeoHistory &, const DDPartSelection &);
   bool operator() ();
@@ -42,7 +43,6 @@ protected:
   inline bool nextChildposp();
   
 private:
-  DDCompareEqual() = delete;  
   const DDGeoHistory & hist_;
   const DDPartSelection & partsel_;
   DDGeoHistory::size_type const hMax_;
@@ -50,13 +50,8 @@ private:
   DDPartSelection::size_type const sMax_;
   DDPartSelection::size_type sIndex_;
   DDLogicalPart sLp_;
-  /*
-  lpredir_type * hLp_;
-  lpredir_type * sLp_;
-  */
   int sCopyno_;
   bool absResult_;
 };
-
 
 #endif

--- a/DetectorDescription/Core/interface/DDDivision.h
+++ b/DetectorDescription/Core/interface/DDDivision.h
@@ -76,8 +76,6 @@ std::ostream & operator<<( std::ostream &, const DDDivision &);
 
 class DDDivision : public DDBase<DDName, DDI::Division*>
 {
-  friend std::ostream & operator<<( std::ostream &, const DDDivision &);
-  
  public:      
   
   //! The default constructor provides an uninitialzed reference object.

--- a/DetectorDescription/Core/interface/DDLogicalPart.h
+++ b/DetectorDescription/Core/interface/DDLogicalPart.h
@@ -91,9 +91,7 @@ std::ostream & operator<<( std::ostream &, const DDLogicalPart &);
 */    
 class DDLogicalPart : public DDBase<DDName,DDI::LogicalPart*>
 {
-  friend std::ostream & operator<<( std::ostream &, const DDLogicalPart &);
-
-public:  
+ public:  
   //! The default constructor provides an uninitialzed reference object. 
   DDLogicalPart( void ) : DDBase<DDName,DDI::LogicalPart*>(){ }   
   

--- a/DetectorDescription/Core/interface/DDPosData.h
+++ b/DetectorDescription/Core/interface/DDPosData.h
@@ -1,5 +1,5 @@
-#ifndef DetectorDescription_Core_DDPosData_h
-#define DetectorDescription_Core_DDPosData_h
+#ifndef DETECTOR_DESCRIPTION_CORE_DD_POS_DATA_H
+#define DETECTOR_DESCRIPTION_CORE_DD_POS_DATA_H
 
 #include "DetectorDescription/Core/interface/DDTransform.h"
 #include "DetectorDescription/Core/interface/DDTranslation.h"
@@ -23,24 +23,25 @@ struct DDPosData
   DDPosData(const DDTranslation & t, const DDRotation& r, int c, const DDDivision * d = nullptr )
    : trans_(t), rot_(r), copyno_(c), div_(d)
    {} 
+  DDPosData() = delete;  
+  DDPosData & operator=(const DDPosData &) = delete;
 
   const DDTranslation & translation() const { return trans_; }
   const DDTranslation & trans() const { return trans_; }
-  
+
   const DDRotationMatrix & rotation() const { return *(rot_.rotation()); }
   const DDRotationMatrix & rot() const { return *(rot_.rotation()); }
+  const DDRotation & ddrot() const { return rot_; }
+  int copyno() const { return copyno_; }
 
   const DDDivision & div() const { return *div_; }
   const DDDivision & division() const { return *div_; }
-  
+
+private:
   DDTranslation trans_; /**< relative translation std::vector */
   DDRotation rot_; /**< relative rotation matrix */
   int copyno_; /**< copy number */
   const DDDivision * div_; /**< provides original division that created this pos */
-
-private:
-  DDPosData() = delete;  
-  DDPosData & operator=(const DDPosData &) = delete;
 };
 
 #endif

--- a/DetectorDescription/Core/interface/DDSolid.h
+++ b/DetectorDescription/Core/interface/DDSolid.h
@@ -79,7 +79,10 @@ private:
 class DDTrap : public DDSolid
 {
 public:
+  
   DDTrap( const DDSolid & s );
+  DDTrap( void ) = delete;
+
   //! half of the z-Axis
   double halfZ( void ) const;
   //! Polar angle of the line joining the centres of the faces at -/+pDz
@@ -101,16 +104,16 @@ public:
   //! Half-length along x of the side at y=+pDy2 of the face at +pDz
   double x4( void ) const;
   //! Angle with respect to the y axis from the centre of the side at y=-pDy2 to the centre at y=+pDy2 of the face at +pDz
-  double alpha2( void ) const;
-  
-private:
-  DDTrap( void ) = delete;
+  double alpha2( void ) const;  
 };
 
 class DDPseudoTrap : public DDSolid
 {
 public:
+  
   DDPseudoTrap( const DDSolid & s );
+  DDPseudoTrap( void ) = delete;
+
   //! half of the z-Axis
   double halfZ( void ) const;
   //! half length along x on -z
@@ -125,16 +128,16 @@ public:
   double radius( void ) const;
   //! true, if cut-out or rounding is on the -z side
   bool atMinusZ( void ) const;
-
-private:
-  DDPseudoTrap( void ) = delete;
 };
   
 /// A truncated tube section    
 class DDTruncTubs : public DDSolid
 {
 public:
+
   DDTruncTubs( const DDSolid & s );
+  DDTruncTubs( void ) = delete;
+
   //! half of the z-Axis
   double zHalf( void ) const;
   //! inner radius
@@ -151,9 +154,6 @@ public:
   double cutAtDelta( void ) const;
   //! true, if truncation is on the inner side of the tube-section
   bool cutInside( void ) const;
-
-private:
-  DDTruncTubs( void ) = delete;
 };
 
 //! Interface to a Box
@@ -164,60 +164,68 @@ private:
 class DDBox : public DDSolid
 {
 public:
+  
   DDBox( const DDSolid & s );
+  DDBox( void ) = delete;
+
   double halfX( void ) const; 
   double halfY( void ) const; 
   double halfZ( void ) const; 
-
-private:
-  DDBox( void ) = delete;
 };
 
 /// This is simply a handle on the solid.
 class DDShapelessSolid : public DDSolid
 {
 public:
-  DDShapelessSolid( const DDSolid & s );
 
-private:
+  DDShapelessSolid( const DDSolid & s );
   DDShapelessSolid( void ) = delete;
 };
 
 class DDReflectionSolid : public DDSolid
 {
 public:
+
   DDReflectionSolid( const DDSolid & s );
+  DDReflectionSolid( void ) = delete; 
+
   DDSolid unreflected( void ) const;
 
 private:
-  DDReflectionSolid( void ) = delete; 
+
   DDI::Reflection * reflected_; 
 }; 
 
 class DDBooleanSolid : public DDSolid
 {
 public:
+
   DDBooleanSolid( const DDSolid & s );
+  DDBooleanSolid( void ) = delete;
+
   DDSolid solidA( void ) const;
   DDSolid solidB( void ) const;
   DDTranslation translation( void ) const;
   DDRotation rotation( void ) const;
 
 private:
-  DDBooleanSolid( void ) = delete;
+
   DDI::BooleanSolid * boolean_;  
 };
 
 class DDMultiUnionSolid : public DDSolid
 {
 public:
+
   DDMultiUnionSolid( const DDSolid & s );
+  DDMultiUnionSolid( void ) = delete;
+
   const std::vector<DDSolid>& solids( void ) const;
   const std::vector<DDTranslation>& translations( void ) const;
   const std::vector<DDRotation>& rotations( void ) const;
 
 private:
-  DDMultiUnionSolid( void ) = delete;
+
   DDI::MultiUnion * union_;  
 };
 
@@ -225,33 +233,37 @@ private:
 class DDPolySolid : public DDSolid
 {
 public:
+
   DDPolySolid( const DDSolid & s );
+  DDPolySolid( void ) = delete;
 
 protected:
   /// note defaults please.
   virtual std::vector<double> getVec( const size_t& which, const size_t& offset = 0, const size_t& nVecs = 1 ) const;
-  DDPolySolid( void );
 };
   
 class DDPolycone : public DDPolySolid
 {
 public:
+  
   DDPolycone( const DDSolid & s );
+  DDPolycone( void ) = delete;
+
   double startPhi( void ) const;
   double deltaPhi( void ) const;
   std::vector<double> zVec( void ) const;
   std::vector<double> rVec( void ) const;
   std::vector<double> rMinVec( void ) const;
   std::vector<double> rMaxVec( void ) const;
-
-private:
-  DDPolycone( void ) = delete;
 };
 
 class DDPolyhedra : public DDPolySolid
 {
 public:
+
   DDPolyhedra( const DDSolid & s );
+  DDPolyhedra( void ) = delete;
+
   int sides( void ) const;
   double startPhi( void ) const;
   double deltaPhi( void ) const;
@@ -259,15 +271,15 @@ public:
   std::vector<double> rVec( void ) const;
   std::vector<double> rMinVec( void ) const;
   std::vector<double> rMaxVec( void ) const;
-
-private:
-  DDPolyhedra( void ) = delete;
 };
 
 class DDExtrudedPolygon : public DDPolySolid
 {
 public:
+
   DDExtrudedPolygon( const DDSolid & s );
+  DDExtrudedPolygon( void ) = delete;
+
   std::vector<double> xVec( void ) const;
   std::vector<double> yVec( void ) const;
   std::vector<double> zVec( void ) const;
@@ -276,7 +288,7 @@ public:
   std::vector<double> zscaleVec( void ) const;
 
 private:
-  DDExtrudedPolygon( void ) = delete;
+
   auto xyPointsSize( void ) const -> std::size_t;
   auto zSectionsSize( void ) const -> std::size_t;
 };
@@ -284,21 +296,24 @@ private:
 class DDTubs : public DDSolid
 {
 public:
+
   DDTubs( const DDSolid & s );
+  DDTubs( void ) = delete;
+
   double zhalf( void ) const;
   double rIn( void ) const;
   double rOut( void ) const;
   double startPhi( void ) const;
   double deltaPhi( void ) const;
-
-private:
-  DDTubs( void ) = delete;
 };
 
 class DDCutTubs : public DDSolid
 {
 public:
+
   DDCutTubs( const DDSolid & s );
+  DDCutTubs( void ) = delete;
+
   double zhalf( void ) const;
   double rIn( void ) const;
   double rOut( void ) const;
@@ -306,15 +321,15 @@ public:
   double deltaPhi( void ) const;
   std::array<double, 3> lowNorm( void ) const;
   std::array<double, 3> highNorm( void ) const;
-
-private:
-  DDCutTubs( void ) = delete;
 };
 
 class DDCons : public DDSolid
 {
 public:
+
   DDCons( const DDSolid & s );
+  DDCons( void ) = delete;
+
   double zhalf( void ) const;
   double rInMinusZ( void ) const;
   double rOutMinusZ( void ) const;
@@ -322,125 +337,118 @@ public:
   double rOutPlusZ( void ) const;
   double phiFrom( void ) const;
   double deltaPhi( void ) const;
-
-private:
-  DDCons( void ) = delete;
 };
 
 class DDTorus : public DDSolid
 {
 public:
+
   DDTorus( const DDSolid & s );
+  DDTorus( void ) = delete;
+
   double rMin( void ) const;
   double rMax( void ) const;
   double rTorus( void ) const;
   double startPhi( void ) const;
   double deltaPhi( void ) const;
-
-private:
-  DDTorus( void ) = delete;
 };
 
 class DDUnion : public DDBooleanSolid
 {
 public:
+
   DDUnion( const DDSolid & s );
-  
-private:
   DDUnion( void ) = delete;
 };
 
 class DDMultiUnion : public DDMultiUnionSolid
 {
 public:
+
   DDMultiUnion( const DDSolid & s );
-  
-private:
   DDMultiUnion( void ) = delete;
 };
 
 class DDIntersection : public DDBooleanSolid
 {
 public:
-  DDIntersection( const DDSolid & s );
 
-private:
+  DDIntersection( const DDSolid & s );
   DDIntersection( void ) = delete;
 };
 
 class DDSubtraction : public DDBooleanSolid
 {
 public:
-  DDSubtraction( const DDSolid & s );
 
-private:
+  DDSubtraction( const DDSolid & s );
   DDSubtraction( void ) = delete;
 };
 
 class DDSphere : public DDSolid
 {
 public:
+
   DDSphere( const DDSolid & s );
+  DDSphere( void ) = delete;
+
   double innerRadius( void ) const;
   double outerRadius( void ) const;
   double startPhi( void ) const;
   double deltaPhi( void ) const;
   double startTheta( void ) const;
   double deltaTheta( void ) const;
-
-private:
-  DDSphere( void ) = delete;
 };
 
 class DDOrb : public DDSolid
 {
 public:
-  DDOrb( const DDSolid & s );
-  double radius( void ) const;
 
-private:
+  DDOrb( const DDSolid & s );
   DDOrb( void ) = delete;
+
+  double radius( void ) const;
 };
 
 class DDEllipticalTube : public DDSolid
 {
 public:
+
   DDEllipticalTube( const DDSolid & s );
+  DDEllipticalTube( void ) = delete;
+
   double xSemiAxis( void ) const;
   double ySemiAxis( void ) const;
   double zHeight( void ) const;
-  
-private:
-  DDEllipticalTube( void ) = delete;
 };
 
 class DDEllipsoid : public DDSolid
 {
 public:
+
   DDEllipsoid( const DDSolid & s );
+  DDEllipsoid( void ) = delete;
+
   double xSemiAxis( void ) const;
   double ySemiAxis( void ) const;
   double zSemiAxis( void ) const;
   double zBottomCut( void ) const;
   double zTopCut( void ) const;
-
-private:
-  DDEllipsoid( void ) = delete;
 };
 
 class DDParallelepiped : public DDSolid
 {
 public:
+
   DDParallelepiped( const DDSolid & s );
+  DDParallelepiped( void ) = delete;
+
   double xHalf( void ) const;
   double yHalf( void ) const;
   double zHalf( void ) const;
   double alpha( void ) const;
   double theta( void ) const;
   double phi( void ) const;
-
-private:
-  DDParallelepiped( void ) = delete;
 };
 
 // Solid generation functions

--- a/DetectorDescription/Core/interface/DDTransform.h
+++ b/DetectorDescription/Core/interface/DDTransform.h
@@ -66,7 +66,6 @@ DDRotationMatrix * DDcreateRotationMatrix(double thetaX, double phiX,
 */
 class DDRotation : public DDBase<DDName,DDRotationMatrix*>
 {
-  friend std::ostream & operator<<(std::ostream &, const DDRotation &);
   friend DDRotation DDrot(const DDName &, DDRotationMatrix *);
   friend std::unique_ptr<DDRotation> DDrotPtr(const DDName &, DDRotationMatrix *);
   friend DDRotation DDrotReflect(const DDName&,double,double,double,double,double,double);

--- a/DetectorDescription/Core/interface/Singleton.h
+++ b/DetectorDescription/Core/interface/Singleton.h
@@ -1,5 +1,5 @@
-#ifndef DDI_Singleton_h
-#define DDI_Singleton_h
+#ifndef DETECTOR_DESCRIPTION_CORE_DDI_SINGLETON_H
+#define DETECTOR_DESCRIPTION_CORE_DDI_SINGLETON_H
 
 namespace DDI {
  template <class I> 
@@ -10,10 +10,10 @@ namespace DDI {
    virtual ~Singleton() {}
    static value_type & instance();
    
- private:
    Singleton(void) = delete;
    Singleton(const Singleton&) = delete;
    Singleton& operator=(const Singleton &) = delete;
  };
 }
+
 #endif

--- a/DetectorDescription/Core/plugins/DDAngular.cc
+++ b/DetectorDescription/Core/plugins/DDAngular.cc
@@ -1,6 +1,6 @@
 #include "DDAngular.h"
 
-#include <math.h>
+#include <cmath>
 
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include "CLHEP/Units/SystemOfUnits.h"

--- a/DetectorDescription/Core/plugins/DDLinear.cc
+++ b/DetectorDescription/Core/plugins/DDLinear.cc
@@ -1,6 +1,6 @@
 #include "DDLinear.h"
 
-#include <math.h>
+#include <cmath>
 
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include "CLHEP/Units/SystemOfUnits.h"

--- a/DetectorDescription/Core/src/Boolean.cc
+++ b/DetectorDescription/Core/src/Boolean.cc
@@ -1,5 +1,5 @@
-#include "DetectorDescription/Core/src/Boolean.h"
-#include "DetectorDescription/Core/src/Solid.h"
+# include "DetectorDescription/Core/src/Boolean.h"
+# include "DetectorDescription/Core/src/Solid.h"
 
 DDI::BooleanSolid::BooleanSolid( const DDSolid & A,
 				 const DDSolid & B, 

--- a/DetectorDescription/Core/src/Box.cc
+++ b/DetectorDescription/Core/src/Box.cc
@@ -5,7 +5,7 @@
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include "CLHEP/Units/SystemOfUnits.h"
 
-void DDI::Box::stream(std::ostream & os) const
+void DDI::Box::stream( std::ostream & os ) const
 {
   os << " xhalf[cm]=" << p_[0]/cm
      << " yhalf[cm]=" << p_[1]/cm

--- a/DetectorDescription/Core/src/DDCheck.cc
+++ b/DetectorDescription/Core/src/DDCheck.cc
@@ -56,10 +56,10 @@ bool DDCheckPD(const DDLogicalPart & lp, DDCompactView::graph_type::edge_range n
 	 edm::LogInfo ("DDCheck") << "  the LogicalPart is meant to be a daughter volume, but its position is missing!" << std::endl;
        } 
        else { // check for the rotation matrix being present
-         const DDRotation & r = g.edgeData(nb.first->second)->rot_;
+         const DDRotation & r = g.edgeData(nb.first->second)->ddrot();
 	 if (! r.isDefined().second ) {
 	 //if (! nb.first->second->rot_.rotation() ) {
-	   const DDRotation & r = g.edgeData(nb.first->second)->rot_;
+	   const DDRotation & r = g.edgeData(nb.first->second)->ddrot();
 	   os << "Rotationmatrix is not defined: " << r << std::endl;
 	 }
        }

--- a/DetectorDescription/Core/src/DDExpandedNode.cc
+++ b/DetectorDescription/Core/src/DDExpandedNode.cc
@@ -20,13 +20,13 @@ DDExpandedNode::~DDExpandedNode()
 
 bool DDExpandedNode::operator==(const DDExpandedNode & n) const {
   return ( (logp_==n.logp_) && 
-	   (posd_->copyno_ == n.posd_->copyno_) );  
+	   (posd_->copyno() == n.posd_->copyno()) );  
 }	 		  		 
      
 int DDExpandedNode::copyno() const 
 {
   assert( posd_ );
-  return posd_->copyno_; 
+  return posd_->copyno(); 
 }
 
 std::ostream & operator<<(std::ostream & os, const DDExpandedNode & n)

--- a/DetectorDescription/Core/src/DDExpandedView.cc
+++ b/DetectorDescription/Core/src/DDExpandedView.cc
@@ -104,7 +104,7 @@ bool DDExpandedView::nextSibling()
 	const DDExpandedNode & expnBefore(history_[hsize-2]);
 	
 	// T = T1 + INV[R1] * T2
-	expn.trans_  = expnBefore.trans_ + (expnBefore.rot_ * expn.posd_->trans_);
+	expn.trans_  = expnBefore.trans_ + (expnBefore.rot_ * expn.posd_->trans());
      
 	// R = R1*INV[R2]	
 	// VI in principle we can do this
@@ -113,7 +113,7 @@ bool DDExpandedView::nextSibling()
 	}
       }
       else {
-	expn.trans_ = expn.posd_->trans_;
+	expn.trans_ = expn.posd_->trans();
 	expn.rot_ = expn.posd_->rot();//.inverse();
       }   
       ++expn.siblingno_;
@@ -147,7 +147,7 @@ bool DDExpandedView::firstChild()
       DDPosData * newPosd = curr.second;
     
           // T = ... (see nextSiblinig())
-      DDTranslation newTrans = expnBefore.trans_ + expnBefore.rot_ * newPosd->trans_;
+      DDTranslation newTrans = expnBefore.trans_ + expnBefore.rot_ * newPosd->trans();
     
       // R = ... (see nextSibling())
       DDRotationMatrix newRot =  expnBefore.rot_ *  newPosd->rot();//.inverse();

--- a/DetectorDescription/Core/src/DDValue.cc
+++ b/DetectorDescription/Core/src/DDValue.cc
@@ -1,5 +1,9 @@
 #include "DetectorDescription/Core/interface/DDValue.h"
 
+#include "DetectorDescription/Core/interface/DDPosData.h"
+#include "DetectorDescription/Core/interface/DDFilteredView.h"
+#include "DetectorDescription/Core/interface/DDComparator.h"
+
 #include <cassert>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -10,7 +14,7 @@ static std::atomic<unsigned int> lastIndex{0};
 void
 DDValue::init( const std::string &name )
 {
-  auto result = indexer().insert( { name, 0 });
+  auto result = indexer().insert( { name, 0 } );
   
   auto& indexToUse = result.first->second;
   

--- a/DetectorDescription/Core/test/DDIsValid.cppunit.cc
+++ b/DetectorDescription/Core/test/DDIsValid.cppunit.cc
@@ -66,7 +66,7 @@ namespace {
       ed(LPNAMES::instance().end());
     for (; it != ed; ++it) {
       bool doit = false;
-      doit = !regexec(&aRegex, it->first.c_str(), 0,0,0);
+      doit = !regexec(&aRegex, it->first.c_str(), 0,nullptr,0);
       //if (doit)  edm::LogInfo("DDLogicalPart") << "rgx: " << aName << ' ' << it->first << ' ' << doit << std::endl;
       if ( doit  ) {
 	std::vector<DDName>::size_type sz = it->second.size(); // no of 'compatible' namespaces
@@ -82,7 +82,7 @@ namespace {
 	  std::vector<DDName>::const_iterator nsit(it->second.begin()), nsed(it->second.end());
 	  for (; nsit !=nsed; ++nsit) {
 	    //edm::LogInfo("DDLogicalPart") << "comparing " << aNs << " with " << *nsit << std::endl;
-	    bool another_doit = !regexec(&aNsRegex, nsit->ns().c_str(), 0,0,0);
+	    bool another_doit = !regexec(&aNsRegex, nsit->ns().c_str(), 0,nullptr,0);
 	    if ( another_doit ) {
 	      //temp.emplace_back(std::make_pair(it->first,*nsit));
 	      result.emplace_back(DDLogicalPart(*nsit));

--- a/DetectorDescription/Core/test/Singleton_.cpp
+++ b/DetectorDescription/Core/test/Singleton_.cpp
@@ -43,8 +43,8 @@ testSingleton::testEquality( void )
   m_s = &DDI::Singleton<Dummy>::instance();
   m_copy = &DDI::Singleton<Dummy>::instance();
 
-  CPPUNIT_ASSERT( m_s != 0 );
-  CPPUNIT_ASSERT( m_copy != 0 );
+  CPPUNIT_ASSERT( m_s != nullptr );
+  CPPUNIT_ASSERT( m_copy != nullptr );
   CPPUNIT_ASSERT( m_s == m_copy );
   CPPUNIT_ASSERT( m_s->value == m_copy->value );
   m_s->value = 50.0;

--- a/DetectorDescription/Core/test/testShapes.cpp
+++ b/DetectorDescription/Core/test/testShapes.cpp
@@ -1,4 +1,4 @@
-#include <stdlib.h>
+#include <cstdlib>
 #include <iostream>
 #include <string>
 #include <vector>

--- a/DetectorDescription/Core/test/test_DDRotation.cpp
+++ b/DetectorDescription/Core/test/test_DDRotation.cpp
@@ -1,4 +1,4 @@
-#include <assert.h>
+#include <cassert>
 #include <string>
 
 #include "DetectorDescription/Core/interface/DDTransform.h"

--- a/DetectorDescription/OfflineDBLoader/interface/DDCoreToDDXMLOutput.h
+++ b/DetectorDescription/OfflineDBLoader/interface/DDCoreToDDXMLOutput.h
@@ -38,7 +38,7 @@ struct DDCoreToDDXMLOutput {
   
   void material ( const DDMaterial& material, std::ostream& xos );
 
-  void rotation ( DDRotation& rotation, std::ostream& xos, const std::string& rotn=""  );
+  void rotation ( const DDRotation& rotation, std::ostream& xos, const std::string& rotn=""  );
 
   void logicalPart ( const DDLogicalPart& lp, std::ostream& xos );
 

--- a/DetectorDescription/OfflineDBLoader/plugins/OutputDDToDDL.cc
+++ b/DetectorDescription/OfflineDBLoader/plugins/OutputDDToDDL.cc
@@ -162,7 +162,7 @@ OutputDDToDDL::beginRun( const edm::Run&, edm::EventSetup const& es )
 	lpStore.insert( ddcurLP );
 	addToMatStore( ddcurLP.material(), matStore );
 	addToSolStore( ddcurLP.solid(), solStore, rotStore );
-	rotStore.insert( gra.edgeData( cit->second )->rot_ );
+	rotStore.insert( gra.edgeData( cit->second )->ddrot() );
 	out.position( ddLP, ddcurLP, gra.edgeData( cit->second ), m_rotNumSeed, *m_xos );
       } // iterate over children
     } // if (children)

--- a/DetectorDescription/OfflineDBLoader/plugins/OutputMagneticFieldDDToDDL.cc
+++ b/DetectorDescription/OfflineDBLoader/plugins/OutputMagneticFieldDDToDDL.cc
@@ -177,7 +177,7 @@ OutputMagneticFieldDDToDDL::beginRun( const edm::Run&, edm::EventSetup const& es
 	lpStore.insert( ddcurLP );
 	addToMatStore( ddcurLP.material(), matStore );
 	addToSolStore( ddcurLP.solid(), solStore, rotStore );
-	rotStore.insert( gra.edgeData( cit->second )->rot_ );
+	rotStore.insert( gra.edgeData( cit->second )->ddrot() );
 	out.position( ddLP, ddcurLP, gra.edgeData( cit->second ), m_rotNumSeed, *m_xos );
       } // iterate over children
     } // if (children)

--- a/DetectorDescription/OfflineDBLoader/src/DDCoreToDDXMLOutput.cc
+++ b/DetectorDescription/OfflineDBLoader/src/DDCoreToDDXMLOutput.cc
@@ -366,11 +366,11 @@ void DDCoreToDDXMLOutput::material( const DDMaterial& material, std::ostream& xo
    }
 }
 
-void DDCoreToDDXMLOutput::rotation( DDRotation& rotation, std::ostream& xos, const std::string& rotn ) 
+void DDCoreToDDXMLOutput::rotation( const DDRotation& rotation, std::ostream& xos, const std::string& rotn ) 
 {
    double tol = 1.0e-3; // Geant4 compatible
    DD3Vector x,y,z; 
-   rotation.matrix()->GetComponents(x,y,z); 
+   rotation.rotation()->GetComponents(x,y,z); 
    double check = (x.Cross(y)).Dot(z); // in case of a LEFT-handed orthogonal system 
                                        // this must be -1
    bool reflection((1.-check)>tol);
@@ -381,7 +381,7 @@ void DDCoreToDDXMLOutput::rotation( DDRotation& rotation, std::ostream& xos, con
       {
          rotName = rotn;
          std::cout << "about to try to make a new DDRotation... should fail!" << std::endl;
-         DDRotation rot( DDName(rotn), rotation.matrix() );
+         DDRotation rot( DDName(rotn), const_cast<DDRotationMatrix*>(rotation.rotation()));
          std:: cout << "new rotation: " << rot << std::endl;
       } 
       else 
@@ -416,32 +416,32 @@ void DDCoreToDDXMLOutput::logicalPart( const DDLogicalPart& lp, std::ostream& xo
 }
 
 void DDCoreToDDXMLOutput::position( const DDLogicalPart& parent,
-                                   const DDLogicalPart& child,
-                                   DDPosData* edgeToChild, 
-                                   int& rotNameSeed,
-                                   std::ostream& xos ) 
+				    const DDLogicalPart& child,
+				    DDPosData* edgeToChild, 
+				    int& rotNameSeed,
+				    std::ostream& xos ) 
 {
-   std::string rotName = edgeToChild->rot_.toString();
-   DDRotationMatrix myIDENT;
+  std::string rotName = edgeToChild->ddrot().toString();
+  DDRotationMatrix myIDENT;
    
-   xos << "<PosPart copyNumber=\"" << edgeToChild->copyno_ << "\">" << std::endl;
-   xos << "<rParent name=\"" << parent.toString() << "\"/>" << std::endl;
-   xos << "<rChild name=\"" << child.toString() << "\"/>" << std::endl;
-   if( *(edgeToChild->rot_.matrix()) != myIDENT ) 
-   {
-      if( rotName == ":" ) 
-      {
-         rotation(edgeToChild->rot_, xos);
-      }
-      else
-      {
-         xos << "<rRotation name=\"" << rotName << "\"/>" << std::endl;
-      }
-   } // else let default Rotation matrix be created?
-   xos << "<Translation x=\"" << edgeToChild->translation().x() <<"*mm\""
-   << " y=\"" << edgeToChild->translation().y() <<"*mm\""
-   << " z=\"" << edgeToChild->translation().z() <<"*mm\"/>" << std::endl;
-   xos << "</PosPart>" << std::endl;
+  xos << "<PosPart copyNumber=\"" << edgeToChild->copyno() << "\">" << std::endl;
+  xos << "<rParent name=\"" << parent.toString() << "\"/>" << std::endl;
+  xos << "<rChild name=\"" << child.toString() << "\"/>" << std::endl;
+  if( *(edgeToChild->ddrot().rotation()) != myIDENT ) 
+  {
+    if( rotName == ":" ) 
+    {
+      rotation(edgeToChild->ddrot(), xos);
+    }
+    else
+    {
+      xos << "<rRotation name=\"" << rotName << "\"/>" << std::endl;
+    }
+  } // else let default Rotation matrix be created?
+  xos << "<Translation x=\"" << edgeToChild->translation().x() <<"*mm\""
+      << " y=\"" << edgeToChild->translation().y() <<"*mm\""
+      << " z=\"" << edgeToChild->translation().z() <<"*mm\"/>" << std::endl;
+  xos << "</PosPart>" << std::endl;
 }
 
 void 

--- a/DetectorDescription/Parser/src/DDLSAX2ConfigHandler.cc
+++ b/DetectorDescription/Parser/src/DDLSAX2ConfigHandler.cc
@@ -62,7 +62,7 @@ DDLSAX2ConfigHandler::startElement( const XMLCh* const uri,
   else if( XMLString::equals( qname, uStr("Schema").ptr()))
   {
     schemaLocation_ = toString(attrs.getValue(uStr("schemaLocation").ptr()));
-    doValidation_ = (XMLString::equals(attrs.getValue(uStr("validation").ptr()), uStr("true").ptr()) ? true : false);
+    doValidation_ = XMLString::equals(attrs.getValue(uStr("validation").ptr()), uStr("true").ptr());
   }
 }
 

--- a/DetectorDescription/Parser/test/dumpDDCompactView.cpp
+++ b/DetectorDescription/Parser/test/dumpDDCompactView.cpp
@@ -123,7 +123,7 @@ int main(int argc, char *argv[])
 	DDCompactView::graph_type::edge_list::const_iterator cend = git->end();
 	for (; cit != cend; ++cit) {
 	  const DDLogicalPart & ddcurLP = gt.nodeData(cit->first);
-	  std::cout << ++i << " c--> " << gt.edgeData(cit->second)->copyno_ << " " << ddcurLP.name() << std::endl;
+	  std::cout << ++i << " c--> " << gt.edgeData(cit->second)->copyno() << " " << ddcurLP.name() << std::endl;
 	}
       }
     }

--- a/DetectorDescription/Parser/test/testDoc.cpp
+++ b/DetectorDescription/Parser/test/testDoc.cpp
@@ -1,4 +1,4 @@
-#include <stdlib.h>
+#include <cstdlib>
 #include <exception>
 #include <iostream>
 #include <string>

--- a/DetectorDescription/Parser/test/testNew.cpp
+++ b/DetectorDescription/Parser/test/testNew.cpp
@@ -5,7 +5,7 @@
     email                : case@ucdhep.ucdavis.edu
  ***************************************************************************/
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <iostream>
 
 #include "DetectorDescription/Core/interface/DDCompactView.h"

--- a/DetectorDescription/RegressionTest/bin/DDErrorReport.cpp
+++ b/DetectorDescription/RegressionTest/bin/DDErrorReport.cpp
@@ -1,4 +1,4 @@
-#include <stdlib.h>
+#include <cstdlib>
 #include <iostream>
 #include <string>
 

--- a/DetectorDescription/RegressionTest/bin/DOMCount.cpp
+++ b/DetectorDescription/RegressionTest/bin/DOMCount.cpp
@@ -15,13 +15,6 @@
  * limitations under the License.
  */
 
-/*
- * $Id$
- */
-
-// ---------------------------------------------------------------------------
-//  Includes
-// ---------------------------------------------------------------------------
 #include <xercesc/util/PlatformUtils.hpp>
 #include <xercesc/parsers/AbstractDOMParser.hpp>
 #include <xercesc/dom/DOMImplementation.hpp>
@@ -36,15 +29,14 @@
 #include <xercesc/dom/DOMNamedNodeMap.hpp>
 #include <xercesc/dom/DOMAttr.hpp>
 #include "DOMCount.hpp"
-#include <string.h>
-#include <stdlib.h>
+#include <cstring>
+#include <cstdlib>
 
 #if defined(XERCES_NEW_IOSTREAMS)
 #include <fstream>
 #else
 #include <fstream.h>
 #endif
-
 
 // ---------------------------------------------------------------------------
 //  This is a simple program which invokes the DOMParser to build a DOM
@@ -70,8 +62,6 @@ static void usage()
             "  * = Default if not provided explicitly.\n"
          << XERCES_STD_QUALIFIER endl;
 }
-
-
 
 // ---------------------------------------------------------------------------
 //
@@ -116,7 +106,7 @@ static int countChildElements(DOMNode *n, bool printOutEncounteredEles)
             }
 			++count;
 		}
-        for (child = n->getFirstChild(); child != 0; child=child->getNextSibling())
+        for (child = n->getFirstChild(); child != nullptr; child=child->getNextSibling())
             count += countChildElements(child, printOutEncounteredEles);
     }
     return count;
@@ -137,7 +127,7 @@ int main(int argC, char* argV[])
         return 1;
     }
 
-    const char*                xmlFile = 0;
+    const char*                xmlFile = nullptr;
     AbstractDOMParser::ValSchemes valScheme = AbstractDOMParser::Val_Auto;
     bool                       doNamespaces       = false;
     bool                       doSchema           = false;
@@ -263,7 +253,7 @@ int main(int argC, char* argV[])
     // Instantiate the DOM parser.
     static const XMLCh gLS[] = { chLatin_L, chLatin_S, chNull };
     DOMImplementation *impl = DOMImplementationRegistry::getDOMImplementation(gLS);
-    DOMLSParser       *parser = ((DOMImplementationLS*)impl)->createLSParser(DOMImplementationLS::MODE_SYNCHRONOUS, 0);
+    DOMLSParser       *parser = ((DOMImplementationLS*)impl)->createLSParser(DOMImplementationLS::MODE_SYNCHRONOUS, nullptr);
     DOMConfiguration  *config = parser->getDomConfig();
 
     config->setParameter(XMLUni::fgDOMNamespaces, doNamespaces);
@@ -336,7 +326,7 @@ int main(int argC, char* argV[])
         //reset error count first
         errorHandler.resetErrors();
 
-        XERCES_CPP_NAMESPACE_QUALIFIER DOMDocument *doc = 0;
+        XERCES_CPP_NAMESPACE_QUALIFIER DOMDocument *doc = nullptr;
 
         try
         {

--- a/DetectorDescription/RegressionTest/bin/DOMCount.hpp
+++ b/DetectorDescription/RegressionTest/bin/DOMCount.hpp
@@ -15,13 +15,6 @@
  * limitations under the License.
  */
 
-/*
- * $Id$
- */
-
-// ---------------------------------------------------------------------------
-//  Includes
-// ---------------------------------------------------------------------------
 #include <xercesc/dom/DOMErrorHandler.hpp>
 #include <xercesc/util/XMLString.hpp>
 #if defined(XERCES_NEW_IOSTREAMS)
@@ -32,24 +25,13 @@
 
 XERCES_CPP_NAMESPACE_USE
 
-// ---------------------------------------------------------------------------
-//  Simple error handler deriviative to install on parser
-// ---------------------------------------------------------------------------
 class DOMCountErrorHandler : public DOMErrorHandler
 {
 public:
-    // -----------------------------------------------------------------------
-    //  Constructors and Destructor
-    // -----------------------------------------------------------------------
     DOMCountErrorHandler();
     ~DOMCountErrorHandler() override;
 
-
-    // -----------------------------------------------------------------------
-    //  Getter methods
-    // -----------------------------------------------------------------------
     bool getSawErrors() const;
-
 
     // -----------------------------------------------------------------------
     //  Implementation of the DOM ErrorHandler interface
@@ -57,14 +39,10 @@ public:
     bool handleError(const DOMError& domError) override;
     void resetErrors();
 
-
-private :
-    // -----------------------------------------------------------------------
-    //  Unimplemented constructors and operators
-    // -----------------------------------------------------------------------
     DOMCountErrorHandler(const DOMCountErrorHandler&) = delete;
     void operator=(const DOMCountErrorHandler&) = delete;
 
+private :
 
     // -----------------------------------------------------------------------
     //  Private data members

--- a/DetectorDescription/RegressionTest/interface/DDHtmlFormatter.h
+++ b/DetectorDescription/RegressionTest/interface/DDHtmlFormatter.h
@@ -1,5 +1,5 @@
-#ifndef DDHtmlFormatter_h
-#define DDHtmlFormatter_h
+#ifndef DETECTOR_DESCRIPTION_REGRESSION_TEST_DD_HTML_FORMATTER_H
+#define DETECTOR_DESCRIPTION_REGRESSION_TEST_DD_HTML_FORMATTER_H
 
 #include <iostream>
 #include <string>
@@ -53,22 +53,14 @@ public:
   // std::string operator<<(std::string o) { o << os_; }
   mutable std::stringstream os_;
 
-private:
-
   DDHtmlFormatter& operator= ( const DDHtmlFormatter& ) = delete;
 };
-
-
-
-
-
 
 /** 
     Generates HTML for DD-namespaces 
 */
 class DDNsGenerator 
-{
- 
+{ 
 public:
   DDNsGenerator(std::ostream & os, 
 		const std::string & title, 
@@ -105,9 +97,6 @@ private:
   std::string t_, n1_, n2_, n3_, u1_, u2_, u3_;
   std::ostream & os_;
 };  		     		     
-	
-// =============================================================================================================
-// +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 class DDHtmlDetails
 {
@@ -170,10 +159,6 @@ public:
   
 };
 
-
-// +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-// =============================================================================================================
-	
 void dd_to_html(DDHtmlDetails & det);
 			 	         
 void dd_html_frameset(std::ostream & os);
@@ -183,7 +168,5 @@ void dd_html_menu_frameset(std::ostream & os);
 void dd_html_menu(std::ostream & os);
 
 void dd_html_ro();
-
-
 
 #endif

--- a/DetectorDescription/RegressionTest/src/DDCompareTools.cc
+++ b/DetectorDescription/RegressionTest/src/DDCompareTools.cc
@@ -150,8 +150,8 @@ bool DDCompareCPV::operator()(const DDCompactView& lhs, const DDCompactView& rhs
       while ( cit1 != cend1 && cit2 != cend2 ) {
 	const DDLogicalPart & ddcurLP1 = g1.nodeData(cit1->first);
 	const DDLogicalPart & ddcurLP2 = g2.nodeData(cit2->first);
-	std::cout << ++i << " c1--> " << g1.edgeData(cit1->second)->copyno_ << " " << ddcurLP1.name().fullname() << std::endl;
-	std::cout << ++i << " c2--> " << g2.edgeData(cit2->second)->copyno_ << " " << ddcurLP2.name().fullname() << std::endl;
+	std::cout << ++i << " c1--> " << g1.edgeData(cit1->second)->copyno() << " " << ddcurLP1.name().fullname() << std::endl;
+	std::cout << ++i << " c2--> " << g2.edgeData(cit2->second)->copyno() << " " << ddcurLP2.name().fullname() << std::endl;
 	const DDPosData* p1(g1.edgeData(cit1->second));
 	const DDPosData* p2(g2.edgeData(cit2->second));
 	//	  if ( g1.edgeData(cit1->second)->copyno_ != g2.edgeData(cit2->second)->copyno_
@@ -162,14 +162,14 @@ bool DDCompareCPV::operator()(const DDCompactView& lhs, const DDCompactView& rhs
 // 		    << ddcurLP2.name().fullname() << ":" << p2->copyno_ << std::endl;
 // 	  ret = false;
 // 	  break;
-	if ( p1->copyno_ != p2->copyno_ || 
+	if ( p1->copyno() != p2->copyno() || 
 	     ! DDCompareLP(ddco_)(ddcurLP1,ddcurLP2) ) {
 	  std::cout << "Failed to match node (fullname:copy_no): 1: " 
-		    << ddcurLP1.name().fullname() << ":" << p1->copyno_ << " 2: " 
-		    << ddcurLP2.name().fullname() << ":" << p2->copyno_ << std::endl;
+		    << ddcurLP1.name().fullname() << ":" << p1->copyno() << " 2: " 
+		    << ddcurLP2.name().fullname() << ":" << p2->copyno() << std::endl;
 	  ret = false;
 	  break;
-	} else if ( ! DDCompareDDTrans()(p1->trans_, p2->trans_) ) {
+	} else if ( ! DDCompareDDTrans()(p1->trans(), p2->trans()) ) {
 	  std::cout << "Failed to match translation " << std::endl;
 // 	  std::cout << "1: " << std::setw(12) << std::fixed << std::setprecision(4) << p1->trans_.x();
 // 	  std::cout << "," << std::setw(12) << std::fixed << std::setprecision(4) << p1->trans_.y();
@@ -179,7 +179,7 @@ bool DDCompareCPV::operator()(const DDCompactView& lhs, const DDCompactView& rhs
 // 	  std::cout << "," << std::setw(12) << std::fixed << std::setprecision(4) << p2->trans_.z() << std::endl;
 	  ret = false;
 	  break;
-	} else if ( ! DDCompareDDRot(ddco_)(p1->rot_, p2->rot_) ) {
+	} else if ( ! DDCompareDDRot(ddco_)(p1->ddrot(), p2->ddrot()) ) {
 	  std::cout << "Failed to match rotation " << std::endl;
 	  ret = false;
 	  break;

--- a/DetectorDescription/RegressionTest/src/DDExpandedViewDump.cc
+++ b/DetectorDescription/RegressionTest/src/DDExpandedViewDump.cc
@@ -36,7 +36,7 @@ void DDExpandedViewDump(ostream & os, DDExpandedView & ex, size_t skip, size_t s
       s << ex.logicalPart().name() << ' '
 	<< ex.copyno() << ' ' 
 	<< ex.geoHistory() << " r="
-	<< ex.geoHistory().back().posdata()->rot_.name() << "\n"; 
+	<< ex.geoHistory().back().posdata()->ddrot().name() << "\n"; 
       DDRotationMatrix rm = ex.rotation();
       {
 	double v[9]; rm.GetComponents(v,v+9);

--- a/DetectorDescription/RegressionTest/test/DDCompareCPV.cpp
+++ b/DetectorDescription/RegressionTest/test/DDCompareCPV.cpp
@@ -1,4 +1,4 @@
-#include <stdlib.h>
+#include <cstdlib>
 #include <iostream>
 #include <string>
 #include <vector>

--- a/DetectorDescription/RegressionTest/test/const_dump.cpp
+++ b/DetectorDescription/RegressionTest/test/const_dump.cpp
@@ -1,4 +1,4 @@
-#include <stdlib.h>
+#include <cstdlib>
 #include <exception>
 #include <iostream>
 #include <string>

--- a/DetectorDescription/RegressionTest/test/simple_dom_parser.cpp
+++ b/DetectorDescription/RegressionTest/test/simple_dom_parser.cpp
@@ -1,5 +1,5 @@
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 #include <xercesc/sax2/SAX2XMLReader.hpp>
 #include <xercesc/sax2/XMLReaderFactory.hpp>
 #include <fstream>
@@ -78,7 +78,7 @@ int main(int argC, char* argV[])
         return 1;
     }
 
-    const char*                  xmlFile      = 0;
+    const char*                  xmlFile      = nullptr;
     SAX2XMLReader::ValSchemes    valScheme    = SAX2XMLReader::Val_Auto;
     bool                         doNamespaces = true;
     bool                         doSchema = true;

--- a/DetectorDescription/RegressionTest/test/simple_dom_parser2.cpp
+++ b/DetectorDescription/RegressionTest/test/simple_dom_parser2.cpp
@@ -1,5 +1,5 @@
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 #include <xercesc/sax2/SAX2XMLReader.hpp>
 #include <xercesc/sax2/XMLReaderFactory.hpp>
 #include <fstream>
@@ -78,7 +78,7 @@ int main(int argC, char* argV[])
         return 1;
     }
 
-    const char*                  xmlFile      = 0;
+    const char*                  xmlFile      = nullptr;
     SAX2XMLReader::ValSchemes    valScheme    = SAX2XMLReader::Val_Auto;
     bool                         doNamespaces = true;
     bool                         doSchema = true;

--- a/DetectorDescription/RegressionTest/test/tutorial.cc
+++ b/DetectorDescription/RegressionTest/test/tutorial.cc
@@ -75,7 +75,7 @@ DDTranslation calc(const DDGeoHistory & aHist)
     vt.emplace_back(h[1].posdata()->translation());
     unsigned int i = 1;
     for (; i <= sz-2; ++i) {
-      vr.emplace_back( vr.back() * *(h[i].posdata()->rot_.rotation()) );
+      vr.emplace_back( vr.back() * *(h[i].posdata()->ddrot().rotation()) );
       vt.emplace_back(h[i+1].posdata()->translation());
     }
   }
@@ -109,16 +109,16 @@ void goPersistent(const DDCompactView & cv, const std::string& file) {
     graph_t::const_edge_iterator eit = it->begin();
     for (; eit != it->end(); ++eit) {
       unsigned int eindex = eit->first;
-      int copyno = g.edgeData(eit->second)->copyno_;
+      int copyno = g.edgeData(eit->second)->copyno();
       double x,y,z;
       
-      x = g.edgeData(eit->second)->trans_.x()/mm;
-      y = g.edgeData(eit->second)->trans_.y()/mm;
-      z = g.edgeData(eit->second)->trans_.z()/mm;
+      x = g.edgeData(eit->second)->trans().x()/mm;
+      y = g.edgeData(eit->second)->trans().y()/mm;
+      z = g.edgeData(eit->second)->trans().z()/mm;
       f << node << " " << eindex << " " << copyno 
         << " " << x << " " << y << " " << z 
-	<< " " << g.edgeData(eit->second)->rot_.ddname().ns()
-	<< " " << g.edgeData(eit->second)->rot_.ddname().name()
+	<< " " << g.edgeData(eit->second)->ddrot().ddname().ns()
+	<< " " << g.edgeData(eit->second)->ddrot().ddname().name()
         << std::endl;
     }
     ++node;  
@@ -268,11 +268,11 @@ void tutorial()
 	    << cpv.root() << "]" << std::endl << std::endl;
  
   // The same, but creating a reference to it:
-  DDLogicalPart root = cpv.root(); 
-  DDLogicalPart world = root; //(DDName("CMS","cms"));
+  const DDLogicalPart& root = cpv.root(); 
+  const DDLogicalPart& world = root; //(DDName("CMS","cms"));
   std::cout << "The world volume is described by following solid:" << std::endl;
   std::cout << world.solid() << std::endl << std::endl;
-  DDMaterial worldMaterial = root.material();
+  const DDMaterial& worldMaterial = root.material();
   std::cout << "The world volume is filled with following material:" << std::endl;
   std::cout << worldMaterial << std::endl << std::endl;
  

--- a/Fireworks/Geometry/src/TGeoFromDddService.cc
+++ b/Fireworks/Geometry/src/TGeoFromDddService.cc
@@ -205,7 +205,7 @@ TGeoFromDddService::createManager(int level)
 	 for(unsigned int i=0; i<parentStack.size();++i) {
 	    std::cout <<" ";
 	 }
-	 std::cout << info.first.name()<<" "<<info.second->copyno_<<" "
+	 std::cout << info.first.name()<<" "<<info.second->copyno()<<" "
 		   << DDSolidShapesName::name(info.first.solid().shape())<<std::endl;
       }
 
@@ -216,7 +216,7 @@ TGeoFromDddService::createManager(int level)
       if (0!=child && info.second != 0)
       {
 	 parentStack.back()->AddNode(child,
-				 info.second->copyno_,
+				     info.second->copyno(),
 				 createPlacement(info.second->rotation(),
 						 info.second->translation()));
 	 child->SetLineColor(kBlue);

--- a/Fireworks/Geometry/src/TGeoMgrFromDdd.cc
+++ b/Fireworks/Geometry/src/TGeoMgrFromDdd.cc
@@ -140,7 +140,7 @@ TGeoMgrFromDdd::produce(const DisplayGeomRecord& iRecord)
 	 for(unsigned int i=0; i<parentStack.size();++i) {
 	    std::cout <<" ";
 	 }
-	 std::cout << info.first.name()<<" "<<info.second->copyno_<<" "
+	 std::cout << info.first.name()<<" "<<info.second->copyno()<<" "
 		   << DDSolidShapesName::name(info.first.solid().shape())<<std::endl;
       }
 
@@ -151,7 +151,7 @@ TGeoMgrFromDdd::produce(const DisplayGeomRecord& iRecord)
       if (0!=child && info.second != 0)
       {
 	 parentStack.back()->AddNode(child,
-				 info.second->copyno_,
+				     info.second->copyno(),
 				 createPlacement(info.second->rotation(),
 						 info.second->translation()));
 	 child->SetLineColor(kBlue);

--- a/SimG4Core/Geometry/src/DDG4Builder.cc
+++ b/SimG4Core/Geometry/src/DDG4Builder.cc
@@ -147,9 +147,9 @@ DDGeometryReturnType DDG4Builder::BuildGeometry() {
 	  edm::LogInfo("SimG4CoreGeometry") << ">>Reflection encountered: " 
 					    << gra.edgeData(cit->second)->ddrot()  
 					    << ">>Placement d=" << gra.nodeData(cit->first).ddname() 
-					    << " m=" << ddLP.ddname() << " cp=" << gra.edgeData(cit->second)->copyno_
+					    << " m=" << ddLP.ddname() << " cp=" << gra.edgeData(cit->second)->copyno()
 					    << " r=" << gra.edgeData(cit->second)->ddrot().ddname();     
-	G4ThreeVector tempTran(gra.edgeData(cit->second)->trans_.X(), gra.edgeData(cit->second)->trans_.Y(), gra.edgeData(cit->second)->trans_.Z());
+	G4ThreeVector tempTran(gra.edgeData(cit->second)->trans().X(), gra.edgeData(cit->second)->trans().Y(), gra.edgeData(cit->second)->trans().Z());
 	G4Translate3D transl = tempTran;
 	CLHEP::HepRep3x3 temp( x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z() ); //matrix representation
 	CLHEP::HepRotation hr ( temp );
@@ -162,7 +162,7 @@ DDGeometryReturnType DDG4Builder::BuildGeometry() {
 		       convertLV(gra.nodeData(cit->first)), 		// daugther
 		       g4LV, 				 		// mother
 		       false,                 		 		// 'ONLY'
-		       gra.edgeData(cit->second)->copyno_+offset+tag, 	// copy number
+		       gra.edgeData(cit->second)->copyno()+offset+tag, 	// copy number
 		       check_);
       } // iterate over children
     } // if (children)

--- a/SimG4Core/Geometry/src/DDG4Builder.cc
+++ b/SimG4Core/Geometry/src/DDG4Builder.cc
@@ -145,10 +145,10 @@ DDGeometryReturnType DDG4Builder::BuildGeometry() {
 	rm.GetComponents(x, y, z);
 	if ((x.Cross(y)).Dot(z)<0)
 	  edm::LogInfo("SimG4CoreGeometry") << ">>Reflection encountered: " 
-					    << gra.edgeData(cit->second)->rot_  
+					    << gra.edgeData(cit->second)->ddrot()  
 					    << ">>Placement d=" << gra.nodeData(cit->first).ddname() 
 					    << " m=" << ddLP.ddname() << " cp=" << gra.edgeData(cit->second)->copyno_
-					    << " r=" << gra.edgeData(cit->second)->rot_.ddname();     
+					    << " r=" << gra.edgeData(cit->second)->ddrot().ddname();     
 	G4ThreeVector tempTran(gra.edgeData(cit->second)->trans_.X(), gra.edgeData(cit->second)->trans_.Y(), gra.edgeData(cit->second)->trans_.Z());
 	G4Translate3D transl = tempTran;
 	CLHEP::HepRep3x3 temp( x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z() ); //matrix representation


### PR DESCRIPTION
* Deleted members should be public
* Modernize deprecated headers
* Use nullptr [modernize-use-nullptr]
* Access DDRotation members via member functions
* Avoiding the copy if a local copy of the variable is never modified [performance-unnecessary-copy-initialization]
* Making a const reference if the variable is copy-constructed from a const reference but is only used as const reference [performance-unnecessary-copy-initialization]