### PR TITLE
Fixed ambigiuous lookup for symbol 'test'

### DIFF
--- a/FWCore/Utilities/interface/RunningAverage.h
+++ b/FWCore/Utilities/interface/RunningAverage.h
@@ -5,7 +5,7 @@
 #include <array>
 
 // Function for testing RunningAverage
-namespace test {
+namespace test_average {
   namespace running_average {
     int test();
   }
@@ -16,7 +16,7 @@ namespace edm {
 // thread safe, fast: does not garantee precise update in case of collision
   class RunningAverage {
     // For tests
-    friend int ::test::running_average::test();
+    friend int ::test_average::running_average::test();
 
   public:
     static constexpr int N = 16;  // better be a power of 2

--- a/FWCore/Utilities/test/RunningAverage_t.cpp
+++ b/FWCore/Utilities/test/RunningAverage_t.cpp
@@ -15,7 +15,7 @@ namespace {
 #include <algorithm>
 #include <type_traits>
 
-namespace test {
+namespace test_average {
   namespace running_average {
     int test() {
     
@@ -74,5 +74,5 @@ namespace test {
 }
 
 int main() {
-  return ::test::running_average::test();
+  return ::test_average::running_average::test();
 }


### PR DESCRIPTION
We use the namespace 'test' in this header which then breaks every
translation unit that also defines a test function, as defining
a namespace and a function with the same name doesn't work.

This patch gives this namespace a more unique name that we don't
run into this problem in the future.