### PR TITLE
GenJetFlavourInfos: fix compiler warning, use prunedGenParticles in associations to correctly match pat jet flavour info

### DIFF
--- a/PhysicsTools/JetMCAlgos/python/AK4GenJetFlavourInfos_cfi.py
+++ b/PhysicsTools/JetMCAlgos/python/AK4GenJetFlavourInfos_cfi.py
@@ -1,5 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.JetMCAlgos.AK4PFJetsMCFlavourInfos_cfi import ak4JetFlavourInfos
 
-ak4GenJetFlavourInfos = ak4JetFlavourInfos.clone(jets = "ak4GenJetsNoNu")
+ak4GenJetFlavourInfos = ak4JetFlavourInfos.clone(
+											jets = "ak4GenJetsNoNu",
+											bHadrons = cms.InputTag("selectedHadronsAndPartonsForGenJetsFlavourInfos","bHadrons"),
+    										cHadrons = cms.InputTag("selectedHadronsAndPartonsForGenJetsFlavourInfos","cHadrons"),
+  											partons  = cms.InputTag("selectedHadronsAndPartonsForGenJetsFlavourInfos","physicsPartons"),
+    										leptons  = cms.InputTag("selectedHadronsAndPartonsForGenJetsFlavourInfos","leptons"),
+)
 

--- a/PhysicsTools/JetMCAlgos/python/AK4GenJetFlavourInfos_cfi.py
+++ b/PhysicsTools/JetMCAlgos/python/AK4GenJetFlavourInfos_cfi.py
@@ -2,10 +2,10 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.JetMCAlgos.AK4PFJetsMCFlavourInfos_cfi import ak4JetFlavourInfos
 
 ak4GenJetFlavourInfos = ak4JetFlavourInfos.clone(
-											jets = "ak4GenJetsNoNu",
-											bHadrons = cms.InputTag("selectedHadronsAndPartonsForGenJetsFlavourInfos","bHadrons"),
-    										cHadrons = cms.InputTag("selectedHadronsAndPartonsForGenJetsFlavourInfos","cHadrons"),
-  											partons  = cms.InputTag("selectedHadronsAndPartonsForGenJetsFlavourInfos","physicsPartons"),
-    										leptons  = cms.InputTag("selectedHadronsAndPartonsForGenJetsFlavourInfos","leptons"),
+                         jets = "ak4GenJetsNoNu",
+                         bHadrons = cms.InputTag("selectedHadronsAndPartonsForGenJetsFlavourInfos","bHadrons"),
+                         cHadrons = cms.InputTag("selectedHadronsAndPartonsForGenJetsFlavourInfos","cHadrons"),
+                         partons  = cms.InputTag("selectedHadronsAndPartonsForGenJetsFlavourInfos","physicsPartons"),
+                         leptons  = cms.InputTag("selectedHadronsAndPartonsForGenJetsFlavourInfos","leptons"),
 )
 

--- a/PhysicsTools/JetMCAlgos/python/HadronAndPartonSelector_cfi.py
+++ b/PhysicsTools/JetMCAlgos/python/HadronAndPartonSelector_cfi.py
@@ -7,3 +7,6 @@ selectedHadronsAndPartons = cms.EDProducer('HadronAndPartonSelector',
     partonMode = cms.string("Auto"),
     fullChainPhysPartons = cms.bool(True)
 )
+# select hadrons and partons for the slimmedGenJetsFlavourInfos, required for origin identification
+
+selectedHadronsAndPartonsForGenJetsFlavourInfos = selectedHadronsAndPartons.clone(particles = "prunedGenParticles")

--- a/PhysicsTools/PatAlgos/plugins/GenJetFlavourInfoPreserver.cc
+++ b/PhysicsTools/PatAlgos/plugins/GenJetFlavourInfoPreserver.cc
@@ -27,9 +27,9 @@ namespace pat {
   class GenJetFlavourInfoPreserver : public edm::stream::EDProducer<> {
   public:
     explicit GenJetFlavourInfoPreserver(const edm::ParameterSet & iConfig);
-    virtual ~GenJetFlavourInfoPreserver() { }
+    ~GenJetFlavourInfoPreserver() override { }
     
-    virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+    void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
     
   private:
     const edm::EDGetTokenT<edm::View<reco::GenJet> > genJetsToken_;
@@ -78,7 +78,7 @@ pat::GenJetFlavourInfoPreserver::produce(edm::Event & iEvent, const edm::EventSe
         slimmedGenJetRef = (*slimmedGenJetAssociation)[genJets->refAt(i)]; 
         if(!slimmedGenJetRef) continue;
         (*jetFlavourInfos)[reco::JetBaseRef(slimmedGenJetRef)] = (*genJetFlavourInfos)[i].second;
-        
+
     }
 
     iEvent.put(std::move(jetFlavourInfos));

--- a/PhysicsTools/PatAlgos/plugins/GenJetFlavourInfoPreserver.cc
+++ b/PhysicsTools/PatAlgos/plugins/GenJetFlavourInfoPreserver.cc
@@ -72,12 +72,13 @@ pat::GenJetFlavourInfoPreserver::produce(edm::Event & iEvent, const edm::EventSe
 
     edm::Ref<std::vector<reco::GenJet> > slimmedGenJetRef;
 
-    int i = -1;
-    for (auto const& genJet : *genJets){
-         i++;
+
+    for (uint i=0; i<genJets->size();++i){
+
         slimmedGenJetRef = (*slimmedGenJetAssociation)[genJets->refAt(i)]; 
         if(!slimmedGenJetRef) continue;
         (*jetFlavourInfos)[reco::JetBaseRef(slimmedGenJetRef)] = (*genJetFlavourInfos)[i].second;
+        
     }
 
     iEvent.put(std::move(jetFlavourInfos));

--- a/PhysicsTools/PatAlgos/plugins/GenJetFlavourInfoPreserver.cc
+++ b/PhysicsTools/PatAlgos/plugins/GenJetFlavourInfoPreserver.cc
@@ -73,7 +73,7 @@ pat::GenJetFlavourInfoPreserver::produce(edm::Event & iEvent, const edm::EventSe
     edm::Ref<std::vector<reco::GenJet> > slimmedGenJetRef;
 
 
-    for (uint i=0; i<genJets->size();++i){
+    for (unsigned int i=0; i<genJets->size();++i){
 
         slimmedGenJetRef = (*slimmedGenJetAssociation)[genJets->refAt(i)]; 
         if(!slimmedGenJetRef) continue;

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -326,6 +326,7 @@ def miniAOD_customizeMC(process):
     #GenJetFlavourInfos
     process.load("PhysicsTools.JetMCAlgos.HadronAndPartonSelector_cfi")
     task.add(process.selectedHadronsAndPartons)
+    task.add(process.selectedHadronsAndPartonsForGenJetsFlavourInfos)
     
     process.load("PhysicsTools.JetMCAlgos.AK4GenJetFlavourInfos_cfi")
     task.add(process.ak4GenJetFlavourInfos)


### PR DESCRIPTION
please see #19048 
addressed comment by @davidlange6 