### PR TITLE
Tools for the management of the payload boost version

### DIFF
--- a/CondCore/Utilities/python/conddb_serialization_metadata.py
+++ b/CondCore/Utilities/python/conddb_serialization_metadata.py
@@ -1,0 +1,182 @@
+__author__ = 'Giacomo Govi'
+
+import subprocess
+import json
+import os
+import re
+
+
+
+def check_cmssw_version( cmssw_version ):
+    if cmssw_version.find('CMSSW_')==-1:
+        raise Exception("CMSSW version '%s' has not been found in the expected format" %cmssw_version)
+    ver = cmssw_version
+    p = re.compile('(CMSSW_.*_X)(_.*)?$')
+    m = p.match(ver)
+    if not m is None:
+        gs = m.groups()
+        if gs[1] != None:
+            raise Exception("IB version can't be processed.")
+    return ver
+
+def is_release_cycle( cmssw_version ):
+    ind = cmssw_version.find('_X')
+    return not ind == -1
+
+def strip_cmssw_version( cmssw_version ):
+    ver = cmssw_version
+    if not cmssw_version.find('_X') == -1: 
+        ver = ver.replace('X','0')
+    ind = ver.find('_pre')
+    if not ind == -1:
+        ver = ver[0:ind]
+    return ver    
+
+def cmssw_version_to_int( cmssw_version ):
+    ver = cmssw_version.split('CMSSW_')[1]
+    ip = 0
+    f = ver.find('_patch')
+    if not f == -1:
+        ip = int(ver[f+6:])
+        ver = ver[0:f]
+    dgs = ver.split('_')
+    return int('%d%02d%02d%02d' %(int(dgs[0]),int(dgs[1]),int(dgs[2]),ip))
+
+def cmp_cmssw_version( ver1, ver2 ):
+    intVer1 = cmssw_version_to_int(ver1)
+    intVer2 = cmssw_version_to_int(ver2)
+    if intVer1<intVer2:
+        return -1
+    elif intVer1>intVer2:
+        return 1
+    else:
+        return 0
+
+def strip_boost_version( boost_version ):
+    bver = boost_version
+    f = bver.find('_')
+    if not f==-1:
+        bver = boost_version.replace('_','.')
+    f = bver.find('-')
+    if not f==-1:
+        bver = bver[0:f]
+    return bver    
+
+def boost_version_to_int( boost_version ):
+    bver = strip_boost_version( boost_version )
+    dgs = bver.split('.')    
+    tmpl = '%d%02d%02d'
+    pars = [0,0,0]
+    ind = 0
+    for d in dgs:
+        if ind <=2:
+            pars[ind] = int(d)
+        ind += 1
+    return int(tmpl %(pars[0],pars[1],pars[2]))
+
+def cmp_boost_version( ver1, ver2 ):
+    intVer1 = boost_version_to_int(ver1)
+    intVer2 = boost_version_to_int(ver2)
+    if intVer1<intVer2:
+        return -1
+    elif intVer1>intVer2:
+        return 1
+    else:
+        return 0
+
+archs = { 3070000 : ['slc5_amd64_gcc434'], 5010100 : ['slc5_amd64_gcc462'], 6000000 : ['slc6_amd64_gcc472'], 
+          7000000 : ['slc6_amd64_gcc481'], 7020000 : ['slc6_amd64_gcc491'], 7060000 : ['slc6_amd64_gcc493'],
+          8000000 : ['slc6_amd64_gcc493','slc6_amd64_gcc530'], 9030000 : ['slc6_amd64_gcc630']}
+
+cmsPath = '/cvmfs/cms.cern.ch'
+
+def get_production_arch( version ):
+    nv = cmssw_version_to_int( version )
+    rbound = None
+    for r in sorted(archs.keys()):
+        if r <= nv:
+            rbound = r
+        else:
+            break
+    if not rbound is None:
+        return archs[rbound]
+    return None
+
+def get_release_root( cmssw_version, arch ):
+    cmssw_folder = 'cmssw'
+    if cmssw_version.find('_patch') != -1:
+        cmssw_folder= 'cmssw-patch'
+    ret = '%s/%s/cms/%s' %(cmsPath,arch,cmssw_folder)
+    return ret 
+
+def get_cmssw_boost( arch, releaseDir ):
+    cmd =  'source %s/cmsset_default.sh; export SCRAM_ARCH=%s; cd %s/src ; eval `scram runtime -sh`; scram tool info boost; ' %(cmsPath,arch,releaseDir)
+    pipe = subprocess.Popen( cmd, shell=True,stdout=subprocess.PIPE,stderr=subprocess.STDOUT)
+    out = pipe.communicate()[0]
+    cfgLines = out.split('\n')
+    boost_version = None
+    for line in cfgLines:
+        if line.startswith('Version'):
+            boost_version = line.split('Version :')[1].strip()
+            break
+    if not boost_version is None:
+        boost_version = strip_boost_version(boost_version)
+    return boost_version
+
+def lookup_boost_for_run( iov, timeType, boost_run_map ):
+    if timeType == 'Lumi':
+        iov = iov >> 32
+        timeType = 'Run'
+    if iov == 0:
+        iov=1
+    entry = None
+    try:
+        if timeType == 'Time':
+            entry = max([x for x in boost_run_map if x[1]<=iov])
+        elif timeType == 'Run':
+            entry = max([x for x in boost_run_map if x[0]<=iov])
+        else:
+            raise Exception('TimeType %s cannot be processed' %timeType)
+    except Exception as e:
+        raise e
+    return entry[2]
+
+def get_boost_version_from_streamer_info( streamer_info ):
+    streamer_info = streamer_info.replace('\x00','')
+    iovBoostVersion = None
+    if streamer_info == '0':
+        iovBoostVersion = '1.51.0'
+    elif streamer_info[0:2]==' {':
+        try:
+            iovBoostVersion = str(json.loads(streamer_info)['tech_version'])
+            iovBoostVersion = strip_boost_version(iovBoostVersion)
+        except ValueError as e:
+            raise Exception("Could not parse streamer info [%s]: %s" %(streamer_info,str(e)))
+    else:
+        raise Exception("Streamer info found in unexpected format.")
+    return iovBoostVersion
+
+def do_update_tag_boost_version( tagBoostVersion, iovBoostVersion, iov, timetype, boost_run_map ):
+    # for hash timetype we need to take the greatest version of the set                                                                                                                 
+    if timetype == 'Hash':
+        if tagBoostVersion is None or cmp_boost_version(tagBoostVersion,iovBoostVersion)<0:
+            tagBoostVersion = iovBoostVersion
+    # for run, lumi and time we lookup in the boost_run_map to find the reference
+    else:
+        if tagBoostVersion is None:
+            tagBoostVersion = iovBoostVersion
+        else:
+            referenceBoost = lookup_boost_for_run( iov, timetype, boost_run_map )
+            if cmp_boost_version( referenceBoost, iovBoostVersion )<0:
+                if cmp_boost_version(  tagBoostVersion, iovBoostVersion )<0:
+                    tagBoostVersion = iovBoostVersion
+            else:
+                if cmp_boost_version(  tagBoostVersion, iovBoostVersion )>0:
+                    tagBoostVersion = iovBoostVersion
+    return tagBoostVersion
+
+def update_tag_boost_version( tagBoostVersion, streamer_info, iov, timetype, boost_run_map ):
+    iovBoostVersion = get_boost_version_from_streamer_info( streamer_info )
+    return iovBoostVersion, do_update_tag_boost_version( tagBoostVersion, iovBoostVersion, iov, timetype, boost_run_map )
+
+            

--- a/CondCore/Utilities/python/conddblib.py
+++ b/CondCore/Utilities/python/conddblib.py
@@ -21,7 +21,7 @@ schema_name = 'CMS_CONDITIONS'
 dbuser_name = 'cms_conditions'
 dbreader_user_name = 'cms_cond_general_r'
 dbwriter_user_name = 'cms_cond_general_w'
-devdbwriter_user_name = 'cms_test_conditions'
+devdbwriter_user_name = 'cms_cond_general_w'
 logger = logging.getLogger(__name__)
 
 # frontier services
@@ -263,6 +263,11 @@ class Tag:
                             'insertion_time':(sqlalchemy.TIMESTAMP,_Col.notNull),
                             'modification_time':(sqlalchemy.TIMESTAMP,_Col.notNull) }
 
+class TagMetadata:
+    __tablename__       = 'TAG_METADATA'
+    columns             = { 'tag_name': (DbRef(Tag,'name'),_Col.pk), 
+                            'min_serialization_v': (sqlalchemy.String(20),_Col.notNull),
+                            'modification_time':(sqlalchemy.TIMESTAMP,_Col.notNull) }
 
 class Payload:
     __tablename__       = 'PAYLOAD'
@@ -316,6 +321,11 @@ class RunInfo:
                             'start_time':(sqlalchemy.TIMESTAMP,_Col.notNull),
                             'end_time':(sqlalchemy.TIMESTAMP,_Col.notNull) }
 
+class BoostRunMap:
+    __tablename__       = 'BOOST_RUN_MAP'
+    columns             = { 'run_number':(sqlalchemy.BIGINT,_Col.pk),
+                            'run_start_time':(sqlalchemy.TIMESTAMP,_Col.notNull),
+                            'boost_version': (sqlalchemy.String(20),_Col.notNull) }
 
 # CondDB object
 class Connection(object):
@@ -370,6 +380,9 @@ class Connection(object):
         self.get_dbtype(GlobalTag)
         self.get_dbtype(GlobalTagMap)
         self.get_dbtype(RunInfo)
+        if not self._is_sqlite:
+            self.get_dbtype(TagMetadata)
+            self.get_dbtype(BoostRunMap)
         self._is_valid = self.is_valid()
 
     def get_dbtype(self,theType):
@@ -383,6 +396,7 @@ class Connection(object):
         s = self._session()
         s.get_dbtype = self.get_dbtype
         s._is_sqlite = self._is_sqlite
+        s.is_oracle = self.is_oracle
         s._url = self._url
         return s
 

--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -22,6 +22,7 @@ import sqlalchemy
 
 import CondCore.Utilities.conddblib as conddb
 import CondCore.Utilities.cond2xml as cond2xml
+import CondCore.Utilities.conddb_serialization_metadata as serialization_metadata
 
 from CondCore.Utilities.tier0 import Tier0Handler, Tier0Error, tier0Url
 # -------------------------------------------------------------------------------------------------------
@@ -1202,19 +1203,28 @@ def _update_tag_log(session,the_tag,the_timestamp,the_action,note):
     TagLog = session.get_dbtype(conddb.TagLog)
     session.add(TagLog(tag_name=the_tag, event_time=the_timestamp, action=the_action, user_name=userName, host_name=hostName, command=userCommand, user_text=note ))
 
-def _copy_payload( args, copyTime, session1, session2, payloadHash ):
+def _copy_payload( args, copyTime, session1, session2, payloadHash, payloadSerializationVersionMap=None ):
     Payload1 = session1.get_dbtype(conddb.Payload)
     Payload2 = session2.get_dbtype(conddb.Payload)
+    ret = False
+    streamerInfo = None
     if _exists(session2, Payload2.hash, payloadHash):
         logging.debug('Skipping copy of payload %s to %s since it already exists...', str_db_object(args.db, payloadHash), str_db_object(args.destdb, payloadHash))
-        return False
+        if payloadSerializationVersionMap is not None:
+            q = session1.query(Payload1.streamer_info).filter(Payload1.hash == payloadHash).one()
+            streamerInfo = str(q[0])
     else:
         logging.info('Copying payload %s to %s ...', str_db_object(args.db, payloadHash), str_db_object(args.destdb, payloadHash))
         q = session1.query(Payload1).filter(Payload1.hash == payloadHash).one()
         payload = _rawdict(q)
         payload['insertion_time'] = copyTime
+        streamerInfo = str(payload['streamer_info'])
         session2.add(Payload2(** payload))
-        return True
+        ret = True
+    if payloadSerializationVersionMap is not None:
+        serialization_version = serialization_metadata.get_boost_version_from_streamer_info(streamerInfo)
+        payloadSerializationVersionMap[payloadHash] = serialization_version
+    return ret
 
 def _copy_tag(args, copyTime, session1, session2, first, second, fromIOV=None, toIOV=None, timeMap=None):
     ret = True
@@ -1281,11 +1291,13 @@ def _copy_tag(args, copyTime, session1, session2, first, second, fromIOV=None, t
             if raw_input().lower() not in ['y', 'yes']:
                 raise Exception('Aborted by the user.')
     else:
-        destSynchro = tag['synchronization']
+        destSynchro = 'any'
         if args.convertTime:
             tag['time_type'] = 'Time'
         destTimeType = tag['time_type']
-        session2.add(Tag2(**tag))
+        dest = Tag2(**tag)
+        dest.synchronization = destSynchro
+        session2.add(dest)
         note = args.note 
         if note is None or note=='' or note==' ':
             note = '-'
@@ -1322,6 +1334,9 @@ def _copy_tag(args, copyTime, session1, session2, first, second, fromIOV=None, t
     query = query.filter(_inserted_before(IOV1,args.snapshot))
     iovs = {}
     hashes = set()
+    payloadSerializationVersionMap = None
+    if session2.is_oracle:
+        payloadSerializationVersionMap = {}
     if not args.o2oTest:
         query = query.order_by(IOV1.since, IOV1.insertion_time.desc())
         for iov in query:
@@ -1344,7 +1359,7 @@ def _copy_tag(args, copyTime, session1, session2, first, second, fromIOV=None, t
                 logging.warning('Skipping older iov with since %s...', since)
         sourceIovSize = len(iovs)
         logging.info('Selected %s source iov(s)' %sourceIovSize)
-        if args.synchronize:
+        if not args.nosynchro:
             # synchronize lower boundary when required
             logging.info('Destination tag synchronization is %s' %destSynchro)
             policy_type = _get_synchro_policy( destSynchro )
@@ -1379,7 +1394,7 @@ def _copy_tag(args, copyTime, session1, session2, first, second, fromIOV=None, t
     # Copy the payloads referenced in the selected iovs
     np = 0
     for h in hashes:
-        if _copy_payload( args, copyTime, session1, session2, h ):
+        if _copy_payload( args, copyTime, session1, session2, h, payloadSerializationVersionMap ):
             np += 1
     if not np==0:
         logging.info('%s payload(s) copied.',np)
@@ -1416,13 +1431,46 @@ def _copy_tag(args, copyTime, session1, session2, first, second, fromIOV=None, t
     
     # Copy the set of IOVs collected        
     session2.merge(Tag2(name=second,modification_time=copyTime))
+    if payloadSerializationVersionMap is not None:
+        BoostRunMap = session2.get_dbtype(conddb.BoostRunMap)
+        q = session2.query(BoostRunMap).order_by(BoostRunMap.run_number)
+        boost_run_map = []
+        for r in q:
+            r = _rawdict(r)
+            boost_run_map.append( (r['run_number'],r['run_start_time'],r['boost_version']) )
+        TagMetadata = session2.get_dbtype(conddb.TagMetadata)
+        q = session2.query(TagMetadata.min_serialization_v).filter(TagMetadata.tag_name == second )
+        tagBoostVersion = None
+        for r in q:
+            tagBoostVersion = r[0]
+            break
+        currentTagBoostVersion = tagBoostVersion
+        if len(iovs)>0 and destExists and currentTagBoostVersion is None:
+            raise Exception('No information found about the destination tag boost version. Cannot proceed with the update.')
+        logging.info('Destination tag boost version is %s' %currentTagBoostVersion )
     niovs = 0
     for k,v in iovs.items():
         logging.debug('Copying IOV %s -> %s...', k, v)
         session2.add(IOV2(tag_name=second,since=k,insertion_time=copyTime,payload_hash=v))
         niovs += 1
+        if payloadSerializationVersionMap is not None:
+            if v in payloadSerializationVersionMap.keys():
+                tagBoostVersion = serialization_metadata.do_update_tag_boost_version(tagBoostVersion,payloadSerializationVersionMap[v], k, destTimeType, boost_run_map )
     if not niovs==0:
         logging.info('%s iov(s) copied.',niovs)
+        merge = False
+        if payloadSerializationVersionMap is not None and tagBoostVersion is not None:
+            if currentTagBoostVersion is not None: 
+                if currentTagBoostVersion != tagBoostVersion:
+                    if serialization_metadata.cmp_boost_version( currentTagBoostVersion, tagBoostVersion )<0:
+                        if destSynchro not in ['any','validation']:
+                            raise Exception('Cannot update existing tag %s, since the minimum serialization version %s is not compatible with the combined boost version of the payloads to add (%s)' %(second,currentTagBoostVersion,tagBoostVersion))
+                    merge = True
+            else:
+                merge = True
+        if merge:
+            session2.merge(TagMetadata(tag_name=second,min_serialization_v=tagBoostVersion,modification_time=copyTime))
+            logging.info('Destination Tag boost Version set to %s ( was %s )' %(tagBoostVersion,currentTagBoostVersion) )
     return ret, niovs
 
 def copy(args):
@@ -1452,25 +1500,26 @@ def copy(args):
             if args.note is None or args.note=='' or args.note==' ':
                 raise Exception('Cannot run in force edit mode without to provide a non-empty editing note.')
         if args.o2oTest:
-            if args.to is not None or getattr(args, 'from') is not None or args.snapshot is not None or args.override or args.synchronize or args.convertTime:
-                raise Exception('Cannot execute the copy for the o2o test with the options from, to, override, synchronize, snapshot or convertTime.')
-        if args.synchronize:
-            if args.override:
-                raise Exception('Override copy is not supported with the synchronization.')
-            if args.convertTime:
-                raise Exception('Copy with time conversion is not supported with the synchronization.')
+            if args.to is not None or getattr(args, 'from') is not None or args.snapshot is not None or args.override or args.nosynchro or args.convertTime:
+                raise Exception('Cannot execute the copy for the o2o test with the options from, to, override, nosynchro, snapshot or convertTime.')
+ 
+        try:
+            ret, niovs = _copy_tag(args, copyTime, session1, session2, args.first, args.second, getattr(args, 'from'), args.to)
+            if niovs!=0:
+                _confirm_changes(args)
+                note = args.note
+                if args.force and args.note is None:
+                    note = _get_user_note(args,'Force edit mode requires an editing note to be provided: ')
+                if note is None or note=='' or note==' ':
+                    note = '-'
+                _update_tag_log(session2,args.second,copyTime,'%s iov(s) inserted.' %niovs,note)
+                session2.commit()
+                logging.info('Changes committed.')
+        except Exception as e:
+            session2.rollback()
+            logging.error('Changes rolled back.')
+            raise e
 
-        ret, niovs = _copy_tag(args, copyTime, session1, session2, args.first, args.second, getattr(args, 'from'), args.to)
-
-        if niovs!=0:
-            _confirm_changes(args)
-            note = args.note
-            if args.force and args.note is None:
-                note = _get_user_note(args,'Force edit mode requires an editing note to be provided: ')
-            if note is None or note=='' or note==' ':
-                note = '-'
-            _update_tag_log(session2,args.second,copyTime,'%s iov(s) inserted.' %niovs,note)
-            session2.commit()
         return 1*( not ret )
 
 
@@ -2094,7 +2143,8 @@ def main():
     parser_copy.add_argument('--override','-o', action='store_true', help='Override the existing iovs for the interval covered by the new iovs.') 
     parser_copy.add_argument('--snapshot','-s', help="Timestamp of the snapshot to consider for the source iovs. The format of the string must be one of the following: '2013-01-20', '2013-01-20 10:11:12' or '2013-01-20 10:11:12.123123'.")
     parser_copy.add_argument('--o2oTest', action='store_true', help='Special copy for o2o test. Copy the second to last iov of the source tag, to allow to run the o2o procedure to add the last iov. It cannot be executed with the from, to, ovveride and snapshot options.')
-    parser_copy.add_argument('--synchronize',action='store_true',help='For tags, set the destination iovs according to the destination tag synchronization. No effect for other object type copy') 
+    parser_copy.add_argument('--synchronize',action='store_true',help='No effect, since the synchronization is applied by default for tags. The option is kept for backward compatibility') 
+    parser_copy.add_argument('--nosynchro',action='store_true',help='For tags, disable the synchronization of the destination iovs. No effect for other object type copy') 
     parser_copy.add_argument('--convertTime',action='store_true',help='For tags, triggers the convertion from run-based iovs to timestamp-based iovs. It will return an error for any combination with input tag non run-based, and existing destination tag non timestamp-based. Not supported with synchronization.') 
     parser_copy.set_defaults(func=copy)
 

--- a/CondCore/Utilities/scripts/conddb_version_mgr.py
+++ b/CondCore/Utilities/scripts/conddb_version_mgr.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python
+
+import cx_Oracle
+import datetime
+import calendar
+import sys
+import logging
+import CondCore.Utilities.conddb_serialization_metadata as sm
+import CondCore.Utilities.credentials as auth
+import os
+
+authPathEnvVar = 'COND_AUTH_PATH'
+prod_db_service = ('cms_orcon_prod',{'w':'cms_orcon_prod/cms_cond_general_w','r':'cms_orcon_prod/cms_cond_general_r'})
+adg_db_service = ('cms_orcon_adg',{'r':'cms_orcon_adg/cms_cond_general_r'})
+dev_db_service = ('cms_orcoff_prep',{'w':'cms_orcoff_prep/cms_cond_general_w','r':'cms_orcoff_prep/cms_cond_general_r'})
+schema_name = 'CMS_CONDITIONS'
+
+fmt_str = "[%(asctime)s] %(levelname)s: %(message)s"
+logLevel = logging.INFO
+logFormatter = logging.Formatter(fmt_str)
+
+def print_table( headers, table ):
+    ws = []
+    for h in headers:
+        ws.append(len(h))
+    for row in table:
+        ind = 0
+        for c in row:
+            c = str(c)
+            if ind<len(ws):
+                if len(c)> ws[ind]:
+                    ws[ind] = len(c)
+            ind += 1
+
+    def printf( row ):
+        line = ''
+        ind = 0
+        for w in ws:
+            fmt = '{:<%s}' %w
+            if ind<len(ws):
+                line += (fmt.format( row[ind] )+' ') 
+            ind += 1
+        print line
+    printf( headers )
+    hsep = ''
+    for w in ws:
+        fmt = '{:-<%s}' %w
+        hsep += (fmt.format('')+' ')
+    print hsep
+    for row in table:
+        printf( row )
+
+class version_db(object):
+    def __init__(self, db ):
+        self.db = db
+        self.cmssw_boost_map = {}
+        self.boost_run_map = []
+
+    def fetch_cmssw_boost_map( self ):
+        cursor = self.db.cursor()
+        cursor.execute('SELECT BOOST_VERSION, CMSSW_VERSION FROM CMSSW_BOOST_MAP');
+        rows = cursor.fetchall()
+        self.cmssw_boost_map = {}
+        for r in rows:
+            self.cmssw_boost_map[r[1]]=r[0]
+        return self.cmssw_boost_map   
+
+    def fetch_boost_run_map( self ):
+        cursor = self.db.cursor()
+        cursor.execute('SELECT RUN_NUMBER, RUN_START_TIME, BOOST_VERSION, INSERTION_TIME FROM BOOST_RUN_MAP ORDER BY RUN_NUMBER, INSERTION_TIME')
+        rows = cursor.fetchall()
+        self.boost_run_map = []
+        for r in rows:
+            self.boost_run_map.append( (r[0],r[1],r[2],str(r[3])) )
+        return self.boost_run_map
+
+    def insert_boost_run_range( self, run, boost_version ):
+        cursor = self.db.cursor()
+        cursor.execute('SELECT MIN(RUN_NUMBER) FROM RUN_INFO WHERE RUN_NUMBER >= :RUN',(run,))
+        min_run = cursor.fetchone()[0]
+        cursor.execute('SELECT START_TIME FROM RUN_INFO WHERE RUN_NUMBER=:RUN',(min_run,))
+        min_run_time = cursor.fetchone()[0]
+        min_run_ts = calendar.timegm( min_run_time.utctimetuple() ) << 32
+        now = datetime.datetime.utcnow()
+        cursor.execute('INSERT INTO BOOST_RUN_MAP ( RUN_NUMBER, RUN_START_TIME, BOOST_VERSION, INSERTION_TIME ) VALUES (:RUN, :RUN_START_T, :BOOST, :TIME)',(run,min_run_ts,boost_version,now) )
+
+    def insert_cmssw_boost( self, cmssw_version,boost_version ):
+        cursor = self.db.cursor()
+        cursor.execute('INSERT INTO CMSSW_BOOST_MAP ( CMSSW_VERSION, BOOST_VERSION ) VALUES ( :CMSSW_VERSION, :BOOST_VERSION )',(cmssw_version,boost_version))
+
+    def lookup_boost_in_cmssw( self, cmssw_version ):
+        cmssw_v = sm.check_cmssw_version(  cmssw_version )
+        the_arch = None
+        releaseRoot = None
+        if sm.is_release_cycle( cmssw_v ):
+            cmssw_v = sm.strip_cmssw_version( cmssw_v )
+            archs = sm.get_production_arch( cmssw_v )
+            for arch in archs:
+                path = sm.get_release_root( cmssw_v, arch )
+                if os.path.exists(os.path.join(path,cmssw_v)):
+                    releaseRoot = path
+                    the_arch = arch
+                    break
+            if releaseRoot is None:
+                for arch in archs:
+                    the_arch = arch
+                    releaseRoot = sm.get_release_root( cmssw_v, arch )    
+                    for r in sorted (os.listdir( releaseRoot )):
+                        if r.startswith(cmssw_v):
+                            cmssw_v = r
+        logging.debug('Boost version will be verified in release %s' %cmssw_v) 
+
+        if cmssw_v in self.cmssw_boost_map.keys():
+            return self.cmssw_boost_map[cmssw_v]
+    
+        if releaseRoot is None:
+            archs = sm.get_production_arch( cmssw_v )
+            for arch in archs:
+                path = sm.get_release_root( cmssw_v, arch )
+                if os.path.exists(os.path.join(path,cmssw_v)):
+                    releaseRoot = path
+                    the_arch = arch
+                    break
+        logging.debug('Release path: %s' %releaseRoot)
+        boost_version = sm.get_cmssw_boost( the_arch, '%s/%s' %(releaseRoot,cmssw_v) )
+        if not boost_version is None:
+            self.cmssw_boost_map[cmssw_v] = boost_version 
+            self.insert_cmssw_boost( cmssw_v,boost_version )
+        return boost_version
+
+    def populate_for_gts( self ):
+        cursor = self.db.cursor()
+        cursor.execute('SELECT DISTINCT(RELEASE) FROM GLOBAL_TAG')
+        rows = cursor.fetchall()
+        for r in rows:
+            self.lookup_boost_in_cmssw( r[0] )
+
+class conddb_tool(object):
+    def __init__( self ):
+        self.db = None
+        self.version_db = None
+        self.args = None
+        self.logger = logging.getLogger()        
+        self.logger.setLevel(logLevel)
+        consoleHandler = logging.StreamHandler(sys.stdout) 
+        consoleHandler.setFormatter(logFormatter)
+        self.logger.addHandler(consoleHandler)
+        self.iovs = None
+        self.versionIovs = None
+
+    def connect( self ):
+        if self.args.db is None:
+            self.args.db = 'pro'
+        if self.args.db == 'dev' or self.args.db == 'oradev' :
+            db_service = dev_db_service
+        elif self.args.db == 'orapro':
+            db_service = adg_db_service    
+        elif self.args.db != 'onlineorapro' or self.args.db != 'pro':
+            db_service = prod_db_service
+        else:
+            raise Exception("Database '%s' is not known." %args.db )
+        if self.args.accessType not in db_service[1].keys():
+            raise Exception('The specified database connection %s does not support the requested action.' %db_service[0])
+        service = db_service[1][self.args.accessType]
+        creds = auth.get_credentials( authPathEnvVar, service, self.args.auth )
+        if creds is None:
+            raise Exception("Could not find credentials for service %s" %service)
+        (username, account, pwd) = creds
+        connStr =  '%s/%s@%s' %(username,pwd,db_service[0])
+        self.db = cx_Oracle.connect(connStr)
+        logging.info('Connected to %s as user %s' %(db_service[0],username))
+        self.db.current_schema = schema_name
+
+    def process_tag_boost_version( self, t, timetype, tagBoostVersion, timeCut ):
+        if self.iovs is None:
+            self.iovs = []
+            cursor = self.db.cursor()
+            stmt = 'SELECT IOV.SINCE SINCE, IOV.INSERTION_TIME INSERTION_TIME, P.STREAMER_INFO STREAMER_INFO FROM TAG, IOV, PAYLOAD P WHERE TAG.NAME = IOV.TAG_NAME AND P.HASH = IOV.PAYLOAD_HASH AND TAG.NAME = :TAG_NAME'
+            params = (t,)
+            stmt = stmt + ' ORDER BY SINCE'
+            logging.debug('Executing: "%s"' %stmt)
+            cursor.execute(stmt,params)
+            for r in cursor:
+                streamer_info = str(r[2].read())
+                self.iovs.append((r[0],r[1],streamer_info))
+        niovs = 0
+        self.versionIovs = []
+        lastBoost = None
+        update = False
+        if tagBoostVersion is not None:
+            update = True        
+        for iov in self.iovs:            
+            if timeCut is not None:
+                if tagBoostVersion is not None:
+                    if timeCut > iov[1]:
+                        continue
+                else:
+                    if timeCut < iov[1]:
+                        continue
+            niovs += 1
+            iovBoostVersion, tagBoostVersion = sm.update_tag_boost_version( tagBoostVersion, iov[2], iov[0], timetype, self.version_db.boost_run_map )
+            logging.debug('iov: %s - boost version: %s - streamer: %s' %(iov[0],iovBoostVersion,iov[2]))
+            if lastBoost is None or lastBoost!=iovBoostVersion:
+                self.versionIovs.append((iov[0],iovBoostVersion))
+                lastBoost = iovBoostVersion
+
+        if tagBoostVersion is None:
+            if niovs == 0:
+                logging.warning( 'No iovs found. boost version cannot be determined.')
+                return None
+            else:
+                logging.error('Could not determine the tag boost version.' )
+                return None
+        else:
+            if niovs == 0:
+                logging.info('Tag boost version has not changed.')
+            else:
+                msg = 'Found tag boost version %s combining payloads from %s iovs' %(tagBoostVersion,niovs)
+                if timeCut is not None:
+                    if update:
+                        msg += ' (iov insertion time>%s)' %str(timeCut)
+                    else:
+                        msg += ' (iov insertion time<%s)' %str(timeCut)
+                logging.info( msg ) 
+        return tagBoostVersion
+
+    def validate_boost_version( self, t, timetype, tagBoostVersion ):
+        cursor = self.db.cursor()
+        cursor.execute('SELECT GT.NAME, GT.RELEASE, GT.SNAPSHOT_TIME FROM GLOBAL_TAG GT, GLOBAL_TAG_MAP GTM WHERE GT.NAME = GTM.GLOBAL_TAG_NAME AND GTM.TAG_NAME = :TAG_NAME',(t,))
+        rows = cursor.fetchall()
+        invalid_gts = []
+        ngt = 0
+        gts = []
+        for r in rows:
+            gts.append((r[0],r[1],r[2]))
+        if len(gts)>0:
+            logging.info('validating %s gts.' %len(gts))
+        boost_snapshot_map = {}
+        for gt in gts:
+            ngt += 1
+            logging.debug('Validating for GT %s (release %s)' %(gt[0],gt[1])) 
+            gtCMSSWVersion =  sm.check_cmssw_version( gt[1] )
+            gtBoostVersion = self.version_db.lookup_boost_in_cmssw( gtCMSSWVersion  )
+            if sm.cmp_boost_version( gtBoostVersion, tagBoostVersion )<0:
+                logging.warning( 'The boost version computed from all the iovs in the tag (%s) is incompatible with the gt [%s] %s (consuming ver: %s, snapshot: %s)' %(tagBoostVersion,ngt,gt[0],gtBoostVersion,str(gt[2])))
+                if str(gt[2]) not in boost_snapshot_map.keys():
+                    tagSnapshotBoostVersion = None
+                    tagSnapshotBoostVersion = self.process_tag_boost_version(t, timetype, tagSnapshotBoostVersion, gt[2])
+                    if tagSnapshotBoostVersion is not None:
+                        boost_snapshot_map[str(gt[2])] = tagSnapshotBoostVersion
+                    else:
+                        continue
+                else:
+                    tagSnapshotBoostVersion = boost_snapshot_map[str(gt[2])] 
+                if sm.cmp_boost_version( gtBoostVersion, tagSnapshotBoostVersion )<0:
+                    logging.error('The snapshot from tag used by gt %s (consuming ver: %s) has an incompatible combined boost version %s' %(gt[0],gtBoostVersion,tagSnapshotBoostVersion))
+                    invalid_gts.append( ( gt[0], gtBoostVersion ) )
+        if len(invalid_gts)==0:
+            if ngt>0:
+                logging.info('boost version for the tag validated in %s referencing Gts' %(ngt))
+            else:
+                logging.info('No GT referencing this tag found.')
+        else:
+            logging.error( 'boost version for the tag is invalid.')
+        return invalid_gts
+
+    def update_tag_boost_version_in_db( self, t, tagBoostVersion, update ):
+        cursor = self.db.cursor()
+        now = datetime.datetime.utcnow()
+        if update:
+            cursor.execute('UPDATE TAG_METADATA SET MIN_SERIALIZATION_V=:BOOST_V, MODIFICATION_TIME=:NOW WHERE TAG_NAME = :NAME',( tagBoostVersion,now,t))
+        else:
+            cursor.execute('INSERT INTO TAG_METADATA ( TAG_NAME, MIN_SERIALIZATION_V, MODIFICATION_TIME ) VALUES ( :NAME, :BOOST_V, :NOW )',(t, tagBoostVersion,now))
+        logging.info('Minimum boost version for the tag updated.')
+        
+    def update_tags( self ):
+        cursor = self.db.cursor()
+        self.version_db = version_db( self.db )
+        self.version_db.fetch_cmssw_boost_map()
+        self.version_db.fetch_boost_run_map()
+        tags = {}
+        wpars = ()
+        if self.args.name is not None:
+            stmt0 = 'SELECT NAME FROM TAG WHERE NAME = :TAG_NAME'
+            wpars = (self.args.name,)
+            cursor.execute(stmt0,wpars);
+            rows = cursor.fetchall()
+            found = False
+            for r in rows:
+                found = True
+                break
+            if not found:
+                raise Exception('Tag %s does not exists in the database.' %self.args.name )
+            tags[self.args.name] = None
+            stmt1 = 'SELECT MIN_SERIALIZATION_V, MODIFICATION_TIME FROM  TAG_METADATA WHERE TAG_NAME = :NAME'
+            cursor.execute(stmt1,wpars);
+            rows = cursor.fetchall()
+            for r in rows:
+                tags[self.args.name] = (r[0],r[1])
+        else:
+            #stmt = 'SELECT MAX(INSERTION_TIME) FROM IOV WHERE TAG_NAME= :TAG_NAME'
+            #cursor.execute(stmt)
+            #rows = cursor.fetchall()
+            #lastInsertionTime = None
+            #for r in rows:
+            #    lastInsertionTime = r[0]
+            #if lastInsertionTime is None:
+            stmt0 = 'SELECT NAME FROM TAG WHERE NAME NOT IN ( SELECT TAG_NAME FROM TAG_METADATA) ORDER BY NAME' 
+            nmax = 100
+            if self.args.max is not None:
+                nmax = self.args.max
+            if self.args.all:
+                nmax = -1
+            if nmax >=0:
+                stmt0 = 'SELECT NAME FROM (SELECT NAME FROM TAG WHERE NAME NOT IN ( SELECT TAG_NAME FROM TAG_METADATA ) ORDER BY NAME) WHERE ROWNUM<= :MAXR'
+                wpars = (nmax,)
+            cursor.execute(stmt0,wpars);
+            rows = cursor.fetchall()
+            for r in rows:
+                tags[r[0]] = None
+            stmt1 = 'SELECT T.NAME NAME, TM.MIN_SERIALIZATION_V MIN_SERIALIZATION_V, TM.MODIFICATION_TIME MODIFICATION_TIME FROM TAG T, TAG_METADATA TM WHERE T.NAME=TM.TAG_NAME AND TM.MODIFICATION_TIME < (SELECT MAX(INSERTION_TIME) FROM IOV WHERE IOV.TAG_NAME=TM.TAG_NAME) ORDER BY NAME' 
+            nmax = nmax-len(tags)
+            if nmax >=0:
+                stmt1 = 'SELECT NAME, MIN_SERIALIZATION_V, MODIFICATION_TIME FROM (SELECT T.NAME NAME, TM.MIN_SERIALIZATION_V MIN_SERIALIZATION_V, TM.MODIFICATION_TIME MODIFICATION_TIME FROM TAG T, TAG_METADATA TM WHERE T.NAME=TM.TAG_NAME AND TM.MODIFICATION_TIME < (SELECT MAX(INSERTION_TIME) FROM IOV WHERE IOV.TAG_NAME=TM.TAG_NAME) ORDER BY NAME) WHERE ROWNUM<= :MAXR'
+                wpars = (nmax,)
+            cursor.execute(stmt1,wpars);
+            rows = cursor.fetchall()
+            i = 0
+            for r in rows:
+                i += 1
+                if nmax >=0 and i>nmax:
+                    break
+                tags[r[0]] = (r[1],r[2])                
+        logging.info( 'Processing boost version for %s tags' %len(tags))
+        count = 0
+        for t in sorted(tags.keys()):
+            count += 1
+            try:
+                update = False
+                cursor.execute('SELECT TIME_TYPE FROM TAG WHERE NAME= :TAG_NAME',(t,))
+                timetype = cursor.fetchone()[0]
+                self.iovs = None
+                logging.info('************************************************************************')
+                logging.info('Tag [%s] %s - timetype: %s' %(count,t,timetype))
+                tagBoostVersion = None
+                timeCut = None
+                if tags[t] is not None:
+                    update = True
+                    tagBoostVersion = tags[t][0]
+                    timeCut = tags[t][1]
+                tagBoostVersion = self.process_tag_boost_version( t, timetype, tagBoostVersion, timeCut )
+                if tagBoostVersion is None:
+                    continue
+                logging.debug('boost versions in the %s iovs: %s' %(len(self.iovs),str(self.versionIovs)))
+                invalid_gts = self.validate_boost_version( t, timetype, tagBoostVersion )
+                if len(invalid_gts)>0:
+                    with open('invalid_tags_in_gts.txt','a') as error_file:
+                        for gt in invalid_gts:
+                            error_file.write('Tag %s (boost %s) is invalid for GT %s ( boost %s) \n' %(t,tagBoostVersion,gt[0],gt[1]))
+                self.update_tag_boost_version_in_db( t, tagBoostVersion, update )
+                self.db.commit()
+            except Exception as e:
+                logging.error(str(e))
+
+    def insert_boost_run( self ):
+        cursor = self.db.cursor()
+        self.version_db = version_db( self.db )
+        self.version_db.insert_boost_run_range( self.args.since, self.args.label )
+        self.db.commit()
+        logging.info('boost version %s inserted with since %s' %(self.args.label,self.args.since))
+
+    def list_boost_run( self ):
+        cursor = self.db.cursor()
+        self.version_db = version_db( self.db )
+        self.version_db.fetch_boost_run_map()
+        headers = ['Run','Run start time','Boost Version','Insertion time']
+        print_table( headers, self.version_db.boost_run_map ) 
+
+    def show_tag_boost_version( self ):
+        cursor = self.db.cursor()
+        tag = self.args.tag_name
+        cursor.execute('SELECT TIME_TYPE FROM TAG WHERE NAME= :TAG_NAME',(tag,))
+        rows = cursor.fetchall()
+        timeType = None
+        t_modificationTime = None
+        for r in rows:
+            timeType = r[0]
+        if timeType is None:
+            raise Exception("Tag %s does not exist in the database." %tag)
+        cursor.execute('SELECT MAX(INSERTION_TIME) FROM IOV WHERE TAG_NAME= :TAG_NAME',(tag,))
+        rows = cursor.fetchall()
+        for r in rows:
+            t_modificationTime = r[0]
+        if t_modificationTime is None:
+            raise Exception("Tag %s does not have any iov stored." %tag)
+        logging.info('Tag %s - timetype: %s' %(tag,timeType))
+        cursor.execute('SELECT MIN_SERIALIZATION_V, MODIFICATION_TIME FROM TAG_METADATA WHERE TAG_NAME= :TAG_NAME',(tag,))
+        rows = cursor.fetchall()
+        tagBoostVersion = None
+        v_modificationTime = None
+        for r in rows:
+            tagBoostVersion = r[0]
+            v_modificationTime = r[1]
+        if v_modificationTime is not None:
+            if t_modificationTime > v_modificationTime:
+                logging.warning('The minimum boost version stored is out of date.')
+            else:
+                logging.info('The minimum boost version stored is up to date.')
+        mt = '-'
+        if v_modificationTime is not None:
+            mt = str(v_modificationTime)
+        r_tagBoostVersion = None
+        if self.args.rebuild or self.args.full:
+            self.version_db = version_db( self.db )
+            self.version_db.fetch_boost_run_map()
+            timeCut = None
+            logging.info('Calculating minimum boost version for the available iovs...')
+            r_tagBoostVersion = self.process_tag_boost_version( tag, timeType, tagBoostVersion, timeCut )
+        print '# Currently stored: %s' %(tagBoostVersion)
+        print '# Last update: %s' %mt
+        print '# Last update on the iovs: %s' %str(t_modificationTime)
+        if self.args.rebuild or self.args.full:
+            print '# Based on the %s available IOVs: %s' %(len(self.iovs),r_tagBoostVersion)
+            if self.args.full:
+                headers = ['Run','Boost Version']
+                print_table( headers, self.versionIovs ) 
+
+import optparse
+import argparse
+
+def main():
+    tool = conddb_tool()
+    parser = argparse.ArgumentParser(description='CMS conddb command-line tool for serialiation metadata. For general help (manual page), use the help subcommand.')
+    parser.add_argument('--db', type=str, help='The target database: pro ( for prod ) or dev ( for prep ). default=pro')
+    parser.add_argument("--auth","-a", type=str,  help="The path of the authentication file")
+    parser.add_argument('--verbose', '-v', action='count', help='The verbosity level')
+    parser_subparsers = parser.add_subparsers(title='Available subcommands')
+    parser_update_tags = parser_subparsers.add_parser('update_tags', description='Update the existing tags headers with the boost version')
+    parser_update_tags.add_argument('--name', '-n', type=str, help='Name of the specific tag to process (default=None - in this case all of the tags will be processed.')
+    parser_update_tags.add_argument('--max', '-m', type=int, help='the maximum number of tags processed',default=100)
+    parser_update_tags.add_argument('--all',action='store_true', help='process all of the tags with boost_version = None')
+    parser_update_tags.set_defaults(func=tool.update_tags,accessType='w')
+    parser_insert_boost_version = parser_subparsers.add_parser('insert_boost_version', description='Insert a new boost version range in the run map')
+    parser_insert_boost_version.add_argument('--label', '-l',type=str, help='The boost version label',required=True)
+    parser_insert_boost_version.add_argument('--since', '-s',type=int, help='The since validity (run number)',required=True)
+    parser_insert_boost_version.set_defaults(func=tool.insert_boost_run,accessType='w')
+    parser_list_boost_versions = parser_subparsers.add_parser('list_boost_versions', description='list the boost versions in the run map')
+    parser_list_boost_versions.set_defaults(func=tool.list_boost_run,accessType='r') 
+    parser_show_version = parser_subparsers.add_parser('show_boost_version', description='Display the minimum boost version for the specified tag (the value stored, by default)')
+    parser_show_version.add_argument('tag_name',help='The name of the tag')
+    parser_show_version.add_argument('--rebuild','-r',action='store_true',default=False,help='Re-calculate the minimum boost versio ')
+    parser_show_version.add_argument('--full',action='store_true',default=False,help='Recalulate the minimum boost version, listing the versions in the iov sequence')
+    parser_show_version.set_defaults(func=tool.show_tag_boost_version,accessType='r')
+    args = parser.parse_args()
+    tool.args = args
+    if args.verbose >=1:
+        tool.logger.setLevel(logging.DEBUG)
+        tool.connect()
+        return args.func()
+    else:
+        try:
+            tool.connect() 
+            sys.exit( args.func())
+        except Exception as e:
+            logging.error(e)
+            sys.exit(1)
+    
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The purpose of this PR is to allow the control of the boost versions of the payloads stored in the condition db.
The main aims are:
- Modify existing copy tool to check that the updates ( adding new payloads ) to existing tags are compatible with the capability ( in terms of boost version ) of the consumer CMSSW release
- Provide a tool for list the current versions
- Provide a tool to update the bookkeeping tables
No changes are made on the C++ code ( producing or consuming the conditions )