### PR TITLE
Cleanup Geant4 sensitive detector classes

### DIFF
--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -22,9 +22,6 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-// To be replaced by something else 
-/* #include "Utilities/Notification/interface/TimerProxy.h" */
- 
 #include "G4VPhysicalVolume.hh"
 #include "G4Track.hh"
 #include "G4VGFlashSensitiveDetector.hh"
@@ -56,8 +53,6 @@ public:
   ~CaloSD() override;
   bool     ProcessHits(G4Step * step, G4TouchableHistory * tHistory) override;
   bool     ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) override;
-  virtual double   getEnergyDeposit(G4Step* step); 
-  //uint32_t setDetUnitId(G4Step* step) override =0;
   
   void     Initialize(G4HCofThisEvent * HCE) override;
   void     EndOfEvent(G4HCofThisEvent * eventHC) override;
@@ -65,11 +60,11 @@ public:
   void     DrawAll() override;
   void     PrintAll() override;
 
-  void     fillHits(edm::PCaloHitContainer&, std::string&) override ;
+  void     fillHits(edm::PCaloHitContainer&, const std::string&) override;
 
 protected:
 
-  virtual G4bool   getStepInfo(G4Step* aStep);
+  virtual G4bool   getStepInfo(const G4Step* aStep);
   G4ThreeVector    setToLocal(const G4ThreeVector&, const G4VTouchable*);
   G4ThreeVector    setToGlobal(const G4ThreeVector&, const G4VTouchable*);
   G4bool           hitExists();
@@ -77,7 +72,7 @@ protected:
   CaloG4Hit*       createNewHit();
   void             updateHit(CaloG4Hit*);
   void             resetForNewPrimary(const G4ThreeVector&, double);
-  double           getAttenuation(G4Step* aStep, double birk1, double birk2,
+  double           getAttenuation(const G4Step* aStep, double birk1, double birk2,
                                   double birk3);
 
   void     update(const BeginOfRun *) override;
@@ -87,11 +82,11 @@ protected:
   void     update(const ::EndOfEvent *) override;
   void     clearHits() override ;
   virtual void     initRun();
-  virtual bool     filterHit(CaloG4Hit*, double);
+  virtual bool     filterHit(const CaloG4Hit*, double);
 
-  virtual int      getTrackID(G4Track*);
-  virtual uint16_t getDepth(G4Step*);   
-  double           getResponseWt(G4Track*);
+  virtual int      getTrackID(const G4Track*);
+  virtual uint16_t getDepth(const G4Step*);   
+  double           getResponseWt(const G4Track*);
   int              getNumberOfHits();
 
 private:
@@ -126,7 +121,6 @@ protected:
 
   const SimTrackManager*          m_trackManager;
   CaloG4Hit*                      currentHit;
-  //  TimerProxy                    theHitTimer;
   bool                            runInit;
 
   bool                            corrTOFBeam, suppressHeavy;

--- a/SimG4CMS/Calo/interface/CaloTrkProcessing.h
+++ b/SimG4CMS/Calo/interface/CaloTrkProcessing.h
@@ -25,28 +25,26 @@ class CaloTrkProcessing : public SensitiveCaloDetector,
 
 public:
 
-  CaloTrkProcessing(G4String aSDname, const DDCompactView & cpv,
+  CaloTrkProcessing(const std::string& aSDname, const DDCompactView & cpv,
 		    const SensitiveDetectorCatalog & clg,
 		    edm::ParameterSet const & p, const SimTrackManager*);
-  virtual ~CaloTrkProcessing();
-  virtual void             Initialize(G4HCofThisEvent * ) {}
-  virtual void             clearHits() {}
-  virtual bool             ProcessHits(G4Step * , G4TouchableHistory * ) {
+  ~CaloTrkProcessing() override;
+  void             Initialize(G4HCofThisEvent * ) override {}
+  void             clearHits() override {}
+  bool             ProcessHits(G4Step * , G4TouchableHistory * ) override {
     return true;
   }
-  virtual uint32_t         setDetUnitId(G4Step * step) {return 0;}
-  virtual void             EndOfEvent(G4HCofThisEvent * ) {}
-  void                     fillHits(edm::PCaloHitContainer&, std::string ) {}
+  uint32_t         setDetUnitId(const G4Step * step) override {return 0;}
+  void             EndOfEvent(G4HCofThisEvent * ) override {}
 
 private:
 
-  void                     update(const BeginOfEvent * evt);
-  void                     update(const G4Step *);
-  std::vector<std::string> getNames(G4String, const DDsvalues_type&);
-  std::vector<double>      getNumbers(G4String, const DDsvalues_type&);
+  void                     update(const BeginOfEvent * evt) override;
+  void                     update(const G4Step *) override;
+  std::vector<std::string> getNames(const G4String&, const DDsvalues_type&);
+  std::vector<double>      getNumbers(const G4String&, const DDsvalues_type&);
   int                      isItCalo(const G4VTouchable*);
   int                      isItInside(const G4VTouchable*, int, int);
-
 
   struct Detector {
     Detector() {}

--- a/SimG4CMS/Calo/interface/ECalSD.h
+++ b/SimG4CMS/Calo/interface/ECalSD.h
@@ -34,28 +34,27 @@ public:
   ECalSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	 edm::ParameterSet const & p, const SimTrackManager*);
   ~ECalSD() override;
-  double                    getEnergyDeposit(G4Step*) override;
-  virtual uint16_t                  getRadiationLength(G4Step *);
-  virtual uint16_t                  getLayerIDForTimeSim(G4Step *);
-  uint32_t                  setDetUnitId(G4Step*) override ;
-  void                              setNumberingScheme(EcalNumberingScheme*);
-  int                       getTrackID(G4Track*) override;
-  uint16_t                  getDepth(G4Step*) override;
+  double                    getEnergyDeposit(const G4Step*) override;
+  virtual uint16_t          getRadiationLength(const G4Step *);
+  virtual uint16_t          getLayerIDForTimeSim(const G4Step *);
+  uint32_t                  setDetUnitId(const G4Step*) override ;
+  void                      setNumberingScheme(const EcalNumberingScheme*);
+  int                       getTrackID(const G4Track*) override;
+  uint16_t                  getDepth(const G4Step*) override;
 
 private:    
-  void                              initMap(const G4String&, const DDCompactView &);
-  double                            curve_LY(); 
-  double                            crystalLength();
-  double                            crystalDepth();
-  void                              getBaseNumber(const G4Step*); 
-  double                            getBirkL3(const G4Step*);
-  std::vector<double>               getDDDArray(const std::string&,
-						const DDsvalues_type&);
-  std::vector<std::string>          getStringArray(const std::string&,
-						   const DDsvalues_type&);
+  void                      initMap(const G4String&, const DDCompactView &);
+  double                    curve_LY(); 
+  double                    crystalLength();
+  double                    crystalDepth();
+  void                      getBaseNumber(const G4Step*); 
+  double                    getBirkL3(const G4Step*);
+  std::vector<double>       getDDDArray(const std::string&, const DDsvalues_type&);
+  std::vector<std::string>  getStringArray(const std::string&, const DDsvalues_type&);
+
   bool                              isEB;
   bool                              isEE;
-  EcalNumberingScheme *             numberingScheme;
+  const EcalNumberingScheme*        numberingScheme;
   bool                              useWeight, storeTrack, storeRL, storeLayerTimeSim;
   bool                              useBirk, useBirkL3;
   double                            birk1, birk2, birk3, birkSlope, birkCut;

--- a/SimG4CMS/Calo/interface/HCalSD.h
+++ b/SimG4CMS/Calo/interface/HCalSD.h
@@ -8,14 +8,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "SimG4CMS/Calo/interface/CaloSD.h"
-#include "SimG4CMS/Calo/interface/HFShower.h"
-#include "SimG4CMS/Calo/interface/HFShowerLibrary.h"
-#include "SimG4CMS/Calo/interface/HFShowerParam.h"
-#include "SimG4CMS/Calo/interface/HFShowerPMT.h"
-#include "SimG4CMS/Calo/interface/HFShowerFibreBundle.h"
-#include "SimG4CMS/Calo/interface/HcalNumberingScheme.h"
-#include "CondFormats/HcalObjects/interface/HBHEDarkening.h"
-#include "SimG4CMS/Calo/interface/HFDarkening.h"
 #include "DetectorDescription/Core/interface/DDsvalues.h"
 #include "SimG4Core/Notification/interface/BeginOfJob.h"
 #include "Geometry/HcalCommonData/interface/HcalNumberingFromDDD.h"
@@ -32,6 +24,15 @@ class G4LogicalVolume;
 class G4Material;
 class G4Step;
 class HcalTestNS;
+class HcalNumberingScheme;
+class HFShowerLibrary;
+class HFShower;
+class HFShowerParam;
+class HFShowerPMT;
+class HFShowerFibreBundle;
+class HBHEDarkening;
+class HFDarkening;
+class HcalTestNS;
 
 class HCalSD : public CaloSD, public Observer<const BeginOfJob *> {
 
@@ -41,37 +42,37 @@ public:
          edm::ParameterSet const &, const SimTrackManager*);
   ~HCalSD() override;
   bool                  ProcessHits(G4Step * , G4TouchableHistory * ) override;
-  double                getEnergyDeposit(G4Step* ) override;
-  uint32_t              setDetUnitId(G4Step* step) override ;
-  void                          setNumberingScheme(HcalNumberingScheme* );
+  double                getEnergyDeposit(const G4Step* ) override;
+  uint32_t              setDetUnitId(const G4Step* step) override ;
+  void                  setNumberingScheme(HcalNumberingScheme* );
 
 protected:
 
   void                  update(const BeginOfJob *) override;
   void                  initRun() override;
-  bool                  filterHit(CaloG4Hit*, double) override;
+  bool                  filterHit(const CaloG4Hit*, double) override;
 
 private:    
 
   uint32_t                      setDetUnitId(int, const G4ThreeVector&, int, int);
   uint32_t                      setDetUnitId(HcalNumberingFromDDD::HcalID& tmp);
-  std::vector<double>           getDDDArray(const std::string&, 
-                                            const DDsvalues_type&);
+  std::vector<double>           getDDDArray(const std::string&, const DDsvalues_type&);
   std::vector<G4String>         getNames(DDFilteredView&);
-  bool                          isItHF(const G4Step *);
-  bool                          isItHF(const G4String&);
-  bool                          isItFibre(G4LogicalVolume*);
-  bool                          isItFibre(const G4String&);
-  bool                          isItPMT(G4LogicalVolume*);
-  bool                          isItStraightBundle(G4LogicalVolume*);
-  bool                          isItConicalBundle(G4LogicalVolume*);
-  bool                          isItScintillator(G4Material*);
-  bool                          isItinFidVolume (const G4ThreeVector&);
+  bool                          isItHF(const G4Step *) const;
+  bool                          isItHF(const G4String&) const;
+  bool                          isApplicableHF(const G4ParticleDefinition*) const;
+  bool                          isItFibre(const G4LogicalVolume*) const;
+  bool                          isItFibre(const G4String&) const;
+  bool                          isItPMT(const G4LogicalVolume*) const;
+  bool                          isItStraightBundle(const G4LogicalVolume*) const;
+  bool                          isItConicalBundle(const G4LogicalVolume*) const;
+  bool                          isItScintillator(const G4Material*) const;
+  bool                          isItinFidVolume (const G4ThreeVector&) const;
   void                          getFromLibrary(G4Step * step, double weight);
-  void                          hitForFibre(G4Step * step, double weight);
+  void                          hitForFibre(const G4Step * step, double weight);
   void                          getFromParam(G4Step * step, double weight);
-  void                          getHitPMT(G4Step * step);
-  void                          getHitFibreBundle(G4Step * step, bool type);
+  void                          getHitPMT(const G4Step * step);
+  void                          getHitFibreBundle(const G4Step * step, bool type);
   int                           setTrackID(const G4Step * step);
   void                          readWeightFromFile(const std::string&);
   double                        layerWeight(int, const G4ThreeVector&, int, int);
@@ -82,7 +83,7 @@ private:
 
   HcalDDDSimConstants*          hcalConstants;
   HcalNumberingFromDDD*         numberingFromDDD;
-  HcalNumberingScheme*          numberingScheme;
+  const HcalNumberingScheme*    numberingScheme;
   HFShowerLibrary *             showerLibrary;
   HFShower *                    hfshower;
   HFShowerParam *               showerParam;
@@ -99,9 +100,10 @@ private:
   bool                          useHF, useShowerLibrary, useParam, applyFidCut;
   double                        eminHitHB, eminHitHE, eminHitHO, eminHitHF;
   double                        deliveredLumi;
-  G4int                         mumPDG, mupPDG, depth_;
+  G4int                         depth_;
   std::vector<double>           gpar;
   std::vector<int>              hfLevels;
+  std::vector<int>              hfPGDcodes;
   std::vector<G4String>         hfNames, fibreNames, matNames;
   std::vector<G4Material*>      materials;
   std::vector<G4LogicalVolume*> hfLV, fibreLV, pmtLV, fibre1LV, fibre2LV;

--- a/SimG4CMS/Calo/interface/HCalSD.h
+++ b/SimG4CMS/Calo/interface/HCalSD.h
@@ -68,9 +68,9 @@ private:
   bool                          isItConicalBundle(const G4LogicalVolume*) const;
   bool                          isItScintillator(const G4Material*) const;
   bool                          isItinFidVolume (const G4ThreeVector&) const;
-  void                          getFromLibrary(G4Step * step, double weight);
+  void                          getFromLibrary(const G4Step * step, double weight);
   void                          hitForFibre(const G4Step * step, double weight);
-  void                          getFromParam(G4Step * step, double weight);
+  void                          getFromParam(const G4Step * step, double weight);
   void                          getHitPMT(const G4Step * step);
   void                          getHitFibreBundle(const G4Step * step, bool type);
   int                           setTrackID(const G4Step * step);
@@ -80,6 +80,7 @@ private:
                                             double edep, double time, int id);
   void                          plotHF(const G4ThreeVector& pos, bool emType);
   void                          modifyDepth(HcalNumberingFromDDD::HcalID& id);
+  void                          killTracks(G4Step*);
 
   HcalDDDSimConstants*          hcalConstants;
   HcalNumberingFromDDD*         numberingFromDDD;
@@ -98,6 +99,7 @@ private:
   bool                          testNumber, neutralDensity, testNS_;
   double                        birk1, birk2, birk3, betaThr;
   bool                          useHF, useShowerLibrary, useParam, applyFidCut;
+  bool                          isPametrized;
   double                        eminHitHB, eminHitHE, eminHitHO, eminHitHF;
   double                        deliveredLumi;
   G4int                         depth_;

--- a/SimG4CMS/Calo/interface/HCalSD.h
+++ b/SimG4CMS/Calo/interface/HCalSD.h
@@ -99,7 +99,7 @@ private:
   bool                          testNumber, neutralDensity, testNS_;
   double                        birk1, birk2, birk3, betaThr;
   bool                          useHF, useShowerLibrary, useParam, applyFidCut;
-  bool                          isPametrized;
+  bool                          isParametrized;
   double                        eminHitHB, eminHitHE, eminHitHO, eminHitHF;
   double                        deliveredLumi;
   G4int                         depth_;

--- a/SimG4CMS/Calo/interface/HFCherenkov.h
+++ b/SimG4CMS/Calo/interface/HFCherenkov.h
@@ -23,20 +23,20 @@ public:
    HFCherenkov(edm::ParameterSet const & p);
    virtual ~HFCherenkov();
   
-   int                 computeNPE(G4Step* step, G4ParticleDefinition* pDef,
-				  double pBeta, double u, double v, double w, 
-				  double step_length, double zFiber, 
-				  double Dose, int Npe_Dose);
+   int computeNPE(const G4Step* step, const G4ParticleDefinition* pDef,
+		  double pBeta, double u, double v, double w, 
+		  double step_length, double zFiber, 
+		  double Dose, int Npe_Dose);
    
-   int                 computeNPEinPMT(G4ParticleDefinition* pDef,double pBeta,
-                                       double u, double v, double w, 
-                                       double step_length);
+   int computeNPEinPMT(const G4ParticleDefinition* pDef,double pBeta,
+		       double u, double v, double w, 
+		       double step_length);
 
-   int                 computeNPhTrapped(double pBeta, double u, double v, 
-					 double w, double step_length,
-					 double zFiber, double Dose,
-					 int Npe_Dose);
-   double              smearNPE(G4int Npe);				  
+   int computeNPhTrapped(double pBeta, double u, double v, 
+			 double w, double step_length,
+			 double zFiber, double Dose,
+			 int Npe_Dose);
+   double smearNPE(G4int Npe);				  
 
    std::vector<double> getMom();
    std::vector<double> getWL();

--- a/SimG4CMS/Calo/interface/HFFibre.h
+++ b/SimG4CMS/Calo/interface/HFFibre.h
@@ -26,7 +26,7 @@ public:
 	  edm::ParameterSet const & p);
   ~HFFibre();
 
-  void                initRun(HcalDDDSimConstants*);
+  void                initRun(const HcalDDDSimConstants*);
   double              attLength(double lambda);
   double              tShift(const G4ThreeVector& point, int depth, 
 			     int fromEndAbs=0);

--- a/SimG4CMS/Calo/interface/HFGflash.h
+++ b/SimG4CMS/Calo/interface/HFGflash.h
@@ -42,7 +42,7 @@ public:
     double              pez = 0.;
   };
 
-  std::vector<Hit> gfParameterization(G4Step * aStep, bool & ok, bool onlyLong=false);
+  std::vector<Hit> gfParameterization(const G4Step * aStep, bool & ok, bool onlyLong=false);
 
 private:    
 

--- a/SimG4CMS/Calo/interface/HFShower.h
+++ b/SimG4CMS/Calo/interface/HFShower.h
@@ -41,7 +41,7 @@ public:
 
   void                initRun(const G4ParticleTable *, const HcalDDDSimConstants*);
   std::vector<Hit>    getHits(const G4Step * aStep, double weight);
-  std::vector<Hit>    getHits(G4Step * aStep, bool forLibraryProducer, double zoffset);
+  std::vector<Hit>    getHits(const G4Step * aStep, bool forLibraryProducer, double zoffset);
 
 private:    
 

--- a/SimG4CMS/Calo/interface/HFShower.h
+++ b/SimG4CMS/Calo/interface/HFShower.h
@@ -6,16 +6,17 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "Geometry/HcalCommonData/interface/HcalDDDSimConstants.h"
-#include "SimG4CMS/Calo/interface/HFCherenkov.h"
-#include "SimG4CMS/Calo/interface/HFFibre.h"
+#include "DetectorDescription/Core/interface/DDsvalues.h"
 
 #include "G4ThreeVector.hh"
 #include "G4String.hh"
 
 class DDCompactView;    
 class G4Step;
+class HFFibre;
+class HFCherenkov;
+class HcalDDDSimConstants;
+class G4ParticleTable;
 
 #include <vector>
  
@@ -38,11 +39,9 @@ public:
     G4ThreeVector     position;
   };
 
-  void                initRun(G4ParticleTable *, HcalDDDSimConstants*);
-  std::vector<Hit>    getHits(G4Step * aStep, double weight);
-  std::vector<Hit>    getHits(G4Step * aStep, bool forLibrary);
+  void                initRun(const G4ParticleTable *, const HcalDDDSimConstants*);
+  std::vector<Hit>    getHits(const G4Step * aStep, double weight);
   std::vector<Hit>    getHits(G4Step * aStep, bool forLibraryProducer, double zoffset);
-
 
 private:    
 

--- a/SimG4CMS/Calo/interface/HFShowerFibreBundle.h
+++ b/SimG4CMS/Calo/interface/HFShowerFibreBundle.h
@@ -24,9 +24,9 @@ public:
   HFShowerFibreBundle(const std::string & name, const DDCompactView & cpv, 
 		      edm::ParameterSet const & p);
   virtual ~HFShowerFibreBundle();
-  double                getHits(G4Step * aStep, bool type);
+  double                getHits(const G4Step * aStep, bool type);
   double                getRadius();
-  void                  initRun(G4ParticleTable *, HcalDDDSimConstants*);
+  void                  initRun(const G4ParticleTable *, const HcalDDDSimConstants*);
 
 private:    
 

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -45,10 +45,10 @@ public:
   };
 
   void                initRun(G4ParticleTable *, HcalDDDSimConstants*);
-  std::vector<Hit>    getHits(G4Step * aStep, bool &ok, double weight, 
+  std::vector<Hit>    getHits(const G4Step * aStep, bool isEM, double weight, 
 			      bool onlyLong=false);
-  std::vector<Hit>    fillHits(G4ThreeVector & p, G4ThreeVector & v,
-                               int parCode, double parEnergy, bool & ok,
+  std::vector<Hit>    fillHits(const G4ThreeVector & p, const G4ThreeVector & v,
+                               int parCode, double parEnergy, bool isEM,
                                double weight, double time, bool onlyLong=false);
 protected:
 
@@ -75,10 +75,6 @@ private:
   double              probMax, backProb;
   double              dphi, rMin, rMax;
   std::vector<double> gpar;
-
-  int                 emPDG, epPDG, gammaPDG;
-  int                 pi0PDG, etaPDG, nuePDG, numuPDG, nutauPDG;
-  int                 anuePDG, anumuPDG, anutauPDG, geantinoPDG;
 
   int                 npe;
   HFShowerPhotonCollection pe;

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -12,7 +12,6 @@
 #include "SimDataFormats/CaloHit/interface/HFShowerPhoton.h"
 #include "DetectorDescription/Core/interface/DDsvalues.h"
 
-#include "G4ParticleTable.hh"
 #include "G4ThreeVector.hh"
  
 //ROOT
@@ -25,6 +24,7 @@
 
 class DDCompactView;    
 class G4Step;
+class G4ParticleTable;
 
 class HFShowerLibrary {
   
@@ -48,7 +48,7 @@ public:
   std::vector<Hit>    getHits(const G4Step * aStep, bool isEM, double weight, 
 			      bool onlyLong=false);
   std::vector<Hit>    fillHits(const G4ThreeVector & p, const G4ThreeVector & v,
-                               int parCode, double parEnergy, bool isEM,
+                               int parCode, double parEnergy, bool & isEM,
                                double weight, double time, bool onlyLong=false);
 protected:
 
@@ -76,6 +76,10 @@ private:
   double              dphi, rMin, rMax;
   std::vector<double> gpar;
 
+  int                 emPDG, epPDG, gammaPDG;
+  int                 pi0PDG, etaPDG, nuePDG, numuPDG, nutauPDG;
+  int                 anuePDG, anumuPDG, anutauPDG, geantinoPDG;
+ 
   int                 npe;
   HFShowerPhotonCollection pe;
   HFShowerPhotonCollection* photo;

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -44,11 +44,11 @@ public:
     double                    time;
   };
 
-  void                initRun(G4ParticleTable *, HcalDDDSimConstants*);
-  std::vector<Hit>    getHits(const G4Step * aStep, bool isEM, double weight, 
+  void                initRun(const G4ParticleTable *, const HcalDDDSimConstants*);
+  std::vector<Hit>    getHits(const G4Step * aStep, bool & ok, double weight, 
 			      bool onlyLong=false);
   std::vector<Hit>    fillHits(const G4ThreeVector & p, const G4ThreeVector & v,
-                               int parCode, double parEnergy, bool & isEM,
+                               int parCode, double parEnergy, bool & ok,
                                double weight, double time, bool onlyLong=false);
 protected:
 

--- a/SimG4CMS/Calo/interface/HFShowerPMT.h
+++ b/SimG4CMS/Calo/interface/HFShowerPMT.h
@@ -24,9 +24,9 @@ public:
   HFShowerPMT(const std::string & name, const DDCompactView & cpv, 
 	      edm::ParameterSet const & p);
   virtual ~HFShowerPMT();
-  double                getHits(G4Step * aStep);
+  double                getHits(const G4Step * aStep);
   double                getRadius();
-  void                  initRun(G4ParticleTable *, HcalDDDSimConstants*);
+  void                  initRun(const G4ParticleTable *, const HcalDDDSimConstants*);
 
 private:    
 

--- a/SimG4CMS/Calo/interface/HFShowerParam.h
+++ b/SimG4CMS/Calo/interface/HFShowerParam.h
@@ -42,9 +42,9 @@ public:
     double              edep;
   };
 
-  void                  initRun(G4ParticleTable*, HcalDDDSimConstants*);
+  void                  initRun(const G4ParticleTable*, const HcalDDDSimConstants*);
 
-  std::vector<HFShowerParam::Hit>  getHits(G4Step* aStep, double weight);
+  std::vector<HFShowerParam::Hit>  getHits(const G4Step* aStep, double weight, bool& ok);
   
 private:    
 

--- a/SimG4CMS/Calo/interface/HFShowerParam.h
+++ b/SimG4CMS/Calo/interface/HFShowerParam.h
@@ -42,8 +42,9 @@ public:
     double              edep;
   };
 
-  void                  initRun(G4ParticleTable *, HcalDDDSimConstants*);
-  std::vector<Hit>      getHits(G4Step * aStep, double weight);
+  void                  initRun(G4ParticleTable*, HcalDDDSimConstants*);
+
+  std::vector<HFShowerParam::Hit>  getHits(G4Step* aStep, double weight);
   
 private:    
 

--- a/SimG4CMS/Calo/interface/HGCSD.h
+++ b/SimG4CMS/Calo/interface/HGCSD.h
@@ -29,23 +29,23 @@ public:
 
   HGCSD(G4String , const DDCompactView &, const SensitiveDetectorCatalog &,
 	edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~HGCSD();
-  virtual bool                    ProcessHits(G4Step * , G4TouchableHistory * );
-  virtual double                  getEnergyDeposit(G4Step* );
-  virtual uint32_t                setDetUnitId(G4Step* step);
+  ~HGCSD() override;
+  bool                    ProcessHits(G4Step * , G4TouchableHistory * ) override;
+  double                  getEnergyDeposit(const G4Step* ) override;
+  uint32_t                setDetUnitId(const G4Step* step) override;
 
 protected:
 
-  virtual void                    update(const BeginOfJob *);
-  virtual void                    initRun();
-  virtual bool                    filterHit(CaloG4Hit*, double);
+  void                    update(const BeginOfJob *) override;
+  void                    initRun() override;
+  bool                    filterHit(const CaloG4Hit*, double) override;
 
 private:    
 
-  uint32_t                        setDetUnitId(ForwardSubdetector&, int, int, 
+  uint32_t                        setDetUnitId(const ForwardSubdetector&, int, int, 
 					       int, int, G4ThreeVector &);
-  bool                            isItinFidVolume (G4ThreeVector&) {return true;}
-  int                             setTrackID(G4Step * step);
+  bool                            isItinFidVolume (const G4ThreeVector&) {return true;}
+  int                             setTrackID(const G4Step * step);
 
   std::string                     nameX;
 

--- a/SimG4CMS/Calo/interface/HcalNumberingScheme.h
+++ b/SimG4CMS/Calo/interface/HcalNumberingScheme.h
@@ -7,15 +7,13 @@
 
 #include "Geometry/CaloGeometry/interface/CaloNumberingScheme.h"
 #include "Geometry/HcalCommonData/interface/HcalNumberingFromDDD.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <boost/cstdint.hpp>
 
 class HcalNumberingScheme : public CaloNumberingScheme {
 
 public:
   HcalNumberingScheme();
   ~HcalNumberingScheme() override;
-  virtual uint32_t getUnitID(const HcalNumberingFromDDD::HcalID& id);
+  virtual uint32_t getUnitID(const HcalNumberingFromDDD::HcalID& id) const;
 
 };
 

--- a/SimG4CMS/Calo/interface/HcalTestNS.h
+++ b/SimG4CMS/Calo/interface/HcalTestNS.h
@@ -5,6 +5,8 @@
 #include "Geometry/HcalCommonData/interface/HcalNumberingFromDDD.h"
 #include "Geometry/HcalCommonData/interface/HcalDDDRecConstants.h"
 
+class HcalNumberingScheme;
+
 class HcalTestNS {
 
 public:    
@@ -16,8 +18,8 @@ public:
 
 private:
 
-  HcalDDDRecConstants*          hcons_;
-
+  HcalDDDRecConstants* hcons_;
+  const HcalNumberingScheme* scheme_;
 };
 
 #endif // HcalTestNS_h

--- a/SimG4CMS/Calo/interface/HcalTestNumberingScheme.h
+++ b/SimG4CMS/Calo/interface/HcalTestNumberingScheme.h
@@ -20,7 +20,7 @@ public:
 				   int& depth, int& eta, int& phi, int& lay);
 private:
 
-  HcalTestNumberingScheme() = delete;
+  HcalTestNumberingScheme();
 
   bool forTBH2;
 };

--- a/SimG4CMS/Calo/interface/HcalTestNumberingScheme.h
+++ b/SimG4CMS/Calo/interface/HcalTestNumberingScheme.h
@@ -13,14 +13,14 @@ class HcalTestNumberingScheme : public HcalNumberingScheme {
 public:
   HcalTestNumberingScheme(bool forTB);
   ~HcalTestNumberingScheme() override;
-  uint32_t getUnitID(const HcalNumberingFromDDD::HcalID& id) override;
+  uint32_t getUnitID(const HcalNumberingFromDDD::HcalID& id) const override;
   static uint32_t  packHcalIndex(int det, int z, int depth, int eta,
                                  int phi, int lay);
   static void      unpackHcalIndex(const uint32_t & idx, int& det, int& z, 
 				   int& depth, int& eta, int& phi, int& lay);
 private:
 
-  HcalTestNumberingScheme();
+  HcalTestNumberingScheme() = delete;
 
   bool forTBH2;
 };

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -195,10 +195,6 @@ bool CaloSD::ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) {
   return false;
 }                                   
 
-double CaloSD::getEnergyDeposit(G4Step* aStep) {
-  return aStep->GetTotalEnergyDeposit();
-}
-
 void CaloSD::Initialize(G4HCofThisEvent * HCE) { 
   totalHits = 0;
   
@@ -236,12 +232,12 @@ void CaloSD::PrintAll() {
   theHC->PrintAllHits();
 } 
 
-void CaloSD::fillHits(edm::PCaloHitContainer& cont, std::string& hitname) {
+void CaloSD::fillHits(edm::PCaloHitContainer& cont, const std::string& hitname) {
   if (slave->name() == hitname) { cont = slave->hits(); }
   slave->Clean();
 }
 
-bool CaloSD::getStepInfo(G4Step* aStep) {  
+bool CaloSD::getStepInfo(const G4Step* aStep) {  
 
   preStepPoint = aStep->GetPreStepPoint(); 
   theLogicalVolume = preStepPoint->GetPhysicalVolume()->GetLogicalVolume();
@@ -367,7 +363,7 @@ CaloG4Hit* CaloSD::createNewHit() {
 			  << " daughter of part. " << theTrack->GetParentID()
 			  << " and created by " ;
   
-  if (theTrack->GetCreatorProcess()!=NULL)
+  if (theTrack->GetCreatorProcess()!=nullptr)
     edm::LogInfo("CaloSim") << theTrack->GetCreatorProcess()->GetProcessName();
   else 
     edm::LogInfo("CaloSim") << "NO process";
@@ -454,7 +450,7 @@ void CaloSD::resetForNewPrimary(const G4ThreeVector& point, double energy) {
 #endif
 }
 
-double CaloSD::getAttenuation(G4Step* aStep, double birk1, double birk2, double birk3) {
+double CaloSD::getAttenuation(const G4Step* aStep, double birk1, double birk2, double birk3) {
   double weight = 1.;
   double charge = aStep->GetPreStepPoint()->GetCharge();
 
@@ -560,7 +556,7 @@ void CaloSD::clearHits() {
 
 void CaloSD::initRun() {}
 
-int CaloSD::getTrackID(G4Track* aTrack) {
+int CaloSD::getTrackID(const G4Track* aTrack) {
   int primaryID = 0;
   forceSave = false;
   TrackInformation* trkInfo=(TrackInformation *)(aTrack->GetUserInformation());
@@ -581,9 +577,9 @@ int CaloSD::getTrackID(G4Track* aTrack) {
   return primaryID;
 }
 
-uint16_t CaloSD::getDepth(G4Step*) { return 0; }
+uint16_t CaloSD::getDepth(const G4Step*) { return 0; }
 
-bool CaloSD::filterHit(CaloG4Hit* hit, double time) {
+bool CaloSD::filterHit(const CaloG4Hit* hit, double time) {
   double emin(eminHit);
   if (hit->getDepth() > 0) emin = eminHitD;
 #ifdef DebugLog
@@ -593,12 +589,12 @@ bool CaloSD::filterHit(CaloG4Hit* hit, double time) {
   return ((time <= tmaxHit) && (hit->getEnergyDeposit() > emin));
 }
 
-double CaloSD::getResponseWt(G4Track* aTrack) {
+double CaloSD::getResponseWt(const G4Track* aTrack) {
   if (meanResponse) {
     TrackInformation * trkInfo = (TrackInformation *)(aTrack->GetUserInformation());
     return meanResponse->getWeight(trkInfo->genParticlePID(), trkInfo->genParticleP());
   } else {
-    return 1;
+    return 1.0;
   }
 }
 

--- a/SimG4CMS/Calo/src/CaloTrkProcessing.cc
+++ b/SimG4CMS/Calo/src/CaloTrkProcessing.cc
@@ -23,12 +23,12 @@
 
 //#define DebugLog
 
-CaloTrkProcessing::CaloTrkProcessing(G4String name, 
+CaloTrkProcessing::CaloTrkProcessing(const std::string& iname, 
 				     const DDCompactView & cpv,
 				     const SensitiveDetectorCatalog & clg,
 				     edm::ParameterSet const & p,
 				     const SimTrackManager* manager) : 
-  SensitiveCaloDetector(name, cpv, clg, p), lastTrackID(-1),
+  SensitiveCaloDetector(iname, cpv, clg, p), lastTrackID(-1),
   m_trackManager(manager) {  
 
   //Initialise the parameter set
@@ -43,7 +43,7 @@ CaloTrkProcessing::CaloTrkProcessing(G4String name,
 
   //Get the names 
   G4String attribute = "ReadOutName"; 
-  DDSpecificsMatchesValueFilter filter{DDValue(attribute,name,0)};
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute,iname,0)};
   DDFilteredView fv(cpv,filter);
   fv.firstChild();
   DDsvalues_type sv(fv.mergedSpecifics());
@@ -100,7 +100,7 @@ CaloTrkProcessing::CaloTrkProcessing(G4String name,
   std::vector<G4LogicalVolume *>::const_iterator lvcite;
   int istart = 0;
   for (unsigned int i=0; i<caloNames.size(); i++) {
-    G4LogicalVolume* lv     = 0;
+    G4LogicalVolume* lv     = nullptr;
     G4String         name   = caloNames[i];
     int              number = static_cast<int>(neighbours[i]);
     for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++) {
@@ -109,7 +109,7 @@ CaloTrkProcessing::CaloTrkProcessing(G4String name,
 	break;
       }
     }
-    if (lv != 0) {
+    if (lv != nullptr) {
      CaloTrkProcessing::Detector detector;
      detector.name  = name;
      detector.lv    = lv;
@@ -125,7 +125,7 @@ CaloTrkProcessing::CaloTrkProcessing(G4String name,
      std::vector<G4LogicalVolume*> insideLV;
      std::vector<int>              insideLevels;
      for (int k = 0; k < number; k++) {
-       lv   = 0;
+       lv   = nullptr;
        name = insideNames[istart+k];
        for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++) 
 	 if ((*lvcite)->GetName() == name) {
@@ -164,7 +164,7 @@ CaloTrkProcessing::~CaloTrkProcessing() {
   edm::LogInfo("CaloSim") << "CaloTrkProcessing: Deleted";
 }
 
-void CaloTrkProcessing::update(const BeginOfEvent * evt) {
+void CaloTrkProcessing::update(const BeginOfEvent *) {
   lastTrackID = -1;
 }
 
@@ -172,13 +172,13 @@ void CaloTrkProcessing::update(const G4Step * aStep) {
   
   // define if you are at the surface of CALO  
   
-  G4Track* theTrack = aStep->GetTrack();   
+  const G4Track* theTrack = aStep->GetTrack();   
   int      id       = theTrack->GetTrackID();
 
   TrackInformation* trkInfo = dynamic_cast<TrackInformation*>
     (theTrack->GetUserInformation());
   
-  if (trkInfo == 0) {
+  if (trkInfo == nullptr) {
     edm::LogError("CaloSim") << "CaloTrkProcessing: No trk info !!!! abort ";
     throw cms::Exception("Unknown", "CaloTrkProcessing")
       << "cannot get trkInfo for Track " << id << "\n";
@@ -222,11 +222,11 @@ void CaloTrkProcessing::update(const G4Step * aStep) {
         }
       }
     } else {
-      G4StepPoint*        postStepPoint = aStep->GetPostStepPoint();   
+      const G4StepPoint*  postStepPoint = aStep->GetPostStepPoint();   
       const G4VTouchable* post_touch    = postStepPoint->GetTouchable();
       int                 ical          = isItCalo(post_touch);
       if (ical >= 0) {
-	G4StepPoint*        preStepPoint = aStep->GetPreStepPoint(); 
+	const G4StepPoint*  preStepPoint = aStep->GetPreStepPoint(); 
 	const G4VTouchable* pre_touch    = preStepPoint->GetTouchable();
 	int                 inside       = isItInside(pre_touch, ical, -1);
 	if (inside >= 0 ||  (theTrack->GetCurrentStepNumber()==1)) {
@@ -248,7 +248,7 @@ void CaloTrkProcessing::update(const G4Step * aStep) {
   }
 }
 
-std::vector<std::string> CaloTrkProcessing::getNames(const G4String str,
+std::vector<std::string> CaloTrkProcessing::getNames(const G4String& str,
 						     const DDsvalues_type &sv){
 
 #ifdef DebugLog
@@ -277,7 +277,7 @@ std::vector<std::string> CaloTrkProcessing::getNames(const G4String str,
   }
 }
 
-std::vector<double> CaloTrkProcessing::getNumbers(const G4String str,
+std::vector<double> CaloTrkProcessing::getNumbers(const G4String& str,
 						  const DDsvalues_type &sv) {
 
 #ifdef DebugLog
@@ -308,7 +308,7 @@ std::vector<double> CaloTrkProcessing::getNumbers(const G4String str,
 int CaloTrkProcessing::isItCalo(const G4VTouchable* touch) {
 
   int lastLevel = -1;
-  G4LogicalVolume* lv=0;
+  G4LogicalVolume* lv=nullptr;
   for (unsigned int it=0; it < detectors.size(); it++) {
     if (lastLevel != detectors[it].level) {
       lastLevel = detectors[it].level;
@@ -337,7 +337,7 @@ int CaloTrkProcessing::isItCalo(const G4VTouchable* touch) {
 int CaloTrkProcessing::isItInside(const G4VTouchable* touch, int idcal,
 				  int idin) {
   int lastLevel = -1;
-  G4LogicalVolume* lv=0;
+  G4LogicalVolume* lv=nullptr;
   int id1, id2;
   if (idcal < 0) {id1 = 0; id2 = static_cast<int>(detectors.size());}
   else           {id1 = idcal; id2 = id1+1;}
@@ -401,7 +401,7 @@ int CaloTrkProcessing::detLevels(const G4VTouchable* touch) const {
 G4LogicalVolume* CaloTrkProcessing::detLV(const G4VTouchable* touch,
 					  int currentlevel) const {
 
-  G4LogicalVolume* lv=0;
+  G4LogicalVolume* lv=nullptr;
   if (touch) {
     int level = ((touch->GetHistoryDepth())+1);
     if (level > 0 && level >= currentlevel) {
@@ -422,7 +422,7 @@ void CaloTrkProcessing::detectorLevel(const G4VTouchable* touch, int& level,
     for (int ii = 0; ii < level; ii++) {
       int i      = level - ii - 1;
       G4VPhysicalVolume* pv = touch->GetVolume(i);
-      if (pv != 0) 
+      if (pv != nullptr) 
 	name[ii] = pv->GetName();
       else
 	name[ii] = unknown;

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -166,10 +166,10 @@ ECalSD::ECalSD(const std::string& name, const DDCompactView & cpv,
 }
 
 ECalSD::~ECalSD() {
-  if (numberingScheme) delete numberingScheme;
+  delete numberingScheme;
 }
 
-double ECalSD::getEnergyDeposit(G4Step * aStep) {
+double ECalSD::getEnergyDeposit(const G4Step * aStep) {
   
   double edep = aStep->GetTotalEnergyDeposit();
   if(edep <= 0.0) { return 0.0; }
@@ -241,7 +241,7 @@ double ECalSD::getEnergyDeposit(G4Step * aStep) {
   return edep;
 }
 
-int ECalSD::getTrackID(G4Track* aTrack) {
+int ECalSD::getTrackID(const G4Track* aTrack) {
 
   int  primaryID(0);
   bool flag(false);
@@ -261,7 +261,7 @@ int ECalSD::getTrackID(G4Track* aTrack) {
   return primaryID;
 }
 
-uint16_t ECalSD::getDepth(G4Step * aStep) {
+uint16_t ECalSD::getDepth(const G4Step * aStep) {
 
   uint16_t depth  = any(useDepth1,theLogicalVolume) ? 1 : (any(useDepth2,theLogicalVolume) ? 2 : 0);
   if (storeRL) {
@@ -282,7 +282,7 @@ uint16_t ECalSD::getDepth(G4Step * aStep) {
   return depth;
 }
 
-uint16_t ECalSD::getRadiationLength(G4Step * aStep) {
+uint16_t ECalSD::getRadiationLength(const G4Step * aStep) {
   
   uint16_t thisX0 = 0;
 #ifdef EDM_ML_DEBUG
@@ -317,7 +317,7 @@ uint16_t ECalSD::getRadiationLength(G4Step * aStep) {
   return thisX0;
 }
 
-uint16_t ECalSD::getLayerIDForTimeSim(G4Step * aStep) 
+uint16_t ECalSD::getLayerIDForTimeSim(const G4Step * aStep) 
 {
   const float layerSize = (float)(1*cm); //layer size in cm
   if (!isEB && !isEE)  return 0;
@@ -327,7 +327,7 @@ uint16_t ECalSD::getLayerIDForTimeSim(G4Step * aStep)
   return (int)detz/layerSize;
 }
 
-uint32_t ECalSD::setDetUnitId(G4Step * aStep) { 
+uint32_t ECalSD::setDetUnitId(const G4Step * aStep) { 
   if (numberingScheme == nullptr) {
     return EBDetId(1,1)();
   } else {
@@ -336,7 +336,7 @@ uint32_t ECalSD::setDetUnitId(G4Step * aStep) {
   }
 }
 
-void ECalSD::setNumberingScheme(EcalNumberingScheme* scheme) {
+void ECalSD::setNumberingScheme(const EcalNumberingScheme* scheme) {
   if (scheme != nullptr && scheme != numberingScheme) {
     edm::LogInfo("EcalSim") << "EcalSD: updates numbering scheme for " 
 			    << GetName();

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -58,7 +58,7 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
   hcalConstants(nullptr), numberingFromDDD(nullptr), numberingScheme(nullptr), showerLibrary(nullptr), 
   hfshower(nullptr), showerParam(nullptr), showerPMT(nullptr), showerBundle(nullptr), 
   m_HBDarkening(nullptr), m_HEDarkening(nullptr),
-  m_HFDarkening(nullptr), hcalTestNS_(nullptr), isPametrized(false), depth_(1) {
+  m_HFDarkening(nullptr), hcalTestNS_(nullptr), isParametrized(false), depth_(1) {
 
   //static SimpleConfigurable<double> bk1(0.013, "HCalSD:BirkC1");
   //static SimpleConfigurable<double> bk2(0.0568,"HCalSD:BirkC2");
@@ -131,7 +131,6 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
   setNumberingScheme(scheme);
 
   const G4LogicalVolumeStore * lvs = G4LogicalVolumeStore::GetInstance();
-  std::vector<G4LogicalVolume *>::const_iterator lvcite;
   G4LogicalVolume* lv;
   std::string attribute, value;
   if (useHF) {
@@ -156,12 +155,13 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
 			    << " elements";
     for (unsigned int i=0; i < hfNames.size(); ++i) {
       G4String namv = hfNames[i];
-      lv            = nullptr;
-      for(lvcite=lvs->begin(); lvcite!=lvs->end(); lvcite++) 
-	if((*lvcite)->GetName()==namv) {
-	  lv = (*lvcite);
+      lv = nullptr;
+      for(auto & lvol : *lvs) {
+	if(lvol->GetName()==namv) {
+          lv = lvol;
 	  break;
 	}
+      }
       hfLV.push_back(lv);
       int level = static_cast<int>(temp[i]);
       hfLevels.push_back(level);
@@ -180,9 +180,9 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
     for (unsigned int i=0; i<fibreNames.size(); ++i) {
       G4String namv = fibreNames[i];
       lv            = nullptr;
-      for (lvcite = lvs->begin(); lvcite != lvs->end(); ++lvcite) {
-        if ((*lvcite)->GetName() == namv) {
-          lv = (*lvcite);
+      for (auto & lvol : *lvs) {
+        if (lvol->GetName() == namv) {
+          lv = lvol;
           break;
         }
       }
@@ -202,11 +202,12 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
     for (unsigned int i=0; i<pmtNames.size(); ++i)  {
       G4String namv = pmtNames[i];
       lv            = nullptr;
-      for (lvcite = lvs->begin(); lvcite != lvs->end(); ++lvcite) 
-        if ((*lvcite)->GetName() == namv) {
-	  lv = (*lvcite);
+      for (auto & lvol : *lvs) {
+        if (lvol->GetName() == namv) {
+	  lv = lvol;
 	  break;
 	}
+      }
       pmtLV.push_back(lv);
       edm::LogInfo("HcalSim") << "HCalSD:  (" << i << ") " << pmtNames[i]
                               << " LV " << pmtLV[i];
@@ -217,20 +218,20 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
     value     = "HFFibreBundleStraight";
     DDSpecificsMatchesValueFilter filter4{DDValue(attribute,value,0)};
     DDFilteredView fv4(cpv,filter4);
-    std::vector<G4String> fibreNames = getNames(fv4);
+    std::vector<G4String> fibreBNames = getNames(fv4);
     edm::LogInfo("HcalSim") << "HCalSD: Names to be tested for " << attribute
-                            << " = " << value << " have " << fibreNames.size()
+                            << " = " << value << " have " << fibreBNames.size()
                             << " entries";
-    for (unsigned int i=0; i<fibreNames.size(); ++i) {
-      G4String namv = fibreNames[i];
+    for (unsigned int i=0; i<fibreBNames.size(); ++i) {
+      G4String namv = fibreBNames[i];
       lv            = nullptr;
-      for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++) 
-        if ((*lvcite)->GetName() == namv) {
-	  lv = (*lvcite);
-	  break;
+      for (auto & lvol : *lvs) {
+        if (lvol->GetName() == namv) {
+	  lv = lvol;
 	}
+      }
       fibre1LV.push_back(lv);
-      edm::LogInfo("HcalSim") << "HCalSD:  (" << i << ") " << fibreNames[i]
+      edm::LogInfo("HcalSim") << "HCalSD:  (" << i << ") " << fibreBNames[i]
                               << " LV " << fibre1LV[i];
     }
 
@@ -238,20 +239,20 @@ HCalSD::HCalSD(const std::string& name, const DDCompactView & cpv,
     value     = "HFFibreBundleConical";
     DDSpecificsMatchesValueFilter filter5{DDValue(attribute,value,0)};
     DDFilteredView fv5(cpv,filter5);
-    fibreNames = getNames(fv5);
+    std::vector<G4String> fibreCNames = getNames(fv5);
     edm::LogInfo("HcalSim") << "HCalSD: Names to be tested for " << attribute
-			    << " = " << value << " have " << fibreNames.size() 
+			    << " = " << value << " have " << fibreCNames.size() 
 			    << " entries";
-    for (unsigned int i=0; i<fibreNames.size(); ++i) {
-      G4String namv = fibreNames[i];
+    for (unsigned int i=0; i<fibreCNames.size(); ++i) {
+      G4String namv = fibreCNames[i];
       lv            = nullptr;
-      for (lvcite = lvs->begin(); lvcite != lvs->end(); ++lvcite) 
-	if ((*lvcite)->GetName() == namv) {
-	  lv = (*lvcite);
-	  break;
+      for (auto & lvol : *lvs) {
+        if (lvol->GetName() == namv) {
+	  lv = lvol;
 	}
+      }
       fibre2LV.push_back(lv);
-      edm::LogInfo("HcalSim") << "HCalSD:  (" << i << ") " << fibreNames[i]
+      edm::LogInfo("HcalSim") << "HCalSD:  (" << i << ") " << fibreCNames[i]
                               << " LV " << fibre2LV[i];
     }
     if (!fibre1LV.empty() || !fibre2LV.empty()) {
@@ -369,7 +370,7 @@ bool HCalSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
   // should be killed
   if (isItHF(aStep)) {
     double weight(1.0);
-    isPametrized = false;
+    isParametrized = false;
     if (m_HFDarkening) {
       G4ThreeVector hitPoint = aStep->GetPreStepPoint()->GetPosition();
       double r = hitPoint.perp()/CLHEP::cm;
@@ -399,7 +400,7 @@ bool HCalSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 			  <<")";
 #endif
       getFromParam(aStep, weight);
-      if(isPametrized) { killTracks(aStep); }
+      if(isParametrized) { killTracks(aStep); }
 #ifdef EDM_ML_DEBUG
       LogDebug("HcalSim") << "HCalSD: " << getNumberOfHits() 
 			  << " hits afterParamS*";
@@ -414,7 +415,7 @@ bool HCalSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 			    << aStep->GetTrack()->GetDefinition()->GetParticleName() << ")";
 #endif
 	getFromLibrary(aStep, weight);
-	if(isPametrized) { killTracks(aStep); }
+	if(isParametrized) { killTracks(aStep); }
       } else if (isItFibre(lv)) {
 #ifdef EDM_ML_DEBUG
 	LogDebug("HcalSim") << "HCalSD: Hit at Fibre in LV: " << lv->GetName()
@@ -800,7 +801,7 @@ void HCalSD::getFromLibrary (const G4Step* aStep, double weight) {
   bool isEM = (pdg == hfPGDcodes[0] || pdg == hfPGDcodes[1] || pdg == hfPGDcodes[2]);
 
   std::vector<HFShowerLibrary::Hit> hits = 
-    showerLibrary->getHits(aStep, isPametrized, weight, false);
+    showerLibrary->getHits(aStep, isParametrized, weight, false);
 
   double etrack    = preStepPoint->GetKineticEnergy();
   int    primaryID = setTrackID(aStep);
@@ -883,11 +884,11 @@ void HCalSD::hitForFibre (const G4Step* aStep, double weight) {
 			  << " of " << preStepPoint->GetKineticEnergy()/GeV 
 			  << " GeV in detector type " << det;
 #endif
-  for (unsigned int i=0; i<hits.size(); ++i) {
-    G4ThreeVector hitPoint = hits[i].position;
+  for (auto & ahit : hits) {
+    G4ThreeVector hitPoint = ahit.position;
     if (isItinFidVolume (hitPoint)) {
-      int depth              = hits[i].depth;
-      double time            = hits[i].time;
+      int depth              = ahit.depth;
+      double time            = ahit.time;
       unsigned int unitID = setDetUnitId(det, hitPoint, depth);
       currentID.setID(unitID, time, primaryID, 0);
 #ifdef plotDebug
@@ -906,17 +907,17 @@ void HCalSD::hitForFibre (const G4Step* aStep, double weight) {
 
 void HCalSD::getFromParam (const G4Step* aStep, double weight) {
 
-  std::vector<HFShowerParam::Hit> hits = showerParam->getHits(aStep, weight, isPametrized);
-  int nHit = static_cast<int>(hits.size());
+  std::vector<HFShowerParam::Hit> hits = 
+    showerParam->getHits(aStep, weight, isParametrized);
 
-  if (nHit > 0) {
+  if (!hits.empty()) {
     preStepPoint  = aStep->GetPreStepPoint();
     posGlobal     = preStepPoint->GetPosition();
     int primaryID = setTrackID(aStep);
    
     int det   = 5;
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalSim") << "HCalSD::getFromParam " << nHit << " hits for " 
+    edm::LogInfo("HcalSim") << "HCalSD::getFromParam " << hits.size() << " hits for " 
                             << GetName() << " of " << primaryID << " with " 
                             <<  aStep->GetTrack()->GetDefinition()->GetParticleName()
                             << " of " << preStepPoint->GetKineticEnergy()/GeV 

--- a/SimG4CMS/Calo/src/HFCherenkov.cc
+++ b/SimG4CMS/Calo/src/HFCherenkov.cc
@@ -79,7 +79,7 @@ int HFCherenkov::computeNPhTrapped(double pBeta,
   return n_photons;
 }
 
-int HFCherenkov::computeNPE(G4Step * aStep, G4ParticleDefinition* pDef,
+int HFCherenkov::computeNPE(const G4Step * aStep, const G4ParticleDefinition* pDef,
 			    double pBeta, double u, double v, double w,
 			    double step_length, double zFiber,
 			    double dose, int npe_Dose) {
@@ -108,7 +108,7 @@ int HFCherenkov::computeNPE(G4Step * aStep, G4ParticleDefinition* pDef,
     return 0;
   } else if (nbOfPhotons > 0) {
     G4StepPoint * preStepPoint = aStep->GetPreStepPoint();
-    G4TouchableHandle theTouchable = preStepPoint->GetTouchableHandle();
+    const G4TouchableHandle& theTouchable = preStepPoint->GetTouchableHandle();
     G4ThreeVector localprepos = theTouchable->GetHistory()->
       GetTopTransform().TransformPoint(aStep->GetPreStepPoint()->GetPosition());
     G4ThreeVector localpostpos = theTouchable->GetHistory()->
@@ -226,7 +226,7 @@ int HFCherenkov::computeNPE(G4Step * aStep, G4ParticleDefinition* pDef,
   return npe;
 }
 
-int HFCherenkov::computeNPEinPMT(G4ParticleDefinition* pDef, double pBeta, 
+int HFCherenkov::computeNPEinPMT(const G4ParticleDefinition* pDef, double pBeta, 
                                  double u, double v, double w, 
                                  double step_length){
   clearVectors();

--- a/SimG4CMS/Calo/src/HFFibre.cc
+++ b/SimG4CMS/Calo/src/HFFibre.cc
@@ -74,7 +74,7 @@ HFFibre::HFFibre(const std::string & name, const DDCompactView & cpv,
 
 HFFibre::~HFFibre() {}
 
-void HFFibre::initRun(HcalDDDSimConstants* hcons) {
+void HFFibre::initRun(const HcalDDDSimConstants* hcons) {
 
   // Now geometry parameters
   gpar      = hcons->getGparHF();

--- a/SimG4CMS/Calo/src/HFGflash.cc
+++ b/SimG4CMS/Calo/src/HFGflash.cc
@@ -88,7 +88,7 @@ HFGflash::~HFGflash() {
 }
 
 
-std::vector<HFGflash::Hit> HFGflash::gfParameterization(G4Step * aStep,bool & ok,bool onlyLong) {
+std::vector<HFGflash::Hit> HFGflash::gfParameterization(const G4Step * aStep,bool & ok,bool onlyLong) {
   double tempZCalo = 26;  // Gflash::Z[jCalorimeter]
   double hfcriticalEnergy = 0.021;  // Gflash::criticalEnergy
 

--- a/SimG4CMS/Calo/src/HFShower.cc
+++ b/SimG4CMS/Calo/src/HFShower.cc
@@ -183,7 +183,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, double weight
   return std::move(hits);
 } 
 
-std::vector<HFShower::Hit> HFShower::getHits(G4Step * aStep, 
+std::vector<HFShower::Hit> HFShower::getHits(const G4Step * aStep, 
                                              bool forLibraryProducer,
 				             double zoffset) {
 

--- a/SimG4CMS/Calo/src/HFShowerFibreBundle.cc
+++ b/SimG4CMS/Calo/src/HFShowerFibreBundle.cc
@@ -82,7 +82,7 @@ HFShowerFibreBundle::~HFShowerFibreBundle() {
   delete cherenkov2;
 }
 
-void HFShowerFibreBundle::initRun(G4ParticleTable *, HcalDDDSimConstants* hcons) {
+void HFShowerFibreBundle::initRun(const G4ParticleTable *, const HcalDDDSimConstants* hcons) {
 
   // Special Geometry parameters
   rTable   = hcons->getRTableHF();
@@ -93,11 +93,11 @@ void HFShowerFibreBundle::initRun(G4ParticleTable *, HcalDDDSimConstants* hcons)
                              << rTable[ig]/cm << " cm";
 }
 
-double HFShowerFibreBundle::getHits(G4Step * aStep, bool type) {
+double HFShowerFibreBundle::getHits(const G4Step * aStep, bool type) {
 
   indexR = indexF = -1;
 
-  G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
+  const G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch   = preStepPoint->GetTouchable();
   int                 boxNo   = touch->GetReplicaNumber(1);
   int                 pmtNo   = touch->GetReplicaNumber(0);
@@ -118,8 +118,8 @@ double HFShowerFibreBundle::getHits(G4Step * aStep, bool type) {
 
   double photons = 0;
   if (indexR >= 0 && indexF > 0) {
-    G4Track *aTrack = aStep->GetTrack();
-    G4ParticleDefinition *particleDef = aTrack->GetDefinition();
+    const G4Track *aTrack = aStep->GetTrack();
+    const G4ParticleDefinition *particleDef = aTrack->GetDefinition();
     double stepl = aStep->GetStepLength();
     double beta  = preStepPoint->GetBeta();
     G4ThreeVector pDir = aTrack->GetDynamicParticle()->GetMomentumDirection();

--- a/SimG4CMS/Calo/src/HFShowerLibrary.cc
+++ b/SimG4CMS/Calo/src/HFShowerLibrary.cc
@@ -128,14 +128,14 @@ HFShowerLibrary::HFShowerLibrary(const std::string & name, const DDCompactView &
 
 HFShowerLibrary::~HFShowerLibrary() {
   if (hf)     hf->Close();
-  delete   fibre;
-  fibre  = nullptr;
+  delete fibre;
   delete photo;
 }
 
-void HFShowerLibrary::initRun(G4ParticleTable * theParticleTable,
-			      HcalDDDSimConstants* hcons) {
+void HFShowerLibrary::initRun(const G4ParticleTable *,
+			      const HcalDDDSimConstants* hcons) {
 
+  G4ParticleTable * theParticleTable = G4ParticleTable::GetParticleTable();
   if (fibre) fibre->initRun(hcons);
 
   G4String parName;
@@ -186,7 +186,7 @@ void HFShowerLibrary::initRun(G4ParticleTable * theParticleTable,
 
 
 std::vector<HFShowerLibrary::Hit> HFShowerLibrary::getHits(const G4Step * aStep,
-							   bool,
+							   bool& ok ,
 							   double weight,
 							   bool onlyLong) {
 
@@ -218,7 +218,6 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::getHits(const G4Step * aStep,
 
   double tSlice = (postStepPoint->GetGlobalTime())/nanosecond;
   double pin    = preStepPoint->GetTotalEnergy();
-  bool ok;
 
   return std::move(fillHits(hitPoint,momDir,parCode,pin,ok,weight,tSlice,onlyLong));
 }

--- a/SimG4CMS/Calo/src/HFShowerPMT.cc
+++ b/SimG4CMS/Calo/src/HFShowerPMT.cc
@@ -74,7 +74,7 @@ HFShowerPMT::~HFShowerPMT() {
   if (cherenkov) delete cherenkov;
 }
 
-void HFShowerPMT::initRun(G4ParticleTable *, HcalDDDSimConstants* hcons) {
+void HFShowerPMT::initRun(const G4ParticleTable *, const HcalDDDSimConstants* hcons) {
 
   // Special Geometry parameters
   rTable   = hcons->getRTableHF();
@@ -85,11 +85,11 @@ void HFShowerPMT::initRun(G4ParticleTable *, HcalDDDSimConstants* hcons) {
                              << rTable[ig]/cm << " cm";
 }
 
-double HFShowerPMT::getHits(G4Step * aStep) {
+double HFShowerPMT::getHits(const G4Step * aStep) {
 
   indexR = indexF = -1;
 
-  G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
+  const G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch   = preStepPoint->GetTouchable();
   int                 boxNo   = touch->GetReplicaNumber(2);
   int                 pmtNo   = touch->GetReplicaNumber(1);
@@ -111,8 +111,8 @@ double HFShowerPMT::getHits(G4Step * aStep) {
 
   double photons = 0;
   if (indexR >= 0 && indexF > 0) {
-    G4Track *aTrack = aStep->GetTrack();
-    G4ParticleDefinition *particleDef = aTrack->GetDefinition();
+    const G4Track *aTrack = aStep->GetTrack();
+    const G4ParticleDefinition *particleDef = aTrack->GetDefinition();
     double stepl = aStep->GetStepLength();
     double beta  = preStepPoint->GetBeta();
     G4ThreeVector pDir = aTrack->GetDynamicParticle()->GetMomentumDirection();

--- a/SimG4CMS/Calo/src/HFShowerParam.cc
+++ b/SimG4CMS/Calo/src/HFShowerParam.cc
@@ -94,8 +94,9 @@ HFShowerParam::~HFShowerParam() {
   delete showerLibrary;
 }
 
-void HFShowerParam::initRun(G4ParticleTable * theParticleTable,
-			    HcalDDDSimConstants* hcons) {
+void HFShowerParam::initRun(const G4ParticleTable *,
+			    const HcalDDDSimConstants* hcons) {
+  G4ParticleTable * theParticleTable = G4ParticleTable::GetParticleTable();
   emPDG = theParticleTable->FindParticle("e-")->GetPDGEncoding();
   epPDG = theParticleTable->FindParticle("e+")->GetPDGEncoding();
   gammaPDG = theParticleTable->FindParticle("gamma")->GetPDGEncoding();
@@ -114,8 +115,8 @@ void HFShowerParam::initRun(G4ParticleTable * theParticleTable,
                              << gpar[ig]/cm << " cm";
 }
 
-std::vector<HFShowerParam::Hit> HFShowerParam::getHits(G4Step * aStep, 
-						       double weight) {
+std::vector<HFShowerParam::Hit> HFShowerParam::getHits(const G4Step * aStep, 
+						       double weight, bool& kill) {
 
   const G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
   G4Track * track    = aStep->GetTrack();   
@@ -162,7 +163,7 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(G4Step * aStep,
   if (isEM || other) {
     // Leave out the last part
     double edep = 0.;
-    bool   kill = false;
+    kill = false;
     if ((!trackEM) && ((zz<(gpar[1]-gpar[2])) || parametrizeLast) && (!other)){
       edep = pin;
       kill = true;
@@ -181,21 +182,21 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(G4Step * aStep,
     if (edep > 0) {
       if ((showerLibrary || gflash) && kill && pin > edMin && (!other)) {
         if (showerLibrary) {
-          std::vector<HFShowerLibrary::Hit> hitSL = 
-	    showerLibrary->getHits(aStep,isEM,weight,onlyLong);
-          for (unsigned int i=0; i<hitSL.size(); i++) {
-            bool ok = true;
 #ifdef DebugLog
-            edm::LogInfo("HFShower") << "HFShowerParam: getHits applyFidCut = " << applyFidCut;
+	  edm::LogInfo("HFShower") << "HFShowerParam: getHits applyFidCut = " << applyFidCut;
 #endif
+          std::vector<HFShowerLibrary::Hit> hitSL = 
+	    showerLibrary->getHits(aStep, kill, weight, onlyLong);
+          for (auto & ahit : hitSL) {
+            bool ok = true;
             if (applyFidCut) { // @@ For showerlibrary no z-cut for Short (no z)
-              int npmt = HFFibreFiducial:: PMTNumber(hitSL[i].position);
+              int npmt = HFFibreFiducial::PMTNumber(ahit.position);
               if (npmt <= 0) ok = false;
             } 
             if (ok) {
-              hit.position = hitSL[i].position;
-              hit.depth    = hitSL[i].depth;
-              hit.time     = hitSL[i].time;
+              hit.position = ahit.position;
+              hit.depth    = ahit.depth;
+              hit.time     = ahit.time;
               hit.edep     = 1;
               hits.push_back(hit);
 #ifdef plotDebug
@@ -224,11 +225,11 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(G4Step * aStep,
             }
           }
         } else { // GFlash clusters with known z
-          std::vector<HFGflash::Hit>hitSL=gflash->gfParameterization(aStep,kill, onlyLong);
-          for (unsigned int i=0; i<hitSL.size(); ++i) {
+          std::vector<HFGflash::Hit> hitSL = gflash->gfParameterization(aStep,kill, onlyLong);
+          for (auto & ahit : hitSL) {
             bool ok = true;
-            G4ThreeVector pe_effect(hitSL[i].position.x(), hitSL[i].position.y(),
-                                    hitSL[i].position.z());
+            G4ThreeVector pe_effect(ahit.position.x(), ahit.position.y(),
+                                    ahit.position.z());
             double zv  = std::abs(pe_effect.z()) - gpar[4];
             //depth
             int depth    = 1;
@@ -292,14 +293,14 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(G4Step * aStep,
 	      if (r2 < weight) {
 		double time = fibre->tShift(localPoint,depth,0);
 
-		hit.position = hitSL[i].position;
+		hit.position = ahit.position;
 		hit.depth    = depth;
-		hit.time     = time + hitSL[i].time;
+		hit.time     = time + ahit.time;
 		hit.edep     = 1;
 		hits.push_back(hit);
 #ifdef plotDebug
 		if (fillHisto) {
-		  em_long_gflash->Fill(pe_effect.z()/cm, hitSL[i].edep);
+		  em_long_gflash->Fill(pe_effect.z()/cm, ahit.edep);
 		  hzvem->Fill(zv);
 		  double sq = sqrt(pow(hit.position.x()/cm,2)+pow(hit.position.y()/cm,2));
 		  double zp = hit.position.z()/cm;
@@ -381,21 +382,6 @@ std::vector<HFShowerParam::Hit> HFShowerParam::getHits(G4Step * aStep,
                                                 <<track->GetDefinition()->GetParticleName()
                                                 << " time " << hit.time;
       }
-#endif
-      if (kill) {
-        track->SetTrackStatus(fStopAndKill);
-        G4TrackVector tv = *(aStep->GetSecondary());
-        for (unsigned int kk=0; kk<tv.size(); ++kk) {
-          if (tv[kk]->GetVolume() == preStepPoint->GetPhysicalVolume())
-	    tv[kk]->SetTrackStatus(fStopAndKill);
-        }
-      }
-#ifdef DebugLog
-      edm::LogInfo("HFShower") << "HFShowerParam: getHits kill (" << kill
-                               << ") track " << track->GetTrackID() 
-                               << " at " << hitPoint
-                               << " and deposit " << edep << " " << hits.size()
-                               << " times" << " ZZ " << zz << " " << gpar[0];
 #endif
     }
   }

--- a/SimG4CMS/Calo/src/HcalNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HcalNumberingScheme.cc
@@ -5,8 +5,8 @@
 #include "SimG4CMS/Calo/interface/HcalNumberingScheme.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include <iostream>
 
 //#define EDM_ML_DEBUG
@@ -16,10 +16,9 @@ HcalNumberingScheme::HcalNumberingScheme() : CaloNumberingScheme(0) {
 }
 
 HcalNumberingScheme::~HcalNumberingScheme() {
-  edm::LogInfo("HcalSim") << "Deleting HcalNumberingScheme" << std::endl;
 }
 
-uint32_t HcalNumberingScheme::getUnitID(const HcalNumberingFromDDD::HcalID& id){
+uint32_t HcalNumberingScheme::getUnitID(const HcalNumberingFromDDD::HcalID& id) const{
 
   int zside = 2*(id.zside) - 1;
   int etaR  = zside*(id.etaR);
@@ -36,8 +35,7 @@ uint32_t HcalNumberingScheme::getUnitID(const HcalNumberingFromDDD::HcalID& id){
 			  << " zside = " << id.zside << " eta/R = " << id.etaR 
 			  << " phi = " << id.phis << " oldphi = " << id.phi
 			  << " packed index = 0x" << std::hex << index 
-			  << std::dec << " " << hid << " " << HcalDetId(index)
-			  << std::endl;
+			  << std::dec << " " << hid << " " << HcalDetId(index);
 #endif
   return index;
 

--- a/SimG4CMS/Calo/src/HcalTestNS.cc
+++ b/SimG4CMS/Calo/src/HcalTestNS.cc
@@ -22,7 +22,9 @@ HcalTestNS::HcalTestNS(const edm::EventSetup* iSetup) {
   scheme_ = new HcalTestNumberingScheme(false);
 }
 
-HcalTestNS::~HcalTestNS() {}
+HcalTestNS::~HcalTestNS() {
+  delete scheme_;
+}
 
 bool HcalTestNS::compare(HcalNumberingFromDDD::HcalID const& tmp, 
 			 uint32_t const& id) {

--- a/SimG4CMS/Calo/src/HcalTestNS.cc
+++ b/SimG4CMS/Calo/src/HcalTestNS.cc
@@ -1,5 +1,6 @@
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/HcalCommonData/interface/HcalHitRelabeller.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "SimG4CMS/Calo/interface/HcalNumberingScheme.h"
@@ -16,8 +17,9 @@ HcalTestNS::HcalTestNS(const edm::EventSetup* iSetup) {
     hcons_ = (HcalDDDRecConstants*)(&(*hdc));
   } else {
     edm::LogError("HcalSim") << "HcalTestNS : Cannot find HcalDDDRecConstant";
-    hcons_ = 0;
+    hcons_ = nullptr;
   }
+  scheme_ = new HcalTestNumberingScheme(false);
 }
 
 HcalTestNS::~HcalTestNS() {}
@@ -25,8 +27,7 @@ HcalTestNS::~HcalTestNS() {}
 bool HcalTestNS::compare(HcalNumberingFromDDD::HcalID const& tmp, 
 			 uint32_t const& id) {
 
-  HcalNumberingScheme* scheme = dynamic_cast<HcalNumberingScheme*>(new HcalTestNumberingScheme(false));
-  uint32_t id0 = scheme->getUnitID(tmp);
+  uint32_t id0 = scheme_->getUnitID(tmp);
   DetId    hid = HcalHitRelabeller::relabel(id0,hcons_);
   bool     ok  =  (id == hid.rawId());
 #ifdef EDM_ML_DEBUG

--- a/SimG4CMS/Calo/src/HcalTestNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HcalTestNumberingScheme.cc
@@ -5,6 +5,7 @@
 #include "SimG4CMS/Calo/interface/HcalTestNumberingScheme.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <iostream>
 
@@ -17,11 +18,10 @@ HcalTestNumberingScheme::HcalTestNumberingScheme(bool forTB) :
 }
 
 HcalTestNumberingScheme::~HcalTestNumberingScheme() {
-  edm::LogInfo("HcalSim") << "Deleting HcalTestNumberingScheme" << std::endl;
 }
 
 uint32_t HcalTestNumberingScheme::getUnitID(const HcalNumberingFromDDD::HcalID& 
-					    id) {
+					    id) const {
 
   //pack it into an integer
   uint32_t index = 0;
@@ -46,7 +46,7 @@ uint32_t HcalTestNumberingScheme::getUnitID(const HcalNumberingFromDDD::HcalID&
 			  << " depth/lay = " << id.depth << "/" << id.lay 
 			  << " zside = " << id.zside << " eta/R = " << id.etaR 
 			  << " phi = " << id.phis << " packed index = 0x" 
-			  << std::hex << index << std::dec << std::endl;
+			  << std::hex << index << std::dec;
 #endif
   return index;
 

--- a/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
+++ b/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
@@ -20,40 +20,39 @@ class DreamSD : public CaloSD {
 
 public:    
 
-  DreamSD(G4String, const DDCompactView &, const SensitiveDetectorCatalog &,
+  DreamSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	  edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~DreamSD() {}
-  virtual bool   ProcessHits(G4Step * step,G4TouchableHistory * tHistory);
-  virtual uint32_t setDetUnitId(G4Step*);
+  ~DreamSD() override {}
+  bool   ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
+  uint32_t setDetUnitId(const G4Step*) override;
 
 protected:
 
-  virtual G4bool getStepInfo(G4Step* aStep);
-  virtual void   initRun();
+  G4bool getStepInfo(const G4Step* aStep) override;
+  void   initRun() override;
 
 private:    
 
   typedef std::pair<double,double> Doubles;
   typedef std::map<G4LogicalVolume*,Doubles> DimensionMap;
 
-  void           initMap(G4String, const DDCompactView &);
-  double         curve_LY(G4Step*, int); 
-  const double   crystalLength(G4LogicalVolume*) const;
-  const double   crystalWidth(G4LogicalVolume*) const;
+  void     initMap(const G4String&, const DDCompactView &);
+  double   curve_LY(); 
+  double   crystalLength() const;
+  double   crystalWidth() const;
 
   /// Returns the total energy due to Cherenkov radiation
-  double         cherenkovDeposit_( G4Step* aStep );
+  double         cherenkovDeposit_(const G4Step* aStep );
   /// Returns average number of photons created by track
-  double getAverageNumberOfPhotons_(const double charge,
-				    const double beta,
+  double getAverageNumberOfPhotons_(double charge,
+				    double beta,
 				    const G4Material* aMaterial,
-				    G4MaterialPropertyVector* rIndex );
+				    const G4MaterialPropertyVector* rIndex );
   /// Returns energy deposit for a given photon
   double getPhotonEnergyDeposit_( const G4ParticleMomentum& p, 
-				  const G4ThreeVector& x,
-				  const G4Step* aStep );
+				  const G4ThreeVector& x);
   /// Sets material properties at run-time...
-  bool setPbWO2MaterialProperties_( G4Material* aMaterial );
+  bool setPbWO2MaterialProperties_(G4Material* aMaterial );
 
   bool         useBirk, doCherenkov_, readBothSide_;
   double       birk1, birk2, birk3;

--- a/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
+++ b/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
@@ -239,7 +239,7 @@ double DreamSD::curve_LY() {
 					preStepPoint->GetTouchable());
   double crlength = crystalLength();
   double localz   = localPoint.x();
-  double dapd = std::abs(0.5 * crlength - side*localz); // Distance from closest APD
+  double dapd = 0.5 * crlength - side*localz; // Distance from closest APD
   if (dapd >= -0.1 || dapd <= crlength+0.1) {
     if (dapd <= 100.)
       weight = 1.0 + slopeLY - dapd * 0.01 * slopeLY;
@@ -270,7 +270,7 @@ double DreamSD::crystalLength() const {
 double DreamSD::crystalWidth() const {
 
   auto ite = xtalLMap.find(theLogicalVolume);
-  return (ite == xtalLMap.end()) ? 0.0 : ite->second.second;
+  return (ite == xtalLMap.end()) ? -1.0 : ite->second.second;
 }
 
 //________________________________________________________________________________________

--- a/SimG4CMS/EcalTestBeam/interface/EcalTBH4BeamSD.h
+++ b/SimG4CMS/EcalTestBeam/interface/EcalTBH4BeamSD.h
@@ -21,11 +21,11 @@ class EcalTBH4BeamSD : public CaloSD {
 
 public:    
 
-  EcalTBH4BeamSD(G4String, const DDCompactView &, const SensitiveDetectorCatalog &,
+  EcalTBH4BeamSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 		 edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~EcalTBH4BeamSD();
-  virtual double getEnergyDeposit(G4Step*);
-  virtual uint32_t setDetUnitId(G4Step* step);
+  ~EcalTBH4BeamSD() override;
+  double getEnergyDeposit(const G4Step*) override;
+  uint32_t setDetUnitId(const G4Step* step) override;
   void setNumberingScheme(EcalNumberingScheme* scheme);
 
 private:    

--- a/SimG4CMS/EcalTestBeam/src/EcalTBH4BeamSD.cc
+++ b/SimG4CMS/EcalTestBeam/src/EcalTBH4BeamSD.cc
@@ -19,11 +19,11 @@
 
 #include "G4SystemOfUnits.hh"
 
-EcalTBH4BeamSD::EcalTBH4BeamSD(G4String name, const DDCompactView & cpv,
+EcalTBH4BeamSD::EcalTBH4BeamSD(const std::string& iname, const DDCompactView & cpv,
 			       const SensitiveDetectorCatalog & clg,
 			       edm::ParameterSet const & p, 
 			       const SimTrackManager* manager) : 
-  CaloSD(name, cpv, clg, p, manager), numberingScheme(0) {
+  CaloSD(iname, cpv, clg, p, manager), numberingScheme(nullptr) {
   
   edm::ParameterSet m_EcalTBH4BeamSD = p.getParameter<edm::ParameterSet>("EcalTBH4BeamSD");
   useBirk= m_EcalTBH4BeamSD.getParameter<bool>("UseBirkLaw");
@@ -31,8 +31,8 @@ EcalTBH4BeamSD::EcalTBH4BeamSD(G4String name, const DDCompactView & cpv,
   birk2  = m_EcalTBH4BeamSD.getParameter<double>("BirkC2");
   birk3  = m_EcalTBH4BeamSD.getParameter<double>("BirkC3");
 
-  EcalNumberingScheme* scheme=0;
-  if     (name == "EcalTBH4BeamHits") { 
+  EcalNumberingScheme* scheme=nullptr;
+  if (iname == "EcalTBH4BeamHits") { 
     scheme = dynamic_cast<EcalNumberingScheme*>(new EcalHodoscopeNumberingScheme());
   } 
   else {edm::LogWarning("EcalTBSim") << "EcalTBH4BeamSD: ReadoutName not supported\n";}
@@ -47,14 +47,11 @@ EcalTBH4BeamSD::EcalTBH4BeamSD(G4String name, const DDCompactView & cpv,
 }
 
 EcalTBH4BeamSD::~EcalTBH4BeamSD() {
-  if (numberingScheme) delete numberingScheme;
+  delete numberingScheme;
 }
 
-double EcalTBH4BeamSD::getEnergyDeposit(G4Step * aStep) {
+double EcalTBH4BeamSD::getEnergyDeposit(const G4Step * aStep) {
   
-  if (aStep == NULL) {
-    return 0;
-  } else {
     preStepPoint        = aStep->GetPreStepPoint();
     G4String nameVolume = preStepPoint->GetPhysicalVolume()->GetName();
 
@@ -66,23 +63,21 @@ double EcalTBH4BeamSD::getEnergyDeposit(G4Step * aStep) {
 			<<" Light Collection Efficiency " << weight 
 			<< " Weighted Energy Deposit " << edep/MeV << " MeV";
     return edep;
-  } 
 }
 
-uint32_t EcalTBH4BeamSD::setDetUnitId(G4Step * aStep) { 
+uint32_t EcalTBH4BeamSD::setDetUnitId(const G4Step * aStep) { 
   getBaseNumber(aStep);
-  return (numberingScheme == 0 ? 0 : numberingScheme->getUnitID(theBaseNumber));
+  return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(theBaseNumber));
 }
 
 void EcalTBH4BeamSD::setNumberingScheme(EcalNumberingScheme* scheme) {
-  if (scheme != 0) {
+  if (scheme != nullptr) {
     edm::LogInfo("EcalTBSim") << "EcalTBH4BeamSD: updates numbering scheme for " 
 			    << GetName() << "\n";
-    if (numberingScheme) delete numberingScheme;
+    delete numberingScheme;
     numberingScheme = scheme;
   }
 }
-
 
 void EcalTBH4BeamSD::getBaseNumber(const G4Step* aStep) {
 

--- a/SimG4CMS/FP420/interface/FP420G4Hit.h
+++ b/SimG4CMS/FP420/interface/FP420G4Hit.h
@@ -21,13 +21,13 @@ class FP420G4Hit : public G4VHit {
 public:
   
   FP420G4Hit();
-  ~FP420G4Hit();
+  ~FP420G4Hit() override;
   FP420G4Hit(const FP420G4Hit &right);
   const FP420G4Hit& operator=(const FP420G4Hit &right);
   int operator==(const FP420G4Hit &){return 0;}
   
-  void         Draw(){}
-  void         Print();
+  void         Draw() override{}
+  void         Print() override;
   
 public:
   

--- a/SimG4CMS/FP420/interface/FP420SD.h
+++ b/SimG4CMS/FP420/interface/FP420SD.h
@@ -12,13 +12,8 @@
 
 #include "SimG4Core/Notification/interface/BeginOfTrack.h"
 #include "SimG4Core/Notification/interface/BeginOfJob.h"
-// last
-//#include "SimG4Core/Application/interface/SimTrackManager.h"
-//#include "SimG4CMS/Calo/interface/CaloSD.h"
 
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
-//#include "SimG4Core/Notification/interface/TrackWithHistory.h"
-//#include "SimG4Core/Notification/interface/TrackContainer.h"
 
 #include "SimG4CMS/FP420/interface/FP420G4Hit.h"
 #include "SimG4CMS/FP420/interface/FP420G4HitCollection.h"
@@ -30,16 +25,9 @@
 #include "G4Track.hh"
 #include "G4VPhysicalVolume.hh"
 
-//#include <iostream>
-//#include <fstream>
-//#include <vector>
-//#include <map>
 #include <string>
  
-
-
 class TrackingSlaveSD;
-//AZ:
 class FP420SD;
 class FrameRotation;
 class TrackInformation;
@@ -54,60 +42,38 @@ class G4TrackToParticleID;
 
 class FP420SD : public SensitiveTkDetector,
                 public Observer<const BeginOfRun *>,
-                public Observer<const BeginOfEvent*>,
-                public Observer<const EndOfEvent*> {
+                public Observer<const BeginOfEvent*> {
 
 public:
   
-  FP420SD(std::string, const DDCompactView &, const SensitiveDetectorCatalog &,
+  FP420SD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
   	  edm::ParameterSet const &, const SimTrackManager* );
 
-//-------------------------------------------------------------------
-/*
-class FP420SD : public CaloSD {
-
-public:    
-  FP420SD(G4String, const DDCompactView &, edm::ParameterSet const &,const SimTrackManager*);
-*/
-//-------------------------------------------------------------------
-
-
-
-
-  virtual ~FP420SD();
+  ~FP420SD() override;
   
-  virtual bool ProcessHits(G4Step *,G4TouchableHistory *);
-  virtual uint32_t  setDetUnitId(G4Step*);
+  bool ProcessHits(G4Step *,G4TouchableHistory *) override;
+  uint32_t  setDetUnitId(const G4Step*) override;
 
-  virtual void Initialize(G4HCofThisEvent * HCE);
-  virtual void EndOfEvent(G4HCofThisEvent * eventHC);
-  virtual void clear();
-  virtual void DrawAll();
-  virtual void PrintAll();
+  void Initialize(G4HCofThisEvent * HCE) override;
+  void EndOfEvent(G4HCofThisEvent * eventHC) override;
+  void clear() override;
+  void DrawAll() override;
+  void PrintAll() override;
 
-  virtual double getEnergyDeposit(G4Step* step);
-  //protected:
-  //    Collection       hits_;
-    void fillHits(edm::PSimHitContainer&, std::string use);
-  
-  std::vector<std::string> getNames();
-  
+  double getEnergyDeposit(const G4Step* step) override;
+
+  void fillHits(edm::PSimHitContainer&, const std::string&) override;
+    
  private:
-  void           update(const BeginOfRun *);
-  void           update(const BeginOfEvent *);
-  void           update(const ::EndOfEvent *);
-  virtual void   clearHits();
+  void           update(const BeginOfRun *) override;
+  void           update(const BeginOfEvent *) override;
+  void   clearHits() override;
   
-  //void SetNumberingScheme(FP420NumberingScheme* scheme);
-  
-  
-  
-  //  int eventno;
  private:
   
   G4ThreeVector SetToLocal(const G4ThreeVector& global);
   G4ThreeVector SetToLocalExit(const G4ThreeVector& globalPoint);
-  void          GetStepInfo(G4Step* aStep);
+  void          GetStepInfo(const G4Step* aStep);
   G4bool        HitExists();
   void          CreateNewHit();
   void          UpdateHit();
@@ -115,47 +81,37 @@ public:
   void          ResetForNewPrimary();
   void          Summarize();
   
-  
  private:
   
   //AZ:
   TrackingSlaveSD* slave;
   FP420NumberingScheme * numberingScheme;
   
-    G4ThreeVector entrancePoint, exitPoint;
-    G4ThreeVector theEntryPoint ;
-    G4ThreeVector theExitPoint  ;
+  G4ThreeVector entrancePoint, exitPoint;
+  G4ThreeVector theEntryPoint ;
+  G4ThreeVector theExitPoint  ;
 
-    //  Local3DPoint  entrancePoint, exitPoint, theEntryPoint, theExitPoint;
-
-
-
-  
   float                incidentEnergy;
   
-  //  G4String             name;
-  std::string             name;
   G4int                    hcID;
   FP420G4HitCollection*       theHC; 
   const SimTrackManager*      theManager;
  
-  G4int                    tsID; 
-  FP420G4Hit*               currentHit;
-  G4Track*                 theTrack;
-  G4VPhysicalVolume*         currentPV;
-  // unsigned int         unitID, previousUnitID;
+  G4int                tsID; 
+  FP420G4Hit*          currentHit;
+  const G4Track*       theTrack;
+  G4VPhysicalVolume*   currentPV;
   uint32_t             unitID, previousUnitID;
   G4int                tSliceID; 
-  unsigned int                primaryID, primID  ; 
+  unsigned int         primaryID, primID; 
   
   G4double             tSlice;
   
-  G4StepPoint*         preStepPoint; 
-  G4StepPoint*         postStepPoint; 
+  const G4StepPoint*   preStepPoint; 
+  const G4StepPoint*   postStepPoint; 
   float                edeposit;
   
   G4ThreeVector        hitPoint;
-  //  G4ThreeVector    Position;
   G4ThreeVector        hitPointExit;
   G4ThreeVector        hitPointLocal;
   G4ThreeVector        hitPointLocalExit;
@@ -186,7 +142,3 @@ public:
 };
 
 #endif // FP420SD_h
-
-
-
-

--- a/SimG4CMS/Forward/interface/BHMSD.h
+++ b/SimG4CMS/Forward/interface/BHMSD.h
@@ -34,36 +34,33 @@ class G4TrackToParticleID;
 
 class BHMSD : public SensitiveTkDetector,
               public Observer<const BeginOfRun *>,
-              public Observer<const BeginOfEvent*>,
-              public Observer<const EndOfEvent*> {
+              public Observer<const BeginOfEvent*> {
 
 public:
   
-  BHMSD(std::string, const DDCompactView &, const SensitiveDetectorCatalog &, 
+  BHMSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &, 
 	edm::ParameterSet const &, const SimTrackManager* );
 
 
-  virtual ~BHMSD();
+  ~BHMSD() override;
   
-  virtual bool ProcessHits(G4Step *,G4TouchableHistory *);
-  virtual uint32_t  setDetUnitId(G4Step*);
+  bool ProcessHits(G4Step *,G4TouchableHistory *) override;
+  uint32_t  setDetUnitId(const G4Step*) override;
 
-  virtual void Initialize(G4HCofThisEvent * HCE);
-  virtual void EndOfEvent(G4HCofThisEvent * eventHC);
-  virtual void clear();
-  virtual void DrawAll();
-  virtual void PrintAll();
+  void Initialize(G4HCofThisEvent * HCE) override;
+  void EndOfEvent(G4HCofThisEvent * eventHC) override;
+  void clear() override;
+  void DrawAll() override;
+  void PrintAll() override;
 
-  virtual double getEnergyDeposit(G4Step* step);
-  void           fillHits(edm::PSimHitContainer&, std::string use);
-  
-  std::vector<std::string> getNames();
+  void           fillHits(edm::PSimHitContainer&, const std::string& use) override;
   
 private:
-  void           update(const BeginOfRun *);
-  void           update(const BeginOfEvent *);
-  void           update(const ::EndOfEvent *);
-  virtual void   clearHits();
+
+  void           stepInfo(const G4Step* aStep);
+  void           update(const BeginOfRun *) override;
+  void           update(const BeginOfEvent *) override;
+  void   clearHits() override;
 
 private:
   
@@ -89,21 +86,20 @@ private:
   float                  incidentEnergy;
   G4int                  primID  ; 
   
-  std::string            name;
   G4int                  hcID;
   BscG4HitCollection*    theHC; 
   const SimTrackManager* theManager;
  
   G4int                  tsID; 
   BscG4Hit*              currentHit;
-  G4Track*               theTrack;
-  G4VPhysicalVolume*     currentPV;
+  const G4Track*         theTrack;
+  const G4VPhysicalVolume* currentPV;
   uint32_t               unitID, previousUnitID;
   G4int                  primaryID, tSliceID;  
   G4double               tSlice;
   
-  G4StepPoint*           preStepPoint; 
-  G4StepPoint*           postStepPoint; 
+  const G4StepPoint*     preStepPoint; 
+  const G4StepPoint*     postStepPoint; 
   float                  edeposit;
   
   G4ThreeVector          hitPoint;

--- a/SimG4CMS/Forward/interface/Bcm1fSD.h
+++ b/SimG4CMS/Forward/interface/Bcm1fSD.h
@@ -34,28 +34,28 @@ class Bcm1fSD : public SensitiveTkDetector,
 
 public:
 
-  Bcm1fSD(std::string, const DDCompactView &, 
+  Bcm1fSD(const std::string&, const DDCompactView &, 
 		       const SensitiveDetectorCatalog &,
 		       edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~Bcm1fSD();
+  ~Bcm1fSD() override;
 
-  virtual bool     ProcessHits(G4Step *,G4TouchableHistory *);
-  virtual uint32_t setDetUnitId(G4Step*);
-  virtual void EndOfEvent(G4HCofThisEvent*);
+  bool     ProcessHits(G4Step *,G4TouchableHistory *) override;
+  uint32_t setDetUnitId(const G4Step*) override;
+  void EndOfEvent(G4HCofThisEvent*) override;
 
-  void fillHits (edm::PSimHitContainer&, std::string use);
+  void fillHits (edm::PSimHitContainer&, const std::string& use) override;
 
 private:
 
   virtual void   sendHit();
-  virtual void   updateHit(G4Step *);
-  virtual bool   newHit(G4Step *);
-  virtual bool   closeHit(G4Step *);
-  virtual void   createHit(G4Step *);
-  void           update(const BeginOfEvent *);
-  void           update(const BeginOfTrack *);
-  void           update(const BeginOfJob *);
-  virtual void   clearHits();
+  virtual void   updateHit(const G4Step *);
+  virtual bool   newHit(const G4Step *);
+  virtual bool   closeHit(const G4Step *);
+  virtual void   createHit(const G4Step *);
+  void           update(const BeginOfEvent *) override;
+  void           update(const BeginOfTrack *) override;
+  void           update(const BeginOfJob *) override;
+  void   clearHits() override;
   TrackInformation* getOrCreateTrackInformation(const G4Track *);
 
 private:
@@ -70,7 +70,7 @@ private:
 
   Local3DPoint globalEntryPoint;
   Local3DPoint globalExitPoint;
-  G4VPhysicalVolume * oldVolume;
+  const G4VPhysicalVolume * oldVolume;
   uint32_t lastId;
   unsigned int lastTrack;
   int eventno;

--- a/SimG4CMS/Forward/interface/BscG4Hit.h
+++ b/SimG4CMS/Forward/interface/BscG4Hit.h
@@ -22,13 +22,13 @@ class BscG4Hit : public G4VHit {
 public:
   
   BscG4Hit();
-  ~BscG4Hit();
+  ~BscG4Hit() override;
   BscG4Hit(const BscG4Hit &right);
   const BscG4Hit& operator=(const BscG4Hit &right);
   int operator==(const BscG4Hit &){return 0;}
   
-  void         Draw(){}
-  void         Print();
+  void         Draw() override{}
+  void         Print() override;
   
 public:
   

--- a/SimG4CMS/Forward/interface/BscSD.h
+++ b/SimG4CMS/Forward/interface/BscSD.h
@@ -10,14 +10,6 @@
 #include "SimG4Core/Notification/interface/BeginOfEvent.h"
 #include "SimG4Core/Notification/interface/EndOfEvent.h"
 
-// last
-//#include "SimG4Core/Application/interface/SimTrackManager.h"
-//#include "SimG4CMS/Calo/interface/CaloSD.h"
-
-
-//#include "SimG4Core/Notification/interface/TrackWithHistory.h"
-//#include "SimG4Core/Notification/interface/TrackContainer.h"
-
 #include "SimG4CMS/Forward/interface/BscG4Hit.h"
 #include "SimG4CMS/Forward/interface/BscG4HitCollection.h"
 #include "SimG4CMS/Forward/interface/BscNumberingScheme.h"
@@ -28,14 +20,7 @@
 #include "G4Track.hh"
 #include "G4VPhysicalVolume.hh"
 
-//#include <CLHEP/Vector/ThreeVector.h>
-//#include <iostream>
-//#include <fstream>
-//#include <vector>
-//#include <map>
 #include <string>
- 
-
 
 class TrackingSlaveSD;
 //AZ:
@@ -53,57 +38,45 @@ class G4TrackToParticleID;
 
 class BscSD : public SensitiveTkDetector,
               public Observer<const BeginOfRun *>,
-              public Observer<const BeginOfEvent*>,
-              public Observer<const EndOfEvent*> {
+              public Observer<const BeginOfEvent*>{
 
 public:
   
-  BscSD(std::string, const DDCompactView &, const SensitiveDetectorCatalog &,
+  BscSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
   	  edm::ParameterSet const &, const SimTrackManager* );
 
 
-  virtual ~BscSD();
+  ~BscSD() override;
   
-  virtual bool ProcessHits(G4Step *,G4TouchableHistory *);
-  virtual uint32_t  setDetUnitId(G4Step*);
+  bool ProcessHits(G4Step *,G4TouchableHistory *) override;
+  uint32_t  setDetUnitId(const G4Step*) override;
 
-  virtual void Initialize(G4HCofThisEvent * HCE);
-  virtual void EndOfEvent(G4HCofThisEvent * eventHC);
-  virtual void clear();
-  virtual void DrawAll();
-  virtual void PrintAll();
+  void Initialize(G4HCofThisEvent * HCE) override;
+  void EndOfEvent(G4HCofThisEvent * eventHC) override;
+  void clear() override;
+  void DrawAll() override;
+  void PrintAll() override;
 
-  virtual double getEnergyDeposit(G4Step* step);
-  //protected:
-  //    Collection       hits_;
-    void fillHits(edm::PSimHitContainer&, std::string use);
-  
-  std::vector<std::string> getNames();
+  void fillHits(edm::PSimHitContainer&, const std::string& use) override;
   
  private:
-  void           update(const BeginOfRun *);
-  void           update(const BeginOfEvent *);
-  void           update(const ::EndOfEvent *);
-  virtual void   clearHits();
-  
-  //void SetNumberingScheme(BscNumberingScheme* scheme);
-  
-  
+  void           update(const BeginOfRun *) override;
+  void           update(const BeginOfEvent *) override;
+  void   clearHits() override;
   
   //  int eventno;
  private:
   
   G4ThreeVector SetToLocal(const G4ThreeVector& global);
   G4ThreeVector SetToLocalExit(const G4ThreeVector& globalPoint);
-  void          GetStepInfo(G4Step* aStep);
+  void          GetStepInfo(const G4Step* aStep);
   G4bool        HitExists();
   void          CreateNewHit();
   void          UpdateHit();
   void          StoreHit(BscG4Hit*);
   void          ResetForNewPrimary();
   void          Summarize();
-  
-  
+    
  private:
   
   //AZ:
@@ -117,27 +90,23 @@ public:
   float                incidentEnergy;
   G4int                primID  ; 
   
-  //  G4String             name;
-  std::string             name;
   G4int                    hcID;
   BscG4HitCollection*       theHC; 
   const SimTrackManager*      theManager;
  
-  G4int                    tsID; 
-  BscG4Hit*               currentHit;
-  G4Track*                 theTrack;
-  G4VPhysicalVolume*         currentPV;
-  // unsigned int         unitID, previousUnitID;
+  G4int                tsID; 
+  BscG4Hit*            currentHit;
+  const G4Track*       theTrack;
+  const G4VPhysicalVolume*   currentPV;
   uint32_t             unitID, previousUnitID;
   G4int                primaryID, tSliceID;  
   G4double             tSlice;
   
-  G4StepPoint*         preStepPoint; 
-  G4StepPoint*         postStepPoint; 
+  const G4StepPoint*   preStepPoint; 
+  const G4StepPoint*   postStepPoint; 
   float                edeposit;
   
   G4ThreeVector        hitPoint;
-  //  G4ThreeVector    Position;
   G4ThreeVector        hitPointExit;
   G4ThreeVector        hitPointLocal;
   G4ThreeVector        hitPointLocalExit;
@@ -159,9 +128,9 @@ public:
   //
   int eventno;
   
- protected:
+  // protected:
   
-  float                edepositEM, edepositHAD;
+  float edepositEM, edepositHAD;
   G4int emPDG;
   G4int epPDG;
   G4int gammaPDG;

--- a/SimG4CMS/Forward/interface/BscSD.h
+++ b/SimG4CMS/Forward/interface/BscSD.h
@@ -60,12 +60,9 @@ public:
   void fillHits(edm::PSimHitContainer&, const std::string& use) override;
   
  private:
-  void           update(const BeginOfRun *) override;
-  void           update(const BeginOfEvent *) override;
-  void   clearHits() override;
-  
-  //  int eventno;
- private:
+  void          update(const BeginOfRun *) override;
+  void          update(const BeginOfEvent *) override;
+  void          clearHits() override;
   
   G4ThreeVector SetToLocal(const G4ThreeVector& global);
   G4ThreeVector SetToLocalExit(const G4ThreeVector& globalPoint);
@@ -91,8 +88,8 @@ public:
   G4int                primID  ; 
   
   G4int                    hcID;
-  BscG4HitCollection*       theHC; 
-  const SimTrackManager*      theManager;
+  BscG4HitCollection*      theHC; 
+  const SimTrackManager*   theManager;
  
   G4int                tsID; 
   BscG4Hit*            currentHit;
@@ -121,14 +118,11 @@ public:
   int ParentId;
   float Vx,Vy,Vz;
   float X,Y,Z;
-  
-  
+   
   //
   // Hist
   //
   int eventno;
-  
-  // protected:
   
   float edepositEM, edepositHAD;
   G4int emPDG;

--- a/SimG4CMS/Forward/interface/CastorSD.h
+++ b/SimG4CMS/Forward/interface/CastorSD.h
@@ -31,30 +31,32 @@ class CastorSD : public CaloSD {
 
 public:    
 
-  CastorSD(G4String, const DDCompactView &, const SensitiveDetectorCatalog & clg,
+  CastorSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog & clg,
 	   edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~CastorSD();
-  virtual double   getEnergyDeposit(G4Step* );
-  virtual uint32_t setDetUnitId(G4Step* step);
+  ~CastorSD() override;
+  bool             ProcessHits(G4Step * step, G4TouchableHistory *) override;
+  double           getEnergyDeposit(const G4Step * step) override;
+  uint32_t setDetUnitId(const G4Step* step) override;
   void             setNumberingScheme(CastorNumberingScheme* scheme);
 
 private:
 
-  void                    getFromLibrary(G4Step*);
-  int                     setTrackID(G4Step*);
-  uint32_t                rotateUnitID(uint32_t, G4Track*, const CastorShowerEvent&);
+  void                    getFromLibrary(const G4Step*);
+  int                     setTrackID(const G4Step*);
+  uint32_t                rotateUnitID(uint32_t, const G4Track*, const CastorShowerEvent&);
   CastorNumberingScheme * numberingScheme;
   CastorShowerLibrary *   showerLibrary;
   G4LogicalVolume         *lvC3EF, *lvC3HF, *lvC4EF, *lvC4HF;
   G4LogicalVolume         *lvCAST;               // Pointer for CAST sensitive volume  (SL trigger)
   
   bool                    useShowerLibrary;
+  bool                    isAppliedSL;
   double                  energyThresholdSL; 
   double		  non_compensation_factor;
 
 protected:
 
-  virtual void            initRun();
+  void            initRun() override;
 
 };
 

--- a/SimG4CMS/Forward/interface/CastorShowerLibrary.h
+++ b/SimG4CMS/Forward/interface/CastorShowerLibrary.h
@@ -34,13 +34,13 @@ class CastorShowerLibrary {
 public:
   
   //Constructor and Destructor
-  CastorShowerLibrary(std::string & name, edm::ParameterSet const & p);
+  CastorShowerLibrary(const std::string & name, edm::ParameterSet const & p);
   ~CastorShowerLibrary();
 
 public:
 
   void                initParticleTable(G4ParticleTable *);
-  CastorShowerEvent   getShowerHits(G4Step*, bool&);
+  CastorShowerEvent   getShowerHits(const G4Step*, bool&);
   int                 FindEnergyBin(double);
   int                 FindEtaBin(double);
   int                 FindPhiBin(double);

--- a/SimG4CMS/Forward/interface/FastTimerSD.h
+++ b/SimG4CMS/Forward/interface/FastTimerSD.h
@@ -34,43 +34,38 @@ class G4TrackToParticleID;
 class FastTimerSD : public SensitiveTkDetector,
                     public Observer<const BeginOfJob *>,
                     public Observer<const BeginOfRun *>,
-                    public Observer<const BeginOfEvent*>,
-                    public Observer<const EndOfEvent*> {
+                    public Observer<const BeginOfEvent*> {
 
 public:
   
-  FastTimerSD(std::string, const DDCompactView &, const SensitiveDetectorCatalog &, 
+  FastTimerSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &, 
 	      edm::ParameterSet const &, const SimTrackManager* );
 
 
-  virtual ~FastTimerSD();
+  ~FastTimerSD() override;
   
-  virtual bool     ProcessHits(G4Step *,G4TouchableHistory *);
-  virtual uint32_t setDetUnitId(G4Step*);
+  bool     ProcessHits(G4Step *,G4TouchableHistory *) override;
+  uint32_t setDetUnitId(const G4Step*) override;
 
-  virtual void     Initialize(G4HCofThisEvent * HCE);
-  virtual void     EndOfEvent(G4HCofThisEvent * eventHC);
-  virtual void     clear();
-  virtual void     DrawAll();
-  virtual void     PrintAll();
+  void     Initialize(G4HCofThisEvent * HCE) override;
+  void     EndOfEvent(G4HCofThisEvent * eventHC) override;
+  void     clear() override;
+  void     DrawAll() override;
+  void     PrintAll() override;
 
-  virtual double   getEnergyDeposit(G4Step* step);
-  void             fillHits(edm::PSimHitContainer&, std::string use);
-  
-  std::vector<std::string> getNames();
+  void             fillHits(edm::PSimHitContainer&, const std::string& use) override;
   
 private:
-  virtual void     update(const BeginOfJob *);
-  virtual void     update(const BeginOfRun *);
-  virtual void     update(const BeginOfEvent *);
-  virtual void     update(const ::EndOfEvent *);
-  virtual void     clearHits();
+  void     update(const BeginOfJob *) override;
+  void     update(const BeginOfRun *) override;
+  void     update(const BeginOfEvent *) override;
+  void     clearHits() override;
 
 private:
   
   G4ThreeVector    SetToLocal(const G4ThreeVector& global);
   G4ThreeVector    SetToLocalExit(const G4ThreeVector& globalPoint);
-  void             GetStepInfo(G4Step* aStep);
+  void             GetStepInfo(const G4Step* aStep);
   G4bool           HitExists();
   void             CreateNewHit();
   void             UpdateHit();
@@ -91,21 +86,20 @@ private:
   float                        incidentEnergy;
   G4int                        primID  ; 
   
-  std::string                  name;
   G4int                        hcID;
   BscG4HitCollection*          theHC; 
   const SimTrackManager*       theManager;
  
   G4int                        tsID; 
   BscG4Hit*                    currentHit;
-  G4Track*                     theTrack;
-  G4VPhysicalVolume*           currentPV;
+  const G4Track*               theTrack;
+  const G4VPhysicalVolume*     currentPV;
   uint32_t                     unitID, previousUnitID;
   G4int                        primaryID, tSliceID;  
   G4double                     tSlice;
   
-  G4StepPoint*                 preStepPoint; 
-  G4StepPoint*                 postStepPoint; 
+  const G4StepPoint*           preStepPoint; 
+  const G4StepPoint*           postStepPoint; 
   float                        edeposit;
   
   G4ThreeVector                hitPoint;
@@ -122,8 +116,6 @@ private:
   float                        X,Y,Z;
   
   int                          eventno;
-  
-protected:
   
   float                        edepositEM, edepositHAD;
   G4int                        emPDG;

--- a/SimG4CMS/Forward/interface/PltSD.h
+++ b/SimG4CMS/Forward/interface/PltSD.h
@@ -34,28 +34,28 @@ class PltSD : public SensitiveTkDetector,
 
 public:
 
-  PltSD(std::string, const DDCompactView &, 
+  PltSD(const std::string&, const DDCompactView &, 
 		       const SensitiveDetectorCatalog &,
 		       edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~PltSD();
+  ~PltSD() override;
 
-  virtual bool     ProcessHits(G4Step *,G4TouchableHistory *);
-  virtual uint32_t setDetUnitId(G4Step*);
-  virtual void EndOfEvent(G4HCofThisEvent*);
+  bool     ProcessHits(G4Step *,G4TouchableHistory *) override;
+  uint32_t setDetUnitId(const G4Step*) override;
+  void EndOfEvent(G4HCofThisEvent*) override;
 
-  void fillHits (edm::PSimHitContainer&, std::string use);
+  void fillHits (edm::PSimHitContainer&, const std::string& use) override;
 
 private:
 
   virtual void   sendHit();
-  virtual void   updateHit(G4Step *);
-  virtual bool   newHit(G4Step *);
-  virtual bool   closeHit(G4Step *);
-  virtual void   createHit(G4Step *);
-  void           update(const BeginOfEvent *);
-  void           update(const BeginOfTrack *);
-  void           update(const BeginOfJob *);
-  virtual void   clearHits();
+  virtual void   updateHit(const G4Step *);
+  virtual bool   newHit(const G4Step *);
+  virtual bool   closeHit(const G4Step *);
+  virtual void   createHit(const G4Step *);
+  void           update(const BeginOfEvent *) override;
+  void           update(const BeginOfTrack *) override;
+  void           update(const BeginOfJob *) override;
+  void   clearHits() override;
   TrackInformation* getOrCreateTrackInformation(const G4Track *);
 
 private:
@@ -63,14 +63,14 @@ private:
   TrackingSlaveSD*            slave;
   G4ProcessTypeEnumerator * theG4ProcessTypeEnumerator;
   G4TrackToParticleID * myG4TrackToParticleID;
-  std::string        myName;
+
   UpdatablePSimHit * mySimHit;
   float energyCut;
   float energyHistoryCut;
 
   Local3DPoint globalEntryPoint;
   Local3DPoint globalExitPoint;
-  G4VPhysicalVolume * oldVolume;
+  const G4VPhysicalVolume * oldVolume;
   uint32_t lastId;
   unsigned int lastTrack;
   int eventno;

--- a/SimG4CMS/Forward/interface/TotemG4Hit.h
+++ b/SimG4CMS/Forward/interface/TotemG4Hit.h
@@ -42,7 +42,7 @@ public:
 
   // ---------- Constructor and destructor -----------------
   TotemG4Hit();
-  ~TotemG4Hit();
+  ~TotemG4Hit() override;
   TotemG4Hit(const TotemG4Hit &right);
 
   // ---------- operators ----------------------------------
@@ -50,8 +50,8 @@ public:
   int operator==(const TotemG4Hit &){return 0;}
 
   // ---------- member functions ---------------------------
-  void         Draw(){}
-  void         Print();
+  void         Draw() override{}
+  void         Print() override;
 
   math::XYZPoint   getEntry() const;
   void         setEntry(double x, double y, double z)      {entry.SetCoordinates(x,y,z);}

--- a/SimG4CMS/Forward/interface/TotemRPNumberingScheme.h
+++ b/SimG4CMS/Forward/interface/TotemRPNumberingScheme.h
@@ -31,7 +31,7 @@ public:
 
   // ---------- Constructor and destructor -----------------
   TotemRPNumberingScheme(int i);
-  ~TotemRPNumberingScheme();
+  ~TotemRPNumberingScheme() override;
 	 
   //  virtual uint32_t GetUnitID(const G4Step* aStep) const ;
 

--- a/SimG4CMS/Forward/interface/TotemRPOrganization.h
+++ b/SimG4CMS/Forward/interface/TotemRPOrganization.h
@@ -32,11 +32,11 @@ public:
 
   // ---------- Constructor and destructor -----------------
   TotemRPOrganization();
-  virtual          ~TotemRPOrganization();
+           ~TotemRPOrganization() override;
 
   // ---------- member functions ---------------------------
   uint32_t         GetUnitID(const G4Step* aStep);
-  uint32_t         GetUnitID(const G4Step* aStep) const;
+  uint32_t         GetUnitID(const G4Step* aStep) const override;
 
 private:
 

--- a/SimG4CMS/Forward/interface/TotemSD.h
+++ b/SimG4CMS/Forward/interface/TotemSD.h
@@ -41,36 +41,35 @@ class TrackingSlaveSD;
 class SimTrackManager;
 
 class TotemSD : public SensitiveTkDetector,
-		public Observer<const BeginOfEvent*>,
-		public Observer<const EndOfEvent*> {
+		public Observer<const BeginOfEvent*> {
 
 public:
 
-  TotemSD(std::string, const DDCompactView &, const SensitiveDetectorCatalog &,
+  TotemSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	  edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~TotemSD();
+  ~TotemSD() override;
 
-  virtual bool   ProcessHits(G4Step *,G4TouchableHistory *);
-  virtual uint32_t setDetUnitId(G4Step*);
+  bool   ProcessHits(G4Step *,G4TouchableHistory *) override;
+  uint32_t setDetUnitId(const G4Step*) override;
 
-  virtual void   Initialize(G4HCofThisEvent * HCE);
-  virtual void   EndOfEvent(G4HCofThisEvent * eventHC);
-  virtual void   clear();
-  virtual void   DrawAll();
-  virtual void   PrintAll();
+  void   Initialize(G4HCofThisEvent * HCE) override;
+  void   EndOfEvent(G4HCofThisEvent * eventHC) override;
+  void   clear() override;
+  void   DrawAll() override;
+  void   PrintAll() override;
 
-  void fillHits(edm::PSimHitContainer&, std::string use);
+  void fillHits(edm::PSimHitContainer&, const std::string& use) override;
 
 private:
 
-  void           update(const BeginOfEvent *);
+  void           update(const BeginOfEvent *) override;
   void           update(const ::EndOfEvent *);
-  virtual void   clearHits();
+  void   clearHits() override;
 
 private:
 
   G4ThreeVector  SetToLocal(const G4ThreeVector& globalPoint);
-  void           GetStepInfo(G4Step* aStep);
+  void           GetStepInfo(const G4Step* aStep);
   bool           HitExists();
   void           CreateNewHit();
   void           CreateNewHitEvo();
@@ -94,21 +93,20 @@ private:
   float                       incidentEnergy;
   G4int                       primID  ; //@@ ID of the primary particle.
 
-  std::string                 name;
   G4int                       hcID;
   TotemG4HitCollection*       theHC; 
   const SimTrackManager*      theManager;
 
   int                         tsID; 
   TotemG4Hit*                 currentHit;
-  G4Track*                    theTrack;
-  G4VPhysicalVolume*          currentPV;
+  const G4Track*              theTrack;
+  const G4VPhysicalVolume*    currentPV;
   uint32_t                    unitID, previousUnitID;
   int                         primaryID, tSliceID;  
   double                      tSlice;
 
-  G4StepPoint*                preStepPoint; 
-  G4StepPoint*                postStepPoint; 
+  const G4StepPoint*          preStepPoint; 
+  const G4StepPoint*          postStepPoint; 
   float                       edeposit;
   G4ThreeVector               hitPoint;
 

--- a/SimG4CMS/Forward/interface/TotemT1NumberingScheme.h
+++ b/SimG4CMS/Forward/interface/TotemT1NumberingScheme.h
@@ -31,7 +31,7 @@ public:
 
   // ---------- Constructor and destructor -----------------
   TotemT1NumberingScheme(int i);
-  ~TotemT1NumberingScheme();
+  ~TotemT1NumberingScheme() override;
 	 
   //  virtual uint32_t GetUnitID(const G4Step* aStep) const ;
 

--- a/SimG4CMS/Forward/interface/TotemT1Organization.h
+++ b/SimG4CMS/Forward/interface/TotemT1Organization.h
@@ -55,11 +55,11 @@ public:
 
   // ---------- Constructor and destructor -----------------
   TotemT1Organization();
-  virtual          ~TotemT1Organization();
+           ~TotemT1Organization() override;
 
   // ---------- member functions ---------------------------
   uint32_t         GetUnitID(const G4Step* aStep);
-  uint32_t         GetUnitID(const G4Step* aStep) const;
+  uint32_t         GetUnitID(const G4Step* aStep) const override;
   
   int              GetCurrentUnitID(void) const;
   void             SetCurrentUnitID(int currentUnitID);

--- a/SimG4CMS/Forward/interface/TotemT2NumberingSchemeGem.h
+++ b/SimG4CMS/Forward/interface/TotemT2NumberingSchemeGem.h
@@ -31,7 +31,7 @@ public:
 
   // ---------- Constructor and destructor -----------------
   TotemT2NumberingSchemeGem(int i);
-  ~TotemT2NumberingSchemeGem();
+  ~TotemT2NumberingSchemeGem() override;
 	 
   //  virtual uint32_t GetUnitID(const G4Step* aStep) const ;
 

--- a/SimG4CMS/Forward/interface/TotemT2OrganizationGem.h
+++ b/SimG4CMS/Forward/interface/TotemT2OrganizationGem.h
@@ -29,11 +29,11 @@ public:
 
   // ---------- Constructor and destructor -----------------
   TotemT2OrganizationGem();
-  virtual          ~TotemT2OrganizationGem();
+           ~TotemT2OrganizationGem() override;
 
   // ---------- member functions ---------------------------
   uint32_t         GetUnitID(const G4Step* aStep);
-  uint32_t         GetUnitID(const G4Step* aStep) const;
+  uint32_t         GetUnitID(const G4Step* aStep) const override;
 
 private:
 

--- a/SimG4CMS/Forward/interface/ZdcSD.h
+++ b/SimG4CMS/Forward/interface/ZdcSD.h
@@ -14,27 +14,28 @@
 class ZdcSD : public CaloSD {
 
 public:    
-  ZdcSD(G4String, const DDCompactView &, const SensitiveDetectorCatalog &,
+  ZdcSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	edm::ParameterSet const &,const SimTrackManager*);
  
-  virtual ~ZdcSD();
-  virtual bool ProcessHits(G4Step * step,G4TouchableHistory * tHistory);
-  virtual uint32_t setDetUnitId(G4Step* step);
-  virtual double getEnergyDeposit(G4Step*, edm::ParameterSet const &);
+  ~ZdcSD() override;
+  bool ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
+  uint32_t setDetUnitId(const G4Step* step) override;
+  double getEnergyDeposit(const G4Step*) override;
  
   void setNumberingScheme(ZdcNumberingScheme* scheme);
-  void getFromLibrary(G4Step * step);
+  void getFromLibrary(const G4Step * step);
  
-
 protected:
-  virtual void initRun();
+  void initRun() override;
 private:    
 
   int verbosity;
   bool  useShowerLibrary,useShowerHits; 
-  int   setTrackID(G4Step * step);
+  bool  isAppliedSL;
+  int   setTrackID(const G4Step * step);
   double thFibDir;
   double zdcHitEnergyCut;
+  float thFibDirRad;
   ZdcShowerLibrary *    showerLibrary;
   ZdcNumberingScheme * numberingScheme;
 

--- a/SimG4CMS/Forward/interface/ZdcShowerLibrary.h
+++ b/SimG4CMS/Forward/interface/ZdcShowerLibrary.h
@@ -25,7 +25,8 @@ class ZdcShowerLibrary {
 public:
   
   //Constructor and Destructor
-  ZdcShowerLibrary(std::string & name, const DDCompactView & cpv, edm::ParameterSet const & p);
+  ZdcShowerLibrary(const std::string & name, const DDCompactView & cpv, 
+		   edm::ParameterSet const & p);
   ~ZdcShowerLibrary();
   
  public:
@@ -43,7 +44,7 @@ public:
 
 
   void                        initRun(G4ParticleTable * theParticleTable);
-  std::vector<Hit>&           getHits(G4Step * aStep, bool & ok);
+  std::vector<Hit>&           getHits(const G4Step * aStep, bool & ok);
   int                         getEnergyFromLibrary(const G4ThreeVector& posHit, const G4ThreeVector& momDir, double energy,
                                                    G4int parCode,HcalZDCDetId::Section section, bool side, int channel);
   int                         photonFluctuation(double eav, double esig,double edis);

--- a/SimG4CMS/Forward/src/BscSD.cc
+++ b/SimG4CMS/Forward/src/BscSD.cc
@@ -5,9 +5,6 @@
 // Modifications: 
 ///////////////////////////////////////////////////////////////////////////////
  
-//#include "Geometry/Vector/interface/LocalPoint.h"
-//#include "Geometry/Vector/interface/LocalVector.h"
-
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 #include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
 #include "SimG4Core/Physics/interface/G4ProcessTypeEnumerator.h"
@@ -45,16 +42,16 @@
 
 #define debug
 //-------------------------------------------------------------------
-BscSD::BscSD(std::string name, const DDCompactView & cpv,
+BscSD::BscSD(const std::string& iname, const DDCompactView & cpv,
 	     const SensitiveDetectorCatalog & clg,
 	     edm::ParameterSet const & p, const SimTrackManager* manager) :
-  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(0), name(name),
-  hcID(-1), theHC(0), theManager(manager), currentHit(0), theTrack(0), 
-  currentPV(0), unitID(0),  previousUnitID(0), preStepPoint(0), 
-  postStepPoint(0), eventno(0){
+  SensitiveTkDetector(iname, cpv, clg, p), numberingScheme(nullptr), 
+  hcID(-1), theHC(nullptr), theManager(manager), currentHit(nullptr), theTrack(nullptr), 
+  currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
+  postStepPoint(nullptr), eventno(0){
     
   //Add Bsc Sentitive Detector Name
-  collectionName.insert(name);
+  collectionName.insert(iname);
     
     
   //Parameters
@@ -66,17 +63,17 @@ BscSD::BscSD(std::string name, const DDCompactView & cpv,
   LogDebug("BscSim") 
     << "*******************************************************\n"
     << "*                                                     *\n"
-    << "* Constructing a BscSD  with name " << name << "\n"
+    << "* Constructing a BscSD  with name " << iname << "\n"
     << "*                                                     *\n"
     << "*******************************************************";
     
     
-  slave  = new TrackingSlaveSD(name);
+  slave = new TrackingSlaveSD(iname);
     
   //
   // attach detectors (LogicalVolumes)
   //
-  const std::vector<std::string>& lvNames = clg.logicalNames(name);
+  const std::vector<std::string>& lvNames = clg.logicalNames(iname);
 
   this->Register();
 
@@ -86,40 +83,30 @@ BscSD::BscSD(std::string name, const DDCompactView & cpv,
     edm::LogInfo("BscSim") << "BscSD : Assigns SD to LV " << (*it);
   }
     
-  if      (name == "BSCHits") {
+  if (iname == "BSCHits") {
     if (verbn > 0) {
       edm::LogInfo("BscSim") << "name = BSCHits and  new BscNumberingSchem";
     }
     numberingScheme = new BscNumberingScheme() ;
   } else {
-    edm::LogWarning("BscSim") << "BscSD: ReadoutName "<<name<<" not supported";
+    edm::LogWarning("BscSim") << "BscSD: ReadoutName "<<iname<<" not supported";
   }
   
   edm::LogInfo("BscSim") << "BscSD: Instantiation completed";
 }
 
-
-
-
 BscSD::~BscSD() { 
-  //AZ:
-  if (slave) delete slave; 
 
-  if (numberingScheme)
-    delete numberingScheme;
-
-}
-
-double BscSD::getEnergyDeposit(G4Step* aStep) {
-  return aStep->GetTotalEnergyDeposit();
+  delete slave; 
+  delete numberingScheme;
 }
 
 void BscSD::Initialize(G4HCofThisEvent * HCE) { 
 #ifdef debug
-  LogDebug("BscSim") << "BscSD : Initialize called for " << name << std::endl;
+  LogDebug("BscSim") << "BscSD : Initialize called for " << nameOfSD();
 #endif
 
-  theHC = new BscG4HitCollection(name, collectionName[0]);
+  theHC = new BscG4HitCollection(nameOfSD(), collectionName[0]);
   if (hcID<0) 
     hcID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]);
   HCE->AddHitsCollection(hcID, theHC);
@@ -130,29 +117,23 @@ void BscSD::Initialize(G4HCofThisEvent * HCE) {
   ////    slave->Initialize();
 }
 
-
 bool BscSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 
-  if (aStep == NULL) {
-    return true;
-  } else {
-    GetStepInfo(aStep);
-    //   LogDebug("BscSim") << edeposit <<std::endl;
+  GetStepInfo(aStep);
+  //   LogDebug("BscSim") << edeposit <<std::endl;
 
-    //AZ
+  //AZ
 #ifdef debug
-    LogDebug("BscSim") << "BscSD :  number of hits = " << theHC->entries() << std::endl;
+  LogDebug("BscSim") << "BscSD :  number of hits = " << theHC->entries() << std::endl;
 #endif
 
-    if (HitExists() == false && edeposit>0. ){ 
-      CreateNewHit();
-      return true;
-    }
+  if (!HitExists() && edeposit>0.f ){ 
+    CreateNewHit();
   }
   return true;
 } 
 
-void BscSD::GetStepInfo(G4Step* aStep) {
+void BscSD::GetStepInfo(const G4Step* aStep) {
   
   preStepPoint = aStep->GetPreStepPoint(); 
   postStepPoint= aStep->GetPostStepPoint(); 
@@ -199,9 +180,9 @@ void BscSD::GetStepInfo(G4Step* aStep) {
   Z  = hitPoint.z();
 }
 
-uint32_t BscSD::setDetUnitId(G4Step * aStep) { 
+uint32_t BscSD::setDetUnitId(const G4Step * aStep) { 
 
-  return (numberingScheme == 0 ? 0 : numberingScheme->getUnitID(aStep));
+  return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(aStep));
 }
 
 
@@ -263,7 +244,7 @@ void BscSD::ResetForNewPrimary() {
 void BscSD::StoreHit(BscG4Hit* hit){
 
   if (primID<0) return;
-  if (hit == 0 ) {
+  if (hit == nullptr ) {
     edm::LogWarning("BscSim") << "BscSD: hit to be stored is NULL !!";
     return;
   }
@@ -291,7 +272,7 @@ void BscSD::CreateNewHit() {
   }
 
   LogDebug("BscSim")  << " and created by " ;
-  if (theTrack->GetCreatorProcess()!=NULL)
+  if (theTrack->GetCreatorProcess()!=nullptr)
     LogDebug("BscSim") << theTrack->GetCreatorProcess()->GetProcessName() ;
   else 
     LogDebug("BscSim") << "NO process";
@@ -414,8 +395,8 @@ void BscSD::PrintAll() {
 } 
 
 
-void BscSD::fillHits(edm::PSimHitContainer& c, std::string n) {
-  if (slave->name() == n) c=slave->hits();
+void BscSD::fillHits(edm::PSimHitContainer& chit, const std::string& nhit) {
+  if (slave->name() == nhit) { chit=slave->hits(); }
 }
 
 void BscSD::update (const BeginOfEvent * i) {
@@ -435,17 +416,8 @@ void BscSD::update(const BeginOfRun *) {
 
 } 
 
-void BscSD::update (const ::EndOfEvent*) {
-}
-
 void BscSD::clearHits(){
   //AZ:
   slave->Initialize();
-}
-
-std::vector<std::string> BscSD::getNames(){
-  std::vector<std::string> temp;
-  temp.push_back(slave->name());
-  return temp;
 }
 

--- a/SimG4CMS/Forward/src/CastorSD.cc
+++ b/SimG4CMS/Forward/src/CastorSD.cc
@@ -28,12 +28,12 @@
 
 //#define debugLog
 
-CastorSD::CastorSD(G4String name, const DDCompactView & cpv,
+CastorSD::CastorSD(const std::string& iname, const DDCompactView & cpv,
 		   const SensitiveDetectorCatalog & clg,
 		   edm::ParameterSet const & p, 
 		   const SimTrackManager* manager) : 
-  CaloSD(name, cpv, clg, p, manager), numberingScheme(0), lvC3EF(0),
-  lvC3HF(0), lvC4EF(0), lvC4HF(0), lvCAST(0) {
+  CaloSD(iname, cpv, clg, p, manager), numberingScheme(nullptr), lvC3EF(nullptr),
+  lvC3HF(nullptr), lvC4EF(nullptr), lvC4HF(nullptr), lvCAST(nullptr), isAppliedSL(false) {
   
   edm::ParameterSet m_CastorSD = p.getParameter<edm::ParameterSet>("CastorSD");
   useShowerLibrary  = m_CastorSD.getParameter<bool>("useShowerLibrary");
@@ -42,7 +42,8 @@ CastorSD::CastorSD(G4String name, const DDCompactView & cpv,
 	  
   non_compensation_factor = m_CastorSD.getParameter<double>("nonCompensationFactor");
   
-  if (useShowerLibrary) showerLibrary = new CastorShowerLibrary(name, p);
+  if (useShowerLibrary) showerLibrary = new CastorShowerLibrary(iname, p);
+  else showerLibrary = nullptr;
   
   setNumberingScheme(new CastorNumberingScheme());
   
@@ -61,7 +62,7 @@ CastorSD::CastorSD(G4String name, const DDCompactView & cpv,
     if (strcmp(((*lvcite)->GetName()).c_str(),"C4EF") == 0) lvC4EF = (*lvcite);
     if (strcmp(((*lvcite)->GetName()).c_str(),"C4HF") == 0) lvC4HF = (*lvcite);
     if (strcmp(((*lvcite)->GetName()).c_str(),"CAST") == 0) lvCAST = (*lvcite);
-    if (lvC3EF != 0 && lvC3HF != 0 && lvC4EF != 0 && lvC4HF != 0 && lvCAST != 0) break;
+    if (lvC3EF != nullptr && lvC3HF != nullptr && lvC4EF != nullptr && lvC4HF != nullptr && lvCAST != nullptr) break;
   }
   edm::LogInfo("ForwardSim") << "CastorSD:: LogicalVolume pointers\n"
 			     << lvC3EF << " for C3EF; " << lvC3HF 
@@ -92,21 +93,52 @@ void CastorSD::initRun(){
 
 //=============================================================================================
 
-double CastorSD::getEnergyDeposit(G4Step * aStep) {
+bool CastorSD::ProcessHits(G4Step * aStep, G4TouchableHistory *) {
+
+  NaNTrap(aStep);
+  isAppliedSL = false;
+  if(getStepInfo(aStep) && !hitExists() && edepositEM+edepositHAD>0.f) {
+    currentHit = createNewHit();
+  }
+  //Now kill the current track
+  if(isAppliedSL) {
+    aStep->GetTrack()->SetTrackStatus(fStopAndKill);
+#ifdef debugLog
+    LogDebug("ForwardSim") << "CastorSD::getFromLibrary:"
+			   << "\n \"theTrack\" with TrackID() = " 
+			   << theTrack->GetTrackID() 
+			   << " and with energy " 
+			   << theTrack->GetTotalEnergy()
+			   << " has been set to be killed" ;
+#endif
+    G4TrackVector tv = *(aStep->GetSecondary());
+    for (unsigned int kk=0; kk<tv.size(); ++kk) {
+      if (tv[kk]->GetVolume() == preStepPoint->GetPhysicalVolume()) {
+	tv[kk]->SetTrackStatus(fStopAndKill);
+#ifdef debugLog
+	LogDebug("ForwardSim") << "CastorSD::getFromLibrary:"
+			       << "\n tv[" << kk << "]->GetTrackID() = " 
+			       << tv[kk]->GetTrackID() 
+			       << " with energy " 
+			       << tv[kk]->GetTotalEnergy()
+			       << " has been set to be killed" ;
+#endif
+      }
+    }
+  }
+  return true;
+} 
+
+//=============================================================================================
+
+double CastorSD::getEnergyDeposit(const G4Step * aStep) {
   
   double NCherPhot = 0.;
 
-  if (aStep == NULL) 
-    return 0;
-
-  // Get theTrack 
-  G4Track*        theTrack = aStep->GetTrack();
-
   // preStepPoint information *********************************************
   
-  G4StepPoint*       preStepPoint = aStep->GetPreStepPoint();
-  G4VPhysicalVolume* currentPV    = preStepPoint->GetPhysicalVolume();
-  G4LogicalVolume*   currentLV    = currentPV->GetLogicalVolume();
+  const G4VPhysicalVolume* currentPV    = preStepPoint->GetPhysicalVolume();
+  const G4LogicalVolume*   currentLV    = currentPV->GetLogicalVolume();
 
 #ifdef debugLog
   G4String           name   = currentPV->GetName();
@@ -188,7 +220,7 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
   if (parCode == mupPDG || parCode == mumPDG ) notaMuon = false;
   
   // angle condition
-  double theta_max = M_PI - 3.1305; // angle in radians corresponding to -5.2 eta
+  double theta_max = pi - 3.1305; // angle in radians corresponding to -5.2 eta
   double R_mom=sqrt(hit_mom.x()*hit_mom.x() + hit_mom.y()*hit_mom.y());
   double theta = atan2(R_mom,std::abs(pz));
   bool angleok = false;
@@ -215,8 +247,6 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
     LogDebug("ForwardSim") << " Current logical volume is " << nameVolume ;
 #endif
     
-    // track is killed in getFromLibrary...
-
     return 0;
   }
   
@@ -239,33 +269,20 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
   
   
   // Usual calculations
-  // G4ThreeVector      hitPoint = preStepPoint->GetPosition();	
-  // G4ThreeVector      hit_mom = preStepPoint->GetMomentumDirection();
   G4double           stepl    = aStep->GetStepLength()/cm;
   G4double           beta     = preStepPoint->GetBeta();
   G4double           charge   = preStepPoint->GetCharge();
-  //        G4VProcess*        curprocess   = preStepPoint->GetProcessDefinedStep();
-  //        G4String           namePr   = preStepPoint->GetProcessDefinedStep()->GetProcessName();
-  //        std::string nameProcess;
-  //        nameProcess.assign(namePr,0,4);
-  
-  //        G4LogicalVolume*   lv    = currentPV->GetLogicalVolume();
-  //        G4Material*        mat   = lv->GetMaterial();
-  //        G4double           rad   = mat->GetRadlen();
-  
   
 #ifdef debugLog
   // postStepPoint information *********************************************
-  G4StepPoint* postStepPoint= aStep->GetPostStepPoint();   
-  G4VPhysicalVolume* postPV= postStepPoint->GetPhysicalVolume();
+  const G4StepPoint* postStepPoint= aStep->GetPostStepPoint();   
+  const G4VPhysicalVolume* postPV= postStepPoint->GetPhysicalVolume();
   
   G4String           postname   = postPV->GetName();
   std::string        postnameVolume;
   postnameVolume.assign(postname,0,4);
   
   // theTrack information  *************************************************
-  // G4Track*        theTrack = aStep->GetTrack();   
-  //G4double        entot    = theTrack->GetTotalEnergy();
   G4ThreeVector   vert_mom = theTrack->GetVertexMomentumDirection();
   
   G4ThreeVector  localPoint = theTrack->GetTouchable()->GetHistory()->
@@ -313,7 +330,6 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
   */  
   if (currentLV == lvC3EF || currentLV == lvC4EF || currentLV == lvC3HF ||
       currentLV == lvC4HF) {
-    //      if(nameVolume == "C3EF" || nameVolume == "C4EF" || nameVolume == "C3HF" || nameVolume == "C4HF") {
     
     double bThreshold = 0.67;
     double nMedium = 1.4925;
@@ -363,16 +379,16 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
     double thcher = acos(std::min(std::max(costhcher,double(-1.)),double(1.)));
     
     // diff thetas of charged part. and quartz direction in LabRF:
-    double DelFibPart = fabs(th - thFibDirRad);
+    double DelFibPart = std::abs(th - thFibDirRad);
     
     // define real distances:
-    double d = fabs(tan(th)-tan(thFibDirRad));   
+    double d = std::abs(tan(th)-tan(thFibDirRad));   
     
     //       double a = fabs(tan(thFibDirRad)-tan(thFibDirRad+thFullReflRad));   
     //       double r = fabs(tan(th)-tan(th+thcher));   
     
     double a = tan(thFibDirRad)+tan(fabs(thFibDirRad-thFullReflRad));   
-    double r = tan(th)+tan(fabs(th-thcher));   
+    double r = tan(th)+tan(std::abs(th-thcher));   
     
     
     // define losses d_qz in cone of full reflection inside quartz direction
@@ -419,9 +435,9 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
 	  double arg_arcos = 0.;
 	  double tan_arcos = 2.*a*d;
 	  if(tan_arcos != 0.) arg_arcos =(r*r-a*a-d*d)/tan_arcos; 
-	  arg_arcos = fabs(arg_arcos);
+	  arg_arcos = std::abs(arg_arcos);
 	  double th_arcos = acos(std::min(std::max(arg_arcos,double(-1.)),double(1.)));
-	  d_qz = fabs(th_arcos/pi/2.);
+	  d_qz = std::abs(th_arcos/pi/2.);
 	  
 	  //	    }
 	  //             else
@@ -446,7 +462,7 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
 	( 1. - 1./(nMedium*nMedium*beta*beta) )*
 	photEnSpectrDE*stepl;
       
-      const double scale = (isHad ? non_compensation_factor : 1.0);
+      double scale = (isHad ? non_compensation_factor : 1.0);
       G4int poissNCherPhot = (G4int) G4Poisson(meanNCherPhot * scale);
       
       if(poissNCherPhot < 0) poissNCherPhot = 0;
@@ -530,15 +546,15 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
 
 //=======================================================================================
 
-uint32_t CastorSD::setDetUnitId(G4Step* aStep) {
-  return (numberingScheme == 0 ? 0 : numberingScheme->getUnitID(aStep));
+uint32_t CastorSD::setDetUnitId(const G4Step* aStep) {
+  return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(aStep));
 }
 
 //=======================================================================================
 
 void CastorSD::setNumberingScheme(CastorNumberingScheme* scheme) {
 
-  if (scheme != 0) {
+  if (scheme != nullptr) {
     edm::LogInfo("ForwardSim") << "CastorSD: updates numbering scheme for " 
 			       << GetName();
     if (numberingScheme) delete numberingScheme;
@@ -548,7 +564,7 @@ void CastorSD::setNumberingScheme(CastorNumberingScheme* scheme) {
 
 //=======================================================================================
 
-int CastorSD::setTrackID (G4Step* aStep) {
+int CastorSD::setTrackID (const G4Step* aStep) {
 
   theTrack     = aStep->GetTrack();
 
@@ -572,7 +588,8 @@ int CastorSD::setTrackID (G4Step* aStep) {
 
 //=======================================================================================
 
-uint32_t CastorSD::rotateUnitID(uint32_t unitID, G4Track* track, const CastorShowerEvent& shower) {
+uint32_t CastorSD::rotateUnitID(uint32_t unitID, const G4Track* track, 
+                                const CastorShowerEvent& shower) {
 // ==============================================================
 //
 //   o   Exploit Castor phi symmetry to return newUnitID for  
@@ -582,15 +599,15 @@ uint32_t CastorSD::rotateUnitID(uint32_t unitID, G4Track* track, const CastorSho
   
   // Get 'track' phi:
   double   trackPhi = track->GetPosition().phi(); 
-  if(trackPhi<0) trackPhi += 2*M_PI ;
+  if(trackPhi<0) trackPhi += twopi;
   // Get phi from primary that gave rise to SL 'shower':
   double  showerPhi = shower.getPrimPhi(); 
-  if(showerPhi<0) showerPhi += 2*M_PI ;
+  if(showerPhi<0) showerPhi += twopi;
   // Delta phi:
   
   //  Find the OctSector for which 'track' and 'shower' belong
-  int  trackOctSector = (int) (  trackPhi / (M_PI/4) ) ;
-  int showerOctSector = (int) ( showerPhi / (M_PI/4) ) ;
+  int  trackOctSector = (int) (  trackPhi / (pi/4) ) ;
+  int showerOctSector = (int) ( showerPhi / (pi/4) ) ;
   
   uint32_t  newUnitID;
   uint32_t         sec = ( ( unitID>>4 ) & 0xF ) ;
@@ -637,7 +654,7 @@ uint32_t CastorSD::rotateUnitID(uint32_t unitID, G4Track* track, const CastorSho
 
 //=======================================================================================
 
-void CastorSD::getFromLibrary (G4Step* aStep) {
+void CastorSD::getFromLibrary (const G4Step* aStep) {
 
 /////////////////////////////////////////////////////////////////////
 //
@@ -650,16 +667,11 @@ void CastorSD::getFromLibrary (G4Step* aStep) {
 //
 /////////////////////////////////////////////////////////////////////
 
-  preStepPoint  = aStep->GetPreStepPoint(); 
-  theTrack      = aStep->GetTrack();   
-  bool ok;
-  
   // ****    Call method to retrieve hits from the ShowerLibrary   ****
-  CastorShowerEvent hits = showerLibrary->getShowerHits(aStep, ok);
+  CastorShowerEvent hits = showerLibrary->getShowerHits(aStep, isAppliedSL);
 
   double etrack    = preStepPoint->GetKineticEnergy();
   int    primaryID = setTrackID(aStep);
-  // int    primaryID = theTrack->GetTrackID();
 
   // Reset entry point for new primary
   posGlobal = preStepPoint->GetPosition();
@@ -688,13 +700,12 @@ void CastorSD::getFromLibrary (G4Step* aStep) {
   double E_SLhit = hits.getPrimE() * GeV ;
   double scale = E_track/E_SLhit ;
 	
-	//Non compensation 
-	if (isHAD){
-		scale=scale*non_compensation_factor; // if hadronic extend the scale with the non-compensation factor
-	} else {
-		scale=scale; // if electromagnetic, don't do anything
-	}
-	
+  //Non compensation 
+  if (isHAD){
+    scale *= non_compensation_factor; 
+    // if hadronic extend the scale with the non-compensation factor
+    // if electromagnetic, don't do anything
+  }
   
 /*    double theTrackEnergy = theTrack->GetTotalEnergy() ; 
   
@@ -722,9 +733,9 @@ void CastorSD::getFromLibrary (G4Step* aStep) {
     if(isEM)  {
        // edepositEM  = nPhotoElectrons*GeV; 
        edepositEM  = nPhotoElectrons; 
-       edepositHAD = 0.;                 
+       edepositHAD = 0.f;           
     } else if(isHAD) {
-       edepositEM  = 0.;                  
+       edepositEM  = 0.f;                  
        edepositHAD = nPhotoElectrons;
        // edepositHAD = nPhotoElectrons*GeV;
     }
@@ -750,32 +761,5 @@ void CastorSD::getFromLibrary (G4Step* aStep) {
       if (!checkHit()) currentHit = createNewHit();
     }
   }  //  End of loop over hits
-
-  //Now kill the current track
-  if (ok) {
-    theTrack->SetTrackStatus(fStopAndKill);
-#ifdef debugLog
-    LogDebug("ForwardSim") << "CastorSD::getFromLibrary:"
-			   << "\n \"theTrack\" with TrackID() = " 
-			   << theTrack->GetTrackID() 
-			   << " and with energy " 
-			   << theTrack->GetTotalEnergy()
-			   << " has been set to be killed" ;
-#endif
-    G4TrackVector tv = *(aStep->GetSecondary());
-    for (unsigned int kk=0; kk<tv.size(); kk++) {
-      if (tv[kk]->GetVolume() == preStepPoint->GetPhysicalVolume()) {
-	tv[kk]->SetTrackStatus(fStopAndKill);
-#ifdef debugLog
-	LogDebug("ForwardSim") << "CastorSD::getFromLibrary:"
-			       << "\n tv[" << kk << "]->GetTrackID() = " 
-			       << tv[kk]->GetTrackID() 
-			       << " with energy " 
-			       << tv[kk]->GetTotalEnergy()
-			       << " has been set to be killed" ;
-#endif
-      }
-    }
-  }
 }
 

--- a/SimG4CMS/Forward/src/CastorShowerLibrary.cc
+++ b/SimG4CMS/Forward/src/CastorShowerLibrary.cc
@@ -20,8 +20,8 @@
 
 //#define DebugLog
 
-CastorShowerLibrary::CastorShowerLibrary(std::string & name, edm::ParameterSet const & p) 
-                                          : hf(0), evtInfo(0), emBranch(0), hadBranch(0),
+CastorShowerLibrary::CastorShowerLibrary(const std::string & name, edm::ParameterSet const & p) 
+                                          : hf(nullptr), evtInfo(nullptr), emBranch(nullptr), hadBranch(nullptr),
                                             nMomBin(0), totEvents(0), evtPerBin(0),
                                             nBinsE(0),nBinsEta(0),nBinsPhi(0),
                                             nEvtPerBinE(0),nEvtPerBinEta(0),nEvtPerBinPhi(0),
@@ -209,17 +209,17 @@ void CastorShowerLibrary::initParticleTable(G4ParticleTable * theParticleTable) 
 
 //=============================================================================================
 
-CastorShowerEvent CastorShowerLibrary::getShowerHits(G4Step * aStep, bool & ok) {
+CastorShowerEvent CastorShowerLibrary::getShowerHits(const G4Step * aStep, bool & ok) {
 
   G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
   // G4StepPoint * postStepPoint = aStep->GetPostStepPoint(); 
   G4Track *     track         = aStep->GetTrack();
   // Get Z-direction 
   const G4DynamicParticle *aParticle = track->GetDynamicParticle();
-  G4ThreeVector               momDir = aParticle->GetMomentumDirection();
+  const G4ThreeVector&               momDir = aParticle->GetMomentumDirection();
   //  double mom = aParticle->GetTotalMomentum();
 
-  G4ThreeVector hitPoint = preStepPoint->GetPosition();   
+  const G4ThreeVector& hitPoint = preStepPoint->GetPosition();   
   G4String      partType = track->GetDefinition()->GetParticleName();
   int           parCode  = track->GetDefinition()->GetPDGEncoding();
 

--- a/SimG4CMS/Forward/src/CastorShowerLibrary.cc
+++ b/SimG4CMS/Forward/src/CastorShowerLibrary.cc
@@ -211,14 +211,9 @@ void CastorShowerLibrary::initParticleTable(G4ParticleTable * theParticleTable) 
 
 CastorShowerEvent CastorShowerLibrary::getShowerHits(const G4Step * aStep, bool & ok) {
 
-  G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
-  // G4StepPoint * postStepPoint = aStep->GetPostStepPoint(); 
+  const G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
   G4Track *     track         = aStep->GetTrack();
   // Get Z-direction 
-  const G4DynamicParticle *aParticle = track->GetDynamicParticle();
-  const G4ThreeVector&               momDir = aParticle->GetMomentumDirection();
-  //  double mom = aParticle->GetTotalMomentum();
-
   const G4ThreeVector& hitPoint = preStepPoint->GetPosition();   
   G4String      partType = track->GetDefinition()->GetParticleName();
   int           parCode  = track->GetDefinition()->GetPDGEncoding();
@@ -234,8 +229,6 @@ CastorShowerEvent CastorShowerLibrary::getShowerHits(const G4Step * aStep, bool 
   ok = true;
 
   double pin    = preStepPoint->GetTotalEnergy();
-  //  double etain  = momDir.getEta();
-  //double phiin  = momDir.getPhi();
   
   double zint = hitPoint.z();
   double R=sqrt(hitPoint.x()*hitPoint.x() + hitPoint.y()*hitPoint.y());

--- a/SimG4CMS/Forward/src/TotemSD.cc
+++ b/SimG4CMS/Forward/src/TotemSD.cc
@@ -45,13 +45,13 @@
 //
 // constructors and destructor
 //
-TotemSD::TotemSD(std::string name, const DDCompactView & cpv,
+TotemSD::TotemSD(const std::string& name, const DDCompactView & cpv,
 		 const SensitiveDetectorCatalog & clg,
 		 edm::ParameterSet const & p, const SimTrackManager* manager) :
-  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(0), name(name),
-  hcID(-1), theHC(0), theManager(manager), currentHit(0), theTrack(0), 
-  currentPV(0), unitID(0),  previousUnitID(0), preStepPoint(0), 
-  postStepPoint(0), eventno(0){
+  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(nullptr), 
+  hcID(-1), theHC(nullptr), theManager(manager), currentHit(nullptr), theTrack(nullptr), 
+  currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
+  postStepPoint(nullptr), eventno(0){
 
   //Add Totem Sentitive Detector Names
   collectionName.insert(name);
@@ -97,17 +97,17 @@ TotemSD::TotemSD(std::string name, const DDCompactView & cpv,
 } 
 
 TotemSD::~TotemSD() { 
-  if (slave)           delete slave; 
-  if (numberingScheme) delete numberingScheme;
+  delete slave; 
+  delete numberingScheme;
 }
 
 bool TotemSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 
-  if (aStep == NULL) {
+  if (aStep == nullptr) {
     return true;
   } else {
     GetStepInfo(aStep);
-    if (HitExists() == false && edeposit>0.) { 
+    if (HitExists() == false && edeposit>0.f) { 
       CreateNewHit();
       return true;
     }
@@ -120,16 +120,16 @@ bool TotemSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
   return true;
 }
 
-uint32_t TotemSD::setDetUnitId(G4Step * aStep) { 
+uint32_t TotemSD::setDetUnitId(const G4Step * aStep) { 
 
-  return (numberingScheme == 0 ? 0 : numberingScheme->GetUnitID(aStep));
+  return (numberingScheme == nullptr ? 0 : numberingScheme->GetUnitID(aStep));
 }
 
 void TotemSD::Initialize(G4HCofThisEvent * HCE) { 
 
-  LogDebug("ForwardSim") << "TotemSD : Initialize called for " << name;
+  LogDebug("ForwardSim") << "TotemSD : Initialize called for " << GetName();
 
-  theHC = new TotemG4HitCollection(name, collectionName[0]);
+  theHC = new TotemG4HitCollection(GetName(), collectionName[0]);
   if (hcID<0) 
     hcID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]);
   HCE->AddHitsCollection(hcID, theHC);
@@ -176,8 +176,8 @@ void TotemSD::PrintAll() {
   theHC->PrintAllHits();
 } 
 
-void TotemSD::fillHits(edm::PSimHitContainer& c, std::string n) {
-  if (slave->name() == n) c=slave->hits();
+void TotemSD::fillHits(edm::PSimHitContainer& chit, const std::string& nhit) {
+  if (slave->name() == nhit) chit=slave->hits();
 }
 
 void TotemSD::update (const BeginOfEvent * i) {
@@ -185,9 +185,6 @@ void TotemSD::update (const BeginOfEvent * i) {
                        << " !" ;
    clearHits();
    eventno = (*i)()->GetEventID();
-}
-
-void TotemSD::update (const ::EndOfEvent*) {
 }
 
 void TotemSD::clearHits(){
@@ -202,17 +199,15 @@ G4ThreeVector TotemSD::SetToLocal(const G4ThreeVector& global) {
   return localPoint;  
 }
 
-void TotemSD::GetStepInfo(G4Step* aStep) {
+void TotemSD::GetStepInfo(const G4Step* aStep) {
   
   preStepPoint = aStep->GetPreStepPoint(); 
   postStepPoint= aStep->GetPostStepPoint(); 
   theTrack     = aStep->GetTrack();   
-  //Local3DPoint theEntryPoint = SensitiveDetector::InitialStepPosition(aStep,LocalCoordinates);  
-  //Local3DPoint theExitPoint  = SensitiveDetector::FinalStepPosition(aStep,LocalCoordinates);
+
   hitPoint     = preStepPoint->GetPosition();	
   currentPV    = preStepPoint->GetPhysicalVolume();
 
-  // double weight = 1; 
   G4String name = currentPV->GetName();
   name.assign(name,0,4);
   G4String particleType = theTrack->GetDefinition()->GetParticleName();
@@ -390,10 +385,10 @@ G4ThreeVector TotemSD::PosizioEvo(const G4ThreeVector& Pos, double vx, double vy
   //  double temp_evo_X;
   //  double temp_evo_Y;
   //  double temp_evo_Z;
-  //  temp_evo_Z = fabs(Pos.z())/Pos.z()*220000.; 
+  //  temp_evo_Z = std::abs(Pos.z())/Pos.z()*220000.; 
  
   //csi=-dp/d
-  double csi = fabs((7000.-pabs)/7000.);
+  double csi = std::abs((7000.-pabs)/7000.);
 
   // all in m 
   const int no_rp=4;
@@ -428,22 +423,22 @@ G4ThreeVector TotemSD::PosizioEvo(const G4ThreeVector& Pos, double vx, double vy
    
    
   //pass TAN@141
-  if (fabs(y_par[0])<pipelim[0][1] && sqrt((y_par[0]*y_par[0])+(x_par[0]*x_par[0]))<pipelim[0][0])  {
+  if (std::abs(y_par[0])<pipelim[0][1] && sqrt((y_par[0]*y_par[0])+(x_par[0]*x_par[0]))<pipelim[0][0])  {
     //pass 149
     if ((sqrt((y_par[1]*y_par[1])+(x_par[1]*x_par[1]))<pipelim[1][0]) &&
-	(fabs(y_par[1])>detlim[1][1] || x_par[1]>detlim[1][0]))  {
+	(std::abs(y_par[1])>detlim[1][1] || x_par[1]>detlim[1][0]))  {
       accettanza = 1;
     }
   }
 
       
   //pass TAN@141
-  if (fabs(y_par[0])<pipelim[0][1] && sqrt((y_par[0])*(y_par[0])+(x_par[0])*(x_par[0]))<pipelim[0][0]) {
+  if (std::abs(y_par[0])<pipelim[0][1] && sqrt((y_par[0])*(y_par[0])+(x_par[0])*(x_par[0]))<pipelim[0][0]) {
     //pass Q5@198
-    if (fabs(y_par[2])<pipelim[2][1] && sqrt((y_par[2]*y_par[2])+(x_par[2]*x_par[2]))<pipelim[2][0]) {
+    if (std::abs(y_par[2])<pipelim[2][1] && sqrt((y_par[2]*y_par[2])+(x_par[2]*x_par[2]))<pipelim[2][0]) {
       //pass 220
       if ((sqrt((y_par[3]*y_par[3])+(x_par[3]*x_par[3]))<pipelim[3][0]) &&
-	  (fabs(y_par[3])>detlim[3][1] || x_par[3]>detlim[3][0])) {
+	  (std::abs(y_par[3])>detlim[3][1] || x_par[3]>detlim[3][0])) {
 	accettanza = 1;
 	
 	PosEvo.setX(1000*x_par[3]);
@@ -508,7 +503,7 @@ void TotemSD::UpdateHit() {
 void TotemSD::StoreHit(TotemG4Hit* hit) {
 
   if (primID<0) return;
-  if (hit == 0 ) {
+  if (hit == nullptr ) {
     edm::LogWarning("ForwardSim") << "TotemSD: hit to be stored is NULL !!";
     return;
   }

--- a/SimG4CMS/Forward/src/ZdcShowerLibrary.cc
+++ b/SimG4CMS/Forward/src/ZdcShowerLibrary.cc
@@ -16,7 +16,7 @@
 #include "Randomize.hh"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
-ZdcShowerLibrary::ZdcShowerLibrary(std::string & name, const DDCompactView & cpv,
+ZdcShowerLibrary::ZdcShowerLibrary(const std::string & name, const DDCompactView & cpv,
 				 edm::ParameterSet const & p) {
   edm::ParameterSet m_HS   = p.getParameter<edm::ParameterSet>("ZdcShowerLibrary");
   verbose                  = m_HS.getUntrackedParameter<int>("Verbosity",0);
@@ -53,17 +53,17 @@ void ZdcShowerLibrary::initRun(G4ParticleTable *theParticleTable){
 		       << anutauPDG;
 }
 
-std::vector<ZdcShowerLibrary::Hit> & ZdcShowerLibrary::getHits(G4Step * aStep, bool & ok) {
+std::vector<ZdcShowerLibrary::Hit> & ZdcShowerLibrary::getHits(const G4Step * aStep, bool & ok) {
 
-  G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
-  G4StepPoint * postStepPoint = aStep->GetPostStepPoint(); 
-  G4Track *     track    = aStep->GetTrack();
+  const G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
+  const G4StepPoint * postStepPoint = aStep->GetPostStepPoint(); 
+  const G4Track *     track    = aStep->GetTrack();
 
   const G4DynamicParticle *aParticle = track->GetDynamicParticle();
-  G4ThreeVector momDir = aParticle->GetMomentumDirection();
+  const G4ThreeVector& momDir = aParticle->GetMomentumDirection();
   double energy = preStepPoint->GetKineticEnergy();
   G4ThreeVector hitPoint = preStepPoint->GetPosition();  
-  G4ThreeVector hitPointOrig = preStepPoint->GetPosition();
+  const G4ThreeVector& hitPointOrig = preStepPoint->GetPosition();
   G4int parCode  = track->GetDefinition()->GetPDGEncoding();
 
   hits.clear();
@@ -87,9 +87,9 @@ std::vector<ZdcShowerLibrary::Hit> & ZdcShowerLibrary::getHits(G4Step * aStep, b
   ZdcShowerLibrary::Hit oneHit;
   side = (hitPointOrig.z() > 0.) ?  true : false;  
   
-  float xWidthEM = fabs(theXChannelBoundaries[0] - theXChannelBoundaries[1]);
-  float zWidthEM = fabs(theZSectionBoundaries[0] - theZSectionBoundaries[1]); 
-  float zWidthHAD = fabs(theZHadChannelBoundaries[0] -theZHadChannelBoundaries[1]); 
+  float xWidthEM = std::abs(theXChannelBoundaries[0] - theXChannelBoundaries[1]);
+  float zWidthEM = std::abs(theZSectionBoundaries[0] - theZSectionBoundaries[1]); 
+  float zWidthHAD = std::abs(theZHadChannelBoundaries[0] -theZHadChannelBoundaries[1]); 
 
   for (int i = 0; i < npe; i++) {
     if(i < 5){
@@ -128,7 +128,7 @@ std::vector<ZdcShowerLibrary::Hit> & ZdcShowerLibrary::getHits(G4Step * aStep, b
     // Note: coodinates of hit are relative to center of detector (X0,Y0,Z0) 
     hitPoint.setX(hitPointOrig.x()-X0);
     hitPoint.setY(hitPointOrig.y()-Y0);
-    double setZ= (hitPointOrig.z()> 0.) ? hitPointOrig.z()- Z0 : fabs(hitPointOrig.z()) - Z0;
+    double setZ= (hitPointOrig.z()> 0.) ? hitPointOrig.z()- Z0 : std::abs(hitPointOrig.z()) - Z0;
     hitPoint.setZ(setZ);
 
     int dE = getEnergyFromLibrary(hitPoint,momDir,energy,parCode,section,side,channel);

--- a/SimG4CMS/HGCalTestBeam/interface/AHCalSD.h
+++ b/SimG4CMS/HGCalTestBeam/interface/AHCalSD.h
@@ -13,11 +13,11 @@ class AHCalSD : public CaloSD {
 
 public:    
 
-  AHCalSD(G4String , const DDCompactView &, const SensitiveDetectorCatalog &,
+  AHCalSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	  edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~AHCalSD();
-  virtual double                getEnergyDeposit(G4Step* );
-  virtual uint32_t              setDetUnitId(G4Step* step);
+  ~AHCalSD() override;
+  double                getEnergyDeposit(const G4Step* ) override;
+  uint32_t              setDetUnitId(const G4Step* step) override;
   bool                          unpackIndex(const uint32_t & idx, int & row, 
 					    int& col, int& depth);
 protected:

--- a/SimG4CMS/HGCalTestBeam/interface/HGCalTB16SD01.h
+++ b/SimG4CMS/HGCalTestBeam/interface/HGCalTB16SD01.h
@@ -20,18 +20,18 @@ class HGCalTB16SD01 : public CaloSD {
 
 public:    
 
-  HGCalTB16SD01(G4String , const DDCompactView &, 
+  HGCalTB16SD01(const std::string& , const DDCompactView &, 
 		const SensitiveDetectorCatalog &, edm::ParameterSet const &, 
 		const SimTrackManager*);
-  virtual ~HGCalTB16SD01();
-  virtual double   getEnergyDeposit(G4Step* );
-  virtual uint32_t setDetUnitId(G4Step* step);
+  ~HGCalTB16SD01() override;
+  double   getEnergyDeposit(const G4Step* ) override;
+  uint32_t setDetUnitId(const G4Step* step) override;
   static uint32_t  packIndex(int det, int lay, int x, int y);
   static void      unpackIndex(const uint32_t & idx, int& det, int& lay,
 			       int& x, int& y);
 
 private:    
-  void             initialize(G4StepPoint* point);
+  void             initialize(const G4StepPoint* point);
 
   std::string      matName_;
   bool             useBirk_;

--- a/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
+++ b/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
@@ -17,7 +17,7 @@
 #include <iomanip>
 //#define EDM_ML_DEBUG
 
-AHCalSD::AHCalSD(G4String name, const DDCompactView & cpv,
+AHCalSD::AHCalSD(const std::string& name, const DDCompactView & cpv,
 		 const SensitiveDetectorCatalog & clg,
 		 edm::ParameterSet const & p, const SimTrackManager* manager) : 
   CaloSD(name, cpv, clg, p, manager,
@@ -40,7 +40,7 @@ AHCalSD::AHCalSD(G4String name, const DDCompactView & cpv,
 
 AHCalSD::~AHCalSD() { }
 
-double AHCalSD::getEnergyDeposit(G4Step* aStep) {
+double AHCalSD::getEnergyDeposit(const G4Step* aStep) {
 
   double destep = aStep->GetTotalEnergyDeposit();
   double wt2    = aStep->GetTrack()->GetWeight();
@@ -57,11 +57,10 @@ double AHCalSD::getEnergyDeposit(G4Step* aStep) {
   return edep;
 }
 
-uint32_t AHCalSD::setDetUnitId(G4Step * aStep) { 
+uint32_t AHCalSD::setDetUnitId(const G4Step * aStep) { 
 
-  G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();
-  G4ThreeVector hitPoint    = preStepPoint->GetPosition();
 
   int depth = (touch->GetReplicaNumber(1));
   int incol = ((touch->GetReplicaNumber(0))%10);

--- a/SimG4CMS/HGCalTestBeam/src/HGCalTB16SD01.cc
+++ b/SimG4CMS/HGCalTestBeam/src/HGCalTB16SD01.cc
@@ -21,7 +21,7 @@
 
 //#define EDM_ML_DEBUG
 
-HGCalTB16SD01::HGCalTB16SD01(G4String name, const DDCompactView & cpv,
+HGCalTB16SD01::HGCalTB16SD01(const std::string& name, const DDCompactView & cpv,
 			     const SensitiveDetectorCatalog & clg,
 			     edm::ParameterSet const & p, 
 			     const SimTrackManager* manager) : 
@@ -44,9 +44,9 @@ HGCalTB16SD01::HGCalTB16SD01(G4String name, const DDCompactView & cpv,
 
 HGCalTB16SD01::~HGCalTB16SD01() {}
 
-double HGCalTB16SD01::getEnergyDeposit(G4Step* aStep) {
+double HGCalTB16SD01::getEnergyDeposit(const G4Step* aStep) {
 
-  G4StepPoint* point = aStep->GetPreStepPoint();
+  const G4StepPoint* point = aStep->GetPreStepPoint();
   if (initialize_) initialize(point);
   double destep = aStep->GetTotalEnergyDeposit();
   double wt2    = aStep->GetTrack()->GetWeight();
@@ -63,9 +63,9 @@ double HGCalTB16SD01::getEnergyDeposit(G4Step* aStep) {
   return weight*destep;
 }
 
-uint32_t HGCalTB16SD01::setDetUnitId(G4Step * aStep) { 
+uint32_t HGCalTB16SD01::setDetUnitId(const G4Step * aStep) { 
 
-  G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
+  const G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();
   G4String name             = preStepPoint->GetPhysicalVolume()->GetName();
 
@@ -106,7 +106,7 @@ void HGCalTB16SD01::unpackIndex(const uint32_t & idx, int& det, int& lay,
 
 }
 
-void HGCalTB16SD01::initialize(G4StepPoint* point) {
+void HGCalTB16SD01::initialize(const G4StepPoint* point) {
   if (matName_ == point->GetMaterial()->GetName()) {
     matScin_    =  point->GetMaterial();
     initialize_ = false;

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB02HcalNumberingScheme.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB02HcalNumberingScheme.h
@@ -25,8 +25,8 @@ class HcalTB02HcalNumberingScheme : public HcalTB02NumberingScheme {
 
 public:
   HcalTB02HcalNumberingScheme();
-  virtual ~HcalTB02HcalNumberingScheme();
-  virtual int getUnitID(const G4Step* aStep) const;
+  ~HcalTB02HcalNumberingScheme() override;
+  int getUnitID(const G4Step* aStep) const override;
 
   int getphiScaleF() const { return phiScale;}
   int getetaScaleF() const { return etaScale;}

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB02SD.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB02SD.h
@@ -24,23 +24,22 @@
 #include "SimG4CMS/HcalTestBeam/interface/HcalTB02NumberingScheme.h"
 
 #include "G4String.hh"
-#include <boost/cstdint.hpp>
 
 class HcalTB02SD : public CaloSD {
 
 public:
-  HcalTB02SD(G4String, const DDCompactView &, const SensitiveDetectorCatalog &,
+  HcalTB02SD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	     edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~HcalTB02SD();
-  virtual double getEnergyDeposit(G4Step*);
-  virtual uint32_t setDetUnitId(G4Step* step);
+  ~HcalTB02SD() override;
+  double getEnergyDeposit(const G4Step*) override;
+  uint32_t setDetUnitId(const G4Step* step) override;
   void setNumberingScheme(HcalTB02NumberingScheme* scheme);
 
 private:    
 
-  void   initMap(G4String, const DDCompactView &);
-  double curve_LY(G4String& , G4StepPoint* ); 
-  double crystalLength(G4String);
+  void   initMap(const G4String&, const DDCompactView &);
+  double curve_LY(const G4String& , const G4StepPoint* ); 
+  double crystalLength(const G4String&);
 
 private:    
 

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB02XtalNumberingScheme.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB02XtalNumberingScheme.h
@@ -25,8 +25,8 @@ class HcalTB02XtalNumberingScheme : public HcalTB02NumberingScheme {
 
 public:
   HcalTB02XtalNumberingScheme();
-  virtual ~HcalTB02XtalNumberingScheme();
-  virtual int getUnitID(const G4Step* aStep) const;
+  ~HcalTB02XtalNumberingScheme() override;
+  int getUnitID(const G4Step* aStep) const override;
 
 };
 

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB06BeamSD.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB06BeamSD.h
@@ -21,17 +21,17 @@ class HcalTB06BeamSD : public CaloSD {
 
 public:    
 
-  HcalTB06BeamSD(const G4String&, const DDCompactView &, 
+  HcalTB06BeamSD(const std::string&, const DDCompactView &, 
                  const SensitiveDetectorCatalog &,
 		 edm::ParameterSet const &, const SimTrackManager*);
   ~HcalTB06BeamSD() override;
-  double getEnergyDeposit(G4Step* ) override;
-  uint32_t setDetUnitId(G4Step* step) override;
+  double getEnergyDeposit(const G4Step* ) override;
+  uint32_t setDetUnitId(const G4Step* step) override;
 
 private:    
 
   std::vector<G4String> getNames(DDFilteredView&);
-  bool                  isItWireChamber(G4String);
+  bool                  isItWireChamber(const G4String&);
 
   bool                  useBirk;
   double                birk1, birk2, birk3;

--- a/SimG4CMS/Muon/interface/MuonEndcapFrameRotation.h
+++ b/SimG4CMS/Muon/interface/MuonEndcapFrameRotation.h
@@ -17,8 +17,8 @@
 
 class MuonEndcapFrameRotation : public MuonFrameRotation {
  public:
-  virtual ~MuonEndcapFrameRotation() {};
-  virtual Local3DPoint transformPoint(const Local3DPoint &,const G4Step *) const;
+  ~MuonEndcapFrameRotation() override {};
+  Local3DPoint transformPoint(const Local3DPoint &,const G4Step *) const override;
  private:
 };
 

--- a/SimG4CMS/Muon/interface/MuonEndcapFrameRotation.h
+++ b/SimG4CMS/Muon/interface/MuonEndcapFrameRotation.h
@@ -18,7 +18,7 @@
 class MuonEndcapFrameRotation : public MuonFrameRotation {
  public:
   ~MuonEndcapFrameRotation() override {};
-  Local3DPoint transformPoint(const Local3DPoint &,const G4Step *) const override;
+  Local3DPoint transformPoint(const Local3DPoint &,const G4Step * step=nullptr) const override;
  private:
 };
 

--- a/SimG4CMS/Muon/interface/MuonGEMFrameRotation.h
+++ b/SimG4CMS/Muon/interface/MuonGEMFrameRotation.h
@@ -22,8 +22,8 @@ class MuonGEMFrameRotation : public MuonFrameRotation {
 
 public:
   MuonGEMFrameRotation( const MuonDDDConstants& muonConstants );
-  virtual ~MuonGEMFrameRotation();
-  virtual Local3DPoint transformPoint(const Local3DPoint &, const G4Step *) const;
+  ~MuonGEMFrameRotation() override;
+  Local3DPoint transformPoint(const Local3DPoint &, const G4Step *) const override;
 
 private:
   MuonG4Numbering* g4numbering;

--- a/SimG4CMS/Muon/interface/MuonME0FrameRotation.h
+++ b/SimG4CMS/Muon/interface/MuonME0FrameRotation.h
@@ -23,8 +23,8 @@ class MuonME0FrameRotation : public MuonFrameRotation {
 
 public:
   MuonME0FrameRotation( const MuonDDDConstants& muonConstants );
-  virtual ~MuonME0FrameRotation();
-  virtual Local3DPoint transformPoint(const Local3DPoint &, const G4Step *) const;
+  ~MuonME0FrameRotation() override;
+  Local3DPoint transformPoint(const Local3DPoint &, const G4Step *) const override;
 
 private:
   MuonG4Numbering* g4numbering;

--- a/SimG4CMS/Muon/interface/MuonRPCFrameRotation.h
+++ b/SimG4CMS/Muon/interface/MuonRPCFrameRotation.h
@@ -21,8 +21,8 @@ class MuonDDDConstants;
 class MuonRPCFrameRotation : public MuonFrameRotation {
  public:
   MuonRPCFrameRotation( const MuonDDDConstants& constants );
-  virtual ~MuonRPCFrameRotation();
-  virtual Local3DPoint transformPoint(const Local3DPoint &, const G4Step *) const;
+  ~MuonRPCFrameRotation() override;
+  Local3DPoint transformPoint(const Local3DPoint &, const G4Step *) const override;
  private:
   MuonG4Numbering* g4numbering;
   int theRegion;

--- a/SimG4CMS/Muon/interface/MuonSensitiveDetector.h
+++ b/SimG4CMS/Muon/interface/MuonSensitiveDetector.h
@@ -44,34 +44,31 @@ class SimTrackManager;
 
 class MuonSensitiveDetector : 
 public SensitiveTkDetector,
-public Observer<const BeginOfEvent*>,
-public Observer<const EndOfEvent*>
+public Observer<const BeginOfEvent*>
  {
 
  public:    
-  MuonSensitiveDetector(std::string, const DDCompactView &,
+  MuonSensitiveDetector(const std::string&, const DDCompactView &,
 			const SensitiveDetectorCatalog &, edm::ParameterSet const &,
 			const SimTrackManager*);
-  virtual ~MuonSensitiveDetector();
-  virtual G4bool ProcessHits(G4Step *,G4TouchableHistory *);
-  virtual uint32_t setDetUnitId(G4Step *);
-  virtual void EndOfEvent(G4HCofThisEvent*);
+  ~MuonSensitiveDetector() override;
+  G4bool ProcessHits(G4Step *,G4TouchableHistory *) override;
+  uint32_t setDetUnitId(const G4Step *) override;
+  void EndOfEvent(G4HCofThisEvent*) override;
 
-  void fillHits(edm::PSimHitContainer&, std::string use);
-  std::vector<std::string> getNames();
-  std::string type();
+  void fillHits(edm::PSimHitContainer&, const std::string& use) override;
+  //  std::string type();
 
   const MuonSlaveSD* GetSlaveMuon() const {
     return slaveMuon; }
   
  private:
-  void update(const BeginOfEvent *);
-  void update(const ::EndOfEvent *);
-  virtual void clearHits();
+  void update(const BeginOfEvent *) override;
+  void clearHits() override;
 
-  Local3DPoint toOrcaRef(Local3DPoint in ,G4Step * s);
-  Local3DPoint toOrcaUnits(Local3DPoint);
-  Global3DPoint toOrcaUnits(Global3DPoint);
+  Local3DPoint toOrcaRef(const Local3DPoint& in ,const G4Step *);
+  Local3DPoint toOrcaUnits(const Local3DPoint&);
+  Global3DPoint toOrcaUnits(const Global3DPoint&);
 
   TrackInformation* getOrCreateTrackInformation( const G4Track* theTrack );
 
@@ -82,10 +79,10 @@ public Observer<const EndOfEvent*>
   MuonFrameRotation* theRotation;
   MuonG4Numbering* g4numbering;
 
-  void storeVolumeAndTrack(G4Step *);
-  bool newHit(G4Step *);
-  void createHit(G4Step *);
-  void updateHit(G4Step *);
+  void storeVolumeAndTrack(const G4Step *);
+  bool newHit(const G4Step *);
+  void createHit(const G4Step *);
+  void updateHit(const G4Step *);
   void saveHit();
   
   /**
@@ -93,8 +90,8 @@ public Observer<const EndOfEvent*>
    * one or more levels up the volume hierarchy: e.g. levelsUp = 1 for immediate parent. <BR>
    * This is done by moving from local_1 -> global -> local_2.
    */
-  Local3DPoint InitialStepPositionVsParent(G4Step * currentStep, G4int levelsUp);
-  Local3DPoint FinalStepPositionVsParent(G4Step * currentStep, G4int levelsUp);
+  Local3DPoint InitialStepPositionVsParent(const G4Step * currentStep, G4int levelsUp);
+  Local3DPoint FinalStepPositionVsParent(const G4Step * currentStep, G4int levelsUp);
 
   G4VPhysicalVolume * thePV;
   UpdatablePSimHit* theHit;

--- a/SimG4CMS/Muon/interface/MuonSlaveSD.h
+++ b/SimG4CMS/Muon/interface/MuonSlaveSD.h
@@ -31,11 +31,11 @@ public:
   typedef std::vector<PSimHit> Collection;
   typedef Collection::const_iterator const_iterator;
   MuonSlaveSD(MuonSubDetector*,const SimTrackManager*);
-  virtual ~MuonSlaveSD();
+  ~MuonSlaveSD() override;
   virtual void clearHits();
-  virtual bool format();
-  virtual const_iterator begin() { return hits_.begin();}
-  virtual const_iterator end()   { return hits_.end();}
+  bool format() override;
+  const_iterator begin() override { return hits_.begin();}
+  const_iterator end() override   { return hits_.end();}
 
 protected: 
   Collection 	     hits_;

--- a/SimG4CMS/Muon/src/MuonEndcapFrameRotation.cc
+++ b/SimG4CMS/Muon/src/MuonEndcapFrameRotation.cc
@@ -3,20 +3,12 @@
 #include "G4StepPoint.hh"
 #include "G4TouchableHistory.hh"
 
-Local3DPoint MuonEndcapFrameRotation::transformPoint(const Local3DPoint & point,const G4Step * s=0) const {
-  if (!s)
-    return Local3DPoint(0.,0.,0.);
+Local3DPoint MuonEndcapFrameRotation::transformPoint(const Local3DPoint & point,const G4Step * step) const {
+  if (!step)
+    return std::move(Local3DPoint(0.,0.,0.));
       
-  const G4StepPoint * preStepPoint = s->GetPreStepPoint();
-  const G4TouchableHistory * theTouchable = (const G4TouchableHistory *)preStepPoint->GetTouchable();
-  const G4ThreeVector trans=theTouchable->GetTranslation();
+  const G4ThreeVector trans = step->GetPreStepPoint()->GetTouchable()->GetTranslation();
   
-  if (trans.z()<0) {
-    //      return Local3DPoint(point.x(),-point.z(),point.y());
-    //      return Local3DPoint(-point.x(),point.z(),-point.y());
-    return Local3DPoint(-point.x(),-point.z(),-point.y());
-  } else {
-    //      return Local3DPoint(point.x(),point.z(),-point.y());
-    return Local3DPoint(point.x(),point.z(),-point.y());
-  }
+  return std::move((trans.z()<0) ? Local3DPoint(-point.x(),-point.z(),-point.y()) 
+		   : Local3DPoint(point.x(),point.z(),-point.y()));
 } 

--- a/SimG4CMS/Muon/src/MuonGEMFrameRotation.cc
+++ b/SimG4CMS/Muon/src/MuonGEMFrameRotation.cc
@@ -22,7 +22,7 @@ MuonGEMFrameRotation::~MuonGEMFrameRotation() {
 }
 
 Local3DPoint MuonGEMFrameRotation::transformPoint(const Local3DPoint & point,const G4Step * aStep=0) const {
-  if (!aStep) return Local3DPoint(0.,0.,0.);  
+  if (!aStep) return std::move(Local3DPoint(0.,0.,0.));  
 
-  return Local3DPoint(point.x(),point.z(),-point.y());
+  return std::move(Local3DPoint(point.x(),point.z(),-point.y()));
 }

--- a/SimG4CMS/Muon/src/MuonME0FrameRotation.cc
+++ b/SimG4CMS/Muon/src/MuonME0FrameRotation.cc
@@ -24,8 +24,8 @@ MuonME0FrameRotation::~MuonME0FrameRotation() {
 }
 
 Local3DPoint MuonME0FrameRotation::transformPoint(const Local3DPoint & point,const G4Step * aStep=0) const {
-  if (!aStep) return Local3DPoint(0.,0.,0.);  
+  if (!aStep) return std::move(Local3DPoint(0.,0.,0.));  
 
   edm::LogVerbatim("MuonME0FrameRotation")<<"MuonME0FrameRotation transformPoint :: Local3DPoint (" <<point.x()<<","<<point.z()<<","<<-point.y()<<")" ;
-  return Local3DPoint(point.x(),point.z(),-point.y());
+  return std::move(Local3DPoint(point.x(),point.z(),-point.y()));
 }

--- a/SimG4CMS/Muon/src/MuonRPCFrameRotation.cc
+++ b/SimG4CMS/Muon/src/MuonRPCFrameRotation.cc
@@ -19,14 +19,14 @@ MuonRPCFrameRotation::~MuonRPCFrameRotation(){
 
 Local3DPoint MuonRPCFrameRotation::transformPoint(const Local3DPoint & point,const G4Step * aStep=0) const {
   if (!aStep)
-    return Local3DPoint(0.,0.,0.);  
+    return std::move(Local3DPoint(0.,0.,0.));  
 
   //check if endcap
   MuonBaseNumber num = g4numbering->PhysicalVolumeToBaseNumber(aStep);
   bool endcap_muon = (num.getSuperNo(theRegion)!=1);
   if (endcap_muon){
-    return Local3DPoint(point.x(),point.z(),-point.y());
+    return std::move(Local3DPoint(point.x(),point.z(),-point.y()));
   } else {
-    return point; 
+    return std::move(point); 
   }
 }

--- a/SimG4CMS/ShowerLibraryProducer/interface/FiberG4Hit.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/FiberG4Hit.h
@@ -16,8 +16,8 @@ class FiberG4Hit : public G4VHit {
 public:
 
   FiberG4Hit();
-  FiberG4Hit(G4LogicalVolume* logVol, G4int tower, G4int depth, G4int tkID);
-  virtual ~FiberG4Hit();
+  FiberG4Hit(const G4LogicalVolume* logVol, G4int tower, G4int depth, G4int tkID);
+  ~FiberG4Hit() override;
   FiberG4Hit(const FiberG4Hit &right);
   const FiberG4Hit& operator=(const FiberG4Hit &right);
   G4int operator==(const FiberG4Hit &right) const;

--- a/SimG4CMS/ShowerLibraryProducer/interface/FiberSD.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/FiberSD.h
@@ -33,25 +33,23 @@ public:
 
   FiberSD(std::string, const DDCompactView&, const SensitiveDetectorCatalog&,
 	  edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~FiberSD();
+  ~FiberSD() override;
 
-  virtual void     Initialize(G4HCofThisEvent*HCE);
-  virtual G4bool   ProcessHits(G4Step* aStep,G4TouchableHistory* ROhist);
-  virtual void     EndOfEvent(G4HCofThisEvent* HCE);
-  virtual void     clear();
-  virtual void     DrawAll();
-  virtual void     PrintAll();
+  void     Initialize(G4HCofThisEvent*HCE) override;
+  G4bool   ProcessHits(G4Step* aStep,G4TouchableHistory* ROhist) override;
+  uint32_t setDetUnitId(const G4Step*) override;
+  void     EndOfEvent(G4HCofThisEvent* HCE) override;
+  void     clear() override;
+  void     DrawAll() override;
+  void     PrintAll() override;
 
 protected:
 
-  virtual void     clearHits();
-  virtual uint32_t setDetUnitId(G4Step*);
-  virtual void     fillHits(edm::PCaloHitContainer&, std::string);
-
-  virtual void     update(const BeginOfJob *);
-  virtual void     update(const BeginOfRun *);
-  virtual void     update(const BeginOfEvent *);
-  virtual void     update(const ::EndOfEvent *);
+  void     clearHits() override;
+  void     update(const BeginOfJob *) override;
+  void     update(const BeginOfRun *) override;
+  void     update(const BeginOfEvent *) override;
+  void     update(const ::EndOfEvent *) override;
 
 private:
 

--- a/SimG4CMS/ShowerLibraryProducer/interface/HFChamberSD.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/HFChamberSD.h
@@ -22,20 +22,19 @@ public:
 
   HFChamberSD(std::string, const DDCompactView&, const SensitiveDetectorCatalog&,
 	  edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~HFChamberSD();
+  ~HFChamberSD() override;
 
-  virtual void     Initialize(G4HCofThisEvent*HCE);
-  virtual G4bool   ProcessHits(G4Step* aStep,G4TouchableHistory* ROhist);
-  virtual void     EndOfEvent(G4HCofThisEvent* HCE);
-  virtual void     clear();
-  virtual void     DrawAll();
-  virtual void     PrintAll();
+  void     Initialize(G4HCofThisEvent*HCE) override;
+  G4bool   ProcessHits(G4Step* aStep,G4TouchableHistory* ROhist) override;
+  uint32_t setDetUnitId(const G4Step*) override;
+  void     EndOfEvent(G4HCofThisEvent* HCE) override;
+  void     clear() override;
+  void     DrawAll() override;
+  void     PrintAll() override;
 
 protected:
 
-  virtual void     clearHits();
-  virtual uint32_t setDetUnitId(G4Step*);
-  virtual void     fillHits(edm::PCaloHitContainer&, std::string);
+  void     clearHits() override;
 
 private:
 

--- a/SimG4CMS/ShowerLibraryProducer/interface/HFShowerG4Hit.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/HFShowerG4Hit.h
@@ -18,7 +18,7 @@ public:
 
   HFShowerG4Hit();
   HFShowerG4Hit(G4int hitId, G4int tkID, double edep, double time);
-  virtual ~HFShowerG4Hit();
+  ~HFShowerG4Hit() override;
   HFShowerG4Hit(const HFShowerG4Hit &right);
   const HFShowerG4Hit& operator=(const HFShowerG4Hit &right);
   G4int operator==(const HFShowerG4Hit &right) const;

--- a/SimG4CMS/ShowerLibraryProducer/interface/HFWedgeSD.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/HFWedgeSD.h
@@ -26,14 +26,15 @@ public:
   HFWedgeSD(std::string name, const DDCompactView & cpv,
 	    const SensitiveDetectorCatalog & clg,
 	    edm::ParameterSet const & p, const SimTrackManager*);
-  virtual ~HFWedgeSD();
+  ~HFWedgeSD() override;
   
-  virtual void     Initialize(G4HCofThisEvent * HCE);
-  virtual bool     ProcessHits(G4Step * step,G4TouchableHistory * tHistory);
-  virtual void     EndOfEvent(G4HCofThisEvent * eventHC);
-  virtual void     clear();
-  virtual void     DrawAll();
-  virtual void     PrintAll();
+  void     Initialize(G4HCofThisEvent * HCE) override;
+  bool     ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
+  uint32_t setDetUnitId(const G4Step*) override;
+  void     EndOfEvent(G4HCofThisEvent * eventHC) override;
+  void     clear() override;
+  void     DrawAll() override;
+  void     PrintAll() override;
 
 protected:
 
@@ -41,10 +42,7 @@ protected:
   HFShowerG4Hit*   createNewHit();
   void             updateHit(HFShowerG4Hit*);
 
-  virtual void     clearHits();
-  virtual uint32_t setDetUnitId(G4Step*);
-  virtual void     fillHits(edm::PCaloHitContainer&, std::string);
-
+  void     clearHits() override;
 
 private:
 

--- a/SimG4CMS/ShowerLibraryProducer/src/FiberG4Hit.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/FiberG4Hit.cc
@@ -4,11 +4,11 @@
 G4ThreadLocal G4Allocator<FiberG4Hit> *fFiberG4HitAllocator = nullptr;
 
 FiberG4Hit::FiberG4Hit() : theTowerId(0), theDepth(0), theTrackId(0),
-			   theNpe(0), theTime(0), theLogV(0) {
+			   theNpe(0), theTime(0), theLogV(nullptr) {
   theHitPos.SetCoordinates(0.,0.,0.);
 }
 
-FiberG4Hit::FiberG4Hit(G4LogicalVolume* logVol, G4int tower, G4int depth,
+FiberG4Hit::FiberG4Hit(const G4LogicalVolume* logVol, G4int tower, G4int depth,
 		       G4int tkID) : theTowerId(tower), theDepth(depth), 
 				     theTrackId(tkID), theNpe(0), theTime(0), 
 				     theLogV(logVol) {

--- a/SimG4CMS/ShowerLibraryProducer/src/HFChamberSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/HFChamberSD.cc
@@ -20,7 +20,7 @@ HFChamberSD::HFChamberSD(std::string name, const DDCompactView & cpv,
 		 const SensitiveDetectorCatalog & clg, edm::ParameterSet const & p,
 		 const SimTrackManager* manager) :
   SensitiveCaloDetector(name, cpv, clg, p), theName(name),
-  m_trackManager(manager), theHCID(-1), theHC(0), theNSteps(0) {
+  m_trackManager(manager), theHCID(-1), theHC(nullptr), theNSteps(0) {
 
   collectionName.insert(name);
   LogDebug("FiberSim") << "***************************************************"
@@ -63,7 +63,7 @@ G4bool HFChamberSD::ProcessHits(G4Step * aStep, G4TouchableHistory*) {
   //do not process hits other than primary particle hits:
   double charge = aStep->GetTrack()->GetDefinition()->GetPDGCharge();
   int trackID = aStep->GetTrack()->GetTrackID();
-  if(charge == 0. || trackID != 1 ||aStep->GetTrack()->GetParentID() != 0 || aStep->GetTrack()->GetCreatorProcess() != NULL) return false;
+  if(charge == 0. || trackID != 1 ||aStep->GetTrack()->GetParentID() != 0 || aStep->GetTrack()->GetCreatorProcess() != nullptr) return false;
   ++theNSteps;
   //if(theNSteps>1)return false;
 
@@ -74,10 +74,10 @@ G4bool HFChamberSD::ProcessHits(G4Step * aStep, G4TouchableHistory*) {
   double edep = aStep->GetTotalEnergyDeposit();
   double time = (preStepPoint->GetGlobalTime())/ns;
 
-  G4ThreeVector globalPos = preStepPoint->GetPosition();
+  const G4ThreeVector& globalPos = preStepPoint->GetPosition();
   G4ThreeVector localPos  = touch->GetHistory()->GetTopTransform().TransformPoint(globalPos);
   const G4DynamicParticle* particle =  aStep->GetTrack()->GetDynamicParticle();
-  G4ThreeVector momDir   = particle->GetMomentumDirection();
+  const G4ThreeVector& momDir   = particle->GetMomentumDirection();
 
   HFShowerG4Hit *aHit = new HFShowerG4Hit(detID, trackID, edep, time);
   aHit->setLocalPos(localPos);
@@ -111,9 +111,7 @@ void HFChamberSD::PrintAll() {}
 
 void HFChamberSD::clearHits() {}
 
-uint32_t HFChamberSD::setDetUnitId(G4Step* aStep) {
+uint32_t HFChamberSD::setDetUnitId(const G4Step* aStep) {
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   return (touch->GetReplicaNumber(0));
 }
-
-void HFChamberSD::fillHits(edm::PCaloHitContainer&, std::string) {}

--- a/SimG4CMS/ShowerLibraryProducer/src/HFWedgeSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/HFWedgeSD.cc
@@ -20,7 +20,7 @@ HFWedgeSD::HFWedgeSD(std::string name, const DDCompactView & cpv,
 		 const SensitiveDetectorCatalog & clg, edm::ParameterSet const & p,
 		 const SimTrackManager* manager) :
   SensitiveCaloDetector(name, cpv, clg, p), theName(name),
-  m_trackManager(manager), hcID(-1), theHC(0), currentHit(0) {
+  m_trackManager(manager), hcID(-1), theHC(nullptr), currentHit(nullptr) {
 
   collectionName.insert(name);
   LogDebug("FiberSim") << "***************************************************"
@@ -145,9 +145,7 @@ void HFWedgeSD::clearHits() {
   previousID = -1;
 }
 
-uint32_t HFWedgeSD::setDetUnitId(G4Step* aStep) {
+uint32_t HFWedgeSD::setDetUnitId(const G4Step* aStep) {
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   return (touch->GetReplicaNumber(0));
 }
-
-void HFWedgeSD::fillHits(edm::PCaloHitContainer&, std::string) {}

--- a/SimG4CMS/Tracker/interface/FakeFrameRotation.h
+++ b/SimG4CMS/Tracker/interface/FakeFrameRotation.h
@@ -13,8 +13,8 @@
 class FakeFrameRotation : public FrameRotation 
 {
 public:
-    virtual ~FakeFrameRotation() = default;
-    virtual Local3DPoint transformPoint(Local3DPoint &,G4VPhysicalVolume *) const;
+  ~FakeFrameRotation() override = default;
+  Local3DPoint transformPoint(const Local3DPoint &, const G4VPhysicalVolume * v=nullptr) const override;
 };
 
 #endif

--- a/SimG4CMS/Tracker/interface/StandardFrameRotation.h
+++ b/SimG4CMS/Tracker/interface/StandardFrameRotation.h
@@ -13,8 +13,8 @@
 class StandardFrameRotation : public FrameRotation 
 {
 public:
-    virtual ~StandardFrameRotation() = default;
-    virtual Local3DPoint transformPoint(Local3DPoint &,G4VPhysicalVolume *) const;
+  ~StandardFrameRotation() override = default;
+  Local3DPoint transformPoint(const Local3DPoint &, const G4VPhysicalVolume * v=nullptr) const override;
 };
 
 #endif

--- a/SimG4CMS/Tracker/interface/TkAccumulatingSensitiveDetector.h
+++ b/SimG4CMS/Tracker/interface/TkAccumulatingSensitiveDetector.h
@@ -34,33 +34,32 @@ public Observer<const BeginOfTrack*>,
 public Observer<const BeginOfJob*>
 { 
 public:    
-    TkAccumulatingSensitiveDetector(std::string, const DDCompactView &,
+    TkAccumulatingSensitiveDetector(const std::string&, const DDCompactView &,
 				    const SensitiveDetectorCatalog &,
 				    edm::ParameterSet const &,
 				    const SimTrackManager*);
-    virtual ~TkAccumulatingSensitiveDetector();
-    virtual bool ProcessHits(G4Step *,G4TouchableHistory *);
-    virtual uint32_t setDetUnitId(G4Step*);
-    virtual void EndOfEvent(G4HCofThisEvent*);
+    ~TkAccumulatingSensitiveDetector() override;
+    bool ProcessHits(G4Step *,G4TouchableHistory *) override;
+    uint32_t setDetUnitId(const G4Step*) override;
+    void EndOfEvent(G4HCofThisEvent*) override;
 
-    void fillHits(edm::PSimHitContainer&, std::string use);
-    std::vector<std::string> getNames();
-    std::string type();
+    void fillHits(edm::PSimHitContainer&, const std::string& use) override;
+    std::vector<std::string> getNames() override;
 
 private:
     virtual void sendHit();
-    virtual void updateHit(G4Step *);
-    virtual bool newHit(G4Step *);
-    virtual bool closeHit(G4Step *);
-    virtual void createHit(G4Step *);
-    void checkExitPoint(Local3DPoint);
-    void update(const BeginOfEvent *);
-    void update(const BeginOfTrack *);
-    void update(const BeginOfJob *);
-    virtual void clearHits();
-    Local3DPoint toOrcaRef(Local3DPoint ,G4VPhysicalVolume *);
+    virtual void updateHit(const G4Step *);
+    virtual bool newHit(const G4Step *);
+    virtual bool closeHit(const G4Step *);
+    virtual void createHit(const G4Step *);
+    void checkExitPoint(const Local3DPoint&);
+    void update(const BeginOfEvent *) override;
+    void update(const BeginOfTrack *) override;
+    void update(const BeginOfJob *) override;
+    void clearHits() override;
+    Local3DPoint toOrcaRef(const Local3DPoint& ,const G4VPhysicalVolume *);
     int tofBin(float);
-    std::string myName; 
+   
     TrackingSlaveSD * slaveLowTof;
     TrackingSlaveSD * slaveHighTof;
     FrameRotation * myRotation;
@@ -69,7 +68,7 @@ private:
     Local3DPoint globalEntryPoint;
     Local3DPoint globalExitPoint;
     const SimTrackManager* theManager;
-    G4VPhysicalVolume * oldVolume;
+    const G4VPhysicalVolume * oldVolume;
     G4ProcessTypeEnumerator * theG4ProcessTypeEnumerator;
     double theSigma;
     uint32_t lastId;

--- a/SimG4CMS/Tracker/interface/TrackerFrameRotation.h
+++ b/SimG4CMS/Tracker/interface/TrackerFrameRotation.h
@@ -13,8 +13,8 @@
 class TrackerFrameRotation : public FrameRotation 
 {
 public:
-    virtual ~TrackerFrameRotation() = default;
-    virtual Local3DPoint transformPoint(Local3DPoint &,G4VPhysicalVolume *) const;
+    ~TrackerFrameRotation() override = default;
+    Local3DPoint transformPoint(const Local3DPoint &, const G4VPhysicalVolume * v=nullptr) const override;
 };
 
 #endif

--- a/SimG4CMS/Tracker/src/FakeFrameRotation.cc
+++ b/SimG4CMS/Tracker/src/FakeFrameRotation.cc
@@ -1,6 +1,6 @@
 #include "SimG4CMS/Tracker/interface/FakeFrameRotation.h"
 #include "G4SystemOfUnits.hh"
 
-Local3DPoint FakeFrameRotation::transformPoint(Local3DPoint & point,G4VPhysicalVolume * v=0) const {
-  return Local3DPoint(point.x()/cm,point.z()/cm,-point.y()/cm);
+Local3DPoint FakeFrameRotation::transformPoint(const Local3DPoint & point, const G4VPhysicalVolume *) const {
+  return std::move(Local3DPoint(point.x()/cm,point.z()/cm,-point.y()/cm));
 }

--- a/SimG4CMS/Tracker/src/StandardFrameRotation.cc
+++ b/SimG4CMS/Tracker/src/StandardFrameRotation.cc
@@ -1,6 +1,6 @@
 #include "SimG4CMS/Tracker/interface/StandardFrameRotation.h"
 #include "G4SystemOfUnits.hh"
 
-Local3DPoint StandardFrameRotation::transformPoint(Local3DPoint & point,G4VPhysicalVolume * v=0) const {
-  return Local3DPoint(point.x()/cm,point.y()/cm,point.z()/cm);
+Local3DPoint StandardFrameRotation::transformPoint(const Local3DPoint & point, const G4VPhysicalVolume *) const {
+  return std::move(Local3DPoint(point.x()/cm,point.y()/cm,point.z()/cm));
 }

--- a/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
+++ b/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
@@ -384,9 +384,8 @@ bool TkAccumulatingSensitiveDetector::newHit(const G4Step * aStep)
     LogDebug("TrackerSimDebug")<< " OLD (d,t) = (" << lastId << "," << lastTrack 
 			       << "), new = (" << theDetUnitId << "," << theTrackID << ") return "
 			       << ((theTrackID == lastTrack) && (lastId == theDetUnitId));
-    if ((mySimHit != nullptr) && (theTrackID == lastTrack) && (lastId == theDetUnitId) && closeHit(aStep))
-      return false;
-    return true;
+    return ((mySimHit != nullptr) && (theTrackID == lastTrack) && (lastId == theDetUnitId) && closeHit(aStep))
+      ? false : true;
 }
 
 bool TkAccumulatingSensitiveDetector::closeHit(const G4Step * aStep)
@@ -405,9 +404,7 @@ void TkAccumulatingSensitiveDetector::EndOfEvent(G4HCofThisEvent *)
 {
 
   LogDebug("TrackerSimDebug")<< " Saving the last hit in a ROU " << GetName();
-
-    if (mySimHit == nullptr) return;
-      sendHit();
+  if (mySimHit) sendHit();
 }
 
 void TkAccumulatingSensitiveDetector::update(const BeginOfEvent * i)
@@ -437,10 +434,9 @@ void TkAccumulatingSensitiveDetector::clearHits()
 
 void TkAccumulatingSensitiveDetector::checkExitPoint(const Local3DPoint& p)
 {
-    double z = p.z();
-    if (std::abs(z)<0.3*mm) return;
+    if (std::abs(p.z())<0.3*mm) return;
     bool sendExc = false;
-    edm::LogWarning("TrackerSimInfo")<< " ************ Hit outside the detector ; Local z " << z 
+    edm::LogWarning("TrackerSimInfo")<< " ************ Hit outside the detector ; Local z " << p.z() 
 				     << "; skipping event = " << sendExc;
     if (sendExc == true)
     {
@@ -454,24 +450,21 @@ TrackInformation* TkAccumulatingSensitiveDetector::getOrCreateTrackInformation( 
   if (temp == nullptr){
     edm::LogError("TrackerSimInfo") <<" ERROR: no G4VUserTrackInformation available";
     abort();
-  }else{
-    TrackInformation* info = dynamic_cast<TrackInformation*>(temp);
-    if (info ==nullptr){
-      edm::LogError("TrackerSimInfo")<<" ERROR: TkSimTrackSelection: the UserInformation does not appear to be a TrackInformation";
-      abort();
-    }
-    return info;
   }
+  TrackInformation* info = dynamic_cast<TrackInformation*>(temp);
+  if (info ==nullptr){
+    edm::LogError("TrackerSimInfo")<<" ERROR: TkSimTrackSelection: the UserInformation does not appear to be a TrackInformation";
+    abort();
+  }
+  return info;
 }
 
 void TkAccumulatingSensitiveDetector::fillHits(edm::PSimHitContainer& chit, const std::string& nhit){
   //
   // do it once for low, once for High
   //
-
   if (slaveLowTof->name() == nhit)  chit=slaveLowTof->hits();
   if (slaveHighTof->name() == nhit) chit=slaveHighTof->hits();
-
 }
 
 std::vector<string> TkAccumulatingSensitiveDetector::getNames(){

--- a/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
+++ b/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
@@ -33,7 +33,6 @@
 
 #include "G4SystemOfUnits.hh"
 
-
 #include <string>
 #include <vector>
 #include <iostream>
@@ -66,7 +65,7 @@ TkAccumulatingSensitiveDetector::TkAccumulatingSensitiveDetector(const std::stri
 								 edm::ParameterSet const & p,
 								 const SimTrackManager* manager) : 
   SensitiveTkDetector(name, cpv, clg, p), myRotation(nullptr),  mySimHit(nullptr),theManager(manager),
-   oldVolume(nullptr), lastId(0), lastTrack(0), eventno(0) ,rTracker(1200.*mm),zTracker(3000.*mm),
+   oldVolume(nullptr), lastId(0), lastTrack(0), eventno(0), rTracker(1200.*mm), zTracker(3000.*mm),
    numberingScheme_(nullptr)
 {
    
@@ -148,9 +147,9 @@ bool TkAccumulatingSensitiveDetector::ProcessHits(G4Step * aStep, G4TouchableHis
     return false;
 }
 
-uint32_t TkAccumulatingSensitiveDetector::setDetUnitId(const G4Step * s)
+uint32_t TkAccumulatingSensitiveDetector::setDetUnitId(const G4Step * step)
 { 
-  uint32_t detId = numberingScheme_->g4ToNumberingScheme(s->GetPreStepPoint()->GetTouchable());
+  uint32_t detId = numberingScheme_->g4ToNumberingScheme(step->GetPreStepPoint()->GetTouchable());
 
   LogDebug("TrackerSimDebug")<< " DetID = "<<detId; 
 
@@ -190,7 +189,7 @@ void TkAccumulatingSensitiveDetector::update(const BeginOfTrack *bot){
   //
   // Check if in Tracker Volume
   //
-  if (pos.perp() < rTracker &&std::abs(pos.z()) < zTracker){
+  if ((float)pos.perp() < rTracker && std::fabs(pos.z()) < zTracker){
     //
     // inside the Tracker
     //
@@ -441,7 +440,6 @@ void TkAccumulatingSensitiveDetector::checkExitPoint(const Local3DPoint& p)
     double z = p.z();
     if (std::abs(z)<0.3*mm) return;
     bool sendExc = false;
-    //static SimpleConfigurable<bool> sendExc(false,"TrackerSim:ThrowOnBadHits");
     edm::LogWarning("TrackerSimInfo")<< " ************ Hit outside the detector ; Local z " << z 
 				     << "; skipping event = " << sendExc;
     if (sendExc == true)
@@ -472,7 +470,7 @@ void TkAccumulatingSensitiveDetector::fillHits(edm::PSimHitContainer& chit, cons
   //
 
   if (slaveLowTof->name() == nhit)  chit=slaveLowTof->hits();
-  else if (slaveHighTof->name() == nhit) chit=slaveHighTof->hits();
+  if (slaveHighTof->name() == nhit) chit=slaveHighTof->hits();
 
 }
 
@@ -480,5 +478,5 @@ std::vector<string> TkAccumulatingSensitiveDetector::getNames(){
   std::vector<string> temp;
   temp.push_back(slaveLowTof->name());
   temp.push_back(slaveHighTof->name());
-  return temp;
+  return std::move(temp);
 }

--- a/SimG4CMS/Tracker/src/TrackerFrameRotation.cc
+++ b/SimG4CMS/Tracker/src/TrackerFrameRotation.cc
@@ -1,6 +1,6 @@
 #include "SimG4CMS/Tracker/interface/TrackerFrameRotation.h"
 #include "G4SystemOfUnits.hh"
 
-Local3DPoint TrackerFrameRotation::transformPoint(Local3DPoint & point,G4VPhysicalVolume * v=0) const {
-  return Local3DPoint(point.x()/cm,point.y()/cm,point.z()/cm);
+Local3DPoint TrackerFrameRotation::transformPoint(const Local3DPoint & point,const G4VPhysicalVolume *) const {
+  return std::move(Local3DPoint(point.x()/cm,point.y()/cm,point.z()/cm));
 }

--- a/SimG4Core/SensitiveDetector/interface/FrameRotation.h
+++ b/SimG4Core/SensitiveDetector/interface/FrameRotation.h
@@ -9,8 +9,8 @@
 class FrameRotation 
 {
 public:
-    virtual ~FrameRotation() = default;
-    virtual Local3DPoint transformPoint(Local3DPoint &,G4VPhysicalVolume *) const = 0;
+  virtual ~FrameRotation() = default;
+  virtual Local3DPoint transformPoint(const Local3DPoint &, const G4VPhysicalVolume *) const = 0;
 };
 
 #endif

--- a/SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h
@@ -14,7 +14,7 @@ public:
 			const SensitiveDetectorCatalog & clg,
 			edm::ParameterSet const & p) :
   SensitiveDetector(iname,cpv,clg,p) {}
-  virtual void fillHits(edm::PCaloHitContainer &, std::string& hitnam) {};
+  virtual void fillHits(edm::PCaloHitContainer &, const std::string& hitnam) {};
 };
 
 #endif

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
@@ -28,7 +28,8 @@ public:
   void Initialize(G4HCofThisEvent * eventHC) override;
   virtual void clearHits() = 0;
   G4bool ProcessHits(G4Step * step ,G4TouchableHistory * tHistory) override = 0;
-  virtual uint32_t setDetUnitId(G4Step * step) = 0;
+  virtual uint32_t setDetUnitId(const G4Step * step) = 0;
+  virtual double getEnergyDeposit(const G4Step* step);
   void Register();
   void AssignSD(const std::string & vname);
   void EndOfEvent(G4HCofThisEvent * eventHC) override; 
@@ -44,7 +45,7 @@ public:
   }    
   inline std::string& nameOfSD() { return name; }
   virtual std::vector<std::string> getNames();
-  void NaNTrap( G4Step* step ) ;
+  void NaNTrap(const G4Step* step );
     
 private:
   std::string name;

--- a/SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h
@@ -10,11 +10,11 @@
 class SensitiveTkDetector : public SensitiveDetector
 {
 public:
-    SensitiveTkDetector(std::string & iname, const DDCompactView & cpv,
-			const SensitiveDetectorCatalog & clg,
-			edm::ParameterSet const & p) : 
-      SensitiveDetector(iname, cpv, clg, p) {}
-    virtual void fillHits(edm::PSimHitContainer &, std::string name = 0) = 0;
+  SensitiveTkDetector(const std::string & iname, const DDCompactView & cpv,
+		      const SensitiveDetectorCatalog & clg,
+		      edm::ParameterSet const & p) : 
+  SensitiveDetector(iname, cpv, clg, p) {}
+  virtual void fillHits(edm::PSimHitContainer &, const std::string& hitname) {};
 };
 
 #endif

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -19,7 +19,7 @@ SensitiveDetector::SensitiveDetector(const std::string & iname,
 
 SensitiveDetector::~SensitiveDetector() {}
 
-void SensitiveDetector::Initialize(G4HCofThisEvent * eventHC) {}
+void SensitiveDetector::Initialize(G4HCofThisEvent*) {}
 
 void SensitiveDetector::Register()
 {
@@ -34,7 +34,7 @@ void SensitiveDetector::AssignSD(const std::string & vname)
   if (v) { v->SetSensitiveDetector(this); }
 }
 
-void SensitiveDetector::EndOfEvent(G4HCofThisEvent * eventHC) {}
+void SensitiveDetector::EndOfEvent(G4HCofThisEvent*) {}
 
 Local3DPoint SensitiveDetector::InitialStepPosition(const G4Step * step, coordinates cc)
 {
@@ -54,7 +54,7 @@ Local3DPoint SensitiveDetector::FinalStepPosition(const G4Step * step, coordinat
                             ->GetTopTransform().TransformPoint(postStepPoint->GetPosition()));
 }
 
-void SensitiveDetector::NaNTrap( G4Step* aStep )
+void SensitiveDetector::NaNTrap(const G4Step* aStep)
 {
   if( aStep != nullptr ) {   
     G4Track* CurrentTrk = aStep->GetTrack();
@@ -80,6 +80,10 @@ void SensitiveDetector::NaNTrap( G4Step* aStep )
     }
   }
   return;
+}
+
+double SensitiveDetector::getEnergyDeposit(const G4Step* aStep) {
+  return aStep->GetTotalEnergyDeposit();
 }
 
 std::vector<std::string> SensitiveDetector::getNames()


### PR DESCRIPTION
Make use of const interface to Geant4 objects were possible and use non-const interface only if they are modified (tracks killed due to use of the shower library).

Removed duplicated code (partly).

Applying codes-checks significantly increases number of modified classes.

No differences in physics is expected.

