### PR TITLE
changing static const to static constexpr

### DIFF
--- a/DQM/PixelLumi/plugins/PixelLumiDQM.h
+++ b/DQM/PixelLumi/plugins/PixelLumiDQM.h
@@ -73,10 +73,10 @@ private:
   // ---------- Member data ----------
 
   // Hard-coded numbers of layers and disks...
-  static size_t const kNumLayers = 5;
-  static size_t const kNumDisks = 12;
-  static size_t const kOffsetLayers = 0;
-  static size_t const kOffsetDisks = 4;
+  static constexpr size_t kNumLayers = 5;
+  static constexpr size_t kNumDisks = 12;
+  static constexpr size_t kOffsetLayers = 0;
+  static constexpr size_t kOffsetDisks = 4;
 
   class PixelClusterCount {
     // B for barrel, F for forwared, M for minus, P for plus side, 


### PR DESCRIPTION
This PR fixes compilation/linkage error listed here https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_3_X_2017-08-28-2300/DQM/PixelLumi