### PR TITLE
Fix compiler warnings physics tools/pat algos

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/GenJetFlavourInfoPreserver.cc
+++ b/PhysicsTools/PatAlgos/plugins/GenJetFlavourInfoPreserver.cc
@@ -27,9 +27,9 @@ namespace pat {
   class GenJetFlavourInfoPreserver : public edm::stream::EDProducer<> {
   public:
     explicit GenJetFlavourInfoPreserver(const edm::ParameterSet & iConfig);
-    virtual ~GenJetFlavourInfoPreserver() { }
+    ~GenJetFlavourInfoPreserver() override { }
     
-    virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+    void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
     
   private:
     const edm::EDGetTokenT<edm::View<reco::GenJet> > genJetsToken_;

--- a/PhysicsTools/PatAlgos/plugins/GenJetFlavourInfoPreserver.cc
+++ b/PhysicsTools/PatAlgos/plugins/GenJetFlavourInfoPreserver.cc
@@ -72,9 +72,7 @@ pat::GenJetFlavourInfoPreserver::produce(edm::Event & iEvent, const edm::EventSe
 
     edm::Ref<std::vector<reco::GenJet> > slimmedGenJetRef;
 
-    int i = -1;
-    for (auto const& genJet : *genJets){
-         i++;
+    for (unsigned i = 0; i < genJets->size(); i++){
         slimmedGenJetRef = (*slimmedGenJetAssociation)[genJets->refAt(i)]; 
         if(!slimmedGenJetRef) continue;
         (*jetFlavourInfos)[reco::JetBaseRef(slimmedGenJetRef)] = (*genJetFlavourInfos)[i].second;


### PR DESCRIPTION
Fixing compiler warnings listed here https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc630/CMSSW_9_3_X_2017-08-29-1100/PhysicsTools/PatAlgos and applying clang-tidy suggestions