### PR TITLE
Updated DQM after front-end optimization 9_2_X

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -100,9 +100,10 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
       std::vector< MonitorElement* > activity_per_bx;
 
       MonitorElement* hitDistribution2d = nullptr;
+      MonitorElement* hitDistribution2d_lumisection = nullptr;
       MonitorElement* hitDistribution2dOOT = nullptr;
       MonitorElement* hitDistribution2dOOT_le = nullptr;
-      MonitorElement* activePlanes = nullptr;
+      MonitorElement* activePlanes = nullptr, *activePlanesInclusive = nullptr;
 
       MonitorElement* trackDistribution = nullptr;
       MonitorElement* trackDistributionOOT = nullptr;
@@ -223,31 +224,33 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
 
   CTPPSDiamondDetId( id ).rpName( title, CTPPSDiamondDetId::nFull );
 
-  activity_per_bx_0_25 = ibooker.book1D( "activity per BX 0 25", title+" Activity per BX 0 - 25 ns;Event.BX", 4002, -1.5, 4000. + 0.5 );
+  activity_per_bx_0_25 = ibooker.book1D( "activity per BX 0 25", title+" Activity per BX 0 - 25 ns;Event.BX", 3600, -1.5, 3598. + 0.5 );
   activity_per_bx.emplace_back(activity_per_bx_0_25);
-  activity_per_bx_25_50 = ibooker.book1D( "activity per BX 25 50", title+" Activity per BX 25 - 50 ns;Event.BX", 4002, -1.5, 4000. + 0.5 );
+  activity_per_bx_25_50 = ibooker.book1D( "activity per BX 25 50", title+" Activity per BX 25 - 50 ns;Event.BX", 3600, -1.5, 3598. + 0.5 );
   activity_per_bx.emplace_back(activity_per_bx_25_50);
-  activity_per_bx_50_75 = ibooker.book1D( "activity per BX 50 75", title+" Activity per BX 50 - 75 ns;Event.BX", 4002, -1.5, 4000. + 0.5 );
+  activity_per_bx_50_75 = ibooker.book1D( "activity per BX 50 75", title+" Activity per BX 50 - 75 ns;Event.BX", 3600, -1.5, 3598. + 0.5 );
   activity_per_bx.emplace_back(activity_per_bx_50_75);
 
   hitDistribution2d = ibooker.book2D( "hits in planes", title+" hits in planes;plane number;x (mm)", 10, -0.5, 4.5, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitDistribution2d_lumisection = ibooker.book2D( "hits in planes lumisection", title+" hits in planes in the last lumisection;plane number;x (mm)", 10, -0.5, 4.5, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   hitDistribution2dOOT= ibooker.book2D( "hits with OOT in planes", title+" hits with OOT in planes;plane number + 0.25 OOT;x (mm)", 17, -0.25, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   hitDistribution2dOOT_le= ibooker.book2D( "hits with OOT in planes (le only)", title+" hits with OOT in planes (le only);plane number + 0.25 OOT;x (mm)", 17, -0.25, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   activePlanes = ibooker.book1D( "active planes", title+" active planes (per event);number of active planes", 6, -0.5, 5.5 );
+  activePlanesInclusive = ibooker.book1D( "active planes inclusive", title+" active planes, MH and le only included (per event);number of active planes", 6, -0.5, 5.5 );
 
   trackDistribution = ibooker.book1D( "tracks", title+" tracks;x (mm)", 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   trackDistributionOOT = ibooker.book2D( "tracks with OOT", title+" tracks with OOT;plane number;x (mm)", 9, -0.5, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
 
-  stripTomographyAllFar_0_25 = ibooker.book2D( "tomography all far 0 25", title+" tomography with strips far 0 - 25 ns (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
+  stripTomographyAllFar_0_25 = ibooker.book2D( "tomography all far 0 25", title+" tomography with strips far 0 - 25 ns (all planes);x + 25*plane(mm);y (mm)", 200, 0, 100, 24, -2, 10 );
   stripTomographyAllFar.emplace_back(stripTomographyAllFar_0_25);
-  stripTomographyAllFar_25_50 = ibooker.book2D( "tomography all far 25 50", title+" tomography with strips far 25 - 50 ns (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
+  stripTomographyAllFar_25_50 = ibooker.book2D( "tomography all far 25 50", title+" tomography with strips far 25 - 50 ns (all planes);x + 25*plane(mm);y (mm)", 200, 0, 100, 24, -2, 10 );
   stripTomographyAllFar.emplace_back(stripTomographyAllFar_25_50);
-  stripTomographyAllFar_50_75 = ibooker.book2D( "tomography all far 50 75", title+" tomography with strips far 50 - 75 ns (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
+  stripTomographyAllFar_50_75 = ibooker.book2D( "tomography all far 50 75", title+" tomography with strips far 50 - 75 ns (all planes);x + 25*plane(mm);y (mm)", 200, 0, 100, 24, -2, 10 );
   stripTomographyAllFar.emplace_back(stripTomographyAllFar_50_75);
 
-  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge (le and te); leading edge (ns)", 75, 0, 75 );
-  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge (le only); leading edge (ns)", 75, 0, 75 );
-  trailingEdgeCumulative_te = ibooker.book1D( "trailing edge (te only)", title+" trailing edge (te only); trailing edge (ns)", 75, 0, 75 );
+  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge (le and te); leading edge (ns)", 125, 0, 125 );
+  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge (le only); leading edge (ns)", 125, 0, 125 );
+  trailingEdgeCumulative_te = ibooker.book1D( "trailing edge (te only)", title+" trailing edge (te only); trailing edge (ns)", 125, 0, 125 );
   timeOverThresholdCumulativePot = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 250, -25, 100 );
   leadingTrailingCorrelationPot = ibooker.book2D( "leading trailing correlation", title+" leading trailing correlation;leading edge (ns);trailing edge (ns)", 75, 0, 75, 75, 0, 75 );
 
@@ -286,7 +289,7 @@ CTPPSDiamondDQMSource::PlanePlots::PlanePlots( DQMStore::IBooker& ibooker, unsig
   hitProfile = ibooker.book1D( "hit profile", title+" hit profile;x (mm)", 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   hit_multiplicity = ibooker.book1D( "channels per plane", title+" channels per plane; ch per plane", 13, -0.5, 12.5 );
 
-  stripTomography_far = ibooker.book2D( "tomography far", title+" tomography with strips far;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
+  stripTomography_far = ibooker.book2D( "tomography far", title+" tomography with strips far;x + 25 OOT (mm);y (mm)", 200, 0, 100, 24, -2, 10 );
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -304,11 +307,11 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, u
   leadingWithoutTrailing->getTH1F()->GetXaxis()->SetBinLabel( 2, "Trailing only" );
   leadingWithoutTrailing->getTH1F()->GetXaxis()->SetBinLabel( 3, "Full" );
 
-  activity_per_bx_0_25 = ibooker.book1D( "activity per BX 0 25", title+" Activity per BX 0 - 25 ns;Event.BX", 4002, -1.5, 4000. + 0.5 );
+  activity_per_bx_0_25 = ibooker.book1D( "activity per BX 0 25", title+" Activity per BX 0 - 25 ns;Event.BX", 1000, -1.5, 998. + 0.5 );
   activity_per_bx.emplace_back(activity_per_bx_0_25);
-  activity_per_bx_25_50 = ibooker.book1D( "activity per BX 25 50", title+" Activity per BX 25 - 50 ns;Event.BX", 4002, -1.5, 4000. + 0.5 );
+  activity_per_bx_25_50 = ibooker.book1D( "activity per BX 25 50", title+" Activity per BX 25 - 50 ns;Event.BX", 1000, -1.5, 998. + 0.5 );
   activity_per_bx.emplace_back(activity_per_bx_25_50);
-  activity_per_bx_50_75 = ibooker.book1D( "activity per BX 50 75", title+" Activity per BX 50 - 75 ns;Event.BX", 4002, -1.5, 4000. + 0.5 );
+  activity_per_bx_50_75 = ibooker.book1D( "activity per BX 50 75", title+" Activity per BX 50 - 75 ns;Event.BX", 1000, -1.5, 998. + 0.5 );
   activity_per_bx.emplace_back(activity_per_bx_50_75);
 
   HPTDCErrorFlags = ibooker.book1D( "hptdc_Errors", title+" HPTDC Errors", 16, -0.5, 16.5 );
@@ -316,17 +319,17 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, u
     HPTDCErrorFlags->getTH1F()->GetXaxis()->SetBinLabel( error_index, HPTDCErrorFlags::getHPTDCErrorName( error_index-1 ).c_str() );
   HPTDCErrorFlags->getTH1F()->GetXaxis()->SetBinLabel( 16, "MH  (%)" );
 
-  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge; leading edge (ns)", 75, 0, 75 );
-  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge; leading edge (ns)", 75, 0, 75 );
-  trailingEdgeCumulative_te = ibooker.book1D( "trailing edge (te only)", title+" trailing edge (te only); trailing edge (ns)", 75, 0, 75 );
+  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge; leading edge (ns)", 125, 0, 125 );
+  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge; leading edge (ns)", 125, 0, 125 );
+  trailingEdgeCumulative_te = ibooker.book1D( "trailing edge (te only)", title+" trailing edge (te only); trailing edge (ns)", 125, 0, 125 );
   TimeOverThresholdCumulativePerChannel = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 75, -25, 50 );
   LeadingTrailingCorrelationPerChannel = ibooker.book2D( "leading trailing correlation", title+" leading trailing correlation;leading edge (ns);trailing edge (ns)", 75, 0, 75, 75, 0, 75 );
 
   ECCheckPerChannel = ibooker.book1D("optorxEC(8bit) - vfatEC vs optorxEC", title+" EC Error;optorxEC-vfatEC", 128, -64, 64 );
 
-  stripTomography_far = ibooker.book2D( "tomography far", "tomography with strips far;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
+  stripTomography_far = ibooker.book2D( "tomography far", "tomography with strips far;x + 25 OOT (mm);y (mm)", 200, 0, 100, 24, -2, 10 );
 
-  hit_rate = ibooker.book1D( "hit rate", title+"hit rate;rate (Hz)", 10, 0, 100 );
+  hit_rate = ibooker.book1D( "hit rate", title+"hit rate;rate (Hz)", 40, 0, 20);
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -399,7 +402,8 @@ CTPPSDiamondDQMSource::bookHistograms( DQMStore::IBooker& ibooker, const edm::Ru
 void
 CTPPSDiamondDQMSource::beginLuminosityBlock( const edm::LuminosityBlock&, const edm::EventSetup& ) 
 {
-  
+  for ( auto& plot : potPlots_ ) 
+    plot.second.hitDistribution2d_lumisection->Reset();
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -571,7 +575,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       for ( const auto& optorx : *fedInfo ) {
         if ( detId.arm() == 1 && optorx.getFEDId() == CTPPS_FED_ID_56 ) {
           potPlots_[detId_pot].ECCheck->Fill((int)((optorx.getLV1()& 0xFF)-((unsigned int) status.getEC() & 0xFF)) & 0xFF);
-          if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_56_ ) && ( static_cast<uint8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
+          if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_56_ ) && ( static_cast<unsigned int8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
             EC_difference_56_ = static_cast<int>( optorx.getLV1() & 0xFF )-( static_cast<unsigned int>( status.getEC() ) & 0xFF );
           if ( EC_difference_56_ != 1 && EC_difference_56_ != -500 && EC_difference_56_ < 128 && EC_difference_56_ > -128 )
             if (verbosity_)
@@ -582,7 +586,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         }
         else if ( detId.arm() == 0 && optorx.getFEDId()== CTPPS_FED_ID_45 ) {
           potPlots_[detId_pot].ECCheck->Fill((int)((optorx.getLV1()& 0xFF)-status.getEC()) & 0xFF);
-          if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_45_ ) && ( static_cast<uint8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
+          if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_45_ ) && ( static_cast<unsigned int8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
             EC_difference_45_ = static_cast<int>( optorx.getLV1() & 0xFF )-( static_cast<unsigned int>( status.getEC() ) & 0xFF );
           if ( EC_difference_45_ != 1 && EC_difference_45_ != -500 && EC_difference_45_ < 128 && EC_difference_45_ > -128 )
             if (verbosity_)
@@ -597,6 +601,8 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
 
   // Using CTPPSDiamondRecHit
   std::unordered_map<unsigned int, std::set<unsigned int> > planes;
+  std::unordered_map<unsigned int, std::set<unsigned int> > planes_inclusive;
+  
 
   for ( const auto& rechits : *diamondRecHits ) {
     CTPPSDiamondDetId detId_pot( rechits.detId() );
@@ -605,8 +611,10 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
     const CTPPSDiamondDetId detId( rechits.detId() );
 
     for ( const auto& rechit : rechits ) {
+      planes_inclusive[detId_pot].insert( detId.plane() );
       if ( excludeMultipleHits_ && rechit.getMultipleHits() > 0 ) continue;
-      planes[detId_pot].insert( detId.plane() );
+      if ( rechit.getToT() != 0 && centralOOT_ != -999 && rechit.getOOTIndex() == centralOOT_ )
+        planes[detId_pot].insert( detId.plane() );
 
       if ( potPlots_.find( detId_pot ) == potPlots_.end() ) continue;
 
@@ -621,6 +629,15 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         for ( int i=0; i<numOfBins; ++i) {
           hitHistoTmp->Fill( detId.plane() + UFSDShift, hitHistoTmpYAxis->GetBinCenter(startBin+i) );
         }
+        
+        hitHistoTmp = potPlots_[detId_pot].hitDistribution2d_lumisection->getTH2F();
+        hitHistoTmpYAxis = hitHistoTmp->GetYaxis();
+        startBin = hitHistoTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
+        numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
+        for ( int i=0; i<numOfBins; ++i) {
+          hitHistoTmp->Fill( detId.plane() + UFSDShift, hitHistoTmpYAxis->GetBinCenter(startBin+i) );
+        }
+        
       }
 
       if ( rechit.getToT() != 0 ) {
@@ -648,13 +665,14 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           }
         }
       }
-      if ( (uint) rechit.getOOTIndex() < potPlots_[detId_pot].activity_per_bx.size() )
+      if ( (unsigned int) rechit.getOOTIndex() < potPlots_[detId_pot].activity_per_bx.size() )
         potPlots_[detId_pot].activity_per_bx.at( rechit.getOOTIndex() )->Fill( event.bunchCrossing() );
     }
   }
 
   for ( const auto& plt : potPlots_ ) {
     plt.second.activePlanes->Fill( planes[plt.first].size() );
+    plt.second.activePlanesInclusive->Fill( planes_inclusive[plt.first].size() );
   }
 
   // Using CTPPSDiamondLocalTrack
@@ -709,7 +727,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
           if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
           if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
-            if ( (uint) rechit.getOOTIndex() < potPlots_[detId_pot].stripTomographyAllFar.size() )
+            if ( (unsigned int) rechit.getOOTIndex() < potPlots_[detId_pot].stripTomographyAllFar.size() )
               potPlots_[detId_pot].stripTomographyAllFar.at( rechit.getOOTIndex() )->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
           }
         }
@@ -876,7 +894,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         ++(channelPlots_[detId].hitsCounterPerLumisection);
       }
 
-      if ( (uint) rechit.getOOTIndex() < channelPlots_[detId].activity_per_bx.size() )
+      if ( (unsigned int) rechit.getOOTIndex() < channelPlots_[detId].activity_per_bx.size() )
         channelPlots_[detId].activity_per_bx.at( rechit.getOOTIndex() )->Fill( event.bunchCrossing() );
     }
 
@@ -937,7 +955,7 @@ CTPPSDiamondDQMSource::endLuminosityBlock( const edm::LuminosityBlock&, const ed
     CTPPSDiamondDetId rpId(plot.first);
     for ( auto& chPlot : channelPlots_ ) {
       CTPPSDiamondDetId chId(chPlot.first);
-      if ( chId.rp() == rpId.rp() ) {
+      if ( chId.arm() == rpId.arm() && chId.rp() == rpId.rp() ) {
        plot.second.MHComprensive->Fill(chId.plane(), chId.channel(), chPlot.second.HPTDCErrorFlags->getBinContent( 16 ) );
       }
     }

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -648,10 +648,8 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           }
         }
       }
-      try {
+      if ( (uint) rechit.getOOTIndex() < potPlots_[detId_pot].activity_per_bx.size() )
         potPlots_[detId_pot].activity_per_bx.at( rechit.getOOTIndex() )->Fill( event.bunchCrossing() );
-      } 
-      catch( ... ) { }
     }
   }
 
@@ -711,10 +709,8 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
           if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
           if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
-            try {
+            if ( (uint) rechit.getOOTIndex() < potPlots_[detId_pot].stripTomographyAllFar.size() )
               potPlots_[detId_pot].stripTomographyAllFar.at( rechit.getOOTIndex() )->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
-            } 
-            catch( ... ) { }
           }
         }
       }
@@ -880,11 +876,8 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         ++(channelPlots_[detId].hitsCounterPerLumisection);
       }
 
-      try {
+      if ( (uint) rechit.getOOTIndex() < channelPlots_[detId].activity_per_bx.size() )
         channelPlots_[detId].activity_per_bx.at( rechit.getOOTIndex() )->Fill( event.bunchCrossing() );
-      } 
-      catch( ... ) { }
-
     }
 
   }

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -83,7 +83,7 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
     /// plots related to the whole system
     struct GlobalPlots
     {
-      MonitorElement* h_trackCorr_hor = NULL;
+      MonitorElement* h_trackCorr_hor = nullptr;
 
       GlobalPlots() {}
       GlobalPlots( DQMStore::IBooker& ibooker );
@@ -94,37 +94,37 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
     /// plots related to one Diamond detector package
     struct PotPlots
     {
-      MonitorElement* activity_per_bx_0_25 = NULL;
-      MonitorElement* activity_per_bx_25_50 = NULL;
-      MonitorElement* activity_per_bx_50_75 = NULL;
+      MonitorElement* activity_per_bx_0_25 = nullptr;
+      MonitorElement* activity_per_bx_25_50 = nullptr;
+      MonitorElement* activity_per_bx_50_75 = nullptr;
       std::vector< MonitorElement* > activity_per_bx;
 
-      MonitorElement* hitDistribution2d = NULL;
-      MonitorElement* hitDistribution2dOOT = NULL;
-      MonitorElement* hitDistribution2dOOT_le = NULL;
-      MonitorElement* activePlanes = NULL;
+      MonitorElement* hitDistribution2d = nullptr;
+      MonitorElement* hitDistribution2dOOT = nullptr;
+      MonitorElement* hitDistribution2dOOT_le = nullptr;
+      MonitorElement* activePlanes = nullptr;
 
-      MonitorElement* trackDistribution = NULL;
-      MonitorElement* trackDistributionOOT = NULL;
+      MonitorElement* trackDistribution = nullptr;
+      MonitorElement* trackDistributionOOT = nullptr;
 
-      MonitorElement* stripTomographyAllFar_0_25 = NULL;
-      MonitorElement* stripTomographyAllFar_25_50 = NULL;
-      MonitorElement* stripTomographyAllFar_50_75 = NULL;
+      MonitorElement* stripTomographyAllFar_0_25 = nullptr;
+      MonitorElement* stripTomographyAllFar_25_50 = nullptr;
+      MonitorElement* stripTomographyAllFar_50_75 = nullptr;
       std::vector< MonitorElement* > stripTomographyAllFar;
 
-      MonitorElement* leadingEdgeCumulative_both = NULL, *leadingEdgeCumulative_le = NULL, *trailingEdgeCumulative_te = NULL;
-      MonitorElement* timeOverThresholdCumulativePot = NULL, *leadingTrailingCorrelationPot = NULL;
-      MonitorElement* leadingWithoutTrailingCumulativePot = NULL;
+      MonitorElement* leadingEdgeCumulative_both = nullptr, *leadingEdgeCumulative_le = nullptr, *trailingEdgeCumulative_te = nullptr;
+      MonitorElement* timeOverThresholdCumulativePot = nullptr, *leadingTrailingCorrelationPot = nullptr;
+      MonitorElement* leadingWithoutTrailingCumulativePot = nullptr;
 
-      MonitorElement* ECCheck = NULL;
+      MonitorElement* ECCheck = nullptr;
 
-      MonitorElement* HPTDCErrorFlags_cumulative = NULL;
-      MonitorElement* MHComprensive = NULL;
+      MonitorElement* HPTDCErrorFlags_cumulative = nullptr;
+      MonitorElement* MHComprensive = nullptr;
 
-      MonitorElement* clock_Digi1_le = NULL;
-      MonitorElement* clock_Digi1_te = NULL;
-      MonitorElement* clock_Digi3_le = NULL;
-      MonitorElement* clock_Digi3_te = NULL;
+      MonitorElement* clock_Digi1_le = nullptr;
+      MonitorElement* clock_Digi1_te = nullptr;
+      MonitorElement* clock_Digi3_le = nullptr;
+      MonitorElement* clock_Digi3_te = nullptr;
 
       unsigned int HitCounter, MHCounter, LeadingOnlyCounter, TrailingOnlyCounter, CompleteCounter;
       
@@ -138,11 +138,11 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
     /// plots related to one Diamond plane
     struct PlanePlots
     {
-      MonitorElement* digiProfileCumulativePerPlane = NULL;
-      MonitorElement* hitProfile = NULL;
-      MonitorElement* hit_multiplicity = NULL;
+      MonitorElement* digiProfileCumulativePerPlane = nullptr;
+      MonitorElement* hitProfile = nullptr;
+      MonitorElement* hit_multiplicity = nullptr;
 
-      MonitorElement* stripTomography_far = NULL;
+      MonitorElement* stripTomography_far = nullptr;
 
       PlanePlots() {}
       PlanePlots( DQMStore::IBooker& ibooker, unsigned int id );
@@ -153,19 +153,19 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
     /// plots related to one Diamond channel
     struct ChannelPlots
     {
-      MonitorElement* activity_per_bx_0_25 = NULL;
-      MonitorElement* activity_per_bx_25_50 = NULL;
-      MonitorElement* activity_per_bx_50_75 = NULL;
+      MonitorElement* activity_per_bx_0_25 = nullptr;
+      MonitorElement* activity_per_bx_25_50 = nullptr;
+      MonitorElement* activity_per_bx_50_75 = nullptr;
       std::vector< MonitorElement* > activity_per_bx;
 
-      MonitorElement* HPTDCErrorFlags = NULL;
-      MonitorElement* leadingEdgeCumulative_both = NULL, *leadingEdgeCumulative_le = NULL, *trailingEdgeCumulative_te = NULL;
-      MonitorElement* TimeOverThresholdCumulativePerChannel = NULL;
-      MonitorElement* LeadingTrailingCorrelationPerChannel = NULL;
-      MonitorElement* leadingWithoutTrailing = NULL;
-      MonitorElement* stripTomography_far = NULL;
-      MonitorElement* hit_rate = NULL;
-      MonitorElement* ECCheckPerChannel = NULL;
+      MonitorElement* HPTDCErrorFlags = nullptr;
+      MonitorElement* leadingEdgeCumulative_both = nullptr, *leadingEdgeCumulative_le = nullptr, *trailingEdgeCumulative_te = nullptr;
+      MonitorElement* TimeOverThresholdCumulativePerChannel = nullptr;
+      MonitorElement* LeadingTrailingCorrelationPerChannel = nullptr;
+      MonitorElement* leadingWithoutTrailing = nullptr;
+      MonitorElement* stripTomography_far = nullptr;
+      MonitorElement* hit_rate = nullptr;
+      MonitorElement* ECCheckPerChannel = nullptr;
       unsigned long hitsCounterPerLumisection;
       
       unsigned int HitCounter, MHCounter, LeadingOnlyCounter, TrailingOnlyCounter, CompleteCounter;
@@ -224,11 +224,11 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
   CTPPSDiamondDetId( id ).rpName( title, CTPPSDiamondDetId::nFull );
 
   activity_per_bx_0_25 = ibooker.book1D( "activity per BX 0 25", title+" Activity per BX 0 - 25 ns;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_bx.push_back(activity_per_bx_0_25);
+  activity_per_bx.emplace_back(activity_per_bx_0_25);
   activity_per_bx_25_50 = ibooker.book1D( "activity per BX 25 50", title+" Activity per BX 25 - 50 ns;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_bx.push_back(activity_per_bx_25_50);
+  activity_per_bx.emplace_back(activity_per_bx_25_50);
   activity_per_bx_50_75 = ibooker.book1D( "activity per BX 50 75", title+" Activity per BX 50 - 75 ns;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_bx.push_back(activity_per_bx_50_75);
+  activity_per_bx.emplace_back(activity_per_bx_50_75);
 
   hitDistribution2d = ibooker.book2D( "hits in planes", title+" hits in planes;plane number;x (mm)", 10, -0.5, 4.5, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   hitDistribution2dOOT= ibooker.book2D( "hits with OOT in planes", title+" hits with OOT in planes;plane number + 0.25 OOT;x (mm)", 17, -0.25, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
@@ -239,11 +239,11 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
   trackDistributionOOT = ibooker.book2D( "tracks with OOT", title+" tracks with OOT;plane number;x (mm)", 9, -0.5, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
 
   stripTomographyAllFar_0_25 = ibooker.book2D( "tomography all far 0 25", title+" tomography with strips far 0 - 25 ns (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
-  stripTomographyAllFar.push_back(stripTomographyAllFar_0_25);
+  stripTomographyAllFar.emplace_back(stripTomographyAllFar_0_25);
   stripTomographyAllFar_25_50 = ibooker.book2D( "tomography all far 25 50", title+" tomography with strips far 25 - 50 ns (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
-  stripTomographyAllFar.push_back(stripTomographyAllFar_25_50);
+  stripTomographyAllFar.emplace_back(stripTomographyAllFar_25_50);
   stripTomographyAllFar_50_75 = ibooker.book2D( "tomography all far 50 75", title+" tomography with strips far 50 - 75 ns (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
-  stripTomographyAllFar.push_back(stripTomographyAllFar_50_75);
+  stripTomographyAllFar.emplace_back(stripTomographyAllFar_50_75);
 
   leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge (le and te); leading edge (ns)", 75, 0, 75 );
   leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge (le only); leading edge (ns)", 75, 0, 75 );
@@ -305,11 +305,11 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, u
   leadingWithoutTrailing->getTH1F()->GetXaxis()->SetBinLabel( 3, "Full" );
 
   activity_per_bx_0_25 = ibooker.book1D( "activity per BX 0 25", title+" Activity per BX 0 - 25 ns;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_bx.push_back(activity_per_bx_0_25);
+  activity_per_bx.emplace_back(activity_per_bx_0_25);
   activity_per_bx_25_50 = ibooker.book1D( "activity per BX 25 50", title+" Activity per BX 25 - 50 ns;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_bx.push_back(activity_per_bx_25_50);
+  activity_per_bx.emplace_back(activity_per_bx_25_50);
   activity_per_bx_50_75 = ibooker.book1D( "activity per BX 50 75", title+" Activity per BX 50 - 75 ns;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_bx.push_back(activity_per_bx_50_75);
+  activity_per_bx.emplace_back(activity_per_bx_50_75);
 
   HPTDCErrorFlags = ibooker.book1D( "hptdc_Errors", title+" HPTDC Errors", 16, -0.5, 16.5 );
   for ( unsigned short error_index=1; error_index<16; ++error_index )

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -241,11 +241,11 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
   trackDistribution = ibooker.book1D( "tracks", title+" tracks;x (mm)", 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   trackDistributionOOT = ibooker.book2D( "tracks with OOT", title+" tracks with OOT;plane number;x (mm)", 9, -0.5, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
 
-  stripTomographyAllFar_0_25 = ibooker.book2D( "tomography all far 0 25", title+" tomography with strips far 0 - 25 ns (all planes);x + 25*plane(mm);y (mm)", 200, 0, 100, 24, -2, 10 );
+  stripTomographyAllFar_0_25 = ibooker.book2D( "tomography all far 0 25", title+" tomography with strips far 0 - 25 ns (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 12, -2, 10 );
   stripTomographyAllFar.emplace_back(stripTomographyAllFar_0_25);
-  stripTomographyAllFar_25_50 = ibooker.book2D( "tomography all far 25 50", title+" tomography with strips far 25 - 50 ns (all planes);x + 25*plane(mm);y (mm)", 200, 0, 100, 24, -2, 10 );
+  stripTomographyAllFar_25_50 = ibooker.book2D( "tomography all far 25 50", title+" tomography with strips far 25 - 50 ns (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 12, -2, 10 );
   stripTomographyAllFar.emplace_back(stripTomographyAllFar_25_50);
-  stripTomographyAllFar_50_75 = ibooker.book2D( "tomography all far 50 75", title+" tomography with strips far 50 - 75 ns (all planes);x + 25*plane(mm);y (mm)", 200, 0, 100, 24, -2, 10 );
+  stripTomographyAllFar_50_75 = ibooker.book2D( "tomography all far 50 75", title+" tomography with strips far 50 - 75 ns (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 12, -2, 10 );
   stripTomographyAllFar.emplace_back(stripTomographyAllFar_50_75);
 
   leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge (le and te); leading edge (ns)", 125, 0, 125 );
@@ -269,9 +269,9 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
   MHComprensive = ibooker.book2D( "MH in channels", title+" MH (%) in channels;plane number;ch number", 10, -0.5, 4.5, 14, -1, 13 );
 
   ibooker.setCurrentFolder( path+"/clock/" );
-  clock_Digi1_le = ibooker.book1D( "clock1 leading edge", title+" clock1;leading edge (ns)", 1000, 0, 125 );
+  clock_Digi1_le = ibooker.book1D( "clock1 leading edge", title+" clock1;leading edge (ns)", 1250, 0, 125 );
   clock_Digi1_te = ibooker.book1D( "clock1 trailing edge", title+" clock1;trailing edge (ns)", 125, 0, 125 );
-  clock_Digi3_le = ibooker.book1D( "clock3 leading edge", title+" clock3;leading edge (ns)", 1000, 0, 125 );
+  clock_Digi3_le = ibooker.book1D( "clock3 leading edge", title+" clock3;leading edge (ns)", 1250, 0, 125 );
   clock_Digi3_te = ibooker.book1D( "clock3 trailing edge", title+" clock3;trailing edge (ns)", 125, 0, 125 );
 }
 
@@ -289,7 +289,7 @@ CTPPSDiamondDQMSource::PlanePlots::PlanePlots( DQMStore::IBooker& ibooker, unsig
   hitProfile = ibooker.book1D( "hit profile", title+" hit profile;x (mm)", 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   hit_multiplicity = ibooker.book1D( "channels per plane", title+" channels per plane; ch per plane", 13, -0.5, 12.5 );
 
-  stripTomography_far = ibooker.book2D( "tomography far", title+" tomography with strips far;x + 25 OOT (mm);y (mm)", 200, 0, 100, 24, -2, 10 );
+  stripTomography_far = ibooker.book2D( "tomography far", title+" tomography with strips far;x + 25 OOT (mm);y (mm)", 50, 0, 50, 12, -2, 10 );
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -327,7 +327,7 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, u
 
   ECCheckPerChannel = ibooker.book1D("optorxEC(8bit) - vfatEC vs optorxEC", title+" EC Error;optorxEC-vfatEC", 128, -64, 64 );
 
-  stripTomography_far = ibooker.book2D( "tomography far", "tomography with strips far;x + 25 OOT (mm);y (mm)", 200, 0, 100, 24, -2, 10 );
+  stripTomography_far = ibooker.book2D( "tomography far", "tomography with strips far;x + 25 OOT (mm);y (mm)", 50, 0, 50, 12, -2, 10 );
 
   hit_rate = ibooker.book1D( "hit rate", title+"hit rate;rate (Hz)", 40, 0, 20);
 }
@@ -451,8 +451,6 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
   //------------------------------
   // RP Plots
   //------------------------------  
-
-  //   if (event.bunchCrossing() > 100) return;
 
   //------------------------------
   // Correlation Plots
@@ -824,7 +822,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
           if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
           if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
-            planePlots_[detId_plane].stripTomography_far->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - ( ( centralOOT_ != -999 ) ? centralOOT_ : 0 ) +1), striplt.getY0() );
+            planePlots_[detId_plane].stripTomography_far->Fill( striplt.getX0() + 25*rechit.getOOTIndex() , striplt.getY0() );
           }
         }
       }

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -39,15 +39,15 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
 {
   public:
     CTPPSDiamondDQMSource( const edm::ParameterSet& );
-    virtual ~CTPPSDiamondDQMSource();
+    ~CTPPSDiamondDQMSource() override;
 
   protected:
     void dqmBeginRun( const edm::Run&, const edm::EventSetup& ) override;
     void bookHistograms( DQMStore::IBooker&, const edm::Run&, const edm::EventSetup& ) override;
-    void analyze( const edm::Event&, const edm::EventSetup& );
-    void beginLuminosityBlock( const edm::LuminosityBlock&, const edm::EventSetup& );
-    void endLuminosityBlock( const edm::LuminosityBlock&, const edm::EventSetup& );
-    void endRun( const edm::Run&, const edm::EventSetup& );
+    void analyze( const edm::Event&, const edm::EventSetup& ) override;
+    void beginLuminosityBlock( const edm::LuminosityBlock&, const edm::EventSetup& ) override;
+    void endLuminosityBlock( const edm::LuminosityBlock&, const edm::EventSetup& ) override;
+    void endRun( const edm::Run&, const edm::EventSetup& ) override;
 
   private:
     // Constants
@@ -270,9 +270,9 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
 
   ibooker.setCurrentFolder( path+"/clock/" );
   clock_Digi1_le = ibooker.book1D( "clock1 leading edge", title+" clock1;leading edge (ns)", 1250, 0, 125 );
-  clock_Digi1_te = ibooker.book1D( "clock1 trailing edge", title+" clock1;trailing edge (ns)", 125, 0, 125 );
+  clock_Digi1_te = ibooker.book1D( "clock1 trailing edge", title+" clock1;trailing edge (ns)", 75, 0, 75 );
   clock_Digi3_le = ibooker.book1D( "clock3 leading edge", title+" clock3;leading edge (ns)", 1250, 0, 125 );
-  clock_Digi3_te = ibooker.book1D( "clock3 trailing edge", title+" clock3;trailing edge (ns)", 125, 0, 125 );
+  clock_Digi3_te = ibooker.book1D( "clock3 trailing edge", title+" clock3;trailing edge (ns)", 75, 0, 75 );
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -573,7 +573,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       for ( const auto& optorx : *fedInfo ) {
         if ( detId.arm() == 1 && optorx.getFEDId() == CTPPS_FED_ID_56 ) {
           potPlots_[detId_pot].ECCheck->Fill((int)((optorx.getLV1()& 0xFF)-((unsigned int) status.getEC() & 0xFF)) & 0xFF);
-          if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_56_ ) && ( static_cast<unsigned int8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
+          if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_56_ ) && ( static_cast<uint8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
             EC_difference_56_ = static_cast<int>( optorx.getLV1() & 0xFF )-( static_cast<unsigned int>( status.getEC() ) & 0xFF );
           if ( EC_difference_56_ != 1 && EC_difference_56_ != -500 && EC_difference_56_ < 128 && EC_difference_56_ > -128 )
             if (verbosity_)
@@ -584,7 +584,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         }
         else if ( detId.arm() == 0 && optorx.getFEDId()== CTPPS_FED_ID_45 ) {
           potPlots_[detId_pot].ECCheck->Fill((int)((optorx.getLV1()& 0xFF)-status.getEC()) & 0xFF);
-          if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_45_ ) && ( static_cast<unsigned int8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
+          if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_45_ ) && ( static_cast<uint8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
             EC_difference_45_ = static_cast<int>( optorx.getLV1() & 0xFF )-( static_cast<unsigned int>( status.getEC() ) & 0xFF );
           if ( EC_difference_45_ != 1 && EC_difference_45_ != -500 && EC_difference_45_ < 128 && EC_difference_45_ > -128 )
             if (verbosity_)

--- a/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
@@ -20,8 +20,18 @@ ctppsDiamondDQMSource = cms.EDAnalyzer("CTPPSDiamondDQMSource",
         ),
         # 2017
         cms.PSet(
-            validityRange = cms.EventRange("292521:min - 999999999:max"),
+            validityRange = cms.EventRange("292521:min - 301417:max"),
             centralOOT = cms.int32(3),
+        ),
+        # 2017, after channel delays corrections
+        cms.PSet(
+            validityRange = cms.EventRange("301418:min - 301517:max"),
+            centralOOT = cms.int32(1),
+        ),
+        # 2017, after channel delays corrections
+        cms.PSet(
+            validityRange = cms.EventRange("301518:min - 9999999:max"),
+            centralOOT = cms.int32(0),
         ),
     ),
   


### PR DESCRIPTION
This PR updates the DQM according to the latest hardware configuration.
9_2_X backport of PR 20270.


The front-end chip (HPTDC) configuration has been optimized during the commissioning of the detector.
The main modification was the introduction of a delay (digital) for the different channels to temporally align them. This allows a better visualization of the online data: for instance all peaks in the leading edge plots are aligned.
Therefore, it was possible to reduce the acquisition window from 5 clock cycle down to 2. Drastically reducing the possibility of 2 hits in the same event.
Out of those 5 time slices, the one synchronized with the trigger (centralOOT) was moved from 4 to 1 and then to 0 (first acquired slice).
Some parameters require the modification of the DQM code; moreover, the readability of some plots has been improved (showing percentage instead of absolute values) and some new plots have been introduced, as the hit map in the last lumisection to immediately spot problems with the detectors.

Also, code has been improved (switch case removed, NULL -> nullptr, histogram binning optimized).

Finally, this code is compatible with the upcoming geometry update (UFSD implementation).

Note about urgency: current version of the DQM is enough to understand if the detector is working, but not enough to show its performance online.