### PR TITLE
fix QIE11 capid accessor

### DIFF
--- a/DataFormats/HcalDigi/interface/QIE11DataFrame.h
+++ b/DataFormats/HcalDigi/interface/QIE11DataFrame.h
@@ -30,7 +30,7 @@ public:
     int adc() const { return frame_[i_]&MASK_ADC; }
     int tdc() const { return (frame_[i_]>>OFFSET_TDC)&MASK_TDC; }
     bool soi() const { return frame_[i_]&MASK_SOI; }
-    int capid() const { return ((((frame_[0]>>OFFSET_CAPID)&MASK_CAPID)+i_)&MASK_CAPID); }
+    int capid() const { return ((((frame_[0]>>OFFSET_CAPID)&MASK_CAPID)+i_-HEADER_WORDS)&MASK_CAPID); }
   private:
     const edm::DataFrame& frame_;
     edm::DataFrame::size_type i_;


### PR DESCRIPTION
It was noticed recently that the `capid()` accessor in the `QIE11DataFrame::Sample` class was not returning the right capids. This was because of an off-by-one error: the index `i_` in the `Sample` class includes the header word as well as the samples, so the number of header words must be subtracted to get the proper capid for TS `i`.

attn: @elaird @jmmans @abdoulline