### PR TITLE
Bugfix for Phase 1 HI Tracking DetachedTripletStep clusters

### DIFF
--- a/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
@@ -21,6 +21,11 @@ hiDetachedTripletStepClusters = cms.EDProducer("HITrackClusterRemover",
 )
 
 
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiDetachedTripletStepClusters,
+     trajectories = cms.InputTag("hiDetachedQuadStepTracks"),
+     overrideTrkQuals = cms.InputTag("hiDetachedQuadStepSelector","hiDetachedQuadStep"),
+)
 
 
 # SEEDING LAYERS
@@ -109,7 +114,6 @@ hiDetachedTripletStepPixelTracks = cms.EDProducer("PixelTrackProducer",
     # Cleaner
     Cleaner = cms.string("trackCleaner")
 )
-from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(hiDetachedTripletStepPixelTracks,
     SeedingHitSets = cms.InputTag("hiDetachedTripletStepTracksHitTripletsCA")
 )


### PR DESCRIPTION
This PR fixes a bug in the modified Phase 1 HI tracking sequence from PR #18646.  The clusters going into the hiDetachedTripletStep were not modified in order to correspond to the new sequence of iterations.  Because of this, the clusters were taken from the end of the 1st iteration, essentially bypassing the hit cleaning steps of the previous 3 iterations.  This PR adds a Phase 1 modifier so that the clusters are taken from the DetachedQuadStep, run just before the DetachedTripletStep.

Tested using workflow 150.  Also quickly tested on central HI events, where timing and memory seemed very similar.

@mandrenguyen 