### PR TITLE
Run2-alca92 Change output command for IsoTrack AlCaReco jobs

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrkFilter_Output_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrkFilter_Output_cff.py
@@ -9,6 +9,8 @@ OutALCARECOHcalCalIsoTrkFilter_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOHcalCalIsoTrkFilter')
     ),
     outputCommands = cms.untracked.vstring( 
+        'keep *_gtStage2Digis_*_*',
+        'keep *_hbheprereco_*_*',
         'keep *_hbhereco_*_*',
         'keep *_ecalRecHit_*_*',
         'keep *_towerMaker_*_*',

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrkNoHLT_Output_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrkNoHLT_Output_cff.py
@@ -14,6 +14,8 @@ OutALCARECOHcalCalIsoTrkNoHLT_noDrop = cms.PSet(
 	'keep *_offlineBeamSpot_*_*',
         'keep recoTracks_generalTracks_*_*',
         'keep recoTrackExtras_generalTracks_*_*',
+        'keep *_gtStage2Digis_*_*',
+        'keep *_hbheprereco_*_*',
         'keep edmTriggerResults_*_*_*',
         'keep triggerTriggerEvent_*_*_*',
         )

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrk_Output_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrk_Output_cff.py
@@ -16,6 +16,8 @@ OutALCARECOHcalCalIsoTrk_noDrop = cms.PSet(
         'keep *_towerMaker_*_*',
 	'keep *_offlineBeamSpot_*_*',
         'keep *_hltTriggerSummaryAOD_*_*',
+        'keep *_gtStage2Digis_*_*',
+        'keep *_hbheprereco_*_*',
         'keep *_TriggerResults_*_*',
         'keep *_generalTracks_*_*',
         'keep *_generalTracksExtra_*_*',

--- a/Calibration/HcalAlCaRecoProducers/python/alcastreamHcalIsotrkOutput_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/alcastreamHcalIsotrkOutput_cff.py
@@ -8,6 +8,8 @@ alcastreamHcalIsotrkOutput = cms.PSet(
                                            'keep *_offlineBeamSpot_*_*',
                                            'keep edmTriggerResults_*_*_*',
                                            'keep triggerTriggerEvent_*_*_*',
+                                           'keep *_gtStage2Digis_*_*',
+                                           'keep *_hbheprereco_*_*',
                                            'keep recoTracks_generalTracks_*_*',
                                            'keep recoTrackExtras_generalTracks_*_*',
                                            'keep *_IsoProd_*_*',

--- a/Calibration/HcalAlCaRecoProducers/test/AlCaIsoTrackFilterProducer_cfg.py
+++ b/Calibration/HcalAlCaRecoProducers/test/AlCaIsoTrackFilterProducer_cfg.py
@@ -21,8 +21,7 @@ process.maxEvents = cms.untracked.PSet(
 )
 process.source = cms.Source("PoolSource",
                             fileNames = cms.untracked.vstring(
-        'file:PoolOutput.root'
-#       '/store/relval/CMSSW_7_4_0_pre6/RelValPhotonJets_Pt_10_13/GEN-SIM-RECO/MCRUN2_74_V1-v1/00000/6EC8FCC8-E2A8-E411-9506-002590596468.root'
+        '/store/relval/CMSSW_7_4_0_pre6/RelValPhotonJets_Pt_10_13/GEN-SIM-RECO/MCRUN2_74_V1-v1/00000/6EC8FCC8-E2A8-E411-9506-002590596468.root'
  )
 )
 
@@ -35,7 +34,22 @@ process.ALCARECOStreamHcalCalIsoTrkFilter = cms.OutputModule("PoolOutputModule",
         filterName = cms.untracked.string('ALCARECOHcalCalIsoTrkFilter')
         ),
                                                              eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
-                                                             outputCommands = process.OutALCARECOHcalCalIsoTrkFilter.outputCommands,
+                                                             #                                                            outputCommands = process.OutALCARECOHcalCalIsoTrkFilter.outputCommands,
+                                                             outputCommands = cms.untracked.vstring(
+        'drop *',
+        'keep *_gtStage2Digis_*_*',
+        'keep *_hbheprereco_*_*',
+        'keep *_hbhereco_*_*',
+        'keep *_ecalRecHit_*_*',
+        'keep *_towerMaker_*_*',
+        'keep *_offlineBeamSpot_*_*',
+        'keep *_hltTriggerSummaryAOD_*_*',
+        'keep *_TriggerResults_*_*',
+        'keep *_generalTracks_*_*',
+        'keep *_generalTracksExtra_*_*',
+        'keep *_offlinePrimaryVertices_*_*',
+        'keep *_TkAlIsoProdFilter_*_*',
+        ),
                                                              fileName = cms.untracked.string('PoolOutput.root'),
                                       )
 


### PR DESCRIPTION
Two collections are added - information about L1 trigger information and prerechit collection for HBHE. This changes the o/p from 0.46 MB per stored event to 0.48 MB per event - an increase by 3.8%