### PR TITLE
Move @relval2017 to V3.0 HLT menu (92X)

### DIFF
--- a/Configuration/HLT/python/autoHLT.py
+++ b/Configuration/HLT/python/autoHLT.py
@@ -8,6 +8,6 @@ autoHLT = {
   'relval50ns' : 'Fake',
   'relval25ns' : 'Fake1',
   'relval2016' : 'Fake2',
-  'relval2017' : '2e34v22',
+  'relval2017' : '2e34v30',
   'test'       : 'GRun',
 }


### PR DESCRIPTION
Move @relval2017 to V3.0 HLT menu (92X)
Based on CMSSW_9_2_X_2017-08-29-2300
Attention: needs #20113 and #20239 integrated first!
