### PR TITLE
Update H130GGgluonfusion_8TeV_TuneCUETP8M1_cfi.py

### DIFF
--- a/Configuration/Generator/python/H130GGgluonfusion_8TeV_TuneCUETP8M1_cfi.py
+++ b/Configuration/Generator/python/H130GGgluonfusion_8TeV_TuneCUETP8M1_cfi.py
@@ -17,7 +17,7 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
         processParameters = cms.vstring(
             'HiggsSM:gg2H = on',
             '25:onMode = off',
-            '25:onIfAny = 22',
+            '25:onIfMatch = 22 22',
             ),
         parameterSets = cms.vstring('pythia8CommonSettings',
                                     'pythia8CUEP8M1Settings',


### PR DESCRIPTION
to fix a trivial bug spotted during validation
https://hypernews.cern.ch/HyperNews/CMS/get/relval/3338/13/1/1/1/1.html
and fixed only for 13 TeV production
https://hypernews.cern.ch/HyperNews/CMS/get/relval/3353/1.html