### PR TITLE
Correcting eos path & call for electronDataDiscovery.

### DIFF
--- a/DQMOffline/EGamma/python/electronDataDiscovery.py
+++ b/DQMOffline/EGamma/python/electronDataDiscovery.py
@@ -227,7 +227,7 @@ def common_search(dd_tier):
       
   elif os.environ['DD_SOURCE'].startswith('/eos/cms/'): # assumed to be an eos dir
   
-    data = os.popen('/afs/cern.ch/project/eos/installation/pro/bin/eos.select find -f '+os.environ['DD_SOURCE'])
+    data = os.popen('eos find -f '+os.environ['DD_SOURCE'])
     lines = data.readlines()
     data.close()
     result = []


### PR DESCRIPTION
A minor correction in order to use the correct path (& call) of eos in the file electronDataDiscovery.py
There is no other correction.

@beaudett @fcouderc 