### PR TITLE
[93X] L1T Validation Module with GeneratorParticle Information: extend x-axis range for number of L1 objects hists

### DIFF
--- a/Validation/L1T/interface/L1Validator.h
+++ b/Validation/L1T/interface/L1Validator.h
@@ -68,7 +68,7 @@
 class L1Validator : public DQMEDAnalyzer {
   public:
     explicit L1Validator(const edm::ParameterSet&);
-    ~L1Validator();
+    ~L1Validator() override;
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
     void analyze(const edm::Event&, const edm::EventSetup&) override;

--- a/Validation/L1T/plugins/L1Validator.cc
+++ b/Validation/L1T/plugins/L1Validator.cc
@@ -111,10 +111,16 @@ void L1Validator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 
   _Hists.NEvents++;
 
-  _Hists.FillNumber(L1ValidatorHists::Type::Muon, MuonsBX->size());
-  _Hists.FillNumber(L1ValidatorHists::Type::Egamma, EGammasBX->size());
-  _Hists.FillNumber(L1ValidatorHists::Type::Tau, TausBX->size());
-  _Hists.FillNumber(L1ValidatorHists::Type::Jet, JetsBX->size());
+  int nL1Muons = 0, nL1EGammas = 0, nL1Taus = 0, nL1Jets = 0;
+  if(MuonsBX->getFirstBX()>=0) nL1Muons = MuonsBX->size(0);
+  if(EGammasBX->getFirstBX()>=0) nL1EGammas = EGammasBX->size(0);
+  if(TausBX->getFirstBX()>=0) nL1Taus = TausBX->size(0);
+  if(JetsBX->getFirstBX()>=0) nL1Jets = JetsBX->size(0);
+
+  _Hists.FillNumber(L1ValidatorHists::Type::Muon, nL1Muons);
+  _Hists.FillNumber(L1ValidatorHists::Type::Egamma, nL1EGammas);
+  _Hists.FillNumber(L1ValidatorHists::Type::Tau, nL1Taus);
+  _Hists.FillNumber(L1ValidatorHists::Type::Jet, nL1Jets);
 
   //For gen jet
 

--- a/Validation/L1T/plugins/L1Validator.cc
+++ b/Validation/L1T/plugins/L1Validator.cc
@@ -70,7 +70,7 @@ L1Validator::~L1Validator(){
 }
 
 void L1Validator::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const &, edm::EventSetup const &) {
-  iBooker.setCurrentFolder(_dirName.c_str());
+  iBooker.setCurrentFolder(_dirName);
   _Hists.Book(iBooker);
 };
 
@@ -135,7 +135,7 @@ void L1Validator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
      double minDR = 999.0;
 
      // match L1T object
-     const l1t::Jet        *L1Part=NULL;
+     const l1t::Jet        *L1Part=nullptr;
      for(int iBx = JetsBX->getFirstBX();  iBx<=JetsBX->getLastBX(); ++iBx){
           if(iBx>0) continue;
           for(std::vector<l1t::Jet>::const_iterator jet = JetsBX->begin(iBx); jet != JetsBX->end(iBx); ++jet){
@@ -167,7 +167,7 @@ void L1Validator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
        if(fabs(GenPart->eta())>2.4) continue;
 
        // match L1T object
-       const l1t::Muon 	*L1Part=NULL;
+       const l1t::Muon 	*L1Part=nullptr;
        for(int iBx = MuonsBX->getFirstBX();  iBx<=MuonsBX->getLastBX(); ++iBx){
 	  if(iBx>0) continue;
           for(std::vector<l1t::Muon>::const_iterator mu = MuonsBX->begin(iBx); mu != MuonsBX->end(iBx); ++mu){
@@ -192,7 +192,7 @@ void L1Validator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
        if(fabs(GenPart->eta())>1.4442 && fabs(GenPart->eta())<1.5660) continue;
 
        // match L1T object
-       const l1t::EGamma 	*L1Part=NULL;
+       const l1t::EGamma 	*L1Part=nullptr;
        for(int iBx = EGammasBX->getFirstBX();  iBx<=EGammasBX->getLastBX(); ++iBx){
 	  if(iBx>0) continue;
           for(std::vector<l1t::EGamma>::const_iterator eg = EGammasBX->begin(iBx); eg != EGammasBX->end(iBx); ++eg){
@@ -213,7 +213,7 @@ void L1Validator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
        if(fabs(GenPart->eta())>2.4) continue;
 
        // match L1T object
-       const l1t::Tau 	*L1Part=NULL;
+       const l1t::Tau 	*L1Part=nullptr;
        for(int iBx = TausBX->getFirstBX();  iBx<=TausBX->getLastBX(); ++iBx){
 	  if(iBx>0) continue;
           for(std::vector<l1t::Tau>::const_iterator tau = TausBX->begin(iBx); tau != TausBX->end(iBx); ++tau){
@@ -233,8 +233,8 @@ void L1Validator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 }
 
 //The next three are exactly the same, but apparently inheritance doesn't work like I thought it did.
-const reco::LeafCandidate *L1Validator::FindBest(const reco::GenParticle *GenPart, const std::vector<l1extra::L1EmParticle> *Collection1, const std::vector<l1extra::L1EmParticle> *Collection2=NULL){
-  const reco::LeafCandidate *BestPart=NULL;
+const reco::LeafCandidate *L1Validator::FindBest(const reco::GenParticle *GenPart, const std::vector<l1extra::L1EmParticle> *Collection1, const std::vector<l1extra::L1EmParticle> *Collection2=nullptr){
+  const reco::LeafCandidate *BestPart=nullptr;
   double BestDR=999.;
 
   for(uint i=0; i < Collection1->size(); i++){
@@ -246,7 +246,7 @@ const reco::LeafCandidate *L1Validator::FindBest(const reco::GenParticle *GenPar
     }
   }
 
-  if(Collection2==NULL) return BestPart;
+  if(Collection2==nullptr) return BestPart;
 
   for(uint i=0; i < Collection2->size(); i++){
     const reco::LeafCandidate *ThisPart = &Collection2->at(i);
@@ -260,8 +260,8 @@ const reco::LeafCandidate *L1Validator::FindBest(const reco::GenParticle *GenPar
   return BestPart;
 }
 
-const reco::LeafCandidate *L1Validator::FindBest(const reco::GenParticle *GenPart, const std::vector<l1extra::L1JetParticle> *Collection1, const std::vector<l1extra::L1JetParticle> *Collection2=NULL){
-  const reco::LeafCandidate *BestPart=NULL;
+const reco::LeafCandidate *L1Validator::FindBest(const reco::GenParticle *GenPart, const std::vector<l1extra::L1JetParticle> *Collection1, const std::vector<l1extra::L1JetParticle> *Collection2=nullptr){
+  const reco::LeafCandidate *BestPart=nullptr;
   double BestDR=999.;
 
   for(uint i=0; i < Collection1->size(); i++){
@@ -273,7 +273,7 @@ const reco::LeafCandidate *L1Validator::FindBest(const reco::GenParticle *GenPar
     }
   }
 
-  if(Collection2==NULL) return BestPart;
+  if(Collection2==nullptr) return BestPart;
 
   for(uint i=0; i < Collection2->size(); i++){
     const reco::LeafCandidate *ThisPart = &Collection2->at(i);
@@ -288,7 +288,7 @@ const reco::LeafCandidate *L1Validator::FindBest(const reco::GenParticle *GenPar
 }
 
 const reco::LeafCandidate *L1Validator::FindBest(const reco::GenParticle *GenPart, const std::vector<l1extra::L1MuonParticle> *Collection1){
-  const reco::LeafCandidate *BestPart=NULL;
+  const reco::LeafCandidate *BestPart=nullptr;
   double BestDR=999.;
 
   for(uint i=0; i < Collection1->size(); i++){

--- a/Validation/L1T/src/L1ValidatorHists.cc
+++ b/Validation/L1T/src/L1ValidatorHists.cc
@@ -60,7 +60,7 @@ void L1ValidatorHists::Fill(int i, const reco::LeafCandidate *GenPart, const rec
   double GenPartPt = GenPart->pt();
   // fill the overflow in the last bin
   if(GenPart->pt()>=160.0) GenPartPt = 159.0;
-  if(L1Part==NULL) {
+  if(L1Part==nullptr) {
      Eff_Pt_Denom[i]->Fill(GenPartPt);
      if(GenPart->pt()>10)Eff_Eta_Denom[i]->Fill(GenPart->eta());
      TurnOn_15_Denom[i]->Fill(GenPartPt);

--- a/Validation/L1T/src/L1ValidatorHists.cc
+++ b/Validation/L1T/src/L1ValidatorHists.cc
@@ -34,7 +34,7 @@ void L1ValidatorHists::Book(DQMStore::IBooker &iBooker){
   int Nptbin = 13;
 
   for(int i=0; i<Type::Number; i++){
-    N[i] = iBooker.book1D( (Name[i]+"_N").c_str(), (Name[i]+" Number").c_str(), 5, -0.5, 4.5);
+    N[i] = iBooker.book1D( (Name[i]+"_N").c_str(), ("L1 " + Name[i]+" Number with BX=0").c_str(), 13, -0.5, 12.5);
 
     Eff_Pt[i] = iBooker.book1D( (Name[i]+"_Eff_Pt").c_str(), (Name[i]+" Efficiency vs Pt; Gen p_{T} [GeV]; L1T Efficiency").c_str(), Nptbin, ptbins);
     Eff_Pt_Denom[i] = iBooker.book1D( (Name[i]+"_Eff_Pt_Denom").c_str(), (Name[i]+" Efficiency vs Pt Denom; Gen p_{T} [GeV]; Entries").c_str(), Nptbin, ptbins);

--- a/Validation/L1T/src/L1ValidatorHists.cc
+++ b/Validation/L1T/src/L1ValidatorHists.cc
@@ -34,7 +34,7 @@ void L1ValidatorHists::Book(DQMStore::IBooker &iBooker){
   int Nptbin = 13;
 
   for(int i=0; i<Type::Number; i++){
-    N[i] = iBooker.book1D( (Name[i]+"_N").c_str(), ("L1 " + Name[i]+" Number with BX=0").c_str(), 13, -0.5, 12.5);
+    N[i] = iBooker.book1D( (Name[i]+"_N").c_str(), ("L1 " + Name[i]+" Number with BX=0").c_str(), 16, -0.5, 15.5);
 
     Eff_Pt[i] = iBooker.book1D( (Name[i]+"_Eff_Pt").c_str(), (Name[i]+" Efficiency vs Pt; Gen p_{T} [GeV]; L1T Efficiency").c_str(), Nptbin, ptbins);
     Eff_Pt_Denom[i] = iBooker.book1D( (Name[i]+"_Eff_Pt_Denom").c_str(), (Name[i]+" Efficiency vs Pt Denom; Gen p_{T} [GeV]; Entries").c_str(), Nptbin, ptbins);


### PR DESCRIPTION
This PR makes two small fixes in Validation/L1T package which is used to fill the L1TriggerVsGen histograms for L1T RelVal:
fill the number of L1 objects when BX=0 instead of the size of BXVector.
extend the range of x axis for the L1 objects number histograms.
The PR has been tested with "runTheMatrix.py -l limited -i all", no problem shows up.