### PR TITLE
Add L1 offline DQM harvesting step - 92x

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -28,7 +28,8 @@ DQMOffline_SecondStep_PreDPG = cms.Sequence( dqmDcsInfoClient *
                                              es_dqm_client_offline *
                                              hcalOfflineHarvesting *
                                              HcalDQMOfflinePostProcessor * 
-                                             dqmFEDIntegrityClient )
+                                             dqmFEDIntegrityClient *
+                                             l1TriggerDqmOfflineClient )
 
 DQMOffline_SecondStepDPG = cms.Sequence( dqmRefHistoRootFileGetter *
                                          DQMOffline_SecondStep_PreDPG *
@@ -86,11 +87,11 @@ DQMHarvestCommon = cms.Sequence( dqmRefHistoRootFileGetter *
                                  PixelOfflineDQMClientNoDataCertification *
                                  triggerOfflineDQMClient *
                                  hltOfflineDQMClient *
+                                 l1TriggerDqmOfflineClient *
                                  dqmFEDIntegrityClient *
                                  alcaBeamMonitorClient *
                                  runTauEff *
-                                 dqmFastTimerServiceClient *
-                                 l1TriggerDqmOfflineClient
+                                 dqmFastTimerServiceClient
                                 )
 DQMHarvestCommonSiStripZeroBias = cms.Sequence(dqmRefHistoRootFileGetter *
                                                DQMMessageLoggerClientSeq *
@@ -100,6 +101,7 @@ DQMHarvestCommonSiStripZeroBias = cms.Sequence(dqmRefHistoRootFileGetter *
                                                PixelOfflineDQMClientNoDataCertification *
                                                triggerOfflineDQMClient *
                                                hltOfflineDQMClient *
+                                               l1TriggerDqmOfflineClient *
                                                dqmFEDIntegrityClient *
                                                alcaBeamMonitorClient *
                                                runTauEff  *

--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -16,6 +16,7 @@ from DQM.BeamMonitor.AlcaBeamMonitorClient_cff import *
 from DQMServices.Components.DQMFEDIntegrityClient_cff import *
 from Validation.RecoTau.DQMSequences_cfi import *
 from DQMOffline.Hcal.HcalDQMOfflinePostProcessor_cff import *
+from DQMOffline.L1Trigger.L1TriggerDqmOffline_cff import *
 from DQM.HcalTasks.OfflineHarvestingSequence_pp import *
 
 DQMOffline_SecondStep_PreDPG = cms.Sequence( dqmDcsInfoClient *
@@ -37,7 +38,6 @@ DQMOffline_SecondStepDPG = cms.Sequence( dqmRefHistoRootFileGetter *
 
 from DQMOffline.Muon.muonQualityTests_cff import *
 from DQMOffline.EGamma.egammaPostProcessing_cff import *
-from DQMOffline.L1Trigger.L1TriggerDqmOffline_cff import *
 from DQMOffline.Trigger.DQMOffline_Trigger_Client_cff import *
 from DQMOffline.Trigger.DQMOffline_HLT_Client_cff import *
 from DQMOffline.RecoB.dqmCollector_cff import *


### PR DESCRIPTION
Add L1 offline DQM harvesting step to all sequences where the first step is also run.

In particular this should produce efficiency histograms for the express stream reco, where currently only the first step DQM histograms are produced.