### PR TITLE
removing hasCoPads variables (unused)

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
@@ -565,7 +565,6 @@ void CSCMotherboardME11GEM::run(const CSCWireDigiCollection* wiredc,
   }
 
   const bool hasPads(!pads_.empty());
-  const bool hasCoPads(hasPads and !coPads_.empty());
   bool hasLCTs(false);
 
   // ALCT-centric matching

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21GEM.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21GEM.cc
@@ -316,7 +316,6 @@ CSCMotherboardME21GEM::run(const CSCWireDigiCollection* wiredc,
   for (int c=0;c<20;++c) used_clct_mask[c]=0;
 
   const bool hasPads(!pads_.empty());
-  const bool hasCoPads(hasPads and !coPads_.empty());
 
   // ALCT centric matching
   for (int bx_alct = 0; bx_alct < CSCAnodeLCTProcessor::MAX_ALCT_BINS; bx_alct++)


### PR DESCRIPTION
Unused vars warnings are listed here https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc630/CMSSW_9_3_X_2017-08-29-2300/L1Trigger/CSCTriggerPrimitives , removing them until further use in their scope