### PR TITLE
Run2-alca93 Backport of #20305 change output command for IsoTrack AlCaReco jobs

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrkFilter_Output_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrkFilter_Output_cff.py
@@ -9,6 +9,8 @@ OutALCARECOHcalCalIsoTrkFilter_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOHcalCalIsoTrkFilter')
     ),
     outputCommands = cms.untracked.vstring( 
+        'keep *_gtStage2Digis_*_*',
+        'keep *_hbheprereco_*_*',
         'keep *_hbhereco_*_*',
         'keep *_ecalRecHit_*_*',
         'keep *_towerMaker_*_*',

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrkNoHLT_Output_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrkNoHLT_Output_cff.py
@@ -14,6 +14,8 @@ OutALCARECOHcalCalIsoTrkNoHLT_noDrop = cms.PSet(
 	'keep *_offlineBeamSpot_*_*',
         'keep recoTracks_generalTracks_*_*',
         'keep recoTrackExtras_generalTracks_*_*',
+        'keep *_gtStage2Digis_*_*',
+        'keep *_hbheprereco_*_*',
         'keep edmTriggerResults_*_*_*',
         'keep triggerTriggerEvent_*_*_*',
         )

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrk_Output_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsoTrk_Output_cff.py
@@ -16,6 +16,8 @@ OutALCARECOHcalCalIsoTrk_noDrop = cms.PSet(
         'keep *_towerMaker_*_*',
 	'keep *_offlineBeamSpot_*_*',
         'keep *_hltTriggerSummaryAOD_*_*',
+        'keep *_gtStage2Digis_*_*',
+        'keep *_hbheprereco_*_*',
         'keep *_TriggerResults_*_*',
         'keep *_generalTracks_*_*',
         'keep *_generalTracksExtra_*_*',

--- a/Calibration/HcalAlCaRecoProducers/python/alcastreamHcalIsotrkOutput_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/alcastreamHcalIsotrkOutput_cff.py
@@ -7,6 +7,8 @@ alcastreamHcalIsotrkOutput = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *', 
                                            'keep *_offlineBeamSpot_*_*',
                                            'keep edmTriggerResults_*_*_*',
+                                           'keep *_gtStage2Digis_*_*',
+                                           'keep *_hbheprereco_*_*',
                                            'keep triggerTriggerEvent_*_*_*',
                                            'keep recoTracks_generalTracks_*_*',
                                            'keep recoTrackExtras_generalTracks_*_*',


### PR DESCRIPTION
Two collections are added - information about L1 trigger information and prerechit collection for HBHE. This changes the o/p from 0.46 MB per stored event to 0.48 MB per event - an increase by 3.8%