### PR TITLE
Changed throw() to noexcept

### DIFF
--- a/DataFormats/Common/interface/debugging_allocator.h
+++ b/DataFormats/Common/interface/debugging_allocator.h
@@ -36,19 +36,19 @@ namespace edm
     template <class U> struct rebind { typedef debugging_allocator<U> other; };
 
 
-    debugging_allocator() throw() : dummy('x') { }
+    debugging_allocator() noexcept : dummy('x') { }
 
-    debugging_allocator(debugging_allocator const&) throw() : dummy('c') { }
+    debugging_allocator(debugging_allocator const&) noexcept : dummy('c') { }
 
-    template <class U> debugging_allocator(debugging_allocator<U> const&) throw() : dummy('u') { }
+    template <class U> debugging_allocator(debugging_allocator<U> const&) noexcept : dummy('u') { }
 
-    ~debugging_allocator() throw() { };
+    ~debugging_allocator() noexcept { };
 
     pointer address(reference value) const {return &value;}
 
     const_pointer address(const_reference value) const {return &value; }    
 
-    size_type max_size() const throw() { return std::numeric_limits<size_type>::max()/sizeof(T); }
+    size_type max_size() const noexcept { return std::numeric_limits<size_type>::max()/sizeof(T); }
 
     pointer allocate(size_type num, void const* hint = 0)
     {
@@ -69,10 +69,10 @@ namespace edm
 
   // instances of all specializations of this allocator are equal
   template <class X, class Y>
-  bool operator==  (debugging_allocator<X> const&, debugging_allocator<Y> const&) throw() { return true; }
+  bool operator==  (debugging_allocator<X> const&, debugging_allocator<Y> const&) noexcept { return true; }
 
   template <class X, class Y>
-  bool operator!=  (debugging_allocator<X> const&, debugging_allocator<Y> const&) throw() { return false; }
+  bool operator!=  (debugging_allocator<X> const&, debugging_allocator<Y> const&) noexcept { return false; }
 
 } //namespace edm
 

--- a/FWCore/Framework/interface/MakeDataException.h
+++ b/FWCore/Framework/interface/MakeDataException.h
@@ -46,10 +46,10 @@ class MakeDataException : public cms::Exception
 {
    public:
       MakeDataException(const EventSetupRecordKey&, const DataKey&);  
-      ~MakeDataException() throw() {}
+      ~MakeDataException() noexcept override {}
 
       // ---------- const member functions ---------------------
-      const char* myMessage() const throw() {
+      const char* myMessage() const noexcept {
          return message_.c_str();
       }
    

--- a/FWCore/Framework/interface/NoDataException.h
+++ b/FWCore/Framework/interface/NoDataException.h
@@ -81,7 +81,7 @@ public:
   NoDataExceptionBase(const EventSetupRecordKey& iRecordKey,
                         const DataKey& iDataKey,
                         const char* category_name = "NoDataException") ;
-  virtual ~NoDataExceptionBase() throw();
+  ~NoDataExceptionBase() noexcept override;
   const DataKey& dataKey() const;
 protected:
   static std::string providerButNoDataMessage(const EventSetupRecordKey& iKey);

--- a/FWCore/Framework/interface/NoRecordException.h
+++ b/FWCore/Framework/interface/NoRecordException.h
@@ -55,7 +55,7 @@ class NoRecordException : public cms::Exception
     no_record_exception_message_builder(*this,heterocontainer::className<T>(), iValue, iKnownRecord);
   }
 
-      ~NoRecordException() throw() override {}
+      ~NoRecordException() noexcept override {}
 
       // ---------- const member functions ---------------------
 

--- a/FWCore/Framework/interface/UnknownModuleException.h
+++ b/FWCore/Framework/interface/UnknownModuleException.h
@@ -36,7 +36,7 @@ namespace edm {
 	"Try running EdmPluginDump to obtain a list "
 	"of available Plugins\n";
     }
-    ~UnknownModuleException() throw(){}
+    ~UnknownModuleException() noexcept override{}
   }; // UnknownModuleException
 
 

--- a/FWCore/Framework/src/NoDataException.cc
+++ b/FWCore/Framework/src/NoDataException.cc
@@ -12,7 +12,7 @@ namespace edm {
      {
      }
      
-     NoDataExceptionBase::~NoDataExceptionBase() throw() {}
+     NoDataExceptionBase::~NoDataExceptionBase() noexcept {}
      
      const DataKey& NoDataExceptionBase::dataKey() const { return dataKey_; }
      

--- a/FWCore/Utilities/interface/EDMException.h
+++ b/FWCore/Utilities/interface/EDMException.h
@@ -82,7 +82,7 @@ namespace edm {
 
     Exception(Exception const& other);
 
-    ~Exception() throw() override;
+    ~Exception() noexcept override;
 
     void swap(Exception& other) {
       std::swap(category_, other.category_);

--- a/FWCore/Utilities/interface/Exception.h
+++ b/FWCore/Utilities/interface/Exception.h
@@ -84,14 +84,14 @@ namespace cms {
               Exception const& another);
 
     Exception(Exception const& other); 
-    ~Exception() throw() override;
+    ~Exception() noexcept override;
 
     void swap(Exception& other);
 
     Exception& operator=(Exception const& other);
 
     // The signature for what() must be identical to that of std::exception::what().
-    char const* what() const throw() override;
+    char const* what() const noexcept override;
 
     virtual std::string explainSelf() const;
 

--- a/FWCore/Utilities/src/EDMException.cc
+++ b/FWCore/Utilities/src/EDMException.cc
@@ -82,7 +82,7 @@ namespace edm {
     category_(other.category_) {
   }
 
-  Exception::~Exception() throw() {
+  Exception::~Exception() noexcept {
   }
 
   Exception&

--- a/FWCore/Utilities/src/Exception.cc
+++ b/FWCore/Utilities/src/Exception.cc
@@ -118,7 +118,7 @@ namespace cms {
     ost_ << other.ost_.str();
   }
 
-  Exception::~Exception() throw() {
+  Exception::~Exception() noexcept {
   }
 
   void
@@ -138,7 +138,7 @@ namespace cms {
     return *this;
   }
   
-  char const* Exception::what() const throw() {
+  char const* Exception::what() const noexcept {
     what_ = explainSelf();
     return what_.c_str();
   }

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.h
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.h
@@ -41,7 +41,7 @@ public:
       : Exception(code), m_code(xrootd_status.code)
     {}
 
-    virtual ~XrootdException() throw() {};
+    ~XrootdException() noexcept override {};
 
     uint16_t getCode() { return m_code; }
 


### PR DESCRIPTION
The throw keyword has been deprecated in C++11 and replaced with the noexcept specification.