### PR TITLE
Simplified non default Table column filling

### DIFF
--- a/FWCore/SOA/interface/Column.h
+++ b/FWCore/SOA/interface/Column.h
@@ -41,7 +41,16 @@
 // forward declarations
 namespace edm {
 namespace soa {
-    
+
+/**Helper class used to fill a column of a table
+  in a 'non standard' way
+*/
+template<typename COL, typename F>
+struct ColumnFillerHolder {
+  using Column_type = COL;
+  F m_f;
+};  
+
 template <const char* LABEL, typename T>
 struct Column
 {
@@ -52,6 +61,9 @@ struct Column
     static char const* const s_label(LABEL);
     return s_label;
   }
+  
+  template <typename F>
+  static ColumnFillerHolder<Column<LABEL,T>,F> filler(F&& iF) { return {iF}; }
   
  private:
   Column() = default;

--- a/FWCore/SOA/interface/ColumnFillers.h
+++ b/FWCore/SOA/interface/ColumnFillers.h
@@ -94,14 +94,6 @@ namespace soa {
     }
   };
 
-  template<typename COL, typename F>
-  struct ColumnFillerHolder {
-    using Column_type = COL;
-    F m_f;
-  };
-  template<typename COL, typename F>
-  ColumnFillerHolder<COL,F> filler_for(F&& iF) { return {iF}; }
-  
   template<typename... Args>
   ColumnFillers<Args...> column_fillers(Args... iArgs) {
     return ColumnFillers<Args...>(std::forward<Args>(iArgs)...);

--- a/FWCore/SOA/test/table_t.cppunit.cpp
+++ b/FWCore/SOA/test/table_t.cppunit.cpp
@@ -266,7 +266,7 @@ void testTable::tableCtrTest()
     std::vector<std::string> labels = {{"jet0","jet1","jet2"}};
     
     int index=0;
-    MyJetTable jt{ j, column_fillers(filler_for<Label>([&index](JetType const&)
+    MyJetTable jt{ j, column_fillers(Label::filler([&index](JetType const&)
                                                             { std::ostringstream s;
                                                               s<<"jet"<<index++;
                                                               return s.str();}) ) };
@@ -282,7 +282,7 @@ void testTable::tableCtrTest()
 
     {
       auto itFillIndex = labels.begin();
-      MyJetTable jt{ j, column_fillers(filler_for<Label>([&itFillIndex](JetType const&)
+      MyJetTable jt{ j, column_fillers(Label::filler([&itFillIndex](JetType const&)
                                                         {return *(itFillIndex++);}) ) };
       auto itLabels = labels.begin();
       for(auto const& v: jt) {
@@ -444,7 +444,7 @@ void testTable::mutabilityTest() {
   CPPUNIT_ASSERT(row.get<Eta>() == 5.);
   CPPUNIT_ASSERT(row.get<Phi>() == 6.);
   
-  row.copyValuesFrom(JetType{7.,8.}, column_fillers(filler_for<Phi>([](JetType const&) {return 9.;})));
+  row.copyValuesFrom(JetType{7.,8.}, column_fillers(Phi::filler([](JetType const&) {return 9.;})));
   CPPUNIT_ASSERT(row.get<Eta>() == 7.);
   CPPUNIT_ASSERT(row.get<Phi>() == 9.);
 


### PR DESCRIPTION
Added the static function Column::filler in order to replace the need for a separate templated function to do the same thing.