### PR TITLE
Async global end LuminosityBlock transition

### DIFF
--- a/DataFormats/Common/interface/BasicHandle.h
+++ b/DataFormats/Common/interface/BasicHandle.h
@@ -44,7 +44,7 @@ namespace edm {
   public:
     BasicHandle() :
       product_(),
-      prov_(0) {}
+      prov_(nullptr) {}
 
     BasicHandle(BasicHandle const& h) :
       product_(h.product_),
@@ -61,7 +61,7 @@ namespace edm {
     ///Used when the attempt to get the data failed
     BasicHandle(std::shared_ptr<HandleExceptionFactory> const& iWhyFailed):
     product_(),
-    prov_(0),
+    prov_(nullptr),
     whyFailedFactory_(iWhyFailed) {}
 
     ~BasicHandle() {}

--- a/DataFormats/Common/interface/ConvertHandle.h
+++ b/DataFormats/Common/interface/ConvertHandle.h
@@ -25,7 +25,7 @@ namespace edm {
       return;
     }
     void const* basicWrapper = bh.wrapper();
-    if(basicWrapper == 0) {
+    if(basicWrapper == nullptr) {
       handleimpl::throwInvalidReference();
     }
     if(!(bh.wrapper()->dynamicTypeInfo() == typeid(T))) {

--- a/DataFormats/Common/interface/FunctorHandleExceptionFactory.h
+++ b/DataFormats/Common/interface/FunctorHandleExceptionFactory.h
@@ -37,7 +37,7 @@ namespace edm {
 
     // ---------- const member functions ---------------------
 
-    std::shared_ptr<cms::Exception> make() const {
+    std::shared_ptr<cms::Exception> make() const override {
       return m_functor();
     }
   private:

--- a/DataFormats/Common/interface/HandleBase.h
+++ b/DataFormats/Common/interface/HandleBase.h
@@ -40,8 +40,8 @@ namespace edm {
   class HandleBase {
   public:
     HandleBase() :
-    product_(0),
-    prov_(0) {}
+    product_(nullptr),
+    prov_(nullptr) {}
     
     HandleBase(void const* prod, Provenance const* prov) :
     product_(prod), prov_(prov) {
@@ -52,8 +52,8 @@ namespace edm {
     ~HandleBase() {}
     
     void clear() {
-      product_ = 0;
-      prov_ = 0;
+      product_ = nullptr;
+      prov_ = nullptr;
       whyFailedFactory_.reset();
     }
     
@@ -92,7 +92,7 @@ namespace edm {
     ///Used when the attempt to get the data failed
     HandleBase(std::shared_ptr<HandleExceptionFactory>&& iWhyFailed) :
     product_(),
-    prov_(0),
+    prov_(nullptr),
     whyFailedFactory_(iWhyFailed) {}
     
 

--- a/DataFormats/Common/interface/OrphanHandleBase.h
+++ b/DataFormats/Common/interface/OrphanHandleBase.h
@@ -39,7 +39,7 @@ namespace edm {
     ~OrphanHandleBase() {}
 
     void clear() {
-      product_ = 0;
+      product_ = nullptr;
       id_ = ProductID();
     }
 

--- a/DataFormats/Common/interface/Wrapper.h
+++ b/DataFormats/Common/interface/Wrapper.h
@@ -28,7 +28,7 @@ namespace edm {
     typedef T wrapped_type; // used with the dictionary to identify Wrappers
     Wrapper() : WrapperBase(), present(false), obj() {}
     explicit Wrapper(std::unique_ptr<T> ptr);
-    virtual ~Wrapper() {}
+    ~Wrapper() override {}
     T const* product() const {return (present ? &obj : 0);}
     T const* operator->() const {return product();}
 
@@ -43,32 +43,32 @@ namespace edm {
     CMS_CLASS_VERSION(3)
 
 private:
-    virtual bool isPresent_() const override {return present;}
-    virtual std::type_info const& dynamicTypeInfo_() const override {return typeid(T);}
-    virtual std::type_info const& wrappedTypeInfo_() const override {return typeid(Wrapper<T>);}
+    bool isPresent_() const override {return present;}
+    std::type_info const& dynamicTypeInfo_() const override {return typeid(T);}
+    std::type_info const& wrappedTypeInfo_() const override {return typeid(Wrapper<T>);}
 
-    virtual std::type_info const& valueTypeInfo_() const override;
-    virtual std::type_info const& memberTypeInfo_() const override;
-    virtual bool isMergeable_() const override;
-    virtual bool mergeProduct_(WrapperBase const* newProduct) override;
-    virtual bool hasIsProductEqual_() const override;
-    virtual bool isProductEqual_(WrapperBase const* newProduct) const override;
+    std::type_info const& valueTypeInfo_() const override;
+    std::type_info const& memberTypeInfo_() const override;
+    bool isMergeable_() const override;
+    bool mergeProduct_(WrapperBase const* newProduct) override;
+    bool hasIsProductEqual_() const override;
+    bool isProductEqual_(WrapperBase const* newProduct) const override;
 
-    virtual void do_fillView(ProductID const& id,
+    void do_fillView(ProductID const& id,
                              std::vector<void const*>& pointers,
                              FillViewHelperVector& helpers) const override;
-    virtual void do_setPtr(std::type_info const& iToType,
+    void do_setPtr(std::type_info const& iToType,
                            unsigned long iIndex,
                            void const*& oPtr) const override;
-    virtual void do_fillPtrVector(std::type_info const& iToType,
+    void do_fillPtrVector(std::type_info const& iToType,
                                   std::vector<unsigned long> const& iIndices,
                                   std::vector<void const*>& oPtr) const override;
 
   private:
     // We wish to disallow copy construction and assignment.
     // We make the copy constructor and assignment operator private.
-    Wrapper(Wrapper<T> const& rh); // disallow copy construction
-    Wrapper<T>& operator=(Wrapper<T> const&); // disallow assignment
+    Wrapper(Wrapper<T> const& rh) = delete; // disallow copy construction
+    Wrapper<T>& operator=(Wrapper<T> const&) = delete; // disallow assignment
 
     bool present;
     T obj;

--- a/DataFormats/Common/interface/WrapperBase.h
+++ b/DataFormats/Common/interface/WrapperBase.h
@@ -18,7 +18,7 @@ namespace edm {
   class WrapperBase : public ViewTypeChecker {
   public:
     WrapperBase();
-    virtual ~WrapperBase();
+    ~WrapperBase() override;
     bool isPresent() const {return isPresent_();}
 
     // We have to use vector<void*> to keep the type information out

--- a/FWCore/Concurrency/interface/SerialTaskQueue.h
+++ b/FWCore/Concurrency/interface/SerialTaskQueue.h
@@ -143,7 +143,7 @@ namespace edm {
       /** Base class for all tasks held by the SerialTaskQueue */
       class TaskBase : public tbb::task {
          friend class SerialTaskQueue;
-         TaskBase(): m_queue(0) {}
+         TaskBase(): m_queue(nullptr) {}
          
       protected:
          tbb::task* finishedTask();
@@ -160,7 +160,7 @@ namespace edm {
          m_action(iAction) {}
          
       private:
-         tbb::task* execute();
+         tbb::task* execute() override;
          
          T m_action;
       };

--- a/FWCore/Concurrency/interface/SerialTaskQueueChain.h
+++ b/FWCore/Concurrency/interface/SerialTaskQueueChain.h
@@ -93,7 +93,7 @@ namespace edm {
     if(m_queues.size() == 1) {
       m_queues[0]->push( [this,iAction]() {this->actionToRun(iAction);} );
     } else {
-      assert(m_queues.size()>0);
+      assert(!m_queues.empty());
       m_queues[0]->push([this, iAction]() {
         this->passDownChain(1, iAction);
       });

--- a/FWCore/Framework/interface/ComponentFactory.h
+++ b/FWCore/Framework/interface/ComponentFactory.h
@@ -63,7 +63,7 @@ template<typename T>
          {
             std::shared_ptr<Maker> wm(edmplugin::PluginFactory<ComponentMakerBase<T>* ()>::get()->create(modtype));
             
-            if(wm.get() == 0) {
+            if(wm.get() == nullptr) {
 	      Exception::throwThis(errors::Configuration,
 	      "UnknownModule",
 	       T::name().c_str(),

--- a/FWCore/Framework/interface/ComponentMaker.h
+++ b/FWCore/Framework/interface/ComponentMaker.h
@@ -72,9 +72,9 @@ namespace edm {
 
       // ---------- member functions ---------------------------
    private:
-      ComponentMaker(const ComponentMaker&); // stop default
+      ComponentMaker(const ComponentMaker&) = delete; // stop default
 
-      const ComponentMaker& operator=(const ComponentMaker&); // stop default
+      const ComponentMaker& operator=(const ComponentMaker&) = delete; // stop default
 
       void setDescription(DataProxyProvider* iProv, const ComponentDescription& iDesc) const {
         iProv->setDescription(iDesc);

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -39,7 +39,7 @@ namespace edm {
     typedef EDProducer ModuleType;
 
     EDProducer ();
-    virtual ~EDProducer();
+    ~EDProducer() override;
 
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
     static void prevalidate(ConfigurationDescriptions& descriptions);

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -67,7 +67,7 @@ namespace edm {
   public:
     Event(EventPrincipal const& ep, ModuleDescription const& md,
           ModuleCallingContext const*);
-    virtual ~Event();
+    ~Event() override;
 
     //Used in conjunction with EDGetToken
     void setConsumer(EDConsumerBase const* iConsumer);
@@ -214,16 +214,16 @@ namespace edm {
     bool
     getProcessParameterSet(std::string const& processName, ParameterSet& ps) const;
 
-    virtual ProcessHistory const&
+    ProcessHistory const&
     processHistory() const override;
 
-    virtual edm::ParameterSet const*
+    edm::ParameterSet const*
     parameterSet(edm::ParameterSetID const& psID) const override;
 
     size_t size() const;
 
-    virtual edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const override;
-    virtual TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const override;
+    edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const override;
+    TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const override;
 
     ModuleCallingContext const* moduleCallingContext() const { return moduleCallingContext_; }
 
@@ -245,10 +245,10 @@ namespace edm {
     makeProductID(BranchDescription const& desc) const;
 
     //override used by EventBase class
-    virtual BasicHandle getByLabelImpl(std::type_info const& iWrapperType, std::type_info const& iProductType, InputTag const& iTag) const override;
+    BasicHandle getByLabelImpl(std::type_info const& iWrapperType, std::type_info const& iProductType, InputTag const& iTag) const override;
 
     //override used by EventBase class
-    virtual BasicHandle getImpl(std::type_info const& iProductType, ProductID const& pid) const override;
+    BasicHandle getImpl(std::type_info const& iProductType, ProductID const& pid) const override;
 
     // commit_() is called to complete the transaction represented by
     // this PrincipalGetAdapter. The friendships required seems gross, but any
@@ -260,8 +260,8 @@ namespace edm {
     friend class ProducerBase;
     template<typename T> friend class stream::ProducingModuleAdaptorBase;
 
-    void commit_(std::vector<edm::ProductResolverIndex> const& iShouldPut, std::vector<BranchID>* previousParentage= 0, ParentageID* previousParentageId = 0);
-    void commit_aux(ProductPtrVec& products, bool record_parents, std::vector<BranchID>* previousParentage = 0, ParentageID* previousParentageId = 0);
+    void commit_(std::vector<edm::ProductResolverIndex> const& iShouldPut, std::vector<BranchID>* previousParentage= nullptr, ParentageID* previousParentageId = nullptr);
+    void commit_aux(ProductPtrVec& products, bool record_parents, std::vector<BranchID>* previousParentage = nullptr, ParentageID* previousParentageId = nullptr);
 
     BasicHandle
     getByProductID_(ProductID const& oid) const;

--- a/FWCore/Framework/interface/EventForOutput.h
+++ b/FWCore/Framework/interface/EventForOutput.h
@@ -51,7 +51,7 @@ namespace edm {
   public:
     EventForOutput(EventPrincipal const& ep, ModuleDescription const& md,
           ModuleCallingContext const*);
-    virtual ~EventForOutput();
+    ~EventForOutput() override;
     
     EventAuxiliary const& eventAuxiliary() const {return aux_;}
     EventID const& id() const {return aux_.id();}

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -59,7 +59,7 @@ namespace edm {
         HistoryAppender* historyAppender,
         unsigned int streamIndex = 0,
         bool isForPrimaryProcess = true);
-    ~EventPrincipal() {}
+    ~EventPrincipal() override {}
 
     void fillEventPrincipal(EventAuxiliary const& aux,
         ProcessHistoryRegistry const& processHistoryRegistry,
@@ -158,9 +158,9 @@ namespace edm {
         std::unique_ptr<WrapperBase> edp,
         ProductProvenance const* productProvenance) const;
 
-    virtual WrapperBase const* getIt(ProductID const& pid) const override;
-    virtual WrapperBase const* getThinnedProduct(ProductID const& pid, unsigned int& key) const override;
-    virtual void getThinnedProducts(ProductID const& pid,
+    WrapperBase const* getIt(ProductID const& pid) const override;
+    WrapperBase const* getThinnedProduct(ProductID const& pid, unsigned int& key) const override;
+    void getThinnedProducts(ProductID const& pid,
                                     std::vector<WrapperBase const*>& foundContainers,
                                     std::vector<unsigned int>& keys) const override;
 
@@ -178,7 +178,7 @@ namespace edm {
 
     edm::ThinnedAssociation const* getThinnedAssociation(edm::BranchID const& branchID) const;
 
-    virtual unsigned int transitionIndex_() const override;
+    unsigned int transitionIndex_() const override;
     
     std::shared_ptr<ProductProvenanceRetriever const> provRetrieverPtr() const {return get_underlying_safe(provRetrieverPtr_);}
     std::shared_ptr<ProductProvenanceRetriever>& provRetrieverPtr() {return get_underlying_safe(provRetrieverPtr_);}

--- a/FWCore/Framework/interface/EventSetupProvider.h
+++ b/FWCore/Framework/interface/EventSetupProvider.h
@@ -57,7 +57,7 @@ class EventSetupProvider {
       typedef std::multimap<RecordName, DataKeyInfo> RecordToDataMap;
       typedef std::map<ComponentDescription, RecordToDataMap> PreferredProviderInfo;
 
-      EventSetupProvider(unsigned subProcessIndex = 0U, PreferredProviderInfo const* iInfo = 0);
+      EventSetupProvider(unsigned subProcessIndex = 0U, PreferredProviderInfo const* iInfo = nullptr);
       virtual ~EventSetupProvider();
 
       // ---------- const member functions ---------------------

--- a/FWCore/Framework/interface/EventSetupRecord.h
+++ b/FWCore/Framework/interface/EventSetupRecord.h
@@ -92,7 +92,7 @@ namespace edm {
          template<typename HolderT>
          void get(HolderT& iHolder) const {
             typename HolderT::value_type const* value = 0;
-            ComponentDescription const* desc = 0;
+            ComponentDescription const* desc = nullptr;
             std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
             this->getImplementation(value, "", desc, iHolder.transientAccessOnly, whyFailedFactory);
 
@@ -106,7 +106,7 @@ namespace edm {
          template<typename HolderT>
          void get(char const* iName, HolderT& iHolder) const {
             typename HolderT::value_type const* value = 0;
-            ComponentDescription const* desc = 0;
+            ComponentDescription const* desc = nullptr;
             std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
             this->getImplementation(value, iName, desc, iHolder.transientAccessOnly, whyFailedFactory);
 
@@ -119,7 +119,7 @@ namespace edm {
          template<typename HolderT>
          void get(std::string const& iName, HolderT& iHolder) const {
             typename HolderT::value_type const* value = 0;
-            ComponentDescription const* desc = 0;
+            ComponentDescription const* desc = nullptr;
             std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
             this->getImplementation(value, iName.c_str(), desc, iHolder.transientAccessOnly, whyFailedFactory);
 
@@ -133,7 +133,7 @@ namespace edm {
          template<typename HolderT>
          void get(ESInputTag const& iTag, HolderT& iHolder) const {
             typename HolderT::value_type const* value = 0;
-            ComponentDescription const* desc = 0;
+            ComponentDescription const* desc = nullptr;
             std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
             this->getImplementation(value, iTag.data().c_str(), desc, iHolder.transientAccessOnly, whyFailedFactory);
 
@@ -229,7 +229,7 @@ namespace edm {
                             DataKey::kDoNotCopyMemory);
 
             void const* pValue = this->getFromProxy(dataKey, iDesc, iTransientAccessOnly);
-            if(0 == pValue) {
+            if(nullptr == pValue) {
               whyFailedFactory =
                 makeESHandleExceptionFactory([=]()->std::exception_ptr {
                     NoProxyException<DataT> ex(this->key(), dataKey);

--- a/FWCore/Framework/interface/ExceptionHelpers.h
+++ b/FWCore/Framework/interface/ExceptionHelpers.h
@@ -49,7 +49,7 @@ namespace edm {
 
   template <typename TReturn>
   TReturn callWithTryCatchAndPrint(std::function<TReturn (void)> iFunc,
-                                   char const* context = 0,
+                                   char const* context = nullptr,
                                    bool disablePrint = false) {
 
     try {

--- a/FWCore/Framework/interface/FunctorESHandleExceptionFactory.h
+++ b/FWCore/Framework/interface/FunctorESHandleExceptionFactory.h
@@ -32,7 +32,7 @@ namespace edm {
   public:
     FunctorESHandleExceptionFactory(T&& iFunctor) : m_functor(std::move(iFunctor)) {}
 
-    std::exception_ptr make() const {
+    std::exception_ptr make() const override {
       return m_functor();
     }
   private:

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -46,10 +46,10 @@ namespace edm {
   public:
     LuminosityBlock(LuminosityBlockPrincipal const& lbp, ModuleDescription const& md,
                     ModuleCallingContext const*);
-    ~LuminosityBlock();
+    ~LuminosityBlock() override;
 
     // AUX functions are defined in LuminosityBlockBase
-    LuminosityBlockAuxiliary const& luminosityBlockAuxiliary() const {return aux_;}
+    LuminosityBlockAuxiliary const& luminosityBlockAuxiliary() const override {return aux_;}
 
     /**\return Reusable index which can be used to separate data for different simultaneous LuminosityBlocks.
      */
@@ -133,7 +133,7 @@ namespace edm {
     luminosityBlockPrincipal() const;
 
     // Override version from LuminosityBlockBase class
-    virtual BasicHandle getByLabelImpl(std::type_info const& iWrapperType, std::type_info const& iProductType, InputTag const& iTag) const;
+    BasicHandle getByLabelImpl(std::type_info const& iWrapperType, std::type_info const& iProductType, InputTag const& iTag) const override;
 
     typedef std::vector<std::pair<edm::propagate_const<std::unique_ptr<WrapperBase>>, BranchDescription const*>> ProductPtrVec;
     ProductPtrVec& putProducts() {return putProducts_;}

--- a/FWCore/Framework/interface/LuminosityBlockPrincipal.h
+++ b/FWCore/Framework/interface/LuminosityBlockPrincipal.h
@@ -42,9 +42,9 @@ namespace edm {
         unsigned int index,
         bool isForPrimaryProcess=true);
 
-    ~LuminosityBlockPrincipal() {}
+    ~LuminosityBlockPrincipal() override {}
 
-    void fillLuminosityBlockPrincipal(ProcessHistoryRegistry const& processHistoryRegistry, DelayedReader* reader = 0);
+    void fillLuminosityBlockPrincipal(ProcessHistoryRegistry const& processHistoryRegistry, DelayedReader* reader = nullptr);
 
     RunPrincipal const& runPrincipal() const {
       return *runPrincipal_;
@@ -105,9 +105,9 @@ namespace edm {
 
   private:
 
-    virtual bool isComplete_() const override {return complete_;}
+    bool isComplete_() const override {return complete_;}
 
-    virtual unsigned int transitionIndex_() const override;
+    unsigned int transitionIndex_() const override;
 
     edm::propagate_const<std::shared_ptr<RunPrincipal>> runPrincipal_;
 

--- a/FWCore/Framework/interface/NoDataException.h
+++ b/FWCore/Framework/interface/NoDataException.h
@@ -81,7 +81,7 @@ public:
   NoDataExceptionBase(const EventSetupRecordKey& iRecordKey,
                         const DataKey& iDataKey,
                         const char* category_name = "NoDataException") ;
-  virtual ~NoDataExceptionBase() throw();
+  ~NoDataExceptionBase() noexcept override;
   const DataKey& dataKey() const;
 protected:
   static std::string providerButNoDataMessage(const EventSetupRecordKey& iKey);

--- a/FWCore/Framework/interface/PathsAndConsumesOfModules.h
+++ b/FWCore/Framework/interface/PathsAndConsumesOfModules.h
@@ -29,23 +29,23 @@ namespace edm {
   class PathsAndConsumesOfModules : public PathsAndConsumesOfModulesBase {
   public:
 
-    virtual ~PathsAndConsumesOfModules();
+    ~PathsAndConsumesOfModules() override;
 
     void initialize(Schedule const*, std::shared_ptr<ProductRegistry const>);
 
   private:
 
-    virtual std::vector<std::string> const& doPaths() const override { return paths_; }
-    virtual std::vector<std::string> const& doEndPaths() const override { return endPaths_; }
+    std::vector<std::string> const& doPaths() const override { return paths_; }
+    std::vector<std::string> const& doEndPaths() const override { return endPaths_; }
 
-    virtual std::vector<ModuleDescription const*> const& doAllModules() const override { return allModuleDescriptions_; }
-    virtual ModuleDescription const* doModuleDescription(unsigned int moduleID) const override;
+    std::vector<ModuleDescription const*> const& doAllModules() const override { return allModuleDescriptions_; }
+    ModuleDescription const* doModuleDescription(unsigned int moduleID) const override;
 
-    virtual std::vector<ModuleDescription const*> const& doModulesOnPath(unsigned int pathIndex) const override;
-    virtual std::vector<ModuleDescription const*> const& doModulesOnEndPath(unsigned int endPathIndex) const override;
-    virtual std::vector<ModuleDescription const*> const& doModulesWhoseProductsAreConsumedBy(unsigned int moduleID) const override;
+    std::vector<ModuleDescription const*> const& doModulesOnPath(unsigned int pathIndex) const override;
+    std::vector<ModuleDescription const*> const& doModulesOnEndPath(unsigned int endPathIndex) const override;
+    std::vector<ModuleDescription const*> const& doModulesWhoseProductsAreConsumedBy(unsigned int moduleID) const override;
 
-    virtual std::vector<ConsumesInfo> doConsumesInfo(unsigned int moduleID) const override;
+    std::vector<ConsumesInfo> doConsumesInfo(unsigned int moduleID) const override;
 
     unsigned int moduleIndex(unsigned int moduleID) const;
 

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -74,7 +74,7 @@ namespace edm {
               HistoryAppender* historyAppender,
               bool isForPrimaryProcess = true);
 
-    virtual ~Principal();
+    ~Principal() override;
 
     bool adjustToNewProductRegistry(ProductRegistry const& reg);
 
@@ -230,9 +230,9 @@ namespace edm {
     void addParentProcessProduct(std::shared_ptr<BranchDescription const> bd);
     
 
-    virtual WrapperBase const* getIt(ProductID const&) const override;
-    virtual WrapperBase const* getThinnedProduct(ProductID const&, unsigned int&) const override;
-    virtual void getThinnedProducts(ProductID const&,
+    WrapperBase const* getIt(ProductID const&) const override;
+    WrapperBase const* getThinnedProduct(ProductID const&, unsigned int&) const override;
+    void getThinnedProducts(ProductID const&,
                                     std::vector<WrapperBase const*>&,
                                     std::vector<unsigned int>&) const override;
 

--- a/FWCore/Framework/interface/RunPrincipal.h
+++ b/FWCore/Framework/interface/RunPrincipal.h
@@ -39,9 +39,9 @@ namespace edm {
         HistoryAppender* historyAppender,
         unsigned int iRunIndex,
         bool isForPrimaryProcess=true);
-    ~RunPrincipal() {}
+    ~RunPrincipal() override {}
 
-    void fillRunPrincipal(ProcessHistoryRegistry const& processHistoryRegistry, DelayedReader* reader = 0);
+    void fillRunPrincipal(ProcessHistoryRegistry const& processHistoryRegistry, DelayedReader* reader = nullptr);
 
     /** Multiple Runs may be processed simultaneously. The
      return value can be used to identify a particular Run.
@@ -96,9 +96,9 @@ namespace edm {
 
   private:
 
-    virtual bool isComplete_() const override {return complete_;}
+    bool isComplete_() const override {return complete_;}
 
-    virtual unsigned int transitionIndex_() const override;
+    unsigned int transitionIndex_() const override;
 
     edm::propagate_const<std::shared_ptr<RunAuxiliary>> aux_;
     ProcessHistoryID m_reducedHistoryID;

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -142,21 +142,10 @@ namespace edm {
                               EventSetup const& eventSetup);
 
     template <typename T>
-    void processOneGlobal(typename T::MyPrincipal& principal,
-                          EventSetup const& eventSetup,
-                          bool cleaningUpAfterException = false);
-
-    template <typename T>
     void processOneGlobalAsync(WaitingTaskHolder iTask,
                                typename T::MyPrincipal& principal,
                                EventSetup const& eventSetup,
                                bool cleaningUpAfterException = false);
-
-    template <typename T>
-    void processOneStream(unsigned int iStreamID,
-                          typename T::MyPrincipal& principal,
-                          EventSetup const& eventSetup,
-                          bool cleaningUpAfterException = false);
 
     template <typename T>
     void processOneStreamAsync(WaitingTaskHolder iTask,
@@ -308,15 +297,6 @@ namespace edm {
     volatile bool           endpathsAreActive_;
   };
 
-
-  template <typename T>
-  void Schedule::processOneStream(unsigned int iStreamID,
-                                  typename T::MyPrincipal& ep,
-                                  EventSetup const& es,
-                                  bool cleaningUpAfterException) {
-    assert(iStreamID<streamSchedules_.size());
-    streamSchedules_[iStreamID]->processOneStream<T>(ep,es,cleaningUpAfterException);
-  }
   
   template <typename T>
   void Schedule::processOneStreamAsync(WaitingTaskHolder iTaskHolder,
@@ -328,14 +308,6 @@ namespace edm {
     streamSchedules_[iStreamID]->processOneStreamAsync<T>(std::move(iTaskHolder),ep,es,cleaningUpAfterException);
   }
 
-  template <typename T>
-  void
-  Schedule::processOneGlobal(typename T::MyPrincipal& ep,
-                                 EventSetup const& es,
-                                 bool cleaningUpAfterException) {
-    globalSchedule_->processOneGlobal<T>(ep,es,cleaningUpAfterException);
-  }
-  
   template <typename T>
   void
   Schedule::processOneGlobalAsync(WaitingTaskHolder iTaskHolder,

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -55,7 +55,7 @@ namespace edm {
                PreallocationConfiguration const& preallocConfig,
                ProcessContext const* parentProcessContext);
 
-    virtual ~SubProcess();
+    ~SubProcess() override;
 
     SubProcess(SubProcess const&) = delete; // Disallow copying
     SubProcess& operator=(SubProcess const&) = delete; // Disallow copying

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -75,40 +75,32 @@ namespace edm {
     void doEventAsync(WaitingTaskHolder iHolder,
                       EventPrincipal const& principal);
 
-    void doBeginRun(RunPrincipal const& principal, IOVSyncValue const& ts);
     void doBeginRunAsync(WaitingTaskHolder iHolder, RunPrincipal const& principal, IOVSyncValue const& ts);
 
-    void doEndRun(RunPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException);
     void doEndRunAsync(WaitingTaskHolder iHolder, RunPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException);
 
-    void doBeginLuminosityBlock(LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts);
     void doBeginLuminosityBlockAsync(WaitingTaskHolder iHolder, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts);
 
-    void doEndLuminosityBlock(LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException);
     void doEndLuminosityBlockAsync(WaitingTaskHolder iHolder, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException);
 
 
     void doBeginStream(unsigned int);
     void doEndStream(unsigned int);
-    void doStreamBeginRun(unsigned int iID, RunPrincipal const& principal, IOVSyncValue const& ts);
     void doStreamBeginRunAsync(WaitingTaskHolder iHolder,
                                unsigned int iID,
                                RunPrincipal const& principal,
                                IOVSyncValue const& ts);
 
-    void doStreamEndRun(unsigned int iID, RunPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException);
     void doStreamEndRunAsync(WaitingTaskHolder iHolder,
                              unsigned int iID, RunPrincipal const& principal,
                              IOVSyncValue const& ts,
                              bool cleaningUpAfterException);
 
-    void doStreamBeginLuminosityBlock(unsigned int iID, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts);
     void doStreamBeginLuminosityBlockAsync(WaitingTaskHolder iHolder,
                                            unsigned int iID,
                                            LuminosityBlockPrincipal const& principal,
                                            IOVSyncValue const& ts);
 
-    void doStreamEndLuminosityBlock(unsigned int iID, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException);
     void doStreamEndLuminosityBlockAsync(WaitingTaskHolder iHolder,
                                          unsigned int iID,
                                          LuminosityBlockPrincipal const& principal,

--- a/FWCore/Framework/interface/UnscheduledCallProducer.h
+++ b/FWCore/Framework/interface/UnscheduledCallProducer.h
@@ -57,26 +57,6 @@ namespace edm {
     const_iterator end() const { return unscheduledWorkers_.end(); }
     
     template <typename T, typename U>
-    void runNow(typename T::MyPrincipal& p, EventSetup const& es, StreamID streamID,
-                typename T::Context const* topContext, U const* context) const {
-      //do nothing for event since we will run when requested
-      if(!T::isEvent_) {
-        for(auto worker: unscheduledWorkers_) {
-          try {
-            ParentContext parentContext(context);
-            worker->doWork<T>(p, es, streamID, parentContext, topContext);
-          }
-          catch (cms::Exception & ex) {
-            if(ex.context().empty()) {
-              addContextToException<T>(ex,worker,p.id());
-            }
-            throw;
-          }
-        }
-      }
-    }
-
-    template <typename T, typename U>
     void runNowAsync(WaitingTask* task,
                      typename T::MyPrincipal& p, EventSetup const& es, StreamID streamID,
                      typename T::Context const* topContext, U const* context) const {

--- a/FWCore/Framework/interface/UnscheduledCallProducer.h
+++ b/FWCore/Framework/interface/UnscheduledCallProducer.h
@@ -43,7 +43,7 @@ namespace edm {
       aux_.postModuleDelayedGetSignal_.connect(std::cref(iReg.postModuleEventDelayedGetSignal_));
     }
     void addWorker(Worker* aWorker) {
-      assert(0 != aWorker);
+      assert(nullptr != aWorker);
       unscheduledWorkers_.push_back(aWorker);
     }
     

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -47,13 +47,6 @@ namespace edm {
     void setOnDemandProducts(ProductRegistry& pregistry, std::set<std::string> const& unscheduledLabels) const;
 
     template <typename T, typename U>
-    void processOneOccurrence(typename T::MyPrincipal& principal,
-                              EventSetup const& eventSetup,
-                              StreamID streamID,
-                              typename T::Context const* topContext,
-                              U const* context,
-                              bool cleaningUpAfterException = false);
-    template <typename T, typename U>
     void processOneOccurrenceAsync(
                               WaitingTask* task,
                               typename T::MyPrincipal& principal,
@@ -95,33 +88,6 @@ namespace edm {
     void const* lastSetupEventPrincipal_;
   };
 
-  template <typename T, typename U>
-  void
-  WorkerManager::processOneOccurrence(typename T::MyPrincipal& ep,
-                                 EventSetup const& es,
-                                 StreamID streamID,
-                                 typename T::Context const* topContext,
-                                 U const* context,
-                                 bool cleaningUpAfterException) {
-    this->resetAll();
-
-    try {
-      convertException::wrap([&]() {
-        //make sure the unscheduled items see this run or lumi transition
-        unscheduled_.runNow<T,U>(ep, es,streamID, topContext, context);
-        }
-      );
-    }
-    catch(cms::Exception& ex) {
-      if (ex.context().empty()) {
-        addContextAndPrintException("Calling function WorkerManager::processOneOccurrence", ex, cleaningUpAfterException);
-      } else {
-        addContextAndPrintException("", ex, cleaningUpAfterException);
-      }
-      throw;
-    }
-  }
-  
   template <typename T, typename U>
   void
   WorkerManager::processOneOccurrenceAsync(WaitingTask* task,

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1184,10 +1184,22 @@ namespace edm {
       //looper_->doStreamEndLuminosityBlock(schedule_->streamID(),lumiPrincipal, es);
     }
     {
+      auto globalWaitTask = make_empty_waiting_task();
+      globalWaitTask->increment_ref_count();
+      
       lumiPrincipal.setAtEndTransition(true);
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> Traits;
-      schedule_->processOneGlobal<Traits>(lumiPrincipal, es, cleaningUpAfterException);
-      for_all(subProcesses_, [&lumiPrincipal, &ts, cleaningUpAfterException](auto& subProcess){	subProcess.doEndLuminosityBlock(lumiPrincipal, ts, cleaningUpAfterException); });
+      endGlobalTransitionAsync<Traits>(WaitingTaskHolder(globalWaitTask.get()),
+                                       *schedule_,
+                                       lumiPrincipal,
+                                       ts,
+                                       es,
+                                       subProcesses_,
+                                       cleaningUpAfterException);
+      globalWaitTask->wait_for_all();
+      if(globalWaitTask->exceptionPtr() != nullptr) {
+        std::rethrow_exception(* (globalWaitTask->exceptionPtr()) );
+      }
     }
     FDEBUG(1) << "\tendLumi " << run << "/" << lumi << "\n";
     if(looper_) {

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -120,7 +120,7 @@ namespace edm {
             std::shared_ptr<ProcessConfiguration const> processConfiguration,
             PreallocationConfiguration const& allocations) {
     ParameterSet* main_input = params.getPSetForUpdate("@main_input");
-    if(main_input == 0) {
+    if(main_input == nullptr) {
       throw Exception(errors::Configuration)
         << "There must be exactly one source in the configuration.\n"
         << "It is missing (or there are sufficient syntax errors such that it is not recognized as the source)\n";
@@ -192,7 +192,7 @@ namespace edm {
 
     std::vector<std::string> loopers = params.getParameter<std::vector<std::string> >("@all_loopers");
 
-    if(loopers.size() == 0) {
+    if(loopers.empty()) {
       return vLooper;
     }
 

--- a/FWCore/Framework/src/SignallingProductRegistry.h
+++ b/FWCore/Framework/src/SignallingProductRegistry.h
@@ -40,7 +40,7 @@ namespace edm {
       SignallingProductRegistry& operator=(SignallingProductRegistry const&) = delete; // Disallow copying and moving
 
    private:
-      virtual void addCalled(BranchDescription const&, bool);
+      void addCalled(BranchDescription const&, bool) override;
       // ---------- member data --------------------------------
       std::map<std::string, unsigned int> typeAddedStack_;
    };

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -408,34 +408,6 @@ namespace edm {
   }
 
   void
-  SubProcess::doBeginRun(RunPrincipal const& principal, IOVSyncValue const& ts) {
-    ServiceRegistry::Operate operate(serviceToken_);
-    beginRun(principal,ts);
-  }
-
-  void
-  SubProcess::beginRun(RunPrincipal const& principal, IOVSyncValue const& ts) {
-    auto aux = std::make_shared<RunAuxiliary>(principal.aux());
-    aux->setProcessHistoryID(principal.processHistoryID());
-    auto rpp = std::make_shared<RunPrincipal>(aux, preg_, *processConfiguration_, &(historyAppenders_[historyRunOffset_+principal.index()]),principal.index(),false);
-    auto & processHistoryRegistry = processHistoryRegistries_[historyRunOffset_+principal.index()];
-    processHistoryRegistry.registerProcessHistory(principal.processHistory());
-    rpp->fillRunPrincipal(processHistoryRegistry, principal.reader());
-    principalCache_.insert(rpp);
-
-    ProcessHistoryID const& parentInputReducedPHID = principal.reducedProcessHistoryID();
-    ProcessHistoryID const& inputReducedPHID       = rpp->reducedProcessHistoryID();
-
-    parentToChildPhID_.insert(std::make_pair(parentInputReducedPHID,inputReducedPHID));
-
-    RunPrincipal& rp = *principalCache_.runPrincipalPtr();
-    propagateProducts(InRun, principal, rp);
-    typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> Traits;
-    schedule_->processOneGlobal<Traits>(rp, esp_->eventSetupForInstance(ts));
-    for_all(subProcesses_, [&rp, &ts](auto& subProcess){ subProcess.doBeginRun(rp, ts); });
-  }
-
-  void
   SubProcess::doBeginRunAsync(WaitingTaskHolder iHolder, RunPrincipal const& principal, IOVSyncValue const& ts) {
     ServiceRegistry::Operate operate(serviceToken_);
 
@@ -464,23 +436,6 @@ namespace edm {
   }
 
   
-  void
-  SubProcess::doEndRun(RunPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException) {
-    ServiceRegistry::Operate operate(serviceToken_);
-    endRun(principal,ts,cleaningUpAfterException);
-  }
-
-  void
-  SubProcess::endRun(RunPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException) {
-    RunPrincipal& rp = *principalCache_.runPrincipalPtr();
-    rp.setComplete();
-    propagateProducts(InRun, principal, rp);
-    typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> Traits;
-    rp.setAtEndTransition(true);
-    schedule_->processOneGlobal<Traits>(rp, esp_->eventSetupForInstance(ts), cleaningUpAfterException);
-    for_all(subProcesses_, [&rp, &ts, cleaningUpAfterException](auto& subProcess){ subProcess.doEndRun(rp, ts, cleaningUpAfterException); });
-  }
-
   void
   SubProcess::doEndRunAsync(WaitingTaskHolder iHolder,
                             RunPrincipal const& principal,
@@ -520,29 +475,6 @@ namespace edm {
   }
 
   void
-  SubProcess::doBeginLuminosityBlock(LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts) {
-    ServiceRegistry::Operate operate(serviceToken_);
-    beginLuminosityBlock(principal,ts);
-  }
-
-  void
-  SubProcess::beginLuminosityBlock(LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts) {
-    auto aux = std::make_shared<LuminosityBlockAuxiliary>(principal.aux());
-    aux->setProcessHistoryID(principal.processHistoryID());
-    auto lbpp = std::make_shared<LuminosityBlockPrincipal>(aux, preg_, *processConfiguration_, &(historyAppenders_[historyLumiOffset_+principal.index()]),principal.index(),false);
-    auto & processHistoryRegistry = processHistoryRegistries_[historyLumiOffset_+principal.index()];
-    processHistoryRegistry.registerProcessHistory(principal.processHistory());
-    lbpp->fillLuminosityBlockPrincipal(processHistoryRegistry, principal.reader());
-    lbpp->setRunPrincipal(principalCache_.runPrincipalPtr());
-    principalCache_.insert(lbpp);
-    LuminosityBlockPrincipal& lbp = *principalCache_.lumiPrincipalPtr();
-    propagateProducts(InLumi, principal, lbp);
-    typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> Traits;
-    schedule_->processOneGlobal<Traits>(lbp, esp_->eventSetupForInstance(ts));
-    for_all(subProcesses_, [&lbp, &ts](auto& subProcess){ subProcess.doBeginLuminosityBlock(lbp, ts); });
-  }
-
-  void
   SubProcess::doBeginLuminosityBlockAsync(WaitingTaskHolder iHolder, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts) {
     ServiceRegistry::Operate operate(serviceToken_);
 
@@ -563,23 +495,6 @@ namespace edm {
                                        ts,
                                        esp_->eventSetupForInstance(ts),
                                        subProcesses_);
-  }
-
-  void
-  SubProcess::doEndLuminosityBlock(LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException) {
-    ServiceRegistry::Operate operate(serviceToken_);
-    endLuminosityBlock(principal,ts,cleaningUpAfterException);
-  }
-
-  void
-  SubProcess::endLuminosityBlock(LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException) {
-    LuminosityBlockPrincipal& lbp = *principalCache_.lumiPrincipalPtr();
-    lbp.setComplete();
-    propagateProducts(InLumi, principal, lbp);
-    typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> Traits;
-    lbp.setAtEndTransition(true);
-    schedule_->processOneGlobal<Traits>(lbp, esp_->eventSetupForInstance(ts), cleaningUpAfterException);
-    for_all(subProcesses_, [&lbp, &ts, cleaningUpAfterException](auto& subProcess){ subProcess.doEndLuminosityBlock(lbp, ts, cleaningUpAfterException); });
   }
 
   void
@@ -633,16 +548,6 @@ namespace edm {
   }
 
   void
-  SubProcess::doStreamBeginRun(unsigned int id, RunPrincipal const& principal, IOVSyncValue const& ts) {
-    ServiceRegistry::Operate operate(serviceToken_);
-    {
-      RunPrincipal& rp = *principalCache_.runPrincipalPtr();
-      typedef OccurrenceTraits<RunPrincipal, BranchActionStreamBegin> Traits;
-      schedule_->processOneStream<Traits>(id,rp, esp_->eventSetupForInstance(ts));
-      for_all(subProcesses_, [id, &rp, &ts](auto& subProcess){ subProcess.doStreamBeginRun(id,rp, ts); });
-    }
-  }
-  void
   SubProcess::doStreamBeginRunAsync(WaitingTaskHolder iHolder,
                                     unsigned int id, RunPrincipal const& principal, IOVSyncValue const& ts) {
     ServiceRegistry::Operate operate(serviceToken_);
@@ -663,17 +568,6 @@ namespace edm {
 
   
   void
-  SubProcess::doStreamEndRun(unsigned int id, RunPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException) {
-    ServiceRegistry::Operate operate(serviceToken_);
-    {
-      RunPrincipal& rp = *principalCache_.runPrincipalPtr();
-      typedef OccurrenceTraits<RunPrincipal, BranchActionStreamEnd> Traits;
-      schedule_->processOneStream<Traits>(id,rp, esp_->eventSetupForInstance(ts),cleaningUpAfterException);
-      for_all(subProcesses_, [id, &rp, &ts, cleaningUpAfterException](auto& subProcess){ subProcess.doStreamEndRun(id,rp, ts,cleaningUpAfterException); });
-    }
-  }
-
-  void
   SubProcess::doStreamEndRunAsync(WaitingTaskHolder iHolder,
                                   unsigned int id, RunPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException) {
     ServiceRegistry::Operate operate(serviceToken_);
@@ -690,16 +584,6 @@ namespace edm {
                                      cleaningUpAfterException);
   }
 
-  void
-  SubProcess::doStreamBeginLuminosityBlock(unsigned int id, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts) {
-    ServiceRegistry::Operate operate(serviceToken_);
-    {
-      LuminosityBlockPrincipal& lbp = *principalCache_.lumiPrincipalPtr();
-      typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin> Traits;
-      schedule_->processOneStream<Traits>(id,lbp, esp_->eventSetupForInstance(ts));
-      for_all(subProcesses_, [id, &lbp, &ts](auto& subProcess){ subProcess.doStreamBeginLuminosityBlock(id,lbp, ts); });
-    }
-  }
   void
   SubProcess::doStreamBeginLuminosityBlockAsync(WaitingTaskHolder iHolder,
                                                 unsigned int id, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts) {
@@ -720,17 +604,6 @@ namespace edm {
 
   
   
-  void
-  SubProcess::doStreamEndLuminosityBlock(unsigned int id, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException) {
-    ServiceRegistry::Operate operate(serviceToken_);
-    {
-      LuminosityBlockPrincipal& lbp = *principalCache_.lumiPrincipalPtr();
-      typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd> Traits;
-      schedule_->processOneStream<Traits>(id,lbp, esp_->eventSetupForInstance(ts),cleaningUpAfterException);
-      for_all(subProcesses_, [id, &lbp, &ts, cleaningUpAfterException](auto& subProcess){ subProcess.doStreamEndLuminosityBlock(id,lbp, ts,cleaningUpAfterException); });
-    }
-  }
-
   void
   SubProcess::doStreamEndLuminosityBlockAsync(WaitingTaskHolder iHolder,
                                               unsigned int id, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException) {

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -256,7 +256,7 @@ namespace edm {
     class TransitionIDValue : public TransitionIDValueBase {
     public:
       TransitionIDValue(T const& iP): p_(iP) {}
-      virtual std::string value() const override {
+      std::string value() const override {
         std::ostringstream iost;
         iost<<p_.id();
         return iost.str();

--- a/FWCore/Framework/src/WorkerInPath.h
+++ b/FWCore/Framework/src/WorkerInPath.h
@@ -28,11 +28,6 @@ namespace edm {
     WorkerInPath(Worker*, FilterAction theAction, unsigned int placeInPath);
 
     template <typename T>
-    bool runWorker(typename T::MyPrincipal const&, EventSetup const&,
-                   StreamID streamID,
-                   typename T::Context const* context);
-
-    template <typename T>
     void runWorkerAsync(WaitingTask* iTask,
                         typename T::MyPrincipal const&, EventSetup const&,
                         StreamID streamID,
@@ -128,46 +123,7 @@ namespace edm {
       ParentContext parentContext(context);
       worker_->doWorkNoPrefetchingAsync<T>(iTask,ep, es,streamID, parentContext, context);
     }
-  }
-  
-  template <typename T>
-  bool WorkerInPath::runWorker(typename T::MyPrincipal const& ep, EventSetup const & es,
-                               StreamID streamID,
-                               typename T::Context const* context) {
-
-    if (T::isEvent_) {
-      ++timesVisited_;
-    }
-    bool rc = true;
-
-    try {
-	// may want to change the return value from the worker to be 
-	// the Worker::FilterAction so conditions in the path will be easier to 
-	// identify
-        if(T::isEvent_) {
-          ParentContext parentContext(&placeInPathContext_);          
-          rc = worker_->doWork<T>(ep, es,streamID, parentContext, context);
-        } else {
-          ParentContext parentContext(context);
-          rc = worker_->doWork<T>(ep, es,streamID, parentContext, context);
-        }
-        // Ignore return code for non-event (e.g. run, lumi) calls
-	if (!T::isEvent_) rc = true;
-	else if (filterAction_ == Veto) rc = !rc;
-        else if (filterAction_ == Ignore) rc = true;
-
-	if (T::isEvent_) {
-	  if(rc) ++timesPassed_; else ++timesFailed_;
-	}
-    }
-    catch(...) {
-	if (T::isEvent_) ++timesExcept_;
-	throw;
-    }
-
-    return rc;
-  }
-
+  }  
 }
 
 #endif

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -1247,33 +1247,6 @@
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end lumi for module: label = 'test' id = 19
-++++++ finished: global end lumi for module: label = 'test' id = 19
-++++++ starting: global end lumi for module: label = 'testmerge' id = 20
-++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
-++++++ starting: global end lumi for module: label = 'getInt' id = 22
-++++++ finished: global end lumi for module: label = 'getInt' id = 22
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'out' id = 24
-++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global end lumi for module: label = 'path1' id = 13
-++++++ finished: global end lumi for module: label = 'path1' id = 13
-++++++ starting: global end lumi for module: label = 'path2' id = 14
-++++++ finished: global end lumi for module: label = 'path2' id = 14
-++++++ starting: global end lumi for module: label = 'path3' id = 15
-++++++ finished: global end lumi for module: label = 'path3' id = 15
-++++++ starting: global end lumi for module: label = 'path4' id = 16
-++++++ finished: global end lumi for module: label = 'path4' id = 16
-++++++ starting: global end lumi for module: label = 'endPath1' id = 17
-++++++ finished: global end lumi for module: label = 'endPath1' id = 17
-++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
@@ -1301,6 +1274,33 @@
 ++++++ finished: global end lumi for module: label = 'path4' id = 29
 ++++++ starting: global end lumi for module: label = 'endPath1' id = 30
 ++++++ finished: global end lumi for module: label = 'endPath1' id = 30
+++++ finished: global end lumi: run = 1 lumi = 1 time = 1
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 19
+++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 20
+++++++ finished: global end lumi for module: label = 'testmerge' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 22
+++++++ finished: global end lumi for module: label = 'getInt' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end lumi for module: label = 'out' id = 24
+++++++ finished: global end lumi for module: label = 'out' id = 24
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global end lumi for module: label = 'path1' id = 13
+++++++ finished: global end lumi for module: label = 'path1' id = 13
+++++++ starting: global end lumi for module: label = 'path2' id = 14
+++++++ finished: global end lumi for module: label = 'path2' id = 14
+++++++ starting: global end lumi for module: label = 'path3' id = 15
+++++++ finished: global end lumi for module: label = 'path3' id = 15
+++++++ starting: global end lumi for module: label = 'path4' id = 16
+++++++ finished: global end lumi for module: label = 'path4' id = 16
+++++++ starting: global end lumi for module: label = 'endPath1' id = 17
+++++++ finished: global end lumi for module: label = 'endPath1' id = 17
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -2177,33 +2177,6 @@
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end lumi for module: label = 'test' id = 19
-++++++ finished: global end lumi for module: label = 'test' id = 19
-++++++ starting: global end lumi for module: label = 'testmerge' id = 20
-++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
-++++++ starting: global end lumi for module: label = 'getInt' id = 22
-++++++ finished: global end lumi for module: label = 'getInt' id = 22
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'out' id = 24
-++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global end lumi for module: label = 'path1' id = 13
-++++++ finished: global end lumi for module: label = 'path1' id = 13
-++++++ starting: global end lumi for module: label = 'path2' id = 14
-++++++ finished: global end lumi for module: label = 'path2' id = 14
-++++++ starting: global end lumi for module: label = 'path3' id = 15
-++++++ finished: global end lumi for module: label = 'path3' id = 15
-++++++ starting: global end lumi for module: label = 'path4' id = 16
-++++++ finished: global end lumi for module: label = 'path4' id = 16
-++++++ starting: global end lumi for module: label = 'endPath1' id = 17
-++++++ finished: global end lumi for module: label = 'endPath1' id = 17
-++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
@@ -2231,6 +2204,33 @@
 ++++++ finished: global end lumi for module: label = 'path4' id = 29
 ++++++ starting: global end lumi for module: label = 'endPath1' id = 30
 ++++++ finished: global end lumi for module: label = 'endPath1' id = 30
+++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 19
+++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 20
+++++++ finished: global end lumi for module: label = 'testmerge' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 22
+++++++ finished: global end lumi for module: label = 'getInt' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end lumi for module: label = 'out' id = 24
+++++++ finished: global end lumi for module: label = 'out' id = 24
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global end lumi for module: label = 'path1' id = 13
+++++++ finished: global end lumi for module: label = 'path1' id = 13
+++++++ starting: global end lumi for module: label = 'path2' id = 14
+++++++ finished: global end lumi for module: label = 'path2' id = 14
+++++++ starting: global end lumi for module: label = 'path3' id = 15
+++++++ finished: global end lumi for module: label = 'path3' id = 15
+++++++ starting: global end lumi for module: label = 'path4' id = 16
+++++++ finished: global end lumi for module: label = 'path4' id = 16
+++++++ starting: global end lumi for module: label = 'endPath1' id = 17
+++++++ finished: global end lumi for module: label = 'endPath1' id = 17
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -2783,33 +2783,6 @@
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end lumi for module: label = 'test' id = 19
-++++++ finished: global end lumi for module: label = 'test' id = 19
-++++++ starting: global end lumi for module: label = 'testmerge' id = 20
-++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
-++++++ starting: global end lumi for module: label = 'getInt' id = 22
-++++++ finished: global end lumi for module: label = 'getInt' id = 22
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'out' id = 24
-++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global end lumi for module: label = 'path1' id = 13
-++++++ finished: global end lumi for module: label = 'path1' id = 13
-++++++ starting: global end lumi for module: label = 'path2' id = 14
-++++++ finished: global end lumi for module: label = 'path2' id = 14
-++++++ starting: global end lumi for module: label = 'path3' id = 15
-++++++ finished: global end lumi for module: label = 'path3' id = 15
-++++++ starting: global end lumi for module: label = 'path4' id = 16
-++++++ finished: global end lumi for module: label = 'path4' id = 16
-++++++ starting: global end lumi for module: label = 'endPath1' id = 17
-++++++ finished: global end lumi for module: label = 'endPath1' id = 17
-++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
@@ -2837,6 +2810,33 @@
 ++++++ finished: global end lumi for module: label = 'path4' id = 29
 ++++++ starting: global end lumi for module: label = 'endPath1' id = 30
 ++++++ finished: global end lumi for module: label = 'endPath1' id = 30
+++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 19
+++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 20
+++++++ finished: global end lumi for module: label = 'testmerge' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 22
+++++++ finished: global end lumi for module: label = 'getInt' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end lumi for module: label = 'out' id = 24
+++++++ finished: global end lumi for module: label = 'out' id = 24
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global end lumi for module: label = 'path1' id = 13
+++++++ finished: global end lumi for module: label = 'path1' id = 13
+++++++ starting: global end lumi for module: label = 'path2' id = 14
+++++++ finished: global end lumi for module: label = 'path2' id = 14
+++++++ starting: global end lumi for module: label = 'path3' id = 15
+++++++ finished: global end lumi for module: label = 'path3' id = 15
+++++++ starting: global end lumi for module: label = 'path4' id = 16
+++++++ finished: global end lumi for module: label = 'path4' id = 16
+++++++ starting: global end lumi for module: label = 'endPath1' id = 17
+++++++ finished: global end lumi for module: label = 'endPath1' id = 17
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: end run: stream = 0 run = 1 time = 50000001
 ++++ finished: end run: stream = 0 run = 1 time = 50000001
@@ -3995,33 +3995,6 @@
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end lumi for module: label = 'test' id = 19
-++++++ finished: global end lumi for module: label = 'test' id = 19
-++++++ starting: global end lumi for module: label = 'testmerge' id = 20
-++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
-++++++ starting: global end lumi for module: label = 'getInt' id = 22
-++++++ finished: global end lumi for module: label = 'getInt' id = 22
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'out' id = 24
-++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global end lumi for module: label = 'path1' id = 13
-++++++ finished: global end lumi for module: label = 'path1' id = 13
-++++++ starting: global end lumi for module: label = 'path2' id = 14
-++++++ finished: global end lumi for module: label = 'path2' id = 14
-++++++ starting: global end lumi for module: label = 'path3' id = 15
-++++++ finished: global end lumi for module: label = 'path3' id = 15
-++++++ starting: global end lumi for module: label = 'path4' id = 16
-++++++ finished: global end lumi for module: label = 'path4' id = 16
-++++++ starting: global end lumi for module: label = 'endPath1' id = 17
-++++++ finished: global end lumi for module: label = 'endPath1' id = 17
-++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
@@ -4049,6 +4022,33 @@
 ++++++ finished: global end lumi for module: label = 'path4' id = 29
 ++++++ starting: global end lumi for module: label = 'endPath1' id = 30
 ++++++ finished: global end lumi for module: label = 'endPath1' id = 30
+++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 19
+++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 20
+++++++ finished: global end lumi for module: label = 'testmerge' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 22
+++++++ finished: global end lumi for module: label = 'getInt' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end lumi for module: label = 'out' id = 24
+++++++ finished: global end lumi for module: label = 'out' id = 24
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global end lumi for module: label = 'path1' id = 13
+++++++ finished: global end lumi for module: label = 'path1' id = 13
+++++++ starting: global end lumi for module: label = 'path2' id = 14
+++++++ finished: global end lumi for module: label = 'path2' id = 14
+++++++ starting: global end lumi for module: label = 'path3' id = 15
+++++++ finished: global end lumi for module: label = 'path3' id = 15
+++++++ starting: global end lumi for module: label = 'path4' id = 16
+++++++ finished: global end lumi for module: label = 'path4' id = 16
+++++++ starting: global end lumi for module: label = 'endPath1' id = 17
+++++++ finished: global end lumi for module: label = 'endPath1' id = 17
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -4925,33 +4925,6 @@
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end lumi for module: label = 'test' id = 19
-++++++ finished: global end lumi for module: label = 'test' id = 19
-++++++ starting: global end lumi for module: label = 'testmerge' id = 20
-++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
-++++++ starting: global end lumi for module: label = 'getInt' id = 22
-++++++ finished: global end lumi for module: label = 'getInt' id = 22
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'out' id = 24
-++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global end lumi for module: label = 'path1' id = 13
-++++++ finished: global end lumi for module: label = 'path1' id = 13
-++++++ starting: global end lumi for module: label = 'path2' id = 14
-++++++ finished: global end lumi for module: label = 'path2' id = 14
-++++++ starting: global end lumi for module: label = 'path3' id = 15
-++++++ finished: global end lumi for module: label = 'path3' id = 15
-++++++ starting: global end lumi for module: label = 'path4' id = 16
-++++++ finished: global end lumi for module: label = 'path4' id = 16
-++++++ starting: global end lumi for module: label = 'endPath1' id = 17
-++++++ finished: global end lumi for module: label = 'endPath1' id = 17
-++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
@@ -4979,6 +4952,33 @@
 ++++++ finished: global end lumi for module: label = 'path4' id = 29
 ++++++ starting: global end lumi for module: label = 'endPath1' id = 30
 ++++++ finished: global end lumi for module: label = 'endPath1' id = 30
+++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 19
+++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 20
+++++++ finished: global end lumi for module: label = 'testmerge' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 22
+++++++ finished: global end lumi for module: label = 'getInt' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end lumi for module: label = 'out' id = 24
+++++++ finished: global end lumi for module: label = 'out' id = 24
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global end lumi for module: label = 'path1' id = 13
+++++++ finished: global end lumi for module: label = 'path1' id = 13
+++++++ starting: global end lumi for module: label = 'path2' id = 14
+++++++ finished: global end lumi for module: label = 'path2' id = 14
+++++++ starting: global end lumi for module: label = 'path3' id = 15
+++++++ finished: global end lumi for module: label = 'path3' id = 15
+++++++ starting: global end lumi for module: label = 'path4' id = 16
+++++++ finished: global end lumi for module: label = 'path4' id = 16
+++++++ starting: global end lumi for module: label = 'endPath1' id = 17
+++++++ finished: global end lumi for module: label = 'endPath1' id = 17
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -5531,33 +5531,6 @@
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end lumi for module: label = 'test' id = 19
-++++++ finished: global end lumi for module: label = 'test' id = 19
-++++++ starting: global end lumi for module: label = 'testmerge' id = 20
-++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
-++++++ starting: global end lumi for module: label = 'getInt' id = 22
-++++++ finished: global end lumi for module: label = 'getInt' id = 22
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'out' id = 24
-++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global end lumi for module: label = 'path1' id = 13
-++++++ finished: global end lumi for module: label = 'path1' id = 13
-++++++ starting: global end lumi for module: label = 'path2' id = 14
-++++++ finished: global end lumi for module: label = 'path2' id = 14
-++++++ starting: global end lumi for module: label = 'path3' id = 15
-++++++ finished: global end lumi for module: label = 'path3' id = 15
-++++++ starting: global end lumi for module: label = 'path4' id = 16
-++++++ finished: global end lumi for module: label = 'path4' id = 16
-++++++ starting: global end lumi for module: label = 'endPath1' id = 17
-++++++ finished: global end lumi for module: label = 'endPath1' id = 17
-++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
@@ -5585,6 +5558,33 @@
 ++++++ finished: global end lumi for module: label = 'path4' id = 29
 ++++++ starting: global end lumi for module: label = 'endPath1' id = 30
 ++++++ finished: global end lumi for module: label = 'endPath1' id = 30
+++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 19
+++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 20
+++++++ finished: global end lumi for module: label = 'testmerge' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 22
+++++++ finished: global end lumi for module: label = 'getInt' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end lumi for module: label = 'out' id = 24
+++++++ finished: global end lumi for module: label = 'out' id = 24
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global end lumi for module: label = 'path1' id = 13
+++++++ finished: global end lumi for module: label = 'path1' id = 13
+++++++ starting: global end lumi for module: label = 'path2' id = 14
+++++++ finished: global end lumi for module: label = 'path2' id = 14
+++++++ starting: global end lumi for module: label = 'path3' id = 15
+++++++ finished: global end lumi for module: label = 'path3' id = 15
+++++++ starting: global end lumi for module: label = 'path4' id = 16
+++++++ finished: global end lumi for module: label = 'path4' id = 16
+++++++ starting: global end lumi for module: label = 'endPath1' id = 17
+++++++ finished: global end lumi for module: label = 'endPath1' id = 17
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: end run: stream = 0 run = 2 time = 100000001
 ++++ finished: end run: stream = 0 run = 2 time = 100000001
@@ -6743,33 +6743,6 @@
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end lumi for module: label = 'test' id = 19
-++++++ finished: global end lumi for module: label = 'test' id = 19
-++++++ starting: global end lumi for module: label = 'testmerge' id = 20
-++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
-++++++ starting: global end lumi for module: label = 'getInt' id = 22
-++++++ finished: global end lumi for module: label = 'getInt' id = 22
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'out' id = 24
-++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global end lumi for module: label = 'path1' id = 13
-++++++ finished: global end lumi for module: label = 'path1' id = 13
-++++++ starting: global end lumi for module: label = 'path2' id = 14
-++++++ finished: global end lumi for module: label = 'path2' id = 14
-++++++ starting: global end lumi for module: label = 'path3' id = 15
-++++++ finished: global end lumi for module: label = 'path3' id = 15
-++++++ starting: global end lumi for module: label = 'path4' id = 16
-++++++ finished: global end lumi for module: label = 'path4' id = 16
-++++++ starting: global end lumi for module: label = 'endPath1' id = 17
-++++++ finished: global end lumi for module: label = 'endPath1' id = 17
-++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
@@ -6797,6 +6770,33 @@
 ++++++ finished: global end lumi for module: label = 'path4' id = 29
 ++++++ starting: global end lumi for module: label = 'endPath1' id = 30
 ++++++ finished: global end lumi for module: label = 'endPath1' id = 30
+++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 19
+++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 20
+++++++ finished: global end lumi for module: label = 'testmerge' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 22
+++++++ finished: global end lumi for module: label = 'getInt' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end lumi for module: label = 'out' id = 24
+++++++ finished: global end lumi for module: label = 'out' id = 24
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global end lumi for module: label = 'path1' id = 13
+++++++ finished: global end lumi for module: label = 'path1' id = 13
+++++++ starting: global end lumi for module: label = 'path2' id = 14
+++++++ finished: global end lumi for module: label = 'path2' id = 14
+++++++ starting: global end lumi for module: label = 'path3' id = 15
+++++++ finished: global end lumi for module: label = 'path3' id = 15
+++++++ starting: global end lumi for module: label = 'path4' id = 16
+++++++ finished: global end lumi for module: label = 'path4' id = 16
+++++++ starting: global end lumi for module: label = 'endPath1' id = 17
+++++++ finished: global end lumi for module: label = 'endPath1' id = 17
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -7673,33 +7673,6 @@
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end lumi for module: label = 'test' id = 19
-++++++ finished: global end lumi for module: label = 'test' id = 19
-++++++ starting: global end lumi for module: label = 'testmerge' id = 20
-++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
-++++++ starting: global end lumi for module: label = 'getInt' id = 22
-++++++ finished: global end lumi for module: label = 'getInt' id = 22
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'out' id = 24
-++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global end lumi for module: label = 'path1' id = 13
-++++++ finished: global end lumi for module: label = 'path1' id = 13
-++++++ starting: global end lumi for module: label = 'path2' id = 14
-++++++ finished: global end lumi for module: label = 'path2' id = 14
-++++++ starting: global end lumi for module: label = 'path3' id = 15
-++++++ finished: global end lumi for module: label = 'path3' id = 15
-++++++ starting: global end lumi for module: label = 'path4' id = 16
-++++++ finished: global end lumi for module: label = 'path4' id = 16
-++++++ starting: global end lumi for module: label = 'endPath1' id = 17
-++++++ finished: global end lumi for module: label = 'endPath1' id = 17
-++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
@@ -7727,6 +7700,33 @@
 ++++++ finished: global end lumi for module: label = 'path4' id = 29
 ++++++ starting: global end lumi for module: label = 'endPath1' id = 30
 ++++++ finished: global end lumi for module: label = 'endPath1' id = 30
+++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 19
+++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 20
+++++++ finished: global end lumi for module: label = 'testmerge' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 22
+++++++ finished: global end lumi for module: label = 'getInt' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end lumi for module: label = 'out' id = 24
+++++++ finished: global end lumi for module: label = 'out' id = 24
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global end lumi for module: label = 'path1' id = 13
+++++++ finished: global end lumi for module: label = 'path1' id = 13
+++++++ starting: global end lumi for module: label = 'path2' id = 14
+++++++ finished: global end lumi for module: label = 'path2' id = 14
+++++++ starting: global end lumi for module: label = 'path3' id = 15
+++++++ finished: global end lumi for module: label = 'path3' id = 15
+++++++ starting: global end lumi for module: label = 'path4' id = 16
+++++++ finished: global end lumi for module: label = 'path4' id = 16
+++++++ starting: global end lumi for module: label = 'endPath1' id = 17
+++++++ finished: global end lumi for module: label = 'endPath1' id = 17
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -8279,33 +8279,6 @@
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end lumi for module: label = 'test' id = 19
-++++++ finished: global end lumi for module: label = 'test' id = 19
-++++++ starting: global end lumi for module: label = 'testmerge' id = 20
-++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
-++++++ starting: global end lumi for module: label = 'getInt' id = 22
-++++++ finished: global end lumi for module: label = 'getInt' id = 22
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'out' id = 24
-++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global end lumi for module: label = 'path1' id = 13
-++++++ finished: global end lumi for module: label = 'path1' id = 13
-++++++ starting: global end lumi for module: label = 'path2' id = 14
-++++++ finished: global end lumi for module: label = 'path2' id = 14
-++++++ starting: global end lumi for module: label = 'path3' id = 15
-++++++ finished: global end lumi for module: label = 'path3' id = 15
-++++++ starting: global end lumi for module: label = 'path4' id = 16
-++++++ finished: global end lumi for module: label = 'path4' id = 16
-++++++ starting: global end lumi for module: label = 'endPath1' id = 17
-++++++ finished: global end lumi for module: label = 'endPath1' id = 17
-++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
@@ -8333,6 +8306,33 @@
 ++++++ finished: global end lumi for module: label = 'path4' id = 29
 ++++++ starting: global end lumi for module: label = 'endPath1' id = 30
 ++++++ finished: global end lumi for module: label = 'endPath1' id = 30
+++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 19
+++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 20
+++++++ finished: global end lumi for module: label = 'testmerge' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 22
+++++++ finished: global end lumi for module: label = 'getInt' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++ starting: global end lumi for module: label = 'out' id = 24
+++++++ finished: global end lumi for module: label = 'out' id = 24
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global end lumi for module: label = 'path1' id = 13
+++++++ finished: global end lumi for module: label = 'path1' id = 13
+++++++ starting: global end lumi for module: label = 'path2' id = 14
+++++++ finished: global end lumi for module: label = 'path2' id = 14
+++++++ starting: global end lumi for module: label = 'path3' id = 15
+++++++ finished: global end lumi for module: label = 'path3' id = 15
+++++++ starting: global end lumi for module: label = 'path4' id = 16
+++++++ finished: global end lumi for module: label = 'path4' id = 16
+++++++ starting: global end lumi for module: label = 'endPath1' id = 17
+++++++ finished: global end lumi for module: label = 'endPath1' id = 17
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: end run: stream = 0 run = 3 time = 150000001
 ++++ finished: end run: stream = 0 run = 3 time = 150000001

--- a/FWCore/MessageLogger/interface/ExceptionMessages.h
+++ b/FWCore/MessageLogger/interface/ExceptionMessages.h
@@ -8,7 +8,7 @@ namespace cms {
 namespace edm {
   class JobReport;
 
-  void printCmsException(cms::Exception& e, edm::JobReport * jobRep = 0, int rc = -1);
+  void printCmsException(cms::Exception& e, edm::JobReport * jobRep = nullptr, int rc = -1);
   void printCmsExceptionWarning(char const* behavior, cms::Exception const& e);
 }
 #endif

--- a/FWCore/MessageLogger/interface/MessageSender.h
+++ b/FWCore/MessageLogger/interface/MessageSender.h
@@ -49,7 +49,7 @@ public:
   }
 
   bool valid() {
-    return errorobj_p != 0;
+    return errorobj_p != nullptr;
   }
   
 private:

--- a/FWCore/ParameterSet/interface/ParameterSetDescriptionFiller.h
+++ b/FWCore/ParameterSet/interface/ParameterSetDescriptionFiller.h
@@ -50,8 +50,8 @@ namespace edm {
     }
 
   private:
-    ParameterSetDescriptionFiller(const ParameterSetDescriptionFiller&); // stop default
-    const ParameterSetDescriptionFiller& operator=(const ParameterSetDescriptionFiller&); // stop default
+    ParameterSetDescriptionFiller(const ParameterSetDescriptionFiller&) = delete; // stop default
+    const ParameterSetDescriptionFiller& operator=(const ParameterSetDescriptionFiller&) = delete; // stop default
     
   };
 
@@ -183,8 +183,8 @@ namespace edm {
     }
 
   private:
-    DescriptionFillerForESSources(const DescriptionFillerForESSources&); // stop default
-    const DescriptionFillerForESSources& operator=(const DescriptionFillerForESSources&); // stop default
+    DescriptionFillerForESSources(const DescriptionFillerForESSources&) = delete; // stop default
+    const DescriptionFillerForESSources& operator=(const DescriptionFillerForESSources&) = delete; // stop default
   };
 
   template<typename T>
@@ -216,8 +216,8 @@ namespace edm {
     }
 
   private:
-    DescriptionFillerForESProducers(const DescriptionFillerForESProducers&); // stop default
-    const DescriptionFillerForESProducers& operator=(const DescriptionFillerForESProducers&); // stop default
+    DescriptionFillerForESProducers(const DescriptionFillerForESProducers&) = delete; // stop default
+    const DescriptionFillerForESProducers& operator=(const DescriptionFillerForESProducers&) = delete; // stop default
   };
 }
 #endif

--- a/FWCore/PluginManager/interface/PluginFactory.h
+++ b/FWCore/PluginManager/interface/PluginFactory.h
@@ -53,7 +53,7 @@ class PluginFactory<R*(Args...)> : public PluginFactoryBase
       };
 
       // ---------- const member functions ---------------------
-      virtual const std::string& category() const ;
+      const std::string& category() const override ;
       
       R* create(const std::string& iName, Args... args) const {
         return reinterpret_cast<PMakerBase*>(PluginFactoryBase::findPMaker(iName))->create(std::forward<Args>(args)...);

--- a/FWCore/ServiceRegistry/interface/ServiceRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ServiceRegistry.h
@@ -47,8 +47,8 @@ namespace edm {
 
          //override operator new to stop use on heap?
       private:
-         Operate(Operate const&); //stop default
-         Operate const& operator=(Operate const&); //stop default
+         Operate(Operate const&) = delete; //stop default
+         Operate const& operator=(Operate const&) = delete; //stop default
          ServiceToken oldToken_;
       };
 
@@ -61,7 +61,7 @@ namespace edm {
       // ---------- const member functions ---------------------
       template<typename T>
       T& get() const {
-         if(0 == manager_.get()) {
+         if(nullptr == manager_.get()) {
             Exception::throwThis(errors::NotFound,
               "Service"
               " no ServiceRegistry has been set for this thread");
@@ -71,7 +71,7 @@ namespace edm {
 
       template<typename T>
       bool isAvailable() const {
-         if(0 == manager_.get()) {
+         if(nullptr == manager_.get()) {
             Exception::throwThis(errors::NotFound,
               "Service"
               " no ServiceRegistry has been set for this thread");

--- a/FWCore/ServiceRegistry/interface/ServiceWrapper.h
+++ b/FWCore/ServiceRegistry/interface/ServiceWrapper.h
@@ -50,9 +50,9 @@ public:
          T& get() { return *service_; }
 
 private:
-         ServiceWrapper(const ServiceWrapper&); // stop default
+         ServiceWrapper(const ServiceWrapper&) = delete; // stop default
          
-         const ServiceWrapper& operator=(const ServiceWrapper&); // stop default
+         const ServiceWrapper& operator=(const ServiceWrapper&) = delete; // stop default
          
          // ---------- member data --------------------------------
          edm::propagate_const<std::unique_ptr<T>> service_;

--- a/FWCore/ServiceRegistry/interface/ServicesManager.h
+++ b/FWCore/ServiceRegistry/interface/ServicesManager.h
@@ -76,7 +76,7 @@ public:
             Type2Maker::const_iterator itFoundMaker ;
             if(itFound == type2Service_.end()) {
                //do on demand building of the service
-               if(0 == type2Maker_.get() ||
+               if(nullptr == type2Maker_.get() ||
                    type2Maker_->end() == (itFoundMaker = type2Maker_->find(TypeIDBase(typeid(T))))) {
                       Exception::throwThis(errors::NotFound,
                         "Service Request unable to find requested service with compiler type name '",
@@ -91,7 +91,7 @@ public:
             }
             //convert it to its actual type
             std::shared_ptr<ServiceWrapper<T> > ptr(std::dynamic_pointer_cast<ServiceWrapper<T> >(itFound->second));
-            assert(0 != ptr.get());
+            assert(nullptr != ptr.get());
             return ptr->get();
          }
 
@@ -102,7 +102,7 @@ public:
             Type2Maker::const_iterator itFoundMaker ;
             if(itFound == type2Service_.end()) {
                //do on demand building of the service
-               if(0 == type2Maker_.get() ||
+               if(nullptr == type2Maker_.get() ||
                    type2Maker_->end() == (itFoundMaker = type2Maker_->find(TypeIDBase(typeid(T))))) {
                   return false;
                } else {

--- a/FWCore/Utilities/interface/CPUTimer.h
+++ b/FWCore/Utilities/interface/CPUTimer.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifdef USE_CLOCK_GETTIME
-#include <time.h>
+#include <ctime>
 #else
 #include <sys/time.h>
 #endif

--- a/FWCore/Utilities/interface/UnixSignalHandlers.h
+++ b/FWCore/Utilities/interface/UnixSignalHandlers.h
@@ -8,7 +8,7 @@ and manipulate Unix-style signal handling.
 
 ----------------------------------------------------------------------*/
 
-#include <signal.h>
+#include <csignal>
 #include <atomic>
 
 namespace edm {

--- a/FWCore/Utilities/interface/WallclockTimer.h
+++ b/FWCore/Utilities/interface/WallclockTimer.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifdef USE_CLOCK_GETTIME
-#include <time.h>
+#include <ctime>
 #else
 #include <sys/time.h>
 #endif


### PR DESCRIPTION
The global end LuminosityBlock transition was supposed to be converted to asynchronous at the same time end Run was changed. This corrects that oversight. This also allowed removing many synchronous methods which were replaced with equivalent asynchronous implementations.