### PR TITLE
Hcal validation fix for digi (for Phase2 Barrel) & Chi2 Fix (avoid nan)

### DIFF
--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -788,6 +788,7 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const& ev, edm::EventSetup const& c
       double enM0  = cenM0[i]; 
       double enM3  = cenM3[i]; 
       double chi2  = cchi2[i];
+      if (chi2<0.01) chi2=0.01;
       double t   = ctime[i];
       double depth = cdepth[i];
 

--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -358,7 +358,7 @@ HcalRecHitsAnalyzer::HcalRecHitsAnalyzer(edm::ParameterSet const& conf)
       meTEprofileHB = ibooker.bookProfile(histo, histo, 150, -5., 295., -48., 92., " "); 
 
       sprintf (histo, "HcalRecHitTask_Log10Chi2_vs_energy_profile_HB" ) ;
-      meLog10Chi2profileHB = ibooker.bookProfile(histo, histo, 150, -5., 295., -2., 10., " "); 
+      meLog10Chi2profileHB = ibooker.bookProfile(histo, histo, 150, -5., 295., -2., 9.9, " "); 
 
       sprintf (histo, "HcalRecHitTask_timing_vs_energy_profile_High_HB" ) ;
       meTEprofileHB_High = ibooker.bookProfile(histo, histo, 150, -5., 2995., -48., 92., " "); 
@@ -431,8 +431,7 @@ HcalRecHitsAnalyzer::HcalRecHitsAnalyzer(edm::ParameterSet const& conf)
       meTEprofileHE = ibooker.bookProfile(histo, histo, 200, -5., 395., -48., 92., " "); 
       
       sprintf (histo, "HcalRecHitTask_Log10Chi2_vs_energy_profile_HE" ) ;
-      meLog10Chi2profileHE = ibooker.bookProfile(histo, histo, 200, -5., 395., -2., 10., " "); 
-      
+      meLog10Chi2profileHE = ibooker.bookProfile(histo, histo, 200, -5., 395., -2., 9.9, " ");       
 
     }
 
@@ -788,7 +787,8 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const& ev, edm::EventSetup const& c
       double enM0  = cenM0[i]; 
       double enM3  = cenM3[i]; 
       double chi2  = cchi2[i];
-      if (chi2<0.01) chi2=0.01;
+      double chi2_log10=9.99; // initial value - stay with this value if chi2<0.
+      if (chi2>0.) chi2_log10=log10(chi2);
       double t   = ctime[i];
       double depth = cdepth[i];
 
@@ -820,8 +820,8 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const& ev, edm::EventSetup const& c
         meRecHitsEnergyM3vM0HB->Fill(enM0,enM3);
         meRecHitsEnergyM3vM2HB->Fill(en,enM3);
 
-        meRecHitsM2Chi2HB->Fill(log10(chi2));
-        meLog10Chi2profileHB->Fill(en,log10(chi2));
+        meRecHitsM2Chi2HB->Fill(chi2_log10);
+        meLog10Chi2profileHB->Fill(en,chi2_log10);
 	
 	meTE_Low_HB->Fill( en, t);
 	meTE_HB->Fill( en, t);
@@ -849,8 +849,8 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const& ev, edm::EventSetup const& c
         meRecHitsEnergyM3vM0HE->Fill(enM0,enM3);
         meRecHitsEnergyM3vM2HE->Fill(en,enM3);
 
-        meRecHitsM2Chi2HE->Fill(log10(chi2));
-        meLog10Chi2profileHE->Fill(en,log10(chi2));	
+        meRecHitsM2Chi2HE->Fill(chi2_log10);
+        meLog10Chi2profileHE->Fill(en,chi2_log10);	
 
 	meTE_Low_HE->Fill( en, t);
 	meTE_HE->Fill( en, t);

--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -10,7 +10,7 @@ HcalRecHitsAnalyzer::HcalRecHitsAnalyzer(edm::ParameterSet const& conf)
   // DQM ROOT output
   outputFile_ = conf.getUntrackedParameter<std::string>("outputFile", "myfile.root");
   
-  if ( outputFile_.size() != 0 ) {
+  if ( !outputFile_.empty() ) {
     edm::LogInfo("OutputInfo") << " Hcal RecHit Task histograms will be saved to '" << outputFile_.c_str() << "'";
   } else {
     edm::LogInfo("OutputInfo") << " Hcal RecHit Task histograms will NOT be saved";

--- a/Validation/HcalDigis/src/HcalDigisValidation.cc
+++ b/Validation/HcalDigis/src/HcalDigisValidation.cc
@@ -67,7 +67,7 @@ HcalDigisValidation::HcalDigisValidation(const edm::ParameterSet& iConfig) {
 
     msm_ = new std::map<std::string, MonitorElement*>();
 
-    if (outputFile_.size() != 0) edm::LogInfo("OutputInfo") << " Hcal Digi Task histograms will be saved to '" << outputFile_.c_str() << "'";
+    if (!outputFile_.empty()) edm::LogInfo("OutputInfo") << " Hcal Digi Task histograms will be saved to '" << outputFile_.c_str() << "'";
     else edm::LogInfo("OutputInfo") << " Hcal Digi Task histograms will NOT be saved";
 
 }
@@ -1262,7 +1262,7 @@ void HcalDigisValidation::fillPf(std::string name, double X, double Y) {
 }
 
 MonitorElement* HcalDigisValidation::monitor(std::string name) {
-    if (!msm_->count(name)) return NULL;
+    if (!msm_->count(name)) return nullptr;
     else return msm_->find(name)->second;
 }
 

--- a/Validation/HcalDigis/src/HcalDigisValidation.cc
+++ b/Validation/HcalDigis/src/HcalDigisValidation.cc
@@ -415,7 +415,10 @@ void HcalDigisValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
     if (subdet_ != "all") {
        noise_ = 0;
-       if (subdet_ == "HB") reco<HBHEDataFrame > (iEvent, iSetup, tok_hbhe_);
+       if (subdet_ == "HB"){
+	 reco<HBHEDataFrame > (iEvent, iSetup, tok_hbhe_);
+         reco<QIE11DataFrame>(iEvent, iSetup, tok_qie11_hbhe_);
+       }
        if (subdet_ == "HE"){
 	 reco<HBHEDataFrame > (iEvent, iSetup, tok_hbhe_);
          reco<QIE11DataFrame>(iEvent, iSetup, tok_qie11_hbhe_);
@@ -430,6 +433,7 @@ void HcalDigisValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             noise_ = 1;
     	    subdet_ = "HB";
             reco<HBHEDataFrame > (iEvent, iSetup, tok_hbhe_);
+            reco<QIE11DataFrame>(iEvent, iSetup, tok_qie11_hbhe_);
             subdet_ = "HE";
             reco<HBHEDataFrame > (iEvent, iSetup, tok_hbhe_);
             reco<QIE11DataFrame>(iEvent, iSetup, tok_qie11_hbhe_);
@@ -446,6 +450,7 @@ void HcalDigisValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
         subdet_ = "HB";
         reco<HBHEDataFrame > (iEvent, iSetup, tok_hbhe_);
+        reco<QIE11DataFrame>(iEvent, iSetup, tok_qie11_hbhe_);
         subdet_ = "HE";
         reco<HBHEDataFrame > (iEvent, iSetup, tok_hbhe_);
         reco<QIE11DataFrame>(iEvent, iSetup, tok_qie11_hbhe_);


### PR DESCRIPTION
+ QIE11 digi validation was added to only to HE and not to HB yet, given that HB phase1 is still not there yet, but this is not good for phase2 barrel validation
+ Method2 chi2 plots were showing nan due to log10 of negative chi2 (when fit fails). Added a protection.