### PR TITLE
G4 sensitive detectors cleanup 4

### DIFF
--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -22,9 +22,6 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-// To be replaced by something else 
-/* #include "Utilities/Notification/interface/TimerProxy.h" */
- 
 #include "G4VPhysicalVolume.hh"
 #include "G4Track.hh"
 #include "G4VGFlashSensitiveDetector.hh"
@@ -52,12 +49,11 @@ public:
   CaloSD(const std::string& aSDname, const DDCompactView & cpv,
          const SensitiveDetectorCatalog & clg,
          edm::ParameterSet const & p, const SimTrackManager*,
-	 float timeSlice=1., bool ignoreTkID=false);
+	 float timeSlice=1.f, bool ignoreTkID=false);
   ~CaloSD() override;
   bool     ProcessHits(G4Step * step, G4TouchableHistory * tHistory) override;
   bool     ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) override;
   virtual double   getEnergyDeposit(G4Step* step); 
-  //uint32_t setDetUnitId(G4Step* step) override =0;
   
   void     Initialize(G4HCofThisEvent * HCE) override;
   void     EndOfEvent(G4HCofThisEvent * eventHC) override;
@@ -65,7 +61,7 @@ public:
   void     DrawAll() override;
   void     PrintAll() override;
 
-  void     fillHits(edm::PCaloHitContainer&, std::string&) override ;
+  void     fillHits(edm::PCaloHitContainer&, const std::string&) override ;
 
 protected:
 
@@ -89,9 +85,9 @@ protected:
   virtual void     initRun();
   virtual bool     filterHit(CaloG4Hit*, double);
 
-  virtual int      getTrackID(G4Track*);
-  virtual uint16_t getDepth(G4Step*);   
-  double           getResponseWt(G4Track*);
+  virtual int      getTrackID(const G4Track*);
+  virtual uint16_t getDepth(const G4Step*);   
+  double           getResponseWt(const G4Track*);
   int              getNumberOfHits();
 
 private:
@@ -126,7 +122,6 @@ protected:
 
   const SimTrackManager*          m_trackManager;
   CaloG4Hit*                      currentHit;
-  //  TimerProxy                    theHitTimer;
   bool                            runInit;
 
   bool                            corrTOFBeam, suppressHeavy;

--- a/SimG4CMS/Calo/interface/CaloTrkProcessing.h
+++ b/SimG4CMS/Calo/interface/CaloTrkProcessing.h
@@ -25,25 +25,24 @@ class CaloTrkProcessing : public SensitiveCaloDetector,
 
 public:
 
-  CaloTrkProcessing(G4String aSDname, const DDCompactView & cpv,
+  CaloTrkProcessing(const std::string& aSDname, const DDCompactView & cpv,
 		    const SensitiveDetectorCatalog & clg,
 		    edm::ParameterSet const & p, const SimTrackManager*);
-  virtual ~CaloTrkProcessing();
-  virtual void             Initialize(G4HCofThisEvent * ) {}
-  virtual void             clearHits() {}
-  virtual bool             ProcessHits(G4Step * , G4TouchableHistory * ) {
+  ~CaloTrkProcessing() override;
+  void             Initialize(G4HCofThisEvent * ) override {}
+  void             clearHits() override {}
+  bool             ProcessHits(G4Step * , G4TouchableHistory * ) override {
     return true;
   }
-  virtual uint32_t         setDetUnitId(G4Step * step) {return 0;}
-  virtual void             EndOfEvent(G4HCofThisEvent * ) {}
-  void                     fillHits(edm::PCaloHitContainer&, std::string ) {}
+  uint32_t         setDetUnitId(const G4Step * step) override {return 0;}
+  void             EndOfEvent(G4HCofThisEvent * ) override {}
 
 private:
 
-  void                     update(const BeginOfEvent * evt);
-  void                     update(const G4Step *);
-  std::vector<std::string> getNames(G4String, const DDsvalues_type&);
-  std::vector<double>      getNumbers(G4String, const DDsvalues_type&);
+  void                     update(const BeginOfEvent * evt) override;
+  void                     update(const G4Step *) override;
+  std::vector<std::string> getNames(const G4String&, const DDsvalues_type&);
+  std::vector<double>      getNumbers(const G4String&, const DDsvalues_type&);
   int                      isItCalo(const G4VTouchable*);
   int                      isItInside(const G4VTouchable*, int, int);
 

--- a/SimG4CMS/Calo/interface/ECalSD.h
+++ b/SimG4CMS/Calo/interface/ECalSD.h
@@ -34,13 +34,13 @@ public:
   ECalSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	 edm::ParameterSet const & p, const SimTrackManager*);
   ~ECalSD() override;
-  double                    getEnergyDeposit(G4Step*) override;
-  virtual uint16_t                  getRadiationLength(G4Step *);
-  virtual uint16_t                  getLayerIDForTimeSim(G4Step *);
-  uint32_t                  setDetUnitId(G4Step*) override ;
+  double                            getEnergyDeposit(G4Step*) override;
+  virtual uint16_t                  getRadiationLength(const G4Step *);
+  virtual uint16_t                  getLayerIDForTimeSim(const G4Step *);
+  uint32_t                          setDetUnitId(const G4Step*) override;
   void                              setNumberingScheme(EcalNumberingScheme*);
-  int                       getTrackID(G4Track*) override;
-  uint16_t                  getDepth(G4Step*) override;
+  int                               getTrackID(const G4Track*) override;
+  uint16_t                          getDepth(const G4Step*) override;
 
 private:    
   void                              initMap(const G4String&, const DDCompactView &);

--- a/SimG4CMS/Calo/interface/HCalSD.h
+++ b/SimG4CMS/Calo/interface/HCalSD.h
@@ -42,8 +42,8 @@ public:
   ~HCalSD() override;
   bool                  ProcessHits(G4Step * , G4TouchableHistory * ) override;
   double                getEnergyDeposit(G4Step* ) override;
-  uint32_t              setDetUnitId(G4Step* step) override ;
-  void                          setNumberingScheme(HcalNumberingScheme* );
+  uint32_t              setDetUnitId(const G4Step* step) override ;
+  void                  setNumberingScheme(HcalNumberingScheme* );
 
 protected:
 

--- a/SimG4CMS/Calo/interface/HGCSD.h
+++ b/SimG4CMS/Calo/interface/HGCSD.h
@@ -27,25 +27,25 @@ class HGCSD : public CaloSD, public Observer<const BeginOfJob *> {
 
 public:    
 
-  HGCSD(G4String , const DDCompactView &, const SensitiveDetectorCatalog &,
+  HGCSD(const std::string& , const DDCompactView &, const SensitiveDetectorCatalog &,
 	edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~HGCSD();
-  virtual bool                    ProcessHits(G4Step * , G4TouchableHistory * );
-  virtual double                  getEnergyDeposit(G4Step* );
-  virtual uint32_t                setDetUnitId(G4Step* step);
+  ~HGCSD() override;
+  bool                    ProcessHits(G4Step * , G4TouchableHistory * ) override;
+  double                  getEnergyDeposit(G4Step* ) override;
+  uint32_t                setDetUnitId(const G4Step* step) override;
 
 protected:
 
-  virtual void                    update(const BeginOfJob *);
-  virtual void                    initRun();
-  virtual bool                    filterHit(CaloG4Hit*, double);
+  void                    update(const BeginOfJob *) override;
+  void                    initRun() override;
+  bool                    filterHit(CaloG4Hit*, double) override;
 
 private:    
 
   uint32_t                        setDetUnitId(ForwardSubdetector&, int, int, 
 					       int, int, G4ThreeVector &);
   bool                            isItinFidVolume (G4ThreeVector&) {return true;}
-  int                             setTrackID(G4Step * step);
+  int                             setTrackID(const G4Step * step);
 
   std::string                     nameX;
 

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -236,7 +236,7 @@ void CaloSD::PrintAll() {
   theHC->PrintAllHits();
 } 
 
-void CaloSD::fillHits(edm::PCaloHitContainer& cont, std::string& hitname) {
+void CaloSD::fillHits(edm::PCaloHitContainer& cont, const std::string& hitname) {
   if (slave->name() == hitname) { cont = slave->hits(); }
   slave->Clean();
 }
@@ -560,7 +560,7 @@ void CaloSD::clearHits() {
 
 void CaloSD::initRun() {}
 
-int CaloSD::getTrackID(G4Track* aTrack) {
+int CaloSD::getTrackID(const G4Track* aTrack) {
   int primaryID = 0;
   forceSave = false;
   TrackInformation* trkInfo=(TrackInformation *)(aTrack->GetUserInformation());
@@ -581,7 +581,7 @@ int CaloSD::getTrackID(G4Track* aTrack) {
   return primaryID;
 }
 
-uint16_t CaloSD::getDepth(G4Step*) { return 0; }
+uint16_t CaloSD::getDepth(const G4Step*) { return 0; }
 
 bool CaloSD::filterHit(CaloG4Hit* hit, double time) {
   double emin(eminHit);
@@ -593,7 +593,7 @@ bool CaloSD::filterHit(CaloG4Hit* hit, double time) {
   return ((time <= tmaxHit) && (hit->getEnergyDeposit() > emin));
 }
 
-double CaloSD::getResponseWt(G4Track* aTrack) {
+double CaloSD::getResponseWt(const G4Track* aTrack) {
   if (meanResponse) {
     TrackInformation * trkInfo = (TrackInformation *)(aTrack->GetUserInformation());
     return meanResponse->getWeight(trkInfo->genParticlePID(), trkInfo->genParticleP());

--- a/SimG4CMS/Calo/src/CaloTrkProcessing.cc
+++ b/SimG4CMS/Calo/src/CaloTrkProcessing.cc
@@ -23,7 +23,7 @@
 
 //#define DebugLog
 
-CaloTrkProcessing::CaloTrkProcessing(G4String name, 
+CaloTrkProcessing::CaloTrkProcessing(const std::string& name, 
 				     const DDCompactView & cpv,
 				     const SensitiveDetectorCatalog & clg,
 				     edm::ParameterSet const & p,
@@ -100,7 +100,7 @@ CaloTrkProcessing::CaloTrkProcessing(G4String name,
   std::vector<G4LogicalVolume *>::const_iterator lvcite;
   int istart = 0;
   for (unsigned int i=0; i<caloNames.size(); i++) {
-    G4LogicalVolume* lv     = 0;
+    G4LogicalVolume* lv     = nullptr;
     G4String         name   = caloNames[i];
     int              number = static_cast<int>(neighbours[i]);
     for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++) {
@@ -109,7 +109,7 @@ CaloTrkProcessing::CaloTrkProcessing(G4String name,
 	break;
       }
     }
-    if (lv != 0) {
+    if (lv != nullptr) {
      CaloTrkProcessing::Detector detector;
      detector.name  = name;
      detector.lv    = lv;
@@ -125,7 +125,7 @@ CaloTrkProcessing::CaloTrkProcessing(G4String name,
      std::vector<G4LogicalVolume*> insideLV;
      std::vector<int>              insideLevels;
      for (int k = 0; k < number; k++) {
-       lv   = 0;
+       lv   = nullptr;
        name = insideNames[istart+k];
        for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++) 
 	 if ((*lvcite)->GetName() == name) {
@@ -178,7 +178,7 @@ void CaloTrkProcessing::update(const G4Step * aStep) {
   TrackInformation* trkInfo = dynamic_cast<TrackInformation*>
     (theTrack->GetUserInformation());
   
-  if (trkInfo == 0) {
+  if (trkInfo == nullptr) {
     edm::LogError("CaloSim") << "CaloTrkProcessing: No trk info !!!! abort ";
     throw cms::Exception("Unknown", "CaloTrkProcessing")
       << "cannot get trkInfo for Track " << id << "\n";
@@ -248,7 +248,7 @@ void CaloTrkProcessing::update(const G4Step * aStep) {
   }
 }
 
-std::vector<std::string> CaloTrkProcessing::getNames(const G4String str,
+std::vector<std::string> CaloTrkProcessing::getNames(const G4String& str,
 						     const DDsvalues_type &sv){
 
 #ifdef DebugLog
@@ -277,7 +277,7 @@ std::vector<std::string> CaloTrkProcessing::getNames(const G4String str,
   }
 }
 
-std::vector<double> CaloTrkProcessing::getNumbers(const G4String str,
+std::vector<double> CaloTrkProcessing::getNumbers(const G4String& str,
 						  const DDsvalues_type &sv) {
 
 #ifdef DebugLog
@@ -308,7 +308,7 @@ std::vector<double> CaloTrkProcessing::getNumbers(const G4String str,
 int CaloTrkProcessing::isItCalo(const G4VTouchable* touch) {
 
   int lastLevel = -1;
-  G4LogicalVolume* lv=0;
+  G4LogicalVolume* lv=nullptr;
   for (unsigned int it=0; it < detectors.size(); it++) {
     if (lastLevel != detectors[it].level) {
       lastLevel = detectors[it].level;
@@ -337,7 +337,7 @@ int CaloTrkProcessing::isItCalo(const G4VTouchable* touch) {
 int CaloTrkProcessing::isItInside(const G4VTouchable* touch, int idcal,
 				  int idin) {
   int lastLevel = -1;
-  G4LogicalVolume* lv=0;
+  G4LogicalVolume* lv=nullptr;
   int id1, id2;
   if (idcal < 0) {id1 = 0; id2 = static_cast<int>(detectors.size());}
   else           {id1 = idcal; id2 = id1+1;}
@@ -401,7 +401,7 @@ int CaloTrkProcessing::detLevels(const G4VTouchable* touch) const {
 G4LogicalVolume* CaloTrkProcessing::detLV(const G4VTouchable* touch,
 					  int currentlevel) const {
 
-  G4LogicalVolume* lv=0;
+  G4LogicalVolume* lv=nullptr;
   if (touch) {
     int level = ((touch->GetHistoryDepth())+1);
     if (level > 0 && level >= currentlevel) {
@@ -422,7 +422,7 @@ void CaloTrkProcessing::detectorLevel(const G4VTouchable* touch, int& level,
     for (int ii = 0; ii < level; ii++) {
       int i      = level - ii - 1;
       G4VPhysicalVolume* pv = touch->GetVolume(i);
-      if (pv != 0) 
+      if (pv != nullptr) 
 	name[ii] = pv->GetName();
       else
 	name[ii] = unknown;

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -241,7 +241,7 @@ double ECalSD::getEnergyDeposit(G4Step * aStep) {
   return edep;
 }
 
-int ECalSD::getTrackID(G4Track* aTrack) {
+int ECalSD::getTrackID(const G4Track* aTrack) {
 
   int  primaryID(0);
   bool flag(false);
@@ -261,7 +261,7 @@ int ECalSD::getTrackID(G4Track* aTrack) {
   return primaryID;
 }
 
-uint16_t ECalSD::getDepth(G4Step * aStep) {
+uint16_t ECalSD::getDepth(const G4Step * aStep) {
 
   uint16_t depth  = any(useDepth1,theLogicalVolume) ? 1 : (any(useDepth2,theLogicalVolume) ? 2 : 0);
   if (storeRL) {
@@ -282,7 +282,7 @@ uint16_t ECalSD::getDepth(G4Step * aStep) {
   return depth;
 }
 
-uint16_t ECalSD::getRadiationLength(G4Step * aStep) {
+uint16_t ECalSD::getRadiationLength(const G4Step * aStep) {
   
   uint16_t thisX0 = 0;
 #ifdef EDM_ML_DEBUG
@@ -317,7 +317,7 @@ uint16_t ECalSD::getRadiationLength(G4Step * aStep) {
   return thisX0;
 }
 
-uint16_t ECalSD::getLayerIDForTimeSim(G4Step * aStep) 
+uint16_t ECalSD::getLayerIDForTimeSim(const G4Step * aStep) 
 {
   const float layerSize = (float)(1*cm); //layer size in cm
   if (!isEB && !isEE)  return 0;
@@ -327,7 +327,7 @@ uint16_t ECalSD::getLayerIDForTimeSim(G4Step * aStep)
   return (int)detz/layerSize;
 }
 
-uint32_t ECalSD::setDetUnitId(G4Step * aStep) { 
+uint32_t ECalSD::setDetUnitId(const G4Step * aStep) { 
   if (numberingScheme == nullptr) {
     return EBDetId(1,1)();
   } else {

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -540,7 +540,7 @@ double HCalSD::getEnergyDeposit(G4Step* aStep) {
   return destep;
 }
 
-uint32_t HCalSD::setDetUnitId(G4Step * aStep) { 
+uint32_t HCalSD::setDetUnitId(const G4Step * aStep) { 
 
   G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();

--- a/SimG4CMS/Calo/src/HGCSD.cc
+++ b/SimG4CMS/Calo/src/HGCSD.cc
@@ -33,13 +33,13 @@
 
 //#define EDM_ML_DEBUG
 
-HGCSD::HGCSD(G4String name, const DDCompactView & cpv,
+HGCSD::HGCSD(const std::string& name, const DDCompactView & cpv,
 	     const SensitiveDetectorCatalog & clg, 
 	     edm::ParameterSet const & p, const SimTrackManager* manager) : 
   CaloSD(name, cpv, clg, p, manager,
          (float)(p.getParameter<edm::ParameterSet>("HGCSD").getParameter<double>("TimeSliceUnit")),
          p.getParameter<edm::ParameterSet>("HGCSD").getParameter<bool>("IgnoreTrackID")), 
-  numberingScheme(0), mouseBite_(0), slopeMin_(0), levelT_(99) {
+  numberingScheme(nullptr), mouseBite_(nullptr), slopeMin_(0), levelT_(99) {
 
   edm::ParameterSet m_HGC = p.getParameter<edm::ParameterSet>("HGCSD");
   eminHit          = m_HGC.getParameter<double>("EminHit")*CLHEP::MeV;
@@ -95,7 +95,7 @@ bool HGCSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 
   NaNTrap( aStep ) ;
   
-  if (aStep == NULL) {
+  if (aStep == nullptr) {
     return true;
   } else {
     double r = aStep->GetPreStepPoint()->GetPosition().perp();
@@ -131,7 +131,7 @@ double HGCSD::getEnergyDeposit(G4Step* aStep) {
   return destep;
 }
 
-uint32_t HGCSD::setDetUnitId(G4Step * aStep) { 
+uint32_t HGCSD::setDetUnitId(const G4Step * aStep) { 
 
   G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();
@@ -243,7 +243,7 @@ uint32_t HGCSD::setDetUnitId (ForwardSubdetector &subdet, int layer, int module,
   return id;
 }
 
-int HGCSD::setTrackID (G4Step* aStep) {
+int HGCSD::setTrackID (const G4Step* aStep) {
   theTrack     = aStep->GetTrack();
 
   double etrack = preStepPoint->GetKineticEnergy();

--- a/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
+++ b/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
@@ -20,29 +20,29 @@ class DreamSD : public CaloSD {
 
 public:    
 
-  DreamSD(G4String, const DDCompactView &, const SensitiveDetectorCatalog &,
+  DreamSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	  edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~DreamSD() {}
-  virtual bool   ProcessHits(G4Step * step,G4TouchableHistory * tHistory);
-  virtual uint32_t setDetUnitId(G4Step*);
+  ~DreamSD() override {}
+  bool   ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
+  uint32_t setDetUnitId(const G4Step*) override;
 
 protected:
 
-  virtual G4bool getStepInfo(G4Step* aStep);
-  virtual void   initRun();
+  G4bool getStepInfo(G4Step* aStep) override;
+  void   initRun() override;
 
 private:    
 
   typedef std::pair<double,double> Doubles;
   typedef std::map<G4LogicalVolume*,Doubles> DimensionMap;
 
-  void           initMap(G4String, const DDCompactView &);
-  double         curve_LY(G4Step*, int); 
+  void           initMap(const G4String&, const DDCompactView &);
+  double         curve_LY(const G4Step*, int); 
   const double   crystalLength(G4LogicalVolume*) const;
   const double   crystalWidth(G4LogicalVolume*) const;
 
   /// Returns the total energy due to Cherenkov radiation
-  double         cherenkovDeposit_( G4Step* aStep );
+  double         cherenkovDeposit_(const G4Step* aStep );
   /// Returns average number of photons created by track
   double getAverageNumberOfPhotons_(const double charge,
 				    const double beta,

--- a/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
+++ b/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
@@ -26,7 +26,7 @@
 #include "G4PhysicalConstants.hh"
 
 //________________________________________________________________________________________
-DreamSD::DreamSD(G4String name, const DDCompactView & cpv,
+DreamSD::DreamSD(const std::string& name, const DDCompactView & cpv,
 	       const SensitiveDetectorCatalog & clg,
 	       edm::ParameterSet const & p, const SimTrackManager* manager) : 
   CaloSD(name, cpv, clg, p, manager) {
@@ -76,7 +76,7 @@ DreamSD::DreamSD(G4String name, const DDCompactView & cpv,
 //________________________________________________________________________________________
 bool DreamSD::ProcessHits(G4Step * aStep, G4TouchableHistory *) {
 
-  if (aStep == NULL) {
+  if (aStep == nullptr) {
     return true;
   } else {
     side = 1;
@@ -182,7 +182,7 @@ void DreamSD::initRun() {
 
 
 //________________________________________________________________________________________
-uint32_t DreamSD::setDetUnitId(G4Step * aStep) { 
+uint32_t DreamSD::setDetUnitId(const G4Step * aStep) { 
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   uint32_t id = (touch->GetReplicaNumber(1))*10 + (touch->GetReplicaNumber(0));
   LogDebug("EcalSim") << "DreamSD:: ID " << id;
@@ -191,7 +191,7 @@ uint32_t DreamSD::setDetUnitId(G4Step * aStep) {
 
 
 //________________________________________________________________________________________
-void DreamSD::initMap(G4String sd, const DDCompactView & cpv) {
+void DreamSD::initMap(const G4String& sd, const DDCompactView & cpv) {
 
   G4String attribute = "ReadOutName";
   DDSpecificsMatchesValueFilter filter{DDValue(attribute,sd,0)};
@@ -205,7 +205,7 @@ void DreamSD::initMap(G4String sd, const DDCompactView & cpv) {
     const DDSolid & sol  = fv.logicalPart().solid();
     std::vector<double> paras(sol.parameters());
     G4String name = sol.name().name();
-    G4LogicalVolume* lv=0;
+    G4LogicalVolume* lv=nullptr;
     for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++) 
       if ((*lvcite)->GetName() == name) {
 	lv = (*lvcite);
@@ -228,7 +228,7 @@ void DreamSD::initMap(G4String sd, const DDCompactView & cpv) {
   int i=0;
   for (; ite != xtalLMap.end(); ite++, i++) {
     G4String name = "Unknown";
-    if (ite->first != 0) name = (ite->first)->GetName();
+    if (ite->first != nullptr) name = (ite->first)->GetName();
     LogDebug("EcalSim") << " " << i << " " << ite->first << " " << name 
 			<< " L = " << ite->second.first
                         << " W = " << ite->second.second;
@@ -236,7 +236,7 @@ void DreamSD::initMap(G4String sd, const DDCompactView & cpv) {
 }
 
 //________________________________________________________________________________________
-double DreamSD::curve_LY(G4Step* aStep, int flag) {
+double DreamSD::curve_LY(const G4Step* aStep, int flag) {
 
   G4StepPoint*     stepPoint = aStep->GetPreStepPoint();
   G4LogicalVolume* lv        = stepPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
@@ -290,7 +290,7 @@ const double DreamSD::crystalWidth(G4LogicalVolume* lv) const {
 //________________________________________________________________________________________
 // Calculate total cherenkov deposit
 // Inspired by Geant4's Cherenkov implementation
-double DreamSD::cherenkovDeposit_( G4Step* aStep ) {
+double DreamSD::cherenkovDeposit_(const G4Step* aStep ) {
 
   double cherenkovEnergy = 0;
   if (!materialPropertiesTable) return cherenkovEnergy;
@@ -298,7 +298,7 @@ double DreamSD::cherenkovDeposit_( G4Step* aStep ) {
 
   // Retrieve refractive index
   G4MaterialPropertyVector* Rindex = materialPropertiesTable->GetProperty("RINDEX"); 
-  if ( Rindex == NULL ) {
+  if ( Rindex == nullptr ) {
     edm::LogWarning("EcalSim") << "Couldn't retrieve refractive index";
     return cherenkovEnergy;
   }
@@ -315,7 +315,7 @@ double DreamSD::cherenkovDeposit_( G4Step* aStep ) {
   // Get particle properties
   G4StepPoint* pPreStepPoint  = aStep->GetPreStepPoint();
   G4StepPoint* pPostStepPoint = aStep->GetPostStepPoint();
-  G4ThreeVector x0 = pPreStepPoint->GetPosition();
+  const G4ThreeVector& x0 = pPreStepPoint->GetPosition();
   G4ThreeVector p0 = aStep->GetDeltaPosition().unit();
   const G4DynamicParticle* aParticle = aStep->GetTrack()->GetDynamicParticle();
   const double charge = aParticle->GetDefinition()->GetPDGCharge();

--- a/SimG4CMS/EcalTestBeam/interface/EcalTBH4BeamSD.h
+++ b/SimG4CMS/EcalTestBeam/interface/EcalTBH4BeamSD.h
@@ -21,11 +21,11 @@ class EcalTBH4BeamSD : public CaloSD {
 
 public:    
 
-  EcalTBH4BeamSD(G4String, const DDCompactView &, const SensitiveDetectorCatalog &,
+  EcalTBH4BeamSD(const G4String&, const DDCompactView &, const SensitiveDetectorCatalog &,
 		 edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~EcalTBH4BeamSD();
-  virtual double getEnergyDeposit(G4Step*);
-  virtual uint32_t setDetUnitId(G4Step* step);
+  ~EcalTBH4BeamSD() override;
+  double getEnergyDeposit(G4Step*) override;
+  uint32_t setDetUnitId(const G4Step* step) override;
   void setNumberingScheme(EcalNumberingScheme* scheme);
 
 private:    

--- a/SimG4CMS/EcalTestBeam/src/EcalTBH4BeamSD.cc
+++ b/SimG4CMS/EcalTestBeam/src/EcalTBH4BeamSD.cc
@@ -19,11 +19,11 @@
 
 #include "G4SystemOfUnits.hh"
 
-EcalTBH4BeamSD::EcalTBH4BeamSD(G4String name, const DDCompactView & cpv,
+EcalTBH4BeamSD::EcalTBH4BeamSD(const G4String& name, const DDCompactView & cpv,
 			       const SensitiveDetectorCatalog & clg,
 			       edm::ParameterSet const & p, 
 			       const SimTrackManager* manager) : 
-  CaloSD(name, cpv, clg, p, manager), numberingScheme(0) {
+  CaloSD(name, cpv, clg, p, manager), numberingScheme(nullptr) {
   
   edm::ParameterSet m_EcalTBH4BeamSD = p.getParameter<edm::ParameterSet>("EcalTBH4BeamSD");
   useBirk= m_EcalTBH4BeamSD.getParameter<bool>("UseBirkLaw");
@@ -31,7 +31,7 @@ EcalTBH4BeamSD::EcalTBH4BeamSD(G4String name, const DDCompactView & cpv,
   birk2  = m_EcalTBH4BeamSD.getParameter<double>("BirkC2");
   birk3  = m_EcalTBH4BeamSD.getParameter<double>("BirkC3");
 
-  EcalNumberingScheme* scheme=0;
+  EcalNumberingScheme* scheme=nullptr;
   if     (name == "EcalTBH4BeamHits") { 
     scheme = dynamic_cast<EcalNumberingScheme*>(new EcalHodoscopeNumberingScheme());
   } 
@@ -52,7 +52,7 @@ EcalTBH4BeamSD::~EcalTBH4BeamSD() {
 
 double EcalTBH4BeamSD::getEnergyDeposit(G4Step * aStep) {
   
-  if (aStep == NULL) {
+  if (aStep == nullptr) {
     return 0;
   } else {
     preStepPoint        = aStep->GetPreStepPoint();
@@ -69,13 +69,13 @@ double EcalTBH4BeamSD::getEnergyDeposit(G4Step * aStep) {
   } 
 }
 
-uint32_t EcalTBH4BeamSD::setDetUnitId(G4Step * aStep) { 
+uint32_t EcalTBH4BeamSD::setDetUnitId(const G4Step * aStep) { 
   getBaseNumber(aStep);
-  return (numberingScheme == 0 ? 0 : numberingScheme->getUnitID(theBaseNumber));
+  return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(theBaseNumber));
 }
 
 void EcalTBH4BeamSD::setNumberingScheme(EcalNumberingScheme* scheme) {
-  if (scheme != 0) {
+  if (scheme != nullptr) {
     edm::LogInfo("EcalTBSim") << "EcalTBH4BeamSD: updates numbering scheme for " 
 			    << GetName() << "\n";
     if (numberingScheme) delete numberingScheme;

--- a/SimG4CMS/FP420/interface/FP420SD.h
+++ b/SimG4CMS/FP420/interface/FP420SD.h
@@ -12,13 +12,8 @@
 
 #include "SimG4Core/Notification/interface/BeginOfTrack.h"
 #include "SimG4Core/Notification/interface/BeginOfJob.h"
-// last
-//#include "SimG4Core/Application/interface/SimTrackManager.h"
-//#include "SimG4CMS/Calo/interface/CaloSD.h"
 
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
-//#include "SimG4Core/Notification/interface/TrackWithHistory.h"
-//#include "SimG4Core/Notification/interface/TrackContainer.h"
 
 #include "SimG4CMS/FP420/interface/FP420G4Hit.h"
 #include "SimG4CMS/FP420/interface/FP420G4HitCollection.h"
@@ -30,14 +25,8 @@
 #include "G4Track.hh"
 #include "G4VPhysicalVolume.hh"
 
-//#include <iostream>
-//#include <fstream>
-//#include <vector>
-//#include <map>
 #include <string>
  
-
-
 class TrackingSlaveSD;
 //AZ:
 class FP420SD;
@@ -59,7 +48,7 @@ class FP420SD : public SensitiveTkDetector,
 
 public:
   
-  FP420SD(std::string, const DDCompactView &, const SensitiveDetectorCatalog &,
+  FP420SD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
   	  edm::ParameterSet const &, const SimTrackManager* );
 
 //-------------------------------------------------------------------
@@ -74,29 +63,27 @@ public:
 
 
 
-  virtual ~FP420SD();
+  ~FP420SD() override;
   
-  virtual bool ProcessHits(G4Step *,G4TouchableHistory *);
-  virtual uint32_t  setDetUnitId(G4Step*);
+  bool ProcessHits(G4Step *,G4TouchableHistory *) override;
+  uint32_t  setDetUnitId(const G4Step*) override;
 
-  virtual void Initialize(G4HCofThisEvent * HCE);
-  virtual void EndOfEvent(G4HCofThisEvent * eventHC);
-  virtual void clear();
-  virtual void DrawAll();
-  virtual void PrintAll();
+  void Initialize(G4HCofThisEvent * HCE) override;
+  void EndOfEvent(G4HCofThisEvent * eventHC) override;
+  void clear() override;
+  void DrawAll() override;
+  void PrintAll() override;
 
   virtual double getEnergyDeposit(G4Step* step);
   //protected:
   //    Collection       hits_;
-    void fillHits(edm::PSimHitContainer&, std::string use);
-  
-  std::vector<std::string> getNames();
-  
+  void fillHits(edm::PSimHitContainer&, const std::string& use) override;
+    
  private:
-  void           update(const BeginOfRun *);
-  void           update(const BeginOfEvent *);
-  void           update(const ::EndOfEvent *);
-  virtual void   clearHits();
+  void           update(const BeginOfRun *) override;
+  void           update(const BeginOfEvent *) override;
+  void           update(const ::EndOfEvent *) override;
+  void   clearHits() override;
   
   //void SetNumberingScheme(FP420NumberingScheme* scheme);
   

--- a/SimG4CMS/FP420/plugins/FP420SD.cc
+++ b/SimG4CMS/FP420/plugins/FP420SD.cc
@@ -5,9 +5,6 @@
 // Modifications: 
 ///////////////////////////////////////////////////////////////////////////////
  
-//#include "Geometry/Vector/interface/LocalPoint.h"
-//#include "Geometry/Vector/interface/LocalVector.h"
-
 #include "SimG4Core/SensitiveDetector/interface/FrameRotation.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 #include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
@@ -54,13 +51,13 @@ using std::string;
 
 //#define debug
 //-------------------------------------------------------------------
-FP420SD::FP420SD(std::string name, const DDCompactView & cpv,
+FP420SD::FP420SD(const std::string& name, const DDCompactView & cpv,
 		 const SensitiveDetectorCatalog & clg,
 		 edm::ParameterSet const & p, const SimTrackManager* manager) :
-  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(0), name(name),
-  hcID(-1), theHC(0), theManager(manager), currentHit(0), theTrack(0), 
-  currentPV(0), unitID(0),  previousUnitID(0), preStepPoint(0), 
-  postStepPoint(0), eventno(0){
+  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(nullptr), name(name),
+  hcID(-1), theHC(nullptr), theManager(manager), currentHit(nullptr), theTrack(nullptr), 
+  currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
+  postStepPoint(nullptr), eventno(0){
 //-------------------------------------------------------------------
 /*
 FP420SD::FP420SD(G4String name, const DDCompactView & cpv,
@@ -121,9 +118,6 @@ FP420SD::FP420SD(G4String name, const DDCompactView & cpv,
     std::cout << "FP420SD: Instantiation completed"<< std::endl;
   }
 
-
-
-
 FP420SD::~FP420SD() { 
   //AZ:
   if (slave) delete slave; 
@@ -157,7 +151,7 @@ void FP420SD::Initialize(G4HCofThisEvent * HCE) {
 
 bool FP420SD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 
-  if (aStep == NULL) {
+  if (aStep == nullptr) {
     return true;
   } else {
     GetStepInfo(aStep);
@@ -223,9 +217,9 @@ void FP420SD::GetStepInfo(G4Step* aStep) {
   Z  = hitPoint.z();
 }
 
-uint32_t FP420SD::setDetUnitId(G4Step * aStep) { 
+uint32_t FP420SD::setDetUnitId(const G4Step * aStep) { 
 
-  return (numberingScheme == 0 ? 0 : numberingScheme->getUnitID(aStep));
+  return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(aStep));
 }
 
 
@@ -287,7 +281,7 @@ void FP420SD::ResetForNewPrimary() {
 void FP420SD::StoreHit(FP420G4Hit* hit){
 
   //  if (primID<0) return;
-  if (hit == 0 ) {
+  if (hit == nullptr ) {
     edm::LogWarning("FP420Sim") << "FP420SD: hit to be stored is NULL !!";
     return;
   }
@@ -506,10 +500,9 @@ void FP420SD::PrintAll() {
 //
 //}
 
-void FP420SD::fillHits(edm::PSimHitContainer& c, std::string n) {
+void FP420SD::fillHits(edm::PSimHitContainer& c, const std::string& n) {
   if (slave->name() == n) {
     c=slave->hits();
-    std::cout << "FP420SD: fillHits to PSimHitContainer for name= " <<  name << std::endl;
   }
 }
 
@@ -536,11 +529,5 @@ void FP420SD::update (const ::EndOfEvent*) {
 void FP420SD::clearHits(){
   //AZ:
     slave->Initialize();
-}
-
-std::vector<std::string> FP420SD::getNames(){
-  std::vector<std::string> temp;
-  temp.push_back(slave->name());
-  return temp;
 }
 

--- a/SimG4CMS/Forward/interface/BHMSD.h
+++ b/SimG4CMS/Forward/interface/BHMSD.h
@@ -39,31 +39,29 @@ class BHMSD : public SensitiveTkDetector,
 
 public:
   
-  BHMSD(std::string, const DDCompactView &, const SensitiveDetectorCatalog &, 
+  BHMSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &, 
 	edm::ParameterSet const &, const SimTrackManager* );
 
 
-  virtual ~BHMSD();
+  ~BHMSD() override;
   
-  virtual bool ProcessHits(G4Step *,G4TouchableHistory *);
-  virtual uint32_t  setDetUnitId(G4Step*);
+  bool ProcessHits(G4Step *,G4TouchableHistory *) override;
+  uint32_t  setDetUnitId(const G4Step*) override;
 
-  virtual void Initialize(G4HCofThisEvent * HCE);
-  virtual void EndOfEvent(G4HCofThisEvent * eventHC);
-  virtual void clear();
-  virtual void DrawAll();
-  virtual void PrintAll();
+  void Initialize(G4HCofThisEvent * HCE) override;
+  void EndOfEvent(G4HCofThisEvent * eventHC) override;
+  void clear() override;
+  void DrawAll() override;
+  void PrintAll() override;
 
   virtual double getEnergyDeposit(G4Step* step);
-  void           fillHits(edm::PSimHitContainer&, std::string use);
-  
-  std::vector<std::string> getNames();
-  
+  void           fillHits(edm::PSimHitContainer&, const std::string& use) override;
+    
 private:
-  void           update(const BeginOfRun *);
-  void           update(const BeginOfEvent *);
-  void           update(const ::EndOfEvent *);
-  virtual void   clearHits();
+  void           update(const BeginOfRun *) override;
+  void           update(const BeginOfEvent *) override;
+  void           update(const ::EndOfEvent *) override;
+  void   clearHits() override;
 
 private:
   

--- a/SimG4CMS/Forward/interface/Bcm1fSD.h
+++ b/SimG4CMS/Forward/interface/Bcm1fSD.h
@@ -34,16 +34,16 @@ class Bcm1fSD : public SensitiveTkDetector,
 
 public:
 
-  Bcm1fSD(std::string, const DDCompactView &, 
+  Bcm1fSD(const std::string&, const DDCompactView &, 
 		       const SensitiveDetectorCatalog &,
 		       edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~Bcm1fSD();
+  ~Bcm1fSD() override;
 
-  virtual bool     ProcessHits(G4Step *,G4TouchableHistory *);
-  virtual uint32_t setDetUnitId(G4Step*);
-  virtual void EndOfEvent(G4HCofThisEvent*);
+  bool     ProcessHits(G4Step *,G4TouchableHistory *) override;
+  uint32_t setDetUnitId(const G4Step*) override;
+  void EndOfEvent(G4HCofThisEvent*) override;
 
-  void fillHits (edm::PSimHitContainer&, std::string use);
+  void fillHits (edm::PSimHitContainer&, const std::string& use) override;
 
 private:
 
@@ -52,10 +52,10 @@ private:
   virtual bool   newHit(G4Step *);
   virtual bool   closeHit(G4Step *);
   virtual void   createHit(G4Step *);
-  void           update(const BeginOfEvent *);
-  void           update(const BeginOfTrack *);
-  void           update(const BeginOfJob *);
-  virtual void   clearHits();
+  void           update(const BeginOfEvent *) override;
+  void           update(const BeginOfTrack *) override;
+  void           update(const BeginOfJob *) override;
+  void   clearHits() override;
   TrackInformation* getOrCreateTrackInformation(const G4Track *);
 
 private:

--- a/SimG4CMS/Forward/interface/BscSD.h
+++ b/SimG4CMS/Forward/interface/BscSD.h
@@ -10,14 +10,6 @@
 #include "SimG4Core/Notification/interface/BeginOfEvent.h"
 #include "SimG4Core/Notification/interface/EndOfEvent.h"
 
-// last
-//#include "SimG4Core/Application/interface/SimTrackManager.h"
-//#include "SimG4CMS/Calo/interface/CaloSD.h"
-
-
-//#include "SimG4Core/Notification/interface/TrackWithHistory.h"
-//#include "SimG4Core/Notification/interface/TrackContainer.h"
-
 #include "SimG4CMS/Forward/interface/BscG4Hit.h"
 #include "SimG4CMS/Forward/interface/BscG4HitCollection.h"
 #include "SimG4CMS/Forward/interface/BscNumberingScheme.h"
@@ -28,14 +20,7 @@
 #include "G4Track.hh"
 #include "G4VPhysicalVolume.hh"
 
-//#include <CLHEP/Vector/ThreeVector.h>
-//#include <iostream>
-//#include <fstream>
-//#include <vector>
-//#include <map>
 #include <string>
- 
-
 
 class TrackingSlaveSD;
 //AZ:
@@ -58,33 +43,31 @@ class BscSD : public SensitiveTkDetector,
 
 public:
   
-  BscSD(std::string, const DDCompactView &, const SensitiveDetectorCatalog &,
+  BscSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
   	  edm::ParameterSet const &, const SimTrackManager* );
 
 
-  virtual ~BscSD();
+  ~BscSD() override;
   
-  virtual bool ProcessHits(G4Step *,G4TouchableHistory *);
-  virtual uint32_t  setDetUnitId(G4Step*);
+  bool ProcessHits(G4Step *,G4TouchableHistory *) override;
+  uint32_t  setDetUnitId(const G4Step*) override;
 
-  virtual void Initialize(G4HCofThisEvent * HCE);
-  virtual void EndOfEvent(G4HCofThisEvent * eventHC);
-  virtual void clear();
-  virtual void DrawAll();
-  virtual void PrintAll();
+  void Initialize(G4HCofThisEvent * HCE) override;
+  void EndOfEvent(G4HCofThisEvent * eventHC) override;
+  void clear() override;
+  void DrawAll() override;
+  void PrintAll() override;
 
   virtual double getEnergyDeposit(G4Step* step);
   //protected:
   //    Collection       hits_;
-    void fillHits(edm::PSimHitContainer&, std::string use);
-  
-  std::vector<std::string> getNames();
+  void fillHits(edm::PSimHitContainer&, const std::string& use) override;
   
  private:
-  void           update(const BeginOfRun *);
-  void           update(const BeginOfEvent *);
-  void           update(const ::EndOfEvent *);
-  virtual void   clearHits();
+  void           update(const BeginOfRun *) override;
+  void           update(const BeginOfEvent *) override;
+  void           update(const ::EndOfEvent *) override;
+  void   clearHits() override;
   
   //void SetNumberingScheme(BscNumberingScheme* scheme);
   

--- a/SimG4CMS/Forward/interface/CastorSD.h
+++ b/SimG4CMS/Forward/interface/CastorSD.h
@@ -31,11 +31,11 @@ class CastorSD : public CaloSD {
 
 public:    
 
-  CastorSD(G4String, const DDCompactView &, const SensitiveDetectorCatalog & clg,
+  CastorSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog & clg,
 	   edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~CastorSD();
-  virtual double   getEnergyDeposit(G4Step* );
-  virtual uint32_t setDetUnitId(G4Step* step);
+  ~CastorSD() override;
+  double   getEnergyDeposit(G4Step* ) override;
+  uint32_t setDetUnitId(const G4Step* step) override;
   void             setNumberingScheme(CastorNumberingScheme* scheme);
 
 private:
@@ -54,7 +54,7 @@ private:
 
 protected:
 
-  virtual void            initRun();
+  void            initRun() override;
 
 };
 

--- a/SimG4CMS/Forward/interface/CastorShowerLibrary.h
+++ b/SimG4CMS/Forward/interface/CastorShowerLibrary.h
@@ -34,7 +34,7 @@ class CastorShowerLibrary {
 public:
   
   //Constructor and Destructor
-  CastorShowerLibrary(std::string & name, edm::ParameterSet const & p);
+  CastorShowerLibrary(const std::string & name, edm::ParameterSet const & p);
   ~CastorShowerLibrary();
 
 public:

--- a/SimG4CMS/Forward/interface/FastTimerSD.h
+++ b/SimG4CMS/Forward/interface/FastTimerSD.h
@@ -39,32 +39,30 @@ class FastTimerSD : public SensitiveTkDetector,
 
 public:
   
-  FastTimerSD(std::string, const DDCompactView &, const SensitiveDetectorCatalog &, 
+  FastTimerSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &, 
 	      edm::ParameterSet const &, const SimTrackManager* );
 
 
-  virtual ~FastTimerSD();
+  ~FastTimerSD() override;
   
-  virtual bool     ProcessHits(G4Step *,G4TouchableHistory *);
-  virtual uint32_t setDetUnitId(G4Step*);
+  bool     ProcessHits(G4Step *,G4TouchableHistory *) override;
+  uint32_t setDetUnitId(const G4Step*) override;
 
-  virtual void     Initialize(G4HCofThisEvent * HCE);
-  virtual void     EndOfEvent(G4HCofThisEvent * eventHC);
-  virtual void     clear();
-  virtual void     DrawAll();
-  virtual void     PrintAll();
+  void     Initialize(G4HCofThisEvent * HCE) override;
+  void     EndOfEvent(G4HCofThisEvent * eventHC) override;
+  void     clear() override;
+  void     DrawAll() override;
+  void     PrintAll() override;
 
   virtual double   getEnergyDeposit(G4Step* step);
-  void             fillHits(edm::PSimHitContainer&, std::string use);
-  
-  std::vector<std::string> getNames();
+  void             fillHits(edm::PSimHitContainer&, const std::string& use) override;
   
 private:
-  virtual void     update(const BeginOfJob *);
-  virtual void     update(const BeginOfRun *);
-  virtual void     update(const BeginOfEvent *);
-  virtual void     update(const ::EndOfEvent *);
-  virtual void     clearHits();
+  void     update(const BeginOfJob *) override;
+  void     update(const BeginOfRun *) override;
+  void     update(const BeginOfEvent *) override;
+  void     update(const ::EndOfEvent *) override;
+  void     clearHits() override;
 
 private:
   

--- a/SimG4CMS/Forward/interface/PltSD.h
+++ b/SimG4CMS/Forward/interface/PltSD.h
@@ -34,16 +34,16 @@ class PltSD : public SensitiveTkDetector,
 
 public:
 
-  PltSD(std::string, const DDCompactView &, 
+  PltSD(const std::string&, const DDCompactView &, 
 		       const SensitiveDetectorCatalog &,
 		       edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~PltSD();
+  ~PltSD() override;
 
-  virtual bool     ProcessHits(G4Step *,G4TouchableHistory *);
-  virtual uint32_t setDetUnitId(G4Step*);
-  virtual void EndOfEvent(G4HCofThisEvent*);
+  bool     ProcessHits(G4Step *,G4TouchableHistory *) override;
+  uint32_t setDetUnitId(const G4Step*) override;
+  void EndOfEvent(G4HCofThisEvent*) override;
 
-  void fillHits (edm::PSimHitContainer&, std::string use);
+  void fillHits (edm::PSimHitContainer&, const std::string& use) override;
 
 private:
 
@@ -52,10 +52,10 @@ private:
   virtual bool   newHit(G4Step *);
   virtual bool   closeHit(G4Step *);
   virtual void   createHit(G4Step *);
-  void           update(const BeginOfEvent *);
-  void           update(const BeginOfTrack *);
-  void           update(const BeginOfJob *);
-  virtual void   clearHits();
+  void           update(const BeginOfEvent *) override;
+  void           update(const BeginOfTrack *) override;
+  void           update(const BeginOfJob *) override;
+  void   clearHits() override;
   TrackInformation* getOrCreateTrackInformation(const G4Track *);
 
 private:

--- a/SimG4CMS/Forward/interface/TotemSD.h
+++ b/SimG4CMS/Forward/interface/TotemSD.h
@@ -46,31 +46,31 @@ class TotemSD : public SensitiveTkDetector,
 
 public:
 
-  TotemSD(std::string, const DDCompactView &, const SensitiveDetectorCatalog &,
+  TotemSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	  edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~TotemSD();
+  ~TotemSD() override;
 
-  virtual bool   ProcessHits(G4Step *,G4TouchableHistory *);
-  virtual uint32_t setDetUnitId(G4Step*);
+  bool   ProcessHits(G4Step *,G4TouchableHistory *) override;
+  uint32_t setDetUnitId(const G4Step*) override;
 
-  virtual void   Initialize(G4HCofThisEvent * HCE);
-  virtual void   EndOfEvent(G4HCofThisEvent * eventHC);
-  virtual void   clear();
-  virtual void   DrawAll();
-  virtual void   PrintAll();
+  void   Initialize(G4HCofThisEvent * HCE) override;
+  void   EndOfEvent(G4HCofThisEvent * eventHC) override;
+  void   clear() override;
+  void   DrawAll() override;
+  void   PrintAll() override;
 
-  void fillHits(edm::PSimHitContainer&, std::string use);
+  void fillHits(edm::PSimHitContainer&, const std::string& use) override;
 
 private:
 
-  void           update(const BeginOfEvent *);
-  void           update(const ::EndOfEvent *);
-  virtual void   clearHits();
+  void           update(const BeginOfEvent *) override;
+  void           update(const ::EndOfEvent *) override;
+  void   clearHits() override;
 
 private:
 
   G4ThreeVector  SetToLocal(const G4ThreeVector& globalPoint);
-  void           GetStepInfo(G4Step* aStep);
+  void           GetStepInfo(const G4Step* aStep);
   bool           HitExists();
   void           CreateNewHit();
   void           CreateNewHitEvo();

--- a/SimG4CMS/Forward/interface/ZdcSD.h
+++ b/SimG4CMS/Forward/interface/ZdcSD.h
@@ -14,12 +14,12 @@
 class ZdcSD : public CaloSD {
 
 public:    
-  ZdcSD(G4String, const DDCompactView &, const SensitiveDetectorCatalog &,
+  ZdcSD(const std::string&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	edm::ParameterSet const &,const SimTrackManager*);
  
-  virtual ~ZdcSD();
-  virtual bool ProcessHits(G4Step * step,G4TouchableHistory * tHistory);
-  virtual uint32_t setDetUnitId(G4Step* step);
+  ~ZdcSD() override;
+  bool ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
+  uint32_t setDetUnitId(const G4Step* step) override;
   virtual double getEnergyDeposit(G4Step*, edm::ParameterSet const &);
  
   void setNumberingScheme(ZdcNumberingScheme* scheme);
@@ -27,12 +27,12 @@ public:
  
 
 protected:
-  virtual void initRun();
+  void initRun() override;
 private:    
 
   int verbosity;
   bool  useShowerLibrary,useShowerHits; 
-  int   setTrackID(G4Step * step);
+  int   setTrackID(const G4Step * step);
   double thFibDir;
   double zdcHitEnergyCut;
   ZdcShowerLibrary *    showerLibrary;

--- a/SimG4CMS/Forward/interface/ZdcShowerLibrary.h
+++ b/SimG4CMS/Forward/interface/ZdcShowerLibrary.h
@@ -25,7 +25,7 @@ class ZdcShowerLibrary {
 public:
   
   //Constructor and Destructor
-  ZdcShowerLibrary(std::string & name, const DDCompactView & cpv, edm::ParameterSet const & p);
+  ZdcShowerLibrary(const std::string & name, const DDCompactView & cpv, edm::ParameterSet const & p);
   ~ZdcShowerLibrary();
   
  public:

--- a/SimG4CMS/Forward/src/BHMSD.cc
+++ b/SimG4CMS/Forward/src/BHMSD.cc
@@ -27,13 +27,13 @@
 
 #define debug
 //-------------------------------------------------------------------
-BHMSD::BHMSD(std::string name, const DDCompactView & cpv,
+BHMSD::BHMSD(const std::string& name, const DDCompactView & cpv,
 	     const SensitiveDetectorCatalog & clg, 
 	     edm::ParameterSet const & p, const SimTrackManager* manager) :
-  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(0), name(name),
-  hcID(-1), theHC(0), theManager(manager), currentHit(0), theTrack(0), 
-  currentPV(0), unitID(0),  previousUnitID(0), preStepPoint(0), 
-  postStepPoint(0), eventno(0){
+  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(nullptr), name(name),
+  hcID(-1), theHC(nullptr), theManager(manager), currentHit(nullptr), theTrack(nullptr), 
+  currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
+  postStepPoint(nullptr), eventno(0){
     
   //Add BHM Sentitive Detector Name
   collectionName.insert(name);
@@ -104,7 +104,7 @@ void BHMSD::Initialize(G4HCofThisEvent * HCE) {
 
 bool BHMSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 
-  if (aStep == NULL) {
+  if (aStep == nullptr) {
     return true;
   } else {
     GetStepInfo(aStep);
@@ -166,8 +166,8 @@ void BHMSD::GetStepInfo(G4Step* aStep) {
   Z  = hitPoint.z();
 }
 
-uint32_t BHMSD::setDetUnitId(G4Step * aStep) { 
-  return (numberingScheme == 0 ? 0 : numberingScheme->getUnitID(aStep));
+uint32_t BHMSD::setDetUnitId(const G4Step * aStep) { 
+  return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(aStep));
 }
 
 
@@ -222,7 +222,7 @@ void BHMSD::ResetForNewPrimary() {
 void BHMSD::StoreHit(BscG4Hit* hit){
 
   if (primID<0) return;
-  if (hit == 0 ) {
+  if (hit == nullptr ) {
     edm::LogWarning("BHMSim") << "BHMSD: hit to be stored is NULL !!";
     return;
   }
@@ -250,7 +250,7 @@ void BHMSD::CreateNewHit() {
   }
 
   LogDebug("BHMSim")  << " and created by " ;
-  if (theTrack->GetCreatorProcess()!=NULL)
+  if (theTrack->GetCreatorProcess()!=nullptr)
     LogDebug("BHMSim") << theTrack->GetCreatorProcess()->GetProcessName() ;
   else 
     LogDebug("BHMSim") << "NO process";
@@ -371,7 +371,7 @@ void BHMSD::PrintAll() {
 } 
 
 
-void BHMSD::fillHits(edm::PSimHitContainer& c, std::string n) {
+void BHMSD::fillHits(edm::PSimHitContainer& c, const std::string& n) {
   if (slave->name() == n) c=slave->hits();
 }
 
@@ -399,8 +399,3 @@ void BHMSD::clearHits(){
   slave->Initialize();
 }
 
-std::vector<std::string> BHMSD::getNames(){
-  std::vector<std::string> temp;
-  temp.push_back(slave->name());
-  return temp;
-}

--- a/SimG4CMS/Forward/src/Bcm1fSD.cc
+++ b/SimG4CMS/Forward/src/Bcm1fSD.cc
@@ -30,13 +30,13 @@
 
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
-Bcm1fSD::Bcm1fSD(std::string name, 
-					   const DDCompactView & cpv,
-					   const SensitiveDetectorCatalog & clg,
-					   edm::ParameterSet const & p,
-					   const SimTrackManager* manager) : 
-  SensitiveTkDetector(name, cpv, clg, p), myName(name), mySimHit(0),
-  oldVolume(0), lastId(0), lastTrack(0), eventno(0) {
+Bcm1fSD::Bcm1fSD(const std::string& name, 
+		 const DDCompactView & cpv,
+		 const SensitiveDetectorCatalog & clg,
+		 edm::ParameterSet const & p,
+		 const SimTrackManager* manager) : 
+  SensitiveTkDetector(name, cpv, clg, p), myName(name), mySimHit(nullptr),
+  oldVolume(nullptr), lastId(0), lastTrack(0), eventno(0) {
   
   edm::ParameterSet m_TrackerSD = p.getParameter<edm::ParameterSet>("Bcm1fSD");
   energyCut           = m_TrackerSD.getParameter<double>("EnergyThresholdForPersistencyInGeV")*GeV; //default must be 0.5 (?)
@@ -98,7 +98,7 @@ bool Bcm1fSD::ProcessHits(G4Step * aStep,  G4TouchableHistory *) {
   return false;
 }
 
-uint32_t Bcm1fSD::setDetUnitId(G4Step * aStep ) {
+uint32_t Bcm1fSD::setDetUnitId(const G4Step * aStep ) {
  
   unsigned int detId = 0;
 
@@ -154,16 +154,16 @@ void Bcm1fSD::EndOfEvent(G4HCofThisEvent *) {
   
   LogDebug("Bcm1fSD")<< " Saving the last hit in a ROU " << myName;
 
-  if (mySimHit == 0) return;
+  if (mySimHit == nullptr) return;
   sendHit();
 }
 
-void Bcm1fSD::fillHits(edm::PSimHitContainer& c, std::string n){
+void Bcm1fSD::fillHits(edm::PSimHitContainer& c, const std::string& n){
   if (slave->name() == n)  c=slave->hits();
 }
 
 void Bcm1fSD::sendHit() {  
-  if (mySimHit == 0) return;
+  if (mySimHit == nullptr) return;
   LogDebug("Bcm1fSD") << " Storing PSimHit: " << pname << " " << mySimHit->detUnitId() 
 				   << " " << mySimHit->trackId() << " " << mySimHit->energyLoss() 
 				   << " " << mySimHit->entryPoint() << " " << mySimHit->exitPoint();
@@ -172,7 +172,7 @@ void Bcm1fSD::sendHit() {
 
   // clean up
   delete mySimHit;
-  mySimHit = 0;
+  mySimHit = nullptr;
   lastTrack = 0;
   lastId = 0;
 }
@@ -203,14 +203,14 @@ bool Bcm1fSD::newHit(G4Step * aStep) {
   LogDebug("Bcm1fSD") << " OLD (d,t) = (" << lastId << "," << lastTrack 
 				   << "), new = (" << theDetUnitId << "," << theTrackID << ") return "
 				   << ((theTrackID == lastTrack) && (lastId == theDetUnitId));
-  if ((mySimHit != 0) && (theTrackID == lastTrack) && (lastId == theDetUnitId) && closeHit(aStep))
+  if ((mySimHit != nullptr) && (theTrackID == lastTrack) && (lastId == theDetUnitId) && closeHit(aStep))
     return false;
   return true;
 }
 
 bool Bcm1fSD::closeHit(G4Step * aStep) {
 
-  if (mySimHit == 0) return false; 
+  if (mySimHit == nullptr) return false; 
   const float tolerance = 0.05 * mm; // 50 micron are allowed between the exit 
   // point of the current hit and the entry point of the new hit
   Local3DPoint theEntryPoint = SensitiveDetector::InitialStepPosition(aStep,LocalCoordinates);  
@@ -222,9 +222,9 @@ bool Bcm1fSD::closeHit(G4Step * aStep) {
 
 void Bcm1fSD::createHit(G4Step * aStep) {
 
-  if (mySimHit != 0) {
+  if (mySimHit != nullptr) {
     delete mySimHit;
-    mySimHit=0;
+    mySimHit=nullptr;
   }
     
   G4Track * theTrack  = aStep->GetTrack(); 
@@ -272,7 +272,7 @@ void Bcm1fSD::update(const BeginOfEvent * i) {
 
   clearHits();
   eventno = (*i)()->GetEventID();
-  mySimHit = 0;
+  mySimHit = nullptr;
 }
 
 void Bcm1fSD::update(const BeginOfTrack *bot) {
@@ -287,12 +287,12 @@ void Bcm1fSD::clearHits() {
 
 TrackInformation* Bcm1fSD::getOrCreateTrackInformation( const G4Track* gTrack) {
   G4VUserTrackInformation* temp = gTrack->GetUserInformation();
-  if (temp == 0){
+  if (temp == nullptr){
     edm::LogError("Bcm1fSD") <<" ERROR: no G4VUserTrackInformation available";
     abort();
   }else{
     TrackInformation* info = dynamic_cast<TrackInformation*>(temp);
-    if (info == 0){
+    if (info == nullptr){
       edm::LogError("Bcm1fSD") <<" ERROR: TkSimTrackSelection: the UserInformation does not appear to be a TrackInformation";
       abort();
     }

--- a/SimG4CMS/Forward/src/BscSD.cc
+++ b/SimG4CMS/Forward/src/BscSD.cc
@@ -45,13 +45,13 @@
 
 #define debug
 //-------------------------------------------------------------------
-BscSD::BscSD(std::string name, const DDCompactView & cpv,
+BscSD::BscSD(const std::string& name, const DDCompactView & cpv,
 	     const SensitiveDetectorCatalog & clg,
 	     edm::ParameterSet const & p, const SimTrackManager* manager) :
-  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(0), name(name),
-  hcID(-1), theHC(0), theManager(manager), currentHit(0), theTrack(0), 
-  currentPV(0), unitID(0),  previousUnitID(0), preStepPoint(0), 
-  postStepPoint(0), eventno(0){
+  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(nullptr), name(name),
+  hcID(-1), theHC(nullptr), theManager(manager), currentHit(nullptr), theTrack(nullptr), 
+  currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
+  postStepPoint(nullptr), eventno(0){
     
   //Add Bsc Sentitive Detector Name
   collectionName.insert(name);
@@ -98,9 +98,6 @@ BscSD::BscSD(std::string name, const DDCompactView & cpv,
   edm::LogInfo("BscSim") << "BscSD: Instantiation completed";
 }
 
-
-
-
 BscSD::~BscSD() { 
   //AZ:
   if (slave) delete slave; 
@@ -133,7 +130,7 @@ void BscSD::Initialize(G4HCofThisEvent * HCE) {
 
 bool BscSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 
-  if (aStep == NULL) {
+  if (aStep == nullptr) {
     return true;
   } else {
     GetStepInfo(aStep);
@@ -199,9 +196,9 @@ void BscSD::GetStepInfo(G4Step* aStep) {
   Z  = hitPoint.z();
 }
 
-uint32_t BscSD::setDetUnitId(G4Step * aStep) { 
+uint32_t BscSD::setDetUnitId(const G4Step * aStep) { 
 
-  return (numberingScheme == 0 ? 0 : numberingScheme->getUnitID(aStep));
+  return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(aStep));
 }
 
 
@@ -250,7 +247,6 @@ G4bool BscSD::HitExists() {
   }    
 }
 
-
 void BscSD::ResetForNewPrimary() {
   
   entrancePoint  = SetToLocal(hitPoint);
@@ -263,7 +259,7 @@ void BscSD::ResetForNewPrimary() {
 void BscSD::StoreHit(BscG4Hit* hit){
 
   if (primID<0) return;
-  if (hit == 0 ) {
+  if (hit == nullptr ) {
     edm::LogWarning("BscSim") << "BscSD: hit to be stored is NULL !!";
     return;
   }
@@ -291,7 +287,7 @@ void BscSD::CreateNewHit() {
   }
 
   LogDebug("BscSim")  << " and created by " ;
-  if (theTrack->GetCreatorProcess()!=NULL)
+  if (theTrack->GetCreatorProcess()!=nullptr)
     LogDebug("BscSim") << theTrack->GetCreatorProcess()->GetProcessName() ;
   else 
     LogDebug("BscSim") << "NO process";
@@ -414,7 +410,7 @@ void BscSD::PrintAll() {
 } 
 
 
-void BscSD::fillHits(edm::PSimHitContainer& c, std::string n) {
+void BscSD::fillHits(edm::PSimHitContainer& c, const std::string& n) {
   if (slave->name() == n) c=slave->hits();
 }
 
@@ -441,11 +437,5 @@ void BscSD::update (const ::EndOfEvent*) {
 void BscSD::clearHits(){
   //AZ:
   slave->Initialize();
-}
-
-std::vector<std::string> BscSD::getNames(){
-  std::vector<std::string> temp;
-  temp.push_back(slave->name());
-  return temp;
 }
 

--- a/SimG4CMS/Forward/src/CastorSD.cc
+++ b/SimG4CMS/Forward/src/CastorSD.cc
@@ -9,7 +9,6 @@
 #include "SimG4Core/Notification/interface/TrackInformationExtractor.h"
 
 #include "SimG4CMS/Forward/interface/CastorSD.h"
-//#include "SimDataFormats/CaloHit/interface/CastorShowerEvent.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "G4SDManager.hh"
@@ -28,12 +27,12 @@
 
 //#define debugLog
 
-CastorSD::CastorSD(G4String name, const DDCompactView & cpv,
+CastorSD::CastorSD(const std::string& name, const DDCompactView & cpv,
 		   const SensitiveDetectorCatalog & clg,
 		   edm::ParameterSet const & p, 
 		   const SimTrackManager* manager) : 
-  CaloSD(name, cpv, clg, p, manager), numberingScheme(0), lvC3EF(0),
-  lvC3HF(0), lvC4EF(0), lvC4HF(0), lvCAST(0) {
+  CaloSD(name, cpv, clg, p, manager), numberingScheme(nullptr), lvC3EF(nullptr),
+  lvC3HF(nullptr), lvC4EF(nullptr), lvC4HF(nullptr), lvCAST(nullptr) {
   
   edm::ParameterSet m_CastorSD = p.getParameter<edm::ParameterSet>("CastorSD");
   useShowerLibrary  = m_CastorSD.getParameter<bool>("useShowerLibrary");
@@ -61,7 +60,7 @@ CastorSD::CastorSD(G4String name, const DDCompactView & cpv,
     if (strcmp(((*lvcite)->GetName()).c_str(),"C4EF") == 0) lvC4EF = (*lvcite);
     if (strcmp(((*lvcite)->GetName()).c_str(),"C4HF") == 0) lvC4HF = (*lvcite);
     if (strcmp(((*lvcite)->GetName()).c_str(),"CAST") == 0) lvCAST = (*lvcite);
-    if (lvC3EF != 0 && lvC3HF != 0 && lvC4EF != 0 && lvC4HF != 0 && lvCAST != 0) break;
+    if (lvC3EF != nullptr && lvC3HF != nullptr && lvC4EF != nullptr && lvC4HF != nullptr && lvCAST != nullptr) break;
   }
   edm::LogInfo("ForwardSim") << "CastorSD:: LogicalVolume pointers\n"
 			     << lvC3EF << " for C3EF; " << lvC3HF 
@@ -96,7 +95,7 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
   
   double NCherPhot = 0.;
 
-  if (aStep == NULL) 
+  if (aStep == nullptr) 
     return 0;
 
   // Get theTrack 
@@ -168,8 +167,8 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
   
   // if particle moves from interaction point or "backwards (halo)
   bool backward = false;
-  G4ThreeVector  hitPoint = preStepPoint->GetPosition();	
-  G4ThreeVector  hit_mom  = preStepPoint->GetMomentumDirection();
+  const G4ThreeVector&  hitPoint = preStepPoint->GetPosition();	
+  const G4ThreeVector&  hit_mom  = preStepPoint->GetMomentumDirection();
   double zint = hitPoint.z();
   double pz   = hit_mom.z();
   
@@ -530,15 +529,15 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
 
 //=======================================================================================
 
-uint32_t CastorSD::setDetUnitId(G4Step* aStep) {
-  return (numberingScheme == 0 ? 0 : numberingScheme->getUnitID(aStep));
+uint32_t CastorSD::setDetUnitId(const G4Step* aStep) {
+  return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(aStep));
 }
 
 //=======================================================================================
 
 void CastorSD::setNumberingScheme(CastorNumberingScheme* scheme) {
 
-  if (scheme != 0) {
+  if (scheme != nullptr) {
     edm::LogInfo("ForwardSim") << "CastorSD: updates numbering scheme for " 
 			       << GetName();
     if (numberingScheme) delete numberingScheme;

--- a/SimG4CMS/Forward/src/CastorShowerLibrary.cc
+++ b/SimG4CMS/Forward/src/CastorShowerLibrary.cc
@@ -20,8 +20,8 @@
 
 //#define DebugLog
 
-CastorShowerLibrary::CastorShowerLibrary(std::string & name, edm::ParameterSet const & p) 
-                                          : hf(0), evtInfo(0), emBranch(0), hadBranch(0),
+CastorShowerLibrary::CastorShowerLibrary(const std::string & name, edm::ParameterSet const & p) 
+                                          : hf(nullptr), evtInfo(nullptr), emBranch(nullptr), hadBranch(nullptr),
                                             nMomBin(0), totEvents(0), evtPerBin(0),
                                             nBinsE(0),nBinsEta(0),nBinsPhi(0),
                                             nEvtPerBinE(0),nEvtPerBinEta(0),nEvtPerBinPhi(0),
@@ -216,10 +216,10 @@ CastorShowerEvent CastorShowerLibrary::getShowerHits(G4Step * aStep, bool & ok) 
   G4Track *     track         = aStep->GetTrack();
   // Get Z-direction 
   const G4DynamicParticle *aParticle = track->GetDynamicParticle();
-  G4ThreeVector               momDir = aParticle->GetMomentumDirection();
+  const G4ThreeVector&               momDir = aParticle->GetMomentumDirection();
   //  double mom = aParticle->GetTotalMomentum();
 
-  G4ThreeVector hitPoint = preStepPoint->GetPosition();   
+  const G4ThreeVector& hitPoint = preStepPoint->GetPosition();   
   G4String      partType = track->GetDefinition()->GetParticleName();
   int           parCode  = track->GetDefinition()->GetPDGEncoding();
 

--- a/SimG4CMS/Forward/src/CastorShowerLibrary.cc
+++ b/SimG4CMS/Forward/src/CastorShowerLibrary.cc
@@ -212,13 +212,8 @@ void CastorShowerLibrary::initParticleTable(G4ParticleTable * theParticleTable) 
 CastorShowerEvent CastorShowerLibrary::getShowerHits(G4Step * aStep, bool & ok) {
 
   G4StepPoint * preStepPoint  = aStep->GetPreStepPoint(); 
-  // G4StepPoint * postStepPoint = aStep->GetPostStepPoint(); 
   G4Track *     track         = aStep->GetTrack();
   // Get Z-direction 
-  const G4DynamicParticle *aParticle = track->GetDynamicParticle();
-  const G4ThreeVector&               momDir = aParticle->GetMomentumDirection();
-  //  double mom = aParticle->GetTotalMomentum();
-
   const G4ThreeVector& hitPoint = preStepPoint->GetPosition();   
   G4String      partType = track->GetDefinition()->GetParticleName();
   int           parCode  = track->GetDefinition()->GetPDGEncoding();

--- a/SimG4CMS/Forward/src/FastTimerSD.cc
+++ b/SimG4CMS/Forward/src/FastTimerSD.cc
@@ -37,14 +37,14 @@
 
 //#define EDM_ML_DEBUG
 //-------------------------------------------------------------------
-FastTimerSD::FastTimerSD(std::string name, const DDCompactView & cpv,
+FastTimerSD::FastTimerSD(const std::string& name, const DDCompactView & cpv,
 			 const SensitiveDetectorCatalog & clg, 
 			 edm::ParameterSet const & p, 
 			 const SimTrackManager* manager) :
-  SensitiveTkDetector(name, cpv, clg, p), ftcons(0), name(name),
-  hcID(-1), theHC(0), theManager(manager), currentHit(0), theTrack(0), 
-  currentPV(0), unitID(0),  previousUnitID(0), preStepPoint(0), 
-  postStepPoint(0), eventno(0) {
+  SensitiveTkDetector(name, cpv, clg, p), ftcons(nullptr), name(name),
+  hcID(-1), theHC(nullptr), theManager(manager), currentHit(nullptr), theTrack(nullptr), 
+  currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
+  postStepPoint(nullptr), eventno(0) {
     
   //Add FastTimer Sentitive Detector Name
   collectionName.insert(name);
@@ -116,7 +116,7 @@ void FastTimerSD::Initialize(G4HCofThisEvent * HCE) {
 
 bool FastTimerSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 
-  if (aStep == NULL) {
+  if (aStep == nullptr) {
     return true;
   } else {
     GetStepInfo(aStep);
@@ -181,7 +181,7 @@ void FastTimerSD::GetStepInfo(G4Step* aStep) {
   Z  = hitPoint.z();
 }
 
-uint32_t FastTimerSD::setDetUnitId(G4Step * aStep) { 
+uint32_t FastTimerSD::setDetUnitId(const G4Step * aStep) { 
 
   //Find the depth segment
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
@@ -252,7 +252,7 @@ void FastTimerSD::ResetForNewPrimary() {
 void FastTimerSD::StoreHit(BscG4Hit* hit){
 
   if (primID<0) return;
-  if (hit == 0) {
+  if (hit == nullptr) {
     edm::LogWarning("FastTimerSim") << "FastTimerSD: hit to be stored is NULL !!";
   } else {
     theHC->insert( hit );
@@ -394,7 +394,7 @@ void FastTimerSD::PrintAll() {
   theHC->PrintAllHits();
 } 
 
-void FastTimerSD::fillHits(edm::PSimHitContainer& c, std::string n) {
+void FastTimerSD::fillHits(edm::PSimHitContainer& c, const std::string& n) {
   if (slave->name() == n) c=slave->hits();
 }
 
@@ -436,12 +436,6 @@ void FastTimerSD::update (const ::EndOfEvent*) {}
 
 void FastTimerSD::clearHits(){
   slave->Initialize();
-}
-
-std::vector<std::string> FastTimerSD::getNames(){
-  std::vector<std::string> temp;
-  temp.push_back(slave->name());
-  return temp;
 }
 
 std::vector<double> FastTimerSD::getDDDArray(const std::string & str, 

--- a/SimG4CMS/Forward/src/PltSD.cc
+++ b/SimG4CMS/Forward/src/PltSD.cc
@@ -32,13 +32,13 @@
 #include <iostream>
 
 
-PltSD::PltSD(std::string name,
+PltSD::PltSD(const std::string& name,
              const DDCompactView & cpv,
              const SensitiveDetectorCatalog & clg,
              edm::ParameterSet const & p,
              const SimTrackManager* manager) :
-SensitiveTkDetector(name, cpv, clg, p), myName(name), mySimHit(0),
-oldVolume(0), lastId(0), lastTrack(0), eventno(0) {
+SensitiveTkDetector(name, cpv, clg, p), myName(name), mySimHit(nullptr),
+oldVolume(nullptr), lastId(0), lastTrack(0), eventno(0) {
     
     edm::ParameterSet m_TrackerSD = p.getParameter<edm::ParameterSet>("PltSD");
     energyCut           = m_TrackerSD.getParameter<double>("EnergyThresholdForPersistencyInGeV")*GeV; //default must be 0.5 (?)
@@ -100,7 +100,7 @@ bool PltSD::ProcessHits(G4Step * aStep,  G4TouchableHistory *) {
     return false;
 }
 
-uint32_t PltSD::setDetUnitId(G4Step * aStep ) {
+uint32_t PltSD::setDetUnitId(const G4Step * aStep ) {
     
     unsigned int detId = 0;
     
@@ -198,16 +198,16 @@ void PltSD::EndOfEvent(G4HCofThisEvent *) {
     
     LogDebug("PltSD")<< " Saving the last hit in a ROU " << myName;
     
-    if (mySimHit == 0) return;
+    if (mySimHit == nullptr) return;
     sendHit();
 }
 
-void PltSD::fillHits(edm::PSimHitContainer& c, std::string n){
+void PltSD::fillHits(edm::PSimHitContainer& c, const std::string& n){
     if (slave->name() == n)  c=slave->hits();
 }
 
 void PltSD::sendHit() {
-    if (mySimHit == 0) return;
+    if (mySimHit == nullptr) return;
     LogDebug("PltSD") << " Storing PSimHit: " << pname << " " << mySimHit->detUnitId()
     << " " << mySimHit->trackId() << " " << mySimHit->energyLoss()
     << " " << mySimHit->entryPoint() << " " << mySimHit->exitPoint();
@@ -216,7 +216,7 @@ void PltSD::sendHit() {
     
     // clean up
     delete mySimHit;
-    mySimHit = 0;
+    mySimHit = nullptr;
     lastTrack = 0;
     lastId = 0;
 }
@@ -247,14 +247,14 @@ bool PltSD::newHit(G4Step * aStep) {
     LogDebug("PltSD") << " OLD (d,t) = (" << lastId << "," << lastTrack
     << "), new = (" << theDetUnitId << "," << theTrackID << ") return "
     << ((theTrackID == lastTrack) && (lastId == theDetUnitId));
-    if ((mySimHit != 0) && (theTrackID == lastTrack) && (lastId == theDetUnitId) && closeHit(aStep))
+    if ((mySimHit != nullptr) && (theTrackID == lastTrack) && (lastId == theDetUnitId) && closeHit(aStep))
     return false;
     return true;
 }
 
 bool PltSD::closeHit(G4Step * aStep) {
     
-    if (mySimHit == 0) return false;
+    if (mySimHit == nullptr) return false;
     const float tolerance = 0.05 * mm; // 50 micron are allowed between the exit
     // point of the current hit and the entry point of the new hit
     Local3DPoint theEntryPoint = SensitiveDetector::InitialStepPosition(aStep,LocalCoordinates);
@@ -266,9 +266,9 @@ bool PltSD::closeHit(G4Step * aStep) {
 
 void PltSD::createHit(G4Step * aStep) {
     
-    if (mySimHit != 0) {
+    if (mySimHit != nullptr) {
         delete mySimHit;
-        mySimHit=0;
+        mySimHit=nullptr;
     }
     
     G4Track * theTrack  = aStep->GetTrack();
@@ -316,7 +316,7 @@ void PltSD::update(const BeginOfEvent * i) {
     
     clearHits();
     eventno = (*i)()->GetEventID();
-    mySimHit = 0;
+    mySimHit = nullptr;
 }
 
 void PltSD::update(const BeginOfTrack *bot) {
@@ -331,12 +331,12 @@ void PltSD::clearHits() {
 
 TrackInformation* PltSD::getOrCreateTrackInformation( const G4Track* gTrack) {
     G4VUserTrackInformation* temp = gTrack->GetUserInformation();
-    if (temp == 0){
+    if (temp == nullptr){
         edm::LogError("PltSD") <<" ERROR: no G4VUserTrackInformation available";
         abort();
     }else{
         TrackInformation* info = dynamic_cast<TrackInformation*>(temp);
-        if (info == 0){
+        if (info == nullptr){
             edm::LogError("PltSD") <<" ERROR: TkSimTrackSelection: the UserInformation does not appear to be a TrackInformation";
             abort();
         }

--- a/SimG4CMS/Forward/src/TotemSD.cc
+++ b/SimG4CMS/Forward/src/TotemSD.cc
@@ -45,13 +45,13 @@
 //
 // constructors and destructor
 //
-TotemSD::TotemSD(std::string name, const DDCompactView & cpv,
+TotemSD::TotemSD(const std::string& name, const DDCompactView & cpv,
 		 const SensitiveDetectorCatalog & clg,
 		 edm::ParameterSet const & p, const SimTrackManager* manager) :
-  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(0), name(name),
-  hcID(-1), theHC(0), theManager(manager), currentHit(0), theTrack(0), 
-  currentPV(0), unitID(0),  previousUnitID(0), preStepPoint(0), 
-  postStepPoint(0), eventno(0){
+  SensitiveTkDetector(name, cpv, clg, p), numberingScheme(nullptr), name(name),
+  hcID(-1), theHC(nullptr), theManager(manager), currentHit(nullptr), theTrack(nullptr), 
+  currentPV(nullptr), unitID(0),  previousUnitID(0), preStepPoint(nullptr), 
+  postStepPoint(nullptr), eventno(0){
 
   //Add Totem Sentitive Detector Names
   collectionName.insert(name);
@@ -103,7 +103,7 @@ TotemSD::~TotemSD() {
 
 bool TotemSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 
-  if (aStep == NULL) {
+  if (aStep == nullptr) {
     return true;
   } else {
     GetStepInfo(aStep);
@@ -120,9 +120,9 @@ bool TotemSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
   return true;
 }
 
-uint32_t TotemSD::setDetUnitId(G4Step * aStep) { 
+uint32_t TotemSD::setDetUnitId(const G4Step * aStep) { 
 
-  return (numberingScheme == 0 ? 0 : numberingScheme->GetUnitID(aStep));
+  return (numberingScheme == nullptr ? 0 : numberingScheme->GetUnitID(aStep));
 }
 
 void TotemSD::Initialize(G4HCofThisEvent * HCE) { 
@@ -176,7 +176,7 @@ void TotemSD::PrintAll() {
   theHC->PrintAllHits();
 } 
 
-void TotemSD::fillHits(edm::PSimHitContainer& c, std::string n) {
+void TotemSD::fillHits(edm::PSimHitContainer& c, const std::string& n) {
   if (slave->name() == n) c=slave->hits();
 }
 
@@ -202,7 +202,7 @@ G4ThreeVector TotemSD::SetToLocal(const G4ThreeVector& global) {
   return localPoint;  
 }
 
-void TotemSD::GetStepInfo(G4Step* aStep) {
+void TotemSD::GetStepInfo(const G4Step* aStep) {
   
   preStepPoint = aStep->GetPreStepPoint(); 
   postStepPoint= aStep->GetPostStepPoint(); 
@@ -508,7 +508,7 @@ void TotemSD::UpdateHit() {
 void TotemSD::StoreHit(TotemG4Hit* hit) {
 
   if (primID<0) return;
-  if (hit == 0 ) {
+  if (hit == nullptr ) {
     edm::LogWarning("ForwardSim") << "TotemSD: hit to be stored is NULL !!";
     return;
   }

--- a/SimG4CMS/Forward/src/ZdcSD.cc
+++ b/SimG4CMS/Forward/src/ZdcSD.cc
@@ -20,10 +20,10 @@
 #include "Randomize.hh"
 #include "G4Poisson.hh"
 
-ZdcSD::ZdcSD(G4String name, const DDCompactView & cpv,
+ZdcSD::ZdcSD(const std::string& name, const DDCompactView & cpv,
 	     const SensitiveDetectorCatalog & clg,
 	     edm::ParameterSet const & p,const SimTrackManager* manager) : 
-  CaloSD(name, cpv, clg, p, manager), numberingScheme(0) {
+  CaloSD(name, cpv, clg, p, manager), numberingScheme(nullptr) {
   edm::ParameterSet m_ZdcSD = p.getParameter<edm::ParameterSet>("ZdcSD");
   useShowerLibrary = m_ZdcSD.getParameter<bool>("UseShowerLibrary");
   useShowerHits    = m_ZdcSD.getParameter<bool>("UseShowerHits");
@@ -79,7 +79,7 @@ bool ZdcSD::ProcessHits(G4Step * aStep, G4TouchableHistory * ) {
 
   NaNTrap( aStep ) ;
 
-  if (aStep == NULL) {
+  if (aStep == nullptr) {
     return true;
   } else {
     if(useShowerLibrary){
@@ -184,7 +184,7 @@ double ZdcSD::getEnergyDeposit(G4Step * aStep, edm::ParameterSet const & p ) {
   float NCherPhot = 0.;
   //std::cout<<"I go through here"<<std::endl;
 
-  if (aStep == NULL) {
+  if (aStep == nullptr) {
     LogDebug("ForwardSim") << "ZdcSD::  getEnergyDeposit: aStep is NULL!";
     return 0;
   } else {
@@ -192,10 +192,10 @@ double ZdcSD::getEnergyDeposit(G4Step * aStep, edm::ParameterSet const & p ) {
     G4SteppingControl  stepControlFlag = aStep->GetControlFlag();
     G4StepPoint*       preStepPoint = aStep->GetPreStepPoint();
     G4VPhysicalVolume* currentPV    = preStepPoint->GetPhysicalVolume();
-    G4String           nameVolume   = currentPV->GetName();
+    const G4String&           nameVolume   = currentPV->GetName();
 
-    G4ThreeVector      hitPoint = preStepPoint->GetPosition();	
-    G4ThreeVector      hit_mom = preStepPoint->GetMomentumDirection();
+    const G4ThreeVector&      hitPoint = preStepPoint->GetPosition();	
+    const G4ThreeVector&      hit_mom = preStepPoint->GetMomentumDirection();
     G4double           stepL = aStep->GetStepLength()/cm;
     G4double           beta     = preStepPoint->GetBeta();
     G4double           charge   = preStepPoint->GetCharge();
@@ -209,14 +209,14 @@ double ZdcSD::getEnergyDeposit(G4Step * aStep, edm::ParameterSet const & p ) {
     // postStepPoint information
     G4StepPoint* postStepPoint = aStep->GetPostStepPoint();   
     G4VPhysicalVolume* postPV = postStepPoint->GetPhysicalVolume();
-    G4String postnameVolume = postPV->GetName();
+    const G4String& postnameVolume = postPV->GetName();
 
     // theTrack information
     G4Track* theTrack = aStep->GetTrack();   
     G4String particleType = theTrack->GetDefinition()->GetParticleName();
     G4int primaryID = theTrack->GetTrackID();
     G4double entot = theTrack->GetTotalEnergy();
-    G4ThreeVector vert_mom = theTrack->GetVertexMomentumDirection();
+    const G4ThreeVector& vert_mom = theTrack->GetVertexMomentumDirection();
     G4ThreeVector localPoint = theTrack->GetTouchable()->GetHistory()->GetTopTransform().TransformPoint(hitPoint);
 
     // calculations
@@ -408,15 +408,15 @@ double ZdcSD::getEnergyDeposit(G4Step * aStep, edm::ParameterSet const & p ) {
   } 
 }
 
-uint32_t ZdcSD::setDetUnitId(G4Step* aStep) {
+uint32_t ZdcSD::setDetUnitId(const G4Step* aStep) {
   uint32_t returnNumber = 0;
-  if(numberingScheme != 0)returnNumber = numberingScheme->getUnitID(aStep);
+  if(numberingScheme != nullptr)returnNumber = numberingScheme->getUnitID(aStep);
   // edm: return (numberingScheme == 0 ? 0 : numberingScheme->getUnitID(aStep));
   return returnNumber;
 }
 
 void ZdcSD::setNumberingScheme(ZdcNumberingScheme* scheme) {
-  if (scheme != 0) {
+  if (scheme != nullptr) {
     edm::LogInfo("ForwardSim") << "ZdcSD: updates numbering scheme for " 
 			       << GetName();
     if (numberingScheme) delete numberingScheme;
@@ -424,7 +424,7 @@ void ZdcSD::setNumberingScheme(ZdcNumberingScheme* scheme) {
   }
 }
 
-int ZdcSD::setTrackID (G4Step* aStep) {
+int ZdcSD::setTrackID (const G4Step* aStep) {
   theTrack     = aStep->GetTrack();
   double etrack = preStepPoint->GetKineticEnergy();
   TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());

--- a/SimG4CMS/Forward/src/ZdcShowerLibrary.cc
+++ b/SimG4CMS/Forward/src/ZdcShowerLibrary.cc
@@ -16,7 +16,7 @@
 #include "Randomize.hh"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
-ZdcShowerLibrary::ZdcShowerLibrary(std::string & name, const DDCompactView & cpv,
+ZdcShowerLibrary::ZdcShowerLibrary(const std::string & name, const DDCompactView & cpv,
 				 edm::ParameterSet const & p) {
   edm::ParameterSet m_HS   = p.getParameter<edm::ParameterSet>("ZdcShowerLibrary");
   verbose                  = m_HS.getUntrackedParameter<int>("Verbosity",0);
@@ -60,10 +60,10 @@ std::vector<ZdcShowerLibrary::Hit> & ZdcShowerLibrary::getHits(G4Step * aStep, b
   G4Track *     track    = aStep->GetTrack();
 
   const G4DynamicParticle *aParticle = track->GetDynamicParticle();
-  G4ThreeVector momDir = aParticle->GetMomentumDirection();
+  const G4ThreeVector& momDir = aParticle->GetMomentumDirection();
   double energy = preStepPoint->GetKineticEnergy();
   G4ThreeVector hitPoint = preStepPoint->GetPosition();  
-  G4ThreeVector hitPointOrig = preStepPoint->GetPosition();
+  const G4ThreeVector& hitPointOrig = preStepPoint->GetPosition();
   G4int parCode  = track->GetDefinition()->GetPDGEncoding();
 
   hits.clear();

--- a/SimG4CMS/HGCalTestBeam/interface/AHCalSD.h
+++ b/SimG4CMS/HGCalTestBeam/interface/AHCalSD.h
@@ -13,16 +13,16 @@ class AHCalSD : public CaloSD {
 
 public:    
 
-  AHCalSD(G4String , const DDCompactView &, const SensitiveDetectorCatalog &,
+  AHCalSD(const G4String& , const DDCompactView &, const SensitiveDetectorCatalog &,
 	  edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~AHCalSD();
-  virtual double                getEnergyDeposit(G4Step* );
-  virtual uint32_t              setDetUnitId(G4Step* step);
+  ~AHCalSD() override;
+  double                getEnergyDeposit(G4Step* ) override;
+  uint32_t              setDetUnitId(const G4Step* step) override;
   bool                          unpackIndex(const uint32_t & idx, int & row, 
 					    int& col, int& depth);
 protected:
 
-  virtual bool                  filterHit(CaloG4Hit*, double);
+  bool                  filterHit(CaloG4Hit*, double) override;
 
 private:    
 

--- a/SimG4CMS/HGCalTestBeam/interface/HGCalTB16SD01.h
+++ b/SimG4CMS/HGCalTestBeam/interface/HGCalTB16SD01.h
@@ -20,12 +20,12 @@ class HGCalTB16SD01 : public CaloSD {
 
 public:    
 
-  HGCalTB16SD01(G4String , const DDCompactView &, 
+  HGCalTB16SD01(const G4String& , const DDCompactView &, 
 		const SensitiveDetectorCatalog &, edm::ParameterSet const &, 
 		const SimTrackManager*);
-  virtual ~HGCalTB16SD01();
-  virtual double   getEnergyDeposit(G4Step* );
-  virtual uint32_t setDetUnitId(G4Step* step);
+  ~HGCalTB16SD01() override;
+  double   getEnergyDeposit(G4Step* ) override;
+  uint32_t setDetUnitId(const G4Step* step) override;
   static uint32_t  packIndex(int det, int lay, int x, int y);
   static void      unpackIndex(const uint32_t & idx, int& det, int& lay,
 			       int& x, int& y);

--- a/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
+++ b/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
@@ -61,7 +61,6 @@ uint32_t AHCalSD::setDetUnitId(const G4Step * aStep) {
 
   G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();
-  const G4ThreeVector& hitPoint    = preStepPoint->GetPosition();
 
   int depth = (touch->GetReplicaNumber(1));
   int incol = ((touch->GetReplicaNumber(0))%10);

--- a/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
+++ b/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
@@ -17,7 +17,7 @@
 #include <iomanip>
 //#define EDM_ML_DEBUG
 
-AHCalSD::AHCalSD(G4String name, const DDCompactView & cpv,
+AHCalSD::AHCalSD(const G4String& name, const DDCompactView & cpv,
 		 const SensitiveDetectorCatalog & clg,
 		 edm::ParameterSet const & p, const SimTrackManager* manager) : 
   CaloSD(name, cpv, clg, p, manager,
@@ -57,11 +57,11 @@ double AHCalSD::getEnergyDeposit(G4Step* aStep) {
   return edep;
 }
 
-uint32_t AHCalSD::setDetUnitId(G4Step * aStep) { 
+uint32_t AHCalSD::setDetUnitId(const G4Step * aStep) { 
 
   G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();
-  G4ThreeVector hitPoint    = preStepPoint->GetPosition();
+  const G4ThreeVector& hitPoint    = preStepPoint->GetPosition();
 
   int depth = (touch->GetReplicaNumber(1));
   int incol = ((touch->GetReplicaNumber(0))%10);

--- a/SimG4CMS/HGCalTestBeam/src/HGCalTB16SD01.cc
+++ b/SimG4CMS/HGCalTestBeam/src/HGCalTB16SD01.cc
@@ -21,7 +21,7 @@
 
 //#define EDM_ML_DEBUG
 
-HGCalTB16SD01::HGCalTB16SD01(G4String name, const DDCompactView & cpv,
+HGCalTB16SD01::HGCalTB16SD01(const G4String& name, const DDCompactView & cpv,
 			     const SensitiveDetectorCatalog & clg,
 			     edm::ParameterSet const & p, 
 			     const SimTrackManager* manager) : 
@@ -63,7 +63,7 @@ double HGCalTB16SD01::getEnergyDeposit(G4Step* aStep) {
   return weight*destep;
 }
 
-uint32_t HGCalTB16SD01::setDetUnitId(G4Step * aStep) { 
+uint32_t HGCalTB16SD01::setDetUnitId(const G4Step * aStep) { 
 
   G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB02SD.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB02SD.h
@@ -29,11 +29,11 @@
 class HcalTB02SD : public CaloSD {
 
 public:
-  HcalTB02SD(G4String, const DDCompactView &, const SensitiveDetectorCatalog &,
+  HcalTB02SD(const G4String&, const DDCompactView &, const SensitiveDetectorCatalog &,
 	     edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~HcalTB02SD();
-  virtual double getEnergyDeposit(G4Step*);
-  virtual uint32_t setDetUnitId(G4Step* step);
+  ~HcalTB02SD() override;
+  double getEnergyDeposit(G4Step*) override;
+  uint32_t setDetUnitId(const G4Step* step) override;
   void setNumberingScheme(HcalTB02NumberingScheme* scheme);
 
 private:    

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB06BeamSD.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB06BeamSD.h
@@ -26,12 +26,12 @@ public:
 		 edm::ParameterSet const &, const SimTrackManager*);
   ~HcalTB06BeamSD() override;
   double getEnergyDeposit(G4Step* ) override;
-  uint32_t setDetUnitId(G4Step* step) override;
+  uint32_t setDetUnitId(const G4Step* step) override;
 
 private:    
 
   std::vector<G4String> getNames(DDFilteredView&);
-  bool                  isItWireChamber(G4String);
+  bool                  isItWireChamber(const G4String&);
 
   bool                  useBirk;
   double                birk1, birk2, birk3;

--- a/SimG4CMS/HcalTestBeam/src/HcalTB02SD.cc
+++ b/SimG4CMS/HcalTestBeam/src/HcalTB02SD.cc
@@ -33,11 +33,11 @@
 // constructors and destructor
 //
 
-HcalTB02SD::HcalTB02SD(G4String name, const DDCompactView & cpv,
+HcalTB02SD::HcalTB02SD(const G4String& name, const DDCompactView & cpv,
 		       const SensitiveDetectorCatalog & clg,
 		       edm::ParameterSet const & p, 
 		       const SimTrackManager* manager) : 
-  CaloSD(name, cpv, clg, p, manager), numberingScheme(0) {
+  CaloSD(name, cpv, clg, p, manager), numberingScheme(nullptr) {
   
   edm::ParameterSet m_SD = p.getParameter<edm::ParameterSet>("HcalTB02SD");
   useBirk= m_SD.getUntrackedParameter<bool>("UseBirkLaw",false);
@@ -46,7 +46,7 @@ HcalTB02SD::HcalTB02SD(G4String name, const DDCompactView & cpv,
   birk3  = m_SD.getUntrackedParameter<double>("BirkC3",1.75);
   useWeight= true;
 
-  HcalTB02NumberingScheme* scheme=0;
+  HcalTB02NumberingScheme* scheme=nullptr;
   if      (name == "EcalHitsEB") {
     scheme = dynamic_cast<HcalTB02NumberingScheme*>(new HcalTB02XtalNumberingScheme());
     useBirk = false;
@@ -86,7 +86,7 @@ HcalTB02SD::~HcalTB02SD() {
  
 double HcalTB02SD::getEnergyDeposit(G4Step * aStep) {
   
-  if (aStep == NULL) {
+  if (aStep == nullptr) {
     return 0;
   } else {
     preStepPoint        = aStep->GetPreStepPoint();
@@ -104,12 +104,12 @@ double HcalTB02SD::getEnergyDeposit(G4Step * aStep) {
   } 
 }
 
-uint32_t HcalTB02SD::setDetUnitId(G4Step * aStep) { 
-  return (numberingScheme == 0 ? 0 : (uint32_t)(numberingScheme->getUnitID(aStep)));
+uint32_t HcalTB02SD::setDetUnitId(const G4Step * aStep) { 
+  return (numberingScheme == nullptr ? 0 : (uint32_t)(numberingScheme->getUnitID(aStep)));
 }
 
 void HcalTB02SD::setNumberingScheme(HcalTB02NumberingScheme* scheme) {
-  if (scheme != 0) {
+  if (scheme != nullptr) {
     edm::LogInfo("HcalTBSim") << "HcalTB02SD: updates numbering scheme for " 
 			      << GetName();
     if (numberingScheme) delete numberingScheme;

--- a/SimG4CMS/HcalTestBeam/src/HcalTB06BeamSD.cc
+++ b/SimG4CMS/HcalTestBeam/src/HcalTB06BeamSD.cc
@@ -107,7 +107,7 @@ double HcalTB06BeamSD::getEnergyDeposit(G4Step* aStep) {
   return weight*destep;
 }
 
-uint32_t HcalTB06BeamSD::setDetUnitId(G4Step * aStep) { 
+uint32_t HcalTB06BeamSD::setDetUnitId(const G4Step * aStep) { 
 
   G4StepPoint* preStepPoint = aStep->GetPreStepPoint(); 
   const G4VTouchable* touch = preStepPoint->GetTouchable();
@@ -144,7 +144,7 @@ std::vector<G4String> HcalTB06BeamSD::getNames(DDFilteredView& fv) {
   return tmp;
 }
  
-bool HcalTB06BeamSD::isItWireChamber (G4String name) {
+bool HcalTB06BeamSD::isItWireChamber (const G4String& name) {
  
   std::vector<G4String>::const_iterator it = wcNames.begin();
   for (; it != wcNames.end(); it++)

--- a/SimG4CMS/Muon/interface/MuonSensitiveDetector.h
+++ b/SimG4CMS/Muon/interface/MuonSensitiveDetector.h
@@ -49,25 +49,23 @@ public Observer<const EndOfEvent*>
  {
 
  public:    
-  MuonSensitiveDetector(std::string, const DDCompactView &,
+  MuonSensitiveDetector(const std::string&, const DDCompactView &,
 			const SensitiveDetectorCatalog &, edm::ParameterSet const &,
 			const SimTrackManager*);
-  virtual ~MuonSensitiveDetector();
-  virtual G4bool ProcessHits(G4Step *,G4TouchableHistory *);
-  virtual uint32_t setDetUnitId(G4Step *);
-  virtual void EndOfEvent(G4HCofThisEvent*);
+  ~MuonSensitiveDetector() override;
+  G4bool ProcessHits(G4Step *,G4TouchableHistory *) override;
+  uint32_t setDetUnitId(const G4Step *) override;
+  void EndOfEvent(G4HCofThisEvent*) override;
 
-  void fillHits(edm::PSimHitContainer&, std::string use);
-  std::vector<std::string> getNames();
-  std::string type();
+  void fillHits(edm::PSimHitContainer&, const std::string& use) override;
 
   const MuonSlaveSD* GetSlaveMuon() const {
     return slaveMuon; }
   
  private:
-  void update(const BeginOfEvent *);
-  void update(const ::EndOfEvent *);
-  virtual void clearHits();
+  void update(const BeginOfEvent *) override;
+  void update(const ::EndOfEvent *) override;
+  void clearHits() override;
 
   Local3DPoint toOrcaRef(Local3DPoint in ,G4Step * s);
   Local3DPoint toOrcaUnits(Local3DPoint);

--- a/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
@@ -29,13 +29,13 @@
 
 #include <iostream>
 
-MuonSensitiveDetector::MuonSensitiveDetector(std::string name, 
+MuonSensitiveDetector::MuonSensitiveDetector(const std::string& name, 
 					     const DDCompactView & cpv,
 					     const SensitiveDetectorCatalog & clg,
 					     edm::ParameterSet const & p,
 					     const SimTrackManager* manager) 
   : SensitiveTkDetector(name, cpv, clg, p),
-    thePV(0), theHit(0), theDetUnitId(0), theTrackID(0), theManager(manager)
+    thePV(nullptr), theHit(nullptr), theDetUnitId(0), theTrackID(0), theManager(manager)
 {
   edm::ParameterSet m_MuonSD = p.getParameter<edm::ParameterSet>("MuonSD");
   STenergyPersistentCut = m_MuonSD.getParameter<double>("EnergyThresholdForPersistency");//Default 1. GeV
@@ -67,7 +67,7 @@ MuonSensitiveDetector::MuonSensitiveDetector(std::string name,
     //    cout << "MuonFrameRotation create MuonME0FrameRotation"<<endl;
     theRotation=new MuonME0FrameRotation( constants );
   }  else {
-    theRotation = 0;
+    theRotation = nullptr;
   }
   LogDebug("MuonSimDebug") << "create MuonSlaveSD"<<std::endl;
   slaveMuon  = new MuonSlaveSD(detector,theManager);
@@ -115,7 +115,7 @@ void MuonSensitiveDetector::update(const BeginOfEvent * i){
   clearHits();
 
   //----- Initialize variables to check if two steps belong to same hit
-  thePV = 0;
+  thePV = nullptr;
   theDetUnitId = 0;
   theTrackID = 0;
 
@@ -158,7 +158,7 @@ bool MuonSensitiveDetector::ProcessHits(G4Step * aStep, G4TouchableHistory * ROh
   return false;
 }
 
-uint32_t MuonSensitiveDetector::setDetUnitId(G4Step * aStep)
+uint32_t MuonSensitiveDetector::setDetUnitId(const G4Step * aStep)
 { 
   //  G4VPhysicalVolume * pv = aStep->GetPreStepPoint()->GetPhysicalVolume();
   MuonBaseNumber num = g4numbering->PhysicalVolumeToBaseNumber(aStep);
@@ -180,7 +180,7 @@ uint32_t MuonSensitiveDetector::setDetUnitId(G4Step * aStep)
 
 
 Local3DPoint MuonSensitiveDetector::toOrcaRef(Local3DPoint in ,G4Step * s){
-  if (theRotation !=0 ) {
+  if (theRotation !=nullptr ) {
     return theRotation->transformPoint(in,s);
   }
   return (in);
@@ -340,7 +340,7 @@ void MuonSensitiveDetector::updateHit(G4Step * aStep){
 
   float theEnergyLoss = aStep->GetTotalEnergyDeposit()/GeV;  
 
-  if( theHit == 0 ){ 
+  if( theHit == nullptr ){ 
     std::cerr << "!!ERRROR in MuonSensitiveDetector::updateHit. It is called when there is no hit " << std::endl;
   }
 
@@ -380,7 +380,7 @@ void MuonSensitiveDetector::saveHit(){
     // seems the hit does not want to be deleted
     // done by the hit collection?
     delete theHit;
-    theHit = 0; //set it to 0, because you are checking that is 0
+    theHit = nullptr; //set it to 0, because you are checking that is 0
   }
 
 }
@@ -388,12 +388,12 @@ void MuonSensitiveDetector::saveHit(){
 TrackInformation* MuonSensitiveDetector::getOrCreateTrackInformation( const G4Track* gTrack)
 {
   G4VUserTrackInformation* temp = gTrack->GetUserInformation();
-  if (temp == 0){
+  if (temp == nullptr){
     std::cerr <<" ERROR: no G4VUserTrackInformation available"<<std::endl;
     abort();
   }else{
     TrackInformation* info = dynamic_cast<TrackInformation*>(temp);
-    if (info ==0){
+    if (info ==nullptr){
       std::cerr <<" ERROR: TkSimTrackSelection: the UserInformation does not appear to be a TrackInformation"<<std::endl;
       abort();
     }
@@ -409,7 +409,7 @@ void MuonSensitiveDetector::EndOfEvent(G4HCofThisEvent*)
 }
 
 
-void MuonSensitiveDetector::fillHits(edm::PSimHitContainer& c, std::string n){
+void MuonSensitiveDetector::fillHits(edm::PSimHitContainer& c, const std::string& n){
   //
   // do it once for low, once for High
   //
@@ -418,16 +418,10 @@ void MuonSensitiveDetector::fillHits(edm::PSimHitContainer& c, std::string n){
 
 }
 
-std::vector<std::string> MuonSensitiveDetector::getNames(){
-  std::vector<std::string> temp;
-  temp.push_back(slaveMuon->name());
-  return temp;
-}
-
 Local3DPoint MuonSensitiveDetector::InitialStepPositionVsParent(G4Step * currentStep, G4int levelsUp) {
   
   G4StepPoint * preStepPoint = currentStep->GetPreStepPoint();
-  G4ThreeVector globalCoordinates = preStepPoint->GetPosition();
+  const G4ThreeVector& globalCoordinates = preStepPoint->GetPosition();
   
   const G4TouchableHistory * theTouchable=(const G4TouchableHistory *)
     (preStepPoint->GetTouchable());
@@ -443,7 +437,7 @@ Local3DPoint MuonSensitiveDetector::FinalStepPositionVsParent(G4Step * currentSt
   
   G4StepPoint * postStepPoint = currentStep->GetPostStepPoint();
   G4StepPoint * preStepPoint  = currentStep->GetPreStepPoint();
-  G4ThreeVector globalCoordinates = postStepPoint->GetPosition();
+  const G4ThreeVector& globalCoordinates = postStepPoint->GetPosition();
     
   const G4TouchableHistory * theTouchable = (const G4TouchableHistory *)
     (preStepPoint->GetTouchable());

--- a/SimG4CMS/ShowerLibraryProducer/interface/FiberSD.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/FiberSD.h
@@ -31,27 +31,26 @@ class FiberSD : public SensitiveCaloDetector,
 
 public:
 
-  FiberSD(std::string, const DDCompactView&, const SensitiveDetectorCatalog&,
+  FiberSD(const std::string&, const DDCompactView&, const SensitiveDetectorCatalog&,
 	  edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~FiberSD();
+  ~FiberSD() override;
 
-  virtual void     Initialize(G4HCofThisEvent*HCE);
-  virtual G4bool   ProcessHits(G4Step* aStep,G4TouchableHistory* ROhist);
-  virtual void     EndOfEvent(G4HCofThisEvent* HCE);
-  virtual void     clear();
-  virtual void     DrawAll();
-  virtual void     PrintAll();
+  void     Initialize(G4HCofThisEvent*HCE) override;
+  G4bool   ProcessHits(G4Step* aStep,G4TouchableHistory* ROhist) override;
+  uint32_t setDetUnitId(const G4Step*) override;
+  void     EndOfEvent(G4HCofThisEvent* HCE) override;
+  void     clear() override;
+  void     DrawAll() override;
+  void     PrintAll() override;
 
 protected:
 
-  virtual void     clearHits();
-  virtual uint32_t setDetUnitId(G4Step*);
-  virtual void     fillHits(edm::PCaloHitContainer&, std::string);
+  void     clearHits() override;
 
-  virtual void     update(const BeginOfJob *);
-  virtual void     update(const BeginOfRun *);
-  virtual void     update(const BeginOfEvent *);
-  virtual void     update(const ::EndOfEvent *);
+  void     update(const BeginOfJob *) override;
+  void     update(const BeginOfRun *) override;
+  void     update(const BeginOfEvent *) override;
+  void     update(const ::EndOfEvent *) override;
 
 private:
 

--- a/SimG4CMS/ShowerLibraryProducer/interface/HFChamberSD.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/HFChamberSD.h
@@ -20,22 +20,21 @@ class HFChamberSD : public SensitiveCaloDetector {
 
 public:
 
-  HFChamberSD(std::string, const DDCompactView&, const SensitiveDetectorCatalog&,
+  HFChamberSD(const std::string&, const DDCompactView&, const SensitiveDetectorCatalog&,
 	  edm::ParameterSet const &, const SimTrackManager*);
-  virtual ~HFChamberSD();
+  ~HFChamberSD() override;
 
-  virtual void     Initialize(G4HCofThisEvent*HCE);
-  virtual G4bool   ProcessHits(G4Step* aStep,G4TouchableHistory* ROhist);
-  virtual void     EndOfEvent(G4HCofThisEvent* HCE);
-  virtual void     clear();
-  virtual void     DrawAll();
-  virtual void     PrintAll();
+  void     Initialize(G4HCofThisEvent*HCE) override;
+  G4bool   ProcessHits(G4Step* aStep,G4TouchableHistory* ROhist) override;
+  uint32_t setDetUnitId(const G4Step*) override;
+  void     EndOfEvent(G4HCofThisEvent* HCE) override;
+  void     clear() override;
+  void     DrawAll() override;
+  void     PrintAll() override;
 
 protected:
 
-  virtual void     clearHits();
-  virtual uint32_t setDetUnitId(G4Step*);
-  virtual void     fillHits(edm::PCaloHitContainer&, std::string);
+  void     clearHits() override;
 
 private:
 

--- a/SimG4CMS/ShowerLibraryProducer/interface/HFWedgeSD.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/HFWedgeSD.h
@@ -23,17 +23,18 @@ class HFWedgeSD : public SensitiveCaloDetector {
 
 public:    
   
-  HFWedgeSD(std::string name, const DDCompactView & cpv,
+  HFWedgeSD(const std::string& name, const DDCompactView & cpv,
 	    const SensitiveDetectorCatalog & clg,
 	    edm::ParameterSet const & p, const SimTrackManager*);
-  virtual ~HFWedgeSD();
+  ~HFWedgeSD() override;
   
-  virtual void     Initialize(G4HCofThisEvent * HCE);
-  virtual bool     ProcessHits(G4Step * step,G4TouchableHistory * tHistory);
-  virtual void     EndOfEvent(G4HCofThisEvent * eventHC);
-  virtual void     clear();
-  virtual void     DrawAll();
-  virtual void     PrintAll();
+  void     Initialize(G4HCofThisEvent * HCE) override;
+  bool     ProcessHits(G4Step * step,G4TouchableHistory * tHistory) override;
+  uint32_t setDetUnitId(const G4Step*) override;
+  void     EndOfEvent(G4HCofThisEvent * eventHC) override;
+  void     clear() override;
+  void     DrawAll() override;
+  void     PrintAll() override;
 
 protected:
 
@@ -41,10 +42,7 @@ protected:
   HFShowerG4Hit*   createNewHit();
   void             updateHit(HFShowerG4Hit*);
 
-  virtual void     clearHits();
-  virtual uint32_t setDetUnitId(G4Step*);
-  virtual void     fillHits(edm::PCaloHitContainer&, std::string);
-
+  void     clearHits() override;
 
 private:
 

--- a/SimG4CMS/ShowerLibraryProducer/src/FiberSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/FiberSD.cc
@@ -18,11 +18,11 @@
 #include "G4SDManager.hh"
 #include "G4ios.hh"
 
-FiberSD::FiberSD(std::string name, const DDCompactView & cpv, 
+FiberSD::FiberSD(const std::string& name, const DDCompactView & cpv, 
 		 const SensitiveDetectorCatalog & clg, edm::ParameterSet const & p,
 		 const SimTrackManager* manager) :
   SensitiveCaloDetector(name, cpv, clg, p), theName(name),
-  m_trackManager(manager), theHCID(-1), theHC(0) {
+  m_trackManager(manager), theHCID(-1), theHC(nullptr) {
 
   collectionName.insert(name);
   LogDebug("FiberSim") << "***************************************************"
@@ -71,7 +71,7 @@ G4bool FiberSD::ProcessHits(G4Step * aStep, G4TouchableHistory*) {
   std::vector<HFShower::Hit> hits = theShower->getHits(aStep,true,zoffset);
 
   
-  if (hits.size() > 0) {
+  if (!hits.empty()) {
     std::vector<HFShowerPhoton> thePE;
     for (unsigned int i=0; i<hits.size(); i++) {
       //std::cout<<"hit position z "<<hits[i].position.z()<<std::endl;
@@ -135,7 +135,7 @@ void FiberSD::update(const BeginOfJob * job) {
   es->get<HcalSimNumberingRecord>().get(hdc);
   if (hdc.isValid()) {
     HcalDDDSimConstants *hcalConstants = (HcalDDDSimConstants*)(&(*hdc));
-    theShower->initRun(0, hcalConstants);
+    theShower->initRun(nullptr, hcalConstants);
   } else {
     edm::LogError("HcalSim") << "HCalSD : Cannot find HcalDDDSimConstant";
     throw cms::Exception("Unknown", "HCalSD") << "Cannot find HcalDDDSimConstant" << "\n";
@@ -151,12 +151,10 @@ void FiberSD::update(const ::EndOfEvent *) {}
 
 void FiberSD::clearHits() {}
 
-uint32_t FiberSD::setDetUnitId(G4Step* aStep) {
+uint32_t FiberSD::setDetUnitId(const G4Step* aStep) {
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   int fibre = (touch->GetReplicaNumber(1))%10;
   int cell  = (touch->GetReplicaNumber(2));
   int tower = (touch->GetReplicaNumber(3));
   return ((tower*1000+cell)*10+fibre);
 }
-
-void FiberSD::fillHits(edm::PCaloHitContainer&, std::string) {}

--- a/SimG4CMS/ShowerLibraryProducer/src/HFChamberSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/HFChamberSD.cc
@@ -16,11 +16,11 @@
 #include "G4PhysicalConstants.hh"
 #include "G4SystemOfUnits.hh"
 
-HFChamberSD::HFChamberSD(std::string name, const DDCompactView & cpv,
+HFChamberSD::HFChamberSD(const std::string& name, const DDCompactView & cpv,
 		 const SensitiveDetectorCatalog & clg, edm::ParameterSet const & p,
 		 const SimTrackManager* manager) :
   SensitiveCaloDetector(name, cpv, clg, p), theName(name),
-  m_trackManager(manager), theHCID(-1), theHC(0), theNSteps(0) {
+  m_trackManager(manager), theHCID(-1), theHC(nullptr), theNSteps(0) {
 
   collectionName.insert(name);
   LogDebug("FiberSim") << "***************************************************"
@@ -63,7 +63,7 @@ G4bool HFChamberSD::ProcessHits(G4Step * aStep, G4TouchableHistory*) {
   //do not process hits other than primary particle hits:
   double charge = aStep->GetTrack()->GetDefinition()->GetPDGCharge();
   int trackID = aStep->GetTrack()->GetTrackID();
-  if(charge == 0. || trackID != 1 ||aStep->GetTrack()->GetParentID() != 0 || aStep->GetTrack()->GetCreatorProcess() != NULL) return false;
+  if(charge == 0. || trackID != 1 ||aStep->GetTrack()->GetParentID() != 0 || aStep->GetTrack()->GetCreatorProcess() != nullptr) return false;
   ++theNSteps;
   //if(theNSteps>1)return false;
 
@@ -74,10 +74,10 @@ G4bool HFChamberSD::ProcessHits(G4Step * aStep, G4TouchableHistory*) {
   double edep = aStep->GetTotalEnergyDeposit();
   double time = (preStepPoint->GetGlobalTime())/ns;
 
-  G4ThreeVector globalPos = preStepPoint->GetPosition();
+  const G4ThreeVector& globalPos = preStepPoint->GetPosition();
   G4ThreeVector localPos  = touch->GetHistory()->GetTopTransform().TransformPoint(globalPos);
   const G4DynamicParticle* particle =  aStep->GetTrack()->GetDynamicParticle();
-  G4ThreeVector momDir   = particle->GetMomentumDirection();
+  const G4ThreeVector& momDir   = particle->GetMomentumDirection();
 
   HFShowerG4Hit *aHit = new HFShowerG4Hit(detID, trackID, edep, time);
   aHit->setLocalPos(localPos);
@@ -111,9 +111,8 @@ void HFChamberSD::PrintAll() {}
 
 void HFChamberSD::clearHits() {}
 
-uint32_t HFChamberSD::setDetUnitId(G4Step* aStep) {
+uint32_t HFChamberSD::setDetUnitId(const G4Step* aStep) {
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   return (touch->GetReplicaNumber(0));
 }
 
-void HFChamberSD::fillHits(edm::PCaloHitContainer&, std::string) {}

--- a/SimG4CMS/ShowerLibraryProducer/src/HFWedgeSD.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/HFWedgeSD.cc
@@ -16,11 +16,11 @@
 #include "G4PhysicalConstants.hh"
 #include "G4SystemOfUnits.hh"
 
-HFWedgeSD::HFWedgeSD(std::string name, const DDCompactView & cpv, 
+HFWedgeSD::HFWedgeSD(const std::string& name, const DDCompactView & cpv, 
 		 const SensitiveDetectorCatalog & clg, edm::ParameterSet const & p,
 		 const SimTrackManager* manager) :
   SensitiveCaloDetector(name, cpv, clg, p), theName(name),
-  m_trackManager(manager), hcID(-1), theHC(0), currentHit(0) {
+  m_trackManager(manager), hcID(-1), theHC(nullptr), currentHit(nullptr) {
 
   collectionName.insert(name);
   LogDebug("FiberSim") << "***************************************************"
@@ -145,9 +145,8 @@ void HFWedgeSD::clearHits() {
   previousID = -1;
 }
 
-uint32_t HFWedgeSD::setDetUnitId(G4Step* aStep) {
+uint32_t HFWedgeSD::setDetUnitId(const G4Step* aStep) {
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   return (touch->GetReplicaNumber(0));
 }
 
-void HFWedgeSD::fillHits(edm::PCaloHitContainer&, std::string) {}

--- a/SimG4CMS/Tracker/interface/TkAccumulatingSensitiveDetector.h
+++ b/SimG4CMS/Tracker/interface/TkAccumulatingSensitiveDetector.h
@@ -34,18 +34,17 @@ public Observer<const BeginOfTrack*>,
 public Observer<const BeginOfJob*>
 { 
 public:    
-    TkAccumulatingSensitiveDetector(std::string, const DDCompactView &,
+    TkAccumulatingSensitiveDetector(const std::string&, const DDCompactView &,
 				    const SensitiveDetectorCatalog &,
 				    edm::ParameterSet const &,
 				    const SimTrackManager*);
-    virtual ~TkAccumulatingSensitiveDetector();
-    virtual bool ProcessHits(G4Step *,G4TouchableHistory *);
-    virtual uint32_t setDetUnitId(G4Step*);
-    virtual void EndOfEvent(G4HCofThisEvent*);
+    ~TkAccumulatingSensitiveDetector() override;
+    bool ProcessHits(G4Step *,G4TouchableHistory *) override;
+    uint32_t setDetUnitId(const G4Step*) override;
+    void EndOfEvent(G4HCofThisEvent*) override;
 
-    void fillHits(edm::PSimHitContainer&, std::string use);
-    std::vector<std::string> getNames();
-    std::string type();
+    void fillHits(edm::PSimHitContainer&, const std::string& use) override;
+    std::vector<std::string> getNames() override;
 
 private:
     virtual void sendHit();
@@ -54,10 +53,10 @@ private:
     virtual bool closeHit(G4Step *);
     virtual void createHit(G4Step *);
     void checkExitPoint(Local3DPoint);
-    void update(const BeginOfEvent *);
-    void update(const BeginOfTrack *);
-    void update(const BeginOfJob *);
-    virtual void clearHits();
+    void update(const BeginOfEvent *) override;
+    void update(const BeginOfTrack *) override;
+    void update(const BeginOfJob *) override;
+    void clearHits() override;
     Local3DPoint toOrcaRef(Local3DPoint ,G4VPhysicalVolume *);
     int tofBin(float);
     std::string myName; 

--- a/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
+++ b/SimG4CMS/Tracker/src/TkAccumulatingSensitiveDetector.cc
@@ -61,14 +61,14 @@ numberingScheme(const DDCompactView& cpv, const GeometricDet& det)
 }
 
 
-TkAccumulatingSensitiveDetector::TkAccumulatingSensitiveDetector(string name, 
+TkAccumulatingSensitiveDetector::TkAccumulatingSensitiveDetector(const std::string& name, 
 								 const DDCompactView & cpv,
 								 const SensitiveDetectorCatalog & clg,
 								 edm::ParameterSet const & p,
 								 const SimTrackManager* manager) : 
-  SensitiveTkDetector(name, cpv, clg, p), myName(name), myRotation(0),  mySimHit(0),theManager(manager),
-   oldVolume(0), lastId(0), lastTrack(0), eventno(0) ,rTracker(1200.*mm),zTracker(3000.*mm),
-   numberingScheme_(0)
+  SensitiveTkDetector(name, cpv, clg, p), myName(name), myRotation(nullptr),  mySimHit(nullptr),theManager(manager),
+   oldVolume(nullptr), lastId(0), lastTrack(0), eventno(0) ,rTracker(1200.*mm),zTracker(3000.*mm),
+   numberingScheme_(nullptr)
 {
    
   edm::ParameterSet m_TrackerSD = p.getParameter<edm::ParameterSet>("TrackerSD");
@@ -91,7 +91,7 @@ TkAccumulatingSensitiveDetector::TkAccumulatingSensitiveDetector(string name,
       myRotation = new TrackerFrameRotation;
     }
   // Just in case (test beam etc)
-  if (myRotation == 0) 
+  if (myRotation == nullptr) 
     {
       edm::LogInfo("TrackerSimInfo")<<" TkAccumulatingSensitiveDetector: using StandardFrameRotation for "<<myName;
       myRotation = new StandardFrameRotation;
@@ -149,9 +149,9 @@ bool TkAccumulatingSensitiveDetector::ProcessHits(G4Step * aStep, G4TouchableHis
     return false;
 }
 
-uint32_t TkAccumulatingSensitiveDetector::setDetUnitId(G4Step * s)
+uint32_t TkAccumulatingSensitiveDetector::setDetUnitId(const G4Step * st)
 { 
- unsigned int detId = numberingScheme_->g4ToNumberingScheme(s->GetPreStepPoint()->GetTouchable());
+ unsigned int detId = numberingScheme_->g4ToNumberingScheme(st->GetPreStepPoint()->GetTouchable());
 
  LogDebug("TrackerSimDebug")<< " DetID = "<<detId; 
 
@@ -169,7 +169,7 @@ int TkAccumulatingSensitiveDetector::tofBin(float tof)
 
 Local3DPoint TkAccumulatingSensitiveDetector::toOrcaRef(Local3DPoint in ,G4VPhysicalVolume * v)
 {
-    if (myRotation !=0) return myRotation->transformPoint(in,v);
+    if (myRotation !=nullptr) return myRotation->transformPoint(in,v);
     return (in);
 }
 
@@ -226,7 +226,7 @@ void TkAccumulatingSensitiveDetector::update(const BeginOfTrack *bot){
 
 void TkAccumulatingSensitiveDetector::sendHit()
 {  
-    if (mySimHit == 0) return;
+    if (mySimHit == nullptr) return;
     LogDebug("TrackerSimDebug")<< " Storing PSimHit: " << pname << " " << mySimHit->detUnitId() 
 	 << " " << mySimHit->trackId() << " " << mySimHit->energyLoss() 
 	 << " " << mySimHit->entryPoint() << " " << mySimHit->exitPoint();
@@ -250,17 +250,17 @@ void TkAccumulatingSensitiveDetector::sendHit()
     //
     // clean up
     delete mySimHit;
-    mySimHit = 0;
+    mySimHit = nullptr;
     lastTrack = 0;
     lastId = 0;
 }
 
 void TkAccumulatingSensitiveDetector::createHit(G4Step * aStep)
 {
-    if (mySimHit != 0) 
+    if (mySimHit != nullptr) 
     {
 	delete mySimHit;
-	mySimHit=0;
+	mySimHit=nullptr;
     }
     
     G4Track * theTrack  = aStep->GetTrack(); 
@@ -313,11 +313,11 @@ void TkAccumulatingSensitiveDetector::createHit(G4Step * aStep)
 
     
     G4VUserTrackInformation * info = theTrack->GetUserInformation();
-    if (info == 0) edm::LogError("TrackerSimInfo")<< " Error: no UserInformation available ";
+    if (info == nullptr) edm::LogError("TrackerSimInfo")<< " Error: no UserInformation available ";
     else
       {
 	TrackInformation * temp = dynamic_cast<TrackInformation* >(info);
-	if (temp ==0) edm::LogError("TrackerSimInfo")<< " Error:G4VUserTrackInformation is not a TrackInformation.";
+	if (temp ==nullptr) edm::LogError("TrackerSimInfo")<< " Error:G4VUserTrackInformation is not a TrackInformation.";
         else {
           if (temp->storeTrack() == false) {
 	    // Go to the mother!
@@ -392,14 +392,14 @@ bool TkAccumulatingSensitiveDetector::newHit(G4Step * aStep)
     LogDebug("TrackerSimDebug")<< " OLD (d,t) = (" << lastId << "," << lastTrack 
 			       << "), new = (" << theDetUnitId << "," << theTrackID << ") return "
 			       << ((theTrackID == lastTrack) && (lastId == theDetUnitId));
-    if ((mySimHit != 0) && (theTrackID == lastTrack) && (lastId == theDetUnitId) && closeHit(aStep))
+    if ((mySimHit != nullptr) && (theTrackID == lastTrack) && (lastId == theDetUnitId) && closeHit(aStep))
       return false;
     return true;
 }
 
 bool TkAccumulatingSensitiveDetector::closeHit(G4Step * aStep)
 {
-    if (mySimHit == 0) return false; 
+    if (mySimHit == nullptr) return false; 
     const float tolerance = 0.05 * mm; // 50 micron are allowed between the exit 
     // point of the current hit and the entry point of the new hit
     G4VPhysicalVolume * v = aStep->GetPreStepPoint()->GetPhysicalVolume();
@@ -415,7 +415,7 @@ void TkAccumulatingSensitiveDetector::EndOfEvent(G4HCofThisEvent *)
 
   LogDebug("TrackerSimDebug")<< " Saving the last hit in a ROU " << myName;
 
-    if (mySimHit == 0) return;
+    if (mySimHit == nullptr) return;
       sendHit();
 }
 
@@ -423,7 +423,7 @@ void TkAccumulatingSensitiveDetector::update(const BeginOfEvent * i)
 {
     clearHits();
     eventno = (*i)()->GetEventID();
-    mySimHit = 0;
+    mySimHit = nullptr;
 }
 
 void TkAccumulatingSensitiveDetector::update(const BeginOfJob * i)
@@ -461,12 +461,12 @@ void TkAccumulatingSensitiveDetector::checkExitPoint(Local3DPoint p)
 
 TrackInformation* TkAccumulatingSensitiveDetector::getOrCreateTrackInformation( const G4Track* gTrack){
   G4VUserTrackInformation* temp = gTrack->GetUserInformation();
-  if (temp == 0){
+  if (temp == nullptr){
     edm::LogError("TrackerSimInfo") <<" ERROR: no G4VUserTrackInformation available";
     abort();
   }else{
     TrackInformation* info = dynamic_cast<TrackInformation*>(temp);
-    if (info ==0){
+    if (info ==nullptr){
       edm::LogError("TrackerSimInfo")<<" ERROR: TkSimTrackSelection: the UserInformation does not appear to be a TrackInformation";
       abort();
     }
@@ -474,7 +474,7 @@ TrackInformation* TkAccumulatingSensitiveDetector::getOrCreateTrackInformation( 
   }
 }
 
-void TkAccumulatingSensitiveDetector::fillHits(edm::PSimHitContainer& c, std::string n){
+void TkAccumulatingSensitiveDetector::fillHits(edm::PSimHitContainer& c, const std::string& n){
   //
   // do it once for low, once for High
   //

--- a/SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h
@@ -14,7 +14,7 @@ public:
 			const SensitiveDetectorCatalog & clg,
 			edm::ParameterSet const & p) :
   SensitiveDetector(iname,cpv,clg,p) {}
-  virtual void fillHits(edm::PCaloHitContainer &, std::string& hitnam) {};
+  virtual void fillHits(edm::PCaloHitContainer &, const std::string& hitnam) {};
 };
 
 #endif

--- a/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveDetector.h
@@ -28,7 +28,7 @@ public:
   void Initialize(G4HCofThisEvent * eventHC) override;
   virtual void clearHits() = 0;
   G4bool ProcessHits(G4Step * step ,G4TouchableHistory * tHistory) override = 0;
-  virtual uint32_t setDetUnitId(G4Step * step) = 0;
+  virtual uint32_t setDetUnitId(const G4Step * step) = 0;
   void Register();
   void AssignSD(const std::string & vname);
   void EndOfEvent(G4HCofThisEvent * eventHC) override; 

--- a/SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h
+++ b/SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h
@@ -10,11 +10,11 @@
 class SensitiveTkDetector : public SensitiveDetector
 {
 public:
-    SensitiveTkDetector(std::string & iname, const DDCompactView & cpv,
+    SensitiveTkDetector(const std::string & iname, const DDCompactView & cpv,
 			const SensitiveDetectorCatalog & clg,
 			edm::ParameterSet const & p) : 
       SensitiveDetector(iname, cpv, clg, p) {}
-    virtual void fillHits(edm::PSimHitContainer &, std::string name = 0) = 0;
+    virtual void fillHits(edm::PSimHitContainer &, const std::string& nam) = 0;
 };
 
 #endif


### PR DESCRIPTION
Clean-up of CMS Sensitive detectors classes:
  - const interfaces to G4Step and G4Track where possible;
  - use strings in interfaces by const references;
  - code-checks applied;
  - removed commented lines and some blank lines.

No code improvement done, only clean-up of interfaces in order to be able to clean the code for sub-libraries separately. So, this is an intermediate step needed because in previous PR #20292 simulation history was changed, likely due to code improvement. 

No change in results is expected.