### PR TITLE
Fix --parent option in hltGetConfiguration script (93X)

### DIFF
--- a/HLTrigger/Configuration/python/Tools/confdb.py
+++ b/HLTrigger/Configuration/python/Tools/confdb.py
@@ -804,7 +804,7 @@ if 'GlobalTag' in %%(dict)s:
       files = dasFileQuery(dataset)
     else:
       # assume a comma-separated list of input files
-      files = self.config.input.split(',')
+      files = input.split(',')
     return files
 
   def build_source(self):


### PR DESCRIPTION
Fix --parent option in hltGetConfiguration script (93X).
Based on CMSSW_9_3_0_pre4
