### PR TITLE
limited:: module types

### DIFF
--- a/FWCore/Concurrency/interface/LimitedTaskQueue.h
+++ b/FWCore/Concurrency/interface/LimitedTaskQueue.h
@@ -65,7 +65,8 @@ namespace edm {
        */
       template<typename T>
       void pushAndWait(const T& iAction);
-      
+     
+     unsigned int concurrencyLimit() const { return m_queues.size(); }
    private:
       LimitedTaskQueue(const LimitedTaskQueue&) = delete;
       const LimitedTaskQueue& operator=(const LimitedTaskQueue&) = delete;

--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -35,6 +35,10 @@ namespace edm {
     class EDProducerBase;
     class EDFilterBase;
   }
+  namespace limited {
+    class EDProducerBase;
+    class EDFilterBase;
+  }
   namespace stream {
     template<typename T> class ProducingModuleAdaptorBase;
   }
@@ -86,6 +90,8 @@ namespace edm {
     friend class one::EDFilterBase;
     friend class global::EDProducerBase;
     friend class global::EDFilterBase;
+    friend class limited::EDProducerBase;
+    friend class limited::EDFilterBase;
     template<typename T> friend class stream::ProducingModuleAdaptorBase;
     
     template< typename P>

--- a/FWCore/Framework/interface/limited/EDAnalyzer.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzer.h
@@ -1,0 +1,62 @@
+#ifndef FWCore_Framework_limited_EDAnalyzer_h
+#define FWCore_Framework_limited_EDAnalyzer_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     edm::limited::EDAnalyzer
+// 
+/**\class edm::limited::EDAnalyzer EDAnalyzer.h "FWCore/Framework/interface/limited/EDAnalyzer.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 18 Jul 2013 11:51:07 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/limited/analyzerAbilityToImplementor.h"
+#include "FWCore/Framework/interface/moduleAbilities.h"
+
+// forward declarations
+
+namespace edm {
+  namespace limited {
+    template< typename... T>
+    class EDAnalyzer : public analyzer::AbilityToImplementor<T>::Type...,
+                       public virtual EDAnalyzerBase
+    {
+      
+    public:
+      EDAnalyzer() = default;
+// We do this only in the case of the intel compiler as this might
+// end up creating a lot of code bloat due to inline symbols being generated 
+// in each DSO which uses this header.
+#ifdef __INTEL_COMPILER
+      virtual ~EDAnalyzer() {}
+#endif
+      // ---------- const member functions ---------------------
+      
+      // ---------- static member functions --------------------
+      
+      // ---------- member functions ---------------------------
+      
+    private:
+      EDAnalyzer(const EDAnalyzer&) = delete;
+      
+      const EDAnalyzer& operator=(const EDAnalyzer&) = delete;
+      
+      // ---------- member data --------------------------------
+      
+    };
+
+  }
+}
+
+#endif

--- a/FWCore/Framework/interface/limited/EDAnalyzer.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzer.h
@@ -34,7 +34,7 @@ namespace edm {
     {
       
     public:
-      EDAnalyzer() = default;
+      EDAnalyzer(edm::ParameterSet const& iPSet) : EDAnalyzerBase(iPSet),analyzer::AbilityToImplementor<T>::Type(iPSet)...  {}
 // We do this only in the case of the intel compiler as this might
 // end up creating a lot of code bloat due to inline symbols being generated 
 // in each DSO which uses this header.

--- a/FWCore/Framework/interface/limited/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzerBase.h
@@ -5,7 +5,7 @@
 // Package:     FWCore/Framework
 // Class  :     EDAnalyzerBase
 // 
-/**\class EDAnalyzerBase EDAnalyzerBase.h "EDAnalyzerBase.h"
+/**\class limited::EDAnalyzerBase EDAnalyzerBase.h "EDAnalyzerBase.h"
 
  Description: [one line class summary]
 
@@ -25,6 +25,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/Concurrency/interface/LimitedTaskQueue.h"
 
 // forward declarations
 
@@ -51,8 +52,8 @@ namespace edm {
       template <typename T> friend class edm::maker::ModuleHolderT;
       typedef EDAnalyzerBase ModuleType;
 
-      EDAnalyzerBase();
-      virtual ~EDAnalyzerBase();
+      EDAnalyzerBase(ParameterSet const& pset);
+      ~EDAnalyzerBase() override;
 
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
       static void prevalidate(ConfigurationDescriptions& descriptions);
@@ -60,7 +61,12 @@ namespace edm {
 
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
+      
+      unsigned int concurrencyLimit() const { return queue_.concurrencyLimit(); }
 
+      LimitedTaskQueue& queue() {
+        return queue_;
+      }
     private:
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
@@ -140,6 +146,8 @@ namespace edm {
       ModuleDescription moduleDescription_;
 
       std::function<void(BranchDescription const&)> callWhenNewProductsRegistered_;
+      
+      LimitedTaskQueue queue_;
     };
 
   }

--- a/FWCore/Framework/interface/limited/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzerBase.h
@@ -1,0 +1,148 @@
+#ifndef FWCore_Framework_limited_EDAnalyzerBase_h
+#define FWCore_Framework_limited_EDAnalyzerBase_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     EDAnalyzerBase
+// 
+/**\class EDAnalyzerBase EDAnalyzerBase.h "EDAnalyzerBase.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 18 Jul 2013 11:51:14 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/EDConsumerBase.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+
+// forward declarations
+
+namespace edm {
+  class ModuleCallingContext;
+  class PreallocationConfiguration;
+  class StreamID;
+  class ActivityRegistry;
+  class ProductRegistry;
+  class ThinnedAssociationsHelper;
+  class WaitingTask;
+
+  namespace maker {
+    template<typename T> class ModuleHolderT;
+  }
+
+  namespace limited {
+    
+    class EDAnalyzerBase : public EDConsumerBase
+    {
+      
+    public:
+      template <typename T> friend class edm::WorkerT;
+      template <typename T> friend class edm::maker::ModuleHolderT;
+      typedef EDAnalyzerBase ModuleType;
+
+      EDAnalyzerBase();
+      virtual ~EDAnalyzerBase();
+
+      static void fillDescriptions(ConfigurationDescriptions& descriptions);
+      static void prevalidate(ConfigurationDescriptions& descriptions);
+      static const std::string& baseType();
+
+      // Warning: the returned moduleDescription will be invalid during construction
+      ModuleDescription const& moduleDescription() const { return moduleDescription_; }
+
+    private:
+      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+                   ActivityRegistry*,
+                   ModuleCallingContext const*);
+      //For now this is a placeholder
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+
+      void doPreallocate(PreallocationConfiguration const&);
+      void doBeginJob();
+      void doEndJob();
+      
+      void doBeginStream(StreamID id);
+      void doEndStream(StreamID id);
+      void doStreamBeginRun(StreamID id,
+                            RunPrincipal const& ep,
+                            EventSetup const& c,
+                            ModuleCallingContext const*);
+      void doStreamEndRun(StreamID id,
+                          RunPrincipal const& ep,
+                          EventSetup const& c,
+                          ModuleCallingContext const*);
+      void doStreamBeginLuminosityBlock(StreamID id,
+                                        LuminosityBlockPrincipal const& ep,
+                                        EventSetup const& c,
+                                        ModuleCallingContext const*);
+      void doStreamEndLuminosityBlock(StreamID id,
+                                      LuminosityBlockPrincipal const& ep,
+                                      EventSetup const& c,
+                                      ModuleCallingContext const*);
+
+      
+      void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+                      ModuleCallingContext const*);
+      void doEndRun(RunPrincipal const& rp, EventSetup const& c,
+                    ModuleCallingContext const*);
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+                                  ModuleCallingContext const*);
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+                                ModuleCallingContext const*);
+      
+      //For now, the following are just dummy implemenations with no ability for users to override
+      void doRespondToOpenInputFile(FileBlock const& fb);
+      void doRespondToCloseInputFile(FileBlock const& fb);
+      void doRegisterThinnedAssociations(ProductRegistry const&,
+                                         ThinnedAssociationsHelper&) { }
+
+      void registerProductsAndCallbacks(EDAnalyzerBase* module, ProductRegistry* reg);
+      std::string workerType() const {return "WorkerT<EDAnalyzer>";}
+      
+      virtual void analyze(StreamID, Event const& , EventSetup const&) const= 0;
+      virtual void beginJob() {}
+      virtual void endJob(){}
+      
+
+      virtual void preallocStreams(unsigned int);
+      virtual void doBeginStream_(StreamID id);
+      virtual void doEndStream_(StreamID id);
+      virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c);
+      virtual void doStreamEndRun_(StreamID id, Run const& rp, EventSetup const& c);
+      virtual void doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c);
+      virtual void doStreamBeginLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
+      virtual void doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
+      virtual void doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
+
+      virtual void doBeginRun_(Run const& rp, EventSetup const& c);
+      virtual void doBeginRunSummary_(Run const& rp, EventSetup const& c);
+      virtual void doEndRunSummary_(Run const& rp, EventSetup const& c);
+      virtual void doEndRun_(Run const& rp, EventSetup const& c);
+      virtual void doBeginLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c);
+      virtual void doBeginLuminosityBlockSummary_(LuminosityBlock const& rp, EventSetup const& c);
+      virtual void doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c);
+      virtual void doEndLuminosityBlock_(LuminosityBlock const& lb, EventSetup const& c);
+      
+      void setModuleDescription(ModuleDescription const& md) {
+        moduleDescription_ = md;
+      }
+      ModuleDescription moduleDescription_;
+
+      std::function<void(BranchDescription const&)> callWhenNewProductsRegistered_;
+    };
+
+  }
+}
+
+#endif

--- a/FWCore/Framework/interface/limited/EDFilter.h
+++ b/FWCore/Framework/interface/limited/EDFilter.h
@@ -1,0 +1,66 @@
+#ifndef FWCore_Framework_limited_EDFilter_h
+#define FWCore_Framework_limited_EDFilter_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     edm::limited::EDFilter
+// 
+/**\class edm::limited::EDFilter EDFilter.h "FWCore/Framework/interface/limited/EDFilter.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Tue, 23 Jul 2013 11:51:07 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/limited/filterAbilityToImplementor.h"
+#include "FWCore/Framework/interface/moduleAbilities.h"
+
+// forward declarations
+
+namespace edm {
+  namespace limited {
+    template< typename... T>
+    class EDFilter : 
+              public virtual EDFilterBase,
+              public filter::SpecializeAbilityToImplementor<
+        CheckAbility<edm::module::Abilities::kRunSummaryCache,T...>::kHasIt & CheckAbility<edm::module::Abilities::kEndRunProducer,T...>::kHasIt,
+        CheckAbility<edm::module::Abilities::kLuminosityBlockSummaryCache,T...>::kHasIt & CheckAbility<edm::module::Abilities::kEndLuminosityBlockProducer,T...>::kHasIt,
+        T>::Type...
+    {
+      
+    public:
+      EDFilter() = default;
+// We do this only in the case of the intel compiler as this might
+// end up creating a lot of code bloat due to inline symbols being generated 
+// in each DSO which uses this header.
+#ifdef __INTEL_COMPILER
+      virtual ~EDFilter() = default;
+#endif
+      // ---------- const member functions ---------------------
+      
+      // ---------- static member functions --------------------
+      
+      // ---------- member functions ---------------------------
+      
+    private:
+      EDFilter(const EDFilter&) = delete;
+      
+      const EDFilter& operator=(const EDFilter&) = delete;
+      
+      // ---------- member data --------------------------------
+      
+    };
+
+  }
+}
+
+#endif

--- a/FWCore/Framework/interface/limited/EDFilter.h
+++ b/FWCore/Framework/interface/limited/EDFilter.h
@@ -38,9 +38,14 @@ namespace edm {
     {
       
     public:
-      EDFilter() = default;
+      EDFilter(edm::ParameterSet const& iPSet) : EDFilterBase(iPSet),
+      filter::SpecializeAbilityToImplementor<
+      CheckAbility<edm::module::Abilities::kRunSummaryCache,T...>::kHasIt & CheckAbility<edm::module::Abilities::kEndRunProducer,T...>::kHasIt,
+      CheckAbility<edm::module::Abilities::kLuminosityBlockSummaryCache,T...>::kHasIt & CheckAbility<edm::module::Abilities::kEndLuminosityBlockProducer,T...>::kHasIt,
+      T>::Type(iPSet)...
+      {}
 // We do this only in the case of the intel compiler as this might
-// end up creating a lot of code bloat due to inline symbols being generated 
+// end up creating a lot of code bloat due to inline symbols being generated
 // in each DSO which uses this header.
 #ifdef __INTEL_COMPILER
       virtual ~EDFilter() = default;

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -1,0 +1,157 @@
+#ifndef FWCore_Framework_limited_EDFilterBase_h
+#define FWCore_Framework_limited_EDFilterBase_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     EDFilterBase
+// 
+/**\class EDFilterBase EDFilterBase.h "EDFilterBase.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 18 Jul 2013 11:51:14 GMT
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/EDConsumerBase.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+
+// forward declarations
+
+namespace edm {
+  class ModuleCallingContext;
+  class PreallocationConfiguration;
+  class StreamID;
+  class ActivityRegistry;
+  class ProductRegistry;
+  class ThinnedAssociationsHelper;
+  class WaitingTask;
+
+  namespace maker {
+    template<typename T> class ModuleHolderT;
+  }
+
+  namespace limited {
+    
+    class EDFilterBase : public ProducerBase, public EDConsumerBase
+    {
+      
+    public:
+      template <typename T> friend class edm::maker::ModuleHolderT;
+      template <typename T> friend class edm::WorkerT;
+      typedef EDFilterBase ModuleType;
+
+      EDFilterBase();
+      virtual ~EDFilterBase();
+
+      static void fillDescriptions(ConfigurationDescriptions& descriptions);
+      static void prevalidate(ConfigurationDescriptions& descriptions);
+      static const std::string& baseType();
+
+      // Warning: the returned moduleDescription will be invalid during construction
+      ModuleDescription const& moduleDescription() const { return moduleDescription_; }
+
+    private:
+      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+                   ActivityRegistry*,
+                   ModuleCallingContext const*);
+      //For now this is a placeholder
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+
+      void doPreallocate(PreallocationConfiguration const&);
+      void doBeginJob();
+      void doEndJob();
+      
+      void doBeginStream(StreamID id);
+      void doEndStream(StreamID id);
+      void doStreamBeginRun(StreamID id,
+                            RunPrincipal const& ep,
+                            EventSetup const& c,
+                            ModuleCallingContext const*);
+      void doStreamEndRun(StreamID id,
+                          RunPrincipal const& ep,
+                          EventSetup const& c,
+                          ModuleCallingContext const*);
+      void doStreamBeginLuminosityBlock(StreamID id,
+                                        LuminosityBlockPrincipal const& ep,
+                                        EventSetup const& c,
+                                        ModuleCallingContext const*);
+      void doStreamEndLuminosityBlock(StreamID id,
+                                      LuminosityBlockPrincipal const& ep,
+                                      EventSetup const& c,
+                                      ModuleCallingContext const*);
+
+      
+      void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+                      ModuleCallingContext const*);
+      void doEndRun(RunPrincipal const& rp, EventSetup const& c,
+                    ModuleCallingContext const*);
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+                                  ModuleCallingContext const*);
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+                                ModuleCallingContext const*);
+      
+      //For now, the following are just dummy implemenations with no ability for users to override
+      void doRespondToOpenInputFile(FileBlock const& fb);
+      void doRespondToCloseInputFile(FileBlock const& fb);
+      void doRegisterThinnedAssociations(ProductRegistry const&,
+                                         ThinnedAssociationsHelper&) { }
+
+      void registerProductsAndCallbacks(EDFilterBase* module, ProductRegistry* reg) {
+        registerProducts(module, reg, moduleDescription_);
+      }
+      std::string workerType() const {return "WorkerT<EDProducer>";}
+      
+      virtual bool filter(StreamID, Event&, EventSetup const&) const= 0;
+      virtual void beginJob() {}
+      virtual void endJob(){}
+
+      virtual void preallocStreams(unsigned int);
+      virtual void doBeginStream_(StreamID id);
+      virtual void doEndStream_(StreamID id);
+      virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c);
+      virtual void doStreamEndRun_(StreamID id, Run const& rp, EventSetup const& c);
+      virtual void doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c);
+      virtual void doStreamBeginLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
+      virtual void doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
+      virtual void doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
+
+      virtual void doBeginRun_(Run const& rp, EventSetup const& c);
+      virtual void doBeginRunSummary_(Run const& rp, EventSetup const& c);
+      virtual void doEndRunSummary_(Run const& rp, EventSetup const& c);
+      virtual void doEndRun_(Run const& rp, EventSetup const& c);
+      virtual void doBeginLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c);
+      virtual void doBeginLuminosityBlockSummary_(LuminosityBlock const& rp, EventSetup const& c);
+      virtual void doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c);
+      virtual void doEndLuminosityBlock_(LuminosityBlock const& lb, EventSetup const& c);
+      
+      virtual void doBeginRunProduce_(Run& rp, EventSetup const& c);
+      virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
+      virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
+      virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
+      
+      
+      void setModuleDescription(ModuleDescription const& md) {
+        moduleDescription_ = md;
+      }
+      ModuleDescription moduleDescription_;
+      std::unique_ptr<std::vector<BranchID>[]> previousParentages_; //Per stream in the future?
+      std::unique_ptr<ParentageID[]> previousParentageIds_;
+    };
+
+  }
+}
+
+#endif

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -27,6 +27,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/Concurrency/interface/LimitedTaskQueue.h"
 
 // forward declarations
 
@@ -53,8 +54,8 @@ namespace edm {
       template <typename T> friend class edm::WorkerT;
       typedef EDFilterBase ModuleType;
 
-      EDFilterBase();
-      virtual ~EDFilterBase();
+      EDFilterBase(ParameterSet const& pset);
+      ~EDFilterBase() override;
 
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
       static void prevalidate(ConfigurationDescriptions& descriptions);
@@ -63,6 +64,11 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+      unsigned int concurrencyLimit() const { return queue_.concurrencyLimit(); }
+
+      LimitedTaskQueue& queue() {
+        return queue_;
+      }
     private:
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
@@ -149,6 +155,8 @@ namespace edm {
       ModuleDescription moduleDescription_;
       std::unique_ptr<std::vector<BranchID>[]> previousParentages_; //Per stream in the future?
       std::unique_ptr<ParentageID[]> previousParentageIds_;
+      
+      LimitedTaskQueue queue_;
     };
 
   }

--- a/FWCore/Framework/interface/limited/EDProducer.h
+++ b/FWCore/Framework/interface/limited/EDProducer.h
@@ -37,7 +37,11 @@ namespace edm {
     {
       
     public:
-      EDProducer() = default;
+      EDProducer(edm::ParameterSet const& iPSet): EDProducerBase(iPSet),
+      producer::SpecializeAbilityToImplementor<
+      CheckAbility<edm::module::Abilities::kRunSummaryCache,T...>::kHasIt & CheckAbility<edm::module::Abilities::kEndRunProducer,T...>::kHasIt,
+      CheckAbility<edm::module::Abilities::kLuminosityBlockSummaryCache,T...>::kHasIt & CheckAbility<edm::module::Abilities::kEndLuminosityBlockProducer,T...>::kHasIt,
+      T>::Type(iPSet)... {}
       
       // ---------- const member functions ---------------------
       

--- a/FWCore/Framework/interface/limited/EDProducer.h
+++ b/FWCore/Framework/interface/limited/EDProducer.h
@@ -1,0 +1,60 @@
+#ifndef FWCore_Framework_limited_EDProducer_h
+#define FWCore_Framework_limited_EDProducer_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     edm::limited::EDProducer
+// 
+/**\class edm::limited::EDProducer EDProducer.h "FWCore/Framework/interface/limited/EDProducer.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 18 Jul 2013 11:51:07 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/limited/producerAbilityToImplementor.h"
+#include "FWCore/Framework/interface/moduleAbilities.h"
+
+// forward declarations
+
+namespace edm {
+  namespace limited {
+    template< typename... T>
+    class EDProducer : public producer::SpecializeAbilityToImplementor<
+        CheckAbility<edm::module::Abilities::kRunSummaryCache,T...>::kHasIt & CheckAbility<edm::module::Abilities::kEndRunProducer,T...>::kHasIt,
+        CheckAbility<edm::module::Abilities::kLuminosityBlockSummaryCache,T...>::kHasIt & CheckAbility<edm::module::Abilities::kEndLuminosityBlockProducer,T...>::kHasIt,
+        T>::Type...,
+                       public virtual EDProducerBase
+    {
+      
+    public:
+      EDProducer() = default;
+      
+      // ---------- const member functions ---------------------
+      
+      // ---------- static member functions --------------------
+      
+      // ---------- member functions ---------------------------
+      
+    private:
+      EDProducer(const EDProducer&) = delete;
+      
+      const EDProducer& operator=(const EDProducer&) = delete;
+      
+      // ---------- member data --------------------------------
+      
+    };
+
+  }
+}
+
+#endif

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -27,6 +27,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/Concurrency/interface/LimitedTaskQueue.h"
 
 // forward declarations
 
@@ -56,8 +57,8 @@ namespace edm {
       
       friend class edm::GlobalSchedule;
 
-      EDProducerBase();
-      virtual ~EDProducerBase();
+      EDProducerBase(ParameterSet const& pset);
+      ~EDProducerBase() override;
 
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
       static void prevalidate(ConfigurationDescriptions& descriptions);
@@ -65,7 +66,12 @@ namespace edm {
 
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
+      
+      unsigned int concurrencyLimit() const { return queue_.concurrencyLimit(); }
 
+      LimitedTaskQueue& queue() {
+        return queue_;
+      }
     private:
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
@@ -152,6 +158,7 @@ namespace edm {
       ModuleDescription moduleDescription_;
       std::unique_ptr<std::vector<BranchID>[]> previousParentages_;
       std::unique_ptr<ParentageID[]> previousParentageIds_;
+      LimitedTaskQueue queue_;
     };
 
   }

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -1,0 +1,160 @@
+#ifndef FWCore_Framework_limited_EDProducerBase_h
+#define FWCore_Framework_limited_EDProducerBase_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     EDProducerBase
+// 
+/**\class EDProducerBase EDProducerBase.h "EDProducerBase.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 18 Jul 2013 11:51:14 GMT
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/EDConsumerBase.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+
+// forward declarations
+
+namespace edm {
+  class ModuleCallingContext;
+  class PreallocationConfiguration;
+  class StreamID;
+  class GlobalSchedule;
+  class ActivityRegistry;
+  class ProductRegistry;
+  class ThinnedAssociationsHelper;
+  class WaitingTask;
+
+  namespace maker {
+    template<typename T> class ModuleHolderT;
+  }
+  
+  namespace limited {
+    
+    class EDProducerBase : public ProducerBase, public EDConsumerBase
+    {
+      
+    public:
+      template <typename T> friend class edm::maker::ModuleHolderT;
+      template <typename T> friend class edm::WorkerT;
+      typedef EDProducerBase ModuleType;
+      
+      friend class edm::GlobalSchedule;
+
+      EDProducerBase();
+      virtual ~EDProducerBase();
+
+      static void fillDescriptions(ConfigurationDescriptions& descriptions);
+      static void prevalidate(ConfigurationDescriptions& descriptions);
+      static const std::string& baseType();
+
+      // Warning: the returned moduleDescription will be invalid during construction
+      ModuleDescription const& moduleDescription() const { return moduleDescription_; }
+
+    private:
+      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+                   ActivityRegistry*,
+                   ModuleCallingContext const*);
+      void doPreallocate(PreallocationConfiguration const&);
+      void doBeginJob();
+      void doEndJob();
+      
+      void doBeginStream(StreamID id);
+      void doEndStream(StreamID id);
+      void doStreamBeginRun(StreamID id,
+                            RunPrincipal const& ep,
+                            EventSetup const& c,
+                            ModuleCallingContext const*);
+      void doStreamEndRun(StreamID id,
+                          RunPrincipal const& ep,
+                          EventSetup const& c,
+                          ModuleCallingContext const*);
+      void doStreamBeginLuminosityBlock(StreamID id,
+                                        LuminosityBlockPrincipal const& ep,
+                                        EventSetup const& c,
+                                        ModuleCallingContext const*);
+      void doStreamEndLuminosityBlock(StreamID id,
+                                      LuminosityBlockPrincipal const& ep,
+                                      EventSetup const& c,
+                                      ModuleCallingContext const*);
+
+      
+      void doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+                      ModuleCallingContext const*);
+      void doEndRun(RunPrincipal const& rp, EventSetup const& c,
+                    ModuleCallingContext const*);
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+                                  ModuleCallingContext const*);
+      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+                                ModuleCallingContext const*);
+      
+      //For now, the following are just dummy implemenations with no ability for users to override
+      void doRespondToOpenInputFile(FileBlock const& fb);
+      void doRespondToCloseInputFile(FileBlock const& fb);
+      void doRegisterThinnedAssociations(ProductRegistry const&,
+                                         ThinnedAssociationsHelper&) { }
+
+      void registerProductsAndCallbacks(EDProducerBase* module, ProductRegistry* reg) {
+        registerProducts(module, reg, moduleDescription_);
+      }
+      std::string workerType() const {return "WorkerT<EDProducer>";}
+      
+      virtual void produce(StreamID, Event&, EventSetup const&) const= 0;
+      //For now this is a placeholder
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+
+      virtual void beginJob() {}
+      virtual void endJob(){}
+
+      virtual void preallocStreams(unsigned int);
+      virtual void doBeginStream_(StreamID id);
+      virtual void doEndStream_(StreamID id);
+      virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c);
+      virtual void doStreamEndRun_(StreamID id, Run const& rp, EventSetup const& c);
+      virtual void doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c);
+      virtual void doStreamBeginLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
+      virtual void doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
+      virtual void doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
+
+      virtual void doBeginRun_(Run const& rp, EventSetup const& c);
+      virtual void doBeginRunSummary_(Run const& rp, EventSetup const& c);
+      virtual void doEndRunSummary_(Run const& rp, EventSetup const& c);
+      virtual void doEndRun_(Run const& rp, EventSetup const& c);
+      virtual void doBeginLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c);
+      virtual void doBeginLuminosityBlockSummary_(LuminosityBlock const& rp, EventSetup const& c);
+      virtual void doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c);
+      virtual void doEndLuminosityBlock_(LuminosityBlock const& lb, EventSetup const& c);
+      
+      virtual void doBeginRunProduce_(Run& rp, EventSetup const& c);
+      virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
+      virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
+      virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
+      
+      
+      void setModuleDescription(ModuleDescription const& md) {
+        moduleDescription_ = md;
+      }
+      ModuleDescription moduleDescription_;
+      std::unique_ptr<std::vector<BranchID>[]> previousParentages_;
+      std::unique_ptr<ParentageID[]> previousParentageIds_;
+    };
+
+  }
+}
+
+#endif

--- a/FWCore/Framework/interface/limited/OutputModule.h
+++ b/FWCore/Framework/interface/limited/OutputModule.h
@@ -1,0 +1,61 @@
+#ifndef FWCore_Framework_limited_OutputModule_h
+#define FWCore_Framework_limited_OutputModule_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     edm::limited::OutputModule
+// 
+/**\class edm::limited::OutputModule OutputModule.h "FWCore/Framework/interface/limited/OutputModule.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/limited/outputmoduleAbilityToImplementor.h"
+
+// forward declarations
+namespace edm {
+  namespace limited {
+    template< typename... T>
+    class OutputModule : public virtual OutputModuleBase,
+        public outputmodule::AbilityToImplementor<T>::Type...
+    {
+      
+    public:
+      OutputModule(edm::ParameterSet const& iPSet): OutputModuleBase(iPSet),
+      outputmodule::AbilityToImplementor<T>::Type(iPSet)...
+       {}
+      // Required to work around ICC bug, but possible source of bloat in gcc.
+      // We do this only in the case of the intel compiler as this might end up
+      // creating a lot of code bloat due to inline symbols being generated in
+      // each DSO which uses this header.
+#ifdef __INTEL_COMPILER
+      virtual ~OutputModule() = default;
+#endif
+      
+      // ---------- const member functions ---------------------
+      
+      // ---------- static member functions --------------------
+      
+      // ---------- member functions ---------------------------
+      
+    private:
+      OutputModule(const OutputModule&) = delete; // stop default
+      
+      const OutputModule& operator=(const OutputModule&) =delete; // stop default
+      
+      // ---------- member data --------------------------------
+      
+    };
+  }
+}
+
+#endif

--- a/FWCore/Framework/interface/limited/OutputModuleBase.h
+++ b/FWCore/Framework/interface/limited/OutputModuleBase.h
@@ -39,6 +39,7 @@
 #include "FWCore/Framework/interface/getAllTriggerNames.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Concurrency/interface/LimitedTaskQueue.h"
 
 // forward declarations
 namespace edm {
@@ -66,7 +67,7 @@ namespace edm {
       typedef OutputModuleBase ModuleType;
       
       explicit OutputModuleBase(ParameterSet const& pset);
-      virtual ~OutputModuleBase();
+      ~OutputModuleBase() override;
       
       OutputModuleBase(OutputModuleBase const&) = delete; // Disallow copying and moving
       OutputModuleBase& operator=(OutputModuleBase const&) = delete; // Disallow copying and moving
@@ -99,6 +100,12 @@ namespace edm {
       
       const ModuleDescription& moduleDescription() const {
         return moduleDescription_;
+      }
+      
+      unsigned int concurrencyLimit() const { return queue_.concurrencyLimit(); }
+
+      LimitedTaskQueue& queue() {
+        return queue_;
       }
     protected:
       
@@ -197,7 +204,7 @@ namespace edm {
 
       edm::propagate_const<std::unique_ptr<ThinnedAssociationsHelper>> thinnedAssociationsHelper_;
       std::map<BranchID, bool> keepAssociation_;
-
+      LimitedTaskQueue queue_;
       
       //------------------------------------------------------------------
       // private member functions
@@ -228,11 +235,11 @@ namespace edm {
       /// Ask the OutputModule if we should end the current file.
       virtual bool shouldWeCloseFile() const {return false;}
       
-      virtual void write(EventForOutput const&) const = 0;
+      virtual void write(EventForOutput const&) = 0;
       virtual void beginJob(){}
       virtual void endJob(){}
-      virtual void writeLuminosityBlock(LuminosityBlockForOutput const&) const = 0;
-      virtual void writeRun(RunForOutput const&) const = 0;
+      virtual void writeLuminosityBlock(LuminosityBlockForOutput const&) = 0;
+      virtual void writeRun(RunForOutput const&) = 0;
       virtual void openFile(FileBlock const&) const {}
       virtual bool isFileOpen() const { return true; }
       

--- a/FWCore/Framework/interface/limited/OutputModuleBase.h
+++ b/FWCore/Framework/interface/limited/OutputModuleBase.h
@@ -1,0 +1,272 @@
+#ifndef FWCore_Framework_limited_OutputModuleBase_h
+#define FWCore_Framework_limited_OutputModuleBase_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     OutputModuleBase
+// 
+/**\class OutputModuleBase OutputModuleBase.h "FWCore/Framework/interface/limited/OutputModuleBase.h"
+
+ Description: Base class for all 'limited' OutputModules
+
+ Usage:
+    <usage>
+
+*/
+//
+//
+
+// system include files
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+#include <map>
+#include <atomic>
+#include <mutex>
+
+// user include files
+#include "DataFormats/Provenance/interface/BranchID.h"
+#include "DataFormats/Provenance/interface/BranchIDList.h"
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "DataFormats/Provenance/interface/SelectedProducts.h"
+
+#include "FWCore/Framework/interface/TriggerResultsBasedEventSelector.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/ProductSelectorRules.h"
+#include "FWCore/Framework/interface/ProductSelector.h"
+#include "FWCore/Framework/interface/EDConsumerBase.h"
+#include "FWCore/Framework/interface/getAllTriggerNames.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
+
+// forward declarations
+namespace edm {
+
+  class ModuleCallingContext;
+  class PreallocationConfiguration;
+  class ActivityRegistry;
+  class ProductRegistry;
+  class ThinnedAssociationsHelper;
+  class WaitingTask;
+
+  template <typename T> class OutputModuleCommunicatorT;
+  
+  namespace maker {
+    template<typename T> class ModuleHolderT;
+  }
+
+  namespace limited {
+    
+    class OutputModuleBase : public EDConsumerBase {
+    public:
+      template <typename U> friend class edm::maker::ModuleHolderT;
+      template <typename T> friend class ::edm::WorkerT;
+      template <typename T> friend class ::edm::OutputModuleCommunicatorT;
+      typedef OutputModuleBase ModuleType;
+      
+      explicit OutputModuleBase(ParameterSet const& pset);
+      virtual ~OutputModuleBase();
+      
+      OutputModuleBase(OutputModuleBase const&) = delete; // Disallow copying and moving
+      OutputModuleBase& operator=(OutputModuleBase const&) = delete; // Disallow copying and moving
+      
+      /// Accessor for maximum number of events to be written.
+      /// -1 is used for unlimited.
+      int maxEvents() const {return maxEvents_;}
+      
+      /// Accessor for remaining number of events to be written.
+      /// -1 is used for unlimited.
+      int remainingEvents() const {return remainingEvents_;}
+      
+      bool selected(BranchDescription const& desc) const;
+      
+      void selectProducts(ProductRegistry const& preg, ThinnedAssociationsHelper const&);
+      std::string const& processName() const {return process_name_;}
+      SelectedProductsForBranchType const& keptProducts() const {return keptProducts_;}
+      std::array<bool, NumBranchTypes> const& hasNewlyDroppedBranch() const {return hasNewlyDroppedBranch_;}
+      
+      static void fillDescription(ParameterSetDescription & desc);
+      static void fillDescriptions(ConfigurationDescriptions& descriptions);
+      static const std::string& baseType();
+      static void prevalidate(ConfigurationDescriptions& );
+      
+      bool wantAllEvents() const {return wantAllEvents_;}
+      
+      BranchIDLists const* branchIDLists();
+
+      ThinnedAssociationsHelper const* thinnedAssociationsHelper() const;
+      
+      const ModuleDescription& moduleDescription() const {
+        return moduleDescription_;
+      }
+    protected:
+      
+      ModuleDescription const& description() const;
+      
+      ParameterSetID selectorConfig() const { return selector_config_id_; }
+
+      void doPreallocate(PreallocationConfiguration const&);
+
+      void doBeginJob();
+      void doEndJob();
+
+      void doBeginStream(StreamID id);
+      void doEndStream(StreamID id);
+      void doStreamBeginRun(StreamID id,
+                            RunPrincipal& ep,
+                            EventSetup const& c,
+                            ModuleCallingContext const*);
+      void doStreamEndRun(StreamID id,
+                          RunPrincipal& ep,
+                          EventSetup const& c,
+                          ModuleCallingContext const*);
+      void doStreamBeginLuminosityBlock(StreamID id,
+                                        LuminosityBlockPrincipal& ep,
+                                        EventSetup const& c,
+                                        ModuleCallingContext const*);
+      void doStreamEndLuminosityBlock(StreamID id,
+                                      LuminosityBlockPrincipal& ep,
+                                      EventSetup const& c,
+                                      ModuleCallingContext const*);
+
+      bool doEvent(EventPrincipal const& ep, EventSetup const& c,
+                   ActivityRegistry*,
+                   ModuleCallingContext const*);
+      //For now this is a placeholder
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+
+      bool doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+                      ModuleCallingContext const*);
+      bool doEndRun(RunPrincipal const& rp, EventSetup const& c,
+                    ModuleCallingContext const*);
+      bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+                                  ModuleCallingContext const*);
+      bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+                                ModuleCallingContext const*);
+      
+      void setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
+                                 bool anyProductProduced);
+      
+      void configure(OutputModuleDescription const& desc);
+      
+      std::map<BranchID::value_type, BranchID::value_type> const& droppedBranchIDToKeptBranchID() {
+        return droppedBranchIDToKeptBranchID_;
+      }
+      
+    private:
+      
+      int maxEvents_;
+      std::atomic<int> remainingEvents_;
+      
+      // TODO: Give OutputModule
+      // an interface (protected?) that supplies client code with the
+      // needed functionality *without* giving away implementation
+      // details ... don't just return a reference to keptProducts_, because
+      // we are looking to have the flexibility to change the
+      // implementation of keptProducts_ without modifying clients. When this
+      // change is made, we'll have a one-time-only task of modifying
+      // clients (classes derived from OutputModule) to use the
+      // newly-introduced interface.
+      // TODO: Consider using shared pointers here?
+      
+      // keptProducts_ are pointers to the BranchDescription objects describing
+      // the branches we are to write.
+      //
+      // We do not own the BranchDescriptions to which we point.
+      SelectedProductsForBranchType keptProducts_;
+      std::array<bool, NumBranchTypes> hasNewlyDroppedBranch_;
+      
+      std::string process_name_;
+      ProductSelectorRules productSelectorRules_;
+      ProductSelector productSelector_;
+      ModuleDescription moduleDescription_;
+      
+      bool wantAllEvents_;
+      std::vector<detail::TriggerResultsBasedEventSelector> selectors_;
+      ParameterSet selectEvents_;
+      // ID of the ParameterSet that configured the event selector
+      // subsystem.
+      ParameterSetID selector_config_id_;
+      
+      // needed because of possible EDAliases.
+      // filled in only if key and value are different.
+      std::map<BranchID::value_type, BranchID::value_type> droppedBranchIDToKeptBranchID_;
+      edm::propagate_const<std::unique_ptr<BranchIDLists>> branchIDLists_;
+      BranchIDLists const* origBranchIDLists_;
+
+      edm::propagate_const<std::unique_ptr<ThinnedAssociationsHelper>> thinnedAssociationsHelper_;
+      std::map<BranchID, bool> keepAssociation_;
+
+      
+      //------------------------------------------------------------------
+      // private member functions
+      //------------------------------------------------------------------
+      
+      void doWriteRun(RunPrincipal const& rp, ModuleCallingContext const*);
+      void doWriteLuminosityBlock(LuminosityBlockPrincipal const& lbp, ModuleCallingContext const*);
+      void doOpenFile(FileBlock const& fb);
+      void doRespondToOpenInputFile(FileBlock const& fb);
+      void doRespondToCloseInputFile(FileBlock const& fb);
+      void doRegisterThinnedAssociations(ProductRegistry const&,
+                                         ThinnedAssociationsHelper&) { }
+
+      std::string workerType() const {return "WorkerT<edm::limited::OutputModuleBase>";}
+      
+      /// Tell the OutputModule that is must end the current file.
+      void doCloseFile();
+      
+      void registerProductsAndCallbacks(OutputModuleBase const*, ProductRegistry const*) {}
+
+      bool prePrefetchSelection(StreamID id, EventPrincipal const&, ModuleCallingContext const*);
+      
+      // Do the end-of-file tasks; this is only called internally, after
+      // the appropriate tests have been done.
+      virtual void reallyCloseFile();
+      
+      
+      /// Ask the OutputModule if we should end the current file.
+      virtual bool shouldWeCloseFile() const {return false;}
+      
+      virtual void write(EventForOutput const&) const = 0;
+      virtual void beginJob(){}
+      virtual void endJob(){}
+      virtual void writeLuminosityBlock(LuminosityBlockForOutput const&) const = 0;
+      virtual void writeRun(RunForOutput const&) const = 0;
+      virtual void openFile(FileBlock const&) const {}
+      virtual bool isFileOpen() const { return true; }
+      
+      virtual void preallocStreams(unsigned int){}
+      virtual void doBeginStream_(StreamID){}
+      virtual void doEndStream_(StreamID){}
+      virtual void doStreamBeginRun_(StreamID, RunForOutput const&, EventSetup const&){}
+      virtual void doStreamEndRun_(StreamID, RunForOutput const&, EventSetup const&){}
+      virtual void doStreamEndRunSummary_(StreamID, RunForOutput const&, EventSetup const&){}
+      virtual void doStreamBeginLuminosityBlock_(StreamID, LuminosityBlockForOutput const&, EventSetup const&){}
+      virtual void doStreamEndLuminosityBlock_(StreamID, LuminosityBlockForOutput const&, EventSetup const&){}
+      virtual void doStreamEndLuminosityBlockSummary_(StreamID, LuminosityBlockForOutput const&, EventSetup const&){}
+
+      virtual void doBeginRun_(RunForOutput const&){}
+      virtual void doBeginRunSummary_(RunForOutput const&, EventSetup const&){}
+      virtual void doEndRun_(RunForOutput const& ){}
+      virtual void doEndRunSummary_(RunForOutput const&, EventSetup const&){}
+      virtual void doBeginLuminosityBlock_(LuminosityBlockForOutput const&){}
+      virtual void doBeginLuminosityBlockSummary_(LuminosityBlockForOutput const&, EventSetup const&){}
+      virtual void doEndLuminosityBlock_(LuminosityBlockForOutput const&){}
+      virtual void doEndLuminosityBlockSummary_(LuminosityBlockForOutput const&, EventSetup const&){}
+      virtual void doRespondToOpenInputFile_(FileBlock const&) {}
+      virtual void doRespondToCloseInputFile_(FileBlock const&) {}
+      
+      void keepThisBranch(BranchDescription const& desc,
+                          std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc,
+                          std::set<BranchID>& keptProductsInEvent);
+
+      void setModuleDescription(ModuleDescription const& md) {
+        moduleDescription_ = md;
+      }
+      
+      bool limitReached() const {return remainingEvents_ == 0;}
+    };
+  }
+}
+#endif

--- a/FWCore/Framework/interface/limited/analyzerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/limited/analyzerAbilityToImplementor.h
@@ -1,0 +1,62 @@
+#ifndef FWCore_Framework_limited_analyzerAbilityToImplementor_h
+#define FWCore_Framework_limited_analyzerAbilityToImplementor_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// File  :     analyzerAbilityToImplementor
+// 
+/**\file  analyzerAbilityToImplementor.h "FWCore/Framework/interface/limited/analyzerAbilityToImplementor.h"
+
+ Description: Class used to pair a module Ability to the actual base class used to implement that ability
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 18 Jul 2013 11:51:33 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/moduleAbilities.h"
+#include "FWCore/Framework/interface/limited/implementors.h"
+#include "FWCore/Framework/interface/limited/EDAnalyzerBase.h"
+
+// forward declarations
+namespace edm {
+  namespace limited {
+    namespace analyzer {
+      template<typename T> struct AbilityToImplementor;
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::StreamCache<C>> {
+        typedef edm::limited::impl::StreamCacheHolder<edm::limited::EDAnalyzerBase,C> Type;
+      };
+
+      template<typename C>
+      struct AbilityToImplementor<edm::RunCache<C>> {
+        typedef edm::limited::impl::RunCacheHolder<edm::limited::EDAnalyzerBase,C> Type;
+      };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::RunSummaryCache<C>> {
+        typedef edm::limited::impl::RunSummaryCacheHolder<edm::limited::EDAnalyzerBase,C> Type;
+      };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::LuminosityBlockCache<C>> {
+        typedef edm::limited::impl::LuminosityBlockCacheHolder<edm::limited::EDAnalyzerBase,C> Type;
+      };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::LuminosityBlockSummaryCache<C>> {
+        typedef edm::limited::impl::LuminosityBlockSummaryCacheHolder<edm::limited::EDAnalyzerBase,C> Type;
+      };
+    }
+  }
+}
+
+#endif

--- a/FWCore/Framework/interface/limited/filterAbilityToImplementor.h
+++ b/FWCore/Framework/interface/limited/filterAbilityToImplementor.h
@@ -1,0 +1,102 @@
+#ifndef FWCore_Framework_limited_filterAbilityToImplementor_h
+#define FWCore_Framework_limited_filterAbilityToImplementor_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// File  :     filterAbilityToImplementor
+// 
+/**\file  filterAbilityToImplementor.h "FWCore/Framework/interface/limited/filterAbilityToImplementor.h"
+
+ Description: Class used to pair a module Ability to the actual base class used to implement that ability
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 18 Jul 2013 11:51:33 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/moduleAbilities.h"
+#include "FWCore/Framework/interface/limited/implementors.h"
+#include "FWCore/Framework/interface/limited/EDFilterBase.h"
+
+// forward declarations
+namespace edm {
+  namespace limited {
+    namespace filter {
+      template<typename T> struct AbilityToImplementor;
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::StreamCache<C>> {
+        typedef edm::limited::impl::StreamCacheHolder<edm::limited::EDFilterBase,C> Type;
+      };
+
+      template<typename C>
+      struct AbilityToImplementor<edm::RunCache<C>> {
+        typedef edm::limited::impl::RunCacheHolder<edm::limited::EDFilterBase,C> Type;
+      };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::RunSummaryCache<C>> {
+        typedef edm::limited::impl::RunSummaryCacheHolder<edm::limited::EDFilterBase,C> Type;
+      };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::LuminosityBlockCache<C>> {
+        typedef edm::limited::impl::LuminosityBlockCacheHolder<edm::limited::EDFilterBase,C> Type;
+      };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::LuminosityBlockSummaryCache<C>> {
+        typedef edm::limited::impl::LuminosityBlockSummaryCacheHolder<edm::limited::EDFilterBase,C> Type;
+      };
+      
+      template<>
+      struct AbilityToImplementor<edm::BeginRunProducer> {
+        typedef edm::limited::impl::BeginRunProducer<edm::limited::EDFilterBase> Type;
+      };
+      
+      template<>
+      struct AbilityToImplementor<edm::EndRunProducer> {
+        typedef edm::limited::impl::EndRunProducer<edm::limited::EDFilterBase> Type;
+      };
+      
+      template<>
+      struct AbilityToImplementor<edm::BeginLuminosityBlockProducer> {
+        typedef edm::limited::impl::BeginLuminosityBlockProducer<edm::limited::EDFilterBase> Type;
+      };
+      
+      template<>
+      struct AbilityToImplementor<edm::EndLuminosityBlockProducer> {
+        typedef edm::limited::impl::EndLuminosityBlockProducer<edm::limited::EDFilterBase> Type;
+      };
+      
+      template<bool,bool,typename T> struct SpecializeAbilityToImplementor {
+        typedef typename AbilityToImplementor<T>::Type Type;
+      };
+      
+      template<bool B,typename C> struct SpecializeAbilityToImplementor<true,B,edm::RunSummaryCache<C>> {
+        typedef typename edm::limited::impl::EndRunSummaryProducer<edm::limited::EDFilterBase,C> Type;
+      };
+      
+      template<bool B> struct SpecializeAbilityToImplementor<true,B,edm::EndRunProducer> {
+        typedef typename edm::limited::impl::EmptyType Type;
+      };
+
+      template<bool B,typename C> struct SpecializeAbilityToImplementor<B,true,edm::LuminosityBlockSummaryCache<C>> {
+        typedef typename edm::limited::impl::EndLuminosityBlockSummaryProducer<edm::limited::EDFilterBase,C> Type;
+      };
+      
+      template<bool B> struct SpecializeAbilityToImplementor<B,true,edm::EndLuminosityBlockProducer> {
+        typedef typename edm::limited::impl::EmptyType Type;
+      };
+    }
+  }
+}
+
+#endif

--- a/FWCore/Framework/interface/limited/implementors.h
+++ b/FWCore/Framework/interface/limited/implementors.h
@@ -54,27 +54,27 @@ namespace edm {
       protected:
         C * streamCache(edm::StreamID iID) const { return caches_[iID.value()]; }
       private:
-        virtual void preallocStreams(unsigned int iNStreams) override final {
+        void preallocStreams(unsigned int iNStreams) final {
           caches_.resize(iNStreams,static_cast<C*>(nullptr));
         }
-        virtual void doBeginStream_(StreamID id) override final {
+        void doBeginStream_(StreamID id) final {
           caches_[id.value()] = beginStream(id).release();
         }
-        virtual void doEndStream_(StreamID id) override final {
+        void doEndStream_(StreamID id) final {
           endStream(id);
           delete caches_[id.value()];
           caches_[id.value()]=nullptr;
         }
-        virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) override final {
+        void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) final {
           streamBeginRun(id,rp,c);
         }
-        virtual void doStreamEndRun_(StreamID id, Run const& rp, EventSetup const& c) override final {
+        void doStreamEndRun_(StreamID id, Run const& rp, EventSetup const& c) final {
           streamEndRun(id,rp,c);
         }
-        virtual void doStreamBeginLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) override final {
+        void doStreamBeginLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) final {
           streamBeginLuminosityBlock(id,lbp,c);
         }
-        virtual void doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) override final {
+        void doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) final {
           streamEndLuminosityBlock(id,lbp,c);
         }
 
@@ -99,10 +99,10 @@ namespace edm {
       protected:
         C const* runCache(edm::RunIndex iID) const { return cache_.get(); }
       private:
-        void doBeginRun_(Run const& rp, EventSetup const& c) override final {
+        void doBeginRun_(Run const& rp, EventSetup const& c) final {
           cache_ = globalBeginRun(rp,c);
         }
-        void doEndRun_(Run const& rp, EventSetup const& c) override final {
+        void doEndRun_(Run const& rp, EventSetup const& c) final {
           globalEndRun(rp,c);
           cache_ = nullptr; // propagate_const<T> has no reset() function
         }
@@ -123,10 +123,10 @@ namespace edm {
       protected:
         C const* luminosityBlockCache(edm::LuminosityBlockIndex iID) const { return cache_.get(); }
       private:
-        void doBeginLuminosityBlock_(LuminosityBlock const& rp, EventSetup const& c) override final {
+        void doBeginLuminosityBlock_(LuminosityBlock const& rp, EventSetup const& c) final {
           cache_ = globalBeginLuminosityBlock(rp,c);
         }
-        void doEndLuminosityBlock_(LuminosityBlock const& rp, EventSetup const& c) override final {
+        void doEndLuminosityBlock_(LuminosityBlock const& rp, EventSetup const& c) final {
           globalEndLuminosityBlock(rp,c);
           cache_.reset();
         }
@@ -148,15 +148,15 @@ namespace edm {
         ~RunSummaryCacheHolder() noexcept(false) {};
       private:
         friend class EndRunSummaryProducer<T,C>;
-        void doBeginRunSummary_(edm::Run const& rp, EventSetup const& c) override final {
+        void doBeginRunSummary_(edm::Run const& rp, EventSetup const& c) final {
           cache_ = globalBeginRunSummary(rp,c);
         }
-        void doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c) override final {
+        void doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c) final {
           //NOTE: in future this will need to be serialized
           std::lock_guard<std::mutex> guard(mutex_);
           streamEndRunSummary(id,rp,c,cache_.get());
         }
-        void doEndRunSummary_(Run const& rp, EventSetup const& c) override final {
+        void doEndRunSummary_(Run const& rp, EventSetup const& c) final {
           globalEndRunSummary(rp,c,cache_.get());
         }
 
@@ -183,16 +183,16 @@ namespace edm {
       private:
         friend class EndLuminosityBlockSummaryProducer<T,C>;
         
-        void doBeginLuminosityBlockSummary_(edm::LuminosityBlock const& lb, EventSetup const& c) override final {
+        void doBeginLuminosityBlockSummary_(edm::LuminosityBlock const& lb, EventSetup const& c) final {
           cache_ = globalBeginLuminosityBlockSummary(lb,c);
         }
 
-        virtual void doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lb, EventSetup const& c) override final
+        void doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lb, EventSetup const& c) final
         {
           std::lock_guard<std::mutex> guard(mutex_);
           streamEndLuminosityBlockSummary(id,lb,c,cache_.get());
         }
-        void doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c) override final {
+        void doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c) final {
           globalEndLuminosityBlockSummary(lb,c,cache_.get());
         }
 
@@ -213,10 +213,10 @@ namespace edm {
         BeginRunProducer(edm::ParameterSet const& iPSet) : T(iPSet) {}
         BeginRunProducer( BeginRunProducer const&) = delete;
         BeginRunProducer& operator=(BeginRunProducer const&) = delete;
-        ~BeginRunProducer() noexcept(false) {};
+        ~BeginRunProducer() noexcept(false) override {};
         
       private:
-        void doBeginRunProduce_(Run& rp, EventSetup const& c) override final;
+        void doBeginRunProduce_(Run& rp, EventSetup const& c) final;
         
         virtual void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const = 0;
       };
@@ -227,11 +227,11 @@ namespace edm {
         EndRunProducer(edm::ParameterSet const& iPSet) : T(iPSet) {}
         EndRunProducer( EndRunProducer const&) = delete;
         EndRunProducer& operator=(EndRunProducer const&) = delete;
-        ~EndRunProducer() noexcept(false) {};
+        ~EndRunProducer() noexcept(false) override {};
         
       private:
         
-        void doEndRunProduce_(Run& rp, EventSetup const& c) override final;
+        void doEndRunProduce_(Run& rp, EventSetup const& c) final;
         
         virtual void globalEndRunProduce(edm::Run&, edm::EventSetup const&) const = 0;
       };
@@ -246,7 +246,7 @@ namespace edm {
         
       private:
         
-        void doEndRunProduce_(Run& rp, EventSetup const& c) override final {
+        void doEndRunProduce_(Run& rp, EventSetup const& c) final {
           globalEndRunProduce(rp,c,RunSummaryCacheHolder<T,C>::cache_.get());
         }
         
@@ -259,10 +259,10 @@ namespace edm {
         BeginLuminosityBlockProducer(edm::ParameterSet const& iPSet) : T(iPSet) {}
         BeginLuminosityBlockProducer( BeginLuminosityBlockProducer const&) = delete;
         BeginLuminosityBlockProducer& operator=(BeginLuminosityBlockProducer const&) = delete;
-        ~BeginLuminosityBlockProducer() noexcept(false) {};
+        ~BeginLuminosityBlockProducer() noexcept(false) override {};
         
       private:
-        void doBeginLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) override final;
+        void doBeginLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) final;
         virtual void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const = 0;
       };
       
@@ -272,10 +272,10 @@ namespace edm {
         EndLuminosityBlockProducer(edm::ParameterSet const& iPSet) : T(iPSet) {}
         EndLuminosityBlockProducer( EndLuminosityBlockProducer const&) = delete;
         EndLuminosityBlockProducer& operator=(EndLuminosityBlockProducer const&) = delete;
-        ~EndLuminosityBlockProducer() noexcept(false) {};
+        ~EndLuminosityBlockProducer() noexcept(false) override {};
         
       private:
-        void doEndLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) override final;
+        void doEndLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) final;
         virtual void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const = 0;
       };
 
@@ -288,7 +288,7 @@ namespace edm {
         ~EndLuminosityBlockSummaryProducer() noexcept(false) {};
         
       private:
-        void doEndLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) override final {
+        void doEndLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) final {
           globalEndLuminosityBlockProduce(lb,c,LuminosityBlockSummaryCacheHolder<T,S>::cache_.get());
         }
         

--- a/FWCore/Framework/interface/limited/outputmoduleAbilityToImplementor.h
+++ b/FWCore/Framework/interface/limited/outputmoduleAbilityToImplementor.h
@@ -36,11 +36,11 @@ namespace edm {
         InputFileWatcher(edm::ParameterSet const&iPSet): OutputModuleBase(iPSet) {}
         InputFileWatcher(InputFileWatcher const&) = delete;
         InputFileWatcher& operator=(InputFileWatcher const&) = delete;
-        ~InputFileWatcher() noexcept(false) {};
+        ~InputFileWatcher() noexcept(false) override {};
         
       private:
-        void doRespondToOpenInputFile_(FileBlock const&) override final;
-        void doRespondToCloseInputFile_(FileBlock const&) override final;
+        void doRespondToOpenInputFile_(FileBlock const&) final;
+        void doRespondToCloseInputFile_(FileBlock const&) final;
         
         virtual void respondToOpenInputFile(FileBlock const&) = 0;
         virtual void respondToCloseInputFile(FileBlock const&) = 0;

--- a/FWCore/Framework/interface/limited/outputmoduleAbilityToImplementor.h
+++ b/FWCore/Framework/interface/limited/outputmoduleAbilityToImplementor.h
@@ -1,0 +1,86 @@
+#ifndef FWCore_Framework_limited_outputmoduleAbilityToImplementor_h
+#define FWCore_Framework_limited_outputmoduleAbilityToImplementor_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     outputmodule::AbilityToImplementor
+// 
+/**\class outputmodule::AbilityToImplementor outputmoduleAbilityToImplementor.h "FWCore/Framework/interface/limited/outputmoduleAbilityToImplementor.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/moduleAbilities.h"
+#include "FWCore/Framework/interface/limited/implementors.h"
+#include "FWCore/Framework/interface/limited/OutputModuleBase.h"
+
+// forward declarations
+
+namespace edm {
+  class FileBlock;
+  class ModuleCallingContext;
+  
+  namespace limited {
+    namespace outputmodule {
+      class InputFileWatcher : public virtual OutputModuleBase {
+      public:
+        InputFileWatcher(edm::ParameterSet const&iPSet): OutputModuleBase(iPSet) {}
+        InputFileWatcher(InputFileWatcher const&) = delete;
+        InputFileWatcher& operator=(InputFileWatcher const&) = delete;
+        ~InputFileWatcher() noexcept(false) {};
+        
+      private:
+        void doRespondToOpenInputFile_(FileBlock const&) override final;
+        void doRespondToCloseInputFile_(FileBlock const&) override final;
+        
+        virtual void respondToOpenInputFile(FileBlock const&) = 0;
+        virtual void respondToCloseInputFile(FileBlock const&) = 0;
+      };
+      
+      template<typename T> struct AbilityToImplementor;
+      
+      template<>
+      struct AbilityToImplementor<edm::WatchInputFiles> {
+        typedef edm::limited::outputmodule::InputFileWatcher Type;
+      };
+
+      template<typename C>
+      struct AbilityToImplementor<edm::StreamCache<C>> {
+        typedef edm::limited::impl::StreamCacheHolder<edm::limited::OutputModuleBase,C> Type;
+      };
+
+      template<typename C>
+      struct AbilityToImplementor<edm::RunCache<C>> {
+        typedef edm::limited::impl::RunCacheHolder<edm::limited::OutputModuleBase,C> Type;
+      };
+
+      template<typename C>
+      struct AbilityToImplementor<edm::RunSummaryCache<C>> {
+        typedef edm::limited::impl::RunSummaryCacheHolder<edm::limited::OutputModuleBase,C> Type;
+      };
+
+      template<typename C>
+      struct AbilityToImplementor<edm::LuminosityBlockCache<C>> {
+        typedef edm::limited::impl::LuminosityBlockCacheHolder<edm::limited::OutputModuleBase,C> Type;
+      };
+
+      template<typename C>
+      struct AbilityToImplementor<edm::LuminosityBlockSummaryCache<C>> {
+        typedef edm::limited::impl::LuminosityBlockSummaryCacheHolder<edm::limited::OutputModuleBase,C> Type;
+      };
+
+    }
+  }
+}
+
+
+#endif

--- a/FWCore/Framework/interface/limited/producerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/limited/producerAbilityToImplementor.h
@@ -1,0 +1,102 @@
+#ifndef FWCore_Framework_limited_producerAbilityToImplementor_h
+#define FWCore_Framework_limited_producerAbilityToImplementor_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// File  :     producerAbilityToImplementor
+// 
+/**\file  producerAbilityToImplementor.h "FWCore/Framework/interface/limited/producerAbilityToImplementor.h"
+
+ Description: Class used to pair a module Ability to the actual base class used to implement that ability
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 18 Jul 2013 11:51:33 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/moduleAbilities.h"
+#include "FWCore/Framework/interface/limited/implementors.h"
+#include "FWCore/Framework/interface/limited/EDProducerBase.h"
+
+// forward declarations
+namespace edm {
+  namespace limited {
+    namespace producer {
+      template<typename T> struct AbilityToImplementor;
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::StreamCache<C>> {
+        typedef edm::limited::impl::StreamCacheHolder<edm::limited::EDProducerBase,C> Type;
+      };
+
+      template<typename C>
+      struct AbilityToImplementor<edm::RunCache<C>> {
+        typedef edm::limited::impl::RunCacheHolder<edm::limited::EDProducerBase,C> Type;
+      };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::RunSummaryCache<C>> {
+        typedef edm::limited::impl::RunSummaryCacheHolder<edm::limited::EDProducerBase,C> Type;
+      };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::LuminosityBlockCache<C>> {
+        typedef edm::limited::impl::LuminosityBlockCacheHolder<edm::limited::EDProducerBase,C> Type;
+      };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::LuminosityBlockSummaryCache<C>> {
+        typedef edm::limited::impl::LuminosityBlockSummaryCacheHolder<edm::limited::EDProducerBase,C> Type;
+      };
+      
+      template<>
+      struct AbilityToImplementor<edm::BeginRunProducer> {
+        typedef edm::limited::impl::BeginRunProducer<edm::limited::EDProducerBase> Type;
+      };
+      
+      template<>
+      struct AbilityToImplementor<edm::EndRunProducer> {
+        typedef edm::limited::impl::EndRunProducer<edm::limited::EDProducerBase> Type;
+      };
+      
+      template<>
+      struct AbilityToImplementor<edm::BeginLuminosityBlockProducer> {
+        typedef edm::limited::impl::BeginLuminosityBlockProducer<edm::limited::EDProducerBase> Type;
+      };
+      
+      template<>
+      struct AbilityToImplementor<edm::EndLuminosityBlockProducer> {
+        typedef edm::limited::impl::EndLuminosityBlockProducer<edm::limited::EDProducerBase> Type;
+      };
+      
+      template<bool,bool,typename T> struct SpecializeAbilityToImplementor {
+        typedef typename AbilityToImplementor<T>::Type Type;
+      };
+      
+      template<bool B,typename C> struct SpecializeAbilityToImplementor<true,B,edm::RunSummaryCache<C>> {
+        typedef typename edm::limited::impl::EndRunSummaryProducer<edm::limited::EDProducerBase,C> Type;
+      };
+      
+      template<bool B> struct SpecializeAbilityToImplementor<true,B,edm::EndRunProducer> {
+        typedef typename edm::limited::impl::EmptyType Type;
+      };
+
+      template<bool B,typename C> struct SpecializeAbilityToImplementor<B,true,edm::LuminosityBlockSummaryCache<C>> {
+        typedef typename edm::limited::impl::EndLuminosityBlockSummaryProducer<edm::limited::EDProducerBase,C> Type;
+      };
+      
+      template<bool B> struct SpecializeAbilityToImplementor<B,true,edm::EndLuminosityBlockProducer> {
+        typedef typename edm::limited::impl::EmptyType Type;
+      };
+    }
+  }
+}
+
+#endif

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.cc
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.cc
@@ -105,15 +105,20 @@ namespace edm {
     std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::one::OutputModuleBase * iMod){
       return std::make_unique<OutputModuleCommunicatorT<edm::one::OutputModuleBase>>(iMod);
     }
+    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::limited::OutputModuleBase * iMod){
+      return std::make_unique<OutputModuleCommunicatorT<edm::limited::OutputModuleBase>>(iMod);
+    }
   }
 }
 
 #include "FWCore/Framework/interface/OutputModule.h"
 #include "FWCore/Framework/interface/global/OutputModuleBase.h"
 #include "FWCore/Framework/interface/one/OutputModuleBase.h"
+#include "FWCore/Framework/interface/limited/OutputModuleBase.h"
 
 namespace edm {
   template class OutputModuleCommunicatorT<OutputModule>;
   template class OutputModuleCommunicatorT<one::OutputModuleBase>;
   template class OutputModuleCommunicatorT<global::OutputModuleBase>;
+  template class OutputModuleCommunicatorT<limited::OutputModuleBase>;
 }

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.h
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.h
@@ -33,33 +33,33 @@ namespace edm {
   public:
     OutputModuleCommunicatorT(T* iModule):
     module_(iModule){}
-    virtual void closeFile() override;
+    void closeFile() override;
     
     ///\return true if output module wishes to close its file
-    virtual bool shouldWeCloseFile() const override;
+    bool shouldWeCloseFile() const override;
     
     ///\return true if no event filtering is applied to OutputModule
-    virtual bool wantAllEvents() const override;
+    bool wantAllEvents() const override;
     
-    virtual void openFile(edm::FileBlock const& fb) override;
+    void openFile(edm::FileBlock const& fb) override;
     
-    virtual void writeRun(edm::RunPrincipal const& rp, ProcessContext const*) override;
+    void writeRun(edm::RunPrincipal const& rp, ProcessContext const*) override;
     
-    virtual void writeLumi(edm::LuminosityBlockPrincipal const& lbp, ProcessContext const*) override;
+    void writeLumi(edm::LuminosityBlockPrincipal const& lbp, ProcessContext const*) override;
     
     ///\return true if OutputModule has reached its limit on maximum number of events it wants to see
-    virtual bool limitReached() const override;
+    bool limitReached() const override;
     
-    virtual void configure(edm::OutputModuleDescription const& desc) override;
+    void configure(edm::OutputModuleDescription const& desc) override;
     
-    virtual edm::SelectedProductsForBranchType const& keptProducts() const override;
+    edm::SelectedProductsForBranchType const& keptProducts() const override;
     
-    virtual void selectProducts(edm::ProductRegistry const& preg, ThinnedAssociationsHelper const&) override;
+    void selectProducts(edm::ProductRegistry const& preg, ThinnedAssociationsHelper const&) override;
     
-    virtual void setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
+    void setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
                                        bool anyProductProduced) override;
     
-    virtual ModuleDescription const& description() const override;
+    ModuleDescription const& description() const override;
 
     static std::unique_ptr<edm::OutputModuleCommunicator> createIfNeeded(T* iMod) {
       return std::move(impl::createCommunicatorIfNeeded(iMod));

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.h
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.h
@@ -16,11 +16,15 @@ namespace edm {
   namespace global {
     class OutputModuleBase;
   }
+  namespace limited {
+    class OutputModuleBase;
+  }
   namespace impl {
     std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(void *);
     std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::OutputModule *);
     std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::one::OutputModuleBase *);
     std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::global::OutputModuleBase *);
+    std::unique_ptr<edm::OutputModuleCommunicator> createCommunicatorIfNeeded(::edm::limited::OutputModuleBase *);
   }
   
   template <typename T>

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -39,6 +39,7 @@ the worker is reset().
 #include "FWCore/ServiceRegistry/interface/PlaceInPathContext.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/Concurrency/interface/SerialTaskQueueChain.h"
+#include "FWCore/Concurrency/interface/LimitedTaskQueue.h"
 #include "FWCore/Concurrency/interface/FunctorTask.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
@@ -78,6 +79,34 @@ namespace edm {
   public:
     enum State { Ready, Pass, Fail, Exception };
     enum Types { kAnalyzer, kFilter, kProducer, kOutputModule};
+    struct TaskQueueAdaptor {
+      SerialTaskQueueChain* serial_ = nullptr;
+      LimitedTaskQueue* limited_ = nullptr;
+      
+      TaskQueueAdaptor() = default;
+      TaskQueueAdaptor(SerialTaskQueueChain* iChain): serial_(iChain) {}
+      TaskQueueAdaptor(LimitedTaskQueue* iLimited): limited_(iLimited) {}
+      
+      operator bool() { return serial_ != nullptr or limited_ != nullptr; }
+      
+      template <class F>
+      void push(F&& iF) {
+        if(serial_) {
+          serial_->push(iF);
+        } else {
+          limited_->push(iF);
+        }
+      }
+      template <class F>
+      void pushAndWait(F&& iF) {
+        if(serial_) {
+          serial_->pushAndWait(iF);
+        } else {
+          limited_->pushAndWait(iF);
+        }
+      }
+      
+    };
 
     Worker(ModuleDescription const& iMD, ExceptionToActionTable const* iActions);
     virtual ~Worker();
@@ -236,7 +265,7 @@ namespace edm {
 
     virtual void implRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) = 0;
     
-    virtual SerialTaskQueueChain* serializeRunModule() = 0;
+    virtual TaskQueueAdaptor serializeRunModule() = 0;
     
     static void exceptionContext(cms::Exception& ex,
                                  ModuleCallingContext const* mcc);
@@ -361,7 +390,7 @@ namespace edm {
             auto parentContext = m_parentContext;
             auto serviceToken = m_serviceToken;
             auto sContext = m_context;
-            queue->push( [worker, &principal, &es, streamID,parentContext,sContext, serviceToken]()
+            queue.push( [worker, &principal, &es, streamID,parentContext,sContext, serviceToken]()
             {
               //Need to make the services available
               ServiceRegistry::Operate guard(serviceToken);
@@ -706,7 +735,7 @@ namespace edm {
         this->waitingTasks_.doneWaiting(exceptionPtr);
       };
       if(auto queue = this->serializeRunModule()) {
-        queue->push( toDo);
+        queue.push( toDo);
       } else {
         auto task = make_functor_task( tbb::task::allocate_root(), toDo);
         tbb::task::spawn(*task);
@@ -806,7 +835,7 @@ namespace edm {
     prefetchSentry.release();
     if(auto queue = serializeRunModule()) {
       auto serviceToken = ServiceRegistry::instance().presentToken();
-      queue->pushAndWait([&]() {
+      queue.pushAndWait([&]() {
         //Need to make the services available
         ServiceRegistry::Operate guard(serviceToken);
         try {

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -18,6 +18,11 @@
 #include "FWCore/Framework/interface/stream/EDFilterAdaptorBase.h"
 #include "FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h"
 
+#include "FWCore/Framework/interface/limited/EDProducerBase.h"
+#include "FWCore/Framework/interface/limited/EDFilterBase.h"
+#include "FWCore/Framework/interface/limited/EDAnalyzerBase.h"
+#include "FWCore/Framework/interface/limited/OutputModuleBase.h"
+
 #include <type_traits>
 
 namespace edm{
@@ -39,6 +44,21 @@ namespace edm{
 
     template<>
     struct has_stream_functions<edm::global::EDAnalyzerBase> {
+      static bool constexpr value = true;
+    };
+
+    template<>
+    struct has_stream_functions<edm::limited::EDProducerBase> {
+      static bool constexpr value = true;
+    };
+    
+    template<>
+    struct has_stream_functions<edm::limited::EDFilterBase> {
+      static bool constexpr value = true;
+    };
+    
+    template<>
+    struct has_stream_functions<edm::limited::EDAnalyzerBase> {
       static bool constexpr value = true;
     };
 
@@ -146,6 +166,15 @@ namespace edm{
   inline
   bool
   WorkerT<edm::global::OutputModuleBase>::implDoPrePrefetchSelection(StreamID id,
+                                                                     EventPrincipal const& ep,
+                                                                     ModuleCallingContext const* mcc) {
+    return module_->prePrefetchSelection(id,ep,mcc);
+  }
+
+  template<>
+  inline
+  bool
+  WorkerT<edm::limited::OutputModuleBase>::implDoPrePrefetchSelection(StreamID id,
                                                                      EventPrincipal const& ep,
                                                                      ModuleCallingContext const* mcc) {
     return module_->prePrefetchSelection(id,ep,mcc);
@@ -350,32 +379,44 @@ namespace edm{
 
   template<typename T>
   inline
-  SerialTaskQueueChain* WorkerT<T>::serializeRunModule() {
-    return nullptr;
+  Worker::TaskQueueAdaptor WorkerT<T>::serializeRunModule() {
+    return Worker::TaskQueueAdaptor{};
   }
-  template<> SerialTaskQueueChain* WorkerT<EDAnalyzer>::serializeRunModule() {
+  template<> Worker::TaskQueueAdaptor WorkerT<EDAnalyzer>::serializeRunModule() {
     return &(module_->sharedResourcesAcquirer().serialQueueChain());
   }
-  template<> SerialTaskQueueChain* WorkerT<EDFilter>::serializeRunModule() {
+  template<> Worker::TaskQueueAdaptor WorkerT<EDFilter>::serializeRunModule() {
     return &(module_->sharedResourcesAcquirer().serialQueueChain());
   }
-  template<> SerialTaskQueueChain* WorkerT<EDProducer>::serializeRunModule() {
+  template<> Worker::TaskQueueAdaptor WorkerT<EDProducer>::serializeRunModule() {
     return &(module_->sharedResourcesAcquirer().serialQueueChain());
   }
-  template<> SerialTaskQueueChain* WorkerT<OutputModule>::serializeRunModule() {
+  template<> Worker::TaskQueueAdaptor WorkerT<OutputModule>::serializeRunModule() {
     return &(module_->sharedResourcesAcquirer().serialQueueChain());
   }
-  template<> SerialTaskQueueChain* WorkerT<one::EDAnalyzerBase>::serializeRunModule() {
+  template<> Worker::TaskQueueAdaptor WorkerT<one::EDAnalyzerBase>::serializeRunModule() {
     return &(module_->sharedResourcesAcquirer().serialQueueChain());
   }
-  template<> SerialTaskQueueChain* WorkerT<one::EDFilterBase>::serializeRunModule() {
+  template<> Worker::TaskQueueAdaptor WorkerT<one::EDFilterBase>::serializeRunModule() {
     return &(module_->sharedResourcesAcquirer().serialQueueChain());
   }
-  template<> SerialTaskQueueChain* WorkerT<one::EDProducerBase>::serializeRunModule() {
+  template<> Worker::TaskQueueAdaptor WorkerT<one::EDProducerBase>::serializeRunModule() {
     return &(module_->sharedResourcesAcquirer().serialQueueChain());
   }
-  template<> SerialTaskQueueChain* WorkerT<one::OutputModuleBase>::serializeRunModule() {
+  template<> Worker::TaskQueueAdaptor WorkerT<one::OutputModuleBase>::serializeRunModule() {
     return &(module_->sharedResourcesAcquirer().serialQueueChain());
+  }
+  template<> Worker::TaskQueueAdaptor WorkerT<limited::EDAnalyzerBase>::serializeRunModule() {
+    return &(module_->queue());
+  }
+  template<> Worker::TaskQueueAdaptor WorkerT<limited::EDFilterBase>::serializeRunModule() {
+    return &(module_->queue());
+  }
+  template<> Worker::TaskQueueAdaptor WorkerT<limited::EDProducerBase>::serializeRunModule() {
+    return &(module_->queue());
+  }
+  template<> Worker::TaskQueueAdaptor WorkerT<limited::OutputModuleBase>::serializeRunModule() {
+    return &(module_->queue());
   }
 
 
@@ -396,6 +437,11 @@ namespace edm{
     template<> bool mustPrefetchMayGet<edm::global::EDFilterBase>() { return true;}
     template<> bool mustPrefetchMayGet<edm::global::EDAnalyzerBase>() { return true;}
     template<> bool mustPrefetchMayGet<edm::global::OutputModuleBase>() { return true;}
+
+    template<> bool mustPrefetchMayGet<edm::limited::EDProducerBase>() { return true;}
+    template<> bool mustPrefetchMayGet<edm::limited::EDFilterBase>() { return true;}
+    template<> bool mustPrefetchMayGet<edm::limited::EDAnalyzerBase>() { return true;}
+    template<> bool mustPrefetchMayGet<edm::limited::OutputModuleBase>() { return true;}
 
     template<> bool mustPrefetchMayGet<edm::stream::EDProducerAdaptorBase>() { return true;}
     template<> bool mustPrefetchMayGet<edm::stream::EDFilterAdaptorBase>() { return true;}
@@ -498,6 +544,15 @@ namespace edm{
   template<>
   Worker::Types WorkerT<edm::global::OutputModuleBase>::moduleType() const { return Worker::kOutputModule;}
 
+  template<>
+  Worker::Types WorkerT<edm::limited::EDProducerBase>::moduleType() const { return Worker::kProducer;}
+  template<>
+  Worker::Types WorkerT<edm::limited::EDFilterBase>::moduleType() const { return Worker::kFilter;}
+  template<>
+  Worker::Types WorkerT<edm::limited::EDAnalyzerBase>::moduleType() const { return Worker::kAnalyzer;}
+  template<>
+  Worker::Types WorkerT<edm::limited::OutputModuleBase>::moduleType() const { return Worker::kOutputModule;}
+
 
   template<>
   Worker::Types WorkerT<edm::stream::EDProducerAdaptorBase>::moduleType() const { return Worker::kProducer;}
@@ -523,4 +578,8 @@ namespace edm{
   template class WorkerT<stream::EDProducerAdaptorBase>;
   template class WorkerT<stream::EDFilterAdaptorBase>;
   template class WorkerT<stream::EDAnalyzerAdaptorBase>;
+  template class WorkerT<limited::EDProducerBase>;
+  template class WorkerT<limited::EDFilterBase>;
+  template class WorkerT<limited::EDAnalyzerBase>;
+  template class WorkerT<limited::OutputModuleBase>;
 }

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -120,7 +120,7 @@ namespace edm{
   WorkerT<T>::WorkerT(std::shared_ptr<T> ed, ModuleDescription const& md, ExceptionToActionTable const* actions) :
     Worker(md, actions),
     module_(ed) {
-    assert(module_ != 0);
+    assert(module_ != nullptr);
   }
 
   template<typename T>

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -104,7 +104,7 @@ namespace edm {
     virtual void implRespondToCloseInputFile(FileBlock const& fb) override;
     virtual void implRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) override;
     virtual std::string workerType() const override;
-    virtual SerialTaskQueueChain* serializeRunModule() override;
+    virtual TaskQueueAdaptor serializeRunModule() override;
 
 
     virtual void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -35,18 +35,18 @@ namespace edm {
             ModuleDescription const&,
             ExceptionToActionTable const* actions);
 
-    virtual ~WorkerT();
+    ~WorkerT() override;
 
     void setModule( std::shared_ptr<T> iModule) {
       module_ = iModule;
       resetModuleDescription(&(module_->moduleDescription()));
     }
     
-    virtual Types moduleType() const override;
+    Types moduleType() const override;
 
-    virtual void updateLookup(BranchType iBranchType,
+    void updateLookup(BranchType iBranchType,
                               ProductResolverIndexHelper const&) override;
-    virtual void resolvePutIndicies(BranchType iBranchType,
+    void resolvePutIndicies(BranchType iBranchType,
                                     std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies) override;
 
     template<typename D>
@@ -75,65 +75,65 @@ namespace edm {
     T const& module() const {return *module_;}
 
   private:
-    virtual bool implDo(EventPrincipal const& ep, EventSetup const& c,
+    bool implDo(EventPrincipal const& ep, EventSetup const& c,
                         ModuleCallingContext const* mcc) override;
-    virtual bool implDoPrePrefetchSelection(StreamID id,
+    bool implDoPrePrefetchSelection(StreamID id,
                                             EventPrincipal const& ep,
                                             ModuleCallingContext const* mcc) override;
-    virtual bool implDoBegin(RunPrincipal const& rp, EventSetup const& c,
+    bool implDoBegin(RunPrincipal const& rp, EventSetup const& c,
                              ModuleCallingContext const* mcc) override;
-    virtual bool implDoStreamBegin(StreamID id, RunPrincipal const& rp, EventSetup const& c,
+    bool implDoStreamBegin(StreamID id, RunPrincipal const& rp, EventSetup const& c,
                                    ModuleCallingContext const* mcc) override;
-    virtual bool implDoStreamEnd(StreamID id, RunPrincipal const& rp, EventSetup const& c,
+    bool implDoStreamEnd(StreamID id, RunPrincipal const& rp, EventSetup const& c,
                                  ModuleCallingContext const* mcc) override;
-    virtual bool implDoEnd(RunPrincipal const& rp, EventSetup const& c,
+    bool implDoEnd(RunPrincipal const& rp, EventSetup const& c,
                            ModuleCallingContext const* mcc) override;
-    virtual bool implDoBegin(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    bool implDoBegin(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                              ModuleCallingContext const* mcc) override;
-    virtual bool implDoStreamBegin(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    bool implDoStreamBegin(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                    ModuleCallingContext const* mcc) override;
-    virtual bool implDoStreamEnd(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    bool implDoStreamEnd(StreamID id, LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                                  ModuleCallingContext const* mcc) override;
-    virtual bool implDoEnd(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+    bool implDoEnd(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
                            ModuleCallingContext const* mcc) override;
-    virtual void implBeginJob() override;
-    virtual void implEndJob() override;
-    virtual void implBeginStream(StreamID) override;
-    virtual void implEndStream(StreamID) override;
-    virtual void implRespondToOpenInputFile(FileBlock const& fb) override;
-    virtual void implRespondToCloseInputFile(FileBlock const& fb) override;
-    virtual void implRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) override;
-    virtual std::string workerType() const override;
-    virtual TaskQueueAdaptor serializeRunModule() override;
+    void implBeginJob() override;
+    void implEndJob() override;
+    void implBeginStream(StreamID) override;
+    void implEndStream(StreamID) override;
+    void implRespondToOpenInputFile(FileBlock const& fb) override;
+    void implRespondToCloseInputFile(FileBlock const& fb) override;
+    void implRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) override;
+    std::string workerType() const override;
+    TaskQueueAdaptor serializeRunModule() override;
 
 
-    virtual void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
+    void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
                                                  ProductRegistry const& preg,
                                                  std::map<std::string, ModuleDescription const*> const& labelsToDesc) const override {
       module_->modulesWhoseProductsAreConsumed(modules, preg, labelsToDesc, module_->moduleDescription().processName());
     }
 
-    virtual void convertCurrentProcessAlias(std::string const& processName) override {
+    void convertCurrentProcessAlias(std::string const& processName) override {
       module_->convertCurrentProcessAlias(processName);
     }
 
-    virtual std::vector<ConsumesInfo> consumesInfo() const override {
+    std::vector<ConsumesInfo> consumesInfo() const override {
       return module_->consumesInfo();
     }
 
-    virtual void itemsToGet(BranchType branchType, std::vector<ProductResolverIndexAndSkipBit>& indexes) const override {
+    void itemsToGet(BranchType branchType, std::vector<ProductResolverIndexAndSkipBit>& indexes) const override {
       module_->itemsToGet(branchType, indexes);
     }
 
-    virtual void itemsMayGet(BranchType branchType, std::vector<ProductResolverIndexAndSkipBit>& indexes) const override {
+    void itemsMayGet(BranchType branchType, std::vector<ProductResolverIndexAndSkipBit>& indexes) const override {
       module_->itemsMayGet(branchType, indexes);
     }
 
-    virtual std::vector<ProductResolverIndexAndSkipBit> const& itemsToGetFrom(BranchType iType) const override final { return module_->itemsToGetFrom(iType); }
+    std::vector<ProductResolverIndexAndSkipBit> const& itemsToGetFrom(BranchType iType) const final { return module_->itemsToGetFrom(iType); }
     
-    virtual std::vector<ProductResolverIndex> const& itemsShouldPutInEvent() const override;
+    std::vector<ProductResolverIndex> const& itemsShouldPutInEvent() const override;
 
-    virtual void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const override {
+    void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const override {
       module_->preActionBeforeRunEventAsync(iTask,iModuleCallingContext,iPrincipal);
     }
 

--- a/FWCore/Framework/src/limited/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/limited/EDAnalyzerBase.cc
@@ -43,8 +43,9 @@ namespace edm {
     //
     // constructors and destructor
     //
-    EDAnalyzerBase::EDAnalyzerBase():
-    moduleDescription_() { }
+    EDAnalyzerBase::EDAnalyzerBase(ParameterSet const& pset):
+    moduleDescription_(),
+    queue_(pset.getUntrackedParameter<unsigned int>("concurrencyLimit")) { }
     
     EDAnalyzerBase::~EDAnalyzerBase()
     {

--- a/FWCore/Framework/src/limited/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/limited/EDAnalyzerBase.cc
@@ -1,0 +1,233 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     limited::EDAnalyzerBase
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 02 May 2013 21:56:04 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/limited/EDAnalyzerBase.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/src/edmodule_mightGet_config.h"
+#include "FWCore/Framework/src/PreallocationConfiguration.h"
+#include "FWCore/Framework/src/EventSignalsSentry.h"
+
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/ConstProductRegistry.h"
+
+
+//
+// constants, enums and typedefs
+//
+namespace edm {
+  namespace limited {
+    //
+    // static data member definitions
+    //
+    
+    //
+    // constructors and destructor
+    //
+    EDAnalyzerBase::EDAnalyzerBase():
+    moduleDescription_() { }
+    
+    EDAnalyzerBase::~EDAnalyzerBase()
+    {
+    }
+    
+    bool
+    EDAnalyzerBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
+                            ActivityRegistry* act,
+                            ModuleCallingContext const* mcc) {
+      Event e(ep, moduleDescription_, mcc);
+      e.setConsumer(this);
+      EventSignalsSentry sentry(act,mcc);
+      this->analyze(e.streamID(), e, c);
+      return true;
+    }
+    
+    void
+    EDAnalyzerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
+      preallocStreams(iPrealloc.numberOfStreams());
+    }
+
+    void
+    EDAnalyzerBase::doBeginJob() {
+      this->beginJob();
+    }
+    
+    void
+    EDAnalyzerBase::doEndJob() {
+      this->endJob();
+    }
+    
+    void
+    EDAnalyzerBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+                               ModuleCallingContext const* mcc) {
+      
+      Run r(rp, moduleDescription_, mcc);
+      r.setConsumer(this);
+      Run const& cnstR = r;
+      this->doBeginRun_(cnstR, c);
+      this->doBeginRunSummary_(cnstR, c);
+    }
+    
+    void
+    EDAnalyzerBase::doEndRun(RunPrincipal const& rp, EventSetup const& c,
+                             ModuleCallingContext const* mcc) {
+      Run r(rp, moduleDescription_, mcc);
+      r.setConsumer(this);
+      Run const& cnstR = r;
+      this->doEndRunSummary_(r,c);
+      this->doEndRun_(cnstR, c);
+    }
+    
+    void
+    EDAnalyzerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+                                           ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
+      lb.setConsumer(this);
+      LuminosityBlock const& cnstLb = lb;
+      this->doBeginLuminosityBlock_(cnstLb, c);
+      this->doBeginLuminosityBlockSummary_(cnstLb, c);
+    }
+    
+    void
+    EDAnalyzerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+                                         ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
+      lb.setConsumer(this);
+      LuminosityBlock const& cnstLb = lb;
+      this->doEndLuminosityBlockSummary_(cnstLb,c);
+      this->doEndLuminosityBlock_(cnstLb, c);
+    }
+    
+    void
+    EDAnalyzerBase::doBeginStream(StreamID id) {
+      doBeginStream_(id);
+    }
+    void
+    EDAnalyzerBase::doEndStream(StreamID id) {
+      doEndStream_(id);
+    }
+    void
+    EDAnalyzerBase::doStreamBeginRun(StreamID id,
+                                     RunPrincipal const& rp,
+                                     EventSetup const& c,
+                                     ModuleCallingContext const* mcc)
+    {
+      Run r(rp, moduleDescription_, mcc);
+      r.setConsumer(this);
+      this->doStreamBeginRun_(id, r, c);
+    }
+    void
+    EDAnalyzerBase::doStreamEndRun(StreamID id,
+                                   RunPrincipal const& rp,
+                                   EventSetup const& c,
+                                   ModuleCallingContext const* mcc) {
+      Run r(rp, moduleDescription_, mcc);
+      r.setConsumer(this);
+      this->doStreamEndRun_(id, r, c);
+      this->doStreamEndRunSummary_(id, r, c);
+    }
+    void
+    EDAnalyzerBase::doStreamBeginLuminosityBlock(StreamID id,
+                                                 LuminosityBlockPrincipal const& lbp,
+                                                 EventSetup const& c,
+                                                 ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
+      lb.setConsumer(this);
+      this->doStreamBeginLuminosityBlock_(id,lb, c);
+    }
+    
+    void
+    EDAnalyzerBase::doStreamEndLuminosityBlock(StreamID id,
+                                               LuminosityBlockPrincipal const& lbp,
+                                               EventSetup const& c,
+                                               ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
+      lb.setConsumer(this);
+      this->doStreamEndLuminosityBlock_(id,lb, c);
+      this->doStreamEndLuminosityBlockSummary_(id,lb, c);
+    }
+    
+    
+    
+    void
+    EDAnalyzerBase::doRespondToOpenInputFile(FileBlock const& fb) {
+      //respondToOpenInputFile(fb);
+    }
+    
+    void
+    EDAnalyzerBase::doRespondToCloseInputFile(FileBlock const& fb) {
+      //respondToCloseInputFile(fb);
+    }
+    
+    void EDAnalyzerBase::preallocStreams(unsigned int) {}
+    void EDAnalyzerBase::doBeginStream_(StreamID id){}
+    void EDAnalyzerBase::doEndStream_(StreamID id) {}
+    void EDAnalyzerBase::doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) {}
+    void EDAnalyzerBase::doStreamEndRun_(StreamID id, Run const& rp, EventSetup const& c) {}
+    void EDAnalyzerBase::doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c) {}
+    void EDAnalyzerBase::doStreamBeginLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDAnalyzerBase::doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDAnalyzerBase::doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) {}
+    
+    
+    void EDAnalyzerBase::doBeginRun_(Run const& rp, EventSetup const& c) {}
+    void EDAnalyzerBase::doEndRun_(Run const& rp, EventSetup const& c) {}
+    void EDAnalyzerBase::doBeginRunSummary_(Run const& rp, EventSetup const& c) {}
+    void EDAnalyzerBase::doEndRunSummary_(Run const& rp, EventSetup const& c) {}
+    
+    void EDAnalyzerBase::doBeginLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDAnalyzerBase::doEndLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDAnalyzerBase::doBeginLuminosityBlockSummary_(LuminosityBlock const& rp, EventSetup const& c) {}
+    void EDAnalyzerBase::doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c) {}
+    
+    void
+    EDAnalyzerBase::fillDescriptions(ConfigurationDescriptions& descriptions) {
+      ParameterSetDescription desc;
+      desc.setUnknown();
+      descriptions.addDefault(desc);
+    }
+    
+    void
+    EDAnalyzerBase::prevalidate(ConfigurationDescriptions& iConfig) {
+      edmodule_mightGet_config(iConfig);
+    }
+    
+    void
+    EDAnalyzerBase::registerProductsAndCallbacks(EDAnalyzerBase*, ProductRegistry* reg) {
+      
+      if (callWhenNewProductsRegistered_) {
+        
+        reg->callForEachBranch(callWhenNewProductsRegistered_);
+        
+        Service<ConstProductRegistry> regService;
+        regService->watchProductAdditions(callWhenNewProductsRegistered_);
+      }
+    }
+    static const std::string kBaseType("EDAnalyzer");
+    
+    const std::string&
+    EDAnalyzerBase::baseType() {
+      return kBaseType;
+    }
+
+  }
+}

--- a/FWCore/Framework/src/limited/EDFilterBase.cc
+++ b/FWCore/Framework/src/limited/EDFilterBase.cc
@@ -37,11 +37,12 @@ namespace edm {
     //
     // constructors and destructor
     //
-    EDFilterBase::EDFilterBase():
+    EDFilterBase::EDFilterBase(ParameterSet const& pset):
     ProducerBase(),
     moduleDescription_(),
     previousParentages_(),
-    previousParentageIds_() { }
+    previousParentageIds_(),
+    queue_(pset.getUntrackedParameter<unsigned int>("concurrencyLimit")) { }
     
     EDFilterBase::~EDFilterBase()
     {

--- a/FWCore/Framework/src/limited/EDFilterBase.cc
+++ b/FWCore/Framework/src/limited/EDFilterBase.cc
@@ -1,0 +1,236 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     limited::EDFilterBase
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 02 May 2013 21:56:04 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/limited/EDFilterBase.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/src/edmodule_mightGet_config.h"
+#include "FWCore/Framework/src/PreallocationConfiguration.h"
+#include "FWCore/Framework/src/EventSignalsSentry.h"
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+
+//
+// constants, enums and typedefs
+//
+namespace edm {
+  namespace limited {
+    //
+    // static data member definitions
+    //
+    
+    //
+    // constructors and destructor
+    //
+    EDFilterBase::EDFilterBase():
+    ProducerBase(),
+    moduleDescription_(),
+    previousParentages_(),
+    previousParentageIds_() { }
+    
+    EDFilterBase::~EDFilterBase()
+    {
+    }
+    
+    bool
+    EDFilterBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
+                          ActivityRegistry* act,
+                          ModuleCallingContext const* mcc) {
+      Event e(ep, moduleDescription_, mcc);
+      e.setConsumer(this);
+      EventSignalsSentry sentry(act,mcc);
+      bool returnValue = this->filter(e.streamID(), e, c);
+      const auto streamIndex =e.streamID().value();
+      commit_(e,&previousParentages_[streamIndex], &previousParentageIds_[streamIndex]);
+      return returnValue;
+    }
+    
+    void
+    EDFilterBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
+      const auto nStreams =iPrealloc.numberOfStreams();
+      previousParentages_.reset(new std::vector<BranchID>[nStreams]);
+      previousParentageIds_.reset(new ParentageID[nStreams]);
+      preallocStreams(nStreams);
+    }
+
+    void
+    EDFilterBase::doBeginJob() {
+      this->beginJob();
+    }
+    
+    void
+    EDFilterBase::doEndJob() {
+      this->endJob();
+    }
+    
+    void
+    EDFilterBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+                             ModuleCallingContext const* mcc) {
+      Run r(rp, moduleDescription_, mcc);
+      r.setConsumer(this);
+      Run const& cnstR = r;
+      this->doBeginRun_(cnstR, c);
+      this->doBeginRunSummary_(cnstR, c);
+      this->doBeginRunProduce_(r,c);
+      commit_(r);
+    }
+    
+    void
+    EDFilterBase::doEndRun(RunPrincipal const& rp, EventSetup const& c,
+                           ModuleCallingContext const* mcc) {
+      Run r(rp, moduleDescription_, mcc);
+      r.setConsumer(this);
+      Run const& cnstR = r;
+      this->doEndRunProduce_(r, c);
+      this->doEndRunSummary_(r,c);
+      this->doEndRun_(cnstR, c);
+      commit_(r);
+    }
+    
+    void
+    EDFilterBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+                                         ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
+      lb.setConsumer(this);
+      LuminosityBlock const& cnstLb = lb;
+      this->doBeginLuminosityBlock_(cnstLb, c);
+      this->doBeginLuminosityBlockSummary_(cnstLb, c);
+      this->doBeginLuminosityBlockProduce_(lb, c);
+      commit_(lb);
+    }
+    
+    void
+    EDFilterBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+                                       ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
+      lb.setConsumer(this);
+      LuminosityBlock const& cnstLb = lb;
+      this->doEndLuminosityBlockProduce_(lb, c);
+      this->doEndLuminosityBlockSummary_(cnstLb,c);
+      this->doEndLuminosityBlock_(cnstLb, c);
+      commit_(lb);
+    }
+    
+    void
+    EDFilterBase::doBeginStream(StreamID id) {
+      doBeginStream_(id);
+    }
+    void
+    EDFilterBase::doEndStream(StreamID id) {
+      doEndStream_(id);
+    }
+    void
+    EDFilterBase::doStreamBeginRun(StreamID id,
+                                     RunPrincipal const& rp,
+                                     EventSetup const& c,
+                                     ModuleCallingContext const* mcc)
+    {
+      Run r(rp, moduleDescription_, mcc);
+      r.setConsumer(this);
+      this->doStreamBeginRun_(id, r, c);
+    }
+    void
+    EDFilterBase::doStreamEndRun(StreamID id,
+                                   RunPrincipal const& rp,
+                                   EventSetup const& c,
+                                   ModuleCallingContext const* mcc) {
+      Run r(rp, moduleDescription_, mcc);
+      r.setConsumer(this);
+      this->doStreamEndRun_(id, r, c);
+      this->doStreamEndRunSummary_(id, r, c);
+    }
+    void
+    EDFilterBase::doStreamBeginLuminosityBlock(StreamID id,
+                                                 LuminosityBlockPrincipal const& lbp,
+                                                 EventSetup const& c,
+                                                 ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
+      lb.setConsumer(this);
+      this->doStreamBeginLuminosityBlock_(id,lb, c);
+    }
+    
+    void
+    EDFilterBase::doStreamEndLuminosityBlock(StreamID id,
+                                               LuminosityBlockPrincipal const& lbp,
+                                               EventSetup const& c,
+                                               ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
+      lb.setConsumer(this);
+      this->doStreamEndLuminosityBlock_(id,lb, c);
+      this->doStreamEndLuminosityBlockSummary_(id,lb, c);
+    }
+    
+    
+    
+    void
+    EDFilterBase::doRespondToOpenInputFile(FileBlock const& fb) {
+      //respondToOpenInputFile(fb);
+    }
+    
+    void
+    EDFilterBase::doRespondToCloseInputFile(FileBlock const& fb) {
+      //respondToCloseInputFile(fb);
+    }
+    
+    void EDFilterBase::preallocStreams(unsigned int) {}
+    void EDFilterBase::doBeginStream_(StreamID id){}
+    void EDFilterBase::doEndStream_(StreamID id) {}
+    void EDFilterBase::doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) {}
+    void EDFilterBase::doStreamEndRun_(StreamID id, Run const& rp, EventSetup const& c) {}
+    void EDFilterBase::doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c) {}
+    void EDFilterBase::doStreamBeginLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDFilterBase::doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDFilterBase::doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) {}
+    
+    
+    void EDFilterBase::doBeginRun_(Run const& rp, EventSetup const& c) {}
+    void EDFilterBase::doEndRun_(Run const& rp, EventSetup const& c) {}
+    void EDFilterBase::doBeginRunSummary_(Run const& rp, EventSetup const& c) {}
+    void EDFilterBase::doEndRunSummary_(Run const& rp, EventSetup const& c) {}
+    
+    void EDFilterBase::doBeginLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDFilterBase::doEndLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDFilterBase::doBeginLuminosityBlockSummary_(LuminosityBlock const& rp, EventSetup const& c) {}
+    void EDFilterBase::doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c) {}
+    
+    void EDFilterBase::doBeginRunProduce_(Run& rp, EventSetup const& c) {}
+    void EDFilterBase::doEndRunProduce_(Run& rp, EventSetup const& c) {}
+    void EDFilterBase::doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) {}
+    void EDFilterBase::doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) {}
+    
+    void
+    EDFilterBase::fillDescriptions(ConfigurationDescriptions& descriptions) {
+      ParameterSetDescription desc;
+      desc.setUnknown();
+      descriptions.addDefault(desc);
+    }
+    
+    void
+    EDFilterBase::prevalidate(ConfigurationDescriptions& iConfig) {
+      edmodule_mightGet_config(iConfig);
+    }
+    
+    static const std::string kBaseType("EDFilter");
+    
+    const std::string&
+    EDFilterBase::baseType() {
+      return kBaseType;
+    }
+
+  }
+}

--- a/FWCore/Framework/src/limited/EDProducerBase.cc
+++ b/FWCore/Framework/src/limited/EDProducerBase.cc
@@ -37,11 +37,12 @@ namespace edm {
     //
     // constructors and destructor
     //
-    EDProducerBase::EDProducerBase():
+    EDProducerBase::EDProducerBase(ParameterSet const& pset):
     ProducerBase(),
     moduleDescription_(),
     previousParentages_(),
-    previousParentageIds_() { }
+    previousParentageIds_(),
+    queue_(pset.getUntrackedParameter<unsigned int>("concurrencyLimit")){ }
     
     EDProducerBase::~EDProducerBase()
     {

--- a/FWCore/Framework/src/limited/EDProducerBase.cc
+++ b/FWCore/Framework/src/limited/EDProducerBase.cc
@@ -1,0 +1,236 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     limited::EDProducerBase
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 02 May 2013 21:56:04 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/limited/EDProducerBase.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/src/edmodule_mightGet_config.h"
+#include "FWCore/Framework/src/PreallocationConfiguration.h"
+#include "FWCore/Framework/src/EventSignalsSentry.h"
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+
+//
+// constants, enums and typedefs
+//
+namespace edm {
+  namespace limited {
+    //
+    // static data member definitions
+    //
+    
+    //
+    // constructors and destructor
+    //
+    EDProducerBase::EDProducerBase():
+    ProducerBase(),
+    moduleDescription_(),
+    previousParentages_(),
+    previousParentageIds_() { }
+    
+    EDProducerBase::~EDProducerBase()
+    {
+    }
+    
+    bool
+    EDProducerBase::doEvent(EventPrincipal const& ep, EventSetup const& c,
+                            ActivityRegistry* act,
+                            ModuleCallingContext const* mcc) {
+      Event e(ep, moduleDescription_, mcc);
+      e.setConsumer(this);
+      EventSignalsSentry sentry(act,mcc);
+      this->produce(e.streamID(), e, c);
+      const auto streamIndex = e.streamID().value();
+      commit_(e,&previousParentages_[streamIndex], &previousParentageIds_[streamIndex]);
+      return true;
+    }
+
+    void
+    EDProducerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
+      auto const nStreams = iPrealloc.numberOfStreams();
+      previousParentages_.reset(new std::vector<BranchID>[nStreams]);
+      previousParentageIds_.reset( new ParentageID[nStreams]);
+      preallocStreams(nStreams);
+    }
+    
+    void
+    EDProducerBase::doBeginJob() {
+      this->beginJob();
+    }
+    
+    void
+    EDProducerBase::doEndJob() {
+      this->endJob();
+    }
+    
+    void
+    EDProducerBase::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
+                               ModuleCallingContext const* mcc) {
+      Run r(rp, moduleDescription_, mcc);
+      r.setConsumer(this);
+      Run const& cnstR = r;
+      this->doBeginRun_(cnstR, c);
+      this->doBeginRunSummary_(cnstR, c);
+      this->doBeginRunProduce_(r,c);
+      commit_(r);
+    }
+    
+    void
+    EDProducerBase::doEndRun(RunPrincipal const& rp, EventSetup const& c,
+                             ModuleCallingContext const* mcc) {
+      Run r(rp, moduleDescription_, mcc);
+      r.setConsumer(this);
+      Run const& cnstR = r;
+      this->doEndRunProduce_(r, c);
+      this->doEndRunSummary_(r,c);
+      this->doEndRun_(cnstR, c);
+      commit_(r);
+    }
+    
+    void
+    EDProducerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+                                           ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
+      lb.setConsumer(this);
+      LuminosityBlock const& cnstLb = lb;
+      this->doBeginLuminosityBlock_(cnstLb, c);
+      this->doBeginLuminosityBlockSummary_(cnstLb, c);
+      this->doBeginLuminosityBlockProduce_(lb, c);
+      commit_(lb);
+    }
+    
+    void
+    EDProducerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
+                                         ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
+      lb.setConsumer(this);
+      LuminosityBlock const& cnstLb = lb;
+      this->doEndLuminosityBlockProduce_(lb, c);
+      this->doEndLuminosityBlockSummary_(cnstLb,c);
+      this->doEndLuminosityBlock_(cnstLb, c);
+      commit_(lb);
+    }
+    
+    void
+    EDProducerBase::doBeginStream(StreamID id) {
+      doBeginStream_(id);
+    }
+    void
+    EDProducerBase::doEndStream(StreamID id) {
+      doEndStream_(id);
+    }
+    void
+    EDProducerBase::doStreamBeginRun(StreamID id,
+                                     RunPrincipal const& rp,
+                                     EventSetup const& c,
+                                     ModuleCallingContext const* mcc)
+    {
+      Run r(rp, moduleDescription_, mcc);
+      r.setConsumer(this);
+      this->doStreamBeginRun_(id, r, c);
+    }
+    void
+    EDProducerBase::doStreamEndRun(StreamID id,
+                                   RunPrincipal const& rp,
+                                   EventSetup const& c,
+                                   ModuleCallingContext const* mcc) {
+      Run r(rp, moduleDescription_, mcc);
+      r.setConsumer(this);
+      this->doStreamEndRun_(id, r, c);
+      this->doStreamEndRunSummary_(id, r, c);
+    }
+    void
+    EDProducerBase::doStreamBeginLuminosityBlock(StreamID id,
+                                                 LuminosityBlockPrincipal const& lbp,
+                                                 EventSetup const& c,
+                                                 ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
+      lb.setConsumer(this);
+      this->doStreamBeginLuminosityBlock_(id,lb, c);
+    }
+    
+    void
+    EDProducerBase::doStreamEndLuminosityBlock(StreamID id,
+                                               LuminosityBlockPrincipal const& lbp,
+                                               EventSetup const& c,
+                                               ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
+      lb.setConsumer(this);
+      this->doStreamEndLuminosityBlock_(id,lb, c);
+      this->doStreamEndLuminosityBlockSummary_(id,lb, c);
+    }
+    
+    
+    
+    void
+    EDProducerBase::doRespondToOpenInputFile(FileBlock const& fb) {
+      //respondToOpenInputFile(fb);
+    }
+    
+    void
+    EDProducerBase::doRespondToCloseInputFile(FileBlock const& fb) {
+      //respondToCloseInputFile(fb);
+    }
+    
+    void EDProducerBase::preallocStreams(unsigned int) {}
+    void EDProducerBase::doBeginStream_(StreamID id){}
+    void EDProducerBase::doEndStream_(StreamID id) {}
+    void EDProducerBase::doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) {}
+    void EDProducerBase::doStreamEndRun_(StreamID id, Run const& rp, EventSetup const& c) {}
+    void EDProducerBase::doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c) {}
+    void EDProducerBase::doStreamBeginLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDProducerBase::doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDProducerBase::doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) {}
+    
+    
+    void EDProducerBase::doBeginRun_(Run const& rp, EventSetup const& c) {}
+    void EDProducerBase::doEndRun_(Run const& rp, EventSetup const& c) {}
+    void EDProducerBase::doBeginRunSummary_(Run const& rp, EventSetup const& c) {}
+    void EDProducerBase::doEndRunSummary_(Run const& rp, EventSetup const& c) {}
+    
+    void EDProducerBase::doBeginLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDProducerBase::doEndLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDProducerBase::doBeginLuminosityBlockSummary_(LuminosityBlock const& rp, EventSetup const& c) {}
+    void EDProducerBase::doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c) {}
+    
+    void EDProducerBase::doBeginRunProduce_(Run& rp, EventSetup const& c) {}
+    void EDProducerBase::doEndRunProduce_(Run& rp, EventSetup const& c) {}
+    void EDProducerBase::doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) {}
+    void EDProducerBase::doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) {}
+    
+    void
+    EDProducerBase::fillDescriptions(ConfigurationDescriptions& descriptions) {
+      ParameterSetDescription desc;
+      desc.setUnknown();
+      descriptions.addDefault(desc);
+    }
+    
+    void
+    EDProducerBase::prevalidate(ConfigurationDescriptions& iConfig) {
+      edmodule_mightGet_config(iConfig);
+    }
+    
+    static const std::string kBaseType("EDProducer");
+    
+    const std::string&
+    EDProducerBase::baseType() {
+      return kBaseType;
+    }
+
+  }
+}

--- a/FWCore/Framework/src/limited/OutputModuleBase.cc
+++ b/FWCore/Framework/src/limited/OutputModuleBase.cc
@@ -54,7 +54,8 @@ namespace edm {
     droppedBranchIDToKeptBranchID_(),
     branchIDLists_(new BranchIDLists),
     origBranchIDLists_(nullptr),
-    thinnedAssociationsHelper_(new ThinnedAssociationsHelper) {
+    thinnedAssociationsHelper_(new ThinnedAssociationsHelper),
+    queue_(pset.getUntrackedParameter<unsigned int>("concurrencyLimit")) {
       
       hasNewlyDroppedBranch_.fill(false);
       
@@ -364,6 +365,7 @@ namespace edm {
     OutputModuleBase::fillDescription(ParameterSetDescription& desc) {
       ProductSelectorRules::fillDescription(desc, "outputCommands");
       EventSelector::fillDescription(desc);
+      desc.addUntracked<unsigned int>("concurrencyLimit",1);
     }
     
     void

--- a/FWCore/Framework/src/limited/OutputModuleBase.cc
+++ b/FWCore/Framework/src/limited/OutputModuleBase.cc
@@ -1,0 +1,389 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     OutputModuleBase
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+//
+
+// system include files
+#include <cassert>
+
+// user include files
+#include "FWCore/Framework/interface/limited/OutputModuleBase.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/ThinnedAssociation.h"
+#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/BranchKey.h"
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
+#include "FWCore/Framework/interface/EventForOutput.h"
+#include "FWCore/Framework/interface/EventPrincipal.h"
+#include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
+#include "FWCore/Framework/interface/RunForOutput.h"
+#include "FWCore/Framework/interface/OutputModuleDescription.h"
+#include "FWCore/Framework/interface/TriggerNamesService.h"
+#include "FWCore/Framework/src/EventSignalsSentry.h"
+#include "FWCore/Framework/src/PreallocationConfiguration.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/DebugMacros.h"
+
+
+namespace edm {
+  namespace limited {
+
+    // -------------------------------------------------------
+    OutputModuleBase::OutputModuleBase(ParameterSet const& pset) :
+    maxEvents_(-1),
+    remainingEvents_(maxEvents_),
+    keptProducts_(),
+    hasNewlyDroppedBranch_(),
+    process_name_(),
+    productSelectorRules_(pset, "outputCommands", "OutputModule"),
+    productSelector_(),
+    moduleDescription_(),
+    wantAllEvents_(false),
+    selectors_(),
+    selector_config_id_(),
+    droppedBranchIDToKeptBranchID_(),
+    branchIDLists_(new BranchIDLists),
+    origBranchIDLists_(nullptr),
+    thinnedAssociationsHelper_(new ThinnedAssociationsHelper) {
+      
+      hasNewlyDroppedBranch_.fill(false);
+      
+      Service<service::TriggerNamesService> tns;
+      process_name_ = tns->getProcessName();
+      
+      selectEvents_ =
+      pset.getUntrackedParameterSet("SelectEvents", ParameterSet());
+      
+      selectEvents_.registerIt(); // Just in case this PSet is not registered
+      
+      selector_config_id_ = selectEvents_.id();
+      
+      //need to set wantAllEvents_ in constructor
+      // we will make the remaining selectors once we know how many streams
+      selectors_.resize(1);
+      wantAllEvents_ = detail::configureEventSelector(selectEvents_,
+                                                      process_name_,
+                                                      getAllTriggerNames(),
+                                                      selectors_[0],
+                                                      consumesCollector());
+
+    }
+    
+    void OutputModuleBase::configure(OutputModuleDescription const& desc) {
+      remainingEvents_ = maxEvents_ = desc.maxEvents_;
+      origBranchIDLists_ = desc.branchIDLists_;
+    }
+    
+    void OutputModuleBase::selectProducts(ProductRegistry const& preg,
+                                          ThinnedAssociationsHelper const& thinnedAssociationsHelper) {
+      if(productSelector_.initialized()) return;
+      productSelector_.initialize(productSelectorRules_, preg.allBranchDescriptions());
+      
+      // TODO: See if we can collapse keptProducts_ and productSelector_ into a
+      // single object. See the notes in the header for ProductSelector
+      // for more information.
+      
+      std::map<BranchID, BranchDescription const*> trueBranchIDToKeptBranchDesc;
+      std::vector<BranchDescription const*> associationDescriptions;
+      std::set<BranchID> keptProductsInEvent;
+
+      for(auto const& it : preg.productList()) {
+        BranchDescription const& desc = it.second;
+        if(desc.transient()) {
+          // if the class of the branch is marked transient, output nothing
+        } else if(!desc.present() && !desc.produced()) {
+          // else if the branch containing the product has been previously dropped,
+          // output nothing
+        } else if(desc.unwrappedType() == typeid(ThinnedAssociation)) {
+          associationDescriptions.push_back(&desc);
+        } else if(selected(desc)) {
+          keepThisBranch(desc, trueBranchIDToKeptBranchDesc, keptProductsInEvent);
+        } else {
+          // otherwise, output nothing,
+          // and mark the fact that there is a newly dropped branch of this type.
+          hasNewlyDroppedBranch_[desc.branchType()] = true;
+        }
+      }
+
+      thinnedAssociationsHelper.selectAssociationProducts(associationDescriptions,
+                                                          keptProductsInEvent,
+                                                          keepAssociation_);
+
+      for(auto association : associationDescriptions) {
+        if(keepAssociation_[association->branchID()]) {
+          keepThisBranch(*association, trueBranchIDToKeptBranchDesc, keptProductsInEvent);
+        } else {
+          hasNewlyDroppedBranch_[association->branchType()] = true;
+        }
+      }
+
+      // Now fill in a mapping needed in the case that a branch was dropped while its EDAlias was kept.
+      ProductSelector::fillDroppedToKept(preg, trueBranchIDToKeptBranchDesc, droppedBranchIDToKeptBranchID_);
+
+      thinnedAssociationsHelper_->updateFromParentProcess(thinnedAssociationsHelper, keepAssociation_, droppedBranchIDToKeptBranchID_);
+    }
+
+    void OutputModuleBase::keepThisBranch(BranchDescription const& desc,
+                        std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc,
+                        std::set<BranchID>& keptProductsInEvent) {
+
+      ProductSelector::checkForDuplicateKeptBranch(desc,
+                                                   trueBranchIDToKeptBranchDesc);
+
+      EDGetToken token;
+      switch (desc.branchType()) {
+      case InEvent:
+        {
+          if(desc.produced()) {
+            keptProductsInEvent.insert(desc.originalBranchID());
+          } else {
+            keptProductsInEvent.insert(desc.branchID());
+          }
+          token = consumes(TypeToGet{desc.unwrappedTypeID(),PRODUCT_TYPE},
+                       InputTag{desc.moduleLabel(),
+                       desc.productInstanceName(),
+                       desc.processName()});
+          break;
+        }
+      case InLumi:
+        {
+          token = consumes<InLumi>(TypeToGet{desc.unwrappedTypeID(),PRODUCT_TYPE},
+                                    InputTag(desc.moduleLabel(),
+                                    desc.productInstanceName(),
+                                    desc.processName()));
+          break;
+        }
+      case InRun:
+        {
+          token = consumes<InRun>(TypeToGet{desc.unwrappedTypeID(),PRODUCT_TYPE},
+                                   InputTag(desc.moduleLabel(),
+                                   desc.productInstanceName(),
+                                   desc.processName()));
+          break;
+        }
+      default:
+        assert(false);
+        break;
+      }
+      // Now put it in the list of selected branches.
+      keptProducts_[desc.branchType()].push_back(std::make_pair(&desc, token));
+    }
+
+    OutputModuleBase::~OutputModuleBase() { }
+    
+    void OutputModuleBase::doPreallocate(PreallocationConfiguration const& iPC) {
+      auto nstreams = iPC.numberOfStreams();
+      selectors_.resize(nstreams);
+      
+      bool seenFirst = false;
+      for(auto& s : selectors_) {
+        if(seenFirst) {
+          detail::configureEventSelector(selectEvents_,
+                                         process_name_,
+                                         getAllTriggerNames(),
+                                         s,
+                                         consumesCollector());
+        } else {
+          seenFirst = true;
+        }
+      }
+    }
+
+    void OutputModuleBase::doBeginJob() {
+      this->beginJob();
+    }
+    
+    void OutputModuleBase::doEndJob() {
+      endJob();
+    }
+    
+    bool OutputModuleBase::prePrefetchSelection(StreamID id, EventPrincipal const& ep, ModuleCallingContext const* mcc) {
+      if(wantAllEvents_) return true;
+      auto& s = selectors_[id.value()];
+      EventForOutput e(ep, moduleDescription_, mcc);
+      e.setConsumer(this);
+      return s.wantEvent(e);
+    }
+    
+    bool
+    OutputModuleBase::doEvent(EventPrincipal const& ep,
+                              EventSetup const&,
+                              ActivityRegistry* act,
+                              ModuleCallingContext const* mcc) {
+      
+      {
+          EventForOutput e(ep, moduleDescription_, mcc);
+          e.setConsumer(this);
+          EventSignalsSentry sentry(act,mcc);
+          write(e);
+      }
+
+      auto remainingEvents = remainingEvents_.load();
+      bool keepTrying = remainingEvents > 0;
+      while(keepTrying) {
+        auto newValue = remainingEvents - 1;
+        keepTrying = !remainingEvents_.compare_exchange_strong(remainingEvents, newValue);
+        if(keepTrying) { 
+          // the exchange failed because the value was changed by another thread.
+          // remainingEvents was changed to be the new value of remainingEvents_;
+          keepTrying = remainingEvents > 0;
+        }
+      }
+      return true;
+    }
+
+    bool
+    OutputModuleBase::doBeginRun(RunPrincipal const& rp,
+                                 EventSetup const&,
+                                 ModuleCallingContext const* mcc) {
+      RunForOutput r(rp, moduleDescription_, mcc);
+      r.setConsumer(this);
+      doBeginRun_(r);
+      return true;
+    }
+    
+    bool
+    OutputModuleBase::doEndRun(RunPrincipal const& rp,
+                               EventSetup const&,
+                               ModuleCallingContext const* mcc) {
+      RunForOutput r(rp, moduleDescription_, mcc);
+      r.setConsumer(this);
+      doEndRun_(r);
+      return true;
+    }
+    
+    void
+    OutputModuleBase::doWriteRun(RunPrincipal const& rp,
+                                 ModuleCallingContext const* mcc) {
+      RunForOutput r(rp, moduleDescription_, mcc);
+      r.setConsumer(this);
+      writeRun(r);
+    }
+    
+    bool
+    OutputModuleBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                                             EventSetup const&,
+                                             ModuleCallingContext const* mcc) {
+      LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc);
+      lb.setConsumer(this);
+      doBeginLuminosityBlock_(lb);
+      return true;
+    }
+    
+    bool
+    OutputModuleBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                                           EventSetup const&,
+                                           ModuleCallingContext const* mcc) {
+      LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc);
+      lb.setConsumer(this);
+      doEndLuminosityBlock_(lb);
+      return true;
+    }
+    
+    void OutputModuleBase::doWriteLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                                                  ModuleCallingContext const* mcc) {
+      LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc);
+      lb.setConsumer(this);
+      writeLuminosityBlock(lb);
+    }
+    
+    void OutputModuleBase::doOpenFile(FileBlock const& fb) {
+      openFile(fb);
+    }
+    
+    void OutputModuleBase::doRespondToOpenInputFile(FileBlock const& fb) {
+      doRespondToOpenInputFile_(fb);
+    }
+    
+    void OutputModuleBase::doRespondToCloseInputFile(FileBlock const& fb) {
+      doRespondToCloseInputFile_(fb);
+    }
+        
+    void OutputModuleBase::doCloseFile() {
+      if(isFileOpen()) {
+        reallyCloseFile();
+      }
+    }
+    
+    void OutputModuleBase::reallyCloseFile() {
+    }
+    
+    BranchIDLists const*
+    OutputModuleBase::branchIDLists() {
+      if(!droppedBranchIDToKeptBranchID_.empty()) {
+        // Make a private copy of the BranchIDLists.
+        *branchIDLists_ = *origBranchIDLists_;
+        // Check for branches dropped while an EDAlias was kept.
+        for(BranchIDList& branchIDList : *branchIDLists_) {
+          for(BranchID::value_type& branchID : branchIDList) {
+            // Replace BranchID of each dropped branch with that of the kept alias, so the alias branch will have the product ID of the original branch.
+            std::map<BranchID::value_type, BranchID::value_type>::const_iterator iter = droppedBranchIDToKeptBranchID_.find(branchID);
+            if(iter != droppedBranchIDToKeptBranchID_.end()) {
+              branchID = iter->second;
+            }
+          }
+        }
+        return branchIDLists_.get();
+      }
+      return origBranchIDLists_;
+    }
+    
+    ThinnedAssociationsHelper const*
+    OutputModuleBase::thinnedAssociationsHelper() const {
+      return thinnedAssociationsHelper_.get();
+    }
+
+    ModuleDescription const&
+    OutputModuleBase::description() const {
+      return moduleDescription_;
+    }
+    
+    bool
+    OutputModuleBase::selected(BranchDescription const& desc) const {
+      return productSelector_.selected(desc);
+    }
+    
+    void
+    OutputModuleBase::fillDescriptions(ConfigurationDescriptions& descriptions) {
+      ParameterSetDescription desc;
+      desc.setUnknown();
+      descriptions.addDefault(desc);
+    }
+    
+    void
+    OutputModuleBase::fillDescription(ParameterSetDescription& desc) {
+      ProductSelectorRules::fillDescription(desc, "outputCommands");
+      EventSelector::fillDescription(desc);
+    }
+    
+    void
+    OutputModuleBase::prevalidate(ConfigurationDescriptions& ) {
+    }
+    
+    
+    static const std::string kBaseType("OutputModule");
+    const std::string&
+    OutputModuleBase::baseType() {
+      return kBaseType;
+    }
+    
+    void
+    OutputModuleBase::setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
+                                        bool anyProductProduced) {
+      selector_config_id_ = detail::registerProperSelectionInfo(getParameterSet(selector_config_id_),
+                                                                description().moduleLabel(),
+                                                                outputModulePathPositions,
+                                                                anyProductProduced);
+    }
+  }
+}

--- a/FWCore/Framework/src/limited/filterImplementors.cc
+++ b/FWCore/Framework/src/limited/filterImplementors.cc
@@ -1,0 +1,28 @@
+// -*- C++ -*-
+//
+// Package:     Package
+// Class  :     filterImplementors
+// 
+// Implementation:
+//     Explicitly instantiate implementor templates for EDFilterBase
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 09 May 2013 20:14:06 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/src/limited/implementorsMethods.h"
+#include "FWCore/Framework/interface/limited/EDFilterBase.h"
+
+namespace edm {
+  namespace limited {
+    namespace impl {
+      template class BeginRunProducer<edm::limited::EDFilterBase>;
+      template class EndRunProducer<edm::limited::EDFilterBase>;
+      template class BeginLuminosityBlockProducer<edm::limited::EDFilterBase>;
+      template class EndLuminosityBlockProducer<edm::limited::EDFilterBase>;
+    }
+  }
+}

--- a/FWCore/Framework/src/limited/implementorsMethods.h
+++ b/FWCore/Framework/src/limited/implementorsMethods.h
@@ -1,0 +1,55 @@
+#ifndef FWCore_Framework_limited_implementorsMethods_h
+#define FWCore_Framework_limited_implementorsMethods_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// File  :     implementorsMethods
+// 
+/**\file implementorsMethods.h "FWCore/Framework/src/limited/implementorsMethods.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 09 May 2013 20:13:53 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/limited/implementors.h"
+
+// forward declarations
+
+namespace edm {
+  namespace limited {
+    namespace impl {
+      template< typename T>
+      void BeginRunProducer<T>::doBeginRunProduce_(Run& rp, EventSetup const& c) {
+        this->globalBeginRunProduce(rp,c);
+      }
+
+      template< typename T>
+      void EndRunProducer<T>::doEndRunProduce_(Run& rp, EventSetup const& c) {
+        this->globalEndRunProduce(rp,c);
+      }
+
+      template< typename T>
+      void BeginLuminosityBlockProducer<T>::doBeginLuminosityBlockProduce_(LuminosityBlock& rp, EventSetup const& c) {
+        this->globalBeginLuminosityBlockProduce(rp,c);
+      }
+      
+      template< typename T>
+      void EndLuminosityBlockProducer<T>::doEndLuminosityBlockProduce_(LuminosityBlock& rp, EventSetup const& c) {
+        this->globalEndLuminosityBlockProduce(rp,c);
+      }
+    }
+  }
+}
+
+
+#endif

--- a/FWCore/Framework/src/limited/outputmoduleImplementors.cc
+++ b/FWCore/Framework/src/limited/outputmoduleImplementors.cc
@@ -1,0 +1,33 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     outputmoduleImplementors
+// 
+// Implementation:
+//     Explicitly instantiate implementor templates for OutputModuleBase
+//
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/src/limited/implementorsMethods.h"
+#include "FWCore/Framework/interface/limited/OutputModule.h"
+
+namespace edm {
+
+  class ModuleCallingContext;
+
+  namespace limited {
+    namespace outputmodule {
+      void InputFileWatcher::doRespondToOpenInputFile_(FileBlock const& iB)
+      {
+        respondToOpenInputFile(iB);
+      }
+      void InputFileWatcher::doRespondToCloseInputFile_(FileBlock const& iB)
+      {
+        respondToCloseInputFile(iB);
+      }
+    }
+  }
+}

--- a/FWCore/Framework/src/limited/producerImplementors.cc
+++ b/FWCore/Framework/src/limited/producerImplementors.cc
@@ -1,0 +1,28 @@
+// -*- C++ -*-
+//
+// Package:     Package
+// Class  :     producerImplementors
+// 
+// Implementation:
+//     Explicitly instantiate implementor templates for EDProducerBase
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 09 May 2013 20:14:06 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/src/limited/implementorsMethods.h"
+#include "FWCore/Framework/interface/limited/EDProducerBase.h"
+
+namespace edm {
+  namespace limited {
+    namespace impl {
+      template class BeginRunProducer<edm::limited::EDProducerBase>;
+      template class EndRunProducer<edm::limited::EDProducerBase>;
+      template class BeginLuminosityBlockProducer<edm::limited::EDProducerBase>;
+      template class EndLuminosityBlockProducer<edm::limited::EDProducerBase>;
+    }
+  }
+}

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -72,6 +72,11 @@
   <use   name="FWCore/Framework"/>
   <use   name="FWCore/ParameterSet"/>
 </library>
+<library   file="stubs/TestLimitedProducers.cc,stubs/TestLimitedAnalyzers.cc,stubs/TestLimitedFilters.cc" name="TestLimitedModules">
+  <flags   EDM_PLUGIN="1"/>
+  <use   name="FWCore/Framework"/>
+  <use   name="FWCore/ParameterSet"/>
+</library>
 <library   file="stubs/TestOneProducers.cc,stubs/TestOneAnalyzers.cc,stubs/TestOneFilters.cc" name="TestOneModules">
   <flags   EDM_PLUGIN="1"/>
   <use   name="FWCore/Framework"/>
@@ -148,7 +153,7 @@
   <use   name="FWCore/Framework"/>
   <use   name="FWCore/ParameterSet"/>
 </library>
-<bin   name="TestFWCoreFramework" file="testRunner.cpp,maker2_t.cppunit.cc,maker_t.cppunit.cc,productregistry.cppunit.cc,edproducer_productregistry_callback.cc,event_getrefbeforeput_t.cppunit.cc,generichandle_t.cppunit.cc,edconsumerbase_t.cppunit.cc,global_module_t.cppunit.cc,one_outputmodule_t.cppunit.cc,global_outputmodule_t.cppunit.cc,stream_module_t.cppunit.cc,throwIfImproperDependencies_t.cppunit.cc">
+<bin   name="TestFWCoreFramework" file="testRunner.cpp,maker2_t.cppunit.cc,maker_t.cppunit.cc,productregistry.cppunit.cc,edproducer_productregistry_callback.cc,event_getrefbeforeput_t.cppunit.cc,generichandle_t.cppunit.cc,edconsumerbase_t.cppunit.cc,global_module_t.cppunit.cc,one_outputmodule_t.cppunit.cc,global_outputmodule_t.cppunit.cc,stream_module_t.cppunit.cc,limited_module_t.cppunit.cc,limited_outputmodule_t.cppunit.cc,throwIfImproperDependencies_t.cppunit.cc">
   <use   name="DataFormats/Common"/>
   <use   name="DataFormats/Provenance"/>
   <use   name="DataFormats/TestObjects"/>

--- a/FWCore/Framework/test/limited_module_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_module_t.cppunit.cc
@@ -1,0 +1,582 @@
+/*
+ *  proxyfactoryproducer_t.cc
+ *  EDMProto
+ *
+ *  Created by Chris Jones on 4/8/05.
+ *  Changed by Viji Sundararajan on 28-Jun-05
+ */
+#include <iostream>
+#include <atomic>
+#include <vector>
+#include <map>
+#include <functional>
+#include "FWCore/Framework/interface/limited/EDProducer.h"
+#include "FWCore/Framework/src/WorkerT.h"
+#include "FWCore/Framework/src/ModuleHolder.h"
+#include "FWCore/Framework/src/PreallocationConfiguration.h"
+#include "FWCore/Framework/interface/OccurrenceTraits.h"
+#include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "DataFormats/Provenance/interface/BranchIDListHelper.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
+#include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
+
+
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "cppunit/extensions/HelperMacros.h"
+
+namespace {
+  edm::ParameterSet makePSet() {
+    edm::ParameterSet pset;
+    const unsigned int kLimit = 1;
+    pset.addUntrackedParameter("concurrencyLimit",kLimit);
+    return pset;
+  }
+  
+  const edm::ParameterSet s_pset = makePSet();
+}
+
+class testLimitedModule: public CppUnit::TestFixture 
+{
+  CPPUNIT_TEST_SUITE(testLimitedModule);
+  
+  CPPUNIT_TEST(basicTest);
+  CPPUNIT_TEST(streamTest);
+  CPPUNIT_TEST(runTest);
+  CPPUNIT_TEST(runSummaryTest);
+  CPPUNIT_TEST(lumiTest);
+  CPPUNIT_TEST(lumiSummaryTest);
+  CPPUNIT_TEST(beginRunProdTest);
+  CPPUNIT_TEST(beginLumiProdTest);
+  CPPUNIT_TEST(endRunProdTest);
+  CPPUNIT_TEST(endLumiProdTest);
+  CPPUNIT_TEST(endRunSummaryProdTest);
+  CPPUNIT_TEST(endLumiSummaryProdTest);
+  
+  CPPUNIT_TEST_SUITE_END();
+public:
+  testLimitedModule();
+  
+  void setUp(){}
+  void tearDown(){}
+
+  void basicTest();
+  void streamTest();
+  void runTest();
+  void runSummaryTest();
+  void lumiTest();
+  void lumiSummaryTest();
+  void beginRunProdTest();
+  void beginLumiProdTest();
+  void endRunProdTest();
+  void endLumiProdTest();
+  void endRunSummaryProdTest();
+  void endLumiSummaryProdTest();
+
+  enum class Trans {
+    kBeginJob,
+    kBeginStream,
+    kGlobalBeginRun,
+    kGlobalBeginRunProduce,
+    kStreamBeginRun,
+    kGlobalBeginLuminosityBlock,
+    kStreamBeginLuminosityBlock,
+    kEvent,
+    kStreamEndLuminosityBlock,
+    kGlobalEndLuminosityBlock,
+    kStreamEndRun,
+    kGlobalEndRun,
+    kEndStream,
+    kEndJob
+  };
+  typedef std::vector<Trans> Expectations;
+
+private:
+
+  
+  std::map<Trans,std::function<void(edm::Worker*)>> m_transToFunc;
+  
+  edm::ProcessConfiguration m_procConfig;
+  std::shared_ptr<edm::ProductRegistry> m_prodReg;
+  std::shared_ptr<edm::BranchIDListHelper> m_idHelper;
+  std::shared_ptr<edm::ThinnedAssociationsHelper> m_associationsHelper;
+  std::unique_ptr<edm::EventPrincipal> m_ep;
+  edm::HistoryAppender historyAppender_;
+  std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
+  std::shared_ptr<edm::RunPrincipal> m_rp;
+  std::shared_ptr<edm::ActivityRegistry> m_actReg; // We do not use propagate_const because the registry itself is mutable.
+  edm::EventSetup* m_es = nullptr;
+  edm::ModuleDescription m_desc = {"Dummy","dummy"};
+  
+  template<typename T>
+  void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
+  
+  class BasicProd : public edm::limited::EDProducer<> {
+  public:
+    BasicProd(): edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<>(s_pset)  {}
+    mutable unsigned int m_count = 0; //[[cms-thread-safe]]
+    
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+  };
+  class StreamProd : public edm::limited::EDProducer<edm::StreamCache<int>> {
+  public:
+    StreamProd(): edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::StreamCache<int>>(s_pset) {}
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    
+    std::unique_ptr<int> beginStream(edm::StreamID) const override {
+      ++m_count;
+      return std::unique_ptr<int>{};
+    }
+    
+    virtual void streamBeginRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const  override{
+      ++m_count;
+    }
+    virtual void streamBeginLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    virtual void streamEndLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    virtual void streamEndRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    void endStream(edm::StreamID) const override {
+      ++m_count;
+    }
+  };
+  
+  class RunProd : public edm::limited::EDProducer<edm::RunCache<int>> {
+  public:
+    RunProd(): edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::RunCache<int>>(s_pset) {}
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    
+    std::shared_ptr<int> globalBeginRun(edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::shared_ptr<int>{};
+    }
+
+    void globalEndRun(edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+  };
+
+
+  class LumiProd : public edm::limited::EDProducer<edm::LuminosityBlockCache<int>> {
+  public:
+    LumiProd(): edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::LuminosityBlockCache<int>>(s_pset) {}
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    
+    std::shared_ptr<int> globalBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::shared_ptr<int>{};
+    }
+    
+    void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+  };
+  
+  class RunSummaryProd : public edm::limited::EDProducer<edm::RunSummaryCache<int>> {
+  public:
+    RunSummaryProd() : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::RunSummaryCache<int>>(s_pset){}
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    
+    std::shared_ptr<int> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::shared_ptr<int>{};
+    }
+    
+    void streamEndRunSummary(edm::StreamID, edm::Run const&, edm::EventSetup const&, int*) const override {
+      ++m_count;
+    }
+    
+    void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, int*) const override {
+      ++m_count;
+    }
+  };
+
+  class LumiSummaryProd : public edm::limited::EDProducer<edm::LuminosityBlockSummaryCache<int>> {
+  public:
+    LumiSummaryProd() : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::LuminosityBlockSummaryCache<int>>(s_pset) {}
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    
+    std::shared_ptr<int> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::shared_ptr<int>{};
+    }
+    
+    void streamEndLuminosityBlockSummary(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&, int*) const override {
+      ++m_count;
+    }
+    
+    void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, int*) const override {
+      ++m_count;
+    }
+  };
+
+  class BeginRunProd : public edm::limited::EDProducer<edm::BeginRunProducer> {
+  public:
+    BeginRunProd() : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::BeginRunProducer>(s_pset) {}
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+
+    void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+  };
+
+  class BeginLumiProd : public edm::limited::EDProducer<edm::BeginLuminosityBlockProducer> {
+  public:
+    BeginLumiProd() : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::BeginLuminosityBlockProducer>(s_pset) {}
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    
+    void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+  };
+
+  class EndRunProd : public edm::limited::EDProducer<edm::EndRunProducer> {
+  public:
+    EndRunProd() : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::EndRunProducer>(s_pset) {}
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    
+    void globalEndRunProduce(edm::Run&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+  };
+  
+  class EndLumiProd : public edm::limited::EDProducer<edm::EndLuminosityBlockProducer> {
+  public:
+    EndLumiProd() : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::EndLuminosityBlockProducer>(s_pset) {}
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    
+    void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+  };
+
+
+  class EndRunSummaryProd : public edm::limited::EDProducer<edm::EndRunProducer, edm::RunSummaryCache<int>> {
+  public:
+    EndRunSummaryProd()
+    : edm::limited::EDProducerBase(s_pset),
+      edm::limited::EDProducer<edm::EndRunProducer, edm::RunSummaryCache<int>>(s_pset) {}
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    
+    std::shared_ptr<int> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::shared_ptr<int>{};
+    }
+    
+    void streamEndRunSummary(edm::StreamID, edm::Run const&, edm::EventSetup const&, int*) const override {
+      ++m_count;
+    }
+    
+    void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, int*) const override {
+      ++m_count;
+    }
+
+    void globalEndRunProduce(edm::Run&, edm::EventSetup const&, int const*) const override {
+      ++m_count;
+    }
+  };
+  
+  class EndLumiSummaryProd : public edm::limited::EDProducer<edm::EndLuminosityBlockProducer, edm::LuminosityBlockSummaryCache<int>> {
+  public:
+    EndLumiSummaryProd()
+    : edm::limited::EDProducerBase(s_pset) ,
+      edm::limited::EDProducer<edm::EndLuminosityBlockProducer, edm::LuminosityBlockSummaryCache<int>>(s_pset){}
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+
+    std::shared_ptr<int> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::shared_ptr<int>{};
+    }
+    
+    void streamEndLuminosityBlockSummary(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&, int*) const override {
+      ++m_count;
+    }
+    
+    void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, int*) const override {
+      ++m_count;
+    }
+
+    void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&, int const*) const override {
+      ++m_count;
+    }
+  };
+};
+
+namespace {
+  struct ShadowStreamID {
+    constexpr ShadowStreamID():value(0){}
+    unsigned int value;
+  };
+  
+  union IDUnion {
+    IDUnion(): m_shadow() {}
+    ShadowStreamID m_shadow;
+    edm::StreamID m_id;
+  };
+}
+static edm::StreamID makeID() {
+  IDUnion u;
+  assert(u.m_id.value() == 0);
+  return u.m_id;
+}
+static const edm::StreamID s_streamID0 = makeID();
+
+
+///registration of the test so that the runner can find it
+CPPUNIT_TEST_SUITE_REGISTRATION(testLimitedModule);
+
+testLimitedModule::testLimitedModule():
+m_prodReg(new edm::ProductRegistry{}),
+m_idHelper(new edm::BranchIDListHelper{}),
+m_associationsHelper(new edm::ThinnedAssociationsHelper{}),
+m_ep()
+{
+  //Setup the principals
+  m_prodReg->setFrozen();
+  m_idHelper->updateFromRegistry(*m_prodReg);
+  edm::EventID eventID = edm::EventID::firstValidEvent();
+  
+  std::string uuid = edm::createGlobalIdentifier();
+  edm::Timestamp now(1234567UL);
+  auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
+  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_,0));
+  auto lumiAux = std::make_shared<edm::LuminosityBlockAuxiliary>(m_rp->run(), 1, now, now);
+  m_lbp.reset(new edm::LuminosityBlockPrincipal(lumiAux, m_prodReg, m_procConfig, &historyAppender_,0));
+  m_lbp->setRunPrincipal(m_rp);
+  edm::EventAuxiliary eventAux(eventID, uuid, now, true);
+
+  m_ep.reset(new edm::EventPrincipal(m_prodReg,
+                                     m_idHelper,
+                                     m_associationsHelper,
+                                     m_procConfig,nullptr));
+  edm::ProcessHistoryRegistry phr;
+  m_ep->fillEventPrincipal(eventAux, phr);
+  m_ep->setLuminosityBlockPrincipal(m_lbp);
+  m_actReg.reset(new edm::ActivityRegistry);
+
+
+  //For each transition, bind a lambda which will call the proper method of the Worker
+  m_transToFunc[Trans::kBeginStream] = [this](edm::Worker* iBase) {
+    edm::StreamContext streamContext(s_streamID0, nullptr);
+    iBase->beginStream(s_streamID0, streamContext); };
+
+  
+  m_transToFunc[Trans::kGlobalBeginRun] = [this](edm::Worker* iBase) {
+    typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
+    edm::ParentContext nullParentContext;
+    iBase->doWork<Traits>(*m_rp,*m_es, s_streamID0, nullParentContext, nullptr); };
+  m_transToFunc[Trans::kStreamBeginRun] = [this](edm::Worker* iBase) {
+    typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamBegin> Traits;
+    edm::ParentContext nullParentContext;
+    iBase->doWork<Traits>(*m_rp,*m_es, s_streamID0, nullParentContext, nullptr); };
+  
+  m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase) {
+    typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
+    edm::ParentContext nullParentContext;
+    iBase->doWork<Traits>(*m_lbp,*m_es, s_streamID0, nullParentContext, nullptr); };
+  m_transToFunc[Trans::kStreamBeginLuminosityBlock] = [this](edm::Worker* iBase) {
+    typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamBegin> Traits;
+    edm::ParentContext nullParentContext;
+    iBase->doWork<Traits>(*m_lbp,*m_es, s_streamID0, nullParentContext, nullptr); };
+  
+  m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase) {
+    typedef edm::OccurrenceTraits<edm::EventPrincipal, edm::BranchActionStreamBegin> Traits;
+    edm::StreamContext streamContext(s_streamID0, nullptr);
+    edm::ParentContext nullParentContext(&streamContext);
+    iBase->setActivityRegistry(m_actReg);
+    iBase->doWork<Traits>(*m_ep,*m_es, s_streamID0, nullParentContext, nullptr); };
+
+  m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this](edm::Worker* iBase) {
+    typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamEnd> Traits;
+    edm::ParentContext nullParentContext;
+    iBase->doWork<Traits>(*m_lbp,*m_es, s_streamID0, nullParentContext, nullptr); };
+  m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase) {
+    typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
+    edm::ParentContext nullParentContext;
+    iBase->doWork<Traits>(*m_lbp,*m_es, s_streamID0, nullParentContext, nullptr); };
+
+  m_transToFunc[Trans::kStreamEndRun] = [this](edm::Worker* iBase) {
+    typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamEnd> Traits;
+    edm::ParentContext nullParentContext;
+    iBase->doWork<Traits>(*m_rp,*m_es, s_streamID0, nullParentContext, nullptr); };
+  m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase) {
+    typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
+    edm::ParentContext nullParentContext;
+    iBase->doWork<Traits>(*m_rp,*m_es, s_streamID0, nullParentContext, nullptr); };
+
+  m_transToFunc[Trans::kEndStream] = [this](edm::Worker* iBase) {
+    edm::StreamContext streamContext(s_streamID0, nullptr);
+    iBase->endStream(s_streamID0, streamContext); };
+
+}
+
+
+namespace {
+  template<typename T>
+  void
+  testTransition(std::shared_ptr<T> iMod, edm::Worker* iWorker, testLimitedModule::Trans iTrans, testLimitedModule::Expectations const& iExpect, std::function<void(edm::Worker*)> iFunc) {
+    assert(0==iMod->m_count);
+    iFunc(iWorker);
+    auto count = std::count(iExpect.begin(),iExpect.end(),iTrans);
+    if(count != iMod->m_count) {
+      std::cout<<"For trans " <<static_cast<std::underlying_type<testLimitedModule::Trans>::type >(iTrans)<< " expected "<<count<<" and got "<<iMod->m_count<<std::endl;
+    }
+    CPPUNIT_ASSERT(iMod->m_count == count);
+    iMod->m_count = 0;
+    iWorker->reset();
+  }
+}
+
+template<typename T>
+void
+testLimitedModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
+  edm::WorkerT<edm::limited::EDProducerBase> w{iMod,m_desc,nullptr};
+  for(auto& keyVal: m_transToFunc) {
+    testTransition(iMod,&w,keyVal.first,iExpect,keyVal.second);
+  }
+}
+
+
+void testLimitedModule::basicTest()
+{
+  auto testProd = std::make_shared<BasicProd>();
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kEvent});
+}
+
+void testLimitedModule::streamTest()
+{
+  auto testProd = std::make_shared<StreamProd>();
+  edm::maker::ModuleHolderT<edm::limited::EDProducerBase> h(testProd,nullptr);
+  h.preallocate(edm::PreallocationConfiguration{});
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kBeginStream, Trans::kStreamBeginRun, Trans::kStreamBeginLuminosityBlock, Trans::kEvent,
+    Trans::kStreamEndLuminosityBlock,Trans::kStreamEndRun,Trans::kEndStream});
+}
+
+void testLimitedModule::runTest()
+{
+  auto testProd = std::make_shared<RunProd>();
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kGlobalEndRun});
+}
+
+void testLimitedModule::runSummaryTest()
+{
+  auto testProd = std::make_shared<RunSummaryProd>();
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kStreamEndRun, Trans::kGlobalEndRun});
+}
+
+void testLimitedModule::lumiTest()
+{
+  auto testProd = std::make_shared<LumiProd>();
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kGlobalEndLuminosityBlock});
+}
+
+void testLimitedModule::lumiSummaryTest()
+{
+  auto testProd = std::make_shared<LumiSummaryProd>();
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kStreamEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock});
+}
+
+void testLimitedModule::beginRunProdTest()
+{
+  auto testProd = std::make_shared<BeginRunProd>();
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kGlobalBeginRun, Trans::kEvent});
+}
+
+void testLimitedModule::beginLumiProdTest()
+{
+  auto testProd = std::make_shared<BeginLumiProd>();
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent});
+}
+
+void testLimitedModule::endRunProdTest()
+{
+  auto testProd = std::make_shared<EndRunProd>();
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kGlobalEndRun, Trans::kEvent});
+}
+
+void testLimitedModule::endLumiProdTest()
+{
+  auto testProd = std::make_shared<EndLumiProd>();
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kGlobalEndLuminosityBlock, Trans::kEvent});
+}
+
+void testLimitedModule::endRunSummaryProdTest()
+{
+  auto testProd = std::make_shared<EndRunSummaryProd>();
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kGlobalEndRun, Trans::kEvent, Trans::kGlobalBeginRun, Trans::kStreamEndRun, Trans::kGlobalEndRun});
+}
+
+void testLimitedModule::endLumiSummaryProdTest()
+{
+  auto testProd = std::make_shared<EndLumiSummaryProd>();
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kGlobalEndLuminosityBlock, Trans::kEvent, Trans::kGlobalBeginLuminosityBlock, Trans::kStreamEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock}); 
+}
+

--- a/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
@@ -1,0 +1,315 @@
+/*
+ *  proxyfactoryproducer_t.cc
+ *  EDMProto
+ *
+ */
+#include <iostream>
+#include <atomic>
+#include <vector>
+#include <map>
+#include <functional>
+#include "FWCore/Framework/interface/limited/OutputModule.h"
+#include "FWCore/Framework/src/OutputModuleCommunicatorT.h"
+#include "FWCore/Framework/src/WorkerT.h"
+#include "FWCore/Framework/interface/OccurrenceTraits.h"
+#include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "DataFormats/Provenance/interface/BranchIDListHelper.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
+#include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
+#include "FWCore/Framework/interface/TriggerNamesService.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+#include "FWCore/Framework/interface/FileBlock.h"
+#include "FWCore/Framework/src/PreallocationConfiguration.h"
+
+
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "cppunit/extensions/HelperMacros.h"
+
+namespace edm {
+  class ModuleCallingContext;
+}
+
+class testLimitedOutputModule: public CppUnit::TestFixture 
+{
+  CPPUNIT_TEST_SUITE(testLimitedOutputModule);
+  
+  CPPUNIT_TEST(basicTest);
+  CPPUNIT_TEST(fileTest);
+  
+  CPPUNIT_TEST_SUITE_END();
+public:
+  testLimitedOutputModule();
+  
+  void setUp(){}
+  void tearDown(){}
+
+  void basicTest();
+  void fileTest();
+
+  enum class Trans {
+    kBeginJob,
+    kGlobalOpenInputFile,
+    kGlobalBeginRun,
+    kGlobalBeginRunProduce,
+    kGlobalBeginLuminosityBlock,
+    kEvent,
+    kGlobalEndLuminosityBlock,
+    kGlobalEndRun,
+    kGlobalCloseInputFile,
+    kEndJob
+  };
+  
+  typedef std::vector<Trans> Expectations;
+
+private:
+
+  std::map<Trans,std::function<void(edm::Worker*,edm::OutputModuleCommunicator*)>> m_transToFunc;
+  
+  edm::ProcessConfiguration m_procConfig;
+  edm::PreallocationConfiguration m_preallocConfig;
+  std::shared_ptr<edm::ProductRegistry> m_prodReg;
+  std::shared_ptr<edm::BranchIDListHelper> m_idHelper;
+  std::shared_ptr<edm::ThinnedAssociationsHelper> m_associationsHelper;
+  std::unique_ptr<edm::EventPrincipal> m_ep;
+  edm::HistoryAppender historyAppender_;
+  std::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
+  std::shared_ptr<edm::RunPrincipal> m_rp;
+  std::shared_ptr<edm::ActivityRegistry> m_actReg; // We do not use propagate_const because the registry itself is mutable.
+  edm::EventSetup* m_es = nullptr;
+  edm::ModuleDescription m_desc = {"Dummy","dummy"};
+  edm::WorkerParams m_params;
+  
+  typedef edm::service::TriggerNamesService TNS;
+  typedef edm::serviceregistry::ServiceWrapper<TNS> w_TNS;
+  std::shared_ptr<w_TNS> tnsptr_;
+  edm::ServiceToken serviceToken_;
+  
+  template<typename T>
+  void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
+  
+  class BasicOutputModule : public edm::limited::OutputModule<> {
+  public:
+    using edm::limited::OutputModuleBase::doPreallocate;
+    BasicOutputModule(edm::ParameterSet const& iPSet): edm::limited::OutputModuleBase(iPSet),edm::limited::OutputModule<>(iPSet){}
+    std::atomic<unsigned int> m_count{0};
+    
+    void write(edm::EventForOutput const&) override {
+      ++m_count;
+    }
+    void writeRun(edm::RunForOutput const&) override {
+      ++m_count;
+    }
+    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override {
+      ++m_count;
+    }
+
+  };
+  
+  class FileOutputModule : public edm::limited::OutputModule<edm::WatchInputFiles> {
+  public:
+    using edm::limited::OutputModuleBase::doPreallocate;
+    FileOutputModule(edm::ParameterSet const& iPSet) : edm::limited::OutputModuleBase(iPSet), edm::limited::OutputModule<edm::WatchInputFiles>(iPSet) {}
+    std::atomic<unsigned int> m_count{0};
+    void write(edm::EventForOutput const&) override {
+      ++m_count;
+    }
+    void writeRun(edm::RunForOutput const&) override {
+      ++m_count;
+    }
+    void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override {
+      ++m_count;
+    }
+    
+    void respondToOpenInputFile(edm::FileBlock const&)  override {
+      ++m_count;
+    }
+    
+    void respondToCloseInputFile(edm::FileBlock const&) override {
+      ++m_count;
+    }
+  };
+  
+};
+
+namespace {
+  struct ShadowStreamID {
+    constexpr ShadowStreamID():value(0){}
+    unsigned int value;
+  };
+  
+  union IDUnion {
+    IDUnion(): m_shadow() {}
+    ShadowStreamID m_shadow;
+    edm::StreamID m_id;
+  };
+}
+static edm::StreamID makeID() {
+  IDUnion u;
+  assert(u.m_id.value() == 0);
+  return u.m_id;
+}
+static const edm::StreamID s_streamID0 = makeID();
+
+///registration of the test so that the runner can find it
+CPPUNIT_TEST_SUITE_REGISTRATION(testLimitedOutputModule);
+
+testLimitedOutputModule::testLimitedOutputModule():
+m_prodReg(new edm::ProductRegistry{}),
+m_idHelper(new edm::BranchIDListHelper{}),
+m_associationsHelper(new edm::ThinnedAssociationsHelper{}),
+m_ep()
+{
+  //Setup the principals
+  m_prodReg->setFrozen();
+  m_idHelper->updateFromRegistry(*m_prodReg);
+  edm::EventID eventID = edm::EventID::firstValidEvent();
+  
+  std::string uuid = edm::createGlobalIdentifier();
+  edm::Timestamp now(1234567UL);
+  auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
+  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_,0));
+  auto lumiAux = std::make_shared<edm::LuminosityBlockAuxiliary>(m_rp->run(), 1, now, now);
+  m_lbp.reset(new edm::LuminosityBlockPrincipal(lumiAux, m_prodReg, m_procConfig, &historyAppender_,0));
+  m_lbp->setRunPrincipal(m_rp);
+  edm::EventAuxiliary eventAux(eventID, uuid, now, true);
+
+  m_ep.reset(new edm::EventPrincipal(m_prodReg,
+                                     m_idHelper,
+                                     m_associationsHelper,
+                                     m_procConfig,nullptr));
+  edm::ProcessHistoryRegistry phr;
+  m_ep->fillEventPrincipal(eventAux, phr);
+  m_ep->setLuminosityBlockPrincipal(m_lbp);
+  m_actReg.reset(new edm::ActivityRegistry);
+
+  //For each transition, bind a lambda which will call the proper method of the Worker
+  m_transToFunc[Trans::kGlobalOpenInputFile] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
+    edm::FileBlock fb;
+    iBase->respondToOpenInputFile(fb);
+  };
+
+
+  m_transToFunc[Trans::kGlobalBeginRun] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
+    typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
+    edm::ParentContext parentContext;
+    iBase->doWork<Traits>(*m_rp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr); };
+  
+  m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
+    typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
+    edm::ParentContext parentContext;
+    iBase->doWork<Traits>(*m_lbp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr); };
+  
+  m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
+    typedef edm::OccurrenceTraits<edm::EventPrincipal, edm::BranchActionStreamBegin> Traits;
+    edm::StreamContext streamContext(s_streamID0, nullptr);
+    edm::ParentContext parentContext(&streamContext);
+    iBase->setActivityRegistry(m_actReg);
+    iBase->doWork<Traits>(*m_ep,*m_es, s_streamID0, parentContext, nullptr); };
+
+  m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
+    typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
+    edm::ParentContext parentContext;
+    iBase->doWork<Traits>(*m_lbp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    iComm->writeLumi(*m_lbp, nullptr);
+  };
+
+  m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
+    typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
+    edm::ParentContext parentContext;
+    iBase->doWork<Traits>(*m_rp,*m_es, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    iComm->writeRun(*m_rp, nullptr);
+  };
+  
+  m_transToFunc[Trans::kGlobalCloseInputFile] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
+    edm::FileBlock fb;
+    iBase->respondToCloseInputFile(fb);
+  };
+
+
+  // We want to create the TriggerNamesService because it is used in
+  // the tests.  We do that here, but first we need to build a minimal
+  // parameter set to pass to its constructor.  Then we build the
+  // service and setup the service system.
+  edm::ParameterSet proc_pset;
+  
+  std::string processName("HLT");
+  proc_pset.addParameter<std::string>("@process_name", processName);
+  
+  std::vector<std::string> paths;
+  edm::ParameterSet trigPaths;
+  trigPaths.addParameter<std::vector<std::string>>("@trigger_paths", paths);
+  proc_pset.addParameter<edm::ParameterSet>("@trigger_paths", trigPaths);
+  
+  std::vector<std::string> endPaths;
+  proc_pset.addParameter<std::vector<std::string>>("@end_paths", endPaths);
+
+  // Now create and setup the service
+  tnsptr_.reset(new w_TNS(std::make_unique<TNS>(proc_pset)));
+  
+  serviceToken_ = edm::ServiceRegistry::createContaining(tnsptr_);
+  
+
+}
+
+
+namespace {
+  template<typename T>
+  void
+  testTransition(std::shared_ptr<T> iMod, edm::Worker* iWorker, edm::OutputModuleCommunicator* iComm, testLimitedOutputModule::Trans iTrans, testLimitedOutputModule::Expectations const& iExpect, std::function<void(edm::Worker*, edm::OutputModuleCommunicator*)> iFunc) {
+    assert(0==iMod->m_count);
+    iFunc(iWorker,iComm);
+    auto count = std::count(iExpect.begin(),iExpect.end(),iTrans);
+    if(count != iMod->m_count) {
+      std::cout<<"For trans " <<static_cast<std::underlying_type<testLimitedOutputModule::Trans>::type >(iTrans)<< " expected "<<count<<" and got "<<iMod->m_count<<std::endl;
+    }
+    CPPUNIT_ASSERT(iMod->m_count == count);
+    iMod->m_count = 0;
+    iWorker->reset();
+  }
+}
+
+template<typename T>
+void
+testLimitedOutputModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
+  iMod->doPreallocate(m_preallocConfig);
+  edm::WorkerT<edm::limited::OutputModuleBase> w{iMod,m_desc,m_params.actions_};
+  edm::OutputModuleCommunicatorT<edm::limited::OutputModuleBase> comm(iMod.get());
+  for(auto& keyVal: m_transToFunc) {
+    testTransition(iMod,&w,&comm,keyVal.first,iExpect,keyVal.second);
+  }
+}
+
+
+void testLimitedOutputModule::basicTest()
+{
+  //make the services available
+  edm::ServiceRegistry::Operate operate(serviceToken_);
+
+  edm::ParameterSet pset;
+  const unsigned int kLimit = 1;
+  pset.addUntrackedParameter("concurrencyLimit",kLimit);
+  auto testProd = std::make_shared<BasicOutputModule>(pset);
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kEvent,Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun});
+}
+
+void testLimitedOutputModule::fileTest()
+{
+  //make the services available
+  edm::ServiceRegistry::Operate operate(serviceToken_);
+  
+  edm::ParameterSet pset;
+  const unsigned int kLimit = 1;
+  pset.addUntrackedParameter("concurrencyLimit",kLimit);
+  auto testProd = std::make_shared<FileOutputModule>(pset);
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(testProd, {Trans::kGlobalOpenInputFile, Trans::kEvent, Trans::kGlobalEndLuminosityBlock, Trans::kGlobalEndRun, Trans::kGlobalCloseInputFile});
+}
+

--- a/FWCore/Framework/test/run_global_stream_one.sh
+++ b/FWCore/Framework/test/run_global_stream_one.sh
@@ -6,9 +6,11 @@ function die { echo $1: status $2 ;  exit $2; }
 F1=${LOCAL_TEST_DIR}/test_global_modules_cfg.py
 F2=${LOCAL_TEST_DIR}/test_stream_modules_cfg.py
 F3=${LOCAL_TEST_DIR}/test_one_modules_cfg.py
+F4=${LOCAL_TEST_DIR}/test_limited_modules_cfg.py
 (cmsRun $F1 ) || die "Failure using $F1" $?
 (cmsRun $F2 ) || die "Failure using $F2" $?
 (cmsRun $F3 ) || die "Failure using $F3" $?
+(cmsRun $F4 ) || die "Failure using $F4" $?
 
 #the last few lines of the output are the printout from the
 # ConcurrentModuleTimer service detailing how much time was
@@ -16,3 +18,5 @@ F3=${LOCAL_TEST_DIR}/test_one_modules_cfg.py
 touch empty_file
 
 (cmsRun ${LOCAL_TEST_DIR}/test_no_concurrent_module_cfg.py 2>&1) | tail -n 3 | grep -v ' 0 ' | grep -v 'e-' | diff - empty_file || die "Failure using test_no_concurrent_module_cfg.py" $?
+
+(cmsRun ${LOCAL_TEST_DIR}/test_limited_concurrent_module_cfg.py 2>&1) | tail -n 3 | grep -v ' 0 ' | grep -v 'e-' | diff - empty_file || die "Failure using test_limited_concurrent_module_cfg.py" $?

--- a/FWCore/Framework/test/stubs/TestLimitedAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestLimitedAnalyzers.cc
@@ -1,0 +1,319 @@
+
+/*----------------------------------------------------------------------
+
+Toy edm::limited::EDAnalyzer modules of 
+edm::*Cache templates 
+for testing purposes only.
+
+----------------------------------------------------------------------*/
+#include <iostream>
+#include <atomic>
+#include <vector>
+#include <map>
+#include <functional>
+#include "FWCore/Framework/interface/limited/EDAnalyzer.h"
+#include "FWCore/Framework/src/WorkerT.h"
+#include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+namespace edmtest {
+namespace limited {
+
+namespace {
+struct Cache { 
+   Cache():value(0) {}
+   //Using mutable since we want to update the value.
+   mutable std::atomic<unsigned int> value;
+};
+
+struct UnsafeCache {
+   UnsafeCache():value(0) {}
+   unsigned int value;
+};
+
+} //end anonymous namespace
+
+  class StreamIntAnalyzer: public edm::limited::EDAnalyzer<edm::StreamCache<UnsafeCache>> {
+  public:
+    explicit StreamIntAnalyzer(edm::ParameterSet const& p) :
+    edm::limited::EDAnalyzerBase(p),
+    edm::limited::EDAnalyzer<edm::StreamCache<UnsafeCache>>(p),
+	trans_(p.getParameter<int>("transitions"))
+    {}
+    const unsigned int trans_;
+    mutable std::atomic<unsigned int> m_count{0};
+    
+    std::unique_ptr<UnsafeCache> beginStream(edm::StreamID iID) const override {
+      ++m_count;
+      auto pCache = std::make_unique<UnsafeCache>();
+      pCache->value = iID.value();
+      return pCache;
+    }
+    
+    void streamBeginRun(edm::StreamID iID, edm::Run const&, edm::EventSetup const&) const  override{
+      ++m_count;
+      if ( (streamCache(iID))->value != iID.value() ) {
+          throw cms::Exception("cache value")
+          << "StreamIntAnalyzer cache value "
+          << (streamCache(iID))->value << " but it was supposed to be " << iID;
+      }
+    }
+
+    void streamBeginLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      if ( (streamCache(iID))->value != iID.value() ) {
+          throw cms::Exception("cache value")
+          << "StreamIntAnalyzer cache value "
+          << (streamCache(iID))->value << " but it was supposed to be " << iID;
+      }
+     }
+
+    void analyze(edm::StreamID iID, const edm::Event&, const edm::EventSetup&) const override {
+      ++m_count;
+      if ( (streamCache(iID))->value != iID.value() ) {
+          throw cms::Exception("cache value")
+          << "StreamIntAnalyzer cache value "
+          << (streamCache(iID))->value << " but it was supposed to be " << iID;
+      }       
+    }
+
+    void streamEndLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      if ( (streamCache(iID))->value != iID.value() ) {
+          throw cms::Exception("cache value")
+          << "StreamIntAnalyzer cache value "
+          << (streamCache(iID))->value << " but it was supposed to be " << iID;
+      }
+    }
+
+    void streamEndRun(edm::StreamID iID, edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+      if ( (streamCache(iID))->value != iID.value() ) {
+          throw cms::Exception("cache value")
+          << "StreamIntAnalyzer cache value "
+          << (streamCache(iID))->value << " but it was supposed to be " << iID;
+      }
+    }
+
+    void endStream(edm::StreamID iID ) const override {
+      ++m_count;
+      if ( (streamCache(iID))->value != iID.value() ) {
+          throw cms::Exception("cache value")
+          << "StreamIntAnalyzer cache value "
+          << (streamCache(iID))->value << " but it was supposed to be " << iID;
+      }
+    } 
+
+    ~StreamIntAnalyzer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "StreamIntAnalyzer transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+  
+  class RunIntAnalyzer: public edm::limited::EDAnalyzer<edm::RunCache<Cache>> {
+  public:
+    explicit RunIntAnalyzer(edm::ParameterSet const& p) :
+    edm::limited::EDAnalyzerBase(p),
+    edm::limited::EDAnalyzer<edm::RunCache<Cache>>(p),
+	trans_(p.getParameter<int>("transitions"))
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {}
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+    
+    std::shared_ptr<Cache> globalBeginRun(edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::make_shared<Cache>();
+    }
+
+    void analyze(edm::StreamID iID, const edm::Event& iEvent, const edm::EventSetup&) const override {
+      ++m_count;
+      ++((runCache(iEvent.getRun().index()))->value);
+       
+    }
+
+    void globalEndRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+      ++m_count;
+      if ( (runCache(iRun.index()))->value != cvalue_ ) {
+          throw cms::Exception("cache value")
+          << "RunIntAnalyzer cache value "
+          << (runCache(iRun.index()))->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+    ~RunIntAnalyzer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "RunIntAnalyzer transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+
+  class LumiIntAnalyzer: public edm::limited::EDAnalyzer<edm::LuminosityBlockCache<Cache>> {
+  public:
+    explicit LumiIntAnalyzer(edm::ParameterSet const& p) :
+    edm::limited::EDAnalyzerBase(p),
+    edm::limited::EDAnalyzer<edm::LuminosityBlockCache<Cache>>(p),
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {}
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+   
+    std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::make_shared<Cache>();
+    }
+
+    void analyze(edm::StreamID, const edm::Event& iEvent, const edm::EventSetup&) const override {
+      ++m_count;
+      ++(luminosityBlockCache(iEvent.getLuminosityBlock().index())->value);
+       
+    }
+     
+    void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      ++m_count;
+      if( (luminosityBlockCache(iLB.index()))->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << "LumiIntAnalyzer cache value "
+          << (luminosityBlockCache(iLB.index()))->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+    ~LumiIntAnalyzer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "LumiIntAnalyzer transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+  
+  class RunSummaryIntAnalyzer: public edm::limited::EDAnalyzer<edm::StreamCache<UnsafeCache>,edm::RunSummaryCache<UnsafeCache>> {
+  public:
+    explicit RunSummaryIntAnalyzer(edm::ParameterSet const& p) :
+    edm::limited::EDAnalyzerBase(p),
+    edm::limited::EDAnalyzer<edm::StreamCache<UnsafeCache>,edm::RunSummaryCache<UnsafeCache>>(p),
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {}
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+
+    std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
+      ++m_count;
+      return std::make_unique<UnsafeCache>();
+    }
+
+    std::shared_ptr<UnsafeCache> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::make_shared<UnsafeCache>();
+    }
+  
+    void analyze(edm::StreamID iID, const edm::Event&, const edm::EventSetup&) const override {
+      ++m_count;
+      ++((streamCache(iID))->value);
+       
+    }
+  
+    void streamEndRunSummary(edm::StreamID iID, edm::Run const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      gCache->value += (streamCache(iID))->value;
+      (streamCache(iID))->value = 0;
+    }
+    
+    void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      if( gCache->value  != cvalue_) {
+        throw cms::Exception("cache value")
+          << "RunSummaryIntAnalyzer cache value "
+          << gCache->value << " but it was supposed to be " << cvalue_;
+      } 
+    }
+
+    ~RunSummaryIntAnalyzer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "RunSummaryIntAnalyzer transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class LumiSummaryIntAnalyzer: public edm::limited::EDAnalyzer<edm::StreamCache<UnsafeCache>,edm::LuminosityBlockSummaryCache<UnsafeCache>> {
+  public:
+    explicit LumiSummaryIntAnalyzer(edm::ParameterSet const& p) :
+    edm::limited::EDAnalyzerBase(p),
+    edm::limited::EDAnalyzer<edm::StreamCache<UnsafeCache>,edm::LuminosityBlockSummaryCache<UnsafeCache>>(p),
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {}
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+
+    std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
+      ++m_count;
+      return std::make_unique<UnsafeCache>();
+    }
+
+    std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::make_shared<UnsafeCache>();
+    }
+    
+    void analyze(edm::StreamID iID, const edm::Event& iEvent, const edm::EventSetup&) const override {
+      ++m_count;
+      ++((streamCache(iID))->value);
+       
+    }
+
+    void streamEndLuminosityBlockSummary(edm::StreamID iID, edm::LuminosityBlock const& iLumiBlock, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      gCache->value += (streamCache(iID))->value;
+      (streamCache(iID))->value = 0;
+    }
+ 
+    void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      if( gCache->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << "LumiSummaryIntAnalyzer cache value "
+          << gCache->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+    ~LumiSummaryIntAnalyzer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "LumiSummaryIntAnalyzer transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+}
+}
+
+DEFINE_FWK_MODULE(edmtest::limited::StreamIntAnalyzer);
+DEFINE_FWK_MODULE(edmtest::limited::RunIntAnalyzer);
+DEFINE_FWK_MODULE(edmtest::limited::LumiIntAnalyzer);
+DEFINE_FWK_MODULE(edmtest::limited::RunSummaryIntAnalyzer);
+DEFINE_FWK_MODULE(edmtest::limited::LumiSummaryIntAnalyzer);
+

--- a/FWCore/Framework/test/stubs/TestLimitedFilters.cc
+++ b/FWCore/Framework/test/stubs/TestLimitedFilters.cc
@@ -1,0 +1,632 @@
+
+/*----------------------------------------------------------------------
+
+Toy edm::limited::EDFilter modules of 
+edm::*Cache templates and edm::*Producer classes
+for testing purposes only.
+
+----------------------------------------------------------------------*/
+#include <iostream>
+#include <atomic>
+#include <vector>
+#include <map>
+#include <functional>
+#include "FWCore/Framework/interface/limited/EDFilter.h"
+#include "FWCore/Framework/src/WorkerT.h"
+#include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+
+
+namespace edmtest {
+namespace limited {
+
+namespace {
+struct Cache { 
+   Cache():value(0),run(0),lumi(0),strm(0),work(0) {}
+   //Using mutable since we want to update the value.
+   mutable std::atomic<unsigned int> value;
+   mutable std::atomic<unsigned int> run;
+   mutable std::atomic<unsigned int> lumi;
+   mutable std::atomic<unsigned int> strm;
+   mutable std::atomic<unsigned int> work;
+};
+
+struct UnsafeCache {
+   UnsafeCache():value(0),run(0),lumi(0),strm(0),work(0) {}
+   unsigned int value;
+   unsigned int run;
+   unsigned int lumi;
+   unsigned int strm;
+   unsigned int work;
+};
+
+struct Dummy {
+};
+
+} //end anonymous namespace
+
+
+  class StreamIntFilter : public edm::limited::EDFilter<edm::StreamCache<UnsafeCache>> {
+  public:
+    explicit StreamIntFilter(edm::ParameterSet const& p) :
+    edm::limited::EDFilterBase(p),
+    edm::limited::EDFilter<edm::StreamCache<UnsafeCache>>(p),
+	trans_(p.getParameter<int>("transitions"))
+    {
+    produces<unsigned int>();
+    }
+
+    const unsigned int trans_; 
+    mutable std::atomic<unsigned int> m_count{0};
+   
+    std::unique_ptr<UnsafeCache> beginStream(edm::StreamID iID) const override {
+      ++m_count;
+      auto sCache = std::make_unique<UnsafeCache>();
+      ++(sCache->strm);
+      sCache->value = iID.value();
+      return sCache;
+    }
+    
+    void streamBeginRun(edm::StreamID iID, edm::Run const&, edm::EventSetup const&) const  override{
+      ++m_count;
+      auto sCache = streamCache(iID);
+      if ( sCache->value != iID.value() ) {
+          throw cms::Exception("cache value")
+          << (streamCache(iID))->value << " but it was supposed to be " << iID;
+      }
+      if ( sCache->run != 0 || sCache->lumi !=0 || sCache->work !=0 || sCache->strm !=1 ) {
+        throw cms::Exception("out of sequence")
+          << "streamBeginRun out of sequence in Stream " << iID.value();
+      }      
+      ++(sCache->run);
+     }
+
+    void streamBeginLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      auto sCache = streamCache(iID);
+      if ( sCache->value != iID.value() ) {
+          throw cms::Exception("cache value")
+          << (streamCache(iID))->value << " but it was supposed to be " << iID;
+      }
+      if ( sCache->lumi != 0 || sCache->work != 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamBeginLuminosityBlock out of sequence in Stream " << iID.value();
+      }      
+       ++(sCache->lumi);
+     }
+
+    bool filter(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+      auto sCache = streamCache(iID);
+      if ( sCache->value != iID.value() ) {
+          throw cms::Exception("cache value")
+          << (streamCache(iID))->value << " but it was supposed to be " << iID;
+      }
+      ++(sCache->work);
+      if ( sCache->lumi == 0 && sCache->run == 0) {
+        throw cms::Exception("out of sequence")
+          << "produce out of sequence in Stream " << iID.value();
+      }       
+       
+      return true;
+    }
+ 
+    void streamEndLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      auto sCache = streamCache(iID);
+      if ( sCache->value != iID.value() ) {
+          throw cms::Exception("cache value")
+          << (streamCache(iID))->value << " but it was supposed to be " << iID;
+      }
+      --(sCache->lumi);
+      sCache->work = 0;
+      if ( sCache->lumi != 0 || sCache->run == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndLuminosityBlock out of sequence in Stream " << iID.value();
+      }      
+     }
+
+    void streamEndRun(edm::StreamID iID, edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+      auto sCache = streamCache(iID);
+      if ( sCache->value != iID.value() ) {
+          throw cms::Exception("cache value")
+          << (streamCache(iID))->value << " but it was supposed to be " << iID;
+      }
+      --(sCache->run);
+      sCache->work = 0;
+      if ( sCache->run != 0 || sCache->lumi != 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndRun out of sequence in Stream " << iID.value();
+      }      
+    }
+
+    void endStream(edm::StreamID iID) const override {
+      ++m_count;
+      auto sCache = streamCache(iID);
+      --(sCache->strm);
+      if ( sCache->value != iID.value() ) {
+          throw cms::Exception("cache value")
+          << (streamCache(iID))->value << " but it was supposed to be " << iID;
+      }
+      if ( sCache->strm != 0 || sCache->run != 0 || sCache->lumi != 0 ) {
+        throw cms::Exception("out of sequence")
+          << "endStream out of sequence in Stream " << iID.value();
+      }      
+   }
+
+    ~StreamIntFilter() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "StreamIntFilter transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+  
+  class RunIntFilter : public edm::limited::EDFilter<edm::StreamCache<UnsafeCache>,edm::RunCache<Cache>> {
+  public:
+    explicit RunIntFilter(edm::ParameterSet const& p) :
+    edm::limited::EDFilterBase(p),
+    edm::limited::EDFilter<edm::StreamCache<UnsafeCache>,edm::RunCache<Cache>>(p),
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {    
+    produces<unsigned int>();
+    }
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+    
+    std::shared_ptr<Cache> globalBeginRun(edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+      auto rCache = std::make_shared<Cache>();
+      ++(rCache->run);
+      return rCache;
+    }
+ 
+    std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
+      return std::make_unique<UnsafeCache>();
+    }
+
+    void streamBeginRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const  override {
+      auto rCache = runCache(iRun.index());
+      if ( rCache->run == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamBeginRun before globalBeginRun in Stream " << iID.value();
+      }      
+    }
+ 
+    bool filter(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const override {
+      ++m_count;
+      auto rCache = runCache(iEvent.getRun().index());
+      ++(rCache->value);
+       
+      return true;
+    }
+
+    void streamEndRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const override {
+      auto rCache = runCache(iRun.index());
+      if ( rCache->run == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndRun after globalEndRun in Stream " << iID.value();
+      }      
+    }
+
+
+    void globalEndRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+      ++m_count;
+      auto rCache = runCache(iRun.index());
+      if ( rCache->value != cvalue_ ) {
+          throw cms::Exception("cache value")
+          << "RunIntFilter cache value "
+          << rCache->value << " but it was supposed to be " << cvalue_;
+      }
+     --(rCache->run);
+    }
+
+    ~RunIntFilter() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "RunIntFilter transitions "     
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+
+  class LumiIntFilter : public edm::limited::EDFilter<edm::StreamCache<UnsafeCache>,edm::LuminosityBlockCache<Cache>> {
+  public:
+    explicit LumiIntFilter(edm::ParameterSet const& p) :
+    edm::limited::EDFilterBase(p),
+    edm::limited::EDFilter<edm::StreamCache<UnsafeCache>,edm::LuminosityBlockCache<Cache>>(p),
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {    
+    produces<unsigned int>();
+    }
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+    
+    std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      auto lCache = std::make_shared<Cache>();
+      ++(lCache->lumi);  
+      return lCache;
+    }
+
+   std::unique_ptr<UnsafeCache> beginStream(edm::StreamID iID) const override {
+      return std::make_unique<UnsafeCache>();
+    }
+
+   void streamBeginLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      auto lCache = luminosityBlockCache(iLB.index()); 
+      if ( lCache->lumi == 0) {
+        throw cms::Exception("out of sequence")
+          << "streamBeginLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+       }
+   }
+
+
+    bool filter(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const override {
+      ++m_count;
+      ++(luminosityBlockCache(iEvent.getLuminosityBlock().index())->value);
+      return true;
+    }
+ 
+   void streamEndLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      auto lCache = luminosityBlockCache(iLB.index()); 
+      if ( lCache->lumi == 0) {
+        throw cms::Exception("out of sequence")
+          << "streamEndLuminosityBlock seen before globalEndLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+       }
+    }
+ 
+    
+    void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      ++m_count;
+      auto lCache = luminosityBlockCache(iLB.index());
+      --(lCache->lumi); 
+      if ( lCache->lumi != 0 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+      }
+      if( lCache->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << "LumiIntFilter cache value "
+          << lCache->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+    ~LumiIntFilter() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "LumiIntFilter transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+  
+  class RunSummaryIntFilter : public edm::limited::EDFilter<edm::StreamCache<Cache>,edm::RunSummaryCache<UnsafeCache>> {
+  public:
+    explicit RunSummaryIntFilter(edm::ParameterSet const& p) :
+    edm::limited::EDFilterBase(p),
+    edm::limited::EDFilter<edm::StreamCache<Cache>,edm::RunSummaryCache<UnsafeCache>>(p),
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {
+    produces<unsigned int>();
+      
+    }
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+
+    std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
+      ++m_count;
+      return std::make_unique<Cache>();
+    }
+    
+    std::shared_ptr<UnsafeCache> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+      auto gCache = std::make_shared<UnsafeCache>();
+      ++(gCache->run);
+      return gCache;
+    }
+    
+    bool filter(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+      ++((streamCache(iID))->value);
+       
+      return true;
+    }
+    
+    void streamEndRunSummary(edm::StreamID iID, edm::Run const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      if ( gCache->run == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndRunSummary after globalEndRunSummary in Stream " << iID.value();
+      }      
+      auto sCache = streamCache(iID);
+      gCache->value += sCache->value;
+      sCache->value = 0;
+    }
+    
+    void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      if( gCache->value  != cvalue_) {
+        throw cms::Exception("cache value")
+          << "RunSummaryIntFilter cache value "
+          << gCache->value << " but it was supposed to be " << cvalue_;
+      }
+      --(gCache->run);
+    }
+
+    ~RunSummaryIntFilter() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "RunSummaryIntFilter transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class LumiSummaryIntFilter : public edm::limited::EDFilter<edm::StreamCache<Cache>,edm::LuminosityBlockSummaryCache<UnsafeCache>> {
+  public:
+    explicit LumiSummaryIntFilter(edm::ParameterSet const& p) :
+    edm::limited::EDFilterBase(p),
+    edm::limited::EDFilter<edm::StreamCache<Cache>,edm::LuminosityBlockSummaryCache<UnsafeCache>>(p),
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {	
+    produces<unsigned int>();
+      
+    }
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+
+    std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
+      ++m_count;
+      return std::make_unique<Cache>();
+    }
+  
+    std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      auto gCache = std::make_shared<UnsafeCache>();
+      ++(gCache->lumi);
+      return gCache;
+    }
+
+    bool filter(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+      ++((streamCache(iID))->value);
+      return true;
+    }
+    
+    void streamEndLuminosityBlockSummary(edm::StreamID iID, edm::LuminosityBlock const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      if ( gCache->lumi == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndLuminosityBlockSummary after globalEndLuminosityBlockSummary in Stream " << iID.value();
+      }
+      auto sCache = streamCache(iID);
+      gCache->value += sCache->value;
+      sCache->value = 0;
+    }
+    
+    void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      if( gCache->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << "LumiSummaryIntFilter cache value "
+          << gCache->value << " but it was supposed to be " << cvalue_;
+      }
+      --(gCache->lumi);
+    }
+
+    ~LumiSummaryIntFilter() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "LumiSummaryIntFilter transitions "     
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class TestBeginRunFilter : public edm::limited::EDFilter<edm::RunCache<Dummy>,edm::BeginRunProducer> {
+  public:
+    explicit TestBeginRunFilter(edm::ParameterSet const& p) :
+    edm::limited::EDFilterBase(p),
+    edm::limited::EDFilter<edm::RunCache<Dummy>,edm::BeginRunProducer>(p),
+	trans_(p.getParameter<int>("transitions")) {
+    produces<unsigned int>();
+    }
+
+    const unsigned int trans_; 
+    mutable std::atomic<unsigned int> m_count{0};
+    mutable std::atomic<bool> brp{false}; 
+
+    std::shared_ptr<Dummy> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+      brp = false;
+      return std::shared_ptr<Dummy>();
+    }
+ 
+    void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const override {
+      ++m_count;
+      brp = true;
+     }
+
+    bool filter(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      if ( !brp ) {
+        throw cms::Exception("out of sequence")
+          << "filter before globalBeginRunProduce in Stream " << iID.value();
+      }
+      return true;
+    }
+
+    void globalEndRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+    }
+
+    ~TestBeginRunFilter() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestBeginRunFilter transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class TestEndRunFilter : public edm::limited::EDFilter<edm::RunCache<Dummy>,edm::EndRunProducer> {
+  public:
+    explicit TestEndRunFilter(edm::ParameterSet const& p) :
+    edm::limited::EDFilterBase(p),
+    edm::limited::EDFilter<edm::RunCache<Dummy>,edm::EndRunProducer>(p),
+	trans_(p.getParameter<int>("transitions")) {
+    produces<unsigned int>();
+    }
+    const unsigned int trans_; 
+    mutable std::atomic<unsigned int> m_count{0};
+    mutable std::atomic<bool> p{false}; 
+
+    std::shared_ptr<Dummy> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+      p = false;
+      return std::shared_ptr<Dummy>();
+    }
+
+
+    bool filter(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      p = true;
+      return true;
+    }
+
+    void globalEndRunProduce(edm::Run&, edm::EventSetup const&) const override {
+      if ( !p ) {
+        throw cms::Exception("out of sequence")
+          << "endRunProduce before produce";
+      }
+       ++m_count;
+    }
+
+    void globalEndRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+    }
+
+    ~TestEndRunFilter() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestEndRunFilter transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class TestBeginLumiBlockFilter : public edm::limited::EDFilter<edm::LuminosityBlockCache<Dummy>,edm::BeginLuminosityBlockProducer> {
+  public:
+    explicit TestBeginLumiBlockFilter(edm::ParameterSet const& p) :
+    edm::limited::EDFilterBase(p),
+    edm::limited::EDFilter<edm::LuminosityBlockCache<Dummy>,edm::BeginLuminosityBlockProducer>(p),
+	trans_(p.getParameter<int>("transitions")) {
+    produces<unsigned int>();
+    }
+    const unsigned int trans_; 
+    mutable std::atomic<unsigned int> m_count{0};
+    mutable std::atomic<bool> gblp{false}; 
+
+    std::shared_ptr<Dummy> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      gblp = false;
+      return std::shared_ptr<Dummy>();
+    }
+
+
+    void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override {
+      ++m_count;
+      gblp = true;
+    }
+
+    bool filter(edm::StreamID iID, edm::Event&, const edm::EventSetup&) const override{
+      if ( !gblp ) {
+        throw cms::Exception("out of sequence")
+          << "filter before globalBeginLuminosityBlockProduce in Stream " << iID.value();
+      }
+      return true;
+    }
+
+    void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+    }
+
+    ~TestBeginLumiBlockFilter() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestBeginLumiBlockFilter transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class TestEndLumiBlockFilter : public edm::limited::EDFilter<edm::LuminosityBlockCache<Dummy>,edm::EndLuminosityBlockProducer> {
+  public:
+    explicit TestEndLumiBlockFilter(edm::ParameterSet const& p) :
+    edm::limited::EDFilterBase(p),
+    edm::limited::EDFilter<edm::LuminosityBlockCache<Dummy>,edm::EndLuminosityBlockProducer>(p),
+	trans_(p.getParameter<int>("transitions")) {
+    produces<unsigned int>();
+    }
+    const unsigned int trans_; 
+    mutable std::atomic<unsigned int> m_count{0};
+    mutable std::atomic<bool> p{false}; 
+
+    std::shared_ptr<Dummy> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      p = false;
+      return std::shared_ptr<Dummy>();
+    }
+
+
+    bool filter(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      p = true;
+      return true;
+    }
+
+    void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override {
+      if ( !p ) {
+        throw cms::Exception("out of sequence")
+          << "endLumiBlockProduce before produce";
+      }
+      ++m_count;
+    }
+
+    void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+    }
+
+    ~TestEndLumiBlockFilter() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestEndLumiBlockFilter transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+
+}
+}
+
+DEFINE_FWK_MODULE(edmtest::limited::StreamIntFilter);
+DEFINE_FWK_MODULE(edmtest::limited::RunIntFilter);
+DEFINE_FWK_MODULE(edmtest::limited::LumiIntFilter);
+DEFINE_FWK_MODULE(edmtest::limited::RunSummaryIntFilter);
+DEFINE_FWK_MODULE(edmtest::limited::LumiSummaryIntFilter);
+DEFINE_FWK_MODULE(edmtest::limited::TestBeginRunFilter);
+DEFINE_FWK_MODULE(edmtest::limited::TestBeginLumiBlockFilter);
+DEFINE_FWK_MODULE(edmtest::limited::TestEndRunFilter);
+DEFINE_FWK_MODULE(edmtest::limited::TestEndLumiBlockFilter);
+

--- a/FWCore/Framework/test/stubs/TestLimitedProducers.cc
+++ b/FWCore/Framework/test/stubs/TestLimitedProducers.cc
@@ -1,0 +1,603 @@
+
+/*----------------------------------------------------------------------
+
+Toy edm::limited::EDProducer modules of 
+edm::*Cache templates and edm::*Producer classes
+for testing purposes only.
+
+----------------------------------------------------------------------*/
+#include <iostream>
+#include <atomic>
+#include <vector>
+#include <map>
+#include <functional>
+#include "FWCore/Framework/interface/limited/EDProducer.h"
+#include "FWCore/Framework/src/WorkerT.h"
+#include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+
+
+namespace edmtest {
+namespace limited {
+
+namespace {
+struct Cache { 
+   Cache():value(0),run(0),lumi(0),strm(0),work(0) {}
+   //Using mutable since we want to update the value.
+   mutable std::atomic<unsigned int> value;
+   mutable std::atomic<unsigned int> run;
+   mutable std::atomic<unsigned int> lumi;
+   mutable std::atomic<unsigned int> strm;
+   mutable std::atomic<unsigned int> work;
+};
+
+struct UnsafeCache {
+   UnsafeCache():value(0),run(0),lumi(0),strm(0),work(0) {}
+   unsigned int value;
+   unsigned int run;
+   unsigned int lumi;
+   unsigned int strm;
+   unsigned int work;
+};
+
+struct Dummy {
+};
+
+} //end anonymous namespace
+
+  class StreamIntProducer : public edm::limited::EDProducer<edm::StreamCache<UnsafeCache>> {
+  public:
+    explicit StreamIntProducer(edm::ParameterSet const& p) :
+    edm::limited::EDProducerBase(p),
+    edm::limited::EDProducer<edm::StreamCache<UnsafeCache>>(p),
+	trans_(p.getParameter<int>("transitions")) 
+    {
+    produces<unsigned int>();
+    }
+
+    const unsigned int trans_; 
+    mutable std::atomic<unsigned int> m_count{0};
+
+   std::unique_ptr<UnsafeCache> beginStream(edm::StreamID iID) const override {
+      ++m_count;
+      auto sCache = std::make_unique<UnsafeCache>();
+      ++(sCache->strm);
+      sCache->value = iID.value();
+      return sCache;
+    }
+    
+    void streamBeginRun(edm::StreamID iID, edm::Run const&, edm::EventSetup const&) const  override {
+      ++m_count;
+      auto sCache = streamCache(iID);
+      if ( sCache->value != iID.value() ) {
+          throw cms::Exception("cache value")
+          << "StreamIntAnalyzer cache value "
+          << (streamCache(iID))->value << " but it was supposed to be " << iID;
+      }
+      if ( sCache->run != 0 || sCache->lumi !=0 || sCache->work !=0 || sCache->strm !=1 ) {
+        throw cms::Exception("out of sequence")
+          << "streamBeginRun out of sequence in Stream " << iID.value();
+      }      
+      ++(sCache->run);
+    }
+
+    void streamBeginLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      auto sCache = streamCache(iID);
+      if ( sCache->lumi != 0 || sCache->work != 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamBeginLuminosityBlock out of sequence in Stream " << iID.value();
+      }      
+       ++(sCache->lumi);
+    }
+
+    void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+      auto sCache = streamCache(iID);
+      ++(sCache->work);
+      if ( sCache->lumi == 0 && sCache->run == 0) {
+        throw cms::Exception("out of sequence")
+          << "produce out of sequence in Stream " << iID.value();
+      }       
+       
+    }
+    
+ 
+    void streamEndLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      auto sCache = streamCache(iID);
+      --(sCache->lumi);
+      sCache->work = 0;
+      if ( sCache->lumi != 0 || sCache->run == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndLuminosityBlock out of sequence in Stream " << iID.value();
+      }      
+     }
+
+    void streamEndRun(edm::StreamID iID, edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+      auto sCache = streamCache(iID);
+      --(sCache->run);
+      sCache->work = 0;
+      if ( sCache->run != 0 || sCache->lumi != 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndRun out of sequence in Stream " << iID.value();
+      }      
+     }
+
+    void endStream(edm::StreamID iID) const override {
+      ++m_count;
+      auto sCache = streamCache(iID);
+      --(sCache->strm);
+      if ( sCache->strm != 0 || sCache->run != 0 || sCache->lumi != 0 ) {
+        throw cms::Exception("out of sequence")
+          << "endStream out of sequence in Stream " << iID.value();
+      }      
+    }
+
+    ~StreamIntProducer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "StreamIntProducer transitions " 
+          << m_count << " but it was supposed to be " << trans_;
+      }
+    }
+  };
+  
+  class RunIntProducer : public edm::limited::EDProducer<edm::StreamCache<UnsafeCache>,edm::RunCache<Cache>> {
+  public:
+    explicit RunIntProducer(edm::ParameterSet const& p) :
+    edm::limited::EDProducerBase(p),
+    edm::limited::EDProducer<edm::StreamCache<UnsafeCache>,edm::RunCache<Cache>>(p),
+	trans_(p.getParameter<int>("transitions"))
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {
+    produces<unsigned int>();
+    }
+
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+
+    std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+      ++m_count;
+      auto rCache = std::make_shared<Cache>();
+      ++(rCache->run);
+      return rCache;
+    }
+
+    std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
+      return std::make_unique<UnsafeCache>();
+    }
+    
+    void streamBeginRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const  override {
+      auto rCache = runCache(iRun.index());
+      if ( rCache->run == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamBeginRun before globalBeginRun in Stream " << iID.value();
+      }      
+    }
+
+
+    void produce(edm::StreamID iID, edm::Event& iEvent, edm::EventSetup const&) const override {
+      auto rCache = runCache(iEvent.getRun().index());
+      ++(rCache->value);
+       
+    }
+
+    void streamEndRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const override {
+      auto rCache = runCache(iRun.index());
+      if ( rCache->run == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndRun after globalEndRun in Stream " << iID.value();
+      }      
+    }
+
+    void globalEndRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+      ++m_count;
+      auto rCache = runCache(iRun.index());
+      if ( rCache->value != cvalue_ ) {
+          throw cms::Exception("cache value")
+          << "RunIntProducer cache value "
+          << rCache->value << " but it was supposed to be " << cvalue_;
+      }
+     --(rCache->run);
+    }
+
+
+    ~RunIntProducer() {
+       if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "RunIntProducer transitions " 
+          << m_count << " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+
+  class LumiIntProducer : public edm::limited::EDProducer<edm::StreamCache<UnsafeCache>,edm::LuminosityBlockCache<Cache>> {
+  public:
+    explicit LumiIntProducer(edm::ParameterSet const& p) :
+    edm::limited::EDProducerBase(p),
+    edm::limited::EDProducer<edm::StreamCache<UnsafeCache>,edm::LuminosityBlockCache<Cache>>(p),
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {
+    produces<unsigned int>();
+    }
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+    
+    std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      ++m_count;
+      auto lCache = std::make_shared<Cache>();
+      ++(lCache->lumi);  
+      return lCache;
+    }
+
+   std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
+      return std::make_unique<UnsafeCache>();
+    }
+
+    void streamBeginLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      auto lCache = luminosityBlockCache(iLB.index()); 
+      if ( lCache->lumi == 0) {
+        throw cms::Exception("out of sequence")
+          << "streamBeginLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+       }
+   }
+
+
+    void produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const override {
+      auto lCache = luminosityBlockCache(iEvent.getLuminosityBlock().index());
+      ++(lCache->value);
+       
+    }
+
+    void streamEndLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      auto lCache = luminosityBlockCache(iLB.index()); 
+      if ( lCache->lumi == 0) {
+        throw cms::Exception("out of sequence")
+          << "streamEndLuminosityBlock seen before globalEndLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+       }
+    }
+  
+    void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      ++m_count;
+      auto lCache = luminosityBlockCache(iLB.index());
+      --(lCache->lumi); 
+      if ( lCache->lumi != 0 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+      }
+      if( lCache->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << "LumiIntProducer cache value "
+          << lCache->value << " but it was supposed to be " << cvalue_;
+      }
+     }
+
+
+    ~LumiIntProducer() {
+       if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "LumiIntProducer transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+       }
+    }
+  };
+  
+  class RunSummaryIntProducer : public edm::limited::EDProducer<edm::StreamCache<UnsafeCache>,edm::RunSummaryCache<UnsafeCache>> {
+  public:
+    explicit RunSummaryIntProducer(edm::ParameterSet const& p) :
+    edm::limited::EDProducerBase(p),
+    edm::limited::EDProducer<edm::StreamCache<UnsafeCache>,edm::RunSummaryCache<UnsafeCache>>(p),
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {
+    produces<unsigned int>();
+      
+    }
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+   
+    std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
+      return std::make_unique<UnsafeCache>();
+    }
+
+    std::shared_ptr<UnsafeCache> globalBeginRunSummary(edm::Run const& iRun, edm::EventSetup const&) const override {
+      ++m_count;
+      auto gCache = std::make_shared<UnsafeCache>();
+      ++(gCache->run);
+      return gCache;
+    }
+
+    void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      auto sCache = streamCache(iID);
+      ++(sCache->value);
+       
+    }
+     
+    void streamEndRunSummary(edm::StreamID iID, edm::Run const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      if ( gCache->run == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndRunSummary after globalEndRunSummary in Stream " << iID.value();
+      }      
+      auto sCache = streamCache(iID);
+      gCache->value += sCache->value;
+      sCache->value = 0;
+    }
+    
+    void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      if( gCache->value  != cvalue_) {
+        throw cms::Exception("cache value")
+          << "RunSummaryIntProducer cache value "
+          << gCache->value << " but it was supposed to be " << cvalue_;
+      }
+      --(gCache->run);
+    }
+
+
+    ~RunSummaryIntProducer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "RunSummaryIntProducer transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class LumiSummaryIntProducer : public edm::limited::EDProducer<edm::StreamCache<UnsafeCache>,edm::LuminosityBlockSummaryCache<UnsafeCache>> {
+  public:
+    explicit LumiSummaryIntProducer(edm::ParameterSet const& p) :
+    edm::limited::EDProducerBase(p),
+    edm::limited::EDProducer<edm::StreamCache<UnsafeCache>,edm::LuminosityBlockSummaryCache<UnsafeCache>>(p),
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {	
+    produces<unsigned int>();
+      
+    }
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+  
+    std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
+      return std::make_unique<UnsafeCache>();
+    }
+
+    std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      ++m_count;
+      auto gCache = std::make_shared<UnsafeCache>();
+      ++(gCache->lumi);
+       return gCache;
+    }
+
+    void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      auto sCache = streamCache(iID);
+      ++(sCache->value);
+       
+    }
+      
+    void streamEndLuminosityBlockSummary(edm::StreamID iID, edm::LuminosityBlock const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      if ( gCache->lumi == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndLuminosityBlockSummary after globalEndLuminosityBlockSummary in Stream " << iID.value();
+      }
+      auto sCache = streamCache(iID);
+      gCache->value += sCache->value;
+      sCache->value = 0;
+    }
+    
+    void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      if( gCache->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << "LumiSummaryIntProducer cache value "
+          << gCache->value << " but it was supposed to be " << cvalue_;
+      }
+      --(gCache->lumi);
+    }
+
+    ~LumiSummaryIntProducer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "LumiSummaryIntProducer transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class TestBeginRunProducer : public edm::limited::EDProducer<edm::RunCache<Dummy>,edm::BeginRunProducer> {
+  public:
+    explicit TestBeginRunProducer(edm::ParameterSet const& p) :
+    edm::limited::EDProducerBase(p),
+    edm::limited::EDProducer<edm::RunCache<Dummy>,edm::BeginRunProducer>(p),
+	trans_(p.getParameter<int>("transitions")) {	
+    produces<unsigned int>();
+    }
+
+    const unsigned int trans_; 
+    mutable std::atomic<unsigned int> m_count{0};
+    mutable std::atomic<bool> brp{false}; 
+ 
+    std::shared_ptr<Dummy> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+      brp = false;
+      return std::shared_ptr<Dummy>();
+    }
+
+    void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      if (!brp) {
+        throw cms::Exception("out of sequence")
+          << "produce before globalBeginRunProduce in Stream " << iID.value();      }
+    }
+
+    void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const override {
+      ++m_count;
+      brp = true;
+    }
+
+    void globalEndRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+    }
+
+    ~TestBeginRunProducer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestBeginRunProducer transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+
+  };
+
+  class TestEndRunProducer : public edm::limited::EDProducer<edm::RunCache<Dummy>,edm::EndRunProducer> {
+  public:
+    explicit TestEndRunProducer(edm::ParameterSet const& p) :
+    edm::limited::EDProducerBase(p),
+    edm::limited::EDProducer<edm::RunCache<Dummy>,edm::EndRunProducer>(p),
+	trans_(p.getParameter<int>("transitions")) {	
+    produces<unsigned int>();
+    }
+    const unsigned int trans_;
+    mutable std::atomic<unsigned int> m_count{0};
+    mutable std::atomic<bool> p{false}; 
+
+    std::shared_ptr<Dummy> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+      p = false;
+      return std::shared_ptr<Dummy>();
+    }
+
+    void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      p = true;
+    }
+
+    void globalEndRunProduce(edm::Run&, edm::EventSetup const&) const override {
+      if ( !p ) {
+        throw cms::Exception("out of sequence")
+          << "endRunProduce before produce";
+      }
+      ++m_count;
+    }
+
+    void globalEndRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+    }
+
+    ~TestEndRunProducer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestEndRunProducer transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class TestBeginLumiBlockProducer : public edm::limited::EDProducer<edm::LuminosityBlockCache<void>,edm::BeginLuminosityBlockProducer> {
+  public:
+    explicit TestBeginLumiBlockProducer(edm::ParameterSet const& p) :
+    edm::limited::EDProducerBase(p),
+    edm::limited::EDProducer<edm::LuminosityBlockCache<void>,edm::BeginLuminosityBlockProducer>(p),
+	trans_(p.getParameter<int>("transitions")) {	
+    produces<unsigned int>();
+    }
+    const unsigned int trans_; 
+    mutable std::atomic<unsigned int> m_count{0};
+    mutable std::atomic<bool> gblp{false}; 
+
+    std::shared_ptr<void> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      gblp = false;
+      return std::shared_ptr<void>();
+    }
+
+    void produce(edm::StreamID iID, edm::Event&, const edm::EventSetup&) const override{
+      if ( !gblp ) {
+        throw cms::Exception("out of sequence")
+          << "produce before globalBeginLuminosityBlockProduce in Stream " << iID.value();
+      }
+    }
+
+    void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override {
+      ++m_count;
+      gblp = true;
+    }
+
+    void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+    }
+
+    ~TestBeginLumiBlockProducer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestBeginLumiBlockProducer transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class TestEndLumiBlockProducer : public edm::limited::EDProducer<edm::LuminosityBlockCache<void>,edm::EndLuminosityBlockProducer> {
+  public:
+    explicit TestEndLumiBlockProducer(edm::ParameterSet const& p) :
+    edm::limited::EDProducerBase(p),
+    edm::limited::EDProducer<edm::LuminosityBlockCache<void>,edm::EndLuminosityBlockProducer>(p),
+	trans_(p.getParameter<int>("transitions")) {	
+    produces<unsigned int>();
+    }
+    const unsigned int trans_; 
+    mutable std::atomic<unsigned int> m_count{0};
+    mutable std::atomic<bool> p{false}; 
+
+    std::shared_ptr<void> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      p = false;
+      return std::shared_ptr<void>();
+    }
+
+
+    void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      p = true;    
+    }
+
+    void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override {
+      if ( !p ) {
+        throw cms::Exception("out of sequence")
+          << "endLumiBlockProduce before produce";
+      }
+      ++m_count;
+    }
+
+    void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+    }
+
+    ~TestEndLumiBlockProducer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestEndLumiBlockProducer transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+}
+}
+
+DEFINE_FWK_MODULE(edmtest::limited::StreamIntProducer);
+DEFINE_FWK_MODULE(edmtest::limited::RunIntProducer);
+DEFINE_FWK_MODULE(edmtest::limited::LumiIntProducer);
+DEFINE_FWK_MODULE(edmtest::limited::RunSummaryIntProducer);
+DEFINE_FWK_MODULE(edmtest::limited::LumiSummaryIntProducer);
+DEFINE_FWK_MODULE(edmtest::limited::TestBeginRunProducer);
+DEFINE_FWK_MODULE(edmtest::limited::TestEndRunProducer);
+DEFINE_FWK_MODULE(edmtest::limited::TestBeginLumiBlockProducer);
+DEFINE_FWK_MODULE(edmtest::limited::TestEndLumiBlockProducer);
+

--- a/FWCore/Framework/test/test_limited_concurrent_module_cfg.py
+++ b/FWCore/Framework/test/test_limited_concurrent_module_cfg.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("LIMITEDCONCURRENT")
+
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+                            numberOfStreams = cms.untracked.uint32(6),
+                            numberOfThreads = cms.untracked.uint32(6)
+)
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(20))
+
+process.i1 = cms.EDProducer("BusyWaitIntLimitedProducer", ivalue = cms.int32(1),
+                            iterations = cms.uint32(300*1000),
+                            concurrencyLimit = cms.untracked.uint32(2))
+
+
+process.c1 = cms.EDAnalyzer("ConsumingOneSharedResourceAnalyzer",
+                            valueMustMatch = cms.untracked.int32(1),
+                            moduleLabel = cms.untracked.InputTag("i1"),
+                            resourceName = cms.untracked.string("foo"))
+                            
+
+process.t = cms.Task(process.i1)
+
+process.p = cms.Path(process.c1, process.t)
+
+process.add_(cms.Service("ConcurrentModuleTimer",
+                         modulesToExclude = cms.untracked.vstring("TriggerResults"),
+                         excludeSource = cms.untracked.bool(True)))

--- a/FWCore/Framework/test/test_limited_modules_cfg.py
+++ b/FWCore/Framework/test/test_limited_modules_cfg.py
@@ -1,0 +1,162 @@
+import FWCore.ParameterSet.Config as cms
+
+nEvtLumi = 4
+nEvtRun = 2*nEvtLumi
+nStreams = 16 
+nEvt = nStreams*nEvtRun*nEvtLumi
+
+process = cms.Process("TESTGLOBALMODULES")
+
+import FWCore.Framework.test.cmsExceptionsFatalOption_cff
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(nStreams)
+)
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(nEvt)
+)
+
+process.source = cms.Source("EmptySource",
+    timeBetweenEvents = cms.untracked.uint64(1000),
+    firstTime = cms.untracked.uint64(1000000),
+    numberEventsInRun = cms.untracked.uint32(nEvtRun),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(nEvtLumi) 
+)
+
+#process.Tracer = cms.Service("Tracer")
+
+process.StreamIntProd = cms.EDProducer("edmtest::limited::StreamIntProducer",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(nEvt+nStreams*(2*(nEvt/nEvtRun)+2*(nEvt/nEvtLumi)+2))
+    ,cachevalue = cms.int32(1)
+)
+
+process.RunIntProd = cms.EDProducer("edmtest::limited::RunIntProducer",
+                                    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(2*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvtRun)
+)
+
+process.LumiIntProd = cms.EDProducer("edmtest::limited::LumiIntProducer",
+                                     concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(2*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.RunSumIntProd = cms.EDProducer("edmtest::limited::RunSummaryIntProducer",
+                                       concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(nStreams*(nEvt/nEvtRun)+2*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvtRun)
+)
+
+process.LumiSumIntProd = cms.EDProducer("edmtest::limited::LumiSummaryIntProducer",
+                                        concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(nStreams*(nEvt/nEvtLumi)+2*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.TestBeginRunProd = cms.EDProducer("edmtest::limited::TestBeginRunProducer",
+                                          concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32((nEvt/nEvtRun))
+)
+
+process.TestEndRunProd = cms.EDProducer("edmtest::limited::TestEndRunProducer",
+                                        concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32((nEvt/nEvtRun))
+)
+
+process.TestBeginLumiBlockProd = cms.EDProducer("edmtest::limited::TestBeginLumiBlockProducer",
+                                                concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32((nEvt/nEvtLumi))
+)
+
+process.TestEndLumiBlockProd = cms.EDProducer("edmtest::limited::TestEndLumiBlockProducer",
+                                              concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32((nEvt/nEvtLumi))
+)
+
+process.StreamIntAn = cms.EDAnalyzer("edmtest::limited::StreamIntAnalyzer",
+                                     concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(nEvt+nStreams*(2*(nEvt/nEvtRun)+2*(nEvt/nEvtLumi)+2))
+    ,cachevalue = cms.int32(1)
+)
+
+process.RunIntAn= cms.EDAnalyzer("edmtest::limited::RunIntAnalyzer",
+                                 concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvtRun)
+)
+
+process.LumiIntAn = cms.EDAnalyzer("edmtest::limited::LumiIntAnalyzer",
+                                   concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.RunSumIntAn = cms.EDAnalyzer("edmtest::limited::RunSummaryIntAnalyzer",
+                                     concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(nEvt+nStreams*((nEvt/nEvtRun)+1)+2*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvtRun)
+)
+
+process.LumiSumIntAn = cms.EDAnalyzer("edmtest::limited::LumiSummaryIntAnalyzer",
+                                      concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(nEvt+nStreams*((nEvt/nEvtLumi)+1)+2*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.StreamIntFil = cms.EDFilter("edmtest::limited::StreamIntFilter",
+                                    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(nEvt+nStreams*(2*(nEvt/nEvtRun)+2*(nEvt/nEvtLumi)+2))
+    ,cachevalue = cms.int32(1)
+)
+
+process.RunIntFil = cms.EDFilter("edmtest::limited::RunIntFilter",
+                                 concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvtRun)
+)
+
+process.LumiIntFil = cms.EDFilter("edmtest::limited::LumiIntFilter",
+                                  concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.RunSumIntFil = cms.EDFilter("edmtest::limited::RunSummaryIntFilter",
+                                    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(nEvt+nStreams*((nEvt/nEvtRun)+1)+2*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvtRun)
+)
+
+process.LumiSumIntFil = cms.EDFilter("edmtest::limited::LumiSummaryIntFilter",
+                                     concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(nEvt+nStreams*((nEvt/nEvtLumi)+1)+2*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.TestBeginRunFil = cms.EDFilter("edmtest::limited::TestBeginRunFilter",
+                                       concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32((nEvt/nEvtRun))
+)
+
+process.TestEndRunFil = cms.EDFilter("edmtest::limited::TestEndRunFilter",
+                                     concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32((nEvt/nEvtRun))
+)
+
+process.TestBeginLumiBlockFil = cms.EDFilter("edmtest::limited::TestBeginLumiBlockFilter",
+                                             concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32((nEvt/nEvtLumi))
+)
+
+process.TestEndLumiBlockFil = cms.EDFilter("edmtest::limited::TestEndLumiBlockFilter",
+                                           concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32((nEvt/nEvtLumi))
+)
+
+
+process.p = cms.Path(process.StreamIntProd+process.RunIntProd+process.LumiIntProd+process.RunSumIntProd+process.LumiSumIntProd+process.TestBeginRunProd+process.TestEndRunProd+process.TestBeginLumiBlockProd+process.TestEndLumiBlockProd+process.StreamIntAn+process.RunIntAn+process.LumiIntAn+process.RunSumIntAn+process.LumiSumIntAn+process.StreamIntFil+process.RunIntFil+process.LumiIntFil+process.RunSumIntFil+process.LumiSumIntFil+process.TestBeginRunFil+process.TestEndRunFil+process.TestBeginLumiBlockFil+process.TestEndLumiBlockFil)
+

--- a/FWCore/ParameterSet/interface/ParameterSetDescriptionFillerBase.h
+++ b/FWCore/ParameterSet/interface/ParameterSetDescriptionFillerBase.h
@@ -55,6 +55,13 @@ namespace edm {
     class OutputModuleBase;
    }
 
+   namespace limited {
+      class EDProducerBase;
+      class EDFilterBase;
+      class EDAnalyzerBase;
+      class OutputModuleBase;
+   }
+
 class ParameterSetDescriptionFillerBase
 {
 
@@ -91,6 +98,10 @@ class ParameterSetDescriptionFillerBase
       static const std::string kExtendedBaseForGlobalEDProducer;
       static const std::string kExtendedBaseForGlobalEDFilter;
       static const std::string kExtendedBaseForGlobalOutputModule;
+      static const std::string kExtendedBaseForLimitedEDAnalyzer;
+      static const std::string kExtendedBaseForLimitedEDProducer;
+      static const std::string kExtendedBaseForLimitedEDFilter;
+      static const std::string kExtendedBaseForLimitedOutputModule;
 
       static const std::string& extendedBaseType(EDAnalyzer const*) {
          return kExtendedBaseForEDAnalyzer;
@@ -137,6 +148,18 @@ class ParameterSetDescriptionFillerBase
       static const std::string& extendedBaseType(global::OutputModuleBase const*) {
          return kExtendedBaseForGlobalOutputModule;
       }
+   static const std::string& extendedBaseType(limited::EDAnalyzerBase const*) {
+      return kExtendedBaseForLimitedEDAnalyzer;
+   }
+   static const std::string& extendedBaseType(limited::EDProducerBase const*) {
+      return kExtendedBaseForLimitedEDProducer;
+   }
+   static const std::string& extendedBaseType(limited::EDFilterBase const*) {
+      return kExtendedBaseForLimitedEDFilter;
+   }
+   static const std::string& extendedBaseType(limited::OutputModuleBase const*) {
+      return kExtendedBaseForLimitedOutputModule;
+   }
       static const std::string& extendedBaseType(void const *) {
          return kEmpty;
       }

--- a/FWCore/ParameterSet/interface/ParameterSetDescriptionFillerBase.h
+++ b/FWCore/ParameterSet/interface/ParameterSetDescriptionFillerBase.h
@@ -165,9 +165,9 @@ class ParameterSetDescriptionFillerBase
       }
   
    private:
-      ParameterSetDescriptionFillerBase(const ParameterSetDescriptionFillerBase&); // stop default
+      ParameterSetDescriptionFillerBase(const ParameterSetDescriptionFillerBase&) = delete; // stop default
 
-      const ParameterSetDescriptionFillerBase& operator=(const ParameterSetDescriptionFillerBase&); // stop default
+      const ParameterSetDescriptionFillerBase& operator=(const ParameterSetDescriptionFillerBase&) = delete; // stop default
 
       // ---------- member data --------------------------------
 

--- a/FWCore/ParameterSet/src/ParameterSetDescriptionFillerBase.cc
+++ b/FWCore/ParameterSet/src/ParameterSetDescriptionFillerBase.cc
@@ -38,6 +38,10 @@ const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForGlobal
 const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForGlobalEDProducer("global::EDProducer");
 const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForGlobalEDFilter("global::EDFilter");
 const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForGlobalOutputModule("global::OutputModule");
+const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForLimitedEDAnalyzer("limited::EDAnalyzer");
+const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForLimitedEDProducer("limited::EDProducer");
+const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForLimitedEDFilter("limited::EDFilter");
+const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForLimitedOutputModule("limited::OutputModule");
 
 //
 // static data member definitions

--- a/FWCore/Services/plugins/ConcurrentModuleTimer.cc
+++ b/FWCore/Services/plugins/ConcurrentModuleTimer.cc
@@ -40,7 +40,7 @@ namespace edm {
       std::vector<std::string> m_modulesToExclude;
       std::vector<unsigned int> m_excludedModuleIds;
       std::chrono::high_resolution_clock::time_point m_time;
-      unsigned int m_nTimeSums;
+      unsigned int m_nTimeSums = 0;
       unsigned int m_nModules;
       std::atomic<bool> m_spinLock;
       bool m_startedTiming;


### PR DESCRIPTION
An edm::limited module is similar to an edm::global module (they share the same interface design), however in the edm::limited module's configuration you specify how many concurrent threads are allowed to call the module at any instance in time.