### PR TITLE
Fix QuickTrackAssociatorByHits for composite hits

### DIFF
--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
@@ -191,7 +191,7 @@ reco::RecoToSimCollection QuickTrackAssociatorByHitsImpl::associateRecoToSimImpl
 		{
 			const edm::Ref<TrackingParticleCollection>& trackingParticleRef=iTrackingParticleQualityPair->first;
 			double numberOfSharedHits=iTrackingParticleQualityPair->second;
-			double numberOfValidTrackHits=weightedNumberOfTrackHits(*pTrack);
+			double numberOfValidTrackClusters=weightedNumberOfTrackClusters(pTrack->recHitsBegin(), pTrack->recHitsEnd());
 
 			if( numberOfSharedHits == 0.0 ) continue; // No point in continuing if there was no association
 
@@ -203,7 +203,7 @@ reco::RecoToSimCollection QuickTrackAssociatorByHitsImpl::associateRecoToSimImpl
 
 			double quality;
 			if( absoluteNumberOfHits_ ) quality = numberOfSharedHits;
-			else if( numberOfValidTrackHits != 0.0 ) quality = numberOfSharedHits / numberOfValidTrackHits;
+			else if( numberOfValidTrackClusters != 0.0 ) quality = numberOfSharedHits / numberOfValidTrackClusters;
 			else quality=0;
 			if( quality > cutRecoToSim_ && !(threeHitTracksAreSpecial_ && pTrack->numberOfValidHits() == 3 && numberOfSharedHits < 3.0) )
 			{
@@ -240,7 +240,7 @@ reco::SimToRecoCollection QuickTrackAssociatorByHitsImpl::associateSimToRecoImpl
 		{
 			const edm::Ref<TrackingParticleCollection>& trackingParticleRef=iTrackingParticleQualityPair->first;
 			double numberOfSharedHits=iTrackingParticleQualityPair->second;
-			double numberOfValidTrackHits=weightedNumberOfTrackHits(*pTrack);
+			double numberOfValidTrackClusters=weightedNumberOfTrackClusters(pTrack->recHitsBegin(), pTrack->recHitsEnd());
 			size_t numberOfSimulatedHits=0; // Set a few lines below, but only if required.
 
 			if( numberOfSharedHits==0.0 ) continue; // No point in continuing if there was no association
@@ -260,11 +260,11 @@ reco::SimToRecoCollection QuickTrackAssociatorByHitsImpl::associateSimToRecoImpl
 				numberOfSharedHits -= getDoubleCount( hitOrClusterAssociator, pTrack->recHitsBegin(), pTrack->recHitsEnd(), trackingParticleRef );
 			}
 
-			double purity = numberOfSharedHits/numberOfValidTrackHits;
+			double purity = numberOfSharedHits/numberOfValidTrackClusters;
 			double quality;
 			if( absoluteNumberOfHits_ ) quality = numberOfSharedHits;
 			else if( simToRecoDenominator_==denomsim && numberOfSimulatedHits != 0 ) quality = numberOfSharedHits/static_cast<double>(numberOfSimulatedHits);
-			else if( simToRecoDenominator_==denomreco && numberOfValidTrackHits != 0 ) quality=purity;
+			else if( simToRecoDenominator_==denomreco && numberOfValidTrackClusters != 0 ) quality=purity;
 			else quality=0;
 
 			if( quality>qualitySimToReco_ && !( threeHitTracksAreSpecial_ && numberOfSimulatedHits==3 && numberOfSharedHits<3.0 ) && ( absoluteNumberOfHits_ || (purity>puritySimToReco_) ) )
@@ -610,7 +610,7 @@ reco::RecoToSimCollectionSeed QuickTrackAssociatorByHitsImpl::associateRecoToSim
 		{
 			const edm::Ref<TrackingParticleCollection>& trackingParticleRef=iTrackingParticleQualityPair->first;
 			double numberOfSharedHits=iTrackingParticleQualityPair->second;
-                        double numberOfValidTrackHits=weightedNumberOfTrackHits(*pSeed);
+			double numberOfValidTrackClusters=weightedNumberOfTrackClusters(pSeed->recHits().first, pSeed->recHits().second);
 
 			if( numberOfSharedHits == 0.0 ) continue; // No point in continuing if there was no association
 
@@ -623,7 +623,7 @@ reco::RecoToSimCollectionSeed QuickTrackAssociatorByHitsImpl::associateRecoToSim
 
 			double quality;
 			if( absoluteNumberOfHits_ ) quality = numberOfSharedHits;
-			else if( numberOfValidTrackHits != 0.0 ) quality = numberOfSharedHits / numberOfValidTrackHits;
+			else if( numberOfValidTrackClusters != 0.0 ) quality = numberOfSharedHits / numberOfValidTrackClusters;
 			else quality=0;
 
 			if( quality > cutRecoToSim_ && !(threeHitTracksAreSpecial_ && pSeed->nHits() == 3 && numberOfSharedHits < 3.0) )
@@ -669,7 +669,7 @@ reco::SimToRecoCollectionSeed QuickTrackAssociatorByHitsImpl::associateSimToReco
 		{
 			const edm::Ref<TrackingParticleCollection>& trackingParticleRef=iTrackingParticleQualityPair->first;
 			double numberOfSharedHits=iTrackingParticleQualityPair->second;
-			double numberOfValidTrackHits=weightedNumberOfTrackHits(*pSeed);
+			double numberOfValidTrackClusters=weightedNumberOfTrackClusters(pSeed->recHits().first, pSeed->recHits().second);
 			size_t numberOfSimulatedHits=0; // Set a few lines below, but only if required.
 
 			if( numberOfSharedHits == 0.0 ) continue; // No point in continuing if there was no association
@@ -690,12 +690,12 @@ reco::SimToRecoCollectionSeed QuickTrackAssociatorByHitsImpl::associateSimToReco
 				numberOfSimulatedHits=trackingParticleRef->numberOfTrackerHits();
 			}
 
-			double purity = numberOfSharedHits / numberOfValidTrackHits;
+			double purity = numberOfSharedHits / numberOfValidTrackClusters;
 			double quality;
 			if( absoluteNumberOfHits_ ) quality = numberOfSharedHits;
 			else if( simToRecoDenominator_ == denomsim && numberOfSimulatedHits != 0 ) quality= numberOfSharedHits
 					/ static_cast<double>( numberOfSimulatedHits );
-			else if( simToRecoDenominator_ == denomreco && numberOfValidTrackHits != 0.0 ) quality=purity;
+			else if( simToRecoDenominator_ == denomreco && numberOfValidTrackClusters != 0.0 ) quality=purity;
 			else quality=0;
 
 			if( quality > qualitySimToReco_ && !(threeHitTracksAreSpecial_ && numberOfSimulatedHits == 3 && numberOfSharedHits < 3.0)
@@ -711,19 +711,21 @@ reco::SimToRecoCollectionSeed QuickTrackAssociatorByHitsImpl::associateSimToReco
 	return returnValue;
 }
 
-double QuickTrackAssociatorByHitsImpl::weightedNumberOfTrackHits(const reco::Track& track) const {
-  const reco::HitPattern& p = track.hitPattern();
-  const auto pixelHits = p.numberOfValidPixelHits();
-  const auto otherHits = p.numberOfValidHits() - pixelHits;
-  return pixelHits*pixelHitWeight_ + otherHits;
-}
+template<typename iter> double QuickTrackAssociatorByHitsImpl::weightedNumberOfTrackClusters(iter begin, iter end) const {
+  LogDebug("QuickTrackAssociatorByHitsImpl") << "QuickTrackAssociatorByHitsImpl::weightedNumberOfTrackClusters ";
+  double weightedClusters = 0.0;
+  for (iter iRecHit = begin; iRecHit != end; ++iRecHit) {
 
-double QuickTrackAssociatorByHitsImpl::weightedNumberOfTrackHits(const TrajectorySeed& seed) const {
-  double sum = 0.0;
-  for(auto iHit=seed.recHits().first; iHit!=seed.recHits().second; ++iHit) {
-    const auto subdetId = getHitFromIter(iHit)->geographicalId().subdetId();
+    const auto subdetId = getHitFromIter(iRecHit)->geographicalId().subdetId();
     const double weight = (subdetId == PixelSubdetector::PixelBarrel || subdetId == PixelSubdetector::PixelEndcap) ?  pixelHitWeight_ : 1.0;
-    sum += weight;
+    LogTrace("QuickTrackAssociatorByHitsImpl") << "  detId: " << getHitFromIter(iRecHit)->geographicalId().rawId();
+    LogTrace("QuickTrackAssociatorByHitsImpl") << "  weight: " << weight;
+    std::vector < OmniClusterRef > oClusters=getMatchedClusters( iRecHit, iRecHit + 1 );  //only for the cluster being checked
+    for( std::vector<OmniClusterRef>::const_iterator it=oClusters.begin(); it != oClusters.end(); ++it ) {
+      weightedClusters += weight;
+    }
   }
-  return sum;
+  LogTrace("QuickTrackAssociatorByHitsImpl") << "  total weighted clusters: " << weightedClusters;
+
+  return weightedClusters;
 }

--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
@@ -190,22 +190,22 @@ reco::RecoToSimCollection QuickTrackAssociatorByHitsImpl::associateRecoToSimImpl
 				++iTrackingParticleQualityPair )
 		{
 			const edm::Ref<TrackingParticleCollection>& trackingParticleRef=iTrackingParticleQualityPair->first;
-			double numberOfSharedHits=iTrackingParticleQualityPair->second;
+			double numberOfSharedClusters=iTrackingParticleQualityPair->second;
 			double numberOfValidTrackClusters=weightedNumberOfTrackClusters(pTrack->recHitsBegin(), pTrack->recHitsEnd());
 
-			if( numberOfSharedHits == 0.0 ) continue; // No point in continuing if there was no association
+			if( numberOfSharedClusters == 0.0 ) continue; // No point in continuing if there was no association
 
 			//if electron subtract double counting
 			if( abs( trackingParticleRef->pdgId() ) == 11 && (trackingParticleRef->g4Track_end() - trackingParticleRef->g4Track_begin()) > 1 )
 			{
-				numberOfSharedHits-=getDoubleCount( hitOrClusterAssociator, pTrack->recHitsBegin(), pTrack->recHitsEnd(), trackingParticleRef );
+				numberOfSharedClusters-=getDoubleCount( hitOrClusterAssociator, pTrack->recHitsBegin(), pTrack->recHitsEnd(), trackingParticleRef );
 			}
 
 			double quality;
-			if( absoluteNumberOfHits_ ) quality = numberOfSharedHits;
-			else if( numberOfValidTrackClusters != 0.0 ) quality = numberOfSharedHits / numberOfValidTrackClusters;
+			if( absoluteNumberOfHits_ ) quality = numberOfSharedClusters;
+			else if( numberOfValidTrackClusters != 0.0 ) quality = numberOfSharedClusters / numberOfValidTrackClusters;
 			else quality=0;
-			if( quality > cutRecoToSim_ && !(threeHitTracksAreSpecial_ && pTrack->numberOfValidHits() == 3 && numberOfSharedHits < 3.0) )
+			if( quality > cutRecoToSim_ && !(threeHitTracksAreSpecial_ && pTrack->numberOfValidHits() == 3 && numberOfSharedClusters < 3.0) )
 			{
 				// Getting the RefToBase is dependent on the type of trackCollection, so delegate that to an overload.
 				returnValue.insert( ::getRefToTrackAt(trackCollection,i), std::make_pair( trackingParticleRef, quality ) );
@@ -239,13 +239,13 @@ reco::SimToRecoCollection QuickTrackAssociatorByHitsImpl::associateSimToRecoImpl
 				iTrackingParticleQualityPair!=trackingParticleQualityPairs.end(); ++iTrackingParticleQualityPair )
 		{
 			const edm::Ref<TrackingParticleCollection>& trackingParticleRef=iTrackingParticleQualityPair->first;
-			double numberOfSharedHits=iTrackingParticleQualityPair->second;
+			double numberOfSharedClusters=iTrackingParticleQualityPair->second;
 			double numberOfValidTrackClusters=weightedNumberOfTrackClusters(pTrack->recHitsBegin(), pTrack->recHitsEnd());
 			size_t numberOfSimulatedHits=0; // Set a few lines below, but only if required.
 
-			if( numberOfSharedHits==0.0 ) continue; // No point in continuing if there was no association
+			if( numberOfSharedClusters==0.0 ) continue; // No point in continuing if there was no association
 
-			if( simToRecoDenominator_==denomsim || (numberOfSharedHits<3.0 && threeHitTracksAreSpecial_) ) // the numberOfSimulatedHits is not always required, so can skip counting in some circumstances
+			if( simToRecoDenominator_==denomsim || (numberOfSharedClusters<3.0 && threeHitTracksAreSpecial_) ) // the numberOfSimulatedHits is not always required, so can skip counting in some circumstances
 			{
 				// Note that in the standard TrackAssociatorByHits, all of the hits in associatedTrackingParticleHits are checked for
 				// various things.  I'm not sure what these checks are for but they depend on the UseGrouping and UseSplitting settings.
@@ -257,17 +257,17 @@ reco::SimToRecoCollection QuickTrackAssociatorByHitsImpl::associateSimToRecoImpl
 			//if electron subtract double counting
 			if (abs(trackingParticleRef->pdgId())==11 && (trackingParticleRef->g4Track_end() - trackingParticleRef->g4Track_begin()) > 1 )
 			{
-				numberOfSharedHits -= getDoubleCount( hitOrClusterAssociator, pTrack->recHitsBegin(), pTrack->recHitsEnd(), trackingParticleRef );
+				numberOfSharedClusters -= getDoubleCount( hitOrClusterAssociator, pTrack->recHitsBegin(), pTrack->recHitsEnd(), trackingParticleRef );
 			}
 
-			double purity = numberOfSharedHits/numberOfValidTrackClusters;
+			double purity = numberOfSharedClusters/numberOfValidTrackClusters;
 			double quality;
-			if( absoluteNumberOfHits_ ) quality = numberOfSharedHits;
-			else if( simToRecoDenominator_==denomsim && numberOfSimulatedHits != 0 ) quality = numberOfSharedHits/static_cast<double>(numberOfSimulatedHits);
+			if( absoluteNumberOfHits_ ) quality = numberOfSharedClusters;
+			else if( simToRecoDenominator_==denomsim && numberOfSimulatedHits != 0 ) quality = numberOfSharedClusters/static_cast<double>(numberOfSimulatedHits);
 			else if( simToRecoDenominator_==denomreco && numberOfValidTrackClusters != 0 ) quality=purity;
 			else quality=0;
 
-			if( quality>qualitySimToReco_ && !( threeHitTracksAreSpecial_ && numberOfSimulatedHits==3 && numberOfSharedHits<3.0 ) && ( absoluteNumberOfHits_ || (purity>puritySimToReco_) ) )
+			if( quality>qualitySimToReco_ && !( threeHitTracksAreSpecial_ && numberOfSimulatedHits==3 && numberOfSharedClusters<3.0 ) && ( absoluteNumberOfHits_ || (purity>puritySimToReco_) ) )
 			{
 				// Getting the RefToBase is dependent on the type of trackCollection, so delegate that to an overload.
 				returnValue.insert( trackingParticleRef, std::make_pair( ::getRefToTrackAt(trackCollection,i), quality ) );
@@ -609,24 +609,24 @@ reco::RecoToSimCollectionSeed QuickTrackAssociatorByHitsImpl::associateRecoToSim
 				++iTrackingParticleQualityPair )
 		{
 			const edm::Ref<TrackingParticleCollection>& trackingParticleRef=iTrackingParticleQualityPair->first;
-			double numberOfSharedHits=iTrackingParticleQualityPair->second;
+			double numberOfSharedClusters=iTrackingParticleQualityPair->second;
 			double numberOfValidTrackClusters=weightedNumberOfTrackClusters(pSeed->recHits().first, pSeed->recHits().second);
 
-			if( numberOfSharedHits == 0.0 ) continue; // No point in continuing if there was no association
+			if( numberOfSharedClusters == 0.0 ) continue; // No point in continuing if there was no association
 
 			//if electron subtract double counting
 			if( abs( trackingParticleRef->pdgId() ) == 11 && (trackingParticleRef->g4Track_end() - trackingParticleRef->g4Track_begin()) > 1 )
 			{
-				if( clusterToTPMap_ ) numberOfSharedHits-=getDoubleCount( *clusterToTPMap_, pSeed->recHits().first, pSeed->recHits().second, trackingParticleRef );
-				else numberOfSharedHits-=getDoubleCount( *hitAssociator_, pSeed->recHits().first, pSeed->recHits().second, trackingParticleRef );
+				if( clusterToTPMap_ ) numberOfSharedClusters-=getDoubleCount( *clusterToTPMap_, pSeed->recHits().first, pSeed->recHits().second, trackingParticleRef );
+				else numberOfSharedClusters-=getDoubleCount( *hitAssociator_, pSeed->recHits().first, pSeed->recHits().second, trackingParticleRef );
 			}
 
 			double quality;
-			if( absoluteNumberOfHits_ ) quality = numberOfSharedHits;
-			else if( numberOfValidTrackClusters != 0.0 ) quality = numberOfSharedHits / numberOfValidTrackClusters;
+			if( absoluteNumberOfHits_ ) quality = numberOfSharedClusters;
+			else if( numberOfValidTrackClusters != 0.0 ) quality = numberOfSharedClusters / numberOfValidTrackClusters;
 			else quality=0;
 
-			if( quality > cutRecoToSim_ && !(threeHitTracksAreSpecial_ && pSeed->nHits() == 3 && numberOfSharedHits < 3.0) )
+			if( quality > cutRecoToSim_ && !(threeHitTracksAreSpecial_ && pSeed->nHits() == 3 && numberOfSharedClusters < 3.0) )
 			{
 				returnValue.insert( edm::RefToBase < TrajectorySeed > (pSeedCollectionHandle_, i), std::make_pair( trackingParticleRef, quality ) );
 			}
@@ -668,20 +668,20 @@ reco::SimToRecoCollectionSeed QuickTrackAssociatorByHitsImpl::associateSimToReco
 				++iTrackingParticleQualityPair )
 		{
 			const edm::Ref<TrackingParticleCollection>& trackingParticleRef=iTrackingParticleQualityPair->first;
-			double numberOfSharedHits=iTrackingParticleQualityPair->second;
+			double numberOfSharedClusters=iTrackingParticleQualityPair->second;
 			double numberOfValidTrackClusters=weightedNumberOfTrackClusters(pSeed->recHits().first, pSeed->recHits().second);
 			size_t numberOfSimulatedHits=0; // Set a few lines below, but only if required.
 
-			if( numberOfSharedHits == 0.0 ) continue; // No point in continuing if there was no association
+			if( numberOfSharedClusters == 0.0 ) continue; // No point in continuing if there was no association
 
 			//if electron subtract double counting
 			if( abs( trackingParticleRef->pdgId() ) == 11 && (trackingParticleRef->g4Track_end() - trackingParticleRef->g4Track_begin()) > 1 )
 			{
-				if( clusterToTPMap_ ) numberOfSharedHits-=getDoubleCount( *clusterToTPMap_, pSeed->recHits().first, pSeed->recHits().second, trackingParticleRef );
-				else numberOfSharedHits-=getDoubleCount( *hitAssociator_, pSeed->recHits().first, pSeed->recHits().second, trackingParticleRef );
+				if( clusterToTPMap_ ) numberOfSharedClusters-=getDoubleCount( *clusterToTPMap_, pSeed->recHits().first, pSeed->recHits().second, trackingParticleRef );
+				else numberOfSharedClusters-=getDoubleCount( *hitAssociator_, pSeed->recHits().first, pSeed->recHits().second, trackingParticleRef );
 			}
 
-			if( simToRecoDenominator_ == denomsim || (numberOfSharedHits < 3.0 && threeHitTracksAreSpecial_) ) // the numberOfSimulatedHits is not always required, so can skip counting in some circumstances
+			if( simToRecoDenominator_ == denomsim || (numberOfSharedClusters < 3.0 && threeHitTracksAreSpecial_) ) // the numberOfSimulatedHits is not always required, so can skip counting in some circumstances
 			{
 				// Note that in the standard TrackAssociatorByHits, all of the hits in associatedTrackingParticleHits are checked for
 				// various things.  I'm not sure what these checks are for but they depend on the UseGrouping and UseSplitting settings.
@@ -690,15 +690,15 @@ reco::SimToRecoCollectionSeed QuickTrackAssociatorByHitsImpl::associateSimToReco
 				numberOfSimulatedHits=trackingParticleRef->numberOfTrackerHits();
 			}
 
-			double purity = numberOfSharedHits / numberOfValidTrackClusters;
+			double purity = numberOfSharedClusters / numberOfValidTrackClusters;
 			double quality;
-			if( absoluteNumberOfHits_ ) quality = numberOfSharedHits;
-			else if( simToRecoDenominator_ == denomsim && numberOfSimulatedHits != 0 ) quality= numberOfSharedHits
+			if( absoluteNumberOfHits_ ) quality = numberOfSharedClusters;
+			else if( simToRecoDenominator_ == denomsim && numberOfSimulatedHits != 0 ) quality= numberOfSharedClusters
 					/ static_cast<double>( numberOfSimulatedHits );
 			else if( simToRecoDenominator_ == denomreco && numberOfValidTrackClusters != 0.0 ) quality=purity;
 			else quality=0;
 
-			if( quality > qualitySimToReco_ && !(threeHitTracksAreSpecial_ && numberOfSimulatedHits == 3 && numberOfSharedHits < 3.0)
+			if( quality > qualitySimToReco_ && !(threeHitTracksAreSpecial_ && numberOfSimulatedHits == 3 && numberOfSharedClusters < 3.0)
 					&& (absoluteNumberOfHits_ || (purity > puritySimToReco_)) )
 			{
 				returnValue.insert( trackingParticleRef, std::make_pair( edm::RefToBase < TrajectorySeed > (pSeedCollectionHandle_, i), quality ) );
@@ -712,7 +712,7 @@ reco::SimToRecoCollectionSeed QuickTrackAssociatorByHitsImpl::associateSimToReco
 }
 
 template<typename iter> double QuickTrackAssociatorByHitsImpl::weightedNumberOfTrackClusters(iter begin, iter end) const {
-  LogDebug("QuickTrackAssociatorByHitsImpl") << "QuickTrackAssociatorByHitsImpl::weightedNumberOfTrackClusters ";
+
   double weightedClusters = 0.0;
   for (iter iRecHit = begin; iRecHit != end; ++iRecHit) {
 

--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.h
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.h
@@ -171,8 +171,14 @@ public:
     return &(*iter);
   }
   
-  template<typename iter> double weightedNumberOfTrackClusters(iter begin, iter end) const ;
+  // The last parameter is used to decide whether we cound hits or clusters
+  double weightedNumberOfTrackClusters(const reco::Track& track, const TrackerHitAssociator&) const;
+  double weightedNumberOfTrackClusters(const TrajectorySeed& seed, const TrackerHitAssociator&) const;
+  double weightedNumberOfTrackClusters(const reco::Track& track, const ClusterTPAssociation&) const;
+  double weightedNumberOfTrackClusters(const TrajectorySeed& seed, const ClusterTPAssociation&) const;
 
+  // called only by weightedNumberOfTrackClusters(..., ClusterTPAssociation)
+  template<typename iter> double weightedNumberOfTrackClusters(iter begin, iter end) const ;
 
   /** @brief creates either a ClusterTPAssociation OR a TrackerHitAssociator and stores it in the provided unique_ptr. The other will be null.
    *

--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.h
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.h
@@ -177,8 +177,8 @@ public:
     return &(*iter);
   }
   
-  double weightedNumberOfTrackHits(const reco::Track& track) const;
-  double weightedNumberOfTrackHits(const TrajectorySeed& seed) const;
+  template<typename iter> double weightedNumberOfTrackClusters(iter begin, iter end) const ;
+
 
   /** @brief creates either a ClusterTPAssociation OR a TrackerHitAssociator and stores it in the provided unique_ptr. The other will be null.
    *

--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.h
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.h
@@ -79,26 +79,20 @@ public:
                                  bool threeHitTracksAreSpecial,
                                  SimToRecoDenomType simToRecoDenominator);
   
-  virtual
     reco::RecoToSimCollection associateRecoToSim( const edm::Handle<edm::View<reco::Track> >& trackCollectionHandle,
                                                   const edm::Handle<TrackingParticleCollection>& trackingParticleCollectionHandle) const override;
-  virtual
     reco::SimToRecoCollection associateSimToReco( const edm::Handle<edm::View<reco::Track> >& trackCollectionHandle,
                                                   const edm::Handle<TrackingParticleCollection>& trackingParticleCollectionHandle) const override;
-  virtual
     reco::RecoToSimCollection associateRecoToSim( const edm::RefToBaseVector<reco::Track>& trackCollection,
                                                   const edm::RefVector<TrackingParticleCollection>& trackingParticleCollection) const override;
   
-  virtual
     reco::SimToRecoCollection associateSimToReco( const edm::RefToBaseVector<reco::Track>& trackCollection,
                                                   const edm::RefVector<TrackingParticleCollection>& trackingParticleCollection) const override;
   
   //seed
-  virtual
     reco::RecoToSimCollectionSeed associateRecoToSim(const edm::Handle<edm::View<TrajectorySeed> >&,
                                                      const edm::Handle<TrackingParticleCollection>&) const override;
   
-  virtual
     reco::SimToRecoCollectionSeed associateSimToReco(const edm::Handle<edm::View<TrajectorySeed> >&,
                                                      const edm::Handle<TrackingParticleCollection>&) const override;
   


### PR DESCRIPTION
This PR fixes a long-standing bug in QuickTrackAssociatorByHits regarding composite hits (=hits having >= 2 clusters). Currently the "matched hit fraction" is in fact calculated as
```
N(clusters of track matched to a TrackingParticle)
--------------------------------------------------
                N(hits of track)
```
so hits with 2 cluster are ounted as 2 in the numerator and 1 in denominator. The bug does not affect the offline track monitoring as in offline the strip matched hits are split in the final fit. The affected cases are
- HLT track monitoring (strip matched hits are not split)
- Strip seed monitoring (strip matched hits are not split)
- VectorHits when they get integrated (in fact this was the context that revealed the bug)

The fix is to change the denominator to `N(clusters of track)` so one could say that the association is now actually done "by clusters". Note that this is done only for `ClusterTPAssociation` mode, the `TrackerHitAssociator` mode is kept in counting hits.

Here are MTV plots for phase1
https://cms-tracking-validation.web.cern.ch/cms-tracking-validation/PR/CMSSW_9_3_0_pre3_PR20364/
showing no effect for tracks
https://cms-tracking-validation.web.cern.ch/cms-tracking-validation/PR/CMSSW_9_3_0_pre3_PR20364/phase1_ttbar_pu35_summary/summary.pdf
and decrease in efficiency of seeds with strip hits
https://cms-tracking-validation.web.cern.ch/cms-tracking-validation/PR/CMSSW_9_3_0_pre3_PR20364/phase1_ttbar_pu35_seeding_summary_seeds/summary.pdf

Plots for HLT (thanks to @JanFSchulte) can be found from
https://cms-tracking-validation.web.cern.ch/cms-tracking-validation/PR/CMSSW_9_3_0_pre3_PR20364_HLT/
showing decrease in efficiency (especially in |eta| > 1) and increase in fake rates.

Tested in 9_3_0_pre3, expecting no changes in offline track plots, and decrease in efficiency and increase in fake rates for HLT track plots.

@rovere @VinInn @ebrondol @JanFSchulte @mtosi @slava77 @perrotta 