### PR TITLE
Small miniAOD improvements

### DIFF
--- a/DataFormats/PatCandidates/interface/Electron.h
+++ b/DataFormats/PatCandidates/interface/Electron.h
@@ -203,7 +203,7 @@ namespace pat {
       reco::CandidatePtr sourceCandidatePtr( size_type i ) const;
 
       // ---- embed various impact parameters with errors ----
-      typedef enum IPTYPE { PV2D = 0, PV3D = 1, BS2D = 2, BS3D = 3, IpTypeSize = 4 } IpType;
+      typedef enum IPTYPE { PV2D = 0, PV3D = 1, BS2D = 2, BS3D = 3, PVDZ = 4, IpTypeSize = 5 } IpType;
       /// Impact parameter wrt primary vertex or beamspot
       double dB(IPTYPE type) const;
       /// Uncertainty on the corresponding impact parameter

--- a/DataFormats/PatCandidates/interface/Electron.h
+++ b/DataFormats/PatCandidates/interface/Electron.h
@@ -64,22 +64,22 @@ namespace pat {
       /// constructor from a Ptr to a reco::GsfElectron
       Electron(const edm::Ptr<reco::GsfElectron> & anElectronRef);
       /// destructor
-      virtual ~Electron();
+      ~Electron() override;
 
       /// required reimplementation of the Candidate's clone method
-      virtual Electron * clone() const { return new Electron(*this); }
+      Electron * clone() const override { return new Electron(*this); }
 
       // ---- methods for content embedding ----
       /// override the virtual reco::GsfElectron::core method, so that the embedded core can be used by GsfElectron client methods
-      virtual reco::GsfElectronCoreRef core() const;
+      reco::GsfElectronCoreRef core() const override;
       /// override the reco::GsfElectron::gsfTrack method, to access the internal storage of the supercluster
-      reco::GsfTrackRef gsfTrack() const;
+      reco::GsfTrackRef gsfTrack() const override;
       /// override the reco::GsfElectron::superCluster method, to access the internal storage of the supercluster
-      reco::SuperClusterRef superCluster() const;
+      reco::SuperClusterRef superCluster() const override;
       /// override the reco::GsfElectron::pflowSuperCluster method, to access the internal storage of the pflowSuperCluster
       reco::SuperClusterRef parentSuperCluster() const;
       /// returns nothing. Use either gsfTrack or closestCtfTrack
-      reco::TrackRef track() const;
+      reco::TrackRef track() const override;
       /// override the reco::GsfElectron::closestCtfTrackRef method, to access the internal storage of the track
       reco::TrackRef closestCtfTrackRef() const;
       /// direct access to the seed cluster
@@ -196,11 +196,11 @@ namespace pat {
       /// embed the PFCandidate pointed to by pfCandidateRef_
       void embedPFCandidate();
       /// get the number of non-null PFCandidates
-      size_t numberOfSourceCandidatePtrs() const {
+      size_t numberOfSourceCandidatePtrs() const override {
         return (pfCandidateRef_.isNonnull() ? 1 : 0) + associatedPackedFCandidateIndices_.size();
       }
       /// get the source candidate pointer with index i
-      reco::CandidatePtr sourceCandidatePtr( size_type i ) const;
+      reco::CandidatePtr sourceCandidatePtr( size_type i ) const override;
 
       // ---- embed various impact parameters with errors ----
       typedef enum IPTYPE { PV2D = 0, PV3D = 1, BS2D = 2, BS3D = 3, PVDZ = 4, IpTypeSize = 5 } IpType;

--- a/DataFormats/PatCandidates/interface/Lepton.h
+++ b/DataFormats/PatCandidates/interface/Lepton.h
@@ -193,7 +193,7 @@ namespace pat {
       void hcalIsoDeposit(const IsoDeposit &dep)  { setIsoDeposit(pat::HcalIso, dep); }
       void userIsoDeposit(const IsoDeposit &dep, uint8_t index=0) { setIsoDeposit(IsolationKeys(UserBaseIso + index), dep); }
 
-      const PFIsolation& miniPFIsolation() { return miniPFIsolation_; }
+      const PFIsolation& miniPFIsolation() const { return miniPFIsolation_; }
       void setMiniPFIsolation(PFIsolation const& iso)  { miniPFIsolation_ = iso; }
 
     protected:

--- a/DataFormats/PatCandidates/interface/Lepton.h
+++ b/DataFormats/PatCandidates/interface/Lepton.h
@@ -36,9 +36,9 @@ namespace pat {
       Lepton(const LeptonType & aLepton);
       Lepton(const edm::RefToBase<LeptonType> & aLeptonRef);
       Lepton(const edm::Ptr<LeptonType> & aLeptonRef);
-      virtual ~Lepton();
+      ~Lepton() override;
 
-      virtual Lepton<LeptonType> * clone() const { return new Lepton<LeptonType>(*this); }
+      Lepton<LeptonType> * clone() const override { return new Lepton<LeptonType>(*this); }
 
       const reco::GenParticle * genLepton() const { return PATObject<LeptonType>::genParticle(); }
 
@@ -169,7 +169,7 @@ namespace pat {
           {
               if (it->first == key) return & it->second;
           }
-          return 0;
+          return nullptr;
       } 
 
       /// Sets the IsoDeposit associated with some key; if it is already existent, it is overwritten.

--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -229,7 +229,7 @@ namespace pat {
 	// IpType defines the type of the impact parameter
 	typedef enum IPTYPE 
 	  {
-	    PV2D = 0, PV3D = 1, BS2D = 2, BS3D = 3, IpTypeSize = 4
+	    PV2D = 0, PV3D = 1, BS2D = 2, BS3D = 3, PVDZ = 4, IpTypeSize = 5
 	  } IpType; 
 	void initImpactParameters(void); // init IP defaults in a constructor
 	double dB(IPTYPE type) const;

--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -59,31 +59,31 @@ namespace pat {
       /// constructor from a Ptr to a reco muon
       Muon(const edm::Ptr<reco::Muon> & aMuonRef);
       /// destructor
-      virtual ~Muon();
+      ~Muon() override;
 
       /// required reimplementation of the Candidate's clone method
-      virtual Muon * clone() const { return new Muon(*this); }
+      Muon * clone() const override { return new Muon(*this); }
 
       // ---- methods for content embedding ----
       /// reference to Track reconstructed in the tracker only (reimplemented from reco::Muon)
-      reco::TrackRef track() const;
+      reco::TrackRef track() const override;
       using reco::RecoCandidate::track; // avoid hiding the base implementation
       /// reference to Track reconstructed in the tracker only (reimplemented from reco::Muon)
-      reco::TrackRef innerTrack() const { return track(); }
+      reco::TrackRef innerTrack() const override { return track(); }
       /// reference to Track reconstructed in the muon detector only (reimplemented from reco::Muon)
-      reco::TrackRef standAloneMuon() const;
+      reco::TrackRef standAloneMuon() const override;
       /// reference to Track reconstructed in the muon detector only (reimplemented from reco::Muon)
-      reco::TrackRef outerTrack() const { return standAloneMuon(); }
+      reco::TrackRef outerTrack() const override { return standAloneMuon(); }
       /// reference to Track reconstructed in both tracked and muon detector (reimplemented from reco::Muon)
-      reco::TrackRef combinedMuon() const;
+      reco::TrackRef combinedMuon() const override;
       /// reference to Track reconstructed in both tracked and muon detector (reimplemented from reco::Muon)
-      reco::TrackRef globalTrack() const { return combinedMuon(); }
+      reco::TrackRef globalTrack() const override { return combinedMuon(); }
       /// Track selected to be the best measurement of the muon parameters (including PFlow global information)
-      const reco::Track * bestTrack() const { return muonBestTrack().get(); }
+      const reco::Track * bestTrack() const override { return muonBestTrack().get(); }
       /// Track selected to be the best measurement of the muon parameters (including PFlow global information)
-      reco::TrackRef      muonBestTrack() const ; 
+      reco::TrackRef      muonBestTrack() const override ; 
       /// Track selected to be the best measurement of the muon parameters (from muon information alone)
-      virtual reco::TrackRef tunePMuonBestTrack() const ;
+      reco::TrackRef tunePMuonBestTrack() const override ;
 
       /// set reference to Track selected to be the best measurement of the muon parameters (reimplemented from reco::Muon)
       /// if force == false, do not embed this track if it's embedded already (e.g. ig it's a tracker track, and that's already embedded)
@@ -109,11 +109,11 @@ namespace pat {
       // ---- methods for TeV refit tracks ----
     
       /// reference to Track reconstructed using hits in the tracker + "good" muon hits (reimplemented from reco::Muon)
-      reco::TrackRef pickyTrack() const;
+      reco::TrackRef pickyTrack() const override;
       /// reference to Track reconstructed using hits in the tracker + info from the first muon station that has hits (reimplemented from reco::Muon)
-      reco::TrackRef tpfmsTrack() const;
+      reco::TrackRef tpfmsTrack() const override;
       /// reference to Track reconstructed using DYT algorithm
-      reco::TrackRef dytTrack() const;
+      reco::TrackRef dytTrack() const override;
       /// Deprecated accessors to call the corresponding above two functions; no dytMuon since this naming is deprecated.
       reco::TrackRef pickyMuon() const { return pickyTrack(); } // JMTBAD gcc deprecated attribute?
       reco::TrackRef tpfmsMuon() const { return tpfmsTrack(); } // JMTBAD gcc deprecated attribute?
@@ -135,14 +135,14 @@ namespace pat {
       /// embed the IsolatedPFCandidate pointed to by pfCandidateRef_
       void embedPFCandidate();
       /// get the number of non-null PF candidates
-      size_t numberOfSourceCandidatePtrs() const { 
+      size_t numberOfSourceCandidatePtrs() const override { 
 	size_t res=0;
         if(pfCandidateRef_.isNonnull()) res++;
         if(refToOrig_.isNonnull()) res++;
 	return res;
       }
       /// get the candidate pointer with index i
-      reco::CandidatePtr sourceCandidatePtr( size_type i ) const;
+      reco::CandidatePtr sourceCandidatePtr( size_type i ) const override;
 
       // ---- methods for accessing muon identification ----
       /// accessor for the various muon id algorithms currently defined

--- a/DataFormats/PatCandidates/interface/libminifloat.h
+++ b/DataFormats/PatCandidates/interface/libminifloat.h
@@ -2,6 +2,8 @@
 #define libminifloat_h
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include <cstdint>
+#include <cassert>
+#include <algorithm>
 
 // ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf
 class MiniFloatConverter {
@@ -75,6 +77,44 @@ class MiniFloatConverter {
             }
             return conv.flt;
         }
+
+        class ReduceMantissaToNbitsRounding {
+            public:
+                ReduceMantissaToNbitsRounding(int bits) : 
+                    shift(23-bits), mask((0xFFFFFFFF >> (shift)) << (shift)), 
+                    test(1 << (shift-1)), maxn((1<<bits)-2) {
+                        assert(bits <= 23); // "max mantissa size is 23 bits"
+                    }
+                float operator()(float f) const {
+                    constexpr uint32_t low23 = (0x007FFFFF); // mask to keep lowest 23 bits = mantissa
+                    constexpr uint32_t  hi9  = (0xFF800000); // mask to keep highest 9 bits = the rest
+                    union { float flt; uint32_t i32; } conv;
+                    conv.flt=f;
+                    if (conv.i32 & test) { // need to round
+                        uint32_t mantissa = (conv.i32 & low23) >> shift;
+                        if (mantissa < maxn) mantissa++;
+                        conv.i32 = (conv.i32 & hi9) | (mantissa << shift);
+                    } else {
+                        conv.i32 &= mask;
+                    }
+                    return conv.flt;
+                }
+            private:
+                const int shift;
+                const uint32_t mask, test, maxn;           
+        };
+
+        inline static float reduceMantissaToNbitsRounding(float f, int bits) 
+        {
+            return ReduceMantissaToNbitsRounding(bits)(f);
+        }
+
+        template<typename InItr, typename OutItr>
+        static void reduceMantissaToNbitsRounding(int bits, InItr begin, InItr end, OutItr out) 
+        {
+            std::transform(begin, end, out, ReduceMantissaToNbitsRounding(bits));
+        }
+        
 
         inline static float max() {
             union { float flt; uint32_t i32; } conv;

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -16,7 +16,8 @@
   <class name="pat::Lepton<reco::BaseTau>" />
 
   <!-- PAT Objects, and embedded data  -->
-  <class name="pat::Electron"  ClassVersion="36">
+  <class name="pat::Electron"  ClassVersion="37">
+   <version ClassVersion="37" checksum="4284869321"/>
    <version ClassVersion="36" checksum="199321903"/>
    <version ClassVersion="35" checksum="482655666"/>
    <version ClassVersion="34" checksum="3720919820"/>
@@ -59,7 +60,8 @@
   </ioread>
 
 
-  <class name="pat::Muon"  ClassVersion="21">
+  <class name="pat::Muon"  ClassVersion="22">
+   <version ClassVersion="22" checksum="1816533594"/>
    <version ClassVersion="21" checksum="1539691612"/>
    <version ClassVersion="20" checksum="357097717"/>
    <version ClassVersion="19" checksum="2754486523"/>

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -1174,6 +1174,9 @@ void PATElectronProducer::embedHighLevel( pat::Electron & anElectron,
   d0_corr = result.second.value();
   d0_err = beamspotIsValid ? result.second.error() : -1.0;
   anElectron.setDB( d0_corr, d0_err, pat::Electron::BS3D);
+
+    // PVDZ
+  anElectron.setDB( track->dz(primaryVertex.position()), track->dzError(), pat::Electron::PVDZ );
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -396,7 +396,7 @@ void PATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
 	  // embed high level selection
 	  if ( embedHighLevelSelection_ ) {
 	    // get the global track
-	    reco::GsfTrackRef track = PfTk;
+	    const reco::GsfTrackRef& track = PfTk;
 
 	    // Make sure the collection it points to is there
 	    if ( track.isNonnull() && track.isAvailable() ) {

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -1176,7 +1176,7 @@ void PATElectronProducer::embedHighLevel( pat::Electron & anElectron,
   anElectron.setDB( d0_corr, d0_err, pat::Electron::BS3D);
 
     // PVDZ
-  anElectron.setDB( track->dz(primaryVertex.position()), track->dzError(), pat::Electron::PVDZ );
+  anElectron.setDB( track->dz(primaryVertex.position()), std::hypot(track->dzError(), primaryVertex.zError()), pat::Electron::PVDZ );
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -701,6 +701,10 @@ void PATMuonProducer::embedHighLevel( pat::Muon & aMuon,
   d0_corr = result.second.value();
   d0_err = beamspotIsValid ? result.second.error() : -1.0;
   aMuon.setDB( d0_corr, d0_err, pat::Muon::BS3D);
+
+
+    // PVDZ
+  aMuon.setDB( track->dz(primaryVertex.position()), track->dzError(), pat::Muon::PVDZ );
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -704,7 +704,7 @@ void PATMuonProducer::embedHighLevel( pat::Muon & aMuon,
 
 
     // PVDZ
-  aMuon.setDB( track->dz(primaryVertex.position()), track->dzError(), pat::Muon::PVDZ );
+  aMuon.setDB( track->dz(primaryVertex.position()), std::hypot(track->dzError(), primaryVertex.zError()), pat::Muon::PVDZ );
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"


### PR DESCRIPTION
 * add a missing `const` in the miniPFIsolation method declaration
 * save dz(PV) into the pat Electron & Muon for convenience of applying it downstream without a PV object, e.g. via string-based selectors (we already do that dxy(PV) and ip3d(PV))
 * add non-templated reduceMantissaToNbits methods with rounding

will push the code-checks to this branch later (to not obscure the content of the PR)

@arizzi @peruzzim @emanueledimarco 

