### PR TITLE
Add the HGCAL-Seeded ElectronSeed collection to the FEVT and RECO event contents.

### DIFF
--- a/TrackingTools/Configuration/python/TrackingTools_EventContent_cff.py
+++ b/TrackingTools/Configuration/python/TrackingTools_EventContent_cff.py
@@ -4,7 +4,6 @@ TrackingToolsFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring('keep *_CkfElectronCandidates_*_*', 
         'keep *_GsfGlobalElectronTest_*_*',
         'keep *_electronMergedSeeds_*_*',
-        'keep *_electronMergedSeedsFromMultiCl_*_*',
         'keep *_electronGsfTracks_*_*'
         )
 )
@@ -32,7 +31,7 @@ TrackingToolsAOD = cms.PSet(
     outputCommands = cms.untracked.vstring('keep recoTracks_GsfGlobalElectronTest_*_*',
         'keep recoGsfTracks_electronGsfTracks_*_*'
                                          
-                                           )
+    )
 )
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal

--- a/TrackingTools/Configuration/python/TrackingTools_EventContent_cff.py
+++ b/TrackingTools/Configuration/python/TrackingTools_EventContent_cff.py
@@ -4,7 +4,6 @@ TrackingToolsFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring('keep *_CkfElectronCandidates_*_*', 
         'keep *_GsfGlobalElectronTest_*_*',
         'keep *_electronMergedSeeds_*_*',
-        'keep *_electronMergedSeedsFromMultiCl_*_*',
         'keep *_electronGsfTracks_*_*'
         )
 )
@@ -13,7 +12,6 @@ TrackingToolsRECO = cms.PSet(
     outputCommands = cms.untracked.vstring('keep *_CkfElectronCandidates_*_*', 
         'keep *_GsfGlobalElectronTest_*_*',
         'keep *_electronMergedSeeds_*_*',
-        'keep *_electronMergedSeedsFromMultiCl_*_*',
         'keep recoGsfTracks_electronGsfTracks_*_*', 
         'keep recoGsfTrackExtras_electronGsfTracks_*_*', 
         'keep recoTrackExtras_electronGsfTracks_*_*', 

--- a/TrackingTools/Configuration/python/TrackingTools_EventContent_cff.py
+++ b/TrackingTools/Configuration/python/TrackingTools_EventContent_cff.py
@@ -13,7 +13,6 @@ TrackingToolsRECO = cms.PSet(
     outputCommands = cms.untracked.vstring('keep *_CkfElectronCandidates_*_*', 
         'keep *_GsfGlobalElectronTest_*_*',
         'keep *_electronMergedSeeds_*_*',
-        'keep *_electronMergedSeedsFromMultiCl_*_*',
         'keep recoGsfTracks_electronGsfTracks_*_*', 
         'keep recoGsfTrackExtras_electronGsfTracks_*_*', 
         'keep recoTrackExtras_electronGsfTracks_*_*', 
@@ -21,10 +20,11 @@ TrackingToolsRECO = cms.PSet(
 )
 
 _phase2_hgcal_TrackingRECO_tokeep = [
-         'keep recoGsfTracks_electronGsfTracksFromMultiCl_*_*',
+        'keep recoGsfTracks_electronGsfTracksFromMultiCl_*_*',
         'keep recoGsfTrackExtras_electronGsfTracksFromMultiCl_*_*',
         'keep recoTrackExtras_electronGsfTracksFromMultiCl_*_*',
-        'keep TrackingRecHitsOwned_electronGsfTracksFromMultiCl_*_*'
+        'keep TrackingRecHitsOwned_electronGsfTracksFromMultiCl_*_*',
+        'keep *_electronMergedSeedsFromMultiCl_*_*'
 ]
 
 #AOD content

--- a/TrackingTools/Configuration/python/TrackingTools_EventContent_cff.py
+++ b/TrackingTools/Configuration/python/TrackingTools_EventContent_cff.py
@@ -4,6 +4,7 @@ TrackingToolsFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring('keep *_CkfElectronCandidates_*_*', 
         'keep *_GsfGlobalElectronTest_*_*',
         'keep *_electronMergedSeeds_*_*',
+        'keep *_electronMergedSeedsFromMultiCl_*_*',
         'keep *_electronGsfTracks_*_*'
         )
 )
@@ -12,6 +13,7 @@ TrackingToolsRECO = cms.PSet(
     outputCommands = cms.untracked.vstring('keep *_CkfElectronCandidates_*_*', 
         'keep *_GsfGlobalElectronTest_*_*',
         'keep *_electronMergedSeeds_*_*',
+        'keep *_electronMergedSeedsFromMultiCl_*_*',
         'keep recoGsfTracks_electronGsfTracks_*_*', 
         'keep recoGsfTrackExtras_electronGsfTracks_*_*', 
         'keep recoTrackExtras_electronGsfTracks_*_*', 


### PR DESCRIPTION
Fix for the missing electronMergedSeedsFromMultiCl collection in the RECO and FEVT event content.
This collection contains the track seeds for the HGCAL-seeds electrons and is needed to run the electron MC validation.
The size is of the "new" collection is about 2901 bytes/event vs 4490 for the default seed collection (determined in ZEE events w/o PU). 

@rovere @beaudett