### PR TITLE
TriggerBxMonitor: add support for 2D plots

### DIFF
--- a/DQM/HLTEvF/plugins/TriggerBxMonitor.cc
+++ b/DQM/HLTEvF/plugins/TriggerBxMonitor.cc
@@ -93,6 +93,9 @@ private:
   const edm::EDGetTokenT<GlobalAlgBlkBxCollection>  m_l1t_results;
   const edm::EDGetTokenT<edm::TriggerResults>       m_hlt_results;
   const std::string                                 m_dqm_path;
+  const bool                                        m_make_1d_plots;
+  const bool                                        m_make_2d_plots;
+  const uint32_t                                    m_ls_range;
 
   // L1T and HLT configuration
   L1TUtmTriggerMenu const * m_l1tMenu;
@@ -105,6 +108,9 @@ private:
   std::vector<TH1F *>       m_tcds_bx;
   std::vector<TH1F *>       m_l1t_bx;
   std::vector<TH1F *>       m_hlt_bx;
+  std::vector<TH2F *>       m_tcds_bx_2d;
+  std::vector<TH2F *>       m_l1t_bx_2d;
+  std::vector<TH2F *>       m_hlt_bx_2d;
 };
 
 // definition
@@ -117,6 +123,9 @@ void TriggerBxMonitor::fillDescriptions(edm::ConfigurationDescriptions & descrip
   desc.addUntracked<edm::InputTag>( "l1tResults", edm::InputTag("gtStage2Digis"));
   desc.addUntracked<edm::InputTag>( "hltResults", edm::InputTag("TriggerResults"));
   desc.addUntracked<std::string>(   "dqmPath",    "HLT/TriggerBx" );
+  desc.addUntracked<bool>(          "make1DPlots", true);
+  desc.addUntracked<bool>(          "make2DPlots", false);
+  desc.addUntracked<uint32_t>(      "lsRange",     4000);
   descriptions.add("triggerBxMonitor", desc);
 }
 
@@ -126,6 +135,9 @@ TriggerBxMonitor::TriggerBxMonitor(edm::ParameterSet const & config) :
   m_l1t_results( consumes<GlobalAlgBlkBxCollection>( config.getUntrackedParameter<edm::InputTag>( "l1tResults" ) ) ),
   m_hlt_results( consumes<edm::TriggerResults>(      config.getUntrackedParameter<edm::InputTag>( "hltResults" ) ) ),
   m_dqm_path(                                        config.getUntrackedParameter<std::string>(   "dqmPath" ) ),
+  m_make_1d_plots(                                   config.getUntrackedParameter<bool>(          "make1DPlots" ) ),
+  m_make_2d_plots(                                   config.getUntrackedParameter<bool>(          "make2DPlots" ) ),
+  m_ls_range(                                        config.getUntrackedParameter<uint32_t>(      "lsRange" ) ),
   // L1T and HLT configuration
   m_l1tMenu(nullptr),
   m_hltConfig(),
@@ -135,7 +147,10 @@ TriggerBxMonitor::TriggerBxMonitor(edm::ParameterSet const & config) :
   m_hlt_bx_all(nullptr),
   m_tcds_bx(),
   m_l1t_bx(),
-  m_hlt_bx()
+  m_hlt_bx(),
+  m_tcds_bx_2d(),
+  m_l1t_bx_2d(),
+  m_hlt_bx_2d()
 {
 }
 
@@ -146,14 +161,26 @@ TriggerBxMonitor::~TriggerBxMonitor()
 void TriggerBxMonitor::dqmBeginRun(edm::Run const & run, edm::EventSetup const & setup)
 {
   // initialise the TCDS vector
-  m_tcds_bx.clear();
-  m_tcds_bx.resize(sizeof(s_tcds_trigger_types) / sizeof(const char *), nullptr);
+  if (m_make_1d_plots) {
+    m_tcds_bx.clear();
+    m_tcds_bx.resize(sizeof(s_tcds_trigger_types) / sizeof(const char *), nullptr);
+  }
+  if (m_make_2d_plots) {
+    m_tcds_bx_2d.clear();
+    m_tcds_bx_2d.resize(sizeof(s_tcds_trigger_types) / sizeof(const char *), nullptr);
+  }
 
   // cache the L1 trigger menu
   m_l1tMenu = & get<L1TUtmTriggerMenuRcd, L1TUtmTriggerMenu>(setup);
   if (m_l1tMenu) {
-    m_l1t_bx.clear();
-    m_l1t_bx.resize(GlobalAlgBlk::maxPhysicsTriggers, nullptr);
+    if (m_make_1d_plots) {
+      m_l1t_bx.clear();
+      m_l1t_bx.resize(GlobalAlgBlk::maxPhysicsTriggers, nullptr);
+    }
+    if (m_make_2d_plots) {
+      m_l1t_bx_2d.clear();
+      m_l1t_bx_2d.resize(GlobalAlgBlk::maxPhysicsTriggers, nullptr);
+    }
   } else {
     edm::LogError("TriggerBxMonitor") << "failed to read the L1 menu from the EventSetup, the L1 trigger bx distribution will not be monitored";
   }
@@ -163,8 +190,14 @@ void TriggerBxMonitor::dqmBeginRun(edm::Run const & run, edm::EventSetup const &
   edm::EDConsumerBase::Labels labels;
   labelsForToken(m_hlt_results, labels);
   if (m_hltConfig.init(run, setup, labels.process, changed)) {
-    m_hlt_bx.clear();
-    m_hlt_bx.resize( m_hltConfig.size(), nullptr );
+    if (m_make_1d_plots) {
+      m_hlt_bx.clear();
+      m_hlt_bx.resize( m_hltConfig.size(), nullptr );
+    }
+    if (m_make_2d_plots) {
+      m_hlt_bx_2d.clear();
+      m_hlt_bx_2d.resize( m_hltConfig.size(), nullptr );
+    }
   } else {
     // HLTConfigProvider not initialised, skip the the HLT monitoring
     edm::LogError("TriggerBxMonitor") << "failed to initialise HLTConfigProvider, the HLT bx distribution will not be monitored";
@@ -185,7 +218,13 @@ void TriggerBxMonitor::bookHistograms(DQMStore::IBooker & booker, edm::Run const
     booker.setCurrentFolder( m_dqm_path + "/TCDS" );
     for (unsigned int i = 0; i < size; ++i) {
       if (s_tcds_trigger_types[i]) {
-        m_tcds_bx.at(i) = booker.book1D(s_tcds_trigger_types[i], s_tcds_trigger_types[i], s_bx_range + 1, -0.5, s_bx_range + 0.5)->getTH1F();
+        if (m_make_1d_plots) {
+          m_tcds_bx.at(i) = booker.book1D(s_tcds_trigger_types[i], s_tcds_trigger_types[i], s_bx_range + 1, -0.5, s_bx_range + 0.5)->getTH1F();
+        }
+        if (m_make_2d_plots) {
+          std::string const & name_ls = std::string(s_tcds_trigger_types[i]) + " vs LS";
+          m_tcds_bx_2d.at(i) = booker.book2D(name_ls, name_ls, s_bx_range + 1, -0.5, s_bx_range + 0.5, m_ls_range, 0.5, m_ls_range + 0.5)->getTH2F();
+        }
         m_tcds_bx_all->GetYaxis()->SetBinLabel(i+1, s_tcds_trigger_types[i]);
       }
     }
@@ -195,14 +234,20 @@ void TriggerBxMonitor::bookHistograms(DQMStore::IBooker & booker, edm::Run const
   if (m_l1tMenu) {
     // book 2D histogram to monitor all L1 triggers in a single plot
     booker.setCurrentFolder( m_dqm_path );
-    m_l1t_bx_all = booker.book2D("Level 1 Triggers", "Level 1 Triggers vs. bunch crossing", s_bx_range + 1, -0.5, s_bx_range + 0.5, m_l1t_bx.size(), -0.5, m_l1t_bx.size() - 0.5)->getTH2F();
+    m_l1t_bx_all = booker.book2D("Level 1 Triggers", "Level 1 Triggers vs. bunch crossing", s_bx_range + 1, -0.5, s_bx_range + 0.5, GlobalAlgBlk::maxPhysicsTriggers, -0.5, GlobalAlgBlk::maxPhysicsTriggers - 0.5)->getTH2F();
 
     // book the individual histograms for the L1 triggers that are included in the L1 menu
     booker.setCurrentFolder( m_dqm_path + "/L1T" );
     for (auto const & keyval: m_l1tMenu->getAlgorithmMap()) {
       unsigned int bit = keyval.second.getIndex();
       std::string const & name = (boost::format("%s (bit %d)") % keyval.first % bit).str();
-      m_l1t_bx.at(bit) = booker.book1D(name, name, s_bx_range + 1, -0.5, s_bx_range + 0.5)->getTH1F();
+      if (m_make_1d_plots) {
+        m_l1t_bx.at(bit) = booker.book1D(name, name, s_bx_range + 1, -0.5, s_bx_range + 0.5)->getTH1F();
+      }
+      if (m_make_2d_plots) {
+        std::string const & name_ls = name + " vs LS";
+        m_l1t_bx_2d.at(bit) = booker.book2D(name_ls, name_ls, s_bx_range + 1, -0.5, s_bx_range + 0.5, m_ls_range, 0.5, m_ls_range + 0.5)->getTH2F();
+      }
       m_l1t_bx_all->GetYaxis()->SetBinLabel(bit+1, keyval.first.c_str());
     }
   }
@@ -217,7 +262,13 @@ void TriggerBxMonitor::bookHistograms(DQMStore::IBooker & booker, edm::Run const
     booker.setCurrentFolder( m_dqm_path + "/HLT" );
     for (unsigned int i = 0; i < m_hltConfig.size(); ++i) {
       std::string const & name = m_hltConfig.triggerName(i);
-      m_hlt_bx[i] = booker.book1D(name, name, s_bx_range + 1, -0.5, s_bx_range + 0.5)->getTH1F();
+      if (m_make_1d_plots) {
+        m_hlt_bx[i] = booker.book1D(name, name, s_bx_range + 1, -0.5, s_bx_range + 0.5)->getTH1F();
+      }
+      if (m_make_2d_plots) {
+        std::string const & name_ls = name + " vs LS";
+        m_hlt_bx_2d[i] = booker.book2D(name_ls, name_ls, s_bx_range + 1, -0.5, s_bx_range + 0.5, m_ls_range, 0.5, m_ls_range + 0.5)->getTH2F();
+      }
       m_hlt_bx_all->GetYaxis()->SetBinLabel(i+1, name.c_str());
     }
   }
@@ -227,13 +278,18 @@ void TriggerBxMonitor::bookHistograms(DQMStore::IBooker & booker, edm::Run const
 void TriggerBxMonitor::analyze(edm::Event const & event, edm::EventSetup const & setup)
 {
   unsigned int bx = event.bunchCrossing();
+  unsigned int ls = event.luminosityBlock();
 
   // monitor the bx distribution for the TCDS trigger types
   {
     size_t size = sizeof(s_tcds_trigger_types) / sizeof(const char *);
     unsigned int type = event.experimentType();
-    if (type < size and m_tcds_bx[type])
-      m_tcds_bx[type]->Fill(bx);
+    if (type < size) {
+      if (m_make_1d_plots and m_tcds_bx.at(type))
+        m_tcds_bx[type]->Fill(bx);
+      if (m_make_2d_plots and m_tcds_bx_2d.at(type))
+        m_tcds_bx_2d[type]->Fill(bx, ls);
+    }
     m_tcds_bx_all->Fill(bx, type);
   }
 
@@ -244,8 +300,10 @@ void TriggerBxMonitor::analyze(edm::Event const & event, edm::EventSetup const &
       auto const & results = bxvector.at(0, 0);
       for (unsigned int i = 0; i < GlobalAlgBlk::maxPhysicsTriggers; ++i)
         if (results.getAlgoDecisionFinal(i)) {
-          if (m_l1t_bx[i])
+          if (m_make_1d_plots and m_l1t_bx.at(i))
             m_l1t_bx[i]->Fill(bx);
+          if (m_make_2d_plots and m_l1t_bx_2d.at(i))
+            m_l1t_bx_2d[i]->Fill(bx, ls);
           m_l1t_bx_all->Fill(bx, i);
         }
     }
@@ -254,15 +312,14 @@ void TriggerBxMonitor::analyze(edm::Event const & event, edm::EventSetup const &
   // monitor the bx distribution for the HLT triggers
   if (m_hltConfig.inited()) {
     auto const & hltResults = get<edm::TriggerResults>(event, m_hlt_results);
-    if (hltResults.size() == m_hlt_bx.size()) {
-      for (unsigned int i = 0; i < m_hlt_bx.size(); ++i) {
-        if (hltResults.at(i).accept()) {
+    for (unsigned int i = 0; i < hltResults.size(); ++i) {
+      if (hltResults.at(i).accept()) {
+        if (m_make_1d_plots and m_hlt_bx.at(i))
           m_hlt_bx[i]->Fill(bx);
-          m_hlt_bx_all->Fill(bx, i);
-        }
+        if (m_make_2d_plots and m_hlt_bx_2d.at(i))
+          m_hlt_bx_2d[i]->Fill(bx, ls);
+        m_hlt_bx_all->Fill(bx, i);
       }
-    } else {
-      edm::LogWarning("TriggerBxMonitor") << "This should never happen: the number of HLT paths has changed since the beginning of the run";
     }
   }
 }


### PR DESCRIPTION
  - add support for plots vs BX and vs lumisetion;
    these plots are disabled by default.

  - make the 1D plots vs BX optional;
    these plots are enabled by default.