### PR TITLE
Add tracking region monitoring to tracking DQM

### DIFF
--- a/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
@@ -29,6 +29,9 @@ Monitoring source for general quantities related to tracks.
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 
+#include "DataFormats/Common/interface/OwnVector.h"
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
+
 class TrackBuildingAnalyzer 
 {
     public:
@@ -62,6 +65,10 @@ class TrackBuildingAnalyzer
             const std::vector<const MVACollection *>& mvaCollections,
             const std::vector<const QualityMaskCollection *>& qualityMaskCollections
         );
+        void analyze
+        (
+            const edm::OwnVector<TrackingRegion>& regions
+        );
 
     private:
 
@@ -69,6 +76,11 @@ class TrackBuildingAnalyzer
         void bookHistos(std::string sname, DQMStore::IBooker & ibooker);
 
         // ----------member data ---------------------------
+
+        // Tracking regions
+        MonitorElement* TrackingRegionEta;
+        MonitorElement* TrackingRegionPhi;
+	MonitorElement* TrackingRegionPhiVsEta;
 
         // Track Seeds
         MonitorElement* SeedPt;
@@ -127,5 +139,6 @@ class TrackBuildingAnalyzer
 	bool doProfETA;
 	bool doStopSource;
 	bool doMVAPlots;
+	bool doRegionPlots;
 };
 #endif

--- a/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
@@ -29,8 +29,7 @@ Monitoring source for general quantities related to tracks.
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 
-#include "DataFormats/Common/interface/OwnVector.h"
-#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
 
 class TrackBuildingAnalyzer 
 {
@@ -67,7 +66,7 @@ class TrackBuildingAnalyzer
         );
         void analyze
         (
-            const edm::OwnVector<TrackingRegion>& regions
+            const reco::CandidateView& regionCandidates
         );
 
     private:
@@ -77,10 +76,11 @@ class TrackBuildingAnalyzer
 
         // ----------member data ---------------------------
 
-        // Tracking regions
-        MonitorElement* TrackingRegionEta;
-        MonitorElement* TrackingRegionPhi;
-	MonitorElement* TrackingRegionPhiVsEta;
+        // Candidates used for tracking regions
+        MonitorElement* TrackingRegionCandidatePt;
+        MonitorElement* TrackingRegionCandidateEta;
+        MonitorElement* TrackingRegionCandidatePhi;
+        MonitorElement* TrackingRegionCandidatePhiVsEta;
 
         // Track Seeds
         MonitorElement* SeedPt;

--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -37,6 +37,9 @@ Monitoring source for general quantities related to tracks.
 
 #include "DataFormats/Scalers/interface/LumiScalers.h"
 
+#include "DataFormats/Common/interface/OwnVector.h"
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
+
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
 namespace dqm {
@@ -91,6 +94,7 @@ class TrackingMonitor : public DQMEDAnalyzer
 	edm::EDGetTokenT<TrackCandidateCollection> trackCandidateToken_;
 	edm::EDGetTokenT<edm::View<TrajectorySeed> > seedToken_;
 	edm::EDGetTokenT<edm::OwnVector<TrackingRegion> > regionToken_;
+	edm::EDGetTokenT<reco::CandidateView> regionCandidateToken_;
 
 	edm::EDGetTokenT<LumiScalersCollection>  lumiscalersToken_;	
 

--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -90,6 +90,7 @@ class TrackingMonitor : public DQMEDAnalyzer
 	edm::EDGetTokenT<edm::View<reco::Track> > trackToken_;
 	edm::EDGetTokenT<TrackCandidateCollection> trackCandidateToken_;
 	edm::EDGetTokenT<edm::View<TrajectorySeed> > seedToken_;
+	edm::EDGetTokenT<edm::OwnVector<TrackingRegion> > regionToken_;
 
 	edm::EDGetTokenT<LumiScalersCollection>  lumiscalersToken_;	
 
@@ -118,12 +119,15 @@ class TrackingMonitor : public DQMEDAnalyzer
 	// Good Tracks 
         MonitorElement * FractionOfGoodTracks;
 
+	// Tracking regions
+	MonitorElement * NumberOfTrackingRegions;
+
         // Track Seeds 
         MonitorElement * NumberOfSeeds;
         MonitorElement * NumberOfSeeds_lumiFlag;
 	std::vector<MonitorElement *> SeedsVsClusters;
 	std::vector<std::string> ClusterLabels;
-	
+
 
         // Track Candidates
         MonitorElement * NumberOfTrackCandidates;
@@ -189,6 +193,7 @@ class TrackingMonitor : public DQMEDAnalyzer
 	bool doHitPropertiesPlots_;
 	bool doTkCandPlots;
 	bool doMVAPlots;
+	bool doRegionPlots;
 	bool doSeedNumberPlot;
 	bool doSeedLumiAnalysis_;
 	bool doSeedVsClusterPlot;

--- a/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
@@ -12,7 +12,6 @@ TrackMon = cms.EDAnalyzer("TrackingMonitor",
     SeedProducer     = cms.InputTag("initialStepSeeds"),
     TCProducer       = cms.InputTag("initialStepTrackCandidates"),
     MVAProducers     = cms.vstring("initialStepClassifier1", "initialStepClassifier2"),
-    RegionProducer   = cms.InputTag("initialStepTrackingRegions"),
     TrackProducerForMVA = cms.InputTag("initialStepTracks"),
     ClusterLabels    = cms.vstring('Tot'), # to decide which Seeds-Clusters correlation plots to have default is Total other options 'Strip', 'Pix'
     beamSpot         = cms.InputTag("offlineBeamSpot"),
@@ -414,11 +413,16 @@ LongDCAMax = cms.double(8.0),
 )
 
 # Overcoming the 255 arguments limit
+# TrackingRegion monitoring
+TrackMon.RegionProducer = cms.InputTag("")
+TrackMon.RegionCandidates = cms.InputTag("")
 TrackMon.doRegionPlots = cms.bool(False)
 TrackMon.RegionSizeBin = cms.int32(20)
 TrackMon.RegionSizeMax = cms.double(19.5)
 TrackMon.RegionSizeMin = cms.double(-0.5)
-
+TrackMon.RegionCandidatePtBin = cms.int32(100)
+TrackMon.RegionCandidatePtMax = cms.double(1000)
+TrackMon.RegionCandidatePtMin = cms.double(0)
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
@@ -12,6 +12,7 @@ TrackMon = cms.EDAnalyzer("TrackingMonitor",
     SeedProducer     = cms.InputTag("initialStepSeeds"),
     TCProducer       = cms.InputTag("initialStepTrackCandidates"),
     MVAProducers     = cms.vstring("initialStepClassifier1", "initialStepClassifier2"),
+    RegionProducer   = cms.InputTag("initialStepTrackingRegions"),
     TrackProducerForMVA = cms.InputTag("initialStepTracks"),
     ClusterLabels    = cms.vstring('Tot'), # to decide which Seeds-Clusters correlation plots to have default is Total other options 'Strip', 'Pix'
     beamSpot         = cms.InputTag("offlineBeamSpot"),
@@ -411,6 +412,13 @@ LongDCABins = cms.int32(100),
 LongDCAMin = cms.double(-8.0),
 LongDCAMax = cms.double(8.0),          
 )
+
+# Overcoming the 255 arguments limit
+TrackMon.doRegionPlots = cms.bool(False)
+TrackMon.RegionSizeBin = cms.int32(20)
+TrackMon.RegionSizeMax = cms.double(19.5)
+TrackMon.RegionSizeMin = cms.double(-0.5)
+
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -32,6 +32,9 @@
 #include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+
 #include "DQM/TrackingMonitor/interface/GetLumi.h"
 
 #include <string>
@@ -135,6 +138,7 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
   doRegionPlots = iConfig.getParameter<bool>("doRegionPlots");
   if(doRegionPlots) {
     regionToken_ = consumes<edm::OwnVector<TrackingRegion> >(iConfig.getParameter<edm::InputTag>("RegionProducer"));
+    regionCandidateToken_ = consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("RegionCandidates"));
   }
 
   edm::InputTag stripClusterInputTag_ = iConfig.getParameter<edm::InputTag>("stripCluster");
@@ -976,11 +980,11 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
       if (doRegionPlots) {
         edm::Handle<edm::OwnVector<TrackingRegion> > hregions;
         iEvent.getByToken(regionToken_, hregions);
-        const auto& regions = *hregions;
+        NumberOfTrackingRegions->Fill(hregions->size());
 
-        NumberOfTrackingRegions->Fill(regions.size());
-
-        theTrackBuildingAnalyzer->analyze(regions);
+        edm::Handle<reco::CandidateView> hcandidates;
+        iEvent.getByToken(regionCandidateToken_, hcandidates);
+        theTrackBuildingAnalyzer->analyze(*hcandidates);
       }
       
       if (doTrackerSpecific_ || doAllPlots) {

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -47,6 +47,7 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
     , NumberOfMeanLayersPerTrack(nullptr)
 				//    , NumberOfGoodTracks(NULL)
     , FractionOfGoodTracks(nullptr)
+    , NumberOfTrackingRegions(nullptr)
     , NumberOfSeeds(nullptr)
     , NumberOfSeeds_lumiFlag(nullptr)
     , NumberOfTrackCandidates(nullptr)
@@ -129,6 +130,11 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
                                                                        consumes<QualityMaskCollection>(edm::InputTag(tag, "QualityMasks")));
                                               });
     mvaTrackToken_ = consumes<edm::View<reco::Track> >(iConfig.getParameter<edm::InputTag>("TrackProducerForMVA"));
+  }
+
+  doRegionPlots = iConfig.getParameter<bool>("doRegionPlots");
+  if(doRegionPlots) {
+    regionToken_ = consumes<edm::OwnVector<TrackingRegion> >(iConfig.getParameter<edm::InputTag>("RegionProducer"));
   }
 
   edm::InputTag stripClusterInputTag_ = iConfig.getParameter<edm::InputTag>("stripCluster");
@@ -602,6 +608,19 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
      }
    }
   
+   if(doRegionPlots) {
+     ibooker.setCurrentFolder(MEFolderName+"/TrackBuilding");
+
+     int    regionBin = conf->getParameter<int>(   "RegionSizeBin");
+     double regionMin = conf->getParameter<double>("RegionSizeMin");
+     double regionMax = conf->getParameter<double>("RegionSizeMax");
+
+     histname = "NumberOfTrackingRegions_"+ seedProducer.label() + "_"+ CategoryName;
+     NumberOfTrackingRegions = ibooker.book1D(histname, histname, regionBin, regionMin, regionMax);
+     NumberOfTrackingRegions->setAxisTitle("Number of TrackingRegions per Event", 1);
+     NumberOfTrackingRegions->setAxisTitle("Number of Events", 2);
+   }
+
    doTkCandPlots=conf->getParameter<bool>("doTrackCandHistos");
   //    if (doAllPlots) doTkCandPlots=true;
   
@@ -952,6 +971,17 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 	}
       }
       
+
+      // plots for tracking regions
+      if (doRegionPlots) {
+        edm::Handle<edm::OwnVector<TrackingRegion> > hregions;
+        iEvent.getByToken(regionToken_, hregions);
+        const auto& regions = *hregions;
+
+        NumberOfTrackingRegions->Fill(regions.size());
+
+        theTrackBuildingAnalyzer->analyze(regions);
+      }
       
       if (doTrackerSpecific_ || doAllPlots) {
 	

--- a/DQM/TrackingMonitorSource/python/IterTrackingModules4seedMonitoring_cfi.py
+++ b/DQM/TrackingMonitorSource/python/IterTrackingModules4seedMonitoring_cfi.py
@@ -11,6 +11,7 @@ clusterLabel      = {}
 clusterBin        = {}
 clusterMax        = {}
 regionLabel       = {}
+regionCandidateLabel = {}
 
 seedInputTag     ['initialStep'] = cms.InputTag("initialStepSeeds")
 trackCandInputTag['initialStep'] = cms.InputTag("initialStepTrackCandidates")
@@ -145,6 +146,7 @@ clusterLabel     ['jetCoreRegionalStep'] = cms.vstring('Tot')
 clusterBin       ['jetCoreRegionalStep'] = cms.int32(100)
 clusterMax       ['jetCoreRegionalStep'] = cms.double(100000)
 regionLabel      ['jetCoreRegionalStep'] = "jetCoreRegionalStepTrackingRegions"
+regionCandidateLabel['jetCoreRegionalStep'] = "jetsForCoreTracking"
 
 for _eraName, _postfix, _era in _cfg.allEras():
     locals()["selectedIterTrackingStep"+_postfix] = _cfg.iterationAlgos(_postfix)

--- a/DQM/TrackingMonitorSource/python/IterTrackingModules4seedMonitoring_cfi.py
+++ b/DQM/TrackingMonitorSource/python/IterTrackingModules4seedMonitoring_cfi.py
@@ -10,6 +10,7 @@ TCSizeMax         = {}
 clusterLabel      = {}
 clusterBin        = {}
 clusterMax        = {}
+regionLabel       = {}
 
 seedInputTag     ['initialStep'] = cms.InputTag("initialStepSeeds")
 trackCandInputTag['initialStep'] = cms.InputTag("initialStepTrackCandidates")
@@ -143,6 +144,7 @@ trackSeedSizeMax ['jetCoreRegionalStep'] = cms.double(199.5)
 clusterLabel     ['jetCoreRegionalStep'] = cms.vstring('Tot')
 clusterBin       ['jetCoreRegionalStep'] = cms.int32(100)
 clusterMax       ['jetCoreRegionalStep'] = cms.double(100000)
+regionLabel      ['jetCoreRegionalStep'] = "jetCoreRegionalStepTrackingRegions"
 
 for _eraName, _postfix, _era in _cfg.allEras():
     locals()["selectedIterTrackingStep"+_postfix] = _cfg.iterationAlgos(_postfix)

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -243,6 +243,9 @@ for step in seedInputTag.iterkeys():
     elif clusterLabel[step] == cms.vstring('Strip') or clusterLabel[step] == cms.vstring('Tot') :
         locals()[label].NClusStrBin = clusterBin[step]
         locals()[label].NClusStrMax = clusterMax[step]
+    if step in regionLabel:
+        locals()[label].doRegionPlots = True
+        locals()[label].RegionProducer = regionLabel[step]
 
 # DQM Services
 dqmInfoTracking = cms.EDAnalyzer("DQMEventInfo",

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -246,6 +246,7 @@ for step in seedInputTag.iterkeys():
     if step in regionLabel:
         locals()[label].doRegionPlots = True
         locals()[label].RegionProducer = regionLabel[step]
+        locals()[label].RegionCandidates = regionCandidateLabel[step]
 
 # DQM Services
 dqmInfoTracking = cms.EDAnalyzer("DQMEventInfo",


### PR DESCRIPTION
This PR adds simple monitoring of tracking regions to tracking DQM with the following quantities
* number of regions
* pT, eta, phi, and eta-vs-phi of candidates used to seed the regions

The monitoring is enabled only for jetCore iteration (the only offline iteration with candidate-seeded regions).

Tested in 9_3_0_pre5, expecting only new histograms and no changes to existing ones.

@rovere @VinInn @mtosi 