### PR TITLE
Add L1menu v3 to run2_hlt_relval

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -35,7 +35,7 @@ autoCond = {
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '92X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '92X_dataRun2_HLT_relval_v7',
+    'run2_hlt_relval'   :   '92X_dataRun2_HLT_relval_v8',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '92X_dataRun2_HLTHI_frozen_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)


### PR DESCRIPTION
As mentioned in https://github.com/cms-sw/cmssw/pull/20239#issuecomment-327140988 I'm adding the new L1Menu to 92X_dataRun2_HLT_relval GT too.

This is an integration to https://github.com/cms-sw/cmssw/pull/20239 that is a backport of https://github.com/cms-sw/cmssw/pull/20238

Only one file changed:
Configuration/AlCa/python/autoCond.py
where the GT 92X_dataRun2_HLT_relval_v7 is now 92X_dataRun2_HLT_relval_v8. The difference is the L1Menu:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/92X_dataRun2_HLT_relval_v8/92X_dataRun2_HLT_relval_v7