### PR TITLE
PixelPhase1 trends by lumiblock for offline

### DIFF
--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -4,7 +4,7 @@ from Configuration.StandardSequences.Eras import eras
 
 process = cms.Process("PIXELDQMLIVE", eras.Run2_2017)
 
-live=False  #set to false for lxplus offline testing
+live=True  #set to false for lxplus offline testing
 offlineTesting=not live
 
 TAG ="PixelPhase1" 
@@ -78,7 +78,7 @@ if (live):
 elif(offlineTesting):
     process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
     from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-    process.GlobalTag = gtCustomise(process.GlobalTag, '92X_dataRun2_HLT_v7', '')
+    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 #-----------------------
 #  Reconstruction Modules

--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -4,7 +4,7 @@ from Configuration.StandardSequences.Eras import eras
 
 process = cms.Process("PIXELDQMLIVE", eras.Run2_2017)
 
-live=True  #set to false for lxplus offline testing
+live=False  #set to false for lxplus offline testing
 offlineTesting=not live
 
 TAG ="PixelPhase1" 
@@ -78,7 +78,7 @@ if (live):
 elif(offlineTesting):
     process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
     from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+    process.GlobalTag = gtCustomise(process.GlobalTag, '92X_dataRun2_HLT_v7', '')
 
 #-----------------------
 #  Reconstruction Modules
@@ -111,6 +111,7 @@ process.load("DQM.SiPixelPhase1Config.SiPixelPhase1OnlineDQM_cff")
 process.PerModule.enabled=True
 process.PerReadout.enabled=True
 process.OverlayCurvesForTiming.enabled=False
+process.IsOffline.enabled=False
 
 #--------------------------
 # Service

--- a/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
@@ -40,7 +40,7 @@ PerLadder = cms.PSet(enabled = cms.bool(True)) # histos per ladder, profiles
 PerLayer2D = cms.PSet(enabled = cms.bool(True)) # 2D maps/profiles of layers
 PerLayer1D = cms.PSet(enabled = cms.bool(True)) # normal histos per layer
 PerReadout = cms.PSet(enabled = cms.bool(True)) # "Readout view", also for initial timing
-OverlayCurvesForTiming= cms.PSet(enabled = cms.bool(True)) #switch to overlay digi/clusters curves for timing scan
+OverlayCurvesForTiming= cms.PSet(enabled = cms.bool(False)) #switch to overlay digi/clusters curves for timing scan
 IsOffline = cms.PSet(enabled = cms.bool(True)) # should be switch off for Online
 
 # Default histogram configuration. This is _not_ used automatically, but you

--- a/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
@@ -40,7 +40,8 @@ PerLadder = cms.PSet(enabled = cms.bool(True)) # histos per ladder, profiles
 PerLayer2D = cms.PSet(enabled = cms.bool(True)) # 2D maps/profiles of layers
 PerLayer1D = cms.PSet(enabled = cms.bool(True)) # normal histos per layer
 PerReadout = cms.PSet(enabled = cms.bool(True)) # "Readout view", also for initial timing
-OverlayCurvesForTiming= cms.PSet(enabled = cms.bool(False)) #switch to overlay digi/clusters curves for timing scan
+OverlayCurvesForTiming= cms.PSet(enabled = cms.bool(True)) #switch to overlay digi/clusters curves for timing scan
+IsOffline = cms.PSet(enabled = cms.bool(True)) # should be switch off for Online
 
 # Default histogram configuration. This is _not_ used automatically, but you
 # can import and pass this (or clones of it) in the plugin config.
@@ -151,23 +152,41 @@ StandardSpecifications1D = [
 ]
 
 StandardSpecificationTrend = [
-    Specification().groupBy("PXBarrel/Lumisection")
+    Specification(PerModule).groupBy("PXBarrel/Lumisection")
                    .reduce("MEAN")
                    .groupBy("PXBarrel", "EXTEND_X")
                    .save(),
-    Specification().groupBy("PXForward/Lumisection")
+    Specification(PerModule).groupBy("PXForward/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXForward", "EXTEND_X")
+                   .save(),
+    Specification(IsOffline).groupBy("PXBarrel/LumiBlock")
+                    .reduce("MEAN")
+                    .groupBy("PXBarrel", "EXTEND_X")
+                    .save(),
+    Specification(IsOffline).groupBy("PXForward/LumiBlock")
                    .reduce("MEAN")
                    .groupBy("PXForward", "EXTEND_X")
                    .save()
 ]
 
 StandardSpecificationTrend2D = [
-    Specification().groupBy("PXBarrel/PXLayer/Lumisection")
+    Specification(PerModule).groupBy("PXBarrel/PXLayer/Lumisection")
                    .reduce("MEAN")
                    .groupBy("PXBarrel/PXLayer", "EXTEND_X")
                    .groupBy("PXBarrel", "EXTEND_Y")
                    .save(),
-    Specification().groupBy("PXForward/PXDisk/Lumisection")
+    Specification(PerModule).groupBy("PXForward/PXDisk/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXDisk","EXTEND_X")
+                   .groupBy("PXForward", "EXTEND_Y")
+                   .save(),
+    Specification(IsOffline).groupBy("PXBarrel/PXLayer/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel/PXLayer", "EXTEND_X")
+                   .groupBy("PXBarrel", "EXTEND_Y")
+                   .save(),
+    Specification(IsOffline).groupBy("PXForward/PXDisk/LumiBlock")
                    .reduce("MEAN")
                    .groupBy("PXForward/PXDisk","EXTEND_X")
                    .groupBy("PXForward", "EXTEND_Y")
@@ -291,36 +310,67 @@ StandardSpecificationInclusive_Num = [#to count inclusively objects in substruct
 ]
 
 StandardSpecificationTrend_Num = [
-
-    Specification().groupBy("PXBarrel/PXLayer/Event")
+    Specification(PerModule).groupBy("PXBarrel/PXLayer/Event")
                    .reduce("COUNT")
                    .groupBy("PXBarrel/PXLayer/Lumisection")
                    .reduce("MEAN")
                    .groupBy("PXBarrel/PXLayer","EXTEND_X")
                    .groupBy("PXBarrel", "EXTEND_Y")
                    .save(),
-    Specification().groupBy("PXBarrel/Event")
+    Specification(PerModule).groupBy("PXBarrel/Event")
                    .reduce("COUNT")
                    .groupBy("PXBarrel/Lumisection")
                    .reduce("MEAN")
                    .groupBy("PXBarrel", "EXTEND_X")
                    .save(),
-    Specification().groupBy("PXForward/PXDisk/Event")
+    Specification(PerModule).groupBy("PXForward/PXDisk/Event")
                    .reduce("COUNT")
                    .groupBy("PXForward/PXDisk/Lumisection")
                    .reduce("MEAN")
                    .groupBy("PXForward/PXDisk","EXTEND_X")
                    .groupBy("PXForward", "EXTEND_Y")
                    .save(),
-    Specification().groupBy("PXForward/Event")
+    Specification(PerModule).groupBy("PXForward/Event")
                    .reduce("COUNT")
                    .groupBy("PXForward/Lumisection")
                    .reduce("MEAN")
                    .groupBy("PXForward", "EXTEND_X")
                    .save(),
-    Specification().groupBy("PXAll/Event")
+    Specification(PerModule).groupBy("PXAll/Event")
                    .reduce("COUNT")
                    .groupBy("PXAll/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXAll", "EXTEND_X")
+                   .save(),
+    Specification(IsOffline).groupBy("PXBarrel/PXLayer/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel/PXLayer/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel/PXLayer","EXTEND_X")
+                   .groupBy("PXBarrel", "EXTEND_Y")
+                   .save(),
+    Specification(IsOffline).groupBy("PXBarrel/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel", "EXTEND_X")
+                   .save(),
+    Specification(IsOffline).groupBy("PXForward/PXDisk/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXForward/PXDisk/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXDisk","EXTEND_X")
+                   .groupBy("PXForward", "EXTEND_Y")
+                   .save(),
+    Specification(IsOffline).groupBy("PXForward/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXForward/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXForward", "EXTEND_X")
+                   .save(),
+    Specification(IsOffline).groupBy("PXAll/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXAll/LumiBlock")
                    .reduce("MEAN")
                    .groupBy("PXAll", "EXTEND_X")
                    .save(),

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
@@ -20,6 +20,7 @@ from DQM.SiPixelPhase1RawData.SiPixelPhase1RawData_cfi import *
 from DQM.SiPixelPhase1Summary.SiPixelPhase1Summary_cfi import *
 
 PerModule.enabled = False
+IsOffline.enabled=True
 
 siPixelPhase1OfflineDQM_source = cms.Sequence(SiPixelPhase1RawDataAnalyzer
                                             + SiPixelPhase1DigisAnalyzer

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_Timing_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_Timing_cff.py
@@ -152,6 +152,8 @@ siPixelPhase1OnlineDQM_source_cosmics = cms.Sequence(
 ## Additional settings for pp_run (Phase 0 test)
 SiPixelPhase1TrackClustersAnalyzer_pprun = SiPixelPhase1TrackClustersAnalyzer.clone()
 SiPixelPhase1TrackClustersAnalyzer_pprun.tracks  = cms.InputTag( "initialStepTracksPreSplitting" )
+SiPixelPhase1TrackClustersAnalyzer_pprun.clusterShapeCache = cms.InputTag("siPixelClusterShapeCachePreSplitting")
+SiPixelPhase1TrackClustersAnalyzer_pprun.vertices = cms.InputTag('firstStepPrimaryVerticesPreSplitting')
 SiPixelPhase1TrackClustersAnalyzer_pprun.VertexCut = cms.untracked.bool(False)
 
 SiPixelPhase1TrackResidualsAnalyzer_pprun = SiPixelPhase1TrackResidualsAnalyzer.clone()

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_Timing_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_Timing_cff.py
@@ -3,8 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
 
 SuperimoposePlotsInOnlineBlocks=True
-
-
+IsOffline.enabled=False
 
 
 StandardSpecifications1D.append(
@@ -153,8 +152,6 @@ siPixelPhase1OnlineDQM_source_cosmics = cms.Sequence(
 ## Additional settings for pp_run (Phase 0 test)
 SiPixelPhase1TrackClustersAnalyzer_pprun = SiPixelPhase1TrackClustersAnalyzer.clone()
 SiPixelPhase1TrackClustersAnalyzer_pprun.tracks  = cms.InputTag( "initialStepTracksPreSplitting" )
-SiPixelPhase1TrackClustersAnalyzer_pprun.clusterShapeCache = cms.InputTag("siPixelClusterShapeCachePreSplitting")
-SiPixelPhase1TrackClustersAnalyzer_pprun.vertices = cms.InputTag('firstStepPrimaryVerticesPreSplitting')
 SiPixelPhase1TrackClustersAnalyzer_pprun.VertexCut = cms.untracked.bool(False)
 
 SiPixelPhase1TrackResidualsAnalyzer_pprun = SiPixelPhase1TrackResidualsAnalyzer.clone()

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
@@ -107,11 +107,11 @@ siPixelPhase1OnlineDQM_harvesting = cms.Sequence(
  + SiPixelPhase1ClustersHarvester
  + SiPixelPhase1RawDataHarvester
  + RunQTests_online
- + SiPixelPhase1Summary_Online
+ + SiPixelPhase1SummaryOnline
 # + SiPixelPhase1GeometryDebugHarvester
 )
 
 siPixelPhase1OnlineDQM_timing_harvesting = siPixelPhase1OnlineDQM_harvesting.copyAndExclude([
  RunQTests_online,
- SiPixelPhase1Summary_Online,
+ SiPixelPhase1SummaryOnline,
 ])

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
 
 SuperimoposePlotsInOnlineBlocks=False
+IsOffline.enabled=False
 
 
 
@@ -106,11 +107,11 @@ siPixelPhase1OnlineDQM_harvesting = cms.Sequence(
  + SiPixelPhase1ClustersHarvester
  + SiPixelPhase1RawDataHarvester
  + RunQTests_online
- + SiPixelPhase1SummaryOnline
+ + SiPixelPhase1Summary_Online
 # + SiPixelPhase1GeometryDebugHarvester
 )
 
 siPixelPhase1OnlineDQM_timing_harvesting = siPixelPhase1OnlineDQM_harvesting.copyAndExclude([
  RunQTests_online,
- SiPixelPhase1SummaryOnline,
+ SiPixelPhase1Summary_Online,
 ])


### PR DESCRIPTION
We've added a switch to produce trends plots by Lumiblock (10LS) for OfflineDQM, while keeping the LS granularity for online. 

This supersedes #20205, which can be closed. 

This approach, suggested by @fioriNTU, should be simpler than the originally proposed in   #20205. 