### PR TITLE
[MuonHLT]:  BugFix for TSGforOI

### DIFF
--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
@@ -96,6 +96,8 @@ void TSGForOI::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSe
   std::unique_ptr<Propagator> propagatorAlong = SetPropagationDirection(*propagatorAlongH,alongMomentum);
   std::unique_ptr<Propagator> propagatorOpposite = SetPropagationDirection(*propagatorOppositeH,oppositeToMomentum);
 
+  edm::ESHandle<Propagator> SmartOpposite;
+  edm::ESHandle<Propagator> SHPOpposite;
   iSetup.get<TrackingComponentsRecord>().get("hltESPSmartPropagatorAnyOpposite", SmartOpposite);
   iSetup.get<TrackingComponentsRecord>().get("hltESPSteppingHelixPropagatorOpposite", SHPOpposite);
 
@@ -238,7 +240,6 @@ void TSGForOI::findSeedsOnLayer(
       }
     }
   }
-  //  numSeedsMade=out->size();
 
   // Hits:
   if (layerCount>numOfLayersToTry_) return;
@@ -279,6 +280,7 @@ int TSGForOI::makeSeedsFromHits(
 				const Propagator& propagatorAlong,
 				const MeasurementTrackerEvent &measurementTracker,
 				edm::ESHandle<Chi2MeasurementEstimatorBase>& estimatorH,
+				unsigned int& numSeedsMade,
 				const double errorSF)  const{
 
   //		Error Rescaling:

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
@@ -87,6 +87,7 @@ private:
 	const double tsosDiff_;
 
 	/// Counters and flags for the implementation
+	const std::string propagatorName_;
 	const std::string theCategory;
 
 	/// Function to find seeds on a given layer
@@ -118,6 +119,7 @@ private:
 				const Propagator& propagatorAlong,
 				const MeasurementTrackerEvent &measurementTracker,
 				edm::ESHandle<Chi2MeasurementEstimatorBase>& estimator_,
+				unsigned int& numSeedsMade,
 				const double errorSF) const;
 
 


### PR DESCRIPTION
This fixes a couple of bugs discovered that were affecting the efficiency specially in the overlap region:
- Added error-rescaling for hit-based seeds.
- Correct reseting of the number of made seeds (affecting the overlap region)
- Add a configuration parameter to chose the name of the propagator in the config file (it was previously hard-coded) 

This only affects the outside-in component of the Muon HLT reconstruction. 
