### PR TITLE
GT Updates with L1T updates and tracker ideal alignment (93X)

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -46,7 +46,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' : '93X_mc2017cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'vphase1_2018_design'       : '93X_upgrade2018_design_IdealBS_v2',
+    'phase1_2018_design'       : '93X_upgrade2018_design_IdealBS_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
     'phase1_2018_realistic'    : '93X_upgrade2018_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -14,7 +14,7 @@ autoCond = {
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
     'run2_mc_50ns'      :   '93X_mcRun2_startup_v0',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '93X_mcRun2_asymptotic_v0',
+    'run2_mc'           :   '93X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'   :   '93X_mcRun2cosmics_startup_deco_v0',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
@@ -38,23 +38,23 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '93X_dataRun2_HLTHI_frozen_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '93X_mc2017_design_IdealBS_v2',
+    'phase1_2017_design'       :  '93X_mc2017_design_IdealBS_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '93X_mc2017_realistic_v2',
+    'phase1_2017_realistic'    : '93X_mc2017_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '93X_mc2017cosmics_realistic_deco_v2',
+    'phase1_2017_cosmics'      : '93X_mc2017cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '93X_mc2017cosmics_realistic_peak_v2',
+    'phase1_2017_cosmics_peak' : '93X_mc2017cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '93X_upgrade2018_design_IdealBS_v1',
+    'vphase1_2018_design'       : '93X_upgrade2018_design_IdealBS_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '93X_upgrade2018_realistic_v1',
+    'phase1_2018_realistic'    : '93X_upgrade2018_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '93X_upgrade2018cosmics_realistic_deco_v1',
+    'phase1_2018_cosmics'      :   '93X_upgrade2018cosmics_realistic_deco_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '93X_upgrade2023_realistic_v1'
+    'phase2_realistic'         : '93X_upgrade2023_realistic_v2'
 }
 
 aliases = {


### PR DESCRIPTION
# Summary of changes in Global Tags

## RunII simulation

   * **RunII Asymptotic scenario** : [93X_mcRun2_asymptotic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_asymptotic_v1) as [93X_mcRun2_asymptotic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_asymptotic_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mcRun2_asymptotic_v1/93X_mcRun2_asymptotic_v0):
      * Added L1TMuonOverlapParams_static_2016_mc

## Upgrade

   * **PhaseII realistic scenario** : [93X_upgrade2023_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_upgrade2023_realistic_v2) as [93X_upgrade2023_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_upgrade2023_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_upgrade2023_realistic_v2/93X_upgrade2023_realistic_v1):
      * Added L1TCaloParams_static_CMSSW_9_2_10_2017_v1_8_2_updateHFSF_v6MET + L1TGlobalPrescalesVetos_passThrough_mc

   * **PhaseI 2018 cosmics scenario** : [93X_upgrade2018cosmics_realistic_deco_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_upgrade2018cosmics_realistic_deco_v2) as [93X_upgrade2018cosmics_realistic_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_upgrade2018cosmics_realistic_deco_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_upgrade2018cosmics_realistic_deco_v2/93X_upgrade2018cosmics_realistic_deco_v1):
      * Added L1TCaloParams_static_CMSSW_9_2_10_2017_v1_8_2_updateHFSF_v6MET

   * **PhaseI 2018 design scenario** : [93X_upgrade2018_design_IdealBS_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_upgrade2018_design_IdealBS_v2) as [93X_upgrade2018_design_IdealBS_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_upgrade2018_design_IdealBS_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_upgrade2018_design_IdealBS_v2/93X_upgrade2018_design_IdealBS_v1):
      * Added L1TCaloParams_static_CMSSW_9_2_10_2017_v1_8_2_updateHFSF_v6MET + TrackerAlignment_Upgrade2017_design_v4

   * **PhaseI 2018 realistic scenario** : [93X_upgrade2018_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_upgrade2018_realistic_v2) as [93X_upgrade2018_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_upgrade2018_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_upgrade2018_realistic_v2/93X_upgrade2018_realistic_v1):
      * Added L1TCaloParams_static_CMSSW_9_2_10_2017_v1_8_2_updateHFSF_v6MET

## 2017_MC

   * **PhaseI 2017 cosmics peak scenario** : [93X_mc2017cosmics_realistic_peak_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mc2017cosmics_realistic_peak_v3) as [93X_mc2017cosmics_realistic_peak_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mc2017cosmics_realistic_peak_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mc2017cosmics_realistic_peak_v3/93X_mc2017cosmics_realistic_peak_v2):
      * Added L1TCaloParams_static_CMSSW_9_2_10_2017_v1_8_2_updateHFSF_v6MET

   * **PhaseI 2017 cosmics scenario** : [93X_mc2017cosmics_realistic_deco_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mc2017cosmics_realistic_deco_v3) as [93X_mc2017cosmics_realistic_deco_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mc2017cosmics_realistic_deco_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mc2017cosmics_realistic_deco_v3/93X_mc2017cosmics_realistic_deco_v2):
      * Added L1TCaloParams_static_CMSSW_9_2_10_2017_v1_8_2_updateHFSF_v6MET

   * **PhaseI 2017 design scenario** : [93X_mc2017_design_IdealBS_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mc2017_design_IdealBS_v3) as [93X_mc2017_design_IdealBS_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mc2017_design_IdealBS_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mc2017_design_IdealBS_v3/93X_mc2017_design_IdealBS_v2):
      * Added L1TCaloParams_static_CMSSW_9_2_10_2017_v1_8_2_updateHFSF_v6MET + TrackerAlignment_Upgrade2017_design_v4

   * **PhaseI 2017 realistic scenario** : [93X_mc2017_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mc2017_realistic_v3) as [93X_mc2017_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mc2017_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mc2017_realistic_v3/93X_mc2017_realistic_v2):
      * Added L1TCaloParams_static_CMSSW_9_2_10_2017_v1_8_2_updateHFSF_v6MET