### PR TITLE
add option for sequential RootEmbeddedFileSequence to not recycle files

### DIFF
--- a/DQM/SiStripMonitorHardware/interface/CMHistograms.hh
+++ b/DQM/SiStripMonitorHardware/interface/CMHistograms.hh
@@ -41,12 +41,12 @@ public:
 
   CMHistograms();
 
-  ~CMHistograms();
+  ~CMHistograms() override;
   
   //initialise histograms
   void initialise(const edm::ParameterSet& iConfig,
 		  std::ostringstream* pDebugStream
-		  );
+		  ) override;
 
   void fillHistograms(const std::vector<CMvalues>& aVec, float aTime, unsigned int aFedId);
 
@@ -61,9 +61,9 @@ public:
 
   void bookAllFEDHistograms(DQMStore::IBooker &);
 
-  bool tkHistoMapEnabled(unsigned int aIndex=0);
+  bool tkHistoMapEnabled(unsigned int aIndex=0) override;
 
-  TkHistoMap * tkHistoMapPointer(unsigned int aIndex=0);
+  TkHistoMap * tkHistoMapPointer(unsigned int aIndex=0) override;
 
 protected:
   

--- a/DQM/SiStripMonitorHardware/interface/FEDErrors.hh
+++ b/DQM/SiStripMonitorHardware/interface/FEDErrors.hh
@@ -151,7 +151,7 @@ public:
 
   //FE/Channel check: rate of channels with error (only considering connected channels)
   float fillNonFatalFEDErrors(const sistrip::FEDBuffer* aBuffer,
-			      const SiStripFedCabling* aCabling = 0);
+			      const SiStripFedCabling* aCabling = nullptr);
 
   //fill errors: define the order of importance.
   bool fillFEDErrors(const FEDRawData& aFedData,

--- a/DQM/SiStripMonitorHardware/interface/FEDHistograms.hh
+++ b/DQM/SiStripMonitorHardware/interface/FEDHistograms.hh
@@ -34,12 +34,12 @@ public:
   
   FEDHistograms();
 
-  ~FEDHistograms();
+  ~FEDHistograms() override;
   
   //initialise histograms
   void initialise(const edm::ParameterSet& iConfig,
 		  std::ostringstream* pDebugStream
-		  );
+		  ) override;
 
   void fillCountersHistograms(const FEDErrors::FEDCounters & aFedLevelCounters, 
 			      const FEDErrors::ChannelCounters & aChLevelCounters,
@@ -86,9 +86,9 @@ public:
 
   void bookAllFEDHistograms(DQMStore::IBooker & , bool);
 
-  bool tkHistoMapEnabled(unsigned int aIndex=0);
+  bool tkHistoMapEnabled(unsigned int aIndex=0) override;
 
-  TkHistoMap * tkHistoMapPointer(unsigned int aIndex=0);
+  TkHistoMap * tkHistoMapPointer(unsigned int aIndex=0) override;
 
   MonitorElement *cmHistPointer(bool aApv1);
 

--- a/DQM/SiStripMonitorHardware/interface/SPYHistograms.h
+++ b/DQM/SiStripMonitorHardware/interface/SPYHistograms.h
@@ -56,12 +56,12 @@ class SPYHistograms: public HistogramBase {
 
   SPYHistograms();
   
-  ~SPYHistograms();
+  ~SPYHistograms() override;
   
   //initialise histograms
   void initialise(const edm::ParameterSet& iConfig,
 		  std::ostringstream* pDebugStream
-		  );
+		  ) override;
 
   //book the top level histograms
   void bookTopLevelHistograms(DQMStore::IBooker &);
@@ -84,12 +84,12 @@ class SPYHistograms: public HistogramBase {
 			      const unsigned int aFedId, 
 			      const unsigned int aFedChannel);
 
-  bool tkHistoMapEnabled(unsigned int aIndex=0){
+  bool tkHistoMapEnabled(unsigned int aIndex=0) override{
     return false;
   };
 
-  TkHistoMap * tkHistoMapPointer(unsigned int aIndex=0){
-    return 0;
+  TkHistoMap * tkHistoMapPointer(unsigned int aIndex=0) override{
+    return nullptr;
 };
 
  protected:

--- a/DQM/SiStripMonitorHardware/interface/SiStripFEDSpyBuffer.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripFEDSpyBuffer.h
@@ -34,8 +34,8 @@ namespace sistrip {
   public:
     //construct from buffer
     FEDSpyBuffer(const uint8_t* fedBuffer, const size_t fedBufferSize);
-    virtual ~FEDSpyBuffer();
-    virtual void print(std::ostream& os) const;
+    ~FEDSpyBuffer() override;
+    void print(std::ostream& os) const override;
       
     //get the run number from the corresponding global run
     uint32_t globalRunNumber() const;
@@ -51,7 +51,7 @@ namespace sistrip {
     //checks that a delay chip is complete i.e. that it all came from the same event
     bool delayChipGood(const uint8_t delayChip) const;
     //checks that a channel is usable (i.e. that the delay chip it is on is good)
-    virtual bool channelGood(const uint8_t internalFEDannelNum) const;
+    bool channelGood(const uint8_t internalFEDannelNum) const override;
   private:
     //mapping of channel index to position in data
     static const uint8_t channelPositionsInData_[FEDCH_PER_DELAY_CHIP];

--- a/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
@@ -177,7 +177,7 @@ namespace sistrip {
     if (productWrapper) {
       return productWrapper->product();
     } else {
-      return NULL;
+      return nullptr;
     }
   }
   

--- a/DQM/SiStripMonitorHardware/python/SiStripSpyEventMatcher_cfi.py
+++ b/DQM/SiStripMonitorHardware/python/SiStripSpyEventMatcher_cfi.py
@@ -19,7 +19,6 @@ SiStripSpyEventMatcher = cms.EDFilter(
         'SpyFileNameWhichNeedsToBeSet SiStripSpyEventMatcher.SpySource.fileNames'
         ),
         sequential = cms.untracked.bool(True),
-        recycleFiles = cms.untracked.bool(False),
       ),
     CounterDiffMaxAllowed = cms.uint32(100)
     )

--- a/DQM/SiStripMonitorHardware/python/SiStripSpyEventMatcher_cfi.py
+++ b/DQM/SiStripMonitorHardware/python/SiStripSpyEventMatcher_cfi.py
@@ -19,6 +19,7 @@ SiStripSpyEventMatcher = cms.EDFilter(
         'SpyFileNameWhichNeedsToBeSet SiStripSpyEventMatcher.SpySource.fileNames'
         ),
         sequential = cms.untracked.bool(True),
+        recycleFiles = cms.untracked.bool(False),
       ),
     CounterDiffMaxAllowed = cms.uint32(100)
     )

--- a/DQM/SiStripMonitorHardware/src/BuildTrackerMap.cc
+++ b/DQM/SiStripMonitorHardware/src/BuildTrackerMap.cc
@@ -57,11 +57,11 @@ class BuildTrackerMapPlugin : public edm::EDAnalyzer
  public:
 
   explicit BuildTrackerMapPlugin(const edm::ParameterSet&);
-  ~BuildTrackerMapPlugin();
+  ~BuildTrackerMapPlugin() override;
  private:
-  virtual void beginJob() override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override;
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
   void read(bool aMechView,
 	    std::string aFile,
@@ -160,7 +160,7 @@ void BuildTrackerMapPlugin::read(bool aMechView,
   std::vector<TkHistoMap *> tkHistoMap;
 
   unsigned int nHists = tkHistoMapNameVec_.size();
-  tkHistoMap.resize(nHists,0);
+  tkHistoMap.resize(nHists,nullptr);
   aValidVec.resize(nHists,true);
 
   std::string dirName = folderName_;
@@ -369,7 +369,7 @@ BuildTrackerMapPlugin::endJob()
 
     //(pset_,pDD1); 
     lTkMap->setPalette(1);
-    lTkMap->showPalette(1);
+    lTkMap->showPalette(true);
     if (!tkHistoMapVec_.at(i) || !isValidMap_.at(i)) {
       std::cout << "Warning, tkHistoMap is invalid for element " << i << "... continuing ..." << std::endl;
       continue;

--- a/DQM/SiStripMonitorHardware/src/CMHistograms.cc
+++ b/DQM/SiStripMonitorHardware/src/CMHistograms.cc
@@ -75,7 +75,7 @@ void CMHistograms::fillHistograms(const std::vector<CMvalues>& aVec, float aTime
 
   }//loop on elements
 
-  if (aVec.size() > 0) {
+  if (!aVec.empty()) {
     lMean = lMean / (2*aVec.size());
     lPrevMean = lPrevMean / (2*aVec.size());
   }
@@ -147,16 +147,16 @@ void CMHistograms::bookTopLevelHistograms(DQMStore::IBooker & ibooker)
     
   //book map after, as it creates a new folder...
   if (tkMapConfig_.enabled){
-    tkmapCM_[0] = new TkHistoMap("SiStrip/TkHisto","TkHMap_MeanCMAPV",0.,500);
-    tkmapCM_[1] = new TkHistoMap("SiStrip/TkHisto","TkHMap_RmsCMAPV",0.,500);
-    tkmapCM_[2] = new TkHistoMap("SiStrip/TkHisto","TkHMap_MeanCMAPV0minusAPV1",-500.,500);
-    tkmapCM_[3] = new TkHistoMap("SiStrip/TkHisto","TkHMap_RmsCMAPV0minusAPV1",-500.,500);
+    tkmapCM_[0] = new TkHistoMap("SiStrip/TkHisto","TkHMap_MeanCMAPV",0.,true);
+    tkmapCM_[1] = new TkHistoMap("SiStrip/TkHisto","TkHMap_RmsCMAPV",0.,true);
+    tkmapCM_[2] = new TkHistoMap("SiStrip/TkHisto","TkHMap_MeanCMAPV0minusAPV1",-500.,true);
+    tkmapCM_[3] = new TkHistoMap("SiStrip/TkHisto","TkHMap_RmsCMAPV0minusAPV1",-500.,true);
   }
   else {
-    tkmapCM_[0] = 0;
-    tkmapCM_[1] = 0;
-    tkmapCM_[2] = 0;
-    tkmapCM_[3] = 0;
+    tkmapCM_[0] = nullptr;
+    tkmapCM_[1] = nullptr;
+    tkmapCM_[2] = nullptr;
+    tkmapCM_[3] = nullptr;
   }
 
   for ( unsigned int i = sistrip::FED_ID_MIN; i <= sistrip::FED_ID_MAX; i++ )
@@ -204,8 +204,8 @@ void CMHistograms::bookChannelsHistograms(DQMStore::IBooker & ibooker , unsigned
   fedIdStream << fedId;
 
   ibooker.setCurrentFolder(fedKey.path());
-  medianperChannelMap_[fedId].resize(sistrip::FEDCH_PER_FED,0);
-  medianAPV0minusAPV1perChannelMap_[fedId].resize(sistrip::FEDCH_PER_FED,0);
+  medianperChannelMap_[fedId].resize(sistrip::FEDCH_PER_FED,nullptr);
+  medianAPV0minusAPV1perChannelMap_[fedId].resize(sistrip::FEDCH_PER_FED,nullptr);
 
   for (unsigned int iCh(0); iCh < sistrip::FEDCH_PER_FED; iCh++){
 

--- a/DQM/SiStripMonitorHardware/src/FEDErrors.cc
+++ b/DQM/SiStripMonitorHardware/src/FEDErrors.cc
@@ -390,14 +390,14 @@ bool FEDErrors::fillFEDErrors(const FEDRawData& aFedData,
 
    
   if (printDebug() && aPrintDebug>2) {
-    const sistrip::FEDBufferBase* debugBuffer = NULL;
+    const sistrip::FEDBufferBase* debugBuffer = nullptr;
 
     if (buffer.get()) debugBuffer = buffer.get();
     //else if (bufferBase.get()) debugBuffer = bufferBase.get();
     if (debugBuffer) {
       std::vector<FEDErrors::APVLevelErrors> & lChVec = getAPVLevelErrors();
       std::ostringstream debugStream;
-      if (lChVec.size()) {
+      if (!lChVec.empty()) {
 	std::sort(lChVec.begin(),lChVec.end());
         debugStream << "[FEDErrors] Cabled channels which had errors: ";
 	
@@ -858,7 +858,7 @@ void FEDErrors::fillEventProperties(long long dbx) {
 
 void FEDErrors::incrementLumiErrors(const bool hasError,
 				    const unsigned int aSubDet){
-  if (!lumiErr_.nTotal.size()) return;
+  if (lumiErr_.nTotal.empty()) return;
   if (aSubDet >= lumiErr_.nTotal.size()) {
     edm::LogError("SiStripMonitorHardware") << " -- FED " << fedID_ 
 					    << ", invalid subdetid : " << aSubDet

--- a/DQM/SiStripMonitorHardware/src/FEDHistograms.cc
+++ b/DQM/SiStripMonitorHardware/src/FEDHistograms.cc
@@ -809,7 +809,7 @@ void FEDHistograms::bookTopLevelHistograms(DQMStore::IBooker & ibooker , std::st
   if (tkMapConfig_.enabled){
     tkmapFED_ = new TkHistoMap(topFolderName,"TkHMap_FractionOfBadChannels",0.,true);
   }
-  else tkmapFED_ = 0;
+  else tkmapFED_ = nullptr;
 
 }
 

--- a/DQM/SiStripMonitorHardware/src/HistogramBase.cc
+++ b/DQM/SiStripMonitorHardware/src/HistogramBase.cc
@@ -37,7 +37,7 @@ void HistogramBase::getConfigForHistogram(HistogramConfig & aConfig,
 					  )
 {
 
-  aConfig.monitorEle = 0;
+  aConfig.monitorEle = nullptr;
   aConfig.enabled = false;
   aConfig.nBins = 0;
   aConfig.min = aConfig.max = 0.;
@@ -98,7 +98,7 @@ void HistogramBase::bookHistogram(DQMStore::IBooker & ibooker , HistogramConfig 
     aConfig.monitorEle = ibooker.book1D(name,title,nBins,min,max);
     aConfig.monitorEle->setAxisTitle(xAxisTitle,1);
   } else {
-    aConfig.monitorEle = 0;
+    aConfig.monitorEle = nullptr;
   }
 
 }
@@ -118,7 +118,7 @@ void HistogramBase::bookHistogram(DQMStore::IBooker & ibooker , HistogramConfig 
     aHist = ibooker.book1D(name,title,nBins,min,max);
     aHist->setAxisTitle(xAxisTitle,1);
   } else {
-    aHist = 0;
+    aHist = nullptr;
   }
 
 }
@@ -151,7 +151,7 @@ void HistogramBase::book2DHistogram(DQMStore::IBooker & ibooker , HistogramConfi
     aConfig.monitorEle->setAxisTitle(xAxisTitle,1);
     aConfig.monitorEle->setAxisTitle(yAxisTitle,2);
   } else {
-    aConfig.monitorEle=NULL;
+    aConfig.monitorEle=nullptr;
   }
 }
 
@@ -175,7 +175,7 @@ void HistogramBase::book2DHistogram(DQMStore::IBooker & ibooker , HistogramConfi
     aHist->setAxisTitle(xAxisTitle,1);
     aHist->setAxisTitle(yAxisTitle,2);
   } else {
-    aHist=NULL;
+    aHist=nullptr;
   }
 }
 
@@ -206,7 +206,7 @@ void HistogramBase::bookProfile(DQMStore::IBooker & ibooker , HistogramConfig & 
     aConfig.monitorEle->setAxisTitle(xAxisTitle,1);
     aConfig.monitorEle->setAxisTitle(yAxisTitle,2);
   } else {
-    aConfig.monitorEle = NULL;
+    aConfig.monitorEle = nullptr;
   }
 }
 

--- a/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
@@ -64,7 +64,7 @@ class SiStripCMMonitorPlugin : public DQMEDAnalyzer
  public:
 
   explicit SiStripCMMonitorPlugin(const edm::ParameterSet&);
-  ~SiStripCMMonitorPlugin();
+  ~SiStripCMMonitorPlugin() override;
  private:
 
   struct Statistics {
@@ -73,7 +73,7 @@ class SiStripCMMonitorPlugin : public DQMEDAnalyzer
     float Counter;
   };
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void dqmBeginRun(const edm::Run& , const edm::EventSetup& ) override;
 
@@ -143,7 +143,7 @@ SiStripCMMonitorPlugin::SiStripCMMonitorPlugin(const edm::ParameterSet& iConfig)
                 << "[SiStripCMMonitorPlugin]\tPrintDebugMessages? " << (printDebug_ ? "yes" : "no") << std::endl;
   }
     
- std::ostringstream* pDebugStream = (printDebug_>1 ? &debugStream : NULL);
+ std::ostringstream* pDebugStream = (printDebug_>1 ? &debugStream : nullptr);
 
  cmHists_.initialise(iConfig,pDebugStream);
 

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDDataCheck.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDDataCheck.cc
@@ -55,12 +55,12 @@ class SiStripFEDCheckPlugin : public DQMEDAnalyzer
 {
  public:
   explicit SiStripFEDCheckPlugin(const edm::ParameterSet&);
-  ~SiStripFEDCheckPlugin();
+  ~SiStripFEDCheckPlugin() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
  private:
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
   
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
@@ -126,11 +126,11 @@ SiStripFEDCheckPlugin::SiStripFEDCheckPlugin(const edm::ParameterSet& iConfig)
   , doPLOTfedNonFatalErrors_ (iConfig.getParameter<bool>("doPLOTfedNonFatalErrors"))
   , doPLOTnFEDinVsLS_        (iConfig.getParameter<bool>("doPLOTnFEDinVsLS")       )
   , doPLOTnFEDinWdataVsLS_   (iConfig.getParameter<bool>("doPLOTnFEDinWdataVsLS")  )
-  , fedsPresent_      (NULL)
-  , fedFatalErrors_   (NULL)
-  , fedNonFatalErrors_(NULL)
-  , nFEDinVsLS_       (NULL)
-  , nFEDinWdataVsLS_  (NULL)
+  , fedsPresent_      (nullptr)
+  , fedFatalErrors_   (nullptr)
+  , fedNonFatalErrors_(nullptr)
+  , nFEDinVsLS_       (nullptr)
+  , nFEDinWdataVsLS_  (nullptr)
   , updateFrequency_(iConfig.getUntrackedParameter<unsigned int>("HistogramUpdateFrequency",0))
   , fedsPresentBinContents_     (FEDNumbering::MAXSiStripFEDID+1,0)
   , fedFatalErrorBinContents_   (FEDNumbering::MAXSiStripFEDID+1,0)
@@ -207,7 +207,7 @@ SiStripFEDCheckPlugin::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 
     //check data exists
     if (!fedData.size() || !fedData.data()) {
-      fillPresent(fedId,0);
+      fillPresent(fedId,false);
       continue;
     }
     if (verbose_) std::cout << "FED " << fedId;
@@ -217,7 +217,7 @@ SiStripFEDCheckPlugin::analyze(const edm::Event& iEvent, const edm::EventSetup& 
     if (fedData.size() && fedData.data()) nFEDinWdata++;
 
     //fill buffer present histogram
-    fillPresent(fedId,1);
+    fillPresent(fedId,true);
 
     //check for fatal errors
     //no need for debug output
@@ -250,7 +250,7 @@ SiStripFEDCheckPlugin::analyze(const edm::Event& iEvent, const edm::EventSetup& 
     }
 
     if (hasFatalErrors) {
-      fillFatalError(fedId,1);
+      fillFatalError(fedId,true);
       if (printDebug_) {
 	if (!buffer.get()) buffer.reset(new sistrip::FEDBuffer(fedData.data(),fedData.size(),true));
 	edm::LogInfo("SiStripFEDCheck") << "Fatal error with FED ID " << fedId << ". Check summary: " 
@@ -261,7 +261,7 @@ SiStripFEDCheckPlugin::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       }
     }
     else {
-      fillFatalError(fedId,0);
+      fillFatalError(fedId,false);
       //fill non-fatal errors histogram if there were no fatal errors
       fillNonFatalError(fedId,rateNonFatal);
       if (printDebug_ && rateNonFatal > 0) {

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDDump.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDDump.cc
@@ -24,9 +24,9 @@ class SiStripFEDDumpPlugin : public DQMEDAnalyzer
 {
  public:
   explicit SiStripFEDDumpPlugin(const edm::ParameterSet&);
-  ~SiStripFEDDumpPlugin();
+  ~SiStripFEDDumpPlugin() override;
  private:
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
   //tag of FEDRawData collection

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDEmulator.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDEmulator.cc
@@ -145,7 +145,7 @@ namespace sistrip{
       ++digi_it;
       
       if (lCount%sistrip::STRIPS_PER_APV == 0 && fillApvsForCM) {
-	if (apvVec.size()) apvs.push_back(apvVec);
+	if (!apvVec.empty()) apvs.push_back(apvVec);
 	apvVec.clear();
 	apvVec.reserve(sistrip::STRIPS_PER_APV);
       }

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDEmulatorModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDEmulatorModule.cc
@@ -60,11 +60,11 @@ namespace sistrip
   public:
 
     explicit FEDEmulatorModule(const edm::ParameterSet&);
-    ~FEDEmulatorModule();
+    ~FEDEmulatorModule() override;
 
   private:
 
-    virtual void produce(edm::Event&, const edm::EventSetup&) override;
+    void produce(edm::Event&, const edm::EventSetup&) override;
     //virtual void endJob();
 
     //tag of spydata collection
@@ -246,7 +246,7 @@ namespace sistrip {
 
       //zero suppress the digis
       fedEmulator_.zeroSuppress(cmSubtrDetSetData, zsDetSetData, algorithms_);
-      if (zsDetSetData.size()) zsData.push_back( zsDetSetData );
+      if (!zsDetSetData.empty()) zsData.push_back( zsDetSetData );
       
     }//loop on input channels
 

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDMonitor.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDMonitor.cc
@@ -62,12 +62,12 @@ class SiStripFEDMonitorPlugin : public DQMEDAnalyzer
 {
  public:
   explicit SiStripFEDMonitorPlugin(const edm::ParameterSet&);
-  ~SiStripFEDMonitorPlugin();
+  ~SiStripFEDMonitorPlugin() override;
  private:
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
 				    const edm::EventSetup& context) override;
-  virtual void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
+  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
 				  const edm::EventSetup& context) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
@@ -150,7 +150,7 @@ SiStripFEDMonitorPlugin::SiStripFEDMonitorPlugin(const edm::ParameterSet& iConfi
   }
   
   //don;t generate debug mesages if debug is disabled
-  std::ostringstream* pDebugStream = (printDebug_>1 ? &debugStream : NULL);
+  std::ostringstream* pDebugStream = (printDebug_>1 ? &debugStream : nullptr);
   
   fedHists_.initialise(iConfig,pDebugStream);
 
@@ -319,7 +319,7 @@ SiStripFEDMonitorPlugin::analyze(const edm::Event& iEvent,
     for (unsigned int iP(0); iP<nParts; ++iP){
       //std::cout << " -- Partition " << iP << std::endl;
       //std::cout << " --- Number of elements in vec = " << lFeMajFrac[iP].size() << std::endl;
-      if (lFeMajFrac[iP].size()==0) continue;
+      if (lFeMajFrac[iP].empty()) continue;
       std::sort(lFeMajFrac[iP].begin(),lFeMajFrac[iP].end(),SiStripFEDMonitorPlugin::pairComparison);
 
       unsigned int lMajorityCounter = 0;
@@ -450,7 +450,7 @@ void SiStripFEDMonitorPlugin::getMajority(const std::vector<std::pair<unsigned i
     }
   }
   //std::cout << " -- Found " << lfedIds.size() << " elements not matching the majority." << std::endl;
-  if (afedIds.size()>0) {
+  if (!afedIds.empty()) {
     std::sort(afedIds.begin(),afedIds.end());
     std::vector<unsigned int>::iterator lIt = std::unique(afedIds.begin(),afedIds.end());
     afedIds.erase(lIt,afedIds.end());

--- a/DQM/SiStripMonitorHardware/src/SiStripShotFilter.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripShotFilter.cc
@@ -55,12 +55,12 @@ class SiStripShotFilter : public edm::EDFilter
  public:
 
   explicit SiStripShotFilter(const edm::ParameterSet&);
-  ~SiStripShotFilter();
+  ~SiStripShotFilter() override;
  private:
 
-  virtual void beginJob() override;
-  virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override;
+  void beginJob() override;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
   //update the cabling if necessary
   void updateCabling(const edm::EventSetup& eventSetup);

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyDigiConverterModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyDigiConverterModule.cc
@@ -38,8 +38,8 @@ namespace sistrip {
   {
   public:
     SpyDigiConverterModule( const edm::ParameterSet& );
-    ~SpyDigiConverterModule();
-    virtual void produce( edm::Event&, const edm::EventSetup& ) override;
+    ~SpyDigiConverterModule() override;
+    void produce( edm::Event&, const edm::EventSetup& ) override;
 
   private:
     const edm::InputTag productLabel_;

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyDisplayModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyDisplayModule.cc
@@ -95,13 +95,13 @@ enum FEDSpyHistogramType {SCOPE_MODE,
 class SiStripSpyDisplayModule : public edm::EDAnalyzer {
   public:
     explicit SiStripSpyDisplayModule(const edm::ParameterSet&);
-    ~SiStripSpyDisplayModule();
+    ~SiStripSpyDisplayModule() override;
 
   private:
-    virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
-    virtual void beginJob() override ;
-    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-    virtual void endJob() override ;
+    void beginRun(const edm::Run&, const edm::EventSetup&) override;
+    void beginJob() override ;
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
+    void endJob() override ;
 
   Bool_t MakeRawDigiHist_(const edm::Handle< edm::DetSetVector<SiStripRawDigi> > & digi_handle,
                             uint32_t specifier,
@@ -263,7 +263,7 @@ SiStripSpyDisplayModule::analyze(const edm::Event& iEvent, const edm::EventSetup
     TFileDirectory evdir = an_dir.mkdir( ev_dir_name.str() );
 
     //if there are no detIds, get them from the comparison digis...
-    if (detIDs_.size()==0) {
+    if (detIDs_.empty()) {
         //get the detIds of the modules in the zero-suppressed comparison
         if (!((inputCompZeroSuppressedDigiLabel_.label()=="") && (inputCompZeroSuppressedDigiLabel_.instance()==""))) {
             edm::Handle< edm::DetSetVector< SiStripDigi > > czs_digis;
@@ -460,7 +460,7 @@ Bool_t SiStripSpyDisplayModule::MakeRawDigiHist_(
     else if (type==POST_COMMON_MODE)       hist = dir.make<TH1S>("PostCommonMode",      ";Strip number;ADC counts / strip",  768, 0, 768);
     else if (type==ZERO_SUPPRESSED_PADDED) hist = dir.make<TH1S>("ZeroSuppressedRaw" ,  ";Strip number;ADC counts / strip",  768, 0, 768);
     else if (type==VR_COMP)                hist = dir.make<TH1S>("VirginRawCom" ,       ";Strip number;ADC counts / strip",  768, 0, 768);
-    else                                  {hist = 0; return false;}
+    else                                  {hist = nullptr; return false;}
 
     // TODO: May need to make this error checking independent when refactoring...
     //std::cout << "| * digis for " << type << " and detID " << specifier;
@@ -492,7 +492,7 @@ Bool_t SiStripSpyDisplayModule::MakeProcessedRawDigiHist_(
     TH1F * hist;
     if (type==NOISE_VALUES) hist = dir.make<TH1F>("NoiseValues",";Strip number;Noise / strip",768, 0, 768);
     else {
-      hist = 0; 
+      hist = nullptr; 
       return false;
     }
 
@@ -527,7 +527,7 @@ Bool_t SiStripSpyDisplayModule::MakeDigiHist_(
     TH1S * hist;
     if      (type==ZERO_SUPPRESSED)        hist = dir.make<TH1S>("ZeroSuppressedDigi",      ";Strip number;ADC counts / strip",  768, 0, 768);
     else if (type==ZERO_SUPPRESSED_COMP)   hist = dir.make<TH1S>("ZeroSuppressedDigiComp",  ";Strip number;ADC counts / strip",  768, 0, 768);
-    else                                  {hist = 0; return false;}
+    else                                  {hist = nullptr; return false;}
     
     // TODO: May need to make this error checking independent when refactoring...
     std::vector< edm::DetSet<SiStripDigi> >::const_iterator digis_it = digi_handle->find( detID );

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
@@ -149,7 +149,7 @@ namespace sistrip {
     std::map<EventKey,SpyEventList>::const_iterator iMatch = eventMatches_.find(eventKey);
     if (iMatch == eventMatches_.end()) {
       LogDebug(mlLabel_) << "No match found for event " << eventId << " with APV address " << uint16_t(apvAddress);
-      return NULL;
+      return nullptr;
     }
     else {
       std::ostringstream ss;
@@ -388,10 +388,10 @@ namespace sistrip {
       totalEventCounters(new std::vector<uint32_t>),
       l1aCounters(new std::vector<uint32_t>),
       apvAddresses(new std::vector<uint32_t>),
-      scopeDigis(theScopeDigisVector ? new edm::DetSetVector<SiStripRawDigi>(*theScopeDigisVector) : NULL),
-      payloadDigis(thePayloadDigisVector ? new edm::DetSetVector<SiStripRawDigi>(*thePayloadDigisVector) : NULL),
-      reorderedDigis(theReorderedDigisVector ? new edm::DetSetVector<SiStripRawDigi>(*theReorderedDigisVector) : NULL),
-      virginRawDigis(theVirginRawDigisVector ? new edm::DetSetVector<SiStripRawDigi>(*theVirginRawDigisVector) : NULL)
+      scopeDigis(theScopeDigisVector ? new edm::DetSetVector<SiStripRawDigi>(*theScopeDigisVector) : nullptr),
+      payloadDigis(thePayloadDigisVector ? new edm::DetSetVector<SiStripRawDigi>(*thePayloadDigisVector) : nullptr),
+      reorderedDigis(theReorderedDigisVector ? new edm::DetSetVector<SiStripRawDigi>(*theReorderedDigisVector) : nullptr),
+      virginRawDigis(theVirginRawDigisVector ? new edm::DetSetVector<SiStripRawDigi>(*theVirginRawDigisVector) : nullptr)
   {
     rawData->swap(theRawData);
     totalEventCounters->swap(theTotalEventCounters);
@@ -412,7 +412,7 @@ namespace sistrip {
   
   SpyEventMatcher::CountersWrapper::CountersWrapper(const Counters* theCounters)
     : pConst(theCounters),
-      p(NULL),
+      p(nullptr),
       deleteP(false)
   {
   }

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
@@ -21,7 +21,6 @@
 #include "FWCore/Utilities/interface/GetPassID.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 #include "DQM/SiStripMonitorHardware/interface/SiStripSpyUtilities.h"
-#include "boost/bind.hpp"
 #include <algorithm>
 #include <limits>
 #include <memory>
@@ -82,8 +81,9 @@ namespace sistrip {
   {
     size_t fileNameHash = 0U;
     //add spy events to the map until there are none left
-    source_->loopOverEvents(*eventPrincipal_,fileNameHash,std::numeric_limits<size_t>::max(),boost::bind(&SpyEventMatcher::addNextEventToMap,this,_1),
-                             nullptr,nullptr,false);
+    source_->loopOverEvents(*eventPrincipal_,fileNameHash,std::numeric_limits<size_t>::max(),
+                            [this](auto const& iE, auto const&){ this->addNextEventToMap(iE); },
+                            nullptr,nullptr,false);
     //debug
     std::ostringstream ss;
     ss << "Events with possible matches (eventID,apvAddress): ";
@@ -228,8 +228,8 @@ namespace sistrip {
     size_t fileNameHash = 0U;
     FEDRawDataCollection outputRawData;
     MatchingOutput mo(outputRawData);
-    source_->loopSpecified(*eventPrincipal_,fileNameHash,matchingEvents->begin(),matchingEvents->end(),boost::bind(&SpyEventMatcher::getCollections,this,_1,
-                                                       eventId,apvAddress,boost::cref(cabling),boost::ref(mo)));
+    source_->loopSpecified(*eventPrincipal_,fileNameHash,matchingEvents->begin(),matchingEvents->end(),
+                           [&](auto const& iE, auto const&){ this->getCollections(iE,eventId,apvAddress,cabling,mo); });
     collectionsToCreate = SpyDataCollections(mo.outputRawData_,mo.outputTotalEventCounters_,mo.outputL1ACounters_,mo.outputAPVAddresses_,
                                    mo.outputScopeDigisVector_.get(),mo.outputPayloadDigisVector_.get(),
                                    mo.outputReorderedDigisVector_.get(),mo.outputVirginRawDigisVector_.get());

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
@@ -82,7 +82,8 @@ namespace sistrip {
   {
     size_t fileNameHash = 0U;
     //add spy events to the map until there are none left
-    source_->loopOverEvents(*eventPrincipal_,fileNameHash,std::numeric_limits<size_t>::max(),boost::bind(&SpyEventMatcher::addNextEventToMap,this,_1));
+    source_->loopOverEvents(*eventPrincipal_,fileNameHash,std::numeric_limits<size_t>::max(),boost::bind(&SpyEventMatcher::addNextEventToMap,this,_1),
+                             nullptr,nullptr,false);
     //debug
     std::ostringstream ss;
     ss << "Events with possible matches (eventID,apvAddress): ";

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcherModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcherModule.cc
@@ -31,9 +31,9 @@ namespace sistrip {
   {
     public:
       SpyEventMatcherModule(const edm::ParameterSet& config);
-      virtual ~SpyEventMatcherModule();
-      virtual void beginJob() override;
-      virtual bool filter(edm::Event& event, const edm::EventSetup& eventSetup) override;  
+      ~SpyEventMatcherModule() override;
+      void beginJob() override;
+      bool filter(edm::Event& event, const edm::EventSetup& eventSetup) override;  
     private:
       void findL1IDandAPVAddress(const edm::Event& event, const SiStripFedCabling& cabling, uint32_t& l1ID, uint8_t& apvAddress) const;
       void copyData(const uint32_t eventId, const uint8_t apvAddress, const SpyEventMatcher::SpyEventList* matches, edm::Event& event,

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventSummaryProducer.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventSummaryProducer.cc
@@ -35,8 +35,8 @@ namespace sistrip {
   {
     public:
       SpyEventSummaryProducer(const edm::ParameterSet& config);
-      virtual ~SpyEventSummaryProducer();
-      virtual void produce(edm::Event& event, const edm::EventSetup&) override;
+      ~SpyEventSummaryProducer() override;
+      void produce(edm::Event& event, const edm::EventSetup&) override;
     private:
       void warnAboutUnsupportedRunType();
       static const char* messageLabel_;

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyExtractRunModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyExtractRunModule.cc
@@ -37,13 +37,13 @@ namespace sistrip {
   public:
 
     explicit SpyExtractRunModule(const edm::ParameterSet&);
-    ~SpyExtractRunModule();
+    ~SpyExtractRunModule() override;
 
   private:
 
-    virtual void beginJob() override;
-    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-    virtual void endJob() override;
+    void beginJob() override;
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
+    void endJob() override;
 
     //check when the current run changes
     const bool updateRun(const uint32_t aRun);

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyIdentifyRuns.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyIdentifyRuns.cc
@@ -40,13 +40,13 @@ namespace sistrip {
   public:
 
     explicit SpyIdentifyRunsModule(const edm::ParameterSet&);
-    ~SpyIdentifyRunsModule();
+    ~SpyIdentifyRunsModule() override;
 
   private:
 
-    virtual void beginJob() override;
-    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-    virtual void endJob() override;
+    void beginJob() override;
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
+    void endJob() override;
 
     void writeRunInFile(const unsigned int aRunNumber);
  

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyMonitorModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyMonitorModule.cc
@@ -54,11 +54,11 @@ class SiStripSpyMonitorModule : public DQMEDAnalyzer
 
 
   explicit SiStripSpyMonitorModule(const edm::ParameterSet&);
-  ~SiStripSpyMonitorModule();
+  ~SiStripSpyMonitorModule() override;
 
  private:
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void dqmBeginRun(const edm::Run& , const edm::EventSetup& ) override;
 

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyUnpackerModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyUnpackerModule.cc
@@ -58,8 +58,8 @@ namespace sistrip {
     {
       public:
         SpyUnpackerModule( const edm::ParameterSet& );
-        virtual ~SpyUnpackerModule();
-        virtual void produce( edm::Event&, const edm::EventSetup& ) override;
+        ~SpyUnpackerModule() override;
+        void produce( edm::Event&, const edm::EventSetup& ) override;
       private:
         static const char* msgLb_;
 
@@ -93,11 +93,11 @@ namespace sistrip {
     allowIncompleteEvents_(pset.getParameter<bool>("AllowIncompleteEvents")),
     storeCounters_(pset.getParameter<bool>("StoreCounters")),
     storeScopeRawDigis_(pset.getParameter<bool>("StoreScopeRawDigis")),
-    unpacker_(NULL)
+    unpacker_(nullptr)
   {
     productToken_ = consumes<FEDRawDataCollection>(productLabel_);
 
-    if ((fed_ids_.size()==0)) {
+    if ((fed_ids_.empty())) {
       LogInfo(msgLb_) << "No FED IDs specified, so will try to unpack all FEDs with data" << std::endl;
       fed_ids_.reserve(FEDNumbering::MAXSiStripFEDID-FEDNumbering::MINSiStripFEDID+1);
       for ( uint32_t ifed = FEDNumbering::MINSiStripFEDID; ifed <= FEDNumbering::MAXSiStripFEDID; ifed++ ) {

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyUtilities.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyUtilities.cc
@@ -19,22 +19,22 @@ using edm::LogInfo;
 
 namespace sistrip {
   SpyUtilities::SpyUtilities() :
-    cabling_(0),
+    cabling_(nullptr),
     cacheId_(0),
-    detCabling_(0),
+    detCabling_(nullptr),
     cacheIdDet_(0),
     pedsCacheId_(0),
-    pedsHandle_(0),
+    pedsHandle_(nullptr),
     noiseCacheId_(0),
-    noiseHandle_(0)
+    noiseHandle_(nullptr)
   {
     
   }
   
   SpyUtilities::~SpyUtilities()
   {
-    if ( cabling_ ) cabling_ = 0;
-    if ( detCabling_ ) detCabling_ = 0;
+    if ( cabling_ ) cabling_ = nullptr;
+    if ( detCabling_ ) detCabling_ = nullptr;
   }
 
   const SiStripFedCabling*  SpyUtilities::getCabling( const edm::EventSetup& setup )
@@ -153,7 +153,7 @@ namespace sistrip {
       lFrame.baseline += val;
     }
 
-    if (channelDigis.size()>0) lFrame.baseline = lFrame.baseline/channelDigis.size();
+    if (!channelDigis.empty()) lFrame.baseline = lFrame.baseline/channelDigis.size();
     lFrame.digitalLow = min;
     lFrame.digitalHigh = max;
 

--- a/FWCore/Sources/interface/ProducerSourceBase.h
+++ b/FWCore/Sources/interface/ProducerSourceBase.h
@@ -20,7 +20,7 @@ namespace edm {
   class ProducerSourceBase : public InputSource {
   public:
     explicit ProducerSourceBase(ParameterSet const& pset, InputSourceDescription const& desc, bool realData);
-    virtual ~ProducerSourceBase() noexcept(false);
+    ~ProducerSourceBase() noexcept(false) override;
 
     unsigned int numberEventsInRun() const {return numberEventsInRun_;} 
     unsigned int numberEventsInLumi() const {return numberEventsInLumi_;} 
@@ -39,22 +39,22 @@ namespace edm {
   protected:
 
   private:
-    virtual ItemType getNextItemType() override final;
+    ItemType getNextItemType() final;
     virtual void initialize(EventID& id, TimeValue_t& time, TimeValue_t& interval);
     virtual bool setRunAndEventInfo(EventID& id, TimeValue_t& time, EventAuxiliary::ExperimentType& etype) = 0;
     virtual void produce(Event& e) = 0;
     virtual bool noFiles() const;
     virtual size_t fileIndex() const;
-    virtual void beginJob() override;
-    virtual void beginRun(Run&) override;
-    virtual void endRun(Run&) override;
-    virtual void beginLuminosityBlock(LuminosityBlock&) override;
-    virtual void endLuminosityBlock(LuminosityBlock&) override;
-    virtual void readEvent_(EventPrincipal& eventPrincipal) override;
-    virtual std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
-    virtual std::shared_ptr<RunAuxiliary> readRunAuxiliary_() override;
-    virtual void skip(int offset) override;
-    virtual void rewind_() override;
+    void beginJob() override;
+    void beginRun(Run&) override;
+    void endRun(Run&) override;
+    void beginLuminosityBlock(LuminosityBlock&) override;
+    void endLuminosityBlock(LuminosityBlock&) override;
+    void readEvent_(EventPrincipal& eventPrincipal) override;
+    std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
+    std::shared_ptr<RunAuxiliary> readRunAuxiliary_() override;
+    void skip(int offset) override;
+    void rewind_() override;
 
     void advanceToNext(EventID& eventID, TimeValue_t& time);
     void retreatToPrevious(EventID& eventID, TimeValue_t& time);

--- a/FWCore/Sources/interface/ProducerSourceFromFiles.h
+++ b/FWCore/Sources/interface/ProducerSourceFromFiles.h
@@ -17,13 +17,13 @@ namespace edm {
   class ProducerSourceFromFiles : public ProducerSourceBase, private FromFiles {
   public:
     ProducerSourceFromFiles(ParameterSet const& pset, InputSourceDescription const& desc, bool realData);
-    virtual ~ProducerSourceFromFiles();
+    ~ProducerSourceFromFiles() override;
 
     using FromFiles::logicalFileNames;
     using FromFiles::fileNames;
     using FromFiles::catalog;
 
-    virtual bool noFiles() const override {
+    bool noFiles() const override {
       return fileNames().empty();
     }
     

--- a/FWCore/Sources/interface/RawInputSource.h
+++ b/FWCore/Sources/interface/RawInputSource.h
@@ -17,7 +17,7 @@ namespace edm {
   class RawInputSource : public InputSource {
   public:
     explicit RawInputSource(ParameterSet const& pset, InputSourceDescription const& desc);
-    virtual ~RawInputSource();
+    ~RawInputSource() override;
     static void fillDescription(ParameterSetDescription& description);
 
   protected:
@@ -27,13 +27,13 @@ namespace edm {
     void setInputFileTransitionsEachEvent() {inputFileTransitionsEachEvent_ = true;}
 
   private:
-    virtual void readEvent_(EventPrincipal& eventPrincipal) override;
-    virtual std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
-    virtual std::shared_ptr<RunAuxiliary> readRunAuxiliary_() override;
+    void readEvent_(EventPrincipal& eventPrincipal) override;
+    std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
+    std::shared_ptr<RunAuxiliary> readRunAuxiliary_() override;
     virtual void reset_();
-    virtual void rewind_() override;
-    virtual ItemType getNextItemType() override;
-    virtual void closeFile_() override final;
+    void rewind_() override;
+    ItemType getNextItemType() override;
+    void closeFile_() final;
     virtual void genuineCloseFile() { }
 
     bool inputFileTransitionsEachEvent_;

--- a/FWCore/Sources/interface/RawInputSourceFromFiles.h
+++ b/FWCore/Sources/interface/RawInputSourceFromFiles.h
@@ -17,7 +17,7 @@ namespace edm {
   class RawInputSourceFromFiles : public RawInputSource, private FromFiles {
   public:
     RawInputSourceFromFiles(ParameterSet const& pset, InputSourceDescription const& desc);
-    virtual ~RawInputSourceFromFiles();
+    ~RawInputSourceFromFiles() override;
 
     using FromFiles::logicalFileNames;
     using FromFiles::fileNames;

--- a/FWCore/Sources/interface/VectorInputSource.h
+++ b/FWCore/Sources/interface/VectorInputSource.h
@@ -30,7 +30,7 @@ namespace edm {
     virtual ~VectorInputSource();
 
     template<typename T>
-    size_t loopOverEvents(EventPrincipal& cache, size_t& fileNameHash, size_t number, T eventOperator, CLHEP::HepRandomEngine* = nullptr, EventID const* id = nullptr);
+    size_t loopOverEvents(EventPrincipal& cache, size_t& fileNameHash, size_t number, T eventOperator, CLHEP::HepRandomEngine* = nullptr, EventID const* id = nullptr, bool recycleFiles = true);
 
     template<typename T, typename Iterator>
     size_t loopSpecified(EventPrincipal& cache, size_t& fileNameHash, Iterator const& begin, Iterator const& end, T eventOperator);
@@ -54,7 +54,7 @@ namespace edm {
     void clearEventPrincipal(EventPrincipal& cache);
 
   private:
-    virtual bool readOneEvent(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id) = 0;
+    virtual bool readOneEvent(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id, bool recycleFiles) = 0;
     virtual void readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& event) = 0;
     void readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, EventID const& event) {
       SecondaryEventIDAndFileInfo info(event, fileNameHash);
@@ -70,11 +70,11 @@ namespace edm {
   };
 
   template<typename T>
-  size_t VectorInputSource::loopOverEvents(EventPrincipal& cache, size_t& fileNameHash, size_t number, T eventOperator, CLHEP::HepRandomEngine* engine, EventID const* id) {
+  size_t VectorInputSource::loopOverEvents(EventPrincipal& cache, size_t& fileNameHash, size_t number, T eventOperator, CLHEP::HepRandomEngine* engine, EventID const* id, bool recycleFiles) {
     size_t i = 0U;
     for(; i < number; ++i) {
       clearEventPrincipal(cache);
-      bool found = readOneEvent(cache, fileNameHash, engine, id);
+      bool found = readOneEvent(cache, fileNameHash, engine, id, recycleFiles);
       if(!found) break;
       eventOperator(cache, fileNameHash);
     }

--- a/IOPool/Input/src/DuplicateChecker.cc
+++ b/IOPool/Input/src/DuplicateChecker.cc
@@ -61,7 +61,7 @@ namespace edm {
       // Compares the current IndexIntoFile to all the previous ones and saves any duplicates.
       // One unintended thing, it also saves the duplicate runs and lumis.
       for(std::vector<std::shared_ptr<IndexIntoFile> >::size_type i = 0; i < currentIndexIntoFile; ++i) {
-        if (indexesIntoFiles[i].get() != 0) {
+        if (indexesIntoFiles[i].get() != nullptr) {
 
           indexIntoFile.set_intersection(*indexesIntoFiles[i], relevantPreviousEvents_);
         }

--- a/IOPool/Input/src/EmbeddedRootSource.cc
+++ b/IOPool/Input/src/EmbeddedRootSource.cc
@@ -54,8 +54,8 @@ namespace edm {
   }
 
   bool
-  EmbeddedRootSource::readOneEvent(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine* engine, EventID const* id) {
-    return fileSequence_->readOneEvent(cache, fileNameHash, engine, id);
+  EmbeddedRootSource::readOneEvent(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine* engine, EventID const* id, bool recycleFiles) {
+    return fileSequence_->readOneEvent(cache, fileNameHash, engine, id, recycleFiles);
   }
 
   void

--- a/IOPool/Input/src/EmbeddedRootSource.h
+++ b/IOPool/Input/src/EmbeddedRootSource.h
@@ -52,7 +52,7 @@ namespace edm {
     virtual void closeFile_();
     void beginJob() override;
     void endJob() override;
-    bool readOneEvent(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id) override;
+    bool readOneEvent(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id, bool recycleFiles) override;
     void readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& id) override;
     void dropUnwantedBranches_(std::vector<std::string> const& wantedBranches) override;
 

--- a/IOPool/Input/src/EmbeddedRootSource.h
+++ b/IOPool/Input/src/EmbeddedRootSource.h
@@ -34,7 +34,7 @@ namespace edm {
   class EmbeddedRootSource : public VectorInputSource {
   public:
     explicit EmbeddedRootSource(ParameterSet const& pset, VectorInputSourceDescription const& desc);
-    virtual ~EmbeddedRootSource();
+    ~EmbeddedRootSource() override;
     using VectorInputSource::processHistoryRegistryForUpdate;
     using VectorInputSource::productRegistryUpdate;
 
@@ -50,11 +50,11 @@ namespace edm {
 
   private:
     virtual void closeFile_();
-    virtual void beginJob() override;
-    virtual void endJob() override;
-    virtual bool readOneEvent(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id) override;
-    virtual void readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& id) override;
-    virtual void dropUnwantedBranches_(std::vector<std::string> const& wantedBranches) override;
+    void beginJob() override;
+    void endJob() override;
+    bool readOneEvent(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id) override;
+    void readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& id) override;
+    void dropUnwantedBranches_(std::vector<std::string> const& wantedBranches) override;
 
     RootServiceChecker rootServiceChecker_;
 

--- a/IOPool/Input/src/InputFile.h
+++ b/IOPool/Input/src/InputFile.h
@@ -45,7 +45,7 @@ namespace edm {
 
     TObject* Get(char const* name) {return file_->Get(name);}
     TFileCacheRead* GetCacheRead() const {return file_->GetCacheRead();}
-    void SetCacheRead(TFileCacheRead* tfcr) {file_->SetCacheRead(tfcr, NULL, TFile::kDoNotDisconnect);}
+    void SetCacheRead(TFileCacheRead* tfcr) {file_->SetCacheRead(tfcr, nullptr, TFile::kDoNotDisconnect);}
     void logFileAction(char const* msg, char const* fileName) const;
   private:
     edm::propagate_const<std::unique_ptr<TFile>> file_;

--- a/IOPool/Input/src/PoolSource.h
+++ b/IOPool/Input/src/PoolSource.h
@@ -32,7 +32,7 @@ namespace edm {
   class PoolSource : public InputSource {
   public:
     explicit PoolSource(ParameterSet const& pset, InputSourceDescription const& desc);
-    virtual ~PoolSource();
+    ~PoolSource() override;
     using InputSource::processHistoryRegistryForUpdate;
     using InputSource::productRegistryUpdate;
 
@@ -49,22 +49,22 @@ namespace edm {
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
   private:
-    virtual void readEvent_(EventPrincipal& eventPrincipal) override;
-    virtual std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
-    virtual void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal) override;
-    virtual std::shared_ptr<RunAuxiliary> readRunAuxiliary_() override;
-    virtual void readRun_(RunPrincipal& runPrincipal) override;
-    virtual std::unique_ptr<FileBlock> readFile_() override;
-    virtual void closeFile_() override;
-    virtual void endJob() override;
-    virtual ItemType getNextItemType() override;
-    virtual bool readIt(EventID const& id, EventPrincipal& eventPrincipal, StreamContext& streamContext) override;
-    virtual void skip(int offset) override;
-    virtual bool goToEvent_(EventID const& eventID) override;
-    virtual void rewind_() override;
-    virtual bool randomAccess_() const override;
-    virtual ProcessingController::ForwardState forwardState_() const override;
-    virtual ProcessingController::ReverseState reverseState_() const override;
+    void readEvent_(EventPrincipal& eventPrincipal) override;
+    std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
+    void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal) override;
+    std::shared_ptr<RunAuxiliary> readRunAuxiliary_() override;
+    void readRun_(RunPrincipal& runPrincipal) override;
+    std::unique_ptr<FileBlock> readFile_() override;
+    void closeFile_() override;
+    void endJob() override;
+    ItemType getNextItemType() override;
+    bool readIt(EventID const& id, EventPrincipal& eventPrincipal, StreamContext& streamContext) override;
+    void skip(int offset) override;
+    bool goToEvent_(EventID const& eventID) override;
+    void rewind_() override;
+    bool randomAccess_() const override;
+    ProcessingController::ForwardState forwardState_() const override;
+    ProcessingController::ReverseState reverseState_() const override;
 
     std::pair<SharedResourcesAcquirer*,std::recursive_mutex*> resourceSharedWithDelayedReader_() override;
     

--- a/IOPool/Input/src/RootDelayedReader.h
+++ b/IOPool/Input/src/RootDelayedReader.h
@@ -40,15 +40,15 @@ namespace edm {
       std::shared_ptr<InputFile> filePtr,
       InputType inputType);
 
-    virtual ~RootDelayedReader();
+    ~RootDelayedReader() override;
 
     RootDelayedReader(RootDelayedReader const&) = delete; // Disallow copying and moving
     RootDelayedReader& operator=(RootDelayedReader const&) = delete; // Disallow copying and moving
 
-    virtual signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadFromSourceSignal() const override final {
+    signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadFromSourceSignal() const final {
       return preEventReadFromSourceSignal_;
     }
-    virtual signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadFromSourceSignal() const override final {
+    signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadFromSourceSignal() const final {
       return postEventReadFromSourceSignal_;
     }
 
@@ -59,9 +59,9 @@ namespace edm {
     }
 
   private:
-    virtual std::unique_ptr<WrapperBase> getProduct_(BranchKey const& k, EDProductGetter const* ep) override;
-    virtual void mergeReaders_(DelayedReader* other) override {nextReader_ = other;}
-    virtual void reset_() override {nextReader_ = nullptr;}
+    std::unique_ptr<WrapperBase> getProduct_(BranchKey const& k, EDProductGetter const* ep) override;
+    void mergeReaders_(DelayedReader* other) override {nextReader_ = other;}
+    void reset_() override {nextReader_ = nullptr;}
     std::pair<SharedResourcesAcquirer*, std::recursive_mutex*> sharedResources_() const override;
 
     BranchMap const& branches() const {return tree_.branches();}

--- a/IOPool/Input/src/RootEmbeddedFileSequence.cc
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.cc
@@ -31,6 +31,7 @@ namespace edm {
     input_(input),
     orderedProcessHistoryIDs_(),
     sequential_(pset.getUntrackedParameter<bool>("sequential", false)),
+    recycle_(pset.getUntrackedParameter<bool>("recycleFiles", true)),
     sameLumiBlock_(pset.getUntrackedParameter<bool>("sameLumiBlock", false)),
     fptr_(nullptr),
     eventsRemainingInFile_(0),
@@ -171,7 +172,11 @@ namespace edm {
     if(!found) {
       setAtNextFile();
       if(noMoreFiles()) {
-        setAtFirstFile();
+        if (recycle_) {
+          setAtFirstFile();          
+        } else {
+          return false;
+        }
       }
       initFile(false);
       assert(rootFile());
@@ -325,6 +330,9 @@ namespace edm {
     desc.addUntracked<bool>("sequential", false)
         ->setComment("True: loopEvents() reads events sequentially from beginning of first file.\n"
                      "False: loopEvents() first reads events beginning at random event. New files also chosen randomly");
+    desc.addUntracked<bool>("recycleFiles", true)
+        ->setComment("True: readOneSequential() loops back to the first file at the end of the last file.\n"
+                     "False: readOneSequential() returns false at the end of the last file");
     desc.addUntracked<bool>("sameLumiBlock", false)
         ->setComment("True: loopEvents() reads events only in same lumi as the specified event.\n"
                      "False: loopEvents() reads events regardless of lumi.");

--- a/IOPool/Input/src/RootEmbeddedFileSequence.h
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.h
@@ -34,12 +34,12 @@ namespace edm {
     explicit RootEmbeddedFileSequence(ParameterSet const& pset,
                                    EmbeddedRootSource& input,
                                    InputFileCatalog const& catalog);
-    virtual ~RootEmbeddedFileSequence();
+    ~RootEmbeddedFileSequence() override;
 
     RootEmbeddedFileSequence(RootEmbeddedFileSequence const&) = delete; // Disallow copying and moving
     RootEmbeddedFileSequence& operator=(RootEmbeddedFileSequence const&) = delete; // Disallow copying and moving
 
-    virtual void closeFile_() override;
+    void closeFile_() override;
     void endJob();
     void skipEntries(unsigned int offset);
     bool readOneEvent(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id);
@@ -51,8 +51,8 @@ namespace edm {
 
     static void fillDescription(ParameterSetDescription & desc);
   private:
-    virtual void initFile_(bool skipBadFiles) override;
-    virtual RootFileSharedPtr makeRootFile(std::shared_ptr<InputFile> filePtr) override; 
+    void initFile_(bool skipBadFiles) override;
+    RootFileSharedPtr makeRootFile(std::shared_ptr<InputFile> filePtr) override; 
 
     EmbeddedRootSource& input_;
 

--- a/IOPool/Input/src/RootEmbeddedFileSequence.h
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.h
@@ -42,11 +42,11 @@ namespace edm {
     void closeFile_() override;
     void endJob();
     void skipEntries(unsigned int offset);
-    bool readOneEvent(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id);
-    bool readOneRandom(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const*);
-    bool readOneRandomWithID(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id);
-    bool readOneSequential(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const*);
-    bool readOneSequentialWithID(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id);
+    bool readOneEvent(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id, bool recycleFiles);
+    bool readOneRandom(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const*, bool);
+    bool readOneRandomWithID(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id, bool);
+    bool readOneSequential(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const*, bool recycleFiles);
+    bool readOneSequentialWithID(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id, bool);
     void readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& id);
 
     static void fillDescription(ParameterSetDescription & desc);
@@ -59,9 +59,8 @@ namespace edm {
     std::vector<ProcessHistoryID> orderedProcessHistoryIDs_;
 
     bool sequential_;
-    bool recycle_;
     bool sameLumiBlock_;
-    bool (RootEmbeddedFileSequence::* fptr_)(EventPrincipal&, size_t&, CLHEP::HepRandomEngine*, EventID const*);
+    bool (RootEmbeddedFileSequence::* fptr_)(EventPrincipal&, size_t&, CLHEP::HepRandomEngine*, EventID const*, bool);
     int eventsRemainingInFile_;
     int initialNumberOfEventsToSkip_;
     unsigned int treeCacheSize_;

--- a/IOPool/Input/src/RootEmbeddedFileSequence.h
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.h
@@ -59,6 +59,7 @@ namespace edm {
     std::vector<ProcessHistoryID> orderedProcessHistoryIDs_;
 
     bool sequential_;
+    bool recycle_;
     bool sameLumiBlock_;
     bool (RootEmbeddedFileSequence::* fptr_)(EventPrincipal&, size_t&, CLHEP::HepRandomEngine*, EventID const*);
     int eventsRemainingInFile_;

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -67,23 +67,23 @@ namespace edm {
   // Algorithm classes for making ProvenanceReader:
   class MakeDummyProvenanceReader : public MakeProvenanceReader {
   public:
-    virtual std::unique_ptr<ProvenanceReaderBase> makeReader(RootTree& eventTree, DaqProvenanceHelper const* daqProvenanceHelper) const override;
+    std::unique_ptr<ProvenanceReaderBase> makeReader(RootTree& eventTree, DaqProvenanceHelper const* daqProvenanceHelper) const override;
   };
   class MakeOldProvenanceReader : public MakeProvenanceReader {
   public:
     MakeOldProvenanceReader(std::unique_ptr<EntryDescriptionMap>&& entryDescriptionMap) : MakeProvenanceReader(), entryDescriptionMap_(std::move(entryDescriptionMap)) {}
-    virtual std::unique_ptr<ProvenanceReaderBase> makeReader(RootTree& eventTree, DaqProvenanceHelper const* daqProvenanceHelper) const override;
+    std::unique_ptr<ProvenanceReaderBase> makeReader(RootTree& eventTree, DaqProvenanceHelper const* daqProvenanceHelper) const override;
   private:
     edm::propagate_const<std::unique_ptr<EntryDescriptionMap>> entryDescriptionMap_;
   };
   class MakeFullProvenanceReader : public MakeProvenanceReader {
   public:
-    virtual std::unique_ptr<ProvenanceReaderBase> makeReader(RootTree& eventTree, DaqProvenanceHelper const* daqProvenanceHelper) const override;
+    std::unique_ptr<ProvenanceReaderBase> makeReader(RootTree& eventTree, DaqProvenanceHelper const* daqProvenanceHelper) const override;
   };
   class MakeReducedProvenanceReader : public MakeProvenanceReader {
   public:
     MakeReducedProvenanceReader(std::vector<ParentageID> const& parentageIDLookup) : parentageIDLookup_(parentageIDLookup) {}
-    virtual std::unique_ptr<ProvenanceReaderBase> makeReader(RootTree& eventTree, DaqProvenanceHelper const* daqProvenanceHelper) const override;
+    std::unique_ptr<ProvenanceReaderBase> makeReader(RootTree& eventTree, DaqProvenanceHelper const* daqProvenanceHelper) const override;
   private:
     std::vector<ParentageID> const& parentageIDLookup_;
   };
@@ -110,8 +110,8 @@ namespace edm {
   class RootFileEventFinder : public IndexIntoFile::EventFinder {
   public:
     explicit RootFileEventFinder(RootTree& eventTree) : eventTree_(eventTree) {}
-    virtual ~RootFileEventFinder() {}
-    virtual
+    ~RootFileEventFinder() override {}
+    
     EventNumber_t getEventNumberOfEntry(roottree::EntryNumber entry) const override {
       roottree::EntryNumber saveEntry = eventTree_.entryNumber();
       eventTree_.setEntryNumber(entry);
@@ -274,7 +274,7 @@ namespace edm {
         psetTree->GetEntry(i);
         psetMap.insert(idToBlob);
       }
-      filePtr_->SetCacheRead(0);
+      filePtr_->SetCacheRead(nullptr);
     }
 
     // backward compatibility
@@ -324,9 +324,9 @@ namespace edm {
 
     if(metaDataTree->FindBranch(poolNames::moduleDescriptionMapBranchName().c_str()) != nullptr) {
       if(metaDataTree->GetBranch(poolNames::moduleDescriptionMapBranchName().c_str())->GetSplitLevel() != 0) {
-        metaDataTree->SetBranchStatus((poolNames::moduleDescriptionMapBranchName() + ".*").c_str(), 0);
+        metaDataTree->SetBranchStatus((poolNames::moduleDescriptionMapBranchName() + ".*").c_str(), false);
       } else {
-        metaDataTree->SetBranchStatus(poolNames::moduleDescriptionMapBranchName().c_str(), 0);
+        metaDataTree->SetBranchStatus(poolNames::moduleDescriptionMapBranchName().c_str(), false);
       }
     }
 
@@ -1833,9 +1833,9 @@ namespace edm {
   public:
     ReducedProvenanceReader(RootTree* iRootTree, std::vector<ParentageID> const& iParentageIDLookup, DaqProvenanceHelper const* daqProvenanceHelper);
 
-    virtual std::set<ProductProvenance> readProvenance(unsigned int) const override;
+    std::set<ProductProvenance> readProvenance(unsigned int) const override;
 private:
-    virtual void readProvenanceAsync(WaitingTask* task,
+    void readProvenanceAsync(WaitingTask* task,
                                      ModuleCallingContext const* moduleCallingContext,
                                      unsigned int transitionIndex,
                                      std::atomic<const std::set<ProductProvenance>*>& writeTo
@@ -1966,10 +1966,10 @@ private:
   class FullProvenanceReader : public ProvenanceReaderBase {
   public:
     explicit FullProvenanceReader(RootTree* rootTree, DaqProvenanceHelper const* daqProvenanceHelper);
-    virtual ~FullProvenanceReader() {}
-    virtual std::set<ProductProvenance> readProvenance(unsigned int transitionIndex) const override;
+    ~FullProvenanceReader() override {}
+    std::set<ProductProvenance> readProvenance(unsigned int transitionIndex) const override;
   private:
-    virtual void readProvenanceAsync(WaitingTask* task,
+    void readProvenanceAsync(WaitingTask* task,
                                      ModuleCallingContext const* moduleCallingContext,
                                      unsigned int transitionIndex,
                                      std::atomic<const std::set<ProductProvenance>*>& writeTo
@@ -2034,10 +2034,10 @@ private:
   class OldProvenanceReader : public ProvenanceReaderBase {
   public:
     explicit OldProvenanceReader(RootTree* rootTree, EntryDescriptionMap const& theMap, DaqProvenanceHelper const* daqProvenanceHelper);
-    virtual ~OldProvenanceReader() {}
-    virtual std::set<ProductProvenance> readProvenance(unsigned int transitionIndex) const override;
+    ~OldProvenanceReader() override {}
+    std::set<ProductProvenance> readProvenance(unsigned int transitionIndex) const override;
   private:
-    virtual void readProvenanceAsync(WaitingTask* task,
+    void readProvenanceAsync(WaitingTask* task,
                                      ModuleCallingContext const* moduleCallingContext,
                                      unsigned int transitionIndex,
                                      std::atomic<const std::set<ProductProvenance>*>& writeTo
@@ -2106,10 +2106,10 @@ private:
   class DummyProvenanceReader : public ProvenanceReaderBase {
   public:
     DummyProvenanceReader();
-    virtual ~DummyProvenanceReader() {}
+    ~DummyProvenanceReader() override {}
   private:
-    virtual std::set<ProductProvenance> readProvenance(unsigned int) const override;
-    virtual void readProvenanceAsync(WaitingTask* task,
+    std::set<ProductProvenance> readProvenance(unsigned int) const override;
+    void readProvenanceAsync(WaitingTask* task,
                                      ModuleCallingContext const* moduleCallingContext,
                                      unsigned int transitionIndex,
                                      std::atomic<const std::set<ProductProvenance>*>& writeTo

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -177,7 +177,7 @@ namespace edm {
     int whyNotFastClonable() const {return whyNotFastClonable_;}
     std::array<bool, NumBranchTypes> const& hasNewlyDroppedBranch() const {return hasNewlyDroppedBranch_;}
     bool branchListIndexesUnchanged() const {return branchListIndexesUnchanged_;}
-    bool modifiedIDs() const {return daqProvenanceHelper_.get() != 0;}
+    bool modifiedIDs() const {return daqProvenanceHelper_.get() != nullptr;}
     std::unique_ptr<FileBlock> createFileBlock() const;
     bool setEntryAtItem(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) {
       return (event != 0) ? setEntryAtEvent(run, lumi, event) : (lumi ? setEntryAtLumi(run, lumi) : setEntryAtRun(run));

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -274,7 +274,7 @@ namespace edm {
           std::ostringstream out;
           out << "Input file " << fileName() << " could not be opened.\n";
           out << "Fallback Input file " << fallbackFileName() << " also could not be opened.";
-          if (originalInfo.size()) {
+          if (!originalInfo.empty()) {
             out << std::endl << "Original exception info is above; fallback exception info is below.";
             ex.addAdditionalInfo(out.str());
             for (auto const & s : originalInfo) {

--- a/IOPool/Input/src/RootPrimaryFileSequence.h
+++ b/IOPool/Input/src/RootPrimaryFileSequence.h
@@ -36,13 +36,13 @@ namespace edm {
     explicit RootPrimaryFileSequence(ParameterSet const& pset,
                                    PoolSource& input,
                                    InputFileCatalog const& catalog);
-    virtual ~RootPrimaryFileSequence();
+    ~RootPrimaryFileSequence() override;
 
     RootPrimaryFileSequence(RootPrimaryFileSequence const&) = delete; // Disallow copying and moving
     RootPrimaryFileSequence& operator=(RootPrimaryFileSequence const&) = delete; // Disallow copying and moving
 
     std::unique_ptr<FileBlock> readFile_();
-    virtual void closeFile_() override;
+    void closeFile_() override;
     void endJob();
     InputSource::ItemType getNextItemType(RunNumber_t& run, LuminosityBlockNumber_t& lumi, EventNumber_t& event);
     bool skipEvents(int offset);
@@ -52,8 +52,8 @@ namespace edm {
     ProcessingController::ForwardState forwardState() const;
     ProcessingController::ReverseState reverseState() const;
   private:
-    virtual void initFile_(bool skipBadFiles) override;
-    virtual RootFileSharedPtr makeRootFile(std::shared_ptr<InputFile> filePtr) override; 
+    void initFile_(bool skipBadFiles) override;
+    RootFileSharedPtr makeRootFile(std::shared_ptr<InputFile> filePtr) override; 
     bool nextFile();
     bool previousFile();
     void rewindFile();

--- a/IOPool/Input/src/RootSecondaryFileSequence.h
+++ b/IOPool/Input/src/RootSecondaryFileSequence.h
@@ -30,17 +30,17 @@ namespace edm {
     explicit RootSecondaryFileSequence(ParameterSet const& pset,
                                    PoolSource& input,
                                    InputFileCatalog const& catalog);
-    virtual ~RootSecondaryFileSequence();
+    ~RootSecondaryFileSequence() override;
 
     RootSecondaryFileSequence(RootSecondaryFileSequence const&) = delete; // Disallow copying and moving
     RootSecondaryFileSequence& operator=(RootSecondaryFileSequence const&) = delete; // Disallow copying and moving
 
-    virtual void closeFile_() override;
+    void closeFile_() override;
     void endJob();
     void initAssociationsFromSecondary(std::set<BranchID> const&);
   private:
-    virtual void initFile_(bool skipBadFiles) override;
-    virtual RootFileSharedPtr makeRootFile(std::shared_ptr<InputFile> filePtr) override; 
+    void initFile_(bool skipBadFiles) override;
+    RootFileSharedPtr makeRootFile(std::shared_ptr<InputFile> filePtr) override; 
 
     PoolSource& input_;
     std::vector<BranchID> associationsFromSecondary_;

--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -58,7 +58,7 @@ namespace edm {
     enablePrefetching_(enablePrefetching),
     enableTriggerCache_(branchType_ == InEvent),
     rootDelayedReader_(new RootDelayedReader(*this, filePtr, inputType)),
-    branchEntryInfoBranch_(metaTree_ ? getProductProvenanceBranch(metaTree_, branchType_) : (tree_ ? getProductProvenanceBranch(tree_, branchType_) : 0)),
+    branchEntryInfoBranch_(metaTree_ ? getProductProvenanceBranch(metaTree_, branchType_) : (tree_ ? getProductProvenanceBranch(tree_, branchType_) : nullptr)),
     infoTree_(dynamic_cast<TTree*>(filePtr_.get() != nullptr ? filePtr->Get(BranchTypeToInfoTreeName(branchType).c_str()) : nullptr)) // backward compatibility
     {
       if(not tree_) {
@@ -183,7 +183,7 @@ namespace edm {
     tree_->SetCacheSize(static_cast<Long64_t>(cacheSize));
     treeCache_.reset(dynamic_cast<TTreeCache*>(filePtr_->GetCacheRead()));
     if(treeCache_) treeCache_->SetEnablePrefetching(enablePrefetching_);
-    filePtr_->SetCacheRead(0);
+    filePtr_->SetCacheRead(nullptr);
     rawTreeCache_.reset();
   }
 
@@ -209,7 +209,7 @@ namespace edm {
 
     entryNumber_ = theEntryNumber;
     tree_->LoadTree(entryNumber_);
-    filePtr_->SetCacheRead(0);
+    filePtr_->SetCacheRead(nullptr);
     if(treeCache_ && trainNow_ && entryNumber_ >= 0) {
       startTraining();
       trainNow_ = false;
@@ -229,7 +229,7 @@ namespace edm {
     if (!treeCache_->IsAsyncReading() && enableTriggerCache_ && (trainedSet_.find(branch) == trainedSet_.end())) {
       return checkTriggerCacheImpl(branch, entryNumber);
     } else {
-      return NULL;
+      return nullptr;
     }
   }
 
@@ -279,7 +279,7 @@ namespace edm {
       }
       performedSwitchOver_ = false;
       rawTriggerTreeCache_->StopLearningPhase();
-      filePtr_->SetCacheRead(0);
+      filePtr_->SetCacheRead(nullptr);
 
       return rawTriggerTreeCache_.get();
     } else if (entryNumber_ < rawTriggerSwitchOverEntry_) {
@@ -305,21 +305,21 @@ namespace edm {
           triggerTreeCache_->AddBranch(*it, kTRUE);
         }
         triggerTreeCache_->StopLearningPhase();
-        filePtr_->SetCacheRead(0);
+        filePtr_->SetCacheRead(nullptr);
       }
       return triggerTreeCache_.get();
     }
 
     // By construction, this case should be impossible.
     assert (false);
-    return NULL;
+    return nullptr;
   }
 
   inline TTreeCache*
   RootTree::selectCache(TBranch* branch, EntryNumber entryNumber) const {
-    TTreeCache *triggerCache = NULL;
+    TTreeCache *triggerCache = nullptr;
     if (!treeCache_) {
-      return NULL;
+      return nullptr;
     } else if (treeCache_->IsLearning() && rawTreeCache_) {
       treeCache_->AddBranch(branch, kTRUE);
       trainedSet_.insert(branch);
@@ -340,11 +340,11 @@ namespace edm {
       TTreeCache * cache = selectCache(branch, entryNumber);
       filePtr_->SetCacheRead(cache);
       branch->GetEntry(entryNumber);
-      filePtr_->SetCacheRead(0);
+      filePtr_->SetCacheRead(nullptr);
     } catch(cms::Exception const& e) {
       // We make sure the treeCache_ is detached from the file,
       // so that ROOT does not also delete it.
-      filePtr_->SetCacheRead(0);
+      filePtr_->SetCacheRead(nullptr);
       Exception t(errors::FileReadError, "", e);
       t.addContext(std::string("Reading branch ")+branch->GetName());
       throw t;
@@ -379,7 +379,7 @@ namespace edm {
     tree_->SetCacheSize(static_cast<Long64_t>(cacheSize_));
     rawTreeCache_.reset(dynamic_cast<TTreeCache *>(filePtr_->GetCacheRead()));
     rawTreeCache_->SetEnablePrefetching(false);
-    filePtr_->SetCacheRead(0);
+    filePtr_->SetCacheRead(nullptr);
     rawTreeCache_->SetLearnEntries(0);
     switchOverEntry_ = entryNumber_ + learningEntries_;
     rawTreeCache_->StartLearningPhase();
@@ -402,7 +402,7 @@ namespace edm {
   RootTree::stopTraining() {
     filePtr_->SetCacheRead(treeCache_.get());
     treeCache_->StopLearningPhase();
-    filePtr_->SetCacheRead(0);
+    filePtr_->SetCacheRead(nullptr);
     rawTreeCache_.reset();
   }
 
@@ -415,7 +415,7 @@ namespace edm {
     // We own the treeCache_.
     // We make sure the treeCache_ is detached from the file,
     // so that ROOT does not also delete it.
-    filePtr_->SetCacheRead(0);
+    filePtr_->SetCacheRead(nullptr);
     // We *must* delete the TTreeCache here because the TFilePrefetch object
     // references the TFile.  If TFile is closed, before the TTreeCache is
     // deleted, the TFilePrefetch may continue to do TFile operations, causing
@@ -444,7 +444,7 @@ namespace edm {
     // We own the treeCache_.
     // We make sure the treeCache_ is detached from the file,
     // so that ROOT does not also delete it.
-    filePtr_->SetCacheRead(0);
+    filePtr_->SetCacheRead(nullptr);
 
     // Must also manually add things to the trained set.
     TObjArray *branches = tree_->GetListOfBranches();
@@ -505,7 +505,7 @@ namespace edm {
       // We own the treeCache_.
       // We make sure the treeCache_ is detached from the file,
       // so that ROOT does not also delete it.
-      file.SetCacheRead(0);
+      file.SetCacheRead(nullptr);
       return treeCache;
     }
   }

--- a/IOPool/Input/src/RunHelper.h
+++ b/IOPool/Input/src/RunHelper.h
@@ -37,20 +37,20 @@ namespace edm {
   class DefaultRunHelper : public RunHelperBase {
   public:
     explicit DefaultRunHelper() = default;
-    virtual ~DefaultRunHelper();
+    ~DefaultRunHelper() override;
   };
 
   class SetRunHelper : public RunHelperBase {
   public: 
     explicit SetRunHelper(ParameterSet const& pset);
-    virtual ~SetRunHelper();
+    ~SetRunHelper() override;
 
-    virtual void setForcedRunOffset(RunNumber_t firstRun) override;
+    void setForcedRunOffset(RunNumber_t firstRun) override;
 
-    virtual void checkRunConsistency(RunNumber_t run, RunNumber_t origninalRun) const override;
-    virtual void overrideRunNumber(EventID& event, bool isRealData) override;
-    virtual void overrideRunNumber(RunID& run) override;
-    virtual void overrideRunNumber(LuminosityBlockID& lumi) override;
+    void checkRunConsistency(RunNumber_t run, RunNumber_t origninalRun) const override;
+    void overrideRunNumber(EventID& event, bool isRealData) override;
+    void overrideRunNumber(RunID& run) override;
+    void overrideRunNumber(LuminosityBlockID& lumi) override;
 
   private:
     RunNumber_t setRun_;
@@ -61,19 +61,19 @@ namespace edm {
   class SetRunForEachLumiHelper : public RunHelperBase {
   public: 
     explicit SetRunForEachLumiHelper(ParameterSet const& pset);
-    virtual ~SetRunForEachLumiHelper();
+    ~SetRunForEachLumiHelper() override;
 
-    virtual InputSource::ItemType nextItemType(
+    InputSource::ItemType nextItemType(
       InputSource::ItemType const& previousItemType,
       InputSource::ItemType const& newIemType) override;
-    virtual RunNumber_t runNumberToUseForThisLumi() const override;
-    virtual bool fakeNewRun() const override {return fakeNewRun_;}
-    virtual void checkForNewRun(RunNumber_t run) override;
+    RunNumber_t runNumberToUseForThisLumi() const override;
+    bool fakeNewRun() const override {return fakeNewRun_;}
+    void checkForNewRun(RunNumber_t run) override;
 
-    virtual void checkRunConsistency(RunNumber_t run, RunNumber_t origninalRun) const override; 
-    virtual void overrideRunNumber(EventID& event, bool isRealData) override;
-    virtual void overrideRunNumber(RunID& run) override;
-    virtual void overrideRunNumber(LuminosityBlockID& lumi) override;
+    void checkRunConsistency(RunNumber_t run, RunNumber_t origninalRun) const override; 
+    void overrideRunNumber(EventID& event, bool isRealData) override;
+    void overrideRunNumber(RunID& run) override;
+    void overrideRunNumber(LuminosityBlockID& lumi) override;
 
   private:
     std::vector<RunNumber_t> setRunNumberForEachLumi_;

--- a/IOPool/Input/test/IOExerciser.cc
+++ b/IOPool/Input/test/IOExerciser.cc
@@ -45,7 +45,7 @@ to use this plugin.
 class IOExerciser : public edm::OutputModule {
    public:
       explicit IOExerciser(const edm::ParameterSet&);
-      ~IOExerciser();
+      ~IOExerciser() override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -57,11 +57,11 @@ class IOExerciser : public edm::OutputModule {
 
       typedef std::map<edm::BranchID, edm::EDGetToken> TokenMap;
       // ----------required OutputModule functions-----------------------------
-      virtual void write(edm::EventForOutput const &e);
-      virtual void writeRun(edm::RunForOutput const&){}
-      virtual void writeLuminosityBlock(edm::LuminosityBlockForOutput const&){}
+      void write(edm::EventForOutput const &e) override;
+      void writeRun(edm::RunForOutput const&) override{}
+      void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override{}
 
-      virtual void respondToOpenInputFile(edm::FileBlock const& fb);
+      void respondToOpenInputFile(edm::FileBlock const& fb) override;
 
       // ----------internal implementation functions---------------------------
       void computeProducts(edm::EventForOutput const& e, TokenMap const& tokens);

--- a/IOPool/Input/test/ProductInfo.h
+++ b/IOPool/Input/test/ProductInfo.h
@@ -45,7 +45,7 @@ void ProductInfo::addBranchSizes(TBranch & branch, Long64_t &size)
    for (Long64_t i = 0; i < nB; ++i)
    {
       TBranch *btemp = (TBranch *)branch.GetListOfBranches()->At(i);
-      if (btemp != NULL)
+      if (btemp != nullptr)
       {
          addBranchSizes(*btemp, size);
       }


### PR DESCRIPTION
PR #9091 changed the behavior of RootInputFileSequence (now re-factored into RootEmbeddedFileSequence) such that, in sequential mode, when the secondary source reaches the end of the last file it loops back to the beginning of the first file instead of halting.  This makes sense for the primary use in the mixing module; however, SiStripSpyEventMatcher depends on the old behavior.  This PR adds an option (recycleFiles, defaults to true) that restores the old behavior when turned off, and modifies the SiStripSpyEventMatcher cfi to set recycleFiles to false.  Fixes issue #20361 
