### PR TITLE
bug fixes for RHStopTracer (94X)

### DIFF
--- a/SimG4Core/CustomPhysics/interface/RHStopTracer.h
+++ b/SimG4Core/CustomPhysics/interface/RHStopTracer.h
@@ -21,12 +21,12 @@ class RHStopTracer :  public SimProducer,
 {
  public:
   RHStopTracer(edm::ParameterSet const & p);
-  virtual ~RHStopTracer();
-  void update(const BeginOfRun *);
-  void update(const BeginOfEvent *);
-  void update(const BeginOfTrack *);
-  void update(const EndOfTrack *);
-  void produce(edm::Event&, const edm::EventSetup&);
+  ~RHStopTracer() override;
+  void update(const BeginOfRun *) override;
+  void update(const BeginOfEvent *) override;
+  void update(const BeginOfTrack *) override;
+  void update(const EndOfTrack *) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
  private:
   struct StopPoint {
     StopPoint (const std::string& fName, double fX, double fY, double fZ, double fT, int fId, double fMass, double fCharge) 

--- a/SimG4Core/CustomPhysics/interface/RHStopTracer.h
+++ b/SimG4Core/CustomPhysics/interface/RHStopTracer.h
@@ -6,6 +6,8 @@
 #include "SimG4Core/Watcher/interface/SimProducer.h"
 #include "SimG4Core/Notification/interface/Observer.h"
 
+#include <regex>
+
 class BeginOfRun;
 class BeginOfEvent;
 class BeginOfTrack;
@@ -43,7 +45,11 @@ class RHStopTracer :  public SimProducer,
   };
   bool mStopRegular;
   double mTraceEnergy;
+  int minPdgId;
+  int maxPdgId;
+  int otherPdgId;
   std::string mTraceParticleName;
+  std::regex rePartName;
   std::vector <StopPoint> mStopPoints;
 };
 

--- a/SimG4Core/CustomPhysics/interface/RHStopTracer.h
+++ b/SimG4Core/CustomPhysics/interface/RHStopTracer.h
@@ -44,7 +44,6 @@ class RHStopTracer :  public SimProducer,
   bool mStopRegular;
   double mTraceEnergy;
   std::string mTraceParticleName;
-  const G4ParticleDefinition* mParticle;
   std::vector <StopPoint> mStopPoints;
 };
 

--- a/SimG4Core/CustomPhysics/plugins/RHStopTracer.cc
+++ b/SimG4Core/CustomPhysics/plugins/RHStopTracer.cc
@@ -59,11 +59,12 @@ void RHStopTracer::update (const BeginOfEvent * fEvent) {
 void RHStopTracer::update (const BeginOfTrack * fTrack) {
   const G4Track* track = (*fTrack)();
   const G4ParticleDefinition* part = track->GetDefinition();
-  std::string stringPartName = part->GetParticleName();
+  const std::string& stringPartName = part->GetParticleName();
   bool matched = false;
-  if( (abs(part->GetPDGEncoding())>minPdgId && abs(part->GetPDGEncoding())<maxPdgId) || abs(part->GetPDGEncoding())==otherPdgId )
+  int pdgid = std::abs(part->GetPDGEncoding());
+  if( (pdgid>minPdgId && pdgid<maxPdgId) || pdgid==otherPdgId )
      matched = std::regex_match(stringPartName,rePartName);
-  if((part && matched) ||  track->GetKineticEnergy() > mTraceEnergy) {
+  if( matched ||  track->GetKineticEnergy() > mTraceEnergy) {
     LogDebug("SimG4CoreCustomPhysics")
       << "RHStopTracer::update-> new track: ID/Name/pdgId/mass/charge/Parent: " 
       << track->GetTrackID() << '/' << part->GetParticleName() << '/' 
@@ -81,11 +82,12 @@ void RHStopTracer::update (const BeginOfTrack * fTrack) {
 void RHStopTracer::update (const EndOfTrack * fTrack) {
   const G4Track* track = (*fTrack)();
   const G4ParticleDefinition* part = track->GetDefinition();
-  std::string stringPartName = part->GetParticleName();
+  const std::string& stringPartName = part->GetParticleName();
   bool matched = false;
-  if( (abs(part->GetPDGEncoding())>minPdgId && abs(part->GetPDGEncoding())<maxPdgId) || abs(part->GetPDGEncoding())==otherPdgId )
+  int pdgid = std::abs(part->GetPDGEncoding());
+  if( (pdgid>minPdgId && pdgid<maxPdgId) || pdgid==otherPdgId )
      matched = std::regex_match(stringPartName,rePartName);
-  if((part && matched) ||  track->GetKineticEnergy() > mTraceEnergy) {
+  if( matched ||  track->GetKineticEnergy() > mTraceEnergy) {
     LogDebug("SimG4CoreCustomPhysics")
       << "RHStopTracer::update-> stop track: ID/Name/pdgId/mass/charge/Parent: " 
       << track->GetTrackID() << '/' << part->GetParticleName() << '/' 


### PR DESCRIPTION
This pull request is to fix two bugs that were introduced into the RHStopTracer module:
- First, the particle names need to be matched with a regular expression
- Secondly, we want to record a "stopped particle" if the particle name is matched OR if the energy of the particle is very high (not AND)