### PR TITLE
include dark current contribution in M2 pedestal constraint for Phase2

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -42,6 +42,15 @@ def customiseFor19989(process):
         process.GlobalParameters = GlobalParameters
     return process
 
+# new parameter for HCAL method 2 reconstruction
+def customiseFor20422(process):
+    from RecoLocalCalo.HcalRecProducers.HBHEMethod2Parameters_cfi import m2Parameters
+    for producer in producers_by_type(process, "HBHEPhase1Reconstructor"):
+        producer.algorithm.applyDCConstraint = m2Parameters.applyDCConstraint
+    for producer in producers_by_type(process, "HcalHitReconstructor"):
+        producer.applyDCConstraint = m2Parameters.applyDCConstraint
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -51,5 +60,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     process = customiseFor19029(process)
     process = customiseFor19824(process)
     process = customiseFor19989(process)
+    process = customiseFor20422(process)
 
     return process

--- a/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
@@ -117,7 +117,7 @@ public:
 		     double iTMin, double iTMax,
 		     const std::vector<double> & its4Chi2, HcalTimeSlew::BiasSetting slewFlavor, int iFitTimes, bool iDCConstraint=false);
 
-    const HcalPulseShapes::Shape* currentPulseShape_=NULL;
+    const HcalPulseShapes::Shape* currentPulseShape_=nullptr;
     void setChi2Term( bool isHPD );
 
     void setPulseShapeTemplate  (const HcalPulseShapes::Shape& ps, bool isHPD);

--- a/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
@@ -115,7 +115,7 @@ public:
 		     double iPedMean, double iPedSigHPD, double iPedSigSiPM,
 		     double iNoiseHPD, double iNoiseSiPM,
 		     double iTMin, double iTMax,
-		     const std::vector<double> & its4Chi2, HcalTimeSlew::BiasSetting slewFlavor, int iFitTimes);
+		     const std::vector<double> & its4Chi2, HcalTimeSlew::BiasSetting slewFlavor, int iFitTimes, bool iDCConstraint=false);
 
     const HcalPulseShapes::Shape* currentPulseShape_=NULL;
     void setChi2Term( bool isHPD );
@@ -163,7 +163,8 @@ private:
     double noise_;    
     double noiseHPD_;
     double noiseSiPM_;
-    HcalTimeSlew::BiasSetting slewFlavor_;    
+    HcalTimeSlew::BiasSetting slewFlavor_;
+    bool dcConstraint_;
 
     bool isCurrentChannelHPD_;
 };

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -529,6 +529,7 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo& channe
   double noisePHArr[HcalConst::maxSamples]={};
   double tsTOT = 0, tstrig = 0; // in fC
   double tsTOTen = 0; // in GeV
+  double sipmDarkCurrentWidth = psfPtr_->getSiPMDarkCurrent(channelData.darkCurrent(),channelData.fcByPE(),channelData.lambda());
 
   // go over the time slices
   for(unsigned int ip=0; ip<cssize; ++ip){
@@ -551,7 +552,7 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo& channe
     // dark current noise relevant for siPM
     noiseDCArr[ip] = 0;
     if(channelData.hasTimeInfo() && (charge-ped)>channelData.tsPedestalWidth(ip)) {
-      noiseDCArr[ip] = psfPtr_->getSiPMDarkCurrent(channelData.darkCurrent(),channelData.fcByPE(),channelData.lambda());
+      noiseDCArr[ip] = sipmDarkCurrentWidth;
     }
 
     // Photo statistics uncertainties
@@ -573,10 +574,11 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo& channe
     }
   }
 
-  double averagePedSig2GeV=0.25*(channelData.tsPedestalWidth(0)*channelData.tsPedestalWidth(0)*channelData.tsGain(0)*channelData.tsGain(0) +
-				 channelData.tsPedestalWidth(1)*channelData.tsPedestalWidth(1)*channelData.tsGain(1)*channelData.tsGain(1) +
-				 channelData.tsPedestalWidth(2)*channelData.tsPedestalWidth(2)*channelData.tsGain(2)*channelData.tsGain(2) +
-				 channelData.tsPedestalWidth(3)*channelData.tsPedestalWidth(3)*channelData.tsGain(3)*channelData.tsGain(3));
+  double sipmDarkCurrentWidth2 = sipmDarkCurrentWidth*sipmDarkCurrentWidth;
+  double averagePedSig2GeV=0.25*((channelData.tsPedestalWidth(0)*channelData.tsPedestalWidth(0)+sipmDarkCurrentWidth2)*channelData.tsGain(0)*channelData.tsGain(0) +
+				 (channelData.tsPedestalWidth(1)*channelData.tsPedestalWidth(1)+sipmDarkCurrentWidth2)*channelData.tsGain(1)*channelData.tsGain(1) +
+				 (channelData.tsPedestalWidth(2)*channelData.tsPedestalWidth(2)+sipmDarkCurrentWidth2)*channelData.tsGain(2)*channelData.tsGain(2) +
+				 (channelData.tsPedestalWidth(3)*channelData.tsPedestalWidth(3)+sipmDarkCurrentWidth2)*channelData.tsGain(3)*channelData.tsGain(3));
 
   // redefine the invertpedSig2
   psfPtr_->setinvertpedSig2(1./(averagePedSig2GeV));

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -209,10 +209,10 @@ namespace FitterFuncs{
 
 PulseShapeFitOOTPileupCorrection::PulseShapeFitOOTPileupCorrection() : cntsetPulseShape(0),
 								       psfPtr_(nullptr), spfunctor_(nullptr), dpfunctor_(nullptr), tpfunctor_(nullptr),
-								       TSMin_(0), TSMax_(0), vts4Chi2_(0), pedestalConstraint_(0),
-								       timeConstraint_(0), addPulseJitter_(0), applyTimeSlew_(0),
+								       TSMin_(0), TSMax_(0), vts4Chi2_(0), pedestalConstraint_(false),
+								       timeConstraint_(false), addPulseJitter_(false), applyTimeSlew_(false),
 								       ts4Min_(0), vts4Max_(0), pulseJitter_(0), timeMean_(0), timeSig_(0), pedMean_(0), pedSig_(0),
-								       noise_(0), dcConstraint_(0) {
+								       noise_(0), dcConstraint_(false) {
    hybridfitter = new PSFitter::HybridMinimizer(PSFitter::HybridMinimizer::kMigrad);
    iniTimesArr = { {-100,-75,-50,-25,0,25,50,75,100,125} };
 }
@@ -474,7 +474,7 @@ void PulseShapeFitOOTPileupCorrection::fit(int iFit,float &timevalfit,float &cha
    //a special number to label the initial condition
    chi2=-1;
    //3 fits why?!
-   const double *results = 0;
+   const double *results = nullptr;
    for(int tries=0; tries<=3;++tries){
      if( fitTimes_ != 2 || tries !=1 ){
         hybridfitter->SetMinimizerType(PSFitter::HybridMinimizer::kMigrad);

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -212,7 +212,7 @@ PulseShapeFitOOTPileupCorrection::PulseShapeFitOOTPileupCorrection() : cntsetPul
 								       TSMin_(0), TSMax_(0), vts4Chi2_(0), pedestalConstraint_(0),
 								       timeConstraint_(0), addPulseJitter_(0), applyTimeSlew_(0),
 								       ts4Min_(0), vts4Max_(0), pulseJitter_(0), timeMean_(0), timeSig_(0), pedMean_(0), pedSig_(0),
-								       noise_(0) {
+								       noise_(0), dcConstraint_(0) {
    hybridfitter = new PSFitter::HybridMinimizer(PSFitter::HybridMinimizer::kMigrad);
    iniTimesArr = { {-100,-75,-50,-25,0,25,50,75,100,125} };
 }
@@ -243,7 +243,7 @@ void PulseShapeFitOOTPileupCorrection::setPUParams(bool   iPedestalConstraint, b
 						   double iNoiseHPD,double iNoiseSiPM,
 						   double iTMin,double iTMax,
 						   const std::vector<double> & its4Chi2,
-						   HcalTimeSlew::BiasSetting slewFlavor, int iFitTimes) {
+						   HcalTimeSlew::BiasSetting slewFlavor, int iFitTimes, bool iDCConstraint) {
 
   TSMin_ = iTMin;
   TSMax_ = iTMax;
@@ -270,6 +270,7 @@ void PulseShapeFitOOTPileupCorrection::setPUParams(bool   iPedestalConstraint, b
   noiseSiPM_          = iNoiseSiPM;
   slewFlavor_         = slewFlavor;
   fitTimes_           = iFitTimes;
+  dcConstraint_       = iDCConstraint;
 
 }
 
@@ -574,7 +575,8 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo& channe
     }
   }
 
-  double sipmDarkCurrentWidth2 = sipmDarkCurrentWidth*sipmDarkCurrentWidth;
+  double sipmDarkCurrentWidth2 = 0.;
+  if(dcConstraint_) sipmDarkCurrentWidth2 = sipmDarkCurrentWidth*sipmDarkCurrentWidth;
   double averagePedSig2GeV=0.25*((channelData.tsPedestalWidth(0)*channelData.tsPedestalWidth(0)+sipmDarkCurrentWidth2)*channelData.tsGain(0)*channelData.tsGain(0) +
 				 (channelData.tsPedestalWidth(1)*channelData.tsPedestalWidth(1)+sipmDarkCurrentWidth2)*channelData.tsGain(1)*channelData.tsGain(1) +
 				 (channelData.tsPedestalWidth(2)*channelData.tsPedestalWidth(2)+sipmDarkCurrentWidth2)*channelData.tsGain(2)*channelData.tsGain(2) +

--- a/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
@@ -14,6 +14,7 @@ static std::unique_ptr<PulseShapeFitOOTPileupCorrection>
 parseHBHEMethod2Description(const edm::ParameterSet& conf)
 {
     const bool iPedestalConstraint = conf.getParameter<bool>  ("applyPedConstraint");
+    const bool iDCConstraint = conf.getParameter<bool>  ("applyDCConstraint");
     const bool iTimeConstraint =     conf.getParameter<bool>  ("applyTimeConstraint");
     const bool iAddPulseJitter =     conf.getParameter<bool>  ("applyPulseJitter");
     const bool iApplyTimeSlew =      conf.getParameter<bool>  ("applyTimeSlew");
@@ -48,7 +49,7 @@ parseHBHEMethod2Description(const edm::ParameterSet& conf)
 		      iPedMean, iPedSigHPD, iPedSigSiPM,
                       iNoiseHPD, iNoiseSiPM,
 		      iTMin, iTMax, its4Chi2,
-                      HcalTimeSlew::Medium, iFitTimes);
+                      HcalTimeSlew::Medium, iFitTimes, iDCConstraint);
 
     return corr;
 }

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEMethod2Parameters_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEMethod2Parameters_cfi.py
@@ -23,6 +23,9 @@ m2Parameters = cms.PSet(
     timeMin               = cms.double(-12.5),#ns
     timeMax               = cms.double(12.5), #ns
     ts4chi2               = cms.vdouble(15.,15.),  #chi2 for triple pulse
-    fitTimes              = cms.int32(1)      # -1 means no constraint on number of fits per channel
-
+    fitTimes              = cms.int32(1),      # -1 means no constraint on number of fits per channel
+    applyDCConstraint     = cms.bool(False),
 )
+
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
+phase2_hcal.toModify(m2Parameters, applyDCConstraint = True)


### PR DESCRIPTION
When SiPM aging is enabled, the dark current (an extra source of electronics noise, separate from the regular pedestal) can increase drastically. The pedestal constraint in HCAL Method 2 reconstruction did not account for this increase, leading to biased energy for some RecHits. Now it is included, but only enabled for Phase2. An additional parameter is added to the Method 2 parameter set, which must eventually be propagated to HLT separately (since M2 parameters are not kept in fillDescriptions).

See the presentation https://indico.cern.ch/event/664043/contributions/2713101/attachments/1519347/2372809/hcal_raddam_phase2_status_sept_6_2017.pdf and this plot that demonstrates improvement in jet energy response:
![JER w/ M2 fix](http://kjplanet.com/pr/RelValRelRspVsRefPt_JetEta0.5to1.3_ak4pfl2l3.png)

This PR will be backported to 93X for inclusion in the HGCal TDR release (hopefully).

attn: @abdoulline @mariadalfonso @hatakeyamak 