### PR TITLE
Refactor track MVA classifier code

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -102,7 +102,6 @@ else:
 #### select tracks based on MaximumImpactParameter, MaximumZ, MinimumTotalLayers, MinimumPixelLayers and MaximumNormChi2
 process.pixelTracksCutClassifier = cms.EDProducer( "TrackCutClassifier",
     src = cms.InputTag( "pixelTracks" ),
-    GBRForestLabel = cms.string( "" ),
     beamspot = cms.InputTag( "offlineBeamSpot" ),
 #    vertices = cms.InputTag( "pixelVertices" ),
     vertices = cms.InputTag( "" ),

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -51,6 +51,18 @@ def customiseFor20422(process):
         producer.applyDCConstraint = m2Parameters.applyDCConstraint
     return process
 
+# Refactor track MVA classifiers
+def customiseFor20429(process):
+    for producer in producers_by_type(process, "TrackMVAClassifierDetached", "TrackMVAClassifierPrompt"):
+        producer.mva.GBRForestLabel = producer.GBRForestLabel
+        producer.mva.GBRForestFileName = producer.GBRForestFileName
+        del producer.GBRForestLabel
+        del producer.GBRForestFileName
+    for producer in producers_by_type(process, "TrackCutClassifier"):
+        del producer.GBRForestLabel
+        del producer.GBRForestFileName
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -61,5 +73,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     process = customiseFor20269(process)
     process = customiseFor19989(process)
     process = customiseFor20422(process)
+    process = customiseFor20429(process)
 
     return process

--- a/RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h
+++ b/RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h
@@ -32,17 +32,14 @@ protected:
   using MVACollection = std::vector<float>;
   using QualityMaskCollection = std::vector<unsigned char>;
 
+  virtual void initEvent(const edm::EventSetup& es) = 0;
+
   virtual void computeMVA(reco::TrackCollection const & tracks,
 			  reco::BeamSpot const & beamSpot,
 			  reco::VertexCollection const & vertices,
-			  GBRForest const * forestP,
 			  MVACollection & mvas) const = 0;
 
-  
 private:
-  
-  void beginStream(edm::StreamID) override final;
-
   void produce(edm::Event& evt, const edm::EventSetup& es ) override final;
 
   /// source collection label
@@ -53,10 +50,6 @@ private:
   bool ignoreVertices_;
 
   // MVA
-  std::unique_ptr<GBRForest> forest_;
-  const std::string forestLabel_;
-  const std::string dbFileName_;
-  const bool useForestFromDB_;
 
   // qualitycuts (loose, tight, hp)
   float qualityCuts[3];
@@ -81,15 +74,22 @@ public:
 
   
 private:
+    void beginStream(edm::StreamID) final {
+      mva.beginStream();
+    }
+
+    void initEvent(const edm::EventSetup& es) final {
+      mva.initEvent(es);
+    }
+
     void computeMVA(reco::TrackCollection const & tracks,
 		    reco::BeamSpot const & beamSpot,
 		    reco::VertexCollection const & vertices,
-		    GBRForest const * forestP,
 		    MVACollection & mvas) const final {
 
       size_t current = 0;
       for (auto const & trk : tracks) {
-	mvas[current++]= mva(trk,beamSpot,vertices,forestP);
+	mvas[current++]= mva(trk,beamSpot,vertices);
       }
     }
 

--- a/RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h
+++ b/RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h
@@ -23,7 +23,7 @@
 class TrackMVAClassifierBase : public edm::stream::EDProducer<> {
 public:
   explicit TrackMVAClassifierBase( const edm::ParameterSet & cfg );
-  ~TrackMVAClassifierBase();
+  ~TrackMVAClassifierBase() override;
 protected:
 
   static void fill( edm::ParameterSetDescription& desc);
@@ -40,7 +40,7 @@ protected:
 			  MVACollection & mvas) const = 0;
 
 private:
-  void produce(edm::Event& evt, const edm::EventSetup& es ) override final;
+  void produce(edm::Event& evt, const edm::EventSetup& es ) final;
 
   /// source collection label
   edm::EDGetTokenT<reco::TrackCollection> src_;

--- a/RecoTracker/FinalTrackSelectors/plugins/DefaultTrackMVAClassifier.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DefaultTrackMVAClassifier.cc
@@ -1,5 +1,8 @@
 #include "RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h"
 
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
@@ -7,17 +10,38 @@
 
 #include "getBestVertex.h"
 
+#include "TFile.h"
+
 namespace {
   
 template<bool PROMPT>
 struct mva {
-  mva(const edm::ParameterSet &){}
+  mva(const edm::ParameterSet &cfg):
+    forestLabel_    ( cfg.getParameter<std::string>("GBRForestLabel") ),
+    dbFileName_     ( cfg.getParameter<std::string>("GBRForestFileName") ),
+    useForestFromDB_( (!forestLabel_.empty()) & dbFileName_.empty())
+  {}
+
+  void beginStream() {
+    if(!dbFileName_.empty()){
+      TFile gbrfile(dbFileName_.c_str());
+      forestFromFile_.reset((GBRForest*)gbrfile.Get(forestLabel_.c_str()));
+    }
+  }
+
+  void initEvent(const edm::EventSetup& es) {
+    forest_ = forestFromFile_.get();
+    if(useForestFromDB_){
+      edm::ESHandle<GBRForest> forestHandle;
+      es.get<GBRWrapperRcd>().get(forestLabel_,forestHandle);
+      forest_ = forestHandle.product();
+    }
+  }
+
   float operator()(reco::Track const & trk,
 		   reco::BeamSpot const & beamSpot,
-		   reco::VertexCollection const & vertices,
-		   GBRForest const * forestP) const {
+		   reco::VertexCollection const & vertices) const {
 
-    auto const & forest = *forestP;
     auto tmva_pt_ = trk.pt();
     auto tmva_ndof_ = trk.ndof();
     auto tmva_nlayers_ = trk.hitPattern().trackerLayersWithMeasurement();
@@ -77,17 +101,22 @@ struct mva {
 
  
 
-    
-    return forest.GetClassifier(gbrVals_);
+    return forest_->GetClassifier(gbrVals_);
     
   }
 
   static const char * name();
 
   static void fillDescriptions(edm::ParameterSetDescription & desc) {
+    desc.add<std::string>("GBRForestLabel",std::string());
+    desc.add<std::string>("GBRForestFileName",std::string());
   }
   
-  
+  std::unique_ptr<GBRForest> forestFromFile_;
+  const GBRForest *forest_ = nullptr; // owned by somebody else
+  const std::string forestLabel_;
+  const std::string dbFileName_;
+  const bool useForestFromDB_;
 };
 
   using TrackMVAClassifierDetached = TrackMVAClassifier<mva<false>>;

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCutClassifier.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCutClassifier.cc
@@ -175,12 +175,12 @@ namespace {
       fillArrayF(drWPVerr_par, dr_par,"drWPVerr_par");
     }
     
-    
+    void beginStream() {}
+    void initEvent(const edm::EventSetup&) {}
     
     float operator()(reco::Track const & trk,
 		     reco::BeamSpot const & beamSpot,
-		     reco::VertexCollection const & vertices,
-		     GBRForest const *) const {
+		     reco::VertexCollection const & vertices) const {
       
       float ret = 1.f;
       // minimum number of hits for by-passing the other checks

--- a/RecoTracker/FinalTrackSelectors/python/classifierTest_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/classifierTest_cff.py
@@ -6,7 +6,7 @@ from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
 
 testTrackClassifier1 = TrackMVAClassifierPrompt.clone()
 testTrackClassifier1.src = 'initialStepTracks'
-testTrackClassifier1.GBRForestLabel = 'MVASelectorIter0_13TeV'
+testTrackClassifier1.mva.GBRForestLabel = 'MVASelectorIter0_13TeV'
 testTrackClassifier1.qualityCuts = [-0.9,-0.8,-0.7]
 
 
@@ -27,7 +27,7 @@ testTrackMerger.minQuality = 'tight'
 
 testTrackClassifier3 = TrackMVAClassifierDetached.clone()
 testTrackClassifier3.src = 'detachedTripletStepTracks'
-testTrackClassifier3.GBRForestLabel = 'MVASelectorIter3_13TeV'
+testTrackClassifier3.mva.GBRForestLabel = 'MVASelectorIter3_13TeV'
 testTrackClassifier3.qualityCuts = [-0.5,0.0,0.5]
 
 

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -190,7 +190,7 @@ detachedQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProduc
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
 detachedQuadStep = TrackMVAClassifierDetached.clone(
     src = 'detachedQuadStepTracks',
-    GBRForestLabel = 'MVASelectorDetachedQuadStep_Phase1',
+    mva = dict(GBRForestLabel = 'MVASelectorDetachedQuadStep_Phase1'),
     qualityCuts = [-0.5,0.0,0.5],
 )
 

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -182,11 +182,11 @@ from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
 detachedTripletStepClassifier1 = TrackMVAClassifierDetached.clone()
 detachedTripletStepClassifier1.src = 'detachedTripletStepTracks'
-detachedTripletStepClassifier1.GBRForestLabel = 'MVASelectorIter3_13TeV'
+detachedTripletStepClassifier1.mva.GBRForestLabel = 'MVASelectorIter3_13TeV'
 detachedTripletStepClassifier1.qualityCuts = [-0.5,0.0,0.5]
 detachedTripletStepClassifier2 = TrackMVAClassifierPrompt.clone()
 detachedTripletStepClassifier2.src = 'detachedTripletStepTracks'
-detachedTripletStepClassifier2.GBRForestLabel = 'MVASelectorIter0_13TeV'
+detachedTripletStepClassifier2.mva.GBRForestLabel = 'MVASelectorIter0_13TeV'
 detachedTripletStepClassifier2.qualityCuts = [-0.2,0.0,0.4]
 
 from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
@@ -194,11 +194,11 @@ detachedTripletStep = ClassifierMerger.clone()
 detachedTripletStep.inputClassifiers=['detachedTripletStepClassifier1','detachedTripletStepClassifier2']
 
 trackingPhase1.toReplaceWith(detachedTripletStep, detachedTripletStepClassifier1.clone(
-     GBRForestLabel = 'MVASelectorDetachedTripletStep_Phase1',
+     mva = dict(GBRForestLabel = 'MVASelectorDetachedTripletStep_Phase1'),
      qualityCuts = [-0.2,0.3,0.8],
 ))
 trackingPhase1QuadProp.toReplaceWith(detachedTripletStep, detachedTripletStepClassifier1.clone(
-     GBRForestLabel = 'MVASelectorDetachedTripletStep_Phase1',
+     mva = dict(GBRForestLabel = 'MVASelectorDetachedTripletStep_Phase1'),
      qualityCuts = [-0.2,0.3,0.8],
 ))
 

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -206,7 +206,7 @@ highPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProdu
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 highPtTripletStep = TrackMVAClassifierPrompt.clone(
     src	= 'highPtTripletStepTracks',
-    GBRForestLabel = 'MVASelectorHighPtTripletStep_Phase1',
+    mva = dict(GBRForestLabel = 'MVASelectorHighPtTripletStep_Phase1'),
     qualityCuts	= [0.2,0.3,0.4],
 )
 

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -248,7 +248,7 @@ from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
 
 initialStepClassifier1 = TrackMVAClassifierPrompt.clone()
 initialStepClassifier1.src = 'initialStepTracks'
-initialStepClassifier1.GBRForestLabel = 'MVASelectorIter0_13TeV'
+initialStepClassifier1.mva.GBRForestLabel = 'MVASelectorIter0_13TeV'
 initialStepClassifier1.qualityCuts = [-0.9,-0.8,-0.7]
 
 from RecoTracker.IterativeTracking.DetachedTripletStep_cff import detachedTripletStepClassifier1
@@ -263,11 +263,11 @@ initialStep = ClassifierMerger.clone()
 initialStep.inputClassifiers=['initialStepClassifier1','initialStepClassifier2','initialStepClassifier3']
 
 trackingPhase1.toReplaceWith(initialStep, initialStepClassifier1.clone(
-        GBRForestLabel = 'MVASelectorInitialStep_Phase1',
+        mva = dict(GBRForestLabel = 'MVASelectorInitialStep_Phase1'),
         qualityCuts = [-0.95,-0.85,-0.75],
 ))
 trackingPhase1QuadProp.toReplaceWith(initialStep, initialStepClassifier1.clone(
-        GBRForestLabel = 'MVASelectorInitialStep_Phase1',
+        mva = dict(GBRForestLabel = 'MVASelectorInitialStep_Phase1'),
         qualityCuts = [-0.95,-0.85,-0.75],
 ))
 

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -172,12 +172,12 @@ jetCoreRegionalStep.vertices = 'firstStepGoodPrimaryVertices'
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 trackingPhase1.toReplaceWith(jetCoreRegionalStep, TrackMVAClassifierPrompt.clone(
      src = 'jetCoreRegionalStepTracks',
-     GBRForestLabel = 'MVASelectorJetCoreRegionalStep_Phase1',
+     mva = dict(GBRForestLabel = 'MVASelectorJetCoreRegionalStep_Phase1'),
      qualityCuts = [-0.2,0.0,0.4],
 ))
 trackingPhase1QuadProp.toReplaceWith(jetCoreRegionalStep, TrackMVAClassifierPrompt.clone(
      src = 'jetCoreRegionalStepTracks',
-     GBRForestLabel = 'MVASelectorJetCoreRegionalStep_Phase1',
+     mva = dict(GBRForestLabel = 'MVASelectorJetCoreRegionalStep_Phase1'),
      qualityCuts = [-0.2,0.0,0.4],
 ))
 

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -181,7 +181,7 @@ lowPtQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 lowPtQuadStep =  TrackMVAClassifierPrompt.clone(
     src = 'lowPtQuadStepTracks',
-    GBRForestLabel = 'MVASelectorLowPtQuadStep_Phase1',
+    mva = dict(GBRForestLabel = 'MVASelectorLowPtQuadStep_Phase1'),
     qualityCuts = [-0.65,-0.35,-0.15],
 )
 

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -215,15 +215,15 @@ trackingPhase2PU140.toModify(lowPtTripletStepTrajectoryCleanerBySharedHits, frac
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 lowPtTripletStep =  TrackMVAClassifierPrompt.clone()
 lowPtTripletStep.src = 'lowPtTripletStepTracks'
-lowPtTripletStep.GBRForestLabel = 'MVASelectorIter1_13TeV'
+lowPtTripletStep.mva.GBRForestLabel = 'MVASelectorIter1_13TeV'
 lowPtTripletStep.qualityCuts = [-0.6,-0.3,-0.1]
 
 trackingPhase1.toReplaceWith(lowPtTripletStep, lowPtTripletStep.clone(
-     GBRForestLabel = 'MVASelectorLowPtTripletStep_Phase1',
+     mva = dict(GBRForestLabel = 'MVASelectorLowPtTripletStep_Phase1'),
      qualityCuts = [0.0,0.2,0.4],
 ))
 trackingPhase1QuadProp.toReplaceWith(lowPtTripletStep, lowPtTripletStep.clone(
-     GBRForestLabel = 'MVASelectorLowPtTripletStep_Phase1',
+     mva = dict(GBRForestLabel = 'MVASelectorLowPtTripletStep_Phase1'),
      qualityCuts = [0.0,0.2,0.4],
 ))
 

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -241,11 +241,11 @@ from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
 mixedTripletStepClassifier1 = TrackMVAClassifierDetached.clone()
 mixedTripletStepClassifier1.src = 'mixedTripletStepTracks'
-mixedTripletStepClassifier1.GBRForestLabel = 'MVASelectorIter4_13TeV'
+mixedTripletStepClassifier1.mva.GBRForestLabel = 'MVASelectorIter4_13TeV'
 mixedTripletStepClassifier1.qualityCuts = [-0.5,0.0,0.5]
 mixedTripletStepClassifier2 = TrackMVAClassifierPrompt.clone()
 mixedTripletStepClassifier2.src = 'mixedTripletStepTracks'
-mixedTripletStepClassifier2.GBRForestLabel = 'MVASelectorIter0_13TeV'
+mixedTripletStepClassifier2.mva.GBRForestLabel = 'MVASelectorIter0_13TeV'
 mixedTripletStepClassifier2.qualityCuts = [-0.2,-0.2,-0.2]
 
 from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
@@ -253,11 +253,11 @@ mixedTripletStep = ClassifierMerger.clone()
 mixedTripletStep.inputClassifiers=['mixedTripletStepClassifier1','mixedTripletStepClassifier2']
 
 trackingPhase1.toReplaceWith(mixedTripletStep, mixedTripletStepClassifier1.clone(
-     GBRForestLabel = 'MVASelectorMixedTripletStep_Phase1',
+     mva = dict(GBRForestLabel = 'MVASelectorMixedTripletStep_Phase1'),
      qualityCuts = [-0.5,0.0,0.5],
 ))
 trackingPhase1QuadProp.toReplaceWith(mixedTripletStep, mixedTripletStepClassifier1.clone(
-     GBRForestLabel = 'MVASelectorMixedTripletStep_Phase1',
+     mva = dict(GBRForestLabel = 'MVASelectorMixedTripletStep_Phase1'),
      qualityCuts = [-0.5,0.0,0.5],
 ))
 

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -239,11 +239,11 @@ from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
 pixelLessStepClassifier1 = TrackMVAClassifierPrompt.clone()
 pixelLessStepClassifier1.src = 'pixelLessStepTracks'
-pixelLessStepClassifier1.GBRForestLabel = 'MVASelectorIter5_13TeV'
+pixelLessStepClassifier1.mva.GBRForestLabel = 'MVASelectorIter5_13TeV'
 pixelLessStepClassifier1.qualityCuts = [-0.4,0.0,0.4]
 pixelLessStepClassifier2 = TrackMVAClassifierPrompt.clone()
 pixelLessStepClassifier2.src = 'pixelLessStepTracks'
-pixelLessStepClassifier2.GBRForestLabel = 'MVASelectorIter0_13TeV'
+pixelLessStepClassifier2.mva.GBRForestLabel = 'MVASelectorIter0_13TeV'
 pixelLessStepClassifier2.qualityCuts = [-0.0,0.0,0.0]
 
 from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
@@ -253,11 +253,11 @@ pixelLessStep.inputClassifiers=['pixelLessStepClassifier1','pixelLessStepClassif
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
 trackingPhase1.toReplaceWith(pixelLessStep, pixelLessStepClassifier1.clone(
-     GBRForestLabel = 'MVASelectorPixelLessStep_Phase1',
+     mva = dict(GBRForestLabel = 'MVASelectorPixelLessStep_Phase1'),
      qualityCuts = [-0.4,0.0,0.4],
 ))
 trackingPhase1QuadProp.toReplaceWith(pixelLessStep, pixelLessStepClassifier1.clone(
-     GBRForestLabel = 'MVASelectorPixelLessStep_Phase1',
+     mva = dict(GBRForestLabel = 'MVASelectorPixelLessStep_Phase1'),
      qualityCuts = [-0.4,0.0,0.4],
 ))
 

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -265,7 +265,7 @@ pixelPairStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 pixelPairStep =  TrackMVAClassifierPrompt.clone()
 pixelPairStep.src = 'pixelPairStepTracks'
-pixelPairStep.GBRForestLabel = 'MVASelectorIter2_13TeV'
+pixelPairStep.mva.GBRForestLabel = 'MVASelectorIter2_13TeV'
 pixelPairStep.qualityCuts = [-0.2,0.0,0.3]
 
 # For LowPU and Phase2PU140

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -290,11 +290,11 @@ from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
 tobTecStepClassifier1 = TrackMVAClassifierDetached.clone()
 tobTecStepClassifier1.src = 'tobTecStepTracks'
-tobTecStepClassifier1.GBRForestLabel = 'MVASelectorIter6_13TeV'
+tobTecStepClassifier1.mva.GBRForestLabel = 'MVASelectorIter6_13TeV'
 tobTecStepClassifier1.qualityCuts = [-0.6,-0.45,-0.3]
 tobTecStepClassifier2 = TrackMVAClassifierPrompt.clone()
 tobTecStepClassifier2.src = 'tobTecStepTracks'
-tobTecStepClassifier2.GBRForestLabel = 'MVASelectorIter0_13TeV'
+tobTecStepClassifier2.mva.GBRForestLabel = 'MVASelectorIter0_13TeV'
 tobTecStepClassifier2.qualityCuts = [0.0,0.0,0.0]
 
 from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
@@ -304,11 +304,11 @@ tobTecStep.inputClassifiers=['tobTecStepClassifier1','tobTecStepClassifier2']
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
 trackingPhase1.toReplaceWith(tobTecStep, tobTecStepClassifier1.clone(
-     GBRForestLabel = 'MVASelectorTobTecStep_Phase1',
+     mva = dict(GBRForestLabel = 'MVASelectorTobTecStep_Phase1'),
      qualityCuts = [-0.6,-0.45,-0.3],
 ))
 trackingPhase1QuadProp.toReplaceWith(tobTecStep, tobTecStepClassifier1.clone(
-     GBRForestLabel = 'MVASelectorTobTecStep_Phase1',
+     mva = dict(GBRForestLabel = 'MVASelectorTobTecStep_Phase1'),
      qualityCuts = [-0.6,-0.45,-0.3],
 ))
 


### PR DESCRIPTION
Currently the base class of track MVA (and cut) classifiers obtaines the `GBRForest` object. But the existing cut-based classifier or any possible future non-BDT classifier should not have to care about `GBRForest, so this PR refactors the MVA classifier classes by moving all `GBRForest` variables to the `MVA` template argument of `TrackMVAClassifier<MVA>`. 

Tested in CMSSW_9_3_X_2017-09-06-1100 (rebased on top of CMSSW_9_4_X_2017-09-15-1100), no changes expected.

@rovere @VinInn @hajohajo @felicepantaleo 