### PR TITLE
fix muon hit related info

### DIFF
--- a/HLTrigger/Muon/interface/HLTScoutingMuonProducer.h
+++ b/HLTrigger/Muon/interface/HLTScoutingMuonProducer.h
@@ -50,13 +50,13 @@ class HLTScoutingMuonProducer : public edm::global::EDProducer<> {
                                                 unsigned int> > RecoChargedCandMap;
     public:
         explicit HLTScoutingMuonProducer(const edm::ParameterSet&);
-        ~HLTScoutingMuonProducer();
+        ~HLTScoutingMuonProducer() override;
 
         static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
     private:
-        virtual void produce(edm::StreamID sid, edm::Event & iEvent, edm::EventSetup const & setup)
-            const override final;
+        void produce(edm::StreamID sid, edm::Event & iEvent, edm::EventSetup const & setup)
+            const final;
 
         const edm::EDGetTokenT<reco::RecoChargedCandidateCollection> ChargedCandidateCollection_;
         const edm::EDGetTokenT<reco::TrackCollection> TrackCollection_;

--- a/HLTrigger/Muon/interface/HLTScoutingMuonProducer.h
+++ b/HLTrigger/Muon/interface/HLTScoutingMuonProducer.h
@@ -42,6 +42,9 @@ Description: Producer for ScoutingMuon
 #include "DataFormats/Scouting/interface/ScoutingMuon.h"
 #include "DataFormats/Scouting/interface/ScoutingVertex.h"
 
+#include "DataFormats/MuonReco/interface/MuonTrackLinks.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+
 class HLTScoutingMuonProducer : public edm::global::EDProducer<> {
     typedef edm::AssociationMap<edm::OneToValue<std::vector<reco::RecoChargedCandidate>, float,
                                                 unsigned int> > RecoChargedCandMap;
@@ -65,6 +68,9 @@ class HLTScoutingMuonProducer : public edm::global::EDProducer<> {
         const double muonPtCut;
         const double muonEtaCut;
 	const double minVtxProbCut;
+
+        const edm::EDGetTokenT<reco::MuonTrackLinksCollection> linkToken_;
+
 };
 
 #endif

--- a/HLTrigger/Muon/src/HLTScoutingMuonProducer.cc
+++ b/HLTrigger/Muon/src/HLTScoutingMuonProducer.cc
@@ -35,7 +35,9 @@ HLTScoutingMuonProducer::HLTScoutingMuonProducer(const edm::ParameterSet& iConfi
     displacedvertexCollection_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("displacedvertexCollection"))),
     muonPtCut(iConfig.getParameter<double>("muonPtCut")),
     muonEtaCut(iConfig.getParameter<double>("muonEtaCut")),
-    minVtxProbCut(iConfig.getParameter<double>("minVtxProbCut"))
+    minVtxProbCut(iConfig.getParameter<double>("minVtxProbCut")),
+    linkToken_ (consumes<reco::MuonTrackLinksCollection>(iConfig.getParameter<edm::InputTag>("InputLinks")))
+
 {
     //register products
     produces<ScoutingMuonCollection>();
@@ -125,6 +127,11 @@ void HLTScoutingMuonProducer::produce(edm::StreamID sid, edm::Event & iEvent,
     std::vector<int> vtxInd;
     float minDR2=1e-06;
     int index = 0;
+
+    // Read Links collection:                                                                                                                                                                                              
+    edm::Handle<reco::MuonTrackLinksCollection> links;
+    iEvent.getByToken(linkToken_, links);
+
     for (auto &muon : *ChargedCandidateCollection) {
       reco::RecoChargedCandidateRef muonRef = getRef(ChargedCandidateCollection, index);
       ++index;
@@ -134,7 +141,22 @@ void HLTScoutingMuonProducer::produce(edm::StreamID sid, edm::Event & iEvent,
       reco::TrackRef track = muon.track();
       if (track.isNull() || !track.isAvailable())
 	continue;
-      
+    
+      int validmuhit=0;
+      int matchedsta=0;
+      for(auto const & link : *links){
+        const reco::Track& trackerTrack = *link.trackerTrack();
+        float dR2 = deltaR2(track->eta(),track->phi(),trackerTrack.eta(),trackerTrack.phi());
+        float dPt = std::abs(track->pt() - trackerTrack.pt());
+        if (track->pt() != 0) dPt = dPt/track->pt();
+
+        if (dR2 < 0.02*0.02 and dPt < 0.001) {
+          const reco::TrackRef staTrack = link.standAloneTrack();
+          validmuhit=staTrack->hitPattern().numberOfValidMuonHits() ;
+          matchedsta=staTrack->hitPattern().muonStationsWithValidHits();
+        }
+      }
+  
       if (muon.pt() < muonPtCut)
 	continue;
       if (fabs(muon.eta()) > muonEtaCut)
@@ -156,9 +178,9 @@ void HLTScoutingMuonProducer::produce(edm::StreamID sid, edm::Event & iEvent,
 			     ecalisopf, hcalisopf,
 			     (*TrackIsoMap)[muonRef], track->chi2(), track->ndof(),
 			     track->charge(), track->dxy(), track->dz(),
-			     track->hitPattern().numberOfValidMuonHits(),
+			     validmuhit,
 			     track->hitPattern().numberOfValidPixelHits(),
-			     0, // nMatchedStations
+			     matchedsta,
 			     track->hitPattern().trackerLayersWithMeasurement(),
 			     2, // Global muon
 			     track->hitPattern().numberOfValidStripHits(),
@@ -196,5 +218,7 @@ void HLTScoutingMuonProducer::fillDescriptions(edm::ConfigurationDescriptions& d
     desc.add<double>("muonPtCut", 4.0);
     desc.add<double>("muonEtaCut", 2.4);
     desc.add<double>("minVtxProbCut", 0.001);
+    desc.add<edm::InputTag>("InputLinks",edm::InputTag("hltL3MuonsIterL3LinksNoVtx"));
+
     descriptions.add("hltScoutingMuonProducer", desc);
 }


### PR DESCRIPTION
Currently, the variable nMatchedStations is set to zero. And number of valid muon hits is accessed in a way that it always returns zero. As these 2 variables will be essential for the analysis that we plan to do using the dimuon scouting data, so I changed the code in a way that these variables returns meaningful value and save that in the event.