### PR TITLE
Minor Framework speed improvements

### DIFF
--- a/DataFormats/Provenance/src/ProcessHistoryRegistry.cc
+++ b/DataFormats/Provenance/src/ProcessHistoryRegistry.cc
@@ -10,12 +10,13 @@ namespace edm {
 
   bool
   ProcessHistoryRegistry::registerProcessHistory(ProcessHistory const& processHistory) {
-    ProcessHistoryID id = processHistory.id();
+    //make sure the process history ID is cached
+    auto tmp = processHistory;
+    ProcessHistoryID id = tmp.setProcessHistoryID();
     bool newlyAdded = (data_.find(id) == data_.end());
     if(newlyAdded) {
-      data_.insert(std::pair<ProcessHistoryID, ProcessHistory>(id, processHistory));
-      ProcessHistory toBeReduced(processHistory);
-      extra_.insert(std::pair<ProcessHistoryID, ProcessHistoryID>(id, toBeReduced.reduce().id()));
+      data_.emplace(id, tmp);
+      extra_.emplace(std::move(id), tmp.reduce().id());
     }
     return newlyAdded;
   }

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -250,6 +250,9 @@ namespace edm {
     void processEventAsync(WaitingTaskHolder iHolder,
                            unsigned int iStreamIndex);
 
+    void processEventAsyncImpl(WaitingTaskHolder iHolder,
+                               unsigned int iStreamIndex);
+
     //returns true if an asynchronous stop was requested
     bool checkForAsyncStopRequest(StatusCode&);
     

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -265,6 +265,7 @@ namespace edm {
     std::shared_ptr<ProcessHistory const> processHistoryPtr_;
 
     ProcessHistoryID processHistoryID_;
+    ProcessHistoryID processHistoryIDBeforeConfig_;
 
     ProcessConfiguration const* processConfiguration_;
 

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -183,6 +183,9 @@ namespace edm {
     if(!previousParentage) {
       assert(!sameAsPrevious);
       previousParentageId = &temp;
+      if(!record_parents) {
+        sameAsPrevious = true;
+      }
     }
     while(pit != pie) {
       // set provenance

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -154,7 +154,7 @@ namespace edm {
     // true).
 
     //Check that previousParentageId is still good by seeing if previousParentage matches gotBranchIDs_
-    bool sameAsPrevious = ((0 != previousParentage) && (previousParentage->size() == gotBranchIDs_.size()));
+    bool sameAsPrevious = ((nullptr != previousParentage) && (previousParentage->size() == gotBranchIDs_.size()));
     if(record_parents && !gotBranchIDs_.empty()) {
       gotBranchIDVector.reserve(gotBranchIDs_.size());
       std::vector<BranchID>::const_iterator itPrevious;
@@ -172,7 +172,7 @@ namespace edm {
           }
         }
       }
-      if(!sameAsPrevious && 0 != previousParentage) {
+      if(!sameAsPrevious && nullptr != previousParentage) {
         previousParentage->assign(gotBranchIDVector.begin(), gotBranchIDVector.end());
       }
     }
@@ -241,7 +241,7 @@ namespace edm {
   TriggerNames const&
   Event::triggerNames(edm::TriggerResults const& triggerResults) const {
     edm::TriggerNames const* names = triggerNames_(triggerResults);
-    if(names != 0) return *names;
+    if(names != nullptr) return *names;
 
     throw cms::Exception("TriggerNamesNotFound")
       << "TriggerNames not found in ParameterSet registry";

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1437,8 +1437,17 @@ namespace edm {
 
   void EventProcessor::processEventAsync(WaitingTaskHolder iHolder,
                                          unsigned int iStreamIndex) {
+    tbb::task::spawn( *make_functor_task( tbb::task::allocate_root(), [=]() {
+      processEventAsyncImpl(iHolder, iStreamIndex);
+    }) );
+  }
+  
+  void EventProcessor::processEventAsyncImpl(WaitingTaskHolder iHolder,
+                                         unsigned int iStreamIndex) {
     auto pep = &(principalCache_.eventPrincipal(iStreamIndex));
     pep->setLuminosityBlockPrincipal(principalCache_.lumiPrincipalPtr());
+
+    ServiceRegistry::Operate operate(serviceToken_);
     Service<RandomNumberGenerator> rng;
     if(rng.isAvailable()) {
       Event ev(*pep, ModuleDescription(), nullptr);

--- a/FWCore/Framework/src/HistoryAppender.cc
+++ b/FWCore/Framework/src/HistoryAppender.cc
@@ -6,7 +6,14 @@
 #include <string>
 #include <cassert>
 
-static const edm::ProcessHistory s_emptyHistory;
+namespace {
+  edm::ProcessHistory initializeEmpty() {
+    edm::ProcessHistory tmp{};
+    tmp.setProcessHistoryID();
+    return tmp;
+  }
+}
+static const edm::ProcessHistory s_emptyHistory = initializeEmpty();
 
 namespace edm {
 

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -510,7 +510,7 @@ namespace edm {
                         ModuleCallingContext const* mcc) const {
 
     ProductData const* result = findProductByLabel(kindOfType, typeID, inputTag, consumer, sra, mcc);
-    if(result == 0) {
+    if(result == nullptr) {
       return BasicHandle(makeHandleExceptionFactory([=]()->std::shared_ptr<cms::Exception> {
         return makeNotFoundException("getByLabel", kindOfType, typeID, inputTag.label(), inputTag.instance(),
                                      appendCurrentProcessIfAlias(inputTag.process(), processConfiguration_->processName()));
@@ -530,7 +530,7 @@ namespace edm {
                         ModuleCallingContext const* mcc) const {
 
     ProductData const* result = findProductByLabel(kindOfType, typeID, label, instance, process,consumer, sra, mcc);
-    if(result == 0) {
+    if(result == nullptr) {
       return BasicHandle(makeHandleExceptionFactory([=]()->std::shared_ptr<cms::Exception> {
         return makeNotFoundException("getByLabel", kindOfType, typeID, label, instance, process);
       }));
@@ -548,7 +548,7 @@ namespace edm {
                         ModuleCallingContext const* mcc) const {
     assert(index !=ProductResolverIndexInvalid);
     auto& productResolver = productResolvers_[index];
-    assert(0!=productResolver.get());
+    assert(nullptr!=productResolver.get());
     auto resolution = productResolver->resolveProduct(*this, skipCurrentProcess, sra, mcc);
     if(resolution.isAmbiguous()) {
       ambiguous = true;
@@ -567,7 +567,7 @@ namespace edm {
                       bool skipCurrentProcess,
                       ModuleCallingContext const* mcc) const {
     auto const& productResolver = productResolvers_.at(index);
-    assert(0!=productResolver.get());
+    assert(nullptr!=productResolver.get());
     productResolver->prefetchAsync(task,*this, skipCurrentProcess,nullptr,mcc);
   }
 
@@ -703,7 +703,7 @@ namespace edm {
         throwAmbiguousException("findProductByLabel", typeID, inputTag.label(), inputTag.instance(),
                                 appendCurrentProcessIfAlias(inputTag.process(), processConfiguration_->processName()));
       } else if (index == ProductResolverIndexInvalid) {
-        return 0;
+        return nullptr;
       }
       inputTag.tryToCacheIndex(index, typeID, branchType(), &productRegistry());
     }
@@ -742,7 +742,7 @@ namespace edm {
     if(index == ProductResolverIndexAmbiguous) {
       throwAmbiguousException("findProductByLabel", typeID, label, instance, process);
     } else if (index == ProductResolverIndexInvalid) {
-      return 0;
+      return nullptr;
     }
     
     if(unlikely( consumer and (not consumer->registeredToConsume(index, false, branchType())))) {


### PR DESCRIPTION
While testing the limits of the framework's event throughput using a 'hyper fast' configuration, a few performance bottlenecks were found. With these changes, and running cmsRun on moderate hardware, one can get 33,000 event/sec with one thread and get a max throughput of 180,000 events/sec using 9 threads.