### PR TITLE
Update SiStripDetSummary usage in the SiStrip Payload Inspector

### DIFF
--- a/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
@@ -955,7 +955,9 @@ namespace {
     
   public:
     SiStripApvGainsTest() : cond::payloadInspector::Histogram1D<SiStripApvGain>("SiStripApv Gains test",
-										"SiStripApv Gains test", 10,0.0,10.0){
+										"SiStripApv Gains test", 10,0.0,10.0),
+      m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXML(edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())}
+    {
       Base::setSingleIov( true );
     }
     
@@ -967,7 +969,7 @@ namespace {
 	  std::vector<uint32_t> detid;
 	  payload->getDetIds(detid);
 	  
-	  SiStripDetSummary summaryGain;
+	  SiStripDetSummary summaryGain{&m_trackerTopo};
 
 	  for (const auto & d : detid) {
 	    SiStripApvGain::Range range=payload->getRange(d);
@@ -989,6 +991,8 @@ namespace {
       }// iovs
       return true;
     }// fill
+  private:
+    TrackerTopology m_trackerTopo;
   };
 
   /************************************************
@@ -1172,7 +1176,9 @@ namespace {
 
   class SiStripApvGainsComparatorByPartition : public cond::payloadInspector::PlotImage<SiStripApvGain> {
   public:
-    SiStripApvGainsComparatorByPartition() : cond::payloadInspector::PlotImage<SiStripApvGain>( "SiStripGains Comparison By Partition" ){
+    SiStripApvGainsComparatorByPartition() : cond::payloadInspector::PlotImage<SiStripApvGain>( "SiStripGains Comparison By Partition" ),
+      m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXML(edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())}
+    {
       setSingleIov( false );
     }
 
@@ -1194,7 +1200,7 @@ namespace {
       std::vector<uint32_t> detid;
       last_payload->getDetIds(detid);
 
-      SiStripDetSummary summaryLastGain;
+      SiStripDetSummary summaryLastGain{&m_trackerTopo};
 
       for (const auto & d : detid) {
 	SiStripApvGain::Range range=last_payload->getRange(d);
@@ -1203,7 +1209,7 @@ namespace {
 	}
       } 
 
-      SiStripDetSummary summaryFirstGain;
+      SiStripDetSummary summaryFirstGain{&m_trackerTopo};
 
       for (const auto & d : detid) {
 	SiStripApvGain::Range range=first_payload->getRange(d);
@@ -1336,6 +1342,8 @@ namespace {
 
       return true;
     }
+  private:
+    TrackerTopology m_trackerTopo;
   };
 
   /************************************************
@@ -1344,7 +1352,9 @@ namespace {
 
   class SiStripApvGainsByPartition : public cond::payloadInspector::PlotImage<SiStripApvGain> {
   public:
-    SiStripApvGainsByPartition() : cond::payloadInspector::PlotImage<SiStripApvGain>( "SiStripGains By Partition" ){
+    SiStripApvGainsByPartition() : cond::payloadInspector::PlotImage<SiStripApvGain>( "SiStripGains By Partition" ),
+      m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXML(edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())}
+    {
       setSingleIov( true );
     }
 
@@ -1355,7 +1365,7 @@ namespace {
       std::vector<uint32_t> detid;
       payload->getDetIds(detid);
 
-      SiStripDetSummary summaryGain;
+      SiStripDetSummary summaryGain{&m_trackerTopo};
 
       for (const auto & d : detid) {
 	SiStripApvGain::Range range=payload->getRange(d);
@@ -1450,6 +1460,8 @@ namespace {
 
       return true;
     }
+  private:
+    TrackerTopology m_trackerTopo;
   };
 
 } // close namespace

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -387,7 +387,9 @@ namespace {
 
   class SiStripBadStripByRegion : public cond::payloadInspector::PlotImage<SiStripBadStrip> {
   public:
-    SiStripBadStripByRegion() : cond::payloadInspector::PlotImage<SiStripBadStrip>( "SiStrip BadStrip By Region" ){
+    SiStripBadStripByRegion() : cond::payloadInspector::PlotImage<SiStripBadStrip>( "SiStrip BadStrip By Region" ),
+      m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXML(edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())}
+    {
       setSingleIov( true );
     }
 
@@ -398,7 +400,7 @@ namespace {
       std::vector<uint32_t> detid;
       payload->getDetIds(detid);
 
-      SiStripDetSummary summaryBadStrips;
+      SiStripDetSummary summaryBadStrips{&m_trackerTopo};
       int totalBadStrips =0;
 
       for (const auto & d : detid) {
@@ -497,6 +499,8 @@ namespace {
 
       return true;
     }
+  private:
+    TrackerTopology m_trackerTopo;
   };
 
 } // close namespace

--- a/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
@@ -7,6 +7,7 @@
 
 #include "CommonTools/TrackerMap/interface/TrackerMap.h"
 #include "CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h"
+#include "CalibTracker/SiStripCommon/interface/StandaloneTrackerTopology.h" 
 
 #include <memory>
 #include <sstream>
@@ -156,7 +157,9 @@ namespace {
     
   public:
     SiStripDetVOffTest() : cond::payloadInspector::Histogram1D<SiStripDetVOff>("SiStrip DetVOff test",
-									       "SiStrip DetVOff test", 10,0.0,10.0){
+									       "SiStrip DetVOff test", 10,0.0,10.0),
+      m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXML(edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())}
+    {
       Base::setSingleIov( true );
     }
     
@@ -168,8 +171,8 @@ namespace {
 	  std::vector<uint32_t> detid;
 	  payload->getDetIds(detid);
 	  
-	  SiStripDetSummary summaryHV;
-	  SiStripDetSummary summaryLV;
+	  SiStripDetSummary summaryHV{&m_trackerTopo};
+	  SiStripDetSummary summaryLV{&m_trackerTopo};
 	  
 	  for (const auto & d : detid) {
 	    if(payload->IsModuleLVOff(d)) summaryLV.add(d);
@@ -195,6 +198,8 @@ namespace {
       }// iovs
       return true;
     }// fill
+  private:
+    TrackerTopology m_trackerTopo;
   };
 
   /************************************************
@@ -203,7 +208,9 @@ namespace {
 
   class SiStripDetVOffByRegion : public cond::payloadInspector::PlotImage<SiStripDetVOff> {
   public:
-    SiStripDetVOffByRegion() : cond::payloadInspector::PlotImage<SiStripDetVOff>( "SiStrip DetVOff By Region" ){
+    SiStripDetVOffByRegion() : cond::payloadInspector::PlotImage<SiStripDetVOff>( "SiStrip DetVOff By Region" ),
+      m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXML(edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())}
+    {
       setSingleIov( true );
     }
 
@@ -214,8 +221,8 @@ namespace {
       std::vector<uint32_t> detid;
       payload->getDetIds(detid);
 
-      SiStripDetSummary summaryHV;
-      SiStripDetSummary summaryLV;
+      SiStripDetSummary summaryHV{&m_trackerTopo};
+      SiStripDetSummary summaryLV{&m_trackerTopo};
       
       for (const auto & d : detid) {
 	if(payload->IsModuleLVOff(d)) summaryLV.add(d);
@@ -361,6 +368,8 @@ namespace {
 
       return true;
     }
+  private:
+    TrackerTopology m_trackerTopo;
   };
 
 }


### PR DESCRIPTION
This should solve the conflict between the changes in #20274 and #20184, and fix the compile errors in new PR tests and the integration builds.
@mmusich could you check that this does not break the SiStrip Payload Inspector?