### PR TITLE
Monitor seed stopping reason and number of trajectory candidates per seed in tracking DQM

### DIFF
--- a/Calibration/IsolatedParticles/python/isoTrack_cff.py
+++ b/Calibration/IsolatedParticles/python/isoTrack_cff.py
@@ -233,7 +233,6 @@ hltHITCkfTrackCandidatesHE = cms.EDProducer("CkfTrackCandidateMaker",
                                             maxNSeeds = cms.uint32( 100000 ),
                                             NavigationSchool = cms.string( "SimpleNavigationSchool" ),
                                             TrajectoryBuilder = cms.string( "hltESPCkfTrajectoryBuilder" ),
-                                            produceSeedStopReasons = cms.bool(False)
                                             )
 hltHITCtfWithMaterialTracksHE = cms.EDProducer("TrackProducer",
                                                src = cms.InputTag( "hltHITCkfTrackCandidatesHE" ),
@@ -393,7 +392,6 @@ hltHITCkfTrackCandidatesHB = cms.EDProducer("CkfTrackCandidateMaker",
                                             maxNSeeds = cms.uint32( 100000 ),
                                             NavigationSchool = cms.string( "SimpleNavigationSchool" ),
                                             TrajectoryBuilder = cms.string( "hltESPCkfTrajectoryBuilder" ),
-                                            produceSeedStopReasons = cms.bool(False)
                                             )
 
 hltHITCtfWithMaterialTracksHB = cms.EDProducer("TrackProducer",

--- a/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
@@ -38,7 +38,7 @@ class TrackBuildingAnalyzer
         using QualityMaskCollection = std::vector<unsigned char>;
 
         TrackBuildingAnalyzer(const edm::ParameterSet&);
-        ~TrackBuildingAnalyzer();
+        ~TrackBuildingAnalyzer() = default;
         void initHisto(DQMStore::IBooker & ibooker, const edm::ParameterSet&);
         void analyze
         (
@@ -77,40 +77,40 @@ class TrackBuildingAnalyzer
         // ----------member data ---------------------------
 
         // Candidates used for tracking regions
-        MonitorElement* TrackingRegionCandidatePt;
-        MonitorElement* TrackingRegionCandidateEta;
-        MonitorElement* TrackingRegionCandidatePhi;
-        MonitorElement* TrackingRegionCandidatePhiVsEta;
+        MonitorElement* TrackingRegionCandidatePt = nullptr;
+        MonitorElement* TrackingRegionCandidateEta = nullptr;
+        MonitorElement* TrackingRegionCandidatePhi = nullptr;
+        MonitorElement* TrackingRegionCandidatePhiVsEta = nullptr;
 
         // Track Seeds
-        MonitorElement* SeedPt;
-        MonitorElement* SeedEta;
-        MonitorElement* SeedPhi;
-	MonitorElement* SeedPhiVsEta;
-        MonitorElement* SeedTheta;
-        MonitorElement* SeedQ;
-        MonitorElement* SeedDxy;
-        MonitorElement* SeedDz;
-        MonitorElement* NumberOfRecHitsPerSeed;
-        MonitorElement* NumberOfRecHitsPerSeedVsPhiProfile;
-        MonitorElement* NumberOfRecHitsPerSeedVsEtaProfile;
+        MonitorElement* SeedPt = nullptr;
+        MonitorElement* SeedEta = nullptr;
+        MonitorElement* SeedPhi = nullptr;
+        MonitorElement* SeedPhiVsEta = nullptr;
+        MonitorElement* SeedTheta = nullptr;
+        MonitorElement* SeedQ = nullptr;
+        MonitorElement* SeedDxy = nullptr;
+        MonitorElement* SeedDz = nullptr;
+        MonitorElement* NumberOfRecHitsPerSeed = nullptr;
+        MonitorElement* NumberOfRecHitsPerSeedVsPhiProfile = nullptr;
+        MonitorElement* NumberOfRecHitsPerSeedVsEtaProfile = nullptr;
 
         // Track Candidate
-        MonitorElement* TrackCandPt;
-        MonitorElement* TrackCandEta;
-        MonitorElement* TrackCandPhi;
-        MonitorElement* TrackCandPhiVsEta;
-	MonitorElement* TrackCandTheta;
-        MonitorElement* TrackCandQ;
-        MonitorElement* TrackCandDxy;
-        MonitorElement* TrackCandDz;
-        MonitorElement* NumberOfRecHitsPerTrackCand;
-        MonitorElement* NumberOfRecHitsPerTrackCandVsPhiProfile;
-        MonitorElement* NumberOfRecHitsPerTrackCandVsEtaProfile;
+        MonitorElement* TrackCandPt = nullptr;
+        MonitorElement* TrackCandEta = nullptr;
+        MonitorElement* TrackCandPhi = nullptr;
+        MonitorElement* TrackCandPhiVsEta = nullptr;
+        MonitorElement* TrackCandTheta = nullptr;
+        MonitorElement* TrackCandQ = nullptr;
+        MonitorElement* TrackCandDxy = nullptr;
+        MonitorElement* TrackCandDz = nullptr;
+        MonitorElement* NumberOfRecHitsPerTrackCand = nullptr;
+        MonitorElement* NumberOfRecHitsPerTrackCandVsPhiProfile = nullptr;
+        MonitorElement* NumberOfRecHitsPerTrackCandVsEtaProfile = nullptr;
 
-	MonitorElement* stoppingSource;
-	MonitorElement* stoppingSourceVSeta;
-	MonitorElement* stoppingSourceVSphi;
+	MonitorElement* stoppingSource = nullptr;
+	MonitorElement* stoppingSourceVSeta = nullptr;
+	MonitorElement* stoppingSourceVSphi = nullptr;
 
 	std::vector<MonitorElement *> trackMVAs;
 	std::vector<MonitorElement *> trackMVAsHP;
@@ -122,23 +122,23 @@ class TrackBuildingAnalyzer
         std::string histname;  //for naming the histograms according to algorithm used
 
 	//to disable some plots
-	bool doAllPlots;
-	bool doAllSeedPlots;
-	bool doTCPlots;
-	bool doAllTCPlots;
-       	bool doPT;
-	bool doETA;
-	bool doPHI;
-	bool doPHIVsETA;
-	bool doTheta;
-	bool doQ;
-	bool doDxy;
-	bool doDz;
-	bool doNRecHits;
-	bool doProfPHI;
-	bool doProfETA;
-	bool doStopSource;
-	bool doMVAPlots;
-	bool doRegionPlots;
+	const bool doAllPlots;
+	const bool doAllSeedPlots;
+	const bool doTCPlots;
+	const bool doAllTCPlots;
+	const bool doPT;
+	const bool doETA;
+	const bool doPHI;
+	const bool doPHIVsETA;
+	const bool doTheta;
+	const bool doQ;
+	const bool doDxy;
+	const bool doDz;
+	const bool doNRecHits;
+	const bool doProfPHI;
+	const bool doProfETA;
+	const bool doStopSource;
+	const bool doMVAPlots;
+	const bool doRegionPlots;
 };
 #endif

--- a/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
@@ -23,6 +23,7 @@ Monitoring source for general quantities related to tracks.
 
 #include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "DataFormats/TrackReco/interface/SeedStopInfo.h"
 #include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
@@ -45,6 +46,7 @@ class TrackBuildingAnalyzer
             const edm::Event& iEvent, 
             const edm::EventSetup& iSetup, 
             const TrajectorySeed& seed, 
+            const SeedStopInfo& stopInfo,
             const reco::BeamSpot& bs, 
             const edm::ESHandle<MagneticField>& theMF,
             const edm::ESHandle<TransientTrackingRecHitBuilder>& theTTRHBuilder
@@ -94,6 +96,16 @@ class TrackBuildingAnalyzer
         MonitorElement* NumberOfRecHitsPerSeed = nullptr;
         MonitorElement* NumberOfRecHitsPerSeedVsPhiProfile = nullptr;
         MonitorElement* NumberOfRecHitsPerSeedVsEtaProfile = nullptr;
+
+        MonitorElement *seedStoppingSource = nullptr;
+        MonitorElement *seedStoppingSourceVsPhi = nullptr;
+        MonitorElement *seedStoppingSourceVsEta = nullptr;
+
+        MonitorElement *numberOfTrajCandsPerSeed = nullptr;
+        MonitorElement *numberOfTrajCandsPerSeedVsPhi = nullptr;
+        MonitorElement *numberOfTrajCandsPerSeedVsEta = nullptr;
+
+        MonitorElement *seedStoppingSourceVsNumberOfTrajCandsPerSeed = nullptr;
 
         // Track Candidate
         MonitorElement* TrackCandPt = nullptr;

--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -93,6 +93,7 @@ class TrackingMonitor : public DQMEDAnalyzer
 	edm::EDGetTokenT<edm::View<reco::Track> > trackToken_;
 	edm::EDGetTokenT<TrackCandidateCollection> trackCandidateToken_;
 	edm::EDGetTokenT<edm::View<TrajectorySeed> > seedToken_;
+	edm::EDGetTokenT<std::vector<SeedStopInfo> > seedStopInfoToken_;
 	edm::EDGetTokenT<edm::OwnVector<TrackingRegion> > regionToken_;
 	edm::EDGetTokenT<reco::CandidateView> regionCandidateToken_;
 

--- a/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
@@ -424,6 +424,11 @@ TrackMon.RegionCandidatePtBin = cms.int32(100)
 TrackMon.RegionCandidatePtMax = cms.double(1000)
 TrackMon.RegionCandidatePtMin = cms.double(0)
 
+# Number of candidates/seed within pattern recognition
+TrackMon.SeedCandBin = cms.int32(20)
+TrackMon.SeedCandMax = cms.double(19.5)
+TrackMon.SeedCandMin = cms.double(-0.5)
+
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase1Pixel.toModify(TrackMon, EtaBin=30, EtaMin=-3, EtaMax=3)

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -636,13 +636,6 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
       }
 
       size_t StopReasonNameSize = sizeof(StopReasonName::StopReasonName)/sizeof(std::string);
-      if(StopReasonNameSize != static_cast<unsigned int>(StopReason::SIZE)) {
-        throw cms::Exception("Assert") << "StopReason::SIZE is " << static_cast<unsigned int>(StopReason::SIZE)
-                                       << " but StopReasonName's only for "
-                                       << StopReasonNameSize
-                                       << ". Please update DataFormats/TrackReco/interface/TrajectoryStopReasons.h.";
-      }
-
       histname = "stoppingSource_";
       stoppingSource = ibooker.book1D(histname+CategoryName, histname+CategoryName, StopReasonNameSize, 0., double(StopReasonNameSize));
       stoppingSource->setAxisTitle("stopping reason",1);

--- a/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
@@ -20,30 +20,26 @@
 
 #include <iostream>
 
-TrackBuildingAnalyzer::TrackBuildingAnalyzer(const edm::ParameterSet& iConfig) 
-    : TrackingRegionCandidatePt(nullptr)
-    , TrackingRegionCandidateEta(nullptr)
-    , TrackingRegionCandidatePhi(nullptr)
-    , TrackingRegionCandidatePhiVsEta(nullptr)
-    , SeedPt(nullptr)
-    , SeedEta(nullptr)
-    , SeedPhi(nullptr)
-    , SeedPhiVsEta(nullptr)
-    , SeedTheta(nullptr)
-    , SeedQ(nullptr)
-    , SeedDxy(nullptr)
-    , SeedDz(nullptr)
-    , NumberOfRecHitsPerSeed(nullptr)
-    , NumberOfRecHitsPerSeedVsPhiProfile(nullptr)
-    , NumberOfRecHitsPerSeedVsEtaProfile(nullptr)
-    , stoppingSource(nullptr)
-    , stoppingSourceVSeta(nullptr)
-    , stoppingSourceVSphi(nullptr)
+TrackBuildingAnalyzer::TrackBuildingAnalyzer(const edm::ParameterSet& iConfig):
+  doAllPlots(    iConfig.getParameter<bool>("doAllPlots")),
+  doAllSeedPlots(iConfig.getParameter<bool>("doSeedParameterHistos")),
+  doTCPlots(     iConfig.getParameter<bool>("doTrackCandHistos")),
+  doAllTCPlots(  iConfig.getParameter<bool>("doAllTrackCandHistos")),
+  doPT(          iConfig.getParameter<bool>("doSeedPTHisto")),
+  doETA(         iConfig.getParameter<bool>("doSeedETAHisto")),
+  doPHI(         iConfig.getParameter<bool>("doSeedPHIHisto")),
+  doPHIVsETA(    iConfig.getParameter<bool>("doSeedPHIVsETAHisto")),
+  doTheta(       iConfig.getParameter<bool>("doSeedThetaHisto")),
+  doQ(           iConfig.getParameter<bool>("doSeedQHisto")),
+  doDxy(         iConfig.getParameter<bool>("doSeedDxyHisto")),
+  doDz(          iConfig.getParameter<bool>("doSeedDzHisto")),
+  doNRecHits(    iConfig.getParameter<bool>("doSeedNRecHitsHisto")),
+  doProfPHI(     iConfig.getParameter<bool>("doSeedNVsPhiProf")),
+  doProfETA(     iConfig.getParameter<bool>("doSeedNVsEtaProf")),
+  doStopSource(  iConfig.getParameter<bool>("doStopSource")),
+  doMVAPlots(    iConfig.getParameter<bool>("doMVAPlots")),
+  doRegionPlots( iConfig.getParameter<bool>("doRegionPlots"))
 {
-}
-
-TrackBuildingAnalyzer::~TrackBuildingAnalyzer() 
-{ 
 }
 
 void TrackBuildingAnalyzer::initHisto(DQMStore::IBooker & ibooker, const edm::ParameterSet& iConfig)
@@ -112,25 +108,6 @@ void TrackBuildingAnalyzer::initHisto(DQMStore::IBooker & ibooker, const edm::Pa
   edm::InputTag tcProducer     = iConfig.getParameter<edm::InputTag>("TCProducer");
   std::vector<std::string> mvaProducers = iConfig.getParameter<std::vector<std::string> >("MVAProducers");
   edm::InputTag regionProducer = iConfig.getParameter<edm::InputTag>("RegionProducer");
-  
-  doAllPlots     = iConfig.getParameter<bool>("doAllPlots");
-  doAllSeedPlots = iConfig.getParameter<bool>("doSeedParameterHistos");
-  doTCPlots      = iConfig.getParameter<bool>("doTrackCandHistos");
-  doAllTCPlots   = iConfig.getParameter<bool>("doAllTrackCandHistos");
-  doPT           = iConfig.getParameter<bool>("doSeedPTHisto");
-  doETA          = iConfig.getParameter<bool>("doSeedETAHisto");
-  doPHI          = iConfig.getParameter<bool>("doSeedPHIHisto");
-  doPHIVsETA     = iConfig.getParameter<bool>("doSeedPHIVsETAHisto");
-  doTheta        = iConfig.getParameter<bool>("doSeedThetaHisto");
-  doQ            = iConfig.getParameter<bool>("doSeedQHisto");
-  doDxy          = iConfig.getParameter<bool>("doSeedDxyHisto");
-  doDz           = iConfig.getParameter<bool>("doSeedDzHisto");
-  doNRecHits     = iConfig.getParameter<bool>("doSeedNRecHitsHisto");
-  doProfPHI      = iConfig.getParameter<bool>("doSeedNVsPhiProf");
-  doProfETA      = iConfig.getParameter<bool>("doSeedNVsEtaProf");
-  doStopSource   = iConfig.getParameter<bool>("doStopSource");
-  doMVAPlots     = iConfig.getParameter<bool>("doMVAPlots");
-  doRegionPlots  = iConfig.getParameter<bool>("doRegionPlots");
   
   //    if (doAllPlots){doAllSeedPlots=true; doTCPlots=true;}
   

--- a/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
@@ -279,13 +279,6 @@ void TrackBuildingAnalyzer::initHisto(DQMStore::IBooker & ibooker, const edm::Pa
   if (doAllTCPlots || doStopSource) {
     // DataFormats/TrackReco/interface/TrajectoryStopReasons.h
     size_t StopReasonNameSize = sizeof(StopReasonName::StopReasonName)/sizeof(std::string);
-    if(StopReasonNameSize != static_cast<unsigned int>(StopReason::SIZE)) {
-      throw cms::Exception("Assert") << "StopReason::SIZE is " << static_cast<unsigned int>(StopReason::SIZE)
-				     << " but StopReasonName's only for "
-				     << StopReasonNameSize
-				     << ". Please update DataFormats/TrackReco/interface/TrajectoryStopReasons.h.";
-    }
-    
     
     histname = "StoppingSource_"+seedProducer.label() + "_";
     stoppingSource = ibooker.book1D(histname+CatagoryName,

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -930,10 +930,10 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 	// get the seed collection
 	edm::Handle<edm::View<TrajectorySeed> > seedHandle;
 	iEvent.getByToken(seedToken_, seedHandle );
-	const edm::View<TrajectorySeed>& seedCollection = *seedHandle;
 	
 	// fill the seed info
 	if (seedHandle.isValid()) {
+          const auto& seedCollection = *seedHandle;
 	  
 	  if(doAllSeedPlots || doSeedNumberPlot) {
 	    NumberOfSeeds->Fill(seedCollection.size());
@@ -963,10 +963,8 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 	    const reco::BeamSpot& bs = *recoBeamSpotHandle;      
 	    
 	    iSetup.get<TransientRecHitRecord>().get(builderName,theTTRHBuilder);
-	    for(size_t i=0; i < seedHandle->size(); ++i) {
-	      
-	      edm::RefToBase<TrajectorySeed> seed(seedHandle, i);
-	      theTrackBuildingAnalyzer->analyze(iEvent, iSetup, *seed, bs, theMF, theTTRHBuilder);
+	    for(size_t i=0; i < seedCollection.size(); ++i) {
+	      theTrackBuildingAnalyzer->analyze(iEvent, iSetup, seedCollection[i], bs, theMF, theTTRHBuilder);
 	    }
 	  }
 	  

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -124,6 +124,7 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
   trackToken_          = consumes<edm::View<reco::Track> >(trackProducer);
   trackCandidateToken_ = consumes<TrackCandidateCollection>(tcProducer); 
   seedToken_           = consumes<edm::View<TrajectorySeed> >(seedProducer);
+  seedStopInfoToken_   = consumes<std::vector<SeedStopInfo> >(tcProducer);
 
   doMVAPlots = iConfig.getParameter<bool>("doMVAPlots");
   if(doMVAPlots) {
@@ -951,21 +952,31 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 	  }
 	  
 	  if (doAllSeedPlots || runTrackBuildingAnalyzerForSeed){
+            edm::Handle<std::vector<SeedStopInfo> > stopHandle;
+            iEvent.getByToken(seedStopInfoToken_, stopHandle);
+            const auto& seedStopInfo = *stopHandle;
+
+            if(seedStopInfo.size() == seedCollection.size()) {
+              //here duplication of mag field and be informations is needed to allow seed and track cand histos to be independent
+              // magnetic field
+              edm::ESHandle<MagneticField> theMF;
+              iSetup.get<IdealMagneticFieldRecord>().get(theMF);
 	    
-	    //here duplication of mag field and be informations is needed to allow seed and track cand histos to be independent
-	    // magnetic field
-	    edm::ESHandle<MagneticField> theMF;
-	    iSetup.get<IdealMagneticFieldRecord>().get(theMF);  
+              // get the beam spot
+              edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
+              iEvent.getByToken(bsSrcToken_, recoBeamSpotHandle);
+              const reco::BeamSpot& bs = *recoBeamSpotHandle;
 	    
-	    // get the beam spot
-	    edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-	    iEvent.getByToken(bsSrcToken_, recoBeamSpotHandle );
-	    const reco::BeamSpot& bs = *recoBeamSpotHandle;      
-	    
-	    iSetup.get<TransientRecHitRecord>().get(builderName,theTTRHBuilder);
-	    for(size_t i=0; i < seedCollection.size(); ++i) {
-	      theTrackBuildingAnalyzer->analyze(iEvent, iSetup, seedCollection[i], bs, theMF, theTTRHBuilder);
-	    }
+              iSetup.get<TransientRecHitRecord>().get(builderName,theTTRHBuilder);
+              for(size_t i=0; i < seedCollection.size(); ++i) {
+                theTrackBuildingAnalyzer->analyze(iEvent, iSetup, seedCollection[i], seedStopInfo[i], bs, theMF, theTTRHBuilder);
+              }
+            }
+            else {
+              edm::LogWarning("TrackingMonitor") << "Seed collection size (" << seedCollection.size()
+                                                 << ") differs from seed stop info collection size (" << seedStopInfo.size()
+                                                 << "). This is a sign of inconsistency in the configuration. Not filling associated histograms.";
+            }
 	  }
 	  
 	} else {

--- a/DQM/TrackingMonitorSource/python/IterTrackingModules4seedMonitoring_cfi.py
+++ b/DQM/TrackingMonitorSource/python/IterTrackingModules4seedMonitoring_cfi.py
@@ -12,6 +12,8 @@ clusterBin        = {}
 clusterMax        = {}
 regionLabel       = {}
 regionCandidateLabel = {}
+trajCandPerSeedBin = {}
+trajCandPerSeedMax = {}
 
 seedInputTag     ['initialStep'] = cms.InputTag("initialStepSeeds")
 trackCandInputTag['initialStep'] = cms.InputTag("initialStepTrackCandidates")
@@ -147,6 +149,8 @@ clusterBin       ['jetCoreRegionalStep'] = cms.int32(100)
 clusterMax       ['jetCoreRegionalStep'] = cms.double(100000)
 regionLabel      ['jetCoreRegionalStep'] = "jetCoreRegionalStepTrackingRegions"
 regionCandidateLabel['jetCoreRegionalStep'] = "jetsForCoreTracking"
+trajCandPerSeedBin['jetCoreRegionalStep'] = 50
+trajCandPerSeedMax['jetCoreRegionalStep'] = 49.5
 
 for _eraName, _postfix, _era in _cfg.allEras():
     locals()["selectedIterTrackingStep"+_postfix] = _cfg.iterationAlgos(_postfix)

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -247,6 +247,9 @@ for step in seedInputTag.iterkeys():
         locals()[label].doRegionPlots = True
         locals()[label].RegionProducer = regionLabel[step]
         locals()[label].RegionCandidates = regionCandidateLabel[step]
+    if step in trajCandPerSeedBin:
+        locals()[label].SeedCandBin = trajCandPerSeedBin[step]
+        locals()[label].SeedCandMax = trajCandPerSeedMax[step]
 
 # DQM Services
 dqmInfoTracking = cms.EDAnalyzer("DQMEventInfo",

--- a/DataFormats/TrackReco/interface/SeedStopInfo.h
+++ b/DataFormats/TrackReco/interface/SeedStopInfo.h
@@ -8,11 +8,15 @@ public:
   SeedStopInfo() {}
   ~SeedStopInfo() = default;
 
+  void setCandidatesPerSeed(unsigned short value) { candidatesPerSeed_ = value; }
+  unsigned short candidatesPerSeed() const { return candidatesPerSeed_; }
+
   void setStopReason(SeedStopReason value) { stopReason_ = value; }
   SeedStopReason stopReason() const { return stopReason_; }
   unsigned char stopReasonUC() const { return static_cast<unsigned char>(stopReason_); }
 
 private:
+  unsigned short candidatesPerSeed_ = 0;
   SeedStopReason stopReason_ = SeedStopReason::UNINITIALIZED;
 };
 

--- a/DataFormats/TrackReco/interface/SeedStopInfo.h
+++ b/DataFormats/TrackReco/interface/SeedStopInfo.h
@@ -1,0 +1,19 @@
+#ifndef DataFormats_TrackReco_SeedStopInfo_h
+#define DataFormats_TrackReco_SeedStopInfo_h
+
+#include "DataFormats/TrackReco/interface/SeedStopReason.h"
+
+class SeedStopInfo {
+public:
+  SeedStopInfo() {}
+  ~SeedStopInfo() = default;
+
+  void setStopReason(SeedStopReason value) { stopReason_ = value; }
+  SeedStopReason stopReason() const { return stopReason_; }
+  unsigned char stopReasonUC() const { return static_cast<unsigned char>(stopReason_); }
+
+private:
+  SeedStopReason stopReason_ = SeedStopReason::UNINITIALIZED;
+};
+
+#endif

--- a/DataFormats/TrackReco/interface/SeedStopReason.h
+++ b/DataFormats/TrackReco/interface/SeedStopReason.h
@@ -1,18 +1,14 @@
 #ifndef DataFormats_TrackReco_SeedStopReason_h
 #define DataFormats_TrackReco_SeedStopReason_h
 
-// Using unscoped enum because all uses are casts to integer, so
-// implicit casting is convenient
-struct SeedStopReason {
-  enum {
-    UNINITIALIZED = 0,
-    NOT_STOPPED = 1,
-    SEED_CLEANING = 2,
-    NO_TRAJECTORY = 3,
-    FINAL_CLEAN = 4,
-    SMOOTHING_FAILED = 5,
-    SIZE = 6
-  };
+enum class SeedStopReason {
+  UNINITIALIZED = 0,
+  NOT_STOPPED = 1,
+  SEED_CLEANING = 2,
+  NO_TRAJECTORY = 3,
+  FINAL_CLEAN = 4,
+  SMOOTHING_FAILED = 5,
+  SIZE = 6
 };
 
 #endif

--- a/DataFormats/TrackReco/interface/SeedStopReason.h
+++ b/DataFormats/TrackReco/interface/SeedStopReason.h
@@ -8,19 +8,21 @@ enum class SeedStopReason {
   NOT_STOPPED = 1,
   SEED_CLEANING = 2,
   NO_TRAJECTORY = 3,
-  FINAL_CLEAN = 4,
-  SMOOTHING_FAILED = 5,
-  SIZE = 6
+  SEED_REGION_REBUILD = 4,
+  FINAL_CLEAN = 5,
+  SMOOTHING_FAILED = 6,
+  SIZE = 7
 };
 
 namespace SeedStopReasonName {
   static const std::string SeedStopReasonName[] = {
-    "UNINITIALIZED",    //  0
-    "NOT_STOPPED",      //  1
-    "SEED_CLEANING",    //  2
-    "NO_TRAJECTORY",    //  3
-    "FINAL_CLEAN",      //  4
-    "SMOOTHING_FAILED"  //  5
+    "UNINITIALIZED",       // 0
+    "NOT_STOPPED",         // 1
+    "SEED_CLEANING",       // 2
+    "NO_TRAJECTORY",       // 3
+    "SEED_REGION_REBUILD", // 4
+    "FINAL_CLEAN",         // 5
+    "SMOOTHING_FAILED"     // 6
   };
 }
 

--- a/DataFormats/TrackReco/interface/SeedStopReason.h
+++ b/DataFormats/TrackReco/interface/SeedStopReason.h
@@ -1,6 +1,8 @@
 #ifndef DataFormats_TrackReco_SeedStopReason_h
 #define DataFormats_TrackReco_SeedStopReason_h
 
+#include <string>
+
 enum class SeedStopReason {
   UNINITIALIZED = 0,
   NOT_STOPPED = 1,
@@ -10,5 +12,16 @@ enum class SeedStopReason {
   SMOOTHING_FAILED = 5,
   SIZE = 6
 };
+
+namespace SeedStopReasonName {
+  static const std::string SeedStopReasonName[] = {
+    "UNINITIALIZED",    //  0
+    "NOT_STOPPED",      //  1
+    "SEED_CLEANING",    //  2
+    "NO_TRAJECTORY",    //  3
+    "FINAL_CLEAN",      //  4
+    "SMOOTHING_FAILED"  //  5
+  };
+}
 
 #endif

--- a/DataFormats/TrackReco/src/SeedStopReason.cc
+++ b/DataFormats/TrackReco/src/SeedStopReason.cc
@@ -1,0 +1,3 @@
+#include "DataFormats/TrackReco/interface/SeedStopReason.h"
+
+static_assert(sizeof(SeedStopReasonName::SeedStopReasonName)/sizeof(std::string) == static_cast<unsigned int>(SeedStopReason::SIZE), "SeedStopReason enum and SeedStopReasonName are out of synch");

--- a/DataFormats/TrackReco/src/TrajectoryStopReasons.cc
+++ b/DataFormats/TrackReco/src/TrajectoryStopReasons.cc
@@ -1,0 +1,3 @@
+#include "DataFormats/TrackReco/interface/TrajectoryStopReasons.h"
+
+static_assert(sizeof(StopReasonName::StopReasonName)/sizeof(std::string) == static_cast<unsigned int>(StopReason::SIZE), "StopReason enum and StopReasonName are out of synch");

--- a/DataFormats/TrackReco/src/classes.h
+++ b/DataFormats/TrackReco/src/classes.h
@@ -29,6 +29,7 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
 #include "DataFormats/TrackReco/interface/DeDxHitInfo.h"
+#include "DataFormats/TrackReco/interface/SeedStopInfo.h"
 
 #include <vector>
 
@@ -138,5 +139,8 @@ namespace DataFormats_TrackReco {
     reco::DeDxHitInfo::DeDxHitInfoContainer hitInfoContainerDEDX;
     reco::DeDxHitInfo::DeDxHitInfoContainerCollection hitInfoContainerDEDXc;
 
+    SeedStopInfo ssi;
+    std::vector<SeedStopInfo> vssi;
+    edm::Wrapper<std::vector<SeedStopInfo> > wvssi;
   };
 }

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -465,4 +465,8 @@
    <class name="edm::Wrapper<reco::DeDxHitInfoCollection>"/>
    <class name="edm::Wrapper<reco::DeDxHitInfoAss>"/>
 
+   <class name="SeedStopInfo" persistent="false"/>
+   <class name="std::vector<SeedStopInfo>" persistent="false"/>
+   <class name="edm::Wrapper<std::vector<SeedStopInfo> >" persistent="false"/>
+
   </lcgdict>

--- a/RecoMuon/L3MuonProducer/test/newL3.py
+++ b/RecoMuon/L3MuonProducer/test/newL3.py
@@ -262,7 +262,6 @@ def addL3ToHLT(process):
 	    ),
 	    MeasurementTrackerEvent = cms.InputTag("hltSiStripClusters"),
 	    reverseTrajectories = cms.bool( True ),
-	    produceSeedStopReasons = cms.bool(False)
 	)
 	
 	###-------------  Fitter-Smoother -------------------
@@ -547,7 +546,6 @@ def addL3ToHLT(process):
 	    TrajectoryBuilderPSet = cms.PSet(  refToPSet_ = cms.string( "HLTIter0HighPtTkMuPSetTrajectoryBuilderIT" ) ),
 	    NavigationSchool = cms.string( "SimpleNavigationSchool" ),
 	    TrajectoryBuilder = cms.string( "" ),
-	    produceSeedStopReasons = cms.bool(False)
 	)
 	process.hltIterL3Iter0HighPtTkMuCtfWithMaterialTracks = cms.EDProducer( "TrackProducer",
 	    src = cms.InputTag( "hltIterL3Iter0HighPtTkMuCkfTrackCandidates" ),
@@ -712,7 +710,6 @@ def addL3ToHLT(process):
 	    TrajectoryBuilderPSet = cms.PSet(  refToPSet_ = cms.string( "HLTIter2HighPtTkMuPSetTrajectoryBuilderIT" ) ),
 	    NavigationSchool = cms.string( "SimpleNavigationSchool" ),
 	    TrajectoryBuilder = cms.string( "" ),
-	    produceSeedStopReasons = cms.bool(False)
 	)
 	process.hltIterL3Iter2HighPtTkMuCtfWithMaterialTracks = cms.EDProducer( "TrackProducer",
 	    src = cms.InputTag( "hltIterL3Iter2HighPtTkMuCkfTrackCandidates" ),

--- a/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
@@ -75,6 +75,7 @@ public:
   // new interface returning the start Trajectory...
   virtual TempTrajectory buildTrajectories (const TrajectorySeed& seed,
 					    TrajectoryContainer &ret,
+					    unsigned int& nCandPerSeed,
 					    const TrajectoryFilter*) const  { assert(0==1); return TempTrajectory();}
   
   

--- a/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
@@ -70,7 +70,7 @@ public:
                            TrajectoryFilter *inOutFilter=nullptr);
   BaseCkfTrajectoryBuilder(const BaseCkfTrajectoryBuilder &) = delete;
   BaseCkfTrajectoryBuilder& operator=(const BaseCkfTrajectoryBuilder&) = delete;
-  virtual ~BaseCkfTrajectoryBuilder();
+  ~BaseCkfTrajectoryBuilder() override;
 
   // new interface returning the start Trajectory...
   virtual TempTrajectory buildTrajectories (const TrajectorySeed& seed,
@@ -85,8 +85,8 @@ public:
 
   void setNavigationSchool(NavigationSchool const * nv) { theNavigationSchool=nv;}
 
-  virtual void setEvent(const edm::Event& event) const ;
-  virtual void unset() const;
+  void setEvent(const edm::Event& event) const override ;
+  void unset() const override;
 
   void setEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup, const MeasurementTrackerEvent *data);
 

--- a/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
@@ -41,12 +41,12 @@ public:
   CkfTrajectoryBuilder(const edm::ParameterSet& conf, edm::ConsumesCollector& iC);
   CkfTrajectoryBuilder(const edm::ParameterSet& conf, TrajectoryFilter *filter);
 
-  ~CkfTrajectoryBuilder() {}
+  ~CkfTrajectoryBuilder() override {}
 
   /// trajectories building starting from a seed
-  virtual TrajectoryContainer trajectories(const TrajectorySeed& seed) const override;
+  TrajectoryContainer trajectories(const TrajectorySeed& seed) const override;
   /// trajectories building starting from a seed
-  virtual void trajectories(const TrajectorySeed& seed, TrajectoryContainer &ret) const override;
+  void trajectories(const TrajectorySeed& seed, TrajectoryContainer &ret) const override;
 
   // new interface returning the start Trajectory...
   TempTrajectory buildTrajectories (const TrajectorySeed&,

--- a/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
@@ -51,6 +51,7 @@ public:
   // new interface returning the start Trajectory...
   TempTrajectory buildTrajectories (const TrajectorySeed&,
 				    TrajectoryContainer &ret,
+				    unsigned int& nCandPerSeed,
 				    const TrajectoryFilter*) const override;
   
   
@@ -76,8 +77,8 @@ public:
 
   virtual void findCompatibleMeasurements(const TrajectorySeed&seed, const TempTrajectory& traj, std::vector<TrajectoryMeasurement> & result) const;
 
-  void limitedCandidates(const TrajectorySeed&seed, TempTrajectory& startingTraj, TrajectoryContainer& result) const;
-  void limitedCandidates(const boost::shared_ptr<const TrajectorySeed> & sharedSeed, TempTrajectoryContainer &candidates, TrajectoryContainer& result) const;
+  unsigned int limitedCandidates(const TrajectorySeed&seed, TempTrajectory& startingTraj, TrajectoryContainer& result) const;
+  unsigned int limitedCandidates(const boost::shared_ptr<const TrajectorySeed> & sharedSeed, TempTrajectoryContainer &candidates, TrajectoryContainer& result) const;
   
   void updateTrajectory( TempTrajectory& traj, TM && tm) const;
 

--- a/RecoTracker/CkfPattern/plugins/CkfTrackCandidateMaker.h
+++ b/RecoTracker/CkfPattern/plugins/CkfTrackCandidateMaker.h
@@ -28,11 +28,8 @@ namespace cms
 
     explicit CkfTrackCandidateMaker(const edm::ParameterSet& conf):
       CkfTrackCandidateMakerBase(conf, consumesCollector()){
-      produceSeedStopReasons_ = conf.getParameter<bool>("produceSeedStopReasons");
       produces<TrackCandidateCollection>();
-      if(produceSeedStopReasons_) {
-        produces<std::vector<short> >();
-      }
+      produces<std::vector<short> >();
     }
 
     virtual ~CkfTrackCandidateMaker(){;}

--- a/RecoTracker/CkfPattern/plugins/CkfTrackCandidateMaker.h
+++ b/RecoTracker/CkfPattern/plugins/CkfTrackCandidateMaker.h
@@ -17,6 +17,7 @@
 #include "RecoTracker/CkfPattern/interface/RedundantSeedCleaner.h"
 #include "RecoTracker/CkfPattern/interface/CkfTrackCandidateMakerBase.h"
 #include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
+#include "DataFormats/TrackReco/interface/SeedStopInfo.h"
 
 class TransientInitialStateEstimator;
 
@@ -29,7 +30,7 @@ namespace cms
     explicit CkfTrackCandidateMaker(const edm::ParameterSet& conf):
       CkfTrackCandidateMakerBase(conf, consumesCollector()){
       produces<TrackCandidateCollection>();
-      produces<std::vector<short> >();
+      produces<std::vector<SeedStopInfo> >();
     }
 
     virtual ~CkfTrackCandidateMaker(){;}

--- a/RecoTracker/CkfPattern/plugins/CkfTrajectoryMaker.h
+++ b/RecoTracker/CkfPattern/plugins/CkfTrajectoryMaker.h
@@ -35,6 +35,7 @@ namespace cms
       if (theTrackCandidateOutput)
 	produces<TrackCandidateCollection>();
       produces<TrajectoryCollection>();
+      produces<std::vector<short> >();
     }
 
     virtual ~CkfTrajectoryMaker(){;}

--- a/RecoTracker/CkfPattern/plugins/CkfTrajectoryMaker.h
+++ b/RecoTracker/CkfPattern/plugins/CkfTrajectoryMaker.h
@@ -17,6 +17,7 @@
 #include "RecoTracker/CkfPattern/interface/RedundantSeedCleaner.h"
 #include "RecoTracker/CkfPattern/interface/CkfTrackCandidateMakerBase.h"
 #include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h" 
+#include "DataFormats/TrackReco/interface/SeedStopInfo.h"
 
 class TransientInitialStateEstimator;
 
@@ -35,7 +36,7 @@ namespace cms
       if (theTrackCandidateOutput)
 	produces<TrackCandidateCollection>();
       produces<TrajectoryCollection>();
-      produces<std::vector<short> >();
+      produces<std::vector<SeedStopInfo> >();
     }
 
     virtual ~CkfTrajectoryMaker(){;}

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
@@ -180,7 +180,7 @@ GroupedCkfTrajectoryBuilder::trajectories (const TrajectorySeed& seed) const
   TrajectoryContainer ret; 
   ret.reserve(10);
   unsigned int tmp;
-  buildTrajectories(seed, ret, tmp, 0);
+  buildTrajectories(seed, ret, tmp, nullptr);
   return ret; 
 }
 
@@ -200,7 +200,7 @@ void
 GroupedCkfTrajectoryBuilder::trajectories (const TrajectorySeed& seed, GroupedCkfTrajectoryBuilder::TrajectoryContainer &ret) const 
 {
   unsigned int tmp;
-  buildTrajectories(seed,ret,tmp,0);
+  buildTrajectories(seed,ret,tmp,nullptr);
 }
 
 void
@@ -262,7 +262,7 @@ GroupedCkfTrajectoryBuilder::buildTrajectories (const TrajectorySeed& seed,
                                                 unsigned int& nCandPerSeed,
 						const TrajectoryFilter* regionalCondition) const
 {
-  if (theMeasurementTracker == 0) {
+  if (theMeasurementTracker == nullptr) {
       throw cms::Exception("LogicError") << "Asking to create trajectories to an un-initialized GroupedCkfTrajectoryBuilder.\nYou have to call clone(const MeasurementTrackerEvent *data) and then call trajectories on it instead.\n";
   }
  
@@ -665,7 +665,7 @@ GroupedCkfTrajectoryBuilder::advanceOneLayer (const TrajectorySeed& seed,
 
   if ( !foundSegments ){
     LogDebug("CkfPattern")<< "GCTB: adding input trajectory to result";
-    if (stateAndLayers.second.size() > 0)
+    if (!stateAndLayers.second.empty())
       traj.setStopReason(StopReason::NO_SEGMENTS_FOR_VALID_LAYERS);
     addToResult(traj, result, inOut);
   }

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
@@ -179,7 +179,8 @@ GroupedCkfTrajectoryBuilder::trajectories (const TrajectorySeed& seed) const
 {
   TrajectoryContainer ret; 
   ret.reserve(10);
-  buildTrajectories(seed, ret, 0);
+  unsigned int tmp;
+  buildTrajectories(seed, ret, tmp, 0);
   return ret; 
 }
 
@@ -189,15 +190,17 @@ GroupedCkfTrajectoryBuilder::trajectories (const TrajectorySeed& seed,
 {
   TrajectoryContainer ret; 
   ret.reserve(10);
+  unsigned int tmp;
   RegionalTrajectoryFilter regionalCondition(region);
-  buildTrajectories(seed, ret, &regionalCondition);
+  buildTrajectories(seed, ret, tmp, &regionalCondition);
   return ret; 
 }
 
 void 
 GroupedCkfTrajectoryBuilder::trajectories (const TrajectorySeed& seed, GroupedCkfTrajectoryBuilder::TrajectoryContainer &ret) const 
 {
-  buildTrajectories(seed,ret,0);
+  unsigned int tmp;
+  buildTrajectories(seed,ret,tmp,0);
 }
 
 void
@@ -206,7 +209,8 @@ GroupedCkfTrajectoryBuilder::trajectories (const TrajectorySeed& seed,
 					    const TrackingRegion& region) const
 {
   RegionalTrajectoryFilter regionalCondition(region);
-  buildTrajectories(seed,ret,&regionalCondition);
+  unsigned int tmp;
+  buildTrajectories(seed,ret,tmp,&regionalCondition);
 }
 
 void  
@@ -255,6 +259,7 @@ GroupedCkfTrajectoryBuilder::rebuildTrajectories(TempTrajectory const & starting
 TempTrajectory
 GroupedCkfTrajectoryBuilder::buildTrajectories (const TrajectorySeed& seed,
                                                 GroupedCkfTrajectoryBuilder::TrajectoryContainer &result,
+                                                unsigned int& nCandPerSeed,
 						const TrajectoryFilter* regionalCondition) const
 {
   if (theMeasurementTracker == 0) {
@@ -272,7 +277,7 @@ GroupedCkfTrajectoryBuilder::buildTrajectories (const TrajectorySeed& seed,
 
   work_.clear();
   const bool inOut = true;
-  groupedLimitedCandidates(seed, startingTraj, regionalCondition, forwardPropagator(seed), inOut, work_);
+  nCandPerSeed = groupedLimitedCandidates(seed, startingTraj, regionalCondition, forwardPropagator(seed), inOut, work_);
   if ( work_.empty() )  return startingTraj;
 
   // cleaning now done here...
@@ -325,7 +330,7 @@ std::cout << "ckf " << kt++ << ": "; for (auto c:chit) std::cout << c <<'/'; std
 }
 
 
-void 
+unsigned int
 GroupedCkfTrajectoryBuilder::groupedLimitedCandidates (const TrajectorySeed& seed,
                                                        TempTrajectory const& startingTraj, 
 						       const TrajectoryFilter* regionalCondition,
@@ -334,6 +339,8 @@ GroupedCkfTrajectoryBuilder::groupedLimitedCandidates (const TrajectorySeed& see
 						       TempTrajectoryContainer& result) const
 {
   unsigned int nIter=1;
+  unsigned int nCands=0; // ignore startingTraj
+  unsigned int prevNewCandSize=0;
   TempTrajectoryContainer candidates;
   TempTrajectoryContainer newCand;
   candidates.push_back( startingTraj);
@@ -349,6 +356,11 @@ GroupedCkfTrajectoryBuilder::groupedLimitedCandidates (const TrajectorySeed& see
       }
 
       LogDebug("CkfPattern")<<"newCand(1): after advanced one layer:\n"<<PrintoutHelper::dumpCandidates(newCand);
+      // account only new candidates, i.e.
+      // - 1 candidate -> 1 candidate, don't increase count
+      // - 1 candidate -> 2 candidates, increase count by 1
+      nCands += newCand.size() - prevNewCandSize;
+      prevNewCandSize = newCand.size();
 
       if ((int)newCand.size() > theMaxCand) {
 	//ShowCand()(newCand);
@@ -383,6 +395,8 @@ GroupedCkfTrajectoryBuilder::groupedLimitedCandidates (const TrajectorySeed& see
 			   <<"\n "<<candidates.size()<<" running candidates are: \n"
 			   <<PrintoutHelper::dumpCandidates(candidates);
   }
+
+  return nCands;
 }
 
 #ifdef EDM_ML_DEBUG

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.h
@@ -28,7 +28,7 @@ class dso_internal GroupedCkfTrajectoryBuilder final : public BaseCkfTrajectoryB
   GroupedCkfTrajectoryBuilder(const edm::ParameterSet& conf, edm::ConsumesCollector& iC);
 
   /// destructor
-  virtual ~GroupedCkfTrajectoryBuilder(){}
+  ~GroupedCkfTrajectoryBuilder() override{}
 
   /// set Event for the internal MeasurementTracker data member
   //  virtual void setEvent(const edm::Event& event) const;

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.h
@@ -49,6 +49,7 @@ class dso_internal GroupedCkfTrajectoryBuilder final : public BaseCkfTrajectoryB
   // also new interface returning the start Trajectory...
   TempTrajectory buildTrajectories (const TrajectorySeed&seed,
 				    TrajectoryContainer &ret,
+				    unsigned int& nCandPerSeed,
 				    const TrajectoryFilter*) const override;
 
 
@@ -120,12 +121,12 @@ private :
 			TempTrajectoryContainer& newCand, 
 			TempTrajectoryContainer& result) const  dso_internal;
 
-  void groupedLimitedCandidates( const TrajectorySeed& seed,
-                                 TempTrajectory const& startingTraj, 
-				 const TrajectoryFilter* regionalCondition,
-				 const Propagator* propagator, 
-                                 bool inOut,
-				 TempTrajectoryContainer& result) const  dso_internal;
+  unsigned int groupedLimitedCandidates( const TrajectorySeed& seed,
+                                         TempTrajectory const& startingTraj, 
+                                         const TrajectoryFilter* regionalCondition,
+                                         const Propagator* propagator, 
+                                         bool inOut,
+                                         TempTrajectoryContainer& result) const  dso_internal;
 
   /// try to find additional hits in seeding region
   void rebuildSeedingRegion (const TrajectorySeed&seed,

--- a/RecoTracker/CkfPattern/python/CkfTrackCandidates_cfi.py
+++ b/RecoTracker/CkfPattern/python/CkfTrackCandidates_cfi.py
@@ -31,6 +31,5 @@ ckfTrackCandidates = cms.EDProducer("CkfTrackCandidateMaker",
         numberMeasurementsForFit = cms.int32(4)
     ),
     MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
-    produceSeedStopReasons = cms.bool(False), # useful only for ntuple/debugging
 )
 

--- a/RecoTracker/CkfPattern/python/CkfTrajectoryBuilder_cfi.py
+++ b/RecoTracker/CkfPattern/python/CkfTrajectoryBuilder_cfi.py
@@ -16,7 +16,6 @@ CkfTrajectoryBuilder = cms.PSet(
 #    propagatorOpposite = cms.string('PropagatorWithMaterialParabolicMfOpposite'),
     lostHitPenalty = cms.double(30.0),
     #SharedSeedCheck = cms.bool(False)
-    produceSeedStopReasons = cms.bool(False), # useful only for ntuple/debugging
 )
 
 

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -298,11 +298,15 @@ namespace cms{
 
 	// Build trajectory from seed outwards
         theTmpTrajectories.clear();
-	auto const & startTraj = theTrajectoryBuilder->buildTrajectories( (*collseed)[j], theTmpTrajectories, nullptr );
-        if(theTmpTrajectories.empty()) {
+        unsigned int nCandPerSeed = 0;
+        auto const & startTraj = theTrajectoryBuilder->buildTrajectories( (*collseed)[j], theTmpTrajectories, nCandPerSeed, nullptr );
+        {
           Lock lock(theMutex);
-          (*outputSeedStopInfos)[j].setStopReason(SeedStopReason::NO_TRAJECTORY);
-          return; // from the lambda!
+          (*outputSeedStopInfos)[j].setCandidatesPerSeed(nCandPerSeed);
+          if(theTmpTrajectories.empty()) {
+            (*outputSeedStopInfos)[j].setStopReason(SeedStopReason::NO_TRAJECTORY);
+            return; // from the lambda!
+          }
         }
 
 	LogDebug("CkfPattern") << "======== In-out trajectory building found " << theTmpTrajectories.size()

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -333,6 +333,11 @@ namespace cms{
   	  LogDebug("CkfPattern") << "======== Out-in trajectory building found " << theTmpTrajectories.size()
   			              << " valid/invalid trajectories from seed " << j << " ========\n"
 				 <<PrintoutHelper::dumpCandidates(theTmpTrajectories);
+          if(theTmpTrajectories.empty()) {
+            Lock lock(theMutex);
+            (*outputSeedStopInfos)[j].setStopReason(SeedStopReason::SEED_REGION_REBUILD);
+            return;
+          }
         }
 
 

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -70,12 +70,12 @@ namespace cms{
     theMaxNSeeds(conf.getParameter<unsigned int>("maxNSeeds")),
     theTrajectoryBuilder(createBaseCkfTrajectoryBuilder(conf.getParameter<edm::ParameterSet>("TrajectoryBuilderPSet"), iC)),
     theTrajectoryCleanerName(conf.getParameter<std::string>("TrajectoryCleaner")),
-    theTrajectoryCleaner(0),
+    theTrajectoryCleaner(nullptr),
     theInitialState(new TransientInitialStateEstimator(conf.getParameter<ParameterSet>("TransientInitialStateEstimatorParameters"))),
     theMagFieldName(conf.exists("SimpleMagneticField") ? conf.getParameter<std::string>("SimpleMagneticField") : ""),
     theNavigationSchoolName(conf.getParameter<std::string>("NavigationSchool")),
-    theNavigationSchool(0),
-    theSeedCleaner(0),
+    theNavigationSchool(nullptr),
+    theSeedCleaner(nullptr),
     maxSeedsBeforeCleaning_(0),
     theMTELabel(iC.consumes<MeasurementTrackerEvent>(conf.getParameter<edm::InputTag>("MeasurementTrackerEvent"))),
     skipClusters_(false),
@@ -112,7 +112,7 @@ namespace cms{
 	conf.getParameter<bool>("onlyPixelHitsForSeedCleaner") : false;
       theSeedCleaner = new CachingSeedCleanerBySharedInput(numHitsForSeedCleaner,onlyPixelHits);
     } else if (cleaner == "none") {
-        theSeedCleaner = 0;
+        theSeedCleaner = nullptr;
     } else {
         throw cms::Exception("RedundantSeedCleaner not found", cleaner);
     }
@@ -220,7 +220,7 @@ namespace cms{
     }
 
     // Step D: Invoke the building algorithm
-    if ((*collseed).size()>0){
+    if (!(*collseed).empty()){
 
       unsigned int lastCleanResult=0;
       std::vector<Trajectory> rawResult;
@@ -433,7 +433,7 @@ namespace cms{
         for (auto it = unsmoothedResult.begin(), ed = unsmoothedResult.end(); it != ed; ++it) {
           // reverse the trajectory only if it has valid hit on the last measurement (should happen)
           if (it->lastMeasurement().updatedState().isValid() &&
-              it->lastMeasurement().recHit().get() != 0     &&
+              it->lastMeasurement().recHit().get() != nullptr     &&
               it->lastMeasurement().recHit()->isValid()) {
             // I can't use reverse in place, because I want to change the seed
             // 1) reverse propagation direction

--- a/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
@@ -142,11 +142,13 @@ CkfTrajectoryBuilder::trajectories(const TrajectorySeed& seed, CkfTrajectoryBuil
     }
   */
 
-  buildTrajectories(seed, result,nullptr);
+  unsigned int tmp;
+  buildTrajectories(seed, result, tmp, nullptr);
 }
 
 TempTrajectory CkfTrajectoryBuilder::buildTrajectories (const TrajectorySeed&seed,
 							TrajectoryContainer &result,
+							unsigned int& nCandPerSeed,
 							const TrajectoryFilter*) const {
   if (theMeasurementTracker == 0) {
       throw cms::Exception("LogicError") << "Asking to create trajectories to an un-initialized CkfTrajectoryBuilder.\nYou have to call clone(const MeasurementTrackerEvent *data) and then call trajectories on it instead.\n";
@@ -156,7 +158,7 @@ TempTrajectory CkfTrajectoryBuilder::buildTrajectories (const TrajectorySeed&see
   
   /// limitedCandidates( startingTraj, regionalCondition, result);
   /// FIXME: restore regionalCondition
-  limitedCandidates(seed, startingTraj, result);
+  nCandPerSeed = limitedCandidates(seed, startingTraj, result);
   
   return startingTraj;
 
@@ -168,21 +170,23 @@ TempTrajectory CkfTrajectoryBuilder::buildTrajectories (const TrajectorySeed&see
   // analyseResult(result);
 }
 
-void CkfTrajectoryBuilder::
+unsigned int CkfTrajectoryBuilder::
 limitedCandidates(const TrajectorySeed&seed, TempTrajectory& startingTraj,
 		   TrajectoryContainer& result) const
 {
   TempTrajectoryContainer candidates;
   candidates.push_back( startingTraj);
   boost::shared_ptr<const TrajectorySeed>  sharedSeed(new TrajectorySeed(seed));
-  limitedCandidates(sharedSeed, candidates,result);
+  return limitedCandidates(sharedSeed, candidates,result);
 }
 
-void CkfTrajectoryBuilder::
+unsigned int CkfTrajectoryBuilder::
 limitedCandidates(const boost::shared_ptr<const TrajectorySeed> & sharedSeed, TempTrajectoryContainer &candidates,
 		   TrajectoryContainer& result) const
 {
   unsigned int nIter=1;
+  unsigned int nCands=0; // ignore startingTraj
+  unsigned int prevNewCandSize=0;
   TempTrajectoryContainer newCand; // = TrajectoryContainer();
   newCand.reserve(2*theMaxCand);
 
@@ -204,7 +208,7 @@ limitedCandidates(const boost::shared_ptr<const TrajectorySeed> & sharedSeed, Te
       if(!analyzeMeasurementsDebugger(*traj,meas,
 				      theMeasurementTracker,
 				      forwardPropagator(*sharedSeed),theEstimator,
-				      theTTRHBuilder)) return;
+				      theTTRHBuilder)) return nCands;
       // ---
 
       if ( meas.empty()) {
@@ -234,6 +238,11 @@ limitedCandidates(const boost::shared_ptr<const TrajectorySeed> & sharedSeed, Te
 	}
       }
 
+      // account only new candidates, i.e.
+      // - 1 candidate -> 1 candidate, don't increase count
+      // - 1 candidate -> 2 candidates, increase count by 1
+      nCands += newCand.size() - prevNewCandSize;
+      prevNewCandSize = newCand.size();
 
       /*
       auto trajVal = [&](TempTrajectory const & a) {
@@ -298,6 +307,7 @@ limitedCandidates(const boost::shared_ptr<const TrajectorySeed> & sharedSeed, Te
 			   <<PrintoutHelper::dumpCandidates(candidates);
 
   }
+  return nCands;
 }
 
 

--- a/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
@@ -150,7 +150,7 @@ TempTrajectory CkfTrajectoryBuilder::buildTrajectories (const TrajectorySeed&see
 							TrajectoryContainer &result,
 							unsigned int& nCandPerSeed,
 							const TrajectoryFilter*) const {
-  if (theMeasurementTracker == 0) {
+  if (theMeasurementTracker == nullptr) {
       throw cms::Exception("LogicError") << "Asking to create trajectories to an un-initialized CkfTrajectoryBuilder.\nYou have to call clone(const MeasurementTrackerEvent *data) and then call trajectories on it instead.\n";
   }
  

--- a/RecoTracker/DebugTools/interface/CkfDebugTrackCandidateMaker.h
+++ b/RecoTracker/DebugTools/interface/CkfDebugTrackCandidateMaker.h
@@ -11,6 +11,7 @@ namespace cms {
   public:
     CkfDebugTrackCandidateMaker(const edm::ParameterSet& conf) : CkfTrackCandidateMakerBase(conf, consumesCollector()) {
       produces<TrackCandidateCollection>();
+      produces<std::vector<short> >();
     }
 
     virtual void beginRun (edm::Run const & run, edm::EventSetup const & es) override {

--- a/RecoTracker/DebugTools/interface/CkfDebugTrackCandidateMaker.h
+++ b/RecoTracker/DebugTools/interface/CkfDebugTrackCandidateMaker.h
@@ -5,13 +5,14 @@
 #include "RecoTracker/CkfPattern/interface/CkfTrackCandidateMakerBase.h"
 #include "RecoTracker/DebugTools/interface/CkfDebugTrajectoryBuilder.h"
 #include "FWCore/Framework/interface/EDProducer.h"
+#include "DataFormats/TrackReco/interface/SeedStopInfo.h"
 
 namespace cms {
   class CkfDebugTrackCandidateMaker : public edm::EDProducer, public CkfTrackCandidateMakerBase {
   public:
     CkfDebugTrackCandidateMaker(const edm::ParameterSet& conf) : CkfTrackCandidateMakerBase(conf, consumesCollector()) {
       produces<TrackCandidateCollection>();
-      produces<std::vector<short> >();
+      produces<SeedStopInfo>();
     }
 
     virtual void beginRun (edm::Run const & run, edm::EventSetup const & es) override {

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -1068,6 +1068,7 @@ private:
   std::vector<unsigned int> see_nPhase2OT;
   std::vector<unsigned int> see_algo    ;
   std::vector<unsigned short> see_stopReason;
+  std::vector<unsigned short> see_nCands;
   std::vector<int> see_trkIdx;
   std::vector<short> see_isTrue;
   std::vector<std::vector<float> > see_shareFrac; // second index runs through matched TrackingParticles
@@ -1448,6 +1449,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
     t->Branch("see_nPhase2OT", &see_nPhase2OT);
     t->Branch("see_algo"     , &see_algo    );
     t->Branch("see_stopReason", &see_stopReason);
+    t->Branch("see_nCands"   , &see_nCands  );
     t->Branch("see_trkIdx"   , &see_trkIdx  );
     if(includeTrackingParticles_) {
       t->Branch("see_shareFrac", &see_shareFrac);
@@ -1733,6 +1735,7 @@ void TrackingNtuple::clearVariables() {
   see_nPhase2OT.clear();
   see_algo    .clear();
   see_stopReason.clear();
+  see_nCands  .clear();
   see_trkIdx  .clear();
   if(includeTrackingParticles_) {
     see_shareFrac.clear();
@@ -2551,6 +2554,7 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       see_dzErr   .push_back( seedFitOk ? seedTrack.dzError() : 0);
       see_algo    .push_back( algo );
       see_stopReason.push_back( seedStopInfo.stopReasonUC() );
+      see_nCands  .push_back( seedStopInfo.candidatesPerSeed() );
 
       const auto& state = seedTrack.seedRef()->startingState();
       const auto& pos = state.parameters().position();

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -334,13 +334,13 @@ namespace {
 class TrackingNtuple : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit TrackingNtuple(const edm::ParameterSet&);
-  ~TrackingNtuple();
+  ~TrackingNtuple() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 
 private:
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   void clearVariables();
 

--- a/Validation/RecoTrack/python/customiseTrackingNtuple.py
+++ b/Validation/RecoTrack/python/customiseTrackingNtuple.py
@@ -17,11 +17,6 @@ def customiseTrackingNtuple(process):
         if not hasattr(process, "reconstruction_step"):
             raise Exception("TrackingNtuple includeSeeds=True needs reconstruction which is missing")
 
-        # enable seed stopping reason in track candidate producer
-        for trkCand in process.trackingNtuple.trackCandidates.value():
-            producer = getattr(process, cms.InputTag(trkCand).getModuleLabel())
-            producer.produceSeedStopReasons = True
-
     # Replace validation_step with ntuplePath
     if not hasattr(process, "validation_step"):
         raise Exception("TrackingNtuple customise assumes process.validation_step exists")

--- a/Validation/RecoTrack/python/plotting/ntupleEnum.py
+++ b/Validation/RecoTrack/python/plotting/ntupleEnum.py
@@ -93,9 +93,10 @@ SeedStopReason = _Enum(
   NOT_STOPPED = 1,
   SEED_CLEANING = 2,
   NO_TRAJECTORY = 3,
-  FINAL_CLEAN = 4,
-  SMOOTHING_FAILED = 5,
-  SIZE = 6
+  SEED_REGION_REBUILD = 4,
+  FINAL_CLEAN = 5,
+  SMOOTHING_FAILED = 6,
+  SIZE = 7
 )
 
 # to be kept is synch with enum HitSimType in TrackingNtuple.py


### PR DESCRIPTION
This PR
* enables the seed stopping reason by default (introduced in #17792 as optional) in `CkfTrackCandidateMakerBase`
  * add new stopping reason (`SEED_REGION_REBUILD`) whose possibility was omitted earlier
* extends the saved information with the number of trajectory candidates per seed (those that the `maxCand` parameter controls)
  * done by adding new transient class `SeedStopInfo` and storing the stop reason and this number there
* add monitoring of both stop reason and number of candidates per seed to tracking DQM
* in addition some minor cleanup + code style checks

Tested in 9_3_0_pre5, expecting only new histograms and no changes in existing quantities or plots.

@rovere @VinInn @mtosi 