### PR TITLE
reject seed candidates not part of superclusters

### DIFF
--- a/RecoEcal/EgammaClusterAlgos/interface/PFECALSuperClusterAlgo.h
+++ b/RecoEcal/EgammaClusterAlgos/interface/PFECALSuperClusterAlgo.h
@@ -108,6 +108,7 @@ class PFECALSuperClusterAlgo {
   void setSatelliteMerging( const bool doit ) { doSatelliteClusterMerge_ = doit; }
   void setSatelliteThreshold( const double t ) { satelliteThreshold_ = t; }
   void setMajorityFraction( const double f ) { fractionForMajority_ = f; }
+  void setDropUnseedable( const bool d ) { dropUnseedable_ = d; }
   //void setThreshPFClusterMustacheOutBarrel(double thresh){ threshPFClusterMustacheOutBarrel_ = thresh;}
   //void setThreshPFClusterMustacheOutEndcap(double thresh){ threshPFClusterMustacheOutEndcap_ = thresh;}
 
@@ -176,6 +177,7 @@ class PFECALSuperClusterAlgo {
 
   bool doSatelliteClusterMerge_; //rock it
   double satelliteThreshold_, fractionForMajority_;
+  bool dropUnseedable_;
 
   bool _useDynamicDPhi;
 

--- a/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
@@ -395,8 +395,17 @@ buildSuperCluster(CalibClusterPtr& seed,
 
   //temporary fix for HGCal issue
   if (not_clustered == clusters.begin()) {
-    clusters.erase(clusters.begin());
-    return;
+    if(dropUnseedable_){
+      clusters.erase(clusters.begin());
+      return;
+    }
+    else {
+      throw cms::Exception("PFECALSuperClusterAlgo::buildSuperCluster")
+        << "Cluster is not seedable!" << std::endl 
+        << "\tNon-Clustered cluster: e = " << (*not_clustered)->energy_nocalib()
+        << " eta = " << (*not_clustered)->eta() << " phi = " << (*not_clustered)->phi()
+        << std::endl;
+    }
   }
 
   // move the clustered clusters out of available cluster list

--- a/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
@@ -393,7 +393,6 @@ buildSuperCluster(CalibClusterPtr& seed,
     }    
   }
 
-  //temporary fix for HGCal issue
   if (not_clustered == clusters.begin()) {
     if(dropUnseedable_){
       clusters.erase(clusters.begin());

--- a/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
@@ -392,6 +392,13 @@ buildSuperCluster(CalibClusterPtr& seed,
 	<< std::endl;
     }    
   }
+
+  //temporary fix for HGCal issue
+  if (not_clustered == clusters.begin()) {
+    clusters.erase(clusters.begin());
+    return;
+  }
+
   // move the clustered clusters out of available cluster list
   // and into a temporary vector for building the SC  
   CalibratedClusterPtrVector clustered(clusters.begin(),not_clustered);

--- a/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
@@ -172,7 +172,7 @@ namespace {
   };
 }
 
-PFECALSuperClusterAlgo::PFECALSuperClusterAlgo() : beamSpot_(0) { }
+PFECALSuperClusterAlgo::PFECALSuperClusterAlgo() : beamSpot_(nullptr) { }
 
 void PFECALSuperClusterAlgo::
 setPFClusterCalibration(const std::shared_ptr<PFEnergyCalibration>& calib) {
@@ -261,7 +261,7 @@ loadAndSortPFClusters(const edm::Event &iEvent) {
         
     // protection for sim clusters
     if( cluster->caloID().detectors() == 0 && 
-	cluster->hitsAndFractions().size() == 0 ) continue;
+	cluster->hitsAndFractions().empty() ) continue;
 
     CalibratedClusterPtr calib_cluster(new CalibratedPFCluster(cluster));
     switch( cluster->layer() ) {

--- a/RecoEcal/EgammaClusterProducers/interface/PFECALSuperClusterProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/PFECALSuperClusterProducer.h
@@ -43,10 +43,10 @@ class GBRWrapperRcd;
 class PFECALSuperClusterProducer : public edm::stream::EDProducer<> {
  public:  
   explicit PFECALSuperClusterProducer(const edm::ParameterSet&);
-  ~PFECALSuperClusterProducer();
+  ~PFECALSuperClusterProducer() override;
 
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions); 
 

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -68,6 +68,7 @@ particleFlowSuperClusterECALBox = cms.EDProducer(
     doSatelliteClusterMerge = cms.bool(False),
     satelliteClusterSeedThreshold = cms.double(50.0),
     satelliteMajorityFraction = cms.double(0.5),
+    dropUnseedable = cms.bool(False),
     #thresh_PFClusterMustacheOutBarrel = cms.double(0.),
     #thresh_PFClusterMustacheOutEndcap = cms.double(0.),                                             
 
@@ -142,6 +143,7 @@ particleFlowSuperClusterECALMustache = cms.EDProducer(
     doSatelliteClusterMerge = cms.bool(False),
     satelliteClusterSeedThreshold = cms.double(50.0),
     satelliteMajorityFraction = cms.double(0.5),
+    dropUnseedable = cms.bool(False),
     #thresh_PFClusterMustacheOutBarrel = cms.double(0.),
     #thresh_PFClusterMustacheOutEndcap = cms.double(0.), 
 

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusteringSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusteringSequence_cff.py
@@ -20,7 +20,8 @@ phase2_hgcal.toModify(
     PFBasicClusterCollectionEndcap = cms.string(""),
     PFSuperClusterCollectionEndcap = cms.string(""),
     PFSuperClusterCollectionEndcapWithPreshower = cms.string(""),
-    thresh_PFClusterEndcap = cms.double(1.5e-1) # 150 MeV threshold
+    thresh_PFClusterEndcap = cms.double(1.5e-1), # 150 MeV threshold
+    dropUnseedable = cms.bool(True),
 )
 
 particleFlowSuperClusterHGCalFromMultiCl = particleFlowSuperClusterHGCal.clone()

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -110,6 +110,7 @@ PFECALSuperClusterProducer::PFECALSuperClusterProducer(const edm::ParameterSet& 
     iConfig.getParameter<double>("satelliteClusterSeedThreshold");
   double satelliteMajorityFraction = 
     iConfig.getParameter<double>("satelliteMajorityFraction");
+  bool dropUnseedable = iConfig.getParameter<bool>("dropUnseedable");
 
   superClusterAlgo_.setVerbosityLevel(verbose_);
   superClusterAlgo_.setClusteringType(_theclusteringtype);
@@ -136,6 +137,7 @@ PFECALSuperClusterProducer::PFECALSuperClusterProducer(const edm::ParameterSet& 
   superClusterAlgo_.setSatelliteMerging( doSatelliteClusterMerge );
   superClusterAlgo_.setSatelliteThreshold( satelliteClusterSeedThreshold );
   superClusterAlgo_.setMajorityFraction( satelliteMajorityFraction );
+  superClusterAlgo_.setDropUnseedable( dropUnseedable );
   //superClusterAlgo_.setThreshPFClusterMustacheOutBarrel( threshPFClusterMustacheOutBarrel );
   //superClusterAlgo_.setThreshPFClusterMustacheOutEndcap( threshPFClusterMustacheOutEndcap );
 
@@ -355,5 +357,6 @@ void PFECALSuperClusterProducer::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<edm::InputTag>("barrelRecHits",edm::InputTag("ecalRecHit","EcalRecHitsEE"));
   desc.add<edm::InputTag>("endcapRecHits",edm::InputTag("ecalRecHit","EcalRecHitsEB"));
   desc.add<std::string>("PFSuperClusterCollectionEndcapWithPreshower","particleFlowSuperClusterECALEndcapWithPreshower");
+  desc.add<bool>("dropUnseedable",false);
   descriptions.add("particleFlowSuperClusterECALMustache",desc);
 }


### PR DESCRIPTION
During relval production for CMSSW_9_3_0_pre5, a crash was observed in `PFECALSuperClusterAlgo`. An [example config+log](http://cms-unified.web.cern.ch/cms-unified/joblogs/sandhya_RVCMSSW_9_3_0_pre5TTbar_14TeV_Timing__2023D17noPUTiming_170906_152309_28/139/RecoFullGlobal_Timing_2023D17/1a3ab292-9416-11e7-a633-02163e00d7b3-0-3-logArchive/cmsRun1/) was provided, which let me get a better stacktrace:
```
#0  0x00007fffad5b4675 in reco::CaloCluster::setCorrectedEnergy (this=0x7fff940785f0, cenergy=0)
    at /cvmfs/cms.cern.ch/slc6_amd64_gcc630/cms/cmssw/CMSSW_9_3_0_pre5/src/DataFormats/CaloRecHit/interface/CaloCluster.h:112
#1  PFECALSuperClusterAlgo::buildSuperCluster (this=this@entry=0x7fffa1082568, seed=..., clusters=std::vector of length 153, capacity 256 = {...})
    at /uscms_data/d3/pedrok/phase2/hgcal/CMSSW_9_3_0_pre5/src/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc:494
#2  0x00007fffad5b6628 in PFECALSuperClusterAlgo::buildAllSuperClusters (this=this@entry=0x7fffa1082568,
    clusters=std::vector of length 153, capacity 256 = {...}, seedthresh=<optimized out>)
    at /uscms_data/d3/pedrok/phase2/hgcal/CMSSW_9_3_0_pre5/src/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc:328
#3  0x00007fffad5b704a in PFECALSuperClusterAlgo::run (this=this@entry=0x7fffa1082568)
    at /uscms_data/d3/pedrok/phase2/hgcal/CMSSW_9_3_0_pre5/src/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc:314
#4  0x00007fffa679b8f8 in PFECALSuperClusterProducer::produce (this=0x7fffa1082400, iEvent=..., iSetup=...)
    at /uscms_data/d3/pedrok/phase2/hgcal/CMSSW_9_3_0_pre5/src/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc:187
```

Using gdb, I found an apparent problem in frame 1:
```
(gdb) frame 1
#1  PFECALSuperClusterAlgo::buildSuperCluster (this=this@entry=0x7fffa1082568, seed=..., clusters=std::vector of length 153, capacity 256 = {...})
    at /uscms_data/d3/pedrok/phase2/hgcal/CMSSW_9_3_0_pre5/src/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc:494
494       new_sc.setCorrectedEnergy(corrSCEnergy);
(gdb) print new_sc
$1 = {<reco::CaloCluster> = {_vptr.CaloCluster = 0x7ffff3f37580 <vtable for reco::SuperCluster+16>, energy_ = 0, correctedEnergy_ = -1,
    correctedEnergyUncertainty_ = -1, position_ = {fCoordinates = {fX = -nan(0x8000000000000), fY = -nan(0x8000000000000), fZ = -nan(0x8000000000000)}},
    caloID_ = {_vptr.CaloID = 0x7ffff3f374a8 <vtable for reco::CaloID+16>, detectors_ = 0}, hitsAndFractions_ = std::vector of length 0, capacity 0,
    algoID_ = reco::CaloCluster::undefined, seedId_ = {static kDetOffset = 28, static kSubdetOffset = 25, id_ = 0}, flags_ = 0,
    static flagsMask_ = 268435455, static flagsOffset_ = 28}, seed_ = {core_ = {cachePtr_ = {_M_b = {_M_p = 0x0}}, processIndex_ = 0, productIndex_ = 0},
    key_ = 18446744073709551615}, clusters_ = {<edm::PtrVectorBase> = {<No data fields>}, <No data fields>},
  preshowerClusters_ = {<edm::PtrVectorBase> = {<No data fields>}, <No data fields>}, preshowerEnergy_ = 0, rawEnergy_ = 0, phiWidth_ = 0, etaWidth_ = 0,
  preshowerEnergy1_ = 0, preshowerEnergy2_ = 0}
(gdb) print clustered
$6 = std::vector of length 0, capacity 0
```

This leads to divide by 0 problems, so the cluster has nan coordinates and no energy. I also turned on the verbose output and saw this:
```
Dumping cluster detail  Passed seed: e = 5.18964 eta = -2.24025 phi = 2.99611
        Clustered cluster: e = 5.18964 eta = -2.24025 phi = 2.99611
    Non-Clustered cluster: e = 0.0662978 eta = -1.71095 phi = -1.38067
...
Dumping cluster detail  Passed seed: e = 0.0662978 eta = -1.71095 phi = -1.38067
    Non-Clustered cluster: e = 0.0662978 eta = -1.71095 phi = -1.38067
```

Somehow the algorithm ends up in a state where everything is a "non-clustered cluster", so the assumption that there's a "clustered cluster" to start the new supercluster is violated. Further description from @rovere:
>Ok, I have some more details about the crash.
We have an HGCAL cluster whose energy/uncalib_energy are: E: 3.21491
UE: 0.0662978, respectively.
Now, the logic of SC is that all clusters are first ordered by Et (in
this case Et uses the Energy to order the clusters), and this little
cluster sits quite high in the final vector since it has a ptfast of
1.1251, thanks to its relatively high energy.
After that, the clusters are stable_partitioned so that all clusters
above a threshold are promoted to be seeds for a possible SC. The
threshold is 1 GeV and is applied on Et (of ptfast, if you prefer) so
this little guy passes the selection and happily becomes a seed
candidate.
After that, the clusters are again stable_partitioned so that all
clusters within the dyn window of the mustache algorithm for the
specific seed under consideration appear first. The problem is that in
doing this partitioning, this little guy is rejected, i.e. it is not
part of the SC it is seeding! And that's because in the mustache
algorithm there is this nice line[1] that is using the
**uncalibrated** energy as input. In this, maybe extremely unlucky
case, its value is 0.066XXX which is below the allowed (and **not
protected**) value of 0.07943XX that makes the sqrt negative, hence
quite a bit of nan, and the following logic simply does not hold any
longer, since the seed itself is not part of the SC.
[1]
https://github.com/cms-sw/cmssw/blob/master/RecoEcal/EgammaCoreTools/src/Mustache.cc#L38

For now, we just discard such clusters to let the algorithm progress. Eventually, for HGCal we should set uncalibrated energy equal to calibrated energy, and consider the consistency of the clustering algorithms in terms of which quantity they use.

This PR is critical for HGCal TDR production, so will be backported to 93X.

attn: @cseez, @bendavid, @felicepantaleo 