### PR TITLE
HGCAL ToA for overlapping events

### DIFF
--- a/DataFormats/HGCDigi/interface/HGCSample.h
+++ b/DataFormats/HGCDigi/interface/HGCSample.h
@@ -20,9 +20,9 @@ public:
   /**
      @short CTOR
    */
- HGCSample() : value_(0) { }
- HGCSample(uint32_t value) : value_(value) { }
- HGCSample( const HGCSample& o ) : value_(o.value_) { }
+ HGCSample() : value_(0), toaFired_(0) { }
+ HGCSample(uint32_t value) : value_(value), toaFired_(0) { }
+ HGCSample( const HGCSample& o ) : value_(o.value_), toaFired_(o.toaFired_) { }
 
   /**
      @short setters

--- a/DataFormats/HGCDigi/interface/HGCSample.h
+++ b/DataFormats/HGCDigi/interface/HGCSample.h
@@ -20,8 +20,8 @@ public:
   /**
      @short CTOR
    */
- HGCSample() : value_(0), toaFired_(0) { }
- HGCSample(uint32_t value) : value_(value), toaFired_(0) { }
+ HGCSample() : value_(0), toaFired_(false) { }
+ HGCSample(uint32_t value) : value_(value), toaFired_(false) { }
  HGCSample( const HGCSample& o ) : value_(o.value_), toaFired_(o.toaFired_) { }
 
   /**

--- a/DataFormats/HGCDigi/interface/HGCSample.h
+++ b/DataFormats/HGCDigi/interface/HGCSample.h
@@ -30,6 +30,7 @@ public:
   void setThreshold(bool thr)           { setWord(thr,  kThreshMask, kThreshShift); }
   void setMode(bool mode)               { setWord(mode, kModeMask,   kModeShift);   }
   void setToA(uint16_t toa)             { setWord(toa,  kToAMask,    kToAShift);    }
+  void setToAValid(bool toaFired)       { toaFired_ = toaFired;  }
   void setData(uint16_t data)           { setWord(data, kDataMask,   kDataShift);   }
   void set(bool thr, bool mode,uint16_t toa, uint16_t data) 
   { 
@@ -56,6 +57,7 @@ public:
   uint32_t raw()  const      { return value_;                   }
   bool threshold() const     { return ( (value_ >> kThreshShift) & kThreshMask );  }
   bool mode() const          { return ( (value_ >> kModeShift)   & kModeMask   );  }
+  bool getToAValid() const   { return toaFired_;                }
   uint32_t toa()  const      { return ( (value_ >> kToAShift)    & kToAMask    ); }
   uint32_t data()  const     { return ( (value_ >> kDataShift)   & kDataMask   ); }
   uint32_t operator()()      { return value_;                   }
@@ -77,6 +79,7 @@ private:
 
   // a 32-bit word
   uint32_t value_;
+  bool toaFired_;
 };
 
   

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalUncalibRecHitRecWeightsAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalUncalibRecHitRecWeightsAlgo.h
@@ -81,7 +81,7 @@ template<class C> class HGCalUncalibRecHitRecWeightsAlgo
         // LG (11/04/2016):
         // offset the TDC upwards to reflect the bin center
 	amplitude_ = ( std::floor(tdcOnsetfC_/adcLSB_) + 1.0 )* adcLSB_ + ( double(sample.data()) + 0.5) * tdcLSB_;
-	jitter_    = double(sample.toa()) * toaLSBToNS_;
+	if(sample.data() != 0.) jitter_    = double(sample.toa()) * toaLSBToNS_;
 	LogDebug("HGCUncalibratedRecHit") << "TDC+: set the charge to: " << amplitude_ << ' ' << sample.data() 
                                           << ' ' << tdcLSB_ << std::endl
                                           << "TDC+: set the ToA to: " << jitter_ << ' ' 
@@ -89,7 +89,7 @@ template<class C> class HGCalUncalibRecHitRecWeightsAlgo
                                           << " flag=" << flag << std::endl;
       } else {
 	amplitude_ = double(sample.data()) * adcLSB_;
-	if(amplitude_ > tdcForToaOnsetfC_[thickness-1]) {jitter_    = double(sample.toa()) * toaLSBToNS_;}
+	if(sample.toa() != 0.) {jitter_    = double(sample.toa()) * toaLSBToNS_;}
 	LogDebug("HGCUncalibratedRecHit") << "ADC+: set the charge to: " << amplitude_ << ' ' << sample.data() 
                                           << ' ' << adcLSB_ << ' ' 
 					  << "TDC+: set the ToA to: " << jitter_ << ' '

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalUncalibRecHitRecWeightsAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalUncalibRecHitRecWeightsAlgo.h
@@ -77,7 +77,7 @@ template<class C> class HGCalUncalibRecHitRecWeightsAlgo
                                           << " flag=" << flag << std::endl;
       } else {
 	amplitude_ = double(sample.data()) * adcLSB_;
-	if(sample.getToAValid()) {jitter_    = double(sample.toa()) * toaLSBToNS_;}
+	if(sample.getToAValid()) jitter_    = double(sample.toa()) * toaLSBToNS_;
 	LogDebug("HGCUncalibratedRecHit") << "ADC+: set the charge to: " << amplitude_ << ' ' << sample.data() 
                                           << ' ' << adcLSB_ << ' ' 
 					  << "TDC+: set the ToA to: " << jitter_ << ' '
@@ -105,7 +105,6 @@ template<class C> class HGCalUncalibRecHitRecWeightsAlgo
    double adcLSB_, tdcLSB_, toaLSBToNS_, tdcOnsetfC_;
    bool   isSiFESim_;  
    std::vector<double> fCPerMIP_;
-   std::array<float, 3> tdcForToaOnsetfC_;
    const HGCalDDDConstants* ddd_;
 };
 #endif

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalUncalibRecHitRecWeightsAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalUncalibRecHitRecWeightsAlgo.h
@@ -81,7 +81,7 @@ template<class C> class HGCalUncalibRecHitRecWeightsAlgo
         // LG (11/04/2016):
         // offset the TDC upwards to reflect the bin center
 	amplitude_ = ( std::floor(tdcOnsetfC_/adcLSB_) + 1.0 )* adcLSB_ + ( double(sample.data()) + 0.5) * tdcLSB_;
-	if(sample.data() != 0.) jitter_    = double(sample.toa()) * toaLSBToNS_;
+	if(sample.toa() != 0.) jitter_    = double(sample.toa()) * toaLSBToNS_;
 	LogDebug("HGCUncalibratedRecHit") << "TDC+: set the charge to: " << amplitude_ << ' ' << sample.data() 
                                           << ' ' << tdcLSB_ << std::endl
                                           << "TDC+: set the ToA to: " << jitter_ << ' ' 

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalUncalibRecHitRecWeightsAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalUncalibRecHitRecWeightsAlgo.h
@@ -81,7 +81,7 @@ template<class C> class HGCalUncalibRecHitRecWeightsAlgo
         // LG (11/04/2016):
         // offset the TDC upwards to reflect the bin center
 	amplitude_ = ( std::floor(tdcOnsetfC_/adcLSB_) + 1.0 )* adcLSB_ + ( double(sample.data()) + 0.5) * tdcLSB_;
-	if(sample.toa() != 0.) jitter_    = double(sample.toa()) * toaLSBToNS_;
+	if(sample.getToAValid()) jitter_    = double(sample.toa()) * toaLSBToNS_;
 	LogDebug("HGCUncalibratedRecHit") << "TDC+: set the charge to: " << amplitude_ << ' ' << sample.data() 
                                           << ' ' << tdcLSB_ << std::endl
                                           << "TDC+: set the ToA to: " << jitter_ << ' ' 
@@ -89,7 +89,7 @@ template<class C> class HGCalUncalibRecHitRecWeightsAlgo
                                           << " flag=" << flag << std::endl;
       } else {
 	amplitude_ = double(sample.data()) * adcLSB_;
-	if(sample.toa() != 0.) {jitter_    = double(sample.toa()) * toaLSBToNS_;}
+	if(sample.getToAValid()) {jitter_    = double(sample.toa()) * toaLSBToNS_;}
 	LogDebug("HGCUncalibratedRecHit") << "ADC+: set the charge to: " << amplitude_ << ' ' << sample.data() 
                                           << ' ' << adcLSB_ << ' ' 
 					  << "TDC+: set the ToA to: " << jitter_ << ' '

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalUncalibRecHitRecWeightsAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalUncalibRecHitRecWeightsAlgo.h
@@ -35,12 +35,6 @@ template<class C> class HGCalUncalibRecHitRecWeightsAlgo
 
   void set_tdcOnsetfC(const double tdcOnset) { tdcOnsetfC_ = tdcOnset; }
 
-  void set_tdcForToaOnsetfC(const std::vector<double>& tdcForToaOnset) { 
-    for( unsigned i = 0; i < tdcForToaOnset.size(); ++i ) {
-      tdcForToaOnsetfC_[i] = (float)tdcForToaOnset[i];
-    }
-  }
-
   void set_fCPerMIP(const std::vector<double>& fCPerMIP) { 
     if( std::any_of(fCPerMIP.cbegin(), 
                     fCPerMIP.cend(), 
@@ -60,12 +54,6 @@ template<class C> class HGCalUncalibRecHitRecWeightsAlgo
     double amplitude_(-1.),  pedestal_(-1.), jitter_(-1.), chi2_(-1.);
     uint32_t flag = 0;
 
-    int thickness = 1;
-    if( ddd_ != nullptr ) {
-      HGCalDetId hid(dataFrame.id());
-      thickness = ddd_->waferTypeL(hid.wafer());
-    }
-    
     constexpr int iSample=2; //only in-time sample
     const auto& sample = dataFrame.sample(iSample);
     
@@ -100,6 +88,12 @@ template<class C> class HGCalUncalibRecHitRecWeightsAlgo
       LogDebug("HGCUncalibratedRecHit") << "ADC+: set the charge to: " << amplitude_ << ' ' << sample.data() 
 						 << ' ' << adcLSB_ << ' ' << std::endl;
     }
+    
+    int thickness = 1;
+    if( ddd_ != nullptr ) {
+      HGCalDetId hid(dataFrame.id());
+      thickness = ddd_->waferTypeL(hid.wafer());
+    }    
     amplitude_ = amplitude_/fCPerMIP_[thickness-1];
 
     LogDebug("HGCUncalibratedRecHit") << "Final uncalibrated amplitude : " << amplitude_ << std::endl;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.cc
@@ -15,8 +15,9 @@ void configureIt(const edm::ParameterSet& conf,
   constexpr char tdcNbits[]         = "tdcNbits";
   constexpr char tdcSaturation[]    = "tdcSaturation";
   constexpr char tdcOnset[]         = "tdcOnset";
+  constexpr char tdcForToaOnset[]   = "tdcForToaOnset";
   constexpr char toaLSB_ns[]        = "toaLSB_ns";
-  constexpr char fCPerMIP[]          = "fCPerMIP";
+  constexpr char fCPerMIP[]         = "fCPerMIP";
   
   if( conf.exists(isSiFE) ) {
     maker.set_isSiFESim(conf.getParameter<bool>(isSiFE));
@@ -44,6 +45,12 @@ void configureIt(const edm::ParameterSet& conf,
     maker.set_TDCLSB(-1.);
     maker.set_tdcOnsetfC(-1.);
   } 
+
+  if( conf.exists(tdcForToaOnset) ) {
+    maker.set_tdcForToaOnsetfC(conf.getParameter<std::vector<double> >(tdcForToaOnset)); // in fC for each thickness
+  } else {
+    maker.set_tdcForToaOnsetfC(std::vector<double>({-1.0}));
+  }
     
   if( conf.exists(toaLSB_ns) ) {
     maker.set_toaLSBToNS(conf.getParameter<double>(toaLSB_ns));

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalUncalibRecHitWorkerWeights.cc
@@ -15,9 +15,8 @@ void configureIt(const edm::ParameterSet& conf,
   constexpr char tdcNbits[]         = "tdcNbits";
   constexpr char tdcSaturation[]    = "tdcSaturation";
   constexpr char tdcOnset[]         = "tdcOnset";
-  constexpr char tdcForToaOnset[]   = "tdcForToaOnset";
   constexpr char toaLSB_ns[]        = "toaLSB_ns";
-  constexpr char fCPerMIP[]         = "fCPerMIP";
+  constexpr char fCPerMIP[]          = "fCPerMIP";
   
   if( conf.exists(isSiFE) ) {
     maker.set_isSiFESim(conf.getParameter<bool>(isSiFE));
@@ -46,12 +45,6 @@ void configureIt(const edm::ParameterSet& conf,
     maker.set_tdcOnsetfC(-1.);
   } 
 
-  if( conf.exists(tdcForToaOnset) ) {
-    maker.set_tdcForToaOnsetfC(conf.getParameter<std::vector<double> >(tdcForToaOnset)); // in fC for each thickness
-  } else {
-    maker.set_tdcForToaOnsetfC(std::vector<double>({-1.0}));
-  }
-    
   if( conf.exists(toaLSB_ns) ) {
     maker.set_toaLSBToNS(conf.getParameter<double>(toaLSB_ns));
   } else {

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
@@ -21,7 +21,6 @@ HGCalUncalibRecHit = cms.EDProducer(
         tdcNbits      = hgceeDigitizer.digiCfg.feCfg.tdcNbits,
         tdcSaturation = hgceeDigitizer.digiCfg.feCfg.tdcSaturation_fC,
         tdcOnset      = hgceeDigitizer.digiCfg.feCfg.tdcOnset_fC,
-        tdcForToaOnset= hgceeDigitizer.digiCfg.feCfg.tdcForToaOnset_fC,
         toaLSB_ns     = hgceeDigitizer.digiCfg.feCfg.toaLSB_ns,
         fCPerMIP      = cms.vdouble(1.25,2.57,3.88) #100um, 200um, 300um
         ),
@@ -35,7 +34,6 @@ HGCalUncalibRecHit = cms.EDProducer(
         tdcNbits      = hgchefrontDigitizer.digiCfg.feCfg.tdcNbits,
         tdcSaturation = hgchefrontDigitizer.digiCfg.feCfg.tdcSaturation_fC,
         tdcOnset      = hgchefrontDigitizer.digiCfg.feCfg.tdcOnset_fC,
-        tdcForToaOnset= hgchefrontDigitizer.digiCfg.feCfg.tdcForToaOnset_fC,
         toaLSB_ns     = hgchefrontDigitizer.digiCfg.feCfg.toaLSB_ns,
         fCPerMIP      = cms.vdouble(1.25,2.57,3.88) #100um, 200um, 300um
         ),

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
@@ -21,6 +21,7 @@ HGCalUncalibRecHit = cms.EDProducer(
         tdcNbits      = hgceeDigitizer.digiCfg.feCfg.tdcNbits,
         tdcSaturation = hgceeDigitizer.digiCfg.feCfg.tdcSaturation_fC,
         tdcOnset      = hgceeDigitizer.digiCfg.feCfg.tdcOnset_fC,
+        tdcForToaOnset= hgceeDigitizer.digiCfg.feCfg.tdcForToaOnset_fC,
         toaLSB_ns     = hgceeDigitizer.digiCfg.feCfg.toaLSB_ns,
         fCPerMIP      = cms.vdouble(1.25,2.57,3.88) #100um, 200um, 300um
         ),
@@ -34,6 +35,7 @@ HGCalUncalibRecHit = cms.EDProducer(
         tdcNbits      = hgchefrontDigitizer.digiCfg.feCfg.tdcNbits,
         tdcSaturation = hgchefrontDigitizer.digiCfg.feCfg.tdcSaturation_fC,
         tdcOnset      = hgchefrontDigitizer.digiCfg.feCfg.tdcOnset_fC,
+        tdcForToaOnset= hgchefrontDigitizer.digiCfg.feCfg.tdcForToaOnset_fC,
         toaLSB_ns     = hgchefrontDigitizer.digiCfg.feCfg.toaLSB_ns,
         fCPerMIP      = cms.vdouble(1.25,2.57,3.88) #100um, 200um, 300um
         ),

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h
@@ -116,6 +116,8 @@ private :
   uint32_t nEvents_;
 
   std::vector<float> cce_;
+  
+  std::map< uint32_t, std::vector< std::pair<float, float> > > hitRefs_bx0;
 };
 
 

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
@@ -46,6 +46,7 @@ class HGCDigitizerBase {
   float keV2fC() const { return keV2fC_; }
   bool toaModeByEnergy() const { return (myFEelectronics_->toaMode()==HGCFEElectronics<DFr>::WEIGHTEDBYE); }
   float tdcOnset() const { return myFEelectronics_->getTDCOnset(); }
+  std::array<float,3> tdcForToaOnset() const { return myFEelectronics_->getTDCForToaOnset(); }
 
   /**
      @short a trivial digitization: sum energies and digitize without noise

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
@@ -46,7 +46,7 @@ class HGCDigitizerBase {
   float keV2fC() const { return keV2fC_; }
   bool toaModeByEnergy() const { return (myFEelectronics_->toaMode()==HGCFEElectronics<DFr>::WEIGHTEDBYE); }
   float tdcOnset() const { return myFEelectronics_->getTDCOnset(); }
-  std::array<float,3> tdcForToaOnset() const { return myFEelectronics_->getTDCForToaOnset(); }
+  std::array<float,3> tdcForToAOnset() const { return myFEelectronics_->getTDCForToAOnset(); }
 
   /**
      @short a trivial digitization: sum energies and digitize without noise

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
@@ -44,14 +44,14 @@ class HGCFEElectronics
   }
 
 
-  void SetNoiseValues(std::vector<float> noise_fC){
-    for( auto noise : noise_fC ) { noise_fC_.push_back( noise ); }
+  void SetNoiseValues(const std::vector<float>& noise_fC){
+    noise_fC_.insert(noise_fC_.end(), noise_fC.begin(), noise_fC.end());
   };
 
   float getTimeJitter(float totalCharge, int thickness){
-    float A2 = jitterNoise2_ns_[thickness-1];
-    float C2 = jitterConstant2_ns_[thickness-1];
-    float X2 = pow((totalCharge/noise_fC_[thickness-1]), 2.);
+    float A2 = jitterNoise2_ns_.at(thickness-1);
+    float C2 = jitterConstant2_ns_.at(thickness-1);
+    float X2 = pow((totalCharge/noise_fC_.at(thickness-1)), 2.);
     float jitter2 = A2 / X2 + C2;
     return sqrt(jitter2);
   };
@@ -63,7 +63,7 @@ class HGCFEElectronics
   float getTDClsb()       { return tdcLSB_fC_;       }  
   float getADCThreshold() { return adcThreshold_fC_; }
   float getTDCOnset()     { return tdcOnset_fC_;     }
-  std::array<float,3> getTDCForToaOnset()    { return tdcForToaOnset_fC_; }
+  std::array<float,3> getTDCForToAOnset()    { return tdcForToAOnset_fC_; }
   void setADClsb(float newLSB) { adcLSB_fC_=newLSB; }
 
   /**
@@ -97,7 +97,7 @@ class HGCFEElectronics
   //private members
   uint32_t fwVersion_;
   std::array<float,6> adcPulse_, pulseAvgT_;
-  std::array<float,3> tdcForToaOnset_fC_;
+  std::array<float,3> tdcForToAOnset_fC_;
   std::vector<float> tdcChargeDrainParameterisation_;
   float adcSaturation_fC_, adcLSB_fC_, tdcLSB_fC_, tdcSaturation_fC_,
     adcThreshold_fC_, tdcOnset_fC_, toaLSB_ns_, tdcResolutionInNs_;

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
@@ -43,6 +43,19 @@ class HGCFEElectronics
       }
   }
 
+
+  void SetNoiseValues(std::vector<float> noise_fC){
+    for( auto noise : noise_fC ) { noise_fC_.push_back( noise ); }
+  };
+
+  float getTimeJitter(float totalCharge, int thickness){
+    float A2 = jitterNoise2_ns_[thickness-1];
+    float C2 = jitterConstant2_ns_[thickness-1];
+    float X2 = pow((totalCharge/noise_fC_[thickness-1]), 2.);
+    float jitter2 = A2 / X2 + C2;
+    return sqrt(jitter2);
+  };
+
   /**
      @short returns the LSB in MIP currently configured
   */
@@ -50,6 +63,7 @@ class HGCFEElectronics
   float getTDClsb()       { return tdcLSB_fC_;       }  
   float getADCThreshold() { return adcThreshold_fC_; }
   float getTDCOnset()     { return tdcOnset_fC_;     }
+  std::array<float,3> getTDCForToaOnset()    { return tdcForToaOnset_fC_; }
   void setADClsb(float newLSB) { adcLSB_fC_=newLSB; }
 
   /**
@@ -83,13 +97,16 @@ class HGCFEElectronics
   //private members
   uint32_t fwVersion_;
   std::array<float,6> adcPulse_, pulseAvgT_;
+  std::array<float,3> tdcForToaOnset_fC_;
   std::vector<float> tdcChargeDrainParameterisation_;
   float adcSaturation_fC_, adcLSB_fC_, tdcLSB_fC_, tdcSaturation_fC_,
-    adcThreshold_fC_, tdcOnset_fC_, toaLSB_ns_, tdcResolutionInNs_; 
+    adcThreshold_fC_, tdcOnset_fC_, toaLSB_ns_, tdcResolutionInNs_;
+  std::array<float,3> jitterNoise2_ns_, jitterConstant2_ns_;
+  std::vector<float> noise_fC_;
   uint32_t toaMode_;
   bool thresholdFollowsMIP_;
   //caches
-  std::array<bool,hgc::nSamples>  busyFlags, totFlags;
+  std::array<bool,hgc::nSamples>  busyFlags, totFlags, totForToaFlags;
   hgc::HGCSimHitData newCharge, toaFromToT;
 };
 

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
@@ -106,7 +106,7 @@ class HGCFEElectronics
   uint32_t toaMode_;
   bool thresholdFollowsMIP_;
   //caches
-  std::array<bool,hgc::nSamples>  busyFlags, totFlags, totForToaFlags;
+  std::array<bool,hgc::nSamples>  busyFlags, totFlags, toaFlags;
   hgc::HGCSimHitData newCharge, toaFromToT;
 };
 

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -54,7 +54,7 @@ hgceeDigitizer = cms.PSet(
             # raise usage of TDC and mode flag (from J. Kaplon)
             tdcOnset_fC       = cms.double(60),
             # raise usage of TDC for TOA only
-            tdcForToaOnset_fC = cms.vdouble(60., 60., 60.),
+            tdcForToAOnset_fC = cms.vdouble(60., 60., 60.),
             # LSB for time of arrival estimate from TDC in ns
             toaLSB_ns         = cms.double(0.005),
             #toa computation mode (0=by weighted energy, 1=simple threshold)
@@ -113,7 +113,7 @@ hgchefrontDigitizer = cms.PSet(
             # raise usage of TDC and mode flag (from J. Kaplon)
             tdcOnset_fC       = cms.double(60), 
             # raise usage of TDC for TOA only                                                                                                                            
-            tdcForToaOnset_fC = cms.vdouble(60., 60., 60.),
+            tdcForToAOnset_fC = cms.vdouble(60., 60., 60.),
             # LSB for time of arrival estimate from TDC in ns
             toaLSB_ns         = cms.double(0.005),
             #toa computation mode (0=by weighted energy, 1=simple threshold)

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -39,6 +39,10 @@ hgceeDigitizer = cms.PSet(
             adcSaturation_fC  = cms.double(100),
             # the tdc resolution smearing (in picoseconds)
             tdcResolutionInPs = cms.double( 0.001 ),
+            # jitter for timing noise term ns
+            jitterNoise_ns = cms.vdouble(0., 0., 0.),
+            # jitter for timing noise term ns
+            jitterConstant_ns = cms.vdouble(0.00, 0.00, 0.00),
             # LSB for TDC, assuming 12 bit dynamic range to 10 pC
             tdcNbits          = cms.uint32(12),
             # TDC saturation
@@ -48,7 +52,9 @@ hgceeDigitizer = cms.PSet(
             adcThreshold_fC   = cms.double(0.672),
             thresholdFollowsMIP        = cms.bool(thresholdTracksMIP),
             # raise usage of TDC and mode flag (from J. Kaplon)
-            tdcOnset_fC       = cms.double(60) ,
+            tdcOnset_fC       = cms.double(60),
+            # raise usage of TDC for TOA only
+            tdcForToaOnset_fC = cms.vdouble(60., 60., 60.),
             # LSB for time of arrival estimate from TDC in ns
             toaLSB_ns         = cms.double(0.005),
             #toa computation mode (0=by weighted energy, 1=simple threshold)
@@ -92,6 +98,10 @@ hgchefrontDigitizer = cms.PSet(
             adcSaturation_fC  = cms.double(100),
             # the tdc resolution smearing (in picoseconds)
             tdcResolutionInPs = cms.double( 0.001 ),
+            # jitter for timing noise term ns
+            jitterNoise_ns = cms.vdouble(0., 0., 0.),
+            # jitter for timing noise term ns
+            jitterConstant_ns = cms.vdouble(0.00, 0.00, 0.00),
             # LSB for TDC, assuming 12 bit dynamic range to 10 pC
             tdcNbits          = cms.uint32(12),
             # TDC saturation
@@ -101,7 +111,9 @@ hgchefrontDigitizer = cms.PSet(
             adcThreshold_fC   = cms.double(0.672),
             thresholdFollowsMIP        = cms.bool(thresholdTracksMIP),
             # raise usage of TDC and mode flag (from J. Kaplon)
-            tdcOnset_fC       = cms.double(60) ,
+            tdcOnset_fC       = cms.double(60), 
+            # raise usage of TDC for TOA only                                                                                                                            
+            tdcForToaOnset_fC = cms.vdouble(60., 60., 60.),
             # LSB for time of arrival estimate from TDC in ns
             toaLSB_ns         = cms.double(0.005),
             #toa computation mode (0=by weighted energy, 1=simple threshold)

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
@@ -315,22 +315,22 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const &hits,
   
   //configuration to apply for the computation of time-of-flight
   bool weightToAbyEnergy(false);
-  std::array<float, 3> tdcForToaOnset{ {0.f, 0.f, 0.f} };
+  std::array<float, 3> tdcForToAOnset{ {0.f, 0.f, 0.f} };
   float keV2fC(0.f);
   switch( mySubDet_ ) {
   case ForwardSubdetector::HGCEE:
     weightToAbyEnergy = theHGCEEDigitizer_->toaModeByEnergy();
-    tdcForToaOnset    = theHGCEEDigitizer_->tdcForToaOnset();
+    tdcForToAOnset    = theHGCEEDigitizer_->tdcForToAOnset();
     keV2fC            = theHGCEEDigitizer_->keV2fC();
     break;
   case ForwardSubdetector::HGCHEF:
     weightToAbyEnergy = theHGCHEfrontDigitizer_->toaModeByEnergy();
-    tdcForToaOnset    = theHGCHEfrontDigitizer_->tdcForToaOnset();
+    tdcForToAOnset    = theHGCHEfrontDigitizer_->tdcForToAOnset();
     keV2fC            = theHGCHEfrontDigitizer_->keV2fC();
     break;
   case ForwardSubdetector::HGCHEB:
     weightToAbyEnergy = theHGCHEbackDigitizer_->toaModeByEnergy();
-    tdcForToaOnset    = theHGCHEbackDigitizer_->tdcForToaOnset();
+    tdcForToAOnset    = theHGCHEbackDigitizer_->tdcForToAOnset();
     keV2fC            = theHGCHEbackDigitizer_->keV2fC();     
     break;
   default:
@@ -411,7 +411,7 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const &hits,
 	std::sort(hitRefs_bx0[id].begin(), hitRefs_bx0[id].end(), comparePairs);
 	for(const auto& step : hitRefs_bx0[id]){
 	  accChargeForToA += step.first;
-	  if(accChargeForToA > tdcForToaOnset[waferThickness-1] && step.second != hitRefs_bx0[id].back().second){
+	  if(accChargeForToA > tdcForToAOnset[waferThickness-1] && step.second != hitRefs_bx0[id].back().second){
 	    while(step != hitRefs_bx0[id].back())  hitRefs_bx0[id].pop_back();
 	    break;
 	  }
@@ -419,7 +419,7 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const &hits,
 	orderChanged = true;
       }
       else{
-        if(accCharge - charge <= tdcForToaOnset[waferThickness-1]){
+        if(accCharge - charge <= tdcForToAOnset[waferThickness-1]){
           hitRefs_bx0[id].push_back(std::pair<float, float>(charge, tof));
           accChargeForToA = accCharge;
         }
@@ -428,14 +428,14 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const &hits,
 
     //time-of-arrival (check how to be used)
     if(weightToAbyEnergy) (simHitIt->second).hit_info[1][itime] += charge*tof;
-    else if(accChargeForToA > tdcForToaOnset[waferThickness-1] &&
+    else if(accChargeForToA > tdcForToAOnset[waferThickness-1] &&
 	    ((simHitIt->second).hit_info[1][itime] == 0 || orderChanged == true) ){
       float fireTDC = hitRefs_bx0[id].back().second;
       if (hitRefs_bx0[id].size() > 1){
 	float chargeBeforeThr = 0.f;
 	float tofchargeBeforeThr = 0.f;
 	for(const auto& step : hitRefs_bx0[id]){
-	  if(step.first + chargeBeforeThr <= tdcForToaOnset[waferThickness-1]){
+	  if(step.first + chargeBeforeThr <= tdcForToAOnset[waferThickness-1]){
 	    chargeBeforeThr += step.first;
 	    tofchargeBeforeThr = step.second;
 	  }
@@ -443,7 +443,7 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const &hits,
 	}
 	float deltaQ = accChargeForToA - chargeBeforeThr;
 	float deltaTOF = fireTDC - tofchargeBeforeThr;
-	fireTDC = (tdcForToaOnset[waferThickness-1] - chargeBeforeThr) * deltaTOF / deltaQ + tofchargeBeforeThr;
+	fireTDC = (tdcForToAOnset[waferThickness-1] - chargeBeforeThr) * deltaTOF / deltaQ + tofchargeBeforeThr;
       }
       (simHitIt->second).hit_info[1][itime] = fireTDC;                                                                  
     }

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
@@ -431,8 +431,8 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const &hits,
 
     //time-of-arrival (check how to be used)
     if(weightToAbyEnergy) (simHitIt->second).hit_info[1][itime] += charge*tof;
-    if(accChargeForToA > tdcForToaOnset[waferThickness-1] &&
-       ((simHitIt->second).hit_info[1][itime] == 0 || orderChanged == true) ){
+    else if(accChargeForToA > tdcForToaOnset[waferThickness-1] &&
+	    ((simHitIt->second).hit_info[1][itime] == 0 || orderChanged == true) ){
       float fireTDC = hitRefs_bx0[id].back().second;
       if (hitRefs_bx0[id].size() > 1){
 	float chargeBeforeThr = 0.;
@@ -450,7 +450,7 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const &hits,
       }
       (simHitIt->second).hit_info[1][itime] = fireTDC;                                                                  
     }
-
+    
   }
   hitRefs.clear();
 }

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
@@ -399,7 +399,7 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const &hits,
 
     //working version with pileup only for in-time hits
     int waferThickness = getCellThickness(geom,id);
-    float accChargeForToA = 0;
+    float accChargeForToA = 0.f;
     bool orderChanged = false;
     if(itime == 9){
       if(hitRefs_bx0[id].empty()){
@@ -432,8 +432,8 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const &hits,
 	    ((simHitIt->second).hit_info[1][itime] == 0 || orderChanged == true) ){
       float fireTDC = hitRefs_bx0[id].back().second;
       if (hitRefs_bx0[id].size() > 1){
-	float chargeBeforeThr = 0.;
-	float tofchargeBeforeThr = 0.;
+	float chargeBeforeThr = 0.f;
+	float tofchargeBeforeThr = 0.f;
 	for(const auto& step : hitRefs_bx0[id]){
 	  if(step.first + chargeBeforeThr <= tdcForToaOnset[waferThickness-1]){
 	    chargeBeforeThr += step.first;

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
@@ -397,8 +397,8 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const &hits,
     //time-of-arrival (check how to be used)
     if(weightToAbyEnergy) (simHitIt->second).hit_info[1][itime] += charge*tof;
     else if((simHitIt->second).hit_info[1][itime]==0) {	
-      //here for constant-fraction discrimination
-      //update in case of change towards constant-threshold discrimination
+      //here for constant-threshold discrimination
+      //update in case of change towards constant-fraction discrimination
       if( accCharge>tdcForToaOnset[waferThickness-1])
 	{
 	  //extrapolate linear using previous simhit if it concerns to the same DetId

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
@@ -47,13 +47,10 @@ namespace {
     HGCalDetId hid(id);
     int wafer = HGCalDetId(id).wafer();
     int waferTypeL = dddConst.waferTypeL(wafer);
-    int isHalf = dddConst.isHalfCell(wafer,hid.cell());
-    int size = (isHalf ? 0.5 : 1.0);
     return waferTypeL;
   }
 
   int getCellThickness(const HcalGeometry* geom, const DetId& detid ) {
-    int size = 1;
     return 1;
   }
 

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
@@ -73,6 +73,7 @@ HGCDigitizerBase<DFr>::HGCDigitizerBase(const edm::ParameterSet& ps) {
   }
   edm::ParameterSet feCfg = myCfg_.getParameter<edm::ParameterSet>("feCfg");
   myFEelectronics_        = std::unique_ptr<HGCFEElectronics<DFr> >( new HGCFEElectronics<DFr>(feCfg) );
+  myFEelectronics_->SetNoiseValues(noise_fC_); 
 }
 
 template<class DFr>

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
@@ -121,6 +121,7 @@ void HGCDigitizerBase<DFr>::runSimple(std::unique_ptr<HGCDigitizerBase::DColl> &
       
       //add noise (in fC)
       //we assume it's randomly distributed and won't impact ToA measurement
+      // need either to move in HGCDigitizer or increase the threshold to fire the ToA
       totalCharge += std::max( (float)CLHEP::RandGaussQ::shoot(engine,0.0,cell.size*noise_fC_[cell.thickness-1]) , 0.f );
       if(totalCharge<0.f) totalCharge=0.f;
       

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
@@ -121,7 +121,7 @@ void HGCDigitizerBase<DFr>::runSimple(std::unique_ptr<HGCDigitizerBase::DColl> &
       
       //add noise (in fC)
       //we assume it's randomly distributed and won't impact ToA measurement
-      // need either to move in HGCDigitizer or increase the threshold to fire the ToA
+      //also assume that it is related to the charge path only and that noise fluctuation for ToA circuit be handled separately
       totalCharge += std::max( (float)CLHEP::RandGaussQ::shoot(engine,0.0,cell.size*noise_fC_[cell.thickness-1]) , 0.f );
       if(totalCharge<0.f) totalCharge=0.f;
       

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -56,8 +56,10 @@ HGCFEElectronics<DFr>::HGCFEElectronics(const edm::ParameterSet &ps) :
   if( ps.exists("tdcOnset_fC") )                    tdcOnset_fC_                    = ps.getParameter<double>("tdcOnset_fC");
   if( ps.exists("tdcForToAOnset_fC") ){
     auto temp = ps.getParameter< std::vector<double> >("tdcForToAOnset_fC");
-    for( unsigned i = 0; i < temp.size(); ++i ) {
-      tdcForToAOnset_fC_[i] = (float)temp[i];
+    if(temp.size() == tdcForToAOnset_fC_.size()){ std::copy_n(temp.begin(), temp.size(), tdcForToAOnset_fC_.begin()); }
+    else{
+      throw cms::Exception("BadConfiguration")
+     	<< " HGCFEElectronics wrong size for ToA thresholds ";
     }
   }
   if( ps.exists("toaLSB_ns") )                      toaLSB_ns_                      = ps.getParameter<double>("toaLSB_ns");
@@ -71,14 +73,19 @@ HGCFEElectronics<DFr>::HGCFEElectronics(const edm::ParameterSet &ps) :
 
   if( ps.exists("jitterNoise_ns") ){
     auto temp = ps.getParameter< std::vector<double> >("jitterNoise_ns");
-    for( unsigned i = 0; i < temp.size(); ++i ) {
-      jitterNoise2_ns_[i] = ((float)temp[i] * (float)temp[i]);
+    if(temp.size() == jitterNoise2_ns_.size()){ std::copy_n(temp.begin(), temp.size(), jitterNoise2_ns_.begin()); }
+    else{
+      throw cms::Exception("BadConfiguration")
+     	<< " HGCFEElectronics wrong size for ToA jitterNoise ";
     }
   }
   if( ps.exists("jitterConstant_ns") ){
     auto temp = ps.getParameter< std::vector<double> >("jitterConstant_ns");
-    for( unsigned i = 0; i < temp.size(); ++i ) {
-      jitterConstant2_ns_[i] = ((float)temp[i] * (float)temp[i]);
+    if(temp.size() == jitterConstant2_ns_.size()){ 
+      std::copy_n(temp.begin(), temp.size(), jitterConstant2_ns_.begin()); }
+    else{
+      throw cms::Exception("BadConfiguration")
+    	<< " HGCFEElectronics wrong size for ToA jitterConstant ";
     }
   }
 }
@@ -306,7 +313,6 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
         if(toaMode_==WEIGHTEDBYE) finalToA /= totalCharge;
       }
       
-      //toaFromToT[it] = CLHEP::RandGaussQ::shoot(engine,finalToA,tdcResolutionInNs_);
       newCharge[it]  = (totalCharge-tdcOnset_fC_);      
       
       if(debug) edm::LogVerbatim("HGCFE") << "\t Final busy estimate="<< integTime << " ns = " << busyBxs << " bxs" << std::endl

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -195,7 +195,7 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
   int fireBX = 9; 
   //noise fluctuation on charge is added after ToA computation
   //do not recheck the ToA firing threshold tdcForToaOnset_fC_[thickness-1] not to bias the efficiency 
-  //to be done properly with realistic ToA shaper and jitter 
+  //to be done properly with realistic ToA shaper and jitter for the moment accounted in the smearing 
   if(toaColl[fireBX] != 0.){
     timeTOA = toaColl[fireBX];
     if(jitterNoise2_ns_[0] != 0) timeTOA = CLHEP::RandGaussQ::shoot(engine, timeTOA, getTimeJitter(chargeColl[fireBX], thickness));
@@ -383,7 +383,6 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
 	      //brute force saturation, maybe could to better with an exponential like saturation
 	      const float saturatedCharge(std::min(newCharge[it],tdcSaturation_fC_));	      
 	      //working version for in-time PU and signal 
-	      //	      newSample.set(true,true,(uint16_t)(toaFromToT[it]/toaLSB_ns_),(uint16_t)(std::floor(saturatedCharge/tdcLSB_fC_)));
 	      newSample.set(true,true,(uint16_t)(timeTOA/toaLSB_ns_),(uint16_t)(std::floor(saturatedCharge/tdcLSB_fC_)));
 	      if(toaFlags[it]) newSample.setToAValid(true);
 	    }
@@ -397,7 +396,6 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
 	   //brute force saturation, maybe could to better with an exponential like saturation
           const float saturatedCharge(std::min(newCharge[it],adcSaturation_fC_));
 	  //working version for in-time PU and signal 
-	  //	  newSample.set(newCharge[it]>adj_thresh, false, (uint16_t)(toaFromToT[it]/toaLSB_ns_), (uint16_t)(std::floor(saturatedCharge/adcLSB_fC_)));
 	  newSample.set(newCharge[it]>adj_thresh, false, (uint16_t)(timeTOA/toaLSB_ns_), (uint16_t)(std::floor(saturatedCharge/adcLSB_fC_)));
 	  if(toaFlags[it]) newSample.setToAValid(true);
 	}

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -396,6 +396,7 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
 	  //working version for in-time PU and signal 
 	  newSample.set(newCharge[it]>adj_thresh, false, (uint16_t)(toaFromToT[it]/toaLSB_ns_), (uint16_t)(std::floor(saturatedCharge/adcLSB_fC_)));
 	}
+      newSample.setToAValid(totForToaFlags[it]);
       dataFrame.setSample(it,newSample);
     }
 

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -360,8 +360,9 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
   runChargeSharing();
 
 
+  //For the future need to understand how to deal with toa for out of time signals
+  //and for that should keep track of the BX firing the ToA somewhere (also to restore the use of finalToA) 
   /*
-  //should keep track of the BX firing the ToA somewhere to restore the use of finalToA 
   float finalToA(0.);
   for(int it=0; it<(int)(newCharge.size()); it++){
     if(toaFlags[it]){

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -200,7 +200,7 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
     timeTOA = toaColl[fireBX];
     if(jitterNoise2_ns_[0] != 0) timeTOA = CLHEP::RandGaussQ::shoot(engine, timeTOA, getTimeJitter(chargeColl[fireBX], thickness));
     else timeTOA = CLHEP::RandGaussQ::shoot(engine, timeTOA, tdcResolutionInNs_);
-    toaFlags[fireBX] = true;
+    if(timeTOA >= 0. && timeTOA <= 25.) toaFlags[fireBX] = true;
   }
 
   //now look at charge

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -54,6 +54,12 @@ HGCFEElectronics<DFr>::HGCFEElectronics(const edm::ParameterSet &ps) :
     }
   if( ps.exists("adcThreshold_fC") )                adcThreshold_fC_                = ps.getParameter<double>("adcThreshold_fC");
   if( ps.exists("tdcOnset_fC") )                    tdcOnset_fC_                    = ps.getParameter<double>("tdcOnset_fC");
+  if( ps.exists("tdcForToaOnset_fC") ){
+    auto temp = ps.getParameter< std::vector<double> >("tdcForToaOnset_fC");
+    for( unsigned i = 0; i < temp.size(); ++i ) {
+      tdcForToaOnset_fC_[i] = (float)temp[i];
+    }
+  }
   if( ps.exists("toaLSB_ns") )                      toaLSB_ns_                      = ps.getParameter<double>("toaLSB_ns");
   if( ps.exists("tdcChargeDrainParameterisation") ) {
     for( auto val : ps.getParameter< std::vector<double> >("tdcChargeDrainParameterisation") ) {
@@ -62,6 +68,19 @@ HGCFEElectronics<DFr>::HGCFEElectronics(const edm::ParameterSet &ps) :
   }
   if( ps.exists("tdcResolutionInPs") )              tdcResolutionInNs_              = ps.getParameter<double>("tdcResolutionInPs")*1e-3; // convert to ns
   if( ps.exists("toaMode") )                        toaMode_                        = ps.getParameter<uint32_t>("toaMode");
+
+  if( ps.exists("jitterNoise_ns") ){
+    auto temp = ps.getParameter< std::vector<double> >("jitterNoise_ns");
+    for( unsigned i = 0; i < temp.size(); ++i ) {
+      jitterNoise2_ns_[i] = ((float)temp[i] * (float)temp[i]);
+    }
+  }
+  if( ps.exists("jitterConstant_ns") ){
+    auto temp = ps.getParameter< std::vector<double> >("jitterConstant_ns");
+    for( unsigned i = 0; i < temp.size(); ++i ) {
+      jitterConstant2_ns_[i] = ((float)temp[i] * (float)temp[i]);
+    }
+  }
 }
 
 
@@ -156,6 +175,7 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
 {
   busyFlags.fill(false);
   totFlags.fill(false);
+  totForToaFlags.fill(false);
   newCharge.fill( 0.f );
   toaFromToT.fill( 0.f );
 
@@ -166,8 +186,11 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
 #endif
 
   bool debug = debug_state;
+  float timeTOA = 0.;
+  bool timeFlags = false;
 
-  //first identify bunches which will trigger ToT
+
+  //first identify sampling bunch which will trigger TDC for ToA
   //if(debug_state) edm::LogVerbatim("HGCFE") << "[runShaperWithToT]" << std::endl;  
   for(int it=0; it<(int)(chargeColl.size()); ++it)
     {
@@ -175,15 +198,23 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
       //if already flagged as busy it can't be re-used to trigger the ToT
       if(busyFlags[it]) continue;
 
-      //if below TDC onset will be handled by SARS ADC later
+      //if below TDC onset will be handled by SARS ADC later for charge computation
+      //fire TDC for ToA estimate anyway if above threshold
       float charge = chargeColl[it];
+      if(charge >= tdcForToaOnset_fC_[thickness-1] && !timeFlags){
+	timeTOA = toaColl[it];
+	toaFromToT[it] = toaColl[it];
+        timeFlags = true;
+        totForToaFlags[it] = true;
+      }
       if(charge < tdcOnset_fC_)  {
         debug = false;
         continue;
       }
 
-      //raise TDC mode
-      float toa    = toaColl[it];
+      //raise TDC mode for charge computation
+      //ToA anyway fired independently 
+      float toa = timeTOA;
       totFlags[it]=true;
 
       if(debug) edm::LogVerbatim("HGCFE") << "\t q=" << charge << " fC with <toa>=" << toa << " ns, triggers ToT @ " << it << std::endl;
@@ -267,7 +298,6 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
         if(toaMode_==WEIGHTEDBYE) finalToA /= totalCharge;
       }
 
-      toaFromToT[it] = CLHEP::RandGaussQ::shoot(engine,finalToA,tdcResolutionInNs_);
       newCharge[it]  = (totalCharge-tdcOnset_fC_);      
       
       if(debug) edm::LogVerbatim("HGCFE") << "\t Final busy estimate="<< integTime << " ns = " << busyBxs << " bxs" << std::endl
@@ -314,6 +344,23 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
   };
   runChargeSharing();
 
+
+
+
+  float finalToA(0.);
+  for(int it=0; it<(int)(newCharge.size()); it++){
+    if(totForToaFlags[it]){
+      finalToA = toaFromToT[it];
+      float chargeInTime = (newCharge.size() > 9) ? newCharge[9] : newCharge[it]; 
+      if(jitterNoise2_ns_[0] != 0) finalToA = CLHEP::RandGaussQ::shoot(engine, finalToA, getTimeJitter(chargeInTime, thickness));
+      else finalToA = CLHEP::RandGaussQ::shoot(engine, finalToA, tdcResolutionInNs_);
+      //to avoid +=25 for small negative time taken as 0
+      while(finalToA < -1.e-5)  finalToA+=25.f; 
+      while(finalToA > 25.f) finalToA-=25.f;
+    }
+  }
+
+
   //set new ADCs and ToA
   if(debug) edm::LogVerbatim("HGCFE") << "\t final result : ";
   const float adj_thresh = thresholdFollowsMIP_ ? thickness*adcThreshold_fC_*cce : thickness*adcThreshold_fC_;
@@ -326,10 +373,6 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
 	{
 	  if(totFlags[it]) 
 	    {
-	      float finalToA(toaFromToT[it]);
-	      while(finalToA < 0.f)  finalToA+=25.f;
-	      while(finalToA > 25.f) finalToA-=25.f;
-
 	      //brute force saturation, maybe could to better with an exponential like saturation
 	      const float saturatedCharge(std::min(newCharge[it],tdcSaturation_fC_));	      
 	      newSample.set(true,true,(uint16_t)(finalToA/toaLSB_ns_),(uint16_t)(std::floor(saturatedCharge/tdcLSB_fC_)));
@@ -343,7 +386,7 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
 	{
 	   //brute force saturation, maybe could to better with an exponential like saturation
           const float saturatedCharge(std::min(newCharge[it],adcSaturation_fC_));
-	  newSample.set(newCharge[it]>adj_thresh,false,(uint16_t)0,(uint16_t)(std::floor(saturatedCharge/adcLSB_fC_)));
+	  newSample.set(newCharge[it]>adj_thresh, false, (uint16_t)(finalToA/toaLSB_ns_), (uint16_t)(std::floor(saturatedCharge/adcLSB_fC_)));
 	}
       dataFrame.setSample(it,newSample);
     }

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -186,7 +186,7 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
 #endif
 
   bool debug = debug_state;
-  float timeTOA = 0.;
+  float timeTOA = 0.f;
 
 
   //first look at time
@@ -196,11 +196,11 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
   //noise fluctuation on charge is added after ToA computation
   //do not recheck the ToA firing threshold tdcForToaOnset_fC_[thickness-1] not to bias the efficiency 
   //to be done properly with realistic ToA shaper and jitter for the moment accounted in the smearing 
-  if(toaColl[fireBX] != 0.){
+  if(toaColl[fireBX] != 0.f){
     timeTOA = toaColl[fireBX];
     if(jitterNoise2_ns_[0] != 0) timeTOA = CLHEP::RandGaussQ::shoot(engine, timeTOA, getTimeJitter(chargeColl[fireBX], thickness));
     else timeTOA = CLHEP::RandGaussQ::shoot(engine, timeTOA, tdcResolutionInNs_);
-    if(timeTOA >= 0. && timeTOA <= 25.) toaFlags[fireBX] = true;
+    if(timeTOA >= 0.f && timeTOA <= 25.f) toaFlags[fireBX] = true;
   }
 
   //now look at charge

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -305,6 +305,7 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr &dataFrame, HGCSimHitData& char
         //finalize ToA contamination
         if(toaMode_==WEIGHTEDBYE) finalToA /= totalCharge;
       }
+      
       //toaFromToT[it] = CLHEP::RandGaussQ::shoot(engine,finalToA,tdcResolutionInNs_);
       newCharge[it]  = (totalCharge-tdcOnset_fC_);      
       


### PR DESCRIPTION
This PR updates the time-of-arrival computation for HGCAL cells and contains:
- ToA path independent from charge path: the charge computation is unchanged for both low and high signals
- ToA fired for signals in-time only: consider the hits with energy deposition that contributes to the in-time time sample (0-25ns) of the charge pulse shape, for example hits that arrive within 25ns-50ns from BX=-1 or in 0-25ns for BX=0...
- ToA fired when the cumulated charge per cell is above threshold: consider all hits from the main event and pileup events and update the ToA estimate if hits earlier in time are cumulated after in the mixing chain
- realistic ToA: inject a smearing as a function of S/N of each cell that is derived from the simulation of the electronics

To be effective, a specific configuration has to be used in the DIGI step, as in https://github.com/amartelli/reco-prodtools/blob/updateConfigs_ToA/templates/partGun_GSD_template.py#L11-L21

Workflow tested on few events with 200 pileup.
ToA performance validate with a single particle gun at zero pileup.