### PR TITLE
New razor and susy clients

### DIFF
--- a/DQMOffline/Trigger/python/RazorMonitor_Client_cff.py
+++ b/DQMOffline/Trigger/python/RazorMonitor_Client_cff.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+RazorEfficiency = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/SUSY/*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_Rsq          'Rsq turnON;            Rsq;        efficiency'     Rsq_numerator          Rsq_denominator",
+        "effic_MR           'MR turnON;             MR [GeV];   efficiency'     MR_numerator           MR_denominator",
+        "effic_dPhiR        'dPhiR turnON;          dphiR;      efficiency'     dPhiR_numerator        dPhiR_denominator",
+        "effic_MRVsRsq      'MR efficiency vs Rsq;  MR [GeV];   Rsq'            MRVsRsq_numerator      MRVsRsq_denominator",
+    ),
+    #efficiencyProfile = cms.untracked.vstring(
+    #    "effic_Rsq_vs_LS 'Rsq efficiency vs LS; LS; Rsq efficiency' RsqVsLS_numerator RsqVsLS_denominator"
+    #),
+  
+)
+
+
+susyHLTRazorClient = cms.Sequence(
+    RazorEfficiency
+    #+ NoBPTXEfficiency
+)

--- a/DQMOffline/Trigger/python/SusyMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/SusyMonitoring_Client_cff.py
@@ -1,4 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+from DQMOffline.Trigger.RazorMonitor_Client_cff import *
+
 susyClient = cms.Sequence(
+               susyHLTRazorClient
 )


### PR DESCRIPTION
Add client to HLT Razor paths.
To make efficiency plots automatically in dqm.
Relevant files:
DQMOffline/Trigger/python/RazorMonitor_Client_cff.py
DQMOffline/Trigger/python/SusyMonitoring_Client_cff.py
test output:
/afs/cern.ch/user/j/jmao/work/public/releases/RazorDQM/DQM_V0001_R000302523__Global__CMSSW_X_Y_Z__RECO.root
