### PR TITLE
Need to exclude PathInserter from the test

### DIFF
--- a/FWCore/Framework/test/test_limited_concurrent_module_cfg.py
+++ b/FWCore/Framework/test/test_limited_concurrent_module_cfg.py
@@ -27,5 +27,5 @@ process.t = cms.Task(process.i1)
 process.p = cms.Path(process.c1, process.t)
 
 process.add_(cms.Service("ConcurrentModuleTimer",
-                         modulesToExclude = cms.untracked.vstring("TriggerResults"),
+                         modulesToExclude = cms.untracked.vstring("TriggerResults","p"),
                          excludeSource = cms.untracked.bool(True)))


### PR DESCRIPTION
The test could sometimes fail because a 4th module (the PathInserter) could sometimes be caught by the service.