### PR TITLE
fix clang build error: replace static const with static constexpr

### DIFF
--- a/DataFormats/L1TGlobal/interface/GlobalAlgBlk.h
+++ b/DataFormats/L1TGlobal/interface/GlobalAlgBlk.h
@@ -49,7 +49,7 @@ public:
 
 
 public:
-    const static unsigned int maxPhysicsTriggers = 512;
+    static constexpr unsigned int maxPhysicsTriggers = 512;
 
     /// set simple members
     void setL1MenuUUID(int uuid)      { m_orbitNr       = uuid; }

--- a/Validation/HGCalValidation/plugins/HGCalHitCalibration.cc
+++ b/Validation/HGCalValidation/plugins/HGCalHitCalibration.cc
@@ -76,7 +76,7 @@ class HGCalHitCalibration : public DQMEDAnalyzer {
   std::map<int, MonitorElement*> hgcal_photon_EoP_CPene_calib_fraction_;
   MonitorElement* LayerOccupancy_;
 
-  static const int layers_ = 60;
+  static constexpr int layers_ = 60;
   std::array<float, layers_> Energy_layer_calib_;
   std::array<float, layers_> Energy_layer_calib_fraction_;
 };

--- a/Validation/HGCalValidation/plugins/HGCalShowerSeparation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalShowerSeparation.cc
@@ -84,7 +84,7 @@ class HGCalShowerSeparation : public DQMEDAnalyzer {
   std::vector<MonitorElement*> idealDeltaXY_;
   std::vector<MonitorElement*> centers_;
 
-  static const int layers_ = 52;
+  static constexpr int layers_ = 52;
 };
 
 HGCalShowerSeparation::HGCalShowerSeparation(const edm::ParameterSet& iConfig)


### PR DESCRIPTION
This should fix the link errors in 94X CLANG IBs
https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/slc6_amd64_gcc630/www/mon/9.4.CLANG-mon-23/CMSSW_9_4_CLANG_X_2017-09-11-2300