### PR TITLE
Pr94x l1t muon zero supression unpacker and dqm

### DIFF
--- a/DQM/L1TMonitor/interface/L1TMP7ZeroSupp.h
+++ b/DQM/L1TMonitor/interface/L1TMP7ZeroSupp.h
@@ -39,8 +39,8 @@ class L1TMP7ZeroSupp : public DQMEDAnalyzer {
   void bookCapIdHistograms(DQMStore::IBooker&, const unsigned int&);
 
   // Add additional bins only before NBINLABELS
-  enum binlabels {EVTS=0, EVTSGOOD, EVTSBAD, BLOCKS, ZSBLKSGOOD, ZSBLKSBAD, ZSBLKSBADFALSEPOS, ZSBLKSBADFALSENEG, NBINLABELS};
-  enum ratioBinlabels {REVTS=0, RBLKS, RBLKSFALSEPOS, RBLKSFALSENEG, RNBINLABELS};
+  enum binlabels {EVTS=0, EVTSGOOD, EVTSBAD, BLOCKS, ZSBLKSGOOD, ZSBLKSBAD, ZSBLKSBADFALSEPOS, ZSBLKSBADFALSENEG, BXBLOCKS, ZSBXBLKSGOOD, ZSBXBLKSBAD, ZSBXBLKSBADFALSEPOS, ZSBXBLKSBADFALSENEG, NBINLABELS};
+  enum ratioBinlabels {REVTS=0, RBLKS, RBLKSFALSEPOS, RBLKSFALSENEG, RBXBLKS, RBXBLKSFALSEPOS, RBXBLKSFALSENEG, RNBINLABELS};
 
   edm::EDGetTokenT<FEDRawDataCollection> fedDataToken_;
   bool zsEnabled_;
@@ -54,7 +54,9 @@ class L1TMP7ZeroSupp : public DQMEDAnalyzer {
   int amc13TrailerSize_;
   int amcHeaderSize_;
   int amcTrailerSize_;
+  int newZsFlagMask_;
   int zsFlagMask_;
+  int dataInvFlagMask_;
 
   int maxFedReadoutSize_;
 

--- a/DQM/L1TMonitor/interface/L1TMP7ZeroSupp.h
+++ b/DQM/L1TMonitor/interface/L1TMP7ZeroSupp.h
@@ -24,19 +24,19 @@ class L1TMP7ZeroSupp : public DQMEDAnalyzer {
  public:
 
   L1TMP7ZeroSupp(const edm::ParameterSet& ps);
-  virtual ~L1TMP7ZeroSupp();
+  ~L1TMP7ZeroSupp() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
  protected:
 
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
-  virtual void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) override;
+  void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
+  void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
  private:
 
-  void bookCapIdHistograms(DQMStore::IBooker&, const unsigned int&);
+  void bookCapIdHistograms(DQMStore::IBooker& ibooker, const unsigned int& id);
 
   // Add additional bins only before NBINLABELS
   enum binlabels {EVTS=0, EVTSGOOD, EVTSBAD, BLOCKS, ZSBLKSGOOD, ZSBLKSBAD, ZSBLKSBADFALSEPOS, ZSBLKSBADFALSENEG, BXBLOCKS, ZSBXBLKSGOOD, ZSBXBLKSBAD, ZSBXBLKSBADFALSEPOS, ZSBXBLKSBADFALSENEG, NBINLABELS};

--- a/DQM/L1TMonitor/src/L1TMP7ZeroSupp.cc
+++ b/DQM/L1TMonitor/src/L1TMP7ZeroSupp.cc
@@ -14,7 +14,9 @@ L1TMP7ZeroSupp::L1TMP7ZeroSupp(const edm::ParameterSet& ps)
       amc13TrailerSize_(ps.getUntrackedParameter<int>("lenAMC13Trailer")),
       amcHeaderSize_(ps.getUntrackedParameter<int>("lenAMCHeader")),
       amcTrailerSize_(ps.getUntrackedParameter<int>("lenAMCTrailer")),
+      newZsFlagMask_(ps.getUntrackedParameter<int>("newZsFlagMask")),
       zsFlagMask_(ps.getUntrackedParameter<int>("zsFlagMask")),
+      dataInvFlagMask_(ps.getUntrackedParameter<int>("dataInvFlagMask")),
       maxFedReadoutSize_(ps.getUntrackedParameter<int>("maxFEDReadoutSize")),
       monitorDir_(ps.getUntrackedParameter<std::string>("monitorDir")),
       verbose_(ps.getUntrackedParameter<bool>("verbose"))
@@ -56,6 +58,8 @@ void L1TMP7ZeroSupp::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.addUntracked<int>("lenAMCHeader", 8)->setComment("Number of AMC header bytes.");
   desc.addUntracked<int>("lenAMCTrailer", 0)->setComment("Number of AMC trailer bytes.");
   desc.addUntracked<int>("zsFlagMask", 0x1)->setComment("Zero suppression flag mask.");
+  desc.addUntracked<int>("newZsFlagMask", 0x2)->setComment("Per-BX zero suppression flag mask.");
+  desc.addUntracked<int>("dataInvFlagMask", 0x1)->setComment("Data inversion flag mask.");
   desc.addUntracked<int>("maxFEDReadoutSize", 10000)->setComment("Maximal FED readout size histogram x-axis value.");
   for (unsigned int i = 0; i < maxMasks_; ++i) {
     desc.addOptionalUntracked<std::vector<int>>(("maskCapId"+std::to_string(i)).c_str())->setComment(("ZS mask for caption id "+std::to_string(i)+".").c_str());
@@ -101,7 +105,7 @@ void L1TMP7ZeroSupp::bookCapIdHistograms(DQMStore::IBooker& ibooker, const unsig
   }
 
   zeroSuppValMap_[id] = ibooker.book1D("zeroSuppVal", summaryTitleText.c_str(), NBINLABELS, 0, NBINLABELS);
-  zeroSuppValMap_[id]->setAxisTitle("Block status", 1);
+  zeroSuppValMap_[id]->setAxisTitle("ZS status", 1);
   zeroSuppValMap_[id]->setBinLabel(EVTS+1, "events", 1);
   zeroSuppValMap_[id]->setBinLabel(EVTSGOOD+1, "good events", 1);
   zeroSuppValMap_[id]->setBinLabel(EVTSBAD+1, "bad events", 1);
@@ -110,18 +114,29 @@ void L1TMP7ZeroSupp::bookCapIdHistograms(DQMStore::IBooker& ibooker, const unsig
   zeroSuppValMap_[id]->setBinLabel(ZSBLKSBAD+1, "bad blocks", 1);
   zeroSuppValMap_[id]->setBinLabel(ZSBLKSBADFALSEPOS+1, "false pos.", 1);
   zeroSuppValMap_[id]->setBinLabel(ZSBLKSBADFALSENEG+1, "false neg.", 1);
+  zeroSuppValMap_[id]->setBinLabel(BXBLOCKS+1, "BX blocks", 1);
+  zeroSuppValMap_[id]->setBinLabel(ZSBXBLKSGOOD+1, "good BX blocks", 1);
+  zeroSuppValMap_[id]->setBinLabel(ZSBXBLKSBAD+1, "bad BX blocks", 1);
+  zeroSuppValMap_[id]->setBinLabel(ZSBXBLKSBADFALSEPOS+1, "BX false pos.", 1);
+  zeroSuppValMap_[id]->setBinLabel(ZSBXBLKSBADFALSENEG+1, "BX false neg.", 1);
 
   errorSummaryNumMap_[id] = ibooker.book1D("errorSummaryNum", summaryTitleText.c_str(), RNBINLABELS, 0, RNBINLABELS);
   errorSummaryNumMap_[id]->setBinLabel(REVTS+1, "bad events", 1);
   errorSummaryNumMap_[id]->setBinLabel(RBLKS+1, "bad blocks", 1);
   errorSummaryNumMap_[id]->setBinLabel(RBLKSFALSEPOS+1, "false pos.", 1);
   errorSummaryNumMap_[id]->setBinLabel(RBLKSFALSENEG+1, "false neg.", 1);
+  errorSummaryNumMap_[id]->setBinLabel(RBXBLKS+1, "bad BX blocks", 1);
+  errorSummaryNumMap_[id]->setBinLabel(RBXBLKSFALSEPOS+1, "BX false pos.", 1);
+  errorSummaryNumMap_[id]->setBinLabel(RBXBLKSFALSENEG+1, "BX false neg.", 1);
 
   errorSummaryDenMap_[id] = ibooker.book1D("errorSummaryDen", "denominators", RNBINLABELS, 0, RNBINLABELS);
   errorSummaryDenMap_[id]->setBinLabel(REVTS+1, "# events", 1);
   errorSummaryDenMap_[id]->setBinLabel(RBLKS+1, "# blocks", 1);
   errorSummaryDenMap_[id]->setBinLabel(RBLKSFALSEPOS+1, "# blocks", 1);
   errorSummaryDenMap_[id]->setBinLabel(RBLKSFALSENEG+1, "# blocks", 1);
+  errorSummaryDenMap_[id]->setBinLabel(RBXBLKS+1, "# BX blocks", 1);
+  errorSummaryDenMap_[id]->setBinLabel(RBXBLKSFALSEPOS+1, "# BX blocks", 1);
+  errorSummaryDenMap_[id]->setBinLabel(RBXBLKSFALSENEG+1, "# BX blocks", 1);
 
   readoutSizeNoZSMap_[id] = ibooker.book1D("readoutSize", (sizeTitleText + "size").c_str(), 100, 0, maxFedReadoutSize_);
   readoutSizeNoZSMap_[id]->setAxisTitle("size (byte)", 1);
@@ -240,13 +255,16 @@ void L1TMP7ZeroSupp::analyze(const edm::Event& e, const edm::EventSetup& c) {
         }
 
         unsigned int blockCapId = block->header().getCapID();
-        unsigned int blockSize = block->header().getSize() * 4;
+        unsigned int blockSize = block->header().getSize() * 4; // times 4 to get the size in byte
         unsigned int blockHeaderSize = sizeof(block->header().raw());
-        bool zsFlagSet = ((block->header().getFlags() & zsFlagMask_) != 0);
-        bool toSuppress = false;
+        unsigned int blockHeaderFlags = block->header().getFlags();
+        bool newZsFlagSet = ((blockHeaderFlags & newZsFlagMask_) != 0); // use the per-BX ZS
+        bool blockZsFlagSet = newZsFlagSet ? true : ((blockHeaderFlags & zsFlagMask_) != 0); // ZS validation flag for whole block
+        bool dataInvertFlagSet = newZsFlagSet && ((blockHeaderFlags & dataInvFlagMask_) != 0); // invert the data before applying the mask
 
         capIds_->Fill(blockCapId);
 
+        // fill the denominator histograms
         bool capIdDefined = false;
         zeroSuppValMap_[maxMasks_]->Fill(BLOCKS);
         errorSummaryDenMap_[maxMasks_]->Fill(RBLKS);
@@ -260,42 +278,126 @@ void L1TMP7ZeroSupp::analyze(const edm::Event& e, const edm::EventSetup& c) {
           errorSummaryDenMap_[blockCapId]->Fill(RBLKSFALSENEG);
         }
 
-        auto totalBlockSize = blockSize + blockHeaderSize;
+        auto totalBlockSize = blockHeaderSize;
+        if (!newZsFlagSet) {
+          totalBlockSize += blockSize;
+        }
+
+        auto bxBlocks = block->getBxBlocks(6, newZsFlagSet); // 6 32 bit MP7 payload words per BX
+
+        // check all BX blocks
+        bool allToSuppress = true;
+        for (const auto bxBlock: bxBlocks) {
+          bool toSuppress = false;
+          bool bxZsFlagSet = ((bxBlock.header().getFlags() & zsFlagMask_) != 0); // ZS validation flag
+
+          // check if this bxblock should be suppressed
+          unsigned int wordcounter = 0;
+          unsigned int wordsum = 0;
+          for (const auto& word: bxBlock.payload()) {
+            if (dataInvertFlagSet) {
+              wordsum += masks_[blockCapId].at(wordcounter%6) & (~word);
+            } else {
+              wordsum += masks_[blockCapId].at(wordcounter%6) & word;
+            }
+            if (verbose_) {
+              std::cout << "word: " << std::hex << std::setw(8) << std::setfill('0') << word << std::dec
+                        << ", maskword" << wordcounter%6 << ": " << std::hex << std::setw(8) << std::setfill('0')
+                        << masks_[blockCapId].at(wordcounter%6) << std::dec << ", wordsum: " << wordsum << std::endl;
+            }
+            if (wordsum > 0) {
+              break;
+            }
+            ++wordcounter;
+          }
+          // the sum of payload words must be 0 for correct ZS
+          if (wordsum == 0 && zsEnabled_) {
+            toSuppress = true;
+            if (verbose_) {
+              std::cout << "wordsum == 0: this BX block should be zero suppressed" << std::endl;
+            }
+          }
+          // update the overall block status
+          allToSuppress &= toSuppress;
+
+          // only fill the BX related things for the per-BX ZS
+          if (newZsFlagSet) {
+            // the ZS flag of the block is the AND of all BX block ZS flags
+            blockZsFlagSet &= bxZsFlagSet;
+
+            // fill the BX related bins of the denominator histogram
+            zeroSuppValMap_[maxMasks_]->Fill(BXBLOCKS);
+            errorSummaryDenMap_[maxMasks_]->Fill(RBXBLKS);
+            errorSummaryDenMap_[maxMasks_]->Fill(RBXBLKSFALSEPOS);
+            errorSummaryDenMap_[maxMasks_]->Fill(RBXBLKSFALSENEG);
+            if (capIdDefined) {
+              zeroSuppValMap_[blockCapId]->Fill(BXBLOCKS);
+              errorSummaryDenMap_[blockCapId]->Fill(RBXBLKS);
+              errorSummaryDenMap_[blockCapId]->Fill(RBXBLKSFALSEPOS);
+              errorSummaryDenMap_[blockCapId]->Fill(RBXBLKSFALSENEG);
+            }
+
+            unsigned int totalBxBlockSize = bxBlock.getSize() * 4 + sizeof(bxBlock.header().raw());  // times 4 to get the size in byte
+            // check if zero suppression flag agrees for the BX block
+            if (toSuppress && bxZsFlagSet) {
+              if (verbose_) std::cout << "GOOD BX block with ZS flag true" << std::endl;
+              zeroSuppValMap_[maxMasks_]->Fill(ZSBXBLKSGOOD);
+              if (capIdDefined) {
+                zeroSuppValMap_[blockCapId]->Fill(ZSBXBLKSGOOD);
+              }
+            } else if (!toSuppress && !bxZsFlagSet) {
+              if (verbose_) std::cout << "GOOD BX block with ZS flag false" << std::endl;
+              zeroSuppValMap_[maxMasks_]->Fill(ZSBXBLKSGOOD);
+              if (capIdDefined) {
+                zeroSuppValMap_[blockCapId]->Fill(ZSBXBLKSGOOD);
+              }
+            } else if (!toSuppress && bxZsFlagSet) {
+              if (verbose_) std::cout << "BAD BX block with ZS flag true" << std::endl;
+              totalBlockSize += totalBxBlockSize;
+              zeroSuppValMap_[maxMasks_]->Fill(ZSBXBLKSBAD);
+              zeroSuppValMap_[maxMasks_]->Fill(ZSBXBLKSBADFALSEPOS);
+              errorSummaryNumMap_[maxMasks_]->Fill(RBXBLKS);
+              errorSummaryNumMap_[maxMasks_]->Fill(RBXBLKSFALSEPOS);
+              evtGood[maxMasks_] = false;
+              if (capIdDefined) {
+                zeroSuppValMap_[blockCapId]->Fill(ZSBXBLKSBAD);
+                zeroSuppValMap_[blockCapId]->Fill(ZSBXBLKSBADFALSEPOS);
+                errorSummaryNumMap_[blockCapId]->Fill(RBXBLKS);
+                errorSummaryNumMap_[blockCapId]->Fill(RBXBLKSFALSEPOS);
+                evtGood[blockCapId] = false;
+              }
+            } else {
+              if (verbose_) std::cout << "BAD BX block with ZS flag false" << std::endl;
+              totalBlockSize += totalBxBlockSize;
+              zeroSuppValMap_[maxMasks_]->Fill(ZSBXBLKSBAD);
+              zeroSuppValMap_[maxMasks_]->Fill(ZSBXBLKSBADFALSENEG);
+              errorSummaryNumMap_[maxMasks_]->Fill(RBXBLKS);
+              errorSummaryNumMap_[maxMasks_]->Fill(RBXBLKSFALSENEG);
+              evtGood[maxMasks_] = false;
+              if (capIdDefined) {
+                zeroSuppValMap_[blockCapId]->Fill(ZSBXBLKSBAD);
+                zeroSuppValMap_[blockCapId]->Fill(ZSBXBLKSBADFALSENEG);
+                errorSummaryNumMap_[blockCapId]->Fill(RBXBLKS);
+                errorSummaryNumMap_[blockCapId]->Fill(RBXBLKSFALSENEG);
+                evtGood[blockCapId] = false;
+              }
+            }
+          }
+        }
+
         readoutSizeNoZSMap[maxMasks_] += totalBlockSize;
         if (capIdDefined) {
           readoutSizeNoZSMap[blockCapId] += totalBlockSize;
         }
 
-        // check if this block should be suppressed
-        unsigned int wordcounter = 0;
-        unsigned int wordsum = 0;
-        for (const auto& word: block->payload()) {
-          wordsum += masks_[blockCapId].at(wordcounter%6) & word;
-          if (verbose_) {
-            std::cout << "word: " << std::hex << std::setw(8) << std::setfill('0') << word << std::dec
-                      << ", maskword" << wordcounter%6 << ": " << std::hex << std::setw(8) << std::setfill('0')
-                      << masks_[blockCapId].at(wordcounter%6) << std::dec << ", wordsum: " << wordsum << std::endl;
-          }
-          if (wordsum > 0) {
-            break;
-          }
-          ++wordcounter;
-        }
-        if (wordsum == 0 && zsEnabled_) {
-          toSuppress = true;
-          if (verbose_) {
-            std::cout << "wordsum == 0: this block should be zero suppressed" << std::endl;
-          }
-        }
-
-        // check if zero suppression flag agrees
-        if (toSuppress && zsFlagSet) {
+        // check if zero suppression flag agrees for the whole block
+        if (allToSuppress && blockZsFlagSet) {
           if (verbose_) std::cout << "GOOD block with ZS flag true" << std::endl;
           zeroSuppValMap_[maxMasks_]->Fill(ZSBLKSGOOD);
           if (capIdDefined) {
             zeroSuppValMap_[blockCapId]->Fill(ZSBLKSGOOD);
           }
-        } else if (!toSuppress && !zsFlagSet) {
+        } else if (!allToSuppress && !blockZsFlagSet) {
           if (verbose_) std::cout << "GOOD block with ZS flag false" << std::endl;
           zeroSuppValMap_[maxMasks_]->Fill(ZSBLKSGOOD);
           readoutSizeZSMap[maxMasks_] += totalBlockSize;
@@ -305,7 +407,7 @@ void L1TMP7ZeroSupp::analyze(const edm::Event& e, const edm::EventSetup& c) {
             readoutSizeZSMap[blockCapId] += totalBlockSize;
             readoutSizeZSExpectedMap[blockCapId] += totalBlockSize;
           }
-        } else if (!toSuppress && zsFlagSet) {
+        } else if (!allToSuppress && blockZsFlagSet) {
           if (verbose_) std::cout << "BAD block with ZS flag true" << std::endl;
           zeroSuppValMap_[maxMasks_]->Fill(ZSBLKSBAD);
           zeroSuppValMap_[maxMasks_]->Fill(ZSBLKSBADFALSEPOS);

--- a/EventFilter/L1TRawToDigi/interface/Block.h
+++ b/EventFilter/L1TRawToDigi/interface/Block.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "EventFilter/L1TRawToDigi/interface/AMCSpec.h"
+#include "EventFilter/L1TRawToDigi/interface/BxBlock.h"
 
 namespace l1t {
    enum block_t { MP7 = 0, CTP7, MTF7 };
@@ -63,6 +64,7 @@ namespace l1t {
          void amc(const amc::Header& h) { amc_ = h; };
          amc::Header amc() const { return amc_; };
 
+         BxBlocks getBxBlocks(unsigned int payloadWordsPerBx, bool bxHeader) const;
       private:
          BlockHeader header_;
          amc::Header amc_;

--- a/EventFilter/L1TRawToDigi/interface/Block.h
+++ b/EventFilter/L1TRawToDigi/interface/Block.h
@@ -50,8 +50,8 @@ namespace l1t {
       public:
          Block(const BlockHeader& h, const uint32_t * payload_start, const uint32_t * payload_end) :
             header_(h), payload_(payload_start, payload_end) {};
-         Block(unsigned int id, const std::vector<uint32_t>& payload, unsigned int capID=0, block_t type=MP7) :
-            header_(id, payload.size(), capID, type), payload_(payload) {};
+         Block(unsigned int id, const std::vector<uint32_t>& payload, unsigned int capID=0, unsigned int flags=0, block_t type=MP7) :
+            header_(id, payload.size(), capID, flags, type), payload_(payload) {};
 
          bool operator<(const Block& o) const { return header() < o.header(); };
 

--- a/EventFilter/L1TRawToDigi/interface/BxBlock.h
+++ b/EventFilter/L1TRawToDigi/interface/BxBlock.h
@@ -1,0 +1,69 @@
+#ifndef EventFilter_L1TRawToDigi_BxBlock_h
+#define EventFilter_L1TRawToDigi_BxBlock_h
+
+#include <memory>
+#include <vector>
+#include <cmath>
+
+namespace l1t {
+   class BxBlockHeader {
+      public:
+         BxBlockHeader() : id_(0), totalBx_(0), flags_(0) {};
+         BxBlockHeader(unsigned int id, unsigned int totalBx, unsigned int flags=0) : id_(id), totalBx_(totalBx), flags_(flags) {};
+         // Create a BX header: everything is contained in the raw uint32
+         BxBlockHeader(const uint32_t raw) : id_((raw >> id_shift) & id_mask)
+                                      , totalBx_((raw >> totalBx_shift) & totalBx_mask)
+                                      , flags_((raw >> flags_shift) & flags_mask) {};
+
+         bool operator<(const BxBlockHeader& o) const { return getBx() < o.getBx(); };
+
+         inline int getBx() const { return (int)id_ - (int)std::floor(totalBx_/2.); };
+         inline unsigned int getId() const { return id_; };
+         inline unsigned int getTotalBx() const { return totalBx_; };
+         inline unsigned int getFlags() const { return flags_; };
+
+         inline uint32_t raw() const { return ((id_ & id_mask) << id_shift)
+                                     | ((totalBx_ & totalBx_mask) << totalBx_shift)
+                                     | ((flags_ & flags_mask) << flags_shift); };
+
+      private:
+         static const unsigned int id_shift = 24;
+         static const unsigned int id_mask = 0xff;
+         static const unsigned int totalBx_shift = 16;
+         static const unsigned int totalBx_mask = 0xff;
+         static const unsigned int flags_shift = 0;
+         static const unsigned int flags_mask = 0xffff;
+
+         unsigned int id_;
+         unsigned int totalBx_;
+         unsigned int flags_;
+   };
+
+   class BxBlock {
+      public:
+         BxBlock(std::vector<uint32_t>::const_iterator bx_start, std::vector<uint32_t>::const_iterator bx_end) :
+            header_(*bx_start), payload_(bx_start+1, bx_end) {};
+         BxBlock(const BxBlockHeader& h, std::vector<uint32_t>::const_iterator payload_start, std::vector<uint32_t>::const_iterator payload_end) :
+            header_(h), payload_(payload_start, payload_end) {};
+         BxBlock(unsigned int id, unsigned int totalBx, std::vector<uint32_t>::const_iterator payload_start, std::vector<uint32_t>::const_iterator payload_end, unsigned int flags=0) :
+            header_(id, totalBx, flags), payload_(payload_start, payload_end) {};
+         BxBlock(unsigned int id, unsigned int totalBx, const std::vector<uint32_t>& payload, unsigned int flags=0) :
+            header_(id, totalBx, flags), payload_(payload) {};
+         ~BxBlock() {};
+
+         bool operator<(const BxBlock& o) const { return header() < o.header(); };
+
+         inline unsigned int getSize() const { return payload_.size(); };
+
+         BxBlockHeader header() const { return header_; };
+         std::vector<uint32_t> payload() const { return payload_; };
+
+      private:
+         BxBlockHeader header_;
+         std::vector<uint32_t> payload_;
+   };
+
+   typedef std::vector<BxBlock> BxBlocks;
+}
+
+#endif

--- a/EventFilter/L1TRawToDigi/interface/BxBlock.h
+++ b/EventFilter/L1TRawToDigi/interface/BxBlock.h
@@ -11,8 +11,8 @@ namespace l1t {
          BxBlockHeader() : id_(0), totalBx_(0), flags_(0) {};
          BxBlockHeader(unsigned int id, unsigned int totalBx, unsigned int flags=0) : id_(id), totalBx_(totalBx), flags_(flags) {};
          // Create a BX header: everything is contained in the raw uint32
-         BxBlockHeader(const uint32_t raw) : id_((raw >> id_shift) & id_mask)
-                                      , totalBx_((raw >> totalBx_shift) & totalBx_mask)
+         BxBlockHeader(const uint32_t raw) : id_(((raw >> id_shift) & id_mask) / n_words)
+                                      , totalBx_(((raw >> totalBx_shift) & totalBx_mask) / n_words)
                                       , flags_((raw >> flags_shift) & flags_mask) {};
 
          bool operator<(const BxBlockHeader& o) const { return getBx() < o.getBx(); };
@@ -22,11 +22,12 @@ namespace l1t {
          inline unsigned int getTotalBx() const { return totalBx_; };
          inline unsigned int getFlags() const { return flags_; };
 
-         inline uint32_t raw() const { return ((id_ & id_mask) << id_shift)
-                                     | ((totalBx_ & totalBx_mask) << totalBx_shift)
+         inline uint32_t raw() const { return (((id_ & id_mask) << id_shift) * n_words)
+                                     | (((totalBx_ & totalBx_mask) << totalBx_shift) * n_words)
                                      | ((flags_ & flags_mask) << flags_shift); };
 
       private:
+         static const unsigned int n_words = 6; // every link transmits 6 32 bit words per bx
          static const unsigned int id_shift = 24;
          static const unsigned int id_mask = 0xff;
          static const unsigned int totalBx_shift = 16;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonUnpacker.cc
@@ -17,6 +17,11 @@ namespace l1t {
       IntermediateMuonUnpacker::unpack(const Block& block, UnpackerCollections *coll)
       {
          LogDebug("L1T") << "Block ID  = " << block.header().getID() << " size = " << block.header().getSize();
+         // process only if there is a payload
+         // If all BX block were zero suppressed the block header size is 0.
+         if (block.header().getSize() < 1) {
+            return true;
+         }
 
          auto payload = block.payload();
 

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonUnpacker.h
@@ -19,10 +19,12 @@ namespace l1t {
             static const unsigned int nWords_ = 6; // every link transmits 6 words (3 muons) per bx
             static const unsigned int bxzs_enable_shift_ = 1;
 
+            MuonBxCollection* res1_;
+            MuonBxCollection* res2_;
             unsigned int algoVersion_;
             unsigned int coll1Cnt_;
 
-            void unpackBx(MuonBxCollection* res1, MuonBxCollection* res2, int bx, const std::vector<uint32_t>& payload, unsigned int startIdx=0);
+            void unpackBx(int bx, const std::vector<uint32_t>& payload, unsigned int startIdx=0);
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonUnpacker.h
@@ -16,7 +16,13 @@ namespace l1t {
             inline void setAlgoVersion(const unsigned int version) { algoVersion_ = version; };
 
          private:
+            static const unsigned int nWords_ = 6; // every link transmits 6 words (3 muons) per bx
+            static const unsigned int bxzs_enable_shift_ = 1;
+
             unsigned int algoVersion_;
+            unsigned int coll1Cnt_;
+
+            void unpackBx(MuonBxCollection* res1, MuonBxCollection* res2, int bx, const std::vector<uint32_t>& payload, unsigned int startIdx=0);
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
@@ -3,8 +3,6 @@
 
 #include "L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h"
 
-#include "L1TObjectCollections.h"
-//#include "GMTCollections.h"
 #include "MuonUnpacker.h"
 
 namespace l1t {
@@ -20,26 +18,39 @@ namespace l1t {
 
          auto payload = block.payload();
 
-         unsigned int nWords = 6; // every link transmits 6 words (3 muons) per bx
          int nBX, firstBX, lastBX;
-         nBX = int(ceil(block.header().getSize() / nWords));
+         // Check if per BX zero suppression was enabled
+         bool bxZsEnabled = ((block.header().getFlags() >> bxzs_enable_shift_) & 0x1) == 1;
+         // Calculate the total number of BXs
+         if (bxZsEnabled) {
+            BxBlockHeader bxHeader(payload.at(0));
+            nBX = bxHeader.getTotalBx();
+         } else {
+            nBX = int(ceil(block.header().getSize() / nWords_));
+         }
          getBXRange(nBX, firstBX, lastBX);
-         // only use central BX for now
-         //firstBX = 0;
-         //lastBX = 0;
-         //LogDebug("L1T") << "BX override. Set first BX = lastBX = 0.";
 
+         // Create the muon collection and set the BX range
          auto res = static_cast<L1TObjectCollections*>(coll)->getMuons(muonCopy_);
          res->setBXRange(firstBX, lastBX);
-
          LogDebug("L1T") << "nBX = " << nBX << " first BX = " << firstBX << " lastBX = " << lastBX;
 
-         // Initialise index
-         int unsigned i = 0;
+         // Get the BX blocks and unpack them
+         auto bxBlocks = block.getBxBlocks(nWords_, bxZsEnabled);
+         for (const auto& bxBlock : bxBlocks) {
+            unpackBx(res, bxBlock.header().getBx(), bxBlock.payload());
+         }
+         return true;
+      }
 
-         // Loop over multiple BX and then number of muons filling muon collection
-         for (int bx = firstBX; bx <= lastBX; ++bx) {
-            for (unsigned nWord = 0; nWord < nWords && i < block.header().getSize(); nWord += 2) {
+
+      void
+      MuonUnpacker::unpackBx(MuonBxCollection* res, int bx, const std::vector<uint32_t>& payload, unsigned int startIdx)
+      {
+         unsigned int i = startIdx;
+         // Check if there are enough words left in the payload
+         if (i + nWords_ <= payload.size()) {
+            for (unsigned nWord = 0; nWord < nWords_; nWord += 2) {
                uint32_t raw_data_00_31 = payload[i++];
                uint32_t raw_data_32_63 = payload[i++];        
                LogDebug("L1T") << "raw_data_00_31 = 0x" << hex << raw_data_00_31 << " raw_data_32_63 = 0x" << raw_data_32_63;
@@ -57,8 +68,9 @@ namespace l1t {
 
                res->push_back(bx, mu);
             }
+         } else {
+            edm::LogWarning("L1T") << "Only " << payload.size() - i << " 32 bit words in this BX but " << nWords_ << " are required. Not unpacking the data for BX " << bx << ".";
          }
-         return true;
       }
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
@@ -15,6 +15,11 @@ namespace l1t {
       MuonUnpacker::unpack(const Block& block, UnpackerCollections *coll)
       {
          LogDebug("L1T") << "Block ID  = " << block.header().getID() << " size = " << block.header().getSize();
+         // process only if there is a payload
+         // If all BX block were zero suppressed the block header size is 0.
+         if (block.header().getSize() < 1) {
+            return true;
+         }
 
          auto payload = block.payload();
 

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
@@ -7,7 +7,7 @@
 
 namespace l1t {
    namespace stage2 {
-      MuonUnpacker::MuonUnpacker() : algoVersion_(0), muonCopy_(0)
+      MuonUnpacker::MuonUnpacker() : res_(nullptr), algoVersion_(0), muonCopy_(0)
       {
       }
 
@@ -30,22 +30,22 @@ namespace l1t {
          }
          getBXRange(nBX, firstBX, lastBX);
 
-         // Create the muon collection and set the BX range
-         auto res = static_cast<L1TObjectCollections*>(coll)->getMuons(muonCopy_);
-         res->setBXRange(firstBX, lastBX);
+         // Set the muon collection and the BX range
+         res_ = static_cast<L1TObjectCollections*>(coll)->getMuons(muonCopy_);
+         res_->setBXRange(firstBX, lastBX);
          LogDebug("L1T") << "nBX = " << nBX << " first BX = " << firstBX << " lastBX = " << lastBX;
 
          // Get the BX blocks and unpack them
          auto bxBlocks = block.getBxBlocks(nWords_, bxZsEnabled);
          for (const auto& bxBlock : bxBlocks) {
-            unpackBx(res, bxBlock.header().getBx(), bxBlock.payload());
+            unpackBx(bxBlock.header().getBx(), bxBlock.payload());
          }
          return true;
       }
 
 
       void
-      MuonUnpacker::unpackBx(MuonBxCollection* res, int bx, const std::vector<uint32_t>& payload, unsigned int startIdx)
+      MuonUnpacker::unpackBx(int bx, const std::vector<uint32_t>& payload, unsigned int startIdx)
       {
          unsigned int i = startIdx;
          // Check if there are enough words left in the payload
@@ -66,7 +66,7 @@ namespace l1t {
 
                LogDebug("L1T") << "Mu" << nWord/2 << ": eta " << mu.hwEta() << " phi " << mu.hwPhi() << " pT " << mu.hwPt() << " iso " << mu.hwIso() << " qual " << mu.hwQual() << " charge " << mu.hwCharge() << " charge valid " << mu.hwChargeValid();
 
-               res->push_back(bx, mu);
+               res_->push_back(bx, mu);
             }
          } else {
             edm::LogWarning("L1T") << "Only " << payload.size() - i << " 32 bit words in this BX but " << nWords_ << " are required. Not unpacking the data for BX " << bx << ".";

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.h
@@ -2,6 +2,8 @@
 #define L1T_PACKER_STAGE2_MUONUNPACKER_H
 
 #include "EventFilter/L1TRawToDigi/interface/Unpacker.h"
+#include "EventFilter/L1TRawToDigi/interface/Block.h"
+#include "L1TObjectCollections.h"
 
 namespace l1t {
    namespace stage2 {
@@ -21,10 +23,14 @@ namespace l1t {
             inline void setMuonCopy(const unsigned int copy) { muonCopy_ = copy; };
 
          private:
+            static const unsigned int nWords_ = 6; // every link transmits 6 words (3 muons) per bx
+            static const unsigned int bxzs_enable_shift_ = 1;
+
             unsigned int algoVersion_;
             int fed_;
             unsigned int muonCopy_;
 
+            void unpackBx(MuonBxCollection* res, int bx, const std::vector<uint32_t>& payload, unsigned int startIdx=0);
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.h
@@ -26,11 +26,12 @@ namespace l1t {
             static const unsigned int nWords_ = 6; // every link transmits 6 words (3 muons) per bx
             static const unsigned int bxzs_enable_shift_ = 1;
 
+            MuonBxCollection* res_;
             unsigned int algoVersion_;
             int fed_;
             unsigned int muonCopy_;
 
-            void unpackBx(MuonBxCollection* res, int bx, const std::vector<uint32_t>& payload, unsigned int startIdx=0);
+            void unpackBx(int bx, const std::vector<uint32_t>& payload, unsigned int startIdx=0);
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
@@ -11,6 +11,11 @@ namespace l1t {
       {
          unsigned int blockId = block.header().getID();
          LogDebug("L1T") << "Block ID  = " << blockId << " size = " << block.header().getSize();
+         // Process only if there is a payload.
+         // If all BX block were zero suppressed the block header size is 0.
+         if (block.header().getSize() < 1) {
+            return true;
+         }
 
          auto payload = block.payload();
 
@@ -72,8 +77,6 @@ namespace l1t {
                   uint32_t raw_data_32_63 = bxPayload[nWord+1];
                   LogDebug("L1T") << "raw_data_00_31 = 0x" << hex << setw(8) << setfill('0') << raw_data_00_31 << " raw_data_32_63 = 0x" << setw(8) << setfill('0') << raw_data_32_63;
                   // skip empty muons (hwPt == 0)
-                  //// the msb are reserved for global information
-                  //if ((raw_data_00_31 & 0x7FFFFFFF) == 0 && (raw_data_32_63 & 0x7FFFFFFF) == 0) {
                   if (((raw_data_00_31 >> l1t::RegionalMuonRawDigiTranslator::ptShift_) & l1t::RegionalMuonRawDigiTranslator::ptMask_) == 0) {
                      LogDebug("L1T") << "Muon hwPt zero. Skip.";
                      continue;
@@ -93,7 +96,8 @@ namespace l1t {
                   res->push_back(bxBlock.header().getBx(), mu);
                }
             } else {
-               edm::LogWarning("L1T") << "Only " << bxPayload.size() << " 32 bit words in this BX but " << nWords_ << " are required. Not unpacking the data for BX " << bxBlock.header().getBx() << ".";
+               unsigned int nWords = nWords_; // This seems unnecessary but it prevents an 'undefined reference' linker error that occurs when using nWords_ directly with LogWarning.
+               edm::LogWarning("L1T") << "Only " << bxPayload.size() << " 32 bit words in this BX but " << nWords << " are required. Not unpacking the data for BX " << bxBlock.header().getBx() << ".";
             }
          }
          return true;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
@@ -2,7 +2,6 @@
 #include "EventFilter/L1TRawToDigi/plugins/UnpackerFactory.h"
 
 #include "L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h"
-#include "GMTCollections.h"
 #include "RegionalMuonGMTUnpacker.h"
 
 namespace l1t {
@@ -15,14 +14,17 @@ namespace l1t {
 
          auto payload = block.payload();
 
-         unsigned int nWords = 6; // every link transmits 6 words (3 muons) per bx
          int nBX, firstBX, lastBX;
-         nBX = int(ceil(block.header().getSize() / nWords));
+         // Check if per BX zero suppression was enabled
+         bool bxZsEnabled = ((block.header().getFlags() >> bxzs_enable_shift_) & 0x1) == 1;
+         // Calculate the total number of BXs
+         if (bxZsEnabled) {
+            BxBlockHeader bxHeader(payload.at(0));
+            nBX = bxHeader.getTotalBx();
+         } else {
+            nBX = int(ceil(block.header().getSize() / nWords_));
+         }
          getBXRange(nBX, firstBX, lastBX);
-         // only use central BX for now
-         //firstBX = 0;
-         //lastBX = 0;
-         //LogDebug("L1T") << "BX override. Set first BX = lastBX = 0.";
 
          // decide which collection to use according to the link ID
          unsigned int linkId = blockId / 2;
@@ -59,35 +61,39 @@ namespace l1t {
 
          LogDebug("L1T") << "nBX = " << nBX << " first BX = " << firstBX << " lastBX = " << lastBX;
 
-         // Initialise index
-         int unsigned i = 0;
-
-         // Loop over multiple BX and then number of muons filling muon collection
-         for (int bx = firstBX; bx <= lastBX; ++bx) {
-            for (unsigned nWord = 0; nWord < nWords && i < block.header().getSize(); nWord += 2) {
-               uint32_t raw_data_00_31 = payload[i++];
-               uint32_t raw_data_32_63 = payload[i++];        
-               LogDebug("L1T") << "raw_data_00_31 = 0x" << hex << setw(8) << setfill('0') << raw_data_00_31 << " raw_data_32_63 = 0x" << setw(8) << setfill('0') << raw_data_32_63;
-               // skip empty muons (hwPt == 0)
-               //// the msb are reserved for global information
-               //if ((raw_data_00_31 & 0x7FFFFFFF) == 0 && (raw_data_32_63 & 0x7FFFFFFF) == 0) {
-               if (((raw_data_00_31 >> l1t::RegionalMuonRawDigiTranslator::ptShift_) & l1t::RegionalMuonRawDigiTranslator::ptMask_) == 0) {
-                  LogDebug("L1T") << "Muon hwPt zero. Skip.";
-                  continue;
-               }
-               // Detect and ignore comma events
-               if (raw_data_00_31 == 0x505050bc || raw_data_32_63 == 0x505050bc) {
-                  edm::LogWarning("L1T") << "Comma detected in raw data stream. Orbit number: " << block.amc().getOrbitNumber() << ", BX ID: " << block.amc().getBX() << ", BX: " << bx << ", linkId: " << linkId << ", Raw data: 0x" << hex << setw(8) << setfill('0') << raw_data_32_63 << setw(8) << setfill('0') << raw_data_00_31 << dec << ". Skip.";
-                  continue;
-               }
+         // Get the BX blocks and unpack them
+         auto bxBlocks = block.getBxBlocks(nWords_, bxZsEnabled);
+         for (const auto& bxBlock : bxBlocks) {
+            // Check if there are enough words left in the BX block payload
+            auto bxPayload = bxBlock.payload();
+            if (nWords_ <= bxPayload.size()) {
+               for (unsigned nWord = 0; nWord < nWords_; nWord += 2) {
+                  uint32_t raw_data_00_31 = bxPayload[nWord];
+                  uint32_t raw_data_32_63 = bxPayload[nWord+1];
+                  LogDebug("L1T") << "raw_data_00_31 = 0x" << hex << setw(8) << setfill('0') << raw_data_00_31 << " raw_data_32_63 = 0x" << setw(8) << setfill('0') << raw_data_32_63;
+                  // skip empty muons (hwPt == 0)
+                  //// the msb are reserved for global information
+                  //if ((raw_data_00_31 & 0x7FFFFFFF) == 0 && (raw_data_32_63 & 0x7FFFFFFF) == 0) {
+                  if (((raw_data_00_31 >> l1t::RegionalMuonRawDigiTranslator::ptShift_) & l1t::RegionalMuonRawDigiTranslator::ptMask_) == 0) {
+                     LogDebug("L1T") << "Muon hwPt zero. Skip.";
+                     continue;
+                  }
+                  // Detect and ignore comma events
+                  if (raw_data_00_31 == 0x505050bc || raw_data_32_63 == 0x505050bc) {
+                     edm::LogWarning("L1T") << "Comma detected in raw data stream. Orbit number: " << block.amc().getOrbitNumber() << ", BX ID: " << block.amc().getBX() << ", BX: " << bxBlock.header().getBx() << ", linkId: " << linkId << ", Raw data: 0x" << hex << setw(8) << setfill('0') << raw_data_32_63 << setw(8) << setfill('0') << raw_data_00_31 << dec << ". Skip.";
+                     continue;
+                  }
  
-               RegionalMuonCand mu;
+                  RegionalMuonCand mu;
  
-               RegionalMuonRawDigiTranslator::fillRegionalMuonCand(mu, raw_data_00_31, raw_data_32_63, processor, trackFinder);
+                  RegionalMuonRawDigiTranslator::fillRegionalMuonCand(mu, raw_data_00_31, raw_data_32_63, processor, trackFinder);
 
-               LogDebug("L1T") << "Mu" << nWord/2 << ": eta " << mu.hwEta() << " phi " << mu.hwPhi() << " pT " << mu.hwPt() << " qual " << mu.hwQual() << " sign " << mu.hwSign() << " sign valid " << mu.hwSignValid();
+                  LogDebug("L1T") << "Mu" << nWord/2 << ": eta " << mu.hwEta() << " phi " << mu.hwPhi() << " pT " << mu.hwPt() << " qual " << mu.hwQual() << " sign " << mu.hwSign() << " sign valid " << mu.hwSignValid();
 
-               res->push_back(bx, mu);
+                  res->push_back(bxBlock.header().getBx(), mu);
+               }
+            } else {
+               edm::LogWarning("L1T") << "Only " << bxPayload.size() << " 32 bit words in this BX but " << nWords_ << " are required. Not unpacking the data for BX " << bxBlock.header().getBx() << ".";
             }
          }
          return true;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.h
@@ -2,12 +2,18 @@
 #define L1T_PACKER_STAGE2_REGIONALMUONGMTUNPACKER_H
 
 #include "EventFilter/L1TRawToDigi/interface/Unpacker.h"
+#include "EventFilter/L1TRawToDigi/interface/Block.h"
+#include "GMTCollections.h"
 
 namespace l1t {
    namespace stage2 {
       class RegionalMuonGMTUnpacker : public Unpacker {
          public:
             virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+
+         private:
+            static const unsigned int nWords_ = 6; // every link transmits 6 words (3 muons) per bx
+            static const unsigned int bxzs_enable_shift_ = 1;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/src/Block.cc
+++ b/EventFilter/L1TRawToDigi/src/Block.cc
@@ -39,6 +39,32 @@ namespace l1t {
       return ((id_ & CTP7_mask) << CTP7_shift);
    }
 
+   BxBlocks
+   Block::getBxBlocks(unsigned int payloadWordsPerBx, bool bxHeader) const
+   {
+      BxBlocks bxBlocks;
+
+      // For MP7 format
+      unsigned int wordsPerBx = payloadWordsPerBx;
+      if (bxHeader) {
+         ++wordsPerBx;
+      }
+      // Calculate how many BxBlock objects can be made with the available payload
+      unsigned int nBxBlocks = payload_.size() / wordsPerBx;
+      for (size_t bxCtr = 0; bxCtr < nBxBlocks; ++bxCtr) {
+         size_t startIdx = bxCtr * wordsPerBx;
+         auto startBxBlock = payload_.cbegin()+startIdx;
+         // Pick the words from the block payload that correspond to the BX and add a BxBlock to the BxBlocks
+         if (bxHeader) {
+            bxBlocks.emplace_back(startBxBlock, startBxBlock+wordsPerBx);
+         } else {
+            bxBlocks.emplace_back(bxCtr, nBxBlocks, startBxBlock, startBxBlock+wordsPerBx);
+         }
+      }
+
+      return bxBlocks;
+   }
+
    std::unique_ptr<Block>
    Payload::getBlock()
    {


### PR DESCRIPTION
PR 94x - Upgrade the Muon Unpacker and DQM to inteligently handle Zero Suppression, making it BX aware.  

This is compatible with past, current, and future  data. 

Needed for data taking and available in the release at P5 before hardware change goes online (soon).

