### PR TITLE
fixed ptMin threshold for PU subtractor

### DIFF
--- a/RecoJets/JetProducers/interface/PileUpSubtractor.h
+++ b/RecoJets/JetProducers/interface/PileUpSubtractor.h
@@ -31,8 +31,7 @@ class PileUpSubtractor{
   
   PileUpSubtractor(const edm::ParameterSet& iConfig,  edm::ConsumesCollector && iC); 
   virtual ~PileUpSubtractor(){;}
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-
+  
   virtual void setDefinition(JetDefPtr const & jetDef);
   virtual void reset(std::vector<edm::Ptr<reco::Candidate> >& input,
 	     std::vector<fastjet::PseudoJet>& towers,

--- a/RecoJets/JetProducers/src/PileUpSubtractor.cc
+++ b/RecoJets/JetProducers/src/PileUpSubtractor.cc
@@ -370,22 +370,6 @@ int PileUpSubtractor::iphi(const reco::CandidatePtr & in) const {
   return it;
 }
 
-// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void PileUpSubtractor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-
-	edm::ParameterSetDescription desc;
-	desc.add<bool> ("doAreaFastjet", 	false);
-	desc.add<bool> ("doRhoFastjet", 	false);
-	desc.add<double> ("Ghost_EtaMax", 5);
-	desc.add<double> ("GhostArea", 0.01);
-	desc.add<int> ("Active_Area_Repeats", 1);
-	desc.add<double> ("jetPtMin",	10.);
-	desc.add<double> ("puPtMin", 	10.);
-	desc.add<double> ("nSigmaPU", 	1.);
-	desc.add<double> ("radiusPU", 	0.5);
-	descriptions.addDefault(desc);
-}
-
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 EDM_REGISTER_PLUGINFACTORY(PileUpSubtractorFactory,"PileUpSubtractorFactory");
 

--- a/RecoJets/JetProducers/src/PileUpSubtractor.cc
+++ b/RecoJets/JetProducers/src/PileUpSubtractor.cc
@@ -17,7 +17,7 @@ using namespace std;
 
 PileUpSubtractor::PileUpSubtractor(const edm::ParameterSet& iConfig, edm::ConsumesCollector && iC) {
 
-	geo_ = 0;
+	geo_ = nullptr;
 	doAreaFastjet_	= iConfig.getParameter<bool>("doAreaFastjet");
 	doRhoFastjet_	= iConfig.getParameter<bool>("doRhoFastjet");
 	nSigmaPU_	= iConfig.getParameter<double>("nSigmaPU");
@@ -62,7 +62,7 @@ void PileUpSubtractor::setupGeometryMap(edm::Event& iEvent,const edm::EventSetup
 
   LogDebug("PileUpSubtractor")<<"The subtractor setting up geometry...\n";
 
-  if(geo_ == 0) {
+  if(geo_ == nullptr) {
     edm::ESHandle<CaloGeometry> pG;
     iSetup.get<CaloGeometryRecord>().get(pG);
     geo_ = pG.product();

--- a/RecoJets/JetProducers/src/PileUpSubtractor.cc
+++ b/RecoJets/JetProducers/src/PileUpSubtractor.cc
@@ -22,6 +22,7 @@ PileUpSubtractor::PileUpSubtractor(const edm::ParameterSet& iConfig, edm::Consum
 	doRhoFastjet_	= iConfig.getParameter<bool>("doRhoFastjet");
 	nSigmaPU_	= iConfig.getParameter<double>("nSigmaPU");
 	radiusPU_	= iConfig.getParameter<double>("radiusPU");
+	jetPtMin_	= iConfig.getParameter<double>("jetPtMin");
 	puPtMin_	= iConfig.getParameter<double>("puPtMin");
 	ghostEtaMax 	= iConfig.getParameter<double>("Ghost_EtaMax");
 	activeAreaRepeats = iConfig.getParameter<int>("Active_Area_Repeats");
@@ -258,7 +259,7 @@ void PileUpSubtractor::offsetCorrectJets()
   LogDebug("PileUpSubtractor")<<"The subtractor correcting jets...\n";
   jetOffset_.clear();
   using namespace reco;
-  
+ 
   //    
   // Reestimate energy of jet (energy of jet with initial map)
   //
@@ -286,11 +287,11 @@ void PileUpSubtractor::offsetCorrectJets()
 	jetOffset_[ijet] += Original_Et - etnew;
       }
     double mScale = newjetet/pseudojetTMP->Et();
-    LogDebug("PileUpSubtractor")<<"pseudojetTMP->Et() : "<<pseudojetTMP->Et()<<"\n";
-    LogDebug("PileUpSubtractor")<<"newjetet : "<<newjetet<<"\n";
-    LogDebug("PileUpSubtractor")<<"jetOffset_[ijet] : "<<jetOffset_[ijet]<<"\n";
-    LogDebug("PileUpSubtractor")<<"pseudojetTMP->Et() - jetOffset_[ijet] : "<<pseudojetTMP->Et() - jetOffset_[ijet]<<"\n";
-    LogDebug("PileUpSubtractor")<<"Scale is : "<<mScale<<"\n";
+    LogDebug("PileUpSubtractor")<<"pseudojetTMP->Et() : "<<pseudojetTMP->Et()<<'\n';
+    LogDebug("PileUpSubtractor")<<"newjetet : "<<newjetet<<'\n';
+    LogDebug("PileUpSubtractor")<<"jetOffset_[ijet] : "<<jetOffset_[ijet]<<'\n';
+    LogDebug("PileUpSubtractor")<<"pseudojetTMP->Et() - jetOffset_[ijet] : "<<pseudojetTMP->Et() - jetOffset_[ijet]<<'\n';
+    LogDebug("PileUpSubtractor")<<"Scale is : "<<mScale<<'\n';
     int cshist = pseudojetTMP->cluster_hist_index();
     pseudojetTMP->reset_momentum(pseudojetTMP->px()*mScale, pseudojetTMP->py()*mScale,
 				 pseudojetTMP->pz()*mScale, pseudojetTMP->e()*mScale);
@@ -378,6 +379,7 @@ void PileUpSubtractor::fillDescriptions(edm::ConfigurationDescriptions& descript
 	desc.add<double> ("Ghost_EtaMax", 5);
 	desc.add<double> ("GhostArea", 0.01);
 	desc.add<int> ("Active_Area_Repeats", 1);
+	desc.add<double> ("jetPtMin",	10.);
 	desc.add<double> ("puPtMin", 	10.);
 	desc.add<double> ("nSigmaPU", 	1.);
 	desc.add<double> ("radiusPU", 	0.5);


### PR DESCRIPTION
When the PU subtractor code was upgraded to factorize the descriptions, ptMin was omitted - readding that ptMin value so HI Jet Reco doesn't ignore the value