### PR TITLE
[93X] remove LumiPixels from list of AlCaRecos from Matrix

### DIFF
--- a/Configuration/AlCa/python/autoAlca.py
+++ b/Configuration/AlCa/python/autoAlca.py
@@ -1,4 +1,4 @@
-AlCaRecoMatrix = {"AlCaLumiPixels" : "LumiPixels+AlCaPCCZeroBias+AlCaPCCRandom",
+AlCaRecoMatrix = {"AlCaLumiPixels" : "AlCaPCCZeroBias+AlCaPCCRandom",
                   "Charmonium"     : "TkAlJpsiMuMu",
                   "Commissioning"  : "HcalCalIsoTrk+HcalCalIsolatedBunchSelector+TkAlMinBias+SiStripCalMinBias",
                   "Cosmics"        : "TkAlCosmics0T+MuAlGlobalCosmics+DtCalibCosmics",


### PR DESCRIPTION
backport of #20473
for the sake of consistency, removing it from 93X as well.

As agreed with Lumi POG, this PR removes the LumiPixel AlCaReco from AlCaMatrix.
This has already been removed from current AlCaReco matrix running at T0 https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/1712/1.html