### PR TITLE
Fix PackedCandidate::dz and PhotonIDValueMapProducer

### DIFF
--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -150,7 +150,8 @@ float pat::PackedCandidate::dxy(const Point &p) const {
 float pat::PackedCandidate::dz(const Point &p) const {
     maybeUnpackBoth();
     const float phi = float(p4_.load()->Phi())+dphi_;
-    return (vertex_.load()->Z()-p.Z())  - ((vertex_.load()->X()-p.X()) * std::cos(phi) + (vertex_.load()->Y()-p.Y()) * std::sin(phi)) * p4_.load()->Pz()/p4_.load()->Pt();
+    const float pzpt = deta_ ? std::sinh(etaAtVtx()) : p4_.load()->Pz()/p4_.load()->Pt();
+    return (vertex_.load()->Z()-p.Z())  - ((vertex_.load()->X()-p.X()) * std::cos(phi) + (vertex_.load()->Y()-p.Y()) * std::sin(phi)) * pzpt;
 }
 
 void pat::PackedCandidate::unpackTrk() const {

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -299,11 +299,11 @@ bool pat::PackedCandidate::overlap( const reco::Candidate & o ) const {
 }
 
 const reco::Candidate * pat::PackedCandidate::daughter( size_type ) const {
-  return 0;
+  return nullptr;
 }
 
 const reco::Candidate * pat::PackedCandidate::mother( size_type ) const {
-  return 0;
+  return nullptr;
 }
 
 const reco::Candidate * pat::PackedCandidate::daughter(const std::string&) const {
@@ -321,7 +321,7 @@ reco::Candidate * pat::PackedCandidate::daughter(const std::string&) {
 
 
 reco::Candidate * pat::PackedCandidate::daughter( size_type ) {
-  return 0;
+  return nullptr;
 }
 
 double pat::PackedCandidate::vertexChi2() const {

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
@@ -42,13 +42,13 @@ class PhotonIDValueMapProducer : public edm::stream::EDProducer<> {
   public:
   
   explicit PhotonIDValueMapProducer(const edm::ParameterSet&);
-  ~PhotonIDValueMapProducer();
+  ~PhotonIDValueMapProducer() override;
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   private:
   
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
   void writeValueMap(edm::Event &iEvent,
 		     const edm::Handle<edm::View<reco::Photon> > & handle,
@@ -269,7 +269,7 @@ void PhotonIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup
   if( !pfCandidatesHandle.isValid() )
     iEvent.getByToken(pfCandidatesTokenMiniAOD_, pfCandidatesHandle);
 
-  if( !isAOD && src->size() ) {
+  if( !isAOD && !src->empty() ) {
     edm::Ptr<pat::Photon> test(src->ptrAt(0));
     if( test.isNull() || !test.isAvailable() ) {
       throw cms::Exception("InvalidConfiguration")
@@ -519,7 +519,7 @@ float PhotonIDValueMapProducer
     allIsolations.push_back(sum);
   }
 
-  if( allIsolations.size()>0 )
+  if( !allIsolations.empty() )
     worstIsolation = * std::max_element( allIsolations.begin(), allIsolations.end() );
   
   return worstIsolation;

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
@@ -76,7 +76,7 @@ class PhotonIDValueMapProducer : public edm::stream::EDProducer<> {
   reco::PFCandidate::ParticleType
   candidatePdgId(const edm::Ptr<reco::Candidate> candidate, bool isAOD);
 
-  const reco::Track* getTrackPointer(const edm::Ptr<reco::Candidate> candidate, bool isAOD);
+  std::pair<float,float> getTrackDxyDz(const edm::Ptr<reco::Candidate> & candidate, const reco::Particle::Point & vtxpos, bool isAOD);
 
 
   // The object that will compute 5x5 quantities  
@@ -378,13 +378,10 @@ void PhotonIDValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup
       if( thisCandidateType == reco::PFCandidate::h ){
 	// for charged hadrons, additionally check consistency
 	// with the PV
-	const reco::Track *theTrack = getTrackPointer( iCand, isAOD );
 
-	float dxy = theTrack->dxy(pv.position());
-	if(fabs(dxy) > dxyMax) continue;
-
-	float dz  = theTrack->dz(pv.position());
-	if (fabs(dz) > dzMax) continue;
+        auto dxydz = getTrackDxyDz(iCand, pv.position(), isAOD);
+        if ( fabs(dxydz.first) > dxyMax) continue;
+        if ( fabs(dxydz.second) > dzMax) continue;
 
 	// The candidate is eligible, increment the isolaiton
 	chargedIsoSum += iCand->pt();
@@ -507,13 +504,10 @@ float PhotonIDValueMapProducer
 
       if (iCand->pt() < ptMin)
 	continue;
-      
-      const reco::Track *theTrack = getTrackPointer( iCand, isAOD );
-      float dxy = theTrack->dxy(vtx->position());
-      if( fabs(dxy) > dxyMax) continue;
-      
-      float dz = theTrack->dz(vtx->position());
-      if ( fabs(dz) > dzMax) continue;
+
+      auto dxydz = getTrackDxyDz(iCand, vtx->position(), isAOD);
+      if ( fabs(dxydz.first) > dxyMax) continue;
+      if ( fabs(dxydz.second) > dzMax) continue;
       
       float dR2 = deltaR2(photon_directionWrtVtx.Eta(), photon_directionWrtVtx.Phi(), 
                           iCand->eta(),      iCand->phi());
@@ -552,16 +546,17 @@ PhotonIDValueMapProducer::candidatePdgId(const edm::Ptr<reco::Candidate> candida
   return thisCandidateType;
 }
 
-const reco::Track* 
-PhotonIDValueMapProducer::getTrackPointer(const edm::Ptr<reco::Candidate> candidate, bool isAOD){
+std::pair<float,float>
+PhotonIDValueMapProducer::getTrackDxyDz(const edm::Ptr<reco::Candidate> & candidate, const reco::Particle::Point & vtxpos, bool isAOD) {
 
-  const reco::Track* theTrack = nullptr;
-  if( isAOD )
-    theTrack = &*( ((const recoCandPtr) candidate)->trackRef());
-  else
-    theTrack = &( ((const patCandPtr) candidate)->pseudoTrack());
+  if( isAOD ) {
+    const reco::Track & theTrack = *recoCandPtr(candidate)->trackRef();
+    return std::make_pair(theTrack.dxy(vtxpos),theTrack.dz(vtxpos));
+  } else {
+    const pat::PackedCandidate & theCand = *(patCandPtr(candidate));
+    return std::make_pair(theCand.dxy(vtxpos),theCand.dz(vtxpos));
+  }
 
-  return theTrack;
 }
 
 DEFINE_FWK_MODULE(PhotonIDValueMapProducer);


### PR DESCRIPTION
* fix the dz(point) method of PackedCandidate to work correctly when point is not the associated PV, and the eta of the candidate is not the eta of the track. This ensures that cand.dz(point) is always the same as cand.track.dz(point) whenever the track is available (as it was already the case for dxy)
* fix the PhotonIDValueMapProducer on miniAOD to get the dxy and dz from the candidate instead of the track (dxy and dy are always available in the candidate, but they're not available in the track at low pT, and in 94X this causes an exception)
