### PR TITLE
[93X] GT Updates for L1T conditions needed for emulator

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,17 +10,17 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '93X_mcRun1_pA_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '93X_mcRun2_design_v0',
+    'run2_design'       :   '93X_mcRun2_design_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '93X_mcRun2_startup_v0',
+    'run2_mc_50ns'      :   '93X_mcRun2_startup_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '93X_mcRun2_asymptotic_v1',
+    'run2_mc'           :   '93X_mcRun2_asymptotic_v2',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '93X_mcRun2cosmics_startup_deco_v0',
+    'run2_mc_cosmics'   :   '93X_mcRun2cosmics_startup_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '93X_mcRun2_HeavyIon_v0',
+    'run2_mc_hi'        :   '93X_mcRun2_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '93X_mcRun2_pA_v0',
+    'run2_mc_pa'        :   '93X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '93X_dataRun2_v0',
     # GlobalTag for Run2 data reprocessing


### PR DESCRIPTION
# Summary of changes in Global Tags 
 
## RunII simulation 
 
   * **RunII Asymptotic scenario** : [93X_mcRun2_asymptotic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_asymptotic_v2) as [93X_mcRun2_asymptotic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_asymptotic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mcRun2_asymptotic_v2/93X_mcRun2_asymptotic_v1): 
      * update of L1T conditions for emulator : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3188/4/1.html

   * **RunII CRAFT scenario** : [93X_mcRun2cosmics_startup_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2cosmics_startup_deco_v1) as [93X_mcRun2cosmics_startup_deco_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2cosmics_startup_deco_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mcRun2cosmics_startup_deco_v1/93X_mcRun2cosmics_startup_deco_v0): 
      * update of L1T conditions for emulator : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3188/4/1.html

   * **RunII Heavy Ions scenario** : [93X_mcRun2_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_HeavyIon_v1) as [93X_mcRun2_HeavyIon_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_HeavyIon_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mcRun2_HeavyIon_v1/93X_mcRun2_HeavyIon_v0): 
      * update of L1T conditions for emulator : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3188/4/1.html

   * **RunII Ideal scenario** : [93X_mcRun2_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_design_v1) as [93X_mcRun2_design_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_design_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mcRun2_design_v1/93X_mcRun2_design_v0): 
      * update of L1T conditions for emulator : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3188/4/1.html

   * **RunII Proton-Lead scenario** : [93X_mcRun2_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_pA_v1) as [93X_mcRun2_pA_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_pA_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mcRun2_pA_v1/93X_mcRun2_pA_v0): 
      * update of L1T conditions for emulator : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3188/4/1.html

   * **RunII Startup scenario** : [93X_mcRun2_startup_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_startup_v1) as [93X_mcRun2_startup_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_startup_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_mcRun2_startup_v1/93X_mcRun2_startup_v0): 
      * update of L1T conditions for emulator : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3188/4/1.html