### PR TITLE
Fix histogram limits in SiPixelClusterSource

### DIFF
--- a/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
+++ b/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
@@ -40,7 +40,7 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 //
 #include <string>
-#include <stdlib.h>
+#include <cstdlib>
 
 using namespace std;
 using namespace edm;
@@ -86,7 +86,7 @@ SiPixelClusterSource::~SiPixelClusterSource()
   std::map<uint32_t,SiPixelClusterModule*>::iterator struct_iter;
   for (struct_iter = thePixelStructure.begin() ; struct_iter != thePixelStructure.end() ; struct_iter++){
     delete struct_iter->second;
-    struct_iter->second = 0;
+    struct_iter->second = nullptr;
   }
 }
 
@@ -297,7 +297,7 @@ void SiPixelClusterSource::buildStructure(const edm::EventSetup& iSetup){
   
   for(TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin(); it != pDD->dets().end(); it++){
     
-    if(dynamic_cast<PixelGeomDetUnit const *>((*it))!=0){
+    if(dynamic_cast<PixelGeomDetUnit const *>((*it))!=nullptr){
 
       DetId detId = (*it)->geographicalId();
       const GeomDetUnit      * geoUnit = pDD->idToDetUnit( detId );

--- a/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
+++ b/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
@@ -160,6 +160,7 @@ void SiPixelClusterSource::bookHistograms(DQMStore::IBooker & iBooker, edm::Run 
     if (i==1) { ybins = 42; ymin = -10.5; ymax = 10.5; }
     if (i==2) { ybins = 66; ymin = -16.5; ymax = 16.5; }
     if (i==3) { ybins = 90; ymin = -22.5; ymax = 22.5; }
+    if (i==4) { ybins = 130; ymin = -32.5; ymax = 32.5; }
     ss1.str(std::string()); ss1 << "pix_bar Occ_roc_online_" + digisrc_. label() + "_layer_" << i;
     ss2.str(std::string()); ss2 << "Pixel Barrel Occupancy, ROC level (Online): Layer " << i;
     meZeroRocBPIX.push_back(iBooker.book2D(ss1.str(),ss2.str(),72,-4.5,4.5,ybins,ymin,ymax));


### PR DESCRIPTION
The module SiPixelClusterSource was causing frequent failures in
the nightly integration tests because the histogram tracking
layer 4 did not have properly defined limits in the y dimension.