### PR TITLE
[94X] Fix geometry centering tool.

### DIFF
--- a/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
@@ -59,23 +59,23 @@
 #include <sstream> 
 
 TrackerGeometryCompare::TrackerGeometryCompare(const edm::ParameterSet& cfg) :	
-  referenceTracker(0),
-  dummyTracker(0),
-  currentTracker(0),
+  referenceTracker(nullptr),
+  dummyTracker(nullptr),
+  currentTracker(nullptr),
   theSurveyIndex(0),
-  theSurveyValues(0),
-  theSurveyErrors(0),
+  theSurveyValues(nullptr),
+  theSurveyErrors(nullptr),
   _levelStrings(cfg.getUntrackedParameter< std::vector<std::string> >("levels")),
   _writeToDB(cfg.getUntrackedParameter<bool>("writeToDB")),
   _commonTrackerLevel(align::invalid),
-  _moduleListFile(0),
+  _moduleListFile(nullptr),
   _moduleList(0),
-  _inputRootFile1(0),
-  _inputRootFile2(0),
-  _inputTree01(0),
-  _inputTree02(0),
-  _inputTree11(0),
-  _inputTree12(0),
+  _inputRootFile1(nullptr),
+  _inputRootFile2(nullptr),
+  _inputTree01(nullptr),
+  _inputTree02(nullptr),
+  _inputTree11(nullptr),
+  _inputTree12(nullptr),
   m_nBins(10000),
   m_rangeLow(-.1),
   m_rangeHigh(.1), 
@@ -702,7 +702,7 @@ void TrackerGeometryCompare::setCommonTrackerSystem(){
 	
 	//adjust translational difference factoring in different rotational CM
 	//needed because rotateInGlobalFrame is about CM of alignable, not Tracker
-	align::GlobalVector::BasicVectorType lpvgf = cmDiff.basicVector();
+	const align::GlobalVector::BasicVectorType& lpvgf = cmDiff.basicVector();
 	align::GlobalVector moveV( rot.multiplyInverse(lpvgf) - lpvgf);
 	align::GlobalVector theRprime(theR + moveV);
 	
@@ -920,7 +920,7 @@ void TrackerGeometryCompare::surveyToTracker(AlignableTracker* ali, Alignments* 
 	for(std::vector<Alignable*>::iterator k = rcdAlis.begin(); k != rcdAlis.end(); k++){
 		
 		const SurveyDet* surveyInfo = (*k)->survey();
-		align::PositionType pos(surveyInfo->position());
+		const align::PositionType& pos(surveyInfo->position());
 		align::RotationType rot(surveyInfo->rotation());
 		CLHEP::Hep3Vector clhepVector(pos.x(),pos.y(),pos.z());
 		CLHEP::HepRotation clhepRotation( CLHEP::HepRep3x3(rot.xx(),rot.xy(),rot.xz(),rot.yx(),rot.yy(),rot.yz(),rot.zx(),rot.zy(),rot.zz()));

--- a/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
@@ -633,7 +633,7 @@ void TrackerGeometryCompare::compareGeometries(Alignable* refAli, Alignable* cur
 		lWtotal.set(0.,0.,0.);
 
 		for (int i = 0; i < 100; i++){
-			AlgebraicVector diff = align::diffAlignables(curAli,refAli, _weightBy, _weightById, _weightByIdVector);
+			AlgebraicVector diff = align::diffAlignables(refAli, curAli, _weightBy, _weightById, _weightByIdVector);
 			CLHEP::Hep3Vector dR(diff[0],diff[1],diff[2]);
 			Rtotal+=dR;
 			CLHEP::Hep3Vector dW(diff[3],diff[4],diff[5]);
@@ -645,9 +645,9 @@ void TrackerGeometryCompare::compareGeometries(Alignable* refAli, Alignable* cur
 			lRtotal.set(diff[6],diff[7],diff[8]);
 			lWtotal.set(diff[9],diff[10],diff[11]);
 			
-			align::moveAlignable(refAli, diff);
+			align::moveAlignable(curAli, diff);
 			float tolerance = 1e-7;
-			AlgebraicVector check = align::diffAlignables(curAli,refAli, _weightBy, _weightById, _weightByIdVector);
+			AlgebraicVector check = align::diffAlignables(refAli, curAli, _weightBy, _weightById, _weightByIdVector);
 			align::GlobalVector checkR(check[0],check[1],check[2]);
 			align::GlobalVector checkW(check[3],check[4],check[5]);
 			if ((checkR.mag() > tolerance)||(checkW.mag() > tolerance)){
@@ -731,7 +731,7 @@ void TrackerGeometryCompare::diffCommonTrackerSystem(Alignable *refAli, Alignabl
 		CLHEP::Hep3Vector Rtotal, Wtotal;
 		Rtotal.set(0.,0.,0.); Wtotal.set(0.,0.,0.);
 		
-		AlgebraicVector diff = align::diffAlignables(curAli,refAli, _weightBy, _weightById, _weightByIdVector);
+		AlgebraicVector diff = align::diffAlignables(refAli, curAli, _weightBy, _weightById, _weightByIdVector);
 		CLHEP::Hep3Vector dR(diff[0],diff[1],diff[2]);
 		Rtotal+=dR;
 		CLHEP::Hep3Vector dW(diff[3],diff[4],diff[5]);

--- a/Alignment/OfflineValidation/test/GeometryCentering_cfg.py
+++ b/Alignment/OfflineValidation/test/GeometryCentering_cfg.py
@@ -9,18 +9,18 @@ process.MessageLogger.destinations = ['cout', 'cerr']
 
 ### needed to get the geometry
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag,"auto:run2_design")
+process.GlobalTag = GlobalTag(process.GlobalTag,"auto:phase1_2017_design")
 
 from CondCore.CondDB.CondDB_cfi import *
 
 CondDBAlignment = CondDB.clone(connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'))
                             
-### example starting MC geometry that is known to be off-centered
+### example starting data geometry that is known to have an off-centered BPIX
 process.ZeroGeom = cms.ESSource("PoolDBESSource",
                                 CondDBAlignment,
                                 timetype = cms.string("runnumber"),
                                 toGet = cms.VPSet(cms.PSet(record = cms.string('TrackerAlignmentRcd'),
-                                                           tag = cms.string('TrackerAlignment_Asymptotic_Run2016_v1_mc')
+                                                           tag = cms.string('TrackerAlignment_StartUp17_v11')
                                                            )
                                                   )                                                            
                                 )
@@ -31,7 +31,7 @@ process.ZeroAPE = cms.ESSource("PoolDBESSource",
                                CondDBAPE,
                                timetype = cms.string("runnumber"),
                                toGet = cms.VPSet(cms.PSet(record = cms.string('TrackerAlignmentErrorExtendedRcd'),
-                                                          tag = cms.string('TrackerIdealGeometryErrorsExtended210_mc')
+                                                          tag = cms.string('TrackerAlignmentErrorsExtended_Upgrade2017_design_v0')
                                                           )
                                                  )
                                )
@@ -56,7 +56,7 @@ process.dump = cms.EDAnalyzer("TrackerGeometryIntoNtuples",
 process.load("Alignment.OfflineValidation.TrackerGeometryCompare_cfi")
 process.TrackerGeometryCompare.inputROOTFile1 = 'IDEAL'
 process.TrackerGeometryCompare.inputROOTFile2 = GeometryIntoNtuplesRootFile
-process.TrackerGeometryCompare.setCommonTrackerSystem = "TPBBarrel"  # for MC
+process.TrackerGeometryCompare.setCommonTrackerSystem = "P1PXBBarrel"  # for MC
 #process.TrackerGeometryCompare.setCommonTrackerSystem = "TOBBarrel"  # for Data
 process.TrackerGeometryCompare.levels = []
 process.TrackerGeometryCompare.writeToDB = True
@@ -66,7 +66,7 @@ process.TFileService = cms.Service("TFileService",
                                    #fileName=cms.string("TOBCenteredOutputComparison.root") #for Data
                                    )
 
-CondDBoutput=CondDB.clone(connect = cms.string('sqlite_file:TrackerAlignment_Asymptotic_Run2016_v1_mc_Centred.db'))
+CondDBoutput=CondDB.clone(connect = cms.string('sqlite_file:TrackerAlignment_StartUp17_v11_BPIX-Centred.db'))
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           CondDBoutput,

--- a/Configuration/AlCa/python/GlobalTag.py
+++ b/Configuration/AlCa/python/GlobalTag.py
@@ -69,7 +69,7 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
             if globaltag not in autoCond:
                 raise Exception('no correspondence for '+globaltag+'\navailable keys are\n'+','.join(autoCond.keys()))
             if 'phase1_2017_design' == globaltag:
-                sys.stderr.write('Warning: %s now points to %s. This has reco- Beamspot centered to (0,0,0)'%(globaltag,autoCond[globaltag]))
+                sys.stderr.write('Warning: %s now points to %s. This has reco-Beamspot centered to (0,0,0)\n'%(globaltag,autoCond[globaltag]))
             autoKey = autoCond[globaltag]
             if isinstance(autoKey, tuple) or isinstance(autoKey, list):
                 globaltag = autoKey[0]


### PR DESCRIPTION
The previous sign-flip in the geometry comparison tool broke the geometry centering tool.
While fixing this I found with the help of @cschomak that one sign flip too much introduced previously.