### PR TITLE
Catch more circular dependencies

### DIFF
--- a/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalUncalIsolElectron_cff.py
+++ b/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalUncalIsolElectron_cff.py
@@ -26,7 +26,7 @@ from RecoLocalCalo.Configuration.ecalLocalRecoSequence_cff import *
 from RecoLocalCalo.EcalRecProducers.ecalGlobalUncalibRecHit_cfi import *
 ecalUncalibRecHitSequence53X = cms.Sequence(ecalGlobalUncalibRecHit * ecalDetIdToBeRecovered)
 
-uncalibRecHitSeq = cms.Sequence( (ecalDigis + ecalPreshowerDigis) * ecalUncalibRecHitSequence)
+uncalibRecHitSeq = cms.Sequence(ecalUncalibRecHitSequence, cms.Task(ecalDigis, ecalPreshowerDigis))
 
 ALCARECOEcalUncalElectronECALSeq = cms.Sequence( uncalibRecHitSeq )
 

--- a/FWCore/Framework/test/throwIfImproperDependencies_t.cppunit.cc
+++ b/FWCore/Framework/test/throwIfImproperDependencies_t.cppunit.cc
@@ -656,5 +656,22 @@ void test_throwIfImproperDependencies::twoPathsWithCycleTest()
     CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
   }
 
+  {
+    // The data dependency for 'D" can be met
+    // by the order of modules on path p2
+    // but NOT by path3
+    ModuleDependsOnMap md = {
+      {"A_TR", {"zEP1","zEP2"}},
+      { "B",{}},
+      {"zFilter", {"A_TR"}}
+    };
+    PathToModules paths = {
+      {"p1", {"zFilter","B","zEP1"}},
+      {"p2", {"zFilter", "B","zEP2"}}
+    };
+    
+    CPPUNIT_ASSERT_THROW( testCase(md,paths), cms::Exception);
+  }
+
 }
 

--- a/FWCore/Framework/test/throwIfImproperDependencies_t.cppunit.cc
+++ b/FWCore/Framework/test/throwIfImproperDependencies_t.cppunit.cc
@@ -517,6 +517,33 @@ void test_throwIfImproperDependencies::twoPathsNoCycleTest()
     CPPUNIT_ASSERT( testCase(md,paths));
   }
 
+  {
+    //The same sequence of modules appear on a Path and EndPath
+    // Check that the framework does not get confused when jumping
+    // from one path to the other path just because of the
+    // TriggerResults connection.
+    
+    ModuleDependsOnMap md = {
+      {"A_TR", {"zEP1"}},
+      {"A", {"B"}},
+      {"B", {"H"}},
+      {"C", {}},
+      {"D" ,{}},
+      {"E" , {}},
+      {"G",{"D"}},
+      {"H",{"D"}},
+      {"zEP1", {}},
+      {"zSEP2", {"A_TR"}}
+    };
+    PathToModules paths = {
+      {"p2", {"D", "G","H","B","C","zEP1"}},
+      {"p3", {"A"}}, //Needed to make graph search start here
+      {"p1", {"zSEP2","E","D","G","H","B", "C"}} };
+  
+    
+    CPPUNIT_ASSERT( testCase(md,paths));
+    
+  }
 }
 
 void test_throwIfImproperDependencies::twoPathsWithCycleTest()

--- a/Validation/RecoB/python/BDHadronTrackValidation_cff.py
+++ b/Validation/RecoB/python/BDHadronTrackValidation_cff.py
@@ -14,14 +14,7 @@ from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import *
 BDHadronTrackMonitoringAnalyze.PatJetSource = cms.InputTag('patJetsBDHadron')
 
 bdHadronTrackValidationSeq = cms.Sequence(BDHadronTrackMonitoringAnalyze,
-                                          cms.Task(patJetCorrectionsTask
-                                                   , patJetCharge
-                                                   , patJetPartonMatch
-                                                   , patJetGenJetMatch
-                                                   , patJetFlavourIdLegacyTask
-                                                   , patJetFlavourIdTask
-                                                   , patJetsBDHadron
-                                                   , tpClusterProducer)
+                                          cms.Task(patJetCorrectionsTask, patJetsBDHadron)
 ) 
 					
 bdHadronTrackPostProcessor = cms.Sequence(BDHadronTrackMonitoringHarvest)

--- a/Validation/RecoB/python/BDHadronTrackValidation_cff.py
+++ b/Validation/RecoB/python/BDHadronTrackValidation_cff.py
@@ -14,7 +14,15 @@ from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import *
 BDHadronTrackMonitoringAnalyze.PatJetSource = cms.InputTag('patJetsBDHadron')
 
 bdHadronTrackValidationSeq = cms.Sequence(BDHadronTrackMonitoringAnalyze,
-                                          cms.Task(patJetCorrectionsTask, patJetsBDHadron)
+                                          cms.Task(patJetCorrectionsTask
+                                                   , patJetCharge
+                                                   , patJetPartonMatch
+                                                   , patJetGenJetMatch
+                                                   , patJetFlavourIdLegacyTask
+                                                   , patJetFlavourIdTask
+                                                   , patJetsBDHadron
+                                                   , tpClusterProducer)
 ) 
+
 					
 bdHadronTrackPostProcessor = cms.Sequence(BDHadronTrackMonitoringHarvest)

--- a/Validation/RecoB/python/BDHadronTrackValidation_cff.py
+++ b/Validation/RecoB/python/BDHadronTrackValidation_cff.py
@@ -13,15 +13,15 @@ from Validation.RecoB.BDHadronTrackMonitoring_cfi import *
 from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import *
 BDHadronTrackMonitoringAnalyze.PatJetSource = cms.InputTag('patJetsBDHadron')
 
-bdHadronTrackValidationSeq = cms.Sequence(patJetCorrections
-                                        * patJetCharge
-                                        * patJetPartonMatch
-                                        * patJetGenJetMatch
-                                        * patJetFlavourIdLegacy
-                                        * patJetFlavourId
-                                        * patJetsBDHadron
-                                        * tpClusterProducer
-                                        * BDHadronTrackMonitoringAnalyze
+bdHadronTrackValidationSeq = cms.Sequence(BDHadronTrackMonitoringAnalyze,
+                                          cms.Task(patJetCorrectionsTask
+                                                   , patJetCharge
+                                                   , patJetPartonMatch
+                                                   , patJetGenJetMatch
+                                                   , patJetFlavourIdLegacyTask
+                                                   , patJetFlavourIdTask
+                                                   , patJetsBDHadron
+                                                   , tpClusterProducer)
 ) 
 					
 bdHadronTrackPostProcessor = cms.Sequence(BDHadronTrackMonitoringHarvest)


### PR DESCRIPTION
The HLT had a case where a circular dependency was missed because the modules involved were on multiple Paths. This change now catches that case and includes an addition unit test.