### PR TITLE
Fix to prevent possible crashes if the prescale table changes during job

### DIFF
--- a/L1Trigger/L1TGlobal/src/L1TGlobalUtil.cc
+++ b/L1Trigger/L1TGlobal/src/L1TGlobalUtil.cc
@@ -115,6 +115,9 @@ void l1t::L1TGlobalUtil::retrieveL1Setup(const edm::EventSetup& evSetup) {
 	// clear and dimension
 	resetPrescaleVectors();
 	resetMaskVectors();
+	m_PreScaleColumn = 0;
+	m_numberOfPreScaleColumns = 0;
+	m_numberPhysTriggers = 0;
 
 	edm::ESHandle< L1TGlobalPrescalesVetos > l1GtPrescalesVetoes;
 	evSetup.get< L1TGlobalPrescalesVetosRcd >().get( l1GtPrescalesVetoes );
@@ -122,6 +125,7 @@ void l1t::L1TGlobalUtil::retrieveL1Setup(const edm::EventSetup& evSetup) {
 	m_l1GtPrescalesVetoes = PrescalesVetosHelper::readFromEventSetup(es);
 
 	m_prescaleFactorsAlgoTrig = &(m_l1GtPrescalesVetoes->prescaleTable());
+	m_numberOfPreScaleColumns = m_prescaleFactorsAlgoTrig->size();
 	m_numberPhysTriggers = (*m_prescaleFactorsAlgoTrig)[0].size(); // assumes all prescale columns are the same length
 
 	m_triggerMaskAlgoTrig   = &(m_l1GtPrescalesVetoes->triggerAlgoBxMask());
@@ -145,7 +149,7 @@ void l1t::L1TGlobalUtil::retrieveL1Setup(const edm::EventSetup& evSetup) {
     }
 
     //Protect against poor prescale column choice (I don't think there is a way this happen as currently structured)
-    if(m_PreScaleColumn > m_prescaleFactorsAlgoTrig->size() || m_PreScaleColumn < 1) {
+    if(m_PreScaleColumn > m_prescaleFactorsAlgoTrig->size()) {
       LogTrace("l1t|Global")
 	<< "\nNo Prescale Set: " << m_PreScaleColumn
 	<< "\nMax Prescale Set value : " << m_prescaleFactorsAlgoTrig->size()

--- a/L1Trigger/L1TGlobal/src/L1TGlobalUtil.cc
+++ b/L1Trigger/L1TGlobal/src/L1TGlobalUtil.cc
@@ -41,8 +41,8 @@ l1t::L1TGlobalUtil::L1TGlobalUtil(){
     m_PreScaleColumn = 0;
     m_readPrescalesFromFile = false;
 
-    m_prescaleFactorsAlgoTrig = 0ULL;
-    m_triggerMaskAlgoTrig = 0ULL;
+    m_prescaleFactorsAlgoTrig = nullptr;
+    m_triggerMaskAlgoTrig = nullptr;
 }
 
 l1t::L1TGlobalUtil::L1TGlobalUtil(edm::ParameterSet const& pset,
@@ -190,7 +190,7 @@ void l1t::L1TGlobalUtil::retrieveL1Setup(const edm::EventSetup& evSetup) {
 	  it++;
 	}
 
-      if (maskedBxs.size()>0){
+      if (!maskedBxs.empty()){
 	LogDebug("l1t|Global") << "i Algo: "<< algBit << "\t" << algName << " masked\n";
 	for ( unsigned int ibx=0; ibx< maskedBxs.size(); ibx++){
 	  // std::cout << "\t" << maskedBxs.at(ibx);
@@ -269,7 +269,7 @@ void l1t::L1TGlobalUtil::retrieveL1Event(const edm::Event& iEvent, const edm::Ev
 	       it++;
 	     }
 
-	   if (maskedBxs.size()>0){
+	   if (!maskedBxs.empty()){
 	     LogDebug("l1t|Global") << "Algo: "<< algBit << "\t" << algName << " masked\n";
 	     for ( unsigned int ibx=0; ibx< maskedBxs.size(); ibx++){
 	       // std::cout << "\t" << maskedBxs.at(ibx);
@@ -333,7 +333,7 @@ void l1t::L1TGlobalUtil::loadPrescalesAndMasks() {
 
       int NumPrescaleSets = 0;
       for( int iCol=0; iCol<int(vec.size()); iCol++ ){
-	if( vec[iCol].size() > 0 ){
+	if( !vec[iCol].empty() ){
 	  int firstRow = vec[iCol][0];
 
 	  if( firstRow >= 0 ) NumPrescaleSets++;
@@ -360,7 +360,7 @@ void l1t::L1TGlobalUtil::loadPrescalesAndMasks() {
 	  if( algoBit < m_numberPhysTriggers ){
 	    for( int iSet=0; iSet<int(vec.size()); iSet++ ){
 	      int useSet = -1;
-	      if( vec[iSet].size() > 0 ){
+	      if( !vec[iSet].empty() ){
 		useSet = vec[iSet][0];
 	      }
 	      useSet -= 1;


### PR DESCRIPTION
Fix to prevent possible crashes in the L1TGlobalUtil code in CMSSW jobs where the prescale table is updated during the job. In the previous version this could sometimes cause an out-of-range exception.