### PR TITLE
[backport 93x] HGCal - bugfix - removing energy of out-of-range hits

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticHitToClusterAssociator.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticHitToClusterAssociator.h
@@ -315,6 +315,7 @@ class RealisticHitToClusterAssociator
                         auto layerId = hit.layerId_;
                         if(XYdistanceFromPointOnSameLayer(hitId, cluster.getCenterOfGravity(layerId)) > maxDistance)
                         {
+                            cluster.increaseEnergy(-hit.totalEnergy_*hAndF[i].second);
                             cluster.modifyFractionByIndex(0.f, i);
                         }
                     }

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRealisticSimClusterHGCCalibrations_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRealisticSimClusterHGCCalibrations_cfi.py
@@ -2,5 +2,5 @@ import FWCore.ParameterSet.Config as cms
 
 minEtaCorrection = cms.double(1.4)
 maxEtaCorrection = cms.double(3.0)
-hadronCorrections = cms.vdouble(1.16, 1.10, 1.08, 1.08, 1.09, 1.11, 1.14, 1.26)  
-egammaCorrections = cms.vdouble(1.00, 1.00, 1.00, 1.00, 1.02, 1.03, 1.03, 1.03)  
+hadronCorrections = cms.vdouble(1.24, 1.24, 1.24, 1.23, 1.24, 1.25, 1.29, 1.29)  
+egammaCorrections = cms.vdouble(1.00, 1.00, 1.01, 1.01, 1.02, 1.03, 1.04, 1.04)  


### PR DESCRIPTION
This PR is a bug fix and should solve the problem in #20458
Hits which are outside the 10cm radius from the center of gravity are removed by setting their fraction to zero, but their energy was never subtracted from the energy of the cluster.
This is a problem as the final energy of the PFCluster is not computed as the sum of the energy of the hits * their fraction, but it gets assigned the energy of the realistic cluster.
Recalibration is also included

backport of #20479
@rovere @kpedro88 