### PR TITLE
add client to razor paths (PR for master/94X)

### DIFF
--- a/DQMOffline/Trigger/python/RazorMonitor_Client_cff.py
+++ b/DQMOffline/Trigger/python/RazorMonitor_Client_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+RazorEfficiency = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/SUSY/*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_Rsq          'Rsq turnON;            Rsq;        efficiency'     Rsq_numerator          Rsq_denominator",
+        "effic_MR           'MR turnON;             MR [GeV];   efficiency'     MR_numerator           MR_denominator",
+        "effic_dPhiR        'dPhiR turnON;          dphiR;      efficiency'     dPhiR_numerator        dPhiR_denominator",
+        "effic_MRVsRsq      'MR efficiency vs Rsq;  MR [GeV];   Rsq'            MRVsRsq_numerator      MRVsRsq_denominator",
+    ),
+)
+
+
+susyHLTRazorClient = cms.Sequence(
+    RazorEfficiency
+)

--- a/DQMOffline/Trigger/python/SusyMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/SusyMonitoring_Client_cff.py
@@ -3,6 +3,7 @@ from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 from DQMOffline.Trigger.VBFSUSYMonitor_Client_cff import *
 from DQMOffline.Trigger.LepHTMonitor_cff import *
 from DQMOffline.Trigger.susyHLTEleCaloJetsClient_cfi import *
+from DQMOffline.Trigger.RazorMonitor_Client_cff import *
 
 #george
 double_soft_muon_muonpt_efficiency = DQMEDHarvester("DQMGenericClient",
@@ -111,4 +112,5 @@ susyClient = cms.Sequence(
   + double_soft_muon_backup_70_mhtpt_efficiency
   + double_soft_muon_backup_90_metpt_efficiency
   + double_soft_muon_backup_90_mhtpt_efficiency
+  + susyHLTRazorClient
 )


### PR DESCRIPTION
Add client to HLT Razor paths.
To make efficiency plots automatically in dqm.
Relevant files:
DQMOffline/Trigger/python/RazorMonitor_Client_cff.py
DQMOffline/Trigger/python/SusyMonitoring_Client_cff.py
same development as PR#20462 for 92X, PR#20506 for 93X