### PR TITLE
correctly update boundary box preventing overwriting in case a hit ha…

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
@@ -18,6 +18,7 @@ void HGCalImagingAlgo::populate(const HGCRecHitCollection& hits){
     computeThreshold();
   }
 
+  std::vector<bool> firstHit(2*(maxlayer+1), true);
   for (unsigned int i=0;i<hits.size();++i) {
 
     const HGCRecHit& hgrh = hits[i];
@@ -48,9 +49,10 @@ void HGCalImagingAlgo::populate(const HGCRecHitCollection& hits){
     points[layer].emplace_back(Hexel(hgrh,detid,isHalf,sigmaNoise,thickness,&rhtools_),position.x(),position.y());
 
     // for each layer, store the minimum and maximum x and y coordinates for the KDTreeBox boundaries
-    if(minpos[layer][0] == 0.0f){
+    if(firstHit[layer]){
       minpos[layer][0] = position.x(); minpos[layer][1] = position.y();
       maxpos[layer][0] = position.x(); maxpos[layer][1] = position.y();
+      firstHit[layer] = false;
     }else{
       minpos[layer][0] = std::min((float)position.x(),minpos[layer][0]);
       minpos[layer][1] = std::min((float)position.y(),minpos[layer][1]);

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
@@ -242,7 +242,7 @@ double HGCalImagingAlgo::calculateDistanceToHigher(std::vector<KDNode> &nd){
   int nearestHigher = -1;
 
 
-  if(rs.size()>0)
+  if(!rs.empty())
     maxdensity = nd[rs[0]].data.rho;
   else
     return maxdensity; // there are no hits


### PR DESCRIPTION
…s x value = 0

This fixes a bug in the HGCal layer clustering: the "box" that was built from the hits that pass the energy thresholds was erroneously reset in case a hit had an x-value of 0. This limited the area used for the clustering, losing whole layer clusters for no reason. It's fixed now using a boolean for each layer. The consequence is that some multiclusters will have more energy than before (and a couple more layer clusters will be built).