### PR TITLE
Adding new paths to the monitoring - Backport of #20536

### DIFF
--- a/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cff.py
+++ b/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cff.py
@@ -124,7 +124,12 @@ refPathsList19 =  cms.vstring(
     "HLT_Mu20_Mu10_DZ_v",
     "HLT_Mu20_Mu10_SameSign_DZ_v",
     "HLT_Mu20_Mu10_SameSign_v",
-    "HLT_Mu20_Mu10_v")
+    "HLT_Mu20_Mu10_v",
+    "HLT_Mu23_Mu12_DZ_v",
+    "HLT_Mu23_Mu12_SameSign_DZ_v",
+    "HLT_Mu23_Mu12_SameSign_v",
+    "HLT_Mu23_Mu12_v"
+    )
 
 globalAnalyzerRef19 = hltMuonOfflineAnalyzer.clone()
 globalAnalyzerRef19.destination = "HLT/Muon/DistributionsGlobal"

--- a/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cff.py
+++ b/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cff.py
@@ -67,16 +67,23 @@ looseAnalyzerTnP.targetParams = looseMuonParams
 #tightAnalyzer.probeParams = cms.PSet() 
 
 
-globalAnalyzerRef = hltMuonOfflineAnalyzer.clone()
-globalAnalyzerRef.destination = "HLT/Muon/DistributionsGlobal"
-globalAnalyzerRef.targetParams = globalMuonParams
-globalAnalyzerRef.hltPathsToCheck = cms.vstring(
+refPathsList = cms.vstring(
     "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v",
     "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v",
     "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v",
     "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v",
     "HLT_TkMu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v",
-    "HLT_TkMu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v")
+    "HLT_TkMu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v"
+    "HLT_Mu18_Mu9_DZ_v",
+    "HLT_Mu18_Mu9_v",
+    "HLT_Mu18_Mu9_SameSign_DZ_v",
+    "HLT_Mu18_Mu9_SameSign_v"
+    )
+
+globalAnalyzerRef = hltMuonOfflineAnalyzer.clone()
+globalAnalyzerRef.destination = "HLT/Muon/DistributionsGlobal"
+globalAnalyzerRef.targetParams = globalMuonParams
+globalAnalyzerRef.hltPathsToCheck = refPathsList
 globalAnalyzerRef.requiredTriggers = cms.untracked.vstring(
     "HLT_Mu17_TrkIsoVVL_v")
 
@@ -85,13 +92,7 @@ globalAnalyzerRef.requiredTriggers = cms.untracked.vstring(
 trackerAnalyzerRef = hltMuonOfflineAnalyzer.clone()
 trackerAnalyzerRef.destination = "HLT/Muon/DistributionsTracker"
 trackerAnalyzerRef.targetParams = trackerMuonParams
-trackerAnalyzerRef.hltPathsToCheck = cms.vstring(
-    "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v",
-    "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v",
-    "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v",
-    "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v",
-    "HLT_TkMu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v",
-    "HLT_TkMu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v")
+trackerAnalyzerRef.hltPathsToCheck = refPathsList
 trackerAnalyzerRef.requiredTriggers = cms.untracked.vstring(
     "HLT_Mu17_TrkIsoVVL_v")
 #trackerAnalyzerRef.probeParams = cms.PSet()
@@ -99,13 +100,8 @@ trackerAnalyzerRef.requiredTriggers = cms.untracked.vstring(
 tightAnalyzerRef = hltMuonOfflineAnalyzer.clone()
 tightAnalyzerRef.destination = "HLT/Muon/DistributionsTight"
 tightAnalyzerRef.targetParams = tightMuonParams
-tightAnalyzerRef.hltPathsToCheck = cms.vstring(
-    "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v",
-    "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v",
-    "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v",
-    "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v",
-    "HLT_TkMu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v",
-    "HLT_TkMu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v")
+tightAnalyzerRef.hltPathsToCheck = refPathsList
+
 tightAnalyzerRef.requiredTriggers = cms.untracked.vstring(
     "HLT_Mu17_TrkIsoVVL_v")
 #tightAnalyzerRef.probeParams = cms.PSet() 
@@ -113,15 +109,54 @@ tightAnalyzerRef.requiredTriggers = cms.untracked.vstring(
 looseAnalyzerRef = hltMuonOfflineAnalyzer.clone()
 looseAnalyzerRef.destination = "HLT/Muon/DistributionsLoose"
 looseAnalyzerRef.targetParams = looseMuonParams
-looseAnalyzerRef.hltPathsToCheck = cms.vstring(
-    "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v",
-    "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v",
-    "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v",
-    "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v",
-    "HLT_TkMu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v",
-    "HLT_TkMu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v")
+looseAnalyzerRef.hltPathsToCheck = refPathsList
 looseAnalyzerRef.requiredTriggers = cms.untracked.vstring(
     "HLT_Mu17_TrkIsoVVL_v")
+#tightAnalyzer.probeParams = cms.PSet() 
+
+
+
+refPathsList19 =  cms.vstring(
+    "HLT_Mu19_TrkIsoVVL_Mu9_TrkIsoVVL_DZ_Mass3p8_v", 
+    "HLT_Mu19_TrkIsoVVL_Mu9_TrkIsoVVL_DZ_Mass8_v"  ,
+    "HLT_Mu19_TrkIsoVVL_Mu9_TrkIsoVVL_DZ_v"        ,
+    "HLT_Mu19_TrkIsoVVL_Mu9_TrkIsoVVL_v",
+    "HLT_Mu20_Mu10_DZ_v",
+    "HLT_Mu20_Mu10_SameSign_DZ_v",
+    "HLT_Mu20_Mu10_SameSign_v",
+    "HLT_Mu20_Mu10_v")
+
+globalAnalyzerRef19 = hltMuonOfflineAnalyzer.clone()
+globalAnalyzerRef19.destination = "HLT/Muon/DistributionsGlobal"
+globalAnalyzerRef19.targetParams = globalMuonParams
+globalAnalyzerRef19.hltPathsToCheck = refPathsList19
+globalAnalyzerRef19.requiredTriggers = cms.untracked.vstring(
+    "HLT_Mu19_TrkIsoVVL_v")
+
+#globalAnalyzerRef19.probeParams = cms.PSet()
+
+trackerAnalyzerRef19 = hltMuonOfflineAnalyzer.clone()
+trackerAnalyzerRef19.destination = "HLT/Muon/DistributionsTracker"
+trackerAnalyzerRef19.targetParams = trackerMuonParams
+trackerAnalyzerRef19.hltPathsToCheck = refPathsList19
+trackerAnalyzerRef19.requiredTriggers = cms.untracked.vstring(
+    "HLT_Mu19_TrkIsoVVL_v")
+#trackerAnalyzerRef19.probeParams = cms.PSet()
+
+tightAnalyzerRef19 = hltMuonOfflineAnalyzer.clone()
+tightAnalyzerRef19.destination = "HLT/Muon/DistributionsTight"
+tightAnalyzerRef19.targetParams = tightMuonParams
+tightAnalyzerRef19.hltPathsToCheck = refPathsList19
+tightAnalyzerRef19.requiredTriggers = cms.untracked.vstring(
+    "HLT_Mu19_TrkIsoVVL_v")
+#tightAnalyzerRef19.probeParams = cms.PSet() 
+
+looseAnalyzerRef19 = hltMuonOfflineAnalyzer.clone()
+looseAnalyzerRef19.destination = "HLT/Muon/DistributionsLoose"
+looseAnalyzerRef19.targetParams = looseMuonParams
+looseAnalyzerRef19.hltPathsToCheck = refPathsList19
+looseAnalyzerRef19.requiredTriggers = cms.untracked.vstring(
+    "HLT_Mu19_TrkIsoVVL_v")
 #tightAnalyzer.probeParams = cms.PSet() 
 
 
@@ -135,7 +170,11 @@ hltMuonOfflineAnalyzers = cms.Sequence(
     globalAnalyzerRef  *
     trackerAnalyzerRef *
     tightAnalyzerRef   *
-    looseAnalyzerRef
+    looseAnalyzerRef   *
+    globalAnalyzerRef19  *
+    trackerAnalyzerRef19 *
+    tightAnalyzerRef19   *
+    looseAnalyzerRef19
 )
 
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016

--- a/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cfi.py
+++ b/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cfi.py
@@ -39,6 +39,14 @@ hltMuonOfflineAnalyzer = cms.EDAnalyzer("HLTMuonOfflineAnalyzer",
       "HLT_IsoTkMu22_eta2p1_v",
       "HLT_IsoMu18_v",
       "HLT_IsoTkMu18_v",
+      "HLT_IsoMu30_v",
+      "HLT_Mu55_v",
+      "HLT_Mu19_TrkIsoVVL_v",
+      "HLT_Mu19_v",
+      "HLT_L2Mu50_v",
+      "HLT_OldMu100_v",
+      "HLT_TkMu100_v",
+      "HLT_DoubleL2Mu50_v",
       "HLT_PAL1DoubleMuOpen_v", #for HI
       "HLT_PAL1DoubleMuOpen_OS_v", #for HI
       "HLT_PAL1DoubleMuOpen_SS_v", #for HI

--- a/DQMOffline/Trigger/python/MuonPostProcessor_cff.py
+++ b/DQMOffline/Trigger/python/MuonPostProcessor_cff.py
@@ -22,7 +22,10 @@ hltMuonEfficiencies = DQMEDHarvester("DQMGenericClient",
         "Refefficiency_TurnOn_Mu2 'Reference efficiency; Pt; N(pass) / N' Refefficiency_TurnOn_Mu2_numer Refefficiency_TurnOn_Mu2_denom",
         "Refefficiency_DZ_Mu 'Reference efficiency; d_{z}; N(pass) / N' Refefficiency_DZ_Mu_numer Refefficiency_DZ_Mu_denom",
         "Refefficiency_DZ_Vertex 'Reference efficiency; d_{z}; N(pass) / N' Refefficiency_DZ_Vertex_numer Refefficiency_DZ_Vertex_denom",
-
+        "Ref_SS_pt1 'Same sign efficiency'; p_{T}; N(pass) / N' Ref_SS_pt1_numer Ref_SS_pt1_denom",
+        "Ref_SS_pt2 'Same sign efficiency'; p_{T}; N(pass) / N' Ref_SS_pt2_numer Ref_SS_pt2_denom",
+        "Ref_SS_eta1 'Same sign efficiency'; p_{T}; N(pass) / N' Ref_SS_eta1_numer Ref_SS_eta1_denom",
+        "Ref_SS_eta2 'Same sign efficiency'; p_{T}; N(pass) / N' Ref_SS_eta2_numer Ref_SS_eta2_denom",
         ),
                                      
 

--- a/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
+++ b/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
@@ -172,7 +172,7 @@ void HLTMuonMatchAndPlot::beginRun(DQMStore::IBooker & iBooker,
     book1D(iBooker, "massVsDZZ_" + suffix,  "z0", ";z0;");
 
     
-    if (requiredTriggers_.size() > 0){
+    if (!requiredTriggers_.empty()){
       book1D(iBooker, "Refefficiency_Eta_Mu1_" + suffix, "etaCoarse", ";#eta;");
       book1D(iBooker, "Refefficiency_Eta_Mu2_" + suffix, "etaCoarse", ";#eta;");
       book1D(iBooker, "Refefficiency_TurnOn_Mu1_" + suffix, "ptCoarse", ";p_{T};");
@@ -192,7 +192,7 @@ void HLTMuonMatchAndPlot::beginRun(DQMStore::IBooker & iBooker,
     // string MRbaseDir = boost::replace_all_copy<string>(baseDir, "HLT/Muon","HLT/Muon/MR");
     iBooker.setCurrentFolder(MRbaseDir + pathSansSuffix + "/");
 
-    if (requiredTriggers_.size() > 0){
+    if (!requiredTriggers_.empty()){
       book1D(iBooker, "MR_Refefficiency_TurnOn_Mu1_" + suffix, "pt", ";p_{T};");
       book1D(iBooker, "MR_Refefficiency_TurnOn_Mu2_" + suffix, "pt", ";p_{T};");
       book1D(iBooker, "MR_Refefficiency_Vertex_" + suffix, "NVertexFine", ";NVertex;");
@@ -427,7 +427,7 @@ void HLTMuonMatchAndPlot::analyze(Handle<MuonCollection>   & allMuons,
   if (!isLastFilter_) return;
   unsigned int numTriggers = trigNames.size();
   bool passTrigger = false;
-  if (requiredTriggers_.size() == 0) passTrigger = true;
+  if (requiredTriggers_.empty()) passTrigger = true;
   for (auto const & requiredTrigger : requiredTriggers_) {
     for ( unsigned int hltIndex = 0; hltIndex < numTriggers; ++hltIndex){
       passTrigger = (trigNames.triggerName(hltIndex).find(requiredTrigger) != std::string::npos && triggerResults->wasrun(hltIndex) && triggerResults->accept(hltIndex));
@@ -439,7 +439,7 @@ void HLTMuonMatchAndPlot::analyze(Handle<MuonCollection>   & allMuons,
   for (unsigned long matche : matches){
     if (matche < targetMuons.size()) nMatched++;
   }
-  if (requiredTriggers_.size() > 0 && targetMuons.size() > 1 && passTrigger){
+  if (!requiredTriggers_.empty() && targetMuons.size() > 1 && passTrigger){
     // denominator: 
     hists_["Refefficiency_Eta_Mu1_denom"]->Fill( targetMuons.at(0).eta());					
     hists_["Refefficiency_Eta_Mu2_denom"]->Fill( targetMuons.at(1).eta());

--- a/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
+++ b/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
@@ -183,6 +183,10 @@ void HLTMuonMatchAndPlot::beginRun(DQMStore::IBooker & iBooker,
       book2D(iBooker, "Refefficiency_Eta_"+suffix, "etaCoarse", "etaCoarse", ";#eta;#eta");
       book2D(iBooker, "Refefficiency_Pt_"+suffix, "ptCoarse", "ptCoarse", ";p_{T};p_{T}");
       book1D(iBooker, "Refefficiency_DZ_Vertex_" + suffix, "NVertex", ";NVertex;");
+      book1D(iBooker, "Ref_SS_pt1_" + suffix, "ptCoarse", ";p_{T}");
+      book1D(iBooker, "Ref_SS_pt2_" + suffix, "ptCoarse", ";p_{T}");
+      book1D(iBooker, "Ref_SS_eta1_" + suffix, "etaCoarse", ";#eta;");
+      book1D(iBooker, "Ref_SS_eta2_" + suffix, "etaCoarse", ";#eta;");
       // book1D(iBooker, "Refefficiency_DZ_Mu2_" + suffix,  "z0", ";z0;");
     }
     // string MRbaseDir = boost::replace_all_copy<string>(baseDir, "HLT/Muon","HLT/Muon/MR");
@@ -359,13 +363,15 @@ void HLTMuonMatchAndPlot::analyze(Handle<MuonCollection>   & allMuons,
 
         if(mass > 60 && mass < 120) {
           if(muon.pt() < targetptCutZ_) continue;
-          hists_["massVsEtaZ_denom"]->Fill(theProbe.eta());
-          hists_["MR_massVsEtaZ_denom"]->Fill(theProbe.eta());
-          hists_["MR_massVsPhiZ_denom"]->Fill(theProbe.phi());
-          hists_["massVsPtZ_denom"]->Fill(theProbe.pt());
-	  hists_["MR_massVsPtZ_denom"]->Fill(theProbe.pt());
-          hists_["massVsVertexZ_denom"]->Fill(vertices->size());
-	  hists_["MR_massVsVertexZ_denom"]->Fill(vertices->size());
+	  hists_["massVsPtZ_denom"]->Fill(theProbe.pt());
+	  hists_["massVsEtaZ_denom"]->Fill(theProbe.eta());
+          if (theProbe.pt() > cutMinPt_){
+	    hists_["MR_massVsEtaZ_denom"]->Fill(theProbe.eta());
+	    hists_["MR_massVsPhiZ_denom"]->Fill(theProbe.phi());
+	    hists_["MR_massVsPtZ_denom"]->Fill(theProbe.pt());
+	    hists_["massVsVertexZ_denom"]->Fill(vertices->size());
+	    hists_["MR_massVsVertexZ_denom"]->Fill(vertices->size());
+	  }
 	  const Track * track = nullptr;
 	  if (theProbe.isTrackerMuon()) track = & * theProbe.innerTrack();
 	  else if (theProbe.isStandAloneMuon()) track = & * theProbe.outerTrack();
@@ -375,18 +381,20 @@ void HLTMuonMatchAndPlot::analyze(Handle<MuonCollection>   & allMuons,
 	  }
 	  hists_["efficiencyDeltaR_denom" ]->Fill(deltaR(theProbe, muon));
           if(matches[k] < targetMuons.size()) {
-            hists_["massVsEtaZ_numer"]->Fill(theProbe.eta());
-            hists_["MR_massVsEtaZ_numer"]->Fill(theProbe.eta());
-            hists_["MR_massVsPhiZ_numer"]->Fill(theProbe.phi());
             hists_["massVsPtZ_numer"]->Fill(theProbe.pt());
 	    hists_["MR_massVsPtZ_numer"]->Fill(theProbe.pt());
-            hists_["massVsVertexZ_numer"]->Fill(vertices->size());
-	    hists_["MR_massVsVertexZ_numer"]->Fill(vertices->size());
-	    hists_["efficiencyDeltaR_numer" ]->Fill(deltaR(theProbe, muon));
+	    if (theProbe.pt() > cutMinPt_){
+	      hists_["MR_massVsPhiZ_numer"]->Fill(theProbe.phi());
+	      hists_["massVsEtaZ_numer"]->Fill(theProbe.eta());
+	      hists_["MR_massVsEtaZ_numer"]->Fill(theProbe.eta());
+	      hists_["massVsVertexZ_numer"]->Fill(vertices->size());
+	      hists_["MR_massVsVertexZ_numer"]->Fill(vertices->size());
+	    }
 	    if (track){
 	      hists_["massVsDZZ_numer"]->Fill(track->dz(beamSpot->position()));
 	      hists_["MR_massVsDZZ_numer"]->Fill(track->dz(beamSpot->position()));
 	    }
+	    hists_["efficiencyDeltaR_numer" ]->Fill(deltaR(theProbe, muon));
           }  
           pairalreadyconsidered = true;
         }
@@ -481,6 +489,35 @@ void HLTMuonMatchAndPlot::analyze(Handle<MuonCollection>   & allMuons,
       // 	hists_["MR_Refefficiency_DZ_Mu2_numer"]->Fill(track1->dz(beamSpot->position()));
       // }
     
+    }
+  }
+
+  string nonSameSignPath = hltPath_;
+  bool ssPath=false;
+  if ( nonSameSignPath.rfind("_SameSign") < nonSameSignPath.length()){
+    ssPath = true;
+    nonSameSignPath = boost::replace_all_copy<string>(nonSameSignPath, "_SameSign","");
+    nonSameSignPath = nonSameSignPath.substr(0, nonSameSignPath.rfind("_v")+2);
+  }
+  bool passTriggerSS = false;
+  if (ssPath){
+    for ( unsigned int hltIndex = 0; hltIndex < numTriggers; ++hltIndex){
+      passTriggerSS = passTriggerSS ||  (trigNames.triggerName(hltIndex).find(nonSameSignPath) != std::string::npos && triggerResults->wasrun(hltIndex) && triggerResults->accept(hltIndex));
+    }
+
+    if (ssPath && targetMuons.size() > 1 && passTriggerSS){
+      if (targetMuons.at(0).charge() * targetMuons.at(1).charge() > 0){
+	hists_["Ref_SS_pt1_denom"]->Fill( targetMuons.at(0).pt() );
+	hists_["Ref_SS_pt2_denom"]->Fill( targetMuons.at(1).pt() );
+	hists_["Ref_SS_eta1_denom"]->Fill( targetMuons.at(0).eta() );
+	hists_["Ref_SS_eta2_denom"]->Fill( targetMuons.at(1).eta() );
+	if (nMatched > 1){
+	  hists_["Ref_SS_pt1_numer"]->Fill( targetMuons.at(0).pt() );
+	  hists_["Ref_SS_pt2_numer"]->Fill( targetMuons.at(1).pt() );
+	  hists_["Ref_SS_eta1_numer"]->Fill( targetMuons.at(0).eta() );
+	  hists_["Ref_SS_eta2_numer"]->Fill( targetMuons.at(1).eta() );
+	}
+      }
     }
   }
 

--- a/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
+++ b/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
@@ -506,16 +506,16 @@ void HLTMuonMatchAndPlot::analyze(Handle<MuonCollection>   & allMuons,
     }
 
     if (ssPath && targetMuons.size() > 1 && passTriggerSS){
-      if (targetMuons.at(0).charge() * targetMuons.at(1).charge() > 0){
-	hists_["Ref_SS_pt1_denom"]->Fill( targetMuons.at(0).pt() );
-	hists_["Ref_SS_pt2_denom"]->Fill( targetMuons.at(1).pt() );
-	hists_["Ref_SS_eta1_denom"]->Fill( targetMuons.at(0).eta() );
-	hists_["Ref_SS_eta2_denom"]->Fill( targetMuons.at(1).eta() );
+      if (targetMuons[0].charge() * targetMuons[1].charge() > 0){
+	hists_["Ref_SS_pt1_denom"]->Fill( targetMuons[0].pt() );
+	hists_["Ref_SS_pt2_denom"]->Fill( targetMuons[1].pt() );
+	hists_["Ref_SS_eta1_denom"]->Fill( targetMuons[0].eta() );
+	hists_["Ref_SS_eta2_denom"]->Fill( targetMuons[1].eta() );
 	if (nMatched > 1){
-	  hists_["Ref_SS_pt1_numer"]->Fill( targetMuons.at(0).pt() );
-	  hists_["Ref_SS_pt2_numer"]->Fill( targetMuons.at(1).pt() );
-	  hists_["Ref_SS_eta1_numer"]->Fill( targetMuons.at(0).eta() );
-	  hists_["Ref_SS_eta2_numer"]->Fill( targetMuons.at(1).eta() );
+	  hists_["Ref_SS_pt1_numer"]->Fill( targetMuons[0].pt() );
+	  hists_["Ref_SS_pt2_numer"]->Fill( targetMuons[1].pt() );
+	  hists_["Ref_SS_eta1_numer"]->Fill( targetMuons[0].eta() );
+	  hists_["Ref_SS_eta2_numer"]->Fill( targetMuons[1].eta() );
 	}
       }
     }


### PR DESCRIPTION
Monitoring for Muon POG paths. 
+ Output of the modules: /afs/cern.ch/work/s/sesanche/public/DQM/sep14/DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root

+ This PR will add 178540 bins
