### PR TITLE
add offlineHLTSourceOnAODextra sequence

### DIFF
--- a/DQMOffline/Trigger/python/B2GMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/B2GMonitoring_cff.py
@@ -74,3 +74,6 @@ b2gMonitorHLT = cms.Sequence(
     B2GegmGsfElectronIDsForDQM*
     B2GegHLTDQMOfflineTnPSource
 )
+
+b2gHLTDQMSourceExtra = cms.Sequence(
+)

--- a/DQMOffline/Trigger/python/BPHMonitor_cff.py
+++ b/DQMOffline/Trigger/python/BPHMonitor_cff.py
@@ -38,3 +38,6 @@ bphMonitorHLT = cms.Sequence(
     tau3MuMonitorHLT    
 )
 
+bphHLTDQMSourceExtra = cms.Sequence(
+)
+

--- a/DQMOffline/Trigger/python/BTVHLTOfflineSource_cff.py
+++ b/DQMOffline/Trigger/python/BTVHLTOfflineSource_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.BTVHLTOfflineSource_cfi import *
+
+btvHLTDQMSourceExtra = cms.Sequence(
+)

--- a/DQMOffline/Trigger/python/BTVHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/BTVHLTOfflineSource_cfi.py
@@ -29,3 +29,6 @@ BTVHLTOfflineSource = cms.EDAnalyzer(
         )    
     )
 )
+
+btvHLTDQMSourceExtra = cms.Sequence(
+)

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
@@ -20,9 +20,9 @@ from DQMOffline.Trigger.HLTTauDQMOffline_cff import *
 from DQMOffline.Trigger.JetMETHLTOfflineAnalyzer_cff import *
 
 # BTV
-from DQMOffline.Trigger.BTVHLTOfflineSource_cfi import *
+from DQMOffline.Trigger.BTVHLTOfflineSource_cff import *
 
-from DQMOffline.Trigger.FSQHLTOfflineSource_cfi import *
+from DQMOffline.Trigger.FSQHLTOfflineSource_cff import *
 from DQMOffline.Trigger.HILowLumiHLTOfflineSource_cfi import *
 
 # TnP
@@ -113,12 +113,46 @@ offlineHLTSourceOnAOD = cms.Sequence(
 )
 
 # offline DQM for running in the standard RECO,DQM (in PromptReco, ReReco, relval, etc)
+## THIS IS THE SEQUENCE TO BE RUN AT TIER0
 ## ADD here only sequences/modules which rely on transient collections produced by the RECO step
 ## and not stored in the AOD format
 offlineHLTSource = cms.Sequence(
     offlineHLTSourceOnAOD
     + hcalMonitoringSequence
     + jetMETHLTOfflineAnalyzer
+)
+
+# offline DQM to be run on AOD (w/o the need of the RECO step on-the-fly) only in the VALIDATION of the HLT menu based on data
+# it is needed in order to have the DQM code in the release, w/o the issue of crashing the tier0
+# asa the new modules in the sequence offlineHLTSourceOnAODextra are tested,
+# these have to be migrated in the main offlineHLTSourceOnAOD sequence
+offlineHLTSourceOnAODextra = cms.Sequence(
+### POG
+    btvHLTDQMSourceExtra
+    * egmHLTDQMSourceExtra
+    * jmeHLTDQMSourceExtra
+    * muoHLTDQMSourceExtra
+    * tauHLTDQMSourceExtra
+    * trkHLTDQMSourceExtra
+### PAG
+    * b2gHLTDQMSourceExtra
+    * bphHLTDQMSourceExtra
+    * exoHLTDQMSourceExtra
+    * higHLTDQMSourceExtra
+    * smpHLTDQMSourceExtra
+    * susHLTDQMSourceExtra
+    * topHLTDQMSourceExtra
+    * fsqHLTDQMSourceExtra
+    * hinHLTDQMSourceExtra
+)
+
+# offline DQM to be run on AOD (w/o the need of the RECO step on-the-fly) in the VALIDATION of the HLT menu based on data
+# it is needed in order to have the DQM code in the release, w/o the issue of crashing the tier0
+# asa the new modules in the sequence offlineHLTSourceOnAODextra are tested
+# these have to be migrated in the main offlineHLTSourceOnAOD sequence
+offlineValidationHLTSource = cms.Sequence(
+    offlineHLTSourceOnAOD 
+    + offlineHLTSourceOnAODextra
 )
 
 # offline DQM for the HLTMonitoring stream

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
@@ -143,7 +143,7 @@ offlineHLTSourceOnAODextra = cms.Sequence(
     * susHLTDQMSourceExtra
     * topHLTDQMSourceExtra
     * fsqHLTDQMSourceExtra
-    * hinHLTDQMSourceExtra
+#    * hinHLTDQMSourceExtra
 )
 
 # offline DQM to be run on AOD (w/o the need of the RECO step on-the-fly) in the VALIDATION of the HLT menu based on data

--- a/DQMOffline/Trigger/python/EgammaMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/EgammaMonitoring_cff.py
@@ -13,3 +13,6 @@ egammaMonitorHLT = cms.Sequence(
     egHLTMuonPhoDQMOfflineTnPSource
     
 )
+
+egmHLTDQMSourceExtra = cms.Sequence(
+)

--- a/DQMOffline/Trigger/python/ExoticaMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/ExoticaMonitoring_cff.py
@@ -17,3 +17,7 @@ exoticaMonitorHLT = cms.Sequence(
   + exoHLTMuonmonitoring
   + exoHLTDisplacedJetmonitoring
 )
+
+
+exoHLTDQMSourceExtra = cms.Sequence(
+)

--- a/DQMOffline/Trigger/python/FSQHLTOfflineSource_cff.py
+++ b/DQMOffline/Trigger/python/FSQHLTOfflineSource_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.FSQHLTOfflineSource_cfi import *
+
+from JetMETCorrections.Configuration.CorrectedJetProducers_cff import *
+fsqHLTOfflineSourceSequence = cms.Sequence(ak4PFL1FastL2L3CorrectorChain + fsqHLTOfflineSource)
+
+fsqHLTDQMSourceExtra = cms.Sequence(
+)
+

--- a/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
@@ -609,6 +609,3 @@ fsqHLTOfflineSource = cms.EDAnalyzer("FSQDiJetAve",
     #useGenWeight = cms.bool(True),
     todo = cms.VPSet(getFSQAll())
 )
-
-from JetMETCorrections.Configuration.CorrectedJetProducers_cff import *
-fsqHLTOfflineSourceSequence = cms.Sequence(ak4PFL1FastL2L3CorrectorChain + fsqHLTOfflineSource)

--- a/DQMOffline/Trigger/python/HLTTauDQMOffline_cff.py
+++ b/DQMOffline/Trigger/python/HLTTauDQMOffline_cff.py
@@ -16,3 +16,6 @@ HLTTauDQMOfflineHarvesting = cms.Sequence(HLTTauPostSeq)
 HLTTauDQMOfflineQuality = cms.Sequence(hltTauOfflineQualityTests)
 
 HLTTauDQMOfflineCertification = cms.Sequence(hltTauOfflineCertification)
+
+tauHLTDQMSourceExtra = cms.Sequence(
+)

--- a/DQMOffline/Trigger/python/HiggsMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/HiggsMonitoring_cff.py
@@ -300,3 +300,6 @@ higgsMonitorHLT = cms.Sequence(
   + mssmHbbBtagTriggerMonitor 
   + mssmHbbMonitorHLT 
 )
+
+higHLTDQMSourceExtra = cms.Sequence(
+)

--- a/DQMOffline/Trigger/python/JetMETHLTOfflineAnalyzer_cff.py
+++ b/DQMOffline/Trigger/python/JetMETHLTOfflineAnalyzer_cff.py
@@ -12,3 +12,6 @@ jetMETHLTOfflineAnalyzer = cms.Sequence(
     * jetMETHLTOfflineSourceAK4Fwd
     * jetMETHLTOfflineSourceAK8Fwd
 )
+
+jmeHLTDQMSourceExtra = cms.Sequence(
+)

--- a/DQMOffline/Trigger/python/JetMETPromptMonitor_cff.py
+++ b/DQMOffline/Trigger/python/JetMETPromptMonitor_cff.py
@@ -5,3 +5,6 @@ from DQMOffline.Trigger.JetMonitor_cff import *
 jetmetMonitorHLT = cms.Sequence(
     HLTJetmonitoring
 )
+
+jmeHLTDQMSourceExtra = cms.Sequence(
+)

--- a/DQMOffline/Trigger/python/MuonOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/MuonOffline_Trigger_cff.py
@@ -5,3 +5,6 @@ from DQMOffline.Trigger.HLTMuonOfflineAnalyzer_cff import *
 muonFullOfflineDQM = cms.Sequence(
     hltMuonOfflineAnalyzers
 )
+
+muoHLTDQMSourceExtra = cms.Sequence(
+)

--- a/DQMOffline/Trigger/python/StandardModelMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/StandardModelMonitoring_cff.py
@@ -2,3 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 smpMonitorHLT = cms.Sequence(
 )
+
+smpHLTDQMSourceExtra = cms.Sequence(
+)

--- a/DQMOffline/Trigger/python/SusyMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SusyMonitoring_cff.py
@@ -184,3 +184,6 @@ susyMonitorHLT = cms.Sequence(
   + double_soft_muon_backup_90_mhtpt
   + susyMuEGMonitoring 
 )
+
+susHLTDQMSourceExtra = cms.Sequence(
+)

--- a/DQMOffline/Trigger/python/TopMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TopMonitoring_cff.py
@@ -631,3 +631,6 @@ topMonitorHLT = cms.Sequence(
     + fullyhadronic_DoubleBTag_DeepCSV_jet
     + fullyhadronic_DoubleBTag_DeepCSV_bjet
     )
+
+topHLTDQMSourceExtra = cms.Sequence(
+)

--- a/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
@@ -164,3 +164,7 @@ egmTrackingMonitorHLT = cms.Sequence(
 #    + iter2HPForElectronsTracksMonitoringHLT
     + iterHLTTracksForElectronsMonitoringHLT
 )
+
+
+trkHLTDQMSourceExtra = cms.Sequence(
+)


### PR DESCRIPTION
as discussed at the XC meeting
it would be probably safer to have a dedicated `cms.Sequence` for testing new DQM code for HLT
which is meant to be used in the HLT validation workflow, but not necessarily at Tier0

new DQM code should be integrated in the offlineHLTSourceOnAODextra sequence
and then it could be ported in the standard offlineHLTSourceOnAOD one (which is run at Tier0)

@fwyzard @gennai @davidlange6 @franzoni 