### PR TITLE
fix clusterizer to handle negative charge

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -274,7 +274,6 @@ void PixelThresholdClusterizer::copy_to_buffer( DigiIterator begin, DigiIterator
     if (adc!=adcOld) std::cout << "VI " << eqD  <<' '<< ic  <<' '<< end-begin <<' '<< i <<' '<< di->adc() <<' ' << adc <<' '<< adcOld << std::endl; else ++eqD;
 #endif
 
-    //if(adc<0) cout<<" negative amplitude "<<adc<<" "<<row<<" "<<col<<" "<<calibrate(di->adc(),col,row)<<" "<<detid_<<endl;   
     if(adc<100) adc=100; // put all negative pixel charges into the 100 elec bin 
 
     if ( adc >= thePixelThreshold) {
@@ -331,8 +330,6 @@ int PixelThresholdClusterizer::calibrate(int adc, int col, int row)
 	  float DBgain     = theSiPixelGainCalibrationService_->getGain(detid_, col, row);
 	  float pedestal   = theSiPixelGainCalibrationService_->getPedestal(detid_, col, row);
 	  float DBpedestal = pedestal * DBgain;
-	  //float DBpedestal = theSiPixelGainCalibrationService_->getPedestal(detid_, col, row) * DBgain;
-	  
 	  
 	  // Roc-6 average
 	  //const float gain = 1./0.313; // 1 ADC = 3.19 VCALs 
@@ -358,25 +355,6 @@ int PixelThresholdClusterizer::calibrate(int adc, int col, int row)
 	  } else {
 	    electrons = int( vcal * theConversionFactor + theOffset); 
 	  }
-
-
-	  // if(adc<0 || adc>255) cout<<" adc wrong range "<<adc<<endl;
-
-	  // if(layer_>0) {
-	  //   if( (layer_==1  && (pedestal<-40. || pedestal>170.) ) || 
-	  // 	(layer_==2  && (pedestal<-260.|| pedestal>230.) ) || 
-	  // 	(layer_==3  && (pedestal<-130.|| pedestal>80.) ) || 
-	  // 	(layer_==4  && (pedestal<-90. || pedestal>110.) ) ) 
-
-	  //     cout<<"PED outside range: layer "<<layer_<<" "<<pedestal<<" "<<DBgain<<" "<<DBpedestal
-	  // 	  <<" "<<adc<<" "<<vcal<<" "<<electrons<<" det: "
-	  // 	  <<detid_<<" row: "<<row<<" col: "<<col<<endl;
-
-	  // }
-
-	  if(electrons<0) 
-	    cout<<" layer "<<layer_<<" "<<adc<<" "<<DBgain<<" "<<pedestal<<" "<<DBpedestal<<" "<<vcal
-		<<" - ";
 
 	}
     }

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -19,9 +19,10 @@ siPixelClusters = cms.EDProducer("SiPixelClusterProducer",
     # ****  Offline - gain:col/ped:pix  ****
     # **************************************
     payloadType = cms.string('Offline'),
+    #payloadType = cms.string('Full'),
     SeedThreshold = cms.int32(1000),
-    ClusterThreshold    = cms.int32(4000),
-    ClusterThreshold_L1 = cms.int32(4000),
+    ClusterThreshold    = cms.int32(1000),
+    ClusterThreshold_L1 = cms.int32(1000),
     # **************************************
     maxNumberOfClusters = cms.int32(-1), # -1 means no limit.
 )
@@ -33,8 +34,11 @@ phase1Pixel.toModify(siPixelClusters,
   VCaltoElectronGain_L1   = cms.int32(50),   # L1:   49.6 +- 2.6
   VCaltoElectronOffset    = cms.int32(-60),  # L2-4: -60 +- 130
   VCaltoElectronOffset_L1 = cms.int32(-670), # L1:   -670 +- 220
-  ChannelThreshold        = cms.int32(250),
-  ClusterThreshold_L1     = cms.int32(2000)
+  ChannelThreshold        = cms.int32(10),
+  SeedThreshold           = cms.int32(1000),
+  ClusterThreshold        = cms.int32(1000),
+  ClusterThreshold_L1     = cms.int32(1000)
+
 )
 
 # Need these until phase2 pixel templates are used

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -21,8 +21,8 @@ siPixelClusters = cms.EDProducer("SiPixelClusterProducer",
     payloadType = cms.string('Offline'),
     #payloadType = cms.string('Full'),
     SeedThreshold = cms.int32(1000),
-    ClusterThreshold    = cms.int32(1000),
-    ClusterThreshold_L1 = cms.int32(1000),
+    ClusterThreshold    = cms.int32(4000),
+    ClusterThreshold_L1 = cms.int32(4000),
     # **************************************
     maxNumberOfClusters = cms.int32(-1), # -1 means no limit.
 )
@@ -36,8 +36,8 @@ phase1Pixel.toModify(siPixelClusters,
   VCaltoElectronOffset_L1 = cms.int32(-670), # L1:   -670 +- 220
   ChannelThreshold        = cms.int32(10),
   SeedThreshold           = cms.int32(1000),
-  ClusterThreshold        = cms.int32(1000),
-  ClusterThreshold_L1     = cms.int32(1000)
+  ClusterThreshold        = cms.int32(4000),
+  ClusterThreshold_L1     = cms.int32(2000)
 
 )
 


### PR DESCRIPTION
This is a one line code addition to the pixel clusterizer to take care of very low pixel charges.
It has to be accompanied by  the lowering of all pixel clusterizer thresholds. Especially the pixel 
threshold (called channelThreshold) has to be below 100 in order to recover low charge pixels. 