### PR TITLE
Support hitless seeds in GroupedCkfTrajectory [92X]

### DIFF
--- a/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
@@ -136,7 +136,6 @@ public:
   void moveToResult( TempTrajectory&& traj, TempTrajectoryContainer& result, bool inOut = false) const;    
 
   StateAndLayers findStateAndLayers(const TrajectorySeed& seed, const TempTrajectory& traj) const;
-  StateAndLayers findStateAndLayers(const TempTrajectory& traj) const;
 
  private:
   void seedMeasurements(const TrajectorySeed& seed, TempTrajectory & result) const;

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
@@ -454,7 +454,7 @@ GroupedCkfTrajectoryBuilder::advanceOneLayer (const TrajectorySeed& seed,
 					      TempTrajectoryContainer& newCand, 
 					      TempTrajectoryContainer& result) const
 {
-  std::pair<TSOS,std::vector<const DetLayer*> > && stateAndLayers = findStateAndLayers(traj);
+  std::pair<TSOS,std::vector<const DetLayer*> > && stateAndLayers = findStateAndLayers(seed,traj);
 
 
   if(maxPt2ForLooperReconstruction>0){
@@ -488,7 +488,7 @@ GroupedCkfTrajectoryBuilder::advanceOneLayer (const TrajectorySeed& seed,
     TSOS stateToUse = stateAndLayers.first;
     
     double dPhiCacheForLoopersReconstruction(0);
-    if unlikely((*il)==traj.lastLayer()){
+    if unlikely(!traj.empty() && (*il)==traj.lastLayer()){
 	
 	if(maxPt2ForLooperReconstruction>0){
 	  // ------ For loopers reconstruction

--- a/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
@@ -227,19 +227,6 @@ BaseCkfTrajectoryBuilder::findStateAndLayers(const TrajectorySeed& seed, const T
     }
 }
 
-BaseCkfTrajectoryBuilder::StateAndLayers
-BaseCkfTrajectoryBuilder::findStateAndLayers(const TempTrajectory& traj) const{
-  //assert(!traj.empty());
-  if ( traj.empty() ) {
-    edm::LogWarning("CkfPattern")<< "empty traj. Skipping.";
-    return StateAndLayers();
-  }
-
-  TSOS const & currentState = traj.lastMeasurement().updatedState();
-  return StateAndLayers(currentState,theNavigationSchool->nextLayers(*traj.lastLayer(), *currentState.freeState(), traj.direction()) );
-}
-
-
 void BaseCkfTrajectoryBuilder::setData(const MeasurementTrackerEvent *data) 
 {
     // possibly do some sanity check here


### PR DESCRIPTION
Enable hitless seed compatibility to the GroupedCkfTrajectory so it can be used in the muon HLT reconstruction. Change is transparent to any user of the GroupedCkfTrajectory.

Removed unused function in BaseCkfTrajectoryBuilder. This is a back port of #20556 