### PR TITLE
Fix BuildFiles to avoid SCRAM warnings about missing tools/packages

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/plugins/BuildFile.xml
+++ b/Calibration/LumiAlCaRecoProducers/plugins/BuildFile.xml
@@ -7,9 +7,6 @@
 <use   name="FWCore/PluginManager"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="CondCore/DBOutputService"/>
-
-<use   name="Calibration/LumiAlCaRecoProducers"/>
-
 <library   file="AlcaPCCProducer.cc" name="AlcaPCCProducer">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/HLTrigger/HLTanalyzers/BuildFile.xml
+++ b/HLTrigger/HLTanalyzers/BuildFile.xml
@@ -20,7 +20,6 @@
 <use   name="DataFormats/L1GlobalTrigger"/>
 <use   name="DataFormats/L1Trigger"/>
 <use   name="DataFormats/METReco"/>
-<use   name="DataFormats/MuonData"/>
 <use   name="DataFormats/MuonReco"/>
 <use   name="DataFormats/RPCDigi"/>
 <use   name="DataFormats/RecoCandidate"/>

--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="histogrammar"/>
+<use name="py2-histogrammar"/>
 <use name="py2-matplotlib"/>
 <use name="py2-root_numpy"/>
 <use name="py2-pandas"/>

--- a/RecoCTPPS/PixelLocal/BuildFile.xml
+++ b/RecoCTPPS/PixelLocal/BuildFile.xml
@@ -10,7 +10,6 @@
 <use name="CondFormats/CTPPSReadoutObjects"/>
 
 <use name="DataFormats/CTPPSDetId"/>
-<use name="CondTools/CTPPS"/>
 <use name="CondCore/DBOutputService"/>
 <use name="FWCore/ServiceRegistry"/>
 

--- a/RecoCTPPS/PixelLocal/plugins/BuildFile.xml
+++ b/RecoCTPPS/PixelLocal/plugins/BuildFile.xml
@@ -5,7 +5,6 @@
 <use name="DataFormats/CTPPSDetId"/>
 <use name="DataFormats/CTPPSDigi"/>
 <use name="DataFormats/CTPPSReco"/>
-<use name="CondTools/CTPPS"/>
 
 <use name="CondFormats/CTPPSReadoutObjects"/>
 <use name="CondFormats/DataRecord"/>

--- a/TauAnalysis/MCEmbeddingTools/plugins/BuildFile.xml
+++ b/TauAnalysis/MCEmbeddingTools/plugins/BuildFile.xml
@@ -6,7 +6,6 @@
 <use name="GeneratorInterface/Pythia8Interface"/>
 <use name="GeneratorInterface/ExternalDecays"/>
 <use name="GeneratorInterface/Herwig6Interface"/>
-<use name="IOMC/EventVertexGenerators"/>
 <use name="DataFormats/RPCRecHit"/>
 <use name="DataFormats/CaloRecHit"/>
 <use name="DataFormats/EcalRecHit"/>


### PR DESCRIPTION
This should fix SCRAM warnings about missing tools/packages
```
****WARNING: Invalid tool IOMC/EventVertexGenerators. Please fix src/TauAnalysis/MCEmbeddingTools/plugins/BuildFile.xml file.
****WARNING: Invalid tool Calibration/LumiAlCaRecoProducers. Please fix src/Calibration/LumiAlCaRecoProducers/plugins/BuildFile.xml file.
****WARNING: Invalid tool DataFormats/MuonData. Please fix src/HLTrigger/HLTanalyzers/BuildFile.xml file.
****WARNING: Invalid tool CondTools/CTPPS. Please fix src/RecoCTPPS/PixelLocal/BuildFile.xml file.
****WARNING: Invalid tool CondTools/CTPPS. Please fix src/RecoCTPPS/PixelLocal/plugins/BuildFile.xml file.
****WARNING: Invalid tool histogrammar. Please fix src/PhysicsTools/PythonAnalysis/test/BuildFile.xml file.

```