### PR TITLE
use ClassDefOverride instead of ClassDef to avoid inconsistent-missing-override warning

### DIFF
--- a/SimDataFormats/CaloHit/interface/CastorShowerEvent.h
+++ b/SimDataFormats/CaloHit/interface/CastorShowerEvent.h
@@ -62,7 +62,7 @@
     float getPrimY()             { return primY; };
     float getPrimZ()             { return primZ; };
     
-    ClassDef(CastorShowerEvent,2)
+    ClassDefOverride(CastorShowerEvent,2)
     
   };
 

--- a/SimDataFormats/CaloHit/interface/CastorShowerLibraryInfo.h
+++ b/SimDataFormats/CaloHit/interface/CastorShowerLibraryInfo.h
@@ -31,7 +31,7 @@ class SLBin: public TObject {
              unsigned int        NBins;
              unsigned int        NEvtPerBin;
              std::vector<double> Bins;
-    ClassDef(SLBin,2);
+    ClassDefOverride(SLBin,2);
 };
 
 class CastorShowerLibraryInfo : public TObject {
@@ -48,7 +48,7 @@ class CastorShowerLibraryInfo : public TObject {
     SLBin Eta;
     SLBin Phi;
 
-    ClassDef(CastorShowerLibraryInfo,2);
+    ClassDefOverride(CastorShowerLibraryInfo,2);
     
   };
 


### PR DESCRIPTION
@Ianna, https://github.com/cms-sw/cmssw/pull/20534 caused inconsistent-missing-override warnings
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc630/CMSSW_9_4_X_2017-09-18-1700/SimDataFormats/CaloHit

This PR should fix these