### PR TITLE
Fix edmPickEvents to use dasgoclient properly

### DIFF
--- a/PhysicsTools/Utilities/scripts/edmPickEvents.py
+++ b/PhysicsTools/Utilities/scripts/edmPickEvents.py
@@ -119,9 +119,9 @@ def getFileNames_das_client(event):
 
 def getFileNames_dasgoclient(event):
     """Return files for given DAS query via dasgoclient"""
-    query = "file dataset=%(dataset)s run=%(run)i lumi=%(lumi)i | grep file.name" % event
-    cmd = 'dasgoclient -query="%s" -json'
-    proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    query = "file dataset=%(dataset)s run=%(run)i lumi=%(lumi)i" % event
+    cmd = ['dasgoclient', '-query', query, '-json']
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     files = []
     err = proc.stderr.read()
     if  err:


### PR DESCRIPTION
1. `-json` and using DAS filters does not output valid JSON. Drop the
   filter, the following code is not adapted to it anyways.
2. Don't pass user input through the shell unescaped.