### PR TITLE
MiniAOD: PackedCandidate::setP4 preserve track kinematic

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -395,9 +395,9 @@ namespace pat {
     virtual void setPz( double pz ) {
       maybeUnpackBoth(); // changing px,py,pz changes also mapping between dxy,dz and x,y,z
       *p4c_ = LorentzVector(p4c_.load()->Px(), p4c_.load()->Py(), pz, p4c_.load()->E());
-      dphi_+=polarP4().Phi()-(*p4c_).Phi();
-      deta_+=polarP4().Eta()-(*p4c_).Eta();
-      dtrkpt_+=polarP4().Pt()-(*p4c_).Pt();
+      dphi_+=polarP4().Phi()- p4c_.load()->Phi();
+      deta_+=polarP4().Eta()- p4c_.load()->Eta();
+      dtrkpt_+=polarP4().Pt()- p4c_.load()->Pt();
       *p4_  = PolarLorentzVector(p4c_.load()->Pt(), p4c_.load()->Eta(), p4c_.load()->Phi(), p4c_.load()->M());
       packBoth();
     }

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -371,12 +371,18 @@ namespace pat {
     /// set 4-momentum                                                                    
     virtual void setP4( const LorentzVector & p4 ) { 
         maybeUnpackBoth(); // changing px,py,pz changes also mapping between dxy,dz and x,y,z
+	dphi_+=polarP4().Phi()-p4.Phi();
+	deta_+=polarP4().Eta()-p4.Eta();
+	dtrkpt_+=polarP4().Pt()-p4.Pt();
         *p4_ = PolarLorentzVector(p4.Pt(), p4.Eta(), p4.Phi(), p4.M());
         packBoth();
     }
     /// set 4-momentum                                                                    
     virtual void setP4( const PolarLorentzVector & p4 ) { 
         maybeUnpackBoth(); // changing px,py,pz changes also mapping between dxy,dz and x,y,z
+	dphi_+=polarP4().Phi()-p4.Phi();
+	deta_+=polarP4().Eta()-p4.Eta();
+	dtrkpt_+=polarP4().Pt()-p4.Pt();
         *p4_ = p4; 
         packBoth();
     }
@@ -389,6 +395,9 @@ namespace pat {
     virtual void setPz( double pz ) {
       maybeUnpackBoth(); // changing px,py,pz changes also mapping between dxy,dz and x,y,z
       *p4c_ = LorentzVector(p4c_.load()->Px(), p4c_.load()->Py(), pz, p4c_.load()->E());
+      dphi_+=polarP4().Phi()-(*p4c_).Phi();
+      deta_+=polarP4().Eta()-(*p4c_).Eta();
+      dtrkpt_+=polarP4().Pt()-(*p4c_).Pt();
       *p4_  = PolarLorentzVector(p4c_.load()->Pt(), p4c_.load()->Eta(), p4c_.load()->Phi(), p4c_.load()->M());
       packBoth();
     }

--- a/DataFormats/PatCandidates/test/testPackedCandidate.cc
+++ b/DataFormats/PatCandidates/test/testPackedCandidate.cc
@@ -107,6 +107,19 @@ testPackedCandidate::testPackUnpack() {
   CPPUNIT_ASSERT(tolerance(pc.ptTrk(),trkPt,0.001));
   CPPUNIT_ASSERT(tolerance(pc.etaAtVtx(),trkEta,0.001));
   CPPUNIT_ASSERT(tolerance(pc.phiAtVtx(),trkPhi,0.001));
+  //Check again after a setP4
+  pc.setP4(plv*2);
+  CPPUNIT_ASSERT(tolerance(pc.ptTrk(),trkPt,0.001));
+  CPPUNIT_ASSERT(tolerance(pc.etaAtVtx(),trkEta,0.001));
+  CPPUNIT_ASSERT(tolerance(pc.phiAtVtx(),trkPhi,0.001));
+  pc.setP4(lv*3);
+  CPPUNIT_ASSERT(tolerance(pc.ptTrk(),trkPt,0.001));
+  CPPUNIT_ASSERT(tolerance(pc.etaAtVtx(),trkEta,0.001));
+  CPPUNIT_ASSERT(tolerance(pc.phiAtVtx(),trkPhi,0.001));
+  pc.setPz(pc.p4().Pz()+3.3);
+  CPPUNIT_ASSERT(tolerance(pc.ptTrk(),trkPt,0.005));
+  CPPUNIT_ASSERT(tolerance(pc.etaAtVtx(),trkEta,0.005));
+  CPPUNIT_ASSERT(tolerance(pc.phiAtVtx(),trkPhi,0.005));
 }
 
 void testPackedCandidate::testSimulateReadFromRoot() {


### PR DESCRIPTION
 update the delta pt,eta,phi when calling setP4 and setPz so that track momentum is unchanged as discussed in XPOG meeting on sept 4th.

Seems to do the right thing (similar unit test added)
root [0] pat::PackedCandidate a;
root [1] a.eta()
(double) 0.000000
root [2] a.etaAtVtx()
(float) 0.00000f
root [3] a.pt()
(double) 0.000000
root [7] a.ptTrk()
(double) 0.000000
root [8] a.setP4(reco::Candidate::PolarLorentzVector(10,2,3,5))
root [9] a.ptTrk()
(double) 0.000000
root [10] a.pt()
(double) 10.000000
root [11] a.eta()
(double) 1.999939
root [12] a.etaAtVtx()
(float) -0.00006f
root [13] a.setPz(10)
root [14] a.eta()
(double) 0.881314
root [15] a.etaAtVtx()
(float) -0.00003f