### PR TITLE
updating splitting function for DIGI step

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -222,7 +222,7 @@ class MatrixInjector(object):
             wmsplit['DigiFullPU']=1
             wmsplit['RecoFullPU']=1
             wmsplit['RECOHID11']=1
-            wmsplit['DigiFullPU_2023D17PU']=1
+            wmsplit['DigiFullTriggerPU_2023D17PU']=1
             wmsplit['RecoFullGlobalPU_2023D17PU']=1
             wmsplit['DIGIUP17']=1
             wmsplit['RECOUP17']=1


### PR DESCRIPTION
Replacing the splitting for the DIGI step that is used for 2023 relvals. Backporting #20329