### PR TITLE
Fix compilation warnings in SimDataFormats/CaloHit

### DIFF
--- a/SimDataFormats/CaloHit/interface/CastorShowerEvent.h
+++ b/SimDataFormats/CaloHit/interface/CastorShowerEvent.h
@@ -62,7 +62,7 @@
     float getPrimY()             { return primY; };
     float getPrimZ()             { return primZ; };
     
-    ClassDef(CastorShowerEvent,2)
+    ClassDefOverride(CastorShowerEvent,2)
     
   };
 

--- a/SimDataFormats/CaloHit/interface/CastorShowerLibraryInfo.h
+++ b/SimDataFormats/CaloHit/interface/CastorShowerLibraryInfo.h
@@ -31,7 +31,7 @@ class SLBin: public TObject {
              unsigned int        NBins;
              unsigned int        NEvtPerBin;
              std::vector<double> Bins;
-    ClassDef(SLBin,2);
+    ClassDefOverride(SLBin,2);
 };
 
 class CastorShowerLibraryInfo : public TObject {
@@ -48,7 +48,7 @@ class CastorShowerLibraryInfo : public TObject {
     SLBin Eta;
     SLBin Phi;
 
-    ClassDef(CastorShowerLibraryInfo,2);
+    ClassDefOverride(CastorShowerLibraryInfo,2);
     
   };
 


### PR DESCRIPTION
Switch the macro used from ClassDef to ClassDefOverride to avoid compilation warnings. 