### PR TITLE
CTPPS pixel gain calibration patch

### DIFF
--- a/CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibrations.h
+++ b/CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibrations.h
@@ -20,8 +20,8 @@ class CTPPSPixelGainCalibrations{
 
   const CalibMap & getCalibMap()const { return m_calibrations;}
 
-  CTPPSPixelGainCalibration getGainCalibration(const uint32_t & detid) const;
-  CTPPSPixelGainCalibration & getGainCalibration(const uint32_t & detid);
+  const CTPPSPixelGainCalibration & getGainCalibration(const uint32_t & detid) const;
+//  CTPPSPixelGainCalibration & getGainCalibration(const uint32_t & detid);
 
   
   

--- a/CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibrations.h
+++ b/CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibrations.h
@@ -21,9 +21,6 @@ class CTPPSPixelGainCalibrations{
   const CalibMap & getCalibMap()const { return m_calibrations;}
 
   const CTPPSPixelGainCalibration & getGainCalibration(const uint32_t & detid) const;
-//  CTPPSPixelGainCalibration & getGainCalibration(const uint32_t & detid);
-
-  
   
   int size() const {return m_calibrations.size();}
 

--- a/CondFormats/CTPPSReadoutObjects/src/CTPPSPixelGainCalibrations.cc
+++ b/CondFormats/CTPPSReadoutObjects/src/CTPPSPixelGainCalibrations.cc
@@ -51,14 +51,10 @@ void CTPPSPixelGainCalibrations::setGainCalibrations(const std::vector<uint32_t>
 
 const CTPPSPixelGainCalibration  & CTPPSPixelGainCalibrations::getGainCalibration(const uint32_t & detid) const{ // returns the object does not change the map
   CalibMap::const_iterator it = m_calibrations.find(detid);
-  if (it != m_calibrations.end()){
-    return it->second;
-  }
-  else{
+  if (it == m_calibrations.end())  
     throw cms::Exception("CTPPSPixelGainCalibrations: ") <<" No gain calibrations defined for detid ";
-  }
-  static const CTPPSPixelGainCalibration a;
-  return a;
+
+  return it->second;
 
 }
 

--- a/CondFormats/CTPPSReadoutObjects/src/CTPPSPixelGainCalibrations.cc
+++ b/CondFormats/CTPPSReadoutObjects/src/CTPPSPixelGainCalibrations.cc
@@ -49,20 +49,15 @@ void CTPPSPixelGainCalibrations::setGainCalibrations(const std::vector<uint32_t>
   }
 }
 
-
-CTPPSPixelGainCalibration & CTPPSPixelGainCalibrations::getGainCalibration(const uint32_t & detid) { // returns the ref and if does not exist it creates
-  return m_calibrations[detid];
-}
-
-CTPPSPixelGainCalibration  CTPPSPixelGainCalibrations::getGainCalibration(const uint32_t & detid) const{ // returns the object does not change the map
+const CTPPSPixelGainCalibration  & CTPPSPixelGainCalibrations::getGainCalibration(const uint32_t & detid) const{ // returns the object does not change the map
   CalibMap::const_iterator it = m_calibrations.find(detid);
-  if (it != m_calibrations.end())
+  if (it != m_calibrations.end()){
     return it->second;
-
-  else
-    edm::LogError("CTPPSPixelGainCalibrations")<< "No gain calibrations defined for detid " << detid << "\n";
-
-  CTPPSPixelGainCalibration a;
+  }
+  else{
+    throw cms::Exception("CTPPSPixelGainCalibrations: ") <<" No gain calibrations defined for detid ";
+  }
+  static const CTPPSPixelGainCalibration a;
   return a;
 
 }


### PR DESCRIPTION
Returning ctpps pixel gain calibration by reference instead of by value to increase speed.
@fravera @robutti @slava77 