### PR TITLE
Add logic to handle exclusion of CALOL2 in DQM

### DIFF
--- a/DQM/L1TMonitor/src/L1TdeStage2CaloLayer2.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2CaloLayer2.cc
@@ -927,6 +927,12 @@ bool L1TdeStage2CaloLayer2::compareSums(
   l1t::EtSumBxCollection::const_iterator dataIt = dataCol->begin(currBx);
   l1t::EtSumBxCollection::const_iterator emulIt = emulCol->begin(currBx);
 
+  // if either data or emulator collections are empty, or they have different
+  // size, mark the event as bad (this should never occur in normal running)
+  if (dataCol->isEmpty(currBx) == 0 || emulCol->isEmpty(currBx) == 0 ||
+      (dataCol->size() != emulCol->size()))
+    return false;
+
   while(true) {
 
     // It should be possible to implement this with a switch statement


### PR DESCRIPTION
PR includes logic to the CALOL2 event-by-event comparisons in Online DQM which should properly handle the exclusion from global running of Calo Layer 2 sub-system of the L1Trigger. This PR will be followed by backports to 93X and 92X (currently used in production).