### PR TITLE
Era update and removal of LumiPixels from AlCaLumiPixel with addition of AlCaPCCZeroBias and AlCaPCCRandom

### DIFF
--- a/Configuration/DataProcessing/python/Impl/AlCaLumiPixels.py
+++ b/Configuration/DataProcessing/python/Impl/AlCaLumiPixels.py
@@ -7,11 +7,13 @@ Scenario supporting proton collisions
 """
 
 from Configuration.DataProcessing.Impl.AlCa import AlCa
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
 
 class AlCaLumiPixels(AlCa):
     def __init__(self):
         AlCa.__init__(self)
-        self.skims=['LumiPixels']
+        self.eras=Run2_2017
+        self.skims=['AlCaPCCZeroBias+AlCaPCCRandom']
     """
     _AlCaLumiPixels_
 


### PR DESCRIPTION
This PR bring two changes related to AlCaLumiPixels 

1. update the AlCaLumiPixels scenario to include the era for 2017 to fix the Layer1 reconstruction of Pixel. 

2. replace LumiPixels by AlCaPCCZeroBias+AlCaPCCRandom as discussed and already removed from AlCaReco Matrix.

These changes will allow T0 to keep using AlCaLumiPixels scenario for the AlCaLumiPixels PD.

Instructions for testing: 
```
cmsrel CMSSW_9_4_X_2017-09-19-0700
cd CMSSW_9_4_X_2017-09-19-0700/src/
git cms-addpkg Configuration/DataProcessing
cmsenv
git fetch git@github.com:arunhep/cmssw.git EraUpdate_AlCaLumiPixels_94X:EraUpdate_AlCaLumiPixels_94X
git checkout EraUpdate_AlCaLumiPixels_94X
scram b
voms-proxy-init -voms cms

T0 like commands to produce the configuration files :

python $CMSSW_BASE/src/Configuration/DataProcessing/test/RunPromptReco.py --scenario=AlCaLumiPixels --global-tag 92X_dataRun2_Prompt_v8 --lfn '/store/data/Run2017D/AlCaLumiPixels/RAW/v1/000/302/159/00000/1C4FF0A4-B48E-E711-A97F-02163E0139AB.root’ --alcarecos=AlCaPCCZeroBias+AlCaPCCRandom --reco

cmsRun -e RunPromptRecoCfg.py

```
and then you can compare it with the current definition of AlCaLumiPixels scenario.


```
cmsrel CMSSW_9_4_0_pre1
cd CMSSW_9_4_0_pre1/src/
git cms-addpkg Configuration/DataProcessing
cmsenv
scram b
voms-proxy-init -voms cms

python $CMSSW_BASE/src/Configuration/DataProcessing/test/RunPromptReco.py --scenario=AlCaLumiPixels --global-tag 92X_dataRun2_Prompt_v8 --lfn '/store/data/Run2017D/AlCaLumiPixels/RAW/v1/000/302/159/00000/1C4FF0A4-B48E-E711-A97F-02163E0139AB.root' --alcarecos=AlCaPCCZeroBias+AlCaPCCRandom --reco

cmsRun -e RunPromptRecoCfg.py

```
if you take the diff of these two configuration files, apart from other differences, you will see that in the file coming from this branch, you see :     `UsePhase1 = cms.bool(True),` which should bring the fix to Layer1 reconstruction.
