### PR TITLE
Skim on DisplacedJet PD for EXO

### DIFF
--- a/Configuration/Skimming/python/PDWG_EXODisplacedJet_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXODisplacedJet_cff.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+DisplacedJetHTTrigger = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
+DisplacedJetHTTrigger.TriggerResultsTag = cms.InputTag( "TriggerResults", "", "HLT" )
+DisplacedJetHTTrigger.HLTPaths = cms.vstring(
+    "HLT_HT425_v*"
+)
+DisplacedJetHTTrigger.throw = False
+DisplacedJetHTTrigger.andOr = True
+
+EXODisplacedJetSkimSequence = cms.Sequence(
+    DisplacedJetHTTrigger
+)

--- a/Configuration/Skimming/python/Skims_PDWG_cff.py
+++ b/Configuration/Skimming/python/Skims_PDWG_cff.py
@@ -244,6 +244,17 @@ SKIMStreamEXOMONOPOLE = cms.FilteredStream(
         dataTier = cms.untracked.string('USER')
         )
 
+from Configuration.Skimming.PDWG_EXODisplacedJet_cff import *
+EXODisplacedJetPath = cms.Path(EXODisplacedJetSkimSequence)
+SKIMStreamEXODisplacedJet = cms.FilteredStream(
+    responsible = 'PDWG',
+    name = 'EXODisplacedJet',
+    paths = (EXODisplacedJetPath),
+    content = skimContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('RAW-RECO')
+)
+
 #####################
 # For the Data on Data Mixing in TSG
 from HLTrigger.Configuration.HLT_Fake1_cff import fragment as _fragment


### PR DESCRIPTION
Thanks to the help of @kfjack , this PR adds the pre-scaled skim for Displaced Jet  with path HLT_HT425_v*.  It's supposed to run on the DisplacedJet PD, where the path HLT_HT425_v is implemented. 

The 9_2_X backport is #20587 