### PR TITLE
Prevent disabing of HGCal electron cluster preselection

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
@@ -58,8 +58,8 @@ using namespace reco ;
 
 ElectronSeedProducer::ElectronSeedProducer( const edm::ParameterSet& iConfig )
  : //conf_(iConfig),
-   applyHOverECut_(true), hcalHelper_(0),
-   caloGeom_(0), caloGeomCacheId_(0), caloTopo_(0), caloTopoCacheId_(0)
+   applyHOverECut_(true), hcalHelper_(nullptr),
+   caloGeom_(nullptr), caloGeomCacheId_(0), caloTopo_(nullptr), caloTopoCacheId_(0)
  {
   conf_ = iConfig.getParameter<edm::ParameterSet>("SeedConfiguration") ;
 
@@ -202,7 +202,7 @@ void ElectronSeedProducer::produce(edm::Event& e, const edm::EventSetup& iSetup)
      { theInitialSeedColl = new TrajectorySeedCollection ; }
    }
   else
-   { theInitialSeedColl = 0 ; } // not needed in this case
+   { theInitialSeedColl = nullptr ; } // not needed in this case
 
   ElectronSeedCollection * seeds = new ElectronSeedCollection ;
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
@@ -273,8 +273,8 @@ void ElectronSeedProducer::filterClusters
          scle = scl.energy() ;
          int det_group = scl.seed()->hitsAndFractions()[0].first.det() ;
          int detector = scl.seed()->hitsAndFractions()[0].first.subdetId() ;
-         if (detector==EcalBarrel && (had<maxHBarrel_ || had/scle<maxHOverEBarrel_)) HoeVeto=true;
-         else if( detector==EcalEndcap && (had<maxHEndcaps_ || had/scle<maxHOverEEndcaps_) ) HoeVeto=true;
+         if ( detector==EcalBarrel && (had<maxHBarrel_ || had/scle<maxHOverEBarrel_)) HoeVeto=true;
+         else if( !allowHGCal_ && detector==EcalEndcap && (had<maxHEndcaps_ || had/scle<maxHOverEEndcaps_) ) HoeVeto=true;
          else if( allowHGCal_ && (detector==HcalEndcap || det_group == DetId::Forward) ) {
            float had_fraction = hgcClusterTools_->getClusterHadronFraction(*(scl.seed()));
            had1 = had_fraction*scl.seed()->energy();


### PR DESCRIPTION
Due to aliasing of enums EcalEndcap=HcalEndcap=2.  I didn't add `det_group == DetId::Ecal` since I was worried the alias might have been permitted for pre-PhaseII detectors in case `hitsAndFractions()[0]` happens to be an HCal hit.  Not sure if that actually happens or not...

Found when looking at hadron fraction of electrons in 930 Zee RelVals, where the [cluster cut](https://github.com/cms-sw/cmssw/blob/master/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeedsParameters_cff.py#L34) appears to not work
![ecaldrivenelectronshadfrac](https://user-images.githubusercontent.com/6587412/30601714-f1c48878-9d62-11e7-95db-5fe5d65a3912.png)

Here are the unique subdet IDs observed in the PF superclusters:
```python
In [23]: ids=set()

In [26]: for e in events:
    ...:     cl = handles.recoSuperClusters_particleFlowSuperClusterHGCalFromMultiCl__RECO
    ...:     ids=ids.union( set([(c.seed().hitsAndFractions()[0].first.det(), c.seed().hitsAndFractions()[0].first.subdetId()) for c in cl]))
    ...:

In [27]: ids
Out[27]: {(4L, 2), (6L, 3), (6L, 4)}
```
i.e. `DetId::Hcal, HcalEndcap`, `DetId::Forward, HGCEE`, and `DetId::Forward, HGCHEF`.
I am not sure why HcalEndcap is used as a subdetId rather than HGCHEB, perhaps someone knows?