### PR TITLE
Dropbox json update for the SiPixelAli for allowing to write in production tag

### DIFF
--- a/CondFormats/Common/test/SiPixelAliRcd_prod.json
+++ b/CondFormats/Common/test/SiPixelAliRcd_prod.json
@@ -2,9 +2,9 @@
     "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
         "SiPixelAli_PCL_v0_hlt": {}, 
-        "TrackerAlignment_PCL_byRun_v1_express": {}
+        "TrackerAlignment_PCL_byRun_v2_express": {}
     }, 
     "inputTag": "SiPixelAli_pcl", 
     "since": null, 
-    "userText": "T0 PCL Upload for SiPixel Ali - temp. not the tag consumed by prompt. (prod)"
+    "userText": "T0 PCL Upload for SiPixel Ali - moved to the tag consumed by prompt. (prod)"
 }


### PR DESCRIPTION
This is to keep the `CondFormats/Common` updated so that one can retrieve the last payload in the Dropbox tag which controls the writing of payloads from PCL workflows.
The change made here is to put back SiPixelAlignment PCL workflow write in production tag consumed by express and prompt wfs.
The tag has been updated already. https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3233.html