### PR TITLE
Small changes in HCAL TP LUTs

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -48,9 +48,10 @@ public:
   void update(const char* filename, bool appendMSB = false);
   void updateXML(const char* filename);
   void setLUTGenerationMode(bool gen){ LUTGenerationMode_ = gen; };
+  void setFGHFthreshold(unsigned int fgthreshold){ FG_HF_threshold_ = fgthreshold; };
   void setMaskBit(int bit){ bitToMask_ = bit; };
-  std::vector<unsigned short> getLinearizationLUTWithMSB(const HcalDetId& id) const;
   void lookupMSB(const HBHEDataFrame& df, std::vector<bool>& msb) const;
+  void lookupMSB(const QIE10DataFrame& df, std::vector<bool>& msb) const;
   void lookupMSB(const QIE11DataFrame& df, std::vector<std::bitset<2>>& msb) const;
   bool getMSB(const HcalDetId& id, int adc) const;
   int getLUTId(HcalSubdetector id, int ieta, int iphi, int depth) const;
@@ -74,18 +75,17 @@ private:
   static const int QIE8_LUT_MSB = 0x400;
   static const int QIE11_LUT_MSB0 = 0x400;
   static const int QIE11_LUT_MSB1 = 0x800;
+  static const int QIE10_LUT_MSB  = 0x1000;
   
   // member variables
   const HcalTopology* topo_;
   bool LUTGenerationMode_;
+  unsigned int FG_HF_threshold_;
   int  bitToMask_;
   int  firstHBEta_, lastHBEta_, nHBEta_, maxDepthHB_, sizeHB_;
   int  firstHEEta_, lastHEEta_, nHEEta_, maxDepthHE_, sizeHE_;
   int  firstHFEta_, lastHFEta_, nHFEta_, maxDepthHF_, sizeHF_;
   std::vector< Lut > inputLUT_;
-  std::vector< Lut > upgradeQIE10LUT_;
-  std::vector< Lut > upgradeQIE11LUT_;
-  std::vector<int> QIEType_;
   std::vector<float> gain_;
   std::vector<float> ped_;
 };

--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -33,16 +33,16 @@ public:
   static const float  lsb_;
 
   HcaluLUTTPGCoder(const HcalTopology* topo);
-  virtual ~HcaluLUTTPGCoder();
-  virtual void adc2Linear(const HBHEDataFrame& df, IntegerCaloSamples& ics) const override;
-  virtual void adc2Linear(const HFDataFrame& df, IntegerCaloSamples& ics) const override;
-  virtual void adc2Linear(const QIE10DataFrame& df, IntegerCaloSamples& ics) const override;
-  virtual void adc2Linear(const QIE11DataFrame& df, IntegerCaloSamples& ics) const override;
-  virtual void compress(const IntegerCaloSamples& ics, const std::vector<bool>& featureBits, HcalTriggerPrimitiveDigi& tp) const override;
-  virtual unsigned short adc2Linear(HcalQIESample sample,HcalDetId id) const override;
-  virtual float getLUTPedestal(HcalDetId id) const override;
-  virtual float getLUTGain(HcalDetId id) const override;
-  virtual std::vector<unsigned short> getLinearizationLUT(HcalDetId id) const override;
+  ~HcaluLUTTPGCoder() override;
+  void adc2Linear(const HBHEDataFrame& df, IntegerCaloSamples& ics) const override;
+  void adc2Linear(const HFDataFrame& df, IntegerCaloSamples& ics) const override;
+  void adc2Linear(const QIE10DataFrame& df, IntegerCaloSamples& ics) const override;
+  void adc2Linear(const QIE11DataFrame& df, IntegerCaloSamples& ics) const override;
+  void compress(const IntegerCaloSamples& ics, const std::vector<bool>& featureBits, HcalTriggerPrimitiveDigi& tp) const override;
+  unsigned short adc2Linear(HcalQIESample sample,HcalDetId id) const override;
+  float getLUTPedestal(HcalDetId id) const override;
+  float getLUTGain(HcalDetId id) const override;
+  std::vector<unsigned short> getLinearizationLUT(HcalDetId id) const override;
 
   void update(const HcalDbService& conditions);
   void update(const char* filename, bool appendMSB = false);

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -50,10 +50,7 @@ HcaluLUTTPGCoder::HcaluLUTTPGCoder(const HcalTopology* top) : topo_(top), LUTGen
   maxDepthHF_ = topo_->maxDepth(HcalForward);
   sizeHF_     = 2*nHFEta_*nFi_*maxDepthHF_;
   size_t nluts= (size_t)(sizeHB_+sizeHE_+sizeHF_+1);
-  inputLUT_   = std::vector<HcaluLUTTPGCoder::Lut>(nluts,HcaluLUTTPGCoder::Lut(INPUT_LUT_SIZE, 0));
-  upgradeQIE10LUT_ = std::vector<HcaluLUTTPGCoder::Lut>(nluts,HcaluLUTTPGCoder::Lut(UPGRADE_LUT_SIZE, 0));
-  upgradeQIE11LUT_ = std::vector<HcaluLUTTPGCoder::Lut>(nluts,HcaluLUTTPGCoder::Lut(UPGRADE_LUT_SIZE, 0));
-  QIEType_    = std::vector<int> (nluts, 0);
+  inputLUT_   = std::vector<HcaluLUTTPGCoder::Lut>(nluts);
   gain_       = std::vector<float>(nluts, 0.);
   ped_        = std::vector<float>(nluts, 0.);
 }
@@ -225,139 +222,116 @@ void HcaluLUTTPGCoder::updateXML(const char* filename) {
 }
 
 void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
+    
+    HcalCalibrations calibrations;
+    const HcalLutMetadata *metadata = conditions.getHcalLutMetadata();
+    assert(metadata !=0);
+    float nominalgain_ = metadata->getNominalGain();
 
-  HcalCalibrations calibrations;
-  const HcalLutMetadata *metadata = conditions.getHcalLutMetadata();
-  assert(metadata !=0);
-  float nominalgain_ = metadata->getNominalGain();
+    std::map<int, float> cosh_ieta;
+    for (int i = firstHFEta_; i <= lastHFEta_; ++i){
+	std::pair<double,double> etas = topo_->etaRange(HcalForward,i);
+	double eta1 = etas.first;
+	double eta2 = etas.second;
+	cosh_ieta[i] = cosh((eta1 + eta2)/2.);
+    }
 
-  std::map<int, float> cosh_ieta;
-  for (int i = firstHFEta_; i <= lastHFEta_; ++i){
-    std::pair<double,double> etas = topo_->etaRange(HcalForward,i);
-    double eta1 = etas.first;
-    double eta2 = etas.second;
-    cosh_ieta[i] = cosh((eta1 + eta2)/2.);
-  }
+    for (const auto& id: metadata->getAllChannels()) {
+     
+	if (not (id.det() == DetId::Hcal and topo_->valid(id))) continue;
 
-  for (const auto& id: metadata->getAllChannels()) {
-     if (not (id.det() == DetId::Hcal and topo_->valid(id)))
-        continue;
-     HcalDetId cell(id);
-     HcalSubdetector subdet = cell.subdet();
-     if (subdet != HcalBarrel and subdet != HcalEndcap and subdet != HcalForward)
-        continue;
+	HcalDetId cell(id);
+	HcalSubdetector subdet = cell.subdet();
+     
+	if (subdet != HcalBarrel and subdet != HcalEndcap and subdet != HcalForward) continue;
 
-     const HcalQIECoder* channelCoder = conditions.getHcalCoder (cell);
-     const HcalQIEShape* shape = conditions.getHcalShape(cell);
-     HcalCoderDb coder (*channelCoder, *shape);
-     const HcalLutMetadatum *meta = metadata->getValues(cell);
+	const HcalQIECoder* channelCoder = conditions.getHcalCoder (cell);
+	const HcalQIEShape* shape = conditions.getHcalShape(cell);
+	HcalCoderDb coder (*channelCoder, *shape);
+	const HcalLutMetadatum *meta = metadata->getValues(cell);
 
-     unsigned int mipMax = 0;
-     unsigned int mipMin = 0;
+	unsigned int mipMax = 0;
+	unsigned int mipMin = 0;
+     
+	if (topo_->triggerMode() >= HcalTopologyMode::TriggerMode_2018 or
+		topo_->triggerMode() == HcalTopologyMode::TriggerMode_2018legacy or
+		topo_->dddConstants()->isPlan1(cell)) {
+	    const HcalTPChannelParameter *channelParameters = conditions.getHcalTPChannelParameter(cell);
+	    mipMax = channelParameters->getFGBitInfo() >> 16;
+	    mipMin = channelParameters->getFGBitInfo() & 0xFFFF;
+	}
 
-     if (topo_->triggerMode() >= HcalTopologyMode::TriggerMode_2018 or
-           topo_->triggerMode() == HcalTopologyMode::TriggerMode_2018legacy or
-           topo_->dddConstants()->isPlan1(cell)) {
-        const HcalTPChannelParameter *channelParameters = conditions.getHcalTPChannelParameter(cell);
-        mipMax = channelParameters->getFGBitInfo() >> 16;
-        mipMin = channelParameters->getFGBitInfo() & 0xFFFF;
-     }
+	int lutId = getLUTId(cell);
+	Lut &lut=inputLUT_[lutId]; 
+	float ped = 0;
+	float gain = 0;
+	uint32_t status = 0;
 
-     int lutId = getLUTId(cell);
-     float ped = 0;
-     float gain = 0;
-     uint32_t status = 0;
+	if (LUTGenerationMode_){
+	    const HcalCalibrations& calibrations = conditions.getHcalCalibrations(cell);
+	    for (auto capId : {0,1,2,3}){
+		ped += calibrations.pedestal(capId);
+		gain += calibrations.LUTrespcorrgain(capId);
+	    }
+	    ped /= 4.0;
+	    gain /= 4.0;
 
-     QIEType_[lutId]=conditions.getHcalQIEType(cell)->getValue();
+	    //Get Channel Quality
+	    const HcalChannelStatus* channelStatus = conditions.getHcalChannelStatus(cell);
+	    status = channelStatus->getValue();
+     
+	} else {
+	    const HcalL1TriggerObject* myL1TObj = conditions.getHcalL1TriggerObject(cell);
+	    ped = myL1TObj->getPedestal();
+	    gain = myL1TObj->getRespGain();
+	    status = myL1TObj->getFlag();
+	} // LUTGenerationMode_
 
-     if (LUTGenerationMode_){
-        const HcalCalibrations& calibrations = conditions.getHcalCalibrations(cell);
-	for (auto capId : {0,1,2,3}){
-           ped += calibrations.pedestal(capId);
-           gain += calibrations.LUTrespcorrgain(capId);
+	ped_[lutId] = ped;
+	gain_[lutId] = gain;
+	bool isMasked = ( (status & bitToMask_) > 0 );
+	float rcalib = meta->getRCalib();
+
+	auto adc2fC = [channelCoder, shape](unsigned int adc){
+	    float fC = 0;
+	    for (auto capId : {0,1,2,3}) fC += channelCoder->charge(*shape, adc, capId);
+	    return fC/4;
+	};
+
+	int QIEtype =conditions.getHcalQIEType(cell)->getValue();
+     
+	const size_t SIZE = QIEtype==0 ? INPUT_LUT_SIZE : UPGRADE_LUT_SIZE;
+	const int MASK = QIEtype==0 ? QIE8_LUT_BITMASK : 
+			 QIEtype==1 ? QIE10_LUT_BITMASK : QIE11_LUT_BITMASK;  
+
+	lut.resize(SIZE, 0);
+
+	// Input LUT for HB/HE/HF
+	if (subdet == HcalBarrel || subdet == HcalEndcap){
+
+	    int granularity = meta->getLutGranularity();
+
+	    for (unsigned int adc = 0; adc < SIZE; ++adc) {
+		if (isMasked) lut[adc] = 0;
+		else {
+		    lut[adc] = (LutElement) std::min(std::max(0, int((adc2fC(adc) - ped) * gain * rcalib / nominalgain_ / granularity)), MASK);
+		    if(QIEtype==2){
+			if (adc >= mipMin and adc < mipMax) lut[adc] |= QIE11_LUT_MSB0;
+			else if (adc >= mipMax) lut[adc] |= QIE11_LUT_MSB1;
+		    }
+		}
+	    }
+	}  
+	else if (subdet == HcalForward){
+	    for (unsigned int adc = 0; adc < SIZE; ++adc) {
+		if (isMasked) lut[adc] = 0;
+		else {
+		    lut[adc] = std::min(std::max(0,int((adc2fC(adc) - ped) * gain * rcalib / lsb_ / cosh_ieta[cell.ietaAbs()] )), MASK);
+		    if(adc>FG_HF_threshold_) lut[adc] |= QIE10_LUT_MSB;
+		}
+	    }
         }
-        ped /= 4.0;
-        gain /= 4.0;
-
-        //Get Channel Quality
-        const HcalChannelStatus* channelStatus = conditions.getHcalChannelStatus(cell);
-        status = channelStatus->getValue();
-     } else {
-        const HcalL1TriggerObject* myL1TObj = conditions.getHcalL1TriggerObject(cell);
-        ped = myL1TObj->getPedestal();
-        gain = myL1TObj->getRespGain();
-        status = myL1TObj->getFlag();
-     } // LUTGenerationMode_
-
-     ped_[lutId] = ped;
-     gain_[lutId] = gain;
-     bool isMasked = ( (status & bitToMask_) > 0 );
-     float rcalib = meta->getRCalib();
-
-     // Input LUT for HB/HE/HF
-     if (subdet == HcalBarrel || subdet == HcalEndcap){
-        HBHEDataFrame frame(cell);
-        frame.setSize(1);
-        CaloSamples samples(cell, 1);
-
-        int granularity = meta->getLutGranularity();
-
-        for (unsigned int adc = 0; adc < INPUT_LUT_SIZE; ++adc) {
-           frame.setSample(0,HcalQIESample(adc));
-           coder.adc2fC(frame,samples);
-           float adc2fC = samples[0];
-
-           if (isMasked) inputLUT_[lutId][adc] = 0;
-           else inputLUT_[lutId][adc] = (LutElement) std::min(std::max(0, int((adc2fC -ped) * gain * rcalib / nominalgain_ / granularity)), QIE8_LUT_BITMASK);
-        }
-
-        unsigned short data[] = {0, 0, 0};
-        QIE11DataFrame upgradeFrame(edm::DataFrame(0, data, 3));
-        CaloSamples upgradeSamples(cell, 1);
-        for (unsigned int adc = 0; adc < UPGRADE_LUT_SIZE; ++adc) {
-           upgradeFrame.setSample(0, adc, 0, true);
-           coder.adc2fC(upgradeFrame, upgradeSamples);
-           float adc2fC = upgradeSamples[0];
-
-           if (isMasked) {
-              upgradeQIE11LUT_[lutId][adc] = 0;
-           } else {
-              upgradeQIE11LUT_[lutId][adc] = (LutElement) std::min(std::max(0, int((adc2fC -ped) * gain * rcalib / nominalgain_ / granularity)), QIE11_LUT_BITMASK);
-              if (adc >= mipMin and adc < mipMax)
-                 upgradeQIE11LUT_[lutId][adc] |= QIE11_LUT_MSB0;
-              else if (adc >= mipMax)
-                 upgradeQIE11LUT_[lutId][adc] |= QIE11_LUT_MSB1;
-           }
-        }
-     }  // endif HBHE
-     else if (subdet == HcalForward){
-        HFDataFrame frame(cell);
-        frame.setSize(1);
-        CaloSamples samples(cell, 1);
-
-        for (unsigned int adc = 0; adc < INPUT_LUT_SIZE; ++adc) {
-           frame.setSample(0,HcalQIESample(adc));
-           coder.adc2fC(frame,samples);
-           float adc2fC = samples[0];
-           if (isMasked) inputLUT_[lutId][adc] = 0;
-           else inputLUT_[lutId][adc] = std::min(std::max(0,int((adc2fC - ped) * gain * rcalib / lsb_ / cosh_ieta[cell.ietaAbs()] )), QIE8_LUT_BITMASK);
-        }
-
-        unsigned short data[] = {0, 0, 0, 0};
-        QIE10DataFrame upgradeFrame(edm::DataFrame(0, data, 4));
-        CaloSamples upgradeSamples(cell, 1);
-        for (unsigned int adc = 0; adc < UPGRADE_LUT_SIZE; ++adc) {
-           upgradeFrame.setSample(0, adc, 0, 0, 0, true);
-           coder.adc2fC(upgradeFrame, upgradeSamples);
-           float adc2fC = upgradeSamples[0];
-
-           if (isMasked)
-              upgradeQIE10LUT_[lutId][adc] = 0;
-           else
-              upgradeQIE10LUT_[lutId][adc] = std::min(std::max(0,int((adc2fC - ped) * gain * rcalib / lsb_ / cosh_ieta[cell.ietaAbs()] )), QIE10_LUT_BITMASK);
-        }
-     } // endif HF
-  }// for cell
+    } 
 }
 
 void HcaluLUTTPGCoder::adc2Linear(const HBHEDataFrame& df, IntegerCaloSamples& ics) const {
@@ -378,7 +352,7 @@ void HcaluLUTTPGCoder::adc2Linear(const HFDataFrame& df, IntegerCaloSamples& ics
 
 void HcaluLUTTPGCoder::adc2Linear(const QIE10DataFrame& df, IntegerCaloSamples& ics) const {
   int lutId = getLUTId(HcalDetId(df.id()));
-  const Lut& lut = upgradeQIE10LUT_.at(lutId);
+  const Lut& lut = inputLUT_.at(lutId);
   for (int i=0; i<df.samples(); i++){
     ics[i] = (lut.at(df[i].adc()) & QIE10_LUT_BITMASK);
   }
@@ -386,7 +360,7 @@ void HcaluLUTTPGCoder::adc2Linear(const QIE10DataFrame& df, IntegerCaloSamples& 
 
 void HcaluLUTTPGCoder::adc2Linear(const QIE11DataFrame& df, IntegerCaloSamples& ics) const {
   int lutId = getLUTId(HcalDetId(df.id()));
-  const Lut& lut = upgradeQIE11LUT_.at(lutId);
+  const Lut& lut = inputLUT_.at(lutId);
   for (int i=0; i<df.samples(); i++){
     ics[i] = (lut.at(df[i].adc()) & QIE11_LUT_BITMASK);
   }
@@ -407,19 +381,9 @@ float HcaluLUTTPGCoder::getLUTGain(HcalDetId id) const {
   return gain_.at(lutId);
 }
 
-std::vector<unsigned short> HcaluLUTTPGCoder::getLinearizationLUTWithMSB(const HcalDetId& id) const{
-  int lutId = getLUTId(id);
-   return inputLUT_.at(lutId);
-}
-
 std::vector<unsigned short> HcaluLUTTPGCoder::getLinearizationLUT(HcalDetId id) const{
-
     int lutId = getLUTId(id);
-    int type=QIEType_[lutId];
-    const std::vector<Lut>& lut= type==0 ? inputLUT_ : 
-				 type==1 ? upgradeQIE10LUT_ : 
-					   upgradeQIE11LUT_ ;
-    return lut.at(lutId);
+    return inputLUT_.at(lutId);
 }
 
 void HcaluLUTTPGCoder::lookupMSB(const HBHEDataFrame& df, std::vector<bool>& msb) const{
@@ -434,11 +398,20 @@ bool HcaluLUTTPGCoder::getMSB(const HcalDetId& id, int adc) const{
   return (lut.at(adc) & QIE8_LUT_MSB);
 }
 
+void HcaluLUTTPGCoder::lookupMSB(const QIE10DataFrame& df, std::vector<bool>& msb) const{
+    msb.resize(df.samples());
+    int lutId = getLUTId(HcalDetId(df.id()));
+    const Lut& lut = inputLUT_.at(lutId);
+    for (int i = 0; i < df.samples(); ++i) {
+	msb[i] = lut.at(df[i].adc()) & QIE10_LUT_MSB;
+    }
+}
+
 void
 HcaluLUTTPGCoder::lookupMSB(const QIE11DataFrame& df, std::vector<std::bitset<2>>& msb) const
 {
    int lutId = getLUTId(HcalDetId(df.id()));
-   const Lut& lut = upgradeQIE11LUT_.at(lutId);
+   const Lut& lut = inputLUT_.at(lutId);
    for (int i = 0; i < df.samples(); ++i) {
       msb[i][0] = lut.at(df[i].adc()) & QIE11_LUT_MSB0;
       msb[i][1] = lut.at(df[i].adc()) & QIE11_LUT_MSB1;

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -210,7 +210,7 @@ void HcaluLUTTPGCoder::updateXML(const char* filename) {
 	  if (!topo_->valid(detid)) continue;
 	  int id = getLUTId(subdet[isub], ieta, iphi, depth);
 	  std::vector<unsigned int>* lut = _xml->getLutFast(detid);
-	  if (lut==0) throw cms::Exception("PROBLEM: No inputLUT_ in xml file for ") << detid << std::endl;
+	  if (lut==nullptr) throw cms::Exception("PROBLEM: No inputLUT_ in xml file for ") << detid << std::endl;
 	  if (lut->size()!=INPUT_LUT_SIZE) throw cms::Exception ("PROBLEM: Wrong inputLUT_ size in xml file for ") << detid << std::endl;
 	  for (unsigned int i=0; i<INPUT_LUT_SIZE; ++i) inputLUT_[id][i] = (LutElement)lut->at(i);
 	}
@@ -225,7 +225,7 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
     
     HcalCalibrations calibrations;
     const HcalLutMetadata *metadata = conditions.getHcalLutMetadata();
-    assert(metadata !=0);
+    assert(metadata !=nullptr);
     float nominalgain_ = metadata->getNominalGain();
 
     std::map<int, float> cosh_ieta;

--- a/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
+++ b/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
@@ -53,6 +53,7 @@ private:
   HcaluLUTTPGCoder* theCoder_;
   bool read_FGLut_, read_Ascii_,read_XML_,LUTGenerationMode_;
   int maskBit_;
+  unsigned int FG_HF_threshold_;
   edm::FileInPath fgfile_,ifilename_;
 };
 
@@ -79,6 +80,7 @@ HcalTPGCoderULUT::HcalTPGCoderULUT(const edm::ParameterSet& iConfig)
     setWhatProduced(this,(dependsOn(&HcalTPGCoderULUT::dbRecordCallback)));
     LUTGenerationMode_ = iConfig.getParameter<bool>("LUTGenerationMode");
     maskBit_ = iConfig.getParameter<int>("MaskBit");
+    FG_HF_threshold_ = iConfig.getParameter<uint32_t>("FG_HF_threshold"); 
   } else {
     ifilename_=iConfig.getParameter<edm::FileInPath>("inputLUTs");
     setWhatProduced(this);
@@ -105,6 +107,7 @@ void HcalTPGCoderULUT::buildCoder(const HcalTopology* topo) {
   } else {
     theCoder_->setLUTGenerationMode(LUTGenerationMode_);
     theCoder_->setMaskBit(maskBit_);
+    theCoder_->setFGHFthreshold(FG_HF_threshold_);
   }  
   coder_=ReturnType(theCoder_);
 }

--- a/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
+++ b/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
@@ -40,7 +40,7 @@
 class HcalTPGCoderULUT : public edm::ESProducer {
 public:
   HcalTPGCoderULUT(const edm::ParameterSet&);
-  ~HcalTPGCoderULUT();
+  ~HcalTPGCoderULUT() override;
      
   typedef std::shared_ptr<HcalTPGCoder> ReturnType;
   void dbRecordCallback(const HcalDbRecord&);
@@ -86,7 +86,7 @@ HcalTPGCoderULUT::HcalTPGCoderULUT(const edm::ParameterSet& iConfig)
     setWhatProduced(this);
   }
 
-  theCoder_=0;
+  theCoder_=nullptr;
 }
 
   
@@ -128,7 +128,7 @@ HcalTPGCoderULUT::~HcalTPGCoderULUT() {
 HcalTPGCoderULUT::ReturnType
 HcalTPGCoderULUT::produce(const HcalTPGRecord& iRecord)
 {
-  if (theCoder_==0) {
+  if (theCoder_==nullptr) {
     edm::ESHandle<HcalTopology> htopo;
     iRecord.getRecord<HcalRecNumberingRecord>().get(htopo);
     const HcalTopology* topo=&(*htopo);
@@ -146,7 +146,7 @@ void HcalTPGCoderULUT::dbRecordCallback(const HcalDbRecord& theRec) {
   theRec.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  if (theCoder_==0) {
+  if (theCoder_==nullptr) {
     buildCoder(topo);
   }
 

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -155,6 +155,7 @@ public:
      IntegerCaloSamples samples;
      QIE10DataFrame digi;
      std::vector<bool> validity;
+     std::vector<bool> fgbit;
   };
   typedef std::map<HcalTrigTowerDetId, std::map<uint32_t, std::array<HFUpgradeDetails, 4>>> HFUpgradeDetailMap;
   HFUpgradeDetailMap theHFUpgradeDetailMap;

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -208,23 +208,32 @@ HcalTriggerPrimitiveAlgo::addSignal(const QIE10DataFrame& frame)
          continue;
       }
 
-      IntegerCaloSamples samples(id, frame.samples());
+      int nsamples=frame.samples();
+
+      IntegerCaloSamples samples(id, nsamples);
       samples.setPresamples(frame.presamples());
       incoder_->adc2Linear(frame, samples);
 
       // Don't add to final collection yet
       // HF PMT veto sum is calculated in analyzerHF()
-      IntegerCaloSamples zero_samples(id, frame.samples());
+      IntegerCaloSamples zero_samples(id, nsamples);
       zero_samples.setPresamples(frame.presamples());
       addSignal(zero_samples);
 
+      std::vector<bool> msb;
+      incoder_->lookupMSB(frame,msb);
+
       auto fid = HcalDetId(frame.id());
       auto& details = theHFUpgradeDetailMap[id][fid.maskDepth()];
-      details[fid.depth() - 1].samples = samples;
-      details[fid.depth() - 1].digi = frame;
-      details[fid.depth() - 1].validity.resize(frame.samples());
-      for (int idx = 0; idx < frame.samples(); ++idx)
-         details[fid.depth() - 1].validity[idx] = validChannel(frame, idx);
+      auto& detail = details[fid.depth()-1];
+      detail.samples = samples;
+      detail.digi = frame;
+      detail.validity.resize(nsamples);
+      detail.fgbit.resize(nsamples);
+      for (int idx = 0; idx < nsamples; ++idx){
+         detail.validity[idx] = validChannel(frame, idx);
+         detail.fgbit[idx] = msb[idx];
+      }
    }
 }
 
@@ -628,7 +637,8 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2017(
 
             for (const auto& detail: details) {
                if (idx < int(detail.digi.size()) and detail.validity[idx] and HcalDetId(detail.digi.id()).ietaAbs() >= FIRST_FINEGRAIN_TOWER) {
-                  finegrain[ibin][1] = finegrain[ibin][1] or (detail.digi[idx].adc() > (int) FG_HF_threshold_);
+                  //finegrain[ibin][1] = finegrain[ibin][1] or (detail.digi[idx].adc() > (int) FG_HF_threshold_);
+                  finegrain[ibin][1] = finegrain[ibin][1] or detail.fgbit[idx];
                }
             }
 

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -220,19 +220,15 @@ HcalTriggerPrimitiveAlgo::addSignal(const QIE10DataFrame& frame)
       zero_samples.setPresamples(frame.presamples());
       addSignal(zero_samples);
 
-      std::vector<bool> msb;
-      incoder_->lookupMSB(frame,msb);
-
       auto fid = HcalDetId(frame.id());
       auto& details = theHFUpgradeDetailMap[id][fid.maskDepth()];
       auto& detail = details[fid.depth()-1];
       detail.samples = samples;
       detail.digi = frame;
       detail.validity.resize(nsamples);
-      detail.fgbit.resize(nsamples);
+      incoder_->lookupMSB(frame, detail.fgbit);
       for (int idx = 0; idx < nsamples; ++idx){
          detail.validity[idx] = validChannel(frame, idx);
-         detail.fgbit[idx] = msb[idx];
       }
    }
 }
@@ -637,7 +633,6 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2017(
 
             for (const auto& detail: details) {
                if (idx < int(detail.digi.size()) and detail.validity[idx] and HcalDetId(detail.digi.id()).ietaAbs() >= FIRST_FINEGRAIN_TOWER) {
-                  //finegrain[ibin][1] = finegrain[ibin][1] or (detail.digi[idx].adc() > (int) FG_HF_threshold_);
                   finegrain[ibin][1] = finegrain[ibin][1] or detail.fgbit[idx];
                }
             }

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cff.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cff.py
@@ -12,6 +12,7 @@ HcalTPGCoderULUT = cms.ESProducer("HcalTPGCoderULUT",
     read_FG_LUTs = cms.bool(False),
     LUTGenerationMode = cms.bool(True),
     MaskBit = cms.int32(0x8000),
+    FG_HF_threshold = cms.uint32(17),
     inputLUTs = cms.FileInPath('CalibCalorimetry/HcalTPGAlgos/data/inputLUTcoder_physics.dat'),
     FGLUTs = cms.FileInPath('CalibCalorimetry/HcalTPGAlgos/data/HBHE_FG_LUT.dat'),
     RCalibFile = cms.FileInPath('CalibCalorimetry/HcalTPGAlgos/data/RecHit-TPG-calib.dat')


### PR DESCRIPTION
The PR includes the following changes:

- use average adc2fC over four CapId's instead of the first one to calculate linearization LUTs.
   This has a small effect on TPs.
- pass HF FG bit threshold through the input LUTs as it's done online
- small cleanup to remove extra LUT arrays.