### PR TITLE
Update track MVA selection cuts and enable phase1-training for pixelPairStep

### DIFF
--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -182,7 +182,7 @@ from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 lowPtQuadStep =  TrackMVAClassifierPrompt.clone(
     src = 'lowPtQuadStepTracks',
     mva = dict(GBRForestLabel = 'MVASelectorLowPtQuadStep_Phase1'),
-    qualityCuts = [-0.65,-0.35,-0.15],
+    qualityCuts = [-0.7,-0.35,-0.15],
 )
 
 # For Phase2PU140

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -220,11 +220,11 @@ lowPtTripletStep.qualityCuts = [-0.6,-0.3,-0.1]
 
 trackingPhase1.toReplaceWith(lowPtTripletStep, lowPtTripletStep.clone(
      mva = dict(GBRForestLabel = 'MVASelectorLowPtTripletStep_Phase1'),
-     qualityCuts = [0.0,0.2,0.4],
+     qualityCuts = [-0.4,0.0,0.3],
 ))
 trackingPhase1QuadProp.toReplaceWith(lowPtTripletStep, lowPtTripletStep.clone(
      mva = dict(GBRForestLabel = 'MVASelectorLowPtTripletStep_Phase1'),
-     qualityCuts = [0.0,0.2,0.4],
+     qualityCuts = [-0.4,0.0,0.3],
 ))
 
 

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -268,6 +268,9 @@ pixelPairStep.src = 'pixelPairStepTracks'
 pixelPairStep.mva.GBRForestLabel = 'MVASelectorIter2_13TeV'
 pixelPairStep.qualityCuts = [-0.2,0.0,0.3]
 
+trackingPhase1.toModify(pixelPairStep, mva=dict(GBRForestLabel = 'MVASelectorPixelPairStep_Phase1'))
+trackingPhase1QuadProp.toModify(pixelPairStep, mva=dict(GBRForestLabel = 'MVASelectorPixelPairStep_Phase1'))
+
 # For LowPU and Phase2PU140
 import RecoTracker.IterativeTracking.LowPtTripletStep_cff
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi


### PR DESCRIPTION
This PR updates the iterative tracking configurations on top of the new training of #20568:
- enable phase1 training for pixelPairStep
- tune cuts (mainly for loose) for lowPtTripletStep and lowPtQuadStep to account the significant changes in the MVA distributions

A preview of the tuning was presented in September 9 RECO meeting
https://indico.cern.ch/event/663391/contributions/2708723/attachments/1520406/2374865/slides_reco_20170908.pdf
demonstrating the improvement of the new lowPtTripletStep training for low pT (400 MeV) muons.

Here are MTV plots for ttbar+PU35 and PU50, and QCD 3000-3500 (noPU)
https://cms-tracking-validation.web.cern.ch/cms-tracking-validation/PR/CMSSW_9_3_0_pre5_PR20568/
separating the effect of #20568 (only new training except for pixelPairStep) and this PR (new training for pixelPairStep and tune cuts)

The main effects are (numbers from ttbar+PU35):
* efficiency in general stays roughly the same
   * improves in lowPt for highPurity (and muons)
   * improves in lowPtTripletStep
* fake rate decreases by ~10 % (~5 % for highPurity, ~15 % for pT > 0.9 GeV)

Here are comparisons with data (legend: black=9_3_0_pre5+#20568+this PR; blue: 9_3_0_pre5+#20568; orange 9_3_0_pre5)
* Single photon run 297227 (matrix test 136.788, 4000 events)
  * http://127.0.0.1:8081/dqm/relval/start?runnr=297227;dataset=/SinglePhoton/CMSSW_9_3_0_pre5-New_training_and_cuts-v13/DQMIO;sampletype=offline_data;filter=all;referencepos=ratiooverlay;referenceshow=all;referencenorm=True;referenceobj1=other%3A%3A/SinglePhoton/CMSSW_9_3_0_pre5-New_training_except_pixelPair-v4_1/DQMIO%3A;referenceobj2=other%3A%3A/SinglePhoton/CMSSW_9_3_0_pre5-Out_of_the_box-v1/DQMIO%3A;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=Tracking/TrackParameters;focus=;zoom=no;
* JetHT run 302131 (as something recent, 2000 events)
  * http://127.0.0.1:8081/dqm/relval/start?runnr=302131;dataset=/JetHT/CMSSW_9_3_0_pre5-New_training_and_cuts-v13/DQMIO;sampletype=offline_data;filter=all;referencepos=ratiooverlay;referenceshow=all;referencenorm=True;referenceobj1=other%3A%3A/JetHT/CMSSW_9_3_0_pre5-New_training_except_pixelPair-v4_1/DQMIO%3A;referenceobj2=other%3A%3A/JetHT/CMSSW_9_3_0_pre5-Out_of_the_box-v1/DQMIO%3A;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=Tracking/TrackParameters;focus=;zoom=no;

(with the ssh tunnel recipe `ssh -L8081:mkdev.cern.ch:8081 lxplus.cern.ch`)

Tested in 9_3_0_pre5 together with the payloads uploaded to CondDB (rebased on top of CMSSW_9_4_X_2017-09-20-2300), expecting changes in phase1 tracking. Needs to be tested with #20568.

@rovere @VinInn @hajohajo