### PR TITLE
Add electrons from HGCAL in the pfCandidate collection

### DIFF
--- a/RecoParticleFlow/Configuration/python/RecoParticleFlow_EventContent_cff.py
+++ b/RecoParticleFlow/Configuration/python/RecoParticleFlow_EventContent_cff.py
@@ -156,7 +156,7 @@ phase2_hgcal.toModify( RecoParticleFlowFEVT, outputCommands = RecoParticleFlowFE
         'keep recoPFClusters_particleFlowClusterHGCalFromMultiCl__*',
         'keep *_particleFlowSuperClusterHGCalFromMultiCl_*_*',
         'keep *_simPFProducer_*_*',
-        'keep *_particleFlowTmpBarrel_*_*',
+        'keep *_particleFlowTmp_*_*'
     ]
 )
 phase2_hgcal.toModify( RecoParticleFlowRECO, outputCommands = RecoParticleFlowRECO.outputCommands + [
@@ -167,7 +167,7 @@ phase2_hgcal.toModify( RecoParticleFlowRECO, outputCommands = RecoParticleFlowRE
   'keep *_particleFlowSuperClusterHGCalFromMultiCl_*_*',
   'keep recoPFBlocks_simPFProducer_*_*',
   'keep recoSuperClusters_simPFProducer_*_*',
-  'keep *_particleFlowTmpBarrel_*_*'
+  'keep *_particleFlowTmp_*_*'
   ] )
 phase2_hgcal.toModify( RecoParticleFlowAOD,  outputCommands = RecoParticleFlowAOD.outputCommands + [
 'keep recoPFRecHits_particleFlowClusterECAL_Cleaned_*',

--- a/RecoParticleFlow/Configuration/python/RecoParticleFlow_EventContent_cff.py
+++ b/RecoParticleFlow/Configuration/python/RecoParticleFlow_EventContent_cff.py
@@ -1,11 +1,11 @@
 # The following comments couldn't be translated into the new config version:
 
 #        "keep recoPFClusters_*_*_*",
-#        "keep recoPFBlocks_*_*_*",	
+#        "keep recoPFBlocks_*_*_*",
 
 import FWCore.ParameterSet.Config as cms
 
-# Full Event content 
+# Full Event content
 RecoParticleFlowFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring(
     'drop CaloTowersSorted_towerMakerPF_*_*',
@@ -21,7 +21,7 @@ RecoParticleFlowFEVT = cms.PSet(
     'keep recoPFRecHits_particleFlowRecHitHF_Cleaned_*',
     'keep recoPFRecHits_particleFlowRecHitPS_Cleaned_*',
     #'keep recoPFClusters_*_*_*',
-    'keep recoPFClusters_particleFlowClusterECAL_*_*',    
+    'keep recoPFClusters_particleFlowClusterECAL_*_*',
     'keep recoPFClusters_particleFlowClusterHCAL_*_*',
     'keep recoPFClusters_particleFlowClusterHO_*_*',
     'keep recoPFClusters_particleFlowClusterHF_*_*',
@@ -31,7 +31,7 @@ RecoParticleFlowFEVT = cms.PSet(
     #'keep recoPFCandidates_*_*_*',
     'keep recoPFCandidates_particleFlowEGamma_*_*',
     'keep recoCaloClusters_particleFlowEGamma_*_*',
-    'keep recoSuperClusters_particleFlowEGamma_*_*',    
+    'keep recoSuperClusters_particleFlowEGamma_*_*',
     'keep recoConversions_particleFlowEGamma_*_*',
     'keep recoPFCandidates_particleFlow_*_*',
     'keep recoPFCandidates_particleFlowTmp_*_*',
@@ -51,7 +51,7 @@ RecoParticleFlowFEVT = cms.PSet(
 # RECO content
 RecoParticleFlowRECO = cms.PSet(
     outputCommands = cms.untracked.vstring(
-    'drop CaloTowersSorted_towerMakerPF_*_*', 
+    'drop CaloTowersSorted_towerMakerPF_*_*',
     #'keep recoPFRecHits_*_Cleaned_*',
     'keep recoPFRecHits_particleFlowClusterECAL_Cleaned_*',
     'keep recoPFRecHits_particleFlowClusterHCAL_Cleaned_*',
@@ -92,8 +92,8 @@ RecoParticleFlowRECO = cms.PSet(
     'keep *_particleFlowTmpPtrs_*_*',
     'keep *_chargedHadronPFTrackIsolation_*_*'
         )
-)    
-    
+)
+
 # AOD content
 RecoParticleFlowAOD = cms.PSet(
     outputCommands = cms.untracked.vstring(
@@ -147,7 +147,7 @@ def _modifyPFEventContentForHGCalFEVT( obj ):
 
 # mods for HGCAL
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-phase2_hgcal.toModify( RecoParticleFlowFEVT, outputCommands = RecoParticleFlowFEVT.outputCommands + [ 
+phase2_hgcal.toModify( RecoParticleFlowFEVT, outputCommands = RecoParticleFlowFEVT.outputCommands + [
         'keep recoPFRecHits_particleFlowClusterECAL__*',
         'keep recoPFRecHits_particleFlowClusterECAL_Cleaned_*',
         'keep recoPFRecHits_particleFlowRecHitHGC__*',
@@ -155,8 +155,7 @@ phase2_hgcal.toModify( RecoParticleFlowFEVT, outputCommands = RecoParticleFlowFE
         'keep recoPFClusters_particleFlowClusterHGCal__*',
         'keep recoPFClusters_particleFlowClusterHGCalFromMultiCl__*',
         'keep *_particleFlowSuperClusterHGCalFromMultiCl_*_*',
-        'keep *_simPFProducer_*_*',
-        'keep *_particleFlowTmp_*_*'
+        'keep *_simPFProducer_*_*'
     ]
 )
 phase2_hgcal.toModify( RecoParticleFlowRECO, outputCommands = RecoParticleFlowRECO.outputCommands + [
@@ -166,8 +165,7 @@ phase2_hgcal.toModify( RecoParticleFlowRECO, outputCommands = RecoParticleFlowRE
   'keep recoPFClusters_particleFlowClusterHGCalFromMultiCl__*',
   'keep *_particleFlowSuperClusterHGCalFromMultiCl_*_*',
   'keep recoPFBlocks_simPFProducer_*_*',
-  'keep recoSuperClusters_simPFProducer_*_*',
-  'keep *_particleFlowTmp_*_*'
+  'keep recoSuperClusters_simPFProducer_*_*'
   ] )
 phase2_hgcal.toModify( RecoParticleFlowAOD,  outputCommands = RecoParticleFlowAOD.outputCommands + [
 'keep recoPFRecHits_particleFlowClusterECAL_Cleaned_*',
@@ -178,18 +176,18 @@ phase2_hgcal.toModify( RecoParticleFlowAOD,  outputCommands = RecoParticleFlowAO
 
 #timing
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
-phase2_timing.toModify( 
-    RecoParticleFlowFEVT, 
+phase2_timing.toModify(
+    RecoParticleFlowFEVT,
     outputCommands = RecoParticleFlowFEVT.outputCommands + [
         'keep *_ecalBarrelClusterFastTimer_*_*'
         ])
-phase2_timing.toModify( 
-    RecoParticleFlowRECO, 
+phase2_timing.toModify(
+    RecoParticleFlowRECO,
     outputCommands = RecoParticleFlowRECO.outputCommands + [
         'keep *_ecalBarrelClusterFastTimer_*_*'
         ])
-phase2_timing.toModify( 
-    RecoParticleFlowAOD, 
+phase2_timing.toModify(
+    RecoParticleFlowAOD,
     outputCommands = RecoParticleFlowAOD.outputCommands + [
         'keep *_ecalBarrelClusterFastTimer_*_*'
         ])

--- a/RecoParticleFlow/PFProducer/plugins/PFLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFLinker.cc
@@ -94,9 +94,6 @@ void PFLinker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       reco::PFCandidate cand(candPtr);
       
       bool isphoton   = cand.particleId() == reco::PFCandidate::gamma && cand.mva_nothing_gamma()>0.;
-      if (cand.particleId() == reco::PFCandidate::gamma)
-          std::cout << "MVA for egamma candidate: " << cand.mva_nothing_gamma() << std::endl;
-          
       bool iselectron = cand.particleId() == reco::PFCandidate::e;
       // PFCandidates may have a valid MuonRef though they are not muons.
       bool hasNonNullMuonRef  = cand.muonRef().isNonnull() && fillMuonRefs_;

--- a/RecoParticleFlow/PFProducer/plugins/PFLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFLinker.cc
@@ -8,37 +8,37 @@
 
 PFLinker::PFLinker(const edm::ParameterSet & iConfig) {
   // vector of InputTag; more than 1 is not for RECO, it is for analysis
-  
+
     std::vector<edm::InputTag> tags  = iConfig.getParameter<std::vector<edm::InputTag> >("PFCandidate");
   for (unsigned int i=0;i<tags.size();++i)
-    inputTagPFCandidates_.push_back(consumes<reco::PFCandidateCollection>(tags[i]));   
-  
+    inputTagPFCandidates_.push_back(consumes<reco::PFCandidateCollection>(tags[i]));
+
 
   inputTagGsfElectrons_=consumes<reco::GsfElectronCollection>(
 	      iConfig.getParameter<edm::InputTag>("GsfElectrons"));
 
   inputTagPhotons_=consumes<reco::PhotonCollection>(iConfig.getParameter<edm::InputTag>("Photons"));
 
-  
+
   muonTag_ = iConfig.getParameter<edm::InputTag>("Muons");
   inputTagMuons_=consumes<reco::MuonCollection>(edm::InputTag(muonTag_.label()));
   inputTagMuonMap_=consumes<reco::MuonToMuonMap>(muonTag_);
-  
-  nameOutputPF_ 
+
+  nameOutputPF_
     = iConfig.getParameter<std::string>("OutputPF");
-  
-  nameOutputElectronsPF_ 
+
+  nameOutputElectronsPF_
     = iConfig.getParameter<std::string>("ValueMapElectrons");
 
-  nameOutputPhotonsPF_ 
+  nameOutputPhotonsPF_
     = iConfig.getParameter<std::string>("ValueMapPhotons");
 
-  producePFCandidates_  
+  producePFCandidates_
     = iConfig.getParameter<bool>("ProducePFCandidates");
 
-  nameOutputMergedPF_ 
-    = iConfig.getParameter<std::string>("ValueMapMerged"); 
-  
+  nameOutputMergedPF_
+    = iConfig.getParameter<std::string>("ValueMapMerged");
+
   fillMuonRefs_
     = iConfig.getParameter<bool>("FillMuonRefs");
 
@@ -63,13 +63,13 @@ PFLinker::PFLinker(const edm::ParameterSet & iConfig) {
 PFLinker::~PFLinker() {;}
 
 void PFLinker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  
+
   auto pfCandidates_p = std::make_unique<reco::PFCandidateCollection>();
-  
+
   edm::Handle<reco::GsfElectronCollection> gsfElectrons;
   iEvent.getByToken(inputTagGsfElectrons_,gsfElectrons);
 
-  std::map<reco::GsfElectronRef,reco::PFCandidatePtr> electronCandidateMap;  
+  std::map<reco::GsfElectronRef,reco::PFCandidatePtr> electronCandidateMap;
 
 
   edm::Handle<reco::PhotonCollection> photons;
@@ -81,34 +81,34 @@ void PFLinker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   if(fillMuonRefs_)
     iEvent.getByToken(inputTagMuonMap_,muonMap);
   std::map<reco::MuonRef,reco::PFCandidatePtr> muonCandidateMap;
-  
+
   unsigned nColPF=inputTagPFCandidates_.size();
-  
+
   edm::Handle<reco::PFCandidateCollection> pfCandidates;
   for(unsigned icol=0;icol<nColPF;++icol) {
     iEvent.getByToken(inputTagPFCandidates_[icol],pfCandidates);
     unsigned ncand=pfCandidates->size();
-    
+
     for( unsigned i=0; i<ncand; ++i) {
       edm::Ptr<reco::PFCandidate> candPtr(pfCandidates,i);
       reco::PFCandidate cand(candPtr);
-      
+
       bool isphoton   = cand.particleId() == reco::PFCandidate::gamma && cand.mva_nothing_gamma()>0.;
       bool iselectron = cand.particleId() == reco::PFCandidate::e;
       // PFCandidates may have a valid MuonRef though they are not muons.
       bool hasNonNullMuonRef  = cand.muonRef().isNonnull() && fillMuonRefs_;
-      
+
       // if not an electron or a photon or a muon just fill the PFCandidate collection
       if ( !(isphoton || iselectron || hasNonNullMuonRef)){pfCandidates_p->push_back(cand); continue;}
-      
-      
+
+
       if (hasNonNullMuonRef) {
 	reco::MuonRef muRef = (*muonMap)[cand.muonRef()];
 	cand.setMuonRef(muRef);
 	muonCandidateMap[muRef] = candPtr;
       }
-                 
-      
+
+
       // if it is an electron. Find the GsfElectron with the same GsfTrack
       if (iselectron) {
 	const reco::GsfTrackRef & gsfTrackRef(cand.gsfTrackRef());
@@ -120,10 +120,10 @@ void PFLinker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	    err << " Problem in PFLinker: no GsfElectron " << std::endl;
 	    edm::LogError("PFLinker") << err.str();
           } else {
-            edm::LogError("PFLinker") 
-              << "Forcing an electron pfCandidate at: " << cand.eta() 
+            LogDebug("PFLinker")
+              << "Forcing an electron pfCandidate at: " << cand.eta()
               << " in HGCAL" << std::endl;
-            pfCandidates_p->push_back(cand);         
+            pfCandidates_p->push_back(cand);
           }
 	  continue; // Watch out ! Continue
 	}
@@ -135,8 +135,8 @@ void PFLinker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
         cand.setDeltaP(electronRef->p4Error(reco::GsfElectron::P4_COMBINATION));
         cand.setP4(electronRef->p4(reco::GsfElectron::P4_COMBINATION));
 	electronCandidateMap[electronRef] = candPtr;
-      }  
-      
+      }
+
       // if it is a photon, find the one with the same PF super-cluster
       if (isphoton) {
 	const reco::SuperClusterRef & scRef(cand.superClusterRef());
@@ -147,61 +147,61 @@ void PFLinker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	  err << " Problem in PFLinker: no Photon " << std::endl;
 	  edm::LogError("PFLinker") << err.str();
 	  continue; // Watch out ! Continue
-	} 
+	}
 	reco::PhotonRef photonRef(photons,itcheck-photons->begin());
 	cand.setPhotonRef(photonRef);
 	cand.setSuperClusterRef(photonRef->superCluster());
-        // update energy information since now it is done post-particleFlowTmp 
+        // update energy information since now it is done post-particleFlowTmp
         cand.setEcalEnergy(photonRef->superCluster()->rawEnergy(),
                            photonRef->getCorrectedEnergy(reco::Photon::regression2));
         cand.setDeltaP(photonRef->getCorrectedEnergyError(reco::Photon::regression2));
         cand.setP4(photonRef->p4(reco::Photon::regression2));
 	photonCandidateMap[photonRef] = candPtr;
-      }      
+      }
 
       pfCandidates_p->push_back(cand);
-    }      
+    }
     // save the PFCandidates and get a valid handle
   }
   const edm::OrphanHandle<reco::PFCandidateCollection> pfCandidateRefProd = (producePFCandidates_) ? iEvent.put(std::move(pfCandidates_p),nameOutputPF_) :
     edm::OrphanHandle<reco::PFCandidateCollection>();
-  
-  
+
+
   // now make the valuemaps
 
-  edm::ValueMap<reco::PFCandidatePtr> pfMapGsfElectrons = fillValueMap<reco::GsfElectronCollection>(iEvent, 
-								nameOutputElectronsPF_, 
-								gsfElectrons, 
+  edm::ValueMap<reco::PFCandidatePtr> pfMapGsfElectrons = fillValueMap<reco::GsfElectronCollection>(iEvent,
+								nameOutputElectronsPF_,
+								gsfElectrons,
 								electronCandidateMap,
 								pfCandidateRefProd);
-  
-  edm::ValueMap<reco::PFCandidatePtr> pfMapPhotons = fillValueMap<reco::PhotonCollection>(iEvent, 
-						      nameOutputPhotonsPF_, 
-						      photons, 
+
+  edm::ValueMap<reco::PFCandidatePtr> pfMapPhotons = fillValueMap<reco::PhotonCollection>(iEvent,
+						      nameOutputPhotonsPF_,
+						      photons,
 						      photonCandidateMap,
 						      pfCandidateRefProd);
-  
+
 
   edm::ValueMap<reco::PFCandidatePtr> pfMapMuons;
 
   if(fillMuonRefs_){
-    edm::Handle<reco::MuonCollection> muons; 
+    edm::Handle<reco::MuonCollection> muons;
     iEvent.getByToken(inputTagMuons_, muons);
-    
-    pfMapMuons = fillValueMap<reco::MuonCollection>(iEvent, 
-						    muonTag_.label(), 
-						    muons, 
+
+    pfMapMuons = fillValueMap<reco::MuonCollection>(iEvent,
+						    muonTag_.label(),
+						    muons,
 						    muonCandidateMap,
 						    pfCandidateRefProd);
   }
-  
+
   auto pfMapMerged = std::make_unique<edm::ValueMap<reco::PFCandidatePtr>>();
   edm::ValueMap<reco::PFCandidatePtr>::Filler pfMapMergedFiller(*pfMapMerged);
-  
+
   *pfMapMerged                   += pfMapGsfElectrons;
   *pfMapMerged                   += pfMapPhotons;
   if(fillMuonRefs_) *pfMapMerged += pfMapMuons;
-  
+
   iEvent.put(std::move(pfMapMerged),nameOutputMergedPF_);
 }
 
@@ -213,12 +213,12 @@ edm::ValueMap<reco::PFCandidatePtr>  PFLinker::fillValueMap(edm::Event & event,
 							    edm::Handle<TYPE>& inputObjCollection,
 							    const std::map<edm::Ref<TYPE>, reco::PFCandidatePtr> & mapToTheCandidate,
 							    const edm::OrphanHandle<reco::PFCandidateCollection> & newPFCandColl) const {
-  
+
   auto pfMap_p = std::make_unique<edm::ValueMap<reco::PFCandidatePtr>>();
   edm::ValueMap<reco::PFCandidatePtr>::Filler filler(*pfMap_p);
-  
-  typedef typename std::map<edm::Ref<TYPE>, reco::PFCandidatePtr>::const_iterator MapTYPE_it; 
-  
+
+  typedef typename std::map<edm::Ref<TYPE>, reco::PFCandidatePtr>::const_iterator MapTYPE_it;
+
   unsigned nObj=inputObjCollection->size();
   std::vector<reco::PFCandidatePtr> values(nObj);
 
@@ -231,8 +231,8 @@ edm::ValueMap<reco::PFCandidatePtr>  PFLinker::fillValueMap(edm::Event & event,
 
     if(itcheck != mapToTheCandidate.end())
       candPtr = producePFCandidates_ ? reco::PFCandidatePtr(newPFCandColl,itcheck->second.key()) : itcheck->second;
-    
-    values[iobj] = candPtr;    
+
+    values[iobj] = candPtr;
   }
 
   filler.insert(inputObjCollection,values.begin(),values.end());

--- a/RecoParticleFlow/PFProducer/plugins/PFLinker.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFLinker.h
@@ -36,9 +36,9 @@ class PFLinker : public edm::stream::EDProducer<> {
 
   explicit PFLinker(const edm::ParameterSet&);
 
-  ~PFLinker();
+  ~PFLinker() override;
   
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
  private:
   template<typename TYPE>
@@ -81,6 +81,8 @@ class PFLinker : public edm::stream::EDProducer<> {
   /// Set muon refs and produce the value map?
   bool fillMuonRefs_;
 
+  /// Put Electrons within HGCAL coming from SimPFProducer
+  bool forceElectronsInHGCAL_;
 };
 
 DEFINE_FWK_MODULE(PFLinker);

--- a/RecoParticleFlow/PFProducer/python/pfLinker_cff.py
+++ b/RecoParticleFlow/PFProducer/python/pfLinker_cff.py
@@ -6,3 +6,6 @@ particleFlow = RecoParticleFlow.PFProducer.pfLinker_cfi.pfLinker.clone()
 particleFlow.PFCandidate = [cms.InputTag("particleFlowTmp")]
 particleFlowPtrs = RecoParticleFlow.PFProducer.particleFlowTmpPtrs_cfi.particleFlowTmpPtrs.clone()
 particleFlowPtrs.src = "particleFlow"
+
+from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
+phase2_hgcal.toModify(particleFlow, forceElectronsInHGCAL = True)

--- a/RecoParticleFlow/PFProducer/python/pfLinker_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/pfLinker_cfi.py
@@ -10,5 +10,6 @@ pfLinker = cms.EDProducer("PFLinker",
                           OutputPF = cms.string(""),
                           ValueMapElectrons = cms.string("electrons"),                              
                           ValueMapPhotons = cms.string("photons"),
-                          ValueMapMerged = cms.string("all")
+                          ValueMapMerged = cms.string("all"),
+                          forceElectronsInHGCAL = cms.bool(False)
                           )


### PR DESCRIPTION
The previously saved collection is created before merging the Barrel and HGCAL-related, sim-driven, components together. The newly saved collection will contain all pfcandidates that should be used to perform physics studies.
This will only affect PhaseII workflows. I expect no regression and very tiny effect on the event size of the final ROOT file.

Also, electrons built within the HGCAL volume were not saved into the particleFlow pfCandidate collection, causing strange effects (artificial MET, missing JETs etc...). Now they are forced into the final collection.

@malgeri, @cseez, @felicepantaleo @kpedro88 

Backport of #20614