### PR TITLE
DetUnitContainer and GeomDetUnit Cleanup

### DIFF
--- a/CalibFormats/SiStripObjects/test/plugins/testSiStripHashedDetId.cc
+++ b/CalibFormats/SiStripObjects/test/plugins/testSiStripHashedDetId.cc
@@ -52,7 +52,7 @@ void testSiStripHashedDetId::initialize( const edm::EventSetup& setup ) {
   // Build list of DetIds
   std::vector<uint32_t> dets;
   dets.reserve(16000);
-  TrackerGeometry::DetUnitContainer::const_iterator iter = geom->detUnits().begin();
+  TrackerGeometry::DetContainer::const_iterator iter = geom->detUnits().begin();
   for( ; iter != geom->detUnits().end(); ++iter ) {
     const auto strip = dynamic_cast<const StripGeomDetUnit*>(*iter);
     if( strip ) {

--- a/CalibMuon/CSCCalibration/test/stubs/CSCIndexerAnalyzer2.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCIndexerAnalyzer2.cc
@@ -115,10 +115,10 @@ void CSCIndexerAnalyzer2::analyze( const edm::Event& iEvent, const edm::EventSet
   int icountAll = 0;
 
   // Iterate over the DetUnits in the CSCGeometry
-  for( CSCGeometry::DetUnitContainer::const_iterator it = pDD->detUnits().begin(); it != pDD->detUnits().end(); ++it ){
+  for( const auto& it : pDD->detUnits()) {
 
     // Check each DetUnit really is a CSC layer
-    auto layer = dynamic_cast<const CSCLayer*>( *it );
+    auto layer = dynamic_cast<const CSCLayer*>( it );
      
     if( layer ) {
       ++icountAll; // how many layers we see

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelDetInfoFileWriter.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelDetInfoFileWriter.cc
@@ -56,7 +56,7 @@ void SiPixelDetInfoFileWriter::beginRun(const edm::Run &run , const edm::EventSe
   
       const PixelGeomDetUnit* mit = dynamic_cast<PixelGeomDetUnit const *>(it);
 
-      if(mit!=0){
+      if(mit!=nullptr){
 	nPixelDets++;
       const PixelTopology & topol = mit->specificTopology();       
       // Get the module sizes.

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelDetInfoFileWriter.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelDetInfoFileWriter.cc
@@ -52,9 +52,9 @@ void SiPixelDetInfoFileWriter::beginRun(const edm::Run &run , const edm::EventSe
     
     int nPixelDets = 0;
 
-    for(TrackerGeometry::DetUnitContainer::const_iterator it = pDD->detUnits().begin(); it != pDD->detUnits().end(); it++){
+    for( const auto& it : pDD->detUnits()) {
   
-      const PixelGeomDetUnit* mit = dynamic_cast<PixelGeomDetUnit const *>(*it);
+      const PixelGeomDetUnit* mit = dynamic_cast<PixelGeomDetUnit const *>(it);
 
       if(mit!=0){
 	nPixelDets++;

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainRandomCalculator.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainRandomCalculator.cc
@@ -70,7 +70,7 @@ void SiStripGainRandomCalculator::algoAnalyze(const edm::Event & event, const ed
     
     for( const auto& it : pDD->detUnits()) {
   
-      if( dynamic_cast<const StripGeomDetUnit*>(it)!=0){
+      if( dynamic_cast<const StripGeomDetUnit*>(it)!=nullptr){
 	uint32_t detid=(it->geographicalId()).rawId();            
 	const StripTopology & p = dynamic_cast<const StripGeomDetUnit*>(it)->specificTopology();
 	unsigned short NAPVs = p.nstrips()/128;

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainRandomCalculator.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainRandomCalculator.cc
@@ -68,11 +68,11 @@ void SiStripGainRandomCalculator::algoAnalyze(const edm::Event & event, const ed
     
     edm::LogInfo("SiStripGainCalculator") <<" There are "<<pDD->detUnits().size() <<" detectors"<<std::endl;
     
-    for(TrackerGeometry::DetUnitContainer::const_iterator it = pDD->detUnits().begin(); it != pDD->detUnits().end(); it++){
+    for( const auto& it : pDD->detUnits()) {
   
-      if( dynamic_cast<const StripGeomDetUnit*>((*it))!=0){
-	uint32_t detid=((*it)->geographicalId()).rawId();            
-	const StripTopology & p = dynamic_cast<const StripGeomDetUnit*>((*it))->specificTopology();
+      if( dynamic_cast<const StripGeomDetUnit*>(it)!=0){
+	uint32_t detid=(it->geographicalId()).rawId();            
+	const StripTopology & p = dynamic_cast<const StripGeomDetUnit*>(it)->specificTopology();
 	unsigned short NAPVs = p.nstrips()/128;
 	if(NAPVs<1 || NAPVs>6 ) {
 	  edm::LogError("SiStripGainCalculator")<<" Problem with Number of strips in detector.. "<< p.nstrips() <<" Exiting program"<<endl;

--- a/CalibTracker/SiStripCommon/plugins/SiStripDetInfoFileWriter.cc
+++ b/CalibTracker/SiStripCommon/plugins/SiStripDetInfoFileWriter.cc
@@ -58,7 +58,7 @@ void SiStripDetInfoFileWriter::beginRun(const edm::Run&, const edm::EventSetup& 
   
       const StripGeomDetUnit* mit = dynamic_cast<StripGeomDetUnit const *>(it);
 
-      if(mit!=0){
+      if(mit!=nullptr){
 
 	uint32_t detid=(mit->geographicalId()).rawId();
 	double stripLength = mit->specificTopology().stripLength();

--- a/CalibTracker/SiStripCommon/plugins/SiStripDetInfoFileWriter.cc
+++ b/CalibTracker/SiStripCommon/plugins/SiStripDetInfoFileWriter.cc
@@ -54,9 +54,9 @@ void SiStripDetInfoFileWriter::beginRun(const edm::Run&, const edm::EventSetup& 
     
     edm::LogInfo("SiStripDetInfoFileWriter") <<" There are "<<pDD->detUnits().size() <<" detectors"<<std::endl;
     
-    for(TrackerGeometry::DetUnitContainer::const_iterator it = pDD->detUnits().begin(); it != pDD->detUnits().end(); it++){
+    for( const auto& it : pDD->detUnits()) {
   
-      const StripGeomDetUnit* mit = dynamic_cast<StripGeomDetUnit const *>(*it);
+      const StripGeomDetUnit* mit = dynamic_cast<StripGeomDetUnit const *>(it);
 
       if(mit!=0){
 

--- a/CalibTracker/SiStripESProducers/plugins/geom/SiStripHashedDetIdESModule.cc
+++ b/CalibTracker/SiStripESProducers/plugins/geom/SiStripHashedDetIdESModule.cc
@@ -39,9 +39,8 @@ SiStripHashedDetId* SiStripHashedDetIdESModule::make( const SiStripHashedDetIdRc
   std::vector<uint32_t> dets;
   dets.reserve(16000);
 
-  TrackerGeometry::DetUnitContainer::const_iterator iter = geom->detUnits().begin();
-  for( ; iter != geom->detUnits().end(); ++iter ) {
-    const auto strip = dynamic_cast<StripGeomDetUnit const*>(*iter);
+  for( const auto& iter : geom->detUnits()) {
+    const auto strip = dynamic_cast<StripGeomDetUnit const*>(iter);
     if ( strip ) { dets.push_back( (strip->geographicalId()).rawId() ); }
   }
   edm::LogVerbatim(mlDqmCommon_)

--- a/CondTools/SiPixel/test/SiPixel2DTemplateDBObjectUploader.cc
+++ b/CondTools/SiPixel/test/SiPixel2DTemplateDBObjectUploader.cc
@@ -119,11 +119,11 @@ SiPixel2DTemplateDBObjectUploader::analyze(const edm::Event& iEvent, const edm::
 	templids[k] = (short) theTemplIds[k];
 	}
 
-	for(TrackerGeometry::DetUnitContainer::const_iterator it = pDD->detUnits().begin(); it != pDD->detUnits().end(); it++){	
-		if( (*it)!=0){
+	for( const auto& it : pDD->detUnits()) {
+		if( it!=0){
 			// Here is the actual looping step over all DetIds:				
-			DetId detid=(*it)->geographicalId();
-                        const DetId detidc = (*it)->geographicalId();
+			DetId detid=it->geographicalId();
+                        const DetId detidc = it->geographicalId();
 
 			unsigned int layer=0, disk=0, side=0, blade=0, panel=0, module=0;
 					

--- a/CondTools/SiPixel/test/SiPixelDynamicInefficiencyReader.cc
+++ b/CondTools/SiPixel/test/SiPixelDynamicInefficiencyReader.cc
@@ -143,9 +143,9 @@ void SiPixelDynamicInefficiencyReader::analyze( const edm::Event& e, const edm::
   double _pu_scale_conf[pu_det];
   unsigned int match=0,mismatch=0,pu_match=0,pu_mismatch=0;
 
-  for(TrackerGeometry::DetUnitContainer::const_iterator it = pDD->detUnits().begin(); it != pDD->detUnits().end(); it++){
-    if( dynamic_cast<PixelGeomDetUnit const*>((*it))==0) continue;
-    const DetId detid=(*it)->geographicalId();
+  for( const auto& it : pDD->detUnits()) {
+    if( dynamic_cast<PixelGeomDetUnit const*>(it)==0) continue;
+    const DetId detid=it->geographicalId();
     double scale_db=1;
 
     //Geom DB factor calculation

--- a/CondTools/SiPixel/test/SiPixelGenErrorDBObjectUploader.cc
+++ b/CondTools/SiPixel/test/SiPixelGenErrorDBObjectUploader.cc
@@ -112,10 +112,10 @@ SiPixelGenErrorDBObjectUploader::analyze(const edm::Event& iEvent, const edm::Ev
 		else {
 			edm::LogInfo("DetUnit Info")<<" There are "<<pDD->detUnits().size()<<" detectors";
 		}
-		for(TrackerGeometry::DetUnitContainer::const_iterator it = pDD->detUnits().begin(); it != pDD->detUnits().end(); it++){
+		for( const auto& it : pDD->detUnits()) {
 			
-			if( dynamic_cast<PixelGeomDetUnit const*>((*it))!=0){
-				DetId detid=(*it)->geographicalId();
+			if( dynamic_cast<PixelGeomDetUnit const*>(it)!=0){
+				DetId detid=it->geographicalId();
 				
 				if(detid.subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel) &&
 					(detid.subdetId() == s_detid || s_detid == 0) ) {

--- a/CondTools/SiPixel/test/SiPixelLorentzAngleDB.cc
+++ b/CondTools/SiPixel/test/SiPixelLorentzAngleDB.cc
@@ -69,11 +69,11 @@ void SiPixelLorentzAngleDB::analyze(const edm::Event& e, const edm::EventSetup& 
 	es.get<TrackerDigiGeometryRecord>().get( pDD );
 	edm::LogInfo("SiPixelLorentzAngle (old)") <<" There are "<<pDD->detUnits().size() <<" detectors (old)"<<std::endl;
 	
-	for(TrackerGeometry::DetUnitContainer::const_iterator it = pDD->detUnits().begin(); it != pDD->detUnits().end(); it++){
+	for( const auto& it : pDD->detUnits()) {
     
-	   if( dynamic_cast<PixelGeomDetUnit const*>((*it))!=0){
-		DetId detid=(*it)->geographicalId();
-                const DetId detidc = (*it)->geographicalId();
+	   if( dynamic_cast<PixelGeomDetUnit const*>(it)!=0){
+		DetId detid=it->geographicalId();
+                const DetId detidc = it->geographicalId();
 			
 		// fill bpix values for LA 
 		if(detid.subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) {

--- a/CondTools/SiPixel/test/SiPixelPerformanceSummaryBuilder.cc
+++ b/CondTools/SiPixel/test/SiPixelPerformanceSummaryBuilder.cc
@@ -31,10 +31,9 @@ void SiPixelPerformanceSummaryBuilder::analyze(const edm::Event& iEvent, const e
   iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
   edm::LogInfo("SiPixelPerformanceSummaryBuilder") << pDD->detUnits().size() <<" detectors" << std::endl;
 
-  for (TrackerGeometry::DetUnitContainer::const_iterator it=pDD->detUnits().begin(); 
-       it!=pDD->detUnits().end(); it++) {
-    if (dynamic_cast<PixelGeomDetUnit const*>((*it))!=0) {
-      detectorModules_.push_back((*it)->geographicalId().rawId());
+  for ( const auto& it : pDD->detUnits()) {
+    if (dynamic_cast<PixelGeomDetUnit const*>(it)!=0) {
+      detectorModules_.push_back(it->geographicalId().rawId());
     }
   }
   edm::LogInfo("Modules") << "detectorModules_.size() = "<< detectorModules_.size();

--- a/CondTools/SiPixel/test/SiPixelTemplateDBObjectUploader.cc
+++ b/CondTools/SiPixel/test/SiPixelTemplateDBObjectUploader.cc
@@ -112,10 +112,10 @@ SiPixelTemplateDBObjectUploader::analyze(const edm::Event& iEvent, const edm::Ev
 		else {
 			edm::LogInfo("DetUnit Info")<<" There are "<<pDD->detUnits().size()<<" detectors";
 		}
-		for(TrackerGeometry::DetUnitContainer::const_iterator it = pDD->detUnits().begin(); it != pDD->detUnits().end(); it++){
+		for( const auto& it : pDD->detUnits()) {
 			
-			if( dynamic_cast<PixelGeomDetUnit const*>((*it))!=0){
-				DetId detid=(*it)->geographicalId();
+			if( dynamic_cast<PixelGeomDetUnit const*>(it)!=0){
+				DetId detid=it->geographicalId();
 				
 				if(detid.subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel) &&
 					(detid.subdetId() == s_detid || s_detid == 0) ) {

--- a/CondTools/SiStrip/plugins/SiStripDetVOffFakeBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripDetVOffFakeBuilder.cc
@@ -32,11 +32,11 @@ void SiStripDetVOffFakeBuilder::initialize( const edm::EventSetup& iSetup ) {
   iSetup.get<TrackerDigiGeometryRecord>().get( pDD );
   edm::LogInfo("SiStripDetVOffFakeBuilder") <<" There are "<<pDD->detUnits().size() <<" detectors"<<std::endl;
   
-  for(TrackerGeometry::DetUnitContainer::const_iterator it = pDD->detUnits().begin(); it != pDD->detUnits().end(); it++){
+  for( const auto& it : pDD->detUnits()) {
   
-    if( dynamic_cast<StripGeomDetUnit const*>((*it))!=0){
-      uint32_t detid=((*it)->geographicalId()).rawId();            
-      const StripTopology& p = dynamic_cast<StripGeomDetUnit const*>((*it))->specificTopology();
+    if( dynamic_cast<StripGeomDetUnit const*>(it)!=0){
+      uint32_t detid=(it->geographicalId()).rawId();            
+      const StripTopology& p = dynamic_cast<StripGeomDetUnit const*>(it)->specificTopology();
       unsigned short Nstrips = p.nstrips();
       if(Nstrips<1 || Nstrips>768 ) {
 	edm::LogError("SiStripDetVOffFakeBuilder")<<" Problem with Number of strips in detector.. "<< p.nstrips() <<" Exiting program"<<endl;

--- a/CondTools/SiStrip/plugins/SiStripDetVOffFakeBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripDetVOffFakeBuilder.cc
@@ -34,7 +34,7 @@ void SiStripDetVOffFakeBuilder::initialize( const edm::EventSetup& iSetup ) {
   
   for( const auto& it : pDD->detUnits()) {
   
-    if( dynamic_cast<StripGeomDetUnit const*>(it)!=0){
+    if( dynamic_cast<StripGeomDetUnit const*>(it)!=nullptr){
       uint32_t detid=(it->geographicalId()).rawId();            
       const StripTopology& p = dynamic_cast<StripGeomDetUnit const*>(it)->specificTopology();
       unsigned short Nstrips = p.nstrips();

--- a/DataFormats/MuonDetId/test/CSCDetIdAnalyzer.cc
+++ b/DataFormats/MuonDetId/test/CSCDetIdAnalyzer.cc
@@ -89,10 +89,10 @@ void CSCDetIdAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup&
    int icountAll = 0;
 
    // Iterate over the DetUnits in the CSCGeometry
-   for( CSCGeometry::DetUnitContainer::const_iterator it = pDD->detUnits().begin(); it != pDD->detUnits().end(); ++it ){
+   for( const auto& it : pDD->detUnits()) {
 
      // Check each DetUnit really is a CSC layer
-     auto layer = dynamic_cast<CSCLayer const*>( *it );
+     auto layer = dynamic_cast<CSCLayer const*>( it );
      
       if( layer ) {
         ++icountAll; // how many layers we see

--- a/DataFormats/MuonDetId/test/CSCDetIdAnalyzer.cc
+++ b/DataFormats/MuonDetId/test/CSCDetIdAnalyzer.cc
@@ -1,6 +1,5 @@
 // Test CSCDetId & CSCIndexer 13.11.2007 ptc
 
-//#include <memory>
 #include <FWCore/Framework/interface/EDAnalyzer.h>
 #include <FWCore/Framework/interface/ESHandle.h>
 #include <FWCore/Framework/interface/EventSetup.h>

--- a/Geometry/CSCGeometry/interface/CSCGeometry.h
+++ b/Geometry/CSCGeometry/interface/CSCGeometry.h
@@ -50,7 +50,7 @@ class CSCGeometry : public TrackingGeometry {
   const DetTypeContainer&  detTypes() const override;
 
   // Return a vector of all GeomDetUnit
-  const DetUnitContainer& detUnits() const override;
+  const DetContainer& detUnits() const override;
 
   // Return a vector of all GeomDet (including all GeomDetUnits)
   const DetContainer& dets() const override;
@@ -62,7 +62,7 @@ class CSCGeometry : public TrackingGeometry {
   const DetIdContainer& detIds() const override;
 
   // Return the pointer to the GeomDetUnit corresponding to a given DetId
-  const GeomDetUnit* idToDetUnit(DetId) const override;
+  const GeomDet* idToDetUnit(DetId) const override;
 
   // Return the pointer to the GeomDet corresponding to a given DetId
   const GeomDet* idToDet(DetId) const override;
@@ -160,7 +160,7 @@ class CSCGeometry : public TrackingGeometry {
   // to save memory.
   DetTypeContainer  theDetTypes;
   DetContainer      theDets;       // all dets (chambers and layers)
-  DetUnitContainer  theDetUnits;   // all layers
+  DetContainer      theDetUnits;   // all layers
   DetIdContainer    theDetIds;
   DetIdContainer    theDetUnitIds;
 

--- a/Geometry/CSCGeometry/src/CSCGeometry.cc
+++ b/Geometry/CSCGeometry/src/CSCGeometry.cc
@@ -66,7 +66,7 @@ const CSCGeometry::DetTypeContainer& CSCGeometry::detTypes() const
 }
 
 
-const CSCGeometry::DetUnitContainer& CSCGeometry::detUnits() const
+const CSCGeometry::DetContainer& CSCGeometry::detUnits() const
 {
   return theDetUnits;
 }
@@ -90,9 +90,9 @@ const CSCGeometry::DetIdContainer& CSCGeometry::detIds() const
 }
 
 
-const GeomDetUnit* CSCGeometry::idToDetUnit(DetId id) const
+const GeomDet* CSCGeometry::idToDetUnit(DetId id) const
 {
-  return dynamic_cast<const GeomDetUnit*>(idToDet(id));
+  return dynamic_cast<const GeomDet*>(idToDet(id));
 }
 
 

--- a/Geometry/CSCGeometry/test/stubs/CSCGeometryAnalyzer.cc
+++ b/Geometry/CSCGeometry/test/stubs/CSCGeometryAnalyzer.cc
@@ -78,12 +78,12 @@ void
    int icount = 0;
 
    // Check the DetUnits
-   for( CSCGeometry::DetUnitContainer::const_iterator it = pDD->detUnits().begin(); it != pDD->detUnits().end(); ++it ){
+   for( const auto& it : pDD->detUnits()) {
 
 
      // Do we really have a CSC layer?
 
-     auto layer = dynamic_cast<CSCLayer const*>( *it );
+     auto layer = dynamic_cast<CSCLayer const*>( it );
      
       if( layer ) {
         ++icount;

--- a/Geometry/CSCGeometry/test/stubs/CSCGeometryOfWires.cc
+++ b/Geometry/CSCGeometry/test/stubs/CSCGeometryOfWires.cc
@@ -71,12 +71,12 @@ void
    int icount = 0;
 
    // Check the DetUnits
-   for( CSCGeometry::DetUnitContainer::const_iterator it = pDD->detUnits().begin(); it != pDD->detUnits().end(); ++it ){
+   for( const auto& it : pDD->detUnits()) {
 
 
      // Do we really have a CSC layer?
 
-     auto layer = dynamic_cast<CSCLayer const*>( *it );
+     auto layer = dynamic_cast<CSCLayer const*>( it );
      
       if( layer ) {
         ++icount;

--- a/Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h
+++ b/Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h
@@ -13,56 +13,56 @@
  *  \author M. Sani
  */
 
-# include <Geometry/CommonDetUnit/interface/TrackingGeometry.h>
+# include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 # include <vector>
-#include <atomic>
+# include <atomic>
 
 class GlobalTrackingGeometry : public TrackingGeometry
 {
-public:
-    /// Constructor
-    GlobalTrackingGeometry(std::vector<const TrackingGeometry*>& geos);
+ public:
 
-    /// Destructor
-    ~GlobalTrackingGeometry() override;  
+  GlobalTrackingGeometry(std::vector<const TrackingGeometry*>& geos);
 
-    // Return a vector of all det types.
-    const DetTypeContainer&  detTypes()         const override;
+  ~GlobalTrackingGeometry() override;  
 
-    // Returm a vector of all GeomDetUnit
-    const DetUnitContainer&  detUnits()         const override;
+  // Return a vector of all det types.
+  const DetTypeContainer&  detTypes() const override;
+  
+  // Returm a vector of all GeomDetUnit
+  const DetContainer& detUnits() const override;
+  
+  // Returm a vector of all GeomDet (including all GeomDetUnits)
+  const DetContainer& dets() const override;
+  
+  // Returm a vector of all GeomDetUnit DetIds
+  const DetIdContainer& detUnitIds() const override;
+  
+  // Returm a vector of all GeomDet DetIds (including those of GeomDetUnits)
+  const DetIdContainer& detIds() const override;
+  
+  // Return the pointer to the GeomDetUnit corresponding to a given DetId
+  const GeomDet* idToDetUnit(DetId) const override;
+  
+  // Return the pointer to the GeomDet corresponding to a given DetId
+  // (valid also for GeomDetUnits)
+  const GeomDet* idToDet(DetId) const override; 
+  
+  /// Return the pointer to the actual geometry for a given DetId
+  const TrackingGeometry* slaveGeometry(DetId id) const;
 
-    // Returm a vector of all GeomDet (including all GeomDetUnits)
-    const DetContainer&      dets()             const override;
+ private:
+  
+  std::vector<const TrackingGeometry*> theGeometries;
 
-    // Returm a vector of all GeomDetUnit DetIds
-    const DetIdContainer&    detUnitIds()       const override;
-
-    // Returm a vector of all GeomDet DetIds (including those of GeomDetUnits)
-    const DetIdContainer&    detIds()           const override;
-
-    // Return the pointer to the GeomDetUnit corresponding to a given DetId
-    const GeomDetUnit*       idToDetUnit(DetId) const override;
-
-    // Return the pointer to the GeomDet corresponding to a given DetId
-    // (valid also for GeomDetUnits)
-    const GeomDet*           idToDet(DetId)     const override; 
-        
-    /// Return the pointer to the actual geometry for a given DetId
-    const TrackingGeometry* slaveGeometry(DetId id) const;
-
-private:
-
-    std::vector<const TrackingGeometry*> theGeometries;
-
-    // The const methods claim to simply return these vectors,
-    // but actually, they'll fill them up the first time they
-    // are called, which is rare (or never).
-    mutable std::atomic<DetTypeContainer*>  theDetTypes;
-    mutable std::atomic<DetUnitContainer*>  theDetUnits;
-    mutable std::atomic<DetContainer*>      theDets;
-    mutable std::atomic<DetIdContainer*>    theDetUnitIds;
-    mutable std::atomic<DetIdContainer*>    theDetIds;
+  // The const methods claim to simply return these vectors,
+  // but actually, they'll fill them up the first time they
+  // are called, which is rare (or never).
+  mutable std::atomic<DetTypeContainer*>  theDetTypes;
+  mutable std::atomic<DetContainer*>      theDetUnits;
+  mutable std::atomic<DetContainer*>      theDets;
+  mutable std::atomic<DetIdContainer*>    theDetUnitIds;
+  mutable std::atomic<DetIdContainer*>    theDetIds;
 };
+
 #endif
 

--- a/Geometry/CommonDetUnit/interface/TrackingGeometry.h
+++ b/Geometry/CommonDetUnit/interface/TrackingGeometry.h
@@ -26,41 +26,36 @@
 class TrackingGeometry
 {
 public:
-  typedef std::vector<GeomDetType const*>          DetTypeContainer;
-  typedef std::vector<GeomDet const*>              DetContainer;
-  typedef std::vector<GeomDetUnit const*>          DetUnitContainer;
-  typedef std::vector<DetId>                 DetIdContainer;
-  typedef  std::unordered_map< unsigned int, GeomDetUnit const*> mapIdToDetUnit;
-  typedef  std::unordered_map< unsigned int, GeomDet const*>     mapIdToDet;
+  using DetTypeContainer = std::vector< const GeomDetType* >;
+  using DetContainer = std::vector< const GeomDet* >;
+  using DetIdContainer = std::vector< DetId >;
+  using mapIdToDetUnit =  std::unordered_map< unsigned int, const GeomDet* >;
+  using mapIdToDet =  std::unordered_map< unsigned int, const GeomDet* >;
 
-  // Default constructor
-  //  virtual TrackingGeometry() {}
-  
   /// Destructor.
   virtual ~TrackingGeometry() {}
   
   /// Return a vector of all det types.
-  virtual const DetTypeContainer&  detTypes()         const = 0;
+  virtual const DetTypeContainer&  detTypes() const = 0;
 
-  /// Returm a vector of all GeomDetUnit
-  virtual const DetUnitContainer&  detUnits()         const = 0;
+  /// Returm a vector of all GeomDet
+  virtual const DetContainer& detUnits() const = 0;
 
   /// Returm a vector of all GeomDet (including all GeomDetUnits)
-  virtual const DetContainer&      dets()             const = 0;
+  virtual const DetContainer& dets() const = 0;
 
   /// Returm a vector of all GeomDetUnit DetIds
-  virtual const DetIdContainer&    detUnitIds()       const = 0;
+  virtual const DetIdContainer& detUnitIds() const = 0;
 
   /// Returm a vector of all GeomDet DetIds (including those of GeomDetUnits)
-  virtual const DetIdContainer&    detIds()           const = 0;
+  virtual const DetIdContainer& detIds() const = 0;
 
   /// Return the pointer to the GeomDetUnit corresponding to a given DetId
-  virtual const GeomDetUnit*       idToDetUnit(DetId) const = 0;
+  virtual const GeomDet* idToDetUnit(DetId) const = 0;
 
   /// Return the pointer to the GeomDet corresponding to a given DetId
   /// (valid also for GeomDetUnits)
-  virtual const GeomDet*           idToDet(DetId)     const = 0; 
-
+  virtual const GeomDet* idToDet(DetId) const = 0;
 };
 
 #endif

--- a/Geometry/CommonDetUnit/src/GlobalTrackingGeometry.cc
+++ b/Geometry/CommonDetUnit/src/GlobalTrackingGeometry.cc
@@ -27,7 +27,7 @@ GlobalTrackingGeometry::~GlobalTrackingGeometry()
     theDetIds = nullptr;
 }
 
-const GeomDetUnit* GlobalTrackingGeometry::idToDetUnit(DetId id) const {
+const GeomDet* GlobalTrackingGeometry::idToDetUnit(DetId id) const {
     
     const TrackingGeometry* tg = slaveGeometry(id);
     
@@ -84,20 +84,20 @@ GlobalTrackingGeometry::detTypes( void ) const
    return *theDetTypes.load(std::memory_order_acquire);
 }
 
-const TrackingGeometry::DetUnitContainer&
+const TrackingGeometry::DetContainer&
 GlobalTrackingGeometry::detUnits( void ) const
 {
    if (!theDetUnits.load(std::memory_order_acquire)) {
-       std::unique_ptr<DetUnitContainer> ptr{new DetUnitContainer()};
+       std::unique_ptr<DetContainer> ptr{new DetContainer()};
        for(auto theGeometrie : theGeometries)
        {
         if( theGeometrie == nullptr ) continue;
-        DetUnitContainer detUnits(theGeometrie->detUnits());
+        DetContainer detUnits(theGeometrie->detUnits());
         if( detUnits.size() + ptr->size() < ptr->capacity()) ptr->resize( detUnits.size() + ptr->size());
         for(auto detUnit : detUnits)
           ptr->emplace_back( detUnit );
        }
-       DetUnitContainer* expect = nullptr;
+       DetContainer* expect = nullptr;
        if(theDetUnits.compare_exchange_strong(expect, ptr.get(), std::memory_order_acq_rel)) {
            ptr.release();
        }

--- a/Geometry/DTGeometry/interface/DTGeometry.h
+++ b/Geometry/DTGeometry/interface/DTGeometry.h
@@ -39,7 +39,7 @@ class DTGeometry : public TrackingGeometry {
     const DetTypeContainer&  detTypes() const override;
 
     // Returm a vector of all GeomDetUnit
-    const DetUnitContainer&  detUnits() const override;
+    const DetContainer&  detUnits() const override;
 
     // Returm a vector of all GeomDet (including all GeomDetUnits)
     const DetContainer& dets() const override;
@@ -51,7 +51,7 @@ class DTGeometry : public TrackingGeometry {
     const DetIdContainer& detIds() const override;
 
     // Return the pointer to the GeomDetUnit corresponding to a given DetId
-    const GeomDetUnit* idToDetUnit(DetId) const override;
+    const GeomDet* idToDetUnit(DetId) const override;
 
     // Return the pointer to the GeomDet corresponding to a given DetId
     const GeomDet* idToDet(DetId) const override;
@@ -112,7 +112,7 @@ class DTGeometry : public TrackingGeometry {
 
     // These are used rarely; they could be computed at runtime 
     // to save memory.
-    DetUnitContainer  theDetUnits;       // all layers
+    DetContainer      theDetUnits;       // all layers
     DetContainer      theDets;           // all chambers, SL, layers
 
     // Replace local static with mutable members

--- a/Geometry/DTGeometry/src/DTGeometry.cc
+++ b/Geometry/DTGeometry/src/DTGeometry.cc
@@ -45,7 +45,7 @@ void DTGeometry::add(DTLayer* l) {
 }
 
 
-const DTGeometry::DetUnitContainer& DTGeometry::detUnits() const{
+const DTGeometry::DetContainer& DTGeometry::detUnits() const{
   return theDetUnits;
 }
 
@@ -67,8 +67,8 @@ const DTGeometry::DetIdContainer& DTGeometry::detIds() const{
 }
 
 
-const GeomDetUnit* DTGeometry::idToDetUnit(DetId id) const{
-  return dynamic_cast<const GeomDetUnit*>(idToDet(id));
+const GeomDet* DTGeometry::idToDetUnit(DetId id) const{
+  return dynamic_cast<const GeomDet*>(idToDet(id));
 }
 
 

--- a/Geometry/DTGeometry/test/DTGeometryAnalyzer.cc
+++ b/Geometry/DTGeometry/test/DTGeometryAnalyzer.cc
@@ -69,16 +69,15 @@ void DTGeometryAnalyzer::analyze( const edm::Event& iEvent,
   cout << "iter " << dashedLine_ << endl;
 
   // check detUnits
-  for(DTGeometry::DetUnitContainer::const_iterator det = pDD->detUnits().begin(); 
-      det != pDD->detUnits().end(); ++det){
+  for( const auto& det : pDD->detUnits()) {
 
-    DetId detId = (*det)->geographicalId();
+    DetId detId = det->geographicalId();
     int id = detId(); // or detId.rawId()
     const GeomDet* gdet_=pDD->idToDet(detId);
     const GeomDetUnit* gdet=pDD->idToDetUnit(detId);
     const DTLayer* lay=dynamic_cast<const DTLayer*>(gdet);
     cout << "GeomDetUnit is of type " << detId.det() << " and raw id = " << id << endl;
-    assert(*det==gdet);
+    assert(det==gdet);
     assert(gdet_==gdet);
     assert(gdet_==lay);
   }

--- a/Geometry/GEMGeometry/interface/GEMEtaPartition.h
+++ b/Geometry/GEMGeometry/interface/GEMEtaPartition.h
@@ -9,7 +9,7 @@
 class StripTopology;
 class GEMEtaPartitionSpecs;
 
-class GEMEtaPartition : public GeomDetUnit
+class GEMEtaPartition : public GeomDet
 {
 public:
   

--- a/Geometry/GEMGeometry/interface/GEMGeometry.h
+++ b/Geometry/GEMGeometry/interface/GEMGeometry.h
@@ -33,20 +33,20 @@ class GEMGeometry : public TrackingGeometry {
   // Return a vector of all det types
   const DetTypeContainer&  detTypes() const override;
 
-  // Return a vector of all GeomDetUnit
-  const DetUnitContainer& detUnits() const override;
+  // Return a vector of all GeomDet
+  const DetContainer& detUnits() const override;
 
   // Return a vector of all GeomDet
   const DetContainer& dets() const override;
   
-  // Return a vector of all GeomDetUnit DetIds
+  // Return a vector of all GeomDet DetIds
   const DetIdContainer& detUnitIds() const override;
 
   // Return a vector of all GeomDet DetIds
   const DetIdContainer& detIds() const override;
 
-  // Return the pointer to the GeomDetUnit corresponding to a given DetId
-  const GeomDetUnit* idToDetUnit(DetId) const override;
+  // Return the pointer to the GeomDet corresponding to a given DetId
+  const GeomDet* idToDetUnit(DetId) const override;
 
   // Return the pointer to the GeomDet corresponding to a given DetId
   const GeomDet* idToDet(DetId) const override;
@@ -109,7 +109,7 @@ class GEMGeometry : public TrackingGeometry {
   void add(const GEMEtaPartition* etaPartition);
 
  private:
-  DetUnitContainer theEtaPartitions;
+  DetContainer theEtaPartitions;
   DetContainer theDets;
   DetTypeContainer theEtaPartitionTypes;
   DetIdContainer theEtaPartitionIds;

--- a/Geometry/GEMGeometry/interface/ME0EtaPartition.h
+++ b/Geometry/GEMGeometry/interface/ME0EtaPartition.h
@@ -8,9 +8,8 @@
 
 class StripTopology;
 class ME0EtaPartitionSpecs;
-//class ME0Chamber;
 
-class ME0EtaPartition : public GeomDetUnit
+class ME0EtaPartition : public GeomDet
 {
 public:
   

--- a/Geometry/GEMGeometry/interface/ME0Geometry.h
+++ b/Geometry/GEMGeometry/interface/ME0Geometry.h
@@ -22,7 +22,7 @@ class ME0Geometry : public TrackingGeometry {
   const DetTypeContainer&  detTypes() const override;
 
   // Return a vector of all GeomDetUnit
-  const DetUnitContainer& detUnits() const override;
+  const DetContainer& detUnits() const override;
 
   // Return a vector of all GeomDet
   const DetContainer& dets() const override;
@@ -34,7 +34,7 @@ class ME0Geometry : public TrackingGeometry {
   const DetIdContainer& detIds() const override;
 
   // Return the pointer to the GeomDetUnit corresponding to a given DetId
-  const GeomDetUnit* idToDetUnit(DetId) const override;
+  const GeomDet* idToDetUnit(DetId) const override;
 
   // Return the pointer to the GeomDet corresponding to a given DetId
   const GeomDet* idToDet(DetId) const override;
@@ -71,7 +71,7 @@ class ME0Geometry : public TrackingGeometry {
   void add(ME0Chamber* chamber);
 
  private:
-  DetUnitContainer theEtaPartitions;
+  DetContainer theEtaPartitions;
   DetTypeContainer theEtaPartitionTypes;
   DetIdContainer   theEtaPartitionIds;
   DetIdContainer   theDetIds;

--- a/Geometry/GEMGeometry/src/GEMEtaPartition.cc
+++ b/Geometry/GEMGeometry/src/GEMEtaPartition.cc
@@ -4,7 +4,7 @@
 
 
 GEMEtaPartition::GEMEtaPartition(GEMDetId id, const BoundPlane::BoundPlanePointer& bp, GEMEtaPartitionSpecs* rrs) :
-  GeomDetUnit(bp), id_(id),specs_(rrs)
+  GeomDet(bp), id_(id),specs_(rrs)
 {
   setDetId(id);
 }

--- a/Geometry/GEMGeometry/src/GEMGeometry.cc
+++ b/Geometry/GEMGeometry/src/GEMGeometry.cc
@@ -14,7 +14,7 @@ const GEMGeometry::DetTypeContainer&  GEMGeometry::detTypes() const{
   return theEtaPartitionTypes;
 }
 
-const GEMGeometry::DetUnitContainer& GEMGeometry::detUnits() const{
+const GEMGeometry::DetContainer& GEMGeometry::detUnits() const{
   return theEtaPartitions;
 }
 
@@ -30,8 +30,8 @@ const GEMGeometry::DetIdContainer& GEMGeometry::detIds() const{
   return theDetIds;
 }
 
-const GeomDetUnit* GEMGeometry::idToDetUnit(DetId id) const{
-  return dynamic_cast<const GeomDetUnit*>(idToDet(id));
+const GeomDet* GEMGeometry::idToDetUnit(DetId id) const{
+  return dynamic_cast<const GeomDet*>(idToDet(id));
 }
 
 
@@ -132,7 +132,7 @@ GEMGeometry::add(const GEMEtaPartition* etaPartition){
   theEtaPartitionIds.emplace_back(etaPartition->geographicalId());
   theDetIds.emplace_back(etaPartition->geographicalId());
   theEtaPartitionTypes.emplace_back(&etaPartition->type());
-  theMap.insert(std::pair<DetId,const GeomDetUnit*>
+  theMap.insert(std::pair<DetId,const GeomDet*>
 		(etaPartition->geographicalId(),etaPartition));
 }
 

--- a/Geometry/GEMGeometry/src/ME0EtaPartition.cc
+++ b/Geometry/GEMGeometry/src/ME0EtaPartition.cc
@@ -4,7 +4,7 @@
 
 
 ME0EtaPartition::ME0EtaPartition(ME0DetId id, const BoundPlane::BoundPlanePointer& bp, ME0EtaPartitionSpecs* rrs) :
-  GeomDetUnit(bp), id_(id),specs_(rrs)
+  GeomDet(bp), id_(id),specs_(rrs)
 {
   setDetId(id);
 }

--- a/Geometry/GEMGeometry/src/ME0Geometry.cc
+++ b/Geometry/GEMGeometry/src/ME0Geometry.cc
@@ -15,7 +15,7 @@ const ME0Geometry::DetTypeContainer&  ME0Geometry::detTypes() const{
 }
 
 
-const ME0Geometry::DetUnitContainer& ME0Geometry::detUnits() const{
+const ME0Geometry::DetContainer& ME0Geometry::detUnits() const{
   return theEtaPartitions;
 }
 
@@ -35,8 +35,8 @@ const ME0Geometry::DetIdContainer& ME0Geometry::detIds() const{
 }
 
 
-const GeomDetUnit* ME0Geometry::idToDetUnit(DetId id) const{
-  return dynamic_cast<const GeomDetUnit*>(idToDet(id));
+const GeomDet* ME0Geometry::idToDetUnit(DetId id) const{
+  return dynamic_cast<const GeomDet*>(idToDet(id));
 }
 
 const GeomDet* ME0Geometry::idToDet(DetId id) const{
@@ -83,7 +83,7 @@ ME0Geometry::add(ME0EtaPartition* etaPartition){
   theDets.emplace_back(etaPartition);
   theDetIds.emplace_back(etaPartition->geographicalId());
   theEtaPartitionTypes.emplace_back(&etaPartition->type());
-  theMap.insert(std::pair<DetId,GeomDetUnit*>
+  theMap.insert(std::pair<DetId,GeomDet*>
 		(etaPartition->geographicalId(),etaPartition));
 }
 
@@ -96,7 +96,7 @@ ME0Geometry::add(ME0Layer* layer){
   theDets.emplace_back(layer);
   theDetIds.emplace_back(layer->geographicalId());
   theEtaPartitionTypes.emplace_back(&layer->type());
-  theMap.insert(std::pair<DetId,GeomDetUnit*>
+  theMap.insert(std::pair<DetId,GeomDet*>
 		(layer->geographicalId(),layer));
 }
 

--- a/Geometry/RPCGeometry/interface/RPCGeometry.h
+++ b/Geometry/RPCGeometry/interface/RPCGeometry.h
@@ -32,7 +32,7 @@ class RPCGeometry : public TrackingGeometry {
   const DetTypeContainer&  detTypes() const override;
 
   // Return a vector of all GeomDetUnit
-  const DetUnitContainer& detUnits() const override;
+  const DetContainer& detUnits() const override;
 
   // Return a vector of all GeomDet
   const DetContainer& dets() const override;
@@ -44,7 +44,7 @@ class RPCGeometry : public TrackingGeometry {
   const DetIdContainer& detIds() const override;
 
   // Return the pointer to the GeomDetUnit corresponding to a given DetId
-  const GeomDetUnit* idToDetUnit(DetId) const override;
+  const GeomDet* idToDetUnit(DetId) const override;
 
   // Return the pointer to the GeomDet corresponding to a given DetId
   const GeomDet* idToDet(DetId) const override;
@@ -71,7 +71,7 @@ class RPCGeometry : public TrackingGeometry {
   void add(RPCChamber* ch);
 
  private:
-  DetUnitContainer theRolls;
+  DetContainer theRolls;
   DetContainer theDets;
   DetTypeContainer theRollTypes;
   DetIdContainer theRollIds;

--- a/Geometry/RPCGeometry/src/RPCGeometry.cc
+++ b/Geometry/RPCGeometry/src/RPCGeometry.cc
@@ -25,7 +25,7 @@ const RPCGeometry::DetTypeContainer&  RPCGeometry::detTypes() const{
 }
 
 
-const RPCGeometry::DetUnitContainer& RPCGeometry::detUnits() const{
+const RPCGeometry::DetContainer& RPCGeometry::detUnits() const{
   return theRolls;
 }
 
@@ -45,8 +45,8 @@ const RPCGeometry::DetIdContainer& RPCGeometry::detIds() const{
 }
 
 
-const GeomDetUnit* RPCGeometry::idToDetUnit(DetId id) const{
-  return dynamic_cast<const GeomDetUnit*>(idToDet(id));
+const GeomDet* RPCGeometry::idToDetUnit(DetId id) const{
+  return dynamic_cast<const GeomDet*>(idToDet(id));
 }
 
 

--- a/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
+++ b/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
@@ -18,7 +18,7 @@ class TrackerGeometry final : public TrackingGeometry {
   friend class TrackerGeomBuilderFromGeometricDet;
 
   void addType(GeomDetType const * p);
-  void addDetUnit(GeomDetUnit const * p);
+  void addDetUnit(GeomDet const * p);
   void addDetUnitId(DetId p);
   void addDet(GeomDet const * p);
   void addDetId(DetId p);
@@ -57,7 +57,7 @@ public:
   ~TrackerGeometry() override ;
 
   const DetTypeContainer&  detTypes()         const override {return theDetTypes;}
-  const DetUnitContainer&  detUnits()         const override {return theDetUnits;}
+  const DetContainer&      detUnits()         const override {return theDetUnits;}
   const DetContainer&      dets()             const override {return theDets;}
   const DetIdContainer&    detUnitIds()       const override {return theDetUnitIds;}
   const DetIdContainer&    detIds()           const override { return theDetIds;}
@@ -98,7 +98,7 @@ private:
   friend class GeometryAligner;
 
   DetTypeContainer  theDetTypes;  // owns the DetTypes
-  DetUnitContainer  theDetUnits;  // they're all also into 'theDets', so we assume 'theDets' owns them
+  DetContainer      theDetUnits;  // they're all also into 'theDets', so we assume 'theDets' owns them
   unsigned int      theOffsetDU[6]; // offsets in the above
   unsigned int      theEndsetDU[6]; // end offsets in the above
   DetContainer      theDets;      // owns *ONLY* the GeomDet * corresponding to GluedDets.

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
@@ -116,9 +116,9 @@ void TrackerGeometry::addType(GeomDetType const * p) {
   theDetTypes.emplace_back(p);  // add to vector
 }
 
-void TrackerGeometry::addDetUnit(GeomDetUnit const * p) {
+void TrackerGeometry::addDetUnit(GeomDet const * p) {
   // set index
-  const_cast<GeomDetUnit *>(p)->setIndex(theDetUnits.size());
+  const_cast<GeomDet *>(p)->setIndex(theDetUnits.size());
   theDetUnits.emplace_back(p);  // add to vector
   theMapUnit.insert(std::make_pair(p->geographicalId().rawId(),p));
 }

--- a/RecoTracker/TkDetLayers/test/TkDetLayersAnalyzer.cc
+++ b/RecoTracker/TkDetLayers/test/TkDetLayersAnalyzer.cc
@@ -157,8 +157,8 @@ TkDetLayersAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& i
   DetTrie trie(0);
 
   {
-    const TrackingGeometry::DetUnitContainer&  modules = pTrackerGeometry->detUnits(); 
-    typedef TrackingGeometry::DetUnitContainer::const_iterator Iter;
+    const TrackingGeometry::DetContainer&  modules = pTrackerGeometry->detUnits(); 
+    typedef TrackingGeometry::DetContainer::const_iterator Iter;
     Iter b=modules.begin();
     Iter e=modules.end();
     Iter last;

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelMCDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelMCDigiWorker.cc
@@ -232,9 +232,9 @@ void DataMixingSiPixelMCDigiWorker::PixelEfficiencies::init_from_db(const edm::E
   std::vector<uint32_t > DetIdmasks = SiPixelDynamicInefficiency->getDetIdmasks();
   
   // Loop on all modules, calculate geometrical scale factors and store in map for easy access
-  for(TrackerGeometry::DetUnitContainer::const_iterator it_module = geom->detUnits().begin(); it_module != geom->detUnits().end(); it_module++) {
-    if( dynamic_cast<PixelGeomDetUnit const*>((*it_module))==nullptr) continue;
-    const DetId detid = (*it_module)->geographicalId();
+  for( const auto& it_module : geom->detUnits()) {
+    if( dynamic_cast<PixelGeomDetUnit const*>(it_module)==nullptr) continue;
+    const DetId detid = it_module->geographicalId();
     uint32_t rawid = detid.rawId();
     PixelGeomFactors[rawid] = 1;
     ColGeomFactors[rawid] = 1;
@@ -249,9 +249,9 @@ void DataMixingSiPixelMCDigiWorker::PixelEfficiencies::init_from_db(const edm::E
   size_t i=0;
   for (auto factor : PUFactors) {
     const DetId db_id = DetId(factor.first);
-    for(TrackerGeometry::DetUnitContainer::const_iterator it_module = geom->detUnits().begin(); it_module != geom->detUnits().end(); it_module++) {
-      if( dynamic_cast<PixelGeomDetUnit const*>((*it_module))==nullptr) continue;
-      const DetId detid = (*it_module)->geographicalId();
+    for( const auto& it_module : geom->detUnits()) {
+      if( dynamic_cast<PixelGeomDetUnit const*>(it_module)==nullptr) continue;
+      const DetId detid = it_module->geographicalId();
       if (!matches(detid, db_id, DetIdmasks)) continue;
       if (iPU.count(detid.rawId())) {
 	throw cms::Exception("Database")<<"Multiple db_ids match to same module in SiPixelDynamicInefficiency DB Object";
@@ -473,12 +473,12 @@ bool DataMixingSiPixelMCDigiWorker::PixelEfficiencies::matches(const DetId& deti
 
     setPileupInfo(ps, bs);
 
-    for(TrackingGeometry::DetUnitContainer::const_iterator iu = pDD->detUnits().begin(); iu != pDD->detUnits().end(); iu ++){
+    for( const auto& iu : pDD->detUnits()) {
       
-      if((*iu)->type().isTrackerPixel()) {
+      if(iu->type().isTrackerPixel()) {
 
 	//
-	const PixelGeomDetUnit* pixdet = dynamic_cast<const PixelGeomDetUnit*>((*iu));
+	const PixelGeomDetUnit* pixdet = dynamic_cast<const PixelGeomDetUnit*>(iu);
 	uint32_t detID = pixdet->geographicalId().rawId();
 
 	// fetch merged hits for this detID

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiStripMCDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiStripMCDigiWorker.cc
@@ -433,9 +433,9 @@ namespace edm
     //Now, do noise, zero suppression, take into account bad channels, etc.
     // This section stolen from SiStripDigitizerAlgorithm
     // must loop over all detIds in the tracker to get all of the noise added properly.
-    for(TrackingGeometry::DetUnitContainer::const_iterator iu = pDD->detUnits().begin(); iu != pDD->detUnits().end(); iu ++){
+    for( const auto& iu : pDD->detUnits()) {
 
-      const StripGeomDetUnit* sgd = dynamic_cast<const StripGeomDetUnit*>((*iu));
+      const StripGeomDetUnit* sgd = dynamic_cast<const StripGeomDetUnit*>(iu);
       if (sgd != nullptr){
 
 	uint32_t detID = sgd->geographicalId().rawId();

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -187,12 +187,12 @@ namespace cms
     // FIX THIS! We only need to clear and (re)fill this map when the geometry type IOV changes.  Use ESWatcher to determine this.
     if(true) { // Replace with ESWatcher 
       detectorUnits.clear();
-      for(TrackingGeometry::DetUnitContainer::const_iterator iu = pDD->detUnits().begin(); iu != pDD->detUnits().end(); ++iu) {
-        unsigned int detId = (*iu)->geographicalId().rawId();
-	if((*iu)->type().isTrackerPixel()) {
-          auto pixdet = dynamic_cast<const PixelGeomDetUnit*>((*iu));
+      for( const auto& iu : pDD->detUnits()) {
+        unsigned int detId = iu->geographicalId().rawId();
+	if(iu->type().isTrackerPixel()) {
+          auto pixdet = dynamic_cast<const PixelGeomDetUnit*>(iu);
           assert(pixdet != nullptr);
-	  if ((*iu)->subDetector()==GeomDetEnumerators::SubDetector::PixelEndcap) { // true ONLY for the phase 0 pixel deetctor
+	  if (iu->subDetector()==GeomDetEnumerators::SubDetector::PixelEndcap) { // true ONLY for the phase 0 pixel deetctor
 	    unsigned int disk = tTopo->layer(detId); // using the generic layer method
 	    //if using pilot blades, then allowing it for current detector only
 	    if ((disk == 3)&&((!pilotBlades)&&(NumberOfEndcapDisks == 2))) continue;
@@ -265,17 +265,17 @@ namespace cms
     }
     _pixeldigialgo->calculateInstlumiFactor(PileupInfo_);   
 
-    for(TrackingGeometry::DetUnitContainer::const_iterator iu = pDD->detUnits().begin(); iu != pDD->detUnits().end(); iu ++){
+    for( const auto& iu : pDD->detUnits()) {
       
-      if((*iu)->type().isTrackerPixel()) {
+      if(iu->type().isTrackerPixel()) {
 
 	//
 
-        edm::DetSet<PixelDigi> collector((*iu)->geographicalId().rawId());
-        edm::DetSet<PixelDigiSimLink> linkcollector((*iu)->geographicalId().rawId());
+        edm::DetSet<PixelDigi> collector(iu->geographicalId().rawId());
+        edm::DetSet<PixelDigiSimLink> linkcollector(iu->geographicalId().rawId());
         
         
-        _pixeldigialgo->digitize(dynamic_cast<const PixelGeomDetUnit*>((*iu)),
+        _pixeldigialgo->digitize(dynamic_cast<const PixelGeomDetUnit*>(iu),
                                  collector.data,
                                  linkcollector.data,
 				 tTopo,

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -501,9 +501,9 @@ void SiPixelDigitizerAlgorithm::PixelEfficiencies::init_from_db(const edm::ESHan
   std::vector<uint32_t > DetIdmasks = SiPixelDynamicInefficiency->getDetIdmasks();
   
   // Loop on all modules, calculate geometrical scale factors and store in map for easy access
-  for(TrackerGeometry::DetUnitContainer::const_iterator it_module = geom->detUnits().begin(); it_module != geom->detUnits().end(); it_module++) {
-    if( dynamic_cast<PixelGeomDetUnit const*>((*it_module))==nullptr) continue;
-    const DetId detid = (*it_module)->geographicalId();
+  for( const auto& it_module : geom->detUnits()) {
+    if( dynamic_cast<PixelGeomDetUnit const*>(it_module)==nullptr) continue;
+    const DetId detid = it_module->geographicalId();
     uint32_t rawid = detid.rawId();
     PixelGeomFactors[rawid] = 1;
     ColGeomFactors[rawid] = 1;
@@ -518,9 +518,9 @@ void SiPixelDigitizerAlgorithm::PixelEfficiencies::init_from_db(const edm::ESHan
   size_t i=0;
   for (auto factor : PUFactors) {
     const DetId db_id = DetId(factor.first);
-    for(TrackerGeometry::DetUnitContainer::const_iterator it_module = geom->detUnits().begin(); it_module != geom->detUnits().end(); it_module++) {
-      if( dynamic_cast<PixelGeomDetUnit const*>((*it_module))==nullptr) continue;
-      const DetId detid = (*it_module)->geographicalId();
+    for( const auto& it_module : geom->detUnits()) {
+      if( dynamic_cast<PixelGeomDetUnit const*>(it_module)==nullptr) continue;
+      const DetId detid = it_module->geographicalId();
       if (!matches(detid, db_id, DetIdmasks)) continue;
       if (iPU.count(detid.rawId())) {
 	throw cms::Exception("Database")<<"Multiple db_ids match to same module in SiPixelDynamicInefficiency DB Object";

--- a/SimTracker/SiStripDigitizer/plugins/DigiSimLinkProducer.cc
+++ b/SimTracker/SiStripDigitizer/plugins/DigiSimLinkProducer.cc
@@ -163,25 +163,25 @@ void DigiSimLinkProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   theDigiLinkVector.reserve(10000);
   theDigiLinkVector.clear();
 
-  for(TrackingGeometry::DetUnitContainer::const_iterator iu = pDD->detUnits().begin(); iu != pDD->detUnits().end(); iu ++){
+  for( const auto& iu : pDD->detUnits()) {
     if(useConfFromDB){
       //apply the cable map _before_ digitization: consider only the detis that are connected 
-      if(theDetIdList.find((*iu)->geographicalId().rawId())==theDetIdList.end())
+      if(theDetIdList.find(iu->geographicalId().rawId())==theDetIdList.end())
         continue;
     }
-    GlobalVector bfield=pSetup->inTesla((*iu)->surface().position());
-    auto sgd = dynamic_cast<StripGeomDetUnit const*>((*iu));
+    GlobalVector bfield=pSetup->inTesla(iu->surface().position());
+    auto sgd = dynamic_cast<StripGeomDetUnit const*>(iu);
     if (sgd != nullptr){
-      edm::DetSet<SiStripDigi> collectorZS((*iu)->geographicalId().rawId());
-      edm::DetSet<SiStripRawDigi> collectorRaw((*iu)->geographicalId().rawId());
-      edm::DetSet<StripDigiSimLink> linkcollector((*iu)->geographicalId().rawId());
-      float langle = (lorentzAngleHandle.isValid()) ? lorentzAngleHandle->getLorentzAngle((*iu)->geographicalId().rawId()) : 0.;
-      theDigiAlgo->run(collectorZS,collectorRaw,SimHitMap[(*iu)->geographicalId().rawId()],sgd,bfield,langle,
+      edm::DetSet<SiStripDigi> collectorZS(iu->geographicalId().rawId());
+      edm::DetSet<SiStripRawDigi> collectorRaw(iu->geographicalId().rawId());
+      edm::DetSet<StripDigiSimLink> linkcollector(iu->geographicalId().rawId());
+      float langle = (lorentzAngleHandle.isValid()) ? lorentzAngleHandle->getLorentzAngle(iu->geographicalId().rawId()) : 0.;
+      theDigiAlgo->run(collectorZS,collectorRaw,SimHitMap[iu->geographicalId().rawId()],sgd,bfield,langle,
 		       gainHandle,thresholdHandle,noiseHandle,pedestalHandle, deadChannelHandle, tTopo, engine);
       if(zeroSuppression){
         if(!collectorZS.data.empty()){
           theDigiVector.push_back(collectorZS);
-          if(!SimHitMap[(*iu)->geographicalId().rawId()].empty()){
+          if(!SimHitMap[iu->geographicalId().rawId()].empty()){
             linkcollector.data = theDigiAlgo->make_link();
             if(!linkcollector.data.empty())
               theDigiLinkVector.push_back(linkcollector);
@@ -190,7 +190,7 @@ void DigiSimLinkProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
       }else{
         if(!collectorRaw.data.empty()){
           theRawDigiVector.push_back(collectorRaw);
-          if(!SimHitMap[(*iu)->geographicalId().rawId()].empty()){
+          if(!SimHitMap[iu->geographicalId().rawId()].empty()){
             linkcollector.data = theDigiAlgo->make_link();
             if(!linkcollector.data.empty())
               theDigiLinkVector.push_back(linkcollector);

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
@@ -200,10 +200,10 @@ void SiStripDigitizer::initializeEvent(edm::Event const& iEvent, edm::EventSetup
   if(changes) { // Replace with ESWatcher
     detectorUnits.clear();
   }
-  for(TrackingGeometry::DetUnitContainer::const_iterator iu = pDD->detUnits().begin(); iu != pDD->detUnits().end(); ++iu) {
-    unsigned int detId = (*iu)->geographicalId().rawId();
-    if((*iu)->type().isTrackerStrip()) {
-      auto stripdet = dynamic_cast<StripGeomDetUnit const*>((*iu));
+  for( const auto& iu : pDD->detUnits()) {
+    unsigned int detId = iu->geographicalId().rawId();
+    if(iu->type().isTrackerStrip()) {
+      auto stripdet = dynamic_cast<StripGeomDetUnit const*>(iu);
       assert(stripdet != nullptr);
       if(changes) { // Replace with ESWatcher
         detectorUnits.insert(std::make_pair(detId, stripdet));
@@ -232,17 +232,17 @@ void SiStripDigitizer::finalizeEvent(edm::Event& iEvent, edm::EventSetup const& 
   theDigiVector.reserve(10000);
   theDigiVector.clear();
 
-  for(TrackingGeometry::DetUnitContainer::const_iterator iu = pDD->detUnits().begin(); iu != pDD->detUnits().end(); iu ++){
+  for( const auto& iu : pDD->detUnits()) {
     if(useConfFromDB){
       //apply the cable map _before_ digitization: consider only the detis that are connected 
-      if(theDetIdList.find((*iu)->geographicalId().rawId())==theDetIdList.end())
+      if(theDetIdList.find(iu->geographicalId().rawId())==theDetIdList.end())
         continue;
     }
-    auto sgd = dynamic_cast<StripGeomDetUnit const*>((*iu));
+    auto sgd = dynamic_cast<StripGeomDetUnit const*>(iu);
     if (sgd != nullptr){
-      edm::DetSet<SiStripDigi> collectorZS((*iu)->geographicalId().rawId());
-      edm::DetSet<SiStripRawDigi> collectorRaw((*iu)->geographicalId().rawId());
-      edm::DetSet<StripDigiSimLink> collectorLink((*iu)->geographicalId().rawId());
+      edm::DetSet<SiStripDigi> collectorZS(iu->geographicalId().rawId());
+      edm::DetSet<SiStripRawDigi> collectorRaw(iu->geographicalId().rawId());
+      edm::DetSet<StripDigiSimLink> collectorLink(iu->geographicalId().rawId());
       theDigiAlgo->digitize(collectorZS,collectorRaw,collectorLink,sgd,
                             gainHandle,thresholdHandle,noiseHandle,pedestalHandle,theAffectedAPVvector,randomEngine(iEvent.streamID()));
       if(zeroSuppression){


### PR DESCRIPTION
* Replace DetUnitContainer with DetContainer since GeomDet is used to define GeomDetUnit
* Apply code checks to modified files

@slava77 - FYI, TrackingGeometry cleanup has been presented here:
https://indico.cern.ch/event/648883/contributions/2638075/attachments/1486221/2308006/Geometry_Reco_Development_2017.pdf