### PR TITLE
Remove GENREFLEX_FAILES_ON_WARNS flag as it has been fixed in root

### DIFF
--- a/DataFormats/TestObjects/BuildFile.xml
+++ b/DataFormats/TestObjects/BuildFile.xml
@@ -1,5 +1,4 @@
 <use   name="DataFormats/Common"/>
-<flags GENREFLEX_FAILES_ON_WARNS="0"/>
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
This flag was added to avoid build error as root 6.10 did not have autoload of variadic templates support. Latest update of root 6.10 now support it so no need have this flag in our BuildFile.