### PR TITLE
Properly compute PFRecHit position for HGCAL

### DIFF
--- a/Geometry/CaloGeometry/interface/CaloCellGeometry.h
+++ b/Geometry/CaloGeometry/interface/CaloCellGeometry.h
@@ -81,7 +81,7 @@ public:
 
   
   /// Returns the position of reference for this cell 
-  const GlobalPoint& getPosition() const {return m_refPoint;}
+  virtual const GlobalPoint& getPosition() const {return m_refPoint;}
   const GlobalPoint& getBackPoint() const {return m_backPoint;} 
 
   RhoEtaPhi const & repPos() const { return m_rep;}

--- a/Geometry/CaloGeometry/interface/CaloCellGeometryHGCALAdapter.h
+++ b/Geometry/CaloGeometry/interface/CaloCellGeometryHGCALAdapter.h
@@ -1,0 +1,16 @@
+#ifndef GeometryCaloCellGeometryHGCALAdapter
+#define GeometryCaloCellGeometryHGCALAdapter
+
+#include "Geometry/CaloGeometry/interface/FlatTrd.h"
+
+class CaloCellGeometryHGCALAdapter : public FlatTrd {
+public:
+  explicit CaloCellGeometryHGCALAdapter (const FlatTrd * f, GlobalPoint p) : FlatTrd(*f), position_(p) {}
+  CaloCellGeometryHGCALAdapter(const CaloCellGeometryHGCALAdapter&) = delete;
+  CaloCellGeometryHGCALAdapter operator=(const CaloCellGeometryHGCALAdapter &) = delete;
+  const GlobalPoint& getPosition() const override {return position_;}
+private:
+  GlobalPoint position_;
+};
+
+#endif

--- a/Geometry/CaloGeometry/interface/FlatTrd.h
+++ b/Geometry/CaloGeometry/interface/FlatTrd.h
@@ -16,7 +16,7 @@
    
 */
 
-class FlatTrd  final : public CaloCellGeometry {
+class FlatTrd : public CaloCellGeometry {
 public:
 
   typedef CaloCellGeometry::CCGFloat CCGFloat ;
@@ -43,7 +43,7 @@ public:
 
   ~FlatTrd() override ;
   
-  virtual const GlobalPoint& getPosition() const { return m_global; }
+  const GlobalPoint& getPosition() const override { return m_global; }
   GlobalPoint getPosition( const Pt3D& local ) const;
   virtual float etaPos() const { return m_global.eta(); }
   virtual float phiPos() const { return m_global.phi(); }

--- a/Geometry/CaloGeometry/src/CaloCellGeometryHGCALAdapter.cc
+++ b/Geometry/CaloGeometry/src/CaloCellGeometryHGCALAdapter.cc
@@ -1,0 +1,1 @@
+#include "Geometry/CaloGeometry/interface/CaloCellGeometryHGCALAdapter.h"


### PR DESCRIPTION
The current CaloGeometry of HGCAL is not capable of handling
the full granularity of the detector. Hence, for all the
detids belonging to the same wafer, the mid position of the
wafer is returned, instead of the more accurate pad's
position. This PR introduces a small adapter for the HGCAL
CaloCell that internally stores the correct position for
each pad and returns it via the usual interface. No changes
are required anywhere in the code except for the code
responsible to import HGCAL RecHit as PFRecHits. This is a
hack that will disappear as soon as a proper CaloGeometry
for the HGCAL detector is in place.

Forward port of #20630 