### PR TITLE
Adding subjet gen jets

### DIFF
--- a/CommonTools/RecoAlgos/plugins/JetConstituentSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/JetConstituentSelector.cc
@@ -17,6 +17,7 @@
 #include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/JetReco/interface/GenJet.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/JetReco/interface/CaloJet.h"
@@ -85,9 +86,11 @@ private:
 };
 
 using PFJetConstituentSelector = JetConstituentSelector<reco::PFJet>;
+using GenJetConstituentSelector = JetConstituentSelector<reco::GenJet, std::vector<edm::FwdPtr<reco::GenParticle>>>;
 using PatJetConstituentSelector = JetConstituentSelector<pat::Jet, std::vector<edm::FwdPtr<pat::PackedCandidate>>>;
 using MiniAODJetConstituentSelector = JetConstituentSelector<reco::PFJet, std::vector<edm::FwdPtr<pat::PackedCandidate>>>;
 
 DEFINE_FWK_MODULE(PFJetConstituentSelector);
+DEFINE_FWK_MODULE(GenJetConstituentSelector);
 DEFINE_FWK_MODULE(PatJetConstituentSelector);
 DEFINE_FWK_MODULE(MiniAODJetConstituentSelector);

--- a/DataFormats/HepMCCandidate/src/classes.h
+++ b/DataFormats/HepMCCandidate/src/classes.h
@@ -5,6 +5,7 @@
 #include "DataFormats/Common/interface/RefVectorHolder.h"
 #include "DataFormats/Common/interface/VectorHolder.h"
 #include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/Common/interface/FwdPtr.h"
 #include "DataFormats/HepMCCandidate/interface/PdfInfo.h"
 #include "DataFormats/HepMCCandidate/interface/FlavorHistory.h"
 #include "DataFormats/HepMCCandidate/interface/FlavorHistoryEvent.h"
@@ -40,6 +41,10 @@ namespace DataFormats_HepMCCandidate {
     edm::RefVectorIterator<std::vector<reco::GenParticle>,reco::GenParticle,edm::refhelper::FindUsingAdvance<std::vector<reco::GenParticle>,reco::GenParticle> > rvigp;
     edm::ValueMap<edm::Ref<std::vector<reco::GenParticle>,reco::GenParticle,edm::refhelper::FindUsingAdvance<std::vector<reco::GenParticle>,reco::GenParticle> > > vmgr;
     edm::Wrapper<edm::ValueMap<edm::Ref<std::vector<reco::GenParticle>,reco::GenParticle,edm::refhelper::FindUsingAdvance<std::vector<reco::GenParticle>,reco::GenParticle> > > > wvmgr;
+    edm::Ptr<reco::GenParticle> gpptr;
+    edm::FwdPtr<reco::GenParticle> gpfp;
+    std::vector<edm::FwdPtr<reco::GenParticle>> vgpfp;
+    edm::Wrapper<std::vector<edm::FwdPtr<reco::GenParticle>>> wvgpfp;    
   };
 }
 

--- a/DataFormats/HepMCCandidate/src/classes_def.xml
+++ b/DataFormats/HepMCCandidate/src/classes_def.xml
@@ -11,12 +11,17 @@
   <class name="edm::Association<std::vector<reco::GenParticle> >" />
   <class name="edm::Wrapper<edm::Association<std::vector<reco::GenParticle> > >" />
 
+
   <class name="reco::GenParticleRef" />
   <class name="reco::GenParticleRefProd" />
   <class name="reco::GenParticleRefVector" />
   <class name="std::vector<std::vector<reco::GenParticleRef> >"/>
   <class name="std::vector<reco::GenParticleRef>" />
   <class name="edm::Wrapper<reco::GenParticleRefVector>" />
+  <class name="edm::Ptr<reco::GenParticle>" />
+  <class name="edm::FwdPtr<reco::GenParticle>" />
+  <class name="std::vector<edm::FwdPtr<reco::GenParticle> >" />
+  <class name="edm::Wrapper<std::vector<edm::FwdPtr<reco::GenParticle> > >" />  
   <class name="edm::reftobase::Holder<reco::Candidate, reco::GenParticleRef>" />
   <class name="edm::reftobase::RefHolder<reco::GenParticleRef>" />
   <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::GenParticleRefVector>" />

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -416,6 +416,10 @@
   <class name="edm::Wrapper<edm::FwdPtr<pat::PackedCandidate> >" />
   <class name="edm::Wrapper<std::vector<edm::FwdPtr<pat::PackedCandidate> > >" />
 
+  <class name="edm::FwdPtr<pat::PackedGenParticle>" />
+  <class name="std::vector<edm::FwdPtr<pat::PackedGenParticle> >" />
+  <class name="edm::Wrapper<edm::FwdPtr<pat::PackedGenParticle> >" />
+  <class name="edm::Wrapper<std::vector<edm::FwdPtr<pat::PackedGenParticle> > >" />
 
   <!-- PAT Object Collections -->
   <class name="std::vector<pat::Electron>" />

--- a/DataFormats/PatCandidates/src/classes_objects.h
+++ b/DataFormats/PatCandidates/src/classes_objects.h
@@ -175,6 +175,12 @@ namespace DataFormats_PatCandidates {
   std::vector< edm::FwdPtr<pat::PackedCandidate> > v_fwdptr_pc;
   edm::Wrapper< std::vector< edm::FwdPtr<pat::PackedCandidate> > > wv_fwdptr_pc;
 
+  edm::FwdPtr<pat::PackedGenParticle> fwdptr_pgp;
+  edm::Wrapper< edm::FwdPtr<pat::PackedGenParticle> > w_fwdptr_pgp;
+  std::vector< edm::FwdPtr<pat::PackedGenParticle> > v_fwdptr_pgp;
+  edm::Wrapper< std::vector< edm::FwdPtr<pat::PackedGenParticle> > > wv_fwdptr_pgp;
+
+    
   edm::Wrapper<edm::Association<pat::PackedCandidateCollection > > w_asso_pc;
   edm::Wrapper<edm::Association<reco::PFCandidateCollection > >    w_asso_pfc;
   edm::Wrapper<edm::Association<std::vector<pat::PackedGenParticle> > > asso_pgp;

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -90,6 +90,7 @@ MicroEventContentGEN = cms.PSet(
         'keep *_slimmedGenJetsFlavourInfos_*_*',
         'keep *_slimmedGenJets__*',
         'keep *_slimmedGenJetsAK8__*',
+        'keep *_slimmedGenJetsAK8SoftDropSubJets__*',
         'keep *_genMetTrue_*_*',
         # RUN
         'keep LHERunInfoProduct_*_*_*',

--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -15,12 +15,24 @@ def applySubstructure( process, postfix="" ) :
     # Configure the RECO jets
     from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJetsPuppi
     from RecoJets.JetProducers.ak8PFJets_cfi import ak8PFJetsPuppi, ak8PFJetsPuppiSoftDrop, ak8PFJetsPuppiConstituents, ak8PFJetsCHSConstituents
+    from RecoJets.JetProducers.ak8GenJets_cfi import ak8GenJets, ak8GenJetsSoftDrop, ak8GenJetsConstituents
     addToProcessAndTask('ak4PFJetsPuppi'+postfix,ak4PFJetsPuppi.clone(), process, task)
     addToProcessAndTask('ak8PFJetsPuppi'+postfix,ak8PFJetsPuppi.clone(), process, task)
     addToProcessAndTask('ak8PFJetsPuppiConstituents', ak8PFJetsPuppiConstituents.clone(cut = cms.string('pt > 170.0 && abs(rapidity()) < 2.4') ), process, task )
     addToProcessAndTask('ak8PFJetsCHSConstituents', ak8PFJetsCHSConstituents.clone(), process, task )
     addToProcessAndTask('ak8PFJetsPuppiSoftDrop'+postfix, ak8PFJetsPuppiSoftDrop.clone( src = cms.InputTag('ak8PFJetsPuppiConstituents', 'constituents') ), process, task)
-
+    addToProcessAndTask('ak8GenJetsNoNuConstituents'+postfix, ak8GenJetsConstituents.clone(src='ak8GenJetsNoNu'), process, task )
+    addToProcessAndTask('ak8GenJetsNoNuSoftDrop'+postfix,ak8GenJetsSoftDrop.clone(src=cms.InputTag('ak8GenJetsNoNuConstituents'+postfix, 'constituents')),process,task)
+    addToProcessAndTask('slimmedGenJetsAK8SoftDropSubJets'+postfix,
+                            cms.EDProducer("PATGenJetSlimmer",
+                                               src = cms.InputTag("ak8GenJetsNoNuSoftDrop"+postfix, "SubJets"),
+                                               packedGenParticles = cms.InputTag("packedGenParticles"),
+                                               cut = cms.string(""),
+                                               clearDaughters = cms.bool(False), #False means rekeying
+                                               dropSpecific = cms.bool(True),  # Save space
+                                               ), process, task )
+    
+    
     #add AK8 CHS
     addJetCollection(process, postfix=postfix, labelName = 'AK8',
                      jetSource = cms.InputTag('ak8PFJetsCHS'+postfix),
@@ -81,6 +93,7 @@ def applySubstructure( process, postfix="" ) :
         labelName = 'AK8PFPuppiSoftDrop' + postfix,
         jetSource = cms.InputTag('ak8PFJetsPuppiSoftDrop'+postfix),
         btagDiscriminators = ['None'],
+        genJetCollection = cms.InputTag('slimmedGenJetsAK8'), 
         jetCorrections = ('AK8PFPuppi', ['L2Relative', 'L3Absolute'], 'None'),
         getJetMCFlavour = False # jet flavor disabled
     )
@@ -96,7 +109,7 @@ def applySubstructure( process, postfix="" ) :
         jetCorrections = ('AK4PFPuppi', ['L2Relative', 'L3Absolute'], 'None'),
         explicitJTA = True,  # needed for subjet b tagging
         svClustering = True, # needed for subjet b tagging
-        genJetCollection = cms.InputTag('slimmedGenJets'), 
+        genJetCollection = cms.InputTag('slimmedGenJetsAK8SoftDropSubJets'), 
         fatJets=cms.InputTag('ak8PFJetsPuppi'),             # needed for subjet flavor clustering
         groomedFatJets=cms.InputTag('ak8PFJetsPuppiSoftDrop') # needed for subjet flavor clustering
     )

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -240,7 +240,7 @@ VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig) {
 		fjRangeDef_ = RangeDefPtr( new fastjet::RangeDefinition(rhoEtaMax_) );
 	} 
 
-	if( ( doFastJetNonUniform_ ) && ( puCenters_.size() == 0 ) ) 
+	if( ( doFastJetNonUniform_ ) && ( puCenters_.empty() ) ) 
 		throw cms::Exception("doFastJetNonUniform") << "Parameter puCenters for doFastJetNonUniform is not defined." << std::endl;
   
         // make the "produces" statements
@@ -289,7 +289,7 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
     LogDebug("VirtualJetProducer") << "Adding PV info\n";
     edm::Handle<reco::VertexCollection> pvCollection;
     iEvent.getByToken(input_vertex_token_ , pvCollection);
-    if (pvCollection->size()>0) vertex_=pvCollection->begin()->position();
+    if (!pvCollection->empty()) vertex_=pvCollection->begin()->position();
   }
 
   // For Pileup subtraction using offset correction:
@@ -314,7 +314,7 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
   
   bool isView = iEvent.getByToken(input_candidateview_token_, inputsHandle);
   if ( isView ) {
-    if ( inputsHandle->size() == 0) {
+    if ( inputsHandle->empty()) {
       output( iEvent, iSetup );
       return;
     }
@@ -328,7 +328,7 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
     bool isGenFwdPtr = iEvent.getByToken(input_packedgencandidatefwdptr_token_, packedgeninputsHandleAsFwdPtr);
     
     if ( isPF ) {
-      if ( pfinputsHandleAsFwdPtr->size() == 0) {
+      if ( pfinputsHandleAsFwdPtr->empty()) {
 	output( iEvent, iSetup );
 	return;
       }
@@ -341,7 +341,7 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
 	}
       }
     } else if ( isPFFwdPtr ) {
-      if ( packedinputsHandleAsFwdPtr->size() == 0) {
+      if ( packedinputsHandleAsFwdPtr->empty()) {
 	output( iEvent, iSetup );
 	return;
       }
@@ -354,7 +354,7 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
 	}
       }
     } else if ( isGen ) {
-      if ( geninputsHandleAsFwdPtr->size() == 0) {
+      if ( geninputsHandleAsFwdPtr->empty()) {
 	output( iEvent, iSetup );
 	return;
       }
@@ -367,7 +367,7 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
 	}
       }
     } else if ( isGenFwdPtr ) {
-      if ( geninputsHandleAsFwdPtr->size() == 0) {
+      if ( geninputsHandleAsFwdPtr->empty()) {
 	output( iEvent, iSetup );
 	return;
       }
@@ -620,7 +620,7 @@ void VirtualJetProducer::writeJets( edm::Event & iEvent, edm::EventSetup const& 
         dynamic_cast<fastjet::ClusterSequenceAreaBase const *> ( &*fjClusterSeq_ );
 
       if (clusterSequenceWithArea ==nullptr ){
-	if (fjJets_.size() > 0) {
+	if (!fjJets_.empty()) {
 	  throw cms::Exception("LogicError")<<"fjClusterSeq is not initialized while inputs are present\n ";
 	}
       } else {
@@ -651,7 +651,7 @@ void VirtualJetProducer::writeJets( edm::Event & iEvent, edm::EventSetup const& 
 	}
       */
       if (clusterSequenceWithArea ==nullptr ){
-	if (fjJets_.size() > 0) {
+	if (!fjJets_.empty()) {
 	  throw cms::Exception("LogicError")<<"fjClusterSeq is not initialized while inputs are present\n ";
 	}
       } else {
@@ -977,7 +977,7 @@ void VirtualJetProducer::writeJetsWithConstituents(  edm::Event & iEvent, edm::E
       reco::CandidatePtr candPtr( constituentHandleAfterPut, *iconst, false );
       i_jetConstituents.push_back( candPtr );
     }
-    if(i_jetConstituents.size()>0) { //only keep jets which have constituents after subtraction
+    if(!i_jetConstituents.empty()) { //only keep jets which have constituents after subtraction
       reco::Particle::Point point(0,0,0);
       reco::PFJet jet;
       reco::writeSpecific(jet,*ip4,point,i_jetConstituents,iSetup);

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.h
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.h
@@ -15,6 +15,7 @@
 #include "DataFormats/JetReco/interface/BasicJet.h"
 #include "DataFormats/JetReco/interface/GenJet.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
 
 #include "DataFormats/JetReco/interface/BasicJetCollection.h"
 
@@ -228,7 +229,9 @@ private:
   edm::EDGetTokenT<reco::CandidateView> input_candidateview_token_;
   edm::EDGetTokenT<std::vector<edm::FwdPtr<reco::PFCandidate> > > input_candidatefwdptr_token_;
   edm::EDGetTokenT<std::vector<edm::FwdPtr<pat::PackedCandidate> > > input_packedcandidatefwdptr_token_;
-
+  edm::EDGetTokenT<std::vector<edm::FwdPtr<reco::GenParticle> > > input_gencandidatefwdptr_token_;
+  edm::EDGetTokenT<std::vector<edm::FwdPtr<pat::PackedGenParticle> > > input_packedgencandidatefwdptr_token_;
+  
  protected:
   edm::EDGetTokenT<reco::VertexCollection> input_vertex_token_;
   

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.h
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.h
@@ -80,7 +80,7 @@ protected:
   //
 public:
   explicit VirtualJetProducer(const edm::ParameterSet& iConfig);
-  virtual ~VirtualJetProducer();
+  ~VirtualJetProducer() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   static void fillDescriptionsFromVirtualJetProducer(edm::ParameterSetDescription& desc);
   
@@ -96,7 +96,7 @@ public:
   // member functions
   //
 public:
-  virtual void  produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  void  produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   std::string   jetType() const { return jetType_; }
   
 protected:

--- a/RecoJets/JetProducers/python/ak8GenJets_cfi.py
+++ b/RecoJets/JetProducers/python/ak8GenJets_cfi.py
@@ -16,3 +16,8 @@ ak8GenJetsSoftDrop = ak8GenJets.clone(
     jetCollInstanceName=cms.string("SubJets"),
     jetPtMin = 100.0
     )
+
+ak8GenJetsConstituents = cms.EDProducer("GenJetConstituentSelector",
+                                          src = cms.InputTag("ak8GenJets"),
+                                          cut = cms.string("pt > 100.0")
+                                         )


### PR DESCRIPTION
JME / SMP / B2G preparation for the nanoAOD:
1. Added soft-dropped subjets from gen jets. This is for nanoAOD to be fully usable for substructure analyses. The CPU time added is negligible (<1 ms/event) because I am not computing the areas for the gen jets (not needed). I also preclustered them with AK8. There is expected to be a small increase in size.

The preclustering required more code than I intended, since, to first order, this is merely a configuration change. However many dictionaries were missing to do the preclustering on GenJets, and the VirtualJetProducer could not understand the vector<FwdPtr<GenParticle>>.


2. Added soft-dropped subjets from gen jets. This is for nanoAOD to be fully usable for substructure analyses. The CPU time added is negligible (<1 ms/event) because I am not computing the areas for the gen jets (not needed). I also preclustered them with AK8. There is expected to be a small increase in size. 

The preclustering required more code than I intended, since, to first order, this is merely a configuration change. However many dictionaries were missing to do the preclustering on GenJets, and the VirtualJetProducer could not understand the ```vector<FwdPtr<GenParticle>>```. 

@arizzi @gpetruc @ahinzmann @clelange  also interested. 