### PR TITLE
Updates to MiniAOD to satisfy JME/SMP/B2G requests for NanoAOD

### DIFF
--- a/CommonTools/RecoAlgos/plugins/JetConstituentSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/JetConstituentSelector.cc
@@ -17,6 +17,7 @@
 #include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/JetReco/interface/GenJet.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/JetReco/interface/CaloJet.h"
@@ -85,9 +86,11 @@ private:
 };
 
 using PFJetConstituentSelector = JetConstituentSelector<reco::PFJet>;
+using GenJetConstituentSelector = JetConstituentSelector<reco::GenJet, std::vector<edm::FwdPtr<reco::GenParticle>>>;
 using PatJetConstituentSelector = JetConstituentSelector<pat::Jet, std::vector<edm::FwdPtr<pat::PackedCandidate>>>;
 using MiniAODJetConstituentSelector = JetConstituentSelector<reco::PFJet, std::vector<edm::FwdPtr<pat::PackedCandidate>>>;
 
 DEFINE_FWK_MODULE(PFJetConstituentSelector);
+DEFINE_FWK_MODULE(GenJetConstituentSelector);
 DEFINE_FWK_MODULE(PatJetConstituentSelector);
 DEFINE_FWK_MODULE(MiniAODJetConstituentSelector);

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -1823,7 +1823,7 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     const TechnicalTriggerWord&  technicalTriggerWordBeforeMaskBx0 = gtReadoutRecord->technicalTriggerWord();
     //const TechnicalTriggerWord&  technicalTriggerWordBeforeMaskBxG = gtReadoutRecord->technicalTriggerWord(1);
     //const TechnicalTriggerWord&  technicalTriggerWordBeforeMaskBxH = gtReadoutRecord->technicalTriggerWord(2);
-    if (m_bitAlgTechTrig_ > -1 && technicalTriggerWordBeforeMaskBx0.size() > 0) {
+    if (m_bitAlgTechTrig_ > -1 && !technicalTriggerWordBeforeMaskBx0.empty()) {
       techTriggerResultBx0 = technicalTriggerWordBeforeMaskBx0.at(m_bitAlgTechTrig_);
       if(techTriggerResultBx0!=0){
 	//techTriggerResultBxE = technicalTriggerWordBeforeMaskBxE.at(m_bitAlgTechTrig_);
@@ -2627,7 +2627,7 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 	  if((*patJets)[ijet].hasSubjets("SoftDropPuppi")){
 	    mnSubJetsSoftDrop=map_of_MEs[DirName+"/"+"nSubJets_SoftDrop"]; if(mnSubJetsSoftDrop && mnSubJetsSoftDrop->getRootObject()) mnSubJetsSoftDrop->Fill((*patJets)[ijet].subjets("SoftDropPuppi").size());
 	  }
-	  if((*patJets)[ijet].hasSubjets("SoftDropPuppi") && (*patJets)[ijet].subjets("SoftDropPuppi").size()>0){
+	  if((*patJets)[ijet].hasSubjets("SoftDropPuppi") && !(*patJets)[ijet].subjets("SoftDropPuppi").empty()){
 	    mSubJet1_SoftDrop_pt=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_pt"]; if(mSubJet1_SoftDrop_pt && mSubJet1_SoftDrop_pt->getRootObject()) mSubJet1_SoftDrop_pt->Fill((*patJets)[ijet].subjets("SoftDropPuppi")[0]->pt());
 	    mSubJet1_SoftDrop_eta=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_eta"]; if(mSubJet1_SoftDrop_eta && mSubJet1_SoftDrop_eta->getRootObject()) mSubJet1_SoftDrop_eta->Fill((*patJets)[ijet].subjets("SoftDropPuppi")[0]->eta());
 	    mSubJet1_SoftDrop_phi=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_phi"]; if(mSubJet1_SoftDrop_phi && mSubJet1_SoftDrop_phi->getRootObject()) mSubJet1_SoftDrop_phi->Fill((*patJets)[ijet].subjets("SoftDropPuppi")[0]->phi());
@@ -2648,7 +2648,7 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 	    if((*patJets)[ijet].hasSubjets("SoftDropPuppi")){
 	      mnSubJetsSoftDrop_boosted=map_of_MEs[DirName+"/"+"nSubJets_SoftDrop_boosted"]; if(mnSubJetsSoftDrop_boosted && mnSubJetsSoftDrop_boosted->getRootObject()) mnSubJetsSoftDrop_boosted->Fill((*patJets)[ijet].subjets("SoftDropPuppi").size());
 	    }
-	    if((*patJets)[ijet].hasSubjets("SoftDropPuppi") && (*patJets)[ijet].subjets("SoftDropPuppi").size()>0){
+	    if((*patJets)[ijet].hasSubjets("SoftDropPuppi") && !(*patJets)[ijet].subjets("SoftDropPuppi").empty()){
 	      mSubJet1_SoftDrop_pt_boosted=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_pt_boosted"]; if(mSubJet1_SoftDrop_pt_boosted && mSubJet1_SoftDrop_pt_boosted->getRootObject()) mSubJet1_SoftDrop_pt_boosted->Fill((*patJets)[ijet].subjets("SoftDropPuppi")[0]->pt());
 	      mSubJet1_SoftDrop_eta_boosted=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_eta_boosted"]; if(mSubJet1_SoftDrop_eta_boosted && mSubJet1_SoftDrop_eta_boosted->getRootObject()) mSubJet1_SoftDrop_eta_boosted->Fill((*patJets)[ijet].subjets("SoftDropPuppi")[0]->eta());
 	      mSubJet1_SoftDrop_phi_boosted=map_of_MEs[DirName+"/"+"SubJet1_SoftDrop_phi_boosted"]; if(mSubJet1_SoftDrop_phi_boosted && mSubJet1_SoftDrop_phi_boosted->getRootObject()) mSubJet1_SoftDrop_phi_boosted->Fill((*patJets)[ijet].subjets("SoftDropPuppi")[0]->phi());
@@ -3199,7 +3199,7 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 	edm::Handle<reco::CaloMETCollection> calometcoll;
 	edm::Handle<reco::PFMETCollection> pfmetcoll;
 	//edm::Handle<pat::METCollection> patmetcoll;
-	const MET *met=NULL;
+	const MET *met=nullptr;
 	if(isCaloJet_){
 	  iEvent.getByToken(caloMetToken_, calometcoll);
 	  if(!calometcoll.isValid()) return;

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -2083,6 +2083,12 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
       }
     }
     if(isMiniAODJet_ && (*patJets)[ijet].isPFJet()){
+
+      // You can't check the jet ID without the specifics. If they were dropped for space savings,
+      // don't monitor this jet. 
+      if ( !(*patJets)[ijet].hasPFSpecific() )
+	continue;
+	  
       pat::strbitset stringbitset=pfjetIDFunctor.getBitTemplate();
       jetpassid = pfjetIDFunctor((*patJets)[ijet],stringbitset);
       if(jetCleaningFlag_){
@@ -2996,11 +3002,7 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 	}//fill quark gluon tagged variables
       }//pfjet 	  
       if(isMiniAODJet_){
-	mCHFrac = map_of_MEs[DirName+"/"+"CHFrac"]; if (mCHFrac && mCHFrac->getRootObject())         mCHFrac ->Fill((*patJets)[ind1].chargedHadronEnergyFraction());
-	mNHFrac = map_of_MEs[DirName+"/"+"NHFrac"]; if (mNHFrac && mNHFrac->getRootObject())         mNHFrac ->Fill((*patJets)[ind1].neutralHadronEnergyFraction());
-	mPhFrac = map_of_MEs[DirName+"/"+"PhFrac"]; if (mPhFrac && mPhFrac->getRootObject())         mPhFrac ->Fill((*patJets)[ind1].neutralEmEnergyFraction());
-	mHFEMFrac = map_of_MEs[DirName+"/"+"HFEMFrac"]; if (mHFEMFrac && mHFEMFrac->getRootObject()) mHFEMFrac ->Fill((*patJets)[ind1].HFEMEnergyFraction());
-	mHFHFrac = map_of_MEs[DirName+"/"+"HFHFrac"]; if (mHFHFrac && mHFHFrac->getRootObject())     mHFHFrac ->Fill((*patJets)[ind1].HFHadronEnergyFraction());
+
 	
 	mJetEnergyCorr = map_of_MEs[DirName+"/"+"JetEnergyCorr"]; if(mJetEnergyCorr && mJetEnergyCorr->getRootObject()) mJetEnergyCorr->Fill(1./(*patJets)[ind1].jecFactor("Uncorrected"));
 	mJetEnergyCorrVSEta = map_of_MEs[DirName+"/"+"JetEnergyCorrVSEta"]; if(mJetEnergyCorrVSEta && mJetEnergyCorrVSEta->getRootObject()) mJetEnergyCorrVSEta->Fill(recoJets[0].eta(),1./(*patJets)[ind1].jecFactor("Uncorrected"));
@@ -3008,45 +3010,55 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 	mJetEnergyCorr = map_of_MEs[DirName+"/"+"JetEnergyCorr"]; if(mJetEnergyCorr && mJetEnergyCorr->getRootObject()) mJetEnergyCorr->Fill(1./(*patJets)[ind2].jecFactor("Uncorrected"));
 	mJetEnergyCorrVSEta = map_of_MEs[DirName+"/"+"JetEnergyCorrVSEta"]; if(mJetEnergyCorrVSEta && mJetEnergyCorrVSEta->getRootObject()) mJetEnergyCorrVSEta->Fill(recoJets[0].eta(),1./(*patJets)[ind2].jecFactor("Uncorrected"));
 	mJetEnergyCorrVSPt = map_of_MEs[DirName+"/"+"JetEnergyCorrVSPt"]; if(mJetEnergyCorrVSPt && mJetEnergyCorrVSPt->getRootObject()) mJetEnergyCorrVSPt->Fill(recoJets[0].pt(),1./(*patJets)[ind2].jecFactor("Uncorrected"));
-	
-	mChargedMultiplicity = map_of_MEs[DirName+"/"+"ChargedMultiplicity"]; if(mChargedMultiplicity && mChargedMultiplicity->getRootObject()) mChargedMultiplicity->Fill((*patJets)[ind1].chargedMultiplicity());
-	mNeutralMultiplicity = map_of_MEs[DirName+"/"+"NeutralMultiplicity"]; if(mNeutralMultiplicity && mNeutralMultiplicity->getRootObject()) mNeutralMultiplicity->Fill((*patJets)[ind1].neutralMultiplicity());
-	mMuonMultiplicity = map_of_MEs[DirName+"/"+"MuonMultiplicity"]; if(mMuonMultiplicity && mMuonMultiplicity->getRootObject())             mMuonMultiplicity->Fill((*patJets)[ind1].muonMultiplicity());
-	//Filling variables for second jet	
-	mCHFrac = map_of_MEs[DirName+"/"+"CHFrac"]; if (mCHFrac && mCHFrac->getRootObject())         mCHFrac ->Fill((*patJets)[ind2].chargedHadronEnergyFraction());
-	mNHFrac = map_of_MEs[DirName+"/"+"NHFrac"]; if (mNHFrac && mNHFrac->getRootObject())         mNHFrac ->Fill((*patJets)[ind2].neutralHadronEnergyFraction());
-	mPhFrac = map_of_MEs[DirName+"/"+"PhFrac"]; if (mPhFrac && mPhFrac->getRootObject())         mPhFrac ->Fill((*patJets)[ind2].neutralEmEnergyFraction());
-	mHFEMFrac = map_of_MEs[DirName+"/"+"HFEMFrac"]; if (mHFEMFrac && mHFEMFrac->getRootObject()) mHFEMFrac ->Fill((*patJets)[ind2].HFEMEnergyFraction());
-	mHFHFrac = map_of_MEs[DirName+"/"+"HFHFrac"]; if (mHFHFrac && mHFHFrac->getRootObject())     mHFHFrac ->Fill((*patJets)[ind2].HFHadronEnergyFraction());
-	
-	mNeutralFraction = map_of_MEs[DirName+"/"+"NeutralConstituentsFraction"];if (mNeutralFraction && mNeutralFraction->getRootObject()) mNeutralFraction->Fill ((double)(*patJets)[ind1].neutralMultiplicity()/(double)(*patJets)[ind1].nConstituents());
-	
-	mChargedMultiplicity = map_of_MEs[DirName+"/"+"ChargedMultiplicity"]; if(mChargedMultiplicity && mChargedMultiplicity->getRootObject()) mChargedMultiplicity->Fill((*patJets)[ind2].chargedMultiplicity());
-	mNeutralMultiplicity = map_of_MEs[DirName+"/"+"NeutralMultiplicity"]; if(mNeutralMultiplicity && mNeutralMultiplicity->getRootObject()) mNeutralMultiplicity->Fill((*patJets)[ind2].neutralMultiplicity());
-	mMuonMultiplicity = map_of_MEs[DirName+"/"+"MuonMultiplicity"]; if(mMuonMultiplicity && mMuonMultiplicity->getRootObject())             mMuonMultiplicity->Fill((*patJets)[ind2].muonMultiplicity());
-	
-	//now fill PATJet profiles for leading jet
-	mCHFrac_profile = map_of_MEs[DirName+"/"+"CHFrac_profile"]; if (mCHFrac_profile && mCHFrac_profile->getRootObject())         mCHFrac_profile ->Fill(numPV, (*patJets)[ind1].chargedHadronEnergyFraction());
-	mNHFrac_profile = map_of_MEs[DirName+"/"+"NHFrac_profile"]; if (mNHFrac_profile && mNHFrac_profile->getRootObject())         mNHFrac_profile ->Fill(numPV, (*patJets)[ind1].neutralHadronEnergyFraction());
-	mPhFrac_profile = map_of_MEs[DirName+"/"+"PhFrac_profile"]; if (mPhFrac_profile && mPhFrac_profile->getRootObject())         mPhFrac_profile ->Fill(numPV, (*patJets)[ind1].neutralEmEnergyFraction());
-	mHFEMFrac_profile = map_of_MEs[DirName+"/"+"HFEMFrac_profile"]; if (mHFEMFrac_profile && mHFEMFrac_profile->getRootObject()) mHFEMFrac_profile ->Fill(numPV, (*patJets)[ind1].HFEMEnergyFraction());
-	mHFHFrac_profile = map_of_MEs[DirName+"/"+"HFHFrac_profile"]; if (mHFHFrac_profile && mHFHFrac_profile->getRootObject())     mHFHFrac_profile ->Fill(numPV, (*patJets)[ind1].HFHadronEnergyFraction());
-	
-	mNeutralFraction = map_of_MEs[DirName+"/"+"NeutralConstituentsFraction"];if (mNeutralFraction && mNeutralFraction->getRootObject()) mNeutralFraction->Fill ((double)(*patJets)[ind2].neutralMultiplicity()/(double)(*patJets)[ind2].nConstituents());
-	
-	mChargedMultiplicity_profile = map_of_MEs[DirName+"/"+"ChargedMultiplicity_profile"]; if(mChargedMultiplicity_profile && mChargedMultiplicity_profile->getRootObject()) mChargedMultiplicity_profile->Fill(numPV, (*patJets)[ind1].chargedMultiplicity());
-	mNeutralMultiplicity_profile = map_of_MEs[DirName+"/"+"NeutralMultiplicity_profile"]; if(mNeutralMultiplicity_profile && mNeutralMultiplicity_profile->getRootObject()) mNeutralMultiplicity_profile->Fill(numPV, (*patJets)[ind1].neutralMultiplicity());
-	mMuonMultiplicity_profile = map_of_MEs[DirName+"/"+"MuonMultiplicity_profile"]; if(mMuonMultiplicity_profile && mMuonMultiplicity_profile->getRootObject())             mMuonMultiplicity->Fill(numPV, (*patJets)[ind1].muonMultiplicity());
-	//now fill PATJet profiles for second leading jet
-	mCHFrac_profile = map_of_MEs[DirName+"/"+"CHFrac_profile"]; if (mCHFrac_profile && mCHFrac_profile->getRootObject())         mCHFrac_profile ->Fill(numPV, (*patJets)[ind2].chargedHadronEnergyFraction());
-	mNHFrac_profile = map_of_MEs[DirName+"/"+"NHFrac_profile"]; if (mNHFrac_profile && mNHFrac_profile->getRootObject())         mNHFrac_profile ->Fill(numPV, (*patJets)[ind2].neutralHadronEnergyFraction());
-	mPhFrac_profile = map_of_MEs[DirName+"/"+"PhFrac_profile"]; if (mPhFrac_profile && mPhFrac_profile->getRootObject())         mPhFrac_profile ->Fill(numPV, (*patJets)[ind2].neutralEmEnergyFraction());
-	mHFEMFrac_profile = map_of_MEs[DirName+"/"+"HFEMFrac_profile"]; if (mHFEMFrac_profile && mHFEMFrac_profile->getRootObject()) mHFEMFrac_profile ->Fill(numPV, (*patJets)[ind2].HFEMEnergyFraction());
-	mHFHFrac_profile = map_of_MEs[DirName+"/"+"HFHFrac_profile"]; if (mHFHFrac_profile && mHFHFrac_profile->getRootObject())     mHFHFrac_profile ->Fill(numPV, (*patJets)[ind2].HFHadronEnergyFraction());
-	
-	mChargedMultiplicity_profile = map_of_MEs[DirName+"/"+"ChargedMultiplicity_profile"]; if(mChargedMultiplicity_profile && mChargedMultiplicity_profile->getRootObject()) mChargedMultiplicity_profile->Fill(numPV, (*patJets)[ind2].chargedMultiplicity());
-	mNeutralMultiplicity_profile = map_of_MEs[DirName+"/"+"NeutralMultiplicity_profile"]; if(mNeutralMultiplicity_profile && mNeutralMultiplicity_profile->getRootObject()) mNeutralMultiplicity_profile->Fill(numPV, (*patJets)[ind2].neutralMultiplicity());
-	mMuonMultiplicity_profile = map_of_MEs[DirName+"/"+"MuonMultiplicity_profile"]; if(mMuonMultiplicity_profile && mMuonMultiplicity_profile->getRootObject())             mMuonMultiplicity_profile->Fill(numPV, (*patJets)[ind2].muonMultiplicity());
+
+	// In MINIAOD, can drop PFSpecifics just to save space, so check they are available. 
+	if ( (*patJets)[ind1].hasPFSpecific() ) {
+	  mCHFrac = map_of_MEs[DirName+"/"+"CHFrac"]; if (mCHFrac && mCHFrac->getRootObject())         mCHFrac ->Fill((*patJets)[ind1].chargedHadronEnergyFraction());
+	  mNHFrac = map_of_MEs[DirName+"/"+"NHFrac"]; if (mNHFrac && mNHFrac->getRootObject())         mNHFrac ->Fill((*patJets)[ind1].neutralHadronEnergyFraction());
+	  mPhFrac = map_of_MEs[DirName+"/"+"PhFrac"]; if (mPhFrac && mPhFrac->getRootObject())         mPhFrac ->Fill((*patJets)[ind1].neutralEmEnergyFraction());
+	  mHFEMFrac = map_of_MEs[DirName+"/"+"HFEMFrac"]; if (mHFEMFrac && mHFEMFrac->getRootObject()) mHFEMFrac ->Fill((*patJets)[ind1].HFEMEnergyFraction());
+	  mHFHFrac = map_of_MEs[DirName+"/"+"HFHFrac"]; if (mHFHFrac && mHFHFrac->getRootObject())     mHFHFrac ->Fill((*patJets)[ind1].HFHadronEnergyFraction());
+	  mChargedMultiplicity = map_of_MEs[DirName+"/"+"ChargedMultiplicity"]; if(mChargedMultiplicity && mChargedMultiplicity->getRootObject()) mChargedMultiplicity->Fill((*patJets)[ind1].chargedMultiplicity());
+	  mNeutralMultiplicity = map_of_MEs[DirName+"/"+"NeutralMultiplicity"]; if(mNeutralMultiplicity && mNeutralMultiplicity->getRootObject()) mNeutralMultiplicity->Fill((*patJets)[ind1].neutralMultiplicity());
+	  mMuonMultiplicity = map_of_MEs[DirName+"/"+"MuonMultiplicity"]; if(mMuonMultiplicity && mMuonMultiplicity->getRootObject())             mMuonMultiplicity->Fill((*patJets)[ind1].muonMultiplicity());
+	  mNeutralFraction = map_of_MEs[DirName+"/"+"NeutralConstituentsFraction"];if (mNeutralFraction && mNeutralFraction->getRootObject()) mNeutralFraction->Fill ((double)(*patJets)[ind1].neutralMultiplicity()/(double)(*patJets)[ind1].nConstituents());
+	  mCHFrac_profile = map_of_MEs[DirName+"/"+"CHFrac_profile"]; if (mCHFrac_profile && mCHFrac_profile->getRootObject())         mCHFrac_profile ->Fill(numPV, (*patJets)[ind1].chargedHadronEnergyFraction());
+	  mNHFrac_profile = map_of_MEs[DirName+"/"+"NHFrac_profile"]; if (mNHFrac_profile && mNHFrac_profile->getRootObject())         mNHFrac_profile ->Fill(numPV, (*patJets)[ind1].neutralHadronEnergyFraction());
+	  mPhFrac_profile = map_of_MEs[DirName+"/"+"PhFrac_profile"]; if (mPhFrac_profile && mPhFrac_profile->getRootObject())         mPhFrac_profile ->Fill(numPV, (*patJets)[ind1].neutralEmEnergyFraction());
+	  mHFEMFrac_profile = map_of_MEs[DirName+"/"+"HFEMFrac_profile"]; if (mHFEMFrac_profile && mHFEMFrac_profile->getRootObject()) mHFEMFrac_profile ->Fill(numPV, (*patJets)[ind1].HFEMEnergyFraction());
+	  mHFHFrac_profile = map_of_MEs[DirName+"/"+"HFHFrac_profile"]; if (mHFHFrac_profile && mHFHFrac_profile->getRootObject())     mHFHFrac_profile ->Fill(numPV, (*patJets)[ind1].HFHadronEnergyFraction());
+	  mChargedMultiplicity_profile = map_of_MEs[DirName+"/"+"ChargedMultiplicity_profile"]; if(mChargedMultiplicity_profile && mChargedMultiplicity_profile->getRootObject()) mChargedMultiplicity_profile->Fill(numPV, (*patJets)[ind1].chargedMultiplicity());
+	  mNeutralMultiplicity_profile = map_of_MEs[DirName+"/"+"NeutralMultiplicity_profile"]; if(mNeutralMultiplicity_profile && mNeutralMultiplicity_profile->getRootObject()) mNeutralMultiplicity_profile->Fill(numPV, (*patJets)[ind1].neutralMultiplicity());
+	  mMuonMultiplicity_profile = map_of_MEs[DirName+"/"+"MuonMultiplicity_profile"]; if(mMuonMultiplicity_profile && mMuonMultiplicity_profile->getRootObject())             mMuonMultiplicity->Fill(numPV, (*patJets)[ind1].muonMultiplicity());
+
+	}
+
+	// In MINIAOD, can drop PFSpecifics just to save space, so check they are available. 
+	//Filling variables for second jet
+	if ( (*patJets)[ind2].hasPFSpecific() ) {
+	  mCHFrac = map_of_MEs[DirName+"/"+"CHFrac"]; if (mCHFrac && mCHFrac->getRootObject())         mCHFrac ->Fill((*patJets)[ind2].chargedHadronEnergyFraction());
+	  mNHFrac = map_of_MEs[DirName+"/"+"NHFrac"]; if (mNHFrac && mNHFrac->getRootObject())         mNHFrac ->Fill((*patJets)[ind2].neutralHadronEnergyFraction());
+	  mPhFrac = map_of_MEs[DirName+"/"+"PhFrac"]; if (mPhFrac && mPhFrac->getRootObject())         mPhFrac ->Fill((*patJets)[ind2].neutralEmEnergyFraction());
+	  mHFEMFrac = map_of_MEs[DirName+"/"+"HFEMFrac"]; if (mHFEMFrac && mHFEMFrac->getRootObject()) mHFEMFrac ->Fill((*patJets)[ind2].HFEMEnergyFraction());
+	  mHFHFrac = map_of_MEs[DirName+"/"+"HFHFrac"]; if (mHFHFrac && mHFHFrac->getRootObject())     mHFHFrac ->Fill((*patJets)[ind2].HFHadronEnergyFraction());
+
+	  mChargedMultiplicity = map_of_MEs[DirName+"/"+"ChargedMultiplicity"]; if(mChargedMultiplicity && mChargedMultiplicity->getRootObject()) mChargedMultiplicity->Fill((*patJets)[ind2].chargedMultiplicity());
+	  mNeutralMultiplicity = map_of_MEs[DirName+"/"+"NeutralMultiplicity"]; if(mNeutralMultiplicity && mNeutralMultiplicity->getRootObject()) mNeutralMultiplicity->Fill((*patJets)[ind2].neutralMultiplicity());
+	  mMuonMultiplicity = map_of_MEs[DirName+"/"+"MuonMultiplicity"]; if(mMuonMultiplicity && mMuonMultiplicity->getRootObject())             mMuonMultiplicity->Fill((*patJets)[ind2].muonMultiplicity());
+
+	  mNeutralFraction = map_of_MEs[DirName+"/"+"NeutralConstituentsFraction"];if (mNeutralFraction && mNeutralFraction->getRootObject()) mNeutralFraction->Fill ((double)(*patJets)[ind2].neutralMultiplicity()/(double)(*patJets)[ind2].nConstituents());
+
+	  //now fill PATJet profiles for second leading jet
+	  mCHFrac_profile = map_of_MEs[DirName+"/"+"CHFrac_profile"]; if (mCHFrac_profile && mCHFrac_profile->getRootObject())         mCHFrac_profile ->Fill(numPV, (*patJets)[ind2].chargedHadronEnergyFraction());
+	  mNHFrac_profile = map_of_MEs[DirName+"/"+"NHFrac_profile"]; if (mNHFrac_profile && mNHFrac_profile->getRootObject())         mNHFrac_profile ->Fill(numPV, (*patJets)[ind2].neutralHadronEnergyFraction());
+	  mPhFrac_profile = map_of_MEs[DirName+"/"+"PhFrac_profile"]; if (mPhFrac_profile && mPhFrac_profile->getRootObject())         mPhFrac_profile ->Fill(numPV, (*patJets)[ind2].neutralEmEnergyFraction());
+	  mHFEMFrac_profile = map_of_MEs[DirName+"/"+"HFEMFrac_profile"]; if (mHFEMFrac_profile && mHFEMFrac_profile->getRootObject()) mHFEMFrac_profile ->Fill(numPV, (*patJets)[ind2].HFEMEnergyFraction());
+	  mHFHFrac_profile = map_of_MEs[DirName+"/"+"HFHFrac_profile"]; if (mHFHFrac_profile && mHFHFrac_profile->getRootObject())     mHFHFrac_profile ->Fill(numPV, (*patJets)[ind2].HFHadronEnergyFraction());
+	  
+	  mChargedMultiplicity_profile = map_of_MEs[DirName+"/"+"ChargedMultiplicity_profile"]; if(mChargedMultiplicity_profile && mChargedMultiplicity_profile->getRootObject()) mChargedMultiplicity_profile->Fill(numPV, (*patJets)[ind2].chargedMultiplicity());
+	  mNeutralMultiplicity_profile = map_of_MEs[DirName+"/"+"NeutralMultiplicity_profile"]; if(mNeutralMultiplicity_profile && mNeutralMultiplicity_profile->getRootObject()) mNeutralMultiplicity_profile->Fill(numPV, (*patJets)[ind2].neutralMultiplicity());
+	  mMuonMultiplicity_profile = map_of_MEs[DirName+"/"+"MuonMultiplicity_profile"]; if(mMuonMultiplicity_profile && mMuonMultiplicity_profile->getRootObject())             mMuonMultiplicity_profile->Fill(numPV, (*patJets)[ind2].muonMultiplicity());
+	}
       }	  
 
 

--- a/DataFormats/HepMCCandidate/src/classes.h
+++ b/DataFormats/HepMCCandidate/src/classes.h
@@ -5,6 +5,7 @@
 #include "DataFormats/Common/interface/RefVectorHolder.h"
 #include "DataFormats/Common/interface/VectorHolder.h"
 #include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/Common/interface/FwdPtr.h"
 #include "DataFormats/HepMCCandidate/interface/PdfInfo.h"
 #include "DataFormats/HepMCCandidate/interface/FlavorHistory.h"
 #include "DataFormats/HepMCCandidate/interface/FlavorHistoryEvent.h"
@@ -40,6 +41,10 @@ namespace DataFormats_HepMCCandidate {
     edm::RefVectorIterator<std::vector<reco::GenParticle>,reco::GenParticle,edm::refhelper::FindUsingAdvance<std::vector<reco::GenParticle>,reco::GenParticle> > rvigp;
     edm::ValueMap<edm::Ref<std::vector<reco::GenParticle>,reco::GenParticle,edm::refhelper::FindUsingAdvance<std::vector<reco::GenParticle>,reco::GenParticle> > > vmgr;
     edm::Wrapper<edm::ValueMap<edm::Ref<std::vector<reco::GenParticle>,reco::GenParticle,edm::refhelper::FindUsingAdvance<std::vector<reco::GenParticle>,reco::GenParticle> > > > wvmgr;
+    edm::Ptr<reco::GenParticle> gpptr;
+    edm::FwdPtr<reco::GenParticle> gpfp;
+    std::vector<edm::FwdPtr<reco::GenParticle>> vgpfp;
+    edm::Wrapper<std::vector<edm::FwdPtr<reco::GenParticle>>> wvgpfp;    
   };
 }
 

--- a/DataFormats/HepMCCandidate/src/classes_def.xml
+++ b/DataFormats/HepMCCandidate/src/classes_def.xml
@@ -11,12 +11,17 @@
   <class name="edm::Association<std::vector<reco::GenParticle> >" />
   <class name="edm::Wrapper<edm::Association<std::vector<reco::GenParticle> > >" />
 
+
   <class name="reco::GenParticleRef" />
   <class name="reco::GenParticleRefProd" />
   <class name="reco::GenParticleRefVector" />
   <class name="std::vector<std::vector<reco::GenParticleRef> >"/>
   <class name="std::vector<reco::GenParticleRef>" />
   <class name="edm::Wrapper<reco::GenParticleRefVector>" />
+  <class name="edm::Ptr<reco::GenParticle>" />
+  <class name="edm::FwdPtr<reco::GenParticle>" />
+  <class name="std::vector<edm::FwdPtr<reco::GenParticle> >" />
+  <class name="edm::Wrapper<std::vector<edm::FwdPtr<reco::GenParticle> > >" />  
   <class name="edm::reftobase::Holder<reco::Candidate, reco::GenParticleRef>" />
   <class name="edm::reftobase::RefHolder<reco::GenParticleRef>" />
   <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::GenParticleRefVector>" />

--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -98,9 +98,9 @@ namespace pat {
       /// constructure from ref to pat::Jet
       Jet(const edm::Ptr<pat::Jet> & aJetRef);
       /// destructor
-      virtual ~Jet();
+      ~Jet() override;
       /// required reimplementation of the Candidate's clone method
-      virtual Jet * clone() const { return new Jet(*this); }
+      Jet * clone() const override { return new Jet(*this); }
 
       /// ---- methods for MC matching ----
 
@@ -183,7 +183,7 @@ namespace pat {
       /// get list of tag info labels
       std::vector<std::string> const & tagInfoLabels() const { return tagInfoLabels_; }
       /// check to see if the given tag info is nonzero
-      bool hasTagInfo( const std::string label) const { return tagInfo(label) != 0; }
+      bool hasTagInfo( const std::string label) const { return tagInfo(label) != nullptr; }
       /// get a tagInfo with the given name, or NULL if none is found.
       /// You should omit the 'TagInfos' part from the label
       const reco::BaseTagInfo            * tagInfo(const std::string &label) const;
@@ -437,7 +437,7 @@ namespace pat {
       ///    If using refactorized PAT, return that. (constituents size > 0)
       ///    Else check the old version of PAT (embedded constituents size > 0)
       ///    Else return the reco Jet number of constituents
-      virtual const reco::Candidate * daughter(size_t i) const;
+      const reco::Candidate * daughter(size_t i) const override;
 
       using reco::LeafCandidate::daughter; // avoid hiding the base implementation
 
@@ -445,7 +445,7 @@ namespace pat {
       ///    If using refactorized PAT, return that. (constituents size > 0)
       ///    Else check the old version of PAT (embedded constituents size > 0)
       ///    Else return the reco Jet number of constituents
-      virtual size_t numberOfDaughters() const;
+      size_t numberOfDaughters() const override;
 
       /// accessing Jet ID information
       reco::JetID const & jetID () const { return jetID_;}

--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -263,6 +263,8 @@ namespace pat {
 	if (specificJPT_.empty()) throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a JPTJet.\n";
 	return specificJPT_[0];
       }
+      /// check to see if the PFSpecific object is stored
+      bool hasPFSpecific() const { return !specificPF_.empty(); }
       /// retrieve the pf specific part of the jet
       const PFSpecific& pfSpecific() const {
 	if (specificPF_.empty()) throw cms::Exception("Type Mismatch") << "This PAT jet was not made from a PFJet.\n";

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -416,6 +416,10 @@
   <class name="edm::Wrapper<edm::FwdPtr<pat::PackedCandidate> >" />
   <class name="edm::Wrapper<std::vector<edm::FwdPtr<pat::PackedCandidate> > >" />
 
+  <class name="edm::FwdPtr<pat::PackedGenParticle>" />
+  <class name="std::vector<edm::FwdPtr<pat::PackedGenParticle> >" />
+  <class name="edm::Wrapper<edm::FwdPtr<pat::PackedGenParticle> >" />
+  <class name="edm::Wrapper<std::vector<edm::FwdPtr<pat::PackedGenParticle> > >" />
 
   <!-- PAT Object Collections -->
   <class name="std::vector<pat::Electron>" />

--- a/DataFormats/PatCandidates/src/classes_objects.h
+++ b/DataFormats/PatCandidates/src/classes_objects.h
@@ -175,6 +175,12 @@ namespace DataFormats_PatCandidates {
   std::vector< edm::FwdPtr<pat::PackedCandidate> > v_fwdptr_pc;
   edm::Wrapper< std::vector< edm::FwdPtr<pat::PackedCandidate> > > wv_fwdptr_pc;
 
+  edm::FwdPtr<pat::PackedGenParticle> fwdptr_pgp;
+  edm::Wrapper< edm::FwdPtr<pat::PackedGenParticle> > w_fwdptr_pgp;
+  std::vector< edm::FwdPtr<pat::PackedGenParticle> > v_fwdptr_pgp;
+  edm::Wrapper< std::vector< edm::FwdPtr<pat::PackedGenParticle> > > wv_fwdptr_pgp;
+
+    
   edm::Wrapper<edm::Association<pat::PackedCandidateCollection > > w_asso_pc;
   edm::Wrapper<edm::Association<reco::PFCandidateCollection > >    w_asso_pfc;
   edm::Wrapper<edm::Association<std::vector<pat::PackedGenParticle> > > asso_pgp;

--- a/PhysicsTools/PatAlgos/plugins/PATGenJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATGenJetSlimmer.cc
@@ -25,9 +25,9 @@ namespace pat {
   class PATGenJetSlimmer : public edm::stream::EDProducer<> {
   public:
     explicit PATGenJetSlimmer(const edm::ParameterSet & iConfig);
-    virtual ~PATGenJetSlimmer() { }
+    ~PATGenJetSlimmer() override { }
     
-    virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup);
+    void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
     
   private:
     const edm::EDGetTokenT<edm::View<reco::GenJet> > src_;

--- a/PhysicsTools/PatAlgos/plugins/PATGenJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATGenJetSlimmer.cc
@@ -34,6 +34,8 @@ namespace pat {
     const edm::EDGetTokenT<edm::Association<std::vector<pat::PackedGenParticle> > > gp2pgp_;
     
     const StringCutObjectSelector<reco::GenJet> cut_;
+    const StringCutObjectSelector<reco::GenJet> cutLoose_;
+    const unsigned nLoose_;
     
     /// reset daughters to an empty vector
     const bool clearDaughters_;
@@ -48,6 +50,8 @@ pat::PATGenJetSlimmer::PATGenJetSlimmer(const edm::ParameterSet & iConfig) :
     src_(consumes<edm::View<reco::GenJet> >(iConfig.getParameter<edm::InputTag>("src"))),
     gp2pgp_(consumes<edm::Association<std::vector<pat::PackedGenParticle> > >(iConfig.getParameter<edm::InputTag>("packedGenParticles"))),
     cut_(iConfig.getParameter<std::string>("cut")),
+    cutLoose_(iConfig.getParameter<std::string>("cutLoose")),
+    nLoose_(iConfig.getParameter<unsigned>("nLoose")),
     clearDaughters_(iConfig.getParameter<bool>("clearDaughters")),
     dropSpecific_(iConfig.getParameter<bool>("dropSpecific"))
 {
@@ -74,8 +78,17 @@ pat::PATGenJetSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSet
     auto mapping = std::make_unique<std::vector<int> >();
     mapping->reserve(src->size());
 
+    unsigned nl = 0; // number of loose jets
     for (View<reco::GenJet>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
-        if (!cut_(*it)) {
+
+	bool selectedLoose = false;
+	if ( nLoose_ > 0 && cutLoose_(*it) ) {
+	  selectedLoose = true;
+	  ++nl;
+	}
+
+	bool pass = cut_(*it) || ( nl <= nLoose_ && selectedLoose );
+        if (!pass ) {
             mapping->push_back(-1);
             continue;
         }

--- a/PhysicsTools/PatAlgos/plugins/PATGenJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATGenJetSlimmer.cc
@@ -82,12 +82,12 @@ pat::PATGenJetSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSet
     for (View<reco::GenJet>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
 
 	bool selectedLoose = false;
-	if ( nLoose_ > 0 && cutLoose_(*it) ) {
+	if ( nLoose_ > 0 && nl < nLoose_ && cutLoose_(*it) ) {
 	  selectedLoose = true;
 	  ++nl;
 	}
 
-	bool pass = cut_(*it) || ( nl <= nLoose_ && selectedLoose );
+	bool pass = cut_(*it) || selectedLoose;
         if (!pass ) {
             mapping->push_back(-1);
             continue;

--- a/PhysicsTools/PatAlgos/plugins/PATJetSelector.h
+++ b/PhysicsTools/PatAlgos/plugins/PATJetSelector.h
@@ -69,15 +69,15 @@ namespace pat {
       for ( edm::View<pat::Jet>::const_iterator ibegin = h_jets->begin(),
 	      iend = h_jets->end(), ijet = ibegin;
 	    ijet != iend; ++ijet ) {
-
-	// Check the selection
+	
 	bool selectedLoose = false;
-	if ( nLoose_ > 0 && selectorLoose_(*ijet) ) {
+	if ( nLoose_ > 0 && nl < nLoose_ && selectorLoose_(*ijet) ) {
 	  selectedLoose = true;
 	  ++nl;
 	}
-	
-	if ( selector_(*ijet) || ( nl <= nLoose_ && selectedLoose ) ) {
+
+
+	if ( selector_(*ijet) || selectedLoose ) {
 	  // Copy over the calo towers
 	  for ( CaloTowerFwdPtrVector::const_iterator itowerBegin = ijet->caloTowersFwdPtr().begin(),
 		  itowerEnd = ijet->caloTowersFwdPtr().end(), itower = itowerBegin;
@@ -132,13 +132,13 @@ namespace pat {
 	      iend = h_jets->end(), ijet = ibegin;
 	    ijet != iend; ++ijet ) {
 
-	// Check the selection
 	bool selectedLoose = false;
-	if ( nLoose_ > 0 && selectorLoose_(*ijet) ) {
+	if ( nLoose_ > 0 && nl < nLoose_ && selectorLoose_(*ijet) ) {
 	  selectedLoose = true;
 	  ++nl;
-	}	
-	if ( selector_(*ijet) || (nl <= nLoose_ && selectedLoose ) ) {
+	}
+
+	if ( selector_(*ijet) || selectedLoose ) {
 	  // Add the jets that pass to the output collection
 	  patJets->push_back( *ijet );
 	 

--- a/PhysicsTools/PatAlgos/plugins/PATJetSelector.h
+++ b/PhysicsTools/PatAlgos/plugins/PATJetSelector.h
@@ -28,8 +28,11 @@ namespace pat {
   PATJetSelector( edm::ParameterSet const & params ) :
       srcToken_(consumes<edm::View<pat::Jet> >( params.getParameter<edm::InputTag>("src") )),
       cut_( params.getParameter<std::string>("cut") ),
+      cutLoose_( params.getParameter<std::string>("cutLoose") ),
       filter_( params.exists("filter") ? params.getParameter<bool>("filter") : false ),
-      selector_( cut_ )
+      nLoose_( params.getParameter<unsigned>("nLoose") ),
+      selector_( cut_ ),
+      selectorLoose_( cutLoose_ )
       {
 	produces< std::vector<pat::Jet> >();
 	produces<reco::GenJetCollection> ("genJets");
@@ -38,7 +41,7 @@ namespace pat {
 	produces<edm::OwnVector<reco::BaseTagInfo> > ("tagInfos");
       }
 
-    virtual ~PATJetSelector() {}
+    ~PATJetSelector() override {}
 
     virtual void beginJob() {}
     virtual void endJob() {}
@@ -61,13 +64,20 @@ namespace pat {
       edm::Handle< edm::View<pat::Jet> > h_jets;
       iEvent.getByToken( srcToken_, h_jets );
 
+      unsigned nl = 0; // number of loose jets
       // First loop over the products and make the secondary output collections
       for ( edm::View<pat::Jet>::const_iterator ibegin = h_jets->begin(),
 	      iend = h_jets->end(), ijet = ibegin;
 	    ijet != iend; ++ijet ) {
 
 	// Check the selection
-	if ( selector_(*ijet) ) {
+	bool selectedLoose = false;
+	if ( nLoose_ > 0 && selectorLoose_(*ijet) ) {
+	  selectedLoose = true;
+	  ++nl;
+	}
+	
+	if ( selector_(*ijet) || ( nl <= nLoose_ && selectedLoose ) ) {
 	  // Copy over the calo towers
 	  for ( CaloTowerFwdPtrVector::const_iterator itowerBegin = ijet->caloTowersFwdPtr().begin(),
 		  itowerEnd = ijet->caloTowersFwdPtr().end(), itower = itowerBegin;
@@ -117,15 +127,21 @@ namespace pat {
       unsigned int tagInfoIndex = 0;
       unsigned int genJetIndex = 0;
       // Now set the Ptrs with the orphan handles.
+      nl = 0; // Reset number of loose jets
       for ( edm::View<pat::Jet>::const_iterator ibegin = h_jets->begin(),
 	      iend = h_jets->end(), ijet = ibegin;
 	    ijet != iend; ++ijet ) {
 
 	// Check the selection
-	if ( selector_(*ijet) ) {
+	bool selectedLoose = false;
+	if ( nLoose_ > 0 && selectorLoose_(*ijet) ) {
+	  selectedLoose = true;
+	  ++nl;
+	}	
+	if ( selector_(*ijet) || (nl <= nLoose_ && selectedLoose ) ) {
 	  // Add the jets that pass to the output collection
 	  patJets->push_back( *ijet );
-
+	 
 	  // Copy over the calo towers
 	  for ( CaloTowerFwdPtrVector::const_iterator itowerBegin = ijet->caloTowersFwdPtr().begin(),
 		  itowerEnd = ijet->caloTowersFwdPtr().end(), itower = itowerBegin;
@@ -190,11 +206,26 @@ namespace pat {
 	return true;
     }
 
+
+    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
+      edm::ParameterSetDescription iDesc;
+      iDesc.setComment("Energy Correlation Functions adder");
+      iDesc.add<edm::InputTag>("src", edm::InputTag("no default"))->setComment("input collection");
+      iDesc.add<std::string> ("cut", "")->setComment("Jet selection.");
+      iDesc.add<std::string> ("cutLoose", "")->setComment("Loose jet selection. Will keep nLoose loose jets.");
+      iDesc.add<bool> ("filter", false)->setComment("Filter selection?");
+      iDesc.add<unsigned>("nLoose", 0)->setComment("Keep nLoose loose jets that satisfy cutLoose");
+      descriptions.add("PATJetSelector", iDesc);
+    }
+    
   protected:
     const edm::EDGetTokenT<edm::View<pat::Jet> > srcToken_;
     const std::string                    cut_;
-    const bool                           filter_;
-    const StringCutObjectSelector<Jet>   selector_;
+    const std::string                    cutLoose_;      // Cut to define loose jets.     
+    const bool                           filter_;    
+    const unsigned                       nLoose_;        // If desired, keep nLoose loose jets. 
+    const StringCutObjectSelector<Jet>   selector_;   
+    const StringCutObjectSelector<Jet>   selectorLoose_; // Selector for loose jets. 
   };
 
 }

--- a/PhysicsTools/PatAlgos/python/selectionLayer1/jetSelector_cfi.py
+++ b/PhysicsTools/PatAlgos/python/selectionLayer1/jetSelector_cfi.py
@@ -6,7 +6,9 @@ import FWCore.ParameterSet.Config as cms
 #
 selectedPatJets = cms.EDFilter("PATJetSelector",
     src = cms.InputTag("patJets"),
-    cut = cms.string("")
+    cut = cms.string(""),    
+    cutLoose = cms.string(""),
+    nLoose = cms.uint32(0),
 )
 
 

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -90,6 +90,7 @@ MicroEventContentGEN = cms.PSet(
         'keep *_slimmedGenJetsFlavourInfos_*_*',
         'keep *_slimmedGenJets__*',
         'keep *_slimmedGenJetsAK8__*',
+        'keep *_slimmedGenJetsAK8SoftDropSubJets__*',
         'keep *_genMetTrue_*_*',
         # RUN
         'keep LHERunInfoProduct_*_*_*',

--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -28,6 +28,8 @@ def applySubstructure( process, postfix="" ) :
                                                src = cms.InputTag("ak8GenJetsNoNuSoftDrop"+postfix, "SubJets"),
                                                packedGenParticles = cms.InputTag("packedGenParticles"),
                                                cut = cms.string(""),
+                                               cutLoose = cms.string(""),
+                                               nLoose = cms.uint32(0),
                                                clearDaughters = cms.bool(False), #False means rekeying
                                                dropSpecific = cms.bool(True),  # Save space
                                                ), process, task )
@@ -159,7 +161,8 @@ def applySubstructure( process, postfix="" ) :
                      )
     getattr(process,"patJetsAK8Puppi"+postfix).userData.userFloats.src = [] # start with empty list of user floats
     getattr(process,"selectedPatJetsAK8Puppi"+postfix).cut = cms.string("pt > 170")
-
+    getattr(process,"selectedPatJetsAK8Puppi"+postfix).cutLoose = cms.string("pt > 30")
+    getattr(process,"selectedPatJetsAK8Puppi"+postfix).nLoose = cms.uint32(2)
 
     from RecoJets.JetAssociationProducers.j2tParametersVX_cfi import j2tParametersVX
     addToProcessAndTask('ak8PFJetsPuppiTracksAssociatorAtVertex'+postfix, cms.EDProducer("JetTracksAssociatorAtVertex",

--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -15,12 +15,24 @@ def applySubstructure( process, postfix="" ) :
     # Configure the RECO jets
     from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJetsPuppi
     from RecoJets.JetProducers.ak8PFJets_cfi import ak8PFJetsPuppi, ak8PFJetsPuppiSoftDrop, ak8PFJetsPuppiConstituents, ak8PFJetsCHSConstituents
+    from RecoJets.JetProducers.ak8GenJets_cfi import ak8GenJets, ak8GenJetsSoftDrop, ak8GenJetsConstituents
     addToProcessAndTask('ak4PFJetsPuppi'+postfix,ak4PFJetsPuppi.clone(), process, task)
     addToProcessAndTask('ak8PFJetsPuppi'+postfix,ak8PFJetsPuppi.clone(), process, task)
     addToProcessAndTask('ak8PFJetsPuppiConstituents', ak8PFJetsPuppiConstituents.clone(cut = cms.string('pt > 170.0 && abs(rapidity()) < 2.4') ), process, task )
     addToProcessAndTask('ak8PFJetsCHSConstituents', ak8PFJetsCHSConstituents.clone(), process, task )
     addToProcessAndTask('ak8PFJetsPuppiSoftDrop'+postfix, ak8PFJetsPuppiSoftDrop.clone( src = cms.InputTag('ak8PFJetsPuppiConstituents', 'constituents') ), process, task)
-
+    addToProcessAndTask('ak8GenJetsNoNuConstituents'+postfix, ak8GenJetsConstituents.clone(src='ak8GenJetsNoNu'), process, task )
+    addToProcessAndTask('ak8GenJetsNoNuSoftDrop'+postfix,ak8GenJetsSoftDrop.clone(src=cms.InputTag('ak8GenJetsNoNuConstituents'+postfix, 'constituents')),process,task)
+    addToProcessAndTask('slimmedGenJetsAK8SoftDropSubJets'+postfix,
+                            cms.EDProducer("PATGenJetSlimmer",
+                                               src = cms.InputTag("ak8GenJetsNoNuSoftDrop"+postfix, "SubJets"),
+                                               packedGenParticles = cms.InputTag("packedGenParticles"),
+                                               cut = cms.string(""),
+                                               clearDaughters = cms.bool(False), #False means rekeying
+                                               dropSpecific = cms.bool(True),  # Save space
+                                               ), process, task )
+    
+    
     #add AK8 CHS
     addJetCollection(process, postfix=postfix, labelName = 'AK8',
                      jetSource = cms.InputTag('ak8PFJetsCHS'+postfix),
@@ -81,6 +93,7 @@ def applySubstructure( process, postfix="" ) :
         labelName = 'AK8PFPuppiSoftDrop' + postfix,
         jetSource = cms.InputTag('ak8PFJetsPuppiSoftDrop'+postfix),
         btagDiscriminators = ['None'],
+        genJetCollection = cms.InputTag('slimmedGenJetsAK8'), 
         jetCorrections = ('AK8PFPuppi', ['L2Relative', 'L3Absolute'], 'None'),
         getJetMCFlavour = False # jet flavor disabled
     )
@@ -96,7 +109,7 @@ def applySubstructure( process, postfix="" ) :
         jetCorrections = ('AK4PFPuppi', ['L2Relative', 'L3Absolute'], 'None'),
         explicitJTA = True,  # needed for subjet b tagging
         svClustering = True, # needed for subjet b tagging
-        genJetCollection = cms.InputTag('slimmedGenJets'), 
+        genJetCollection = cms.InputTag('slimmedGenJetsAK8SoftDropSubJets'), 
         fatJets=cms.InputTag('ak8PFJetsPuppi'),             # needed for subjet flavor clustering
         groomedFatJets=cms.InputTag('ak8PFJetsPuppiSoftDrop') # needed for subjet flavor clustering
     )

--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -39,11 +39,12 @@ def applySubstructure( process, postfix="" ) :
     addJetCollection(process, postfix=postfix, labelName = 'AK8',
                      jetSource = cms.InputTag('ak8PFJetsCHS'+postfix),
                      algo= 'AK', rParam = 0.8,
+                     btagDiscriminators = ['None'],
                      jetCorrections = ('AK8PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
                      genJetCollection = cms.InputTag('slimmedGenJetsAK8')
                      )
     getattr(process,"patJetsAK8"+postfix).userData.userFloats.src = [] # start with empty list of user floats
-    getattr(process,"selectedPatJetsAK8").cut = cms.string("pt > 100")
+    getattr(process,"selectedPatJetsAK8").cut = cms.string("pt > 170")
 
 
     ## add AK8 groomed masses with CHS
@@ -156,7 +157,15 @@ def applySubstructure( process, postfix="" ) :
                      jetSource = cms.InputTag('ak8PFJetsPuppi'+postfix),
                      algo= 'AK', rParam = 0.8,
                      jetCorrections = ('AK8PFPuppi', cms.vstring(['L2Relative', 'L3Absolute']), 'None'),
-                     btagDiscriminators = ([x.value() for x in patJetsDefault.discriminatorSources] + ['pfBoostedDoubleSecondaryVertexAK8BJetTags']),
+                     btagDiscriminators = ([
+                         'pfCombinedSecondaryVertexV2BJetTags',
+                         'pfCombinedInclusiveSecondaryVertexV2BJetTags',
+                         'pfCombinedMVAV2BJetTags',
+                         'pfDeepCSVJetTags:probb',
+                         'pfDeepCSVJetTags:probc',
+                         'pfDeepCSVJetTags:probudsg',
+                         'pfDeepCSVJetTags:probbb',
+                         'pfBoostedDoubleSecondaryVertexAK8BJetTags']),
                      genJetCollection = cms.InputTag('slimmedGenJetsAK8')
                      )
     getattr(process,"patJetsAK8Puppi"+postfix).userData.userFloats.src = [] # start with empty list of user floats
@@ -279,4 +288,7 @@ def applySubstructure( process, postfix="" ) :
 
     # switch off daughter re-keying since it's done in the JetSubstructurePacker (and can't be done afterwards)
     process.slimmedJetsAK8.rekeyDaughters = "0"
-
+    # Reconfigure the slimmedAK8 jet information to keep 
+    process.slimmedJetsAK8.dropDaughters = cms.string("pt < 170")
+    process.slimmedJetsAK8.dropSpecific = cms.string("pt < 170")
+    process.slimmedJetsAK8.dropTagInfos = cms.string("pt < 170")

--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -43,7 +43,7 @@ def applySubstructure( process, postfix="" ) :
                      genJetCollection = cms.InputTag('slimmedGenJetsAK8')
                      )
     getattr(process,"patJetsAK8"+postfix).userData.userFloats.src = [] # start with empty list of user floats
-    getattr(process,"selectedPatJetsAK8").cut = cms.string("pt > 170")
+    getattr(process,"selectedPatJetsAK8").cut = cms.string("pt > 100")
 
 
     ## add AK8 groomed masses with CHS
@@ -65,7 +65,7 @@ def applySubstructure( process, postfix="" ) :
     addToProcessAndTask('NjettinessAK8'+postfix, process.Njettiness.clone(), process, task)
     getattr(process,"NjettinessAK8").src = cms.InputTag("ak8PFJetsCHS"+postfix)
     getattr(process,"NjettinessAK8").cone = cms.double(0.8)
-    getattr(process,"patJetsAK8").userData.userFloats.src += ['NjettinessAK8'+postfix+':tau1','NjettinessAK8'+postfix+':tau2','NjettinessAK8'+postfix+':tau3']
+    getattr(process,"patJetsAK8").userData.userFloats.src += ['NjettinessAK8'+postfix+':tau1','NjettinessAK8'+postfix+':tau2','NjettinessAK8'+postfix+':tau3','NjettinessAK8'+postfix+':tau4']
 
     # add Njetiness from CHS
     addToProcessAndTask('NjettinessAK8Subjets'+postfix, process.Njettiness.clone(), process, task)
@@ -127,7 +127,7 @@ def applySubstructure( process, postfix="" ) :
     addToProcessAndTask('nb2AK8PuppiSoftDropSubjets'+postfix, process.ecfNbeta2.clone(src = cms.InputTag("ak8PFJetsPuppiSoftDrop"+postfix, "SubJets")), process, task)
     getattr(process,"patJetsAK8PFPuppiSoftDropSubjets"+postfix).userData.userFloats.src += ['nb1AK8PuppiSoftDropSubjets'+postfix+':ecfN2','nb1AK8PuppiSoftDropSubjets'+postfix+':ecfN3']
     getattr(process,"patJetsAK8PFPuppiSoftDropSubjets"+postfix).userData.userFloats.src += ['nb2AK8PuppiSoftDropSubjets'+postfix+':ecfN2','nb2AK8PuppiSoftDropSubjets'+postfix+':ecfN3']
-    getattr(process,"patJetsAK8PFPuppiSoftDropSubjets"+postfix).userData.userFloats.src += ['NjettinessAK8Subjets'+postfix+':tau1','NjettinessAK8Subjets'+postfix+':tau2','NjettinessAK8Subjets'+postfix+':tau3']
+    getattr(process,"patJetsAK8PFPuppiSoftDropSubjets"+postfix).userData.userFloats.src += ['NjettinessAK8Subjets'+postfix+':tau1','NjettinessAK8Subjets'+postfix+':tau2','NjettinessAK8Subjets'+postfix+':tau3','NjettinessAK8Subjets'+postfix+':tau4']
 
     # rekey the groomed ECF value maps to the ungroomed reco jets, which will then be picked
     # up by PAT in the user floats. 
@@ -160,9 +160,9 @@ def applySubstructure( process, postfix="" ) :
                      genJetCollection = cms.InputTag('slimmedGenJetsAK8')
                      )
     getattr(process,"patJetsAK8Puppi"+postfix).userData.userFloats.src = [] # start with empty list of user floats
-    getattr(process,"selectedPatJetsAK8Puppi"+postfix).cut = cms.string("pt > 170")
+    getattr(process,"selectedPatJetsAK8Puppi"+postfix).cut = cms.string("pt > 100")
     getattr(process,"selectedPatJetsAK8Puppi"+postfix).cutLoose = cms.string("pt > 30")
-    getattr(process,"selectedPatJetsAK8Puppi"+postfix).nLoose = cms.uint32(2)
+    getattr(process,"selectedPatJetsAK8Puppi"+postfix).nLoose = cms.uint32(3)
 
     from RecoJets.JetAssociationProducers.j2tParametersVX_cfi import j2tParametersVX
     addToProcessAndTask('ak8PFJetsPuppiTracksAssociatorAtVertex'+postfix, cms.EDProducer("JetTracksAssociatorAtVertex",
@@ -192,7 +192,7 @@ def applySubstructure( process, postfix="" ) :
     addToProcessAndTask('NjettinessAK8Puppi'+postfix, process.Njettiness.clone(), process, task)
     getattr(process,"NjettinessAK8Puppi"+postfix).src = cms.InputTag("ak8PFJetsPuppi"+postfix)
     getattr(process,"NjettinessAK8Puppi").cone = cms.double(0.8)
-    getattr(process,"patJetsAK8Puppi").userData.userFloats.src += ['NjettinessAK8Puppi'+postfix+':tau1','NjettinessAK8Puppi'+postfix+':tau2','NjettinessAK8Puppi'+postfix+':tau3']
+    getattr(process,"patJetsAK8Puppi").userData.userFloats.src += ['NjettinessAK8Puppi'+postfix+':tau1','NjettinessAK8Puppi'+postfix+':tau2','NjettinessAK8Puppi'+postfix+':tau3','NjettinessAK8Puppi'+postfix+':tau4']
 
     # Now combine the CHS and PUPPI information into the PUPPI jets via delta R value maps
     addToProcessAndTask("ak8PFJetsCHSValueMap"+postfix, cms.EDProducer("RecoJetToPatJetDeltaRValueMapProducer",
@@ -205,6 +205,7 @@ def applySubstructure( process, postfix="" ) :
                                                 'userFloat("NjettinessAK8'+postfix+':tau1")',
                                                 'userFloat("NjettinessAK8'+postfix+':tau2")',
                                                 'userFloat("NjettinessAK8'+postfix+':tau3")',
+                                                'userFloat("NjettinessAK8'+postfix+':tau4")',
                                                 'pt','eta','phi','mass'
                                             ]),
                                             valueLabels = cms.vstring( [
@@ -213,6 +214,7 @@ def applySubstructure( process, postfix="" ) :
                                                 'NjettinessAK8CHSTau1',
                                                 'NjettinessAK8CHSTau2',
                                                 'NjettinessAK8CHSTau3',
+                                                'NjettinessAK8CHSTau4',
                                                 'pt','eta','phi','mass'
                                             ]) ),
                         process, task)
@@ -225,6 +227,7 @@ def applySubstructure( process, postfix="" ) :
                                                    cms.InputTag('ak8PFJetsCHSValueMap'+postfix,'NjettinessAK8CHSTau1'),
                                                    cms.InputTag('ak8PFJetsCHSValueMap'+postfix,'NjettinessAK8CHSTau2'),
                                                    cms.InputTag('ak8PFJetsCHSValueMap'+postfix,'NjettinessAK8CHSTau3'),
+                                                   cms.InputTag('ak8PFJetsCHSValueMap'+postfix,'NjettinessAK8CHSTau4'),
                                                    cms.InputTag('ak8PFJetsCHSValueMap'+postfix,'pt'),
                                                    cms.InputTag('ak8PFJetsCHSValueMap'+postfix,'eta'),
                                                    cms.InputTag('ak8PFJetsCHSValueMap'+postfix,'phi'),

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedGenJets_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedGenJets_cfi.py
@@ -13,9 +13,9 @@ slimmedGenJets = cms.EDProducer("PATGenJetSlimmer",
 slimmedGenJetsAK8 = cms.EDProducer("PATGenJetSlimmer",
     src = cms.InputTag("ak8GenJetsNoNu"),
     packedGenParticles = cms.InputTag("packedGenParticles"),
-    cut = cms.string("pt > 150"),
+    cut = cms.string("pt > 80"),
     cutLoose = cms.string("pt > 10."),
-    nLoose = cms.uint32(2),
+    nLoose = cms.uint32(3),
     clearDaughters = cms.bool(False), #False means rekeying
     dropSpecific = cms.bool(False),
 )

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedGenJets_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedGenJets_cfi.py
@@ -4,6 +4,8 @@ slimmedGenJets = cms.EDProducer("PATGenJetSlimmer",
     src = cms.InputTag("ak4GenJetsNoNu"),
     packedGenParticles = cms.InputTag("packedGenParticles"),
     cut = cms.string("pt > 8"),
+    cutLoose = cms.string(""),
+    nLoose = cms.uint32(0),
     clearDaughters = cms.bool(False), #False means rekeying
     dropSpecific = cms.bool(False),
 )
@@ -12,6 +14,8 @@ slimmedGenJetsAK8 = cms.EDProducer("PATGenJetSlimmer",
     src = cms.InputTag("ak8GenJetsNoNu"),
     packedGenParticles = cms.InputTag("packedGenParticles"),
     cut = cms.string("pt > 150"),
+    cutLoose = cms.string("pt > 10."),
+    nLoose = cms.uint32(2),
     clearDaughters = cms.bool(False), #False means rekeying
     dropSpecific = cms.bool(False),
 )

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -240,7 +240,7 @@ VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig) {
 		fjRangeDef_ = RangeDefPtr( new fastjet::RangeDefinition(rhoEtaMax_) );
 	} 
 
-	if( ( doFastJetNonUniform_ ) && ( puCenters_.size() == 0 ) ) 
+	if( ( doFastJetNonUniform_ ) && ( puCenters_.empty() ) ) 
 		throw cms::Exception("doFastJetNonUniform") << "Parameter puCenters for doFastJetNonUniform is not defined." << std::endl;
   
         // make the "produces" statements
@@ -289,7 +289,7 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
     LogDebug("VirtualJetProducer") << "Adding PV info\n";
     edm::Handle<reco::VertexCollection> pvCollection;
     iEvent.getByToken(input_vertex_token_ , pvCollection);
-    if (pvCollection->size()>0) vertex_=pvCollection->begin()->position();
+    if (!pvCollection->empty()) vertex_=pvCollection->begin()->position();
   }
 
   // For Pileup subtraction using offset correction:
@@ -314,7 +314,7 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
   
   bool isView = iEvent.getByToken(input_candidateview_token_, inputsHandle);
   if ( isView ) {
-    if ( inputsHandle->size() == 0) {
+    if ( inputsHandle->empty()) {
       output( iEvent, iSetup );
       return;
     }
@@ -328,7 +328,7 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
     bool isGenFwdPtr = iEvent.getByToken(input_packedgencandidatefwdptr_token_, packedgeninputsHandleAsFwdPtr);
     
     if ( isPF ) {
-      if ( pfinputsHandleAsFwdPtr->size() == 0) {
+      if ( pfinputsHandleAsFwdPtr->empty()) {
 	output( iEvent, iSetup );
 	return;
       }
@@ -341,7 +341,7 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
 	}
       }
     } else if ( isPFFwdPtr ) {
-      if ( packedinputsHandleAsFwdPtr->size() == 0) {
+      if ( packedinputsHandleAsFwdPtr->empty()) {
 	output( iEvent, iSetup );
 	return;
       }
@@ -354,7 +354,7 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
 	}
       }
     } else if ( isGen ) {
-      if ( geninputsHandleAsFwdPtr->size() == 0) {
+      if ( geninputsHandleAsFwdPtr->empty()) {
 	output( iEvent, iSetup );
 	return;
       }
@@ -367,7 +367,7 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
 	}
       }
     } else if ( isGenFwdPtr ) {
-      if ( geninputsHandleAsFwdPtr->size() == 0) {
+      if ( geninputsHandleAsFwdPtr->empty()) {
 	output( iEvent, iSetup );
 	return;
       }
@@ -620,7 +620,7 @@ void VirtualJetProducer::writeJets( edm::Event & iEvent, edm::EventSetup const& 
         dynamic_cast<fastjet::ClusterSequenceAreaBase const *> ( &*fjClusterSeq_ );
 
       if (clusterSequenceWithArea ==nullptr ){
-	if (fjJets_.size() > 0) {
+	if (!fjJets_.empty()) {
 	  throw cms::Exception("LogicError")<<"fjClusterSeq is not initialized while inputs are present\n ";
 	}
       } else {
@@ -651,7 +651,7 @@ void VirtualJetProducer::writeJets( edm::Event & iEvent, edm::EventSetup const& 
 	}
       */
       if (clusterSequenceWithArea ==nullptr ){
-	if (fjJets_.size() > 0) {
+	if (!fjJets_.empty()) {
 	  throw cms::Exception("LogicError")<<"fjClusterSeq is not initialized while inputs are present\n ";
 	}
       } else {
@@ -977,7 +977,7 @@ void VirtualJetProducer::writeJetsWithConstituents(  edm::Event & iEvent, edm::E
       reco::CandidatePtr candPtr( constituentHandleAfterPut, *iconst, false );
       i_jetConstituents.push_back( candPtr );
     }
-    if(i_jetConstituents.size()>0) { //only keep jets which have constituents after subtraction
+    if(!i_jetConstituents.empty()) { //only keep jets which have constituents after subtraction
       reco::Particle::Point point(0,0,0);
       reco::PFJet jet;
       reco::writeSpecific(jet,*ip4,point,i_jetConstituents,iSetup);

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.h
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.h
@@ -15,6 +15,7 @@
 #include "DataFormats/JetReco/interface/BasicJet.h"
 #include "DataFormats/JetReco/interface/GenJet.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
 
 #include "DataFormats/JetReco/interface/BasicJetCollection.h"
 
@@ -228,7 +229,9 @@ private:
   edm::EDGetTokenT<reco::CandidateView> input_candidateview_token_;
   edm::EDGetTokenT<std::vector<edm::FwdPtr<reco::PFCandidate> > > input_candidatefwdptr_token_;
   edm::EDGetTokenT<std::vector<edm::FwdPtr<pat::PackedCandidate> > > input_packedcandidatefwdptr_token_;
-
+  edm::EDGetTokenT<std::vector<edm::FwdPtr<reco::GenParticle> > > input_gencandidatefwdptr_token_;
+  edm::EDGetTokenT<std::vector<edm::FwdPtr<pat::PackedGenParticle> > > input_packedgencandidatefwdptr_token_;
+  
  protected:
   edm::EDGetTokenT<reco::VertexCollection> input_vertex_token_;
   

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.h
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.h
@@ -80,7 +80,7 @@ protected:
   //
 public:
   explicit VirtualJetProducer(const edm::ParameterSet& iConfig);
-  virtual ~VirtualJetProducer();
+  ~VirtualJetProducer() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   static void fillDescriptionsFromVirtualJetProducer(edm::ParameterSetDescription& desc);
   
@@ -96,7 +96,7 @@ public:
   // member functions
   //
 public:
-  virtual void  produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  void  produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   std::string   jetType() const { return jetType_; }
   
 protected:

--- a/RecoJets/JetProducers/python/ak8GenJets_cfi.py
+++ b/RecoJets/JetProducers/python/ak8GenJets_cfi.py
@@ -16,3 +16,8 @@ ak8GenJetsSoftDrop = ak8GenJets.clone(
     jetCollInstanceName=cms.string("SubJets"),
     jetPtMin = 100.0
     )
+
+ak8GenJetsConstituents = cms.EDProducer("GenJetConstituentSelector",
+                                          src = cms.InputTag("ak8GenJets"),
+                                          cut = cms.string("pt > 100.0")
+                                         )


### PR DESCRIPTION
JME / SMP / B2G preparation for the nanoAOD. 

1. Added soft-dropped subjets from gen jets. 

This is for nanoAOD to be fully usable for substructure analyses. The CPU time added is negligible (<1 ms/event) because I am not computing the areas for the gen jets (not needed). I also preclustered them with AK8. There is expected to be a small increase in size.

The preclustering required more code than I intended, since, to first order, this is merely a configuration change. However many dictionaries were missing to do the preclustering on GenJets, and the VirtualJetProducer could not understand the ```vector<FwdPtr<GenParticle>>```.


2. Adding 2 AK8 jets with lower pt for SMP-J measurements. We now have:

- all AK8 PF jets with pt > 100 GeV with b-tagging information, (New: lower pt threshold)
   - if pt > 170 GeV, add grooming, tau1-tau4, and N2 (add tau4)
   - if pt > 250 GeV, add N3 (unchanged in this PR)
- 3 AK8 jets with pt > 30 with only b-tagging information, no grooming nor substructure. (New)
- all AK8 Gen jets with pt > 120 GeV with grooming (As in 1 from this PR). 
- 3 AK8 Gen jets with pt > 10 with no grooming nor substructure (New). 


This is expected to add 3 AK8 jets and 3 AK8 genjets per event. 


@arizzi, @gpetruc, @clelange also watching. 