### PR TITLE
Add possibility to cut on timing to IVF

### DIFF
--- a/DataFormats/Candidate/interface/VertexCompositePtrCandidate.h
+++ b/DataFormats/Candidate/interface/VertexCompositePtrCandidate.h
@@ -15,63 +15,97 @@
 namespace reco {
   class VertexCompositePtrCandidate : public CompositePtrCandidate {
   public:
+    enum { dimension4D = 4 };
+    /// covariance error matrix (3x3)
+    typedef math::Error<dimension4D>::type CovarianceMatrix4D;
+    /// matix size
+    enum { size4D = dimension4D * (dimension4D + 1)/2 };
+
     VertexCompositePtrCandidate() : CompositePtrCandidate() { }
     /// constructor from values
     VertexCompositePtrCandidate(Charge q, const LorentzVector & p4, const Point & vtx,
-			     int pdgId = 0, int status = 0, bool integerCharge = true) :
+				int pdgId = 0, int status = 0, bool integerCharge = true) :
       CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge),
-      chi2_(0), ndof_(0) { }
+	chi2_(0), ndof_(0), time_(0) { }
+    VertexCompositePtrCandidate(Charge q, const LorentzVector & p4, const Point & vtx,
+				double time, int pdgId = 0, int status = 0, 
+				bool integerCharge = true) :
+      CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge),
+	chi2_(0), ndof_(0), time_(time) { }
     /// constructor from values
     VertexCompositePtrCandidate(Charge q, const LorentzVector & p4, const Point & vtx,
-			     const CovarianceMatrix & err, double chi2, double ndof,
-			     int pdgId = 0, int status = 0, bool integerCharge = true);
+				const CovarianceMatrix & err, double chi2, double ndof,
+				int pdgId = 0, int status = 0, bool integerCharge = true);
+    VertexCompositePtrCandidate(Charge q, const LorentzVector & p4, const Point & vtx,
+				double time, const CovarianceMatrix4D & err, double chi2, 
+				double ndof, int pdgId = 0, int status = 0, 
+				bool integerCharge = true);
      /// constructor from values
     explicit VertexCompositePtrCandidate(const Candidate & p) :
-      CompositePtrCandidate(p), chi2_(0), ndof_(0) { }
+      CompositePtrCandidate(p), chi2_(0), ndof_(0), time_(0) { }
      /// constructor from values
     explicit VertexCompositePtrCandidate(const CompositePtrCandidate & p) :
-      CompositePtrCandidate(p), chi2_(0), ndof_(0) { }
+      CompositePtrCandidate(p), chi2_(0), ndof_(0), time_(0) { }
     /// destructor
-    virtual ~VertexCompositePtrCandidate();
+    ~VertexCompositePtrCandidate() override;
     /// returns a clone of the candidate
-    virtual VertexCompositePtrCandidate * clone() const;
+    VertexCompositePtrCandidate * clone() const override;
+
     /// chi-squares
-    virtual double vertexChi2() const { return chi2_; }
+    double vertexChi2() const override { return chi2_; }
     /** Number of degrees of freedom
      *  Meant to be Double32_t for soft-assignment fitters: 
      *  tracks may contribute to the vertex with fractional weights.
      *  The ndof is then = to the sum of the track weights.
      *  see e.g. CMS NOTE-2006/032, CMS NOTE-2004/002
      */
-    virtual double vertexNdof() const { return ndof_; }
+    double vertexNdof() const override { return ndof_; }
     /// chi-squared divided by n.d.o.f.
-    virtual double vertexNormalizedChi2() const { return chi2_ / ndof_; }
-    /// (i, j)-th element of error matrix, i, j = 0, ... 2
-    virtual double vertexCovariance(int i, int j) const { 
+    double vertexNormalizedChi2() const override { return chi2_ / ndof_; }
+    /// (i, j)-th element of error matrix, i, j = 0, ... 3
+    double vertexCovariance(int i, int j) const override { 
       return covariance_[idx(i, j)]; 
     }
     using reco::LeafCandidate::vertexCovariance; // avoid hiding the
+    /// return SMatrix 4D
+    CovarianceMatrix4D vertexCovariance4D() const { CovarianceMatrix4D m; fillVertexCovariance( m ); return m; }
+
     /// fill SMatrix
-    virtual void fillVertexCovariance(CovarianceMatrix & v) const;
+    void fillVertexCovariance(CovarianceMatrix & v) const override;
+    /// 4D version
+    void fillVertexCovariance( CovarianceMatrix4D & v ) const;
+
     /// set chi2 and ndof
     void setChi2AndNdof(double chi2, double ndof) {
       chi2_ = chi2; ndof_ = ndof;
     }
     /// set covariance matrix
     void setCovariance(const CovarianceMatrix &m);
+    /// set covariance matrix
+    void setCovariance(const CovarianceMatrix4D &m);
+
+    // set time
+    void setTime(double time) { time_ = time; }
 
     /// the following functions are implemented to have a more consistent interface with the one of reco::Vertex
-    typedef math::Error<dimension>::type Error;  
+    typedef math::Error<dimension>::type Error;
+    typedef math::Error<dimension4D>::type Error4D;
     const Point & position() const {return vertex();} 	
+    double t() const { return time_; }
+    double tError() const { return std::sqrt( vertexCovariance(3,3) ); }
     Error  error() const { Error m; fillVertexCovariance( m ); return m; }
+    /// return SMatrix 4D
+    Error4D error4D() const { Error4D m; fillVertexCovariance( m ); return m; }
 
   private:
     /// chi-sqared
     Double32_t chi2_;
     /// number of degrees of freedom
     Double32_t ndof_;
-    /// covariance matrix (3x3) as vector
-    Double32_t covariance_[size];
+    /// covariance matrix (4x4) as vector
+    Double32_t covariance_[size4D];
+    /// vertex time
+    Double32_t time_;
     /// position index
     index idx(index i, index j) const {
       int a = (i <= j ? i : j), b = (i <= j ? j : i);

--- a/DataFormats/Candidate/interface/VertexCompositePtrCandidate.h
+++ b/DataFormats/Candidate/interface/VertexCompositePtrCandidate.h
@@ -21,7 +21,7 @@ namespace reco {
     /// matix size
     enum { size4D = dimension4D * (dimension4D + 1)/2 };
 
-    VertexCompositePtrCandidate() : CompositePtrCandidate() { }
+    VertexCompositePtrCandidate() : CompositePtrCandidate(), chi2_(0), ndof_(0), time_(0) { }
     /// constructor from values
     VertexCompositePtrCandidate(Charge q, const LorentzVector & p4, const Point & vtx,
 				int pdgId = 0, int status = 0, bool integerCharge = true) :

--- a/DataFormats/Candidate/src/VertexCompositePtrCandidate.cc
+++ b/DataFormats/Candidate/src/VertexCompositePtrCandidate.cc
@@ -6,7 +6,15 @@ VertexCompositePtrCandidate::VertexCompositePtrCandidate(Charge q, const Lorentz
 						   const CovarianceMatrix & err, double chi2, double ndof,
 						   int pdgId, int status, bool integerCharge) :
   CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge),
-  chi2_(chi2), ndof_(ndof) { 
+  chi2_(chi2), ndof_(ndof), time_(0.) { 
+  setCovariance(err);
+}
+
+VertexCompositePtrCandidate::VertexCompositePtrCandidate(Charge q, const LorentzVector & p4, const Point & vtx,
+						   double time, const CovarianceMatrix4D & err, double chi2, 
+						   double ndof, int pdgId, int status, bool integerCharge) :
+  CompositePtrCandidate(q, p4, vtx, pdgId, status, integerCharge),
+  chi2_(chi2), ndof_(ndof), time_(time) { 
   setCovariance(err);
 }
 
@@ -17,15 +25,34 @@ VertexCompositePtrCandidate * VertexCompositePtrCandidate::clone() const {
 }
 
 void VertexCompositePtrCandidate::fillVertexCovariance(CovarianceMatrix& err) const {
+  Error4D temp;
+  fillVertexCovariance(temp);
+  err = temp.Sub<Error>(0,0);  
+}
+
+void VertexCompositePtrCandidate::fillVertexCovariance(CovarianceMatrix4D& err) const {
   index idx = 0;
-  for(index i = 0; i < dimension; ++i) 
-    for(index j = 0; j <= i; ++ j)
+  for(index i = 0; i < dimension4D; ++i) 
+    for(index j = 0; j <= i; ++ j) 
       err(i, j) = covariance_[idx++];
 }
 
 void VertexCompositePtrCandidate::setCovariance(const CovarianceMatrix & err) {
   index idx = 0;
-  for(index i = 0; i < dimension; ++i) 
+  for(index i = 0; i < dimension4D; ++i) { 
+    for(index j = 0; j <= i; ++j) {
+      if( i == dimension || j == dimension ) {
+        covariance_[ idx ++ ] = 0.0;
+      } else {
+        covariance_[ idx ++ ] = err( i, j );
+      }
+    }
+  }
+}
+
+void VertexCompositePtrCandidate::setCovariance(const CovarianceMatrix4D & err) {
+  index idx = 0;
+  for(index i = 0; i < dimension4D; ++i) 
     for(index j = 0; j <= i; ++j)
       covariance_[idx++] = err(i, j);
 }

--- a/DataFormats/Candidate/src/classes_def.xml
+++ b/DataFormats/Candidate/src/classes_def.xml
@@ -61,29 +61,14 @@
    <version ClassVersion="12" checksum="3253990857"/>
    <version ClassVersion="11" checksum="2070976353"/>
    <version ClassVersion="10" checksum="955269040"/>
-  </class>
-  <ioread sourceClass="reco::VertexCompositePtrCandidate" version="[-13]" targetClass="reco::VertexCompositePtrCandidate" 
-	  source="Double32_t chi2_" 
-          target="chi2_">    
-    <![CDATA[chi2_ = onfile.chi2_;]]>
-  </ioread>
-  <ioread sourceClass="reco::VertexCompositePtrCandidate" version="[-13]" targetClass="reco::VertexCompositePtrCandidate" 
-	  source="Double32_t ndof_" 
-          target="ndof_">  
-    <![CDATA[ndof_ = onfile.ndof_;]]>
-  </ioread>
+  </class>  
   <ioread sourceClass="reco::VertexCompositePtrCandidate" version="[-13]" targetClass="reco::VertexCompositePtrCandidate" 
 	  source="Double32_t covariance_[6]" 
           target="covariance_">
     <![CDATA[
 	   for( unsigned i = 0; i < 4; ++i ) { for( unsigned j = i; j< 4; ++j ) { unsigned a = (i <= j ? i : j), b = (i <= j ? j : i); unsigned idx = b * (b + 1)/2 + a; covariance_[idx] = ( i == 3 || j == 3 ) ? 0.0 : onfile.covariance_[idx]; } }
     ]]>
-  </ioread>
-  <ioread sourceClass="reco::VertexCompositePtrCandidate" version="[-13]" targetClass="reco::VertexCompositePtrCandidate" 
-	  source="" 
-          target="time_">
-    <![CDATA[time_ = 0.;]]>
-  </ioread>
+  </ioread>  
 
   <class name="reco::VertexCompositeCandidate" ClassVersion="13">
    <version ClassVersion="13" checksum="1561694123"/>

--- a/DataFormats/Candidate/src/classes_def.xml
+++ b/DataFormats/Candidate/src/classes_def.xml
@@ -55,12 +55,36 @@
     <version ClassVersion="10" checksum="2404784677"/>
    </class>
 
-  <class name="reco::VertexCompositePtrCandidate" ClassVersion="13">
+  <class name="reco::VertexCompositePtrCandidate" ClassVersion="14">
+   <version ClassVersion="14" checksum="2052765294"/>
    <version ClassVersion="13" checksum="3584734005"/>
    <version ClassVersion="12" checksum="3253990857"/>
    <version ClassVersion="11" checksum="2070976353"/>
    <version ClassVersion="10" checksum="955269040"/>
   </class>
+  <ioread sourceClass="reco::VertexCompositePtrCandidate" version="[-13]" targetClass="reco::VertexCompositePtrCandidate" 
+	  source="Double32_t chi2_" 
+          target="chi2_">    
+    <![CDATA[chi2_ = onfile.chi2_;]]>
+  </ioread>
+  <ioread sourceClass="reco::VertexCompositePtrCandidate" version="[-13]" targetClass="reco::VertexCompositePtrCandidate" 
+	  source="Double32_t ndof_" 
+          target="ndof_">  
+    <![CDATA[ndof_ = onfile.ndof_;]]>
+  </ioread>
+  <ioread sourceClass="reco::VertexCompositePtrCandidate" version="[-13]" targetClass="reco::VertexCompositePtrCandidate" 
+	  source="Double32_t covariance_[6]" 
+          target="covariance_">
+    <![CDATA[
+	   for( unsigned i = 0; i < 4; ++i ) { for( unsigned j = i; j< 4; ++j ) { unsigned a = (i <= j ? i : j), b = (i <= j ? j : i); unsigned idx = b * (b + 1)/2 + a; covariance_[idx] = ( i == 3 || j == 3 ) ? 0.0 : onfile.covariance_[idx]; } }
+    ]]>
+  </ioread>
+  <ioread sourceClass="reco::VertexCompositePtrCandidate" version="[-13]" targetClass="reco::VertexCompositePtrCandidate" 
+	  source="" 
+          target="time_">
+    <![CDATA[time_ = 0.;]]>
+  </ioread>
+
   <class name="reco::VertexCompositeCandidate" ClassVersion="13">
    <version ClassVersion="13" checksum="1561694123"/>
    <version ClassVersion="12" checksum="1204062111"/>

--- a/RecoVertex/AdaptiveVertexFinder/interface/SVTimeHelpers.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/SVTimeHelpers.h
@@ -1,0 +1,36 @@
+#ifndef __RecoVertex_AdaptiveVertexFinder_SVTimeHelpers_h__
+#define __RecoVertex_AdaptiveVertexFinder_SVTimeHelpers_h__ 
+
+#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+
+#include "FWCore/Utilities/interface/isFinite.h"
+
+namespace svtime{
+
+  inline void updateVertexTime(TransientVertex& vtx) {
+    const auto& trks = vtx.originalTracks();
+    double meantime = 0., expv_x2 = 0., normw = 0., timecov = 0.;		  
+    for( const auto& trk : trks ) {
+      if( edm::isFinite(trk.timeExt()) ) {
+	const double time = trk.timeExt();
+	const double inverr = 1.0/trk.dtErrorExt();
+	const double w = inverr*inverr;
+	meantime += time*w;
+	expv_x2  += time*time*w;
+	normw    += w;
+      }
+    }
+    if( normw > 0. ) {
+      meantime = meantime/normw;
+      expv_x2 = expv_x2/normw;
+      timecov = expv_x2 - meantime*meantime;
+      auto err = vtx.positionError().matrix4D();
+      err(3,3) = timecov/(double)trks.size();  
+      vtx = TransientVertex(vtx.position(),meantime,err,vtx.originalTracks(),vtx.totalChiSquared());
+      //std::cout << "updated svertex time: " << vtx.time() << " +/- " << std::sqrt(err(3,3)) << std::endl;
+    }
+  }
+}
+
+#endif

--- a/RecoVertex/AdaptiveVertexFinder/interface/SVTimeHelpers.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/SVTimeHelpers.h
@@ -6,7 +6,7 @@
 
 #include "FWCore/Utilities/interface/isFinite.h"
 
-namespace svtime{
+namespace svhelper{
 
   inline void updateVertexTime(TransientVertex& vtx) {
     const auto& trks = vtx.originalTracks();
@@ -28,7 +28,6 @@ namespace svtime{
       auto err = vtx.positionError().matrix4D();
       err(3,3) = timecov/(double)trks.size();  
       vtx = TransientVertex(vtx.position(),meantime,err,vtx.originalTracks(),vtx.totalChiSquared());
-      //std::cout << "updated svertex time: " << vtx.time() << " +/- " << std::sqrt(err(3,3)) << std::endl;
     }
   }
 }

--- a/RecoVertex/AdaptiveVertexFinder/interface/TrackVertexArbitration.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/TrackVertexArbitration.h
@@ -271,7 +271,7 @@ std::vector<VTX> TrackVertexArbitration<VTX>::trackVertexArbitrator(
              	 singleFitVertex = theAdaptiveFitter.vertex(selTracks,ssv);
 		 
               	if(singleFitVertex.isValid())  { 
-		  svtime::updateVertexTime(singleFitVertex);
+		  svhelper::updateVertexTime(singleFitVertex);
 		  recoVertices.push_back(VTX(singleFitVertex));
 		  
 

--- a/RecoVertex/AdaptiveVertexFinder/interface/TrackVertexArbitration.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/TrackVertexArbitration.h
@@ -48,8 +48,8 @@
 //#define VTXDEBUG
 
 namespace svhelper {
-  double cov33(const reco::Vertex & sv) { return sv.covariance(3,3); }
-  double cov33(const reco::VertexCompositePtrCandidate & sv) { return sv.vertexCovariance(3,3); }
+  inline double cov33(const reco::Vertex & sv) { return sv.covariance(3,3); }
+  inline double cov33(const reco::VertexCompositePtrCandidate & sv) { return sv.vertexCovariance(3,3); }
 }
 
 
@@ -174,8 +174,8 @@ std::vector<VTX> TrackVertexArbitration<VTX>::trackVertexArbitrator(
         for(typename std::vector<VTX>::const_iterator sv = secondaryVertices.begin();
 	    sv != secondaryVertices.end(); ++sv) {
 
-	  const bool svHasTime = ( svhelper::cov33(*sv) > 0. );
 	  const double svTime(sv->t()), svTimeCov(svhelper::cov33(*sv));
+          const bool svHasTime = svTimeCov > 0.;
 	    
 	    GlobalPoint ssv(sv->position().x(),sv->position().y(),sv->position().z());
             GlobalVector flightDir = ssv-ppv;

--- a/RecoVertex/AdaptiveVertexFinder/interface/TrackVertexArbitratration.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/TrackVertexArbitratration.h
@@ -2,7 +2,7 @@
 #define TrackVertexArbitration_H
 #include <memory>
 #include <set>
-
+#include <unordered_map>
 
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/TransientTrack/interface/CandidatePtrTransientTrack.h"
@@ -37,10 +37,22 @@
 #include "RecoVertex/KalmanVertexFit/interface/KalmanVertexSmoother.h"
 #include "TrackingTools/GeomPropagators/interface/AnalyticalImpactPointExtrapolator.h"
 #include "RecoVertex/VertexPrimitives/interface/ConvertToFromReco.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
+#include "RecoVertex/AdaptiveVertexFinder/interface/SVTimeHelpers.h"
+
+#include "FWCore/Utilities/interface/isFinite.h"
 //#include "DataFormats/Math/interface/deltaR.h"
 
 //#define VTXDEBUG
+
+namespace svhelper {
+  double cov33(const reco::Vertex & sv) { return sv.covariance(3,3); }
+  double cov33(const reco::VertexCompositePtrCandidate & sv) { return sv.vertexCovariance(3,3); }
+}
+
+
 
 template <class VTX>
 class TrackVertexArbitration{
@@ -72,7 +84,8 @@ class TrackVertexArbitration{
 	double 					fitterRatio;//    = 0.25;
 	int 					trackMinLayers;
 	double					trackMinPt;
-	int					trackMinPixels;   
+	int					trackMinPixels;  
+	double                                  maxTimeSignificance;
 };
 
 #include "DataFormats/GeometryVector/interface/VectorUtil.h"
@@ -91,7 +104,8 @@ TrackVertexArbitration<VTX>::TrackVertexArbitration(const edm::ParameterSet &par
 	fitterRatio               (params.getParameter<double>("fitterRatio")),
 	trackMinLayers            (params.getParameter<int32_t>("trackMinLayers")),
 	trackMinPt                (params.getParameter<double>("trackMinPt")),
-	trackMinPixels            (params.getParameter<int32_t>("trackMinPixels"))
+	trackMinPixels            (params.getParameter<int32_t>("trackMinPixels")),
+	maxTimeSignificance       (params.getParameter<double>("maxTimeSignificance"))
 {
 	dRCut*=dRCut;
 }
@@ -156,10 +170,13 @@ std::vector<VTX> TrackVertexArbitration<VTX>::trackVertexArbitrator(
         VertexDistance3D vdist;
         GlobalPoint ppv(pv.position().x(),pv.position().y(),pv.position().z());
 
-        std::map<unsigned int, Measurement1D> cachedIP;  
+        std::unordered_map<unsigned int, Measurement1D> cachedIP;  
         for(typename std::vector<VTX>::const_iterator sv = secondaryVertices.begin();
 	    sv != secondaryVertices.end(); ++sv) {
 
+	  const bool svHasTime = ( svhelper::cov33(*sv) > 0. );
+	  const double svTime(sv->t()), svTimeCov(svhelper::cov33(*sv));
+	    
 	    GlobalPoint ssv(sv->position().x(),sv->position().y(),sv->position().z());
             GlobalVector flightDir = ssv-ppv;
 //            std::cout << "Vertex : " << sv-secondaryVertices->begin() << " " << sv->position() << std::endl;
@@ -171,14 +188,14 @@ std::vector<VTX> TrackVertexArbitration<VTX>::trackVertexArbitrator(
                 tt.setBeamSpot(*beamSpot);
 	        float w = trackWeight(*sv,tt);
  	        Measurement1D ipv;
-		if(cachedIP.find(itrack)!=cachedIP.end()) {
-				ipv=cachedIP[itrack];
+		if( cachedIP.count(itrack) ) {
+		  ipv=cachedIP[itrack];
 		} else {
-	 	                std::pair<bool,Measurement1D> ipvp = IPTools::absoluteImpactParameter3D(tt,pv);
-				cachedIP[itrack]=ipvp.second;
-				ipv=ipvp.second;
+		  std::pair<bool,Measurement1D> ipvp = IPTools::absoluteImpactParameter3D(tt,pv);
+		  cachedIP[itrack]=ipvp.second;
+		  ipv=ipvp.second;
 		}
-
+		
 		AnalyticalImpactPointExtrapolator extrapolator(tt.field());
 		TrajectoryStateOnSurface tsos = extrapolator.extrapolate(tt.impactPointState(), RecoVertex::convertPos(sv->position()));
 		if(! tsos.isValid()) continue;
@@ -187,12 +204,18 @@ std::vector<VTX> TrackVertexArbitration<VTX>::trackVertexArbitrator(
 		Measurement1D isv = dist.distance(VertexState(RecoVertex::convertPos(sv->position()),RecoVertex::convertError(sv->error())),VertexState(refPoint, refPointErr));	   
 
 		float dR = Geom::deltaR2(flightDir,tt.track()); //.eta(), flightDir.phi(), tt.track().eta(), tt.track().phi());
+		
+		double timeSig = 0.;
+		if( svHasTime && edm::isFinite(tt.timeExt()) ) {
+		  double tError = std::sqrt( std::pow( tt.dtErrorExt(), 2 ) + svTimeCov );
+		  timeSig = std::abs(tt.timeExt() - svTime)/tError;
+		}
 
-                if( w > 0 || ( isv.significance() < sigCut && isv.value() < distCut && isv.value() < dlen.value()*dLenFraction ) )
+                if( w > 0 || ( isv.significance() < sigCut && isv.value() < distCut && isv.value() < dlen.value()*dLenFraction && timeSig < maxTimeSignificance) )
                 {
 
                   if(( isv.value() < ipv.value()  ) && isv.value() < distCut && isv.value() < dlen.value()*dLenFraction 
-                  && dR < dRCut  ) 
+                  && dR < dRCut && timeSig < maxTimeSignificance ) 
                   {
 #ifdef VTXDEBUG
                      if(w > 0.5) std::cout << " = ";
@@ -206,7 +229,7 @@ std::vector<VTX> TrackVertexArbitration<VTX>::trackVertexArbitrator(
                   else std::cout << "   ";
 #endif
                      //add also the tracks used in previous fitting that are still closer to Sv than Pv 
-                     if(w > 0.5 && isv.value() <= ipv.value() && dR < dRCut) {  
+                     if(w > 0.5 && isv.value() <= ipv.value() && dR < dRCut && timeSig < maxTimeSignificance) {  
                        selTracks.push_back(tt);
 #ifdef VTXDEBUG
                        std::cout << " = ";
@@ -246,7 +269,11 @@ std::vector<VTX> TrackVertexArbitration<VTX>::trackVertexArbitrator(
               { 
              	 TransientVertex singleFitVertex;
              	 singleFitVertex = theAdaptiveFitter.vertex(selTracks,ssv);
-              	if(singleFitVertex.isValid())  { recoVertices.push_back(VTX(singleFitVertex));
+		 
+              	if(singleFitVertex.isValid())  { 
+		  svtime::updateVertexTime(singleFitVertex);
+		  recoVertices.push_back(VTX(singleFitVertex));
+		  
 
 #ifdef VTXDEBUG
                 const VTX & extVertex = recoVertices.back();

--- a/RecoVertex/AdaptiveVertexFinder/interface/TracksClusteringFromDisplacedSeed.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/TracksClusteringFromDisplacedSeed.h
@@ -25,8 +25,8 @@
 class TracksClusteringFromDisplacedSeed {
     public:
     struct Cluster 
-    { 
-      GlobalPoint seedPoint;  
+    {       
+      GlobalPoint seedPoint;      
       reco::TransientTrack seedingTrack;
       std::vector<reco::TransientTrack> tracks;
     };
@@ -52,6 +52,7 @@ class TracksClusteringFromDisplacedSeed {
         double 					clusterMaxSignificance;
         double 					distanceRatio;
         double 					clusterMinAngleCosine;
+	double                                  maxTimeSignificance;
 
 
 };

--- a/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.h
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.h
@@ -55,7 +55,6 @@ class TemplatedInclusiveVertexFinder : public edm::stream::EDProducer<> {
             pdesc.add<edm::InputTag>("tracks",edm::InputTag("particleFlow"));
             pdesc.add<unsigned int>("minHits",0);
           } else {
-            std::cout << "TIVF defaulted!" << std::endl;
             pdesc.add<edm::InputTag>("tracks",edm::InputTag("generalTracks"));
           }	  
 	  
@@ -96,7 +95,6 @@ class TemplatedInclusiveVertexFinder : public edm::stream::EDProducer<> {
           } else if ( std::is_same<VTX,reco::VertexCompositePtrCandidate>::value ) {
             cdesc.add("inclusiveCandidateVertexFinderDefault",pdesc);
           } else {
-            std::cout << "TIVF defaulted!" << std::endl;
             cdesc.addDefault(pdesc);
           }
 	}

--- a/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.h
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.h
@@ -31,6 +31,9 @@
 #include "RecoVertex/MultiVertexFit/interface/MultiVertexFitter.h"
 
 #include "RecoVertex/AdaptiveVertexFinder/interface/TTHelpers.h"
+#include "RecoVertex/AdaptiveVertexFinder/interface/SVTimeHelpers.h"
+#include "FWCore/Utilities/interface/isFinite.h"
+
 //#define VTXDEBUG 1
 template <class InputContainer, class VTX>
 class TemplatedInclusiveVertexFinder : public edm::stream::EDProducer<> {
@@ -38,6 +41,47 @@ class TemplatedInclusiveVertexFinder : public edm::stream::EDProducer<> {
 	typedef std::vector<VTX> Product;
 	typedef typename InputContainer::value_type TRK;
 	TemplatedInclusiveVertexFinder(const edm::ParameterSet &params);
+
+	static void fillDescriptions(edm::ConfigurationDescriptions & cdesc) {
+	  edm::ParameterSetDescription pdesc;
+	  pdesc.add<edm::InputTag>("beamSpot",edm::InputTag("offlineBeamSpot"));
+	  pdesc.add<edm::InputTag>("primaryVertices",edm::InputTag("offlinePrimaryVertices"));
+	  pdesc.add<edm::InputTag>("tracks",edm::InputTag("generalTracks"));
+	  pdesc.add<unsigned int>("minHits",8);
+	  pdesc.add<double>("maximumLongitudinalImpactParameter",0.3);
+	  pdesc.add<double>("maximumTimeSignificance",3.0);
+	  pdesc.add<double>("minPt",0.8);
+	  pdesc.add<unsigned int>("maxNTracks",30);
+	  //clusterizer pset
+	  edm::ParameterSetDescription clusterizer;
+	  clusterizer.add<double>("seedMax3DIPSignificance",9999.0);
+	  clusterizer.add<double>("seedMax3DIPValue",9999.0);
+	  clusterizer.add<double>("seedMin3DIPSignificance",1.2);
+	  clusterizer.add<double>("seedMin3DIPValue",0.005);
+	  clusterizer.add<double>("clusterMaxDistance",0.05);
+	  clusterizer.add<double>("clusterMaxSignificance",4.5);
+	  clusterizer.add<double>("distanceRatio",20.0);
+	  clusterizer.add<double>("clusterMinAngleCosine",0.5);
+	  clusterizer.add<double>("maxTimeSignificance",3.5);
+	  pdesc.add<edm::ParameterSetDescription>("clusterizer", clusterizer);
+	  // vertex and fitter config
+	  pdesc.add<double>("vertexMinAngleCosine",0.95);
+	  pdesc.add<double>("vertexMinDLen2DSig",2.5);
+	  pdesc.add<double>("vertexMinDLenSig",0.5);
+	  pdesc.add<double>("fitterSigmacut",3.0);
+	  pdesc.add<double>("fitterTini",256.0);
+	  pdesc.add<double>("fitterRatio",0.25);
+	  pdesc.add<bool>("useDirectVertexFitter",true);
+	  pdesc.add<bool>("useVertexReco",true);
+	  // vertexReco pset
+	  edm::ParameterSetDescription vertexReco;
+	  vertexReco.add<std::string>("finder", std::string("avr"));
+	  vertexReco.add<double>("primcut",1.0);
+	  vertexReco.add<double>("seccut",3.0);
+	  vertexReco.add<bool>("smoothing",true);
+          pdesc.add<edm::ParameterSetDescription>("vertexReco", vertexReco);
+	  cdesc.addDefault(pdesc);
+	}
 
 	virtual void produce(edm::Event &event, const edm::EventSetup &es) override;
 
@@ -51,6 +95,7 @@ class TemplatedInclusiveVertexFinder : public edm::stream::EDProducer<> {
 	unsigned int				minHits;
 	unsigned int				maxNTracks;
 	double					maxLIP;
+	double                                  maxTimeSig;
         double 					minPt;
         double 					vertexMinAngleCosine;
         double 					vertexMinDLen2DSig;
@@ -69,6 +114,7 @@ TemplatedInclusiveVertexFinder<InputContainer,VTX>::TemplatedInclusiveVertexFind
 	minHits(params.getParameter<unsigned int>("minHits")),
 	maxNTracks(params.getParameter<unsigned int>("maxNTracks")),
        	maxLIP(params.getParameter<double>("maximumLongitudinalImpactParameter")),
+	maxTimeSig(params.getParameter<double>("maximumTimeSignificance")),
  	minPt(params.getParameter<double>("minPt")), //0.8
         vertexMinAngleCosine(params.getParameter<double>("vertexMinAngleCosine")), //0.98
         vertexMinDLen2DSig(params.getParameter<double>("vertexMinDLen2DSig")), //2.5
@@ -147,6 +193,11 @@ void TemplatedInclusiveVertexFinder<InputContainer,VTX>::produce(edm::Event &eve
 			continue;
                 if( std::abs(tt.track().dz(pv.position())) > maxLIP)
 			continue;
+		if( edm::isFinite(tt.timeExt()) && pv.covariance(3,3) > 0. ) { // only apply if time available
+		  auto tError = std::sqrt( std::pow(tt.dtErrorExt(),2) + pv.covariance(3,3) );
+		  auto dtSig = std::abs(tt.timeExt() - pv.t())/tError;
+		  if( dtSig > maxTimeSig ) continue;
+		}
 		tt.setBeamSpot(*beamSpot);
 		tts.push_back(tt);
 	}
@@ -186,6 +237,12 @@ void TemplatedInclusiveVertexFinder<InputContainer,VTX>::produce(edm::Event &eve
 			if(singleFitVertex.isValid())
 				vertices.push_back(singleFitVertex);
 		}
+		
+		// for each transient vertex state determine if a time can be measured and fill covariance
+		for(auto& vtx : vertices) {
+		  svtime::updateVertexTime(vtx);
+		}
+
 		for(std::vector<TransientVertex>::const_iterator v = vertices.begin();
 		    v != vertices.end(); ++v) {
 			Measurement1D dlen= vdist.distance(pv,*v);
@@ -196,6 +253,7 @@ void TemplatedInclusiveVertexFinder<InputContainer,VTX>::produce(edm::Event &eve
 			std::cout << " dlen: " << dlen.value() << " error: " << dlen.error() << " signif: " << dlen.significance();
 			std::cout << " dlen2: " << dlen2.value() << " error2: " << dlen2.error() << " signif2: " << dlen2.significance();
 			std::cout << " pos: " << vv.position() << " error: " <<vv.xError() << " " << vv.yError() << " " << vv.zError() << std::endl;
+			std::cout << " time: " << vv.time() << " error: " << vv.tError() << std::endl;
 #endif
 			GlobalVector dir;  
 			std::vector<reco::TransientTrack> ts = v->originalTracks();

--- a/RecoVertex/AdaptiveVertexFinder/plugins/TemplatedVertexArbitrator.h
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/TemplatedVertexArbitrator.h
@@ -54,6 +54,25 @@ class TemplatedVertexArbitrator : public edm::stream::EDProducer<> {
 	typedef std::vector<VTX> Product;
 	TemplatedVertexArbitrator(const edm::ParameterSet &params); 
 
+	static void fillDescriptions(edm::ConfigurationDescriptions & cdesc) {
+	  edm::ParameterSetDescription pdesc;
+	  pdesc.add<edm::InputTag>("beamSpot",edm::InputTag("offlineBeamSpot"));
+	  pdesc.add<edm::InputTag>("primaryVertices",edm::InputTag("offlinePrimaryVertices"));
+	  pdesc.add<edm::InputTag>("tracks",edm::InputTag("particleFlow"));
+	  pdesc.add<edm::InputTag>("secondaryVertices",edm::InputTag("candidateVertexMerger"));
+	  pdesc.add<double>("dLenFraction",0.3333);
+	  pdesc.add<double>("dRCut",0.4);
+	  pdesc.add<double>("distCut",0.04);
+	  pdesc.add<double>("sigCut",5.0);
+	  pdesc.add<double>("fitterSigmacut",3.0);
+	  pdesc.add<double>("fitterTini",256);
+	  pdesc.add<double>("fitterRatio",0.25);
+	  pdesc.add<int>("trackMinLayers",4);
+	  pdesc.add<double>("trackMinPt",0.4);
+	  pdesc.add<int>("trackMinPixels",1);
+	  pdesc.add<double>("maxTimeSignificance",3.5);
+	  cdesc.addDefault(pdesc);
+	}
 
 	virtual void produce(edm::Event &event, const edm::EventSetup &es) override ;
 

--- a/RecoVertex/AdaptiveVertexFinder/plugins/TemplatedVertexArbitrator.h
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/TemplatedVertexArbitrator.h
@@ -38,7 +38,7 @@
 
 
 #include "RecoVertex/ConfigurableVertexReco/interface/ConfigurableVertexReconstructor.h"
-#include "RecoVertex/AdaptiveVertexFinder/interface/TrackVertexArbitratration.h"
+#include "RecoVertex/AdaptiveVertexFinder/interface/TrackVertexArbitration.h"
 #include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
 
 #include "RecoVertex/AdaptiveVertexFinder/interface/TTHelpers.h"
@@ -58,8 +58,16 @@ class TemplatedVertexArbitrator : public edm::stream::EDProducer<> {
 	  edm::ParameterSetDescription pdesc;
 	  pdesc.add<edm::InputTag>("beamSpot",edm::InputTag("offlineBeamSpot"));
 	  pdesc.add<edm::InputTag>("primaryVertices",edm::InputTag("offlinePrimaryVertices"));
-	  pdesc.add<edm::InputTag>("tracks",edm::InputTag("particleFlow"));
-	  pdesc.add<edm::InputTag>("secondaryVertices",edm::InputTag("candidateVertexMerger"));
+          if( std::is_same<VTX,reco::Vertex>::value ) {
+            pdesc.add<edm::InputTag>("tracks",edm::InputTag("generalTracks"));
+            pdesc.add<edm::InputTag>("secondaryVertices",edm::InputTag("vertexMerger"));
+          } else if (  std::is_same<VTX,reco::VertexCompositePtrCandidate>::value ) {
+            pdesc.add<edm::InputTag>("tracks",edm::InputTag("particleFlow"));
+            pdesc.add<edm::InputTag>("secondaryVertices",edm::InputTag("candidateVertexMerger"));
+          } else {
+            pdesc.add<edm::InputTag>("tracks",edm::InputTag("generalTracks"));
+            pdesc.add<edm::InputTag>("secondaryVertices",edm::InputTag("vertexMerger"));
+          }
 	  pdesc.add<double>("dLenFraction",0.3333);
 	  pdesc.add<double>("dRCut",0.4);
 	  pdesc.add<double>("distCut",0.04);
@@ -71,7 +79,14 @@ class TemplatedVertexArbitrator : public edm::stream::EDProducer<> {
 	  pdesc.add<double>("trackMinPt",0.4);
 	  pdesc.add<int>("trackMinPixels",1);
 	  pdesc.add<double>("maxTimeSignificance",3.5);
-	  cdesc.addDefault(pdesc);
+          if( std::is_same<VTX,reco::Vertex>::value ) {
+            cdesc.add("trackVertexArbitratorDefault",pdesc); 
+          } else if (  std::is_same<VTX,reco::VertexCompositePtrCandidate>::value ) {
+            cdesc.add("candidateVertexArbitratorDefault",pdesc); 
+          } else {
+            std::cout << "TVA defaulted!" << std::endl;
+            cdesc.addDefault(pdesc); 
+          }
 	}
 
 	virtual void produce(edm::Event &event, const edm::EventSetup &es) override ;

--- a/RecoVertex/AdaptiveVertexFinder/plugins/TemplatedVertexArbitrator.h
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/TemplatedVertexArbitrator.h
@@ -68,7 +68,7 @@ class TemplatedVertexArbitrator : public edm::stream::EDProducer<> {
             pdesc.add<edm::InputTag>("tracks",edm::InputTag("generalTracks"));
             pdesc.add<edm::InputTag>("secondaryVertices",edm::InputTag("vertexMerger"));
           }
-	  pdesc.add<double>("dLenFraction",0.3333);
+	  pdesc.add<double>("dLenFraction",0.333);
 	  pdesc.add<double>("dRCut",0.4);
 	  pdesc.add<double>("distCut",0.04);
 	  pdesc.add<double>("sigCut",5.0);

--- a/RecoVertex/AdaptiveVertexFinder/plugins/TemplatedVertexArbitrator.h
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/TemplatedVertexArbitrator.h
@@ -84,7 +84,6 @@ class TemplatedVertexArbitrator : public edm::stream::EDProducer<> {
           } else if (  std::is_same<VTX,reco::VertexCompositePtrCandidate>::value ) {
             cdesc.add("candidateVertexArbitratorDefault",pdesc); 
           } else {
-            std::cout << "TVA defaulted!" << std::endl;
             cdesc.addDefault(pdesc); 
           }
 	}

--- a/RecoVertex/AdaptiveVertexFinder/python/candidateVertexArbitrator_cfi.py
+++ b/RecoVertex/AdaptiveVertexFinder/python/candidateVertexArbitrator_cfi.py
@@ -14,8 +14,8 @@ candidateVertexArbitrator = cms.EDProducer("CandidateVertexArbitrator",
        fitterRatio = cms.double(0.25),
        trackMinLayers = cms.int32(4),
        trackMinPt = cms.double(0.4),
-       trackMinPixels = cms.int32(1)
-
+       trackMinPixels = cms.int32(1),
+       maxTimeSignificance = cms.double(3.5)
 )
 
 

--- a/RecoVertex/AdaptiveVertexFinder/python/candidateVertexArbitrator_cfi.py
+++ b/RecoVertex/AdaptiveVertexFinder/python/candidateVertexArbitrator_cfi.py
@@ -1,21 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-candidateVertexArbitrator = cms.EDProducer("CandidateVertexArbitrator",
-       beamSpot = cms.InputTag("offlineBeamSpot"),
-       primaryVertices = cms.InputTag("offlinePrimaryVertices"),
-       tracks = cms.InputTag("particleFlow"),
-       secondaryVertices = cms.InputTag("candidateVertexMerger"),
-       dLenFraction = cms.double(0.333),
-       dRCut = cms.double(0.4),
-       distCut = cms.double(0.04),
-       sigCut = cms.double(5),
-       fitterSigmacut =  cms.double(3),
-       fitterTini = cms.double(256),
-       fitterRatio = cms.double(0.25),
-       trackMinLayers = cms.int32(4),
-       trackMinPt = cms.double(0.4),
-       trackMinPixels = cms.int32(1),
-       maxTimeSignificance = cms.double(3.5)
-)
+from RecoVertex.AdaptiveVertexFinder.candidateVertexArbitratorDefault_cfi import candidateVertexArbitratorDefault
+
+candidateVertexArbitrator = candidateVertexArbitratorDefault.clone()
 
 

--- a/RecoVertex/AdaptiveVertexFinder/python/inclusiveCandidateVertexFinder_cfi.py
+++ b/RecoVertex/AdaptiveVertexFinder/python/inclusiveCandidateVertexFinder_cfi.py
@@ -6,6 +6,7 @@ inclusiveCandidateVertexFinder  = cms.EDProducer("InclusiveCandidateVertexFinder
        tracks = cms.InputTag("particleFlow"),
        minHits = cms.uint32(0),
        maximumLongitudinalImpactParameter = cms.double(0.3),
+       maximumTimeSignificance = cms.double(3.0),
        minPt = cms.double(0.8),
        maxNTracks = cms.uint32(30),
 
@@ -18,6 +19,7 @@ inclusiveCandidateVertexFinder  = cms.EDProducer("InclusiveCandidateVertexFinder
            clusterMaxSignificance = cms.double(4.5), #4.5 sigma
            distanceRatio = cms.double(20), # was cluster scale = 1 / density factor =0.05 
            clusterMinAngleCosine = cms.double(0.5), # only forward decays
+           maxTimeSignificance = cms.double(3.5) #3.5 sigma, since the time cut is track-to-track
        ),
 
        vertexMinAngleCosine = cms.double(0.95), # scalar prod direction of tracks and flight dir

--- a/RecoVertex/AdaptiveVertexFinder/python/inclusiveCandidateVertexFinder_cfi.py
+++ b/RecoVertex/AdaptiveVertexFinder/python/inclusiveCandidateVertexFinder_cfi.py
@@ -1,43 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-inclusiveCandidateVertexFinder  = cms.EDProducer("InclusiveCandidateVertexFinder",
-       beamSpot = cms.InputTag("offlineBeamSpot"),
-       primaryVertices = cms.InputTag("offlinePrimaryVertices"),
-       tracks = cms.InputTag("particleFlow"),
-       minHits = cms.uint32(0),
-       maximumLongitudinalImpactParameter = cms.double(0.3),
-       maximumTimeSignificance = cms.double(3.0),
-       minPt = cms.double(0.8),
-       maxNTracks = cms.uint32(30),
+from RecoVertex.AdaptiveVertexFinder.inclusiveCandidateVertexFinderDefault_cfi import inclusiveCandidateVertexFinderDefault
 
-       clusterizer = cms.PSet(
-           seedMax3DIPSignificance = cms.double(9999.),
-           seedMax3DIPValue = cms.double(9999.),
-           seedMin3DIPSignificance = cms.double(1.2),
-           seedMin3DIPValue = cms.double(0.005),
-           clusterMaxDistance = cms.double(0.05), #500um
-           clusterMaxSignificance = cms.double(4.5), #4.5 sigma
-           distanceRatio = cms.double(20), # was cluster scale = 1 / density factor =0.05 
-           clusterMinAngleCosine = cms.double(0.5), # only forward decays
-           maxTimeSignificance = cms.double(3.5) #3.5 sigma, since the time cut is track-to-track
-       ),
+inclusiveCandidateVertexFinder  = inclusiveCandidateVertexFinderDefault.clone()
 
-       vertexMinAngleCosine = cms.double(0.95), # scalar prod direction of tracks and flight dir
-       vertexMinDLen2DSig = cms.double(2.5), #2.5 sigma
-       vertexMinDLenSig = cms.double(0.5), #0.5 sigma
-       fitterSigmacut =  cms.double(3),
-       fitterTini = cms.double(256),
-       fitterRatio = cms.double(0.25),
-       useDirectVertexFitter = cms.bool(True),
-       useVertexReco  = cms.bool(True),
-       vertexReco = cms.PSet(
-               finder = cms.string('avr'),
-               primcut = cms.double(1.0),
-               seccut = cms.double(3),
-               smoothing = cms.bool(True)
-       )
-
-
-)
 
 

--- a/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexFinder_cfi.py
+++ b/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexFinder_cfi.py
@@ -6,6 +6,7 @@ inclusiveVertexFinder  = cms.EDProducer("InclusiveVertexFinder",
        tracks = cms.InputTag("generalTracks"),
        minHits = cms.uint32(8),
        maximumLongitudinalImpactParameter = cms.double(0.3),
+       maximumTimeSignificance = cms.double(3.0),
        minPt = cms.double(0.8),
        maxNTracks = cms.uint32(30),
 
@@ -18,6 +19,7 @@ inclusiveVertexFinder  = cms.EDProducer("InclusiveVertexFinder",
            clusterMaxSignificance = cms.double(4.5), #4.5 sigma
            distanceRatio = cms.double(20), # was cluster scale = 1 / density factor =0.05 
            clusterMinAngleCosine = cms.double(0.5), # only forward decays
+           maxTimeSignificance = cms.double(3.5) #3.5 sigma, since the time cut is track-to-track
        ),
 
        vertexMinAngleCosine = cms.double(0.95), # scalar prod direction of tracks and flight dir

--- a/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexFinder_cfi.py
+++ b/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexFinder_cfi.py
@@ -1,43 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-inclusiveVertexFinder  = cms.EDProducer("InclusiveVertexFinder",
-       beamSpot = cms.InputTag("offlineBeamSpot"),
-       primaryVertices = cms.InputTag("offlinePrimaryVertices"),
-       tracks = cms.InputTag("generalTracks"),
-       minHits = cms.uint32(8),
-       maximumLongitudinalImpactParameter = cms.double(0.3),
-       maximumTimeSignificance = cms.double(3.0),
-       minPt = cms.double(0.8),
-       maxNTracks = cms.uint32(30),
+from RecoVertex.AdaptiveVertexFinder.inclusiveVertexFinderDefault import inclusiveVertexFinderDefault
 
-       clusterizer = cms.PSet(
-           seedMax3DIPSignificance = cms.double(9999.),
-           seedMax3DIPValue = cms.double(9999.),
-           seedMin3DIPSignificance = cms.double(1.2),
-           seedMin3DIPValue = cms.double(0.005),
-           clusterMaxDistance = cms.double(0.05), #500um
-           clusterMaxSignificance = cms.double(4.5), #4.5 sigma
-           distanceRatio = cms.double(20), # was cluster scale = 1 / density factor =0.05 
-           clusterMinAngleCosine = cms.double(0.5), # only forward decays
-           maxTimeSignificance = cms.double(3.5) #3.5 sigma, since the time cut is track-to-track
-       ),
-
-       vertexMinAngleCosine = cms.double(0.95), # scalar prod direction of tracks and flight dir
-       vertexMinDLen2DSig = cms.double(2.5), #2.5 sigma
-       vertexMinDLenSig = cms.double(0.5), #0.5 sigma
-       fitterSigmacut =  cms.double(3),
-       fitterTini = cms.double(256),
-       fitterRatio = cms.double(0.25),
-       useDirectVertexFitter = cms.bool(True),
-       useVertexReco  = cms.bool(True),
-       vertexReco = cms.PSet(
-               finder = cms.string('avr'),
-               primcut = cms.double(1.0),
-               seccut = cms.double(3),
-               smoothing = cms.bool(True)
-       )
-
-
-)
-
+inclusiveVertexFinder  = inclusiveVertexFinderDefault.clone()
 

--- a/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexFinder_cfi.py
+++ b/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexFinder_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoVertex.AdaptiveVertexFinder.inclusiveVertexFinderDefault import inclusiveVertexFinderDefault
+from RecoVertex.AdaptiveVertexFinder.inclusiveVertexFinderDefault_cfi import inclusiveVertexFinderDefault
 
 inclusiveVertexFinder  = inclusiveVertexFinderDefault.clone()
 

--- a/RecoVertex/AdaptiveVertexFinder/python/trackVertexArbitrator_cfi.py
+++ b/RecoVertex/AdaptiveVertexFinder/python/trackVertexArbitrator_cfi.py
@@ -14,7 +14,8 @@ trackVertexArbitrator = cms.EDProducer("TrackVertexArbitrator",
        fitterRatio = cms.double(0.25),
        trackMinLayers = cms.int32(4),
        trackMinPt = cms.double(0.4),
-       trackMinPixels = cms.int32(1)
+       trackMinPixels = cms.int32(1),
+       maxTimeSignificance = cms.double(3.5)
 
 )
 

--- a/RecoVertex/AdaptiveVertexFinder/python/trackVertexArbitrator_cfi.py
+++ b/RecoVertex/AdaptiveVertexFinder/python/trackVertexArbitrator_cfi.py
@@ -1,22 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-trackVertexArbitrator = cms.EDProducer("TrackVertexArbitrator",
-       beamSpot = cms.InputTag("offlineBeamSpot"),
-       primaryVertices = cms.InputTag("offlinePrimaryVertices"),
-       tracks = cms.InputTag("generalTracks"),
-       secondaryVertices = cms.InputTag("vertexMerger"),
-       dLenFraction = cms.double(0.333),
-       dRCut = cms.double(0.4),
-       distCut = cms.double(0.04),
-       sigCut = cms.double(5),
-       fitterSigmacut =  cms.double(3),
-       fitterTini = cms.double(256),
-       fitterRatio = cms.double(0.25),
-       trackMinLayers = cms.int32(4),
-       trackMinPt = cms.double(0.4),
-       trackMinPixels = cms.int32(1),
-       maxTimeSignificance = cms.double(3.5)
+from RecoVertex.AdaptiveVertexFinder.trackVertexArbitratorDefault_cfi import trackVertexArbitratorDefault
 
-)
+trackVertexArbitrator = trackVertexArbitratorDefault.clone()
 
 

--- a/TrackingTools/TransientTrack/BuildFile.xml
+++ b/TrackingTools/TransientTrack/BuildFile.xml
@@ -13,6 +13,8 @@
 <use   name="TrackingTools/PatternTools"/>
 <use   name="TrackingTools/TrajectoryState"/>
 <use   name="DataFormats/Candidate"/>
+<use   name="DataFormats/ParticleFlowCandidate"/>
+<use   name="DataFormats/PatCandidates"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/TrackingTools/TransientTrack/src/TransientTrack.cc
+++ b/TrackingTools/TransientTrack/src/TransientTrack.cc
@@ -46,6 +46,11 @@ TransientTrack::TransientTrack( const CandidatePtr & tk , const MagneticField* f
 				const edm::ESHandle<GlobalTrackingGeometry>& tg) :
   Base( new CTT(tk, field, tg)) {}
 
+TransientTrack::TransientTrack( const CandidatePtr & tk, const double time, 
+				const double dtime, 
+				const MagneticField* field,  
+				const edm::ESHandle<GlobalTrackingGeometry>& tg) :
+  Base( new CTT(tk, time, dtime, field, tg) ) {}
 
 // TransientTrack::TransientTrack( const TransientTrack & tt ) :
 //   Base( new TTT(tt)) {}

--- a/TrackingTools/TransientTrack/src/TransientTrackBuilder.cc
+++ b/TrackingTools/TransientTrack/src/TransientTrackBuilder.cc
@@ -45,14 +45,7 @@ TransientTrack TransientTrackBuilder::build (const CandidatePtr * t) const {
 }
 
 TransientTrack TransientTrackBuilder::build (const CandidatePtr & t) const {
-  reco::PFCandidatePtr tryPF(t);
-  edm::Ptr<pat::PackedCandidate> tryPacked(t);
-  if( tryPF.get() != nullptr && tryPF->isTimeValid() ) {
-    return TransientTrack(t, tryPF->time(), tryPF->timeError(), theField, theTrackingGeometry);
-  } else if ( tryPacked.get() != nullptr && tryPacked->timeError() > 0.f ) {
-    return TransientTrack(t, (double)tryPacked->time(), (double)tryPacked->timeError(), theField, theTrackingGeometry);
-  }
-  return TransientTrack(t, theField, theTrackingGeometry);
+  return this->build(&t);  
 }
 
 TransientTrack TransientTrackBuilder::build (const TrackRef * t) const {

--- a/TrackingTools/TransientTrack/src/TransientTrackBuilder.cc
+++ b/TrackingTools/TransientTrack/src/TransientTrackBuilder.cc
@@ -4,6 +4,10 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrackFromFTS.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
 using namespace reco;
 using namespace std;
@@ -30,10 +34,24 @@ TransientTrack TransientTrackBuilder::build (const GsfTrack & t) const {
 }
 
 TransientTrack TransientTrackBuilder::build (const CandidatePtr * t) const {
+  reco::PFCandidatePtr tryPF(*t);
+  edm::Ptr<pat::PackedCandidate> tryPacked(*t);
+  if( tryPF.get() != nullptr && tryPF->isTimeValid() ) {
+    return TransientTrack(*t, tryPF->time(), tryPF->timeError(), theField, theTrackingGeometry);
+  } else if ( tryPacked.get() != nullptr && tryPacked->timeError() > 0.f ) {
+    return TransientTrack(*t, (double)tryPacked->time(), (double)tryPacked->timeError(), theField, theTrackingGeometry);
+  }
   return TransientTrack(*t, theField, theTrackingGeometry);
 }
 
 TransientTrack TransientTrackBuilder::build (const CandidatePtr & t) const {
+  reco::PFCandidatePtr tryPF(t);
+  edm::Ptr<pat::PackedCandidate> tryPacked(t);
+  if( tryPF.get() != nullptr && tryPF->isTimeValid() ) {
+    return TransientTrack(t, tryPF->time(), tryPF->timeError(), theField, theTrackingGeometry);
+  } else if ( tryPacked.get() != nullptr && tryPacked->timeError() > 0.f ) {
+    return TransientTrack(t, (double)tryPacked->time(), (double)tryPacked->timeError(), theField, theTrackingGeometry);
+  }
   return TransientTrack(t, theField, theTrackingGeometry);
 }
 


### PR DESCRIPTION
This PR adds the possibility to cut on the time significance between a vertex with timing and a time stamped track. 

Timing is checked for dynamically in both the vertex and the transient track. If not present in both the timing cut is skipped.

This will only affect timing workflows where the 1D vertex reconstruction is overridden (Phase2_timing_layer / D19).