### PR TITLE
Several fixes for boost version handling

### DIFF
--- a/CondCore/Utilities/python/conddb_serialization_metadata.py
+++ b/CondCore/Utilities/python/conddb_serialization_metadata.py
@@ -156,7 +156,7 @@ def get_boost_version_from_streamer_info( streamer_info ):
         raise Exception("Streamer info found in unexpected format.")
     return iovBoostVersion
 
-def do_update_tag_boost_version( tagBoostVersion, iovBoostVersion, iov, timetype, boost_run_map ):
+def do_update_tag_boost_version( tagBoostVersion, minIov, iovBoostVersion, iov, timetype, boost_run_map ):
     # for hash timetype we need to take the greatest version of the set                                                                                                                 
     if timetype == 'Hash':
         if tagBoostVersion is None or cmp_boost_version(tagBoostVersion,iovBoostVersion)<0:
@@ -166,17 +166,23 @@ def do_update_tag_boost_version( tagBoostVersion, iovBoostVersion, iov, timetype
         if tagBoostVersion is None:
             tagBoostVersion = iovBoostVersion
         else:
-            referenceBoost = lookup_boost_for_run( iov, timetype, boost_run_map )
-            if cmp_boost_version( referenceBoost, iovBoostVersion )<0:
+            iovRefBoost = lookup_boost_for_run( iov, timetype, boost_run_map )
+            # the case when the iov does not follow the standard run history
+            if cmp_boost_version( iovRefBoost, iovBoostVersion )<0:
                 if cmp_boost_version(  tagBoostVersion, iovBoostVersion )<0:
                     tagBoostVersion = iovBoostVersion
+            # iov in agreement witjh the standard run history
             else:
-                if cmp_boost_version(  tagBoostVersion, iovBoostVersion )>0:
-                    tagBoostVersion = iovBoostVersion
+                tagRefBoost = lookup_boost_for_run( minIov, timetype, boost_run_map )
+                # also the current tag follows the standard run history
+                if cmp_boost_version( tagRefBoost, tagBoostVersion )>=0:
+                    # in this case the min boost version should decrease to 
+                    if cmp_boost_version(  tagBoostVersion, iovRefBoost )>0:
+                        tagBoostVersion = iovRefBoost
     return tagBoostVersion
 
-def update_tag_boost_version( tagBoostVersion, streamer_info, iov, timetype, boost_run_map ):
+def update_tag_boost_version( tagBoostVersion, minIov, streamer_info, iov, timetype, boost_run_map ):
     iovBoostVersion = get_boost_version_from_streamer_info( streamer_info )
-    return iovBoostVersion, do_update_tag_boost_version( tagBoostVersion, iovBoostVersion, iov, timetype, boost_run_map )
+    return iovBoostVersion, do_update_tag_boost_version( tagBoostVersion, minIov, iovBoostVersion, iov, timetype, boost_run_map )
 
             

--- a/CondCore/Utilities/python/conddblib.py
+++ b/CondCore/Utilities/python/conddblib.py
@@ -267,6 +267,7 @@ class TagMetadata:
     __tablename__       = 'TAG_METADATA'
     columns             = { 'tag_name': (DbRef(Tag,'name'),_Col.pk), 
                             'min_serialization_v': (sqlalchemy.String(20),_Col.notNull),
+                            'min_since': (sqlalchemy.BIGINT,_Col.notNull),
                             'modification_time':(sqlalchemy.TIMESTAMP,_Col.notNull) }
 
 class Payload:

--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -1439,10 +1439,12 @@ def _copy_tag(args, copyTime, session1, session2, first, second, fromIOV=None, t
             r = _rawdict(r)
             boost_run_map.append( (r['run_number'],r['run_start_time'],r['boost_version']) )
         TagMetadata = session2.get_dbtype(conddb.TagMetadata)
-        q = session2.query(TagMetadata.min_serialization_v).filter(TagMetadata.tag_name == second )
+        q = session2.query(TagMetadata.min_serialization_v,TagMetadata.min_since).filter(TagMetadata.tag_name == second )
         tagBoostVersion = None
+        minIov = None
         for r in q:
             tagBoostVersion = r[0]
+            minIov = r[1]
             break
         currentTagBoostVersion = tagBoostVersion
         if len(iovs)>0 and destExists and currentTagBoostVersion is None:
@@ -1455,7 +1457,9 @@ def _copy_tag(args, copyTime, session1, session2, first, second, fromIOV=None, t
         niovs += 1
         if payloadSerializationVersionMap is not None:
             if v in payloadSerializationVersionMap.keys():
-                tagBoostVersion = serialization_metadata.do_update_tag_boost_version(tagBoostVersion,payloadSerializationVersionMap[v], k, destTimeType, boost_run_map )
+                tagBoostVersion = serialization_metadata.do_update_tag_boost_version(tagBoostVersion,minIov,payloadSerializationVersionMap[v], k, destTimeType, boost_run_map )
+        if minIov is None or k<minIov:
+            minIov = k
     if not niovs==0:
         logging.info('%s iov(s) copied.',niovs)
         merge = False
@@ -1469,7 +1473,7 @@ def _copy_tag(args, copyTime, session1, session2, first, second, fromIOV=None, t
             else:
                 merge = True
         if merge:
-            session2.merge(TagMetadata(tag_name=second,min_serialization_v=tagBoostVersion,modification_time=copyTime))
+            session2.merge(TagMetadata(tag_name=second,min_serialization_v=tagBoostVersion,min_since=minIov,modification_time=copyTime))
             logging.info('Destination Tag boost Version set to %s ( was %s )' %(tagBoostVersion,currentTagBoostVersion) )
     return ret, niovs
 


### PR DESCRIPTION
The fixes in this PR only concern the command line tools, addressing essentially he algorithm for the tag minimum boost version, to be applied in the initialisation phase, to fill the new TAG_METADATA table.
 