### PR TITLE
add LumiCorrections records and definitions; adding LumiInfo.h members/methods

### DIFF
--- a/CondCore/LuminosityPlugins/src/plugin.cc
+++ b/CondCore/LuminosityPlugins/src/plugin.cc
@@ -1,9 +1,10 @@
 #include "CondCore/ESSources/interface/registration_macros.h"
 #include "CondFormats/Luminosity/interface/LumiSectionData.h"
 #include "CondFormats/DataRecord/interface/LumiSectionDataRcd.h"
+#include "CondFormats/Luminosity/interface/LumiCorrections.h"
+#include "CondFormats/DataRecord/interface/LumiCorrectionsRcd.h"
 
 
 REGISTER_PLUGIN(LumiSectionDataRcd, lumi::LumiSectionData);
-
-
+REGISTER_PLUGIN(LumiCorrectionsRcd, LumiCorrections);
 

--- a/CondFormats/DataRecord/interface/LumiCorrectionsRcd.h
+++ b/CondFormats/DataRecord/interface/LumiCorrectionsRcd.h
@@ -1,0 +1,25 @@
+#ifndef DataRecord_LumiCorrectionsRcd_h
+#define DataRecord_LumiCorrectionsRcd_h
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     LumiCorrectionsRcd
+// 
+/**\class LumiCorrectionsRcd LumiCorrectionsRcd.h CondFormats/DataRecord/interface/LumiCorrectionsRcd.h
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:      Sam Higginbotham
+// Created:     Fri, 21 Jul 2017 18:15:12 GMT
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class LumiCorrectionsRcd : public edm::eventsetup::EventSetupRecordImplementation<LumiCorrectionsRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/src/LumiCorrectionsRcd.cc
+++ b/CondFormats/DataRecord/src/LumiCorrectionsRcd.cc
@@ -1,0 +1,15 @@
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     LumiCorrectionsRcd
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Author:      Sam Higginbotham
+// Created:     Fri, 21 Jul 2017 18:15:12 GMT
+
+#include "CondFormats/DataRecord/interface/LumiCorrectionsRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(LumiCorrectionsRcd);

--- a/CondFormats/Luminosity/interface/LumiCorrections.h
+++ b/CondFormats/Luminosity/interface/LumiCorrections.h
@@ -1,0 +1,36 @@
+#ifndef LUMICORRECTIONS_H
+#define LUMICORRECTIONS_H
+
+
+/*
+*Author: Sam Higginbotham
+*Purpose: to save the corrections for the luminosity to the database 
+*
+*/
+#include <sstream>
+#include <cstring>
+#include <vector>
+#include <boost/serialization/vector.hpp>
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+class LumiCorrections {
+    public:
+        void  SetOverallCorrection(float overallCorrection){m_overallCorrection=overallCorrection;}
+        void  SetType1Fraction(float type1frac){m_type1Fraction=type1frac;}
+        void  SetType1Residual(float type1res){m_type1Residual=type1res;}
+        void  SetType2Residual(float type2res){m_type2Residual=type2res;}
+        void  SetCorrectionsBX(std::vector<float>& correctBX){m_correctionsBX.assign(correctBX.begin(),correctBX.end());} 
+        float GetOverallCorrection(){return m_overallCorrection;}
+        float GetType1Fraction(){return m_type1Fraction;}
+        float GetType1Residual(){return m_type1Residual;}
+        float GetType2Residual(){return m_type2Residual;}
+        const std::vector<float>& GetCorrectionsBX() const{return m_correctionsBX;} 
+    private:
+        float m_overallCorrection;
+        float m_type1Fraction;
+        float m_type1Residual;
+        float m_type2Residual;
+        std::vector<float> m_correctionsBX;
+        COND_SERIALIZABLE; 
+};
+#endif 

--- a/CondFormats/Luminosity/interface/LumiCorrections.h
+++ b/CondFormats/Luminosity/interface/LumiCorrections.h
@@ -15,16 +15,16 @@
 
 class LumiCorrections {
     public:
-        void  SetOverallCorrection(float overallCorrection){m_overallCorrection=overallCorrection;}
-        void  SetType1Fraction(float type1frac){m_type1Fraction=type1frac;}
-        void  SetType1Residual(float type1res){m_type1Residual=type1res;}
-        void  SetType2Residual(float type2res){m_type2Residual=type2res;}
-        void  SetCorrectionsBX(std::vector<float>& correctBX){m_correctionsBX.assign(correctBX.begin(),correctBX.end());} 
-        float GetOverallCorrection(){return m_overallCorrection;}
-        float GetType1Fraction(){return m_type1Fraction;}
-        float GetType1Residual(){return m_type1Residual;}
-        float GetType2Residual(){return m_type2Residual;}
-        const std::vector<float>& GetCorrectionsBX() const{return m_correctionsBX;} 
+        void  setOverallCorrection(float overallCorrection){m_overallCorrection=overallCorrection;}
+        void  setType1Fraction(float type1frac){m_type1Fraction=type1frac;}
+        void  setType1Residual(float type1res){m_type1Residual=type1res;}
+        void  setType2Residual(float type2res){m_type2Residual=type2res;}
+        void  setCorrectionsBX(std::vector<float>& correctBX){m_correctionsBX.assign(correctBX.begin(),correctBX.end());} 
+        float getOverallCorrection(){return m_overallCorrection;}
+        float getType1Fraction(){return m_type1Fraction;}
+        float getType1Residual(){return m_type1Residual;}
+        float getType2Residual(){return m_type2Residual;}
+        const std::vector<float>& getCorrectionsBX() const{return m_correctionsBX;} 
     private:
         float m_overallCorrection;
         float m_type1Fraction;

--- a/CondFormats/Luminosity/interface/LumiCorrections.h
+++ b/CondFormats/Luminosity/interface/LumiCorrections.h
@@ -1,12 +1,19 @@
-#ifndef LUMICORRECTIONS_H
-#define LUMICORRECTIONS_H
+#ifndef CondFormats_Luminosity_LumiCorrections_h
+#define CondFormats_Luminosity_LumiCorrections_h
+
+/** 
+ * \class LumiCorrections
+ * 
+ * \author Sam Higginbotham, Chris Palmer
+ *  
+ *  This class should contain scale factors for correcting
+ *  out-of-time pile-up per bunch crossing on rates intended
+ *  for luminosity estimates.  There is the option of saving 
+ *  the total scale factor on the total luminosity in
+ *  m_overallCorrection as well.  
+ */
 
 
-/*
-*Author: Sam Higginbotham
-*Purpose: to save the corrections for the luminosity to the database 
-*
-*/
 #include <sstream>
 #include <cstring>
 #include <vector>
@@ -21,6 +28,7 @@ class LumiCorrections {
         void  setType2Residual(float type2res){m_type2Residual=type2res;}
         void  setCorrectionsBX(std::vector<float>& correctBX){m_correctionsBX.assign(correctBX.begin(),correctBX.end());} 
         float getOverallCorrection(){return m_overallCorrection;}
+        float getCorrectionAtBX(float bx){return m_correctionsBX[bx];}
         float getType1Fraction(){return m_type1Fraction;}
         float getType1Residual(){return m_type1Residual;}
         float getType2Residual(){return m_type2Residual;}

--- a/CondFormats/Luminosity/src/T_EventSetup_LumiCorrections.cc
+++ b/CondFormats/Luminosity/src/T_EventSetup_LumiCorrections.cc
@@ -1,0 +1,6 @@
+// T_EventSetup_LumiCorrections.cc
+
+#include "CondFormats/Luminosity/interface/LumiCorrections.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(LumiCorrections);

--- a/CondFormats/Luminosity/src/classes_def.xml
+++ b/CondFormats/Luminosity/src/classes_def.xml
@@ -6,4 +6,5 @@
  <class name="std::vector< lumi::HLTInfo >"/>
  <class name="std::vector< lumi::TriggerInfo >"/>
  <class name="std::vector< lumi::BunchCrossingInfo >"/>
+ <class name="LumiCorrections" class_version="0"/>
 </lcgdict>  

--- a/CondFormats/Luminosity/src/headers.h
+++ b/CondFormats/Luminosity/src/headers.h
@@ -1,1 +1,2 @@
 #include "CondFormats/Luminosity/interface/LumiSectionData.h"
+#include "CondFormats/Luminosity/interface/LumiCorrections.h"

--- a/CondFormats/Luminosity/test/BuildFile.xml
+++ b/CondFormats/Luminosity/test/BuildFile.xml
@@ -1,3 +1,6 @@
 <bin file="testSerializationLuminosity.cpp">
     <use   name="CondFormats/Luminosity"/>
 </bin>
+<bin file="testSerializationLumiCorrections.cpp">
+    <use   name="CondFormats/Luminosity"/>
+</bin>

--- a/CondFormats/Luminosity/test/testSerializationLumiCorrections.cpp
+++ b/CondFormats/Luminosity/test/testSerializationLumiCorrections.cpp
@@ -1,6 +1,5 @@
 #include "CondFormats/Serialization/interface/Test.h"
-
-#include "../src/headers.h"
+#include "CondFormats/Luminosity/interface/LumiCorrections.h"
 
 int main()
 {

--- a/CondFormats/Luminosity/test/testSerializationLumiCorrections.cpp
+++ b/CondFormats/Luminosity/test/testSerializationLumiCorrections.cpp
@@ -1,0 +1,8 @@
+#include "CondFormats/Serialization/interface/Test.h"
+
+#include "../src/headers.h"
+
+int main()
+{
+    testSerialization<LumiCorrections>();
+}

--- a/DataFormats/Luminosity/interface/LumiInfo.h
+++ b/DataFormats/Luminosity/interface/LumiInfo.h
@@ -1,8 +1,8 @@
 #ifndef DataFormats_Luminosity_LumiInfo_h
 #define DataFormats_Luminosity_LumiInfo_h
  
-/** \class LumiInfo
- *
+/** 
+ * \class LumiInfo
  *
  * LumiInfo has been created by merging the content of
  * the old LumiSummary and LumiDetails classes to streamline
@@ -15,10 +15,10 @@
  *         Zhen Xie
  *         Paul Lujan
  * \version   1st Version June 7 2007, merged September 10 2014
- * \update    October 2017 by Chris Palmer and Sam Higginbotham for PCC projects
+ * \version    October 2017 by Chris Palmer and Sam Higginbotham for PCC projects
  * 
  *
- ************************************************************/
+ */
  
 #include <vector>
 #include <iosfwd>
@@ -26,103 +26,159 @@
 #include "DataFormats/Luminosity/interface/LumiConstants.h"
 
 class LumiInfo {
-public:
-  /// default constructor
-  LumiInfo():
-  deadtimeFraction_(0)
-  { 
-    instLumiByBX_.assign(LumiConstants::numBX, 0.0);
-    instLumiStatErrByBX_.assign(LumiConstants::numBX, 0.0);
-    totalInstLuminosity_=0;
-    totalInstLumiStatErr_=0;
-  } 
+  public:
+    /** 
+     * default constructor
+     */
+    LumiInfo():
+    deadtimeFraction_(0)
+    { 
+        instLumiByBX_.assign(LumiConstants::numBX, 0.0);
+        instLumiStatErrByBX_.assign(LumiConstants::numBX, 0.0);
+        totalInstLuminosity_=0;
+        totalInstLumiStatErr_=0;
+    } 
   
-  /// constructor with fill; if total algo is the same as summing
- LumiInfo(float deadtimeFraction, const std::vector<float>& instLumiByBX):
-  deadtimeFraction_(deadtimeFraction)
-  {
-    instLumiByBX_.assign(instLumiByBX.begin(), instLumiByBX.end());
-    instLumiStatErrByBX_.assign(LumiConstants::numBX, 0.0);
-    setTotalInstToBXSum() ;
-    totalInstLumiStatErr_=0;
-  }
 
-  /// constructor with fill; if total algo DIFFERS from summing
- LumiInfo(float deadtimeFraction, const std::vector<float>& instLumiByBX, float totalInstLumi):
-  deadtimeFraction_(deadtimeFraction)
-  {
-    instLumiByBX_.assign(instLumiByBX.begin(), instLumiByBX.end());
-    instLumiStatErrByBX_.assign(LumiConstants::numBX, 0.0);
-    totalInstLuminosity_=totalInstLumi;
-    totalInstLumiStatErr_=0;
-  }
+    /** 
+     * constructor with fill; if total algo is the same as summing
+     */
+    LumiInfo(float deadtimeFraction, const std::vector<float>& instLumiByBX):
+    deadtimeFraction_(deadtimeFraction)
+    {
+        instLumiByBX_.assign(instLumiByBX.begin(), instLumiByBX.end());
+        instLumiStatErrByBX_.assign(LumiConstants::numBX, 0.0);
+        setTotalInstToBXSum() ;
+        totalInstLumiStatErr_=0;
+    }
 
-  /// constructor with fill; if total algo DIFFERS from summing and adding including stats
- LumiInfo(float deadtimeFraction, const std::vector<float>& instLumiByBX, float totalInstLumi,
+    /** 
+     * constructor with fill; if total algo DIFFERS from summing
+     */
+    LumiInfo(float deadtimeFraction, const std::vector<float>& instLumiByBX, float totalInstLumi):
+    deadtimeFraction_(deadtimeFraction)
+    {
+        instLumiByBX_.assign(instLumiByBX.begin(), instLumiByBX.end());
+        instLumiStatErrByBX_.assign(LumiConstants::numBX, 0.0);
+        totalInstLuminosity_=totalInstLumi;
+        totalInstLumiStatErr_=0;
+    }
+
+    /** 
+     * constructor with fill; if total algo DIFFERS from summing and adding including stats
+     */
+    LumiInfo(float deadtimeFraction, const std::vector<float>& instLumiByBX, float totalInstLumi,
     const std::vector<float>& instLumiErrByBX, float totalInstLumiErr):
-  deadtimeFraction_(deadtimeFraction)
-  {
-    instLumiByBX_.assign(instLumiByBX.begin(), instLumiByBX.end());
-    instLumiStatErrByBX_.assign(instLumiErrByBX.begin(), instLumiErrByBX.end());
-    totalInstLuminosity_=totalInstLumi;
-    totalInstLumiStatErr_=totalInstLumiErr;
-  }
+    deadtimeFraction_(deadtimeFraction)
+    {
+        instLumiByBX_.assign(instLumiByBX.begin(), instLumiByBX.end());
+        instLumiStatErrByBX_.assign(instLumiErrByBX.begin(), instLumiErrByBX.end());
+        totalInstLuminosity_=totalInstLumi;
+        totalInstLumiStatErr_=totalInstLumiErr;
+    }
 
-  /// destructor
-  ~LumiInfo(){}
+    /** 
+     * destructor
+     */
+    ~LumiInfo(){}
 
-  //Total Luminosity Saved 
-  float getTotalInstLumi() const{return totalInstLuminosity_;}
+    //
+    // all getters
+    //
 
-  //Statistical Error on total lumi
-  float getTotalInstStatError() const{return totalInstLumiStatErr_;}
-
-  // Instantaneous luminosity (in Hz/ub)
-  float instLuminosityBXSum() const;
+    /** 
+     *  Returns total instantanious luminosity in hz/uB
+     */
+    float getTotalInstLumi() const{return totalInstLuminosity_;}
+    /** 
+     *  Returns statistical error on total instantanious luminosity in hz/uB
+     */
+    float getTotalInstStatError() const{return totalInstLumiStatErr_;}
+    /** 
+     *  Returns instantaneous luminosity of all bunches
+     */
+    const std::vector<float>& getInstLumiAllBX() const { return instLumiByBX_; }
+    /** 
+     * Returns statistical error of instantaneous luminosity for all bunches
+     */
+    const std::vector<float>& getErrorLumiAllBX() const { return instLumiStatErrByBX_; }
+    /** 
+     *  Returns instantaneous luminosity of one bunch
+     */
+    float getInstLumiBX(int bx) const { return instLumiByBX_.at(bx); }
+    /** 
+     * Deadtime fraction
+     */
+    float getDeadFraction() const { return deadtimeFraction_; }
+    /** 
+     * Livetime fraction (1-deadtime frac)
+     */
+    float getLiveFraction() const { return 1-deadtimeFraction_; }
   
-  void setTotalInstToBXSum() ;
+    
+    //
+    // all setters
+    //
 
-  // Integrated (delivered) luminosity (in ub^-1)
-  float integLuminosity() const;
+    /** 
+     * Set the deadtime fraction
+     */
+    void setDeadFraction(float deadtimeFraction) { deadtimeFraction_ = deadtimeFraction; }
+    /** 
+     * Set total instantanious luminosity in hz/uB
+     */
+    void setTotalInstLumi(float totalLumi){ totalInstLuminosity_=totalLumi;}
+    /** 
+     *  Set statistical error on total instantanious luminosity in hz/uB
+     */
+    void setTotalInstStatError(float statError){ totalInstLumiStatErr_=statError;}
+    /** 
+     *  Set statistical error of instantaneous luminosity for all bunches
+     */
+    void setInstLumiAllBX(std::vector<float>& instLumiByBX);
+    /** 
+     *  Set statistical error of instantaneous luminosity for all bunches
+     */
+    void setErrorLumiAllBX(std::vector<float>& errLumiByBX);
 
-  // Recorded (integrated) luminosity (in ub^-1)
-  // (==integLuminosity * (1-deadtimeFraction))
-  float recordedLuminosity() const;
+  
+    /** 
+     *  Resets totalInstLuminosity_ to be the sum of instantaneous 
+     *  luminosity 
+     */
+    void setTotalInstToBXSum() ;
 
-  // Deadtime/livetime fraction
-  float deadFraction() const { return deadtimeFraction_; }
-  float liveFraction() const { return 1-deadtimeFraction_; }
 
-  // lumi section length in seconds = numorbits*3564*25e-09
-  float lumiSectionLength() const;
+    /** 
+     *  Returns the sum of the instantaneous luminosity in Hz/uB,
+     *  which not always the same as totalInstLuminosity_.
+     */
+    float instLuminosityBXSum() const;
+    /** 
+     * Integrated (delivered) luminosity (in ub^-1)
+     */
+    float integLuminosity() const;
+    /** 
+     * Recorded (integrated) luminosity (in ub^-1)
+     * (==integLuminosity * (1-deadtimeFraction))
+     */
+    float recordedLuminosity() const;
+    /** 
+     * lumi section length in seconds = numorbits*3564*25e-09
+     */
+    float lumiSectionLength() const;
+    /** 
+     *  This method checks if all the essential values of this LumiInfo are
+     *  the same as the ones in the LumiInfo given as an argument.
+     */
+    bool isProductEqual(LumiInfo const& next) const;
 
-  void setInstLumi(std::vector<float>& instLumiByBX);
-
-  void setErrLumiBX(std::vector<float>& errLumiByBX);
-
-  // Inst lumi by bunch
-  float getInstLumiBX(int bx) const { return instLumiByBX_.at(bx); }
-  const std::vector<float>& getInstLumiAllBX() const { return instLumiByBX_; }
-  const std::vector<float>& getErrorLumiAllBX() const { return instLumiStatErrByBX_; }
-
-  bool isProductEqual(LumiInfo const& next) const;
-
-  //
-  //setters
-  //
-
-  void setDeadFraction(float deadtimeFraction) { deadtimeFraction_ = deadtimeFraction; }
-  //set the total raw luminosity
-  void setTotalInstLumi(float totalLumi){ totalInstLuminosity_=totalLumi;}
-  //set the statistical error
-  void setTotalStatError(float statError){ totalInstLumiStatErr_=statError;}
-
-private:
-  float totalInstLuminosity_;
-  float totalInstLumiStatErr_;
-  float deadtimeFraction_;
-  std::vector<float> instLumiByBX_;
-  std::vector<float> instLumiStatErrByBX_;
+  private:
+    float totalInstLuminosity_;
+    float totalInstLumiStatErr_;
+    float deadtimeFraction_;
+    std::vector<float> instLumiByBX_;
+    std::vector<float> instLumiStatErrByBX_;
 }; 
 
 std::ostream& operator<<(std::ostream& s, const LumiInfo& lumiInfo);

--- a/DataFormats/Luminosity/interface/LumiInfo.h
+++ b/DataFormats/Luminosity/interface/LumiInfo.h
@@ -30,6 +30,9 @@ public:
   deadtimeFraction_(0)
   { 
     instLumiByBX_.assign(LumiConstants::numBX, 0.0);
+    errLumiByBX_.assign(LumiConstants::numBX, 0.0);
+    totalLuminosity_=0;
+    totalStatError_=0;
   } 
   
   /// constructor with fill
@@ -42,6 +45,12 @@ public:
 
   /// destructor
   ~LumiInfo(){}
+
+  //Total Luminosity Saved 
+  float getTotalLumi() const{return totalLuminosity_;}
+
+  //Statistical Error on total lumi
+  float getTotalStatError() const{return totalStatError_;}
 
   // Instantaneous luminosity (in Hz/ub)
   float instLuminosity() const;
@@ -60,9 +69,14 @@ public:
   // lumi section length in seconds = numorbits*3564*25e-09
   float lumiSectionLength() const;
 
+  void setInstLumi(std::vector<float>& instLumiByBX);
+
+  void setErrLumiBX(std::vector<float>& errLumiByBX);
+
   // Inst lumi by bunch
   float getInstLumiBX(int bx) const { return instLumiByBX_.at(bx); }
   const std::vector<float>& getInstLumiAllBX() const { return instLumiByBX_; }
+  const std::vector<float>& getErrorLumiAllBX() const { return errLumiByBX_; }
 
   bool isProductEqual(LumiInfo const& next) const;
 
@@ -71,14 +85,17 @@ public:
   //
 
   void setDeadFraction(float deadtimeFraction) { deadtimeFraction_ = deadtimeFraction; }
-  // fill inst lumi
-  void fill(const std::vector<float>& instLumiByBX);
-  // synonym for above
-  void fillInstLumi(const std::vector<float>& instLumiByBX);
+  //set the total raw luminosity
+  void setTotalLumi(float totalLumi){ totalLuminosity_=totalLumi;}
+  //set the statistical error
+  void setTotalStatError(float statError){ totalStatError_=statError;}
 
 private:
+  float totalLuminosity_;
+  float totalStatError_;
   float deadtimeFraction_;
   std::vector<float> instLumiByBX_;
+  std::vector<float> errLumiByBX_;
 }; 
 
 std::ostream& operator<<(std::ostream& s, const LumiInfo& lumiInfo);

--- a/DataFormats/Luminosity/interface/LumiInfo.h
+++ b/DataFormats/Luminosity/interface/LumiInfo.h
@@ -15,6 +15,8 @@
  *         Zhen Xie
  *         Paul Lujan
  * \version   1st Version June 7 2007, merged September 10 2014
+ * \update    October 2017 by Chris Palmer and Sam Higginbotham for PCC projects
+ * 
  *
  ************************************************************/
  
@@ -30,30 +32,53 @@ public:
   deadtimeFraction_(0)
   { 
     instLumiByBX_.assign(LumiConstants::numBX, 0.0);
-    errLumiByBX_.assign(LumiConstants::numBX, 0.0);
-    totalLuminosity_=0;
-    totalStatError_=0;
+    instLumiStatErrByBX_.assign(LumiConstants::numBX, 0.0);
+    totalInstLuminosity_=0;
+    totalInstLumiStatErr_=0;
   } 
   
-  /// constructor with fill
- LumiInfo(float deadtimeFraction,
-	  const std::vector<float>& instLumiByBX):
+  /// constructor with fill; if total algo is the same as summing
+ LumiInfo(float deadtimeFraction, const std::vector<float>& instLumiByBX):
   deadtimeFraction_(deadtimeFraction)
   {
     instLumiByBX_.assign(instLumiByBX.begin(), instLumiByBX.end());
+    instLumiStatErrByBX_.assign(LumiConstants::numBX, 0.0);
+    totalInstLuminosity_=instLuminosityBXSum();
+    totalInstLumiStatErr_=0;
+  }
+
+  /// constructor with fill; if total algo DIFFERS from summing
+ LumiInfo(float deadtimeFraction, const std::vector<float>& instLumiByBX, float totalInstLumi):
+  deadtimeFraction_(deadtimeFraction)
+  {
+    instLumiByBX_.assign(instLumiByBX.begin(), instLumiByBX.end());
+    instLumiStatErrByBX_.assign(LumiConstants::numBX, 0.0);
+    totalInstLuminosity_=totalInstLumi;
+    totalInstLumiStatErr_=0;
+  }
+
+  /// constructor with fill; if total algo DIFFERS from summing and adding including stats
+ LumiInfo(float deadtimeFraction, const std::vector<float>& instLumiByBX, float totalInstLumi,
+    const std::vector<float>& instLumiErrByBX, float totalInstLumiErr):
+  deadtimeFraction_(deadtimeFraction)
+  {
+    instLumiByBX_.assign(instLumiByBX.begin(), instLumiByBX.end());
+    instLumiStatErrByBX_.assign(instLumiErrByBX.begin(), instLumiErrByBX.end());
+    totalInstLuminosity_=totalInstLumi;
+    totalInstLumiStatErr_=totalInstLumiErr;
   }
 
   /// destructor
   ~LumiInfo(){}
 
   //Total Luminosity Saved 
-  float getTotalLumi() const{return totalLuminosity_;}
+  float getTotalInstLumi() const{return totalInstLuminosity_;}
 
   //Statistical Error on total lumi
-  float getTotalStatError() const{return totalStatError_;}
+  float getTotalInstStatError() const{return totalInstLumiStatErr_;}
 
   // Instantaneous luminosity (in Hz/ub)
-  float instLuminosity() const;
+  float instLuminosityBXSum() const;
 
   // Integrated (delivered) luminosity (in ub^-1)
   float integLuminosity() const;
@@ -76,7 +101,7 @@ public:
   // Inst lumi by bunch
   float getInstLumiBX(int bx) const { return instLumiByBX_.at(bx); }
   const std::vector<float>& getInstLumiAllBX() const { return instLumiByBX_; }
-  const std::vector<float>& getErrorLumiAllBX() const { return errLumiByBX_; }
+  const std::vector<float>& getErrorLumiAllBX() const { return instLumiStatErrByBX_; }
 
   bool isProductEqual(LumiInfo const& next) const;
 
@@ -86,16 +111,16 @@ public:
 
   void setDeadFraction(float deadtimeFraction) { deadtimeFraction_ = deadtimeFraction; }
   //set the total raw luminosity
-  void setTotalLumi(float totalLumi){ totalLuminosity_=totalLumi;}
+  void setTotalLumi(float totalLumi){ totalInstLuminosity_=totalLumi;}
   //set the statistical error
-  void setTotalStatError(float statError){ totalStatError_=statError;}
+  void setTotalStatError(float statError){ totalInstLumiStatErr_=statError;}
 
 private:
-  float totalLuminosity_;
-  float totalStatError_;
+  float totalInstLuminosity_;
+  float totalInstLumiStatErr_;
   float deadtimeFraction_;
   std::vector<float> instLumiByBX_;
-  std::vector<float> errLumiByBX_;
+  std::vector<float> instLumiStatErrByBX_;
 }; 
 
 std::ostream& operator<<(std::ostream& s, const LumiInfo& lumiInfo);

--- a/DataFormats/Luminosity/interface/LumiInfo.h
+++ b/DataFormats/Luminosity/interface/LumiInfo.h
@@ -44,9 +44,9 @@ class LumiInfo {
      * constructor with fill; if total algo is the same as summing
      */
     LumiInfo(float deadtimeFraction, const std::vector<float>& instLumiByBX):
-    deadtimeFraction_(deadtimeFraction)
+    deadtimeFraction_(deadtimeFraction),
+    instLumiByBX_(instLumiByBX)
     {
-        instLumiByBX_.assign(instLumiByBX.begin(), instLumiByBX.end());
         instLumiStatErrByBX_.assign(LumiConstants::numBX, 0.0);
         setTotalInstToBXSum() ;
         totalInstLumiStatErr_=0;
@@ -56,11 +56,11 @@ class LumiInfo {
      * constructor with fill; if total algo DIFFERS from summing
      */
     LumiInfo(float deadtimeFraction, const std::vector<float>& instLumiByBX, float totalInstLumi):
-    deadtimeFraction_(deadtimeFraction)
+    deadtimeFraction_(deadtimeFraction),
+    totalInstLuminosity_(totalInstLumi),
+    instLumiByBX_(instLumiByBX)
     {
-        instLumiByBX_.assign(instLumiByBX.begin(), instLumiByBX.end());
         instLumiStatErrByBX_.assign(LumiConstants::numBX, 0.0);
-        totalInstLuminosity_=totalInstLumi;
         totalInstLumiStatErr_=0;
     }
 
@@ -69,12 +69,12 @@ class LumiInfo {
      */
     LumiInfo(float deadtimeFraction, const std::vector<float>& instLumiByBX, float totalInstLumi,
     const std::vector<float>& instLumiErrByBX, float totalInstLumiErr):
-    deadtimeFraction_(deadtimeFraction)
+    deadtimeFraction_(deadtimeFraction),
+    totalInstLuminosity_(totalInstLumi),
+    totalInstLumiStatErr_(totalInstLumiErr),
+    instLumiByBX_(instLumiByBX),
+    instLumiStatErrByBX_(instLumiErrByBX)
     {
-        instLumiByBX_.assign(instLumiByBX.begin(), instLumiByBX.end());
-        instLumiStatErrByBX_.assign(instLumiErrByBX.begin(), instLumiErrByBX.end());
-        totalInstLuminosity_=totalInstLumi;
-        totalInstLumiStatErr_=totalInstLumiErr;
     }
 
     /** 
@@ -174,9 +174,9 @@ class LumiInfo {
     bool isProductEqual(LumiInfo const& next) const;
 
   private:
+    float deadtimeFraction_;
     float totalInstLuminosity_;
     float totalInstLumiStatErr_;
-    float deadtimeFraction_;
     std::vector<float> instLumiByBX_;
     std::vector<float> instLumiStatErrByBX_;
 }; 

--- a/DataFormats/Luminosity/interface/LumiInfo.h
+++ b/DataFormats/Luminosity/interface/LumiInfo.h
@@ -43,7 +43,7 @@ public:
   {
     instLumiByBX_.assign(instLumiByBX.begin(), instLumiByBX.end());
     instLumiStatErrByBX_.assign(LumiConstants::numBX, 0.0);
-    totalInstLuminosity_=instLuminosityBXSum();
+    setTotalInstToBXSum() ;
     totalInstLumiStatErr_=0;
   }
 
@@ -79,6 +79,8 @@ public:
 
   // Instantaneous luminosity (in Hz/ub)
   float instLuminosityBXSum() const;
+  
+  void setTotalInstToBXSum() ;
 
   // Integrated (delivered) luminosity (in ub^-1)
   float integLuminosity() const;
@@ -111,7 +113,7 @@ public:
 
   void setDeadFraction(float deadtimeFraction) { deadtimeFraction_ = deadtimeFraction; }
   //set the total raw luminosity
-  void setTotalLumi(float totalLumi){ totalInstLuminosity_=totalLumi;}
+  void setTotalInstLumi(float totalLumi){ totalInstLuminosity_=totalLumi;}
   //set the statistical error
   void setTotalStatError(float statError){ totalInstLumiStatErr_=statError;}
 

--- a/DataFormats/Luminosity/interface/PixelClusterCounts.h
+++ b/DataFormats/Luminosity/interface/PixelClusterCounts.h
@@ -41,7 +41,12 @@ class PixelClusterCounts {
         std::vector<int> const & readCounts() const {
             return(m_counts);
         }
-  
+        std::vector<int> const & readEvents() const {
+            return(m_events);
+        }
+        std::vector<int> const & readModID() const {
+            return(m_ModID);
+        } 
 
       private:
         std::vector<int> m_counts;

--- a/DataFormats/Luminosity/src/LumiInfo.cc
+++ b/DataFormats/Luminosity/src/LumiInfo.cc
@@ -1,5 +1,6 @@
 #include "DataFormats/Luminosity/interface/LumiInfo.h"
 
+#include <vector>
 #include <iomanip>
 #include <ostream>
 #include <iostream>
@@ -31,12 +32,12 @@ bool LumiInfo::isProductEqual(LumiInfo const& next) const {
 	  instLumiByBX_ == next.instLumiByBX_);
 }
 
-void LumiInfo::fillInstLumi(const std::vector<float>& instLumiByBX) {
+void LumiInfo::setInstLumi(std::vector<float>& instLumiByBX) {
   instLumiByBX_.assign(instLumiByBX.begin(), instLumiByBX.end());
 }
 
-void LumiInfo::fill(const std::vector<float>& instLumiByBX) {
-  fillInstLumi(instLumiByBX);
+void LumiInfo::setErrLumiBX(std::vector<float>& errLumiByBX){
+  errLumiByBX_.assign(errLumiByBX.begin(),errLumiByBX.end());
 }
 
 std::ostream& operator<<(std::ostream& s, const LumiInfo& lumiInfo) {

--- a/DataFormats/Luminosity/src/LumiInfo.cc
+++ b/DataFormats/Luminosity/src/LumiInfo.cc
@@ -36,11 +36,11 @@ bool LumiInfo::isProductEqual(LumiInfo const& next) const {
 	  instLumiByBX_ == next.instLumiByBX_);
 }
 
-void LumiInfo::setInstLumi(std::vector<float>& instLumiByBX) {
+void LumiInfo::setInstLumiAllBX(std::vector<float>& instLumiByBX) {
   instLumiByBX_.assign(instLumiByBX.begin(), instLumiByBX.end());
 }
 
-void LumiInfo::setErrLumiBX(std::vector<float>& errLumiByBX){
+void LumiInfo::setErrorLumiAllBX(std::vector<float>& errLumiByBX){
   instLumiStatErrByBX_.assign(errLumiByBX.begin(),errLumiByBX.end());
 }
 
@@ -49,7 +49,7 @@ std::ostream& operator<<(std::ostream& s, const LumiInfo& lumiInfo) {
   s << "  getTotalInstLumi = " << lumiInfo.getTotalInstLumi() << "\n";
   s << "  integLuminosity = " << lumiInfo.integLuminosity() << "\n";
   s << "  recordedLuminosity = " << lumiInfo.recordedLuminosity() << "\n";
-  s << "  deadtimeFraction = " << lumiInfo.deadFraction() << "\n";
+  s << "  deadtimeFraction = " << lumiInfo.getDeadFraction() << "\n";
   s << "  instLumiByBX = ";
   const std::vector<float>& lumiBX = lumiInfo.getInstLumiAllBX();
   for (unsigned int i=0; i<10 && i<lumiBX.size(); ++i) {

--- a/DataFormats/Luminosity/src/LumiInfo.cc
+++ b/DataFormats/Luminosity/src/LumiInfo.cc
@@ -5,7 +5,7 @@
 #include <ostream>
 #include <iostream>
 
-float LumiInfo::instLuminosity() const {
+float LumiInfo::instLuminosityBXSum() const {
   float totLum = 0;
   for (std::vector<float>::const_iterator it = instLumiByBX_.begin();
        it != instLumiByBX_.end(); ++it) {
@@ -15,7 +15,7 @@ float LumiInfo::instLuminosity() const {
 }
 
 float LumiInfo::integLuminosity() const {
-  return instLuminosity()*lumiSectionLength();
+  return getTotalInstLumi()*lumiSectionLength();
 }
 
 float LumiInfo::recordedLuminosity() const {
@@ -37,12 +37,12 @@ void LumiInfo::setInstLumi(std::vector<float>& instLumiByBX) {
 }
 
 void LumiInfo::setErrLumiBX(std::vector<float>& errLumiByBX){
-  errLumiByBX_.assign(errLumiByBX.begin(),errLumiByBX.end());
+  instLumiStatErrByBX_.assign(errLumiByBX.begin(),errLumiByBX.end());
 }
 
 std::ostream& operator<<(std::ostream& s, const LumiInfo& lumiInfo) {
   s << "\nDumping LumiInfo\n\n";
-  s << "  instLuminosity = " << lumiInfo.instLuminosity() << "\n";
+  s << "  getTotalInstLumi = " << lumiInfo.getTotalInstLumi() << "\n";
   s << "  integLuminosity = " << lumiInfo.integLuminosity() << "\n";
   s << "  recordedLuminosity = " << lumiInfo.recordedLuminosity() << "\n";
   s << "  deadtimeFraction = " << lumiInfo.deadFraction() << "\n";

--- a/DataFormats/Luminosity/src/LumiInfo.cc
+++ b/DataFormats/Luminosity/src/LumiInfo.cc
@@ -18,6 +18,10 @@ float LumiInfo::integLuminosity() const {
   return getTotalInstLumi()*lumiSectionLength();
 }
 
+void LumiInfo::setTotalInstToBXSum() {
+  setTotalInstLumi(instLuminosityBXSum());
+}
+
 float LumiInfo::recordedLuminosity() const {
   return integLuminosity()*(1-deadtimeFraction_);
 }

--- a/DataFormats/Luminosity/src/classes_def.xml
+++ b/DataFormats/Luminosity/src/classes_def.xml
@@ -16,6 +16,7 @@
   </class>
   <class name="LumiInfo"  ClassVersion="11">
    <version ClassVersion="11" checksum="3173942899"/>
+   <version ClassVersion="10" checksum="4234044727"/>
   </class>
   <class name="BeamCurrentInfo" ClassVersion="10">
    <version ClassVersion="10" checksum="706652033"/>

--- a/DataFormats/Luminosity/src/classes_def.xml
+++ b/DataFormats/Luminosity/src/classes_def.xml
@@ -15,7 +15,7 @@
    <version ClassVersion="10" checksum="3459250671"/>
   </class>
   <class name="LumiInfo"  ClassVersion="11">
-   <version ClassVersion="11" checksum="3173942899"/>
+   <version ClassVersion="11" checksum="4029613815"/>
    <version ClassVersion="10" checksum="4234044727"/>
   </class>
   <class name="BeamCurrentInfo" ClassVersion="10">

--- a/DataFormats/Luminosity/src/classes_def.xml
+++ b/DataFormats/Luminosity/src/classes_def.xml
@@ -15,7 +15,7 @@
    <version ClassVersion="10" checksum="3459250671"/>
   </class>
   <class name="LumiInfo"  ClassVersion="11">
-   <version ClassVersion="11" checksum="4029613815"/>
+   <version ClassVersion="11" checksum="323813487"/>
    <version ClassVersion="10" checksum="4234044727"/>
   </class>
   <class name="BeamCurrentInfo" ClassVersion="10">

--- a/DataFormats/Luminosity/src/classes_def.xml
+++ b/DataFormats/Luminosity/src/classes_def.xml
@@ -14,8 +14,8 @@
   <class name="LumiInfoRunHeader"  ClassVersion="10">
    <version ClassVersion="10" checksum="3459250671"/>
   </class>
-  <class name="LumiInfo"  ClassVersion="10">
-   <version ClassVersion="10" checksum="4234044727"/>
+  <class name="LumiInfo"  ClassVersion="11">
+   <version ClassVersion="11" checksum="3173942899"/>
   </class>
   <class name="BeamCurrentInfo" ClassVersion="10">
    <version ClassVersion="10" checksum="706652033"/>

--- a/DataFormats/Luminosity/test/lumiInfo_t.cpp
+++ b/DataFormats/Luminosity/test/lumiInfo_t.cpp
@@ -47,7 +47,7 @@ TestLumiInfo::testFill() {
   lumBX.push_back(2.0f);
   lumBX.push_back(3.0f);
 
-  lumiInfo.fill(lumBX);
+  lumiInfo.setInstLumi(lumBX);
 
   CPPUNIT_ASSERT(std::abs(lumiInfo.getInstLumiBX(0) - 1.0f) < tol);
   CPPUNIT_ASSERT(std::abs(lumiInfo.getInstLumiBX(1) - 2.0f) < tol);

--- a/DataFormats/Luminosity/test/lumiInfo_t.cpp
+++ b/DataFormats/Luminosity/test/lumiInfo_t.cpp
@@ -34,8 +34,8 @@ TestLumiInfo::testConstructor() {
   LumiInfo lumiInfo;
   
   lumiInfo.setDeadFraction(0.4);
-  CPPUNIT_ASSERT(std::abs(lumiInfo.deadFraction() - 0.4) < tol);
-  CPPUNIT_ASSERT(std::abs(lumiInfo.liveFraction() - 0.6) < tol);
+  CPPUNIT_ASSERT(std::abs(lumiInfo.getDeadFraction() - 0.4) < tol);
+  CPPUNIT_ASSERT(std::abs(lumiInfo.getLiveFraction() - 0.6) < tol);
 }
 
 void
@@ -47,7 +47,7 @@ TestLumiInfo::testFill() {
   lumBX.push_back(2.0f);
   lumBX.push_back(3.0f);
 
-  lumiInfo.setInstLumi(lumBX);
+  lumiInfo.setInstLumiAllBX(lumBX);
   lumiInfo.setTotalInstLumi(8.0f);
 
   CPPUNIT_ASSERT(std::abs(lumiInfo.getInstLumiBX(0) - 1.0f) < tol);

--- a/DataFormats/Luminosity/test/lumiInfo_t.cpp
+++ b/DataFormats/Luminosity/test/lumiInfo_t.cpp
@@ -53,7 +53,7 @@ TestLumiInfo::testFill() {
   CPPUNIT_ASSERT(std::abs(lumiInfo.getInstLumiBX(1) - 2.0f) < tol);
   CPPUNIT_ASSERT(std::abs(lumiInfo.getInstLumiBX(2) - 3.0f) < tol);
 
-  CPPUNIT_ASSERT(std::abs(lumiInfo.getTotalInstLumi() - 6.0f) < tol);
+  CPPUNIT_ASSERT(std::abs(lumiInfo.instLuminosityBXSum() - 6.0f) < tol);
   CPPUNIT_ASSERT(std::abs(lumiInfo.integLuminosity() - 6.0f*lumiInfo.lumiSectionLength()) < tol);
   CPPUNIT_ASSERT(std::abs(lumiInfo.recordedLuminosity() - 3.0f*lumiInfo.lumiSectionLength()) < tol);
   

--- a/DataFormats/Luminosity/test/lumiInfo_t.cpp
+++ b/DataFormats/Luminosity/test/lumiInfo_t.cpp
@@ -48,15 +48,22 @@ TestLumiInfo::testFill() {
   lumBX.push_back(3.0f);
 
   lumiInfo.setInstLumi(lumBX);
+  lumiInfo.setTotalInstLumi(8.0f);
 
   CPPUNIT_ASSERT(std::abs(lumiInfo.getInstLumiBX(0) - 1.0f) < tol);
   CPPUNIT_ASSERT(std::abs(lumiInfo.getInstLumiBX(1) - 2.0f) < tol);
   CPPUNIT_ASSERT(std::abs(lumiInfo.getInstLumiBX(2) - 3.0f) < tol);
 
+  CPPUNIT_ASSERT(std::abs(lumiInfo.getTotalInstLumi() - 8.0f) < tol);
   CPPUNIT_ASSERT(std::abs(lumiInfo.instLuminosityBXSum() - 6.0f) < tol);
-  CPPUNIT_ASSERT(std::abs(lumiInfo.integLuminosity() - 6.0f*lumiInfo.lumiSectionLength()) < tol);
-  CPPUNIT_ASSERT(std::abs(lumiInfo.recordedLuminosity() - 3.0f*lumiInfo.lumiSectionLength()) < tol);
-  
+  CPPUNIT_ASSERT(std::abs(lumiInfo.integLuminosity() - 8.0f*lumiInfo.lumiSectionLength()) < tol);
+  CPPUNIT_ASSERT(std::abs(lumiInfo.recordedLuminosity() - 4.0f*lumiInfo.lumiSectionLength()) < tol);
+
+ 
+  lumiInfo.setTotalInstToBXSum();
+  CPPUNIT_ASSERT(std::abs(lumiInfo.getTotalInstLumi() - 6.0f) < tol);
+
+
   CPPUNIT_ASSERT(lumiInfo.isProductEqual(lumiInfo));
 
   LumiInfo lumiInfo2;

--- a/DataFormats/Luminosity/test/lumiInfo_t.cpp
+++ b/DataFormats/Luminosity/test/lumiInfo_t.cpp
@@ -53,7 +53,7 @@ TestLumiInfo::testFill() {
   CPPUNIT_ASSERT(std::abs(lumiInfo.getInstLumiBX(1) - 2.0f) < tol);
   CPPUNIT_ASSERT(std::abs(lumiInfo.getInstLumiBX(2) - 3.0f) < tol);
 
-  CPPUNIT_ASSERT(std::abs(lumiInfo.instLuminosity() - 6.0f) < tol);
+  CPPUNIT_ASSERT(std::abs(lumiInfo.getTotalInstLumi() - 6.0f) < tol);
   CPPUNIT_ASSERT(std::abs(lumiInfo.integLuminosity() - 6.0f*lumiInfo.lumiSectionLength()) < tol);
   CPPUNIT_ASSERT(std::abs(lumiInfo.recordedLuminosity() - 3.0f*lumiInfo.lumiSectionLength()) < tol);
   


### PR DESCRIPTION
This is for 94X.  @arunhep suggested making these changes ahead of a PR for adding modules to be run at PCL because the record has to be in 94X.