### PR TITLE
Fix link error in CLANG IBs caused by static const uninit vars

### DIFF
--- a/DataFormats/L1Trigger/interface/BxBlock.h
+++ b/DataFormats/L1Trigger/interface/BxBlock.h
@@ -27,13 +27,13 @@ namespace l1t {
                                      | ((flags_ & flags_mask) << flags_shift); };
 
       private:
-         static const unsigned int n_words = 6; // every link transmits 6 32 bit words per bx
-         static const unsigned int id_shift = 24;
-         static const unsigned int id_mask = 0xff;
-         static const unsigned int totalBx_shift = 16;
-         static const unsigned int totalBx_mask = 0xff;
-         static const unsigned int flags_shift = 0;
-         static const unsigned int flags_mask = 0xffff;
+         static constexpr unsigned n_words = 6; // every link transmits 6 32 bit words per bx
+         static constexpr unsigned id_shift = 24;
+         static constexpr unsigned id_mask = 0xff;
+         static constexpr unsigned totalBx_shift = 16;
+         static constexpr unsigned totalBx_mask = 0xff;
+         static constexpr unsigned flags_shift = 0;
+         static constexpr unsigned flags_mask = 0xffff;
 
          unsigned int id_;
          unsigned int totalBx_;

--- a/EventFilter/L1TRawToDigi/interface/Block.h
+++ b/EventFilter/L1TRawToDigi/interface/Block.h
@@ -29,16 +29,16 @@ namespace l1t {
          uint32_t raw(block_t type=MP7) const;
 
       private:
-         static const unsigned int CTP7_shift = 0;
-         static const unsigned int CTP7_mask = 0xffff;
-         static const unsigned int ID_shift = 24;
-         static const unsigned int ID_mask = 0xff;
-         static const unsigned int size_shift = 16;
-         static const unsigned int size_mask = 0xff;
-         static const unsigned int capID_shift = 8;
-         static const unsigned int capID_mask = 0xff;
-         static const unsigned int flags_shift = 0;
-         static const unsigned int flags_mask = 0xff;
+         static constexpr unsigned CTP7_shift = 0;
+         static constexpr unsigned CTP7_mask = 0xffff;
+         static constexpr unsigned ID_shift = 24;
+         static constexpr unsigned ID_mask = 0xff;
+         static constexpr unsigned size_shift = 16;
+         static constexpr unsigned size_mask = 0xff;
+         static constexpr unsigned capID_shift = 8;
+         static constexpr unsigned capID_mask = 0xff;
+         static constexpr unsigned flags_shift = 0;
+         static constexpr unsigned flags_mask = 0xff;
 
          unsigned int id_;
          unsigned int size_;
@@ -109,13 +109,13 @@ namespace l1t {
          std::unique_ptr<Block> getBlock() override;
       private:
          // sizes in 16 bit words
-         static const unsigned int header_size = 12;
-         static const unsigned int counter_size = 4;
-         static const unsigned int trailer_size = 8;
+         static constexpr unsigned header_size = 12;
+         static constexpr unsigned counter_size = 4;
+         static constexpr unsigned trailer_size = 8;
 
          // maximum of the block length (64bits) and bit patterns of the
          // first bits (of 16bit words)
-         static const unsigned int max_block_length_ = 3;
+         static constexpr unsigned max_block_length_ = 3;
          static const std::vector<unsigned int> block_patterns_;
 
          int count(unsigned int pattern, unsigned int length) const;
@@ -129,8 +129,8 @@ namespace l1t {
          BlockHeader getHeader() override;
       private:
          // FIXME check values
-         static const unsigned int size_mask = 0xff;
-         static const unsigned int size_shift = 16;
+         static constexpr unsigned size_mask = 0xff;
+         static constexpr unsigned size_shift = 16;
 
          unsigned size_;
    };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonUnpacker.h
@@ -16,8 +16,8 @@ namespace l1t {
             inline void setAlgoVersion(const unsigned int version) { algoVersion_ = version; };
 
          private:
-            static const unsigned int nWords_ = 6; // every link transmits 6 words (3 muons) per bx
-            static const unsigned int bxzs_enable_shift_ = 1;
+            static constexpr unsigned nWords_ = 6; // every link transmits 6 words (3 muons) per bx
+            static constexpr unsigned bxzs_enable_shift_ = 1;
 
             MuonBxCollection* res1_;
             MuonBxCollection* res2_;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.h
@@ -23,8 +23,8 @@ namespace l1t {
             inline void setMuonCopy(const unsigned int copy) { muonCopy_ = copy; };
 
          private:
-            static const unsigned int nWords_ = 6; // every link transmits 6 words (3 muons) per bx
-            static const unsigned int bxzs_enable_shift_ = 1;
+	    static constexpr unsigned nWords_ = 6; // every link transmits 6 words (3 muons) per bx
+            static constexpr unsigned bxzs_enable_shift_ = 1;
 
             MuonBxCollection* res_;
             unsigned int algoVersion_;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.h
@@ -12,8 +12,8 @@ namespace l1t {
             bool unpack(const Block& block, UnpackerCollections *coll) override;
 
          private:
-            static const unsigned int nWords_ = 6; // every link transmits 6 words (3 muons) per bx
-            static const unsigned int bxzs_enable_shift_ = 1;
+            static constexpr unsigned nWords_ = 6; // every link transmits 6 words (3 muons) per bx
+            static constexpr unsigned bxzs_enable_shift_ = 1;
       };
    }
 }


### PR DESCRIPTION
change static const to static constexpr as it was causing link error in CLANG IBs 
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc630/CMSSW_9_4_CLANG_X_2017-09-25-2300/EventFilter/L1TRawToDigi
due to that as static const the var might not get (and it's not) initialized