### PR TITLE
Adding chsMET and trackMET to miniAOD

### DIFF
--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -57,12 +57,12 @@ namespace pat {
       /// constructor for corrected METs (keeping specific informations from src MET)
       MET(const reco::MET & corMET, const MET& srcMET );
       /// destructor
-      virtual ~MET();
+      ~MET() override;
 
       MET& operator=(MET const&);
 
       /// required reimplementation of the Candidate's clone method
-      virtual MET * clone() const { return new MET(*this); }
+      MET * clone() const override { return new MET(*this); }
 
       // ---- methods for generated MET link ----
       /// return the associated GenMET

--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -76,26 +76,6 @@ namespace pat {
       // get the MET significance
       double metSignificance() const;
 
-      // ----- CHS MET functions ----
-      // set CHS MET
-      void setCHSMETpt(const double& chsMETpt);
-      void setCHSMETphi(const double& chsMETphi);
-      void setCHSMETsumEt(const double& chsMETsumEt);
-      // get CHS MET
-      double CHSMETpt() const;
-      double CHSMETphi() const;
-      double CHSMETsumEt() const;
-
-      // ----- Track MET functions ----
-      // set Track MET
-      void setTrkMETpt(const double& trkMETpt);
-      void setTrkMETphi(const double& trkMETphi);
-      void setTrkMETsumEt(const double& trkMETsumEt);
-      // get Track MET
-      double TrkMETpt() const;
-      double TrkMETphi() const;
-      double TrkMETsumEt() const;
-
       // ---- methods for uncorrected MET ----
       // Methods not yet defined
       //float uncorrectedPt() const;
@@ -178,12 +158,12 @@ namespace pat {
       enum METCorrectionLevel {
         Raw=0, Type1=1, Type01=2, TypeXY=3, Type1XY=4, Type01XY=5,
 	Type1Smear=6, Type01Smear=7, Type1SmearXY=8, 
-	Type01SmearXY=9, RawCalo=10, METCorrectionLevelSize=11
+    Type01SmearXY=9, RawCalo=10, RawChs=11, RawTrk=12, METCorrectionLevelSize=13
       };
       enum METCorrectionType {
         None=0, T1=1, T0=2, TXY=3, TXYForRaw=4,
 	TXYForT01=5, TXYForT1Smear=6, TXYForT01Smear=7,
-	Smear=8, Calo=9, METCorrectionTypeSize=10
+    Smear=8, Calo=9, Chs=10, Trk=11, METCorrectionTypeSize=12
       };
 
       struct Vector2 { 
@@ -271,16 +251,6 @@ namespace pat {
       // MET significance
       double metSig_;
       
-      // MET CHS
-      double chsMETpt_;
-      double chsMETphi_;
-      double chsMETsumEt_;
-
-      // MET Track
-      double trkMETpt_;
-      double trkMETphi_;
-      double trkMETsumEt_;
-
       const PackedMETUncertainty findMETTotalShift(MET::METCorrectionLevel cor, MET::METUncertainty shift) const;
    
       std::map<MET::METCorrectionLevel, std::vector<MET::METCorrectionType> > corMap_;

--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -76,6 +76,25 @@ namespace pat {
       // get the MET significance
       double metSignificance() const;
 
+      // ----- CHS MET functions ----
+      // set CHS MET
+      void setCHSMETpt(const double& chsMETpt);
+      void setCHSMETphi(const double& chsMETphi);
+      void setCHSMETsumEt(const double& chsMETsumEt);
+      // get CHS MET
+      double CHSMETpt() const;
+      double CHSMETphi() const;
+      double CHSMETsumEt() const;
+
+      // ----- Track MET functions ----
+      // set Track MET
+      void setTrkMETpt(const double& trkMETpt);
+      void setTrkMETphi(const double& trkMETphi);
+      void setTrkMETsumEt(const double& trkMETsumEt);
+      // get Track MET
+      double TrkMETpt() const;
+      double TrkMETphi() const;
+      double TrkMETsumEt() const;
 
       // ---- methods for uncorrected MET ----
       // Methods not yet defined
@@ -252,6 +271,16 @@ namespace pat {
       // MET significance
       double metSig_;
       
+      // MET CHS
+      double chsMETpt_;
+      double chsMETphi_;
+      double chsMETsumEt_;
+
+      // MET Track
+      double trkMETpt_;
+      double trkMETphi_;
+      double trkMETsumEt_;
+
       const PackedMETUncertainty findMETTotalShift(MET::METCorrectionLevel cor, MET::METUncertainty shift) const;
    
       std::map<MET::METCorrectionLevel, std::vector<MET::METCorrectionType> > corMap_;

--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -149,21 +149,21 @@ namespace pat {
 
       // ---- members for MET corrections ----
       enum METUncertainty {
-	JetResUp=0, JetResDown=1, JetEnUp=2, JetEnDown=3,
-        MuonEnUp=4, MuonEnDown=5, ElectronEnUp=6, ElectronEnDown=7,
-	TauEnUp=8, TauEnDown=9, UnclusteredEnUp=10, UnclusteredEnDown=11,
-	PhotonEnUp=12, PhotonEnDown=13, NoShift=14, METUncertaintySize=15,
-	JetResUpSmear=16, JetResDownSmear=17, METFullUncertaintySize=18
+       JetResUp=0, JetResDown=1, JetEnUp=2, JetEnDown=3,
+       MuonEnUp=4, MuonEnDown=5, ElectronEnUp=6, ElectronEnDown=7,
+       TauEnUp=8, TauEnDown=9, UnclusteredEnUp=10, UnclusteredEnDown=11,
+       PhotonEnUp=12, PhotonEnDown=13, NoShift=14, METUncertaintySize=15,
+       JetResUpSmear=16, JetResDownSmear=17, METFullUncertaintySize=18
       };
       enum METCorrectionLevel {
-        Raw=0, Type1=1, Type01=2, TypeXY=3, Type1XY=4, Type01XY=5,
-	Type1Smear=6, Type01Smear=7, Type1SmearXY=8, 
-    Type01SmearXY=9, RawCalo=10, RawChs=11, RawTrk=12, METCorrectionLevelSize=13
+       Raw=0, Type1=1, Type01=2, TypeXY=3, Type1XY=4, Type01XY=5,
+       Type1Smear=6, Type01Smear=7, Type1SmearXY=8, 
+       Type01SmearXY=9, RawCalo=10, RawChs=11, RawTrk=12, METCorrectionLevelSize=13
       };
       enum METCorrectionType {
-        None=0, T1=1, T0=2, TXY=3, TXYForRaw=4,
-	TXYForT01=5, TXYForT1Smear=6, TXYForT01Smear=7,
-    Smear=8, Calo=9, Chs=10, Trk=11, METCorrectionTypeSize=12
+       None=0, T1=1, T0=2, TXY=3, TXYForRaw=4,
+       TXYForT01=5, TXYForT1Smear=6, TXYForT01Smear=7,
+       Smear=8, Calo=9, Chs=10, Trk=11, METCorrectionTypeSize=12
       };
 
       struct Vector2 { 

--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -16,11 +16,11 @@ MET::MET() {
 /// constructor from reco::MET
 MET::MET(const reco::MET & aMET) : PATObject<reco::MET>(aMET) {
     const reco::CaloMET * calo = dynamic_cast<const reco::CaloMET *>(&aMET);
-    if (calo != 0) caloMET_.push_back(calo->getSpecific());
+    if (calo != nullptr) caloMET_.push_back(calo->getSpecific());
     const reco::PFMET * pf = dynamic_cast<const reco::PFMET *>(&aMET);
-    if (pf != 0) pfMET_.push_back(pf->getSpecific());
+    if (pf != nullptr) pfMET_.push_back(pf->getSpecific());
     const pat::MET * pm = dynamic_cast<const pat::MET *>(&aMET);
-    if (pm != 0) this->operator=(*pm);
+    if (pm != nullptr) this->operator=(*pm);
 
     metSig_ =0.;
     chsMETpt_ =0.;
@@ -36,11 +36,11 @@ MET::MET(const reco::MET & aMET) : PATObject<reco::MET>(aMET) {
 /// constructor from ref to reco::MET
 MET::MET(const edm::RefToBase<reco::MET> & aMETRef) : PATObject<reco::MET>(aMETRef) {
     const reco::CaloMET * calo = dynamic_cast<const reco::CaloMET *>(aMETRef.get());
-    if (calo != 0) caloMET_.push_back(calo->getSpecific());
+    if (calo != nullptr) caloMET_.push_back(calo->getSpecific());
     const reco::PFMET * pf = dynamic_cast<const reco::PFMET *>(aMETRef.get());
-    if (pf != 0) pfMET_.push_back(pf->getSpecific());
+    if (pf != nullptr) pfMET_.push_back(pf->getSpecific());
     const pat::MET * pm = dynamic_cast<const pat::MET *>(aMETRef.get());
-    if (pm != 0) this->operator=(*pm);
+    if (pm != nullptr) this->operator=(*pm);
 
     metSig_ =0.;
     chsMETpt_ =0.;
@@ -55,11 +55,11 @@ MET::MET(const edm::RefToBase<reco::MET> & aMETRef) : PATObject<reco::MET>(aMETR
 /// constructor from ref to reco::MET
 MET::MET(const edm::Ptr<reco::MET> & aMETRef) : PATObject<reco::MET>(aMETRef) {
     const reco::CaloMET * calo = dynamic_cast<const reco::CaloMET *>(aMETRef.get());
-    if (calo != 0) caloMET_.push_back(calo->getSpecific());
+    if (calo != nullptr) caloMET_.push_back(calo->getSpecific());
     const reco::PFMET * pf = dynamic_cast<const reco::PFMET *>(aMETRef.get());
-    if (pf != 0) pfMET_.push_back(pf->getSpecific());
+    if (pf != nullptr) pfMET_.push_back(pf->getSpecific());
     const pat::MET * pm = dynamic_cast<const pat::MET *>(aMETRef.get());
-    if (pm != 0) this->operator=(*pm);
+    if (pm != nullptr) this->operator=(*pm);
 
     metSig_ =0.;
     chsMETpt_ = 0.;
@@ -144,7 +144,7 @@ MET& MET::operator=(MET const& iOther) {
 
 /// return the generated MET from neutrinos
 const reco::GenMET * MET::genMET() const {
-  return (genMET_.size() > 0 ? &genMET_.front() : 0 );
+  return (!genMET_.empty() ? &genMET_.front() : nullptr );
 }
 
 /// method to set the generated MET
@@ -320,7 +320,7 @@ MET::Vector2 MET::shiftedP2(MET::METUncertainty shift, MET::METCorrectionLevel c
   //backward compatibility with 74X samples -> the only one
   // with uncertaintiesType1_/uncertaintiesRaw_ not empty
   //will be removed once 74X is not used anymore
-  if(uncertaintiesType1_.size()!=0 || uncertaintiesRaw_.size()!=0) {
+  if(!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
     if(cor!=MET::METCorrectionLevel::RawCalo) {
       vo = shiftedP2_74x(shift, cor);
     } else {
@@ -343,7 +343,7 @@ MET::Vector MET::shiftedP3(MET::METUncertainty shift, MET::METCorrectionLevel co
   //backward compatibility with 74X samples -> the only one
   // with uncertaintiesType1_/uncertaintiesRaw_ not empty
   //will be removed once 74X is not used anymore
-  if(uncertaintiesType1_.size()!=0 || uncertaintiesRaw_.size()!=0) {
+  if(!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
     if(cor!=MET::METCorrectionLevel::RawCalo) {
       vo = shiftedP3_74x(shift, cor);
     } else {
@@ -366,7 +366,7 @@ MET::LorentzVector MET::shiftedP4(METUncertainty shift, MET::METCorrectionLevel 
   //backward compatibility with 74X samples -> the only one
   // with uncertaintiesType1_/uncertaintiesRaw_ not empty
   //will be removed once 74X is not used anymore
-  if(uncertaintiesType1_.size()!=0 || uncertaintiesRaw_.size()!=0) {
+  if(!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
     if(cor!=MET::METCorrectionLevel::RawCalo) {
       vo = shiftedP4_74x(shift, cor);
     } else {
@@ -391,7 +391,7 @@ double MET::shiftedSumEt(MET::METUncertainty shift, MET::METCorrectionLevel cor)
   //backward compatibility with 74X samples -> the only one
   // with uncertaintiesType1_/uncertaintiesRaw_ not empty
   //will be removed once 74X is not used anymore
-  if(uncertaintiesType1_.size()!=0 || uncertaintiesRaw_.size()!=0) {
+  if(!uncertaintiesType1_.empty() || !uncertaintiesRaw_.empty()) {
     if(cor!=MET::METCorrectionLevel::RawCalo) {
       sumEto = shiftedSumEt_74x(shift, cor);
     } else {

--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -189,7 +189,7 @@ MET::initCorMap() {
   tmpRawChs.push_back(MET::Chs);
   corMap_[MET::RawChs] = tmpRawChs;
 
-  //specific chs case
+  //specific trk case
   std::vector<MET::METCorrectionType> tmpRawTrk;
   tmpRawTrk.push_back(MET::Trk);
   corMap_[MET::RawTrk] = tmpRawTrk;

--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -23,6 +23,12 @@ MET::MET(const reco::MET & aMET) : PATObject<reco::MET>(aMET) {
     if (pm != 0) this->operator=(*pm);
 
     metSig_ =0.;
+    chsMETpt_ =0.;
+    chsMETphi_ =0.;
+    chsMETsumEt_ =0.;
+    trkMETpt_ =0.;
+    trkMETphi_ =0.;
+    trkMETsumEt_ =0.;
     initCorMap();
 }
 
@@ -37,6 +43,12 @@ MET::MET(const edm::RefToBase<reco::MET> & aMETRef) : PATObject<reco::MET>(aMETR
     if (pm != 0) this->operator=(*pm);
 
     metSig_ =0.;
+    chsMETpt_ =0.;
+    chsMETphi_ =0.;
+    chsMETsumEt_ =0.;
+    trkMETpt_ =0.;
+    trkMETphi_ =0.;
+    trkMETsumEt_ =0.;
     initCorMap();
 }
 
@@ -50,6 +62,12 @@ MET::MET(const edm::Ptr<reco::MET> & aMETRef) : PATObject<reco::MET>(aMETRef) {
     if (pm != 0) this->operator=(*pm);
 
     metSig_ =0.;
+    chsMETpt_ = 0.;
+    chsMETphi_ =0.;
+    chsMETsumEt_ =0.;
+    trkMETpt_ =0.;
+    trkMETphi_ =0.;
+    trkMETsumEt_ =0.;
     initCorMap();
 }
 
@@ -60,6 +78,12 @@ genMET_(iOther.genMET_),
 caloMET_(iOther.caloMET_),
 pfMET_(iOther.pfMET_),
 metSig_(iOther.metSig_),
+chsMETpt_(iOther.chsMETpt_),
+chsMETphi_(iOther.chsMETphi_),
+chsMETsumEt_(iOther.chsMETsumEt_),
+trkMETpt_(iOther.trkMETpt_),
+trkMETphi_(iOther.trkMETphi_),
+trkMETsumEt_(iOther.trkMETsumEt_),
 uncertaintiesRaw_(iOther.uncertaintiesRaw_), //74X reading compatibility
 uncertaintiesType1_(iOther.uncertaintiesType1_), //74X compatibility
 uncertaintiesType1p2_(iOther.uncertaintiesType1p2_), //74X compatibility
@@ -78,6 +102,12 @@ genMET_(srcMET.genMET_),
 caloMET_(srcMET.caloMET_),
 pfMET_(srcMET.pfMET_),
 metSig_(srcMET.metSig_),
+chsMETpt_(srcMET.chsMETpt_),
+chsMETphi_(srcMET.chsMETphi_),
+chsMETsumEt_(srcMET.chsMETsumEt_),
+trkMETpt_(srcMET.trkMETpt_),
+trkMETphi_(srcMET.trkMETphi_),
+trkMETsumEt_(srcMET.trkMETsumEt_),
 caloPackedMet_(srcMET.caloPackedMet_) {
 
   setSignificanceMatrix(srcMET.getSignificanceMatrix());
@@ -101,6 +131,12 @@ MET& MET::operator=(MET const& iOther) {
    uncertainties_ = iOther.uncertainties_;
    corrections_ = iOther.corrections_;
    metSig_ = iOther.metSig_;
+   chsMETpt_ = iOther.chsMETpt_;
+   chsMETphi_ = iOther.chsMETphi_;
+   chsMETsumEt_ = iOther.chsMETsumEt_;
+   trkMETpt_ = iOther.trkMETpt_;
+   trkMETphi_ = iOther.trkMETphi_;
+   trkMETsumEt_ = iOther.trkMETsumEt_;
    caloPackedMet_ = iOther.caloPackedMet_;
 
    return *this;
@@ -125,6 +161,60 @@ void MET::setMETSignificance(const double& metSig) {
 
 double MET::metSignificance() const {
   return metSig_;
+}
+
+//Method to set the CHS MET
+void MET::setCHSMETpt(const double& chsMETpt) {
+  chsMETpt_ = chsMETpt;
+}
+
+double MET::CHSMETpt() const {
+  return chsMETpt_;
+}
+
+//Method to set the CHS MET
+void MET::setCHSMETphi(const double& chsMETphi) {
+  chsMETphi_ = chsMETphi;
+}
+
+double MET::CHSMETphi() const {
+  return chsMETphi_;
+}
+
+//Method to set the CHS MET
+void MET::setCHSMETsumEt(const double& chsMETsumEt) {
+  chsMETsumEt_ = chsMETsumEt;
+}
+
+double MET::CHSMETsumEt() const {
+  return chsMETsumEt_;
+}
+
+//Method to set the Track MET
+void MET::setTrkMETpt(const double& trkMETpt) {
+  trkMETpt_ = trkMETpt;
+}
+
+double MET::TrkMETpt() const {
+  return trkMETpt_;
+}
+
+//Method to set the CHS MET
+void MET::setTrkMETphi(const double& trkMETphi) {
+  trkMETphi_ = trkMETphi;
+}
+
+double MET::TrkMETphi() const {
+  return trkMETphi_;
+}
+
+//Method to set the CHS MET
+void MET::setTrkMETsumEt(const double& trkMETsumEt) {
+  trkMETsumEt_ = trkMETsumEt;
+}
+
+double MET::TrkMETsumEt() const {
+  return trkMETsumEt_;
 }
 
 

--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -23,12 +23,6 @@ MET::MET(const reco::MET & aMET) : PATObject<reco::MET>(aMET) {
     if (pm != nullptr) this->operator=(*pm);
 
     metSig_ =0.;
-    chsMETpt_ =0.;
-    chsMETphi_ =0.;
-    chsMETsumEt_ =0.;
-    trkMETpt_ =0.;
-    trkMETphi_ =0.;
-    trkMETsumEt_ =0.;
     initCorMap();
 }
 
@@ -43,12 +37,6 @@ MET::MET(const edm::RefToBase<reco::MET> & aMETRef) : PATObject<reco::MET>(aMETR
     if (pm != nullptr) this->operator=(*pm);
 
     metSig_ =0.;
-    chsMETpt_ =0.;
-    chsMETphi_ =0.;
-    chsMETsumEt_ =0.;
-    trkMETpt_ =0.;
-    trkMETphi_ =0.;
-    trkMETsumEt_ =0.;
     initCorMap();
 }
 
@@ -62,12 +50,6 @@ MET::MET(const edm::Ptr<reco::MET> & aMETRef) : PATObject<reco::MET>(aMETRef) {
     if (pm != nullptr) this->operator=(*pm);
 
     metSig_ =0.;
-    chsMETpt_ = 0.;
-    chsMETphi_ =0.;
-    chsMETsumEt_ =0.;
-    trkMETpt_ =0.;
-    trkMETphi_ =0.;
-    trkMETsumEt_ =0.;
     initCorMap();
 }
 
@@ -78,12 +60,6 @@ genMET_(iOther.genMET_),
 caloMET_(iOther.caloMET_),
 pfMET_(iOther.pfMET_),
 metSig_(iOther.metSig_),
-chsMETpt_(iOther.chsMETpt_),
-chsMETphi_(iOther.chsMETphi_),
-chsMETsumEt_(iOther.chsMETsumEt_),
-trkMETpt_(iOther.trkMETpt_),
-trkMETphi_(iOther.trkMETphi_),
-trkMETsumEt_(iOther.trkMETsumEt_),
 uncertaintiesRaw_(iOther.uncertaintiesRaw_), //74X reading compatibility
 uncertaintiesType1_(iOther.uncertaintiesType1_), //74X compatibility
 uncertaintiesType1p2_(iOther.uncertaintiesType1p2_), //74X compatibility
@@ -102,12 +78,6 @@ genMET_(srcMET.genMET_),
 caloMET_(srcMET.caloMET_),
 pfMET_(srcMET.pfMET_),
 metSig_(srcMET.metSig_),
-chsMETpt_(srcMET.chsMETpt_),
-chsMETphi_(srcMET.chsMETphi_),
-chsMETsumEt_(srcMET.chsMETsumEt_),
-trkMETpt_(srcMET.trkMETpt_),
-trkMETphi_(srcMET.trkMETphi_),
-trkMETsumEt_(srcMET.trkMETsumEt_),
 caloPackedMet_(srcMET.caloPackedMet_) {
 
   setSignificanceMatrix(srcMET.getSignificanceMatrix());
@@ -131,12 +101,6 @@ MET& MET::operator=(MET const& iOther) {
    uncertainties_ = iOther.uncertainties_;
    corrections_ = iOther.corrections_;
    metSig_ = iOther.metSig_;
-   chsMETpt_ = iOther.chsMETpt_;
-   chsMETphi_ = iOther.chsMETphi_;
-   chsMETsumEt_ = iOther.chsMETsumEt_;
-   trkMETpt_ = iOther.trkMETpt_;
-   trkMETphi_ = iOther.trkMETphi_;
-   trkMETsumEt_ = iOther.trkMETsumEt_;
    caloPackedMet_ = iOther.caloPackedMet_;
 
    return *this;
@@ -162,61 +126,6 @@ void MET::setMETSignificance(const double& metSig) {
 double MET::metSignificance() const {
   return metSig_;
 }
-
-//Method to set the CHS MET
-void MET::setCHSMETpt(const double& chsMETpt) {
-  chsMETpt_ = chsMETpt;
-}
-
-double MET::CHSMETpt() const {
-  return chsMETpt_;
-}
-
-//Method to set the CHS MET
-void MET::setCHSMETphi(const double& chsMETphi) {
-  chsMETphi_ = chsMETphi;
-}
-
-double MET::CHSMETphi() const {
-  return chsMETphi_;
-}
-
-//Method to set the CHS MET
-void MET::setCHSMETsumEt(const double& chsMETsumEt) {
-  chsMETsumEt_ = chsMETsumEt;
-}
-
-double MET::CHSMETsumEt() const {
-  return chsMETsumEt_;
-}
-
-//Method to set the Track MET
-void MET::setTrkMETpt(const double& trkMETpt) {
-  trkMETpt_ = trkMETpt;
-}
-
-double MET::TrkMETpt() const {
-  return trkMETpt_;
-}
-
-//Method to set the CHS MET
-void MET::setTrkMETphi(const double& trkMETphi) {
-  trkMETphi_ = trkMETphi;
-}
-
-double MET::TrkMETphi() const {
-  return trkMETphi_;
-}
-
-//Method to set the CHS MET
-void MET::setTrkMETsumEt(const double& trkMETsumEt) {
-  trkMETsumEt_ = trkMETsumEt;
-}
-
-double MET::TrkMETsumEt() const {
-  return trkMETsumEt_;
-}
-
 
 void
 MET::initCorMap() {
@@ -274,6 +183,16 @@ MET::initCorMap() {
   std::vector<MET::METCorrectionType> tmpRawCalo;
   tmpRawCalo.push_back(MET::Calo);
   corMap_[MET::RawCalo] = tmpRawCalo;
+
+  //specific chs case
+  std::vector<MET::METCorrectionType> tmpRawChs;
+  tmpRawChs.push_back(MET::Chs);
+  corMap_[MET::RawChs] = tmpRawChs;
+
+  //specific chs case
+  std::vector<MET::METCorrectionType> tmpRawTrk;
+  tmpRawTrk.push_back(MET::Trk);
+  corMap_[MET::RawTrk] = tmpRawTrk;
 }
 
 const MET::PackedMETUncertainty

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -243,10 +243,7 @@
   <ioread sourceClass = "pat::Jet" version="[1-11]" targetClass="pat::Jet" source="int partonFlavour_" target="jetFlavourInfo_">
     <![CDATA[jetFlavourInfo_ = reco::JetFlavourInfo(0,onfile.partonFlavour_);]]>
   </ioread>
-  <class name="pat::MET"  ClassVersion="18">
-   <version ClassVersion="18" checksum="428901429"/>
-   <version ClassVersion="17" checksum="2630287804"/>
-   <version ClassVersion="16" checksum="4025491907"/>
+  <class name="pat::MET"  ClassVersion="15">
     <version ClassVersion="15" checksum="428901429"/>
     <field name="corMap_" transient="true"/>
    <version ClassVersion="14" checksum="1795935545"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -243,7 +243,8 @@
   <ioread sourceClass = "pat::Jet" version="[1-11]" targetClass="pat::Jet" source="int partonFlavour_" target="jetFlavourInfo_">
     <![CDATA[jetFlavourInfo_ = reco::JetFlavourInfo(0,onfile.partonFlavour_);]]>
   </ioread>
-  <class name="pat::MET"  ClassVersion="17">
+  <class name="pat::MET"  ClassVersion="18">
+   <version ClassVersion="18" checksum="428901429"/>
    <version ClassVersion="17" checksum="2630287804"/>
    <version ClassVersion="16" checksum="4025491907"/>
     <version ClassVersion="15" checksum="428901429"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -243,7 +243,9 @@
   <ioread sourceClass = "pat::Jet" version="[1-11]" targetClass="pat::Jet" source="int partonFlavour_" target="jetFlavourInfo_">
     <![CDATA[jetFlavourInfo_ = reco::JetFlavourInfo(0,onfile.partonFlavour_);]]>
   </ioread>
-  <class name="pat::MET"  ClassVersion="15">
+  <class name="pat::MET"  ClassVersion="17">
+   <version ClassVersion="17" checksum="2630287804"/>
+   <version ClassVersion="16" checksum="4025491907"/>
     <version ClassVersion="15" checksum="428901429"/>
     <field name="corMap_" transient="true"/>
    <version ClassVersion="14" checksum="1795935545"/>

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
@@ -21,10 +21,6 @@ PATMETProducer::PATMETProducer(const edm::ParameterSet & iConfig):
   // initialize the configurables
   metSrc_         = iConfig.getParameter<edm::InputTag>("metSource");
   metToken_       = consumes<edm::View<reco::MET> >(metSrc_);
-  chsmetSrc_      = iConfig.getParameter<edm::InputTag>("chsmetSource");
-  chsmetToken_    = consumes<edm::View<reco::MET> >(chsmetSrc_);
-  trkmetSrc_      = iConfig.getParameter<edm::InputTag>("trkmetSource");
-  trkmetToken_    = consumes<edm::View<reco::MET> >(trkmetSrc_);
   addGenMET_      = iConfig.getParameter<bool>         ("addGenMET");
   genMETToken_    = mayConsume<edm::View<reco::GenMET> >(iConfig.getParameter<edm::InputTag>("genMETSource"));
   addResolutions_ = iConfig.getParameter<bool>         ("addResolutions");
@@ -88,12 +84,6 @@ void PATMETProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
     iEvent.getByToken(genMETToken_, genMETs);
   }
 
-  edm::Handle<edm::View<reco::MET> > chsMETs;
-  iEvent.getByToken(chsmetToken_, chsMETs);
-
-  edm::Handle<edm::View<reco::MET> > trkMETs;
-  iEvent.getByToken(trkmetToken_, trkMETs);
-
   // loop over mets
   std::vector<MET> * patMETs = new std::vector<MET>();
   for (edm::View<reco::MET>::const_iterator itMET = mets->begin(); itMET != mets->end(); itMET++) {
@@ -105,17 +95,6 @@ void PATMETProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
     // add the generated MET
     if (addGenMET_) amet.setGenMET((*genMETs)[idx]);
 
-
-    if (chsMETs.isValid()){
-        amet.setCHSMETpt((*chsMETs)[idx].pt());
-        amet.setCHSMETphi((*chsMETs)[idx].phi());
-        amet.setCHSMETsumEt((*chsMETs)[idx].sumEt());
-    }
-    if (trkMETs.isValid()){
-        amet.setTrkMETpt((*trkMETs)[idx].pt());
-        amet.setTrkMETphi((*trkMETs)[idx].phi());
-        amet.setTrkMETsumEt((*trkMETs)[idx].sumEt());
-    }
 
     //add the MET significance
     if(calculateMETSignificance_) {
@@ -137,7 +116,6 @@ void PATMETProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
     if ( useUserData_ ) {
       userDataHelper_.add( amet, iEvent, iSetup );
     }
-
 
     // correct for muons if demanded... never more: it's now done by JetMETCorrections
     // add the MET to the vector of METs

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
@@ -21,6 +21,10 @@ PATMETProducer::PATMETProducer(const edm::ParameterSet & iConfig):
   // initialize the configurables
   metSrc_         = iConfig.getParameter<edm::InputTag>("metSource");
   metToken_       = consumes<edm::View<reco::MET> >(metSrc_);
+  chsmetSrc_      = iConfig.getParameter<edm::InputTag>("chsmetSource");
+  chsmetToken_    = consumes<edm::View<reco::MET> >(chsmetSrc_);
+  trkmetSrc_      = iConfig.getParameter<edm::InputTag>("trkmetSource");
+  trkmetToken_    = consumes<edm::View<reco::MET> >(trkmetSrc_);
   addGenMET_      = iConfig.getParameter<bool>         ("addGenMET");
   genMETToken_    = mayConsume<edm::View<reco::GenMET> >(iConfig.getParameter<edm::InputTag>("genMETSource"));
   addResolutions_ = iConfig.getParameter<bool>         ("addResolutions");
@@ -84,6 +88,12 @@ void PATMETProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
     iEvent.getByToken(genMETToken_, genMETs);
   }
 
+  edm::Handle<edm::View<reco::MET> > chsMETs;
+  iEvent.getByToken(chsmetToken_, chsMETs);
+
+  edm::Handle<edm::View<reco::MET> > trkMETs;
+  iEvent.getByToken(trkmetToken_, trkMETs);
+
   // loop over mets
   std::vector<MET> * patMETs = new std::vector<MET>();
   for (edm::View<reco::MET>::const_iterator itMET = mets->begin(); itMET != mets->end(); itMET++) {
@@ -94,6 +104,14 @@ void PATMETProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
     MET amet(metsRef);
     // add the generated MET
     if (addGenMET_) amet.setGenMET((*genMETs)[idx]);
+
+    amet.setCHSMETpt((*chsMETs)[idx].pt());
+    amet.setCHSMETphi((*chsMETs)[idx].phi());
+    amet.setCHSMETsumEt((*chsMETs)[idx].sumEt());
+
+    amet.setTrkMETpt((*trkMETs)[idx].pt());
+    amet.setTrkMETphi((*trkMETs)[idx].phi());
+    amet.setTrkMETsumEt((*trkMETs)[idx].sumEt());
 
     //add the MET significance
     if(calculateMETSignificance_) {

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
@@ -105,13 +105,17 @@ void PATMETProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
     // add the generated MET
     if (addGenMET_) amet.setGenMET((*genMETs)[idx]);
 
-    amet.setCHSMETpt((*chsMETs)[idx].pt());
-    amet.setCHSMETphi((*chsMETs)[idx].phi());
-    amet.setCHSMETsumEt((*chsMETs)[idx].sumEt());
 
-    amet.setTrkMETpt((*trkMETs)[idx].pt());
-    amet.setTrkMETphi((*trkMETs)[idx].phi());
-    amet.setTrkMETsumEt((*trkMETs)[idx].sumEt());
+    if (chsMETs.isValid()){
+        amet.setCHSMETpt((*chsMETs)[idx].pt());
+        amet.setCHSMETphi((*chsMETs)[idx].phi());
+        amet.setCHSMETsumEt((*chsMETs)[idx].sumEt());
+    }
+    if (trkMETs.isValid()){
+        amet.setTrkMETpt((*trkMETs)[idx].pt());
+        amet.setTrkMETphi((*trkMETs)[idx].phi());
+        amet.setTrkMETsumEt((*trkMETs)[idx].sumEt());
+    }
 
     //add the MET significance
     if(calculateMETSignificance_) {

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
@@ -40,9 +40,9 @@ namespace pat {
     public:
 
       explicit PATMETProducer(const edm::ParameterSet & iConfig);
-      ~PATMETProducer();
+      ~PATMETProducer() override;
 
-      virtual void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+      void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
@@ -51,6 +51,10 @@ namespace pat {
       // configurables
       edm::InputTag metSrc_;
       edm::EDGetTokenT<edm::View<reco::MET> > metToken_;
+      edm::InputTag chsmetSrc_;
+      edm::EDGetTokenT<edm::View<reco::MET> > chsmetToken_;
+      edm::InputTag trkmetSrc_;
+      edm::EDGetTokenT<edm::View<reco::MET> > trkmetToken_;
       bool          addGenMET_;
       edm::EDGetTokenT<edm::View<reco::GenMET> > genMETToken_;
       bool          addResolutions_;

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
@@ -51,10 +51,6 @@ namespace pat {
       // configurables
       edm::InputTag metSrc_;
       edm::EDGetTokenT<edm::View<reco::MET> > metToken_;
-      edm::InputTag chsmetSrc_;
-      edm::EDGetTokenT<edm::View<reco::MET> > chsmetToken_;
-      edm::InputTag trkmetSrc_;
-      edm::EDGetTokenT<edm::View<reco::MET> > trkmetToken_;
       bool          addGenMET_;
       edm::EDGetTokenT<edm::View<reco::GenMET> > genMETToken_;
       bool          addResolutions_;

--- a/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
@@ -19,9 +19,9 @@ namespace pat {
   class PATMETSlimmer : public edm::global::EDProducer<> {
   public:
     explicit PATMETSlimmer(const edm::ParameterSet & iConfig);
-    virtual ~PATMETSlimmer() { }
+    ~PATMETSlimmer() override { }
     
-    virtual void produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const;
+    void produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const override;
     
   private:
     class OneMETShift {

--- a/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
@@ -65,6 +65,8 @@ pat::PATMETSlimmer::PATMETSlimmer(const edm::ParameterSet & iConfig) :
   maybeReadShifts( iConfig, "tXYUncForT1Smear", pat::MET::TXYForT1Smear );
   maybeReadShifts( iConfig, "tXYUncForT01Smear", pat::MET::TXYForT01Smear );
   maybeReadShifts( iConfig, "caloMET", pat::MET::Calo );
+  maybeReadShifts( iConfig, "chsMET", pat::MET::Chs );
+  maybeReadShifts( iConfig, "trkMET", pat::MET::Trk );
 
   produces<std::vector<pat::MET> >();
 }

--- a/PhysicsTools/PatAlgos/python/producersLayer1/metProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/metProducer_cfi.py
@@ -5,6 +5,8 @@ from RecoMET.METProducers.METSignificanceParams_cfi import METSignificanceParams
 patMETs = cms.EDProducer("PATMETProducer",
     # input
     metSource  = cms.InputTag("pfMetT1"),
+    chsmetSource = cms.InputTag("pfMetCHS"),                         
+    trkmetSource = cms.InputTag("pfMetTrk"),                         
 
     # add user data
     userData = cms.PSet(

--- a/PhysicsTools/PatAlgos/python/producersLayer1/metProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/metProducer_cfi.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoMET.METProducers.METSignificanceParams_cfi import METSignificanceParams
 
+
 patMETs = cms.EDProducer("PATMETProducer",
     # input
     metSource  = cms.InputTag("pfMetT1"),
-    chsmetSource = cms.InputTag("pfMetCHS"),                         
-    trkmetSource = cms.InputTag("pfMetTrk"),                         
+
+    # additional sources
+    chsmetSource = cms.InputTag(''),                         
+    trkmetSource = cms.InputTag(''),                         
 
     # add user data
     userData = cms.PSet(
@@ -60,5 +63,3 @@ patMETs = cms.EDProducer("PATMETProducer",
     srcRho = cms.InputTag('fixedGridRhoAll'),
     parameters = METSignificanceParams
 )
-
-

--- a/PhysicsTools/PatAlgos/python/producersLayer1/metProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/metProducer_cfi.py
@@ -7,10 +7,6 @@ patMETs = cms.EDProducer("PATMETProducer",
     # input
     metSource  = cms.InputTag("pfMetT1"),
 
-    # additional sources
-    chsmetSource = cms.InputTag(''),                         
-    trkmetSource = cms.InputTag(''),                         
-
     # add user data
     userData = cms.PSet(
       # add custom classes here

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -185,10 +185,14 @@ def miniAOD_customizeCommon(process):
                                       globalThreshold = cms.double(0.0),
                                       calculateSignificance = cms.bool(False),
                                       )
-
     task.add(process.pfMetCHS)    
 
-    process.patMETs.chsmetSource = cms.InputTag("pfMetCHS")
+    addMETCollection(process,
+                     labelName = "patChsMet",
+                     metSource = "pfMetCHS"
+                     )
+
+    process.patChsMet.computeMETSignificance = cms.bool(False)
 
     #  ==================  CHSMET 
 
@@ -208,7 +212,12 @@ def miniAOD_customizeCommon(process):
 
     task.add(process.pfMetTrk)
 
-    process.patMETs.trkmetSource = cms.InputTag("pfMetTrk")
+    addMETCollection(process,
+                     labelName = "patTrkMet",
+                     metSource = "pfMetTrk"
+                     )
+
+    process.patTrkMet.computeMETSignificance = cms.bool(False)
 
     #  ==================  TrkMET 
     

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -199,7 +199,7 @@ def miniAOD_customizeCommon(process):
     #  ==================  TrkMET 
     process.TrkCands = cms.EDFilter("CandPtrSelector",
                                     src=cms.InputTag("packedPFCandidates"),
-                                    cut=cms.string("fromPV(0) > 0 && charge()!=0")
+                                    cut=cms.string("charge()!=0 && pvAssociationQuality()>=4 && vertexRef().key()==0")
                                     )
     task.add(process.TrkCands)
 

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -188,6 +188,8 @@ def miniAOD_customizeCommon(process):
 
     task.add(process.pfMetCHS)    
 
+    process.patMETs.chsmetSource = cms.InputTag("pfMetCHS")
+
     #  ==================  CHSMET 
 
     #  ==================  TrkMET 
@@ -205,7 +207,11 @@ def miniAOD_customizeCommon(process):
                                       )
 
     task.add(process.pfMetTrk)
+
+    process.patMETs.trkmetSource = cms.InputTag("pfMetTrk")
+
     #  ==================  TrkMET 
+    
 
     ## PU JetID
     process.load("RecoJets.JetProducers.PileupJetID_cfi")

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -188,11 +188,11 @@ def miniAOD_customizeCommon(process):
     task.add(process.pfMetCHS)    
 
     addMETCollection(process,
-                     labelName = "patChsMet",
+                     labelName = "patCHSMet",
                      metSource = "pfMetCHS"
                      )
 
-    process.patChsMet.computeMETSignificance = cms.bool(False)
+    process.patCHSMet.computeMETSignificance = cms.bool(False)
 
     #  ==================  CHSMET 
 

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -179,24 +179,15 @@ def miniAOD_customizeCommon(process):
                                     )
     task.add(process.CHSCands)
 
-    runMetCorAndUncForMiniAODProduction(process,
-                                        pfCandColl=cms.InputTag("CHSCands"),
-                                        recoMetFromPFCs=True,
-                                        postfix="CHS"
-                                        )
+    process.pfMetCHS = cms.EDProducer("PFMETProducer",
+                                      src = cms.InputTag("CHSCands"),
+                                      alias = cms.string('pfMet'),
+                                      globalThreshold = cms.double(0.0),
+                                      calculateSignificance = cms.bool(False),
+                                      )
 
-    addToProcessAndTask('slimmedMETsCHS', process.slimmedMETs.clone(), process, task)
-    process.slimmedMETsCHS.src = cms.InputTag("patMETsCHS")
-    process.slimmedMETsCHS.rawVariation =  cms.InputTag("patPFMetCHS")
-    process.slimmedMETsCHS.t1Uncertainties = cms.InputTag("patPFMetT1%sCHS") 
-    process.slimmedMETsCHS.t01Variation = cms.InputTag("patPFMetT0pcT1CHS")
-    process.slimmedMETsCHS.t1SmearedVarsAndUncs = cms.InputTag("patPFMetT1Smear%sCHS")
-    process.slimmedMETsCHS.tXYUncForRaw = cms.InputTag("patPFMetTxyCHS")
-    process.slimmedMETsCHS.tXYUncForT1 = cms.InputTag("patPFMetT1TxyCHS")
-    process.slimmedMETsCHS.tXYUncForT01 = cms.InputTag("patPFMetT0pcT1TxyCHS")
-    process.slimmedMETsCHS.tXYUncForT1Smear = cms.InputTag("patPFMetT1SmearTxyCHS")
-    process.slimmedMETsCHS.tXYUncForT01Smear = cms.InputTag("patPFMetT0pcT1SmearTxyCHS")
-    del process.slimmedMETsCHS.caloMET
+    task.add(process.pfMetCHS)    
+
     #  ==================  CHSMET 
 
     #  ==================  TrkMET 
@@ -206,24 +197,14 @@ def miniAOD_customizeCommon(process):
                                     )
     task.add(process.TrkCands)
 
-    runMetCorAndUncForMiniAODProduction(process,
-                                        pfCandColl=cms.InputTag("TrkCands"),
-                                        recoMetFromPFCs=True,
-                                        postfix="Trk"
-                                        )
+    process.pfMetTrk = cms.EDProducer("PFMETProducer",
+                                      src = cms.InputTag("TrkCands"),
+                                      alias = cms.string('pfMet'),
+                                      globalThreshold = cms.double(0.0),
+                                      calculateSignificance = cms.bool(False),
+                                      )
 
-    addToProcessAndTask('slimmedMETsTrk', process.slimmedMETs.clone(), process, task)
-    process.slimmedMETsTrk.src = cms.InputTag("patMETsTrk")
-    process.slimmedMETsTrk.rawVariation =  cms.InputTag("patPFMetTrk")
-    process.slimmedMETsTrk.t1Uncertainties = cms.InputTag("patPFMetT1%sTrk") 
-    process.slimmedMETsTrk.t01Variation = cms.InputTag("patPFMetT0pcT1Trk")
-    process.slimmedMETsTrk.t1SmearedVarsAndUncs = cms.InputTag("patPFMetT1Smear%sTrk")
-    process.slimmedMETsTrk.tXYUncForRaw = cms.InputTag("patPFMetTxyTrk")
-    process.slimmedMETsTrk.tXYUncForT1 = cms.InputTag("patPFMetT1TxyTrk")
-    process.slimmedMETsTrk.tXYUncForT01 = cms.InputTag("patPFMetT0pcT1TxyTrk")
-    process.slimmedMETsTrk.tXYUncForT1Smear = cms.InputTag("patPFMetT1SmearTxyTrk")
-    process.slimmedMETsTrk.tXYUncForT01Smear = cms.InputTag("patPFMetT0pcT1SmearTxyTrk")
-    del process.slimmedMETsTrk.caloMET
+    task.add(process.pfMetTrk)
     #  ==================  TrkMET 
 
     ## PU JetID

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -172,6 +172,60 @@ def miniAOD_customizeCommon(process):
     del process.slimmedMETsNoHF.caloMET
     # ================== NoHF pfMET
 
+    #  ==================  CHSMET 
+    process.CHSCands = cms.EDFilter("CandPtrSelector",
+                                    src=cms.InputTag("packedPFCandidates"),
+                                    cut=cms.string("fromPV(0) > 0")
+                                    )
+    task.add(process.CHSCands)
+
+    runMetCorAndUncForMiniAODProduction(process,
+                                        pfCandColl=cms.InputTag("CHSCands"),
+                                        recoMetFromPFCs=True,
+                                        postfix="CHS"
+                                        )
+
+    addToProcessAndTask('slimmedMETsCHS', process.slimmedMETs.clone(), process, task)
+    process.slimmedMETsCHS.src = cms.InputTag("patMETsCHS")
+    process.slimmedMETsCHS.rawVariation =  cms.InputTag("patPFMetCHS")
+    process.slimmedMETsCHS.t1Uncertainties = cms.InputTag("patPFMetT1%sCHS") 
+    process.slimmedMETsCHS.t01Variation = cms.InputTag("patPFMetT0pcT1CHS")
+    process.slimmedMETsCHS.t1SmearedVarsAndUncs = cms.InputTag("patPFMetT1Smear%sCHS")
+    process.slimmedMETsCHS.tXYUncForRaw = cms.InputTag("patPFMetTxyCHS")
+    process.slimmedMETsCHS.tXYUncForT1 = cms.InputTag("patPFMetT1TxyCHS")
+    process.slimmedMETsCHS.tXYUncForT01 = cms.InputTag("patPFMetT0pcT1TxyCHS")
+    process.slimmedMETsCHS.tXYUncForT1Smear = cms.InputTag("patPFMetT1SmearTxyCHS")
+    process.slimmedMETsCHS.tXYUncForT01Smear = cms.InputTag("patPFMetT0pcT1SmearTxyCHS")
+    del process.slimmedMETsCHS.caloMET
+    #  ==================  CHSMET 
+
+    #  ==================  TrkMET 
+    process.TrkCands = cms.EDFilter("CandPtrSelector",
+                                    src=cms.InputTag("packedPFCandidates"),
+                                    cut=cms.string("fromPV(0) > 0 && charge()!=0")
+                                    )
+    task.add(process.TrkCands)
+
+    runMetCorAndUncForMiniAODProduction(process,
+                                        pfCandColl=cms.InputTag("TrkCands"),
+                                        recoMetFromPFCs=True,
+                                        postfix="Trk"
+                                        )
+
+    addToProcessAndTask('slimmedMETsTrk', process.slimmedMETs.clone(), process, task)
+    process.slimmedMETsTrk.src = cms.InputTag("patMETsTrk")
+    process.slimmedMETsTrk.rawVariation =  cms.InputTag("patPFMetTrk")
+    process.slimmedMETsTrk.t1Uncertainties = cms.InputTag("patPFMetT1%sTrk") 
+    process.slimmedMETsTrk.t01Variation = cms.InputTag("patPFMetT0pcT1Trk")
+    process.slimmedMETsTrk.t1SmearedVarsAndUncs = cms.InputTag("patPFMetT1Smear%sTrk")
+    process.slimmedMETsTrk.tXYUncForRaw = cms.InputTag("patPFMetTxyTrk")
+    process.slimmedMETsTrk.tXYUncForT1 = cms.InputTag("patPFMetT1TxyTrk")
+    process.slimmedMETsTrk.tXYUncForT01 = cms.InputTag("patPFMetT0pcT1TxyTrk")
+    process.slimmedMETsTrk.tXYUncForT1Smear = cms.InputTag("patPFMetT1SmearTxyTrk")
+    process.slimmedMETsTrk.tXYUncForT01Smear = cms.InputTag("patPFMetT0pcT1SmearTxyTrk")
+    del process.slimmedMETsTrk.caloMET
+    #  ==================  TrkMET 
+
     ## PU JetID
     process.load("RecoJets.JetProducers.PileupJetID_cfi")
     task.add(process.pileUpJetIDTask)

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedMETs_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedMETs_cfi.py
@@ -17,7 +17,7 @@ slimmedMETs = cms.EDProducer("PATMETSlimmer",
    caloMET = cms.InputTag("patCaloMet"),
 
    #adding CHS and Track MET for the Jet/MET studies
-   chsMET = cms.InputTag("patChsMet"),
+   chsMET = cms.InputTag("patCHSMet"),
    trkMET = cms.InputTag("patTrkMet"),
 
    #switch to read the type0 correction from the existing slimmedMET

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedMETs_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedMETs_cfi.py
@@ -16,6 +16,10 @@ slimmedMETs = cms.EDProducer("PATMETSlimmer",
    #caloMET, will be used for the beginning of ata takin by the JetMET people
    caloMET = cms.InputTag("patCaloMet"),
 
+   #adding CHS and Track MET for the Jet/MET studies
+   chsMET = cms.InputTag("patChsMet"),
+   trkMET = cms.InputTag("patTrkMet"),
+
    #switch to read the type0 correction from the existing slimmedMET
    #when running on top of miniAOD (type0 cannot be redone at the miniAOD level
    runningOnMiniAOD = cms.bool(False)

--- a/PhysicsTools/PatAlgos/test/patTuple_updateMet_fromMiniAOD_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_updateMet_fromMiniAOD_cfg.py
@@ -36,6 +36,8 @@ from Configuration.EventContent.EventContent_cff import MINIAODSIMEventContent
 process.out.outputCommands = MINIAODSIMEventContent.outputCommands
 process.out.outputCommands.append("keep *_slimmedMETs_*_*")
 process.out.outputCommands.append("keep *_patPFMet_*_*")
+process.out.outputCommands.append("keep *_patChsMet_*_*")
+process.out.outputCommands.append("keep *_patTrkMet_*_*")
 process.out.outputCommands.append("keep *_patPFMetT1_*_*")
 process.out.outputCommands.append("keep *_patPFMetT1JetResDown_*_*")
 process.out.outputCommands.append("keep *_patPFMetT1JetResUp_*_*")

--- a/PhysicsTools/PatAlgos/test/patTuple_updateMet_fromMiniAOD_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_updateMet_fromMiniAOD_cfg.py
@@ -36,7 +36,7 @@ from Configuration.EventContent.EventContent_cff import MINIAODSIMEventContent
 process.out.outputCommands = MINIAODSIMEventContent.outputCommands
 process.out.outputCommands.append("keep *_slimmedMETs_*_*")
 process.out.outputCommands.append("keep *_patPFMet_*_*")
-process.out.outputCommands.append("keep *_patChsMet_*_*")
+process.out.outputCommands.append("keep *_patCHSMet_*_*")
 process.out.outputCommands.append("keep *_patTrkMet_*_*")
 process.out.outputCommands.append("keep *_patPFMetT1_*_*")
 process.out.outputCommands.append("keep *_patPFMetT1JetResDown_*_*")

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -1523,8 +1523,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             ##adding the necessary chs and track met configuration
             task = getPatAlgosToolsTask(process)
 
-            pfChs = cms.EDFilter("CandPtrSelector", src = "packedPFCandidates", cut = cms.string("fromPV(0)>0"))
-
+            pfChs = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string("fromPV(0)>0"))
             addToProcessAndTask("pfChs", pfChs, process, task)
             pfMetChs = cms.EDProducer("PFMETProducer",
                                       src = cms.InputTag('pfChs'),
@@ -1547,10 +1546,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             patMetModuleSequence += getattr(process, "pfMetChs")
             patMetModuleSequence += getattr(process, "patChsMet")
 
-            pfTrk = cms.EDFilter("CandPtrSelector", src = "packedPFCandidates", cut = cms.string("charge()!=0 && pvAssociationQuality()>=4 && vertexRef().key()==0"))
-
+            pfTrk = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string("fromPV(0) > 0 && charge()!=0"))
             addToProcessAndTask("pfTrk", pfTrk, process, task)
-
             pfMetTrk = cms.EDProducer("PFMETProducer",
                                       src = cms.InputTag('pfTrk'),
                                       alias = cms.string('pfMet'),

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -1523,7 +1523,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             ##adding the necessary chs and track met configuration
             task = getPatAlgosToolsTask(process)
 
-            pfChs = cms.EDFilter("CandPtrSelector", src = pfCandCollection, cut = cms.string("fromPV(0)>0"))
+            pfChs = cms.EDFilter("CandPtrSelector", src = "packedPFCandidates", cut = cms.string("fromPV(0)>0"))
+
             addToProcessAndTask("pfChs", pfChs, process, task)
             pfMetChs = cms.EDProducer("PFMETProducer",
                                       src = cms.InputTag('pfChs'),
@@ -1546,8 +1547,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             patMetModuleSequence += getattr(process, "pfMetChs")
             patMetModuleSequence += getattr(process, "patChsMet")
 
-            pfTrk = cms.EDFilter("CandPtrSelector", src = pfCandCollection, cut = cms.string("fromPV(0) > 0 && charge()!=0"))
+            pfTrk = cms.EDFilter("CandPtrSelector", src = "packedPFCandidates", cut = cms.string("charge()!=0 && pvAssociationQuality()>=4 && vertexRef().key()==0"))
+
             addToProcessAndTask("pfTrk", pfTrk, process, task)
+
             pfMetTrk = cms.EDProducer("PFMETProducer",
                                       src = cms.InputTag('pfTrk'),
                                       alias = cms.string('pfMet'),

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -1523,28 +1523,28 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             ##adding the necessary chs and track met configuration
             task = getPatAlgosToolsTask(process)
 
-            pfChs = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string("fromPV(0)>0"))
-            addToProcessAndTask("pfChs", pfChs, process, task)
-            pfMetChs = cms.EDProducer("PFMETProducer",
-                                      src = cms.InputTag('pfChs'),
+            pfCHS = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string("fromPV(0)>0"))
+            addToProcessAndTask("pfCHS", pfCHS, process, task)
+            pfMetCHS = cms.EDProducer("PFMETProducer",
+                                      src = cms.InputTag('pfCHS'),
                                       alias = cms.string('pfMet'),
                                       globalThreshold = cms.double(0.0),
                                       calculateSignificance = cms.bool(False),
                                       )            
 
-            addToProcessAndTask("pfMetChs", pfMetChs, process, task)
+            addToProcessAndTask("pfMetCHS", pfMetCHS, process, task)
 
             addMETCollection(process,
-                             labelName = "patChsMet",
-                             metSource = "pfMetChs"
+                             labelName = "patCHSMet",
+                             metSource = "pfMetCHS"
                              )
 
-            getattr(process,"patChsMet").computeMETSignificance = cms.bool(False)
-            getattr(process,"patChsMet").addGenMET = False
+            process.patCHSMet.computeMETSignificant = cms.bool(False)
+            process.patCHSMet.addGenMET = cms.bool(False)
 
-            patMetModuleSequence += getattr(process, "pfChs")
-            patMetModuleSequence += getattr(process, "pfMetChs")
-            patMetModuleSequence += getattr(process, "patChsMet")
+            patMetModuleSequence += getattr(process, "pfCHS")
+            patMetModuleSequence += getattr(process, "pfMetCHS")
+            patMetModuleSequence += getattr(process, "patCHSMet")
 
             pfTrk = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string("fromPV(0) > 0 && charge()!=0"))
             addToProcessAndTask("pfTrk", pfTrk, process, task)
@@ -1562,8 +1562,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                              metSource = "pfMetTrk"
                              )
 
-            getattr(process,"patTrkMet").computeMETSignificance = cms.bool(False)
-            getattr(process,"patTrkMet").addGenMET = False
+            process.patTrkMet.computeMETSignificant = cms.bool(False)
+            process.patTrkMet.addGenMET = cms.bool(False)
 
             patMetModuleSequence += getattr(process, "pfTrk")
             patMetModuleSequence += getattr(process, "pfMetTrk")


### PR DESCRIPTION
Adding the chsMET and chs/trkMET to miniAOD as a function of the pat MET. The chs MET will be used by the JERC group and the track MET was a request from the analyzers / nanoAOD developers. 