### PR TITLE
MiniAOD: change motherRef in packed Candidate

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedGenParticle.h
+++ b/DataFormats/PatCandidates/interface/PackedGenParticle.h
@@ -110,7 +110,18 @@ namespace pat {
     /// return mother at a given position (throws an exception)
     virtual const reco::Candidate * mother( size_type ) const;
     /// direct access to the mother reference (may be null)
-    const reco::GenParticleRef & motherRef() const { return mother_; }
+    reco::GenParticleRef motherRef() const { 
+	if(mother_.isNonnull() && mother_.isAvailable()&& mother_->status()==1 ){ //if pointing to the pruned version of myself
+   	  if(mother_->numberOfMothers() > 0) 
+	  	  return mother_->motherRef(0); // return my mother's (that is actually myself) mother
+	 	else
+		  return edm::Ref<reco::GenParticleCollection>(); // return null ref
+	} else { 
+	  return mother_; //the stored ref is really my mother, or null, return that
+	}
+    }
+    /// last surviving in pruned
+    const reco::GenParticleRef & lastPrunedRef() const { return mother_; }
 
     /// return daughter at a given position (throws an exception)
     virtual reco::Candidate * daughter( size_type );

--- a/DataFormats/PatCandidates/interface/PackedGenParticle.h
+++ b/DataFormats/PatCandidates/interface/PackedGenParticle.h
@@ -100,15 +100,15 @@ namespace pat {
     }
 
     /// destructor
-    virtual ~PackedGenParticle();
+    ~PackedGenParticle() override;
     /// number of daughters
-    virtual size_t numberOfDaughters() const;
+    size_t numberOfDaughters() const override;
     /// return daughter at a given position (throws an exception)
-    virtual const reco::Candidate * daughter( size_type ) const;
+    const reco::Candidate * daughter( size_type ) const override;
     /// number of mothers
-    virtual size_t numberOfMothers() const;
+    size_t numberOfMothers() const override;
     /// return mother at a given position (throws an exception)
-    virtual const reco::Candidate * mother( size_type ) const;
+    const reco::Candidate * mother( size_type ) const override;
     /// direct access to the mother reference (may be null)
     reco::GenParticleRef motherRef() const { 
 	if(mother_.isNonnull() && mother_.isAvailable()&& mother_->status()==1 ){ //if pointing to the pruned version of myself
@@ -124,108 +124,108 @@ namespace pat {
     const reco::GenParticleRef & lastPrunedRef() const { return mother_; }
 
     /// return daughter at a given position (throws an exception)
-    virtual reco::Candidate * daughter( size_type );
+    reco::Candidate * daughter( size_type ) override;
     /// return daughter with a specified role name
-    virtual reco::Candidate * daughter(const std::string& s );
+    reco::Candidate * daughter(const std::string& s ) override;
     /// return daughter with a specified role name                                        
-    virtual const reco::Candidate * daughter(const std::string& s ) const;
+    const reco::Candidate * daughter(const std::string& s ) const override;
     /// return the number of source Candidates                                            
     /// ( the candidates used to construct this Candidate)                                
-    virtual size_t numberOfSourceCandidatePtrs() const {return 0;}
+    size_t numberOfSourceCandidatePtrs() const override {return 0;}
     /// return a Ptr to one of the source Candidates                                      
     /// ( the candidates used to construct this Candidate)                                
-    virtual reco::CandidatePtr sourceCandidatePtr( size_type i ) const {
+    reco::CandidatePtr sourceCandidatePtr( size_type i ) const override {
       return reco::CandidatePtr();
     }
 
     /// electric charge
-    virtual int charge() const {
+    int charge() const override {
 	return charge_;	
     }
     /// set electric charge                                                               
-    virtual void setCharge( int charge) {charge_=charge;}
+    void setCharge( int charge) override {charge_=charge;}
     /// electric charge                                                                   
-    virtual int threeCharge() const {return charge()*3;}
+    int threeCharge() const override {return charge()*3;}
     /// set electric charge                                                               
-    virtual void setThreeCharge( int threecharge) {}
+    void setThreeCharge( int threecharge) override {}
     /// four-momentum Lorentz vecto r                                                      
-    virtual const LorentzVector & p4() const { if (!p4c_) unpack(); return *p4c_; }  
+    const LorentzVector & p4() const override { if (!p4c_) unpack(); return *p4c_; }  
     /// four-momentum Lorentz vector                                                      
-    virtual const PolarLorentzVector & polarP4() const { if (!p4c_) unpack(); return *p4_; }
+    const PolarLorentzVector & polarP4() const override { if (!p4c_) unpack(); return *p4_; }
     /// spatial momentum vector                                                           
-    virtual Vector momentum() const  { if (!p4c_) unpack(); return p4c_.load()->Vect(); }
+    Vector momentum() const override  { if (!p4c_) unpack(); return p4c_.load()->Vect(); }
     /// boost vector to boost a Lorentz vector                                            
     /// to the particle center of mass system                                             
-    virtual Vector boostToCM() const { if (!p4c_) unpack(); return p4c_.load()->BoostToCM(); }
+    Vector boostToCM() const override { if (!p4c_) unpack(); return p4c_.load()->BoostToCM(); }
     /// magnitude of momentum vector                                                      
-    virtual double p() const { if (!p4c_) unpack(); return p4c_.load()->P(); }
+    double p() const override { if (!p4c_) unpack(); return p4c_.load()->P(); }
     /// energy                                                                            
-    virtual double energy() const { if (!p4c_) unpack(); return p4c_.load()->E(); }
+    double energy() const override { if (!p4c_) unpack(); return p4c_.load()->E(); }
    /// transverse energy   
-    double et() const { return (pt()<=0) ? 0 : p4c_.load()->Et(); }
+    double et() const override { return (pt()<=0) ? 0 : p4c_.load()->Et(); }
     /// transverse energy squared (use this for cuts)!
-    double et2() const { return (pt()<=0) ? 0 : p4c_.load()->Et2(); }
+    double et2() const override { return (pt()<=0) ? 0 : p4c_.load()->Et2(); }
     /// mass                                                                              
-    virtual double mass() const { if (!p4c_) unpack(); return p4_.load()->M(); }
+    double mass() const override { if (!p4c_) unpack(); return p4_.load()->M(); }
     /// mass squared                                                                      
-    virtual double massSqr() const { if (!p4c_) unpack(); return p4_.load()->M()*p4_.load()->M(); }
+    double massSqr() const override { if (!p4c_) unpack(); return p4_.load()->M()*p4_.load()->M(); }
 
     /// transverse mass                                                                   
-    virtual double mt() const { if (!p4c_) unpack(); return p4_.load()->Mt(); }
+    double mt() const override { if (!p4c_) unpack(); return p4_.load()->Mt(); }
     /// transverse mass squared                                                           
-    virtual double mtSqr() const { if (!p4c_) unpack(); return p4_.load()->Mt2(); }
+    double mtSqr() const override { if (!p4c_) unpack(); return p4_.load()->Mt2(); }
     /// x coordinate of momentum vector                                                   
-    virtual double px() const { if (!p4c_) unpack(); return p4c_.load()->Px(); }
+    double px() const override { if (!p4c_) unpack(); return p4c_.load()->Px(); }
     /// y coordinate of momentum vector                                                   
-    virtual double py() const { if (!p4c_) unpack(); return p4c_.load()->Py(); }
+    double py() const override { if (!p4c_) unpack(); return p4c_.load()->Py(); }
     /// z coordinate of momentum vector                                                   
-    virtual double pz() const { if (!p4c_) unpack(); return p4c_.load()->Pz(); }
+    double pz() const override { if (!p4c_) unpack(); return p4c_.load()->Pz(); }
     /// transverse momentum                                                               
-    virtual double pt() const { if (!p4c_) unpack(); return p4_.load()->Pt();}
+    double pt() const override { if (!p4c_) unpack(); return p4_.load()->Pt();}
     /// momentum azimuthal angle                                                          
-    virtual double phi() const { if (!p4c_) unpack(); return p4_.load()->Phi(); }
+    double phi() const override { if (!p4c_) unpack(); return p4_.load()->Phi(); }
     /// momentum polar angle                                                              
-    virtual double theta() const { if (!p4c_) unpack(); return p4_.load()->Theta(); }
+    double theta() const override { if (!p4c_) unpack(); return p4_.load()->Theta(); }
     /// momentum pseudorapidity                                                           
-    virtual double eta() const { if (!p4c_) unpack(); return p4_.load()->Eta(); }
+    double eta() const override { if (!p4c_) unpack(); return p4_.load()->Eta(); }
     /// rapidity                                                                          
-    virtual double rapidity() const { if (!p4c_) unpack(); return p4_.load()->Rapidity(); }
+    double rapidity() const override { if (!p4c_) unpack(); return p4_.load()->Rapidity(); }
     /// rapidity                                                                          
-    virtual double y() const { if (!p4c_) unpack(); return p4_.load()->Rapidity(); }
+    double y() const override { if (!p4c_) unpack(); return p4_.load()->Rapidity(); }
     /// set 4-momentum                                                                    
-    virtual void setP4( const LorentzVector & p4 ) { 
+    void setP4( const LorentzVector & p4 ) override { 
         unpack(); // changing px,py,pz changes also mapping between dxy,dz and x,y,z
         *p4_ = PolarLorentzVector(p4.Pt(), p4.Eta(), p4.Phi(), p4.M());
         pack();
     }
     /// set 4-momentum                                                                    
-    virtual void setP4( const PolarLorentzVector & p4 ) { 
+    void setP4( const PolarLorentzVector & p4 ) override { 
         unpack(); // changing px,py,pz changes also mapping between dxy,dz and x,y,z
         *p4_ = p4; 
         pack();
     }
     /// set particle mass                                                                 
-    virtual void setMass( double m ) {
+    void setMass( double m ) override {
       if (!p4c_) unpack(); 
       *p4_ = PolarLorentzVector(p4_.load()->Pt(), p4_.load()->Eta(), p4_.load()->Phi(), m); 
       pack();
     }
-    virtual void setPz( double pz ) {
+    void setPz( double pz ) override {
       unpack(); // changing px,py,pz changes also mapping between dxy,dz and x,y,z
       *p4c_ = LorentzVector(p4c_.load()->Px(), p4c_.load()->Py(), pz, p4c_.load()->E());
       *p4_  = PolarLorentzVector(p4c_.load()->Pt(), p4c_.load()->Eta(), p4c_.load()->Phi(), p4c_.load()->M());
       pack();
     }
     /// vertex position
-    virtual const Point & vertex() const { return vertex_; }//{ if (fromPV_) return Point(0,0,0); else return Point(0,0,100); }
+    const Point & vertex() const override { return vertex_; }//{ if (fromPV_) return Point(0,0,0); else return Point(0,0,100); }
     /// x coordinate of vertex position                                                   
-    virtual double vx() const  {  return vertex_.X(); }//{ return 0; }
+    double vx() const override  {  return vertex_.X(); }//{ return 0; }
     /// y coordinate of vertex position                                                   
-    virtual double vy() const  {  return vertex_.Y(); }//{ return 0; }
+    double vy() const override  {  return vertex_.Y(); }//{ return 0; }
     /// z coordinate of vertex position                                                   
-    virtual double vz() const  {  return vertex_.Z(); }//{ if (fromPV_) return 0; else return 100; }
+    double vz() const override  {  return vertex_.Z(); }//{ if (fromPV_) return 0; else return 100; }
     /// set vertex                                                                        
-    virtual void setVertex( const Point & vertex ) { vertex_ = vertex;  }
+    void setVertex( const Point & vertex ) override { vertex_ = vertex;  }
 
     enum PVAssoc { NoPV=0, PVLoose=1, PVTight=2, PVUsedInFit=3 } ;
 
@@ -241,76 +241,76 @@ namespace pat {
 
 
     /// PDG identifier                                                                    
-    virtual int pdgId() const   { return pdgId_; }
+    int pdgId() const override   { return pdgId_; }
     // set PDG identifier                                                                 
-    virtual void setPdgId( int pdgId )   { pdgId_ = pdgId; }
+    void setPdgId( int pdgId ) override   { pdgId_ = pdgId; }
     /// status word                                                                       
-    virtual int status() const   { return 1; } /*FIXME*/
+    int status() const override   { return 1; } /*FIXME*/
     /// set status word                                                                   
-    virtual void setStatus( int status ) {} /*FIXME*/
+    void setStatus( int status ) override {} /*FIXME*/
     /// long lived flag                                                                   
     static const unsigned int longLivedTag = 0; /*FIXME*/
     /// set long lived flag                                                               
-    virtual void setLongLived() {} /*FIXME*/
+    void setLongLived() override {} /*FIXME*/
     /// is long lived?                                                                    
-    virtual bool longLived() const;
+    bool longLived() const override;
     /// do mass constraint flag
     static const unsigned int massConstraintTag = 0; /*FIXME*/ 
     /// set mass constraint flag
-    virtual void setMassConstraint() {} /*FIXME*/
+    void setMassConstraint() override {} /*FIXME*/
     /// do mass constraint?
-    virtual bool massConstraint() const;
+    bool massConstraint() const override;
 
     /// returns a clone of the Candidate object                                           
-    virtual PackedGenParticle * clone() const  {
+    PackedGenParticle * clone() const override  {
       return new PackedGenParticle( *this );
     }
 
     /// chi-squares                                                                                                    
-    virtual double vertexChi2() const;
+    double vertexChi2() const override;
     /** Number of degrees of freedom                                                                                   
      *  Meant to be Double32_t for soft-assignment fitters:                                                            
      *  tracks may contribute to the vertex with fractional weights.                                                   
      *  The ndof is then = to the sum of the track weights.                                                            
      *  see e.g. CMS NOTE-2006/032, CMS NOTE-2004/002                                                                  
      */
-    virtual double vertexNdof() const;
+    double vertexNdof() const override;
     /// chi-squared divided by n.d.o.f.                                                                                
-    virtual double vertexNormalizedChi2() const;
+    double vertexNormalizedChi2() const override;
     /// (i, j)-th element of error matrix, i, j = 0, ... 2                                                             
-    virtual double vertexCovariance(int i, int j) const;
+    double vertexCovariance(int i, int j) const override;
     /// return SMatrix                                                                                                 
-    CovarianceMatrix vertexCovariance() const   { CovarianceMatrix m; fillVertexCovariance(m); return m; }
+    CovarianceMatrix vertexCovariance() const override   { CovarianceMatrix m; fillVertexCovariance(m); return m; }
     /// fill SMatrix                                                                                                   
-    virtual void fillVertexCovariance(CovarianceMatrix & v) const;
+    void fillVertexCovariance(CovarianceMatrix & v) const override;
     /// returns true if this candidate has a reference to a master clone.                                              
     /// This only happens if the concrete Candidate type is ShallowCloneCandidate                                      
-    virtual bool hasMasterClone() const;
+    bool hasMasterClone() const override;
     /// returns ptr to master clone, if existing.                                                                      
     /// Throws an exception unless the concrete Candidate type is ShallowCloneCandidate                                
-    virtual const reco::CandidateBaseRef & masterClone() const;
+    const reco::CandidateBaseRef & masterClone() const override;
     /// returns true if this candidate has a ptr to a master clone.                                                    
     /// This only happens if the concrete Candidate type is ShallowClonePtrCandidate                                   
-    virtual bool hasMasterClonePtr() const;
+    bool hasMasterClonePtr() const override;
     /// returns ptr to master clone, if existing.                                                                      
     /// Throws an exception unless the concrete Candidate type is ShallowClonePtrCandidate                             
 
-    virtual const reco::CandidatePtr & masterClonePtr() const;
+    const reco::CandidatePtr & masterClonePtr() const override;
 
     /// cast master clone reference to a concrete type
     template<typename Ref>
       Ref masterRef() const { return masterClone().template castTo<Ref>(); }
     /// get a component
 
-    virtual bool isElectron() const;
-    virtual bool isMuon() const;
-    virtual bool isStandAloneMuon() const;
-    virtual bool isGlobalMuon() const;
-    virtual bool isTrackerMuon() const;
-    virtual bool isCaloMuon() const;
-    virtual bool isPhoton() const;
-    virtual bool isConvertedPhoton() const;
-    virtual bool isJet() const;
+    bool isElectron() const override;
+    bool isMuon() const override;
+    bool isStandAloneMuon() const override;
+    bool isGlobalMuon() const override;
+    bool isTrackerMuon() const override;
+    bool isCaloMuon() const override;
+    bool isPhoton() const override;
+    bool isConvertedPhoton() const override;
+    bool isJet() const override;
     
     const reco::GenStatusFlags &statusFlags() const { return statusFlags_; }
     reco::GenStatusFlags &statusFlags() { return statusFlags_; }
@@ -368,7 +368,7 @@ namespace pat {
     reco::GenStatusFlags statusFlags_;
 
     /// check overlap with another Candidate                                              
-    virtual bool overlap( const reco::Candidate & ) const;
+    bool overlap( const reco::Candidate & ) const override;
     template<typename, typename, typename> friend struct component;
     friend class ::OverlapChecker;
     friend class ShallowCloneCandidate;

--- a/DataFormats/PatCandidates/src/PackedGenParticle.cc
+++ b/DataFormats/PatCandidates/src/PackedGenParticle.cc
@@ -95,7 +95,7 @@ bool pat::PackedGenParticle::overlap( const reco::Candidate & o ) const {
 }
 
 const reco::Candidate * pat::PackedGenParticle::daughter( size_type ) const {
-  return 0;
+  return nullptr;
 }
 
 const reco::Candidate * pat::PackedGenParticle::mother( size_type ) const {
@@ -117,7 +117,7 @@ reco::Candidate * pat::PackedGenParticle::daughter(const std::string&) {
 
 
 reco::Candidate * pat::PackedGenParticle::daughter( size_type ) {
-  return 0;
+  return nullptr;
 }
 
 double pat::PackedGenParticle::vertexChi2() const {

--- a/DataFormats/PatCandidates/src/PackedGenParticle.cc
+++ b/DataFormats/PatCandidates/src/PackedGenParticle.cc
@@ -85,7 +85,7 @@ size_t pat::PackedGenParticle::numberOfDaughters() const {
 }
 
 size_t pat::PackedGenParticle::numberOfMothers() const { 
-  if(mother_.isNonnull())   return 1; 
+  if(motherRef().isNonnull())   return 1; 
   return 0;
 }
 
@@ -99,7 +99,7 @@ const reco::Candidate * pat::PackedGenParticle::daughter( size_type ) const {
 }
 
 const reco::Candidate * pat::PackedGenParticle::mother( size_type ) const {
-  return mother_.get();
+  return motherRef().get();
 }
 
 const reco::Candidate * pat::PackedGenParticle::daughter(const std::string&) const {

--- a/PhysicsTools/PatAlgos/plugins/PATPackedGenParticleProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedGenParticleProducer.cc
@@ -40,9 +40,9 @@ namespace pat {
   class PATPackedGenParticleProducer : public edm::global::EDProducer<> {
   public:
     explicit PATPackedGenParticleProducer(const edm::ParameterSet&);
-    ~PATPackedGenParticleProducer();
+    ~PATPackedGenParticleProducer() override;
     
-    virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const;
+    void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
     
   private:
     const edm::EDGetTokenT<reco::GenParticleCollection>    Cands_;

--- a/PhysicsTools/PatAlgos/plugins/PATPackedGenParticleProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedGenParticleProducer.cc
@@ -73,6 +73,7 @@ void pat::PATPackedGenParticleProducer::produce(edm::StreamID, edm::Event& iEven
     iEvent.getByToken( Cands_, cands );
     std::vector<reco::Candidate>::const_iterator cand;
 
+    //from prunedGenParticlesWithStatusOne to prunedGenParticles
     edm::Handle<edm::Association<reco::GenParticleCollection> > asso;
     iEvent.getByToken( Asso_, asso );
 
@@ -102,14 +103,18 @@ void pat::PATPackedGenParticleProducer::produce(edm::StreamID, edm::Event& iEven
 		// Obtain original gen particle collection reference from input reference and map
 		edm::Ref<reco::GenParticleCollection> inputRef = edm::Ref<reco::GenParticleCollection>(cands,ic);
 		edm::Ref<reco::GenParticleCollection> originalRef=reverseMap[inputRef];
+		edm::Ref<reco::GenParticleCollection> finalPrunedRef=(*asso)[inputRef];
 		mapping[originalRef.key()]=packed;
 		packed++;
-		if(cand.numberOfMothers() > 0) {
+		if(finalPrunedRef.isNonnull()){ //this particle exists also in the final pruned
+                        outPtrP->push_back( pat::PackedGenParticle(cand,finalPrunedRef));
+		}else{
+		  if(cand.numberOfMothers() > 0) {
 			edm::Ref<reco::GenParticleCollection> newRef=(*asso)[cand.motherRef(0)];
 	        	outPtrP->push_back( pat::PackedGenParticle(cand,newRef));
-		} else {
+	  	  } else {
 	        	outPtrP->push_back( pat::PackedGenParticle(cand,edm::Ref<reco::GenParticleCollection>()));
-			
+		  }
 		}
 
 	}	


### PR DESCRIPTION
With this the reference to prunedParticles contained in the packedGen is set to the same-particle-in-pruned when available.
The behaviour of the accessors is the same and should be backward compatible.

This will allow a better merging of pruned+packed in downstream processing (e.g. for Rivet ParticleLevel producer) and avoid exact matching on pt  as done in:
https://github.com/cms-sw/cmssw/blob/master/GeneratorInterface/RivetInterface/plugins/MergedGenParticleProducer.cc#L44

@gpetruc @perrozzi @intrepid42 

