### PR TITLE
Sped up principal 'put'

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/plugins/AlcaPCCProducer.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/AlcaPCCProducer.cc
@@ -33,13 +33,13 @@ ________________________________________________________________**/
 class AlcaPCCProducer : public edm::one::EDProducer<edm::EndLuminosityBlockProducer,edm::one::WatchLuminosityBlocks>{
   public:
     explicit AlcaPCCProducer(const edm::ParameterSet&);
-    ~AlcaPCCProducer();
+    ~AlcaPCCProducer() override;
 
   private:
-    virtual void beginLuminosityBlock     (edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) ;
-    virtual void endLuminosityBlock       (edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) ;
-    virtual void endLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup) ;
-    virtual void produce                  (edm::Event& iEvent, const edm::EventSetup& iSetup) ;
+    void beginLuminosityBlock     (edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) override ;
+    void endLuminosityBlock       (edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) override ;
+    void endLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup) override ;
+    void produce                  (edm::Event& iEvent, const edm::EventSetup& iSetup) override ;
  
     edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> >  pixelToken;
     edm::InputTag   fPixelClusterLabel;

--- a/Calibration/LumiAlCaRecoProducers/plugins/AlcaPCCProducer.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/AlcaPCCProducer.cc
@@ -60,7 +60,7 @@ AlcaPCCProducer::AlcaPCCProducer(const edm::ParameterSet& iConfig)
 
     countLumi_ = 0;
 
-    produces<reco::PixelClusterCounts, edm::InLumi>(trigstring_);
+    produces<reco::PixelClusterCounts, edm::Transition::EndLuminosityBlock>(trigstring_);
     pixelToken=consumes<edmNew::DetSetVector<SiPixelCluster> >(fPixelClusterLabel);
 }
 

--- a/DQMServices/StreamerIO/plugins/DQMProtobufReader.cc
+++ b/DQMServices/StreamerIO/plugins/DQMProtobufReader.cc
@@ -18,8 +18,8 @@ DQMProtobufReader::DQMProtobufReader(edm::ParameterSet const& pset,
   flagDeleteDatFiles_ = pset.getUntrackedParameter<bool>("deleteDatFiles");
   flagLoadFiles_ = pset.getUntrackedParameter<bool>("loadFiles");
 
-  produces<std::string, edm::InLumi>("sourceDataPath");
-  produces<std::string, edm::InLumi>("sourceJsonPath");
+  produces<std::string, edm::Transition::BeginLuminosityBlock>("sourceDataPath");
+  produces<std::string, edm::Transition::BeginLuminosityBlock>("sourceJsonPath");
 }
 
 DQMProtobufReader::~DQMProtobufReader() {}

--- a/DQMServices/StreamerIO/plugins/DQMProtobufReader.cc
+++ b/DQMServices/StreamerIO/plugins/DQMProtobufReader.cc
@@ -11,7 +11,7 @@ using namespace dqmservices;
 
 DQMProtobufReader::DQMProtobufReader(edm::ParameterSet const& pset,
                                      edm::InputSourceDescription const& desc)
-    : InputSource(pset, desc), fiterator_(pset) {
+    : PuttableSourceBase(pset, desc), fiterator_(pset) {
 
   flagSkipFirstLumis_ = pset.getUntrackedParameter<bool>("skipFirstLumis");
   flagEndOfRunKills_ = pset.getUntrackedParameter<bool>("endOfRunKills");

--- a/DQMServices/StreamerIO/plugins/DQMProtobufReader.h
+++ b/DQMServices/StreamerIO/plugins/DQMProtobufReader.h
@@ -7,13 +7,14 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Sources/interface/ProducerSourceBase.h"
+#include "FWCore/Sources/interface/PuttableSourceBase.h"
 
 #include "DQMFileIterator.h"
 #include "DQMMonitoringService.h"
 
 namespace dqmservices {
 
-class DQMProtobufReader : public edm::InputSource {
+class DQMProtobufReader : public edm::PuttableSourceBase {
  public:
   explicit DQMProtobufReader(edm::ParameterSet const&,
                              edm::InputSourceDescription const&);

--- a/DQMServices/StreamerIO/plugins/DQMProtobufReader.h
+++ b/DQMServices/StreamerIO/plugins/DQMProtobufReader.h
@@ -18,21 +18,21 @@ class DQMProtobufReader : public edm::PuttableSourceBase {
  public:
   explicit DQMProtobufReader(edm::ParameterSet const&,
                              edm::InputSourceDescription const&);
-  ~DQMProtobufReader();
+  ~DQMProtobufReader() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
  private:
-  virtual edm::InputSource::ItemType getNextItemType() override;
-  virtual std::shared_ptr<edm::RunAuxiliary> readRunAuxiliary_() override;
-  virtual std::shared_ptr<edm::LuminosityBlockAuxiliary>
+  edm::InputSource::ItemType getNextItemType() override;
+  std::shared_ptr<edm::RunAuxiliary> readRunAuxiliary_() override;
+  std::shared_ptr<edm::LuminosityBlockAuxiliary>
   readLuminosityBlockAuxiliary_() override;
-  virtual void readRun_(edm::RunPrincipal& rpCache) override;
-  virtual void readLuminosityBlock_(
+  void readRun_(edm::RunPrincipal& rpCache) override;
+  void readLuminosityBlock_(
       edm::LuminosityBlockPrincipal& lbCache) override;
-  virtual void readEvent_(edm::EventPrincipal&) override;
+  void readEvent_(edm::EventPrincipal&) override;
 
   // actual reading will happen here
-  virtual void beginLuminosityBlock(edm::LuminosityBlock& lb) override;
+  void beginLuminosityBlock(edm::LuminosityBlock& lb) override;
 
   void logFileAction(char const* msg, char const* fileName) const;
   bool prepareNextFile();

--- a/DataFormats/Provenance/interface/Hash.h
+++ b/DataFormats/Provenance/interface/Hash.h
@@ -49,6 +49,9 @@ namespace edm {
 
     Hash(Hash<I> const&);
     Hash<I>& operator=(Hash<I> const& iRHS);
+    
+    Hash(Hash<I>&&) = default;
+    Hash<I>& operator=(Hash<I>&&) = default;
 
     void reset();
 

--- a/DataFormats/Provenance/interface/ProductProvenance.h
+++ b/DataFormats/Provenance/interface/ProductProvenance.h
@@ -24,14 +24,14 @@ namespace edm {
   class ProductProvenance {
   public:
     ProductProvenance();
-    explicit ProductProvenance(BranchID const& bid);
-    ProductProvenance(BranchID const& bid,
-                      ParentageID const& id);
+    explicit ProductProvenance(BranchID bid);
+    ProductProvenance(BranchID bid,
+                      ParentageID id);
 
-    ProductProvenance(BranchID const& bid,
+    ProductProvenance(BranchID bid,
                       std::vector<BranchID> const& parents);
 
-    ProductProvenance(BranchID const& bid,
+    ProductProvenance(BranchID bid,
                       std::vector<BranchID>&& parents);
 
     ~ProductProvenance() {}

--- a/DataFormats/Provenance/interface/ProductProvenance.h
+++ b/DataFormats/Provenance/interface/ProductProvenance.h
@@ -34,8 +34,6 @@ namespace edm {
     ProductProvenance(BranchID bid,
                       std::vector<BranchID>&& parents);
 
-    ~ProductProvenance() {}
-
     ProductProvenance makeProductProvenance() const;
 
     void write(std::ostream& os) const;

--- a/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
+++ b/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
@@ -65,7 +65,7 @@ namespace edm {
 
     ProductProvenance const* branchIDToProvenanceForProducedOnly(BranchID const& bid) const;
     
-    void insertIntoSet(ProductProvenance const& provenanceProduct) const;
+    void insertIntoSet(ProductProvenance provenanceProduct) const;
 
     void mergeProvenanceRetrievers(std::shared_ptr<ProductProvenanceRetriever> other);
 

--- a/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
+++ b/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
@@ -61,6 +61,7 @@ ProductRegistry is frozen.
 #include <set>
 #include <string>
 #include <vector>
+#include <tuple>
 #include <unordered_map>
 
 namespace edm {
@@ -120,7 +121,7 @@ namespace edm {
                              char const* instance,
                              char const* process = 0) const;
     
-    using ModulesToIndiciesMap =std::unordered_multimap<std::string,ProductResolverIndex>;
+    using ModulesToIndiciesMap =std::unordered_multimap<std::string,std::tuple<TypeID const*, const  char*, ProductResolverIndex>>;
     ModulesToIndiciesMap indiciesForModulesInProcess( const std::string& iProcessName ) const;
 
     class Matches {

--- a/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
+++ b/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
@@ -119,7 +119,7 @@ namespace edm {
                              TypeID const& typeID,
                              char const* moduleLabel,
                              char const* instance,
-                             char const* process = 0) const;
+                             char const* process = nullptr) const;
     
     using ModulesToIndiciesMap =std::unordered_multimap<std::string,std::tuple<TypeID const*, const  char*, ProductResolverIndex>>;
     ModulesToIndiciesMap indiciesForModulesInProcess( const std::string& iProcessName ) const;

--- a/DataFormats/Provenance/src/ProductProvenance.cc
+++ b/DataFormats/Provenance/src/ProductProvenance.cc
@@ -17,20 +17,20 @@ namespace edm {
     parentageID_()
   {}
 
-  ProductProvenance::ProductProvenance(BranchID const& bid) :
-    branchID_(bid),
+  ProductProvenance::ProductProvenance(BranchID bid) :
+    branchID_(std::move(bid)),
     parentageID_()
   {}
 
-   ProductProvenance::ProductProvenance(BranchID const& bid,
-				    ParentageID const& edid) :
-    branchID_(bid),
-    parentageID_(edid)
+   ProductProvenance::ProductProvenance(BranchID bid,
+				    ParentageID edid) :
+    branchID_(std::move(bid)),
+    parentageID_(std::move(edid))
   {}
 
-  ProductProvenance::ProductProvenance(BranchID const& bid,
+  ProductProvenance::ProductProvenance(BranchID bid,
 		   std::vector<BranchID> const& parents) :
-    branchID_(bid),
+    branchID_(std::move(bid)),
     parentageID_() {
       Parentage p;
       p.setParents(parents);
@@ -38,9 +38,9 @@ namespace edm {
       ParentageRegistry::instance()->insertMapped(p);
   }
 
-  ProductProvenance::ProductProvenance(BranchID const& bid,
+  ProductProvenance::ProductProvenance(BranchID bid,
                                        std::vector<BranchID>&& parents) :
-  branchID_(bid),
+  branchID_(std::move(bid)),
   parentageID_() {
     Parentage p;
     p.setParents(std::move(parents));

--- a/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
+++ b/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
@@ -92,12 +92,12 @@ namespace edm {
   }
 
   void
-  ProductProvenanceRetriever::insertIntoSet(ProductProvenance const& entryInfo) const {
+  ProductProvenanceRetriever::insertIntoSet(ProductProvenance entryInfo) const {
     //NOTE:do not read provenance here because we only need the full
     // provenance when someone tries to access it not when doing the insert
     // doing the delay saves 20% of time when doing an analysis job
     //readProvenance();
-    entryInfoSet_.insert(entryInfo);
+    entryInfoSet_.insert(std::move(entryInfo));
   }
  
   void

--- a/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
+++ b/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
@@ -591,7 +591,13 @@ namespace edm {
         auto const& indexAndNames = indexAndNames_[j];
         if(0 == strcmp(&processNames_[indexAndNames.startInProcessNames()], iProcessName.c_str())) {
           //The first null terminated string is the module label
-          result.emplace(&bigNamesContainer_[indexAndNames.startInBigNamesContainer()],indexAndNames.index());
+          auto pModLabel = &bigNamesContainer_[indexAndNames.startInBigNamesContainer()];
+          auto l = strlen(pModLabel);
+          auto pInstance = pModLabel+l+1;
+          result.emplace(pModLabel,
+                         std::make_tuple(&sortedTypeIDs_[i],
+                                         pInstance,
+                                         indexAndNames.index()));
         }
       }
     }

--- a/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
+++ b/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
@@ -65,7 +65,7 @@ namespace edm {
   
     TypeID 
     getContainedType(TypeID const& typeID) {
-      std::string className = typeID.className();
+      const std::string& className = typeID.className();
       TypeWithDict const wrappedType = TypeWithDict::byName(wrappedClassName(className));
       TypeID const wrappedTypeID = TypeID(wrappedType.typeInfo());
       return getContainedTypeFromWrapper(wrappedTypeID, className);
@@ -158,7 +158,7 @@ namespace edm {
                                                              typeID,
                                                              moduleLabel,
                                                              instance,
-                                                             0);
+                                                             nullptr);
     unsigned int numberOfMatches = 1;
 
     if (startInIndexAndNames == std::numeric_limits<unsigned int>::max()) {
@@ -206,7 +206,7 @@ namespace edm {
         << "ProductResolverIndexHelper::insert - Attempt to insert more elements after frozen.\n";
     }
 
-    if (process == 0 || *process == '\0') {
+    if (process == nullptr || *process == '\0') {
       throw Exception(errors::LogicError)
         << "ProductResolverIndexHelper::insert - Empty process.\n";
     }

--- a/DataFormats/Provenance/test/productResolverIndexHelper_t.cppunit.cc
+++ b/DataFormats/Provenance/test/productResolverIndexHelper_t.cppunit.cc
@@ -131,7 +131,7 @@ void TestProductResolverIndexHelper::testOneEntry() {
     CPPUNIT_ASSERT(indexToModules.size() == 1);
     CPPUNIT_ASSERT(indexToModules.count("labelA") == 1);
     auto const& range = indexToModules.equal_range("labelA");
-    CPPUNIT_ASSERT( range.first->second == indexWithProcess);
+    CPPUNIT_ASSERT( std::get<2>(range.first->second) == indexWithProcess);
   }
   
   {

--- a/EventFilter/L1GlobalTriggerRawToDigi/src/L1GtTriggerMenuLiteProducer.cc
+++ b/EventFilter/L1GlobalTriggerRawToDigi/src/L1GtTriggerMenuLiteProducer.cc
@@ -63,7 +63,7 @@ L1GtTriggerMenuLiteProducer::L1GtTriggerMenuLiteProducer(
     m_physicsDaqPartition(0) {
 
     // EDM product in Run Data
-    produces<L1GtTriggerMenuLite, edm::InRun>();
+    produces<L1GtTriggerMenuLite, edm::Transition::BeginRun>();
 
 }
 

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -48,6 +48,7 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include <vector>
 
 class testEventGetRefBeforePut;
+class testEvent;
 
 namespace edm {
 
@@ -241,7 +242,7 @@ namespace edm {
 
     void labelsForToken(EDGetToken const& iToken, ProductLabels& oLabels) const { provRecorder_.labelsForToken(iToken, oLabels); }
 
-    typedef std::vector<std::pair<edm::propagate_const<std::unique_ptr<WrapperBase>>, BranchDescription const*> > ProductPtrVec;
+    typedef std::vector<edm::propagate_const<std::unique_ptr<WrapperBase>>> ProductPtrVec;
 
     EDProductGetter const&
     productGetter() const;
@@ -249,7 +250,8 @@ namespace edm {
   private:
     //for testing
     friend class ::testEventGetRefBeforePut;
-
+    friend class ::testEvent;
+    
     EventPrincipal const&
     eventPrincipal() const;
 
@@ -273,7 +275,7 @@ namespace edm {
     template<typename T> friend class stream::ProducingModuleAdaptorBase;
 
     void commit_(std::vector<edm::ProductResolverIndex> const& iShouldPut, std::vector<BranchID>* previousParentage= nullptr, ParentageID* previousParentageId = nullptr);
-    void commit_aux(ProductPtrVec& products, bool record_parents, std::vector<BranchID>* previousParentage = nullptr, ParentageID* previousParentageId = nullptr);
+    void commit_aux(ProductPtrVec& products, std::vector<BranchID>* previousParentage = nullptr, ParentageID* previousParentageId = nullptr);
 
     BasicHandle
     getByProductID_(ProductID const& oid) const;
@@ -281,25 +283,19 @@ namespace edm {
     ProductPtrVec& putProducts() {return putProducts_;}
     ProductPtrVec const& putProducts() const {return putProducts_;}
 
-    ProductPtrVec& putProductsWithoutParents() {return putProductsWithoutParents_;}
-
-    ProductPtrVec const& putProductsWithoutParents() const {return putProductsWithoutParents_;}
-
     PrincipalGetAdapter provRecorder_;
 
-    // putProducts_ and putProductsWithoutParents_ are the holding
-    // pens for EDProducts inserted into this PrincipalGetAdapter. Pointers
-    // in these collections own the products to which they point.
+    // putProducts_ is a holding pen for EDProducts inserted into this
+    // PrincipalGetAdapter.
     //
-    ProductPtrVec putProducts_;               // keep parentage info for these
-    ProductPtrVec putProductsWithoutParents_; // ... but not for these
+    ProductPtrVec putProducts_;
 
     EventAuxiliary const& aux_;
     std::shared_ptr<LuminosityBlock const> const luminosityBlock_;
 
     // gotBranchIDs_ must be mutable because it records all 'gets',
     // which do not logically modify the PrincipalGetAdapter. gotBranchIDs_ is
-    // merely a cache reflecting what has been retreived from the
+    // merely a cache reflecting what has been retrieved from the
     // Principal class.
     typedef std::set<BranchID> BranchIDSet;
     mutable BranchIDSet gotBranchIDs_;
@@ -313,33 +309,6 @@ namespace edm {
 
     static const std::string emptyString_;
   };
-
-  // The following functions objects are used by Event::put, under the
-  // control of a metafunction if, to put the given pair into the
-  // right collection.
-  template<typename PROD>
-  struct RecordInParentless {
-    typedef Event::ProductPtrVec ptrvec_t;
-    void do_it(ptrvec_t& /*ignored*/,
-               ptrvec_t& used,
-               std::unique_ptr<Wrapper<PROD> > wp,
-               BranchDescription const* desc) const {
-      used.emplace_back(std::move(wp), desc);
-    }
-  };
-
-  template<typename PROD>
-  struct RecordInParentfull {
-    typedef Event::ProductPtrVec ptrvec_t;
-
-    void do_it(ptrvec_t& used,
-               ptrvec_t& /*ignored*/,
-               std::unique_ptr<Wrapper<PROD> > wp,
-               BranchDescription const* desc) const {
-      used.emplace_back(std::move(wp), desc);
-    }
-  };
-
 
   template<typename PROD>
   bool
@@ -390,25 +359,16 @@ namespace edm {
                        DoNotPostInsert<PROD>> maybe_inserter;
     maybe_inserter(product.get());
 
-    BranchDescription const& desc =
-      provRecorder_.getBranchDescription(TypeID(*product), productInstanceName);
-
+    auto index =
+      provRecorder_.getPutTokenIndex(TypeID(*product), productInstanceName);
+    assert(index != std::numeric_limits<unsigned int>::max());
+    assert(index < putProducts().size());
+    
     std::unique_ptr<Wrapper<PROD> > wp(new Wrapper<PROD>(std::move(product)));
     PROD const* prod = wp->product();
 
-    std::conditional_t<detail::has_donotrecordparents<PROD>::value,
-                       RecordInParentless<PROD>,
-                       RecordInParentfull<PROD>> parentage_recorder;
-    parentage_recorder.do_it(putProducts(),
-                             putProductsWithoutParents(),
-                             std::move(wp),
-                             &desc);
-
-    //  putProducts().push_back(std::make_pair(edp, &desc));
-
-    // product.release(); // The object has been copied into the Wrapper.
-    // The old copy must be deleted, so we cannot release ownership.
-
+    putProducts()[index]=std::move(wp);
+    auto const& desc = provRecorder_.getBranchDescription(index);
     return(OrphanHandle<PROD>(prod, makeProductID(desc)));
   }
 

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -368,8 +368,8 @@ namespace edm {
     PROD const* prod = wp->product();
 
     putProducts()[index]=std::move(wp);
-    auto const& desc = provRecorder_.getBranchDescription(index);
-    return(OrphanHandle<PROD>(prod, makeProductID(desc)));
+    auto const& prodID = provRecorder_.getProductID(index);
+    return(OrphanHandle<PROD>(prod, prodID));
   }
 
   template<typename PROD>

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -382,7 +382,7 @@ namespace edm {
   template<typename PROD>
   OrphanHandle<PROD>
   Event::put(std::unique_ptr<PROD> product, std::string const& productInstanceName) {
-    if(unlikely(product.get() == 0)) {                // null pointer is illegal
+    if(unlikely(product.get() == nullptr)) {                // null pointer is illegal
       TypeID typeID(typeid(PROD));
       principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, productInstanceName);
     }

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -42,7 +42,7 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 
 #include <memory>
 #include <string>
-#include <set>
+#include <unordered_set>
 #include <typeinfo>
 #include <type_traits>
 #include <vector>
@@ -77,7 +77,7 @@ namespace edm {
 
     void setSharedResourcesAcquirer( SharedResourcesAcquirer* iResourceAcquirer);
     
-    void setProducer( ProducerBase const* iProd);
+    void setProducer( ProducerBase const* iProd, std::vector<BranchID>* previousParentage );
 
     // AUX functions are defined in EventBase
     EventAuxiliary const& eventAuxiliary() const override {return aux_;}
@@ -274,8 +274,8 @@ namespace edm {
     friend class ProducerBase;
     template<typename T> friend class stream::ProducingModuleAdaptorBase;
 
-    void commit_(std::vector<edm::ProductResolverIndex> const& iShouldPut, std::vector<BranchID>* previousParentage= nullptr, ParentageID* previousParentageId = nullptr);
-    void commit_aux(ProductPtrVec& products, std::vector<BranchID>* previousParentage = nullptr, ParentageID* previousParentageId = nullptr);
+    void commit_(std::vector<edm::ProductResolverIndex> const& iShouldPut, ParentageID* previousParentageId = nullptr);
+    void commit_aux(ProductPtrVec& products, ParentageID* previousParentageId = nullptr);
 
     BasicHandle
     getByProductID_(ProductID const& oid) const;
@@ -297,8 +297,11 @@ namespace edm {
     // which do not logically modify the PrincipalGetAdapter. gotBranchIDs_ is
     // merely a cache reflecting what has been retrieved from the
     // Principal class.
-    typedef std::set<BranchID> BranchIDSet;
+    typedef std::unordered_set<BranchID::value_type> BranchIDSet;
     mutable BranchIDSet gotBranchIDs_;
+    mutable std::vector<bool> gotBranchIDsFromPrevious_;
+    std::vector<BranchID>* previousBranchIDs_ = nullptr;
+    
     void addToGotBranchIDs(Provenance const& prov) const;
 
     // We own the retrieved Views, and have to destroy them.

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -407,6 +407,10 @@ namespace edm {
     if(unlikely(token.isUninitialized())) {
       principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
     }
+    if(unlikely(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
+      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD), provRecorder_.getTypeIDForPutTokenIndex(token.index()));
+    }
+
     return putImpl(token.index(),std::move(product));
   }
 

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -153,6 +153,10 @@ namespace edm {
         std::unique_ptr<WrapperBase> edp,
         ProductProvenance const& productProvenance) const;
 
+    void put(ProductResolverIndex index,
+             std::unique_ptr<WrapperBase> edp,
+             ParentageID productProvenance) const;
+
     void putOnRead(
         BranchDescription const& bd,
         std::unique_ptr<WrapperBase> edp,

--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -215,16 +215,16 @@ namespace edm {
     void doEndJob();
 
     /// Called by framework at beginning of lumi block
-    void doBeginLumi(LuminosityBlockPrincipal& lbp, ProcessContext const*);
+    virtual void doBeginLumi(LuminosityBlockPrincipal& lbp, ProcessContext const*);
 
     /// Called by framework at end of lumi block
-    void doEndLumi(LuminosityBlockPrincipal& lbp, bool cleaningUpAfterException, ProcessContext const*);
+    virtual void doEndLumi(LuminosityBlockPrincipal& lbp, bool cleaningUpAfterException, ProcessContext const*);
 
     /// Called by framework at beginning of run
-    void doBeginRun(RunPrincipal& rp, ProcessContext const*);
+    virtual void doBeginRun(RunPrincipal& rp, ProcessContext const*);
 
     /// Called by framework at end of run
-    void doEndRun(RunPrincipal& rp, bool cleaningUpAfterException, ProcessContext const*);
+    virtual void doEndRun(RunPrincipal& rp, bool cleaningUpAfterException, ProcessContext const*);
 
     /// Accessor for the current time, as seen by the input source
     Timestamp const& timestamp() const {return time_;}
@@ -400,10 +400,6 @@ namespace edm {
     virtual void setRun(RunNumber_t r);
     virtual void setLumi(LuminosityBlockNumber_t lb);
     virtual void rewind_();
-    virtual void beginLuminosityBlock(LuminosityBlock&);
-    virtual void endLuminosityBlock(LuminosityBlock&);
-    virtual void beginRun(Run&);
-    virtual void endRun(Run&);
     virtual void beginJob();
     virtual void endJob();
     virtual std::pair<SharedResourcesAcquirer*,std::recursive_mutex*> resourceSharedWithDelayedReader_();

--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -47,7 +47,6 @@ Some examples of InputSource subclasses may be:
 #include "DataFormats/Provenance/interface/Timestamp.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/ProcessingController.h"
-#include "FWCore/Framework/interface/ProductRegistryHelper.h"
 
 #include "FWCore/Utilities/interface/Signal.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
@@ -72,7 +71,7 @@ namespace edm {
   class SharedResourcesAcquirer;
   class ThinnedAssociationsHelper;
 
-  class InputSource : private ProductRegistryHelper {
+  class InputSource {
   public:
     enum ItemType {
       IsInvalid,
@@ -91,7 +90,6 @@ namespace edm {
       RunsLumisAndEvents
     };
 
-    typedef ProductRegistryHelper::TypeLabelList TypeLabelList;
     /// Constructor
     explicit InputSource(ParameterSet const&, InputSourceDescription const&);
 
@@ -158,7 +156,7 @@ namespace edm {
     void issueReports(EventID const& eventID);
 
     /// Register any produced products
-    void registerProducts();
+    virtual void registerProducts();
 
     /// Accessors for product registry
     std::shared_ptr<ProductRegistry const> productRegistry() const {return get_underlying_safe(productRegistry_);}
@@ -257,9 +255,6 @@ namespace edm {
     bool randomAccess() const;
     ProcessingController::ForwardState forwardState() const;
     ProcessingController::ReverseState reverseState() const;
-
-    using ProductRegistryHelper::produces;
-    using ProductRegistryHelper::typeLabelList;
 
     class SourceSentry {
     public:

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -146,7 +146,11 @@ namespace edm {
     // Override version from LuminosityBlockBase class
     BasicHandle getByLabelImpl(std::type_info const& iWrapperType, std::type_info const& iProductType, InputTag const& iTag) const override;
 
-    typedef std::vector<std::pair<edm::propagate_const<std::unique_ptr<WrapperBase>>, BranchDescription const*>> ProductPtrVec;
+    template<typename PROD>
+    void
+    putImpl(EDPutToken::value_type token, std::unique_ptr<PROD> product);
+
+    typedef std::vector<edm::propagate_const<std::unique_ptr<WrapperBase>>> ProductPtrVec;
     ProductPtrVec& putProducts() {return putProducts_;}
     ProductPtrVec const& putProducts() const {return putProducts_;}
 
@@ -154,7 +158,6 @@ namespace edm {
     // this PrincipalGetAdapter. The friendships required seems gross, but any
     // alternative is not great either.  Putting it into the
     // public interface is asking for trouble
-    friend class InputSource;
     friend class RawInputSource;
     friend class ProducerBase;
     template<typename T> friend class stream::ProducingModuleAdaptorBase;
@@ -173,39 +176,60 @@ namespace edm {
 
   template <typename PROD>
   void
-  LuminosityBlock::put(std::unique_ptr<PROD> product, std::string const& productInstanceName) {
-    if(product.get() == nullptr) {                // null pointer is illegal
-      TypeID typeID(typeid(PROD));
-      principal_get_adapter_detail::throwOnPutOfNullProduct("LuminosityBlock", typeID, productInstanceName);
-    }
-
+  LuminosityBlock::putImpl(EDPutToken::value_type index,std::unique_ptr<PROD> product) {
     // The following will call post_insert if T has such a function,
     // and do nothing if T has no such function.
     std::conditional_t<detail::has_postinsert<PROD>::value,
-                       DoPostInsert<PROD>,
-                       DoNotPostInsert<PROD>> maybe_inserter;
+    DoPostInsert<PROD>,
+    DoNotPostInsert<PROD>> maybe_inserter;
     maybe_inserter(product.get());
-
-    BranchDescription const& desc =
-      provRecorder_.getBranchDescription(TypeID(*product), productInstanceName);
-
+    
+    assert(index < putProducts().size());
+    
     std::unique_ptr<Wrapper<PROD> > wp(new Wrapper<PROD>(std::move(product)));
-    putProducts().emplace_back(std::move(wp), &desc);
+    putProducts()[index]=std::move(wp);
+  }
 
-    // product.release(); // The object has been copied into the Wrapper.
-    // The old copy must be deleted, so we cannot release ownership.
+  template <typename PROD>
+  void
+  LuminosityBlock::put(std::unique_ptr<PROD> product, std::string const& productInstanceName) {
+    if(unlikely(product.get() == nullptr)) {                // null pointer is illegal
+      TypeID typeID(typeid(PROD));
+      principal_get_adapter_detail::throwOnPutOfNullProduct("LuminosityBlock", typeID, productInstanceName);
+    }
+    auto index =
+    provRecorder_.getPutTokenIndex(TypeID(*product), productInstanceName);
+    putImpl(index, std::move(product));
   }
 
   template<typename PROD>
   void
   LuminosityBlock::put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product) {
-    put(std::move(product), provRecorder_.productInstanceLabel(token));
+    if(unlikely(product.get() == 0)) {                // null pointer is illegal
+      TypeID typeID(typeid(PROD));
+      principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, provRecorder_.productInstanceLabel(token));
+    }
+    if(unlikely(token.isUninitialized())) {
+      principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
+    }
+    putImpl(token.index(),std::move(product));
   }
   
   template<typename PROD>
   void
   LuminosityBlock::put(EDPutToken token, std::unique_ptr<PROD> product) {
-    put(std::move(product), provRecorder_.productInstanceLabel(token));
+    if(unlikely(product.get() == 0)) {                // null pointer is illegal
+      TypeID typeID(typeid(PROD));
+      principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, provRecorder_.productInstanceLabel(token));
+    }
+    if(unlikely(token.isUninitialized())) {
+      principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
+    }
+    if(unlikely(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
+      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD), provRecorder_.getTypeIDForPutTokenIndex(token.index()));
+    }
+    
+    putImpl(token.index(),std::move(product));
   }
 
   template<typename PROD>

--- a/FWCore/Framework/interface/LuminosityBlockPrincipal.h
+++ b/FWCore/Framework/interface/LuminosityBlockPrincipal.h
@@ -98,6 +98,8 @@ namespace edm {
         BranchDescription const& bd,
         std::unique_ptr<WrapperBase> edp) const;
 
+    void put(ProductResolverIndex index,
+             std::unique_ptr<WrapperBase> edp) const;
 
     void setComplete() {
       complete_ = true;

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -121,6 +121,8 @@ namespace edm {
     void
     throwOnPutOfUninitializedToken(char const* principalType, std::type_info const& productType);
     void
+    throwOnPutOfWrongType(std::type_info const& wrongType, TypeID const& rightType);
+    void
     throwOnPrematureRead(char const* principalType, TypeID const& productType, std::string const& moduleLabel, std::string const& productInstanceName);
     void
     throwOnPrematureRead(char const* principalType, TypeID const& productType);
@@ -178,6 +180,7 @@ namespace edm {
     EDPutToken::value_type
     getPutTokenIndex(TypeID const& type, std::string const& productInstanceName) const;
 
+    TypeID const& getTypeIDForPutTokenIndex(EDPutToken::value_type index) const;
     std::string const& productInstanceLabel(EDPutToken) const;
     typedef std::vector<BasicHandle>  BasicHandleVec;
 

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -179,6 +179,7 @@ namespace edm {
 
     BranchDescription const&
     getBranchDescription(unsigned int iPutTokenIndex) const;
+    ProductID const& getProductID(unsigned int iPutTokenIndex) const;
     
     std::vector<edm::ProductResolverIndex> const&
     putTokenIndexToProductResolverIndex() const ;

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -151,6 +151,8 @@ namespace edm {
       prodBase_ = iProd;
     }
 
+    size_t numberOfProductsConsumed() const ;
+    
     bool isComplete() const;
 
     template <typename PROD>

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -106,6 +106,7 @@ edm::Ref<AppleCollection> ref(refApples, index);
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/ProductLabels.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/Transition.h"
 
 
 namespace edm {
@@ -155,6 +156,8 @@ namespace edm {
     template <typename PROD>
     bool 
     checkIfComplete() const;
+    
+    Transition transition() const;
 
     template <typename PROD>
     void 
@@ -168,9 +171,20 @@ namespace edm {
     BranchDescription const&
     getBranchDescription(TypeID const& type, std::string const& productInstanceName) const;
 
+    unsigned int
+    getPutTokenIndex(TypeID const& type, std::string const& productInstanceName) const;
+
     std::string const& productInstanceLabel(EDPutToken) const;
     typedef std::vector<BasicHandle>  BasicHandleVec;
 
+    BranchDescription const&
+    getBranchDescription(unsigned int iPutTokenIndex) const;
+    
+    std::vector<edm::ProductResolverIndex> const&
+    putTokenIndexToProductResolverIndex() const ;
+    
+    //uses the EDPutToken index
+    std::vector<bool> const& recordProvenanceList() const;
     //------------------------------------------------------------
     // Protected functions.
     //
@@ -282,16 +296,6 @@ namespace edm {
     struct has_postinsert {
       static constexpr bool value = std::is_same<decltype(has_postinsert_helper<T>(nullptr)), yes_tag>::value &&
 	!std::is_base_of<DoNotSortUponInsertion, T>::value;
-    };
-
-
-    // has_donotrecordparents<T>::value is true if we should not
-    // record parentage for type T, and false otherwise.
-
-    template <typename T>
-    struct has_donotrecordparents {
-      static constexpr bool value =
-	std::is_base_of<DoNotRecordParents,T>::value;
     };
 
   }

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -119,6 +119,8 @@ namespace edm {
     void
     throwOnPutOfNullProduct(char const* principalType, TypeID const& productType, std::string const& productInstanceName);
     void
+    throwOnPutOfUninitializedToken(char const* principalType, std::type_info const& productType);
+    void
     throwOnPrematureRead(char const* principalType, TypeID const& productType, std::string const& moduleLabel, std::string const& productInstanceName);
     void
     throwOnPrematureRead(char const* principalType, TypeID const& productType);
@@ -243,6 +245,9 @@ namespace edm {
     void
     throwAmbiguousException(TypeID const& productType, EDGetToken token) const;
 
+    void
+    throwUnregisteredPutException(TypeID const& type,
+                                  std::string const& productInstanceLabel) const;
   private:
     //------------------------------------------------------------
     // Data members

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -175,7 +175,7 @@ namespace edm {
     BranchDescription const&
     getBranchDescription(TypeID const& type, std::string const& productInstanceName) const;
 
-    unsigned int
+    EDPutToken::value_type
     getPutTokenIndex(TypeID const& type, std::string const& productInstanceName) const;
 
     std::string const& productInstanceLabel(EDPutToken) const;

--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -71,6 +71,7 @@ namespace edm {
 
     using ProductRegistryHelper::produces;
     using ProductRegistryHelper::typeLabelList;
+    using ProductRegistryHelper::recordProvenanceList;
 
     void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func) {
        callWhenNewProductsRegistered_ = func;

--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -100,6 +100,7 @@ namespace edm {
     friend class global::EDFilterBase;
     friend class limited::EDProducerBase;
     friend class limited::EDFilterBase;
+    friend class ProducerSourceBase;
     template<typename T> friend class stream::ProducingModuleAdaptorBase;
     
     template< typename P>

--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -100,7 +100,7 @@ namespace edm {
     friend class global::EDFilterBase;
     friend class limited::EDProducerBase;
     friend class limited::EDFilterBase;
-    friend class ProducerSourceBase;
+    friend class PuttableSourceBase;
     template<typename T> friend class stream::ProducingModuleAdaptorBase;
     
     template< typename P>

--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -77,12 +77,19 @@ namespace edm {
        callWhenNewProductsRegistered_ = func;
     }
     
+    using ModuleToResolverIndicies = std::unordered_multimap<std::string,
+    std::tuple<edm::TypeID const*, const char*, edm::ProductResolverIndex>>;
     void resolvePutIndicies(BranchType iBranchType,
-                            std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies,
+                            ModuleToResolverIndicies const& iIndicies,
                             std::string const& moduleLabel);
     
     std::vector<edm::ProductResolverIndex> const& indiciesForPutProducts(BranchType iBranchType) const {
       return putIndicies_[iBranchType];
+    }
+    
+    std::vector<edm::ProductResolverIndex> const&
+    putTokenIndexToProductResolverIndex() const {
+      return putTokenToResolverIndex_;
     }
   private:
     friend class EDProducer;
@@ -107,6 +114,7 @@ namespace edm {
 
     std::function<void(BranchDescription const&)> callWhenNewProductsRegistered_;
     std::array<std::vector<edm::ProductResolverIndex>, edm::NumBranchTypes> putIndicies_;
+    std::vector<edm::ProductResolverIndex> putTokenToResolverIndex_;
   };
 }
 #endif

--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -107,9 +107,9 @@ namespace edm {
       iPrincipal.commit_(putIndicies_[producerbasehelper::PrincipalTraits<P>::kBranchType]);
     }
 
-    template< typename P, typename L, typename I>
-    void commit_(P& iPrincipal, L* iList, I* iID) {
-      iPrincipal.commit_(putIndicies_[producerbasehelper::PrincipalTraits<P>::kBranchType], iList,iID);
+    template< typename P, typename I>
+    void commit_(P& iPrincipal, I* iID) {
+      iPrincipal.commit_(putIndicies_[producerbasehelper::PrincipalTraits<P>::kBranchType], iID);
     }
 
     std::function<void(BranchDescription const&)> callWhenNewProductsRegistered_;

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -55,9 +55,7 @@ namespace edm {
       provRecorder_.setSharedResourcesAcquirer(iResourceAcquirer);
     }
 
-    void setProducer(ProducerBase const* iProducer) {
-      provRecorder_.setProducer(iProducer);
-    }
+    void setProducer(ProducerBase const* iProducer);
 
     typedef PrincipalGetAdapter Base;
     // AUX functions are defined in RunBase
@@ -160,7 +158,11 @@ namespace edm {
     // Override version from RunBase class
     BasicHandle getByLabelImpl(std::type_info const& iWrapperType, std::type_info const& iProductType, InputTag const& iTag) const override;
 
-    typedef std::vector<std::pair<edm::propagate_const<std::unique_ptr<WrapperBase>>, BranchDescription const*>> ProductPtrVec;
+    template<typename PROD>
+    void
+    putImpl(EDPutToken::value_type token, std::unique_ptr<PROD> product);
+    
+    typedef std::vector<edm::propagate_const<std::unique_ptr<WrapperBase>>> ProductPtrVec;
     ProductPtrVec& putProducts() {return putProducts_;}
     ProductPtrVec const& putProducts() const {return putProducts_;}
 
@@ -168,7 +170,6 @@ namespace edm {
     // this PrincipalGetAdapter. The friendships required seems gross, but any
     // alternative is not great either.  Putting it into the
     // public interface is asking for trouble
-    friend class InputSource;
     friend class RawInputSource;
     friend class ProducerBase;
     template<typename T> friend class stream::ProducingModuleAdaptorBase;
@@ -186,39 +187,60 @@ namespace edm {
 
   template <typename PROD>
   void
-  Run::put(std::unique_ptr<PROD> product, std::string const& productInstanceName) {
-    if (product.get() == 0) {                // null pointer is illegal
-      TypeID typeID(typeid(PROD));
-      principal_get_adapter_detail::throwOnPutOfNullProduct("Run", typeID, productInstanceName);
-    }
-
+  Run::putImpl(EDPutToken::value_type index,std::unique_ptr<PROD> product) {
     // The following will call post_insert if T has such a function,
     // and do nothing if T has no such function.
     std::conditional_t<detail::has_postinsert<PROD>::value,
-                       DoPostInsert<PROD>,
-                       DoNotPostInsert<PROD>> maybe_inserter;
+    DoPostInsert<PROD>,
+    DoNotPostInsert<PROD>> maybe_inserter;
     maybe_inserter(product.get());
-
-    BranchDescription const& desc =
-      provRecorder_.getBranchDescription(TypeID(*product), productInstanceName);
-
+    
+    assert(index < putProducts().size());
+    
     std::unique_ptr<Wrapper<PROD> > wp(new Wrapper<PROD>(std::move(product)));
-    putProducts().emplace_back(std::move(wp), &desc);
-
-    // product.release(); // The object has been copied into the Wrapper.
-    // The old copy must be deleted, so we cannot release ownership.
+    putProducts()[index]=std::move(wp);
   }
-
+  
+  template <typename PROD>
+  void
+  Run::put(std::unique_ptr<PROD> product, std::string const& productInstanceName) {
+    if(unlikely(product.get() == nullptr)) {                // null pointer is illegal
+      TypeID typeID(typeid(PROD));
+      principal_get_adapter_detail::throwOnPutOfNullProduct("LuminosityBlock", typeID, productInstanceName);
+    }
+    auto index =
+    provRecorder_.getPutTokenIndex(TypeID(*product), productInstanceName);
+    putImpl(index, std::move(product));
+  }
+  
   template<typename PROD>
   void
   Run::put(EDPutTokenT<PROD> token, std::unique_ptr<PROD> product) {
-    put(std::move(product), provRecorder_.productInstanceLabel(token));
+    if(unlikely(product.get() == 0)) {                // null pointer is illegal
+      TypeID typeID(typeid(PROD));
+      principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, provRecorder_.productInstanceLabel(token));
+    }
+    if(unlikely(token.isUninitialized())) {
+      principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
+    }
+    putImpl(token.index(),std::move(product));
   }
   
   template<typename PROD>
   void
   Run::put(EDPutToken token, std::unique_ptr<PROD> product) {
-    put(std::move(product), provRecorder_.productInstanceLabel(token));
+    if(unlikely(product.get() == 0)) {                // null pointer is illegal
+      TypeID typeID(typeid(PROD));
+      principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, provRecorder_.productInstanceLabel(token));
+    }
+    if(unlikely(token.isUninitialized())) {
+      principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeid(PROD));
+    }
+    if(unlikely(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID{typeid(PROD)})) {
+      principal_get_adapter_detail::throwOnPutOfWrongType(typeid(PROD), provRecorder_.getTypeIDForPutTokenIndex(token.index()));
+    }
+    
+    putImpl(token.index(),std::move(product));
   }
 
   template <typename PROD>

--- a/FWCore/Framework/interface/RunPrincipal.h
+++ b/FWCore/Framework/interface/RunPrincipal.h
@@ -90,6 +90,9 @@ namespace edm {
         BranchDescription const& bd,
         std::unique_ptr<WrapperBase> edp) const;
 
+    void put(ProductResolverIndex index,
+             std::unique_ptr<WrapperBase> edp) const;
+
     void setComplete() {
       complete_ = true;
     }

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -116,9 +116,9 @@ namespace edm {
       void commit(LuminosityBlock& iLumi) {
         iLumi.commit_(m_streamModules[0]->indiciesForPutProducts(InLumi));
       }
-      template<typename L, typename I>
-      void commit(Event& iEvent, L* iList, I* iID) {
-        iEvent.commit_(m_streamModules[0]->indiciesForPutProducts(InEvent), iList,iID);
+      template<typename I>
+      void commit(Event& iEvent, I* iID) {
+        iEvent.commit_(m_streamModules[0]->indiciesForPutProducts(InEvent), iID);
       }
 
       const EDConsumerBase* consumer() {

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -93,8 +93,11 @@ namespace edm {
 
       std::vector<ConsumesInfo> consumesInfo() const;
 
+      using ModuleToResolverIndicies = std::unordered_multimap<std::string,
+      std::tuple<edm::TypeID const*, const char*, edm::ProductResolverIndex>>;
+      
       void resolvePutIndicies(BranchType iBranchType,
-                              std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies,
+                              ModuleToResolverIndicies const& iIndicies,
                               std::string const& moduleLabel);
       
       std::vector<edm::ProductResolverIndex> const& indiciesForPutProducts(BranchType iBranchType) const;

--- a/FWCore/Framework/src/EDFilter.cc
+++ b/FWCore/Framework/src/EDFilter.cc
@@ -33,11 +33,11 @@ namespace edm {
     bool rc = false;
     Event e(ep, moduleDescription_, mcc);
     e.setConsumer(this);
-    e.setProducer(this);
+    e.setProducer(this,&previousParentage_);
     e.setSharedResourcesAcquirer(&resourceAcquirer_);
     EventSignalsSentry sentry(act,mcc);
     rc = this->filter(e, c);
-    commit_(e,&previousParentage_, &previousParentageId_);
+    commit_(e, &previousParentageId_);
     return rc;
   }
 

--- a/FWCore/Framework/src/EDProducer.cc
+++ b/FWCore/Framework/src/EDProducer.cc
@@ -33,11 +33,11 @@ namespace edm {
                       ModuleCallingContext const* mcc) {
     Event e(ep, moduleDescription_, mcc);
     e.setConsumer(this);
-    e.setProducer(this);
+    e.setProducer(this, &previousParentage_);
     e.setSharedResourcesAcquirer(&resourceAcquirer_);
     EventSignalsSentry sentry(act,mcc);
     this->produce(e, c);
-    commit_(e, &previousParentage_, &previousParentageId_);
+    commit_(e, &previousParentageId_);
     return true;
   }
 

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -173,6 +173,26 @@ namespace edm {
   }
 
   void
+  EventPrincipal::put(
+             ProductResolverIndex index,
+             std::unique_ptr<WrapperBase> edp,
+             ParentageID parentage) const {
+    if(edp.get() == nullptr) {
+      throw Exception(errors::InsertFailure, "Null Pointer")
+      << "put: Cannot put because ptr to product is null."
+      << "\n";
+    }
+    auto phb = getProductResolverByIndex(index);
+    
+    productProvenanceRetrieverPtr()->insertIntoSet(ProductProvenance(phb->branchDescription().branchID(), std::move(parentage)));
+
+    assert(phb);
+    // ProductResolver assumes ownership
+    phb->putProduct(std::move(edp));
+
+  }
+
+  void
   EventPrincipal::putOnRead(
         BranchDescription const& bd,
         std::unique_ptr<WrapperBase> edp,

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1004,6 +1004,11 @@ namespace edm {
 
   void EventProcessor::endRun(ProcessHistoryID const& phid, RunNumber_t run, bool cleaningUpAfterException) {
     RunPrincipal& runPrincipal = principalCache_.runPrincipal(phid, run);
+    runPrincipal.setAtEndTransition(true);
+    //We need to reset failed items since they might
+    // be set this time around
+    runPrincipal.resetFailedFromThisProcess();
+
     {
       SendSourceTerminationSignalIfException sentry(actReg_.get());
 
@@ -1050,7 +1055,6 @@ namespace edm {
       auto globalWaitTask = make_empty_waiting_task();
       globalWaitTask->increment_ref_count();
 
-      runPrincipal.setAtEndTransition(true);
       typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> Traits;
       endGlobalTransitionAsync<Traits>(WaitingTaskHolder(globalWaitTask.get()),
                                        *schedule_,
@@ -1141,6 +1145,11 @@ namespace edm {
 
   void EventProcessor::endLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi, bool cleaningUpAfterException) {
     LuminosityBlockPrincipal& lumiPrincipal = principalCache_.lumiPrincipal(phid, run, lumi);
+    lumiPrincipal.setAtEndTransition(true);
+    //We need to reset failed items since they might
+    // be set this time around
+    lumiPrincipal.resetFailedFromThisProcess();
+
     {
       SendSourceTerminationSignalIfException sentry(actReg_.get());
 
@@ -1187,7 +1196,6 @@ namespace edm {
       auto globalWaitTask = make_empty_waiting_task();
       globalWaitTask->increment_ref_count();
       
-      lumiPrincipal.setAtEndTransition(true);
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> Traits;
       endGlobalTransitionAsync<Traits>(WaitingTaskHolder(globalWaitTask.get()),
                                        *schedule_,

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -44,7 +44,6 @@ namespace edm {
   }
 
   InputSource::InputSource(ParameterSet const& pset, InputSourceDescription const& desc) :
-      ProductRegistryHelper(),
       actReg_(desc.actReg_),
       maxEvents_(desc.maxEvents_),
       remainingEvents_(maxEvents_),
@@ -235,9 +234,6 @@ namespace edm {
 
   void
   InputSource::registerProducts() {
-    if(!typeLabelList().empty()) {
-      addToRegistry(typeLabelList().begin(), typeLabelList().end(), moduleDescription(), productRegistryUpdate());
-    }
   }
 
   // Return a dummy file block.

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -9,9 +9,7 @@
 #include "FWCore/Framework/interface/ExceptionHelpers.h"
 #include "FWCore/Framework/interface/FileBlock.h"
 #include "FWCore/Framework/interface/InputSourceDescription.h"
-#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
-#include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -443,30 +441,18 @@ namespace edm {
 
   void
   InputSource::doBeginRun(RunPrincipal& rp, ProcessContext const* ) {
-    Run run(rp, moduleDescription(), nullptr);
-    callWithTryCatchAndPrint<void>( [this,&run](){ beginRun(run); }, "Calling InputSource::beginRun" );
-    run.commit_(std::vector<edm::ProductResolverIndex>());
   }
 
   void
   InputSource::doEndRun(RunPrincipal& rp, bool cleaningUpAfterException, ProcessContext const* ) {
-    Run run(rp, moduleDescription(), nullptr);
-    callWithTryCatchAndPrint<void>( [this,&run](){ endRun(run); }, "Calling InputSource::endRun", cleaningUpAfterException );
-    run.commit_(std::vector<edm::ProductResolverIndex>());
   }
 
   void
   InputSource::doBeginLumi(LuminosityBlockPrincipal& lbp, ProcessContext const* ) {
-    LuminosityBlock lb(lbp, moduleDescription(), nullptr);
-    callWithTryCatchAndPrint<void>( [this,&lb](){ beginLuminosityBlock(lb); }, "Calling InputSource::beginLuminosityBlock" );
-    lb.commit_(std::vector<edm::ProductResolverIndex>());
   }
 
   void
   InputSource::doEndLumi(LuminosityBlockPrincipal& lbp, bool cleaningUpAfterException, ProcessContext const* ) {
-    LuminosityBlock lb(lbp, moduleDescription(), nullptr);
-    callWithTryCatchAndPrint<void>( [this,&lb](){ endLuminosityBlock(lb); }, "Calling InputSource::endLuminosityBlock", cleaningUpAfterException );
-    lb.commit_(std::vector<edm::ProductResolverIndex>());
   }
 
   bool
@@ -486,18 +472,6 @@ namespace edm {
     return callWithTryCatchAndPrint<ProcessingController::ReverseState>( [this](){ return reverseState_(); },
                                                                          "Calling InputSource::reverseState__" );
   }
-
-  void
-  InputSource::beginLuminosityBlock(LuminosityBlock&) {}
-
-  void
-  InputSource::endLuminosityBlock(LuminosityBlock&) {}
-
-  void
-  InputSource::beginRun(Run&) {}
-
-  void
-  InputSource::endRun(Run&) {}
 
   void
   InputSource::beginJob() {}

--- a/FWCore/Framework/src/LuminosityBlock.cc
+++ b/FWCore/Framework/src/LuminosityBlock.cc
@@ -46,6 +46,9 @@ namespace edm {
   void
   LuminosityBlock::setProducer(ProducerBase const* iProducer) {
     provRecorder_.setProducer(iProducer);
+    //set appropriate size
+    putProducts_.resize(
+            provRecorder_.putTokenIndexToProductResolverIndex().size());
   }
 
 
@@ -67,16 +70,17 @@ namespace edm {
   void
   LuminosityBlock::commit_(std::vector<edm::ProductResolverIndex> const& iShouldPut) {
     LuminosityBlockPrincipal const& lbp = luminosityBlockPrincipal();
-    ProductPtrVec::iterator pit(putProducts().begin());
-    ProductPtrVec::iterator pie(putProducts().end());
-
-    while(pit != pie) {
-        lbp.put(*pit->second, std::move(get_underlying_safe(pit->first)));
-        ++pit;
+    size_t nPut = 0;
+    for(size_t i = 0; i < putProducts().size();++i) {
+      auto& p = get_underlying_safe(putProducts()[i]);
+      if(p) {
+        lbp.put(provRecorder_.putTokenIndexToProductResolverIndex()[i],  std::move(p));
+        ++nPut;
+      }
     }
     
     auto sz = iShouldPut.size();
-    if(sz !=0 and sz != putProducts().size()) {
+    if(sz !=0 and sz != nPut) {
       //some were missed
       auto& p = provRecorder_.principal();
       for(auto index: iShouldPut){

--- a/FWCore/Framework/src/LuminosityBlockPrincipal.cc
+++ b/FWCore/Framework/src/LuminosityBlockPrincipal.cc
@@ -39,6 +39,13 @@ namespace edm {
     putOrMerge(bd,std::move(edp));
   }
 
+  void
+  LuminosityBlockPrincipal::put(ProductResolverIndex index,
+                                std::unique_ptr<WrapperBase> edp) const {
+    auto phb = getProductResolverByIndex(index);
+    phb->putOrMergeProduct(std::move(edp));
+  }
+
   unsigned int
   LuminosityBlockPrincipal::transitionIndex_() const {
     return index().value();

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -54,7 +54,19 @@ namespace edm {
     << "::put: An uninitialized EDPutToken was passed to 'put'.\n"
     << "The pointer is of type "
     << productType
-    << "'.\n";
+    << ".\n";
+  }
+
+  void
+  principal_get_adapter_detail::throwOnPutOfWrongType(std::type_info const& wrongType, TypeID const& rightType) {
+    TypeID wrongTypeID{wrongType};
+    throw Exception(errors::LogicError)
+    << "The registered type for an EDPutToken does not match the put type.\n"
+    << "The expected type "
+    << rightType
+    << "\nThe put type "
+    << wrongTypeID
+    << ".\n";
   }
 
   void
@@ -331,6 +343,12 @@ namespace edm {
   PrincipalGetAdapter::productInstanceLabel(EDPutToken iToken) const {
     return prodBase_->typeLabelList()[iToken.index()].productInstanceName_;
   }
+  
+  TypeID const&
+  PrincipalGetAdapter::getTypeIDForPutTokenIndex(EDPutToken::value_type index) const {
+    return prodBase_->typeLabelList()[index].typeID_;
+  }
+
 
   std::vector<edm::ProductResolverIndex> const&
   PrincipalGetAdapter::putTokenIndexToProductResolverIndex() const {

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -259,7 +259,17 @@ namespace edm {
     assert(phb != nullptr);
     return phb->branchDescription();
   }
-  
+
+  ProductID const&
+  PrincipalGetAdapter::getProductID(unsigned int iPutTokenIndex) const {
+    auto index = prodBase_->putTokenIndexToProductResolverIndex()[iPutTokenIndex];
+    ProductResolverBase const*  phb = principal_.getProductResolverByIndex(index);
+    assert(phb != nullptr);
+    auto prov = phb->stableProvenance();
+    assert(prov != nullptr);
+    return prov->productID();
+  }
+
   Transition
   PrincipalGetAdapter::transition() const {
     if(likely(principal().branchType() == InEvent)) {

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -311,7 +311,7 @@ namespace edm {
     //Must be lumi
   }
 
-  unsigned int
+  EDPutToken::value_type
   PrincipalGetAdapter::getPutTokenIndex(TypeID const& type, std::string const& productInstanceName) const {
     auto tran = transition();
     size_t index = 0;

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -98,6 +98,11 @@ namespace edm {
     << "The index of the token was "<<token.index()<<".\n";
   }
   
+  size_t
+  PrincipalGetAdapter::numberOfProductsConsumed() const {
+    return consumer_->itemsToGetFrom(InEvent).size();
+  }
+
   void
   PrincipalGetAdapter::labelsForToken(EDGetToken const& iToken, ProductLabels& oLabels) const {
     consumer_->labelsForToken(iToken,oLabels);

--- a/FWCore/Framework/src/ProducerBase.cc
+++ b/FWCore/Framework/src/ProducerBase.cc
@@ -83,12 +83,26 @@ namespace edm {
   }
   
   void ProducerBase::resolvePutIndicies(BranchType iBranchType,
-                          std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies,
+                          ModuleToResolverIndicies const& iIndicies,
                           std::string const& moduleLabel) {
+    auto const& plist = typeLabelList();
+    if(putTokenToResolverIndex_.size() != plist.size()) {
+      putTokenToResolverIndex_.resize(plist.size(),std::numeric_limits<unsigned int>::max());
+    }
     auto range = iIndicies.equal_range(moduleLabel);
     putIndicies_[iBranchType].reserve(iIndicies.count(moduleLabel));
     for(auto it = range.first; it != range.second;++it) {
-      putIndicies_[iBranchType].push_back(it->second);
+      putIndicies_[iBranchType].push_back(std::get<2>(it->second));
+      unsigned int i = 0;
+      for(auto const& tl: plist) {
+        if(convertToBranchType(tl.transition_) == iBranchType and
+           (tl.typeID_ == *std::get<0>(it->second)) and
+           (tl.productInstanceName_ == std::get<1>(it->second)) ) {
+          putTokenToResolverIndex_[i] = std::get<2>(it->second);
+          break;
+        }
+        ++i;
+      }
     }
   }
 }

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -463,7 +463,7 @@ namespace edm {
   DataManagingProductResolver::checkType(WrapperBase const& prod) const {
     // Check if the types match.
     TypeID typeID(prod.dynamicTypeInfo());
-    if(typeID != branchDescription().unwrappedTypeID()) {
+    if(typeID !=TypeID{branchDescription().unwrappedType().unvalidatedTypeInfo()}) {
       // Types do not match.
       throw Exception(errors::EventCorruption)
       << "Product on branch " << branchDescription().branchName() << " is of wrong type.\n"

--- a/FWCore/Framework/src/RunPrincipal.cc
+++ b/FWCore/Framework/src/RunPrincipal.cc
@@ -35,6 +35,13 @@ namespace edm {
     putOrMerge(bd,std::move(edp));
   }
 
+  void
+  RunPrincipal::put(ProductResolverIndex index,
+                    std::unique_ptr<WrapperBase> edp) const {
+    auto phb = getProductResolverByIndex(index);
+    phb->putOrMergeProduct(std::move(edp));
+  }
+  
   unsigned int
   RunPrincipal::transitionIndex_() const {
     return index().value();

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -642,7 +642,7 @@ namespace edm {
     ParameterSet const& maxEventsPSet = proc_pset.getUntrackedParameterSet("maxEvents", ParameterSet());
     int maxEventSpecs = 0;
     int maxEventsOut = -1;
-    ParameterSet const* vMaxEventsOut = 0;
+    ParameterSet const* vMaxEventsOut = nullptr;
     std::vector<std::string> intNamesE = maxEventsPSet.getParameterNamesForType<int>(false);
     if (search_all(intNamesE, output)) {
       maxEventsOut = maxEventsPSet.getUntrackedParameter<int>(output);
@@ -662,7 +662,7 @@ namespace edm {
 
     for (auto& c : all_output_communicators_) {
       OutputModuleDescription desc(branchIDLists, maxEventsOut, subProcessParentageHelper);
-      if (vMaxEventsOut != 0 && !vMaxEventsOut->empty()) {
+      if (vMaxEventsOut != nullptr && !vMaxEventsOut->empty()) {
         std::string const& moduleLabel = c->description().moduleLabel();
         try {
           desc.maxEvents_ = vMaxEventsOut->getUntrackedParameter<int>(moduleLabel);

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -5,6 +5,7 @@
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
+#include "DataFormats/Provenance/interface/ProductResolverIndexHelper.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Framework/interface/OutputModuleDescription.h"
 #include "FWCore/Framework/interface/SubProcess.h"
@@ -1068,6 +1069,16 @@ namespace edm {
       found->updateLookup(InRun,*runLookup);
       found->updateLookup(InLumi,*lumiLookup);
       found->updateLookup(InEvent,*eventLookup);
+      
+      auto const& processName = newMod->moduleDescription().processName();
+      auto const& runModuleToIndicies = runLookup->indiciesForModulesInProcess(processName);
+      auto const& lumiModuleToIndicies = lumiLookup->indiciesForModulesInProcess(processName);
+      auto const& eventModuleToIndicies = eventLookup->indiciesForModulesInProcess(processName);
+      found->resolvePutIndicies(InRun,runModuleToIndicies);
+      found->resolvePutIndicies(InLumi,lumiModuleToIndicies);
+      found->resolvePutIndicies(InEvent,eventModuleToIndicies);
+
+
     }
 
     return true;

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -176,7 +176,7 @@ namespace edm {
     virtual void updateLookup(BranchType iBranchType,
                       ProductResolverIndexHelper const&) = 0;
     virtual void resolvePutIndicies(BranchType iBranchType,
-                                    std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies) = 0;
+                                    std::unordered_multimap<std::string, std::tuple<TypeID const*, const char*, edm::ProductResolverIndex>> const& iIndicies) = 0;
 
     virtual void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
                                                  ProductRegistry const& preg,

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -457,29 +457,31 @@ namespace edm{
   }
 
   namespace {
+    using ModuleToResolverIndicies = std::unordered_multimap<std::string,
+    std::tuple<edm::TypeID const*, const char*, edm::ProductResolverIndex>>;
     void resolvePutIndiciesImpl(void*,
                                 BranchType iBranchType,
-                                std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies,
+                                ModuleToResolverIndicies const& iIndicies,
                                 std::string const& iModuleLabel) {
       //Do nothing
     }
 
     void resolvePutIndiciesImpl(ProducerBase* iProd,
                                 BranchType iBranchType,
-                                std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies,
+                                ModuleToResolverIndicies const& iIndicies,
                                 std::string const& iModuleLabel) {
       iProd->resolvePutIndicies(iBranchType, iIndicies, iModuleLabel);
     }
 
     void resolvePutIndiciesImpl(edm::stream::EDProducerAdaptorBase* iProd,
                                 BranchType iBranchType,
-                                std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies,
+                                ModuleToResolverIndicies const& iIndicies,
                                 std::string const& iModuleLabel) {
       iProd->resolvePutIndicies(iBranchType, iIndicies, iModuleLabel);
     }
     void resolvePutIndiciesImpl(edm::stream::EDFilterAdaptorBase* iProd,
                                 BranchType iBranchType,
-                                std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies,
+                                ModuleToResolverIndicies const& iIndicies,
                                 std::string const& iModuleLabel) {
       iProd->resolvePutIndicies(iBranchType, iIndicies, iModuleLabel);
     }
@@ -506,7 +508,8 @@ namespace edm{
 
   template<typename T>
   void WorkerT<T>::resolvePutIndicies(BranchType iBranchType,
-                                      std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies) {
+                                      std::unordered_multimap<std::string,
+                                      std::tuple<TypeID const*, const char*, edm::ProductResolverIndex>> const& iIndicies) {
     resolvePutIndiciesImpl(&module(), iBranchType,iIndicies, description().moduleLabel());
   }
 

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -47,7 +47,7 @@ namespace edm {
     void updateLookup(BranchType iBranchType,
                               ProductResolverIndexHelper const&) override;
     void resolvePutIndicies(BranchType iBranchType,
-                                    std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies) override;
+                                    std::unordered_multimap<std::string, std::tuple<TypeID const*, const char*, edm::ProductResolverIndex>> const& iIndicies) override;
 
     template<typename D>
     void callWorkerBeginStream(D, StreamID);

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -53,11 +53,11 @@ namespace edm {
                           ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
-      e.setProducer(this);
+      const auto streamIndex =e.streamID().value();
+      e.setProducer(this, &previousParentages_[streamIndex]);
       EventSignalsSentry sentry(act,mcc);
       bool returnValue = this->filter(e.streamID(), e, c);
-      const auto streamIndex =e.streamID().value();
-      commit_(e,&previousParentages_[streamIndex], &previousParentageIds_[streamIndex]);
+      commit_(e, &previousParentageIds_[streamIndex]);
       return returnValue;
     }
     

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -53,11 +53,11 @@ namespace edm {
                             ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
-      e.setProducer(this);
+      const auto streamIndex = e.streamID().value();
+      e.setProducer(this, &previousParentages_[streamIndex]);
       EventSignalsSentry sentry(act,mcc);
       this->produce(e.streamID(), e, c);
-      const auto streamIndex = e.streamID().value();
-      commit_(e,&previousParentages_[streamIndex], &previousParentageIds_[streamIndex]);
+      commit_(e, &previousParentageIds_[streamIndex]);
       return true;
     }
 

--- a/FWCore/Framework/src/limited/EDFilterBase.cc
+++ b/FWCore/Framework/src/limited/EDFilterBase.cc
@@ -54,11 +54,11 @@ namespace edm {
                           ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
-      e.setProducer(this);
+      const auto streamIndex =e.streamID().value();
+      e.setProducer(this, &previousParentages_[streamIndex]);
       EventSignalsSentry sentry(act,mcc);
       bool returnValue = this->filter(e.streamID(), e, c);
-      const auto streamIndex =e.streamID().value();
-      commit_(e,&previousParentages_[streamIndex], &previousParentageIds_[streamIndex]);
+      commit_(e, &previousParentageIds_[streamIndex]);
       return returnValue;
     }
     

--- a/FWCore/Framework/src/limited/EDProducerBase.cc
+++ b/FWCore/Framework/src/limited/EDProducerBase.cc
@@ -54,11 +54,11 @@ namespace edm {
                             ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
-      e.setProducer(this);
+      const auto streamIndex = e.streamID().value();
+      e.setProducer(this,&previousParentages_[streamIndex]);
       EventSignalsSentry sentry(act,mcc);
       this->produce(e.streamID(), e, c);
-      const auto streamIndex = e.streamID().value();
-      commit_(e,&previousParentages_[streamIndex], &previousParentageIds_[streamIndex]);
+      commit_(e, &previousParentageIds_[streamIndex]);
       return true;
     }
 

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -55,12 +55,12 @@ namespace edm {
                           ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
-      e.setProducer(this);
+      e.setProducer(this,&previousParentage_);
       bool returnValue =true;
       e.setSharedResourcesAcquirer(&resourcesAcquirer_);
       EventSignalsSentry sentry(act,mcc);
       returnValue = this->filter(e, c);
-      commit_(e,&previousParentage_, &previousParentageId_);
+      commit_(e, &previousParentageId_);
       return returnValue;
     }
     

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -54,11 +54,11 @@ namespace edm {
                             ModuleCallingContext const* mcc) {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
-      e.setProducer(this);
+      e.setProducer(this, &previousParentage_);
       e.setSharedResourcesAcquirer(&resourcesAcquirer_);
       EventSignalsSentry sentry(act,mcc);
       this->produce(e, c);
-      commit_(e,&previousParentage_, &previousParentageId_);
+      commit_(e, &previousParentageId_);
       return true;
     }
     

--- a/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
@@ -53,10 +53,10 @@ namespace edm {
       auto mod = m_streamModules[ep.streamID()];
       Event e(ep, moduleDescription(), mcc);
       e.setConsumer(mod);
-      e.setProducer(mod);
+      e.setProducer(mod,&mod->previousParentage_);
       EventSignalsSentry sentry(act,mcc);
       bool result = mod->filter(e, c);
-      commit(e,&mod->previousParentage_, &mod->previousParentageId_);
+      commit(e, &mod->previousParentageId_);
       return result;
     }
     

--- a/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
@@ -53,10 +53,10 @@ namespace edm {
       auto mod = m_streamModules[ep.streamID()];
       Event e(ep, moduleDescription(), mcc);
       e.setConsumer(mod);
-      e.setProducer(mod);
+      e.setProducer(mod,&mod->previousParentage_);
       EventSignalsSentry sentry(act,mcc);
       mod->produce(e, c);
-      commit(e,&mod->previousParentage_, &mod->previousParentageId_);
+      commit(e, &mod->previousParentageId_);
       return true;
     }
     

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -144,7 +144,9 @@ namespace edm {
     ProducingModuleAdaptorBase<T>::resolvePutIndicies(BranchType iBranchType,
                             ModuleToResolverIndicies const& iIndicies,
                             std::string const& moduleLabel) {
-      m_streamModules[0]->resolvePutIndicies(iBranchType,iIndicies,moduleLabel);
+      for(auto mod: m_streamModules) {
+        mod->resolvePutIndicies(iBranchType,iIndicies,moduleLabel);
+      }
     }
 
 

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -142,7 +142,7 @@ namespace edm {
     template< typename T>
     void
     ProducingModuleAdaptorBase<T>::resolvePutIndicies(BranchType iBranchType,
-                            std::unordered_multimap<std::string, edm::ProductResolverIndex> const& iIndicies,
+                            ModuleToResolverIndicies const& iIndicies,
                             std::string const& moduleLabel) {
       m_streamModules[0]->resolvePutIndicies(iBranchType,iIndicies,moduleLabel);
     }

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -89,6 +89,7 @@ class testEvent: public CppUnit::TestFixture {
   CPPUNIT_TEST(getByTokenFromEmpty);
   CPPUNIT_TEST(putAnIntProduct);
   CPPUNIT_TEST(putAndGetAnIntProduct);
+  CPPUNIT_TEST(putAndGetAnIntProductByToken);
   CPPUNIT_TEST(getByProductID);
   CPPUNIT_TEST(transaction);
   CPPUNIT_TEST(getByLabel);
@@ -108,6 +109,7 @@ class testEvent: public CppUnit::TestFixture {
   void getByTokenFromEmpty();
   void putAnIntProduct();
   void putAndGetAnIntProduct();
+  void putAndGetAnIntProductByToken();
   void getByProductID();
   void transaction();
   void getByLabel();
@@ -144,6 +146,10 @@ class testEvent: public CppUnit::TestFixture {
   std::unique_ptr<ProducerBase> putProduct(std::unique_ptr<T> product,
                   std::string const& productInstanceLabel,
                                            bool doCommit=true);
+  template <class T>
+  std::unique_ptr<ProducerBase> putProductUsingToken(std::unique_ptr<T> product,
+                                                     std::string const& productInstanceLabel,
+                                                     bool doCommit=true);
 
   std::shared_ptr<ProductRegistry>   availableProducts_;
   std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
@@ -261,6 +267,29 @@ testEvent::putProduct(std::unique_ptr<T> product,
   }
   return prod;
 }
+
+template <class T>
+std::unique_ptr<ProducerBase>
+testEvent::putProductUsingToken(std::unique_ptr<T> product,
+                                std::string const& productInstanceLabel,
+                                bool doCommit) {
+  auto prod = std::make_unique<ProducerBase>();
+  EDPutTokenT<edmtest::IntProduct> token = prod->produces<edmtest::IntProduct>(productInstanceLabel);
+  auto index =principal_->productLookup().index(PRODUCT_TYPE,
+                                                edm::TypeID(typeid(T)),
+                                                currentModuleDescription_->moduleLabel().c_str(),
+                                                productInstanceLabel.c_str(),
+                                                currentModuleDescription_->processName().c_str());
+  CPPUNIT_ASSERT(index != std::numeric_limits<unsigned int>::max());
+  const_cast<std::vector<edm::ProductResolverIndex>&>(prod->putTokenIndexToProductResolverIndex()).push_back(index);
+  currentEvent_->setProducer(prod.get(),nullptr);
+  currentEvent_->put(token,std::move(product));
+  if(doCommit) {
+    currentEvent_->commit_(std::vector<ProductResolverIndex>());
+  }
+  return prod;
+}
+
 
 testEvent::testEvent() :
   availableProducts_(new ProductRegistry()),
@@ -457,6 +486,19 @@ void testEvent::putAnIntProduct() {
 
 void testEvent::putAndGetAnIntProduct() {
   auto p = putProduct(std::make_unique<edmtest::IntProduct>(4),"int1");
+  
+  InputTag should_match("modMulti", "int1", "CURRENT");
+  InputTag should_not_match("modMulti", "int1", "NONESUCH");
+  Handle<edmtest::IntProduct> h;
+  currentEvent_->getByLabel(should_match, h);
+  CPPUNIT_ASSERT(h.isValid());
+  CPPUNIT_ASSERT(!currentEvent_->getByLabel(should_not_match, h));
+  CPPUNIT_ASSERT(!h.isValid());
+  CPPUNIT_ASSERT_THROW(*h, cms::Exception);
+}
+
+void testEvent::putAndGetAnIntProductByToken() {
+  auto p = putProductUsingToken(std::make_unique<edmtest::IntProduct>(4),"int1");
   
   InputTag should_match("modMulti", "int1", "CURRENT");
   InputTag should_not_match("modMulti", "int1", "NONESUCH");

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -233,7 +233,7 @@ testEvent::addProduct(std::unique_ptr<T> product,
                                          description->second.processName().c_str())
   );
 
-  temporaryEvent.setProducer(&prod);
+  temporaryEvent.setProducer(&prod,nullptr);
   OrphanHandle<T> h = temporaryEvent.put(std::move(product), productLabel);
   ProductID id = h.id();
   temporaryEvent.commit_(std::vector<ProductResolverIndex>());
@@ -254,7 +254,7 @@ testEvent::putProduct(std::unique_ptr<T> product,
                                                 currentModuleDescription_->processName().c_str());
   CPPUNIT_ASSERT(index != std::numeric_limits<unsigned int>::max());
   const_cast<std::vector<edm::ProductResolverIndex>&>(prod->putTokenIndexToProductResolverIndex()).push_back(index);
-  currentEvent_->setProducer(prod.get());
+  currentEvent_->setProducer(prod.get(),nullptr);
   currentEvent_->put(std::move(product), productInstanceLabel);
   if(doCommit) {
     currentEvent_->commit_(std::vector<ProductResolverIndex>());

--- a/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
+++ b/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
@@ -160,7 +160,7 @@ void testEventGetRefBeforePut::getRefTest() {
     edm::ProducerBase prod;
     prod.produces<edmtest::IntProduct>(productInstanceName);
     const_cast<std::vector<edm::ProductResolverIndex>&>(prod.putTokenIndexToProductResolverIndex()).push_back(0);
-    event.setProducer(&prod);
+    event.setProducer(&prod,nullptr);
     auto pr = std::make_unique<edmtest::IntProduct>();
     pr->value = 10;
 

--- a/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
+++ b/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
@@ -85,6 +85,8 @@ void testEventGetRefBeforePut::failGetProductNotRegisteredTest() {
      auto processConfiguration = std::make_shared<edm::ProcessConfiguration>();
      edm::ModuleDescription modDesc(pset.id(), "Blah", "blahs", processConfiguration.get(), edm::ModuleDescription::getUniqueID());
      edm::Event event(ep, modDesc, nullptr);
+     edm::ProducerBase prod;
+     event.setProducer(&prod,nullptr);
 
      std::string label("this does not exist");
      edm::RefProd<edmtest::DummyProduct> ref = event.getRefBeforePut<edmtest::DummyProduct>(label);

--- a/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
+++ b/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
@@ -20,6 +20,7 @@ Test of the EventPrincipal class.
 #include "FWCore/Framework/interface/HistoryAppender.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/GetPassID.h"
@@ -156,6 +157,10 @@ void testEventGetRefBeforePut::getRefTest() {
     edm::ModuleDescription modDesc("Blah", label, pcPtr.get());
 
     edm::Event event(ep, modDesc, nullptr);
+    edm::ProducerBase prod;
+    prod.produces<edmtest::IntProduct>(productInstanceName);
+    const_cast<std::vector<edm::ProductResolverIndex>&>(prod.putTokenIndexToProductResolverIndex()).push_back(0);
+    event.setProducer(&prod);
     auto pr = std::make_unique<edmtest::IntProduct>();
     pr->value = 10;
 

--- a/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
+++ b/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
@@ -98,6 +98,27 @@ void testEventGetRefBeforePut::failGetProductNotRegisteredTest() {
   catch (...) {
     CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
   }
+  
+  try {
+    edm::ParameterSet pset;
+    pset.registerIt();
+    auto processConfiguration = std::make_shared<edm::ProcessConfiguration>();
+    edm::ModuleDescription modDesc(pset.id(), "Blah", "blahs", processConfiguration.get(), edm::ModuleDescription::getUniqueID());
+    edm::Event event(ep, modDesc, nullptr);
+    edm::ProducerBase prod;
+    event.setProducer(&prod,nullptr);
+    
+    std::string label("this does not exist");
+    edm::RefProd<edmtest::DummyProduct> ref = event.getRefBeforePut<edmtest::DummyProduct>(edm::EDPutTokenT<edmtest::DummyProduct>{});
+    CPPUNIT_ASSERT("Failed to throw required exception" == 0);
+  }
+  catch (edm::Exception& x) {
+    // nothing to do
+  }
+  catch (...) {
+    CPPUNIT_ASSERT("Threw wrong kind of exception" == 0);
+  }
+
 }
 
 void testEventGetRefBeforePut::getRefTest() {

--- a/FWCore/Integration/test/CatchCmsExceptiontest.sh
+++ b/FWCore/Integration/test/CatchCmsExceptiontest.sh
@@ -17,7 +17,7 @@ echo running cmsRun CatchCmsExceptionFromSource_cfg.py
 cmsRun ${LOCAL_TEST_DIR}/CatchCmsExceptionFromSource_cfg.py &> CatchCmsExceptionFromSource.log && \
 die 'Failed because expected exception was not thrown while running cmsRun CatchCmsExceptionFromSource_cfg.py' $? 
 
-grep -q "Calling InputSource::beginRun" CatchCmsExceptionFromSource.log || die 'Failed to find string Calling InputSource::beginRun' $?
+grep -q "Calling Source::beginRun" CatchCmsExceptionFromSource.log || die 'Failed to find string Calling Source::beginRun' $?
 
 # It is intentional that this test throws an exception. The test fails if it does not.
 cmsRun ${LOCAL_TEST_DIR}/testMissingDictionaryChecking_cfg.py &> testMissingDictionaryChecking.log && die 'Failed to get exception running testMissingDictionaryChecking_cfg.py' 1

--- a/FWCore/Integration/test/ThingWithMergeProducer.cc
+++ b/FWCore/Integration/test/ThingWithMergeProducer.cc
@@ -28,7 +28,7 @@ namespace edmtest {
     produces<Thing>("event");
     produces<Thing, edm::Transition::BeginLuminosityBlock>("beginLumi");
     produces<Thing, edm::Transition::EndLuminosityBlock>("endLumi");
-    produces<Thing, edm::Transition::BeginLuminosityBlock>("beginRun");
+    produces<Thing, edm::Transition::BeginRun>("beginRun");
     produces<Thing, edm::Transition::EndRun>("endRun");
 
     produces<ThingWithMerge>("event");

--- a/FWCore/Integration/test/ThingWithMergeProducer.cc
+++ b/FWCore/Integration/test/ThingWithMergeProducer.cc
@@ -26,9 +26,9 @@ namespace edmtest {
     noPut_(pset.getUntrackedParameter<bool>("noPut", false))
 {
     produces<Thing>("event");
-    produces<Thing, edm::InLumi>("beginLumi");
+    produces<Thing, edm::Transition::BeginLuminosityBlock>("beginLumi");
     produces<Thing, edm::Transition::EndLuminosityBlock>("endLumi");
-    produces<Thing, edm::InRun>("beginRun");
+    produces<Thing, edm::Transition::BeginLuminosityBlock>("beginRun");
     produces<Thing, edm::Transition::EndRun>("endRun");
 
     produces<ThingWithMerge>("event");

--- a/FWCore/Sources/interface/ProducerSourceBase.h
+++ b/FWCore/Sources/interface/ProducerSourceBase.h
@@ -37,6 +37,7 @@ namespace edm {
 
     static void fillDescription(ParameterSetDescription& desc);
     
+    using ProducerBase::resolvePutIndicies;
     using ProducerBase::registerProducts;
     void registerProducts() final;
 

--- a/FWCore/Sources/interface/ProducerSourceBase.h
+++ b/FWCore/Sources/interface/ProducerSourceBase.h
@@ -11,13 +11,14 @@
 #include "DataFormats/Provenance/interface/Timestamp.h"
 #include "DataFormats/Provenance/interface/RunID.h"
 #include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
 
 #include <memory>
 
 namespace edm {
   class ParameterSet;
   class ParameterSetDescription;
-  class ProducerSourceBase : public InputSource {
+  class ProducerSourceBase : public InputSource, public ProducerBase {
   public:
     explicit ProducerSourceBase(ParameterSet const& pset, InputSourceDescription const& desc, bool realData);
     ~ProducerSourceBase() noexcept(false) override;
@@ -35,6 +36,9 @@ namespace edm {
     LuminosityBlockNumber_t luminosityBlock() const {return eventID_.luminosityBlock();}
 
     static void fillDescription(ParameterSetDescription& desc);
+    
+    using ProducerBase::registerProducts;
+    void registerProducts() final;
 
   protected:
 

--- a/FWCore/Sources/interface/ProducerSourceBase.h
+++ b/FWCore/Sources/interface/ProducerSourceBase.h
@@ -51,10 +51,17 @@ namespace edm {
     virtual bool noFiles() const;
     virtual size_t fileIndex() const;
     void beginJob() override;
-    void beginRun(Run&) override;
-    void endRun(Run&) override;
-    void beginLuminosityBlock(LuminosityBlock&) override;
-    void endLuminosityBlock(LuminosityBlock&) override;
+    
+    void doBeginLumi(LuminosityBlockPrincipal& lbp, ProcessContext const*) override;
+    void doEndLumi(LuminosityBlockPrincipal& lbp, bool cleaningUpAfterException, ProcessContext const*) override;
+    void doBeginRun(RunPrincipal& rp, ProcessContext const*) override;
+    void doEndRun(RunPrincipal& rp, bool cleaningUpAfterException, ProcessContext const*) override;
+    
+
+    virtual void beginRun(Run&);
+    virtual void endRun(Run&);
+    virtual void beginLuminosityBlock(LuminosityBlock&);
+    virtual void endLuminosityBlock(LuminosityBlock&);
     void readEvent_(EventPrincipal& eventPrincipal) override;
     std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
     std::shared_ptr<RunAuxiliary> readRunAuxiliary_() override;

--- a/FWCore/Sources/interface/ProducerSourceBase.h
+++ b/FWCore/Sources/interface/ProducerSourceBase.h
@@ -4,21 +4,20 @@
 /*----------------------------------------------------------------------
 ----------------------------------------------------------------------*/
 
-#include "FWCore/Framework/interface/InputSource.h"
+#include "FWCore/Sources/interface/PuttableSourceBase.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
 #include "DataFormats/Provenance/interface/RunID.h"
 #include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
 
 #include <memory>
 
 namespace edm {
   class ParameterSet;
   class ParameterSetDescription;
-  class ProducerSourceBase : public InputSource, public ProducerBase {
+  class ProducerSourceBase : public PuttableSourceBase {
   public:
     explicit ProducerSourceBase(ParameterSet const& pset, InputSourceDescription const& desc, bool realData);
     ~ProducerSourceBase() noexcept(false) override;
@@ -37,10 +36,6 @@ namespace edm {
 
     static void fillDescription(ParameterSetDescription& desc);
     
-    using ProducerBase::resolvePutIndicies;
-    using ProducerBase::registerProducts;
-    void registerProducts() final;
-
   protected:
 
   private:
@@ -52,16 +47,6 @@ namespace edm {
     virtual size_t fileIndex() const;
     void beginJob() override;
     
-    void doBeginLumi(LuminosityBlockPrincipal& lbp, ProcessContext const*) override;
-    void doEndLumi(LuminosityBlockPrincipal& lbp, bool cleaningUpAfterException, ProcessContext const*) override;
-    void doBeginRun(RunPrincipal& rp, ProcessContext const*) override;
-    void doEndRun(RunPrincipal& rp, bool cleaningUpAfterException, ProcessContext const*) override;
-    
-
-    virtual void beginRun(Run&);
-    virtual void endRun(Run&);
-    virtual void beginLuminosityBlock(LuminosityBlock&);
-    virtual void endLuminosityBlock(LuminosityBlock&);
     void readEvent_(EventPrincipal& eventPrincipal) override;
     std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
     std::shared_ptr<RunAuxiliary> readRunAuxiliary_() override;

--- a/FWCore/Sources/interface/PuttableSourceBase.h
+++ b/FWCore/Sources/interface/PuttableSourceBase.h
@@ -1,0 +1,69 @@
+#ifndef FWCore_Sources_PuttableSourceBase_h
+#define FWCore_Sources_PuttableSourceBase_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Sources
+// Class  :     PuttableSourceBase
+// 
+/**\class PuttableSourceBase PuttableSourceBase.h "PuttableSourceBase.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  root
+//         Created:  Tue, 26 Sep 2017 20:51:50 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/InputSource.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
+
+// forward declarations
+namespace edm {
+  class PuttableSourceBase : public InputSource, public ProducerBase
+{
+  
+public:
+  PuttableSourceBase(ParameterSet const&, InputSourceDescription const&);
+  
+  // ---------- const member functions ---------------------
+  
+  // ---------- static member functions --------------------
+  
+  // ---------- member functions ---------------------------
+  using ProducerBase::resolvePutIndicies;
+  using ProducerBase::registerProducts;
+  void registerProducts() final;
+  
+protected:
+  //If inheriting class overrides, they need to call this function as well
+  void beginJob() override;
+private:
+  void doBeginLumi(LuminosityBlockPrincipal& lbp, ProcessContext const*) override;
+  void doEndLumi(LuminosityBlockPrincipal& lbp, bool cleaningUpAfterException, ProcessContext const*) override;
+  void doBeginRun(RunPrincipal& rp, ProcessContext const*) override;
+  void doEndRun(RunPrincipal& rp, bool cleaningUpAfterException, ProcessContext const*) override;
+  
+  
+  virtual void beginRun(Run&);
+  virtual void endRun(Run&);
+  virtual void beginLuminosityBlock(LuminosityBlock&);
+  virtual void endLuminosityBlock(LuminosityBlock&);
+  
+  PuttableSourceBase(const PuttableSourceBase&) = delete;
+  
+  PuttableSourceBase& operator=(const PuttableSourceBase&) = delete;
+  
+  // ---------- member data --------------------------------
+  
+};
+}
+
+#endif

--- a/FWCore/Sources/src/ProducerSourceBase.cc
+++ b/FWCore/Sources/src/ProducerSourceBase.cc
@@ -10,7 +10,10 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ExceptionHelpers.h"
 #include "FWCore/Sources/interface/ProducerSourceBase.h"
 
 namespace edm {
@@ -116,6 +119,38 @@ namespace edm {
     // initialize cannot be called from the constructor, because it is a virtual function
     // that needs to be invoked from a derived class if the derived class overrides it.
     initialize(eventID_, presentTime_, timeBetweenEvents_);
+  }
+
+  void
+  ProducerSourceBase::doBeginRun(RunPrincipal& rp, ProcessContext const* ) {
+    Run run(rp, moduleDescription(), nullptr);
+    run.setProducer(this);
+    callWithTryCatchAndPrint<void>( [this,&run](){ beginRun(run); }, "Calling Source::beginRun" );
+    commit_(run);
+  }
+  
+  void
+  ProducerSourceBase::doEndRun(RunPrincipal& rp, bool cleaningUpAfterException, ProcessContext const* ) {
+    Run run(rp, moduleDescription(), nullptr);
+    run.setProducer(this);
+    callWithTryCatchAndPrint<void>( [this,&run](){ endRun(run); }, "Calling Source::endRun", cleaningUpAfterException );
+    commit_(run);
+  }
+  
+  void
+  ProducerSourceBase::doBeginLumi(LuminosityBlockPrincipal& lbp, ProcessContext const* ) {
+    LuminosityBlock lb(lbp, moduleDescription(), nullptr);
+    lb.setProducer(this);
+    callWithTryCatchAndPrint<void>( [this,&lb](){ beginLuminosityBlock(lb); }, "Calling Source::beginLuminosityBlock" );
+    commit_(lb);
+  }
+  
+  void
+  ProducerSourceBase::doEndLumi(LuminosityBlockPrincipal& lbp, bool cleaningUpAfterException, ProcessContext const* ) {
+    LuminosityBlock lb(lbp, moduleDescription(), nullptr);
+    lb.setProducer(this);
+    callWithTryCatchAndPrint<void>( [this,&lb](){ endLuminosityBlock(lb); }, "Calling Source::endLuminosityBlock", cleaningUpAfterException );
+    commit_(lb);
   }
 
   void

--- a/FWCore/Sources/src/ProducerSourceBase.cc
+++ b/FWCore/Sources/src/ProducerSourceBase.cc
@@ -5,6 +5,8 @@
 
 #include "DataFormats/Provenance/interface/LuminosityBlockAuxiliary.h"
 #include "DataFormats/Provenance/interface/RunAuxiliary.h"
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "DataFormats/Provenance/interface/ProductResolverIndexHelper.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
@@ -40,6 +42,12 @@ namespace edm {
   }
 
   ProducerSourceBase::~ProducerSourceBase() noexcept(false) {
+  }
+
+  
+  void
+  ProducerSourceBase::registerProducts() {
+    registerProducts(this,&productRegistryUpdate(),moduleDescription());
   }
 
   std::shared_ptr<RunAuxiliary>

--- a/FWCore/Sources/src/ProducerSourceBase.cc
+++ b/FWCore/Sources/src/ProducerSourceBase.cc
@@ -71,7 +71,7 @@ namespace edm {
     EventAuxiliary aux(eventID_, processGUID(), Timestamp(presentTime_), isRealData_, eType_);
     eventPrincipal.fillEventPrincipal(aux, processHistoryRegistry());
     Event e(eventPrincipal, moduleDescription(), nullptr);
-    e.setProducer(this);
+    e.setProducer(this,nullptr);
     produce(e);
     e.commit_(std::vector<ProductResolverIndex>());
     resetEventCached();

--- a/FWCore/Sources/src/PuttableSourceBase.cc
+++ b/FWCore/Sources/src/PuttableSourceBase.cc
@@ -1,0 +1,113 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Sources
+// Class  :     PuttableSourceBase
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  root
+//         Created:  Tue, 26 Sep 2017 20:52:26 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Sources/interface/PuttableSourceBase.h"
+
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "DataFormats/Provenance/interface/ProductResolverIndexHelper.h"
+
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ExceptionHelpers.h"
+
+using namespace edm;
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+PuttableSourceBase::PuttableSourceBase(ParameterSet const& iPSet, InputSourceDescription const& iISD):
+InputSource(iPSet,iISD)
+{
+}
+
+void
+PuttableSourceBase::registerProducts() {
+  registerProducts(this,&productRegistryUpdate(),moduleDescription());
+}
+
+void
+PuttableSourceBase::beginJob() {
+  auto r = productRegistry();
+  auto const runLookup = r->productLookup(InRun);
+  auto const lumiLookup = r->productLookup(InLumi);
+  auto const eventLookup = r->productLookup(InEvent);
+  auto const& processName = moduleDescription().processName();
+  auto const& moduleLabel = moduleDescription().moduleLabel();
+  
+  auto const& runModuleToIndicies = runLookup->indiciesForModulesInProcess(processName);
+  auto const& lumiModuleToIndicies = lumiLookup->indiciesForModulesInProcess(processName);
+  auto const& eventModuleToIndicies = eventLookup->indiciesForModulesInProcess(processName);
+  resolvePutIndicies(InRun,runModuleToIndicies,moduleLabel);
+  resolvePutIndicies(InLumi,lumiModuleToIndicies,moduleLabel);
+  resolvePutIndicies(InEvent,eventModuleToIndicies,moduleLabel);
+}
+
+void
+PuttableSourceBase::doBeginRun(RunPrincipal& rp, ProcessContext const* ) {
+  Run run(rp, moduleDescription(), nullptr);
+  run.setProducer(this);
+  callWithTryCatchAndPrint<void>( [this,&run](){ beginRun(run); }, "Calling Source::beginRun" );
+  commit_(run);
+}
+
+void
+PuttableSourceBase::doEndRun(RunPrincipal& rp, bool cleaningUpAfterException, ProcessContext const* ) {
+  Run run(rp, moduleDescription(), nullptr);
+  run.setProducer(this);
+  callWithTryCatchAndPrint<void>( [this,&run](){ endRun(run); }, "Calling Source::endRun", cleaningUpAfterException );
+  commit_(run);
+}
+
+void
+PuttableSourceBase::doBeginLumi(LuminosityBlockPrincipal& lbp, ProcessContext const* ) {
+  LuminosityBlock lb(lbp, moduleDescription(), nullptr);
+  lb.setProducer(this);
+  callWithTryCatchAndPrint<void>( [this,&lb](){ beginLuminosityBlock(lb); }, "Calling Source::beginLuminosityBlock" );
+  commit_(lb);
+}
+
+void
+PuttableSourceBase::doEndLumi(LuminosityBlockPrincipal& lbp, bool cleaningUpAfterException, ProcessContext const* ) {
+  LuminosityBlock lb(lbp, moduleDescription(), nullptr);
+  lb.setProducer(this);
+  callWithTryCatchAndPrint<void>( [this,&lb](){ endLuminosityBlock(lb); }, "Calling Source::endLuminosityBlock", cleaningUpAfterException );
+  commit_(lb);
+}
+
+void
+PuttableSourceBase::beginRun(Run&) {
+}
+
+void
+PuttableSourceBase::endRun(Run&) {
+}
+
+void
+PuttableSourceBase::beginLuminosityBlock(LuminosityBlock&) {
+}
+
+void
+PuttableSourceBase::endLuminosityBlock(LuminosityBlock&) {
+}
+
+

--- a/FWCore/Utilities/interface/EDPutToken.h
+++ b/FWCore/Utilities/interface/EDPutToken.h
@@ -36,6 +36,7 @@ namespace edm {
     friend class ProductRegistryHelper;
     
   public:
+    using value_type = unsigned int;
     
     EDPutToken() : m_value{s_uninitializedValue} {}
 
@@ -43,7 +44,7 @@ namespace edm {
     EDPutToken(EDPutTokenT<T> iOther): m_value{iOther.m_value} {}
 
     // ---------- const member functions ---------------------
-    unsigned int index() const { return m_value; }
+    value_type index() const { return m_value; }
     bool isUninitialized() const { return m_value == s_uninitializedValue; }
 
   private:
@@ -55,7 +56,7 @@ namespace edm {
     explicit EDPutToken(unsigned int iValue) : m_value(iValue) { }
 
     // ---------- member data --------------------------------
-    unsigned int m_value;
+    value_type m_value;
   };
 
   template<typename T>
@@ -65,11 +66,13 @@ namespace edm {
     friend class EDPutToken;
 
   public:
+    using value_type = EDPutToken::value_type;
 
+    
     EDPutTokenT() : m_value{s_uninitializedValue} {}
   
     // ---------- const member functions ---------------------
-    unsigned int index() const { return m_value; }
+    value_type index() const { return m_value; }
     bool isUninitialized() const { return m_value == s_uninitializedValue; }
 
   private:
@@ -81,7 +84,7 @@ namespace edm {
     explicit EDPutTokenT(unsigned int iValue) : m_value(iValue) { }
 
     // ---------- member data --------------------------------
-    unsigned int m_value;
+    value_type m_value;
   };
 }
 

--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -71,6 +71,10 @@ public:
   explicit operator bool() const;
   bool invalidTypeInfo() const;
   std::type_info const& typeInfo() const;
+  //Do not check is 'invalidTypeInfo()' would return true
+  std::type_info const& unvalidatedTypeInfo() const {
+    return *ti_;
+  }
   TClass* getClass() const;
   TEnum* getEnum() const;
   TDataType* getDataType() const;

--- a/GeneratorInterface/AlpgenInterface/plugins/AlpgenSource.cc
+++ b/GeneratorInterface/AlpgenInterface/plugins/AlpgenSource.cc
@@ -33,12 +33,12 @@ public:
 	       const edm::InputSourceDescription &desc);
 
   /// Destructor
-  virtual ~AlpgenSource();
+  ~AlpgenSource() override;
 
 private:
-  virtual bool setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&, edm::EventAuxiliary::ExperimentType&) override;
-  virtual void produce(edm::Event &event) override;
-  virtual void beginRun(edm::Run &run) override;
+  bool setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&, edm::EventAuxiliary::ExperimentType&) override;
+  void produce(edm::Event &event) override;
+  void beginRun(edm::Run &run) override;
 
   /// Function to get parameter by name from AlpgenHeader.
   template<typename T>
@@ -246,7 +246,7 @@ void AlpgenSource::beginRun(edm::Run &run)
   // If requested by the user, we also add any specific header provided.
   // Nota bene: the header is put in the LHERunInfoProduct AS IT WAS GIVEN.
   // That means NO CROSS-CHECKS WHATSOEVER. Use with care.
-  LHERunInfoProduct::Header extraHeader(extraHeaderName_.c_str());
+  LHERunInfoProduct::Header extraHeader(extraHeaderName_);
   if(writeExtraHeader) {
     std::ifstream extraascii(extraHeaderFileName_.c_str());
     while(extraascii.getline(buffer,512)) {

--- a/GeneratorInterface/AlpgenInterface/plugins/AlpgenSource.cc
+++ b/GeneratorInterface/AlpgenInterface/plugins/AlpgenSource.cc
@@ -140,7 +140,7 @@ AlpgenSource::AlpgenSource(const edm::ParameterSet &params,
       << "unweighted parameter file." << std::endl;
 
   // Declare the products.
-  produces<LHERunInfoProduct, edm::InRun>();
+   produces<LHERunInfoProduct, edm::Transition::BeginRun>();
   produces<LHEEventProduct>();
 }
 

--- a/GeneratorInterface/MCatNLOInterface/plugins/MCatNLOSource.cc
+++ b/GeneratorInterface/MCatNLOInterface/plugins/MCatNLOSource.cc
@@ -64,7 +64,7 @@ MCatNLOSource::MCatNLOSource(const edm::ParameterSet &params,
 	reader.reset(new std::ifstream(fileName.c_str()));
 
 	produces<LHEEventProduct>();
-	produces<LHERunInfoProduct, edm::InRun>();
+	produces<LHERunInfoProduct, edm::Transition::BeginRun>();
 }
 
 MCatNLOSource::~MCatNLOSource()

--- a/IOMC/RandomEngine/src/RandomEngineStateProducer.cc
+++ b/IOMC/RandomEngine/src/RandomEngineStateProducer.cc
@@ -12,7 +12,7 @@
 #include <memory>
 
 RandomEngineStateProducer::RandomEngineStateProducer(edm::ParameterSet const&) {
-  produces<edm::RandomEngineStates, edm::InLumi>("beginLumi");
+  produces<edm::RandomEngineStates, edm::Transition::BeginLuminosityBlock>("beginLumi");
   produces<edm::RandomEngineStates>();
 }
 

--- a/RecoLuminosity/LumiProducer/plugins/ExpressLumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/ExpressLumiProducer.cc
@@ -75,15 +75,15 @@ public:
   
   explicit ExpressLumiProducer(const edm::ParameterSet&);
   
-  ~ExpressLumiProducer();
+  ~ExpressLumiProducer() override;
   
 private:
   
 
-  virtual void produce(edm::Event&, const edm::EventSetup&) override final;
+  void produce(edm::Event&, const edm::EventSetup&) final;
 
-  virtual void beginLuminosityBlockProduce(edm::LuminosityBlock & iLBlock,
-				    edm::EventSetup const& iSetup) override final;
+  void beginLuminosityBlockProduce(edm::LuminosityBlock & iLBlock,
+				    edm::EventSetup const& iSetup) final;
 
   bool fillLumi(edm::LuminosityBlock & iLBlock);
   void fillLSCache(unsigned int runnum,unsigned int luminum);

--- a/RecoLuminosity/LumiProducer/plugins/ExpressLumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/ExpressLumiProducer.cc
@@ -101,8 +101,8 @@ ExpressLumiProducer::
 ExpressLumiProducer::ExpressLumiProducer(const edm::ParameterSet& iConfig):m_cachedrun(0),m_isNullRun(false),m_cachesize(0)
 {
   // register your products
-  produces<LumiSummary, edm::InLumi>();
-  produces<LumiDetails, edm::InLumi>();
+  produces<LumiSummary, edm::Transition::BeginLuminosityBlock>();
+  produces<LumiDetails, edm::Transition::BeginLuminosityBlock>();
   // set up cache
   m_connectStr=iConfig.getParameter<std::string>("connect");
   m_cachesize=iConfig.getUntrackedParameter<unsigned int>("ncacheEntries",5);

--- a/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingLHEProducer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingLHEProducer.cc
@@ -121,7 +121,7 @@ EmbeddingLHEProducer::EmbeddingLHEProducer(const edm::ParameterSet& iConfig)
 {
    //register your products
    produces<LHEEventProduct>();
-   produces<LHERunInfoProduct, edm::Transition::EndRun>();
+   produces<LHERunInfoProduct, edm::Transition::BeginRun>();
    produces<math::XYZTLorentzVectorD>("vertexPosition");
 
    muonsCollection_ = consumes<edm::View<pat::Muon>>(iConfig.getParameter<edm::InputTag>("src"));

--- a/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingLHEProducer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingLHEProducer.cc
@@ -74,17 +74,17 @@ class EmbeddingLHEProducer : public edm::one::EDProducer<edm::BeginRunProducer,
                                                         edm::EndRunProducer> {
    public:
       explicit EmbeddingLHEProducer(const edm::ParameterSet&);
-      ~EmbeddingLHEProducer();
+      ~EmbeddingLHEProducer() override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void beginJob() override;
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
+      void beginJob() override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
+      void endJob() override;
 
-      virtual void beginRunProduce(edm::Run& run, edm::EventSetup const& es) override;
-      virtual void endRunProduce(edm::Run&, edm::EventSetup const&) override;
+      void beginRunProduce(edm::Run& run, edm::EventSetup const& es) override;
+      void endRunProduce(edm::Run&, edm::EventSetup const&) override;
 
       void fill_lhe_from_mumu(TLorentzVector &positiveLepton, TLorentzVector &negativeLepton, lhef::HEPEUP &outlhe, CLHEP::HepRandomEngine* engine);
       void fill_lhe_with_particle(lhef::HEPEUP &outlhe, TLorentzVector &particle, int pdgid, double spin, double ctau);
@@ -403,12 +403,12 @@ void EmbeddingLHEProducer::transform_mumu_to_tautau(TLorentzVector &positiveLept
 
 void EmbeddingLHEProducer::assign_4vector(TLorentzVector &Lepton, const pat::Muon* muon, std::string FSRmode)
 {
-    if("afterFSR" == FSRmode && muon->genParticle() != 0)
+    if("afterFSR" == FSRmode && muon->genParticle() != nullptr)
     {
         const reco::GenParticle* afterFSRMuon = muon->genParticle();
         Lepton.SetPxPyPzE(afterFSRMuon->p4().px(),afterFSRMuon->p4().py(),afterFSRMuon->p4().pz(), afterFSRMuon->p4().e());
     }
-    else if ("beforeFSR" == FSRmode && muon->genParticle() != 0)
+    else if ("beforeFSR" == FSRmode && muon->genParticle() != nullptr)
     {
         const reco::Candidate* beforeFSRMuon = find_original_muon(muon->genParticle());
         Lepton.SetPxPyPzE(beforeFSRMuon->p4().px(),beforeFSRMuon->p4().py(),beforeFSRMuon->p4().pz(), beforeFSRMuon->p4().e());
@@ -422,7 +422,7 @@ void EmbeddingLHEProducer::assign_4vector(TLorentzVector &Lepton, const pat::Muo
 
 const reco::Candidate* EmbeddingLHEProducer::find_original_muon(const reco::Candidate* muon)
 {
-    if(muon->mother(0) == 0) return muon;
+    if(muon->mother(0) == nullptr) return muon;
     if(muon->pdgId() == muon->mother(0)->pdgId()) return find_original_muon(muon->mother(0));
     else return muon;
 }


### PR DESCRIPTION
Sped up the time it takes to 'put' data into the Event, LuminosityBlock and Run. 

Using a configuration with the same topology as the HLT but with trivial modules, the code makes that configuration run 20% faster.