### PR TITLE
delete unused PFBlockElementTrack

### DIFF
--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
@@ -163,6 +163,7 @@ importToBlock( const edm::Event& e,
       if( vetoed.count(pftrackref->trackRef().key()) == 0 || muonref.isNonnull()){
 	elems.emplace_back(trkElem);
       }
+      else delete trkElem;
     }
   }
   elems.shrink_to_fit();

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
@@ -93,7 +93,7 @@ importToBlock( const edm::Event& e,
 	// if there is no displaced vertex reference  and it is marked
 	// as a conversion it's gotta be a converted brem
 	if( trkel->trackType(reco::PFBlockElement::T_FROM_GAMMACONV) &&
-	    cRef.size() == 0 && dvRef.isNull() && v0Ref.isNull() ) {
+	    cRef.empty() && dvRef.isNull() && v0Ref.isNull() ) {
 	  // if the Pt resolution is bad we kill this element
 	  if( !PFTrackAlgoTools::goodPtResolution( trkel->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, debug_ ) ) {
 	    itr = elems.erase(itr);
@@ -134,7 +134,7 @@ importToBlock( const edm::Event& e,
   }
   // now we actually insert tracks, again tagging muons along the way
   reco::PFRecTrackRef pftrackref;  
-  reco::PFBlockElementTrack* trkElem = NULL;
+  reco::PFBlockElementTrack* trkElem = nullptr;
   for( auto track = btrack;  track != etrack; ++track) {
     const unsigned idx = std::distance(btrack,track);
     // since we already set muon refs in the previously imported tracks,


### PR DESCRIPTION
Some 930 relval workflows crashed with bus errors, indicating a memory leak. See e.g. http://cms-unified.web.cern.ch/cms-unified/joblogs/sandhya_RVCMSSW_9_3_0TTbar_14TeV_Timing_PU25ns__2023D17PU140_170918_163355_2603/135/RecoFullGlobalPU_Timing_2023D17PU/5dc3710e-9d83-11e7-9242-02163e00d7b3-0-2-logArchive/cmsRun1/.

Running valgrind (on 0PU equivalent workflow), I found a memory leak in PF. This seems to be the culprit, comparing MemoryCheck output for the failing workflow above for 10 events before:
```
Begin processing the 10th record. Run 1, Event 2510, LumiSection 26 at 26-Sep-2017 18:35:31.780 CDT
MemoryCheck: module MixingModule:mix VSIZE 10413.9 0.390625 RSS 7344.68 -528.73
```
and after:
```
Begin processing the 10th record. Run 1, Event 2510, LumiSection 26 at 27-Sep-2017 10:28:38.319 CDT
MemoryCheck: module MixingModule:mix VSIZE 8084.34 0.390625 RSS 5014.22 -532.316
```

attn: @jnsandhya @slava77 