### PR TITLE
HeavyFlavor Validation update [93X]

### DIFF
--- a/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationHarvestingSequence_cff.py
+++ b/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationHarvestingSequence_cff.py
@@ -4,46 +4,46 @@ from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 baseFolderPath = 'HLT/HeavyFlavor/HLT/'
 
 hfv1 = heavyFlavorValidationHarvesting.clone(
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_DoubleMu4_3_Bs_v')
+  MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_DoubleMu4_3_Bs_v')
 )
 hfv2 = heavyFlavorValidationHarvesting.clone(
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_DoubleMu4_3_Jpsi_Displaced_v')
+  MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_DoubleMu4_3_Jpsi_Displaced_v')
 )
 
 
 hfvTnP1 = heavyFlavorValidationHarvesting.clone(
-    MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Mu7p5_L2Mu2_Jpsi_v')
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Mu7p5_L2Mu2_Jpsi_v')
 )
 hfvTnP2 = heavyFlavorValidationHarvesting.clone(
-    MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Mu7p5_L2Mu2_Upsilon_v')
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Mu7p5_L2Mu2_Upsilon_v')
 )
 hfvTnP3 = heavyFlavorValidationHarvesting.clone(
-    MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Mu7p5_Track2_Jpsi_v')
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Mu7p5_Track2_Jpsi_v')
 )
 hfvTnP4 = heavyFlavorValidationHarvesting.clone(
-    MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Mu7p5_Track3p5_Jpsi_v')
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Mu7p5_Track3p5_Jpsi_v')
 )
 hfvTnP5 = heavyFlavorValidationHarvesting.clone(
-    MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Mu7p5_Track7_Jpsi_v')
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Mu7p5_Track7_Jpsi_v')
 )
 hfvTnP6 = heavyFlavorValidationHarvesting.clone(
-    MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Mu7p5_Track2_Upsilon_v')
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Mu7p5_Track2_Upsilon_v')
 )
 hfvTnP7 = heavyFlavorValidationHarvesting.clone(
-    MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Mu7p5_Track3p5_Upsilon_v')
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Mu7p5_Track3p5_Upsilon_v')
 )
 hfvTnP8 = heavyFlavorValidationHarvesting.clone(
-    MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Mu7p5_Track7_Upsilon_v')
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Mu7p5_Track7_Upsilon_v')
 )
 
 hfv7 = heavyFlavorValidationHarvesting.clone(
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_DoubleMu4_JpsiTrk_Displaced_v')
+  MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_DoubleMu4_JpsiTrk_Displaced_v')
 )
 hfv8 = heavyFlavorValidationHarvesting.clone(
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_DoubleMu4_PsiPrimeTrk_Displaced_v')
+  MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_DoubleMu4_PsiPrimeTrk_Displaced_v')
 )
 hfv9 = heavyFlavorValidationHarvesting.clone(
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_DoubleMu4_LowMassNonResonantTrk_Displaced_v')
+  MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_DoubleMu4_LowMassNonResonantTrk_Displaced_v')
 )
 
 ### 2017 additions

--- a/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationHarvestingSequence_cff.py
+++ b/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationHarvestingSequence_cff.py
@@ -1,34 +1,15 @@
 from HLTriggerOffline.HeavyFlavor.heavyFlavorValidationHarvesting_cfi import *
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
+baseFolderPath = 'HLT/HeavyFlavor/HLT/'
+
 hfv1 = heavyFlavorValidationHarvesting.clone(
   MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_DoubleMu4_3_Bs_v')
 )
 hfv2 = heavyFlavorValidationHarvesting.clone(
   MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_DoubleMu4_3_Jpsi_Displaced_v')
 )
-hfv3 = heavyFlavorValidationHarvesting.clone(
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Dimuon20_Jpsi_v')
-)
-hfv4 = heavyFlavorValidationHarvesting.clone(
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Dimuon13_PsiPrime_v')
-)
-hfv5 = heavyFlavorValidationHarvesting.clone(
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Dimuon13_Upsilon_v')
-)
 
-hfvQuadmu1 = heavyFlavorValidationHarvesting.clone(
-    MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Dimuon0_Jpsi_Muon_v')
-)
-hfvQuadmu2 = heavyFlavorValidationHarvesting.clone(
-    MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Dimuon0_Upsilon_Muon_v')
-)
-hfvQuadmu3 = heavyFlavorValidationHarvesting.clone(
-    MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_QuadMuon0_Dimuon0_Jpsi_v')
-)
-hfvQuadmu4 = heavyFlavorValidationHarvesting.clone(
-    MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_QuadMuon0_Dimuon0_Upsilon_v')
-)
 
 hfvTnP1 = heavyFlavorValidationHarvesting.clone(
     MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Mu7p5_L2Mu2_Jpsi_v')
@@ -54,19 +35,7 @@ hfvTnP7 = heavyFlavorValidationHarvesting.clone(
 hfvTnP8 = heavyFlavorValidationHarvesting.clone(
     MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Mu7p5_Track7_Upsilon_v')
 )
-hfvTnP9 = heavyFlavorValidationHarvesting.clone(
-    MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Dimuon0er16_Jpsi_NoOS_NoVertexing_v')
-)
-hfvTnP10 = heavyFlavorValidationHarvesting.clone(
-    MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Dimuon0er16_Jpsi_NoVertexing_v')
-)
-hfvTnP11 = heavyFlavorValidationHarvesting.clone(
-    MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Dimuon6_Jpsi_NoVertexing_v')
-)
 
-hfv6 = heavyFlavorValidationHarvesting.clone(
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Mu25_TkMu0_dEta18_Onia_v')
-)
 hfv7 = heavyFlavorValidationHarvesting.clone(
   MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_DoubleMu4_JpsiTrk_Displaced_v')
 )
@@ -77,38 +46,63 @@ hfv9 = heavyFlavorValidationHarvesting.clone(
   MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_DoubleMu4_LowMassNonResonantTrk_Displaced_v')
 )
 
-### 7E33 quarkonia
-hfvQ1 = heavyFlavorValidationHarvesting.clone(
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Dimuon10_Jpsi_Barrel_v')
-)
-hfvQ2 = heavyFlavorValidationHarvesting.clone(
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Dimuon16_Jpsi_v')
-)
-hfvQ3 = heavyFlavorValidationHarvesting.clone(
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Dimuon8_PsiPrime_Barrel_v')
-)
-hfvQ4 = heavyFlavorValidationHarvesting.clone(
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Dimuon8_Upsilon_Barrel_v')
-)
-hfvQ5 = heavyFlavorValidationHarvesting.clone(
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Dimuon0_Phi_Barrel_v')
-)
-hfvQ6 = heavyFlavorValidationHarvesting.clone(
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Mu16_TkMu0_dEta18_Onia_v')
-)
-hfvQ7 = heavyFlavorValidationHarvesting.clone(
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Mu16_TkMu0_dEta18_Phi_v')
+### 2017 additions
+hfjpsiMuon = heavyFlavorValidationHarvesting.clone(
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Dimuon0_Jpsi3p5_Muon2_v')
 )
 
-### tau3mu
-hfvTau3mu = heavyFlavorValidationHarvesting.clone(
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_DoubleMu3_Trk_tau3mu_v')
+hfjpsiNoVertexing = heavyFlavorValidationHarvesting.clone(
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Dimuon0_Jpsi_NoVertexing_v')
 )
 
-### DoubleMu0
-hfvDoubleMu0 = heavyFlavorValidationHarvesting.clone(
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_DoubleMu0')
+hfjpsiNoVertexingNoOS = heavyFlavorValidationHarvesting.clone(
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Dimuon0_Jpsi_NoVertexing_NoOS_v')
 )
+
+hfjpsiBarrel = heavyFlavorValidationHarvesting.clone(
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Dimuon20_Jpsi_Barrel_Seagulls_v')
+)
+
+hfpsiBarrel = heavyFlavorValidationHarvesting.clone(
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Dimuon10_PsiPrime_Barrel_Seagulls_v')
+)
+
+hfupsilonBarrel = heavyFlavorValidationHarvesting.clone(
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Dimuon10_Upsilon_Barrel_Seagulls_v')
+)
+
+hfphiBarrel = heavyFlavorValidationHarvesting.clone(
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Dimuon10_Phi_Barrel_Seagulls_v')
+)
+
+hfmu25Onia = heavyFlavorValidationHarvesting.clone(
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Mu25_TkMu0_Onia_v')
+)
+
+hfmu30Onia = heavyFlavorValidationHarvesting.clone(
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Mu30_TkMu0_Onia_v')
+)
+
+hfmu25Phi = heavyFlavorValidationHarvesting.clone(
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Mu25_TkMu0_Phi_v')
+)
+
+hfmu20Phi = heavyFlavorValidationHarvesting.clone(
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Mu20_TkMu0_Phi_v')
+)
+
+hfjpsi = heavyFlavorValidationHarvesting.clone(
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Dimuon25_Jpsi_v')
+)
+
+hfpsi = heavyFlavorValidationHarvesting.clone(
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Dimuon18_PsiPrime_v')
+)
+
+hfupsilon = heavyFlavorValidationHarvesting.clone(
+    MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_Dimuon12_Upsilon_eta1p5_v')
+)
+
 
 combiner = DQMEDHarvester('PlotCombiner',
   MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT'),
@@ -137,16 +131,16 @@ combiner2 = combiner.clone(
   Plots = cms.untracked.VPSet(
     cms.untracked.PSet(
       InputMEnames = cms.untracked.vstring(
-        'HLT_Dimuon20_Jpsi_v/effPathDiglobAND_recoEtaPtY',
-        'HLT_Dimuon13_PsiPrime_v/effPathDiglobAND_recoEtaPtY',
-        'HLT_Dimuon13_Upsilon_v/effPathDiglobAND_recoEtaPtY',
-        'HLT_Mu25_TkMu0_dEta18_Onia_v/effPathDiglobAND_recoEtaPtY',
+          'HLT_Dimuon25_Jpsi_v/effPathDiglobAND_recoEtaPtY',
+          'HLT_Dimuon18_PsiPrime_v/effPathDiglobAND_recoEtaPtY',
+          'HLT_Dimuon12_Upsilon_eta1p5_v/effPathDiglobAND_recoEtaPtY',
+          'HLT_Mu30_TkMu0_Onia_v/effPathDiglobAND_recoEtaPtY'
       ),
       InputLabels = cms.untracked.vstring(
-        'HLT_Dimuon20_Jpsi_v',
-        'HLT_Dimuon13_PsiPrime_v',
-        'HLT_Dimuon13_Upsilon_v',
-        'HLT_Mu25_TkMu0_dEta18_Onia_v',
+          'HLT_Dimuon25_Jpsi_v',
+          'HLT_Dimuon18_PsiPrime_v',
+          'HLT_Dimuon12_Upsilon_eta1p5_v',
+          'HLT_Mu30_TkMu0_Onia_v'
       ),
       OutputMEname = cms.untracked.string('effPathGlob_recoHighPt')
     )
@@ -154,13 +148,20 @@ combiner2 = combiner.clone(
 )
 
 heavyFlavorValidationHarvestingSequence = cms.Sequence(
-  hfv1+hfv2+hfv3+hfv4+hfv5 
-  +hfvQuadmu1+hfvQuadmu2+hfvQuadmu3+hfvQuadmu4
-  +hfvTnP1+hfvTnP2+hfvTnP3+hfvTnP4+hfvTnP5+hfvTnP6+hfvTnP7+hfvTnP8+hfvTnP9+hfvTnP10+hfvTnP11
-  +hfv6+hfv7+hfv8+hfv9
-  +hfvQ1+hfvQ2+hfvQ3+hfvQ4+hfvQ5+hfvQ6+hfvQ7
-  +hfvTau3mu
-  +hfvDoubleMu0
-	+combiner+combiner2
+  hfv1+hfv2
+  +hfvTnP1+hfvTnP2+hfvTnP3+hfvTnP4+hfvTnP5+hfvTnP6+hfvTnP7+hfvTnP8
+  +hfv7+hfv8+hfv9
+    + hfjpsiMuon
+    + hfjpsiNoVertexing
+    + hfjpsiNoVertexingNoOS
+    + hfjpsiBarrel
+    + hfpsiBarrel
+    + hfmu25Onia
+    + hfmu30Onia
+    + hfmu25Phi
+    + hfmu20Phi
+    + hfjpsi
+    + hfpsi
+    + hfupsilon
+    +combiner+combiner2
 )
-

--- a/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationHarvestingSequence_cff.py
+++ b/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationHarvestingSequence_cff.py
@@ -1,7 +1,7 @@
 from HLTriggerOffline.HeavyFlavor.heavyFlavorValidationHarvesting_cfi import *
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
-baseFolderPath = 'HLT/HeavyFlavor/HLT/'
+baseFolderPath = 'HLT/BPH/HLT/'
 
 hfv1 = heavyFlavorValidationHarvesting.clone(
   MyDQMrootFolder = cms.untracked.string(baseFolderPath + 'HLT_DoubleMu4_3_Bs_v')
@@ -105,7 +105,7 @@ hfupsilon = heavyFlavorValidationHarvesting.clone(
 
 
 combiner = DQMEDHarvester('PlotCombiner',
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT'),
+  MyDQMrootFolder = cms.untracked.string('HLT/BPH/HLT'),
   Plots = cms.untracked.VPSet(
     cms.untracked.PSet(
       InputMEnames = cms.untracked.vstring(

--- a/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationHarvesting_cfi.py
+++ b/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationHarvesting_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 heavyFlavorValidationHarvesting = DQMEDHarvester("HeavyFlavorHarvesting",
-  MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Mu5'),
+  MyDQMrootFolder = cms.untracked.string('HLT/BPH/HLT/HLT_Mu5'),
   Efficiencies = cms.untracked.VPSet(
     cms.untracked.PSet( NumDenEffMEnames = cms.untracked.vstring("globMuon_genEtaPt","genMuon_genEtaPt","effGlobGen_genEtaPt") ),
     cms.untracked.PSet( NumDenEffMEnames = cms.untracked.vstring("filt1Muon_recoEtaPt","globMuon_recoEtaPt","effFilt1Glob_recoEtaPt") ),

--- a/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationSequence_cff.py
+++ b/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationSequence_cff.py
@@ -20,19 +20,6 @@ hfv5 = hfv1.clone(
     TriggerPathName = cms.untracked.string("HLT_DoubleMu4_LowMassNonResonantTrk_Displaced_v")
 )
 
-hfvQuadmu1 = hfv1.clone(
-    TriggerPathName = cms.untracked.string("HLT_Dimuon0_Jpsi_Muon_v")
-)
-hfvQuadmu2 = hfv1.clone(
-    TriggerPathName = cms.untracked.string("HLT_Dimuon0_Upsilon_Muon_v")
-)
-hfvQuadmu3 = hfv1.clone(
-    TriggerPathName = cms.untracked.string("HLT_QuadMuon0_Dimuon0_Jpsi_v")
-)
-hfvQuadmu4 = hfv1.clone(
-    TriggerPathName = cms.untracked.string("HLT_QuadMuon0_Dimuon0_Upsilon_v")
-)
-
 hfvTnP1 = hfv1.clone(
     TriggerPathName = cms.untracked.string("HLT_Mu7p5_L2Mu2_Jpsi_v")
 )
@@ -57,70 +44,80 @@ hfvTnP7 = hfv1.clone(
 hfvTnP8 = hfv1.clone(
     TriggerPathName = cms.untracked.string("HLT_Mu7p5_Track7_Upsilon_v")
 )
-hfvTnP9 = hfv1.clone(
-    TriggerPathName = cms.untracked.string("HLT_Dimuon0er16_Jpsi_NoOS_NoVertexing_v")
-)
-hfvTnP10 = hfv1.clone(
-    TriggerPathName = cms.untracked.string("HLT_Dimuon0er16_Jpsi_NoVertexing_v")
-)
-hfvTnP11 = hfv1.clone(
-    TriggerPathName = cms.untracked.string("HLT_Dimuon6_Jpsi_NoVertexing_v")
+
+## 2017 additions
+hfjpsiMuon = hfv1.clone(
+    TriggerPathName = cms.untracked.string("HLT_Dimuon0_Jpsi3p5_Muon2_v")
 )
 
-### Quarkonia 7E33
-hfvQ1 = hfv1.clone(
-    TriggerPathName = cms.untracked.string("HLT_Dimuon10_Jpsi_Barrel_v")
-)
-hfvQ2 = hfv1.clone(
-    TriggerPathName = cms.untracked.string("HLT_Dimuon16_Jpsi_v")
-)
-hfvQ3 = hfv1.clone(
-    TriggerPathName = cms.untracked.string("HLT_Dimuon8_PsiPrime_Barrel_v")
-)
-hfvQ4 = hfv1.clone(
-    TriggerPathName = cms.untracked.string("HLT_Dimuon8_Upsilon_Barrel_v")
-)
-hfvQ5 = hfv1.clone(
-    TriggerPathName = cms.untracked.string("HLT_Dimuon0_Phi_Barrel_v")
-)
-hfvQ6 = hfv1.clone(
-    TriggerPathName = cms.untracked.string("HLT_Mu16_TkMu0_dEta18_Onia_v")
-)
-hfvQ7 = hfv1.clone(
-    TriggerPathName = cms.untracked.string("HLT_Mu16_TkMu0_dEta18_Phi_v")
+hfjpsiNoVertexing = hfv1.clone(
+    TriggerPathName = cms.untracked.string("HLT_Dimuon0_Jpsi_NoVertexing_v")
 )
 
-hfv6 = hfv1.clone(
-    TriggerPathName = cms.untracked.string("HLT_Dimuon20_Jpsi_v"),
-    MuonPtBins = cms.untracked.vdouble(7.5, 10., 12.5, 15., 17.5, 20., 22.5, 25., 27.5, 30.),
-    DimuonPtBins = cms.untracked.vdouble(10., 12.5, 15., 17.5, 20., 22.5, 25., 27.5, 30.)
-)
-hfv7 = hfv6.clone(
-    TriggerPathName = cms.untracked.string("HLT_Dimuon13_PsiPrime_v"),
-)
-hfv8 = hfv6.clone(
-    TriggerPathName = cms.untracked.string("HLT_Dimuon13_Upsilon_v"),
-)
-hfv9 = hfv6.clone(
-    TriggerPathName = cms.untracked.string("HLT_Mu25_TkMu0_dEta18_Onia_v"),
+hfjpsiNoVertexingNoOS = hfv1.clone(
+    TriggerPathName = cms.untracked.string("HLT_Dimuon0_Jpsi_NoVertexing_NoOS_v")
 )
 
-### tau3mu
-hfvTau3mu = hfv1.clone(
-    TriggerPathName = cms.untracked.string("HLT_DoubleMu3_Trk_tau3mu_v")
+hfjpsiBarrel = hfv1.clone(
+    TriggerPathName = cms.untracked.string("HLT_Dimuon20_Jpsi_Barrel_Seagulls_v")
 )
 
-### DoubleMu0
-hfvDoubleMu0 = hfv1.clone(
-    TriggerPathName = cms.untracked.string("HLT_DoubleMu0")
+hfpsiBarrel = hfv1.clone(
+    TriggerPathName = cms.untracked.string("HLT_Dimuon10_PsiPrime_Barrel_Seagulls_v")
 )
+
+hfupsilonBarrel = hfv1.clone(
+    TriggerPathName = cms.untracked.string("HLT_Dimuon10_Upsilon_Barrel_Seagulls_v")
+)
+
+hfphiBarrel = hfv1.clone(
+    TriggerPathName = cms.untracked.string("HLT_Dimuon14_Phi_Barrel_Seagulls_v")
+)
+
+hfmu25Onia = hfv1.clone(
+    TriggerPathName = cms.untracked.string("HLT_Mu25_TkMu0_Onia_v")
+)
+
+hfmu30Onia = hfv1.clone(
+    TriggerPathName = cms.untracked.string("HLT_Mu30_TkMu0_Onia_v")
+)
+
+hfmu25Phi = hfv1.clone(
+    TriggerPathName = cms.untracked.string("HLT_Mu25_TkMu0_Phi_v")
+)
+
+hfmu20Phi = hfv1.clone(
+    TriggerPathName = cms.untracked.string("HLT_Mu20_TkMu0_Phi_v")
+)
+
+hfjpsi = hfv1.clone(
+    TriggerPathName = cms.untracked.string("HLT_Dimuon25_Jpsi_v")
+)
+
+hfpsi = hfv1.clone(
+    TriggerPathName = cms.untracked.string("HLT_Dimuon18_PsiPrime_v")
+)
+
+hfupsilon = hfv1.clone(
+    TriggerPathName = cms.untracked.string("HLT_Dimuon12_Upsilon_eta1p5_v")
+)
+
 
 heavyFlavorValidationSequence = cms.Sequence(
-  hfv1+hfv2+hfv3+hfv4+hfv5 
-  +hfvQuadmu1+hfvQuadmu2+hfvQuadmu3+hfvQuadmu4
-  +hfvTnP1+hfvTnP2+hfvTnP3+hfvTnP4+hfvTnP5+hfvTnP6+hfvTnP7+hfvTnP8+hfvTnP9+hfvTnP10+hfvTnP11
-  +hfv6+hfv7+hfv8+hfv9
-  +hfvTau3mu
-  +hfvDoubleMu0
-  +hfvQ1+hfvQ2+hfvQ3+hfvQ4+hfvQ5+hfvQ6+hfvQ7
+    hfv1+hfv2+hfv3+hfv4+hfv5
+    +hfvTnP1+hfvTnP2+hfvTnP3+hfvTnP4+hfvTnP5+hfvTnP6+hfvTnP7+hfvTnP8
+    + hfjpsiMuon
+    + hfjpsiNoVertexing
+    + hfjpsiNoVertexingNoOS
+    + hfjpsiBarrel
+    + hfpsiBarrel
+    + hfupsilonBarrel
+    + hfphiBarrel
+    + hfmu25Onia
+    + hfmu30Onia
+    + hfmu25Phi
+    + hfmu20Phi
+    + hfjpsi
+    + hfpsi
+    + hfupsilon
 )

--- a/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidation_cfi.py
+++ b/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidation_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 heavyFlavorValidation = cms.EDAnalyzer("HeavyFlavorValidation",
-    DQMFolder = cms.untracked.string("HLT/HeavyFlavor"),
+    DQMFolder = cms.untracked.string("HLT/BPH"),
     TriggerProcessName = cms.untracked.string("HLT"),
     TriggerPathName = cms.untracked.string("HLT_Mu5"),
     TriggerSummaryRAW = cms.untracked.string("hltTriggerSummaryRAW"),

--- a/HLTriggerOffline/HeavyFlavor/src/HeavyFlavorValidation.cc
+++ b/HLTriggerOffline/HeavyFlavor/src/HeavyFlavorValidation.cc
@@ -8,6 +8,7 @@
 // Original Author:  Zoltan Gecse
 
 #include <memory>
+#include <initializer_list>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -73,6 +74,18 @@ class HeavyFlavorValidation : public DQMEDAnalyzer {
     void myBook1D(DQMStore::IBooker & ibooker, TString name, vector<double> &xBins, TString label ){
       myBook1D(ibooker, name, xBins, label, name );
     }
+
+    /**
+     * Get the filter "level" (as it is defined for the use of this module and its corresponding
+     * harvesting module).
+     *
+     * level 1 - 3 -> more or less synonymously to the the trigger levels
+     * level 4 and 5 -> vertex, dz, track, etc.. filters
+     *
+     * See the comments in the definition for some more details.
+     */
+    int getFilterLevel(const std::string &moduleName, const HLTConfigProvider &hltConfig);
+
     string dqmFolder;
     string triggerProcessName;
     string triggerPathName;
@@ -145,43 +158,29 @@ void HeavyFlavorValidation::dqmBeginRun(const edm::Run& iRun, const edm::EventSe
 		LogWarning("HLTriggerOfflineHeavyFlavor") << "Could not initialize HLTConfigProvider with process name: "<<triggerProcessName<<endl;
 		return;
 	}
-	stringstream os;
 	vector<string> triggerNames = hltConfig.triggerNames();
-	for( size_t i = 0; i < triggerNames.size(); i++) {
-		TString triggerName = triggerNames[i];
-		if (triggerName.Contains(triggerPathName)){ 
-			vector<string> moduleNames = hltConfig.moduleLabels( triggerNames[i] );
-			for( size_t j = 0; j < moduleNames.size(); j++) {
-				TString name = moduleNames[j];
-                                // MK 2016-12-09: added requirement for the module EDM type to be
-                                // EDFilter, as without it the name check can match also any EDProducer
-                                // (and would be fragile; ok I think it is still fragile, but the added
-                                // check allows PR #16792 to go forward)
-				if(name.Contains("Filter") && hltConfig.moduleEDMType(moduleNames[j]) == "EDFilter"){
-					int level = 0;
-					if(name.Contains("L1"))
-						level = 1;
-					if(name.Contains("L2"))
-						level = 2;
-					if(name.Contains("L3"))
-						level = 3;
-					if(name.Contains("mumuFilter") || name.Contains("DiMuon") || name.Contains("MuonL3Filtered") || name.Contains("TrackMassFiltered"))
-						level = 4;
-					if(name.Contains("Vertex") || name.Contains("Dz"))
-						level = 5;
-					filterNamesLevels.push_back( pair<string,int>(moduleNames[j],level) );
-					os<<" "<<moduleNames[j];
-				}
-			}
-			break;
+        for (const auto &trigName : triggerNames) {
+                // TString triggerName = trigName;
+                if (trigName.find(triggerPathName) != std::string::npos) {
+		        vector<string> moduleNames = hltConfig.moduleLabels( trigName );
+                        for (const auto &moduleName : moduleNames) {
+                                const int level = getFilterLevel(moduleName, hltConfig);
+                                if (level > 0) {
+                                        filterNamesLevels.push_back( {moduleName, level} );
+                                }
+                        }
+                        break;
 		}
 	}
+
 	if(filterNamesLevels.size()==0){
 		LogDebug("HLTriggerOfflineHeavyFlavor")<<"Bad Trigger Path: "<<triggerPathName<<endl;
 		return;
 	}else{
+          	stringstream os;
+                for (const auto &filters : filterNamesLevels) os << " " << filters.first;
 		LogDebug("HLTriggerOfflineHeavyFlavor")<<"Trigger Path: "<<triggerPathName<<" has filters:"<<os.str();
-	}  
+	}
 }
 
 
@@ -193,7 +192,7 @@ void HeavyFlavorValidation::bookHistograms(DQMStore::IBooker & ibooker,
           ibooker.setCurrentFolder((dqmFolder+"/")+triggerProcessName+"/"+triggerPathName);
 
 	// create Monitor Elements
-	// Eta Pt Single  
+	// Eta Pt Single
 	  myBook2D(ibooker, "genMuon_genEtaPt", muonEtaBins, "#mu eta", muonPtBins, " #mu pT (GeV)");
 	  myBook2D(ibooker, "globMuon_genEtaPt", muonEtaBins, "#mu eta", muonPtBins, " #mu pT (GeV)");
 	  myBook2D(ibooker, "globMuon_recoEtaPt", muonEtaBins, "#mu eta", muonPtBins, " #mu pT (GeV)");
@@ -209,18 +208,18 @@ void HeavyFlavorValidation::bookHistograms(DQMStore::IBooker & ibooker,
 	    myBookProfile2D(ibooker, TString::Format("resFilt%dGlob_recoEtaPt",int(i+1)), muonEtaBins, "#mu eta", muonPtBins, " #mu pT (GeV)", filterNamesLevels[i].first);
 	  }
 	  myBookProfile2D(ibooker, "resPathGlob_recoEtaPt", muonEtaBins, "#mu eta", muonPtBins, " #mu pT (GeV)", triggerPathName);
-	// Eta Pt Double  
+	// Eta Pt Double
 	  myBook2D(ibooker, "genDimuon_genEtaPt", dimuonEtaBins, "#mu#mu eta", dimuonPtBins, " #mu#mu pT (GeV)");
 	  myBook2D(ibooker, "globDimuon_genEtaPt", dimuonEtaBins, "#mu#mu eta", dimuonPtBins, " #mu#mu pT (GeV)");
 	  myBook2D(ibooker, "globDimuon_recoEtaPt", dimuonEtaBins, "#mu#mu eta", dimuonPtBins, " #mu#mu pT (GeV)");
 	  for(size_t i=0; i<filterNamesLevels.size(); i++){
 	    myBook2D(ibooker, TString::Format("filt%dDimuon_recoEtaPt",int(i+1)), dimuonEtaBins, "#mu#mu eta", dimuonPtBins, " #mu#mu pT (GeV)", filterNamesLevels[i].first);
-	  }  
+	  }
 	  myBook2D(ibooker, "pathDimuon_recoEtaPt", dimuonEtaBins, "#mu#mu eta", dimuonPtBins, " #mu#mu pT (GeV)", triggerPathName);
 	  myBook2D(ibooker, "resultDimuon_recoEtaPt", dimuonEtaBins, "#mu#mu eta", dimuonPtBins, " #mu#mu pT (GeV)");
 	  for(size_t i=0; i<filterNamesLevels.size(); i++){
 	    myBook2D(ibooker, TString::Format("diFilt%dDimuon_recoEtaPt",int(i+1)), dimuonEtaBins, "#mu#mu eta", dimuonPtBins, " #mu#mu pT (GeV)", filterNamesLevels[i].first);
-	  }  
+	  }
 	  myBook2D(ibooker, "diPathDimuon_recoEtaPt", dimuonEtaBins, "#mu#mu eta", dimuonPtBins, " #mu#mu pT (GeV)", triggerPathName);
 	// Eta Phi Single
 	  myBook2D(ibooker, "genMuon_genEtaPhi", muonEtaBins, "#mu eta", muonPhiBins, "#mu phi");
@@ -237,14 +236,14 @@ void HeavyFlavorValidation::bookHistograms(DQMStore::IBooker & ibooker,
 	  myBook2D(ibooker, "globDimuon_recoRapPt", dimuonEtaBins, "#mu#mu rapidity", dimuonPtBins, " #mu#mu pT (GeV)");
 	  for(size_t i=0; i<filterNamesLevels.size(); i++){
 	    myBook2D(ibooker, TString::Format("filt%dDimuon_recoRapPt",int(i+1)), dimuonEtaBins, "#mu#mu rapidity", dimuonPtBins, " #mu#mu pT (GeV)", filterNamesLevels[i].first);
-	  }  
+	  }
 	  myBook2D(ibooker, "pathDimuon_recoRapPt", dimuonEtaBins, "#mu#mu rapidity", dimuonPtBins, " #mu#mu pT (GeV)", triggerPathName);
 	  myBook2D(ibooker, "resultDimuon_recoRapPt", dimuonEtaBins, "#mu#mu rapidity", dimuonPtBins, " #mu#mu pT (GeV)");
 	  for(size_t i=0; i<filterNamesLevels.size(); i++){
 	    myBook2D(ibooker, TString::Format("diFilt%dDimuon_recoRapPt",int(i+1)), dimuonEtaBins, "#mu#mu rapidity", dimuonPtBins, " #mu#mu pT (GeV)", filterNamesLevels[i].first);
-	  }  
+	  }
 	  myBook2D(ibooker, "diPathDimuon_recoRapPt", dimuonEtaBins, "#mu#mu rapidity", dimuonPtBins, " #mu#mu pT (GeV)", triggerPathName);
-	// Pt DR Double  
+	// Pt DR Double
 	  myBook2D(ibooker, "genDimuon_genPtDR", dimuonPtBins, " #mu#mu pT (GeV)", dimuonDRBins, "#mu#mu #Delta R at IP");
 	  myBook2D(ibooker, "globDimuon_genPtDR", dimuonPtBins, " #mu#mu pT (GeV)", dimuonDRBins, "#mu#mu #Delta R at IP");
 	  myBook2D(ibooker, "globDimuon_recoPtDR", dimuonPtBins, " #mu#mu pT (GeV)", dimuonDRBins, "#mu#mu #Delta R at IP");
@@ -254,10 +253,10 @@ void HeavyFlavorValidation::bookHistograms(DQMStore::IBooker & ibooker,
 	  myBook2D(ibooker, "pathDimuon_recoPtDR", dimuonPtBins, " #mu#mu pT (GeV)", dimuonDRBins, "#mu#mu #Delta R at IP", triggerPathName);
 	  for(size_t i=0; i<filterNamesLevels.size(); i++){
 	    myBook2D(ibooker, TString::Format("diFilt%dDimuon_recoPtDR",int(i+1)), dimuonPtBins, " #mu#mu pT (GeV)", dimuonDRBins, "#mu#mu #Delta R at IP", filterNamesLevels[i].first);
-	  }  
+	  }
 	  myBook2D(ibooker, "diPathDimuon_recoPtDR", dimuonPtBins, " #mu#mu pT (GeV)", dimuonDRBins, "#mu#mu #Delta R at IP", triggerPathName);
 	  myBook2D(ibooker, "resultDimuon_recoPtDR", dimuonPtBins, " #mu#mu pT (GeV)", dimuonDRBins, "#mu#mu #Delta R at IP");
-	// Pt DRpos Double  
+	// Pt DRpos Double
 	  myBook2D(ibooker, "globDimuon_recoPtDRpos", dimuonPtBins, " #mu#mu pT (GeV)", dimuonDRBins, "#mu#mu #Delta R in MS");
 	  for(size_t i=0; i<filterNamesLevels.size(); i++){
 	    myBook2D(ibooker, TString::Format("filt%dDimuon_recoPtDRpos",int(i+1)), dimuonPtBins, " #mu#mu pT (GeV)", dimuonDRBins, "#mu#mu #Delta R in MS", filterNamesLevels[i].first);
@@ -265,7 +264,7 @@ void HeavyFlavorValidation::bookHistograms(DQMStore::IBooker & ibooker,
 	  myBook2D(ibooker, "pathDimuon_recoPtDRpos", dimuonPtBins, " #mu#mu pT (GeV)", dimuonDRBins, "#mu#mu #Delta R in MS", triggerPathName);
 	  for(size_t i=0; i<filterNamesLevels.size(); i++){
 	    myBook2D(ibooker, TString::Format("diFilt%dDimuon_recoPtDRpos",int(i+1)), dimuonPtBins, " #mu#mu pT (GeV)", dimuonDRBins, "#mu#mu #Delta R in MS", filterNamesLevels[i].first);
-	  }  
+	  }
 	  myBook2D(ibooker, "diPathDimuon_recoPtDRpos", dimuonPtBins, " #mu#mu pT (GeV)", dimuonDRBins, "#mu#mu #Delta R in MS", triggerPathName);
 	  myBook2D(ibooker, "resultDimuon_recoPtDRpos", dimuonPtBins, " #mu#mu pT (GeV)", dimuonDRBins, "#mu#mu #Delta R in MS");
 
@@ -273,7 +272,7 @@ void HeavyFlavorValidation::bookHistograms(DQMStore::IBooker & ibooker,
 	  myBook2D(ibooker, "globGen_deltaEtaDeltaPhi", deltaEtaBins, "#Delta eta", deltaPhiBins, "#Delta phi");
 	  for(size_t i=0; i<filterNamesLevels.size(); i++){
 	    myBook2D(ibooker, TString::Format("filt%dGlob_deltaEtaDeltaPhi",int(i+1)), deltaEtaBins, "#Delta eta", deltaPhiBins, "#Delta phi", filterNamesLevels[i].first);
-	  }    
+	  }
 	  myBook2D(ibooker, "pathGlob_deltaEtaDeltaPhi", deltaEtaBins, "#Delta eta", deltaPhiBins, "#Delta phi", triggerPathName);
 	// Size of containers
 	  vector<double> sizeBins; sizeBins.push_back(10); sizeBins.push_back(0); sizeBins.push_back(10);
@@ -281,24 +280,24 @@ void HeavyFlavorValidation::bookHistograms(DQMStore::IBooker & ibooker,
 	  myBook1D(ibooker, "globMuon_size", sizeBins, "container size" );
 	  for(size_t i=0; i<filterNamesLevels.size(); i++){
 	    myBook1D(ibooker, TString::Format("filt%dMuon_size",int(i+1)), sizeBins, "container size", filterNamesLevels[i].first);
-	  }    
+	  }
 	  myBook1D(ibooker, "pathMuon_size", sizeBins, "container size", triggerPathName );
 }
 
 void HeavyFlavorValidation::analyze(const Event& iEvent, const EventSetup& iSetup){
-  if(filterNamesLevels.size()==0){ 
+  if(filterNamesLevels.size()==0){
     return;
-  } 
+  }
 //access the containers and create LeafCandidate copies
   vector<LeafCandidate> genMuons;
   Handle<GenParticleCollection> genParticles;
   iEvent.getByToken(genParticlesToken, genParticles);
   if(genParticles.isValid()){
     for(GenParticleCollection::const_iterator p=genParticles->begin(); p!= genParticles->end(); ++p){
-      if( p->status() == 1 && std::abs(p->pdgId())==13 && 
+      if( p->status() == 1 && std::abs(p->pdgId())==13 &&
           ( find( motherIDs.begin(), motherIDs.end(), -1 )!=motherIDs.end() || find( motherIDs.begin(), motherIDs.end(), getMotherId(&(*p)) )!=motherIDs.end() ) ){
         genMuons.push_back( *p );
-      }  
+      }
     }
   }else{
     LogDebug("HLTriggerOfflineHeavyFlavor")<<"Could not access GenParticleCollection"<<endl;
@@ -306,7 +305,7 @@ void HeavyFlavorValidation::analyze(const Event& iEvent, const EventSetup& iSetu
   sort(genMuons.begin(), genMuons.end(), GreaterByPt<LeafCandidate>());
   ME["genMuon_size"]->Fill(genMuons.size());
   LogDebug("HLTriggerOfflineHeavyFlavor")<<"GenParticleCollection from "<<genParticlesTag<<" has size: "<<genMuons.size()<<endl;
-  
+
   vector<LeafCandidate> globMuons;
   vector<LeafCandidate> globMuons_position;
   Handle<MuonCollection> recoMuonsHandle;
@@ -324,9 +323,9 @@ void HeavyFlavorValidation::analyze(const Event& iEvent, const EventSetup& iSetu
   ME["globMuon_size"]->Fill(globMuons.size());
   LogDebug("HLTriggerOfflineHeavyFlavor")<<"Global Muons from "<<recoMuonsTag<<" has size: "<<globMuons.size()<<endl;
 
-// access RAW trigger event  
+// access RAW trigger event
   vector<vector<LeafCandidate> > muonsAtFilter;
-  vector<vector<LeafCandidate> > muonPositionsAtFilter;  
+  vector<vector<LeafCandidate> > muonPositionsAtFilter;
   for(size_t i=0; i<filterNamesLevels.size(); i++){
     muonsAtFilter.push_back(vector<LeafCandidate>());
     muonPositionsAtFilter.push_back(vector<LeafCandidate>());
@@ -344,7 +343,7 @@ void HeavyFlavorValidation::analyze(const Event& iEvent, const EventSetup& iSetu
             muonsAtFilter[i].push_back(*l1Cands[j]);
           }
         }else{
-          vector<RecoChargedCandidateRef> hltCands;        
+          vector<RecoChargedCandidateRef> hltCands;
           rawTriggerEvent->getObjects( index, TriggerMuon, hltCands );
           for(size_t j=0; j<hltCands.size(); j++){
             muonsAtFilter[i].push_back(*hltCands[j]);
@@ -361,13 +360,13 @@ void HeavyFlavorValidation::analyze(const Event& iEvent, const EventSetup& iSetu
     LogDebug("HLTriggerOfflineHeavyFlavor")<<"Could not access RAWTriggerEvent"<<endl;
   }
 
-// access AOD trigger event  
+// access AOD trigger event
   vector<LeafCandidate> pathMuons;
   Handle<TriggerEvent> aodTriggerEvent;
   iEvent.getByToken(triggerSummaryAODTag,aodTriggerEvent);
   if(aodTriggerEvent.isValid()){
     TriggerObjectCollection allObjects = aodTriggerEvent->getObjects();
-    for(int i=0; i<aodTriggerEvent->sizeFilters(); i++){         
+    for(int i=0; i<aodTriggerEvent->sizeFilters(); i++){
      if(aodTriggerEvent->filterTag(i)==InputTag((filterNamesLevels.end()-1)->first,"",triggerProcessName)){
         Keys keys = aodTriggerEvent->filterKeys(i);
         for(size_t j=0; j<keys.size(); j++){
@@ -409,7 +408,7 @@ void HeavyFlavorValidation::analyze(const Event& iEvent, const EventSetup& iSetu
   match( ME["globGen_deltaEtaDeltaPhi"], genMuons, globMuons, genGlobDeltaRMatchingCut, glob_gen );
   vector<vector<int> > filt_glob;
   for(size_t i=0; i<filterNamesLevels.size(); i++){
-    filt_glob.push_back( vector<int>(globMuons.size(),-1) );            
+    filt_glob.push_back( vector<int>(globMuons.size(),-1) );
     if( filterNamesLevels[i].second == 1 ){
       match( ME[TString::Format("filt%dGlob_deltaEtaDeltaPhi",int(i+1))], globMuons_position, muonsAtFilter[i] ,globL1DeltaRMatchingCut, filt_glob[i] );
     }else if( filterNamesLevels[i].second == 2 ){
@@ -426,33 +425,33 @@ void HeavyFlavorValidation::analyze(const Event& iEvent, const EventSetup& iSetu
   }else if( (filterNamesLevels.end()-1)->second > 2){
     match( ME["pathGlob_deltaEtaDeltaPhi"], globMuons, pathMuons ,globL3DeltaRMatchingCut, path_glob );
   }
-    
+
 //fill histos
   bool first = true;
-  for(size_t i=0; i<genMuons.size(); i++){ 
+  for(size_t i=0; i<genMuons.size(); i++){
     ME["genMuon_genEtaPt"]->Fill(genMuons[i].eta(), genMuons[i].pt());
     ME["genMuon_genEtaPhi"]->Fill(genMuons[i].eta(), genMuons[i].phi());
-    if(glob_gen[i] != -1) { 
+    if(glob_gen[i] != -1) {
       ME["resGlobGen_genEtaPt"]->Fill(genMuons[i].eta(), genMuons[i].pt(), (globMuons[glob_gen[i]].pt()-genMuons[i].pt())/genMuons[i].pt() );
       ME["globMuon_genEtaPt"]->Fill(genMuons[i].eta(), genMuons[i].pt());
       ME["globMuon_genEtaPhi"]->Fill(genMuons[i].eta(), genMuons[i].phi());
       ME["globMuon_recoEtaPt"]->Fill(globMuons[glob_gen[i]].eta(), globMuons[glob_gen[i]].pt());
       ME["globMuon_recoEtaPhi"]->Fill(globMuons[glob_gen[i]].eta(), globMuons[glob_gen[i]].phi());
-      for(size_t f=0; f<filterNamesLevels.size(); f++) { 
-        if(filt_glob[f][glob_gen[i]] != -1) { 
+      for(size_t f=0; f<filterNamesLevels.size(); f++) {
+        if(filt_glob[f][glob_gen[i]] != -1) {
           ME[TString::Format("resFilt%dGlob_recoEtaPt",int(f+1))]->Fill(globMuons[glob_gen[i]].eta(), globMuons[glob_gen[i]].pt(), (muonsAtFilter[f][filt_glob[f][glob_gen[i]]].pt()-globMuons[glob_gen[i]].pt())/globMuons[glob_gen[i]].pt() );
           ME[TString::Format("filt%dMuon_recoEtaPt",int(f+1))]->Fill(globMuons[glob_gen[i]].eta(), globMuons[glob_gen[i]].pt());
           ME[TString::Format("filt%dMuon_recoEtaPhi",int(f+1))]->Fill(globMuons[glob_gen[i]].eta(), globMuons[glob_gen[i]].phi());
         }else{
           break;
-        }  
+        }
       }
       if(path_glob[glob_gen[i]] != -1){
         ME["resPathGlob_recoEtaPt"]->Fill(globMuons[glob_gen[i]].eta(), globMuons[glob_gen[i]].pt(), (pathMuons[path_glob[glob_gen[i]]].pt()-globMuons[glob_gen[i]].pt())/globMuons[glob_gen[i]].pt() );
         ME["pathMuon_recoEtaPt"]->Fill(globMuons[glob_gen[i]].eta(), globMuons[glob_gen[i]].pt());
         ME["pathMuon_recoEtaPhi"]->Fill(globMuons[glob_gen[i]].eta(), globMuons[glob_gen[i]].phi());
       }
-//highest pt muon      
+//highest pt muon
       if( first ){
         first = false;
         if( triggerFired ){
@@ -460,10 +459,10 @@ void HeavyFlavorValidation::analyze(const Event& iEvent, const EventSetup& iSetu
           ME["resultMuon_recoEtaPhi"]->Fill(globMuons[glob_gen[i]].eta(), globMuons[glob_gen[i]].phi());
         }
       }
-    } 
-  }  
- 
-//fill dimuon histograms (highest pT, opposite charge) 
+    }
+  }
+
+//fill dimuon histograms (highest pT, opposite charge)
   int secondMuon = 0;
   for(size_t j=1; j<genMuons.size(); j++){
     if(genMuons[0].charge()*genMuons[j].charge()==-1){
@@ -495,7 +494,7 @@ void HeavyFlavorValidation::analyze(const Event& iEvent, const EventSetup& iSetu
       ME["globDimuon_recoRapPt"]->Fill( globDimuonRap, globDimuonPt );
       if(highPt) ME["globDimuon_recoPtDR"]->Fill( globDimuonPt, globDimuonDR );
       if(highPt) ME["globDimuon_recoPtDRpos"]->Fill( globDimuonPt, globDimuonDRpos );
-//two filter objects    
+//two filter objects
       for(size_t f=0; f<filterNamesLevels.size(); f++){
         if(filt_glob[f][glob_gen[0]] != -1 && filt_glob[f][glob_gen[secondMuon]] != -1){
           ME[TString::Format("diFilt%dDimuon_recoEtaPt",int(f+1))]->Fill( globDimuonEta, globDimuonPt );
@@ -504,8 +503,8 @@ void HeavyFlavorValidation::analyze(const Event& iEvent, const EventSetup& iSetu
           if(highPt) ME[TString::Format("diFilt%dDimuon_recoPtDRpos",int(f+1))]->Fill( globDimuonPt, globDimuonDRpos );
         }else{
           break;
-        }  
-      } 
+        }
+      }
 //one filter object
       for(size_t f=0; f<filterNamesLevels.size(); f++){
         if(filt_glob[f][glob_gen[0]] != -1 || filt_glob[f][glob_gen[secondMuon]] != -1){
@@ -647,6 +646,72 @@ void HeavyFlavorValidation::myBook1D(DQMStore::IBooker & ibooker, TString name, 
   h->SetTitle(title);
   ME[name] = ibooker.book1D( name.Data(), h );
   delete h;
+}
+
+int HeavyFlavorValidation::getFilterLevel(const std::string &moduleName, const HLTConfigProvider &hltConfig)
+{
+  // helper lambda to check if a string contains a substring
+  const auto contains = [](const std::string &s, const std::string &sub) -> bool {
+    return s.find(sub) != std::string::npos;
+  };
+
+  // helper lambda to check if a string contains any of a list of substrings
+  const auto containsAny = [](const std::string &s, const std::vector<std::string> &subs) -> bool {
+    for (const auto &sub : subs) {
+      if (s.find(sub) != std::string::npos) return true;
+    }
+    return false;
+  };
+
+  // helper lambda to check if string s is any of the strings in vector ms
+  // using an initializer_list of char*, because std::sting has no constexpr constructor
+  const auto isAnyOf = [](const std::string &s, const std::initializer_list<const char* const>& ms) -> bool {
+    for (const auto &m : ms) {
+      if (s == m) return true;
+    }
+    return false;
+  };
+
+  // tmadlener, 20.08.2017:
+  // define the valid module names for the different "levels", to add a little bit more stability
+  // to the checking compared to just doing some name matching.
+  // Note, that the name matching is not completely remved, since at level 4 and 5 some of the
+  // valid modules are the same, so that the name matching is still needed.
+  // With the current definition this yields the exact same levels as before, but weeds out some
+  // of the "false" positives at level 3 (naming matches also to some HLTMuonL1TFilter modules due to
+  // the 'forIterL3' in the name)
+  constexpr auto l1Filter = "HLTMuonL1TFilter";
+  constexpr auto l2Filter = "HLTMuonL2FromL1TPreFilter";
+  constexpr auto l3Filters = {"HLTMuonDimuonL3Filter", "HLTMuonL3PreFilter"};
+  constexpr auto l4Filters = {"HLTDisplacedmumuFilter", "HLTDiMuonGlbTrkFilter",
+                              "HLTMuonTrackMassFilter"};
+  constexpr auto l5Filters = {"HLTmumutkFilter", "HLT2MuonMuonDZ", "HLTDisplacedmumuFilter"};
+
+  if (contains(moduleName, "Filter") && hltConfig.moduleEDMType(moduleName) == "EDFilter") {
+    int level = -1; // if we get here, one of the following clauses should always catch!
+    if (contains(moduleName, "L1") && !contains(moduleName, "ForIterL3") &&
+        hltConfig.moduleType(moduleName) == l1Filter) {
+      level = 1;
+    }
+    if (contains(moduleName, "L2") && hltConfig.moduleType(moduleName) == l2Filter) {
+      level = 2;
+    }
+    if (contains(moduleName, "L3") && isAnyOf(hltConfig.moduleType(moduleName), l3Filters)) {
+      level = 3;
+    }
+    if (containsAny(moduleName, {"mumuFilter", "DiMuon", "MuonL3Filtered", "TrackMassFiltered"}) &&
+        isAnyOf(hltConfig.moduleType(moduleName), l4Filters)) {
+      level = 4;
+    }
+    if (containsAny(moduleName, {"Vertex", "Dz"}) &&
+        isAnyOf(hltConfig.moduleType(moduleName), l5Filters)) {
+      level = 5;
+    }
+
+    return level;
+  }
+
+  return -1;
 }
 
 HeavyFlavorValidation::~HeavyFlavorValidation(){

--- a/HLTriggerOffline/HeavyFlavor/src/HeavyFlavorValidation.cc
+++ b/HLTriggerOffline/HeavyFlavor/src/HeavyFlavorValidation.cc
@@ -54,11 +54,11 @@ using namespace trigger;
 class HeavyFlavorValidation : public DQMEDAnalyzer {
   public:
     explicit HeavyFlavorValidation(const edm::ParameterSet&);
-    ~HeavyFlavorValidation();
+    ~HeavyFlavorValidation() override;
   protected:
     void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
     void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
   private:
     int getMotherId( const Candidate * p );
     void match( MonitorElement * me, vector<LeafCandidate> & from, vector<LeafCandidate> & to, double deltaRMatchingCut, vector<int> & map );
@@ -173,7 +173,7 @@ void HeavyFlavorValidation::dqmBeginRun(const edm::Run& iRun, const edm::EventSe
 		}
 	}
 
-	if(filterNamesLevels.size()==0){
+	if(filterNamesLevels.empty()){
 		LogDebug("HLTriggerOfflineHeavyFlavor")<<"Bad Trigger Path: "<<triggerPathName<<endl;
 		return;
 	}else{
@@ -285,7 +285,7 @@ void HeavyFlavorValidation::bookHistograms(DQMStore::IBooker & ibooker,
 }
 
 void HeavyFlavorValidation::analyze(const Event& iEvent, const EventSetup& iSetup){
-  if(filterNamesLevels.size()==0){
+  if(filterNamesLevels.empty()){
     return;
   }
 //access the containers and create LeafCandidate copies

--- a/HLTriggerOffline/HeavyFlavor/src/HeavyFlavorValidation.cc
+++ b/HLTriggerOffline/HeavyFlavor/src/HeavyFlavorValidation.cc
@@ -664,8 +664,7 @@ int HeavyFlavorValidation::getFilterLevel(const std::string &moduleName, const H
   };
 
   // helper lambda to check if string s is any of the strings in vector ms
-  // using an initializer_list of char*, because std::sting has no constexpr constructor
-  const auto isAnyOf = [](const std::string &s, const std::initializer_list<const char* const>& ms) -> bool {
+  const auto isAnyOf = [](const std::string &s, const std::vector<std::string>& ms) -> bool {
     for (const auto &m : ms) {
       if (s == m) return true;
     }
@@ -680,12 +679,12 @@ int HeavyFlavorValidation::getFilterLevel(const std::string &moduleName, const H
   // With the current definition this yields the exact same levels as before, but weeds out some
   // of the "false" positives at level 3 (naming matches also to some HLTMuonL1TFilter modules due to
   // the 'forIterL3' in the name)
-  constexpr auto l1Filter = "HLTMuonL1TFilter";
-  constexpr auto l2Filter = "HLTMuonL2FromL1TPreFilter";
-  constexpr auto l3Filters = {"HLTMuonDimuonL3Filter", "HLTMuonL3PreFilter"};
-  constexpr auto l4Filters = {"HLTDisplacedmumuFilter", "HLTDiMuonGlbTrkFilter",
+  const std::string l1Filter = "HLTMuonL1TFilter";
+  const std::string l2Filter = "HLTMuonL2FromL1TPreFilter";
+  const std::vector<std::string> l3Filters = {"HLTMuonDimuonL3Filter", "HLTMuonL3PreFilter"};
+  const std::vector<std::string> l4Filters = {"HLTDisplacedmumuFilter", "HLTDiMuonGlbTrkFilter",
                               "HLTMuonTrackMassFilter"};
-  constexpr auto l5Filters = {"HLTmumutkFilter", "HLT2MuonMuonDZ", "HLTDisplacedmumuFilter"};
+  const std::vector<std::string> l5Filters = {"HLTmumutkFilter", "HLT2MuonMuonDZ", "HLTDisplacedmumuFilter"};
 
   if (contains(moduleName, "Filter") && hltConfig.moduleEDMType(moduleName) == "EDFilter") {
     int level = -1; // if we get here, one of the following clauses should always catch!

--- a/HLTriggerOffline/HeavyFlavor/src/HeavyFlavorValidation.cc
+++ b/HLTriggerOffline/HeavyFlavor/src/HeavyFlavorValidation.cc
@@ -177,9 +177,10 @@ void HeavyFlavorValidation::dqmBeginRun(const edm::Run& iRun, const edm::EventSe
 		LogDebug("HLTriggerOfflineHeavyFlavor")<<"Bad Trigger Path: "<<triggerPathName<<endl;
 		return;
 	}else{
-          	stringstream os;
-                for (const auto &filters : filterNamesLevels) os << " " << filters.first;
-		LogDebug("HLTriggerOfflineHeavyFlavor")<<"Trigger Path: "<<triggerPathName<<" has filters:"<<os.str();
+                std::string str;
+                str.reserve(512); // avoid too many realloctions in the following loop (allows for filter names with roughly 100 chars each)
+                for (const auto &filters : filterNamesLevels) str = str + " " + filters.first;
+		LogDebug("HLTriggerOfflineHeavyFlavor")<<"Trigger Path: "<<triggerPathName<<" has filters:"<<str;
 	}
 }
 
@@ -687,27 +688,24 @@ int HeavyFlavorValidation::getFilterLevel(const std::string &moduleName, const H
   const std::vector<std::string> l5Filters = {"HLTmumutkFilter", "HLT2MuonMuonDZ", "HLTDisplacedmumuFilter"};
 
   if (contains(moduleName, "Filter") && hltConfig.moduleEDMType(moduleName) == "EDFilter") {
-    int level = -1; // if we get here, one of the following clauses should always catch!
     if (contains(moduleName, "L1") && !contains(moduleName, "ForIterL3") &&
         hltConfig.moduleType(moduleName) == l1Filter) {
-      level = 1;
+      return 1;
     }
     if (contains(moduleName, "L2") && hltConfig.moduleType(moduleName) == l2Filter) {
-      level = 2;
+      return 2;
     }
     if (contains(moduleName, "L3") && isAnyOf(hltConfig.moduleType(moduleName), l3Filters)) {
-      level = 3;
+      return 3;
     }
-    if (containsAny(moduleName, {"mumuFilter", "DiMuon", "MuonL3Filtered", "TrackMassFiltered"}) &&
+    if (containsAny(moduleName, {"DisplacedmumuFilter", "DiMuon", "MuonL3Filtered", "TrackMassFiltered"}) &&
         isAnyOf(hltConfig.moduleType(moduleName), l4Filters)) {
-      level = 4;
+      return 4;
     }
     if (containsAny(moduleName, {"Vertex", "Dz"}) &&
         isAnyOf(hltConfig.moduleType(moduleName), l5Filters)) {
-      level = 5;
+      return 5;
     }
-
-    return level;
   }
 
   return -1;


### PR DESCRIPTION
backport of #20520 

Necessary updates to have meaningful/filled validation plots again for the HeavyFlavor validation package (used by BPH for RelVal):

- Update the trigger paths to the 2017 HLT menu. Where possible the paths from 2016 have been updated to their 2017 version. Some paths don't have a 2017 version. These have been removed.
- Refactored the assignment of filter levels to the different filters (based on the filter name) to make it more stable and to get rid of newly introduced duplicates due to the IterL3 modules in the paths.