### PR TITLE
Allow gridpack execution to override runtime environment also for legacy gridpacks [93x]

### DIFF
--- a/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh
+++ b/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh
@@ -47,8 +47,6 @@ LHEWORKDIR=`pwd`
 
 if [ "$use_gridpack_env" = false -a -n "$scram_arch_version" -a -n  "$cmssw_version" ]; then
   echo "%MSG-MG5 CMSSW version = $cmssw_version"
-  export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
-  source $VO_CMS_SW_DIR/cmsset_default.sh
   export SCRAM_ARCH=${scram_arch_version}
   scramv1 project CMSSW ${cmssw_version}
   cd ${cmssw_version}/src

--- a/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh
+++ b/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh
@@ -26,9 +26,35 @@ echo "%MSG-MG5 random seed used for the run = $rnum"
 ncpu=${4}
 echo "%MSG-MG5 thread count requested = $ncpu"
 
-echo "%MSG-MG5 residual arguments = ${@:5}"
+echo "%MSG-MG5 residual/optional arguments = ${@:5}"
+
+if [ -n "${5}" ]; then
+  use_gridpack_env=${5}
+  echo "%MSG-MG5 use_gridpack_env = $use_gridpack_env"
+fi
+
+if [ -n "${6}" ]; then
+  scram_arch_version=${6}
+  echo "%MSG-MG5 override scram_arch_version = $scram_arch_version"
+fi
+
+if [ -n "${7}" ]; then
+  cmssw_version=${7}
+  echo "%MSG-MG5 override cmssw_version = $cmssw_version"
+fi
 
 LHEWORKDIR=`pwd`
+
+if [ "$use_gridpack_env" = false -a -n "$scram_arch_version" -a -n  "$cmssw_version" ]; then
+  echo "%MSG-MG5 CMSSW version = $cmssw_version"
+  export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
+  source $VO_CMS_SW_DIR/cmsset_default.sh
+  export SCRAM_ARCH=${scram_arch_version}
+  scramv1 project CMSSW ${cmssw_version}
+  cd ${cmssw_version}/src
+  eval `scramv1 runtime -sh`
+  cd $LHEWORKDIR
+fi
 
 if [[ -d lheevent ]]
     then


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmssw/pull/20676

This is needed in order to allow reuse of existing gridpacks from PhaseIISummer17wmLHEGENOnly campaign (CMSSW_9_1_2_patch1 slc6_amd64_gcc530) in HGCal tdr campaign (PhaseIITDRFall17wmLHEGS slc6_amd64_gcc630) since remaking them would be a large effort and there are no other changes to the contents needed.