### PR TITLE
Phase1 pixel validation cluster loop fix

### DIFF
--- a/Validation/SiPixelPhase1TrackClustersV/python/SiPixelPhase1TrackClustersV_cfi.py
+++ b/Validation/SiPixelPhase1TrackClustersV/python/SiPixelPhase1TrackClustersV_cfi.py
@@ -5,8 +5,8 @@ from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
 SiPixelPhase1TrackClustersCharge = DefaultHisto.clone(
   name = "charge",
   title = "Corrected Cluster Charge",
-  range_min = 0, range_max = 100, range_nbins = 200,
-  xlabel = "Charge size (in ke)",
+  range_min = 0, range_max = 200e3, range_nbins = 200,
+  xlabel = "Charge size",
   topFolderName = "PixelPhase1V/Clusters",
   specs = VPSet(
     Specification().groupBy("PXBarrel/PXLayer").save(),


### PR DESCRIPTION
Fixed issue mentioned in: https://github.com/cms-sw/cmssw/pull/19403#discussion_r141295332
The cluster quantity loop used to be inside a track loop, as originally on- and off-track clusters were plotted separately. As this distinction is no longer required, the loop is no longer needed - removal will reduce resource usage.
Also, only the cluster charge is plotted now, as the "corrected" charge requires track parameter information and the former ought to be sufficient for validation purposes.

@fioriNTU, @boudoul and @slava77 will be interested in this.