### PR TITLE
Fix comp warnings from RecoParticleFlow/PFProducer & DataFormats HcalDigi/ 

### DIFF
--- a/DataFormats/HcalDigi/src/QIE10DataFrame.cc
+++ b/DataFormats/HcalDigi/src/QIE10DataFrame.cc
@@ -43,7 +43,7 @@ QIE10DataFrame::Sample::Sample(const wide_type wide) {
 QIE10DataFrame::Sample::wide_type QIE10DataFrame::Sample::wideRaw() const {
   static_assert(sizeof(QIE10DataFrame::Sample::wide_type) == 2*sizeof(word1_),
                 "The wide result type must be able to contain two words");
-  wide_type result;
+  wide_type result = 0;
   edm::DataFrame::data_type* ptr =
       reinterpret_cast<edm::DataFrame::data_type*>(&result);
   ptr[0] = word1_;

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -572,7 +572,7 @@ namespace {
 				       matched_pfcs.end()));	
       }
       for( const auto& clelem : best_comb ) {
-	const reco::PFClusterRef& clref = clelem->clusterRef();
+	//const reco::PFClusterRef& clref = clelem->clusterRef();
 	if( std::find(cluster_list.begin(),cluster_list.end(),clelem) ==
 	    cluster_list.end() ) {
 	  cluster_list.push_back(clelem);


### PR DESCRIPTION
Removing unused var and initializing a uint32_t var to 0 to dispose of comp warnings for gcc7 builds
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_aarch64_gcc700/CMSSW_9_4_X_2017-09-27-2300/RecoTauTag/HLTProducers and here https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_4_X_2017-09-27-2300/DataFormats/HcalDigi