### PR TITLE
add PU vs LS

### DIFF
--- a/DQM/HLTEvF/plugins/LumiMonitor.cc
+++ b/DQM/HLTEvF/plugins/LumiMonitor.cc
@@ -51,8 +51,8 @@ MEbinning LumiMonitor::getHistoLSPSet(edm::ParameterSet pset)
 {
   return MEbinning{
     pset.getParameter<int32_t>("nbins"),
-      0.,
-      double(pset.getParameter<int32_t>("nbins"))
+      -0.5,
+      double(pset.getParameter<int32_t>("nbins")-0.5)
       };
 }
 

--- a/DQM/HLTEvF/plugins/LumiMonitor.cc
+++ b/DQM/HLTEvF/plugins/LumiMonitor.cc
@@ -64,7 +64,7 @@ void LumiMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
   std::string histname, histtitle;
 
   std::string currentFolder = folderName_ ;
-  ibooker.setCurrentFolder(currentFolder.c_str());
+  ibooker.setCurrentFolder(currentFolder);
 
   if ( doPixelLumi_ ) {
     histname = "numberOfPixelClustersVsLS"; histtitle = "number of pixel clusters vs LS";
@@ -128,7 +128,7 @@ void LumiMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetu
   float scal_pu   = -1.;
   edm::Handle<LumiScalersCollection> lumiScalers;
   iEvent.getByToken(lumiScalersToken_, lumiScalers);
-  if ( lumiScalers.isValid() && lumiScalers->size() ) {
+  if ( lumiScalers.isValid() && !lumiScalers->empty() ) {
     LumiScalersCollection::const_iterator scalit = lumiScalers->begin();
     scal_lumi = scalit->instantLumi();
     scal_pu   = scalit->pileup();

--- a/DQM/HLTEvF/plugins/LumiMonitor.cc
+++ b/DQM/HLTEvF/plugins/LumiMonitor.cc
@@ -13,6 +13,7 @@ LumiMonitor::LumiMonitor( const edm::ParameterSet& iConfig ) :
   folderName_             ( iConfig.getParameter<std::string>("FolderName") )
   , lumiScalersToken_     ( consumes<LumiScalersCollection>(iConfig.getParameter<edm::InputTag>("scalers") ) ) 
   , lumi_binning_         ( getHistoPSet  (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("lumiPSet"))         )
+  , pu_binning_           ( getHistoPSet  (iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("puPSet"))           )
   , ls_binning_           ( getHistoLSPSet(iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("lsPSet"))           )
   , doPixelLumi_          ( iConfig.getParameter<bool>("doPixelLumi") )
   , pixelClustersToken_           ( doPixelLumi_ ? consumes<edmNew::DetSetVector<SiPixelCluster> >(iConfig.getParameter<edm::InputTag>("pixelClusters") ) : edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> () )
@@ -26,6 +27,7 @@ LumiMonitor::LumiMonitor( const edm::ParameterSet& iConfig ) :
   numberOfPixelClustersVsLS_   = nullptr;
   numberOfPixelClustersVsLumi_ = nullptr;
   lumiVsLS_                    = nullptr;
+  puVsLS_                      = nullptr;
   pixelLumiVsLS_               = nullptr;
   pixelLumiVsLumi_             = nullptr;
 
@@ -103,6 +105,14 @@ void LumiMonitor::bookHistograms(DQMStore::IBooker     & ibooker,
   lumiVsLS_->setAxisTitle("LS",1);
   lumiVsLS_->setAxisTitle("scal inst lumi E30 [Hz cm^{-2}]",2);
 
+  histname = "puVsLS"; histtitle = "scal PU vs LS";
+  puVsLS_ = ibooker.bookProfile(histname, histtitle, 
+				  ls_binning_.nbins, ls_binning_.xmin, ls_binning_.xmax,
+				  pu_binning_.xmin, pu_binning_.xmax);
+  //  puVsLS_->getTH1()->SetCanExtend(TH1::kAllAxes);
+  puVsLS_->setAxisTitle("LS",1);
+  puVsLS_->setAxisTitle("scal PU",2);
+
 }
 
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -115,15 +125,19 @@ void LumiMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetu
   int ls = iEvent.id().luminosityBlock();
 
   float scal_lumi = -1.;
+  float scal_pu   = -1.;
   edm::Handle<LumiScalersCollection> lumiScalers;
   iEvent.getByToken(lumiScalersToken_, lumiScalers);
   if ( lumiScalers.isValid() && lumiScalers->size() ) {
     LumiScalersCollection::const_iterator scalit = lumiScalers->begin();
     scal_lumi = scalit->instantLumi();
+    scal_pu   = scalit->pileup();
   } else {
     scal_lumi = -1.;
+    scal_pu   = -1.;
   }
   lumiVsLS_ -> Fill(ls, scal_lumi);
+  puVsLS_   -> Fill(ls, scal_pu  );
 
   if ( doPixelLumi_ ) {
     size_t pixel_clusters = 0;
@@ -200,6 +214,10 @@ void LumiMonitor::fillDescriptions(edm::ConfigurationDescriptions & descriptions
   edm::ParameterSetDescription lumiPSet;
   fillHistoPSetDescription(lumiPSet);
   histoPSet.add<edm::ParameterSetDescription>("lumiPSet", lumiPSet);
+
+  edm::ParameterSetDescription puPSet;
+  fillHistoPSetDescription(puPSet);
+  histoPSet.add<edm::ParameterSetDescription>("puPSet", puPSet);
 
   edm::ParameterSetDescription pixellumiPSet;
   fillHistoPSetDescription(pixellumiPSet);

--- a/DQM/HLTEvF/plugins/LumiMonitor.h
+++ b/DQM/HLTEvF/plugins/LumiMonitor.h
@@ -41,7 +41,7 @@ class LumiMonitor : public DQMEDAnalyzer
 {
 public:
   LumiMonitor( const edm::ParameterSet& );
-  ~LumiMonitor() = default;
+  ~LumiMonitor() override = default;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
   static void fillHistoPSetDescription(edm::ParameterSetDescription & pset);
   static void fillHistoLSPSetDescription(edm::ParameterSetDescription & pset);

--- a/DQM/HLTEvF/plugins/LumiMonitor.h
+++ b/DQM/HLTEvF/plugins/LumiMonitor.h
@@ -60,6 +60,7 @@ private:
 
   edm::EDGetTokenT<LumiScalersCollection> lumiScalersToken_;
   MEbinning lumi_binning_;
+  MEbinning pu_binning_;
   MEbinning ls_binning_;
 
   bool  doPixelLumi_;
@@ -76,6 +77,7 @@ private:
   MonitorElement* numberOfPixelClustersVsLS_;
   MonitorElement* numberOfPixelClustersVsLumi_;
   MonitorElement* lumiVsLS_;
+  MonitorElement* puVsLS_;
   MonitorElement* pixelLumiVsLS_;
   MonitorElement* pixelLumiVsLumi_;
 

--- a/DQM/HLTEvF/python/LumiMonitor_cff.py
+++ b/DQM/HLTEvF/python/LumiMonitor_cff.py
@@ -19,6 +19,11 @@ lumiMonitor = cms.EDAnalyzer("LumiMonitor",
             xmin  = cms.double( 3000.),
             xmax  = cms.double(12000.),
       ),
+      puPSet                      = cms.PSet(
+            nbins = cms.int32 (260 ),
+            xmin  = cms.double(  0.),
+            xmax  = cms.double(130.),
+      ),
       pixellumiPSet               = cms.PSet(
             nbins = cms.int32 (300 ),
             xmin  = cms.double(  0.),

--- a/DQM/TrackingMonitor/python/MonitorTrackInnerTrackMuons_cff.py
+++ b/DQM/TrackingMonitor/python/MonitorTrackInnerTrackMuons_cff.py
@@ -44,4 +44,4 @@ MonitorTrackMuonsInnerTrack.doEffFromHitPatternVsPU = True
 MonitorTrackMuonsInnerTrack.doEffFromHitPatternVsBX = False
 
 #MonitorTrackINNMuons = cms.Sequence(muonInnerTrack+MonitorTrackMuonsInnerTrack)
-MonitorTrackINNMuons = cms.Sequence(muonsPt10+muonInnerTrack+MonitorTrackMuonsInnerTrack)
+MonitorTrackINNMuons = cms.Sequence(cms.ignore(muonsPt10)+muonInnerTrack+MonitorTrackMuonsInnerTrack)

--- a/DQMOffline/Trigger/python/DQMOffline_LumiMontiroring_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_LumiMontiroring_cff.py
@@ -4,33 +4,42 @@ import FWCore.ParameterSet.Config as cms
 #hltScalersRawToDigi4DQM = cms.EDProducer( "ScalersRawToDigi",
 #    scalersInputTag = cms.InputTag( "rawDataCollector" )
 #)
-hltLumiMonitor = cms.EDAnalyzer( "LumiMonitor",
-    useBPixLayer1 = cms.bool( False ),
-    minPixelClusterCharge = cms.double( 15000.0 ),
-    histoPSet = cms.PSet(
-      lsPSet = cms.PSet(  nbins = cms.int32( 2500 ) ),
-      pixelClusterPSet = cms.PSet(
-        nbins = cms.int32( 200 ),
-        xmin = cms.double( -0.5 ),
-        xmax = cms.double( 19999.5 )
-      ),
-      lumiPSet = cms.PSet(
-        nbins = cms.int32( 5000 ),
-        xmin = cms.double( 0.0 ),
-        xmax = cms.double( 20000.0 )
-      ),
-      pixellumiPSet = cms.PSet(
-        nbins = cms.int32( 300 ),
-        xmin = cms.double( 0.0 ),
-        xmax = cms.double( 3.0 )
-      )
+
+from DQM.HLTEvF.lumiMonitor_cfi import lumiMonitor
+
+hltLumiMonitor = lumiMonitor.clone()
+hltLumiMonitor.useBPixLayer1 = cms.bool( False )
+hltLumiMonitor.minPixelClusterCharge = cms.double( 15000.0 )
+hltLumiMonitor.histoPSet = cms.PSet(
+    lsPSet = cms.PSet(  
+      nbins = cms.int32( 2500 ) 
     ),
-    minNumberOfPixelsPerCluster = cms.int32( 2 ),
-    FolderName = cms.string( "HLT/LumiMonitoring" ),
-    scalers = cms.InputTag( "scalersRawToDigi" ),
-    pixelClusters = cms.InputTag( "hltSiPixelClusters" ),
-    doPixelLumi = cms.bool( False )
+    pixelClusterPSet = cms.PSet(
+      nbins = cms.int32( 200 ),
+      xmin = cms.double( -0.5 ),
+      xmax = cms.double( 19999.5 )
+    ),
+    puPSet = cms.PSet(
+      nbins = cms.int32( 130  ),
+      xmin = cms.double(   0. ),
+      xmax = cms.double( 130. )
+    ),
+    lumiPSet = cms.PSet(
+      nbins = cms.int32(   440 ),
+      xmin = cms.double(     0.0 ),
+      xmax = cms.double( 22000.0 )
+    ),
+    pixellumiPSet = cms.PSet(
+      nbins = cms.int32( 300 ),
+      xmin = cms.double( 0.0 ),
+      xmax = cms.double( 3.0 )
+    )
 )
+hltLumiMonitor.minNumberOfPixelsPerCluster = cms.int32( 2 )
+hltLumiMonitor.FolderName = cms.string( "HLT/LumiMonitoring" )
+hltLumiMonitor.scalers = cms.InputTag( "scalersRawToDigi" )
+hltLumiMonitor.pixelClusters = cms.InputTag( "hltSiPixelClusters" )
+hltLumiMonitor.doPixelLumi = cms.bool( False )
 
 lumiMonitorHLTsequence = cms.Sequence(
 #    hltScalersRawToDigi4DQM +

--- a/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
+++ b/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
@@ -38,6 +38,7 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
   static void fillLumiMePSetDescription(edm::ParameterSetDescription & pset);
+  static void fillPUMePSetDescription(edm::ParameterSetDescription & pset);
 
 private:
   std::string m_dqm_path;
@@ -54,9 +55,11 @@ private:
 
   bool doPlotsVsScalLumi_;
   bool doPlotsVsPixelLumi_;
+  bool doPlotsVsPU_;
 
   MEPSet scalLumiMEPSet_;
   MEPSet pixelLumiMEPSet_;
+  MEPSet puMEPSet_;
 
 };
 
@@ -65,8 +68,10 @@ FastTimerServiceClient::FastTimerServiceClient(edm::ParameterSet const & config)
   m_dqm_path( config.getUntrackedParameter<std::string>( "dqmPath" ) )
   , doPlotsVsScalLumi_ ( config.getParameter<bool>( "doPlotsVsScalLumi" )  )
   , doPlotsVsPixelLumi_( config.getParameter<bool>( "doPlotsVsPixelLumi" ) )
-  , scalLumiMEPSet_ ( doPlotsVsScalLumi_ ? getHistoPSet(config.getParameter<edm::ParameterSet>("scalLumiME")) : MEPSet{}  )
+  , doPlotsVsPU_       ( config.getParameter<bool>( "doPlotsVsPU" )        )
+  , scalLumiMEPSet_ ( doPlotsVsScalLumi_  ? getHistoPSet(config.getParameter<edm::ParameterSet>("scalLumiME") ) : MEPSet{} )
   , pixelLumiMEPSet_( doPlotsVsPixelLumi_ ? getHistoPSet(config.getParameter<edm::ParameterSet>("pixelLumiME")) : MEPSet{} )
+  , puMEPSet_       ( doPlotsVsPU_        ? getHistoPSet(config.getParameter<edm::ParameterSet>("puME")   ) : MEPSet{} )
 {
 }
 
@@ -131,6 +136,8 @@ FastTimerServiceClient::fillProcessSummaryPlots(DQMStore::IBooker & booker, DQMS
     fillPlotsVsLumi( booker,getter, current_path, "VsScalLumi", scalLumiMEPSet_ );
   if ( doPlotsVsPixelLumi_ )
     fillPlotsVsLumi( booker,getter, current_path, "VsPixelLumi", pixelLumiMEPSet_ );
+  if ( doPlotsVsPU_ )
+    fillPlotsVsLumi( booker,getter, current_path, "VsPU", puMEPSet_ );
 
   //  getter.setCurrentFolder(current_path);
 
@@ -347,6 +354,8 @@ FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker & booker, DQMStor
       fillPlotsVsLumi( booker,getter, subsubdir, "VsScalLumi", scalLumiMEPSet_ );
     if ( doPlotsVsPixelLumi_ )
       fillPlotsVsLumi( booker,getter, subsubdir, "VsPixelLumi", pixelLumiMEPSet_ );
+    if ( doPlotsVsPU_ )
+      fillPlotsVsLumi( booker,getter, subsubdir, "VsPU", puMEPSet_ );
 
   }
 
@@ -379,7 +388,7 @@ FastTimerServiceClient::fillPlotsVsLumi(DQMStore::IBooker & booker, DQMStore::IG
   double      xmin   = pset.xmin;
   double      xmax   = pset.xmax;
 
-  // get lumi VS LS ME
+  // get lumi/PU VS LS ME
   getter.setCurrentFolder(folder);
   MonitorElement* lumiVsLS = getter.get(folder+"/"+name);
   // if no ME available, return
@@ -395,8 +404,8 @@ FastTimerServiceClient::fillPlotsVsLumi(DQMStore::IBooker & booker, DQMStore::IG
   std::vector<double> lumi;
   std::vector<int> LS;
   for ( size_t ibin=1; ibin <= size; ++ibin ) {
-    // avoid to store points w/ no info
-    if ( lumiVsLS->getTProfile()->GetBinContent(ibin) == 0. ) continue;
+    //    // avoid to store points w/ no info
+    //    if ( lumiVsLS->getTProfile()->GetBinContent(ibin) == 0. ) continue;
 
     lumi.push_back( lumiVsLS->getTProfile()->GetBinContent(ibin) );
     LS.push_back  ( lumiVsLS->getTProfile()->GetXaxis()->GetBinCenter(ibin) );
@@ -439,9 +448,19 @@ void
 FastTimerServiceClient::fillLumiMePSetDescription(edm::ParameterSetDescription & pset) {
   pset.add<std::string>("folder", "HLT/LumiMonitoring");
   pset.add<std::string>("name"  , "lumiVsLS");
-  pset.add<int>   ("nbins",  6500 );
+  pset.add<int>   ("nbins",   440 );
   pset.add<double>("xmin",      0.);
-  pset.add<double>("xmax",  13000.);
+  pset.add<double>("xmax",  22000.);
+}
+
+
+void 
+FastTimerServiceClient::fillPUMePSetDescription(edm::ParameterSetDescription & pset) {
+  pset.add<std::string>("folder", "HLT/LumiMonitoring");
+  pset.add<std::string>("name"  , "puVsLS");
+  pset.add<int>   ("nbins", 260 );
+  pset.add<double>("xmin",    0.);
+  pset.add<double>("xmax",  130.);
 }
 
 
@@ -464,6 +483,7 @@ FastTimerServiceClient::fillDescriptions(edm::ConfigurationDescriptions & descri
   desc.addUntracked<std::string>( "dqmPath", "HLT/TimerService");
   desc.add<bool>( "doPlotsVsScalLumi",  true  );
   desc.add<bool>( "doPlotsVsPixelLumi", false );
+  desc.add<bool>( "doPlotsVsPU",        true  );
 
   edm::ParameterSetDescription scalLumiMEPSet;
   fillLumiMePSetDescription(scalLumiMEPSet);
@@ -473,6 +493,10 @@ FastTimerServiceClient::fillDescriptions(edm::ConfigurationDescriptions & descri
   fillLumiMePSetDescription(pixelLumiMEPSet);
   desc.add<edm::ParameterSetDescription>("pixelLumiME", pixelLumiMEPSet);
 
+  edm::ParameterSetDescription puMEPSet;
+  fillPUMePSetDescription(puMEPSet);
+  desc.add<edm::ParameterSetDescription>("puME", puMEPSet);
+  
   descriptions.add("fastTimerServiceClient", desc);
 }
 

--- a/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
+++ b/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
@@ -34,7 +34,7 @@ struct MEPSet {
 class FastTimerServiceClient : public DQMEDHarvester {
 public:
   explicit FastTimerServiceClient(edm::ParameterSet const &);
-  ~FastTimerServiceClient();
+  ~FastTimerServiceClient() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
   static void fillLumiMePSetDescription(edm::ParameterSetDescription & pset);
@@ -128,7 +128,7 @@ void
 FastTimerServiceClient::fillProcessSummaryPlots(DQMStore::IBooker & booker, DQMStore::IGetter & getter, std::string const & current_path) {
 
   MonitorElement * me = getter.get(current_path + "/event time_real");
-  if (me == 0)
+  if (me == nullptr)
     // no FastTimerService DQM information
     return;
 
@@ -229,13 +229,13 @@ FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker & booker, DQMStor
 
     getter.setCurrentFolder(subsubdir);
     std::vector<std::string> allmenames = getter.getMEs();
-    if ( allmenames.size() == 0 ) continue;
+    if ( allmenames.empty() ) continue;
 
     MonitorElement * me_counter      = getter.get( subsubdir + "/module_counter" );
     MonitorElement * me_real_total   = getter.get( subsubdir + "/module_time_real_total" );
     MonitorElement * me_thread_total = getter.get( subsubdir + "/module_time_thread_total" );
 
-    if (me_counter == 0 or me_real_total == 0)
+    if (me_counter == nullptr or me_real_total == nullptr)
       continue;
 
     TH1D * counter      = me_counter   ->getTH1D();
@@ -378,7 +378,7 @@ FastTimerServiceClient::fillPlotsVsLumi(DQMStore::IBooker & booker, DQMStore::IG
       menames.push_back(m);
   }
   // if no MEs available, return
-  if ( menames.size() == 0 )
+  if ( menames.empty() )
     return;
 
   // get info for getting the lumi VS LS histogram


### PR DESCRIPTION
* add PU vs LS ME (enable by default) in the LumiMonitor module
   it is generally run by HLT job in p5 and by the DQMOffline_Trigger_cff
* update the FastTimerServiceClient in order to make the timing plots vs PU as well

while testing this code,
I realized there was a message in the DQM step about a module (`muonsPt10`) I recentely added,
and I fixed that issue as well