### PR TITLE
New muon validation bug fixes

### DIFF
--- a/Validation/RecoHI/python/NewMuonValidationHeavyIons_cff.py
+++ b/Validation/RecoHI/python/NewMuonValidationHeavyIons_cff.py
@@ -20,6 +20,7 @@ hiMABH.tpTag = 'NEWcutsTpMuons'
 hiMABH.PurityCut_track = 0.75
 hiMABH.PurityCut_muon = 0.75
 #hiMABH.EfficiencyCut_track = 0.5 # maybe this could be added
+#hiMABH.EfficiencyCut_muon = 0.5 # maybe this could be added
 #hiMABH.includeZeroHitMuons = False # maybe this could be added
 ################################################
 

--- a/Validation/RecoMuon/plugins/NewMuonTrackValidator.cc
+++ b/Validation/RecoMuon/plugins/NewMuonTrackValidator.cc
@@ -47,7 +47,7 @@ void NewMuonTrackValidator::bookHistograms(DQMStore::IBooker& ibooker, edm::Run 
         dirName+="_TkAsso";
       }
       std::replace(dirName.begin(), dirName.end(), ':', '_');
-      ibooker.setCurrentFolder(dirName.c_str());
+      ibooker.setCurrentFolder(dirName);
 
       h_tracks.push_back( ibooker.book1D("Ntracks","Number of reconstructed tracks",100,-0.5,99.5) );
       h_fakes.push_back( ibooker.book1D("Nfakes","Number of fake reco tracks",20,-0.5,19.5) );
@@ -403,7 +403,7 @@ void NewMuonTrackValidator::analyze(const edm::Event& event, const edm::EventSet
 	int assoc_recoTrack_NValidHits = 0;
 	if(simRecColl.find(tpr) != simRecColl.end()) {
 	  auto const & rt = simRecColl[tpr];
-	  if (rt.size()!=0) {
+	  if (!rt.empty()) {
 	    RefToBase<Track> assoc_recoTrack = rt.begin()->first;
 	    edm::LogVerbatim("NewMuonTrackValidator")<<"-----------------------------associated Track #"<<assoc_recoTrack.key();
 	    TP_is_matched = true;
@@ -512,7 +512,7 @@ void NewMuonTrackValidator::analyze(const edm::Event& event, const edm::EventSet
 	  
 	  if(recSimColl.find(track) != recSimColl.end()) {
 	    tp = recSimColl[track];	
-	    if (tp.size() != 0) {
+	    if (!tp.empty()) {
 	      tpr = tp.begin()->first;	
 	      // RtS and StR must associate the same pair !
 	      if(simRecColl.find(tpr) != simRecColl.end()) {
@@ -541,7 +541,7 @@ void NewMuonTrackValidator::analyze(const edm::Event& event, const edm::EventSet
 	else {
 	  if(recSimColl.find(track) != recSimColl.end()){
 	    tp = recSimColl[track];
-	    if (tp.size()!=0) {
+	    if (!tp.empty()) {
 	      tpr = tp.begin()->first;
 	      Track_is_matched = true;
 	      at++;

--- a/Validation/RecoMuon/python/NewAssociators_cff.py
+++ b/Validation/RecoMuon/python/NewAssociators_cff.py
@@ -31,15 +31,9 @@ MABH = SimMuon.MCTruth.NewMuonAssociatorByHits_cfi.NewMuonAssociatorByHits.clone
 ##############################################
 MABH.EfficiencyCut_track = 0.5
 MABH.PurityCut_track = 0.75
-#MABH.EfficiencyCut_muon = 0.5
-MABH.EfficiencyCut_muon = 0.     # for high pt muons this is a better choice
+MABH.EfficiencyCut_muon = 0.5
 MABH.PurityCut_muon = 0.75
 MABH.includeZeroHitMuons = False
-#
-# temporary fix for Phase2
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify( MABH, EfficiencyCut_track = 0. )
-phase2_tracker.toModify( MABH, PurityCut_track = 0. )
 #
 MABHhlt = MABH.clone()
 MABHhlt.EfficiencyCut_track = 0. # backup solution as UseGrouped/UseSplitting are always assumed to be true
@@ -57,6 +51,7 @@ NEWtpToStaSeedAssociation = MABH.clone()
 NEWtpToStaSeedAssociation.tracksTag = 'NEWseedsOfSTAmuons'
 NEWtpToStaSeedAssociation.UseTracker = False
 NEWtpToStaSeedAssociation.UseMuon = True
+NEWtpToStaSeedAssociation.EfficiencyCut_muon = 0.
 
 NEWtpToStaMuonAssociation = MABH.clone()
 NEWtpToStaMuonAssociation.tracksTag = 'standAloneMuons'
@@ -92,6 +87,7 @@ NEWtpToDisplacedStaSeedAssociation = MABH.clone()
 NEWtpToDisplacedStaSeedAssociation.tracksTag = 'NEWseedsOfDisplacedSTAmuons'
 NEWtpToDisplacedStaSeedAssociation.UseTracker = False
 NEWtpToDisplacedStaSeedAssociation.UseMuon = True
+NEWtpToDisplacedStaSeedAssociation.EfficiencyCut_muon = 0.
 
 NEWtpToDisplacedStaMuonAssociation = MABH.clone()
 NEWtpToDisplacedStaMuonAssociation.tracksTag = 'displacedStandAloneMuons'
@@ -107,16 +103,19 @@ NEWtpToTevFirstMuonAssociation = MABH.clone()
 NEWtpToTevFirstMuonAssociation.tracksTag = 'tevMuons:firstHit'
 NEWtpToTevFirstMuonAssociation.UseTracker = True
 NEWtpToTevFirstMuonAssociation.UseMuon = True
+NEWtpToTevFirstMuonAssociation.EfficiencyCut_muon = 0.
 
 NEWtpToTevPickyMuonAssociation = MABH.clone()
 NEWtpToTevPickyMuonAssociation.tracksTag = 'tevMuons:picky'
 NEWtpToTevPickyMuonAssociation.UseTracker = True
 NEWtpToTevPickyMuonAssociation.UseMuon = True
+NEWtpToTevPickyMuonAssociation.EfficiencyCut_muon = 0.
 
 NEWtpToTevDytMuonAssociation = MABH.clone()
 NEWtpToTevDytMuonAssociation.tracksTag = 'tevMuons:dyt'
 NEWtpToTevDytMuonAssociation.UseTracker = True
 NEWtpToTevDytMuonAssociation.UseMuon = True
+NEWtpToTevDytMuonAssociation.EfficiencyCut_muon = 0.
 
 NEWtpToME0MuonMuonAssociation = MABH.clone()
 NEWtpToME0MuonMuonAssociation.tracksTag = 'NEWextractMe0Muons'


### PR DESCRIPTION
These are bug-fixes to the new muon track validation, already tested one by one on RelVals.
They do not affect anything of the current validation workflow, but need to enter the release to allow a forthcoming switch to the new validation with a correct and consistent baseline code. 

In detail the changes are:

- removal of a leftover (unintended) Phase2 customization which is not needed anymore
- setting of an efficiency cut on the SimToReco association of muon hits with general threshold at 0.5. A few particular cases keep no minimum threshold:
        -- association of global TeV refits, as they are expected to select a subset of all the muon hits
        -- association of seeds of standalone muons (standard or displaced), for a similar reason (they could be made of just one segment out of four stations)
- bug fix in the (New) MuonTrackValidator: for HLT muon tracks the denominator of the efficiency was not correctly defined in events missing specific HLT muon track collections (in particular hltL3Muons and hltL3TkTracksFromL2). Curiously the bug appeared in recent releases, while it was not effective in an earlier test made in 900pre4 (with the same code).

As said each change has been tested on RelVals and the results are fine.
