### PR TITLE
Extract timing for tracker-only muons

### DIFF
--- a/RecoMuon/MuonIdentification/interface/CSCTimingExtractor.h
+++ b/RecoMuon/MuonIdentification/interface/CSCTimingExtractor.h
@@ -71,6 +71,10 @@ public:
      float weightInvbeta;
   };
 
+  void fillTiming(TimeMeasurementSequence &tmSequence,
+		 const std::vector<const CSCSegment*> &segments,
+		 reco::TrackRef muonTrack,
+                  const edm::Event& iEvent, const edm::EventSetup& iSetup);
   void fillTiming(TimeMeasurementSequence &tmSequence, reco::TrackRef muonTrack,
                   const edm::Event& iEvent, const edm::EventSetup& iSetup);
 

--- a/RecoMuon/MuonIdentification/interface/DTTimingExtractor.h
+++ b/RecoMuon/MuonIdentification/interface/DTTimingExtractor.h
@@ -73,8 +73,13 @@ public:
      DetId driftCell;
   };
 
-  void fillTiming(TimeMeasurementSequence &tmSequence, reco::TrackRef muonTrack,
-                  const edm::Event& iEvent, const edm::EventSetup& iSetup);
+ void fillTiming(TimeMeasurementSequence &tmSequence, 
+		 const std::vector<const DTRecSegment4D*> &segments,
+		 reco::TrackRef muonTrack,
+		 const edm::Event& iEvent, const edm::EventSetup& iSetup);
+
+ void fillTiming(TimeMeasurementSequence &tmSequence, reco::TrackRef muonTrack,
+		 const edm::Event& iEvent, const edm::EventSetup& iSetup);
 
 private:
   double fitT0(double &a, double &b, const std::vector<double>& xl, const std::vector<double>& yl, const std::vector<double>& xr, const std::vector<double>& yr );

--- a/RecoMuon/MuonIdentification/src/CSCTimingExtractor.cc
+++ b/RecoMuon/MuonIdentification/src/CSCTimingExtractor.cc
@@ -125,7 +125,7 @@ void CSCTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence,
     CSCDetId chamberId(id.rawId());
     //    int station = chamberId.station();
 
-    if (!(*rechit)->specificRecHits().size()) continue;
+    if ((*rechit)->specificRecHits().empty()) continue;
 
     const std::vector<CSCRecHit2D> hits2d = (*rechit)->specificRecHits();
 

--- a/RecoMuon/MuonIdentification/src/CSCTimingExtractor.cc
+++ b/RecoMuon/MuonIdentification/src/CSCTimingExtractor.cc
@@ -92,15 +92,11 @@ CSCTimingExtractor::~CSCTimingExtractor()
 // member functions
 //
 
-// ------------ method called to produce the data  ------------
-void
-CSCTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence, reco::TrackRef muonTrack, 
-                               const edm::Event& iEvent, const edm::EventSetup& iSetup)
+void CSCTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence,
+				    const std::vector<const CSCSegment*> &segments,
+				    reco::TrackRef muonTrack,
+				    const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-
-  if (debug) 
-    std::cout << " *** CSC Timimng Extractor ***" << std::endl;
-
   theService->update(iSetup);
 
   const GlobalTrackingGeometry *theTrackingGeometry = &*theService->trackingGeometry();
@@ -120,12 +116,9 @@ CSCTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence, reco::TrackR
   GlobalVector momv(mom.x(), mom.y(), mom.z());
   FreeTrajectoryState muonFTS(posp, momv, (TrackCharge)muonTrack->charge(), theService->magneticField().product());
 
-  // get the CSC segments that were used to construct the muon
-  std::vector<const CSCSegment*> range = theMatcher->matchCSC(*muonTrack,iEvent);
-
   // create a collection on TimeMeasurements for the track        
   std::vector<TimeMeasurement> tms;
-  for (std::vector<const CSCSegment*>::iterator rechit = range.begin(); rechit!=range.end();++rechit) {
+  for (std::vector<const CSCSegment*>::const_iterator rechit = segments.begin(); rechit!=segments.end();++rechit) {
 
     // Create the ChamberId
     DetId id = (*rechit)->geographicalId();
@@ -256,7 +249,22 @@ CSCTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence, reco::TrackR
 
   tmSequence.totalWeightInvbeta=totalWeightInvbeta;
   tmSequence.totalWeightTimeVtx=totalWeightTimeVtx;
+}
 
+
+// ------------ method called to produce the data  ------------
+void
+CSCTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence, reco::TrackRef muonTrack, 
+                               const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+
+  if (debug) 
+    std::cout << " *** CSC Timimng Extractor ***" << std::endl;
+
+  // get the CSC segments that were used to construct the muon
+  std::vector<const CSCSegment*> range = theMatcher->matchCSC(*muonTrack,iEvent);
+  
+  fillTiming(tmSequence, range, muonTrack, iEvent, iSetup);
 }
 
 //define this as a plug-in

--- a/RecoMuon/MuonIdentification/src/CSCTimingExtractor.cc
+++ b/RecoMuon/MuonIdentification/src/CSCTimingExtractor.cc
@@ -118,21 +118,21 @@ void CSCTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence,
 
   // create a collection on TimeMeasurements for the track        
   std::vector<TimeMeasurement> tms;
-  for (std::vector<const CSCSegment*>::const_iterator rechit = segments.begin(); rechit!=segments.end();++rechit) {
+  for (const auto& rechit : segments) {
 
     // Create the ChamberId
-    DetId id = (*rechit)->geographicalId();
+    DetId id = rechit->geographicalId();
     CSCDetId chamberId(id.rawId());
     //    int station = chamberId.station();
 
-    if ((*rechit)->specificRecHits().empty()) continue;
+    if (rechit->specificRecHits().empty()) continue;
 
-    const std::vector<CSCRecHit2D> hits2d = (*rechit)->specificRecHits();
+    const std::vector<CSCRecHit2D> hits2d = rechit->specificRecHits();
 
     // store all the hits from the segment
-    for (std::vector<CSCRecHit2D>::const_iterator hiti=hits2d.begin(); hiti!=hits2d.end(); hiti++) {
+    for (const auto& hiti : hits2d) {
 
-      const GeomDet* cscDet = theTrackingGeometry->idToDet(hiti->geographicalId());
+      const GeomDet* cscDet = theTrackingGeometry->idToDet(hiti.geographicalId());
       TimeMeasurement thisHit;
 
       std::pair< TrajectoryStateOnSurface, double> tsos;
@@ -140,20 +140,20 @@ void CSCTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence,
 
       double dist;            
       if (tsos.first.isValid()) dist = tsos.second+posp.mag(); 
-        else dist = cscDet->toGlobal(hiti->localPosition()).mag();
+        else dist = cscDet->toGlobal(hiti.localPosition()).mag();
 
       thisHit.distIP = dist;
       if (UseStripTime) {
         thisHit.weightInvbeta = dist*dist/(theStripError_*theStripError_*30.*30.);
         thisHit.weightTimeVtx = 1./(theStripError_*theStripError_);
-        thisHit.timeCorr = hiti->tpeak()-theStripTimeOffset_;
+        thisHit.timeCorr = hiti.tpeak()-theStripTimeOffset_;
         tms.push_back(thisHit);
       }
 
       if (UseWireTime) {
 	thisHit.weightInvbeta = dist*dist/(theWireError_*theWireError_*30.*30.);
         thisHit.weightTimeVtx = 1./(theWireError_*theWireError_);
-        thisHit.timeCorr = hiti->wireTime()-theWireTimeOffset_;
+        thisHit.timeCorr = hiti.wireTime()-theWireTimeOffset_;
         tms.push_back(thisHit);
       }
       
@@ -180,13 +180,13 @@ void CSCTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence,
     totalWeightInvbeta=0;
     totalWeightTimeVtx=0;
       
-    for (std::vector<TimeMeasurement>::iterator tm=tms.begin(); tm!=tms.end(); ++tm) {
-      dstnc.push_back(tm->distIP);
-      local_t0.push_back(tm->timeCorr);
-      hitWeightInvbeta.push_back(tm->weightInvbeta);
-      hitWeightTimeVtx.push_back(tm->weightTimeVtx);
-      totalWeightInvbeta+=tm->weightInvbeta;
-      totalWeightTimeVtx+=tm->weightTimeVtx;
+    for (auto& tm : tms) {
+      dstnc.push_back(tm.distIP);
+      local_t0.push_back(tm.timeCorr);
+      hitWeightInvbeta.push_back(tm.weightInvbeta);
+      hitWeightTimeVtx.push_back(tm.weightTimeVtx);
+      totalWeightInvbeta+=tm.weightInvbeta;
+      totalWeightTimeVtx+=tm.weightTimeVtx;
     }
           
     if (totalWeightInvbeta==0) break;        

--- a/RecoMuon/MuonIdentification/src/CSCTimingExtractor.cc
+++ b/RecoMuon/MuonIdentification/src/CSCTimingExtractor.cc
@@ -127,7 +127,7 @@ void CSCTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence,
 
     if (rechit->specificRecHits().empty()) continue;
 
-    const std::vector<CSCRecHit2D> hits2d = rechit->specificRecHits();
+    const std::vector<CSCRecHit2D>& hits2d(rechit->specificRecHits());
 
     // store all the hits from the segment
     for (const auto& hiti : hits2d) {

--- a/RecoMuon/MuonIdentification/src/DTTimingExtractor.cc
+++ b/RecoMuon/MuonIdentification/src/DTTimingExtractor.cc
@@ -155,7 +155,7 @@ void DTTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence,
       if (segm->specificRecHits().empty()) continue;
 
       const GeomDet* geomDet = theTrackingGeometry->idToDet(segm->geographicalId());
-      const std::vector<DTRecHit1D> hits1d = segm->specificRecHits();
+      const std::vector<DTRecHit1D>& hits1d(segm->specificRecHits());
 
       // store all the hits from the segment
       for (const auto& hiti : hits1d) {

--- a/RecoMuon/MuonIdentification/src/DTTimingExtractor.cc
+++ b/RecoMuon/MuonIdentification/src/DTTimingExtractor.cc
@@ -151,8 +151,8 @@ void DTTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence,
       }    
         else segm = dynamic_cast<const DTRecSegment2D*>((*rechit)->zSegment());
 
-      if(segm == 0) continue;
-      if (!segm->specificRecHits().size()) continue;
+      if(segm == nullptr) continue;
+      if (segm->specificRecHits().empty()) continue;
 
       const GeomDet* geomDet = theTrackingGeometry->idToDet(segm->geographicalId());
       const std::vector<DTRecHit1D> hits1d = segm->specificRecHits();
@@ -276,7 +276,7 @@ void DTTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence,
 	}
 
 	// a segment must have at least one left and one right hit
-	if ((!hitxl.size()) || (!hityl.size())) continue;
+	if ((hitxl.empty()) || (hityl.empty())) continue;
 
 	int segidx=0;
 	for (std::vector<TimeMeasurement>::const_iterator tm=seg.begin(); tm!=seg.end(); ++tm) {

--- a/RecoMuon/MuonIdentification/src/DTTimingExtractor.cc
+++ b/RecoMuon/MuonIdentification/src/DTTimingExtractor.cc
@@ -98,11 +98,10 @@ DTTimingExtractor::~DTTimingExtractor()
 //
 // member functions
 //
-
-// ------------ method called to produce the data  ------------
-void
-DTTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence, reco::TrackRef muonTrack,
-                              const edm::Event& iEvent, const edm::EventSetup& iSetup)
+void DTTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence, 
+				   const std::vector<const DTRecSegment4D*> &segments,
+				   reco::TrackRef muonTrack,
+				   const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
   if (debug) 
     std::cout << " *** DT Timimng Extractor ***" << std::endl;
@@ -126,15 +125,9 @@ DTTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence, reco::TrackRe
   GlobalVector momv(mom.x(), mom.y(), mom.z());
   FreeTrajectoryState muonFTS(posp, momv, (TrackCharge)muonTrack->charge(), theService->magneticField().product());
 
-  // get the DT segments that were used to construct the muon
-  std::vector<const DTRecSegment4D*> range = theMatcher->matchDT(*muonTrack,iEvent);
-  
-  if (debug) 
-    std::cout << " The muon track matches " << range.size() << " segments." << std::endl;
-  
   // create a collection on TimeMeasurements for the track        
   std::vector<TimeMeasurement> tms;
-  for (std::vector<const DTRecSegment4D*>::iterator rechit = range.begin(); rechit!=range.end();++rechit) {
+  for (std::vector<const DTRecSegment4D*>::const_iterator rechit = segments.begin(); rechit!=segments.end();++rechit) {
 
     // Create the ChamberId
     DetId id = (*rechit)->geographicalId();
@@ -373,7 +366,19 @@ DTTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence, reco::TrackRe
 
   tmSequence.totalWeightInvbeta=totalWeightInvbeta;
   tmSequence.totalWeightTimeVtx=totalWeightTimeVtx;
+}
 
+// ------------ method called to produce the data  ------------
+void
+DTTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence, reco::TrackRef muonTrack,
+                              const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  // get the DT segments that were used to construct the muon
+  std::vector<const DTRecSegment4D*> range = theMatcher->matchDT(*muonTrack,iEvent);
+  
+  if (debug) 
+    std::cout << " The muon track matches " << range.size() << " segments." << std::endl;
+  fillTiming(tmSequence,range,muonTrack,iEvent,iSetup);
 }
 
 double

--- a/RecoMuon/MuonIdentification/src/MuonTimingFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonTimingFiller.cc
@@ -94,11 +94,27 @@ MuonTimingFiller::fillTiming( const reco::Muon& muon,
   if ( !(muon.combinedMuon().isNull()) ) {
     theDTTimingExtractor_->fillTiming(dtTmSeq, muon.combinedMuon(), iEvent, iSetup);
     theCSCTimingExtractor_->fillTiming(cscTmSeq, muon.combinedMuon(), iEvent, iSetup);
-  } else
+  } else {
     if ( !(muon.standAloneMuon().isNull()) ) {
       theDTTimingExtractor_->fillTiming(dtTmSeq, muon.standAloneMuon(), iEvent, iSetup);
       theCSCTimingExtractor_->fillTiming(cscTmSeq, muon.standAloneMuon(), iEvent, iSetup);
+    } else {
+      if ( muon.isTrackerMuon() ) {
+	std::vector<const DTRecSegment4D*> dtSegments;
+	std::vector<const CSCSegment*> cscSegments;
+	for( auto& chamber: muon.matches() ){
+	  for ( auto& segment : chamber.segmentMatches ){
+	    if ( !(segment.dtSegmentRef.isNull()))
+	      dtSegments.push_back(segment.dtSegmentRef.get());
+	    if ( !(segment.cscSegmentRef.isNull()))
+	      cscSegments.push_back(segment.cscSegmentRef.get());
+	  }
+	}
+	theDTTimingExtractor_->fillTiming(dtTmSeq, dtSegments, muon.innerTrack(), iEvent, iSetup);
+	theCSCTimingExtractor_->fillTiming(cscTmSeq, cscSegments, muon.innerTrack(), iEvent, iSetup);
+      }
     }
+  }
   
   // Fill DT-specific timing information block     
   fillTimeFromMeasurements(dtTmSeq, dtTime);

--- a/RecoMuon/MuonIdentification/src/MuonTimingFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonTimingFiller.cc
@@ -291,7 +291,7 @@ MuonTimingFiller::rawFit(double &a, double &da, double &b, double &db, const std
   double sxx=0,sxy=0;
 
   a=b=0;
-  if (hitsx.size()==0) return;
+  if (hitsx.empty()) return;
   if (hitsx.size()==1) {
     b=hitsy[0];
   } else {

--- a/RecoMuon/MuonIdentification/src/MuonTimingFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonTimingFiller.cc
@@ -147,9 +147,9 @@ MuonTimingFiller::fillTiming( const reco::Muon& muon,
 void 
 MuonTimingFiller::fillTimeFromMeasurements( const TimeMeasurementSequence& tmSeq, reco::MuonTimeExtra &muTime ) {
   std::vector <double> x,y;
-  double invbeta=0, invbetaerr=0;
-  double vertexTime=0, vertexTimeErr=0, vertexTimeR=0, vertexTimeRErr=0;    
-  double freeBeta, freeBetaErr, freeTime, freeTimeErr;
+  double invbeta(0), invbetaerr(0);
+  double vertexTime(0), vertexTimeErr(0), vertexTimeR(0), vertexTimeRErr(0);    
+  double freeBeta(0), freeBetaErr(0), freeTime(0), freeTimeErr(0);
 
   if (tmSeq.dstnc.size()<=1) return;
 
@@ -285,15 +285,20 @@ MuonTimingFiller::addEcalTime( const reco::Muon& muon,
 
 
 void 
-MuonTimingFiller::rawFit(double &a, double &da, double &b, double &db, const std::vector<double>& hitsx, const std::vector<double>& hitsy) {
+MuonTimingFiller::rawFit(double &freeBeta, double &freeBetaErr, double &freeTime, double &freeTimeErr, 
+			 const std::vector<double>& hitsx, const std::vector<double>& hitsy) {
 
   double s=0,sx=0,sy=0,x,y;
   double sxx=0,sxy=0;
 
-  a=b=0;
+  freeBeta = 0;
+  freeBetaErr = 0;
+  freeTime = 0;
+  freeTimeErr = 0;
+
   if (hitsx.empty()) return;
   if (hitsx.size()==1) {
-    b=hitsy[0];
+    freeTime=hitsy[0];
   } else {
     for (unsigned int i = 0; i != hitsx.size(); i++) {
       x=hitsx[i];
@@ -306,10 +311,10 @@ MuonTimingFiller::rawFit(double &a, double &da, double &b, double &db, const std
     }
 
     double d = s*sxx - sx*sx;
-    b = (sxx*sy- sx*sxy)/ d;
-    a = (s*sxy - sx*sy) / d;
-    da = sqrt(sxx/d);
-    db = sqrt(s/d);
+    freeTime = (sxx*sy- sx*sxy)/ d;
+    freeBeta = (s*sxy - sx*sy) / d;
+    freeBetaErr = sqrt(sxx/d);
+    freeTimeErr = sqrt(s/d);
   }
 }
 

--- a/RecoMuon/MuonIdentification/src/MuonTimingFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonTimingFiller.cc
@@ -104,10 +104,16 @@ MuonTimingFiller::fillTiming( const reco::Muon& muon,
 	std::vector<const CSCSegment*> cscSegments;
 	for( auto& chamber: muon.matches() ){
 	  for ( auto& segment : chamber.segmentMatches ){
-	    if ( !(segment.dtSegmentRef.isNull()))
-	      dtSegments.push_back(segment.dtSegmentRef.get());
-	    if ( !(segment.cscSegmentRef.isNull()))
-	      cscSegments.push_back(segment.cscSegmentRef.get());
+	    // Use only the segments that passed arbitration to avoid mixing
+	    // segments from in-time and out-of-time muons that may bias the result
+	    // SegmentAndTrackArbitration
+            if(segment.isMask(reco::MuonSegmentMatch::BestInStationByDR) &&
+	       segment.isMask(reco::MuonSegmentMatch::BelongsToTrackByDR)){
+	      if ( !(segment.dtSegmentRef.isNull()))
+		dtSegments.push_back(segment.dtSegmentRef.get());
+	      if ( !(segment.cscSegmentRef.isNull()))
+		cscSegments.push_back(segment.cscSegmentRef.get());
+	    }
 	  }
 	}
 	theDTTimingExtractor_->fillTiming(dtTmSeq, dtSegments, muon.innerTrack(), iEvent, iSetup);


### PR DESCRIPTION
Modified CSC/DT timing extraction code to handle cases of tracker-only muons. Timing distributions will change since muons that didn't have timing computed before will not have non-zero values. Many fake TrackerMuons have wrong timing, so having significant deviations from zero timing is expected. It's a critical development for high-pileup fake suppression. Needed for 94X.