### PR TITLE
GT Updates : Deploying Legacy2016 and Early2017 ReReco Conditions in offline GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '93X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '94X_dataRun2_v0',
+    'run1_data'         :   '94X_dataRun2_v1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '94X_dataRun2_v0',
+    'run2_data'         :   '94X_dataRun2_v1',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '94X_dataRun2_relval_v0',
+    'run2_data_relval'  :   '94X_dataRun2_relval_v1',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
     'run2_data_promptlike' : '94X_dataRun2_PromptLike_v1',
     # GlobalTag for Run1 HLT: it points to the online GT


### PR DESCRIPTION
# Summary of changes in Global Tags

## RunI data

   * **RunI Offline processing** : [94X_dataRun2_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_v1) as [94X_dataRun2_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_v1/94X_dataRun2_v0):
      * Update of all ECAL local reco conditions
      * Update of Pixel local reco conditions
      * Update of SiStrip G2
      * Update of Tracker Alignment package
      * Update of all HCAL local reco conditions
      * Update of Muon Alignments and GPR
      * Update of BeamSpot

## RunII data

   * **RunII Offline processing** : [94X_dataRun2_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_v1) as [94X_dataRun2_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_v1/94X_dataRun2_v0):
     * Update of all ECAL local reco conditions
      * Update of Pixel local reco conditions
      * Update of SiStrip G2
      * Update of Tracker Alignment package
      * Update of all HCAL local reco conditions
      * Update of Muon Alignments and GPR
      * Update of BeamSpot

   * **RunII Offline relval processing** : [94X_dataRun2_relval_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_relval_v1) as [94X_dataRun2_relval_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_relval_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_relval_v1/94X_dataRun2_relval_v0):
     * Update of all ECAL local reco conditions
      * Update of Pixel local reco conditions
      * Update of SiStrip G2
      * Update of Tracker Alignment package
      * Update of all HCAL local reco conditions
      * Update of Muon Alignments and GPR
      * Update of BeamSpot

Validation Campaigns for Leagcy 2016 and Early re-reco 2017 are given below : 

Legacy 2016 : https://cms-pdmv.cern.ch/valdb/?srch=LegRP&selected=AlCa_LegRP_2016C,AlCa_LegRP_2016E,AlCa_LegRP_2016G,AlCa_LegRP_2016H&Reconstruction=true&RData=true&RFull=true&RFast=true&HLT=true&HData=true&HFull=true&HFast=true&PAGs=true&PData=true&PFull=true&PFast=true

Early Re-Reco 2017 : https://cms-pdmv.cern.ch/valdb/?srch=Alca&selected=AlCa-ReReco17-297656,AlCa-ReReco17-297227,AlCa-ReReco17-300401&RData=true&RFull=true&RFast=true&PAGs=true&PData=true&PFull=true&PFast=true&Reconstruction=true