### PR TITLE
Better splitting and Tcrit definition for 4D vertexing

### DIFF
--- a/RecoVertex/Configuration/python/RecoVertex_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_cff.py
@@ -37,7 +37,7 @@ from RecoVertex.PrimaryVertexProducer.TkClusParameters_cff import DA2D_vectParam
 DA2D_vectParameters.TkDAClusParameters.verbose = cms.untracked.bool(False)
 unsortedOfflinePrimaryVertices4D = unsortedOfflinePrimaryVertices.clone( verbose = cms.untracked.bool(False),
                                                                          TkClusParameters = DA2D_vectParameters )
-unsortedOfflinePrimaryVertices4D.TkFilterParameters.minPt = cms.double(0.7)
+unsortedOfflinePrimaryVertices4D.TkFilterParameters.minPt = cms.double(0.0)
 unsortedOfflinePrimaryVertices4D.TrackTimesLabel = cms.InputTag("trackTimeValueMapProducer:generalTracksConfigurableFlatResolutionModel")
 unsortedOfflinePrimaryVertices4D.TrackTimeResosLabel = cms.InputTag("trackTimeValueMapProducer:generalTracksConfigurableFlatResolutionModelResolution")
 offlinePrimaryVertices4D=sortedPrimaryVertices.clone(vertices="unsortedOfflinePrimaryVertices4D", particles="trackRefsForJetsBeforeSorting4D", trackTimeTag=cms.InputTag("trackTimeValueMapProducer","generalTracksConfigurableFlatResolutionModel"),trackTimeResoTag=cms.InputTag("trackTimeValueMapProducer","generalTracksConfigurableFlatResolutionModelResolution"),assignment=dict(useTiming=True))

--- a/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZT_vect.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZT_vect.h
@@ -60,14 +60,12 @@ public:
 
     double * dz2_; // square of the error of z(pca)
     double * dt2_; // square of the error of t(pca)
-    // double * errsum_; // sum of squares of the pca errors     obsolete
     double * Z_sum_; // Z[i]   for DA clustering
     
     std::vector<double> z; // z-coordinate at point of closest approach to the beamline
     std::vector<double> t; // t-coordinate at point of closest approach to the beamline
     std::vector<double> dz2; // square of the error of z(pca)
     std::vector<double> dt2; // square of the error of t(pca)
-    //std::vector<double> errsum; // sum of squares of the pca errors    
     std::vector<double> Z_sum; // Z[i]   for DA clustering
     std::vector<double> pi; // track weight
     std::vector< const reco::TransientTrack* > tt; // a pointer to the Transient Track
@@ -83,11 +81,9 @@ public:
       
       ei_cache.push_back( 0.0 );
       ei.push_back( 0.0 );
-      //sw.push_back( 0.0 );
       swz.push_back( 0.0);
       swt.push_back( 0.0);
       se.push_back( 0.0);
-      //swE.push_back( 0.0);
       nuz.push_back(0.0);
       nut.push_back(0.0);
       szz.push_back(0.0);
@@ -110,11 +106,9 @@ public:
       pk_ = &pk.front();
       
       ei_ = &ei.front();
-      //sw_ = &sw.front();
       swz_ = &swz.front();
       swt_ = &swt.front();
       se_ = &se.front();
-      //swE_ = &swE.front();
       nuz_ = &nuz.front();
       nut_ = &nut.front();
       szz_ = &szz.front();
@@ -199,11 +193,9 @@ public:
     
     double * ei_cache_;
     double * ei_;
-    //double * sw_;
     double * swz_;
     double * swt_;
     double * se_;
-    //    double * swE_;   
     double * szz_;
     double * stt_;
     double * szt_;
@@ -213,11 +205,9 @@ public:
     // --- temporary numbers, used during update
     std::vector<double> ei_cache;
     std::vector<double> ei;
-    //std::vector<double> sw; replaced by nuz, nut
     std::vector<double> swz;
     std::vector<double> swt;
     std::vector<double> se;
-    //    std::vector<double> swE; replaced by szz,stt,stz
     std::vector<double> nuz;
     std::vector<double> nut;
     std::vector<double> szz;

--- a/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZT_vect.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZT_vect.h
@@ -32,7 +32,6 @@ public:
       t.push_back( new_t );
       dz2.push_back( new_dz2 );
       dt2.push_back( new_dt2 );
-      errsum.push_back( 1./(1./new_dz2 + 1./new_dt2) );
       tt.push_back( new_tt );
       
       pi.push_back( new_pi ); // track weight
@@ -51,7 +50,6 @@ public:
       t_ = &t.front();
       dz2_ = &dz2.front();
       dt2_ = &dt2.front();
-      errsum_ = &errsum.front();
       Z_sum_ = &Z_sum.front();
       pi_ = &pi.front();
     }
@@ -62,14 +60,14 @@ public:
 
     double * dz2_; // square of the error of z(pca)
     double * dt2_; // square of the error of t(pca)
-    double * errsum_; // sum of squares of the pca errors    
+    // double * errsum_; // sum of squares of the pca errors     obsolete
     double * Z_sum_; // Z[i]   for DA clustering
     
     std::vector<double> z; // z-coordinate at point of closest approach to the beamline
     std::vector<double> t; // t-coordinate at point of closest approach to the beamline
     std::vector<double> dz2; // square of the error of z(pca)
     std::vector<double> dt2; // square of the error of t(pca)
-    std::vector<double> errsum; // sum of squares of the pca errors    
+    //std::vector<double> errsum; // sum of squares of the pca errors    
     std::vector<double> Z_sum; // Z[i]   for DA clustering
     std::vector<double> pi; // track weight
     std::vector< const reco::TransientTrack* > tt; // a pointer to the Transient Track
@@ -85,11 +83,16 @@ public:
       
       ei_cache.push_back( 0.0 );
       ei.push_back( 0.0 );
-      sw.push_back( 0.0 );
+      //sw.push_back( 0.0 );
       swz.push_back( 0.0);
       swt.push_back( 0.0);
       se.push_back( 0.0);
-      swE.push_back( 0.0);
+      //swE.push_back( 0.0);
+      nuz.push_back(0.0);
+      nut.push_back(0.0);
+      szz.push_back(0.0);
+      stt.push_back(0.0);
+      szt.push_back(0.0);
       
       extractRaw();
     }
@@ -107,11 +110,17 @@ public:
       pk_ = &pk.front();
       
       ei_ = &ei.front();
-      sw_ = &sw.front();
+      //sw_ = &sw.front();
       swz_ = &swz.front();
       swt_ = &swt.front();
       se_ = &se.front();
-      swE_ = &swE.front();
+      //swE_ = &swE.front();
+      nuz_ = &nuz.front();
+      nut_ = &nut.front();
+      szz_ = &szz.front();
+      stt_ = &stt.front();
+      szt_ = &szt.front();
+
       ei_cache_ = &ei_cache.front();
       
     }
@@ -124,12 +133,15 @@ public:
       
       ei_cache.insert(ei_cache.begin() + i, 0.0 );
       ei.insert( ei.begin()  + i, 0.0 );
-      sw.insert( sw.begin()  + i, 0.0 );
       swz.insert(swz.begin() + i, 0.0 );
       swt.insert(swt.begin() + i, 0.0 );
       se.insert( se.begin()  + i, 0.0 );
-      swE.insert(swE.begin() + i, 0.0 );
-      
+
+      nuz.insert(nuz.begin() +i, 0.0 );
+      nut.insert(nut.begin() +i, 0.0 );
+      szz.insert(szz.begin() + i, 0.0 );
+      stt.insert(stt.begin() + i, 0.0 );
+      szt.insert(szt.begin() + i, 0.0 );
       extractRaw();
     }
     
@@ -141,16 +153,33 @@ public:
       
       ei_cache.erase( ei_cache.begin() + i);
       ei.erase( ei.begin() + i);
-      sw.erase( sw.begin() + i);
       swz.erase( swz.begin() + i);
       swt.erase( swt.begin() + i);
       se.erase(se.begin() + i);
-      swE.erase(swE.begin() + i);
+
+      nuz.erase(nuz.begin() + i);
+      nut.erase(nut.begin() + i);
+      szz.erase(szz.begin() + i);
+      stt.erase(stt.begin() + i);
+      szt.erase(szt.begin() + i);
       
       extractRaw();
     }
     
-    void debugOut()
+ 
+    unsigned int insertOrdered( double z, double t, double pk){
+      // insert a new cluster according to it's z-position, return the index at which it was inserted
+
+      unsigned int k = 0;
+      for( ; k < getSize(); k++){
+	if (z < z_[k]) break;
+      }
+      insertItem(k ,z, t, pk);
+      return k;
+    }
+
+
+   void debugOut()
     {
       std::cout <<  "vertex_t size: " << getSize() << std::endl;
       
@@ -170,20 +199,30 @@ public:
     
     double * ei_cache_;
     double * ei_;
-    double * sw_;
+    //double * sw_;
     double * swz_;
     double * swt_;
     double * se_;
-    double * swE_;   
+    //    double * swE_;   
+    double * szz_;
+    double * stt_;
+    double * szt_;
+    double * nuz_;
+    double * nut_;
     
     // --- temporary numbers, used during update
     std::vector<double> ei_cache;
     std::vector<double> ei;
-    std::vector<double> sw;
+    //std::vector<double> sw; replaced by nuz, nut
     std::vector<double> swz;
     std::vector<double> swt;
     std::vector<double> se;
-    std::vector<double> swE;
+    //    std::vector<double> swE; replaced by szz,stt,stz
+    std::vector<double> nuz;
+    std::vector<double> nut;
+    std::vector<double> szz;
+    std::vector<double> stt;
+    std::vector<double> szt;
   };
   
   DAClusterizerInZT_vect(const edm::ParameterSet& conf);  
@@ -202,6 +241,8 @@ public:
 
   void dump(const double beta, const vertex_t & y,
 	    const track_t & tks, const int verbosity = 0) const;
+  void zorder(vertex_t & y)const;
+  bool find_nearest(double z, double t, vertex_t & y, unsigned int & k_min, double dz, double dt)const;
   bool merge(vertex_t & y, double & beta)const;
   bool purge(vertex_t &, track_t &, double &,
 	     const double) const;
@@ -210,6 +251,7 @@ public:
   
   double beta0(const double betamax, track_t const & tks, vertex_t const & y) const;
     
+  double get_Tc(const vertex_t & y, int k) const;
   
 private:
   bool verbose_;

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
@@ -668,15 +668,15 @@ DAClusterizerInZT_vect::split(const double beta,  track_t &tks, vertex_t & y, do
       }
     }
 
-    if(wz1 > 0){z1 /= wz1;} else {z1 = y.z_[k] - epsilonz * cq; cout << "warning, wz1 = " << scientific << wz1 << endl;}
-    if(wt1 > 0){t1 /= wt1;} else {t1 = y.t_[k] - epsilont * sq; cout << "warning, w11 = " << scientific << wt1 << endl;}
-    if(wz2 > 0){z2 /= wz2;} else {z2 = y.z_[k] + epsilonz * cq; cout << "warning, wz2 = " << scientific << wz2 << endl;}
-    if(wt2 > 0){t2 /= wt2;} else {t2 = y.t_[k] + epsilont * sq; cout << "warning, wt2 = " << scientific << wt2 << endl;}
+    if(wz1 > 0){z1 /= wz1;} else {z1 = y.z_[k] - epsilonz * cq; edm::LogWarning("DAClusterizerInZT_vect") << "warning, wz1 = " << scientific << wz1 << endl;}
+    if(wt1 > 0){t1 /= wt1;} else {t1 = y.t_[k] - epsilont * sq; edm::LogWarning("DAClusterizerInZT_vect") << "warning, w11 = " << scientific << wt1 << endl;}
+    if(wz2 > 0){z2 /= wz2;} else {z2 = y.z_[k] + epsilonz * cq; edm::LogWarning("DAClusterizerInZT_vect") << "warning, wz2 = " << scientific << wz2 << endl;}
+    if(wt2 > 0){t2 /= wt2;} else {t2 = y.t_[k] + epsilont * sq; edm::LogWarning("DAClusterizerInZT_vect") << "warning, wt2 = " << scientific << wt2 << endl;}
 
-    unsigned int k_min1, k_min2;
+    unsigned int k_min1 = k, k_min2 = k;
     while(   (find_nearest(z1, t1, y, k_min1, epsilonz, epsilont) && (k_min1 != k))
 	     || (find_nearest(z2,t2, y, k_min2, epsilonz, epsilont) && (k_min2 !=k)) ){
-      z1 = 0.5*( z1 + y.z_[k]);      z1 = 0.5*( t1 + y.z_[k]);
+      z1 = 0.5*( z1 + y.z_[k]);      t1 = 0.5*( t1 + y.z_[k]);
       z2 = 0.5*( z2 + y.z_[k]);      t2 = 0.5*( t2 + y.z_[k]);
     }
     

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
@@ -676,8 +676,8 @@ DAClusterizerInZT_vect::split(const double beta,  track_t &tks, vertex_t & y, do
     unsigned int k_min1 = k, k_min2 = k;
     while(   (find_nearest(z1, t1, y, k_min1, epsilonz, epsilont) && (k_min1 != k))
 	     || (find_nearest(z2,t2, y, k_min2, epsilonz, epsilont) && (k_min2 !=k)) ){
-      z1 = 0.5*( z1 + y.z_[k]);      t1 = 0.5*( t1 + y.z_[k]);
-      z2 = 0.5*( z2 + y.z_[k]);      t2 = 0.5*( t2 + y.z_[k]);
+      z1 = 0.5*( z1 + y.z_[k]);      t1 = 0.5*( t1 + y.t_[k]);
+      z2 = 0.5*( z2 + y.z_[k]);      t2 = 0.5*( t2 + y.t_[k]);
     }
     
 #ifdef VI_DEBUG

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
@@ -11,6 +11,7 @@
 #include "vdt/vdtMath.h"
 
 using namespace std;
+#define VI_DEBUG
 
 DAClusterizerInZT_vect::DAClusterizerInZT_vect(const edm::ParameterSet& conf) {
 
@@ -25,9 +26,9 @@ DAClusterizerInZT_vect::DAClusterizerInZT_vect(const edm::ParameterSet& conf) {
   zdumpwidth_ = conf.getUntrackedParameter<double> ("zdumpwidth", 20.);
   
   // configurable parameters
-  double minT = conf.getParameter<double> ("Tmin")*std::sqrt(2.0);
-  double purgeT = conf.getParameter<double> ("Tpurge")*std::sqrt(2.0);
-  double stopT = conf.getParameter<double> ("Tstop")*std::sqrt(2.0);
+  double minT = conf.getParameter<double> ("Tmin");
+  double purgeT = conf.getParameter<double> ("Tpurge");
+  double stopT = conf.getParameter<double> ("Tstop");
   vertexSize_ = conf.getParameter<double> ("vertexSize");
   vertexSizeTime_ = conf.getParameter<double> ("vertexSizeTime");
   coolingFactor_ = conf.getParameter<double> ("coolingFactor");
@@ -36,7 +37,6 @@ DAClusterizerInZT_vect::DAClusterizerInZT_vect(const edm::ParameterSet& conf) {
     coolingFactor_=-coolingFactor_; 
     useTc_=false;
   }
-  coolingFactor_ = std::sqrt(coolingFactor_);
   d0CutOff_ = conf.getParameter<double> ("d0CutOff");
   dzCutOff_ = conf.getParameter<double> ("dzCutOff");
   dtCutOff_ = conf.getParameter<double> ("dtCutOff");
@@ -122,10 +122,18 @@ DAClusterizerInZT_vect::fill(const vector<reco::TransientTrack> & tracks) const 
       + (std::pow(beamspot.BeamWidthX()*t_mom.x(),2)+std::pow(beamspot.BeamWidthY()*t_mom.y(),2))*std::pow(t_mom.z(),2)/std::pow(t_mom.perp2(),2) // beam spot width
       + std::pow(vertexSize_, 2); // intrinsic vertex size, safer for outliers and short lived decays
     t_dz2 = 1./ t_dz2;
-    double t_dt2 =std::pow(tk.dtErrorExt(),2.) + std::pow(vertexSizeTime_,2.); // the ~injected~ timing error, need to add a small minimum vertex size in time
-    t_dt2 = 1./t_dt2;
     if (edm::isNotFinite(t_dz2) || t_dz2 < std::numeric_limits<double>::min() ) continue;
-    if (edm::isNotFinite(t_dt2) || t_dt2 < std::numeric_limits<double>::min() ) continue;
+
+
+    double t_dt2 =std::pow(tk.dtErrorExt(),2.) + std::pow(vertexSizeTime_,2.); // the ~injected~ timing error, need to add a small minimum vertex size in time
+    if (tk.dtErrorExt()>0.3){ 
+      t_dt2 = 0; // tracks with no time measurement
+    }else{
+      t_dt2 = 1./t_dt2;
+      if (edm::isNotFinite(t_dt2) || t_dt2 < std::numeric_limits<double>::min() ) continue;
+    }
+
+
     if (d0CutOff_ > 0) {
       Measurement1D atIP =
 	tk.stateAtBeamLine().transverseImpactParameter();// error contains beamspot
@@ -211,30 +219,42 @@ double DAClusterizerInZT_vect::update(double beta, track_t & gtracks,
 						  vertex_t & y_vec ) {
     auto tmp_trk_pi = tks_vec.pi_[track_num];
     auto o_trk_Z_sum = 1./tks_vec.Z_sum_[track_num];
-    auto o_trk_err_sum = tks_vec.errsum_[track_num];
+    auto o_trk_err_z = tks_vec.dz2_[track_num];
+    auto o_trk_err_t = tks_vec.dt2_[track_num];
     auto tmp_trk_z = tks_vec.z_[track_num];
     auto tmp_trk_t = tks_vec.t_[track_num];
-    auto obeta =  -1./beta;
-    
+
+
     // auto-vectorized
     for (unsigned int k = 0; k < nv; ++k) {
       // parens are important for numerical stability
       y_vec.se_[k] +=  tmp_trk_pi*( y_vec.ei_[k] * o_trk_Z_sum );      
-      const auto w = tmp_trk_pi * (y_vec.pk_[k] * y_vec.ei_[k] * o_trk_Z_sum) * o_trk_err_sum; 
-      y_vec.sw_[k]  += w;
-      y_vec.swz_[k] += w * tmp_trk_z;
-      y_vec.swt_[k] += w * tmp_trk_t;
-      y_vec.swE_[k] += w * y_vec.ei_cache_[k]*obeta;
+      const auto w = tmp_trk_pi * (y_vec.pk_[k] * y_vec.ei_[k] * o_trk_Z_sum);  // p_{ik}
+      const auto wz = w * o_trk_err_z; 
+      const auto wt = w * o_trk_err_t; 
+      y_vec.nuz_[k] += wz;
+      y_vec.nut_[k] += wt;
+      y_vec.swz_[k] += wz * tmp_trk_z;
+      y_vec.swt_[k] += wt * tmp_trk_t;
+      /* this is really only needed when we want to get Tc too, mayb better to do it elsewhere? */
+      const auto dsz = (tmp_trk_z - y_vec.z[k]) * o_trk_err_z;
+      const auto dst = (tmp_trk_t - y_vec.t[k]) * o_trk_err_t;
+      y_vec.szz_[k] += w * dsz * dsz;
+      y_vec.stt_[k] += w * dst * dst;
+      y_vec.szt_[k] += w * dsz * dst;
     }
   };
   
   
   for (auto ivertex = 0U; ivertex < nv; ++ivertex) {
     gvertices.se_[ivertex] = 0.0;
-    gvertices.sw_[ivertex] = 0.0;
+    gvertices.nuz_[ivertex] = 0.0;
+    gvertices.nut_[ivertex] = 0.0;
     gvertices.swz_[ivertex] = 0.0;
     gvertices.swt_[ivertex] = 0.0;
-    gvertices.swE_[ivertex] = 0.0;
+    gvertices.szz_[ivertex] = 0.0;
+    gvertices.stt_[ivertex] = 0.0;
+    gvertices.szt_[ivertex] = 0.0;
   }
   
    
@@ -257,24 +277,30 @@ double DAClusterizerInZT_vect::update(double beta, track_t & gtracks,
   auto kernel_calc_zt = [  sumpi, nv, this, useRho0 ] (vertex_t & vertices ) -> double {
     
     double delta=0;
+
     // does not vectorizes
     for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex ) {
-      if (vertices.sw_[ivertex] > 0.) {
-	auto znew = vertices.swz_[ ivertex ] / vertices.sw_[ ivertex ];
+
+      if (vertices.nuz_[ivertex] > 0.) {
+	auto znew = vertices.swz_[ ivertex ] / vertices.nuz_[ ivertex ];
 	// prevents from vectorizing if 
 	delta += std::pow( vertices.z_[ ivertex ] - znew, 2 );
 	vertices.z_[ ivertex ] = znew;
-        auto tnew = vertices.swt_[ ivertex ] / vertices.sw_[ ivertex ];
+      }
+
+      if(vertices.nut_[ivertex] > 0.) {
+        auto tnew = vertices.swt_[ ivertex ] / vertices.nut_[ ivertex ];
 	// prevents from vectorizing if 
 	delta += std::pow( vertices.t_[ ivertex ] - tnew, 2 );
         vertices.t_[ ivertex ] = tnew;
       }         
+
 #ifdef VI_DEBUG
       else {
-	edm::LogInfo("sumw") << "invalid sum of weights in fit: " << vertices.sw_[ivertex] << endl;
+	edm::LogInfo("sumw") << "invalid sum of weights in fit: " << endl;//vertices.sw_[ivertex] << endl;
 	if (this->verbose_) {
 	  std::cout  << " a cluster melted away ?  pk=" << vertices.pk_[ ivertex ] << " sumw="
-		     << vertices.sw_[ivertex] << endl;
+		     << /*vertices.sw_[ivertex] << */ endl;
 	}
       }
 #endif
@@ -297,9 +323,141 @@ double DAClusterizerInZT_vect::update(double beta, track_t & gtracks,
 
 
 
+
+void DAClusterizerInZT_vect::zorder(vertex_t & y)const{
+  const unsigned int nv = y.getSize();
+
+  if (nv < 2) return;
+
+
+  bool reordering = true;
+  bool modified = false;
+
+  while(reordering){
+    reordering = false;
+    for (unsigned int k = 0; (k + 1) < nv; k++) {
+      if ( y.z[k + 1] < y.z[k] ) {
+	auto ztemp =  y.z[k];   y.z[k] = y.z[k+1];    y.z[k+1] = ztemp;
+	auto ttemp =  y.t[k];   y.t[k] = y.t[k+1];    y.t[k+1] = ttemp;
+	auto ptemp =  y.pk[k];  y.pk[k] = y.pk[k+1];  y.pk[k+1] = ptemp;
+	reordering = true;
+      }
+    }
+    modified |= reordering;
+  }
+  
+  if( modified ) y.extractRaw();
+}
+
+
+
+bool DAClusterizerInZT_vect::find_nearest( double z, double t, vertex_t & y, unsigned int & k_min, double dz, double dt)const{
+  // find the cluster nearest to (z,t)
+  // distance measure is   delta = (delta_z / dz )**2  + (delta_t/ d_t)**2
+  // assumes that clusters are ordered n z
+  // return value is false if o neighbour with distance < 1 is found
+
+  unsigned int nv = y.getSize();
+
+  // find nearest in z, binary search later
+  unsigned int k = 0;
+  for(unsigned int k0 = 1; k0 < nv; k0++){
+    if (std::abs( y.z_[k0]-z ) < std::abs( y.z_[k]-z )){
+      k = k0;
+    }
+  }
+
+  double delta_min = 1.;
+
+  //search left
+  unsigned int k1 = k;
+  while( ( k1 > 0) && ((y.z[k] - y.z[--k1]) < dz ) ){
+    auto delta = std::pow( (y.z_[k] - y.z_[k1]) / dz, 2)
+                +std::pow( (y.t_[k] - y.t_[k1]) / dt, 2);
+    if (delta < delta_min){
+      k_min = k1;
+      delta_min = delta;
+    }
+  }      
+
+  //search right
+  k1 = k;
+  while( ((++k1) < nv) && ((y.z[k1] - y.z[k]) < dz ) ){
+    auto delta = std::pow( (y.z_[k1] - y.z_[k]) / dz, 2)
+                +std::pow( (y.t_[k1] - y.t_[k]) / dt, 2);
+    if (delta < delta_min){
+      k_min = k1;
+      delta_min = delta;
+    }
+  }      
+    
+  return (delta_min < 1.);
+}
+
+
+
+
+bool DAClusterizerInZT_vect::merge(vertex_t & y, double & beta)const{
+  // merge clusters that collapsed or never separated,
+  // return true if vertices were merged, false otherwise
+  const unsigned int nv = y.getSize();
+
+  if (nv < 2)
+    return false;
+
+  // merge the smallest distance clusters first
+  unsigned int k1_min = 0, k2_min = 0;
+  double delta_min = 0;
+
+  for (unsigned int k1 = 0; (k1 + 1) < nv; k1++) {
+    unsigned int k2 = k1;
+    while( (++k2 < nv) && ( std::fabs(y.z[k2] - y.z_[k1] ) < zmerge_ ) ){
+      auto delta = std::pow( (y.z_[k2] - y.z_[k1]) / zmerge_, 2)
+	          +std::pow( (y.t_[k2] - y.t_[k1]) / tmerge_, 2);
+      if ( (delta < delta_min)  || (k1_min == k2_min) ){
+	k1_min = k1;
+        k2_min = k2;
+	delta_min = delta;
+      }
+    }
+  }
+
+  if( (k1_min  == k2_min) || (delta_min > 1) ){
+    return false;
+  }
+
+
+  double rho = y.pk_[k1_min] + y.pk_[k2_min];
+#ifdef VI_DEBUG
+  if(verbose_){ std::cout << "merging (" << setw(8) << fixed  << setprecision(4) << y.z_[k1_min] << ',' << y.t_[k1_min] << ") and (" <<  y.z_[k2_min] << ',' << y.t_[k2_min] << ")" <<  "  idx=" << k1_min << "," << k2_min << std::endl;}
+#endif
+  if(rho > 0){
+    y.z_[k1_min] = (y.pk_[k1_min] * y.z_[k1_min] + y.pk_[k2_min] * y.z_[k2_min])/rho;
+    y.t_[k1_min] = (y.pk_[k1_min] * y.t_[k1_min] + y.pk_[k2_min] * y.t_[k2_min])/rho;
+  }else{
+    y.z_[k1_min] = 0.5 * (y.z_[k1_min] + y.z_[k2_min]);
+    y.t_[k1_min] = 0.5 * (y.t_[k1_min] + y.t_[k2_min]);
+  }
+  y.pk_[k1_min] = rho;
+  /*unnecessary if we always update after merge
+  y.nuz_[k1_min] += y.nuz_[k2_min];
+  y.nut_[k1_min] += y.nut_[k2_min];
+  y.szz_[k_min] += y.szz_[k2_min];
+  y.stt_[k_min] += y.stt_[k2_min];
+  y.szt_[k_min] += y.szt_[k2_min];
+  */
+  y.removeItem(k2_min);
+  y.extractRaw();
+  return true;
+}
+
+
+
+/*
 bool DAClusterizerInZT_vect::merge(vertex_t & y, double & beta)const{
   // merge clusters that collapsed or never separated,
   // only merge if the estimated critical temperature of the merged vertex is below the current temperature
+  // FIXME / TODO  : don't have an estimate yet for the critical temperature after 2d merging, currently not tested
   // return true if vertices were merged, false otherwise
   const unsigned int nv = y.getSize();
 
@@ -313,7 +471,7 @@ bool DAClusterizerInZT_vect::merge(vertex_t & y, double & beta)const{
          std::fabs(y.t_[k + 1] - y.t_[k]) < tmerge_    ) {
       auto dt2 = std::pow(y.t_[k + 1] - y.t_[k],2);
       auto dz2 = std::pow(y.z_[k + 1] - y.z_[k],2);
-      critical.push_back( make_pair( dz2 + dt2, k ) );
+      critical.push_back( make_pair( dz2 + dt2, k ) );  // better use different scales for z/t ?
     }
   }
   if (critical.empty()) return false;
@@ -324,12 +482,10 @@ bool DAClusterizerInZT_vect::merge(vertex_t & y, double & beta)const{
   for (unsigned int ik=0; ik < critical.size(); ik++){
     unsigned int k = critical[ik].second;
     double rho = y.pk_[k]+y.pk_[k+1];
-    double swE = y.swE_[k]+y.swE_[k+1]-y.pk_[k]*y.pk_[k+1] / rho*( std::pow(y.z_[k+1]-y.z_[k],2) + std::pow(y.t_[k+1]-y.t_[k],2) );
-    double Tc = 2*swE / (y.sw_[k]+y.sw_[k+1]);
-
-    if(Tc*beta < 1){
+    double Tc  = 0;
+    //if(Tc*beta < 1){
 #ifdef VI_DEBUG
-      if(verbose_){ std::cout << "merging (" << y.z_[k + 1] << ',' << y.t_[k + 1] << ") and (" <<  y.z_[k] << ',' << y.t_[k] << ")  Tc = " << Tc <<  "  sw = "  << y.sw_[k]+y.sw_[k+1]  <<std::endl;}
+    if(verbose_){ std::cout << "merging (" << y.z_[k + 1] << ',' << y.t_[k + 1] << ") and (" <<  y.z_[k] << ',' << y.t_[k] << ")  Tc = " << Tc <<  / *"  sw = "  << y.sw_[k]+y.sw_[k+1]  <<* / std::endl;}
 #endif
       if(rho > 0){
 	y.z_[k] = (y.pk_[k]*y.z_[k] + y.pk_[k+1]*y.z_[k + 1])/rho;
@@ -339,16 +495,19 @@ bool DAClusterizerInZT_vect::merge(vertex_t & y, double & beta)const{
         y.t_[k] = 0.5 * (y.t_[k] + y.t_[k + 1]);
       }
       y.pk_[k] = rho;
-      y.sw_[k] += y.sw_[k+1];
-      y.swE_[k] = swE;
+      y.nuz_[k] += y.nuz_[k+1];
+      y.nut_[k] += y.nut_[k+1];
+      y.szz_[k] += y.szz_[k+1];
+      y.stt_[k] += y.stt_[k+1];
+      y.szt_[k] += y.szt_[k+1];
       y.removeItem(k+1);
       return true;
-    }
+      // }
   }
 
   return false;
 }
-
+*/
 
 
 
@@ -413,7 +572,7 @@ DAClusterizerInZT_vect::purge(vertex_t & y, track_t & tks, double & rho0, const 
   if (k0 != nv) {
 #ifdef VI_DEBUG
     if (verbose_) {
-      std::cout  << "eliminating prototype at " << std::setw(10) << std::setprecision(4) << y.z_[k0] 
+      std::cout  << "eliminating prototype at " << std::setw(10) << std::setprecision(4) << y.z_[k0] << "," << y.t_[k0] 
 		 << " with sump=" << sumpmin
 		 << "  rho*nt =" << y.pk_[k0]*nt
 		 << endl;
@@ -442,26 +601,36 @@ DAClusterizerInZT_vect::beta0(double betamax, track_t const  & tks, vertex_t con
     // vertex fit at T=inf
     double sumwz = 0;
     double sumwt = 0;
-    double sumw = 0;
+    double sumw_z = 0;
+    double sumw_t = 0;
     for (unsigned int i = 0; i < nt; i++) {
-      double w = tks.pi_[i] * tks.errsum_[i];
-      sumwz += w * tks.z_[i];
-      sumwt += w * tks.t_[i];
-      sumw += w;
+      double w_z = tks.pi_[i] * tks.dz2_[i];
+      double w_t = tks.pi_[i] * tks.dt2_[i];
+      sumwz += w_z * tks.z_[i];
+      sumwt += w_t * tks.t_[i];
+      sumw_z += w_z;
+      sumw_t += w_t;
     }
-    y.z_[k] = sumwz / sumw;
-    y.t_[k] = sumwt / sumw;
+    y.z_[k] = sumwz / sumw_z;
+    y.t_[k] = sumwt / sumw_t;
     
-    // estimate Tcrit, eventually do this in the same loop
-    double a = 0, b = 0;
+    // estimate Tc, eventually do this in the same loop
+    double szz = 0, stt = 0, szt = 0;
+    double nuz = 0, nut = 0;
     for (unsigned int i = 0; i < nt; i++) {
-      double dx = tks.z_[i] - y.z_[k];
-      double dt = tks.t_[i] - y.t_[k];
-      double w = tks.pi_[i] * tks.errsum_[i];
-      a += w * std::pow(dx, 2) * tks.dz2_[i] + std::pow(dt,2) * tks.dt2_[i];
-      b += w;
+      double dz = (tks.z_[i] - y.z_[k]) * tks.dz2_[i];
+      double dt = (tks.t_[i] - y.t_[k]) * tks.dt2_[i];
+      double w = tks.pi_[i];
+      szz += w * dz * dz;
+      stt += w * dt * dt;
+      szt += w * dz * dt;
+      nuz += w * tks.dz2_[i];
+      nut += w * tks.dt2_[i];
     }
-    double Tc = 2. * a / b; // the critical temperature of this vertex
+    double Tz = szz/nuz;
+    double Tt = stt/nut;
+    double Tc = Tz + Tt + sqrt( pow(Tz - Tt, 2) + 4 * szt * szt / nuz / nut);
+
     if (Tc > T0) T0 = Tc;
   }// vertex loop (normally there should be only one vertex at beta=0)
   
@@ -482,7 +651,18 @@ DAClusterizerInZT_vect::beta0(double betamax, track_t const  & tks, vertex_t con
   }
 }
 
-
+double DAClusterizerInZT_vect::get_Tc(const vertex_t & y, int k)const{
+  double Tz = y.szz_[k]/y.nuz_[k];  // actually 0.5*Tc(z)
+  double Tt = y.stt_[k]/y.nut_[k];
+  double mx = y.szt_[k]/y.nuz_[k]*y.szt_[k]/y.nut_[k];
+  /*
+  cout << "get_Tc " << endl;
+  cout << "szz=" << scientific << y.szz[k] << "   stt=" << y.stt_[k] << "   szt=" << y.szt_[k] << endl;
+  cout << "nuz=" << scientific << y.nuz[k] << "   nut=" << y.nut_[k] << endl;
+  cout << "Tz=" << scientific << 2*Tz << "   Tt=" << 2*Tt << endl;
+  */
+  return Tz + Tt + sqrt(pow(Tz - Tt, 2) + 4 * mx);
+}
   
 bool 
 DAClusterizerInZT_vect::split(const double beta,  track_t &tks, vertex_t & y, double threshold ) const{
@@ -493,12 +673,13 @@ DAClusterizerInZT_vect::split(const double beta,  track_t &tks, vertex_t & y, do
   constexpr double epsilonz=1e-3;      // minimum split size z
   constexpr double epsilont=1e-2;      // minimum split size t
   unsigned int nv = y.getSize();
+  const double twoBeta = 2.0*beta;
   
   // avoid left-right biases by splitting highest Tc first
   
   std::vector<std::pair<double, unsigned int> > critical;
   for(unsigned int k=0; k<nv; k++){    
-    double Tc= 2*y.swE_[k]/y.sw_[k];
+    double Tc= get_Tc(y, k);                                                                                         
     if (beta*Tc > threshold){
       critical.push_back( make_pair(Tc, k));
     }
@@ -507,61 +688,99 @@ DAClusterizerInZT_vect::split(const double beta,  track_t &tks, vertex_t & y, do
 
 
   std::stable_sort(critical.begin(), critical.end(), std::greater<std::pair<double, unsigned int> >() );
-  
-  
+
   bool split=false;
   const unsigned int nt = tks.getSize();
 
   for(unsigned int ic=0; ic<critical.size(); ic++){
     unsigned int k=critical[ic].second;
 
+    // split direction in the (z,t)-plane
+    
+    double Mzz = y.nuz_[k] - twoBeta*y.szz_[k];
+    double Mtt = y.nut_[k] - twoBeta*y.stt_[k];
+    double Mzt =           - twoBeta*y.szt_[k];
+    const double twoMzt = 2.0*Mzt;
+    double D = sqrt( pow(Mtt-Mzz, 2) + twoMzt*twoMzt);
+    double l1 = 0.5*(-Mzz-Mtt+D);
+    double q1 = atan2(-Mtt+Mzz+D, -twoMzt);
+#ifdef VI_DEBUG
+    if(verbose_){
+      double l2 = 0.5*(-Mzz-Mtt-D);
+      //double q2 = atan2(-Mtt+Mzz-D, -twoMzt);
+      //      cout << "split matrix  idx = " << k << "  l1=" <<  scientific << l1 << "  l2="<< l2 << "  q1=" << q1 << "  q2= "<< q2 << endl;
+      if( (std::abs(l1) < 1e-4)&&(std::abs(l2) < 1e-4) ){
+	cout << "warning, bad eigenvalues!  idx=" << k << " z= " << y.z_[k] << " Mzz=" << Mzz << "   Mtt=" << Mtt << "  Mzt=" << Mzt << endl; 
+      }
+    }
+#endif
+
+    double qsplit = q1;
+    double cq = cos(qsplit);
+    double sq = sin(qsplit);
+    if(cq < 0){ cq=-cq; sq=-sq; } // prefer cq>0 to keep z-ordering
+
     // estimate subcluster positions and weight
-    double p1=0, z1=0, t1=0, w1=0;
-    double p2=0, z2=0, t2=0, w2=0;
+    double p1=0, z1=0, t1=0, wz1=0, wt1=0;
+    double p2=0, z2=0, t2=0, wz2=0, wt2=0;
     for(unsigned int i=0; i<nt; ++i){
       if (tks.Z_sum_[i] > 1.e-100) {
+	double lr = (tks.z_[i]-y.z_[k]) * cq + (tks.t[i] - y.t_[k]) * sq;
 	// winner-takes-all, usually overestimates splitting
-	double tl = tks.z_[i] < y.z_[k] ? 1.: 0.;
+	double tl = lr < 0 ? 1.: 0.;
 	double tr = 1. - tl;
 
-	// soften it, especially at low T
-	/*
-	double arg = ( tks.z_[i] - y.z_[k] ) * sqrt(beta * tks.dz2_[i]); // + std::fabs(tks.t_[i] - y.t_[k])
-	std::cout << arg << std::endl;
-	if(std::fabs(arg) < 20){
+	// soften it, especially at low T	
+	double arg = lr * std::sqrt(beta * ( cq*cq*tks.dz2_[i] + sq*sq*tks.dt2_[i] ) ); 
+	if(std::abs(arg) < 20){
 	  double t = local_exp(-arg);
 	  tl = t/(t+1.);
 	  tr = 1/(t+1.);
 	}
-	*/
 
 	double p = y.pk_[k] * tks.pi_[i] * local_exp(-beta * Eik(tks.z_[i], y.z_[k], tks.dz2_[i], 
                                                                  tks.t_[i], y.t_[k], tks.dt2_[i])) / tks.Z_sum_[i];
-	double w = p*tks.errsum_[i];
-	p1 += p*tl;  z1 += w*tl*tks.z_[i]; t1 += w*tl*tks.t_[i]; w1 += w*tl;
-	p2 += p*tr;  z2 += w*tr*tks.z_[i]; t2 += w*tr*tks.t_[i]; w2 += w*tr;
+	double wz = p*tks.dz2_[i];
+	double wt = p*tks.dt2_[i];
+	p1 += p*tl;  z1 += wz*tl*tks.z_[i]; t1 += wt*tl*tks.t_[i]; wz1 += wz*tl; wt1 += wt*tl;
+	p2 += p*tr;  z2 += wz*tr*tks.z_[i]; t2 += wt*tr*tks.t_[i]; wz2 += wz*tr; wt2 += wt*tr;
       }
     }
 
-    if(w1>0){z1 = z1/w1; t1 = t1/w1;} else {z1=y.z_[k]-epsilonz; t1=y.t_[k]-epsilont;}
-    if(w2>0){z2 = z2/w2; t2 = t2/w2;} else {z2=y.z_[k]+epsilonz; t2=y.t_[k]+epsilont;}
-    
+    if(wz1 > 0){z1 /= wz1;} else {z1 = y.z_[k] - epsilonz * cq; cout << "warning, wz1 = " << scientific << wz1 << endl;}
+    if(wt1 > 0){t1 /= wt1;} else {t1 = y.t_[k] - epsilont * sq; cout << "warning, w11 = " << scientific << wt1 << endl;}
+    if(wz2 > 0){z2 /= wz2;} else {z2 = y.z_[k] + epsilonz * cq; cout << "warning, wz2 = " << scientific << wz2 << endl;}
+    if(wt2 > 0){t2 /= wt2;} else {t2 = y.t_[k] + epsilont * sq; cout << "warning, wt2 = " << scientific << wt2 << endl;}
+
+    unsigned int k_min1, k_min2;
+    while(   (find_nearest(z1, t1, y, k_min1, epsilonz, epsilont) && (k_min1 != k))
+	     || (find_nearest(z2,t2, y, k_min2, epsilonz, epsilont) && (k_min2 !=k)) ){
+      z1 = 0.5*( z1 + y.z_[k]);      z1 = 0.5*( t1 + y.z_[k]);
+      z2 = 0.5*( z2 + y.z_[k]);      t2 = 0.5*( t2 + y.z_[k]);
+      cout << " reducing split size @ " << y.z_[k] << endl;
+    }
+
+    /*
     // reduce split size if there is not enough room
     if( ( k   > 0 ) && ( z1 < (0.6*y.z_[k] + 0.4*y.z_[k-1])) ){ 
-      z1 = 0.5*y.z_[k] + 0.5*y.z_[k-1]; 
-      t1 = 0.5*y.t_[k] + 0.5*y.t_[k-1]; 
+      cout << "warning, reducing split size @ z=" << y.z_[k] << endl;
+      z1 = 0.6*y.z_[k] + 0.4*y.z_[k-1]; 
+      t1 = 0.6*y.t_[k] + 0.4*y.t_[k-1];  // maybe not in t ?
     }
     if( ( k+1 < nv) && ( z2 > (0.6*y.z_[k] + 0.4*y.z_[k+1])) ){ 
-      z2 = 0.5*y.z_[k] + 0.5*y.z_[k+1]; 
-      t2 = 0.5*y.t_[k] + 0.5*y.t_[k+1]; 
+      cout << "warning, reducing split size @ z=" << y.z_[k] << endl;
+      z2 = 0.6*y.z_[k] + 0.4*y.z_[k+1]; 
+      t2 = 0.6*y.t_[k] + 0.4*y.t_[k+1]; 
     }
+    */
     
 #ifdef VI_DEBUG
     if(verbose_){
       if (std::fabs(y.z_[k] - zdumpcenter_) < zdumpwidth_){
-	std::cout << " T= " << std::setw(8) << 1./beta 
+	std::cout << " T= " << std::setw(10) << std::setprecision(1) << 1./beta 
 		  << " Tc= " << critical[ic].first 
-		  << "    splitting " << std::fixed << std::setprecision(4) << y.z_[k] 
+	          << " direction =" << std::setprecision(4) << qsplit 
+		  << "    splitting (" << std::setw(8) <<  std::fixed << std::setprecision(4) << y.z_[k] <<"," << y.t_[k] << ")"
 		  << " --> (" << z1 << ',' << t1<< "),(" << z2 << ',' << t2 
 		  << ")     [" << p1 << "," << p2 << "]" ;
 	if (std::fabs(z2-z1) > epsilonz || std::fabs(t2-t1) > epsilont){
@@ -573,22 +792,48 @@ DAClusterizerInZT_vect::split(const double beta,  track_t &tks, vertex_t & y, do
     }
 #endif
 
+    if(z1>z2){
+      edm::LogInfo("DAClusterizerInZT") << "warning   swapping z in split  qsplit=" << qsplit << "   cq=" << cq << "  sq=" << sq << endl;
+      auto ztemp = z1;
+      auto ttemp = t1;
+      auto ptemp = p1;
+      z1 = z2; t1=t2; p1=p2;
+      z2 = ztemp; t2=ttemp; p2=ptemp; 
+    }
+
+
+
+
     // split if the new subclusters are significantly separated
     if( std::fabs(z2-z1) > epsilonz || std::fabs(t2-t1) > epsilont){
       split = true;
       double pk1 = p1*y.pk_[k]/(p1+p2);
       double pk2 = p2*y.pk_[k]/(p1+p2);
-      y.z_[k]  =  z2;
-      y.t_[k]  =  t2;
-      y.pk_[k] = pk2;
-      y.insertItem(k, z1, t1, pk1);
+
+      // replace the original by (z2,t2)
+      y.removeItem(k);
+      unsigned int k2 = y.insertOrdered(z2, t2, pk2);
+      // adjust pointers if necessary
+      if( !(k == k2) ){
+	for(unsigned int jc=ic; jc < critical.size(); jc++){
+	  if (critical[jc].second > k ) {critical[jc].second--;}
+	  if (critical[jc].second >= k2) {critical[jc].second++;}
+	}
+      }
+      
+      // insert (z1,t1) where it belongs
+      unsigned int k1 = y.insertOrdered(z1, t1, pk1);
       nv++;
 
      // adjust remaining pointers
       for(unsigned int jc=ic; jc < critical.size(); jc++){
-        if (critical[jc].second > k) {critical[jc].second++;}
+        if (critical[jc].second >= k1) {critical[jc].second++;} // need to backport the ">-"?
       }
+
+    }else{
+      cout << "warning ! split rejected, too small." << endl;
     }
+
   }
   return split;
 }
@@ -608,7 +853,7 @@ void DAClusterizerInZT_vect::splitAll( vertex_t & y) const {
 #ifdef VI_DEBUG
   if (verbose_) {
     std::cout << "Before Split "<< std::endl;
-    y.DebugOut();
+    y.debugOut();
   }
 #endif
 
@@ -651,7 +896,7 @@ void DAClusterizerInZT_vect::splitAll( vertex_t & y) const {
 #ifdef VI_DEBUG
   if (verbose_) {
     std::cout << "After split " << std::endl;
-    y.DebugOut();
+    y.debugOut();
   }
 #endif
 }
@@ -694,6 +939,7 @@ DAClusterizerInZT_vect::vertices(const vector<reco::TransientTrack> & tracks, co
   while (beta < betafreeze) {
     if(useTc_){
       update(beta, tks,y, false, rho0);
+      zorder(y);
       while(merge(y, beta)){update(beta, tks, y, false, rho0);}
       split(beta, tks, y);
       beta=beta/coolingFactor_;
@@ -707,7 +953,9 @@ DAClusterizerInZT_vect::vertices(const vector<reco::TransientTrack> & tracks, co
     while ((update(beta, tks, y, false, rho0) > 1.e-6) && 
 	   (niter++ < maxIterations_)) {}
 
-    if(verbose_){ dump( beta, y, tks, 0); }
+#ifdef VI_DEBUG
+   if(verbose_){ dump( beta, y, tks, 0); }
+#endif
   }
   
 
@@ -717,12 +965,16 @@ DAClusterizerInZT_vect::vertices(const vector<reco::TransientTrack> & tracks, co
     if(verbose_){ std::cout << "last spliting at " << 1./beta << std::endl; }
 #endif
     update(beta, tks,y, false, rho0);// make sure Tc is up-to-date
+    zorder(y);
     while(merge(y,beta)){update(beta, tks,y, false, rho0);}
     unsigned int ntry=0;
     double threshold = 1.0;
     while( split(beta, tks, y, threshold) && (ntry++<10) ){
       niter=0; 
       while((update(beta, tks,y, false, rho0)>1.e-6)  && (niter++ < maxIterations_)){}
+      zorder(y);
+      if(verbose_) dump(beta, y, tks, 2); 
+
       while(merge(y,beta)){update(beta, tks,y, false, rho0);}
 #ifdef VI_DEBUG
       if(verbose_){ 
@@ -763,6 +1015,7 @@ DAClusterizerInZT_vect::vertices(const vector<reco::TransientTrack> & tracks, co
 #endif
 
   // merge again  (some cluster split by outliers collapse here)
+  zorder(y);
   while (merge(y, beta)) {update(beta, tks, y, true, rho0); }
 #ifdef VI_DEBUG
   if (verbose_) {
@@ -782,7 +1035,8 @@ DAClusterizerInZT_vect::vertices(const vector<reco::TransientTrack> & tracks, co
   // eliminate insigificant vertices, this is more restrictive at higher T
   while (purge(y, tks, rho0, beta)) {
     niter = 0;
-    while (( update(beta, tks, y, true, rho0) >  2.5e-7 * y.getSize() ) && (niter++ < maxIterations_)) {
+    while (( update(beta, tks, y, true, rho0) >  1.e-6 ) && (niter++ < maxIterations_)) {
+      zorder(y);
     }
   }
 
@@ -799,6 +1053,7 @@ DAClusterizerInZT_vect::vertices(const vector<reco::TransientTrack> & tracks, co
     beta = min( beta/coolingFactor_, betastop_);
     niter =0;
     while ((update(beta, tks, y, true, rho0) > 1.e-8) && (niter++ < maxIterations_)) {}
+    zorder(y);
   }
 
 #ifdef VI_DEBUG
@@ -807,6 +1062,12 @@ DAClusterizerInZT_vect::vertices(const vector<reco::TransientTrack> & tracks, co
     dump(beta, y, tks, 2);
   }
 #endif
+
+
+  // new, merge here and not in "clusterize"
+  // final merging step
+  double betadummy = 1;
+  while( merge(y, betadummy) );
 
   // select significant tracks and use a TransientVertex as a container
   GlobalError dummyError(0.01, 0, 0.01, 0., 0., 0.01);
@@ -841,7 +1102,7 @@ DAClusterizerInZT_vect::vertices(const vector<reco::TransientTrack> & tracks, co
 	}
       }
     }
-    TransientVertex v(pos, dummyError, vertexTracks, 0);
+    TransientVertex v(pos, y.t_[k], dummyError, vertexTracks, 0);
     clusters.push_back(v);
   }
 
@@ -865,20 +1126,31 @@ vector<vector<reco::TransientTrack> > DAClusterizerInZT_vect::clusterize(
   
 #ifdef VI_DEBUG
   if (verbose_) {
-    std::cout  << "# DAClusterizerInZT::clusterize   pv.size=" << pv.size()
-					     << endl;
+    std::cout  << "# DAClusterizerInZT::clusterize   pv.size=" << pv.size() << endl;
   }
 #endif
 
   if (pv.empty()) {
     return clusters;
   }
-  
+
+  // fill into clusters, don't merge
+   for (auto k = pv.begin(); k != pv.end(); k++) {
+     vector<reco::TransientTrack> aCluster = k->originalTracks();
+      if (aCluster.size()>1){
+	clusters.push_back(aCluster);
+      }
+   }
+
+   return clusters;
+
+   /*
   // fill into clusters and merge
   vector<reco::TransientTrack> aCluster = pv.begin()->originalTracks();
   
   for (auto k = pv.begin() + 1; k != pv.end(); k++) {
-    if ( std::abs(k->position().z() - (k - 1)->position().z()) > (2 * vertexSize_)) {
+     if (  (std::abs(k->position().z() - (k - 1)->position().z()) > (2 * vertexSize_))
+	  ||(std::abs(k->time() - (k - 1)->time() ) > (2 * vertexSizeTime_)) ){ // still not perfect
       // close a cluster
       if (aCluster.size()>1){
 	clusters.push_back(aCluster);
@@ -899,7 +1171,7 @@ vector<vector<reco::TransientTrack> > DAClusterizerInZT_vect::clusterize(
   clusters.emplace_back(std::move(aCluster));
   
   return clusters;
-
+   */
 }
 
 
@@ -915,25 +1187,45 @@ void DAClusterizerInZT_vect::dump(const double beta, const vertex_t & y,
 	std::sort(iz.begin(), iz.end(), [tks](unsigned int a, unsigned int b){ return tks.z_[a]<tks.z_[b];} ); 
 	std::cout  << std::endl;
 	std::cout  << "-----DAClusterizerInZT::dump ----" <<  nv << "  clusters " << std::endl;
-	std::cout  << "                                                                z= ";
+	string h = "                                                                                 ";
+	std::cout  << h << " k= ";
+	for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex) {
+	  if (std::fabs(y.z_[ivertex]-zdumpcenter_) < zdumpwidth_){
+	    std::cout  << setw(8) << fixed << ivertex;
+	  }
+	}
+	std::cout  << endl;
+
+	std::cout  << h << " z= ";
 	std::cout  << setprecision(4);
 	for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex) {
 	  if (std::fabs(y.z_[ivertex]-zdumpcenter_) < zdumpwidth_){
 		std::cout  << setw(8) << fixed << y.z_[ivertex];
 	  }
 	}
-	std::cout  << endl << "T=" << setw(15) << 1. / beta
-		   << " Tmin =" << setw(10) << 1./betamax_
-			<< "                             Tc= ";
+	std::cout  << endl;
+
+	std::cout  << h << " t= ";
+	std::cout  << setprecision(4);
 	for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex) {
 	  if (std::fabs(y.z_[ivertex]-zdumpcenter_) < zdumpwidth_){
-	    double Tc = 2*y.swE_[ivertex]/y.sw_[ivertex];
+		std::cout  << setw(8) << fixed << y.t_[ivertex];
+	  }
+	}
+	std::cout  << endl;
+
+	std::cout  << "T=" << setw(15) << 1. / beta
+		   << " Tmin =" << setw(10) << 1./betamax_
+			<< "                                               Tc= ";
+	for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex) {
+	  if (std::fabs(y.z_[ivertex]-zdumpcenter_) < zdumpwidth_){
+	    double Tc = get_Tc(y, ivertex);
 	    std::cout  << setw(8) << fixed << setprecision(1) <<  Tc;
 	  }
 	}
 	std::cout  << endl;
 
-	std::cout  <<  "                                                               pk= ";
+	std::cout  <<  h << "pk= ";
 	double sumpk = 0;
 	for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex) {
 		sumpk += y.pk_[ivertex];
@@ -942,7 +1234,7 @@ void DAClusterizerInZT_vect::dump(const double beta, const vertex_t & y,
 	}
 	std::cout  << endl;
 
-	std::cout << "                                                               nt= ";
+	std::cout << h << "nt= ";
 	for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex) {
 		sumpk += y.pk_[ivertex];
 		if  (std::fabs(y.z_[ivertex] - zdumpcenter_) > zdumpwidth_) continue;
@@ -954,7 +1246,7 @@ void DAClusterizerInZT_vect::dump(const double beta, const vertex_t & y,
 		double E = 0, F = 0;
 		std::cout  << endl;
 		std::cout 
-		<< "----        z +/- dz                ip +/-dip       pt    phi  eta    weights  ----"
+		<< "----        z +/- dz          t +/- dt                ip +/-dip       pt    phi  eta   weights  ----"
 		<< endl;
 		std::cout  << setprecision(4);
 		for (unsigned int i0 = 0; i0 < nt; i0++) {
@@ -967,6 +1259,13 @@ void DAClusterizerInZT_vect::dump(const double beta, const vertex_t & y,
 			if( std::fabs(tz - zdumpcenter_) > zdumpwidth_) continue;
 			std::cout  << setw(4) << i << ")" << setw(8) << fixed << setprecision(4)
 			 << tz << " +/-" << setw(6) << sqrt(1./tks.dz2_[i]);
+
+			if( tks.dt2_[i] >0){
+			  std::cout  <<  setw(8) << fixed << setprecision(4)
+				     << tks.t_[i] << " +/-" << setw(6) << sqrt(1./tks.dt2_[i]);
+			}else{
+			  std::cout  <<  "                  ";
+			}
 
 			if (tks.tt[i]->track().quality(reco::TrackBase::highPurity)) {
 				std::cout  << " *";


### PR DESCRIPTION
This PR implements an improved splitting strategy and better Tcrit definition for track clusters in time-aware vertexing. Improvements are from @werdmann.

This significantly speeds up vertexing to the point that the minimum pT cut that has been in place before may be removed.