### PR TITLE
Trk hit assoc log debug

### DIFF
--- a/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
+++ b/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
@@ -98,7 +98,7 @@ class TrackerHitAssociator {
   std::vector<SimHitIdpr> associateFastRecHit(const FastTrackerRecHit * rechit) const;
   std::vector<SimHitIdpr> associateMultiRecHitId(const SiTrackerMultiRecHit * multirechit, std::vector<simhitAddr>* simhitCFPos=nullptr) const;
   std::vector<PSimHit>    associateMultiRecHit(const SiTrackerMultiRecHit * multirechit) const;
-  
+ 
   
   typedef std::map<unsigned int, std::vector<PSimHit> > simhit_map;
   simhit_map SimHitMap;
@@ -109,6 +109,7 @@ class TrackerHitAssociator {
   typedef std::vector<std::string> vstring;
 
   void makeMaps(const edm::Event& theEvent, const Config& config);
+  inline std::string printDetBnchEvtTrk(const DetId& detid, const uint32_t& detID, std::vector<SimHitIdpr>& simtrackid) const;
   edm::Handle< edm::DetSetVector<StripDigiSimLink> >  stripdigisimlink;
   edm::Handle< edm::DetSetVector<PixelDigiSimLink> >  pixeldigisimlink;
   edm::Handle< edm::DetSetVector<PixelDigiSimLink> >  ph2trackerdigisimlink;

--- a/SimTracker/TrackerHitAssociation/python/test/messageLoggerDebug_cff.py
+++ b/SimTracker/TrackerHitAssociation/python/test/messageLoggerDebug_cff.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+from FWCore.MessageService.MessageLogger_cfi import *
+# MessageLogger.destinations = cms.untracked.vstring('cout')
+MessageLogger.debugModules.append('testassociator')
+MessageLogger.categories.append('TrkHitAssocTrace')
+MessageLogger.categories.append('TrkHitAssocDbg')
+MessageLogger.cout = cms.untracked.PSet(
+  threshold = cms.untracked.string('DEBUG'),
+  default = cms.untracked.PSet( limit = cms.untracked.int32(0) )
+    , TrkHitAssocTrace = cms.untracked.PSet(limit = cms.untracked.int32(-1))
+    , TrkHitAssocDbg = cms.untracked.PSet(limit = cms.untracked.int32(-1))
+)

--- a/SimTracker/TrackerHitAssociation/test/TestAssoc_Phase0-1_cfg.py
+++ b/SimTracker/TrackerHitAssociation/test/TestAssoc_Phase0-1_cfg.py
@@ -1,0 +1,113 @@
+# Imports
+import FWCore.ParameterSet.Config as cms
+import os 
+
+# Create a new CMS process
+process = cms.Process('Phase01TrackerRecHitTest')
+
+from Configuration.StandardSequences.Eras import eras  # wtf(2)
+process = cms.Process('assocTest',eras.Run2_2017)
+
+# Import all the necessary files
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+### "Run2"
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+
+process.load('Configuration.EventContent.EventContent_cff')  # wtf(5)
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.RawToDigi_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_cff')
+
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+# (See /Configuration/AlCa/python/autoCond.py)
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_realistic', '')
+# Process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+
+# Input source
+process.source = cms.Source('PoolSource',
+  fileNames = cms.untracked.vstring(
+'/store/relval/CMSSW_9_4_0_pre1/RelValSingleMuPt100/GEN-SIM-DIGI-RAW/93X_mc2017_realistic_v3-v1/00000/409345CD-F79C-E711-8383-0CC47A4D76C8.root',
+'/store/relval/CMSSW_9_4_0_pre1/RelValSingleMuPt100/GEN-SIM-DIGI-RAW/93X_mc2017_realistic_v3-v1/00000/9C783844-F79C-E711-96E3-0CC47A4D76AA.root',
+'/store/relval/CMSSW_9_4_0_pre1/RelValSingleMuPt100/GEN-SIM-DIGI-RAW/93X_mc2017_realistic_v3-v1/00000/DC94E5C6-F79C-E711-B3EC-0CC47A4D7606.root'
+
+# '/store/relval/CMSSW_9_0_0/RelValSingleMuPt100_UP15/GEN-SIM-DIGI-RAW-HLTDEBUG/90X_mcRun2_asymptotic_v5-v1/00000/00C6B64E-4B0F-E711-B45F-0CC47A7C3410.root',
+# '/store/relval/CMSSW_9_0_0/RelValSingleMuPt100_UP15/GEN-SIM-DIGI-RAW-HLTDEBUG/90X_mcRun2_asymptotic_v5-v1/00000/52E12C5D-4A0F-E711-8ACE-0025905A6104.root' 
+
+        #'file:/batch/handies/testFile.root'
+        #'file:/tmp/emiglior/step3.root'
+        #'file:'+os.environ.get('REMOTEDIR')+'/step3.root'
+  )
+)
+
+# Output
+process.TFileService = cms.Service('TFileService',
+    fileName = cms.string('file:Run2_Trk_rechits_validation.root')
+)
+
+process.mix.playback = True  # wtf (3)
+process.mix.digitizers = cms.PSet()
+for a in process.aliases: delattr(process, a)
+
+
+# RecHits are not persistent... re-create them on-the-fly
+process.load("RecoLocalTracker.SiPixelRecHits.SiPixelRecHits_cfi")
+
+# Insert this in path to see what products the event contains
+process.content = cms.EDAnalyzer("EventContentAnalyzer")
+
+# Analyzer
+process.testassociator = cms.EDAnalyzer("TestAssociator",
+   siPixelRecHits = cms.InputTag("siPixelRecHits"),
+   matchedRecHit = cms.InputTag("siStripMatchedRecHits", "matchedRecHit"),
+   rphiRecHit = cms.InputTag("siStripMatchedRecHits", "rphiRecHit"),
+   stereoRecHit = cms.InputTag("siStripMatchedRecHits", "stereoRecHit"),
+   siPhase2RecHits = cms.InputTag("siPhase2RecHits"),
+   ### for using track hit association
+   #
+   associateRecoTracks = cms.bool(False),
+   associateHitbySimTrack = cms.bool(False),
+   associatePixel = cms.bool(True),       
+   associateStrip = cms.bool(True),
+   usePhase2Tracker = cms.bool(False),
+   pixelSimLinkSrc = cms.InputTag("simSiPixelDigis"),
+   stripSimLinkSrc = cms.InputTag("simSiStripDigis"),
+   phase2TrackerSimLinkSrc = cms.InputTag("simSiPixelDigis", "Tracker"),
+   ROUList = cms.vstring('TrackerHitsPixelBarrelLowTof',
+                         'TrackerHitsPixelBarrelHighTof',
+                         'TrackerHitsPixelEndcapLowTof',
+                         'TrackerHitsPixelEndcapHighTof',
+                         'TrackerHitsTIBLowTof',
+                         'TrackerHitsTIBHighTof',
+                         'TrackerHitsTIDLowTof',
+                         'TrackerHitsTIDHighTof',
+                         'TrackerHitsTOBLowTof',
+                         'TrackerHitsTOBHighTof',
+                         'TrackerHitsTECLowTof',
+                         'TrackerHitsTECHighTof')
+)
+
+# To enable debugging:
+# [scram b clean ;] scram b USER_CXXFLAGS="-DEDM_ML_DEBUG"
+
+# process.load("SimTracker.TrackerHitAssociation.test.messageLoggerDebug_cff")
+
+process.MessageLogger.cerr.FwkReport.reportEvery = 1
+
+# Number of events (-1 = all)
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(5) )
+
+# Processes to run
+
+process.raw2digi_step = cms.Path(process.RawToDigi)  # wtf (3)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+
+# process.validation_step = cms.Path(process.content*process.testassociator)
+process.validation_step = cms.Path(process.testassociator)
+
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.validation_step)

--- a/SimTracker/TrackerHitAssociation/test/TestAssoc_Phase2_cfg.py
+++ b/SimTracker/TrackerHitAssociation/test/TestAssoc_Phase2_cfg.py
@@ -1,0 +1,129 @@
+# Imports
+import FWCore.ParameterSet.Config as cms
+import os 
+
+# Create a new CMS process
+process = cms.Process('Phase2TrackerRecHitTest')
+
+from Configuration.StandardSequences.Eras import eras  # wtf(2)
+process = cms.Process('assocTest',eras.Phase2)
+
+# Import all the necessary files
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+### "Run2"
+# process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+
+### uncomment next fragment for "D17" 
+process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
+# temporary: use fake conditions for LA 
+process.load('SLHCUpgradeSimulations.Geometry.fakeConditions_phase2TkTilted4025_cff')
+### end of "D17"
+
+process.load('Configuration.StandardSequences.MagneticField_cff')
+
+process.load('Configuration.EventContent.EventContent_cff')  # wtf(5)
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.RawToDigi_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_cff')
+
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+# (See /Configuration/AlCa/python/autoCond.py)
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+'/store/relval/CMSSW_9_3_0/RelValSingleMuPt100Extended/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/00000/1C1AFFEE-429B-E711-9127-0CC47A7C345E.root',
+'/store/relval/CMSSW_9_3_0/RelValSingleMuPt100Extended/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/00000/362A31F1-3E9B-E711-8BCB-0025905B8598.root',
+'/store/relval/CMSSW_9_3_0/RelValSingleMuPt100Extended/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/00000/3C136CC9-4B9B-E711-A423-0025905AA9F0.root',
+'/store/relval/CMSSW_9_3_0/RelValSingleMuPt100Extended/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/00000/8E16441D-489B-E711-B6A7-0025905B8576.root',
+'/store/relval/CMSSW_9_3_0/RelValSingleMuPt100Extended/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/00000/A81F36AA-469B-E711-B45A-0CC47A4C8ECA.root'
+    )
+#     , secondaryFileNames = cms.untracked.vstring(
+# '/store/relval/CMSSW_9_3_0/RelValSingleMuPt100Extended/GEN-SIM-DIGI-RAW/93X_upgrade2023_realistic_v2_2023D17noPU-v1/00000/14F04A4A-3C9B-E711-9509-0CC47A4D764A.root',
+# '/store/relval/CMSSW_9_3_0/RelValSingleMuPt100Extended/GEN-SIM-DIGI-RAW/93X_upgrade2023_realistic_v2_2023D17noPU-v1/00000/18A33AC5-389B-E711-A7EA-0025905A60CE.root',
+# '/store/relval/CMSSW_9_3_0/RelValSingleMuPt100Extended/GEN-SIM-DIGI-RAW/93X_upgrade2023_realistic_v2_2023D17noPU-v1/00000/5C456E4D-3C9B-E711-8E08-0025905B8594.root',
+# '/store/relval/CMSSW_9_3_0/RelValSingleMuPt100Extended/GEN-SIM-DIGI-RAW/93X_upgrade2023_realistic_v2_2023D17noPU-v1/00000/C88F4190-339B-E711-B773-0025905B858A.root'
+#     )
+)
+
+# Output
+process.TFileService = cms.Service('TFileService',
+    fileName = cms.string('file:phase2Trk_rechits_validation.root')
+)
+
+process.mix.playback = True  # wtf (3)
+process.mix.digitizers = cms.PSet()
+for a in process.aliases: delattr(process, a)
+
+
+# RecHits are not persistent... re-create them on-the-fly
+process.load("RecoLocalTracker.SiPixelRecHits.SiPixelRecHits_cfi")
+process.load('RecoLocalTracker.SiPhase2Clusterizer.phase2TrackerClusterizer_cfi')
+process.load('RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEESProducer_cfi')
+process.load('RecoLocalTracker.Phase2TrackerRecHits.Phase2TrackerRecHits_cfi')
+# process.siPhase2RecHits.Phase2StripCPE = cms.ESInputTag("phase2StripCPEESProducer", "Phase2StripCPE")
+
+# Insert this in path to see what products the event contains
+process.content = cms.EDAnalyzer("EventContentAnalyzer")
+
+# Analyzer
+process.testassociator = cms.EDAnalyzer("TestAssociator",
+   siPixelRecHits = cms.InputTag("siPixelRecHits"),
+   matchedRecHit = cms.InputTag("siStripMatchedRecHits", "matchedRecHit"),
+   rphiRecHit = cms.InputTag("siStripMatchedRecHits", "rphiRecHit"),
+   stereoRecHit = cms.InputTag("siStripMatchedRecHits", "stereoRecHit"),
+   siPhase2RecHits = cms.InputTag("siPhase2RecHits"),
+   ### for using track hit association
+   #
+   associateRecoTracks = cms.bool(False),
+   associateHitbySimTrack = cms.bool(False),
+   associatePixel = cms.bool(True),       
+   associateStrip = cms.bool(True),
+   usePhase2Tracker = cms.bool(False),
+   pixelSimLinkSrc = cms.InputTag("simSiPixelDigis"),
+   stripSimLinkSrc = cms.InputTag("simSiStripDigis"),
+   phase2TrackerSimLinkSrc = cms.InputTag("simSiPixelDigis", "Tracker"),
+   ROUList = cms.vstring('TrackerHitsPixelBarrelLowTof',
+                         'TrackerHitsPixelBarrelHighTof',
+                         'TrackerHitsPixelEndcapLowTof',
+                         'TrackerHitsPixelEndcapHighTof',
+                         'TrackerHitsTIBLowTof',
+                         'TrackerHitsTIBHighTof',
+                         'TrackerHitsTIDLowTof',
+                         'TrackerHitsTIDHighTof',
+                         'TrackerHitsTOBLowTof',
+                         'TrackerHitsTOBHighTof',
+                         'TrackerHitsTECLowTof',
+                         'TrackerHitsTECHighTof')
+)
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(process.testassociator,
+   usePhase2Tracker = cms.bool(True),
+   siPhase2RecHits = cms.InputTag("siPhase2RecHits"),
+   pixelSimLinkSrc = cms.InputTag("simSiPixelDigis", "Pixel"),
+   phase2TrackerSimLinkSrc = cms.InputTag("simSiPixelDigis", "Tracker"),
+)
+
+# To enable debugging:
+# [scram b clean ;] scram b USER_CXXFLAGS="-DEDM_ML_DEBUG"
+
+# process.load("SimTracker.TrackerHitAssociation.test.messageLoggerDebug_cff")
+
+process.MessageLogger.cerr.FwkReport.reportEvery = 1
+
+# Number of events (-1 = all)
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(20) )
+
+# Processes to run
+
+process.rechits_step = cms.Path(process.siPixelRecHits*process.siPhase2Clusters*process.siPhase2RecHits)
+
+# process.validation_step = cms.Path(process.content*process.testassociator)
+process.validation_step = cms.Path(process.testassociator)
+
+process.schedule = cms.Schedule(process.rechits_step, process.validation_step)  # wtf

--- a/SimTracker/TrackerHitAssociation/test/TestAssociator.h
+++ b/SimTracker/TrackerHitAssociation/test/TestAssociator.h
@@ -3,33 +3,17 @@
 
 /* \class TestAssociator
  *
- * \author Patrizia Azzi (INFN PD), Vincenzo Chiochia (Uni Zuerich)
+ * \author Patrizia Azzi (INFN PD), Vincenzo Chiochia (Uni Zuerich), Bill Ford (Colorado)
  *
  *
  ************************************************************/
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
- 
- 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
- 
-//--- for SimHit
-#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
-#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
-#include "Geometry/CommonTopologies/interface/StripTopology.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 
-#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"                                                                                                                          
-//needed for the geometry:
-#include "DataFormats/DetId/interface/DetId.h"
-
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"                                                                                                    
 
 class TestAssociator : public edm::EDAnalyzer
 {
@@ -40,21 +24,21 @@ class TestAssociator : public edm::EDAnalyzer
   ~TestAssociator() override;
 
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
-  
-  std::vector<PSimHit> matched;
 
  private:
   
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;
-  const StripTopology* topol;
-  int numStrips;    // number of strips in the module
-  bool doPixel_, doStrip_;
+  bool doPixel_, doStrip_, useOTph2_;
 
   edm::EDGetTokenT<edmNew::DetSetVector<SiStripMatchedRecHit2D> > matchedRecHitToken;
   edm::EDGetTokenT<edmNew::DetSetVector<SiStripRecHit2D> > rphiRecHitToken,stereoRecHitToken;
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelRecHit> > siPixelRecHitsToken;
+  edm::EDGetTokenT<edmNew::DetSetVector<Phase2TrackerRecHit1D> > siPhase2RecHitsToken;
+
+  template<typename rechitType>
+    void printRechitSimhit(const edm::Handle<edmNew::DetSetVector<rechitType>> rechitCollection,
+			   const char* rechitName, int hitCounter, TrackerHitAssociator& associate) const;
+
 };
-
-
 
 #endif


### PR DESCRIPTION
Cleanup of TrackerHitAssociator per request of @kpedro88 for earlier PR#18354:  commented couts removed or replaced by LogDebug; auto iterator and range-based loops.  test/TestAssociator rewritten to replace duplicated code with a templated function, and add phase 2 tracker.