### PR TITLE
tuning of Strip QTest for higher PU/track-density

### DIFF
--- a/DQM/SiStripMonitorClient/data/sistrip_qualitytest_config.xml
+++ b/DQM/SiStripMonitorClient/data/sistrip_qualitytest_config.xml
@@ -58,7 +58,7 @@
         <PARAM name="MaxRel">5.</PARAM>
         <PARAM name="UseEmptyBins">0</PARAM>
         <PARAM name="MinAbs">0.</PARAM>
-        <PARAM name="MaxAbs">20.</PARAM> 
+        <PARAM name="MaxAbs">40.</PARAM> 
 	<PARAM name="error">0.30</PARAM>
         <PARAM name="warning">0.70</PARAM>
         <PARAM name="StatCut">100</PARAM>
@@ -69,7 +69,7 @@
         <PARAM name="MaxRel">5.</PARAM>
         <PARAM name="UseEmptyBins">0</PARAM>
         <PARAM name="MinAbs">0.</PARAM>
-        <PARAM name="MaxAbs">45.</PARAM>
+        <PARAM name="MaxAbs">90.</PARAM>
         <PARAM name="error">0.30</PARAM>
         <PARAM name="warning">0.70</PARAM>
         <PARAM name="StatCut">200</PARAM>

--- a/DQM/SiStripMonitorClient/data/sistrip_qualitytest_config_heavyion.xml
+++ b/DQM/SiStripMonitorClient/data/sistrip_qualitytest_config_heavyion.xml
@@ -50,7 +50,7 @@
         <PARAM name="MaxRel">5.</PARAM>
         <PARAM name="UseEmptyBins">0</PARAM>
         <PARAM name="MinAbs">0.</PARAM>
-        <PARAM name="MaxAbs">50.</PARAM> 
+        <PARAM name="MaxAbs">70.</PARAM> 
 	<PARAM name="error">0.30</PARAM>
         <PARAM name="warning">0.70</PARAM>
         <PARAM name="StatCut">100</PARAM>
@@ -61,7 +61,7 @@
         <PARAM name="MaxRel">5.</PARAM>
         <PARAM name="UseEmptyBins">0</PARAM>
         <PARAM name="MinAbs">0.</PARAM>
-        <PARAM name="MaxAbs">120.</PARAM>
+        <PARAM name="MaxAbs">180.</PARAM>
         <PARAM name="error">0.30</PARAM>
         <PARAM name="warning">0.70</PARAM>
         <PARAM name="StatCut">200</PARAM>

--- a/DQM/SiStripMonitorClient/data/sistrip_qualitytest_config_tier0.xml
+++ b/DQM/SiStripMonitorClient/data/sistrip_qualitytest_config_tier0.xml
@@ -54,7 +54,7 @@
         <PARAM name="MaxRel">5.</PARAM>
         <PARAM name="UseEmptyBins">0</PARAM>
         <PARAM name="MinAbs">0.001</PARAM>
-        <PARAM name="MaxAbs">20.</PARAM> 
+        <PARAM name="MaxAbs">40.</PARAM> 
 	<PARAM name="error">0.30</PARAM>
         <PARAM name="warning">0.70</PARAM>
         <PARAM name="StatCut">100</PARAM>
@@ -66,7 +66,7 @@
         <PARAM name="MaxRel">5.</PARAM>
         <PARAM name="UseEmptyBins">0</PARAM>
         <PARAM name="MinAbs">0.01</PARAM>
-        <PARAM name="MaxAbs">45.</PARAM>
+        <PARAM name="MaxAbs">90.</PARAM>
         <PARAM name="error">0.30</PARAM>
         <PARAM name="warning">0.70</PARAM>
         <PARAM name="StatCut">200</PARAM>

--- a/DQM/SiStripMonitorClient/data/sistrip_qualitytest_config_tier0_heavyions.xml
+++ b/DQM/SiStripMonitorClient/data/sistrip_qualitytest_config_tier0_heavyions.xml
@@ -50,7 +50,7 @@
         <PARAM name="MaxRel">5.</PARAM>
         <PARAM name="UseEmptyBins">0</PARAM>
         <PARAM name="MinAbs">0.</PARAM>
-        <PARAM name="MaxAbs">60.</PARAM> 
+        <PARAM name="MaxAbs">70.</PARAM> 
 	<PARAM name="error">0.30</PARAM>
         <PARAM name="warning">0.70</PARAM>
         <PARAM name="StatCut">100</PARAM>
@@ -61,7 +61,7 @@
         <PARAM name="MaxRel">5.</PARAM>
         <PARAM name="UseEmptyBins">0</PARAM>
         <PARAM name="MinAbs">0.</PARAM>
-        <PARAM name="MaxAbs">100.</PARAM>
+        <PARAM name="MaxAbs">180.</PARAM>
         <PARAM name="error">0.30</PARAM>
         <PARAM name="warning">0.70</PARAM>
         <PARAM name="StatCut">200</PARAM>


### PR DESCRIPTION
This PR tune the Strip QTest thresholds to cope with the higher PU in recent physics fills and with higher track density in view of the hi collisions