### PR TITLE
[93X backport of PR20723] Make muon HLT (L3/TkMu) work in phaseII scenarios

### DIFF
--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
@@ -67,12 +67,14 @@ void TSGForOI::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSe
   edm::ESHandle<MagneticField>                  magfieldH;
   edm::ESHandle<Propagator>                     propagatorAlongH;
   edm::ESHandle<Propagator>                     propagatorOppositeH;
+  edm::ESHandle<TrackerGeometry>                tmpTkGeometryH;  
   edm::ESHandle<GlobalTrackingGeometry>         geometryH;
 
   iSetup.get<IdealMagneticFieldRecord>().get(magfieldH);
   iSetup.get<TrackingComponentsRecord>().get("PropagatorWithMaterial", propagatorOppositeH);
   iSetup.get<TrackingComponentsRecord>().get("PropagatorWithMaterial", propagatorAlongH);
   iSetup.get<GlobalTrackingGeometryRecord>().get(geometryH);
+  iSetup.get<TrackerDigiGeometryRecord>().get(tmpTkGeometryH);
   iSetup.get<TrackingComponentsRecord>().get(estimatorName_,estimatorH);
   iEvent.getByToken(measurementTrackerTag_, measurementTrackerH);
 
@@ -85,8 +87,12 @@ void TSGForOI::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSe
 
   //	Get vector of Detector layers once:
   std::vector<BarrelDetLayer const*> const& tob = measurementTrackerH->geometricSearchTracker()->tobLayers();
-  std::vector<ForwardDetLayer const*> const& tecPositive = measurementTrackerH->geometricSearchTracker()->posTecLayers();
-  std::vector<ForwardDetLayer const*> const& tecNegative = measurementTrackerH->geometricSearchTracker()->negTecLayers();
+  std::vector<ForwardDetLayer const*> const& tecPositive = tmpTkGeometryH->isThere(GeomDetEnumerators::P2OTEC) ? 
+                                                                measurementTrackerH->geometricSearchTracker()->posTidLayers() : 
+                                                                measurementTrackerH->geometricSearchTracker()->posTecLayers(); 
+  std::vector<ForwardDetLayer const*> const& tecNegative = tmpTkGeometryH->isThere(GeomDetEnumerators::P2OTEC) ? 
+                                                                measurementTrackerH->geometricSearchTracker()->negTidLayers() : 
+                                                                measurementTrackerH->geometricSearchTracker()->negTecLayers();
   edm::ESHandle<TrackerTopology> tTopo_handle;
   iSetup.get<TrackerTopologyRcd>().get(tTopo_handle);
   const TrackerTopology* tTopo = tTopo_handle.product();

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
@@ -220,7 +220,7 @@ void TSGForOI::findSeedsOnLayer(
     LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: Start hitless" << endl;
     std::vector< GeometricSearchDet::DetWithState > dets;
     layer.compatibleDetsV(tsosAtIP, propagatorAlong, *estimatorH, dets);
-    if (dets.size()>0) {  
+    if (!dets.empty()) {  
       auto const& detOnLayer = dets.front().first;
       auto const& tsosOnLayer = dets.front().second;
       LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: tsosOnLayer " << tsosOnLayer << endl;

--- a/RecoTracker/MeasurementDet/plugins/MaskedMeasurementTrackerEventProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MaskedMeasurementTrackerEventProducer.cc
@@ -18,17 +18,18 @@ private:
 
       edm::EDGetTokenT<MeasurementTrackerEvent> src_;
 
+      bool skipClusters_;
+      bool phase2skipClusters_;
+
       edm::EDGetTokenT<StripMask> maskStrips_;
       edm::EDGetTokenT<PixelMask> maskPixels_;
       edm::EDGetTokenT<Phase2OTMask> maskPhase2OTs_;
-
-      bool skipClusters_;
-      bool phase2skipClusters_;
 };
 
 
 MaskedMeasurementTrackerEventProducer::MaskedMeasurementTrackerEventProducer(const edm::ParameterSet &iConfig) :
-    src_(consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("src")))
+    src_(consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("src"))),
+    skipClusters_(false), phase2skipClusters_(false)
 {
     //FIXME:temporary solution in order to use this class for both phase0/1 and phase2
     if (iConfig.existsAs<edm::InputTag>("clustersToSkip")) {

--- a/RecoTracker/MeasurementDet/plugins/MaskedMeasurementTrackerEventProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MaskedMeasurementTrackerEventProducer.cc
@@ -8,7 +8,7 @@
 class dso_hidden MaskedMeasurementTrackerEventProducer final : public edm::stream::EDProducer<> {
 public:
       explicit MaskedMeasurementTrackerEventProducer(const edm::ParameterSet &iConfig) ;
-      ~MaskedMeasurementTrackerEventProducer() {}
+      ~MaskedMeasurementTrackerEventProducer() override {}
 private:
       void produce(edm::Event&, const edm::EventSetup&) override;
 


### PR DESCRIPTION
This PR (backport of [PR 20723](https://github.com/cms-sw/cmssw/pull/20723)):
- makes `TSGForOI` work in Phase2  (as done for offline the outside-in muon iteration in [PR 18553](https://github.com/cms-sw/cmssw/pull/18553))
- fixes a small initilaization issue in `MaskedMeasurementTrackerEventProducer`