### PR TITLE
[90X] Backport HLT (EGamma/MuL3/TkMu) and validation changes for phaseII

### DIFF
--- a/DataFormats/EgammaReco/interface/ElectronSeed.h
+++ b/DataFormats/EgammaReco/interface/ElectronSeed.h
@@ -1,14 +1,38 @@
-#ifndef ElectronSeed_h
-#define ElectronSeed_h 1
+#ifndef DataFormats_EgammaReco_ElectronSeed_h
+#define DataFormats_EgammaReco_ElectronSeed_h
 
-/** \class reco::ElectronSeed
- *
- * ElectronSeed is a seed for gsf tracking,  constructed from
- * either a supercluster or a ctf track.
- *
- * \author D.Chamont, U.Berthon, C.Charlot, LLR Palaiseau
- *
- ************************************************************/
+//********************************************************************
+//
+// A verson of reco::ElectronSeed which can have N hits as part of the 
+// 2017 upgrade of E/gamma pixel matching for the phaseI pixels
+//
+// author: S. Harper (RAL), 2017
+//
+//notes:
+// While it is technically named ElectronSeed, it is effectively a new class
+// However to simplify things, the name ElectronSeed was kept
+// (trust me it was simplier...)
+//
+// Noticed that h/e values never seem to used anywhere and they are a 
+// mild pain to propagate in the new framework so they were removed
+//
+// infinities are used to mark invalid unset values to maintain 
+// compatibilty with the orginal ElectronSeed class
+//
+//description:
+// An ElectronSeed is a TrajectorySeed with E/gamma specific information
+// A TrajectorySeed has a series of hits associated with it 
+// (accessed by TrajectorySeed::nHits(), TrajectorySeed::recHits())
+// and ElectronSeed stores which of those hits match well to a supercluster
+// together with the matching parameters (this is known as EcalDriven).
+// ElectronSeeds can be TrackerDriven in which case the matching is not done.
+// It used to be fixed to two matched hits, now this is an arbitary number
+// Its designed with pixel matching with mind but tries to be generally 
+// applicable to strips as well.
+// It is worth noting that due to different ways ElectronSeeds can be created
+// they do not always have all parameters filled
+//
+//********************************************************************
 
 #include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
@@ -23,93 +47,124 @@
 #include <limits>
 
 namespace reco
- {
-
-class ElectronSeed : public TrajectorySeed
- {
+{
+  
+  class ElectronSeed : public TrajectorySeed {
   public :
+    struct PMVars {
+      float dRZPos;
+      float dRZNeg;
+      float dPhiPos;
+      float dPhiNeg;
+      int detId; //this is already stored as the hit is stored in traj seed but a useful sanity check
+      int layerOrDiskNr;//redundant as stored in detId but its a huge pain to hence why its saved here
 
+      PMVars();
+      
+      void setDPhi(float pos,float neg);
+      void setDRZ(float pos,float neg);
+      void setDet(int iDetId,int iLayerOrDiskNr);
+ 
+    };
+    
     typedef edm::OwnVector<TrackingRecHit> RecHitContainer ;
     typedef edm::RefToBase<CaloCluster> CaloClusterRef ;
     typedef edm::Ref<TrackCollection> CtfTrackRef ;
-
+ 
     static std::string const & name()
-     {
+    {
       static std::string const name_("ElectronSeed") ;
       return name_;
-     }
-
+    }
+    
     //! Construction of base attributes
     ElectronSeed() ;
     ElectronSeed( const TrajectorySeed & ) ;
     ElectronSeed( PTrajectoryStateOnDet & pts, RecHitContainer & rh,  PropagationDirection & dir ) ;
     ElectronSeed * clone() const { return new ElectronSeed(*this) ; }
-    virtual ~ElectronSeed() ;
+    virtual ~ElectronSeed();
 
     //! Set additional info
     void setCtfTrack( const CtfTrackRef & ) ;
-    void setCaloCluster
-     ( const CaloClusterRef &,
-       unsigned char hitsMask =0,
-       int subDet2 =0, int subDet1 =0,
-       float hoe1 =std::numeric_limits<float>::infinity(),
-       float hoe2 =std::numeric_limits<float>::infinity() ) ;
-    void setNegAttributes
-     ( float dRz2 =std::numeric_limits<float>::infinity(),
-       float dPhi2 =std::numeric_limits<float>::infinity(),
-       float dRz1 =std::numeric_limits<float>::infinity(),
-       float dPhi1 =std::numeric_limits<float>::infinity() ) ;
-    void setPosAttributes
-     ( float dRz2 =std::numeric_limits<float>::infinity(),
-       float dPhi2 =std::numeric_limits<float>::infinity(),
-       float dRz1 =std::numeric_limits<float>::infinity(),
-       float dPhi1 =std::numeric_limits<float>::infinity() ) ;
-
+    void setCaloCluster( const CaloClusterRef& clus){caloCluster_=clus;isEcalDriven_=true;}
+    void addHitInfo(const PMVars& hitVars){hitInfo_.push_back(hitVars);}
+    void setNrLayersAlongTraj(int val){nrLayersAlongTraj_=val;}
     //! Accessors
     const CtfTrackRef& ctfTrack() const { return ctfTrack_ ; }
     const CaloClusterRef& caloCluster() const { return caloCluster_ ; }
-    unsigned char hitsMask() const { return hitsMask_ ; }
-    int subDet2() const { return subDet2_ ; }
-    float dRz2() const { return dRz2_ ; }
-    float dPhi2() const { return dPhi2_ ; }
-    float dRz2Pos() const { return dRz2Pos_ ; }
-    float dPhi2Pos() const { return dPhi2Pos_ ; }
-    int subDet1() const { return subDet1_ ; }
-    float dRz1() const { return dRz1_ ; }
-    float dPhi1() const { return dPhi1_ ; }
-    float dRz1Pos() const { return dRz1Pos_ ; }
-    float dPhi1Pos() const { return dPhi1Pos_ ; }
-    float hoe1() const { return hcalDepth1OverEcal_ ; }
-    float hoe2() const { return hcalDepth2OverEcal_ ; }
-
+   
     //! Utility
     TrackCharge getCharge() const { return startingState().parameters().charge() ; }
 
     bool isEcalDriven() const { return isEcalDriven_ ; }
     bool isTrackerDriven() const { return isTrackerDriven_ ; }
 
+    const std::vector<PMVars>& hitInfo()const{return hitInfo_;}
+    float dPhiNeg(size_t hitNr)const{return getVal(hitNr,&PMVars::dPhiNeg);}
+    float dPhiPos(size_t hitNr)const{return getVal(hitNr,&PMVars::dPhiPos);}
+    float dPhiBest(size_t hitNr)const{return bestVal(dPhiNeg(hitNr),dPhiPos(hitNr));}
+    float dRZPos(size_t hitNr)const{return getVal(hitNr,&PMVars::dRZPos);}
+    float dRZNeg(size_t hitNr)const{return getVal(hitNr,&PMVars::dRZNeg);}
+    float dRZBest(size_t hitNr)const{return bestVal(dRZNeg(hitNr),dRZPos(hitNr));}
+    int detId(size_t hitNr)const{return hitNr<hitInfo_.size() ? hitInfo_[hitNr].detId : 0;}
+    int subDet(size_t hitNr)const{return DetId(detId(hitNr)).subdetId();}
+    int layerOrDiskNr(size_t hitNr)const{return getVal(hitNr,&PMVars::layerOrDiskNr);}
+    int nrLayersAlongTraj()const{return nrLayersAlongTraj_;}
+
+    //redundant, backwards compatible function names
+    //to be cleaned up asap
+    //no new code should use them
+    //they were created as time is short and there is less risk having
+    //the functions here rather than adapting all the function call to them in other
+    //CMSSW code 
+    float dPhi1()const{return dPhiNeg(0);}
+    float dPhi1Pos()const{return dPhiPos(0);}
+    float dPhi2()const{return dPhiNeg(1);}
+    float dPhi2Pos()const{return dPhiPos(1);}
+    float dRz1()const{return dRZNeg(0);}
+    float dRz1Pos()const{return dRZPos(0);}   
+    float dRz2()const{return dRZNeg(1);}
+    float dRz2Pos()const{return dRZPos(1);}   
+    int subDet1()const{return subDet(0);}
+    int subDet2()const{return subDet(1);}
+    unsigned int hitsMask()const; 
+    void initTwoHitSeed(const unsigned char hitMask);
+    void setNegAttributes(const float dRZ2=std::numeric_limits<float>::infinity(),
+			  const float dPhi2=std::numeric_limits<float>::infinity(),
+			  const float dRZ1=std::numeric_limits<float>::infinity(),
+			  const float dPhi1=std::numeric_limits<float>::infinity());
+    void setPosAttributes(const float dRZ2=std::numeric_limits<float>::infinity(),
+			  const float dPhi2=std::numeric_limits<float>::infinity(),
+			  const float dRZ1=std::numeric_limits<float>::infinity(),
+			  const float dPhi1=std::numeric_limits<float>::infinity());
+    
+    //this is a backwards compatible function designed to 
+    //convert old format ElectronSeeds to the new format
+    //only public due to root io rules, not intended for any other use
+    //also in theory not necessary to part of this class
+    static std::vector<PMVars> createHitInfo(const float dPhi1Pos,const float dPhi1Neg,
+					     const float dRZ1Pos,const float dRZ1Neg,
+					     const float dPhi2Pos,const float dPhi2Neg,
+					     const float dRZ2Pos,const float dRZ2Neg, 
+					     const char hitMask,const TrajectorySeed::range recHits);
   private:
+    static float bestVal(float val1,float val2){return std::abs(val1)<std::abs(val2) ? val1 : val2;}
+    template<typename T>
+    T getVal(unsigned int hitNr,T PMVars::*val)const{
+      return hitNr<hitInfo_.size() ? hitInfo_[hitNr].*val : std::numeric_limits<T>::infinity();
+    }
+    static std::vector<unsigned int> hitNrsFromMask(unsigned int hitMask);
+    
+  private:
+    CtfTrackRef ctfTrack_;
+    CaloClusterRef caloCluster_;
+    std::vector<PMVars> hitInfo_;
+    int nrLayersAlongTraj_; 
+    
+    bool isEcalDriven_;
+    bool isTrackerDriven_;
 
-    CtfTrackRef ctfTrack_ ;
-    CaloClusterRef caloCluster_ ;
-    unsigned char hitsMask_ ;
-    int subDet2_ ;
-    float dRz2_ ;
-    float dPhi2_ ;
-    float dRz2Pos_ ;
-    float dPhi2Pos_ ;
-    int subDet1_ ;
-    float dRz1_ ;
-    float dPhi1_ ;
-    float dRz1Pos_ ;
-    float dPhi1Pos_ ;
-    float hcalDepth1OverEcal_ ; // hcal over ecal seed cluster energy using first hcal depth
-    float hcalDepth2OverEcal_ ; // hcal over ecal seed cluster energy using 2nd hcal depth
-    bool isEcalDriven_ ;
-    bool isTrackerDriven_ ;
-
- } ;
-
- }
+  };
+}
 
 #endif

--- a/DataFormats/EgammaReco/interface/ElectronSeedFwd.h
+++ b/DataFormats/EgammaReco/interface/ElectronSeedFwd.h
@@ -17,7 +17,7 @@ namespace reco {
   /// vector of objects in the same collection of ElectronSeed objects
   typedef edm::RefVector<ElectronSeedCollection> ElectronSeedRefVector;
   /// iterator over a vector of reference to ElectronSeed objects
-  typedef ElectronSeedRefVector::iterator electronephltseed_iterator;
+  typedef ElectronSeedRefVector::iterator electronseed_iterator;
 }
 
 #endif

--- a/DataFormats/EgammaReco/src/ElectronSeed.cc
+++ b/DataFormats/EgammaReco/src/ElectronSeed.cc
@@ -1,105 +1,190 @@
 
 #include "DataFormats/EgammaReco/interface/ElectronSeed.h"
-#include "DataFormats/TrackReco/interface/Track.h"
+
+#include <climits>
 
 using namespace reco ;
 
 
 ElectronSeed::ElectronSeed()
- : TrajectorySeed(), ctfTrack_(), caloCluster_(), hitsMask_(0),
-   subDet2_(0),
-   dRz2_(std::numeric_limits<float>::infinity()),
-   dPhi2_(std::numeric_limits<float>::infinity()),
-   dRz2Pos_(std::numeric_limits<float>::infinity()),
-   dPhi2Pos_(std::numeric_limits<float>::infinity()),
-   subDet1_(0),
-   dRz1_(std::numeric_limits<float>::infinity()),
-   dPhi1_(std::numeric_limits<float>::infinity()),
-   dRz1Pos_(std::numeric_limits<float>::infinity()),
-   dPhi1Pos_(std::numeric_limits<float>::infinity()),
-   hcalDepth1OverEcal_(std::numeric_limits<float>::infinity()),
-   hcalDepth2OverEcal_(std::numeric_limits<float>::infinity()),
-   isEcalDriven_(false), isTrackerDriven_(false)
- {}
+  : TrajectorySeed(), ctfTrack_(), caloCluster_(), hitInfo_(),
+    nrLayersAlongTraj_(0),
+    isEcalDriven_(false), isTrackerDriven_(false)
+   
+{}
 
 ElectronSeed::ElectronSeed
- ( const TrajectorySeed & seed )
- : TrajectorySeed(seed),
-   ctfTrack_(), caloCluster_(), hitsMask_(0),
-   subDet2_(0),
-   dRz2_(std::numeric_limits<float>::infinity()),
-   dPhi2_(std::numeric_limits<float>::infinity()),
-   dRz2Pos_(std::numeric_limits<float>::infinity()),
-   dPhi2Pos_(std::numeric_limits<float>::infinity()),
-   subDet1_(0),
-   dRz1_(std::numeric_limits<float>::infinity()),
-   dPhi1_(std::numeric_limits<float>::infinity()),
-   dRz1Pos_(std::numeric_limits<float>::infinity()),
-   dPhi1Pos_(std::numeric_limits<float>::infinity()),
-   hcalDepth1OverEcal_(std::numeric_limits<float>::infinity()),
-   hcalDepth2OverEcal_(std::numeric_limits<float>::infinity()),
-   isEcalDriven_(false), isTrackerDriven_(false)
- {}
+( const TrajectorySeed & seed )
+  : TrajectorySeed(seed),
+    ctfTrack_(), caloCluster_(), hitInfo_(),
+    nrLayersAlongTraj_(0),
+    isEcalDriven_(false), isTrackerDriven_(false)
+{}
 
 ElectronSeed::ElectronSeed
  ( PTrajectoryStateOnDet & pts, recHitContainer & rh, PropagationDirection & dir )
- : TrajectorySeed(pts,rh,dir),
-   ctfTrack_(), caloCluster_(), hitsMask_(0),
-   subDet2_(0),
-   dRz2_(std::numeric_limits<float>::infinity()),
-   dPhi2_(std::numeric_limits<float>::infinity()),
-   dRz2Pos_(std::numeric_limits<float>::infinity()),
-   dPhi2Pos_(std::numeric_limits<float>::infinity()),
-   subDet1_(0),
-   dRz1_(std::numeric_limits<float>::infinity()),
-   dPhi1_(std::numeric_limits<float>::infinity()),
-   dRz1Pos_(std::numeric_limits<float>::infinity()),
-   dPhi1Pos_(std::numeric_limits<float>::infinity()),
-   hcalDepth1OverEcal_(std::numeric_limits<float>::infinity()),
-   hcalDepth2OverEcal_(std::numeric_limits<float>::infinity()),
-   isEcalDriven_(false), isTrackerDriven_(false)
- {}
+   : TrajectorySeed(pts,rh,dir),
+     ctfTrack_(), caloCluster_(), hitInfo_(),
+     nrLayersAlongTraj_(0),
+     isEcalDriven_(false), isTrackerDriven_(false)
+{}
+
+ElectronSeed::~ElectronSeed()=default;
 
 void ElectronSeed::setCtfTrack
- ( const CtfTrackRef & ctfTrack )
- {
+( const CtfTrackRef & ctfTrack )
+{
   ctfTrack_ = ctfTrack ;
   isTrackerDriven_ = true ;
- }
+}
 
-void ElectronSeed::setCaloCluster
- ( const CaloClusterRef & scl,
-   unsigned char hitsMask,
-   int subDet2, int subDet1,
-   float hoe1, float hoe2 )
- {
-  caloCluster_ = scl ;
-  hitsMask_ = hitsMask ;
-  isEcalDriven_ = true ;
-  subDet2_ = subDet2 ;
-  subDet1_ = subDet1 ;
-  hcalDepth1OverEcal_ = hoe1 ;
-  hcalDepth2OverEcal_ = hoe2 ;
- }
+//the hit mask tells us which hits were used in the seed
+//typically all are used at the HLT but this could change in the future
+//RECO only uses some of them
+unsigned int ElectronSeed::hitsMask()const
+{
+  int mask=0;
+  for(size_t hitNr=0;hitNr<nHits();hitNr++){
+    int bitNr = 0x1 << hitNr;
+    int hitDetId = (recHits().first+hitNr)->geographicalId().rawId();
+    auto detIdMatcher = [hitDetId](const ElectronSeed::PMVars& var){return hitDetId==var.detId;};
+    if(std::find_if(hitInfo_.begin(),hitInfo_.end(),detIdMatcher)!=hitInfo_.end()){
+      mask|=bitNr;
+    }
+  }
+  return mask;
+}
 
-void ElectronSeed::setNegAttributes
- ( float dRz2, float dPhi2, float dRz1, float dPhi1 )
- {
-  dRz2_ = dRz2 ;
-  dPhi2_ = dPhi2 ;
-  dRz1_ = dRz1 ;
-  dPhi1_ = dPhi1 ;
- }
+void ElectronSeed::initTwoHitSeed(const unsigned char hitMask)
+{
+  hitInfo_.resize(2);
 
-void ElectronSeed::setPosAttributes
- ( float dRz2, float dPhi2, float dRz1, float dPhi1 )
- {
-  dRz2Pos_ = dRz2 ;
-  dPhi2Pos_ = dPhi2 ;
-  dRz1Pos_ = dRz1 ;
-  dPhi1Pos_ = dPhi1 ;
- }
+  std::vector<unsigned int> hitNrs = hitNrsFromMask(hitMask);
+  if(hitNrs.size()!=2){
+    throw cms::Exception("LogicError") 
+      <<"in ElectronSeed::"<<__FUNCTION__<<","<<__LINE__
+      <<": number of hits in hit mask is "<<hitNrs.size()<<"\n"
+      <<"pre-2017 pixel upgrade ecalDriven ElectronSeeds should have exactly 2 hits\n "
+      <<"mask "<<static_cast<unsigned int>(hitMask)<<std::endl;
+  }
+  if(hitNrs[0]>=nHits() || hitNrs[1]>=nHits()){
+    throw cms::Exception("LogicError")
+      <<"in ElectronSeed::"<<__FUNCTION__<<","<<__LINE__
+      <<": hits are "<<hitNrs[0]<<" and  "<<hitNrs[1]
+      <<" while number of hits are "<<nHits()<<"\n"
+      <<"this means there was a bug in storing or creating the electron seeds "
+      <<"mask "<<static_cast<unsigned int>(hitMask)<<std::endl;
+  }
+  for(size_t hitNr=0;hitNr<hitInfo_.size();hitNr++){
+    auto& info = hitInfo_[hitNr];
+    info.setDPhi(std::numeric_limits<float>::infinity(),std::numeric_limits<float>::infinity());
+    info.setDRZ(std::numeric_limits<float>::infinity(),std::numeric_limits<float>::infinity());
+    info.setDet((recHits().first+hitNrs[hitNr])->geographicalId(),-1);
+  }
+  
+}
 
-ElectronSeed::~ElectronSeed()
- {}
+void ElectronSeed::setNegAttributes(float dRZ2,float dPhi2,float dRZ1,float dPhi1)
+{
+  if(hitInfo_.size()!=2){
+    throw cms::Exception("LogicError") <<"ElectronSeed::setNegAttributes should only operate on seeds with exactly two hits. This is because it is a legacy function to preverse backwards compatiblity and should not be used on new code which matches variable number of hits";
+  }
+  hitInfo_[0].dRZNeg = dRZ1;
+  hitInfo_[1].dRZNeg = dRZ2;
+  hitInfo_[0].dPhiNeg = dPhi1;
+  hitInfo_[1].dPhiNeg = dPhi2;
+  
+}
+
+void ElectronSeed::setPosAttributes(float dRZ2,float dPhi2,float dRZ1,float dPhi1)
+{
+  if(hitInfo_.size()!=2){
+    throw cms::Exception("LogicError") <<"ElectronSeed::setPosAttributes should only operate on seeds with exactly two hits. This is because it is a legacy function to preverse backwards compatiblity and should not be used on new code which matches variable number of hits";
+  }
+  hitInfo_[0].dRZPos = dRZ1;
+  hitInfo_[1].dRZPos = dRZ2;
+  hitInfo_[0].dPhiPos = dPhi1;
+  hitInfo_[1].dPhiPos = dPhi2;
+}
+
+std::vector<unsigned int>
+ElectronSeed::hitNrsFromMask(unsigned int hitMask)
+{
+  std::vector<unsigned int> hitNrs;
+  for(size_t bitNr=0; bitNr<sizeof(hitMask)*CHAR_BIT ; bitNr++){
+    char bit = 0x1 << bitNr;
+    if((hitMask&bit)!=0) hitNrs.push_back(bitNr);
+  }
+  return hitNrs;
+}
+
+std::vector<ElectronSeed::PMVars> 
+ElectronSeed::createHitInfo(const float dPhi1Pos,const float dPhi1Neg,
+			    const float dRZ1Pos,const float dRZ1Neg,
+			    const float dPhi2Pos,const float dPhi2Neg,
+			    const float dRZ2Pos,const float dRZ2Neg,
+			    const char hitMask,const TrajectorySeed::range recHits)
+{
+  if(hitMask==0) return std::vector<ElectronSeed::PMVars>(); //was trackerDriven so no matched hits
+
+  size_t nrRecHits = std::distance(recHits.first,recHits.second);
+  std::vector<unsigned int> hitNrs = hitNrsFromMask(hitMask);
+
+  if(hitNrs.size()!=2){
+    throw cms::Exception("LogicError")
+      <<"in ElectronSeed::"<<__FUNCTION__<<","<<__LINE__
+      <<": number of hits in hit mask is "<<nrRecHits<<"\n"
+      <<"pre-2017 pixel upgrade ecalDriven ElectronSeeds should have exactly 2 hits\n"
+      <<"mask "<<static_cast<unsigned int>(hitMask)<<std::endl;
+  }
+  if(hitNrs[0]>=nrRecHits || hitNrs[1]>=nrRecHits){
+    throw cms::Exception("LogicError")
+      <<"in ElectronSeed::"<<__FUNCTION__<<","<<__LINE__
+      <<": hits are "<<hitNrs[0]<<" and "<<hitNrs[1]
+      <<" while number of hits are "<<nrRecHits<<"\n"
+      <<"this means there was a bug in storing or creating the electron seeds "
+      <<"mask "<<static_cast<unsigned int>(hitMask)<<std::endl;
+  }
+  
+  std::vector<PMVars> hitInfo(2);
+  hitInfo[0].setDPhi(dPhi1Pos,dPhi1Neg);
+  hitInfo[0].setDRZ(dRZ1Pos,dRZ1Neg);
+  hitInfo[0].setDet((recHits.first+hitNrs[0])->geographicalId(),-1); //getting the layer information needs tracker topo, hence why its stored in the first as its a pain to access
+  hitInfo[1].setDPhi(dPhi2Pos,dPhi2Neg);
+  hitInfo[1].setDRZ(dRZ2Pos,dRZ2Neg);
+  hitInfo[1].setDet((recHits.first+hitNrs[1])->geographicalId(),-1); //getting the layer information needs tracker topo, hence why its stored in the first as its a pain to access
+  return hitInfo;
+
+}
+
+
+ElectronSeed::PMVars::PMVars():
+  dRZPos(std::numeric_limits<float>::infinity()),
+  dRZNeg(std::numeric_limits<float>::infinity()),
+  dPhiPos(std::numeric_limits<float>::infinity()),
+  dPhiNeg(std::numeric_limits<float>::infinity()),
+  detId(0),
+  layerOrDiskNr(-1)
+{}
+
+void ElectronSeed::PMVars::setDPhi(float pos,float neg)
+{
+  dPhiPos = pos;
+  dPhiNeg = neg;
+}
+
+void ElectronSeed::PMVars::setDRZ(float pos,float neg)
+{
+  dRZPos = pos;
+  dRZNeg = neg;
+}
+
+void ElectronSeed::PMVars::setDet(int iDetId,int iLayerOrDiskNr)
+{
+  detId = iDetId;
+  layerOrDiskNr = iLayerOrDiskNr;
+}
+
+
+
 

--- a/DataFormats/EgammaReco/src/classes.h
+++ b/DataFormats/EgammaReco/src/classes.h
@@ -43,8 +43,8 @@ namespace DataFormats_EgammaReco {
     edm::Ref<reco::SuperClusterCollection> r3;
     edm::RefProd<reco::SuperClusterCollection> rp3;
     edm::Wrapper<edm::RefVector<reco::SuperClusterCollection> > wrv3;
-
-
+    std::vector<edm::Ref<std::vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> > >vr3;
+    edm::Wrapper<std::vector<edm::Ref<std::vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> > > > wvr3;
     reco::EgammaTriggerCollection v4;
     edm::Wrapper<reco::EgammaTriggerCollection> w4;
     edm::Ref<reco::EgammaTriggerCollection> r4;

--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -34,6 +34,8 @@
   <class name="edm::RefProd<std::vector<reco::SuperCluster> >"/>
   <class name="edm::RefVector<std::vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> >"/>
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> > >"/>
+  <class name="std::vector<edm::Ref<std::vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> > >"/>
+  <class name="edm::Wrapper<std::vector<edm::Ref<std::vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> > > >"/>
 
   <class name="reco::ClusterShape" ClassVersion="11">
    <version ClassVersion="11" checksum="3739311734"/>
@@ -86,11 +88,19 @@
   <class name="edm::RefVector<std::vector<reco::PreshowerClusterShape>,reco::PreshowerClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::PreshowerClusterShape>,reco::PreshowerClusterShape> >"/>
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::PreshowerClusterShape>,reco::PreshowerClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::PreshowerClusterShape>,reco::PreshowerClusterShape> > >" splitLevel="0"/>
 
-  <class name="reco::ElectronSeed" ClassVersion="12">
+  <class name="reco::ElectronSeed" ClassVersion="13">
+   <version ClassVersion="13" checksum="3112955595"/> 
    <version ClassVersion="12" checksum="536071409"/>
    <version ClassVersion="11" checksum="3831394066"/>
    <version ClassVersion="10" checksum="534580602"/>
   </class>
+  <ioread sourceClass="reco::ElectronSeed" version="[1-12]" targetClass="reco::ElectronSeed" source="float dRz2_; float dPhi2_; float dRz2Pos_; float dPhi2Pos_; float dRz1_; float dPhi1_; float dRz1Pos_; float dPhi1Pos_; unsigned char hitsMask_;" target="hitInfo_">
+    <![CDATA[hitInfo_ = reco::ElectronSeed::createHitInfo(onfile.dPhi1Pos_,onfile.dPhi1_,onfile.dRz1Pos_,onfile.dRz1_,onfile.dPhi2Pos_,onfile.dPhi2_,onfile.dRz2Pos_,onfile.dRz2_,onfile.hitsMask_,newObj->recHits());]]>
+  </ioread>
+  <class name="reco::ElectronSeed::PMVars" ClassVersion="3">
+    <version ClassVersion="3" checksum="1322802316"/>
+  </class>
+
   <class name="std::vector<reco::ElectronSeed>"/>
   <class name="edm::Ref<std::vector<reco::ElectronSeed>,reco::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ElectronSeed>,reco::ElectronSeed> >"/>
   <class name="edm::RefProd<std::vector<reco::ElectronSeed> >"/>
@@ -102,7 +112,6 @@
   <class name="edm::reftobase::IndirectHolder<reco::ElectronSeed>" />
   <class name="edm::reftobase::RefHolder<edm::Ref<std::vector<reco::ElectronSeed>,reco::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ElectronSeed>,reco::ElectronSeed> > >"/>
   <class name="edm::reftobase::Holder<reco::ElectronSeed,edm::Ref<std::vector<reco::ElectronSeed>,reco::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ElectronSeed>,reco::ElectronSeed> > >"/>
-
 
   <class name="reco::PreshowerCluster" ClassVersion="14">
    <version ClassVersion="14" checksum="3782728123"/>

--- a/RecoEgamma/EgammaElectronAlgos/interface/TrajSeedMatcher.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/TrajSeedMatcher.h
@@ -1,0 +1,301 @@
+#ifndef RecoEgamma_EgammaElectronAlgos_TrajSeedMatcher_h
+#define RecoEgamma_EgammaElectronAlgos_TrajSeedMatcher_h
+
+
+//******************************************************************************
+//
+// Part of the refactorisation of of the E/gamma pixel matching for 2017 pixels
+// This refactorisation converts the monolithic  approach to a series of 
+// independent producer modules, with each modules performing  a specific 
+// job as recommended by the 2017 tracker framework
+//
+//
+// The module is based of PixelHitMatcher (the seed based functions) but
+// extended to match on an arbitary number of hits rather than just doublets.
+// It is also aware of how many layers the supercluster trajectory passed through
+// and uses that information to determine how many hits to require
+// Other than that, its a direct port and follows what PixelHitMatcher did
+// 
+//
+// Author : Sam Harper (RAL), 2017
+//
+//*******************************************************************************
+
+
+
+
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+#include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
+#include "TrackingTools/DetLayers/interface/NavigationSchool.h"
+#include "TrackingTools/RecoGeometry/interface/GlobalDetLayerGeometry.h"
+#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
+
+#include <unordered_map>
+
+namespace edm{
+  class EventSetup;
+  class ConfigurationDescriptions;
+  class ParameterSet;
+  class ParameterSetDescription;
+}
+
+class FreeTrajectoryState;
+class TrackingRecHit;
+
+
+//stolen from PixelHitMatcher
+//decide if its evil or not later
+//actually I think the answer is, yes, yes its evil
+//maybe replace with less evil?
+namespace std{
+  template<>
+    struct hash<std::pair<int,GlobalPoint> > {
+    std::size_t operator()(const std::pair<int,GlobalPoint>& g) const {
+      auto h1 = std::hash<unsigned long long>()((unsigned long long)g.first);
+      unsigned long long k; memcpy(&k, &g.second,sizeof(k));
+      auto h2 = std::hash<unsigned long long>()(k);
+      return h1 ^ (h2 << 1);
+      }
+  };
+  template<>
+  struct equal_to<std::pair<int,GlobalPoint> > : public std::binary_function<std::pair<int,GlobalPoint>,std::pair<int,GlobalPoint>,bool> {
+    bool operator()(const std::pair<int,GlobalPoint>& a, 
+		    const std::pair<int,GlobalPoint>& b)  const {
+      return (a.first == b.first) & (a.second == b.second);
+    }
+  };
+}
+
+class TrajSeedMatcher {
+public:
+  class SCHitMatch {
+  public:
+    SCHitMatch():detId_(0),
+	      dRZ_(std::numeric_limits<float>::max()),
+	      dPhi_(std::numeric_limits<float>::max()),
+	      hit_(nullptr),
+	      et_(0),eta_(0),phi_(0),charge_(0),nrClus_(0){}
+
+    //does not set charge,et,nrclus
+    SCHitMatch(const GlobalPoint& vtxPos,
+	    const TrajectoryStateOnSurface& trajState,
+	    const TrackingRecHit& hit
+	    );
+    ~SCHitMatch()=default;
+
+    void setExtra(float et, float eta, float phi, int charge, int nrClus){
+      et_=et;
+      eta_=eta;
+      phi_=phi;
+      charge_=charge;
+      nrClus_=nrClus;
+    }
+    
+    int subdetId()const{return detId_.subdetId();}
+    DetId detId()const{return detId_;}
+    float dRZ()const{return dRZ_;}
+    float dPhi()const{return dPhi_;}
+    const GlobalPoint& hitPos()const{return hitPos_;}
+    float et()const{return et_;}
+    float eta()const{return eta_;}
+    float phi()const{return phi_;}
+    int charge()const{return charge_;}
+    int nrClus()const{return nrClus_;}
+    const TrackingRecHit* hit()const{return hit_;}
+  private:
+    DetId detId_;
+    GlobalPoint hitPos_;
+    float dRZ_;
+    float dPhi_;    
+    const TrackingRecHit* hit_; //we do not own this
+    //extra quanities which are set later
+    float et_;
+    float eta_;
+    float phi_;
+    int charge_;
+    int nrClus_;
+  };
+
+ 
+
+  struct MatchInfo {
+  public:
+    DetId detId;
+    float dRZPos,dRZNeg;
+    float dPhiPos,dPhiNeg;
+    
+    MatchInfo(const DetId& iDetId,
+	      float iDRZPos, float iDRZNeg,
+	      float iDPhiPos, float iDPhiNeg):
+      detId(iDetId),dRZPos(iDRZPos),dRZNeg(iDRZNeg),
+      dPhiPos(iDPhiPos),dPhiNeg(iDPhiNeg){}
+  };
+
+  class SeedWithInfo {
+  public:
+    SeedWithInfo(const TrajectorySeed& seed,
+		 const std::vector<SCHitMatch>& posCharge,
+		 const std::vector<SCHitMatch>& negCharge,
+		 int nrValidLayers);
+    ~SeedWithInfo()=default;
+    
+    const TrajectorySeed& seed()const{return seed_;}
+    float dRZPos(size_t hitNr)const{return getVal(hitNr,&MatchInfo::dRZPos);}
+    float dRZNeg(size_t hitNr)const{return getVal(hitNr,&MatchInfo::dRZNeg);}
+    float dPhiPos(size_t hitNr)const{return getVal(hitNr,&MatchInfo::dPhiPos);}
+    float dPhiNeg(size_t hitNr)const{return getVal(hitNr,&MatchInfo::dPhiNeg);}
+    DetId detId(size_t hitNr)const{return hitNr<matchInfo_.size() ? matchInfo_[hitNr].detId : DetId(0);}
+    size_t nrMatchedHits()const{return matchInfo_.size();}
+    const std::vector<MatchInfo>& matches()const{return matchInfo_;}
+    int nrValidLayers()const{return nrValidLayers_;}
+  private:
+    float getVal(size_t hitNr,float MatchInfo::*val)const{
+      return hitNr<matchInfo_.size() ? matchInfo_[hitNr].*val : std::numeric_limits<float>::max();
+    }
+
+  private:
+    const TrajectorySeed& seed_;
+    std::vector<MatchInfo> matchInfo_;
+    int nrValidLayers_;
+  };
+
+  class MatchingCuts {
+  public:
+    MatchingCuts(){}
+    virtual ~MatchingCuts(){}
+    virtual bool operator()(const SCHitMatch& scHitMatch)const=0;
+  };
+
+  class MatchingCutsV1 : public MatchingCuts {
+  public:
+    explicit MatchingCutsV1(const edm::ParameterSet& pset);
+    bool operator()(const SCHitMatch& scHitMatch)const;
+  private:
+    float getDRZCutValue(const float scEt, const float scEta)const;
+  private:
+    const double dPhiMax_;
+    const double dRZMax_;
+    const double dRZMaxLowEtThres_;
+    const std::vector<double> dRZMaxLowEtEtaBins_; 
+    const std::vector<double> dRZMaxLowEt_; 
+  };
+
+  class MatchingCutsV2 : public MatchingCuts {
+  public:
+    explicit MatchingCutsV2(const edm::ParameterSet& pset);
+    bool operator()(const SCHitMatch& scHitMatch)const;
+  private:
+    size_t getBinNr(float eta)const;
+    float getCutValue(float et, float highEt, float highEtThres, float lowEtGrad)const{
+      return  highEt + std::min(0.f,et-highEtThres)*lowEtGrad;
+    }
+  private:
+    std::vector<double> dPhiHighEt_,dPhiHighEtThres_,dPhiLowEtGrad_;
+    std::vector<double> dRZHighEt_,dRZHighEtThres_,dRZLowEtGrad_;
+    std::vector<double> etaBins_;
+  };
+
+
+public:  
+  explicit TrajSeedMatcher(const edm::ParameterSet& pset);
+  ~TrajSeedMatcher()=default;
+
+  static edm::ParameterSetDescription makePSetDescription();
+
+  void doEventSetup(const edm::EventSetup& iSetup);
+  
+  std::vector<TrajSeedMatcher::SeedWithInfo>
+  compatibleSeeds(const TrajectorySeedCollection& seeds, const GlobalPoint& candPos,
+		  const GlobalPoint & vprim, const float energy);
+
+  void setMeasTkEvtHandle(edm::Handle<MeasurementTrackerEvent> handle){measTkEvt_=std::move(handle);}
+  
+private:
+  
+  std::vector<SCHitMatch> processSeed(const TrajectorySeed& seed, const GlobalPoint& candPos,
+				   const GlobalPoint & vprim, const float energy, const int charge );
+
+  static float getZVtxFromExtrapolation(const GlobalPoint& primeVtxPos, const GlobalPoint& hitPos,
+					const GlobalPoint& candPos);
+  
+  bool passTrajPreSel(const GlobalPoint& hitPos,const GlobalPoint& candPos)const;
+  
+  TrajSeedMatcher::SCHitMatch matchFirstHit(const TrajectorySeed& seed,
+					    const TrajectoryStateOnSurface& trajState,
+					    const GlobalPoint& vtxPos,
+					    const PropagatorWithMaterial& propagator);
+
+  TrajSeedMatcher::SCHitMatch match2ndToNthHit(const TrajectorySeed& seed,
+					       const FreeTrajectoryState& trajState,
+					       const size_t hitNr,	
+					       const GlobalPoint& prevHitPos,
+					       const GlobalPoint& vtxPos,
+					       const PropagatorWithMaterial& propagator);
+  
+  const TrajectoryStateOnSurface& getTrajStateFromVtx(const TrackingRecHit& hit,
+						      const TrajectoryStateOnSurface& initialState,
+						      const PropagatorWithMaterial& propagator);
+
+  const TrajectoryStateOnSurface& getTrajStateFromPoint(const TrackingRecHit& hit,
+							const FreeTrajectoryState& initialState,
+							const GlobalPoint& point,
+							const PropagatorWithMaterial& propagator);
+
+  void clearCache();
+
+  bool passesMatchSel(const SCHitMatch& hit, const size_t hitNr)const;
+
+  int getNrValidLayersAlongTraj(const SCHitMatch& hit1, const SCHitMatch& hit2,
+				const GlobalPoint& candPos,
+				const GlobalPoint & vprim, 
+				const float energy, const int charge);
+
+  int getNrValidLayersAlongTraj(const DetId& hitId,
+				const TrajectoryStateOnSurface& hitTrajState)const;
+				
+  bool layerHasValidHits(const DetLayer& layer,const TrajectoryStateOnSurface& hitSurState,
+			 const Propagator& propToLayerFromState)const;
+  
+  size_t getNrHitsRequired(const int nrValidLayers)const;
+    
+private:
+  static constexpr float kElectronMass_ = 0.000511;
+  static constexpr float kPhiCut_ = -0.801144;//cos(2.5)
+  std::unique_ptr<PropagatorWithMaterial> forwardPropagator_;
+  std::unique_ptr<PropagatorWithMaterial> backwardPropagator_;
+  unsigned long long cacheIDMagField_;
+  edm::ESHandle<MagneticField> magField_;
+  edm::Handle<MeasurementTrackerEvent> measTkEvt_;
+  edm::ESHandle<NavigationSchool> navSchool_;
+  edm::ESHandle<DetLayerGeometry> detLayerGeom_;
+  std::string navSchoolLabel_;
+  std::string detLayerGeomLabel_;
+
+  bool useRecoVertex_;
+  std::vector<std::unique_ptr<MatchingCuts> > matchingCuts_;
+  
+  //these two varibles determine how hits we require 
+  //based on how many valid layers we had
+  //right now we always need atleast two hits
+  //also highly dependent on the seeds you pass in 
+  //which also require a given number of hits
+  const std::vector<unsigned int> minNrHits_;
+  const std::vector<int> minNrHitsValidLayerBins_;
+
+  std::unordered_map<int,TrajectoryStateOnSurface> trajStateFromVtxPosChargeCache_;
+  std::unordered_map<int,TrajectoryStateOnSurface> trajStateFromVtxNegChargeCache_;
+
+  std::unordered_map<std::pair<int,GlobalPoint>,TrajectoryStateOnSurface> trajStateFromPointPosChargeCache_;
+  std::unordered_map<std::pair<int,GlobalPoint>,TrajectoryStateOnSurface> trajStateFromPointNegChargeCache_;
+
+};
+
+#endif

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
@@ -475,7 +475,8 @@ void ElectronSeedGenerator::seedsFromTrajectorySeeds
   for ( s = pixelSeeds.begin() ; s != pixelSeeds.end() ; s++ )
    {
     reco::ElectronSeed seed(s->seed()) ;
-    seed.setCaloCluster(cluster,s->hitsMask(),s->subDet2(),s->subDet1(),hoe1,hoe2) ;
+    seed.setCaloCluster(cluster);
+    seed.initTwoHitSeed(s->hitsMask());
     addSeed(seed,&*s,positron,out) ;
    }
  }

--- a/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
@@ -1,0 +1,486 @@
+#include "RecoEgamma/EgammaElectronAlgos/interface/TrajSeedMatcher.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/PerpendicularBoundPlaneBuilder.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+
+#include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
+#include "TrackingTools/RecoGeometry/interface/RecoGeometryRecord.h"
+#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h" 
+
+#include "RecoTracker/Record/interface/NavigationSchoolRecord.h"
+
+#include "RecoEgamma/EgammaElectronAlgos/interface/FTSFromVertexToPointFactory.h"
+#include "RecoEgamma/EgammaElectronAlgos/interface/ElectronUtilities.h"
+
+constexpr float TrajSeedMatcher::kElectronMass_;
+
+TrajSeedMatcher::TrajSeedMatcher(const edm::ParameterSet& pset):
+  cacheIDMagField_(0),
+  minNrHits_(pset.getParameter<std::vector<unsigned int> >("minNrHits")),
+  minNrHitsValidLayerBins_(pset.getParameter<std::vector<int> >("minNrHitsValidLayerBins"))
+{
+  useRecoVertex_ = pset.getParameter<bool>("useRecoVertex");
+  navSchoolLabel_ = pset.getParameter<std::string>("navSchool");
+  detLayerGeomLabel_ = pset.getParameter<std::string>("detLayerGeom");
+  const auto cutsPSets=pset.getParameter<std::vector<edm::ParameterSet> >("matchingCuts");
+  for(const auto & cutPSet : cutsPSets){
+    int version=cutPSet.getParameter<int>("version");
+    switch(version){
+    case 1:
+      matchingCuts_.emplace_back(std::make_unique<MatchingCutsV1>(cutPSet));
+      break;
+    case 2:
+      matchingCuts_.emplace_back(std::make_unique<MatchingCutsV2>(cutPSet));
+      break;
+    default:
+      throw cms::Exception("InvalidConfig") <<" Error TrajSeedMatcher::TrajSeedMatcher pixel match cuts version "<<version<<" not recognised"<<std::endl;
+    }
+  }
+ 
+  if(minNrHitsValidLayerBins_.size()+1!=minNrHits_.size()){  
+    throw cms::Exception("InvalidConfig")<<" TrajSeedMatcher::TrajSeedMatcher minNrHitsValidLayerBins should be 1 less than minNrHits when its "<<minNrHitsValidLayerBins_.size()<<" vs "<<minNrHits_.size();
+  }
+}
+
+edm::ParameterSetDescription TrajSeedMatcher::makePSetDescription()
+{
+  edm::ParameterSetDescription desc;
+  desc.add<bool>("useRecoVertex",false);
+  desc.add<std::string>("navSchool","SimpleNavigationSchool");
+  desc.add<std::string>("detLayerGeom","hltESPGlobalDetLayerGeometry");
+  desc.add<std::vector<int> >("minNrHitsValidLayerBins",{4});
+  desc.add<std::vector<unsigned int> >("minNrHits",{2,3});
+  
+  edm::ParameterSetDescription cutsDesc;
+  auto cutDescCases = 
+    1 >> 
+    (edm::ParameterDescription<double>("dPhiMax",0.04,true) and
+     edm::ParameterDescription<double>("dRZMax",0.09,true) and
+     edm::ParameterDescription<double>("dRZMaxLowEtThres",20.,true) and
+     edm::ParameterDescription<std::vector<double> >("dRZMaxLowEtEtaBins",std::vector<double>{1.,1.5},true) and
+     edm::ParameterDescription<std::vector<double> >("dRZMaxLowEt",std::vector<double>{0.09,0.15,0.09},true)) or
+    2 >> 
+    (edm::ParameterDescription<std::vector<double> >("dPhiMaxHighEt",{0.003},true) and
+     edm::ParameterDescription<std::vector<double> >("dPhiMaxHighEtThres",{0.0},true) and
+     edm::ParameterDescription<std::vector<double> >("dPhiMaxLowEtGrad",{0.0},true) and
+     edm::ParameterDescription<std::vector<double> >("dRZMaxHighEt",{0.005},true) and
+     edm::ParameterDescription<std::vector<double> >("dRZMaxHighEtThres",{30},true) and
+     edm::ParameterDescription<std::vector<double> >("dRZMaxLowEtGrad",{-0.002},true) and
+     edm::ParameterDescription<std::vector<double> >("etaBins",{},true));
+  cutsDesc.ifValue(edm::ParameterDescription<int>("version",1,true), std::move(cutDescCases));
+
+  edm::ParameterSet defaults;
+  defaults.addParameter<double>("dPhiMax",0.04);
+  defaults.addParameter<double>("dRZMax",0.09);
+  defaults.addParameter<double>("dRZMaxLowEtThres",0.09);
+  defaults.addParameter<std::vector<double> >("dRZMaxLowEtEtaBins",std::vector<double>{1.,1.5});
+  defaults.addParameter<std::vector<double> >("dRZMaxLowEt",std::vector<double>{0.09,0.09,0.09});
+  defaults.addParameter<int>("version",1);
+  desc.addVPSet("matchingCuts",cutsDesc,std::vector<edm::ParameterSet>{defaults,defaults,defaults});
+  return desc;
+}
+
+void TrajSeedMatcher::doEventSetup(const edm::EventSetup& iSetup)
+{
+  if (cacheIDMagField_!=iSetup.get<IdealMagneticFieldRecord>().cacheIdentifier()) {
+    iSetup.get<IdealMagneticFieldRecord>().get(magField_);
+    cacheIDMagField_=iSetup.get<IdealMagneticFieldRecord>().cacheIdentifier();
+    forwardPropagator_=std::make_unique<PropagatorWithMaterial>(alongMomentum,kElectronMass_,&*(magField_));
+    backwardPropagator_=std::make_unique<PropagatorWithMaterial>(oppositeToMomentum,kElectronMass_,&*(magField_));
+  }
+  iSetup.get<NavigationSchoolRecord>().get(navSchoolLabel_,navSchool_);
+  iSetup.get<RecoGeometryRecord>().get(detLayerGeomLabel_,detLayerGeom_);
+}
+
+
+std::vector<TrajSeedMatcher::SeedWithInfo>
+TrajSeedMatcher::compatibleSeeds(const TrajectorySeedCollection& seeds, const GlobalPoint& candPos,
+				  const GlobalPoint & vprim, const float energy)
+{
+  if(!forwardPropagator_ || !backwardPropagator_ || !magField_.isValid()){
+    throw cms::Exception("LogicError") <<__FUNCTION__<<" can not make pixel seeds as event setup has not properly been called";
+  }
+
+  clearCache();
+  
+  std::vector<SeedWithInfo> matchedSeeds;
+  for(const auto& seed : seeds) {
+    std::vector<SCHitMatch> matchedHitsNeg = processSeed(seed,candPos,vprim,energy,-1);
+    std::vector<SCHitMatch> matchedHitsPos = processSeed(seed,candPos,vprim,energy,+1);
+    int nrValidLayersPos = 0;
+    int nrValidLayersNeg = 0;
+    if(matchedHitsNeg.size()>=2){
+      nrValidLayersNeg = getNrValidLayersAlongTraj(matchedHitsNeg[0],
+						   matchedHitsNeg[1],
+						   candPos,vprim,energy,-1);
+    }
+    if(matchedHitsPos.size()>=2){
+      nrValidLayersPos = getNrValidLayersAlongTraj(matchedHitsPos[0],
+						   matchedHitsPos[1],
+						   candPos,vprim,energy,+1);
+    }
+    
+    int nrValidLayers = std::max(nrValidLayersNeg,nrValidLayersPos);
+    size_t nrHitsRequired = getNrHitsRequired(nrValidLayers);
+    //so we require the number of hits to exactly match, this is because we currently do not
+    //do any duplicate cleaning for the input seeds
+    //this means is a hit pair with a 3rd hit will appear twice (or however many hits it has)
+    //so if you did >=nrHitsRequired, you would get the same seed multiple times
+    //ideally we should fix this and clean our input seed collection so each seed is only in once
+    //also it should be studied what impact having a 3rd hit has on a GsfTrack
+    //ie will we get a significantly different result seeding with a hit pair 
+    //and the same the hit pair with a 3rd hit added
+    //in that case, perhaps it should be >=
+    if(matchedHitsNeg.size()==nrHitsRequired ||
+       matchedHitsPos.size()==nrHitsRequired){
+      matchedSeeds.push_back({seed,matchedHitsPos,matchedHitsNeg,nrValidLayers});
+    }
+    
+
+  }
+  return matchedSeeds;
+}
+
+//checks if the hits of the seed match within requested selection
+//matched hits are required to be consecutive, as soon as hit isnt matched,
+//the function returns, it doesnt allow skipping hits
+std::vector<TrajSeedMatcher::SCHitMatch>
+TrajSeedMatcher::processSeed(const TrajectorySeed& seed, const GlobalPoint& candPos,
+			     const GlobalPoint & vprim, const float energy, const int charge )
+{
+  const float candEta = candPos.eta();
+  const float candEt = energy*std::sin(candPos.theta());
+  
+  FreeTrajectoryState trajStateFromVtx = FTSFromVertexToPointFactory::get(*magField_, candPos, vprim, energy, charge);
+  PerpendicularBoundPlaneBuilder bpb;
+  TrajectoryStateOnSurface initialTrajState(trajStateFromVtx,*bpb(trajStateFromVtx.position(), 
+								  trajStateFromVtx.momentum()));
+ 
+  std::vector<SCHitMatch> matchedHits;
+  SCHitMatch firstHit = matchFirstHit(seed,initialTrajState,vprim,*backwardPropagator_);
+  firstHit.setExtra(candEt,candEta,candPos.phi(),charge,1);
+  if(passesMatchSel(firstHit,0)){
+    matchedHits.push_back(firstHit);
+
+    //now we can figure out the z vertex
+    double zVertex = useRecoVertex_ ? vprim.z() : getZVtxFromExtrapolation(vprim,firstHit.hitPos(),candPos);
+    GlobalPoint vertex(vprim.x(),vprim.y(),zVertex);
+    
+    FreeTrajectoryState firstHitFreeTraj = FTSFromVertexToPointFactory::get(*magField_, firstHit.hitPos(), 
+									    vertex, energy, charge) ;
+ 
+    GlobalPoint prevHitPos = firstHit.hitPos();
+    for(size_t hitNr=1;hitNr<matchingCuts_.size() && hitNr<seed.nHits();hitNr++){
+      SCHitMatch hit = match2ndToNthHit(seed,firstHitFreeTraj,hitNr,prevHitPos,vertex,*forwardPropagator_);
+      hit.setExtra(candEt,candEta,candPos.phi(),charge,1);
+      if(passesMatchSel(hit,hitNr)){
+	matchedHits.push_back(hit);
+	prevHitPos = hit.hitPos();
+      }else break;
+    }
+  }
+  return matchedHits;
+}
+
+// compute the z vertex from the candidate position and the found pixel hit
+float TrajSeedMatcher::getZVtxFromExtrapolation(const GlobalPoint& primeVtxPos, const GlobalPoint& hitPos,
+						const GlobalPoint& candPos)
+{
+  auto sq = [](float x){return x*x;};
+  auto calRDiff = [sq](const GlobalPoint& p1,const GlobalPoint& p2){
+    return std::sqrt(sq(p2.x()-p1.x()) + sq(p2.y()-p1.y()));
+  };
+  const double r1Diff = calRDiff(primeVtxPos,hitPos);
+  const double r2Diff = calRDiff(hitPos,candPos);
+  return hitPos.z() - r1Diff*(candPos.z()-hitPos.z())/r2Diff;
+}
+
+bool TrajSeedMatcher::passTrajPreSel(const GlobalPoint& hitPos, const GlobalPoint& candPos)const
+{
+  float dt = hitPos.x()*candPos.x()+hitPos.y()*candPos.y();
+  if (dt<0) return false;
+  if (dt<kPhiCut_*(candPos.perp()*hitPos.perp())) return false;
+  return true;
+}
+
+const TrajectoryStateOnSurface& TrajSeedMatcher::getTrajStateFromVtx(const TrackingRecHit& hit,
+								     const TrajectoryStateOnSurface& initialState,
+								     const PropagatorWithMaterial& propagator)
+{
+  auto& trajStateFromVtxCache = initialState.charge()==1 ? trajStateFromVtxPosChargeCache_ :
+                                                           trajStateFromVtxNegChargeCache_;
+
+  auto key = hit.det()->gdetIndex();
+  auto res = trajStateFromVtxCache.find(key);
+  if(res!=trajStateFromVtxCache.end()) return res->second;
+  else{ //doesnt exist, need to make it
+    //FIXME: check for efficiency
+    auto val = trajStateFromVtxCache.emplace(key,propagator.propagate(initialState,hit.det()->surface()));
+    return val.first->second;
+  }
+}
+
+const TrajectoryStateOnSurface& TrajSeedMatcher::getTrajStateFromPoint(const TrackingRecHit& hit,
+								       const FreeTrajectoryState& initialState,
+								       const GlobalPoint& point,
+								       const PropagatorWithMaterial& propagator)
+{
+  
+  auto& trajStateFromPointCache = initialState.charge()==1 ? trajStateFromPointPosChargeCache_ :
+                                                             trajStateFromPointNegChargeCache_;
+
+  auto key = std::make_pair(hit.det()->gdetIndex(),point);
+  auto res = trajStateFromPointCache.find(key);
+  if(res!=trajStateFromPointCache.end()) return res->second;
+  else{ //doesnt exist, need to make it
+    //FIXME: check for efficiency
+    auto val = trajStateFromPointCache.emplace(key,propagator.propagate(initialState,hit.det()->surface()));
+    return val.first->second;
+  }
+}
+
+TrajSeedMatcher::SCHitMatch TrajSeedMatcher::matchFirstHit(const TrajectorySeed& seed,
+							   const TrajectoryStateOnSurface& initialState,
+							   const GlobalPoint& vtxPos,
+							   const PropagatorWithMaterial& propagator)
+{
+  const TrajectorySeed::range& hits = seed.recHits();
+  auto hitIt = hits.first;
+
+  if(hitIt->isValid()){
+    const TrajectoryStateOnSurface& trajStateFromVtx = getTrajStateFromVtx(*hitIt,initialState,propagator);
+    if(trajStateFromVtx.isValid()) return SCHitMatch(vtxPos,trajStateFromVtx,*hitIt);  
+  }
+  return SCHitMatch();
+}
+
+TrajSeedMatcher::SCHitMatch TrajSeedMatcher::match2ndToNthHit(const TrajectorySeed& seed,
+							   const FreeTrajectoryState& initialState,
+							   const size_t hitNr,
+							   const GlobalPoint& prevHitPos,
+							   const GlobalPoint& vtxPos,
+							   const PropagatorWithMaterial& propagator)
+{
+  const TrajectorySeed::range& hits = seed.recHits();
+  auto hitIt = hits.first+hitNr;
+  
+  if(hitIt->isValid()){
+    const TrajectoryStateOnSurface& trajState = getTrajStateFromPoint(*hitIt,initialState,prevHitPos,propagator);
+    
+    if(trajState.isValid()){
+      return SCHitMatch(vtxPos,trajState,*hitIt);  
+    }
+  }
+  return SCHitMatch();
+  
+}
+
+void TrajSeedMatcher::clearCache()
+{
+  trajStateFromVtxPosChargeCache_.clear();
+  trajStateFromVtxNegChargeCache_.clear();
+  trajStateFromPointPosChargeCache_.clear();
+  trajStateFromPointNegChargeCache_.clear();
+}
+
+bool TrajSeedMatcher::passesMatchSel(const TrajSeedMatcher::SCHitMatch& hit, const size_t hitNr)const
+{
+  if(hitNr<matchingCuts_.size()){
+    return (*matchingCuts_[hitNr])(hit);
+  }else{
+    throw cms::Exception("LogicError") <<" Error, attempting to apply selection to hit "<<hitNr<<" but only cuts for "<<matchingCuts_.size()<<" defined";
+  }
+}
+
+int TrajSeedMatcher::getNrValidLayersAlongTraj(const SCHitMatch& hit1, const SCHitMatch& hit2,
+						const GlobalPoint& candPos,
+						const GlobalPoint & vprim, 
+						const float energy, const int charge)
+{
+  double zVertex = useRecoVertex_ ? vprim.z() : getZVtxFromExtrapolation(vprim,hit1.hitPos(),candPos);
+  GlobalPoint vertex(vprim.x(),vprim.y(),zVertex);
+  
+  FreeTrajectoryState firstHitFreeTraj = FTSFromVertexToPointFactory::get(*magField_,hit1.hitPos(), 
+									  vertex, energy, charge);
+  const TrajectoryStateOnSurface& secondHitTraj = getTrajStateFromPoint(*hit2.hit(),firstHitFreeTraj,hit1.hitPos(),*forwardPropagator_);
+  return getNrValidLayersAlongTraj(hit2.hit()->geographicalId(),secondHitTraj); 
+}
+
+int TrajSeedMatcher::getNrValidLayersAlongTraj(const DetId& hitId, const TrajectoryStateOnSurface& hitTrajState)const
+{
+  
+  const DetLayer* detLayer = detLayerGeom_->idToLayer(hitId);
+  if(detLayer==nullptr) return 0;
+
+  const FreeTrajectoryState& hitFreeState = *hitTrajState.freeState();
+  const std::vector<const DetLayer*> inLayers  = navSchool_->compatibleLayers(*detLayer,hitFreeState,oppositeToMomentum); 
+  const std::vector<const DetLayer*> outLayers = navSchool_->compatibleLayers(*detLayer,hitFreeState,alongMomentum); 
+  
+  int nrValidLayers=1; //because our current hit is also valid and wont be included in the count otherwise
+  int nrPixInLayers=0;
+  int nrPixOutLayers=0;
+  for(auto layer : inLayers){
+    if(GeomDetEnumerators::isTrackerPixel(layer->subDetector())){ 
+      nrPixInLayers++;
+      if(layerHasValidHits(*layer,hitTrajState,*backwardPropagator_)) nrValidLayers++;  
+    }
+  }
+  for(auto layer : outLayers){
+    if(GeomDetEnumerators::isTrackerPixel(layer->subDetector())){ 
+      nrPixOutLayers++;
+      if(layerHasValidHits(*layer,hitTrajState,*forwardPropagator_)) nrValidLayers++;  
+    }
+  }
+  return nrValidLayers;
+}
+						 
+bool TrajSeedMatcher::layerHasValidHits(const DetLayer& layer, const TrajectoryStateOnSurface& hitSurState,
+					const Propagator& propToLayerFromState)const
+{
+  //FIXME: do not hardcode with werid magic numbers stolen from ancient tracking code
+  //its taken from https://cmssdt.cern.ch/dxr/CMSSW/source/RecoTracker/TrackProducer/interface/TrackProducerBase.icc#165
+  //which inspires this code
+  Chi2MeasurementEstimator estimator(30.,-3.0,0.5,2.0,0.5,1.e12);  // same as defauts....
+  
+  const std::vector<GeometricSearchDet::DetWithState>& detWithState = layer.compatibleDets(hitSurState,propToLayerFromState,estimator);
+  if(detWithState.empty()) return false;
+  else{
+    DetId id = detWithState.front().first->geographicalId();
+    MeasurementDetWithData measDet = measTkEvt_->idToDet(id);
+    if(measDet.isActive()) return true;
+    else return false;
+  }
+}
+
+
+size_t TrajSeedMatcher::getNrHitsRequired(const int nrValidLayers)const
+{
+  for(size_t binNr=0;binNr<minNrHitsValidLayerBins_.size();binNr++){
+    if(nrValidLayers<minNrHitsValidLayerBins_[binNr]) return minNrHits_[binNr];
+  }
+  return minNrHits_.back();
+  
+}
+
+TrajSeedMatcher::SCHitMatch::SCHitMatch(const GlobalPoint& vtxPos,
+					const TrajectoryStateOnSurface& trajState,
+					const TrackingRecHit& hit):
+  detId_(hit.geographicalId()),
+  hitPos_(hit.globalPosition()),
+  hit_(&hit),
+  et_(0),eta_(0),phi_(0),charge_(0),nrClus_(0)
+{
+  EleRelPointPair pointPair(hitPos_,trajState.globalParameters().position(),vtxPos);
+  dRZ_ = detId_.subdetId()==PixelSubdetector::PixelBarrel ? pointPair.dZ() : pointPair.dPerp();
+  dPhi_ = pointPair.dPhi();
+}
+    
+
+TrajSeedMatcher::SeedWithInfo::
+SeedWithInfo(const TrajectorySeed& seed,
+	     const std::vector<SCHitMatch>& posCharge,
+	     const std::vector<SCHitMatch>& negCharge,
+	     int nrValidLayers):
+  seed_(seed),nrValidLayers_(nrValidLayers)
+{
+  size_t nrHitsMax = std::max(posCharge.size(),negCharge.size());
+  for(size_t hitNr=0;hitNr<nrHitsMax;hitNr++){
+    DetId detIdPos = hitNr<posCharge.size() ? posCharge[hitNr].detId() : DetId(0);
+    float dRZPos = hitNr<posCharge.size() ? posCharge[hitNr].dRZ() : std::numeric_limits<float>::max();
+    float dPhiPos = hitNr<posCharge.size() ? posCharge[hitNr].dPhi() : std::numeric_limits<float>::max();
+
+    DetId detIdNeg = hitNr<negCharge.size() ? negCharge[hitNr].detId() : DetId(0);
+    float dRZNeg = hitNr<negCharge.size() ? negCharge[hitNr].dRZ() : std::numeric_limits<float>::max();
+    float dPhiNeg = hitNr<negCharge.size() ? negCharge[hitNr].dPhi() : std::numeric_limits<float>::max();
+    
+    if(detIdPos!=detIdNeg && (detIdPos.rawId()!=0 && detIdNeg.rawId()!=0)){
+      cms::Exception("LogicError")<<" error in "<<__FILE__<<", "<<__LINE__<<" hits to be combined have different detIDs, this should not be possible and nothing good will come of it";
+    }
+    DetId detId = detIdPos.rawId()!=0 ? detIdPos : detIdNeg;
+    matchInfo_.push_back(MatchInfo(detId,dRZPos,dRZNeg,dPhiPos,dPhiNeg));
+  }
+}
+
+TrajSeedMatcher::MatchingCutsV1::MatchingCutsV1(const edm::ParameterSet& pset):
+  dPhiMax_(pset.getParameter<double>("dPhiMax")),
+  dRZMax_(pset.getParameter<double>("dRZMax")),
+  dRZMaxLowEtThres_(pset.getParameter<double>("dRZMaxLowEtThres")),
+  dRZMaxLowEtEtaBins_(pset.getParameter<std::vector<double> >("dRZMaxLowEtEtaBins")),
+  dRZMaxLowEt_(pset.getParameter<std::vector<double> >("dRZMaxLowEt"))
+{
+  if(dRZMaxLowEtEtaBins_.size()+1!=dRZMaxLowEt_.size()){
+    throw cms::Exception("InvalidConfig")<<" dRZMaxLowEtEtaBins should be 1 less than dRZMaxLowEt when its "<<dRZMaxLowEtEtaBins_.size()<<" vs "<<dRZMaxLowEt_.size();
+  }
+}
+
+bool TrajSeedMatcher::MatchingCutsV1::operator()(const TrajSeedMatcher::SCHitMatch& scHitMatch)const
+{
+  if(dPhiMax_>=0 && std::abs(scHitMatch.dPhi()) > dPhiMax_) return false;
+  
+  const float dRZMax = getDRZCutValue(scHitMatch.et(),scHitMatch.eta());
+  if(dRZMax_>=0 && std::abs(scHitMatch.dRZ()) > dRZMax) return false;
+	       
+  return true;
+}
+
+float TrajSeedMatcher::MatchingCutsV1::getDRZCutValue(const float scEt, const float scEta)const
+{
+  if(scEt>=dRZMaxLowEtThres_) return dRZMax_;
+  else{
+    const float absEta = std::abs(scEta);
+    for(size_t etaNr=0;etaNr<dRZMaxLowEtEtaBins_.size();etaNr++){
+      if(absEta<dRZMaxLowEtEtaBins_[etaNr]) return dRZMaxLowEt_[etaNr];
+    }
+    return dRZMaxLowEt_.back();
+  }
+}
+
+TrajSeedMatcher::MatchingCutsV2::MatchingCutsV2(const edm::ParameterSet& pset):
+  dPhiHighEt_(pset.getParameter<std::vector<double> >("dPhiMaxHighEt")),
+  dPhiHighEtThres_(pset.getParameter<std::vector<double> >("dPhiMaxHighEtThres")),
+  dPhiLowEtGrad_(pset.getParameter<std::vector<double> >("dPhiMaxLowEtGrad")),
+  dRZHighEt_(pset.getParameter<std::vector<double> >("dRZMaxHighEt")),
+  dRZHighEtThres_(pset.getParameter<std::vector<double> >("dRZMaxHighEtThres")),
+  dRZLowEtGrad_(pset.getParameter<std::vector<double> >("dRZMaxLowEtGrad")),
+  etaBins_(pset.getParameter<std::vector<double> >("etaBins"))
+{
+  auto binSizeCheck = [](size_t sizeEtaBins,const std::vector<double>& vec,const std::string& name){
+    if(vec.size()!=sizeEtaBins+1){ 
+      throw cms::Exception("InvalidConfig")<<" when constructing TrajSeedMatcher::MatchingCutsV2 "<< name<<" has "<<vec.size()<<" bins, it should be equal to #bins of etaBins+1"<<sizeEtaBins+1;
+    }
+  };
+  binSizeCheck(etaBins_.size(),dPhiHighEt_,"dPhiMaxHighEt");
+  binSizeCheck(etaBins_.size(),dPhiHighEtThres_,"dPhiMaxHighEtThres");
+  binSizeCheck(etaBins_.size(),dPhiLowEtGrad_,"dPhiMaxLowEtGrad");
+  binSizeCheck(etaBins_.size(),dRZHighEt_,"dRZMaxHighEt");
+  binSizeCheck(etaBins_.size(),dRZHighEtThres_,"dRZMaxHighEtThres");
+  binSizeCheck(etaBins_.size(),dRZLowEtGrad_,"dRZMaxLowEtGrad");
+}
+
+bool TrajSeedMatcher::MatchingCutsV2::operator()(const TrajSeedMatcher::SCHitMatch& scHitMatch)const
+{
+  size_t binNr=getBinNr(scHitMatch.eta());
+  float dPhiMax = getCutValue(scHitMatch.et(),dPhiHighEt_[binNr],dPhiHighEtThres_[binNr],dPhiLowEtGrad_[binNr]); 
+  if(dPhiMax>=0 && std::abs(scHitMatch.dPhi()) > dPhiMax) return false;  
+  float dRZMax = getCutValue(scHitMatch.et(),dRZHighEt_[binNr],dRZHighEtThres_[binNr],dRZLowEtGrad_[binNr]);
+  if(dRZMax>=0 && std::abs(scHitMatch.dRZ()) > dRZMax) return false;
+  
+  return true;
+}
+
+//eta bins is exactly 1 smaller than the vectors which will be accessed by this bin nr
+size_t TrajSeedMatcher::MatchingCutsV2::getBinNr(float eta)const
+{
+  const float absEta = std::abs(eta);
+  for(size_t etaNr=0;etaNr<etaBins_.size();etaNr++){
+    if(absEta<etaBins_[etaNr]) return etaNr;
+  }
+  return etaBins_.size();
+}
+

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronNHitSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronNHitSeedProducer.cc
@@ -1,0 +1,179 @@
+//******************************************************************************
+//
+// Part of the refactorisation of of the E/gamma pixel matching for 2017 pixels
+// This refactorisation converts the monolithic  approach to a series of 
+// independent producer modules, with each modules performing  a specific 
+// job as recommended by the 2017 tracker framework
+//
+//
+// The module produces the ElectronSeeds, similarly to ElectronSeedProducer
+// although with a varible number of required hits
+// 
+//
+// Author : Sam Harper (RAL), 2017
+//
+//*******************************************************************************
+
+
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeed.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
+#include "RecoEgamma/EgammaElectronAlgos/interface/TrajSeedMatcher.h"
+
+class ElectronNHitSeedProducer : public edm::stream::EDProducer<> {
+public:
+  
+  
+  explicit ElectronNHitSeedProducer( const edm::ParameterSet & ) ;
+  virtual ~ElectronNHitSeedProducer()=default;  
+  
+  virtual void produce( edm::Event &, const edm::EventSetup & ) override final;
+  
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+
+  TrajSeedMatcher matcher_;
+  
+  std::vector<edm::EDGetTokenT<std::vector<reco::SuperClusterRef>> > superClustersTokens_;
+  edm::EDGetTokenT<TrajectorySeedCollection> initialSeedsToken_ ;
+  edm::EDGetTokenT<std::vector<reco::Vertex> > verticesToken_;
+  edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_ ;
+  edm::EDGetTokenT<MeasurementTrackerEvent> measTkEvtToken_;
+  
+};
+
+namespace {
+  template<typename T> 
+  edm::Handle<T> getHandle(const edm::Event& event,const edm::EDGetTokenT<T>& token)
+  {
+    edm::Handle<T> handle;
+    event.getByToken(token,handle);
+    return handle;
+  }
+
+  template<typename T>
+  GlobalPoint convertToGP(const T& orgPoint){
+    return GlobalPoint(orgPoint.x(),orgPoint.y(),orgPoint.z());
+  }
+
+  int getLayerOrDiskNr(DetId detId,const TrackerTopology& trackerTopo)
+  {
+    if(detId.subdetId()==PixelSubdetector::PixelBarrel){
+      return trackerTopo.pxbLayer(detId);
+    }else if(detId.subdetId()==PixelSubdetector::PixelEndcap){
+      return trackerTopo.pxfDisk(detId);
+    }else return -1;
+  }
+  
+  reco::ElectronSeed::PMVars 
+  makeSeedPixelVar(const TrajSeedMatcher::MatchInfo& matchInfo,
+		   const TrackerTopology& trackerTopo)
+  {
+    
+    int layerOrDisk = getLayerOrDiskNr(matchInfo.detId,trackerTopo);
+    reco::ElectronSeed::PMVars pmVars;
+    pmVars.setDet(matchInfo.detId,layerOrDisk);
+    pmVars.setDPhi(matchInfo.dPhiPos,matchInfo.dPhiNeg);
+    pmVars.setDRZ(matchInfo.dRZPos,matchInfo.dRZNeg);
+    
+    return pmVars;
+  }  
+
+}
+
+ElectronNHitSeedProducer::ElectronNHitSeedProducer( const edm::ParameterSet& pset):
+  matcher_(pset.getParameter<edm::ParameterSet>("matcherConfig")),
+  initialSeedsToken_(consumes<TrajectorySeedCollection>(pset.getParameter<edm::InputTag>("initialSeeds"))),
+  verticesToken_(consumes<std::vector<reco::Vertex> >(pset.getParameter<edm::InputTag>("vertices"))),
+  beamSpotToken_(consumes<reco::BeamSpot>(pset.getParameter<edm::InputTag>("beamSpot"))),
+  measTkEvtToken_(consumes<MeasurementTrackerEvent>(pset.getParameter<edm::InputTag>("measTkEvt")))
+{
+  const auto superClusTags = pset.getParameter<std::vector<edm::InputTag> >("superClusters");
+  for(const auto& scTag : superClusTags){
+    superClustersTokens_.emplace_back(consumes<std::vector<reco::SuperClusterRef>>(scTag));
+  }
+  produces<reco::ElectronSeedCollection>() ;
+}
+
+void ElectronNHitSeedProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+{
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("initialSeeds",edm::InputTag("hltElePixelSeedsCombined"));
+  desc.add<edm::InputTag>("vertices",edm::InputTag());
+  desc.add<edm::InputTag>("beamSpot",edm::InputTag("hltOnlineBeamSpot")); 
+  desc.add<edm::InputTag>("measTkEvt",edm::InputTag("hltSiStripClusters"));
+  desc.add<std::vector<edm::InputTag> >("superClusters",std::vector<edm::InputTag>{edm::InputTag{"hltEgammaSuperClustersToPixelMatch"}});
+  desc.add<edm::ParameterSetDescription>("matcherConfig",TrajSeedMatcher::makePSetDescription());
+  
+  descriptions.add("electronNHitSeedProducer",desc);
+}
+
+void ElectronNHitSeedProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{ 
+  edm::ESHandle<TrackerTopology> trackerTopoHandle;
+  iSetup.get<TrackerTopologyRcd>().get(trackerTopoHandle);
+  
+  matcher_.doEventSetup(iSetup);
+  matcher_.setMeasTkEvtHandle(getHandle(iEvent,measTkEvtToken_));
+
+  auto eleSeeds = std::make_unique<reco::ElectronSeedCollection>();
+  
+  auto initialSeedsHandle = getHandle(iEvent,initialSeedsToken_);
+
+  auto beamSpotHandle = getHandle(iEvent,beamSpotToken_);
+  GlobalPoint primVtxPos = convertToGP(beamSpotHandle->position());
+
+  for(const auto& superClustersToken : superClustersTokens_){
+    auto superClustersHandle = getHandle(iEvent,superClustersToken);
+    for(auto& superClusRef : *superClustersHandle){
+
+      //the eta of the supercluster when mustache clustered is slightly biased due to bending in magnetic field
+      //the eta of its seed cluster is a better estimate of the orginal position
+      GlobalPoint caloPosition(GlobalPoint::Polar(superClusRef->seed()->position().theta(), //seed theta
+						  superClusRef->position().phi(), //supercluster phi
+						  superClusRef->position().r())); //supercluster r
+
+
+      const std::vector<TrajSeedMatcher::SeedWithInfo> matchedSeeds = 
+	matcher_.compatibleSeeds(*initialSeedsHandle,caloPosition,
+				 primVtxPos,superClusRef->energy());
+      
+      for(auto& matchedSeed : matchedSeeds){
+	reco::ElectronSeed eleSeed(matchedSeed.seed()); 
+	reco::ElectronSeed::CaloClusterRef caloClusRef(superClusRef);
+	eleSeed.setCaloCluster(caloClusRef);
+	eleSeed.setNrLayersAlongTraj(matchedSeed.nrValidLayers());
+	for(auto& matchInfo : matchedSeed.matches()){
+	  eleSeed.addHitInfo(makeSeedPixelVar(matchInfo,*trackerTopoHandle));
+	}
+	eleSeeds->emplace_back(eleSeed);
+      }
+    }
+    
+  }
+  iEvent.put(std::move(eleSeeds));
+}
+  
+
+  
+DEFINE_FWK_MODULE(ElectronNHitSeedProducer);

--- a/RecoEgamma/EgammaElectronProducers/plugins/TrackingRegionsFromSuperClustersEDProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/TrackingRegionsFromSuperClustersEDProducer.cc
@@ -1,0 +1,9 @@
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducerFactory.h"
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionEDProducerT.h"
+#include "RecoEgamma/EgammaElectronProducers/plugins/TrackingRegionsFromSuperClustersProducer.h"
+DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, TrackingRegionsFromSuperClustersProducer, "TrackingRegionsFromSuperClustersProducer");
+using TrackingRegionsFromSuperClustersEDProducer = TrackingRegionEDProducerT<TrackingRegionsFromSuperClustersProducer>;
+DEFINE_FWK_MODULE(TrackingRegionsFromSuperClustersEDProducer);

--- a/RecoEgamma/EgammaElectronProducers/plugins/TrackingRegionsFromSuperClustersProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/TrackingRegionsFromSuperClustersProducer.h
@@ -1,0 +1,314 @@
+#ifndef RecoTracker_TkTrackingRegions_TrackingRegionsFromSuperClustersProducer_H 
+#define RecoTracker_TkTrackingRegions_TrackingRegionsFromSuperClustersProducer_H
+
+//******************************************************************************
+//
+// Part of the refactorisation of of the E/gamma pixel matching pre-2017
+// This refactorisation converts the monolithic  approach to a series of 
+// independent producer modules, with each modules performing  a specific 
+// job as recommended by the 2017 tracker framework
+//
+// This module is called a Producer even though its not an ED producer
+// This was done to be consistant with other TrackingRegion producers
+// in RecoTracker/TkTrackingRegions
+//
+// The module closely follows the other TrackingRegion producers
+// in RecoTracker/TkTrackingRegions and is intended to become an EDProducer
+// by TrackingRegionEDProducerT<TrackingRegionsFromSuperClustersProducer>
+
+// This module c tracking regions from the superclusters. It mostly
+// replicates the functionality of the SeedFilter class
+// although unlike that class, it does not actually create seeds
+//
+// Author : Sam Harper (RAL), 2017
+//
+//*******************************************************************************
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/GeometryVector/interface/GlobalVector.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+
+
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h"
+#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
+#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
+
+#include "RecoEgamma/EgammaElectronAlgos/interface/FTSFromVertexToPointFactory.h"
+
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "CommonTools/Utils/interface/StringToEnumValue.h"
+
+//stick this in common tools
+#include "TEnum.h"
+#include "TEnumConstant.h"
+namespace{ 
+  template<typename MyEnum> MyEnum strToEnum(std::string const& enumConstName){
+    TEnum* en = TEnum::GetEnum(typeid(MyEnum));
+    if (en != nullptr){
+      if (TEnumConstant const* enc = en->GetConstant(enumConstName.c_str())){
+	return static_cast<MyEnum>(enc->GetValue());
+      }else{
+	throw cms::Exception("Configuration") <<enumConstName<<" is not a valid member of "<<typeid(MyEnum).name();
+      }
+    }
+    throw cms::Exception("LogicError") <<typeid(MyEnum).name()<<" not recognised by ROOT";
+  }
+  template<> RectangularEtaPhiTrackingRegion::UseMeasurementTracker strToEnum(std::string const& enumConstName){
+    using MyEnum = RectangularEtaPhiTrackingRegion::UseMeasurementTracker;
+    if(enumConstName=="kNever") return MyEnum::kNever;
+    else if(enumConstName=="kForSiStrips") return MyEnum::kForSiStrips;
+    else if(enumConstName=="kAlways") return MyEnum::kAlways;
+    else{
+      throw cms::Exception("InvalidConfiguration") <<enumConstName<<" is not a valid member of "<<typeid(MyEnum).name()<<" (or strToEnum needs updating, this is a manual translation found at "<<__FILE__<<" line "<<__LINE__<<")";
+    }
+  }
+
+} 
+class TrackingRegionsFromSuperClustersProducer : public TrackingRegionProducer
+{
+public: 
+  enum class Charge{
+    NEG=-1,POS=+1
+  };
+  
+public:
+
+  TrackingRegionsFromSuperClustersProducer(const edm::ParameterSet& cfg,
+					   edm::ConsumesCollector && cc);
+
+  virtual ~TrackingRegionsFromSuperClustersProducer(){}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+    
+  virtual std::vector<std::unique_ptr<TrackingRegion> >
+  regions (const edm::Event& iEvent, const edm::EventSetup& iSetup)const override;
+
+private:
+  GlobalPoint getVtxPos(const edm::Event& iEvent,double& deltaZVertex)const;
+  
+  std::unique_ptr<TrackingRegion> 
+  createTrackingRegion(const reco::SuperCluster& superCluster,const GlobalPoint& vtxPos,
+		       const double deltaZVertex,const Charge charge,
+		       const MeasurementTrackerEvent* measTrackerEvent,
+		       const MagneticField& magField)const;
+  
+private:
+  void validateConfigSettings()const;
+
+private:
+  //there are 3 modes in which to define the Z area of the tracking region
+  //1) from first vertex in the passed vertices collection +/- originHalfLength in z (useZInVertex=true)
+  //2) the beamspot +/- nrSigmaForBSDeltaZ* zSigma of beamspot (useZInBeamspot=true)
+  //   the zSigma of the beamspot can have a minimum value specified 
+  //   we do this because a common error is that beamspot has too small of a value
+  //3) defaultZ_ +/- originHalfLength  (if useZInVertex and useZInBeamspot are both false)
+  double ptMin_; 
+  double originRadius_; 
+  double originHalfLength_;
+  double deltaEtaRegion_;
+  double deltaPhiRegion_;
+  bool useZInVertex_;
+  bool useZInBeamspot_;
+  double nrSigmaForBSDeltaZ_;
+  double defaultZ_;
+  double minBSDeltaZ_;
+  bool precise_;
+  RectangularEtaPhiTrackingRegion::UseMeasurementTracker whereToUseMeasTracker_;
+  
+  edm::EDGetTokenT<reco::VertexCollection> verticesToken_; 
+  edm::EDGetTokenT<reco::BeamSpot>  beamSpotToken_; 
+  edm::EDGetTokenT<MeasurementTrackerEvent> measTrackerEventToken_;
+  std::vector<edm::EDGetTokenT<std::vector<reco::SuperClusterRef>> > superClustersTokens_;
+
+};
+
+
+
+namespace {
+  template<typename T>
+  edm::Handle<T> getHandle(const edm::Event& event,const edm::EDGetTokenT<T> & token){
+    edm::Handle<T> handle;
+    event.getByToken(token,handle);
+    return handle;
+  }
+}
+
+TrackingRegionsFromSuperClustersProducer::
+TrackingRegionsFromSuperClustersProducer(const edm::ParameterSet& cfg,
+					 edm::ConsumesCollector && iC)
+{ 
+  edm::ParameterSet regionPSet = cfg.getParameter<edm::ParameterSet>("RegionPSet");
+  
+  ptMin_                 = regionPSet.getParameter<double>("ptMin");
+  originRadius_          = regionPSet.getParameter<double>("originRadius");
+  originHalfLength_      = regionPSet.getParameter<double>("originHalfLength");
+  deltaPhiRegion_        = regionPSet.getParameter<double>("deltaPhiRegion");
+  deltaEtaRegion_        = regionPSet.getParameter<double>("deltaEtaRegion");
+  useZInVertex_          = regionPSet.getParameter<bool>("useZInVertex");
+  useZInBeamspot_        = regionPSet.getParameter<bool>("useZInBeamspot");
+  nrSigmaForBSDeltaZ_    = regionPSet.getParameter<double>("nrSigmaForBSDeltaZ"); 
+  defaultZ_              = regionPSet.getParameter<double>("defaultZ");
+  minBSDeltaZ_           = regionPSet.getParameter<double>("minBSDeltaZ");
+  precise_               = regionPSet.getParameter<bool>("precise");
+  whereToUseMeasTracker_ = strToEnum<RectangularEtaPhiTrackingRegion::UseMeasurementTracker>(regionPSet.getParameter<std::string>("whereToUseMeasTracker"));
+  
+  validateConfigSettings();
+
+  auto verticesTag         = regionPSet.getParameter<edm::InputTag>("vertices");
+  auto beamSpotTag         = regionPSet.getParameter<edm::InputTag>("beamSpot");
+  auto superClustersTags   = regionPSet.getParameter<std::vector<edm::InputTag> >("superClusters");
+  auto measTrackerEventTag = regionPSet.getParameter<edm::InputTag>("measurementTrackerEvent");
+  
+  if(useZInVertex_){
+    verticesToken_    = iC.consumes<reco::VertexCollection>(verticesTag);
+  }else{
+    beamSpotToken_    = iC.consumes<reco::BeamSpot>(beamSpotTag);
+  }
+  if(whereToUseMeasTracker_ != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever){
+    measTrackerEventToken_ = iC.consumes<MeasurementTrackerEvent>(measTrackerEventTag);
+  }
+  for(const auto& tag : superClustersTags){
+    superClustersTokens_.emplace_back(iC.consumes<std::vector<reco::SuperClusterRef>>(tag));
+  }
+}   
+
+
+
+void TrackingRegionsFromSuperClustersProducer::
+fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+{ 
+  edm::ParameterSetDescription desc;
+  
+  desc.add<double>("ptMin", 1.5);
+  desc.add<double>("originRadius", 0.2);
+  desc.add<double>("originHalfLength", 15.0)->setComment("z range is +/- this value except when using the beamspot (useZInBeamspot=true)");
+  desc.add<double>("deltaPhiRegion",0.4);
+  desc.add<double>("deltaEtaRegion",0.1);
+  desc.add<bool>("useZInVertex", false)->setComment("use the leading vertex  position +/-orginHalfLength, mutually exclusive with useZInBeamspot");
+  desc.add<bool>("useZInBeamspot", true)->setComment("use the beamspot  position +/- nrSigmaForBSDeltaZ* sigmaZ_{bs}, mutually exclusive with useZInVertex");
+  desc.add<double>("nrSigmaForBSDeltaZ",3.0)->setComment("# of sigma to extend the z region when using the beamspot, only active if useZInBeamspot=true");
+  desc.add<double>("minBSDeltaZ",0.0)->setComment("a minimum value of the beamspot sigma z to use, only active if useZInBeamspot=true");
+  desc.add<double>("defaultZ",0.)->setComment("the default z position, only used if useZInVertex and useZInBeamspot are both false");
+  desc.add<bool>("precise", true);
+  desc.add<std::string>("whereToUseMeasTracker","kNever");
+  desc.add<edm::InputTag>("beamSpot", edm::InputTag("hltOnlineBeamSpot"))->setComment("only used if useZInBeamspot is true");
+  desc.add<edm::InputTag>("vertices", edm::InputTag())->setComment("only used if useZInVertex is true");
+  desc.add<std::vector<edm::InputTag> >("superClusters", std::vector<edm::InputTag>{edm::InputTag{"hltEgammaSuperClustersToPixelMatch"}});
+  desc.add<edm::InputTag>("measurementTrackerEvent",edm::InputTag()); 
+  
+  edm::ParameterSetDescription descRegion;
+  descRegion.add<edm::ParameterSetDescription>("RegionPSet", desc);
+
+  descriptions.add("trackingRegionsFromSuperClusters", descRegion);
+}
+
+
+
+std::vector<std::unique_ptr<TrackingRegion> >
+TrackingRegionsFromSuperClustersProducer::
+regions(const edm::Event& iEvent, const edm::EventSetup& iSetup)const
+{
+  std::vector<std::unique_ptr<TrackingRegion> > trackingRegions;
+  
+  double deltaZVertex=0;
+  GlobalPoint vtxPos = getVtxPos(iEvent,deltaZVertex);
+
+  const MeasurementTrackerEvent *measTrackerEvent = nullptr;    
+  if(!measTrackerEventToken_.isUninitialized()){
+    measTrackerEvent = getHandle(iEvent,measTrackerEventToken_).product();
+  }
+  edm::ESHandle<MagneticField> magFieldHandle;
+  iSetup.get<IdealMagneticFieldRecord>().get(magFieldHandle);
+  
+  for(auto& superClustersToken : superClustersTokens_){
+    auto superClustersHandle = getHandle(iEvent,superClustersToken);
+    for(auto& superClusterRef : *superClustersHandle){
+      //do both charge hypothesises 
+      trackingRegions.emplace_back(createTrackingRegion(*superClusterRef,vtxPos,deltaZVertex,Charge::POS,measTrackerEvent,*magFieldHandle));
+      trackingRegions.emplace_back(createTrackingRegion(*superClusterRef,vtxPos,deltaZVertex,Charge::NEG,measTrackerEvent,*magFieldHandle));
+    }
+  }
+  return trackingRegions;
+}
+
+GlobalPoint TrackingRegionsFromSuperClustersProducer::
+getVtxPos(const edm::Event& iEvent,double& deltaZVertex)const
+{
+  if(useZInVertex_){
+    auto verticesHandle = getHandle(iEvent,verticesToken_);
+    //we throw if the vertices are not there but if no vertex is 
+    //recoed in the event, we default to 0,0,defaultZ as the vertex
+    if(!verticesHandle->empty()){ 
+      deltaZVertex = originHalfLength_;
+      const auto& pv = verticesHandle->front();
+      return GlobalPoint(pv.x(),pv.y(),pv.z());
+    }else{
+      deltaZVertex = originHalfLength_;
+      return GlobalPoint(0,0,defaultZ_);
+    }
+  }else{
+
+    auto beamSpotHandle = getHandle(iEvent,beamSpotToken_);
+    const reco::BeamSpot::Point& bsPos = beamSpotHandle->position();
+    
+    if(useZInBeamspot_){
+      //as this is what has been done traditionally for e/gamma, others just use sigmaZ
+      const double bsSigmaZ = std::sqrt(beamSpotHandle->sigmaZ()*beamSpotHandle->sigmaZ() + 
+					beamSpotHandle->sigmaZ0Error()*beamSpotHandle->sigmaZ0Error());
+      const double sigmaZ = std::max(bsSigmaZ,minBSDeltaZ_);
+      deltaZVertex = nrSigmaForBSDeltaZ_*sigmaZ;
+    
+      return GlobalPoint(bsPos.x(),bsPos.y(),bsPos.z());
+    }else{
+      deltaZVertex = originHalfLength_;
+      return GlobalPoint(bsPos.x(),bsPos.y(),defaultZ_); 
+    }
+  }
+  
+}
+
+std::unique_ptr<TrackingRegion>
+TrackingRegionsFromSuperClustersProducer::
+createTrackingRegion(const reco::SuperCluster& superCluster,const GlobalPoint& vtxPos,
+		     const double deltaZVertex,const Charge charge,
+		     const MeasurementTrackerEvent* measTrackerEvent,
+		     const MagneticField& magField)const
+{   
+  const GlobalPoint clusterPos(superCluster.position().x(), superCluster.position().y(), superCluster.position().z());
+  const double energy = superCluster.energy();
+  
+  FreeTrajectoryState freeTrajState = FTSFromVertexToPointFactory::get(magField, clusterPos, vtxPos, energy, static_cast<int>(charge));
+  return std::make_unique<RectangularEtaPhiTrackingRegion>(freeTrajState.momentum(),
+							   vtxPos,
+							   ptMin_,
+							   originRadius_,
+							   deltaZVertex,
+							   deltaEtaRegion_,
+							   deltaPhiRegion_,
+							   whereToUseMeasTracker_,
+							   precise_,
+							   measTrackerEvent);
+}
+
+void TrackingRegionsFromSuperClustersProducer::validateConfigSettings()const
+{
+  if(useZInVertex_ && useZInBeamspot_){
+    throw cms::Exception("InvalidConfiguration") <<" when constructing TrackingRegionsFromSuperClustersProducer both useZInVertex ("<<useZInVertex_<<") and useZInBeamspot ("<<useZInBeamspot_<<") can not be true as they are mutually exclusive options"<<std::endl;
+  }
+}
+
+#endif 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTFilteredSuperClusterProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTFilteredSuperClusterProducer.cc
@@ -1,0 +1,168 @@
+#ifndef RECOEGAMMA_EGAMMAHLTPRODUCERS_EGAMMAHLTFILTEREDSUPERCLUSTERPRODUCER_H
+#define RECOEGAMMA_EGAMMAHLTPRODUCERS_EGAMMAHLTFILTEREDSUPERCLUSTERPRODUCER_H
+
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h" 
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidateFwd.h"
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidateIsolation.h"
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
+
+namespace {
+  template<typename T> edm::Handle<T> getHandle(const edm::Event& event,const edm::EDGetTokenT<T>& token)
+  {
+    edm::Handle<T> handle;
+    event.getByToken(token,handle);
+    return handle;
+  }
+
+}
+
+class EgammaHLTFilteredSuperClusterProducer : public edm::stream::EDProducer<>{
+public:  
+  class SelectionCut {
+  private:
+    struct CutValues {
+      float cut;
+      float cutOverE;
+      float cutOverE2;
+      bool useEt;
+      std::function<bool(float,float)> compFunc;
+
+      CutValues(const edm::ParameterSet& pset):
+	cut(pset.getParameter<double>("cut")),
+	cutOverE(pset.getParameter<double>("cutOverE")),
+	cutOverE2(pset.getParameter<double>("cutOverE2")),
+	useEt(pset.getParameter<bool>("useEt")),
+	compFunc(std::less<float>()) {}
+    
+      bool operator()(const reco::RecoEcalCandidate& cand,float value)const{
+	float energy = useEt ? cand.et() : cand.energy();
+	return compFunc(value,cut) || compFunc(value/energy,cutOverE) || 
+	  compFunc(value/energy/energy,cutOverE2);
+      }
+    };
+  public:
+    SelectionCut(const edm::ParameterSet& pset,edm::ConsumesCollector && iC):
+      ebCut_(pset.getParameter<edm::ParameterSet>("barrelCut")),
+      eeCut_(pset.getParameter<edm::ParameterSet>("endcapCut")),
+      varToken_(iC.consumes<reco::RecoEcalCandidateIsolationMap>(pset.getParameter<edm::InputTag>("var")))
+    {}
+      
+    ~SelectionCut()=default;
+
+    bool operator()(const reco::RecoEcalCandidateRef& cand)const{
+      CutValues cut = std::abs(cand->eta())<1.479 ? ebCut_ : eeCut_;
+      return cut(*cand,getVar(cand));
+    }
+
+    float getVar(const reco::RecoEcalCandidateRef& cand)const{ 
+      auto res = varHandle_->find(cand);
+      if(res!=varHandle_->end()) return res->val;
+      else{
+	//FIX ME: add some provenance info to this
+	throw cms::Exception("LogicError") <<" candidate not found in collection ";
+      }
+    }
+
+    void getHandles(const edm::Event& event){
+      event.getByToken(varToken_,varHandle_);
+    }
+  private:
+    CutValues ebCut_;
+    CutValues eeCut_;
+    edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> varToken_;
+    edm::Handle<reco::RecoEcalCandidateIsolationMap> varHandle_;
+  };
+
+  explicit EgammaHLTFilteredSuperClusterProducer(const edm::ParameterSet& pset);
+  ~EgammaHLTFilteredSuperClusterProducer()=default;
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+
+   void produce(edm::Event&, const edm::EventSetup&) override;    
+  
+
+private:
+  edm::EDGetTokenT<reco::RecoEcalCandidateCollection> candsToken_;
+  std::vector<SelectionCut> cuts_;
+};
+
+EgammaHLTFilteredSuperClusterProducer::
+EgammaHLTFilteredSuperClusterProducer(const edm::ParameterSet& pset):
+  candsToken_(consumes<reco::RecoEcalCandidateCollection>(pset.getParameter<edm::InputTag>("cands")))
+{
+  const auto& cutPsets = pset.getParameter<std::vector<edm::ParameterSet> >("cuts");
+  for(auto& cutPset : cutPsets){
+    cuts_.push_back(SelectionCut(cutPset,consumesCollector()));
+  }
+
+  produces<std::vector<reco::SuperClusterRef>>();
+  
+}
+ 
+void EgammaHLTFilteredSuperClusterProducer::
+fillDescriptions(edm::ConfigurationDescriptions & descriptions)
+{
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("cands",edm::InputTag("hltEgammaCandidates"));
+  
+  edm::ParameterSetDescription cutsDesc;
+  edm::ParameterSetDescription regionCutsDesc;
+  regionCutsDesc.add<double>("cut",-1);
+  regionCutsDesc.add<double>("cutOverE",-1);
+  regionCutsDesc.add<double>("cutOverE2",-1);
+  regionCutsDesc.add<bool>("useEt",false);
+  edm::ParameterSet cutDefaults;
+  cutDefaults.addParameter<double>("cutOverE",0.2);
+  cutDefaults.addParameter<double>("useEt",false);
+  
+  cutsDesc.add<edm::ParameterSetDescription>("barrelCut",regionCutsDesc);
+  cutsDesc.add<edm::ParameterSetDescription>("endcapCut",regionCutsDesc);
+  cutsDesc.add<edm::InputTag>("var",edm::InputTag("hltEgammaHoverE"));
+  
+  edm::ParameterSet defaults;
+  defaults.addParameter<edm::InputTag>("var",edm::InputTag("hltEgammaHoverE"));
+  defaults.addParameter<edm::ParameterSet>("barrelCut",cutDefaults);
+  defaults.addParameter<edm::ParameterSet>("endcapCut",cutDefaults);
+  desc.addVPSet("cuts",cutsDesc,std::vector<edm::ParameterSet>{defaults});
+ 
+  descriptions.add("egammaHLTFilteredSuperClusterProducer",desc);
+
+}
+
+void EgammaHLTFilteredSuperClusterProducer::
+produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
+{
+  for(auto& cut : cuts_) cut.getHandles(iEvent);
+  auto candsHandle = getHandle(iEvent,candsToken_);
+  
+  auto outputSCs = std::make_unique<std::vector<reco::SuperClusterRef>>();
+
+  for(size_t candNr=0;candNr<candsHandle->size();candNr++){
+    reco::RecoEcalCandidateRef candRef(candsHandle,candNr);
+    bool passAllCuts=true;
+    for(const auto& cut: cuts_){
+      if(!cut(candRef)){
+	passAllCuts=false;
+	break;
+      }
+    }
+    if(passAllCuts) outputSCs->push_back(candRef->superCluster());
+  }
+  
+  iEvent.put(std::move(outputSCs));
+}
+
+DEFINE_FWK_MODULE(EgammaHLTFilteredSuperClusterProducer);
+
+#endif

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchVarProducer.cc
@@ -1,7 +1,7 @@
 
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -24,14 +24,88 @@
 
 #include "RecoEgamma/EgammaHLTProducers/interface/EgammaHLTPixelMatchParamObjects.h"
 
-class EgammaHLTPixelMatchVarProducer : public edm::global::EDProducer<> {
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+namespace {
+  //first 4 bits are sub detect of each hit (0=barrel, 1 = endcap) 
+  //next 8 bits are layer information (0=no hit, 1 = hit), first 4 are barrel, next 4 are endcap (theres an empty bit here
+  //next 4 bits are nr of layers info
+  int makeSeedInfo(const reco::ElectronSeed& seed){
+    int info = 0;
+    for(size_t hitNr=0;hitNr<seed.hitInfo().size();hitNr++){
+      int subDetBit = 0x1 <<hitNr;
+      if(seed.subDet(hitNr)==PixelSubdetector::PixelEndcap) info |=subDetBit;
+      int layerOffset = 3;
+      if(seed.subDet(hitNr)==PixelSubdetector::PixelEndcap) layerOffset+=4;
+      int layerBit = 0x1 << layerOffset << seed.layerOrDiskNr(hitNr) ;
+      info |=layerBit;
+
+      int nrLayersAlongTrajShifted = seed.nrLayersAlongTraj()<<12;
+      info |=nrLayersAlongTrajShifted;
+    }
+    return info;
+  }
+
+}
+
+struct PixelData {
+  
+public:
+  PixelData(std::string name,size_t hitNr,float (reco::ElectronSeed::*func)(size_t)const,
+	    const edm::Handle<reco::RecoEcalCandidateCollection>& candHandle):
+    name_(std::move(name)),hitNr_(hitNr),func_(func),
+    val_(std::numeric_limits<float>::max()),
+    valInfo_(0)
+  {
+    valMap_=std::make_unique<reco::RecoEcalCandidateIsolationMap>(candHandle);
+    valInfoMap_=std::make_unique<reco::RecoEcalCandidateIsolationMap>(candHandle);
+  }
+  PixelData(PixelData&& rhs)=default;
+  
+  void resetVal(){val_=std::numeric_limits<float>::max();valInfo_=0;}
+  void fill(const reco::ElectronSeed& seed){
+    if(hitNr_<seed.hitInfo().size()){
+      float seedVal = (seed.*func_)(hitNr_);
+      if(std::abs(seedVal) < std::abs(val_) ){
+	val_ = seedVal;
+	valInfo_ = makeSeedInfo(seed);
+      }
+    }
+  }
+  void fill(const reco::RecoEcalCandidateRef& candRef){
+    valMap_->insert(candRef,val_);
+    valInfoMap_->insert(candRef,valInfo_);
+    val_ = std::numeric_limits<float>::max();
+    valInfo_ = 0;
+  }
+  
+  void putInto(edm::Event& event){
+    event.put(std::move(valMap_),name_+std::to_string(hitNr_+1));
+    event.put(std::move(valInfoMap_),name_+std::to_string(hitNr_+1)+"Info");
+  }
+
+private:
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> valMap_;
+  std::unique_ptr<reco::RecoEcalCandidateIsolationMap> valInfoMap_;
+  std::string name_;
+  size_t hitNr_;
+  float (reco::ElectronSeed::*func_)(size_t)const; 
+  float val_;
+  float valInfo_;
+
+};
+
+
+class EgammaHLTPixelMatchVarProducer : public edm::stream::EDProducer<> {
 public:
 
   explicit EgammaHLTPixelMatchVarProducer(const edm::ParameterSet&);
   ~EgammaHLTPixelMatchVarProducer();
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  void produce(edm::StreamID sid, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
   std::array<float,4> calS2(const reco::ElectronSeed& seed,int charge)const;
 
 private: 
@@ -45,7 +119,7 @@ private:
   egPM::Param<reco::ElectronSeed> dRZ2Para_;
   
   int productsToWrite_;
-  
+  size_t nrHits_;
 };
 
 EgammaHLTPixelMatchVarProducer::EgammaHLTPixelMatchVarProducer(const edm::ParameterSet& config) : 
@@ -54,7 +128,8 @@ EgammaHLTPixelMatchVarProducer::EgammaHLTPixelMatchVarProducer(const edm::Parame
   dPhi1Para_(config.getParameter<edm::ParameterSet>("dPhi1SParams")),
   dPhi2Para_(config.getParameter<edm::ParameterSet>("dPhi2SParams")),
   dRZ2Para_(config.getParameter<edm::ParameterSet>("dRZ2SParams")),
-  productsToWrite_(config.getParameter<int>("productsToWrite"))
+  productsToWrite_(config.getParameter<int>("productsToWrite")),
+  nrHits_(4)
   
 {
   //register your products  
@@ -64,7 +139,19 @@ EgammaHLTPixelMatchVarProducer::EgammaHLTPixelMatchVarProducer(const edm::Parame
     produces < reco::RecoEcalCandidateIsolationMap >("dPhi2BestS2");
     produces < reco::RecoEcalCandidateIsolationMap >("dzBestS2");
   }
-
+  if(productsToWrite_>=2){
+    //note for product names we start from index 1
+    for(size_t hitNr=1;hitNr<=nrHits_;hitNr++){
+      produces < reco::RecoEcalCandidateIsolationMap >("dPhi"+std::to_string(hitNr));
+      produces < reco::RecoEcalCandidateIsolationMap >("dPhi"+std::to_string(hitNr)+"Info");
+      produces < reco::RecoEcalCandidateIsolationMap >("dRZ"+std::to_string(hitNr));
+      produces < reco::RecoEcalCandidateIsolationMap >("dRZ"+std::to_string(hitNr)+"Info");
+    } 
+    produces < reco::RecoEcalCandidateIsolationMap >("nrClus");
+    produces < reco::RecoEcalCandidateIsolationMap >("seedClusEFrac");
+    produces < reco::RecoEcalCandidateIsolationMap >("phiWidth");
+    produces < reco::RecoEcalCandidateIsolationMap >("etaWidth");
+  }
 
 }
 
@@ -114,7 +201,7 @@ void EgammaHLTPixelMatchVarProducer::fillDescriptions(edm::ConfigurationDescript
   descriptions.add(("hltEgammaHLTPixelMatchVarProducer"), desc);  
 }
 
-void EgammaHLTPixelMatchVarProducer::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+void EgammaHLTPixelMatchVarProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
   
   // Get the HLT filtered objects
   edm::Handle<reco::RecoEcalCandidateCollection> recoEcalCandHandle;
@@ -124,15 +211,38 @@ void EgammaHLTPixelMatchVarProducer::produce(edm::StreamID sid, edm::Event& iEve
   edm::Handle<reco::ElectronSeedCollection> pixelSeedsHandle;
   iEvent.getByToken(pixelSeedsToken_,pixelSeedsHandle);
 
-  if(!recoEcalCandHandle.isValid() || !pixelSeedsHandle.isValid()) return;
+  if(!recoEcalCandHandle.isValid()) return;
+  else if(!pixelSeedsHandle.isValid()){
+    auto s2Map = std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandHandle);
+    for(unsigned int candNr = 0; candNr<recoEcalCandHandle->size(); candNr++) {
+      reco::RecoEcalCandidateRef candRef(recoEcalCandHandle,candNr);
+      s2Map->insert(candRef,0);
+    }
+    iEvent.put(std::move(s2Map),"s2");
+    return;
+  }
 
+  edm::ESHandle<TrackerTopology> trackerTopoHandle;
+  iSetup.get<TrackerTopologyRcd>().get(trackerTopoHandle);
+  
   auto dPhi1BestS2Map = std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandHandle);
   auto dPhi2BestS2Map = std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandHandle);
   auto dzBestS2Map = std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandHandle);
   auto s2Map = std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandHandle);
   
+  auto nrClusMap = std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandHandle);
+  auto seedClusEFracMap = std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandHandle); 
+  auto phiWidthMap = std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandHandle); 
+  auto etaWidthMap = std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandHandle); 
+  
+  std::vector<PixelData> pixelData;
+  for(size_t hitNr=0;hitNr<nrHits_;hitNr++){
+    pixelData.emplace_back(PixelData("dPhi",hitNr,&reco::ElectronSeed::dPhiBest,recoEcalCandHandle));
+    pixelData.emplace_back(PixelData("dRZ",hitNr,&reco::ElectronSeed::dRZBest,recoEcalCandHandle));
+  }
+
   for(unsigned int candNr = 0; candNr<recoEcalCandHandle->size(); candNr++) {
-    
+
     reco::RecoEcalCandidateRef candRef(recoEcalCandHandle,candNr);
     reco::SuperClusterRef candSCRef = candRef->superCluster();
     
@@ -147,6 +257,11 @@ void EgammaHLTPixelMatchVarProducer::produce(edm::StreamID sid, edm::Event& iEve
 	if(s2Data[0]<bestS2[0]) bestS2=s2Data;
 	if(s2DataPos[0]<bestS2[0]) bestS2=s2DataPos;
 	
+	if(productsToWrite_>=2){
+	  for(auto& pixelDatum : pixelData){
+	    pixelDatum.fill(seed);
+	  }
+	}
       }
     }
 
@@ -157,7 +272,21 @@ void EgammaHLTPixelMatchVarProducer::produce(edm::StreamID sid, edm::Event& iEve
       dPhi2BestS2Map->insert(candRef,bestS2[2]);
       dzBestS2Map->insert(candRef,bestS2[3]);
     }
-    
+    if(productsToWrite_>=2){
+       nrClusMap->insert(candRef,candSCRef->clustersSize());
+       float seedClusEFrac = candSCRef->rawEnergy()>0 ? candSCRef->seed()->energy() / candSCRef->rawEnergy() : 0.;
+       //       std::cout <<"cand "<<candSCRef->energy()<<" E Corr "<<candSCRef->correctedEnergyUncertainty()<<" "<<candSCRef->correctedEnergy()<<" width "<<candSCRef->phiWidth()<<std::endl;
+       //  float seedClusEFrac = candSCRef->phiWidth();
+       seedClusEFracMap->insert(candRef,seedClusEFrac);
+       float phiWidth = candSCRef->phiWidth();
+       float etaWidth = candSCRef->etaWidth();
+       phiWidthMap->insert(candRef,phiWidth);
+       etaWidthMap->insert(candRef,etaWidth);
+       
+       for(auto& pixelDatum : pixelData){
+	 pixelDatum.fill(candRef);
+       }
+    } 
   }
 
   iEvent.put(std::move(s2Map),"s2");
@@ -165,6 +294,15 @@ void EgammaHLTPixelMatchVarProducer::produce(edm::StreamID sid, edm::Event& iEve
     iEvent.put(std::move(dPhi1BestS2Map),"dPhi1BestS2");
     iEvent.put(std::move(dPhi2BestS2Map),"dPhi2BestS2");
     iEvent.put(std::move(dzBestS2Map),"dzBestS2");
+  }
+  if(productsToWrite_>=2){
+    for(auto& pixelDatum : pixelData){
+      pixelDatum.putInto(iEvent);
+    }   
+    iEvent.put(std::move(nrClusMap),"nrClus");
+    iEvent.put(std::move(seedClusEFracMap),"seedClusEFrac");
+    iEvent.put(std::move(phiWidthMap),"phiWidth");
+    iEvent.put(std::move(etaWidthMap),"etaWidth");
   }
 }
 
@@ -174,9 +312,9 @@ std::array<float,4> EgammaHLTPixelMatchVarProducer::calS2(const reco::ElectronSe
   const float dPhi2Const = dPhi2Para_(seed);
   const float dRZ2Const = dRZ2Para_(seed);
   
-  float dPhi1 = (charge <0 ? seed.dPhi1() : seed.dPhi1Pos())/dPhi1Const;
-  float dPhi2 = (charge <0 ? seed.dPhi2() : seed.dPhi2Pos())/dPhi2Const;
-  float dRz2 = (charge <0 ? seed.dRz2() : seed.dRz2Pos())/dRZ2Const;
+  float dPhi1 = (charge <0 ? seed.dPhiNeg(0) : seed.dPhiPos(0))/dPhi1Const;
+  float dPhi2 = (charge <0 ? seed.dPhiNeg(1) : seed.dPhiPos(1))/dPhi2Const;
+  float dRz2 = (charge <0 ? seed.dRZNeg(1) : seed.dRZPos(1))/dRZ2Const;
   
   float s2 = dPhi1*dPhi1+dPhi2*dPhi2+dRz2*dRz2;
   return std::array<float,4>{{s2,dPhi1,dPhi2,dRz2}}; 

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
@@ -58,16 +58,23 @@ void TSGForOI::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   iSetup.get<GlobalTrackingGeometryRecord>().get(geometry_);
   iSetup.get<TrackingComponentsRecord>().get(estimatorName_,estimator_);
   iEvent.getByToken(measurementTrackerTag_, measurementTracker_);
+
+  edm::ESHandle<TrackerGeometry> tmpTkGeometry;
+  iSetup.get<TrackerDigiGeometryRecord>().get(tmpTkGeometry);
+
   edm::Handle<reco::TrackCollection> l2TrackCol;					
   iEvent.getByToken(src_, l2TrackCol);
 
-  //	The product:
+  //The product:
   std::unique_ptr<std::vector<TrajectorySeed> > result(new std::vector<TrajectorySeed>());
 
-  //	Get vector of Detector layers once:
   std::vector<BarrelDetLayer const*> const& tob = measurementTracker_->geometricSearchTracker()->tobLayers();
-  std::vector<ForwardDetLayer const*> const& tecPositive = measurementTracker_->geometricSearchTracker()->posTecLayers();
-  std::vector<ForwardDetLayer const*> const& tecNegative = measurementTracker_->geometricSearchTracker()->negTecLayers();
+  std::vector<ForwardDetLayer const*> const& tecPositive = tmpTkGeometry->isThere(GeomDetEnumerators::P2OTEC) ? 
+                                                                measurementTracker_->geometricSearchTracker()->posTidLayers() : 
+                                                                measurementTracker_->geometricSearchTracker()->posTecLayers(); 
+  std::vector<ForwardDetLayer const*> const& tecNegative = tmpTkGeometry->isThere(GeomDetEnumerators::P2OTEC) ? 
+                                                                measurementTracker_->geometricSearchTracker()->negTidLayers() : 
+                                                                measurementTracker_->geometricSearchTracker()->negTecLayers();
 
   //	Get the suitable propagators:
   std::unique_ptr<Propagator> propagatorAlong = SetPropagationDirection(*propagatorAlong_,alongMomentum);

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
@@ -5,7 +5,7 @@
  */
 
 #include "RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h"
-#include "DataFormats/SiStripDetId/interface/TECDetId.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 #include <memory>
 
@@ -14,6 +14,7 @@ using namespace std;
 
 TSGForOI::TSGForOI(const edm::ParameterSet & iConfig) :
   src_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+  numOfMaxSeedsParam_(iConfig.getParameter<uint32_t>("maxSeeds")),
   numOfLayersToTry_(iConfig.getParameter<int32_t>("layersToTry")),
   numOfHitsToTry_(iConfig.getParameter<int32_t>("hitsToTry")),
   fixedErrorRescalingForHits_(iConfig.getParameter<double>("fixedErrorRescaleFactorForHits")),
@@ -25,7 +26,6 @@ TSGForOI::TSGForOI(const edm::ParameterSet & iConfig) :
   maxEtaForTOB_(iConfig.getParameter<double>("maxEtaForTOB")),
   useHitLessSeeds_(iConfig.getParameter<bool>("UseHitLessSeeds")),
   useStereoLayersInTEC_(iConfig.getParameter<bool>("UseStereoLayersInTEC")),
-  dummyPlane_(Plane::build(Plane::PositionType(), Plane::RotationType())),
   updator_(new KFUpdator()),
   measurementTrackerTag_(consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("MeasurementTrackerEvent"))),
   pT1_(iConfig.getParameter<double>("pT1")),
@@ -38,12 +38,10 @@ TSGForOI::TSGForOI(const edm::ParameterSet & iConfig) :
   SF3_(iConfig.getParameter<double>("SF3")),
   SF4_(iConfig.getParameter<double>("SF4")),
   SF5_(iConfig.getParameter<double>("SF5")),
-  tsosDiff_(iConfig.getParameter<double>("tsosDiff"))
+  tsosDiff_(iConfig.getParameter<double>("tsosDiff")),
+  theCategory(string("Muon|RecoMuon|TSGForOI"))
 {
-  numOfMaxSeeds_=iConfig.getParameter<uint32_t>("maxSeeds");
   produces<std::vector<TrajectorySeed> >();
-  numSeedsMade_=0;
-  theCategory = "Muon|RecoMuon|TSGForOI";
 }
 
 
@@ -51,27 +49,57 @@ TSGForOI::~TSGForOI(){
 }
 
 
-void TSGForOI::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  iSetup.get<IdealMagneticFieldRecord>().get(magfield_);
-  iSetup.get<TrackingComponentsRecord>().get("PropagatorWithMaterial", propagatorOpposite_);
-  iSetup.get<TrackingComponentsRecord>().get("PropagatorWithMaterial", propagatorAlong_);
-  iSetup.get<GlobalTrackingGeometryRecord>().get(geometry_);
-  iSetup.get<TrackingComponentsRecord>().get(estimatorName_,estimator_);
-  iEvent.getByToken(measurementTrackerTag_, measurementTracker_);
-  edm::Handle<reco::TrackCollection> l2TrackCol;					
+void TSGForOI::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  /// Init variables
+  unsigned int numOfMaxSeeds = numOfMaxSeedsParam_;
+  unsigned int numSeedsMade=0;
+  bool analysedL2 = false;
+  bool foundHitlessSeed = false; 
+  unsigned int layerCount = 0;
+
+
+  /// Surface used to make a TSOS at the PCA to the beamline
+  Plane::PlanePointer dummyPlane = Plane::build(Plane::PositionType(), Plane::RotationType());
+
+  /// Read ESHandles
+  edm::Handle<MeasurementTrackerEvent>          measurementTrackerH;
+  edm::ESHandle<Chi2MeasurementEstimatorBase>   estimatorH;
+  edm::ESHandle<MagneticField>                  magfieldH;
+  edm::ESHandle<Propagator>                     propagatorAlongH;
+  edm::ESHandle<Propagator>                     propagatorOppositeH;
+  edm::ESHandle<TrackerGeometry>                tmpTkGeometryH;  
+  edm::ESHandle<GlobalTrackingGeometry>         geometryH;
+
+  iSetup.get<IdealMagneticFieldRecord>().get(magfieldH);
+  iSetup.get<TrackingComponentsRecord>().get("PropagatorWithMaterial", propagatorOppositeH);
+  iSetup.get<TrackingComponentsRecord>().get("PropagatorWithMaterial", propagatorAlongH);
+  iSetup.get<GlobalTrackingGeometryRecord>().get(geometryH);
+  iSetup.get<TrackerDigiGeometryRecord>().get(tmpTkGeometryH);
+  iSetup.get<TrackingComponentsRecord>().get(estimatorName_,estimatorH);
+  iEvent.getByToken(measurementTrackerTag_, measurementTrackerH);
+
+  /// Read L2 track collection
+  edm::Handle<reco::TrackCollection> l2TrackCol;
   iEvent.getByToken(src_, l2TrackCol);
 
   //	The product:
   std::unique_ptr<std::vector<TrajectorySeed> > result(new std::vector<TrajectorySeed>());
 
   //	Get vector of Detector layers once:
-  std::vector<BarrelDetLayer const*> const& tob = measurementTracker_->geometricSearchTracker()->tobLayers();
-  std::vector<ForwardDetLayer const*> const& tecPositive = measurementTracker_->geometricSearchTracker()->posTecLayers();
-  std::vector<ForwardDetLayer const*> const& tecNegative = measurementTracker_->geometricSearchTracker()->negTecLayers();
+  std::vector<BarrelDetLayer const*> const& tob = measurementTrackerH->geometricSearchTracker()->tobLayers();
+  std::vector<ForwardDetLayer const*> const& tecPositive = tmpTkGeometryH->isThere(GeomDetEnumerators::P2OTEC) ? 
+                                                                measurementTrackerH->geometricSearchTracker()->posTidLayers() : 
+                                                                measurementTrackerH->geometricSearchTracker()->posTecLayers(); 
+  std::vector<ForwardDetLayer const*> const& tecNegative = tmpTkGeometryH->isThere(GeomDetEnumerators::P2OTEC) ? 
+                                                                measurementTrackerH->geometricSearchTracker()->negTidLayers() : 
+                                                                measurementTrackerH->geometricSearchTracker()->negTecLayers();
+  edm::ESHandle<TrackerTopology> tTopo_handle;
+  iSetup.get<TrackerTopologyRcd>().get(tTopo_handle);
+  const TrackerTopology* tTopo = tTopo_handle.product();
 
   //	Get the suitable propagators:
-  std::unique_ptr<Propagator> propagatorAlong = SetPropagationDirection(*propagatorAlong_,alongMomentum);
-  std::unique_ptr<Propagator> propagatorOpposite = SetPropagationDirection(*propagatorOpposite_,oppositeToMomentum);
+  std::unique_ptr<Propagator> propagatorAlong = SetPropagationDirection(*propagatorAlongH,alongMomentum);
+  std::unique_ptr<Propagator> propagatorOpposite = SetPropagationDirection(*propagatorOppositeH,oppositeToMomentum);
 
   edm::ESHandle<Propagator> SmartOpposite;
   edm::ESHandle<Propagator> SHPOpposite;
@@ -85,13 +113,13 @@ void TSGForOI::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     std::unique_ptr<std::vector<TrajectorySeed> > out(new std::vector<TrajectorySeed>());
     LogTrace("TSGForOI") << "TSGForOI::produce: L2 muon pT, eta, phi --> " << l2->pt() << " , " << l2->eta() << " , " << l2->phi() << endl;
     
-    FreeTrajectoryState fts = trajectoryStateTransform::initialFreeState(*l2, magfield_.product());
-    dummyPlane_->move(fts.position() - dummyPlane_->position());
-    TrajectoryStateOnSurface tsosAtIP = TrajectoryStateOnSurface(fts, *dummyPlane_);
+    FreeTrajectoryState fts = trajectoryStateTransform::initialFreeState(*l2, magfieldH.product());
+    dummyPlane->move(fts.position() - dummyPlane->position());
+    TrajectoryStateOnSurface tsosAtIP = TrajectoryStateOnSurface(fts, *dummyPlane);
     LogTrace("TSGForOI") << "TSGForOI::produce: Created TSOSatIP: " << tsosAtIP << std::endl;
     
     // get the TSOS on the innermost layer of the L2. 
-    TrajectoryStateOnSurface tsosAtMuonSystem = trajectoryStateTransform::innerStateOnSurface(*l2, *geometry_, magfield_.product());
+    TrajectoryStateOnSurface tsosAtMuonSystem = trajectoryStateTransform::innerStateOnSurface(*l2, *geometryH, magfieldH.product());
     LogTrace("TSGForOI") << "TSGForOI::produce: Created TSOSatMuonSystem: " << tsosAtMuonSystem <<endl;
     
     if (useHitLessSeeds_){  // 
@@ -111,43 +139,46 @@ void TSGForOI::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	dist = sqrt(deta*deta+dphi*dphi);
       }
       if (dist>tsosDiff_){
-	++numOfMaxSeeds_;	// add a hit-based seed
+	++numOfMaxSeeds;	// add a hit-based seed
       }
     } 
 
-    numSeedsMade_=0;
-    analysedL2_ = false;
-    foundHitlessSeed_ = false; 
+    numSeedsMade=0;
+    analysedL2 = false;
+    foundHitlessSeed = false; 
 
     //		BARREL
     if (std::abs(l2->eta()) < maxEtaForTOB_) {
-      layerCount_ = 0;
+      layerCount = 0;
       for (auto it=tob.rbegin(); it!=tob.rend(); ++it) {	//This goes from outermost to innermost layer
-	LogTrace("TSGForOI") << "TSGForOI::produce: looping in TOB layer " << layerCount_ << endl; 
-	findSeedsOnLayer(**it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2, out);
+	LogTrace("TSGForOI") << "TSGForOI::produce: looping in TOB layer " << layerCount << endl; 
+	findSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2, 
+			 estimatorH, measurementTrackerH, numSeedsMade, numOfMaxSeeds, layerCount, foundHitlessSeed, analysedL2, out);
       }
     }
     
     //		Reset Number of seeds if in overlap region:
     if (std::abs(l2->eta())>minEtaForTEC_ && std::abs(l2->eta())<maxEtaForTOB_){
-      numSeedsMade_=0;
+      numSeedsMade=0;
     }
 
     //		ENDCAP+
     if (l2->eta() > minEtaForTEC_) {
-      layerCount_ = 0;
+      layerCount = 0;
       for (auto it=tecPositive.rbegin(); it!=tecPositive.rend(); ++it) {
-	LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC+ layer " << layerCount_ << endl; 
-	findSeedsOnLayer(**it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2, out);
+	LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC+ layer " << layerCount << endl; 
+	findSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2, 
+			 estimatorH, measurementTrackerH, numSeedsMade, numOfMaxSeeds, layerCount, foundHitlessSeed, analysedL2, out);
       }
     }
 
     //		ENDCAP-
     if (l2->eta() < -minEtaForTEC_) {
-      layerCount_ = 0;
+      layerCount = 0;
       for (auto it=tecNegative.rbegin(); it!=tecNegative.rend(); ++it) {
-	LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC- layer " << layerCount_ << endl; 
-	findSeedsOnLayer(**it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2, out);
+	LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC- layer " << layerCount << endl; 
+	findSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2, 
+			 estimatorH, measurementTrackerH, numSeedsMade, numOfMaxSeeds, layerCount, foundHitlessSeed, analysedL2, out);
       }
     }
 
@@ -160,27 +191,36 @@ void TSGForOI::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   iEvent.put(std::move(result));
 }
 
-void TSGForOI::findSeedsOnLayer(const GeometricSearchDet &layer,
+void TSGForOI::findSeedsOnLayer(
+				const TrackerTopology* tTopo,
+				const GeometricSearchDet &layer,
 				const TrajectoryStateOnSurface &tsosAtIP,
 				const Propagator& propagatorAlong,
 				const Propagator& propagatorOpposite,
 				const reco::TrackRef l2,
-				std::unique_ptr<std::vector<TrajectorySeed> >& out) {
+				edm::ESHandle<Chi2MeasurementEstimatorBase>& estimatorH,
+				edm::Handle<MeasurementTrackerEvent>& measurementTrackerH,
+				unsigned int& numSeedsMade,
+				unsigned int& numOfMaxSeeds,
+				unsigned int& layerCount,
+				bool& foundHitlessSeed,
+				bool& analysedL2,
+				std::unique_ptr<std::vector<TrajectorySeed> >& out)  const{
   
-  if (numSeedsMade_>numOfMaxSeeds_) return;
-  LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: numSeedsMade = " << numSeedsMade_ << " , layerCount = " <<  layerCount_ << endl;
+  if (numSeedsMade>numOfMaxSeeds) return;
+  LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: numSeedsMade = " << numSeedsMade << " , layerCount = " <<  layerCount << endl;
   
-  double errorSFHits_=1.0;
-  double errorSFHitless_=1.0;
-  if (!adjustErrorsDynamicallyForHits_)    errorSFHits_ = fixedErrorRescalingForHits_;
-  if (!adjustErrorsDynamicallyForHitless_) errorSFHitless_ = fixedErrorRescalingForHitless_;
+  double errorSFHits=1.0;
+  double errorSFHitless=1.0;
+  if (!adjustErrorsDynamicallyForHits_)    errorSFHits = fixedErrorRescalingForHits_;
+  if (!adjustErrorsDynamicallyForHitless_) errorSFHitless = fixedErrorRescalingForHitless_;
 
   // Hitless:
-  if (useHitLessSeeds_ && !foundHitlessSeed_) {
+  if (useHitLessSeeds_ && !foundHitlessSeed) {
     LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: Start hitless" << endl;
     std::vector< GeometricSearchDet::DetWithState > dets;
-    layer.compatibleDetsV(tsosAtIP, propagatorAlong, *estimator_, dets);
-    if (dets.size()>0) {  
+    layer.compatibleDetsV(tsosAtIP, propagatorAlong, *estimatorH, dets);
+    if (!dets.empty()) {  
       auto const& detOnLayer = dets.front().first;
       auto const& tsosOnLayer = dets.front().second;
       LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: tsosOnLayer " << tsosOnLayer << endl;
@@ -189,31 +229,31 @@ void TSGForOI::findSeedsOnLayer(const GeometricSearchDet &layer,
       }
       else{
 	// calculate SF from L2 (only once -- if needed)
-	if (!analysedL2_ && adjustErrorsDynamicallyForHitless_) {
-	  errorSFHitless_=calculateSFFromL2(l2);
-	  analysedL2_=true;
+	if (!analysedL2 && adjustErrorsDynamicallyForHitless_) {
+	  errorSFHitless=calculateSFFromL2(l2);
+	  analysedL2=true;
 	}
 	
-	dets.front().second.rescaleError(errorSFHitless_);
+	dets.front().second.rescaleError(errorSFHitless);
 	PTrajectoryStateOnDet const& ptsod = trajectoryStateTransform::persistentState(tsosOnLayer,detOnLayer->geographicalId().rawId());
 	TrajectorySeed::recHitContainer rHC;
 	out->push_back(TrajectorySeed(ptsod,rHC,oppositeToMomentum));
 	LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: TSOD (Hitless) done " << endl;
-	foundHitlessSeed_=true;
+	foundHitlessSeed=true;
       }
-      numSeedsMade_=out->size();
+      numSeedsMade=out->size();
     }
   }
-  //  numSeedsMade_=out->size();
+  //  numSeedsMade=out->size();
 
   // Hits:
-  if (layerCount_>numOfLayersToTry_) return;
+  if (layerCount>numOfLayersToTry_) return;
   LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: Start Hits" <<endl;  
-  if (makeSeedsFromHits(layer, tsosAtIP, *out, propagatorAlong, *measurementTracker_, errorSFHits_))  ++layerCount_; 
-  numSeedsMade_=out->size();
+  if (makeSeedsFromHits(tTopo, layer, tsosAtIP, *out, propagatorAlong, *measurementTrackerH, estimatorH, errorSFHits))  ++layerCount; 
+  numSeedsMade=out->size();
 }
 
-double TSGForOI::calculateSFFromL2(const reco::TrackRef track){
+double TSGForOI::calculateSFFromL2(const reco::TrackRef track) const{
 
   double theSF=1.0;
   //	L2 direction vs pT blowup - as was previously done:
@@ -238,19 +278,22 @@ double TSGForOI::calculateSFFromL2(const reco::TrackRef track){
 }
 
 
-int TSGForOI::makeSeedsFromHits(const GeometricSearchDet &layer,
+int TSGForOI::makeSeedsFromHits(
+				const TrackerTopology* tTopo,
+				const GeometricSearchDet &layer,
 				const TrajectoryStateOnSurface &tsosAtIP,
 				std::vector<TrajectorySeed> &out,
 				const Propagator& propagatorAlong,
 				const MeasurementTrackerEvent &measurementTracker,
-				const double errorSF) {
+				edm::ESHandle<Chi2MeasurementEstimatorBase>& estimatorH,
+				const double errorSF)  const{
 
   //		Error Rescaling:
   TrajectoryStateOnSurface onLayer(tsosAtIP);
   onLayer.rescaleError(errorSF);    
 
   std::vector< GeometricSearchDet::DetWithState > dets;
-  layer.compatibleDetsV(onLayer, propagatorAlong, *estimator_, dets);
+  layer.compatibleDetsV(onLayer, propagatorAlong, *estimatorH, dets);
   
   //	Find Measurements on each DetWithState:
   LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: find measurements on each detWithState  " << dets.size() << endl;
@@ -262,7 +305,7 @@ int TSGForOI::makeSeedsFromHits(const GeometricSearchDet &layer,
     }
     if (!it->second.isValid()) continue;	//Skip if TSOS is not valid
 
-    std::vector < TrajectoryMeasurement > mymeas = det.fastMeasurements(it->second, onLayer, propagatorAlong, *estimator_);	//Second TSOS is not used
+    std::vector < TrajectoryMeasurement > mymeas = det.fastMeasurements(it->second, onLayer, propagatorAlong, *estimatorH);	//Second TSOS is not used
     for (std::vector<TrajectoryMeasurement>::const_iterator it2 = mymeas.begin(), ed2 = mymeas.end(); it2 != ed2; ++it2) {
       if (it2->recHit()->isValid()) meas.push_back(*it2);	//Only save those which are valid
     }
@@ -282,8 +325,7 @@ int TSGForOI::makeSeedsFromHits(const GeometricSearchDet &layer,
     if (useStereoLayersInTEC_) { 
       DetId detid = ((*it).recHit()->hit())->geographicalId();
       if (detid.subdetId() == StripSubdetector::TEC) {
-	TECDetId myDet(detid.rawId());
-	if (!myDet.isStereo()) break;  //try another Layer 
+		if (!tTopo->tecIsStereo(detid.rawId())) break;  // try another layer
       }
     }
     

--- a/RecoTracker/MeasurementDet/plugins/MaskedMeasurementTrackerEventProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MaskedMeasurementTrackerEventProducer.cc
@@ -18,17 +18,18 @@ private:
 
       edm::EDGetTokenT<MeasurementTrackerEvent> src_;
 
+      bool skipClusters_;
+      bool phase2skipClusters_;
+
       edm::EDGetTokenT<StripMask> maskStrips_;
       edm::EDGetTokenT<PixelMask> maskPixels_;
       edm::EDGetTokenT<Phase2OTMask> maskPhase2OTs_;
-
-      bool skipClusters_;
-      bool phase2skipClusters_;
 };
 
 
 MaskedMeasurementTrackerEventProducer::MaskedMeasurementTrackerEventProducer(const edm::ParameterSet &iConfig) :
-    src_(consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("src")))
+    src_(consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("src"))),
+    skipClusters_(false), phase2skipClusters_(false)
 {
     //FIXME:temporary solution in order to use this class for both phase0/1 and phase2
     if (iConfig.existsAs<edm::InputTag>("clustersToSkip")) {

--- a/RecoTracker/TkDetLayers/src/Phase2OTtiltedBarrelLayer.cc
+++ b/RecoTracker/TkDetLayers/src/Phase2OTtiltedBarrelLayer.cc
@@ -97,11 +97,14 @@ Phase2OTtiltedBarrelLayer::groupedCompatibleDetsV( const TrajectoryStateOnSurfac
   vector<DetGroup> closestResultNeg;
   vector<DetGroup> closestResultPos;
   Phase2OTBarrelLayer::groupedCompatibleDetsV(tsos, prop, est, closestResultRods);
-  for(auto ring : theNegativeRingsComps){
-    ring->groupedCompatibleDetsV(tsos, prop, est, closestResultNeg);
-  }
-  for(auto ring : thePositiveRingsComps){
-    ring->groupedCompatibleDetsV(tsos, prop, est, closestResultPos);
+  if(tsos.globalPosition().z()<0){
+    for(auto& ring : theNegativeRingsComps){
+      ring->groupedCompatibleDetsV(tsos, prop, est, closestResultNeg);
+    }
+  } else {
+    for(auto& ring : thePositiveRingsComps){
+      ring->groupedCompatibleDetsV(tsos, prop, est, closestResultPos);
+    }
   }
 
   result.assign(closestResultRods.begin(),closestResultRods.end());

--- a/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
+++ b/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
@@ -70,8 +70,10 @@ muonAssociatorByHitsCommonParameters = cms.PSet(
     #
     associatePixel = cms.bool(True),
     associateStrip = cms.bool(True),
+    usePhase2Tracker = cms.bool(False),
     pixelSimLinkSrc = cms.InputTag("simSiPixelDigis"),
     stripSimLinkSrc = cms.InputTag("simSiStripDigis"),
+    phase2TrackerSimLinkSrc  = cms.InputTag("simSiPixelDigis","Tracker"),
     associateRecoTracks = cms.bool(True),
     #                                
     ROUList = cms.vstring('TrackerHitsTIBLowTof', 
@@ -142,6 +144,5 @@ muonAssociatorByHits = cms.EDProducer("MuonAssociatorEDProducer",
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( muonAssociatorByHits, useGEMs = cms.bool(True) )
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify( muonAssociatorByHits, usePhase2Tracker = cms.bool(True) )
 phase2_tracker.toModify( muonAssociatorByHits, pixelSimLinkSrc = "simSiPixelDigis:Pixel" )
-phase2_tracker.toModify( muonAssociatorByHits, stripSimLinkSrc = "simSiPixelDigis:Tracker" )
-

--- a/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
+++ b/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
@@ -41,6 +41,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
+#include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
 #include "DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiTrackerMultiRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/FastTrackerRecHit.h"
@@ -57,9 +58,9 @@ class TrackerHitAssociator {
   struct Config {
     Config(const edm::ParameterSet& conf, edm::ConsumesCollector && iC);
     Config(edm::ConsumesCollector && iC);
-    bool doPixel_, doStrip_, doTrackAssoc_, assocHitbySimTrack_;
+    bool doPixel_, doStrip_, useOTph2_, doTrackAssoc_, assocHitbySimTrack_;
     edm::EDGetTokenT<edm::DetSetVector<StripDigiSimLink> > stripToken_;
-    edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > pixelToken_;
+    edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > pixelToken_, ph2OTrToken_;
     std::vector<edm::EDGetTokenT<CrossingFrame<PSimHit> > > cfTokens_;
     std::vector<edm::EDGetTokenT<std::vector<PSimHit> > > simHitTokens_;
   };
@@ -92,7 +93,8 @@ class TrackerHitAssociator {
 
   std::vector<SimHitIdpr> associateMatchedRecHit(const SiStripMatchedRecHit2D * matchedrechit, std::vector<simhitAddr>* simhitCFPos=0) const;
   std::vector<SimHitIdpr> associateProjectedRecHit(const ProjectedSiStripRecHit2D * projectedrechit, std::vector<simhitAddr>* simhitCFPos=0) const;
-  void associatePixelRecHit(const SiPixelRecHit * pixelrechit, std::vector<SimHitIdpr> & simhitid, std::vector<simhitAddr>* simhitCFPos=0) const;
+  void associatePhase2TrackerRecHit(const Phase2TrackerRecHit1D* rechit, std::vector<SimHitIdpr> & simtrackid, std::vector<simhitAddr>* simhitCFPos=0) const;
+  void associatePixelRecHit(const SiPixelRecHit * pixelrechit, std::vector<SimHitIdpr> & simtrackid, std::vector<simhitAddr>* simhitCFPos=0) const;
   std::vector<SimHitIdpr> associateFastRecHit(const FastTrackerRecHit * rechit) const;
   std::vector<SimHitIdpr> associateMultiRecHitId(const SiTrackerMultiRecHit * multirechit, std::vector<simhitAddr>* simhitCFPos=0) const;
   std::vector<PSimHit>    associateMultiRecHit(const SiTrackerMultiRecHit * multirechit) const;
@@ -109,7 +111,8 @@ class TrackerHitAssociator {
   void makeMaps(const edm::Event& theEvent, const Config& config);
   edm::Handle< edm::DetSetVector<StripDigiSimLink> >  stripdigisimlink;
   edm::Handle< edm::DetSetVector<PixelDigiSimLink> >  pixeldigisimlink;
-  bool doPixel_, doStrip_, doTrackAssoc_, assocHitbySimTrack_;
+  edm::Handle< edm::DetSetVector<PixelDigiSimLink> >  ph2trackerdigisimlink;
+  bool doPixel_, doStrip_, useOTph2_, doTrackAssoc_, assocHitbySimTrack_;
 };
 
 #endif


### PR DESCRIPTION
This PR (aimed at superseeding [PR 20235](https://github.com/cms-sw/cmssw/pull/20235)):

backports logical changes from [PR 20723](https://github.com/cms-sw/cmssw/pull/20723): 
- makes TSGForOI work in phaseII
- fixes a small initilaization issue in MaskedMeasurementTrackerEventProducer

includes Egamma changes from [PR 20235](https://github.com/cms-sw/cmssw/pull/20235)

backports a change to `Phase2OTtiltedBarrelLayer.cc` from [PR 18801](https://github.com/cms-sw/cmssw/pull/18801/)

backports phaseII related changes to `TrackerHitAssociator` and corresponding cfgs
