### PR TITLE
Fix compiler warning: Removed unused variable

### DIFF
--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -572,7 +572,6 @@ namespace {
 				       matched_pfcs.end()));	
       }
       for( const auto& clelem : best_comb ) {
-	const reco::PFClusterRef& clref = clelem->clusterRef();
 	if( std::find(cluster_list.begin(),cluster_list.end(),clelem) ==
 	    cluster_list.end() ) {
 	  cluster_list.push_back(clelem);


### PR DESCRIPTION
```
RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc:575:28: warning: unused variable 'clref' [-Wunused-variable]
   const reco::PFClusterRef& clref = clelem->clusterRef();
```