### PR TITLE
Update quality test limits

### DIFF
--- a/DQM/SiPixelPhase1Config/test/qTests/mean_adc_qualitytest_config.xml
+++ b/DQM/SiPixelPhase1Config/test/qTests/mean_adc_qualitytest_config.xml
@@ -5,149 +5,149 @@
     <!-- PXLAYER 1 -->
     <QTEST name="Yrange:PXLayer_1__Shell_mI:mean_adc" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">120.</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.65</PARAM>
+      <PARAM name="warning">0.80</PARAM>
+      <PARAM name="ymin">100.</PARAM>
       <PARAM name="ymax">160.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_1__Shell_mO:mean_adc" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">120.</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.65</PARAM>
+      <PARAM name="warning">0.80</PARAM>
+      <PARAM name="ymin">100.</PARAM>
       <PARAM name="ymax">160.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_1__Shell_pI:mean_adc" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">120.</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.65</PARAM>
+      <PARAM name="warning">0.80</PARAM>
+      <PARAM name="ymin">100.</PARAM>
       <PARAM name="ymax">160.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_1__Shell_pO:mean_adc" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">120.</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.65</PARAM>
+      <PARAM name="warning">0.80</PARAM>
+      <PARAM name="ymin">100.</PARAM>
       <PARAM name="ymax">160.</PARAM>
     </QTEST>
 
     <!-- PXLAYER 2 -->
     <QTEST name="Yrange:PXLayer_2__Shell_mI:mean_adc" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.75</PARAM>
+      <PARAM name="warning">0.90</PARAM>
       <PARAM name="ymin">80.</PARAM>
       <PARAM name="ymax">120.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_2__Shell_mO:mean_adc" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.75</PARAM>
+      <PARAM name="warning">0.90</PARAM>
       <PARAM name="ymin">80.</PARAM>
       <PARAM name="ymax">120.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_2__Shell_pI:mean_adc" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.75</PARAM>
+      <PARAM name="warning">0.90</PARAM>
       <PARAM name="ymin">80.</PARAM>
-      <PARAM name="ymax">110.</PARAM>
+      <PARAM name="ymax">120.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_2__Shell_pO:mean_adc" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.75</PARAM>
+      <PARAM name="warning">0.90</PARAM>
       <PARAM name="ymin">80.</PARAM>
-      <PARAM name="ymax">110.</PARAM>
+      <PARAM name="ymax">120.</PARAM>
     </QTEST>
 
     <!-- PXLAYER 3 -->
     <QTEST name="Yrange:PXLayer_3__Shell_mI:mean_adc" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">80.</PARAM>
-      <PARAM name="ymax">110.</PARAM>
+      <PARAM name="ymin">85.</PARAM>
+      <PARAM name="ymax">120.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_3__Shell_mO:mean_adc" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">80.</PARAM>
-      <PARAM name="ymax">110.</PARAM>
+      <PARAM name="ymin">90.</PARAM>
+      <PARAM name="ymax">120.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_3__Shell_pI:mean_adc" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">80.</PARAM>
-      <PARAM name="ymax">110.</PARAM>
+      <PARAM name="ymin">82.</PARAM>
+      <PARAM name="ymax">120.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_3__Shell_pO:mean_adc" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">80.</PARAM>
-      <PARAM name="ymax">110.</PARAM>
+      <PARAM name="ymin">90.</PARAM>
+      <PARAM name="ymax">120.</PARAM>
     </QTEST>
 
     <!-- PXLAYER 4 -->
     <QTEST name="Yrange:PXLayer_4__Shell_mI:mean_adc" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">80.</PARAM>
-      <PARAM name="ymax">110.</PARAM>
+      <PARAM name="ymin">85.</PARAM>
+      <PARAM name="ymax">120.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_4__Shell_mO:mean_adc" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
       <PARAM name="ymin">80.</PARAM>
-      <PARAM name="ymax">110.</PARAM>
+      <PARAM name="ymax">120.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_4__Shell_pI:mean_adc" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">80.</PARAM>
-      <PARAM name="ymax">110.</PARAM>
+      <PARAM name="ymin">85.</PARAM>
+      <PARAM name="ymax">120.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_4__Shell_pO:mean_adc" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
       <PARAM name="ymin">75.</PARAM>
-      <PARAM name="ymax">105.</PARAM>
+      <PARAM name="ymax">120.</PARAM>
     </QTEST>
 
   <!-- PXFORWARD -->
@@ -155,64 +155,64 @@
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-1:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-2:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-3:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-1:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-2:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-3:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
     <!-- HCMO -->
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-1:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
@@ -221,73 +221,73 @@
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-2:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-3:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-1:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-2:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">85.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-3:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">85.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymin">90.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
     <!-- HCPI -->
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+1:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+2:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+3:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
@@ -297,25 +297,25 @@
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+1:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+2:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+3:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
@@ -326,57 +326,57 @@
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+1:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+2:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+3:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+1:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+2:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+3:mean_adc" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">90.</PARAM>
-        <PARAM name="ymax">110.</PARAM>
+        <PARAM name="ymax">120.</PARAM>
       </QTEST>
 
 

--- a/DQM/SiPixelPhase1Config/test/qTests/mean_charge_qualitytest_config.xml
+++ b/DQM/SiPixelPhase1Config/test/qTests/mean_charge_qualitytest_config.xml
@@ -5,149 +5,149 @@
     <!-- PXLAYER 1 -->
     <QTEST name="Yrange:PXLayer_1__Shell_mI:mean_charge" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">70000</PARAM>
-      <PARAM name="ymax">90000.</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.65</PARAM>
+      <PARAM name="warning">0.80</PARAM>
+      <PARAM name="ymin">35000.</PARAM>
+      <PARAM name="ymax">72500.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_1__Shell_mO:mean_charge" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">65000</PARAM>
-      <PARAM name="ymax">80000.</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.65</PARAM>
+      <PARAM name="warning">0.80</PARAM>
+      <PARAM name="ymin">35000.</PARAM>
+      <PARAM name="ymax">70000.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_1__Shell_pI:mean_charge" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">70000</PARAM>
-      <PARAM name="ymax">90000.</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.65</PARAM>
+      <PARAM name="warning">0.80</PARAM>
+      <PARAM name="ymin">35000.</PARAM>
+      <PARAM name="ymax">75000.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_1__Shell_pO:mean_charge" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">70000</PARAM>
-      <PARAM name="ymax">9000.</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.65</PARAM>
+      <PARAM name="warning">0.80</PARAM>
+      <PARAM name="ymin">35000.</PARAM>
+      <PARAM name="ymax">70000.</PARAM>
     </QTEST>
 
     <!-- PXLAYER 2 -->
     <QTEST name="Yrange:PXLayer_2__Shell_mI:mean_charge" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">70000</PARAM>
-      <PARAM name="ymax">110000.</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.75</PARAM>
+      <PARAM name="warning">0.90</PARAM>
+      <PARAM name="ymin">40000.</PARAM>
+      <PARAM name="ymax">75000.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_2__Shell_mO:mean_charge" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">70000</PARAM>
-      <PARAM name="ymax">110000.</PARAM>
+      <PARAM name="ymin">40000.</PARAM>
+      <PARAM name="ymax">77500.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_2__Shell_pI:mean_charge" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">65000</PARAM>
-      <PARAM name="ymax">90000.</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.75</PARAM>
+      <PARAM name="warning">0.90</PARAM>
+      <PARAM name="ymin">35000.</PARAM>
+      <PARAM name="ymax">65000.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_2__Shell_pO:mean_charge" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">70000</PARAM>
-      <PARAM name="ymax">90000.</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.75</PARAM>
+      <PARAM name="warning">0.90</PARAM>
+      <PARAM name="ymin">40000.</PARAM>
+      <PARAM name="ymax">65000.</PARAM>
     </QTEST>
 
     <!-- PXLAYER 3 -->
     <QTEST name="Yrange:PXLayer_3__Shell_mI:mean_charge" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">60000</PARAM>
-      <PARAM name="ymax">80000.</PARAM>
+      <PARAM name="ymin">40000.</PARAM>
+      <PARAM name="ymax">60000.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_3__Shell_mO:mean_charge" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">65000</PARAM>
-      <PARAM name="ymax">80000.</PARAM>
+      <PARAM name="ymin">40000.</PARAM>
+      <PARAM name="ymax">60000.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_3__Shell_pI:mean_charge" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">60000</PARAM>
-      <PARAM name="ymax">80000.</PARAM>
+      <PARAM name="ymin">40000.</PARAM>
+      <PARAM name="ymax">60000.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_3__Shell_pO:mean_charge" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">60000</PARAM>
-      <PARAM name="ymax">80000.</PARAM>
+      <PARAM name="ymin">40000</PARAM>
+      <PARAM name="ymax">60000.</PARAM>
     </QTEST>
 
     <!-- PXLAYER 4 -->
     <QTEST name="Yrange:PXLayer_4__Shell_mI:mean_charge" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">60000</PARAM>
-      <PARAM name="ymax">80000.</PARAM>
+      <PARAM name="ymin">40000.</PARAM>
+      <PARAM name="ymax">60000.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_4__Shell_mO:mean_charge" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">60000</PARAM>
-      <PARAM name="ymax">75000.</PARAM>
+      <PARAM name="ymin">40000.</PARAM>
+      <PARAM name="ymax">60000.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_4__Shell_pI:mean_charge" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">60000</PARAM>
-      <PARAM name="ymax">75000.</PARAM>
+      <PARAM name="ymin">40000.</PARAM>
+      <PARAM name="ymax">60000.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_4__Shell_pO:mean_charge" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">60000</PARAM>
-      <PARAM name="ymax">75000.</PARAM>
+      <PARAM name="ymin">40000.</PARAM>
+      <PARAM name="ymax">60000.</PARAM>
     </QTEST>
 
   <!-- PXFORWARD -->
@@ -155,57 +155,57 @@
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-1:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">40000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">25000.</PARAM>
+        <PARAM name="ymax">40000.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-2:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">40000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">25000.</PARAM>
+        <PARAM name="ymax">40000.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-3:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">40000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">25000.</PARAM>
+        <PARAM name="ymax">40000.</PARAM>
       </QTEST>
 
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-1:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">40000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">35000.</PARAM>
+        <PARAM name="ymax">45000.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-2:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">40000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">30000.</PARAM>
+        <PARAM name="ymax">45000.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-3:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">40000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">30000.</PARAM>
+        <PARAM name="ymax">45000.</PARAM>
       </QTEST>
 
 
@@ -213,57 +213,57 @@
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-1:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">40000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">30000.</PARAM>
+        <PARAM name="ymax">40000.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-2:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">40000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">30000.</PARAM>
+        <PARAM name="ymax">40000.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-3:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">40000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">30000.</PARAM>
+        <PARAM name="ymax">40000.</PARAM>
       </QTEST>
 
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-1:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">45000</PARAM>
-        <PARAM name="ymax">60000.</PARAM>
+        <PARAM name="ymin">35000.</PARAM>
+        <PARAM name="ymax">45000.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-2:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">45000</PARAM>
-        <PARAM name="ymax">60000.</PARAM>
+        <PARAM name="ymin">30000.</PARAM>
+        <PARAM name="ymax">45000.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-3:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">40000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">30000.</PARAM>
+        <PARAM name="ymax">42000.</PARAM>
       </QTEST>
 
     
@@ -271,57 +271,57 @@
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+1:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">40000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">30000.</PARAM>
+        <PARAM name="ymax">40000.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+2:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">45000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">30000.</PARAM>
+        <PARAM name="ymax">40000.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+3:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">40000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">30000.</PARAM>
+        <PARAM name="ymax">40000.</PARAM>
       </QTEST>
 
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+1:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">45000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">35000.</PARAM>
+        <PARAM name="ymax">45000.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+2:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">45000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">35000.</PARAM>
+        <PARAM name="ymax">45000.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+3:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">45000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">35000.</PARAM>
+        <PARAM name="ymax">45000.</PARAM>
       </QTEST>
 
      
@@ -329,57 +329,57 @@
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+1:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">40000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">30000.</PARAM>
+        <PARAM name="ymax">40000.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+2:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">40000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">30000.</PARAM>
+        <PARAM name="ymax">40000.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+3:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">40000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">30000.</PARAM>
+        <PARAM name="ymax">40000.</PARAM>
       </QTEST>
 
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+1:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">45000</PARAM>
-        <PARAM name="ymax">60000.</PARAM>
+        <PARAM name="ymin">30000.</PARAM>
+        <PARAM name="ymax">45000.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+2:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">45000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">30000</PARAM>
+        <PARAM name="ymax">45000.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+3:mean_charge" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">40000</PARAM>
-        <PARAM name="ymax">55000.</PARAM>
+        <PARAM name="ymin">30000.</PARAM>
+        <PARAM name="ymax">45000.</PARAM>
       </QTEST>
 
      

--- a/DQM/SiPixelPhase1Config/test/qTests/mean_num_clusters_qualitytest_config.xml
+++ b/DQM/SiPixelPhase1Config/test/qTests/mean_num_clusters_qualitytest_config.xml
@@ -5,149 +5,149 @@
     <!-- PXLAYER 1 -->
     <QTEST name="Yrange:PXLayer_1__Shell_mI:mean_num_clusters" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">15.</PARAM>
-      <PARAM name="ymax">40.</PARAM>
+      <PARAM name="ymin">0.4</PARAM>
+      <PARAM name="ymax">120.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_1__Shell_mO:mean_num_clusters" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">14.</PARAM>
-      <PARAM name="ymax">40.</PARAM>
+      <PARAM name="ymin">0.4</PARAM>
+      <PARAM name="ymax">130.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_1__Shell_pI:mean_num_clusters" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">10.</PARAM>
-      <PARAM name="ymax">40.</PARAM>
+      <PARAM name="ymin">0.4</PARAM>
+      <PARAM name="ymax">120.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_1__Shell_pO:mean_num_clusters" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">12.</PARAM>
-      <PARAM name="ymax">40.</PARAM>
+      <PARAM name="ymin">0.4</PARAM>
+      <PARAM name="ymax">140.</PARAM>
     </QTEST>
 
     <!-- PXLAYER 2 -->
     <QTEST name="Yrange:PXLayer_2__Shell_mI:mean_num_clusters" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">2.5</PARAM>
-      <PARAM name="ymax">15.</PARAM>
+      <PARAM name="ymin">0.06</PARAM>
+      <PARAM name="ymax">25.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_2__Shell_mO:mean_num_clusters" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">3.</PARAM>
-      <PARAM name="ymax">15.</PARAM>
+      <PARAM name="ymin">0.08</PARAM>
+      <PARAM name="ymax">25.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_2__Shell_pI:mean_num_clusters" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">4.</PARAM>
-      <PARAM name="ymax">16.</PARAM>
+      <PARAM name="ymin">0.08</PARAM>
+      <PARAM name="ymax">30.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_2__Shell_pO:mean_num_clusters" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">4.</PARAM>
-      <PARAM name="ymax">16.</PARAM>
+      <PARAM name="ymin">0.1</PARAM>
+      <PARAM name="ymax">30.</PARAM>
     </QTEST>
 
     <!-- PXLAYER 3 -->
     <QTEST name="Yrange:PXLayer_3__Shell_mI:mean_num_clusters" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">2.</PARAM>
-      <PARAM name="ymax">10.</PARAM>
+      <PARAM name="ymin">0.06</PARAM>
+      <PARAM name="ymax">12.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_3__Shell_mO:mean_num_clusters" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">2.5</PARAM>
-      <PARAM name="ymax">10.</PARAM>
+      <PARAM name="ymin">0.035</PARAM>
+      <PARAM name="ymax">12.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_3__Shell_pI:mean_num_clusters" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">2.</PARAM>
-      <PARAM name="ymax">10.</PARAM>
+      <PARAM name="ymin">0.045</PARAM>
+      <PARAM name="ymax">14.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_3__Shell_pO:mean_num_clusters" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">2.</PARAM>
-      <PARAM name="ymax">10.</PARAM>
+      <PARAM name="ymin">0.065</PARAM>
+      <PARAM name="ymax">14.</PARAM>
     </QTEST>
 
     <!-- PXLAYER 4 -->
     <QTEST name="Yrange:PXLayer_4__Shell_mI:mean_num_clusters" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">1.</PARAM>
-      <PARAM name="ymax">5.</PARAM>
+      <PARAM name="ymin">0.03</PARAM>
+      <PARAM name="ymax">10.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_4__Shell_mO:mean_num_clusters" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">1.</PARAM>
-      <PARAM name="ymax">5.</PARAM>
+      <PARAM name="ymin">0.025</PARAM>
+      <PARAM name="ymax">8.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_4__Shell_pI:mean_num_clusters" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">1.</PARAM>
-      <PARAM name="ymax">5.</PARAM>
+      <PARAM name="ymin">0.035</PARAM>
+      <PARAM name="ymax">7.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_4__Shell_pO:mean_num_clusters" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">1.</PARAM>
-      <PARAM name="ymax">5.</PARAM>
+      <PARAM name="ymin">0.025</PARAM>
+      <PARAM name="ymax">10.</PARAM>
     </QTEST>
 
   <!-- PXFORWARD -->
@@ -155,228 +155,228 @@
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-1:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">3.</PARAM>
-        <PARAM name="ymax">20.</PARAM>
+        <PARAM name="ymin">0.1</PARAM>
+        <PARAM name="ymax">24.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-2:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">3.</PARAM>
-        <PARAM name="ymax">20.</PARAM>
+        <PARAM name="ymin">0.2</PARAM>
+        <PARAM name="ymax">28.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-3:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">5.</PARAM>
-        <PARAM name="ymax">20.</PARAM>
+        <PARAM name="ymin">0.15</PARAM>
+        <PARAM name="ymax">30.</PARAM>
       </QTEST>
 
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-1:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymin">0.06</PARAM>
         <PARAM name="ymax">10.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-2:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymin">0.025</PARAM>
         <PARAM name="ymax">10.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-3:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">1.</PARAM>
-        <PARAM name="ymax">10.</PARAM>
+        <PARAM name="ymin">0.025</PARAM>
+        <PARAM name="ymax">12.</PARAM>
       </QTEST>
 
     <!-- HCMO -->
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-1:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">3.</PARAM>
-        <PARAM name="ymax">20.</PARAM>
+        <PARAM name="ymin">0.15</PARAM>
+        <PARAM name="ymax">25.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-2:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">7.</PARAM>
-        <PARAM name="ymax">20.</PARAM>
+        <PARAM name="ymin">0.15</PARAM>
+        <PARAM name="ymax">28.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-3:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">7.</PARAM>
-        <PARAM name="ymax">20.</PARAM>
+        <PARAM name="ymin">0.2</PARAM>
+        <PARAM name="ymax">28.</PARAM>
       </QTEST>
 
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-1:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymin">0.06</PARAM>
         <PARAM name="ymax">10.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-2:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymin">0.04</PARAM>
         <PARAM name="ymax">10.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-3:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">1.</PARAM>
-        <PARAM name="ymax">10.</PARAM>
+        <PARAM name="ymin">0.06</PARAM>
+        <PARAM name="ymax">12.</PARAM>
       </QTEST>
 
     <!-- HCPI -->
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+1:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">3.</PARAM>
-        <PARAM name="ymax">20.</PARAM>
+        <PARAM name="ymin">0.1</PARAM>
+        <PARAM name="ymax">25.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+2:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">2.</PARAM>
-        <PARAM name="ymax">20.</PARAM>
+        <PARAM name="ymin">0.2</PARAM>
+        <PARAM name="ymax">28.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+3:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">3.</PARAM>
-        <PARAM name="ymax">20.</PARAM>
+        <PARAM name="ymin">0.2</PARAM>
+        <PARAM name="ymax">28.</PARAM>
       </QTEST>
 
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+1:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymin">0.04</PARAM>
         <PARAM name="ymax">10.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+2:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymin">0.04</PARAM>
         <PARAM name="ymax">10.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+3:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">1.</PARAM>
-        <PARAM name="ymax">10.</PARAM>
+        <PARAM name="ymin">0.3</PARAM>
+        <PARAM name="ymax">12.</PARAM>
       </QTEST>
 
     <!-- HCPO -->
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+1:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">3.</PARAM>
-        <PARAM name="ymax">20.</PARAM>
+        <PARAM name="ymin">0.08</PARAM>
+        <PARAM name="ymax">26.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+2:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">2.</PARAM>
-        <PARAM name="ymax">20.</PARAM>
+        <PARAM name="ymin">0.25</PARAM>
+        <PARAM name="ymax">26.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+3:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">3.</PARAM>
-        <PARAM name="ymax">20.</PARAM>
+        <PARAM name="ymin">0.35</PARAM>
+        <PARAM name="ymax">28.</PARAM>
       </QTEST>
 
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+1:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymin">0.065</PARAM>
         <PARAM name="ymax">10.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+2:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">1.</PARAM>
+        <PARAM name="ymin">0.075</PARAM>
         <PARAM name="ymax">10.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+3:mean_num_clusters" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">1.</PARAM>
-        <PARAM name="ymax">10.</PARAM>
+        <PARAM name="ymin">0.075</PARAM>
+        <PARAM name="ymax">12.</PARAM>
       </QTEST>
 
 

--- a/DQM/SiPixelPhase1Config/test/qTests/mean_num_digis_qualitytest_config.xml
+++ b/DQM/SiPixelPhase1Config/test/qTests/mean_num_digis_qualitytest_config.xml
@@ -5,149 +5,149 @@
     <!-- PXLAYER 1 -->
     <QTEST name="Yrange:PXLayer_1__Shell_mI:mean_num_digis" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">5.</PARAM>
-      <PARAM name="ymax">20.</PARAM>
+      <PARAM name="ymin">0.8</PARAM>
+      <PARAM name="ymax">360.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_1__Shell_mO:mean_num_digis" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">50.</PARAM>
-      <PARAM name="ymax">150.</PARAM>
+      <PARAM name="ymin">0.8</PARAM>
+      <PARAM name="ymax">380.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_1__Shell_pI:mean_num_digis" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">30.</PARAM>
-      <PARAM name="ymax">150.</PARAM>
+      <PARAM name="ymin">0.8</PARAM>
+      <PARAM name="ymax">360.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_1__Shell_pO:mean_num_digis" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">45.</PARAM>
-      <PARAM name="ymax">150.</PARAM>
+      <PARAM name="ymin">0.8</PARAM>
+      <PARAM name="ymax">360.</PARAM>
     </QTEST>
 
     <!-- PXLAYER 2 -->
     <QTEST name="Yrange:PXLayer_2__Shell_mI:mean_num_digis" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">10.</PARAM>
-      <PARAM name="ymax">70.</PARAM>
+      <PARAM name="ymin">0.1</PARAM>
+      <PARAM name="ymax">90.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_2__Shell_mO:mean_num_digis" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">15.</PARAM>
-      <PARAM name="ymax">70.</PARAM>
+      <PARAM name="ymin">0.2</PARAM>
+      <PARAM name="ymax">90.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_2__Shell_pI:mean_num_digis" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">20.</PARAM>
-      <PARAM name="ymax">70.</PARAM>
+      <PARAM name="ymin">0.14</PARAM>
+      <PARAM name="ymax">100.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_2__Shell_pO:mean_num_digis" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">20.</PARAM>
-      <PARAM name="ymax">70.</PARAM>
+      <PARAM name="ymin">0.1</PARAM>
+      <PARAM name="ymax">100.</PARAM>
     </QTEST>
 
     <!-- PXLAYER 3 -->
     <QTEST name="Yrange:PXLayer_3__Shell_mI:mean_num_digis" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">10.</PARAM>
-      <PARAM name="ymax">30.</PARAM>
+      <PARAM name="ymin">0.1</PARAM>
+      <PARAM name="ymax">44.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_3__Shell_mO:mean_num_digis" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">10.</PARAM>
-      <PARAM name="ymax">30.</PARAM>
+      <PARAM name="ymin">0.13</PARAM>
+      <PARAM name="ymax">44.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_3__Shell_pI:mean_num_digis" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">10.</PARAM>
-      <PARAM name="ymax">30.</PARAM>
+      <PARAM name="ymin">0.1</PARAM>
+      <PARAM name="ymax">46.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_3__Shell_pO:mean_num_digis" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">10.</PARAM>
-      <PARAM name="ymax">30.</PARAM>
+      <PARAM name="ymin">0.12</PARAM>
+      <PARAM name="ymax">44.</PARAM>
     </QTEST>
 
     <!-- PXLAYER 4 -->
     <QTEST name="Yrange:PXLayer_4__Shell_mI:mean_num_digis" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">5.</PARAM>
-      <PARAM name="ymax">20.</PARAM>
+      <PARAM name="ymin">0.07</PARAM>
+      <PARAM name="ymax">24.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_4__Shell_mO:mean_num_digis" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">5.</PARAM>
-      <PARAM name="ymax">20.</PARAM>
+      <PARAM name="ymin">0.07</PARAM>
+      <PARAM name="ymax">24.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_4__Shell_pI:mean_num_digis" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">5.</PARAM>
-      <PARAM name="ymax">20.</PARAM>
+      <PARAM name="ymin">0.06</PARAM>
+      <PARAM name="ymax">24.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_4__Shell_pO:mean_num_digis" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">5.</PARAM>
-      <PARAM name="ymax">20.</PARAM>
+      <PARAM name="ymin">0.06</PARAM>
+      <PARAM name="ymax">24.</PARAM>
     </QTEST>
 
   <!-- PXFORWARD -->
@@ -155,56 +155,56 @@
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-1:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">10.</PARAM>
-        <PARAM name="ymax">70.</PARAM>
+        <PARAM name="ymin">0.12</PARAM>
+        <PARAM name="ymax">80.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-2:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">10.</PARAM>
-        <PARAM name="ymax">70.</PARAM>
+        <PARAM name="ymin">0.14</PARAM>
+        <PARAM name="ymax">90.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-3:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">15.</PARAM>
-        <PARAM name="ymax">70.</PARAM>
+        <PARAM name="ymin">0.14</PARAM>
+        <PARAM name="ymax">90.</PARAM>
       </QTEST>
 
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-1:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">8.</PARAM>
+        <PARAM name="ymin">0.09</PARAM>
         <PARAM name="ymax">40.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-2:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">8.</PARAM>
+        <PARAM name="ymin">0.1</PARAM>
         <PARAM name="ymax">40.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-3:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">5.</PARAM>
+        <PARAM name="ymin">0.06</PARAM>
         <PARAM name="ymax">40.</PARAM>
       </QTEST>
 
@@ -212,171 +212,171 @@
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-1:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">10.</PARAM>
-        <PARAM name="ymax">70.</PARAM>
+        <PARAM name="ymin">0.25</PARAM>
+        <PARAM name="ymax">80.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-2:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">25.</PARAM>
-        <PARAM name="ymax">70.</PARAM>
+        <PARAM name="ymin">0.22</PARAM>
+        <PARAM name="ymax">90.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-3:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">25.</PARAM>
-        <PARAM name="ymax">70.</PARAM>
+        <PARAM name="ymin">0.22</PARAM>
+        <PARAM name="ymax">90.</PARAM>
       </QTEST>
 
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-1:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">8.</PARAM>
-        <PARAM name="ymax">25.</PARAM>
+        <PARAM name="ymin">0.13</PARAM>
+        <PARAM name="ymax">40.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-2:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">5.</PARAM>
-        <PARAM name="ymax">25.</PARAM>
+        <PARAM name="ymin">0.10</PARAM>
+        <PARAM name="ymax">40.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-3:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">5.</PARAM>
-        <PARAM name="ymax">25.</PARAM>
+        <PARAM name="ymin">0.10</PARAM>
+        <PARAM name="ymax">40.</PARAM>
       </QTEST>
 
     <!-- HCPI -->
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+1:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">10.</PARAM>
-        <PARAM name="ymax">100.</PARAM>
+        <PARAM name="ymin">0.12</PARAM>
+        <PARAM name="ymax">90.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+2:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">20.</PARAM>
-        <PARAM name="ymax">100.</PARAM>
+        <PARAM name="ymin">0.14</PARAM>
+        <PARAM name="ymax">90.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+3:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">25.</PARAM>
-        <PARAM name="ymax">100.</PARAM>
+        <PARAM name="ymin">0.12</PARAM>
+        <PARAM name="ymax">90.</PARAM>
       </QTEST>
 
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+1:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">5.</PARAM>
-        <PARAM name="ymax">25.</PARAM>
+        <PARAM name="ymin">0.05</PARAM>
+        <PARAM name="ymax">40.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+2:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">5.</PARAM>
-        <PARAM name="ymax">30.</PARAM>
+        <PARAM name="ymin">0.05</PARAM>
+        <PARAM name="ymax">40.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+3:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">6.</PARAM>
-        <PARAM name="ymax">35.</PARAM>
+        <PARAM name="ymin">0.06</PARAM>
+        <PARAM name="ymax">40.</PARAM>
       </QTEST>
 
     <!-- HCPO -->
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+1:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">10.</PARAM>
-        <PARAM name="ymax">75.</PARAM>
+        <PARAM name="ymin">0.12</PARAM>
+        <PARAM name="ymax">80.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+2:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">5.</PARAM>
-        <PARAM name="ymax">75.</PARAM>
+        <PARAM name="ymin">0.12</PARAM>
+        <PARAM name="ymax">90.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+3:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">10.</PARAM>
-        <PARAM name="ymax">75.</PARAM>
+        <PARAM name="ymin">0.14</PARAM>
+        <PARAM name="ymax">90.</PARAM>
       </QTEST>
 
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+1:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">8.</PARAM>
-        <PARAM name="ymax">25.</PARAM>
+        <PARAM name="ymin">0.1</PARAM>
+        <PARAM name="ymax">35.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+2:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">8.</PARAM>
-        <PARAM name="ymax">25.</PARAM>
+        <PARAM name="ymin">0.1</PARAM>
+        <PARAM name="ymax">35.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+3:mean_num_digis" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">5.</PARAM>
-        <PARAM name="ymax">25.</PARAM>
+        <PARAM name="ymin">0.1</PARAM>
+        <PARAM name="ymax">40.</PARAM>
       </QTEST>
 
 

--- a/DQM/SiPixelPhase1Config/test/qTests/mean_size_qualitytest_config.xml
+++ b/DQM/SiPixelPhase1Config/test/qTests/mean_size_qualitytest_config.xml
@@ -5,90 +5,90 @@
     <!-- PXLAYER 1 -->
     <QTEST name="Yrange:PXLayer_1__Shell_mI:mean_size" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">3.5</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.65</PARAM>
+      <PARAM name="warning">0.80</PARAM>
+      <PARAM name="ymin">2.5</PARAM>
       <PARAM name="ymax">5.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_1__Shell_mO:mean_size" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">3.</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.65</PARAM>
+      <PARAM name="warning">0.80</PARAM>
+      <PARAM name="ymin">2.5</PARAM>
       <PARAM name="ymax">5.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_1__Shell_pI:mean_size" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">3.5</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.65</PARAM>
+      <PARAM name="warning">0.80</PARAM>
+      <PARAM name="ymin">3.</PARAM>
       <PARAM name="ymax">5.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_1__Shell_pO:mean_size" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">3.5</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.65</PARAM>
+      <PARAM name="warning">0.80</PARAM>
+      <PARAM name="ymin">3.</PARAM>
       <PARAM name="ymax">5.</PARAM>
     </QTEST>
 
     <!-- PXLAYER 2 -->
     <QTEST name="Yrange:PXLayer_2__Shell_mI:mean_size" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">4.</PARAM>
-      <PARAM name="ymax">6.</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.75</PARAM>
+      <PARAM name="warning">0.90</PARAM>
+      <PARAM name="ymin">3.</PARAM>
+      <PARAM name="ymax">5.5</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_2__Shell_mO:mean_size" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">4.</PARAM>
-      <PARAM name="ymax">6.</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.75</PARAM>
+      <PARAM name="warning">0.90</PARAM>
+      <PARAM name="ymin">3.</PARAM>
+      <PARAM name="ymax">5.5</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_2__Shell_pI:mean_size" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">4.</PARAM>
-      <PARAM name="ymax">6.</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.75</PARAM>
+      <PARAM name="warning">0.90</PARAM>
+      <PARAM name="ymin">3.</PARAM>
+      <PARAM name="ymax">5.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_2__Shell_pO:mean_size" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">4.</PARAM>
-      <PARAM name="ymax">6.</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.75</PARAM>
+      <PARAM name="warning">0.90</PARAM>
+      <PARAM name="ymin">3.</PARAM>
+      <PARAM name="ymax">5.</PARAM>
     </QTEST>
 
     <!-- PXLAYER 3 -->
     <QTEST name="Yrange:PXLayer_3__Shell_mI:mean_size" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">3.5</PARAM>
-      <PARAM name="ymax">5.</PARAM>
+      <PARAM name="ymin">4.</PARAM>
+      <PARAM name="ymax">4.5</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_3__Shell_mO:mean_size" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
       <PARAM name="ymin">4.</PARAM>
@@ -97,26 +97,26 @@
 
     <QTEST name="Yrange:PXLayer_3__Shell_pI:mean_size" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
+      <PARAM name="error">0.85</PARAM>
+      <PARAM name="warning">0.95</PARAM>
+      <PARAM name="ymin">3.5</PARAM>
+      <PARAM name="ymax">5.</PARAM>
+    </QTEST>
+
+    <QTEST name="Yrange:PXLayer_3__Shell_pO:mean_size" activate="true">
+      <TYPE>ContentsYRange</TYPE>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
       <PARAM name="ymin">4.</PARAM>
       <PARAM name="ymax">5.</PARAM>
     </QTEST>
 
-    <QTEST name="Yrange:PXLayer_3__Shell_pO:mean_size" activate="true">
-      <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
-      <PARAM name="error">0.85</PARAM>
-      <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">3.5</PARAM>
-      <PARAM name="ymax">4.5</PARAM>
-    </QTEST>
-
     <!-- PXLAYER 4 -->
     <QTEST name="Yrange:PXLayer_4__Shell_mI:mean_size" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
       <PARAM name="ymin">3.5</PARAM>
@@ -125,29 +125,29 @@
 
     <QTEST name="Yrange:PXLayer_4__Shell_mO:mean_size" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
       <PARAM name="ymin">3.5</PARAM>
-      <PARAM name="ymax">4.5</PARAM>
+      <PARAM name="ymax">5.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_4__Shell_pI:mean_size" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
       <PARAM name="ymin">3.5</PARAM>
-      <PARAM name="ymax">4.5</PARAM>
+      <PARAM name="ymax">5.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_4__Shell_pO:mean_size" activate="true">
       <TYPE>ContentsYRange</TYPE>
-      <PARAM name="useEmptyBins">1</PARAM>
+      <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
       <PARAM name="ymin">3.5</PARAM>
-      <PARAM name="ymax">4.5</PARAM>
+      <PARAM name="ymax">5.</PARAM>
     </QTEST>
 
   <!-- PXFORWARD -->
@@ -155,25 +155,25 @@
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-1:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">3.</PARAM>
-        <PARAM name="ymax">4.</PARAM>
+        <PARAM name="ymin">2.5</PARAM>
+        <PARAM name="ymax">3.5</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-2:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">3.</PARAM>
-        <PARAM name="ymax">4.</PARAM>
+        <PARAM name="ymin">2.5</PARAM>
+        <PARAM name="ymax">3.5</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_1__PXDisk_-3:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">2.5</PARAM>
@@ -183,7 +183,7 @@
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-1:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">3.</PARAM>
@@ -192,7 +192,7 @@
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-2:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">3.</PARAM>
@@ -201,7 +201,7 @@
 
       <QTEST name="Yrange:HalfCylinder_mI__PXRing_2__PXDisk_-3:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">3.</PARAM>
@@ -212,7 +212,7 @@
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-1:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">3.</PARAM>
@@ -221,7 +221,7 @@
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-2:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">2.5</PARAM>
@@ -230,7 +230,7 @@
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_1__PXDisk_-3:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">2.5</PARAM>
@@ -240,16 +240,16 @@
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-1:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">3.5</PARAM>
-        <PARAM name="ymax">4.5</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">4.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-2:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">3.</PARAM>
@@ -258,7 +258,7 @@
 
       <QTEST name="Yrange:HalfCylinder_mO__PXRing_2__PXDisk_-3:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">3.</PARAM>
@@ -269,7 +269,7 @@
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+1:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">3.</PARAM>
@@ -278,16 +278,16 @@
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+2:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymin">2.5</PARAM>
         <PARAM name="ymax">4.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_1__PXDisk_+3:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">2.5</PARAM>
@@ -297,7 +297,7 @@
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+1:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">3.3</PARAM>
@@ -306,16 +306,16 @@
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+2:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">3.3</PARAM>
+        <PARAM name="ymin">3.0</PARAM>
         <PARAM name="ymax">4.3</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pI__PXRing_2__PXDisk_+3:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">3.</PARAM>
@@ -326,7 +326,7 @@
       <!-- PXRING 1 --> 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+1:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">3.</PARAM>
@@ -335,44 +335,44 @@
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+2:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">3.</PARAM>
-        <PARAM name="ymax">4.</PARAM>
+        <PARAM name="ymin">2.5</PARAM>
+        <PARAM name="ymax">3.5</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_1__PXDisk_+3:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">2.8</PARAM>
+        <PARAM name="ymin">2.5</PARAM>
         <PARAM name="ymax">3.8</PARAM>
       </QTEST>
 
       <!-- PXRING 2 --> 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+1:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">3.5</PARAM>
-        <PARAM name="ymax">4.5</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">4.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+2:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">3.4</PARAM>
-        <PARAM name="ymax">4.4</PARAM>
+        <PARAM name="ymin">3.</PARAM>
+        <PARAM name="ymax">4.</PARAM>
       </QTEST>
 
       <QTEST name="Yrange:HalfCylinder_pO__PXRing_2__PXDisk_+3:mean_size" activate="true">
         <TYPE>ContentsYRange</TYPE>
-        <PARAM name="useEmptyBins">1</PARAM>
+        <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
         <PARAM name="ymin">3.</PARAM>


### PR DESCRIPTION
Change quality test limits for collision runs. This should stop the Grand Summary showing mostly errors on most runs.

Limits based on HDQM data and have been checked against reference runs.