### PR TITLE
Work around inconsistency in ExternalLHEProducer

### DIFF
--- a/FWCore/Framework/src/ProducerBase.cc
+++ b/FWCore/Framework/src/ProducerBase.cc
@@ -99,7 +99,10 @@ namespace edm {
            (tl.typeID_ == *std::get<0>(it->second)) and
            (tl.productInstanceName_ == std::get<1>(it->second)) ) {
           putTokenToResolverIndex_[i] = std::get<2>(it->second);
-          break;
+          //NOTE: The ExternalLHEProducer puts the 'same' product in at
+          // both beginRun and endRun. Therefore we can get multiple matches.
+          // When the module is finally fixed, we can use the 'break'
+          //break;
         }
         ++i;
       }

--- a/FWCore/Framework/src/ProductRegistryHelper.cc
+++ b/FWCore/Framework/src/ProductRegistryHelper.cc
@@ -10,6 +10,7 @@
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 
 #include <vector>
+#include <typeindex>
 
 namespace edm {
   ProductRegistryHelper::~ProductRegistryHelper() { }
@@ -27,6 +28,7 @@ namespace edm {
 
     std::vector<std::string> missingDictionaries;
     std::vector<std::string> producedTypes;
+    std::set<std::tuple<BranchType,std::type_index,std::string>> registeredProducts;
 
     for(TypeLabelList::const_iterator p = iBegin; p != iEnd; ++p) {
 
@@ -35,9 +37,20 @@ namespace edm {
         producedTypes.emplace_back(p->typeID_.className());
         continue;
       }
+      auto branchType = convertToBranchType(p->transition_);
+      if(branchType != InEvent) {
+        std::tuple<BranchType, std::type_index, std::string> entry{ branchType,p->typeID_.typeInfo(),p->productInstanceName_};
+        if(registeredProducts.end() != registeredProducts.find(entry) ) {
+          //ignore registration of items if in both begin and end transitions for now
+          // This is to work around ExternalLHEProducer
+          continue;
+        } else {
+          registeredProducts.insert(entry);
+        }
+      }
 
       TypeWithDict type(p->typeID_.typeInfo());
-      BranchDescription pdesc(convertToBranchType(p->transition_),
+      BranchDescription pdesc(branchType,
                               iDesc.moduleLabel(),
                               iDesc.processName(),
                               p->typeID_.userClassName(),

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -137,7 +137,7 @@ ExternalLHEProducer::ExternalLHEProducer(const edm::ParameterSet& iConfig) :
 
   produces<LHEEventProduct>();
   produces<LHERunInfoProduct, edm::Transition::BeginRun>();
-  //produces<LHERunInfoProduct, edm::Transition::EndRun>();
+  produces<LHERunInfoProduct, edm::Transition::EndRun>();
 }
 
 

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -66,16 +66,16 @@ class ExternalLHEProducer : public edm::one::EDProducer<edm::BeginRunProducer,
                                                         edm::EndRunProducer> {
 public:
   explicit ExternalLHEProducer(const edm::ParameterSet& iConfig);
-  virtual ~ExternalLHEProducer() override;
+  ~ExternalLHEProducer() override;
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
 private:
 
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void beginRunProduce(edm::Run& run, edm::EventSetup const& es) override;
-  virtual void endRunProduce(edm::Run&, edm::EventSetup const&) override;
-  virtual void preallocThreads(unsigned int) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void beginRunProduce(edm::Run& run, edm::EventSetup const& es) override;
+  void endRunProduce(edm::Run&, edm::EventSetup const&) override;
+  void preallocThreads(unsigned int) override;
 
   int closeDescriptors(int preserve);
   void executeScript();
@@ -125,7 +125,7 @@ private:
 // constructors and destructor
 //
 ExternalLHEProducer::ExternalLHEProducer(const edm::ParameterSet& iConfig) :
-  scriptName_((iConfig.getParameter<edm::FileInPath>("scriptName")).fullPath().c_str()),
+  scriptName_((iConfig.getParameter<edm::FileInPath>("scriptName")).fullPath()),
   outputFile_(iConfig.getParameter<std::string>("outputFile")),
   args_(iConfig.getParameter<std::vector<std::string> >("args")),
   npars_(iConfig.getParameter<uint32_t>("numberOfParameters")),
@@ -334,7 +334,7 @@ ExternalLHEProducer::closeDescriptors(int preserve)
   maxfd = preserve;
   if ((dir = opendir("/proc/self/fd"))) {
     errno = 0;
-    while ((dp = readdir (dir)) != NULL) {
+    while ((dp = readdir (dir)) != nullptr) {
       if ((strcmp(dp->d_name, ".") == 0)  || (strcmp(dp->d_name, "..") == 0)) {
         continue;
       }
@@ -391,7 +391,7 @@ ExternalLHEProducer::executeScript()
   for (unsigned int i=1; i<argc; i++) {
     argv[i] = strdup(args_[i-1].c_str());
   }
-  argv[argc] = NULL;
+  argv[argc] = nullptr;
 
   pid_t pid = fork();
   if (pid == 0) {


### PR DESCRIPTION
The ExternalLHEProducer puts the 'same' data product into the Run
at both beginRun and endRun. This is not a behavior the framework
was intended to support (and causes sematic problems). However,
in order to avoid breaking existing workflows, we must accomodate
this behavior for the moment.