### PR TITLE
Update of wf1010.0 and run2_data_relval key

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -28,7 +28,7 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '94X_dataRun2_v1',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '94X_dataRun2_relval_v1',
+    'run2_data_relval'  :   '94X_dataRun2_relval_v2',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
     'run2_data_promptlike' : '94X_dataRun2_PromptLike_v1',
     # GlobalTag for Run1 HLT: it points to the online GT

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1594,7 +1594,7 @@ steps['ALCAEXP']={'-s':'ALCAOUTPUT:SiStripCalZeroBias+TkAlMinBias+DtCalib+Hotlin
 steps['ALCAEXPHI']=merge([{'-s':'ALCA:PromptCalibProd+PromptCalibProdSiStrip+PromptCalibProdSiStripGains+PromptCalibProdSiStripGainsAAG',
                   '--scenario':'HeavyIons'},steps['ALCAEXP']])
 steps['ALCAEXPTE']={'-s':'ALCA:PromptCalibProdEcalPedestals',
-                    '--conditions':'auto:run2_data',
+                    '--conditions':'auto:run2_data_relval',
                     '--datatier':'ALCARECO',
                     '--eventcontent':'ALCARECO',
                     '--triggerResultsProcess': 'RECO'}


### PR DESCRIPTION
This PR will fix the crash reported by @smuzaffar https://github.com/cms-sw/cmssw/pull/20707#issuecomment-334055250
It brings two changes : 
1. Update of wf 1010.0 to run on data relval key rather than offline key. This will keep intact the offline GT according to the real offline conditions where ECAL Pedestals have time based IOVs. This workflow requires run-based IOVs and I dont think its a good idea to keep mixture of offline and non-offline conditions in run2_data key. run2_data_relval should suffice this.

2. Update of GT corresponds to run2_data_relval key that includes the ECALPedestal tag from Express/Prompt (this was the way earlier) which is run-based.

I performed the local checks with : runTheMatrix.py -l 1010.0 --command='-n 1'
and I see no more crashes.

@argiro @fabozzi 

