### PR TITLE
DTDQM change to monitor ZS data

### DIFF
--- a/DQM/DTMonitorModule/src/DTLocalTriggerBaseTask.cc
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerBaseTask.cc
@@ -61,7 +61,7 @@ private:
 
 
 DTLocalTriggerBaseTask::DTLocalTriggerBaseTask(const edm::ParameterSet& ps) :
-  nEvents(0), nLumis(0), theTrigGeomUtils(0) {
+  nEvents(0), nLumis(0), theTrigGeomUtils(nullptr) {
 
   LogTrace("DTDQM|DTMonitorModule|DTLocalTriggerBaseTask")
     << "[DTLocalTriggerBaseTask]: Constructor"<<endl;
@@ -284,6 +284,12 @@ void DTLocalTriggerBaseTask::bookHistos(DQMStore::IBooker & ibooker, const DTCha
       chamberHistos[dtCh.rawId()][histoTag] = ibooker.book2D(histoTag+chTag,
 	          "1st/2nd trig flag vs quality",7,-0.5,6.5,2,-0.5,1.5);
       setQLabels(chamberHistos[rawId][histoTag],1);
+
+      histoTag = (*typeIt) + "_FlagUpDownvsQual" + labelInOut;
+      chamberHistos[dtCh.rawId()][histoTag] = ibooker.book2D(histoTag+chTag,
+                  "Up/Down trig flag vs quality",7,-0.5,6.5,2,-0.5,1.5);
+      setQLabels(chamberHistos[rawId][histoTag],1);
+
     }
 
     if (*typeIt=="TM") {
@@ -397,6 +403,8 @@ void DTLocalTriggerBaseTask::runTMAnalysis( std::vector<L1MuDTChambPhDigi> const
     int qual  = iph->code();
     int is1st = iph->Ts2Tag() ? 1 : 0;
     int bx    = iph->bxNum() - is1st;
+    int updown = iph->UpDownTag();
+
     if (qual <0 || qual>6) continue; // Check that quality is in a valid range
 
     DTChamberId dtChId(wh,st,sec);
@@ -416,6 +424,7 @@ void DTLocalTriggerBaseTask::runTMAnalysis( std::vector<L1MuDTChambPhDigi> const
     } else {
       innerME["TM_BXvsQual_In"]->Fill(qual,bx);         // SM BX vs Qual Phi view (1st tracks)
       innerME["TM_Flag1stvsQual_In"]->Fill(qual,is1st); // SM Qual 1st/2nd track flag Phi view
+      innerME["TM_FlagUpDownvsQual_In"]->Fill(qual,updown); // SM Qual Up/Down track flag Phi view
       if (!is1st) innerME["TM_QualvsPhirad_In"]->Fill(pos,qual);  // SM Qual vs radial angle Phi view ONLY for 1st tracks
       if (detailedAnalysis) {
 	innerME["TM_QualvsPhibend_In"]->Fill(dir,qual); // SM Qual vs bending Phi view
@@ -435,7 +444,7 @@ void DTLocalTriggerBaseTask::runTMAnalysis( std::vector<L1MuDTChambPhDigi> const
     int qual  = iph->code();
     int is1st = iph->Ts2Tag() ? 1 : 0;
     int bx    = iph->bxNum() - is1st;
-
+    int updown = iph->UpDownTag();
     if (qual <0 || qual>6) continue; // Check that quality is in a valid range
 
     DTChamberId dtChId(wh,st,sec);
@@ -455,6 +464,8 @@ void DTLocalTriggerBaseTask::runTMAnalysis( std::vector<L1MuDTChambPhDigi> const
     } else {
       innerME["TM_BXvsQual_Out"]->Fill(qual,bx);         // SM BX vs Qual Phi view (1st tracks)
       innerME["TM_Flag1stvsQual_Out"]->Fill(qual,is1st); // SM Qual 1st/2nd track flag Phi view
+      innerME["TM_FlagUpDownvsQual_Out"]->Fill(qual,updown); // SM Qual Up/Down track flag Phi view
+
       if (!is1st) innerME["TM_QualvsPhirad_Out"]->Fill(pos,qual);  // SM Qual vs radial angle Phi view ONLY for 1st tracks
       if (detailedAnalysis) {
         innerME["TM_QualvsPhibend_Out"]->Fill(dir,qual); // SM Qual vs bending Phi view
@@ -603,7 +614,7 @@ void DTLocalTriggerBaseTask::setQLabels(MonitorElement* me, short int iaxis){
   TH1* histo = me->getTH1();
   if (!histo) return;
 
-  TAxis* axis=0;
+  TAxis* axis=nullptr;
   if (iaxis==1) {
     axis=histo->GetXaxis();
   }
@@ -625,7 +636,7 @@ void DTLocalTriggerBaseTask::setQLabelsTheta(MonitorElement* me, short int iaxis
   TH1* histo = me->getTH1();
   if (!histo) return;
 
-  TAxis* axis=0;
+  TAxis* axis=nullptr;
   if (iaxis==1) {
     axis=histo->GetXaxis();
   }

--- a/DQM/DTMonitorModule/src/DTLocalTriggerTask.cc
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerTask.cc
@@ -33,7 +33,7 @@ using namespace edm;
 using namespace std;
 
 DTLocalTriggerTask::DTLocalTriggerTask(const edm::ParameterSet& ps) :
-  trigGeomUtils(0),
+  trigGeomUtils(nullptr),
   isLocalRun(ps.getUntrackedParameter<bool>("localrun", true))
  {
   if (!isLocalRun) {
@@ -47,14 +47,14 @@ DTLocalTriggerTask::DTLocalTriggerTask(const edm::ParameterSet& ps) :
   detailedAnalysis = ps.getUntrackedParameter<bool>("detailedAnalysis", false);
   doTMTheta       = ps.getUntrackedParameter<bool>("enableTMTheta", false);
   tm_Token_       = consumes<L1MuDTChambPhContainer>(
-      edm::InputTag(ps.getUntrackedParameter<string>("tm_label", "twinMuxStage2Digis:PhIn")));
+      ps.getUntrackedParameter<InputTag>("tm_label",InputTag("twinMuxStage2Digis:PhIn")));
   tmTh_Token_       = consumes<L1MuDTChambThContainer>(
-	edm::InputTag(ps.getUntrackedParameter<string>("tmTh_label","twinMuxStage2Digis:ThIn")));
+      ps.getUntrackedParameter<edm::InputTag>("tmTh_label",InputTag("twinMuxStage2Digis:ThIn")));
 
   ros_Token_       = consumes<DTLocalTriggerCollection>(
-      edm::InputTag(ps.getUntrackedParameter<string>("ros_label", "dtunpacker")));
+      ps.getUntrackedParameter<InputTag>("ros_label", InputTag("dtunpacker")));
   seg_Token_       = consumes<DTRecSegment4DCollection>(
-      edm::InputTag(ps.getUntrackedParameter<string>("seg_label", "dt4DSegments")));
+      ps.getUntrackedParameter<InputTag>("seg_label", InputTag("dt4DSegments")));
 
   if (tpMode) {
     baseFolderTM = "DT/11-LocalTriggerTP-TM/";
@@ -144,6 +144,8 @@ void DTLocalTriggerTask::bookHistograms(DQMStore::IBooker & ibooker, edm::Run co
 		  bookHistos(ibooker, dtChId,"LocalTriggerPhiIn","TM_QualvsPhibend_In"+(*trigSrcIt));
 		}
 		bookHistos(ibooker, dtChId,"LocalTriggerPhiIn","TM_Flag1stvsQual_In"+(*trigSrcIt));
+                bookHistos(ibooker, dtChId,"LocalTriggerPhiIn","TM_FlagUpDownvsQual_In"+(*trigSrcIt));
+
 		bookHistos(ibooker, dtChId,"LocalTriggerPhiIn","TM_BestQual_In"+(*trigSrcIt));
 		if (stat!=4 && doTMTheta){
 		  bookHistos(ibooker, dtChId,"LocalTriggerTheta","TM_PositionvsBX"+(*trigSrcIt));
@@ -383,6 +385,13 @@ void DTLocalTriggerTask::bookHistos(DQMStore::IBooker & ibooker, const DTChamber
       setQLabels((digiHistos[dtCh.rawId()])[histoTag],1);
       return ;
     }
+    if( histoType == "FlagUpDownvsQual" ) {
+      (digiHistos[dtCh.rawId()])[histoTag] =
+        ibooker.book2D(histoName,"Up/Down trig flag vs quality",7,-0.5,6.5,2,-0.5,1.5);
+      setQLabels((digiHistos[dtCh.rawId()])[histoTag],1);
+      return ;
+    }
+
     if( histoType == "QualDDUvsQualTM" ){
       (digiHistos[dtCh.rawId()])[histoTag] =
 	ibooker.book2D(histoName,"DDU quality vs TM quality",8,-1.5,6.5,8,-1.5,6.5);
@@ -532,6 +541,7 @@ void DTLocalTriggerTask::runTMAnalysis(std::vector<L1MuDTChambPhDigi> const* phT
     int phbx    = iph->bxNum();
     int phcode  = iph->code();
     int phi1st  = iph->Ts2Tag();
+    int updown  = iph->UpDownTag();
 
     // FIXME: workaround for TM data with station ID
     if(phst == 0) {
@@ -559,6 +569,7 @@ void DTLocalTriggerTask::runTMAnalysis(std::vector<L1MuDTChambPhDigi> const* phT
     else {
       innerME.find("TM_BXvsQual_In"+trigsrc)->second->Fill(phcode,phbx-phi1st);    // SM BX vs Qual Phi view (1st tracks)
       innerME.find("TM_Flag1stvsQual_In"+trigsrc)->second->Fill(phcode,phi1st);    // SM Qual 1st/2nd track flag Phi view
+      innerME.find("TM_FlagUpDownvsQual_In"+trigsrc)->second->Fill(phcode,updown);    // SM Qual Up/Down track flag Phi view
       if (detailedAnalysis) {
 	innerME.find("TM_QualvsPhirad_In"+trigsrc)->second->Fill(x,phcode);          // SM Qual vs radial angle Phi view
 	innerME.find("TM_QualvsPhibend_In"+trigsrc)->second->Fill(angle,phcode);     // SM Qual vs bending Phi view
@@ -717,7 +728,7 @@ void DTLocalTriggerTask::runSegmentAnalysis(Handle<DTRecSegment4DCollection>& se
   for (chamberId = segments4D->id_begin(); chamberId != segments4D->id_end(); ++chamberId){
 
     DTRecSegment4DCollection::range  range = segments4D->get(*chamberId);
-    const DTRecSegment4D* tmpBest=0;
+    const DTRecSegment4D* tmpBest=nullptr;
     int tmpdof = 0;
     int dof = 0;
 
@@ -918,7 +929,7 @@ void DTLocalTriggerTask::setQLabels(MonitorElement* me, short int iaxis){
   TH1* histo = me->getTH1();
   if (!histo) return;
 
-  TAxis* axis=0;
+  TAxis* axis=nullptr;
   if (iaxis==1) {
     axis=histo->GetXaxis();
   }
@@ -940,7 +951,7 @@ void DTLocalTriggerTask::setQLabelsTheta (MonitorElement* me, short int iaxis){
   TH1* histo = me->getTH1();
   if (!histo) return;
 
-  TAxis* axis=0;
+  TAxis* axis=nullptr;
   if (iaxis==1) {
     axis=histo->GetXaxis();
   }


### PR DESCRIPTION
Adds the following plots:
TM_FlagUpDownvsQual_In
TM_FlagUpDownvsQual_Out

92X backport of #20732 
Needs PR #20598 
It should go along with deployment: PR https://github.com/dmwm/deployment/pull/547
