### PR TITLE
add HLTScouting event content

### DIFF
--- a/HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py
+++ b/HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py
@@ -669,3 +669,18 @@ HLTDebugFEVT  = cms.PSet(
     ) )
 )
 
+HLTScouting  = cms.PSet(
+    outputCommands = cms.vstring( *(
+        'drop *_hlt*_*_*',
+        'keep *_hltFEDSelectorL1_*_*',
+        'keep *_hltScoutingCaloPacker_*_*',
+        'keep *_hltScoutingEgammaPacker_*_*',
+        'keep *_hltScoutingMuonPackerCalo_*_*',
+        'keep *_hltScoutingMuonPacker_*_*',
+        'keep *_hltScoutingPFPacker_*_*',
+        'keep *_hltScoutingPrimaryVertexPackerCaloMuon_*_*',
+        'keep *_hltScoutingPrimaryVertexPacker_*_*',
+        'keep edmTriggerResults_*_*_*'
+    ) )
+)
+

--- a/HLTrigger/Configuration/test/getEventContent.py
+++ b/HLTrigger/Configuration/test/getEventContent.py
@@ -22,12 +22,14 @@ def extractBlock(config, blocks, target):
   proc.wait()
 
 def extractBlocks(config):
-  outputA    = ( 'hltOutputA', 'hltOutputPhysicsCommissioning' )
-  outputALCA = ( 'hltOutputALCAPHISYM', 'hltOutputALCAP0', 'hltOutputALCALUMIPIXELS' , 'hltOutputRPCMON' )
-  outputMON  = ( 'hltOutputA', 'hltOutputPhysicsCommissioning', 'hltOutputDQM', 'hltOutputHLTMonitor', 'hltOutputLookArea', 'hltOutputReleaseValidation' )
-  extractBlock(config, outputA,    'hltOutputA_cff.py')
-  extractBlock(config, outputALCA, 'hltOutputALCA_cff.py')
-  extractBlock(config, outputMON,  'hltOutputMON_cff.py')
+  outputA        = ( 'hltOutputA', 'hltOutputPhysicsCommissioning' )
+  outputALCA     = ( 'hltOutputALCAPHISYM', 'hltOutputALCAP0', 'hltOutputALCALUMIPIXELS' , 'hltOutputRPCMON' )
+  outputMON      = ( 'hltOutputA', 'hltOutputPhysicsCommissioning', 'hltOutputDQM', 'hltOutputHLTMonitor', 'hltOutputLookArea', 'hltOutputReleaseValidation')
+  outputScouting = ( 'hltOutputScoutingPF', 'hltOutputScoutingCaloMuon')
+  extractBlock(config, outputA,         'hltOutputA_cff.py')
+  extractBlock(config, outputALCA,      'hltOutputALCA_cff.py')
+  extractBlock(config, outputMON,       'hltOutputMON_cff.py')
+  extractBlock(config, outputScouting,  'hltScouting_cff.py')
 
 def makePSet(statements):
   statements = list(statements)
@@ -71,6 +73,7 @@ extractBlocks( config )
 import hltOutputA_cff
 import hltOutputALCA_cff
 import hltOutputMON_cff
+import hltScouting_cff
 
 # hltDebugOutput
 
@@ -120,6 +123,20 @@ hltDebugWithAlCaOutputBlocks = (
 )
 hltDebugWithAlCaOutputContent = buildPSet(hltDebugWithAlCaOutputBlocks)
 
+# hltScoutingOutput
+
+if not hasattr(hltScouting_cff,'block_hltOutputScoutingPF'):
+  hltScouting_cff.block_hltOutputScoutingPF = cms.PSet(outputCommands = cms.untracked.vstring( 'drop *' ))
+if not hasattr(hltScouting_cff,'block_hltOutputScoutingCaloMuon'):
+  hltScouting_cff.block_hltOutputScoutingCaloMuon = cms.PSet(outputCommands = cms.untracked.vstring( 'drop *' ))
+
+hltScoutingOutputBlocks = (
+  # the DQM, HLTDQM and HLTMON streams have the HLT debug outputs used online
+  hltScouting_cff.block_hltOutputScoutingPF.outputCommands,
+  hltScouting_cff.block_hltOutputScoutingCaloMuon.outputCommands,
+)
+hltScoutingOutputContent = buildPSet(hltScoutingOutputBlocks)
+
 
 # hltDefaultOutput
 if not hasattr(hltOutputA_cff,'block_hltOutputA'):
@@ -165,6 +182,11 @@ HLTDebugFEVT = cms.PSet(
 )
 HLTDebugFEVT.outputCommands.extend(hltDebugWithAlCaOutputContent.outputCommands)
 
+# Scouting event content
+HLTScouting = cms.PSet(
+    outputCommands = cms.vstring()
+)
+HLTScouting.outputCommands.extend(hltScoutingOutputContent.outputCommands)
 
 # dump the expanded event content configurations to a python configuration fragment
 dump = open('HLTrigger_EventContent_cff.py', 'w')
@@ -184,4 +206,5 @@ dump.write('HLTriggerRECO = cms.PSet(\n    outputCommands = cms.vstring( *(\n%s\
 dump.write('HLTriggerAOD  = cms.PSet(\n    outputCommands = cms.vstring( *(\n%s\n    ) )\n)\n\n'  % ',\n'.join( '        \'%s\'' % keep for keep in HLTriggerAOD.outputCommands))
 dump.write('HLTDebugRAW   = cms.PSet(\n    outputCommands = cms.vstring( *(\n%s\n    ) )\n)\n\n'  % ',\n'.join( '        \'%s\'' % keep for keep in HLTDebugRAW.outputCommands))
 dump.write('HLTDebugFEVT  = cms.PSet(\n    outputCommands = cms.vstring( *(\n%s\n    ) )\n)\n\n'  % ',\n'.join( '        \'%s\'' % keep for keep in HLTDebugFEVT.outputCommands))
+dump.write('HLTScouting  = cms.PSet(\n    outputCommands = cms.vstring( *(\n%s\n    ) )\n)\n\n'  % ',\n'.join( '        \'%s\'' % keep for keep in HLTScouting.outputCommands))
 dump.close()


### PR DESCRIPTION
This PR adds the definition of HLTScouting event content as the variables saved in the ScoutingPF and ScoutingCaloMuon streams, in HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py .
This will allow - with another PR - to add scouting variables in the next MC production.

cc: @swagata87 @jmduarte please add also other people interested in scouting