### PR TITLE
Protect against missing track info in MiniAOD

### DIFF
--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -151,7 +151,7 @@ std::unique_ptr<const GBRForest> PileupJetIdAlgo::getMVA(const std::vector<std::
             if( tmvaNames_[*it].empty() ) tmvaNames_[*it] = *it;
             tmpTMVAReader.AddSpectator( *it, variables_[ tmvaNames_[*it] ].first );
         }
-        reco::details::loadTMVAWeights(&tmpTMVAReader,  tmvaMethod_.c_str(), tmvaWeights.c_str());
+        reco::details::loadTMVAWeights(&tmpTMVAReader,  tmvaMethod_, tmvaWeights);
         return( std::make_unique<const GBRForest> ( dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(tmvaMethod_.c_str()) ) ) );
 }
 
@@ -177,7 +177,7 @@ float PileupJetIdAlgo::getMVAval(const std::vector<std::string> &varList, const 
         float mvaval = -2;
         std::vector<float> vars;
         for(std::vector<std::string>::const_iterator it=varList.begin(); it!=varList.end(); ++it) {
-            std::pair<float *,float> var = variables_.at((*it).c_str());
+            std::pair<float *,float> var = variables_.at(*it);
             vars.push_back( *var.first );
         }
         mvaval = reader->GetClassifier(vars.data());

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -391,12 +391,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 			  }
 			  if(pfTrk==nullptr) { //protection against empty pointers for the miniAOD case
 			    //To handle the electron case
-			    if(lPF!=nullptr) {
-			      pfTrk=(lPF->trackRef().get()==nullptr)?lPF->gsfTrackRef().get():lPF->trackRef().get();
-			      internalId_.d0_ = std::abs(pfTrk->dxy(vtx->position()));
-			      internalId_.dZ_ = std::abs(pfTrk->dz(vtx->position()));
-			    }
-			    if(lPack!=nullptr) {
+			    if(isPacked) {
 			      if (lPack->hasTrackDetails()) {
 			        const reco::Track& impactTrack = lPack->pseudoTrack();
 			        internalId_.d0_ = std::abs(impactTrack.dxy(vtx->position()));
@@ -405,6 +400,11 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 			        internalId_.d0_ = -1000.;
 			        internalId_.dZ_ = -1000.;
 			      }
+			    }
+			    else if(lPF!=nullptr) {
+			      pfTrk=(lPF->trackRef().get()==nullptr)?lPF->gsfTrackRef().get():lPF->trackRef().get();
+			      internalId_.d0_ = std::abs(pfTrk->dxy(vtx->position()));
+			      internalId_.dZ_ = std::abs(pfTrk->dz(vtx->position()));
 			    }
 			  }
 			  else {

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -393,10 +393,19 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 			    //To handle the electron case
 			    if(lPF!=nullptr) {
 			      pfTrk=(lPF->trackRef().get()==nullptr)?lPF->gsfTrackRef().get():lPF->trackRef().get();
+			      internalId_.d0_ = std::abs(pfTrk->dxy(vtx->position()));
+			      internalId_.dZ_ = std::abs(pfTrk->dz(vtx->position()));
 			    }
-			    const reco::Track& impactTrack = (lPack==nullptr)?(*pfTrk):(lPack->pseudoTrack());
-			    internalId_.d0_ = std::abs(impactTrack.dxy(vtx->position()));
-			    internalId_.dZ_ = std::abs(impactTrack.dz(vtx->position()));
+			    if(lPack!=nullptr) {
+			      if (lPack->hasTrackDetails()) {
+			        const reco::Track& impactTrack = lPack->pseudoTrack();
+			        internalId_.d0_ = std::abs(impactTrack.dxy(vtx->position()));
+			        internalId_.dZ_ = std::abs(impactTrack.dz(vtx->position()));
+			      } else {
+			        internalId_.d0_ = -1000.;
+			        internalId_.dZ_ = -1000.;
+			      }
+			    }
 			  }
 			  else {
 			    internalId_.d0_ = std::abs(pfTrk->dxy(vtx->position()));

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -392,14 +392,8 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 			  if(pfTrk==nullptr) { //protection against empty pointers for the miniAOD case
 			    //To handle the electron case
 			    if(isPacked) {
-			      if (lPack->hasTrackDetails()) {
-			        const reco::Track& impactTrack = lPack->pseudoTrack();
-			        internalId_.d0_ = std::abs(impactTrack.dxy(vtx->position()));
-			        internalId_.dZ_ = std::abs(impactTrack.dz(vtx->position()));
-			      } else {
-			        internalId_.d0_ = -1000.;
-			        internalId_.dZ_ = -1000.;
-			      }
+			      internalId_.d0_ = std::abs(lPack->dxy(vtx->position()));
+			      internalId_.dZ_ = std::abs(lPack->dz(vtx->position()));
 			    }
 			    else if(lPF!=nullptr) {
 			      pfTrk=(lPF->trackRef().get()==nullptr)?lPF->gsfTrackRef().get():lPF->trackRef().get();


### PR DESCRIPTION
When pileup jet ID is reran on top of an existing MiniAOD, it crashes due to missing tracking information.
The fix sets the corresponding variables to default values if no information is available.
The affected variables are not used in the default MVA training of pileup jet ID, thus have no effect on the observable used in analyses.
Backport to 93 for analyses: #20740