### PR TITLE
Fix xerces xmlparser issue in aarch64 unique_ptr related sigsegv

### DIFF
--- a/Geometry/VeryForwardGeometryBuilder/src/RPAlignmentCorrectionsDataSequence.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/RPAlignmentCorrectionsDataSequence.cc
@@ -154,6 +154,7 @@ RPAlignmentCorrectionsDataSequence::loadXMLFile( const std::string& fileName )
     std::map<TimeValidityInterval,RPAlignmentCorrectionsData>::insert( std::make_pair( tvi, corrections ) );
   }
 
+  parser.reset();
   XMLPlatformUtils::Terminate();
 }
 


### PR DESCRIPTION
This PR fixes the latest Xerces related relval fails in aarch64 listed here 
https://cms-sw.github.io/relvalLogDetail.html#slc7_aarch64_gcc700;CMSSW_9_4_X_2017-10-03-2300
with this description 
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_aarch64_gcc700/CMSSW_9_4_X_2017-10-03-2300/pyRelValMatrixLogs/run/5.2_SingleMuPt10+SingleMuPt10FS+HARVESTFS/step1_SingleMuPt10+SingleMuPt10FS+HARVESTFS.log
which were due to this object 
https://github.com/cms-sw/cmssw/blob/efff9c203d32546e1646a17660b15dca05c2b24c/Geometry/VeryForwardGeometryBuilder/src/RPAlignmentCorrectionsDataSequence.cc#L81
not properly deleted (or pointer still pointing somewhere it was not supposed to) when going out of scope 
even though the recipe prescribed by apache 
https://xerces.apache.org/xerces-c/program-3.html
was properly repeated. 
Similar implementations of the same thing exists also in other places in CMSSW :
https://github.com/cms-sw/cmssw/search?utf8=%E2%9C%93&q=XMLPlatformUtils%3A%3ATerminate%28%29&type=