### PR TITLE
clang-tidy check for FWCore

### DIFF
--- a/FWCore/Common/src/EventBase.cc
+++ b/FWCore/Common/src/EventBase.cc
@@ -63,8 +63,8 @@ namespace edm
       // Look for the parameter set containing the trigger names in the parameter
       // set registry using the ID from TriggerResults as the key used to find it.
       edm::pset::Registry* psetRegistry = edm::pset::Registry::instance();
-      edm::ParameterSet const* pset=0;
-      if (0!=(pset=psetRegistry->getMapped(triggerResults.parameterSetID()))) {
+      edm::ParameterSet const* pset=nullptr;
+      if (nullptr!=(pset=psetRegistry->getMapped(triggerResults.parameterSetID()))) {
 
 	 if (pset->existsAs<std::vector<std::string> >("@trigger_paths", true)) {
             TriggerNames triggerNames(*pset);
@@ -85,7 +85,7 @@ namespace edm
          }
       }
       // For backward compatibility to very old data
-      if (triggerResults.getTriggerNames().size() > 0U) {
+      if (!triggerResults.getTriggerNames().empty()) {
 	 edm::ParameterSet fakePset;
          fakePset.addParameter<std::vector<std::string> >("@trigger_paths", triggerResults.getTriggerNames());
          fakePset.registerIt();
@@ -105,6 +105,6 @@ namespace edm
             triggerNamesMap.insert(std::pair<edm::ParameterSetID, edm::TriggerNames>(fakePset.id(), triggerNames));
          return &(ret.first->second);
       }
-      return 0;
+      return nullptr;
    }
 }

--- a/FWCore/Common/src/TriggerResultsByName.cc
+++ b/FWCore/Common/src/TriggerResultsByName.cc
@@ -13,7 +13,7 @@ namespace edm {
     triggerNames_(triggerNames) {
 
    // If either of these is true the object is in an invalid state
-   if (triggerResults_ == 0 || triggerNames_ == 0) {
+   if (triggerResults_ == nullptr || triggerNames_ == nullptr) {
      return;
    }
 
@@ -38,42 +38,42 @@ namespace edm {
   bool
   TriggerResultsByName::
   isValid() const {
-    if (triggerResults_ == 0 || triggerNames_ == 0) return false;
+    if (triggerResults_ == nullptr || triggerNames_ == nullptr) return false;
     return true;
   }
 
   ParameterSetID const&
   TriggerResultsByName::
   parameterSetID() const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
     return triggerResults_->parameterSetID();
   }
 
   bool
   TriggerResultsByName::
   wasrun() const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
     return triggerResults_->wasrun();
   }
 
   bool
   TriggerResultsByName::
   accept() const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
     return triggerResults_->accept();
   }
 
   bool
   TriggerResultsByName::
   error() const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
     return triggerResults_->error();
   }
 
   HLTPathStatus const& 
   TriggerResultsByName::
   at(std::string const& pathName) const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
     unsigned i = getAndCheckIndex(pathName);
     return triggerResults_->at(i);
   }
@@ -81,14 +81,14 @@ namespace edm {
   HLTPathStatus const&
   TriggerResultsByName::
   at(unsigned i) const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
     return triggerResults_->at(i);
   }
 
   HLTPathStatus const& 
   TriggerResultsByName::
   operator[](std::string const& pathName) const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
     unsigned i = getAndCheckIndex(pathName);
     return triggerResults_->at(i);
   }
@@ -96,14 +96,14 @@ namespace edm {
   HLTPathStatus const&
   TriggerResultsByName::
   operator[](unsigned i) const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
     return triggerResults_->at(i);
   }
 
   bool
   TriggerResultsByName::
   wasrun(std::string const& pathName) const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
     unsigned i = getAndCheckIndex(pathName);
     return triggerResults_->wasrun(i);
   }
@@ -111,14 +111,14 @@ namespace edm {
   bool
   TriggerResultsByName::
   wasrun(unsigned i) const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
     return triggerResults_->wasrun(i);
   }
 
   bool
   TriggerResultsByName::
   accept(std::string const& pathName) const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
     unsigned i = getAndCheckIndex(pathName);
     return triggerResults_->accept(i);
   }
@@ -126,14 +126,14 @@ namespace edm {
   bool
   TriggerResultsByName::
   accept(unsigned i) const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
     return triggerResults_->accept(i);
   }
 
   bool
   TriggerResultsByName::
   error(std::string const& pathName) const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
     unsigned i = getAndCheckIndex(pathName);
     return triggerResults_->error(i);
   }
@@ -141,14 +141,14 @@ namespace edm {
   bool
   TriggerResultsByName::
   error(unsigned i) const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
     return triggerResults_->error(i);
   }
 
   hlt::HLTState
   TriggerResultsByName::
   state(std::string const& pathName) const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
     unsigned i = getAndCheckIndex(pathName);
     return triggerResults_->state(i);
   }
@@ -156,14 +156,14 @@ namespace edm {
   hlt::HLTState
   TriggerResultsByName::
   state(unsigned i) const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
     return triggerResults_->state(i);
   }
 
   unsigned
   TriggerResultsByName::
   index(std::string const& pathName) const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
     unsigned i = getAndCheckIndex(pathName);
     return triggerResults_->index(i);
   }
@@ -171,45 +171,45 @@ namespace edm {
   unsigned
   TriggerResultsByName::
   index(unsigned i) const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
     return triggerResults_->index(i);
   }
 
   std::vector<std::string> const&
   TriggerResultsByName::
   triggerNames() const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
-    if (triggerNames_ == 0) throwTriggerNamesMissing(); 
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
+    if (triggerNames_ == nullptr) throwTriggerNamesMissing(); 
     return triggerNames_->triggerNames();
   }
 
   std::string const&
   TriggerResultsByName::
   triggerName(unsigned i) const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
-    if (triggerNames_ == 0) throwTriggerNamesMissing(); 
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
+    if (triggerNames_ == nullptr) throwTriggerNamesMissing(); 
     return triggerNames_->triggerName(i);    
   }
 
   unsigned
   TriggerResultsByName::
   triggerIndex(std::string const& pathName) const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
-    if (triggerNames_ == 0) throwTriggerNamesMissing(); 
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
+    if (triggerNames_ == nullptr) throwTriggerNamesMissing(); 
     return triggerNames_->triggerIndex(pathName);    
   }
 
   std::vector<std::string>::size_type
   TriggerResultsByName::
   size() const {
-    if (triggerResults_ == 0) throwTriggerResultsMissing();
+    if (triggerResults_ == nullptr) throwTriggerResultsMissing();
     return triggerResults_->size();
   }
 
   unsigned
   TriggerResultsByName::
   getAndCheckIndex(std::string const& pathName) const {
-    if (triggerNames_ == 0) throwTriggerNamesMissing(); 
+    if (triggerNames_ == nullptr) throwTriggerNamesMissing(); 
     unsigned i = triggerNames_->triggerIndex(pathName);
     if (i == triggerNames_->size()) {
       throw edm::Exception(edm::errors::LogicError)

--- a/FWCore/Concurrency/src/SerialTaskQueue.cc
+++ b/FWCore/Concurrency/src/SerialTaskQueue.cc
@@ -37,7 +37,7 @@ bool
 SerialTaskQueue::resume() {
   if(0==--m_pauseCount) {
     tbb::task* t = pickNextTask();
-    if(0 != t) {
+    if(nullptr != t) {
       tbb::task::spawn(*t);
     }
     return true;
@@ -48,15 +48,15 @@ SerialTaskQueue::resume() {
 void
 SerialTaskQueue::pushTask(TaskBase* iTask) {
   tbb::task* t = pushAndGetNextTask(iTask);
-  if(0!=t) {
+  if(nullptr!=t) {
     tbb::task::spawn(*t);      
   }
 }
 
 tbb::task* 
 SerialTaskQueue::pushAndGetNextTask(TaskBase* iTask) {
-  tbb::task* returnValue{0};
-  if likely(0!=iTask) {
+  tbb::task* returnValue{nullptr};
+  if likely(nullptr!=iTask) {
     m_tasks.push(iTask);
     returnValue = pickNextTask();
   }
@@ -75,7 +75,7 @@ SerialTaskQueue::pickNextTask() {
   
   bool expect = false;
   if likely(0 == m_pauseCount and m_taskChosen.compare_exchange_strong(expect,true)) {
-    TaskBase* t=0;
+    TaskBase* t=nullptr;
     if likely(m_tasks.try_pop(t)) {
       return t;
     }
@@ -85,7 +85,7 @@ SerialTaskQueue::pickNextTask() {
     //was a new entry added after we called 'try_pop' but before we did the clear?
     expect = false;
     if(not m_tasks.empty() and m_taskChosen.compare_exchange_strong(expect,true)) {
-      TaskBase* t=0;
+      TaskBase* t=nullptr;
       if(m_tasks.try_pop(t)) {
         return t;
       }
@@ -94,7 +94,7 @@ SerialTaskQueue::pickNextTask() {
       
     }
   }
-  return 0;
+  return nullptr;
 }
 
 void SerialTaskQueue::pushAndWait(tbb::empty_task* iWait, TaskBase* iTask) {

--- a/FWCore/FWLite/interface/AutoLibraryLoader.h
+++ b/FWCore/FWLite/interface/AutoLibraryLoader.h
@@ -23,8 +23,8 @@ public:
 private:
   static bool enabled_;
   AutoLibraryLoader();
-  AutoLibraryLoader(const AutoLibraryLoader&); // stop default
-  const AutoLibraryLoader& operator=(const AutoLibraryLoader&); // stop default
+  AutoLibraryLoader(const AutoLibraryLoader&) = delete; // stop default
+  const AutoLibraryLoader& operator=(const AutoLibraryLoader&) = delete; // stop default
 };
 
 

--- a/FWCore/FWLite/src/BareRootProductGetter.h
+++ b/FWCore/FWLite/src/BareRootProductGetter.h
@@ -44,10 +44,10 @@ class BareRootProductGetter : public edm::EDProductGetter {
 
    public:
       BareRootProductGetter();
-      virtual ~BareRootProductGetter();
+      ~BareRootProductGetter() override;
 
       // ---------- const member functions ---------------------
-      virtual edm::WrapperBase const* getIt(edm::ProductID const&) const override;
+      edm::WrapperBase const* getIt(edm::ProductID const&) const override;
 
      // getThinnedProduct assumes getIt was already called and failed to find
      // the product. The input key is the index of the desired element in the
@@ -56,7 +56,7 @@ class BareRootProductGetter : public edm::EDProductGetter {
      // in a thinned container and key is modified to be the index into
      // that thinned container. If the desired element is not found, then
      // nullptr is returned.
-      virtual edm::WrapperBase const* getThinnedProduct(edm::ProductID const&,
+      edm::WrapperBase const* getThinnedProduct(edm::ProductID const&,
                                                         unsigned int& key) const override;
 
      // getThinnedProducts assumes getIt was already called and failed to find
@@ -70,7 +70,7 @@ class BareRootProductGetter : public edm::EDProductGetter {
      // is modified to be the key into the container where the element
      // was found. The WrapperBase pointers might or might not all point
      // to the same thinned container.
-      virtual void getThinnedProducts(edm::ProductID const&,
+      void getThinnedProducts(edm::ProductID const&,
                                       std::vector<edm::WrapperBase const*>& foundContainers,
                                       std::vector<unsigned int>& keys) const override;
 
@@ -79,7 +79,7 @@ class BareRootProductGetter : public edm::EDProductGetter {
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------
-      virtual unsigned int transitionIndex_() const override {
+      unsigned int transitionIndex_() const override {
         return 0u;
       }
 
@@ -99,9 +99,9 @@ class BareRootProductGetter : public edm::EDProductGetter {
         edm::propagate_const<TClass*> class_;
       };
 
-      BareRootProductGetter(BareRootProductGetter const&); // stop default
+      BareRootProductGetter(BareRootProductGetter const&) = delete; // stop default
 
-      BareRootProductGetter const& operator=(BareRootProductGetter const&); // stop default
+      BareRootProductGetter const& operator=(BareRootProductGetter const&) = delete; // stop default
 
       Buffer* createNewBuffer(edm::BranchID const&) const;
       edm::ThinnedAssociation const* getThinnedAssociation(edm::BranchID const& branchID, Long_t eventEntry) const;

--- a/FWCore/FWLite/src/BranchMapReader.cc
+++ b/FWCore/FWLite/src/BranchMapReader.cc
@@ -54,23 +54,23 @@ namespace fwlite {
       typedef std::map<edm::BranchID, edm::BranchDescription> bidToDesc;
 
       Strategy(TFile* file, int fileVersion);
-      virtual ~Strategy();
-      virtual bool updateFile(TFile* file) override;
-      virtual bool updateEvent(Long_t eventEntry) override { eventEntry_ = eventEntry; return true; }
-      virtual bool updateLuminosityBlock(Long_t luminosityBlockEntry) override {
+      ~Strategy() override;
+      bool updateFile(TFile* file) override;
+      bool updateEvent(Long_t eventEntry) override { eventEntry_ = eventEntry; return true; }
+      bool updateLuminosityBlock(Long_t luminosityBlockEntry) override {
         luminosityBlockEntry_ = luminosityBlockEntry;
         return true;
       }
-      virtual bool updateRun(Long_t runEntry) override {
+      bool updateRun(Long_t runEntry) override {
         runEntry_ = runEntry;
         return true;
       }
-      virtual bool updateMap() override { return true; }
-      virtual edm::BranchID productToBranchID(edm::ProductID const& pid) override;
-      virtual edm::BranchDescription const& productToBranch(edm::ProductID const& pid) override;
-      virtual edm::BranchDescription const& branchIDToBranch(edm::BranchID const& bid) const override;
-      virtual std::vector<edm::BranchDescription> const& getBranchDescriptions() override;
-      virtual edm::ThinnedAssociationsHelper const& thinnedAssociationsHelper() const override { return *thinnedAssociationsHelper_; }
+      bool updateMap() override { return true; }
+      edm::BranchID productToBranchID(edm::ProductID const& pid) override;
+      edm::BranchDescription const& productToBranch(edm::ProductID const& pid) override;
+      edm::BranchDescription const& branchIDToBranch(edm::BranchID const& bid) const override;
+      std::vector<edm::BranchDescription> const& getBranchDescriptions() override;
+      edm::ThinnedAssociationsHelper const& thinnedAssociationsHelper() const override { return *thinnedAssociationsHelper_; }
 
       TBranch* getBranchRegistry(edm::ProductRegistry** pReg);
 
@@ -150,9 +150,9 @@ namespace fwlite {
     class BranchMapReaderStrategyV1 : public Strategy {
     public:
       BranchMapReaderStrategyV1(TFile* file, int fileVersion);
-      virtual bool updateFile(TFile* file) override;
-      virtual bool updateMap() override;
-      virtual edm::BranchListIndexes const& branchListIndexes() const override {return dummyBranchListIndexes_;}
+      bool updateFile(TFile* file) override;
+      bool updateMap() override;
+      edm::BranchListIndexes const& branchListIndexes() const override {return dummyBranchListIndexes_;}
     private:
       edm::BranchListIndexes dummyBranchListIndexes_;
     };
@@ -203,7 +203,7 @@ namespace fwlite {
     class BranchMapReaderStrategyV7 : public BranchMapReaderStrategyV1 {
     public:
       BranchMapReaderStrategyV7(TFile* file, int fileVersion);
-      virtual edm::BranchListIndexes const& branchListIndexes() const override {return dummyBranchListIndexes_;}
+      edm::BranchListIndexes const& branchListIndexes() const override {return dummyBranchListIndexes_;}
     private:
       edm::BranchListIndexes dummyBranchListIndexes_;
     };
@@ -216,12 +216,12 @@ namespace fwlite {
     class BranchMapReaderStrategyV8 : public Strategy {
     public:
       BranchMapReaderStrategyV8(TFile* file, int fileVersion);
-      virtual bool updateFile(TFile* file) override;
-      virtual bool updateEvent(Long_t eventEntry) override;
-      virtual bool updateLuminosityBlock(Long_t luminosityBlockEntry) override;
-      virtual bool updateRun(Long_t runEntry) override;
-      virtual bool updateMap() override;
-      virtual edm::BranchListIndexes const& branchListIndexes() const override {return dummyBranchListIndexes_;}
+      bool updateFile(TFile* file) override;
+      bool updateEvent(Long_t eventEntry) override;
+      bool updateLuminosityBlock(Long_t luminosityBlockEntry) override;
+      bool updateRun(Long_t runEntry) override;
+      bool updateMap() override;
+      edm::BranchListIndexes const& branchListIndexes() const override {return dummyBranchListIndexes_;}
     private:
       edm::propagate_const<TBranch*> entryInfoBranch_;
       edm::EventEntryInfoVector  eventEntryInfoVector_;
@@ -316,13 +316,13 @@ namespace fwlite {
     class BranchMapReaderStrategyV11 : public Strategy {
     public:
       BranchMapReaderStrategyV11(TFile* file, int fileVersion);
-      virtual bool updateFile(TFile* file) override;
-      virtual bool updateEvent(Long_t eventEntry) override;
-      virtual bool updateLuminosityBlock(Long_t luminosityBlockEntry) override;
-      virtual bool updateRun(Long_t runEntry) override;
-      virtual bool updateMap() override;
-      virtual edm::BranchID productToBranchID(edm::ProductID const& pid) override;
-      virtual edm::BranchListIndexes const& branchListIndexes() const override {return history_.branchListIndexes();}
+      bool updateFile(TFile* file) override;
+      bool updateEvent(Long_t eventEntry) override;
+      bool updateLuminosityBlock(Long_t luminosityBlockEntry) override;
+      bool updateRun(Long_t runEntry) override;
+      bool updateMap() override;
+      edm::BranchID productToBranchID(edm::ProductID const& pid) override;
+      edm::BranchListIndexes const& branchListIndexes() const override {return history_.branchListIndexes();}
     private:
       edm::propagate_const<std::unique_ptr<edm::BranchIDLists>> branchIDLists_;
       edm::propagate_const<TTree*> eventHistoryTree_;
@@ -371,7 +371,7 @@ namespace fwlite {
       }
       branchIDLists_ = std::make_unique<edm::BranchIDLists>();
       edm::BranchIDLists* branchIDListsPtr = branchIDLists_.get();
-      if(metaDataTree->FindBranch(edm::poolNames::branchIDListBranchName().c_str()) != 0) {
+      if(metaDataTree->FindBranch(edm::poolNames::branchIDListBranchName().c_str()) != nullptr) {
         TBranch* b = metaDataTree->GetBranch(edm::poolNames::branchIDListBranchName().c_str());
         b->SetAddress(&branchIDListsPtr);
         b->GetEntry(0);
@@ -433,13 +433,13 @@ namespace fwlite {
     class BranchMapReaderStrategyV17 : public Strategy {
     public:
       BranchMapReaderStrategyV17(TFile* file, int fileVersion);
-      virtual bool updateFile(TFile* file) override;
-      virtual bool updateEvent(Long_t eventEntry) override;
-      virtual bool updateLuminosityBlock(Long_t luminosityBlockEntry) override;
-      virtual bool updateRun(Long_t runEntry) override;
-      virtual bool updateMap() override;
-      virtual edm::BranchID productToBranchID(edm::ProductID const& pid) override;
-      virtual edm::BranchListIndexes const& branchListIndexes() const override {return branchListIndexes_;}
+      bool updateFile(TFile* file) override;
+      bool updateEvent(Long_t eventEntry) override;
+      bool updateLuminosityBlock(Long_t luminosityBlockEntry) override;
+      bool updateRun(Long_t runEntry) override;
+      bool updateMap() override;
+      edm::BranchID productToBranchID(edm::ProductID const& pid) override;
+      edm::BranchListIndexes const& branchListIndexes() const override {return branchListIndexes_;}
     private:
       edm::propagate_const<std::unique_ptr<edm::BranchIDLists>> branchIDLists_;
       edm::propagate_const<TTree*> eventsTree_;
@@ -495,7 +495,7 @@ namespace fwlite {
 
       branchIDLists_ = std::make_unique<edm::BranchIDLists>();
       edm::BranchIDLists* branchIDListsPtr = branchIDLists_.get();
-      if(metaDataTree->FindBranch(edm::poolNames::branchIDListBranchName().c_str()) != 0) {
+      if(metaDataTree->FindBranch(edm::poolNames::branchIDListBranchName().c_str()) != nullptr) {
         TBranch* b = metaDataTree->GetBranch(edm::poolNames::branchIDListBranchName().c_str());
         b->SetAddress(&branchIDListsPtr);
         b->GetEntry(0);

--- a/FWCore/FWLite/src/branchToClass.cc
+++ b/FWCore/FWLite/src/branchToClass.cc
@@ -27,14 +27,14 @@ public:
   
 private:
   ///NOTE: do not call this, it is only here because ROOT demands it
-  BranchToClass();
+  BranchToClass() = delete;
 };
 
 TClass*
 BranchToClass::doit( const TBranch* iBranch )
 {
   TClass* contained = nullptr;
-  TClass* type = TVirtualBranchBrowsable::GetCollectionContainedType(iBranch,0,contained);
+  TClass* type = TVirtualBranchBrowsable::GetCollectionContainedType(iBranch,nullptr,contained);
   if( type == nullptr) {
     type = contained;
   }

--- a/FWCore/Framework/interface/Callback.h
+++ b/FWCore/Framework/interface/Callback.h
@@ -105,9 +105,9 @@ namespace edm {
          }
          
      private:
-         Callback(const Callback&); // stop default
+         Callback(const Callback&) = delete; // stop default
          
-         const Callback& operator=(const Callback&); // stop default
+         const Callback& operator=(const Callback&) = delete; // stop default
 
          std::vector<void*> proxyData_;
          edm::propagate_const<T*> producer_;

--- a/FWCore/Framework/interface/CallbackProxy.h
+++ b/FWCore/Framework/interface/CallbackProxy.h
@@ -48,7 +48,7 @@ namespace edm {
             //  hold onto a temporary copy of the result of the callback since the callback is allowed
             //  to return multiple items where only one item is needed by this Proxy
             iCallback->holdOntoPointer(&data_) ; }
-         virtual ~CallbackProxy() {
+         ~CallbackProxy() override {
             DataT* dummy(nullptr);
             callback_->holdOntoPointer(dummy) ;
          }
@@ -57,20 +57,20 @@ namespace edm {
          // ---------- static member functions --------------------
          
          // ---------- member functions ---------------------------
-         const void* getImpl(const EventSetupRecord& iRecord, const DataKey&) {
+         const void* getImpl(const EventSetupRecord& iRecord, const DataKey&) override {
             assert(iRecord.key() == RecordT::keyForClass());
             (*callback_)(static_cast<const record_type&>(iRecord));
             return &(*data_);
          }
          
-         void invalidateCache() {
+         void invalidateCache() override {
             data_ = DataT();
             callback_->newRecordComing();
          }
       private:
-         CallbackProxy(const CallbackProxy&); // stop default
+         CallbackProxy(const CallbackProxy&) = delete; // stop default
          
-         const CallbackProxy& operator=(const CallbackProxy&); // stop default
+         const CallbackProxy& operator=(const CallbackProxy&) = delete; // stop default
          
          // ---------- member data --------------------------------
          DataT data_;

--- a/FWCore/Framework/interface/ComponentMaker.h
+++ b/FWCore/Framework/interface/ComponentMaker.h
@@ -63,10 +63,10 @@ namespace edm {
    typedef typename T::base_type base_type;
 
       // ---------- const member functions ---------------------
-   virtual std::shared_ptr<base_type> addTo(EventSetupsController& esController,
+   std::shared_ptr<base_type> addTo(EventSetupsController& esController,
                                               EventSetupProvider& iProvider,
                                               ParameterSet const& iConfiguration,
-                                              bool replaceExisting) const;
+                                              bool replaceExisting) const override;
    
       // ---------- static member functions --------------------
 

--- a/FWCore/Framework/interface/DataProxy.h
+++ b/FWCore/Framework/interface/DataProxy.h
@@ -83,9 +83,9 @@ namespace edm {
 
          void clearCacheIsValid();
       private:
-         DataProxy(DataProxy const&); // stop default
+         DataProxy(DataProxy const&) = delete; // stop default
 
-         DataProxy const& operator=(DataProxy const&); // stop default
+         DataProxy const& operator=(DataProxy const&) = delete; // stop default
 
          // ---------- member data --------------------------------
          [[cms::thread_safe]] mutable void const* cache_; //protected by a global mutex

--- a/FWCore/Framework/interface/DependentRecordImplementation.h
+++ b/FWCore/Framework/interface/DependentRecordImplementation.h
@@ -76,9 +76,9 @@ class DependentRecordImplementation : public EventSetupRecordImplementation<Reco
       // ---------- member functions ---------------------------
 
    private:
-      DependentRecordImplementation(const DependentRecordImplementation&); // stop default
+      DependentRecordImplementation(const DependentRecordImplementation&) = delete; // stop default
 
-      const DependentRecordImplementation& operator=(const DependentRecordImplementation&); // stop default
+      const DependentRecordImplementation& operator=(const DependentRecordImplementation&) = delete; // stop default
 
       // ---------- member data --------------------------------
 

--- a/FWCore/Framework/interface/DependentRecordIntervalFinder.h
+++ b/FWCore/Framework/interface/DependentRecordIntervalFinder.h
@@ -38,7 +38,7 @@ class DependentRecordIntervalFinder : public EventSetupRecordIntervalFinder
 
    public:
       DependentRecordIntervalFinder(const EventSetupRecordKey&);
-      virtual ~DependentRecordIntervalFinder();
+      ~DependentRecordIntervalFinder() override;
 
       // ---------- const member functions ---------------------
       bool haveProviders() const {
@@ -52,14 +52,14 @@ class DependentRecordIntervalFinder : public EventSetupRecordIntervalFinder
       
       void setAlternateFinder(std::shared_ptr<EventSetupRecordIntervalFinder>);
    protected:
-      virtual void setIntervalFor(const EventSetupRecordKey&,
+      void setIntervalFor(const EventSetupRecordKey&,
                                    const IOVSyncValue& , 
-                                   ValidityInterval&);
+                                   ValidityInterval&) override;
       
    private:
-      DependentRecordIntervalFinder(const DependentRecordIntervalFinder&); // stop default
+      DependentRecordIntervalFinder(const DependentRecordIntervalFinder&) = delete; // stop default
 
-      const DependentRecordIntervalFinder& operator=(const DependentRecordIntervalFinder&); // stop default
+      const DependentRecordIntervalFinder& operator=(const DependentRecordIntervalFinder&) = delete; // stop default
 
       // ---------- member data --------------------------------
       typedef std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordProvider>>> Providers;

--- a/FWCore/Framework/interface/EDAnalyzer.h
+++ b/FWCore/Framework/interface/EDAnalyzer.h
@@ -31,7 +31,7 @@ namespace edm {
     typedef EDAnalyzer ModuleType;
 
     EDAnalyzer();
-    virtual ~EDAnalyzer();
+    ~EDAnalyzer() override;
     
     std::string workerType() const {return "WorkerT<EDAnalyzer>";}
 

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -42,7 +42,7 @@ namespace edm {
     typedef EDFilter ModuleType;
     
     EDFilter();
-    virtual ~EDFilter();
+    ~EDFilter() override;
 
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
     static void prevalidate(ConfigurationDescriptions& );

--- a/FWCore/Framework/interface/EDLooper.h
+++ b/FWCore/Framework/interface/EDLooper.h
@@ -29,7 +29,7 @@ namespace edm {
     public:
 
       EDLooper();
-      virtual ~EDLooper();
+      ~EDLooper() override;
 
       EDLooper(EDLooper const&) = delete; // Disallow copying and moving
       EDLooper& operator=(EDLooper const&) = delete; // Disallow copying and moving
@@ -42,7 +42,7 @@ namespace edm {
     
     /**override base class interface and just call the above duringLoop
      */
-    virtual Status duringLoop(const edm::Event&, const edm::EventSetup&, ProcessingController& );
+    Status duringLoop(const edm::Event&, const edm::EventSetup&, ProcessingController& ) override;
     
     
   };

--- a/FWCore/Framework/interface/ESPreFunctorDecorator.h
+++ b/FWCore/Framework/interface/ESPreFunctorDecorator.h
@@ -53,7 +53,7 @@ class ESPreFunctorDecorator
    private:
       //ESPreFunctorDecorator(const ESPreFunctorDecorator&); // stop default
 
-      const ESPreFunctorDecorator& operator=(const ESPreFunctorDecorator&); // stop default
+      const ESPreFunctorDecorator& operator=(const ESPreFunctorDecorator&) = delete; // stop default
 
       // ---------- member data --------------------------------
       TFunctor caller_;

--- a/FWCore/Framework/interface/ESProducer.h
+++ b/FWCore/Framework/interface/ESProducer.h
@@ -99,7 +99,7 @@ class ESProducer : public ESProxyFactoryProducer
 
    public:
       ESProducer();
-      virtual ~ESProducer() noexcept(false);
+      ~ESProducer() noexcept(false) override;
 
       // ---------- const member functions ---------------------
 
@@ -180,9 +180,9 @@ class ESProducer : public ESProxyFactoryProducer
          }
       */
    private:
-      ESProducer(const ESProducer&); // stop default
+      ESProducer(const ESProducer&) = delete; // stop default
 
-      ESProducer const& operator=(const ESProducer&); // stop default
+      ESProducer const& operator=(const ESProducer&) = delete; // stop default
 
       /*
       template<typename T, typename TProduct>

--- a/FWCore/Framework/interface/ESProducerLooper.h
+++ b/FWCore/Framework/interface/ESProducerLooper.h
@@ -41,22 +41,22 @@ namespace edm {
 
       // ---------- static member functions --------------------
 
-      virtual std::set<eventsetup::EventSetupRecordKey> modifyingRecords() const;
+      std::set<eventsetup::EventSetupRecordKey> modifyingRecords() const override;
       // ---------- member functions ---------------------------
 
    protected:
       void setIntervalFor(const eventsetup::EventSetupRecordKey& iKey,
                           const IOVSyncValue& iTime, 
-                          ValidityInterval& oInterval);
+                          ValidityInterval& oInterval) override;
         
       //use this to 'snoop' on what records are being used by the Producer
-      virtual void registerFactoryWithKey(const eventsetup::EventSetupRecordKey& iRecord ,
+      void registerFactoryWithKey(const eventsetup::EventSetupRecordKey& iRecord ,
                                           std::unique_ptr<eventsetup::ProxyFactoryBase> iFactory,
-                                          const std::string& iLabel= std::string() );
+                                          const std::string& iLabel= std::string() ) override;
 private:
-      ESProducerLooper(const ESProducerLooper&); // stop default
+      ESProducerLooper(const ESProducerLooper&) = delete; // stop default
 
-      const ESProducerLooper& operator=(const ESProducerLooper&); // stop default
+      const ESProducerLooper& operator=(const ESProducerLooper&) = delete; // stop default
 
       // ---------- member data --------------------------------
 

--- a/FWCore/Framework/interface/ESProxyFactoryProducer.h
+++ b/FWCore/Framework/interface/ESProxyFactoryProducer.h
@@ -81,7 +81,7 @@ class ESProxyFactoryProducer : public eventsetup::DataProxyProvider
 
    public:
       ESProxyFactoryProducer();
-      virtual ~ESProxyFactoryProducer() noexcept(false);
+      ~ESProxyFactoryProducer() noexcept(false) override;
 
       // ---------- const member functions ---------------------
 
@@ -89,13 +89,13 @@ class ESProxyFactoryProducer : public eventsetup::DataProxyProvider
 
       // ---------- member functions ---------------------------
       ///overrides DataProxyProvider method
-      virtual void newInterval(const eventsetup::EventSetupRecordKey& iRecordType,
-                                const ValidityInterval& iInterval) ;
+      void newInterval(const eventsetup::EventSetupRecordKey& iRecordType,
+                                const ValidityInterval& iInterval) override ;
 
    protected:
       ///override DataProxyProvider method
-      virtual void registerProxies(const eventsetup::EventSetupRecordKey& iRecord ,
-                                    KeyedProxies& aProxyList) ;
+      void registerProxies(const eventsetup::EventSetupRecordKey& iRecord ,
+                                    KeyedProxies& aProxyList) override ;
 
       /** \param iFactory unique_ptr holding a new instance of a Factory
          \param iLabel extra string label used to get data (optional)
@@ -118,9 +118,9 @@ class ESProxyFactoryProducer : public eventsetup::DataProxyProvider
                                           const std::string& iLabel= std::string() );
 
    private:
-      ESProxyFactoryProducer(const ESProxyFactoryProducer&); // stop default
+      ESProxyFactoryProducer(const ESProxyFactoryProducer&) = delete; // stop default
 
-      const ESProxyFactoryProducer& operator=(const ESProxyFactoryProducer&); // stop default
+      const ESProxyFactoryProducer& operator=(const ESProxyFactoryProducer&) = delete; // stop default
 
       
       // ---------- member data --------------------------------

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -129,9 +129,9 @@ class EventSetup
    private:
       EventSetup();
       
-      EventSetup(EventSetup const&); // stop default
+      EventSetup(EventSetup const&) = delete; // stop default
 
-      EventSetup const& operator=(EventSetup const&); // stop default
+      EventSetup const& operator=(EventSetup const&) = delete; // stop default
 
       void insert(const eventsetup::EventSetupRecordKey&,
                   const eventsetup::EventSetupRecord*);

--- a/FWCore/Framework/interface/EventSetupProvider.h
+++ b/FWCore/Framework/interface/EventSetupProvider.h
@@ -117,9 +117,9 @@ class EventSetupProvider {
          }
 
    private:
-      EventSetupProvider(EventSetupProvider const&); // stop default
+      EventSetupProvider(EventSetupProvider const&) = delete; // stop default
 
-      EventSetupProvider const& operator=(EventSetupProvider const&); // stop default
+      EventSetupProvider const& operator=(EventSetupProvider const&) = delete; // stop default
 
       void insert(EventSetupRecordKey const&, std::unique_ptr<EventSetupRecordProvider>);
 

--- a/FWCore/Framework/interface/EventSetupRecordImplementation.h
+++ b/FWCore/Framework/interface/EventSetupRecordImplementation.h
@@ -40,7 +40,7 @@ namespace edm {
          //virtual ~EventSetupRecordImplementation();
 
          // ---------- const member functions ---------------------
-         virtual EventSetupRecordKey key() const {
+         EventSetupRecordKey key() const override {
             return EventSetupRecordKey::makeKey<T>();
          }
 
@@ -55,9 +55,9 @@ namespace edm {
          EventSetupRecordImplementation() {}
 
       private:
-         EventSetupRecordImplementation(EventSetupRecordImplementation const&); // stop default
+         EventSetupRecordImplementation(EventSetupRecordImplementation const&) = delete; // stop default
 
-         EventSetupRecordImplementation const& operator=(EventSetupRecordImplementation const&); // stop default
+         EventSetupRecordImplementation const& operator=(EventSetupRecordImplementation const&) = delete; // stop default
 
          // ---------- member data --------------------------------
       };

--- a/FWCore/Framework/interface/EventSetupRecordIntervalFinder.h
+++ b/FWCore/Framework/interface/EventSetupRecordIntervalFinder.h
@@ -66,9 +66,9 @@ class EventSetupRecordIntervalFinder
       void findingRecordWithKey(const eventsetup::EventSetupRecordKey&);
       
 private:
-      EventSetupRecordIntervalFinder(const EventSetupRecordIntervalFinder&); // stop default
+      EventSetupRecordIntervalFinder(const EventSetupRecordIntervalFinder&) = delete; // stop default
 
-      const EventSetupRecordIntervalFinder& operator=(const EventSetupRecordIntervalFinder&); // stop default
+      const EventSetupRecordIntervalFinder& operator=(const EventSetupRecordIntervalFinder&) = delete; // stop default
 
       /** override this method if you need to delay setting what records you will be using until after all modules are loaded*/
       virtual void delaySettingRecords();

--- a/FWCore/Framework/interface/EventSetupRecordProvider.h
+++ b/FWCore/Framework/interface/EventSetupRecordProvider.h
@@ -121,9 +121,9 @@ class EventSetupRecordProvider {
       }
 
    private:
-      EventSetupRecordProvider(EventSetupRecordProvider const&); // stop default
+      EventSetupRecordProvider(EventSetupRecordProvider const&) = delete; // stop default
 
-      EventSetupRecordProvider const& operator=(EventSetupRecordProvider const&); // stop default
+      EventSetupRecordProvider const& operator=(EventSetupRecordProvider const&) = delete; // stop default
 
       void resetTransients();
       bool checkResetTransients();

--- a/FWCore/Framework/interface/EventSetupRecordProviderFactory.h
+++ b/FWCore/Framework/interface/EventSetupRecordProviderFactory.h
@@ -41,9 +41,9 @@ class EventSetupRecordProviderFactory
    protected:
       EventSetupRecordProviderFactory() {}
    private:
-      EventSetupRecordProviderFactory(const EventSetupRecordProviderFactory&); // stop default
+      EventSetupRecordProviderFactory(const EventSetupRecordProviderFactory&) = delete; // stop default
 
-      const EventSetupRecordProviderFactory& operator=(const EventSetupRecordProviderFactory&); // stop default
+      const EventSetupRecordProviderFactory& operator=(const EventSetupRecordProviderFactory&) = delete; // stop default
 
       // ---------- member data --------------------------------
 

--- a/FWCore/Framework/interface/EventSetupRecordProviderFactoryManager.h
+++ b/FWCore/Framework/interface/EventSetupRecordProviderFactoryManager.h
@@ -49,9 +49,9 @@ class EventSetupRecordProviderFactoryManager
 
    private:
       EventSetupRecordProviderFactoryManager();
-      EventSetupRecordProviderFactoryManager(const EventSetupRecordProviderFactoryManager&); // stop default
+      EventSetupRecordProviderFactoryManager(const EventSetupRecordProviderFactoryManager&) = delete; // stop default
 
-      const EventSetupRecordProviderFactoryManager& operator=(const EventSetupRecordProviderFactoryManager&); // stop default
+      const EventSetupRecordProviderFactoryManager& operator=(const EventSetupRecordProviderFactoryManager&) = delete; // stop default
 
       // ---------- member data --------------------------------
       std::map<EventSetupRecordKey, const EventSetupRecordProviderFactory*> factories_;

--- a/FWCore/Framework/interface/EventSetupRecordProviderFactoryTemplate.h
+++ b/FWCore/Framework/interface/EventSetupRecordProviderFactoryTemplate.h
@@ -44,7 +44,7 @@ class EventSetupRecordProviderFactoryTemplate : public EventSetupRecordProviderF
       //virtual ~EventSetupRecordProviderFactoryTemplate();
 
       // ---------- const member functions ---------------------
-      virtual std::unique_ptr<EventSetupRecordProvider> makeRecordProvider() const {
+      std::unique_ptr<EventSetupRecordProvider> makeRecordProvider() const override {
          return std::unique_ptr<EventSetupRecordProvider>(
                      new EventSetupRecordProviderTemplate<T>());
       }
@@ -54,9 +54,9 @@ class EventSetupRecordProviderFactoryTemplate : public EventSetupRecordProviderF
       // ---------- member functions ---------------------------
 
    private:
-      EventSetupRecordProviderFactoryTemplate(const EventSetupRecordProviderFactoryTemplate&); // stop default
+      EventSetupRecordProviderFactoryTemplate(const EventSetupRecordProviderFactoryTemplate&) = delete; // stop default
 
-      const EventSetupRecordProviderFactoryTemplate& operator=(const EventSetupRecordProviderFactoryTemplate&); // stop default
+      const EventSetupRecordProviderFactoryTemplate& operator=(const EventSetupRecordProviderFactoryTemplate&) = delete; // stop default
 
       // ---------- member data --------------------------------
 

--- a/FWCore/Framework/interface/EventSetupRecordProviderTemplate.h
+++ b/FWCore/Framework/interface/EventSetupRecordProviderTemplate.h
@@ -95,16 +95,16 @@ namespace edm {
          // ---------- static member functions --------------------
          
          // ---------- member functions ---------------------------
-         std::set<EventSetupRecordKey> dependentRecords() const {
+         std::set<EventSetupRecordKey> dependentRecords() const override {
             return findDependentRecordsFor<T>();
          }
       protected:
-         EventSetupRecord& record() { return record_; }
+         EventSetupRecord& record() override { return record_; }
          
       private:
-         EventSetupRecordProviderTemplate(EventSetupRecordProviderTemplate const&); // stop default
+         EventSetupRecordProviderTemplate(EventSetupRecordProviderTemplate const&) = delete; // stop default
          
-         EventSetupRecordProviderTemplate const& operator=(EventSetupRecordProviderTemplate const&); // stop default
+         EventSetupRecordProviderTemplate const& operator=(EventSetupRecordProviderTemplate const&) = delete; // stop default
          
          // ---------- member data --------------------------------
          T record_;

--- a/FWCore/Framework/interface/GenericHandle.h
+++ b/FWCore/Framework/interface/GenericHandle.h
@@ -96,7 +96,7 @@ public:
    }
    
    bool isValid() const {
-      return prod_ && 0!= prov_;
+      return prod_ && nullptr!= prov_;
    }
 
    bool failedToGet() const {
@@ -116,7 +116,7 @@ public:
    
    ProductID id() const {return prov_->productID();}
 
-   void clear() { prov_ = 0; whyFailedFactory_=nullptr;}
+   void clear() { prov_ = nullptr; whyFailedFactory_=nullptr;}
       
   void setWhyFailedFactory(std::shared_ptr<HandleExceptionFactory> const& iWhyFailed) {
     whyFailedFactory_=iWhyFailed;

--- a/FWCore/Framework/interface/LuminosityBlockForOutput.h
+++ b/FWCore/Framework/interface/LuminosityBlockForOutput.h
@@ -40,7 +40,7 @@ namespace edm {
   public:
     LuminosityBlockForOutput(LuminosityBlockPrincipal const& lbp, ModuleDescription const& md,
                     ModuleCallingContext const*);
-    ~LuminosityBlockForOutput();
+    ~LuminosityBlockForOutput() override;
 
     LuminosityBlockAuxiliary const& luminosityBlockAuxiliary() const {return aux_;}
     LuminosityBlockID const& id() const {return aux_.id();}

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -56,7 +56,7 @@ namespace edm {
     typedef OutputModule ModuleType;
 
     explicit OutputModule(ParameterSet const& pset);
-    virtual ~OutputModule();
+    ~OutputModule() override;
 
     OutputModule(OutputModule const&) = delete; // Disallow copying and moving
     OutputModule& operator=(OutputModule const&) = delete; // Disallow copying and moving

--- a/FWCore/Framework/interface/ProcessingController.h
+++ b/FWCore/Framework/interface/ProcessingController.h
@@ -91,9 +91,9 @@ namespace edm {
       void setLastOperationSucceeded(bool value);
 
    private:
-      ProcessingController(const ProcessingController&); // stop default
+      ProcessingController(const ProcessingController&) = delete; // stop default
       
-      const ProcessingController& operator=(const ProcessingController&); // stop default
+      const ProcessingController& operator=(const ProcessingController&) = delete; // stop default
       
       // ---------- member data --------------------------------
       ForwardState forwardState_;

--- a/FWCore/Framework/interface/ProxyArgumentFactoryTemplate.h
+++ b/FWCore/Framework/interface/ProxyArgumentFactoryTemplate.h
@@ -41,11 +41,11 @@ class ProxyArgumentFactoryTemplate : public ProxyFactoryBase
       //virtual ~ProxyArgumentFactoryTemplate()
 
       // ---------- const member functions ---------------------
-      virtual std::unique_ptr<DataProxy> makeProxy() const {
+      std::unique_ptr<DataProxy> makeProxy() const override {
          return std::make_unique<T>(arg_);
       }
             
-      virtual DataKey makeKey(const std::string& iName) const {
+      DataKey makeKey(const std::string& iName) const override {
          return DataKey(DataKey::makeTypeTag< typename T::value_type>(),iName.c_str());
       }
       
@@ -54,9 +54,9 @@ class ProxyArgumentFactoryTemplate : public ProxyFactoryBase
       // ---------- member functions ---------------------------
 
    private:
-      ProxyArgumentFactoryTemplate(const ProxyArgumentFactoryTemplate&); // stop default
+      ProxyArgumentFactoryTemplate(const ProxyArgumentFactoryTemplate&) = delete; // stop default
 
-      const ProxyArgumentFactoryTemplate& operator=(const ProxyArgumentFactoryTemplate&); // stop default
+      const ProxyArgumentFactoryTemplate& operator=(const ProxyArgumentFactoryTemplate&) = delete; // stop default
 
       // ---------- member data --------------------------------
       mutable ArgT arg_;

--- a/FWCore/Framework/interface/ProxyFactoryBase.h
+++ b/FWCore/Framework/interface/ProxyFactoryBase.h
@@ -45,9 +45,9 @@ class ProxyFactoryBase
       // ---------- member functions ---------------------------
 
    private:
-      ProxyFactoryBase(const ProxyFactoryBase&); // stop default
+      ProxyFactoryBase(const ProxyFactoryBase&) = delete; // stop default
 
-      const ProxyFactoryBase& operator=(const ProxyFactoryBase&); // stop default
+      const ProxyFactoryBase& operator=(const ProxyFactoryBase&) = delete; // stop default
 
       // ---------- member data --------------------------------
 

--- a/FWCore/Framework/interface/RunForOutput.h
+++ b/FWCore/Framework/interface/RunForOutput.h
@@ -39,7 +39,7 @@ namespace edm {
   public:
     RunForOutput(RunPrincipal const& rp, ModuleDescription const& md,
         ModuleCallingContext const*);
-    ~RunForOutput();
+    ~RunForOutput() override;
 
     RunAuxiliary const& runAuxiliary() const {return aux_;}
     RunID const& id() const {return aux_.id();}

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -52,7 +52,7 @@ namespace edm {
       typedef EDAnalyzerBase ModuleType;
 
       EDAnalyzerBase();
-      virtual ~EDAnalyzerBase();
+      ~EDAnalyzerBase() override;
 
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
       static void prevalidate(ConfigurationDescriptions& descriptions);

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -54,7 +54,7 @@ namespace edm {
       typedef EDFilterBase ModuleType;
 
       EDFilterBase();
-      virtual ~EDFilterBase();
+      ~EDFilterBase() override;
 
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
       static void prevalidate(ConfigurationDescriptions& descriptions);

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -57,7 +57,7 @@ namespace edm {
       friend class edm::GlobalSchedule;
 
       EDProducerBase();
-      virtual ~EDProducerBase();
+      ~EDProducerBase() override;
 
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
       static void prevalidate(ConfigurationDescriptions& descriptions);

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -66,7 +66,7 @@ namespace edm {
       typedef OutputModuleBase ModuleType;
       
       explicit OutputModuleBase(ParameterSet const& pset);
-      virtual ~OutputModuleBase();
+      ~OutputModuleBase() override;
       
       OutputModuleBase(OutputModuleBase const&) = delete; // Disallow copying and moving
       OutputModuleBase& operator=(OutputModuleBase const&) = delete; // Disallow copying and moving

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -51,27 +51,27 @@ namespace edm {
       protected:
         C * streamCache(edm::StreamID iID) const { return caches_[iID.value()]; }
       private:
-        virtual void preallocStreams(unsigned int iNStreams) override final {
+        void preallocStreams(unsigned int iNStreams) final {
           caches_.resize(iNStreams,static_cast<C*>(nullptr));
         }
-        virtual void doBeginStream_(StreamID id) override final {
+        void doBeginStream_(StreamID id) final {
           caches_[id.value()] = beginStream(id).release();
         }
-        virtual void doEndStream_(StreamID id) override final {
+        void doEndStream_(StreamID id) final {
           endStream(id);
           delete caches_[id.value()];
           caches_[id.value()]=nullptr;
         }
-        virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) override final {
+        void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) final {
           streamBeginRun(id,rp,c);
         }
-        virtual void doStreamEndRun_(StreamID id, Run const& rp, EventSetup const& c) override final {
+        void doStreamEndRun_(StreamID id, Run const& rp, EventSetup const& c) final {
           streamEndRun(id,rp,c);
         }
-        virtual void doStreamBeginLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) override final {
+        void doStreamBeginLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) final {
           streamBeginLuminosityBlock(id,lbp,c);
         }
-        virtual void doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) override final {
+        void doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) final {
           streamEndLuminosityBlock(id,lbp,c);
         }
 
@@ -96,10 +96,10 @@ namespace edm {
       protected:
         C const* runCache(edm::RunIndex iID) const { return cache_.get(); }
       private:
-        void doBeginRun_(Run const& rp, EventSetup const& c) override final {
+        void doBeginRun_(Run const& rp, EventSetup const& c) final {
           cache_ = globalBeginRun(rp,c);
         }
-        void doEndRun_(Run const& rp, EventSetup const& c) override final {
+        void doEndRun_(Run const& rp, EventSetup const& c) final {
           globalEndRun(rp,c);
           cache_ = nullptr; // propagate_const<T> has no reset() function
         }
@@ -120,10 +120,10 @@ namespace edm {
       protected:
         C const* luminosityBlockCache(edm::LuminosityBlockIndex iID) const { return cache_.get(); }
       private:
-        void doBeginLuminosityBlock_(LuminosityBlock const& rp, EventSetup const& c) override final {
+        void doBeginLuminosityBlock_(LuminosityBlock const& rp, EventSetup const& c) final {
           cache_ = globalBeginLuminosityBlock(rp,c);
         }
-        void doEndLuminosityBlock_(LuminosityBlock const& rp, EventSetup const& c) override final {
+        void doEndLuminosityBlock_(LuminosityBlock const& rp, EventSetup const& c) final {
           globalEndLuminosityBlock(rp,c);
           cache_.reset();
         }
@@ -145,15 +145,15 @@ namespace edm {
         ~RunSummaryCacheHolder() noexcept(false) {};
       private:
         friend class EndRunSummaryProducer<T,C>;
-        void doBeginRunSummary_(edm::Run const& rp, EventSetup const& c) override final {
+        void doBeginRunSummary_(edm::Run const& rp, EventSetup const& c) final {
           cache_ = globalBeginRunSummary(rp,c);
         }
-        void doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c) override final {
+        void doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c) final {
           //NOTE: in future this will need to be serialized
           std::lock_guard<std::mutex> guard(mutex_);
           streamEndRunSummary(id,rp,c,cache_.get());
         }
-        void doEndRunSummary_(Run const& rp, EventSetup const& c) override final {
+        void doEndRunSummary_(Run const& rp, EventSetup const& c) final {
           globalEndRunSummary(rp,c,cache_.get());
         }
 
@@ -180,16 +180,16 @@ namespace edm {
       private:
         friend class EndLuminosityBlockSummaryProducer<T,C>;
         
-        void doBeginLuminosityBlockSummary_(edm::LuminosityBlock const& lb, EventSetup const& c) override final {
+        void doBeginLuminosityBlockSummary_(edm::LuminosityBlock const& lb, EventSetup const& c) final {
           cache_ = globalBeginLuminosityBlockSummary(lb,c);
         }
 
-        virtual void doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lb, EventSetup const& c) override final
+        void doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lb, EventSetup const& c) final
         {
           std::lock_guard<std::mutex> guard(mutex_);
           streamEndLuminosityBlockSummary(id,lb,c,cache_.get());
         }
-        void doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c) override final {
+        void doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c) final {
           globalEndLuminosityBlockSummary(lb,c,cache_.get());
         }
 
@@ -210,10 +210,10 @@ namespace edm {
         BeginRunProducer() = default;
         BeginRunProducer( BeginRunProducer const&) = delete;
         BeginRunProducer& operator=(BeginRunProducer const&) = delete;
-        ~BeginRunProducer() noexcept(false) {};
+        ~BeginRunProducer() noexcept(false) override {};
         
       private:
-        void doBeginRunProduce_(Run& rp, EventSetup const& c) override final;
+        void doBeginRunProduce_(Run& rp, EventSetup const& c) final;
         
         virtual void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const = 0;
       };
@@ -224,11 +224,11 @@ namespace edm {
         EndRunProducer() = default;
         EndRunProducer( EndRunProducer const&) = delete;
         EndRunProducer& operator=(EndRunProducer const&) = delete;
-        ~EndRunProducer() noexcept(false) {};
+        ~EndRunProducer() noexcept(false) override {};
         
       private:
         
-        void doEndRunProduce_(Run& rp, EventSetup const& c) override final;
+        void doEndRunProduce_(Run& rp, EventSetup const& c) final;
         
         virtual void globalEndRunProduce(edm::Run&, edm::EventSetup const&) const = 0;
       };
@@ -243,7 +243,7 @@ namespace edm {
         
       private:
         
-        void doEndRunProduce_(Run& rp, EventSetup const& c) override final {
+        void doEndRunProduce_(Run& rp, EventSetup const& c) final {
           globalEndRunProduce(rp,c,RunSummaryCacheHolder<T,C>::cache_.get());
         }
         
@@ -256,10 +256,10 @@ namespace edm {
         BeginLuminosityBlockProducer() = default;
         BeginLuminosityBlockProducer( BeginLuminosityBlockProducer const&) = delete;
         BeginLuminosityBlockProducer& operator=(BeginLuminosityBlockProducer const&) = delete;
-        ~BeginLuminosityBlockProducer() noexcept(false) {};
+        ~BeginLuminosityBlockProducer() noexcept(false) override {};
         
       private:
-        void doBeginLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) override final;
+        void doBeginLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) final;
         virtual void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const = 0;
       };
       
@@ -269,10 +269,10 @@ namespace edm {
         EndLuminosityBlockProducer() = default;
         EndLuminosityBlockProducer( EndLuminosityBlockProducer const&) = delete;
         EndLuminosityBlockProducer& operator=(EndLuminosityBlockProducer const&) = delete;
-        ~EndLuminosityBlockProducer() noexcept(false) {};
+        ~EndLuminosityBlockProducer() noexcept(false) override {};
         
       private:
-        void doEndLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) override final;
+        void doEndLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) final;
         virtual void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const = 0;
       };
 
@@ -285,7 +285,7 @@ namespace edm {
         ~EndLuminosityBlockSummaryProducer() noexcept(false) {};
         
       private:
-        void doEndLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) override final {
+        void doEndLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) final {
           globalEndLuminosityBlockProduce(lb,c,LuminosityBlockSummaryCacheHolder<T,S>::cache_.get());
         }
         

--- a/FWCore/Framework/interface/global/outputmoduleAbilityToImplementor.h
+++ b/FWCore/Framework/interface/global/outputmoduleAbilityToImplementor.h
@@ -36,11 +36,11 @@ namespace edm {
         InputFileWatcher(edm::ParameterSet const&iPSet): OutputModuleBase(iPSet) {}
         InputFileWatcher(InputFileWatcher const&) = delete;
         InputFileWatcher& operator=(InputFileWatcher const&) = delete;
-        ~InputFileWatcher() noexcept(false) {};
+        ~InputFileWatcher() noexcept(false) override {};
         
       private:
-        void doRespondToOpenInputFile_(FileBlock const&) override final;
-        void doRespondToCloseInputFile_(FileBlock const&) override final;
+        void doRespondToOpenInputFile_(FileBlock const&) final;
+        void doRespondToCloseInputFile_(FileBlock const&) final;
         
         virtual void respondToOpenInputFile(FileBlock const&) = 0;
         virtual void respondToCloseInputFile(FileBlock const&) = 0;

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -54,7 +54,7 @@ namespace edm {
 
       
       EDAnalyzerBase();
-      virtual ~EDAnalyzerBase();
+      ~EDAnalyzerBase() override;
       
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
       static void prevalidate(ConfigurationDescriptions& descriptions);

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -54,7 +54,7 @@ namespace edm {
 
       
       EDFilterBase();
-      virtual ~EDFilterBase();
+      ~EDFilterBase() override;
       
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
       static void prevalidate(ConfigurationDescriptions& descriptions);

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -54,7 +54,7 @@ namespace edm {
 
       
       EDProducerBase();
-      virtual ~EDProducerBase();
+      ~EDProducerBase() override;
       
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
       static void prevalidate(ConfigurationDescriptions& descriptions);

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -69,7 +69,7 @@ namespace edm {
       typedef OutputModuleBase ModuleType;
       
       explicit OutputModuleBase(ParameterSet const& pset);
-      virtual ~OutputModuleBase();
+      ~OutputModuleBase() override;
       
       OutputModuleBase(OutputModuleBase const&) = delete; // Disallow copying and moving
       OutputModuleBase& operator=(OutputModuleBase const&) = delete; // Disallow copying and moving

--- a/FWCore/Framework/interface/one/implementors.h
+++ b/FWCore/Framework/interface/one/implementors.h
@@ -41,7 +41,7 @@ namespace edm {
             SharedResourcesUser(SharedResourcesUser const&) = delete;
             SharedResourcesUser& operator=(SharedResourcesUser const&) = delete;
             
-            virtual ~SharedResourcesUser() {}
+            ~SharedResourcesUser() override {}
             
          protected:
             
@@ -58,11 +58,11 @@ namespace edm {
             RunWatcher() = default;
             RunWatcher(RunWatcher const&) = delete;
             RunWatcher& operator=(RunWatcher const&) = delete;
-            ~RunWatcher() noexcept(false) {};
+            ~RunWatcher() noexcept(false) override {};
             
          private:
-            void doBeginRun_(Run const& rp, EventSetup const& c) override final;
-            void doEndRun_(Run const& rp, EventSetup const& c) override final;
+            void doBeginRun_(Run const& rp, EventSetup const& c) final;
+            void doEndRun_(Run const& rp, EventSetup const& c) final;
 
             
             virtual void beginRun(edm::Run const&, edm::EventSetup const&) = 0;
@@ -75,11 +75,11 @@ namespace edm {
             LuminosityBlockWatcher() = default;
             LuminosityBlockWatcher(LuminosityBlockWatcher const&) = delete;
             LuminosityBlockWatcher& operator=(LuminosityBlockWatcher const&) = delete;
-            ~LuminosityBlockWatcher() noexcept(false) {};
+            ~LuminosityBlockWatcher() noexcept(false) override {};
             
          private:
-            void doBeginLuminosityBlock_(LuminosityBlock const& rp, EventSetup const& c) override final;
-            void doEndLuminosityBlock_(LuminosityBlock const& rp, EventSetup const& c) override final;
+            void doBeginLuminosityBlock_(LuminosityBlock const& rp, EventSetup const& c) final;
+            void doEndLuminosityBlock_(LuminosityBlock const& rp, EventSetup const& c) final;
 
             virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) = 0;
             virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) = 0;
@@ -91,10 +91,10 @@ namespace edm {
             BeginRunProducer() = default;
             BeginRunProducer( BeginRunProducer const&) = delete;
             BeginRunProducer& operator=(BeginRunProducer const&) = delete;
-            ~BeginRunProducer() noexcept(false) {};
+            ~BeginRunProducer() noexcept(false) override {};
             
          private:
-            void doBeginRunProduce_(Run& rp, EventSetup const& c) override final;
+            void doBeginRunProduce_(Run& rp, EventSetup const& c) final;
 
             virtual void beginRunProduce(edm::Run&, edm::EventSetup const&) = 0;
          };
@@ -105,11 +105,11 @@ namespace edm {
             EndRunProducer() = default;
             EndRunProducer( EndRunProducer const&) = delete;
             EndRunProducer& operator=(EndRunProducer const&) = delete;
-            ~EndRunProducer() noexcept(false) {};
+            ~EndRunProducer() noexcept(false) override {};
             
          private:
             
-            void doEndRunProduce_(Run& rp, EventSetup const& c) override final;
+            void doEndRunProduce_(Run& rp, EventSetup const& c) final;
 
             virtual void endRunProduce(edm::Run&, edm::EventSetup const&) = 0;
          };
@@ -120,10 +120,10 @@ namespace edm {
             BeginLuminosityBlockProducer() = default;
             BeginLuminosityBlockProducer( BeginLuminosityBlockProducer const&) = delete;
             BeginLuminosityBlockProducer& operator=(BeginLuminosityBlockProducer const&) = delete;
-            ~BeginLuminosityBlockProducer() noexcept(false) {};
+            ~BeginLuminosityBlockProducer() noexcept(false) override {};
             
          private:
-            void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) override final;
+            void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) final;
 
             virtual void beginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) = 0;
          };
@@ -134,10 +134,10 @@ namespace edm {
             EndLuminosityBlockProducer() = default;
             EndLuminosityBlockProducer( EndLuminosityBlockProducer const&) = delete;
             EndLuminosityBlockProducer& operator=(EndLuminosityBlockProducer const&) = delete;
-            ~EndLuminosityBlockProducer() noexcept(false) {};
+            ~EndLuminosityBlockProducer() noexcept(false) override {};
             
          private:
-            void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) override final;
+            void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) final;
 
             virtual void endLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) = 0;
          };

--- a/FWCore/Framework/interface/one/outputmoduleAbilityToImplementor.h
+++ b/FWCore/Framework/interface/one/outputmoduleAbilityToImplementor.h
@@ -39,11 +39,11 @@ namespace edm {
         RunWatcher(edm::ParameterSet const&iPSet): OutputModuleBase(iPSet){}
         RunWatcher(RunWatcher const&) = delete;
         RunWatcher& operator=(RunWatcher const&) = delete;
-        ~RunWatcher() noexcept(false) {};
+        ~RunWatcher() noexcept(false) override {};
         
       private:
-        virtual void doBeginRun_(RunForOutput const& r) override final;
-        virtual void doEndRun_(RunForOutput const& r) override final;
+        void doBeginRun_(RunForOutput const& r) final;
+        void doEndRun_(RunForOutput const& r) final;
         
         virtual void beginRun(edm::RunForOutput const&) = 0;
         virtual void endRun(edm::RunForOutput const&) = 0;
@@ -54,11 +54,11 @@ namespace edm {
         LuminosityBlockWatcher(edm::ParameterSet const&iPSet): OutputModuleBase(iPSet) {}
         LuminosityBlockWatcher(LuminosityBlockWatcher const&) = delete;
         LuminosityBlockWatcher& operator=(LuminosityBlockWatcher const&) = delete;
-        ~LuminosityBlockWatcher() noexcept(false) {};
+        ~LuminosityBlockWatcher() noexcept(false) override {};
         
       private:
-        virtual void doBeginLuminosityBlock_(LuminosityBlockForOutput const& lb) override final;
-        virtual void doEndLuminosityBlock_(LuminosityBlockForOutput const& lb) override final;
+        void doBeginLuminosityBlock_(LuminosityBlockForOutput const& lb) final;
+        void doEndLuminosityBlock_(LuminosityBlockForOutput const& lb) final;
         
         virtual void beginLuminosityBlock(edm::LuminosityBlockForOutput const&) = 0;
         virtual void endLuminosityBlock(edm::LuminosityBlockForOutput const&) = 0;
@@ -69,11 +69,11 @@ namespace edm {
         InputFileWatcher(edm::ParameterSet const&iPSet): OutputModuleBase(iPSet) {}
         InputFileWatcher(InputFileWatcher const&) = delete;
         InputFileWatcher& operator=(InputFileWatcher const&) = delete;
-        ~InputFileWatcher() noexcept(false) {};
+        ~InputFileWatcher() noexcept(false) override {};
         
       private:
-        void doRespondToOpenInputFile_(FileBlock const&) override final;
-        void doRespondToCloseInputFile_(FileBlock const&) override final;
+        void doRespondToOpenInputFile_(FileBlock const&) final;
+        void doRespondToCloseInputFile_(FileBlock const&) final;
         
         virtual void respondToOpenInputFile(FileBlock const&) = 0;
         virtual void respondToCloseInputFile(FileBlock const&) = 0;

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
@@ -58,7 +58,7 @@ namespace edm {
         typename T::GlobalCache const* dummy=nullptr;
         m_global = impl::makeGlobal<T>(iPSet,dummy);
       }
-      ~EDAnalyzerAdaptor() {
+      ~EDAnalyzerAdaptor() override {
       }
       
       static void fillDescriptions(ConfigurationDescriptions& descriptions) {
@@ -76,7 +76,7 @@ namespace edm {
       typedef CallGlobalLuminosityBlock<T> MyGlobalLuminosityBlock;
       typedef CallGlobalLuminosityBlockSummary<T> MyGlobalLuminosityBlockSummary;
       
-      void setupStreamModules() override final {
+      void setupStreamModules() final {
         this->createStreamModules([this] () -> EDAnalyzerBase* {
           auto tmp = impl::makeStreamModule<T>(*m_pset,m_global.get());
           MyGlobal::set(tmp,m_global.get());
@@ -85,27 +85,27 @@ namespace edm {
         m_pset= nullptr;
       }
 
-      void doEndJob() override final {
+      void doEndJob() final {
         MyGlobal::endJob(m_global.get());
       }
-      void setupRun(EDAnalyzerBase* iProd, RunIndex iIndex) override final {
+      void setupRun(EDAnalyzerBase* iProd, RunIndex iIndex) final {
         MyGlobalRun::set(iProd, m_runs[iIndex].get());
       }
       void streamEndRunSummary(EDAnalyzerBase* iProd,
                                edm::Run const& iRun,
-                               edm::EventSetup const& iES) override final {
+                               edm::EventSetup const& iES) final {
         auto s = m_runSummaries[iRun.index()].get();
         std::lock_guard<decltype(m_runSummaryLock)> guard(m_runSummaryLock);
         MyGlobalRunSummary::streamEndRunSummary(iProd,iRun,iES,s);
       }
  
-      void setupLuminosityBlock(EDAnalyzerBase* iProd, LuminosityBlockIndex iIndex) override final
+      void setupLuminosityBlock(EDAnalyzerBase* iProd, LuminosityBlockIndex iIndex) final
       {
         MyGlobalLuminosityBlock::set(iProd, m_lumis[iIndex].get());
       }
       void streamEndLuminosityBlockSummary(EDAnalyzerBase* iProd,
                                            edm::LuminosityBlock const& iLumi,
-                                           edm::EventSetup const& iES) override final {
+                                           edm::EventSetup const& iES) final {
         auto s = m_lumiSummaries[iLumi.index()].get();
         std::lock_guard<decltype(m_lumiSummaryLock)> guard(m_lumiSummaryLock);
         MyGlobalLuminosityBlockSummary::streamEndLuminosityBlockSummary(iProd,iLumi,iES,s);
@@ -113,7 +113,7 @@ namespace edm {
 
       void doBeginRun(RunPrincipal const& rp,
                       EventSetup const& c,
-                      ModuleCallingContext const* mcc) override final {
+                      ModuleCallingContext const* mcc) final {
         if(T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache) {
           Run r(rp, moduleDescription(), mcc);
           r.setConsumer(consumer());
@@ -126,7 +126,7 @@ namespace edm {
       }
       void doEndRun(RunPrincipal const& rp,
                     EventSetup const& c,
-                    ModuleCallingContext const* mcc) override final
+                    ModuleCallingContext const* mcc) final
       {
         if(T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache) {
           
@@ -142,7 +142,7 @@ namespace edm {
 
       void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
                                   EventSetup const& c,
-                                  ModuleCallingContext const* mcc) override final
+                                  ModuleCallingContext const* mcc) final
       {
         if(T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache) {
           LuminosityBlock lb(lbp, moduleDescription(), mcc);
@@ -159,7 +159,7 @@ namespace edm {
       }
       void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
                                 EventSetup const& c,
-                                ModuleCallingContext const* mcc) override final {
+                                ModuleCallingContext const* mcc) final {
         if(T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache) {
           
           LuminosityBlock lb(lbp, moduleDescription(), mcc);
@@ -173,9 +173,9 @@ namespace edm {
         }
       }
 
-      EDAnalyzerAdaptor(const EDAnalyzerAdaptor&); // stop default
+      EDAnalyzerAdaptor(const EDAnalyzerAdaptor&) = delete; // stop default
       
-      const EDAnalyzerAdaptor& operator=(const EDAnalyzerAdaptor&); // stop default
+      const EDAnalyzerAdaptor& operator=(const EDAnalyzerAdaptor&) = delete; // stop default
       
       // ---------- member data --------------------------------
       typename impl::choose_unique_ptr<typename T::GlobalCache>::type m_global;

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -104,9 +104,9 @@ namespace edm {
       std::vector<ConsumesInfo> consumesInfo() const;
 
     private:
-      EDAnalyzerAdaptorBase(const EDAnalyzerAdaptorBase&); // stop default
+      EDAnalyzerAdaptorBase(const EDAnalyzerAdaptorBase&) = delete; // stop default
       
-      const EDAnalyzerAdaptorBase& operator=(const EDAnalyzerAdaptorBase&); // stop default
+      const EDAnalyzerAdaptorBase& operator=(const EDAnalyzerAdaptorBase&) = delete; // stop default
       
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,

--- a/FWCore/Framework/interface/stream/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerBase.h
@@ -42,7 +42,7 @@ namespace edm {
 
 
       EDAnalyzerBase();
-      virtual ~EDAnalyzerBase();
+      ~EDAnalyzerBase() override;
       
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
       static void prevalidate(ConfigurationDescriptions& descriptions);

--- a/FWCore/Framework/interface/stream/EDFilterBase.h
+++ b/FWCore/Framework/interface/stream/EDFilterBase.h
@@ -48,7 +48,7 @@ namespace edm {
 
 
       EDFilterBase();
-      virtual ~EDFilterBase();
+      ~EDFilterBase() override;
       
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
       static void prevalidate(ConfigurationDescriptions& descriptions);

--- a/FWCore/Framework/interface/stream/EDProducerBase.h
+++ b/FWCore/Framework/interface/stream/EDProducerBase.h
@@ -48,7 +48,7 @@ namespace edm {
       typedef EDProducerAdaptorBase ModuleType;
 
       EDProducerBase();
-      virtual ~EDProducerBase();
+      ~EDProducerBase() override;
       
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
       static void prevalidate(ConfigurationDescriptions& descriptions);

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
@@ -49,7 +49,7 @@ namespace edm {
         typename T::GlobalCache const* dummy=nullptr;
         m_global = impl::makeGlobal<T>(iPSet,dummy);
       }
-      ~ProducingModuleAdaptor() {
+      ~ProducingModuleAdaptor() override {
       }
       
       static void fillDescriptions(ConfigurationDescriptions& descriptions) {

--- a/FWCore/Framework/src/DataKey.cc
+++ b/FWCore/Framework/src/DataKey.cc
@@ -85,7 +85,7 @@ DataKey::swap(DataKey& iOther)
             }
             ArrayHolder(const char* iPtr): ptr_(iPtr) {}
             ~ArrayHolder() { delete [] ptr_; }
-            void release() { ptr_=0;}
+            void release() { ptr_=nullptr;}
          private:
             const char* ptr_;
          };

--- a/FWCore/Framework/src/DataProxy.cc
+++ b/FWCore/Framework/src/DataProxy.cc
@@ -74,7 +74,7 @@ DataProxy::~DataProxy()
 void DataProxy::clearCacheIsValid() {
    cacheIsValid_.store(false, std::memory_order_release);
    nonTransientAccessRequested_.store(false, std::memory_order_release);
-   cache_ = 0;
+   cache_ = nullptr;
 }
       
 void 
@@ -117,7 +117,7 @@ DataProxy::get(const EventSetupRecord& iRecord, const DataKey& iKey, bool iTrans
       nonTransientAccessRequested_.store(true, std::memory_order_release);
    }
 
-   if(0 == cache_) {
+   if(nullptr == cache_) {
       throwMakeException(iRecord, iKey);
    }
    return cache_;

--- a/FWCore/Framework/src/DataProxyProvider.cc
+++ b/FWCore/Framework/src/DataProxyProvider.cc
@@ -105,7 +105,7 @@ DataProxyProvider::setAppendToDataLabel(const edm::ParameterSet& iToAppend)
 {
   std::string oldValue( appendToDataLabel_);
   //this can only be changed once and the default value is the empty string
-  assert(0 == oldValue.size());
+  assert(oldValue.empty());
   
   const std::string kParamName("appendToDataLabel");
   if(iToAppend.exists(kParamName) ) {    
@@ -147,7 +147,7 @@ DataProxyProvider::keyedProxies(const EventSetupRecordKey& iRecordKey) const
       const_cast<DataProxyProvider*>(this)->registerProxies(iRecordKey,
                                                             proxies);
 
-      bool mustChangeLabels = (0 != appendToDataLabel_.size());
+      bool mustChangeLabels = (!appendToDataLabel_.empty());
       for(KeyedProxies::iterator itProxy = proxies.begin(), itProxyEnd = proxies.end();
           itProxy != itProxyEnd;
           ++itProxy) {

--- a/FWCore/Framework/src/DependentRecordIntervalFinder.cc
+++ b/FWCore/Framework/src/DependentRecordIntervalFinder.cc
@@ -80,7 +80,7 @@ DependentRecordIntervalFinder::setIntervalFor(const EventSetupRecordKey& iKey,
    
    //I am assuming that an invalidTime is always less then the first valid time
    assert(IOVSyncValue::invalidIOVSyncValue() < IOVSyncValue::beginOfTime());
-   if(providers_.size() == 0 && alternate_.get() == 0 ) {
+   if(providers_.empty() && alternate_.get() == nullptr ) {
       oInterval = ValidityInterval::invalidInterval();
       return;
    }
@@ -88,7 +88,7 @@ DependentRecordIntervalFinder::setIntervalFor(const EventSetupRecordKey& iKey,
    bool allRecordsValid = true;
    ValidityInterval newInterval(IOVSyncValue::beginOfTime(), IOVSyncValue::endOfTime());
    
-   if (alternate_.get() != 0) {
+   if (alternate_.get() != nullptr) {
      ValidityInterval test = alternate_->findIntervalFor(iKey, iTime);
      if ( test != ValidityInterval::invalidInterval() ) {
        haveAValidDependentRecord =true;

--- a/FWCore/Framework/src/EndPathStatusInserter.h
+++ b/FWCore/Framework/src/EndPathStatusInserter.h
@@ -14,7 +14,7 @@ namespace edm {
 
     EndPathStatusInserter(unsigned int numberOfStreams);
 
-    void produce(StreamID, Event&, EventSetup const&) const override final;
+    void produce(StreamID, Event&, EventSetup const&) const final;
   };
 }
 #endif

--- a/FWCore/Framework/src/EventSetup.cc
+++ b/FWCore/Framework/src/EventSetup.cc
@@ -93,7 +93,7 @@ EventSetup::find(const eventsetup::EventSetupRecordKey& iKey) const
    std::map<eventsetup::EventSetupRecordKey, eventsetup::EventSetupRecord const *>::const_iterator itFind
    = recordMap_.find(iKey);
    if(itFind == recordMap_.end()) {
-      return 0;
+      return nullptr;
    }
    return itFind->second;
 }

--- a/FWCore/Framework/src/EventSetupProvider.cc
+++ b/FWCore/Framework/src/EventSetupProvider.cc
@@ -67,7 +67,7 @@ providers_(),
 knownRecordsSupplier_( std::make_unique<KnownRecordsSupplierImpl>(providers_)),
 mustFinishConfiguration_(true),
 subProcessIndex_(subProcessIndex),
-preferredProviderInfo_((0!=iInfo) ? (new PreferredProviderInfo(*iInfo)): 0),
+preferredProviderInfo_((nullptr!=iInfo) ? (new PreferredProviderInfo(*iInfo)): nullptr),
 finders_(new std::vector<std::shared_ptr<EventSetupRecordIntervalFinder> >() ),
 dataProviders_(new std::vector<std::shared_ptr<DataProxyProvider> >() ),
 referencedDataKeys_(new std::map<EventSetupRecordKey, std::map<DataKey, ComponentDescription const*> >),
@@ -114,7 +114,7 @@ EventSetupProvider::insert(const EventSetupRecordKey& iKey, std::unique_ptr<Even
 void 
 EventSetupProvider::add(std::shared_ptr<DataProxyProvider> iProvider)
 {
-   assert(iProvider.get() != 0);
+   assert(iProvider.get() != nullptr);
    dataProviders_->push_back(iProvider);
 }
 
@@ -132,7 +132,7 @@ EventSetupProvider::replaceExisting(std::shared_ptr<DataProxyProvider> dataProxy
 void 
 EventSetupProvider::add(std::shared_ptr<EventSetupRecordIntervalFinder> iFinder)
 {
-   assert(iFinder.get() != 0);
+   assert(iFinder.get() != nullptr);
    finders_->push_back(iFinder);
 }
 
@@ -201,7 +201,7 @@ RecordToPreferred determinePreferred(const EventSetupProvider::PreferredProvider
 {
    using namespace edm::eventsetup;
    RecordToPreferred returnValue;
-   if(0 != iInfo){
+   if(nullptr != iInfo){
       for(EventSetupProvider::PreferredProviderInfo::const_iterator itInfo = iInfo->begin(),
           itInfoEnd = iInfo->end();
           itInfo != itInfoEnd;
@@ -358,7 +358,7 @@ EventSetupProvider::finishConfiguration()
       itProvider->second->usePreferred(*preferredInfo);
       
       std::set<EventSetupRecordKey> records = itProvider->second->dependentRecords();
-      if(records.size() != 0) {
+      if(!records.empty()) {
          std::string missingRecords;
          std::vector<std::shared_ptr<EventSetupRecordProvider> > depProviders;
          depProviders.reserve(records.size());
@@ -370,7 +370,7 @@ EventSetupProvider::finishConfiguration()
             Providers::iterator itFound = providers_.find(*itRecord);
             if(itFound == providers_.end()) {
                foundAllProviders = false;
-               if(missingRecords.size() == 0) {
+               if(missingRecords.empty()) {
                  missingRecords = itRecord->name();
                } else {
                  missingRecords += ", ";

--- a/FWCore/Framework/src/EventSetupRecord.cc
+++ b/FWCore/Framework/src/EventSetupRecord.cc
@@ -102,7 +102,7 @@ EventSetupRecord::add(const DataKey& iKey ,
 {
    //
    const DataProxy* proxy = find(iKey);
-   if (0 != proxy) {
+   if (nullptr != proxy) {
       //
       // we already know the field exist, so do not need to check against end()
       //
@@ -176,9 +176,9 @@ EventSetupRecord::getFromProxy(DataKey const & iKey ,
 
    const DataProxy* proxy = this->find(iKey);
    
-   const void* hold = 0;
+   const void* hold = nullptr;
    
-   if(0!=proxy) {
+   if(nullptr!=proxy) {
       try {
         convertException::wrap([&]() {
             hold = proxy->get(*this, iKey,iTransientAccessOnly);
@@ -202,13 +202,13 @@ EventSetupRecord::find(const DataKey& iKey) const
    if (entry != proxies_.end()) {
       return entry->second;
    }
-   return 0;
+   return nullptr;
 }
       
 bool 
 EventSetupRecord::doGet(const DataKey& aKey, bool aGetTransiently) const {
    const DataProxy* proxy = find(aKey);
-   if(0 != proxy) {
+   if(nullptr != proxy) {
       try {
          convertException::wrap([&]() {
             proxy->doGet(*this, aKey, aGetTransiently);
@@ -221,13 +221,13 @@ EventSetupRecord::doGet(const DataKey& aKey, bool aGetTransiently) const {
          throw;
       }
    }
-   return 0 != proxy;
+   return nullptr != proxy;
 }
 
 bool 
 EventSetupRecord::wasGotten(const DataKey& aKey) const {
    const DataProxy* proxy = find(aKey);
-   if(0 != proxy) {
+   if(nullptr != proxy) {
       return proxy->cacheIsValid();
    }
    return false;
@@ -236,10 +236,10 @@ EventSetupRecord::wasGotten(const DataKey& aKey) const {
 edm::eventsetup::ComponentDescription const* 
 EventSetupRecord::providerDescription(const DataKey& aKey) const {
    const DataProxy* proxy = find(aKey);
-   if(0 != proxy) {
+   if(nullptr != proxy) {
       return proxy->providerDescription();
    }
-   return 0;
+   return nullptr;
 }
 
 void 
@@ -259,7 +259,7 @@ EventSetupRecord::fillRegisteredDataKeys(std::vector<DataKey>& oToFill) const
 void 
 EventSetupRecord::validate(const ComponentDescription* iDesc, const ESInputTag& iTag) const
 {
-   if(iDesc && iTag.module().size()) {
+   if(iDesc && !iTag.module().empty()) {
       bool matched = false;
       if(iDesc->label_.empty()) {
          matched = iDesc->type_ == iTag.module();

--- a/FWCore/Framework/src/EventSetupRecordProviderFactoryManager.cc
+++ b/FWCore/Framework/src/EventSetupRecordProviderFactoryManager.cc
@@ -76,7 +76,7 @@ EventSetupRecordProviderFactoryManager::makeRecordProvider(const EventSetupRecor
    assert(itFound != factories_.end());
    
    const EventSetupRecordProviderFactory* factory = itFound->second;
-   assert(0 != factory);
+   assert(nullptr != factory);
    return std::unique_ptr<EventSetupRecordProvider>(factory->makeRecordProvider());
 }
 

--- a/FWCore/Framework/src/EventSetupsController.cc
+++ b/FWCore/Framework/src/EventSetupsController.cc
@@ -303,7 +303,7 @@ namespace edm {
         << "EventSetupsController::getESProducerPSet\n"
         << "Subprocess index not found. This should never happen\n"
         << "Please report this to a Framework Developer\n";
-      return 0;
+      return nullptr;
     }
 
     void

--- a/FWCore/Framework/src/EventSetupsController.h
+++ b/FWCore/Framework/src/EventSetupsController.h
@@ -124,9 +124,9 @@ namespace edm {
          bool mustFinishConfiguration() const { return mustFinishConfiguration_; }
 
       private:
-         EventSetupsController(EventSetupsController const&); // stop default
+         EventSetupsController(EventSetupsController const&) = delete; // stop default
          
-         EventSetupsController const& operator=(EventSetupsController const&); // stop default
+         EventSetupsController const& operator=(EventSetupsController const&) = delete; // stop default
 
          void checkESProducerSharing();
          

--- a/FWCore/Framework/src/ExceptionHelpers.cc
+++ b/FWCore/Framework/src/ExceptionHelpers.cc
@@ -12,7 +12,7 @@ namespace edm {
   addContextAndPrintException(char const* context,
                               cms::Exception& ex,
                               bool disablePrint) {
-    if (context != 0 && strlen(context) != 0U) {
+    if (context != nullptr && strlen(context) != 0U) {
       ex.addContext(context);
     }
     if (!disablePrint) {

--- a/FWCore/Framework/src/Factory.cc
+++ b/FWCore/Framework/src/Factory.cc
@@ -41,7 +41,7 @@ namespace edm {
     {
       std::unique_ptr<Maker> wm(MakerPluginFactory::get()->create(modtype));
       
-      if(wm.get()==0)
+      if(wm.get()==nullptr)
         throw edm::Exception(errors::Configuration,"UnknownModule")
         << "Module " << modtype
         << " with version " << p.processConfiguration_->releaseVersion()

--- a/FWCore/Framework/src/HCTypeTag.cc
+++ b/FWCore/Framework/src/HCTypeTag.cc
@@ -126,7 +126,7 @@ namespace edm {
          {
             std::pair<const char*,const std::type_info*> p = typelookup::findType(iTypeName);
             
-            if(0 == p.second) {
+            if(nullptr == p.second) {
                return HCTypeTag();
             }
             //need to take name from the 'findType' since that address is guaranteed to be long lived

--- a/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.h
+++ b/FWCore/Framework/src/IntersectingIOVRecordIntervalFinder.h
@@ -34,7 +34,7 @@ namespace edm {
          
       public:
          explicit IntersectingIOVRecordIntervalFinder(const EventSetupRecordKey&);
-         virtual ~IntersectingIOVRecordIntervalFinder();
+         ~IntersectingIOVRecordIntervalFinder() override;
          
          // ---------- const member functions ---------------------
          
@@ -43,14 +43,14 @@ namespace edm {
          // ---------- member functions ---------------------------
          void swapFinders(std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>>&);
       protected:
-         virtual void setIntervalFor(const EventSetupRecordKey&,
+         void setIntervalFor(const EventSetupRecordKey&,
                                      const IOVSyncValue& , 
-                                     ValidityInterval&);
+                                     ValidityInterval&) override;
          
       private:
-         IntersectingIOVRecordIntervalFinder(const IntersectingIOVRecordIntervalFinder&); // stop default
+         IntersectingIOVRecordIntervalFinder(const IntersectingIOVRecordIntervalFinder&) = delete; // stop default
          
-         const IntersectingIOVRecordIntervalFinder& operator=(const IntersectingIOVRecordIntervalFinder&); // stop default
+         const IntersectingIOVRecordIntervalFinder& operator=(const IntersectingIOVRecordIntervalFinder&) = delete; // stop default
          
          // ---------- member data --------------------------------
          std::vector<edm::propagate_const<std::shared_ptr<EventSetupRecordIntervalFinder>>> finders_;

--- a/FWCore/Framework/src/ModuleHolder.h
+++ b/FWCore/Framework/src/ModuleHolder.h
@@ -56,11 +56,11 @@ namespace edm {
     class ModuleHolderT : public ModuleHolder {
     public:
       ModuleHolderT(std::shared_ptr<T> iModule, Maker const* iMaker) :ModuleHolder(iMaker), m_mod(iModule) {}
-      ~ModuleHolderT() {}
+      ~ModuleHolderT() override {}
       std::shared_ptr<T> module() const { return m_mod; }
       void replaceModuleFor(Worker* iWorker) const override {
         auto w = dynamic_cast<WorkerT<T>*>(iWorker);
-        assert(0!=w);
+        assert(nullptr!=w);
         w->setModule(m_mod);
       }
       ModuleDescription const& moduleDescription() const override {

--- a/FWCore/Framework/src/PathStatusInserter.h
+++ b/FWCore/Framework/src/PathStatusInserter.h
@@ -18,7 +18,7 @@ namespace edm {
 
     void setPathStatus(StreamID const&, HLTPathStatus const&);
 
-    void produce(StreamID, Event&, EventSetup const&) const override final;
+    void produce(StreamID, Event&, EventSetup const&) const final;
 
   private:
 

--- a/FWCore/Framework/src/PrincipalCache.cc
+++ b/FWCore/Framework/src/PrincipalCache.cc
@@ -26,7 +26,7 @@ namespace edm {
   PrincipalCache::runPrincipal(ProcessHistoryID const& phid, RunNumber_t run) const {
     if (phid != reducedInputProcessHistoryID_ ||
         run != run_ ||
-        runPrincipal_.get() == 0) {
+        runPrincipal_.get() == nullptr) {
       throwRunMissing();
     }
     return *runPrincipal_.get();
@@ -36,7 +36,7 @@ namespace edm {
   PrincipalCache::runPrincipalPtr(ProcessHistoryID const& phid, RunNumber_t run) const {
     if (phid != reducedInputProcessHistoryID_ ||
         run != run_ ||
-        runPrincipal_.get() == 0) {
+        runPrincipal_.get() == nullptr) {
       throwRunMissing();
     }
     return runPrincipal_;
@@ -44,7 +44,7 @@ namespace edm {
 
   RunPrincipal&
   PrincipalCache::runPrincipal() const {
-    if (runPrincipal_.get() == 0) {
+    if (runPrincipal_.get() == nullptr) {
       throwRunMissing();
     }
     return *runPrincipal_.get();
@@ -52,7 +52,7 @@ namespace edm {
 
   std::shared_ptr<RunPrincipal> const&
   PrincipalCache::runPrincipalPtr() const {
-    if (runPrincipal_.get() == 0) {
+    if (runPrincipal_.get() == nullptr) {
       throwRunMissing();
     }
     return runPrincipal_;
@@ -63,7 +63,7 @@ namespace edm {
     if (phid != reducedInputProcessHistoryID_ ||
         run != run_ ||
         lumi != lumi_ ||
-        lumiPrincipal_.get() == 0) {
+        lumiPrincipal_.get() == nullptr) {
       throwLumiMissing();
     }
     return *lumiPrincipal_.get();
@@ -74,7 +74,7 @@ namespace edm {
     if (phid != reducedInputProcessHistoryID_ ||
         run != run_ ||
         lumi != lumi_ ||
-        lumiPrincipal_.get() == 0) {
+        lumiPrincipal_.get() == nullptr) {
       throwLumiMissing();
     }
     return lumiPrincipal_;
@@ -82,7 +82,7 @@ namespace edm {
 
   LuminosityBlockPrincipal&
   PrincipalCache::lumiPrincipal() const {
-    if (lumiPrincipal_.get() == 0) {
+    if (lumiPrincipal_.get() == nullptr) {
       throwLumiMissing();
     }
     return *lumiPrincipal_.get();
@@ -90,14 +90,14 @@ namespace edm {
 
   std::shared_ptr<LuminosityBlockPrincipal> const&
   PrincipalCache::lumiPrincipalPtr() const {
-    if (lumiPrincipal_.get() == 0) {
+    if (lumiPrincipal_.get() == nullptr) {
       throwLumiMissing();
     }
     return lumiPrincipal_;
   }
 
   void PrincipalCache::merge(std::shared_ptr<RunAuxiliary> aux, std::shared_ptr<ProductRegistry const> reg) {
-    if (runPrincipal_.get() == 0) {
+    if (runPrincipal_.get() == nullptr) {
       throw edm::Exception(edm::errors::LogicError)
         << "PrincipalCache::merge\n"
         << "Illegal attempt to merge run into cache\n"
@@ -127,7 +127,7 @@ namespace edm {
   }
 
   void PrincipalCache::merge(std::shared_ptr<LuminosityBlockAuxiliary> aux, std::shared_ptr<ProductRegistry const> reg) {
-    if (lumiPrincipal_.get() == 0) {
+    if (lumiPrincipal_.get() == nullptr) {
       throw edm::Exception(edm::errors::LogicError)
         << "PrincipalCache::merge\n"
         << "Illegal attempt to merge luminosity block into cache\n"
@@ -158,7 +158,7 @@ namespace edm {
   }
 
   void PrincipalCache::insert(std::shared_ptr<RunPrincipal> rp) {
-    if (runPrincipal_.get() != 0) {
+    if (runPrincipal_.get() != nullptr) {
       throw edm::Exception(edm::errors::LogicError)
         << "PrincipalCache::insert\n"
         << "Illegal attempt to insert run into cache\n"
@@ -173,13 +173,13 @@ namespace edm {
   }
 
   void PrincipalCache::insert(std::shared_ptr<LuminosityBlockPrincipal> lbp) {
-    if (lumiPrincipal_.get() != 0) {
+    if (lumiPrincipal_.get() != nullptr) {
       throw edm::Exception(edm::errors::LogicError)
         << "PrincipalCache::insert\n"
         << "Illegal attempt to insert lumi into cache\n"
         << "Contact a Framework Developer\n";
     }
-    if (runPrincipal_.get() == 0) {
+    if (runPrincipal_.get() == nullptr) {
       throw edm::Exception(edm::errors::LogicError)
         << "PrincipalCache::insert\n"
         << "Illegal attempt to insert lumi into cache\n"
@@ -214,7 +214,7 @@ namespace edm {
   }
 
   void PrincipalCache::deleteRun(ProcessHistoryID const& phid, RunNumber_t run) {
-    if (runPrincipal_.get() == 0) {
+    if (runPrincipal_.get() == nullptr) {
       throw edm::Exception(edm::errors::LogicError)
         << "PrincipalCache::deleteRun\n"
         << "Illegal attempt to delete run from cache\n"
@@ -233,7 +233,7 @@ namespace edm {
   }
 
   void PrincipalCache::deleteLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi) {
-    if (lumiPrincipal_.get() == 0) {
+    if (lumiPrincipal_.get() == nullptr) {
       throw edm::Exception(edm::errors::LogicError)
         << "PrincipalCache::deleteLumi\n"
         << "Illegal attempt to delete luminosity block from cache\n"

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -47,12 +47,12 @@ namespace edm {
     theStatus_(iDefaultStatus),
     defaultStatus_(iDefaultStatus){}
 
-    virtual void connectTo(ProductResolverBase const&, Principal const*) override final;
+    void connectTo(ProductResolverBase const&, Principal const*) final;
 
     void resetStatus() {theStatus_ = defaultStatus_;}
 
     //Give AliasProductResolver access
-    virtual void resetProductData_(bool deleteEarly) override;
+    void resetProductData_(bool deleteEarly) override;
 
   protected:
     void setProduct(std::unique_ptr<WrapperBase> edp) const;
@@ -72,21 +72,21 @@ namespace edm {
     // merges the product with the pre-existing product
     void mergeProduct(std::unique_ptr<WrapperBase> edp) const;
 
-    virtual void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod) const override final;
-    virtual bool productUnavailable_() const override final;
-    virtual bool productResolved_() const override final;
-    virtual bool productWasDeleted_() const override final;
-    virtual bool productWasFetchedAndIsValid_( bool iSkipCurrentProcess) const override final;
+    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod) const final;
+    bool productUnavailable_() const final;
+    bool productResolved_() const final;
+    bool productWasDeleted_() const final;
+    bool productWasFetchedAndIsValid_( bool iSkipCurrentProcess) const final;
 
-    virtual BranchDescription const& branchDescription_() const override final {return *getProductData().branchDescription();}
-    virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override final {productData_.resetBranchDescription(bd);}
-    virtual Provenance const* provenance_() const override final {return &productData_.provenance();}
+    BranchDescription const& branchDescription_() const final {return *getProductData().branchDescription();}
+    void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) final {productData_.resetBranchDescription(bd);}
+    Provenance const* provenance_() const final {return &productData_.provenance();}
 
-    virtual std::string const& resolvedModuleLabel_() const override final {return moduleLabel();}
-    virtual void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) override final;
-    virtual void setProcessHistory_(ProcessHistory const& ph) override final;
-    virtual ProductProvenance const* productProvenancePtr_() const override final;
-    virtual bool singleProduct_() const override final;
+    std::string const& resolvedModuleLabel_() const final {return moduleLabel();}
+    void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) final;
+    void setProcessHistory_(ProcessHistory const& ph) final;
+    ProductProvenance const* productProvenancePtr_() const final;
+    bool singleProduct_() const final;
 
     ProductData productData_;
     mutable std::atomic<ProductStatus> theStatus_;
@@ -100,28 +100,28 @@ namespace edm {
       m_prefetchRequested{ false },
       aux_{nullptr} {}
 
-    virtual void setupUnscheduled(UnscheduledConfigurator const&) override final;
+    void setupUnscheduled(UnscheduledConfigurator const&) final;
 
     private:
-      virtual bool isFromCurrentProcess() const override final;
+      bool isFromCurrentProcess() const final;
 
 
-      virtual Resolution resolveProduct_(Principal const& principal,
+      Resolution resolveProduct_(Principal const& principal,
                                          bool skipCurrentProcess,
                                          SharedResourcesAcquirer* sra,
                                          ModuleCallingContext const* mcc) const override;
-    virtual  void prefetchAsync_(WaitingTask* waitTask,
+     void prefetchAsync_(WaitingTask* waitTask,
                                  Principal const& principal,
                                  bool skipCurrentProcess,
                                  SharedResourcesAcquirer* sra,
                                  ModuleCallingContext const* mcc) const override;
-      virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
+      void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
 
-      virtual void retrieveAndMerge_(Principal const& principal) const override;
+      void retrieveAndMerge_(Principal const& principal) const override;
 
-      virtual bool unscheduledWasNotRun_() const override final {return false;}
+      bool unscheduledWasNotRun_() const final {return false;}
 
-      virtual void resetProductData_(bool deleteEarly) override;
+      void resetProductData_(bool deleteEarly) override;
 
       mutable std::atomic<bool> m_prefetchRequested;
       mutable WaitingTaskList m_waitingTasks;
@@ -134,12 +134,12 @@ namespace edm {
     public:
       ProducedProductResolver(std::shared_ptr<BranchDescription const> bd, ProductStatus iDefaultStatus) : DataManagingProductResolver(bd, iDefaultStatus) {assert(bd->produced());}
 
-      virtual void resetFailedFromThisProcess() override;
+      void resetFailedFromThisProcess() override;
 
     protected:
-      virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
+      void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
     private:
-      virtual bool isFromCurrentProcess() const override final;
+      bool isFromCurrentProcess() const final;
 
   };
 
@@ -147,22 +147,22 @@ namespace edm {
   public:
     explicit PuttableProductResolver(std::shared_ptr<BranchDescription const> bd) : ProducedProductResolver(bd, ProductStatus::NotPut), worker_(nullptr), prefetchRequested_(false) {}
 
-    virtual void setupUnscheduled(UnscheduledConfigurator const&) override final;
+    void setupUnscheduled(UnscheduledConfigurator const&) final;
 
   private:
-    virtual Resolution resolveProduct_(Principal const& principal,
+    Resolution resolveProduct_(Principal const& principal,
                                        bool skipCurrentProcess,
                                        SharedResourcesAcquirer* sra,
                                        ModuleCallingContext const* mcc) const override;
-    virtual  void prefetchAsync_(WaitingTask* waitTask,
+     void prefetchAsync_(WaitingTask* waitTask,
                                  Principal const& principal,
                                  bool skipCurrentProcess,
                                  SharedResourcesAcquirer* sra,
                                  ModuleCallingContext const* mcc) const override;
-    virtual bool unscheduledWasNotRun_() const override {return false;}
+    bool unscheduledWasNotRun_() const override {return false;}
 
-    virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-    virtual void resetProductData_(bool deleteEarly) override;
+    void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
+    void resetProductData_(bool deleteEarly) override;
 
     mutable WaitingTaskList m_waitingTasks;
     Worker* worker_;
@@ -177,21 +177,21 @@ namespace edm {
        aux_(nullptr),
        prefetchRequested_(false){}
 
-      virtual void setupUnscheduled(UnscheduledConfigurator const&) override final;
+      void setupUnscheduled(UnscheduledConfigurator const&) final;
 
     private:
-      virtual Resolution resolveProduct_(Principal const& principal,
+      Resolution resolveProduct_(Principal const& principal,
                                          bool skipCurrentProcess,
                                          SharedResourcesAcquirer* sra,
                                          ModuleCallingContext const* mcc) const override;
-      virtual  void prefetchAsync_(WaitingTask* waitTask,
+       void prefetchAsync_(WaitingTask* waitTask,
                                    Principal const& principal,
                                    bool skipCurrentProcess,
                                    SharedResourcesAcquirer* sra,
                                    ModuleCallingContext const* mcc) const override;
-      virtual bool unscheduledWasNotRun_() const override {return status() == ProductStatus::ResolveNotRun;}
+      bool unscheduledWasNotRun_() const override {return status() == ProductStatus::ResolveNotRun;}
 
-      virtual void resetProductData_(bool deleteEarly) override;
+      void resetProductData_(bool deleteEarly) override;
 
       mutable WaitingTaskList waitingTasks_;
       UnscheduledAuxiliary const* aux_;
@@ -204,44 +204,44 @@ namespace edm {
       typedef ProducedProductResolver::ProductStatus ProductStatus;
       explicit AliasProductResolver(std::shared_ptr<BranchDescription const> bd, ProducedProductResolver& realProduct) : ProductResolverBase(), realProduct_(realProduct), bd_(bd) {}
 
-      virtual void connectTo(ProductResolverBase const& iOther, Principal const* iParentPrincipal) override final {
+      void connectTo(ProductResolverBase const& iOther, Principal const* iParentPrincipal) final {
         realProduct_.connectTo(iOther, iParentPrincipal );
       };
 
     private:
-      virtual Resolution resolveProduct_(Principal const& principal,
+      Resolution resolveProduct_(Principal const& principal,
                                          bool skipCurrentProcess,
                                          SharedResourcesAcquirer* sra,
                                          ModuleCallingContext const* mcc) const override {
         return realProduct_.resolveProduct(principal, skipCurrentProcess, sra, mcc);}
-      virtual  void prefetchAsync_(WaitingTask* waitTask,
+       void prefetchAsync_(WaitingTask* waitTask,
                                    Principal const& principal,
                                    bool skipCurrentProcess,
                                    SharedResourcesAcquirer* sra,
                                    ModuleCallingContext const* mcc) const override {
         realProduct_.prefetchAsync(waitTask, principal, skipCurrentProcess, sra, mcc);
       }
-      virtual bool unscheduledWasNotRun_() const override {return realProduct_.unscheduledWasNotRun();}
-      virtual bool productUnavailable_() const override {return realProduct_.productUnavailable();}
-      virtual bool productResolved_() const override final {
+      bool unscheduledWasNotRun_() const override {return realProduct_.unscheduledWasNotRun();}
+      bool productUnavailable_() const override {return realProduct_.productUnavailable();}
+      bool productResolved_() const final {
           return realProduct_.productResolved(); }
-      virtual bool productWasDeleted_() const override {return realProduct_.productWasDeleted();}
-      virtual bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const override final {
+      bool productWasDeleted_() const override {return realProduct_.productWasDeleted();}
+      bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const final {
         return realProduct_.productWasFetchedAndIsValid(iSkipCurrentProcess);
       }
 
-      virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-      virtual void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod) const override final;
-      virtual BranchDescription const& branchDescription_() const override {return *bd_;}
-      virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override {bd_ = bd;}
-      virtual Provenance const* provenance_() const override final { return realProduct_.provenance(); }
+      void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
+      void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod) const final;
+      BranchDescription const& branchDescription_() const override {return *bd_;}
+      void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override {bd_ = bd;}
+      Provenance const* provenance_() const final { return realProduct_.provenance(); }
 
-      virtual std::string const& resolvedModuleLabel_() const override {return realProduct_.moduleLabel();}
-      virtual void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
-      virtual void setProcessHistory_(ProcessHistory const& ph) override;
-      virtual ProductProvenance const* productProvenancePtr_() const override;
-      virtual void resetProductData_(bool deleteEarly) override;
-      virtual bool singleProduct_() const override;
+      std::string const& resolvedModuleLabel_() const override {return realProduct_.moduleLabel();}
+      void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
+      void setProcessHistory_(ProcessHistory const& ph) override;
+      ProductProvenance const* productProvenancePtr_() const override;
+      void resetProductData_(bool deleteEarly) override;
+      bool singleProduct_() const override;
 
       ProducedProductResolver& realProduct_;
       std::shared_ptr<BranchDescription const> bd_;
@@ -252,20 +252,20 @@ namespace edm {
     typedef ProducedProductResolver::ProductStatus ProductStatus;
     explicit ParentProcessProductResolver(std::shared_ptr<BranchDescription const> bd) : ProductResolverBase(), realProduct_(nullptr), bd_(bd), provRetriever_(nullptr), parentPrincipal_(nullptr) {}
 
-    virtual void connectTo(ProductResolverBase const& iOther, Principal const* iParentPrincipal) override final {
+    void connectTo(ProductResolverBase const& iOther, Principal const* iParentPrincipal) final {
       realProduct_ = &iOther;
       parentPrincipal_ = iParentPrincipal;
     };
 
   private:
-    virtual Resolution resolveProduct_(Principal const& principal,
+    Resolution resolveProduct_(Principal const& principal,
                                        bool skipCurrentProcess,
                                        SharedResourcesAcquirer* sra,
                                        ModuleCallingContext const* mcc) const override {
       skipCurrentProcess = false;
       return realProduct_->resolveProduct(*parentPrincipal_, skipCurrentProcess, sra, mcc);
     }
-    virtual  void prefetchAsync_(WaitingTask* waitTask,
+     void prefetchAsync_(WaitingTask* waitTask,
                                  Principal const& principal,
                                  bool skipCurrentProcess,
                                  SharedResourcesAcquirer* sra,
@@ -273,31 +273,31 @@ namespace edm {
       skipCurrentProcess = false;
       realProduct_->prefetchAsync( waitTask, *parentPrincipal_, skipCurrentProcess, sra, mcc);
     }
-    virtual bool unscheduledWasNotRun_() const override {
+    bool unscheduledWasNotRun_() const override {
       if (realProduct_) return realProduct_->unscheduledWasNotRun();
       throwNullRealProduct();
       return false;
     }
-    virtual bool productUnavailable_() const override {return realProduct_->productUnavailable();}
-    virtual bool productResolved_() const override final { return realProduct_->productResolved(); }
-    virtual bool productWasDeleted_() const override {return realProduct_->productWasDeleted();}
-    virtual bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const override {
+    bool productUnavailable_() const override {return realProduct_->productUnavailable();}
+    bool productResolved_() const final { return realProduct_->productResolved(); }
+    bool productWasDeleted_() const override {return realProduct_->productWasDeleted();}
+    bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const override {
       iSkipCurrentProcess = false;
       return realProduct_->productWasFetchedAndIsValid(iSkipCurrentProcess);
     }
 
-    virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-    virtual void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod) const override final;
-    virtual BranchDescription const& branchDescription_() const override {return *bd_;}
-    virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override {bd_ = bd;}
-    virtual Provenance const* provenance_() const override final {return realProduct_->provenance();
+    void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
+    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod) const final;
+    BranchDescription const& branchDescription_() const override {return *bd_;}
+    void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override {bd_ = bd;}
+    Provenance const* provenance_() const final {return realProduct_->provenance();
     }
-    virtual std::string const& resolvedModuleLabel_() const override {return realProduct_->moduleLabel();}
-    virtual void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
-    virtual void setProcessHistory_(ProcessHistory const& ph) override;
-    virtual ProductProvenance const* productProvenancePtr_() const override;
-    virtual void resetProductData_(bool deleteEarly) override;
-    virtual bool singleProduct_() const override;
+    std::string const& resolvedModuleLabel_() const override {return realProduct_->moduleLabel();}
+    void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
+    void setProcessHistory_(ProcessHistory const& ph) override;
+    ProductProvenance const* productProvenancePtr_() const override;
+    void resetProductData_(bool deleteEarly) override;
+    bool singleProduct_() const override;
     void throwNullRealProduct() const;
 
     ProductResolverBase const* realProduct_;
@@ -312,7 +312,7 @@ namespace edm {
       NoProcessProductResolver(std::vector<ProductResolverIndex> const& matchingHolders,
                              std::vector<bool> const& ambiguous);
 
-    virtual void connectTo(ProductResolverBase const& iOther, Principal const*) override final ;
+    void connectTo(ProductResolverBase const& iOther, Principal const*) final ;
 
     void tryPrefetchResolverAsync(unsigned int iProcessingIndex,
                                   Principal const& principal,
@@ -331,33 +331,33 @@ namespace edm {
                         std::exception_ptr iExceptPtr) const;
     private:
       unsigned int unsetIndexValue() const;
-      virtual Resolution resolveProduct_(Principal const& principal,
+      Resolution resolveProduct_(Principal const& principal,
                                          bool skipCurrentProcess,
                                          SharedResourcesAcquirer* sra,
                                          ModuleCallingContext const* mcc) const override;
-      virtual  void prefetchAsync_(WaitingTask* waitTask,
+       void prefetchAsync_(WaitingTask* waitTask,
                                    Principal const& principal,
                                    bool skipCurrentProcess,
                                    SharedResourcesAcquirer* sra,
                                    ModuleCallingContext const* mcc) const override;
-      virtual bool unscheduledWasNotRun_() const override;
-      virtual bool productUnavailable_() const override;
-      virtual bool productWasDeleted_() const override;
-      virtual bool productResolved_() const override final;
-      virtual bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const override;
+      bool unscheduledWasNotRun_() const override;
+      bool productUnavailable_() const override;
+      bool productWasDeleted_() const override;
+      bool productResolved_() const final;
+      bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const override;
 
-      virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-      virtual void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod) const override final;
-      virtual BranchDescription const& branchDescription_() const override;
-      virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override;
-      virtual Provenance const* provenance_() const override;
+      void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
+      void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod) const final;
+      BranchDescription const& branchDescription_() const override;
+      void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override;
+      Provenance const* provenance_() const override;
 
-      virtual std::string const& resolvedModuleLabel_() const override {return moduleLabel();}
-      virtual void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
-      virtual void setProcessHistory_(ProcessHistory const& ph) override;
-      virtual ProductProvenance const* productProvenancePtr_() const override;
-      virtual void resetProductData_(bool deleteEarly) override;
-      virtual bool singleProduct_() const override;
+      std::string const& resolvedModuleLabel_() const override {return moduleLabel();}
+      void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
+      void setProcessHistory_(ProcessHistory const& ph) override;
+      ProductProvenance const* productProvenancePtr_() const override;
+      void resetProductData_(bool deleteEarly) override;
+      bool singleProduct_() const override;
 
       Resolution tryResolver(unsigned int index,
                              Principal const& principal,
@@ -384,36 +384,36 @@ namespace edm {
     SingleChoiceNoProcessProductResolver(ProductResolverIndex iChoice):
     ProductResolverBase(), realResolverIndex_(iChoice) {}
 
-    virtual void connectTo(ProductResolverBase const& iOther, Principal const*) override final ;
+    void connectTo(ProductResolverBase const& iOther, Principal const*) final ;
 
   private:
-    virtual Resolution resolveProduct_(Principal const& principal,
+    Resolution resolveProduct_(Principal const& principal,
                                        bool skipCurrentProcess,
                                        SharedResourcesAcquirer* sra,
                                        ModuleCallingContext const* mcc) const override;
-    virtual  void prefetchAsync_(WaitingTask* waitTask,
+     void prefetchAsync_(WaitingTask* waitTask,
                                  Principal const& principal,
                                  bool skipCurrentProcess,
                                  SharedResourcesAcquirer* sra,
                                  ModuleCallingContext const* mcc) const override;
-    virtual bool unscheduledWasNotRun_() const override;
-    virtual bool productUnavailable_() const override;
-    virtual bool productWasDeleted_() const override;
-    virtual bool productResolved_() const override final;
-    virtual bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const override;
+    bool unscheduledWasNotRun_() const override;
+    bool productUnavailable_() const override;
+    bool productWasDeleted_() const override;
+    bool productResolved_() const final;
+    bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const override;
 
-    virtual void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
-    virtual void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod) const override final;
-    virtual BranchDescription const& branchDescription_() const override;
-    virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override;
-    virtual Provenance const* provenance_() const override;
+    void putProduct_(std::unique_ptr<WrapperBase> edp) const override;
+    void putOrMergeProduct_(std::unique_ptr<WrapperBase> prod) const final;
+    BranchDescription const& branchDescription_() const override;
+    void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override;
+    Provenance const* provenance_() const override;
 
-    virtual std::string const& resolvedModuleLabel_() const override {return moduleLabel();}
-    virtual void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
-    virtual void setProcessHistory_(ProcessHistory const& ph) override;
-    virtual ProductProvenance const* productProvenancePtr_() const override;
-    virtual void resetProductData_(bool deleteEarly) override;
-    virtual bool singleProduct_() const override;
+    std::string const& resolvedModuleLabel_() const override {return moduleLabel();}
+    void setProvenance_(ProductProvenanceRetriever const* provRetriever, ProcessHistory const& ph, ProductID const& pid) override;
+    void setProcessHistory_(ProcessHistory const& ph) override;
+    ProductProvenance const* productProvenancePtr_() const override;
+    void resetProductData_(bool deleteEarly) override;
+    bool singleProduct_() const override;
 
     ProductResolverIndex realResolverIndex_;
   };

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -256,7 +256,7 @@ namespace edm {
     initializeBranchToReadingWorker(opts,preg,branchToReadingWorker);
     
     //If no delete early items have been specified we don't have to do anything
-    if(branchToReadingWorker.size()==0) {
+    if(branchToReadingWorker.empty()) {
       return;
     }
     const std::vector<std::string> kEmpty;
@@ -269,7 +269,7 @@ namespace edm {
     modReg.forAllModuleHolders([this, &branchToReadingWorker,&nUniqueBranchesToDelete](maker::ModuleHolder* iHolder){
       auto comm = iHolder->createOutputModuleCommunicator();
       if (comm) {
-        if(branchToReadingWorker.size()>0) {
+        if(!branchToReadingWorker.empty()) {
           //If an OutputModule needs a product, we can't delete it early
           // so we should remove it from our list
           SelectedProductsForBranchType const& kept = comm->keptProducts();
@@ -285,14 +285,14 @@ namespace edm {
       }
     });
     
-    if(branchToReadingWorker.size()==0) {
+    if(branchToReadingWorker.empty()) {
       return;
     }
     
     for (auto w :allWorkers()) {
       //determine if this module could read a branch we want to delete early
       auto pset = pset::Registry::instance()->getMapped(w->description().parameterSetID());
-      if(0!=pset) {
+      if(nullptr!=pset) {
         auto branches = pset->getUntrackedParameter<std::vector<std::string>>("mightGet",kEmpty);
         if(not branches.empty()) {
           ++upperLimitOnReadingWorker;
@@ -334,7 +334,7 @@ namespace edm {
         }
       }
     }  
-    if(0!=branchToReadingWorker.size()) {
+    if(!branchToReadingWorker.empty()) {
       earlyDeleteHelpers_.reserve(upperLimitOnReadingWorker);
       earlyDeleteHelperToBranchIndicies_.resize(upperLimitOnIndicies,0);
       earlyDeleteBranchToCount_.reserve(nUniqueBranchesToDelete);
@@ -422,7 +422,7 @@ namespace edm {
 
       bool isTracked;
       ParameterSet* modpset = proc_pset.getPSetForUpdate(moduleLabel, isTracked);
-      if (modpset == 0) {
+      if (modpset == nullptr) {
         std::string pathType("endpath");
         if (!search_all(endPathNames, pathName)) {
           pathType = std::string("path");
@@ -824,7 +824,7 @@ namespace edm {
     sum.timesExcept += path.timesExcept();
     
     Path::size_type sz = path.size();
-    if(sum.moduleInPathSummaries.size()==0) {
+    if(sum.moduleInPathSummaries.empty()) {
       std::vector<ModuleInPathSummary> temp(sz);
       for (size_t i = 0; i != sz; ++i) {
         fillModuleInPathSummary(path, i, temp[i]);

--- a/FWCore/Framework/src/TriggerResultInserter.h
+++ b/FWCore/Framework/src/TriggerResultInserter.h
@@ -41,7 +41,7 @@ namespace edm
 
     void setTrigResultForStream(unsigned int iStreamIndex,
                                 const TrigResPtr& trptr);
-    void produce(StreamID id, edm::Event& e, edm::EventSetup const& c) const override final;
+    void produce(StreamID id, edm::Event& e, edm::EventSetup const& c) const final;
 
   private:
     std::vector<edm::propagate_const<TrigResPtr>> resultsPerStream_;

--- a/FWCore/Framework/src/WorkerMaker.h
+++ b/FWCore/Framework/src/WorkerMaker.h
@@ -59,10 +59,10 @@ protected:
     //typedef T worker_type;
     explicit WorkerMaker();
   private:
-    virtual void fillDescriptions(ConfigurationDescriptions& iDesc) const;
-    virtual std::unique_ptr<Worker> makeWorker(ExceptionToActionTable const* actions, ModuleDescription const& md, maker::ModuleHolder const* mod) const;
-    virtual std::shared_ptr<maker::ModuleHolder> makeModule(edm::ParameterSet const& p) const;
-    virtual const std::string& baseType() const;
+    void fillDescriptions(ConfigurationDescriptions& iDesc) const override;
+    std::unique_ptr<Worker> makeWorker(ExceptionToActionTable const* actions, ModuleDescription const& md, maker::ModuleHolder const* mod) const override;
+    std::shared_ptr<maker::ModuleHolder> makeModule(edm::ParameterSet const& p) const override;
+    const std::string& baseType() const override;
   };
 
   template <class T>

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -101,7 +101,7 @@ namespace edm {
     auto const runLookup = iRegistry.productLookup(InRun);
     auto const lumiLookup = iRegistry.productLookup(InLumi);
     auto const eventLookup = iRegistry.productLookup(InEvent);
-    if(allWorkers_.size()>0) {
+    if(!allWorkers_.empty()) {
       auto const& processName = allWorkers_[0]->description().processName();
       auto runModuleToIndicies = runLookup->indiciesForModulesInProcess(processName);
       auto lumiModuleToIndicies = lumiLookup->indiciesForModulesInProcess(processName);

--- a/FWCore/MessageLogger/interface/AbstractMLscribe.h
+++ b/FWCore/MessageLogger/interface/AbstractMLscribe.h
@@ -19,8 +19,8 @@ public:
 
 private:
   // --- no copying:
-  AbstractMLscribe(AbstractMLscribe const &);
-  void  operator = (AbstractMLscribe const &);
+  AbstractMLscribe(AbstractMLscribe const &) = delete;
+  void  operator = (AbstractMLscribe const &) = delete;
 
 };  // AbstractMLscribe
 

--- a/FWCore/MessageLogger/interface/MessageDrop.h
+++ b/FWCore/MessageLogger/interface/MessageDrop.h
@@ -86,8 +86,8 @@ struct MessageDrop {
 private:
   MessageDrop();					// change log 10:
   							// moved to cc file  
-  MessageDrop( MessageDrop const& );
-  MessageDrop& operator=( MessageDrop const& );
+  MessageDrop( MessageDrop const& ) = delete;
+  MessageDrop& operator=( MessageDrop const& ) = delete;
 public:
   ~MessageDrop();					// change log 10
   static MessageDrop * instance ();

--- a/FWCore/MessageLogger/interface/MessageLogger.h
+++ b/FWCore/MessageLogger/interface/MessageLogger.h
@@ -158,8 +158,8 @@ public:
 				      { if(ap.valid()) ap << f; return *this; }     
 private:
   MessageSender ap; 
-  LogWarning( LogWarning const& );				// Change log 9
-  LogWarning& operator=( LogWarning const& );
+  LogWarning( LogWarning const& ) = delete;				// Change log 9
+  LogWarning& operator=( LogWarning const& ) = delete;
    
 };  // LogWarning
 
@@ -183,8 +183,8 @@ public:
 
 private:
   MessageSender ap; 
-  LogError( LogError const& );					// Change log 9
-  LogError& operator=( LogError const& );
+  LogError( LogError const& ) = delete;					// Change log 9
+  LogError& operator=( LogError const& ) = delete;
 
 };  // LogError
 
@@ -208,8 +208,8 @@ public:
 
 private:
   MessageSender ap; 
-  LogSystem( LogSystem const& );				// Change log 9
-  LogSystem& operator=( LogSystem const& );
+  LogSystem( LogSystem const& ) = delete;				// Change log 9
+  LogSystem& operator=( LogSystem const& ) = delete;
 
 };  // LogSystem
 
@@ -233,8 +233,8 @@ public:
 
 private:
   MessageSender ap; 
-  LogInfo( LogInfo const& );					// Change log 9
-  LogInfo& operator=( LogInfo const& );
+  LogInfo( LogInfo const& ) = delete;					// Change log 9
+  LogInfo& operator=( LogInfo const& ) = delete;
   
 };  // LogInfo
 
@@ -260,8 +260,8 @@ public:
 
 private:
   MessageSender ap; 
-  LogVerbatim( LogVerbatim const& );				// Change log 9
-  LogVerbatim& operator=( LogVerbatim const& );
+  LogVerbatim( LogVerbatim const& ) = delete;				// Change log 9
+  LogVerbatim& operator=( LogVerbatim const& ) = delete;
   
 };  // LogVerbatim
 
@@ -287,8 +287,8 @@ public:
 
 private:
   MessageSender ap; 
-  LogPrint( LogPrint const& );					// Change log 9
-  LogPrint& operator=( LogPrint const& );
+  LogPrint( LogPrint const& ) = delete;					// Change log 9
+  LogPrint& operator=( LogPrint const& ) = delete;
   
 };  // LogPrint
 
@@ -314,8 +314,8 @@ public:
 
 private:
   MessageSender ap; 
-  LogProblem( LogProblem const& );				// Change log 9
-  LogProblem& operator=( LogProblem const& );
+  LogProblem( LogProblem const& ) = delete;				// Change log 9
+  LogProblem& operator=( LogProblem const& ) = delete;
 
 };  // LogProblem
 
@@ -340,8 +340,8 @@ public:
 
 private:
   MessageSender ap; 
-  LogImportant( LogImportant const& );				// Change log 9
-  LogImportant& operator=( LogImportant const& );
+  LogImportant( LogImportant const& ) = delete;				// Change log 9
+  LogImportant& operator=( LogImportant const& ) = delete;
 
 };  // LogImportant
 
@@ -366,8 +366,8 @@ public:
 
 private:
   MessageSender ap; 
-  LogAbsolute( LogAbsolute const& );				// Change log 9
-  LogAbsolute& operator=( LogAbsolute const& );
+  LogAbsolute( LogAbsolute const& ) = delete;				// Change log 9
+  LogAbsolute& operator=( LogAbsolute const& ) = delete;
 
 };  // LogAbsolute
 
@@ -458,8 +458,8 @@ public:
 				      { if(ap.valid()) ap << f; return *this; }     
 private:
   MessageSender ap; 
-  LogWarningThatSuppressesLikeLogInfo( LogWarningThatSuppressesLikeLogInfo const& );				// Change log 9
-  LogWarningThatSuppressesLikeLogInfo& operator=( LogWarningThatSuppressesLikeLogInfo const& );
+  LogWarningThatSuppressesLikeLogInfo( LogWarningThatSuppressesLikeLogInfo const& ) = delete;				// Change log 9
+  LogWarningThatSuppressesLikeLogInfo& operator=( LogWarningThatSuppressesLikeLogInfo const& ) = delete;
    
 };  // LogWarningThatSuppressesLikeLogInfo
 } // end namespace edmmltest

--- a/FWCore/MessageLogger/interface/MessageLoggerQ.h
+++ b/FWCore/MessageLogger/interface/MessageLoggerQ.h
@@ -77,8 +77,8 @@ private:
 				   std::string const & commandMnemonic);
 
   // --- no copying:
-  MessageLoggerQ( MessageLoggerQ const & );
-  void  operator = ( MessageLoggerQ const & );
+  MessageLoggerQ( MessageLoggerQ const & ) = delete;
+  void  operator = ( MessageLoggerQ const & ) = delete;
 
   // --- data:
   [[cms::thread_safe]] static  std::shared_ptr<edm::service::AbstractMLscribe> mlscribe_ptr;

--- a/FWCore/MessageLogger/interface/SilentMLscribe.h
+++ b/FWCore/MessageLogger/interface/SilentMLscribe.h
@@ -30,17 +30,17 @@ namespace edm {
          
       public:
          SilentMLscribe();
-         virtual ~SilentMLscribe();
+         ~SilentMLscribe() override;
          
          
          // ---------- member functions ---------------------------
-         virtual
-         void  runCommand(MessageLoggerQ::OpCode  opcode, void * operand);
+         
+         void  runCommand(MessageLoggerQ::OpCode  opcode, void * operand) override;
          
       private:
-         SilentMLscribe(const SilentMLscribe&); // stop default
+         SilentMLscribe(const SilentMLscribe&) = delete; // stop default
          
-         const SilentMLscribe& operator=(const SilentMLscribe&); // stop default
+         const SilentMLscribe& operator=(const SilentMLscribe&) = delete; // stop default
          
          // ---------- member data --------------------------------
          

--- a/FWCore/MessageLogger/src/ELmap.cc
+++ b/FWCore/MessageLogger/src/ELmap.cc
@@ -47,7 +47,7 @@ LimitAndTimespan::LimitAndTimespan( int lim, int ts, int ivl )
 CountAndLimit::CountAndLimit( int lim, int ts, int ivl )
 : n         ( 0 )
 , aggregateN( 0 )
-, lastTime  ( time(0) )
+, lastTime  ( time(nullptr) )
 , limit     ( lim )
 , timespan  ( ts  )
 , interval  ( ivl )
@@ -57,7 +57,7 @@ CountAndLimit::CountAndLimit( int lim, int ts, int ivl )
 
 bool  CountAndLimit::add()  {
 
-  time_t  now = time(0);
+  time_t  now = time(nullptr);
 
 #ifdef ELcountTRACE
   std::cerr << "&&&--- CountAndLimit::add \n";

--- a/FWCore/MessageLogger/src/ErrorObj.cc
+++ b/FWCore/MessageLogger/src/ErrorObj.cc
@@ -244,7 +244,7 @@ void ErrorObj::set( const ELseverityLevel & sev, const ELstring & id )  {
 
   clear();
 
-  myTimestamp = time( 0 );
+  myTimestamp = time( nullptr );
   mySerial = ++ ourSerial;
 
   setID( id );

--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -328,7 +328,7 @@ namespace edm {
   }
 
     JobReport::JobReport() :
-      impl_(new JobReportImpl(0)) {
+      impl_(new JobReportImpl(nullptr)) {
     }
 
     JobReport::JobReport(std::ostream* iOstream) : impl_(new JobReportImpl(iOstream)) {

--- a/FWCore/MessageLogger/src/MessageDrop.cc
+++ b/FWCore/MessageLogger/src/MessageDrop.cc
@@ -88,7 +88,7 @@ class StringProducerWithPhase : public StringProducer
     {
     }
 
-    virtual std::string theContext() const override {
+    std::string theContext() const override {
       if (cache_.empty()) {
         if (moduleID_ != std::numeric_limits<unsigned int>::max()) {
           auto nameLableIter = idLabelMap_.find(moduleID_);
@@ -133,7 +133,7 @@ class StringProducerPath : public StringProducer{
     , cache_()
     {
     }
-     virtual std::string theContext() const override {
+     std::string theContext() const override {
       if ( cache_.empty() ) {
         cache_.assign(typePtr_);
         cache_.append(path_);
@@ -157,7 +157,7 @@ class StringProducerSinglet : public StringProducer{
     : singlet_("(NoModuleName)")
     {
     }
-    virtual std::string theContext() const override {
+    std::string theContext() const override {
       return singlet_;
     }
     void set(const char * sing) {singlet_ = sing; } 

--- a/FWCore/MessageLogger/src/MessageLoggerQ.cc
+++ b/FWCore/MessageLogger/src/MessageLoggerQ.cc
@@ -59,13 +59,13 @@ namespace {
       StandAloneScribe() {}
             
       // ---------- member functions ---------------------------
-      virtual
+      
       void  runCommand(edm::MessageLoggerQ::OpCode  opcode, void * operand) override;
       
    private:
-      StandAloneScribe(const StandAloneScribe&); // stop default
+      StandAloneScribe(const StandAloneScribe&) = delete; // stop default
       
-      const StandAloneScribe& operator=(const StandAloneScribe&); // stop default
+      const StandAloneScribe& operator=(const StandAloneScribe&) = delete; // stop default
       
       // ---------- member data --------------------------------
       
@@ -175,13 +175,13 @@ void
 void
   MessageLoggerQ::MLqEND()
 {
-  simpleCommand (END_THREAD, (void *)0); 
+  simpleCommand (END_THREAD, (void *)nullptr); 
 }  // MessageLoggerQ::END()
 
 void
   MessageLoggerQ::MLqSHT()
 {
-  simpleCommand (SHUT_UP, (void *)0); 
+  simpleCommand (SHUT_UP, (void *)nullptr); 
 }  // MessageLoggerQ::SHT()
 
 void
@@ -200,7 +200,7 @@ void
 void
   MessageLoggerQ::MLqSUM( )
 {
-  simpleCommand (SUMMARIZE, 0); 
+  simpleCommand (SUMMARIZE, nullptr); 
 }  // MessageLoggerQ::SUM()
 
 void
@@ -217,7 +217,7 @@ void
   // place to convey exception information.  FLS does not need this, nor does
   // it need the parameter set, but we are reusing ConfigurationHandshake 
   // rather than reinventing the mechanism.
-  handshakedCommand(FLUSH_LOG_Q, 0, "FLS" );
+  handshakedCommand(FLUSH_LOG_Q, nullptr, "FLS" );
 }  // MessageLoggerQ::FLS()
 
 void

--- a/FWCore/MessageLogger/src/MessageSender.cc
+++ b/FWCore/MessageLogger/src/MessageSender.cc
@@ -97,7 +97,7 @@ MessageSender::MessageSender( ELseverityLevel const & sev,
 // boost::thread_resoruce_error is thrown at static destruction time,
 // if the MessageLogger library is loaded -- even if it is not used.
 void MessageSender::ErrorObjDeleter::operator()(ErrorObj * errorObjPtr) {
-  if (errorObjPtr == 0) {
+  if (errorObjPtr == nullptr) {
     return;
   }
   try 
@@ -170,7 +170,7 @@ namespace edm {
   
   bool FreshErrorsExist(unsigned int iStreamID) {
     assert(iStreamID<errorSummaryMaps.size());
-    return  errorSummaryMaps[iStreamID].size()>0;
+    return  !errorSummaryMaps[iStreamID].empty();
   }
   
   std::vector<ErrorSummaryEntry> LoggedErrorsSummary(unsigned int iStreamID) {

--- a/FWCore/MessageService/interface/ELdestination.h
+++ b/FWCore/MessageService/interface/ELdestination.h
@@ -131,8 +131,8 @@ protected:
   // -----  Verboten methods:
   //
 private:
-  ELdestination( const ELdestination & orig );
-  ELdestination& operator= ( const ELdestination & orig );
+  ELdestination( const ELdestination & orig ) = delete;
+  ELdestination& operator= ( const ELdestination & orig ) = delete;
 
 };  // ELdestination
 

--- a/FWCore/MessageService/interface/ELoutput.h
+++ b/FWCore/MessageService/interface/ELoutput.h
@@ -54,12 +54,12 @@ public:
   ELoutput( std::ostream & os, bool emitAtStart = false );	// 6/11/07 mf
   ELoutput( const ELstring & fileName, bool emitAtStart = false );
   ELoutput( const ELoutput & orig );
-  virtual ~ELoutput();
+  ~ELoutput() override;
 
   // ---  Methods invoked by the ELadministrator:
   //
 public:
-  virtual bool log( const edm::ErrorObj & msg ) override;
+  bool log( const edm::ErrorObj & msg ) override;
 
 protected:
     // trivial clearSummary(), wipe(), zero() from base class
@@ -71,28 +71,28 @@ protected:
 protected:
   void emitToken( const ELstring & s, bool nl=false ) ;
 
-  virtual void suppressTime() override;
-  virtual void includeTime() override;
-  virtual void suppressModule()override;
-  virtual void includeModule() override;
-  virtual void suppressSubroutine() override;
-  virtual void includeSubroutine() override;
-  virtual void suppressText() override;
-  virtual void includeText() override;
-  virtual void suppressContext() override;
-  virtual void includeContext() override;
-  virtual void suppressSerial() override;
-  virtual void includeSerial() override;
-  virtual void useFullContext() override;
-  virtual void useContext() override;
-  virtual void separateTime() override;
-  virtual void attachTime() override;
-  virtual void separateEpilogue() override;
-  virtual void attachEpilogue() override;
+  void suppressTime() override;
+  void includeTime() override;
+  void suppressModule()override;
+  void includeModule() override;
+  void suppressSubroutine() override;
+  void includeSubroutine() override;
+  void suppressText() override;
+  void includeText() override;
+  void suppressContext() override;
+  void includeContext() override;
+  void suppressSerial() override;
+  void includeSerial() override;
+  void useFullContext() override;
+  void useContext() override;
+  void separateTime() override;
+  void attachTime() override;
+  void separateEpilogue() override;
+  void attachEpilogue() override;
 
-  virtual void changeFile (std::ostream & os) override;
-  virtual void changeFile (const ELstring & filename) override;
-  virtual void flush() override;
+  void changeFile (std::ostream & os) override;
+  void changeFile (const ELstring & filename) override;
+  void flush() override;
 
 
 protected:

--- a/FWCore/MessageService/interface/ELstatistics.h
+++ b/FWCore/MessageService/interface/ELstatistics.h
@@ -61,7 +61,7 @@ public:
   ELstatistics( int spaceLimit );
   ELstatistics( int spaceLimit, std::ostream & osp );
   ELstatistics( const ELstatistics & orig );
-  virtual ~ELstatistics();
+  ~ELstatistics() override;
 
   // -----  Methods invoked by the ELadministrator:
   //
@@ -71,7 +71,7 @@ public:
 		//-| of copying a destination onto the list:  ofstream
 		//-| ownership is passed to the new copy.
 
-  virtual bool log( const edm::ErrorObj & msg ) override;
+  bool log( const edm::ErrorObj & msg ) override;
 
   // output( const ELstring & item, const ELseverityLevel & sev )
   // from base class
@@ -85,12 +85,12 @@ public:
   void summary( unsigned long overfullWaitCount );
   void noTerminationSummary();
   void summaryForJobReport (std::map<std::string, double> & sm);
-  virtual void wipe() override;
+  void wipe() override;
 
 protected:
   void clearSummary();
 
-  virtual void zero() override;
+  void zero() override;
 
 
   std::map<ELextendedID,StatsCount> statisticsMap() const;

--- a/FWCore/MessageService/interface/MainThreadMLscribe.h
+++ b/FWCore/MessageService/interface/MainThreadMLscribe.h
@@ -41,11 +41,11 @@ class MainThreadMLscribe : public AbstractMLscribe
 public:
   // ---  birth/death:
   MainThreadMLscribe(std::shared_ptr<ThreadQueue> tqp);
-  virtual ~MainThreadMLscribe();
+  ~MainThreadMLscribe() override;
 
   // --- receive and act on messages:
-  virtual							
-  void  runCommand(MessageLoggerQ::OpCode  opcode, void * operand);
+  							
+  void  runCommand(MessageLoggerQ::OpCode  opcode, void * operand) override;
 		  						
 
 private:

--- a/FWCore/MessageService/interface/MessageLoggerScribe.h
+++ b/FWCore/MessageService/interface/MessageLoggerScribe.h
@@ -92,13 +92,13 @@ public:
   /// --- If queue is NULL, this sets singleThread true 
   explicit MessageLoggerScribe(std::shared_ptr<ThreadQueue> queue);
   
-  virtual ~MessageLoggerScribe();
+  ~MessageLoggerScribe() override;
 
   // --- receive and act on messages:
   virtual
   void  run();
-  virtual							// changelog 10
-  void  runCommand(MessageLoggerQ::OpCode  opcode, void * operand);
+  							// changelog 10
+  void  runCommand(MessageLoggerQ::OpCode  opcode, void * operand) override;
 		  						// changeLog 9
 
 private:

--- a/FWCore/MessageService/interface/MessageServicePresence.h
+++ b/FWCore/MessageService/interface/MessageServicePresence.h
@@ -19,7 +19,7 @@ class MessageServicePresence : public Presence
 public:
   // ---  birth/death:
   MessageServicePresence();
-  ~MessageServicePresence();
+  ~MessageServicePresence() override;
 
 private:
   // --- no copying:

--- a/FWCore/MessageService/interface/SingleThreadMSPresence.h
+++ b/FWCore/MessageService/interface/SingleThreadMSPresence.h
@@ -11,15 +11,15 @@ class SingleThreadMSPresence : public Presence
 public:
   // ---  birth/death:
   SingleThreadMSPresence();
-  ~SingleThreadMSPresence();
+  ~SingleThreadMSPresence() override;
 
   // --- Access to the scribe
   // REMOVED AbstractMLscribe * scribe_ptr() { return &m; }  
 
 private:
   // --- no copying:
-  SingleThreadMSPresence(SingleThreadMSPresence const &);
-  void  operator = (SingleThreadMSPresence const &);
+  SingleThreadMSPresence(SingleThreadMSPresence const &) = delete;
+  void  operator = (SingleThreadMSPresence const &) = delete;
   
 };  // SingleThreadMSPresence
 

--- a/FWCore/MessageService/interface/ThreadQueue.h
+++ b/FWCore/MessageService/interface/ThreadQueue.h
@@ -48,9 +48,9 @@ class ThreadQueue
 
  
    private:
-      ThreadQueue(const ThreadQueue&); // stop default
+      ThreadQueue(const ThreadQueue&) = delete; // stop default
 
-      const ThreadQueue& operator=(const ThreadQueue&); // stop default
+      const ThreadQueue& operator=(const ThreadQueue&) = delete; // stop default
 
       // ---------- member data --------------------------------
 

--- a/FWCore/MessageService/interface/ThreadSafeLogMessageLoggerScribe.h
+++ b/FWCore/MessageService/interface/ThreadSafeLogMessageLoggerScribe.h
@@ -44,11 +44,11 @@ public:
   /// --- If queue is NULL, this sets singleThread true 
   explicit ThreadSafeLogMessageLoggerScribe();
   
-  virtual ~ThreadSafeLogMessageLoggerScribe();
+  ~ThreadSafeLogMessageLoggerScribe() override;
 
   // --- receive and act on messages:
-  virtual							// changelog 10
-  void  runCommand(MessageLoggerQ::OpCode  opcode, void * operand);
+  							// changelog 10
+  void  runCommand(MessageLoggerQ::OpCode  opcode, void * operand) override;
 		  						// changeLog 9
 
 private:

--- a/FWCore/MessageService/src/ELoutput.cc
+++ b/FWCore/MessageService/src/ELoutput.cc
@@ -239,7 +239,7 @@ ELoutput::ELoutput( const ELstring & fileName, bool emitAtStart )
     }
   }
   if (emitAtStart) {
-    ELstring const& ftime = formatTime(time(0)); // Change log 7
+    ELstring const& ftime = formatTime(time(nullptr)); // Change log 7
     emitToken( ftime, true );
     emitToken( "\n=======================================================\n",
                                                                 true );
@@ -645,7 +645,7 @@ void ELoutput::changeFile (std::ostream & os_) {
   os.reset(&os_, do_nothing_deleter());
   emitToken( "\n=======================================================", true );
   emitToken( "\nError Log changed to this stream\n" );
-  ELstring const& ftime = formatTime(time(0)); // Change log 7
+  ELstring const& ftime = formatTime(time(nullptr)); // Change log 7
   emitToken( ftime, true );
   emitToken( "\n=======================================================\n", true );
 }
@@ -654,7 +654,7 @@ void ELoutput::changeFile (const ELstring & filename) {
   os.reset(new std::ofstream( filename.c_str(), std::ios/*_base*/::app), close_and_delete());
   emitToken( "\n=======================================================", true );
   emitToken( "\nError Log changed to this file\n" );
-  ELstring const& ftime = formatTime(time(0)); // Change log 7
+  ELstring const& ftime = formatTime(time(nullptr)); // Change log 7
   emitToken( ftime, true );
   emitToken( "\n=======================================================\n", true );
 }

--- a/FWCore/MessageService/src/MessageLoggerScribe.cc
+++ b/FWCore/MessageService/src/MessageLoggerScribe.cc
@@ -202,7 +202,7 @@
 #include <cassert>
 #include <fstream>
 #include <string>
-#include <signal.h>
+#include <csignal>
 
 using std::cerr;
 
@@ -217,7 +217,7 @@ MessageLoggerScribe::MessageLoggerScribe(std::shared_ptr<ThreadQueue> queue)
 , job_pset_p( )
 , clean_slate_configuration( true )
 , active( true )
-, singleThread (queue.get() == 0)				// changeLog 36
+, singleThread (queue.get() == nullptr)				// changeLog 36
 , done (false)							// changeLog 32
 , purge_mode (false)						// changeLog 32
 , count (false)							// changeLog 32
@@ -262,7 +262,7 @@ void
       break;
     }
     case MessageLoggerQ::END_THREAD:  {
-      assert( operand == 0 );
+      assert( operand == nullptr );
       done = true;
       MessageDrop::instance()->messageLoggerScribeIsRunning = 
 	      (unsigned char) -1; 				// ChangeLog 30
@@ -331,7 +331,7 @@ void
       }
     }
     case MessageLoggerQ::SUMMARIZE: {
-      assert( operand == 0 );
+      assert( operand == nullptr );
       try {
 	triggerStatisticsSummaries();
       }
@@ -362,7 +362,7 @@ void
       break;
     }
     case MessageLoggerQ::SHUT_UP:  {
-      assert( operand == 0 );
+      assert( operand == nullptr );
       active = false;
       break;
     }
@@ -603,7 +603,7 @@ void
     if (timespan == NO_VALUE_SET) timespan = dest_default_timespan;
        								// change log 7 
 
-    std::string category = msgID;
+    const std::string& category = msgID;
     if ( limit     == NO_VALUE_SET )  {				// change log 24
        limit = messageLoggerDefaults->limit(filename,category);
     }  
@@ -863,7 +863,7 @@ void
      )
   {
     String statname = *it;
-    String psetname = statname;
+    const String& psetname = statname;
 
     // check that this destination is not just a placeholder // change log 20
     PSet  stat_pset = getAparameter<PSet>(*job_pset_p, psetname, empty_PSet);

--- a/FWCore/MessageService/src/MessageServicePSetValidation.cc
+++ b/FWCore/MessageService/src/MessageServicePSetValidation.cc
@@ -174,7 +174,7 @@ suppressionLists ( ParameterSet const & pset )
   } 
   suppressDebug = check<vString>
   	(pset, "MessageLogger", "suppressDebug");
-  if ( (suppressDebug.size() > 0)  && (!dmStar) ) {
+  if ( (!suppressDebug.empty())  && (!dmStar) ) {
     flaws << "MessageLogger" << " PSet: \n"
 	  << "suppressDebug contains modules, but debugModules is not *\n"
 	  << "Unless all the debugModules are enabled,\n"

--- a/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.cc
+++ b/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.cc
@@ -28,7 +28,7 @@
 #include <cassert>
 #include <fstream>
 #include <string>
-#include <signal.h>
+#include <csignal>
 
 using std::cerr;
 
@@ -120,7 +120,7 @@ namespace edm {
           break;
         }
         case MessageLoggerQ::SUMMARIZE: {
-          assert( operand == 0 );
+          assert( operand == nullptr );
           try {
             triggerStatisticsSummaries();
           }
@@ -151,7 +151,7 @@ namespace edm {
           break;
         }
         case MessageLoggerQ::SHUT_UP:  {
-          assert( operand == 0 );
+          assert( operand == nullptr );
           active = false;
           break;
         }
@@ -390,7 +390,7 @@ namespace edm {
         if (timespan == NO_VALUE_SET) timespan = dest_default_timespan;
         // change log 7
         
-        std::string category = msgID;
+        const std::string& category = msgID;
         if ( limit     == NO_VALUE_SET )  {				// change log 24
           limit = messageLoggerDefaults->limit(filename,category);
         }
@@ -648,7 +648,7 @@ namespace edm {
           )
       {
         String statname = *it;
-        String psetname = statname;
+        const String& psetname = statname;
         
         // check that this destination is not just a placeholder // change log 20
         PSet  stat_pset = getAparameter<PSet>(*job_pset_p, psetname, empty_PSet);

--- a/FWCore/Modules/src/AbortOnEventIDAnalyzer.cc
+++ b/FWCore/Modules/src/AbortOnEventIDAnalyzer.cc
@@ -29,7 +29,7 @@
 #include <algorithm>
 #include <memory>
 #include <vector>
-#include <stdlib.h>
+#include <cstdlib>
 
 //
 // class decleration
@@ -38,14 +38,14 @@
 class AbortOnEventIDAnalyzer : public edm::EDAnalyzer {
 public:
    explicit AbortOnEventIDAnalyzer(edm::ParameterSet const&);
-   ~AbortOnEventIDAnalyzer();
+   ~AbortOnEventIDAnalyzer() override;
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 
 private:
-   virtual void beginJob() override;
-   virtual void analyze(edm::Event const&, edm::EventSetup const&) override;
-   virtual void endJob() override;
+   void beginJob() override;
+   void analyze(edm::Event const&, edm::EventSetup const&) override;
+   void endJob() override;
 
    // ----------member data ---------------------------
    std::vector<edm::EventID> ids_;

--- a/FWCore/Modules/src/AsciiOutputModule.cc
+++ b/FWCore/Modules/src/AsciiOutputModule.cc
@@ -23,13 +23,13 @@ namespace edm {
   public:
     // We do not take ownership of passed stream.
     explicit AsciiOutputModule(ParameterSet const& pset);
-    virtual ~AsciiOutputModule();
+    ~AsciiOutputModule() override;
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
   private:
-    virtual void write(EventForOutput const& e) override;
-    virtual void writeLuminosityBlock(LuminosityBlockForOutput const&) override {}
-    virtual void writeRun(RunForOutput const&) override {}
+    void write(EventForOutput const& e) override;
+    void writeLuminosityBlock(LuminosityBlockForOutput const&) override {}
+    void writeRun(RunForOutput const&) override {}
     int prescale_;
     int verbosity_;
     int counter_;

--- a/FWCore/Modules/src/EmptyESSource.cc
+++ b/FWCore/Modules/src/EmptyESSource.cc
@@ -24,9 +24,9 @@ class EmptyESSource : public  EventSetupRecordIntervalFinder {
                         ValidityInterval& oInterval) override;
       
    private:
-      EmptyESSource(EmptyESSource const&); // stop default
+      EmptyESSource(EmptyESSource const&) = delete; // stop default
 
-      EmptyESSource const& operator=(EmptyESSource const&); // stop default
+      EmptyESSource const& operator=(EmptyESSource const&) = delete; // stop default
       
       void delaySettingRecords() override;
       // ---------- member data --------------------------------
@@ -71,7 +71,7 @@ EmptyESSource::setIntervalFor(eventsetup::EventSetupRecordKey const&,
                                ValidityInterval& oInterval) {
    oInterval = ValidityInterval::invalidInterval();
    //if no intervals given, fail immediately
-   if (setOfIOV_.size() == 0) {
+   if (setOfIOV_.empty()) {
       return;
    }
    

--- a/FWCore/Modules/src/EmptySource.cc
+++ b/FWCore/Modules/src/EmptySource.cc
@@ -8,11 +8,11 @@ namespace edm {
   class EmptySource : public ProducerSourceBase {
   public:
     explicit EmptySource(ParameterSet const&, InputSourceDescription const&);
-    ~EmptySource();
+    ~EmptySource() override;
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
   private:
-    virtual bool setRunAndEventInfo(EventID& id, TimeValue_t& time, edm::EventAuxiliary::ExperimentType&) override;
-    virtual void produce(Event &) override;
+    bool setRunAndEventInfo(EventID& id, TimeValue_t& time, edm::EventAuxiliary::ExperimentType&) override;
+    void produce(Event &) override;
   };
 
   EmptySource::EmptySource(ParameterSet const& pset,

--- a/FWCore/Modules/src/EventAuxiliaryHistoryProducer.cc
+++ b/FWCore/Modules/src/EventAuxiliaryHistoryProducer.cc
@@ -12,10 +12,10 @@ namespace edm {
   class EventAuxiliaryHistoryProducer : public EDProducer {
   public:
     explicit EventAuxiliaryHistoryProducer(ParameterSet const&);
-    virtual ~EventAuxiliaryHistoryProducer();
+    ~EventAuxiliaryHistoryProducer() override;
 
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
-    virtual void produce(Event& e, EventSetup const& c) override;
+    void produce(Event& e, EventSetup const& c) override;
     void endJob() override;
 
   private:
@@ -36,7 +36,7 @@ namespace edm {
     EventAuxiliary aux(e.id(), "", e.time(), e.isRealData(), e.experimentType(),
                        e.bunchCrossing(), EventAuxiliary::invalidStoreNumber, e.orbitNumber()); 
   //EventAuxiliary const& aux = e.auxiliary(); // when available
-    if(history_.size() > 0) {
+    if(!history_.empty()) {
       if(history_.back().id().next(aux.luminosityBlock()) != aux.id()) history_.clear();
       if(history_.size() >= depth_) history_.pop_front();
     }

--- a/FWCore/Modules/src/EventContentAnalyzer.cc
+++ b/FWCore/Modules/src/EventContentAnalyzer.cc
@@ -118,15 +118,15 @@ namespace edm {
                      ObjectWithDict const& iObject,
                      std::string const& iIndent,
                      std::string const& iIndentDelta) {
-       std::string printName = iName;
-       ObjectWithDict objectToPrint = iObject;
+       const std::string& printName = iName;
+       const ObjectWithDict& objectToPrint = iObject;
        std::string indent(iIndent);
        if(iObject.typeOf().isPointer()) {
          LogAbsolute("EventContent") << iIndent << iName << kNameValueSep << formatClassName(iObject.typeOf().name()) << std::hex << iObject.address() << std::dec;// << "\n";
           TypeWithDict pointedType = iObject.typeOf().toType(); // for Pointers, I get the real type this way
           if(TypeWithDict::byName("void") == pointedType ||
              pointedType.isPointer() ||
-             iObject.address() == 0) {
+             iObject.address() == nullptr) {
              return;
           }
           return;
@@ -200,7 +200,7 @@ namespace edm {
           // memory for a ref (which should just be a pointer to the object and not the object itself)
           //So we will create memory on the stack which can be used to hold a reference
           bool const isRef = atReturnType.isReference();
-          void* refMemoryBuffer = 0;
+          void* refMemoryBuffer = nullptr;
           size_t index = 0;
           //The argument to the 'at' function is the index. Since the argument list holds pointers to the arguments
           // we only need to create it once and then when the value of index changes the pointer already
@@ -262,10 +262,10 @@ namespace edm {
   class EventContentAnalyzer : public EDAnalyzer {
   public:
      explicit EventContentAnalyzer(ParameterSet const&);
-     ~EventContentAnalyzer();
+     ~EventContentAnalyzer() override;
 
-     virtual void analyze(Event const&, EventSetup const&) override;
-     virtual void endJob() override;
+     void analyze(Event const&, EventSetup const&) override;
+     void endJob() override;
 
      static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
@@ -290,9 +290,9 @@ namespace edm {
     indentation_(iConfig.getUntrackedParameter("indentation", std::string("++"))),
     verboseIndentation_(iConfig.getUntrackedParameter("verboseIndentation", std::string("  "))),
     moduleLabels_(iConfig.getUntrackedParameter("verboseForModuleLabels", std::vector<std::string>())),
-    verbose_(iConfig.getUntrackedParameter("verbose", false) || moduleLabels_.size()>0),
+    verbose_(iConfig.getUntrackedParameter("verbose", false) || !moduleLabels_.empty()),
     getModuleLabels_(iConfig.getUntrackedParameter("getDataForModuleLabels", std::vector<std::string>())),
-    getData_(iConfig.getUntrackedParameter("getData", false) || getModuleLabels_.size()>0),
+    getData_(iConfig.getUntrackedParameter("getData", false) || !getModuleLabels_.empty()),
     evno_(1),
     listContent_(iConfig.getUntrackedParameter("listContent", true))
   {

--- a/FWCore/Modules/src/EventIDChecker.cc
+++ b/FWCore/Modules/src/EventIDChecker.cc
@@ -37,14 +37,14 @@
 class EventIDChecker : public edm::EDAnalyzer {
 public:
    explicit EventIDChecker(edm::ParameterSet const&);
-   ~EventIDChecker();
+   ~EventIDChecker() override;
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 
 private:
-   virtual void beginJob() override;
-   virtual void analyze(edm::Event const&, edm::EventSetup const&) override;
-   virtual void endJob() override;
+   void beginJob() override;
+   void analyze(edm::Event const&, edm::EventSetup const&) override;
+   void endJob() override;
 
    // ----------member data ---------------------------
    std::vector<edm::EventID> ids_;

--- a/FWCore/Modules/src/EventSetupCacheIdentifierChecker.cc
+++ b/FWCore/Modules/src/EventSetupCacheIdentifierChecker.cc
@@ -44,19 +44,19 @@ namespace edm {
   class EventSetupCacheIdentifierChecker : public edm::EDAnalyzer {
    public:
     explicit EventSetupCacheIdentifierChecker(const edm::ParameterSet&);
-    ~EventSetupCacheIdentifierChecker();
+    ~EventSetupCacheIdentifierChecker() override;
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 
    private:
     //virtual void beginJob() ;
-    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
     //virtual void endJob() ;
 
-    virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+    void beginRun(edm::Run const&, edm::EventSetup const&) override;
     //virtual void endRun(edm::Run const&, edm::EventSetup const&);
-    virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
     //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
 
     void check(edm::EventSetup const&);
@@ -150,7 +150,7 @@ EventSetupCacheIdentifierChecker::beginLuminosityBlock(edm::LuminosityBlock cons
 void
 EventSetupCacheIdentifierChecker::check(edm::EventSetup const& iSetup)
 {
-  if(0==m_recordKeysToExpectedCacheIdentifiers.size()) {
+  if(m_recordKeysToExpectedCacheIdentifiers.empty()) {
     initialize();
   }
   using namespace edm::eventsetup;
@@ -160,13 +160,13 @@ EventSetupCacheIdentifierChecker::check(edm::EventSetup const& iSetup)
       it != itEnd;
       ++it) {
     EventSetupRecord const* pRecord = iSetup.find(it->first);
-    if(0 == pRecord) {
+    if(nullptr == pRecord) {
       edm::LogWarning("RecordNotInIOV") <<"The EventSetup Record '"<<it->first.name()<<"' is not available for this IOV.";
     }
     if(it->second.size() <= m_index) {
       throw cms::Exception("TooFewCacheIDs")<<"The vector of cacheIdentifiers for the record "<<it->first.name()<<" is too short";
     }
-    if(0 != pRecord && pRecord->cacheIdentifier() != it->second[m_index]) {
+    if(nullptr != pRecord && pRecord->cacheIdentifier() != it->second[m_index]) {
       throw cms::Exception("IncorrectCacheID")<<"The Record "<<it->first.name()<<" was supposed to have cacheIdentifier: "<<it->second[m_index]<<" but instead has "<<pRecord->cacheIdentifier();
     }
   }

--- a/FWCore/Modules/src/EventSetupRecordDataGetter.cc
+++ b/FWCore/Modules/src/EventSetupRecordDataGetter.cc
@@ -41,12 +41,12 @@ namespace edm {
    class EventSetupRecordDataGetter : public edm::stream::EDAnalyzer< > {
 public:
      explicit EventSetupRecordDataGetter(ParameterSet const&);
-     ~EventSetupRecordDataGetter();
+     ~EventSetupRecordDataGetter() override;
       
       
-     virtual void analyze(Event const&, EventSetup const&) override;
-     virtual void beginRun(Run const&, EventSetup const&) override;
-     virtual void beginLuminosityBlock(LuminosityBlock const&, EventSetup const&) override;
+     void analyze(Event const&, EventSetup const&) override;
+     void beginRun(Run const&, EventSetup const&) override;
+     void beginLuminosityBlock(LuminosityBlock const&, EventSetup const&) override;
 
      static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
@@ -129,7 +129,7 @@ private:
    
    void
    EventSetupRecordDataGetter::doGet(EventSetup const& iSetup) {  
-      if(0 == recordToDataKeys_.size()) {
+      if(recordToDataKeys_.empty()) {
          typedef std::vector<ParameterSet> Parameters;
          Parameters const& toGet = pSet_.getParameterSetVector("toGet");
          
@@ -177,7 +177,7 @@ private:
                 itRKey != itRKeyEnd;
                 ++itRKey) {               
                eventsetup::EventSetupRecord const* record = iSetup.find(*itRKey);
-               assert(record != 0);
+               assert(record != nullptr);
                dataKeys.clear();
                record->fillRegisteredDataKeys(dataKeys);
                recordToDataKeys_.insert(std::make_pair(*itRKey, dataKeys));
@@ -194,10 +194,10 @@ private:
            itRecord != itRecordEnd;
            ++itRecord) {
          EventSetupRecord const* pRecord = iSetup.find(itRecord->first);
-         if(0 == pRecord) {
+         if(nullptr == pRecord) {
            edm::LogWarning("RecordNotInIOV") <<"The EventSetup Record '"<<itRecord->first.name()<<"' is not available for this IOV.";
          }
-         if(0 != pRecord && pRecord->cacheIdentifier() != recordToCacheIdentifier_[itRecord->first]) {
+         if(nullptr != pRecord && pRecord->cacheIdentifier() != recordToCacheIdentifier_[itRecord->first]) {
             recordToCacheIdentifier_[itRecord->first] = pRecord->cacheIdentifier();
             typedef std::vector<DataKey> Keys;
             Keys const& keys = itRecord->second;

--- a/FWCore/Modules/src/GetProductCheckerOutputModule.cc
+++ b/FWCore/Modules/src/GetProductCheckerOutputModule.cc
@@ -33,13 +33,13 @@ namespace edm {
    public:
       // We do not take ownership of passed stream.
       explicit GetProductCheckerOutputModule(ParameterSet const& pset);
-      virtual ~GetProductCheckerOutputModule();
+      ~GetProductCheckerOutputModule() override;
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void write(EventForOutput const& e) override;
-      virtual void writeLuminosityBlock(LuminosityBlockForOutput const&) override;
-      virtual void writeRun(RunForOutput const&) override;
+      void write(EventForOutput const& e) override;
+      void writeLuminosityBlock(LuminosityBlockForOutput const&) override;
+      void writeRun(RunForOutput const&) override;
    };
 
 //

--- a/FWCore/Modules/src/IterateNTimesLooper.cc
+++ b/FWCore/Modules/src/IterateNTimesLooper.cc
@@ -23,21 +23,21 @@ namespace edm {
 
     public:
       IterateNTimesLooper(ParameterSet const&);
-      virtual ~IterateNTimesLooper();
+      ~IterateNTimesLooper() override;
 
       // ---------- const member functions ---------------------
 
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------
-      virtual void startingNewLoop(unsigned int) override;
-      virtual Status duringLoop(Event const&, EventSetup const&) override;
-      virtual Status endOfLoop(EventSetup const&, unsigned int) override;
+      void startingNewLoop(unsigned int) override;
+      Status duringLoop(Event const&, EventSetup const&) override;
+      Status endOfLoop(EventSetup const&, unsigned int) override;
 
     private:
-      IterateNTimesLooper(IterateNTimesLooper const&); // stop default
+      IterateNTimesLooper(IterateNTimesLooper const&) = delete; // stop default
 
-      IterateNTimesLooper const& operator=(IterateNTimesLooper const&); // stop default
+      IterateNTimesLooper const& operator=(IterateNTimesLooper const&) = delete; // stop default
 
       // ---------- member data --------------------------------
       unsigned int max_;

--- a/FWCore/Modules/src/LogErrorFilter.cc
+++ b/FWCore/Modules/src/LogErrorFilter.cc
@@ -35,13 +35,13 @@
 class LogErrorFilter : public edm::stream::EDFilter<> {
 public:
   explicit LogErrorFilter(edm::ParameterSet const&);
-  ~LogErrorFilter();
+  ~LogErrorFilter() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual bool filter(edm::Event&, edm::EventSetup const&) override;
+  bool filter(edm::Event&, edm::EventSetup const&) override;
 
-  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override ;
+  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override ;
 
   // ----------member data ---------------------------
   edm::EDGetTokenT<std::vector<edm::ErrorSummaryEntry>> harvesterToken_;
@@ -134,7 +134,7 @@ LogErrorFilter::filter(edm::Event& iEvent, edm::EventSetup const&) {
     } else {
       //no separation by kind, just count any errors/warnings
       if(atLeastOneEntry_) {
-	if(avoidCategories_.size() != 0) {
+	if(!avoidCategories_.empty()) {
 	  for(unsigned int iE = 0; iE != errorsAndWarnings->size(); ++iE) {
 	    //veto categories from user input.
 	    if(std::find(avoidCategories_.begin(),avoidCategories_.end(), ((*errorsAndWarnings)[iE]).category) != avoidCategories_.end()) {
@@ -145,7 +145,7 @@ LogErrorFilter::filter(edm::Event& iEvent, edm::EventSetup const&) {
 	  }
 	  return false;
 	} else {
-	  return (errorsAndWarnings->size() != 0);
+	  return (!errorsAndWarnings->empty());
 	}
       } else {
 	if(atLeastOneError_ || atLeastOneWarning_) {
@@ -153,7 +153,7 @@ LogErrorFilter::filter(edm::Event& iEvent, edm::EventSetup const&) {
 	  unsigned int nWarning = 0;
 	  for(unsigned int iE = 0; iE != errorsAndWarnings->size(); ++iE) {
 	    //veto categories from user input.
-	    if(avoidCategories_.size() != 0) {
+	    if(!avoidCategories_.empty()) {
 	      if(std::find(avoidCategories_.begin(),avoidCategories_.end(), ((*errorsAndWarnings)[iE]).category) != avoidCategories_.end()) {
 		continue;
 	      }

--- a/FWCore/Modules/src/ModuloEventIDFilter.cc
+++ b/FWCore/Modules/src/ModuloEventIDFilter.cc
@@ -12,7 +12,7 @@ namespace edm {
     explicit ModuloEventIDFilter(ParameterSet const&);
 
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
-    virtual bool filter(StreamID, Event& e, EventSetup const& c) const override final;
+    bool filter(StreamID, Event& e, EventSetup const& c) const final;
 
   private:
     const unsigned int n_; // accept one in n

--- a/FWCore/Modules/src/ModuloStreamIDFilter.cc
+++ b/FWCore/Modules/src/ModuloStreamIDFilter.cc
@@ -9,10 +9,10 @@ namespace edm {
   class ModuloStreamIDFilter : public global::EDFilter<> {
   public:
     explicit ModuloStreamIDFilter(ParameterSet const&);
-    virtual ~ModuloStreamIDFilter();
+    ~ModuloStreamIDFilter() override;
 
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
-    virtual bool filter(StreamID, Event& e, EventSetup const& c) const override final;
+    bool filter(StreamID, Event& e, EventSetup const& c) const final;
 
   private:
     const unsigned int n_; // accept one in n

--- a/FWCore/Modules/src/NavigateEventsLooper.cc
+++ b/FWCore/Modules/src/NavigateEventsLooper.cc
@@ -30,15 +30,15 @@ namespace edm {
 
   public:
     NavigateEventsLooper(ParameterSet const& pset);
-    virtual ~NavigateEventsLooper();
+    ~NavigateEventsLooper() override;
 
-    virtual void startingNewLoop(unsigned int iIteration) override;
-    virtual Status duringLoop(Event const& ev, EventSetup const& es, ProcessingController& pc) override;
-    virtual Status endOfLoop(EventSetup const& es, unsigned int iCounter) override;
+    void startingNewLoop(unsigned int iIteration) override;
+    Status duringLoop(Event const& ev, EventSetup const& es, ProcessingController& pc) override;
+    Status endOfLoop(EventSetup const& es, unsigned int iCounter) override;
 
   private:
-    NavigateEventsLooper(NavigateEventsLooper const&); // stop default
-    NavigateEventsLooper const& operator=(NavigateEventsLooper const&); // stop default
+    NavigateEventsLooper(NavigateEventsLooper const&) = delete; // stop default
+    NavigateEventsLooper const& operator=(NavigateEventsLooper const&) = delete; // stop default
 
     int maxLoops_;
     int countLoops_;

--- a/FWCore/Modules/src/PathStatusFilter.cc
+++ b/FWCore/Modules/src/PathStatusFilter.cc
@@ -71,7 +71,7 @@ namespace edm {
   public:
     explicit PathStatusFilter(ParameterSet const&);
     static void fillDescriptions(ConfigurationDescriptions&);
-    virtual bool filter(StreamID, Event&, EventSetup const&) const override final;
+    bool filter(StreamID, Event&, EventSetup const&) const final;
 
   private:
     edm::propagate_const<std::unique_ptr<pathStatusExpression::Evaluator>> evaluator_;
@@ -126,7 +126,7 @@ namespace edm {
     public:
       EvaluatorType type() const override { return Not; }
 
-      virtual void setLeft(std::unique_ptr<Evaluator> && v) override { operand_ = std::move(v); }
+      void setLeft(std::unique_ptr<Evaluator> && v) override { operand_ = std::move(v); }
 
       void print(std::ostream & out, unsigned int indentation) const override {
         out << std::string( indentation, ' ' ) << "not\n";
@@ -150,8 +150,8 @@ namespace edm {
     public:
       EvaluatorType type() const override;
 
-      virtual void setLeft(std::unique_ptr<Evaluator> && v) override { left_ = std::move(v); }
-      virtual void setRight(std::unique_ptr<Evaluator> && v) override { right_ = std::move(v); }
+      void setLeft(std::unique_ptr<Evaluator> && v) override { left_ = std::move(v); }
+      void setRight(std::unique_ptr<Evaluator> && v) override { right_ = std::move(v); }
 
       void print(std::ostream & out, unsigned int indentation) const override;
 

--- a/FWCore/Modules/src/Prescaler.cc
+++ b/FWCore/Modules/src/Prescaler.cc
@@ -10,10 +10,10 @@ namespace edm {
   class Prescaler : public global::EDFilter<> {
   public:
     explicit Prescaler(ParameterSet const&);
-    virtual ~Prescaler();
+    ~Prescaler() override;
 
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
-    virtual bool filter(StreamID, Event& e, EventSetup const& c) const override final;
+    bool filter(StreamID, Event& e, EventSetup const& c) const final;
 
   private:
     mutable std::atomic<int> count_;

--- a/FWCore/Modules/src/PrintEventSetupContent.cc
+++ b/FWCore/Modules/src/PrintEventSetupContent.cc
@@ -42,19 +42,19 @@ namespace edm {
   class PrintEventSetupContent : public one::EDAnalyzer<one::WatchRuns,one::WatchLuminosityBlocks> {
     public:
       explicit PrintEventSetupContent(ParameterSet const&);
-      ~PrintEventSetupContent();
+      ~PrintEventSetupContent() override;
 
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
     private:
-      virtual void beginJob() override;
+      void beginJob() override;
 
-      virtual void analyze(Event const&, EventSetup const&) override;
-      virtual void endJob() override ;
-      virtual void beginRun(Run const&, EventSetup const&) override;
-      virtual void endRun(Run const&, EventSetup const&) override;
-      virtual void beginLuminosityBlock(LuminosityBlock const&, EventSetup const&) override;
-      virtual void endLuminosityBlock(LuminosityBlock const&, EventSetup const&) override;
+      void analyze(Event const&, EventSetup const&) override;
+      void endJob() override ;
+      void beginRun(Run const&, EventSetup const&) override;
+      void endRun(Run const&, EventSetup const&) override;
+      void beginLuminosityBlock(LuminosityBlock const&, EventSetup const&) override;
+      void endLuminosityBlock(LuminosityBlock const&, EventSetup const&) override;
 
       void print(EventSetup const&);
 
@@ -131,7 +131,7 @@ namespace edm {
 
       eventsetup::EventSetupRecord const* rec = iSetup.find(*itrecords);
 
-      if (0 != rec && cacheIdentifiers_[*itrecords] != rec->cacheIdentifier()) {
+      if (nullptr != rec && cacheIdentifiers_[*itrecords] != rec->cacheIdentifier()) {
         cacheIdentifiers_[*itrecords] = rec->cacheIdentifier();
         rec->fillRegisteredDataKeys(data);
         if (compact_) {

--- a/FWCore/Modules/src/PrintEventSetupDataRetrieval.cc
+++ b/FWCore/Modules/src/PrintEventSetupDataRetrieval.cc
@@ -146,7 +146,7 @@ namespace edm {
           ++it) {
          //std::cout <<"  "<<it->name()<<std::endl;
          const eventsetup::EventSetupRecord* r = iES.find(*it);
-         assert(r != 0);
+         assert(r != nullptr);
          
          RetrievedDataMap::iterator itRetrievedData =  m_retrievedDataMap.find(*it);
          if(itRetrievedData == m_retrievedDataMap.end()) {

--- a/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
+++ b/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
@@ -34,13 +34,13 @@ namespace edm {
    public:
       // We do not take ownership of passed stream.
       explicit ProvenanceCheckerOutputModule(ParameterSet const& pset);
-      virtual ~ProvenanceCheckerOutputModule();
+      ~ProvenanceCheckerOutputModule() override;
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void write(EventForOutput const& e) override;
-      virtual void writeLuminosityBlock(LuminosityBlockForOutput const&) override {}
-      virtual void writeRun(RunForOutput const&) override {}
+      void write(EventForOutput const& e) override;
+      void writeLuminosityBlock(LuminosityBlockForOutput const&) override {}
+      void writeRun(RunForOutput const&) override {}
    };
 
 
@@ -152,7 +152,7 @@ namespace edm {
          }
       }
 
-      if(missingFromMapper.size()) {
+      if(!missingFromMapper.empty()) {
          LogError("ProvenanceChecker") << "Missing the following BranchIDs from ProductProvenanceRetriever\n";
          for(std::set<BranchID>::iterator it = missingFromMapper.begin(), itEnd = missingFromMapper.end();
              it != itEnd;
@@ -161,7 +161,7 @@ namespace edm {
          }
       }
 
-      if(missingProductProvenance.size()) {
+      if(!missingProductProvenance.empty()) {
          LogError("ProvenanceChecker") << "The ProductResolvers for the following BranchIDs have no ProductProvenance\n";
          for(std::set<BranchID>::iterator it = missingProductProvenance.begin(), itEnd = missingProductProvenance.end();
              it != itEnd;
@@ -170,18 +170,18 @@ namespace edm {
          }
       }
 
-      if(missingFromReg.size()) {
+      if(!missingFromReg.empty()) {
          LogError("ProvenanceChecker") << "Missing the following BranchIDs from ProductRegistry\n";
          for(auto const& item : missingFromReg) {
             LogProblem("ProvenanceChecker") << item << " " << *(idToBranchDescriptions[item]);
          }
       }
 
-      if(missingFromMapper.size() || missingProductProvenance.size() || missingFromReg.size()) {
+      if(!missingFromMapper.empty() || !missingProductProvenance.empty() || !missingFromReg.empty()) {
          throw cms::Exception("ProvenanceError")
-         << (missingFromMapper.size() ? "Having missing ancestors from ProductProvenanceRetriever.\n" : "")
-         << (missingProductProvenance.size() ? " Have missing ProductProvenance's from ProductResolver in Event.\n" : "")
-         << (missingFromReg.size() ? " Have missing info from ProductRegistry.\n" : "");
+         << (!missingFromMapper.empty() ? "Having missing ancestors from ProductProvenanceRetriever.\n" : "")
+         << (!missingProductProvenance.empty() ? " Have missing ProductProvenance's from ProductResolver in Event.\n" : "")
+         << (!missingFromReg.empty() ? " Have missing info from ProductRegistry.\n" : "");
       }
    }
 

--- a/FWCore/Modules/src/RunLumiEventChecker.cc
+++ b/FWCore/Modules/src/RunLumiEventChecker.cc
@@ -43,19 +43,19 @@
 class RunLumiEventChecker : public edm::EDAnalyzer {
 public:
    explicit RunLumiEventChecker(edm::ParameterSet const&);
-   ~RunLumiEventChecker();
+   ~RunLumiEventChecker() override;
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-   virtual void beginJob() override;
-   virtual void analyze(edm::Event const&, edm::EventSetup const&) override;
-   virtual void endJob() override;
+   void beginJob() override;
+   void analyze(edm::Event const&, edm::EventSetup const&) override;
+   void endJob() override;
 
-   virtual void beginRun(edm::Run const& run, edm::EventSetup const& es) override;
-   virtual void endRun(edm::Run const& run, edm::EventSetup const& es) override;
+   void beginRun(edm::Run const& run, edm::EventSetup const& es) override;
+   void endRun(edm::Run const& run, edm::EventSetup const& es) override;
    
-   virtual void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& es) override;
-   virtual void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& es) override;
+   void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& es) override;
+   void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& es) override;
 
    void check(edm::EventID const& iID, bool isEvent);
    

--- a/FWCore/ParameterSet/src/ConfigurationDescriptions.cc
+++ b/FWCore/ParameterSet/src/ConfigurationDescriptions.cc
@@ -68,14 +68,14 @@ namespace edm {
         throw edm::Exception(edm::errors::LogicError,
           "ConfigurationDescriptions::add, when adding a ParameterSetDescription for a source the label must be \"source\"\n");
       }
-      if (descriptions_.size() != 0U ||
+      if (!descriptions_.empty() ||
           defaultDescDefined_ == true) {
         throw edm::Exception(edm::errors::LogicError,
           "ConfigurationDescriptions::add, for a source only 1 ParameterSetDescription may be added\n");
       }
     }
     else if (0==strcmp(baseType_.c_str(),kService)) {
-      if (descriptions_.size() != 0U ||
+      if (!descriptions_.empty() ||
           defaultDescDefined_ == true) {
         throw edm::Exception(edm::errors::LogicError,
           "ConfigurationDescriptions::add, for a service only 1 ParameterSetDescription may be added\n");
@@ -97,7 +97,7 @@ namespace edm {
   ConfigurationDescriptions::addDefault(ParameterSetDescription const& psetDescription) {
 
     if (0==strcmp(baseType_.c_str(),kSource) || 0==strcmp(baseType_.c_str(),kService)) {
-      if (descriptions_.size() != 0U ||
+      if (!descriptions_.empty() ||
           defaultDescDefined_ == true) {
         throw edm::Exception(edm::errors::LogicError,
           "ConfigurationDescriptions::addDefault, for a source or service only 1 ParameterSetDescription may be added\n");
@@ -114,7 +114,7 @@ namespace edm {
     if (defaultDescDefined_) {
       return &defaultDesc_;
     }
-    return 0;
+    return nullptr;
   }
   
   ConfigurationDescriptions::iterator 
@@ -128,14 +128,14 @@ namespace edm {
   ConfigurationDescriptions::validate(ParameterSet & pset,
                                       std::string const& moduleLabel) const {
     
-    ParameterSetDescription const* psetDesc = 0;
+    ParameterSetDescription const* psetDesc = nullptr;
     for_all(descriptions_, std::bind(&matchLabel,
                                        std::placeholders::_1,
                                        std::cref(moduleLabel),
                                        std::ref(psetDesc)));
 
     // If there is a matching label
-    if (psetDesc != 0) {
+    if (psetDesc != nullptr) {
       psetDesc->validate(pset);
     }
     // Is there an explicit description to be used for a non standard label
@@ -143,7 +143,7 @@ namespace edm {
       defaultDesc_.validate(pset);
     }
     // Otherwise use the first one.
-    else if (descriptions_.size() > 0U) {
+    else if (!descriptions_.empty()) {
       descriptions_[0].second.validate(pset);
     }
     // It is possible for no descriptions to be defined and no validation occurs

--- a/FWCore/ParameterSet/src/Entry.cc
+++ b/FWCore/ParameterSet/src/Entry.cc
@@ -240,7 +240,7 @@ namespace edm {
       }
       default:  {
         // We should never get here.
-        assert ("Invalid type code" == 0);
+        assert ("Invalid type code" == nullptr);
         //throw EntryError(std::string("invalid type code ") + type);
         break;
       }
@@ -976,7 +976,7 @@ namespace edm {
            os <<  start<< *i;
            start = between;
          }
-         if (whole.size()) {
+         if (!whole.empty()) {
            os << std::endl;
          }
          os << "}";

--- a/FWCore/ParameterSet/src/FileInPath.cc
+++ b/FWCore/ParameterSet/src/FileInPath.cc
@@ -391,7 +391,7 @@ namespace edm
 
   void
   FileInPath::getEnvironment() {
-    static std::string const searchPath = removeSymLinksTokens(PathVariableName.c_str());
+    static std::string const searchPath = removeSymLinksTokens(PathVariableName);
     if (searchPath.empty()) {
       throw edm::Exception(edm::errors::FileInPathError)
 	<< PathVariableName
@@ -399,13 +399,13 @@ namespace edm
     }
     searchPath_ = searchPath;
 
-    static std::string const releaseTop = removeSymLinksSrc(RELEASETOP.c_str());
+    static std::string const releaseTop = removeSymLinksSrc(RELEASETOP);
     releaseTop_ = releaseTop;
 
-    static std::string const localTop = removeSymLinksSrc(LOCALTOP.c_str());
+    static std::string const localTop = removeSymLinksSrc(LOCALTOP);
     localTop_ = localTop;
 
-    static std::string const dataTop = removeSymLinks(DATATOP.c_str());
+    static std::string const dataTop = removeSymLinks(DATATOP);
     dataTop_ = dataTop;
 
     if (releaseTop_.empty()) {

--- a/FWCore/ParameterSet/src/ParameterSet.cc
+++ b/FWCore/ParameterSet/src/ParameterSet.cc
@@ -236,7 +236,7 @@ namespace edm {
   Entry const*
   ParameterSet::getEntryPointerOrThrow_(std::string const& name) const {
     Entry const* result = retrieveUntracked(name);
-    if(result == 0)
+    if(result == nullptr)
       throw Exception(errors::Configuration, "MissingParameter:")
         << "The required parameter '" << name
         << "' was not specified.\n";
@@ -289,7 +289,7 @@ namespace edm {
   ParameterSet::retrieveUntracked(std::string const& name) const {
     table::const_iterator  it = tbl_.find(name);
 
-    if(it == tbl_.end()) return 0;
+    if(it == tbl_.end()) return nullptr;
     if(it->second.isTracked()) {
       if(name[0] == '@') {
         throw Exception(errors::Configuration, "StatusMismatch:")
@@ -334,7 +334,7 @@ namespace edm {
   ParameterSet::retrieveUntrackedParameterSet(std::string const& name) const {
     psettable::const_iterator  it = psetTable_.find(name);
 
-    if(it == psetTable_.end()) return 0;
+    if(it == psetTable_.end()) return nullptr;
     if(it->second.isTracked()) {
       if(name[0] == '@') {
         throw Exception(errors::Configuration, "StatusMismatch:")
@@ -373,7 +373,7 @@ namespace edm {
   ParameterSet::retrieveUntrackedVParameterSet(std::string const& name) const {
     vpsettable::const_iterator it = vpsetTable_.find(name);
 
-    if(it == vpsetTable_.end()) return 0;
+    if(it == vpsetTable_.end()) return nullptr;
     if(it->second.isTracked()) {
       throw Exception(errors::Configuration, "StatusMismatch:")
         << "VParameterSet '" << name
@@ -393,7 +393,7 @@ namespace edm {
   ParameterSet::retrieveUnknown(std::string const& name) const {
     table::const_iterator it = tbl_.find(name);
     if(it == tbl_.end()) {
-      return 0;
+      return nullptr;
     }
     return &it->second;
   }
@@ -402,7 +402,7 @@ namespace edm {
   ParameterSet::retrieveUnknownParameterSet(std::string const& name) const {
     psettable::const_iterator  it = psetTable_.find(name);
     if(it == psetTable_.end()) {
-      return 0;
+      return nullptr;
     }
     return &it->second;
   }
@@ -411,7 +411,7 @@ namespace edm {
   ParameterSet::retrieveUnknownVParameterSet(std::string const& name) const {
     vpsettable::const_iterator  it = vpsetTable_.find(name);
     if(it == vpsetTable_.end()) {
-      return 0;
+      return nullptr;
     }
     return &it->second;
   }
@@ -532,7 +532,7 @@ namespace edm {
     assert(!isRegistered());
     isTracked = false;
     psettable::iterator it = psetTable_.find(name);
-    if(it == psetTable_.end()) return 0;
+    if(it == psetTable_.end()) return nullptr;
     isTracked = it->second.isTracked();
     return &it->second.psetForUpdate();
   }
@@ -541,7 +541,7 @@ namespace edm {
   ParameterSet::getPSetVectorForUpdate(std::string const& name) {
     assert(!isRegistered());
     vpsettable::iterator it = vpsetTable_.find(name);
-    if(it == vpsetTable_.end()) return 0;
+    if(it == vpsetTable_.end()) return nullptr;
     return &it->second;
   }
 
@@ -1227,7 +1227,7 @@ namespace edm {
   bool
   ParameterSet::getUntrackedParameter<bool>(std::string const& name, bool const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getBool();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getBool();
   }
 
   template<>
@@ -1243,7 +1243,7 @@ namespace edm {
   int
   ParameterSet::getUntrackedParameter<int>(std::string const& name, int const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getInt32();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getInt32();
   }
 
   template<>
@@ -1256,7 +1256,7 @@ namespace edm {
   std::vector<int>
   ParameterSet::getUntrackedParameter<std::vector<int> >(std::string const& name, std::vector<int> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVInt32();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVInt32();
   }
 
   template<>
@@ -1272,7 +1272,7 @@ namespace edm {
   unsigned int
   ParameterSet::getUntrackedParameter<unsigned int>(std::string const& name, unsigned int const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getUInt32();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getUInt32();
   }
 
   template<>
@@ -1285,7 +1285,7 @@ namespace edm {
   std::vector<unsigned int>
   ParameterSet::getUntrackedParameter<std::vector<unsigned int> >(std::string const& name, std::vector<unsigned int> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVUInt32();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVUInt32();
   }
 
   template<>
@@ -1301,7 +1301,7 @@ namespace edm {
   unsigned long long
   ParameterSet::getUntrackedParameter<unsigned long long>(std::string const& name, unsigned long long const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getUInt64();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getUInt64();
   }
 
   template<>
@@ -1314,7 +1314,7 @@ namespace edm {
   std::vector<unsigned long long>
   ParameterSet::getUntrackedParameter<std::vector<unsigned long long> >(std::string const& name, std::vector<unsigned long long> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVUInt64();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVUInt64();
   }
 
   template<>
@@ -1330,7 +1330,7 @@ namespace edm {
   long long
   ParameterSet::getUntrackedParameter<long long>(std::string const& name, long long const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getInt64();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getInt64();
   }
 
   template<>
@@ -1343,7 +1343,7 @@ namespace edm {
   std::vector<long long>
   ParameterSet::getUntrackedParameter<std::vector<long long> >(std::string const& name, std::vector<long long> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVInt64();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVInt64();
   }
 
   template<>
@@ -1359,7 +1359,7 @@ namespace edm {
   double
   ParameterSet::getUntrackedParameter<double>(std::string const& name, double const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getDouble();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getDouble();
   }
 
   template<>
@@ -1371,7 +1371,7 @@ namespace edm {
   template<>
   std::vector<double>
   ParameterSet::getUntrackedParameter<std::vector<double> >(std::string const& name, std::vector<double> const& defaultValue) const {
-    Entry const* entryPtr = retrieveUntracked(name); return entryPtr == 0 ? defaultValue : entryPtr->getVDouble();
+    Entry const* entryPtr = retrieveUntracked(name); return entryPtr == nullptr ? defaultValue : entryPtr->getVDouble();
   }
 
   template<>
@@ -1387,7 +1387,7 @@ namespace edm {
   std::string
   ParameterSet::getUntrackedParameter<std::string>(std::string const& name, std::string const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getString();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getString();
   }
 
   template<>
@@ -1400,7 +1400,7 @@ namespace edm {
   std::vector<std::string>
   ParameterSet::getUntrackedParameter<std::vector<std::string> >(std::string const& name, std::vector<std::string> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVString();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVString();
   }
 
   template<>
@@ -1416,7 +1416,7 @@ namespace edm {
   FileInPath
   ParameterSet::getUntrackedParameter<FileInPath>(std::string const& name, FileInPath const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getFileInPath();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getFileInPath();
   }
 
   template<>
@@ -1432,7 +1432,7 @@ namespace edm {
   InputTag
   ParameterSet::getUntrackedParameter<InputTag>(std::string const& name, InputTag const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getInputTag();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getInputTag();
   }
 
   template<>
@@ -1446,7 +1446,7 @@ namespace edm {
   ParameterSet::getUntrackedParameter<std::vector<InputTag> >(std::string const& name,
                                       std::vector<InputTag> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVInputTag();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVInputTag();
   }
 
   template<>
@@ -1462,7 +1462,7 @@ namespace edm {
    ESInputTag
    ParameterSet::getUntrackedParameter<ESInputTag>(std::string const& name, ESInputTag const& defaultValue) const {
       Entry const* entryPtr = retrieveUntracked(name);
-      return entryPtr == 0 ? defaultValue : entryPtr->getESInputTag();
+      return entryPtr == nullptr ? defaultValue : entryPtr->getESInputTag();
    }
 
    template<>
@@ -1476,7 +1476,7 @@ namespace edm {
    ParameterSet::getUntrackedParameter<std::vector<ESInputTag> >(std::string const& name,
                                                                std::vector<ESInputTag> const& defaultValue) const {
       Entry const* entryPtr = retrieveUntracked(name);
-      return entryPtr == 0 ? defaultValue : entryPtr->getVESInputTag();
+      return entryPtr == nullptr ? defaultValue : entryPtr->getVESInputTag();
    }
 
    template<>
@@ -1492,7 +1492,7 @@ namespace edm {
   EventID
   ParameterSet::getUntrackedParameter<EventID>(std::string const& name, EventID const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getEventID();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getEventID();
   }
 
   template<>
@@ -1506,7 +1506,7 @@ namespace edm {
   ParameterSet::getUntrackedParameter<std::vector<EventID> >(std::string const& name,
                                       std::vector<EventID> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVEventID();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVEventID();
   }
 
   template<>
@@ -1522,7 +1522,7 @@ namespace edm {
   LuminosityBlockID
   ParameterSet::getUntrackedParameter<LuminosityBlockID>(std::string const& name, LuminosityBlockID const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getLuminosityBlockID();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getLuminosityBlockID();
   }
 
   template<>
@@ -1536,7 +1536,7 @@ namespace edm {
   ParameterSet::getUntrackedParameter<std::vector<LuminosityBlockID> >(std::string const& name,
                                       std::vector<LuminosityBlockID> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVLuminosityBlockID();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVLuminosityBlockID();
   }
 
   template<>
@@ -1552,7 +1552,7 @@ namespace edm {
   EventRange
   ParameterSet::getUntrackedParameter<EventRange>(std::string const& name, EventRange const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getEventRange();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getEventRange();
   }
 
   template<>
@@ -1566,7 +1566,7 @@ namespace edm {
   ParameterSet::getUntrackedParameter<std::vector<EventRange> >(std::string const& name,
                                       std::vector<EventRange> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVEventRange();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVEventRange();
   }
 
   template<>
@@ -1582,7 +1582,7 @@ namespace edm {
   LuminosityBlockRange
   ParameterSet::getUntrackedParameter<LuminosityBlockRange>(std::string const& name, LuminosityBlockRange const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getLuminosityBlockRange();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getLuminosityBlockRange();
   }
 
   template<>
@@ -1596,7 +1596,7 @@ namespace edm {
   ParameterSet::getUntrackedParameter<std::vector<LuminosityBlockRange> >(std::string const& name,
                                       std::vector<LuminosityBlockRange> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVLuminosityBlockRange();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVLuminosityBlockRange();
   }
 
   template<>
@@ -1857,7 +1857,7 @@ namespace edm {
   bool
   ParameterSet::getUntrackedParameter<bool>(char const* name, bool const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getBool();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getBool();
   }
 
   template<>
@@ -1873,7 +1873,7 @@ namespace edm {
   int
   ParameterSet::getUntrackedParameter<int>(char const* name, int const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getInt32();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getInt32();
   }
 
   template<>
@@ -1886,7 +1886,7 @@ namespace edm {
   std::vector<int>
   ParameterSet::getUntrackedParameter<std::vector<int> >(char const* name, std::vector<int> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVInt32();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVInt32();
   }
 
   template<>
@@ -1902,7 +1902,7 @@ namespace edm {
   unsigned int
   ParameterSet::getUntrackedParameter<unsigned int>(char const* name, unsigned int const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getUInt32();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getUInt32();
   }
 
   template<>
@@ -1915,7 +1915,7 @@ namespace edm {
   std::vector<unsigned int>
   ParameterSet::getUntrackedParameter<std::vector<unsigned int> >(char const* name, std::vector<unsigned int> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVUInt32();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVUInt32();
   }
 
   template<>
@@ -1931,7 +1931,7 @@ namespace edm {
   unsigned long long
   ParameterSet::getUntrackedParameter<unsigned long long>(char const* name, unsigned long long const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getUInt64();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getUInt64();
   }
 
   template<>
@@ -1944,7 +1944,7 @@ namespace edm {
   std::vector<unsigned long long>
   ParameterSet::getUntrackedParameter<std::vector<unsigned long long> >(char const* name, std::vector<unsigned long long> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVUInt64();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVUInt64();
   }
 
   template<>
@@ -1960,7 +1960,7 @@ namespace edm {
   long long
   ParameterSet::getUntrackedParameter<long long>(char const* name, long long const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getInt64();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getInt64();
   }
 
   template<>
@@ -1973,7 +1973,7 @@ namespace edm {
   std::vector<long long>
   ParameterSet::getUntrackedParameter<std::vector<long long> >(char const* name, std::vector<long long> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVInt64();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVInt64();
   }
 
   template<>
@@ -1989,7 +1989,7 @@ namespace edm {
   double
   ParameterSet::getUntrackedParameter<double>(char const* name, double const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getDouble();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getDouble();
   }
 
   template<>
@@ -2001,7 +2001,7 @@ namespace edm {
   template<>
   std::vector<double>
   ParameterSet::getUntrackedParameter<std::vector<double> >(char const* name, std::vector<double> const& defaultValue) const {
-    Entry const* entryPtr = retrieveUntracked(name); return entryPtr == 0 ? defaultValue : entryPtr->getVDouble();
+    Entry const* entryPtr = retrieveUntracked(name); return entryPtr == nullptr ? defaultValue : entryPtr->getVDouble();
   }
 
   template<>
@@ -2017,7 +2017,7 @@ namespace edm {
   std::string
   ParameterSet::getUntrackedParameter<std::string>(char const* name, std::string const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getString();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getString();
   }
 
   template<>
@@ -2030,7 +2030,7 @@ namespace edm {
   std::vector<std::string>
   ParameterSet::getUntrackedParameter<std::vector<std::string> >(char const* name, std::vector<std::string> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVString();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVString();
   }
 
   template<>
@@ -2046,7 +2046,7 @@ namespace edm {
   FileInPath
   ParameterSet::getUntrackedParameter<FileInPath>(char const* name, FileInPath const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getFileInPath();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getFileInPath();
   }
 
   template<>
@@ -2062,7 +2062,7 @@ namespace edm {
   InputTag
   ParameterSet::getUntrackedParameter<InputTag>(char const* name, InputTag const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getInputTag();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getInputTag();
   }
 
   template<>
@@ -2076,7 +2076,7 @@ namespace edm {
   ParameterSet::getUntrackedParameter<std::vector<InputTag> >(char const* name,
                                       std::vector<InputTag> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVInputTag();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVInputTag();
   }
 
   template<>
@@ -2092,7 +2092,7 @@ namespace edm {
    ESInputTag
    ParameterSet::getUntrackedParameter<ESInputTag>(char const* name, ESInputTag const& defaultValue) const {
       Entry const* entryPtr = retrieveUntracked(name);
-      return entryPtr == 0 ? defaultValue : entryPtr->getESInputTag();
+      return entryPtr == nullptr ? defaultValue : entryPtr->getESInputTag();
    }
 
    template<>
@@ -2106,7 +2106,7 @@ namespace edm {
    ParameterSet::getUntrackedParameter<std::vector<ESInputTag> >(char const* name,
                                                                std::vector<ESInputTag> const& defaultValue) const {
       Entry const* entryPtr = retrieveUntracked(name);
-      return entryPtr == 0 ? defaultValue : entryPtr->getVESInputTag();
+      return entryPtr == nullptr ? defaultValue : entryPtr->getVESInputTag();
    }
 
    template<>
@@ -2122,7 +2122,7 @@ namespace edm {
   EventID
   ParameterSet::getUntrackedParameter<EventID>(char const* name, EventID const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getEventID();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getEventID();
   }
 
   template<>
@@ -2136,7 +2136,7 @@ namespace edm {
   ParameterSet::getUntrackedParameter<std::vector<EventID> >(char const* name,
                                       std::vector<EventID> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVEventID();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVEventID();
   }
 
   template<>
@@ -2152,7 +2152,7 @@ namespace edm {
   LuminosityBlockID
   ParameterSet::getUntrackedParameter<LuminosityBlockID>(char const* name, LuminosityBlockID const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getLuminosityBlockID();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getLuminosityBlockID();
   }
 
   template<>
@@ -2166,7 +2166,7 @@ namespace edm {
   ParameterSet::getUntrackedParameter<std::vector<LuminosityBlockID> >(char const* name,
                                       std::vector<LuminosityBlockID> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVLuminosityBlockID();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVLuminosityBlockID();
   }
 
   template<>
@@ -2182,7 +2182,7 @@ namespace edm {
   EventRange
   ParameterSet::getUntrackedParameter<EventRange>(char const* name, EventRange const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getEventRange();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getEventRange();
   }
 
   template<>
@@ -2196,7 +2196,7 @@ namespace edm {
   ParameterSet::getUntrackedParameter<std::vector<EventRange> >(char const* name,
                                       std::vector<EventRange> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVEventRange();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVEventRange();
   }
 
   template<>
@@ -2212,7 +2212,7 @@ namespace edm {
   LuminosityBlockRange
   ParameterSet::getUntrackedParameter<LuminosityBlockRange>(char const* name, LuminosityBlockRange const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getLuminosityBlockRange();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getLuminosityBlockRange();
   }
 
   template<>
@@ -2226,7 +2226,7 @@ namespace edm {
   ParameterSet::getUntrackedParameter<std::vector<LuminosityBlockRange> >(char const* name,
                                       std::vector<LuminosityBlockRange> const& defaultValue) const {
     Entry const* entryPtr = retrieveUntracked(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->getVLuminosityBlockRange();
+    return entryPtr == nullptr ? defaultValue : entryPtr->getVLuminosityBlockRange();
   }
 
   template<>
@@ -2378,7 +2378,7 @@ namespace edm {
   ParameterSet
   ParameterSet::getUntrackedParameterSet(char const* name, ParameterSet const& defaultValue) const {
     ParameterSetEntry const* entryPtr = retrieveUntrackedParameterSet(name);
-    if(entryPtr == 0) {
+    if(entryPtr == nullptr) {
       return defaultValue;
     }
     return entryPtr->pset();
@@ -2392,7 +2392,7 @@ namespace edm {
   ParameterSet const&
   ParameterSet::getUntrackedParameterSet(char const* name) const {
     ParameterSetEntry const* result = retrieveUntrackedParameterSet(name);
-    if(result == 0)
+    if(result == nullptr)
       throw Exception(errors::Configuration, "MissingParameter:")
         << "The required ParameterSet '" << name << "' was not specified.\n";
     return result->pset();
@@ -2416,7 +2416,7 @@ namespace edm {
   VParameterSet
   ParameterSet::getUntrackedParameterSetVector(char const* name, VParameterSet const& defaultValue) const {
     VParameterSetEntry const* entryPtr = retrieveUntrackedVParameterSet(name);
-    return entryPtr == 0 ? defaultValue : entryPtr->vpset();
+    return entryPtr == nullptr ? defaultValue : entryPtr->vpset();
   }
 
   VParameterSet const&
@@ -2427,7 +2427,7 @@ namespace edm {
   VParameterSet const&
   ParameterSet::getUntrackedParameterSetVector(char const* name) const {
     VParameterSetEntry const* result = retrieveUntrackedVParameterSet(name);
-    if(result == 0)
+    if(result == nullptr)
       throw Exception(errors::Configuration, "MissingParameter:")
         << "The required ParameterSetVector '" << name << "' was not specified.\n";
     return result->vpset();

--- a/FWCore/ParameterSet/src/ParameterSetEntry.cc
+++ b/FWCore/ParameterSet/src/ParameterSetEntry.cc
@@ -10,7 +10,7 @@ namespace edm {
 
   ParameterSetEntry::ParameterSetEntry()
   : isTracked_(false),
-    thePSet_(0),
+    thePSet_(nullptr),
     theID_()
   {
   }

--- a/FWCore/ParameterSet/src/ParameterWildcard.cc
+++ b/FWCore/ParameterSet/src/ParameterWildcard.cc
@@ -120,7 +120,7 @@ namespace edm {
 
     std::vector<std::string> parameterNames  = pset.getParameterNamesForType<ParameterSet>(isTracked());
 
-    if(criteria() == RequireAtLeastOne) return parameterNames.size() >= 1U;
+    if(criteria() == RequireAtLeastOne) return !parameterNames.empty();
     return parameterNames.size() == 1U;
   }
 
@@ -239,7 +239,7 @@ namespace edm {
 
     std::vector<std::string> parameterNames  = pset.getParameterNamesForType<std::vector<ParameterSet> >(isTracked());
 
-    if(criteria() == RequireAtLeastOne) return parameterNames.size() >= 1U;
+    if(criteria() == RequireAtLeastOne) return !parameterNames.empty();
     return parameterNames.size() == 1U;
   }
 }

--- a/FWCore/ParameterSet/src/ParameterWildcardBase.cc
+++ b/FWCore/ParameterSet/src/ParameterWildcardBase.cc
@@ -47,14 +47,14 @@ namespace edm {
                         bool optional) const {
     validatedLabels.insert(matchingNames.begin(), matchingNames.end());
     if(criteria_ == RequireZeroOrMore) return;
-    if(criteria_ == RequireAtLeastOne && matchingNames.size() < 1U && !optional) {
+    if(criteria_ == RequireAtLeastOne && matchingNames.empty() && !optional) {
       throw Exception(errors::Configuration)
         << "Parameter wildcard of type \"" << parameterTypeEnumToString(type()) << "\" requires "
         << "at least one match\n"
         << "and there are no parameters in the configuration matching\n"
         << "that type.\n";
     } else if(criteria_ == RequireExactlyOne) {
-      if((matchingNames.size() < 1U && !optional) ||
+      if((matchingNames.empty() && !optional) ||
            matchingNames.size() > 1U) {
         throw Exception(errors::Configuration)
           << "Parameter wildcard of type \"" << parameterTypeEnumToString(type()) << "\" requires\n"

--- a/FWCore/ParameterSet/src/types.cc
+++ b/FWCore/ParameterSet/src/types.cc
@@ -739,9 +739,9 @@ static void
   edm::decode(edm::EventID& to, std::string const& from) {
     std::vector<std::string> tokens = edm::tokenize(from, ":");
     assert(tokens.size() == 2 || tokens.size() == 3);
-    unsigned int run = strtoul(tokens[0].c_str(), 0, 0);
-    unsigned int lumi = (tokens.size() == 2 ? 0 : strtoul(tokens[1].c_str(), 0, 0));
-    unsigned long long event = strtoull(tokens[tokens.size() - 1].c_str(), 0, 0);
+    unsigned int run = strtoul(tokens[0].c_str(), nullptr, 0);
+    unsigned int lumi = (tokens.size() == 2 ? 0 : strtoul(tokens[1].c_str(), nullptr, 0));
+    unsigned long long event = strtoull(tokens[tokens.size() - 1].c_str(), nullptr, 0);
     to = edm::EventID(run, lumi, event);
 
     return true;
@@ -803,8 +803,8 @@ static void
   edm::decode(edm::LuminosityBlockID& to, std::string const& from) {
       std::vector<std::string> tokens = edm::tokenize(from, ":");
       assert(tokens.size() == 2);
-      unsigned int run = strtoul(tokens[0].c_str(), 0, 0);
-      unsigned int lumi = strtoul(tokens[1].c_str(), 0, 0);
+      unsigned int run = strtoul(tokens[0].c_str(), nullptr, 0);
+      unsigned int lumi = strtoul(tokens[1].c_str(), nullptr, 0);
       to = edm::LuminosityBlockID(run, lumi);
       return true;
     } // decode to LuminosityBlockID

--- a/FWCore/PluginManager/interface/CacheParser.h
+++ b/FWCore/PluginManager/interface/CacheParser.h
@@ -63,9 +63,9 @@ class CacheParser
    private:
       //for testing
       friend class ::TestCacheParser;
-      CacheParser(const CacheParser&); // stop default
+      CacheParser(const CacheParser&) = delete; // stop default
 
-      const CacheParser& operator=(const CacheParser&); // stop default
+      const CacheParser& operator=(const CacheParser&) = delete; // stop default
 
       static bool readline(std::istream& iIn, const boost::filesystem::path& iDirectory,
                unsigned long iRecordNumber, PluginInfo &oInfo, std::string& oPluginType);

--- a/FWCore/PluginManager/interface/PluginCapabilities.h
+++ b/FWCore/PluginManager/interface/PluginCapabilities.h
@@ -33,11 +33,11 @@ class PluginCapabilities : public PluginFactoryBase
 {
    friend class DummyFriend;
    public:
-      virtual ~PluginCapabilities();
+      ~PluginCapabilities() override;
 
       // ---------- const member functions ---------------------
-      virtual std::vector<PluginInfo> available() const;
-      virtual const std::string& category() const; 
+      std::vector<PluginInfo> available() const override;
+      const std::string& category() const override; 
       
       // ---------- static member functions --------------------
       static PluginCapabilities* get();
@@ -53,9 +53,9 @@ class PluginCapabilities : public PluginFactoryBase
 
    private:
       PluginCapabilities();
-      PluginCapabilities(const PluginCapabilities&); // stop default
+      PluginCapabilities(const PluginCapabilities&) = delete; // stop default
 
-      const PluginCapabilities& operator=(const PluginCapabilities&); // stop default
+      const PluginCapabilities& operator=(const PluginCapabilities&) = delete; // stop default
 
       // ---------- member data --------------------------------
       std::map<std::string, boost::filesystem::path> classToLoadable_;

--- a/FWCore/PluginManager/interface/PluginFactory.h
+++ b/FWCore/PluginManager/interface/PluginFactory.h
@@ -47,7 +47,7 @@ class PluginFactory<R*(Args...)> : public PluginFactoryBase
         PMaker(const std::string& iName) {
           PluginFactory<R*(Args...)>::get()->registerPMaker(this,iName);
         }
-        virtual R* create(Args... args) const {
+        R* create(Args... args) const override {
           return new TPlug(std::forward<Args>(args)...);
         }
       };

--- a/FWCore/PluginManager/interface/PluginFactoryBase.h
+++ b/FWCore/PluginManager/interface/PluginFactoryBase.h
@@ -108,9 +108,9 @@ class PluginFactoryBase
       void registerPMaker(void* iPMaker, const std::string& iName);
       
    private:
-      PluginFactoryBase(const PluginFactoryBase&); // stop default
+      PluginFactoryBase(const PluginFactoryBase&) = delete; // stop default
 
-      const PluginFactoryBase& operator=(const PluginFactoryBase&); // stop default
+      const PluginFactoryBase& operator=(const PluginFactoryBase&) = delete; // stop default
 
       void checkProperLoadable(const std::string& iName, const std::string& iLoadedFrom) const;
       // ---------- member data --------------------------------

--- a/FWCore/PluginManager/interface/PluginFactoryManager.h
+++ b/FWCore/PluginManager/interface/PluginFactoryManager.h
@@ -51,9 +51,9 @@ class PluginFactoryManager
       
    private:
       PluginFactoryManager();
-      PluginFactoryManager(const PluginFactoryManager&); // stop default
+      PluginFactoryManager(const PluginFactoryManager&) = delete; // stop default
 
-      const PluginFactoryManager& operator=(const PluginFactoryManager&); // stop default
+      const PluginFactoryManager& operator=(const PluginFactoryManager&) = delete; // stop default
 
       // ---------- member data --------------------------------
       std::vector<const PluginFactoryBase*> factories_;

--- a/FWCore/PluginManager/interface/PluginManager.h
+++ b/FWCore/PluginManager/interface/PluginManager.h
@@ -107,9 +107,9 @@ class PluginManager
       edm::signalslot::Signal<void(const std::string&,const std::string&)> askedToLoadCategoryWithPlugin_;
    private:
       PluginManager(const Config&);
-      PluginManager(const PluginManager&); // stop default
+      PluginManager(const PluginManager&) = delete; // stop default
 
-      const PluginManager& operator=(const PluginManager&); // stop default
+      const PluginManager& operator=(const PluginManager&) = delete; // stop default
 
       void newFactory(const PluginFactoryBase* );
       static std::string& loadingLibraryNamed_();

--- a/FWCore/PluginManager/interface/ProblemTracker.h
+++ b/FWCore/PluginManager/interface/ProblemTracker.h
@@ -23,7 +23,7 @@ namespace edm
   private:
     ProblemTracker();
     ~ProblemTracker();
-    ProblemTracker(const ProblemTracker&);
+    ProblemTracker(const ProblemTracker&) = delete;
   };
 
   class AssertHandler
@@ -32,7 +32,7 @@ namespace edm
     AssertHandler();
     ~AssertHandler();
   private:
-    AssertHandler(const AssertHandler&);
+    AssertHandler(const AssertHandler&) = delete;
     ProblemTracker const* pt_;
   };
 

--- a/FWCore/PluginManager/interface/SharedLibrary.h
+++ b/FWCore/PluginManager/interface/SharedLibrary.h
@@ -42,9 +42,9 @@ class SharedLibrary
       // ---------- member functions ---------------------------
       
    private:
-      SharedLibrary(const SharedLibrary&); // stop default
+      SharedLibrary(const SharedLibrary&) = delete; // stop default
 
-      const SharedLibrary& operator=(const SharedLibrary&); // stop default
+      const SharedLibrary& operator=(const SharedLibrary&) = delete; // stop default
 
       // ---------- member data --------------------------------
       void* libraryHandle_;

--- a/FWCore/PluginManager/src/PluginCapabilities.cc
+++ b/FWCore/PluginManager/src/PluginCapabilities.cc
@@ -113,7 +113,7 @@ PluginCapabilities::tryToLoad(const std::string& iName)
   if(classToLoadable_.end() == classToLoadable_.find(iName) ) {
     const SharedLibrary* lib = PluginManager::get()->tryToLoad(category(),
                                                           iName);
-    if( 0 == lib) {
+    if( nullptr == lib) {
       return false;
     }
     //read the items from the 'capabilities' symbol

--- a/FWCore/PluginManager/src/PluginFactoryBase.cc
+++ b/FWCore/PluginManager/src/PluginFactoryBase.cc
@@ -101,7 +101,7 @@ PluginFactoryBase::tryToFindPMaker(const std::string& iName) const
   Plugins::const_iterator itFound = m_plugins.find(iName);
   if(itFound == m_plugins.end()) {
     const SharedLibrary* slib = PluginManager::get()->tryToLoad(this->category(),iName);
-    if(0!=slib) {
+    if(nullptr!=slib) {
       std::string lib = slib->path().string();
       itFound = m_plugins.find(iName);
       if(itFound == m_plugins.end()) {
@@ -163,7 +163,7 @@ PluginFactoryBase::checkProperLoadable(const std::string& iName, const std::stri
 
 void 
 PluginFactoryBase::registerPMaker(void* iPMaker, const std::string& iName) {
-  assert(0!= iPMaker);
+  assert(nullptr!= iPMaker);
   m_plugins[iName].push_back(PluginMakerInfo(iPMaker,PluginManager::loadingFile()));
   newPlugin(iName);
 }

--- a/FWCore/PluginManager/src/PluginManager.cc
+++ b/FWCore/PluginManager/src/PluginManager.cc
@@ -61,11 +61,11 @@ PluginManager::PluginManager(const PluginManager::Config& iConfig) :
   searchPath_( iConfig.searchPath() )
 {
     using std::placeholders::_1;
-    const boost::filesystem::path kCacheFile(standard::cachefileName());
+    const boost::filesystem::path& kCacheFile(standard::cachefileName());
     // This is the filename of a file which contains plugins which exist in the
     // base release and which should exists in the local area, otherwise they
     // were removed and we want to catch their usage.
-    const boost::filesystem::path kPoisonedCacheFile(standard::poisonedCachefileName());
+    const boost::filesystem::path& kPoisonedCacheFile(standard::poisonedCachefileName());
     //NOTE: This may not be needed :/
     PluginFactoryManager* pfm = PluginFactoryManager::get();
     pfm->newFactory_.connect(std::bind(std::mem_fn(&PluginManager::newFactory),this,_1));
@@ -287,7 +287,7 @@ PluginManager::tryToLoad(const std::string& iCategory,
   const boost::filesystem::path& p = loadableFor_(iCategory,iPlugin, ioThrowIfFailElseSucceedStatus);
   
   if( not ioThrowIfFailElseSucceedStatus ) {
-    return 0;
+    return nullptr;
   }
   
 
@@ -325,7 +325,7 @@ PluginManager*
 PluginManager::get()
 {
   PluginManager* manager = singleton();
-  if(0==manager) {
+  if(nullptr==manager) {
     throw cms::Exception("PluginManagerNotConfigured")<<"PluginManager::get() was called before PluginManager::configure.";
   }
   return manager;
@@ -335,11 +335,11 @@ PluginManager&
 PluginManager::configure(const Config& iConfig )
 {
   PluginManager*& s = singleton();
-  if( 0 != s ){
+  if( nullptr != s ){
     throw cms::Exception("PluginManagerReconfigured");
   }
   
-  Config realConfig = iConfig;
+  const Config& realConfig = iConfig;
   if (realConfig.searchPath().empty() ) {
     throw cms::Exception("PluginManagerEmptySearchPath");
   }
@@ -366,14 +366,14 @@ PluginManager::loadingLibraryNamed_()
 
 PluginManager*& PluginManager::singleton()
 {
-  [[cms::thread_safe]] static PluginManager* s_singleton=0;
+  [[cms::thread_safe]] static PluginManager* s_singleton=nullptr;
   return s_singleton;
 }
 
 bool
 PluginManager::isAvailable()
 {
-  return 0 != singleton();
+  return nullptr != singleton();
 }
 
 }

--- a/FWCore/PluginManager/src/PresenceFactory.cc
+++ b/FWCore/PluginManager/src/PresenceFactory.cc
@@ -25,7 +25,7 @@ namespace edm {
   makePresence(std::string const & presence_type) const {
     std::unique_ptr<Presence> sp(PresencePluginFactory::get()->create(presence_type));
 
-    if(sp.get()==0) {
+    if(sp.get()==nullptr) {
 	throw edm::Exception(errors::Configuration, "NoPresenceModule")
 	  << "Presence Factory:\n"
 	  << "Cannot find presence type: "

--- a/FWCore/PluginManager/src/SharedLibrary.cc
+++ b/FWCore/PluginManager/src/SharedLibrary.cc
@@ -13,7 +13,7 @@
 // system include files
 #include <string> /*needed by the following include*/
 #include <dlfcn.h>
-#include <errno.h>
+#include <cerrno>
 
 // user include files
 #include "FWCore/PluginManager/interface/SharedLibrary.h"

--- a/FWCore/PythonParameterSet/src/PythonWrapper.cc
+++ b/FWCore/PythonParameterSet/src/PythonWrapper.cc
@@ -6,7 +6,7 @@ namespace edm {
 void pythonToCppException(const std::string& iType)
  {
   using namespace boost::python;
-  PyObject *exc=NULL, *val=NULL, *trace=NULL;
+  PyObject *exc=nullptr, *val=nullptr, *trace=nullptr;
   PyErr_Fetch(&exc,&val,&trace);
   PyErr_NormalizeException(&exc,&val,&trace);
   handle<> hExc(allow_null(exc));

--- a/FWCore/ServiceRegistry/interface/ServiceMaker.h
+++ b/FWCore/ServiceRegistry/interface/ServiceMaker.h
@@ -76,23 +76,23 @@ public:
          //virtual ~ServiceMaker();
 
          // ---------- const member functions ---------------------
-         virtual std::type_info const& serviceType() const { return typeid(T); }
+         std::type_info const& serviceType() const override { return typeid(T); }
 
-         virtual bool make(ParameterSet const& iPS,
+         bool make(ParameterSet const& iPS,
                            ActivityRegistry& iAR,
-                           ServicesManager& oSM) const {
+                           ServicesManager& oSM) const override {
             TMaker maker;
             std::unique_ptr<T> pService(maker.make(iPS, iAR));
             auto ptr = std::make_shared<ServiceWrapper<T> >(std::move(pService));
             return oSM.put(ptr);
          }
 
-         virtual bool saveConfiguration() const {
-            return ServiceMakerBase::testSaveConfiguration(static_cast<typename TMaker::concrete_t const*>(0));
+         bool saveConfiguration() const override {
+            return ServiceMakerBase::testSaveConfiguration(static_cast<typename TMaker::concrete_t const*>(nullptr));
          }
 
-         virtual bool processWideService() const {
-            return service::isProcessWideService(static_cast<typename TMaker::concrete_t const*>(0));
+         bool processWideService() const override {
+            return service::isProcessWideService(static_cast<typename TMaker::concrete_t const*>(nullptr));
          }
 
          // ---------- static member functions --------------------
@@ -100,9 +100,9 @@ public:
          // ---------- member functions ---------------------------
 
 private:
-         ServiceMaker(ServiceMaker const&); // stop default
+         ServiceMaker(ServiceMaker const&) = delete; // stop default
 
-         ServiceMaker const& operator=(ServiceMaker const&); // stop default
+         ServiceMaker const& operator=(ServiceMaker const&) = delete; // stop default
 
          // ---------- member data --------------------------------
 

--- a/FWCore/ServiceRegistry/interface/ServiceMakerBase.h
+++ b/FWCore/ServiceRegistry/interface/ServiceMakerBase.h
@@ -63,9 +63,9 @@ protected:
          bool testSaveConfiguration(void const*) const {return false;}
 
 private:
-         ServiceMakerBase(ServiceMakerBase const&); // stop default
+         ServiceMakerBase(ServiceMakerBase const&) = delete; // stop default
 
-         ServiceMakerBase const& operator=(ServiceMakerBase const&); // stop default
+         ServiceMakerBase const& operator=(ServiceMakerBase const&) = delete; // stop default
 
          // ---------- member data --------------------------------
       };

--- a/FWCore/ServiceRegistry/interface/ServiceRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ServiceRegistry.h
@@ -138,9 +138,9 @@ private:
       void unsetContext(ServiceToken const& iOldToken);
 
       ServiceRegistry();
-      ServiceRegistry(ServiceRegistry const&); // stop default
+      ServiceRegistry(ServiceRegistry const&) = delete; // stop default
 
-      ServiceRegistry const& operator=(ServiceRegistry const&); // stop default
+      ServiceRegistry const& operator=(ServiceRegistry const&) = delete; // stop default
 
       // ---------- member data --------------------------------
       std::shared_ptr<serviceregistry::ServicesManager> manager_;

--- a/FWCore/ServiceRegistry/interface/ServiceWrapperBase.h
+++ b/FWCore/ServiceRegistry/interface/ServiceWrapperBase.h
@@ -40,9 +40,9 @@ public:
          // ---------- member functions ---------------------------
          
 private:
-         ServiceWrapperBase(const ServiceWrapperBase&); // stop default
+         ServiceWrapperBase(const ServiceWrapperBase&) = delete; // stop default
          
-         const ServiceWrapperBase& operator=(const ServiceWrapperBase&); // stop default
+         const ServiceWrapperBase& operator=(const ServiceWrapperBase&) = delete; // stop default
          
          // ---------- member data --------------------------------
          

--- a/FWCore/ServiceRegistry/interface/ServicesManager.h
+++ b/FWCore/ServiceRegistry/interface/ServicesManager.h
@@ -144,9 +144,9 @@ public:
          void copySlotsFrom(ActivityRegistry&);
 
 private:
-         ServicesManager(ServicesManager const&); // stop default
+         ServicesManager(ServicesManager const&) = delete; // stop default
 
-         ServicesManager const& operator=(ServicesManager const&); // stop default
+         ServicesManager const& operator=(ServicesManager const&) = delete; // stop default
 
          void fillListOfMakers(std::vector<ParameterSet>&);
          void createServices();

--- a/FWCore/ServiceRegistry/interface/connect_but_block_self.h
+++ b/FWCore/ServiceRegistry/interface/connect_but_block_self.h
@@ -40,7 +40,7 @@ namespace edm {
          // ---------- const member functions ---------------------
          template<typename... Args>
          void operator()(Args&&... args) {
-            std::shared_ptr<void> guard(static_cast<void*>(0), std::bind(&BlockingWrapper::unblock,this) );
+            std::shared_ptr<void> guard(static_cast<void*>(nullptr), std::bind(&BlockingWrapper::unblock,this) );
            if( startBlocking() ) { func_(std::forward<Args>(args)...); }
          }
 

--- a/FWCore/ServiceRegistry/src/ServiceToken.cc
+++ b/FWCore/ServiceRegistry/src/ServiceToken.cc
@@ -59,14 +59,14 @@
 void
 edm::ServiceToken::connectTo(edm::ActivityRegistry& iConnectTo)
 {
-   if(0!=manager_.get()){
+   if(nullptr!=manager_.get()){
       manager_->connectTo(iConnectTo);
    }
 }
 void
 edm::ServiceToken::connect(edm::ActivityRegistry& iConnectTo)
 {
-   if(0!=manager_.get()){
+   if(nullptr!=manager_.get()){
       manager_->connect(iConnectTo);
    }
 }
@@ -74,14 +74,14 @@ edm::ServiceToken::connect(edm::ActivityRegistry& iConnectTo)
 void
 edm::ServiceToken::copySlotsTo(edm::ActivityRegistry& iConnectTo)
 {
-  if(0!=manager_.get()){
+  if(nullptr!=manager_.get()){
     manager_->copySlotsTo(iConnectTo);
   }
 }
 void
 edm::ServiceToken::copySlotsFrom(edm::ActivityRegistry& iConnectTo)
 {
-  if(0!=manager_.get()){
+  if(nullptr!=manager_.get()){
     manager_->copySlotsFrom(iConnectTo);
   }
 }

--- a/FWCore/ServiceRegistry/src/ServicesManager.cc
+++ b/FWCore/ServiceRegistry/src/ServicesManager.cc
@@ -92,7 +92,7 @@ namespace edm {
          }
 
          TypeSet tokenTypes;
-         if(0 != iToken.manager_.get()) {
+         if(nullptr != iToken.manager_.get()) {
             for(Type2Service::iterator itType = iToken.manager_->type2Service_.begin(),
                 itTypeEnd = iToken.manager_->type2Service_.end();
                 itType != itTypeEnd;
@@ -239,7 +239,7 @@ namespace edm {
               ++itParam) {
             std::shared_ptr<ServiceMakerBase> base(ServicePluginFactory::get()->create(itParam->getParameter<std::string>("@service_type")));
 
-            if(0 == base.get()) {
+            if(nullptr == base.get()) {
                throw Exception(errors::Configuration, "Service")
                << "could not find a service named "
                << itParam->getParameter<std::string>("@service_type")

--- a/FWCore/Services/plugins/CPU.cc
+++ b/FWCore/Services/plugins/CPU.cc
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <sys/time.h>
 #include <sys/resource.h>
-#include <stdio.h>
+#include <cstdio>
 #include <string>
 #include <fstream>
 #include <sstream>
@@ -30,7 +30,7 @@
 
 #ifdef __linux__
 #include <sched.h>
-#include <errno.h>
+#include <cerrno>
 #endif
 
 namespace edm {
@@ -39,11 +39,11 @@ namespace edm {
     class CPU : public CPUServiceBase {
     public:
       CPU(ParameterSet const&, ActivityRegistry&);
-      ~CPU();
+      ~CPU() override;
 
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
-      virtual bool cpuInfo(std::string &models, double &avgSpeed) override;
+      bool cpuInfo(std::string &models, double &avgSpeed) override;
 
     private:
       const bool reportCPUProperties_;

--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -24,7 +24,7 @@
 #include <thread>
 #include <sys/wait.h>
 #include <sstream>
-#include <string.h>
+#include <cstring>
 #include <poll.h>
 #include <atomic>
 
@@ -73,7 +73,7 @@ namespace edm {
         ThreadTracker() : tbb::task_scheduler_observer() {
           observe(true);
         }
-        void on_scheduler_entry(bool) {
+        void on_scheduler_entry(bool) override {
           // ensure thread local has been allocated; not necessary on Linux with
           // the current cmsRun linkage, but could be an issue if the platform
           // or linkage leads to "lazy" allocation of the thread local.  By
@@ -89,7 +89,7 @@ namespace edm {
       };
 
       explicit InitRootHandlers(ParameterSet const& pset, ActivityRegistry& iReg);
-      virtual ~InitRootHandlers();
+      ~InitRootHandlers() override;
       
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
       static void stacktraceFromThread();
@@ -100,9 +100,9 @@ namespace edm {
       static std::atomic<std::size_t> nextModule_, doneModules_;
     private:
       static char *const *getPstackArgv();
-      virtual void enableWarnings_() override;
-      virtual void ignoreWarnings_() override;
-      virtual void willBeUsingThreads() override;
+      void enableWarnings_() override;
+      void ignoreWarnings_() override;
+      void willBeUsingThreads() override;
 
       void cachePidInfo();
       static void stacktraceHelperThread();
@@ -179,10 +179,10 @@ namespace {
   // Arrange to report the error location as furnished by Root
 
     std::string el_location = "@SUB=?";
-    if (location != 0) el_location = std::string("@SUB=")+std::string(location);
+    if (location != nullptr) el_location = std::string("@SUB=")+std::string(location);
 
     std::string el_message  = "?";
-    if (message != 0) el_message  = message;
+    if (message != nullptr) el_message  = message;
 
   // Try to create a meaningful id string using knowledge of ROOT error messages
   //
@@ -410,7 +410,7 @@ namespace {
       sigset_t sigset;
       sigemptyset(&sigset);
       sigaddset(&sigset, RESUME_SIGNAL);
-      pthread_sigmask(SIG_UNBLOCK, &sigset, 0);
+      pthread_sigmask(SIG_UNBLOCK, &sigset, nullptr);
 #endif
       // sleep interrrupts on a handled delivery of the resume signal
       sleep(InitRootHandlers::stackTracePause());
@@ -446,13 +446,13 @@ namespace {
         act.sa_sigaction = sig_pause_for_stacktrace;
         act.sa_flags = 0;
         sigemptyset(&act.sa_mask);
-        sigaction(PAUSE_SIGNAL, &act, NULL);
+        sigaction(PAUSE_SIGNAL, &act, nullptr);
 
         // unblock pause signal globally, resume is unblocked in the pause handler
         sigset_t pausesigset;
         sigemptyset(&pausesigset);
         sigaddset(&pausesigset, PAUSE_SIGNAL);
-        sigprocmask(SIG_UNBLOCK, &pausesigset, 0);
+        sigprocmask(SIG_UNBLOCK, &pausesigset, nullptr);
 
         // send a pause signal to all CMSSW/TBB threads other than self
         for (auto id : tids) {
@@ -464,7 +464,7 @@ namespace {
 #ifdef RESUME_SIGNAL
         // install the "resume" handler
         act.sa_sigaction = sig_resume_handler;
-        sigaction(RESUME_SIGNAL, &act, NULL);
+        sigaction(RESUME_SIGNAL, &act, nullptr);
 #endif
       }
 #endif

--- a/FWCore/Services/plugins/LoadAllDictionaries.cc
+++ b/FWCore/Services/plugins/LoadAllDictionaries.cc
@@ -44,9 +44,9 @@ namespace edm {
       // ---------- member functions ---------------------------
       
     private:
-      LoadAllDictionaries(const LoadAllDictionaries&); // stop default
+      LoadAllDictionaries(const LoadAllDictionaries&) = delete; // stop default
       
-      const LoadAllDictionaries& operator=(const LoadAllDictionaries&); // stop default
+      const LoadAllDictionaries& operator=(const LoadAllDictionaries&) = delete; // stop default
       
       // ---------- member data --------------------------------
       

--- a/FWCore/Services/plugins/PrintLoadingPlugins.cc
+++ b/FWCore/Services/plugins/PrintLoadingPlugins.cc
@@ -49,9 +49,9 @@ public:
   
 private:
   
-  PrintLoadingPlugins(const PrintLoadingPlugins&); // stop default
+  PrintLoadingPlugins(const PrintLoadingPlugins&) = delete; // stop default
   
-  const PrintLoadingPlugins& operator=(const PrintLoadingPlugins&); // stop default
+  const PrintLoadingPlugins& operator=(const PrintLoadingPlugins&) = delete; // stop default
   
   // ---------- member data --------------------------------
   

--- a/FWCore/Services/plugins/SimpleMemoryCheck.cc
+++ b/FWCore/Services/plugins/SimpleMemoryCheck.cc
@@ -432,7 +432,7 @@ namespace edm {
 
     SimpleMemoryCheck::~SimpleMemoryCheck() {
 #ifdef LINUX
-      if(0 != smapsFile_) {
+      if(nullptr != smapsFile_) {
         fclose(smapsFile_);
       }
 #endif
@@ -463,7 +463,7 @@ namespace edm {
       if (monitorPssAndPrivate_) {
         std::ostringstream smapsNameOst;
         smapsNameOst <<"/proc/"<<getpid()<<"/smaps";
-        if((smapsFile_ =fopen(smapsNameOst.str().c_str(), "r"))==0) {
+        if((smapsFile_ =fopen(smapsNameOst.str().c_str(), "r"))==nullptr) {
           throw Exception(errors::Configuration) <<"Failed to open smaps file "<<smapsNameOst.str()<<std::endl;
         }
       }

--- a/FWCore/Services/src/SiteLocalConfigService.cc
+++ b/FWCore/Services/src/SiteLocalConfigService.cc
@@ -478,7 +478,7 @@ namespace edm {
 		if (statsDestList->getLength() > 0) {
 		  DOMElement *statsDest = static_cast<DOMElement *>(statsDestList->item(0));
 		  m_statisticsDestination = toString(statsDest->getAttribute(uStr("endpoint").ptr()));
-		  if (!m_statisticsDestination.size()) {
+		  if (m_statisticsDestination.empty()) {
 		    m_statisticsDestination = toString(statsDest->getAttribute(uStr("name").ptr()));
 		  }
 		  std::string tmpStatisticsInfo = toString(statsDest->getAttribute(uStr("info").ptr()));

--- a/FWCore/Services/src/SiteLocalConfigService.h
+++ b/FWCore/Services/src/SiteLocalConfigService.h
@@ -46,7 +46,7 @@ namespace edm {
 
             // implicit copy constructor
             // implicit assignment operator
-            ~SiteLocalConfigService();
+            ~SiteLocalConfigService() override;
 
             static void fillDescriptions(ConfigurationDescriptions& descriptions);
 

--- a/FWCore/TFWLiteSelector/interface/TFWLiteSelector.h
+++ b/FWCore/TFWLiteSelector/interface/TFWLiteSelector.h
@@ -59,7 +59,7 @@ class TFWLiteSelector : public TFWLiteSelectorBasic
 
    public:
       TFWLiteSelector() : worker_() {}
-      virtual ~TFWLiteSelector() {}
+      ~TFWLiteSelector() override {}
 
       // ---------- const member functions ---------------------
 
@@ -72,13 +72,13 @@ class TFWLiteSelector : public TFWLiteSelectorBasic
 
       const TFWLiteSelector& operator=(const TFWLiteSelector&); // stop default
 
-      virtual void preProcessing(const TList*in, TList& out) {
+      void preProcessing(const TList*in, TList& out) override {
         worker_ = std::make_shared<TWorker>(in,out);
       }
-      virtual void process(const edm::Event& iEvent) {
+      void process(const edm::Event& iEvent) override {
         worker_->process(iEvent);
       }
-      virtual void postProcessing(TList& out) {
+      void postProcessing(TList& out) override {
         worker_->postProcess(out);
       }
       

--- a/FWCore/TFWLiteSelector/interface/TFWLiteSelectorBasic.h
+++ b/FWCore/TFWLiteSelector/interface/TFWLiteSelectorBasic.h
@@ -44,7 +44,7 @@ class TFWLiteSelectorBasic : public TSelector
 
    public:
       TFWLiteSelectorBasic();
-      virtual ~TFWLiteSelectorBasic();
+      ~TFWLiteSelectorBasic() override;
 
       // ---------- const member functions ---------------------
 
@@ -86,14 +86,14 @@ class TFWLiteSelectorBasic : public TSelector
 
       const TFWLiteSelectorBasic& operator=(const TFWLiteSelectorBasic&); // stop default
 
-      virtual void        Begin(TTree *) ;
-      virtual void        SlaveBegin(TTree *);
-      virtual void        Init(TTree*);
-      virtual Bool_t      Notify() ;
-      virtual Bool_t      Process(Long64_t /*entry*/) ;
-      virtual void        SlaveTerminate();
-      virtual void        Terminate();
-      virtual Int_t Version() const { return 1; }
+      void        Begin(TTree *) override ;
+      void        SlaveBegin(TTree *) override;
+      void        Init(TTree*) override;
+      Bool_t      Notify() override ;
+      Bool_t      Process(Long64_t /*entry*/) override ;
+      void        SlaveTerminate() override;
+      void        Terminate() override;
+      Int_t Version() const override { return 1; }
       
       void setupNewFile(TFile&);
       // ---------- member data --------------------------------

--- a/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
+++ b/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
@@ -68,17 +68,17 @@ namespace edm {
       void set(std::shared_ptr<ProductRegistry const> iReg) { reg_ = iReg;}
      private:
       std::unique_ptr<WrapperBase> getTheProduct(BranchKey const& k) const;
-      virtual std::unique_ptr<WrapperBase> getProduct_(BranchKey const& k, EDProductGetter const* ep) override;
+      std::unique_ptr<WrapperBase> getProduct_(BranchKey const& k, EDProductGetter const* ep) override;
       virtual std::unique_ptr<EventEntryDescription> getProvenance_(BranchKey const&) const {
         return std::unique_ptr<EventEntryDescription>();
       }
-      virtual void mergeReaders_(DelayedReader*) override {}
-      virtual void reset_() override {}
+      void mergeReaders_(DelayedReader*) override {}
+      void reset_() override {}
       
-      virtual signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadFromSourceSignal() const override {
+      signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadFromSourceSignal() const override {
         return nullptr;
       }
-      virtual signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadFromSourceSignal() const override {
+      signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadFromSourceSignal() const override {
         return nullptr;
       };
 

--- a/FWCore/TFWLiteSelectorTest/src/ThingsTSelector.h
+++ b/FWCore/TFWLiteSelectorTest/src/ThingsTSelector.h
@@ -16,11 +16,11 @@ namespace tfwliteselectortest {
 class ThingsTSelector : public TFWLiteSelectorBasic {
 public :
       ThingsTSelector() : h_a(nullptr), h_refA(nullptr) {}
-      void begin(TList*&);
-      void preProcessing(const TList*, TList&);
-      void process(const edm::Event&);
-      void postProcessing(TList&);
-      void terminate(TList&);
+      void begin(TList*&) override;
+      void preProcessing(const TList*, TList&) override;
+      void process(const edm::Event&) override;
+      void postProcessing(TList&) override;
+      void terminate(TList&) override;
 
 private:
   /// histograms

--- a/FWCore/TFWLiteSelectorTest/src/ThingsTSelector2.h
+++ b/FWCore/TFWLiteSelectorTest/src/ThingsTSelector2.h
@@ -23,8 +23,8 @@ namespace tfwliteselectortest {
   class ThingsTSelector2 : public TFWLiteSelector<ThingsWorker> {
 public :
     ThingsTSelector2() {}
-    void begin(TList*&);
-    void terminate(TList&);
+    void begin(TList*&) override;
+    void terminate(TList&) override;
     
 private:
     

--- a/FWCore/Utilities/interface/Adler32Calculator.h
+++ b/FWCore/Utilities/interface/Adler32Calculator.h
@@ -2,7 +2,7 @@
 #define FWCore_Utilities_Adler32Calculator_h
 
 #include <sys/types.h>
-#include <stdint.h>
+#include <cstdint>
 
 /*
 Code to calculate a Adler32 checksum on a file.  This code is based

--- a/FWCore/Utilities/interface/SingleConsumerQ.h
+++ b/FWCore/Utilities/interface/SingleConsumerQ.h
@@ -109,7 +109,7 @@ namespace edm {
 
   private:
     // no copy
-    SingleConsumerQ(const SingleConsumerQ&);
+    SingleConsumerQ(const SingleConsumerQ&) = delete;
 
     // the memory for the buffers
     typedef std::vector<char> ByteArray;

--- a/FWCore/Utilities/src/CPUTimer.cc
+++ b/FWCore/Utilities/src/CPUTimer.cc
@@ -12,7 +12,7 @@
 
 // system include files
 #include <sys/resource.h>
-#include <errno.h>
+#include <cerrno>
 
 // user include files
 #include "FWCore/Utilities/interface/CPUTimer.h"

--- a/FWCore/Utilities/src/DebugMacros.cc
+++ b/FWCore/Utilities/src/DebugMacros.cc
@@ -7,7 +7,7 @@ namespace edm {
 
   debugvalue::debugvalue():
     cvalue_(getenv("PROC_DEBUG")),
-    value_(cvalue_==0 ? 0 : atoi(cvalue_))
+    value_(cvalue_==nullptr ? 0 : atoi(cvalue_))
   { }
   
   debugvalue debugit;

--- a/FWCore/Utilities/src/ExceptionCollector.cc
+++ b/FWCore/Utilities/src/ExceptionCollector.cc
@@ -13,7 +13,7 @@ namespace edm {
     cms::Exception("MultipleExceptions", iMessage),
     returnValue_(iReturnValue) {}
     
-    virtual Exception* clone() const override {
+    Exception* clone() const override {
       return new MultipleException(*this);
     }
 

--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -144,7 +144,7 @@ namespace edm {
                 //static regex const eComma(",");
                 //result = regex_replace(result,eComma,"");
                 std::cout <<" no template match for \""<<result<<"\""<<std::endl;
-                assert(0 =="failed to find a match for template class");
+                assert(nullptr =="failed to find a match for template class");
              }
           } else {
              shouldStop=true;

--- a/FWCore/Utilities/src/Guid.cc
+++ b/FWCore/Utilities/src/Guid.cc
@@ -13,7 +13,7 @@
 #include <cassert>
 #include <cstdio>
 #include <cstring>
-#include <stdlib.h>
+#include <cstdlib>
 #include <string>
 #include "uuid/uuid.h"
 
@@ -55,31 +55,31 @@ namespace edm {
     size_t const sSize = 4;
     size_t const cSize = 2;
     size_t offset = 0;
-    Data1 = strtol(source.substr(offset, iSize).c_str(), 0, 16);
+    Data1 = strtol(source.substr(offset, iSize).c_str(), nullptr, 16);
     offset += iSize;
     assert(dash == source[offset++]); 
-    Data2 = strtol(source.substr(offset, sSize).c_str(), 0, 16);
+    Data2 = strtol(source.substr(offset, sSize).c_str(), nullptr, 16);
     offset += sSize;
     assert(dash == source[offset++]); 
-    Data3 = strtol(source.substr(offset, sSize).c_str(), 0, 16);
+    Data3 = strtol(source.substr(offset, sSize).c_str(), nullptr, 16);
     offset += sSize;
     assert(dash == source[offset++]); 
-    Data4[0] = strtol(source.substr(offset, cSize).c_str(), 0, 16);
+    Data4[0] = strtol(source.substr(offset, cSize).c_str(), nullptr, 16);
     offset += cSize;
-    Data4[1] = strtol(source.substr(offset, cSize).c_str(), 0, 16);
+    Data4[1] = strtol(source.substr(offset, cSize).c_str(), nullptr, 16);
     offset += cSize;
     assert(dash == source[offset++]);
-    Data4[2] = strtol(source.substr(offset, cSize).c_str(), 0, 16);
+    Data4[2] = strtol(source.substr(offset, cSize).c_str(), nullptr, 16);
     offset += cSize;
-    Data4[3] = strtol(source.substr(offset, cSize).c_str(), 0, 16);
+    Data4[3] = strtol(source.substr(offset, cSize).c_str(), nullptr, 16);
     offset += cSize;
-    Data4[4] = strtol(source.substr(offset, cSize).c_str(), 0, 16);
+    Data4[4] = strtol(source.substr(offset, cSize).c_str(), nullptr, 16);
     offset += cSize;
-    Data4[5] = strtol(source.substr(offset, cSize).c_str(), 0, 16);
+    Data4[5] = strtol(source.substr(offset, cSize).c_str(), nullptr, 16);
     offset += cSize;
-    Data4[6] = strtol(source.substr(offset, cSize).c_str(), 0, 16);
+    Data4[6] = strtol(source.substr(offset, cSize).c_str(), nullptr, 16);
     offset += cSize;
-    Data4[7] = strtol(source.substr(offset, cSize).c_str(), 0, 16);
+    Data4[7] = strtol(source.substr(offset, cSize).c_str(), nullptr, 16);
     offset += cSize;
     assert(source.size() == offset);
     return *this;

--- a/FWCore/Utilities/src/MallocOpts.cc
+++ b/FWCore/Utilities/src/MallocOpts.cc
@@ -185,7 +185,7 @@ namespace edm
   bool MallocOptionSetter::retrieveFromEnv()
   {
     const char* par = getenv("CMSRUN_MALLOC_RESET");
-    if(par==0) return false; // leave quickly here
+    if(par==nullptr) return false; // leave quickly here
     std::string spar(par);
     bool rc = false;
       

--- a/FWCore/Utilities/src/TestHelper.cc
+++ b/FWCore/Utilities/src/TestHelper.cc
@@ -30,7 +30,7 @@ int run_script(std::string const& shell, std::string const& script) {
   }
 
   if(pid == 0) { // child
-    execlp(shell.c_str(), "sh", "-c", script.c_str(), static_cast<char const*>(0));
+    execlp(shell.c_str(), "sh", "-c", script.c_str(), static_cast<char const*>(nullptr));
     std::cerr << "child failed becuase '" << strerror(errno) << "'\n";
     _exit(127); // signal parent and children processes
   } else { // parent
@@ -67,7 +67,7 @@ int do_work(int argc, char* argv[], char** env) {
     std::cout << "Current directory is: " << currentPath.string() << '\n';
     std::cout << "Current environment:\n";
     std::cout << "---------------------\n";
-    for(int i = 0; env[i] != 0; ++i) std::cout << env[i] << '\n';
+    for(int i = 0; env[i] != nullptr; ++i) std::cout << env[i] << '\n';
     std::cout << "---------------------\n";
     std::cout << "Executable name: " << argv[0] << '\n';
     return -1;

--- a/FWCore/Utilities/src/TimeOfDay.cc
+++ b/FWCore/Utilities/src/TimeOfDay.cc
@@ -2,7 +2,7 @@
 #include <iomanip>
 #include <locale>
 #include <ostream>
-#include <time.h>
+#include <ctime>
 
 namespace {
   int const power[] = {1000*1000, 100*1000, 10*1000, 1000, 100, 10, 1};
@@ -19,7 +19,7 @@ namespace edm {
   timeval
   TimeOfDay::setTime_() {
     timeval tv;
-    gettimeofday(&tv, 0);
+    gettimeofday(&tv, nullptr);
     return tv;
   }
 

--- a/FWCore/Utilities/src/TypeDemangler.cc
+++ b/FWCore/Utilities/src/TypeDemangler.cc
@@ -97,8 +97,8 @@ namespace edm {
   std::string
   typeDemangle(char const* mangledName) {
     int status = 0;
-    size_t* const nullSize = 0;
-    char* const null = 0;
+    size_t* const nullSize = nullptr;
+    char* const null = nullptr;
     
     // The demangled C style string is allocated with malloc, so it must be deleted with free().
     char* demangled = abi::__cxa_demangle(mangledName, null, nullSize, &status);

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -128,7 +128,7 @@ namespace edm {
       ret.arrayDimensions_ = value_ptr<std::vector<size_t> >(new std::vector<size_t>);
       std::string const dimensions = name.substr(first);
       char const* s = dimensions.c_str();
-      while(1) {
+      while(true) {
         size_t x = 0;
         int count = sscanf(s, "[%lu]", &x);
         assert(count == 1);

--- a/FWCore/Utilities/src/UnixSignalHandlers.cc
+++ b/FWCore/Utilities/src/UnixSignalHandlers.cc
@@ -60,10 +60,10 @@ namespace edm {
 
 
 	  MUST_BE_ZERO(sigaddset(&myset,num));
-	  MUST_BE_ZERO(sigaction(num,&tmpact,NULL));
+	  MUST_BE_ZERO(sigaction(num,&tmpact,nullptr));
       }
       
-      MUST_BE_ZERO(pthread_sigmask(SIG_BLOCK,&myset,0));
+      MUST_BE_ZERO(pthread_sigmask(SIG_BLOCK,&myset,nullptr));
 #endif
     }
 
@@ -72,7 +72,7 @@ namespace edm {
     void reenableSigs( sigset_t* oldset )
     {
       // reenable the signals
-      MUST_BE_ZERO(pthread_sigmask(SIG_SETMASK,oldset,0));
+      MUST_BE_ZERO(pthread_sigmask(SIG_SETMASK,oldset,nullptr));
     }
 
 //--------------------------------------------------------------
@@ -125,7 +125,7 @@ namespace edm {
 	return;
       }
       
-      if(sigaction(mysig,&act,NULL) != 0) {
+      if(sigaction(mysig,&act,nullptr) != 0) {
 	  perror("sigaction failed");
 	  abort();
       }
@@ -133,7 +133,7 @@ namespace edm {
       sigset_t newset;
       MUST_BE_ZERO(sigemptyset(&newset));
       MUST_BE_ZERO(sigaddset(&newset,mysig));
-      MUST_BE_ZERO(pthread_sigmask(SIG_UNBLOCK,&newset,0));
+      MUST_BE_ZERO(pthread_sigmask(SIG_UNBLOCK,&newset,nullptr));
     }
 
 //--------------------------------------------------------------

--- a/FWCore/Utilities/src/WallclockTimer.cc
+++ b/FWCore/Utilities/src/WallclockTimer.cc
@@ -12,7 +12,7 @@
 
 // system include files
 #include <sys/resource.h>
-#include <errno.h>
+#include <cerrno>
 
 // user include files
 #include "FWCore/Utilities/interface/WallclockTimer.h"

--- a/FWCore/Utilities/src/typelookup.cc
+++ b/FWCore/Utilities/src/typelookup.cc
@@ -78,7 +78,7 @@ edm::typelookup::findType(const char* iTypeName) {
    auto itFind = typeNameToValueMap().find(iTypeName);
    
    if(itFind == typeNameToValueMap().end()) {
-      return std::make_pair(static_cast<const char*>(0), static_cast<std::type_info*> (0));
+      return std::make_pair(static_cast<const char*>(nullptr), static_cast<std::type_info*> (nullptr));
    }
    
    return (*itFind);


### PR DESCRIPTION
PR to apply clang-tidy checks to all FWCore files except those that are a part of open pull requests (as of an hour ago) and files in test directories