### PR TITLE
clang-tidy checks for AnalysisAlgos subsystem

### DIFF
--- a/AnalysisAlgos/SiStripClusterInfoProducer/plugins/SiStripProcessedRawDigiProducer.h
+++ b/AnalysisAlgos/SiStripClusterInfoProducer/plugins/SiStripProcessedRawDigiProducer.h
@@ -27,7 +27,7 @@ class SiStripProcessedRawDigiProducer : public edm::EDProducer {
 
  private:
 
-  void produce(edm::Event& e, const edm::EventSetup& es);
+  void produce(edm::Event& e, const edm::EventSetup& es) override;
   template<class T> std::string findInput(edm::Handle<T>& handle, const std::vector<edm::EDGetTokenT<T> >& tokens, const edm::Event& e);
 
   void vr_process(const edm::DetSetVector<SiStripRawDigi>&, edm::DetSetVector<SiStripProcessedRawDigi>&);

--- a/AnalysisAlgos/TrackInfoProducer/interface/TrackInfoProducer.h
+++ b/AnalysisAlgos/TrackInfoProducer/interface/TrackInfoProducer.h
@@ -28,9 +28,9 @@ class TrackInfoProducer : public edm::EDProducer {
   //  TrackInfoProducer(){}
   explicit TrackInfoProducer(const edm::ParameterSet& iConfig);
 
-  virtual ~TrackInfoProducer(){};
+  ~TrackInfoProducer() override{};
 
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 
  private:


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this tomorrow to avoid conflicts to the extent possible]