### PR TITLE
clang-tidy checks for AnalysisDataFormats subsystem

### DIFF
--- a/AnalysisDataFormats/EWK/interface/WMuNuCandidate.h
+++ b/AnalysisDataFormats/EWK/interface/WMuNuCandidate.h
@@ -18,7 +18,7 @@ class WMuNuCandidate : public reco::CompositeCandidate {
 public:
   WMuNuCandidate();
   WMuNuCandidate(edm::Ptr<reco::Muon>,edm::Ptr<reco::MET>);
-  ~WMuNuCandidate();
+  ~WMuNuCandidate() override;
 
       //WARNING: W Candidates combine the information from a Muon with the (px,py) information of the MET as the Neutrino
       // --> There is no Pz information!!!!

--- a/AnalysisDataFormats/EWK/interface/WMuNuCandidatePtr.h
+++ b/AnalysisDataFormats/EWK/interface/WMuNuCandidatePtr.h
@@ -18,7 +18,7 @@ class WMuNuCandidatePtr : public reco::CompositePtrCandidate {
 public:
   WMuNuCandidatePtr();
   WMuNuCandidatePtr(const reco::CandidatePtr,const reco::CandidatePtr);
-  ~WMuNuCandidatePtr();
+  ~WMuNuCandidatePtr() override;
 
       //WARNING: W Candidates combine the information from a Muon with the (px,py) information of the MET as the Neutrino
       // --> There is no Pz information!!!!

--- a/AnalysisDataFormats/TopObjects/interface/StEvtSolution.h
+++ b/AnalysisDataFormats/TopObjects/interface/StEvtSolution.h
@@ -64,10 +64,10 @@ class StEvtSolution {
   //-------------------------------------------
   // get objects from kinematic fit
   //-------------------------------------------
-  pat::Particle getFitBottom() const { return (fitBottom_.size()>0 ? fitBottom_.front() : pat::Particle()); };
-  pat::Particle getFitLight() const { return (fitLight_.size()>0 ? fitLight_.front() : pat::Particle()); };
-  pat::Particle getFitLepton() const { return (fitLepton_.size()>0 ? fitLepton_.front() : pat::Particle()); };
-  pat::Particle getFitNeutrino() const { return (fitNeutrino_.size()>0 ? fitNeutrino_.front() : pat::Particle()); };
+  pat::Particle getFitBottom() const { return (!fitBottom_.empty() ? fitBottom_.front() : pat::Particle()); };
+  pat::Particle getFitLight() const { return (!fitLight_.empty() ? fitLight_.front() : pat::Particle()); };
+  pat::Particle getFitLepton() const { return (!fitLepton_.empty() ? fitLepton_.front() : pat::Particle()); };
+  pat::Particle getFitNeutrino() const { return (!fitNeutrino_.empty() ? fitNeutrino_.front() : pat::Particle()); };
   reco::Particle getFitLepW() const;
   reco::Particle getFitLept() const;
 

--- a/AnalysisDataFormats/TopObjects/interface/StGenEvent.h
+++ b/AnalysisDataFormats/TopObjects/interface/StGenEvent.h
@@ -22,7 +22,7 @@ class StGenEvent: public TopGenEvent {
   /// default constructor
   StGenEvent(reco::GenParticleRefProd&, reco::GenParticleRefProd&);
   /// default destructor
-  virtual ~StGenEvent();
+  ~StGenEvent() override;
 
   /// return single lepton if available; 0 else
   const reco::GenParticle* singleLepton() const;

--- a/AnalysisDataFormats/TopObjects/interface/TtDilepEvtSolution.h
+++ b/AnalysisDataFormats/TopObjects/interface/TtDilepEvtSolution.h
@@ -51,16 +51,16 @@ class TtDilepEvtSolution {
   // get the matched gen particles
   //-------------------------------------------
   const edm::RefProd<TtGenEvent> & getGenEvent() const { return theGenEvt_; };
-  const reco::GenParticle * getGenT() const { if (!theGenEvt_) return 0; else return theGenEvt_->top(); };
-  const reco::GenParticle * getGenWp() const { if (!theGenEvt_) return 0; else return theGenEvt_->wPlus(); };
-  const reco::GenParticle * getGenB() const { if (!theGenEvt_) return 0; else return theGenEvt_->b(); };
-  const reco::GenParticle * getGenLepp() const { if (!theGenEvt_) return 0; else return theGenEvt_->leptonBar(); };
-  const reco::GenParticle * getGenN() const { if (!theGenEvt_) return 0; else return theGenEvt_->neutrino(); };
-  const reco::GenParticle * getGenTbar() const { if (!theGenEvt_) return 0; else return theGenEvt_->topBar(); };
-  const reco::GenParticle * getGenWm() const { if (!theGenEvt_) return 0; else return theGenEvt_->wMinus(); };
-  const reco::GenParticle * getGenBbar() const { if (!theGenEvt_) return 0; else return theGenEvt_->bBar(); };
-  const reco::GenParticle * getGenLepm() const { if (!theGenEvt_) return 0; else return theGenEvt_->lepton(); };
-  const reco::GenParticle * getGenNbar() const { if (!theGenEvt_) return 0; else return theGenEvt_->neutrinoBar(); };
+  const reco::GenParticle * getGenT() const { if (!theGenEvt_) return nullptr; else return theGenEvt_->top(); };
+  const reco::GenParticle * getGenWp() const { if (!theGenEvt_) return nullptr; else return theGenEvt_->wPlus(); };
+  const reco::GenParticle * getGenB() const { if (!theGenEvt_) return nullptr; else return theGenEvt_->b(); };
+  const reco::GenParticle * getGenLepp() const { if (!theGenEvt_) return nullptr; else return theGenEvt_->leptonBar(); };
+  const reco::GenParticle * getGenN() const { if (!theGenEvt_) return nullptr; else return theGenEvt_->neutrino(); };
+  const reco::GenParticle * getGenTbar() const { if (!theGenEvt_) return nullptr; else return theGenEvt_->topBar(); };
+  const reco::GenParticle * getGenWm() const { if (!theGenEvt_) return nullptr; else return theGenEvt_->wMinus(); };
+  const reco::GenParticle * getGenBbar() const { if (!theGenEvt_) return nullptr; else return theGenEvt_->bBar(); };
+  const reco::GenParticle * getGenLepm() const { if (!theGenEvt_) return nullptr; else return theGenEvt_->lepton(); };
+  const reco::GenParticle * getGenNbar() const { if (!theGenEvt_) return nullptr; else return theGenEvt_->neutrinoBar(); };
 
   //-------------------------------------------
   // get (un-)/calibrated reco objects

--- a/AnalysisDataFormats/TopObjects/interface/TtEvent.h
+++ b/AnalysisDataFormats/TopObjects/interface/TtEvent.h
@@ -106,9 +106,9 @@ class TtEvent {
   /// get combined 4-vector of top and topBar of the given hypothesis
   const reco::Candidate* topPair(const std::string& key, const unsigned& cmb=0) const { return topPair(hypoClassKeyFromString(key), cmb); };
   /// get combined 4-vector of top and topBar of the given hypothesis
-  const reco::Candidate* topPair(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : (reco::Candidate*)&eventHypo(key,cmb); };
+  const reco::Candidate* topPair(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : (reco::Candidate*)&eventHypo(key,cmb); };
   /// get combined 4-vector of top and topBar from the TtGenEvent
-  const math::XYZTLorentzVector* topPair() const { return (!genEvt_ ? 0 : this->genEvent()->topPair()); };
+  const math::XYZTLorentzVector* topPair() const { return (!genEvt_ ? nullptr : this->genEvent()->topPair()); };
 
   /// print pt, eta, phi, mass of a given candidate into an existing LogInfo
   void printParticle(edm::LogInfo &log, const char* name, const reco::Candidate* cand) const;

--- a/AnalysisDataFormats/TopObjects/interface/TtFullHadEvtPartons.h
+++ b/AnalysisDataFormats/TopObjects/interface/TtFullHadEvtPartons.h
@@ -29,10 +29,10 @@ class TtFullHadEvtPartons : public TtEventPartons {
   /// default constructor
   TtFullHadEvtPartons(const std::vector<std::string>& partonsToIgnore = std::vector<std::string>());
   /// default destructor
-  ~TtFullHadEvtPartons(){};
+  ~TtFullHadEvtPartons() override{};
 
   /// return vector of partons in the order defined in the corresponding enum
-  std::vector<const reco::Candidate*> vec(const TtGenEvent& genEvt);
+  std::vector<const reco::Candidate*> vec(const TtGenEvent& genEvt) override;
 
 };
 

--- a/AnalysisDataFormats/TopObjects/interface/TtFullHadronicEvent.h
+++ b/AnalysisDataFormats/TopObjects/interface/TtFullHadronicEvent.h
@@ -27,81 +27,81 @@ class TtFullHadronicEvent: public TtEvent {
   /// empty constructor
   TtFullHadronicEvent(){};
   /// default destructor
-  virtual ~TtFullHadronicEvent(){};
+  ~TtFullHadronicEvent() override{};
 
   /// get top of the given hypothesis
   const reco::Candidate* top(const std::string& key, const unsigned& cmb=0) const { return top(hypoClassKeyFromString(key), cmb); };
   /// get top of the given hypothesis
-  const reco::Candidate* top(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : eventHypo(key,cmb). daughter(TtFullHadDaughter::Top); };
+  const reco::Candidate* top(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : eventHypo(key,cmb). daughter(TtFullHadDaughter::Top); };
   /// get b of the given hypothesis
   const reco::Candidate* b(const std::string& key, const unsigned& cmb=0) const { return b(hypoClassKeyFromString(key), cmb); };
   /// get b of the given hypothesis
-  const reco::Candidate* b(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : top(key,cmb)->daughter(TtFullHadDaughter::B); };
+  const reco::Candidate* b(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : top(key,cmb)->daughter(TtFullHadDaughter::B); };
 
   /// get light Q of the given hypothesis
   const reco::Candidate* lightQ(const std::string& key, const unsigned& cmb=0) const { return lightQ(hypoClassKeyFromString(key), cmb); };
   /// get light Q of the given hypothesis
-  const reco::Candidate* lightQ(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : wPlus(key,cmb)->daughter(TtFullHadDaughter::LightQ); };
+  const reco::Candidate* lightQ(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : wPlus(key,cmb)->daughter(TtFullHadDaughter::LightQ); };
 
   /// get light P of the given hypothesis
   const reco::Candidate* lightP(const std::string& key, const unsigned& cmb=0) const { return lightP(hypoClassKeyFromString(key), cmb); };
   /// get light P of the given hypothesis
-  const reco::Candidate* lightP(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : wMinus(key,cmb)->daughter(TtFullHadDaughter::LightP); };
+  const reco::Candidate* lightP(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : wMinus(key,cmb)->daughter(TtFullHadDaughter::LightP); };
 
   /// get Wplus of the given hypothesis
   const reco::Candidate* wPlus(const std::string& key, const unsigned& cmb=0) const { return wPlus(hypoClassKeyFromString(key), cmb); };
   /// get Wplus of the given hypothesis
-  const reco::Candidate* wPlus(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : top(key,cmb)->daughter(TtFullHadDaughter::WPlus); };
+  const reco::Candidate* wPlus(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : top(key,cmb)->daughter(TtFullHadDaughter::WPlus); };
 
   /// get anti-top of the given hypothesis
   const reco::Candidate* topBar(const std::string& key, const unsigned& cmb=0) const { return topBar(hypoClassKeyFromString(key), cmb); };
   /// get anti-top of the given hypothesis
-  const reco::Candidate* topBar(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : eventHypo(key,cmb). daughter(TtFullHadDaughter::TopBar); };
+  const reco::Candidate* topBar(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : eventHypo(key,cmb). daughter(TtFullHadDaughter::TopBar); };
   /// get anti-b of the given hypothesis
   const reco::Candidate* bBar(const std::string& key, const unsigned& cmb=0) const { return bBar(hypoClassKeyFromString(key), cmb); };
   /// get anti-b of the given hypothesis
-  const reco::Candidate* bBar(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : topBar(key,cmb)->daughter(TtFullHadDaughter::BBar  ); };
+  const reco::Candidate* bBar(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : topBar(key,cmb)->daughter(TtFullHadDaughter::BBar  ); };
 
   /// get light Q bar of the given hypothesis
   const reco::Candidate* lightQBar(const std::string& key, const unsigned& cmb=0) const { return lightQBar(hypoClassKeyFromString(key), cmb); };
   /// get light Q bar of the given hypothesis
-  const reco::Candidate* lightQBar(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : wPlus(key,cmb)->daughter(TtFullHadDaughter::LightQBar); };
+  const reco::Candidate* lightQBar(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : wPlus(key,cmb)->daughter(TtFullHadDaughter::LightQBar); };
 
   /// get light P bar of the given hypothesis
   const reco::Candidate* lightPBar(const std::string& key, const unsigned& cmb=0) const { return lightPBar(hypoClassKeyFromString(key), cmb); };
   /// get light P bar of the given hypothesis
-  const reco::Candidate* lightPBar(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : wMinus(key,cmb)->daughter(TtFullHadDaughter::LightPBar); };
+  const reco::Candidate* lightPBar(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : wMinus(key,cmb)->daughter(TtFullHadDaughter::LightPBar); };
 
   /// get Wminus of the given hypothesis
   const reco::Candidate* wMinus(const std::string& key, const unsigned& cmb=0) const { return wMinus(hypoClassKeyFromString(key), cmb); };
   /// get Wminus of the given hypothesis
-  const reco::Candidate* wMinus(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : topBar(key,cmb)->daughter(TtFullHadDaughter::WMinus); };
+  const reco::Candidate* wMinus(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : topBar(key,cmb)->daughter(TtFullHadDaughter::WMinus); };
 
   /// get top of the TtGenEvent
-  const reco::GenParticle* top        () const { return (!genEvt_ ? 0 : this->genEvent()->top()  ); };
+  const reco::GenParticle* top        () const { return (!genEvt_ ? nullptr : this->genEvent()->top()  ); };
   /// get b of the TtGenEvent
-  const reco::GenParticle* b          () const { return (!genEvt_ ? 0 : this->genEvent()->b()    ); };
+  const reco::GenParticle* b          () const { return (!genEvt_ ? nullptr : this->genEvent()->b()    ); };
 
   /// get light Q of the TtGenEvent
-  const reco::GenParticle* lightQ     () const { return (!genEvt_ ? 0 : this->genEvent()->daughterQuarkOfWPlus()   ); };
+  const reco::GenParticle* lightQ     () const { return (!genEvt_ ? nullptr : this->genEvent()->daughterQuarkOfWPlus()   ); };
   /// get light P of the TtGenEvent
-  const reco::GenParticle* lightP     () const { return (!genEvt_ ? 0 : this->genEvent()->daughterQuarkOfWMinus()  ); };
+  const reco::GenParticle* lightP     () const { return (!genEvt_ ? nullptr : this->genEvent()->daughterQuarkOfWMinus()  ); };
 
   /// get Wplus of the TtGenEvent
-  const reco::GenParticle* wPlus      () const { return (!genEvt_ ? 0 : this->genEvent()->wPlus()   ); };
+  const reco::GenParticle* wPlus      () const { return (!genEvt_ ? nullptr : this->genEvent()->wPlus()   ); };
 
   /// get anti-top of the TtGenEvent
-  const reco::GenParticle* topBar     () const { return (!genEvt_ ? 0 : this->genEvent()->topBar()  ); };
+  const reco::GenParticle* topBar     () const { return (!genEvt_ ? nullptr : this->genEvent()->topBar()  ); };
   /// get anti-b of the TtGenEvent
-  const reco::GenParticle* bBar       () const { return (!genEvt_ ? 0 : this->genEvent()->bBar()    ); };
+  const reco::GenParticle* bBar       () const { return (!genEvt_ ? nullptr : this->genEvent()->bBar()    ); };
 
   /// get light Q bar of the TtGenEvent
-  const reco::GenParticle* lightQBar  () const { return (!genEvt_ ? 0 : this->genEvent()->daughterQuarkBarOfWPlus()   ); };
+  const reco::GenParticle* lightQBar  () const { return (!genEvt_ ? nullptr : this->genEvent()->daughterQuarkBarOfWPlus()   ); };
   /// get light P bar of the TtGenEvent
-  const reco::GenParticle* lightPBar  () const { return (!genEvt_ ? 0 : this->genEvent()->daughterQuarkBarOfWMinus()  ); };
+  const reco::GenParticle* lightPBar  () const { return (!genEvt_ ? nullptr : this->genEvent()->daughterQuarkBarOfWMinus()  ); };
 
   /// get Wminus of the TtGenEvent
-  const reco::GenParticle* wMinus     () const { return (!genEvt_ ? 0 : this->genEvent()->wMinus()  ); };
+  const reco::GenParticle* wMinus     () const { return (!genEvt_ ? nullptr : this->genEvent()->wMinus()  ); };
 
   /// print full content of the structure as formated 
   /// LogInfo to the MessageLogger output for debugging  

--- a/AnalysisDataFormats/TopObjects/interface/TtFullLepEvtPartons.h
+++ b/AnalysisDataFormats/TopObjects/interface/TtFullLepEvtPartons.h
@@ -29,10 +29,10 @@ class TtFullLepEvtPartons : public TtEventPartons {
   /// default constructor
   TtFullLepEvtPartons(const std::vector<std::string>& partonsToIgnore = std::vector<std::string>());
   /// default destructor
-  ~TtFullLepEvtPartons(){};
+  ~TtFullLepEvtPartons() override{};
 
   /// return vector of partons in the order defined in the corresponding enum
-  std::vector<const reco::Candidate*> vec(const TtGenEvent& genEvt);
+  std::vector<const reco::Candidate*> vec(const TtGenEvent& genEvt) override;
 
 };
 

--- a/AnalysisDataFormats/TopObjects/interface/TtFullLeptonicEvent.h
+++ b/AnalysisDataFormats/TopObjects/interface/TtFullLeptonicEvent.h
@@ -27,69 +27,69 @@ class TtFullLeptonicEvent: public TtEvent {
   /// empty constructor
   TtFullLeptonicEvent(){};
   /// default destructor
-  virtual ~TtFullLeptonicEvent(){};
+  ~TtFullLeptonicEvent() override{};
 
   /// get top of the given hypothesis
   const reco::Candidate* top(const std::string& key, const unsigned& cmb=0) const { return top(hypoClassKeyFromString(key), cmb); };
   /// get top of the given hypothesis
-  const reco::Candidate* top(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : eventHypo(key,cmb). daughter(TtFullLepDaughter::Top); };
+  const reco::Candidate* top(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : eventHypo(key,cmb). daughter(TtFullLepDaughter::Top); };
   /// get b of the given hypothesis
   const reco::Candidate* b(const std::string& key, const unsigned& cmb=0) const { return b(hypoClassKeyFromString(key), cmb); };
   /// get b of the given hypothesis
-  const reco::Candidate* b(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : top(key,cmb)->daughter(TtFullLepDaughter::B); };
+  const reco::Candidate* b(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : top(key,cmb)->daughter(TtFullLepDaughter::B); };
   /// get Wplus of the given hypothesis
   const reco::Candidate* wPlus(const std::string& key, const unsigned& cmb=0) const { return wPlus(hypoClassKeyFromString(key), cmb); };
   /// get Wplus of the given hypothesis
-  const reco::Candidate* wPlus(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : top(key,cmb)->daughter(TtFullLepDaughter::WPlus); };
+  const reco::Candidate* wPlus(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : top(key,cmb)->daughter(TtFullLepDaughter::WPlus); };
   /// get anti-lepton of the given hypothesis
   const reco::Candidate* leptonBar(const std::string& key, const unsigned& cmb=0) const { return leptonBar(hypoClassKeyFromString(key), cmb); };
   /// get anti-lepton of the given hypothesis
-  const reco::Candidate* leptonBar(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : wPlus(key,cmb)->daughter(TtFullLepDaughter::LepBar); };
+  const reco::Candidate* leptonBar(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : wPlus(key,cmb)->daughter(TtFullLepDaughter::LepBar); };
   /// get neutrino of the given hypothesis
   const reco::Candidate* neutrino(const std::string& key, const unsigned& cmb=0) const { return neutrino(hypoClassKeyFromString(key), cmb); };
   /// get neutrino of the given hypothesis
-  const reco::Candidate* neutrino(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : wPlus(key,cmb)->daughter(TtFullLepDaughter::Nu    ); };
+  const reco::Candidate* neutrino(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : wPlus(key,cmb)->daughter(TtFullLepDaughter::Nu    ); };
   /// get anti-top of the given hypothesis
   const reco::Candidate* topBar(const std::string& key, const unsigned& cmb=0) const { return topBar(hypoClassKeyFromString(key), cmb); };
   /// get anti-top of the given hypothesis
-  const reco::Candidate* topBar(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : eventHypo(key,cmb). daughter(TtFullLepDaughter::TopBar); };
+  const reco::Candidate* topBar(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : eventHypo(key,cmb). daughter(TtFullLepDaughter::TopBar); };
   /// get anti-b of the given hypothesis
   const reco::Candidate* bBar(const std::string& key, const unsigned& cmb=0) const { return bBar(hypoClassKeyFromString(key), cmb); };
   /// get anti-b of the given hypothesis
-  const reco::Candidate* bBar(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : topBar(key,cmb)->daughter(TtFullLepDaughter::BBar  ); };
+  const reco::Candidate* bBar(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : topBar(key,cmb)->daughter(TtFullLepDaughter::BBar  ); };
   /// get Wminus of the given hypothesis
   const reco::Candidate* wMinus(const std::string& key, const unsigned& cmb=0) const { return wMinus(hypoClassKeyFromString(key), cmb); };
   /// get Wminus of the given hypothesis
-  const reco::Candidate* wMinus(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : topBar(key,cmb)->daughter(TtFullLepDaughter::WMinus); };
+  const reco::Candidate* wMinus(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : topBar(key,cmb)->daughter(TtFullLepDaughter::WMinus); };
   /// get lepton of the given hypothesis
   const reco::Candidate* lepton(const std::string& key, const unsigned& cmb=0) const { return lepton(hypoClassKeyFromString(key), cmb); };
   /// get lepton of the given hypothesis
-  const reco::Candidate* lepton(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : wMinus(key,cmb)->daughter(TtFullLepDaughter::Lep   ); };
+  const reco::Candidate* lepton(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : wMinus(key,cmb)->daughter(TtFullLepDaughter::Lep   ); };
   /// get anti-neutrino of the given hypothesis
   const reco::Candidate* neutrinoBar(const std::string& key, const unsigned& cmb=0) const { return neutrinoBar(hypoClassKeyFromString(key), cmb); };
   /// get anti-neutrino of the given hypothesis
-  const reco::Candidate* neutrinoBar(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : wMinus   (key,cmb)->daughter(TtFullLepDaughter::NuBar ); };
+  const reco::Candidate* neutrinoBar(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : wMinus   (key,cmb)->daughter(TtFullLepDaughter::NuBar ); };
 
   /// get top of the TtGenEvent
-  const reco::GenParticle* genTop        () const { return (!genEvt_ ? 0 : this->genEvent()->top()        ); };
+  const reco::GenParticle* genTop        () const { return (!genEvt_ ? nullptr : this->genEvent()->top()        ); };
   /// get b of the TtGenEvent
-  const reco::GenParticle* genB          () const { return (!genEvt_ ? 0 : this->genEvent()->b()          ); };
+  const reco::GenParticle* genB          () const { return (!genEvt_ ? nullptr : this->genEvent()->b()          ); };
   /// get Wplus of the TtGenEvent
-  const reco::GenParticle* genWPlus      () const { return (!genEvt_ ? 0 : this->genEvent()->wPlus()      ); };
+  const reco::GenParticle* genWPlus      () const { return (!genEvt_ ? nullptr : this->genEvent()->wPlus()      ); };
   /// get anti-lepton of the TtGenEvent
-  const reco::GenParticle* genLeptonBar  () const { return (!genEvt_ ? 0 : this->genEvent()->leptonBar()  ); };
+  const reco::GenParticle* genLeptonBar  () const { return (!genEvt_ ? nullptr : this->genEvent()->leptonBar()  ); };
   /// get neutrino of the TtGenEvent
-  const reco::GenParticle* genNeutrino   () const { return (!genEvt_ ? 0 : this->genEvent()->neutrino()   ); };
+  const reco::GenParticle* genNeutrino   () const { return (!genEvt_ ? nullptr : this->genEvent()->neutrino()   ); };
   /// get anti-top of the TtGenEvent
-  const reco::GenParticle* genTopBar     () const { return (!genEvt_ ? 0 : this->genEvent()->topBar()     ); };
+  const reco::GenParticle* genTopBar     () const { return (!genEvt_ ? nullptr : this->genEvent()->topBar()     ); };
   /// get anti-b of the TtGenEvent
-  const reco::GenParticle* genBBar       () const { return (!genEvt_ ? 0 : this->genEvent()->bBar()       ); };
+  const reco::GenParticle* genBBar       () const { return (!genEvt_ ? nullptr : this->genEvent()->bBar()       ); };
   /// get Wminus of the TtGenEvent
-  const reco::GenParticle* genWMinus     () const { return (!genEvt_ ? 0 : this->genEvent()->wMinus()     ); };
+  const reco::GenParticle* genWMinus     () const { return (!genEvt_ ? nullptr : this->genEvent()->wMinus()     ); };
   /// get lepton of the TtGenEvent
-  const reco::GenParticle* genLepton     () const { return (!genEvt_ ? 0 : this->genEvent()->lepton()     ); };
+  const reco::GenParticle* genLepton     () const { return (!genEvt_ ? nullptr : this->genEvent()->lepton()     ); };
   /// get anti-neutrino of the TtGenEvent
-  const reco::GenParticle* genNeutrinoBar() const { return (!genEvt_ ? 0 : this->genEvent()->neutrinoBar()); };
+  const reco::GenParticle* genNeutrinoBar() const { return (!genEvt_ ? nullptr : this->genEvent()->neutrinoBar()); };
 
   /// return the weight of the kinematic solution of hypothesis 'cmb' if available; -1 else
   double solWeight(const unsigned& cmb=0) const { return (cmb<solWeight_.size() ? solWeight_[cmb] : -1.); }    

--- a/AnalysisDataFormats/TopObjects/interface/TtGenEvent.h
+++ b/AnalysisDataFormats/TopObjects/interface/TtGenEvent.h
@@ -24,7 +24,7 @@ class TtGenEvent: public TopGenEvent {
   /// default constructor from decaySubset and initSubset
   TtGenEvent(reco::GenParticleRefProd& decaySubset, reco::GenParticleRefProd& initSubset);
   /// default destructor
-  virtual ~TtGenEvent() {};
+  ~TtGenEvent() override {};
 
   /// check if the event can be classified as ttbar
   bool isTtBar() const {return (top() && topBar());}
@@ -84,7 +84,7 @@ class TtGenEvent: public TopGenEvent {
   const reco::GenParticle* neutrinoBar(bool excludeTauLeptons=false) const;
 
   /// return combined 4-vector of top and topBar
-  const math::XYZTLorentzVector* topPair() const { return isTtBar() ? &topPair_ : 0; };
+  const math::XYZTLorentzVector* topPair() const { return isTtBar() ? &topPair_ : nullptr; };
 
  protected:
 

--- a/AnalysisDataFormats/TopObjects/interface/TtHadEvtSolution.h
+++ b/AnalysisDataFormats/TopObjects/interface/TtHadEvtSolution.h
@@ -48,12 +48,12 @@ class TtHadEvtSolution {
   // get the matched gen particles
   //-------------------------------------------
   const edm::RefProd<TtGenEvent> & getGenEvent() const { return theGenEvt_; };
-  const reco::GenParticle * getGenHadb() const { if (!theGenEvt_) return 0; else return theGenEvt_->b(); };
-  const reco::GenParticle * getGenHadbbar() const { if (!theGenEvt_) return 0; else return theGenEvt_->bBar(); };
-  const reco::GenParticle * getGenHadp() const { if (!theGenEvt_) return 0; else return theGenEvt_->daughterQuarkOfWPlus(); };
-  const reco::GenParticle * getGenHadq() const { if (!theGenEvt_) return 0; else return theGenEvt_->daughterQuarkBarOfWPlus(); };
-  const reco::GenParticle * getGenHadj() const { if (!theGenEvt_) return 0; else return theGenEvt_->daughterQuarkOfWMinus(); };
-  const reco::GenParticle * getGenHadk() const { if (!theGenEvt_) return 0; else return theGenEvt_->daughterQuarkBarOfWMinus(); };
+  const reco::GenParticle * getGenHadb() const { if (!theGenEvt_) return nullptr; else return theGenEvt_->b(); };
+  const reco::GenParticle * getGenHadbbar() const { if (!theGenEvt_) return nullptr; else return theGenEvt_->bBar(); };
+  const reco::GenParticle * getGenHadp() const { if (!theGenEvt_) return nullptr; else return theGenEvt_->daughterQuarkOfWPlus(); };
+  const reco::GenParticle * getGenHadq() const { if (!theGenEvt_) return nullptr; else return theGenEvt_->daughterQuarkBarOfWPlus(); };
+  const reco::GenParticle * getGenHadj() const { if (!theGenEvt_) return nullptr; else return theGenEvt_->daughterQuarkOfWMinus(); };
+  const reco::GenParticle * getGenHadk() const { if (!theGenEvt_) return nullptr; else return theGenEvt_->daughterQuarkBarOfWMinus(); };
   
   //-------------------------------------------
   // get (un-)/calibrated reco objects
@@ -88,12 +88,12 @@ class TtHadEvtSolution {
   reco::Particle getFitHadtbar() const;
   reco::Particle getFitHadW_plus() const;
   reco::Particle getFitHadW_minus() const;
-  pat::Particle getFitHadb() const { return (fitHadb_.size()>0 ? fitHadb_.front() : pat::Particle()); };
-  pat::Particle getFitHadbbar() const { return (fitHadbbar_.size()>0 ? fitHadbbar_.front() : pat::Particle()); };
-  pat::Particle getFitHadp() const { return (fitHadp_.size()>0 ? fitHadp_.front() : pat::Particle()); };
-  pat::Particle getFitHadq() const { return (fitHadq_.size()>0 ? fitHadq_.front() : pat::Particle()); };
-  pat::Particle getFitHadj() const { return (fitHadj_.size()>0 ? fitHadj_.front() : pat::Particle()); };
-  pat::Particle getFitHadk() const { return (fitHadk_.size()>0 ? fitHadk_.front() : pat::Particle()); };
+  pat::Particle getFitHadb() const { return (!fitHadb_.empty() ? fitHadb_.front() : pat::Particle()); };
+  pat::Particle getFitHadbbar() const { return (!fitHadbbar_.empty() ? fitHadbbar_.front() : pat::Particle()); };
+  pat::Particle getFitHadp() const { return (!fitHadp_.empty() ? fitHadp_.front() : pat::Particle()); };
+  pat::Particle getFitHadq() const { return (!fitHadq_.empty() ? fitHadq_.front() : pat::Particle()); };
+  pat::Particle getFitHadj() const { return (!fitHadj_.empty() ? fitHadj_.front() : pat::Particle()); };
+  pat::Particle getFitHadk() const { return (!fitHadk_.empty() ? fitHadk_.front() : pat::Particle()); };
 
   //-------------------------------------------  
   // get the selected hadronic decay chain 

--- a/AnalysisDataFormats/TopObjects/interface/TtSemiEvtSolution.h
+++ b/AnalysisDataFormats/TopObjects/interface/TtSemiEvtSolution.h
@@ -59,16 +59,16 @@ class TtSemiEvtSolution {
   // get the matched gen particles
   //-------------------------------------------
   const edm::RefProd<TtGenEvent> & getGenEvent() const { return theGenEvt_; };
-  const reco::GenParticle * getGenHadt() const { if (!theGenEvt_) return 0; else return this->getGenEvent()->hadronicDecayTop(); };
-  const reco::GenParticle * getGenHadW() const { if (!theGenEvt_) return 0; else return this->getGenEvent()->hadronicDecayW(); };
-  const reco::GenParticle * getGenHadb() const { if (!theGenEvt_) return 0; else return this->getGenEvent()->hadronicDecayB(); };
-  const reco::GenParticle * getGenHadp() const { if (!theGenEvt_) return 0; else return this->getGenEvent()->hadronicDecayQuark(); };
-  const reco::GenParticle * getGenHadq() const { if (!theGenEvt_) return 0; else return this->getGenEvent()->hadronicDecayQuarkBar(); };
-  const reco::GenParticle * getGenLept() const { if (!theGenEvt_) return 0; else return this->getGenEvent()->leptonicDecayTop(); };
-  const reco::GenParticle * getGenLepW() const { if (!theGenEvt_) return 0; else return this->getGenEvent()->leptonicDecayW(); };
-  const reco::GenParticle * getGenLepb() const { if (!theGenEvt_) return 0; else return this->getGenEvent()->leptonicDecayB(); };
-  const reco::GenParticle * getGenLepl() const { if (!theGenEvt_) return 0; else return this->getGenEvent()->singleLepton(); };
-  const reco::GenParticle * getGenLepn() const { if (!theGenEvt_) return 0; else return this->getGenEvent()->singleNeutrino(); };
+  const reco::GenParticle * getGenHadt() const { if (!theGenEvt_) return nullptr; else return this->getGenEvent()->hadronicDecayTop(); };
+  const reco::GenParticle * getGenHadW() const { if (!theGenEvt_) return nullptr; else return this->getGenEvent()->hadronicDecayW(); };
+  const reco::GenParticle * getGenHadb() const { if (!theGenEvt_) return nullptr; else return this->getGenEvent()->hadronicDecayB(); };
+  const reco::GenParticle * getGenHadp() const { if (!theGenEvt_) return nullptr; else return this->getGenEvent()->hadronicDecayQuark(); };
+  const reco::GenParticle * getGenHadq() const { if (!theGenEvt_) return nullptr; else return this->getGenEvent()->hadronicDecayQuarkBar(); };
+  const reco::GenParticle * getGenLept() const { if (!theGenEvt_) return nullptr; else return this->getGenEvent()->leptonicDecayTop(); };
+  const reco::GenParticle * getGenLepW() const { if (!theGenEvt_) return nullptr; else return this->getGenEvent()->leptonicDecayW(); };
+  const reco::GenParticle * getGenLepb() const { if (!theGenEvt_) return nullptr; else return this->getGenEvent()->leptonicDecayB(); };
+  const reco::GenParticle * getGenLepl() const { if (!theGenEvt_) return nullptr; else return this->getGenEvent()->singleLepton(); };
+  const reco::GenParticle * getGenLepn() const { if (!theGenEvt_) return nullptr; else return this->getGenEvent()->singleNeutrino(); };
 
   //-------------------------------------------
   // get (un-)/calibrated reco objects
@@ -103,14 +103,14 @@ class TtSemiEvtSolution {
   //-------------------------------------------  
   reco::Particle getFitHadt() const;
   reco::Particle getFitHadW() const;
-  pat::Particle getFitHadb() const { return (fitHadb_.size()>0 ? fitHadb_.front() : pat::Particle()); };
-  pat::Particle getFitHadp() const { return (fitHadp_.size()>0 ? fitHadp_.front() : pat::Particle()); };
-  pat::Particle getFitHadq() const { return (fitHadq_.size()>0 ? fitHadq_.front() : pat::Particle()); };
+  pat::Particle getFitHadb() const { return (!fitHadb_.empty() ? fitHadb_.front() : pat::Particle()); };
+  pat::Particle getFitHadp() const { return (!fitHadp_.empty() ? fitHadp_.front() : pat::Particle()); };
+  pat::Particle getFitHadq() const { return (!fitHadq_.empty() ? fitHadq_.front() : pat::Particle()); };
   reco::Particle getFitLept() const;      
   reco::Particle getFitLepW() const;
-  pat::Particle getFitLepb() const { return (fitLepb_.size()>0 ? fitLepb_.front() : pat::Particle()); };
-  pat::Particle getFitLepl() const { return (fitLepl_.size()>0 ? fitLepl_.front() : pat::Particle()); }; 
-  pat::Particle getFitLepn() const { return (fitLepn_.size()>0 ? fitLepn_.front() : pat::Particle()); };    
+  pat::Particle getFitLepb() const { return (!fitLepb_.empty() ? fitLepb_.front() : pat::Particle()); };
+  pat::Particle getFitLepl() const { return (!fitLepl_.empty() ? fitLepl_.front() : pat::Particle()); }; 
+  pat::Particle getFitLepn() const { return (!fitLepn_.empty() ? fitLepn_.front() : pat::Particle()); };    
 
   //-------------------------------------------
   // get the selected semileptonic decay chain 

--- a/AnalysisDataFormats/TopObjects/interface/TtSemiLepEvtPartons.h
+++ b/AnalysisDataFormats/TopObjects/interface/TtSemiLepEvtPartons.h
@@ -29,10 +29,10 @@ class TtSemiLepEvtPartons : public TtEventPartons {
   /// default constructor
   TtSemiLepEvtPartons(const std::vector<std::string>& partonsToIgnore = std::vector<std::string>());
   /// default destructor
-  ~TtSemiLepEvtPartons(){};
+  ~TtSemiLepEvtPartons() override{};
 
   /// return vector of partons in the order defined in the corresponding enum
-  std::vector<const reco::Candidate*> vec(const TtGenEvent& genEvt);
+  std::vector<const reco::Candidate*> vec(const TtGenEvent& genEvt) override;
 
 };
 

--- a/AnalysisDataFormats/TopObjects/interface/TtSemiLeptonicEvent.h
+++ b/AnalysisDataFormats/TopObjects/interface/TtSemiLeptonicEvent.h
@@ -28,69 +28,69 @@ class TtSemiLeptonicEvent: public TtEvent {
   /// empty constructor
   TtSemiLeptonicEvent(){};
   /// default destructor
-  virtual ~TtSemiLeptonicEvent(){};
+  ~TtSemiLeptonicEvent() override{};
 
   /// get hadronic top of the given hypothesis
   const reco::Candidate* hadronicDecayTop(const std::string& key, const unsigned& cmb=0) const { return hadronicDecayTop(hypoClassKeyFromString(key), cmb); };
   /// get hadronic top of the given hypothesis
-  const reco::Candidate* hadronicDecayTop(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : eventHypo(key,cmb). daughter(TtSemiLepDaughter::HadTop); };
+  const reco::Candidate* hadronicDecayTop(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : eventHypo(key,cmb). daughter(TtSemiLepDaughter::HadTop); };
   /// get hadronic b of the given hypothesis
   const reco::Candidate* hadronicDecayB(const std::string& key, const unsigned& cmb=0) const { return hadronicDecayB(hypoClassKeyFromString(key), cmb); };
   /// get hadronic b of the given hypothesis
-  const reco::Candidate* hadronicDecayB(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : hadronicDecayTop(key,cmb)->daughter(TtSemiLepDaughter::HadB); };
+  const reco::Candidate* hadronicDecayB(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : hadronicDecayTop(key,cmb)->daughter(TtSemiLepDaughter::HadB); };
   /// get hadronic W of the given hypothesis
   const reco::Candidate* hadronicDecayW(const std::string& key, const unsigned& cmb=0) const { return hadronicDecayW(hypoClassKeyFromString(key), cmb); };
   /// get hadronic W of the given hypothesis
-  const reco::Candidate* hadronicDecayW(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : hadronicDecayTop(key,cmb)->daughter(TtSemiLepDaughter::HadW); };
+  const reco::Candidate* hadronicDecayW(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : hadronicDecayTop(key,cmb)->daughter(TtSemiLepDaughter::HadW); };
   /// get hadronic light quark of the given hypothesis
   const reco::Candidate* hadronicDecayQuark(const std::string& key, const unsigned& cmb=0) const { return hadronicDecayQuark(hypoClassKeyFromString(key), cmb); };
   /// get hadronic light quark of the given hypothesis
-  const reco::Candidate* hadronicDecayQuark(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : hadronicDecayW(key,cmb)->daughter(TtSemiLepDaughter::HadP); };
+  const reco::Candidate* hadronicDecayQuark(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : hadronicDecayW(key,cmb)->daughter(TtSemiLepDaughter::HadP); };
   /// get hadronic light quark of the given hypothesis
   const reco::Candidate* hadronicDecayQuarkBar(const std::string& key, const unsigned& cmb=0) const { return hadronicDecayQuarkBar(hypoClassKeyFromString(key), cmb); };
   /// get hadronic light quark of the given hypothesis
-  const reco::Candidate* hadronicDecayQuarkBar(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : hadronicDecayW(key,cmb)->daughter(TtSemiLepDaughter::HadQ); };
+  const reco::Candidate* hadronicDecayQuarkBar(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : hadronicDecayW(key,cmb)->daughter(TtSemiLepDaughter::HadQ); };
   /// get leptonic top of the given hypothesis
   const reco::Candidate* leptonicDecayTop(const std::string& key, const unsigned& cmb=0) const { return leptonicDecayTop(hypoClassKeyFromString(key), cmb); };
   /// get leptonic top of the given hypothesis
-  const reco::Candidate* leptonicDecayTop(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : eventHypo(key,cmb). daughter(TtSemiLepDaughter::LepTop); };
+  const reco::Candidate* leptonicDecayTop(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : eventHypo(key,cmb). daughter(TtSemiLepDaughter::LepTop); };
   /// get leptonic b of the given hypothesis
   const reco::Candidate* leptonicDecayB(const std::string& key, const unsigned& cmb=0) const { return leptonicDecayB(hypoClassKeyFromString(key), cmb); };
   /// get leptonic b of the given hypothesis
-  const reco::Candidate* leptonicDecayB(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : leptonicDecayTop(key,cmb)->daughter(TtSemiLepDaughter::LepB); };
+  const reco::Candidate* leptonicDecayB(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : leptonicDecayTop(key,cmb)->daughter(TtSemiLepDaughter::LepB); };
   /// get leptonic W of the given hypothesis
   const reco::Candidate* leptonicDecayW(const std::string& key, const unsigned& cmb=0) const { return leptonicDecayW(hypoClassKeyFromString(key), cmb); };
   /// get leptonic W of the given hypothesis
-  const reco::Candidate* leptonicDecayW(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : leptonicDecayTop(key,cmb)->daughter(TtSemiLepDaughter::LepW); };
+  const reco::Candidate* leptonicDecayW(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : leptonicDecayTop(key,cmb)->daughter(TtSemiLepDaughter::LepW); };
   /// get leptonic light quark of the given hypothesis
   const reco::Candidate* singleNeutrino(const std::string& key, const unsigned& cmb=0) const { return singleNeutrino(hypoClassKeyFromString(key), cmb); };
   /// get leptonic light quark of the given hypothesis
-  const reco::Candidate* singleNeutrino(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : leptonicDecayW(key,cmb)->daughter(TtSemiLepDaughter::Nu); };
+  const reco::Candidate* singleNeutrino(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : leptonicDecayW(key,cmb)->daughter(TtSemiLepDaughter::Nu); };
   /// get leptonic light quark of the given hypothesis
   const reco::Candidate* singleLepton(const std::string& key, const unsigned& cmb=0) const { return singleLepton(hypoClassKeyFromString(key), cmb); };
   /// get leptonic light quark of the given hypothesis
-  const reco::Candidate* singleLepton(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? 0 : leptonicDecayW(key,cmb)->daughter(TtSemiLepDaughter::Lep); };
+  const reco::Candidate* singleLepton(const HypoClassKey& key, const unsigned& cmb=0) const { return !isHypoValid(key,cmb) ? nullptr : leptonicDecayW(key,cmb)->daughter(TtSemiLepDaughter::Lep); };
 
   /// get hadronic top of the TtGenEvent
-  const reco::GenParticle* hadronicDecayTop() const { return (!genEvt_ ? 0 : this->genEvent()->hadronicDecayTop()); };
+  const reco::GenParticle* hadronicDecayTop() const { return (!genEvt_ ? nullptr : this->genEvent()->hadronicDecayTop()); };
   /// get hadronic b of the TtGenEvent
-  const reco::GenParticle* hadronicDecayB() const { return (!genEvt_ ? 0 : this->genEvent()->hadronicDecayB()); };
+  const reco::GenParticle* hadronicDecayB() const { return (!genEvt_ ? nullptr : this->genEvent()->hadronicDecayB()); };
   /// get hadronic W of the TtGenEvent
-  const reco::GenParticle* hadronicDecayW() const { return (!genEvt_ ? 0 : this->genEvent()->hadronicDecayW()); };
+  const reco::GenParticle* hadronicDecayW() const { return (!genEvt_ ? nullptr : this->genEvent()->hadronicDecayW()); };
   /// get hadronic light quark of the TtGenEvent
-  const reco::GenParticle* hadronicDecayQuark() const { return (!genEvt_ ? 0 : this->genEvent()->hadronicDecayQuark()); };
+  const reco::GenParticle* hadronicDecayQuark() const { return (!genEvt_ ? nullptr : this->genEvent()->hadronicDecayQuark()); };
   /// get hadronic light quark of the TtGenEvent
-  const reco::GenParticle* hadronicDecayQuarkBar() const { return (!genEvt_ ? 0 : this->genEvent()->hadronicDecayQuarkBar()); };
+  const reco::GenParticle* hadronicDecayQuarkBar() const { return (!genEvt_ ? nullptr : this->genEvent()->hadronicDecayQuarkBar()); };
   /// get leptonic top of the TtGenEvent
-  const reco::GenParticle* leptonicDecayTop() const { return (!genEvt_ ? 0 : this->genEvent()->leptonicDecayTop()); };
+  const reco::GenParticle* leptonicDecayTop() const { return (!genEvt_ ? nullptr : this->genEvent()->leptonicDecayTop()); };
   /// get leptonic b of the TtGenEvent
-  const reco::GenParticle* leptonicDecayB() const { return (!genEvt_ ? 0 : this->genEvent()->leptonicDecayB()); };
+  const reco::GenParticle* leptonicDecayB() const { return (!genEvt_ ? nullptr : this->genEvent()->leptonicDecayB()); };
   /// get leptonic W of the TtGenEvent
-  const reco::GenParticle* leptonicDecayW() const { return (!genEvt_ ? 0 : this->genEvent()->leptonicDecayW()); };
+  const reco::GenParticle* leptonicDecayW() const { return (!genEvt_ ? nullptr : this->genEvent()->leptonicDecayW()); };
   /// get lepton top of the TtGenEvent
-  const reco::GenParticle* singleLepton() const { return (!genEvt_ ? 0 : this->genEvent()->singleLepton());   };
+  const reco::GenParticle* singleLepton() const { return (!genEvt_ ? nullptr : this->genEvent()->singleLepton());   };
   /// get neutrino of the TtGenEvent
-  const reco::GenParticle* singleNeutrino() const { return (!genEvt_ ? 0 : this->genEvent()->singleNeutrino()); };
+  const reco::GenParticle* singleNeutrino() const { return (!genEvt_ ? nullptr : this->genEvent()->singleNeutrino()); };
 
   /// print full content of the structure as formated 
   /// LogInfo to the MessageLogger output for debugging

--- a/AnalysisDataFormats/TopObjects/src/StEvtSolution.cc
+++ b/AnalysisDataFormats/TopObjects/src/StEvtSolution.cc
@@ -84,7 +84,7 @@ reco::Particle StEvtSolution::getLept() const
 // FIXME: provide defaults if the genevent is invalid
 const reco::GenParticle * StEvtSolution::getGenBottom() const 
 { 
-  if(!theGenEvt_) return 0; 
+  if(!theGenEvt_) return nullptr; 
   else return theGenEvt_->decayB();
 }
 
@@ -97,25 +97,25 @@ const reco::GenParticle * StEvtSolution::getGenBottom() const
 
 const reco::GenParticle * StEvtSolution::getGenLepton() const 
 { 
-  if(!theGenEvt_) return 0; 
+  if(!theGenEvt_) return nullptr; 
   else return theGenEvt_->singleLepton(); 
 }
 
 const reco::GenParticle * StEvtSolution::getGenNeutrino() const 
 { 
-  if(!theGenEvt_) return 0; 
+  if(!theGenEvt_) return nullptr; 
   else return theGenEvt_->singleNeutrino(); 
 }
 
 const reco::GenParticle * StEvtSolution::getGenLepW() const 
 { 
-  if (!theGenEvt_) return 0; 
+  if (!theGenEvt_) return nullptr; 
   else return theGenEvt_->singleW(); 
 }
 
 const reco::GenParticle * StEvtSolution::getGenLept() const 
 { 
-  if (!theGenEvt_) return 0; 
+  if (!theGenEvt_) return nullptr; 
   else return theGenEvt_->singleTop(); 
 }
 

--- a/AnalysisDataFormats/TopObjects/src/StGenEvent.cc
+++ b/AnalysisDataFormats/TopObjects/src/StGenEvent.cc
@@ -23,7 +23,7 @@ StGenEvent::~StGenEvent()
 const reco::GenParticle* 
 StGenEvent::decayB() const 
 {
-  const reco::GenParticle* cand=0;
+  const reco::GenParticle* cand=nullptr;
   if (singleLepton()) {
     const reco::GenParticleCollection & partsColl = *parts_;
     const reco::GenParticle & singleLep = *singleLepton();
@@ -41,7 +41,7 @@ StGenEvent::decayB() const
 const reco::GenParticle* 
 StGenEvent::associatedB() const 
 {
-  const reco::GenParticle* cand=0;
+  const reco::GenParticle* cand=nullptr;
   if (singleLepton()) {
     const reco::GenParticleCollection & partsColl = *parts_;
     const reco::GenParticle & singleLep = *singleLepton();
@@ -59,7 +59,7 @@ StGenEvent::associatedB() const
 const reco::GenParticle* 
 StGenEvent::singleLepton() const 
 {
-  const reco::GenParticle* cand = 0;
+  const reco::GenParticle* cand = nullptr;
   const reco::GenParticleCollection& partsColl = *parts_;
   for (unsigned int i = 0; i < partsColl.size(); ++i) {
     if (reco::isLepton(partsColl[i]) && partsColl[i].mother() &&
@@ -73,7 +73,7 @@ StGenEvent::singleLepton() const
 const reco::GenParticle* 
 StGenEvent::singleNeutrino() const 
 {
-  const reco::GenParticle* cand=0;
+  const reco::GenParticle* cand=nullptr;
   const reco::GenParticleCollection & partsColl = *parts_;
   for (unsigned int i = 0; i < partsColl.size(); ++i) {
     if (reco::isNeutrino(partsColl[i]) && partsColl[i].mother() &&
@@ -87,7 +87,7 @@ StGenEvent::singleNeutrino() const
 const reco::GenParticle* 
 StGenEvent::singleW() const 
 {
-  const reco::GenParticle* cand=0;
+  const reco::GenParticle* cand=nullptr;
   if (singleLepton()) {
     const reco::GenParticleCollection & partsColl = *parts_;
     const reco::GenParticle & singleLep = *singleLepton();
@@ -105,7 +105,7 @@ StGenEvent::singleW() const
 const reco::GenParticle* 
 StGenEvent::singleTop() const 
 {
-  const reco::GenParticle* cand=0;
+  const reco::GenParticle* cand=nullptr;
   if (singleLepton()) {
     const reco::GenParticleCollection & partsColl = *parts_;
     const reco::GenParticle & singleLep = *singleLepton();

--- a/AnalysisDataFormats/TopObjects/src/TopGenEvent.cc
+++ b/AnalysisDataFormats/TopObjects/src/TopGenEvent.cc
@@ -15,7 +15,7 @@ TopGenEvent::TopGenEvent(reco::GenParticleRefProd& decaySubset, reco::GenParticl
 const reco::GenParticle*
 TopGenEvent::candidate(int id, unsigned int parentId) const
 {
-  const reco::GenParticle* cand=0;
+  const reco::GenParticle* cand=nullptr;
   const reco::GenParticleCollection & partsColl = *parts_;
   for( unsigned int i = 0; i < partsColl.size(); ++i ) {
     if( partsColl[i].pdgId()==id ){
@@ -137,7 +137,7 @@ TopGenEvent::topSisters() const
     if( part->numberOfMothers()==0 && std::abs(part->pdgId())!= TopDecayID::tID){
       // choose top sister which do not have a 
       // mother and are whether top nor anti-top 
-      if( dynamic_cast<const reco::GenParticle*>( &(*part) ) == 0){
+      if( dynamic_cast<const reco::GenParticle*>( &(*part) ) == nullptr){
 	throw edm::Exception( edm::errors::InvalidReference, "Not a GenParticle" );
       }
       sisters.push_back( part->clone() );
@@ -149,13 +149,13 @@ TopGenEvent::topSisters() const
 const reco::GenParticle*
 TopGenEvent::daughterQuarkOfTop(bool invertCharge) const
 {
-  const reco::GenParticle* cand=0;
+  const reco::GenParticle* cand=nullptr;
   for(reco::GenParticleCollection::const_iterator top = parts_->begin(); top<parts_->end(); ++top){
     if( top->pdgId()==(invertCharge?-TopDecayID::tID:TopDecayID::tID) ){
       for(reco::GenParticle::const_iterator quark = top->begin(); quark<top->end(); ++quark){
 	if( std::abs(quark->pdgId())<= TopDecayID::bID ){
 	  cand = dynamic_cast<const reco::GenParticle* > (&(*quark));
-	  if(cand == 0){
+	  if(cand == nullptr){
 	    throw edm::Exception( edm::errors::InvalidReference, "Not a GenParticle" );
 	  }
 	  break;
@@ -169,7 +169,7 @@ TopGenEvent::daughterQuarkOfTop(bool invertCharge) const
 const reco::GenParticle* 
 TopGenEvent::daughterQuarkOfWPlus(bool invertQuarkCharge, bool invertBosonCharge) const 
 {
-  const reco::GenParticle* cand=0;
+  const reco::GenParticle* cand=nullptr;
   const reco::GenParticleCollection & partsColl = *parts_;
   for (unsigned int i = 0; i < partsColl.size(); ++i) {
     if(partsColl[i].mother() && partsColl[i].mother()->pdgId()==(invertBosonCharge?-TopDecayID::WID:TopDecayID::WID) &&
@@ -186,7 +186,7 @@ TopGenEvent::lightQuarks(bool includingBQuarks) const
   std::vector<const reco::GenParticle*> lightQuarks;
   for (reco::GenParticleCollection::const_iterator part = parts_->begin(); part < parts_->end(); ++part) {
     if( (includingBQuarks && std::abs(part->pdgId())==TopDecayID::bID) || std::abs(part->pdgId())<TopDecayID::bID ) {
-      if( dynamic_cast<const reco::GenParticle*>( &(*part) ) == 0){
+      if( dynamic_cast<const reco::GenParticle*>( &(*part) ) == nullptr){
 	throw edm::Exception( edm::errors::InvalidReference, "Not a GenParticle" );
       }
       lightQuarks.push_back( part->clone() );
@@ -201,7 +201,7 @@ TopGenEvent::radiatedGluons(int pdgId) const{
   for (reco::GenParticleCollection::const_iterator part = parts_->begin(); part < parts_->end(); ++part) {
     if ( part->mother() && part->mother()->pdgId()==pdgId ){
       if(part->pdgId()==TopDecayID::glueID){
-	if( dynamic_cast<const reco::GenParticle*>( &(*part) ) == 0){
+	if( dynamic_cast<const reco::GenParticle*>( &(*part) ) == nullptr){
 	  throw edm::Exception( edm::errors::InvalidReference, "Not a GenParticle" );
 	}
       }

--- a/AnalysisDataFormats/TopObjects/src/TtGenEvent.cc
+++ b/AnalysisDataFormats/TopObjects/src/TtGenEvent.cc
@@ -69,7 +69,7 @@ TtGenEvent::fullLeptonicChannel() const
 const reco::GenParticle* 
 TtGenEvent::lepton(bool excludeTauLeptons) const 
 {
-  const reco::GenParticle* cand = 0;
+  const reco::GenParticle* cand = nullptr;
   const reco::GenParticleCollection& partsColl = *parts_;
   for (unsigned int i = 0; i < partsColl.size(); ++i) {
     if (reco::isLepton(partsColl[i]) && partsColl[i].mother() &&
@@ -85,7 +85,7 @@ TtGenEvent::lepton(bool excludeTauLeptons) const
 const reco::GenParticle* 
 TtGenEvent::leptonBar(bool excludeTauLeptons) const 
 {
-  const reco::GenParticle* cand = 0;
+  const reco::GenParticle* cand = nullptr;
   const reco::GenParticleCollection& partsColl = *parts_;
   for (unsigned int i = 0; i < partsColl.size(); ++i) {
     if (reco::isLepton(partsColl[i]) && partsColl[i].mother() &&
@@ -101,7 +101,7 @@ TtGenEvent::leptonBar(bool excludeTauLeptons) const
 const reco::GenParticle* 
 TtGenEvent::singleLepton(bool excludeTauLeptons) const 
 {
-  const reco::GenParticle* cand = 0;
+  const reco::GenParticle* cand = nullptr;
   if( isSemiLeptonic(excludeTauLeptons) ){
     const reco::GenParticleCollection& partsColl = *parts_;
     for (unsigned int i = 0; i < partsColl.size(); ++i) {
@@ -117,7 +117,7 @@ TtGenEvent::singleLepton(bool excludeTauLeptons) const
 const reco::GenParticle* 
 TtGenEvent::neutrino(bool excludeTauLeptons) const 
 {
-  const reco::GenParticle* cand=0;
+  const reco::GenParticle* cand=nullptr;
   const reco::GenParticleCollection & partsColl = *parts_;
   for (unsigned int i = 0; i < partsColl.size(); ++i) {
     if (reco::isNeutrino(partsColl[i]) && partsColl[i].mother() &&
@@ -133,7 +133,7 @@ TtGenEvent::neutrino(bool excludeTauLeptons) const
 const reco::GenParticle* 
 TtGenEvent::neutrinoBar(bool excludeTauLeptons) const 
 {
-  const reco::GenParticle* cand=0;
+  const reco::GenParticle* cand=nullptr;
   const reco::GenParticleCollection & partsColl = *parts_;
   for (unsigned int i = 0; i < partsColl.size(); ++i) {
     if (reco::isNeutrino(partsColl[i]) && partsColl[i].mother() &&
@@ -149,7 +149,7 @@ TtGenEvent::neutrinoBar(bool excludeTauLeptons) const
 const reco::GenParticle* 
 TtGenEvent::singleNeutrino(bool excludeTauLeptons) const 
 {
-  const reco::GenParticle* cand=0;
+  const reco::GenParticle* cand=nullptr;
   if( isSemiLeptonic(excludeTauLeptons) ) {
     const reco::GenParticleCollection & partsColl = *parts_;
     for (unsigned int i = 0; i < partsColl.size(); ++i) {
@@ -165,7 +165,7 @@ TtGenEvent::singleNeutrino(bool excludeTauLeptons) const
 const reco::GenParticle* 
 TtGenEvent::hadronicDecayQuark(bool invertFlavor) const 
 {
-  const reco::GenParticle* cand=0;
+  const reco::GenParticle* cand=nullptr;
   // catch W boson and check its daughters for a quark; 
   // make sure the decay is semi-leptonic first; this 
   // only makes sense if taus are not excluded from the 
@@ -179,7 +179,7 @@ TtGenEvent::hadronicDecayQuark(bool invertFlavor) const
 	  if( std::abs(wd->pdgId())<TopDecayID::tID ){
 	    if( invertFlavor?reco::flavour(*wd)<0:reco::flavour(*wd)>0 ){
 	      cand = dynamic_cast<const reco::GenParticle* > (&(*wd));
-	      if(cand == 0){
+	      if(cand == nullptr){
 		throw edm::Exception( edm::errors::InvalidReference, "Not a GenParticle" );
 	      }
 	      break;
@@ -195,7 +195,7 @@ TtGenEvent::hadronicDecayQuark(bool invertFlavor) const
 const reco::GenParticle* 
 TtGenEvent::hadronicDecayB(bool excludeTauLeptons) const 
 {
-  const reco::GenParticle* cand=0;
+  const reco::GenParticle* cand=nullptr;
   if( singleLepton(excludeTauLeptons) ){
     const reco::GenParticleCollection& partsColl = *parts_;
     const reco::GenParticle& singleLep = *singleLepton(excludeTauLeptons);
@@ -212,7 +212,7 @@ TtGenEvent::hadronicDecayB(bool excludeTauLeptons) const
 const reco::GenParticle* 
 TtGenEvent::hadronicDecayW(bool excludeTauLeptons) const 
 {
-  const reco::GenParticle* cand=0;
+  const reco::GenParticle* cand=nullptr;
   if( singleLepton(excludeTauLeptons) ){
     const reco::GenParticleCollection& partsColl = *parts_;
     const reco::GenParticle& singleLep = *singleLepton(excludeTauLeptons);
@@ -230,7 +230,7 @@ TtGenEvent::hadronicDecayW(bool excludeTauLeptons) const
 const reco::GenParticle* 
 TtGenEvent::hadronicDecayTop(bool excludeTauLeptons) const 
 {
-  const reco::GenParticle* cand=0;
+  const reco::GenParticle* cand=nullptr;
   if( singleLepton(excludeTauLeptons) ){
     const reco::GenParticleCollection& partsColl = *parts_;
     const reco::GenParticle& singleLep = *singleLepton(excludeTauLeptons);
@@ -247,7 +247,7 @@ TtGenEvent::hadronicDecayTop(bool excludeTauLeptons) const
 const reco::GenParticle* 
 TtGenEvent::leptonicDecayB(bool excludeTauLeptons) const 
 {
-  const reco::GenParticle* cand=0;
+  const reco::GenParticle* cand=nullptr;
   if( singleLepton(excludeTauLeptons) ){
     const reco::GenParticleCollection& partsColl = *parts_;
     const reco::GenParticle& singleLep = *singleLepton(excludeTauLeptons);
@@ -264,7 +264,7 @@ TtGenEvent::leptonicDecayB(bool excludeTauLeptons) const
 const reco::GenParticle* 
 TtGenEvent::leptonicDecayW(bool excludeTauLeptons) const 
 {
-  const reco::GenParticle* cand=0;
+  const reco::GenParticle* cand=nullptr;
   if( singleLepton(excludeTauLeptons) ){
     const reco::GenParticleCollection& partsColl = *parts_;
     const reco::GenParticle& singleLep = *singleLepton(excludeTauLeptons);
@@ -282,7 +282,7 @@ TtGenEvent::leptonicDecayW(bool excludeTauLeptons) const
 const reco::GenParticle* 
 TtGenEvent::leptonicDecayTop(bool excludeTauLeptons) const 
 {
-  const reco::GenParticle* cand=0;
+  const reco::GenParticle* cand=nullptr;
   if( singleLepton(excludeTauLeptons) ){
     const reco::GenParticleCollection& partsColl = *parts_;
     const reco::GenParticle& singleLep = *singleLepton(excludeTauLeptons);

--- a/AnalysisDataFormats/TrackInfo/src/RecoTracktoTP.cc
+++ b/AnalysisDataFormats/TrackInfo/src/RecoTracktoTP.cc
@@ -35,7 +35,7 @@ TrackingParticle RecoTracktoTP::TPMother(unsigned short i) const
                         break;
                     }
                 }
-                if(result.size()) break;
+                if(!result.empty()) break;
             }
         }
         else

--- a/AnalysisDataFormats/TrackInfo/src/TPtoRecoTrack.cc
+++ b/AnalysisDataFormats/TrackInfo/src/TPtoRecoTrack.cc
@@ -35,7 +35,7 @@ TrackingParticle TPtoRecoTrack::TPMother(unsigned short i) const
                         break;
                     }
                 }
-                if(result.size()) break;
+                if(!result.empty()) break;
             }
         }
         else

--- a/AnalysisDataFormats/TrackInfo/src/TrackInfo.cc
+++ b/AnalysisDataFormats/TrackInfo/src/TrackInfo.cc
@@ -21,7 +21,7 @@ const PTrajectoryStateOnDet * TrackInfo::stateOnDet(StateType statetype,Tracking
   TrajectoryInfo::const_iterator states=trajstates_.find(hit);
   if(states!=trajstates_.end())return states->second.stateOnDet(statetype);
   else edm::LogError("TrackInfo")<<"This rechit does not exist";
-  return 0;
+  return nullptr;
 }
 
 const LocalVector  TrackInfo::localTrackMomentum(StateType statetype,TrackingRecHitRef hit)const{ 
@@ -30,7 +30,7 @@ const LocalVector  TrackInfo::localTrackMomentum(StateType statetype,TrackingRec
   if(states!=trajstates_.end())
     {
       const PTrajectoryStateOnDet * state=states->second.stateOnDet(statetype);
-      if(state!=0) return state->parameters().momentum();
+      if(state!=nullptr) return state->parameters().momentum();
     }
   else edm::LogError("TrackInfo")<<"This rechit does not exist";
   return LocalVector(0,0,0); 
@@ -57,7 +57,7 @@ const LocalPoint  TrackInfo::localTrackPosition(StateType statetype,TrackingRecH
   if(states!=trajstates_.end())
     {
       const PTrajectoryStateOnDet * state=states->second.stateOnDet(statetype);
-      if(state!=0) return state->parameters().position();
+      if(state!=nullptr) return state->parameters().position();
     }
   else edm::LogError("TrackInfo")<<"This rechit does not exist";
   return LocalPoint(0,0,0);

--- a/AnalysisDataFormats/TrackInfo/src/TrackingRecHitInfo.cc
+++ b/AnalysisDataFormats/TrackInfo/src/TrackingRecHitInfo.cc
@@ -36,5 +36,5 @@ const PTrajectoryStateOnDet * TrackingRecHitInfo::stateOnDet(StateType statetype
   TrackingStates::const_iterator state=states_.find(statetype);
   if(state!=states_.end())return state->second.stateOnDet();
   else edm::LogError("TrackInfo")<<"This rechit does not exist";
-  return 0;
+  return nullptr;
 }


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this tomorrow to avoid conflicts to the extent possible]