### PR TITLE
clang checks for CalibMuon subsystem

### DIFF
--- a/CalibMuon/CSCCalibration/interface/CSCBadChambersConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCBadChambersConditions.h
@@ -20,7 +20,7 @@
 class CSCBadChambersConditions: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
  public:
   CSCBadChambersConditions(const edm::ParameterSet&);
-  ~CSCBadChambersConditions();
+  ~CSCBadChambersConditions() override;
   
 
   inline static CSCBadChambers *  prefillBadChambers();
@@ -31,7 +31,7 @@ class CSCBadChambersConditions: public edm::ESProducer, public edm::EventSetupRe
   
  private:
   // ----------member data ---------------------------
-  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
   CSCBadChambers *cndbBadChambers ;
 
 };

--- a/CalibMuon/CSCCalibration/interface/CSCBadStripsConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCBadStripsConditions.h
@@ -20,7 +20,7 @@
 class CSCBadStripsConditions: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
  public:
   CSCBadStripsConditions(const edm::ParameterSet&);
-  ~CSCBadStripsConditions();
+  ~CSCBadStripsConditions() override;
   
 
   inline static CSCBadStrips *  prefillBadStrips();
@@ -31,7 +31,7 @@ class CSCBadStripsConditions: public edm::ESProducer, public edm::EventSetupReco
   
  private:
   // ----------member data ---------------------------
-  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
   CSCBadStrips *cndbBadStrips ;
 
 };

--- a/CalibMuon/CSCCalibration/interface/CSCBadWiresConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCBadWiresConditions.h
@@ -20,7 +20,7 @@
 class CSCBadWiresConditions: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
  public:
   CSCBadWiresConditions(const edm::ParameterSet&);
-  ~CSCBadWiresConditions();
+  ~CSCBadWiresConditions() override;
   
 
   inline static CSCBadWires *  prefillBadWires();
@@ -31,7 +31,7 @@ class CSCBadWiresConditions: public edm::ESProducer, public edm::EventSetupRecor
   
  private:
   // ----------member data ---------------------------
-  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
   CSCBadWires *cndbBadWires ;
 
 };

--- a/CalibMuon/CSCCalibration/interface/CSCChannelMapperESProducer.h
+++ b/CalibMuon/CSCCalibration/interface/CSCChannelMapperESProducer.h
@@ -14,7 +14,7 @@ class CSCChannelMapperESProducer : public edm::ESProducer {
   typedef std::shared_ptr<CSCChannelMapperBase> BSP_TYPE;
 
   CSCChannelMapperESProducer(const edm::ParameterSet&);
-  ~CSCChannelMapperESProducer();
+  ~CSCChannelMapperESProducer() override;
 
   BSP_TYPE produce(const CSCChannelMapperRecord&);
 

--- a/CalibMuon/CSCCalibration/interface/CSCChannelMapperPostls1.h
+++ b/CalibMuon/CSCCalibration/interface/CSCChannelMapperPostls1.h
@@ -30,23 +30,23 @@ class CSCChannelMapperPostls1 : public CSCChannelMapperBase {
  public:
 
   CSCChannelMapperPostls1() {}
-  ~CSCChannelMapperPostls1() {}
+  ~CSCChannelMapperPostls1() override {}
 
-  virtual std::string name() const {return "CSCChannelMapperPostls1";}
+  std::string name() const override {return "CSCChannelMapperPostls1";}
 
   /// Return raw strip channel number for input geometrical channel number
-  int rawStripChannel( const CSCDetId& id, int igeom ) const;
+  int rawStripChannel( const CSCDetId& id, int igeom ) const override;
 
   /// Return geometrical strip channel number for input raw channel number
-  int geomStripChannel( const CSCDetId& id, int iraw ) const ;
+  int geomStripChannel( const CSCDetId& id, int iraw ) const override ;
 
   /// Offline conversion of a strip (geometric labelling) back to channel
   /// (Postls1: 1-1 correspondence strip to channel)
-  int channelFromStrip( const CSCDetId& id, int strip ) const;
+  int channelFromStrip( const CSCDetId& id, int strip ) const override;
 
   /// Construct raw CSCDetId matching supplied offline CSCDetid
   /// (Postls1: leave ME1a detid alone)
-  CSCDetId rawCSCDetId( const CSCDetId& id ) const;
+  CSCDetId rawCSCDetId( const CSCDetId& id ) const override;
 
 };
 

--- a/CalibMuon/CSCCalibration/interface/CSCChannelMapperStartup.h
+++ b/CalibMuon/CSCCalibration/interface/CSCChannelMapperStartup.h
@@ -32,23 +32,23 @@ class CSCChannelMapperStartup : public CSCChannelMapperBase {
  public:
 
   CSCChannelMapperStartup() {}
-  ~CSCChannelMapperStartup() {}
+  ~CSCChannelMapperStartup() override {}
 
-  virtual std::string name() const {return "CSCChannelMapperStartup";}
+  std::string name() const override {return "CSCChannelMapperStartup";}
 
   /// Return raw strip channel number for input geometrical channel number
-  int rawStripChannel( const CSCDetId& id, int igeom ) const;
+  int rawStripChannel( const CSCDetId& id, int igeom ) const override;
 
   /// Return geometrical strip channel number for input raw channel number
-  int geomStripChannel( const CSCDetId& id, int iraw ) const ;
+  int geomStripChannel( const CSCDetId& id, int iraw ) const override ;
 
   /// Offline conversion of a strip (geometric labelling) back to channel
   /// (Startup: convert the 48 strips of ME1A to 16 ganged channels.)
-  int channelFromStrip( const CSCDetId& id, int strip ) const;
+  int channelFromStrip( const CSCDetId& id, int strip ) const override;
 
   /// Construct raw CSCDetId matching supplied offline CSCDetid
   /// (Startup:  return the ME11 CSCDetID when supplied with that for ME1A)
-  CSCDetId rawCSCDetId( const CSCDetId& id ) const;
+  CSCDetId rawCSCDetId( const CSCDetId& id ) const override;
 
 };
 

--- a/CalibMuon/CSCCalibration/interface/CSCChipSpeedCorrectionDBConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCChipSpeedCorrectionDBConditions.h
@@ -21,7 +21,7 @@
 class CSCChipSpeedCorrectionDBConditions: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
  public:
   CSCChipSpeedCorrectionDBConditions(const edm::ParameterSet&);
-  ~CSCChipSpeedCorrectionDBConditions();
+  ~CSCChipSpeedCorrectionDBConditions() override;
   
   inline static CSCDBChipSpeedCorrection * prefillDBChipSpeedCorrection(bool isForMC, std::string dataCorrFileName, float dataOffse);
 
@@ -31,7 +31,7 @@ class CSCChipSpeedCorrectionDBConditions: public edm::ESProducer, public edm::Ev
   
  private:
   // ----------member data ---------------------------
-  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
   CSCDBChipSpeedCorrection *cndbChipCorr ;
 
   //Flag for determining if this is for setting MC or data corrections

--- a/CalibMuon/CSCCalibration/interface/CSCCrosstalkConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCCrosstalkConditions.h
@@ -19,7 +19,7 @@
 class CSCCrosstalkConditions: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
  public:
   CSCCrosstalkConditions(const edm::ParameterSet&);
-  ~CSCCrosstalkConditions();
+  ~CSCCrosstalkConditions() override;
   
 
   static  CSCcrosstalk * prefillCrosstalk();
@@ -30,7 +30,7 @@ class CSCCrosstalkConditions: public edm::ESProducer, public edm::EventSetupReco
   
  private:
   // ----------member data ---------------------------
-  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
   CSCcrosstalk *cnCrosstalk ;
   
 };

--- a/CalibMuon/CSCCalibration/interface/CSCCrosstalkDBConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCCrosstalkDBConditions.h
@@ -20,7 +20,7 @@
 class CSCCrosstalkDBConditions: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
  public:
   CSCCrosstalkDBConditions(const edm::ParameterSet&);
-  ~CSCCrosstalkDBConditions();
+  ~CSCCrosstalkDBConditions() override;
   
 
   inline static CSCDBCrosstalk * prefillDBCrosstalk();
@@ -31,7 +31,7 @@ class CSCCrosstalkDBConditions: public edm::ESProducer, public edm::EventSetupRe
   
  private:
   // ----------member data ---------------------------
-  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
 
 
   CSCDBCrosstalk *cndbCrosstalk ;

--- a/CalibMuon/CSCCalibration/interface/CSCFakeCrosstalkConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakeCrosstalkConditions.h
@@ -19,7 +19,7 @@
 class CSCFakeCrosstalkConditions: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
  public:
   CSCFakeCrosstalkConditions(const edm::ParameterSet&);
-  ~CSCFakeCrosstalkConditions();
+  ~CSCFakeCrosstalkConditions() override;
   
   float mean,min,minchi;
   int seed;long int M;
@@ -32,7 +32,7 @@ class CSCFakeCrosstalkConditions: public edm::ESProducer, public edm::EventSetup
   
  private:
   // ----------member data ---------------------------
-  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
   CSCcrosstalk *cncrosstalk ;
   
 };

--- a/CalibMuon/CSCCalibration/interface/CSCFakeDBCrosstalk.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakeDBCrosstalk.h
@@ -20,7 +20,7 @@
 class CSCFakeDBCrosstalk: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
    public:
       CSCFakeDBCrosstalk(const edm::ParameterSet&);
-      ~CSCFakeDBCrosstalk();
+      ~CSCFakeDBCrosstalk() override;
 
       inline static CSCDBCrosstalk * prefillDBCrosstalk(); 
 
@@ -30,7 +30,7 @@ class CSCFakeDBCrosstalk: public edm::ESProducer, public edm::EventSetupRecordIn
 
    private:
       // ----------member data ---------------------------
-    void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+    void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
     Pointer cndbCrosstalk ;
 
 };

--- a/CalibMuon/CSCCalibration/interface/CSCFakeDBGains.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakeDBGains.h
@@ -20,7 +20,7 @@
 class CSCFakeDBGains: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
    public:
       CSCFakeDBGains(const edm::ParameterSet&);
-      ~CSCFakeDBGains();
+      ~CSCFakeDBGains() override;
 
       inline static CSCDBGains* prefillDBGains(); 
 
@@ -28,7 +28,7 @@ class CSCFakeDBGains: public edm::ESProducer, public edm::EventSetupRecordInterv
       Pointer produceDBGains(const CSCDBGainsRcd&);
 
    private:
-    void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+    void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
 
     // member data
     Pointer cndbGains ;

--- a/CalibMuon/CSCCalibration/interface/CSCFakeDBNoiseMatrix.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakeDBNoiseMatrix.h
@@ -20,7 +20,7 @@
 class CSCFakeDBNoiseMatrix: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
    public:
       CSCFakeDBNoiseMatrix(const edm::ParameterSet&);
-      ~CSCFakeDBNoiseMatrix();
+      ~CSCFakeDBNoiseMatrix() override;
 
       inline static CSCDBNoiseMatrix * prefillDBNoiseMatrix(); 
 
@@ -30,7 +30,7 @@ class CSCFakeDBNoiseMatrix: public edm::ESProducer, public edm::EventSetupRecord
 
    private:
       // ----------member data ---------------------------
-    void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+    void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
     Pointer cndbNoiseMatrix ;
 
 };

--- a/CalibMuon/CSCCalibration/interface/CSCFakeDBPedestals.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakeDBPedestals.h
@@ -20,7 +20,7 @@
 class CSCFakeDBPedestals: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
    public:
       CSCFakeDBPedestals(const edm::ParameterSet&);
-      ~CSCFakeDBPedestals();
+      ~CSCFakeDBPedestals() override;
       
        inline static CSCDBPedestals * prefillDBPedestals();
 
@@ -30,7 +30,7 @@ class CSCFakeDBPedestals: public edm::ESProducer, public edm::EventSetupRecordIn
 
    private:
       // ----------member data ---------------------------
-    void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+    void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
 
       Pointer cndbPedestals ;   
 };

--- a/CalibMuon/CSCCalibration/interface/CSCFakeGainsConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakeGainsConditions.h
@@ -20,7 +20,7 @@
 class CSCFakeGainsConditions: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
    public:
       CSCFakeGainsConditions(const edm::ParameterSet&);
-      ~CSCFakeGainsConditions();
+      ~CSCFakeGainsConditions() override;
 
       float mean,min,minchi;
       int seed;long int M;
@@ -33,7 +33,7 @@ class CSCFakeGainsConditions: public edm::ESProducer, public edm::EventSetupReco
 
    private:
       // ----------member data ---------------------------
-    void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+    void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
     CSCGains *cngains ;
 
 };

--- a/CalibMuon/CSCCalibration/interface/CSCFakeNoiseMatrixConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakeNoiseMatrixConditions.h
@@ -20,7 +20,7 @@
 class CSCFakeNoiseMatrixConditions: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
    public:
       CSCFakeNoiseMatrixConditions(const edm::ParameterSet&);
-      ~CSCFakeNoiseMatrixConditions();
+      ~CSCFakeNoiseMatrixConditions() override;
       
       void prefillNoiseMatrix();
       
@@ -28,7 +28,7 @@ class CSCFakeNoiseMatrixConditions: public edm::ESProducer, public edm::EventSet
       ReturnType produceNoiseMatrix(const CSCNoiseMatrixRcd&);
 
  private:
-      void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+      void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
       CSCNoiseMatrix *cnmatrix ;
       
 };

--- a/CalibMuon/CSCCalibration/interface/CSCFakePedestalsConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakePedestalsConditions.h
@@ -20,7 +20,7 @@
 class CSCFakePedestalsConditions: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
    public:
       CSCFakePedestalsConditions(const edm::ParameterSet&);
-      ~CSCFakePedestalsConditions();
+      ~CSCFakePedestalsConditions() override;
 
       float meanped,meanrms;
       int seed;long int M;
@@ -33,7 +33,7 @@ class CSCFakePedestalsConditions: public edm::ESProducer, public edm::EventSetup
 
    private:
       // ----------member data ---------------------------
-    void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+    void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
       CSCPedestals *cnpedestals ;   
 };
 

--- a/CalibMuon/CSCCalibration/interface/CSCGainsConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCGainsConditions.h
@@ -19,7 +19,7 @@
 class CSCGainsConditions: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
  public:
   CSCGainsConditions(const edm::ParameterSet&);
-  ~CSCGainsConditions();
+  ~CSCGainsConditions() override;
   
   static CSCGains * prefillGains();
 
@@ -29,7 +29,7 @@ class CSCGainsConditions: public edm::ESProducer, public edm::EventSetupRecordIn
   
  private:
   // ----------member data ---------------------------
-  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
   CSCGains *cnGains ;
 
 };

--- a/CalibMuon/CSCCalibration/interface/CSCGainsDBConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCGainsDBConditions.h
@@ -20,7 +20,7 @@
 class CSCGainsDBConditions: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
  public:
   CSCGainsDBConditions(const edm::ParameterSet&);
-  ~CSCGainsDBConditions();
+  ~CSCGainsDBConditions() override;
   
 
   inline static CSCDBGains *  prefillDBGains();
@@ -31,7 +31,7 @@ class CSCGainsDBConditions: public edm::ESProducer, public edm::EventSetupRecord
   
  private:
   // ----------member data ---------------------------
-  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
   CSCDBGains *cndbGains ;
 
 };

--- a/CalibMuon/CSCCalibration/interface/CSCGasGainCorrectionDBConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCGasGainCorrectionDBConditions.h
@@ -21,7 +21,7 @@
 class CSCGasGainCorrectionDBConditions: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
  public:
   CSCGasGainCorrectionDBConditions(const edm::ParameterSet&);
-  ~CSCGasGainCorrectionDBConditions();
+  ~CSCGasGainCorrectionDBConditions() override;
   
   inline static CSCDBGasGainCorrection * prefillDBGasGainCorrection(bool isForMC, std::string dataCorrFileName);
 
@@ -31,7 +31,7 @@ class CSCGasGainCorrectionDBConditions: public edm::ESProducer, public edm::Even
   
  private:
   // ----------member data ---------------------------
-  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
   CSCDBGasGainCorrection *cndbGasGainCorr ;
 
   //Flag for determining if this is for setting MC or data corrections

--- a/CalibMuon/CSCCalibration/interface/CSCIndexerESProducer.h
+++ b/CalibMuon/CSCCalibration/interface/CSCIndexerESProducer.h
@@ -14,7 +14,7 @@ class CSCIndexerESProducer : public edm::ESProducer {
   typedef std::shared_ptr<CSCIndexerBase> BSP_TYPE;
 
   CSCIndexerESProducer(const edm::ParameterSet&);
-  ~CSCIndexerESProducer();
+  ~CSCIndexerESProducer() override;
 
   BSP_TYPE produce(const CSCIndexerRecord&);
 

--- a/CalibMuon/CSCCalibration/interface/CSCIndexerPostls1.h
+++ b/CalibMuon/CSCCalibration/interface/CSCIndexerPostls1.h
@@ -39,16 +39,16 @@ class CSCIndexerPostls1 : public CSCIndexerBase
 {
 public:
 
-  ~CSCIndexerPostls1();
+  ~CSCIndexerPostls1() override;
 
-  std::string name() const { return "CSCIndexerPostls1"; }
+  std::string name() const override { return "CSCIndexerPostls1"; }
 
 
   /// \name maxIndexMethods
   //@{
-  LongIndexType maxStripChannelIndex() const { return 273024; }
-  IndexType maxChipIndex() const             { return 17064; }
-  IndexType maxGasGainIndex() const          { return 57240; }
+  LongIndexType maxStripChannelIndex() const override { return 273024; }
+  IndexType maxChipIndex() const override             { return 17064; }
+  IndexType maxGasGainIndex() const override          { return 57240; }
   //@}
 
 
@@ -60,7 +60,7 @@ public:
    * \warning: ME1a and ME1b are considered as two separate
    * 'online' rings for the upgrade
    */
-  IndexType onlineRingsInStation( IndexType is ) const
+  IndexType onlineRingsInStation( IndexType is ) const override
   {
     const IndexType nrings[5] = { 0, 4, 2, 2, 2 };
     return nrings[is];
@@ -72,7 +72,7 @@ public:
    *
    * Assume ME1a has 48 unganged readout channels.
    */
-  IndexType stripChannelsPerOfflineLayer( IndexType is, IndexType ir ) const
+  IndexType stripChannelsPerOfflineLayer( IndexType is, IndexType ir ) const override
   {
     const IndexType nSC[16] = { 64,80,64,48,  80,80,0,0,  80,80,0,0,  80,80,0,0 };
     return nSC[(is-1)*4 + ir - 1];
@@ -85,7 +85,7 @@ public:
    * Assume ME1a has 48 unganged readout channels.
    * Online chambers ME1a and ME1b are separate.
    */
-  IndexType stripChannelsPerOnlineLayer( IndexType is, IndexType ir ) const
+  IndexType stripChannelsPerOnlineLayer( IndexType is, IndexType ir ) const override
   {
     const IndexType nSC[16] = { 64,80,64,48,  80,80,0,0,  80,80,0,0,  80,80,0,0 };
     return nSC[(is-1)*4 + ir - 1];
@@ -99,7 +99,7 @@ public:
    * 'Online' ME11 for the upgrade is considered as split into 1a and 1b
    * chambers with 3 and 4 CFEBs respectively
    */
-  IndexType chipsPerOnlineLayer( IndexType is, IndexType ir ) const
+  IndexType chipsPerOnlineLayer( IndexType is, IndexType ir ) const override
   {
     const IndexType nCinL[16] = { 4,5,4,3,  5,5,0,0,  5,5,0,0,  5,5,0,0 };
     return nCinL[(is - 1)*4 + ir - 1];
@@ -121,7 +121,7 @@ public:
    * 80 indices wide ranges inherited from Startup (with the last 65-80 indices remaining unused),
    * while the ME1/1A unganged channels get their own 48 indices wide ranges.
    */
-  IndexType stripChannelsPerLayer( IndexType is, IndexType ir ) const
+  IndexType stripChannelsPerLayer( IndexType is, IndexType ir ) const override
   {
     const IndexType nSCinC[16] = { 80,80,64,48,  80,80,0,0,  80,80,0,0,  80,80,0,0 };
     return nSCinC[(is - 1)*4 + ir - 1];
@@ -134,7 +134,7 @@ public:
    *
    * WARNING: ME1a channels are  NOT  considered the last 16 of the 80 total in each layer of an ME11 chamber!
    */
-  LongIndexType stripChannelStart( IndexType ie, IndexType is, IndexType ir ) const
+  LongIndexType stripChannelStart( IndexType ie, IndexType is, IndexType ir ) const override
   {
     // These are in the ranges 1-217728 (CSCs 2008), 217729-252288 (ME42), and 252289-273024 (unganged ME1a)
     // There are 1-108884 channels per endcap (CSCs 2008), 17280 channels per endcap (ME42),
@@ -167,7 +167,7 @@ public:
    * - ME1a channels are considered to be unganged and have their own 3 chips (ME1b has 4 chips).
    * - ME1b keeps 5 chips for the indexing purposes, however indices for the chip #5 are ignored in the unganged case.
    */
-  IndexType chipsPerLayer( IndexType is, IndexType ir ) const
+  IndexType chipsPerLayer( IndexType is, IndexType ir ) const override
   {
     const IndexType nCinL[16] = { 5,5,4,3,  5,5,0,0,  5,5,0,0,  5,5,0,0 };
     return nCinL[(is - 1)*4 + ir - 1];
@@ -181,7 +181,7 @@ public:
    *
    * \warning: ME1a chips are the last 3 of the 7 chips total in each layer of an ME11 chamber,
    */
-  IndexType chipStart( IndexType ie, IndexType is, IndexType ir ) const
+  IndexType chipStart( IndexType ie, IndexType is, IndexType ir ) const override
   {
     // These are in the ranges 1-13608 (CSCs 2008) and 13609-15768 (ME42) and 15769-17064 (ME1a).
     // There are 1-6804 chips per endcap (CSCs 2008) and 1080 chips per endcap (ME42) and 648 chips per endcap (ME1a).
@@ -208,7 +208,7 @@ public:
    * \warning:  unganged ME1a has 3 own chips, which are currently appended to the end of the index range,
    *            ME1b still keeps 5 chips with the chip #5 index being unused.
    */
-  IndexType sectorStart( IndexType ie, IndexType is, IndexType ir ) const
+  IndexType sectorStart( IndexType ie, IndexType is, IndexType ir ) const override
   {
     // There are 36 chambers * 6 layers * 5 CFEB's * 1 HV segment = 1080 gas-gain sectors in ME1/1 (non-upgraded)
     // There are 36 chambers * 6 layers * 3 CFEB's * 1 HV segment = 648 gas-gain sectors in ME1/1a (upgraded)
@@ -237,9 +237,9 @@ public:
   /**
    *  Decode CSCDetId from various indexes and labels
    */
-  std::pair<CSCDetId, IndexType> detIdFromStripChannelIndex( LongIndexType ichi ) const;
-  std::pair<CSCDetId, IndexType> detIdFromChipIndex( IndexType ichi ) const;
-  CSCIndexerBase::GasGainIndexType detIdFromGasGainIndex( IndexType igg ) const;
+  std::pair<CSCDetId, IndexType> detIdFromStripChannelIndex( LongIndexType ichi ) const override;
+  std::pair<CSCDetId, IndexType> detIdFromChipIndex( IndexType ichi ) const override;
+  CSCIndexerBase::GasGainIndexType detIdFromGasGainIndex( IndexType igg ) const override;
 
   /**
    * Build index used internally in online CSC conditions databases (the 'Igor Index')
@@ -250,7 +250,7 @@ public:
    * WARNING: This is now ADAPTED for unganged ME1a channels
    *          (we expect that the online conditions DB will adopt it too).
    */
-  int dbIndex(const CSCDetId & id, int & channel) const;
+  int dbIndex(const CSCDetId & id, int & channel) const override;
 
 };
 

--- a/CalibMuon/CSCCalibration/interface/CSCIndexerStartup.h
+++ b/CalibMuon/CSCCalibration/interface/CSCIndexerStartup.h
@@ -36,15 +36,15 @@ class CSCIndexerStartup : public CSCIndexerBase {
 
 public:
 
-  ~CSCIndexerStartup();
+  ~CSCIndexerStartup() override;
 
-  std::string name() const {return "CSCIndexerStartup";}
+  std::string name() const override {return "CSCIndexerStartup";}
 
   /// \name maxIndexMethods
   //@{
-  LongIndexType maxStripChannelIndex() const { return 252288; }
-  IndexType maxChipIndex() const             { return 15768; }
-  IndexType maxGasGainIndex() const          { return 55944; }
+  LongIndexType maxStripChannelIndex() const override { return 252288; }
+  IndexType maxChipIndex() const override             { return 15768; }
+  IndexType maxGasGainIndex() const override          { return 55944; }
   //@}
 
 
@@ -56,7 +56,7 @@ public:
    * \warning: ME1a + ME1b are considered as single ME1/1
    * 'online' rings for the startup
    */
-  IndexType onlineRingsInStation( IndexType is ) const
+  IndexType onlineRingsInStation( IndexType is ) const override
   {
     const IndexType nrings[5] = { 0, 3, 2, 2, 2 };
     return nrings[is];
@@ -69,7 +69,7 @@ public:
    *
    * Assume ME1a has 16 ganged readout channels.
    */
-  IndexType stripChannelsPerOfflineLayer( IndexType is, IndexType ir ) const
+  IndexType stripChannelsPerOfflineLayer( IndexType is, IndexType ir ) const override
   {
     const IndexType nSC[16] = { 64,80,64,16,  80,80,0,0,  80,80,0,0,  80,80,0,0 };
     return nSC[(is-1)*4 + ir - 1];
@@ -82,7 +82,7 @@ public:
    *
    * Assume ME1a has 16 ganged readout channels. Online chamber has 64+16=80 channels.
    */
-  IndexType stripChannelsPerOnlineLayer( IndexType is, IndexType ir ) const
+  IndexType stripChannelsPerOnlineLayer( IndexType is, IndexType ir ) const override
   {
     const IndexType nSC[16] = { 80,80,64,80,  80,80,0,0,  80,80,0,0,  80,80,0,0 };
     return nSC[(is-1)*4 + ir - 1];
@@ -95,7 +95,7 @@ public:
    *
    * 'Online' ME11 for the startup is considered as a single chamber with 5 chips
    */
-  IndexType chipsPerOnlineLayer( IndexType is, IndexType ir ) const
+  IndexType chipsPerOnlineLayer( IndexType is, IndexType ir ) const override
   {
     const IndexType nCinL[16] = { 5,5,4,5,  5,5,0,0,  5,5,0,0,  5,5,0,0 };
     return nCinL[(is - 1)*4 + ir - 1];
@@ -117,7 +117,7 @@ public:
    * and 65-80 belonging to ME1a. So the ME1/a database indices are mapped to extend the ME1/b index ranges,
    * which is how the raw hardware channels numbering is implemented.
    */
-  IndexType stripChannelsPerLayer( IndexType is, IndexType ir ) const
+  IndexType stripChannelsPerLayer( IndexType is, IndexType ir ) const override
   {
     const IndexType nSCinC[16] = { 80,80,64,80,  80,80,0,0,  80,80,0,0,  80,80,0,0 };
     return nSCinC[(is - 1)*4 + ir - 1];
@@ -131,7 +131,7 @@ public:
    * WARNING: while ME1a channels are the last 16 of the 80 total in each layer of an ME11 chamber,
    * their start index here defaults to the start index of ME1a.
    */
-  LongIndexType stripChannelStart( IndexType ie, IndexType is, IndexType ir ) const
+  LongIndexType stripChannelStart( IndexType ie, IndexType is, IndexType ir ) const override
   {
     // These are in the ranges 1-217728 (CSCs 2008) and 217729-252288 (ME42).
     // There are 1-108884 channels per endcap (CSCs 2008) and 17280 channels per endcap (ME42).
@@ -159,7 +159,7 @@ public:
    *
    * Considers ME42 as standard 5 chip per layer chambers.
    */
-  IndexType chipsPerLayer( IndexType is, IndexType ir ) const
+  IndexType chipsPerLayer( IndexType is, IndexType ir ) const override
   {
     const IndexType nCinL[16] = { 5,5,4,5,  5,5,0,0,  5,5,0,0,  5,5,0,0 };
     return nCinL[(is - 1)*4 + ir - 1];
@@ -173,7 +173,7 @@ public:
    * \warning: while ME1a chip is the last 1 of the 5 chips total in each layer of an ME11 chamber,
    * here the ME1a input ir=4 defaults to the ME1b start index (ir=4 <=> ir=1).
    */
-  IndexType chipStart( IndexType ie, IndexType is, IndexType ir ) const
+  IndexType chipStart( IndexType ie, IndexType is, IndexType ir ) const override
   {
     // These are in the ranges 1-13608 (CSCs 2008) and 13609-15768 (ME42).
     // There are 1-6804 chips per endcap (CSCs 2008) and 1080 channels per endcap (ME42).
@@ -198,7 +198,7 @@ public:
    * \warning: ME1a chip is the last 1 of the 5 chips total in each layer of an ME11 chamber,
    *            and an input ir=4 in this case would give the same result as ir=1
    */
-  IndexType sectorStart( IndexType ie, IndexType is, IndexType ir ) const
+  IndexType sectorStart( IndexType ie, IndexType is, IndexType ir ) const override
   {
     // There are 36 chambers * 6 layers * 5 CFEB's * 1 HV segment = 1080 gas-gain sectors in ME1/1
     // There are 36*6*5*3 = 3240 gas-gain sectors in ME1/2
@@ -225,9 +225,9 @@ public:
   /**
    *  Decode CSCDetId from various indexes and labels
    */
-  std::pair<CSCDetId, IndexType> detIdFromStripChannelIndex( LongIndexType ichi ) const;
-  std::pair<CSCDetId, IndexType> detIdFromChipIndex( IndexType ichi ) const;
-  GasGainIndexType detIdFromGasGainIndex( IndexType igg ) const;
+  std::pair<CSCDetId, IndexType> detIdFromStripChannelIndex( LongIndexType ichi ) const override;
+  std::pair<CSCDetId, IndexType> detIdFromChipIndex( IndexType ichi ) const override;
+  GasGainIndexType detIdFromGasGainIndex( IndexType igg ) const override;
 
   /**
    * Build index used internally in online CSC conditions databases (the 'Igor Index')
@@ -236,7 +236,7 @@ public:
    * (ie=1-2, is=1-4, ir=1-4, ic=1-36, il=1-6) <br>
    * Channels 1-16 in ME1A (is=1, ir=4) are reset to channels 65-80 of ME11.
    */
-  int dbIndex(const CSCDetId & id, int & channel) const;
+  int dbIndex(const CSCDetId & id, int & channel) const override;
 };
 
 #endif

--- a/CalibMuon/CSCCalibration/interface/CSCL1TPParametersConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCL1TPParametersConditions.h
@@ -20,7 +20,7 @@
 class CSCL1TPParametersConditions: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
  public:
   CSCL1TPParametersConditions(const edm::ParameterSet&);
-  ~CSCL1TPParametersConditions();
+  ~CSCL1TPParametersConditions() override;
   
 
   inline static CSCL1TPParameters *  prefillCSCL1TPParameters();
@@ -31,7 +31,7 @@ class CSCL1TPParametersConditions: public edm::ESProducer, public edm::EventSetu
   
  private:
   // ----------member data ---------------------------
-  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
   CSCL1TPParameters *CSCl1TPParameters ;
 
 };

--- a/CalibMuon/CSCCalibration/interface/CSCNoiseMatrixConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCNoiseMatrixConditions.h
@@ -19,7 +19,7 @@
 class CSCNoiseMatrixConditions: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
  public:
   CSCNoiseMatrixConditions(const edm::ParameterSet&);
-  ~CSCNoiseMatrixConditions();
+  ~CSCNoiseMatrixConditions() override;
   
   static CSCNoiseMatrix * prefillNoiseMatrix();
   
@@ -30,7 +30,7 @@ class CSCNoiseMatrixConditions: public edm::ESProducer, public edm::EventSetupRe
   
  private:
   // ----------member data ---------------------------
-  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
   CSCNoiseMatrix *cnMatrix ;
 
 };

--- a/CalibMuon/CSCCalibration/interface/CSCNoiseMatrixDBConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCNoiseMatrixDBConditions.h
@@ -20,7 +20,7 @@
 class CSCNoiseMatrixDBConditions: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
  public:
   CSCNoiseMatrixDBConditions(const edm::ParameterSet&);
-  ~CSCNoiseMatrixDBConditions();
+  ~CSCNoiseMatrixDBConditions() override;
   
   inline static CSCDBNoiseMatrix * prefillDBNoiseMatrix();
 
@@ -30,7 +30,7 @@ class CSCNoiseMatrixDBConditions: public edm::ESProducer, public edm::EventSetup
   
  private:
   // ----------member data ---------------------------
-  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
   CSCDBNoiseMatrix *cndbMatrix ;
 
 };

--- a/CalibMuon/CSCCalibration/interface/CSCPedestalsDBConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCPedestalsDBConditions.h
@@ -20,7 +20,7 @@
 class CSCPedestalsDBConditions: public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
  public:
   CSCPedestalsDBConditions(const edm::ParameterSet&);
-  ~CSCPedestalsDBConditions();
+  ~CSCPedestalsDBConditions() override;
   
   inline static CSCDBPedestals * prefillDBPedestals();
 
@@ -30,7 +30,7 @@ class CSCPedestalsDBConditions: public edm::ESProducer, public edm::EventSetupRe
   
  private:
   // ----------member data ---------------------------
-  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & );
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
   CSCDBPedestals *cndbPedestals ;
 
 };

--- a/CalibMuon/CSCCalibration/src/CSCConditions.cc
+++ b/CalibMuon/CSCCalibration/src/CSCConditions.cc
@@ -38,7 +38,7 @@ CSCConditions::CSCConditions( const edm::ParameterSet& ps )
 : theGains(), theCrosstalk(), thePedestals(), theNoiseMatrix(),
   theBadStrips(), theBadWires(), theBadChambers(),
   theChipCorrections(), theChamberTimingCorrections(), theGasGainCorrections(),
-  indexer_(0), mapper_(0),
+  indexer_(nullptr), mapper_(nullptr),
   readBadChannels_(false), readBadChambers_(false),
   useTimingCorrections_(false), useGasGainCorrections_(false), 
   idOfBadChannelWords_(CSCDetId()), badStripWord_(0), badWireWord_(0), theAverageGain( -1.0 )
@@ -163,7 +163,7 @@ void CSCConditions::fillBadStripWord( const CSCDetId& id ){
     //    short f1 = theBadStrips->channels[j].flag1;
     //    short f2 = theBadStrips->channels[j].flag2;
     //    short f3 = theBadStrips->channels[j].flag3;
-        badStripWord_.set( chan-1, 1 ); // set bit 0-79 (111) in 80 (112)-bit bitset representing this layer
+        badStripWord_.set( chan-1, true ); // set bit 0-79 (111) in 80 (112)-bit bitset representing this layer
       } // j
     } // i
 
@@ -195,7 +195,7 @@ void CSCConditions::fillBadWireWord( const CSCDetId& id ){
     //    short f1 = theBadWires->channels[j].flag1;
     //    short f2 = theBadWires->channels[j].flag2;
     //    short f3 = theBadWires->channels[j].flag3;
-        badWireWord_.set( chan-1, 1 ); // set bit 0-111 in 112-bit bitset representing this layer
+        badWireWord_.set( chan-1, true ); // set bit 0-111 in 112-bit bitset representing this layer
       } // j
     } // i
 

--- a/CalibMuon/DTCalibration/interface/DTCalibMuonSelection.h
+++ b/CalibMuon/DTCalibration/interface/DTCalibMuonSelection.h
@@ -18,14 +18,14 @@ public:
 
   explicit DTCalibMuonSelection(const edm::ParameterSet&);
 
-  ~DTCalibMuonSelection();
+  ~DTCalibMuonSelection() override;
   
 private:
-  virtual void beginJob() ;
+  void beginJob() override ;
 
-  virtual bool filter(edm::Event&, const edm::EventSetup&);
+  bool filter(edm::Event&, const edm::EventSetup&) override;
 
-  virtual void endJob() ;
+  void endJob() override ;
   
   edm::EDGetTokenT<reco::MuonCollection> muonList;
 

--- a/CalibMuon/DTCalibration/plugins/DTCalibrationMap.cc
+++ b/CalibMuon/DTCalibration/plugins/DTCalibrationMap.cc
@@ -118,7 +118,7 @@ const DTCalibrationMap::CalibConsts* DTCalibrationMap::getConsts(DTWireId wireId
     cache = (*res);
     return &((*res).second);
   } else {
-    return 0;
+    return nullptr;
   }
 }
   
@@ -128,7 +128,7 @@ const DTCalibrationMap::CalibConsts* DTCalibrationMap::getConsts(DTWireId wireId
 // constants available for a particluar wire
 float DTCalibrationMap::getField(DTWireId wireId, int field) const {
   const CalibConsts* cals = getConsts(wireId);
-  if (cals == 0) {
+  if (cals == nullptr) {
     throw cms::Exception("NoCalibConsts") << "DTCalibrationMap:" << endl
 						<< "No parameters for wire: " << wireId << endl
 						<< "Check the " << calibConstFileName << " file!" << endl;

--- a/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.h
+++ b/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.h
@@ -34,7 +34,7 @@ public:
 
   DTFakeT0ESProducer(const edm::ParameterSet& pset);
 
-  virtual ~DTFakeT0ESProducer();
+  ~DTFakeT0ESProducer() override;
 
   DTT0* produce(const DTT0Rcd& iRecord);
 
@@ -43,7 +43,7 @@ private:
   void parseDDD(const DTT0Rcd& iRecord);
 
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&,
-		      edm::ValidityInterval & oValidity);
+		      edm::ValidityInterval & oValidity) override;
 
   std::map<DTLayerId,std::pair<unsigned int,unsigned int> > theLayerIdWiresMap;
 

--- a/CalibMuon/DTCalibration/plugins/DTMapGenerator.h
+++ b/CalibMuon/DTCalibration/plugins/DTMapGenerator.h
@@ -23,15 +23,15 @@ public:
   DTMapGenerator(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~DTMapGenerator();
+  ~DTMapGenerator() override;
 
   // Operations
 
-  virtual void beginJob(){}
+  void beginJob() override{}
 
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup){}
+  void analyze(const edm::Event& event, const edm::EventSetup& setup) override{}
 
-  virtual void endJob();
+  void endJob() override;
 
 protected:
 

--- a/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseCalibration.h
@@ -34,12 +34,12 @@ class DTNoiseCalibration: public edm::EDAnalyzer{
   /// Constructor
   DTNoiseCalibration(const edm::ParameterSet& ps);
   /// Destructor
-  virtual ~DTNoiseCalibration();
+  ~DTNoiseCalibration() override;
 
-  void beginJob();
-  void beginRun(const edm::Run& run, const edm::EventSetup& setup );
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
-  void endJob();
+  void beginJob() override;
+  void beginRun(const edm::Run& run, const edm::EventSetup& setup ) override;
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+  void endJob() override;
 
 private:
   std::string getChannelName(const DTWireId&) const;

--- a/CalibMuon/DTCalibration/plugins/DTNoiseComputation.h
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseComputation.h
@@ -40,17 +40,17 @@ class DTNoiseComputation: public edm::EDAnalyzer{
   DTNoiseComputation(const edm::ParameterSet& ps);
   
   /// Destructor
-  virtual ~DTNoiseComputation();
+  ~DTNoiseComputation() override;
 
   /// BeginJob
-  void beginJob() {}
+  void beginJob() override {}
 
-  void beginRun(const edm::Run&, const edm::EventSetup& setup);
+  void beginRun(const edm::Run&, const edm::EventSetup& setup) override;
 
-  void analyze(const edm::Event& event, const edm::EventSetup& setup) {}
+  void analyze(const edm::Event& event, const edm::EventSetup& setup) override {}
 
   /// Endjob
-  void endJob();
+  void endJob() override;
 
 
 protected:

--- a/CalibMuon/DTCalibration/plugins/DTT0FEBPathCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTT0FEBPathCorrection.h
@@ -28,10 +28,10 @@ public:
   DTT0FEBPathCorrection(const edm::ParameterSet&);
 
   // Destructor
-  virtual ~DTT0FEBPathCorrection();
+  ~DTT0FEBPathCorrection() override;
 
-  virtual void setES(const edm::EventSetup& setup);
-  virtual DTT0Data correction(const DTWireId&);
+  void setES(const edm::EventSetup& setup) override;
+  DTT0Data correction(const DTWireId&) override;
 
   float t0FEBPathCorrection(int wheel, int st, int sec, int sl, int l, int w);
 private:

--- a/CalibMuon/DTCalibration/plugins/DTTPAnalyzer.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTPAnalyzer.cc
@@ -20,7 +20,7 @@ class TFile;
 class DTTPAnalyzer : public edm::EDAnalyzer {
 public:
   DTTPAnalyzer( const edm::ParameterSet& );
-  virtual ~DTTPAnalyzer();
+  ~DTTPAnalyzer() override;
 
   //void beginJob();
   void beginRun( const edm::Run& , const edm::EventSetup& ) override;
@@ -68,7 +68,7 @@ private:
 DTTPAnalyzer::DTTPAnalyzer(const edm::ParameterSet& pset):
   subtractT0_(pset.getParameter<bool>("subtractT0")),
   digiLabel_(pset.getParameter<edm::InputTag>("digiLabel")),
-  tTrigSync_(0) {
+  tTrigSync_(nullptr) {
 
   std::string rootFileName = pset.getUntrackedParameter<std::string>("rootFileName");
   rootFile_ = new TFile(rootFileName.c_str(), "RECREATE");
@@ -124,7 +124,7 @@ void DTTPAnalyzer::analyze(const edm::Event & event, const edm::EventSetup& setu
        //FIXME: Reject digis not coming from TP
 
        if(subtractT0_) {
-          const DTLayer* layer = 0; //fake
+          const DTLayer* layer = nullptr; //fake
 	  const GlobalPoint glPt; //fake
 	  double offset = tTrigSync_->offset(layer, wireId, glPt);
           t0 -= offset;

--- a/CalibMuon/DTCalibration/plugins/DTTPDeadWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTTPDeadWriter.h
@@ -28,18 +28,18 @@ public:
   DTTPDeadWriter(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~DTTPDeadWriter();
+  ~DTTPDeadWriter() override;
 
   // Operations
 
   ///Read t0 map from event
-  virtual void beginRun(const edm::Run&, const edm::EventSetup& setup);
+  void beginRun(const edm::Run&, const edm::EventSetup& setup) override;
 
   /// Compute the ttrig by fiting the TB rising edge
-  virtual void analyze(const edm::Event & event, const edm::EventSetup& eventSetup);
+  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
 
   /// Write ttrig in the DB
-  virtual void endJob();
+  void endJob() override;
 
  
 protected:

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCalibration.h
@@ -35,15 +35,15 @@ public:
   DTTTrigCalibration(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~DTTTrigCalibration();
+  ~DTTTrigCalibration() override;
 
   // Operations
 
   /// Fill the time boxes
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup);
+  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
 
   /// Fit the time box rising edge and write the resulting ttrig to the DB
-  void endJob();
+  void endJob() override;
 
 
 protected:

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrection.h
@@ -26,14 +26,14 @@ public:
   DTTTrigCorrection(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~DTTTrigCorrection();
+  ~DTTTrigCorrection() override;
 
   // Operations
 
-  virtual void beginJob() {}
-  virtual void beginRun( const edm::Run& run, const edm::EventSetup& setup );
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup){}
-  virtual void endJob();
+  void beginJob() override {}
+  void beginRun( const edm::Run& run, const edm::EventSetup& setup ) override;
+  void analyze(const edm::Event& event, const edm::EventSetup& setup) override{}
+  void endJob() override;
 
 protected:
 

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.h
@@ -23,15 +23,15 @@ public:
   DTTTrigCorrectionFirst(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~DTTTrigCorrectionFirst();
+  ~DTTTrigCorrectionFirst() override;
 
   // Operations
 
-  virtual void beginJob() {}
-  virtual void beginRun( const edm::Run& run, const edm::EventSetup& setup );
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup){}
+  void beginJob() override {}
+  void beginRun( const edm::Run& run, const edm::EventSetup& setup ) override;
+  void analyze(const edm::Event& event, const edm::EventSetup& setup) override{}
 
-  virtual void endJob();
+  void endJob() override;
 
 protected:
 

--- a/CalibMuon/DTCalibration/plugins/DTTTrigFillWithAverage.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigFillWithAverage.h
@@ -26,10 +26,10 @@ public:
   DTTTrigFillWithAverage(const edm::ParameterSet&);
 
   // Destructor
-  virtual ~DTTTrigFillWithAverage();
+  ~DTTTrigFillWithAverage() override;
 
-  virtual void setES(const edm::EventSetup& setup);
-  virtual DTTTrigData correction(const DTSuperLayerId&);
+  void setES(const edm::EventSetup& setup) override;
+  DTTTrigData correction(const DTSuperLayerId&) override;
 
 private:
   void getAverage();

--- a/CalibMuon/DTCalibration/plugins/DTTTrigMatchRPhi.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigMatchRPhi.h
@@ -26,10 +26,10 @@ public:
   DTTTrigMatchRPhi(const edm::ParameterSet&);
 
   // Destructor
-  virtual ~DTTTrigMatchRPhi();
+  ~DTTTrigMatchRPhi() override;
 
-  virtual void setES(const edm::EventSetup& setup);
-  virtual DTTTrigData correction(const DTSuperLayerId&);
+  void setES(const edm::EventSetup& setup) override;
+  DTTTrigData correction(const DTSuperLayerId&) override;
 
 private:
   const DTTtrig *tTrigMap_;

--- a/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigOffsetCalibration.h
@@ -29,11 +29,11 @@ public:
   // Constructor
   DTTTrigOffsetCalibration(const edm::ParameterSet& pset);
   // Destructor
-  virtual ~DTTTrigOffsetCalibration();
+  ~DTTTrigOffsetCalibration() override;
 
-  void beginRun(const edm::Run& run, const edm::EventSetup& setup);
-  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup);
-  void endJob();
+  void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
+  void endJob() override;
   
 private:
   typedef std::map<DTChamberId, std::vector<TH1F*> > ChamberHistosMap;

--- a/CalibMuon/DTCalibration/plugins/DTTTrigResidualCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigResidualCorrection.h
@@ -31,10 +31,10 @@ public:
   DTTTrigResidualCorrection(const edm::ParameterSet&);
 
   // Destructor
-  virtual ~DTTTrigResidualCorrection();
+  ~DTTTrigResidualCorrection() override;
 
-  virtual void setES(const edm::EventSetup& setup);
-  virtual DTTTrigData correction(const DTSuperLayerId&);
+  void setES(const edm::EventSetup& setup) override;
+  DTTTrigData correction(const DTSuperLayerId&) override;
 
 private:
   const TH1F* getHisto(const DTSuperLayerId&);

--- a/CalibMuon/DTCalibration/plugins/DTTTrigT0SegCorrection.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigT0SegCorrection.h
@@ -29,10 +29,10 @@ public:
   DTTTrigT0SegCorrection(const edm::ParameterSet&);
 
   // Destructor
-  virtual ~DTTTrigT0SegCorrection();
+  ~DTTTrigT0SegCorrection() override;
 
-  virtual void setES(const edm::EventSetup& setup);
-  virtual DTTTrigData correction(const DTSuperLayerId&);
+  void setES(const edm::EventSetup& setup) override;
+  DTTTrigData correction(const DTSuperLayerId&) override;
 
 private:
   const TH1F* getHisto(const DTSuperLayerId&);

--- a/CalibMuon/DTCalibration/plugins/DTTTrigWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigWriter.h
@@ -30,15 +30,15 @@ public:
   DTTTrigWriter(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~DTTTrigWriter();
+  ~DTTTrigWriter() override;
 
   // Operations
 
   /// Compute the ttrig by fiting the TB rising edge
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup);
+  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
 
   /// Write ttrig in the DB
-  void endJob();
+  void endJob() override;
 
  
 protected:

--- a/CalibMuon/DTCalibration/plugins/DTVDriftCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftCalibration.cc
@@ -234,7 +234,7 @@ void DTVDriftCalibration::analyze(const Event & event, const EventSetup& eventSe
           DTWireId wireId(slId, 0, 0);
           theFile->cd();
           cellInfo* cell = theWireIdAndCellMap[wireId];
-          if (cell==0) {
+          if (cell==nullptr) {
             TString name = (((((TString) "TMax"+(long) slId.wheel()) +(long) slId.station())
                              +(long) slId.sector())+(long) slId.superLayer());
             cell = new cellInfo(name);
@@ -304,7 +304,7 @@ void DTVDriftCalibration::endJob() {
 	if(vDriftAndReso.front() == -1)
 	  continue;
 	const DTCalibrationMap::CalibConsts* oldConstants = calibValuesFile.getConsts(wireId);
-	if(oldConstants != 0) {
+	if(oldConstants != nullptr) {
 	  newConstants.push_back((*oldConstants)[0]);
 	  newConstants.push_back((*oldConstants)[1]);
 	  newConstants.push_back((*oldConstants)[2]);
@@ -409,7 +409,7 @@ void DTVDriftCalibration::cellInfo::add(const vector<const TMax*>& _tMaxes) {
   unsigned hSubGroup = 0;
   for (vector<const TMax*>::const_iterator it=tMaxes.begin(); it!=tMaxes.end();
        ++it) {
-    if(*it == 0) {
+    if(*it == nullptr) {
       continue;  
     }
     else { 

--- a/CalibMuon/DTCalibration/plugins/DTVDriftCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftCalibration.h
@@ -36,13 +36,13 @@ public:
   DTVDriftCalibration(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~DTVDriftCalibration();
+  ~DTVDriftCalibration() override;
 
   // Operations
 
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup);
+  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
 
-  void endJob();
+  void endJob() override;
   
 protected:
 

--- a/CalibMuon/DTCalibration/plugins/DTVDriftMeanTimer.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftMeanTimer.h
@@ -19,10 +19,10 @@ namespace dtCalibration {
 class DTVDriftMeanTimer: public DTVDriftBaseAlgo {
 public:
    DTVDriftMeanTimer(edm::ParameterSet const&);
-   virtual ~DTVDriftMeanTimer();
+   ~DTVDriftMeanTimer() override;
 
-   virtual void setES(const edm::EventSetup& setup);
-   virtual DTVDriftData compute(const DTSuperLayerId&);
+   void setES(const edm::EventSetup& setup) override;
+   DTVDriftData compute(const DTSuperLayerId&) override;
 private:
    TFile* rootFile_;
    DTMeanTimerFitter* fitter_;

--- a/CalibMuon/DTCalibration/plugins/DTVDriftSegment.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftSegment.h
@@ -23,10 +23,10 @@ namespace dtCalibration {
 class DTVDriftSegment: public DTVDriftBaseAlgo {
 public:
    DTVDriftSegment(edm::ParameterSet const&);
-   virtual ~DTVDriftSegment();
+   ~DTVDriftSegment() override;
 
-   virtual void setES(const edm::EventSetup& setup);
-   virtual DTVDriftData compute(const DTSuperLayerId&);
+   void setES(const edm::EventSetup& setup) override;
+   DTVDriftData compute(const DTSuperLayerId&) override;
 private:
    TH1F* getHisto(const DTSuperLayerId&);
    std::string getHistoName(const DTSuperLayerId&);

--- a/CalibMuon/DTCalibration/plugins/DTVDriftSegmentCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftSegmentCalibration.h
@@ -24,12 +24,12 @@ public:
   // Constructor
   DTVDriftSegmentCalibration(const edm::ParameterSet& pset);
   // Destructor
-  virtual ~DTVDriftSegmentCalibration();
+  ~DTVDriftSegmentCalibration() override;
 
-  void beginJob();
-  void beginRun(const edm::Run& run, const edm::EventSetup& setup);
-  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup);
-  void endJob();
+  void beginJob() override;
+  void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
+  void endJob() override;
   
 private:
   typedef std::map<DTChamberId, std::vector<TH1F*> > ChamberHistosMapTH1F;

--- a/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
@@ -24,12 +24,12 @@ namespace dtCalibration {
 class DTVDriftWriter : public edm::EDAnalyzer {
 public:
   DTVDriftWriter(const edm::ParameterSet& pset);
-  virtual ~DTVDriftWriter();
+  ~DTVDriftWriter() override;
 
   // Operations
-  virtual void beginRun(const edm::Run& run, const edm::EventSetup& setup);
-  virtual void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) {}
-  virtual void endJob();
+  void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
+  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override {}
+  void endJob() override;
  
 private:
   std::string granularity_; // enforced by SL

--- a/CalibMuon/DTCalibration/src/DTMeanTimerFitter.cc
+++ b/CalibMuon/DTCalibration/src/DTMeanTimerFitter.cc
@@ -34,7 +34,7 @@ vector<float> DTMeanTimerFitter::evaluateVDriftAndReso (const TString& N) {
   vector<float> vDriftAndReso;
 
   // Check that the histo for this cell exists
-  if(histos->hTmax123 != 0) {
+  if(histos->hTmax123 != nullptr) {
     vector<TH1F*> hTMax;  // histograms for <T_max> calculation
     vector <TH1F*> hT0;   // histograms for T0 evaluation
     hTMax.push_back(histos->hTmax123); 
@@ -210,7 +210,7 @@ TF1* DTMeanTimerFitter::fitTMax(TH1F* histo){
       } catch(std::exception){
 	edm::LogError("DTMeanTimerFitter") << "Exception when fitting TMax..histogram " << histo->GetName()
 	     << "   setting return function pointer to zero";   
-	return 0;
+	return nullptr;
       }	
       TF1 *f1 = histo->GetFunction("rGaus");
       return f1;

--- a/CalibMuon/DTCalibration/src/DTTMax.cc
+++ b/CalibMuon/DTCalibration/src/DTTMax.cc
@@ -42,8 +42,8 @@ DTTMax::InfoLayer::InfoLayer(const DTRecHit1D& rh_, const DTSuperLayer & isl, Gl
 
 DTTMax::DTTMax(const vector<DTRecHit1D>& hits, const DTSuperLayer & isl, GlobalVector dir, 
 	       GlobalPoint pos, DTTTrigBaseSync* sync):
-  theInfoLayers(4,(InfoLayer*)0), //FIXME
-  theTMaxes(4,(TMax*)0) 
+  theInfoLayers(4,(InfoLayer*)nullptr), //FIXME
+  theTMaxes(4,(TMax*)nullptr) 
 {
   // debug parameter for verbose output
   debug = "true";
@@ -55,7 +55,7 @@ DTTMax::DTTMax(const vector<DTRecHit1D>& hits, const DTSuperLayer & isl, GlobalV
     
     InfoLayer* layInfo = new InfoLayer((*hit), isl, dir, pos, sync);
     int ilay = layInfo->idWire.layer();
-    if (getInfoLayer(ilay)==0) {
+    if (getInfoLayer(ilay)==nullptr) {
       getInfoLayer(ilay) = layInfo;
     } else {
       // FIXME: in case there is > 1 hit/layer, the first is taken and the others are IGNORED.
@@ -70,7 +70,7 @@ DTTMax::DTTMax(const vector<DTRecHit1D>& hits, const DTSuperLayer & isl, GlobalV
   int nGoodHits=0;
   for(vector<InfoLayer*>::const_iterator ilay =  theInfoLayers.begin();
       ilay != theInfoLayers.end(); ++ilay) {
-    if ((*ilay) == 0 ) {
+    if ((*ilay) == nullptr ) {
       theSegType+= "X";
       continue;
     }

--- a/CalibMuon/DTCalibration/src/DTTimeBoxFitter.cc
+++ b/CalibMuon/DTCalibration/src/DTTimeBoxFitter.cc
@@ -18,7 +18,7 @@
 
 using namespace std;
 
-DTTimeBoxFitter::DTTimeBoxFitter(const TString& debugFileName) : hDebugFile(0),
+DTTimeBoxFitter::DTTimeBoxFitter(const TString& debugFileName) : hDebugFile(nullptr),
 								 theVerbosityLevel(0),
 								 theSigma(10.) {
   // Create a root file for debug output only if needed
@@ -30,7 +30,7 @@ DTTimeBoxFitter::DTTimeBoxFitter(const TString& debugFileName) : hDebugFile(0),
 
 
 DTTimeBoxFitter::~DTTimeBoxFitter() {
-  if(hDebugFile != 0) hDebugFile->Close();
+  if(hDebugFile != nullptr) hDebugFile->Close();
 }
 
 
@@ -161,7 +161,7 @@ void DTTimeBoxFitter::getFitSeeds(TH1F *hTBox, double& mean, double& sigma, doub
     nRebins++;
   }
 
-  if(hDebugFile != 0) hDebugFile->cd();
+  if(hDebugFile != nullptr) hDebugFile->cd();
   TString hLName = TString(hTBox->GetName())+"L";
   TH1F hLTB(hLName.Data(), "Logic Time Box", nBins, xMin, xMax);
   // Loop over all time box bins and discriminate them accordigly to the threshold
@@ -169,7 +169,7 @@ void DTTimeBoxFitter::getFitSeeds(TH1F *hTBox, double& mean, double& sigma, doub
     if(hTBox->GetBinContent(i) > threshold)
       hLTB.SetBinContent(i, 1);
   }
-  if(hDebugFile != 0) hLTB.Write();
+  if(hDebugFile != nullptr) hLTB.Write();
   
   // Look for the time box in the "logic histo" and save beginning and lenght of each plateau
   vector< pair<int, int> > startAndLenght;

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.h
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.h
@@ -57,28 +57,28 @@ public:
   DTTTrigSyncFromDB(const edm::ParameterSet& config);
 
   /// Destructor
-  virtual ~DTTTrigSyncFromDB();
+  ~DTTTrigSyncFromDB() override;
 
   // Operations
 
   /// Pass the Event Setup to the algo at each event
-  virtual void setES(const edm::EventSetup& setup);
+  void setES(const edm::EventSetup& setup) override;
 
 
   /// Time (ns) to be subtracted to the digi time,
   /// Parameters are the layer and the wireId to which the
   /// digi is referred and the estimation of
   /// the 3D hit position (globPos)
-  virtual double offset(const DTLayer* layer,
+  double offset(const DTLayer* layer,
 			const DTWireId& wireId,
 			const GlobalPoint& globPos,
 			double& tTrig,
 			double& wirePropCorr,
-			double& tofCorr);
+			double& tofCorr) override;
 
   /// Time (ns) to be subtracted to the digi time.
   /// It does not take into account TOF and signal propagation along the wire
-  double offset(const DTWireId& wireId);
+  double offset(const DTWireId& wireId) override;
 
 
   /// Time (ns) to be subtracted to the digi time for emulation purposes
@@ -86,9 +86,9 @@ public:
   /// It also returns the different contributions separately:
   ///     - tTrig is the offset (t_trig)
   ///     - t0cell is the t0 from pulses
-  virtual double emulatorOffset(const DTWireId& wireId,
+  double emulatorOffset(const DTWireId& wireId,
 				double &tTrig,
-				double &t0cell);
+				double &t0cell) override;
 
 
  private:

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncT0Only.h
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncT0Only.h
@@ -27,32 +27,32 @@ public:
   DTTTrigSyncT0Only(const edm::ParameterSet& config);
 
   /// Destructor
-  virtual ~DTTTrigSyncT0Only();
+  ~DTTTrigSyncT0Only() override;
 
   // Operations
 
   /// Pass the Event Setup to the algo at each event
-  virtual void setES(const edm::EventSetup& setup);
+  void setES(const edm::EventSetup& setup) override;
 
 
   /// Time (ns) to be subtracted to the digi time,
   /// Parameters are the layer and the wireId to which the
   /// digi is referred and the estimation of
   /// the 3D hit position (globPos)
-  virtual double offset(const DTLayer* layer,
+  double offset(const DTLayer* layer,
 			const DTWireId& wireId,
 			const GlobalPoint& globPos,
 			double& tTrig,
 			double& wirePropCorr,
-			double& tofCorr);
+			double& tofCorr) override;
 
-  virtual double offset(const DTWireId& wireId);
+  double offset(const DTWireId& wireId) override;
 
   /// Time (ns) to be subtracted to the digi time for emulation purposes
   /// Returns just 0 in this implementation of the plugin
-  virtual double emulatorOffset(const DTWireId& wireId,
+  double emulatorOffset(const DTWireId& wireId,
 				double &tTrig,
-				double &t0cell);
+				double &t0cell) override;
 
 
  private:

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncTOFCorr.h
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncTOFCorr.h
@@ -53,12 +53,12 @@ public:
   DTTTrigSyncTOFCorr(const edm::ParameterSet& config);
 
   /// Destructor
-  virtual ~DTTTrigSyncTOFCorr();
+  ~DTTTrigSyncTOFCorr() override;
 
   // Operations
 
   /// Pass the Event Setup to the algo at each event
-  virtual void setES(const edm::EventSetup& setup) {}
+  void setES(const edm::EventSetup& setup) override {}
 
 
   /// Time (ns) to be subtracted to the digi time,
@@ -69,23 +69,23 @@ public:
   ///     - tTrig is the offset (t_trig)
   ///     - wirePropCorr is the delay for signal propagation along the wire
   ///     - tofCorr is the correction due to the particle TOF 
-  virtual double offset(const DTLayer* layer,
+  double offset(const DTLayer* layer,
 			const DTWireId& wireId,
 			const GlobalPoint& globPos,
 			double& tTrig,
 			double& wirePropCorr,
-			double& tofCorr);
+			double& tofCorr) override;
 
-  virtual double offset(const DTWireId& wireId);
+  double offset(const DTWireId& wireId) override;
 
   /// Time (ns) to be subtracted to the digi time for emulation purposes
   /// It does not take into account TOF and signal propagation along the wire
   /// It also returns the different contributions separately:
   ///     - tTrig is the offset (t_trig)
   ///     - t0cell is the t0 from pulses (always 0 in this case)
-  virtual double emulatorOffset(const DTWireId& wireId,
+  double emulatorOffset(const DTWireId& wireId,
 				double &tTrig,
-				double &t0cell);
+				double &t0cell) override;
 
  private:
   // The fixed t_trig to be subtracted to digi time (ns)

--- a/CalibMuon/RPCCalibration/interface/RPCCalibSetUp.h
+++ b/CalibMuon/RPCCalibration/interface/RPCCalibSetUp.h
@@ -13,7 +13,7 @@
 #include <iostream>
 #include<cstring>
 #include<string>
-#include<stdlib.h>
+#include<cstdlib>
 #include <utility>
 
 class RPCDigitizer;

--- a/CalibMuon/RPCCalibration/interface/RPCFakeCalibration.h
+++ b/CalibMuon/RPCCalibration/interface/RPCFakeCalibration.h
@@ -24,13 +24,13 @@ class RPCFakeCalibration : public RPCPerformanceESSource {
  public:
 
   RPCFakeCalibration( const edm::ParameterSet& );
-  virtual ~RPCFakeCalibration() {;}
+  ~RPCFakeCalibration() override {;}
   
      
 private:
   
 
-  RPCStripNoises* makeNoise();
+  RPCStripNoises* makeNoise() override;
 
   RPCClusterSize* makeCls();
 

--- a/CalibMuon/RPCCalibration/interface/RPCPerformanceESSource.h
+++ b/CalibMuon/RPCCalibration/interface/RPCPerformanceESSource.h
@@ -21,15 +21,15 @@ class RPCPerformanceESSource : public edm::ESProducer, public edm::EventSetupRec
  public:
 
   RPCPerformanceESSource( const edm::ParameterSet& );
-  virtual ~RPCPerformanceESSource() {;}
+  ~RPCPerformanceESSource() override {;}
   
   std::unique_ptr<RPCStripNoises> produce( const RPCStripNoisesRcd& );
   
   // protected:
 
-  virtual void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
 			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& );
+			       edm::ValidityInterval& ) override;
   
   // private:
   

--- a/CalibMuon/RPCCalibration/src/RPCCalibSetUp.cc
+++ b/CalibMuon/RPCCalibration/src/RPCCalibSetUp.cc
@@ -12,14 +12,14 @@
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 
 #include <cmath>
-#include <math.h>
+#include <cmath>
 #include <fstream>
 #include <sstream>
 #include <iostream>
 #include<cstring>
 #include<string>
 #include<vector>
-#include<stdlib.h>
+#include<cstdlib>
 #include <utility>
 #include <map>
 

--- a/CalibMuon/RPCCalibration/src/RPCFakeCalibration.cc
+++ b/CalibMuon/RPCCalibration/src/RPCFakeCalibration.cc
@@ -17,7 +17,7 @@
 #include "CondFormats/DataRecord/interface/RPCStripNoisesRcd.h"
 
 #include <cmath>
-#include <math.h>
+#include <cmath>
 #include <iostream>
 #include <memory>
 #include <fstream>


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this tomorrow to avoid conflicts to the extent possible]