### PR TITLE
clang-tidy checks for CalibTracker subsystem

### DIFF
--- a/CalibTracker/SiPixelConnectivity/interface/PixelToFEDAssociate.h
+++ b/CalibTracker/SiPixelConnectivity/interface/PixelToFEDAssociate.h
@@ -29,7 +29,7 @@ public:
 
   /// LNK id for module
   virtual const CablingRocId * operator()(const DetectorRocId & roc) const {
-    return 0;
+    return nullptr;
   }
 };
 #endif 

--- a/CalibTracker/SiPixelConnectivity/interface/PixelToFEDAssociateFromAscii.h
+++ b/CalibTracker/SiPixelConnectivity/interface/PixelToFEDAssociateFromAscii.h
@@ -24,10 +24,10 @@ public:
   PixelToFEDAssociateFromAscii(const std::string & fileName);
 
   /// FED id for module
-  virtual int operator()(const PixelModuleName &) const override;
+  int operator()(const PixelModuleName &) const override;
 
   /// version
-  virtual std::string version() const override;
+  std::string version() const override;
 
 
   /// FED id to which barrel modul (identified by name) should be assigned 

--- a/CalibTracker/SiPixelConnectivity/interface/PixelToLNKAssociateFromAscii.h
+++ b/CalibTracker/SiPixelConnectivity/interface/PixelToLNKAssociateFromAscii.h
@@ -25,10 +25,10 @@ public:
 
   PixelToLNKAssociateFromAscii(const std::string & fileName, const bool phase1=false);
 
-  virtual const CablingRocId * operator()(const DetectorRocId& roc) const;
+  const CablingRocId * operator()(const DetectorRocId& roc) const override;
 
   /// version
-  virtual std::string version() const;
+  std::string version() const override;
 
 private:
   typedef TRange<int> Range; 

--- a/CalibTracker/SiPixelConnectivity/plugins/PixelToFEDAssociateFromAsciiESProducer.h
+++ b/CalibTracker/SiPixelConnectivity/plugins/PixelToFEDAssociateFromAsciiESProducer.h
@@ -11,7 +11,7 @@
 class PixelToFEDAssociateFromAsciiESProducer : public edm::ESProducer {
 public:
   PixelToFEDAssociateFromAsciiESProducer(const edm::ParameterSet & p);
-  virtual ~PixelToFEDAssociateFromAsciiESProducer();
+  ~PixelToFEDAssociateFromAsciiESProducer() override;
   std::shared_ptr<PixelToFEDAssociate> produce(const TrackerDigiGeometryRecord&);
 private:
   std::shared_ptr<PixelToFEDAssociate> theAssociator;

--- a/CalibTracker/SiPixelConnectivity/plugins/PixelToLNKAssociateFromAsciiESProducer.h
+++ b/CalibTracker/SiPixelConnectivity/plugins/PixelToLNKAssociateFromAsciiESProducer.h
@@ -11,7 +11,7 @@
 class PixelToLNKAssociateFromAsciiESProducer : public edm::ESProducer {
 public:
   PixelToLNKAssociateFromAsciiESProducer(const edm::ParameterSet & p);
-  virtual ~PixelToLNKAssociateFromAsciiESProducer();
+  ~PixelToLNKAssociateFromAsciiESProducer() override;
   std::shared_ptr<PixelToFEDAssociate> produce(const TrackerDigiGeometryRecord&);
 private:
   std::shared_ptr<PixelToFEDAssociate> theAssociator;

--- a/CalibTracker/SiPixelConnectivity/src/PixelToFEDAssociateFromAscii.cc
+++ b/CalibTracker/SiPixelConnectivity/src/PixelToFEDAssociateFromAscii.cc
@@ -165,8 +165,8 @@ void PixelToFEDAssociateFromAscii::init(const string & cfg_name)
 void PixelToFEDAssociateFromAscii::send(
     pair<int,vector<Bdu> > & b, pair<int,vector<Edu> > & e)
 {
-  if (b.second.size() > 0) theBarrel.push_back(b);
-  if (e.second.size() > 0) theEndcap.push_back(e);
+  if (!b.second.empty()) theBarrel.push_back(b);
+  if (!e.second.empty()) theEndcap.push_back(e);
   b.second.clear();
   e.second.clear();
 }
@@ -219,14 +219,14 @@ PixelToFEDAssociateFromAscii::Range
   int num2 = -1;
   const char * line = l.c_str();
   while (line) {
-    char * evp = 0;
+    char * evp = nullptr;
     int num = strtol(line, &evp, 10);
     { stringstream s; s<<"raad from line: "; s<<num; LogDebug(s.str()); }
     if (evp != line) {
       line = evp +1;
       if (first) { num1 = num; first = false; }
       num2 = num;
-    } else line = 0;
+    } else line = nullptr;
   }
   if (first) {
     string s = "** PixelToFEDAssociateFromAscii, read data, cant intrpret: " ;

--- a/CalibTracker/SiPixelConnectivity/src/PixelToLNKAssociateFromAscii.cc
+++ b/CalibTracker/SiPixelConnectivity/src/PixelToLNKAssociateFromAscii.cc
@@ -29,7 +29,7 @@ const PixelToLNKAssociateFromAscii::CablingRocId * PixelToLNKAssociateFromAscii:
       return &(im->second);  
     }
   }
-  return 0;
+  return nullptr;
 }
 
 // This is where the reading and interpretation of the ascci cabling input file is

--- a/CalibTracker/SiPixelConnectivity/src/SiPixelFedCablingMapBuilder.cc
+++ b/CalibTracker/SiPixelConnectivity/src/SiPixelFedCablingMapBuilder.cc
@@ -101,10 +101,10 @@ SiPixelFedCablingTree * SiPixelFedCablingMapBuilder::produce( const edm::EventSe
 
   for (ITG it = pDD->dets().begin(); it != pDD->dets().end(); it++) {
     const PixelGeomDetUnit * pxUnit = dynamic_cast<const PixelGeomDetUnit*>(*it);
-    if (pxUnit  ==0 ) continue;
+    if (pxUnit  ==nullptr ) continue;
     npxdets++;
     DetId geomid = pxUnit->geographicalId();
-    PixelModuleName * name =  0;
+    PixelModuleName * name =  nullptr;
     if (1 == geomid.subdetId()) {  // bpix 
       name = new PixelBarrelName(geomid,tt,phase1_);
     } else {                      // fpix 

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileWriter.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileWriter.h
@@ -28,13 +28,13 @@ class SiPixelDetInfoFileWriter : public edm::EDAnalyzer {
 public:
 
   explicit SiPixelDetInfoFileWriter(const edm::ParameterSet&);
-  ~SiPixelDetInfoFileWriter();
+  ~SiPixelDetInfoFileWriter() override;
 
 private:
 
-  void beginJob();
-  void beginRun(const edm::Run &, const edm::EventSetup &);
-  void analyze(const edm::Event &, const edm::EventSetup &);
+  void beginJob() override;
+  void beginRun(const edm::Run &, const edm::EventSetup &) override;
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
 
 private:
 

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeCPEGenericErrorParmESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeCPEGenericErrorParmESSource.h
@@ -13,15 +13,15 @@ class SiPixelFakeCPEGenericErrorParmESSource : public edm::ESProducer, public ed
 
  public:
   SiPixelFakeCPEGenericErrorParmESSource(const edm::ParameterSet &);
-  ~SiPixelFakeCPEGenericErrorParmESSource();
+  ~SiPixelFakeCPEGenericErrorParmESSource() override;
   
    virtual std::unique_ptr<SiPixelCPEGenericErrorParm>  produce(const SiPixelCPEGenericErrorParmRcd &);
   
  protected:
   
-  virtual void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
 			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& );
+			       edm::ValidityInterval& ) override;
   
  private:
   

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainESSource.h
@@ -36,7 +36,7 @@ class SiPixelFakeGainESSource : public edm::ESProducer, public edm::EventSetupRe
 
  public:
   SiPixelFakeGainESSource(const edm::ParameterSet &);
-  ~SiPixelFakeGainESSource();
+  ~SiPixelFakeGainESSource() override;
   
   //      typedef edm::ESProducts<> ReturnType;
   
@@ -44,9 +44,9 @@ class SiPixelFakeGainESSource : public edm::ESProducer, public edm::EventSetupRe
   
  protected:
   
-  virtual void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
 			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& );
+			       edm::ValidityInterval& ) override;
   
   
  private:

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainForHLTESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainForHLTESSource.h
@@ -36,7 +36,7 @@ class SiPixelFakeGainForHLTESSource : public edm::ESProducer, public edm::EventS
 
  public:
   SiPixelFakeGainForHLTESSource(const edm::ParameterSet &);
-  ~SiPixelFakeGainForHLTESSource();
+  ~SiPixelFakeGainForHLTESSource() override;
   
   //      typedef edm::ESProducts<> ReturnType;
   
@@ -44,9 +44,9 @@ class SiPixelFakeGainForHLTESSource : public edm::ESProducer, public edm::EventS
   
  protected:
   
-  virtual void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
 			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& );
+			       edm::ValidityInterval& ) override;
   
   
  private:

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainOfflineESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGainOfflineESSource.h
@@ -36,7 +36,7 @@ class SiPixelFakeGainOfflineESSource : public edm::ESProducer, public edm::Event
 
  public:
   SiPixelFakeGainOfflineESSource(const edm::ParameterSet &);
-  ~SiPixelFakeGainOfflineESSource();
+  ~SiPixelFakeGainOfflineESSource() override;
   
   //      typedef edm::ESProducts<> ReturnType;
   
@@ -44,9 +44,9 @@ class SiPixelFakeGainOfflineESSource : public edm::ESProducer, public edm::Event
   
  protected:
   
-  virtual void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
 			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& );
+			       edm::ValidityInterval& ) override;
   
   
  private:

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGenErrorDBObjectESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeGenErrorDBObjectESSource.h
@@ -13,7 +13,7 @@ class SiPixelFakeGenErrorDBObjectESSource : public edm::ESProducer, public edm::
 
  public:
   SiPixelFakeGenErrorDBObjectESSource(const edm::ParameterSet &);
-  ~SiPixelFakeGenErrorDBObjectESSource();
+  ~SiPixelFakeGenErrorDBObjectESSource() override;
   
   typedef std::vector<std::string> vstring;
   
@@ -21,9 +21,9 @@ class SiPixelFakeGenErrorDBObjectESSource : public edm::ESProducer, public edm::
   
  protected:
   
-  virtual void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
 			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& );
+			       edm::ValidityInterval& ) override;
   
  private:
   

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeLorentzAngleESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeLorentzAngleESSource.h
@@ -37,7 +37,7 @@ class SiPixelFakeLorentzAngleESSource : public edm::ESProducer, public edm::Even
 
  public:
   SiPixelFakeLorentzAngleESSource(const edm::ParameterSet &);
-  ~SiPixelFakeLorentzAngleESSource();
+  ~SiPixelFakeLorentzAngleESSource() override;
   
   //      typedef edm::ESProducts<> ReturnType;
   
@@ -45,9 +45,9 @@ class SiPixelFakeLorentzAngleESSource : public edm::ESProducer, public edm::Even
   
  protected:
   
-  virtual void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
 			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& );
+			       edm::ValidityInterval& ) override;
   
   
  private:

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeQualityESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeQualityESSource.h
@@ -37,7 +37,7 @@ class SiPixelFakeQualityESSource : public edm::ESProducer, public edm::EventSetu
 
  public:
   SiPixelFakeQualityESSource(const edm::ParameterSet &);
-  ~SiPixelFakeQualityESSource();
+  ~SiPixelFakeQualityESSource() override;
   
   //      typedef edm::ESProducts<> ReturnType;
   
@@ -45,9 +45,9 @@ class SiPixelFakeQualityESSource : public edm::ESProducer, public edm::EventSetu
   
  protected:
   
-  virtual void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
 			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& );
+			       edm::ValidityInterval& ) override;
   
   
  private:

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelFakeTemplateDBObjectESSource.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelFakeTemplateDBObjectESSource.h
@@ -13,7 +13,7 @@ class SiPixelFakeTemplateDBObjectESSource : public edm::ESProducer, public edm::
 
  public:
   SiPixelFakeTemplateDBObjectESSource(const edm::ParameterSet &);
-  ~SiPixelFakeTemplateDBObjectESSource();
+  ~SiPixelFakeTemplateDBObjectESSource() override;
   
   typedef std::vector<std::string> vstring;
   
@@ -21,9 +21,9 @@ class SiPixelFakeTemplateDBObjectESSource : public edm::ESProducer, public edm::
   
  protected:
   
-  virtual void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
 			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& );
+			       edm::ValidityInterval& ) override;
   
  private:
   

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTService.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTService.h
@@ -23,18 +23,18 @@ class SiPixelGainCalibrationForHLTService final : public SiPixelGainCalibrationS
 
  public:
   explicit SiPixelGainCalibrationForHLTService(const edm::ParameterSet& conf) : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationForHLT,SiPixelGainCalibrationForHLTRcd>(conf){};
-  ~SiPixelGainCalibrationForHLTService(){};
+  ~SiPixelGainCalibrationForHLTService() override{};
 
-  void calibrate(uint32_t detID, DigiIterator b, DigiIterator e, float conversionFactor, float offset, int * electron);
+  void calibrate(uint32_t detID, DigiIterator b, DigiIterator e, float conversionFactor, float offset, int * electron) override;
 
 
   // column granularity
-  float   getPedestal  ( const uint32_t& detID,const int& col, const int& row);
-  float   getGain      ( const uint32_t& detID,const int& col, const int& row);
-  bool    isDead       ( const uint32_t& detID,const int& col, const int& row); //also return dead by column.
-  bool    isDeadColumn ( const uint32_t& detID,const int& col, const int& row);
-  bool    isNoisy       ( const uint32_t& detID,const int& col, const int& row);
-  bool    isNoisyColumn ( const uint32_t& detID,const int& col, const int& row);
+  float   getPedestal  ( const uint32_t& detID,const int& col, const int& row) override;
+  float   getGain      ( const uint32_t& detID,const int& col, const int& row) override;
+  bool    isDead       ( const uint32_t& detID,const int& col, const int& row) override; //also return dead by column.
+  bool    isDeadColumn ( const uint32_t& detID,const int& col, const int& row) override;
+  bool    isNoisy       ( const uint32_t& detID,const int& col, const int& row) override;
+  bool    isNoisyColumn ( const uint32_t& detID,const int& col, const int& row) override;
 
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTSimService.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTSimService.h
@@ -24,15 +24,15 @@ class SiPixelGainCalibrationForHLTSimService : public SiPixelGainCalibrationServ
 
  public:
   explicit SiPixelGainCalibrationForHLTSimService(const edm::ParameterSet& conf) : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationForHLT,SiPixelGainCalibrationForHLTSimRcd>(conf){};
-  ~SiPixelGainCalibrationForHLTSimService(){};
+  ~SiPixelGainCalibrationForHLTSimService() override{};
 
   // column granularity
-  float   getPedestal  ( const uint32_t& detID,const int& col, const int& row);
-  float   getGain      ( const uint32_t& detID,const int& col, const int& row);
-  bool    isDead       ( const uint32_t& detID,const int& col, const int& row); //also return dead by column.
-  bool    isDeadColumn ( const uint32_t& detID,const int& col, const int& row);
-  bool    isNoisy       ( const uint32_t& detID,const int& col, const int& row);
-  bool    isNoisyColumn ( const uint32_t& detID,const int& col, const int& row);
+  float   getPedestal  ( const uint32_t& detID,const int& col, const int& row) override;
+  float   getGain      ( const uint32_t& detID,const int& col, const int& row) override;
+  bool    isDead       ( const uint32_t& detID,const int& col, const int& row) override; //also return dead by column.
+  bool    isDeadColumn ( const uint32_t& detID,const int& col, const int& row) override;
+  bool    isNoisy       ( const uint32_t& detID,const int& col, const int& row) override;
+  bool    isNoisyColumn ( const uint32_t& detID,const int& col, const int& row) override;
 
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineService.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineService.h
@@ -23,14 +23,14 @@ class SiPixelGainCalibrationOfflineService : public SiPixelGainCalibrationServic
 
  public:
   explicit SiPixelGainCalibrationOfflineService(const edm::ParameterSet& conf) : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationOffline,SiPixelGainCalibrationOfflineRcd>(conf){};
-  ~SiPixelGainCalibrationOfflineService(){};
+  ~SiPixelGainCalibrationOfflineService() override{};
 
   // pixel granularity
-  float   getPedestal  ( const uint32_t& detID,const int& col, const int& row);
-  float   getGain      ( const uint32_t& detID,const int& col, const int& row);
-  bool    isDead       ( const uint32_t& detID,const int& col, const int& row);
-  bool    isDeadColumn ( const uint32_t& detID,const int& col, const int& row);
-  bool    isNoisy       ( const uint32_t& detID,const int& col, const int& row);
-  bool    isNoisyColumn ( const uint32_t& detID,const int& col, const int& row);
+  float   getPedestal  ( const uint32_t& detID,const int& col, const int& row) override;
+  float   getGain      ( const uint32_t& detID,const int& col, const int& row) override;
+  bool    isDead       ( const uint32_t& detID,const int& col, const int& row) override;
+  bool    isDeadColumn ( const uint32_t& detID,const int& col, const int& row) override;
+  bool    isNoisy       ( const uint32_t& detID,const int& col, const int& row) override;
+  bool    isNoisyColumn ( const uint32_t& detID,const int& col, const int& row) override;
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineSimService.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineSimService.h
@@ -24,14 +24,14 @@ class SiPixelGainCalibrationOfflineSimService : public SiPixelGainCalibrationSer
 
  public:
   explicit SiPixelGainCalibrationOfflineSimService(const edm::ParameterSet& conf) : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationOffline,SiPixelGainCalibrationOfflineSimRcd>(conf){};
-  ~SiPixelGainCalibrationOfflineSimService(){};
+  ~SiPixelGainCalibrationOfflineSimService() override{};
 
   // pixel granularity
-  float   getPedestal  ( const uint32_t& detID,const int& col, const int& row);
-  float   getGain      ( const uint32_t& detID,const int& col, const int& row);
-  bool    isDead       ( const uint32_t& detID,const int& col, const int& row);
-  bool    isDeadColumn ( const uint32_t& detID,const int& col, const int& row);
-  bool    isNoisy       ( const uint32_t& detID,const int& col, const int& row);
-  bool    isNoisyColumn ( const uint32_t& detID,const int& col, const int& row);
+  float   getPedestal  ( const uint32_t& detID,const int& col, const int& row) override;
+  float   getGain      ( const uint32_t& detID,const int& col, const int& row) override;
+  bool    isDead       ( const uint32_t& detID,const int& col, const int& row) override;
+  bool    isDeadColumn ( const uint32_t& detID,const int& col, const int& row) override;
+  bool    isNoisy       ( const uint32_t& detID,const int& col, const int& row) override;
+  bool    isNoisyColumn ( const uint32_t& detID,const int& col, const int& row) override;
 };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationService.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationService.h
@@ -23,15 +23,15 @@ class SiPixelGainCalibrationService : public SiPixelGainCalibrationServicePayloa
 
  public:
   explicit SiPixelGainCalibrationService(const edm::ParameterSet& conf) : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibration,SiPixelGainCalibrationRcd>(conf){};
-  ~SiPixelGainCalibrationService(){};
+  ~SiPixelGainCalibrationService() override{};
 
   // pixel granularity
-  float   getPedestal  ( const uint32_t& detID,const int& col, const int& row);
-  float   getGain      ( const uint32_t& detID,const int& col, const int& row);
-  bool    isDead       ( const uint32_t& detID,const int& col, const int& row);
-  bool    isDeadColumn ( const uint32_t& detID,const int& col, const int& row); //throws exception!
-  bool    isNoisy       ( const uint32_t& detID,const int& col, const int& row);
-  bool    isNoisyColumn ( const uint32_t& detID,const int& col, const int& row);
+  float   getPedestal  ( const uint32_t& detID,const int& col, const int& row) override;
+  float   getGain      ( const uint32_t& detID,const int& col, const int& row) override;
+  bool    isDead       ( const uint32_t& detID,const int& col, const int& row) override;
+  bool    isDeadColumn ( const uint32_t& detID,const int& col, const int& row) override; //throws exception!
+  bool    isNoisy       ( const uint32_t& detID,const int& col, const int& row) override;
+  bool    isNoisyColumn ( const uint32_t& detID,const int& col, const int& row) override;
 
 
 };

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h
@@ -59,25 +59,25 @@ class SiPixelGainCalibrationServicePayloadGetter : public SiPixelGainCalibration
 
  public:
   explicit SiPixelGainCalibrationServicePayloadGetter(const edm::ParameterSet& conf);
-  virtual ~SiPixelGainCalibrationServicePayloadGetter(){};
+  ~SiPixelGainCalibrationServicePayloadGetter() override{};
 
   //Abstract methods
-  virtual float getGain(const uint32_t& detID, const int& col, const int& row)=0;
-  virtual float getPedestal(const uint32_t& detID, const int& col, const int& row)=0;
+  float getGain(const uint32_t& detID, const int& col, const int& row) override =0;
+  float getPedestal(const uint32_t& detID, const int& col, const int& row) override =0;
 
-  virtual bool isDead       ( const uint32_t& detID, const int& col, const int& row )=0;
-  virtual bool isDeadColumn ( const uint32_t& detID, const int& col, const int& row )=0;
+  bool isDead       ( const uint32_t& detID, const int& col, const int& row ) override =0;
+  bool isDeadColumn ( const uint32_t& detID, const int& col, const int& row ) override =0;
 
-  virtual bool isNoisy       ( const uint32_t& detID, const int& col, const int& row )=0;
-  virtual bool isNoisyColumn ( const uint32_t& detID, const int& col, const int& row )=0;
+  bool isNoisy       ( const uint32_t& detID, const int& col, const int& row ) override =0;
+  bool isNoisyColumn ( const uint32_t& detID, const int& col, const int& row ) override =0;
 
-  void    setESObjects(const edm::EventSetup& es );
+  void    setESObjects(const edm::EventSetup& es ) override;
 
-  std::vector<uint32_t> getDetIds();
-  double getGainLow();
-  double getGainHigh();
-  double getPedLow();
-  double getPedHigh();
+  std::vector<uint32_t> getDetIds() override;
+  double getGainLow() override;
+  double getGainHigh() override;
+  double getPedLow() override;
+  double getPedHigh() override;
 
  protected:
 

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGenErrorDBObjectESProducer.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGenErrorDBObjectESProducer.h
@@ -27,7 +27,7 @@ class SiPixelGenErrorDBObjectESProducer : public edm::ESProducer  {
 public:
 
 	SiPixelGenErrorDBObjectESProducer(const edm::ParameterSet& iConfig);
-  ~SiPixelGenErrorDBObjectESProducer();
+  ~SiPixelGenErrorDBObjectESProducer() override;
 	std::shared_ptr<SiPixelGenErrorDBObject> produce(const SiPixelGenErrorDBObjectESProducerRcd &);
  };
 #endif

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelQualityESProducer.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelQualityESProducer.h
@@ -40,16 +40,16 @@ class SiPixelQualityESProducer : public edm::ESProducer, public edm::EventSetupR
 
  public:
   SiPixelQualityESProducer(const edm::ParameterSet & iConfig);
-  ~SiPixelQualityESProducer();
+  ~SiPixelQualityESProducer() override;
   
   
   /* virtual*/ std::unique_ptr<SiPixelQuality> produce(const SiPixelQualityRcd & iRecord) ;
   
 protected:
   
-  virtual void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
 			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& );
+			       edm::ValidityInterval& ) override;
   
   
  private:

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelTemplateDBObjectESProducer.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelTemplateDBObjectESProducer.h
@@ -27,7 +27,7 @@ class SiPixelTemplateDBObjectESProducer : public edm::ESProducer  {
 public:
 
 	SiPixelTemplateDBObjectESProducer(const edm::ParameterSet& iConfig);
-  ~SiPixelTemplateDBObjectESProducer();
+  ~SiPixelTemplateDBObjectESProducer() override;
 	std::shared_ptr<SiPixelTemplateDBObject> produce(const SiPixelTemplateDBObjectESProducerRcd &);
  };
 #endif

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainESSource.cc
@@ -52,7 +52,7 @@ std::unique_ptr<SiPixelGainCalibration> SiPixelFakeGainESSource::produce(const S
    uint32_t nchannels = 0;
    SiPixelGainCalibration * obj = new SiPixelGainCalibration(25.,30., 2.,3.);
    SiPixelDetInfoFileReader reader(fp_.fullPath());
-   const std::vector<uint32_t> DetIds = reader.getAllDetIds();
+   const std::vector<uint32_t>& DetIds = reader.getAllDetIds();
 
    // Loop over detectors
    for(std::vector<uint32_t>::const_iterator detit=DetIds.begin(); detit!=DetIds.end(); detit++) {

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainForHLTESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainForHLTESSource.cc
@@ -52,7 +52,7 @@ std::unique_ptr<SiPixelGainCalibrationForHLT> SiPixelFakeGainForHLTESSource::pro
    uint32_t nchannels = 0;
    SiPixelGainCalibrationForHLT * obj = new SiPixelGainCalibrationForHLT(25.,30., 2.,3.);
    SiPixelDetInfoFileReader reader(fp_.fullPath());
-   const std::vector<uint32_t> DetIds = reader.getAllDetIds();
+   const std::vector<uint32_t>& DetIds = reader.getAllDetIds();
 
    // Loop over detectors
    for(std::vector<uint32_t>::const_iterator detit=DetIds.begin(); detit!=DetIds.end(); detit++) {

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainOfflineESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainOfflineESSource.cc
@@ -52,7 +52,7 @@ std::unique_ptr<SiPixelGainCalibrationOffline> SiPixelFakeGainOfflineESSource::p
    uint32_t nchannels = 0;
    SiPixelGainCalibrationOffline * obj = new SiPixelGainCalibrationOffline(25.,30., 2.,3.);
    SiPixelDetInfoFileReader reader(fp_.fullPath());
-   const std::vector<uint32_t> DetIds = reader.getAllDetIds();
+   const std::vector<uint32_t>& DetIds = reader.getAllDetIds();
 
    // Loop over detectors
    for(std::vector<uint32_t>::const_iterator detit=DetIds.begin(); detit!=DetIds.end(); detit++) {

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeLorentzAngleESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeLorentzAngleESSource.cc
@@ -50,7 +50,7 @@ std::unique_ptr<SiPixelLorentzAngle> SiPixelFakeLorentzAngleESSource::produce(co
 	unsigned int nmodules = 0;
 	SiPixelLorentzAngle * obj = new SiPixelLorentzAngle();
 	SiPixelDetInfoFileReader reader(fp_.fullPath());
-	const std::vector<uint32_t> DetIds = reader.getAllDetIds();
+	const std::vector<uint32_t>& DetIds = reader.getAllDetIds();
 	
 	// Loop over detectors
 	for(std::vector<uint32_t>::const_iterator detit = DetIds.begin(); detit!=DetIds.end(); detit++) {

--- a/CalibTracker/SiPixelErrorEstimation/interface/SiPixelErrorEstimation.h
+++ b/CalibTracker/SiPixelErrorEstimation/interface/SiPixelErrorEstimation.h
@@ -65,11 +65,11 @@ class SiPixelErrorEstimation : public edm::EDAnalyzer
  public:
   
   explicit SiPixelErrorEstimation(const edm::ParameterSet&);
-  virtual ~SiPixelErrorEstimation();
+  ~SiPixelErrorEstimation() override;
     
-  virtual void beginJob() ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  void beginJob() override ;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
 
   void computeAnglesFromDetPosition( const SiPixelCluster & cl, 
 				     const GeomDetUnit    & det, 

--- a/CalibTracker/SiPixelErrorEstimation/src/SiPixelErrorEstimation.cc
+++ b/CalibTracker/SiPixelErrorEstimation/src/SiPixelErrorEstimation.cc
@@ -33,8 +33,8 @@
 using namespace std;
 using namespace edm;
 
-SiPixelErrorEstimation::SiPixelErrorEstimation(const edm::ParameterSet& ps):tfile_(0), ttree_all_hits_(0), 
-									    ttree_track_hits_(0), ttree_track_hits_strip_(0),
+SiPixelErrorEstimation::SiPixelErrorEstimation(const edm::ParameterSet& ps):tfile_(nullptr), ttree_all_hits_(nullptr), 
+									    ttree_track_hits_(nullptr), ttree_track_hits_strip_(nullptr),
 									    trackerHitAssociatorConfig_(consumesCollector())
 {
   //Read config file
@@ -515,12 +515,12 @@ SiPixelErrorEstimation::analyze(const edm::Event& e, const edm::EventSetup& es)
 
 	  const TransientTrackingRecHit::ConstRecHitPointer trans_trk_rec_hit_point = itTraj->recHit();
 	 
-	  if ( trans_trk_rec_hit_point == NULL )
+	  if ( trans_trk_rec_hit_point == nullptr )
 	    continue;
 
 	  const TrackingRecHit *trk_rec_hit = (*trans_trk_rec_hit_point).hit();
 
-	  if ( trk_rec_hit == NULL )
+	  if ( trk_rec_hit == nullptr )
 	    continue;
 
 	  DetId detid = (trk_rec_hit)->geographicalId();
@@ -586,7 +586,7 @@ SiPixelErrorEstimation::analyze(const edm::Event& e, const edm::EventSetup& es)
 	  //const StripGeomDetUnit* strip_geom_det_unit = dynamic_cast<const StripGeomDetUnit*> ( tracker->idToDet( detid ) );
 	  const StripGeomDetUnit* strip_geom_det_unit = (const StripGeomDetUnit*)tracker->idToDetUnit( detid );
 	  
-	  if ( strip_geom_det_unit != NULL )
+	  if ( strip_geom_det_unit != nullptr )
 	    {
 	      LocalVector lbfield 
 		= (strip_geom_det_unit->surface()).toLocal( (*magneticField).inTesla( strip_geom_det_unit->surface().position() ) ); 
@@ -1366,7 +1366,7 @@ SiPixelErrorEstimation::analyze(const edm::Event& e, const edm::EventSetup& es)
       const reco::TrackCollection *tracks = trackCollection.product();
       reco::TrackCollection::const_iterator tciter;
       
-      if ( tracks->size() > 0 )
+      if ( !tracks->empty() )
 	{
 	  // Loop on tracks
 	  for ( tciter=tracks->begin(); tciter!=tracks->end(); ++tciter)

--- a/CalibTracker/SiPixelGainCalibration/plugins/SiPixelCalibDigiProducer.cc
+++ b/CalibTracker/SiPixelGainCalibration/plugins/SiPixelCalibDigiProducer.cc
@@ -94,13 +94,13 @@ SiPixelCalibDigiProducer::store()
   //  std::cout << "in store() " << std::endl;
   if(iEventCounter_%pattern_repeat_==0){
     //    std::cout << "now at event " << iEventCounter_ <<" where we save the calibration information into the CMSSW digi";
-    return 1;
+    return true;
   }
   else if(iEventCounter_==calib_->expectedTotalEvents())
-    return 1;
+    return true;
   else
-    return 0;
-  return 1;
+    return false;
+  return true;
 }
 ////////////////////////////////////////////////////////////////////
 // function description:
@@ -332,7 +332,7 @@ bool SiPixelCalibDigiProducer::checkPixel(uint32_t detid, short row, short col){
   
   
   edm::LogInfo("SiPixelCalibDigiProducer") << "Event" << iEventCounter_ << ",now in checkpixel() " << std::endl;
-  if(currentpattern_.size()==0)
+  if(currentpattern_.empty())
     setPattern();
   //  uint32_t iroc;
   uint32_t fedid = detid_to_fedid_[detid];

--- a/CalibTracker/SiPixelGainCalibration/plugins/SiPixelCalibDigiProducer.h
+++ b/CalibTracker/SiPixelGainCalibration/plugins/SiPixelCalibDigiProducer.h
@@ -55,11 +55,11 @@
 class SiPixelCalibDigiProducer : public edm::EDProducer {
    public:
       explicit SiPixelCalibDigiProducer(const edm::ParameterSet& iConfig);
-      ~SiPixelCalibDigiProducer();
+      ~SiPixelCalibDigiProducer() override;
 
    private:
 
-      virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+      void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
       virtual bool store();
       virtual void setPattern();
       virtual void fill(edm::Event &iEvent, const edm::EventSetup& iSetup);

--- a/CalibTracker/SiPixelGainCalibration/plugins/SiPixelGainCalibrationAnalysis.cc
+++ b/CalibTracker/SiPixelGainCalibration/plugins/SiPixelGainCalibrationAnalysis.cc
@@ -22,7 +22,7 @@ Implementation:
 #include "SiPixelGainCalibrationAnalysis.h"
 #include <sstream>
 #include <vector>
-#include <math.h>
+#include <cmath>
 #include "TGraphErrors.h"
 #include "TMath.h"
 
@@ -240,14 +240,14 @@ SiPixelGainCalibrationAnalysis::doFits(uint32_t detid, std::vector<SiPixelCalibD
   
   // calculate plateau value from last 4 entries
   double plateauval=0;
-  bool noPlateau=0;
+  bool noPlateau=false;
   if(nallpoints>=4){
     for(int ii=nallpoints-1; ii>nallpoints-5; --ii) plateauval+=yvalsall[ii];
     plateauval/=4;
     for(int ii=nallpoints-1; ii>nallpoints-5; --ii){
       if(fabs(yvalsall[ii]-plateauval)>5){
         plateauval=255;
-	noPlateau=1;
+	noPlateau=true;
         continue;
       }
     }
@@ -432,7 +432,7 @@ SiPixelGainCalibrationAnalysis::doFits(uint32_t detid, std::vector<SiPixelCalibD
 
     if(!savePixelHists_)
     return true;
-  if(detidfinder==listofdetids_.end() && listofdetids_.size()!=0)
+  if(detidfinder==listofdetids_.end() && !listofdetids_.empty())
     return true;
   if(makehistopersistent){
     std::ostringstream pixelinfo;

--- a/CalibTracker/SiPixelGainCalibration/plugins/SiPixelGainCalibrationAnalysis.h
+++ b/CalibTracker/SiPixelGainCalibration/plugins/SiPixelGainCalibrationAnalysis.h
@@ -48,19 +48,19 @@ Implementation:
 class SiPixelGainCalibrationAnalysis : public SiPixelOfflineCalibAnalysisBase {
 public:
   explicit SiPixelGainCalibrationAnalysis(const edm::ParameterSet& iConfig);
-  ~SiPixelGainCalibrationAnalysis();
+  ~SiPixelGainCalibrationAnalysis() override;
 
   void doSetup(const edm::ParameterSet&);
-  virtual bool doFits(uint32_t detid, std::vector<SiPixelCalibDigi>::const_iterator ipix);
+  bool doFits(uint32_t detid, std::vector<SiPixelCalibDigi>::const_iterator ipix) override;
 
-  virtual bool checkCorrectCalibrationType();
+  bool checkCorrectCalibrationType() override;
 
 private:
       
-  virtual void calibrationSetup(const edm::EventSetup& iSetup);
+  void calibrationSetup(const edm::EventSetup& iSetup) override;
       
-  virtual void calibrationEnd();
-  virtual void newDetID(uint32_t detid);
+  void calibrationEnd() override;
+  void newDetID(uint32_t detid) override;
   void fillDatabase();
   void printSummary();
   std::vector<float> CalculateAveragePerColumn(uint32_t detid, std::string label);

--- a/CalibTracker/SiPixelIsAliveCalibration/src/SiPixelIsAliveCalibration.cc
+++ b/CalibTracker/SiPixelIsAliveCalibration/src/SiPixelIsAliveCalibration.cc
@@ -37,18 +37,18 @@
 class SiPixelIsAliveCalibration : public SiPixelOfflineCalibAnalysisBase {
    public:
       explicit SiPixelIsAliveCalibration(const edm::ParameterSet&);
-      ~SiPixelIsAliveCalibration();
+      ~SiPixelIsAliveCalibration() override;
 
   void doSetup(const edm::ParameterSet &);
-      virtual bool doFits(uint32_t detid, std::vector<SiPixelCalibDigi>::const_iterator ipix) override;
+      bool doFits(uint32_t detid, std::vector<SiPixelCalibDigi>::const_iterator ipix) override;
   
 
    private:
   
-      virtual void calibrationSetup(const edm::EventSetup&) override ;
-      virtual void calibrationEnd() override ;
-  virtual void newDetID(uint32_t detid) override;
-  virtual bool checkCorrectCalibrationType() override;
+      void calibrationSetup(const edm::EventSetup&) override ;
+      void calibrationEnd() override ;
+  void newDetID(uint32_t detid) override;
+  bool checkCorrectCalibrationType() override;
       // ----------member data ---------------------------
 
   std::map<uint32_t,MonitorElement *> bookkeeper_;

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.cc
@@ -186,7 +186,7 @@ void SiPixelLorentzAngle::analyze(const edm::Event& e, const edm::EventSetup& es
   // get the association map between tracks and trajectories
   edm::Handle<TrajTrackAssociationCollection> trajTrackCollectionHandle;
   e.getByToken(t_trajTrack,trajTrackCollectionHandle);
-  if(trajTrackCollectionHandle->size() >0){
+  if(!trajTrackCollectionHandle->empty()){
     trackEventsCounter_++;
     for(TrajTrackAssociationCollection::const_iterator it = trajTrackCollectionHandle->begin(); it!=trajTrackCollectionHandle->end();++it){
       const Track&      track = *it->val;

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.h
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.h
@@ -91,11 +91,11 @@ class SiPixelLorentzAngle : public edm::EDAnalyzer
   
   explicit SiPixelLorentzAngle(const edm::ParameterSet& conf);
   
-  virtual ~SiPixelLorentzAngle();
+  ~SiPixelLorentzAngle() override;
   //virtual void beginJob(const edm::EventSetup& c);
-  virtual void beginJob();
-  virtual void endJob(); 
-  virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void beginJob() override;
+  void endJob() override; 
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   
  private:
   

--- a/CalibTracker/SiPixelSCurveCalibration/interface/SiPixelSCurveCalibrationAnalysis.h
+++ b/CalibTracker/SiPixelSCurveCalibration/interface/SiPixelSCurveCalibrationAnalysis.h
@@ -57,10 +57,10 @@ typedef std::map<uint32_t, sCurveHistogramHolder> detIDHistogramMap;
 class SiPixelSCurveCalibrationAnalysis : public SiPixelOfflineCalibAnalysisBase {
    public:
       explicit SiPixelSCurveCalibrationAnalysis(const edm::ParameterSet& iConfig):SiPixelOfflineCalibAnalysisBase(iConfig){doSetup(iConfig);};
-      ~SiPixelSCurveCalibrationAnalysis();
+      ~SiPixelSCurveCalibrationAnalysis() override;
       void doSetup(const edm::ParameterSet&);
 
-      virtual bool doFits(uint32_t detid, std::vector<SiPixelCalibDigi>::const_iterator ipix);
+      bool doFits(uint32_t detid, std::vector<SiPixelCalibDigi>::const_iterator ipix) override;
 
       static std::vector<float> efficiencies_;
       static std::vector<float> effErrors_;
@@ -105,11 +105,11 @@ class SiPixelSCurveCalibrationAnalysis : public SiPixelOfflineCalibAnalysisBase 
       //holds histogrms entered
       detIDHistogramMap histograms_;
 
-      virtual void calibrationSetup(const edm::EventSetup& iSetup);
-      virtual bool checkCorrectCalibrationType();
-      virtual void newDetID(uint32_t detid);
+      void calibrationSetup(const edm::EventSetup& iSetup) override;
+      bool checkCorrectCalibrationType() override;
+      void newDetID(uint32_t detid) override;
       void makeThresholdSummary(void);
-      virtual void calibrationEnd() ;
+      void calibrationEnd() override ;
       
       // ----------member data ---------------------------
 };

--- a/CalibTracker/SiPixelSCurveCalibration/src/SiPixelSCurveCalibrationAnalysis.cc
+++ b/CalibTracker/SiPixelSCurveCalibration/src/SiPixelSCurveCalibrationAnalysis.cc
@@ -351,7 +351,7 @@ bool SiPixelSCurveCalibrationAnalysis::doFits(uint32_t detid, std::vector<SiPixe
 
       //get Chi2
       Double_t params[3]   = {threshold, sigma, amplitude};
-      gMinuit->Eval(3, NULL, chi2, params, 0);
+      gMinuit->Eval(3, nullptr, chi2, params, 0);
       //calculate Chi2 proability
       if (nDOF <= 0)
          chi2probability = 0;

--- a/CalibTracker/SiPixelTools/interface/SiPixelOfflineCalibAnalysisBase.h
+++ b/CalibTracker/SiPixelTools/interface/SiPixelOfflineCalibAnalysisBase.h
@@ -67,7 +67,7 @@
 class SiPixelOfflineCalibAnalysisBase : public edm::EDAnalyzer {
 public:
   explicit SiPixelOfflineCalibAnalysisBase(const edm::ParameterSet&); 
-  ~SiPixelOfflineCalibAnalysisBase();
+  ~SiPixelOfflineCalibAnalysisBase() override;
   
   //no argument constructor only used to throw exception in the case of derived 
   //class constructor not calling SiPixelOfflineCalibAnalysisBase(const edm::ParameterSet&)
@@ -130,9 +130,9 @@ private:
   
   //the beginJob is used to load the calib database.  It then calls the pure
   //virtual calibrationSetup() function.  Derived classes should put beginJob functionality there.
-  virtual void beginRun(const edm::Run &, const edm::EventSetup &);
+  void beginRun(const edm::Run &, const edm::EventSetup &) override;
   void beginRun(const edm::EventSetup& iSetup);
-  void beginJob();
+  void beginJob() override;
   
   //calibrationSetup will be used by derived classes
   virtual void calibrationSetup(const edm::EventSetup& iSetup);
@@ -143,10 +143,10 @@ private:
   //called when new DetID discovered
   virtual void newDetID(uint32_t detid);
   
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   // the endJob method is used to save things like histograms etc.
   // for additional actions derived classes should use the calibrationEnd() method for endJob functionality.
-  void endJob() ;
+  void endJob() override ;
   // calibrationEnd() will be used by derived classes
   virtual void calibrationEnd() ;
  

--- a/CalibTracker/SiPixelTools/plugins/SiPixelCalibDigiFilter.cc
+++ b/CalibTracker/SiPixelTools/plugins/SiPixelCalibDigiFilter.cc
@@ -72,7 +72,7 @@ SiPixelCalibDigiFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
    Handle<DetSetVector<SiPixelCalibDigi> > listOfDetIds;
    iEvent.getByToken(tPixelCalibDigi, listOfDetIds);
 
-   if (listOfDetIds->size() == 0)
+   if (listOfDetIds->empty())
       return false;
    else
       return true;

--- a/CalibTracker/SiPixelTools/plugins/SiPixelCalibDigiFilter.h
+++ b/CalibTracker/SiPixelTools/plugins/SiPixelCalibDigiFilter.h
@@ -38,12 +38,12 @@
 class SiPixelCalibDigiFilter : public edm::EDFilter {
    public:
       explicit SiPixelCalibDigiFilter(const edm::ParameterSet&);
-      ~SiPixelCalibDigiFilter();
+      ~SiPixelCalibDigiFilter() override;
 
    private:
-      virtual void beginJob();
-      virtual bool filter(edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+      void beginJob() override;
+      bool filter(edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
       
       // ----------member data ---------------------------
       edm::EDGetTokenT<edm::DetSetVector<SiPixelCalibDigi>> tPixelCalibDigi;

--- a/CalibTracker/SiPixelTools/plugins/SiPixelDQMRocLevelAnalyzer.h
+++ b/CalibTracker/SiPixelTools/plugins/SiPixelDQMRocLevelAnalyzer.h
@@ -46,13 +46,13 @@
 class SiPixelDQMRocLevelAnalyzer : public edm::EDAnalyzer {
    public:
       explicit SiPixelDQMRocLevelAnalyzer(const edm::ParameterSet&);
-      ~SiPixelDQMRocLevelAnalyzer();
+      ~SiPixelDQMRocLevelAnalyzer() override;
 
 
    private:
-      virtual void beginJob();
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+      void beginJob() override;
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
 
       //
       void RocSummary(std::string tagname);

--- a/CalibTracker/SiPixelTools/plugins/SiPixelErrorsDigisToCalibDigis.h
+++ b/CalibTracker/SiPixelTools/plugins/SiPixelErrorsDigisToCalibDigis.h
@@ -51,7 +51,7 @@ Description: Create monitorElements for the Errors in created in the reduction o
 class SiPixelErrorsDigisToCalibDigis : public edm::EDAnalyzer {
  public:
   explicit SiPixelErrorsDigisToCalibDigis(const edm::ParameterSet&);
-  ~SiPixelErrorsDigisToCalibDigis();
+  ~SiPixelErrorsDigisToCalibDigis() override;
   
   MonitorElement*  bookDQMHistogram2D(uint32_t detid, std::string name, std::string title, int nchX, double lowX, double highX, int nchY, double lowY, double highY);      
   MonitorElement*  bookDQMHistoPlaquetteSummary2D(uint32_t detid, std::string name,std::string title); // take the detid to determine the size of rows and columns, this saves looking up everything in the cabling map by the user. 
@@ -63,9 +63,9 @@ class SiPixelErrorsDigisToCalibDigis : public edm::EDAnalyzer {
        edm::ESHandle<TrackerGeometry> geom_;
 
    private:
-      virtual void beginJob() ;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+      void beginJob() override ;
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
 
       // ----------member data ---------------------------
 

--- a/CalibTracker/SiPixelTools/plugins/SiPixelFedFillerWordEventNumber.cc
+++ b/CalibTracker/SiPixelTools/plugins/SiPixelFedFillerWordEventNumber.cc
@@ -379,7 +379,7 @@ SiPixelFedFillerWordEventNumber ::produce(edm::Event& iEvent, const edm::EventSe
       int value = PwordSlink64((uint64_t*)fedRawData.data(),(int)fedRawData.size(), totword);
       if(value!=0){
 	//====== Verify that the vector is not empty
-	if(vecSaveFillerWords.size()!=0){
+	if(!vecSaveFillerWords.empty()){
 	  for(vecSaveFillerWords_It = vecSaveFillerWords.begin(); vecSaveFillerWords_It != vecSaveFillerWords.end(); vecSaveFillerWords_It++){
 	    SaveFillerWords->push_back(*vecSaveFillerWords_It);
 	  }

--- a/CalibTracker/SiPixelTools/plugins/SiPixelFedFillerWordEventNumber.h
+++ b/CalibTracker/SiPixelTools/plugins/SiPixelFedFillerWordEventNumber.h
@@ -2,7 +2,7 @@
 #define SiPixelFedFillerWordEventNumber_H
 
 // user include files
-#include <stdio.h>
+#include <cstdio>
 #include <vector>
 #include <iostream>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -22,15 +22,15 @@
 class SiPixelFedFillerWordEventNumber  : public edm::EDProducer {
    public:
       explicit SiPixelFedFillerWordEventNumber (const edm::ParameterSet&);
-      ~SiPixelFedFillerWordEventNumber ();
+      ~SiPixelFedFillerWordEventNumber () override;
       std::string label;
       std::string instance;
       bool SaveFillerWordsbool;
       
    private:
-      virtual void beginJob() ;
-      virtual void produce(edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+      void beginJob() override ;
+      void produce(edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
       edm::ParameterSet config_;
       int status; 
       unsigned int EventNum;

--- a/CalibTracker/SiPixelTools/src/SiPixelOfflineCalibAnalysisBase.cc
+++ b/CalibTracker/SiPixelTools/src/SiPixelOfflineCalibAnalysisBase.cc
@@ -29,7 +29,7 @@
 #include "CondFormats/SiPixelObjects/interface/LocalPixel.h"
 #include "TList.h"
 
-TF1* SiPixelOfflineCalibAnalysisBase::fitFunction_ = NULL;
+TF1* SiPixelOfflineCalibAnalysisBase::fitFunction_ = nullptr;
 std::vector<short>  SiPixelOfflineCalibAnalysisBase::vCalValues_(0);
 // constructors and destructor
 //
@@ -76,7 +76,7 @@ SiPixelOfflineCalibAnalysisBase::analyze(const edm::Event& iEvent, const edm::Ev
      return;
    
    uint32_t runnumber=iEvent.id().run();
-   if(runnumbers_.size()==0)
+   if(runnumbers_.empty())
      runnumbers_.push_back(runnumber);
    else{
      bool foundnumber=false;

--- a/CalibTracker/SiStripAPVAnalysis/interface/MedianCommonModeCalculator.h
+++ b/CalibTracker/SiStripAPVAnalysis/interface/MedianCommonModeCalculator.h
@@ -13,16 +13,16 @@ public:
     
   MedianCommonModeCalculator();
 
-  virtual ~MedianCommonModeCalculator();
+  ~MedianCommonModeCalculator() override;
 
-  ApvAnalysis::PedestalType doIt(const ApvAnalysis::PedestalType&); 
+  ApvAnalysis::PedestalType doIt(const ApvAnalysis::PedestalType&) override; 
   
-  void setCM(TkCommonMode* in) {theTkCommonMode = in;}
-  void setCM(const std::vector<float>& in) {theTkCommonMode->setCommonMode(in);}
-  TkCommonMode* commonMode() {return theTkCommonMode;}
+  void setCM(TkCommonMode* in) override {theTkCommonMode = in;}
+  void setCM(const std::vector<float>& in) override {theTkCommonMode->setCommonMode(in);}
+  TkCommonMode* commonMode() override {return theTkCommonMode;}
 
-  void newEvent();
-  float getCMSlope() { return slope;}
+  void newEvent() override;
+  float getCMSlope() override { return slope;}
   
 protected:
   

--- a/CalibTracker/SiStripAPVAnalysis/interface/SimpleNoiseCalculator.h
+++ b/CalibTracker/SiStripAPVAnalysis/interface/SimpleNoiseCalculator.h
@@ -14,17 +14,17 @@ public:
   // be obsolete.
   SimpleNoiseCalculator();
   SimpleNoiseCalculator(int evnt_ini, bool useDB);
-  virtual ~SimpleNoiseCalculator();
+  ~SimpleNoiseCalculator() override;
 
-  void setStripNoise(ApvAnalysis::PedestalType& in) {theNoise.clear(); theNoise = in;}
-  ApvAnalysis::PedestalType noise() const {return theNoise;}
-  float stripNoise(int in) const {return theNoise[in];}
+  void setStripNoise(ApvAnalysis::PedestalType& in) override {theNoise.clear(); theNoise = in;}
+  ApvAnalysis::PedestalType noise() const override {return theNoise;}
+  float stripNoise(int in) const override {return theNoise[in];}
   int nevents() const {return numberOfEvents;}
 
-  void updateStatus();  
-  void resetNoise() {theNoise.clear();}
-  void updateNoise(ApvAnalysis::PedestalType& in);
-  void newEvent();
+  void updateStatus() override;  
+  void resetNoise() override {theNoise.clear();}
+  void updateNoise(ApvAnalysis::PedestalType& in) override;
+  void newEvent() override;
   
   ApvAnalysis::PedestalType stripCMPSubtractedSignal() const
                {return theCMPSubtractedSignal;}

--- a/CalibTracker/SiStripAPVAnalysis/interface/SimplePedestalCalculator.h
+++ b/CalibTracker/SiStripAPVAnalysis/interface/SimplePedestalCalculator.h
@@ -11,26 +11,26 @@ class SimplePedestalCalculator: public TkPedestalCalculator {
 public: 
 
   SimplePedestalCalculator(int evnt_ini);
-  virtual ~SimplePedestalCalculator();
+  ~SimplePedestalCalculator() override;
 
 
 
-  void resetPedestals() {
+  void resetPedestals() override {
     thePedestal.clear();
     theRawNoise.clear();
   } 
-  void setPedestals (ApvAnalysis::PedestalType& in) {thePedestal=in;}
+  void setPedestals (ApvAnalysis::PedestalType& in) override {thePedestal=in;}
   void setRawNoise (ApvAnalysis::PedestalType& in) {theRawNoise=in;}
     
-  void updateStatus();
+  void updateStatus() override;
 
-  void updatePedestal (ApvAnalysis::RawSignalType& in);
+  void updatePedestal (ApvAnalysis::RawSignalType& in) override;
 
-  ApvAnalysis::PedestalType rawNoise() const { return theRawNoise;}
-  ApvAnalysis::PedestalType  pedestal() const { return thePedestal;}
+  ApvAnalysis::PedestalType rawNoise() const override { return theRawNoise;}
+  ApvAnalysis::PedestalType  pedestal() const override { return thePedestal;}
 
  
-  void newEvent();
+  void newEvent() override;
 
 private:
   void init();

--- a/CalibTracker/SiStripAPVAnalysis/interface/TT6ApvMask.h
+++ b/CalibTracker/SiStripAPVAnalysis/interface/TT6ApvMask.h
@@ -13,12 +13,12 @@ public:
   // Use the first constructor, as the second one will soon
   // be obsolete.
   TT6ApvMask( int ctype, float ncut, float dcut, float tcut);
-  virtual ~TT6ApvMask();  
+  ~TT6ApvMask() override;  
 
-  void setMask(const MaskType& in) {theMask_ = in;}
-  MaskType mask() {return theMask_;}
+  void setMask(const MaskType& in) override {theMask_ = in;}
+  MaskType mask() override {return theMask_;}
   
-  void calculateMask(const ApvAnalysis::PedestalType&);
+  void calculateMask(const ApvAnalysis::PedestalType&) override;
 
 protected:
   bool defineNoisy(float avrg, float rms,float noise);

--- a/CalibTracker/SiStripAPVAnalysis/interface/TT6CommonModeCalculator.h
+++ b/CalibTracker/SiStripAPVAnalysis/interface/TT6CommonModeCalculator.h
@@ -14,16 +14,16 @@ public:
   TT6CommonModeCalculator(TkNoiseCalculator* noise_calc,
                           TkApvMask* mask_calc, float sig_cut);
 
-  virtual ~TT6CommonModeCalculator();
+  ~TT6CommonModeCalculator() override;
 
-  ApvAnalysis::PedestalType doIt(const ApvAnalysis::PedestalType&); 
+  ApvAnalysis::PedestalType doIt(const ApvAnalysis::PedestalType&) override; 
   
-  void setCM(TkCommonMode* in) {theTkCommonMode = in;}
-  void setCM(const std::vector<float>& in) {theTkCommonMode->setCommonMode(in);}
-  TkCommonMode* commonMode() {return theTkCommonMode;}
+  void setCM(TkCommonMode* in) override {theTkCommonMode = in;}
+  void setCM(const std::vector<float>& in) override {theTkCommonMode->setCommonMode(in);}
+  TkCommonMode* commonMode() override {return theTkCommonMode;}
 
-  void newEvent();
-  float getCMSlope() { return slope;}
+  void newEvent() override;
+  float getCMSlope() override { return slope;}
   
 protected:
   

--- a/CalibTracker/SiStripAPVAnalysis/interface/TT6NTPedestalCalculator.h
+++ b/CalibTracker/SiStripAPVAnalysis/interface/TT6NTPedestalCalculator.h
@@ -19,47 +19,47 @@ class TT6NTPedestalCalculator: public TkPedestalCalculator
 {
   public:
     TT6NTPedestalCalculator();
-    virtual ~TT6NTPedestalCalculator() {}
+    ~TT6NTPedestalCalculator() override {}
 
     /*
      * @brief
      *   Celar all Pedestals
      */
-    inline virtual void resetPedestals() { pedestals_.empty(); }
+    inline void resetPedestals() override { pedestals_.empty(); }
 
     /*
      * @brief
      *   Set Pedestals
      */
-    inline virtual void setPedestals( ApvAnalysis::PedestalType &rInput) 
+    inline void setPedestals( ApvAnalysis::PedestalType &rInput) override 
       { pedestals_ = rInput; }
 
     /*
      * @brief
      *   Update Pedestals with set of Raw Signals: plug
      */
-    inline virtual void updatePedestal( ApvAnalysis::RawSignalType &rInput) {}
+    inline void updatePedestal( ApvAnalysis::RawSignalType &rInput) override {}
 
     /*
      * @brief
      *   Retrieve Pedestals
      */
-    inline virtual ApvAnalysis::PedestalType pedestal() const { return pedestals_; }
+    inline ApvAnalysis::PedestalType pedestal() const override { return pedestals_; }
 
     /*
      * @brief
      *   Retrieve Raw Noise
      */
-    inline virtual ApvAnalysis::PedestalType rawNoise() const { return rawNoise_; }
+    inline ApvAnalysis::PedestalType rawNoise() const override { return rawNoise_; }
 
-    inline virtual void setNoise( ApvAnalysis::PedestalType &rInput)
+    inline void setNoise( ApvAnalysis::PedestalType &rInput) override
       { rawNoise_ = rInput; }
 
     /*
      * @brief
      *   Request status flag update: plug
      */
-    inline virtual void updateStatus() {}
+    inline void updateStatus() override {}
 
   private:
     ApvAnalysis::PedestalType pedestals_;

--- a/CalibTracker/SiStripAPVAnalysis/interface/TT6NoiseCalculator.h
+++ b/CalibTracker/SiStripAPVAnalysis/interface/TT6NoiseCalculator.h
@@ -14,17 +14,17 @@ public:
   // be obsolete.
   TT6NoiseCalculator();
   TT6NoiseCalculator(int evnt_ini,int evnt_iter,float sig_cut);
-  virtual ~TT6NoiseCalculator();
+  ~TT6NoiseCalculator() override;
 
-  void setStripNoise(ApvAnalysis::PedestalType& in) {theNoise.clear(); theNoise = in;}
-  ApvAnalysis::PedestalType noise() const {return theNoise;}
-  float stripNoise(int in) const {return theNoise[in];}
+  void setStripNoise(ApvAnalysis::PedestalType& in) override {theNoise.clear(); theNoise = in;}
+  ApvAnalysis::PedestalType noise() const override {return theNoise;}
+  float stripNoise(int in) const override {return theNoise[in];}
   int nevents() const {return numberOfEvents;}
 
-  void updateStatus();  
-  void resetNoise() {theNoise.clear();}
-  void updateNoise(ApvAnalysis::PedestalType& in);
-  void newEvent();
+  void updateStatus() override;  
+  void resetNoise() override {theNoise.clear();}
+  void updateNoise(ApvAnalysis::PedestalType& in) override;
+  void newEvent() override;
   
   ApvAnalysis::PedestalType stripCMPSubtractedSignal() const
                {return theCMPSubtractedSignal;}

--- a/CalibTracker/SiStripAPVAnalysis/interface/TT6PedestalCalculator.h
+++ b/CalibTracker/SiStripAPVAnalysis/interface/TT6PedestalCalculator.h
@@ -11,26 +11,26 @@ class TT6PedestalCalculator: public TkPedestalCalculator {
 public: 
 
   TT6PedestalCalculator(int evnt_ini, int evnt_iter, float sig_cut);
-  virtual ~TT6PedestalCalculator();
+  ~TT6PedestalCalculator() override;
 
 
 
-  void resetPedestals() {
+  void resetPedestals() override {
     thePedestal.clear();
     theRawNoise.clear();
   } 
-  void setPedestals (ApvAnalysis::PedestalType& in) {thePedestal=in;}
+  void setPedestals (ApvAnalysis::PedestalType& in) override {thePedestal=in;}
   void setRawNoise (ApvAnalysis::PedestalType& in) {theRawNoise=in;}
     
-  void updateStatus();
+  void updateStatus() override;
 
-  void updatePedestal (ApvAnalysis::RawSignalType& in);
+  void updatePedestal (ApvAnalysis::RawSignalType& in) override;
 
-  ApvAnalysis::PedestalType rawNoise() const { return theRawNoise;}
-  ApvAnalysis::PedestalType  pedestal() const { return thePedestal;}
+  ApvAnalysis::PedestalType rawNoise() const override { return theRawNoise;}
+  ApvAnalysis::PedestalType  pedestal() const override { return thePedestal;}
 
  
-  void newEvent();
+  void newEvent() override;
 
 private:
   void init();

--- a/CalibTracker/SiStripAPVAnalysis/src/ApvAnalysis.cc
+++ b/CalibTracker/SiStripAPVAnalysis/src/ApvAnalysis.cc
@@ -9,10 +9,10 @@ using namespace std;
 ApvAnalysis::ApvAnalysis(int nEvForUpdate)
 {
 
-  theTkCommonModeCalculator =0;
-  theTkPedestalCalculator =0;
-  theTkNoiseCalculator =0;
-  theTkApvMask =0;
+  theTkCommonModeCalculator =nullptr;
+  theTkPedestalCalculator =nullptr;
+  theTkNoiseCalculator =nullptr;
+  theTkApvMask =nullptr;
   nEventsForNoiseCalibration_ =0;
   eventsRequiredToUpdate_ = nEvForUpdate;
 
@@ -32,7 +32,7 @@ void ApvAnalysis::updateCalibration(edm::DetSet<SiStripRawDigi>& in) {
   if(theTkPedestalCalculator->status()->isUpdating()){
     nEventsForNoiseCalibration_++; 
 
-    if(theTkNoiseCalculator->noise().size() == 0) {
+    if(theTkNoiseCalculator->noise().empty()) {
       noise = theTkPedestalCalculator->rawNoise();
       theTkNoiseCalculator->setStripNoise(noise);
       theTkApvMask->calculateMask(noise);
@@ -48,7 +48,7 @@ void ApvAnalysis::updateCalibration(edm::DetSet<SiStripRawDigi>& in) {
       i++;
     }
     PedestalType tmp2 = theTkCommonModeCalculator->doIt(tmp);
-    if(tmp2.size() > 0) {
+    if(!tmp2.empty()) {
       theTkNoiseCalculator->updateNoise(tmp2);
     }   
     if(nEventsForNoiseCalibration_%eventsRequiredToUpdate_ == 1 && nEventsForNoiseCalibration_ >1)

--- a/CalibTracker/SiStripAPVAnalysis/src/ApvAnalysisFactory.cc
+++ b/CalibTracker/SiStripAPVAnalysis/src/ApvAnalysisFactory.cc
@@ -95,10 +95,10 @@ void ApvAnalysisFactory::constructAuxiliaryApvClasses( ApvAnalysis* theAPV,
   // N.B. Don't call this twice for the same APV!
   //-----------------------------------------------------------------
   // cout<<"VirtualApvAnalysisFactory::constructAuxiliaryApvClasses"<<endl;
-  TkPedestalCalculator*   thePedestal =0;
-  TkNoiseCalculator*      theNoise=0;
-  TkApvMask*              theMask=0;
-  TkCommonModeCalculator* theCM=0;
+  TkPedestalCalculator*   thePedestal =nullptr;
+  TkNoiseCalculator*      theNoise=nullptr;
+  TkApvMask*              theMask=nullptr;
+  TkCommonModeCalculator* theCM=nullptr;
 
   TkCommonMode*   theCommonMode = new TkCommonMode();
   TkCommonModeTopology* theTopology = new TkCommonModeTopology(128, theNumCMstripsInGroup_);

--- a/CalibTracker/SiStripAPVAnalysis/src/MedianCommonModeCalculator.cc
+++ b/CalibTracker/SiStripAPVAnalysis/src/MedianCommonModeCalculator.cc
@@ -7,14 +7,14 @@ MedianCommonModeCalculator::MedianCommonModeCalculator() :
     //  theApvMask(mask_calc),
   alreadyUsedEvent(false)
 {
-  if (0) cout << "Constructing MedianCommonMode Calculator ..." << endl;
+  if (false) cout << "Constructing MedianCommonMode Calculator ..." << endl;
   //  cutToAvoidSignal = sig_cut;
 }
 //
 //  Destructor 
 //
 MedianCommonModeCalculator::~MedianCommonModeCalculator() {
-  if (0) cout << "Destructing TT6CommonModeCalculator " << endl;
+  if (false) cout << "Destructing TT6CommonModeCalculator " << endl;
 }
 //
 // Action :
@@ -26,7 +26,7 @@ ApvAnalysis::PedestalType MedianCommonModeCalculator::doIt
   ApvAnalysis::PedestalType out;
   calculateCommonMode(indat);
   int setNumber;
-  if(theCommonModeValues.size() >0) {
+  if(!theCommonModeValues.empty()) {
     for (unsigned int i=0; i<indat.size(); i++){
       setNumber = theTkCommonMode->topology().setOfStrip(i);
       out.push_back(indat[i] - theCommonModeValues[setNumber]);

--- a/CalibTracker/SiStripAPVAnalysis/src/SimpleNoiseCalculator.cc
+++ b/CalibTracker/SiStripAPVAnalysis/src/SimpleNoiseCalculator.cc
@@ -11,7 +11,7 @@ SimpleNoiseCalculator::SimpleNoiseCalculator() :
   numberOfEvents(0) ,
   alreadyUsedEvent(false)  
 {
-  if (0) cout << "Constructing SimpleNoiseCalculator " << endl;
+  if (false) cout << "Constructing SimpleNoiseCalculator " << endl;
   init();
 }
 //
@@ -19,7 +19,7 @@ SimpleNoiseCalculator::SimpleNoiseCalculator(int evnt_ini, bool use_DB) :
   numberOfEvents(0) ,
   alreadyUsedEvent(false)  
 {
-  if (0) cout << "Constructing SimpleNoiseCalculator " << endl;
+  if (false) cout << "Constructing SimpleNoiseCalculator " << endl;
   useDB_ = use_DB;
   eventsRequiredToCalibrate_ = evnt_ini;
   //  eventsRequiredToUpdate_    = evnt_iter;
@@ -41,7 +41,7 @@ void SimpleNoiseCalculator::init() {
 //  Destructor 
 //
 SimpleNoiseCalculator::~SimpleNoiseCalculator() {
-  if (0) cout << "Destructing SimpleNoiseCalculator " << endl;
+  if (false) cout << "Destructing SimpleNoiseCalculator " << endl;
 }
 //
 // Update the Status of Noise Calculation
@@ -105,7 +105,7 @@ void SimpleNoiseCalculator::updateNoise(ApvAnalysis::PedestalType& in){
 
         theNoise.push_back(static_cast<float>(rmsVal));
   
-        if (0) cout << " SimpleNoiseCalculator::updateNoise " 
+        if (false) cout << " SimpleNoiseCalculator::updateNoise " 
                     << theNoiseSum[i] << " " 
                     << theNoiseSqSum[i] << " "
                     << theEventPerStrip[i] << " "  

--- a/CalibTracker/SiStripAPVAnalysis/src/SimplePedestalCalculator.cc
+++ b/CalibTracker/SiStripAPVAnalysis/src/SimplePedestalCalculator.cc
@@ -10,7 +10,7 @@ SimplePedestalCalculator::SimplePedestalCalculator(int evnt_ini) :
                         numberOfEvents(0),
                         alreadyUsedEvent(false)
 {
-  if (0) cout << "Constructing SimplePedestalCalculator " << endl;
+  if (false) cout << "Constructing SimplePedestalCalculator " << endl;
   eventsRequiredToCalibrate = evnt_ini; 
   //  eventsRequiredToUpdate    = evnt_iter;
   //  cutToAvoidSignal          = sig_cut;
@@ -32,7 +32,7 @@ void SimplePedestalCalculator::init() {
 //  -- Destructor  
 //
 SimplePedestalCalculator::~SimplePedestalCalculator() {
-  if (0) cout << "Destructing SimplePedestalCalculator " << endl;
+  if (false) cout << "Destructing SimplePedestalCalculator " << endl;
 }
 
 

--- a/CalibTracker/SiStripAPVAnalysis/src/TT6ApvMask.cc
+++ b/CalibTracker/SiStripAPVAnalysis/src/TT6ApvMask.cc
@@ -17,7 +17,7 @@ TT6ApvMask::TT6ApvMask(int ctype, float ncut, float dcut, float tcut) {
 //  Destructor :
 //
 TT6ApvMask::~TT6ApvMask(){
-  if (0) cout << "Destructing TT6ApvMask " << endl;
+  if (false) cout << "Destructing TT6ApvMask " << endl;
 }
 //
 // Calculate the Mask 
@@ -41,7 +41,7 @@ void TT6ApvMask::calculateMask(const ApvAnalysis::PedestalType& in){
   avVal    = (effSize) ? sumVal/float(effSize):0.0;
   sqAvVal  = (effSize) ? sqSumVal/float(effSize):0.0;
   rmsVal   = (sqAvVal - avVal*avVal > 0.0) ? sqrt(sqAvVal - avVal*avVal):0.0; 
-  if (0) cout << " TT6ApvMask::calculateMask  Mean " << avVal <<
+  if (false) cout << " TT6ApvMask::calculateMask  Mean " << avVal <<
 	   " RMS " << rmsVal << " " <<  effSize << endl;       
   for (unsigned int i=0; i<in.size(); i++){
     if (defineNoisy( static_cast<float>(avVal),
@@ -65,7 +65,7 @@ bool TT6ApvMask::defineNoisy(float avrg,float rms,float noise){
   if (theCalculationFlag_ == 1){
    if ((noise-avrg) > theNoiseCut_*rms) {
      temp=true;
-     if (0) cout << " Mean " << avrg << " rms " << rms << " Noise " << noise << endl;
+     if (false) cout << " Mean " << avrg << " rms " << rms << " Noise " << noise << endl;
    }
   } else if (theCalculationFlag_ == 2){
     if ((noise-avrg) > avrg*theNoiseCut_) temp=true;

--- a/CalibTracker/SiStripAPVAnalysis/src/TT6CommonModeCalculator.cc
+++ b/CalibTracker/SiStripAPVAnalysis/src/TT6CommonModeCalculator.cc
@@ -7,14 +7,14 @@ TT6CommonModeCalculator::TT6CommonModeCalculator(TkNoiseCalculator* noise_calc, 
   theApvMask(mask_calc),
   alreadyUsedEvent(false)
 {
-  if (0) cout << "Constructing TT6CommonMode Calculator ..." << endl;
+  if (false) cout << "Constructing TT6CommonMode Calculator ..." << endl;
   cutToAvoidSignal = sig_cut;
 }
 //
 //  Destructor 
 //
 TT6CommonModeCalculator::~TT6CommonModeCalculator() {
-  if (0) cout << "Destructing TT6CommonModeCalculator " << endl;
+  if (false) cout << "Destructing TT6CommonModeCalculator " << endl;
 }
 //
 // Action :
@@ -26,7 +26,7 @@ ApvAnalysis::PedestalType TT6CommonModeCalculator::doIt
   ApvAnalysis::PedestalType out;
   calculateCommonMode(indat);
   int setNumber;
-  if(theCommonModeValues.size() >0) {
+  if(!theCommonModeValues.empty()) {
     for (unsigned int i=0; i<indat.size(); i++){
       setNumber = theTkCommonMode->topology().setOfStrip(i);
       out.push_back(indat[i] - theCommonModeValues[setNumber]);
@@ -48,7 +48,7 @@ void TT6CommonModeCalculator::calculateCommonMode(ApvAnalysis::PedestalType& ind
     ApvAnalysis::PedestalType strip_noise = theNoiseCalculator->noise();
     theCommonModeValues.clear();
     
-    if(strip_noise.size() > 0) {
+    if(!strip_noise.empty()) {
       int nSet = theTkCommonMode->topology().numberOfSets();
       for (int i=0; i<nSet; i++){
         int initial   = theTkCommonMode->topology().initialStrips()[i];

--- a/CalibTracker/SiStripAPVAnalysis/src/TT6NoiseCalculator.cc
+++ b/CalibTracker/SiStripAPVAnalysis/src/TT6NoiseCalculator.cc
@@ -11,7 +11,7 @@ TT6NoiseCalculator::TT6NoiseCalculator() :
   numberOfEvents(0) ,
   alreadyUsedEvent(false)  
 {
-  if (0) cout << "Constructing TT6NoiseCalculator " << endl;
+  if (false) cout << "Constructing TT6NoiseCalculator " << endl;
   init();
 }
 //
@@ -20,7 +20,7 @@ TT6NoiseCalculator::TT6NoiseCalculator(int evnt_ini,
   numberOfEvents(0) ,
   alreadyUsedEvent(false)  
 {
-  if (0) cout << "Constructing TT6NoiseCalculator " << endl;
+  if (false) cout << "Constructing TT6NoiseCalculator " << endl;
   eventsRequiredToCalibrate_ = evnt_ini;
   eventsRequiredToUpdate_    = evnt_iter;
   cutToAvoidSignal_          = sig_cut;
@@ -41,7 +41,7 @@ void TT6NoiseCalculator::init() {
 //  Destructor 
 //
 TT6NoiseCalculator::~TT6NoiseCalculator() {
-  if (0) cout << "Destructing TT6NoiseCalculator " << endl;
+  if (false) cout << "Destructing TT6NoiseCalculator " << endl;
 }
 //
 // Update the Status of Noise Calculation
@@ -105,7 +105,7 @@ void TT6NoiseCalculator::updateNoise(ApvAnalysis::PedestalType& in){
 
         theNoise.push_back(static_cast<float>(rmsVal));
   
-        if (0) cout << " TT6NoiseCalculator::updateNoise " 
+        if (false) cout << " TT6NoiseCalculator::updateNoise " 
                     << theNoiseSum[i] << " " 
                     << theNoiseSqSum[i] << " "
                     << theEventPerStrip[i] << " "  

--- a/CalibTracker/SiStripAPVAnalysis/src/TT6PedestalCalculator.cc
+++ b/CalibTracker/SiStripAPVAnalysis/src/TT6PedestalCalculator.cc
@@ -9,7 +9,7 @@ TT6PedestalCalculator::TT6PedestalCalculator(int evnt_ini,
                         numberOfEvents(0),
                         alreadyUsedEvent(false)
 {
-  if (0) cout << "Constructing TT6PedestalCalculator " << endl;
+  if (false) cout << "Constructing TT6PedestalCalculator " << endl;
   eventsRequiredToCalibrate = evnt_ini; 
   eventsRequiredToUpdate    = evnt_iter;
   cutToAvoidSignal          = sig_cut;
@@ -30,7 +30,7 @@ void TT6PedestalCalculator::init() {
 //  -- Destructor  
 //
 TT6PedestalCalculator::~TT6PedestalCalculator() {
-  if (0) cout << "Destructing TT6PedestalCalculator " << endl;
+  if (false) cout << "Destructing TT6PedestalCalculator " << endl;
 }
 //
 // -- Set Pedestal Update Status

--- a/CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h
+++ b/CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 #include <utility>
-#include <stdint.h>
+#include <cstdint>
 
 
 namespace APVGain {
@@ -30,7 +30,7 @@ namespace APVGain {
             subdetectorId(v1),subdetectorSide(v2),subdetectorPlane(v3),monitor(v4) {}
     };
 
-    std::vector<MonitorElement*> FetchMonitor(std::vector<APVmon>, uint32_t, const TrackerTopology* topo=0);
+    std::vector<MonitorElement*> FetchMonitor(std::vector<APVmon>, uint32_t, const TrackerTopology* topo=nullptr);
 };
 
 #endif

--- a/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLHarvester.h
+++ b/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLHarvester.h
@@ -44,15 +44,15 @@
 class SiStripGainsPCLHarvester : public  DQMEDHarvester {
    public:
       explicit SiStripGainsPCLHarvester(const edm::ParameterSet& ps);
-      virtual void beginRun(edm::Run const& run, edm::EventSetup const & isetup);
-      virtual void endRun(edm::Run const& run, edm::EventSetup const & isetup);
+      void beginRun(edm::Run const& run, edm::EventSetup const & isetup) override;
+      void endRun(edm::Run const& run, edm::EventSetup const & isetup) override;
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
 
       virtual void checkBookAPVColls(const edm::EventSetup& setup);
       virtual void checkAndRetrieveTopology(const edm::EventSetup& setup);
-      virtual void dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::IGetter& igetter_);
+      void dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::IGetter& igetter_) override;
 
       void gainQualityMonitor(DQMStore::IBooker& ibooker_, const MonitorElement* Charge_Vs_Index) const;
 

--- a/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
+++ b/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
@@ -80,9 +80,9 @@ public:
 
 private:
     virtual void beginJob() ;
-    virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &);   
-    virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&);
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;   
+    void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
     virtual void endJob() ;
     
     void processEvent(const TrackerTopology* topo); //what really does the job
@@ -145,34 +145,34 @@ private:
     //Event data
     unsigned int                       eventnumber    =0;
     unsigned int                       runnumber      =0;
-    const std::vector<bool>*           TrigTech       =0;  edm::EDGetTokenT<std::vector<bool>           > TrigTech_token_;
+    const std::vector<bool>*           TrigTech       =nullptr;  edm::EDGetTokenT<std::vector<bool>           > TrigTech_token_;
 
     // Track data
-    const std::vector<double>*         trackchi2ndof  =0;  edm::EDGetTokenT<std::vector<double>         > trackchi2ndof_token_;
-    const std::vector<float>*          trackp         =0;  edm::EDGetTokenT<std::vector<float>          > trackp_token_;
-    const std::vector<float>*          trackpt        =0;  edm::EDGetTokenT<std::vector<float>          > trackpt_token_;
-    const std::vector<double>*         tracketa       =0;  edm::EDGetTokenT<std::vector<double>         > tracketa_token_;
-    const std::vector<double>*         trackphi       =0;  edm::EDGetTokenT<std::vector<double>         > trackphi_token_;
-    const std::vector<unsigned int>*   trackhitsvalid =0;  edm::EDGetTokenT<std::vector<unsigned int>   > trackhitsvalid_token_;
-    const std::vector<int>*            trackalgo      =0;  edm::EDGetTokenT<std::vector<int>   >          trackalgo_token_;
+    const std::vector<double>*         trackchi2ndof  =nullptr;  edm::EDGetTokenT<std::vector<double>         > trackchi2ndof_token_;
+    const std::vector<float>*          trackp         =nullptr;  edm::EDGetTokenT<std::vector<float>          > trackp_token_;
+    const std::vector<float>*          trackpt        =nullptr;  edm::EDGetTokenT<std::vector<float>          > trackpt_token_;
+    const std::vector<double>*         tracketa       =nullptr;  edm::EDGetTokenT<std::vector<double>         > tracketa_token_;
+    const std::vector<double>*         trackphi       =nullptr;  edm::EDGetTokenT<std::vector<double>         > trackphi_token_;
+    const std::vector<unsigned int>*   trackhitsvalid =nullptr;  edm::EDGetTokenT<std::vector<unsigned int>   > trackhitsvalid_token_;
+    const std::vector<int>*            trackalgo      =nullptr;  edm::EDGetTokenT<std::vector<int>   >          trackalgo_token_;
 
     // CalibTree data
-    const std::vector<int>*            trackindex     =0;  edm::EDGetTokenT<std::vector<int>            > trackindex_token_;
-    const std::vector<unsigned int>*   rawid          =0;  edm::EDGetTokenT<std::vector<unsigned int>   > rawid_token_;
-    const std::vector<double>*         localdirx      =0;  edm::EDGetTokenT<std::vector<double>         > localdirx_token_;
-    const std::vector<double>*         localdiry      =0;  edm::EDGetTokenT<std::vector<double>         > localdiry_token_;
-    const std::vector<double>*         localdirz      =0;  edm::EDGetTokenT<std::vector<double>         > localdirz_token_;
-    const std::vector<unsigned short>* firststrip     =0;  edm::EDGetTokenT<std::vector<unsigned short> > firststrip_token_;
-    const std::vector<unsigned short>* nstrips        =0;  edm::EDGetTokenT<std::vector<unsigned short> > nstrips_token_;
-    const std::vector<bool>*           saturation     =0;  edm::EDGetTokenT<std::vector<bool>           > saturation_token_;
-    const std::vector<bool>*           overlapping    =0;  edm::EDGetTokenT<std::vector<bool>           > overlapping_token_;
-    const std::vector<bool>*           farfromedge    =0;  edm::EDGetTokenT<std::vector<bool>           > farfromedge_token_;
-    const std::vector<unsigned int>*   charge         =0;  edm::EDGetTokenT<std::vector<unsigned int>   > charge_token_;
-    const std::vector<double>*         path           =0;  edm::EDGetTokenT<std::vector<double>         > path_token_;
-    const std::vector<double>*         chargeoverpath =0;  edm::EDGetTokenT<std::vector<double>         > chargeoverpath_token_;
-    const std::vector<unsigned char>*  amplitude      =0;  edm::EDGetTokenT<std::vector<unsigned char>  > amplitude_token_;
-    const std::vector<double>*         gainused       =0;  edm::EDGetTokenT<std::vector<double>         > gainused_token_;
-    const std::vector<double>*         gainusedTick   =0;  edm::EDGetTokenT<std::vector<double>         > gainusedTick_token_;
+    const std::vector<int>*            trackindex     =nullptr;  edm::EDGetTokenT<std::vector<int>            > trackindex_token_;
+    const std::vector<unsigned int>*   rawid          =nullptr;  edm::EDGetTokenT<std::vector<unsigned int>   > rawid_token_;
+    const std::vector<double>*         localdirx      =nullptr;  edm::EDGetTokenT<std::vector<double>         > localdirx_token_;
+    const std::vector<double>*         localdiry      =nullptr;  edm::EDGetTokenT<std::vector<double>         > localdiry_token_;
+    const std::vector<double>*         localdirz      =nullptr;  edm::EDGetTokenT<std::vector<double>         > localdirz_token_;
+    const std::vector<unsigned short>* firststrip     =nullptr;  edm::EDGetTokenT<std::vector<unsigned short> > firststrip_token_;
+    const std::vector<unsigned short>* nstrips        =nullptr;  edm::EDGetTokenT<std::vector<unsigned short> > nstrips_token_;
+    const std::vector<bool>*           saturation     =nullptr;  edm::EDGetTokenT<std::vector<bool>           > saturation_token_;
+    const std::vector<bool>*           overlapping    =nullptr;  edm::EDGetTokenT<std::vector<bool>           > overlapping_token_;
+    const std::vector<bool>*           farfromedge    =nullptr;  edm::EDGetTokenT<std::vector<bool>           > farfromedge_token_;
+    const std::vector<unsigned int>*   charge         =nullptr;  edm::EDGetTokenT<std::vector<unsigned int>   > charge_token_;
+    const std::vector<double>*         path           =nullptr;  edm::EDGetTokenT<std::vector<double>         > path_token_;
+    const std::vector<double>*         chargeoverpath =nullptr;  edm::EDGetTokenT<std::vector<double>         > chargeoverpath_token_;
+    const std::vector<unsigned char>*  amplitude      =nullptr;  edm::EDGetTokenT<std::vector<unsigned char>  > amplitude_token_;
+    const std::vector<double>*         gainused       =nullptr;  edm::EDGetTokenT<std::vector<double>         > gainused_token_;
+    const std::vector<double>*         gainusedTick   =nullptr;  edm::EDGetTokenT<std::vector<double>         > gainusedTick_token_;
 
     std::string EventPrefix_; //("");
     std::string EventSuffix_; //("");

--- a/CalibTracker/SiStripChannelGain/plugins/DeDxDiscriminatorLearner.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/DeDxDiscriminatorLearner.cc
@@ -73,7 +73,7 @@ void  DeDxDiscriminatorLearner::algoBeginJob(const edm::EventSetup& iSetup)
 {
    Charge_Vs_Path = new TH3F ("Charge_Vs_Path"     , "Charge_Vs_Path" , P_NBins, P_Min, P_Max, Path_NBins, Path_Min, Path_Max, Charge_NBins, Charge_Min, Charge_Max);
 
-   if(useCalibration && calibGains.size()==0){
+   if(useCalibration && calibGains.empty()){
       edm::ESHandle<TrackerGeometry> tkGeom;
       iSetup.get<TrackerDigiGeometryRecord>().get( tkGeom );
       m_off = tkGeom->offsetDU(GeomDetEnumerators::PixelBarrel); //index start at the first pixel
@@ -219,25 +219,25 @@ void DeDxDiscriminatorLearner::algoAnalyzeTheTree(const edm::EventSetup& iSetup)
       TString CalibPrefix("GainCalibration");
       TString CalibSuffix("");
 
-      unsigned int                 eventnumber    = 0;    tree->SetBranchAddress(EventPrefix + "event"          + EventSuffix, &eventnumber   , NULL);
-      unsigned int                 runnumber      = 0;    tree->SetBranchAddress(EventPrefix + "run"            + EventSuffix, &runnumber     , NULL);
-      std::vector<bool>*           TrigTech       = 0;    tree->SetBranchAddress(EventPrefix + "TrigTech"       + EventSuffix, &TrigTech   , NULL);
+      unsigned int                 eventnumber    = 0;    tree->SetBranchAddress(EventPrefix + "event"          + EventSuffix, &eventnumber   , nullptr);
+      unsigned int                 runnumber      = 0;    tree->SetBranchAddress(EventPrefix + "run"            + EventSuffix, &runnumber     , nullptr);
+      std::vector<bool>*           TrigTech       = nullptr;    tree->SetBranchAddress(EventPrefix + "TrigTech"       + EventSuffix, &TrigTech   , nullptr);
 
-      std::vector<double>*         trackchi2ndof  = 0;    tree->SetBranchAddress(TrackPrefix + "chi2ndof"       + TrackSuffix, &trackchi2ndof , NULL);
-      std::vector<float>*          trackp         = 0;    tree->SetBranchAddress(TrackPrefix + "momentum"       + TrackSuffix, &trackp        , NULL);
-      std::vector<float>*          trackpt        = 0;    tree->SetBranchAddress(TrackPrefix + "pt"             + TrackSuffix, &trackpt       , NULL);
-      std::vector<double>*         tracketa       = 0;    tree->SetBranchAddress(TrackPrefix + "eta"            + TrackSuffix, &tracketa      , NULL);
-      std::vector<double>*         trackphi       = 0;    tree->SetBranchAddress(TrackPrefix + "phi"            + TrackSuffix, &trackphi      , NULL);
-      std::vector<unsigned int>*   trackhitsvalid = 0;    tree->SetBranchAddress(TrackPrefix + "hitsvalid"      + TrackSuffix, &trackhitsvalid, NULL);
+      std::vector<double>*         trackchi2ndof  = nullptr;    tree->SetBranchAddress(TrackPrefix + "chi2ndof"       + TrackSuffix, &trackchi2ndof , nullptr);
+      std::vector<float>*          trackp         = nullptr;    tree->SetBranchAddress(TrackPrefix + "momentum"       + TrackSuffix, &trackp        , nullptr);
+      std::vector<float>*          trackpt        = nullptr;    tree->SetBranchAddress(TrackPrefix + "pt"             + TrackSuffix, &trackpt       , nullptr);
+      std::vector<double>*         tracketa       = nullptr;    tree->SetBranchAddress(TrackPrefix + "eta"            + TrackSuffix, &tracketa      , nullptr);
+      std::vector<double>*         trackphi       = nullptr;    tree->SetBranchAddress(TrackPrefix + "phi"            + TrackSuffix, &trackphi      , nullptr);
+      std::vector<unsigned int>*   trackhitsvalid = nullptr;    tree->SetBranchAddress(TrackPrefix + "hitsvalid"      + TrackSuffix, &trackhitsvalid, nullptr);
 
-      std::vector<int>*            trackindex     = 0;    tree->SetBranchAddress(CalibPrefix + "trackindex"     + CalibSuffix, &trackindex    , NULL);
-      std::vector<unsigned int>*   rawid          = 0;    tree->SetBranchAddress(CalibPrefix + "rawid"          + CalibSuffix, &rawid         , NULL);
-      std::vector<unsigned short>* firststrip     = 0;    tree->SetBranchAddress(CalibPrefix + "firststrip"     + CalibSuffix, &firststrip    , NULL);
-      std::vector<unsigned short>* nstrips        = 0;    tree->SetBranchAddress(CalibPrefix + "nstrips"        + CalibSuffix, &nstrips       , NULL);
-      std::vector<unsigned int>*   charge         = 0;    tree->SetBranchAddress(CalibPrefix + "charge"         + CalibSuffix, &charge        , NULL);
-      std::vector<float>*          path           = 0;    tree->SetBranchAddress(CalibPrefix + "path"           + CalibSuffix, &path          , NULL);
-      std::vector<unsigned char>*  amplitude      = 0;    tree->SetBranchAddress(CalibPrefix + "amplitude"      + CalibSuffix, &amplitude     , NULL);
-      std::vector<double>*         gainused       = 0;    tree->SetBranchAddress(CalibPrefix + "gainused"       + CalibSuffix, &gainused      , NULL);
+      std::vector<int>*            trackindex     = nullptr;    tree->SetBranchAddress(CalibPrefix + "trackindex"     + CalibSuffix, &trackindex    , nullptr);
+      std::vector<unsigned int>*   rawid          = nullptr;    tree->SetBranchAddress(CalibPrefix + "rawid"          + CalibSuffix, &rawid         , nullptr);
+      std::vector<unsigned short>* firststrip     = nullptr;    tree->SetBranchAddress(CalibPrefix + "firststrip"     + CalibSuffix, &firststrip    , nullptr);
+      std::vector<unsigned short>* nstrips        = nullptr;    tree->SetBranchAddress(CalibPrefix + "nstrips"        + CalibSuffix, &nstrips       , nullptr);
+      std::vector<unsigned int>*   charge         = nullptr;    tree->SetBranchAddress(CalibPrefix + "charge"         + CalibSuffix, &charge        , nullptr);
+      std::vector<float>*          path           = nullptr;    tree->SetBranchAddress(CalibPrefix + "path"           + CalibSuffix, &path          , nullptr);
+      std::vector<unsigned char>*  amplitude      = nullptr;    tree->SetBranchAddress(CalibPrefix + "amplitude"      + CalibSuffix, &amplitude     , nullptr);
+      std::vector<double>*         gainused       = nullptr;    tree->SetBranchAddress(CalibPrefix + "gainused"       + CalibSuffix, &gainused      , nullptr);
 
       printf("Number of Events = %i + %i = %i\n",NEvent,(unsigned int)tree->GetEntries(),(unsigned int)(NEvent+tree->GetEntries()));NEvent+=tree->GetEntries();
       printf("Progressing Bar              :0%%       20%%       40%%       60%%       80%%       100%%\n");

--- a/CalibTracker/SiStripChannelGain/plugins/DeDxDiscriminatorLearner.h
+++ b/CalibTracker/SiStripChannelGain/plugins/DeDxDiscriminatorLearner.h
@@ -23,17 +23,17 @@ class DeDxDiscriminatorLearner : public ConditionDBWriter<PhysicsTools::Calibrat
 public:
 
   explicit DeDxDiscriminatorLearner(const edm::ParameterSet&);
-  ~DeDxDiscriminatorLearner();
+  ~DeDxDiscriminatorLearner() override;
 
 private:
-  virtual void algoBeginJob(const edm::EventSetup&) ;
-  virtual void algoAnalyze(const edm::Event&, const edm::EventSetup&);
-  virtual void algoEndJob();
+  void algoBeginJob(const edm::EventSetup&) override ;
+  void algoAnalyze(const edm::Event&, const edm::EventSetup&) override;
+  void algoEndJob() override;
 
   void         processHit(const TrackingRecHit* recHit, float trackMomentum, float& cosine,  const TrajectoryStateOnSurface& trajState);
   void         algoAnalyzeTheTree(const edm::EventSetup& iSetup);
 
-  PhysicsTools::Calibration::HistogramD3D * getNewObject();
+  PhysicsTools::Calibration::HistogramD3D * getNewObject() override;
 
   // ----------member data ---------------------------
   edm::EDGetTokenT<TrajTrackAssociationCollection>   m_trajTrackAssociationTag;

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainCosmicCalculator.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainCosmicCalculator.cc
@@ -105,7 +105,7 @@ void SiStripGainCosmicCalculator::algoBeginJob(const edm::EventSetup& iSetup)
    // get tracker geometry and find nr. of apv pairs for each active detector 
    edm::ESHandle<TrackerGeometry> tkGeom; iSetup.get<TrackerDigiGeometryRecord>().get( tkGeom );     
    for(TrackerGeometry::DetContainer::const_iterator it = tkGeom->dets().begin(); it != tkGeom->dets().end(); it++){ // loop over detector modules
-     if( dynamic_cast<const StripGeomDetUnit*>((*it))!=0){
+     if( dynamic_cast<const StripGeomDetUnit*>((*it))!=nullptr){
        uint32_t detid= ((*it)->geographicalId()).rawId();
        // get thickness for all detector modules, not just for active, this is strange 
        double module_thickness = (*it)->surface().bounds().thickness(); // get thickness of detector from GeomDet (DetContainer == vector<GeomDet*>)
@@ -231,7 +231,7 @@ std::pair<double,double> SiStripGainCosmicCalculator::getPeakOfLandau( TH1F * in
   double chi2overndf = chi2 / ndf;
   // in case things went wrong, try to refit in smaller range
   if(adcs< 2. || (error/adcs)>1.8 ){
-     inputHisto->Fit(fitfunction.get(),"0Q",0,0.,400.);
+     inputHisto->Fit(fitfunction.get(),"0Q",nullptr,0.,400.);
      std::cout<<"refitting landau for histogram "<<inputHisto->GetTitle()<<std::endl;
      std::cout<<"initial error/adcs ="<<error<<" / "<<adcs<<std::endl;
      std::cout<<"new     error/adcs ="<<fitfunction->GetParError(1)<<" / "<<fitfunction->GetParameter("MPV")<<std::endl;
@@ -254,7 +254,7 @@ double SiStripGainCosmicCalculator::moduleWidth(const uint32_t detid, const edm:
   edm::ESHandle<TrackerGeometry> tkGeom; iSetup->get<TrackerDigiGeometryRecord>().get( tkGeom );     
   double module_width=0.;
   const GeomDetUnit* it = tkGeom->idToDetUnit(DetId(detid));
-  if (dynamic_cast<const StripGeomDetUnit*>(it)==0 && dynamic_cast<const PixelGeomDetUnit*>(it)==0) {
+  if (dynamic_cast<const StripGeomDetUnit*>(it)==nullptr && dynamic_cast<const PixelGeomDetUnit*>(it)==nullptr) {
     std::cout << "this detID doesn't seem to belong to the Tracker" << std::endl;
   }else{
     module_width = it->surface().bounds().width();
@@ -268,7 +268,7 @@ double SiStripGainCosmicCalculator::moduleThickness(const uint32_t detid, const 
   edm::ESHandle<TrackerGeometry> tkGeom; iSetup->get<TrackerDigiGeometryRecord>().get( tkGeom );
   double module_thickness=0.;
   const GeomDetUnit* it = tkGeom->idToDetUnit(DetId(detid));
-  if (dynamic_cast<const StripGeomDetUnit*>(it)==0 && dynamic_cast<const PixelGeomDetUnit*>(it)==0) {
+  if (dynamic_cast<const StripGeomDetUnit*>(it)==nullptr && dynamic_cast<const PixelGeomDetUnit*>(it)==nullptr) {
     std::cout << "this detID doesn't seem to belong to the Tracker" << std::endl;
   }else{
     module_thickness = it->surface().bounds().thickness();

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainCosmicCalculator.h
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainCosmicCalculator.h
@@ -25,12 +25,12 @@ class TrackerTopology;
 class SiStripGainCosmicCalculator : public ConditionDBWriter<SiStripApvGain> {
 public:
   explicit SiStripGainCosmicCalculator(const edm::ParameterSet&);
-  ~SiStripGainCosmicCalculator();
+  ~SiStripGainCosmicCalculator() override;
 private:
-  void algoAnalyze(const edm::Event &, const edm::EventSetup &);
-  void algoBeginJob(const edm::EventSetup&);
-  void algoEndJob();
-  SiStripApvGain * getNewObject();
+  void algoAnalyze(const edm::Event &, const edm::EventSetup &) override;
+  void algoBeginJob(const edm::EventSetup&) override;
+  void algoEndJob() override;
+  SiStripApvGain * getNewObject() override;
 private:
   std::pair<double,double> getPeakOfLandau( TH1F * inputHisto );
   double moduleWidth(const uint32_t detid, const edm::EventSetup* iSetup);

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromAsciiFile.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromAsciiFile.cc
@@ -36,12 +36,12 @@ SiStripApvGain * SiStripGainFromAsciiFile::getNewObject(){
   FILE* infile = fopen (Asciifilename_.c_str(), "r");
   char line[4096];
   if (infile){
-    while(fgets(line, 4096, infile)!=NULL){
+    while(fgets(line, 4096, infile)!=nullptr){
        uint32_t detid;
        ModuleGain MG;
        MG.apv[0] = 0.0;  MG.apv[1] = 0.0; MG.apv[2] = 0.0; MG.apv[3] = 0.0; MG.apv[4] = 0.0; MG.apv[5] = 0.0;
        char* pch=strtok(line," "); int Arg=0;
-       while (pch!=NULL){
+       while (pch!=nullptr){
             if(Arg==0){
                sscanf(pch, "%d", &detid);
             }else if(Arg<=6){
@@ -49,7 +49,7 @@ SiStripApvGain * SiStripGainFromAsciiFile::getNewObject(){
             }else{
                //nothing to do here
             }       
-            pch=strtok(NULL," ");Arg++;
+            pch=strtok(nullptr," ");Arg++;
       }
       ss << detid << " " <<  MG.apv[0] << " " <<  MG.apv[1] << " " <<  MG.apv[2] << " " <<  MG.apv[3] << " " <<  MG.apv[4] << " " <<  MG.apv[5] << std::endl;
       GainsMap.insert(std::pair<unsigned int,ModuleGain>(detid,MG));
@@ -65,7 +65,7 @@ SiStripApvGain * SiStripGainFromAsciiFile::getNewObject(){
 
   SiStripDetInfoFileReader reader(fp_.fullPath());
   
-  const std::vector<uint32_t> DetIds = reader.getAllDetIds();
+  const std::vector<uint32_t>& DetIds = reader.getAllDetIds();
   
   ss.str("");
   ss << "[SiStripGainFromAsciiFile::getNewObject]\n Filling SiStripApvGain object";

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromAsciiFile.h
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromAsciiFile.h
@@ -14,11 +14,11 @@ class SiStripGainFromAsciiFile : public ConditionDBWriter<SiStripApvGain> {
 public:
 
   explicit SiStripGainFromAsciiFile(const edm::ParameterSet&);
-  ~SiStripGainFromAsciiFile();
+  ~SiStripGainFromAsciiFile() override;
 
 private:
 
-  SiStripApvGain * getNewObject();
+  SiStripApvGain * getNewObject() override;
 
 private:
 

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
@@ -80,15 +80,15 @@ struct stAPVGain{unsigned int Index; int DetId; int APVId; int SubDet; float Eta
 class SiStripGainFromData : public ConditionDBWriter<SiStripApvGain> {
    public:
       explicit SiStripGainFromData(const edm::ParameterSet&);
-      ~SiStripGainFromData();
+      ~SiStripGainFromData() override;
 
 
    private:
-      virtual void algoBeginJob(const edm::EventSetup&) override ;
-      virtual void algoEndJob() override ;
-      virtual void algoBeginRun(const edm::Run &, const edm::EventSetup &) override;
+      void algoBeginJob(const edm::EventSetup&) override ;
+      void algoEndJob() override ;
+      void algoBeginRun(const edm::Run &, const edm::EventSetup &) override;
 //      virtual void algoBeginRun(const edm::Event& iEvent, const edm::EventSetup& iSetup);
-      virtual void algoAnalyze(const edm::Event &, const edm::EventSetup &) override;
+      void algoAnalyze(const edm::Event &, const edm::EventSetup &) override;
 
       SiStripApvGain* getNewObject() override;
       DQMStore* dqmStore_;
@@ -567,7 +567,7 @@ SiStripGainFromData::algoEndJob() {
    if( strcmp(AlgoMode.c_str(),"WriteOnDB")==0 || strcmp(AlgoMode.c_str(),"Merge")==0){
       TH1::AddDirectory(kTRUE);
 
-      TFile* file = NULL;
+      TFile* file = nullptr;
       for(unsigned int f=0;f<VInputFiles.size();f++){
          printf("Loading New Input File : %s\n", VInputFiles[f].c_str());
  	 if(CheckIfFileExist){
@@ -637,7 +637,7 @@ SiStripGainFromData::algoEndJob() {
 
 
    if( strcmp(AlgoMode.c_str(),"MultiJob")!=0 ){
-      TH1D* Proj = NULL;
+      TH1D* Proj = nullptr;
       double* FitResults = new double[5];
       I=0;
       for(auto it = APVsColl.begin();it!=APVsColl.end();it++){
@@ -648,7 +648,7 @@ SiStripGainFromData::algoEndJob() {
          int bin = APV_Charge->GetXaxis()->FindBin(APV->Index);
          Proj = APV_Charge->ProjectionY(" ",bin,bin,"e");
          Proj = (TH1D*)Proj->Clone();
-         if(Proj==NULL)continue;
+         if(Proj==nullptr)continue;
 
 	 // ADD PROJECTTIONS COMMING FROM THE SECOND APV IN THE PAIR
          if(CalibrationLevel==1){
@@ -662,7 +662,7 @@ SiStripGainFromData::algoEndJob() {
 
             int bin2 = APV_Charge->GetXaxis()->FindBin(APV2->Index);
             TH1D* Proj2 = APV_Charge->ProjectionY(" ",bin2,bin2,"e");
-            if(Proj2!=NULL){
+            if(Proj2!=nullptr){
 		Proj->Add(Proj2,1);
 	    }
          }else if(CalibrationLevel>1){
@@ -675,7 +675,7 @@ SiStripGainFromData::algoEndJob() {
 
                 int bin2 = APV_Charge->GetXaxis()->FindBin(APV2->Index);
                 TH1D* Proj2 = APV_Charge->ProjectionY(" ",bin2,bin2,"e");
-                if(Proj2!=NULL){
+                if(Proj2!=nullptr){
 //                   printf("%8i %i--> %4.0f + %4.0f\n",APV2->DetId, APV2->APVId, Proj->GetEntries(), Proj2->GetEntries());
                    Proj->Add(Proj2,1);
                 }
@@ -752,7 +752,7 @@ SiStripGainFromData::algoEndJob() {
 
 
          Proj = APV_PathLength->ProjectionY(" ",bin,bin,"e");
-         if(Proj==NULL)continue;
+         if(Proj==nullptr)continue;
 
          APV_PathLengthM->SetBinContent(APV->Index, Proj->GetMean(1)      );
          APV_PathLengthM->SetBinError  (APV->Index, Proj->GetMeanError(1) );
@@ -964,7 +964,7 @@ SiStripGainFromData::algoEndJob() {
    }
 
    dqmStore_->cd();
-   dqmStore_->save(OutputHistos.c_str());
+   dqmStore_->save(OutputHistos);
 
 }
 
@@ -1198,7 +1198,7 @@ bool SiStripGainFromData::IsFarFromBorder(TrajectoryStateOnSurface trajState, co
   LocalError  HitLocalError = trajState.localError().positionError() ;
 
   const GeomDetUnit* it = tkGeom->idToDetUnit(DetId(detid));
-  if (dynamic_cast<const StripGeomDetUnit*>(it)==0 && dynamic_cast<const PixelGeomDetUnit*>(it)==0) {
+  if (dynamic_cast<const StripGeomDetUnit*>(it)==nullptr && dynamic_cast<const PixelGeomDetUnit*>(it)==nullptr) {
      std::cout << "this detID doesn't seem to belong to the Tracker" << std::endl;
      return false;
   }
@@ -1288,14 +1288,14 @@ SiStripApvGain* SiStripGainFromData::getNewObject()
 
 
    SiStripApvGain * obj = new SiStripApvGain();
-   std::vector<float>* theSiStripVector = NULL;
+   std::vector<float>* theSiStripVector = nullptr;
    int PreviousDetId = -1; 
    for(unsigned int a=0;a<APVsCollOrdered.size();a++)
    {
       stAPVGain* APV = APVsCollOrdered[a];
-      if(APV==NULL){ printf("Bug\n"); continue; }
+      if(APV==nullptr){ printf("Bug\n"); continue; }
       if(APV->DetId != PreviousDetId){
-         if(theSiStripVector!=NULL){
+         if(theSiStripVector!=nullptr){
 	    SiStripApvGain::Range range(theSiStripVector->begin(),theSiStripVector->end());
 	    if ( !obj->put(PreviousDetId,range) )  printf("Bug to put detId = %i\n",PreviousDetId);
 	 }
@@ -1308,7 +1308,7 @@ SiStripApvGain* SiStripGainFromData::getNewObject()
 //      theSiStripVector->push_back(APV->Gain);
    }
 
-   if(theSiStripVector!=NULL){
+   if(theSiStripVector!=nullptr){
       SiStripApvGain::Range range(theSiStripVector->begin(),theSiStripVector->end());
       if ( !obj->put(PreviousDetId,range) )  printf("Bug to put detId = %i\n",PreviousDetId);
    }

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainRandomCalculator.h
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainRandomCalculator.h
@@ -28,13 +28,13 @@ class SiStripGainRandomCalculator : public ConditionDBWriter<SiStripApvGain> {
 public:
 
   explicit SiStripGainRandomCalculator(const edm::ParameterSet&);
-  ~SiStripGainRandomCalculator();
+  ~SiStripGainRandomCalculator() override;
 
 private:
 
-  void algoAnalyze(const edm::Event &, const edm::EventSetup &);
+  void algoAnalyze(const edm::Event &, const edm::EventSetup &) override;
 
-  SiStripApvGain * getNewObject();
+  SiStripApvGain * getNewObject() override;
 
 private:
 

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
@@ -117,13 +117,13 @@ void SiStripGainsPCLHarvester::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::
   std::string DQM_dir = m_DQMdir;
    
   std::string stag =  *(std::find(dqm_tag_.begin(), dqm_tag_.end(),m_calibrationMode));
-  if(stag.size()!=0 && stag[0]!='_') stag.insert(0,1,'_');
+  if(!stag.empty() && stag[0]!='_') stag.insert(0,1,'_');
 
   std::string cvi      = DQM_dir + std::string("/Charge_Vs_Index") + stag;
      
-  MonitorElement* Charge_Vs_Index           = igetter_.get(cvi.c_str());
+  MonitorElement* Charge_Vs_Index           = igetter_.get(cvi);
   
-  if (Charge_Vs_Index==0) {
+  if (Charge_Vs_Index==nullptr) {
     edm::LogError("SiStripGainsPCLHarvester") << "Harvesting: could not retrieve " << cvi.c_str()
 					      << ", statistics will not be summed!" << std::endl;
   } else {
@@ -228,7 +228,7 @@ SiStripGainsPCLHarvester::gainQualityMonitor(DQMStore::IBooker& ibooker_, const 
   for(unsigned int a=0;a<APVsCollOrdered.size();a++){
 
     std::shared_ptr<stAPVGain> APV = APVsCollOrdered[a];
-    if(APV==NULL)continue;
+    if(APV==nullptr)continue;
 
     unsigned int  Index        = APV->Index;
     unsigned int  SubDet       = APV->SubDet;
@@ -339,11 +339,11 @@ void
 SiStripGainsPCLHarvester::algoComputeMPVandGain(const MonitorElement* Charge_Vs_Index) {
 
   unsigned int I=0;
-  TH1F* Proj = NULL;
+  TH1F* Proj = nullptr;
   double FitResults[6];
   double MPVmean = 300;
 
-  if ( Charge_Vs_Index==0 ) {
+  if ( Charge_Vs_Index==nullptr ) {
     edm::LogError("SiStripGainsPCLHarvester") << "Harvesting: could not execute algoComputeMPVandGain method because "
 					      << m_calibrationMode <<" statistics cannot be retrieved.\n"
 					      << "Please check if input contains " 
@@ -578,7 +578,7 @@ bool SiStripGainsPCLHarvester::produceTagFilter(const MonitorElement* Charge_Vs_
   // The goal of this function is to check wether or not there is enough statistics
   // to produce a meaningful tag for the DB
 
-  if( Charge_Vs_Index==0 ) {
+  if( Charge_Vs_Index==nullptr ) {
     edm::LogError("SiStripGainsPCLHarvester") << "produceTagFilter -> Return false: could not retrieve the "
 					      << m_calibrationMode <<" statistics.\n"
 					      << "Please check if input contains " 
@@ -620,7 +620,7 @@ SiStripGainsPCLHarvester::getNewObject(const MonitorElement* Charge_Vs_Index)
   unsigned int PreviousDetId = 0; 
   for(unsigned int a=0;a<APVsCollOrdered.size();a++){
     std::shared_ptr<stAPVGain> APV = APVsCollOrdered[a];
-    if(APV==NULL){ printf("Bug\n"); continue; }
+    if(APV==nullptr){ printf("Bug\n"); continue; }
     if(APV->SubDet<=2)continue;
     if(APV->DetId != PreviousDetId){
       if(!theSiStripVector.empty()){

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
@@ -47,15 +47,15 @@ SiStripGainsPCLWorker::SiStripGainsPCLWorker(const edm::ParameterSet& iConfig) :
   dqm_tag_.push_back( "IsoMuon0T" );     // statistic collection from Isolated Muon @ 0 T
   dqm_tag_.push_back( "Harvest" );       // statistic collection: Harvest
   
-  Charge_Vs_Index.insert( Charge_Vs_Index.begin(), dqm_tag_.size(), 0);
-  Charge_Vs_PathlengthTIB.insert( Charge_Vs_PathlengthTIB.begin(), dqm_tag_.size(), 0);
-  Charge_Vs_PathlengthTOB.insert( Charge_Vs_PathlengthTOB.begin(), dqm_tag_.size(), 0);
-  Charge_Vs_PathlengthTIDP.insert( Charge_Vs_PathlengthTIDP.begin(), dqm_tag_.size(), 0);
-  Charge_Vs_PathlengthTIDM.insert( Charge_Vs_PathlengthTIDM.begin(), dqm_tag_.size(), 0);
-  Charge_Vs_PathlengthTECP1.insert( Charge_Vs_PathlengthTECP1.begin(), dqm_tag_.size(), 0);
-  Charge_Vs_PathlengthTECP2.insert( Charge_Vs_PathlengthTECP2.begin(), dqm_tag_.size(), 0);
-  Charge_Vs_PathlengthTECM1.insert( Charge_Vs_PathlengthTECM1.begin(), dqm_tag_.size(), 0);
-  Charge_Vs_PathlengthTECM2.insert( Charge_Vs_PathlengthTECM2.begin(), dqm_tag_.size(), 0);
+  Charge_Vs_Index.insert( Charge_Vs_Index.begin(), dqm_tag_.size(), nullptr);
+  Charge_Vs_PathlengthTIB.insert( Charge_Vs_PathlengthTIB.begin(), dqm_tag_.size(), nullptr);
+  Charge_Vs_PathlengthTOB.insert( Charge_Vs_PathlengthTOB.begin(), dqm_tag_.size(), nullptr);
+  Charge_Vs_PathlengthTIDP.insert( Charge_Vs_PathlengthTIDP.begin(), dqm_tag_.size(), nullptr);
+  Charge_Vs_PathlengthTIDM.insert( Charge_Vs_PathlengthTIDM.begin(), dqm_tag_.size(), nullptr);
+  Charge_Vs_PathlengthTECP1.insert( Charge_Vs_PathlengthTECP1.begin(), dqm_tag_.size(), nullptr);
+  Charge_Vs_PathlengthTECP2.insert( Charge_Vs_PathlengthTECP2.begin(), dqm_tag_.size(), nullptr);
+  Charge_Vs_PathlengthTECM1.insert( Charge_Vs_PathlengthTECM1.begin(), dqm_tag_.size(), nullptr);
+  Charge_Vs_PathlengthTECM2.insert( Charge_Vs_PathlengthTECM2.begin(), dqm_tag_.size(), nullptr);
 
   // configure token for gathering the ntuple variables 
   edm::ParameterSet swhallowgain_pset = iConfig.getUntrackedParameter<edm::ParameterSet>("gain");
@@ -502,7 +502,7 @@ SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
   ibooker.setCurrentFolder(dqm_dir);
  
   std::string stag(tag);
-  if(stag.size()!=0 && stag[0]!='_') stag.insert(0,1,'_');
+  if(!stag.empty() && stag[0]!='_') stag.insert(0,1,'_');
   
   std::string cvi      = std::string("Charge_Vs_Index") + stag;
   std::string cvpTIB   = std::string("Charge_Vs_PathlengthTIB")   + stag;

--- a/CalibTracker/SiStripCommon/interface/Book.h
+++ b/CalibTracker/SiStripCommon/interface/Book.h
@@ -32,7 +32,7 @@ class Book {
   
  public:
   
-  Book() : title_(""), directory(0) {}
+  Book() : title_(""), directory(nullptr) {}
   Book(string_t t) : title_(t), directory(new TDirectory(t.c_str(),t.c_str())) {}
 
   string_t& title() const { return title_;}
@@ -41,7 +41,7 @@ class Book {
 
   TH1* book(string_t name, TH1*const hist)   { book_[name]=hist; hist->SetDirectory(directory); if(!hist->GetSumw2N()) hist->Sumw2(); return hist;}
   TH1*& operator[](string_t name)       { return book_[name]; }
-  const TH1*  operator[](string_t name) const { book_t::const_iterator it = book_.find(name); return it==book_.end() ? 0 : it->second;}
+  const TH1*  operator[](string_t name) const { book_t::const_iterator it = book_.find(name); return it==book_.end() ? nullptr : it->second;}
 
   typedef boost::filter_iterator<match_name,book_t::iterator> iterator;
   typedef boost::filter_iterator<match_name,book_t::const_iterator> const_iterator;

--- a/CalibTracker/SiStripCommon/interface/ShallowClustersProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowClustersProducer.h
@@ -24,7 +24,7 @@ class ShallowClustersProducer : public edm::EDProducer {
 
   edm::InputTag theClustersLabel;
   std::string Prefix;
-  void produce( edm::Event &, const edm::EventSetup & );
+  void produce( edm::Event &, const edm::EventSetup & ) override;
 
   struct moduleVars {
     moduleVars(uint32_t, const TrackerTopology*);

--- a/CalibTracker/SiStripCommon/interface/ShallowDigisProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowDigisProducer.h
@@ -30,7 +30,7 @@ class ShallowDigisProducer : public edm::EDProducer {
   std::vector<edm::InputTag> inputTags;
   edm::ESHandle<SiStripNoises> noiseHandle;
 
-  void produce(edm::Event&, const edm::EventSetup&);
+  void produce(edm::Event&, const edm::EventSetup&) override;
   template<class T> bool findInput(edm::Handle<T>&, const edm::Event&);
   template<class T> void recordDigis(const T &, products&);
   void insert(products&, edm::Event&);  

--- a/CalibTracker/SiStripCommon/interface/ShallowEventDataProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowEventDataProducer.h
@@ -11,7 +11,7 @@ class ShallowEventDataProducer : public edm::EDProducer {
  public: 
   explicit ShallowEventDataProducer(const edm::ParameterSet&);
  private: 
-  void produce( edm::Event &, const edm::EventSetup & );
+  void produce( edm::Event &, const edm::EventSetup & ) override;
 	edm::EDGetTokenT< L1GlobalTriggerReadoutRecord > trig_token_;
 	edm::EDGetTokenT< LumiScalersCollection > scalerToken_; 
 };

--- a/CalibTracker/SiStripCommon/interface/ShallowGainCalibration.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowGainCalibration.h
@@ -66,7 +66,7 @@ private:
   std::string Suffix;
   std::string Prefix;
 
-  void   produce( edm::Event &, const edm::EventSetup & );
+  void   produce( edm::Event &, const edm::EventSetup & ) override;
 //  virtual void beginJob(EventSetup const&);
 //  virtual void beginRun(Run&, EventSetup const&);
   bool   IsFarFromBorder(TrajectoryStateOnSurface* trajState, const uint32_t detid, const edm::EventSetup* iSetup);

--- a/CalibTracker/SiStripCommon/interface/ShallowRechitClustersProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowRechitClustersProducer.h
@@ -17,7 +17,7 @@ private:
   const edm::EDGetTokenT< edmNew::DetSetVector<SiStripCluster> > clusters_token_;
 	std::vector< edm::EDGetTokenT<SiStripRecHit2DCollection> > rec_hits_tokens_;
   //std::vector<edm::InputTag> inputTags;
-  void produce( edm::Event &, const edm::EventSetup & );
+  void produce( edm::Event &, const edm::EventSetup & ) override;
 };
 
 #endif

--- a/CalibTracker/SiStripCommon/interface/ShallowSimhitClustersProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowSimhitClustersProducer.h
@@ -19,7 +19,7 @@ class ShallowSimhitClustersProducer : public edm::EDProducer {
   std::string Prefix;
 	std::string runningmode_;
 
-  void produce( edm::Event &, const edm::EventSetup & );
+  void produce( edm::Event &, const edm::EventSetup & ) override;
   shallow::CLUSTERMAP::const_iterator match_cluster(const unsigned&, 
 						    const float&, 
 						    const shallow::CLUSTERMAP&, 

--- a/CalibTracker/SiStripCommon/interface/ShallowTrackClustersProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowTrackClustersProducer.h
@@ -19,6 +19,6 @@ private:
   std::string Suffix;
   std::string Prefix;
 
-  void produce( edm::Event &, const edm::EventSetup & );
+  void produce( edm::Event &, const edm::EventSetup & ) override;
 };
 #endif

--- a/CalibTracker/SiStripCommon/interface/ShallowTracksProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowTracksProducer.h
@@ -14,6 +14,6 @@ private:
   edm::InputTag theTracksLabel;
   std::string Prefix;
   std::string Suffix;
-  void produce( edm::Event &, const edm::EventSetup & );
+  void produce( edm::Event &, const edm::EventSetup & ) override;
 };
 #endif

--- a/CalibTracker/SiStripCommon/interface/ShallowTree.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowTree.h
@@ -32,9 +32,9 @@
 
 class ShallowTree : public edm::EDAnalyzer {
 private:    
-  virtual void beginJob();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob(){}
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override{}
 
 	template <class T> 
 	void eat(edm::BranchDescription const* desc) {
@@ -56,7 +56,7 @@ private:
     T* object_ptr_;
   public:
     TypedBranchConnector(edm::BranchDescription const*, std::string, TTree*);
-    void connect(const edm::Event&);
+    void connect(const edm::Event&) override;
   };
 
   edm::Service<TFileService> fs_;

--- a/CalibTracker/SiStripCommon/plugins/ShallowEventDataProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowEventDataProducer.cc
@@ -30,8 +30,8 @@ produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle< L1GlobalTriggerReadoutRecord > gtRecord;
   iEvent.getByToken(trig_token_, gtRecord);
 
-  std::vector<bool> TrigTech_(64,0);
-  std::vector<bool> TrigPh_(128,0);
+  std::vector<bool> TrigTech_(64,false);
+  std::vector<bool> TrigPh_(128,false);
 
   // Get dWord after masking disabled bits
   DecisionWord dWord = gtRecord->decisionWord();

--- a/CalibTracker/SiStripCommon/plugins/ShallowGainCalibration.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowGainCalibration.cc
@@ -70,8 +70,8 @@ produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
           const SiStripMatchedRecHit2D* sistripmatchedhit   = dynamic_cast<const SiStripMatchedRecHit2D*>(hit);
           const SiPixelRecHit*          sipixelhit          = dynamic_cast<const SiPixelRecHit*>(hit);
 
-          const SiPixelCluster*   PixelCluster = NULL;
-          const SiStripCluster*   StripCluster = NULL;
+          const SiPixelCluster*   PixelCluster = nullptr;
+          const SiStripCluster*   StripCluster = nullptr;
           uint32_t                DetId = 0;
 
           for(unsigned int h=0;h<2;h++){
@@ -260,7 +260,7 @@ bool ShallowGainCalibration::IsFarFromBorder(TrajectoryStateOnSurface* trajState
   LocalError  HitLocalError = trajState->localError().positionError() ;
 
   const GeomDetUnit* it = tkGeom->idToDetUnit(DetId(detid));
-  if (dynamic_cast<const StripGeomDetUnit*>(it)==0 && dynamic_cast<const PixelGeomDetUnit*>(it)==0) {
+  if (dynamic_cast<const StripGeomDetUnit*>(it)==nullptr && dynamic_cast<const PixelGeomDetUnit*>(it)==nullptr) {
      std::cout << "this detID doesn't seem to belong to the Tracker" << std::endl;
      return false;
   }
@@ -295,8 +295,8 @@ double ShallowGainCalibration::thickness(DetId id)
    double detThickness=1.;
    //compute thickness normalization
    const GeomDetUnit* it = m_tracker->idToDetUnit(DetId(id));
-   bool isPixel = dynamic_cast<const PixelGeomDetUnit*>(it)!=0;
-   bool isStrip = dynamic_cast<const StripGeomDetUnit*>(it)!=0;
+   bool isPixel = dynamic_cast<const PixelGeomDetUnit*>(it)!=nullptr;
+   bool isStrip = dynamic_cast<const StripGeomDetUnit*>(it)!=nullptr;
    if (!isPixel && ! isStrip) {
    //FIXME throw exception
       edm::LogWarning("DeDxHitsProducer") << "\t\t this detID doesn't seem to belong to the Tracker";

--- a/CalibTracker/SiStripCommon/plugins/ShallowTrackClustersProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowTrackClustersProducer.cc
@@ -142,7 +142,7 @@ produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 		size_t trk_strt_idx = ontrk_cluster_idx;
 
     BOOST_FOREACH( const TrajectoryMeasurement measurement, traj->measurements() ) {
-      const TrajectoryStateOnSurface tsos = measurement.updatedState();
+      const TrajectoryStateOnSurface& tsos = measurement.updatedState();
       const TrajectoryStateOnSurface unbiased = combiner(measurement.forwardPredictedState(), measurement.backwardPredictedState());
 
       const TrackingRecHit*         hit        = measurement.recHit()->hit();

--- a/CalibTracker/SiStripCommon/plugins/SiStripBFieldFilter.cc
+++ b/CalibTracker/SiStripCommon/plugins/SiStripBFieldFilter.cc
@@ -14,7 +14,7 @@
 class SiStripBFieldFilter : public edm::EDFilter {
   public:
   SiStripBFieldFilter( const edm::ParameterSet & );
-  ~SiStripBFieldFilter();
+  ~SiStripBFieldFilter() override;
 
   private:
   double MagFieldCurrentTh_;   /*!<  Threshold for the Magnet current. */

--- a/CalibTracker/SiStripCommon/plugins/SiStripDCSFilter.cc
+++ b/CalibTracker/SiStripCommon/plugins/SiStripDCSFilter.cc
@@ -11,7 +11,7 @@
 class SiStripDCSFilter : public edm::EDFilter {
  public:
  SiStripDCSFilter( const edm::ParameterSet & );
- ~SiStripDCSFilter();
+ ~SiStripDCSFilter() override;
 
   private:
   bool filter( edm::Event &, edm::EventSetup const& ) override;

--- a/CalibTracker/SiStripCommon/plugins/SiStripDetInfoFileWriter.h
+++ b/CalibTracker/SiStripCommon/plugins/SiStripDetInfoFileWriter.h
@@ -28,13 +28,13 @@ class SiStripDetInfoFileWriter : public edm::EDAnalyzer {
 public:
 
   explicit SiStripDetInfoFileWriter(const edm::ParameterSet&);
-  ~SiStripDetInfoFileWriter();
+  ~SiStripDetInfoFileWriter() override;
 
 private:
 
-  void beginRun(const edm::Run& , const edm::EventSetup& iSetup);
+  void beginRun(const edm::Run& , const edm::EventSetup& iSetup) override;
 
-  void analyze(const edm::Event &, const edm::EventSetup &){};
+  void analyze(const edm::Event &, const edm::EventSetup &) override{};
 
 private:
 

--- a/CalibTracker/SiStripCommon/src/SiStripDCSStatus.cc
+++ b/CalibTracker/SiStripCommon/src/SiStripDCSStatus.cc
@@ -51,7 +51,7 @@ bool SiStripDCSStatus::getStatus(edm::Event const& e, edm::EventSetup const& eSe
   //  e.getByLabel("scalersRawToDigi", dcsStatus);
   e.getByToken(dcsStatusToken_, dcsStatus);
   if ( trackerAbsent || !dcsStatus.isValid())  return retVal;
-  if ((*dcsStatus).size() == 0) return retVal;
+  if ((*dcsStatus).empty()) return retVal;
 
   statusTIBTID = true;
   statusTOB    = true;

--- a/CalibTracker/SiStripDCS/plugins/FilterTrackerOn.h
+++ b/CalibTracker/SiStripDCS/plugins/FilterTrackerOn.h
@@ -31,12 +31,12 @@ class FilterTrackerOn : public edm::EDFilter
 {
  public:
   explicit FilterTrackerOn(const edm::ParameterSet&);
-  ~FilterTrackerOn();
+  ~FilterTrackerOn() override;
 
  private:
-  virtual void beginJob() ;
-  virtual bool filter(edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  void beginJob() override ;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
 
   int minModulesWithHVoff_;
 };

--- a/CalibTracker/SiStripDCS/plugins/SiStripDetVOffTkMapPlotter.cc
+++ b/CalibTracker/SiStripDCS/plugins/SiStripDetVOffTkMapPlotter.cc
@@ -21,9 +21,9 @@
 class SiStripDetVOffTkMapPlotter : public edm::EDAnalyzer {
 public:
   explicit SiStripDetVOffTkMapPlotter(const edm::ParameterSet& iConfig );
-  virtual ~SiStripDetVOffTkMapPlotter();
-  virtual void analyze( const edm::Event& evt, const edm::EventSetup& evtSetup);
-  virtual void endJob();
+  ~SiStripDetVOffTkMapPlotter() override;
+  void analyze( const edm::Event& evt, const edm::EventSetup& evtSetup) override;
+  void endJob() override;
 
 private:
   std::string formatIOV(cond::Time_t iov, std::string format="%Y-%m-%d__%H_%M_%S");

--- a/CalibTracker/SiStripDCS/plugins/SiStripDetVOffTrendPlotter.cc
+++ b/CalibTracker/SiStripDCS/plugins/SiStripDetVOffTrendPlotter.cc
@@ -29,9 +29,9 @@ public:
   const std::vector<Color_t> PLOT_COLORS {kRed, kBlue, kBlack, kOrange, kMagenta};
 
   explicit SiStripDetVOffTrendPlotter(const edm::ParameterSet& iConfig );
-  virtual ~SiStripDetVOffTrendPlotter();
-  virtual void analyze( const edm::Event& evt, const edm::EventSetup& evtSetup);
-  virtual void endJob();
+  ~SiStripDetVOffTrendPlotter() override;
+  void analyze( const edm::Event& evt, const edm::EventSetup& evtSetup) override;
+  void endJob() override;
 
 private:
   std::string formatIOV(cond::Time_t iov, std::string format="%Y-%m-%d__%H_%M_%S");

--- a/CalibTracker/SiStripDCS/plugins/TkVoltageMapCreator.cc
+++ b/CalibTracker/SiStripDCS/plugins/TkVoltageMapCreator.cc
@@ -30,15 +30,15 @@
 class TkVoltageMapCreator : public edm::EDAnalyzer {
  public:
     explicit TkVoltageMapCreator(const edm::ParameterSet&);
-    ~TkVoltageMapCreator();
+    ~TkVoltageMapCreator() override;
 
 
    private:
-      virtual void beginJob() override ;
-      virtual void beginRun(const edm::Run&, const edm::EventSetup&) override ;
-      virtual void endRun(const edm::Run&, const edm::EventSetup&) override ;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override ;
+      void beginJob() override ;
+      void beginRun(const edm::Run&, const edm::EventSetup&) override ;
+      void endRun(const edm::Run&, const edm::EventSetup&) override ;
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
 
       // ----------member data ---------------------------
 

--- a/CalibTracker/SiStripDCS/src/SiStripPsuDetIdMap.cc
+++ b/CalibTracker/SiStripDCS/src/SiStripPsuDetIdMap.cc
@@ -189,7 +189,7 @@ void SiStripPsuDetIdMap::getDetID(std::string PSUChannel,const bool debug,std::v
   //3-crosstalking_detids->the detids that are matching the PSU in question but exhibit the HV channel cross-talking behavior (they are ON as long as ANY of the 2 HV channels of the supply is ON, so they only go OFF when both channels are OFF)
   //The second and third vectors are only relevant for the HV case, when unmapped and cross-talking channels need further processing before being turned ON and OFF.
   
-  std::string PSUChannelFromQuery = PSUChannel;
+  const std::string& PSUChannelFromQuery = PSUChannel;
 
   //Get the channel to see if it is LV or HV, they will be treated differently
   std::string ChannelFromQuery=PSUChannelFromQuery.substr(PSUChannelFromQuery.size()-10);
@@ -461,7 +461,7 @@ void SiStripPsuDetIdMap::printControlMap() {
 }
 
 std::vector< std::pair<uint32_t, std::string> > SiStripPsuDetIdMap::getDcuPsuMap() {
-  if (pgMap.size() != 0) { return pgMap; }
+  if (!pgMap.empty()) { return pgMap; }
   std::vector< std::pair<uint32_t, std::string> > emptyVec;
   return emptyVec;
 }

--- a/CalibTracker/SiStripESProducers/interface/Phase2TrackerCablingESProducer.h
+++ b/CalibTracker/SiStripESProducers/interface/Phase2TrackerCablingESProducer.h
@@ -14,14 +14,14 @@ class Phase2TrackerCablingESProducer : public edm::ESProducer {
  public:
   
   Phase2TrackerCablingESProducer( const edm::ParameterSet& );
-  virtual ~Phase2TrackerCablingESProducer();
+  ~Phase2TrackerCablingESProducer() override;
   
   virtual std::unique_ptr<Phase2TrackerCabling> produce( const Phase2TrackerCablingRcd& );
   
  private:
   
-  Phase2TrackerCablingESProducer( const Phase2TrackerCablingESProducer& );
-  const Phase2TrackerCablingESProducer& operator=( const Phase2TrackerCablingESProducer& );
+  Phase2TrackerCablingESProducer( const Phase2TrackerCablingESProducer& ) = delete;
+  const Phase2TrackerCablingESProducer& operator=( const Phase2TrackerCablingESProducer& ) = delete;
   
   virtual Phase2TrackerCabling* make( const Phase2TrackerCablingRcd& ) = 0; 
   

--- a/CalibTracker/SiStripESProducers/interface/SiStripFedCablingESProducer.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripFedCablingESProducer.h
@@ -19,15 +19,15 @@ class SiStripFedCablingESProducer : public edm::ESProducer {
  public:
   
   SiStripFedCablingESProducer( const edm::ParameterSet& );
-  virtual ~SiStripFedCablingESProducer();
+  ~SiStripFedCablingESProducer() override;
   
   /** Calls pure virtual make() method, to force concrete implementation. */
   virtual std::unique_ptr<SiStripFedCabling> produce( const SiStripFedCablingRcd& );
   
  private:
   
-  SiStripFedCablingESProducer( const SiStripFedCablingESProducer& );
-  const SiStripFedCablingESProducer& operator=( const SiStripFedCablingESProducer& );
+  SiStripFedCablingESProducer( const SiStripFedCablingESProducer& ) = delete;
+  const SiStripFedCablingESProducer& operator=( const SiStripFedCablingESProducer& ) = delete;
   
   virtual SiStripFedCabling* make( const SiStripFedCablingRcd& ) = 0; 
   

--- a/CalibTracker/SiStripESProducers/interface/SiStripGainESSource.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripGainESSource.h
@@ -20,20 +20,20 @@ class SiStripGainESSource : public edm::ESProducer, public edm::EventSetupRecord
  public:
 
   SiStripGainESSource( const edm::ParameterSet& );
-  virtual ~SiStripGainESSource() {;}
+  ~SiStripGainESSource() override {;}
   
   virtual std::unique_ptr<SiStripApvGain> produce( const SiStripApvGainRcd& );
   
  protected:
 
-  virtual void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
 			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& );
+			       edm::ValidityInterval& ) override;
   
  private:
   
-  SiStripGainESSource( const SiStripGainESSource& );
-  const SiStripGainESSource& operator=( const SiStripGainESSource& );
+  SiStripGainESSource( const SiStripGainESSource& ) = delete;
+  const SiStripGainESSource& operator=( const SiStripGainESSource& ) = delete;
 
   virtual SiStripApvGain* makeGain() = 0; 
 

--- a/CalibTracker/SiStripESProducers/interface/SiStripHashedDetIdESProducer.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripHashedDetIdESProducer.h
@@ -19,15 +19,15 @@ class SiStripHashedDetIdESProducer : public edm::ESProducer {
  public:
 
   SiStripHashedDetIdESProducer( const edm::ParameterSet& );
-  virtual ~SiStripHashedDetIdESProducer();
+  ~SiStripHashedDetIdESProducer() override;
 
   /** Calls pure virtual make() method, to force concrete implementation. */
   virtual std::unique_ptr<SiStripHashedDetId> produce( const SiStripHashedDetIdRcd& );
   
  private:
   
-  SiStripHashedDetIdESProducer( const SiStripHashedDetIdESProducer& );
-  const SiStripHashedDetIdESProducer& operator=( const SiStripHashedDetIdESProducer& );
+  SiStripHashedDetIdESProducer( const SiStripHashedDetIdESProducer& ) = delete;
+  const SiStripHashedDetIdESProducer& operator=( const SiStripHashedDetIdESProducer& ) = delete;
   
   virtual SiStripHashedDetId* make( const SiStripHashedDetIdRcd& ) = 0; 
   

--- a/CalibTracker/SiStripESProducers/interface/SiStripNoiseESSource.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripNoiseESSource.h
@@ -21,20 +21,20 @@ class SiStripNoiseESSource : public edm::ESProducer, public edm::EventSetupRecor
  public:
 
   SiStripNoiseESSource( const edm::ParameterSet& );
-  virtual ~SiStripNoiseESSource() {;}
+  ~SiStripNoiseESSource() override {;}
   
   virtual std::unique_ptr<SiStripNoises> produce( const SiStripNoisesRcd& );
   
  protected:
 
-  virtual void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
 			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& );
+			       edm::ValidityInterval& ) override;
   
  private:
   
-  SiStripNoiseESSource( const SiStripNoiseESSource& );
-  const SiStripNoiseESSource& operator=( const SiStripNoiseESSource& );
+  SiStripNoiseESSource( const SiStripNoiseESSource& ) = delete;
+  const SiStripNoiseESSource& operator=( const SiStripNoiseESSource& ) = delete;
 
   virtual SiStripNoises* makeNoise() = 0; 
 

--- a/CalibTracker/SiStripESProducers/interface/SiStripPedestalsESSource.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripPedestalsESSource.h
@@ -21,20 +21,20 @@ class SiStripPedestalsESSource : public edm::ESProducer, public edm::EventSetupR
  public:
 
   SiStripPedestalsESSource( const edm::ParameterSet& );
-  virtual ~SiStripPedestalsESSource() {;}
+  ~SiStripPedestalsESSource() override {;}
   
   virtual std::unique_ptr<SiStripPedestals> produce( const SiStripPedestalsRcd& );
   
  protected:
 
-  virtual void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
 			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& );
+			       edm::ValidityInterval& ) override;
   
  private:
   
-  SiStripPedestalsESSource( const SiStripPedestalsESSource& );
-  const SiStripPedestalsESSource& operator=( const SiStripPedestalsESSource& );
+  SiStripPedestalsESSource( const SiStripPedestalsESSource& ) = delete;
+  const SiStripPedestalsESSource& operator=( const SiStripPedestalsESSource& ) = delete;
 
   virtual SiStripPedestals* makePedestals() = 0; 
 

--- a/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondDBWriter.h
+++ b/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondDBWriter.h
@@ -22,10 +22,10 @@ class DummyCondDBWriter : public edm::EDAnalyzer {
 public:
 
   explicit DummyCondDBWriter(const edm::ParameterSet& iConfig);
-  ~DummyCondDBWriter();
-  void analyze(const edm::Event& e, const edm::EventSetup&es){};
+  ~DummyCondDBWriter() override;
+  void analyze(const edm::Event& e, const edm::EventSetup&es) override{};
 
-  void endRun(const edm::Run & run, const edm::EventSetup & es);
+  void endRun(const edm::Run & run, const edm::EventSetup & es) override;
 
  private:
   edm::ParameterSet iConfig_;

--- a/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondObjPrinter.h
+++ b/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondObjPrinter.h
@@ -18,8 +18,8 @@ class DummyCondObjPrinter : public edm::EDAnalyzer {
 public:
 
   explicit DummyCondObjPrinter(const edm::ParameterSet& iConfig);
-  ~DummyCondObjPrinter();
-  void analyze(const edm::Event& e, const edm::EventSetup&es);
+  ~DummyCondObjPrinter() override;
+  void analyze(const edm::Event& e, const edm::EventSetup&es) override;
 
 
  private:

--- a/CalibTracker/SiStripESProducers/plugins/DBWriter/SiStripFedCablingManipulator.cc
+++ b/CalibTracker/SiStripESProducers/plugins/DBWriter/SiStripFedCablingManipulator.cc
@@ -19,7 +19,7 @@ void SiStripFedCablingManipulator::endRun(const edm::Run & run, const edm::Event
   es.get<SiStripFedCablingRcd>().get( esobj ); 
 
 
-  SiStripFedCabling *obj=0;
+  SiStripFedCabling *obj=nullptr;
   manipulate(esobj.product(),obj);
 
   cond::Time_t Time_ = 0;
@@ -28,7 +28,7 @@ void SiStripFedCablingManipulator::endRun(const edm::Run & run, const edm::Event
   edm::Service<cond::service::PoolDBOutputService> dbservice;
   if( dbservice.isAvailable() ){
 
-    if(obj==NULL){
+    if(obj==nullptr){
       edm::LogError("SiStripFedCablingManipulator")<<"null pointer obj. nothing will be written "<<std::endl;
       return;
     }

--- a/CalibTracker/SiStripESProducers/plugins/DBWriter/SiStripFedCablingManipulator.h
+++ b/CalibTracker/SiStripESProducers/plugins/DBWriter/SiStripFedCablingManipulator.h
@@ -20,10 +20,10 @@ class SiStripFedCablingManipulator : public edm::EDAnalyzer {
 public:
 
   explicit SiStripFedCablingManipulator(const edm::ParameterSet& iConfig);
-  ~SiStripFedCablingManipulator();
-  void analyze(const edm::Event& e, const edm::EventSetup&es){};
+  ~SiStripFedCablingManipulator() override;
+  void analyze(const edm::Event& e, const edm::EventSetup&es) override{};
 
-  void endRun(const edm::Run & run, const edm::EventSetup & es);
+  void endRun(const edm::Run & run, const edm::EventSetup & es) override;
 
  private:
 

--- a/CalibTracker/SiStripESProducers/plugins/fake/Phase2TrackerCablingCfgESSource.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/Phase2TrackerCablingCfgESSource.h
@@ -13,13 +13,13 @@ class Phase2TrackerCablingCfgESSource : public Phase2TrackerCablingESProducer, p
  public:
   
   explicit Phase2TrackerCablingCfgESSource( const edm::ParameterSet& );
-  ~Phase2TrackerCablingCfgESSource();
+  ~Phase2TrackerCablingCfgESSource() override;
   
  protected:
   
-  virtual void setIntervalFor( const edm::eventsetup::EventSetupRecordKey& key,
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey& key,
 			       const edm::IOVSyncValue& iov_sync,
-			       edm::ValidityInterval& iov_validity ) {
+			       edm::ValidityInterval& iov_validity ) override {
     edm::ValidityInterval infinity( iov_sync.beginOfTime(), iov_sync.endOfTime() );
     iov_validity = infinity;
   }
@@ -27,7 +27,7 @@ class Phase2TrackerCablingCfgESSource : public Phase2TrackerCablingESProducer, p
  private:
   
   // Builds cabling map based on the ParameterSet
-  virtual Phase2TrackerCabling* make( const Phase2TrackerCablingRcd& ); 
+  Phase2TrackerCabling* make( const Phase2TrackerCablingRcd& ) override; 
 
   // The configuration used to generated the cabling record
   edm::ParameterSet pset_;

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripApvGainBuilderFromTag.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripApvGainBuilderFromTag.cc
@@ -50,7 +50,7 @@ void SiStripApvGainBuilderFromTag::analyze(const edm::Event& evt, const edm::Eve
   SiStripDetInfoFileReader reader(fp_.fullPath());
 
   uint32_t count = 0;
-  const std::map<uint32_t, SiStripDetInfoFileReader::DetInfo > DetInfos = reader.getAllData();
+  const std::map<uint32_t, SiStripDetInfoFileReader::DetInfo >& DetInfos = reader.getAllData();
   for(std::map<uint32_t, SiStripDetInfoFileReader::DetInfo >::const_iterator it = DetInfos.begin(); it != DetInfos.end(); it++) {
 
     // Find if this DetId is in the input tag and if so how many are the Apvs for which it contains information

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripApvGainBuilderFromTag.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripApvGainBuilderFromTag.h
@@ -34,9 +34,9 @@ class SiStripApvGainBuilderFromTag : public edm::EDAnalyzer
 
   explicit SiStripApvGainBuilderFromTag( const edm::ParameterSet& iConfig);
 
-  ~SiStripApvGainBuilderFromTag(){};
+  ~SiStripApvGainBuilderFromTag() override{};
 
-  virtual void analyze(const edm::Event& , const edm::EventSetup& );
+  void analyze(const edm::Event& , const edm::EventSetup& ) override;
 
  private:
   /// Fills the parameters read from cfg and matching the name in the given map

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripApvGainFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripApvGainFakeESSource.cc
@@ -25,9 +25,9 @@
 class SiStripApvGainFakeESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   SiStripApvGainFakeESSource(const edm::ParameterSet&);
-  ~SiStripApvGainFakeESSource();
+  ~SiStripApvGainFakeESSource() override;
 
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity );
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity ) override;
 
   typedef std::shared_ptr<SiStripApvGain> ReturnType;
   ReturnType produce(const SiStripApvGainRcd&);

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripBackPlaneCorrectionFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripBackPlaneCorrectionFakeESSource.cc
@@ -25,9 +25,9 @@
 class SiStripBackPlaneCorrectioNFakeESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   SiStripBackPlaneCorrectioNFakeESSource(const edm::ParameterSet&);
-  ~SiStripBackPlaneCorrectioNFakeESSource();
+  ~SiStripBackPlaneCorrectioNFakeESSource() override;
 
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity );
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity ) override;
 
   typedef std::shared_ptr<SiStripBackPlaneCorrection> ReturnType;
   ReturnType produce(const SiStripBackPlaneCorrectionRcd&);

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripBadModuleConfigurableFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripBadModuleConfigurableFakeESSource.cc
@@ -26,9 +26,9 @@
 class SiStripBadModuleConfigurableFakeESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   SiStripBadModuleConfigurableFakeESSource(const edm::ParameterSet&);
-  ~SiStripBadModuleConfigurableFakeESSource();
+  ~SiStripBadModuleConfigurableFakeESSource() override;
 
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity );
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity ) override;
 
   typedef std::shared_ptr<SiStripBadStrip> ReturnType;
   ReturnType produce(const SiStripBadModuleRcd&);

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripBaseDelayFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripBaseDelayFakeESSource.cc
@@ -25,9 +25,9 @@
 class SiStripBaseDelayFakeESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   SiStripBaseDelayFakeESSource(const edm::ParameterSet&);
-  ~SiStripBaseDelayFakeESSource();
+  ~SiStripBaseDelayFakeESSource() override;
 
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity );
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity ) override;
 
   typedef std::shared_ptr<SiStripBaseDelay> ReturnType;
   ReturnType produce(const SiStripBaseDelayRcd&);
@@ -68,7 +68,7 @@ SiStripBaseDelayFakeESSource::produce(const SiStripBaseDelayRcd& iRecord)
 
   SiStripDetInfoFileReader reader{m_file.fullPath()};
 
-  const auto detInfos = reader.getAllData();
+  const auto& detInfos = reader.getAllData();
   if ( detInfos.empty() ) {
     edm::LogError("SiStripBaseDelayGenerator") << "Error: detInfo map is empty.";
   }

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripConfObjectFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripConfObjectFakeESSource.cc
@@ -25,9 +25,9 @@
 class SiStripConfObjectFakeESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   SiStripConfObjectFakeESSource(const edm::ParameterSet&);
-  ~SiStripConfObjectFakeESSource();
+  ~SiStripConfObjectFakeESSource() override;
 
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity );
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity ) override;
 
   typedef std::shared_ptr<SiStripConfObject> ReturnType;
   ReturnType produce(const SiStripConfObjectRcd&);

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripFedCablingFakeESSource.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripFedCablingFakeESSource.h
@@ -19,18 +19,18 @@ class SiStripFedCablingFakeESSource : public SiStripFedCablingESProducer, public
  public:
   
   explicit SiStripFedCablingFakeESSource( const edm::ParameterSet& );
-  ~SiStripFedCablingFakeESSource();
+  ~SiStripFedCablingFakeESSource() override;
   
  protected:
   
-  virtual void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
 			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& );
+			       edm::ValidityInterval& ) override;
   
  private:
   
   /** Builds cabling map based on ascii files. */
-  virtual SiStripFedCabling* make( const SiStripFedCablingRcd& ); 
+  SiStripFedCabling* make( const SiStripFedCablingRcd& ) override; 
 
   /** Location of ascii file containing DetIds. */
   edm::FileInPath detIds_;

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripHashedDetIdFakeESSource.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripHashedDetIdFakeESSource.h
@@ -19,18 +19,18 @@ class SiStripHashedDetIdFakeESSource : public SiStripHashedDetIdESProducer, publ
  public:
   
   explicit SiStripHashedDetIdFakeESSource( const edm::ParameterSet& );
-  virtual ~SiStripHashedDetIdFakeESSource();
+  ~SiStripHashedDetIdFakeESSource() override;
   
  protected:
   
-  virtual void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
 			       const edm::IOVSyncValue&,
-			       edm::ValidityInterval& );
+			       edm::ValidityInterval& ) override;
   
  private:
   
   /** Builds hashed DetId map based on ascii file. */
-  virtual SiStripHashedDetId* make( const SiStripHashedDetIdRcd& ); 
+  SiStripHashedDetId* make( const SiStripHashedDetIdRcd& ) override; 
   
   /** Location of ascii file containing DetIds. */
   edm::FileInPath detIds_;

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripLatencyFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripLatencyFakeESSource.cc
@@ -25,9 +25,9 @@
 class SiStripLatencyFakeESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   SiStripLatencyFakeESSource(const edm::ParameterSet&);
-  ~SiStripLatencyFakeESSource();
+  ~SiStripLatencyFakeESSource() override;
 
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity );
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity ) override;
 
   typedef std::shared_ptr<SiStripLatency> ReturnType;
   ReturnType produce(const SiStripLatencyRcd&);
@@ -67,7 +67,7 @@ SiStripLatencyFakeESSource::produce(const SiStripLatencyRcd& iRecord)
   std::shared_ptr<SiStripLatency> latency{new SiStripLatency};
 
   SiStripDetInfoFileReader reader{m_file.fullPath()};
-  const auto detInfos = reader.getAllData();
+  const auto& detInfos = reader.getAllData();
   // Take the last detId. Since the map is sorted it will be the biggest value
   if ( ! detInfos.empty() ) {
     // Set the apv number as 6, the highest possible

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripLorentzAngleFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripLorentzAngleFakeESSource.cc
@@ -34,9 +34,9 @@
 class SiStripLorentzAngleFakeESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   SiStripLorentzAngleFakeESSource(const edm::ParameterSet&);
-  ~SiStripLorentzAngleFakeESSource();
+  ~SiStripLorentzAngleFakeESSource() override;
 
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity );
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity ) override;
 
   typedef std::shared_ptr<SiStripLorentzAngle> ReturnType;
   ReturnType produce(const SiStripLorentzAngleRcd&);

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripNoiseNormalizedWithApvGainBuilder.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripNoiseNormalizedWithApvGainBuilder.cc
@@ -55,7 +55,7 @@ void SiStripNoiseNormalizedWithApvGainBuilder::analyze(const edm::Event& evt, co
   printDebug_ = pset_.getUntrackedParameter<uint32_t>("printDebug", 5);
 
   unsigned int count = 0;
-  const std::map<uint32_t, SiStripDetInfoFileReader::DetInfo > DetInfos = reader.getAllData();
+  const std::map<uint32_t, SiStripDetInfoFileReader::DetInfo >& DetInfos = reader.getAllData();
   for(std::map<uint32_t, SiStripDetInfoFileReader::DetInfo >::const_iterator it = DetInfos.begin(); it != DetInfos.end(); it++) {
 
     // Find if this DetId is in the input tag and if so how many are the Apvs for which it contains information

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripNoiseNormalizedWithApvGainBuilder.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripNoiseNormalizedWithApvGainBuilder.h
@@ -31,9 +31,9 @@ class SiStripNoiseNormalizedWithApvGainBuilder : public edm::EDAnalyzer
 
   explicit SiStripNoiseNormalizedWithApvGainBuilder( const edm::ParameterSet& iConfig);
 
-  ~SiStripNoiseNormalizedWithApvGainBuilder(){};
+  ~SiStripNoiseNormalizedWithApvGainBuilder() override{};
 
-  virtual void analyze(const edm::Event& , const edm::EventSetup& );
+  void analyze(const edm::Event& , const edm::EventSetup& ) override;
 
  private:
   /// Fills the parameters read from cfg and matching the name in the given map

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripNoisesFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripNoisesFakeESSource.cc
@@ -29,9 +29,9 @@
 class SiStripNoisesFakeESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   SiStripNoisesFakeESSource(const edm::ParameterSet&);
-  ~SiStripNoisesFakeESSource();
+  ~SiStripNoisesFakeESSource() override;
 
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity );
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity ) override;
 
   typedef std::shared_ptr<SiStripNoises> ReturnType;
   ReturnType produce(const SiStripNoisesRcd&);

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripPedestalsFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripPedestalsFakeESSource.cc
@@ -25,9 +25,9 @@
 class SiStripPedestalsFakeESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   SiStripPedestalsFakeESSource(const edm::ParameterSet&);
-  ~SiStripPedestalsFakeESSource();
+  ~SiStripPedestalsFakeESSource() override;
 
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity );
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity ) override;
 
   typedef std::shared_ptr<SiStripPedestals> ReturnType;
   ReturnType produce(const SiStripPedestalsRcd&);

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripQualityFakeESSource.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripQualityFakeESSource.h
@@ -25,7 +25,7 @@
 class SiStripQualityFakeESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
  public:
   SiStripQualityFakeESSource(const edm::ParameterSet&);
-  ~SiStripQualityFakeESSource(){};
+  ~SiStripQualityFakeESSource() override{};
   
   
   std::unique_ptr<SiStripQuality> produce(const SiStripQualityRcd&);
@@ -34,10 +34,10 @@ private:
   
   void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
 		       const edm::IOVSyncValue& iov,
-		       edm::ValidityInterval& iValidity);
+		       edm::ValidityInterval& iValidity) override;
   
-  SiStripQualityFakeESSource( const SiStripQualityFakeESSource& );
-  const SiStripQualityFakeESSource& operator=( const SiStripQualityFakeESSource& );
+  SiStripQualityFakeESSource( const SiStripQualityFakeESSource& ) = delete;
+  const SiStripQualityFakeESSource& operator=( const SiStripQualityFakeESSource& ) = delete;
 };
 
 #endif

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripTemplateEmptyFakeESSource.h
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripTemplateEmptyFakeESSource.h
@@ -22,7 +22,7 @@ template< typename TObject , typename TRecord>
 class SiStripTemplateEmptyFakeESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
  public:
   SiStripTemplateEmptyFakeESSource(const edm::ParameterSet&);
-  ~SiStripTemplateEmptyFakeESSource(){};
+  ~SiStripTemplateEmptyFakeESSource() override{};
   
   
   std::unique_ptr<TObject> produce(const TRecord&);
@@ -31,10 +31,10 @@ private:
   
   void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
 		       const edm::IOVSyncValue& iov,
-		       edm::ValidityInterval& iValidity);
+		       edm::ValidityInterval& iValidity) override;
   
-  SiStripTemplateEmptyFakeESSource( const SiStripTemplateEmptyFakeESSource& );
-  const SiStripTemplateEmptyFakeESSource& operator=( const SiStripTemplateEmptyFakeESSource& );
+  SiStripTemplateEmptyFakeESSource( const SiStripTemplateEmptyFakeESSource& ) = delete;
+  const SiStripTemplateEmptyFakeESSource& operator=( const SiStripTemplateEmptyFakeESSource& ) = delete;
 };
 
 template< typename TObject , typename TRecord>

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripThresholdFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripThresholdFakeESSource.cc
@@ -25,9 +25,9 @@
 class SiStripThresholdFakeESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   SiStripThresholdFakeESSource(const edm::ParameterSet&);
-  ~SiStripThresholdFakeESSource();
+  ~SiStripThresholdFakeESSource() override;
 
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity );
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity ) override;
 
   typedef std::shared_ptr<SiStripThreshold> ReturnType;
   ReturnType produce(const SiStripThresholdRcd&);

--- a/CalibTracker/SiStripESProducers/plugins/geom/SiStripConnectivity.h
+++ b/CalibTracker/SiStripESProducers/plugins/geom/SiStripConnectivity.h
@@ -13,7 +13,7 @@ class SiStripConnectivity: public edm::ESProducer {
  public:
   
   SiStripConnectivity( const edm::ParameterSet& );
-  virtual ~SiStripConnectivity();
+  ~SiStripConnectivity() override;
   
   std::unique_ptr<SiStripFecCabling> produceFecCabling( const SiStripFecCablingRcd& );
   std::unique_ptr<SiStripDetCabling> produceDetCabling( const SiStripDetCablingRcd& );

--- a/CalibTracker/SiStripESProducers/plugins/geom/SiStripHashedDetIdESModule.h
+++ b/CalibTracker/SiStripESProducers/plugins/geom/SiStripHashedDetIdESModule.h
@@ -17,12 +17,12 @@ class SiStripHashedDetIdESModule : public SiStripHashedDetIdESProducer {
  public:
   
   SiStripHashedDetIdESModule( const edm::ParameterSet& );
-  virtual ~SiStripHashedDetIdESModule();
+  ~SiStripHashedDetIdESModule() override;
   
  private:
   
   /** Builds hashed DetId map based on geometry. */
-  virtual SiStripHashedDetId* make( const SiStripHashedDetIdRcd& ); 
+  SiStripHashedDetId* make( const SiStripHashedDetIdRcd& ) override; 
   
 };
 

--- a/CalibTracker/SiStripESProducers/plugins/geom/SiStripRegionConnectivity.cc
+++ b/CalibTracker/SiStripESProducers/plugins/geom/SiStripRegionConnectivity.cc
@@ -73,7 +73,7 @@ std::unique_ptr<SiStripRegionCabling> SiStripRegionConnectivity::produceRegionCa
     auto &  elem = regioncabling[reg][subdet][layer].back();
     elem.first=idet->first; elem.second.resize(conns.size());
     for ( ; iconn != jconn; ++iconn ) {
-      if ( ((*iconn) != 0) && ((*iconn)->apvPairNumber() < conns.size()) ) { 
+      if ( ((*iconn) != nullptr) && ((*iconn)->apvPairNumber() < conns.size()) ) { 
 	elem.second[(*iconn)->apvPairNumber()] = **iconn;
       }
     }

--- a/CalibTracker/SiStripESProducers/plugins/geom/SiStripRegionConnectivity.h
+++ b/CalibTracker/SiStripESProducers/plugins/geom/SiStripRegionConnectivity.h
@@ -17,7 +17,7 @@ class SiStripRegionConnectivity: public edm::ESProducer {
  public:
 
   SiStripRegionConnectivity( const edm::ParameterSet& );
-  virtual ~SiStripRegionConnectivity();
+  ~SiStripRegionConnectivity() override;
   
   std::unique_ptr<SiStripRegionCabling> produceRegionCabling( const SiStripRegionCablingRcd&  );
   

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripBackPlaneCorrectionDepESProducer.h
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripBackPlaneCorrectionDepESProducer.h
@@ -21,7 +21,7 @@
 class SiStripBackPlaneCorrectionDepESProducer : public edm::ESProducer {
  public:
   SiStripBackPlaneCorrectionDepESProducer(const edm::ParameterSet&);
-  ~SiStripBackPlaneCorrectionDepESProducer(){};
+  ~SiStripBackPlaneCorrectionDepESProducer() override{};
   
   std::shared_ptr<SiStripBackPlaneCorrection> produce(const SiStripBackPlaneCorrectionDepRcd&);
    

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripBadModuleFedErrESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripBadModuleFedErrESSource.cc
@@ -43,9 +43,9 @@ class MonitorElement;
 class SiStripBadModuleFedErrESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   SiStripBadModuleFedErrESSource(const edm::ParameterSet&);
-  ~SiStripBadModuleFedErrESSource();
+  ~SiStripBadModuleFedErrESSource() override;
 
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity );
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue& iov, edm::ValidityInterval& iValidity ) override;
 
   typedef std::shared_ptr<SiStripBadStrip> ReturnType;
   ReturnType produce( const SiStripBadModuleFedErrRcd& );

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripDelayESProducer.h
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripDelayESProducer.h
@@ -20,7 +20,7 @@
 class SiStripDelayESProducer : public edm::ESProducer {
  public:
   SiStripDelayESProducer(const edm::ParameterSet&);
-  ~SiStripDelayESProducer(){};
+  ~SiStripDelayESProducer() override{};
   
   std::shared_ptr<SiStripDelay> produce(const SiStripDelayRcd&);
    

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripGainESProducerTemplate.h
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripGainESProducerTemplate.h
@@ -25,7 +25,7 @@ template<typename TDependentRecord, typename TInputRecord>
 class SiStripGainESProducerTemplate : public edm::ESProducer {
  public:
   SiStripGainESProducerTemplate(const edm::ParameterSet&);
-  ~SiStripGainESProducerTemplate(){};
+  ~SiStripGainESProducerTemplate() override{};
   
   std::unique_ptr<SiStripGain> produce(const TDependentRecord&);
 

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripLorentzAngleDepESProducer.h
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripLorentzAngleDepESProducer.h
@@ -21,7 +21,7 @@
 class SiStripLorentzAngleDepESProducer : public edm::ESProducer {
  public:
   SiStripLorentzAngleDepESProducer(const edm::ParameterSet&);
-  ~SiStripLorentzAngleDepESProducer(){};
+  ~SiStripLorentzAngleDepESProducer() override{};
   
   std::shared_ptr<SiStripLorentzAngle> produce(const SiStripLorentzAngleDepRcd&);
    

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.h
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.h
@@ -20,7 +20,7 @@
 class SiStripQualityESProducer : public edm::ESProducer {
  public:
   SiStripQualityESProducer(const edm::ParameterSet&);
-  ~SiStripQualityESProducer(){};
+  ~SiStripQualityESProducer() override{};
   
   std::shared_ptr<SiStripQuality> produce(const SiStripQualityRcd&);
    

--- a/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
+++ b/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
@@ -50,13 +50,13 @@ class HitEff : public edm::EDAnalyzer {
   double checkConsistency(const StripClusterParameterEstimator::LocalValues& parameters, double xx, double xerr);
   bool isDoubleSided(unsigned int iidd, const TrackerTopology* tTopo) const;
   bool check2DPartner(unsigned int iidd, const std::vector<TrajectoryMeasurement>& traj);
-  virtual ~HitEff();
+  ~HitEff() override;
   unsigned int checkLayer(unsigned int iidd, const TrackerTopology* tTopo);
 
  private:
-  virtual void beginJob();
-  virtual void endJob(); 
-  virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void beginJob() override;
+  void endJob() override; 
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
         // ----------member data ---------------------------
 

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
@@ -93,12 +93,12 @@ struct hit{
 class SiStripHitEffFromCalibTree : public ConditionDBWriter<SiStripBadStrip> {
   public:
     explicit SiStripHitEffFromCalibTree(const edm::ParameterSet&);
-    ~SiStripHitEffFromCalibTree();
+    ~SiStripHitEffFromCalibTree() override;
 
   private:
     virtual void algoBeginJob();
-    virtual void algoEndJob() override;
-    virtual void algoAnalyze(const edm::Event& e, const edm::EventSetup& c) override;
+    void algoEndJob() override;
+    void algoAnalyze(const edm::Event& e, const edm::EventSetup& c) override;
     void SetBadComponents(int i, int component,SiStripQuality::BadComponent& BC, std::stringstream ssV[4][19], int NBadComponent[4][19][4]);
     void makeTKMap();
     void makeHotColdMaps();
@@ -240,7 +240,7 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
       badModules_file.close();
 	}
   }
-  if(badModules_list.size()) cout<<"Remove additionnal bad modules from the analysis: "<<endl;
+  if(!badModules_list.empty()) cout<<"Remove additionnal bad modules from the analysis: "<<endl;
   set<uint32_t>::iterator itBadMod;
   for (itBadMod=badModules_list.begin(); itBadMod!=badModules_list.end(); ++itBadMod) 
     cout<<" "<<*itBadMod<<endl;
@@ -297,7 +297,7 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
 	TLeaf* BunchLf = CalibTree->GetLeaf("bunchx");
 	TLeaf* InstLumiLf = CalibTree->GetLeaf("instLumi");
 	TLeaf* PULf = CalibTree->GetLeaf("PU");
-	TLeaf* CMLf = 0;
+	TLeaf* CMLf = nullptr;
 	if(_useCM) CMLf = CalibTree->GetLeaf("commonMode");
 
 	int nevents = CalibTree->GetEntries();
@@ -332,9 +332,9 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
       unsigned int bx = (unsigned int)BunchLf->GetValue();
       if(_bunchx > 0 && _bunchx != bx) continue;
 	  double instLumi = 0;
-	  if(InstLumiLf!=0) instLumi = InstLumiLf->GetValue();
+	  if(InstLumiLf!=nullptr) instLumi = InstLumiLf->GetValue();
 	  double PU = 0;
-	  if(PULf!=0) PU = PULf->GetValue();
+	  if(PULf!=nullptr) PU = PULf->GetValue();
 	  int CM = -100;
 	  if(_useCM) CM = CMLf->GetValue();
 
@@ -391,7 +391,7 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
     	  float htedge   = 0;
     	  float hapoth   = 0;
 		  if(layer>=11) {
-			const BoundPlane plane = stripdet->surface();
+			const BoundPlane& plane = stripdet->surface();
 			const TrapezoidalPlaneBounds* trapezoidalBounds( dynamic_cast<const TrapezoidalPlaneBounds*>(&(plane.bounds())));
 			std::array<const float, 4> const & parameters = (*trapezoidalBounds).parameters(); 
 			hbedge         = parameters[0];

--- a/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
@@ -274,7 +274,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
   const   reco::TrackCollection *tracksCKF=trackCollectionCKF.product();
   if (DEBUG)  cout << "number ckf tracks found = " << tracksCKF->size() << endl;
   //if (tracksCKF->size() == 1 ){
-  if (tracksCKF->size() > 0) {
+  if (!tracksCKF->empty()) {
     if( cutOnTracks_ && (tracksCKF->size() >= trackMultiplicityCut_) ) return;
     if( DEBUG && cutOnTracks_ ) cout << "starting checking good event with < "<< trackMultiplicityCut_ <<" tracks" << endl;
 
@@ -300,7 +300,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
     Handle<MuonCollection> muH;
     if(e.getByLabel("muonsWitht0Correction",muH)){
       const MuonCollection & muonsT0  =  *muH.product();
-      if(muonsT0.size()!=0) {
+      if(!muonsT0.empty()) {
 	MuonTime mt0 = muonsT0[0].time();
 	timeDT = mt0.timeAtIpInOut; 
 	timeDTErr = mt0.timeAtIpInOutErr;
@@ -415,7 +415,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
 	    // if no detId is available, ie detId==0, then no compatible layer was crossed
 	    // otherwise, use that TM for the efficiency measurement
 	    TrajectoryMeasurement tob6TM(tmp.back());
-	    auto tob6Hit = tob6TM.recHit();
+	    const auto& tob6Hit = tob6TM.recHit();
 	    
 	    if (tob6Hit->geographicalId().rawId()!=0) {
 	      if (DEBUG) cout << "tob6 hit actually being added to TM vector" << endl;
@@ -461,7 +461,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
 	    // if no detId is available, ie detId==0, then no compatible layer was crossed
 	    // otherwise, use that TM for the efficiency measurement
 	    TrajectoryMeasurement tec9TM(tmp.back());
-	    auto tec9Hit = tec9TM.recHit();
+	    const auto& tec9Hit = tec9TM.recHit();
 	    
 	    unsigned int tec9id = tec9Hit->geographicalId().rawId();
 	    if (DEBUG) cout << "tec9id = " << tec9id << " is Double sided = " <<  isDoubleSided(tec9id, tTopo) << "  and 0x3 = " << (tec9id & 0x3) << endl;
@@ -520,7 +520,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
 	    
 	    // RPhi RecHit Efficiency 
 	    
-	    if (input.size() > 0 ) {  
+	    if (!input.empty() ) {  
 	      if (DEBUG) cout << "Checking clusters with size = " << input.size() << endl;
 	      int nClusters = 0;
 	      std::vector< std::vector<float> > VCluster_info; //fill with X residual, X residual pull, local X, sig(X), local Y, sig(Y), StoN
@@ -540,7 +540,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es){
                   float uylfac   = 0.0;
                   float uxlden   = 0.0;
                   if(TKlayers>=11) {
-                     const BoundPlane plane = stripdet->surface();
+                     const BoundPlane& plane = stripdet->surface();
                      const TrapezoidalPlaneBounds* trapezoidalBounds( dynamic_cast<const TrapezoidalPlaneBounds*>(&(plane.bounds())));
 		     std::array<const float, 4> const & parameterTrap = (*trapezoidalBounds).parameters(); // el bueno aqui
                      hbedge         = parameterTrap[0];

--- a/CalibTracker/SiStripLorentzAngle/interface/LA_Filler_Fitter.h
+++ b/CalibTracker/SiStripLorentzAngle/interface/LA_Filler_Fitter.h
@@ -47,11 +47,11 @@ class LA_Filler_Fitter {
   static std::string method(Method m,bool fit=true) { 
     switch(m) {
     case WIDTH: return      "_width_prof";
-    case PROB1: return fit? SymmetryFit::name(method(m,0)): "_prob_w1"   ;  
-    case AVGV2: return fit? SymmetryFit::name(method(m,0)): "_avg_var_w2";  
-    case AVGV3: return fit? SymmetryFit::name(method(m,0)): "_avg_var_w3";  
-    case RMSV2: return fit? SymmetryFit::name(method(m,0)): "_rms_var_w2";  
-    case RMSV3: return fit? SymmetryFit::name(method(m,0)): "_rms_var_w3";  
+    case PROB1: return fit? SymmetryFit::name(method(m,false)): "_prob_w1"   ;  
+    case AVGV2: return fit? SymmetryFit::name(method(m,false)): "_avg_var_w2";  
+    case AVGV3: return fit? SymmetryFit::name(method(m,false)): "_avg_var_w3";  
+    case RMSV2: return fit? SymmetryFit::name(method(m,false)): "_rms_var_w2";  
+    case RMSV3: return fit? SymmetryFit::name(method(m,false)): "_rms_var_w3";  
     default: return "_UNKNOWN";
     }
   }

--- a/CalibTracker/SiStripLorentzAngle/interface/SiStripCalibLorentzAngle.h
+++ b/CalibTracker/SiStripLorentzAngle/interface/SiStripCalibLorentzAngle.h
@@ -1,7 +1,7 @@
 #ifndef CalibTracker_SiStripLorentzAngle_SiStripCalibLorentzAngle_h
 #define CalibTracker_SiStripLorentzAngle_SiStripCalibLorentzAngle_h
 
-#include <string.h>
+#include <cstring>
 #include <iostream>
 #include <map>
 #include "FWCore/Framework/interface/EDAnalyzer.h"
@@ -40,11 +40,11 @@ class SiStripCalibLorentzAngle : public ConditionDBWriter<SiStripLorentzAngle>
   
   explicit SiStripCalibLorentzAngle(const edm::ParameterSet& conf);
   
-  virtual ~SiStripCalibLorentzAngle();
+  ~SiStripCalibLorentzAngle() override;
   
-  SiStripLorentzAngle* getNewObject();
+  SiStripLorentzAngle* getNewObject() override;
   
-  void algoBeginJob(const edm::EventSetup&);
+  void algoBeginJob(const edm::EventSetup&) override;
   
  private:
  

--- a/CalibTracker/SiStripLorentzAngle/interface/SiStripLAProfileBooker.h
+++ b/CalibTracker/SiStripLorentzAngle/interface/SiStripLAProfileBooker.h
@@ -33,13 +33,13 @@ class SiStripLAProfileBooker : public edm::EDAnalyzer
   
   explicit SiStripLAProfileBooker(const edm::ParameterSet& conf);
   
-  ~SiStripLAProfileBooker();
+  ~SiStripLAProfileBooker() override;
   
-  void beginRun(edm::Run const&,const edm::EventSetup& c);
+  void beginRun(edm::Run const&,const edm::EventSetup& c) override;
   
-  void endJob(); 
+  void endJob() override; 
   
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   
   void getlayer(const DetId & detid, const TrackerTopology* tTopo, std::string &name,unsigned int &layerid);
   

--- a/CalibTracker/SiStripLorentzAngle/plugins/EnsembleCalibrationLA.h
+++ b/CalibTracker/SiStripLorentzAngle/plugins/EnsembleCalibrationLA.h
@@ -11,9 +11,9 @@ class EnsembleCalibrationLA : public edm::EDAnalyzer {
  public:
 
   explicit EnsembleCalibrationLA(const edm::ParameterSet&);
-  void analyze(const edm::Event&, const edm::EventSetup&) {}
-  void endRun(const edm::Run&, const edm::EventSetup&);
-  void endJob();
+  void analyze(const edm::Event&, const edm::EventSetup&) override {}
+  void endRun(const edm::Run&, const edm::EventSetup&) override;
+  void endJob() override;
 
  private:
   

--- a/CalibTracker/SiStripLorentzAngle/plugins/MeasureLA.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/MeasureLA.cc
@@ -113,7 +113,7 @@ process_reports() const {
 void MeasureLA::
 write_report_plots(std::string name, LA_Filler_Fitter::Method method, GRANULARITY gran) const {
   TFile file((name+".root").c_str(),"RECREATE");
-  const std::string key = ".*" + granularity(gran) + ".*("+LA_Filler_Fitter::method(method)+"|"+LA_Filler_Fitter::method(method,0)+".*)";
+  const std::string key = ".*" + granularity(gran) + ".*("+LA_Filler_Fitter::method(method)+"|"+LA_Filler_Fitter::method(method,false)+".*)";
   for(Book::const_iterator hist = book.begin(key); hist!=book.end(); ++hist) 
     if(hist->second) hist->second->Write();
   file.Close();

--- a/CalibTracker/SiStripLorentzAngle/plugins/SiStripCalibLorentzAngle.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/SiStripCalibLorentzAngle.cc
@@ -311,8 +311,8 @@ void SiStripCalibLorentzAngle::algoBeginJob(const edm::EventSetup& c){
   
   for(histo=histolist.begin();histo!=histolist.end();++histo){
   
-  FitFunction = 0;
-  FitFunction2IT = 0;
+  FitFunction = nullptr;
+  FitFunction2IT = nullptr;
   bool Good2ITFit = false;
   bool ModuleHisto = true;
   
@@ -343,7 +343,7 @@ void SiStripCalibLorentzAngle::algoBeginJob(const edm::EventSetup& c){
     ModuleHisto=false;
     edm::LogInfo("SiStripCalibLorentzAngle")<<"### NO MODULE HISTOGRAM";}
     
-    if(stripdet!=0 && ModuleHisto==true){
+    if(stripdet!=nullptr && ModuleHisto==true){
     
       if(subid.subdetId() == int (StripSubdetector::TIB)){
       
@@ -367,7 +367,7 @@ void SiStripCalibLorentzAngle::algoBeginJob(const edm::EventSetup& c){
     
     //get magnetic field
     const StripGeomDetUnit* det = dynamic_cast<const StripGeomDetUnit*>(estracker->idToDetUnit(detid));
-    if (det==0){
+    if (det==nullptr){
     edm::LogError("SiStripCalibLorentzAngle") << "[SiStripCalibLorentzAngle::getNewObject] the detID " << id << " doesn't seem to belong to Tracker" <<std::endl; 	
     continue;
     }
@@ -376,7 +376,7 @@ void SiStripCalibLorentzAngle::algoBeginJob(const edm::EventSetup& c){
     theBfield = (theBfield > 0) ? theBfield : 0.00001; 
     TH1Ds["MagneticField"]->Fill(theBfield);    
     }
-    if(stripdet==0)continue;
+    if(stripdet==nullptr)continue;
       
     if(((*histo)->getEntries()<=FitCuts_Entries)&&ModuleHisto==true){
     if(((*histo)->getEntries()==0)&&ModuleHisto==true){    
@@ -404,10 +404,10 @@ void SiStripCalibLorentzAngle::algoBeginJob(const edm::EventSetup& c){
     gStyle->SetOptFit(111);  
     
     //Extract TProfile from Monitor Element to ProfileMap
-    Profiles[name.c_str()] = new TProfile;   
+    Profiles[name] = new TProfile;   
     TProfile* theProfile=ExtractTObject<TProfile>().extract(*histo);   
-    theProfile->Copy(*Profiles[name.c_str()]);    
-    Profiles[name.c_str()]->SetName(name.c_str());
+    theProfile->Copy(*Profiles[name]);    
+    Profiles[name]->SetName(name.c_str());
   
     if(((*histo)->getEntries()>FitCuts_Entries) && ModuleHisto==true){   
       histocounter++;            
@@ -427,7 +427,7 @@ void SiStripCalibLorentzAngle::algoBeginJob(const edm::EventSetup& c){
       fitfunc->FixParameter(3, pitch);
       fitfunc->FixParameter(4, thickness);
       
-      Profiles[name.c_str()]->Fit(fitfunc.get(),"E","",ModuleRangeMin, ModuleRangeMax);
+      Profiles[name]->Fit(fitfunc.get(),"E","",ModuleRangeMin, ModuleRangeMax);
             
       FitFunction = fitfunc.get();
       chi2norm = FitFunction->GetChisquare()/FitFunction->GetNDF();
@@ -443,7 +443,7 @@ void SiStripCalibLorentzAngle::algoBeginJob(const edm::EventSetup& c){
       fitfunc2IT->FixParameter(4, thickness);
       
       //2nd Iteration
-      Profiles[name.c_str()]->Fit(fitfunc2IT.get(),"E","",ModuleRangeMin2IT, ModuleRangeMax2IT);
+      Profiles[name]->Fit(fitfunc2IT.get(),"E","",ModuleRangeMin2IT, ModuleRangeMax2IT);
       
       FitFunction = fitfunc2IT.get();
       chi2norm = FitFunction->GetChisquare()/FitFunction->GetNDF();
@@ -453,9 +453,9 @@ void SiStripCalibLorentzAngle::algoBeginJob(const edm::EventSetup& c){
       if(FitFunction->GetParameter(0)>FitCuts_p0 || FitFunction->GetParameter(1)<FitCuts_p1 || FitFunction->GetParameter(2)<FitCuts_p2 || chi2norm>FitCuts_chi2 || FitFunction->GetParError(0)<FitCuts_ParErr_p0){
       
       if(subid.subdetId() == int (StripSubdetector::TIB)){
-      Profiles[name.c_str()]->SetDirectory(TIB_2IT_BadFit);
+      Profiles[name]->SetDirectory(TIB_2IT_BadFit);
       }else{
-      Profiles[name.c_str()]->SetDirectory(TOB_2IT_BadFit);} 
+      Profiles[name]->SetDirectory(TOB_2IT_BadFit);} 
             
       SecondIT_badfit++;
       badFit=1;     
@@ -467,9 +467,9 @@ void SiStripCalibLorentzAngle::algoBeginJob(const edm::EventSetup& c){
       if(FitFunction->GetParameter(0)<FitCuts_p0 && FitFunction->GetParameter(1)>FitCuts_p1 && FitFunction->GetParameter(2)>FitCuts_p2 && chi2norm<FitCuts_chi2 && FitFunction->GetParError(0)>FitCuts_ParErr_p0){
       
       if(subid.subdetId() == int (StripSubdetector::TIB)){
-      Profiles[name.c_str()]->SetDirectory(TIB_2IT_GoodFit);
+      Profiles[name]->SetDirectory(TIB_2IT_GoodFit);
       }else{
-      Profiles[name.c_str()]->SetDirectory(TOB_2IT_GoodFit);} 
+      Profiles[name]->SetDirectory(TOB_2IT_GoodFit);} 
       
       SecondIT_goodfit++;      
       Good2ITFit = true;
@@ -486,9 +486,9 @@ void SiStripCalibLorentzAngle::algoBeginJob(const edm::EventSetup& c){
 	goodFit1IT = 1;
 	
 	if(subid.subdetId() == int (StripSubdetector::TIB)){
-        Profiles[name.c_str()]->SetDirectory(TIB_1IT_GoodFit);
+        Profiles[name]->SetDirectory(TIB_1IT_GoodFit);
         }else{
-        Profiles[name.c_str()]->SetDirectory(TOB_1IT_GoodFit);} 
+        Profiles[name]->SetDirectory(TOB_1IT_GoodFit);} 
 	
 	}
 	

--- a/CalibTracker/SiStripLorentzAngle/plugins/SiStripLAProfileBooker.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/SiStripLAProfileBooker.cc
@@ -85,7 +85,7 @@ void SiStripLAProfileBooker::beginRun(const edm::Run &,const edm::EventSetup& c)
   tracker=&(*estracker); 
 
   std::vector<uint32_t> activeDets;
-  edm::ESHandle<SiStripDetCabling> tkmechstruct=0;
+  edm::ESHandle<SiStripDetCabling> tkmechstruct=nullptr;
   if (conf_.getParameter<bool>("UseStripCablingDB")){ 
     c.get<SiStripDetCablingRcd>().get(tkmechstruct);
     activeDets.clear();
@@ -202,7 +202,7 @@ void SiStripLAProfileBooker::beginRun(const edm::Run &,const edm::EventSetup& c)
       float thickness=stripdet->specificSurface().bounds().thickness();
       
       folder_organizer.setDetectorFolder(Iditer->rawId(), tTopo);
-      hid = hidmanager.createHistoId(TkTag.label().c_str(),"det",Iditer->rawId());
+      hid = hidmanager.createHistoId(TkTag.label(),"det",Iditer->rawId());
       MonitorElement * profile=dbe_->bookProfile(hid,hid,module_bin,ModuleRangeMin,ModuleRangeMax,20,0,5,"");
       detparameters *param=new detparameters;
       histos[Iditer->rawId()] = profile;
@@ -221,10 +221,10 @@ void SiStripLAProfileBooker::beginRun(const edm::Run &,const edm::EventSetup& c)
       std::string name;
       unsigned int layerid;
       getlayer(subid,tTopo,name,layerid);
-      name+=TkTag.label().c_str();
+      name+=TkTag.label();
       if(summaryhisto.find(layerid)==(summaryhisto.end())){
 	folder_organizer.setSiStripFolder();
-	MonitorElement * summaryprofile=0;
+	MonitorElement * summaryprofile=nullptr;
 	if (subid.subdetId()==int (StripSubdetector::TIB)||subid.subdetId()==int (StripSubdetector::TID))
 	  summaryprofile=dbe_->bookProfile(name,name,SUM_bin,TIBRangeMin,TIBRangeMax,20,0,5,"");
 	else if (subid.subdetId()==int (StripSubdetector::TOB)||subid.subdetId()==int (StripSubdetector::TEC))

--- a/CalibTracker/SiStripLorentzAngle/src/LA_Filler.cc
+++ b/CalibTracker/SiStripLorentzAngle/src/LA_Filler.cc
@@ -64,8 +64,8 @@ allAndOne(const unsigned width) const
 poly<std::string> LA_Filler_Fitter::
 varWidth(const unsigned width) const { 
   poly<std::string> vw; vw++; 
-  if(width==2 && methods_ & (AVGV2|RMSV2) ) vw*=method(AVGV2,0);
-  if(width==3 && methods_ & (AVGV3|RMSV3) ) vw*=method(AVGV3,0);
+  if(width==2 && methods_ & (AVGV2|RMSV2) ) vw*=method(AVGV2,false);
+  if(width==3 && methods_ & (AVGV3|RMSV3) ) vw*=method(AVGV3,false);
   return vw;
 }
 

--- a/CalibTracker/SiStripLorentzAngle/src/LA_Fitter.cc
+++ b/CalibTracker/SiStripLorentzAngle/src/LA_Fitter.cc
@@ -11,7 +11,7 @@ fit_width_profile(Book& book) {
   for(Book::iterator it = book.begin(".*"+method(WIDTH)); it!=book.end(); ++it) {
     it->second->SetTitle("Mean Cluster Width;tan#theta_{t}");
     TH1* const p = it->second;
-    if(p->GetEntries() < 400) { delete p; book[it->first]=0; continue;}
+    if(p->GetEntries() < 400) { delete p; book[it->first]=nullptr; continue;}
     p->SetTitle(";tan#theta_{t};");
     const float min = p->GetMinimum();
     const float max = p->GetMaximum();
@@ -36,36 +36,36 @@ make_and_fit_symmchi2(Book& book) {
     const std::string base = boost::erase_all_copy(it->first,"_all");
 
     std::vector<Book::iterator> rebin_hists;              
-    Book::iterator    all = it;	                             rebin_hists.push_back(all);   
+    const Book::iterator&    all = it;	                             rebin_hists.push_back(all);   
     Book::iterator     w1 = book.find(base+"_w1");           rebin_hists.push_back(w1);    
-    Book::iterator var_w2 = book.find(base+method(AVGV2,0)); rebin_hists.push_back(var_w2);
-    Book::iterator var_w3 = book.find(base+method(AVGV3,0)); rebin_hists.push_back(var_w3);
+    Book::iterator var_w2 = book.find(base+method(AVGV2,false)); rebin_hists.push_back(var_w2);
+    Book::iterator var_w3 = book.find(base+method(AVGV3,false)); rebin_hists.push_back(var_w3);
 
     const unsigned rebin = std::max( var_w2==book.end() ? 0 : find_rebin(var_w2->second), 
 				     var_w3==book.end() ? 0 : find_rebin(var_w3->second) );
     BOOST_FOREACH(Book::iterator it, rebin_hists) if(it!=book.end()) it->second->Rebin( rebin>1 ? rebin<7 ? rebin : 6 : 1);
 
-    TH1* const prob_w1 = w1==book.end()     ? 0 : subset_probability( base+method(PROB1,0) ,w1->second,all->second);
-    TH1* const rmsv_w2 = var_w2==book.end() ? 0 :        rms_profile( base+method(RMSV2,0), (TProfile*const)var_w2->second);
-    TH1* const rmsv_w3 = var_w3==book.end() ? 0 :        rms_profile( base+method(RMSV3,0), (TProfile*const)var_w3->second);
+    TH1* const prob_w1 = w1==book.end()     ? nullptr : subset_probability( base+method(PROB1,false) ,w1->second,all->second);
+    TH1* const rmsv_w2 = var_w2==book.end() ? nullptr :        rms_profile( base+method(RMSV2,false), (TProfile*const)var_w2->second);
+    TH1* const rmsv_w3 = var_w3==book.end() ? nullptr :        rms_profile( base+method(RMSV3,false), (TProfile*const)var_w3->second);
     
     std::vector<TH1*> fit_hists;
     if(prob_w1) {
-      book.book(base+method(PROB1,0),prob_w1);
+      book.book(base+method(PROB1,false),prob_w1);
       fit_hists.push_back(prob_w1);  prob_w1->SetTitle("Width==1 Probability;tan#theta_{t}-(dx/dz)_{reco}");
     }
     if(var_w2!=book.end())  {
-      book.book(base+method(RMSV2,0),rmsv_w2);
+      book.book(base+method(RMSV2,false),rmsv_w2);
       fit_hists.push_back(var_w2->second);   var_w2->second->SetTitle("Width==2 Mean Variance;tan#theta_{t}-(dx/dz)_{reco}");
       fit_hists.push_back(rmsv_w2);                 rmsv_w2->SetTitle("Width==2 RMS Variance;tan#theta_{t}-(dx/dz)_{reco}");
     }
     if(var_w3!=book.end())  {
-      book.book(base+method(RMSV3,0),rmsv_w3);
+      book.book(base+method(RMSV3,false),rmsv_w3);
       fit_hists.push_back(var_w3->second);   var_w3->second->SetTitle("Width==3 Mean Variance;tan#theta_{t}-(dx/dz)_{reco}");
       fit_hists.push_back(rmsv_w3);                 rmsv_w3->SetTitle("Width==3 RMS Variance;tan#theta_{t}-(dx/dz)_{reco}");
     }
 
-    if(!fit_hists.size()) continue;
+    if(fit_hists.empty()) continue;
     const unsigned bins = fit_hists[0]->GetNbinsX();
     const unsigned guess = fit_hists[0]->FindBin(0);
     const std::pair<unsigned,unsigned> range(guess-bins/30,guess+bins/30);

--- a/CalibTracker/SiStripLorentzAngle/src/LA_Results.cc
+++ b/CalibTracker/SiStripLorentzAngle/src/LA_Results.cc
@@ -37,8 +37,8 @@ result(Method m, const std::string name, const Book& book) {
       p.ndof = (unsigned) (f->GetParameter(3));
       p.entries = 
 	(m&PROB1)         ? (unsigned) book[base+"_w1"]->GetEntries() : 
-	(m&(AVGV2|RMSV2)) ? (unsigned) book[base+method(AVGV2,0)]->GetEntries() : 
-	(m&(AVGV3|RMSV3)) ? (unsigned) book[base+method(AVGV3,0)]->GetEntries() : 0 ;
+	(m&(AVGV2|RMSV2)) ? (unsigned) book[base+method(AVGV2,false)]->GetEntries() : 
+	(m&(AVGV3|RMSV3)) ? (unsigned) book[base+method(AVGV3,false)]->GetEntries() : 0 ;
       break;
     }
     default: break;

--- a/CalibTracker/SiStripLorentzAngle/src/SymmetryFit.cc
+++ b/CalibTracker/SiStripLorentzAngle/src/SymmetryFit.cc
@@ -18,7 +18,7 @@ TH1* SymmetryFit::symmetryChi2(std::string basename, const std::vector<TH1*>& ca
   }
 
   int status = combined.fit();
-  if(status) { delete combined.chi2_; combined.chi2_=0;}
+  if(status) { delete combined.chi2_; combined.chi2_=nullptr;}
   return combined.chi2_;
 }
 
@@ -26,7 +26,7 @@ TH1* SymmetryFit::symmetryChi2(const TH1* candidate, const std::pair<unsigned,un
 {
   SymmetryFit sf(candidate, range);
   int status = sf.fit();
-  if(status) { delete sf.chi2_; sf.chi2_=0; }
+  if(status) { delete sf.chi2_; sf.chi2_=nullptr; }
   return sf.chi2_;
 }
 
@@ -36,7 +36,7 @@ SymmetryFit::SymmetryFit(const TH1* h, const std::pair<unsigned,unsigned> r)
     range_(r),
     minmaxUsable_(findUsableMinMax()),
     ndf_( minmaxUsable_.first<minmaxUsable_.second ? minmaxUsable_.second-minmaxUsable_.first : 0),
-    chi2_(0)
+    chi2_(nullptr)
 {
   makeChi2Histogram();
   fillchi2();
@@ -124,7 +124,7 @@ float SymmetryFit::chi2_element(std::pair<unsigned,unsigned> range)
 int SymmetryFit::fit() {
 
   std::vector<double> p = pol2_from_pol3(chi2_);
-  if( !p.size() || 
+  if( p.empty() || 
       p[0] < chi2_->GetBinCenter(1) || 
       p[0] > chi2_->GetBinCenter(chi2_->GetNbinsX()))
     return 7;

--- a/CalibTracker/SiStripQuality/plugins/SiStripBadModuleByHandBuilder.h
+++ b/CalibTracker/SiStripQuality/plugins/SiStripBadModuleByHandBuilder.h
@@ -19,12 +19,12 @@ class SiStripBadModuleByHandBuilder : public ConditionDBWriter<SiStripBadStrip> 
 public:
 
   explicit SiStripBadModuleByHandBuilder(const edm::ParameterSet&);
-  ~SiStripBadModuleByHandBuilder();
+  ~SiStripBadModuleByHandBuilder() override;
 
 
 private:
 
-  SiStripBadStrip* getNewObject();
+  SiStripBadStrip* getNewObject() override;
 
 private:
   edm::FileInPath fp_;

--- a/CalibTracker/SiStripQuality/plugins/SiStripBadStripFromASCIIFile.h
+++ b/CalibTracker/SiStripQuality/plugins/SiStripBadStripFromASCIIFile.h
@@ -16,12 +16,12 @@ class SiStripBadStripFromASCIIFile:public ConditionDBWriter<SiStripBadStrip> {
 
   explicit SiStripBadStripFromASCIIFile( const edm::ParameterSet& iConfig);
 
-  ~SiStripBadStripFromASCIIFile(){};
+  ~SiStripBadStripFromASCIIFile() override{};
 
 
 
  private:
-  virtual SiStripBadStrip * getNewObject();
+  SiStripBadStrip * getNewObject() override;
   edm::FileInPath fp_;
   bool printdebug_;
 };

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.h
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.h
@@ -24,24 +24,24 @@ class SiStripQualityHotStripIdentifier : public ConditionDBWriter<SiStripBadStri
 public:
 
   explicit SiStripQualityHotStripIdentifier(const edm::ParameterSet&);
-  ~SiStripQualityHotStripIdentifier();
+  ~SiStripQualityHotStripIdentifier() override;
 
 private:
 
  //Will be called at the beginning of the job
-  void algoBeginJob(const edm::EventSetup&){}
+  void algoBeginJob(const edm::EventSetup&) override{}
   //Will be called at the beginning of each run in the job
-  void algoBeginRun(const edm::Run &, const edm::EventSetup &);
+  void algoBeginRun(const edm::Run &, const edm::EventSetup &) override;
   //Will be called at the beginning of each luminosity block in the run
-  void algoBeginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &){ resetHistos(); }
+  void algoBeginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) override{ resetHistos(); }
   //Will be called at the end of the job
-  void algoEndJob();
+  void algoEndJob() override;
 
 
   //Will be called at every event
-  void algoAnalyze(const edm::Event&, const edm::EventSetup&);
+  void algoAnalyze(const edm::Event&, const edm::EventSetup&) override;
 
-  SiStripBadStrip* getNewObject();
+  SiStripBadStrip* getNewObject() override;
 
 
   void bookHistos();

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics.cc
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics.cc
@@ -24,7 +24,7 @@
 
 #include <iostream>
 #include <iomanip>
-#include <stdio.h>
+#include <cstdio>
 #include <sys/time.h>
 
 
@@ -34,12 +34,12 @@ SiStripQualityStatistics::SiStripQualityStatistics( const edm::ParameterSet& iCo
   TkMapFileName_(iConfig.getUntrackedParameter<std::string>("TkMapFileName","")),
   fp_(iConfig.getUntrackedParameter<edm::FileInPath>("file",edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat"))),
   saveTkHistoMap_(iConfig.getUntrackedParameter<bool>("SaveTkHistoMap",true)),
-  tkMap(0),tkMapFullIOVs(0)
+  tkMap(nullptr),tkMapFullIOVs(nullptr)
 {  
   reader = new SiStripDetInfoFileReader(fp_.fullPath());
 
   tkMapFullIOVs=new TrackerMap( "BadComponents" );
-  tkhisto=0;
+  tkhisto=nullptr;
   if (TkMapFileName_!=""){
     tkhisto   =new TkHistoMap("BadComp","BadComp",-1.); //here the baseline (the value of the empty,not assigned bins) is put to -1 (default is zero)
   }
@@ -49,9 +49,9 @@ void SiStripQualityStatistics::endJob(){
 
   std::string filename=TkMapFileName_;
   if (filename!=""){
-    tkMapFullIOVs->save(false,0,0,filename.c_str());
+    tkMapFullIOVs->save(false,0,0,filename);
     filename.erase(filename.begin()+filename.find("."),filename.end());
-    tkMapFullIOVs->print(false,0,0,filename.c_str());
+    tkMapFullIOVs->print(false,0,0,filename);
   
     if(saveTkHistoMap_){
       tkhisto->save(filename+".root");
@@ -205,7 +205,7 @@ void SiStripQualityStatistics::analyze( const edm::Event& e, const edm::EventSet
 
     //------- Global Statistics on percentage of bad components along the IOVs ------//
     tkMapFullIOVs->fill(detid,percentage);
-    if(tkhisto!=NULL)
+    if(tkhisto!=nullptr)
       tkhisto->fill(detid,percentage);
   }
   
@@ -269,9 +269,9 @@ void SiStripQualityStatistics::analyze( const edm::Event& e, const edm::EventSet
     
   if (filename!=""){
     filename.insert(filename.find("."),sRun.str());
-    tkMap->save(true,0,0,filename.c_str());
+    tkMap->save(true,0,0,filename);
     filename.erase(filename.begin()+filename.find("."),filename.end());
-    tkMap->print(true,0,0,filename.c_str());
+    tkMap->print(true,0,0,filename);
   }
 }
 

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics.h
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics.h
@@ -25,10 +25,10 @@ class SiStripQualityStatistics : public edm::EDAnalyzer {
 
  public:
   explicit SiStripQualityStatistics( const edm::ParameterSet& );
-  ~SiStripQualityStatistics(){};
+  ~SiStripQualityStatistics() override{};
   
-  void analyze( const edm::Event&, const edm::EventSetup& );
-  void endJob();
+  void analyze( const edm::Event&, const edm::EventSetup& ) override;
+  void endJob() override;
  
  private:
 

--- a/CalibTracker/SiStripQuality/src/SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy.cc
+++ b/CalibTracker/SiStripQuality/src/SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy.cc
@@ -358,7 +358,7 @@ void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::extractBadAPVSandStr
 
   if (WriteDQMHistograms_==true){
     dqmStore->cd();
-    dqmStore->save(DQMOutfileName_.c_str());
+    dqmStore->save(DQMOutfileName_);
   }
 
   LogTrace("SiStripBadAPV") << ss.str() << std::endl;


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this tomorrow to avoid conflicts to the extent possible]