### PR TITLE
GT Updates with inclusion of RPCLink Maps for L1T, HCAL Pedestals and widths, StripBadChannel for MCV2

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,7 +16,7 @@ autoCond = {
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
     'run2_mc'           :   '94X_mcRun2_asymptotic_v0',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '94X_mcRun2_asymptotic_v0',
+    'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'   :   '94X_mcRun2cosmics_startup_deco_v0',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,61 +2,61 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '94X_mcRun1_design_v0',
+    'run1_design'       :   '94X_mcRun1_design_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '94X_mcRun1_realistic_v0',
+    'run1_mc'           :   '94X_mcRun1_realistic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '94X_mcRun1_HeavyIon_v0',
+    'run1_mc_hi'        :   '94X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '94X_mcRun1_pA_v0',
+    'run1_mc_pa'        :   '94X_mcRun1_pA_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '93X_mcRun2_design_v1',
+    'run2_design'       :   '94X_mcRun2_design_v0',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '93X_mcRun2_startup_v1',
+    'run2_mc_50ns'      :   '94X_mcRun2_startup_v0',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '93X_mcRun2_asymptotic_v2',
+    'run2_mc'           :   '94X_mcRun2_asymptotic_v0',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v1',
+    'run2_mc_l1stage1'  :   '94X_mcRun2_asymptotic_v0',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '93X_mcRun2cosmics_startup_deco_v1',
+    'run2_mc_cosmics'   :   '94X_mcRun2cosmics_startup_deco_v0',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '93X_mcRun2_HeavyIon_v1',
+    'run2_mc_hi'        :   '94X_mcRun2_HeavyIon_v0',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '93X_mcRun2_pA_v1',
+    'run2_mc_pa'        :   '94X_mcRun2_pA_v0',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '94X_dataRun2_v1',
+    'run1_data'         :   '94X_dataRun2_v2',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '94X_dataRun2_v1',
+    'run2_data'         :   '94X_dataRun2_v2',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '94X_dataRun2_relval_v2',
+    'run2_data_relval'  :   '94X_dataRun2_relval_v3',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '94X_dataRun2_PromptLike_v1',
+    'run2_data_promptlike' : '94X_dataRun2_PromptLike_v3',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '94X_dataRun2_HLT_frozen_v2',
+    'run1_hlt'          :   '94X_dataRun2_HLT_frozen_v3',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '94X_dataRun2_HLT_frozen_v2',
+    'run2_hlt'          :   '94X_dataRun2_HLT_frozen_v3',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '94X_dataRun2_HLT_relval_v1',
+    'run2_hlt_relval'   :   '94X_dataRun2_HLT_relval_v2',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '94X_dataRun2_HLTHI_frozen_v1',
+    'run2_hlt_hi'       :   '94X_dataRun2_HLTHI_frozen_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '94X_mc2017_design_IdealBS_v0',
+    'phase1_2017_design'       :  '94X_mc2017_design_IdealBS_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '94X_mc2017_realistic_v1',
+    'phase1_2017_realistic'    : '94X_mc2017_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '94X_mc2017cosmics_realistic_deco_v0',
+    'phase1_2017_cosmics'      : '94X_mc2017cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '94X_mc2017cosmics_realistic_peak_v0',
+    'phase1_2017_cosmics_peak' : '94X_mc2017cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '94X_upgrade2018_design_IdealBS_v1',
+    'phase1_2018_design'       : '94X_upgrade2018_design_IdealBS_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '94X_upgrade2018_realistic_v1',
+    'phase1_2018_realistic'    : '94X_upgrade2018_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '94X_upgrade2018cosmics_realistic_deco_v0',
+    'phase1_2018_cosmics'      :   '94X_upgrade2018cosmics_realistic_deco_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '93X_upgrade2023_realistic_v2'
+    'phase2_realistic'         : '94X_upgrade2023_realistic_v0'
 }
 
 aliases = {


### PR DESCRIPTION
# Summary of changes in Global Tags 
 
## RunI simulation 
 
   * **RunI Heavy Ions scenario** : [94X_mcRun1_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun1_HeavyIon_v1) as [94X_mcRun1_HeavyIon_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun1_HeavyIon_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun1_HeavyIon_v1/94X_mcRun1_HeavyIon_v0): 
      * update of RPC Link maps needed for L1T

   * **RunI Ideal scenario** : [94X_mcRun1_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun1_design_v1) as [94X_mcRun1_design_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun1_design_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun1_design_v1/94X_mcRun1_design_v0): 
      * update of RPC Link maps needed for L1T

   * **RunI Proton-Lead scenario** : [94X_mcRun1_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun1_pA_v1) as [94X_mcRun1_pA_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun1_pA_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun1_pA_v1/94X_mcRun1_pA_v0): 
      * update of RPC Link maps needed for L1T

   * **RunI Realistic scenario** : [94X_mcRun1_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun1_realistic_v1) as [94X_mcRun1_realistic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun1_realistic_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun1_realistic_v1/94X_mcRun1_realistic_v0): 
      * update of RPC Link maps needed for L1T

## RunII simulation 
 
   * **RunII Asymptotic scenario** : [94X_mcRun2_asymptotic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2_asymptotic_v0) as [93X_mcRun2_asymptotic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_asymptotic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun2_asymptotic_v0/93X_mcRun2_asymptotic_v2): 
      * update of RPC Link maps needed for L1T

   * **RunII CRAFT scenario** : [94X_mcRun2cosmics_startup_deco_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2cosmics_startup_deco_v0) as [93X_mcRun2cosmics_startup_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2cosmics_startup_deco_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun2cosmics_startup_deco_v0/93X_mcRun2cosmics_startup_deco_v1): 
      * update of RPC Link maps needed for L1T

   * **RunII Heavy Ions scenario** : [94X_mcRun2_HeavyIon_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2_HeavyIon_v0) as [93X_mcRun2_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_HeavyIon_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun2_HeavyIon_v0/93X_mcRun2_HeavyIon_v1): 
      * update of RPC Link maps needed for L1T

   * **RunII Ideal scenario** : [94X_mcRun2_design_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2_design_v0) as [93X_mcRun2_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_design_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun2_design_v0/93X_mcRun2_design_v1): 
      * update of RPC Link maps needed for L1T

   * **RunII Proton-Lead scenario** : [94X_mcRun2_pA_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2_pA_v0) as [93X_mcRun2_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_pA_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun2_pA_v0/93X_mcRun2_pA_v1): 
      * update of RPC Link maps needed for L1T

   * **RunII Startup scenario** : [94X_mcRun2_startup_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2_startup_v0) as [93X_mcRun2_startup_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_startup_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun2_startup_v0/93X_mcRun2_startup_v1): 
      * update of RPC Link maps needed for L1T

## RunI data 
 
   * **RunI HLT processing** : [94X_dataRun2_HLT_frozen_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_frozen_v3) as [94X_dataRun2_HLT_frozen_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_frozen_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_HLT_frozen_v3/94X_dataRun2_HLT_frozen_v2): 
      * update of RPC Link maps needed for L1T

   * **RunI Offline processing** : [94X_dataRun2_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_v2) as [94X_dataRun2_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_v2/94X_dataRun2_v1): 
      * update of RPC Link maps needed for L1T

## RunII data 
 
   * **RunII HLTHI processing** : [94X_dataRun2_HLTHI_frozen_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLTHI_frozen_v2) as [94X_dataRun2_HLTHI_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLTHI_frozen_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_HLTHI_frozen_v2/94X_dataRun2_HLTHI_frozen_v1): 
      * update of RPC Link maps needed for L1T

   * **RunII HLT relval processing** : [94X_dataRun2_HLT_relval_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_relval_v2) as [94X_dataRun2_HLT_relval_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_relval_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_HLT_relval_v2/94X_dataRun2_HLT_relval_v1): 
      * update of RPC Link maps needed for L1T

   * **RunII Offline processing** : [94X_dataRun2_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_v2) as [94X_dataRun2_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_v2/94X_dataRun2_v1): 
      * update of RPC Link maps needed for L1T

   * **RunII Offline relval processing** : [94X_dataRun2_relval_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_relval_v3) as [94X_dataRun2_relval_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_relval_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_relval_v3/94X_dataRun2_relval_v2): 
      * update of RPC Link maps needed for L1T

   * **RunII Prompt processing** : [94X_dataRun2_PromptLike_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_PromptLike_v3) as [94X_dataRun2_PromptLike_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_PromptLike_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_PromptLike_v3/94X_dataRun2_PromptLike_v1): 
      * update of RPC Link maps needed for L1T

   * **RunI HLT processing** : [94X_dataRun2_HLT_frozen_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_frozen_v3) as [94X_dataRun2_HLT_frozen_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_frozen_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_HLT_frozen_v3/94X_dataRun2_HLT_frozen_v2): 
      * update of RPC Link maps needed for L1T

## Upgrade 
 
   * **PhaseII realistic scenario** : [94X_upgrade2023_realistic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2023_realistic_v0) as [93X_upgrade2023_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_upgrade2023_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_upgrade2023_realistic_v0/93X_upgrade2023_realistic_v2): 
      * update of RPC Link maps needed for L1T
      * update of SiStrip Bad channel tag : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3281.html
      * update of HCAL Electronics map : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3277.html

   * **PhaseI 2018 cosmics scenario** : [94X_upgrade2018cosmics_realistic_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018cosmics_realistic_deco_v1) as [94X_upgrade2018cosmics_realistic_deco_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018cosmics_realistic_deco_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_upgrade2018cosmics_realistic_deco_v1/94X_upgrade2018cosmics_realistic_deco_v0): 
      * update of RPC Link maps needed for L1T
      * update of SiStrip Bad channel tag : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3281.html

   * **PhaseI 2018 design scenario** : [94X_upgrade2018_design_IdealBS_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018_design_IdealBS_v2) as [94X_upgrade2018_design_IdealBS_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018_design_IdealBS_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_upgrade2018_design_IdealBS_v2/94X_upgrade2018_design_IdealBS_v2): 
      * update of RPC Link maps needed for L1T

   * **PhaseI 2018 realistic scenario** : [94X_upgrade2018_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018_realistic_v2) as [94X_upgrade2018_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_upgrade2018_realistic_v2/94X_upgrade2018_realistic_v1): 
      * update of RPC Link maps needed for L1T
      * update of SiStrip Bad channel tag : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3281.html

## 2017_MC 
 
   * **PhaseI 2017 cosmics peak scenario** : [94X_mc2017cosmics_realistic_peak_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017cosmics_realistic_peak_v1) as [94X_mc2017cosmics_realistic_peak_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017cosmics_realistic_peak_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017cosmics_realistic_peak_v1/94X_mc2017cosmics_realistic_peak_v0): 
      * update of HCAL Pedestals, Pedestal widths and QIE : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3265.html
      * update of SiStrip Bad channel tag : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3281.html
      * update of RPC maps needed for L1T

   * **PhaseI 2017 cosmics scenario** : [94X_mc2017cosmics_realistic_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017cosmics_realistic_deco_v1) as [94X_mc2017cosmics_realistic_deco_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017cosmics_realistic_deco_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017cosmics_realistic_deco_v1/94X_mc2017cosmics_realistic_deco_v0): 
      * update of HCAL Pedestals, Pedestal widths and QIE : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3265.html
      * update of SiStrip Bad channel tag : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3281.html
      * update of RPC maps needed for L1T

   * **PhaseI 2017 design scenario** : [94X_mc2017_design_IdealBS_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017_design_IdealBS_v2) as [94X_mc2017_design_IdealBS_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017_design_IdealBS_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017_design_IdealBS_v2/94X_mc2017_design_IdealBS_v0): 
      * update of HCAL Pedestals, Pedestal widths and QIE : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3265.html
      * update of RPC maps needed for L1T
      * update of Jet Probability calibration for b-tagging

   * **PhaseI 2017 realistic scenario** : [94X_mc2017_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017_realistic_v2) as [94X_mc2017_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017_realistic_v2/94X_mc2017_realistic_v1): 
      * update of HCAL Pedestals, Pedestal widths and QIE : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3265.html
      * update of RPC maps needed for L1T
      * update of SiStrip Bad channel tag : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3281.html