### PR TITLE
fix TRKDQM @HLT

### DIFF
--- a/DQM/HLTEvF/plugins/HLTObjectsMonitor.cc
+++ b/DQM/HLTEvF/plugins/HLTObjectsMonitor.cc
@@ -99,14 +99,14 @@ class HLTObjectsMonitor : public DQMEDAnalyzer {
 
    public:
       explicit HLTObjectsMonitor(const edm::ParameterSet&);
-      ~HLTObjectsMonitor() = default;
+      ~HLTObjectsMonitor() override = default;
 
   //      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 
    private:
       void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void bookHistograms(DQMStore::IBooker &i, edm::Run const&, edm::EventSetup const&) override;
+      void bookHistograms(DQMStore::IBooker &i, edm::Run const&, edm::EventSetup const&) override;
       void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
 
       static hltPlot getPlotPSet(edm::ParameterSet pset);

--- a/DQM/HLTEvF/plugins/HLTObjectsMonitor.cc
+++ b/DQM/HLTEvF/plugins/HLTObjectsMonitor.cc
@@ -503,7 +503,7 @@ HLTObjectsMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 		plot.q1q2ME.first->Fill(q1q2);
 
 		if ( abs(id) != abs(id2) )
-		  edm::LogWarning ("HLTObjectsMonitor") << "objects have different ID !?!";
+		  edm::LogWarning ("HLTObjectsMonitor") << plot.pathNAME << " " << plot.moduleNAME << " objects have different ID !?!" << abs(id) << " and " << abs(id2);
 
 		if( (id+id2 ) == 0 ) {   // check di-object system charge and flavor
 		  

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
@@ -96,6 +96,24 @@ hltSiPixelPhase1TrackClustersOnTrackPositionF = hltDefaultHistoTrack.clone(
   )
 )
 
+hltSiPixelPhase1DigisHitmapOnTrack = hltDefaultHistoTrack.clone(
+  enabled = False,
+  name = "digi_occupancy_ontrack",
+  title = "Digi Occupancy (OnTrack)",
+  ylabel = "#digis",
+  dimensions = 0,
+  specs = VPSet(
+    Specification(PerModule).groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName/row/col")
+                            .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName/row", "EXTEND_X")
+                            .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName", "EXTEND_Y")
+                            .save(),
+    Specification(PerModule).groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName/row/col")
+                            .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName/row", "EXTEND_X")
+                            .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName", "EXTEND_Y")
+                            .save(),
+  )
+)
+
 hltSiPixelPhase1TrackClustersNTracks = hltDefaultHistoTrack.clone(
   name = "ntracks",
   title = "Number of Tracks",
@@ -205,6 +223,20 @@ hltSiPixelPhase1TrackClustersOnTrackSizeXYF = hltSiPixelPhase1TrackClustersOnTra
 
 )
 
+hltSiPixelPhase1ClustersChargeVsSizeOnTrack = hltDefaultHistoTrack.clone(
+  name = "chargevssize_on_track",
+  title = "Cluster Charge vs. Cluster Size (OnTrack)",
+  xlabel = "size[pixels]",
+  ylabel = "Cluster charge",
+  range_min =  0, range_max = 30, range_nbins = 15,
+  range_y_min = 0, range_y_max = 80e3, range_y_nbins = 100,
+  dimensions = 2,
+  specs = VPSet(
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save()
+  )
+)
+
 hltSiPixelPhase1TrackClustersOnTrackChargeOuter = hltDefaultHistoTrack.clone(
   name = "chargeOuter",
   title = "Corrected Cluster Charge (OnTrack) outer ladders",
@@ -248,6 +280,7 @@ hltSiPixelPhase1TrackClustersConf = cms.VPSet(
    hltSiPixelPhase1TrackClustersOnTrackNClusters,
    hltSiPixelPhase1TrackClustersOnTrackPositionB,
    hltSiPixelPhase1TrackClustersOnTrackPositionF,
+   hltSiPixelPhase1DigisHitmapOnTrack,
  
    hltSiPixelPhase1TrackClustersNTracks,
    hltSiPixelPhase1TrackClustersNTracksInVolume,
@@ -269,7 +302,8 @@ hltSiPixelPhase1TrackClustersConf = cms.VPSet(
  
    hltSiPixelPhase1TrackClustersOnTrackSizeXYOuter,
    hltSiPixelPhase1TrackClustersOnTrackSizeXYInner,
-   hltSiPixelPhase1TrackClustersOnTrackSizeXYF
+   hltSiPixelPhase1TrackClustersOnTrackSizeXYF,
+   hltSiPixelPhase1ClustersChargeVsSizeOnTrack
 )
 
 hltSiPixelPhase1TrackClustersAnalyzer = cms.EDAnalyzer("SiPixelPhase1TrackClusters",

--- a/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
+++ b/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
@@ -24,9 +24,9 @@ vertexAssociatorByPositionAndTracks4pfMuonMergingTracks.trackAssociation = cms.I
 
 
 hltPixelPVanalysis = hltMultiPVanalysis.clone()
-hltMultiPVanalysis.do_generic_sim_plots  = True
-hltMultiPVanalysis.trackAssociatorMap    = cms.untracked.InputTag("tpToHLTpixelTrackAssociation")
-hltMultiPVanalysis.vertexAssociator      = cms.untracked.InputTag("vertexAssociatorByPositionAndTracks4pixelTracks")
+hltPixelPVanalysis.do_generic_sim_plots  = True
+hltPixelPVanalysis.trackAssociatorMap    = cms.untracked.InputTag("tpToHLTpixelTrackAssociation")
+hltPixelPVanalysis.vertexAssociator      = cms.untracked.InputTag("vertexAssociatorByPositionAndTracks4pixelTracks")
 hltPixelPVanalysis.vertexRecoCollections = cms.VInputTag(
     "hltPixelVertices",
     "hltTrimmedPixelVertices",
@@ -35,8 +35,8 @@ hltPixelPVanalysis.vertexRecoCollections = cms.VInputTag(
 
 
 hltPVanalysis = hltMultiPVanalysis.clone()
-hltMultiPVanalysis.trackAssociatorMap = cms.untracked.InputTag("tpToHLTpfMuonMergingTrackAssociation")
-hltMultiPVanalysis.vertexAssociator   = cms.untracked.InputTag("vertexAssociatorByPositionAndTracks4pfMuonMergingTracks")
+hltPVanalysis.trackAssociatorMap = cms.untracked.InputTag("tpToHLTpfMuonMergingTrackAssociation")
+hltPVanalysis.vertexAssociator   = cms.untracked.InputTag("vertexAssociatorByPositionAndTracks4pfMuonMergingTracks")
 hltPVanalysis.vertexRecoCollections   = cms.VInputTag(
     "hltVerticesPFFilter"
 #    "hltFastPVPixelVertices"


### PR DESCRIPTION
as reported by @davidlange6 in https://hypernews.cern.ch/HyperNews/CMS/get/dqmDevel/2395.html
this PR fixes 

1. the issue related to the module `hltSiPixelPhase1TrackClustersAnalyzer`,
    which was no more in synch w/ the plugins 
    because of offline updates not propagated to the HLT configuration (again)
2. the typos in the PV validation @HLT configuration