### PR TITLE
Disabling high pt trained regression except for saturated E/gammas

### DIFF
--- a/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
@@ -50,18 +50,18 @@ public:
   };
 
   EGExtraInfoModifierFromDB(const edm::ParameterSet& conf);
-  ~EGExtraInfoModifierFromDB();
+  ~EGExtraInfoModifierFromDB() override;
     
-  void setEvent(const edm::Event&) override final;
-  void setEventContent(const edm::EventSetup&) override final;
-  void setConsumes(edm::ConsumesCollector&) override final;
+  void setEvent(const edm::Event&) final;
+  void setEventContent(const edm::EventSetup&) final;
+  void setConsumes(edm::ConsumesCollector&) final;
   
-  void modifyObject(reco::GsfElectron&) const override final;
-  void modifyObject(reco::Photon&) const override final;
+  void modifyObject(reco::GsfElectron&) const final;
+  void modifyObject(reco::Photon&) const final;
   
   // just calls reco versions
-  void modifyObject(pat::Electron&) const override final; 
-  void modifyObject(pat::Photon&) const override final;
+  void modifyObject(pat::Electron&) const final; 
+  void modifyObject(pat::Photon&) const final;
 
 private:
   electron_config e_conf;
@@ -90,7 +90,8 @@ private:
   double eOverP_ECALTRKThr_;     // 0.025
   double epDiffSig_ECALTRKThr_;  // 15
   double epSig_ECALTRKThr_;      // 10
-  
+  bool forceHighEnergyEcalTrainingIfSaturated_;
+
   
 };
 
@@ -107,7 +108,7 @@ EGExtraInfoModifierFromDB::EGExtraInfoModifierFromDB(const edm::ParameterSet& co
   eOverP_ECALTRKThr_ = conf.getParameter<double>("eOverP_ECALTRKThr");
   epDiffSig_ECALTRKThr_ = conf.getParameter<double>("epDiffSig_ECALTRKThr");
   epSig_ECALTRKThr_ = conf.getParameter<double>("epSig_ECALTRKThr");
-
+  forceHighEnergyEcalTrainingIfSaturated_ = conf.getParameter<bool>("forceHighEnergyEcalTrainingIfSaturated");
   rhoTag_ = conf.getParameter<edm::InputTag>("rhoCollection");
 
   constexpr char electronSrc[] =  "electronSrc";
@@ -445,15 +446,17 @@ void EGExtraInfoModifierFromDB::modifyObject(reco::GsfElectron& ele) const {
   
   size_t coridx = 0;
   float raw_pt = raw_energy*the_sc->position().rho()/the_sc->position().r();
-
-  if (iseb && raw_pt < lowEnergy_ECALonlyThr_)
-    coridx = 0;
-  else if (iseb && raw_pt >= lowEnergy_ECALonlyThr_)
-    coridx = 1;
-  else if (!iseb && raw_pt < lowEnergy_ECALonlyThr_)
-    coridx = 2;
-  else if (!iseb && raw_pt >= lowEnergy_ECALonlyThr_)
-    coridx = 3;
+  bool isSaturated = ele.nSaturatedXtals()!=0;
+  
+  if(raw_pt >= lowEnergy_ECALonlyThr_ || 
+     (isSaturated && forceHighEnergyEcalTrainingIfSaturated_)){
+    if(iseb) coridx = 1;
+    else coridx = 3;
+  }else{
+    if(iseb) coridx = 0;
+    else coridx = 2;
+  }
+  
   
   //these are the actual BDT responses
   double rawmean = e_forestH_mean_[coridx]->GetResponse(eval.data());
@@ -539,7 +542,7 @@ void EGExtraInfoModifierFromDB::modifyObject(reco::GsfElectron& ele) const {
 								    oldFourMomentum.y()*combinedEnergy/oldFourMomentum.t(),
 								    oldFourMomentum.z()*combinedEnergy/oldFourMomentum.t(),
 								    combinedEnergy);
- 
+
   ele.correctMomentum(newFourMomentum, ele.trackMomentumError(), combinedEnergyError);
 }
 
@@ -639,15 +642,16 @@ void EGExtraInfoModifierFromDB::modifyObject(reco::Photon& pho) const {
   
   size_t coridx = 0;
   float raw_pt = raw_energy*the_sc->position().rho()/the_sc->position().r();
-
-  if (iseb && raw_pt < lowEnergy_ECALonlyThr_)
-    coridx = 0;
-  else if (iseb && raw_pt >= lowEnergy_ECALonlyThr_)
-    coridx = 1;
-  else if (!iseb && raw_pt < lowEnergy_ECALonlyThr_)
-    coridx = 2;
-  else if (!iseb && raw_pt >= lowEnergy_ECALonlyThr_)
-    coridx = 3;
+  bool isSaturated = pho.nSaturatedXtals();
+  
+  if(raw_pt >= lowEnergy_ECALonlyThr_ || 
+     (isSaturated && forceHighEnergyEcalTrainingIfSaturated_)){
+    if(iseb) coridx = 1;
+    else coridx = 3;
+  }else{
+    if(iseb) coridx = 0;
+    else coridx = 2;
+  }
   
   //these are the actual BDT responses
   double rawmean = ph_forestH_mean_[coridx]->GetResponse(eval.data());

--- a/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
@@ -366,6 +366,10 @@ void EGExtraInfoModifierFromDB::modifyObject(reco::GsfElectron& ele) const {
   const int numberOfClusters =  the_sc->clusters().size();
   const bool missing_clusters = !the_sc->clusters()[numberOfClusters-1].isAvailable();
   if( missing_clusters ) return ; // do not apply corrections in case of missing info (slimmed MiniAOD electrons)
+  
+  //check if fbrem is filled as its needed for E/p combination so abort if its set to the default value 
+  //this will be the case for <5 (or current cuts) for miniAOD electrons
+  if(ele.fbrem()==reco::GsfElectron::ClassificationVariables().trackFbrem) return;
 
   const bool iseb = ele.isEB();  
 

--- a/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
+++ b/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
@@ -17,12 +17,13 @@ regressionModifier = \
                 uncertaintyKey_ecalonly = cms.vstring('photon_eb_ECALonly_lowpt_var', 'photon_eb_ECALonly_var', 'photon_ee_ECALonly_lowpt_var', 'photon_ee_ECALonly_var'),
                                           ),
 
-              lowEnergy_ECALonlyThr = cms.double(300.),
+              lowEnergy_ECALonlyThr = cms.double(99999.),
               lowEnergy_ECALTRKThr = cms.double(50.),
               highEnergy_ECALTRKThr = cms.double(200.),
               eOverP_ECALTRKThr = cms.double(0.025),
               epDiffSig_ECALTRKThr = cms.double(15.),
               epSig_ECALTRKThr = cms.double(10.),
+              forceHighEnergyEcalTrainingIfSaturated = cms.bool(True)
 
               )
     


### PR DESCRIPTION
Dear All,

edit: removing the notification that the PR is still in testing, I;m completely happy with it now as mentioned below 

>  Note: this PR is still in internal testing and should not yet be considered for inclusion. However I thought it would be useful to have a PR showing what E/gamma is considering doing.

This PR would disable the high pt trained regression which is used above 300 GeV for electrons and photons except when the electron or photon has a saturated crystals. Instead it would use the low pt trained regression. This will make the energy of high pt electron/photons easier to understand while also improving the behavior on fakes. The main benfit of the high pt regression is for staturated objects so the code still falls back to that in that case.

This is a change E/gamma wants regardless of what is ultimately decided for fixing the jetMET issue. Hopefully this will also fix the jet met issue.


