### PR TITLE
FWCore/ParameterSet: Replace Exception in MassSearchReplaceAnyInputTagVisitor.enter()

### DIFF
--- a/FWCore/ParameterSet/python/MassReplace.py
+++ b/FWCore/ParameterSet/python/MassReplace.py
@@ -60,8 +60,9 @@ class MassSearchReplaceAnyInputTagVisitor(object):
     def enter(self,visitee):
         label = ''
         if (not self._skipLabelTest):
-            try:    label = visitee.label_()
-            except AttributeError: label = '<Module not in a Process>'
+            if hasattr(visitee,"hasLabel_") and visitee.hasLabel_():
+		label = visitee.label_()
+            else: label = '<Module not in a Process>'
         else:
             label = '<Module label not tested>'
         self.doIt(visitee, label)


### PR DESCRIPTION
FWCore/ParameterSet: Replace Exception in MassSearchReplaceAnyInputTagVisitor.enter() so that it can work on Sequences that contain Tasks.