### PR TITLE
Clang-tidy checks for CondFormats

### DIFF
--- a/CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h
+++ b/CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h
@@ -13,7 +13,7 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-#include <math.h>
+#include <cmath>
 #include <sstream>
 #include <cstring>
 

--- a/CondFormats/CSCObjects/interface/CSCReadoutMappingForSliceTest.h
+++ b/CondFormats/CSCObjects/interface/CSCReadoutMappingForSliceTest.h
@@ -17,7 +17,7 @@ class CSCReadoutMappingForSliceTest : public CSCReadoutMapping {
    CSCReadoutMappingForSliceTest();
 
   /// Destructor
-   virtual ~CSCReadoutMappingForSliceTest();
+   ~CSCReadoutMappingForSliceTest() override;
 
  private: 
 
@@ -29,7 +29,7 @@ class CSCReadoutMappingForSliceTest : public CSCReadoutMapping {
      * number might not be neighbour of dmb?
      * But for slice test (Nov-2005 on) only relevant labels are vme and dmb.
      */
-   int hwId( int endcap, int station, int vme, int dmb, int tmb ) const;
+   int hwId( int endcap, int station, int vme, int dmb, int tmb ) const override;
 
 };
 

--- a/CondFormats/CSCObjects/interface/CSCReadoutMappingFromFile.h
+++ b/CondFormats/CSCObjects/interface/CSCReadoutMappingFromFile.h
@@ -20,10 +20,10 @@ class CSCReadoutMappingFromFile : public CSCReadoutMappingForSliceTest {
    CSCReadoutMappingFromFile() {}
 
   /// Destructor
-   virtual ~CSCReadoutMappingFromFile();
+   ~CSCReadoutMappingFromFile() override;
 
   /// Fill mapping store
-   virtual void fill( const edm::ParameterSet& ps );
+   void fill( const edm::ParameterSet& ps ) override;
 
  private: 
    std::string theMappingFile;

--- a/CondFormats/CSCObjects/interface/CSCTriggerElectronicsMapping.h
+++ b/CondFormats/CSCObjects/interface/CSCTriggerElectronicsMapping.h
@@ -17,7 +17,7 @@ class CSCTriggerElectronicsMapping : public CSCTriggerMapping {
    CSCTriggerElectronicsMapping();
 
   /// Destructor
-   virtual ~CSCTriggerElectronicsMapping();
+   ~CSCTriggerElectronicsMapping() override;
 
  private: 
 
@@ -26,7 +26,7 @@ class CSCTriggerElectronicsMapping : public CSCTriggerMapping {
      * readout.
      *
      */
-    int hwId( int SPboardId, int FPGA, int cscid, int zero1=0, int zero2=0 ) const;
+    int hwId( int SPboardId, int FPGA, int cscid, int zero1=0, int zero2=0 ) const override;
 
 };
 

--- a/CondFormats/CSCObjects/interface/CSCTriggerElectronicsMappingFromFile.h
+++ b/CondFormats/CSCObjects/interface/CSCTriggerElectronicsMappingFromFile.h
@@ -18,10 +18,10 @@ class CSCTriggerElectronicsMappingFromFile : public CSCTriggerElectronicsMapping
    CSCTriggerElectronicsMappingFromFile() {}
 
   /// Destructor
-   virtual ~CSCTriggerElectronicsMappingFromFile();
+   ~CSCTriggerElectronicsMappingFromFile() override;
 
   /// Fill mapping store
-   virtual void fill( void );
+   void fill( void ) override;
 
  private: 
    std::string filename_;

--- a/CondFormats/CSCObjects/interface/CSCTriggerMappingFromFile.h
+++ b/CondFormats/CSCObjects/interface/CSCTriggerMappingFromFile.h
@@ -18,10 +18,10 @@ class CSCTriggerMappingFromFile : public CSCTriggerSimpleMapping {
    CSCTriggerMappingFromFile() {}
 
   /// Destructor
-   virtual ~CSCTriggerMappingFromFile();
+   ~CSCTriggerMappingFromFile() override;
 
   /// Fill mapping store
-   virtual void fill( void );
+   void fill( void ) override;
 
  private: 
    std::string filename_;

--- a/CondFormats/CSCObjects/interface/CSCTriggerSimpleMapping.h
+++ b/CondFormats/CSCObjects/interface/CSCTriggerSimpleMapping.h
@@ -17,7 +17,7 @@ class CSCTriggerSimpleMapping : public CSCTriggerMapping {
    CSCTriggerSimpleMapping();
 
   /// Destructor
-   virtual ~CSCTriggerSimpleMapping();
+   ~CSCTriggerSimpleMapping() override;
 
  private: 
 
@@ -26,7 +26,7 @@ class CSCTriggerSimpleMapping : public CSCTriggerMapping {
      * readout.
      *
      */
-    int hwId( int endcap, int station, int sector, int subsector, int cscid ) const;
+    int hwId( int endcap, int station, int sector, int subsector, int cscid ) const override;
 
 };
 

--- a/CondFormats/CTPPSReadoutObjects/plugins/CTPPSPixelDAQMappingESSourceXML.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/CTPPSPixelDAQMappingESSourceXML.cc
@@ -65,7 +65,7 @@ public:
 
 
   CTPPSPixelDAQMappingESSourceXML(const edm::ParameterSet &);
-  ~CTPPSPixelDAQMappingESSourceXML();
+  ~CTPPSPixelDAQMappingESSourceXML() override;
 
   std::unique_ptr<CTPPSPixelAnalysisMask> produceCTPPSPixelAnalysisMask( const CTPPSPixelAnalysisMaskRcd & );
   std::unique_ptr<CTPPSPixelDAQMapping> produceCTPPSPixelDAQMapping( const CTPPSPixelDAQMappingRcd &);
@@ -152,7 +152,7 @@ private:
 
 protected:
 /// sets infinite validity of this data
-  virtual void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue&, edm::ValidityInterval&);
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue&, edm::ValidityInterval&) override;
 };
 
 //----------------------------------------------------------------------------------------------------

--- a/CondFormats/CTPPSReadoutObjects/plugins/PrintTotemDAQMapping.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/PrintTotemDAQMapping.cc
@@ -26,13 +26,13 @@ class PrintTotemDAQMapping : public edm::one::EDAnalyzer<>
 {
   public:
     PrintTotemDAQMapping(const edm::ParameterSet &ps);
-    ~PrintTotemDAQMapping() {}
+    ~PrintTotemDAQMapping() override {}
 
   private:
     /// label of the CTPPS sub-system
     std::string subSystemName;
 
-    virtual void analyze(const edm::Event &e, const edm::EventSetup &es) override;
+    void analyze(const edm::Event &e, const edm::EventSetup &es) override;
 };
 
 using namespace std;

--- a/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
@@ -71,7 +71,7 @@ public:
   static const std::string tagDiamondCh; 
 
   TotemDAQMappingESSourceXML(const edm::ParameterSet &);
-  ~TotemDAQMappingESSourceXML();
+  ~TotemDAQMappingESSourceXML() override;
 
   edm::ESProducts< std::shared_ptr<TotemDAQMapping>, std::shared_ptr<TotemAnalysisMask> > produce( const TotemReadoutRcd & );
 
@@ -168,7 +168,7 @@ private:
 
 protected:
   /// sets infinite validity of this data
-  virtual void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue&, edm::ValidityInterval&);
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&, const edm::IOVSyncValue&, edm::ValidityInterval&) override;
 };
 
 //----------------------------------------------------------------------------------------------------

--- a/CondFormats/Calibration/interface/BlobNoises.h
+++ b/CondFormats/Calibration/interface/BlobNoises.h
@@ -4,7 +4,7 @@
 
 #include<vector>
 //#include<boost/cstdint.hpp>
-#include <stdint.h>
+#include <cstdint>
 
 class BlobNoises {
 public:

--- a/CondFormats/Calibration/interface/Efficiency.h
+++ b/CondFormats/Calibration/interface/Efficiency.h
@@ -42,7 +42,7 @@ namespace condex {
       cutLow(cm), cutHigh(ch),
       low(el), high(eh){}
   private:
-    virtual float value(float pt, float) const {
+    float value(float pt, float) const override {
       if ( pt<low) return cutLow;
       if ( pt>high) return cutHigh;
       return cutLow + (pt-low)/(high-low)*(cutHigh-cutLow);
@@ -62,7 +62,7 @@ class ParametricEfficiencyInEta : public Efficiency {
       cutLow(cmin), cutHigh(cmax),
       low(el), high(eh){}
   private:
-    virtual float value(float, float eta) const {
+    float value(float, float eta) const override {
       eta = std::abs(eta);
       if ( eta<low) return cutLow;
       if ( eta>high) return cutHigh;

--- a/CondFormats/CastorObjects/interface/CastorCondObjectContainer.h
+++ b/CondFormats/CastorObjects/interface/CastorCondObjectContainer.h
@@ -73,7 +73,7 @@ CastorCondObjectContainer<Item>::initContainer()
 template<class Item> const Item*
 CastorCondObjectContainer<Item>::getValues(DetId fId, bool throwOnFail) const
 {
-  const Item* cell = NULL;
+  const Item* cell = nullptr;
   HcalCastorDetId myId(fId);
 
   if (fId.det()==DetId::Calo && fId.subdetId()==HcalCastorDetId::SubdetectorId) {
@@ -89,7 +89,7 @@ CastorCondObjectContainer<Item>::getValues(DetId fId, bool throwOnFail) const
       throw cms::Exception ("Conditions not found") 
 	<< "Unavailable Conditions of type " << myname() << " for cell " << myId;
     } else {
-      cell=0;
+      cell=nullptr;
     }
   }
   return cell;

--- a/CondFormats/CastorObjects/src/CastorElectronicsMap.cc
+++ b/CondFormats/CastorObjects/src/CastorElectronicsMap.cc
@@ -62,7 +62,7 @@ const CastorElectronicsMap::PrecisionItem* CastorElectronicsMap::findById (unsig
   item = std::lower_bound ((*mPItemsById).begin(), (*mPItemsById).end(), &target, castor_impl::LessById());
   if (item == (*mPItemsById).end() || (*item)->mId != fId) 
     //    throw cms::Exception ("Conditions not found") << "Unavailable Electronics map for cell " << fId;
-    return 0;
+    return nullptr;
   return *item;
 }
 
@@ -70,7 +70,7 @@ const CastorElectronicsMap::PrecisionItem* CastorElectronicsMap::findPByElId (un
   CastorElectronicsId eid(fElId);
   const PrecisionItem* i=&(mPItems[eid.linearIndex()]);
   
-  if (i!=0 && i->mElId!=fElId) i=0;
+  if (i!=nullptr && i->mElId!=fElId) i=nullptr;
   return i;
 }
 
@@ -78,7 +78,7 @@ const CastorElectronicsMap::TriggerItem* CastorElectronicsMap::findTByElId (unsi
   CastorElectronicsId eid(fElId);
   const TriggerItem* i=&(mTItems[eid.linearIndex()]);
   
-  if (i!=0 && i->mElId!=fElId) i=0;
+  if (i!=nullptr && i->mElId!=fElId) i=nullptr;
   return i;
 }
 
@@ -92,7 +92,7 @@ const CastorElectronicsMap::TriggerItem* CastorElectronicsMap::findByTrigId (uns
   item = std::lower_bound ((*mTItemsByTrigId).begin(), (*mTItemsByTrigId).end(), &target, castor_impl::LessByTrigId());
   if (item == (*mTItemsByTrigId).end() || (*item)->mTrigId != fTrigId) 
     //    throw cms::Exception ("Conditions not found") << "Unavailable Electronics map for cell " << fId;
-    return 0;
+    return nullptr;
   return *item;
 }
 
@@ -118,7 +118,7 @@ const CastorElectronicsId CastorElectronicsMap::lookupTrigger(DetId fId) const {
 
 bool CastorElectronicsMap::lookup(const CastorElectronicsId pid, CastorElectronicsId& eid, HcalGenericDetId& did) const {
   const PrecisionItem* i=&(mPItems[pid.linearIndex()]);
-  if (i!=0 && i->mId!=0) {
+  if (i!=nullptr && i->mId!=0) {
     eid=CastorElectronicsId(i->mElId);
     did=HcalGenericDetId(i->mId);
     return true;
@@ -127,7 +127,7 @@ bool CastorElectronicsMap::lookup(const CastorElectronicsId pid, CastorElectroni
 
 bool CastorElectronicsMap::lookup(const CastorElectronicsId pid, CastorElectronicsId& eid, HcalTrigTowerDetId& did) const {
   const TriggerItem* i=&(mTItems[pid.linearIndex()]);
-  if (i!=0 && i->mTrigId!=0) {
+  if (i!=nullptr && i->mTrigId!=0) {
     eid=CastorElectronicsId(i->mElId);
     did=HcalGenericDetId(i->mTrigId);
     return true;

--- a/CondFormats/CastorObjects/src/CastorPedestalWidth.cc
+++ b/CondFormats/CastorObjects/src/CastorPedestalWidth.cc
@@ -8,7 +8,7 @@ $Revision: 1.9 $
 Adapted for CASTOR by L. Mundim
 */
 
-#include <math.h>
+#include <cmath>
 #include <iostream>
 
 #include "CondFormats/CastorObjects/interface/CastorPedestalWidth.h"

--- a/CondFormats/Common/interface/GenericSummary.h
+++ b/CondFormats/Common/interface/GenericSummary.h
@@ -13,16 +13,16 @@ namespace cond {
   public:
     
     GenericSummary();
-    virtual ~GenericSummary();
+    ~GenericSummary() override;
     
     //
     explicit GenericSummary(std::string const & s);
     
     // short message (just content to be used in a table)
-    virtual void shortMessage(std::ostream & os) const;
+    void shortMessage(std::ostream & os) const override;
     
     // long message (to be used in pop-up, single views)
-    virtual void longMessage(std::ostream & os) const;
+    void longMessage(std::ostream & os) const override;
     
     
   private:

--- a/CondFormats/Common/interface/SmallWORMDict.h
+++ b/CondFormats/Common/interface/SmallWORMDict.h
@@ -30,7 +30,7 @@ namespace cond {
     ~SmallWORMDict();
     
     struct Frame {
-      Frame(): b(0){}
+      Frame(): b(nullptr){}
       Frame(char const * ib,
 	    unsigned int il,
 	    unsigned int iind) :
@@ -42,7 +42,7 @@ namespace cond {
 
     struct IterHelp {
       typedef Frame result_type;
-      IterHelp() : v(0){}
+      IterHelp() : v(nullptr){}
       IterHelp(SmallWORMDict const & iv) : v(&iv){}
       
       result_type const & operator()(int i) const {

--- a/CondFormats/Common/interface/TimeConversions.h
+++ b/CondFormats/Common/interface/TimeConversions.h
@@ -74,7 +74,7 @@ namespace cond {
     
     inline Time_t now() {
       ::timeval stv;
-      ::gettimeofday(&stv,0);
+      ::gettimeofday(&stv,nullptr);
       return  from_timeval(stv);
     }
     

--- a/CondFormats/Common/src/MultiFileBlob.cc
+++ b/CondFormats/Common/src/MultiFileBlob.cc
@@ -49,7 +49,7 @@ MultiFileBlob::Range MultiFileBlob::rawBlob(const std::string& name) const {
   Positions::const_iterator pos = positions.find(name);
   if (pos==positions.end()) {
     edm::LogError("MultiFileBlob:")<< name << "not in this object";
-    return Range(0,0);
+    return Range(nullptr,nullptr);
   }
   unsigned long long b = (*pos).second;
   unsigned long long e = isize;

--- a/CondFormats/DTObjects/interface/DTCCBConfig.h
+++ b/CondFormats/DTObjects/interface/DTCCBConfig.h
@@ -122,8 +122,8 @@ class DTCCBConfig {
 
  private:
 
-  DTCCBConfig(DTCCBConfig const&);
-  DTCCBConfig& operator=(DTCCBConfig const&);
+  DTCCBConfig(DTCCBConfig const&) = delete;
+  DTCCBConfig& operator=(DTCCBConfig const&) = delete;
 
   int timeStamp;
   std::string dataVersion;

--- a/CondFormats/DTObjects/interface/DTDeadFlag.h
+++ b/CondFormats/DTObjects/interface/DTDeadFlag.h
@@ -247,8 +247,8 @@ class DTDeadFlag {
 
  private:
 
-  DTDeadFlag(DTDeadFlag const&);
-  DTDeadFlag& operator=(DTDeadFlag const&);
+  DTDeadFlag(DTDeadFlag const&) = delete;
+  DTDeadFlag& operator=(DTDeadFlag const&) = delete;
 
   std::string dataVersion;
 

--- a/CondFormats/DTObjects/interface/DTHVStatus.h
+++ b/CondFormats/DTObjects/interface/DTHVStatus.h
@@ -185,8 +185,8 @@ class DTHVStatus {
 
  private:
 
-  DTHVStatus(DTHVStatus const&);
-  DTHVStatus& operator=(DTHVStatus const&);
+  DTHVStatus(DTHVStatus const&) = delete;
+  DTHVStatus& operator=(DTHVStatus const&) = delete;
 
   std::string dataVersion;
 

--- a/CondFormats/DTObjects/interface/DTKeyedConfig.h
+++ b/CondFormats/DTObjects/interface/DTKeyedConfig.h
@@ -45,7 +45,7 @@ class DTKeyedConfig: public cond::BaseKeyed {
 
   /** Destructor
    */
-  virtual ~DTKeyedConfig();
+  ~DTKeyedConfig() override;
 
   /** Operations
    */

--- a/CondFormats/DTObjects/interface/DTLVStatus.h
+++ b/CondFormats/DTObjects/interface/DTLVStatus.h
@@ -152,8 +152,8 @@ class DTLVStatus {
 
  private:
 
-  DTLVStatus(DTLVStatus const&);
-  DTLVStatus& operator=(DTLVStatus const&);
+  DTLVStatus(DTLVStatus const&) = delete;
+  DTLVStatus& operator=(DTLVStatus const&) = delete;
 
   std::string dataVersion;
 

--- a/CondFormats/DTObjects/interface/DTMtime.h
+++ b/CondFormats/DTObjects/interface/DTMtime.h
@@ -268,8 +268,8 @@ class DTMtime {
 
  private:
 
-  DTMtime(DTMtime const&);
-  DTMtime& operator=(DTMtime const&);
+  DTMtime(DTMtime const&) = delete;
+  DTMtime& operator=(DTMtime const&) = delete;
 
   std::string dataVersion;
   float nsPerCount;

--- a/CondFormats/DTObjects/interface/DTPerformance.h
+++ b/CondFormats/DTObjects/interface/DTPerformance.h
@@ -208,8 +208,8 @@ class DTPerformance {
 
  private:
 
-  DTPerformance(DTPerformance const&);
-  DTPerformance& operator=(DTPerformance const&);
+  DTPerformance(DTPerformance const&) = delete;
+  DTPerformance& operator=(DTPerformance const&) = delete;
 
   std::string dataVersion;
   float nsPerCount;

--- a/CondFormats/DTObjects/interface/DTRangeT0.h
+++ b/CondFormats/DTObjects/interface/DTRangeT0.h
@@ -146,8 +146,8 @@ class DTRangeT0 {
 
  private:
 
-  DTRangeT0(DTRangeT0 const&);
-  DTRangeT0& operator=(DTRangeT0 const&);
+  DTRangeT0(DTRangeT0 const&) = delete;
+  DTRangeT0& operator=(DTRangeT0 const&) = delete;
 
   std::string dataVersion;
 

--- a/CondFormats/DTObjects/interface/DTReadOutMapping.h
+++ b/CondFormats/DTObjects/interface/DTReadOutMapping.h
@@ -155,8 +155,8 @@ class DTReadOutMapping {
 
  private:
 
-  DTReadOutMapping(DTReadOutMapping const&);
-  DTReadOutMapping& operator=(DTReadOutMapping const&);
+  DTReadOutMapping(DTReadOutMapping const&) = delete;
+  DTReadOutMapping& operator=(DTReadOutMapping const&) = delete;
 
   edm::AtomicPtrCache<DTReadOutMappingCache> const& atomicCache() const { return atomicCache_; }
   edm::AtomicPtrCache<DTReadOutMappingCache> & atomicCache() { return atomicCache_; }

--- a/CondFormats/DTObjects/interface/DTRecoConditions.h
+++ b/CondFormats/DTObjects/interface/DTRecoConditions.h
@@ -18,7 +18,7 @@
 #include <map>
 #include <vector>
 #include <string>
-#include <stdint.h>
+#include <cstdint>
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include <atomic>
 #endif
@@ -49,7 +49,7 @@ public:
 
   /// Get the value correspoding to the given WireId, 
   //// using x[] as parameters of the parametrization when relevant
-  float get(const DTWireId& wireid, double* x=0) const;
+  float get(const DTWireId& wireid, double* x=nullptr) const;
 
   /// Set the expression representing the formula used for parametrization
   void setFormulaExpr(const std::string& expr) {

--- a/CondFormats/DTObjects/interface/DTRecoUncertainties.h
+++ b/CondFormats/DTObjects/interface/DTRecoUncertainties.h
@@ -13,7 +13,7 @@
 #include <map>
 #include <vector>
 #include <string>
-#include <stdint.h>
+#include <cstdint>
 
 class DTWireId;
 

--- a/CondFormats/DTObjects/interface/DTStatusFlag.h
+++ b/CondFormats/DTObjects/interface/DTStatusFlag.h
@@ -267,8 +267,8 @@ class DTStatusFlag {
 
  private:
 
-  DTStatusFlag(DTStatusFlag const&);
-  DTStatusFlag& operator=(DTStatusFlag const&);
+  DTStatusFlag(DTStatusFlag const&) = delete;
+  DTStatusFlag& operator=(DTStatusFlag const&) = delete;
 
   std::string dataVersion;
 

--- a/CondFormats/DTObjects/interface/DTTPGParameters.h
+++ b/CondFormats/DTObjects/interface/DTTPGParameters.h
@@ -136,7 +136,7 @@ class DTTPGParameters {
 
  private:
 
-  DTTPGParameters(DTTPGParameters const&);
+  DTTPGParameters(DTTPGParameters const&) = delete;
 
   std::string dataVersion;
   float nsPerCount;

--- a/CondFormats/DTObjects/interface/DTTtrig.h
+++ b/CondFormats/DTObjects/interface/DTTtrig.h
@@ -188,8 +188,8 @@ class DTTtrig {
 
  private:
 
-  DTTtrig(DTTtrig const&);
-  DTTtrig& operator=(DTTtrig const&);
+  DTTtrig(DTTtrig const&) = delete;
+  DTTtrig& operator=(DTTtrig const&) = delete;
 
   std::string dataVersion;
   float nsPerCount;

--- a/CondFormats/DTObjects/src/DTCCBConfig.cc
+++ b/CondFormats/DTObjects/src/DTCCBConfig.cc
@@ -122,21 +122,21 @@ DTCCBConfig::configKeyMap() const {
   std::vector< std::pair<DTCCBId,int>* >::iterator t_iend = tempList.end();
   while ( t_iter != t_iend ) {
     std::pair<DTCCBId,int>* ptr = *t_iter++;
-    if ( ptr == 0 ) continue;
+    if ( ptr == nullptr ) continue;
     DTCCBId& ccbId = ptr->first;
     std::vector<int> cfgKeys;
     cfgKeys.push_back( ptr->second );
     std::vector< std::pair<DTCCBId,int>* >::iterator n_iter( t_iter );
     while( n_iter != t_iend ) {
       std::pair<DTCCBId,int>*& pck = *n_iter++;
-      if ( pck == 0 ) continue; 
+      if ( pck == nullptr ) continue; 
       DTCCBId& chkId = pck->first;
       if ( ( chkId.  wheelId == ccbId.  wheelId ) && 
            ( chkId.stationId == ccbId.stationId ) && 
            ( chkId. sectorId == ccbId. sectorId ) ) {
         cfgKeys.push_back( pck->second );
         delete pck;
-        pck = 0;
+        pck = nullptr;
       }
     }
     keyList.push_back( std::pair< DTCCBId,std::vector<int> >( ccbId,

--- a/CondFormats/DTObjects/src/DTReadOutMapping.cc
+++ b/CondFormats/DTObjects/src/DTReadOutMapping.cc
@@ -649,7 +649,7 @@ void DTReadOutMapping::cacheMap() const {
       cellKey.push_back( link.   slId );
       std::vector<int>* robMLgr;
       localCache->grROB.find( cellKey.begin(), cellKey.end(), robMLgr );
-      if ( robMLgr == 0 ) {
+      if ( robMLgr == nullptr ) {
         std::unique_ptr<std::vector<int> > newVector(new std::vector<int>);
         robMLgr = newVector.get();
         localCache->grROB.insert( cellKey.begin(), cellKey.end(),
@@ -670,7 +670,7 @@ void DTReadOutMapping::cacheMap() const {
       cellKey.push_back( link.stationId );
       std::vector<int>* rosMLgr;
       localCache->grROS.find( cellKey.begin(), cellKey.end(), rosMLgr );
-      if ( rosMLgr == 0 ) {
+      if ( rosMLgr == nullptr ) {
         std::unique_ptr<std::vector<int> > newVector(new std::vector<int>);
         rosMLgr = newVector.get();
         localCache->grROS.insert( cellKey.begin(), cellKey.end(),
@@ -730,9 +730,9 @@ void DTReadOutMapping::cacheMap() const {
         cellKey.push_back(    mapId );
         cellKey.push_back(  wheelId );
         cellKey.push_back( sectorId );
-        std::vector<int>* dduMLgr = 0;
+        std::vector<int>* dduMLgr = nullptr;
         localCache->grDDU.find( cellKey.begin(), cellKey.end(), dduMLgr );
-        if ( dduMLgr == 0 ) {
+        if ( dduMLgr == nullptr ) {
           std::unique_ptr<std::vector<int> > newVector(new std::vector<int>);
           dduMLgr = newVector.get();
           localCache->grDDU.insert( cellKey.begin(), cellKey.end(),

--- a/CondFormats/EcalObjects/src/EcalSRSettings.cc
+++ b/CondFormats/EcalObjects/src/EcalSRSettings.cc
@@ -3,7 +3,7 @@
 
 #include <sstream>
 #include <iostream>
-#include <stdlib.h>
+#include <cstdlib>
 #include <cassert>
 #include <algorithm>
 

--- a/CondFormats/EcalObjects/src/EcalSampleMask.cc
+++ b/CondFormats/EcalObjects/src/EcalSampleMask.cc
@@ -4,7 +4,7 @@
  * $Id: EcalSampleMask.cc,v 1.1 2012/05/10 08:22:09 argiro Exp $
  **/
 
-#include <assert.h>
+#include <cassert>
 #include "CondFormats/EcalObjects/interface/EcalSampleMask.h"
 #include "DataFormats/EcalDigi/interface/EcalDataFrame.h"
 

--- a/CondFormats/EgammaObjects/interface/GBRForest.h
+++ b/CondFormats/EgammaObjects/interface/GBRForest.h
@@ -20,8 +20,8 @@
 
 #include <vector>
 #include "GBRTree.h"
-#include <math.h>
-#include <stdio.h>
+#include <cmath>
+#include <cstdio>
 
   namespace TMVA {
     class MethodBDT;

--- a/CondFormats/EgammaObjects/interface/GBRForestD.h
+++ b/CondFormats/EgammaObjects/interface/GBRForestD.h
@@ -20,8 +20,8 @@
 
 #include <vector>
 #include "GBRTreeD.h"
-#include <math.h>
-#include <stdio.h>
+#include <cmath>
+#include <cstdio>
 #include "Rtypes.h"
 
 class GBRForestD {

--- a/CondFormats/EgammaObjects/interface/GBRTreeD.h
+++ b/CondFormats/EgammaObjects/interface/GBRTreeD.h
@@ -26,7 +26,7 @@
 
 #include <vector>
 #include <map>
-#include <stdio.h>
+#include <cstdio>
 #include <cmath>
 #include "Rtypes.h"
 

--- a/CondFormats/HcalObjects/interface/DummyOOTPileupCorrection.h
+++ b/CondFormats/HcalObjects/interface/DummyOOTPileupCorrection.h
@@ -16,7 +16,7 @@ public:
         : descr_(itemDescription), scale_(scale) {}
 
     // Destructor
-    inline virtual ~DummyOOTPileupCorrection() {}
+    inline ~DummyOOTPileupCorrection() override {}
 
     // Inspectors
     inline const std::string& description() const {return descr_;}
@@ -29,14 +29,14 @@ public:
                unsigned firstTimeSlice, unsigned nTimeSlices,
                double* correctedCharge, unsigned lenCorrectedCharge,
                bool* pulseShapeCorrApplied, bool* leakCorrApplied,
-               bool* readjustTiming) const;
+               bool* readjustTiming) const override;
 
     // Are we using charge or energy?
-    inline bool inputIsEnergy() const {return false;}
+    inline bool inputIsEnergy() const override {return false;}
 
 protected:
     // Comparison function must be implemented
-    bool isEqual(const AbsOOTPileupCorrection& otherBase) const;
+    bool isEqual(const AbsOOTPileupCorrection& otherBase) const override;
 
 public:
     // Default constructor needed for serialization.

--- a/CondFormats/HcalObjects/interface/HBHEChannelGroups.h
+++ b/CondFormats/HcalObjects/interface/HBHEChannelGroups.h
@@ -37,7 +37,7 @@ public:
     inline unsigned size() const {return group_.size();}
 
     inline const uint32_t* groupData() const
-        {return group_.empty() ? 0 : &group_[0];}
+        {return group_.empty() ? nullptr : &group_[0];}
 
     inline unsigned getGroup(const unsigned linearChannel) const
         {return group_.at(linearChannel);}
@@ -46,7 +46,7 @@ public:
     {
         unsigned lg = 0;
         const unsigned sz = group_.size();
-        const uint32_t* dat = sz ? &group_[0] : 0;
+        const uint32_t* dat = sz ? &group_[0] : nullptr;
         for (unsigned i=0; i<sz; ++i)
             if (dat[i] > lg)
                 lg = dat[i];

--- a/CondFormats/HcalObjects/interface/HcalChannelQuality.h
+++ b/CondFormats/HcalObjects/interface/HcalChannelQuality.h
@@ -18,11 +18,11 @@ class HcalChannelQuality: public HcalCondObjectContainer<HcalChannelStatus>
 {
  public:
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalChannelQuality():HcalCondObjectContainer<HcalChannelStatus>(0) {}
+  HcalChannelQuality():HcalCondObjectContainer<HcalChannelStatus>(nullptr) {}
 #endif
   HcalChannelQuality(const HcalTopology* topo):HcalCondObjectContainer<HcalChannelStatus>(topo) {}
 
-  std::string myname() const {return (std::string)"HcalChannelQuality";}
+  std::string myname() const override {return (std::string)"HcalChannelQuality";}
 
  private:
 

--- a/CondFormats/HcalObjects/interface/HcalChebyshevFunctor.h
+++ b/CondFormats/HcalObjects/interface/HcalChebyshevFunctor.h
@@ -27,14 +27,14 @@ public:
                                   double xmin, double xmax,
                                   double outOfRangeValue = 0.0);
 
-    inline virtual ~HcalChebyshevFunctor() {}
+    inline ~HcalChebyshevFunctor() override {}
 
-    virtual double operator()(double x) const override;
-    inline virtual double xmin() const override {return xmax_;};
-    inline virtual double xmax() const override {return xmin_;}
+    double operator()(double x) const override;
+    inline double xmin() const override {return xmax_;};
+    inline double xmax() const override {return xmin_;}
 
 protected:
-    inline virtual bool isEqual(const AbsHcalFunctor& other) const override
+    inline bool isEqual(const AbsHcalFunctor& other) const override
     {
         const HcalChebyshevFunctor& r =
             static_cast<const HcalChebyshevFunctor&>(other);

--- a/CondFormats/HcalObjects/interface/HcalCondObjectContainer.h
+++ b/CondFormats/HcalObjects/interface/HcalCondObjectContainer.h
@@ -145,7 +145,7 @@ template<class Item> const Item*
 HcalCondObjectContainer<Item>::getValues(DetId fId, bool throwOnFail) const {
   unsigned int index=indexFor(fId);
   
-  const Item* cell = NULL;
+  const Item* cell = nullptr;
 
   if (index<0xFFFFFFFu) {
     if (fId.det()==DetId::Hcal) {
@@ -190,7 +190,7 @@ HcalCondObjectContainer<Item>::getValues(DetId fId, bool throwOnFail) const {
       throw cms::Exception ("Conditions mismatch") 
 	<< "Requested conditions of type " << myname() << " for cell " << textForId(fId) << " got conditions for cell " << textForId(DetId(cell->rawId()));
     } 
-    cell=0;
+    cell=nullptr;
   }
 
   return cell;
@@ -213,34 +213,34 @@ HcalCondObjectContainer<Item>::addValues(const Item& myItem) {
   DetId fId(myItem.rawId());
   unsigned int index=indexFor(fId);
   
-  Item* cell = NULL;
+  Item* cell = nullptr;
 
   if (index<0xFFFFFFFu) {
     if (fId.det()==DetId::Hcal) {
       switch (HcalSubdetector(fId.subdetId())) {
 	case HcalBarrel:
-	  if (!HBcontainer.size() ) initContainer(fId);
+	  if (HBcontainer.empty() ) initContainer(fId);
 	  if (index < HBcontainer.size()) cell = &(HBcontainer.at(index) );
 	  break;
 	case HcalEndcap:
-	  if (!HEcontainer.size() ) initContainer(fId);
+	  if (HEcontainer.empty() ) initContainer(fId);
 	  if (index < HEcontainer.size()) cell = &(HEcontainer.at(index) );
 	  break;
 	case HcalForward:
-	  if (!HFcontainer.size() ) initContainer(fId);
+	  if (HFcontainer.empty() ) initContainer(fId);
 	  if (index < HFcontainer.size()) cell = &(HFcontainer.at(index) );
 	  break;
 	case HcalOuter:
-	  if (!HOcontainer.size() ) initContainer(fId);
+	  if (HOcontainer.empty() ) initContainer(fId);
 	  if (index < HOcontainer.size()) cell = &(HOcontainer.at(index) );
 	  break;
 	case HcalTriggerTower:
-	  if (!HTcontainer.size() ) initContainer(fId);
+	  if (HTcontainer.empty() ) initContainer(fId);
 	  if (index < HTcontainer.size()) cell = &(HTcontainer.at(index) );
 	  break;  
 	case HcalOther:
 	  if (extractOther(fId)==HcalCalibration) {
-	    if (!CALIBcontainer.size() ) initContainer(fId);
+	    if (CALIBcontainer.empty() ) initContainer(fId);
 	    if (index < CALIBcontainer.size()) cell = &(CALIBcontainer.at(index) );  
 	  }
 	  break; 
@@ -249,16 +249,16 @@ HcalCondObjectContainer<Item>::addValues(const Item& myItem) {
       }
     } else if (fId.det()==DetId::Calo) {
       if (fId.subdetId()==HcalCastorDetId::SubdetectorId) {
-	if (!CASTORcontainer.size() ) initContainer(fId);
+	if (CASTORcontainer.empty() ) initContainer(fId);
 	if (index < CASTORcontainer.size()) cell = &(CASTORcontainer.at(index) );
       } else if (fId.subdetId()==HcalZDCDetId::SubdetectorId) {	
-	if (!ZDCcontainer.size() ) initContainer(fId);
+	if (ZDCcontainer.empty() ) initContainer(fId);
 	if (index < ZDCcontainer.size()) cell = &(ZDCcontainer.at(index) );
       }
     }
   }
 
-  if (cell!=0) {
+  if (cell!=nullptr) {
     (*cell)=myItem;
     success=true;
   }

--- a/CondFormats/HcalObjects/interface/HcalConstFunctor.h
+++ b/CondFormats/HcalObjects/interface/HcalConstFunctor.h
@@ -18,12 +18,12 @@ public:
     // Normal constructor
     explicit HcalConstFunctor(const double value);
 
-    inline virtual ~HcalConstFunctor() {}
+    inline ~HcalConstFunctor() override {}
 
-    virtual double operator()(double x) const override;
+    double operator()(double x) const override;
 
 protected:
-    inline virtual bool isEqual(const AbsHcalFunctor& other) const override
+    inline bool isEqual(const AbsHcalFunctor& other) const override
     {
         const HcalConstFunctor& r = static_cast<const HcalConstFunctor&>(other);
         return value_ == r.value_;

--- a/CondFormats/HcalObjects/interface/HcalCubicInterpolator.h
+++ b/CondFormats/HcalObjects/interface/HcalCubicInterpolator.h
@@ -28,18 +28,18 @@ public:
     // given in arbitrary order.
     explicit HcalCubicInterpolator(const std::vector<Triple>& points);
 
-    inline virtual ~HcalCubicInterpolator() {}
+    inline ~HcalCubicInterpolator() override {}
 
-    virtual double operator()(double x) const override;
-    virtual double xmin() const override;
-    virtual double xmax() const override;
+    double operator()(double x) const override;
+    double xmin() const override;
+    double xmax() const override;
 
     // Cubic approximation to the inverse curve (note, not the real
     // solution of the direct cubic equation). Use at your own risc.
     HcalCubicInterpolator approximateInverse() const;
 
 protected:
-    inline virtual bool isEqual(const AbsHcalFunctor& other) const override
+    inline bool isEqual(const AbsHcalFunctor& other) const override
     {
         const HcalCubicInterpolator& r =
             static_cast<const HcalCubicInterpolator&>(other);

--- a/CondFormats/HcalObjects/interface/HcalDcsValue.h
+++ b/CondFormats/HcalObjects/interface/HcalDcsValue.h
@@ -4,7 +4,7 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
 class HcalDcsValue {

--- a/CondFormats/HcalObjects/interface/HcalFlagHFDigiTimeParams.h
+++ b/CondFormats/HcalObjects/interface/HcalFlagHFDigiTimeParams.h
@@ -11,11 +11,11 @@ class HcalFlagHFDigiTimeParams: public HcalCondObjectContainer<HcalFlagHFDigiTim
 {
  public:
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalFlagHFDigiTimeParams():HcalCondObjectContainer<HcalFlagHFDigiTimeParam>(0) {}
+  HcalFlagHFDigiTimeParams():HcalCondObjectContainer<HcalFlagHFDigiTimeParam>(nullptr) {}
 #endif
   HcalFlagHFDigiTimeParams(const HcalTopology* ht):HcalCondObjectContainer<HcalFlagHFDigiTimeParam>(ht) {}
 
-  std::string myname() const {return (std::string)"HcalFlagHFDigiTimeParams";}
+  std::string myname() const override {return (std::string)"HcalFlagHFDigiTimeParams";}
 
  private:
 

--- a/CondFormats/HcalObjects/interface/HcalGainWidths.h
+++ b/CondFormats/HcalObjects/interface/HcalGainWidths.h
@@ -18,11 +18,11 @@ class HcalGainWidths: public HcalCondObjectContainer<HcalGainWidth>
 {
  public:
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalGainWidths():HcalCondObjectContainer<HcalGainWidth>(0) {}
+  HcalGainWidths():HcalCondObjectContainer<HcalGainWidth>(nullptr) {}
 #endif
   HcalGainWidths(const HcalTopology* topo):HcalCondObjectContainer<HcalGainWidth>(topo) {}
 
-  std::string myname() const {return (std::string)"HcalGainWidths";}
+  std::string myname() const override {return (std::string)"HcalGainWidths";}
 
  private:
 

--- a/CondFormats/HcalObjects/interface/HcalGains.h
+++ b/CondFormats/HcalObjects/interface/HcalGains.h
@@ -18,11 +18,11 @@ class HcalGains: public HcalCondObjectContainer<HcalGain>
 {
  public:
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalGains():HcalCondObjectContainer<HcalGain>(0) {}
+  HcalGains():HcalCondObjectContainer<HcalGain>(nullptr) {}
 #endif
   HcalGains(const HcalTopology* topo):HcalCondObjectContainer<HcalGain>(topo) {}
 
-  std::string myname() const {return (std::string)"HcalGains";}
+  std::string myname() const override {return (std::string)"HcalGains";}
 
  private:
 

--- a/CondFormats/HcalObjects/interface/HcalInterpolatedTableFunctor.h
+++ b/CondFormats/HcalObjects/interface/HcalInterpolatedTableFunctor.h
@@ -29,11 +29,11 @@ public:
                                  bool leftExtrapolationLinear,
                                  bool rightExtrapolationLinear);
 
-    inline virtual ~HcalInterpolatedTableFunctor() {}
+    inline ~HcalInterpolatedTableFunctor() override {}
 
-    virtual double operator()(double x) const override;
-    inline virtual double xmin() const override {return xmin_;}
-    inline virtual double xmax() const override {return xmax_;}
+    double operator()(double x) const override;
+    inline double xmin() const override {return xmin_;}
+    inline double xmax() const override {return xmax_;}
 
     // Check if the interpolated values are strictly increasing or decreasing
     bool isStrictlyMonotonous() const;
@@ -43,7 +43,7 @@ public:
     HcalPiecewiseLinearFunctor inverse() const;
 
 protected:
-    inline virtual bool isEqual(const AbsHcalFunctor& other) const override
+    inline bool isEqual(const AbsHcalFunctor& other) const override
     {
         const HcalInterpolatedTableFunctor& r =
             static_cast<const HcalInterpolatedTableFunctor&>(other);

--- a/CondFormats/HcalObjects/interface/HcalItemCollById.h
+++ b/CondFormats/HcalObjects/interface/HcalItemCollById.h
@@ -59,7 +59,7 @@ public:
         HcalDetIdTransform::validateCode(transformCode_);
     }
 
-    inline virtual ~HcalItemCollById() {}
+    inline ~HcalItemCollById() override {}
 
     // Modifier for the default item
     inline void setDefault(std::unique_ptr<Item> f)
@@ -101,7 +101,7 @@ public:
     }
 
 protected:
-    virtual bool isEqual(const AbsHcalAlgoData& other) const override
+    bool isEqual(const AbsHcalAlgoData& other) const override
     {
         const HcalItemCollById& r =
             static_cast<const HcalItemCollById&>(other);

--- a/CondFormats/HcalObjects/interface/HcalL1TriggerObjects.h
+++ b/CondFormats/HcalObjects/interface/HcalL1TriggerObjects.h
@@ -15,7 +15,7 @@ class HcalL1TriggerObjects: public HcalCondObjectContainer<HcalL1TriggerObject>
 {
  public:
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
- HcalL1TriggerObjects():HcalCondObjectContainer<HcalL1TriggerObject>(0) { }
+ HcalL1TriggerObjects():HcalCondObjectContainer<HcalL1TriggerObject>(nullptr) { }
 #endif
   HcalL1TriggerObjects(const HcalTopology* topo):HcalCondObjectContainer<HcalL1TriggerObject>(topo) {}
 
@@ -26,7 +26,7 @@ class HcalL1TriggerObjects: public HcalCondObjectContainer<HcalL1TriggerObject>
   std::string getTagString() const {return (std::string)mTag;}
   std::string getAlgoString() const {return (std::string)mAlgo;}
 
-  std::string myname() const {return (std::string)"HcalL1TriggerObjects";}
+  std::string myname() const override {return (std::string)"HcalL1TriggerObjects";}
 
  private:
   char mTag[128];

--- a/CondFormats/HcalObjects/interface/HcalLUTCorrs.h
+++ b/CondFormats/HcalObjects/interface/HcalLUTCorrs.h
@@ -18,11 +18,11 @@ class HcalLUTCorrs: public HcalCondObjectContainer<HcalLUTCorr>
 {
  public:
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalLUTCorrs():HcalCondObjectContainer<HcalLUTCorr>(0) {}
+  HcalLUTCorrs():HcalCondObjectContainer<HcalLUTCorr>(nullptr) {}
 #endif
   HcalLUTCorrs(const HcalTopology* topo):HcalCondObjectContainer<HcalLUTCorr>(topo) {}
 
-  std::string myname() const {return (std::string)"HcalLUTCorrs";}
+  std::string myname() const override {return (std::string)"HcalLUTCorrs";}
 
  private:
 

--- a/CondFormats/HcalObjects/interface/HcalLinearCompositionFunctor.h
+++ b/CondFormats/HcalObjects/interface/HcalLinearCompositionFunctor.h
@@ -24,18 +24,18 @@ public:
     HcalLinearCompositionFunctor(boost::shared_ptr<AbsHcalFunctor> p,
                                  double a, double b);
 
-    inline virtual ~HcalLinearCompositionFunctor() {}
+    inline ~HcalLinearCompositionFunctor() override {}
 
-    virtual double operator()(double x) const override;
+    double operator()(double x) const override;
 
-    inline virtual double xmin() const override {return other_->xmin();}
-    inline virtual double xmax() const override {return other_->xmax();}
+    inline double xmin() const override {return other_->xmin();}
+    inline double xmax() const override {return other_->xmax();}
 
     inline double a() const {return a_;}
     inline double b() const {return b_;}
 
 protected:
-    inline virtual bool isEqual(const AbsHcalFunctor& other) const override
+    inline bool isEqual(const AbsHcalFunctor& other) const override
     {
         const HcalLinearCompositionFunctor& r =
             static_cast<const HcalLinearCompositionFunctor&>(other);

--- a/CondFormats/HcalObjects/interface/HcalLongRecoParams.h
+++ b/CondFormats/HcalObjects/interface/HcalLongRecoParams.h
@@ -12,11 +12,11 @@ class HcalLongRecoParams: public HcalCondObjectContainer<HcalLongRecoParam>
 {
  public:
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalLongRecoParams():HcalCondObjectContainer<HcalLongRecoParam>(0) {}
+  HcalLongRecoParams():HcalCondObjectContainer<HcalLongRecoParam>(nullptr) {}
 #endif
   HcalLongRecoParams(const HcalTopology* topo):HcalCondObjectContainer<HcalLongRecoParam>(topo) {}
 
-  std::string myname() const {return (std::string)"HcalLongRecoParams";}
+  std::string myname() const override {return (std::string)"HcalLongRecoParams";}
 
  private:
 

--- a/CondFormats/HcalObjects/interface/HcalLutMetadata.h
+++ b/CondFormats/HcalObjects/interface/HcalLutMetadata.h
@@ -16,11 +16,11 @@ class HcalLutMetadata: public HcalCondObjectContainer<HcalLutMetadatum>
 {
  public:
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalLutMetadata() : HcalCondObjectContainer<HcalLutMetadatum>(0){}
+  HcalLutMetadata() : HcalCondObjectContainer<HcalLutMetadatum>(nullptr){}
 #endif
   HcalLutMetadata(const HcalTopology* topo) : HcalCondObjectContainer<HcalLutMetadatum>(topo){}
     
-  std::string myname() const {return (std::string)"HcalLutMetadata";}
+  std::string myname() const override {return (std::string)"HcalLutMetadata";}
     
   bool  setRctLsb(float rctlsb);
   float getRctLsb() const {return mNonChannelData.mRctLsb;}

--- a/CondFormats/HcalObjects/interface/HcalMCParams.h
+++ b/CondFormats/HcalObjects/interface/HcalMCParams.h
@@ -12,11 +12,11 @@ class HcalMCParams: public HcalCondObjectContainer<HcalMCParam>
 {
  public:
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalMCParams():HcalCondObjectContainer<HcalMCParam>(0) {}
+  HcalMCParams():HcalCondObjectContainer<HcalMCParam>(nullptr) {}
 #endif
   HcalMCParams(const HcalTopology* topo):HcalCondObjectContainer<HcalMCParam>(topo) {}
 
-  std::string myname() const {return (std::string)"HcalMCParams";}
+  std::string myname() const override {return (std::string)"HcalMCParams";}
 
  private:
 

--- a/CondFormats/HcalObjects/interface/HcalObjectAddons.h
+++ b/CondFormats/HcalObjects/interface/HcalObjectAddons.h
@@ -11,7 +11,7 @@ namespace HcalObjectAddons {
     Less less;
     auto item = std::lower_bound (itemsByT.begin(), itemsByT.end(), target, less);
     if (item == itemsByT.end() || !less.equal(*item,target)){
-      return 0;
+      return nullptr;
     }
     return *item;
   }

--- a/CondFormats/HcalObjects/interface/HcalPFCorrs.h
+++ b/CondFormats/HcalObjects/interface/HcalPFCorrs.h
@@ -18,11 +18,11 @@ class HcalPFCorrs: public HcalCondObjectContainer<HcalPFCorr>
 {
  public:
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalPFCorrs():HcalCondObjectContainer<HcalPFCorr>(0) {}
+  HcalPFCorrs():HcalCondObjectContainer<HcalPFCorr>(nullptr) {}
 #endif
   HcalPFCorrs(const HcalTopology* topo):HcalCondObjectContainer<HcalPFCorr>(topo) {}
 
-  std::string myname() const {return (std::string)"HcalPFCorrs";}
+  std::string myname() const override {return (std::string)"HcalPFCorrs";}
 
  private:
 

--- a/CondFormats/HcalObjects/interface/HcalPedestalWidths.h
+++ b/CondFormats/HcalObjects/interface/HcalPedestalWidths.h
@@ -19,7 +19,7 @@ class HcalPedestalWidths: public HcalCondObjectContainer<HcalPedestalWidth>
  public:
   //constructor definition: has to contain 
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalPedestalWidths():HcalCondObjectContainer<HcalPedestalWidth>(0), unitIsADC(false) {}
+  HcalPedestalWidths():HcalCondObjectContainer<HcalPedestalWidth>(nullptr), unitIsADC(false) {}
 #endif
   HcalPedestalWidths(const HcalTopology* topo):HcalCondObjectContainer<HcalPedestalWidth>(topo), unitIsADC(false) {}
   HcalPedestalWidths(const HcalTopology* topo,bool isADC):HcalCondObjectContainer<HcalPedestalWidth>(topo), unitIsADC(isADC) {}
@@ -29,7 +29,7 @@ class HcalPedestalWidths: public HcalCondObjectContainer<HcalPedestalWidth>
   // set unit boolean
   void setUnitADC(bool isADC) {unitIsADC = isADC;}
 
-  std::string myname() const {return (std::string)"HcalPedestalWidths";}
+  std::string myname() const override {return (std::string)"HcalPedestalWidths";}
 
  private:
   bool unitIsADC;

--- a/CondFormats/HcalObjects/interface/HcalPedestals.h
+++ b/CondFormats/HcalObjects/interface/HcalPedestals.h
@@ -19,7 +19,7 @@ class HcalPedestals: public HcalCondObjectContainer<HcalPedestal>
  public:
   //constructor definition: has to contain 
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalPedestals():HcalCondObjectContainer<HcalPedestal>(0), unitIsADC(false) {}
+  HcalPedestals():HcalCondObjectContainer<HcalPedestal>(nullptr), unitIsADC(false) {}
 #endif
   HcalPedestals(const HcalTopology* topo):HcalCondObjectContainer<HcalPedestal>(topo), unitIsADC(false) {}
   HcalPedestals(const HcalTopology* topo, bool isADC):HcalCondObjectContainer<HcalPedestal>(topo), unitIsADC(isADC) {}
@@ -29,7 +29,7 @@ class HcalPedestals: public HcalCondObjectContainer<HcalPedestal>
   // set unit boolean
   void setUnitADC(bool isADC) {unitIsADC = isADC;}
 
-  std::string myname() const {return (std::string)"HcalPedestals";}
+  std::string myname() const override {return (std::string)"HcalPedestals";}
 
  private:
   bool unitIsADC;

--- a/CondFormats/HcalObjects/interface/HcalPiecewiseLinearFunctor.h
+++ b/CondFormats/HcalObjects/interface/HcalPiecewiseLinearFunctor.h
@@ -38,11 +38,11 @@ public:
                                bool leftExtrapolationLinear,
                                bool rightExtrapolationLinear);
 
-    inline virtual ~HcalPiecewiseLinearFunctor() {}
+    inline ~HcalPiecewiseLinearFunctor() override {}
 
-    virtual double operator()(double x) const override;
-    virtual double xmin() const override;
-    virtual double xmax() const override;
+    double operator()(double x) const override;
+    double xmin() const override;
+    double xmax() const override;
 
     // Check if the interpolated values are strictly increasing or decreasing
     bool isStrictlyMonotonous() const;
@@ -52,7 +52,7 @@ public:
     HcalPiecewiseLinearFunctor inverse() const;
 
 protected:
-    inline virtual bool isEqual(const AbsHcalFunctor& other) const override
+    inline bool isEqual(const AbsHcalFunctor& other) const override
     {
         const HcalPiecewiseLinearFunctor& r =
             static_cast<const HcalPiecewiseLinearFunctor&>(other);

--- a/CondFormats/HcalObjects/interface/HcalPolynomialFunctor.h
+++ b/CondFormats/HcalObjects/interface/HcalPolynomialFunctor.h
@@ -30,14 +30,14 @@ public:
                                    double xmax = DBL_MAX,
                                    double outOfRangeValue = 0.0);
 
-    inline virtual ~HcalPolynomialFunctor() {}
+    inline ~HcalPolynomialFunctor() override {}
 
-    virtual double operator()(double x) const override;
-    inline virtual double xmin() const override {return xmax_;};
-    inline virtual double xmax() const override {return xmin_;}
+    double operator()(double x) const override;
+    inline double xmin() const override {return xmax_;};
+    inline double xmax() const override {return xmin_;}
 
 protected:
-    inline virtual bool isEqual(const AbsHcalFunctor& other) const override
+    inline bool isEqual(const AbsHcalFunctor& other) const override
     {
         const HcalPolynomialFunctor& r =
             static_cast<const HcalPolynomialFunctor&>(other);

--- a/CondFormats/HcalObjects/interface/HcalQIEData.h
+++ b/CondFormats/HcalObjects/interface/HcalQIEData.h
@@ -26,7 +26,7 @@ class HcalQIEData: public HcalCondObjectContainer<HcalQIECoder>
 {
  public:
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalQIEData():HcalCondObjectContainer<HcalQIECoder>(0) {setupShape();}
+  HcalQIEData():HcalCondObjectContainer<HcalQIECoder>(nullptr) {setupShape();}
 #endif
   // constructor, destructor, and all methods stay the same
   HcalQIEData(const HcalTopology* topo):HcalCondObjectContainer<HcalQIECoder>(topo) {setupShape();}
@@ -44,7 +44,7 @@ class HcalQIEData: public HcalCondObjectContainer<HcalQIECoder>
   // sort values by channelId - remove in the next version  
   void sort () {}
   
-  std::string myname() const {return (std::string)"HcalQIEData";}
+  std::string myname() const override {return (std::string)"HcalQIEData";}
 
   //not needed/not used  HcalQIEData(const HcalQIEData&);
 

--- a/CondFormats/HcalObjects/interface/HcalQIETypes.h
+++ b/CondFormats/HcalObjects/interface/HcalQIETypes.h
@@ -18,11 +18,11 @@ class HcalQIETypes: public HcalCondObjectContainer<HcalQIEType>
 {
  public:
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalQIETypes():HcalCondObjectContainer<HcalQIEType>(0) {}
+  HcalQIETypes():HcalCondObjectContainer<HcalQIEType>(nullptr) {}
 #endif
   HcalQIETypes(const HcalTopology* topo):HcalCondObjectContainer<HcalQIEType>(topo) {}
 
-  std::string myname() const {return (std::string)"HcalQIETypes";}
+  std::string myname() const override {return (std::string)"HcalQIETypes";}
 
  private:
 

--- a/CondFormats/HcalObjects/interface/HcalRecoParams.h
+++ b/CondFormats/HcalObjects/interface/HcalRecoParams.h
@@ -12,11 +12,11 @@ class HcalRecoParams: public HcalCondObjectContainer<HcalRecoParam>
 {
  public:
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalRecoParams():HcalCondObjectContainer<HcalRecoParam>(0) {}
+  HcalRecoParams():HcalCondObjectContainer<HcalRecoParam>(nullptr) {}
 #endif
   HcalRecoParams(const HcalTopology* topo):HcalCondObjectContainer<HcalRecoParam>(topo) {}
 
-  std::string myname() const {return (std::string)"HcalRecoParams";}
+  std::string myname() const override {return (std::string)"HcalRecoParams";}
 
  private:
 

--- a/CondFormats/HcalObjects/interface/HcalRespCorrs.h
+++ b/CondFormats/HcalObjects/interface/HcalRespCorrs.h
@@ -18,11 +18,11 @@ class HcalRespCorrs: public HcalCondObjectContainer<HcalRespCorr>
 {
  public:
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalRespCorrs():HcalCondObjectContainer<HcalRespCorr>(0) {}
+  HcalRespCorrs():HcalCondObjectContainer<HcalRespCorr>(nullptr) {}
 #endif
   HcalRespCorrs(const HcalTopology* topo):HcalCondObjectContainer<HcalRespCorr>(topo) {}
 
-  std::string myname() const {return (std::string)"HcalRespCorrs";}
+  std::string myname() const override {return (std::string)"HcalRespCorrs";}
 
  private:
 

--- a/CondFormats/HcalObjects/interface/HcalSiPMParameters.h
+++ b/CondFormats/HcalObjects/interface/HcalSiPMParameters.h
@@ -10,11 +10,11 @@ class HcalSiPMParameters: public HcalCondObjectContainer<HcalSiPMParameter> {
 public:
   //constructor definition: has to contain 
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalSiPMParameters():HcalCondObjectContainer<HcalSiPMParameter>(0) {}
+  HcalSiPMParameters():HcalCondObjectContainer<HcalSiPMParameter>(nullptr) {}
 #endif
   HcalSiPMParameters(const HcalTopology* topo):HcalCondObjectContainer<HcalSiPMParameter>(topo) {}
 
-  std::string myname() const {return (std::string)"HcalSiPMParameters";}
+  std::string myname() const override {return (std::string)"HcalSiPMParameters";}
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/HcalObjects/interface/HcalTPChannelParameters.h
+++ b/CondFormats/HcalObjects/interface/HcalTPChannelParameters.h
@@ -10,11 +10,11 @@ class HcalTPChannelParameters: public HcalCondObjectContainer<HcalTPChannelParam
 public:
   //constructor definition: has to contain 
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalTPChannelParameters():HcalCondObjectContainer<HcalTPChannelParameter>(0) {}
+  HcalTPChannelParameters():HcalCondObjectContainer<HcalTPChannelParameter>(nullptr) {}
 #endif
   HcalTPChannelParameters(const HcalTopology* topo):HcalCondObjectContainer<HcalTPChannelParameter>(topo) {}
 
-  std::string myname() const {return (std::string)"HcalTPChannelParameters";}
+  std::string myname() const override {return (std::string)"HcalTPChannelParameters";}
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/HcalObjects/interface/HcalTimeCorrs.h
+++ b/CondFormats/HcalObjects/interface/HcalTimeCorrs.h
@@ -18,11 +18,11 @@ class HcalTimeCorrs: public HcalCondObjectContainer<HcalTimeCorr>
 {
  public:
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalTimeCorrs():HcalCondObjectContainer<HcalTimeCorr>(0) {}
+  HcalTimeCorrs():HcalCondObjectContainer<HcalTimeCorr>(nullptr) {}
 #endif
   HcalTimeCorrs(const HcalTopology* topo):HcalCondObjectContainer<HcalTimeCorr>(topo) {}
 
-  std::string myname() const {return (std::string)"HcalTimeCorrs";}
+  std::string myname() const override {return (std::string)"HcalTimeCorrs";}
 
  private:
 

--- a/CondFormats/HcalObjects/interface/HcalTimingParams.h
+++ b/CondFormats/HcalObjects/interface/HcalTimingParams.h
@@ -12,11 +12,11 @@ class HcalTimingParams: public HcalCondObjectContainer<HcalTimingParam>
 {
  public:
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalTimingParams():HcalCondObjectContainer<HcalTimingParam>(0) {}
+  HcalTimingParams():HcalCondObjectContainer<HcalTimingParam>(nullptr) {}
 #endif
   HcalTimingParams(const HcalTopology* topo):HcalCondObjectContainer<HcalTimingParam>(topo) {}
 
-  std::string myname() const {return (std::string)"HcalTimingParams";}
+  std::string myname() const override {return (std::string)"HcalTimingParams";}
 
  private:
 

--- a/CondFormats/HcalObjects/interface/HcalValidationCorrs.h
+++ b/CondFormats/HcalObjects/interface/HcalValidationCorrs.h
@@ -18,11 +18,11 @@ class HcalValidationCorrs: public HcalCondObjectContainer<HcalValidationCorr>
 {
  public:
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalValidationCorrs():HcalCondObjectContainer<HcalValidationCorr>(0) {}
+  HcalValidationCorrs():HcalCondObjectContainer<HcalValidationCorr>(nullptr) {}
 #endif
   HcalValidationCorrs(const HcalTopology* topo):HcalCondObjectContainer<HcalValidationCorr>(topo) {}
 
-  std::string myname() const {return (std::string)"HcalValidationCorrs";}
+  std::string myname() const override {return (std::string)"HcalValidationCorrs";}
 
  private:
 

--- a/CondFormats/HcalObjects/interface/HcalZDCLowGainFractions.h
+++ b/CondFormats/HcalObjects/interface/HcalZDCLowGainFractions.h
@@ -11,11 +11,11 @@ class HcalZDCLowGainFractions: public HcalCondObjectContainer<HcalZDCLowGainFrac
 {
  public:
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalZDCLowGainFractions():HcalCondObjectContainer<HcalZDCLowGainFraction>(0) {}
+  HcalZDCLowGainFractions():HcalCondObjectContainer<HcalZDCLowGainFraction>(nullptr) {}
 #endif
   HcalZDCLowGainFractions(const HcalTopology* topo):HcalCondObjectContainer<HcalZDCLowGainFraction>(topo) {}
 
-  std::string myname() const {return (std::string)"HcalZDCLowGainFractions";}
+  std::string myname() const override {return (std::string)"HcalZDCLowGainFractions";}
 
  private:
 

--- a/CondFormats/HcalObjects/interface/HcalZSThresholds.h
+++ b/CondFormats/HcalObjects/interface/HcalZSThresholds.h
@@ -18,11 +18,11 @@ class HcalZSThresholds: public HcalCondObjectContainer<HcalZSThreshold>
 {
  public:
 #ifndef HCAL_COND_SUPPRESS_DEFAULT
-  HcalZSThresholds():HcalCondObjectContainer<HcalZSThreshold>(0) {}
+  HcalZSThresholds():HcalCondObjectContainer<HcalZSThreshold>(nullptr) {}
 #endif
   HcalZSThresholds(const HcalTopology* topo):HcalCondObjectContainer<HcalZSThreshold>(topo) {}
 
-  std::string myname() const {return (std::string)"HcalZSThresholds";}
+  std::string myname() const override {return (std::string)"HcalZSThresholds";}
 
  private:
 

--- a/CondFormats/HcalObjects/interface/OOTPileupCorrData.h
+++ b/CondFormats/HcalObjects/interface/OOTPileupCorrData.h
@@ -54,7 +54,7 @@ public:
                       double chargeLimit, int requireFirstTS,
                       int requireNTS, bool readjustTiming);
 
-    inline virtual ~OOTPileupCorrData() {}
+    inline ~OOTPileupCorrData() override {}
 
     // Main correction function
     void apply(const HcalDetId& id,
@@ -63,10 +63,10 @@ public:
                unsigned firstTimeSlice, unsigned nTimeSlices,
                double* correctedCharge, unsigned lenCorrectedCharge,
                bool* pulseShapeCorrApplied, bool* leakCorrApplied,
-               bool* readjustTiming) const;
+               bool* readjustTiming) const override;
 
     // Are we using charge or energy?
-    inline bool inputIsEnergy() const {return false;}
+    inline bool inputIsEnergy() const override {return false;}
 
     // Simplified correction function which does actual work
     inline void apply(const HcalDetId& id, double* ts, const int tsTrig) const
@@ -104,7 +104,7 @@ public:
 
 protected:
     // Comparison function must be implemented
-    inline bool isEqual(const AbsOOTPileupCorrection& otherBase) const
+    inline bool isEqual(const AbsOOTPileupCorrection& otherBase) const override
     {
         const OOTPileupCorrData& r = 
             static_cast<const OOTPileupCorrData&>(otherBase);

--- a/CondFormats/HcalObjects/interface/OOTPileupCorrectionBuffer.h
+++ b/CondFormats/HcalObjects/interface/OOTPileupCorrectionBuffer.h
@@ -28,11 +28,11 @@ public:
     inline std::size_t length() const {return m_buffer.size();}
     inline bool empty() const {return m_buffer.empty();}
     inline const char* getBuffer() const
-        {return m_buffer.empty() ? static_cast<const char*>(0) : &m_buffer[0];}
+        {return m_buffer.empty() ? static_cast<const char*>(nullptr) : &m_buffer[0];}
 
     // Modifiers
     inline char* getBuffer() 
-        {return m_buffer.empty() ? static_cast<char*>(0) : &m_buffer[0];}
+        {return m_buffer.empty() ? static_cast<char*>(nullptr) : &m_buffer[0];}
     inline void setStr(const std::string& s) {m_buffer = s;}
 
 private:

--- a/CondFormats/HcalObjects/src/DummyOOTPileupCorrection.cc
+++ b/CondFormats/HcalObjects/src/DummyOOTPileupCorrection.cc
@@ -14,10 +14,10 @@ void DummyOOTPileupCorrection::apply(
     bool* readjustTiming) const
 {
     // Check the arguments
-    if (inputCharge == 0 || correctedCharge == 0 ||
+    if (inputCharge == nullptr || correctedCharge == nullptr ||
         lenCorrectedCharge < lenInputCharge ||
-        pulseShapeCorrApplied == 0 || leakCorrApplied == 0 ||
-        readjustTiming == 0)
+        pulseShapeCorrApplied == nullptr || leakCorrApplied == nullptr ||
+        readjustTiming == nullptr)
         throw cms::Exception(
             "Invalid arguments in DummyOOTPileupCorrection::apply");
 

--- a/CondFormats/HcalObjects/src/HcalDcsValues.cc
+++ b/CondFormats/HcalObjects/src/HcalDcsValues.cc
@@ -71,7 +71,7 @@ bool HcalDcsValues::exists(HcalDcsDetId const& fid) {
 }
 
 HcalDcsValues::DcsSet HcalDcsValues::getValues(HcalDcsDetId const& fid) {
-  DcsSet * valList = 0;
+  DcsSet * valList = nullptr;
   switch(fid.subdet()) {
   case HcalDcsBarrel : 
     valList = &mHBValues; 
@@ -94,7 +94,7 @@ HcalDcsValues::DcsSet HcalDcsValues::getValues(HcalDcsDetId const& fid) {
     valList = &mHFValues; 
     if (!mHFsorted) mHFsorted = sortList(mHFValues);
     break;
-  default : valList = 0;
+  default : valList = nullptr;
   }
 
   if (valList) {
@@ -207,7 +207,7 @@ bool HcalDcsValues::subDetOk(DcsSet const& valList, int LS) const {
     }
     ++val;
   }
-  return (badIds.size()==0);
+  return (badIds.empty());
 }
 
 bool HcalDcsValues::sortList(DcsSet& valList) const {

--- a/CondFormats/HcalObjects/src/HcalElectronicsMap.cc
+++ b/CondFormats/HcalObjects/src/HcalElectronicsMap.cc
@@ -54,7 +54,7 @@ const HcalElectronicsMap::PrecisionItem* HcalElectronicsMap::findPByElId (unsign
   HcalElectronicsId eid(fElId);
   const PrecisionItem* i=&(mPItems[eid.linearIndex()]);
   
-  if (i!=0 && i->mElId!=fElId) i=0;
+  if (i!=nullptr && i->mElId!=fElId) i=nullptr;
   return i;
 }
 
@@ -62,7 +62,7 @@ const HcalElectronicsMap::TriggerItem* HcalElectronicsMap::findTByElId (unsigned
   HcalElectronicsId eid(fElId);
   const TriggerItem* i=&(mTItems[eid.linearIndex()]);
   
-  if (i!=0 && i->mElId!=fElId) i=0;
+  if (i!=nullptr && i->mElId!=fElId) i=nullptr;
   return i;
 }
 
@@ -94,7 +94,7 @@ const HcalElectronicsId HcalElectronicsMap::lookupTrigger(DetId fId) const {
 
 bool HcalElectronicsMap::lookup(const HcalElectronicsId pid, HcalElectronicsId& eid, HcalGenericDetId& did) const {
   const PrecisionItem* i=&(mPItems[pid.linearIndex()]);
-  if (i!=0 && i->mId!=0) {
+  if (i!=nullptr && i->mId!=0) {
     eid=HcalElectronicsId(i->mElId);
     did=HcalGenericDetId(i->mId);
     return true;
@@ -103,7 +103,7 @@ bool HcalElectronicsMap::lookup(const HcalElectronicsId pid, HcalElectronicsId& 
 
 bool HcalElectronicsMap::lookup(const HcalElectronicsId pid, HcalElectronicsId& eid, HcalTrigTowerDetId& did) const {
   const TriggerItem* i=&(mTItems[pid.linearIndex()]);
-  if (i!=0 && i->mTrigId!=0) {
+  if (i!=nullptr && i->mTrigId!=0) {
     eid=HcalElectronicsId(i->mElId);
     did=HcalGenericDetId(i->mTrigId);
     return true;

--- a/CondFormats/HcalObjects/src/HcalLogicalMap.cc
+++ b/CondFormats/HcalObjects/src/HcalLogicalMap.cc
@@ -8,8 +8,8 @@
 #include <iostream>
 #include <fstream>
 #include <sstream>
-#include <stdio.h>
-#include <time.h>
+#include <cstdio>
+#include <ctime>
 #include <memory>
 
 using namespace std;

--- a/CondFormats/HcalObjects/src/HcalMappingEntry.cc
+++ b/CondFormats/HcalObjects/src/HcalMappingEntry.cc
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <fstream>
 #include <sstream>
-#include <stdio.h>
+#include <cstdio>
 #include <string>
 #include <cstring>
 

--- a/CondFormats/HcalObjects/src/HcalPedestalWidth.cc
+++ b/CondFormats/HcalObjects/src/HcalPedestalWidth.cc
@@ -7,7 +7,7 @@ $Date: 2008/11/07 16:06:24 $
 $Revision: 1.8 $
 */
 
-#include <math.h>
+#include <cmath>
 #include <iostream>
 
 #include "CondFormats/HcalObjects/interface/HcalPedestalWidth.h"

--- a/CondFormats/HcalObjects/src/OOTPileupCorrData.cc
+++ b/CondFormats/HcalObjects/src/OOTPileupCorrData.cc
@@ -46,10 +46,10 @@ void OOTPileupCorrData::apply(const HcalDetId& id,
     bool* readjustTiming) const
 {
     // Check the arguments
-    if (inputCharge == 0 || correctedCharge == 0 ||
+    if (inputCharge == nullptr || correctedCharge == nullptr ||
         lenCorrectedCharge < lenInputCharge ||
-        pulseShapeCorrApplied == 0 || leakCorrApplied == 0 ||
-        readjustTiming == 0)
+        pulseShapeCorrApplied == nullptr || leakCorrApplied == nullptr ||
+        readjustTiming == nullptr)
         throw cms::Exception(
             "Invalid arguments in OOTPileupCorrData::apply");
 

--- a/CondFormats/JetMETObjects/interface/FFTJetCorrectorParameters.h
+++ b/CondFormats/JetMETObjects/interface/FFTJetCorrectorParameters.h
@@ -28,11 +28,11 @@ public:
     inline std::size_t length() const {return m_buffer.size();}
     inline bool empty() const {return m_buffer.empty();}
     inline const char* getBuffer() const
-        {return m_buffer.empty() ? static_cast<const char*>(0) : &m_buffer[0];}
+        {return m_buffer.empty() ? static_cast<const char*>(nullptr) : &m_buffer[0];}
 
     // Modifiers
     inline char* getBuffer() 
-        {return m_buffer.empty() ? static_cast<char*>(0) : &m_buffer[0];}
+        {return m_buffer.empty() ? static_cast<char*>(nullptr) : &m_buffer[0];}
     inline void setStr(const std::string& s) {m_buffer = s;}
 
 private:

--- a/CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h
+++ b/CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h
@@ -46,8 +46,8 @@ class FactorizedJetCorrector
        
   private:
   //---- Member Functions ----  
-    FactorizedJetCorrector(const FactorizedJetCorrector&);
-    FactorizedJetCorrector& operator= (const FactorizedJetCorrector&);
+    FactorizedJetCorrector(const FactorizedJetCorrector&) = delete;
+    FactorizedJetCorrector& operator= (const FactorizedJetCorrector&) = delete;
     //---- Member Data ---------
     FactorizedJetCorrectorCalculator::VariableValues mValues;
     FactorizedJetCorrectorCalculator mCalc;

--- a/CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h
+++ b/CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h
@@ -87,8 +87,8 @@ class FactorizedJetCorrectorCalculator
        
   private:
   //---- Member Functions ----  
-    FactorizedJetCorrectorCalculator(const FactorizedJetCorrectorCalculator&);
-    FactorizedJetCorrectorCalculator& operator= (const FactorizedJetCorrectorCalculator&);
+    FactorizedJetCorrectorCalculator(const FactorizedJetCorrectorCalculator&) = delete;
+    FactorizedJetCorrectorCalculator& operator= (const FactorizedJetCorrectorCalculator&) = delete;
     float getLepPt(const VariableValues&)    const;
     float getRelLepPt(const VariableValues&) const;
     float getPtRel(const VariableValues&)    const;

--- a/CondFormats/JetMETObjects/interface/JetCorrectionUncertainty.h
+++ b/CondFormats/JetMETObjects/interface/JetCorrectionUncertainty.h
@@ -29,8 +29,8 @@ class JetCorrectionUncertainty
     float getUncertainty(bool fDirection);
 
  private:
-  JetCorrectionUncertainty(const JetCorrectionUncertainty&);
-  JetCorrectionUncertainty& operator= (const JetCorrectionUncertainty&);
+  JetCorrectionUncertainty(const JetCorrectionUncertainty&) = delete;
+  JetCorrectionUncertainty& operator= (const JetCorrectionUncertainty&) = delete;
   std::vector<float> fillVector(const std::vector<std::string>& fNames);
   float getPtRel();
   //---- Member Data ---------

--- a/CondFormats/JetMETObjects/interface/SimpleJetCorrectionUncertainty.h
+++ b/CondFormats/JetMETObjects/interface/SimpleJetCorrectionUncertainty.h
@@ -18,8 +18,8 @@ class SimpleJetCorrectionUncertainty
   float uncertainty(const std::vector<float>& fX, float fY, bool fDirection) const;
 
  private:
-  SimpleJetCorrectionUncertainty(const SimpleJetCorrectionUncertainty&);
-  SimpleJetCorrectionUncertainty& operator= (const SimpleJetCorrectionUncertainty&);
+  SimpleJetCorrectionUncertainty(const SimpleJetCorrectionUncertainty&) = delete;
+  SimpleJetCorrectionUncertainty& operator= (const SimpleJetCorrectionUncertainty&) = delete;
   int findBin(const std::vector<float>& v, float x) const;
   float uncertaintyBin(unsigned fBin, float fY, bool fDirection) const;
   float linearInterpolation (float fZ, const float fX[2], const float fY[2]) const;

--- a/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
@@ -10,7 +10,7 @@
 #include <iomanip>
 #include <fstream>
 #include <sstream>
-#include <stdlib.h>
+#include <cstdlib>
 #include <algorithm>
 #include <cmath>
 #include <iterator>

--- a/CondFormats/JetMETObjects/src/JetCorrectorParametersHelper.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectorParametersHelper.cc
@@ -6,7 +6,7 @@
 //
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParametersHelper.h"
 #include <sstream>
-#include <stdlib.h>
+#include <cstdlib>
 #include <algorithm>
 #include <cmath>
 #include <iterator>

--- a/CondFormats/JetMETObjects/src/JetResolution.cc
+++ b/CondFormats/JetMETObjects/src/JetResolution.cc
@@ -39,7 +39,7 @@ double fnc_gaussalpha1alpha2(double*xx,double*pp);
 
 //______________________________________________________________________________
 JetResolution::JetResolution()
-  : resolutionFnc_(0)
+  : resolutionFnc_(nullptr)
 {
   resolutionFnc_ = new TF1();
 }
@@ -47,7 +47,7 @@ JetResolution::JetResolution()
 
 //______________________________________________________________________________
 JetResolution::JetResolution(const string& fileName,bool doGaussian)
-  : resolutionFnc_(0)
+  : resolutionFnc_(nullptr)
 {
   initialize(fileName,doGaussian);
 }
@@ -153,8 +153,8 @@ TF1* JetResolution::parameterEta(const string& parameterName, float eta)
 //______________________________________________________________________________
 TF1* JetResolution::parameter(const string& parameterName,const vector<float>& x)
 {
-  TF1* result(0);
-  for (unsigned i=0;i<parameterFncs_.size()&&result==0;i++) {
+  TF1* result(nullptr);
+  for (unsigned i=0;i<parameterFncs_.size()&&result==nullptr;i++) {
     string fncname = parameterFncs_[i]->GetName();
     if (fncname.find("f"+parameterName)==0) {
       stringstream ssname; ssname<<parameterFncs_[i]->GetName();
@@ -171,7 +171,7 @@ TF1* JetResolution::parameter(const string& parameterName,const vector<float>& x
     }
   }
 
-  if (0==result) cerr<<"JetResolution::parameter() ERROR: no parameter "
+  if (nullptr==result) cerr<<"JetResolution::parameter() ERROR: no parameter "
 		     <<parameterName<<" found."<<endl;
 
   return result;
@@ -181,8 +181,8 @@ TF1* JetResolution::parameter(const string& parameterName,const vector<float>& x
 //______________________________________________________________________________
 double JetResolution::parameterEtaEval(const std::string& parameterName, float eta, float pt)
 {
-  TF1* func(0);
-  JetCorrectorParameters* params(0);
+  TF1* func(nullptr);
+  JetCorrectorParameters* params(nullptr);
   for (std::vector<TF1*>::size_type ifunc = 0; ifunc < parameterFncs_.size(); ++ifunc)
     {
       std::string fncname = parameterFncs_[ifunc]->GetName();

--- a/CondFormats/JetMETObjects/src/JetResolutionObject.cc
+++ b/CondFormats/JetMETObjects/src/JetResolutionObject.cc
@@ -176,7 +176,7 @@ namespace JME {
     }
 
     void JetResolutionObject::Definition::init() {
-        if (m_formula_str.size())
+        if (!m_formula_str.empty())
             m_formula = std::make_shared<TFormula>("jet_resolution_formula", m_formula_str.c_str());
 
         for (const auto& bin: m_bins_name) {
@@ -240,12 +240,12 @@ namespace JME {
         }
 
         for (std::string line; std::getline(f, line); ) {
-            if ((line.size() == 0) || (line[0] == '#'))
+            if ((line.empty()) || (line[0] == '#'))
                 continue;
 
             std::string definition = getDefinitionLine(line);
 
-            if (definition.size() > 0) {
+            if (!definition.empty()) {
                 m_definition = Definition(definition);
             } else {
                 m_records.push_back(Record(line, m_definition));

--- a/CondFormats/JetMETObjects/src/METCorrectorParameters.cc
+++ b/CondFormats/JetMETObjects/src/METCorrectorParameters.cc
@@ -6,7 +6,7 @@
 #include <iomanip>
 #include <fstream>
 #include <sstream>
-#include <stdlib.h>
+#include <cstdlib>
 #include <algorithm>
 #include <cmath>
 #include <iterator>

--- a/CondFormats/JetMETObjects/src/MEtXYcorrectParameters.cc
+++ b/CondFormats/JetMETObjects/src/MEtXYcorrectParameters.cc
@@ -7,7 +7,7 @@
 #include <iomanip>
 #include <fstream>
 #include <sstream>
-#include <stdlib.h>
+#include <cstdlib>
 #include <algorithm>
 #include <cmath>
 #include <iterator>

--- a/CondFormats/JetMETObjects/src/SimpleJetCorrector.cc
+++ b/CondFormats/JetMETObjects/src/SimpleJetCorrector.cc
@@ -39,7 +39,7 @@ float SimpleJetCorrector::correction(const std::vector<float>& fX,const std::vec
   float tmp    = 0.0;
   float cor    = 0.0;
   int bin = -1;
-  bin = (fX.size()<=3 && fX.size()>0) ? mParameters.binIndexN(fX) : mParameters.binIndex(fX);
+  bin = (fX.size()<=3 && !fX.empty()) ? mParameters.binIndexN(fX) : mParameters.binIndex(fX);
   if (bin<0)
     return result;
   if (!mDoInterpolation)

--- a/CondFormats/L1TObjects/interface/DTTFBitArray.h
+++ b/CondFormats/L1TObjects/interface/DTTFBitArray.h
@@ -358,13 +358,13 @@ class DTTFBitArray {
    int nw = this->nWords();
     int ub = this->unusedBits();
     if(this->dataWord(nw-1)<<ub!=         // check last word
-           a.dataWord(nw-1)<<ub)return 0;
+           a.dataWord(nw-1)<<ub)return false;
     if(nw>1){
       for (int iw=0;iw<nw-1;iw++){
-	if(this->dataWord(iw)!=a.dataWord(iw)) return 0;
+	if(this->dataWord(iw)!=a.dataWord(iw)) return false;
       }
     }
-    return 1;
+    return true;
   }
   
   // logical operators <
@@ -374,20 +374,20 @@ class DTTFBitArray {
     unsigned aaa = this->dataWord(nw-1)<<ub; // ignore unused bits
     unsigned bbb =     a.dataWord(nw-1)<<ub; // in both operands
     if        (aaa<bbb) {
-      return 1;
+      return true;
     } else if (aaa>bbb) {
-      return 0;
+      return false;
     }
     if(nw>1){
       for (int iw=nw-2;iw>=0;iw--){
 	if        (this->dataWord(iw)<a.dataWord(iw)) {
-	  return 1;
+	  return true;
 	} else if (this->dataWord(iw)>a.dataWord(iw)) {
-	  return 0;
+	  return false;
 	}
       }
     }
-    return 0;
+    return false;
   }
   
   // logical operators !=

--- a/CondFormats/L1TObjects/interface/L1CaloEcalScale.h
+++ b/CondFormats/L1TObjects/interface/L1CaloEcalScale.h
@@ -23,7 +23,7 @@
 
 #include <vector>
 #include <ostream>
-#include <stdint.h>
+#include <cstdint>
 
 class L1CaloEcalScale {
 

--- a/CondFormats/L1TObjects/interface/L1CaloHcalScale.h
+++ b/CondFormats/L1TObjects/interface/L1CaloHcalScale.h
@@ -23,7 +23,7 @@
 
 #include <vector>
 #include <ostream>
-#include <stdint.h>
+#include <cstdint>
 
 class L1CaloHcalScale {
 

--- a/CondFormats/L1TObjects/interface/L1GctJetFinderParams.h
+++ b/CondFormats/L1TObjects/interface/L1GctJetFinderParams.h
@@ -4,7 +4,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <vector>
-#include <stdint.h>
+#include <cstdint>
 #include <iosfwd>
 
 class L1GctJetFinderParams

--- a/CondFormats/L1TObjects/interface/L1GtBptxTemplate.h
+++ b/CondFormats/L1TObjects/interface/L1GtBptxTemplate.h
@@ -54,7 +54,7 @@ public:
     L1GtBptxTemplate(const L1GtBptxTemplate&);
 
     // destructor
-    virtual ~L1GtBptxTemplate();
+    ~L1GtBptxTemplate() override;
 
     // assign operator
     L1GtBptxTemplate& operator=(const L1GtBptxTemplate&);
@@ -62,7 +62,7 @@ public:
 public:
 
     /// print the condition
-    virtual void print(std::ostream& myCout) const;
+    void print(std::ostream& myCout) const override;
 
     /// output stream operator
     friend std::ostream& operator<<(std::ostream&, const L1GtBptxTemplate&);

--- a/CondFormats/L1TObjects/interface/L1GtCaloTemplate.h
+++ b/CondFormats/L1TObjects/interface/L1GtCaloTemplate.h
@@ -49,7 +49,7 @@ public:
     L1GtCaloTemplate( const L1GtCaloTemplate& );
 
     // destructor
-    virtual ~L1GtCaloTemplate();
+    ~L1GtCaloTemplate() override;
 
     // assign operator
     L1GtCaloTemplate& operator= (const L1GtCaloTemplate&);
@@ -97,7 +97,7 @@ public:
 
 
     /// print the condition
-    virtual void print(std::ostream& myCout) const;
+    void print(std::ostream& myCout) const override;
 
     /// output stream operator
     friend std::ostream& operator<<(std::ostream&, const L1GtCaloTemplate&);

--- a/CondFormats/L1TObjects/interface/L1GtCastorTemplate.h
+++ b/CondFormats/L1TObjects/interface/L1GtCastorTemplate.h
@@ -53,7 +53,7 @@ public:
     L1GtCastorTemplate(const L1GtCastorTemplate&);
 
     // destructor
-    virtual ~L1GtCastorTemplate();
+    ~L1GtCastorTemplate() override;
 
     // assign operator
     L1GtCastorTemplate& operator=(const L1GtCastorTemplate&);
@@ -61,7 +61,7 @@ public:
 public:
 
     /// print the condition
-    virtual void print(std::ostream& myCout) const;
+    void print(std::ostream& myCout) const override;
 
     /// output stream operator
     friend std::ostream& operator<<(std::ostream&, const L1GtCastorTemplate&);

--- a/CondFormats/L1TObjects/interface/L1GtCorrelationTemplate.h
+++ b/CondFormats/L1TObjects/interface/L1GtCorrelationTemplate.h
@@ -59,7 +59,7 @@ public:
     L1GtCorrelationTemplate( const L1GtCorrelationTemplate& );
 
     /// destructor
-    virtual ~L1GtCorrelationTemplate();
+    ~L1GtCorrelationTemplate() override;
 
     /// assign operator
     L1GtCorrelationTemplate& operator= (const L1GtCorrelationTemplate&);
@@ -115,7 +115,7 @@ public:
 
 
     /// print the condition
-    virtual void print(std::ostream& myCout) const;
+    void print(std::ostream& myCout) const override;
 
     /// output stream operator
     friend std::ostream& operator<<(std::ostream&, const L1GtCorrelationTemplate&);

--- a/CondFormats/L1TObjects/interface/L1GtEnergySumTemplate.h
+++ b/CondFormats/L1TObjects/interface/L1GtEnergySumTemplate.h
@@ -51,7 +51,7 @@ public:
     L1GtEnergySumTemplate(const L1GtEnergySumTemplate&);
 
     // destructor
-    virtual ~L1GtEnergySumTemplate();
+    ~L1GtEnergySumTemplate() override;
 
     // assign operator
     L1GtEnergySumTemplate& operator=(const L1GtEnergySumTemplate&);
@@ -70,7 +70,7 @@ public:
       unsigned long long phiRange1Word;
 
       // make sure all objects (esp. the bool) are properly initialised to avoid problems with serialisation:
-      ObjectParameter() : etThreshold(0), energyOverflow(0), phiRange0Word(0), phiRange1Word(0) { /*nop*/;};
+      ObjectParameter() : etThreshold(0), energyOverflow(false), phiRange0Word(0), phiRange1Word(0) { /*nop*/;};
 
     COND_SERIALIZABLE;
 };
@@ -85,7 +85,7 @@ public:
     void setConditionParameter(const std::vector<ObjectParameter>&);
 
     /// print the condition
-    virtual void print(std::ostream& myCout) const;
+    void print(std::ostream& myCout) const override;
 
     /// output stream operator
     friend std::ostream& operator<<(std::ostream&, const L1GtEnergySumTemplate&);

--- a/CondFormats/L1TObjects/interface/L1GtExternalTemplate.h
+++ b/CondFormats/L1TObjects/interface/L1GtExternalTemplate.h
@@ -54,7 +54,7 @@ public:
     L1GtExternalTemplate(const L1GtExternalTemplate&);
 
     // destructor
-    virtual ~L1GtExternalTemplate();
+    ~L1GtExternalTemplate() override;
 
     // assign operator
     L1GtExternalTemplate& operator=(const L1GtExternalTemplate&);
@@ -62,7 +62,7 @@ public:
 public:
 
     /// print the condition
-    virtual void print(std::ostream& myCout) const;
+    void print(std::ostream& myCout) const override;
 
     /// output stream operator
     friend std::ostream& operator<<(std::ostream&, const L1GtExternalTemplate&);

--- a/CondFormats/L1TObjects/interface/L1GtHfBitCountsTemplate.h
+++ b/CondFormats/L1TObjects/interface/L1GtHfBitCountsTemplate.h
@@ -49,7 +49,7 @@ public:
     L1GtHfBitCountsTemplate( const L1GtHfBitCountsTemplate& );
 
     // destructor
-    virtual ~L1GtHfBitCountsTemplate();
+    ~L1GtHfBitCountsTemplate() override;
 
     // assign operator
     L1GtHfBitCountsTemplate& operator= (const L1GtHfBitCountsTemplate&);
@@ -80,7 +80,7 @@ public:
 
 
     /// print the condition
-    virtual void print(std::ostream& myCout) const;
+    void print(std::ostream& myCout) const override;
 
     /// output stream operator
     friend std::ostream& operator<<(std::ostream&, const L1GtHfBitCountsTemplate&);

--- a/CondFormats/L1TObjects/interface/L1GtHfRingEtSumsTemplate.h
+++ b/CondFormats/L1TObjects/interface/L1GtHfRingEtSumsTemplate.h
@@ -49,7 +49,7 @@ public:
     L1GtHfRingEtSumsTemplate( const L1GtHfRingEtSumsTemplate& );
 
     // destructor
-    virtual ~L1GtHfRingEtSumsTemplate();
+    ~L1GtHfRingEtSumsTemplate() override;
 
     // assign operator
     L1GtHfRingEtSumsTemplate& operator= (const L1GtHfRingEtSumsTemplate&);
@@ -80,7 +80,7 @@ public:
 
 
     /// print the condition
-    virtual void print(std::ostream& myCout) const;
+    void print(std::ostream& myCout) const override;
 
     /// output stream operator
     friend std::ostream& operator<<(std::ostream&, const L1GtHfRingEtSumsTemplate&);

--- a/CondFormats/L1TObjects/interface/L1GtJetCountsTemplate.h
+++ b/CondFormats/L1TObjects/interface/L1GtJetCountsTemplate.h
@@ -51,7 +51,7 @@ public:
     L1GtJetCountsTemplate( const L1GtJetCountsTemplate& );
 
     // destructor
-    virtual ~L1GtJetCountsTemplate();
+    ~L1GtJetCountsTemplate() override;
 
     // assign operator
     L1GtJetCountsTemplate& operator= (const L1GtJetCountsTemplate&);
@@ -61,7 +61,7 @@ public:
     /// typedef for a single object template
     struct ObjectParameter
     {
-      ObjectParameter() : countOverflow(0) {}
+      ObjectParameter() : countOverflow(false) {}
         unsigned int countIndex;
         unsigned int countThreshold;
 
@@ -84,7 +84,7 @@ public:
 
 
     /// print the condition
-    virtual void print(std::ostream& myCout) const;
+    void print(std::ostream& myCout) const override;
 
     /// output stream operator
     friend std::ostream& operator<<(std::ostream&, const L1GtJetCountsTemplate&);

--- a/CondFormats/L1TObjects/interface/L1GtMuonTemplate.h
+++ b/CondFormats/L1TObjects/interface/L1GtMuonTemplate.h
@@ -49,7 +49,7 @@ public:
     L1GtMuonTemplate( const L1GtMuonTemplate& );
 
     // destructor
-    virtual ~L1GtMuonTemplate();
+    ~L1GtMuonTemplate() override;
 
     // assign operator
     L1GtMuonTemplate& operator= (const L1GtMuonTemplate&);
@@ -106,7 +106,7 @@ public:
 
 
     /// print the condition
-    virtual void print(std::ostream& myCout) const;
+    void print(std::ostream& myCout) const override;
 
     /// output stream operator
     friend std::ostream& operator<<(std::ostream&, const L1GtMuonTemplate&);

--- a/CondFormats/L1TObjects/interface/L1MuCSCPtLut.h
+++ b/CondFormats/L1TObjects/interface/L1MuCSCPtLut.h
@@ -4,7 +4,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <string>
-#include <string.h>
+#include <cstring>
 
 class CSCTFConfigProducer;
 

--- a/CondFormats/L1TObjects/interface/L1MuPacking.h
+++ b/CondFormats/L1TObjects/interface/L1MuPacking.h
@@ -57,11 +57,11 @@ template<unsigned int Bits>
 class L1MuUnsignedPacking : public L1MuPacking{
  public:
   /// get the sign from the packed notation. always psitive (0)
-  virtual int signFromPacked(unsigned packed) const { return 0;}; 
+  int signFromPacked(unsigned packed) const override { return 0;}; 
   /// get the value from the packed notation (always positive)
-  virtual int idxFromPacked(unsigned packed) const { return (int) packed;};
+  int idxFromPacked(unsigned packed) const override { return (int) packed;};
   /// get the packed notation of a value, check the range
-  virtual unsigned packedFromIdx(int idx) const { 
+  unsigned packedFromIdx(int idx) const override { 
     if (idx >= (1 << Bits) ) edm::LogWarning("ScaleRangeViolation") 
                   << "L1MuUnignedPacking::packedFromIdx: warning value " << idx 
 		  << "exceeds " << Bits << "-bit range !!!";        
@@ -94,12 +94,12 @@ template<unsigned int Bits>
 class L1MuSignedPacking : public L1MuPacking {
  public:
   /// get the sign from the packed notation (0=positive, 1=negative)
-  virtual int signFromPacked(unsigned packed) const { return packed & (1 << (Bits-1)) ? 1 : 0;};
+  int signFromPacked(unsigned packed) const override { return packed & (1 << (Bits-1)) ? 1 : 0;};
 
   /// get the value from the packed notation (+/-)
-  virtual int idxFromPacked(unsigned packed) const { return packed & (1 << (Bits-1)) ? (packed - (1 << Bits) ) : packed;};
+  int idxFromPacked(unsigned packed) const override { return packed & (1 << (Bits-1)) ? (packed - (1 << Bits) ) : packed;};
   /// get the packed notation of a value, check range
-  virtual unsigned packedFromIdx(int idx) const { 
+  unsigned packedFromIdx(int idx) const override { 
     unsigned maxabs = 1 << (Bits-1) ;
     if (idx < -(int)maxabs && idx >= (int)maxabs) edm::LogWarning("ScaleRangeViolation") 
                                                        << "L1MuSignedPacking::packedFromIdx: warning value " << idx 
@@ -136,21 +136,21 @@ class L1MuSignedPackingGeneric : public L1MuPacking {
 class L1MuPseudoSignedPacking : public L1MuPacking {
  public:
       L1MuPseudoSignedPacking() {}
-  virtual ~L1MuPseudoSignedPacking() {};
+  ~L1MuPseudoSignedPacking() override {};
   L1MuPseudoSignedPacking(unsigned int nbits) : m_nbits(nbits) {};
 
   /// get the (pseudo-)sign from the packed notation (0=positive, 1=negative)
-  virtual int signFromPacked(unsigned packed) const { return ( packed & (1 << (m_nbits-1)) ) ? 1 : 0;};
+  int signFromPacked(unsigned packed) const override { return ( packed & (1 << (m_nbits-1)) ) ? 1 : 0;};
 
   /// get the value from the packed notation (+/-)
-  virtual int idxFromPacked(unsigned packed) const {
+  int idxFromPacked(unsigned packed) const override {
     unsigned mask = (1 << (m_nbits-1)) - 1; // for lower bits
     int absidx = (int) ( packed & mask );
     unsigned psmask = (1 << (m_nbits-1) );
     return absidx * ( ( (packed & psmask) == psmask ) ? -1 : 1 ); // pseudo sign==1 is negative
   };  
   /// get the packed notation of a value, check range
-  virtual unsigned packedFromIdx(int idx) const {
+  unsigned packedFromIdx(int idx) const override {
     unsigned packed = std::abs(idx);
     unsigned maxabs = (1 << (m_nbits-1)) -1;
     if (packed > maxabs) edm::LogWarning("ScaleRangeViolation") 

--- a/CondFormats/L1TObjects/interface/L1MuScale.h
+++ b/CondFormats/L1TObjects/interface/L1MuScale.h
@@ -25,7 +25,7 @@
 #include <sstream>
 #include <iomanip>
 #include <vector>
-#include <math.h>
+#include <cmath>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CondFormats/L1TObjects/interface/L1MuPacking.h"
 
@@ -149,30 +149,30 @@ class L1MuBinnedScale : public L1MuScale {
   };
 
   /// destructor
-  virtual ~L1MuBinnedScale() {
+  ~L1MuBinnedScale() override {
 //    delete m_packing;
   };
 
  
   /// get the center of bin represented by packed
-  virtual float getCenter(unsigned packed) const {
+  float getCenter(unsigned packed) const override {
     int idx = get_idx(packed);
     return (m_Scale[idx] + m_Scale[idx+1] )/ 2.;    
   };
 
   /// get the low edge of bin represented by packed
-  virtual float getLowEdge(unsigned packed) const{
+  float getLowEdge(unsigned packed) const override{
     return m_Scale[get_idx(packed)];
   };
 
   /// get the upper edge of bin represented by packed
-  virtual float getHighEdge(unsigned packed) const{
+  float getHighEdge(unsigned packed) const override{
     return m_Scale[get_idx(packed)+1];
   };
   
   /// pack a value
 
-  virtual unsigned getPacked(float value) const {
+  unsigned getPacked(float value) const override {
     if (value < m_Scale[0] || value > m_Scale[m_NBins]) 
       edm::LogWarning("ScaleRangeViolation") << "L1MuBinnedScale::getPacked: value out of scale range: " << value << std::endl;
     int idx = 0;
@@ -189,18 +189,18 @@ class L1MuBinnedScale : public L1MuScale {
   };
 
   /// get the upper edge of the last bin
-  virtual float getScaleMax() const { return m_Scale[m_NBins]; }
+  float getScaleMax() const override { return m_Scale[m_NBins]; }
 
   /// get the lower edge of the first bin
-  virtual float getScaleMin() const { return m_Scale[0]; }
+  float getScaleMin() const override { return m_Scale[0]; }
 
   /// get number of bins
-  virtual unsigned getNBins() const { return m_NBins; }
+  unsigned getNBins() const override { return m_NBins; }
 
   /// get value of the underlying vector for bin i
-  virtual float getValue(unsigned i) const { return m_Scale[i]; }
+  float getValue(unsigned i) const override { return m_Scale[i]; }
 
-  virtual std::string print() const {
+  std::string print() const override {
     std::ostringstream str;
 
     str << " ind |   low edge |     center |  high edge" << std::endl;
@@ -295,12 +295,12 @@ class L1MuSymmetricBinnedScale : public L1MuScale {
   };
 
   /// destructor
-  virtual ~L1MuSymmetricBinnedScale() {
+  ~L1MuSymmetricBinnedScale() override {
 //    delete m_packing;
   };
 
   /// get the center of bin represented by packed
-  virtual float getCenter(unsigned packed) const {
+  float getCenter(unsigned packed) const override {
     int absidx = abs ( m_packing.idxFromPacked( packed ) );
     if (absidx>=m_NBins) absidx=m_NBins-1;
     float center = (m_Scale[absidx] + m_Scale[absidx+1] )/ 2.;    
@@ -309,7 +309,7 @@ class L1MuSymmetricBinnedScale : public L1MuScale {
   };
 
   /// get the low edge of bin represented by packed
-  virtual float getLowEdge(unsigned packed) const{ // === edge towards 0 
+  float getLowEdge(unsigned packed) const override{ // === edge towards 0 
     int absidx = abs ( m_packing.idxFromPacked( packed ) );
     if (absidx>=m_NBins) absidx=m_NBins-1;
     float low = m_Scale[absidx];    
@@ -318,13 +318,13 @@ class L1MuSymmetricBinnedScale : public L1MuScale {
   };
 
   /// get the upper edge of bin represented by packed
-  virtual float getHighEdge(unsigned packed) const{
+  float getHighEdge(unsigned packed) const override{
     edm::LogWarning("NotImplemented") << "L1MuSymmetricBinnedScale::getHighEdge not implemented" << std::endl;
     return 0;
   };
 
   /// pack a value
-  virtual unsigned getPacked(float value) const {
+  unsigned getPacked(float value) const override {
     float absval = fabs ( value );
     if (absval < m_Scale[0] || absval > m_Scale[m_NBins]) edm::LogWarning("ScaleRangeViolation") 
                  << "L1MuSymmetricBinnedScale::getPacked: value out of scale range!!! abs(val) = " 
@@ -336,18 +336,18 @@ class L1MuSymmetricBinnedScale : public L1MuScale {
     return m_packing.packedFromIdx(idx, (value>=0) ? 0 : 1);
   };
   /// get the upper edge of the last bin (posivie half)
-  virtual float getScaleMax() const { return m_Scale[m_NBins]; }
+  float getScaleMax() const override { return m_Scale[m_NBins]; }
 
   /// get the lower edge of the first bin (positive half)
-  virtual float getScaleMin() const { return m_Scale[0]; }
+  float getScaleMin() const override { return m_Scale[0]; }
 
   /// get number of bins
-  virtual unsigned getNBins() const { return m_NBins; }
+  unsigned getNBins() const override { return m_NBins; }
 
   /// get value of the underlying vector for bin i
-  virtual float getValue(unsigned i) const { return m_Scale[i]; }
+  float getValue(unsigned i) const override { return m_Scale[i]; }
 
-  virtual std::string print() const {
+  std::string print() const override {
     std::ostringstream str;
     
     str << " ind |   low edge |     center" << std::endl;

--- a/CondFormats/L1TObjects/interface/L1TMuonOverlapParams.h
+++ b/CondFormats/L1TObjects/interface/L1TMuonOverlapParams.h
@@ -43,7 +43,7 @@ class L1TMuonOverlapParams {
     ///I.e both layers have to fire to account a hit
     unsigned int connectedToLayer;
 
-    LayerMapNode(void):hwNumber(0),logicNumber(0),bendingLayer(0),connectedToLayer(0){}
+    LayerMapNode(void):hwNumber(0),logicNumber(0),bendingLayer(false),connectedToLayer(0){}
 
     COND_SERIALIZABLE;
   };

--- a/CondFormats/L1TObjects/src/L1GctJetFinderParams.cc
+++ b/CondFormats/L1TObjects/src/L1GctJetFinderParams.cc
@@ -2,7 +2,7 @@
 
 #include <iostream>
 #include <iomanip>
-#include <math.h>
+#include <cmath>
 
 #include "FWCore/Utilities/interface/Exception.h"
 

--- a/CondFormats/L1TObjects/src/L1GtDefinitions.cc
+++ b/CondFormats/L1TObjects/src/L1GtDefinitions.cc
@@ -52,7 +52,7 @@ constexpr entry<L1GtBoardType> l1GtBoardTypeStringToEnumMap[] = {
             {"TCS", TCS},
             {"TIM", TIM},
             {"BoardNull", BoardNull},
-            {0, (L1GtBoardType)-1}
+            {nullptr, (L1GtBoardType)-1}
 };
 
 constexpr entry<L1GtPsbQuad> l1GtPsbQuadStringToEnumMap[] = {
@@ -82,7 +82,7 @@ constexpr entry<L1GtPsbQuad> l1GtPsbQuadStringToEnumMap[] = {
         {"BptxQ", BptxQ},
         {"GtExternalQ", GtExternalQ},
         {"PsbQuadNull", PsbQuadNull},
-        {0, (L1GtPsbQuad) - 1}
+        {nullptr, (L1GtPsbQuad) - 1}
 };
 
 // L1GtConditionType
@@ -104,7 +104,7 @@ constexpr entry<L1GtConditionType> l1GtConditionTypeStringToEnumMap[] = {
         {"TypeHfRingEtSums", TypeHfRingEtSums},
         {"TypeBptx", TypeBptx},
         {"TypeExternal", TypeExternal},
-        {0, (L1GtConditionType) - 1}
+        {nullptr, (L1GtConditionType) - 1}
 };
 
 // L1GtConditionCategory
@@ -120,7 +120,7 @@ constexpr entry<L1GtConditionCategory> l1GtConditionCategoryStringToEnumMap[] = 
   {"CondHfRingEtSums", CondHfRingEtSums},
   {"CondBptx", CondBptx},
   {"CondExternal", CondExternal},
-  {0, (L1GtConditionCategory) - 1}
+  {nullptr, (L1GtConditionCategory) - 1}
 };
 
 }

--- a/CondFormats/L1TObjects/src/L1MuCSCPtLut.cc
+++ b/CondFormats/L1TObjects/src/L1MuCSCPtLut.cc
@@ -2,7 +2,7 @@
 #include <FWCore/MessageLogger/interface/MessageLogger.h>
 #include <sstream>
 #include <iostream>
-#include <errno.h>
+#include <cerrno>
 
 void L1MuCSCPtLut::readFromDBS( std::string& ptLUT )
 {

--- a/CondFormats/L1TObjects/src/L1MuCSCTFConfiguration.cc
+++ b/CondFormats/L1TObjects/src/L1MuCSCTFConfiguration.cc
@@ -1,7 +1,7 @@
 #include "CondFormats/L1TObjects/interface/L1MuCSCTFConfiguration.h"
 #include <sstream>
 #include <iostream>
-#include <stdlib.h>
+#include <cstdlib>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 edm::ParameterSet L1MuCSCTFConfiguration::parameters(int sp) const {
@@ -15,14 +15,14 @@ edm::ParameterSet L1MuCSCTFConfiguration::parameters(int sp) const {
   // core configuration
   // by default everything is disabled: we need to set them
   // coincidence and singles
-  bool run_core        = 0;
-  bool trigger_on_ME1a = 0;
-  bool trigger_on_ME1b = 0;
-  bool trigger_on_ME2  = 0;
-  bool trigger_on_ME3  = 0;
-  bool trigger_on_ME4  = 0;
-  bool trigger_on_MB1a = 0;
-  bool trigger_on_MB1d = 0;
+  bool run_core        = false;
+  bool trigger_on_ME1a = false;
+  bool trigger_on_ME1b = false;
+  bool trigger_on_ME2  = false;
+  bool trigger_on_ME3  = false;
+  bool trigger_on_ME4  = false;
+  bool trigger_on_MB1a = false;
+  bool trigger_on_MB1d = false;
 
   unsigned int BXAdepth   = 0;
   unsigned int useDT      = 0;
@@ -34,11 +34,11 @@ edm::ParameterSet L1MuCSCTFConfiguration::parameters(int sp) const {
   // these are very important parameters.
   // Double check with Alex
   unsigned int CoreLatency = 7;
-  bool rescaleSinglesPhi = 1;
+  bool rescaleSinglesPhi = true;
 
   // ask Alex if use or remove them or what
-  bool AllowALCTonly = 0;
-  bool AllowCLCTonly = 0;
+  bool AllowALCTonly = false;
+  bool AllowCLCTonly = false;
 
   // other useful parameters in general not set in the OMDS  
   unsigned int QualityEnableME1a = 0xFFFF;
@@ -248,7 +248,7 @@ edm::ParameterSet L1MuCSCTFConfiguration::parameters(int sp) const {
     std::string comments_;     std::getline(line,comments_);
 
     if( register_=="CSR_REQ" && chip_=="SP" ){
-      unsigned int value = ::strtol(writeValue_.c_str(),NULL,16);
+      unsigned int value = ::strtol(writeValue_.c_str(),nullptr,16);
       run_core        = (value&0x8000);
       trigger_on_ME1a = (value&0x0001);
       trigger_on_ME1b = (value&0x0002);
@@ -261,7 +261,7 @@ edm::ParameterSet L1MuCSCTFConfiguration::parameters(int sp) const {
 
 
     if( register_=="CSR_SCC" && chip_=="SP" ){
-      unsigned int value = ::strtol(writeValue_.c_str(),NULL,16);
+      unsigned int value = ::strtol(writeValue_.c_str(),nullptr,16);
       
       BXAdepth   = (value&0x3);
       useDT      = ( (value&0x80)>>7 );
@@ -271,46 +271,46 @@ edm::ParameterSet L1MuCSCTFConfiguration::parameters(int sp) const {
 
 
     if( register_=="CSR_LQE" && chip_=="F1" && muon_=="M1" )
-      QualityEnableME1a = ::strtol(writeValue_.c_str(),NULL,16);
+      QualityEnableME1a = ::strtol(writeValue_.c_str(),nullptr,16);
     if( register_=="CSR_LQE" && chip_=="F1" && muon_=="M2" )
-      QualityEnableME1b = ::strtol(writeValue_.c_str(),NULL,16);
+      QualityEnableME1b = ::strtol(writeValue_.c_str(),nullptr,16);
     if( register_=="CSR_LQE" && chip_=="F1" && muon_=="M3" )
-      QualityEnableME1c = ::strtol(writeValue_.c_str(),NULL,16);
+      QualityEnableME1c = ::strtol(writeValue_.c_str(),nullptr,16);
     if( register_=="CSR_LQE" && chip_=="F2" && muon_=="M1" )
-      QualityEnableME1d = ::strtol(writeValue_.c_str(),NULL,16);
+      QualityEnableME1d = ::strtol(writeValue_.c_str(),nullptr,16);
     if( register_=="CSR_LQE" && chip_=="F2" && muon_=="M2" )
-      QualityEnableME1e = ::strtol(writeValue_.c_str(),NULL,16);
+      QualityEnableME1e = ::strtol(writeValue_.c_str(),nullptr,16);
     if( register_=="CSR_LQE" && chip_=="F2" && muon_=="M3" )
-      QualityEnableME1f = ::strtol(writeValue_.c_str(),NULL,16);
+      QualityEnableME1f = ::strtol(writeValue_.c_str(),nullptr,16);
     if( register_=="CSR_LQE" && chip_=="F3" && muon_=="M1" )
-      QualityEnableME2a = ::strtol(writeValue_.c_str(),NULL,16);
+      QualityEnableME2a = ::strtol(writeValue_.c_str(),nullptr,16);
     if( register_=="CSR_LQE" && chip_=="F3" && muon_=="M2" )
-      QualityEnableME2b = ::strtol(writeValue_.c_str(),NULL,16);
+      QualityEnableME2b = ::strtol(writeValue_.c_str(),nullptr,16);
     if( register_=="CSR_LQE" && chip_=="F3" && muon_=="M3" )
-      QualityEnableME2c = ::strtol(writeValue_.c_str(),NULL,16);
+      QualityEnableME2c = ::strtol(writeValue_.c_str(),nullptr,16);
     if( register_=="CSR_LQE" && chip_=="F4" && muon_=="M1" )
-      QualityEnableME3a = ::strtol(writeValue_.c_str(),NULL,16);
+      QualityEnableME3a = ::strtol(writeValue_.c_str(),nullptr,16);
     if( register_=="CSR_LQE" && chip_=="F4" && muon_=="M2" )
-      QualityEnableME3b = ::strtol(writeValue_.c_str(),NULL,16);
+      QualityEnableME3b = ::strtol(writeValue_.c_str(),nullptr,16);
     if( register_=="CSR_LQE" && chip_=="F4" && muon_=="M3" )
-      QualityEnableME3c = ::strtol(writeValue_.c_str(),NULL,16);
+      QualityEnableME3c = ::strtol(writeValue_.c_str(),nullptr,16);
     if( register_=="CSR_LQE" && chip_=="F5" && muon_=="M1" )
-      QualityEnableME4a = ::strtol(writeValue_.c_str(),NULL,16);
+      QualityEnableME4a = ::strtol(writeValue_.c_str(),nullptr,16);
     if( register_=="CSR_LQE" && chip_=="F5" && muon_=="M2" )
-      QualityEnableME4b = ::strtol(writeValue_.c_str(),NULL,16);
+      QualityEnableME4b = ::strtol(writeValue_.c_str(),nullptr,16);
     if( register_=="CSR_LQE" && chip_=="F5" && muon_=="M3" )
-      QualityEnableME4c = ::strtol(writeValue_.c_str(),NULL,16);
+      QualityEnableME4c = ::strtol(writeValue_.c_str(),nullptr,16);
 
     if( register_=="CSR_KFL" )
-      kill_fiber = ::strtol(writeValue_.c_str(),NULL,16);
+      kill_fiber = ::strtol(writeValue_.c_str(),nullptr,16);
 
     if( register_=="CSR_SFC" && chip_=="SP" ){
-      unsigned int value = ::strtol(writeValue_.c_str(),NULL,16);
+      unsigned int value = ::strtol(writeValue_.c_str(),nullptr,16);
       singlesTrackOutput = ((value&0x3000)>>12);
     }
 
     if( register_=="CNT_ETA" && chip_=="SP" ){
-      unsigned int value = ::strtol(writeValue_.c_str(),NULL,16);
+      unsigned int value = ::strtol(writeValue_.c_str(),nullptr,16);
       eta_cnt = value;
     }
     
@@ -318,7 +318,7 @@ edm::ParameterSet L1MuCSCTFConfiguration::parameters(int sp) const {
     // LATEST VERSION FROM CORE 2010-01-22 at http://www.phys.ufl.edu/~madorsky/sp/2010-01-22
     if( register_=="DAT_ETA" && chip_=="SP" ){
       
-      unsigned int value = ::strtol(writeValue_.c_str(),NULL,16);
+      unsigned int value = ::strtol(writeValue_.c_str(),nullptr,16);
 
       //std::cout<<"DAT_ETA SP value:"<<value<<std::endl;
 

--- a/CondFormats/Luminosity/src/LumiSectionData.cc
+++ b/CondFormats/Luminosity/src/LumiSectionData.cc
@@ -62,7 +62,7 @@ lumi::LumiSectionData::nHLTPath()const{
 }
 bool 
 lumi::LumiSectionData::HLThasData()const{
-  return m_hlt.size()>0;
+  return !m_hlt.empty();
 }
 lumi::HLTIterator
 lumi::LumiSectionData::hltBegin()const{
@@ -74,7 +74,7 @@ lumi::LumiSectionData::hltEnd()const{
 }
 bool
 lumi::LumiSectionData::TriggerhasData()const{
-  return m_trigger.size()>0;
+  return !m_trigger.empty();
 }
 lumi::TriggerIterator
 lumi::LumiSectionData::trgBegin()const{

--- a/CondFormats/MFObjects/src/MagFieldConfig.cc
+++ b/CondFormats/MFObjects/src/MagFieldConfig.cc
@@ -28,7 +28,7 @@ MagFieldConfig::MagFieldConfig(const edm::ParameterSet& pset, bool debug) {
   typedef vector<edm::ParameterSet> VPSet;
   
   VPSet fileSpec = pset.getParameter<VPSet>("gridFiles");
-  if (fileSpec.size()!=0) {
+  if (!fileSpec.empty()) {
     for(VPSet::const_iterator rule = fileSpec.begin(); rule != fileSpec.end(); ++rule){
       string s_volumes = rule->getParameter<string>("volumes");
       string s_sectors = rule->getParameter<string>("sectors"); // 0 means all volumes

--- a/CondFormats/OptAlignObjects/src/OpticalAlignInfo.cc
+++ b/CondFormats/OptAlignObjects/src/OpticalAlignInfo.cc
@@ -69,7 +69,7 @@ OpticalAlignParam::OpticalAlignParam( const OpticalAlignParam &rhs )
 
 OpticalAlignParam* OpticalAlignInfo::findExtraEntry( std::string& name )
 {
-  OpticalAlignParam* param = 0;
+  OpticalAlignParam* param = nullptr;
   std::vector<OpticalAlignParam>::iterator ite;
   for( ite = extraEntries_.begin(); ite != extraEntries_.end(); ite++ ){
     if( (*ite).name_ == name ){

--- a/CondFormats/PCLConfig/interface/AlignPCLThreshold.h
+++ b/CondFormats/PCLConfig/interface/AlignPCLThreshold.h
@@ -70,7 +70,7 @@ public:
   float getMaxMoveThetaYcut()  const {return m_thetaYCoord.m_maxMoveCut;}
   float getMaxMoveThetaZcut()  const {return m_thetaZCoord.m_maxMoveCut;}
 
-  bool hasExtraDOF()           const {return (m_extraDOF.size()>0);}
+  bool hasExtraDOF()           const {return (!m_extraDOF.empty());}
   unsigned int extraDOFSize()  const {return m_extraDOF.size();}
   std::array<float,4> getExtraDOFCuts(const unsigned int i) const;
   std::string getExtraDOFLabel(const unsigned int i) const;

--- a/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
+++ b/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
@@ -14,13 +14,13 @@ namespace edmtest
   class AlignPCLThresholdsReader : public edm::one::EDAnalyzer<> {
   public:
     explicit AlignPCLThresholdsReader(edm::ParameterSet const& p); 
-    ~AlignPCLThresholdsReader(); 
+    ~AlignPCLThresholdsReader() override; 
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
   private:
     
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
     // ----------member data ---------------------------
     const bool printdebug_;
@@ -72,7 +72,7 @@ namespace edmtest
       thresholds->printAll();
     }
  
-    FILE* pFile=NULL;
+    FILE* pFile=nullptr;
     if(formatedOutput_!="")pFile=fopen(formatedOutput_.c_str(), "w");
     if(pFile){
 

--- a/CondFormats/PCLConfig/plugins/AlignPCLThresholdsWriter.cc
+++ b/CondFormats/PCLConfig/plugins/AlignPCLThresholdsWriter.cc
@@ -48,15 +48,15 @@ namespace DOFs {
 class AlignPCLThresholdsWriter : public edm::one::EDAnalyzer<>  {
    public:
       explicit AlignPCLThresholdsWriter(const edm::ParameterSet&);
-      ~AlignPCLThresholdsWriter();
+      ~AlignPCLThresholdsWriter() override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 
    private:
-      virtual void beginJob() override;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
+      void beginJob() override;
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
+      void endJob() override;
       DOFs::dof mapOntoEnum(std::string coord);
 
       // ----------member data ---------------------------

--- a/CondFormats/PhysicsToolsObjects/interface/MVAComputer.h
+++ b/CondFormats/PhysicsToolsObjects/interface/MVAComputer.h
@@ -75,7 +75,7 @@ class Variable {
 
 class ProcOptional : public VarProcessor {
     public:
-        virtual std::unique_ptr<VarProcessor> clone() const;
+        std::unique_ptr<VarProcessor> clone() const override;
 	std::vector<double>		neutralPos;
 
   COND_SERIALIZABLE;
@@ -83,13 +83,13 @@ class ProcOptional : public VarProcessor {
 
 class ProcCount : public VarProcessor {
     public:
-        virtual std::unique_ptr<VarProcessor> clone() const;
+        std::unique_ptr<VarProcessor> clone() const override;
   COND_SERIALIZABLE;
 };
 
 class ProcClassed : public VarProcessor {
     public:
-        virtual std::unique_ptr<VarProcessor> clone() const;
+        std::unique_ptr<VarProcessor> clone() const override;
 	unsigned int			nClasses;
 
   COND_SERIALIZABLE;
@@ -97,7 +97,7 @@ class ProcClassed : public VarProcessor {
 
 class ProcSplitter : public VarProcessor {
     public:
-        virtual std::unique_ptr<VarProcessor> clone() const;
+        std::unique_ptr<VarProcessor> clone() const override;
 	unsigned int			nFirst;
 
   COND_SERIALIZABLE;
@@ -105,7 +105,7 @@ class ProcSplitter : public VarProcessor {
 
 class ProcForeach : public VarProcessor {
     public:
-        virtual std::unique_ptr<VarProcessor> clone() const;
+        std::unique_ptr<VarProcessor> clone() const override;
 	unsigned int			nProcs;
 
   COND_SERIALIZABLE;
@@ -113,7 +113,7 @@ class ProcForeach : public VarProcessor {
 
 class ProcSort : public VarProcessor {
     public:
-        virtual std::unique_ptr<VarProcessor> clone() const;
+        std::unique_ptr<VarProcessor> clone() const override;
 	unsigned int			sortByIndex;
 	bool				descending;
 
@@ -122,7 +122,7 @@ class ProcSort : public VarProcessor {
 
 class ProcCategory : public VarProcessor {
     public:
-        virtual std::unique_ptr<VarProcessor> clone() const;
+        std::unique_ptr<VarProcessor> clone() const override;
 	typedef std::vector<double> BinLimits;
 
 	std::vector<BinLimits>		variableBinLimits;
@@ -133,7 +133,7 @@ class ProcCategory : public VarProcessor {
 
 class ProcNormalize : public VarProcessor {
     public:
-        virtual std::unique_ptr<VarProcessor> clone() const;
+        std::unique_ptr<VarProcessor> clone() const override;
 	std::vector<HistogramF>		distr;
 	int				categoryIdx;
 
@@ -142,7 +142,7 @@ class ProcNormalize : public VarProcessor {
 
 class ProcLikelihood : public VarProcessor {
     public:
-        virtual std::unique_ptr<VarProcessor> clone() const;
+        std::unique_ptr<VarProcessor> clone() const override;
 	class SigBkg {
 	    public:
 		HistogramF		background;
@@ -165,7 +165,7 @@ class ProcLikelihood : public VarProcessor {
 
 class ProcLinear : public VarProcessor {
     public:
-        virtual std::unique_ptr<VarProcessor> clone() const;
+        std::unique_ptr<VarProcessor> clone() const override;
 	std::vector<double>		coeffs;
 	double				offset;
 
@@ -174,7 +174,7 @@ class ProcLinear : public VarProcessor {
 
 class ProcMultiply : public VarProcessor {
     public:
-        virtual std::unique_ptr<VarProcessor> clone() const;
+        std::unique_ptr<VarProcessor> clone() const override;
 	typedef std::vector<unsigned int>	Config;
 
 	unsigned int			in;
@@ -185,7 +185,7 @@ class ProcMultiply : public VarProcessor {
 
 class ProcMatrix : public VarProcessor {
     public:
-        virtual std::unique_ptr<VarProcessor> clone() const;
+        std::unique_ptr<VarProcessor> clone() const override;
 	Matrix				matrix;
 
   COND_SERIALIZABLE;
@@ -193,8 +193,8 @@ class ProcMatrix : public VarProcessor {
 
 class ProcExternal : public VarProcessor {
     public:
-        virtual std::unique_ptr<VarProcessor> clone() const;
-	virtual std::string getInstanceName() const;
+        std::unique_ptr<VarProcessor> clone() const override;
+	std::string getInstanceName() const override;
 
 	std::string			method;
 	std::vector<unsigned char>	store;
@@ -204,7 +204,7 @@ class ProcExternal : public VarProcessor {
 
 class ProcMLP : public VarProcessor {
     public:
-        virtual std::unique_ptr<VarProcessor> clone() const;
+        std::unique_ptr<VarProcessor> clone() const override;
 	typedef std::pair<double, std::vector<double> >	Neuron;
 	typedef std::pair<std::vector<Neuron>, bool>	Layer;
 

--- a/CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromBinnedTFormula.h
+++ b/CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromBinnedTFormula.h
@@ -26,20 +26,20 @@ class PerformancePayloadFromBinnedTFormula : public PerformancePayload {
     initialize();    
   }
 
-  void initialize();
+  void initialize() override;
 
   PerformancePayloadFromBinnedTFormula(){}
-  virtual ~PerformancePayloadFromBinnedTFormula(){
+  ~PerformancePayloadFromBinnedTFormula() override{
     compiledFormulas_.clear();
   }
 
-  float getResult(PerformanceResult::ResultType,const BinningPointByMap&) const ; // gets from the full payload
+  float getResult(PerformanceResult::ResultType,const BinningPointByMap&) const override ; // gets from the full payload
   
   virtual bool isParametrizedInVariable(const BinningVariables::BinningVariablesType p)  const {
     return (limitPos(p) != PerformancePayloadFromBinnedTFormula::InvalidPos);
   }
   
-  virtual bool isInPayload(PerformanceResult::ResultType,const BinningPointByMap&) const ;
+  bool isInPayload(PerformanceResult::ResultType,const BinningPointByMap&) const override ;
   
   const std::vector<PhysicsTFormulaPayload> & formulaPayloads() const {return pls;}
   

--- a/CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h
+++ b/CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h
@@ -28,7 +28,7 @@ class PerformancePayloadFromTFormula : public PerformancePayload {
 
   PerformancePayloadFromTFormula(){}
 
-  void initialize(); 
+  void initialize() override; 
 
  PerformancePayloadFromTFormula(const PerformancePayloadFromTFormula& b) :
     pl(b.pl), 
@@ -36,19 +36,19 @@ class PerformancePayloadFromTFormula : public PerformancePayload {
     variables_(b.variables_), 
     compiledFormulas_(b.compiledFormulas_) {}
 
-  virtual ~PerformancePayloadFromTFormula(){    
+  ~PerformancePayloadFromTFormula() override{    
     compiledFormulas_.clear();
   }
 
 
 
-  float getResult(PerformanceResult::ResultType,const BinningPointByMap&) const ; // gets from the full payload
+  float getResult(PerformanceResult::ResultType,const BinningPointByMap&) const override ; // gets from the full payload
   
   virtual bool isParametrizedInVariable(const BinningVariables::BinningVariablesType p)  const {
     return (limitPos(p) != PerformancePayloadFromTFormula::InvalidPos);
   }
   
-  virtual bool isInPayload(PerformanceResult::ResultType,const BinningPointByMap&) const ;
+  bool isInPayload(PerformanceResult::ResultType,const BinningPointByMap&) const override ;
   
   const PhysicsTFormulaPayload & formulaPayload() const {return pl;}
   

--- a/CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTable.h
+++ b/CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTable.h
@@ -25,15 +25,15 @@ class PerformancePayloadFromTable : public PerformancePayload {
       results_(r), binning_(b) {}
 
   PerformancePayloadFromTable(){}
-virtual ~PerformancePayloadFromTable(){}
+~PerformancePayloadFromTable() override{}
 
-  float getResult(PerformanceResult::ResultType,const BinningPointByMap&) const ; // gets from the full payload
+  float getResult(PerformanceResult::ResultType,const BinningPointByMap&) const override ; // gets from the full payload
 
   virtual bool isParametrizedInVariable(const BinningVariables::BinningVariablesType p)  const {
     return (minPos(p) != PerformancePayloadFromTable::InvalidPos);
   }
   
-  virtual bool isInPayload(PerformanceResult::ResultType,const BinningPointByMap&) const ;
+  bool isInPayload(PerformanceResult::ResultType,const BinningPointByMap&) const override ;
 
 const PhysicsPerformancePayload & payLoad() const {return pl;}
 

--- a/CondFormats/PhysicsToolsObjects/src/MVAComputer.cc
+++ b/CondFormats/PhysicsToolsObjects/src/MVAComputer.cc
@@ -35,7 +35,7 @@ std::string VarProcessor::getInstanceName() const
 {
 	static const char prefix[] = "PhysicsTools::Calibration::";
         edm::TypeID typeID(typeid(*this));
-	std::string type(typeID.className());
+	const std::string& type(typeID.className());
 	if (type.size() <= sizeof prefix - 1 ||
 	    type.substr(0, sizeof prefix - 1) != prefix)
 		throw cms::Exception("MVAComputerCalibration")

--- a/CondFormats/RPCObjects/interface/L1RPCConeBuilder.h
+++ b/CondFormats/RPCObjects/interface/L1RPCConeBuilder.h
@@ -23,7 +23,7 @@
 
 #include <vector>
 #include <map>
-#include <stdint.h>
+#include <cstdint>
 #include <cstdlib>
 #include "CondFormats/L1TObjects/interface/L1RPCConeDefinition.h"
 #include <memory>

--- a/CondFormats/RPCObjects/interface/RPCEMap.h
+++ b/CondFormats/RPCObjects/interface/RPCEMap.h
@@ -45,7 +45,7 @@ public:
     int theCode;
     int nFebs;
   
-    lbItem() : theMaster(0), theLinkBoardNumInLink(0), theCode(0), nFebs(0) { /* nop */ };
+    lbItem() : theMaster(false), theLinkBoardNumInLink(0), theCode(0), nFebs(0) { /* nop */ };
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/RPCObjects/src/DccSpec.cc
+++ b/CondFormats/RPCObjects/src/DccSpec.cc
@@ -27,7 +27,7 @@ const TriggerBoardSpec * DccSpec::triggerBoard(int channelNumber) const
   for (IT it=theTBs.begin(); it != theTBs.end(); it++) {
     if(channelNumber ==it->dccInputChannelNum()) return &(*it);
   }
-  return 0;
+  return nullptr;
 
 }
 

--- a/CondFormats/RPCObjects/src/LinkBoardSpec.cc
+++ b/CondFormats/RPCObjects/src/LinkBoardSpec.cc
@@ -17,7 +17,7 @@ const FebConnectorSpec * LinkBoardSpec::feb(int febInputNum) const
   for (IT it=theFebs.begin(); it != theFebs.end(); it++) {
     if(febInputNum==it->linkBoardInputNum()) return &(*it);
   }
-  return 0;
+  return nullptr;
 }
 
 std::string LinkBoardSpec::linkBoardName() const

--- a/CondFormats/RPCObjects/src/LinkConnSpec.cc
+++ b/CondFormats/RPCObjects/src/LinkConnSpec.cc
@@ -25,6 +25,6 @@ const LinkBoardSpec * LinkConnSpec::linkBoard( int linkBoardNumInLink) const
   for (IT it=theLBs.begin(); it != theLBs.end(); it++) {
     if(linkBoardNumInLink==it->linkBoardNumInLink()) return &(*it);
   }
-  return 0;
+  return nullptr;
 }
 

--- a/CondFormats/RPCObjects/src/RPCReadOutMapping.cc
+++ b/CondFormats/RPCObjects/src/RPCReadOutMapping.cc
@@ -22,7 +22,7 @@ const DccSpec * RPCReadOutMapping::dcc( int dccId) const
 {
   IMAP im = theFeds.find(dccId);
   const DccSpec & ddc = (*im).second;
-  return (im != theFeds.end()) ?  &ddc : 0;
+  return (im != theFeds.end()) ?  &ddc : nullptr;
 }
 
 void RPCReadOutMapping::add(const DccSpec & dcc)
@@ -125,7 +125,7 @@ const LinkBoardSpec*
       }
     }
   }
-  return 0;
+  return nullptr;
 }
 
 RPCReadOutMapping::StripInDetUnit 

--- a/CondFormats/RPCObjects/src/TriggerBoardSpec.cc
+++ b/CondFormats/RPCObjects/src/TriggerBoardSpec.cc
@@ -13,7 +13,7 @@ const LinkConnSpec * TriggerBoardSpec::linkConn(int tbInputNumber) const
   for (IT it=theLinks.begin(); it != theLinks.end(); it++) {
     if(tbInputNumber==it->triggerBoardInputNumber()) return &(*it);
   }
-  return 0;
+  return nullptr;
 }
 
 std::vector<const LinkConnSpec* > TriggerBoardSpec::enabledLinkConns() const

--- a/CondFormats/SiPixelObjects/interface/PixelFEDCabling.h
+++ b/CondFormats/SiPixelObjects/interface/PixelFEDCabling.h
@@ -26,7 +26,7 @@ public:
 
   /// return link identified by id. Link id's are ranged [1, numberOfLinks]
   const PixelFEDLink * link(unsigned int id) const 
-    { return (id > 0 && id <= theLinks.size()) ? &theLinks[id-1] : 0; }
+    { return (id > 0 && id <= theLinks.size()) ? &theLinks[id-1] : nullptr; }
 
   /// number of links in FED
   unsigned int numberOfLinks() const { return theLinks.size(); }

--- a/CondFormats/SiPixelObjects/interface/PixelFEDLink.h
+++ b/CondFormats/SiPixelObjects/interface/PixelFEDLink.h
@@ -35,7 +35,7 @@ public:
 
   /// return ROC identified by id. ROC ids are ranged [1,numberOfROCs]
   const PixelROC * roc(unsigned int id) const
-    { return (id > 0 && id <= theROCs.size() ) ?  &theROCs[id-1] : 0; }
+    { return (id > 0 && id <= theROCs.size() ) ?  &theROCs[id-1] : nullptr; }
 
   /// check ROC in link numbering consistency, ie. that ROC position in
   /// vector is the same as its id. To be called by owner

--- a/CondFormats/SiPixelObjects/interface/SiPixel2DTemplateDBObject.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixel2DTemplateDBObject.h
@@ -5,7 +5,7 @@
 
 #include <vector>
 #include <map>
-#include <stdint.h>
+#include <cstdint>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 // ******************************************************************************************

--- a/CondFormats/SiPixelObjects/interface/SiPixelCalibConfiguration.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelCalibConfiguration.h
@@ -13,7 +13,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
-#include <stdint.h>
+#include <cstdint>
 #include "CalibFormats/SiPixelObjects/interface/PixelCalibConfiguration.h"
 
 class SiPixelCalibConfiguration

--- a/CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h
@@ -29,18 +29,18 @@ public:
 
   void initializeRocs();
 
-  virtual ~SiPixelFedCablingMap() {}
+  ~SiPixelFedCablingMap() override {}
 
 #ifdef NO_DICT
   std::unique_ptr<SiPixelFedCablingTree> cablingTree() const; 
 #endif
 
-  virtual std::string version() const override { return theVersion; }
+  std::string version() const override { return theVersion; }
 
-  virtual const sipixelobjects::PixelROC* findItem(
+  const sipixelobjects::PixelROC* findItem(
       const sipixelobjects::CablingPathToDetUnit & path) const override;
 
-  virtual std::vector<sipixelobjects::CablingPathToDetUnit> pathToDetUnit(uint32_t rawDetId) const override;
+  std::vector<sipixelobjects::CablingPathToDetUnit> pathToDetUnit(uint32_t rawDetId) const override;
 
   std::unordered_map<uint32_t, unsigned int> det2fedMap() const override;
   std::map< uint32_t,std::vector<sipixelobjects::CablingPathToDetUnit> > det2PathMap() const override;

--- a/CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h
@@ -15,7 +15,7 @@ public:
 
   SiPixelFedCablingTree(const std::string & version="") : theVersion(version) {}
 
-  virtual ~SiPixelFedCablingTree() {}
+  ~SiPixelFedCablingTree() override {}
 
   /// add cabling for one fed
   void addFed(const PixelFEDCabling& f);
@@ -26,15 +26,15 @@ public:
   std::vector<const PixelFEDCabling *> fedList() const;
 
   ///map version
-  virtual std::string version() const { return theVersion; }
+  std::string version() const override { return theVersion; }
 
   std::string print(int depth = 0) const;
 
   void addItem(unsigned int fedId, unsigned int linkId, const sipixelobjects::PixelROC& roc);
 
-  virtual std::vector<sipixelobjects::CablingPathToDetUnit> pathToDetUnit(uint32_t rawDetId) const;
+  std::vector<sipixelobjects::CablingPathToDetUnit> pathToDetUnit(uint32_t rawDetId) const override;
 
-  virtual const sipixelobjects::PixelROC* findItem(const sipixelobjects::CablingPathToDetUnit & path) const;  
+  const sipixelobjects::PixelROC* findItem(const sipixelobjects::CablingPathToDetUnit & path) const override;  
 
   const sipixelobjects::PixelROC* findItemInFed(const sipixelobjects::CablingPathToDetUnit & path, 
 						const PixelFEDCabling * aFed) const;  

--- a/CondFormats/SiPixelObjects/interface/SiPixelGenErrorDBObject.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelGenErrorDBObject.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 #include <map>
-#include <stdint.h>
+#include <cstdint>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/Serialization/interface/Serializable.h"

--- a/CondFormats/SiPixelObjects/interface/SiPixelTemplateDBObject.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelTemplateDBObject.h
@@ -5,7 +5,7 @@
 
 #include <vector>
 #include <map>
-#include <stdint.h>
+#include <cstdint>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 // ******************************************************************************************

--- a/CondFormats/SiPixelObjects/src/SiPixelFedCablingMap.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFedCablingMap.cc
@@ -79,7 +79,7 @@ SiPixelFedCablingMap::SiPixelFedCablingMap(const SiPixelFedCablingTree *cab)
     unsigned int numLink = (**ifed).numberOfLinks();
     for (unsigned int link=1; link <= numLink; link++) {
       const PixelFEDLink * pLink = (**ifed).link(link); 
-      if (pLink==0) continue;
+      if (pLink==nullptr) continue;
       //unsigned int linkId = pLink->id();
       //if (linkId != 0 && linkId!= link) 
       //  std::cout << "PROBLEM WITH LINK NUMBER!!!!" << std::endl;
@@ -87,7 +87,7 @@ SiPixelFedCablingMap::SiPixelFedCablingMap(const SiPixelFedCablingTree *cab)
 
       for (unsigned int roc=1; roc <= numberROC; roc++) {
         const PixelROC * pROC = pLink->roc(roc);
-        if (pROC==0) continue;
+        if (pROC==nullptr) continue;
         //if (pROC->idInLink() != roc) 
 	//  std::cout << "PROBLEM WITH ROC NUMBER!!!!" << std::endl;
         Key key = {fed, link, roc}; 
@@ -121,7 +121,7 @@ std::vector<unsigned int> SiPixelFedCablingMap::fedIds() const {
 
 const sipixelobjects::PixelROC* SiPixelFedCablingMap::findItem(
     const sipixelobjects::CablingPathToDetUnit & path) const {
-  const PixelROC* roc = 0;
+  const PixelROC* roc = nullptr;
   Key key = {path.fed, path.link, path.roc};
   Map::const_iterator inMap = theMap.find(key);
   if (inMap!= theMap.end()) roc = &(inMap->second);

--- a/CondFormats/SiPixelObjects/src/SiPixelFedCablingTree.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFedCablingTree.cc
@@ -74,7 +74,7 @@ void SiPixelFedCablingTree::addFed(const PixelFEDCabling & f)
 const PixelFEDCabling * SiPixelFedCablingTree::fed(unsigned int id) const
 {
   auto  it = theFedCablings.find(id);
-  return ( it == theFedCablings.end() ) ? 0 : & (*it).second;
+  return ( it == theFedCablings.end() ) ? nullptr : & (*it).second;
 }
 
 string SiPixelFedCablingTree::print(int depth) const
@@ -111,7 +111,7 @@ void SiPixelFedCablingTree::addItem(unsigned int fedId, unsigned int linkId, con
 const sipixelobjects::PixelROC* SiPixelFedCablingTree::findItem(
 								const CablingPathToDetUnit & path) const
 {
-  const PixelROC* roc = 0;
+  const PixelROC* roc = nullptr;
   const PixelFEDCabling * aFed = fed(path.fed);
   if (aFed) {
     const  PixelFEDLink * aLink = aFed->link(path.link);
@@ -125,7 +125,7 @@ const sipixelobjects::PixelROC* SiPixelFedCablingTree::findItemInFed(
 								const CablingPathToDetUnit & path, 
 								const PixelFEDCabling * aFed) const
 {
-  const PixelROC* roc = 0;
+  const PixelROC* roc = nullptr;
   const  PixelFEDLink * aLink = aFed->link(path.link);
   if (aLink) roc = aLink->roc(path.roc);
   return roc;

--- a/CondFormats/SiPixelObjects/src/SiPixelFrameReverter.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFrameReverter.cc
@@ -41,7 +41,7 @@ void SiPixelFrameReverter::buildStructure(const edm::EventSetup& iSetup)
 
   for(auto it = pDD->dets().begin(); it != pDD->dets().end(); it++){
     
-    if(dynamic_cast<PixelGeomDetUnit const *>((*it))!=0){
+    if(dynamic_cast<PixelGeomDetUnit const *>((*it))!=nullptr){
 
       DetId detId = (*it)->geographicalId();
       uint32_t id = detId();

--- a/CondFormats/SiStripObjects/interface/ApvLatencyAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/ApvLatencyAnalysis.h
@@ -20,15 +20,15 @@ class ApvLatencyAnalysis : public CommissioningAnalysis {
 
   ApvLatencyAnalysis();
 
-  virtual ~ApvLatencyAnalysis() {;}
+  ~ApvLatencyAnalysis() override {;}
 
   friend class ApvLatencyAlgorithm;
 
   inline const uint16_t& latency() const;
 
-  void print( std::stringstream&, uint32_t not_used = 0 );
+  void print( std::stringstream&, uint32_t not_used = 0 ) override;
   
-  void reset();
+  void reset() override;
   
  private:
 

--- a/CondFormats/SiStripObjects/interface/ApvTimingAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/ApvTimingAnalysis.h
@@ -22,14 +22,14 @@ class ApvTimingAnalysis : public CommissioningAnalysis {
   
   ApvTimingAnalysis();
   
-  virtual ~ApvTimingAnalysis() {;}
+  ~ApvTimingAnalysis() override {;}
   
   friend class ApvTimingAlgorithm;
   
   // ---------- public interface ----------
   
   /** Identifies if analysis is valid or not. */
-  bool isValid() const;
+  bool isValid() const override;
   
   /** Identifies if tick mark is found or not. */
   bool foundTickMark() const;
@@ -67,13 +67,13 @@ class ApvTimingAnalysis : public CommissioningAnalysis {
   // ---------- misc ----------
 
   /** Prints analysis results. */
-  void print( std::stringstream&, uint32_t not_used = 0 );
+  void print( std::stringstream&, uint32_t not_used = 0 ) override;
   
   /** Adds error codes for analysis (overrides private base). */ 
-  inline void addErrorCode( const std::string& error );
+  inline void addErrorCode( const std::string& error ) override;
   
   /** Resets analysis member data. */
-  void reset();
+  void reset() override;
   
   // ---------- public static data ----------
   

--- a/CondFormats/SiStripObjects/interface/CalibrationAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/CalibrationAnalysis.h
@@ -24,7 +24,7 @@ class CalibrationAnalysis : public CommissioningAnalysis {
   CalibrationAnalysis( const bool& deconv, 
 		       int calchan );
   
-  virtual ~CalibrationAnalysis() {;}
+  ~CalibrationAnalysis() override {;}
   
   friend class CalibrationAlgorithm;
 
@@ -72,9 +72,9 @@ class CalibrationAnalysis : public CommissioningAnalysis {
   inline bool deconvMode() const { return deconv_; }
   inline int calchan() const { return calchan_; }
 
-  void print( std::stringstream&, uint32_t not_used = 0 );
+  void print( std::stringstream&, uint32_t not_used = 0 ) override;
   
-  void reset();
+  void reset() override;
   
  private:
   

--- a/CondFormats/SiStripObjects/interface/DaqScopeModeAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/DaqScopeModeAnalysis.h
@@ -21,7 +21,7 @@ class DaqScopeModeAnalysis : public CommissioningAnalysis {
 
   DaqScopeModeAnalysis();
 
-  virtual ~DaqScopeModeAnalysis() {;}
+  ~DaqScopeModeAnalysis() override {;}
 
   friend class DaqScopeModeAlgorithm;
   
@@ -39,9 +39,9 @@ class DaqScopeModeAnalysis : public CommissioningAnalysis {
 
   inline const float& max() const; 
   
-  void print( std::stringstream&, uint32_t not_used = 0 );
+  void print( std::stringstream&, uint32_t not_used = 0 ) override;
   
-  void reset();
+  void reset() override;
   
  private:
   

--- a/CondFormats/SiStripObjects/interface/FastFedCablingAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/FastFedCablingAnalysis.h
@@ -23,7 +23,7 @@ class FastFedCablingAnalysis : public CommissioningAnalysis {
 
   FastFedCablingAnalysis();
 
-  virtual ~FastFedCablingAnalysis() {;}
+  ~FastFedCablingAnalysis() override {;}
   
   typedef std::map<uint32_t,uint16_t> Candidates;
 
@@ -32,7 +32,7 @@ class FastFedCablingAnalysis : public CommissioningAnalysis {
   // ---------- public interface ----------
 
   /** Identifies if analysis is valid or not. */
-  bool isValid() const;
+  bool isValid() const override;
 
   /** Identifies if fibre is dirty or not. */
   bool isDirty() const;
@@ -67,16 +67,16 @@ class FastFedCablingAnalysis : public CommissioningAnalysis {
   // ---------- misc ----------
 
   /** Prints analysis results. */
-  void print( std::stringstream&, uint32_t not_used = 0 );
+  void print( std::stringstream&, uint32_t not_used = 0 ) override;
   
   /** Header information for analysis print(). */
-  void header( std::stringstream& ) const;
+  void header( std::stringstream& ) const override;
   
   /** Overrides base method. */
-  void summary( std::stringstream& ) const;
+  void summary( std::stringstream& ) const override;
   
   /** Resets analysis member data. */
-  void reset();
+  void reset() override;
 
   // ---------- public static data ----------
 

--- a/CondFormats/SiStripObjects/interface/FedCablingAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/FedCablingAnalysis.h
@@ -23,7 +23,7 @@ class FedCablingAnalysis : public CommissioningAnalysis {
 
   FedCablingAnalysis();
 
-  virtual ~FedCablingAnalysis() {;}
+  ~FedCablingAnalysis() override {;}
   
   typedef std::map<uint32_t,uint16_t> Candidates;
 
@@ -32,7 +32,7 @@ class FedCablingAnalysis : public CommissioningAnalysis {
   // ---------- public interface ----------
 
   /** Identifies if analysis is valid or not. */
-  bool isValid() const;
+  bool isValid() const override;
 
   /** FED id. */
   inline const uint16_t& fedId() const;
@@ -49,10 +49,10 @@ class FedCablingAnalysis : public CommissioningAnalysis {
   // ---------- misc ----------
   
   /** Prints analysis results. */
-  void print( std::stringstream&, uint32_t not_used = 0 );
+  void print( std::stringstream&, uint32_t not_used = 0 ) override;
   
   /** Resets analysis member data. */
-  void reset();
+  void reset() override;
   
   // ---------- public static data ----------
 

--- a/CondFormats/SiStripObjects/interface/FedTimingAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/FedTimingAnalysis.h
@@ -21,7 +21,7 @@ class FedTimingAnalysis : public CommissioningAnalysis {
 
   FedTimingAnalysis();
 
-  virtual ~FedTimingAnalysis() {;}
+  ~FedTimingAnalysis() override {;}
 
   friend class FedTimingAlgorithm;
   
@@ -41,9 +41,9 @@ class FedTimingAnalysis : public CommissioningAnalysis {
   
   void max( const float& ); 
   
-  void print( std::stringstream&, uint32_t not_used = 0 );
+  void print( std::stringstream&, uint32_t not_used = 0 ) override;
   
-  void reset();
+  void reset() override;
   
  private:
   

--- a/CondFormats/SiStripObjects/interface/NoiseAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/NoiseAnalysis.h
@@ -22,14 +22,14 @@ class NoiseAnalysis : public CommissioningAnalysis {
 
   NoiseAnalysis();
 
-  virtual ~NoiseAnalysis() {;}
+  ~NoiseAnalysis() override {;}
 
   friend class NoiseAlgorithm;
 
   // ---------- public interface ----------
 
   /** Identifies if analysis is valid or not. */
-  bool isValid() const;
+  bool isValid() const override;
   
   // Pedestal, noise and raw noise (128-strip vector per APV)
   inline const VVFloat& peds() const;
@@ -59,13 +59,13 @@ class NoiseAnalysis : public CommissioningAnalysis {
   // ---------- misc ----------
   
   /** Prints analysis results. */
-  void print( std::stringstream&, uint32_t apv_number = 0 );
+  void print( std::stringstream&, uint32_t apv_number = 0 ) override;
   
   /** Overrides base method. */
-  void summary( std::stringstream& ) const;
+  void summary( std::stringstream& ) const override;
   
   /** Resets analysis member data. */
-  void reset();
+  void reset() override;
   
   // ---------- private member data ----------
 

--- a/CondFormats/SiStripObjects/interface/OptoScanAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/OptoScanAnalysis.h
@@ -22,14 +22,14 @@ class OptoScanAnalysis : public CommissioningAnalysis {
 
   OptoScanAnalysis();
 
-  virtual ~OptoScanAnalysis() {;}
+  ~OptoScanAnalysis() override {;}
 
   friend class OptoScanAlgorithm;
 
   // ---------- public interface ----------
 
   /** Identifies if analysis is valid or not. */
-  bool isValid() const;
+  bool isValid() const override;
   
   /** Optimum LLD gain setting */
   inline const uint16_t& gain() const;
@@ -61,13 +61,13 @@ class OptoScanAnalysis : public CommissioningAnalysis {
   // ---------- misc ----------
 
   /** Prints analysis results. */
-  void print( std::stringstream&, uint32_t gain_setting = sistrip::invalid_ );
+  void print( std::stringstream&, uint32_t gain_setting = sistrip::invalid_ ) override;
   
   /** Overrides base method. */
-  void summary( std::stringstream& ) const;
+  void summary( std::stringstream& ) const override;
 
   /** Resets analysis member data. */
-  void reset();
+  void reset() override;
 
   // ---------- public static data ----------
   

--- a/CondFormats/SiStripObjects/interface/PedestalsAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/PedestalsAnalysis.h
@@ -22,14 +22,14 @@ class PedestalsAnalysis : public CommissioningAnalysis {
 
   PedestalsAnalysis();
 
-  virtual ~PedestalsAnalysis() {;}
+  ~PedestalsAnalysis() override {;}
 
   friend class PedestalsAlgorithm;
 
   // ---------- public interface ----------
 
   /** Identifies if analysis is valid or not. */
-  bool isValid() const;
+  bool isValid() const override;
   
   // Pedestal, noise and raw noise (128-strip vector per APV)
   inline const VVFloat& peds() const;
@@ -59,13 +59,13 @@ class PedestalsAnalysis : public CommissioningAnalysis {
   // ---------- misc ----------
   
   /** Prints analysis results. */
-  void print( std::stringstream&, uint32_t apv_number = 0 );
+  void print( std::stringstream&, uint32_t apv_number = 0 ) override;
   
   /** Overrides base method. */
-  void summary( std::stringstream& ) const;
+  void summary( std::stringstream& ) const override;
   
   /** Resets analysis member data. */
-  void reset();
+  void reset() override;
   
   // ---------- private member data ----------
 

--- a/CondFormats/SiStripObjects/interface/PedsFullNoiseAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/PedsFullNoiseAnalysis.h
@@ -22,7 +22,7 @@ class PedsFullNoiseAnalysis : public CommissioningAnalysis {
 
     PedsFullNoiseAnalysis();
 
-    virtual ~PedsFullNoiseAnalysis() {;}
+    ~PedsFullNoiseAnalysis() override {;}
 
     friend class PedestalsAlgorithm;
     friend class PedsFullNoiseAlgorithm;
@@ -30,7 +30,7 @@ class PedsFullNoiseAnalysis : public CommissioningAnalysis {
     // ---------- public interface ----------
 
   	/** Identifies if analysis is valid or not. */
-  	bool isValid() const;
+  	bool isValid() const override;
   
   	// Pedestal, noise and raw noise (128-strip vector per APV)
 	inline const VVFloat& peds() const;
@@ -72,13 +72,13 @@ class PedsFullNoiseAnalysis : public CommissioningAnalysis {
     // ---------- misc ----------
 
     /** Prints analysis results. */
-    void print( std::stringstream&, uint32_t apv_number = 0 );
+    void print( std::stringstream&, uint32_t apv_number = 0 ) override;
 
     /** Overrides base method. */
-    void summary( std::stringstream& ) const;
+    void summary( std::stringstream& ) const override;
 
     /** Resets analysis member data. */
-    void reset();
+    void reset() override;
 
     // ---------- private member data ----------
 

--- a/CondFormats/SiStripObjects/interface/PedsOnlyAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/PedsOnlyAnalysis.h
@@ -22,14 +22,14 @@ class PedsOnlyAnalysis : public CommissioningAnalysis {
 
   PedsOnlyAnalysis();
 
-  virtual ~PedsOnlyAnalysis() {;}
+  ~PedsOnlyAnalysis() override {;}
 
   friend class PedsOnlyAlgorithm;
 
   // ---------- public interface ----------
 
   /** Identifies if analysis is valid or not. */
-  bool isValid() const;
+  bool isValid() const override;
   
   // Pedestal, noise and raw noise (128-strip vector per APV)
   inline const VVFloat& peds() const;
@@ -50,13 +50,13 @@ class PedsOnlyAnalysis : public CommissioningAnalysis {
   // ---------- misc ----------
   
   /** Prints analysis results. */
-  void print( std::stringstream&, uint32_t apv_number = 0 );
+  void print( std::stringstream&, uint32_t apv_number = 0 ) override;
   
   /** Overrides base method. */
-  void summary( std::stringstream& ) const;
+  void summary( std::stringstream& ) const override;
   
   /** Resets analysis member data. */
-  void reset();
+  void reset() override;
   
   // ---------- private member data ----------
 

--- a/CondFormats/SiStripObjects/interface/SamplingAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/SamplingAnalysis.h
@@ -22,7 +22,7 @@ class SamplingAnalysis : public CommissioningAnalysis {
 
   SamplingAnalysis();
 
-  virtual ~SamplingAnalysis() {;}
+  ~SamplingAnalysis() override {;}
 
   friend class SamplingAlgorithm;
 
@@ -34,9 +34,9 @@ class SamplingAnalysis : public CommissioningAnalysis {
 
   float getSoNcut() const { return sOnCut_; }
   
-  void print( std::stringstream&, uint32_t not_used = 0 );
+  void print( std::stringstream&, uint32_t not_used = 0 ) override;
   
-  void reset();
+  void reset() override;
 
   float limit(float SoNcut) const;
 

--- a/CondFormats/SiStripObjects/interface/VpspScanAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/VpspScanAnalysis.h
@@ -22,14 +22,14 @@ class VpspScanAnalysis : public CommissioningAnalysis {
 
   VpspScanAnalysis();
 
-  virtual ~VpspScanAnalysis() {;}
+  ~VpspScanAnalysis() override {;}
 
   friend class VpspScanAlgorithm;
 
   // ---------- public interface ----------
   
   /** Identifies if analysis is valid or not. */
-  bool isValid() const;
+  bool isValid() const override;
 
   /** VPSP settings for both APVs. */
   inline const VInt& vpsp() const;
@@ -55,13 +55,13 @@ class VpspScanAnalysis : public CommissioningAnalysis {
   // ---------- misc ----------
 
   /** Prints analysis results. */
-  void print( std::stringstream&, uint32_t not_used = 0 );
+  void print( std::stringstream&, uint32_t not_used = 0 ) override;
   
   /** Overrides base method. */
-  void summary( std::stringstream& ) const;
+  void summary( std::stringstream& ) const override;
   
   /** Resets analysis member data. */
-  void reset();
+  void reset() override;
 
   // ---------- private member data ----------
   


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this tomorrow to avoid conflicts to the extent possible]