### PR TITLE
Clang-tidy checks for Configuration

### DIFF
--- a/Configuration/Skimming/interface/LeptonRecoSkim.h
+++ b/Configuration/Skimming/interface/LeptonRecoSkim.h
@@ -59,12 +59,12 @@
 class LeptonRecoSkim : public edm::EDFilter {
  public:
   explicit LeptonRecoSkim(const edm::ParameterSet&);
-  ~LeptonRecoSkim();
+  ~LeptonRecoSkim() override;
   
  private:
-  virtual void beginJob() ;
-  virtual bool filter(edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  void beginJob() override ;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
   
   void handleObjects(const edm::Event&, const edm::EventSetup& iSetup);
 


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this tomorrow to avoid conflicts to the extent possible]