### PR TITLE
Clang-tidy checks for DataFormats

### DIFF
--- a/DataFormats/Alignment/interface/SiStripLaserRecHit2D.h
+++ b/DataFormats/Alignment/interface/SiStripLaserRecHit2D.h
@@ -14,12 +14,12 @@ class SiStripLaserRecHit2D : public RecHit2DLocalPos {
 public:
 
   SiStripLaserRecHit2D(): RecHit2DLocalPos(0) {}
-  ~SiStripLaserRecHit2D() {}
+  ~SiStripLaserRecHit2D() override {}
   SiStripLaserRecHit2D( const LocalPoint& p, const LocalError& e, const SiStripDetId& id ) : RecHit2DLocalPos( id ), position( p ), error( e ) { detId = id; }
 
-  virtual LocalPoint localPosition() const { return position; }
-  virtual LocalError localPositionError() const { return error; }
-  virtual SiStripLaserRecHit2D* clone() const { return new SiStripLaserRecHit2D( *this ); }
+  LocalPoint localPosition() const override { return position; }
+  LocalError localPositionError() const override { return error; }
+  SiStripLaserRecHit2D* clone() const override { return new SiStripLaserRecHit2D( *this ); }
 
   const SiStripDetId& getDetId( void ) const { return detId; }
 

--- a/DataFormats/Alignment/interface/TkFittedLasBeam.h
+++ b/DataFormats/Alignment/interface/TkFittedLasBeam.h
@@ -21,7 +21,7 @@ class TkFittedLasBeam : public TkLasBeam {
   
   TkFittedLasBeam(); 
   TkFittedLasBeam(const TkLasBeam &lasBeam);
-  virtual ~TkFittedLasBeam() {} // anyway virtual since inherited...
+  ~TkFittedLasBeam() override {} // anyway virtual since inherited...
     
   /// the parametrisation type used (0 means undefined...)
   unsigned int parametrisation() const { return parametrisation_;}

--- a/DataFormats/BTauReco/interface/BoostedDoubleSVTagInfo.h
+++ b/DataFormats/BTauReco/interface/BoostedDoubleSVTagInfo.h
@@ -19,13 +19,13 @@ public:
       m_list(list),
       m_svTagInfoRef(svTagInfoRef) { }
 
-  virtual ~BoostedDoubleSVTagInfo(void) { }
+  ~BoostedDoubleSVTagInfo(void) override { }
 
-  virtual BoostedDoubleSVTagInfo* clone(void) const { return new BoostedDoubleSVTagInfo(*this); }
+  BoostedDoubleSVTagInfo* clone(void) const override { return new BoostedDoubleSVTagInfo(*this); }
 
-  virtual edm::RefToBase<Jet> jet(void) const { return m_svTagInfoRef->jet(); }
+  edm::RefToBase<Jet> jet(void) const override { return m_svTagInfoRef->jet(); }
 
-  virtual TaggingVariableList taggingVariables(void) const { return m_list; }
+  TaggingVariableList taggingVariables(void) const override { return m_list; }
 
 protected:
   TaggingVariableList                                 m_list;

--- a/DataFormats/BTauReco/interface/IPTagInfo.h
+++ b/DataFormats/BTauReco/interface/IPTagInfo.h
@@ -68,10 +68,10 @@ public:
 
   IPTagInfo() {}
   
-  virtual ~IPTagInfo() {}
+  ~IPTagInfo() override {}
   
   /// clone
-  virtual IPTagInfo * clone(void) const
+  IPTagInfo * clone(void) const override
   { return new IPTagInfo(*this); }
 
  /**
@@ -128,7 +128,7 @@ public:
   Container sorted(const std::vector<size_t>& indexes) const;
   Container sortedTracks(const std::vector<size_t>& indexes) const {return sorted(indexes);}
 
-  virtual TaggingVariableList taggingVariables(void) const; 
+  TaggingVariableList taggingVariables(void) const override; 
  
   const edm::Ref<VertexCollection> & primaryVertex() const { return m_pv; }
 
@@ -173,7 +173,7 @@ template <class Container, class Base> TaggingVariableList IPTagInfo<Container,B
      using namespace ROOT::Math;
      const Track * track = selectedTrack(*it);
      const btag::TrackIPData *data = &m_data[*it];
-     math::XYZVector trackMom = track->momentum();
+     const math::XYZVector& trackMom = track->momentum();
      double trackMag = std::sqrt(trackMom.Mag2());
 
      vars.insert(btau::trackMomentum, trackMag, true);
@@ -222,7 +222,7 @@ template<class Container, class Base> std::vector<bool> IPTagInfo<Container,Base
     //Track parameters
     const Track * track =  selectedTrack(i);    
     double trackpT = track->pt();
-    math::XYZVector trackMom = track->momentum();
+    const math::XYZVector& trackMom = track->momentum();
 
     // do the math in passVariableJTA
     result.push_back(passVariableJTA( params, jetpT, trackpT, ROOT::Math::VectorUtil::DeltaR(trackMom, jetDir)));

--- a/DataFormats/BTauReco/interface/IsolatedTauTagInfo.h
+++ b/DataFormats/BTauReco/interface/IsolatedTauTagInfo.h
@@ -33,7 +33,7 @@ namespace reco {
     { }   
 
     //destructor
-    virtual ~IsolatedTauTagInfo() {}
+    ~IsolatedTauTagInfo() override {}
     
     //get the tracks from the jetTag
     const TrackRefVector allTracks() const { return tracks(); }
@@ -41,7 +41,7 @@ namespace reco {
     //get the selected tracks used to computed the isolation
     const TrackRefVector  selectedTracks() const {return selectedTracks_;}
     
-    virtual IsolatedTauTagInfo* clone() const { return new IsolatedTauTagInfo( *this ); }
+    IsolatedTauTagInfo* clone() const override { return new IsolatedTauTagInfo( *this ); }
   
     // default discriminator: returns the value of the discriminator of the jet tag, i.e. the one computed with the parameters taken from the cfg file
     float discriminator() const { return m_discriminator; }

--- a/DataFormats/BTauReco/interface/JTATagInfo.h
+++ b/DataFormats/BTauReco/interface/JTATagInfo.h
@@ -13,15 +13,15 @@ public:
   JTATagInfo(void) : m_jetTracksAssociation() { }
   JTATagInfo(const JetTracksAssociationRef & jtaRef) : m_jetTracksAssociation(jtaRef) { }
 
-  virtual ~JTATagInfo(void) { }
+  ~JTATagInfo(void) override { }
   
-  virtual JTATagInfo* clone(void) const { return new JTATagInfo(*this); }
+  JTATagInfo* clone(void) const override { return new JTATagInfo(*this); }
 
-  virtual edm::RefToBase<Jet>     jet(void)    const { return m_jetTracksAssociation->first ; }
-  virtual TrackRefVector          tracks(void) const { return m_jetTracksAssociation->second; }
+  edm::RefToBase<Jet>     jet(void)    const override { return m_jetTracksAssociation->first ; }
+  TrackRefVector          tracks(void) const override { return m_jetTracksAssociation->second; }
   const JetTracksAssociationRef & jtaRef(void) const { return m_jetTracksAssociation; }
 
-  virtual bool hasTracks(void) const { return true; }
+  bool hasTracks(void) const override { return true; }
   
   void setJTARef(const JetTracksAssociationRef & jtaRef) { m_jetTracksAssociation = jtaRef; } 
   

--- a/DataFormats/BTauReco/interface/JetTagInfo.h
+++ b/DataFormats/BTauReco/interface/JetTagInfo.h
@@ -15,11 +15,11 @@ public:
 
   JetTagInfo(const edm::RefToBase<Jet> & jetRef) : m_jet(jetRef) { }
 
-  virtual ~JetTagInfo(void) { }
+  ~JetTagInfo(void) override { }
   
-  virtual JetTagInfo* clone(void) const { return new JetTagInfo(*this); }
+  JetTagInfo* clone(void) const override { return new JetTagInfo(*this); }
 
-  virtual edm::RefToBase<Jet> jet(void) const { return m_jet; }
+  edm::RefToBase<Jet> jet(void) const override { return m_jet; }
   
   template <typename T>
   void setJetRef(const edm::Ref<T> & jetRef) { m_jet = edm::RefToBase<Jet>( jetRef ); } 

--- a/DataFormats/BTauReco/interface/TauMassTagInfo.h
+++ b/DataFormats/BTauReco/interface/TauMassTagInfo.h
@@ -21,9 +21,9 @@ namespace reco {
     typedef ClusterTrackAssociationCollection::value_type ClusterTrackAssociation;
 
     TauMassTagInfo() {}
-    virtual ~TauMassTagInfo() {}
+    ~TauMassTagInfo() override {}
     
-    virtual TauMassTagInfo* clone() const { return new TauMassTagInfo( * this ); }
+    TauMassTagInfo* clone() const override { return new TauMassTagInfo( * this ); }
     
     //default discriminator: returns the discriminator of the jet tag
     float discriminator() const {return -1. ;}

--- a/DataFormats/BTauReco/interface/TemplatedSecondaryVertexTagInfo.h
+++ b/DataFormats/BTauReco/interface/TemplatedSecondaryVertexTagInfo.h
@@ -96,7 +96,7 @@ class TemplatedSecondaryVertexTagInfo : public BaseTagInfo {
 	typedef typename IPTI::input_container input_container;
 
 	TemplatedSecondaryVertexTagInfo() {}
-	virtual ~TemplatedSecondaryVertexTagInfo() {}
+	~TemplatedSecondaryVertexTagInfo() override {}
 
 	TemplatedSecondaryVertexTagInfo(
 	                const std::vector<IndexedTrackData> &trackData,
@@ -105,14 +105,14 @@ class TemplatedSecondaryVertexTagInfo : public BaseTagInfo {
 			 const edm::Ref<std::vector<IPTI> >&);
 
         /// clone
-        virtual TemplatedSecondaryVertexTagInfo * clone(void) const {
+        TemplatedSecondaryVertexTagInfo * clone(void) const override {
             return new TemplatedSecondaryVertexTagInfo(*this);
         }
   
 	const edm::Ref<std::vector<IPTI> > &trackIPTagInfoRef() const
 	{ return m_trackIPTagInfoRef; }
 
-	virtual edm::RefToBase<Jet> jet(void) const
+	edm::RefToBase<Jet> jet(void) const override
 	{ return m_trackIPTagInfoRef->jet(); }
 
 //	virtual input_container ipTracks(void) const
@@ -155,7 +155,7 @@ class TemplatedSecondaryVertexTagInfo : public BaseTagInfo {
         }
 	const GlobalVector &flightDirection(unsigned int index) const
 	{ return m_svData[index].direction; }
-	virtual TaggingVariableList taggingVariables() const;
+	TaggingVariableList taggingVariables() const override;
 	
 	// Used by ROOT storage
 	CMS_CLASS_VERSION(11)

--- a/DataFormats/BTauReco/interface/TemplatedSoftLeptonTagInfo.h
+++ b/DataFormats/BTauReco/interface/TemplatedSoftLeptonTagInfo.h
@@ -120,9 +120,9 @@ public:
     
     TemplatedSoftLeptonTagInfo(void) : m_leptons() {}
 
-    virtual ~TemplatedSoftLeptonTagInfo(void) {}
+    ~TemplatedSoftLeptonTagInfo(void) override {}
   
-    virtual TemplatedSoftLeptonTagInfo* clone(void) const { return new TemplatedSoftLeptonTagInfo(*this); }
+    TemplatedSoftLeptonTagInfo* clone(void) const override { return new TemplatedSoftLeptonTagInfo(*this); }
 
     unsigned int leptons(void) const { 
         return m_leptons.size(); 
@@ -141,7 +141,7 @@ public:
     }
 
     /// returns a description of the extended informations in a TaggingVariableList
-    virtual TaggingVariableList taggingVariables(void) const;
+    TaggingVariableList taggingVariables(void) const override;
 
     // Used by ROOT storage
     CMS_CLASS_VERSION(2)

--- a/DataFormats/BTauReco/interface/TrackCountingTagInfo.h
+++ b/DataFormats/BTauReco/interface/TrackCountingTagInfo.h
@@ -24,7 +24,7 @@ class TrackCountingTagInfo : public JTATagInfo
 
   TrackCountingTagInfo() {}
   
-  virtual ~TrackCountingTagInfo() {}
+  ~TrackCountingTagInfo() override {}
   
   /* virtual const Track & track(size_t n,int ipType) const
   {
@@ -75,7 +75,7 @@ class TrackCountingTagInfo : public JTATagInfo
    else return m_significance2d.size();
   }   
   
-  virtual TrackCountingTagInfo* clone() const { return new TrackCountingTagInfo( * this ); }
+  TrackCountingTagInfo* clone() const override { return new TrackCountingTagInfo( * this ); }
  
   private:
    std::vector<double> m_significance2d;  //create a smarter container instead of 

--- a/DataFormats/BTauReco/interface/TrackProbabilityTagInfo.h
+++ b/DataFormats/BTauReco/interface/TrackProbabilityTagInfo.h
@@ -24,7 +24,7 @@ class TrackProbabilityTagInfo : public JTATagInfo
 
   TrackProbabilityTagInfo() {}
   
-  virtual ~TrackProbabilityTagInfo() {}
+  ~TrackProbabilityTagInfo() override {}
 
 int factorial(int n) const
 {
@@ -124,7 +124,7 @@ int factorial(int n) const
     return *tracks()[trackIndex(n,ipType)];
   }
  
-  virtual TrackProbabilityTagInfo* clone() const { return new TrackProbabilityTagInfo( * this ); }
+  TrackProbabilityTagInfo* clone() const override { return new TrackProbabilityTagInfo( * this ); }
   
   private:
    std::vector<double> m_probability2d;     //

--- a/DataFormats/BTauReco/src/IsolatedTauTagInfo.cc
+++ b/DataFormats/BTauReco/src/IsolatedTauTagInfo.cc
@@ -58,7 +58,7 @@ const TrackRef IsolatedTauTagInfo::leadingSignalTrack(const float rm_cone, const
   const  RefVector<TrackCollection>  sTracks = tracksInCone(jet3Vec, rm_cone, pt_min);
   TrackRef leadTk;
   float pt_cut = pt_min;
-  if (sTracks.size() >0) 
+  if (!sTracks.empty()) 
     {
       RefVector<TrackCollection>::const_iterator myTrack =sTracks.begin();
       for(;myTrack!=sTracks.end();myTrack++)
@@ -77,7 +77,7 @@ const TrackRef  IsolatedTauTagInfo::leadingSignalTrack(const math::XYZVector& my
   const RefVector<TrackCollection> sTracks = tracksInCone(myVector, rm_cone, pt_min);
   TrackRef leadTk;
   float pt_cut = pt_min;
-  if (sTracks.size() >0) 
+  if (!sTracks.empty()) 
     {
       RefVector<TrackCollection>::const_iterator myTrack =sTracks.begin();
       for(;myTrack!=sTracks.end();myTrack++)
@@ -106,7 +106,7 @@ float IsolatedTauTagInfo::discriminator(float m_cone, float sig_cone, float iso_
   const RefVector<TrackCollection> signalTracks = tracksInCone(trackMomentum, sig_cone, pt_min_tk);
   const RefVector<TrackCollection> isolationTracks = tracksInCone(trackMomentum, iso_cone, pt_min_tk); 
   
-  if (signalTracks.size() > 0 && (int)(isolationTracks.size() - signalTracks.size()) <= nTracksIsoRing)
+  if (!signalTracks.empty() && (int)(isolationTracks.size() - signalTracks.size()) <= nTracksIsoRing)
     myDiscriminator=1;
 
   return myDiscriminator;
@@ -128,7 +128,7 @@ const  TrackRef leadTk = leadingSignalTrack(myVector, m_cone, pt_min_lt);
   const RefVector<TrackCollection> signalTracks = tracksInCone(trackMomentum, sig_cone, pt_min_tk);
   const RefVector<TrackCollection> isolationTracks = tracksInCone(trackMomentum, iso_cone, pt_min_tk); 
   
-  if (signalTracks.size() > 0 && (int)(isolationTracks.size() - signalTracks.size()) <= nTracksIsoRing)
+  if (!signalTracks.empty() && (int)(isolationTracks.size() - signalTracks.size()) <= nTracksIsoRing)
     myDiscriminator=1;
 
   return myDiscriminator;
@@ -151,7 +151,7 @@ float IsolatedTauTagInfo::discriminator(float m_cone, float sig_cone, float iso_
   const RefVector<TrackCollection> signalTracks = tracksInCone(trackMomentum, sig_cone, pt_min_tk, z_pv, dz_lt);
   const RefVector<TrackCollection> isolationTracks = tracksInCone(trackMomentum, iso_cone, pt_min_tk, z_pv, dz_lt); 
   
-  if (signalTracks.size() > 0 && (int)(isolationTracks.size() - signalTracks.size()) <= nTracksIsoRing)
+  if (!signalTracks.empty() && (int)(isolationTracks.size() - signalTracks.size()) <= nTracksIsoRing)
     myDiscriminator=1;
 
   return myDiscriminator;
@@ -171,7 +171,7 @@ const  TrackRef leadTk = leadingSignalTrack(myVector, m_cone, pt_min_lt);
   const RefVector<TrackCollection> signalTracks = tracksInCone(trackMomentum, sig_cone, pt_min_tk, z_pv, dz_lt);
   const RefVector<TrackCollection> isolationTracks = tracksInCone(trackMomentum, iso_cone, pt_min_tk, z_pv, dz_lt); 
   
-  if (signalTracks.size() > 0 && (int)(isolationTracks.size() - signalTracks.size()) <= nTracksIsoRing)
+  if (!signalTracks.empty() && (int)(isolationTracks.size() - signalTracks.size()) <= nTracksIsoRing)
     myDiscriminator=1;
 
   return myDiscriminator;

--- a/DataFormats/BTauReco/src/TauImpactParameterInfo.cc
+++ b/DataFormats/BTauReco/src/TauImpactParameterInfo.cc
@@ -36,7 +36,7 @@ const reco::TauImpactParameterTrackData* TauImpactParameterInfo::getTrackData(co
 
         if (iter != trackDataMap.end()) return &(iter->val);
 
-	return 0; // if track not found return 0
+	return nullptr; // if track not found return 0
 }
 
 void reco::TauImpactParameterInfo::storeTrackData(const reco::TrackRef & trackRef,

--- a/DataFormats/BTauReco/src/TauMassTagInfo.cc
+++ b/DataFormats/BTauReco/src/TauMassTagInfo.cc
@@ -52,7 +52,7 @@ bool reco::TauMassTagInfo::calculateTrkP4(double matching_cone,
   const RefVector<TrackCollection> signalTracks = 
                  isolatedTau->tracksInCone(momentum,signal_cone,1.0);
 //  if (signalTracks.size() == 0 || signalTracks.size()%2 == 0) return false;
-  if (signalTracks.size() == 0) return false;
+  if (signalTracks.empty()) return false;
 
   double px_inv = 0.0;
   double py_inv = 0.0;

--- a/DataFormats/CSCDigi/src/CSCCFEBStatusDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCFEBStatusDigi.cc
@@ -99,7 +99,7 @@ void CSCCFEBStatusDigi::print() const {
   
   std::ostringstream ost;
   ost << " SCAFullCond: ";
-  if(getSCAFullCond().size()!=0){
+  if(!getSCAFullCond().empty()){
     for (size_t i = 0; i<4; ++i ){ ost << " " <<(getSCAFullCond())[i]; }
   }
   else {

--- a/DataFormats/CSCRecHit/interface/CSCRecHit2D.h
+++ b/DataFormats/CSCRecHit/interface/CSCRecHit2D.h
@@ -42,13 +42,13 @@ public:
                int scaledWireTime=0,
 	       float energyDeposit=-995.); 
 	
-  ~CSCRecHit2D();
+  ~CSCRecHit2D() override;
 
 
   /// RecHit2DLocalPos base class interface
-  CSCRecHit2D* clone() const { return new CSCRecHit2D( *this ); }
-  LocalPoint localPosition() const { return theLocalPosition; }
-  LocalError localPositionError() const { return theLocalError; }
+  CSCRecHit2D* clone() const override { return new CSCRecHit2D( *this ); }
+  LocalPoint localPosition() const override { return theLocalPosition; }
+  LocalError localPositionError() const override { return theLocalError; }
   CSCDetId cscDetId() const { return geographicalId(); }
 
   /// Extracting strip channel numbers comprising the rechit - low
@@ -100,7 +100,7 @@ public:
   float energyDepositedInLayer() const { return theEnergyDeposit; }
 
   /// Returns true if the two TrackingRecHits are using the same input information, false otherwise.  In this case, looks at the geographical ID and channel numbers for strips and wires.
-  virtual bool sharesInput(const TrackingRecHit *other, TrackingRecHit::SharedInputType what) const;
+  bool sharesInput(const TrackingRecHit *other, TrackingRecHit::SharedInputType what) const override;
   
   /// Returns true if the two TrackingRecHits are using the same input information, false otherwise.  In this case, looks at the geographical ID and channel numbers for strips and wires.
   bool sharesInput(const TrackingRecHit *other, CSCRecHit2D::SharedInputType what) const;

--- a/DataFormats/CSCRecHit/interface/CSCSegment.h
+++ b/DataFormats/CSCRecHit/interface/CSCSegment.h
@@ -30,35 +30,35 @@ public:
         	LocalVector direction, const AlgebraicSymMatrix& errors, double chi2);
   
     /// Destructor
-    virtual ~CSCSegment();
+    ~CSCSegment() override;
 
     //--- Base class interface
-    CSCSegment* clone() const { return new CSCSegment(*this); }
+    CSCSegment* clone() const override { return new CSCSegment(*this); }
 
-    LocalPoint localPosition() const { return theOrigin; }
-    LocalError localPositionError() const ;
+    LocalPoint localPosition() const override { return theOrigin; }
+    LocalError localPositionError() const override ;
 	
-    LocalVector localDirection() const { return theLocalDirection; }
-    LocalError localDirectionError() const ;
+    LocalVector localDirection() const override { return theLocalDirection; }
+    LocalError localDirectionError() const override ;
 
     /// Parameters of the segment, for the track fit in the order (dx/dz, dy/dz, x, y )
-    AlgebraicVector parameters() const;
+    AlgebraicVector parameters() const override;
 
     /// Covariance matrix of parameters()
-    AlgebraicSymMatrix parametersError() const { return theCovMatrix; }
+    AlgebraicSymMatrix parametersError() const override { return theCovMatrix; }
 
     /// The projection matrix relates the trajectory state parameters to the segment parameters().
-    virtual AlgebraicMatrix projectionMatrix() const;
+    AlgebraicMatrix projectionMatrix() const override;
 
-    virtual std::vector<const TrackingRecHit*> recHits() const;
+    std::vector<const TrackingRecHit*> recHits() const override;
 
-    virtual std::vector<TrackingRecHit*> recHits();
+    std::vector<TrackingRecHit*> recHits() override;
 
-    double chi2() const { return theChi2; };
+    double chi2() const override { return theChi2; };
 
-    virtual int dimension() const { return 4; }
+    int dimension() const override { return 4; }
 
-    virtual int degreesOfFreedom() const { return 2*nRecHits() - 4;}	 
+    int degreesOfFreedom() const override { return 2*nRecHits() - 4;}	 
 
     //--- Extension of the interface
         
@@ -70,7 +70,7 @@ public:
 
     void setDuplicateSegments(std::vector<CSCSegment*>& duplicates);
 
-    bool isME11a_duplicate() const { return (theDuplicateSegments.size() > 0 ? true : false); }
+    bool isME11a_duplicate() const { return (!theDuplicateSegments.empty() ? true : false); }
     // a copy of the duplicated segments (ME1/1a only) 
     const std::vector< CSCSegment> & duplicateSegments() const { return theDuplicateSegments; } 
     

--- a/DataFormats/Candidate/interface/CompositeCandidate.h
+++ b/DataFormats/Candidate/interface/CompositeCandidate.h
@@ -36,7 +36,7 @@ namespace reco {
     /// constructor from values
     explicit CompositeCandidate( const Candidate & p, const std::string& name, role_collection const & roles );
     /// destructor
-    virtual ~CompositeCandidate();
+    ~CompositeCandidate() override;
     /// get the name of the candidate
     std::string name() const { return name_;}
     /// set the name of the candidate
@@ -46,16 +46,16 @@ namespace reco {
     /// set the roles    
     void                    setRoles( const role_collection & roles ) { roles_.clear(); roles_ = roles; }
     /// returns a clone of the candidate
-    virtual CompositeCandidate * clone() const;
+    CompositeCandidate * clone() const override;
     /// number of daughters
-    virtual size_type numberOfDaughters() const;
+    size_type numberOfDaughters() const override;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1 (read only mode)
-    virtual const Candidate * daughter( size_type ) const;
+    const Candidate * daughter( size_type ) const override;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1
-    virtual Candidate * daughter( size_type );
+    Candidate * daughter( size_type ) override;
     // Get candidate based on role
-    virtual Candidate *       daughter(const std::string& s );
-    virtual const Candidate * daughter(const std::string& s ) const;
+    Candidate *       daughter(const std::string& s ) override;
+    const Candidate * daughter(const std::string& s ) const override;
     /// add a clone of the passed candidate as daughter 
     void addDaughter( const Candidate &, const std::string& s="" );
     /// add a clone of the passed candidate as daughter 
@@ -67,15 +67,15 @@ namespace reco {
     // Apply the roles to the objects
     void applyRoles();
     /// number of mothers (zero or one in most of but not all the cases)
-    virtual size_type numberOfMothers() const;
+    size_type numberOfMothers() const override;
     /// return pointer to mother
-    virtual const Candidate * mother( size_type i = 0 ) const;
+    const Candidate * mother( size_type i = 0 ) const override;
 
   private:
     /// collection of daughters
     daughters dau;
     /// check overlap with another daughter
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
     /// candidate name
     std::string name_;
     /// candidate roles

--- a/DataFormats/Candidate/interface/CompositePtrCandidate.h
+++ b/DataFormats/Candidate/interface/CompositePtrCandidate.h
@@ -33,18 +33,18 @@ namespace reco {
     /// constructor from a Candidate
     explicit CompositePtrCandidate( const Candidate & p ) : LeafCandidate( p ) { }
     /// destructor
-    virtual ~CompositePtrCandidate();
+    ~CompositePtrCandidate() override;
     /// returns a clone of the candidate
-    virtual CompositePtrCandidate * clone() const;
+    CompositePtrCandidate * clone() const override;
     /// number of daughters
-    virtual size_t numberOfDaughters() const;
+    size_t numberOfDaughters() const override;
     /// number of mothers
-    virtual size_t numberOfMothers() const;
+    size_t numberOfMothers() const override;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1 (read only mode)
-    virtual const Candidate * daughter( size_type ) const;
+    const Candidate * daughter( size_type ) const override;
     using reco::LeafCandidate::daughter; // avoid hiding the base
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1
-    virtual Candidate * daughter( size_type );
+    Candidate * daughter( size_type ) override;
     /// add a daughter via a reference
     void addDaughter( const CandidatePtr & );    
     /// clear daughter references
@@ -54,23 +54,23 @@ namespace reco {
     /// references to daughtes
     const daughters & daughterPtrVector() const { return dau; }
     /// return pointer to mother
-    virtual const Candidate * mother( size_t i = 0 ) const;
+    const Candidate * mother( size_t i = 0 ) const override;
     /// number of source candidates 
     /// ( the candidates used to construct this Candidate). 
     /// for CompositeRefBaseCandidates, the source candidates 
     /// are the daughters. 
-    virtual size_type numberOfSourceCandidatePtrs() const ;
+    size_type numberOfSourceCandidatePtrs() const override ;
     /// return a RefToBase to one of the source Candidates 
     /// ( the candidates used to construct this Candidate). 
     /// for CompositeRefBaseCandidates, the source candidates 
     /// are the daughters. 
-    virtual CandidatePtr sourceCandidatePtr( size_type i ) const;
+    CandidatePtr sourceCandidatePtr( size_type i ) const override;
 
   private:
     /// collection of references to daughters
     daughters dau;
     /// check overlap with another candidate
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
   };
 
   inline void CompositePtrCandidate::addDaughter( const CandidatePtr & cand ) { 

--- a/DataFormats/Candidate/interface/CompositeRefBaseCandidate.h
+++ b/DataFormats/Candidate/interface/CompositeRefBaseCandidate.h
@@ -31,19 +31,19 @@ namespace reco {
     /// constructor from a particle
     explicit CompositeRefBaseCandidate( const Candidate & c ) : LeafCandidate( c ) { }
     /// destructor
-    virtual ~CompositeRefBaseCandidate();
+    ~CompositeRefBaseCandidate() override;
     /// returns a clone of the candidate
-    virtual CompositeRefBaseCandidate * clone() const;
+    CompositeRefBaseCandidate * clone() const override;
     /// number of daughters
-    virtual size_t numberOfDaughters() const;
+    size_t numberOfDaughters() const override;
     /// number of mothers
-    virtual size_t numberOfMothers() const;
+    size_t numberOfMothers() const override;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1 (read only mode)
-    virtual const Candidate * daughter( size_type ) const;
+    const Candidate * daughter( size_type ) const override;
     /// return mother at a given position, i = 0, ... numberOfMothers() - 1 (read only mode)
-    virtual const Candidate * mother( size_type ) const;
+    const Candidate * mother( size_type ) const override;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1
-    virtual Candidate * daughter( size_type );
+    Candidate * daughter( size_type ) override;
     using reco::LeafCandidate::daughter; // avoid hiding the base
     /// add a daughter via a reference
     void addDaughter( const CandidateBaseRef & );    
@@ -56,7 +56,7 @@ namespace reco {
     /// collection of references to daughters
     daughters dau;
     /// check overlap with another candidate
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
   };
 
   inline void CompositeRefBaseCandidate::addDaughter( const CandidateBaseRef & cand ) { 

--- a/DataFormats/Candidate/interface/CompositeRefCandidate.h
+++ b/DataFormats/Candidate/interface/CompositeRefCandidate.h
@@ -33,15 +33,15 @@ namespace reco {
     /// constructor from a candidate
     explicit CompositeRefCandidate( const Candidate & p ) : LeafCandidate( p ) { }
     /// destructor
-    virtual ~CompositeRefCandidate();
+    ~CompositeRefCandidate() override;
     /// returns a clone of the candidate
-    virtual CompositeRefCandidate * clone() const;
+    CompositeRefCandidate * clone() const override;
     /// number of daughters
-    virtual size_t numberOfDaughters() const;
+    size_t numberOfDaughters() const override;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1 (read only mode)
-    virtual const Candidate * daughter( size_type ) const;
+    const Candidate * daughter( size_type ) const override;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1
-    virtual Candidate * daughter( size_type );
+    Candidate * daughter( size_type ) override;
     using reco::LeafCandidate::daughter; // avoid hiding the base
     /// add a daughter via a reference
     void addDaughter( const CandidateRef & );    
@@ -60,9 +60,9 @@ namespace reco {
     /// set daughters product ID
     void resetDaughters( const edm::ProductID & id ) { dau = daughters( id ); }
     /// number of mothers (zero or one in most of but not all the cases)
-    virtual size_t numberOfMothers() const;
+    size_t numberOfMothers() const override;
     /// return pointer to mother
-    virtual const Candidate * mother( size_t i = 0 ) const;
+    const Candidate * mother( size_t i = 0 ) const override;
 
   private:
     /// collection of references to daughters
@@ -70,7 +70,7 @@ namespace reco {
     /// collection of references to mothers
     daughters mom;
     /// check overlap with another candidate
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
   };
 
   inline void CompositeRefCandidate::addDaughter( const CandidateRef & cand ) { 

--- a/DataFormats/Candidate/interface/CompositeRefCandidateT.h
+++ b/DataFormats/Candidate/interface/CompositeRefCandidateT.h
@@ -35,20 +35,20 @@ namespace reco {
     /// constructor from a particle
     explicit CompositeRefCandidateT( const LeafCandidate& c ) : LeafCandidate( c ) { }
     /// destructor
-    virtual ~CompositeRefCandidateT();
+    ~CompositeRefCandidateT() override;
     /// returns a clone of the candidate
-    virtual CompositeRefCandidateT<D> * clone() const;
+    CompositeRefCandidateT<D> * clone() const override;
     /// number of daughters
-    virtual size_t numberOfDaughters() const;
+    size_t numberOfDaughters() const override;
     /// number of mothers
-    virtual size_t numberOfMothers() const;
+    size_t numberOfMothers() const override;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1 (read only mode)
-    virtual const Candidate * daughter(size_type) const;
+    const Candidate * daughter(size_type) const override;
     using ::reco::LeafCandidate::daughter; // avoid hiding the base
     /// return mother at a given position, i = 0, ... numberOfMothers() - 1 (read only mode)
-    virtual const Candidate * mother(size_type = 0) const;
+    const Candidate * mother(size_type = 0) const override;
     /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1
-    virtual Candidate * daughter(size_type);
+    Candidate * daughter(size_type) override;
     /// add a daughter via a reference
     void addDaughter( const typename daughters::value_type & );    
     /// add a daughter via a reference
@@ -78,7 +78,7 @@ namespace reco {
     /// collection of references to mothers
     daughters mom;
     /// check overlap with another candidate
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
   };
 
   template<typename D>
@@ -102,17 +102,17 @@ namespace reco {
   
   template<typename D>
   const Candidate * CompositeRefCandidateT<D>::daughter( size_type i ) const { 
-    return ( i < numberOfDaughters() ) ? & * dau[ i ] : 0;
+    return ( i < numberOfDaughters() ) ? & * dau[ i ] : nullptr;
   }
   
   template<typename D>
   const Candidate * CompositeRefCandidateT<D>::mother( size_type i ) const { 
-    return ( i < numberOfMothers() ) ? & * mom[ i ] : 0;
+    return ( i < numberOfMothers() ) ? & * mom[ i ] : nullptr;
   }
   
   template<typename D>
   Candidate * CompositeRefCandidateT<D>::daughter( size_type i ) { 
-    return 0;
+    return nullptr;
   }
   
   template<typename D>

--- a/DataFormats/Candidate/interface/LeafCandidate.h
+++ b/DataFormats/Candidate/interface/LeafCandidate.h
@@ -63,153 +63,153 @@ namespace reco {
     }
 
     /// destructor
-    virtual ~LeafCandidate();
+    ~LeafCandidate() override;
     /// number of daughters
-    virtual size_t numberOfDaughters() const;
+    size_t numberOfDaughters() const override;
     /// return daughter at a given position (throws an exception)
-    virtual const Candidate * daughter( size_type ) const;
+    const Candidate * daughter( size_type ) const override;
     /// number of mothers
-    virtual size_t numberOfMothers() const;
+    size_t numberOfMothers() const override;
     /// return mother at a given position (throws an exception)
-    virtual const Candidate * mother( size_type ) const;
+    const Candidate * mother( size_type ) const override;
     /// return daughter at a given position (throws an exception)
-    virtual Candidate * daughter( size_type );
+    Candidate * daughter( size_type ) override;
     /// return daughter with a specified role name
-    virtual Candidate * daughter(const std::string& s );
+    Candidate * daughter(const std::string& s ) override;
     /// return daughter with a specified role name                                        
-    virtual const Candidate * daughter(const std::string& s ) const;
+    const Candidate * daughter(const std::string& s ) const override;
     /// return the number of source Candidates                                            
     /// ( the candidates used to construct this Candidate)                                
-    virtual size_t numberOfSourceCandidatePtrs() const { return 0;}
+    size_t numberOfSourceCandidatePtrs() const override { return 0;}
     /// return a Ptr to one of the source Candidates                                      
     /// ( the candidates used to construct this Candidate)                                
-    virtual CandidatePtr sourceCandidatePtr( size_type i ) const {
+    CandidatePtr sourceCandidatePtr( size_type i ) const override {
       return CandidatePtr();
     }
 
     /// electric charge
-    virtual int charge() const final { return m_state.charge(); }
+    int charge() const final { return m_state.charge(); }
     /// set electric charge                                                               
-    virtual void setCharge( Charge q ) final { m_state.setCharge(q); }
+    void setCharge( Charge q ) final { m_state.setCharge(q); }
     /// electric charge                                                                   
-    virtual int threeCharge() const final { return m_state.threeCharge(); }
+    int threeCharge() const final { return m_state.threeCharge(); }
     /// set electric charge                                                               
-    virtual void setThreeCharge( Charge qx3 ) final {m_state.setThreeCharge(qx3); }
+    void setThreeCharge( Charge qx3 ) final {m_state.setThreeCharge(qx3); }
     /// four-momentum Lorentz vector                                                      
-    virtual const LorentzVector & p4() const final { return m_state.p4(); }
+    const LorentzVector & p4() const final { return m_state.p4(); }
     /// four-momentum Lorentz vector                                                      
-    virtual const PolarLorentzVector & polarP4() const final { return m_state.polarP4(); }
+    const PolarLorentzVector & polarP4() const final { return m_state.polarP4(); }
     /// spatial momentum vector                                                           
-    virtual Vector momentum() const final { return m_state.momentum(); }
+    Vector momentum() const final { return m_state.momentum(); }
     /// boost vector to boost a Lorentz vector                                            
     /// to the particle center of mass system                                             
-    virtual Vector boostToCM() const final { return m_state.boostToCM(); }
+    Vector boostToCM() const final { return m_state.boostToCM(); }
     /// magnitude of momentum vector                                                      
-    virtual double p() const final { return m_state.p(); }
+    double p() const final { return m_state.p(); }
     /// energy                                                                            
-    virtual double energy() const final { return m_state.energy(); }
+    double energy() const final { return m_state.energy(); }
     /// transverse energy                                                                 
-    virtual double et() const final { return m_state.et(); }
+    double et() const final { return m_state.et(); }
     /// transverse energy squared (use this for cut!)                                                                 
-    virtual double et2() const final { return m_state.et2(); }
+    double et2() const final { return m_state.et2(); }
     /// mass                                                                              
-    virtual double mass() const final { return m_state.mass(); }
+    double mass() const final { return m_state.mass(); }
     /// mass squared                                                                      
-    virtual double massSqr() const final { return mass() * mass(); }
+    double massSqr() const final { return mass() * mass(); }
 
     /// transverse mass                                                                   
-    virtual double mt() const final  { return m_state.mt(); }
+    double mt() const final  { return m_state.mt(); }
     /// transverse mass squared                                                           
-    virtual double mtSqr() const final  { return m_state.mtSqr(); }
+    double mtSqr() const final  { return m_state.mtSqr(); }
     /// x coordinate of momentum vector                                                   
-    virtual double px() const final  {  return m_state.px(); }
+    double px() const final  {  return m_state.px(); }
     /// y coordinate of momentum vector                                                   
-    virtual double py() const final  { return m_state.py(); }
+    double py() const final  { return m_state.py(); }
     /// z coordinate of momentum vector                                                   
-    virtual double pz() const final  {  return m_state.pz(); }
+    double pz() const final  {  return m_state.pz(); }
     /// transverse momentum                                                               
-    virtual double pt() const final  { return m_state.pt();}
+    double pt() const final  { return m_state.pt();}
     /// momentum azimuthal angle                                                          
-    virtual double phi() const final  { return m_state.phi(); }
+    double phi() const final  { return m_state.phi(); }
     /// momentum polar angle                                                              
-    virtual double theta() const final  {  return m_state.theta(); }
+    double theta() const final  {  return m_state.theta(); }
     /// momentum pseudorapidity                                                           
-    virtual  double eta() const final  { return m_state.eta(); }
+     double eta() const final  { return m_state.eta(); }
     /// rapidity                                                                          
-    virtual double rapidity() const final  {  return m_state.rapidity(); }
+    double rapidity() const final  {  return m_state.rapidity(); }
     /// rapidity                                                                          
-    virtual double y() const final  { return rapidity(); }
+    double y() const final  { return rapidity(); }
     /// set 4-momentum                                                                    
-    virtual void setP4( const LorentzVector & p4 ) final  { m_state.setP4(p4);}
+    void setP4( const LorentzVector & p4 ) final  { m_state.setP4(p4);}
     /// set 4-momentum                                                                    
-    virtual void setP4( const PolarLorentzVector & p4 ) final  {m_state.setP4(p4); }
+    void setP4( const PolarLorentzVector & p4 ) final  {m_state.setP4(p4); }
     /// set particle mass                                                                 
-    virtual void setMass( double m ) final  {m_state.setMass(m);}
-    virtual void setPz( double pz ) final  { m_state.setPz(pz);}
+    void setMass( double m ) final  {m_state.setMass(m);}
+    void setPz( double pz ) final  { m_state.setPz(pz);}
     /// vertex position                 (overwritten by PF...)                                                  
-    virtual const Point & vertex() const { return m_state.vertex(); }
+    const Point & vertex() const override { return m_state.vertex(); }
     /// x coordinate of vertex position                                                   
-    virtual double vx() const  { return m_state.vx(); }
+    double vx() const override  { return m_state.vx(); }
     /// y coordinate of vertex position                                                   
-    virtual double vy() const  { return m_state.vy(); }
+    double vy() const override  { return m_state.vy(); }
     /// z coordinate of vertex position                                                   
-    virtual double vz() const  { return m_state.vz(); }
+    double vz() const override  { return m_state.vz(); }
     /// set vertex                                                                        
-    virtual void setVertex( const Point & vertex )   { m_state.setVertex(vertex); }
+    void setVertex( const Point & vertex ) override   { m_state.setVertex(vertex); }
 
     /// PDG identifier                                                                    
-    virtual int pdgId() const final  { return m_state.pdgId(); }
+    int pdgId() const final  { return m_state.pdgId(); }
     // set PDG identifier                                                                 
-    virtual void setPdgId( int pdgId ) final  { m_state.setPdgId(pdgId); }
+    void setPdgId( int pdgId ) final  { m_state.setPdgId(pdgId); }
     /// status word                                                                       
-    virtual int status() const final  { return m_state.status(); }
+    int status() const final  { return m_state.status(); }
     /// set status word                                                                   
-    virtual void setStatus( int status ) final  { m_state.setStatus(status); }
+    void setStatus( int status ) final  { m_state.setStatus(status); }
     /// long lived flag                                                                   
     /// set long lived flag                                                               
-    virtual void setLongLived() final  { m_state.setLongLived(); }
+    void setLongLived() final  { m_state.setLongLived(); }
     /// is long lived?                                                                    
-    virtual bool longLived() const final  { return m_state.longLived(); }
+    bool longLived() const final  { return m_state.longLived(); }
     /// do mass constraint flag
     /// set mass constraint flag
-    virtual void setMassConstraint() final  { m_state.setMassConstraint();}
+    void setMassConstraint() final  { m_state.setMassConstraint();}
     /// do mass constraint?
-    virtual bool massConstraint() const final  { return m_state.massConstraint(); }
+    bool massConstraint() const final  { return m_state.massConstraint(); }
 
     /// returns a clone of the Candidate object                                           
-    virtual LeafCandidate * clone() const  {
+    LeafCandidate * clone() const override  {
       return new LeafCandidate( *this );
     }
 
     /// chi-squares                                                                                                    
-    virtual double vertexChi2() const;
+    double vertexChi2() const override;
     /** Number of degrees of freedom                                                                                   
      *  Meant to be Double32_t for soft-assignment fitters:                                                            
      *  tracks may contribute to the vertex with fractional weights.                                                   
      *  The ndof is then = to the sum of the track weights.                                                            
      *  see e.g. CMS NOTE-2006/032, CMS NOTE-2004/002                                                                  
      */
-    virtual double vertexNdof() const;
+    double vertexNdof() const override;
     /// chi-squared divided by n.d.o.f.                                                                                
-    virtual double vertexNormalizedChi2() const;
+    double vertexNormalizedChi2() const override;
     /// (i, j)-th element of error matrix, i, j = 0, ... 2                                                             
-    virtual double vertexCovariance(int i, int j) const;
+    double vertexCovariance(int i, int j) const override;
     /// return SMatrix                                                                                                 
     CovarianceMatrix vertexCovariance() const final  { CovarianceMatrix m; fillVertexCovariance(m); return m; }
     /// fill SMatrix                                                                                                   
-    virtual void fillVertexCovariance(CovarianceMatrix & v) const;
+    void fillVertexCovariance(CovarianceMatrix & v) const override;
     /// returns true if this candidate has a reference to a master clone.                                              
     /// This only happens if the concrete Candidate type is ShallowCloneCandidate                                      
-    virtual bool hasMasterClone() const;
+    bool hasMasterClone() const override;
     /// returns ptr to master clone, if existing.                                                                      
     /// Throws an exception unless the concrete Candidate type is ShallowCloneCandidate                                
-    virtual const CandidateBaseRef & masterClone() const;
+    const CandidateBaseRef & masterClone() const override;
     /// returns true if this candidate has a ptr to a master clone.                                                    
     /// This only happens if the concrete Candidate type is ShallowClonePtrCandidate                                   
-    virtual bool hasMasterClonePtr() const;
+    bool hasMasterClonePtr() const override;
     /// returns ptr to master clone, if existing.                                                                      
     /// Throws an exception unless the concrete Candidate type is ShallowClonePtrCandidate                             
-    virtual const CandidatePtr & masterClonePtr() const;
+    const CandidatePtr & masterClonePtr() const override;
 
     /// cast master clone reference to a concrete type                                                                 
     template<typename Ref>
@@ -248,22 +248,22 @@ namespace reco {
 
 
 
-    virtual bool isElectron() const;
-    virtual bool isMuon() const;
-    virtual bool isStandAloneMuon() const;
-    virtual bool isGlobalMuon() const;
-    virtual bool isTrackerMuon() const;
-    virtual bool isCaloMuon() const;
-    virtual bool isPhoton() const;
-    virtual bool isConvertedPhoton() const;
-    virtual bool isJet() const;
+    bool isElectron() const override;
+    bool isMuon() const override;
+    bool isStandAloneMuon() const override;
+    bool isGlobalMuon() const override;
+    bool isTrackerMuon() const override;
+    bool isCaloMuon() const override;
+    bool isPhoton() const override;
+    bool isConvertedPhoton() const override;
+    bool isJet() const override;
 
   private:
     ParticleState m_state;
 
     private:
     /// check overlap with another Candidate                                              
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
     template<typename, typename, typename> friend struct component;
     friend class ::OverlapChecker;
     friend class ShallowCloneCandidate;

--- a/DataFormats/Candidate/interface/LeafRefCandidateT.h
+++ b/DataFormats/Candidate/interface/LeafRefCandidateT.h
@@ -40,7 +40,7 @@ namespace reco {
       LeafCandidate(c->charge(),PolarLorentzVector(c->pt(), c->eta(), c->phi(), m ),c->vertex()),
       ref_(c.refCore(), c.key()){}
     /// destructor
-    virtual ~LeafRefCandidateT() {}
+    ~LeafRefCandidateT() override {}
 
 protected:
     // get the ref (better be the correct ref!)
@@ -49,25 +49,25 @@ protected:
 
 public:
     /// number of daughters
-    virtual size_t numberOfDaughters() const final  { return 0; }
+    size_t numberOfDaughters() const final  { return 0; }
     /// return daughter at a given position (throws an exception)
-    virtual const Candidate * daughter( size_type ) const final  { return 0; }
+    const Candidate * daughter( size_type ) const final  { return nullptr; }
     /// number of mothers
-    virtual size_t numberOfMothers() const final  { return 0; }
+    size_t numberOfMothers() const final  { return 0; }
     /// return mother at a given position (throws an exception)
-    virtual const Candidate * mother( size_type ) const final  { return 0; }
+    const Candidate * mother( size_type ) const final  { return nullptr; }
     /// return daughter at a given position (throws an exception)
-    virtual Candidate * daughter( size_type ) final  { return 0; }
+    Candidate * daughter( size_type ) final  { return nullptr; }
     /// return daughter with a specified role name
-    virtual Candidate * daughter(const std::string& s ) final  { return 0; }
+    Candidate * daughter(const std::string& s ) final  { return nullptr; }
     /// return daughter with a specified role name                                        
-    virtual const Candidate * daughter(const std::string& s ) const final  { return 0; }
+    const Candidate * daughter(const std::string& s ) const final  { return nullptr; }
     /// return the number of source Candidates                                            
     /// ( the candidates used to construct this Candidate)                                
-    virtual size_t numberOfSourceCandidatePtrs() const final  { return 0;}
+    size_t numberOfSourceCandidatePtrs() const final  { return 0;}
     /// return a Ptr to one of the source Candidates                                      
     /// ( the candidates used to construct this Candidate)                                
-    virtual CandidatePtr sourceCandidatePtr( size_type i ) const final  {
+    CandidatePtr sourceCandidatePtr( size_type i ) const final  {
       static const CandidatePtr dummyPtr;
       return dummyPtr;
     }
@@ -75,18 +75,18 @@ public:
 
                      
     /// This only happens if the concrete Candidate type is ShallowCloneCandidate                                      
-    virtual bool hasMasterClone() const final  { return false; }
+    bool hasMasterClone() const final  { return false; }
     /// returns ptr to master clone, if existing.                                                                      
     /// Throws an exception unless the concrete Candidate type is ShallowCloneCandidate                                
-    virtual const CandidateBaseRef & masterClone() const final  { 
+    const CandidateBaseRef & masterClone() const final  { 
       static const CandidateBaseRef dummyRef; return dummyRef; 
     }
     /// returns true if this candidate has a ptr to a master clone.                                                    
     /// This only happens if the concrete Candidate type is ShallowClonePtrCandidate                                   
-    virtual bool hasMasterClonePtr() const final  { return false; }
+    bool hasMasterClonePtr() const final  { return false; }
     /// returns ptr to master clone, if existing.                                                                      
     /// Throws an exception unless the concrete Candidate type is ShallowClonePtrCandidate                             
-    virtual const CandidatePtr & masterClonePtr() const final  { 
+    const CandidatePtr & masterClonePtr() const final  { 
       static const CandidatePtr dummyPtr; return dummyPtr; 
     }
 
@@ -126,22 +126,22 @@ public:
     }
 
 
-    virtual bool isElectron() const final  { return false; }
-    virtual bool isMuon() const final  { return false; }
-    virtual bool isStandAloneMuon() const final  { return false; }
-    virtual bool isGlobalMuon() const final  { return false; }
-    virtual bool isTrackerMuon() const final  { return false; }
-    virtual bool isCaloMuon() const final  { return false; }
-    virtual bool isPhoton() const final  { return false; }
-    virtual bool isConvertedPhoton() const final  { return false; }
-    virtual bool isJet() const final  { return false; }
+    bool isElectron() const final  { return false; }
+    bool isMuon() const final  { return false; }
+    bool isStandAloneMuon() const final  { return false; }
+    bool isGlobalMuon() const final  { return false; }
+    bool isTrackerMuon() const final  { return false; }
+    bool isCaloMuon() const final  { return false; }
+    bool isPhoton() const final  { return false; }
+    bool isConvertedPhoton() const final  { return false; }
+    bool isJet() const final  { return false; }
 
     CMS_CLASS_VERSION(13)
 
   protected:
  
     /// check overlap with another Candidate                                              
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
     virtual bool overlap( const LeafRefCandidateT & ) const;
     template<typename, typename, typename> friend struct component;
     friend class ::OverlapChecker;

--- a/DataFormats/Candidate/interface/NamedCompositeCandidate.h
+++ b/DataFormats/Candidate/interface/NamedCompositeCandidate.h
@@ -40,9 +40,9 @@ namespace reco {
 			     const Candidate & p );
  
     /// destructor
-    virtual ~NamedCompositeCandidate();
+    ~NamedCompositeCandidate() override;
     /// returns a clone of the candidate
-    virtual NamedCompositeCandidate * clone() const;
+    NamedCompositeCandidate * clone() const override;
     // get name
     std::string             name() const { return name_; }
     // set name
@@ -52,11 +52,11 @@ namespace reco {
     // set roles
     void                    setRoles( const NamedCompositeCandidate::role_collection & roles ) { roles_.clear(); roles_ = roles; }
     // Get candidate based on role
-    virtual Candidate *       daughter(const std::string& s );
-    virtual const Candidate * daughter(const std::string& s ) const;
+    Candidate *       daughter(const std::string& s ) override;
+    const Candidate * daughter(const std::string& s ) const override;
     // Get candidate based on index
-    virtual Candidate *       daughter( size_type i ) { return CompositeCandidate::daughter(i); }
-    virtual const Candidate * daughter( size_type i ) const  { return CompositeCandidate::daughter(i); }
+    Candidate *       daughter( size_type i ) override { return CompositeCandidate::daughter(i); }
+    const Candidate * daughter( size_type i ) const override  { return CompositeCandidate::daughter(i); }
     // Add daughters
     void                    addDaughter( const Candidate &, const std::string&s );
     void                    addDaughter( std::unique_ptr<Candidate>, const std::string& s );

--- a/DataFormats/Candidate/interface/ShallowCloneCandidate.h
+++ b/DataFormats/Candidate/interface/ShallowCloneCandidate.h
@@ -34,37 +34,37 @@ namespace reco {
 			   Charge q, const PolarLorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ) ) : 
       LeafCandidate( q, p4, vtx ), masterClone_( masterClone ) { }
     /// destructor
-    virtual ~ShallowCloneCandidate();
+    ~ShallowCloneCandidate() override;
     /// returns a clone of the Candidate object
-    virtual ShallowCloneCandidate * clone() const;
+    ShallowCloneCandidate * clone() const override;
     /// number of daughters
-    virtual size_t numberOfDaughters() const;
+    size_t numberOfDaughters() const override;
     /// number of daughters
-    virtual size_t numberOfMothers() const;
+    size_t numberOfMothers() const override;
     /// return daughter at a given position (throws an exception)
-    virtual const Candidate * daughter( size_type i ) const;
+    const Candidate * daughter( size_type i ) const override;
     /// return daughter at a given position (throws an exception)
-    virtual const Candidate * mother( size_type i ) const;
+    const Candidate * mother( size_type i ) const override;
     /// return daughter at a given position (throws an exception)
-    virtual Candidate * daughter( size_type i );
+    Candidate * daughter( size_type i ) override;
     using reco::LeafCandidate::daughter; // avoid hiding the base
     /// has master clone
-    virtual bool hasMasterClone() const;
+    bool hasMasterClone() const override;
     /// returns reference to master clone
-    virtual const CandidateBaseRef & masterClone() const;
+    const CandidateBaseRef & masterClone() const override;
 
-    virtual bool isElectron() const;
-    virtual bool isMuon() const;
-    virtual bool isGlobalMuon() const;
-    virtual bool isStandAloneMuon() const;
-    virtual bool isTrackerMuon() const;
-    virtual bool isCaloMuon() const;
-    virtual bool isPhoton() const;
-    virtual bool isConvertedPhoton() const;
-    virtual bool isJet() const;
+    bool isElectron() const override;
+    bool isMuon() const override;
+    bool isGlobalMuon() const override;
+    bool isStandAloneMuon() const override;
+    bool isTrackerMuon() const override;
+    bool isCaloMuon() const override;
+    bool isPhoton() const override;
+    bool isConvertedPhoton() const override;
+    bool isJet() const override;
   private:
     /// check overlap with another Candidate
-    virtual bool overlap( const Candidate & c ) const { return masterClone_->overlap( c ); }
+    bool overlap( const Candidate & c ) const override { return masterClone_->overlap( c ); }
     /// CandidateBaseReference to master clone
     CandidateBaseRef masterClone_;
   };

--- a/DataFormats/Candidate/interface/ShallowClonePtrCandidate.h
+++ b/DataFormats/Candidate/interface/ShallowClonePtrCandidate.h
@@ -32,38 +32,38 @@ namespace reco {
 			   Charge q, const PolarLorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ) ) : 
       LeafCandidate( q, p4, vtx ), masterClone_( masterClone ) { }
     /// destructor
-    virtual ~ShallowClonePtrCandidate();
+    ~ShallowClonePtrCandidate() override;
     /// returns a clone of the Candidate object
-    virtual ShallowClonePtrCandidate * clone() const;
+    ShallowClonePtrCandidate * clone() const override;
     /// number of daughters
-    virtual size_t numberOfDaughters() const;
+    size_t numberOfDaughters() const override;
     /// number of mothers
-    virtual size_t numberOfMothers() const;
+    size_t numberOfMothers() const override;
     /// return daughter at a given position (throws an exception)
-    virtual const Candidate * daughter( size_type i ) const;
+    const Candidate * daughter( size_type i ) const override;
     /// return mother at a given position (throws an exception)
-    virtual const Candidate * mother( size_type i ) const;
+    const Candidate * mother( size_type i ) const override;
     /// return daughter at a given position (throws an exception)
-    virtual Candidate * daughter( size_type i );
+    Candidate * daughter( size_type i ) override;
     using reco::LeafCandidate::daughter; // avoid hiding the base
     /// has master clone pointer
-    virtual bool hasMasterClonePtr() const;
+    bool hasMasterClonePtr() const override;
     /// returns reference to master clone pointer
-    virtual const CandidatePtr & masterClonePtr() const;
+    const CandidatePtr & masterClonePtr() const override;
 
 
-    virtual bool isElectron() const;
-    virtual bool isMuon() const;
-    virtual bool isGlobalMuon() const;
-    virtual bool isStandAloneMuon() const;
-    virtual bool isTrackerMuon() const;
-    virtual bool isCaloMuon() const;
-    virtual bool isPhoton() const;
-    virtual bool isConvertedPhoton() const;
-    virtual bool isJet() const;
+    bool isElectron() const override;
+    bool isMuon() const override;
+    bool isGlobalMuon() const override;
+    bool isStandAloneMuon() const override;
+    bool isTrackerMuon() const override;
+    bool isCaloMuon() const override;
+    bool isPhoton() const override;
+    bool isConvertedPhoton() const override;
+    bool isJet() const override;
   private:
     /// check overlap with another Candidate
-    virtual bool overlap( const Candidate & c ) const { return masterClone_->overlap( c ); }
+    bool overlap( const Candidate & c ) const override { return masterClone_->overlap( c ); }
     /// CandidatePtrerence to master clone
     CandidatePtr masterClone_;
   };

--- a/DataFormats/Candidate/interface/VertexCompositeCandidate.h
+++ b/DataFormats/Candidate/interface/VertexCompositeCandidate.h
@@ -32,27 +32,27 @@ namespace reco {
     explicit VertexCompositeCandidate(const CompositeCandidate & p) :
       CompositeCandidate(p), chi2_(0), ndof_(0) { }
     /// destructor
-    virtual ~VertexCompositeCandidate();
+    ~VertexCompositeCandidate() override;
     /// returns a clone of the candidate
-    virtual VertexCompositeCandidate * clone() const;
+    VertexCompositeCandidate * clone() const override;
     /// chi-squares
-    virtual double vertexChi2() const { return chi2_; }
+    double vertexChi2() const override { return chi2_; }
     /** Number of degrees of freedom
      *  Meant to be Double32_t for soft-assignment fitters: 
      *  tracks may contribute to the vertex with fractional weights.
      *  The ndof is then = to the sum of the track weights.
      *  see e.g. CMS NOTE-2006/032, CMS NOTE-2004/002
      */
-    virtual double vertexNdof() const { return ndof_; }
+    double vertexNdof() const override { return ndof_; }
     /// chi-squared divided by n.d.o.f.
-    virtual double vertexNormalizedChi2() const { return chi2_ / ndof_; }
+    double vertexNormalizedChi2() const override { return chi2_ / ndof_; }
     /// (i, j)-th element of error matrix, i, j = 0, ... 2
-    virtual double vertexCovariance(int i, int j) const { 
+    double vertexCovariance(int i, int j) const override { 
       return covariance_[idx(i, j)]; 
     }
     using reco::LeafCandidate::vertexCovariance; // avoid hiding the
     /// fill SMatrix
-    virtual void fillVertexCovariance(CovarianceMatrix & v) const;
+    void fillVertexCovariance(CovarianceMatrix & v) const override;
     /// set chi2 and ndof
     void setChi2AndNdof(double chi2, double ndof) {
       chi2_ = chi2; ndof_ = ndof;

--- a/DataFormats/Candidate/interface/const_iterator.h
+++ b/DataFormats/Candidate/interface/const_iterator.h
@@ -17,7 +17,7 @@ namespace reco {
       typedef const Candidate & reference;
       typedef ptrdiff_t difference_type;
       typedef std::vector<int>::const_iterator::iterator_category iterator_category;
-      const_iterator() : me(0), i( 0 ) { }
+      const_iterator() : me(nullptr), i( 0 ) { }
       const_iterator(pointer ime, difference_type ii ) : me(ime), i(ii) { }
       const_iterator(const iterator & it) : me(it.me), i(it.i) { }
       const_iterator & operator=( const iterator & it ) { me = it.me; i=it.i;  return *this; }

--- a/DataFormats/Candidate/interface/iterator.h
+++ b/DataFormats/Candidate/interface/iterator.h
@@ -17,7 +17,7 @@ namespace reco {
       typedef Candidate & reference;
       typedef ptrdiff_t difference_type;
       typedef std::vector<int>::iterator::iterator_category iterator_category;
-      iterator() : me(0), i( 0 ) { }
+      iterator() : me(nullptr), i( 0 ) { }
       iterator(pointer ime, difference_type ii ) : me(ime), i(ii) { }
       iterator& operator++() { ++i; return *this; }
       iterator operator++( int ) { iterator ci = *this; ++i; return ci; }

--- a/DataFormats/Candidate/src/CompositeCandidate.cc
+++ b/DataFormats/Candidate/src/CompositeCandidate.cc
@@ -32,16 +32,16 @@ CompositeCandidate::~CompositeCandidate() { }
 CompositeCandidate * CompositeCandidate::clone() const { return new CompositeCandidate(* this); }
 
 const Candidate * CompositeCandidate::daughter(size_type i) const { 
-  return (i < numberOfDaughters()) ? & dau[ i ] : 0; // i >= 0, since i is unsigned
+  return (i < numberOfDaughters()) ? & dau[ i ] : nullptr; // i >= 0, since i is unsigned
 }
 
 Candidate * CompositeCandidate::daughter(size_type i) { 
-  Candidate * d = (i < numberOfDaughters()) ? & dau[ i ] : 0; // i >= 0, since i is unsigned
+  Candidate * d = (i < numberOfDaughters()) ? & dau[ i ] : nullptr; // i >= 0, since i is unsigned
   return d;
 }
 
 const Candidate * CompositeCandidate::mother(size_type i) const { 
-  return 0;
+  return nullptr;
 }
 
 size_t CompositeCandidate::numberOfDaughters() const { return dau.size(); }
@@ -54,7 +54,7 @@ bool CompositeCandidate::overlap(const Candidate & c2) const {
 
 void CompositeCandidate::applyRoles() {
 
-  if (roles_.size() == 0)
+  if (roles_.empty())
     return;
 
   // Check if there are the same number of daughters and roles
@@ -70,7 +70,7 @@ void CompositeCandidate::applyRoles() {
     Candidate * c = CompositeCandidate::daughter(i);
 
     CompositeCandidate * c1 = dynamic_cast<CompositeCandidate *>(c);
-    if (c1 != 0) {
+    if (c1 != nullptr) {
       c1->setName(role);
     }
   }
@@ -126,7 +126,7 @@ void CompositeCandidate::addDaughter(const Candidate & cand, const std::string& 
     }
     roles_.push_back(s);
     CompositeCandidate * c1 = dynamic_cast<CompositeCandidate*>(&*c);
-    if (c1 != 0) {
+    if (c1 != nullptr) {
       c1->setName(s);
     }
   }
@@ -144,7 +144,7 @@ void CompositeCandidate::addDaughter(std::unique_ptr<Candidate> cand, const std:
     }
     roles_.push_back(s);  
     CompositeCandidate * c1 = dynamic_cast<CompositeCandidate*>(&*cand);
-    if (c1 != 0) {
+    if (c1 != nullptr) {
       c1->setName(s);
     }
   }

--- a/DataFormats/Candidate/src/CompositePtrCandidate.cc
+++ b/DataFormats/Candidate/src/CompositePtrCandidate.cc
@@ -11,15 +11,15 @@ CompositePtrCandidate * CompositePtrCandidate::clone() const {
 }
 
 const Candidate * CompositePtrCandidate::daughter( size_type i ) const { 
-  return ( i < numberOfDaughters() ) ? & * dau[ i ] : 0; // i >= 0, since i is unsigned
+  return ( i < numberOfDaughters() ) ? & * dau[ i ] : nullptr; // i >= 0, since i is unsigned
 }
 
 const Candidate * CompositePtrCandidate::mother( size_type i ) const { 
-  return 0;
+  return nullptr;
 }
 
 Candidate * CompositePtrCandidate::daughter( size_type i ) { 
-  return 0;
+  return nullptr;
 }
 
 size_t CompositePtrCandidate::numberOfDaughters() const { 

--- a/DataFormats/Candidate/src/CompositeRefBaseCandidate.cc
+++ b/DataFormats/Candidate/src/CompositeRefBaseCandidate.cc
@@ -11,15 +11,15 @@ CompositeRefBaseCandidate * CompositeRefBaseCandidate::clone() const {
 }
 
 const Candidate * CompositeRefBaseCandidate::daughter( size_type i ) const { 
-  return ( i < numberOfDaughters() ) ? & * dau[ i ] : 0; // i >= 0, since i is unsigned
+  return ( i < numberOfDaughters() ) ? & * dau[ i ] : nullptr; // i >= 0, since i is unsigned
 }
 
 const Candidate * CompositeRefBaseCandidate::mother( size_type i ) const { 
- return 0;
+ return nullptr;
 }
 
 Candidate * CompositeRefBaseCandidate::daughter( size_type i ) { 
-  return 0;
+  return nullptr;
 }
 
 size_t CompositeRefBaseCandidate::numberOfDaughters() const { 

--- a/DataFormats/Candidate/src/CompositeRefCandidate.cc
+++ b/DataFormats/Candidate/src/CompositeRefCandidate.cc
@@ -11,15 +11,15 @@ CompositeRefCandidate * CompositeRefCandidate::clone() const {
 }
 
 const Candidate * CompositeRefCandidate::daughter( size_type i ) const { 
-  return ( i < numberOfDaughters() ) ? & * dau[ i ] : 0; // i >= 0, since i is unsigned
+  return ( i < numberOfDaughters() ) ? & * dau[ i ] : nullptr; // i >= 0, since i is unsigned
 }
 
 const Candidate * CompositeRefCandidate::mother( size_type i ) const { 
-  return ( i < numberOfMothers() ) ? & * mom[ i ] : 0; // i >= 0, since i is unsigned
+  return ( i < numberOfMothers() ) ? & * mom[ i ] : nullptr; // i >= 0, since i is unsigned
 }
 
 Candidate * CompositeRefCandidate::daughter( size_type i ) { 
-  return 0;
+  return nullptr;
 }
 
 size_t CompositeRefCandidate::numberOfDaughters() const { 

--- a/DataFormats/Candidate/src/LeafCandidate.cc
+++ b/DataFormats/Candidate/src/LeafCandidate.cc
@@ -38,11 +38,11 @@ bool LeafCandidate::overlap( const Candidate & o ) const {
 }
 
 const Candidate * LeafCandidate::daughter( size_type ) const {
-  return 0;
+  return nullptr;
 }
 
 const Candidate * LeafCandidate::mother( size_type ) const {
-  return 0;
+  return nullptr;
 }
 
 const Candidate * LeafCandidate::daughter(const std::string&) const {
@@ -60,7 +60,7 @@ Candidate * LeafCandidate::daughter(const std::string&) {
 
 
 Candidate * LeafCandidate::daughter( size_type ) {
-  return 0;
+  return nullptr;
 }
 
 double LeafCandidate::vertexChi2() const {

--- a/DataFormats/Candidate/src/NamedCompositeCandidate.cc
+++ b/DataFormats/Candidate/src/NamedCompositeCandidate.cc
@@ -43,7 +43,7 @@ void NamedCompositeCandidate::applyRoles()
     Candidate * c = CompositeCandidate::daughter( i );
 
     NamedCompositeCandidate * c1 = dynamic_cast<NamedCompositeCandidate *>(c);
-    if ( c1 != 0 ) {
+    if ( c1 != nullptr ) {
       c1->setName( role );
     }
   }
@@ -103,7 +103,7 @@ void NamedCompositeCandidate::addDaughter( const Candidate & cand, const std::st
   roles_.push_back( s );
   std::unique_ptr<Candidate> c( cand.clone() );
   NamedCompositeCandidate * c1 =  dynamic_cast<NamedCompositeCandidate*>(&*c);
-  if ( c1 != 0 ) {
+  if ( c1 != nullptr ) {
     c1->setName( s );
   }
   CompositeCandidate::addDaughter( std::move(c) );
@@ -121,7 +121,7 @@ void NamedCompositeCandidate::addDaughter( std::unique_ptr<Candidate> cand, cons
 
   roles_.push_back( s );
   NamedCompositeCandidate * c1 = dynamic_cast<NamedCompositeCandidate*>(&*cand);
-  if ( c1 != 0 ) {
+  if ( c1 != nullptr ) {
     c1->setName( s );
   }
   CompositeCandidate::addDaughter( std::move(cand) );

--- a/DataFormats/Candidate/src/ShallowCloneCandidate.cc
+++ b/DataFormats/Candidate/src/ShallowCloneCandidate.cc
@@ -25,7 +25,7 @@ const Candidate * ShallowCloneCandidate::mother( size_type i ) const {
 }
 
 Candidate * ShallowCloneCandidate::daughter( size_type i ) { 
-  return 0;
+  return nullptr;
 }
 
 bool ShallowCloneCandidate::hasMasterClone() const {

--- a/DataFormats/Candidate/src/ShallowClonePtrCandidate.cc
+++ b/DataFormats/Candidate/src/ShallowClonePtrCandidate.cc
@@ -25,7 +25,7 @@ const Candidate * ShallowClonePtrCandidate::mother( size_type i ) const {
 }
 
 Candidate * ShallowClonePtrCandidate::daughter( size_type i ) { 
-  return 0;
+  return nullptr;
 }
 
 bool ShallowClonePtrCandidate::hasMasterClonePtr() const {

--- a/DataFormats/CastorReco/interface/CastorEgamma.h
+++ b/DataFormats/CastorReco/interface/CastorEgamma.h
@@ -24,7 +24,7 @@ namespace reco {
     CastorEgamma(const double energycal, const CastorClusterRef& usedCluster);
 
     /// destructor
-    virtual ~CastorEgamma();
+    ~CastorEgamma() override;
 
     /// Egamma energy
     double energy() const { return (*usedCluster_).energy(); }

--- a/DataFormats/CastorReco/interface/CastorJet.h
+++ b/DataFormats/CastorReco/interface/CastorJet.h
@@ -24,7 +24,7 @@ namespace reco {
     CastorJet(const double energycal, const CastorClusterRef& usedCluster);
 
     /// destructor
-    virtual ~CastorJet();
+    ~CastorJet() override;
 
     /// Jet energy
     double energy() const { return (*usedCluster_).energy(); }

--- a/DataFormats/CastorReco/interface/CastorTower.h
+++ b/DataFormats/CastorReco/interface/CastorTower.h
@@ -39,7 +39,7 @@ namespace reco {
 		const double depth, const double fhot, const CastorRecHitRefs& usedRecHits);
 
     /// destructor
-    virtual ~CastorTower();
+    ~CastorTower() override;
 
     /// tower centroid position
     ROOT::Math::XYZPoint position() const { return position_; }

--- a/DataFormats/Common/interface/AssociationVector.h
+++ b/DataFormats/Common/interface/AssociationVector.h
@@ -72,7 +72,7 @@ namespace edm {
     typedef std::vector<value_type> transient_vector_type;
     typedef value_type const& const_reference;
     AssociationVector();
-    AssociationVector(KeyRefProd const& ref, CKey const* = 0);
+    AssociationVector(KeyRefProd const& ref, CKey const* = nullptr);
     AssociationVector(AssociationVector const&);
     ~AssociationVector();
 
@@ -130,8 +130,8 @@ namespace edm {
   template<typename KeyRefProd, typename CVal, typename KeyRef, typename SizeType, typename KeyReferenceHelper>
   inline AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::AssociationVector(KeyRefProd const& ref,
 												      CKey const* coll) :
-    data_(coll == 0 ? ref->size() : coll->size()), ref_(ref),
-    transientVector_( new transient_vector_type(coll == 0 ? ref->size() : coll->size())) { }
+    data_(coll == nullptr ? ref->size() : coll->size()), ref_(ref),
+    transientVector_( new transient_vector_type(coll == nullptr ? ref->size() : coll->size())) { }
 
   template<typename KeyRefProd, typename CVal, typename KeyRef, typename SizeType, typename KeyReferenceHelper>
   inline AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::

--- a/DataFormats/Common/interface/ContainerMaskTraits.h
+++ b/DataFormats/Common/interface/ContainerMaskTraits.h
@@ -37,10 +37,10 @@ namespace edm {
       
    private:
       //virtual ~ContainerMaskTraits();
-      ContainerMaskTraits();
-      ContainerMaskTraits(const ContainerMaskTraits&); // stop default
+      ContainerMaskTraits() = delete;
+      ContainerMaskTraits(const ContainerMaskTraits&) = delete; // stop default
 
-      const ContainerMaskTraits& operator=(const ContainerMaskTraits&); // stop default
+      const ContainerMaskTraits& operator=(const ContainerMaskTraits&) = delete; // stop default
 
       // ---------- member data --------------------------------
 

--- a/DataFormats/Common/interface/DataFrame.h
+++ b/DataFormats/Common/interface/DataFrame.h
@@ -23,7 +23,7 @@ namespace edm {
     
     
     inline
-    DataFrame() : m_id(0), m_data(0), m_size(0){}
+    DataFrame() : m_id(0), m_data(nullptr), m_size(0){}
     inline
     DataFrame(id_type i, data_type const * idata, size_type isize) :
       m_id(i), m_data(idata), m_size(isize) {}

--- a/DataFormats/Common/interface/DataFrameContainer.h
+++ b/DataFormats/Common/interface/DataFrameContainer.h
@@ -8,7 +8,7 @@
 
 #include<vector>
 #include<algorithm>
-#include <stddef.h> // for size_t
+#include <cstddef> // for size_t
 #include <utility> // for pair
 
 class TestDataFrame;

--- a/DataFormats/Common/interface/DetSet.h
+++ b/DataFormats/Common/interface/DetSet.h
@@ -12,8 +12,8 @@ own copy of the common DetId.
 ----------------------------------------------------------------------*/
 
 #include <vector>
-#include <stdint.h>
-#include <stddef.h>
+#include <cstdint>
+#include <cstddef>
 #include "DataFormats/Common/interface/CMS_CLASS_VERSION.h"
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
 

--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -310,7 +310,7 @@ namespace edmNew {
       }
       ~TSFastFiller() {
         bool expected=false;
-        while (!m_v.m_filling.compare_exchange_weak(expected,true))  { expected=false; nanosleep(0,0);}
+        while (!m_v.m_filling.compare_exchange_weak(expected,true))  { expected=false; nanosleep(nullptr,nullptr);}
         int offset = m_v.m_data.size();
         if (m_v.onDemand() && full()) {
           m_v.m_filling = false;
@@ -385,7 +385,7 @@ namespace edmNew {
 #ifdef DSVN_USE_ATOMIC
       {
         bool expected=false;
-        while (!iContainer.m_filling.compare_exchange_weak(expected,true,std::memory_order_acq_rel))  { expected=false; nanosleep(0,0);}
+        while (!iContainer.m_filling.compare_exchange_weak(expected,true,std::memory_order_acq_rel))  { expected=false; nanosleep(nullptr,nullptr);}
         typename self::result_type item =  &(iContainer.m_data[iIndex]);
         assert(iContainer.m_filling==true);
         iContainer.m_filling = false;
@@ -673,7 +673,7 @@ namespace edmNew {
 			     typename Container::Item const & item, bool update) {
     // if an item is being updated we wait
     if (update) icont.update(item);
-    while(item.initializing()) nanosleep(0,0);
+    while(item.initializing()) nanosleep(nullptr,nullptr);
     m_data=&icont.data();
     m_id=item.id; 
     m_offset = item.offset; 

--- a/DataFormats/Common/interface/FwdPtr.h
+++ b/DataFormats/Common/interface/FwdPtr.h
@@ -115,7 +115,7 @@ namespace edm {
     RefCore const& refCore() const {return ptr_.isNonnull() ? ptr_.refCore() : backPtr_.refCore() ;}
     // ---------- member functions ---------------------------
     
-    void const* product() const {return 0;}
+    void const* product() const {return nullptr;}
     
     Ptr<value_type> const& ptr() const { return ptr_;}
     Ptr<value_type> const& backPtr() const { return backPtr_;}

--- a/DataFormats/Common/interface/Holder.h
+++ b/DataFormats/Common/interface/Holder.h
@@ -21,29 +21,29 @@ namespace edm {
       explicit Holder(REF const& iRef);
       Holder& operator= (Holder const& rhs);
       void swap(Holder& other);
-      virtual ~Holder();
-      virtual BaseHolder<T>* clone() const override;
+      ~Holder() override;
+      BaseHolder<T>* clone() const override;
 
-      virtual T const* getPtr() const override;
-      virtual ProductID id() const override;
-      virtual size_t key() const override;
-      virtual bool isEqualTo(BaseHolder<T> const& rhs) const override;
+      T const* getPtr() const override;
+      ProductID id() const override;
+      size_t key() const override;
+      bool isEqualTo(BaseHolder<T> const& rhs) const override;
       REF const& getRef() const;
 
-      virtual bool fillRefIfMyTypeMatches(RefHolderBase& fillme,
+      bool fillRefIfMyTypeMatches(RefHolderBase& fillme,
 					  std::string& msg) const override;
 
-      virtual std::unique_ptr<RefHolderBase> holder() const override {
+      std::unique_ptr<RefHolderBase> holder() const override {
 	return std::unique_ptr<RefHolderBase>( new RefHolder<REF>( ref_ ) );
       }
-      virtual std::unique_ptr<BaseVectorHolder<T> > makeVectorHolder() const override;
-      virtual EDProductGetter const* productGetter() const override;
+      std::unique_ptr<BaseVectorHolder<T> > makeVectorHolder() const override;
+      EDProductGetter const* productGetter() const override;
 
       /// Checks if product collection is in memory or available
       /// in the Event. No type checking is done.
-      virtual bool isAvailable() const override { return ref_.isAvailable(); }
+      bool isAvailable() const override { return ref_.isAvailable(); }
 
-      virtual bool isTransient() const override { return ref_.isTransient(); }
+      bool isTransient() const override { return ref_.isTransient(); }
 
       //Used by ROOT storage
       CMS_CLASS_VERSION(10)
@@ -152,7 +152,7 @@ namespace edm {
 					  std::string& msg) const
     {
       RefHolder<REF>* h = dynamic_cast<RefHolder<REF>*>(&fillme);
-      bool conversion_worked = (h != 0);
+      bool conversion_worked = (h != nullptr);
 
       if (conversion_worked)
  	h->setRef(ref_);

--- a/DataFormats/Common/interface/IndirectHolder.h
+++ b/DataFormats/Common/interface/IndirectHolder.h
@@ -33,25 +33,25 @@ namespace edm {
       IndirectHolder(IndirectHolder const& other);
       IndirectHolder& operator= (IndirectHolder const& rhs);
       void swap(IndirectHolder& other);
-      virtual ~IndirectHolder();
+      ~IndirectHolder() override;
       
-      virtual BaseHolder<T>* clone() const override;
-      virtual T const* getPtr() const override;
-      virtual ProductID id() const override;
-      virtual size_t key() const override;
-      virtual bool isEqualTo(BaseHolder<T> const& rhs) const override;
+      BaseHolder<T>* clone() const override;
+      T const* getPtr() const override;
+      ProductID id() const override;
+      size_t key() const override;
+      bool isEqualTo(BaseHolder<T> const& rhs) const override;
 
-      virtual bool fillRefIfMyTypeMatches(RefHolderBase& fillme,
+      bool fillRefIfMyTypeMatches(RefHolderBase& fillme,
 					  std::string& msg) const override;
-      virtual std::unique_ptr<RefHolderBase> holder() const override;
-      virtual std::unique_ptr<BaseVectorHolder<T> > makeVectorHolder() const override;
-      virtual EDProductGetter const* productGetter() const override;
+      std::unique_ptr<RefHolderBase> holder() const override;
+      std::unique_ptr<BaseVectorHolder<T> > makeVectorHolder() const override;
+      EDProductGetter const* productGetter() const override;
 
       /// Checks if product collection is in memory or available
       /// in the Event. No type checking is done.
-      virtual bool isAvailable() const override { return helper_->isAvailable(); }
+      bool isAvailable() const override { return helper_->isAvailable(); }
 
-      virtual bool isTransient() const override { return helper_->isTransient(); }
+      bool isTransient() const override { return helper_->isTransient(); }
 
       //Used by ROOT storage
       CMS_CLASS_VERSION(10)

--- a/DataFormats/Common/interface/IndirectVectorHolder.h
+++ b/DataFormats/Common/interface/IndirectVectorHolder.h
@@ -22,24 +22,24 @@ namespace edm {
       IndirectVectorHolder( const IndirectVectorHolder & other);
       IndirectVectorHolder(std::shared_ptr<RefVectorHolderBase> p);
       IndirectVectorHolder(RefVectorHolderBase * p);
-      virtual ~IndirectVectorHolder();
+      ~IndirectVectorHolder() override;
       IndirectVectorHolder& operator= (IndirectVectorHolder const& rhs);
       void swap(IndirectVectorHolder& other);
-      virtual BaseVectorHolder<T>* clone() const override;
-      virtual BaseVectorHolder<T>* cloneEmpty() const override;
-      virtual ProductID id() const override;
-      virtual EDProductGetter const* productGetter() const override;
-      virtual bool empty() const override;
-      virtual size_type size() const override;
-      virtual void clear() override;
-      virtual base_ref_type const at(size_type idx) const override;
-      virtual std::unique_ptr<reftobase::RefVectorHolderBase> vectorHolder() const override {
+      BaseVectorHolder<T>* clone() const override;
+      BaseVectorHolder<T>* cloneEmpty() const override;
+      ProductID id() const override;
+      EDProductGetter const* productGetter() const override;
+      bool empty() const override;
+      size_type size() const override;
+      void clear() override;
+      base_ref_type const at(size_type idx) const override;
+      std::unique_ptr<reftobase::RefVectorHolderBase> vectorHolder() const override {
 	return std::unique_ptr<reftobase::RefVectorHolderBase>( helper_->clone() );
       }
-      virtual void push_back( const BaseHolder<T> * r ) override {
+      void push_back( const BaseHolder<T> * r ) override {
 	typedef IndirectHolder<T> holder_type;
 	const holder_type * h = dynamic_cast<const holder_type *>( r );
-	if( h == 0 )
+	if( h == nullptr )
 	  Exception::throwThis( errors::InvalidReference,
 	    "In IndirectHolder<T> trying to push_back wrong reference type");
 	helper_->push_back( h->helper_ );
@@ -47,7 +47,7 @@ namespace edm {
 
       /// Checks if product collection is in memory or available
       /// in the Event. No type checking is done.
-      virtual bool isAvailable() const override { return helper_->isAvailable(); }
+      bool isAvailable() const override { return helper_->isAvailable(); }
 
       //Used by ROOT storage
       CMS_CLASS_VERSION(10)
@@ -61,27 +61,27 @@ namespace edm {
 	typedef ptrdiff_t difference_type;
 	const_iterator_imp_specific() { }
 	explicit const_iterator_imp_specific( const typename RefVectorHolderBase::const_iterator & it ) : i ( it ) { }
-	~const_iterator_imp_specific() { }
-	const_iterator_imp_specific * clone() const { return new const_iterator_imp_specific( i ); }
-	void increase() { ++i; }
-	void decrease() { --i; }
-	void increase( difference_type d ) { i += d; }
-	void decrease( difference_type d ) { i -= d; }
-	bool equal_to( const const_iterator_imp * o ) const { return i == dc( o ); }
-	bool less_than( const const_iterator_imp * o ) const { return i < dc( o ); }
-	void assign( const const_iterator_imp * o ) { i = dc( o ); }
-	base_ref_type deref() const {
+	~const_iterator_imp_specific() override { }
+	const_iterator_imp_specific * clone() const override { return new const_iterator_imp_specific( i ); }
+	void increase() override { ++i; }
+	void decrease() override { --i; }
+	void increase( difference_type d ) override { i += d; }
+	void decrease( difference_type d ) override { i -= d; }
+	bool equal_to( const const_iterator_imp * o ) const override { return i == dc( o ); }
+	bool less_than( const const_iterator_imp * o ) const override { return i < dc( o ); }
+	void assign( const const_iterator_imp * o ) override { i = dc( o ); }
+	base_ref_type deref() const override {
 	  return base_ref_type( * i );
 	}
-	difference_type difference( const const_iterator_imp * o ) const { return i - dc( o ); }
+	difference_type difference( const const_iterator_imp * o ) const override { return i - dc( o ); }
       private:
 	const typename RefVectorHolderBase::const_iterator & dc( const const_iterator_imp * o ) const {
-	  if ( o == 0 ) {
+	  if ( o == nullptr ) {
 	    Exception::throwThis( edm::errors::InvalidReference,
 	      "In IndirectVectorHolder trying to dereference a null pointer");
 	  }
 	  const const_iterator_imp_specific * oo = dynamic_cast<const const_iterator_imp_specific *>( o );
-	  if ( oo == 0 ) {
+	  if ( oo == nullptr ) {
 	    Exception::throwThis( errors::InvalidReference,
 	      "In IndirectVectorHolder trying to cast iterator to wrong type ");
 	  }

--- a/DataFormats/Common/interface/OwnVector.h
+++ b/DataFormats/Common/interface/OwnVector.h
@@ -292,7 +292,7 @@ namespace edm {
     // able to bind to an lvalue.
     // This should be called only for lvalues.
     data_.push_back(d);
-    d = 0;
+    d = nullptr;
   }
 
   template<typename T, typename P>

--- a/DataFormats/Common/interface/Ptr.h
+++ b/DataFormats/Common/interface/Ptr.h
@@ -47,7 +47,7 @@ namespace edm {
     // General purpose constructor from handle.
     template<typename C>
     Ptr(Handle<C> const& handle, key_type itemKey, bool /*setNow*/ = true):
-    core_(handle.id(), getItem_(handle.product(), itemKey), 0, false), key_(itemKey) {}
+    core_(handle.id(), getItem_(handle.product(), itemKey), nullptr, false), key_(itemKey) {}
 
     // General purpose constructor from orphan handle.
     template<typename C>
@@ -68,8 +68,8 @@ namespace edm {
 
     template<typename C>
     Ptr(C const* iProduct, key_type iItemKey, bool /*setNow*/ = true):
-      core_(ProductID(), iProduct != 0 ? getItem_(iProduct,iItemKey) : 0, 0, true),
-      key_(iProduct != 0 ? iItemKey : key_traits<key_type>::value) {}
+      core_(ProductID(), iProduct != nullptr ? getItem_(iProduct,iItemKey) : nullptr, nullptr, true),
+      key_(iProduct != nullptr ? iItemKey : key_traits<key_type>::value) {}
 
     Ptr(T const* item, key_type iItemKey):
       core_(ProductID(), item, nullptr, true),
@@ -86,7 +86,7 @@ namespace edm {
      but have a pointer to a product getter (such as the EventPrincipal).
      prodGetter will ususally be a pointer to the event principal. */
     Ptr(ProductID const& productID, key_type itemKey, EDProductGetter const* prodGetter) :
-    core_(productID, 0, mustBeNonZero(prodGetter, "Ptr", productID), false), key_(itemKey) {
+    core_(productID, nullptr, mustBeNonZero(prodGetter, "Ptr", productID), false), key_(itemKey) {
     }
 
     /** Constructor for use in the various X::fillView(...) functions
@@ -97,7 +97,7 @@ namespace edm {
      Event. The given ProductID must be the id of the collection
      in the Event. */
     Ptr(ProductID const& productID, T const* item, key_type item_key) :
-    core_(productID, item, 0, false),
+    core_(productID, item, nullptr, false),
     key_(item_key) {
     }
 
@@ -111,7 +111,7 @@ namespace edm {
      ProductID). */
 
     explicit Ptr(ProductID const& iId) :
-    core_(iId, 0, 0, false),
+    core_(iId, nullptr, nullptr, false),
     key_(key_traits<key_type>::value)
     { }
 
@@ -121,9 +121,9 @@ namespace edm {
     {}
 
     template<typename U>
-    Ptr(Ptr<U> const& iOther, std::enable_if_t<std::is_base_of<T, U>::value> * = 0):
+    Ptr(Ptr<U> const& iOther, std::enable_if_t<std::is_base_of<T, U>::value> * = nullptr):
     core_(iOther.id(),
-          (iOther.hasProductCache() ? static_cast<T const*>(iOther.get()): static_cast<T const*>(0)),
+          (iOther.hasProductCache() ? static_cast<T const*>(iOther.get()): static_cast<T const*>(nullptr)),
           iOther.productGetter(),
           iOther.isTransient()),
     key_(iOther.key()) {
@@ -157,7 +157,7 @@ namespace edm {
 
     /// Returns C++ pointer to the item
     T const* get() const {
-      return isNull() ? 0 : this->operator->();
+      return isNull() ? nullptr : this->operator->();
     }
 
     /// Checks for null
@@ -189,7 +189,7 @@ namespace edm {
     RefCore const& refCore() const {return core_;}
     // ---------- member functions ---------------------------
 
-    void const* product() const {return 0;}
+    void const* product() const {return nullptr;}
 
     //Used by ROOT storage
     CMS_CLASS_VERSION(10)
@@ -227,7 +227,7 @@ namespace edm {
   template<typename T>
   template<typename C>
   T const* Ptr<T>::getItem_(C const* iProduct, key_type iKey) {
-    assert (iProduct != 0);
+    assert (iProduct != nullptr);
     typename C::const_iterator it = iProduct->begin();
     std::advance(it,iKey);
     T const* address = detail::GetProduct<C>::address(it);

--- a/DataFormats/Common/interface/PtrVector.h
+++ b/DataFormats/Common/interface/PtrVector.h
@@ -140,7 +140,7 @@ namespace edm {
     void push_back(Ptr<T> const& iPtr) {
       this->push_back_base(iPtr.refCore(),
                            iPtr.key(),
-                           iPtr.hasProductCache() ? iPtr.operator->() : static_cast<void const*>(0));
+                           iPtr.hasProductCache() ? iPtr.operator->() : static_cast<void const*>(nullptr));
     }
 
     template<typename U>
@@ -149,7 +149,7 @@ namespace edm {
       static_assert( std::is_base_of<T, U>::value, "Ptr used in push_back can not be converted to type used by PtrVector." );
       this->push_back_base(iPtr.refCore(),
                            iPtr.key(),
-                           iPtr.hasProductCache() ? iPtr.operator->() : static_cast<void const*>(0));
+                           iPtr.hasProductCache() ? iPtr.operator->() : static_cast<void const*>(nullptr));
     }
 
     void swap(PtrVector& other) {
@@ -171,7 +171,7 @@ namespace edm {
   private:
 
     //PtrVector const& operator=(PtrVector const&); // stop default
-    std::type_info const& typeInfo() const {return typeid(T);}
+    std::type_info const& typeInfo() const override {return typeid(T);}
 
     // ---------- member data --------------------------------
     Ptr<T> fromItr(std::vector<void const*>::const_iterator const& iItr) const {

--- a/DataFormats/Common/interface/PtrVectorBase.h
+++ b/DataFormats/Common/interface/PtrVectorBase.h
@@ -35,8 +35,8 @@ namespace edm {
     typedef unsigned long key_type;
     typedef key_type size_type;
 
-    explicit PtrVectorBase(ProductID const& productID, void const* prodPtr = 0,
-                           EDProductGetter const* prodGetter = 0)
+    explicit PtrVectorBase(ProductID const& productID, void const* prodPtr = nullptr,
+                           EDProductGetter const* prodGetter = nullptr)
     :
       core_(productID, prodPtr, prodGetter, false), indicies_(), cachedItems_(nullptr) {}
     
@@ -93,7 +93,7 @@ namespace edm {
     bool isTransient() const {return core_.isTransient();}
 
     void const* product() const {
-      return 0;
+      return nullptr;
     }
 
   protected:
@@ -158,7 +158,7 @@ namespace edm {
     //returns false if the cache is not yet set
     bool checkCachedItems() const;
     
-    PtrVectorBase& operator=(const PtrVectorBase&);
+    PtrVectorBase& operator=(const PtrVectorBase&) = delete;
 
     //Used when we need an iterator but cache is not yet set
     static const std::vector<void const*>& emptyCache();

--- a/DataFormats/Common/interface/Ref.h
+++ b/DataFormats/Common/interface/Ref.h
@@ -197,7 +197,7 @@ namespace edm {
     /// but have a pointer to a product getter (such as the EventPrincipal).
     /// prodGetter will ususally be a pointer to the event principal.
     Ref(ProductID const& productID, key_type itemKey, EDProductGetter const* prodGetter) :
-      product_(productID, 0, mustBeNonZero(prodGetter, "Ref", productID), false), index_(itemKey) {
+      product_(productID, nullptr, mustBeNonZero(prodGetter, "Ref", productID), false), index_(itemKey) {
     }
 
     /// Constructor for use in the various X::fillView(...) functions.
@@ -212,7 +212,7 @@ namespace edm {
     { }
 
     Ref(ProductID const& iProductID, T const* item, key_type itemKey) :
-      product_(iProductID, item, 0, false), index_(itemKey)
+      product_(iProductID, item, nullptr, false), index_(itemKey)
     { }
 
     Ref(ProductID const& iProductID, T const* item, key_type itemKey, bool transient) :
@@ -224,7 +224,7 @@ namespace edm {
     /// ProductID).
 
     explicit Ref(ProductID const& iId) :
-      product_(iId, 0, 0, false), index_(key_traits<key_type>::value)
+      product_(iId, nullptr, nullptr, false), index_(key_traits<key_type>::value)
     { }
 
     /// Constructor from RefProd<C> and key
@@ -354,7 +354,7 @@ namespace edm {
     /// but have a pointer to a product getter (such as the EventPrincipal).
     /// prodGetter will ususally be a pointer to the event principal.
     Ref(ProductID const& productID, key_type itemKey, EDProductGetter const* prodGetter) :
-    product_(productID, 0, mustBeNonZero(prodGetter, "Ref", productID), false,itemKey) {
+    product_(productID, nullptr, mustBeNonZero(prodGetter, "Ref", productID), false,itemKey) {
     }
     
     /// Constructor for use in the various X::fillView(...) functions.
@@ -369,11 +369,11 @@ namespace edm {
     { }
 
     Ref(ProductID const& iProductID, T const* item, key_type itemKey) :
-    product_(iProductID, item, 0, false, itemKey)
+    product_(iProductID, item, nullptr, false, itemKey)
     { }
 
     Ref(ProductID const& iProductID, T const* item, key_type itemKey, bool transient) :
-    product_(iProductID, item, 0, transient, itemKey)
+    product_(iProductID, item, nullptr, transient, itemKey)
     { }
 
     /// Constructor that creates an invalid ("null") Ref that is
@@ -381,7 +381,7 @@ namespace edm {
     /// ProductID).
     
     explicit Ref(ProductID const& iId) :
-    product_(iId, 0, 0, false,key_traits<key_type>::value)
+    product_(iId, nullptr, nullptr, false,key_traits<key_type>::value)
     { }
     
     /// Constructor from RefProd<C> and key
@@ -400,7 +400,7 @@ namespace edm {
     
     /// Returns C++ pointer to the item
     T const* get() const {
-      return isNull() ? 0 : this->operator->();
+      return isNull() ? nullptr : this->operator->();
     }
     
     /// Checks for null
@@ -518,7 +518,7 @@ namespace edm {
   template <typename E>
   inline
   Ref<REF_FOR_VECTOR_ARGS>::Ref(std::vector<E> const* iProduct, key_type itemKey, bool) :
-    product_(ProductID(), nullptr, nullptr, true, iProduct != 0 ? itemKey : key_traits<key_type>::value) {
+    product_(ProductID(), nullptr, nullptr, true, iProduct != nullptr ? itemKey : key_traits<key_type>::value) {
     if(iProduct != nullptr) {
       refitem::findRefItem<product_type, value_type, finder_type, key_type>(product_.toRefCore(), iProduct, itemKey);
     }

--- a/DataFormats/Common/interface/RefCoreStreamer.h
+++ b/DataFormats/Common/interface/RefCoreStreamer.h
@@ -12,9 +12,9 @@ namespace edm {
   public:
     explicit RefCoreStreamer() : cl_("edm::RefCore"){}
 
-    void operator() (TBuffer &R__b, void *objp);
+    void operator() (TBuffer &R__b, void *objp) override;
 
-    TClassStreamer* Generate() const;
+    TClassStreamer* Generate() const override;
     
   private:
     TClassRef cl_;
@@ -24,9 +24,9 @@ namespace edm {
   public:
     explicit RefCoreWithIndexStreamer() : cl_("edm::RefCoreWithIndex"){}
     
-    void operator() (TBuffer &R__b, void *objp);
+    void operator() (TBuffer &R__b, void *objp) override;
 
-    TClassStreamer* Generate() const;
+    TClassStreamer* Generate() const override;
   private:
     TClassRef cl_;
   };

--- a/DataFormats/Common/interface/RefHolder_.h
+++ b/DataFormats/Common/interface/RefHolder_.h
@@ -22,29 +22,29 @@ namespace edm {
       RefHolder();
       explicit RefHolder(REF const& ref);
       void swap(RefHolder& other);
-      virtual ~RefHolder();
-      virtual RefHolderBase* clone() const override;
+      ~RefHolder() override;
+      RefHolderBase* clone() const override;
 
-      virtual ProductID id() const override;
-      virtual size_t key() const override;
-      virtual bool isEqualTo(RefHolderBase const& rhs) const override;
-      virtual bool fillRefIfMyTypeMatches(RefHolderBase& fillme,
+      ProductID id() const override;
+      size_t key() const override;
+      bool isEqualTo(RefHolderBase const& rhs) const override;
+      bool fillRefIfMyTypeMatches(RefHolderBase& fillme,
 					  std::string& msg) const override;
       REF const& getRef() const;
       void setRef(REF const& r);
-      virtual std::unique_ptr<RefVectorHolderBase> makeVectorHolder() const override;
-      virtual EDProductGetter const* productGetter() const override;
+      std::unique_ptr<RefVectorHolderBase> makeVectorHolder() const override;
+      EDProductGetter const* productGetter() const override;
 
       /// Checks if product collection is in memory or available
       /// in the Event. No type checking is done.
-      virtual bool isAvailable() const override { return ref_.isAvailable(); }
+      bool isAvailable() const override { return ref_.isAvailable(); }
 
-      virtual bool isTransient() const override { return ref_.isTransient(); }
+      bool isTransient() const override { return ref_.isTransient(); }
 
       //Needed for ROOT storage
       CMS_CLASS_VERSION(10)
     private:
-      virtual void const* pointerToType(std::type_info const& iToType) const override;
+      void const* pointerToType(std::type_info const& iToType) const override;
       REF ref_;
     };
 
@@ -94,7 +94,7 @@ namespace edm {
 					   std::string& msg) const
     {
       RefHolder* h = dynamic_cast<RefHolder*>(&fillme);
-      bool conversion_worked = (h != 0);
+      bool conversion_worked = (h != nullptr);
       if (conversion_worked)
 	h->setRef(ref_);
       else

--- a/DataFormats/Common/interface/RefProd.h
+++ b/DataFormats/Common/interface/RefProd.h
@@ -62,13 +62,13 @@ namespace edm {
 
     /// General purpose constructor from handle.
     explicit RefProd(Handle<C> const& handle) :
-    product_(handle.id(), handle.product(), 0, false) {
+    product_(handle.id(), handle.product(), nullptr, false) {
       checkTypeAtCompileTime(handle.product());
     }
 
     /// General purpose constructor from orphan handle.
     explicit RefProd(OrphanHandle<C> const& handle) :
-    product_(handle.id(), handle.product(), 0, false) {
+    product_(handle.id(), handle.product(), nullptr, false) {
       checkTypeAtCompileTime(handle.product());
     }
 
@@ -96,7 +96,7 @@ namespace edm {
     // but have a pointer to a product getter (such as the EventPrincipal).
     // prodGetter will ususally be a pointer to the event principal.
     RefProd(ProductID const& productID, EDProductGetter const* prodGetter) :
-      product_(productID, 0, mustBeNonZero(prodGetter, "RefProd", productID), false) {
+      product_(productID, nullptr, mustBeNonZero(prodGetter, "RefProd", productID), false) {
     }
 
     /// Destructor
@@ -111,7 +111,7 @@ namespace edm {
     /// Returns C++ pointer to the product
     /// Will attempt to retrieve product
     product_type const* get() const {
-      return isNull() ? 0 : this->operator->();
+      return isNull() ? nullptr : this->operator->();
     }
 
     /// Returns C++ pointer to the product

--- a/DataFormats/Common/interface/RefVector.h
+++ b/DataFormats/Common/interface/RefVector.h
@@ -77,7 +77,7 @@ namespace edm {
       key_type const& key = refVector_.keys()[idx];
       void const* memberPointer = refVector_.cachedMemberPointer(idx);
       if(memberPointer) {
-        RefCore newCore(core);
+        const RefCore& newCore(core);
         newCore.setProductPtr(memberPointer);
         return value_type(newCore, key);
       }
@@ -90,7 +90,7 @@ namespace edm {
       key_type const& key = refVector_.keys().at(idx);
       void const* memberPointer = refVector_.cachedMemberPointer(idx);
       if(memberPointer) {
-        RefCore newCore(core);
+        const RefCore& newCore(core);
         newCore.setProductPtr(memberPointer);
         return value_type(newCore, key);
       }

--- a/DataFormats/Common/interface/RefVectorBase.h
+++ b/DataFormats/Common/interface/RefVectorBase.h
@@ -53,8 +53,8 @@ namespace edm {
 
 
 
-    explicit RefVectorBase(ProductID const& productID, void const* prodPtr = 0,
-                           EDProductGetter const* prodGetter = 0) :
+    explicit RefVectorBase(ProductID const& productID, void const* prodPtr = nullptr,
+                           EDProductGetter const* prodGetter = nullptr) :
       product_(productID, prodPtr, prodGetter, false), keys_() {}
 
 

--- a/DataFormats/Common/interface/RefVectorHolder.h
+++ b/DataFormats/Common/interface/RefVectorHolder.h
@@ -20,20 +20,20 @@ namespace edm {
       }
       explicit RefVectorHolder(ProductID const& iId) : RefVectorHolderBase(), refs_(iId) {
       }
-      virtual ~RefVectorHolder() { }
+      ~RefVectorHolder() override { }
       void swap(RefVectorHolder& other);
       RefVectorHolder& operator=(RefVectorHolder const& rhs);
-      virtual bool empty() const;
-      virtual size_type size() const;
-      virtual void clear();
-      virtual void push_back(RefHolderBase const* r);
-      virtual void reserve(size_type n);
-      virtual ProductID id() const;
-      virtual EDProductGetter const* productGetter() const;
-      virtual RefVectorHolder<REFV> * clone() const;
-      virtual RefVectorHolder<REFV> * cloneEmpty() const;
+      bool empty() const override;
+      size_type size() const override;
+      void clear() override;
+      void push_back(RefHolderBase const* r) override;
+      void reserve(size_type n) override;
+      ProductID id() const override;
+      EDProductGetter const* productGetter() const override;
+      RefVectorHolder<REFV> * clone() const override;
+      RefVectorHolder<REFV> * cloneEmpty() const override;
       void setRefs(REFV const& refs);
-      virtual size_t keyForIndex(size_t idx) const;
+      size_t keyForIndex(size_t idx) const override;
 
       //Needed for ROOT storage
       CMS_CLASS_VERSION(10)
@@ -46,25 +46,25 @@ namespace edm {
 	typedef ptrdiff_t difference_type;
 	const_iterator_imp_specific() { }
 	explicit const_iterator_imp_specific(typename REFV::const_iterator const& it) : i (it) { }
-	~const_iterator_imp_specific() { }
-	const_iterator_imp_specific * clone() const { return new const_iterator_imp_specific(i); }
-	void increase() { ++i; }
-	void decrease() { --i; }
-	void increase(difference_type d) { i += d; }
-	void decrease(difference_type d) { i -= d; }
-	bool equal_to(const_iterator_imp const* o) const { return i == dc(o); }
-	bool less_than(const_iterator_imp const* o) const { return i < dc(o); }
-	void assign(const_iterator_imp const* o) { i = dc(o); }
-	std::shared_ptr<RefHolderBase> deref() const;
-	difference_type difference(const_iterator_imp const* o) const { return i - dc(o); }
+	~const_iterator_imp_specific() override { }
+	const_iterator_imp_specific * clone() const override { return new const_iterator_imp_specific(i); }
+	void increase() override { ++i; }
+	void decrease() override { --i; }
+	void increase(difference_type d) override { i += d; }
+	void decrease(difference_type d) override { i -= d; }
+	bool equal_to(const_iterator_imp const* o) const override { return i == dc(o); }
+	bool less_than(const_iterator_imp const* o) const override { return i < dc(o); }
+	void assign(const_iterator_imp const* o) override { i = dc(o); }
+	std::shared_ptr<RefHolderBase> deref() const override;
+	difference_type difference(const_iterator_imp const* o) const override { return i - dc(o); }
       private:
 	typename REFV::const_iterator const& dc(const_iterator_imp const* o) const {
-	  if (o == 0) {
+	  if (o == nullptr) {
 	    Exception::throwThis(errors::InvalidReference,
 	      "In RefVectorHolder trying to dereference a null pointer\n");
 	  }
 	  const_iterator_imp_specific const* oo = dynamic_cast<const_iterator_imp_specific const*>(o);
-	  if (oo == 0) {
+	  if (oo == nullptr) {
 	    Exception::throwThis(errors::InvalidReference,
 	      "In RefVectorHolder trying to cast iterator to wrong type\n");
 	  }
@@ -75,19 +75,19 @@ namespace edm {
 
       typedef typename RefVectorHolderBase::const_iterator const_iterator;
 
-      const_iterator begin() const {
+      const_iterator begin() const override {
 	return const_iterator(new const_iterator_imp_specific(refs_.begin()));
       }
-      const_iterator end() const {
+      const_iterator end() const override {
 	return const_iterator(new const_iterator_imp_specific(refs_.end()));
       }
 
       /// Checks if product collection is in memory or available
       /// in the Event. No type checking is done.
-      virtual bool isAvailable() const { return refs_.isAvailable(); }
+      bool isAvailable() const override { return refs_.isAvailable(); }
 
     private:
-      virtual std::shared_ptr<reftobase::RefHolderBase> refBase(size_t idx) const;
+      std::shared_ptr<reftobase::RefHolderBase> refBase(size_t idx) const override;
       REFV refs_;
     };
 
@@ -190,7 +190,7 @@ namespace edm {
     void RefVectorHolder<REFV>::push_back(RefHolderBase const* h) {
       typedef typename REFV::value_type REF;
       RefHolder<REF> const* rh = dynamic_cast<RefHolder<REF> const*>(h);
-      if(rh == 0) {
+      if(rh == nullptr) {
 	Exception::throwThis(errors::InvalidReference,
 	  "RefVectorHolder: attempting to cast a RefHolderBase "
 	  "to an invalid type.\nExpected: ",

--- a/DataFormats/Common/interface/RefVectorHolderBase.h
+++ b/DataFormats/Common/interface/RefVectorHolderBase.h
@@ -46,9 +46,9 @@ namespace edm {
       struct const_iterator : public std::iterator <std::random_access_iterator_tag, void*>{
         typedef std::shared_ptr<RefHolderBase> value_type;
         typedef std::ptrdiff_t difference_type;
-        const_iterator() : i(0) { }
+        const_iterator() : i(nullptr) { }
         const_iterator(const_iterator_imp* it) : i(it) { }
-        const_iterator(const_iterator const& it) : i(it.isValid() ? it.i->clone() : 0) { }
+        const_iterator(const_iterator const& it) : i(it.isValid() ? it.i->clone() : nullptr) { }
         ~const_iterator() { delete i; }
         const_iterator& operator=(const_iterator const& it) {
           if(isInvalid()) i = it.i;
@@ -145,8 +145,8 @@ namespace edm {
           i->increase(d);
           return *this;
         }
-        bool isValid() const { return i != 0; }
-        bool isInvalid() const { return i == 0; }
+        bool isValid() const { return i != nullptr; }
+        bool isInvalid() const { return i == nullptr; }
 
       private:
         const_iterator_imp* i;

--- a/DataFormats/Common/interface/VectorHolder.h
+++ b/DataFormats/Common/interface/VectorHolder.h
@@ -29,17 +29,17 @@ namespace edm {
 
       explicit VectorHolder(const ref_vector_type& iRefVector) : base_type(), refVector_(iRefVector) {}
       explicit VectorHolder(const ProductID& iId) : base_type(), refVector_(iId) {}
-      virtual ~VectorHolder()  noexcept {}
-      virtual base_type* clone() const { return new VectorHolder(*this); }
-      virtual base_type* cloneEmpty() const { return new VectorHolder(refVector_.id()); }
-      base_ref_type const at(size_type idx) const { return base_ref_type( refVector_.at( idx ) ); }
-      bool empty() const { return refVector_.empty(); }
-      size_type size() const { return refVector_.size(); }
+      ~VectorHolder()  noexcept override {}
+      base_type* clone() const override { return new VectorHolder(*this); }
+      base_type* cloneEmpty() const override { return new VectorHolder(refVector_.id()); }
+      base_ref_type const at(size_type idx) const override { return base_ref_type( refVector_.at( idx ) ); }
+      bool empty() const override { return refVector_.empty(); }
+      size_type size() const override { return refVector_.size(); }
       //size_type capacity() const { return refVector_.capacity(); }
       //void reserve(size_type n) { refVector_.reserve(n); }
-      void clear() { refVector_.clear(); }
-      ProductID id() const { return refVector_.id(); }
-      EDProductGetter const* productGetter() const { return refVector_.productGetter(); }
+      void clear() override { refVector_.clear(); }
+      ProductID id() const override { return refVector_.id(); }
+      EDProductGetter const* productGetter() const override { return refVector_.productGetter(); }
       void swap(VectorHolder& other)  noexcept {
         this->BaseVectorHolder<T>::swap(other);
         refVector_.swap(other.refVector_);
@@ -57,27 +57,27 @@ namespace edm {
      }
 #endif
       
-      const_iterator begin() const {
+      const_iterator begin() const override {
         return const_iterator( new const_iterator_imp_specific( refVector_.begin() ) );
       }
-      const_iterator end() const {
+      const_iterator end() const override {
         return const_iterator( new const_iterator_imp_specific( refVector_.end() ) );
       }
-      virtual void push_back( const BaseHolder<T> * r ) {
+      void push_back( const BaseHolder<T> * r ) override {
         typedef Holder<T, typename REFV::value_type > holder_type;
         const holder_type * h = dynamic_cast<const holder_type *>( r );
-        if( h == 0 )
+        if( h == nullptr )
           Exception::throwThis( errors::InvalidReference,
                                "In VectorHolder<T, REFV> trying to push_back wrong reference type");
         refVector_.push_back( h->getRef() );
       }
-      virtual std::unique_ptr<RefVectorHolderBase> vectorHolder() const {
+      std::unique_ptr<RefVectorHolderBase> vectorHolder() const override {
         return std::unique_ptr<RefVectorHolderBase>( new RefVectorHolder<REFV>( refVector_ ) );
       }
       
       /// Checks if product collection is in memory or available
       /// in the Event. No type checking is done.
-      virtual bool isAvailable() const { return refVector_.isAvailable(); }
+      bool isAvailable() const override { return refVector_.isAvailable(); }
       
       //Used by ROOT storage
       CMS_CLASS_VERSION(10)
@@ -94,24 +94,24 @@ namespace edm {
         typedef ptrdiff_t difference_type;
         const_iterator_imp_specific() { }
         explicit const_iterator_imp_specific( const typename REFV::const_iterator & it ) : i ( it ) { }
-        ~const_iterator_imp_specific() { }
-        const_iterator_imp_specific * clone() const { return new const_iterator_imp_specific( i ); }
-        void increase() { ++i; }
-        void decrease() { --i; }
-        void increase( difference_type d ) { i += d; }
-        void decrease( difference_type d ) { i -= d; }
-        bool equal_to( const const_iterator_imp * o ) const { return i == dc( o ); }
-        bool less_than( const const_iterator_imp * o ) const { return i < dc( o ); }
-        void assign( const const_iterator_imp * o ) { i = dc( o ); }
-        base_ref_type deref() const { return base_ref_type( * i ); }
-        difference_type difference( const const_iterator_imp * o ) const { return i - dc( o ); }
+        ~const_iterator_imp_specific() override { }
+        const_iterator_imp_specific * clone() const override { return new const_iterator_imp_specific( i ); }
+        void increase() override { ++i; }
+        void decrease() override { --i; }
+        void increase( difference_type d ) override { i += d; }
+        void decrease( difference_type d ) override { i -= d; }
+        bool equal_to( const const_iterator_imp * o ) const override { return i == dc( o ); }
+        bool less_than( const const_iterator_imp * o ) const override { return i < dc( o ); }
+        void assign( const const_iterator_imp * o ) override { i = dc( o ); }
+        base_ref_type deref() const override { return base_ref_type( * i ); }
+        difference_type difference( const const_iterator_imp * o ) const override { return i - dc( o ); }
       private:
         const typename ref_vector_type::const_iterator & dc( const const_iterator_imp * o ) const {
-          if ( o == 0 )
+          if ( o == nullptr )
             Exception::throwThis( errors::InvalidReference,
                                  "In RefToBaseVector<T> trying to dereference a null pointer");
           const const_iterator_imp_specific * oo = dynamic_cast<const const_iterator_imp_specific *>( o );
-          if ( oo == 0 )
+          if ( oo == nullptr )
             Exception::throwThis( errors::InvalidReference,
                                  "In RefToBaseVector<T> trying to cast iterator to wrong type ");
           return oo->i;

--- a/DataFormats/Common/interface/View.h
+++ b/DataFormats/Common/interface/View.h
@@ -103,7 +103,7 @@ namespace edm {
          FillViewHelperVector const& helpers,
          EDProductGetter const* getter);
 
-    virtual ~View();
+    ~View() override;
 
     void swap(View& other);
 
@@ -182,7 +182,7 @@ namespace edm {
       void const* p = pointers[i];
       auto const& h = helpers[i];
       items_.push_back(static_cast<pointer>(p));
-      if(0!=p) {
+      if(nullptr!=p) {
          vPtrs_.push_back(Ptr<T>(h.first, static_cast<T const*>(p), h.second));
       } else if(getter != nullptr) {
          vPtrs_.push_back(Ptr<T>(h.first, h.second, getter));

--- a/DataFormats/Common/interface/Wrapper.h
+++ b/DataFormats/Common/interface/Wrapper.h
@@ -29,7 +29,7 @@ namespace edm {
     Wrapper() : WrapperBase(), present(false), obj() {}
     explicit Wrapper(std::unique_ptr<T> ptr);
     ~Wrapper() override {}
-    T const* product() const {return (present ? &obj : 0);}
+    T const* product() const {return (present ? &obj : nullptr);}
     T const* operator->() const {return product();}
 
     //these are used by FWLite

--- a/DataFormats/Common/src/PtrVectorBase.cc
+++ b/DataFormats/Common/src/PtrVectorBase.cc
@@ -116,7 +116,7 @@ namespace edm {
     if(hasCache()) {
       return;
     }
-    if(indicies_.size() == 0) {
+    if(indicies_.empty()) {
       return;
     }
     //NOTE: Another thread could be getting the data

--- a/DataFormats/Common/src/RefCore.cc
+++ b/DataFormats/Common/src/RefCore.cc
@@ -272,7 +272,7 @@ namespace edm {
       }
     }
     auto prodGetter = productToBeInserted.productGetter();
-    if (productGetter() == 0 &&  prodGetter != 0) {
+    if (productGetter() == nullptr &&  prodGetter != nullptr) {
       setProductGetter(prodGetter);
     }
   }

--- a/DataFormats/Common/src/RefCoreStreamer.cc
+++ b/DataFormats/Common/src/RefCoreStreamer.cc
@@ -78,34 +78,34 @@ namespace edm {
     {
       TClass *cl = TClass::GetClass("edm::RefCore");
       TClassStreamer *st = cl->GetStreamer();
-      if (st == 0) {
+      if (st == nullptr) {
         cl->AdoptStreamer(new RefCoreStreamer());
       }
       {
         TClass *cl = TClass::GetClass("edm::RefCoreWithIndex");
         TClassStreamer *st = cl->GetStreamer();
-        if (st == 0) {
+        if (st == nullptr) {
           cl->AdoptStreamer(new RefCoreWithIndexStreamer());
         }
       }
     }
-    EDProductGetter::switchProductGetter(0);
+    EDProductGetter::switchProductGetter(nullptr);
   }
 
   EDProductGetter const* setRefCoreStreamer(EDProductGetter const* ep) {
-    EDProductGetter const* returnValue=0;
-    if (ep != 0) {
+    EDProductGetter const* returnValue=nullptr;
+    if (ep != nullptr) {
       {
         TClass *cl = TClass::GetClass("edm::RefCore");
         TClassStreamer *st = cl->GetStreamer();
-        if (st == 0) {
+        if (st == nullptr) {
           cl->AdoptStreamer(new RefCoreStreamer());
         }
       }
       {
         TClass *cl = TClass::GetClass("edm::RefCoreWithIndex");
         TClassStreamer *st = cl->GetStreamer();
-        if (st == 0) {
+        if (st == nullptr) {
           cl->AdoptStreamer(new RefCoreWithIndexStreamer());
         }
       }

--- a/DataFormats/DTRecHit/interface/DTChamberRecSegment2D.h
+++ b/DataFormats/DTRecHit/interface/DTChamberRecSegment2D.h
@@ -45,12 +45,12 @@ class DTChamberRecSegment2D : public DTRecSegment2D {
 			std::vector<DTRecHit1D> &hits1D);
   
   /// Destructor
-  virtual ~DTChamberRecSegment2D(){};
+  ~DTChamberRecSegment2D() override{};
 
   /* Operations */ 
 
   /// The clone method needed by the clone policy
-  virtual DTChamberRecSegment2D* clone() const;
+  DTChamberRecSegment2D* clone() const override;
   
   /// The id of the chamber on which reside the segment
   DTChamberId chamberId() const;

--- a/DataFormats/DTRecHit/interface/DTRecHit1D.h
+++ b/DataFormats/DTRecHit/interface/DTRecHit1D.h
@@ -53,29 +53,29 @@ class DTRecHit1D : public RecHit1D {
 
 
   /// Destructor
-  virtual ~DTRecHit1D();
+  ~DTRecHit1D() override;
 
 
   /// Return the 3-dimensional local position
-  virtual LocalPoint localPosition() const {
+  LocalPoint localPosition() const override {
     return theLocalPosition;
   }
 
 
   /// Return the 3-dimensional error on the local position
-  virtual LocalError localPositionError() const {
+  LocalError localPositionError() const override {
     return theLocalError;
   }
 
-  virtual  DTRecHit1D* clone() const;
+   DTRecHit1D* clone() const override;
 
   
   /// No components rechits: it returns a null vector
-  virtual std::vector<const TrackingRecHit*> recHits() const;
+  std::vector<const TrackingRecHit*> recHits() const override;
 
 
   /// No components rechits: it returns a null vector
-  virtual std::vector<TrackingRecHit*> recHits();
+  std::vector<TrackingRecHit*> recHits() override;
 
 
   /// The side of the cell

--- a/DataFormats/DTRecHit/interface/DTRecHit1DPair.h
+++ b/DataFormats/DTRecHit/interface/DTRecHit1DPair.h
@@ -34,33 +34,33 @@ public:
 
 
   /// Destructor
-  virtual ~DTRecHit1DPair();
+  ~DTRecHit1DPair() override;
 
   // Operations
 
-  virtual DTRecHit1DPair * clone() const;
+  DTRecHit1DPair * clone() const override;
 
 
   /// Return the 3-dimensional local position.
   /// The average theLeftHit/theRightHit hits position, namely the wire position
   /// is returned. 
-  virtual LocalPoint localPosition() const;
+  LocalPoint localPosition() const override;
 
 
   /// Return the 3-dimensional error on the local position. 
   /// The error is defiened as half
   /// the distance between theLeftHit and theRightHit pos
-  virtual LocalError localPositionError() const;
+  LocalError localPositionError() const override;
 
 
   /// Access to component RecHits.
   /// Return the two recHits (L/R)
-  virtual std::vector<const TrackingRecHit*> recHits() const;
+  std::vector<const TrackingRecHit*> recHits() const override;
 
 
   /// Non-const access to component RecHits.
   /// Return the two recHits (L/R)
-  virtual std::vector<TrackingRecHit*> recHits();
+  std::vector<TrackingRecHit*> recHits() override;
 
 
   /// Return the detId of the Det (a DTLayer).

--- a/DataFormats/DTRecHit/interface/DTRecSegment2D.h
+++ b/DataFormats/DTRecHit/interface/DTRecSegment2D.h
@@ -60,54 +60,54 @@ class DTRecSegment2D : public RecSegment{
 		 std::vector<DTRecHit1D> &hits1D);
 
   /// Destructor
-  virtual ~DTRecSegment2D();
+  ~DTRecSegment2D() override;
 
   /* Operations */ 
 
-  virtual DTRecSegment2D* clone() const { return new DTRecSegment2D(*this);}
+  DTRecSegment2D* clone() const override { return new DTRecSegment2D(*this);}
 
 
   /// the vector of parameters (dx/dz,x)
-  virtual AlgebraicVector parameters() const {
+  AlgebraicVector parameters() const override {
     return param( localPosition(), localDirection());
   }
 
   // The parameter error matrix 
-  virtual AlgebraicSymMatrix parametersError() const;
+  AlgebraicSymMatrix parametersError() const override;
 
   /** return the projection matrix, which must project a parameter vector,
    * whose components are (q/p, dx/dz, dy/dz, x, y), into the vector returned
    * by parameters() */
-  virtual AlgebraicMatrix projectionMatrix() const {
+  AlgebraicMatrix projectionMatrix() const override {
     return theProjectionMatrix;
   }
     
   /// return 2. The dimension of the matrix
-  virtual int dimension() const { return 2;}
+  int dimension() const override { return 2;}
     
   /// local position in SL frame
-  virtual LocalPoint localPosition() const {return thePosition; }
+  LocalPoint localPosition() const override {return thePosition; }
   
   /// local position error in SL frame
-  virtual LocalError localPositionError() const ;
+  LocalError localPositionError() const override ;
   
   /// the local direction in SL frame
-  virtual LocalVector localDirection() const { return theDirection; }
+  LocalVector localDirection() const override { return theDirection; }
 
   /// the local direction error (xx,xy,yy) in SL frame: only xx is not 0.
-  virtual LocalError localDirectionError() const;
+  LocalError localDirectionError() const override;
 
   /// the chi2 of the fit
-  virtual double chi2() const { return theChi2; }
+  double chi2() const override { return theChi2; }
     
   /// return the DOF of the segment 
-  virtual int degreesOfFreedom() const ;
+  int degreesOfFreedom() const override ;
 
   // Access to component RecHits (if any)
-  virtual std::vector<const TrackingRecHit*> recHits() const ;
+  std::vector<const TrackingRecHit*> recHits() const override ;
 
   // Non-const access to component RecHits (if any)
-  virtual std::vector<TrackingRecHit*> recHits() ;
+  std::vector<TrackingRecHit*> recHits() override ;
 
   /// Access to specific components
   std::vector<DTRecHit1D> specificRecHits() const ;

--- a/DataFormats/DTRecHit/interface/DTRecSegment4D.h
+++ b/DataFormats/DTRecHit/interface/DTRecSegment4D.h
@@ -37,50 +37,50 @@ class DTRecSegment4D : public RecSegment {
   DTRecSegment4D(const DTSLRecSegment2D& zedSeg, const LocalPoint& posZInCh, const LocalVector& dirZInCh);
 
   /// Destructor
-  ~DTRecSegment4D() ;
+  ~DTRecSegment4D() override ;
 
   //--- Base class interface
 
-  virtual DTRecSegment4D* clone() const { return new DTRecSegment4D(*this);}
+  DTRecSegment4D* clone() const override { return new DTRecSegment4D(*this);}
 
   /// Parameters of the segment, for the track fit. 
   /// For a 4D segment: (dx/dy,dy/dz,x,y)
   /// For a 2D, phi-only segment: (dx/dz,x)
   /// For a 2D, Z-only segment: (dy/dz,y)
-  AlgebraicVector parameters() const ;
+  AlgebraicVector parameters() const override ;
 
   /// Covariance matrix fo parameters()
-  AlgebraicSymMatrix parametersError() const ;
+  AlgebraicSymMatrix parametersError() const override ;
 
   /// The projection matrix relates the trajectory state parameters to the segment parameters().
-  virtual AlgebraicMatrix projectionMatrix() const;
+  AlgebraicMatrix projectionMatrix() const override;
 
   /// Local position in Chamber frame
-  virtual LocalPoint localPosition() const { return thePosition;}
+  LocalPoint localPosition() const override { return thePosition;}
 
   /// Local position error in Chamber frame
-  virtual LocalError localPositionError() const ;
+  LocalError localPositionError() const override ;
 
   /// Local direction in Chamber frame
-  virtual LocalVector localDirection() const { return theDirection; }
+  LocalVector localDirection() const override { return theDirection; }
 
   /// Local direction error in the Chamber frame
-  virtual LocalError localDirectionError() const ;
+  LocalError localDirectionError() const override ;
 
   // Chi2 of the segment fit
-  virtual double chi2() const ;
+  double chi2() const override ;
   
   // Degrees of freedom of the segment fit
-  virtual int degreesOfFreedom() const ;
+  int degreesOfFreedom() const override ;
 
   // Dimension (in parameter space)
-  virtual int dimension() const { return theDimension; }
+  int dimension() const override { return theDimension; }
 
   // Access to component RecHits (if any)
-  virtual std::vector<const TrackingRecHit*> recHits() const ;
+  std::vector<const TrackingRecHit*> recHits() const override ;
 
   // Non-const access to component RecHits (if any)
-  virtual std::vector<TrackingRecHit*> recHits() ;
+  std::vector<TrackingRecHit*> recHits() override ;
 
 
   //--- Extension of the interface
@@ -94,12 +94,12 @@ class DTRecSegment4D : public RecSegment {
   
   /// The superPhi segment: 0 if no phi projection available
   const DTChamberRecSegment2D *phiSegment() const {
-    return hasPhi()? &thePhiSeg: 0;
+    return hasPhi()? &thePhiSeg: nullptr;
   }
     
   /// The Z segment: 0 if not zed projection available
   const DTSLRecSegment2D *zSegment() const {
-    return hasZed()? &theZedSeg : 0;
+    return hasZed()? &theZedSeg : nullptr;
   }
     
   /// Set position

--- a/DataFormats/DTRecHit/interface/DTSLRecCluster.h
+++ b/DataFormats/DTRecHit/interface/DTSLRecCluster.h
@@ -44,41 +44,41 @@ class DTSLRecCluster : public RecHit1D {
                    const std::vector<DTRecHit1DPair>& pair) ;
 
     /* Destructor */ 
-    virtual ~DTSLRecCluster() {}
+    ~DTSLRecCluster() override {}
 
     /* Operations */ 
     /// The clone method needed by the clone policy
-    virtual DTSLRecCluster* clone() const { return new DTSLRecCluster(*this); }
+    DTSLRecCluster* clone() const override { return new DTSLRecCluster(*this); }
 
     /// The id of the superlayer on which reside the segment
     DTSuperLayerId superLayerId() const { return theSlid; }
 
     /// the vector of parameters (dx/dz,x)
-    virtual AlgebraicVector parameters() const {
+    AlgebraicVector parameters() const override {
       return param( localPosition());
     }
 
     // The parameter error matrix 
-    virtual AlgebraicSymMatrix parametersError() const {
+    AlgebraicSymMatrix parametersError() const override {
       return parError( localPositionError());
     }
 
     /** return the projection matrix, which must project a parameter vector,
      * whose components are (q/p, dx/dz, dy/dz, x, y), into the vector returned
      * by parameters() */
-    virtual AlgebraicMatrix projectionMatrix() const {
+    AlgebraicMatrix projectionMatrix() const override {
       return theProjectionMatrix;
     }
 
     /// return 2. The dimension of the matrix
-    virtual int dimension() const { return 2;}
-    virtual LocalPoint localPosition() const { return thePos; }
-    virtual LocalError localPositionError() const { return thePosError; }
+    int dimension() const override { return 2;}
+    LocalPoint localPosition() const override { return thePos; }
+    LocalError localPositionError() const override { return thePosError; }
 
     /// return the hits
-    virtual std::vector<const TrackingRecHit*> recHits() const ;
+    std::vector<const TrackingRecHit*> recHits() const override ;
 
-    virtual std::vector<TrackingRecHit*> recHits() ;
+    std::vector<TrackingRecHit*> recHits() override ;
 
     /// Access to specific components
     std::vector<DTRecHit1DPair> specificRecHits() const { return thePairs; }

--- a/DataFormats/DTRecHit/interface/DTSLRecSegment2D.h
+++ b/DataFormats/DTRecHit/interface/DTSLRecSegment2D.h
@@ -27,12 +27,12 @@ public:
 		   std::vector<DTRecHit1D> &hits1D);
 
   /// Destructor
-  virtual ~DTSLRecSegment2D(){};
+  ~DTSLRecSegment2D() override{};
 
   // Operations
 
   /// The clone method needed by the clone policy
-  virtual DTSLRecSegment2D* clone() const;
+  DTSLRecSegment2D* clone() const override;
   
   /// The id of the superlayer on which reside the segment
   DTSuperLayerId superLayerId() const;

--- a/DataFormats/DetId/interface/DetId.h
+++ b/DataFormats/DetId/interface/DetId.h
@@ -5,7 +5,7 @@
 //FIXME shall be removed and implemented where the operator is defined
 #include <ostream>
 
-#include <stdint.h>
+#include <cstdint>
 /** \class DetId
 
 Parent class for all detector ids in CMS.  The DetId is a 32-bit

--- a/DataFormats/EcalDetId/interface/EcalElectronicsId.h
+++ b/DataFormats/EcalDetId/interface/EcalElectronicsId.h
@@ -2,7 +2,7 @@
 #define DATAFORMATS_ECALDETID_ECALELECTRONICSID_H 1
 
 #include <ostream>
-#include <stdint.h>
+#include <cstdint>
 
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 

--- a/DataFormats/EcalDetId/interface/EcalTriggerElectronicsId.h
+++ b/DataFormats/EcalDetId/interface/EcalTriggerElectronicsId.h
@@ -2,7 +2,7 @@
 #define DATAFORMATS_ECALDETID_ECALTRIGGERELECTRONICSID_H 1
 
 #include <ostream>
-#include <stdint.h>
+#include <cstdint>
 
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 

--- a/DataFormats/EcalDigi/interface/EBDataFrame.h
+++ b/DataFormats/EcalDigi/interface/EBDataFrame.h
@@ -26,7 +26,7 @@ class EBDataFrame : public EcalDataFrame
    */
   float spikeEstimator() const;
     
-  virtual ~EBDataFrame() {}
+  ~EBDataFrame() override {}
 
   key_type id() const { return Base::id(); }
 

--- a/DataFormats/EcalDigi/interface/EBSrFlag.h
+++ b/DataFormats/EcalDigi/interface/EBSrFlag.h
@@ -33,7 +33,7 @@ public:
   /** For edm::SortedCollection.
    * @return det id of the trigger tower the flag is assigned to.
    */
-  const EcalTrigTowerDetId& id() const { return ttId_;}
+  const EcalTrigTowerDetId& id() const override { return ttId_;}
   
 private:
   /** trigger tower id

--- a/DataFormats/EcalDigi/interface/EEDataFrame.h
+++ b/DataFormats/EcalDigi/interface/EEDataFrame.h
@@ -23,7 +23,7 @@ class EEDataFrame : public EcalDataFrame
   EEDataFrame(edm::DataFrame const & base) : Base(base) {}
   EEDataFrame(EcalDataFrame const & base) : Base(base) {}
     
-  virtual ~EEDataFrame() {}
+  ~EEDataFrame() override {}
 
   key_type id() const { return Base::id(); }
 

--- a/DataFormats/EcalDigi/interface/EESrFlag.h
+++ b/DataFormats/EcalDigi/interface/EESrFlag.h
@@ -34,7 +34,7 @@ public:
   /** For edm::SortedCollection.
    * @return det id of the trigger tower the flag is assigned to.
    */
-  const EcalScDetId& id() const { return scId_;}
+  const EcalScDetId& id() const override { return scId_;}
   
 private:
   /** trigger tower id

--- a/DataFormats/EcalDigi/interface/EcalTrigPrimCompactColl.h
+++ b/DataFormats/EcalDigi/interface/EcalTrigPrimCompactColl.h
@@ -2,7 +2,7 @@
 #define ECALTRIGPRIMCOMPACTCOLL_H
 
 #include <vector>
-#include <inttypes.h>
+#include <cinttypes>
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "DataFormats/EcalDigi/interface/EcalTriggerPrimitiveDigi.h"

--- a/DataFormats/EcalRecHit/src/EcalRecHit.cc
+++ b/DataFormats/EcalRecHit/src/EcalRecHit.cc
@@ -4,7 +4,7 @@
 #include "DataFormats/EcalDetId/interface/ESDetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <cassert>
-#include <math.h>
+#include <cmath>
 
 
 std::ostream& operator<<(std::ostream& s, const EcalRecHit& hit) {

--- a/DataFormats/EgammaCandidates/interface/Electron.h
+++ b/DataFormats/EgammaCandidates/interface/Electron.h
@@ -21,16 +21,16 @@ namespace reco {
     Electron( Charge q, const LorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ) ) :
       RecoCandidate( q, p4, vtx, -11 * q ) { }
     /// destructor
-    virtual ~Electron();
+    ~Electron() override;
     /// returns a clone of the candidate
-    virtual Electron * clone() const;
+    Electron * clone() const override;
     /// reference to a Track
     using reco::RecoCandidate::track ; // avoid hiding the base
-    virtual reco::TrackRef track() const;
+    reco::TrackRef track() const override;
     /// reference to a SuperCluster
-    virtual reco::SuperClusterRef superCluster() const;
+    reco::SuperClusterRef superCluster() const override;
     /// reference to a GsfTrack
-    virtual reco::GsfTrackRef gsfTrack() const;
+    reco::GsfTrackRef gsfTrack() const override;
     /// set refrence to Photon component
     void setSuperCluster( const reco::SuperClusterRef & r ) { superCluster_ = r; }
     /// set refrence to Track component
@@ -38,10 +38,10 @@ namespace reco {
     /// set reference to GsfTrack component
     void setGsfTrack( const reco::GsfTrackRef & r ) { gsfTrack_ = r; }
 
-    bool isElectron() const;
+    bool isElectron() const override;
   private:
     /// check overlap with another candidate
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
     /// reference to a SuperCluster
     reco::SuperClusterRef superCluster_;
     /// reference to a Track

--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -102,7 +102,7 @@ class GsfElectron : public RecoCandidate
       const ConversionRejection &,
       const SaturationInfo &
      ) ;
-    GsfElectron * clone() const ;
+    GsfElectron * clone() const override ;
     GsfElectron * clone
      (
       const GsfElectronCoreRef & core,
@@ -111,7 +111,7 @@ class GsfElectron : public RecoCandidate
       const TrackBaseRef & conversionPartner,
       const GsfTrackRefVector & ambiguousTracks
      ) const ;
-    virtual ~GsfElectron() {} ;
+    ~GsfElectron() override {} ;
 
   private:
 
@@ -157,8 +157,8 @@ class GsfElectron : public RecoCandidate
     const ChargeInfo & chargeInfo() const { return chargeInfo_ ; }
 
     // Candidate redefined methods
-    virtual bool isElectron() const { return true ; }
-    virtual bool overlap( const Candidate & ) const ;
+    bool isElectron() const override { return true ; }
+    bool overlap( const Candidate & ) const override ;
 
   private:
 
@@ -181,8 +181,8 @@ class GsfElectron : public RecoCandidate
     void setCore(const reco::GsfElectronCoreRef &core) { core_ = core; }
 
     // forward core methods
-    virtual SuperClusterRef superCluster() const { return core()->superCluster() ; }
-    virtual GsfTrackRef gsfTrack() const { return core()->gsfTrack() ; }
+    SuperClusterRef superCluster() const override { return core()->superCluster() ; }
+    GsfTrackRef gsfTrack() const override { return core()->gsfTrack() ; }
     virtual TrackRef closestTrack() const { return core()->ctfTrack() ; }
     float ctfGsfOverlap() const { return core()->ctfGsfOverlap() ; }
     bool ecalDrivenSeed() const { return core()->ecalDrivenSeed() ; }

--- a/DataFormats/EgammaCandidates/interface/Photon.h
+++ b/DataFormats/EgammaCandidates/interface/Photon.h
@@ -41,10 +41,10 @@ namespace reco {
 	    const Point & vtx = Point( 0, 0, 0 ) );
 
     /// destructor
-    virtual ~Photon();
+    ~Photon() override;
 
     /// returns a clone of the candidate
-    virtual Photon * clone() const;
+    Photon * clone() const override;
 
     /// returns a reference to the core photon object
     reco::PhotonCoreRef photonCore() const { return photonCore_;}
@@ -57,7 +57,7 @@ namespace reco {
     bool isPFlowPhoton() const {return this->photonCore()->isPFlowPhoton();}
     bool isStandardPhoton() const {return this->photonCore()->isStandardPhoton();}
     /// Ref to SuperCluster
-    reco::SuperClusterRef superCluster() const;
+    reco::SuperClusterRef superCluster() const override;
     /// Ref to PFlow SuperCluster
     reco::SuperClusterRef parentSuperCluster() const {return this->photonCore()->parentSuperCluster();}
     /// vector of references to  Conversion's
@@ -69,20 +69,20 @@ namespace reco {
     /// vector of references to  one leg Conversion's
     reco::ConversionRefVector conversionsOneLeg() const {return this->photonCore()->conversionsOneLeg() ;} 
     /// Bool flagging photons with a vector of refereces to conversions with size >0
-    bool hasConversionTracks() const { if (this->photonCore()->conversions().size() > 0 || this->photonCore()->conversionsOneLeg().size() > 0)  return true; else return false;}
+    bool hasConversionTracks() const { if (!this->photonCore()->conversions().empty() || !this->photonCore()->conversionsOneLeg().empty())  return true; else return false;}
     /// reference to electron Pixel seed 
     reco::ElectronSeedRefVector electronPixelSeeds() const {return this->photonCore()->electronPixelSeeds();}
     /// Bool flagging photons having a non-zero size vector of Ref to electornPixel seeds
-    bool hasPixelSeed() const { if ((this->photonCore()->electronPixelSeeds()).size() > 0 ) return true; else return false; }
+    bool hasPixelSeed() const { if (!(this->photonCore()->electronPixelSeeds()).empty() ) return true; else return false; }
     int conversionTrackProvenance(const edm::RefToBase<reco::Track>& convTrack) const;
 
  
     /// position in ECAL: this is th SC position if r9<0.93. If r8>0.93 is position of seed BasicCluster taking shower depth for unconverted photon
     math::XYZPointF caloPosition() const {return caloPosition_;}
     /// set primary event vertex used to define photon direction
-    void setVertex(const Point & vertex);
+    void setVertex(const Point & vertex) override;
     /// Implement Candidate method for particle species
-    bool isPhoton() const { return true ; }
+    bool isPhoton() const override { return true ; }
  
 
     //=======================================================
@@ -521,7 +521,7 @@ namespace reco {
     
   private:
     /// check overlap with another candidate
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
     /// position of seed BasicCluster for shower depth of unconverted photon
     math::XYZPointF caloPosition_;
     /// reference to the PhotonCore

--- a/DataFormats/EgammaCandidates/interface/SiStripElectron.h
+++ b/DataFormats/EgammaCandidates/interface/SiStripElectron.h
@@ -71,11 +71,11 @@ namespace reco {
     SiStripElectron( Charge q, const P4 & p4, const Point & vtx = Point( 0, 0, 0 ) ) : 
       RecoCandidate( q, p4, vtx, -11 * q ) { }
     /// destructor
-    virtual ~SiStripElectron();
+    ~SiStripElectron() override;
     /// returns a clone of the candidate
-    virtual SiStripElectron * clone() const;
+    SiStripElectron * clone() const override;
     /// reference to a SuperCluster
-    virtual reco::SuperClusterRef superCluster() const;
+    reco::SuperClusterRef superCluster() const override;
     
     /// reference to the rphiRecHits identified as belonging to an electron
     const std::vector<SiStripRecHit2D>& rphiRecHits() const { return rphiRecHits_; }
@@ -103,10 +103,10 @@ namespace reco {
     /// returns number of endcap zphi hits in phi band
     unsigned int numberOfEndcapZphiHits() const { return numberOfEndcapZphiHits_; }
 
-    bool isElectron() const;
+    bool isElectron() const override;
   private:
     /// check overlap with another candidate
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
     /// reference to a SuperCluster
     reco::SuperClusterRef superCluster_;
     std::vector<SiStripRecHit2D> rphiRecHits_;

--- a/DataFormats/EgammaCandidates/src/Electron.cc
+++ b/DataFormats/EgammaCandidates/src/Electron.cc
@@ -22,7 +22,7 @@ SuperClusterRef Electron::superCluster() const {
 
 bool Electron::overlap( const Candidate & c ) const {
   const RecoCandidate * o = dynamic_cast<const RecoCandidate *>( & c );
-  return ( o != 0 && 
+  return ( o != nullptr && 
 	   ( checkOverlap( track(), o->track() ) ||
 	     checkOverlap( superCluster(), o->superCluster() ) ) 
 	   );

--- a/DataFormats/EgammaCandidates/src/GsfElectron.cc
+++ b/DataFormats/EgammaCandidates/src/GsfElectron.cc
@@ -151,7 +151,7 @@ GsfElectron::GsfElectron
 
 bool GsfElectron::overlap( const Candidate & c ) const {
   const RecoCandidate * o = dynamic_cast<const RecoCandidate *>( & c );
-  return ( o != 0 &&
+  return ( o != nullptr &&
 	   ( checkOverlap( gsfTrack(), o->gsfTrack() ) ||
 	     checkOverlap( superCluster(), o->superCluster() ) )
 	   );

--- a/DataFormats/EgammaCandidates/src/Photon.cc
+++ b/DataFormats/EgammaCandidates/src/Photon.cc
@@ -42,7 +42,7 @@ Photon * Photon::clone() const {
 
 bool Photon::overlap( const Candidate & c ) const {
   const RecoCandidate * o = dynamic_cast<const RecoCandidate *>( & c );
-  return ( o != 0 &&
+  return ( o != nullptr &&
 	   ( checkOverlap( superCluster(), o->superCluster() ) )
 	   );
   return false;

--- a/DataFormats/EgammaCandidates/src/SiStripElectron.cc
+++ b/DataFormats/EgammaCandidates/src/SiStripElectron.cc
@@ -63,7 +63,7 @@ SuperClusterRef SiStripElectron::superCluster() const {
 
 bool SiStripElectron::overlap( const Candidate & c ) const {
   const RecoCandidate * o = dynamic_cast<const RecoCandidate *>( & c );
-  return ( o != 0 && ! 
+  return ( o != nullptr && ! 
 	   ( checkOverlap( track(), o->track() ) ||
 	     checkOverlap( superCluster(), o->superCluster() ) ) 
 	   );

--- a/DataFormats/EgammaReco/interface/ElectronSeed.h
+++ b/DataFormats/EgammaReco/interface/ElectronSeed.h
@@ -81,8 +81,8 @@ namespace reco
     ElectronSeed() ;
     ElectronSeed( const TrajectorySeed & ) ;
     ElectronSeed( PTrajectoryStateOnDet & pts, RecHitContainer & rh,  PropagationDirection & dir ) ;
-    ElectronSeed * clone() const { return new ElectronSeed(*this) ; }
-    virtual ~ElectronSeed();
+    ElectronSeed * clone() const override { return new ElectronSeed(*this) ; }
+    ~ElectronSeed() override;
 
     //! Set additional info
     void setCtfTrack( const CtfTrackRef & ) ;

--- a/DataFormats/EgammaReco/interface/PreshowerCluster.h
+++ b/DataFormats/EgammaReco/interface/PreshowerCluster.h
@@ -21,7 +21,7 @@ namespace reco {
     /// default constructor
     PreshowerCluster() : CaloCluster(0., Point(0.,0.,0.)) { };
 
-    virtual ~PreshowerCluster();
+    ~PreshowerCluster() override;
 
     /// Constructor from EcalRecHits
     PreshowerCluster(const double E, const Point& pos, 

--- a/DataFormats/FP420Cluster/src/ClusterCollectionFP420.cc
+++ b/DataFormats/FP420Cluster/src/ClusterCollectionFP420.cc
@@ -47,7 +47,7 @@ void ClusterCollectionFP420::put(ClusterCollectionFP420::Range input, unsigned i
   }
 
   // since we start from 0, then the last element will be size-1
-  if(container_.size() != 0) {
+  if(!container_.empty()) {
     inputRange.second = container_.size()-1;
   }
   else {

--- a/DataFormats/FP420Cluster/src/RecoCollectionFP420.cc
+++ b/DataFormats/FP420Cluster/src/RecoCollectionFP420.cc
@@ -47,7 +47,7 @@ void RecoCollectionFP420::put(RecoCollectionFP420::Range input, unsigned int sta
   }
   
   // since we start from 0, then the last element will be size-1
-  if(container_.size() != 0) {
+  if(!container_.empty()) {
     inputRange.second = container_.size()-1;
   }
   else {

--- a/DataFormats/FP420Cluster/src/TrackCollectionFP420.cc
+++ b/DataFormats/FP420Cluster/src/TrackCollectionFP420.cc
@@ -47,7 +47,7 @@ void TrackCollectionFP420::put(TrackCollectionFP420::Range input, unsigned int s
   }
 
   // since we start from 0, then the last element will be size-1
-  if(container_.size() != 0) {
+  if(!container_.empty()) {
     inputRange.second = container_.size()-1;
   }
   else {

--- a/DataFormats/FP420Digi/src/DigiCollectionFP420.cc
+++ b/DataFormats/FP420Digi/src/DigiCollectionFP420.cc
@@ -52,7 +52,7 @@ void DigiCollectionFP420::put(Range input, unsigned int detID) {
   } //for
   
   // since we start from 0, then the last element will be size-1
-  if(container_.size() != 0) {
+  if(!container_.empty()) {
     inputRange.second = container_.size()-1;
   }
   else {

--- a/DataFormats/FWLite/interface/ChainEvent.h
+++ b/DataFormats/FWLite/interface/ChainEvent.h
@@ -49,7 +49,7 @@ namespace fwlite {
    public:
 
       ChainEvent(std::vector<std::string> const& iFileNames);
-      virtual ~ChainEvent();
+      ~ChainEvent() override;
 
       ChainEvent const& operator++() override;
 
@@ -66,7 +66,7 @@ namespace fwlite {
       ChainEvent const& toBegin() override;
 
       // ---------- const member functions ---------------------
-      virtual std::string const getBranchNameFor(std::type_info const&,
+      std::string const getBranchNameFor(std::type_info const&,
                                                  char const*,
                                                  char const*,
                                                  char const*) const override;
@@ -74,20 +74,20 @@ namespace fwlite {
       using fwlite::EventBase::getByLabel;
 
       // This function should only be called by fwlite::Handle<>
-      virtual bool getByLabel(std::type_info const&, char const*, char const*, char const*, void*) const override;
+      bool getByLabel(std::type_info const&, char const*, char const*, char const*, void*) const override;
       //void getByBranchName(std::type_info const&, char const*, void*&) const;
 
       bool isValid() const;
       operator bool() const;
-      virtual bool atEnd() const override;
+      bool atEnd() const override;
 
       Long64_t size() const;
 
-      virtual edm::EventAuxiliary const& eventAuxiliary() const override;
+      edm::EventAuxiliary const& eventAuxiliary() const override;
 
       std::vector<edm::BranchDescription> const& getBranchDescriptions() const;
       std::vector<std::string> const& getProcessHistory() const;
-      virtual edm::ProcessHistory const& processHistory() const override;
+      edm::ProcessHistory const& processHistory() const override;
       TFile* getTFile() const {
         return event_->getTFile();
       }
@@ -99,7 +99,7 @@ namespace fwlite {
       // 0 events. To get the path of the file where the current event resides
       // in, fwlite::ChainEvent::getTFile()->GetPath() is preferred.
       Long64_t eventIndex() const { return eventIndex_; }
-      virtual Long64_t fileIndex() const override { return eventIndex_; }
+      Long64_t fileIndex() const override { return eventIndex_; }
 
       void setGetter(std::shared_ptr<edm::EDProductGetter const> getter){
          event_->setGetter(getter);
@@ -107,18 +107,18 @@ namespace fwlite {
 
       Event const* event() const { return &*event_; }
 
-      virtual edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const override;
+      edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const override;
       void fillParameterSetRegistry() const ;
-      virtual edm::TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const override;
+      edm::TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const override;
 
-      virtual edm::ParameterSet const* parameterSet(edm::ParameterSetID const& psID) const override;
+      edm::ParameterSet const* parameterSet(edm::ParameterSetID const& psID) const override;
 
       // ---------- static member functions --------------------
       static void throwProductNotFoundException(std::type_info const&, char const*, char const*, char const*);
 
       // ---------- member functions ---------------------------
 
-      virtual edm::WrapperBase const* getByProductID(edm::ProductID const&) const override;
+      edm::WrapperBase const* getByProductID(edm::ProductID const&) const override;
       edm::WrapperBase const* getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const;
 
       void getThinnedProducts(edm::ProductID const& pid,

--- a/DataFormats/FWLite/interface/EventBase.h
+++ b/DataFormats/FWLite/interface/EventBase.h
@@ -39,7 +39,7 @@ namespace fwlite
       public:
          EventBase();
 
-         virtual ~EventBase();
+         ~EventBase() override;
 
          virtual bool getByLabel(
                                   std::type_info const&,
@@ -68,8 +68,8 @@ namespace fwlite
 
       private:
 
-         virtual edm::BasicHandle getByLabelImpl(std::type_info const&, std::type_info const&, const edm::InputTag&) const;
-         virtual edm::BasicHandle getImpl(std::type_info const&, edm::ProductID const&) const;
+         edm::BasicHandle getByLabelImpl(std::type_info const&, std::type_info const&, const edm::InputTag&) const override;
+         edm::BasicHandle getImpl(std::type_info const&, edm::ProductID const&) const override;
    };
 } // fwlite namespace
 

--- a/DataFormats/FWLite/interface/EventHistoryGetter.h
+++ b/DataFormats/FWLite/interface/EventHistoryGetter.h
@@ -25,15 +25,15 @@ namespace fwlite {
     class EventHistoryGetter : public HistoryGetterBase{
         public:
             EventHistoryGetter(const Event*);
-            virtual ~EventHistoryGetter();
+            ~EventHistoryGetter() override;
 
             // ---------- const member functions ---------------------
-            const edm::ProcessHistory& history() const;
+            const edm::ProcessHistory& history() const override;
 
         private:
-            EventHistoryGetter(const EventHistoryGetter&); // stop default
+            EventHistoryGetter(const EventHistoryGetter&) = delete; // stop default
 
-            const EventHistoryGetter& operator=(const EventHistoryGetter&); // stop default
+            const EventHistoryGetter& operator=(const EventHistoryGetter&) = delete; // stop default
 
             // ---------- member data --------------------------------
             const fwlite::Event* event_;

--- a/DataFormats/FWLite/interface/EventSetup.h
+++ b/DataFormats/FWLite/interface/EventSetup.h
@@ -98,9 +98,9 @@ namespace fwlite
    
 
    private:
-      EventSetup(const EventSetup&); // stop default
+      EventSetup(const EventSetup&) = delete; // stop default
 
-      const EventSetup& operator=(const EventSetup&); // stop default
+      const EventSetup& operator=(const EventSetup&) = delete; // stop default
 
       // ---------- member data --------------------------------
       edm::EventID m_syncedEvent;

--- a/DataFormats/FWLite/interface/HistoryGetterBase.h
+++ b/DataFormats/FWLite/interface/HistoryGetterBase.h
@@ -30,9 +30,9 @@ namespace fwlite {
             virtual const edm::ProcessHistory& history() const = 0;
 
         private:
-            HistoryGetterBase(const HistoryGetterBase&); // stop default
+            HistoryGetterBase(const HistoryGetterBase&) = delete; // stop default
 
-            const HistoryGetterBase& operator=(const HistoryGetterBase&); // stop default
+            const HistoryGetterBase& operator=(const HistoryGetterBase&) = delete; // stop default
 
             // ---------- member data --------------------------------
     };

--- a/DataFormats/FWLite/interface/LumiHistoryGetter.h
+++ b/DataFormats/FWLite/interface/LumiHistoryGetter.h
@@ -25,15 +25,15 @@ namespace fwlite {
     class LumiHistoryGetter : public HistoryGetterBase{
         public:
             LumiHistoryGetter(const LuminosityBlock*);
-            virtual ~LumiHistoryGetter();
+            ~LumiHistoryGetter() override;
 
             // ---------- const member functions ---------------------
-            const edm::ProcessHistory& history() const;
+            const edm::ProcessHistory& history() const override;
 
         private:
-            LumiHistoryGetter(const LumiHistoryGetter&); // stop default
+            LumiHistoryGetter(const LumiHistoryGetter&) = delete; // stop default
 
-            const LumiHistoryGetter& operator=(const LumiHistoryGetter&); // stop default
+            const LumiHistoryGetter& operator=(const LumiHistoryGetter&) = delete; // stop default
 
             // ---------- member data --------------------------------
             const fwlite::LuminosityBlock* lumi_;

--- a/DataFormats/FWLite/interface/LuminosityBlock.h
+++ b/DataFormats/FWLite/interface/LuminosityBlock.h
@@ -61,15 +61,15 @@ namespace fwlite {
          // at least as long as LuminosityBlock
          LuminosityBlock(TFile* iFile);
          LuminosityBlock(std::shared_ptr<BranchMapReader> branchMap,  std::shared_ptr<RunFactory> runFactory);
-         virtual ~LuminosityBlock();
+         ~LuminosityBlock() override;
 
-         const LuminosityBlock& operator++();
+         const LuminosityBlock& operator++() override;
 
          /// Go to event by Run & LuminosityBlock number
          bool to (edm::RunNumber_t run, edm::LuminosityBlockNumber_t lumi);
 
          // Go to the very first Event.
-         const LuminosityBlock& toBegin();
+         const LuminosityBlock& toBegin() override;
 
          // ---------- const member functions ---------------------
          virtual std::string const getBranchNameFor(std::type_info const&,
@@ -79,16 +79,16 @@ namespace fwlite {
 
          // This function should only be called by fwlite::Handle<>
          using fwlite::LuminosityBlockBase::getByLabel;
-         virtual bool getByLabel(std::type_info const&, char const*, char const*, char const*, void*) const;
+         bool getByLabel(std::type_info const&, char const*, char const*, char const*, void*) const override;
          //void getByBranchName(std::type_info const&, char const*, void*&) const;
 
          bool isValid() const;
          operator bool () const;
-         virtual bool atEnd() const;
+         bool atEnd() const override;
 
          Long64_t size() const;
 
-         virtual edm::LuminosityBlockAuxiliary const& luminosityBlockAuxiliary() const;
+         edm::LuminosityBlockAuxiliary const& luminosityBlockAuxiliary() const override;
 
          std::vector<edm::BranchDescription> const& getBranchDescriptions() const {
             return branchMap_->getBranchDescriptions();
@@ -108,9 +108,9 @@ namespace fwlite {
          friend class internal::ProductGetter;
          friend class LumiHistoryGetter;
 
-         LuminosityBlock(const LuminosityBlock&); // stop default
+         LuminosityBlock(const LuminosityBlock&) = delete; // stop default
 
-         const LuminosityBlock& operator=(const LuminosityBlock&); // stop default
+         const LuminosityBlock& operator=(const LuminosityBlock&) = delete; // stop default
 
          const edm::ProcessHistory& history() const;
          void updateAux(Long_t lumiIndex) const;

--- a/DataFormats/FWLite/interface/LuminosityBlockBase.h
+++ b/DataFormats/FWLite/interface/LuminosityBlockBase.h
@@ -33,7 +33,7 @@ namespace fwlite
       public:
          LuminosityBlockBase();
 
-         virtual ~LuminosityBlockBase();
+         ~LuminosityBlockBase() override;
 
          virtual bool getByLabel(
                                   std::type_info const&,
@@ -55,7 +55,7 @@ namespace fwlite
 
       private:
 
-         virtual edm::BasicHandle getByLabelImpl(std::type_info const&, std::type_info const&, const edm::InputTag&) const;
+         edm::BasicHandle getByLabelImpl(std::type_info const&, std::type_info const&, const edm::InputTag&) const override;
    };
 } // fwlite namespace
 

--- a/DataFormats/FWLite/interface/MultiChainEvent.h
+++ b/DataFormats/FWLite/interface/MultiChainEvent.h
@@ -59,7 +59,7 @@ class MultiChainEvent: public EventBase
       MultiChainEvent(std::vector<std::string> const& iFileNames1,
 		      std::vector<std::string> const& iFileNames2,
 		      bool useSecFileMapSorted = false);
-      virtual ~MultiChainEvent();
+      ~MultiChainEvent() override;
 
       const MultiChainEvent& operator++() override;
 
@@ -76,7 +76,7 @@ class MultiChainEvent: public EventBase
       const MultiChainEvent& toBegin() override;
 
       // ---------- const member functions ---------------------
-      virtual std::string const getBranchNameFor(std::type_info const&,
+      std::string const getBranchNameFor(std::type_info const&,
                                                  char const*,
                                                  char const*,
                                                  char const*) const override;
@@ -84,7 +84,7 @@ class MultiChainEvent: public EventBase
       using fwlite::EventBase::getByLabel;
 
       /** This function should only be called by fwlite::Handle<>*/
-      virtual bool getByLabel(std::type_info const&, char const*, char const*, char const*, void*) const override;
+      bool getByLabel(std::type_info const&, char const*, char const*, char const*, void*) const override;
       //void getByBranchName(std::type_info const&, char const*, void*&) const;
 
       bool isValid() const;
@@ -93,7 +93,7 @@ class MultiChainEvent: public EventBase
 
       Long64_t size() const;
 
-      virtual edm::EventAuxiliary const& eventAuxiliary() const override;
+      edm::EventAuxiliary const& eventAuxiliary() const override;
 
       std::vector<edm::BranchDescription> const& getBranchDescriptions() const;
       std::vector<std::string> const& getProcessHistory() const;
@@ -117,15 +117,15 @@ class MultiChainEvent: public EventBase
       }
 
 
-      virtual Long64_t fileIndex()          const override
+      Long64_t fileIndex()          const override
       { return event1_->eventIndex(); }
-      virtual Long64_t secondaryFileIndex() const override
+      Long64_t secondaryFileIndex() const override
       { return event2_->eventIndex(); }
 
-      virtual edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const override;
-      virtual edm::TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const override;
+      edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const override;
+      edm::TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const override;
 
-      virtual edm::ParameterSet const* parameterSet(edm::ParameterSetID const& psID) const override;
+      edm::ParameterSet const* parameterSet(edm::ParameterSetID const& psID) const override;
 
       // ---------- static member functions --------------------
       static void throwProductNotFoundException(std::type_info const&, char const*, char const*, char const*);
@@ -136,7 +136,7 @@ class MultiChainEvent: public EventBase
 
       // ---------- member functions ---------------------------
 
-      virtual edm::WrapperBase const* getByProductID(edm::ProductID const&) const override;
+      edm::WrapperBase const* getByProductID(edm::ProductID const&) const override;
 
       edm::WrapperBase const* getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const;
 

--- a/DataFormats/FWLite/interface/Record.h
+++ b/DataFormats/FWLite/interface/Record.h
@@ -65,9 +65,9 @@ namespace fwlite
       void syncTo(const edm::EventID&, const edm::Timestamp&);
 
    private:
-      Record(const Record&); // stop default
+      Record(const Record&) = delete; // stop default
 
-      const Record& operator=(const Record&); // stop default
+      const Record& operator=(const Record&) = delete; // stop default
 
       cms::Exception* get(const edm::TypeID&, const char* iLabel, const void*&) const;
       void resetCaches();

--- a/DataFormats/FWLite/interface/Run.h
+++ b/DataFormats/FWLite/interface/Run.h
@@ -58,15 +58,15 @@ namespace fwlite {
          // at least as long as Run
          Run(TFile* iFile);
          Run(std::shared_ptr<BranchMapReader> branchMap);
-         virtual ~Run();
+         ~Run() override;
 
-         const Run& operator++();
+         const Run& operator++() override;
 
          /// Go to event by Run & Run number
          bool to (edm::RunNumber_t run);
 
          // Go to the very first Event.
-         const Run& toBegin();
+         const Run& toBegin() override;
 
          // ---------- const member functions ---------------------
          virtual std::string const getBranchNameFor(std::type_info const&,
@@ -76,16 +76,16 @@ namespace fwlite {
 
          // This function should only be called by fwlite::Handle<>
          using fwlite::RunBase::getByLabel;
-         virtual bool getByLabel(std::type_info const&, char const*, char const*, char const*, void*) const;
+         bool getByLabel(std::type_info const&, char const*, char const*, char const*, void*) const override;
          //void getByBranchName(std::type_info const&, char const*, void*&) const;
 
          bool isValid() const;
          operator bool () const;
-         virtual bool atEnd() const;
+         bool atEnd() const override;
 
          Long64_t size() const;
 
-         virtual edm::RunAuxiliary const& runAuxiliary() const;
+         edm::RunAuxiliary const& runAuxiliary() const override;
 
          std::vector<edm::BranchDescription> const& getBranchDescriptions() const {
             return branchMap_->getBranchDescriptions();
@@ -104,9 +104,9 @@ namespace fwlite {
          friend class internal::ProductGetter;
          friend class RunHistoryGetter;
 
-         Run(const Run&); // stop default
+         Run(const Run&) = delete; // stop default
 
-         const Run& operator=(const Run&); // stop default
+         const Run& operator=(const Run&) = delete; // stop default
 
          const edm::ProcessHistory& history() const;
          void updateAux(Long_t runIndex) const;

--- a/DataFormats/FWLite/interface/RunBase.h
+++ b/DataFormats/FWLite/interface/RunBase.h
@@ -35,7 +35,7 @@ namespace fwlite
       public:
          RunBase();
 
-         virtual ~RunBase();
+         ~RunBase() override;
 
          virtual bool getByLabel(
                                   std::type_info const&,
@@ -62,7 +62,7 @@ namespace fwlite
 
       private:
 
-         virtual edm::BasicHandle getByLabelImpl(std::type_info const&, std::type_info const&, const edm::InputTag&) const;
+         edm::BasicHandle getByLabelImpl(std::type_info const&, std::type_info const&, const edm::InputTag&) const override;
    };
 } // fwlite namespace
 

--- a/DataFormats/FWLite/interface/RunFactory.h
+++ b/DataFormats/FWLite/interface/RunFactory.h
@@ -32,9 +32,9 @@ namespace fwlite {
             std::shared_ptr<fwlite::Run> makeRun(std::shared_ptr<BranchMapReader> branchMap) const;
 
         private:
-            RunFactory(const RunFactory&); // stop default
+            RunFactory(const RunFactory&) = delete; // stop default
 
-            const RunFactory& operator=(const RunFactory&); // stop default
+            const RunFactory& operator=(const RunFactory&) = delete; // stop default
             mutable std::shared_ptr<fwlite::Run> run_;
 
 

--- a/DataFormats/FWLite/interface/RunHistoryGetter.h
+++ b/DataFormats/FWLite/interface/RunHistoryGetter.h
@@ -25,15 +25,15 @@ namespace fwlite {
     class RunHistoryGetter : public HistoryGetterBase{
         public:
             RunHistoryGetter(const Run*);
-            virtual ~RunHistoryGetter();
+            ~RunHistoryGetter() override;
 
             // ---------- const member functions ---------------------
-            const edm::ProcessHistory& history() const;
+            const edm::ProcessHistory& history() const override;
 
         private:
-            RunHistoryGetter(const RunHistoryGetter&); // stop default
+            RunHistoryGetter(const RunHistoryGetter&) = delete; // stop default
 
-            const RunHistoryGetter& operator=(const RunHistoryGetter&); // stop default
+            const RunHistoryGetter& operator=(const RunHistoryGetter&) = delete; // stop default
 
             // ---------- member data --------------------------------
             const fwlite::Run* run_;

--- a/DataFormats/FWLite/src/ChainEvent.cc
+++ b/DataFormats/FWLite/src/ChainEvent.cc
@@ -62,7 +62,7 @@ ChainEvent::ChainEvent(std::vector<std::string> const& iFileNames):
   // total accumulated size (last enry + 1) at the end of last file
   accumulatedSize_.push_back(summedSize);
 
-  if (fileNames_.size() > 0)
+  if (!fileNames_.empty())
     switchToFile(0);
 }
 

--- a/DataFormats/FWLite/src/EntryFinder.cc
+++ b/DataFormats/FWLite/src/EntryFinder.cc
@@ -34,8 +34,8 @@ namespace fwlite {
   class FWLiteEventFinder : public edm::IndexIntoFile::EventFinder {
   public:
     explicit FWLiteEventFinder(TBranch* auxBranch) : auxBranch_(auxBranch) {}
-    virtual ~FWLiteEventFinder() {}
-    virtual
+    ~FWLiteEventFinder() override {}
+    
     edm::EventNumber_t getEventNumberOfEntry(edm::IndexIntoFile::EntryNumber_t entry) const override {
       void* saveAddress = auxBranch_->GetAddress();
       edm::EventAuxiliary eventAux;
@@ -112,7 +112,7 @@ namespace fwlite {
         throw cms::Exception("NoMetaTree") << "The TFile does not contain a TTree named "
           << edm::poolNames::metaDataTreeName();
       }
-      if (meta->FindBranch(edm::poolNames::indexIntoFileBranchName().c_str()) != 0) {
+      if (meta->FindBranch(edm::poolNames::indexIntoFileBranchName().c_str()) != nullptr) {
         edm::IndexIntoFile* indexPtr = &indexIntoFile_;
         TBranch* b = meta->GetBranch(edm::poolNames::indexIntoFileBranchName().c_str());
         b->SetAddress(&indexPtr);
@@ -128,7 +128,7 @@ namespace fwlite {
         indexIntoFile_.setNumberOfEvents(auxBranch->GetEntries());
         indexIntoFile_.setEventFinder(std::shared_ptr<edm::IndexIntoFile::EventFinder>(std::make_shared<FWLiteEventFinder>(auxBranch)));
 
-      } else if (meta->FindBranch(edm::poolNames::fileIndexBranchName().c_str()) != 0) {
+      } else if (meta->FindBranch(edm::poolNames::fileIndexBranchName().c_str()) != nullptr) {
         edm::FileIndex* findexPtr = &fileIndex_;
         TBranch* b = meta->GetBranch(edm::poolNames::fileIndexBranchName().c_str());
         b->SetAddress(&findexPtr);

--- a/DataFormats/FWLite/src/ErrorThrower.cc
+++ b/DataFormats/FWLite/src/ErrorThrower.cc
@@ -35,7 +35,7 @@ namespace {
          <<"'\n  productInstance='"<<((nullptr != instance_)?instance_:"")<<"'\n  process='"<<((nullptr != process_)?process_:"")<<"'\n"
          "but no data is available for this Event";
       }
-      virtual ErrorThrower* clone() const override {
+      ErrorThrower* clone() const override {
          return new NoProductErrorThrower(*this);
       }
 
@@ -58,7 +58,7 @@ namespace {
          <<"'\n  productInstance='"<<((nullptr != instance_)?instance_:"")<<"'\n  process='"<<((nullptr != process_)?process_:"")<<"'";
       }
       
-      virtual ErrorThrower* clone() const override {
+      ErrorThrower* clone() const override {
          return new NoBranchErrorThrower(*this);
       }
       
@@ -74,7 +74,7 @@ namespace {
          throw cms::Exception("UnsetHandle")<<"The fwlite::Handle was never set";
       }
       
-      virtual ErrorThrower* clone() const override {
+      ErrorThrower* clone() const override {
          return new UnsetErrorThrower(*this);
       }
       

--- a/DataFormats/FWLite/src/MultiChainEvent.cc
+++ b/DataFormats/FWLite/src/MultiChainEvent.cc
@@ -31,24 +31,24 @@ namespace fwlite {
 public:
       MultiProductGetter(MultiChainEvent const* iEvent) : event_(iEvent) {}
 
-      virtual edm::WrapperBase const*
+      edm::WrapperBase const*
       getIt(edm::ProductID const& iID) const override {
         return event_->getByProductID(iID);
       }
 
-      virtual edm::WrapperBase const*
+      edm::WrapperBase const*
       getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const override {
         return event_->getThinnedProduct(pid, key);
       }
 
-      virtual void getThinnedProducts(edm::ProductID const& pid,
+      void getThinnedProducts(edm::ProductID const& pid,
                                       std::vector<edm::WrapperBase const*>& foundContainers,
                                       std::vector<unsigned int>& keys) const override {
         event_->getThinnedProducts(pid, foundContainers, keys);
       }
 
 private:
-      virtual unsigned int transitionIndex_() const override {
+      unsigned int transitionIndex_() const override {
         return 0U;
       }
 

--- a/DataFormats/GEMRecHit/interface/GEMCSCSegment.h
+++ b/DataFormats/GEMRecHit/interface/GEMCSCSegment.h
@@ -34,31 +34,31 @@ public:
     GEMCSCSegment(const CSCSegment* csc_segment, const std::vector<const GEMRecHit*> gem_rhs, LocalPoint origin, LocalVector direction, AlgebraicSymMatrix errors, double chi2);
       
     /// Destructor
-    virtual ~GEMCSCSegment();
+    ~GEMCSCSegment() override;
 
     //--- Base class interface
-    GEMCSCSegment* clone() const { return new GEMCSCSegment(*this); }
+    GEMCSCSegment* clone() const override { return new GEMCSCSegment(*this); }
 
-    LocalPoint localPosition() const { return theOrigin; }
-    LocalError localPositionError() const ;
+    LocalPoint localPosition() const override { return theOrigin; }
+    LocalError localPositionError() const override ;
 	
-    LocalVector localDirection() const { return theLocalDirection; }
-    LocalError localDirectionError() const ;
+    LocalVector localDirection() const override { return theLocalDirection; }
+    LocalError localDirectionError() const override ;
 
     /// Parameters of the segment, for the track fit in the order (dx/dz, dy/dz, x, y )
-    AlgebraicVector parameters() const;
+    AlgebraicVector parameters() const override;
 
     /// Covariance matrix of parameters()
-    AlgebraicSymMatrix parametersError() const { return theCovMatrix; }
+    AlgebraicSymMatrix parametersError() const override { return theCovMatrix; }
 
     /// The projection matrix relates the trajectory state parameters to the segment parameters().
-    virtual AlgebraicMatrix projectionMatrix() const;
+    AlgebraicMatrix projectionMatrix() const override;
 
-    double chi2() const { return theChi2; };
+    double chi2() const override { return theChi2; };
 
-    virtual int dimension() const { return 4; }
+    int dimension() const override { return 4; }
 
-    virtual int degreesOfFreedom() const { return 2*nRecHits() - 4;}
+    int degreesOfFreedom() const override { return 2*nRecHits() - 4;}
 
     int nRecHits() const 
     { 
@@ -72,8 +72,8 @@ public:
     const CSCSegment                        cscSegment() const { return theCSCSegment; }
     const std::vector<GEMRecHit>&           gemRecHits() const { return theGEMRecHits; }
     const std::vector<CSCRecHit2D>&         cscRecHits() const { return theCSCSegment.specificRecHits(); }
-    virtual std::vector<const TrackingRecHit*> recHits() const;
-    virtual std::vector<TrackingRecHit*>       recHits();
+    std::vector<const TrackingRecHit*> recHits() const override;
+    std::vector<TrackingRecHit*>       recHits() override;
 
     CSCDetId cscDetId() const { return  geographicalId(); }
     

--- a/DataFormats/GEMRecHit/interface/GEMRecHit.h
+++ b/DataFormats/GEMRecHit/interface/GEMRecHit.h
@@ -46,32 +46,32 @@ class GEMRecHit : public RecHit2DLocalPos {
 	    const LocalError& err);
   
   /// Destructor
-  virtual ~GEMRecHit();
+  ~GEMRecHit() override;
 
 
   /// Return the 3-dimensional local position
-  virtual LocalPoint localPosition() const {
+  LocalPoint localPosition() const override {
     return theLocalPosition;
   }
 
 
   /// Return the 3-dimensional error on the local position
-  virtual LocalError localPositionError() const {
+  LocalError localPositionError() const override {
     return theLocalError;
   }
 
 
-  virtual GEMRecHit* clone() const;
+  GEMRecHit* clone() const override;
 
   
   /// Access to component RecHits.
   /// No components rechits: it returns a null vector
-  virtual std::vector<const TrackingRecHit*> recHits() const;
+  std::vector<const TrackingRecHit*> recHits() const override;
 
 
   /// Non-const access to component RecHits.
   /// No components rechits: it returns a null vector
-  virtual std::vector<TrackingRecHit*> recHits();
+  std::vector<TrackingRecHit*> recHits() override;
 
 
   /// Set local position 

--- a/DataFormats/GEMRecHit/interface/GEMSegment.h
+++ b/DataFormats/GEMRecHit/interface/GEMSegment.h
@@ -34,35 +34,35 @@ public:
 	       const LocalVector& direction, const AlgebraicSymMatrix& errors, double chi2, double time, double timeErr);
   
     /// Destructor
-    virtual ~GEMSegment();
+    ~GEMSegment() override;
 
     //--- Base class interface
-    GEMSegment* clone() const { return new GEMSegment(*this); }
+    GEMSegment* clone() const override { return new GEMSegment(*this); }
 
-    LocalPoint localPosition() const { return theOrigin; }
-    LocalError localPositionError() const ;
+    LocalPoint localPosition() const override { return theOrigin; }
+    LocalError localPositionError() const override ;
 	
-    LocalVector localDirection() const { return theLocalDirection; }
-    LocalError localDirectionError() const ;
+    LocalVector localDirection() const override { return theLocalDirection; }
+    LocalError localDirectionError() const override ;
 
     /// Parameters of the segment, for the track fit in the order (dx/dz, dy/dz, x, y )
-    AlgebraicVector parameters() const;
+    AlgebraicVector parameters() const override;
 
     /// Covariance matrix of parameters()
-    AlgebraicSymMatrix parametersError() const { return theCovMatrix; }
+    AlgebraicSymMatrix parametersError() const override { return theCovMatrix; }
 
     /// The projection matrix relates the trajectory state parameters to the segment parameters().
-    virtual AlgebraicMatrix projectionMatrix() const;
+    AlgebraicMatrix projectionMatrix() const override;
 
-    virtual std::vector<const TrackingRecHit*> recHits() const;
+    std::vector<const TrackingRecHit*> recHits() const override;
 
-    virtual std::vector<TrackingRecHit*> recHits();
+    std::vector<TrackingRecHit*> recHits() override;
 
-    double chi2() const { return theChi2; };
+    double chi2() const override { return theChi2; };
 
-    virtual int dimension() const { return 4; }
+    int dimension() const override { return 4; }
 
-    virtual int degreesOfFreedom() const { return 2*nRecHits() - 4;}	 
+    int degreesOfFreedom() const override { return 2*nRecHits() - 4;}	 
 
     //--- Extension of the interface
         

--- a/DataFormats/GEMRecHit/interface/ME0RecHit.h
+++ b/DataFormats/GEMRecHit/interface/ME0RecHit.h
@@ -40,32 +40,32 @@ const LocalError& err);
   
 
   /// Destructor
-  virtual ~ME0RecHit();
+  ~ME0RecHit() override;
 
 
   /// Return the 3-dimensional local position
-  virtual LocalPoint localPosition() const {
+  LocalPoint localPosition() const override {
     return theLocalPosition;
   }
 
 
   /// Return the 3-dimensional error on the local position
-  virtual LocalError localPositionError() const {
+  LocalError localPositionError() const override {
     return theLocalError;
   }
 
 
-  virtual ME0RecHit* clone() const;
+  ME0RecHit* clone() const override;
 
   
   /// Access to component RecHits.
   /// No components rechits: it returns a null vector
-  virtual std::vector<const TrackingRecHit*> recHits() const;
+  std::vector<const TrackingRecHit*> recHits() const override;
 
 
   /// Non-const access to component RecHits.
   /// No components rechits: it returns a null vector
-  virtual std::vector<TrackingRecHit*> recHits();
+  std::vector<TrackingRecHit*> recHits() override;
 
 
   /// Set local position

--- a/DataFormats/GEMRecHit/interface/ME0Segment.h
+++ b/DataFormats/GEMRecHit/interface/ME0Segment.h
@@ -32,35 +32,35 @@ class ME0Segment final : public RecSegment {
 	     const LocalVector& direction, const AlgebraicSymMatrix& errors, float chi2, float time, float timeErr, float deltaPhi);
   
   /// Destructor
-  virtual ~ME0Segment();
+  ~ME0Segment() override;
 
   //--- Base class interface
-  ME0Segment* clone() const { return new ME0Segment(*this); }
+  ME0Segment* clone() const override { return new ME0Segment(*this); }
 
-  LocalPoint localPosition() const { return theOrigin; }
-  LocalError localPositionError() const ;
+  LocalPoint localPosition() const override { return theOrigin; }
+  LocalError localPositionError() const override ;
 	
-  LocalVector localDirection() const { return theLocalDirection; }
-  LocalError localDirectionError() const ;
+  LocalVector localDirection() const override { return theLocalDirection; }
+  LocalError localDirectionError() const override ;
 
   /// Parameters of the segment, for the track fit in the order (dx/dz, dy/dz, x, y )
-  AlgebraicVector parameters() const;
+  AlgebraicVector parameters() const override;
 
   /// Covariance matrix of parameters()
-  AlgebraicSymMatrix parametersError() const { return theCovMatrix; }
+  AlgebraicSymMatrix parametersError() const override { return theCovMatrix; }
 
   /// The projection matrix relates the trajectory state parameters to the segment parameters().
-  virtual AlgebraicMatrix projectionMatrix() const;
+  AlgebraicMatrix projectionMatrix() const override;
 
-  virtual std::vector<const TrackingRecHit*> recHits() const;
+  std::vector<const TrackingRecHit*> recHits() const override;
 
-  virtual std::vector<TrackingRecHit*> recHits();
+  std::vector<TrackingRecHit*> recHits() override;
 
-  double chi2() const { return theChi2; };
+  double chi2() const override { return theChi2; };
 
-  virtual int dimension() const { return 4; }
+  int dimension() const override { return 4; }
 
-  virtual int degreesOfFreedom() const { return 2*nRecHits() - 4;}	 
+  int degreesOfFreedom() const override { return 2*nRecHits() - 4;}	 
 
   //--- Extension of the interface
         

--- a/DataFormats/GeometryCommonDetAlgo/interface/ErrorFrameTransformer.h
+++ b/DataFormats/GeometryCommonDetAlgo/interface/ErrorFrameTransformer.h
@@ -57,7 +57,7 @@ struct   ErrorFrameTransformer {
   //new Jacobian for 6x6 APE in muon code
   static LocalErrorExtended transform46(const GlobalErrorExtended& ge, const AlgebraicVector& positions, const AlgebraicVector& directions) {
 
-    AlgebraicSymMatrix66 as(ge.matrix());
+    const AlgebraicSymMatrix66& as(ge.matrix());
 
     AlgebraicMatrix46 jacobian46;
     jacobian46[0][0] = 1.;

--- a/DataFormats/GeometrySurface/interface/BoundDisk.h
+++ b/DataFormats/GeometrySurface/interface/BoundDisk.h
@@ -42,7 +42,7 @@ public:
   }
 
 
-  virtual ~Disk() {}
+  ~Disk() override {}
 
 
   // -- DEPRECATED CONSTRUCTORS

--- a/DataFormats/GeometrySurface/interface/Cone.h
+++ b/DataFormats/GeometrySurface/interface/Cone.h
@@ -60,13 +60,13 @@ public:
 
   // -- Implementation of Surface interface    
 
-  virtual Side side( const LocalPoint& p, Scalar tolerance) const {return side( toGlobal(p), tolerance);}
-  virtual Side side( const GlobalPoint& p, Scalar tolerance) const;
+  Side side( const LocalPoint& p, Scalar tolerance) const override {return side( toGlobal(p), tolerance);}
+  Side side( const GlobalPoint& p, Scalar tolerance) const override;
 
   // Tangent plane to surface from global point
-  virtual ConstReferenceCountingPointer<TangentPlane> tangentPlane (const GlobalPoint&) const;
+  ConstReferenceCountingPointer<TangentPlane> tangentPlane (const GlobalPoint&) const override;
   // Tangent plane to surface from local point
-  virtual ConstReferenceCountingPointer<TangentPlane> tangentPlane (const LocalPoint&) const;
+  ConstReferenceCountingPointer<TangentPlane> tangentPlane (const LocalPoint&) const override;
 
 
 private:

--- a/DataFormats/GeometrySurface/interface/Cylinder.h
+++ b/DataFormats/GeometrySurface/interface/Cylinder.h
@@ -49,16 +49,16 @@ public:
   */
 
   static CylinderPointer build(const PositionType& pos, const RotationType& rot,
-			       Scalar radius, Bounds* bounds=0) {
+			       Scalar radius, Bounds* bounds=nullptr) {
     return CylinderPointer(new Cylinder(radius,pos,rot,bounds));
   }
 
   static CylinderPointer build(Scalar radius, const PositionType& pos, const RotationType& rot,
-			       Bounds* bounds=0) {
+			       Bounds* bounds=nullptr) {
     return CylinderPointer(new Cylinder(radius,pos,rot,bounds));
   }
 
-  ~Cylinder(){}
+  ~Cylinder() override{}
 
 
   // -- Extension of Surface interface for cylinder
@@ -69,12 +69,12 @@ public:
   // -- Implementation of Surface interface    
 
   using Surface::side;
-  virtual Side side( const LocalPoint& p, Scalar toler) const;
+  Side side( const LocalPoint& p, Scalar toler) const override;
 
   /// tangent plane to surface from global point
-  virtual ConstReferenceCountingPointer<TangentPlane> tangentPlane (const GlobalPoint&) const;
+  ConstReferenceCountingPointer<TangentPlane> tangentPlane (const GlobalPoint&) const override;
   /// tangent plane to surface from local point
-  virtual ConstReferenceCountingPointer<TangentPlane> tangentPlane (const LocalPoint&) const;
+  ConstReferenceCountingPointer<TangentPlane> tangentPlane (const LocalPoint&) const override;
 
   /// tangent plane to surface from global point
   Plane fastTangent(const GlobalPoint& aPoint) const{

--- a/DataFormats/GeometrySurface/interface/GeneralNSurfaceDelimitedBounds.h
+++ b/DataFormats/GeometrySurface/interface/GeneralNSurfaceDelimitedBounds.h
@@ -23,20 +23,20 @@ public:
 				    const std::vector<SurfaceAndSide>& limits) :
 	theLimits( limits), theSurface(surf) {}
 
-  virtual float length()    const { return 0;}
-  virtual float width()     const { return 0;}
-  virtual float thickness() const { return 0;}
+  float length()    const override { return 0;}
+  float width()     const override { return 0;}
+  float thickness() const override { return 0;}
 
 
   using Bounds::inside;
 
-  virtual bool inside( const Local3DPoint& lp) const {
+  bool inside( const Local3DPoint& lp) const override {
     return myInside(lp,0);
   }
     
-  virtual bool inside( const Local3DPoint&, const LocalError&, float scale=1.f) const;
+  bool inside( const Local3DPoint&, const LocalError&, float scale=1.f) const override;
 
-  virtual Bounds* clone() const {return new GeneralNSurfaceDelimitedBounds(*this);}
+  Bounds* clone() const override {return new GeneralNSurfaceDelimitedBounds(*this);}
     
 private:
 

--- a/DataFormats/GeometrySurface/interface/GeomExceptions.h
+++ b/DataFormats/GeometrySurface/interface/GeomExceptions.h
@@ -8,8 +8,8 @@ class BaseGeomException : public std::exception {
 public:
   BaseGeomException() throw() {}
   BaseGeomException( const std::string& message) : theMessage(message) {}
-  virtual ~BaseGeomException() throw() {}
-  virtual const char* what() const throw() { return theMessage.c_str();}
+  ~BaseGeomException() throw() override {}
+  const char* what() const throw() override { return theMessage.c_str();}
 private:
   std::string theMessage;
 };
@@ -18,7 +18,7 @@ class GeometryError : public BaseGeomException {
 public:
   GeometryError() throw() {}
   GeometryError( const std::string& message) : BaseGeomException(message) {}
-  virtual ~GeometryError() throw() {}
+  ~GeometryError() throw() override {}
 };
 
 #endif

--- a/DataFormats/GeometrySurface/interface/Plane.h
+++ b/DataFormats/GeometrySurface/interface/Plane.h
@@ -34,7 +34,7 @@ public:
     return PlanePointer(new Plane(std::forward<Args>(args)...));
   }
  
-  ~Plane(){}
+  ~Plane() override{}
 
 // extension of Surface interface for planes
 
@@ -64,22 +64,22 @@ public:
 
 // implementation of Surface interface    
 
-  virtual SurfaceOrientation::Side side( const LocalPoint& p, Scalar toler) const final {
+  SurfaceOrientation::Side side( const LocalPoint& p, Scalar toler) const final {
     return (std::abs(p.z())<toler) ? SurfaceOrientation::onSurface : 
 	(p.z()>0 ? SurfaceOrientation::positiveSide : SurfaceOrientation::negativeSide);
   }
 
-  virtual SurfaceOrientation::Side side( const GlobalPoint& p, Scalar toler) const final {
+  SurfaceOrientation::Side side( const GlobalPoint& p, Scalar toler) const final {
     Scalar lz = localZ(p);
     return (std::abs(lz)<toler ? SurfaceOrientation::onSurface : 
 	    (lz>0 ? SurfaceOrientation::positiveSide : SurfaceOrientation::negativeSide));
   }
 
   /// tangent plane to surface from global point
-  virtual ConstReferenceCountingPointer<TangentPlane> tangentPlane (const GlobalPoint&) const final;
+  ConstReferenceCountingPointer<TangentPlane> tangentPlane (const GlobalPoint&) const final;
 
   /// tangent plane to surface from local point
-  virtual ConstReferenceCountingPointer<TangentPlane> tangentPlane (const LocalPoint&) const final;
+  ConstReferenceCountingPointer<TangentPlane> tangentPlane (const LocalPoint&) const final;
 
 private:
   void setPosPrec() {

--- a/DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h
+++ b/DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h
@@ -17,25 +17,25 @@ public:
   /// Construct from  half width (extension in local X),
   /// half length (Y) and half thickness (Z)
   RectangularPlaneBounds( float w, float h, float t);
-  ~RectangularPlaneBounds();
+  ~RectangularPlaneBounds() override;
 
   /// Lenght along local Y
-  virtual float length()    const { return 2*halfLength;}
+  float length()    const override { return 2*halfLength;}
   /// Width along local X
-  virtual float width()     const { return 2*halfWidth;}
+  float width()     const override { return 2*halfWidth;}
   /// Thickness of the volume in local Z 
-  virtual float thickness() const { return 2*halfThickness;}
+  float thickness() const override { return 2*halfThickness;}
 
   // basic bounds function
   using Bounds::inside;
 
-  virtual bool inside( const Local2DPoint& p) const {
+  bool inside( const Local2DPoint& p) const override {
     return
      (std::abs(p.x()) < halfWidth) &
      (std::abs(p.y()) < halfLength);
   }
 
-  virtual bool inside( const Local3DPoint& p) const {
+  bool inside( const Local3DPoint& p) const override {
     return
      (std::abs(p.x()) < halfWidth) &
      (std::abs(p.y()) < halfLength) &
@@ -44,22 +44,22 @@ public:
 
 
 
-  virtual bool inside(const Local2DPoint& p, float tollerance) const {
+  bool inside(const Local2DPoint& p, float tollerance) const override {
     return (std::abs(p.x()) < (halfWidth  + tollerance) ) &
            (std::abs(p.y()) < (halfLength + tollerance) );
   }
 
 
-  virtual bool inside( const Local3DPoint& p, const LocalError& err,
-		       float scale=1.f) const;
+  bool inside( const Local3DPoint& p, const LocalError& err,
+		       float scale=1.f) const override;
 
-  virtual bool inside( const Local2DPoint& p, const LocalError& err, float scale=1.f) const;
+  bool inside( const Local2DPoint& p, const LocalError& err, float scale=1.f) const override;
 
   // compatible of being inside or outside...
  std::pair<bool,bool> inout( const Local3DPoint& p, const LocalError& err, float scale=1.f) const;
 
 
-  virtual Bounds* clone() const;
+  Bounds* clone() const override;
 
 private:
   float halfWidth;

--- a/DataFormats/GeometrySurface/interface/SimpleCylinderBounds.h
+++ b/DataFormats/GeometrySurface/interface/SimpleCylinderBounds.h
@@ -23,22 +23,22 @@ public:
   SimpleCylinderBounds( float rmin, float rmax, float zmin, float zmax);
 
   /// Lenght of the cylinder
-  virtual float length()    const { return theZmax - theZmin;}
+  float length()    const override { return theZmax - theZmin;}
   /// Outer diameter of the cylinder
-  virtual float width()     const { return 2*theRmax;}
+  float width()     const override { return 2*theRmax;}
   /// Thikness of the "pipe", i.e. difference between outer and inner radius
-  virtual float thickness() const { return theRmax-theRmin;}
+  float thickness() const override { return theRmax-theRmin;}
 
   using Bounds::inside;
-  virtual bool inside( const Local3DPoint& p) const;
+  bool inside( const Local3DPoint& p) const override;
 
     
-  virtual bool inside( const Local3DPoint& p, const LocalError& err,float scale) const;
+  bool inside( const Local3DPoint& p, const LocalError& err,float scale) const override;
 
   virtual bool inside( const Local2DPoint& p, const LocalError& err) const;
  
 
-  virtual Bounds* clone() const;
+  Bounds* clone() const override;
 
 private:
   float theRmin;

--- a/DataFormats/GeometrySurface/interface/SimpleDiskBounds.h
+++ b/DataFormats/GeometrySurface/interface/SimpleDiskBounds.h
@@ -16,22 +16,22 @@ public:
   /// Construct the bounds from min and max R and Z in LOCAL coordinates.
   SimpleDiskBounds( float rmin, float rmax, float zmin, float zmax);
 
-  virtual float length()    const { return theZmax - theZmin;}
-  virtual float width()     const { return 2*theRmax;}
-  virtual float thickness() const { return theZmax-theZmin;}
+  float length()    const override { return theZmax - theZmin;}
+  float width()     const override { return 2*theRmax;}
+  float thickness() const override { return theZmax-theZmin;}
 
-  virtual bool inside( const Local3DPoint& p) const {
+  bool inside( const Local3DPoint& p) const override {
     return  ((p.z() > theZmin) & (p.z() < theZmax)) &&
     ( (p.perp2() > theRmin*theRmin) & (p.perp2() < theRmax*theRmax) );
   }
 
   using Bounds::inside;
     
-  virtual bool inside( const Local3DPoint& p, const LocalError& err, float scale) const;
+  bool inside( const Local3DPoint& p, const LocalError& err, float scale) const override;
 
   virtual bool inside( const Local2DPoint& p, const LocalError& err) const;
 
-  virtual Bounds* clone() const;
+  Bounds* clone() const override;
 
   /// Extension of the Bounds interface
   float innerRadius() const {return theRmin;}

--- a/DataFormats/GeometrySurface/interface/Surface.h
+++ b/DataFormats/GeometrySurface/interface/Surface.h
@@ -47,7 +47,7 @@ public:
 
   using Base = GloballyPositioned<float>;
 
-  virtual ~Surface(){}
+  ~Surface() override{}
 
 protected:
   Surface(){}

--- a/DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h
+++ b/DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h
@@ -27,29 +27,29 @@ public:
   
 
   /** apothem (full, not half)*/
-  virtual float length() const    { return 2 * hapothem;}
+  float length() const override    { return 2 * hapothem;}
 
   /** largest width (full, not half)*/
-  virtual float width()  const    { return 2 * std::max( hbotedge, htopedge);}
+  float width()  const override    { return 2 * std::max( hbotedge, htopedge);}
 
   /** thickness (full, not half)*/
-  virtual float thickness() const { return 2 * hthickness;}
+  float thickness() const override { return 2 * hthickness;}
 
   /** Width at half length. Useful for e.g. pitch definition.
    */
-  virtual float widthAtHalfLength() const {return hbotedge+htopedge;}
+  float widthAtHalfLength() const override {return hbotedge+htopedge;}
 
   virtual int yAxisOrientation() const;
 
   using Bounds::inside;
 
-  virtual bool inside( const Local2DPoint& p) const;
+  bool inside( const Local2DPoint& p) const override;
 
-  virtual bool inside( const Local3DPoint& p) const;
+  bool inside( const Local3DPoint& p) const override;
 
-  virtual bool inside( const Local3DPoint& p, const LocalError& err, float scale) const;
+  bool inside( const Local3DPoint& p, const LocalError& err, float scale) const override;
 
-  virtual bool inside( const Local2DPoint& p, const LocalError& err, float scale) const;
+  bool inside( const Local2DPoint& p, const LocalError& err, float scale) const override;
 
   /** returns the 4 parameters needed for construction, in the order
    * ( half bottom edge, half top edge, half thickness, half apothem).
@@ -57,7 +57,7 @@ public:
    */
     virtual const std::array<const float, 4> parameters() const;
 
-  virtual Bounds* clone() const;
+  Bounds* clone() const override;
 
 private:
   // persistent part

--- a/DataFormats/GeometryVector/src/TrackingJacobians.cc
+++ b/DataFormats/GeometryVector/src/TrackingJacobians.cc
@@ -9,7 +9,7 @@ AlgebraicMatrix65 jacobianCurvilinearToCartesian(const GlobalVector & momentum, 
   GlobalVector yt(-xt.y(), xt.x(), 0.); 
   GlobalVector zt = xt.cross(yt);
 
-  GlobalVector pvec=momentum;
+  const GlobalVector& pvec=momentum;
   double pt = pvec.perp();
   // for neutrals: qbp is 1/p instead of q/p - 
   //   equivalent to charge 1
@@ -59,7 +59,7 @@ AlgebraicMatrix56 jacobianCartesianToCurvilinear(const GlobalVector & momentum,i
   GlobalVector xt=momentum;
   GlobalVector yt(-xt.y(), xt.x(), 0.);
   GlobalVector zt = xt.cross(yt);
-  GlobalVector pvec=momentum;
+  const GlobalVector& pvec=momentum;
   double pt = pvec.perp(), p = pvec.mag();
   double px = pvec.x(), py = pvec.y(), pz = pvec.z();
   double pt2 = pt*pt, p2 = p*p, p3 = p*p*p;

--- a/DataFormats/HGCRecHit/src/HGCRecHit.cc
+++ b/DataFormats/HGCRecHit/src/HGCRecHit.cc
@@ -3,7 +3,7 @@
 #include "DataFormats/ForwardDetId/interface/HGCHEDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include <cassert>
-#include <math.h>
+#include <cmath>
 
 HGCRecHit::HGCRecHit() : CaloRecHit(), flagBits_(0) {
 }

--- a/DataFormats/HGCRecHit/src/HGCUncalibratedRecHit.cc
+++ b/DataFormats/HGCRecHit/src/HGCUncalibratedRecHit.cc
@@ -1,5 +1,5 @@
 #include "DataFormats/HGCRecHit/interface/HGCUncalibratedRecHit.h"
-#include <math.h>
+#include <cmath>
 
 HGCUncalibratedRecHit::HGCUncalibratedRecHit() :
   amplitude_(0.), pedestal_(0.), jitter_(0.), chi2_(10000.), OOTamplitude_(0.), OOTchi2_(10000.), flags_(0), aux_(0) { }

--- a/DataFormats/HLTReco/interface/TriggerTypeDefs.h
+++ b/DataFormats/HLTReco/interface/TriggerTypeDefs.h
@@ -11,7 +11,7 @@
  */
 
 #include <vector>
-#include <stdint.h>
+#include <cstdint>
 
 namespace trigger
 {

--- a/DataFormats/HcalDetId/interface/CastorElectronicsId.h
+++ b/DataFormats/HcalDetId/interface/CastorElectronicsId.h
@@ -3,7 +3,7 @@
 
 #include <string>
 #include <ostream>
-#include <stdint.h>
+#include <cstdint>
 
 /** \brief Readout chain identification for Castor 
 Bits for the readout chain : some names need change!

--- a/DataFormats/HcalDetId/interface/HcalElectronicsId.h
+++ b/DataFormats/HcalDetId/interface/HcalElectronicsId.h
@@ -3,7 +3,7 @@
 
 #include <string>
 #include <ostream>
-#include <stdint.h>
+#include <cstdint>
 
 /** \brief Readout chain identification for Hcal
 

--- a/DataFormats/HcalDetId/interface/HcalFrontEndId.h
+++ b/DataFormats/HcalDetId/interface/HcalFrontEndId.h
@@ -2,7 +2,7 @@
 #define HcalFrontEndId_h
 
 #include <string>
-#include <stdint.h>
+#include <cstdint>
 #include <iosfwd>
 
 class HcalFrontEndId {

--- a/DataFormats/HcalDigi/interface/HcalTTPDigi.h
+++ b/DataFormats/HcalDigi/interface/HcalTTPDigi.h
@@ -1,7 +1,7 @@
 #ifndef DATAFORMATS_HCALDIGI_HCALTTPDIGI_H
 #define DATAFORMATS_HCALDIGI_HCALTTPDIGI_H 1
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 #include <ostream>
 

--- a/DataFormats/HcalDigi/src/HcalUMNioDigi.cc
+++ b/DataFormats/HcalDigi/src/HcalUMNioDigi.cc
@@ -38,7 +38,7 @@ uint16_t HcalUMNioDigi::spillCounter() const {
   return (payload_[11])&0x7FFF;
 }
 bool HcalUMNioDigi::isSpill() const {
-  if (invalid()) return 0;
+  if (invalid()) return false;
   return (payload_[11]&0x8000);
 }
 

--- a/DataFormats/HcalIsolatedTrack/interface/EcalIsolatedParticleCandidate.h
+++ b/DataFormats/HcalIsolatedTrack/interface/EcalIsolatedParticleCandidate.h
@@ -29,9 +29,9 @@ namespace reco {
       ,enIn_(enIn), enOut_(enOut), nhitIn_(nhitIn), nhitOut_(nhitOut) {} 
 
     /// destructor
-    virtual ~EcalIsolatedParticleCandidate();
+    ~EcalIsolatedParticleCandidate() override;
     /// returns a clone of the candidate
-    virtual EcalIsolatedParticleCandidate * clone() const;
+    EcalIsolatedParticleCandidate * clone() const override;
     
     /// reference to a tau jet
     virtual l1extra::L1JetParticleRef l1TauJet() const;

--- a/DataFormats/HcalIsolatedTrack/interface/HcalIsolatedTrackCandidate.h
+++ b/DataFormats/HcalIsolatedTrack/interface/HcalIsolatedTrackCandidate.h
@@ -53,13 +53,13 @@ namespace reco {
     HcalIsolatedTrackCandidate(const HcalIsolatedTrackCandidate&);
 
     /// destructor
-    virtual ~HcalIsolatedTrackCandidate();
+    ~HcalIsolatedTrackCandidate() override;
 
     /// returns a clone of the candidate
-    virtual HcalIsolatedTrackCandidate * clone() const;
+    HcalIsolatedTrackCandidate * clone() const override;
 
     /// refrence to a Track
-    virtual reco::TrackRef track() const;
+    reco::TrackRef track() const override;
     void setTrack(const reco::TrackRef & tr) { track_ = tr; }
 
     /// highest energy of other tracks in the cone around the candidate
@@ -104,7 +104,7 @@ namespace reco {
 
   private:
     /// check overlap with another candidate
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
     /// reference to a Track
     reco::TrackRef track_;
     /// reference to a L1 tau jet

--- a/DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidate.h
+++ b/DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidate.h
@@ -97,13 +97,13 @@ namespace reco {
     IsolatedPixelTrackCandidate(const IsolatedPixelTrackCandidate&);
 
     /// destructor
-    virtual ~IsolatedPixelTrackCandidate();
+    ~IsolatedPixelTrackCandidate() override;
 
     /// returns a clone of the candidate
-    virtual IsolatedPixelTrackCandidate * clone() const;
+    IsolatedPixelTrackCandidate * clone() const override;
 
     /// refrence to a Track
-    virtual reco::TrackRef track() const;
+    reco::TrackRef track() const override;
     void setTrack( const reco::TrackRef & tr ) { track_ = tr; }
 
     /// highest Pt of other pixel tracks in the cone around the candidate
@@ -152,7 +152,7 @@ namespace reco {
 
   private:
     /// check overlap with another candidate
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
     /// reference to a Track
     reco::TrackRef track_;
     /// reference to a L1 tau jet

--- a/DataFormats/HcalIsolatedTrack/src/HcalIsolatedTrackCandidate.cc
+++ b/DataFormats/HcalIsolatedTrack/src/HcalIsolatedTrackCandidate.cc
@@ -41,5 +41,5 @@ math::XYZTLorentzVector HcalIsolatedTrackCandidate::l1jetp() const {
 
 bool HcalIsolatedTrackCandidate::overlap( const Candidate & c ) const {
   const RecoCandidate * o = dynamic_cast<const RecoCandidate *>( & c );
-  return ( o != 0 &&  checkOverlap( track(), o->track() ) );
+  return ( o != nullptr &&  checkOverlap( track(), o->track() ) );
 }

--- a/DataFormats/HcalIsolatedTrack/src/IsolatedPixelTrackCandidate.cc
+++ b/DataFormats/HcalIsolatedTrack/src/IsolatedPixelTrackCandidate.cc
@@ -35,7 +35,7 @@ l1t::TauRef IsolatedPixelTrackCandidate::l1ttau() const {
 
 bool IsolatedPixelTrackCandidate::overlap( const Candidate & c ) const {
   const RecoCandidate * o = dynamic_cast<const RecoCandidate *>( & c );
-  return ( o != 0 &&  checkOverlap( track(), o->track() ) );
+  return ( o != nullptr &&  checkOverlap( track(), o->track() ) );
 }
 
 std::pair<int,int> IsolatedPixelTrackCandidate::towerIndex() const {

--- a/DataFormats/HeavyIonEvent/interface/CentralityBins.h
+++ b/DataFormats/HeavyIonEvent/interface/CentralityBins.h
@@ -9,7 +9,7 @@
 class CBin : public TObject {
  public:
    CBin(){;}
-   ~CBin(){;}
+   ~CBin() override{;}
 
    float bin_edge;
    float n_part_mean;
@@ -47,7 +47,7 @@ class CentralityBins : public TNamed {
 	 table_.push_back(b); 
       }
    }
-      ~CentralityBins() {;}
+      ~CentralityBins() override {;}
       int getBin(double value) const;
       int getNbins() const {return table_.size();}
       float lowEdge(double value) const { return lowEdgeOfBin(getBin(value));}

--- a/DataFormats/HepMCCandidate/interface/GenParticle.h
+++ b/DataFormats/HepMCCandidate/interface/GenParticle.h
@@ -32,9 +32,9 @@ namespace reco {
     GenParticle(Charge q, const PolarLorentzVector & p4, const Point & vtx, 
 		int pdgId, int status, bool integerCharge);
     /// destructor
-    virtual ~GenParticle();
+    ~GenParticle() override;
     /// return a clone
-    GenParticle * clone() const;
+    GenParticle * clone() const override;
     void setCollisionId(int s) {collisionId_ = s;}
     int collisionId() const {return collisionId_;}
 
@@ -104,7 +104,7 @@ namespace reco {
     
   private:
     /// checp overlap with another candidate
-    bool overlap(const Candidate &) const;
+    bool overlap(const Candidate &) const override;
     int collisionId_;
     GenStatusFlags statusFlags_;
  };

--- a/DataFormats/HepMCCandidate/src/FlavorHistoryEvent.cc
+++ b/DataFormats/HepMCCandidate/src/FlavorHistoryEvent.cc
@@ -77,7 +77,7 @@ void FlavorHistoryEvent::cache()
   //      2c. Flavor excitation
   //      2d. Gluon splitting
   //  3. delta R (if applicable)
-  if ( classification.size() > 0 ) { 
+  if ( !classification.empty() ) { 
 
 
     std::sort( classification.begin(), classification.end() );

--- a/DataFormats/JetReco/interface/BasicJet.h
+++ b/DataFormats/JetReco/interface/BasicJet.h
@@ -27,17 +27,17 @@ class BasicJet : public Jet {
   BasicJet(const LorentzVector& fP4, const Point& fVertex);
   BasicJet(const LorentzVector& fP4, const Point& fVertex, const Jet::Constituents& fConstituents);
   
-  virtual ~BasicJet() {};
+  ~BasicJet() override {};
 
   /// Polymorphic clone
-  virtual BasicJet* clone () const;
+  BasicJet* clone () const override;
 
   /// Print object
-  virtual std::string print () const;
+  std::string print () const override;
   
  private:
   /// Polymorphic overlap
-  virtual bool overlap( const Candidate & ) const;
+  bool overlap( const Candidate & ) const override;
 };
 }
 // temporary fix before include_checcker runs globally

--- a/DataFormats/JetReco/interface/CaloJet.h
+++ b/DataFormats/JetReco/interface/CaloJet.h
@@ -90,7 +90,7 @@ class CaloJet : public Jet {
 	  const Jet::Constituents& fConstituents);
 
   
-  virtual ~CaloJet() {};
+  ~CaloJet() override {};
   
   /** Returns the maximum energy deposited in ECAL towers*/
   float maxEInEmTowers() const {return m_specific.mMaxEInEmTowers;}
@@ -149,16 +149,16 @@ class CaloJet : public Jet {
   const Specific& getSpecific () const {return m_specific;}
 
   /// Polymorphic clone
-  virtual CaloJet* clone () const;
+  CaloJet* clone () const override;
 
   /// Print object
-  virtual std::string print () const;
+  std::string print () const override;
 
   /// CaloTowers indexes
   std::vector<CaloTowerDetId> getTowerIndices() const;
  private:
   /// Polymorphic overlap
-  virtual bool overlap( const Candidate & ) const;
+  bool overlap( const Candidate & ) const override;
   
   //Variables specific to to the CaloJet class
   Specific m_specific;

--- a/DataFormats/JetReco/interface/DiscretizedEnergyFlow.h
+++ b/DataFormats/JetReco/interface/DiscretizedEnergyFlow.h
@@ -31,7 +31,7 @@ namespace reco {
 
     inline const double* data() const
     {
-        if (data_.empty()) return 0;
+        if (data_.empty()) return nullptr;
         else return &data_[0];
     }
     inline const char* title() const {return title_.c_str();}

--- a/DataFormats/JetReco/interface/GenJet.h
+++ b/DataFormats/JetReco/interface/GenJet.h
@@ -52,7 +52,7 @@ public:
   GenJet(const LorentzVector& fP4, const Specific& fSpecific, 
 	 const Jet::Constituents& fConstituents);
 
-  virtual ~GenJet() {};
+  ~GenJet() override {};
   /** Returns energy of electromagnetic particles*/
   float emEnergy() const {return m_specific.m_EmEnergy;};
   /** Returns energy of hadronic particles*/
@@ -80,14 +80,14 @@ public:
   void setSpecific (const Specific &spec ) {m_specific = spec;}
   
   /// Polymorphic clone
-  virtual GenJet* clone () const;
+  GenJet* clone () const override;
 
   /// Print object
-  virtual std::string print () const;
+  std::string print () const override;
   
 private:
   /// Polymorphic overlap
-  virtual bool overlap( const Candidate & ) const;
+  bool overlap( const Candidate & ) const override;
   
   // Data members
   //Variables specific to to the GenJet class

--- a/DataFormats/JetReco/interface/GenericJet.h
+++ b/DataFormats/JetReco/interface/GenericJet.h
@@ -23,7 +23,7 @@ namespace reco {
     /// Initiator
     GenericJet (const LorentzVector& fP4, const Point& fVertex, const std::vector<CandidateBaseRef>& fConstituents);
     /// Destructor
-    virtual ~GenericJet () {}
+    ~GenericJet () override {}
 
     /// # of constituents
     virtual int nConstituents () const;

--- a/DataFormats/JetReco/interface/JPTJet.h
+++ b/DataFormats/JetReco/interface/JPTJet.h
@@ -85,7 +85,7 @@ class JPTJet : public Jet {
   /** backward compatible, vertex=(0,0,0) */
   JPTJet(const LorentzVector& fP4, const Specific& fSpecific, const Jet::Constituents& fConstituents);
   
-  virtual ~JPTJet() {};
+  ~JPTJet() override {};
 
 
   /// chargedHadronEnergy 
@@ -133,16 +133,16 @@ class JPTJet : public Jet {
   const Specific& getSpecific () const {return mspecific;}
   
   /// Polymorphic clone
-  virtual JPTJet* clone () const;
+  JPTJet* clone () const override;
   
   /// Print object in details
   virtual void printJet () const;
   
-  virtual std::string print () const;
+  std::string print () const override;
   
  private:
   /// Polymorphic overlap
-  virtual bool overlap( const Candidate & ) const;
+  bool overlap( const Candidate & ) const override;
   
   //Variables specific to to the JPTJet class
  

--- a/DataFormats/JetReco/interface/Jet.h
+++ b/DataFormats/JetReco/interface/Jet.h
@@ -38,7 +38,7 @@ namespace reco {
     Jet (const LorentzVector& fP4, const Point& fVertex);
     Jet (const LorentzVector& fP4, const Point& fVertex, const Constituents& fConstituents);
     /// Destructor
-    virtual ~Jet () {}
+    ~Jet () override {}
 
     /// eta-phi statistics, ET weighted
     EtaPhiMoments etaPhiStatistics () const;
@@ -114,7 +114,7 @@ namespace reco {
     ///  number of passes taken by algorithm
     virtual int nPasses () const {return mPassNumber;}
 
-    bool isJet() const;
+    bool isJet() const override;
     
   private:
     float mJetArea;

--- a/DataFormats/JetReco/interface/PFClusterJet.h
+++ b/DataFormats/JetReco/interface/PFClusterJet.h
@@ -34,12 +34,12 @@ namespace reco {
       /// Constructor from RecoChargedRefCandidate constituents
       PFClusterJet(const LorentzVector & fP4, const Point & fVertex, const Jet::Constituents & fConstituents);
       /// Destructor
-      virtual ~PFClusterJet() {}
+      ~PFClusterJet() override {}
       /// Polymorphic clone
-      virtual PFClusterJet * clone () const;
+      PFClusterJet * clone () const override;
 
       /// Print object
-      virtual std::string print () const;
+      std::string print () const override;
       
       /// Easy Constituent access
       reco::PFClusterRef   pfCluster( size_t i) const;
@@ -47,7 +47,7 @@ namespace reco {
     private:
 
       /// Polymorphic overlap
-      virtual bool overlap(const Candidate & dummy) const;
+      bool overlap(const Candidate & dummy) const override;
 
     private:
 

--- a/DataFormats/JetReco/interface/PFJet.h
+++ b/DataFormats/JetReco/interface/PFJet.h
@@ -92,7 +92,7 @@ class PFJet : public Jet {
 	  const Jet::Constituents& fConstituents);
 
   
-  virtual ~PFJet() {};
+  ~PFJet() override {};
 
   /// chargedHadronEnergy 
   float chargedHadronEnergy () const {return m_specific.mChargedHadronEnergy;}
@@ -177,15 +177,15 @@ class PFJet : public Jet {
   const Specific& getSpecific () const {return m_specific;}
 
   /// Polymorphic clone
-  virtual PFJet* clone () const;
+  PFJet* clone () const override;
 
   /// Print object in details
-  virtual std::string print () const;
+  std::string print () const override;
 
 
  private:
   /// Polymorphic overlap
-  virtual bool overlap( const Candidate & ) const;
+  bool overlap( const Candidate & ) const override;
   
   //Variables specific to to the PFJet class
   Specific m_specific;

--- a/DataFormats/JetReco/interface/TrackJet.h
+++ b/DataFormats/JetReco/interface/TrackJet.h
@@ -35,9 +35,9 @@ namespace reco {
       /// Constructor from RecoChargedRefCandidate constituents
       TrackJet(const LorentzVector & fP4, const Point & fVertex, const Jet::Constituents & fConstituents);
       /// Destructor
-      virtual ~TrackJet() {}
+      ~TrackJet() override {}
       /// Polymorphic clone
-      virtual TrackJet * clone () const;
+      TrackJet * clone () const override;
 
       /// Number of track daughters
       size_t numberOfTracks() const { return numberOfDaughters(); }
@@ -56,12 +56,12 @@ namespace reco {
       bool fromHardVertex() const { return (this->primaryVertex().index() == 0); }
 
       /// Print object
-      virtual std::string print () const;
+      std::string print () const override;
 
     private:
 
       /// Polymorphic overlap
-      virtual bool overlap(const Candidate & dummy) const;
+      bool overlap(const Candidate & dummy) const override;
 
     private:
 

--- a/DataFormats/JetReco/src/GenJet.cc
+++ b/DataFormats/JetReco/src/GenJet.cc
@@ -52,7 +52,7 @@ const GenParticle* GenJet::getGenConstituent (unsigned fIndex) const {
     const Candidate* constituent = &*daugh; // deref
     return genParticle (constituent);
   }
-  return 0;
+  return nullptr;
 }
 
 std::vector <const GenParticle*> GenJet::getGenConstituents () const {

--- a/DataFormats/L1CSCTrackFinder/interface/L1Track.h
+++ b/DataFormats/L1CSCTrackFinder/interface/L1Track.h
@@ -27,7 +27,7 @@ namespace csc{
 
       const csc::L1Track& operator=(const csc::L1Track&);
 
-      virtual ~L1Track();
+      ~L1Track() override;
 
       unsigned rank() const;
       void setRank(const unsigned& rank) { m_rank = rank; }

--- a/DataFormats/L1DTTrackFinder/interface/L1MuDTTrackCand.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1MuDTTrackCand.h
@@ -46,7 +46,7 @@ class L1MuDTTrackCand: public L1MuRegionalCand {
                    int uwh, int usc, int utag, int adr1, int adr2, int adr3, int adr4 );
 
   //  Destructor
-  ~L1MuDTTrackCand();
+  ~L1MuDTTrackCand() override;
 
   // Operations
   int whNum()        const;

--- a/DataFormats/L1DTTrackFinder/src/L1MuDTChambPhContainer.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1MuDTChambPhContainer.cc
@@ -83,7 +83,7 @@ int L1MuDTChambPhContainer::bxSize(int step1, int step2) const {
 
 L1MuDTChambPhDigi const* L1MuDTChambPhContainer::chPhiSegm1(int wheel, int stat, int sect, int step) const {
 
-  L1MuDTChambPhDigi const* rT=0;
+  L1MuDTChambPhDigi const* rT=nullptr;
 
   for ( Phi_iterator i  = phiSegments.begin();
                      i != phiSegments.end();
@@ -98,7 +98,7 @@ L1MuDTChambPhDigi const* L1MuDTChambPhContainer::chPhiSegm1(int wheel, int stat,
 
 L1MuDTChambPhDigi const* L1MuDTChambPhContainer::chPhiSegm2(int wheel, int stat, int sect, int step) const {
 
-  L1MuDTChambPhDigi const* rT=0;
+  L1MuDTChambPhDigi const* rT=nullptr;
 
   for ( Phi_iterator i  = phiSegments.begin();
                      i != phiSegments.end();

--- a/DataFormats/L1DTTrackFinder/src/L1MuDTChambThContainer.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1MuDTChambThContainer.cc
@@ -80,7 +80,7 @@ int L1MuDTChambThContainer::bxSize(int step1, int step2) const {
 
 L1MuDTChambThDigi const* L1MuDTChambThContainer::chThetaSegm(int wheel, int stat, int sect, int step) const {
 
-  L1MuDTChambThDigi const* rT=0;
+  L1MuDTChambThDigi const* rT=nullptr;
 
   for ( The_iterator i  = theSegments.begin();
                      i != theSegments.end();

--- a/DataFormats/L1DTTrackFinder/src/L1MuDTTrackContainer.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1MuDTTrackContainer.cc
@@ -81,7 +81,7 @@ int L1MuDTTrackContainer::bxSize(int step1, int step2) const {
 
 L1MuDTTrackCand const* L1MuDTTrackContainer::dtTrackCand1(int wheel, int sect, int step) const {
 
-  L1MuDTTrackCand const* rT=0;
+  L1MuDTTrackCand const* rT=nullptr;
 
   for ( Trackiterator i  = dtTracks.begin();
                       i != dtTracks.end();
@@ -96,7 +96,7 @@ L1MuDTTrackCand const* L1MuDTTrackContainer::dtTrackCand1(int wheel, int sect, i
 
 L1MuDTTrackCand const* L1MuDTTrackContainer::dtTrackCand2(int wheel, int sect, int step) const {
 
-  L1MuDTTrackCand const* rT=0;
+  L1MuDTTrackCand const* rT=nullptr;
 
   for ( Trackiterator i  = dtTracks.begin();
                       i != dtTracks.end();

--- a/DataFormats/L1GlobalCaloTrigger/interface/L1GctEmCand.h
+++ b/DataFormats/L1GlobalCaloTrigger/interface/L1GctEmCand.h
@@ -43,31 +43,31 @@ public:
   L1GctEmCand(L1CaloEmCand& c);
 
   /// destructor (virtual to prevent compiler warnings)
-  virtual ~L1GctEmCand();
+  ~L1GctEmCand() override;
   
   /// region associated with the candidate
-  L1CaloRegionDetId regionId() const;
+  L1CaloRegionDetId regionId() const override;
 
   /// name of object
   std::string name() const;
 
   /// was an object really found?
-  bool empty() const  {  return (rank() == 0); }
+  bool empty() const override  {  return (rank() == 0); }
  
   /// get the raw data
   uint16_t raw() const { return m_data; }
   
   /// get rank bits
-  unsigned rank() const  { return m_data & 0x3f; }
+  unsigned rank() const override  { return m_data & 0x3f; }
 
   /// get eta index -6 to -0, +0 to +6 (bit 3 is sign, 1 for -ve Z, 0 for +ve Z)
-  unsigned etaIndex() const  { return (m_data>>6) & 0xf; } 
+  unsigned etaIndex() const override  { return (m_data>>6) & 0xf; } 
 
   /// get eta sign (1 for -ve Z, 0 for +ve Z) 
-  unsigned etaSign() const { return (m_data>>9) & 0x1; } 
+  unsigned etaSign() const override { return (m_data>>9) & 0x1; } 
 
   /// get phi index (0-17)
-  unsigned phiIndex() const  { return (m_data>>10) & 0x1f; } 
+  unsigned phiIndex() const override  { return (m_data>>10) & 0x1f; } 
 
   /// which stream did this come from
   bool isolated() const { return m_iso; }

--- a/DataFormats/L1GlobalCaloTrigger/interface/L1GctEtHad.h
+++ b/DataFormats/L1GlobalCaloTrigger/interface/L1GctEtHad.h
@@ -2,7 +2,7 @@
 #define L1GCTETHAD_H
 
 #include <ostream>
-#include <stdint.h>
+#include <cstdint>
 
 /*! \file L1GctEtHad.h
  * \Header file for the GCT energy sum output

--- a/DataFormats/L1GlobalCaloTrigger/interface/L1GctEtMiss.h
+++ b/DataFormats/L1GlobalCaloTrigger/interface/L1GctEtMiss.h
@@ -2,7 +2,7 @@
 #define L1GCTETMISS_H
 
 #include <ostream>
-#include <stdint.h>
+#include <cstdint>
 
 /*! \file L1GctEtMiss.h
  * \Header file for the GCT energy sum output

--- a/DataFormats/L1GlobalCaloTrigger/interface/L1GctEtTotal.h
+++ b/DataFormats/L1GlobalCaloTrigger/interface/L1GctEtTotal.h
@@ -2,7 +2,7 @@
 #define L1GCTETTOTAL_H
 
 #include <ostream>
-#include <stdint.h>
+#include <cstdint>
 
 /*! \file L1GctEtTotal.h
  * \Header file for the GCT energy sum output

--- a/DataFormats/L1GlobalCaloTrigger/interface/L1GctFibreWord.h
+++ b/DataFormats/L1GlobalCaloTrigger/interface/L1GctFibreWord.h
@@ -3,7 +3,7 @@
 
 #include <ostream>
 #include <string>
-#include <stdint.h>
+#include <cstdint>
 
 /*! \class L1GctFibreWord
  * \brief Global Calorimeter Trigger SC -> CC fibre data word

--- a/DataFormats/L1GlobalCaloTrigger/interface/L1GctHFBitCounts.h
+++ b/DataFormats/L1GlobalCaloTrigger/interface/L1GctHFBitCounts.h
@@ -3,7 +3,7 @@
 
 #include <ostream>
 #include <string>
-#include <stdint.h>
+#include <cstdint>
 
 /// \class L1GctHFBitCounts
 /// \brief L1 GCT HF ring Et sums

--- a/DataFormats/L1GlobalCaloTrigger/interface/L1GctHFRingEtSums.h
+++ b/DataFormats/L1GlobalCaloTrigger/interface/L1GctHFRingEtSums.h
@@ -3,7 +3,7 @@
 
 #include <ostream>
 #include <string>
-#include <stdint.h>
+#include <cstdint>
 
 /// \class L1GctHFRingEtSums
 /// \brief L1 GCT HF ring Et sums

--- a/DataFormats/L1GlobalCaloTrigger/interface/L1GctHtMiss.h
+++ b/DataFormats/L1GlobalCaloTrigger/interface/L1GctHtMiss.h
@@ -2,7 +2,7 @@
 #define L1GCTHTMISS_H
 
 #include <ostream>
-#include <stdint.h>
+#include <cstdint>
 
 /*! \file L1GctHtMiss.h
  * 

--- a/DataFormats/L1GlobalCaloTrigger/interface/L1GctInternEtSum.h
+++ b/DataFormats/L1GlobalCaloTrigger/interface/L1GctInternEtSum.h
@@ -3,7 +3,7 @@
 
 #include <ostream>
 #include <string>
-#include <stdint.h>
+#include <cstdint>
 
 /// \class L1GctInternEtSum
 /// \brief L1 GCT internal energy sum

--- a/DataFormats/L1GlobalCaloTrigger/interface/L1GctInternHFData.h
+++ b/DataFormats/L1GlobalCaloTrigger/interface/L1GctInternHFData.h
@@ -3,7 +3,7 @@
 
 #include <ostream>
 #include <string>
-#include <stdint.h>
+#include <cstdint>
 
 /// \class L1GctInternHFData
 /// \brief L1 GCT internal ring sums and/or bit counts

--- a/DataFormats/L1GlobalCaloTrigger/interface/L1GctInternHtMiss.h
+++ b/DataFormats/L1GlobalCaloTrigger/interface/L1GctInternHtMiss.h
@@ -12,7 +12,7 @@
 
 // C++ headers
 #include <ostream>
-#include <stdint.h>
+#include <cstdint>
 
 class L1GctInternHtMiss
 {

--- a/DataFormats/L1GlobalCaloTrigger/interface/L1GctJetCand.h
+++ b/DataFormats/L1GlobalCaloTrigger/interface/L1GctJetCand.h
@@ -35,31 +35,31 @@ public:
   L1GctJetCand(unsigned rank, unsigned phi, unsigned eta, bool isTau, bool isFor, uint16_t block, uint16_t index, int16_t bx);
 
   /// destructor (virtual to prevent compiler warnings)
-  virtual ~L1GctJetCand();
+  ~L1GctJetCand() override;
 
   /// region associated with the candidate
-  L1CaloRegionDetId regionId() const;
+  L1CaloRegionDetId regionId() const override;
 
   /// name of object
   std::string name() const;
 
   /// was an object really found?
-  bool empty() const  { return (rank() == 0); }
+  bool empty() const override  { return (rank() == 0); }
 
   /// get the raw data
   uint16_t raw() const { return m_data; }
   
   /// get rank bits
-  unsigned rank() const  { return m_data & 0x3f; }
+  unsigned rank() const override  { return m_data & 0x3f; }
 
   /// get eta index (bit 3 is sign, 1 for -ve Z, 0 for +ve Z)
-  unsigned etaIndex() const { return (m_data>>6) & 0xf; }
+  unsigned etaIndex() const override { return (m_data>>6) & 0xf; }
 
   /// get eta sign bit (1 for -ve Z, 0 for +ve Z)
-  unsigned etaSign() const { return (m_data>>9) & 0x1; }
+  unsigned etaSign() const override { return (m_data>>9) & 0x1; }
   
   /// get phi index (0-17)
-  unsigned phiIndex() const  { return (m_data>>10) & 0x1f; }
+  unsigned phiIndex() const override  { return (m_data>>10) & 0x1f; }
 
   /// check if this is a central jet
   bool isCentral() const { return (!m_isTau) && (!m_isFor); }

--- a/DataFormats/L1GlobalCaloTrigger/interface/L1GctJetCounts.h
+++ b/DataFormats/L1GlobalCaloTrigger/interface/L1GctJetCounts.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 #include <ostream>
-#include <stdint.h>
+#include <cstdint>
 
 ///
 /// \class L1GctJetCounts

--- a/DataFormats/L1GlobalCaloTrigger/src/L1GctInternEtSum.cc
+++ b/DataFormats/L1GlobalCaloTrigger/src/L1GctInternEtSum.cc
@@ -1,5 +1,5 @@
 #include "DataFormats/L1GlobalCaloTrigger/interface/L1GctInternEtSum.h"
-#include <stdint.h>
+#include <cstdint>
 
 
 L1GctInternEtSum::L1GctInternEtSum() {

--- a/DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTExtendedCand.h
+++ b/DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTExtendedCand.h
@@ -57,7 +57,7 @@ class L1MuGMTExtendedCand : public L1MuGMTCand {
     L1MuGMTExtendedCand(const L1MuGMTExtendedCand&);
 
     /// destructor
-     virtual ~L1MuGMTExtendedCand();
+     ~L1MuGMTExtendedCand() override;
 
     /// reset muon candidate
     void reset();

--- a/DataFormats/L1GlobalTrigger/interface/L1GtfeExtWord.h
+++ b/DataFormats/L1GlobalTrigger/interface/L1GtfeExtWord.h
@@ -55,7 +55,7 @@ public:
 
 
     /// destructor
-    virtual ~L1GtfeExtWord();
+    ~L1GtfeExtWord() override;
 
     /// equal operator
     bool operator==(const L1GtfeExtWord&) const;
@@ -135,14 +135,14 @@ public:
     void resize(int bstSizeBytes);
 
     /// reset the content of a L1GtfeExtWord
-    void reset();
+    void reset() override;
 
     /// pretty print the content of a L1GtfeExtWord
-    virtual void print(std::ostream& myCout) const;
+    void print(std::ostream& myCout) const override;
 
     /// unpack GTFE
     /// gtfePtr pointer to the beginning of the GTFE block in the raw data
-    virtual void unpack(const unsigned char* gtfePtr);
+    void unpack(const unsigned char* gtfePtr) override;
 
 private:
 

--- a/DataFormats/L1GlobalTrigger/src/L1GlobalTriggerEvmReadoutRecord.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1GlobalTriggerEvmReadoutRecord.cc
@@ -18,7 +18,7 @@
 // system include files
 #include <iomanip>
 #include <bitset>
-#include <stdint.h>
+#include <cstdint>
 
 // user include files
 

--- a/DataFormats/L1GlobalTrigger/src/L1GlobalTriggerObjectMap.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1GlobalTriggerObjectMap.cc
@@ -52,7 +52,7 @@ const CombinationsInCond* L1GlobalTriggerObjectMap::getCombinationsInCond(
         << "\n  does not exists in the operand token vector."
         << "\n  Returning zero pointer for getCombinationsInCond\n\n" << std::endl;
 
-    return 0;
+    return nullptr;
 
 }
 
@@ -73,7 +73,7 @@ const CombinationsInCond* L1GlobalTriggerObjectMap::getCombinationsInCond(const 
         << "\n  does not exists in the operand token vector."
         << "\n  Returning zero pointer for getCombinationsInCond\n\n" << std::endl;
 
-    return 0;
+    return nullptr;
 
 }
 // return the result for the condition condNameVal
@@ -165,7 +165,7 @@ void L1GlobalTriggerObjectMap::print(std::ostream& myCout) const
 
         myCout << "    ";
 
-        if ((*itVVV).size() == 0) {
+        if ((*itVVV).empty()) {
             myCout << "(none)";
         } else {
 

--- a/DataFormats/L1GlobalTrigger/src/L1GlobalTriggerObjectMapRecord.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1GlobalTriggerObjectMapRecord.cc
@@ -51,7 +51,7 @@ const L1GlobalTriggerObjectMap* L1GlobalTriggerObjectMapRecord::getObjectMap(
         << " does not exist in the trigger menu."
         << " Returning zero pointer for getObjectMap." << std::endl;
 
-    return 0;
+    return nullptr;
 
 }
     
@@ -75,7 +75,7 @@ const L1GlobalTriggerObjectMap* L1GlobalTriggerObjectMapRecord::getObjectMap(
         << " does not exist in the trigger menu."
         << " Returning zero pointer for getObjectMap." << std::endl;
 
-    return 0;
+    return nullptr;
     
 }
 
@@ -103,7 +103,7 @@ const CombinationsInCond* L1GlobalTriggerObjectMapRecord::getCombinationsInCond(
     << " Returning zero pointer for getCombinationsInCond."
     << std::endl;
 
-    return 0;
+    return nullptr;
 
 }
 
@@ -129,7 +129,7 @@ const CombinationsInCond* L1GlobalTriggerObjectMapRecord::getCombinationsInCond(
     << " Returning zero pointer for getCombinationsInCond."
     << std::endl;
 
-    return 0;
+    return nullptr;
 
 }
 

--- a/DataFormats/L1GlobalTrigger/src/L1GlobalTriggerObjectMaps.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1GlobalTriggerObjectMaps.cc
@@ -121,7 +121,7 @@ getCombinationsInCondition(int algorithmBitNumber,
   unsigned short nObjectsPerCombination = m_conditionResults[startIndex + conditionNumber].nObjectsPerCombination();
 
   if (endObjectIndex == beginObjectIndex) {
-    return CombinationsInCondition(0, 0, 0);
+    return CombinationsInCondition(nullptr, 0, 0);
   }
   if (endObjectIndex < beginObjectIndex ||
       m_combinations.size() < endObjectIndex ||

--- a/DataFormats/L1GlobalTrigger/src/L1GtLogicParser.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1GtLogicParser.cc
@@ -1548,7 +1548,7 @@ const L1GtLogicParser::OperationRule* L1GtLogicParser::getRuleFromType(Operation
     }
 
     if (m_operationRules[i].opType == OP_NULL) {
-        return 0;
+        return nullptr;
     }
 
     return &(m_operationRules[i]);
@@ -1653,6 +1653,6 @@ const struct L1GtLogicParser::OperationRule L1GtLogicParser::m_operationRules[] 
         { "NOT",  OP_NOT,           OP_OPERAND | OP_CLOSEBRACKET                       },
         { "(",    OP_OPENBRACKET,   OP_OPERAND | OP_CLOSEBRACKET                       },
         { ")",    OP_CLOSEBRACKET,  OP_AND | OP_OR | OP_NOT | OP_OPENBRACKET           },
-        { NULL,   OP_OPERAND,       OP_OPERAND | OP_CLOSEBRACKET                       },
-        { NULL,   OP_NULL,          OP_NULL                                            }
+        { nullptr,   OP_OPERAND,       OP_OPERAND | OP_CLOSEBRACKET                       },
+        { nullptr,   OP_NULL,          OP_NULL                                            }
     };

--- a/DataFormats/L1GlobalTrigger/src/L1GtObject.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1GtObject.cc
@@ -42,7 +42,7 @@ L1GtObject l1GtObjectStringToEnum(const std::string& label) {
             {"BPTX", BPTX},
             {"GtExternal", GtExternal},
             {"ObjNull", ObjNull},
-            {0, (L1GtObject) - 1}
+            {nullptr, (L1GtObject) - 1}
     };
 
     L1GtObject value = (L1GtObject) - 1;

--- a/DataFormats/L1GlobalTrigger/src/L1GtTechnicalTriggerRecord.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1GtTechnicalTriggerRecord.cc
@@ -60,7 +60,7 @@ const L1GtTechnicalTrigger* L1GtTechnicalTriggerRecord::getTechnicalTrigger(
             << "\n  Returning zero pointer for getTechnicalTrigger\n\n"
             << std::endl;
 
-    return 0;
+    return nullptr;
 
 }
 
@@ -88,7 +88,7 @@ const L1GtTechnicalTrigger* L1GtTechnicalTriggerRecord::getTechnicalTrigger(
             << "\n  Returning zero pointer for getTechnicalTrigger\n\n"
             << std::endl;
 
-    return 0;
+    return nullptr;
 
 }
 

--- a/DataFormats/L1GlobalTrigger/src/L1GtTriggerMenuLite.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1GtTriggerMenuLite.cc
@@ -383,7 +383,7 @@ std::ostream& operator<<(std::ostream& streamRec,
 const std::string* L1GtTriggerMenuLite::gtAlgorithmAlias(
         const unsigned int bitNumber, int& errorCode) const {
 
-    const std::string* gtAlgorithmAlias = 0;
+    const std::string* gtAlgorithmAlias = nullptr;
 
     for (CItL1Trig itTrig = m_algorithmAliasMap.begin(); itTrig
             != m_algorithmAliasMap.end(); itTrig++) {
@@ -407,7 +407,7 @@ const std::string* L1GtTriggerMenuLite::gtAlgorithmAlias(
 const std::string* L1GtTriggerMenuLite::gtAlgorithmName(
         const unsigned int bitNumber, int& errorCode) const {
 
-    const std::string* gtAlgorithmName = 0;
+    const std::string* gtAlgorithmName = nullptr;
 
     for (CItL1Trig itTrig = m_algorithmMap.begin(); itTrig
             != m_algorithmMap.end(); itTrig++) {
@@ -429,7 +429,7 @@ const std::string* L1GtTriggerMenuLite::gtAlgorithmName(
 const std::string* L1GtTriggerMenuLite::gtTechTrigName(
         const unsigned int bitNumber, int& errorCode) const {
 
-    const std::string* gtTechTrigName = 0;
+    const std::string* gtTechTrigName = nullptr;
 
     for (CItL1Trig itTrig = m_technicalTriggerMap.begin(); itTrig
             != m_technicalTriggerMap.end(); itTrig++) {

--- a/DataFormats/L1GlobalTrigger/src/L1GtfeExtWord.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1GtfeExtWord.cc
@@ -17,7 +17,7 @@
 
 // system include files
 #include <iomanip>
-#include <stdint.h>
+#include <cstdint>
 
 // user include files
 #include "FWCore/Utilities/interface/EDMException.h"

--- a/DataFormats/L1TCalorimeter/interface/CaloCluster.h
+++ b/DataFormats/L1TCalorimeter/interface/CaloCluster.h
@@ -34,7 +34,7 @@ namespace l1t {
           int phi=0
           );
 
-      ~CaloCluster();
+      ~CaloCluster() override;
 
 
 

--- a/DataFormats/L1TCalorimeter/interface/CaloEmCand.h
+++ b/DataFormats/L1TCalorimeter/interface/CaloEmCand.h
@@ -16,7 +16,7 @@ namespace l1t {
 		int qual=0
 		);
 
-    ~CaloEmCand();
+    ~CaloEmCand() override;
 
   private:
     //

--- a/DataFormats/L1TCalorimeter/interface/CaloRegion.h
+++ b/DataFormats/L1TCalorimeter/interface/CaloRegion.h
@@ -21,7 +21,7 @@ namespace l1t {
 	   int hwEtEm=0,
 	   int hwEtHad=0);
     
-    ~CaloRegion();
+    ~CaloRegion() override;
 
     void setEtEm( double et );
     void setEtHad( double et );

--- a/DataFormats/L1TCalorimeter/interface/CaloStage1Cluster.h
+++ b/DataFormats/L1TCalorimeter/interface/CaloStage1Cluster.h
@@ -17,7 +17,7 @@ namespace l1t {
 		       int qual=0
 		       );
     
-    ~CaloStage1Cluster();
+    ~CaloStage1Cluster() override;
 
   private:
     //

--- a/DataFormats/L1TCalorimeter/interface/CaloTower.h
+++ b/DataFormats/L1TCalorimeter/interface/CaloTower.h
@@ -27,7 +27,7 @@ namespace l1t {
 	       int hwEtHad=0,
 	       int hwEtRatio=0);
     
-    ~CaloTower();
+    ~CaloTower() override;
 
     void setEtEm( double et );
     void setEtHad( double et );

--- a/DataFormats/L1TGlobal/src/GlobalAlgBlk.cc
+++ b/DataFormats/L1TGlobal/src/GlobalAlgBlk.cc
@@ -33,7 +33,7 @@ GlobalAlgBlk::GlobalAlgBlk(int orbitNr, int bxNr, int bxInEvent):
 {
 
     //Clear out the header data
-    m_finalOR=0;
+    m_finalOR=false;
     m_preScColumn=0;
 
     // Reserve/Clear out the decision words
@@ -57,9 +57,9 @@ GlobalAlgBlk::GlobalAlgBlk( )
     m_orbitNr=0;
     m_bxNr=0;
     m_bxInEvent=0;
-    m_finalOR=0;
-    m_finalORPreVeto = 0;
-    m_finalORVeto = 0;    
+    m_finalOR=false;
+    m_finalORPreVeto = false;
+    m_finalORVeto = false;    
     m_preScColumn=0;
 
     // Reserve/Clear out the decision words
@@ -147,9 +147,9 @@ void GlobalAlgBlk::reset()
     m_orbitNr=0;
     m_bxNr=0;
     m_bxInEvent=0;
-    m_finalOR=0;
-    m_finalORPreVeto = 0;
-    m_finalORVeto = 0;
+    m_finalOR=false;
+    m_finalORPreVeto = false;
+    m_finalORVeto = false;
     m_preScColumn=0;
 
     // Clear out the decision words

--- a/DataFormats/L1TGlobal/src/GlobalLogicParser.cc
+++ b/DataFormats/L1TGlobal/src/GlobalLogicParser.cc
@@ -1548,7 +1548,7 @@ const GlobalLogicParser::OperationRule* GlobalLogicParser::getRuleFromType(Opera
     }
 
     if (m_operationRules[i].opType == OP_NULL) {
-        return 0;
+        return nullptr;
     }
 
     return &(m_operationRules[i]);
@@ -1653,6 +1653,6 @@ const struct GlobalLogicParser::OperationRule GlobalLogicParser::m_operationRule
         { "NOT",  OP_NOT,           OP_OPERAND | OP_CLOSEBRACKET                       },
         { "(",    OP_OPENBRACKET,   OP_OPERAND | OP_CLOSEBRACKET                       },
         { ")",    OP_CLOSEBRACKET,  OP_AND | OP_OR | OP_NOT | OP_OPENBRACKET           },
-        { NULL,   OP_OPERAND,       OP_OPERAND | OP_CLOSEBRACKET                       },
-        { NULL,   OP_NULL,          OP_NULL                                            }
+        { nullptr,   OP_OPERAND,       OP_OPERAND | OP_CLOSEBRACKET                       },
+        { nullptr,   OP_NULL,          OP_NULL                                            }
     };

--- a/DataFormats/L1TGlobal/src/GlobalObject.cc
+++ b/DataFormats/L1TGlobal/src/GlobalObject.cc
@@ -46,7 +46,7 @@ l1t::GlobalObject l1TGtObjectStringToEnum(const std::string& label) {
 	    {"ETTem", gtETTem},
             {"External", gtExternal},
             {"ObjNull", ObjNull},
-            {0, (GlobalObject) - 1}
+            {nullptr, (GlobalObject) - 1}
     };
 
     l1t::GlobalObject value = (GlobalObject) - 1;

--- a/DataFormats/L1TGlobal/src/GlobalObjectMap.cc
+++ b/DataFormats/L1TGlobal/src/GlobalObjectMap.cc
@@ -51,7 +51,7 @@ const CombinationsInCond* GlobalObjectMap::getCombinationsInCond(
         << "\n  does not exists in the operand token vector."
         << "\n  Returning zero pointer for getCombinationsInCond\n\n" << std::endl;
 
-    return 0;
+    return nullptr;
 
 }
 
@@ -72,7 +72,7 @@ const CombinationsInCond* GlobalObjectMap::getCombinationsInCond(const int condN
         << "\n  does not exists in the operand token vector."
         << "\n  Returning zero pointer for getCombinationsInCond\n\n" << std::endl;
 
-    return 0;
+    return nullptr;
 
 }
 // return the result for the condition condNameVal
@@ -164,7 +164,7 @@ void GlobalObjectMap::print(std::ostream& myCout) const
 
         myCout << "    ";
 
-        if ((*itVVV).size() == 0) {
+        if ((*itVVV).empty()) {
             myCout << "(none)";
         } else {
 

--- a/DataFormats/L1TGlobal/src/GlobalObjectMapRecord.cc
+++ b/DataFormats/L1TGlobal/src/GlobalObjectMapRecord.cc
@@ -48,7 +48,7 @@ const GlobalObjectMap* GlobalObjectMapRecord::getObjectMap(
         << "\n  does not exists in the trigger menu."
         << "\n  Returning zero pointer for getObjectMap\n\n" << std::endl;
 
-    return 0;
+    return nullptr;
 
 }
     
@@ -72,7 +72,7 @@ const GlobalObjectMap* GlobalObjectMapRecord::getObjectMap(
         << "\n  does not exists in the trigger menu."
         << "\n  Returning zero pointer for getObjectMap\n\n" << std::endl;
 
-    return 0;
+    return nullptr;
     
 }
 
@@ -100,7 +100,7 @@ const CombinationsInCond* GlobalObjectMapRecord::getCombinationsInCond(
     << "\n  Returning zero pointer for getCombinationsInCond\n\n"
     << std::endl;
 
-    return 0;
+    return nullptr;
 
 }
 
@@ -126,7 +126,7 @@ const CombinationsInCond* GlobalObjectMapRecord::getCombinationsInCond(
     << "\n  Returning zero pointer for getCombinationsInCond\n\n"
     << std::endl;
 
-    return 0;
+    return nullptr;
 
 }
 

--- a/DataFormats/L1THGCal/interface/HGCalCluster.h
+++ b/DataFormats/L1THGCal/interface/HGCalCluster.h
@@ -22,7 +22,7 @@ namespace l1t {
 
       HGCalCluster( const edm::Ptr<l1t::HGCalTriggerCell> &tc );
       
-      ~HGCalCluster();
+      ~HGCalCluster() override;
 
       void setModule(uint32_t module) {module_ = module;}
       uint32_t module() const {return module_;}

--- a/DataFormats/L1THGCal/interface/HGCalClusterT.h
+++ b/DataFormats/L1THGCal/interface/HGCalClusterT.h
@@ -44,7 +44,7 @@ namespace l1t
         addConstituent(c);
       }
       
-      ~HGCalClusterT() {};
+      ~HGCalClusterT() override {};
       
       const edm::PtrVector<C>& constituents() const {return constituents_;}        
       const_iterator constituents_begin() const {return constituents_.begin();}

--- a/DataFormats/L1THGCal/interface/HGCalMulticluster.h
+++ b/DataFormats/L1THGCal/interface/HGCalMulticluster.h
@@ -21,7 +21,7 @@ namespace l1t {
 
       HGCalMulticluster( const edm::Ptr<l1t::HGCalCluster> &tc );
       
-      ~HGCalMulticluster();
+      ~HGCalMulticluster() override;
 
 
   };

--- a/DataFormats/L1THGCal/interface/HGCalTower.h
+++ b/DataFormats/L1THGCal/interface/HGCalTower.h
@@ -27,7 +27,7 @@ namespace l1t {
 	       int hwEtHad=0,
 	       int hwEtRatio=0);
     
-    ~HGCalTower();
+    ~HGCalTower() override;
 
     void setEtEm( double et );
     void setEtHad( double et );

--- a/DataFormats/L1THGCal/interface/HGCalTriggerCell.h
+++ b/DataFormats/L1THGCal/interface/HGCalTriggerCell.h
@@ -27,7 +27,7 @@ namespace l1t
                     int qual=0, 
                     uint32_t detid=0);
 
-            ~HGCalTriggerCell();
+            ~HGCalTriggerCell() override;
 
             void setDetId(uint32_t detid) {detid_ = HGCalDetId(detid);}
             void setPosition(const GlobalPoint& position) {position_ = position;}

--- a/DataFormats/L1TrackTrigger/src/TTCluster.cc
+++ b/DataFormats/L1TrackTrigger/src/TTCluster.cc
@@ -20,7 +20,7 @@ unsigned int TTCluster< edm::Ref< edm::DetSetVector< Phase2TrackerDigi >, Phase2
   for ( unsigned int i = 0; i < theHits.size(); i++ )
   {
     int row = 0;
-    if ( this->getRows().size() == 0 )
+    if ( this->getRows().empty() )
     {
       row = theHits[i]->row();
     }
@@ -42,7 +42,7 @@ MeasurementPoint TTCluster< edm::Ref< edm::DetSetVector< Phase2TrackerDigi >, Ph
 {
   /// NOTE in this case, DO NOT add 0.5
   /// to get the center of the pixel
-  if ( this->getRows().size() == 0 || this->getCols().size() == 0 )
+  if ( this->getRows().empty() || this->getCols().empty() )
   {
     MeasurementPoint mp( theHits[hitIdx]->row(), theHits[hitIdx]->column() );
     return mp;
@@ -64,9 +64,9 @@ MeasurementPoint TTCluster< edm::Ref< edm::DetSetVector< Phase2TrackerDigi >, Ph
   double averageRow = 0.0;
 
   /// Loop over the hits and calculate the average coordinates
-  if ( theHits.size() != 0 )
+  if ( !theHits.empty() )
   {
-    if ( this->getRows().size() == 0 || this->getCols().size() == 0 )
+    if ( this->getRows().empty() || this->getCols().empty() )
     {
       typename std::vector< edm::Ref< edm::DetSetVector< Phase2TrackerDigi >, Phase2TrackerDigi > >::const_iterator hitIter;
       for ( hitIter = theHits.begin();
@@ -101,9 +101,9 @@ MeasurementPoint TTCluster< edm::Ref< edm::DetSetVector< Phase2TrackerDigi >, Ph
   double averageRow = 0.0;
 
   /// Loop over the hits and calculate the average coordinates
-  if ( theHits.size() != 0 )
+  if ( !theHits.empty() )
   {
-    if ( this->getRows().size() == 0 || this->getCols().size() == 0 )
+    if ( this->getRows().empty() || this->getCols().empty() )
     {
       typename std::vector< edm::Ref< edm::DetSetVector< Phase2TrackerDigi >, Phase2TrackerDigi > >::const_iterator hitIter;
       for ( hitIter = theHits.begin();

--- a/DataFormats/L1Trigger/interface/CaloSpare.h
+++ b/DataFormats/L1Trigger/interface/CaloSpare.h
@@ -38,7 +38,7 @@ namespace l1t {
 	   int qual=0);
 
 
-    ~CaloSpare();
+    ~CaloSpare() override;
 
     void setType(CaloSpareType type);
 

--- a/DataFormats/L1Trigger/interface/EGamma.h
+++ b/DataFormats/L1Trigger/interface/EGamma.h
@@ -36,7 +36,7 @@ namespace l1t {
 	    int qual=0,
 	    int iso=0);
 
-    ~EGamma();
+    ~EGamma() override;
 
     void setTowerIEta(short int ieta);  // ieta of seed tower
     void setTowerIPhi(short int iphi);  // iphi of seed tower

--- a/DataFormats/L1Trigger/interface/EtSum.h
+++ b/DataFormats/L1Trigger/interface/EtSum.h
@@ -58,7 +58,7 @@ namespace l1t {
 	   int qual=0);
 
 
-    ~EtSum();
+    ~EtSum() override;
 
     void setType(EtSumType type);
 

--- a/DataFormats/L1Trigger/interface/Jet.h
+++ b/DataFormats/L1Trigger/interface/Jet.h
@@ -28,7 +28,7 @@ namespace l1t {
        int phi=0,
        int qual=0);
 
-  ~Jet();
+  ~Jet() override;
 
                   
   void setTowerIEta(short int ieta);  // ieta of seed tower                   

--- a/DataFormats/L1Trigger/interface/L1Candidate.h
+++ b/DataFormats/L1Trigger/interface/L1Candidate.h
@@ -34,7 +34,7 @@ namespace l1t {
 		 int qual=0,
 		 int iso=0);
 
-    ~L1Candidate();
+    ~L1Candidate() override;
 
     // methods to set integer values
     // in general, these should not be needed

--- a/DataFormats/L1Trigger/interface/L1DataEmulRecord.h
+++ b/DataFormats/L1Trigger/interface/L1DataEmulRecord.h
@@ -37,7 +37,7 @@ class L1DataEmulRecord {
   void setColl(const L1DEDigiCollection& col) {deColl = col;}
   void setGlt(const GltDEDigi& glt) {deGlt = glt;}
   
-  bool empty() const {return deColl.size()==0;}
+  bool empty() const {return deColl.empty();}
 
  private:
 

--- a/DataFormats/L1Trigger/interface/L1EmParticle.h
+++ b/DataFormats/L1Trigger/interface/L1EmParticle.h
@@ -56,7 +56,7 @@ namespace l1extra {
                        EmType type = kUndefined,
 		       int bx = 0 ) ;
 
-	 virtual ~L1EmParticle() {}
+	 ~L1EmParticle() override {}
 
 	 // ---------- const member functions ---------------------
          EmType type() const
@@ -68,7 +68,7 @@ namespace l1extra {
 	 const L1GctEmCand* gctEmCand() const
 	 { return ref_.get() ; }
 
-         virtual L1EmParticle* clone() const
+         L1EmParticle* clone() const override
          { return new L1EmParticle( *this ) ; }
 
 	 int bx() const

--- a/DataFormats/L1Trigger/interface/L1EtMissParticle.h
+++ b/DataFormats/L1Trigger/interface/L1EtMissParticle.h
@@ -61,7 +61,7 @@ namespace l1extra {
 	L1GctEtHadCollection >(),
 	int bx = 0 ) ;
 
-      virtual ~L1EtMissParticle() {}
+      ~L1EtMissParticle() override {}
 
       // ---------- const member functions ---------------------
 
@@ -107,7 +107,7 @@ namespace l1extra {
       const L1GctEtHad* gctEtHad() const
 	{ return etHadRef_.get() ; }
 
-      virtual L1EtMissParticle* clone() const
+      L1EtMissParticle* clone() const override
 	{ return new L1EtMissParticle( *this ) ; }
 
       int bx() const

--- a/DataFormats/L1Trigger/interface/L1JetParticle.h
+++ b/DataFormats/L1Trigger/interface/L1JetParticle.h
@@ -57,7 +57,7 @@ namespace l1extra {
                         JetType type = kUndefined,
 			int bx = 0 ) ;
 
-	 virtual ~L1JetParticle() {}
+	 ~L1JetParticle() override {}
 
 	 // ---------- const member functions ---------------------
          JetType type() const
@@ -69,7 +69,7 @@ namespace l1extra {
 	 const L1GctJetCand* gctJetCand() const
 	 { return ref_.get() ; }
 
-         virtual L1JetParticle* clone() const
+         L1JetParticle* clone() const override
          { return new L1JetParticle( *this ) ; }
 
 	 int bx() const

--- a/DataFormats/L1Trigger/interface/L1MuonParticle.h
+++ b/DataFormats/L1Trigger/interface/L1MuonParticle.h
@@ -63,7 +63,7 @@ namespace l1extra {
 			 unsigned int detector = 0,
 			 int bx = 0 ) ;
 
-	 virtual ~L1MuonParticle() {}
+	 ~L1MuonParticle() override {}
 
 	 // ---------- const member functions ---------------------
          bool isIsolated() const
@@ -81,7 +81,7 @@ namespace l1extra {
 	 const L1MuGMTExtendedCand& gmtMuonCand() const
 	 { return cand_ ; }
 
-	 virtual L1MuonParticle* clone() const
+	 L1MuonParticle* clone() const override
 	 { return new L1MuonParticle( *this ) ; }
 
 	 int bx() const

--- a/DataFormats/L1Trigger/interface/Tau.h
+++ b/DataFormats/L1Trigger/interface/Tau.h
@@ -31,7 +31,7 @@ namespace l1t {
 	    int iso=0);
 
 
-    ~Tau();
+    ~Tau() override;
 
     void setTowerIEta(short int ieta);  // ieta of seed tower
     void setTowerIPhi(short int iphi);  // iphi of seed tower

--- a/DataFormats/L1Trigger/src/L1DataEmulRecord.cc
+++ b/DataFormats/L1Trigger/src/L1DataEmulRecord.cc
@@ -1,9 +1,9 @@
 #include "DataFormats/L1Trigger/interface/L1DataEmulRecord.h"
 
-L1DataEmulRecord::L1DataEmulRecord() : deAgree(0), deGlt() {
+L1DataEmulRecord::L1DataEmulRecord() : deAgree(false), deGlt() {
   for(int i=0; i<DEnsys; i++) {
-    deMatch[i] = 0;
-    deSysCompared[i] = 0;
+    deMatch[i] = false;
+    deSysCompared[i] = false;
     for(int j=0; j<2; j++) 
       deNCand[i][j] =  0;
   }

--- a/DataFormats/L1Trigger/src/L1ParticleMap.cc
+++ b/DataFormats/L1Trigger/src/L1ParticleMap.cc
@@ -184,7 +184,7 @@ L1ParticleMap::L1ParticleMap(
    const L1IndexComboVector& indexCombos )
    : triggerType_( triggerType ),
      triggerDecision_( triggerDecision ),
-     indexCombosState_{static_cast<char>(indexCombos.size()>0? kSet:IndexComboStates::kUnset)},
+     indexCombosState_{static_cast<char>(!indexCombos.empty()? kSet:IndexComboStates::kUnset)},
      objectTypes_( objectTypes ),
      emParticles_( emParticles ),
      jetParticles_( jetParticles ),
@@ -371,7 +371,7 @@ L1ParticleMap::candidateInCombo( int aIndexInCombo,
    }
    else
    {
-      return 0 ;
+      return nullptr ;
    }
 }
 
@@ -388,7 +388,7 @@ L1ParticleMap::emParticleInCombo( int aIndexInCombo,
    }
    else
    {
-      return 0 ;
+      return nullptr ;
    }
 }
 
@@ -405,7 +405,7 @@ L1ParticleMap::jetParticleInCombo( int aIndexInCombo,
    }
    else
    {
-      return 0 ;
+      return nullptr ;
    }
 }
 
@@ -422,7 +422,7 @@ L1ParticleMap::muonParticleInCombo( int aIndexInCombo,
    }
    else
    {
-      return 0 ;
+      return nullptr ;
    }
 }
 
@@ -438,7 +438,7 @@ L1ParticleMap::etMissParticleInCombo( int aIndexInCombo,
    }
    else
    {
-      return 0 ;
+      return nullptr ;
    }
 }
 

--- a/DataFormats/Luminosity/interface/BeamCurrentInfo.h
+++ b/DataFormats/Luminosity/interface/BeamCurrentInfo.h
@@ -26,7 +26,7 @@
 #include <vector>
 #include <iosfwd>
 #include <string>
-#include <stdint.h>
+#include <cstdint>
 #include "DataFormats/Luminosity/interface/LumiConstants.h"
 
 class BeamCurrentInfo {

--- a/DataFormats/Luminosity/src/LumiDetails.cc
+++ b/DataFormats/Luminosity/src/LumiDetails.cc
@@ -55,7 +55,7 @@ LumiDetails::lumiVersion() const {
 
 bool
 LumiDetails::isValid() const {
-  return m_allValues.size()!=0;
+  return !m_allValues.empty();
 }
 
 void

--- a/DataFormats/Luminosity/src/LumiSummary.cc
+++ b/DataFormats/Luminosity/src/LumiSummary.cc
@@ -45,7 +45,7 @@ LumiSummary::deadFrac() const {
   if(lumiversion_=="DIP"){
     return float(deadcount_)/float(bitzerocount_);
   }
-  if (l1data_.size()==0) return 1.0;
+  if (l1data_.empty()) return 1.0;
   if (bitzerocount_==0) return -1.0;
   return float(deadcount_)/float(bitzerocount_);
 }

--- a/DataFormats/METReco/interface/BeamHaloSummary.h
+++ b/DataFormats/METReco/interface/BeamHaloSummary.h
@@ -34,18 +34,18 @@ namespace reco {
     //destructor
     virtual ~BeamHaloSummary() {}
   
-    const bool HcalLooseHaloId()const { return  HcalHaloReport.size() ?  HcalHaloReport[0] : false ; }
+    const bool HcalLooseHaloId()const { return  !HcalHaloReport.empty() ?  HcalHaloReport[0] : false ; }
     const bool HcalTightHaloId()const { return  HcalHaloReport.size() > 1 ? HcalHaloReport[1] : false ; }
     
-    const bool EcalLooseHaloId()const { return  EcalHaloReport.size() ?  EcalHaloReport[0] : false ; }
+    const bool EcalLooseHaloId()const { return  !EcalHaloReport.empty() ?  EcalHaloReport[0] : false ; }
     const bool EcalTightHaloId()const { return  EcalHaloReport.size() > 1 ? EcalHaloReport[1] : false ; }
 
-    const bool CSCLooseHaloId() const { return CSCHaloReport.size() ? CSCHaloReport[0] : false ; }
+    const bool CSCLooseHaloId() const { return !CSCHaloReport.empty() ? CSCHaloReport[0] : false ; }
     const bool CSCTightHaloId() const { return CSCHaloReport.size() > 1 ? CSCHaloReport[1] : false ; }
     const bool CSCTightHaloIdTrkMuUnveto() const { return CSCHaloReport.size() > 4 ? CSCHaloReport[4] : false ; }
     const bool CSCTightHaloId2015() const { return CSCHaloReport.size() > 5 ? CSCHaloReport[5] : false ; }
     
-    const bool GlobalLooseHaloId() const { return GlobalHaloReport.size() ? GlobalHaloReport[0] : false ; }
+    const bool GlobalLooseHaloId() const { return !GlobalHaloReport.empty() ? GlobalHaloReport[0] : false ; }
     const bool GlobalTightHaloId() const { return GlobalHaloReport.size() > 1 ? GlobalHaloReport[1] : false ; }
     const bool GlobalTightHaloId2016() const { return GlobalHaloReport.size() > 2 ? GlobalHaloReport[2] : false ; }
     const bool GlobalSuperTightHaloId2016() const { return GlobalHaloReport.size() > 3 ? GlobalHaloReport[3] : false ; }

--- a/DataFormats/METReco/interface/CaloMET.h
+++ b/DataFormats/METReco/interface/CaloMET.h
@@ -32,7 +32,7 @@ namespace reco
 	       const LorentzVector& fP4, const Point& fVertex ) 
 	: MET( sumet_, corr_, fP4, fVertex ), calo_data( calo_data_ ) {}
       /* Default destructor*/
-      virtual ~CaloMET() {}
+      ~CaloMET() override {}
       
       /* Returns the maximum energy deposited in ECAL towers */
       double maxEtInEmTowers() const {return calo_data.MaxEtInEmTowers;};
@@ -79,7 +79,7 @@ namespace reco
       SpecificCaloMETData getSpecific() const {return calo_data;}
       
     private:
-      virtual bool overlap( const Candidate & ) const;
+      bool overlap( const Candidate & ) const override;
       // Data members
       //Variables specific to to the CaloMET class
       SpecificCaloMETData calo_data;

--- a/DataFormats/METReco/interface/GenMET.h
+++ b/DataFormats/METReco/interface/GenMET.h
@@ -27,7 +27,7 @@ namespace reco
 	       const LorentzVector& fP4, const Point& fVertex ) 
 	: MET( sumet_, fP4, fVertex ), gen_data( gen_data_ ) {}
       /* Default destructor*/
-      virtual ~GenMET() {}
+      ~GenMET() override {}
 
       //Get Neutral EM Et Fraction
       double NeutralEMEtFraction() const { return gen_data.NeutralEMEtFraction ; }
@@ -80,7 +80,7 @@ namespace reco
 
       // block accessors
     private:
-      virtual bool overlap( const Candidate & ) const;
+      bool overlap( const Candidate & ) const override;
       // Data members
       //Variables specific to to the GenMET class
       SpecificGenMETData gen_data;

--- a/DataFormats/METReco/interface/MET.h
+++ b/DataFormats/METReco/interface/MET.h
@@ -49,7 +49,7 @@ namespace reco
     MET( double sumet_, const std::vector<CorrMETData>& corr_,
 	 const LorentzVector& p4_, const Point& vtx_ );
 
-    MET * clone() const;
+    MET * clone() const override;
 
     //________________________________________________________________________||
     //scalar sum of transverse energy over all objects
@@ -74,7 +74,7 @@ namespace reco
     reco::METCovMatrix getSignificanceMatrix(void) const;
 
   private:
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
     double sumet;
     double elongit;
     // bookkeeping for the significance

--- a/DataFormats/METReco/interface/PFClusterMET.h
+++ b/DataFormats/METReco/interface/PFClusterMET.h
@@ -18,7 +18,7 @@ namespace reco
 		  const LorentzVector& fP4, const Point& fVertex )
       : MET( sumet_, fP4, fVertex )  {}
 
-    virtual ~PFClusterMET() {}
+    ~PFClusterMET() override {}
     
 
   };

--- a/DataFormats/METReco/interface/PFMET.h
+++ b/DataFormats/METReco/interface/PFMET.h
@@ -23,7 +23,7 @@ namespace reco
 	   const LorentzVector& fP4, const Point& fVertex )
       : MET( sumet_, fP4, fVertex ), pf_data( pf_data_ ) {}
 
-    virtual ~PFMET() {}
+    ~PFMET() override {}
     
     //getters
     double photonEtFraction() const { return pf_data.NeutralEMFraction; }

--- a/DataFormats/METReco/src/HcalCaloFlagTool.cc
+++ b/DataFormats/METReco/src/HcalCaloFlagTool.cc
@@ -1,5 +1,5 @@
 #include "DataFormats/METReco/interface/HcalCaloFlagTool.h"
-#include <string.h>
+#include <cstring>
 #include <cstdio>
 
 HcalCaloFlagTool::HcalCaloFlagTool(const std::string& releaseName) : 

--- a/DataFormats/METReco/src/HcalNoiseRBX.cc
+++ b/DataFormats/METReco/src/HcalNoiseRBX.cc
@@ -65,7 +65,7 @@ float HcalNoiseRBX::allChargeTotal(void) const
 float HcalNoiseRBX::allChargeHighest2TS(unsigned int firstts) const
 {
   float total=0;
-  for(unsigned int i=firstts; i<firstts+2 && allCharge_.size(); i++)
+  for(unsigned int i=firstts; i<firstts+2 && !allCharge_.empty(); i++)
     total += allCharge_[i];
   return total;
 }
@@ -73,7 +73,7 @@ float HcalNoiseRBX::allChargeHighest2TS(unsigned int firstts) const
 float HcalNoiseRBX::allChargeHighest3TS(unsigned int firstts) const
 {
   float total=0;
-  for(unsigned int i=firstts; i<firstts+3 && allCharge_.size(); i++)
+  for(unsigned int i=firstts; i<firstts+3 && !allCharge_.empty(); i++)
     total += allCharge_[i];
   return total;
 }

--- a/DataFormats/MuonDetId/src/RPCCompDetId.cc
+++ b/DataFormats/MuonDetId/src/RPCCompDetId.cc
@@ -120,7 +120,7 @@ RPCCompDetId::type() const{
 std::string
 RPCCompDetId::dbname() const{
   std::string a=_dbname;
-  if (a.size() == 0){
+  if (a.empty()){
     if(this->type() == 0){
       a=this->gasDBname();
     }

--- a/DataFormats/MuonReco/interface/EmulatedME0Segment.h
+++ b/DataFormats/MuonReco/interface/EmulatedME0Segment.h
@@ -25,35 +25,35 @@ public:
     EmulatedME0Segment(const LocalPoint& origin, const LocalVector& direction, const AlgebraicSymMatrix& errors, const double chi2);
   
     /// Destructor
-    virtual ~EmulatedME0Segment();
+    ~EmulatedME0Segment() override;
 
     //--- Base class interface
-    EmulatedME0Segment* clone() const { return new EmulatedME0Segment(*this); }
+    EmulatedME0Segment* clone() const override { return new EmulatedME0Segment(*this); }
 
-    virtual LocalPoint localPosition() const { return theOrigin; }
-    LocalError localPositionError() const ;
+    LocalPoint localPosition() const override { return theOrigin; }
+    LocalError localPositionError() const override ;
 	
-    LocalVector localDirection() const { return theLocalDirection; }
-    LocalError localDirectionError() const ;
+    LocalVector localDirection() const override { return theLocalDirection; }
+    LocalError localDirectionError() const override ;
 
     /// Parameters of the segment, for the track fit in the order (dx/dz, dy/dz, x, y )
-    AlgebraicVector parameters() const;
+    AlgebraicVector parameters() const override;
 
     /// Covariance matrix of parameters()
-    virtual AlgebraicSymMatrix parametersError() const { return theCovMatrix; }
+    AlgebraicSymMatrix parametersError() const override { return theCovMatrix; }
 
     /// The projection matrix relates the trajectory state parameters to the segment parameters(). 
-    AlgebraicMatrix projectionMatrix() const;
+    AlgebraicMatrix projectionMatrix() const override;
 
-    virtual std::vector<const TrackingRecHit*> recHits() const {return std::vector<const TrackingRecHit*> (); }
+    std::vector<const TrackingRecHit*> recHits() const override {return std::vector<const TrackingRecHit*> (); }
 
-    virtual std::vector<TrackingRecHit*> recHits() {return std::vector<TrackingRecHit*>();}
+    std::vector<TrackingRecHit*> recHits() override {return std::vector<TrackingRecHit*>();}
 
-    virtual double chi2() const { return theChi2; }
+    double chi2() const override { return theChi2; }
 
-    virtual int dimension() const { return 4; }
+    int dimension() const override { return 4; }
 
-    virtual int degreesOfFreedom() const { return -1;}	 //Maybe  change later?
+    int degreesOfFreedom() const override { return -1;}	 //Maybe  change later?
 
     //--- Extension of the interface
         

--- a/DataFormats/MuonReco/interface/ME0Muon.h
+++ b/DataFormats/MuonReco/interface/ME0Muon.h
@@ -23,11 +23,11 @@ namespace reco {
     ME0Muon();
     //ME0Muon( const TrackRef & t, const ME0Segment & s) { innerTrack_ = t; me0Segment_ = s;}
     ME0Muon( const TrackRef & t, const ME0Segment & s, const int v, const double c) { innerTrack_ = t; me0Segment_ = s; me0segid_=v; trackCharge_ = c;}
-    virtual ~ME0Muon(){}     
+    ~ME0Muon() override{}     
     
     /// reference to Track reconstructed in the tracker only
     TrackRef innerTrack() const { return innerTrack_; }
-    virtual TrackRef track() const { return innerTrack(); }
+    TrackRef track() const override { return innerTrack(); }
     /// set reference to Track
     void setInnerTrack( const TrackRef & t ) { innerTrack_ = t; }
     void setTrack( const TrackRef & t ) { setInnerTrack(t); }
@@ -60,7 +60,7 @@ namespace reco {
      
   private:
     /// check overlap with another candidate
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
 
     /// reference to Track reconstructed in the tracker only
     TrackRef innerTrack_;

--- a/DataFormats/MuonReco/interface/MuonQuality.h
+++ b/DataFormats/MuonReco/interface/MuonQuality.h
@@ -33,12 +33,12 @@ namespace reco {
       math::XYZPoint glbKink_position;
       
       MuonQuality():
-	updatedSta(0),
+	updatedSta(false),
 	trkKink(0), glbKink(0),
 	trkRelChi2(0), staRelChi2(0),
 	chi2LocalPosition(0),chi2LocalMomentum(0),
 	localDistance(0),globalDeltaEtaPhi(0),
-	tightMatch(0),glbTrackProbability(0)
+	tightMatch(false),glbTrackProbability(0)
       { }
        
     };

--- a/DataFormats/MuonReco/src/ME0Muon.cc
+++ b/DataFormats/MuonReco/src/ME0Muon.cc
@@ -11,7 +11,7 @@ ME0Muon::ME0Muon() {
 
 bool ME0Muon::overlap( const Candidate & c ) const {
   const RecoCandidate * o = dynamic_cast<const RecoCandidate *>( & c );
-  return ( o != 0 && 
+  return ( o != nullptr && 
 	   ( checkOverlap( track(), o->track() ))
 	   );
 }

--- a/DataFormats/MuonReco/src/MuonCocktails.cc
+++ b/DataFormats/MuonReco/src/MuonCocktails.cc
@@ -32,7 +32,7 @@ reco::Muon::MuonTrackTypePair  muon::tevOptimized(const reco::TrackRef& combined
   // just not in the event, or if the (re)fit ended up with no valid
   // hits.
   double prob[nAlgo] = {0.,0.,0.,0.,0.};
-  bool valid[nAlgo] = {0,0,0,0,0};
+  bool valid[nAlgo] = {false,false,false,false,false};
 
   double dptmin = 1.;
 

--- a/DataFormats/MuonSeed/interface/L2MuonTrajectorySeed.h
+++ b/DataFormats/MuonSeed/interface/L2MuonTrajectorySeed.h
@@ -34,7 +34,7 @@ public:
 		       l1t::MuonRef l1Ref);
 
   /// Destructor
-  virtual ~L2MuonTrajectorySeed(){};
+  ~L2MuonTrajectorySeed() override{};
 
   // Operations
 

--- a/DataFormats/ParticleFlowCandidate/interface/IsolatedPFCandidate.h
+++ b/DataFormats/ParticleFlowCandidate/interface/IsolatedPFCandidate.h
@@ -25,10 +25,10 @@ namespace reco {
 			 double isolation );
 
     /// destructor
-    virtual ~IsolatedPFCandidate();
+    ~IsolatedPFCandidate() override;
 
     /// return a clone
-    virtual IsolatedPFCandidate * clone() const;
+    IsolatedPFCandidate * clone() const override;
     
 /*     const PFCandidateRef& parent() const { return parent_;} */
 

--- a/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
+++ b/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
@@ -104,12 +104,12 @@ namespace reco {
     PFCandidate( const PFCandidate&);
 
     /// destructor
-    virtual ~PFCandidate();
+    ~PFCandidate() override;
 
     PFCandidate& operator=(PFCandidate const&);
 
     /// return a clone
-    virtual PFCandidate * clone() const;
+    PFCandidate * clone() const override;
 
 
     /*    /// set source ref */
@@ -124,11 +124,11 @@ namespace reco {
     using reco::Candidate::setSourceCandidatePtr;
     void setSourceCandidatePtr(const PFCandidatePtr& ptr) { sourcePtr_ = ptr; }
 
-    size_t numberOfSourceCandidatePtrs() const { 
+    size_t numberOfSourceCandidatePtrs() const override { 
       return 1;
     }
     
-    CandidatePtr sourceCandidatePtr( size_type i ) const {
+    CandidatePtr sourceCandidatePtr( size_type i ) const override {
       return sourcePtr_;
     }
 
@@ -158,7 +158,7 @@ namespace reco {
 
     /// return a pointer to the best track, if available.
     /// otherwise, return a null pointer
-    virtual const reco::Track * bestTrack() const {
+    const reco::Track * bestTrack() const override {
       if ( (abs(pdgId()) == 11 || pdgId() == 22) && gsfTrackRef().isNonnull() && gsfTrackRef().isAvailable() )
         return &(*gsfTrackRef());
       else if ( trackRef().isNonnull() && trackRef().isAvailable() )
@@ -167,9 +167,9 @@ namespace reco {
         return nullptr;
     }
     /// uncertainty on dz 
-    virtual float dzError() const { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dzError(); else return 0; }
+    float dzError() const override { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dzError(); else return 0; }
     /// uncertainty on dxy
-    virtual float dxyError() const { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dxyError(); else return 0; }
+    float dxyError() const override { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dxyError(); else return 0; }
 
     /// set gsftrack reference 
     void setGsfTrackRef(const reco::GsfTrackRef& ref);   
@@ -405,14 +405,14 @@ namespace reco {
     // and modify the vertex() method accordingly.
     void setVertexSource( PFVertexType vt) { vertexType_=vt; if (vertexType_!=kCandVertex) LeafCandidate::setVertex(Point(0.,0.,0.));}
 
-    virtual void setVertex( const math::XYZPoint& p) {
+    void setVertex( const math::XYZPoint& p) override {
       LeafCandidate::setVertex(p); vertexType_ = kCandVertex;
     }
 
-    virtual const Point & vertex() const;
-    virtual double vx() const {return vertex().x();}
-    virtual double vy() const {return vertex().y();}
-    virtual double vz() const {return vertex().z();}
+    const Point & vertex() const override;
+    double vx() const override {return vertex().x();}
+    double vy() const override {return vertex().y();}
+    double vz() const override {return vertex().z();}
 
     /// do we have a valid time information
     bool isTimeValid() const { return timeError_ >= 0.f; }
@@ -425,7 +425,7 @@ namespace reco {
 
   private:
     /// Polymorphic overlap
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
 
     void setFlag(unsigned shift, unsigned flag, bool value);
 

--- a/DataFormats/ParticleFlowCandidate/interface/PileUpPFCandidate.h
+++ b/DataFormats/ParticleFlowCandidate/interface/PileUpPFCandidate.h
@@ -25,10 +25,10 @@ namespace reco {
 		       const VertexRef& vertexRef);
 
     /// destructor
-    virtual ~PileUpPFCandidate();
+    ~PileUpPFCandidate() override;
 
     /// return a clone
-    virtual PileUpPFCandidate * clone() const;
+    PileUpPFCandidate * clone() const override;
     
     /// return reference to the associated vertex
     const VertexRef&  vertexRef() const {return vertexRef_;}

--- a/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
+++ b/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
@@ -48,7 +48,7 @@ PFCandidate::PFCandidate() :
   mva_nothing_gamma_(bigMva_),
   mva_nothing_nh_(bigMva_),
   mva_gamma_nh_(bigMva_),
-  getter_(0),storedRefsBitPattern_(0),
+  getter_(nullptr),storedRefsBitPattern_(0),
   time_(0.f),timeError_(-1.f)
 {
 
@@ -90,7 +90,7 @@ PFCandidate::PFCandidate( Charge charge,
   mva_nothing_gamma_(bigMva_),
   mva_nothing_nh_(bigMva_),
   mva_gamma_nh_(bigMva_),
-  getter_(0),storedRefsBitPattern_(0),
+  getter_(nullptr),storedRefsBitPattern_(0),
   time_(0.f),timeError_(-1.f)
 {
   refsInfo_.reserve(3);
@@ -216,7 +216,7 @@ PFCandidate * PFCandidate::clone() const {
 void PFCandidate::addElementInBlock( const reco::PFBlockRef& blockref,
                                      unsigned elementIndex ) {
   //elementsInBlocks_.push_back( make_pair(blockref.key(), elementIndex) );
-  if (blocksStorage_.size()==0)
+  if (blocksStorage_.empty())
     blocksStorage_ =Blocks(blockref.id());
   blocksStorage_.push_back(blockref);
   elementsStorage_.push_back(elementIndex);
@@ -371,22 +371,22 @@ void PFCandidate::storeRefInfo(unsigned int iMask,
 			       const edm::EDProductGetter* iGetter) {
 
   size_t index = s_refsBefore[storedRefsBitPattern_ & iMask];
-  if ( 0 == getter_) {
+  if ( nullptr == getter_) {
     getter_ = iGetter;
   }
 
   if(iIsValid) {
     if(0 == (storedRefsBitPattern_ & iBit) ) {
       refsInfo_.insert(refsInfo_.begin()+index, bitPackRefInfo(iCore,iKey));
-      if (iGetter==0)
+      if (iGetter==nullptr)
 	refsCollectionCache_.insert(refsCollectionCache_.begin()+index,
 				    static_cast<void const*>(iCore.productPtr()));
       else
-	refsCollectionCache_.insert(refsCollectionCache_.begin()+index,0);
+	refsCollectionCache_.insert(refsCollectionCache_.begin()+index,nullptr);
     } else {
       assert(refsInfo_.size()>index);
       *(refsInfo_.begin()+index)=bitPackRefInfo(iCore,iKey);
-      if (iGetter==0)
+      if (iGetter==nullptr)
 	*(refsCollectionCache_.begin()+index)=static_cast<void const*>(iCore.productPtr());
       else
 	*(refsCollectionCache_.begin()+index)=nullptr;

--- a/DataFormats/ParticleFlowCandidate/src/PFCandidateEGammaExtra.cc
+++ b/DataFormats/ParticleFlowCandidate/src/PFCandidateEGammaExtra.cc
@@ -78,7 +78,7 @@ void PFCandidateEGammaExtra::setEarlyBrem(float val) {
 
 void PFCandidateEGammaExtra::setHadEnergy(float val) {
   hadEnergy_ = val;
-  if(clusterEnergies_.size()>0)
+  if(!clusterEnergies_.empty())
     setVariable(MVA_HOverHE,hadEnergy_/(hadEnergy_+clusterEnergies_[0]));
 }
 

--- a/DataFormats/ParticleFlowCandidate/src/PFCandidateElectronExtra.cc
+++ b/DataFormats/ParticleFlowCandidate/src/PFCandidateElectronExtra.cc
@@ -78,7 +78,7 @@ void PFCandidateElectronExtra::setEarlyBrem(float val) {
 
 void PFCandidateElectronExtra::setHadEnergy(float val) {
   hadEnergy_ = val;
-  if(clusterEnergies_.size()>0)
+  if(!clusterEnergies_.empty())
     setVariable(MVA_HOverHE,hadEnergy_/(hadEnergy_+clusterEnergies_[0]));
 }
 

--- a/DataFormats/ParticleFlowReco/interface/CaloBox.h
+++ b/DataFormats/ParticleFlowReco/interface/CaloBox.h
@@ -46,7 +46,7 @@ public:
 
 private:
 	std::map<std::pair<int, int>, double> energies_;
-	CaloBox();
+	CaloBox() = delete;
 
 };
 

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElementBrem.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElementBrem.h
@@ -22,9 +22,9 @@ namespace reco {
     PFBlockElementBrem(const GsfPFRecTrackRef& gsfref, const double DeltaP, const double SigmaDeltaP, const unsigned int indTrajPoint);
 
       
-    PFBlockElement* clone() const { return new PFBlockElementBrem(*this); }
+    PFBlockElement* clone() const override { return new PFBlockElementBrem(*this); }
     void Dump(std::ostream& out = std::cout, 
-              const char* tab = " " ) const;
+              const char* tab = " " ) const override;
     
 
     const GsfPFRecTrackRef& GsftrackRefPF() const {

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElementCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElementCluster.h
@@ -26,17 +26,17 @@ namespace reco {
       PFBlockElement(type),
       clusterRef_( ref ) {}
     
-    PFBlockElement* clone() const { return new PFBlockElementCluster(*this); }
+    PFBlockElement* clone() const override { return new PFBlockElementCluster(*this); }
     
     /// \return reference to the corresponding cluster
-    const PFClusterRef&  clusterRef() const {return clusterRef_;}
+    const PFClusterRef&  clusterRef() const override {return clusterRef_;}
     const SuperClusterRef& superClusterRef() const { return superClusterRef_;}
 
     void setSuperClusterRef(const SuperClusterRef& ref) 
     { superClusterRef_ = ref;}
 
     void Dump(std::ostream& out = std::cout, 
-              const char* tab = " " ) const;
+              const char* tab = " " ) const override;
   
   private:
     /// reference to the corresponding cluster

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElementGsfTrack.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElementGsfTrack.h
@@ -24,23 +24,23 @@ namespace reco {
 			   const math::XYZTLorentzVector& Pin, 
 			   const math::XYZTLorentzVector& Pout);
 
-    PFBlockElement* clone() const { return new PFBlockElementGsfTrack(*this); }
+    PFBlockElement* clone() const override { return new PFBlockElementGsfTrack(*this); }
     
     void Dump(std::ostream& out = std::cout, 
-              const char* tab = " " ) const;
+              const char* tab = " " ) const override;
 
     /// \return tracktype
-    virtual bool trackType(TrackType trType) const { 
+    bool trackType(TrackType trType) const override { 
       return (trackType_>>trType) & 1; 
     }
       
     /// \set the trackType
-    virtual void setTrackType(TrackType trType, bool value) {
+    void setTrackType(TrackType trType, bool value) override {
       if(value)  trackType_ = trackType_ | (1<<trType);
       else trackType_ = trackType_ ^ (1<<trType);
     }
     
-    bool isSecondary() const { 
+    bool isSecondary() const override { 
       return trackType(T_FROM_GAMMACONV); 
     }
 

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElementSuperCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElementSuperCluster.h
@@ -31,7 +31,7 @@ namespace reco {
       fromPhoton_(false),
       fromPFSuperCluster_(false){}
       
-    PFBlockElement* clone() const { return new PFBlockElementSuperCluster(*this); }
+    PFBlockElement* clone() const override { return new PFBlockElementSuperCluster(*this); }
     
     /// \return reference to the corresponding cluster
     const SuperClusterRef&  superClusterRef() const {return superClusterRef_;}
@@ -40,7 +40,7 @@ namespace reco {
     const PhotonRef& photonRef() const {return photonRef_;}
 
     void Dump(std::ostream& out = std::cout, 
-              const char* tab = " " ) const;
+              const char* tab = " " ) const override;
 
     /// set the track Iso
     void setTrackIso(float val) {trackIso_=val;}

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h
@@ -21,18 +21,18 @@ namespace reco {
 
     PFBlockElementTrack(const PFRecTrackRef& ref);
 
-    PFBlockElement* clone() const { return new PFBlockElementTrack(*this); }
+    PFBlockElement* clone() const override { return new PFBlockElementTrack(*this); }
     
     void Dump(std::ostream& out = std::cout, 
-              const char* tab = " " ) const;
+              const char* tab = " " ) const override;
 
     /// \return tracktype
-    virtual bool trackType(TrackType trType) const { 
+    bool trackType(TrackType trType) const override { 
       return (trackType_>>trType) & 1; 
     }
 
     /// \set the trackType
-    virtual void setTrackType(TrackType trType, bool value) {
+    void setTrackType(TrackType trType, bool value) override {
       if(value)  trackType_ = trackType_ | (1<<trType);
       else trackType_ = trackType_ ^ (1<<trType);
     }
@@ -51,30 +51,30 @@ namespace reco {
     
     /// \return reference to the corresponding PFRecTrack
     /// please do not use this function after the block production stage!
-    const PFRecTrackRef& trackRefPF() const { return trackRefPF_; }
+    const PFRecTrackRef& trackRefPF() const override { return trackRefPF_; }
     
     /// \return reference to the corresponding Track
-    const reco::TrackRef& trackRef() const { return trackRef_; }
+    const reco::TrackRef& trackRef() const override { return trackRef_; }
 
     /// check if the track is secondary
-    bool isSecondary() const { 
+    bool isSecondary() const override { 
       return 
 	trackType(T_FROM_DISP) || 
 	trackType(T_FROM_GAMMACONV) || 
 	trackType(T_FROM_V0); 
     }
 
-    bool isPrimary() const{
+    bool isPrimary() const override{
       return trackType(T_TO_DISP); 
     }
 
-    bool isLinkedToDisplacedVertex() const{
+    bool isLinkedToDisplacedVertex() const override{
       return isSecondary() || isPrimary();
     }
 
     /// \return the displaced vertex associated
     const PFDisplacedTrackerVertexRef& 
-      displacedVertexRef(TrackType trType) const {
+      displacedVertexRef(TrackType trType) const override {
       if (trType == T_TO_DISP)
 	return displacedVertexDaughterRef_;
       else if (trType == T_FROM_DISP)
@@ -83,7 +83,7 @@ namespace reco {
     }
 
     /// \set the ref to the displaced vertex interaction
-    void setDisplacedVertexRef(const PFDisplacedTrackerVertexRef& niref, TrackType trType) { 
+    void setDisplacedVertexRef(const PFDisplacedTrackerVertexRef& niref, TrackType trType) override { 
 
       if (trType == T_TO_DISP) {
 	displacedVertexDaughterRef_ = niref; setTrackType(trType,true);}
@@ -92,26 +92,26 @@ namespace reco {
     } 
     
     /// \return reference to the corresponding Muon
-    const reco::MuonRef& muonRef() const { return muonRef_; }
+    const reco::MuonRef& muonRef() const override { return muonRef_; }
 
     /// \set reference to the Muon
-    void setMuonRef(const MuonRef& muref) { 
+    void setMuonRef(const MuonRef& muref) override { 
       muonRef_=muref; setTrackType(MUON,true); 
     }
 
     /// \return ref to original recoConversion
-    const ConversionRefVector& convRefs() const {return convRefs_;} 
+    const ConversionRefVector& convRefs() const override {return convRefs_;} 
 
     /// \set the ref to  gamma conversion
-    void setConversionRef(const ConversionRef& convRef, TrackType trType) { 
+    void setConversionRef(const ConversionRef& convRef, TrackType trType) override { 
       convRefs_.push_back(convRef); setTrackType(trType,true); 
     } 
 
     /// \return ref to original V0
-    const VertexCompositeCandidateRef& V0Ref() const {return v0Ref_;} 
+    const VertexCompositeCandidateRef& V0Ref() const override {return v0Ref_;} 
 
     /// \set the ref to  V0
-    void setV0Ref(const VertexCompositeCandidateRef& V0Ref, TrackType trType) { 
+    void setV0Ref(const VertexCompositeCandidateRef& V0Ref, TrackType trType) override { 
       v0Ref_ = V0Ref; setTrackType(trType,true); 
     } 
 

--- a/DataFormats/ParticleFlowReco/interface/PFDisplacedVertexSeed.h
+++ b/DataFormats/ParticleFlowReco/interface/PFDisplacedVertexSeed.h
@@ -58,7 +58,7 @@ namespace reco {
     void mergeWith(const PFDisplacedVertexSeed& displacedVertex);
 
     /// Check if it is a new Seed
-    bool isEmpty() const {return (elements_.size() == 0);}
+    bool isEmpty() const {return (elements_.empty());}
 
     /// \return set of references to tracks 
     const std::set < TrackBaseRef, Compare >& elements() const 

--- a/DataFormats/ParticleFlowReco/interface/RecoPFClusterRefCandidate.h
+++ b/DataFormats/ParticleFlowReco/interface/RecoPFClusterRefCandidate.h
@@ -16,9 +16,9 @@ namespace reco {
     RecoPFClusterRefCandidate() : LeafRefCandidateT() {}
     RecoPFClusterRefCandidate(PFClusterRef ref, float m) : LeafRefCandidateT( ref, m) {}
     
-    ~RecoPFClusterRefCandidate() {}
+    ~RecoPFClusterRefCandidate() override {}
 
-    RecoPFClusterRefCandidate * clone() const { return new RecoPFClusterRefCandidate(*this);}
+    RecoPFClusterRefCandidate * clone() const override { return new RecoPFClusterRefCandidate(*this);}
 
     reco::PFClusterRef pfCluster() const {
       return getRef<reco::PFClusterRef>();

--- a/DataFormats/ParticleFlowReco/src/Calibratable.cc
+++ b/DataFormats/ParticleFlowReco/src/Calibratable.cc
@@ -112,7 +112,7 @@ CandidateWrapper Calibratable::computeMean(
 		const std::vector<CandidateWrapper>& wrappers) {
 	CandidateWrapper cw;
 
-	if (wrappers.size() == 0)
+	if (wrappers.empty())
 		return cw;
 	for (std::vector<CandidateWrapper>::const_iterator it = wrappers.begin(); it
 			!= wrappers.end(); ++it) {
@@ -138,7 +138,7 @@ CandidateWrapper Calibratable::computeMean(
 CalibratableElement Calibratable::computeMean(const std::vector<
 		CalibratableElement>& diets) {
 	CalibratableElement dmean;
-	if (diets.size() == 0)
+	if (diets.empty())
 		return dmean;
 	for (std::vector<CalibratableElement>::const_iterator cit = diets.begin(); cit
 			!= diets.end(); ++cit) {

--- a/DataFormats/ParticleFlowReco/src/CaloEllipse.cc
+++ b/DataFormats/ParticleFlowReco/src/CaloEllipse.cc
@@ -96,7 +96,7 @@ double CaloEllipse::getEccentricity() const {
 
 Point CaloEllipse::getPosition() const {
 
-	if (dataPoints_.size() < 1) {
+	if (dataPoints_.empty()) {
 		return Point(0, 0);
 	}
 

--- a/DataFormats/ParticleFlowReco/src/HGCalMultiCluster.cc
+++ b/DataFormats/ParticleFlowReco/src/HGCalMultiCluster.cc
@@ -7,7 +7,7 @@ HGCalMultiCluster::HGCalMultiCluster(double energy,
                                      ClusterCollection &thecls) :  
   PFCluster(PFLayer::HGCAL, energy, x, y, z),
   myclusters(thecls) {
-  assert(myclusters.size() > 0 && "Invalid cluster collection, zero length.");
+  assert(!myclusters.empty() && "Invalid cluster collection, zero length.");
   }
 
   

--- a/DataFormats/ParticleFlowReco/src/PFBlock.cc
+++ b/DataFormats/ParticleFlowReco/src/PFBlock.cc
@@ -208,7 +208,7 @@ ostream& reco::operator<<(  ostream& out,
 				reco::PFBlockElement::ECAL,
 				reco::PFBlock::LINKTEST_ALL );
       iBREM++;
-      if ( ecalElems.size() ) { 
+      if ( !ecalElems.empty() ) { 
 	ss << "BR" << iBREM;
       } else {
 	toPrint[ie] = false;

--- a/DataFormats/ParticleFlowReco/src/PFDisplacedVertexSeed.cc
+++ b/DataFormats/ParticleFlowReco/src/PFDisplacedVertexSeed.cc
@@ -47,8 +47,8 @@ void PFDisplacedVertexSeed::mergeWith(const PFDisplacedVertexSeed& displacedVert
 
   
   double weight = displacedVertex.totalWeight();
-  set<TrackBaseRef, Compare> newElements= displacedVertex.elements();
-  GlobalPoint dcaPoint = displacedVertex.seedPoint();
+  const set<TrackBaseRef, Compare>& newElements= displacedVertex.elements();
+  const GlobalPoint& dcaPoint = displacedVertex.seedPoint();
 
   Basic3DVector<double>vertexSeedVector(seedPoint_);
   Basic3DVector<double>dcaVector(dcaPoint);

--- a/DataFormats/ParticleFlowReco/src/PFLayer.cc
+++ b/DataFormats/ParticleFlowReco/src/PFLayer.cc
@@ -2,7 +2,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include <assert.h>
+#include <cassert>
 #include <iostream>
 
 using namespace reco;

--- a/DataFormats/PatCandidates/interface/CompositeCandidate.h
+++ b/DataFormats/PatCandidates/interface/CompositeCandidate.h
@@ -40,10 +40,10 @@ namespace pat {
       /// constructor from a composite candidate
       CompositeCandidate(const reco::CompositeCandidate & aCompositeCandidate);
       /// destructor
-      virtual ~CompositeCandidate();
+      ~CompositeCandidate() override;
 
       /// required reimplementation of the Candidate's clone method
-      virtual CompositeCandidate * clone() const { return new CompositeCandidate(*this); }
+      CompositeCandidate * clone() const override { return new CompositeCandidate(*this); }
 
   };
 

--- a/DataFormats/PatCandidates/interface/EventHypothesis.h
+++ b/DataFormats/PatCandidates/interface/EventHypothesis.h
@@ -113,14 +113,14 @@ namespace pat {
         struct AcceptAllFilter : public ParticleFilter {
             AcceptAllFilter(){}
             static const AcceptAllFilter & get() { return s_dummyFilter; }
-            virtual bool operator()(const CandRefType &cand, const std::string &role) const { return true; }
+            bool operator()(const CandRefType &cand, const std::string &role) const override { return true; }
             private:
                static const AcceptAllFilter s_dummyFilter;
         };
         class RoleRegexpFilter : public ParticleFilter {
             public:
                 explicit RoleRegexpFilter(const std::string &roleRegexp) : re_(roleRegexp) {}
-                virtual bool operator()(const CandRefType &cand, const std::string &role) const {
+                bool operator()(const CandRefType &cand, const std::string &role) const override {
                     return boost::regex_match(role, re_);
                 }
             private:
@@ -165,7 +165,7 @@ namespace pat {
    {
        CandRefType ref = get(role, index);
        const T* ret = dynamic_cast<const T*>(ref.get());
-       if ((ret == 0) && (ref.get() != 0)) throw cms::Exception("Type Checking") << createExceptionMessage<T>(ref);
+       if ((ret == 0) && (ref.get() != nullptr)) throw cms::Exception("Type Checking") << createExceptionMessage<T>(ref);
        return ret;
    }
    template<typename T> 
@@ -174,7 +174,7 @@ namespace pat {
    {
        CandRefType ref = get(filter, index);
        const T* ret = dynamic_cast<const T*>(ref.get());
-       if ((ret == 0) && (ref.get() != 0)) throw cms::Exception("Type Checking") << createExceptionMessage<T>(ref);
+       if ((ret == 0) && (ref.get() != nullptr)) throw cms::Exception("Type Checking") << createExceptionMessage<T>(ref);
        return ret;
    }
    template<typename T>

--- a/DataFormats/PatCandidates/interface/EventHypothesisLooper.h
+++ b/DataFormats/PatCandidates/interface/EventHypothesisLooper.h
@@ -26,7 +26,7 @@ namespace pat { namespace eventhypothesis {
         template<typename T>
         const T * DynCastCandPtr<T>::get(const reco::Candidate *ptr) {
             doPtr(ptr);
-            if ((ptr != 0) && (cachePtr_ == 0)) throw cms::Exception("Type Checking") <<
+            if ((ptr != nullptr) && (cachePtr_ == 0)) throw cms::Exception("Type Checking") <<
                 "You can't convert a " << typeid(*ptr).name() << " to a " << typeid(T).name() << "\n" <<
                 "note: you can use c++filt command to convert the above in human readable types.\n";
             return cachePtr_;

--- a/DataFormats/PatCandidates/interface/GenericParticle.h
+++ b/DataFormats/PatCandidates/interface/GenericParticle.h
@@ -50,43 +50,43 @@ namespace pat {
       /// constructor from ref to Candidate
       GenericParticle(const edm::Ptr<reco::Candidate> & aGenericParticleRef);
       /// destructor
-      virtual ~GenericParticle();
+      ~GenericParticle() override;
 
       /// required reimplementation of the Candidate's clone method
-      virtual GenericParticle * clone() const { return new GenericParticle(*this); }
+      GenericParticle * clone() const override { return new GenericParticle(*this); }
 
       /// Checks for overlap with another candidate. 
       /// It will return 'true' if the other candidate is a RecoCandidate, 
       /// and if they reference to at least one same non null track, supercluster or calotower (except for the multiple tracks)
       /// NOTE: It won't work with embedded references
-      virtual bool overlap( const Candidate & ) const ;
+      bool overlap( const Candidate & ) const override ;
 
       /// reference to a master track (might be transient refs if Tracks are embedded)
       /// returns null ref if there is no master track
-      virtual reco::TrackRef track() const    { return track_.empty() ? trackRef_ : reco::TrackRef(&track_, 0); }
+      reco::TrackRef track() const override    { return track_.empty() ? trackRef_ : reco::TrackRef(&track_, 0); }
       /// reference to one of a set of multiple tracks (might be transient refs if Tracks are embedded)
       /// throws exception if idx >= numberOfTracks()
-      virtual reco::TrackRef track( size_t idx ) const {  
+      reco::TrackRef track( size_t idx ) const override {  
             if (idx >= numberOfTracks()) throw cms::Exception("Index out of bounds") << "Requested track " << idx << " out of " << numberOfTracks() << ".\n";
             return (tracks_.empty() ? trackRefs_[idx] : reco::TrackRef(&tracks_, idx) );
       }
       /// number of multiple tracks (not including the master one)
-      virtual size_t numberOfTracks() const { return tracks_.empty() ? trackRefs_.size() : tracks_.size(); }
+      size_t numberOfTracks() const override { return tracks_.empty() ? trackRefs_.size() : tracks_.size(); }
       /// reference to a GsfTrack (might be transient ref if SuperCluster is embedded)
       /// returns null ref if there is no gsf track
-      virtual reco::GsfTrackRef gsfTrack() const    { return (gsfTrack_.empty() ? gsfTrackRef_ : reco::GsfTrackRef(&gsfTrack_, 0)); }
+      reco::GsfTrackRef gsfTrack() const override    { return (gsfTrack_.empty() ? gsfTrackRef_ : reco::GsfTrackRef(&gsfTrack_, 0)); }
       /// reference to a stand-alone muon Track (might be transient ref if SuperCluster is embedded)
       /// returns null ref if there is no stand-alone muon track
-      virtual reco::TrackRef standAloneMuon() const { return (standaloneTrack_.empty() ? standaloneTrackRef_ : reco::TrackRef(&standaloneTrack_, 0)); }
+      reco::TrackRef standAloneMuon() const override { return (standaloneTrack_.empty() ? standaloneTrackRef_ : reco::TrackRef(&standaloneTrack_, 0)); }
       /// reference to a combined muon Track (might be transient ref if SuperCluster is embedded)
       /// returns null ref if there is no combined muon track
-      virtual reco::TrackRef combinedMuon()   const { return (combinedTrack_.empty() ? combinedTrackRef_ : reco::TrackRef(&combinedTrack_, 0)); }
+      reco::TrackRef combinedMuon()   const override { return (combinedTrack_.empty() ? combinedTrackRef_ : reco::TrackRef(&combinedTrack_, 0)); }
       /// reference to a SuperCluster (might be transient ref if SuperCluster is embedded)
       /// returns null ref if there is no supercluster
-      virtual reco::SuperClusterRef superCluster() const { return superCluster_.empty() ? superClusterRef_ : reco::SuperClusterRef(&superCluster_, 0); }
+      reco::SuperClusterRef superCluster() const override { return superCluster_.empty() ? superClusterRef_ : reco::SuperClusterRef(&superCluster_, 0); }
       /// reference to a CaloTower  (might be transient ref if CaloTower is embedded)
       /// returns null ref if there is no calotower
-      virtual CaloTowerRef caloTower() const { return caloTower_.empty() ? caloTowerRef_ : CaloTowerRef(&caloTower_, 0); }
+      CaloTowerRef caloTower() const override { return caloTower_.empty() ? caloTowerRef_ : CaloTowerRef(&caloTower_, 0); }
 
       /// sets master track reference (or even embed it into the object)
       virtual void setTrack(const reco::TrackRef &ref, bool embed=false) ;
@@ -220,7 +220,7 @@ namespace pat {
           {
               if (it->first == key) return & it->second;
           }
-          return 0;
+          return nullptr;
       } 
 
       /// Sets the IsoDeposit associated with some key; if it is already existent, it is overwritten.
@@ -245,7 +245,7 @@ namespace pat {
       void userIsoDeposit(const IsoDeposit &dep, uint8_t index=0) { setIsoDeposit(IsolationKeys(UserBaseIso + index), dep); }
 
       /// Vertex association (or associations, if any). Return null pointer if none has been set
-      const pat::VertexAssociation              * vertexAssociation(size_t index=0) const { return vtxAss_.size() > index ? & vtxAss_[index] : 0; }
+      const pat::VertexAssociation              * vertexAssociation(size_t index=0) const { return vtxAss_.size() > index ? & vtxAss_[index] : nullptr; }
       /// Vertex associations. Can be empty if it was not enabled in the config file
       const std::vector<pat::VertexAssociation> & vertexAssociations()              const { return vtxAss_; }
       /// Set a single vertex association

--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -603,7 +603,7 @@ namespace pat {
             return static_cast<const T *>( baseTagInfo );
           }
         }
-        return 0;
+        return nullptr;
       }
 
       template<typename T> const T * tagInfoByTypeOrLabel(const std::string &label="") const

--- a/DataFormats/PatCandidates/interface/JetCorrFactors.h
+++ b/DataFormats/PatCandidates/interface/JetCorrFactors.h
@@ -30,7 +30,7 @@
 
 #include <vector>
 #include <string>
-#include <math.h>
+#include <cmath>
 
 namespace pat {
 

--- a/DataFormats/PatCandidates/interface/MHT.h
+++ b/DataFormats/PatCandidates/interface/MHT.h
@@ -12,7 +12,7 @@ namespace pat {
     MHT () {}
     MHT (const Candidate::LorentzVector& p4, double ht, double signif) :
       CompositeRefBaseCandidate(0,p4), ht_(ht), significance_(signif) {}
-    virtual ~MHT () {}
+    ~MHT () override {}
     
     double mht() const {return pt();}
     // ????double phi() const {return phi();}

--- a/DataFormats/PatCandidates/interface/PATObject.h
+++ b/DataFormats/PatCandidates/interface/PATObject.h
@@ -60,7 +60,7 @@ namespace pat {
       /// constructor from reference
       PATObject(const edm::Ptr<ObjectType> & ref);
       /// destructor
-      virtual ~PATObject() {}
+      ~PATObject() override {}
       // returns a clone                                  // NO: ObjectType can be an abstract type like reco::Candidate
       // virtual PATObject<ObjectType> * clone() const ;  //     for which the clone() can't be defined
 
@@ -243,7 +243,7 @@ namespace pat {
       /// If you stored multiple GenParticles, you can specify which one you want.
       const reco::GenParticle * genParticle(size_t idx=0)    const {
             reco::GenParticleRef ref = genParticleRef(idx);
-            return ref.isNonnull() ? ref.get() : 0;
+            return ref.isNonnull() ? ref.get() : nullptr;
       }
       /// Number of generator level particles stored as ref or embedded
       size_t genParticlesSize() const {
@@ -488,7 +488,7 @@ namespace pat {
     if (refToOrig_.isNull()) {
       // this object was not produced from a reference, so no link to the
       // original object exists -> return a 0-pointer
-      return 0;
+      return nullptr;
     } else if (!refToOrig_.isAvailable()) {
       throw edm::Exception(edm::errors::ProductNotFound) << "The original collection from which this PAT object was made is not present any more in the event, hence you cannot access the originating object anymore.";
     } else {
@@ -501,9 +501,9 @@ namespace pat {
 
   template <class ObjectType>
   const TriggerObjectStandAlone * PATObject<ObjectType>::triggerObjectMatch( const size_t idx ) const {
-    if ( idx >= triggerObjectMatches().size() ) return 0;
+    if ( idx >= triggerObjectMatches().size() ) return nullptr;
     TriggerObjectStandAloneRef ref( &triggerObjectMatchesEmbedded_, idx );
-    return ref.isNonnull() ? ref.get() : 0;
+    return ref.isNonnull() ? ref.get() : nullptr;
   }
 
   template <class ObjectType>
@@ -521,9 +521,9 @@ namespace pat {
     for ( size_t i = 0; i < triggerObjectMatches().size(); ++i ) {
       if ( triggerObjectMatch( i ) != 0 && triggerObjectMatch( i )->hasTriggerObjectType( triggerObjectType ) ) refs.push_back( i );
     }
-    if ( idx >= refs.size() ) return 0;
+    if ( idx >= refs.size() ) return nullptr;
     TriggerObjectStandAloneRef ref( &triggerObjectMatchesEmbedded_, refs.at( idx ) );
-    return ref.isNonnull() ? ref.get() : 0;
+    return ref.isNonnull() ? ref.get() : nullptr;
   }
 
   template <class ObjectType>
@@ -543,9 +543,9 @@ namespace pat {
         refs.push_back( i );
       }
     }
-    if ( idx >= refs.size() ) return 0;
+    if ( idx >= refs.size() ) return nullptr;
     TriggerObjectStandAloneRef ref( &triggerObjectMatchesEmbedded_, refs.at( idx ) );
-    return ref.isNonnull() ? ref.get() : 0;
+    return ref.isNonnull() ? ref.get() : nullptr;
   }
 
   template <class ObjectType>
@@ -563,9 +563,9 @@ namespace pat {
     for ( size_t i = 0; i < triggerObjectMatches().size(); ++i ) {
       if ( triggerObjectMatch( i ) != 0 && triggerObjectMatch( i )->hasConditionName( nameCondition ) ) refs.push_back( i );
     }
-    if ( idx >= refs.size() ) return 0;
+    if ( idx >= refs.size() ) return nullptr;
     TriggerObjectStandAloneRef ref( &triggerObjectMatchesEmbedded_, refs.at( idx ) );
-    return ref.isNonnull() ? ref.get() : 0;
+    return ref.isNonnull() ? ref.get() : nullptr;
   }
 
   template <class ObjectType>
@@ -583,9 +583,9 @@ namespace pat {
     for ( size_t i = 0; i < triggerObjectMatches().size(); ++i ) {
       if ( triggerObjectMatch( i ) != 0 && triggerObjectMatch( i )->hasAlgorithmName( nameAlgorithm, algoCondAccepted ) ) refs.push_back( i );
     }
-    if ( idx >= refs.size() ) return 0;
+    if ( idx >= refs.size() ) return nullptr;
     TriggerObjectStandAloneRef ref( &triggerObjectMatchesEmbedded_, refs.at( idx ) );
-    return ref.isNonnull() ? ref.get() : 0;
+    return ref.isNonnull() ? ref.get() : nullptr;
   }
 
   template <class ObjectType>
@@ -603,9 +603,9 @@ namespace pat {
     for ( size_t i = 0; i < triggerObjectMatches().size(); ++i ) {
       if ( triggerObjectMatch( i ) != 0 && triggerObjectMatch( i )->hasFilterLabel( labelFilter ) ) refs.push_back( i );
     }
-    if ( idx >= refs.size() ) return 0;
+    if ( idx >= refs.size() ) return nullptr;
     TriggerObjectStandAloneRef ref( &triggerObjectMatchesEmbedded_, refs.at( idx ) );
-    return ref.isNonnull() ? ref.get() : 0;
+    return ref.isNonnull() ? ref.get() : nullptr;
   }
 
   template <class ObjectType>
@@ -623,9 +623,9 @@ namespace pat {
     for ( size_t i = 0; i < triggerObjectMatches().size(); ++i ) {
       if ( triggerObjectMatch( i ) != 0 && triggerObjectMatch( i )->hasPathName( namePath, pathLastFilterAccepted, pathL3FilterAccepted ) ) refs.push_back( i );
     }
-    if ( idx >= refs.size() ) return 0;
+    if ( idx >= refs.size() ) return nullptr;
     TriggerObjectStandAloneRef ref( &triggerObjectMatchesEmbedded_, refs.at( idx ) );
-    return ref.isNonnull() ? ref.get() : 0;
+    return ref.isNonnull() ? ref.get() : nullptr;
   }
 
   template <class ObjectType>

--- a/DataFormats/PatCandidates/interface/PFParticle.h
+++ b/DataFormats/PatCandidates/interface/PFParticle.h
@@ -41,10 +41,10 @@ namespace pat {
       /// constructor from ref
       PFParticle(const edm::RefToBase<reco::PFCandidate> & aPFParticle);
       /// destructor
-      virtual ~PFParticle() {}
+      ~PFParticle() override {}
 
       /// required reimplementation of the Candidate's clone method
-      virtual PFParticle * clone() const { return new PFParticle(*this); }
+      PFParticle * clone() const override { return new PFParticle(*this); }
     
   };
   

--- a/DataFormats/PatCandidates/interface/PackedTriggerPrescales.h
+++ b/DataFormats/PatCandidates/interface/PackedTriggerPrescales.h
@@ -9,7 +9,7 @@ namespace pat {
 
 class PackedTriggerPrescales {
     public:
-        PackedTriggerPrescales() : triggerNames_(0) {}
+        PackedTriggerPrescales() : triggerNames_(nullptr) {}
         PackedTriggerPrescales(const edm::Handle<edm::TriggerResults> & handle) ;
         ~PackedTriggerPrescales() {}
 

--- a/DataFormats/PatCandidates/interface/Particle.h
+++ b/DataFormats/PatCandidates/interface/Particle.h
@@ -38,10 +38,10 @@ namespace pat {
       /// constructor from a LeafCandidate
       Particle(const reco::LeafCandidate & aParticle);
       /// destructor
-      virtual ~Particle();
+      ~Particle() override;
 
       /// required reimplementation of the Candidate's clone method
-      virtual Particle * clone() const { return new Particle(*this); }
+      Particle * clone() const override { return new Particle(*this); }
 
   };
 

--- a/DataFormats/PatCandidates/interface/Photon.h
+++ b/DataFormats/PatCandidates/interface/Photon.h
@@ -59,14 +59,14 @@ namespace pat {
       /// constructor from a Ptr to a reco photon
       Photon(const edm::Ptr<reco::Photon> & aPhotonRef);
       /// destructor
-      virtual ~Photon();
+      ~Photon() override;
 
       /// required reimplementation of the Candidate's clone method
-      virtual Photon * clone() const { return new Photon(*this); }
+      Photon * clone() const override { return new Photon(*this); }
 
       // ---- methods for content embedding ----
       /// override the superCluster method from CaloJet, to access the internal storage of the supercluster
-      reco::SuperClusterRef superCluster() const;
+      reco::SuperClusterRef superCluster() const override;
       /// direct access to the seed cluster
       reco::CaloClusterPtr seed() const; 
 
@@ -213,7 +213,7 @@ namespace pat {
           {
               if (it->first == key) return & it->second;
           }
-          return 0;
+          return nullptr;
       } 
       /// Return the tracker IsoDeposit
       const IsoDeposit * trackIsoDeposit() const { return isoDeposit(pat::TrackIso); }
@@ -330,9 +330,9 @@ namespace pat {
       }
  
       /// get the number of non-null PFCandidates
-      size_t numberOfSourceCandidatePtrs() const { return associatedPackedFCandidateIndices_.size(); }
+      size_t numberOfSourceCandidatePtrs() const override { return associatedPackedFCandidateIndices_.size(); }
       /// get the source candidate pointer with index i
-      reco::CandidatePtr sourceCandidatePtr( size_type i ) const;
+      reco::CandidatePtr sourceCandidatePtr( size_type i ) const override;
 
       friend class PATPhotonSlimmer;
 

--- a/DataFormats/PatCandidates/interface/Tau.h
+++ b/DataFormats/PatCandidates/interface/Tau.h
@@ -71,18 +71,18 @@ namespace pat {
       /// constructor from a Ptr to a reco tau
       Tau(const edm::Ptr<reco::BaseTau> & aTauRef);
       /// destructor
-      virtual ~Tau();
+      ~Tau() override;
 
       /// required reimplementation of the Candidate's clone method
-      virtual Tau * clone() const { return new Tau(*this); }
+      Tau * clone() const override { return new Tau(*this); }
 
       // ---- methods for content embedding ----
       /// override the reco::BaseTau::isolationTracks method, to access the internal storage of the isolation tracks
-      const reco::TrackRefVector & isolationTracks() const;
+      const reco::TrackRefVector & isolationTracks() const override;
       /// override the reco::BaseTau::leadTrack method, to access the internal storage of the leading track
-      reco::TrackRef leadTrack() const;
+      reco::TrackRef leadTrack() const override;
       /// override the reco::BaseTau::signalTracks method, to access the internal storage of the signal tracks
-      const reco::TrackRefVector & signalTracks() const;	
+      const reco::TrackRefVector & signalTracks() const override;	
       /// method to store the isolation tracks internally
       void embedIsolationTracks();
       /// method to store the leading track internally
@@ -302,9 +302,9 @@ namespace pat {
 
       /// ----- Top Projection business ------- 
       /// get the number of non-null PFCandidates
-      size_t numberOfSourceCandidatePtrs() const ;
+      size_t numberOfSourceCandidatePtrs() const override ;
       /// get the source candidate pointer with index i
-      reco::CandidatePtr sourceCandidatePtr( size_type i ) const;
+      reco::CandidatePtr sourceCandidatePtr( size_type i ) const override;
 
 
       /// ---- Tau lifetime information ----

--- a/DataFormats/PatCandidates/interface/TauJetCorrFactors.h
+++ b/DataFormats/PatCandidates/interface/TauJetCorrFactors.h
@@ -24,7 +24,7 @@
 
 #include <vector>
 #include <string>
-#include <math.h>
+#include <cmath>
 
 namespace pat {
 

--- a/DataFormats/PatCandidates/interface/TriggerObject.h
+++ b/DataFormats/PatCandidates/interface/TriggerObject.h
@@ -76,7 +76,7 @@ namespace pat {
       TriggerObject( const reco::Particle::PolarLorentzVector & vec, int id = 0 );
 
       /// Destructor
-      virtual ~TriggerObject() {};
+      ~TriggerObject() override {};
 
       /// Methods
 
@@ -112,19 +112,19 @@ namespace pat {
       /// Getters specific to the 'l1extra' particle type for
       /// - EM
       const l1extra::L1EmParticleRef origL1EmRef() const;
-      const L1GctEmCand * origL1GctEmCand() const { return origL1EmRef().isNonnull() ? origL1EmRef()->gctEmCand() : 0; };
+      const L1GctEmCand * origL1GctEmCand() const { return origL1EmRef().isNonnull() ? origL1EmRef()->gctEmCand() : nullptr; };
       /// - EtMiss
       const l1extra::L1EtMissParticleRef origL1EtMissRef() const;
-      const L1GctEtMiss  * origL1GctEtMiss()  const { return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctEtMiss()  : 0; };
-      const L1GctEtTotal * origL1GctEtTotal() const { return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctEtTotal() : 0; };
-      const L1GctHtMiss  * origL1GctHtMiss()  const { return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctHtMiss()  : 0; };
-      const L1GctEtHad   * origL1GctEtHad()   const { return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctEtHad()   : 0; };
+      const L1GctEtMiss  * origL1GctEtMiss()  const { return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctEtMiss()  : nullptr; };
+      const L1GctEtTotal * origL1GctEtTotal() const { return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctEtTotal() : nullptr; };
+      const L1GctHtMiss  * origL1GctHtMiss()  const { return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctHtMiss()  : nullptr; };
+      const L1GctEtHad   * origL1GctEtHad()   const { return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctEtHad()   : nullptr; };
       /// - Jet
       const l1extra::L1JetParticleRef origL1JetRef() const;
-      const L1GctJetCand * origL1GctJetCand() const { return origL1JetRef().isNonnull() ? origL1JetRef()->gctJetCand() : 0; };
+      const L1GctJetCand * origL1GctJetCand() const { return origL1JetRef().isNonnull() ? origL1JetRef()->gctJetCand() : nullptr; };
       /// - Muon
       const l1extra::L1MuonParticleRef origL1MuonRef() const;
-      const L1MuGMTExtendedCand * origL1GmtMuonCand() const { return origL1MuonRef().isNonnull() ? &( origL1MuonRef()->gmtMuonCand() ) : 0; };
+      const L1MuGMTExtendedCand * origL1GmtMuonCand() const { return origL1MuonRef().isNonnull() ? &( origL1MuonRef()->gmtMuonCand() ) : nullptr; };
 
       /// Special methods for the cut string parser
       /// - argument types usable in the cut string parser

--- a/DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h
+++ b/DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h
@@ -77,8 +77,8 @@ namespace pat {
       /// Checks, if a certain HLT path or L1 algorithm name is assigned
       bool hasPathOrAlgorithm( const std::string & name, bool pathLastFilterAccepted, bool pathL3FilterAccepted ) const;
       /// Check, if the usage indicator vectors have been filled
-      bool hasLastFilter() const { return ( pathLastFilterAccepted_.size() > 0 && pathLastFilterAccepted_.size() == pathNames_.size() ); };
-      bool hasL3Filter() const { return ( pathL3FilterAccepted_.size() > 0 && pathL3FilterAccepted_.size() == pathNames_.size() ); };
+      bool hasLastFilter() const { return ( !pathLastFilterAccepted_.empty() && pathLastFilterAccepted_.size() == pathNames_.size() ); };
+      bool hasL3Filter() const { return ( !pathL3FilterAccepted_.empty() && pathL3FilterAccepted_.size() == pathNames_.size() ); };
 
       /// Check if trigger names have been packed by calling packPathNames() and not yet unpacked
       bool checkIfPathsAreUnpacked(bool throwIfPacked=true) const ;
@@ -103,7 +103,7 @@ namespace pat {
       TriggerObjectStandAlone( const TriggerObjectStandAlone& ) = default;
 
       /// Destructor
-      virtual ~TriggerObjectStandAlone() {};
+      ~TriggerObjectStandAlone() override {};
 
       /// Methods
 
@@ -138,8 +138,8 @@ namespace pat {
       /// Checks, if a certain L1 algorithm name is assigned
       bool hasAlgorithmName( const std::string & algorithmName, bool algoCondAccepted = true ) const { return hasPathOrAlgorithm( algorithmName, algoCondAccepted, false ); };
       /// Checks, if a certain label of original collection is assigned (method overrides)
-      virtual bool hasCollection( const std::string & collName ) const;
-      virtual bool hasCollection( const edm::InputTag & collName ) const { return hasCollection( collName.encode() ); };
+      bool hasCollection( const std::string & collName ) const override;
+      bool hasCollection( const edm::InputTag & collName ) const override { return hasCollection( collName.encode() ); };
       /// Checks, if the usage indicator vector has been filled
       bool hasPathLastFilterAccepted() const { return hasLastFilter(); };
       bool hasAlgoCondAccepted() const { return hasLastFilter(); };
@@ -158,7 +158,7 @@ namespace pat {
       /// Calls 'hasAlgorithmName(...)'
       bool algo( const std::string & algorithmName, unsigned algoCondAccepted = 1 ) const { return hasAlgorithmName( algorithmName, bool( algoCondAccepted ) ); };
       /// Calls 'hasCollection(...)' (method override)
-      virtual bool coll( const std::string & collName ) const { return hasCollection( collName ); };
+      bool coll( const std::string & collName ) const override { return hasCollection( collName ); };
 
       ///set the psetid of the trigger process
       void setPSetID(const edm::ParameterSetID &psetId){psetId_=psetId;}

--- a/DataFormats/PatCandidates/interface/UserData.h
+++ b/DataFormats/PatCandidates/interface/UserData.h
@@ -69,13 +69,13 @@ namespace pat {
         UserHolder() : obj_() {}
         UserHolder(const T &data) : obj_(data) {}
         /// Clone
-        virtual UserHolder<T> * clone() const override { return new UserHolder<T>(*this); }
+        UserHolder<T> * clone() const override { return new UserHolder<T>(*this); }
         /// Concrete type of stored data
-        virtual const std::type_info & typeId()   const override { return typeid(T); }
+        const std::type_info & typeId()   const override { return typeid(T); }
         /// Human readable name of the concrete type of stored data
-        virtual const std::string    & typeName() const override { return typeName_(); }
+        const std::string    & typeName() const override { return typeName_(); }
     protected:
-        virtual const void *           data_()  const override { return &obj_; }
+        const void *           data_()  const override { return &obj_; }
     private: 
         T obj_;
         static const std::string & typeName_() ;

--- a/DataFormats/PatCandidates/interface/Vertexing.h
+++ b/DataFormats/PatCandidates/interface/Vertexing.h
@@ -43,18 +43,18 @@ namespace pat {
             //! Return the vertex (that is, you can do "const reco::Vertex &vtx = *assoc")
             const reco::Vertex & operator*()  const { return * operator->(); }
             //! Allows VertexAssociation to behave like a vertex ref  (e.g. to do "assoc->position()")
-            const reco::Vertex * operator->() const { return vertex_.isNull() ? 0 : vertex_.get(); }
+            const reco::Vertex * operator->() const { return vertex_.isNull() ? nullptr : vertex_.get(); }
             // --- Methods to get the Vertex and track
             //! Returns the reference to the vertex (can be a null reference)
             const reco::VertexRef & vertexRef() const  { return vertex_; }
             //! Returns a pointer to the vertex, or a null pointer if there is no vertex (null association)
-            const reco::Vertex    * vertex()    const  { return vertex_.isNull() ? 0 : vertex_.get(); }
+            const reco::Vertex    * vertex()    const  { return vertex_.isNull() ? nullptr : vertex_.get(); }
             //! Returns 'true' if a reference to a track was stored in this VertexAssociation
             bool                       hasTrack() const { return !track_.isNull(); }
             //! Returns a reference to the track stored in this vertex (can be null)
             const reco::TrackBaseRef & trackRef() const { return track_; }
             //! Returns a C++ pointer to the track stored in this vertex (can be a null pointer)
-            const reco::Track        * track()    const { return hasTrack() ? track_.get() : 0; }
+            const reco::Track        * track()    const { return hasTrack() ? track_.get() : nullptr; }
             // --- Methods to return distances
             //! Distance between the object and the vertex along the Z axis, and it's error.
             /// Note 1: if the BeamSpot was used as Vertex, the error includes the BeamSpot spread!

--- a/DataFormats/PatCandidates/src/Electron.cc
+++ b/DataFormats/PatCandidates/src/Electron.cc
@@ -143,14 +143,14 @@ reco::SuperClusterRef Electron::superCluster() const {
             if (embeddedSeedCluster_ && !(*sc)[0].seed().isAvailable()) {
                 (*sc)[0].setSeed(seed());
             }
-            if (basicClusters_.size() && !(*sc)[0].clusters().isAvailable()) {
+            if (!basicClusters_.empty() && !(*sc)[0].clusters().isAvailable()) {
                 reco::CaloClusterPtrVector clusters;
                 for (unsigned int iclus=0; iclus<basicClusters_.size(); ++iclus) {
                     clusters.push_back(reco::CaloClusterPtr(&basicClusters_,iclus));
                 }
                 (*sc)[0].setClusters(clusters);
             }
-            if (preshowerClusters_.size() && !(*sc)[0].preshowerClusters().isAvailable()) {
+            if (!preshowerClusters_.empty() && !(*sc)[0].preshowerClusters().isAvailable()) {
                 reco::CaloClusterPtrVector clusters;
                 for (unsigned int iclus=0; iclus<preshowerClusters_.size(); ++iclus) {
                     clusters.push_back(reco::CaloClusterPtr(&preshowerClusters_,iclus));
@@ -307,7 +307,7 @@ void Electron::embedTrack() {
 
 // method to store the RecHits internally
 void Electron::embedRecHits(const EcalRecHitCollection * rechits) {
-  if (rechits!=0) {
+  if (rechits!=nullptr) {
     recHits_ = *rechits;
     embeddedRecHits_ = true;
   }

--- a/DataFormats/PatCandidates/src/GenericParticle.cc
+++ b/DataFormats/PatCandidates/src/GenericParticle.cc
@@ -150,7 +150,7 @@ void GenericParticle::fillInFrom(const reco::Candidate &cand) {
     setStatus(cand.status());
     // then RECO part, if available
     const reco::RecoCandidate *rc = dynamic_cast<const reco::RecoCandidate *>(&cand);
-    if (rc != 0) {
+    if (rc != nullptr) {
         setTrack(rc->track());    
         setGsfTrack(rc->gsfTrack());    
         setStandAloneMuon(rc->standAloneMuon());    
@@ -170,7 +170,7 @@ void GenericParticle::fillInFrom(const reco::Candidate &cand) {
 
 bool GenericParticle::overlap( const reco::Candidate &cand ) const {
     const reco::RecoCandidate *rc = dynamic_cast<const reco::RecoCandidate *>(&cand);
-    if (rc != 0) {
+    if (rc != nullptr) {
         if (rc->track().isNonnull()          && (track() == rc->track())) return true;
         if (rc->gsfTrack().isNonnull()       && (gsfTrack() == rc->gsfTrack())) return true;
         if (rc->standAloneMuon().isNonnull() && (standAloneMuon() == rc->standAloneMuon())) return true;
@@ -179,7 +179,7 @@ bool GenericParticle::overlap( const reco::Candidate &cand ) const {
         if (rc->caloTower().isNonnull()      && (caloTower() == rc->caloTower())) return true;
    }
     const GenericParticle *rc2 = dynamic_cast<const GenericParticle *>(&cand);
-    if (rc2 != 0) {
+    if (rc2 != nullptr) {
         if (rc2->track().isNonnull()          && (track() == rc2->track())) return true;
         if (rc2->gsfTrack().isNonnull()       && (gsfTrack() == rc2->gsfTrack())) return true;
         if (rc2->standAloneMuon().isNonnull() && (standAloneMuon() == rc2->standAloneMuon())) return true;

--- a/DataFormats/PatCandidates/src/Jet.cc
+++ b/DataFormats/PatCandidates/src/Jet.cc
@@ -87,11 +87,11 @@ void Jet::tryImportSpecific(const reco::Jet& source)
   } else if( type == typeid(reco::JPTJet) ){
     reco::JPTJet const & jptJet = static_cast<reco::JPTJet const &>(source);
     specificJPT_.push_back( jptJet.getSpecific() );
-    reco::CaloJet const * caloJet = 0;
+    reco::CaloJet const * caloJet = nullptr;
     if ( jptJet.getCaloJetRef().isNonnull() && jptJet.getCaloJetRef().isAvailable() ) {
       caloJet = dynamic_cast<reco::CaloJet const *>( jptJet.getCaloJetRef().get() );
     }
-    if ( caloJet != 0 ) {
+    if ( caloJet != nullptr ) {
       specificCalo_.push_back( caloJet->getSpecific() );
     }
     else {
@@ -112,13 +112,13 @@ Jet::~Jet() {
 CaloTowerPtr Jet::getCaloConstituent (unsigned fIndex) const {
     if (embeddedCaloTowers_) {
       // Refactorized PAT access
-      if ( caloTowersFwdPtr_.size() > 0 ) {
+      if ( !caloTowersFwdPtr_.empty() ) {
 	return (fIndex < caloTowersFwdPtr_.size() ?
 		caloTowersFwdPtr_[fIndex].ptr() : CaloTowerPtr());
       }
       // Compatibility PAT access
       else {
-	if ( caloTowers_.size() > 0 ) {
+	if ( !caloTowers_.empty() ) {
 	  return (fIndex < caloTowers_.size() ?
 		  CaloTowerPtr(&caloTowers_, fIndex) : CaloTowerPtr());
 
@@ -129,7 +129,7 @@ CaloTowerPtr Jet::getCaloConstituent (unsigned fIndex) const {
     else {
       Constituent dau = daughterPtr (fIndex);
       const CaloTower* caloTower = dynamic_cast <const CaloTower*> (dau.get());
-      if (caloTower != 0) {
+      if (caloTower != nullptr) {
 	return CaloTowerPtr(dau.id(), caloTower, dau.key() );
       }
       else {
@@ -144,7 +144,7 @@ CaloTowerPtr Jet::getCaloConstituent (unsigned fIndex) const {
 
 
 std::vector<CaloTowerPtr> const & Jet::getCaloConstituents () const {
-  if ( !caloTowersTemp_.isSet() || caloTowers_.size() > 0 ) cacheCaloTowers();
+  if ( !caloTowersTemp_.isSet() || !caloTowers_.empty() ) cacheCaloTowers();
   return *caloTowersTemp_;
 }
 
@@ -154,13 +154,13 @@ std::vector<CaloTowerPtr> const & Jet::getCaloConstituents () const {
 reco::PFCandidatePtr Jet::getPFConstituent (unsigned fIndex) const {
     if (embeddedPFCandidates_) {
       // Refactorized PAT access
-      if ( pfCandidatesFwdPtr_.size() > 0 ) {
+      if ( !pfCandidatesFwdPtr_.empty() ) {
 	return (fIndex < pfCandidatesFwdPtr_.size() ?
 		pfCandidatesFwdPtr_[fIndex].ptr() : reco::PFCandidatePtr());
       }
       // Compatibility PAT access
       else {
-	if ( pfCandidates_.size() > 0 ) {
+	if ( !pfCandidates_.empty() ) {
 	  return (fIndex < pfCandidates_.size() ?
 		  reco::PFCandidatePtr(&pfCandidates_, fIndex) : reco::PFCandidatePtr());
 
@@ -184,22 +184,22 @@ reco::PFCandidatePtr Jet::getPFConstituent (unsigned fIndex) const {
 }
 
 std::vector<reco::PFCandidatePtr> const & Jet::getPFConstituents () const {
-  if ( !pfCandidatesTemp_.isSet() || pfCandidates_.size() > 0 ) cachePFCandidates();
+  if ( !pfCandidatesTemp_.isSet() || !pfCandidates_.empty() ) cachePFCandidates();
   return *pfCandidatesTemp_;
 }
 
 const reco::Candidate * Jet::daughter(size_t i) const {
   if (isCaloJet() || isJPTJet() ) {
     if ( embeddedCaloTowers_ ) {
-      if ( caloTowersFwdPtr_.size() > 0 ) return caloTowersFwdPtr_[i].get();
-      else if ( caloTowers_.size() > 0 ) return &caloTowers_[i];
+      if ( !caloTowersFwdPtr_.empty() ) return caloTowersFwdPtr_[i].get();
+      else if ( !caloTowers_.empty() ) return &caloTowers_[i];
       else return reco::Jet::daughter(i);
     }
   }
   if (isPFJet()) {
     if ( embeddedPFCandidates_ ) {
-      if ( pfCandidatesFwdPtr_.size() > 0 ) return pfCandidatesFwdPtr_[i].get();
-      else if ( pfCandidates_.size() > 0 ) return &pfCandidates_[i];
+      if ( !pfCandidatesFwdPtr_.empty() ) return pfCandidatesFwdPtr_[i].get();
+      else if ( !pfCandidates_.empty() ) return &pfCandidates_[i];
       else return reco::Jet::daughter(i);
     }
   }
@@ -209,15 +209,15 @@ const reco::Candidate * Jet::daughter(size_t i) const {
 size_t Jet::numberOfDaughters() const {
   if (isCaloJet() || isJPTJet()) {
     if ( embeddedCaloTowers_ ) {
-      if ( caloTowersFwdPtr_.size() > 0 ) return caloTowersFwdPtr_.size();
-      else if ( caloTowers_.size() > 0 ) return caloTowers_.size();
+      if ( !caloTowersFwdPtr_.empty() ) return caloTowersFwdPtr_.size();
+      else if ( !caloTowers_.empty() ) return caloTowers_.size();
       else return reco::Jet::numberOfDaughters();
     }
   }
   if (isPFJet()) {
     if ( embeddedPFCandidates_ ) {
-      if ( pfCandidatesFwdPtr_.size() > 0 ) return pfCandidatesFwdPtr_.size();
-      else if ( pfCandidates_.size() > 0 ) return pfCandidates_.size();
+      if ( !pfCandidatesFwdPtr_.empty() ) return pfCandidatesFwdPtr_.size();
+      else if ( !pfCandidates_.empty() ) return pfCandidates_.size();
       else return reco::Jet::numberOfDaughters();
     }
   }
@@ -226,8 +226,8 @@ size_t Jet::numberOfDaughters() const {
 
 /// return the matched generated jet
 const reco::GenJet * Jet::genJet() const {
-  if (genJet_.size()) return  &(genJet_.front());
-  else if ( genJetRef_.size() ) return genJetRef_[0].get();
+  if (!genJet_.empty()) return  &(genJet_.front());
+  else if ( !genJetRef_.empty() ) return genJetRef_[0].get();
   else return genJetFwdRef_.get();
 }
 
@@ -364,12 +364,12 @@ float Jet::bDiscriminator(const std::string & aLabel) const {
 const reco::BaseTagInfo * Jet::tagInfo(const std::string &label) const {
   for(int i=(int(tagInfoLabels_.size())-1); i>=0; i--){
     if (tagInfoLabels_[i] == label) {
-      if ( tagInfosFwdPtr_.size() > 0 ) return tagInfosFwdPtr_[i].get();
-      else if ( tagInfos_.size() > 0 )  return & tagInfos_[i];
-      return 0;
+      if ( !tagInfosFwdPtr_.empty() ) return tagInfosFwdPtr_[i].get();
+      else if ( !tagInfos_.empty() )  return & tagInfos_[i];
+      return nullptr;
     }
   }
-  return 0;
+  return nullptr;
 }
 
 
@@ -501,7 +501,7 @@ void Jet::cacheCaloTowers() const {
   std::unique_ptr<std::vector<CaloTowerPtr>> caloTowersTemp{ new std::vector<CaloTowerPtr>{}};
   if ( embeddedCaloTowers_ ) {
     // Refactorized PAT access
-    if ( caloTowersFwdPtr_.size() > 0 ) {
+    if ( !caloTowersFwdPtr_.empty() ) {
       caloTowersTemp->reserve(caloTowersFwdPtr_.size());
       for ( CaloTowerFwdPtrVector::const_iterator ibegin=caloTowersFwdPtr_.begin(),
 	      iend = caloTowersFwdPtr_.end(),
@@ -511,7 +511,7 @@ void Jet::cacheCaloTowers() const {
       }
     }
     // Compatibility access
-    else if ( caloTowers_.size() > 0 ) {
+    else if ( !caloTowers_.empty() ) {
       caloTowersTemp->reserve(caloTowers_.size());
       for ( CaloTowerCollection::const_iterator ibegin=caloTowers_.begin(),
 	      iend = caloTowers_.end(),
@@ -546,7 +546,7 @@ void Jet::cachePFCandidates() const {
   // Here is where we've embedded constituents
   if ( embeddedPFCandidates_ ) {
     // Refactorized PAT access
-    if ( pfCandidatesFwdPtr_.size() > 0 ) {
+    if ( !pfCandidatesFwdPtr_.empty() ) {
       pfCandidatesTemp->reserve(pfCandidatesFwdPtr_.size());
       for ( PFCandidateFwdPtrCollection::const_iterator ibegin=pfCandidatesFwdPtr_.begin(),
 	      iend = pfCandidatesFwdPtr_.end(),
@@ -556,7 +556,7 @@ void Jet::cachePFCandidates() const {
       }
     }
     // Compatibility access
-    else if ( pfCandidates_.size() > 0 ) {
+    else if ( !pfCandidates_.empty() ) {
       pfCandidatesTemp->reserve(pfCandidates_.size());
       for ( reco::PFCandidateCollection::const_iterator ibegin=pfCandidates_.begin(),
 	      iend = pfCandidates_.end(),

--- a/DataFormats/PatCandidates/src/PackedTriggerPrescales.cc
+++ b/DataFormats/PatCandidates/src/PackedTriggerPrescales.cc
@@ -5,7 +5,7 @@
 pat::PackedTriggerPrescales::PackedTriggerPrescales(const edm::Handle<edm::TriggerResults> & handle) :
     prescaleValues_(), 
     triggerResults_(edm::RefProd<edm::TriggerResults>(handle).refCore()),
-    triggerNames_(0)
+    triggerNames_(nullptr)
 {
     prescaleValues_.resize(handle->size(),0);
 }
@@ -16,7 +16,7 @@ int pat::PackedTriggerPrescales::getPrescaleForIndex(int index) const {
 }
 
 int pat::PackedTriggerPrescales::getPrescaleForName(const std::string & name, bool prefixOnly) const {
-    if (triggerNames_ == 0) throw cms::Exception("LogicError", "getPrescaleForName called without having called setTriggerNames first");
+    if (triggerNames_ == nullptr) throw cms::Exception("LogicError", "getPrescaleForName called without having called setTriggerNames first");
     if (prefixOnly) {
         const std::vector<std::string> &names = triggerNames_->triggerNames();
         size_t siz = name.length()-1;

--- a/DataFormats/PatCandidates/src/Photon.cc
+++ b/DataFormats/PatCandidates/src/Photon.cc
@@ -195,14 +195,14 @@ reco::SuperClusterRef Photon::superCluster() const {
             if (embeddedSeedCluster_ && !(*sc)[0].seed().isAvailable()) {
                 (*sc)[0].setSeed(seed());
             }
-            if (basicClusters_.size() && !(*sc)[0].clusters().isAvailable()) {
+            if (!basicClusters_.empty() && !(*sc)[0].clusters().isAvailable()) {
                 reco::CaloClusterPtrVector clusters;
                 for (unsigned int iclus=0; iclus<basicClusters_.size(); ++iclus) {
                     clusters.push_back(reco::CaloClusterPtr(&basicClusters_,iclus));
                 }
                 (*sc)[0].setClusters(clusters);
             }
-            if (preshowerClusters_.size() && !(*sc)[0].preshowerClusters().isAvailable()) {
+            if (!preshowerClusters_.empty() && !(*sc)[0].preshowerClusters().isAvailable()) {
                 reco::CaloClusterPtrVector clusters;
                 for (unsigned int iclus=0; iclus<preshowerClusters_.size(); ++iclus) {
                     clusters.push_back(reco::CaloClusterPtr(&preshowerClusters_,iclus));
@@ -273,7 +273,7 @@ void Photon::embedPreshowerClusters() {
 
 // method to store the RecHits internally
 void Photon::embedRecHits(const EcalRecHitCollection * rechits) {
-  if (rechits!=0) {
+  if (rechits!=nullptr) {
     recHits_ = *rechits;
     embeddedRecHits_ = true;
   }

--- a/DataFormats/PatCandidates/src/Tau.cc
+++ b/DataFormats/PatCandidates/src/Tau.cc
@@ -48,12 +48,12 @@ Tau::Tau(const reco::BaseTau & aTau) :
     ,embeddedIsolationPFGammaCands_(false)
 {
     const reco::PFTau * pfTau = dynamic_cast<const reco::PFTau *>(&aTau);
-    if (pfTau != 0){
+    if (pfTau != nullptr){
       pfSpecific_.push_back(pat::tau::TauPFSpecific(*pfTau));
       pfEssential_.push_back(pat::tau::TauPFEssential(*pfTau));
     }
     const reco::CaloTau * caloTau = dynamic_cast<const reco::CaloTau *>(&aTau);
-    if (caloTau != 0) caloSpecific_.push_back(pat::tau::TauCaloSpecific(*caloTau));
+    if (caloTau != nullptr) caloSpecific_.push_back(pat::tau::TauCaloSpecific(*caloTau));
 }
 
 /// constructor from ref to reco::BaseTau
@@ -75,12 +75,12 @@ Tau::Tau(const edm::RefToBase<reco::BaseTau> & aTauRef) :
     ,embeddedIsolationPFGammaCands_(false)
 {
     const reco::PFTau * pfTau = dynamic_cast<const reco::PFTau *>(aTauRef.get());
-    if (pfTau != 0){
+    if (pfTau != nullptr){
       pfSpecific_.push_back(pat::tau::TauPFSpecific(*pfTau));
       pfEssential_.push_back(pat::tau::TauPFEssential(*pfTau));
     }
     const reco::CaloTau * caloTau = dynamic_cast<const reco::CaloTau *>(aTauRef.get());
-    if (caloTau != 0) caloSpecific_.push_back(pat::tau::TauCaloSpecific(*caloTau));
+    if (caloTau != nullptr) caloSpecific_.push_back(pat::tau::TauCaloSpecific(*caloTau));
 }
 
 /// constructor from ref to reco::BaseTau
@@ -102,12 +102,12 @@ Tau::Tau(const edm::Ptr<reco::BaseTau> & aTauRef) :
     ,embeddedIsolationPFGammaCands_(false)
 {
     const reco::PFTau * pfTau = dynamic_cast<const reco::PFTau *>(aTauRef.get());
-    if (pfTau != 0){
+    if (pfTau != nullptr){
       pfSpecific_.push_back(pat::tau::TauPFSpecific(*pfTau));
       pfEssential_.push_back(pat::tau::TauPFEssential(*pfTau));
     }
     const reco::CaloTau * caloTau = dynamic_cast<const reco::CaloTau *>(aTauRef.get());
-    if (caloTau != 0) caloSpecific_.push_back(pat::tau::TauCaloSpecific(*caloTau));
+    if (caloTau != nullptr) caloSpecific_.push_back(pat::tau::TauCaloSpecific(*caloTau));
 }
 
 /// destructor
@@ -217,7 +217,7 @@ void Tau::setGenJet(const reco::GenJetRef& gj) {
 
 /// return the matched generated jet
 const reco::GenJet * Tau::genJet() const {
-  return (genJet_.size() > 0 ? &genJet_.front() : 0);
+  return (!genJet_.empty() ? &genJet_.front() : nullptr);
 }
 
 
@@ -438,7 +438,7 @@ void Tau::embedIsolationPFGammaCands() {
 
 reco::PFRecoTauChargedHadronRef Tau::leadTauChargedHadronCandidate() const {
   if(!isPFTau() ) throw cms::Exception("Type Error") << "Requesting content that is not stored in miniAOD.\n";
-  if ( pfSpecific().signalTauChargedHadronCandidates_.size() > 0 ) {
+  if ( !pfSpecific().signalTauChargedHadronCandidates_.empty() ) {
     return reco::PFRecoTauChargedHadronRef(&pfSpecific().signalTauChargedHadronCandidates_,0);
   } else {
     return reco::PFRecoTauChargedHadronRef();

--- a/DataFormats/PatCandidates/src/TriggerEvent.cc
+++ b/DataFormats/PatCandidates/src/TriggerEvent.cc
@@ -102,7 +102,7 @@ const TriggerAlgorithm * TriggerEvent::algorithm( const std::string & nameAlgori
   for ( TriggerAlgorithmCollection::const_iterator iAlgorithm = algorithms()->begin(); iAlgorithm != algorithms()->end(); ++iAlgorithm ) {
     if ( nameAlgorithm == iAlgorithm->name() ) return &*iAlgorithm;
   }
-  return 0;
+  return nullptr;
 }
 
 
@@ -274,7 +274,7 @@ const TriggerCondition * TriggerEvent::condition( const std::string & nameCondit
   for ( TriggerConditionCollection::const_iterator iCondition = conditions()->begin(); iCondition != conditions()->end(); ++iCondition ) {
     if ( nameCondition == iCondition->name() ) return &*iCondition;
   }
-  return 0;
+  return nullptr;
 }
 
 
@@ -331,7 +331,7 @@ const TriggerPath * TriggerEvent::path( const std::string & namePath ) const
   for ( TriggerPathCollection::const_iterator iPath = paths()->begin(); iPath != paths()->end(); ++iPath ) {
     if ( namePath == iPath->name() ) return &*iPath;
   }
-  return 0;
+  return nullptr;
 }
 
 
@@ -388,7 +388,7 @@ const TriggerFilter * TriggerEvent::filter( const std::string & labelFilter ) co
   for ( TriggerFilterCollection::const_iterator iFilter = filters()->begin(); iFilter != filters()->end(); ++iFilter ) {
     if ( labelFilter == iFilter->label() ) return &*iFilter;
   }
-  return 0;
+  return nullptr;
 }
 
 
@@ -604,7 +604,7 @@ TriggerFilterRefVector TriggerEvent::pathModules( const std::string & namePath, 
 {
   TriggerFilterRefVector thePathFilters;
   if ( const TriggerPath * pathPtr = path( namePath ) ) {
-    if ( pathPtr->modules().size() > 0 ) {
+    if ( !pathPtr->modules().empty() ) {
       const unsigned onePastLastFilter = all ? pathPtr->modules().size() : pathPtr->lastActiveFilterSlot() + 1;
       for ( unsigned iM = 0; iM < onePastLastFilter; ++iM ) {
         const std::string labelFilter( pathPtr->modules().at( iM ) );
@@ -789,5 +789,5 @@ const TriggerObjectMatch * TriggerEvent::triggerObjectMatchResult( const std::st
 {
   const TriggerObjectMatchContainer::const_iterator iMatch( triggerObjectMatchResults()->find( labelMatcher ) );
   if ( iMatch != triggerObjectMatchResults()->end() ) return iMatch->second.get();
-  return 0;
+  return nullptr;
 }

--- a/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
+++ b/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
@@ -406,7 +406,7 @@ std::vector<std::string>  const* TriggerObjectStandAlone::allLabels(edm::Paramet
          return &iter->second;
       }
 
-      auto   triggerNames= event.triggerNames(res); 
+      const auto&   triggerNames= event.triggerNames(res); 
       edm::ParameterSet const* pset=nullptr;
       //getting the ParameterSet from the event ensures that the registry is filled
       if (nullptr!=(pset=event.parameterSet(psetid ))) {
@@ -425,7 +425,7 @@ std::vector<std::string>  const* TriggerObjectStandAlone::allLabels(edm::Paramet
 		    auto moduleStrip=module.front()!='-' ? module : module.substr(1);
  
 		    if (pset->exists(moduleStrip)) {
-			auto modulePSet= pset->getParameterSet(moduleStrip);
+			const auto& modulePSet= pset->getParameterSet(moduleStrip);
 			if (modulePSet.existsAs<bool>("saveTags",true) and 
 			    modulePSet.getParameter<bool>("saveTags") ) {
 			    saveTags.insert(moduleStrip);
@@ -439,6 +439,6 @@ std::vector<std::string>  const* TriggerObjectStandAlone::allLabels(edm::Paramet
                allLabelsMap.insert(std::pair<edm::ParameterSetID, std::vector<std::string> >(psetid, allModules));
          return &(ret.first->second);
       }
-      return 0;
+      return nullptr;
    }
 

--- a/DataFormats/PatCandidates/src/UserData.cc
+++ b/DataFormats/PatCandidates/src/UserData.cc
@@ -7,9 +7,9 @@
 void pat::UserData::checkDictionaries(const std::type_info &type) {
     if (!edm::hasDictionary(type)) {
         int status = 0;
-        char * demangled = abi::__cxa_demangle(type.name(),  0, 0, &status);
+        char * demangled = abi::__cxa_demangle(type.name(),  nullptr, nullptr, &status);
         std::string typeName(status == 0 ? demangled : type.name());
-        if ((demangled != 0) && (status == 0)) free(demangled);
+        if ((demangled != nullptr) && (status == 0)) free(demangled);
         throw edm::Exception(edm::errors::DictionaryNotFound)
             << "   No REFLEX data dictionary found for the following class:\n\t"
             << typeName 
@@ -27,6 +27,6 @@ void pat::UserData::checkDictionaries(const std::type_info &type) {
 
 std::string pat::UserData::typeNameFor(std::type_info const& iType) {
     int status = 0;
-    const char * demangled = abi::__cxa_demangle(iType.name(),  0, 0, &status);
+    const char * demangled = abi::__cxa_demangle(iType.name(),  nullptr, nullptr, &status);
     return std::string(status == 0 ? demangled : "[UNKNOWN]");
 }

--- a/DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h
+++ b/DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h
@@ -1,7 +1,7 @@
 #ifndef DataFormats_Phase2TrackerDigi_Phase2TrackerDigi_H
 #define DataFormats_Phase2TrackerDigi_Phase2TrackerDigi_H
 
-#include <stdint.h>
+#include <cstdint>
 #include <utility>
 #include <cassert> 
 

--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -590,25 +590,25 @@ namespace edm {
                                long long indexToEvent,
                                long long nEvents);
 
-        virtual IndexIntoFileItrImpl* clone() const;
+        IndexIntoFileItrImpl* clone() const override;
 
-        virtual int processHistoryIDIndex() const;
-        virtual RunNumber_t run() const;
-        virtual LuminosityBlockNumber_t lumi() const;
-        virtual EntryNumber_t entry() const;
-        virtual LuminosityBlockNumber_t peekAheadAtLumi() const;
-        virtual EntryNumber_t peekAheadAtEventEntry() const;
-        virtual bool skipLumiInRun();
+        int processHistoryIDIndex() const override;
+        RunNumber_t run() const override;
+        LuminosityBlockNumber_t lumi() const override;
+        EntryNumber_t entry() const override;
+        LuminosityBlockNumber_t peekAheadAtLumi() const override;
+        EntryNumber_t peekAheadAtEventEntry() const override;
+        bool skipLumiInRun() override;
 
       private:
 
-        virtual void initializeLumi_();
-        virtual bool nextEventRange();
-        virtual bool previousEventRange();
-        virtual bool setToLastEventInRange(int index);
-        virtual EntryType getRunOrLumiEntryType(int index) const;
-        virtual bool isSameLumi(int index1, int index2) const;
-        virtual bool isSameRun(int index1, int index2) const;
+        void initializeLumi_() override;
+        bool nextEventRange() override;
+        bool previousEventRange() override;
+        bool setToLastEventInRange(int index) override;
+        EntryType getRunOrLumiEntryType(int index) const override;
+        bool isSameLumi(int index1, int index2) const override;
+        bool isSameRun(int index1, int index2) const override;
       };
 
       //*****************************************************************************
@@ -624,24 +624,24 @@ namespace edm {
                                long long indexToEvent,
                                long long nEvents);
 
-        virtual IndexIntoFileItrImpl* clone() const;
-        virtual int processHistoryIDIndex() const;
-        virtual RunNumber_t run() const;
-        virtual LuminosityBlockNumber_t lumi() const;
-        virtual EntryNumber_t entry() const;
-        virtual LuminosityBlockNumber_t peekAheadAtLumi() const;
-        virtual EntryNumber_t peekAheadAtEventEntry() const;
-        virtual bool skipLumiInRun();
+        IndexIntoFileItrImpl* clone() const override;
+        int processHistoryIDIndex() const override;
+        RunNumber_t run() const override;
+        LuminosityBlockNumber_t lumi() const override;
+        EntryNumber_t entry() const override;
+        LuminosityBlockNumber_t peekAheadAtLumi() const override;
+        EntryNumber_t peekAheadAtEventEntry() const override;
+        bool skipLumiInRun() override;
 
       private:
 
-        virtual void initializeLumi_();
-        virtual bool nextEventRange();
-        virtual bool previousEventRange();
-        virtual bool setToLastEventInRange(int index);
-        virtual EntryType getRunOrLumiEntryType(int index) const;
-        virtual bool isSameLumi(int index1, int index2) const;
-        virtual bool isSameRun(int index1, int index2) const;
+        void initializeLumi_() override;
+        bool nextEventRange() override;
+        bool previousEventRange() override;
+        bool setToLastEventInRange(int index) override;
+        EntryType getRunOrLumiEntryType(int index) const override;
+        bool isSameLumi(int index1, int index2) const override;
+        bool isSameRun(int index1, int index2) const override;
       };
 
       //*****************************************************************************

--- a/DataFormats/Provenance/src/BranchDescription.cc
+++ b/DataFormats/Provenance/src/BranchDescription.cc
@@ -213,7 +213,7 @@ namespace edm {
     }
 
     if (wp && wp->HasKey("splitLevel")) {
-      setSplitLevel(strtol(wp->GetPropertyAsString("splitLevel"), 0, 0));
+      setSplitLevel(strtol(wp->GetPropertyAsString("splitLevel"), nullptr, 0));
       if (splitLevel() < 0) {
         throw cms::Exception("IllegalSplitLevel") << "' An illegal ROOT split level of " <<
           splitLevel() << " is specified for class " << wrappedName() << ".'\n";
@@ -221,7 +221,7 @@ namespace edm {
       setSplitLevel(splitLevel() + 1); //Compensate for wrapper
     }
     if (wp && wp->HasKey("basketSize")) {
-      setBasketSize(strtol(wp->GetPropertyAsString("basketSize"), 0, 0));
+      setBasketSize(strtol(wp->GetPropertyAsString("basketSize"), nullptr, 0));
       if (basketSize() <= 0) {
         throw cms::Exception("IllegalBasketSize") << "' An illegal ROOT basket size of " <<
           basketSize() << " is specified for class " << wrappedName() << "'.\n";

--- a/DataFormats/Provenance/src/IndexIntoFile.cc
+++ b/DataFormats/Provenance/src/IndexIntoFile.cc
@@ -787,7 +787,7 @@ namespace edm {
     if(iter2 == iEnd2) return;
     if(back1 < iter2.runOrLumiIndexes()) return;
 
-    RunOrLumiIndexes const* previousIndexes = 0;
+    RunOrLumiIndexes const* previousIndexes = nullptr;
 
     // Loop through the both IndexIntoFile objects and look for matching lumis
     while(iter1 != iEnd1 && iter2 != iEnd2) {
@@ -862,7 +862,7 @@ namespace edm {
 
   bool IndexIntoFile::containsDuplicateEvents() const {
 
-    RunOrLumiIndexes const* previousIndexes = 0;
+    RunOrLumiIndexes const* previousIndexes = nullptr;
 
     for(SortedRunOrLumiItr iter = beginRunOrLumi(),
                             iEnd = endRunOrLumi();

--- a/DataFormats/RPCDigi/interface/EmptyWord.h
+++ b/DataFormats/RPCDigi/interface/EmptyWord.h
@@ -10,7 +10,7 @@ private:
   static const int  EW_TYPE = 0xE800;
 public:
   EmptyWord() : DataRecord(EW_TYPE) {}
-  virtual ~EmptyWord(){}
+  ~EmptyWord() override{}
   std::string print()  const { return " EMPTY "; }
   static bool matchType(const DataRecord & record) { return record.data()==EW_TYPE; }
 };

--- a/DataFormats/RPCDigi/interface/RecordBX.h
+++ b/DataFormats/RPCDigi/interface/RecordBX.h
@@ -26,7 +26,7 @@ public:
   // specialize given recort to this type
   RecordBX(const DataRecord & rec) : DataRecord(rec) {}
 
-  virtual ~RecordBX() {}
+  ~RecordBX() override {}
   int bx() const { return ((theData>>BX_SHIFT)&BX_MASK); } 
   std::string print()  const;
   static bool matchType(const DataRecord & record);

--- a/DataFormats/RPCDigi/interface/RecordCD.h
+++ b/DataFormats/RPCDigi/interface/RecordCD.h
@@ -43,7 +43,7 @@ public:
   // specialize given recort to this type
   RecordCD(const DataRecord & rec) : DataRecord(rec) {}
 
-  virtual ~RecordCD() {}
+  ~RecordCD() override {}
 
   static bool matchType(const DataRecord & record) {
     return ( (record.data() >> CD_TYPE_SHIFT) < CD_TYPE_LESSTHENFLAG);

--- a/DataFormats/RPCDigi/interface/RecordSLD.h
+++ b/DataFormats/RPCDigi/interface/RecordSLD.h
@@ -29,7 +29,7 @@ public:
   // specialize given recort to this type
   RecordSLD(const DataRecord & rec) : DataRecord(rec) {}
 
-  virtual ~RecordSLD() {}
+  ~RecordSLD() override {}
 
   int tbLinkInputNumber() const {
      return (theData >> TB_LINK_INPUT_NUMBER_SHIFT)& TB_LINK_INPUT_NUMBER_MASK;

--- a/DataFormats/RPCRecHit/interface/RPCRecHit.h
+++ b/DataFormats/RPCRecHit/interface/RPCRecHit.h
@@ -46,32 +46,32 @@ class RPCRecHit : public RecHit2DLocalPos {
 	    const LocalError& err);
   
   /// Destructor
-  virtual ~RPCRecHit();
+  ~RPCRecHit() override;
 
 
   /// Return the 3-dimensional local position
-  virtual LocalPoint localPosition() const {
+  LocalPoint localPosition() const override {
     return theLocalPosition;
   }
 
 
   /// Return the 3-dimensional error on the local position
-  virtual LocalError localPositionError() const {
+  LocalError localPositionError() const override {
     return theLocalError;
   }
 
 
-  virtual RPCRecHit* clone() const;
+  RPCRecHit* clone() const override;
 
   
   /// Access to component RecHits.
   /// No components rechits: it returns a null vector
-  virtual std::vector<const TrackingRecHit*> recHits() const;
+  std::vector<const TrackingRecHit*> recHits() const override;
 
 
   /// Non-const access to component RecHits.
   /// No components rechits: it returns a null vector
-  virtual std::vector<TrackingRecHit*> recHits();
+  std::vector<TrackingRecHit*> recHits() override;
 
 
   /// Set local position 

--- a/DataFormats/RecoCandidate/interface/CaloRecHitCandidate.h
+++ b/DataFormats/RecoCandidate/interface/CaloRecHitCandidate.h
@@ -26,9 +26,9 @@ namespace reco {
     CaloRecHitCandidate( const PolarLorentzVector & p4, Charge q = 0, const Point & vtx = Point( 0, 0, 0 ) ) :
       LeafCandidate( q, p4, vtx ) { }
     /// destructor
-    virtual ~CaloRecHitCandidate();
+    ~CaloRecHitCandidate() override;
     /// returns a clone of the candidate
-    virtual CaloRecHitCandidate * clone() const;
+    CaloRecHitCandidate * clone() const override;
     /// set CaloRecHit reference
     void setCaloRecHit( const CaloRecHitRef & r ) { caloRecHit_ = r; }
     /// reference to a CaloRecHit
@@ -36,7 +36,7 @@ namespace reco {
 
   private:
     /// check overlap with another candidate
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
     /// reference to a CaloRecHit
     CaloRecHitRef caloRecHit_;
   };

--- a/DataFormats/RecoCandidate/interface/IsoDepositVetos.h
+++ b/DataFormats/RecoCandidate/interface/IsoDepositVetos.h
@@ -10,8 +10,8 @@ namespace reco {
             public:
                 ConeVeto(Direction dir, double dr) : vetoDir_(dir), dR2_(dr*dr) {}
                 ConeVeto(const reco::IsoDeposit::Veto &veto) : vetoDir_(veto.vetoDir), dR2_(veto.dR*veto.dR) {}
-                virtual bool veto(double eta, double phi, float value) const ;
-                virtual void centerOn(double eta, double phi) ;
+                bool veto(double eta, double phi, float value) const override ;
+                void centerOn(double eta, double phi) override ;
             private:
                 Direction vetoDir_; float dR2_; 
         };
@@ -19,8 +19,8 @@ namespace reco {
         class ThresholdVeto : public AbsVeto { 
             public:
                 ThresholdVeto(double threshold) : threshold_(threshold) {}
-                virtual bool veto(double eta, double phi, float value) const ;
-                virtual void centerOn(double eta, double phi) ;
+                bool veto(double eta, double phi, float value) const override ;
+                void centerOn(double eta, double phi) override ;
             private:
                 float threshold_;
         };
@@ -28,8 +28,8 @@ namespace reco {
         class ThresholdVetoFromTransverse : public AbsVeto {
             public:
                 ThresholdVetoFromTransverse(double threshold) : threshold_(threshold) {}
-                virtual bool veto(double eta, double phi, float value) const ;
-                virtual void centerOn(double eta, double phi) ;
+                bool veto(double eta, double phi, float value) const override ;
+                void centerOn(double eta, double phi) override ;
             private:
                 float threshold_;
         };
@@ -37,8 +37,8 @@ namespace reco {
         class AbsThresholdVeto : public AbsVeto { 
             public:
                 AbsThresholdVeto(double threshold) : threshold_(threshold) {}
-                virtual bool veto(double eta, double phi, float value) const ;
-                virtual void centerOn(double eta, double phi) ;
+                bool veto(double eta, double phi, float value) const override ;
+                void centerOn(double eta, double phi) override ;
             private:
                 float threshold_;
         };
@@ -46,8 +46,8 @@ namespace reco {
         class AbsThresholdVetoFromTransverse : public AbsVeto {
             public:
                 AbsThresholdVetoFromTransverse(double threshold) : threshold_(threshold) {}
-                virtual bool veto(double eta, double phi, float value) const ;
-                virtual void centerOn(double eta, double phi) ;
+                bool veto(double eta, double phi, float value) const override ;
+                void centerOn(double eta, double phi) override ;
             private:
                 float threshold_;
         };
@@ -55,8 +55,8 @@ namespace reco {
         class ConeThresholdVeto : public AbsVeto { 
             public:
                 ConeThresholdVeto(Direction dir, double dr, double threshold) : vetoDir_(dir), dR2_(dr*dr), threshold_(threshold) {}
-                virtual bool veto(double eta, double phi, float value) const ;
-                virtual void centerOn(double eta, double phi) ;
+                bool veto(double eta, double phi, float value) const override ;
+                void centerOn(double eta, double phi) override ;
             private:
                 Direction vetoDir_; float dR2_; float threshold_;
         };
@@ -65,8 +65,8 @@ namespace reco {
             public:
                 AngleConeVeto(const math::XYZVectorD& dir, double angle) ;
                 AngleConeVeto(Direction dir, double angle) ;
-                virtual bool veto(double eta, double phi, float value) const ;
-                virtual void centerOn(double eta, double phi) ;
+                bool veto(double eta, double phi, float value) const override ;
+                void centerOn(double eta, double phi) override ;
             private:
                 math::XYZVectorD vetoDir_; float cosTheta_; 
         };
@@ -75,8 +75,8 @@ namespace reco {
             public:
                 AngleCone(const math::XYZVectorD& dir, double angle) ;
                 AngleCone(Direction dir, double angle) ;
-                virtual bool veto(double eta, double phi, float value) const ;
-                virtual void centerOn(double eta, double phi) ;
+                bool veto(double eta, double phi, float value) const override ;
+                void centerOn(double eta, double phi) override ;
             private:
                 math::XYZVectorD coneDir_; float cosTheta_; 
         };
@@ -85,8 +85,8 @@ namespace reco {
             public:
                 RectangularEtaPhiVeto(const math::XYZVectorD& dir, double etaMin, double etaMax, double phiMin, double phiMax) ;
                 RectangularEtaPhiVeto(Direction dir, double etaMin, double etaMax, double phiMin, double phiMax) ;
-                virtual bool veto(double eta, double phi, float value) const ;
-                virtual void centerOn(double eta, double phi) ;
+                bool veto(double eta, double phi, float value) const override ;
+                void centerOn(double eta, double phi) override ;
             private:
                 Direction vetoDir_;
                 double etaMin_, etaMax_, phiMin_, phiMax_;

--- a/DataFormats/RecoCandidate/interface/RecoCaloTowerCandidate.h
+++ b/DataFormats/RecoCandidate/interface/RecoCaloTowerCandidate.h
@@ -23,17 +23,17 @@ namespace reco {
     RecoCaloTowerCandidate( Charge q , const PolarLorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ) ) :
       RecoCandidate( q, p4, vtx ) { }
     /// destructor
-    virtual ~RecoCaloTowerCandidate();
+    ~RecoCaloTowerCandidate() override;
     /// returns a clone of the candidate
-    virtual RecoCaloTowerCandidate * clone() const;
+    RecoCaloTowerCandidate * clone() const override;
     /// set CaloTower reference
     void setCaloTower( const CaloTowerRef & r ) { caloTower_ = r; }
     /// reference to a CaloTower
-    virtual CaloTowerRef caloTower() const;
+    CaloTowerRef caloTower() const override;
 
   private:
     /// check overlap with another candidate
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
     /// reference to a CaloTower
     CaloTowerRef caloTower_;
   };

--- a/DataFormats/RecoCandidate/interface/RecoCandidate.h
+++ b/DataFormats/RecoCandidate/interface/RecoCandidate.h
@@ -27,11 +27,11 @@ namespace reco {
 		   int pdgId = 0, int status = 0 ) : 
       LeafCandidate( q, p4, vtx, pdgId, status ) { }
     /// destructor
-    virtual ~RecoCandidate();
+    ~RecoCandidate() override;
     /// check overlap with another candidate
-    virtual bool overlap( const Candidate & ) const = 0;
+    bool overlap( const Candidate & ) const override = 0;
     /// returns a clone of the Candidate object                                           
-    virtual RecoCandidate * clone() const ;
+    RecoCandidate * clone() const override ;
 
     /// reference to a Track
     virtual reco::TrackRef track() const;
@@ -50,7 +50,7 @@ namespace reco {
     /// reference to a CaloTower
     virtual CaloTowerRef caloTower() const;
     /// best track pointer
-    virtual const Track * bestTrack() const;
+    const Track * bestTrack() const override;
     /// best track RefToBase
     virtual TrackBaseRef bestTrackRef() const;
     /// track type
@@ -58,9 +58,9 @@ namespace reco {
     ///track type
     virtual TrackType bestTrackType() const;
     /// uncertainty on dz 
-    virtual float dzError() const; 
+    float dzError() const override; 
     /// uncertainty on dxy
-    virtual float dxyError() const; 
+    float dxyError() const override; 
 
 
   protected:

--- a/DataFormats/RecoCandidate/interface/RecoChargedCandidate.h
+++ b/DataFormats/RecoCandidate/interface/RecoChargedCandidate.h
@@ -25,17 +25,17 @@ namespace reco {
 			  int pdgId = 0, int status = 0 ) :
       RecoCandidate( q, p4, vtx, pdgId, status ) { }
     /// destructor
-    virtual ~RecoChargedCandidate();
+    ~RecoChargedCandidate() override;
     /// returns a clone of the candidate
-    virtual RecoChargedCandidate * clone() const;
+    RecoChargedCandidate * clone() const override;
     /// set reference to track
     void setTrack( const reco::TrackRef & r ) { track_ = r; }
     /// reference to a track
-    virtual reco::TrackRef track() const;
+    reco::TrackRef track() const override;
 
   private:
     /// check overlap with another candidate
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
     /// reference to a track
     reco::TrackRef track_;
   };

--- a/DataFormats/RecoCandidate/interface/RecoChargedRefCandidate.h
+++ b/DataFormats/RecoCandidate/interface/RecoChargedRefCandidate.h
@@ -16,16 +16,16 @@ namespace reco {
     RecoChargedRefCandidate() {}
     RecoChargedRefCandidate(TrackRef ref, float m) : LeafRefCandidateT( ref, m) {}
     
-    ~RecoChargedRefCandidate() {}
+    ~RecoChargedRefCandidate() override {}
 
-    RecoChargedRefCandidate * clone() const { return new RecoChargedRefCandidate(*this);}
+    RecoChargedRefCandidate * clone() const override { return new RecoChargedRefCandidate(*this);}
 
     reco::TrackRef track() const {
       return getRef<reco::TrackRef>();
     }
     // return a pointer to the best track, if available.
     // otherwise, return a null pointer
-    virtual const reco::Track * bestTrack() const {
+    const reco::Track * bestTrack() const override {
       if ( track().isNonnull() && track().isAvailable() )
         return &(*track());
       else
@@ -33,9 +33,9 @@ namespace reco {
     }
 
     /// uncertainty on dz 
-    virtual float dzError() const { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dzError(); else return 0; }
+    float dzError() const override { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dzError(); else return 0; }
     /// uncertainty on dxy
-    virtual float dxyError() const { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dxyError(); else return 0; }
+    float dxyError() const override { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dxyError(); else return 0; }
  
   };
 }

--- a/DataFormats/RecoCandidate/interface/RecoEcalCandidate.h
+++ b/DataFormats/RecoCandidate/interface/RecoEcalCandidate.h
@@ -25,17 +25,17 @@ namespace reco {
 		       int pdgId = 0, int status = 0 ) :
       RecoCandidate( q, p4, vtx, pdgId, status ) { }
     /// destructor
-    virtual ~RecoEcalCandidate();
+    ~RecoEcalCandidate() override;
     /// returns a clone of the candidate
-    virtual RecoEcalCandidate * clone() const;
+    RecoEcalCandidate * clone() const override;
     /// set reference to superCluster
     void setSuperCluster( const reco::SuperClusterRef & r ) { superCluster_ = r; }
     /// reference to a superCluster
-    virtual reco::SuperClusterRef superCluster() const;
+    reco::SuperClusterRef superCluster() const override;
 
   private:
     /// check overlap with another candidate
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
     /// reference to a superCluster
     reco::SuperClusterRef superCluster_;
   };

--- a/DataFormats/RecoCandidate/interface/RecoStandAloneMuonCandidate.h
+++ b/DataFormats/RecoCandidate/interface/RecoStandAloneMuonCandidate.h
@@ -25,17 +25,17 @@ namespace reco {
 			  int pdgId = 0, int status = 0 ) :
       RecoCandidate( q, p4, vtx, pdgId, status ) { }
     /// destructor
-    virtual ~RecoStandAloneMuonCandidate();
+    ~RecoStandAloneMuonCandidate() override;
     /// returns a clone of the candidate
-    virtual RecoStandAloneMuonCandidate * clone() const;
+    RecoStandAloneMuonCandidate * clone() const override;
     /// set reference to track
     void setTrack( const reco::TrackRef & r ) { standAloneMuonTrack_ = r; }
     /// reference to a track
-    virtual reco::TrackRef standAloneMuon() const;
+    reco::TrackRef standAloneMuon() const override;
 
   private:
     /// check overlap with another candidate
-    virtual bool overlap( const Candidate & ) const;
+    bool overlap( const Candidate & ) const override;
     /// reference to a track
     reco::TrackRef standAloneMuonTrack_;
   };

--- a/DataFormats/RecoCandidate/src/CaloRecHitCandidate.cc
+++ b/DataFormats/RecoCandidate/src/CaloRecHitCandidate.cc
@@ -10,7 +10,7 @@ CaloRecHitCandidate * CaloRecHitCandidate::clone() const {
 
 bool CaloRecHitCandidate::overlap( const Candidate & c ) const {
   const CaloRecHitCandidate * o = dynamic_cast<const CaloRecHitCandidate *>( & c );
-  if ( o == 0 ) return false;
+  if ( o == nullptr ) return false;
   if ( caloRecHit().isNull() ) return false;
   if ( o->caloRecHit().isNull() ) return false;
   return ( caloRecHit() != o->caloRecHit() );

--- a/DataFormats/RecoCandidate/src/RecoCaloTowerCandidate.cc
+++ b/DataFormats/RecoCandidate/src/RecoCaloTowerCandidate.cc
@@ -14,7 +14,7 @@ CaloTowerRef RecoCaloTowerCandidate::caloTower() const {
 
 bool RecoCaloTowerCandidate::overlap( const Candidate & c ) const {
   const RecoCandidate * o = dynamic_cast<const RecoCandidate *>( & c );
-  return ( o != 0 &&  
+  return ( o != nullptr &&  
 	   checkOverlap( caloTower(), o->caloTower() ) 
 	   );
 }

--- a/DataFormats/RecoCandidate/src/RecoCandidate.cc
+++ b/DataFormats/RecoCandidate/src/RecoCandidate.cc
@@ -55,7 +55,7 @@ const Track * RecoCandidate::bestTrack() const {
   TrackRef staRef = standAloneMuon(); 
   if ( staRef.isNonnull() ) 
     return staRef.get(); 
-  return 0;
+  return nullptr;
 }
 
 TrackBaseRef RecoCandidate::bestTrackRef() const {

--- a/DataFormats/RecoCandidate/src/RecoChargedCandidate.cc
+++ b/DataFormats/RecoCandidate/src/RecoChargedCandidate.cc
@@ -14,7 +14,7 @@ TrackRef RecoChargedCandidate::track() const {
 
 bool RecoChargedCandidate::overlap( const Candidate & c ) const {
   const RecoCandidate * o = dynamic_cast<const RecoCandidate *>( & c );
-  return (o != 0 && 
+  return (o != nullptr && 
 	  (checkOverlap(track(), o->track()) || 
 	   checkOverlap(track(), o->standAloneMuon()) ||
 	   checkOverlap(track(), o->combinedMuon()))

--- a/DataFormats/RecoCandidate/src/RecoEcalCandidate.cc
+++ b/DataFormats/RecoCandidate/src/RecoEcalCandidate.cc
@@ -14,7 +14,7 @@ SuperClusterRef RecoEcalCandidate::superCluster() const {
 
 bool RecoEcalCandidate::overlap( const Candidate & c ) const {
   const RecoCandidate * o = dynamic_cast<const RecoCandidate *>( & c );
-  return ( o != 0 && 
+  return ( o != nullptr && 
 	   checkOverlap( superCluster(), o->superCluster() ) 
 	   );
 }

--- a/DataFormats/RecoCandidate/src/RecoStandAloneMuonCandidate.cc
+++ b/DataFormats/RecoCandidate/src/RecoStandAloneMuonCandidate.cc
@@ -14,7 +14,7 @@ TrackRef RecoStandAloneMuonCandidate::standAloneMuon() const {
 
 bool RecoStandAloneMuonCandidate::overlap( const Candidate & c ) const {
   const RecoCandidate * o = dynamic_cast<const RecoCandidate *>( & c );
-  return (o != 0 && 
+  return (o != nullptr && 
 	  (checkOverlap(standAloneMuon(), o->track()) || 
 	   checkOverlap(standAloneMuon(), o->standAloneMuon()) ||
 	   checkOverlap(standAloneMuon(), o->combinedMuon()))

--- a/DataFormats/Scalers/src/Level1TriggerScalers.cc
+++ b/DataFormats/Scalers/src/Level1TriggerScalers.cc
@@ -6,7 +6,7 @@
 #include "DataFormats/Scalers/interface/ScalersRaw.h"
 
 #include <iostream>
-#include <time.h>
+#include <ctime>
 #include <cstdio>
 
 Level1TriggerScalers::Level1TriggerScalers():

--- a/DataFormats/Scalers/src/LumiScalers.cc
+++ b/DataFormats/Scalers/src/LumiScalers.cc
@@ -60,7 +60,7 @@ LumiScalers::LumiScalers(const unsigned char * rawData)
   bunchNumber_  = ( raw->header >> 20 ) &      0xFFFULL;
   version_      = raw->version;
 
-  struct LumiScalersRaw_v1 const * lumi = NULL;
+  struct LumiScalersRaw_v1 const * lumi = nullptr;
 
   if ( version_ >= 1 )
   {

--- a/DataFormats/SiPixelDetId/interface/PixelBarrelName.h
+++ b/DataFormats/SiPixelDetId/interface/PixelBarrelName.h
@@ -33,12 +33,12 @@ public:
   /// ctor from name string
   PixelBarrelName(std::string name, bool phase=false);
 
-  virtual ~PixelBarrelName() { }
+  ~PixelBarrelName() override { }
 
   inline int convertLadderNumber(int oldLadder);
 
   /// from base class
-  virtual std::string name() const;
+  std::string name() const override;
 
   Shell shell() const { return thePart; }
 
@@ -58,14 +58,14 @@ public:
   bool isHalfModule() const;
   
   /// module Type
-  virtual PixelModuleName::ModuleType  moduleType() const;
+  PixelModuleName::ModuleType  moduleType() const override;
 
   /// return the DetId
   PXBDetId getDetId();
   DetId getDetId(const TrackerTopology* tt);
 
   /// check equality of modules from datamemebers
-  virtual bool operator== (const PixelModuleName &) const;
+  bool operator== (const PixelModuleName &) const override;
 
 private:
   Shell thePart;

--- a/DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h
+++ b/DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h
@@ -28,10 +28,10 @@ public:
   /// ctor from name string
   PixelBarrelNameUpgrade(std::string name);
 
-  virtual ~PixelBarrelNameUpgrade() { }
+  ~PixelBarrelNameUpgrade() override { }
 
   /// from base class
-  virtual std::string name() const;
+  std::string name() const override;
 
   Shell shell() const { return thePart; }
 
@@ -51,13 +51,13 @@ public:
   bool isHalfModule() const;
   
   /// module Type
-  virtual PixelModuleName::ModuleType  moduleType() const;
+  PixelModuleName::ModuleType  moduleType() const override;
 
   /// return the DetId
   PXBDetId getDetId();
 
   /// check equality of modules from datamemebers
-  virtual bool operator== (const PixelModuleName &) const;
+  bool operator== (const PixelModuleName &) const override;
 
 private:
   Shell thePart;

--- a/DataFormats/SiPixelDetId/interface/PixelEndcapName.h
+++ b/DataFormats/SiPixelDetId/interface/PixelEndcapName.h
@@ -33,10 +33,10 @@ public:
   /// ctor from name string
   PixelEndcapName(std::string name, bool phase=false);
 
-  virtual ~PixelEndcapName() { }
+  ~PixelEndcapName() override { }
 
   /// from base class
-  virtual std::string name() const;
+  std::string name() const override;
 
   HalfCylinder halfCylinder() const { return thePart; } 
 
@@ -56,14 +56,14 @@ public:
   int ringName() const { return thePlaquette; }
 
   /// module Type
-   virtual PixelModuleName::ModuleType  moduleType() const;
+   PixelModuleName::ModuleType  moduleType() const override;
 
   /// return DetId
   PXFDetId getDetId(); 
   DetId getDetId(const TrackerTopology* tt); 
 
   /// check equality of modules from datamemebers
-  virtual bool operator== (const PixelModuleName &) const;
+  bool operator== (const PixelModuleName &) const override;
 
 
 private:

--- a/DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h
+++ b/DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h
@@ -30,10 +30,10 @@ public:
   /// ctor from name string
   PixelEndcapNameUpgrade(std::string name);
 
-  virtual ~PixelEndcapNameUpgrade() { }
+  ~PixelEndcapNameUpgrade() override { }
 
   /// from base class
-  virtual std::string name() const;
+  std::string name() const override;
 
   HalfCylinder halfCylinder() const { return thePart; } 
 
@@ -50,13 +50,13 @@ public:
   int plaquetteName() const { return thePlaquette; }
 
   /// module Type
-   virtual PixelModuleName::ModuleType  moduleType() const;
+   PixelModuleName::ModuleType  moduleType() const override;
 
   /// return DetId
   PXFDetId getDetId(); 
 
   /// check equality of modules from datamemebers
-  virtual bool operator== (const PixelModuleName &) const;
+  bool operator== (const PixelModuleName &) const override;
 
 
 private:

--- a/DataFormats/SiPixelDetId/interface/PixelModuleName.h
+++ b/DataFormats/SiPixelDetId/interface/PixelModuleName.h
@@ -3,7 +3,7 @@
 
 #include <string>
 #include <iostream>
-#include <stdint.h>
+#include <cstdint>
 
 /** \class PixelModuleName
  * Base class to Pixel modules naming, provides a name as in PixelDatabase

--- a/DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h
+++ b/DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h
@@ -14,7 +14,7 @@
 #include "FWCore/Utilities/interface/typedefs.h"
 
 #include <string>
-#include <stdint.h>
+#include <cstdint>
 
 class SiPixelRawDataError {
   public:

--- a/DataFormats/SiStripCommon/interface/Constants.h
+++ b/DataFormats/SiStripCommon/interface/Constants.h
@@ -3,7 +3,7 @@
 #define DataFormats_SiStripCommon_Constants_H
 
 #include <string>
-#include <stdint.h>
+#include <cstdint>
 
 /** 
     @file Constants.h

--- a/DataFormats/SiStripCommon/interface/SiStripDetKey.h
+++ b/DataFormats/SiStripCommon/interface/SiStripDetKey.h
@@ -81,41 +81,41 @@ class SiStripDetKey : public SiStripKey {
   // ---------- Utility methods ---------- 
 
   /** Identifies key objects with identical member data. */
-  bool isEqual( const SiStripKey& ) const;
+  bool isEqual( const SiStripKey& ) const override;
   
   /** "Consistent" means identical and/or null (ie, "all") data. */
-  bool isConsistent( const SiStripKey& ) const;
+  bool isConsistent( const SiStripKey& ) const override;
   
   /** Identifies all member data as being "valid" or null ("all"). */
-  bool isValid() const;
+  bool isValid() const override;
   
   /** All member data to level of "Granularity" are valid. If
       sistrip::Granularity is "undefined", returns false. */
-  bool isValid( const sistrip::Granularity& ) const;
+  bool isValid( const sistrip::Granularity& ) const override;
   
   /** Identifies all member data as being invalid. */
-  bool isInvalid() const;
+  bool isInvalid() const override;
   
   /** All member data to level of "Granularity" are invalid. If
       sistrip::Granularity is "undefined", returns true.  */
-  bool isInvalid( const sistrip::Granularity& ) const;
+  bool isInvalid( const sistrip::Granularity& ) const override;
 
   // ---------- Print methods ----------
   
   /** Print member data of the key  */
-  virtual void print( std::stringstream& ss ) const;
+  void print( std::stringstream& ss ) const override;
   
   /** A terse summary of the key  */
-  virtual void terse( std::stringstream& ss ) const;
+  void terse( std::stringstream& ss ) const override;
   
  private: 
 
   // ---------- Private methods ----------
 
-  void initFromValue();
-  void initFromKey();
-  void initFromPath();
-  void initGranularity();
+  void initFromValue() override;
+  void initFromKey() override;
+  void initFromPath() override;
+  void initGranularity() override;
   
   // ---------- Private member data ----------
 

--- a/DataFormats/SiStripCommon/interface/SiStripFecKey.h
+++ b/DataFormats/SiStripCommon/interface/SiStripFecKey.h
@@ -120,41 +120,41 @@ class SiStripFecKey : public SiStripKey {
   // ---------- Utility methods ---------- 
   
   /** Identifies key objects with identical member data. */
-  bool isEqual( const SiStripKey& ) const;
+  bool isEqual( const SiStripKey& ) const override;
   
   /** "Consistent" means identical and/or null (ie, "all") data. */
-  bool isConsistent( const SiStripKey& ) const;
+  bool isConsistent( const SiStripKey& ) const override;
   
   /** Identifies all member data as being "valid" or "all" (null). */
-  bool isValid() const;
+  bool isValid() const override;
   
   /** All member data to level of "Granularity" are "valid". If
       sistrip::Granularity is "undefined", returns false. */
-  bool isValid( const sistrip::Granularity& ) const;
+  bool isValid( const sistrip::Granularity& ) const override;
   
   /** Identifies all member data as being "invalid". */
-  bool isInvalid() const;
+  bool isInvalid() const override;
 
   /** All member data to level of "Granularity" are invalid. If
       sistrip::Granularity is "undefined", returns true.  */
-  bool isInvalid( const sistrip::Granularity& ) const;
+  bool isInvalid( const sistrip::Granularity& ) const override;
 
   // ---------- Print methods ----------
 
   /** A terse summary of the key  */
-  virtual void print( std::stringstream& ss ) const;
+  void print( std::stringstream& ss ) const override;
 
   /** A terse summary of the key  */
-  virtual void terse( std::stringstream& ss ) const;
+  void terse( std::stringstream& ss ) const override;
   
  private:
   
   // ---------- Private methods ----------
   
-  void initFromValue();
-  void initFromKey();
-  void initFromPath();
-  void initGranularity();
+  void initFromValue() override;
+  void initFromKey() override;
+  void initFromPath() override;
+  void initGranularity() override;
   
   // ---------- Private member data ----------
 

--- a/DataFormats/SiStripCommon/interface/SiStripFedKey.h
+++ b/DataFormats/SiStripCommon/interface/SiStripFedKey.h
@@ -121,41 +121,41 @@ class SiStripFedKey : public SiStripKey {
   // ---------- Utility methods ---------- 
 
   /** Identifies key objects with identical member data. */
-  bool isEqual( const SiStripKey& ) const;
+  bool isEqual( const SiStripKey& ) const override;
   
   /** "Consistent" means identical and/or null (ie, "all") data. */
-  bool isConsistent( const SiStripKey& ) const;
+  bool isConsistent( const SiStripKey& ) const override;
 
   /** Identifies all member data as being "valid" or null ("all"). */
-  bool isValid() const;
+  bool isValid() const override;
   
   /** All member data to level of "Granularity" are valid. If
       sistrip::Granularity is "undefined", returns false. */
-  bool isValid( const sistrip::Granularity& ) const;
+  bool isValid( const sistrip::Granularity& ) const override;
   
   /** Identifies all member data as being invalid. */
-  bool isInvalid() const;
+  bool isInvalid() const override;
 
   /** All member data to level of "Granularity" are invalid. If
       sistrip::Granularity is "undefined", returns true.  */
-  bool isInvalid( const sistrip::Granularity& ) const;
+  bool isInvalid( const sistrip::Granularity& ) const override;
 
   // ---------- Print methods ----------
   
   /** Print member data of the key  */
-  virtual void print( std::stringstream& ss ) const;
+  void print( std::stringstream& ss ) const override;
   
   /** A terse summary of the key  */
-  virtual void terse( std::stringstream& ss ) const;
+  void terse( std::stringstream& ss ) const override;
   
  private:
   
   // ---------- Private methods ----------
 
-  void initFromValue();
-  void initFromKey();
-  void initFromPath();
-  void initGranularity();
+  void initFromValue() override;
+  void initFromKey() override;
+  void initFromPath() override;
+  void initGranularity() override;
   
   // ---------- Private member data ----------
 

--- a/DataFormats/SiStripCommon/interface/SiStripNullKey.h
+++ b/DataFormats/SiStripCommon/interface/SiStripNullKey.h
@@ -29,41 +29,41 @@ class SiStripNullKey : public SiStripKey {
   // ---------- Utility methods ---------- 
 
   /** Identifies key objects with identical member data. */
-  bool isEqual( const SiStripKey& ) const;
+  bool isEqual( const SiStripKey& ) const override;
   
   /** "Consistent" means identical and/or null (ie, "all") data. */
-  bool isConsistent( const SiStripKey& ) const;
+  bool isConsistent( const SiStripKey& ) const override;
 
   /** Identifies all member data as being "valid" or null ("all"). */
-  bool isValid() const;
+  bool isValid() const override;
   
   /** All member data to level of "Granularity" are valid. If
       sistrip::Granularity is "undefined", returns false. */
-  bool isValid( const sistrip::Granularity& ) const;
+  bool isValid( const sistrip::Granularity& ) const override;
   
   /** Identifies all member data as being invalid. */
-  bool isInvalid() const;
+  bool isInvalid() const override;
 
   /** All member data to level of "Granularity" are invalid. If
       sistrip::Granularity is "undefined", returns true.  */
-  bool isInvalid( const sistrip::Granularity& ) const;
+  bool isInvalid( const sistrip::Granularity& ) const override;
 
   // ---------- Print methods ----------
   
   /** Print member data of the key  */
-  virtual void print( std::stringstream& ss ) const;
+  void print( std::stringstream& ss ) const override;
   
   /** A terse summary of the key  */
-  virtual void terse( std::stringstream& ss ) const {;}
+  void terse( std::stringstream& ss ) const override {;}
   
  private: 
 
   // ---------- Private methods ----------
 
-  void initFromValue();
-  void initFromKey();
-  void initFromPath();
-  void initGranularity();
+  void initFromValue() override;
+  void initFromKey() override;
+  void initFromPath() override;
+  void initGranularity() override;
   
 };
 

--- a/DataFormats/SiStripDetId/interface/SiStripSubStructure.h
+++ b/DataFormats/SiStripDetId/interface/SiStripSubStructure.h
@@ -19,7 +19,7 @@
 //
 
 #include <vector>
-#include <stdint.h>
+#include <cstdint>
 
 class SiStripSubStructure
 {
@@ -59,9 +59,9 @@ class SiStripSubStructure
                            uint32_t ster          = 0) const;            // ster = 1(sterero), else(nonstereo), 0(ALL)
 
    private:
-      SiStripSubStructure(const SiStripSubStructure&); // stop default
+      SiStripSubStructure(const SiStripSubStructure&) = delete; // stop default
 
-      const SiStripSubStructure& operator=(const SiStripSubStructure&); // stop default
+      const SiStripSubStructure& operator=(const SiStripSubStructure&) = delete; // stop default
 
       // ---------- member data --------------------------------
 

--- a/DataFormats/TauReco/interface/BaseTau.h
+++ b/DataFormats/TauReco/interface/BaseTau.h
@@ -20,8 +20,8 @@ namespace reco {
   public:
     BaseTau();
     BaseTau(Charge q,const LorentzVector &,const Point & = Point(0,0,0));
-    virtual ~BaseTau(){}
-    BaseTau* clone()const;
+    ~BaseTau() override{}
+    BaseTau* clone()const override;
 
     // rec. jet Lorentz-vector combining (Tracks and neutral ECAL Island BasicClusters) or (charged hadr. PFCandidates and gamma PFCandidates)
     math::XYZTLorentzVector alternatLorentzVect()const;
@@ -40,7 +40,7 @@ namespace reco {
     void setisolationTracks(const TrackRefVector&);  
   private:
     // check overlap with another candidate
-    virtual bool overlap(const Candidate&)const;
+    bool overlap(const Candidate&)const override;
     math::XYZTLorentzVector alternatLorentzVect_;
     reco::TrackRef leadTrack_;
     reco::TrackRefVector signalTracks_, isolationTracks_;

--- a/DataFormats/TauReco/interface/CaloTau.h
+++ b/DataFormats/TauReco/interface/CaloTau.h
@@ -20,8 +20,8 @@ namespace reco {
   public:
     CaloTau();
     CaloTau(Charge q, const LorentzVector &, const Point & = Point( 0, 0, 0 ) );
-    virtual ~CaloTau(){}
-    CaloTau* clone()const;
+    ~CaloTau() override{}
+    CaloTau* clone()const override;
     
     const CaloTauTagInfoRef& caloTauTagInfoRef()const;
     void setcaloTauTagInfoRef(const CaloTauTagInfoRef);
@@ -61,7 +61,7 @@ namespace reco {
     void setmaximumHCALhitEt(const float&);    
   private:
     // check overlap with another candidate
-    virtual bool overlap(const Candidate&d)const;
+    bool overlap(const Candidate&d)const override;
     CaloTauTagInfoRef CaloTauTagInfoRef_;  
     float leadTracksignedSipt_;
     float leadTrackHCAL3x3hitsEtSum_;

--- a/DataFormats/TauReco/interface/CaloTauTagInfo.h
+++ b/DataFormats/TauReco/interface/CaloTauTagInfo.h
@@ -20,7 +20,7 @@ namespace reco{
   class CaloTauTagInfo : public BaseTauTagInfo {
   public:
     CaloTauTagInfo(){}
-    virtual ~CaloTauTagInfo(){};
+    ~CaloTauTagInfo() override{};
     virtual CaloTauTagInfo* clone()const;
     
     //the reference to the CaloJet

--- a/DataFormats/TauReco/interface/PFRecoTauChargedHadron.h
+++ b/DataFormats/TauReco/interface/PFRecoTauChargedHadron.h
@@ -44,7 +44,7 @@ class PFRecoTauChargedHadron : public CompositePtrCandidate
 			 PFRecoTauChargedHadronAlgorithm algo = kUndefined);
 
   /// destructor
-  ~PFRecoTauChargedHadron();
+  ~PFRecoTauChargedHadron() override;
 
   /// reference to "charged" PFCandidate (either charged PFCandidate or PFNeutralHadron)
   const PFCandidatePtr& getChargedPFCandidate() const;

--- a/DataFormats/TauReco/interface/PFTau.h
+++ b/DataFormats/TauReco/interface/PFTau.h
@@ -55,8 +55,8 @@ class PFTau : public BaseTau {
 
     PFTau();
     PFTau(Charge q,const LorentzVector &,const Point & = Point( 0, 0, 0 ) );
-    virtual ~PFTau() {};
-    PFTau* clone() const;
+    ~PFTau() override {};
+    PFTau* clone() const override;
 
     const PFJetRef& jetRef() const;
     void setjetRef(const PFJetRef&);
@@ -193,11 +193,11 @@ class PFTau : public BaseTau {
     /// ( the candidates used to construct this Candidate)
     /// in the case of taus, there is only one source candidate,
     /// which is the corresponding PFJet
-    size_type numberOfSourceCandidatePtrs() const {return 1;}
+    size_type numberOfSourceCandidatePtrs() const override {return 1;}
 
     /// return a RefToBase to the source Candidates
     /// ( the candidates used to construct this Candidate)
-    CandidatePtr sourceCandidatePtr( size_type i ) const;
+    CandidatePtr sourceCandidatePtr( size_type i ) const override;
 
     /// prints information on this PFTau
     void dump(std::ostream& out = std::cout) const;
@@ -213,7 +213,7 @@ class PFTau : public BaseTau {
     std::vector<PFRecoTauChargedHadron>& isolationTauChargedHadronCandidatesRestricted();
 
     // check overlap with another candidate
-    virtual bool overlap(const Candidate&) const;
+    bool overlap(const Candidate&) const override;
 
     bool muonDecision_;
     bool electronPreIDDecision_;

--- a/DataFormats/TauReco/interface/PFTauDecayMode.h
+++ b/DataFormats/TauReco/interface/PFTauDecayMode.h
@@ -62,8 +62,8 @@ namespace reco {
                      const CompositeCandidate&                       piZeroes,
                      const CompositeCandidate&                       filteredObjects);
 
-      virtual ~PFTauDecayMode(){}
-      PFTauDecayMode* clone() const;
+      ~PFTauDecayMode() override{}
+      PFTauDecayMode* clone() const override;
 
       /// return reference to associated PFTau object
       const PFTauRef& pfTauRef() const          { return pfTauRef_;  }

--- a/DataFormats/TauReco/interface/PFTauTagInfo.h
+++ b/DataFormats/TauReco/interface/PFTauTagInfo.h
@@ -20,7 +20,7 @@ namespace reco{
   class PFTauTagInfo : public BaseTauTagInfo {
   public:
     PFTauTagInfo(){}
-    virtual ~PFTauTagInfo(){};
+    ~PFTauTagInfo() override{};
     virtual PFTauTagInfo* clone()const;
     
     //get the PFCandidates which compose the PF jet and were filtered by RecoTauTag/TauTagTools/ TauTagTools::filteredPFChargedHadrCands(.,...), filteredPFNeutrHadrCands(.), filteredPFGammaCands(.) functions through RecoTauTag/RecoTauTag/ PFRecoTauTagInfoProducer EDProducer

--- a/DataFormats/TauReco/interface/RecoTauPiZero.h
+++ b/DataFormats/TauReco/interface/RecoTauPiZero.h
@@ -57,7 +57,7 @@ class RecoTauPiZero : public CompositePtrCandidate {
     }
 
     /// destructor
-    ~RecoTauPiZero(){};
+    ~RecoTauPiZero() override{};
 
     /// Number of PFGamma constituents
     size_t numberOfGammas() const;

--- a/DataFormats/TauReco/src/BaseTau.cc
+++ b/DataFormats/TauReco/src/BaseTau.cc
@@ -32,5 +32,5 @@ void BaseTau::setisolationTracks(const TrackRefVector& myTracks)  { isolationTra
 
 bool BaseTau::overlap(const Candidate& theCand)const{
   const RecoCandidate* theRecoCand=dynamic_cast<const RecoCandidate *>(&theCand);
-  return (theRecoCand!=0 && (checkOverlap(track(),theRecoCand->track())));
+  return (theRecoCand!=nullptr && (checkOverlap(track(),theRecoCand->track())));
 }

--- a/DataFormats/TauReco/src/CaloTau.cc
+++ b/DataFormats/TauReco/src/CaloTau.cc
@@ -59,5 +59,5 @@ void CaloTau::setmaximumHCALhitEt(const float& x){maximumHCALhitEt_=x;}
 
 bool CaloTau::overlap(const reco::Candidate& theCand)const{
   const reco::RecoCandidate* theRecoCand=dynamic_cast<const RecoCandidate *>(&theCand);
-  return (theRecoCand!=0 && (checkOverlap(track(),theRecoCand->track())));
+  return (theRecoCand!=nullptr && (checkOverlap(track(),theRecoCand->track())));
 }

--- a/DataFormats/TauReco/src/PFRecoTauChargedHadron.cc
+++ b/DataFormats/TauReco/src/PFRecoTauChargedHadron.cc
@@ -104,7 +104,7 @@ void PFRecoTauChargedHadron::print(std::ostream& stream) const
     stream << "N/A" << std::endl;
   }
   stream << "neutral PFCandidates:";
-  if ( neutralPFCandidates_.size() >= 1 ) {
+  if ( !neutralPFCandidates_.empty() ) {
     stream << std::endl;
     int idx = 0;
     for ( std::vector<PFCandidatePtr>::const_iterator neutralPFCandidate = neutralPFCandidates_.begin();

--- a/DataFormats/TauReco/src/PFTau.cc
+++ b/DataFormats/TauReco/src/PFTau.cc
@@ -164,7 +164,7 @@ void PFTau::setisolationPiZeroCandidates(std::vector<RecoTauPiZero> cands) {
 
 // Tau Charged Hadron information
 PFRecoTauChargedHadronRef PFTau::leadTauChargedHadronCandidate() const {
-  if ( signalTauChargedHadronCandidatesRefs_.size() > 0 ) {
+  if ( !signalTauChargedHadronCandidatesRefs_.empty() ) {
     return signalTauChargedHadronCandidatesRefs_[0];
   } else {
     return PFRecoTauChargedHadronRef();
@@ -270,7 +270,7 @@ CandidatePtr PFTau::sourceCandidatePtr( size_type i ) const {
 
 bool PFTau::overlap(const Candidate& theCand) const {
     const RecoCandidate* theRecoCand = dynamic_cast<const RecoCandidate *>(&theCand);
-    return (theRecoCand!=0 && (checkOverlap(track(), theRecoCand->track())));
+    return (theRecoCand!=nullptr && (checkOverlap(track(), theRecoCand->track())));
 }
 
 void PFTau::dump(std::ostream& out) const {

--- a/DataFormats/TestObjects/interface/ToyProducts.h
+++ b/DataFormats/TestObjects/interface/ToyProducts.h
@@ -111,9 +111,9 @@ namespace edmtest {
 
   struct SimpleDerived : public Simple {
     SimpleDerived() : Simple(), dummy(0.0) {}
-    virtual ~SimpleDerived();
+    ~SimpleDerived() override;
     double dummy;
-    virtual SimpleDerived* clone() const;
+    SimpleDerived* clone() const override;
   };
 
   struct Sortable {

--- a/DataFormats/TrackReco/interface/Track.h
+++ b/DataFormats/TrackReco/interface/Track.h
@@ -34,7 +34,7 @@ public:
     Track() { }
 
     /// virtual destructor
-    virtual ~Track();
+    ~Track() override;
 
     /// constructor from fit parameters and error matrix
     Track(double chi2, double ndof, const Point & referencePoint,

--- a/DataFormats/TrackerCommon/interface/ClusterSummary.h
+++ b/DataFormats/TrackerCommon/interface/ClusterSummary.h
@@ -28,7 +28,7 @@
 #include <map>
 #include <vector>
 #include<iostream>
-#include <string.h>
+#include <cstring>
 #include <sstream>
 #include "FWCore/Utilities/interface/Exception.h"
 

--- a/DataFormats/TrackerCommon/src/TrackerTopology.cc
+++ b/DataFormats/TrackerCommon/src/TrackerTopology.cc
@@ -180,7 +180,7 @@ bool TrackerTopology::isStereo(const DetId &id) const {
       return tecStereo(id)!=0;
 
     throw cms::Exception("Invalid DetId") << "Unsupported DetId in TrackerTopology::isStereo";
-    return 0;
+    return false;
 }
 
 bool TrackerTopology::isRPhi(const DetId &id) const {
@@ -200,7 +200,7 @@ bool TrackerTopology::isRPhi(const DetId &id) const {
       return tecRPhi(id)!=0;
 
     throw cms::Exception("Invalid DetId") << "Unsupported DetId in TrackerTopology::isRPhi";
-    return 0;
+    return false;
 }
 bool TrackerTopology::isLower(const DetId &id) const {
 
@@ -219,7 +219,7 @@ bool TrackerTopology::isLower(const DetId &id) const {
       return tecLower(id)!=0;
 
     throw cms::Exception("Invalid DetId") << "Unsupported DetId in TrackerTopology::isLower";
-    return 0;
+    return false;
 
 }
 
@@ -240,7 +240,7 @@ bool TrackerTopology::isUpper(const DetId &id) const {
       return tecUpper(id)!=0;
 
     throw cms::Exception("Invalid DetId") << "Unsupported DetId in TrackerTopology::isUpper";
-    return 0;
+    return false;
 }
 
 DetId TrackerTopology::partnerDetId(const DetId &id) const {

--- a/DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h
@@ -37,7 +37,7 @@ public:
   // fake TTRH interface
   BaseTrackerRecHit const * hit() const final { return this;}  
 
-  virtual ~BaseTrackerRecHit() {}
+  ~BaseTrackerRecHit() override {}
 
   // no position (as in persistent)
  BaseTrackerRecHit(DetId id, trackerHitRTTI::RTTI rt) :  TrackingRecHit(id,(unsigned int)(rt)),qualWord_(0) {}
@@ -73,9 +73,9 @@ public:
 
   bool hasPositionAndError() const  final; 
 
-  virtual LocalPoint localPosition() const  final { check(); return pos_;}
+  LocalPoint localPosition() const  final { check(); return pos_;}
 
-  virtual LocalError localPositionError() const  final { check(); return err_;}
+  LocalError localPositionError() const  final { check(); return err_;}
 
  
   const LocalPoint & localPositionFast()      const { check(); return pos_; }
@@ -84,8 +84,8 @@ public:
 
 
   // to be specialized for 1D and 2D
-  virtual void getKfComponents( KfComponentsHolder & holder ) const=0;
-  virtual int dimension() const=0; 
+  void getKfComponents( KfComponentsHolder & holder ) const override =0;
+  int dimension() const override =0; 
 
   void getKfComponents1D( KfComponentsHolder & holder ) const;
   void getKfComponents2D( KfComponentsHolder & holder ) const;
@@ -93,10 +93,10 @@ public:
 
   // global coordinates
   // Extension of the TrackingRecHit interface
-  virtual const Surface * surface() const final {return &(det()->surface());}
+  const Surface * surface() const final {return &(det()->surface());}
 
 
-  virtual GlobalPoint globalPosition() const final {
+  GlobalPoint globalPosition() const final {
       return surface()->toGlobal(localPosition());
   }
   
@@ -126,9 +126,9 @@ public:
 public:
 
   // obsolete (for what tracker is concerned...) interface
-  virtual AlgebraicVector parameters() const;
-  virtual AlgebraicSymMatrix parametersError() const;
-  virtual AlgebraicMatrix projectionMatrix() const;
+  AlgebraicVector parameters() const override;
+  AlgebraicSymMatrix parametersError() const override;
+  AlgebraicMatrix projectionMatrix() const override;
 
 private:
 

--- a/DataFormats/TrackerRecHit2D/interface/FastMatchedTrackerRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/FastMatchedTrackerRecHit.h
@@ -12,7 +12,7 @@ class FastMatchedTrackerRecHit : public FastTrackerRecHit{
 	: stereoHitFirst_(false)
 	{}
     
-    ~FastMatchedTrackerRecHit() {}
+    ~FastMatchedTrackerRecHit() override {}
     
     FastMatchedTrackerRecHit( const LocalPoint & pos, 
 			      const LocalError & err,
@@ -26,15 +26,15 @@ class FastMatchedTrackerRecHit : public FastTrackerRecHit{
 	, componentStereo_(rStereo)
     {};
     
-    virtual FastMatchedTrackerRecHit * clone() const {FastMatchedTrackerRecHit * p =  new FastMatchedTrackerRecHit( * this); p->load(); return p;}
+    FastMatchedTrackerRecHit * clone() const override {FastMatchedTrackerRecHit * p =  new FastMatchedTrackerRecHit( * this); p->load(); return p;}
 
-    size_t    nIds()                    const { return 2;}
-    int32_t   id(size_t i = 0)          const { return i==0 ? monoHit().id() : stereoHit().id(); }
-    int32_t   eventId(size_t i = 0)     const { return i==0 ? monoHit().eventId() : stereoHit().eventId(); }
+    size_t    nIds()                    const override { return 2;}
+    int32_t   id(size_t i = 0)          const override { return i==0 ? monoHit().id() : stereoHit().id(); }
+    int32_t   eventId(size_t i = 0)     const override { return i==0 ? monoHit().eventId() : stereoHit().eventId(); }
     
-    size_t    nSimTrackIds()            const { return componentMono_.nSimTrackIds() + componentStereo_.nSimTrackIds();}                             ///< see addSimTrackId(int32_t simTrackId)
-    int32_t   simTrackId(size_t i)      const { return i < componentMono_.nSimTrackIds() ? componentMono_.simTrackId(i) : componentStereo_.simTrackId(i-componentMono_.nSimTrackIds()); }
-    int32_t   simTrackEventId(size_t i) const { return i < componentMono_.nSimTrackIds() ? componentMono_.simTrackEventId(i) : componentStereo_.simTrackEventId(i-componentMono_.nSimTrackIds()); }
+    size_t    nSimTrackIds()            const override { return componentMono_.nSimTrackIds() + componentStereo_.nSimTrackIds();}                             ///< see addSimTrackId(int32_t simTrackId)
+    int32_t   simTrackId(size_t i)      const override { return i < componentMono_.nSimTrackIds() ? componentMono_.simTrackId(i) : componentStereo_.simTrackId(i-componentMono_.nSimTrackIds()); }
+    int32_t   simTrackEventId(size_t i) const override { return i < componentMono_.nSimTrackIds() ? componentMono_.simTrackEventId(i) : componentStereo_.simTrackEventId(i-componentMono_.nSimTrackIds()); }
     
     const FastSingleTrackerRecHit &   monoHit()                const { return componentMono_;}
     const FastSingleTrackerRecHit &   stereoHit()              const { return componentStereo_;}
@@ -43,9 +43,9 @@ class FastMatchedTrackerRecHit : public FastTrackerRecHit{
     
 
     void setStereoLayerFirst(bool stereoHitFirst = true){stereoHitFirst_ = stereoHitFirst;}
-    void setEventId(int32_t eventId){componentMono_.setEventId(eventId);componentStereo_.setEventId(eventId);}
+    void setEventId(int32_t eventId) override{componentMono_.setEventId(eventId);componentStereo_.setEventId(eventId);}
 
-    void setRecHitCombinationIndex(int32_t recHitCombinationIndex) {
+    void setRecHitCombinationIndex(int32_t recHitCombinationIndex) override {
 	FastTrackerRecHit::setRecHitCombinationIndex(recHitCombinationIndex);
 	componentMono_.setRecHitCombinationIndex(recHitCombinationIndex);
 	componentStereo_.setRecHitCombinationIndex(recHitCombinationIndex);

--- a/DataFormats/TrackerRecHit2D/interface/FastProjectedTrackerRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/FastProjectedTrackerRecHit.h
@@ -11,7 +11,7 @@ class FastProjectedTrackerRecHit : public FastTrackerRecHit {
           
     FastProjectedTrackerRecHit() {};
     
-    ~FastProjectedTrackerRecHit() {};
+    ~FastProjectedTrackerRecHit() override {};
     
     FastProjectedTrackerRecHit( const LocalPoint& pos, 
 				const LocalError& err, 
@@ -25,17 +25,17 @@ class FastProjectedTrackerRecHit : public FastTrackerRecHit {
     {}
     
     const FastSingleTrackerRecHit & originalHit() const {return originalHit_;}
-    virtual FastProjectedTrackerRecHit * clone() const {FastProjectedTrackerRecHit * p =  new FastProjectedTrackerRecHit( * this); p->load(); return p;}
-    size_t                       nIds()                    const { return 1;}
-    int32_t                      id(size_t i = 0)          const { return originalHit().id(i);}
-    int32_t                      eventId(size_t i = 0)     const { return originalHit().eventId(i);}
-    size_t                       nSimTrackIds()            const { return originalHit_.nSimTrackIds();}                             ///< see addSimTrackId(int32_t simTrackId)
-    int32_t                      simTrackId(size_t i)      const { return originalHit_.simTrackId(i);}                              ///< see addSimTrackId(int32_t simTrackId)
-    int32_t                      simTrackEventId(size_t i) const { return originalHit_.simTrackEventId(i);;}                        ///< see addSimTrackId(int32_t simTrackId)
+    FastProjectedTrackerRecHit * clone() const override {FastProjectedTrackerRecHit * p =  new FastProjectedTrackerRecHit( * this); p->load(); return p;}
+    size_t                       nIds()                    const override { return 1;}
+    int32_t                      id(size_t i = 0)          const override { return originalHit().id(i);}
+    int32_t                      eventId(size_t i = 0)     const override { return originalHit().eventId(i);}
+    size_t                       nSimTrackIds()            const override { return originalHit_.nSimTrackIds();}                             ///< see addSimTrackId(int32_t simTrackId)
+    int32_t                      simTrackId(size_t i)      const override { return originalHit_.simTrackId(i);}                              ///< see addSimTrackId(int32_t simTrackId)
+    int32_t                      simTrackEventId(size_t i) const override { return originalHit_.simTrackEventId(i);;}                        ///< see addSimTrackId(int32_t simTrackId)
 
-    void setEventId(int32_t eventId){originalHit_.setEventId(eventId);}
+    void setEventId(int32_t eventId) override{originalHit_.setEventId(eventId);}
 
-    void setRecHitCombinationIndex(int32_t recHitCombinationIndex) {
+    void setRecHitCombinationIndex(int32_t recHitCombinationIndex) override {
 	FastTrackerRecHit::setRecHitCombinationIndex(recHitCombinationIndex);
 	originalHit_.setRecHitCombinationIndex(recHitCombinationIndex);
     }

--- a/DataFormats/TrackerRecHit2D/interface/FastSingleTrackerRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/FastSingleTrackerRecHit.h
@@ -2,7 +2,7 @@
 #define FastSingleTrackerRecHit_H
 
 #include "DataFormats/TrackerRecHit2D/interface/FastTrackerRecHit.h"
-#include "stdint.h"
+#include <cstdint>
 
 class FastSingleTrackerRecHit : public FastTrackerRecHit {
 
@@ -21,7 +21,7 @@ class FastSingleTrackerRecHit : public FastTrackerRecHit {
     
     public:
 
-    virtual FastSingleTrackerRecHit * clone() const override  {FastSingleTrackerRecHit * p =  new FastSingleTrackerRecHit( * this); p->load(); return p;}
+    FastSingleTrackerRecHit * clone() const override  {FastSingleTrackerRecHit * p =  new FastSingleTrackerRecHit( * this); p->load(); return p;}
 
     size_t                       nIds()                    const override { return 1;}
     int32_t                      id(size_t i =0)           const override { return i == 0 ? id_ : -1;}

--- a/DataFormats/TrackerRecHit2D/interface/FastTrackerRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/FastTrackerRecHit.h
@@ -48,7 +48,7 @@ class FastTrackerRecHit : public BaseTrackerRecHit
     
     /// destructor
     ///
-    ~FastTrackerRecHit() {}
+    ~FastTrackerRecHit() override {}
     
     /// constructor
     /// requires a position with error in local detector coordinates,
@@ -60,7 +60,7 @@ class FastTrackerRecHit : public BaseTrackerRecHit
 	, recHitCombinationIndex_(-1)
 	{store();}
 
-    virtual FastTrackerRecHit * clone() const override {FastTrackerRecHit * p =  new FastTrackerRecHit( * this); p->load(); return p;}
+    FastTrackerRecHit * clone() const override {FastTrackerRecHit * p =  new FastTrackerRecHit( * this); p->load(); return p;}
 
     /// Steers behaviour of hit in track fit.
     /// Hit is interpreted as 1D or 2D depending on value of is2D_
@@ -72,7 +72,7 @@ class FastTrackerRecHit : public BaseTrackerRecHit
 
     /// Steers behaviour of hit in track fit.
     /// FastSim hit smearing assumes
-    virtual bool canImproveWithTrack() const override {return false;}
+    bool canImproveWithTrack() const override {return false;}
 
     /* getters */
 
@@ -98,11 +98,11 @@ class FastTrackerRecHit : public BaseTrackerRecHit
 
     /// bogus function : 
     /// implement purely virtual function of TrackingRecHit
-    virtual std::vector<const TrackingRecHit*> recHits() const override { return std::vector<TrackingRecHit const*>();}
+    std::vector<const TrackingRecHit*> recHits() const override { return std::vector<TrackingRecHit const*>();}
 
     /// bogus function : 
     /// implement purely virtual function of TrackingRecHit
-    virtual std::vector<TrackingRecHit*> recHits() override { return std::vector<TrackingRecHit*>();}
+    std::vector<TrackingRecHit*> recHits() override { return std::vector<TrackingRecHit*>();}
  
     /// bogus function : 
     /// implement purely virutal function of BaseTrackerRecHit
@@ -173,7 +173,7 @@ class FastTrackerRecHit : public BaseTrackerRecHit
 
     protected:
 
-    virtual FastTrackerRecHit * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+    FastTrackerRecHit * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
 	return this->clone();
     }
   

--- a/DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h
+++ b/DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h
@@ -16,31 +16,31 @@ public:
 
   Phase2TrackerRecHit1D() {}
 
-  ~Phase2TrackerRecHit1D() {}
+  ~Phase2TrackerRecHit1D() override {}
 
   Phase2TrackerRecHit1D( const LocalPoint& pos, const LocalError& err, 
                          GeomDet const & idet,
 		         CluRef const&  clus) : TrackerSingleRecHit(pos,err,idet,clus){}
 
-  virtual Phase2TrackerRecHit1D * clone() const override { return new Phase2TrackerRecHit1D( * this); }
-  virtual RecHitPointer cloneSH() const override { return std::make_shared<Phase2TrackerRecHit1D>(*this);}
+  Phase2TrackerRecHit1D * clone() const override { return new Phase2TrackerRecHit1D( * this); }
+  RecHitPointer cloneSH() const override { return std::make_shared<Phase2TrackerRecHit1D>(*this);}
 
   CluRef cluster()  const { return cluster_phase2OT(); }
   void setClusterRef(CluRef const & ref)  {setClusterPhase2Ref(ref);}
 
-  virtual bool isPhase2() const override { return true; }
+  bool isPhase2() const override { return true; }
   //FIXME::check dimension of this!!
-  virtual int dimension() const override {return 2;}
-  virtual void getKfComponents( KfComponentsHolder & holder ) const override { getKfComponents2D(holder); }
+  int dimension() const override {return 2;}
+  void getKfComponents( KfComponentsHolder & holder ) const override { getKfComponents2D(holder); }
 
-  virtual bool canImproveWithTrack() const override {return true;}
+  bool canImproveWithTrack() const override {return true;}
 
 private:
   // double dispatch
-  virtual Phase2TrackerRecHit1D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+  Phase2TrackerRecHit1D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner(*this,tsos).release();
   }
-  virtual  RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+   RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner.makeShared(*this,tsos);
   }
 };

--- a/DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h
@@ -40,15 +40,15 @@ public:
     }
 
 
-  virtual void setDet(const GeomDet & idet);
+  void setDet(const GeomDet & idet) override;
 
-  virtual bool canImproveWithTrack() const {return true;}
+  bool canImproveWithTrack() const override {return true;}
 
-  virtual ProjectedSiStripRecHit2D* clone() const {return new ProjectedSiStripRecHit2D( *this); }
+  ProjectedSiStripRecHit2D* clone() const override {return new ProjectedSiStripRecHit2D( *this); }
 
   
-  virtual int dimension() const {return 2;}
-  virtual void getKfComponents( KfComponentsHolder & holder ) const { getKfComponents2D(holder); }
+  int dimension() const override {return 2;}
+  void getKfComponents( KfComponentsHolder & holder ) const override { getKfComponents2D(holder); }
   
   typedef OmniClusterRef::ClusterStripRef         ClusterRef;
   ClusterRef cluster()  const { return cluster_strip() ; }
@@ -61,11 +61,11 @@ public:
   SiStripRecHit2D originalHit() const { return SiStripRecHit2D(originalId(), omniClusterRef());}
   
   
-  virtual std::vector<const TrackingRecHit*> recHits() const{
+  std::vector<const TrackingRecHit*> recHits() const override{
     std::vector<const TrackingRecHit*> rechits;
     return rechits;
   }
-  virtual std::vector<TrackingRecHit*> recHits() {
+  std::vector<TrackingRecHit*> recHits() override {
     std::vector<TrackingRecHit*> rechits;
     return rechits;
   }
@@ -73,11 +73,11 @@ public:
 
 private:
   // double dispatch
-  virtual ProjectedSiStripRecHit2D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
+  ProjectedSiStripRecHit2D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner(*this,tsos).release();
   }
 #ifndef __GCCXML__
-  virtual  ConstRecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
+   ConstRecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner.makeShared(*this,tsos);
   }
 #endif

--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
@@ -28,7 +28,7 @@ public:
   
   SiPixelRecHit(){}
   
-  ~SiPixelRecHit(){}
+  ~SiPixelRecHit() override{}
 
   SiPixelRecHit( const LocalPoint& pos , const LocalError& err, 
 		 SiPixelRecHitQuality::QualWordType qual,
@@ -37,12 +37,12 @@ public:
     TrackerSingleRecHit(pos,err,idet, clus){
     qualWord_=qual; }
 
-  virtual bool isPixel() const override { return true;}
+  bool isPixel() const override { return true;}
 
   
-  virtual SiPixelRecHit * clone() const override {return new SiPixelRecHit( * this); }
+  SiPixelRecHit * clone() const override {return new SiPixelRecHit( * this); }
 #ifndef __GCCXML__
-  virtual RecHitPointer cloneSH() const override { return std::make_shared<SiPixelRecHit>(*this);}
+  RecHitPointer cloneSH() const override { return std::make_shared<SiPixelRecHit>(*this);}
 #endif
 
   
@@ -50,18 +50,18 @@ public:
 
   void setClusterRef(ClusterRef const & ref)  {setClusterPixelRef(ref);}
 
-  virtual int dimension() const override {return 2;}
-  virtual void getKfComponents( KfComponentsHolder & holder ) const override { getKfComponents2D(holder); }
+  int dimension() const override {return 2;}
+  void getKfComponents( KfComponentsHolder & holder ) const override { getKfComponents2D(holder); }
   
   
-  virtual bool canImproveWithTrack() const override {return true;}
+  bool canImproveWithTrack() const override {return true;}
 private:
   // double dispatch
-  virtual SiPixelRecHit * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+  SiPixelRecHit * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner(*this,tsos).release();
   }
 #ifndef __GCCXML__
-  virtual  RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+   RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner.makeShared(*this,tsos);
   }
 #endif  

--- a/DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h
@@ -10,7 +10,7 @@ class SiStripMatchedRecHit2D final : public BaseTrackerRecHit {
   typedef BaseTrackerRecHit Base;
 
   SiStripMatchedRecHit2D(){}
-  ~SiStripMatchedRecHit2D(){}
+  ~SiStripMatchedRecHit2D() override{}
 
   SiStripMatchedRecHit2D( const LocalPoint& pos, const LocalError& err, GeomDet const & idet,
 			  const SiStripRecHit2D* rMono,const SiStripRecHit2D* rStereo):
@@ -24,7 +24,7 @@ class SiStripMatchedRecHit2D final : public BaseTrackerRecHit {
   unsigned int monoId()   const { return rawId()+2;}
 
   // (to be improved)
-  virtual OmniClusterRef const & firstClusterRef() const { return monoClusterRef();}
+  OmniClusterRef const & firstClusterRef() const override { return monoClusterRef();}
 
 
   OmniClusterRef const & stereoClusterRef() const { return clusterStereo_;}
@@ -41,33 +41,33 @@ class SiStripMatchedRecHit2D final : public BaseTrackerRecHit {
   }  
 
 
-  virtual SiStripMatchedRecHit2D * clone() const {return new SiStripMatchedRecHit2D( * this);}
+  SiStripMatchedRecHit2D * clone() const override {return new SiStripMatchedRecHit2D( * this);}
 #ifndef __GCCXML__
-  virtual RecHitPointer cloneSH() const { return std::make_shared<SiStripMatchedRecHit2D>(*this);}
+  RecHitPointer cloneSH() const override { return std::make_shared<SiStripMatchedRecHit2D>(*this);}
 #endif
 
  
-  virtual int dimension() const {return 2;}
-  virtual void getKfComponents( KfComponentsHolder & holder ) const { getKfComponents2D(holder); }
+  int dimension() const override {return 2;}
+  void getKfComponents( KfComponentsHolder & holder ) const override { getKfComponents2D(holder); }
 
 
 
-  virtual bool sharesInput( const TrackingRecHit* other, SharedInputType what) const;
+  bool sharesInput( const TrackingRecHit* other, SharedInputType what) const override;
 
   bool sharesInput(TrackerSingleRecHit const & other) const;
 
-  virtual std::vector<const TrackingRecHit*> recHits() const; 
+  std::vector<const TrackingRecHit*> recHits() const override; 
 
-  virtual std::vector<TrackingRecHit*> recHits(); 
+  std::vector<TrackingRecHit*> recHits() override; 
 
-  virtual bool canImproveWithTrack() const {return true;}
+  bool canImproveWithTrack() const override {return true;}
 private:
   // double dispatch
-  virtual SiStripMatchedRecHit2D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
+  SiStripMatchedRecHit2D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner(*this,tsos).release();
   }
 #ifndef __GCCXML__
-  virtual  RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
+   RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner.makeShared(*this,tsos);
   }
 #endif 

--- a/DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h
@@ -27,23 +27,23 @@ public:
   void setClusterRef(ClusterRef const & ref)  {setClusterStripRef(ref);}
 
 
-  virtual SiStripRecHit1D * clone() const override {return new SiStripRecHit1D( * this); }
+  SiStripRecHit1D * clone() const override {return new SiStripRecHit1D( * this); }
 #ifndef __GCCXML__
-  virtual RecHitPointer cloneSH() const override { return std::make_shared<SiStripRecHit1D>(*this);}
+  RecHitPointer cloneSH() const override { return std::make_shared<SiStripRecHit1D>(*this);}
 #endif
   
 
-  virtual int dimension() const override {return 1;}
-  virtual void getKfComponents( KfComponentsHolder & holder ) const override {getKfComponents1D(holder);}
+  int dimension() const override {return 1;}
+  void getKfComponents( KfComponentsHolder & holder ) const override {getKfComponents1D(holder);}
 
-  virtual bool canImproveWithTrack() const override {return true;}
+  bool canImproveWithTrack() const override {return true;}
 private:
   // double dispatch
-  virtual SiStripRecHit1D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+  SiStripRecHit1D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner(*this,tsos).release();
   }
 #ifndef __GCCXML__
-  virtual  RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+   RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner.makeShared(*this,tsos);
   }
 #endif 

--- a/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h
@@ -10,7 +10,7 @@ public:
 
   SiStripRecHit2D() {}
 
-  ~SiStripRecHit2D() {} 
+  ~SiStripRecHit2D() override {} 
 
   typedef OmniClusterRef::ClusterStripRef         ClusterRef;
 
@@ -29,22 +29,22 @@ public:
   ClusterRef cluster()  const { return cluster_strip() ; }
   void setClusterRef(ClusterRef const & ref)  {setClusterStripRef(ref);}
 
-  virtual SiStripRecHit2D * clone() const override {return new SiStripRecHit2D( * this); }
+  SiStripRecHit2D * clone() const override {return new SiStripRecHit2D( * this); }
 #ifndef __GCCXML__
-  virtual RecHitPointer cloneSH() const override { return std::make_shared<SiStripRecHit2D>(*this);}
+  RecHitPointer cloneSH() const override { return std::make_shared<SiStripRecHit2D>(*this);}
 #endif
   
-  virtual int dimension() const override {return 2;}
-  virtual void getKfComponents( KfComponentsHolder & holder ) const override { getKfComponents2D(holder); }
+  int dimension() const override {return 2;}
+  void getKfComponents( KfComponentsHolder & holder ) const override { getKfComponents2D(holder); }
 
-  virtual bool canImproveWithTrack() const override {return true;}
+  bool canImproveWithTrack() const override {return true;}
 private:
   // double dispatch
-  virtual SiStripRecHit2D* clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+  SiStripRecHit2D* clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner(*this,tsos).release();
   }
 #ifndef __GCCXML__
-  virtual  RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
+   RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const override {
     return cloner.makeShared(*this,tsos);
   }
 #endif 

--- a/DataFormats/TrackerRecHit2D/interface/SiTrackerMultiRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiTrackerMultiRecHit.h
@@ -18,30 +18,30 @@ public:
     theHits(),
     theWeights(),
     annealing_(0){}
-  virtual ~SiTrackerMultiRecHit(){}	
+  ~SiTrackerMultiRecHit() override{}	
   
   
   SiTrackerMultiRecHit(const LocalPoint&, const LocalError&, GeomDet const & idet,
 		       const std::vector< std::pair<const TrackingRecHit*, float> >&, double);
   
-  virtual SiTrackerMultiRecHit* clone() const {return new SiTrackerMultiRecHit(*this);}
+  SiTrackerMultiRecHit* clone() const override {return new SiTrackerMultiRecHit(*this);}
 #ifdef NO_DICT
   virtual RecHitPointer cloneSH() const { return std::make_shared<SiTrackerMultiRecHit>(*this);}
 #endif
   
 //  virtual int dimension() const {return 2;}
-  virtual int dimension() const; 
-  virtual void getKfComponents( KfComponentsHolder & holder ) const;
+  int dimension() const override; 
+  void getKfComponents( KfComponentsHolder & holder ) const override;
 
   // at the momement nobody care of MultiHit!!!
   // used by trackMerger (to be improved)
-  virtual OmniClusterRef const & firstClusterRef() const { return static_cast<BaseTrackerRecHit const *>(&theHits.front())->firstClusterRef();}
+  OmniClusterRef const & firstClusterRef() const override { return static_cast<BaseTrackerRecHit const *>(&theHits.front())->firstClusterRef();}
 
   /// Access to component RecHits (if any)
-  virtual std::vector<const TrackingRecHit*> recHits() const;
+  std::vector<const TrackingRecHit*> recHits() const override;
    
   /// Non-const access to component RecHits (if any)
-  virtual std::vector<TrackingRecHit*> recHits() ;
+  std::vector<TrackingRecHit*> recHits() override ;
   
   //vector of weights
   std::vector<float> const & weights() const {return theWeights;}
@@ -56,7 +56,7 @@ public:
   virtual double getAnnealingFactor() const { return annealing_; }
 	
   bool sharesInput(const TrackingRecHit* other,
-		   SharedInputType what) const;
+		   SharedInputType what) const override;
 
 private:
   

--- a/DataFormats/TrackerRecHit2D/interface/TrackerSingleRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/TrackerSingleRecHit.h
@@ -39,12 +39,12 @@ public:
 		      CluRef const&  clus) : Base(p,e,idet, rt), cluster_(clus){}
 
   // a single hit is on a detunit
-  const GeomDetUnit* detUnit() const {
+  const GeomDetUnit* detUnit() const override {
     return static_cast<const GeomDetUnit*>(det());
   }
 
   // used by trackMerger (to be improved)
-  virtual OmniClusterRef const & firstClusterRef() const  final { return cluster_;}
+  OmniClusterRef const & firstClusterRef() const  final { return cluster_;}
 
   OmniClusterRef const & omniClusterRef() const { return cluster_;}
   OmniClusterRef const & omniCluster() const { return cluster_;}
@@ -81,7 +81,7 @@ public:
   void setClusterStripRef(ClusterStripRef const & ref) {  cluster_ = OmniClusterRef(ref); }
   void setClusterPhase2Ref(ClusterPhase2Ref const & ref) { cluster_ = OmniClusterRef(ref); }
 
-  virtual bool sharesInput( const TrackingRecHit* other, SharedInputType what) const  final;
+  bool sharesInput( const TrackingRecHit* other, SharedInputType what) const  final;
 
 
   bool sharesInput(TrackerSingleRecHit const & other) const {
@@ -92,8 +92,8 @@ public:
     return oh == cluster_;
   }
 
-  virtual std::vector<const TrackingRecHit*> recHits() const;
-  virtual std::vector<TrackingRecHit*> recHits();
+  std::vector<const TrackingRecHit*> recHits() const override;
+  std::vector<TrackingRecHit*> recHits() override;
 
 private:
  

--- a/DataFormats/TrackerRecHit2D/src/SiTrackerMultiRecHit.cc
+++ b/DataFormats/TrackerRecHit2D/src/SiTrackerMultiRecHit.cc
@@ -38,7 +38,7 @@ bool SiTrackerMultiRecHit::sharesInput(const TrackingRecHit* other,
   }
   else{
     for(OwnVector<TrackingRecHit>::const_iterator hit=theHits.begin();hit!=theHits.end();++hit){
-      if(otherhits.size()!=0){ 
+      if(!otherhits.empty()){ 
 	for(vector<const TrackingRecHit*>::iterator otherhit=otherhits.begin();otherhit!=otherhits.end();++otherhit){
 	  if((hit)->sharesInput(*otherhit,some))return true;
 	}

--- a/DataFormats/TrackingRecHit/interface/InvalidTrackingRecHit.h
+++ b/DataFormats/TrackingRecHit/interface/InvalidTrackingRecHit.h
@@ -14,31 +14,31 @@ public:
 
   InvalidTrackingRecHit() : TrackingRecHit(DetId(0), TrackingRecHit::missing) {}
 
-  virtual ~InvalidTrackingRecHit() {}
+  ~InvalidTrackingRecHit() override {}
 
-  virtual InvalidTrackingRecHit * clone() const override {return new InvalidTrackingRecHit(*this);}
+  InvalidTrackingRecHit * clone() const override {return new InvalidTrackingRecHit(*this);}
 #ifndef __GCCXML__
-  virtual RecHitPointer cloneSH() const override { return RecHitPointer(clone());}
+  RecHitPointer cloneSH() const override { return RecHitPointer(clone());}
 #endif
 
   
-  virtual AlgebraicVector parameters() const override;
+  AlgebraicVector parameters() const override;
 
-  virtual AlgebraicSymMatrix parametersError() const override;
+  AlgebraicSymMatrix parametersError() const override;
 
-  virtual AlgebraicMatrix projectionMatrix() const override;
+  AlgebraicMatrix projectionMatrix() const override;
 
-  virtual int dimension() const override { return 0;}
+  int dimension() const override { return 0;}
 
-  virtual LocalPoint localPosition() const override;
+  LocalPoint localPosition() const override;
 
-  virtual LocalError localPositionError() const override;
+  LocalError localPositionError() const override;
 
-  virtual std::vector<const TrackingRecHit*> recHits() const override;
+  std::vector<const TrackingRecHit*> recHits() const override;
 
-  virtual std::vector<TrackingRecHit*> recHits() override;
+  std::vector<TrackingRecHit*> recHits() override;
 
-  virtual bool sharesInput( const TrackingRecHit* other, SharedInputType what) const override;
+  bool sharesInput( const TrackingRecHit* other, SharedInputType what) const override;
 
 private:
 
@@ -52,7 +52,7 @@ public:
   InvalidTrackingRecHitNoDet() {}
   InvalidTrackingRecHitNoDet(Surface const & surface, Type type) : InvalidTrackingRecHit(type), m_surface(&surface){}
 
-  virtual InvalidTrackingRecHitNoDet * clone() const override {return new InvalidTrackingRecHitNoDet(*this);}
+  InvalidTrackingRecHitNoDet * clone() const override {return new InvalidTrackingRecHitNoDet(*this);}
 
   const Surface* surface() const override {  return  m_surface; }
 

--- a/DataFormats/TrackingRecHit/interface/RecHit1D.h
+++ b/DataFormats/TrackingRecHit/interface/RecHit1D.h
@@ -24,34 +24,34 @@ class RecHit1D : public TrackingRecHit {
   RecHit1D(TrackingRecHit::id_type id=0) : TrackingRecHit(id) {}
 
   /// Destructor
-  virtual ~RecHit1D() {}
+  ~RecHit1D() override {}
 
 
   /// Return just the x
-  virtual AlgebraicVector parameters() const;
+  AlgebraicVector parameters() const override;
 
 
   /// Return just "(sigma_x)^2"
-  virtual AlgebraicSymMatrix parametersError() const;
+  AlgebraicSymMatrix parametersError() const override;
 
 
   ///Return the projection matrix
-  virtual AlgebraicMatrix projectionMatrix() const {
+  AlgebraicMatrix projectionMatrix() const override {
     return theProjectionMatrix;
   }
 
   /// Return the RecHit dimension
-  virtual int dimension() const {
+  int dimension() const override {
     return 1;
   }
 
 
   /// Local position
-  virtual LocalPoint localPosition() const = 0;
+  LocalPoint localPosition() const override = 0;
 
 
   /// Error on the local position
-  virtual LocalError localPositionError() const = 0;
+  LocalError localPositionError() const override = 0;
 
 
  private:

--- a/DataFormats/TrackingRecHit/interface/RecHit2DLocalPos.h
+++ b/DataFormats/TrackingRecHit/interface/RecHit2DLocalPos.h
@@ -13,27 +13,27 @@ public:
   
   RecHit2DLocalPos(DetId id) : TrackingRecHit(id) {}
   RecHit2DLocalPos(TrackingRecHit::id_type id=0) : TrackingRecHit(id) {}
-  virtual ~RecHit2DLocalPos() {}
+  ~RecHit2DLocalPos() override {}
   
-  virtual RecHit2DLocalPos * clone() const = 0;
+  RecHit2DLocalPos * clone() const override = 0;
   
-  virtual AlgebraicVector parameters() const;
+  AlgebraicVector parameters() const override;
 
-  virtual AlgebraicSymMatrix parametersError() const;
+  AlgebraicSymMatrix parametersError() const override;
 
-  virtual AlgebraicMatrix projectionMatrix() const {
+  AlgebraicMatrix projectionMatrix() const override {
     return theProjectionMatrix;
   }
 
-  virtual int dimension() const { return 2;}
+  int dimension() const override { return 2;}
 
-  virtual LocalPoint localPosition() const = 0;
+  LocalPoint localPosition() const override = 0;
 
-  virtual LocalError localPositionError() const = 0;
+  LocalError localPositionError() const override = 0;
 
-  virtual std::vector<const TrackingRecHit*> recHits() const;
+  std::vector<const TrackingRecHit*> recHits() const override;
 
-  virtual std::vector<TrackingRecHit*> recHits();
+  std::vector<TrackingRecHit*> recHits() override;
 
 private:
 

--- a/DataFormats/TrackingRecHit/interface/RecSegment.h
+++ b/DataFormats/TrackingRecHit/interface/RecSegment.h
@@ -31,7 +31,7 @@ class RecSegment : public TrackingRecHit{
   RecSegment(TrackingRecHit::id_type id=0) : TrackingRecHit(id) {}
 
   /// Destructor
-  virtual ~RecSegment() {};
+  ~RecSegment() override {};
 
   /// Local direction
   virtual LocalVector localDirection() const = 0;
@@ -46,7 +46,7 @@ class RecSegment : public TrackingRecHit{
   virtual int degreesOfFreedom() const = 0 ;
 
   /// Dimension (in parameter space)
-  virtual int dimension() const = 0 ;
+  int dimension() const override = 0 ;
 
 };
 #endif // TrackingRecHit_RecSegment_h


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this tomorrow to avoid conflicts to the extent possible]