### PR TITLE
Clang-tidy checks for TauAnalysis

### DIFF
--- a/TauAnalysis/MCEmbeddingTools/plugins/CaloCleaner.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/CaloCleaner.h
@@ -38,10 +38,10 @@ class CaloCleaner : public  edm::stream::EDProducer<>
 {
  public:
   explicit CaloCleaner(const edm::ParameterSet&);
-  ~CaloCleaner();
+  ~CaloCleaner() override;
 
  private:
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
   typedef edm::SortedCollection<T> RecHitCollection;
 
@@ -99,7 +99,7 @@ void CaloCleaner<T>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   for (edm::View<pat::Muon>::const_iterator iMuon = muons.begin(); iMuon != muons.end(); ++iMuon) {
     // get the basic informaiton like fill reco mouon does 
     //     RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
-    const reco::Track* track = 0;
+    const reco::Track* track = nullptr;
     if      ( iMuon->track().isNonnull() ) track = iMuon->track().get();
     else if ( iMuon->standAloneMuon().isNonnull() ) track = iMuon->standAloneMuon().get();
     else throw cms::Exception("FatalError") << "Failed to fill muon id information for a muon with undefined references to tracks";

--- a/TauAnalysis/MCEmbeddingTools/plugins/CollectionMerger.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/CollectionMerger.h
@@ -44,10 +44,10 @@ class CollectionMerger : public  edm::stream::EDProducer<>
 {
  public:
   explicit CollectionMerger(const edm::ParameterSet&);
-  ~CollectionMerger();
+  ~CollectionMerger() override;
 
  private:
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
   typedef T1 MergeCollection;
   typedef T2 BaseHit;

--- a/TauAnalysis/MCEmbeddingTools/plugins/DYToMuMuGenFilter.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/DYToMuMuGenFilter.cc
@@ -17,14 +17,14 @@
 class DYToMuMuGenFilter: public edm::stream::EDFilter<> {
    public:
       explicit DYToMuMuGenFilter(const edm::ParameterSet&);
-      ~DYToMuMuGenFilter();
+      ~DYToMuMuGenFilter() override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void beginStream(edm::StreamID) override;
-      virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-      virtual void endStream() override;
+      void beginStream(edm::StreamID) override;
+      bool filter(edm::Event&, const edm::EventSetup&) override;
+      void endStream() override;
       
       edm::InputTag inputTag_;
       edm::EDGetTokenT<reco::GenParticleCollection> genParticleCollection_;

--- a/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingVertexCorrector.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingVertexCorrector.cc
@@ -60,13 +60,13 @@ namespace HepMC {
 class EmbeddingVertexCorrector : public edm::stream::EDProducer<> {
    public:
       explicit EmbeddingVertexCorrector(const edm::ParameterSet&);
-      ~EmbeddingVertexCorrector();
+      ~EmbeddingVertexCorrector() override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void beginRun(const edm::Run & , const edm::EventSetup& iEventSetup) override;
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      void beginRun(const edm::Run & , const edm::EventSetup& iEventSetup) override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
 
       // ----------member data ---------------------------
       edm::InputTag sourceLabel;

--- a/TauAnalysis/MCEmbeddingTools/plugins/MuMuForEmbeddingSelector.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MuMuForEmbeddingSelector.cc
@@ -40,14 +40,14 @@
 class MuMuForEmbeddingSelector : public edm::stream::EDProducer<> {
    public:
       explicit MuMuForEmbeddingSelector(const edm::ParameterSet&);
-      ~MuMuForEmbeddingSelector();
+      ~MuMuForEmbeddingSelector() override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void beginStream(edm::StreamID) override;
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endStream() override;
+      void beginStream(edm::StreamID) override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
+      void endStream() override;
 
       //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
       //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;

--- a/TauAnalysis/MCEmbeddingTools/plugins/MuonDetCleaner.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MuonDetCleaner.h
@@ -37,10 +37,10 @@ class MuonDetCleaner : public edm::stream::EDProducer<>
 {
  public:
   explicit MuonDetCleaner(const edm::ParameterSet&);
-  ~MuonDetCleaner();
+  ~MuonDetCleaner() override;
 
  private:
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
   typedef edm::RangeMap<T1, edm::OwnVector<T2> > RecHitCollection;
   void fillVetoHits(const TrackingRecHit& , std::vector<uint32_t>* );
@@ -83,7 +83,7 @@ void MuonDetCleaner<T1,T2>::produce(edm::Event& iEvent, const edm::EventSetup& e
    iEvent.getByToken(mu_input_, muonHandle);
    edm::View<pat::Muon> muons = *muonHandle;
    for (edm::View<pat::Muon>::const_iterator iMuon = muons.begin(); iMuon != muons.end(); ++iMuon) {     
-      const reco::Track* track = 0;
+      const reco::Track* track = nullptr;
       if( iMuon->isGlobalMuon() ) track = iMuon->outerTrack().get();
       else if  ( iMuon->isStandAloneMuon() ) track =   iMuon->outerTrack().get();
       else if  ( iMuon->isRPCMuon() ) track =   iMuon->innerTrack().get(); // To add, try to access the rpc track 
@@ -133,7 +133,7 @@ template <typename T1, typename T2>
 void MuonDetCleaner<T1,T2>::fillVetoHits(const TrackingRecHit& rh, std::vector<uint32_t>* HitsList)
 {
     std::vector<const TrackingRecHit*> rh_components = rh.recHits();
-    if ( rh_components.size() == 0 ) {
+    if ( rh_components.empty() ) {
       HitsList->push_back(rh.rawId());
     } 
     else {

--- a/TauAnalysis/MCEmbeddingTools/plugins/TrackMergeremb.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/TrackMergeremb.h
@@ -39,10 +39,10 @@ class TrackMergeremb : public edm::stream::EDProducer<>
 {
  public:
   explicit TrackMergeremb(const edm::ParameterSet&);
-  ~TrackMergeremb();
+  ~TrackMergeremb() override;
 
  private:
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
   
   typedef T1 TrackCollectionemb;
   

--- a/TauAnalysis/MCEmbeddingTools/plugins/TrackerCleaner.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/TrackerCleaner.h
@@ -41,10 +41,10 @@ class TrackerCleaner : public edm::stream::EDProducer<>
 {
  public:
   explicit TrackerCleaner(const edm::ParameterSet&);
-  ~TrackerCleaner();
+  ~TrackerCleaner() override;
 
  private:
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
   const edm::EDGetTokenT<edm::View<pat::Muon> > mu_input_;
   typedef edmNew::DetSetVector<T> TrackClusterCollection;


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this tomorrow to avoid conflicts to the extent possible]