### PR TITLE
Clang-tidy checks for Utilities

### DIFF
--- a/Utilities/DCacheAdaptor/interface/DCacheFile.h
+++ b/Utilities/DCacheAdaptor/interface/DCacheFile.h
@@ -12,7 +12,7 @@ public:
   DCacheFile (IOFD fd);
   DCacheFile (const char *name, int flags = IOFlags::OpenRead, int perms = 0666);
   DCacheFile (const std::string &name, int flags = IOFlags::OpenRead, int perms = 0666);
-  ~DCacheFile (void);
+  ~DCacheFile (void) override;
 
   virtual void	create (const char *name,
     			bool exclusive = false,
@@ -31,15 +31,15 @@ public:
   using Storage::write;
   using Storage::position;
 
-  virtual IOSize	read (void *into, IOSize n);
-  virtual IOSize	readv (IOBuffer *into, IOSize buffers);
-  virtual IOSize	readv (IOPosBuffer *into, IOSize buffers);
-  virtual IOSize	write (const void *from, IOSize n);
+  IOSize	read (void *into, IOSize n) override;
+  IOSize	readv (IOBuffer *into, IOSize buffers) override;
+  IOSize	readv (IOPosBuffer *into, IOSize buffers) override;
+  IOSize	write (const void *from, IOSize n) override;
 
-  virtual IOOffset	position (IOOffset offset, Relative whence = SET);
-  virtual void		resize (IOOffset size);
+  IOOffset	position (IOOffset offset, Relative whence = SET) override;
+  void		resize (IOOffset size) override;
 
-  virtual void		close (void);
+  void		close (void) override;
   virtual void		abort (void);
 
 private:

--- a/Utilities/DCacheAdaptor/plugins/DCacheStorageMaker.cc
+++ b/Utilities/DCacheAdaptor/plugins/DCacheStorageMaker.cc
@@ -29,7 +29,7 @@ public:
 
   /** Open a storage object for the given URL (protocol + path), using the
       @a mode bits.  No temporary files are downloaded.  */
-  virtual std::unique_ptr<Storage> open (const std::string &proto,
+  std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &path,
 			 int mode,
        AuxSettings const& aux) const override
@@ -49,13 +49,13 @@ public:
     return f->wrapNonLocalFile(std::move(file), proto, std::string(), mode);
   }
 
-  virtual void stagein (const std::string &proto,
+  void stagein (const std::string &proto,
 		        const std::string &path,
             const AuxSettings& aux) const override
   {
     setTimeout(aux.timeout);
     std::string npath = normalise(proto, path);
-    if (dc_stage(npath.c_str(), 0, 0) != 0) {
+    if (dc_stage(npath.c_str(), 0, nullptr) != 0) {
       cms::Exception ex("FileStageInError");
       ex << "Cannot stage in file '" << npath
 	 << "', error was: " << dc_strerror(dc_errno)
@@ -65,10 +65,10 @@ public:
     }
   }
 
-  virtual bool check (const std::string &proto,
+  bool check (const std::string &proto,
 		      const std::string &path,
           const AuxSettings& aux,
-		      IOOffset *size = 0) const override
+		      IOOffset *size = nullptr) const override
   {
     setTimeout(aux.timeout);
     std::string testpath (normalise (proto, path));

--- a/Utilities/DCacheAdaptor/src/DCacheFile.cc
+++ b/Utilities/DCacheAdaptor/src/DCacheFile.cc
@@ -75,7 +75,7 @@ DCacheFile::open (const char *name,
                   int perms /* = 066 */)
 {
   // Actual open
-  if ((name == 0) || (*name == 0)) {
+  if ((name == nullptr) || (*name == 0)) {
     edm::Exception ex(edm::errors::FileOpenError);
     ex << "Cannot open a file without a name";
     ex.addContext("Calling DCacheFile::open()");

--- a/Utilities/DavixAdaptor/interface/DavixFile.h
+++ b/Utilities/DavixAdaptor/interface/DavixFile.h
@@ -11,7 +11,7 @@ public:
   DavixFile(const char *name, int flags = IOFlags::OpenRead, int perms = 0666);
   DavixFile(const std::string &name, int flags = IOFlags::OpenRead,
             int perms = 0666);
-  ~DavixFile(void);
+  ~DavixFile(void) override;
   static void configureDavixLogLevel();
 
   virtual void create(const char *name, bool exclusive = false,
@@ -27,14 +27,14 @@ public:
   using Storage::write;
   using Storage::position;
 
-  virtual IOSize read(void *into, IOSize n) override;
-  virtual IOSize readv(IOBuffer *into, IOSize buffers) override;
-  virtual IOSize readv(IOPosBuffer *into, IOSize buffers) override;
-  virtual IOSize write(const void *from, IOSize n) override;
-  virtual IOOffset position(IOOffset offset, Relative whence = SET) override;
-  virtual void resize(IOOffset size) override;
+  IOSize read(void *into, IOSize n) override;
+  IOSize readv(IOBuffer *into, IOSize buffers) override;
+  IOSize readv(IOPosBuffer *into, IOSize buffers) override;
+  IOSize write(const void *from, IOSize n) override;
+  IOOffset position(IOOffset offset, Relative whence = SET) override;
+  void resize(IOOffset size) override;
 
-  virtual void close(void) override;
+  void close(void) override;
   virtual void abort(void);
 
 private:

--- a/Utilities/DavixAdaptor/plugins/DavixStorageMaker.cc
+++ b/Utilities/DavixAdaptor/plugins/DavixStorageMaker.cc
@@ -11,7 +11,7 @@ class DavixStorageMaker : public StorageMaker {
 public:
   /** Open a storage object for the given URL (protocol + path), using the
       @a mode bits.  No temporary files are downloaded.  */
-  virtual std::unique_ptr<Storage> open(const std::string &proto, const std::string &path, int mode,
+  std::unique_ptr<Storage> open(const std::string &proto, const std::string &path, int mode,
                                         AuxSettings const &aux) const override {
     const StorageFactory *f = StorageFactory::get();
     std::string newurl((proto == "web" ? "http" : proto) + ":" + path);
@@ -19,14 +19,14 @@ public:
     return f->wrapNonLocalFile(std::move(file), proto, std::string(), mode);
   }
 
-  virtual bool check(const std::string &proto, const std::string &path, const AuxSettings &aux,
-                     IOOffset *size = 0) const override {
+  bool check(const std::string &proto, const std::string &path, const AuxSettings &aux,
+                     IOOffset *size = nullptr) const override {
     std::string newurl((proto == "web" ? "http" : proto) + ":" + path);
     Davix::DavixError *err = nullptr;
     Davix::Context c;
     Davix::DavPosix davixPosix(&c);
     Davix::StatInfo info;
-    davixPosix.stat64(NULL, newurl, &info, &err);
+    davixPosix.stat64(nullptr, newurl, &info, &err);
     if (err) {
       std::unique_ptr<Davix::DavixError> davixErrManaged(err);
       cms::Exception ex("FileCheckError");

--- a/Utilities/DavixAdaptor/src/DavixFile.cc
+++ b/Utilities/DavixAdaptor/src/DavixFile.cc
@@ -4,9 +4,9 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include <cassert>
 #include <davix.hpp>
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <unistd.h>
 #include <vector>
 #include <mutex>
@@ -67,7 +67,7 @@ void DavixFile::configureDavixLogLevel() {
   long logLevel = 0;
   char *logptr = nullptr;
   char const * const davixDebug = getenv("Davix_Debug");
-  if (davixDebug != NULL) {
+  if (davixDebug != nullptr) {
     logLevel = strtol(davixDebug, &logptr, 0);
     if (errno) {
       edm::LogWarning("DavixFile") << "Got error while converting "
@@ -161,7 +161,7 @@ void DavixFile::open(const std::string &name, int flags /* = IOFlags::OpenRead *
 
 void DavixFile::open(const char *name, int flags /* = IOFlags::OpenRead */, int perms /* = 066 */) {
   // Actual open
-  if ((name == 0) || (*name == 0)) {
+  if ((name == nullptr) || (*name == 0)) {
     edm::Exception ex(edm::errors::FileOpenError);
     ex << "Cannot open a file without name";
     ex.addContext("Calling DavixFile::open()");
@@ -192,10 +192,10 @@ void DavixFile::open(const char *name, int flags /* = IOFlags::OpenRead */, int 
   DavixError *davixErr = nullptr;
   RequestParams davixReqParams;
   // Set up X509 authentication
-  davixReqParams.setClientCertCallbackX509(&X509Authentication, NULL);
+  davixReqParams.setClientCertCallbackX509(&X509Authentication, nullptr);
   // Set also CERT_DIR if it is set in envinroment, otherwise use default
-  const char *cert_dir = NULL;
-  if ((cert_dir = getenv("X509_CERT_DIR")) == NULL)
+  const char *cert_dir = nullptr;
+  if ((cert_dir = getenv("X509_CERT_DIR")) == nullptr)
     cert_dir = "/etc/grid-security/certificates";
   davixReqParams.addCertificateAuthorityPath(cert_dir);
 

--- a/Utilities/General/src/ClassName.cc
+++ b/Utilities/General/src/ClassName.cc
@@ -2,12 +2,12 @@
 #include <cxxabi.h>
 #include <cstring>
 
-Demangle::Demangle(const char * sc) : demangle(0) {
-  if (sc==0) return;
+Demangle::Demangle(const char * sc) : demangle(nullptr) {
+  if (sc==nullptr) return;
   int status;
-  demangle = abi::__cxa_demangle(sc,  0, 0, &status);
+  demangle = abi::__cxa_demangle(sc,  nullptr, nullptr, &status);
   if(status == 0) return;  
-  demangle = 0;
+  demangle = nullptr;
   if(status == -1)
     throw std::bad_alloc();
   else if(status == -2) {

--- a/Utilities/LStoreAdaptor/interface/LStoreFile.h
+++ b/Utilities/LStoreAdaptor/interface/LStoreFile.h
@@ -12,7 +12,7 @@ public:
   LStoreFile (void * fd);
   LStoreFile (const char *name, int flags = IOFlags::OpenRead, int perms = 0666);
   LStoreFile (const std::string &name, int flags = IOFlags::OpenRead, int perms = 0666);
-  ~LStoreFile (void);
+  ~LStoreFile (void) override;
 
   virtual void	create (const char *name,
     			bool exclusive = false,
@@ -31,13 +31,13 @@ public:
   using Storage::write;
   using Storage::position;
 
-  virtual IOSize	read (void *into, IOSize n);
-  virtual IOSize	write (const void *from, IOSize n);
+  IOSize	read (void *into, IOSize n) override;
+  IOSize	write (const void *from, IOSize n) override;
 
-  virtual IOOffset	position (IOOffset offset, Relative whence = SET);
-  virtual void		resize (IOOffset size);
+  IOOffset	position (IOOffset offset, Relative whence = SET) override;
+  void		resize (IOOffset size) override;
 
-  virtual void		close (void);
+  void		close (void) override;
   virtual void		abort (void);
   
   class MutexWrapper {

--- a/Utilities/LStoreAdaptor/plugins/LStoreStorageMaker.cc
+++ b/Utilities/LStoreAdaptor/plugins/LStoreStorageMaker.cc
@@ -12,7 +12,7 @@ class LStoreStorageMaker : public StorageMaker
   public:
   /** Open a storage object for the given URL (protocol + path), using the
       @a mode bits.  No temporary files are downloaded.  */
-  virtual std::unique_ptr<Storage> open (const std::string &proto,
+  std::unique_ptr<Storage> open (const std::string &proto,
              const std::string &path,
              int mode,
              const AuxSettings&) const override
@@ -35,10 +35,10 @@ class LStoreStorageMaker : public StorageMaker
   }
 */
 
-  virtual bool check (const std::string &proto,
+  bool check (const std::string &proto,
               const std::string &path,
               const AuxSettings&,
-              IOOffset *size = 0) const override
+              IOOffset *size = nullptr) const override
   {
 	std::string fullpath = proto + ":" + path;
 	try {

--- a/Utilities/LStoreAdaptor/src/LStoreFile.cc
+++ b/Utilities/LStoreAdaptor/src/LStoreFile.cc
@@ -8,7 +8,7 @@
 #include <pthread.h>
 #include <dlfcn.h>
 #include <iostream>
-#include <string.h>
+#include <cstring>
 
 
 
@@ -16,20 +16,20 @@
 pthread_mutex_t LStoreFile::m_dlopen_lock = PTHREAD_MUTEX_INITIALIZER;
 
 LStoreFile::LStoreFile (void)
-  : m_fd (0),
+  : m_fd (nullptr),
     m_close (false),
     m_name(),
-    m_library_handle(0),
+    m_library_handle(nullptr),
     m_is_loaded(false),
-    redd_init(0),
-    redd_read(0),
-    redd_close(0),
-    redd_lseek(0),
-    redd_open(0),
-    redd_write(0),
-    redd_term(0),
-    redd_errno(0),
-    redd_strerror(0)
+    redd_init(nullptr),
+    redd_read(nullptr),
+    redd_close(nullptr),
+    redd_lseek(nullptr),
+    redd_open(nullptr),
+    redd_write(nullptr),
+    redd_term(nullptr),
+    redd_errno(nullptr),
+    redd_strerror(nullptr)
 {
 	loadLibrary();	
 }
@@ -38,17 +38,17 @@ LStoreFile::LStoreFile (void * fd)
   : m_fd (fd),
     m_close (true),
     m_name(),
-    m_library_handle(0),
+    m_library_handle(nullptr),
     m_is_loaded(false),
-    redd_init(0),
-    redd_read(0),
-    redd_close(0),
-    redd_lseek(0),
-    redd_open(0),
-    redd_write(0),
-    redd_term(0),
-    redd_errno(0),
-    redd_strerror(0)
+    redd_init(nullptr),
+    redd_read(nullptr),
+    redd_close(nullptr),
+    redd_lseek(nullptr),
+    redd_open(nullptr),
+    redd_write(nullptr),
+    redd_term(nullptr),
+    redd_errno(nullptr),
+    redd_strerror(nullptr)
 {
 	loadLibrary();	
 }
@@ -56,7 +56,7 @@ LStoreFile::LStoreFile (void * fd)
 LStoreFile::LStoreFile (const char *name,
     	    int flags /* = IOFlags::OpenRead */,
     	    int perms /* = 066 */ )
-  : m_fd (NULL),
+  : m_fd (nullptr),
     m_close (false),
 	m_is_loaded(false)
 {   loadLibrary();
@@ -65,7 +65,7 @@ LStoreFile::LStoreFile (const char *name,
 LStoreFile::LStoreFile (const std::string &name,
     	    int flags /* = IOFlags::OpenRead*/, 
     	    int perms /* = 066 */)
-  : m_fd (NULL),
+  : m_fd (nullptr),
     m_close (false),
 	m_is_loaded(false)
 {   loadLibrary();
@@ -108,12 +108,12 @@ void LStoreFile::loadLibrary() {
 
 	m_library_handle =
 	     dlopen("libreddnet.so", RTLD_LAZY);
-	if (m_library_handle == NULL) {
+	if (m_library_handle == nullptr) {
 		throw cms::Exception("LStoreFile::loadLibrary()")
 			<< "Can't dlopen() LStore libraries: " << dlerror();
 	}
 
-	char * retval = NULL;
+	char * retval = nullptr;
 	// Explicitly state the size of these values, keeps weird 64/32 bit stuff away
 	REDD_LOAD_SYMBOL( redd_init, int32_t(*)()); 
 	REDD_LOAD_SYMBOL( redd_read, int64_t(*)(void *, char*, int64_t));
@@ -146,7 +146,7 @@ void LStoreFile::closeLibrary() {
 					<< "Error in redd_term: " << (*redd_strerror)();
 			}
 		}
-		if ( m_library_handle != NULL ) {
+		if ( m_library_handle != nullptr ) {
 			if ( dlclose( m_library_handle ) ) {
 				throw cms::Exception("LStoreFile::closeLibrary()")
 					<< "Error on dlclose(): " << dlerror();
@@ -195,7 +195,7 @@ LStoreFile::open (const char *name,
                   int perms /* = 066 */)
 {
   // Actual open
-  if ((name == 0) || (*name == 0))
+  if ((name == nullptr) || (*name == 0))
     throw cms::Exception("LStoreFile::open()")
       << "Cannot open a file without a name";
 
@@ -204,7 +204,7 @@ LStoreFile::open (const char *name,
       << "Must open file '" << name << "' at least for read or write";
 
   // If I am already open, close old file first
-  if (m_fd != NULL && m_close)
+  if (m_fd != nullptr && m_close)
     close ();
 
   // Translate our flags to system flags
@@ -232,8 +232,8 @@ LStoreFile::open (const char *name,
   if (flags & IOFlags::OpenTruncate)
     openflags |= O_TRUNC;
 
-  void * newfd = NULL;
-  if ((newfd = (*redd_open) (name, openflags, perms)) == NULL)
+  void * newfd = nullptr;
+  if ((newfd = (*redd_open) (name, openflags, perms)) == nullptr)
     throw cms::Exception("LStoreFile::open()")
       << "redd_open(name='" << name
       << "', flags=0x" << std::hex << openflags
@@ -252,7 +252,7 @@ LStoreFile::open (const char *name,
 void
 LStoreFile::close (void)
 {
-  if (m_fd == NULL)
+  if (m_fd == nullptr)
   {
     edm::LogError("LStoreFileError")
       << "LStoreFile::close(name='" << m_name
@@ -268,7 +268,7 @@ LStoreFile::close (void)
       << "' (redd_errno=" << (*redd_errno)() << ")";
 
   m_close = false;
-  m_fd = NULL;
+  m_fd = nullptr;
 
   // Caused hang.  Will be added back after problem is fixed.
   // edm::LogInfo("LStoreFileInfo") << "Closed " << m_name;
@@ -277,11 +277,11 @@ LStoreFile::close (void)
 void
 LStoreFile::abort (void)
 {
-  if (m_fd != NULL)
+  if (m_fd != nullptr)
     (*redd_close) (m_fd);
 
   m_close = false;
-  m_fd = NULL;
+  m_fd = nullptr;
 }
 
 
@@ -325,7 +325,7 @@ LStoreFile::write (const void *from, IOSize n)
 IOOffset
 LStoreFile::position (IOOffset offset, Relative whence /* = SET */)
 {
-  if (m_fd == NULL)
+  if (m_fd == nullptr)
     throw cms::Exception("LStoreFile::position()")
       << "LStoreFile::position() called on a closed file";
   if (whence != CURRENT && whence != SET && whence != END)

--- a/Utilities/StorageFactory/interface/LocalFileSystem.h
+++ b/Utilities/StorageFactory/interface/LocalFileSystem.h
@@ -29,8 +29,8 @@ private:
   std::vector<std::string> fstypes_;
 
   // undefined, no semantics
-  LocalFileSystem(LocalFileSystem &);
-  void operator=(LocalFileSystem &);
+  LocalFileSystem(LocalFileSystem &) = delete;
+  void operator=(LocalFileSystem &) = delete;
 };
 
 #endif // STORAGE_FACTORY_LOCAL_FILE_SYSTEM_H

--- a/Utilities/StorageFactory/interface/RemoteFile.h
+++ b/Utilities/StorageFactory/interface/RemoteFile.h
@@ -8,15 +8,15 @@
 class RemoteFile : protected File
 {
 public:
-  ~RemoteFile (void) { remove (); }
+  ~RemoteFile (void) override { remove (); }
 
   static int local (const std::string &tmpdir, std::string &temp);
   static std::unique_ptr<Storage> get (int localfd, const std::string &name,
 		       char **cmd, int mode);
 
 protected:
-  virtual void close (void);
-  virtual void abort (void);
+  void close (void) override;
+  void abort (void) override;
 
 private:
   RemoteFile (IOFD fd, const std::string &name);

--- a/Utilities/StorageFactory/plugins/GsiFTPStorageMaker.cc
+++ b/Utilities/StorageFactory/plugins/GsiFTPStorageMaker.cc
@@ -6,7 +6,7 @@
 class GsiFTPStorageMaker : public StorageMaker
 {
 public:
-  virtual std::unique_ptr<Storage> open (const std::string &proto,
+  std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &path,
 			 int mode,
        const AuxSettings&) const override
@@ -16,7 +16,7 @@ public:
     int            localfd = RemoteFile::local (f->tempDir(), temp);
     std::string    lurl = "file://" + temp;
     std::string    newurl ((proto == "sfn" ? "gsiftp" : proto) + ":" + path);
-    const char	   *ftpopts [] = { "globus-url-copy", newurl.c_str (), lurl.c_str (), 0 };
+    const char	   *ftpopts [] = { "globus-url-copy", newurl.c_str (), lurl.c_str (), nullptr };
     return RemoteFile::get (localfd, temp, (char **) ftpopts, mode);
   }
 };

--- a/Utilities/StorageFactory/plugins/HttpStorageMaker.cc
+++ b/Utilities/StorageFactory/plugins/HttpStorageMaker.cc
@@ -6,7 +6,7 @@
 class HttpStorageMaker : public StorageMaker
 {
 public:
-  virtual std::unique_ptr<Storage> open (const std::string &proto,
+  std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &path,
 			 int mode,
        const AuxSettings&) const override
@@ -17,7 +17,7 @@ public:
     std::string    newurl ((proto == "web" ? "http" : proto) + ":" + path);
     const char     *curlopts [] = {
       "curl", "-L", "-f", "-o", temp.c_str(), "-q", "-s", "--url",
-      newurl.c_str (), 0
+      newurl.c_str (), nullptr
     };
 
     return RemoteFile::get (localfd, temp, (char **) curlopts, mode);

--- a/Utilities/StorageFactory/plugins/LocalStorageMaker.cc
+++ b/Utilities/StorageFactory/plugins/LocalStorageMaker.cc
@@ -11,7 +11,7 @@
 class LocalStorageMaker : public StorageMaker
 {
 public:
-  virtual std::unique_ptr<Storage> open (const std::string &proto,
+  std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &path,
 			 int mode,
        const AuxSettings&) const override
@@ -30,10 +30,10 @@ public:
       return f->wrapNonLocalFile (std::move(file), proto, path, mode);
     }
 
-  virtual bool check (const std::string &/*proto*/,
+  bool check (const std::string &/*proto*/,
 		      const std::string &path,
           const AuxSettings&,
-		      IOOffset *size = 0) const override
+		      IOOffset *size = nullptr) const override
     {
       struct stat st;
       if (stat (path.c_str(), &st) != 0)

--- a/Utilities/StorageFactory/plugins/StormLCGStorageMaker.cc
+++ b/Utilities/StorageFactory/plugins/StormLCGStorageMaker.cc
@@ -55,7 +55,7 @@ class StormLcgGtStorageMaker : public StorageMaker
 
 
 public:
-  virtual std::unique_ptr<Storage> open (const std::string &proto,
+  std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &surl,
 			 int mode,
        const AuxSettings& ) const override
@@ -75,10 +75,10 @@ public:
     return f->wrapNonLocalFile (std::move(file), proto, path, mode);
   }
 
-  virtual bool check (const std::string &/*proto*/,
+  bool check (const std::string &/*proto*/,
 		      const std::string &path,
           const AuxSettings&,
-		      IOOffset *size = 0) const override
+		      IOOffset *size = nullptr) const override
   {
     struct stat st;
     if (stat (getTURL(path).c_str(), &st) != 0)

--- a/Utilities/StorageFactory/plugins/StormStorageMaker.cc
+++ b/Utilities/StorageFactory/plugins/StormStorageMaker.cc
@@ -54,7 +54,7 @@ class StormStorageMaker : public StorageMaker
 
 
 public:
-  virtual std::unique_ptr<Storage> open (const std::string &proto,
+  std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &surl,
 			 int mode,
        const AuxSettings&) const override
@@ -74,10 +74,10 @@ public:
     return f->wrapNonLocalFile (std::move(file), proto, path, mode);
   }
 
-  virtual bool check (const std::string &/*proto*/,
+  bool check (const std::string &/*proto*/,
 		      const std::string &path,
           const AuxSettings&,
-		      IOOffset *size = 0) const override
+		      IOOffset *size = nullptr) const override
   {
     struct stat st;
     if (stat (getTURL(path).c_str(), &st) != 0)

--- a/Utilities/StorageFactory/src/LocalCacheFile.cc
+++ b/Utilities/StorageFactory/src/LocalCacheFile.cc
@@ -2,11 +2,11 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 #include <utility>
 #include <iostream>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 #include <unistd.h>
 #include <sys/mman.h>
-#include <errno.h>
+#include <cerrno>
 #include <sstream>
 
 static const IOOffset CHUNK_SIZE = 128*1024*1024;
@@ -72,7 +72,7 @@ LocalCacheFile::cache(IOOffset start, IOOffset end)
     IOSize len = std::min(image_ - start, CHUNK_SIZE);
     if (! present_[index])
     {
-      void *window = mmap(0, len, PROT_READ | PROT_WRITE, MAP_SHARED, file_->fd(), start);
+      void *window = mmap(nullptr, len, PROT_READ | PROT_WRITE, MAP_SHARED, file_->fd(), start);
       if (window == MAP_FAILED)
       {
         edm::Exception ex(edm::errors::FileReadError);

--- a/Utilities/StorageFactory/src/RemoteFile.cc
+++ b/Utilities/StorageFactory/src/RemoteFile.cc
@@ -95,7 +95,7 @@ RemoteFile::get (int localfd, const std::string &name, char **cmd, int mode)
   assert (! (mode & (IOFlags::OpenWrite | IOFlags::OpenCreate)));
 
   pid_t	 pid = -1;
-  int    rc = posix_spawnp (&pid, cmd[0], 0, 0, cmd, environ);
+  int    rc = posix_spawnp (&pid, cmd[0], nullptr, nullptr, cmd, environ);
 
   if (rc == -1)
   {

--- a/Utilities/StorageFactory/src/SysFile.h
+++ b/Utilities/StorageFactory/src/SysFile.h
@@ -5,7 +5,7 @@
 # include <sys/stat.h>
 # include <fcntl.h>
 # include <utime.h>
-# include <limits.h>
+# include <climits>
 # include <cerrno>
 # include <cstdlib>
 

--- a/Utilities/StorageFactory/src/SysIOChannel.h
+++ b/Utilities/StorageFactory/src/SysIOChannel.h
@@ -1,7 +1,7 @@
 #ifndef STORAGE_FACTORY_SYS_IO_CHANNEL_H
 # define STORAGE_FACTORY_SYS_IO_CHANNEL_H
 
-# include <errno.h>
+# include <cerrno>
 # include <unistd.h>
 # include <fcntl.h>
 # include <sys/types.h>

--- a/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
+++ b/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
@@ -18,8 +18,8 @@
 class MakerResponseHandler : public XrdCl::ResponseHandler
 {
 public:
-    virtual void HandleResponse( XrdCl::XRootDStatus *status,
-                                 XrdCl::AnyObject    *response )
+    void HandleResponse( XrdCl::XRootDStatus *status,
+                                 XrdCl::AnyObject    *response ) override
     {
         // Note: Prepare call has a response object.
         delete response;
@@ -53,7 +53,7 @@ public:
 
   /** Open a storage object for the given URL (protocol + path), using the
       @a mode bits.  No temporary files are downloaded.  */
-  virtual std::unique_ptr<Storage> open (const std::string &proto,
+  std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &path,
 			 int mode,
        const AuxSettings& aux) const override
@@ -76,7 +76,7 @@ public:
     return f->wrapNonLocalFile(std::move(file), proto, std::string(), mode);
   }
 
-  virtual void stagein (const std::string &proto, const std::string &path,
+  void stagein (const std::string &proto, const std::string &path,
                         const AuxSettings& aux) const override
   {
     setDebugLevel(aux.debugLevel);
@@ -94,10 +94,10 @@ public:
     }
   }
 
-  virtual bool check (const std::string &proto,
+  bool check (const std::string &proto,
 		      const std::string &path,
           const AuxSettings& aux,
-		      IOOffset *size = 0) const override
+		      IOOffset *size = nullptr) const override
   {
     setDebugLevel(aux.debugLevel);
     setTimeout(aux.timeout);

--- a/Utilities/XrdAdaptor/src/XrdFile.cc
+++ b/Utilities/XrdAdaptor/src/XrdFile.cc
@@ -6,7 +6,7 @@
 #include <vector>
 #include <sstream>
 #include <iostream>
-#include <assert.h>
+#include <cassert>
 #include <chrono>
 
 using namespace XrdAdaptor;
@@ -95,7 +95,7 @@ XrdFile::open (const char *name,
                int perms /* = 066 */)
 {
   // Actual open
-  if ((name == 0) || (*name == 0)) {
+  if ((name == nullptr) || (*name == 0)) {
     edm::Exception ex(edm::errors::FileOpenError);
     ex << "Cannot open a file without a name";
     ex.addContext("Calling XrdFile::open()");
@@ -152,7 +152,7 @@ XrdFile::open (const char *name,
   // Stat the file so we can keep track of the offset better.
   auto file = getActiveFile();
   XrdCl::XRootDStatus status;
-  XrdCl::StatInfo *statInfo = NULL;
+  XrdCl::StatInfo *statInfo = nullptr;
   if (! (status = file->Stat(false, statInfo)).IsOK()) {
     edm::Exception ex(edm::errors::FileOpenError);
     ex << "XrdCl::File::Stat(name='" << name

--- a/Utilities/XrdAdaptor/src/XrdFile.h
+++ b/Utilities/XrdAdaptor/src/XrdFile.h
@@ -21,7 +21,7 @@ public:
   XrdFile (IOFD fd);
   XrdFile (const char *name, int flags = IOFlags::OpenRead, int perms = 0666);
   XrdFile (const std::string &name, int flags = IOFlags::OpenRead, int perms = 0666);
-  ~XrdFile (void);
+  ~XrdFile (void) override;
 
   virtual void	create (const char *name,
     			bool exclusive = false,
@@ -41,18 +41,18 @@ public:
   using Storage::write;
   using Storage::position;
 
-  virtual bool		prefetch (const IOPosBuffer *what, IOSize n);
-  virtual IOSize	read (void *into, IOSize n);
-  virtual IOSize	read (void *into, IOSize n, IOOffset pos);
-  virtual IOSize	readv (IOBuffer *into, IOSize n);
-  virtual IOSize	readv (IOPosBuffer *into, IOSize n);
-  virtual IOSize	write (const void *from, IOSize n);
-  virtual IOSize	write (const void *from, IOSize n, IOOffset pos);
+  bool		prefetch (const IOPosBuffer *what, IOSize n) override;
+  IOSize	read (void *into, IOSize n) override;
+  IOSize	read (void *into, IOSize n, IOOffset pos) override;
+  IOSize	readv (IOBuffer *into, IOSize n) override;
+  IOSize	readv (IOPosBuffer *into, IOSize n) override;
+  IOSize	write (const void *from, IOSize n) override;
+  IOSize	write (const void *from, IOSize n, IOOffset pos) override;
 
-  virtual IOOffset	position (IOOffset offset, Relative whence = SET);
-  virtual void		resize (IOOffset size);
+  IOOffset	position (IOOffset offset, Relative whence = SET) override;
+  void		resize (IOOffset size) override;
 
-  virtual void		close (void);
+  void		close (void) override;
   virtual void		abort (void);
 
 private:

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.h
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.h
@@ -250,12 +250,12 @@ private:
             return instance;
         }
 
-        ~OpenHandler();
+        ~OpenHandler() override;
 
         /**
          * Handle the file-open response
          */
-        virtual void HandleResponseWithHosts(XrdCl::XRootDStatus *status, XrdCl::AnyObject *response, XrdCl::HostList *hostList) override;
+        void HandleResponseWithHosts(XrdCl::XRootDStatus *status, XrdCl::AnyObject *response, XrdCl::HostList *hostList) override;
 
         /**
          * Future-based version of the handler


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this tomorrow to avoid conflicts to the extent possible]