### PR TITLE
Clang-tidy checks for TBDataFormats

### DIFF
--- a/TBDataFormats/EcalTBObjects/interface/EcalTBHodoscopePlaneRawHits.h
+++ b/TBDataFormats/EcalTBObjects/interface/EcalTBHodoscopePlaneRawHits.h
@@ -20,7 +20,7 @@ class EcalTBHodoscopePlaneRawHits {
     {
       rawChannelHits_.reserve(channels);
       for (unsigned int i=0;i<channels;i++)
-	rawChannelHits_[i]=0;
+	rawChannelHits_[i]=false;
     }
   
   /// Get Methods

--- a/TBDataFormats/HcalTBObjects/src/HcalTBTriggerData.cc
+++ b/TBDataFormats/HcalTBObjects/src/HcalTBTriggerData.cc
@@ -1,6 +1,6 @@
 #include "TBDataFormats/HcalTBObjects/interface/HcalTBTriggerData.h"
 #include <cstdio>
-#include <stdint.h>
+#include <cstdint>
 
 using namespace std;
 


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this tomorrow to avoid conflicts to the extent possible]