### PR TITLE
Clang-tidy checks for RecoRomanPot

### DIFF
--- a/RecoRomanPot/RecoFP420/interface/ClusterizerFP420.h
+++ b/RecoRomanPot/RecoFP420/interface/ClusterizerFP420.h
@@ -36,14 +36,14 @@ namespace cms
     
     explicit ClusterizerFP420(const edm::ParameterSet& conf);
     
-    virtual ~ClusterizerFP420();
+    ~ClusterizerFP420() override;
     
-    virtual void beginJob();
+    void beginJob() override;
     
     //  virtual void produce(DigiCollectionFP420*, ClusterCollectionFP420 &);
     // virtual void produce(DigiCollectionFP420 &, ClusterCollectionFP420 &);
     
-    virtual void produce(edm::Event& e, const edm::EventSetup& c);
+    void produce(edm::Event& e, const edm::EventSetup& c) override;
     
   private:
     typedef std::vector<std::string> vstring;

--- a/RecoRomanPot/RecoFP420/interface/ReconstructerFP420.h
+++ b/RecoRomanPot/RecoFP420/interface/ReconstructerFP420.h
@@ -30,12 +30,12 @@ namespace cms
     explicit ReconstructerFP420(const edm::ParameterSet& conf);
     //ReconstructerFP420();
     
-    virtual ~ReconstructerFP420();
+    ~ReconstructerFP420() override;
     
-    virtual void beginJob();
+    void beginJob() override;
     
     //  virtual void produce(ClusterCollectionFP420 &, RecoCollectionFP420 &);
-    virtual void produce(edm::Event& e, const edm::EventSetup& c);
+    void produce(edm::Event& e, const edm::EventSetup& c) override;
     
   private:
     typedef std::vector<std::string> vstring;

--- a/RecoRomanPot/RecoFP420/interface/TrackerizerFP420.h
+++ b/RecoRomanPot/RecoFP420/interface/TrackerizerFP420.h
@@ -34,12 +34,12 @@ namespace cms
     explicit TrackerizerFP420(const edm::ParameterSet& conf);
     //TrackerizerFP420();
     
-    virtual ~TrackerizerFP420();
+    ~TrackerizerFP420() override;
     
-    virtual void beginJob();
+    void beginJob() override;
     
     //  virtual void produce(ClusterCollectionFP420 &, TrackCollectionFP420 &);
-    virtual void produce(edm::Event& e, const edm::EventSetup& c);
+    void produce(edm::Event& e, const edm::EventSetup& c) override;
     
   private:
     typedef std::vector<std::string> vstring;

--- a/RecoRomanPot/RecoFP420/src/FP420ClusterMain.cc
+++ b/RecoRomanPot/RecoFP420/src/FP420ClusterMain.cc
@@ -108,7 +108,7 @@ FP420ClusterMain::FP420ClusterMain(const edm::ParameterSet& conf, int dn, int sn
 }
 
 FP420ClusterMain::~FP420ClusterMain() {
-  if ( threeThreshold_ != 0 ) {
+  if ( threeThreshold_ != nullptr ) {
     delete threeThreshold_;
   }
 }
@@ -194,7 +194,7 @@ void FP420ClusterMain::run(edm::Handle<DigiCollectionFP420> &input, ClusterColle
 	    for ( ;sort_begin != sort_end; ++sort_begin ) {
 	      dcollector.push_back(*sort_begin);
 	    } // for
-	    if (dcollector.size()>0) {
+	    if (!dcollector.empty()) {
 	      
 	      DigiCollectionFP420::ContainerIterator digiRangeIteratorBegin = digiRange.first;
 	      DigiCollectionFP420::ContainerIterator digiRangeIteratorEnd   = digiRange.second;
@@ -264,7 +264,7 @@ void FP420ClusterMain::run(edm::Handle<DigiCollectionFP420> &input, ClusterColle
 		  
 		}// if (UseNoiseBadElectrodeFlagFromDB
 		
-		if (collector.size()>0){
+		if (!collector.empty()){
 		  ClusterCollectionFP420::Range inputRange;
 		  inputRange.first = collector.begin();
 		  inputRange.second = collector.end();

--- a/RecoRomanPot/RecoFP420/src/FP420RecoMain.cc
+++ b/RecoRomanPot/RecoFP420/src/FP420RecoMain.cc
@@ -19,7 +19,7 @@
 
 // #include "CLHEP/Vector/LorentzVector.h"
 // #include "CLHEP/Random/RandFlat.h"
-#include <math.h>
+#include <cmath>
 
 using namespace std;
 
@@ -53,7 +53,7 @@ FP420RecoMain::FP420RecoMain(const edm::ParameterSet& conf):conf_(conf)  {
 }
 
 FP420RecoMain::~FP420RecoMain() {
-  if ( finderParameters_ != 0 ) {
+  if ( finderParameters_ != nullptr ) {
     delete finderParameters_;
   }
 }
@@ -161,7 +161,7 @@ void FP420RecoMain::run(edm::Handle<TrackCollectionFP420> &input, RecoCollection
     if (verbosity > 1) {
       std::cout << "FP420RecoMain: track rcollector.size=" << rcollector.size() << std::endl;
     }
-    if (rcollector.size()>0){
+    if (!rcollector.empty()){
       RecoCollectionFP420::Range rinputRange;
       rinputRange.first = rcollector.begin();
       rinputRange.second = rcollector.end();

--- a/RecoRomanPot/RecoFP420/src/FP420TrackMain.cc
+++ b/RecoRomanPot/RecoFP420/src/FP420TrackMain.cc
@@ -127,7 +127,7 @@ FP420TrackMain::FP420TrackMain(const edm::ParameterSet& conf):conf_(conf)  {
 }
 
 FP420TrackMain::~FP420TrackMain() {
-  if ( finderParameters_ != 0 ) {
+  if ( finderParameters_ != nullptr ) {
     delete finderParameters_;
   }
 }
@@ -201,7 +201,7 @@ void FP420TrackMain::run(edm::Handle<ClusterCollectionFP420> &input, TrackCollec
       //	 collector = finderParameters_->trackFinder3D(input); //
       // }// if ( trackMode
       
-      if (collector.size()>0){
+      if (!collector.empty()){
 	TrackCollectionFP420::Range inputRange;
 	inputRange.first = collector.begin();
 	inputRange.second = collector.end();

--- a/RecoRomanPot/RecoFP420/src/RecoProducerFP420.cc
+++ b/RecoRomanPot/RecoFP420/src/RecoProducerFP420.cc
@@ -7,7 +7,7 @@
 
 #include "CLHEP/Vector/LorentzVector.h"
 
-#include <math.h>
+#include <cmath>
 
 //#include <iostream>
 

--- a/RecoRomanPot/RecoFP420/src/TrackProducerFP420.cc
+++ b/RecoRomanPot/RecoFP420/src/TrackProducerFP420.cc
@@ -5,7 +5,7 @@
 // Modifications: 
 ///////////////////////////////////////////////////////////////////////////////
 #include "RecoRomanPot/RecoFP420/interface/TrackProducerFP420.h"
-#include <stdio.h>
+#include <cstdio>
 #include <gsl/gsl_fit.h>
 #include<vector>
 #include <iostream>


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this quickly to avoid conflicts to the extent possible]