### PR TITLE
Clang-tidy checks for RecoTracker

### DIFF
--- a/RecoTracker/CkfPattern/interface/CachingSeedCleanerByHitPosition.h
+++ b/RecoTracker/CkfPattern/interface/CachingSeedCleanerByHitPosition.h
@@ -7,19 +7,19 @@ class CachingSeedCleanerByHitPosition : public RedundantSeedCleaner  {
   public:
 
    /** In this implementation, it does nothing */
-   virtual void add(const Trajectory *traj) ;
+   void add(const Trajectory *traj) override ;
 
    /** \brief Provides the cleaner a pointer to the vector where trajectories are stored, in case it does not want to keep a local collection of trajectories */
-   virtual void init(const std::vector<Trajectory> *vect) ;
+   void init(const std::vector<Trajectory> *vect) override ;
 
-   virtual void done() ;
+   void done() override ;
    
    /** \brief Returns true if the seed is not overlapping with another trajectory */
-   virtual bool good(const TrajectorySeed *seed) ;
+   bool good(const TrajectorySeed *seed) override ;
 
    CachingSeedCleanerByHitPosition() : RedundantSeedCleaner(), theVault(), theCache()
                                             /*, comps_(0), tracks_(0), calls_(0)*/ {}
-   virtual ~CachingSeedCleanerByHitPosition() { theVault.clear(); theCache.clear(); }
+   ~CachingSeedCleanerByHitPosition() override { theVault.clear(); theCache.clear(); }
   private:
     std::vector<Trajectory::RecHitContainer> theVault;
     std::multimap<uint32_t, unsigned int> theCache;

--- a/RecoTracker/CkfPattern/interface/CachingSeedCleanerBySharedInput.h
+++ b/RecoTracker/CkfPattern/interface/CachingSeedCleanerBySharedInput.h
@@ -9,22 +9,22 @@ class CachingSeedCleanerBySharedInput : public RedundantSeedCleaner  {
   public:
 
    /** In this implementation, it does nothing */
-   virtual void add(const Trajectory *traj) ;
+   void add(const Trajectory *traj) override ;
 
    /** \brief Provides the cleaner a pointer to the vector where trajectories are stored, in case it does not want to keep a local collection of trajectories */
-   virtual void init(const std::vector<Trajectory> *vect) ;
+   void init(const std::vector<Trajectory> *vect) override ;
 
-   virtual void done() ;
+   void done() override ;
    
    /** \brief Returns true if the seed is not overlapping with another trajectory */
-   virtual bool good(const TrajectorySeed *seed) ;
+   bool good(const TrajectorySeed *seed) override ;
 
  CachingSeedCleanerBySharedInput(unsigned int numHitsForSeedCleaner=4,
 				 bool onlyPixelHits=false) : 
    RedundantSeedCleaner(), theVault(), theCache(),
    theNumHitsForSeedCleaner(numHitsForSeedCleaner),theOnlyPixelHits(onlyPixelHits){}
 
-   virtual ~CachingSeedCleanerBySharedInput() { theVault.clear(); theCache.clear(); }
+   ~CachingSeedCleanerBySharedInput() override { theVault.clear(); theCache.clear(); }
   private:
     std::vector<Trajectory::RecHitContainer> theVault;
     //std::multimap<uint32_t, unsigned int> theCache;

--- a/RecoTracker/CkfPattern/interface/SeedCleanerByHitPosition.h
+++ b/RecoTracker/CkfPattern/interface/SeedCleanerByHitPosition.h
@@ -5,18 +5,18 @@
 class SeedCleanerByHitPosition : public RedundantSeedCleaner  {
   public:
    /** In this implementation, it does nothing */
-   virtual void add(const Trajectory *traj) { }
+   void add(const Trajectory *traj) override { }
 
    /** \brief Provides the cleaner a pointer to the vector where trajectories are stored, in case it does not want to keep a local collection of trajectories */
-   virtual void init(const std::vector<Trajectory> *vect) { trajectories = vect; }
+   void init(const std::vector<Trajectory> *vect) override { trajectories = vect; }
 
-   virtual void done() ;
+   void done() override ;
    
    /** \brief Returns true if the seed is not overlapping with another trajectory */
-   virtual bool good(const TrajectorySeed *seed) ;
+   bool good(const TrajectorySeed *seed) override ;
 
    
-   SeedCleanerByHitPosition() : RedundantSeedCleaner(), trajectories(0) /*,comps_(0), tracks_(0), calls_(0)*/ {}
+   SeedCleanerByHitPosition() : RedundantSeedCleaner(), trajectories(nullptr) /*,comps_(0), tracks_(0), calls_(0)*/ {}
   private:
    const std::vector<Trajectory> *trajectories; 
    //uint64_t comps_, tracks_, calls_;

--- a/RecoTracker/CkfPattern/interface/SeedCleanerBySharedInput.h
+++ b/RecoTracker/CkfPattern/interface/SeedCleanerBySharedInput.h
@@ -8,18 +8,18 @@
 class SeedCleanerBySharedInput : public RedundantSeedCleaner  {
   public:
    /** In this implementation, it does nothing */
-   virtual void add(const Trajectory *traj) { }
+   void add(const Trajectory *traj) override { }
 
    /** \brief Provides the cleaner a pointer to the vector where trajectories are stored, in case it does not want to keep a local collection of trajectories */
-   virtual void init(const std::vector<Trajectory> *vect) { trajectories = vect; }
+   void init(const std::vector<Trajectory> *vect) override { trajectories = vect; }
 
-   virtual void done() { trajectories = 0; };
+   void done() override { trajectories = nullptr; };
    
    /** \brief Returns true if the seed is not overlapping with another trajectory */
-   virtual bool good(const TrajectorySeed *seed) ;
+   bool good(const TrajectorySeed *seed) override ;
 
    
-   SeedCleanerBySharedInput() : RedundantSeedCleaner(), trajectories(0) {}
+   SeedCleanerBySharedInput() : RedundantSeedCleaner(), trajectories(nullptr) {}
   private:
    const std::vector<Trajectory> *trajectories; 
    

--- a/RecoTracker/CkfPattern/plugins/CkfTrackCandidateMaker.h
+++ b/RecoTracker/CkfPattern/plugins/CkfTrackCandidateMaker.h
@@ -33,11 +33,11 @@ namespace cms
       produces<std::vector<SeedStopInfo> >();
     }
 
-    virtual ~CkfTrackCandidateMaker(){;}
+    ~CkfTrackCandidateMaker() override{;}
 
-    virtual void beginRun (edm::Run const& r, edm::EventSetup const & es) override {beginRunBase(r,es);}
+    void beginRun (edm::Run const& r, edm::EventSetup const & es) override {beginRunBase(r,es);}
 
-    virtual void produce(edm::Event& e, const edm::EventSetup& es) override {produceBase(e,es);}
+    void produce(edm::Event& e, const edm::EventSetup& es) override {produceBase(e,es);}
     
   };
 }

--- a/RecoTracker/CkfPattern/plugins/CkfTrajectoryMaker.h
+++ b/RecoTracker/CkfPattern/plugins/CkfTrajectoryMaker.h
@@ -39,11 +39,11 @@ namespace cms
       produces<std::vector<SeedStopInfo> >();
     }
 
-    virtual ~CkfTrajectoryMaker(){;}
+    ~CkfTrajectoryMaker() override{;}
 
-    virtual void beginRun (edm::Run const & run, edm::EventSetup const & es) override {beginRunBase(run,es);}
+    void beginRun (edm::Run const & run, edm::EventSetup const & es) override {beginRunBase(run,es);}
 
-    virtual void produce(edm::Event& e, const edm::EventSetup& es) override {produceBase(e,es);}
+    void produce(edm::Event& e, const edm::EventSetup& es) override {produceBase(e,es);}
   };
 }
 

--- a/RecoTracker/CkfPattern/src/SeedCleanerByHitPosition.cc
+++ b/RecoTracker/CkfPattern/src/SeedCleanerByHitPosition.cc
@@ -7,7 +7,7 @@ void SeedCleanerByHitPosition::done() {
         // edm::LogInfo("SeedCleanerByHitPosition") << " Calls: " << calls_ << ", Tracks: " << tracks_ <<", Comps: " << comps_  << " Vault: " << trajectories->size() << ".";
         // calls_ = comps_ = tracks_ = 0;
 
-        trajectories = 0; 
+        trajectories = nullptr; 
 }
 bool SeedCleanerByHitPosition::good(const TrajectorySeed *seed) {
     const RecHitComparatorByPosition comp;

--- a/RecoTracker/ConversionSeedGenerators/interface/IdealHelixParameters.h
+++ b/RecoTracker/ConversionSeedGenerators/interface/IdealHelixParameters.h
@@ -23,7 +23,7 @@ class IdealHelixParameters{
  public:
 
  IdealHelixParameters():
-  _magnField(0),_track(0),
+  _magnField(nullptr),_track(nullptr),
     _refPoint               (math::XYZVector(0,0,0)),
     _tangentPoint           (math::XYZVector(0,0,0)),
     _MomentumAtTangentPoint(math::XYZVector(0,0,0)){};

--- a/RecoTracker/ConversionSeedGenerators/plugins/CombinedHitQuadrupletGeneratorForPhotonConversion.h
+++ b/RecoTracker/ConversionSeedGenerators/plugins/CombinedHitQuadrupletGeneratorForPhotonConversion.h
@@ -37,7 +37,7 @@ public:
 
   /*------------------------*/
 private:
-  CombinedHitQuadrupletGeneratorForPhotonConversion(const CombinedHitQuadrupletGeneratorForPhotonConversion & cb); 
+  CombinedHitQuadrupletGeneratorForPhotonConversion(const CombinedHitQuadrupletGeneratorForPhotonConversion & cb) = delete; 
 
   edm::EDGetTokenT<SeedingLayerSetsHits> theSeedingLayerToken;
   const unsigned int theMaxElement;

--- a/RecoTracker/ConversionSeedGenerators/plugins/Conv4HitsReco.h
+++ b/RecoTracker/ConversionSeedGenerators/plugins/Conv4HitsReco.h
@@ -3,7 +3,7 @@
 
 #include <iostream>
 #include <iomanip>
-#include <math.h>
+#include <cmath>
 
 #include <TVector3.h>
 

--- a/RecoTracker/ConversionSeedGenerators/plugins/Conv4HitsReco2.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/Conv4HitsReco2.cc
@@ -11,7 +11,7 @@
 //#include "Conv4HitsReco2.h"
 //#include "FWCore/MessegeLogger/interface/MessegeLogger.h"
 #include "Conv4HitsReco2.h"
-#include <time.h>
+#include <ctime>
 
 Conv4HitsReco2::Conv4HitsReco2(math::XYZVector &vPhotVertex, math::XYZVector &h1, math::XYZVector &h2, math::XYZVector &h3, math::XYZVector &h4)
 {

--- a/RecoTracker/ConversionSeedGenerators/plugins/Conv4HitsReco2.h
+++ b/RecoTracker/ConversionSeedGenerators/plugins/Conv4HitsReco2.h
@@ -11,7 +11,7 @@
 
 #include <iostream>
 #include <iomanip>
-#include <math.h>
+#include <cmath>
 #include "DataFormats/Math/interface/Vector3D.h"
 #include "DataFormats/Math/interface/Point3D.h"
 

--- a/RecoTracker/ConversionSeedGenerators/plugins/ConversionSeedFilter.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/ConversionSeedFilter.cc
@@ -41,10 +41,10 @@
 class ConversionSeedFilter : public edm::stream::EDProducer<> {
 public:
   explicit ConversionSeedFilter(const edm::ParameterSet&);
-  ~ConversionSeedFilter();
+  ~ConversionSeedFilter() override;
   
 private:
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
   bool isCompatible(double *vars1, double* vars2);
   void getKine(const TrajectoryStateOnSurface& tsos, double *vars);
   void SearchAmongSeeds(const TrajectorySeedCollection* pInPos,const TrajectorySeedCollection* pInNeg, TrajectorySeedCollection& selectedColl, std::vector<bool>& idxPosColl1, std::vector<bool>& idxPosColl2);

--- a/RecoTracker/ConversionSeedGenerators/plugins/ConversionSeedFilterCharge.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/ConversionSeedFilterCharge.cc
@@ -37,10 +37,10 @@
 class ConversionSeedFilterCharge : public edm::global::EDProducer<> {
 public:
   explicit ConversionSeedFilterCharge(const edm::ParameterSet&);
-  ~ConversionSeedFilterCharge();
+  ~ConversionSeedFilterCharge() override;
   
 private:
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   edm::EDGetTokenT<TrajectorySeedCollection> inputCollPos;
   edm::EDGetTokenT<TrajectorySeedCollection> inputCollNeg;
   const double deltaPhiCut, deltaCotThetaCut, deltaRCut, deltaZCut;

--- a/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromQuadruplets.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromQuadruplets.cc
@@ -16,7 +16,7 @@
 class PhotonConversionTrajectorySeedProducerFromQuadruplets : public edm::stream::EDProducer<> {
 public:
   PhotonConversionTrajectorySeedProducerFromQuadruplets(const edm::ParameterSet& );
-  ~PhotonConversionTrajectorySeedProducerFromQuadruplets(){}
+  ~PhotonConversionTrajectorySeedProducerFromQuadruplets() override{}
   void produce(edm::Event& , const edm::EventSetup& ) override;
 
 private:
@@ -40,7 +40,7 @@ void PhotonConversionTrajectorySeedProducerFromQuadruplets::produce(edm::Event& 
   auto result = std::make_unique<TrajectorySeedCollection>();  
   try{
     _theFinder->analyze(ev,es);
-    if(_theFinder->getTrajectorySeedCollection()->size())
+    if(!_theFinder->getTrajectorySeedCollection()->empty())
       result->insert(result->end(),
 		     _theFinder->getTrajectorySeedCollection()->begin(),
 		     _theFinder->getTrajectorySeedCollection()->end());

--- a/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromQuadrupletsAlgo.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromQuadrupletsAlgo.cc
@@ -21,7 +21,7 @@ assign the parameters to some data member to avoid search at every event
 PhotonConversionTrajectorySeedProducerFromQuadrupletsAlgo::
 PhotonConversionTrajectorySeedProducerFromQuadrupletsAlgo(const edm::ParameterSet & conf,
 	edm::ConsumesCollector && iC)
-  :_conf(conf),seedCollection(0),
+  :_conf(conf),seedCollection(nullptr),
    theClusterCheck(conf.getParameter<edm::ParameterSet>("ClusterCheckPSet"), iC),
    QuadCutPSet(conf.getParameter<edm::ParameterSet>("QuadCutPSet")),
    theSilentOnClusterCheck(conf.getParameter<edm::ParameterSet>("ClusterCheckPSet").getUntrackedParameter<bool>("silentClusterCheck",false)),
@@ -43,7 +43,7 @@ analyze(const edm::Event & event, const edm::EventSetup &setup){
   myEsetup = &setup;
   myEvent = &event;
 
-  if(seedCollection!=0)
+  if(seedCollection!=nullptr)
     delete seedCollection;
 
   seedCollection= new TrajectorySeedCollection();

--- a/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromSingleLeg.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromSingleLeg.cc
@@ -15,7 +15,7 @@
 class dso_hidden PhotonConversionTrajectorySeedProducerFromSingleLeg final : public edm::stream::EDProducer<> {
 public:
   PhotonConversionTrajectorySeedProducerFromSingleLeg(const edm::ParameterSet& );
-  ~PhotonConversionTrajectorySeedProducerFromSingleLeg(){delete _theFinder;}
+  ~PhotonConversionTrajectorySeedProducerFromSingleLeg() override{delete _theFinder;}
   PhotonConversionTrajectorySeedProducerFromSingleLeg(const PhotonConversionTrajectorySeedProducerFromSingleLeg&)=delete;
   PhotonConversionTrajectorySeedProducerFromSingleLeg& operator=(const PhotonConversionTrajectorySeedProducerFromSingleLeg&)=delete;
   void produce(edm::Event& , const edm::EventSetup& ) override;

--- a/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromSingleLegAlgo.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromSingleLegAlgo.cc
@@ -181,7 +181,7 @@ selectPriVtxCompatibleWithTrack(const reco::Track& tk, std::vector<reco::Vertex>
       
     idx.push_back(std::pair<double,short>(fabs(_dz),count));
   }
-  if(idx.size()==0) {
+  if(idx.empty()) {
 #ifdef debugTSPFSLA
     ss << "no vertex selected " << std::endl; 
 #endif

--- a/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversion1Leg.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversion1Leg.cc
@@ -31,7 +31,7 @@ const TrajectorySeed * SeedForPhotonConversion1Leg::trajectorySeed(
     float cotTheta, std::stringstream& ss)
 {
   pss = &ss;
-  if ( hits.size() < 2) return 0;
+  if ( hits.size() < 2) return nullptr;
 
   GlobalTrajectoryParameters kine = initialKinematic(hits, vertex, es, cotTheta);
   float sinTheta = sin(kine.momentum().theta());
@@ -163,23 +163,23 @@ const TrajectorySeed * SeedForPhotonConversion1Leg::buildSeed(
   TrajectoryStateOnSurface updatedState;
   edm::OwnVector<TrackingRecHit> seedHits;
   
-  const TrackingRecHit* hit = 0;
+  const TrackingRecHit* hit = nullptr;
   for ( unsigned int iHit = 0; iHit < hits.size() && iHit<1; iHit++) {
     hit = hits[iHit];
     TrajectoryStateOnSurface state = (iHit==0) ? 
       propagator->propagate(fts,tracker->idToDet(hit->geographicalId())->surface())
       : propagator->propagate(updatedState, tracker->idToDet(hit->geographicalId())->surface());
-    if (!state.isValid()) return 0;
+    if (!state.isValid()) return nullptr;
     
     SeedingHitSet::ConstRecHitPointer tth = hits[iHit]; 
     
     std::unique_ptr<BaseTrackerRecHit> newtth(refitHit( tth, state));
 
     
-    if (!checkHit(state,&*newtth,es)) return 0;
+    if (!checkHit(state,&*newtth,es)) return nullptr;
 
     updatedState =  updator.update(state, *newtth);
-    if (!updatedState.isValid()) return 0;
+    if (!updatedState.isValid()) return nullptr;
     
     seedHits.push_back(newtth.release());
 #ifdef mydebug_seed

--- a/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversionFromQuadruplets.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/SeedForPhotonConversionFromQuadruplets.cc
@@ -70,7 +70,7 @@ const TrajectorySeed * SeedForPhotonConversionFromQuadruplets::trajectorySeed(
 
 
 	bool rejectAllQuads=QuadCutPSet.getParameter<bool>("rejectAllQuads");
-	if(rejectAllQuads) return 0;
+	if(rejectAllQuads) return nullptr;
 
 	bool applyDeltaPhiCuts=QuadCutPSet.getParameter<bool>("apply_DeltaPhiCuts");
     bool ClusterShapeFiltering=QuadCutPSet.getParameter<bool>("apply_ClusterShapeFilter");
@@ -88,8 +88,8 @@ const TrajectorySeed * SeedForPhotonConversionFromQuadruplets::trajectorySeed(
 
   pss = &ss;
 
-  if ( phits.size() < 2) return 0;
-  if ( mhits.size() < 2) return 0;
+  if ( phits.size() < 2) return nullptr;
+  if ( mhits.size() < 2) return nullptr;
 
   //PUT HERE THE QUADRUPLET ALGORITHM, AND IN CASE USE THE METHODS ALREADY DEVELOPED, ADAPTING THEM
 
@@ -117,7 +117,7 @@ const TrajectorySeed * SeedForPhotonConversionFromQuadruplets::trajectorySeed(
   vHit[3]=mtth2->globalPosition();
 
   //Photon source vertex primary vertex
-  GlobalPoint vgPhotVertex=region.origin();
+  const GlobalPoint& vgPhotVertex=region.origin();
   math::XYZVector vPhotVertex(vgPhotVertex.x(), vgPhotVertex.y(), vgPhotVertex.z());
 
   math::XYZVector h1(vHit[0].x(),vHit[0].y(),vHit[0].z());
@@ -198,7 +198,7 @@ than CleaningmaxRadialDistance cm, the combination is rejected.
   double maxIPrho2=IPrho+CleaningmaxRadialDistance; maxIPrho2*=maxIPrho2;
 
   if( IPrho<BeamPipeRadiusCut || P1rho2>maxIPrho2 || M1rho2>maxIPrho2){
-	  return 0;
+	  return nullptr;
   }
 
   if(applyDeltaPhiCuts) {
@@ -320,7 +320,7 @@ std::cout << "d" << d << std::endl;
     double DeltaPhiManualM1P1=DeltaPhiManual(M1,P1);
 
 if(DeltaPhiManualM1P1>DeltaPhiMaxM1P1+tol_DeltaPhiMaxM1P1 || DeltaPhiManualM1P1<0-tol_DeltaPhiMaxM1P1){
-	return 0;
+	return nullptr;
 }
 
   }//if rMax > rLayerM1
@@ -385,13 +385,13 @@ if(DeltaPhiManualM1P1>DeltaPhiMaxM1P1+tol_DeltaPhiMaxM1P1 || DeltaPhiManualM1P1<
 		    double DeltaPhiManualM2M1=DeltaPhiManual(M2,M1);
 
 		  if(DeltaPhiManualM2M1>DeltaPhiMaxM2+tol_DeltaPhiMaxM2 || DeltaPhiManualM2M1<0-tol_DeltaPhiMaxM2){
-			  return 0;
+			  return nullptr;
 		  }
 
 		  //Using the lazy solution for P2: DeltaPhiMaxP2=DeltaPhiMaxM2
 		  double DeltaPhiManualP1P2=DeltaPhiManual(P1,P2);
 		  if(DeltaPhiManualP1P2>DeltaPhiMaxM2+tol_DeltaPhiMaxM2 || DeltaPhiManualP1P2<0-tol_DeltaPhiMaxM2){
-		  	return 0;
+		  	return nullptr;
 		  }
 
 	  }
@@ -418,7 +418,7 @@ if(DeltaPhiManualM1P1>DeltaPhiMaxM1P1+tol_DeltaPhiMaxM1P1 || DeltaPhiManualM1P1<
   //double rPlus, rMinus;
   int nite = quad.ConversionCandidate(candVtx, candPtPlus, candPtMinus);
 
-  if ( ! (nite && abs(nite) < 25 && nite != -1000 && nite != -2000) ) return 0;
+  if ( ! (nite && abs(nite) < 25 && nite != -1000 && nite != -2000) ) return nullptr;
 
 //  math::XYZVector plusCenter = quad.GetPlusCenter(rPlus);
 //  math::XYZVector minusCenter = quad.GetMinusCenter(rMinus);
@@ -434,17 +434,17 @@ if(DeltaPhiManualM1P1>DeltaPhiMaxM1P1+tol_DeltaPhiMaxM1P1 || DeltaPhiManualM1P1<
 
     //
     // Cut on leg's transverse momenta
-    if ( candPtPlus < minLegPt ) return 0;
-    if ( candPtMinus < minLegPt ) return 0;
+    if ( candPtPlus < minLegPt ) return nullptr;
+    if ( candPtMinus < minLegPt ) return nullptr;
     //
-    if ( candPtPlus > maxLegPt ) return 0;
-    if ( candPtMinus > maxLegPt ) return 0;
+    if ( candPtPlus > maxLegPt ) return nullptr;
+    if ( candPtMinus > maxLegPt ) return nullptr;
     //
     // Cut on radial distance between estimated conversion vertex and inner hits
     double cr = std::sqrt(candVtx.Perp2());
     double maxr2 = (maxRadialDistance + cr); maxr2*=maxr2;
-    if (h2.Perp2() > maxr2) return 0;
-    if (h3.Perp2() > maxr2) return 0;
+    if (h2.Perp2() > maxr2) return nullptr;
+    if (h3.Perp2() > maxr2) return nullptr;
 
 
 // At this point implement cleaning cuts after building the seed
@@ -476,8 +476,8 @@ if(DeltaPhiManualM1P1>DeltaPhiMaxM1P1+tol_DeltaPhiMaxM1P1 || DeltaPhiManualM1P1<
 		  FastHelix mhelix(mtth2->globalPosition(), mtth1->globalPosition(), vertexPos, nomField,&*bfield, vertexPos);
 		  mkine = mhelix.stateAtVertex();
 
-		  if(theComparitor&&!theComparitor->compatible(phits, pkine, phelix)) { return 0; }
-		  if(theComparitor&&!theComparitor->compatible(mhits, mkine, mhelix)) { return 0; }
+		  if(theComparitor&&!theComparitor->compatible(phits, pkine, phelix)) { return nullptr; }
+		  if(theComparitor&&!theComparitor->compatible(mhits, mkine, mhelix)) { return nullptr; }
     }
 
 
@@ -505,7 +505,7 @@ if(DeltaPhiManualM1P1>DeltaPhiMaxM1P1+tol_DeltaPhiMaxM1P1 || DeltaPhiManualM1P1<
     thisQuad.ptPlus = candPtPlus;
     thisQuad.ptMinus = candPtMinus;
     thisQuad.cot = quadPhotCotTheta;
-        if ( similarQuadExist(thisQuad, quadV) && applyArbitration ) return 0;
+        if ( similarQuadExist(thisQuad, quadV) && applyArbitration ) return nullptr;
 
     // not able to get the mag field... doing the dirty way
     //
@@ -593,7 +593,7 @@ if(DeltaPhiManualM1P1>DeltaPhiMaxM1P1+tol_DeltaPhiMaxM1P1 || DeltaPhiManualM1P1<
         buildSeed(seedCollection,mhits,ftsMinus,es,false,region);
 	}
 
-    return 0;
+    return nullptr;
 
 }
 
@@ -711,7 +711,7 @@ const TrajectorySeed * SeedForPhotonConversionFromQuadruplets::buildSeed(
   TrajectoryStateOnSurface updatedState;
   edm::OwnVector<TrackingRecHit> seedHits;
 
-  const TrackingRecHit* hit = 0;
+  const TrackingRecHit* hit = nullptr;
   for ( unsigned int iHit = 0; iHit < hits.size() && iHit<2; iHit++) {
     hit = hits[iHit];
     TrajectoryStateOnSurface state = (iHit==0) ?
@@ -781,7 +781,7 @@ bool SeedForPhotonConversionFromQuadruplets::buildSeedBool(
   TrajectoryStateOnSurface updatedState;
   edm::OwnVector<TrackingRecHit> seedHits;
 
-  const TrackingRecHit* hit = 0;
+  const TrackingRecHit* hit = nullptr;
   for ( unsigned int iHit = 0; iHit < hits.size() && iHit<2; iHit++) {
     hit = hits[iHit]->hit();
     TrajectoryStateOnSurface state = (iHit==0) ?

--- a/RecoTracker/DebugTools/interface/CkfDebugTrackCandidateMaker.h
+++ b/RecoTracker/DebugTools/interface/CkfDebugTrackCandidateMaker.h
@@ -15,13 +15,13 @@ namespace cms {
       produces<SeedStopInfo>();
     }
 
-    virtual void beginRun (edm::Run const & run, edm::EventSetup const & es) override {
+    void beginRun (edm::Run const & run, edm::EventSetup const & es) override {
       beginRunBase(run,es); 
       initDebugger(es);
     }
 
-    virtual void produce(edm::Event& e, const edm::EventSetup& es) override {produceBase(e,es);}
-    virtual void endJob() override {delete dbg; }
+    void produce(edm::Event& e, const edm::EventSetup& es) override {produceBase(e,es);}
+    void endJob() override {delete dbg; }
 
   private:
     virtual TrajectorySeedCollection::const_iterator 

--- a/RecoTracker/DebugTools/interface/CkfDebugTrajectoryBuilder.h
+++ b/RecoTracker/DebugTools/interface/CkfDebugTrajectoryBuilder.h
@@ -15,7 +15,7 @@ class CkfDebugTrajectoryBuilder: public CkfTrajectoryBuilder{
     }
 
 
-  virtual void setDebugger( CkfDebugger * dbg) const { theDbg = dbg;}
+  void setDebugger( CkfDebugger * dbg) const override { theDbg = dbg;}
   virtual CkfDebugger * debugger() const{ return theDbg;}
 
  private:
@@ -33,7 +33,7 @@ class CkfDebugTrajectoryBuilder: public CkfTrajectoryBuilder{
     return theDbg->analyseCompatibleMeasurements(traj,meas,theMeasurementTracker,theForwardPropagator,theEstimator,theTTRHBuilder);
   };
   void fillSeedHistoDebugger(std::vector<TrajectoryMeasurement>::iterator begin, 
-			     std::vector<TrajectoryMeasurement>::iterator end) const {
+			     std::vector<TrajectoryMeasurement>::iterator end) const override {
     //edm::LogVerbatim("CkfDebugger") <<"CkfDebugTrajectoryBuilder::fillSeedHistoDebugger "<<theDbg;
     if (end-begin>=2)
       theDbg->fillSeedHist(begin->recHit(),(begin+1)->recHit(),(begin+1)->updatedState());

--- a/RecoTracker/DebugTools/interface/TestHits.h
+++ b/RecoTracker/DebugTools/interface/TestHits.h
@@ -50,12 +50,12 @@
 class TestHits : public edm::EDAnalyzer {
 public:
   explicit TestHits(const edm::ParameterSet&);
-  ~TestHits();
+  ~TestHits() override;
 
 private:
-  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override;
+  void beginRun(edm::Run const& run, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
   std::pair<LocalPoint,LocalVector> projectHit(const PSimHit&, const StripGeomDetUnit*, const BoundPlane&);
 

--- a/RecoTracker/DebugTools/interface/TestSmoothHits.h
+++ b/RecoTracker/DebugTools/interface/TestSmoothHits.h
@@ -51,12 +51,12 @@
 class TestSmoothHits : public edm::EDAnalyzer {
 public:
   explicit TestSmoothHits(const edm::ParameterSet&);
-  ~TestSmoothHits();
+  ~TestSmoothHits() override;
 
 private:
-  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override;
+  void beginRun(edm::Run const& run, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
   std::pair<LocalPoint,LocalVector> projectHit(const PSimHit&, const StripGeomDetUnit*, const BoundPlane&);
 

--- a/RecoTracker/DebugTools/interface/TestTrackHits.h
+++ b/RecoTracker/DebugTools/interface/TestTrackHits.h
@@ -55,12 +55,12 @@
 class TestTrackHits : public edm::EDAnalyzer {
 public:
   explicit TestTrackHits(const edm::ParameterSet&);
-  ~TestTrackHits();
+  ~TestTrackHits() override;
 
 private:
-  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override;
+  void beginRun(edm::Run const& run, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
   std::pair<LocalPoint,LocalVector> projectHit(const PSimHit&, const StripGeomDetUnit*, const BoundPlane&);
 

--- a/RecoTracker/DebugTools/plugins/CkfDebugger.cc
+++ b/RecoTracker/DebugTools/plugins/CkfDebugger.cc
@@ -229,7 +229,7 @@ bool CkfDebugger::analyseCompatibleMeasurements(const Trajectory& traj,
   //const PSimHit* correctHit = nextCorrectHit(traj, trajId);
   //if ( correctHit == 0) return true; // no more simhits on this track
   std::vector<const PSimHit*> correctHits = nextCorrectHits(traj, trajId);
-  if ( correctHits.size() == 0) return true; // no more simhits on this track
+  if ( correctHits.empty()) return true; // no more simhits on this track
 
   for (std::vector<const PSimHit*>::iterator corHit=correctHits.begin();corHit!=correctHits.end();corHit++){
     for (std::vector<TM>::const_iterator i=meas.begin(); i!=meas.end(); i++) {
@@ -258,7 +258,7 @@ bool CkfDebugger::analyseCompatibleMeasurements(const Trajectory& traj,
 				      << " subdet " << i->recHit()->det()->geographicalId().subdetId() 
 				      << " Chi2 " << i->estimate() ;
     }
-    else if (i->recHit()->det() == 0) {
+    else if (i->recHit()->det() == nullptr) {
       edm::LogVerbatim("CkfDebugger") << "Invalid RecHit returned with zero Det pointer" ;
     }
     else if (i->recHit()->det() == det(correctHit)) {
@@ -273,7 +273,7 @@ bool CkfDebugger::analyseCompatibleMeasurements(const Trajectory& traj,
   //Look if the correct RecHit exists
   std::pair<CTTRHp, double> correctRecHit = 
     analyseRecHitExistance( *correctHit, traj.lastMeasurement().updatedState());
-  if (correctRecHit.first==0 ) {
+  if (correctRecHit.first==nullptr ) {
     //the hit does not exist or is uncorrectly matched
     if ( fabs(correctRecHit.second-0)<0.01 ) {dump[1]++;}//other
     if ( fabs(correctRecHit.second+1)<0.01 ) {dump[8]++;}//propagation
@@ -472,7 +472,7 @@ bool CkfDebugger::correctTrajectory( const Trajectory& traj,unsigned int& trajId
   Trajectory::RecHitContainer hits = traj.recHits();
 
   std::vector<SimHitIdpr> currentTrackId = hitAssociator->associateHitId(*hits.front()->hit());
-  if (currentTrackId.size() == 0) return false;
+  if (currentTrackId.empty()) return false;
 
   for (Trajectory::RecHitContainer::const_iterator rh=hits.begin(); rh!=hits.end(); ++rh) {
 
@@ -517,7 +517,7 @@ int CkfDebugger::assocTrackId(CTTRHp rechit) const
   }
 
   std::vector<SimHitIdpr> ids = hitAssociator->associateHitId(*rechit->hit());
-  if (ids.size()!=0) {
+  if (!ids.empty()) {
     return ids[0].first;//FIXME if size>1!!
   }
   else {
@@ -556,7 +556,7 @@ vector<const PSimHit*> CkfDebugger::nextCorrectHits( const Trajectory& traj, uns
   }
 
   //choose the simHit from the same track that has the highest tof
-  const PSimHit * lastPSH = 0;
+  const PSimHit * lastPSH = nullptr;
   if (!pSimHitVec.empty()) {
     float maxTOF = 0;
     for (std::vector<PSimHit>::const_iterator ch=pSimHitVec.begin(); ch!=pSimHitVec.end(); ++ch) {
@@ -567,7 +567,7 @@ vector<const PSimHit*> CkfDebugger::nextCorrectHits( const Trajectory& traj, uns
     }
   }
   else return result;//return empty vector: no more hits on the sim track
-  if (lastPSH == 0) return result; //return empty vector: no more good hits on the sim track
+  if (lastPSH == nullptr) return result; //return empty vector: no more good hits on the sim track
   edm::LogVerbatim("CkfDebugger") << "CkfDebugger: corresponding SimHit is at gpos " << position(&*lastPSH) ;
 
   //take the simHits on the simTrack that are in the nextLayer (could be > 1 if overlap or matched)
@@ -634,7 +634,7 @@ bool CkfDebugger::associated(CTTRHp rechit, const PSimHit& pSimHit) const
 bool CkfDebugger::correctMeas( const TM& tm, const PSimHit* correctHit) const
 {
   LogTrace("CkfDebugger") << "now in correctMeas" ;
-  CTTRHp recHit = tm.recHit();
+  const CTTRHp& recHit = tm.recHit();
   if (recHit->isValid()) LogTrace("CkfDebugger") << "hit at position:" << recHit->globalPosition() ;
   TransientTrackingRecHit::RecHitContainer comp = recHit->transientHits();
   if (comp.empty()) {
@@ -886,7 +886,7 @@ pair<CTTRHp, double> CkfDebugger::analyseRecHitExistance( const PSimHit& sh, con
   }
   other++;
 #endif
-  return std::pair<CTTRHp, double>((CTTRHp)(0),0);//other
+  return std::pair<CTTRHp, double>((CTTRHp)(nullptr),0);//other
 }
 
 const PSimHit* CkfDebugger::pSimHit(unsigned int tkId, DetId detId)
@@ -898,7 +898,7 @@ const PSimHit* CkfDebugger::pSimHit(unsigned int tkId, DetId detId)
       return (*shi);
     }
   }
-  return 0;
+  return nullptr;
 }
 
 int CkfDebugger::analyseRecHitNotFound(const Trajectory& traj, CTTRHp correctRecHit)
@@ -915,7 +915,7 @@ int CkfDebugger::analyseRecHitNotFound(const Trajectory& traj, CTTRHp correctRec
   }
 
   TkLayerLess lless;//FIXME - was lless(traj.direction())
-  const DetLayer* detLayer = 0;
+  const DetLayer* detLayer = nullptr;
   bool navLayerAfter = false;
   bool test = false;
   for (std::vector<const DetLayer*>::iterator il = nl.begin(); il != nl.end(); il++) {
@@ -992,7 +992,7 @@ double CkfDebugger::testSeed(CTTRHp recHit1, CTTRHp recHit2, TSOS state){
   const std::vector<PSimHit>& pSimHitVec1 = hitAssociator->associateHit(*recHit1->hit());
   const std::vector<PSimHit>& pSimHitVec2 = hitAssociator->associateHit(*recHit2->hit());
   
-  if ( pSimHitVec1.size()==0 || pSimHitVec2.size()==0 || hasDelta(&(*pSimHitVec1.begin())) || hasDelta(&(*pSimHitVec2.begin())) ) {
+  if ( pSimHitVec1.empty() || pSimHitVec2.empty() || hasDelta(&(*pSimHitVec1.begin())) || hasDelta(&(*pSimHitVec2.begin())) ) {
     edm::LogVerbatim("CkfDebugger") << "Seed has delta or problems" ;
     return -1;
   }
@@ -1004,7 +1004,7 @@ double CkfDebugger::testSeed(CTTRHp recHit1, CTTRHp recHit2, TSOS state){
   //   double stlp4 = state.localParameters().vector()[3];
   //   double stlp5 = state.localParameters().vector()[4];
 
-  if (pSimHitVec2.size()!=0) {
+  if (!pSimHitVec2.empty()) {
     const PSimHit& simHit = *pSimHitVec2.begin();
     
     double shlp1 = -1/simHit.momentumAtEntry().mag();

--- a/RecoTracker/DebugTools/plugins/TestHits.cc
+++ b/RecoTracker/DebugTools/plugins/TestHits.cc
@@ -226,7 +226,7 @@ void TestHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 
     //call the fitter
     std::vector<Trajectory> result = fit->fit(theTC->seed(), hits, theTSOS);
-    if (result.size()==0) continue;
+    if (result.empty()) continue;
     std::vector<TrajectoryMeasurement> vtm = result[0].measurements();
     double tchi2 = 0;
 
@@ -234,7 +234,7 @@ void TestHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     for (std::vector<TrajectoryMeasurement>::iterator tm=vtm.begin(); tm!=vtm.end();tm++){
 
       TransientTrackingRecHit::ConstRecHitPointer rhit = tm->recHit();
-      if ((rhit)->isValid()==0&&rhit->det()!=0) continue;
+      if ((rhit)->isValid()==0&&rhit->det()!=nullptr) continue;
       LogTrace("TestHits") << "*****************new hit*****************" ;
 
       int subdetId = rhit->det()->geographicalId().subdetId();
@@ -246,7 +246,7 @@ void TestHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
       LocalPoint rhitLPv = rhit->localPosition();
 
       std::vector<PSimHit> assSimHits = hitAssociator.associateHit(*(rhit->hit()));
-      if (assSimHits.size()==0) continue;
+      if (assSimHits.empty()) continue;
       PSimHit shit;
       for(std::vector<PSimHit>::const_iterator m=assSimHits.begin(); m<assSimHits.end(); m++){
 	if ((m->localPosition()-rhitLPv).mag()<delta) {
@@ -401,12 +401,12 @@ void TestHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 	LogTrace("TestHits") << "MONO HIT" << std::endl;
         auto m = dynamic_cast<const SiStripMatchedRecHit2D*>((rhit)->hit())->monoHit();
 	CTTRHp tMonoHit = theBuilder->build(&m);
-	if (tMonoHit==0) continue;
+	if (tMonoHit==nullptr) continue;
 	vector<PSimHit> assMonoSimHits = hitAssociator.associateHit(*tMonoHit->hit());
-	if (assMonoSimHits.size()==0) continue;
+	if (assMonoSimHits.empty()) continue;
 	const PSimHit sMonoHit = *(assSimHits.begin());
 	const Surface * monoSurf = &( tMonoHit->det()->surface() );
-	if (monoSurf==0) continue;
+	if (monoSurf==nullptr) continue;
 	TSOS monoState = thePropagator->propagate(lastState,*monoSurf);
 	if (monoState.isValid()==0) continue;
 
@@ -496,12 +496,12 @@ void TestHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
         auto s = dynamic_cast<const SiStripMatchedRecHit2D*>((rhit)->hit())->stereoHit();
 	CTTRHp tStereoHit = 
 	  theBuilder->build(&s);
-	if (tStereoHit==0) continue;
+	if (tStereoHit==nullptr) continue;
 	vector<PSimHit> assStereoSimHits = hitAssociator.associateHit(*tStereoHit->hit());
-	if (assStereoSimHits.size()==0) continue;
+	if (assStereoSimHits.empty()) continue;
 	const PSimHit sStereoHit = *(assSimHits.begin());
 	const Surface * stereoSurf = &( tStereoHit->det()->surface() );
-	if (stereoSurf==0) continue;
+	if (stereoSurf==nullptr) continue;
 	TSOS stereoState = thePropagator->propagate(lastState,*stereoSurf);
 	if (stereoState.isValid()==0) continue;
 

--- a/RecoTracker/DebugTools/plugins/TestOutliers.cc
+++ b/RecoTracker/DebugTools/plugins/TestOutliers.cc
@@ -55,13 +55,13 @@
 class TestOutliers : public edm::EDAnalyzer {
 public:
   explicit TestOutliers(const edm::ParameterSet&);
-  ~TestOutliers();
+  ~TestOutliers() override;
 
 
 private:
-  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override ;
+  void beginRun(edm::Run const& run, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
 
   // ----------member data ---------------------------
   edm::InputTag trackTagsOut_; //used to select what tracks to read from configuration file
@@ -290,11 +290,11 @@ TestOutliers::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
       }
     } 
 
-    if (outtest.size()==0 || trackOut.get()==0 ) {//no out track found for the old track
+    if (outtest.empty() || trackOut.get()==nullptr ) {//no out track found for the old track
       if(recSimCollOld.find(trackOld) != recSimCollOld.end()){      
 	vector<pair<TrackingParticleRef, double> > tpOld;
 	tpOld = recSimCollOld[trackOld];
-	if (tpOld.size()!=0) { 
+	if (!tpOld.empty()) { 
 	  LogTrace("TestOutliers") <<"no match: old associated and out lost! old has #hits=" << trackOld->numberOfValidHits() 
 				   << " and fraction=" << tpOld.begin()->second;
 	  if (tpOld.begin()->second>0.5) hitsPerTrackLost->Fill(trackOld->numberOfValidHits());
@@ -343,7 +343,7 @@ TestOutliers::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
     if(outAssoc) {//save the ids od the tp associate to the out track
       tpOut = recSimCollOut[trackOut];
-      if (tpOut.size()!=0) {
+      if (!tpOut.empty()) {
 	countOutA->Fill(1);
 	tprOut = tpOut.begin()->first;
 	fracOut = tpOut.begin()->second;
@@ -355,12 +355,12 @@ TestOutliers::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
     if(oldAssoc){//save the ids od the tp associate to the old track
       tpOld = recSimCollOld[trackOld];
-      if (tpOld.size()!=0) { 
+      if (!tpOld.empty()) { 
 	tprOld = tpOld.begin()->first;
 	// 	LogTrace("TestOutliers") <<"old associated and out not! old has #hits=" << trackOld->numberOfValidHits() 
 	// 				 << " and fraction=" << tpOld.begin()->second;
 	// 	if (tpOld.begin()->second>0.5) hitsPerTrackLost->Fill(trackOld->numberOfValidHits());//deve essere un plot diverso tipo LostAssoc
-	if (tpOut.size()==0) {
+	if (tpOut.empty()) {
 	  for (TrackingParticle::g4t_iterator g4T=tprOld->g4Track_begin(); g4T!=tprOld->g4Track_end(); ++g4T) {
 	    tpids.push_back(g4T->trackId());
 	  }
@@ -368,9 +368,9 @@ TestOutliers::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
       }
     }
 
-    if (tprOut.get()!=0 || tprOld.get()!=0) { //at least one of the tracks has to be associated
+    if (tprOut.get()!=nullptr || tprOld.get()!=nullptr) { //at least one of the tracks has to be associated
 
-      tpr = tprOut.get()!=0 ? tprOut : tprOld;
+      tpr = tprOut.get()!=nullptr ? tprOut : tprOld;
 
       const SimTrack * assocTrack = &(*tpr->g4Track_begin());
       
@@ -445,8 +445,8 @@ TestOutliers::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	LogTrace("TestOutliers") << "deltahits=" << trackOld->numberOfValidHits()-trackOut->numberOfValidHits();		  
 	deltahits->Fill(trackOld->numberOfValidHits()-trackOut->numberOfValidHits());
 
-	if(tprOut.get()!=0 && tprOld.get()==0) { //out associated and old not: gained track
-	  if (tpOld.size()!=0 && tpOld.begin()->second<=0.5) {
+	if(tprOut.get()!=nullptr && tprOld.get()==nullptr) { //out associated and old not: gained track
+	  if (!tpOld.empty() && tpOld.begin()->second<=0.5) {
 	    deltahitsAssocGained->Fill(trackOld->numberOfValidHits()-trackOut->numberOfValidHits());
 	    hitsPerTrackAssocGained->Fill(trackOut->numberOfValidHits());
 	    LogTrace("TestOutliers") << "a) gained (assoc) track out #hits==" << trackOut->numberOfValidHits() << " old #hits=" << trackOld->numberOfValidHits();    
@@ -455,7 +455,7 @@ TestOutliers::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	    hitsPerTrackAssocGained->Fill(trackOut->numberOfValidHits());
 	    LogTrace("TestOutliers") << "b) gained (assoc) track out #hits==" << trackOut->numberOfValidHits() << " old #hits=" << trackOld->numberOfValidHits();    
 	  }
-	} else if(tprOut.get()==0 && tprOld.get()!=0) { //old associated and out not: lost track
+	} else if(tprOut.get()==nullptr && tprOld.get()!=nullptr) { //old associated and out not: lost track
 	  LogTrace("TestOutliers") <<"old associated and out not! old has #hits=" << trackOld->numberOfValidHits() 
 				   << " and fraction=" << tpOld.begin()->second;
 	  if (tpOld.begin()->second>0.5) {      
@@ -612,7 +612,7 @@ TestOutliers::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	    std::vector<double> energyLossM;
 	    std::vector<double> energyLossS;
 	    std::vector<PSimHit> assSimHits = hitAssociator.associateHit(**itHit);
-	    if (assSimHits.size()==0) continue;
+	    if (assSimHits.empty()) continue;
 	    PSimHit shit;
 	    std::vector<unsigned int> trackIds;
 	    energyLossS.clear();
@@ -730,8 +730,8 @@ TestOutliers::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
 		const SiStripMatchedRecHit2D* tmp = dynamic_cast<const SiStripMatchedRecHit2D*>(&**itHit);
 		LogTrace("TestOutliers") << "tmp=" << tmp; 
 		LogTrace("TestOutliers") << "assSimHits.size()=" << assSimHits.size(); 
-		if ( (assSimHits.size()>1 && tmp==0) || 
-		     (assSimHits.size()>2 && tmp!=0) ) {
+		if ( (assSimHits.size()>1 && tmp==nullptr) || 
+		     (assSimHits.size()>2 && tmp!=nullptr) ) {
 		  //std::cout << "MERGED HIT" << std::endl;
 		  //LogTrace("TestOutliers") << "merged";		  
 		  mergedlayer->Fill(layerval);
@@ -860,7 +860,7 @@ TestOutliers::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	}
       } 
       //else if ( trackOut->numberOfValidHits() > trackOld->numberOfValidHits() ) {
-      else if ( 0 ) {
+      else if ( false ) {
 	LogTrace("TestOutliers") << "outliers for track with #hits=" << trackOut->numberOfValidHits();
 	tracks->Fill(1);
 	LogTrace("TestOutliers") << "Out->pt=" << trackOut->pt() << " Old->pt=" << trackOld->pt() 

--- a/RecoTracker/DebugTools/plugins/TestSmoothHits.cc
+++ b/RecoTracker/DebugTools/plugins/TestSmoothHits.cc
@@ -233,14 +233,14 @@ void TestSmoothHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
       std::vector<Trajectory> smoothed = smooth->trajectories(*it);
       result.insert(result.end(), smoothed.begin(), smoothed.end());
     }
-    if (result.size()==0) continue;
+    if (result.empty()) continue;
     std::vector<TrajectoryMeasurement> vtm = result[0].measurements();
 
     TSOS lastState = theTSOS;
     for (std::vector<TrajectoryMeasurement>::iterator tm=vtm.begin(); tm!=vtm.end();tm++){
 
       TransientTrackingRecHit::ConstRecHitPointer rhit = tm->recHit();
-      if ((rhit)->isValid()==0&&rhit->det()!=0) continue;
+      if ((rhit)->isValid()==0&&rhit->det()!=nullptr) continue;
       LogTrace("TestSmoothHits") << "new hit" ;
 
       int subdetId = rhit->det()->geographicalId().subdetId();
@@ -252,7 +252,7 @@ void TestSmoothHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
       LocalPoint rhitLPv = rhit->localPosition();
 
       std::vector<PSimHit> assSimHits = hitAssociator.associateHit(*(rhit->hit()));
-      if (assSimHits.size()==0) continue;
+      if (assSimHits.empty()) continue;
       PSimHit shit;
       for(std::vector<PSimHit>::const_iterator m=assSimHits.begin(); m<assSimHits.end(); m++){
 	if ((m->localPosition()-rhitLPv).mag()<delta) {
@@ -439,12 +439,12 @@ void TestSmoothHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
         auto m = dynamic_cast<const SiStripMatchedRecHit2D*>((rhit)->hit())->monoHit();
 	CTTRHp tMonoHit = 
 	  theBuilder->build(&m);
-	if (tMonoHit==0) continue;
+	if (tMonoHit==nullptr) continue;
 	vector<PSimHit> assMonoSimHits = hitAssociator.associateHit(*tMonoHit->hit());
-	if (assMonoSimHits.size()==0) continue;
+	if (assMonoSimHits.empty()) continue;
 	const PSimHit sMonoHit = *(assSimHits.begin());
 	const Surface * monoSurf = &( tMonoHit->det()->surface() );
-	if (monoSurf==0) continue;
+	if (monoSurf==nullptr) continue;
 	TSOS monoState = thePropagator->propagate(lastState,*monoSurf);
 	if (monoState.isValid()==0) continue;
 
@@ -534,12 +534,12 @@ void TestSmoothHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
         auto s = dynamic_cast<const SiStripMatchedRecHit2D*>((rhit)->hit())->stereoHit();
 	CTTRHp tStereoHit = 
 	  theBuilder->build(&s);
-	if (tStereoHit==0) continue;
+	if (tStereoHit==nullptr) continue;
 	vector<PSimHit> assStereoSimHits = hitAssociator.associateHit(*tStereoHit->hit());
-	if (assStereoSimHits.size()==0) continue;
+	if (assStereoSimHits.empty()) continue;
 	const PSimHit sStereoHit = *(assSimHits.begin());
 	const Surface * stereoSurf = &( tStereoHit->det()->surface() );
-	if (stereoSurf==0) continue;
+	if (stereoSurf==nullptr) continue;
 	TSOS stereoState = thePropagator->propagate(lastState,*stereoSurf);
 	if (stereoState.isValid()==0) continue;
 

--- a/RecoTracker/DebugTools/plugins/TestTrackHits.cc
+++ b/RecoTracker/DebugTools/plugins/TestTrackHits.cc
@@ -297,7 +297,7 @@ void TestTrackHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
     std::vector<std::pair<TrackingParticleRef, double> > tP;
     if(recSimColl.find(track) != recSimColl.end()){
       tP = recSimColl[track];
-      if (tP.size()!=0) {
+      if (!tP.empty()) {
 	edm::LogVerbatim("TestTrackHits") << "reco::Track #" << ++yyy << " with pt=" << track->pt() 
 					  << " associated with quality:" << tP.begin()->second <<" good track #" << ++yy << " has hits:" << track->numberOfValidHits() << "\n";
       }
@@ -338,7 +338,7 @@ void TestTrackHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
       //TSOS state = tm->forwardPredictedState();
       TSOS state = combiner(tm->backwardPredictedState(), tm->forwardPredictedState());
 
-      if (rhit->isValid()==0 && rhit->det()!=0) continue;
+      if (rhit->isValid()==0 && rhit->det()!=nullptr) continue;
       evtHits++;
       LogTrace("TestTrackHits") << "valid hit #" << ++pp << "of hits=" << track->numberOfValidHits();
 
@@ -348,7 +348,7 @@ void TestTrackHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
       LogTrace("TestTrackHits") << "subdetId=" << subdetId << " layerId=" << layerId ;
 
       const Surface * surf = rhit->surface();
-      if (surf==0) continue;
+      if (surf==nullptr) continue;
 
       double energyLoss_ = 0.;
       unsigned int monoId = 0;
@@ -728,12 +728,12 @@ void TestTrackHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 	LogTrace("TestTrackHits") << "MONO HIT" ;
         auto m = dynamic_cast<const SiStripMatchedRecHit2D*>(rhit->hit())->monoHit();
 	CTTRHp tMonoHit = theBuilder->build(&m);
-	if (tMonoHit==0) continue;
+	if (tMonoHit==nullptr) continue;
 	vector<PSimHit> assMonoSimHits = hitAssociator.associateHit(*tMonoHit->hit());
-	if (assMonoSimHits.size()==0) continue;
+	if (assMonoSimHits.empty()) continue;
 	const PSimHit sMonoHit = *(assMonoSimHits.begin());
 	const Surface * monoSurf = &( tMonoHit->det()->surface() );
-	if (monoSurf==0) continue;
+	if (monoSurf==nullptr) continue;
 	TSOS monoState = thePropagatorAnyDir->propagate(state,*monoSurf);
 	if (monoState.isValid()==0) continue;
 
@@ -832,12 +832,12 @@ void TestTrackHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 	LogTrace("TestTrackHits") << "STEREO HIT" ;
         auto s = dynamic_cast<const SiStripMatchedRecHit2D*>(rhit->hit())->stereoHit();
 	CTTRHp tStereoHit = theBuilder->build(&s);
-	if (tStereoHit==0) continue;
+	if (tStereoHit==nullptr) continue;
 	vector<PSimHit> assStereoSimHits = hitAssociator.associateHit(*tStereoHit->hit());
-	if (assStereoSimHits.size()==0) continue;
+	if (assStereoSimHits.empty()) continue;
 	const PSimHit sStereoHit = *(assStereoSimHits.begin());
 	const Surface * stereoSurf = &( tStereoHit->det()->surface() );
-	if (stereoSurf==0) continue;
+	if (stereoSurf==nullptr) continue;
 	TSOS stereoState = thePropagatorAnyDir->propagate(state,*stereoSurf);
 	if (stereoState.isValid()==0) continue;
 

--- a/RecoTracker/DebugTools/plugins/TrackAlgoCompareUtil.cc
+++ b/RecoTracker/DebugTools/plugins/TrackAlgoCompareUtil.cc
@@ -154,7 +154,7 @@ TrackAlgoCompareUtil::produce(edm::StreamID, edm::Event& iEvent, const edm::Even
         }       
         
         // get the reco primary vertex info
-        if(UseVertex && vertexCollAlgoA->size())  
+        if(UseVertex && !vertexCollAlgoA->empty())  
         {
             recoTracktoTP.SetRecoVertex( reco::VertexRef(vertexCollAlgoA, 0) );
         }
@@ -191,7 +191,7 @@ TrackAlgoCompareUtil::produce(edm::StreamID, edm::Event& iEvent, const edm::Even
         }       
         
         // get the reco primary vertex info
-        if(UseVertex && vertexCollAlgoB->size())  
+        if(UseVertex && !vertexCollAlgoB->empty())  
         {
             recoTracktoTP.SetRecoVertex( reco::VertexRef(vertexCollAlgoB, 0) );
         }
@@ -227,7 +227,7 @@ TrackAlgoCompareUtil::produce(edm::StreamID, edm::Event& iEvent, const edm::Even
         }
         
         // get the recoVertex algo A
-        if(UseVertex && vertexCollAlgoA->size())
+        if(UseVertex && !vertexCollAlgoA->empty())
         {
             tptoRecoTrack.SetRecoVertex_AlgoA( reco::VertexRef(vertexCollAlgoA, 0) );
         }
@@ -249,7 +249,7 @@ TrackAlgoCompareUtil::produce(edm::StreamID, edm::Event& iEvent, const edm::Even
             tptoRecoTrack.SetShared_AlgoB(-1.0);
         }
         // get the recoVertex algo B
-        if(UseVertex && vertexCollAlgoB->size())
+        if(UseVertex && !vertexCollAlgoB->empty())
         {
             tptoRecoTrack.SetRecoVertex_AlgoB( reco::VertexRef(vertexCollAlgoB, 0) );
         }

--- a/RecoTracker/DebugTools/plugins/TrackAlgoCompareUtil.h
+++ b/RecoTracker/DebugTools/plugins/TrackAlgoCompareUtil.h
@@ -55,11 +55,11 @@ class TrackAlgoCompareUtil : public edm::global::EDProducer<>
  public:
    
   explicit TrackAlgoCompareUtil(const edm::ParameterSet&);
-  ~TrackAlgoCompareUtil();
+  ~TrackAlgoCompareUtil() override;
   
  private:
   
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   
   void SetTrackingParticleD0Dz(TrackingParticleRef tp, const reco::BeamSpot &bs, const MagneticField *bf, TPtoRecoTrack& TPRT) const;
   void SetTrackingParticleD0Dz(TrackingParticleRef tp, const reco::BeamSpot &bs, const MagneticField *bf, RecoTracktoTP& RTTP) const;

--- a/RecoTracker/DebugTools/src/GetTrackTrajInfo.cc
+++ b/RecoTracker/DebugTools/src/GetTrackTrajInfo.cc
@@ -75,7 +75,7 @@ std::vector< GetTrackTrajInfo::Result > GetTrackTrajInfo::analyze(const edm::Eve
       LogDebug("GTTI")<<"    hit in subdet="<<subDet<<" layer="<<layer;
 
       // Get corresponding DetLayer object (based on code in GeometricSearchTracker::idToLayer(...)
-      const DetLayer* detLayer = 0;
+      const DetLayer* detLayer = nullptr;
       if (subDet == StripSubdetector::TIB) {
         detLayer = tracker->tibLayers()[layer - 1];
       } else if (subDet == StripSubdetector::TOB) {
@@ -105,7 +105,7 @@ std::vector< GetTrackTrajInfo::Result > GetTrackTrajInfo::analyze(const edm::Eve
 	propagator.setPropagationDirection(along);
 	std::vector< GeometricSearchDet::DetWithState > detWithState = detLayer->compatibleDets(initTSOS, propagator, estimator);
 	// Check that at least one sensor was compatible with the track trajectory.
-	if(detWithState.size() > 0) {
+	if(!detWithState.empty()) {
 	  // Store track trajectory at this sensor.
 	  result.valid    = true;
 	  result.accurate = true;

--- a/RecoTracker/FinalTrackSelectors/plugins/AnalyticalTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/AnalyticalTrackSelector.cc
@@ -39,7 +39,7 @@ using namespace reco;
             /// constructor 
             explicit AnalyticalTrackSelector( const edm::ParameterSet & cfg ) ;
             /// destructor
-            virtual ~AnalyticalTrackSelector() ;
+            ~AnalyticalTrackSelector() override ;
 
         private:
             typedef math::XYZPoint Point;

--- a/RecoTracker/FinalTrackSelectors/plugins/ClassifierMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/ClassifierMerger.cc
@@ -35,7 +35,7 @@ namespace {
       using MVACollection = std::vector<float>;
       using QualityMaskCollection = std::vector<unsigned char>;
 
-      virtual void produce(edm::StreamID, edm::Event& evt, const edm::EventSetup&) const override {
+      void produce(edm::StreamID, edm::Event& evt, const edm::EventSetup&) const override {
 
 	// get Master
 	edm::Handle<MVACollection> hmva;

--- a/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSelector.cc
@@ -35,7 +35,7 @@ using namespace reco;
 		     // constructor 
 		     explicit CosmicTrackSelector( const edm::ParameterSet & cfg ) ;
 		     // destructor
-		     virtual ~CosmicTrackSelector() ;
+		     ~CosmicTrackSelector() override ;
 		     
 		   private:
 		     typedef math::XYZPoint Point;

--- a/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSplitter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSplitter.cc
@@ -78,7 +78,7 @@ namespace reco { namespace modules {
        class CosmicTrackSplitter : public edm::stream::EDProducer<> {
     public:
 		CosmicTrackSplitter(const edm::ParameterSet &iConfig) ;
-		virtual void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
+		void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
 
     private:
 		edm::EDGetTokenT<reco::TrackCollection> tokenTracks;

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
@@ -44,7 +44,7 @@ class DuplicateListMerger final : public edm::global::EDProducer<> {
   /// constructor
   explicit DuplicateListMerger(const edm::ParameterSet& iPara);
   /// destructor
-  virtual ~DuplicateListMerger();
+  ~DuplicateListMerger() override;
   
   /// alias for container of candidate and input tracks
   using CandidateToDuplicate = std::vector<std::pair<int, int>>;

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
@@ -41,7 +41,7 @@ namespace {
     /// constructor
     explicit DuplicateTrackMerger(const edm::ParameterSet& iPara);
     /// destructor
-    virtual ~DuplicateTrackMerger();
+    ~DuplicateTrackMerger() override;
     
     using CandidateToDuplicate = std::vector<std::pair<int, int>>;
 	 
@@ -412,8 +412,8 @@ void DuplicateTrackMerger::produce(edm::Event& iEvent, const edm::EventSetup& iS
     if(!TSCP1.isValid()) return false;
     if(!TSCP2.isValid()) return false;
 
-    const FreeTrajectoryState ftsn1 = TSCP1.theState();
-    const FreeTrajectoryState ftsn2 = TSCP2.theState();
+    const FreeTrajectoryState& ftsn1 = TSCP1.theState();
+    const FreeTrajectoryState& ftsn2 = TSCP2.theState();
  
     IfLogTrace(debug_, "DuplicateTrackMerger") << " DCA2 " << (ftsn2.position()-ftsn1.position()).mag2();
     if ( (ftsn2.position()-ftsn1.position()).mag2() > maxDCA2_ ) return false;

--- a/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
@@ -91,7 +91,7 @@ MultiTrackSelector::MultiTrackSelector( const edm::ParameterSet & cfg ) :
     qualityToSet_.push_back( TrackBase::undefQuality );
     // parameters for vertex selection
     vtxNumber_.push_back( useVertices_ ? trkSelectors[i].getParameter<int32_t>("vtxNumber") : 0 );
-    vertexCut_.push_back( useVertices_ ? trkSelectors[i].getParameter<std::string>("vertexCut") : 0);
+    vertexCut_.push_back( useVertices_ ? trkSelectors[i].getParameter<std::string>("vertexCut") : nullptr);
     //  parameters for adapted optimal cuts on chi2 and primary vertex compatibility
     res_par_.push_back(trkSelectors[i].getParameter< std::vector<double> >("res_par") );
     chi2n_par_.push_back( trkSelectors[i].getParameter<double>("chi2n_par") );
@@ -641,7 +641,7 @@ MultiTrackSelector::Point MultiTrackSelector::getBestVertex(TrackBaseRef track,V
   bool weightMatch = false;
   for(auto const & vertex : vertices){
     float w = vertex.trackWeight(track);
-    Point v_pos = vertex.position();
+    const Point& v_pos = vertex.position();
     if(w > bestWeight){
       p = v_pos;
       bestWeight = w;

--- a/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.h
+++ b/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.h
@@ -39,14 +39,14 @@
 	    explicit MultiTrackSelector();
             explicit MultiTrackSelector( const edm::ParameterSet & cfg ) ;
             /// destructor
-            virtual ~MultiTrackSelector() ;
+            ~MultiTrackSelector() override ;
 
            using MVACollection = std::vector<float>;
            using QualityMaskCollection = std::vector<unsigned char>;
 
 
         protected:
-            void beginStream(edm::StreamID) override final;
+            void beginStream(edm::StreamID) final;
  
             // void streamBeginRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const final {
             //  init();
@@ -56,7 +56,7 @@
 
             typedef math::XYZPoint Point;
             /// process one event
-            void produce(edm::Event& evt, const edm::EventSetup& es ) override final {
+            void produce(edm::Event& evt, const edm::EventSetup& es ) final {
                run(evt,es);
             }
             virtual void run( edm::Event& evt, const edm::EventSetup& es ) const;

--- a/RecoTracker/FinalTrackSelectors/plugins/SimpleTrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/SimpleTrackListMerger.cc
@@ -35,9 +35,9 @@ class SimpleTrackListMerger : public edm::stream::EDProducer<> {
 
     explicit SimpleTrackListMerger(const edm::ParameterSet& conf);
 
-    virtual ~SimpleTrackListMerger();
+    ~SimpleTrackListMerger() override;
 
-    virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
+    void produce(edm::Event& e, const edm::EventSetup& c) override;
 
   private:
     edm::ParameterSet conf_;
@@ -211,7 +211,7 @@ namespace {
     // this allows SimpleTrackListMerger to be used as a cleaner only if handed just one list
     // if both input lists don't exist, will issue 2 warnings and generate an empty output collection
     //
-    const reco::TrackCollection *TC1 = 0;
+    const reco::TrackCollection *TC1 = nullptr;
     static const reco::TrackCollection s_empty1, s_empty2;
     edm::Handle<reco::TrackCollection> trackCollection1;
     e.getByToken(trackProducer1Token, trackCollection1);
@@ -224,7 +224,7 @@ namespace {
     }
     const reco::TrackCollection tC1 = *TC1;
 
-    const reco::TrackCollection *TC2 = 0;
+    const reco::TrackCollection *TC2 = nullptr;
     edm::Handle<reco::TrackCollection> trackCollection2;
     e.getByToken(trackProducer2Token, trackCollection2);
     if (trackCollection2.isValid()) {
@@ -276,7 +276,7 @@ namespace {
 
     std::vector<int> selected1; for (unsigned int i=0; i<tC1.size(); ++i){selected1.push_back(1);}
 
-   if ( 0<tC1.size() ){
+   if ( !tC1.empty() ){
       i=-1;
       for (reco::TrackCollection::const_iterator track=tC1.begin(); track!=tC1.end(); track++){
         i++;
@@ -306,7 +306,7 @@ namespace {
 
     std::vector<int> selected2; for (unsigned int i=0; i<tC2.size(); ++i){selected2.push_back(1);}
 
-   if ( 0<tC2.size() ){
+   if ( !tC2.empty() ){
       i=-1;
       for (reco::TrackCollection::const_iterator track=tC2.begin(); track!=tC2.end(); track++){
         i++;
@@ -352,7 +352,7 @@ namespace {
      }
    }
 
-   if ( (0<tC1.size())&&(0<tC2.size()) ){
+   if ( (!tC1.empty())&&(!tC2.empty()) ){
     i=-1;
     for (reco::TrackCollection::const_iterator track=tC1.begin(); track!=tC1.end(); ++track){
       i++;
@@ -426,7 +426,7 @@ namespace {
    std::vector<edm::RefToBase<TrajectorySeed> > seedsRefs(tC1.size()+tC2.size());
    size_t current = 0;
 
-   if ( 0<tC1.size() ){
+   if ( !tC1.empty() ){
      i=0;
      for (reco::TrackCollection::const_iterator track=tC1.begin(); track!=tC1.end();
 	  ++track, ++current, ++i){
@@ -547,7 +547,7 @@ namespace {
 
    short offset = current; //save offset into trackRefs
 
-   if ( 0<tC2.size() ){
+   if ( !tC2.empty() ){
     i=0;
     for (reco::TrackCollection::const_iterator track=tC2.begin(); track!=tC2.end();
 	 ++track, ++current, ++i){

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackAlgoPriorityOrderESProducer.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackAlgoPriorityOrderESProducer.cc
@@ -9,7 +9,7 @@
 class TrackAlgoPriorityOrderESProducer: public edm::ESProducer {
 public:
   TrackAlgoPriorityOrderESProducer(const edm::ParameterSet& iConfig);
-  ~TrackAlgoPriorityOrderESProducer() = default;
+  ~TrackAlgoPriorityOrderESProducer() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCandidateTopBottomHitFilter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCandidateTopBottomHitFilter.cc
@@ -42,11 +42,11 @@ Implementation:
 class dso_hidden TrackCandidateTopBottomHitFilter final : public edm::stream::EDProducer<> {
 public:
   explicit TrackCandidateTopBottomHitFilter(const edm::ParameterSet&);
-  ~TrackCandidateTopBottomHitFilter();
+  ~TrackCandidateTopBottomHitFilter() override;
 
 private:
-  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) override;
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void beginRun(edm::Run const& run, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
   edm::EDGetTokenT<TrackCandidateCollection> label;
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
   std::string builderName;

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionFilterCloner.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionFilterCloner.cc
@@ -27,7 +27,7 @@ class TrackCollectionFilterCloner final : public edm::global::EDProducer<> {
   /// constructor
   explicit TrackCollectionFilterCloner(const edm::ParameterSet& iConfig);
   /// destructor
-  virtual ~TrackCollectionFilterCloner();
+  ~TrackCollectionFilterCloner() override;
   
   /// alias for container of candidate and input tracks
   using CandidateToDuplicate = std::vector<std::pair<int, int>>;

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionMerger.cc
@@ -95,7 +95,7 @@ namespace {
     bool  m_allowFirstHitShare;
     bool  m_enableMerging;
     
-    virtual void produce(edm::StreamID, edm::Event& evt, const edm::EventSetup&) const override;
+    void produce(edm::StreamID, edm::Event& evt, const edm::EventSetup&) const override;
     
 
     bool areDuplicate(IHitV const& rh1, IHitV const& rh2) const;

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
@@ -35,9 +35,9 @@ class dso_hidden TrackListMerger : public edm::stream::EDProducer<>
 
     explicit TrackListMerger(const edm::ParameterSet& conf);
 
-    virtual ~TrackListMerger();
+    ~TrackListMerger() override;
 
-    virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
+    void produce(edm::Event& e, const edm::EventSetup& c) override;
 
   private:
 
@@ -329,7 +329,7 @@ TrackListMerger::~TrackListMerger() { }
     std::vector<const reco::TrackCollection *> trackColls;
     std::vector<edm::Handle<reco::TrackCollection> > trackHandles(trackProducers_.size());
     for ( unsigned int i=0; i<trackProducers_.size(); i++) {
-      trackColls.push_back(0);
+      trackColls.push_back(nullptr);
       //edm::Handle<reco::TrackCollection> trackColl;
       e.getByToken(trackProducers_[i].tk, trackHandles[i]);
       if (trackHandles[i].isValid()) {
@@ -381,7 +381,7 @@ TrackListMerger::~TrackListMerger() { }
 	e.getByToken(trackProducers_[j].tsel, trackSelColl);
       }
 
-      if ( 0<tC1->size() ){
+      if ( !tC1->empty() ){
 	unsigned int iC=0;
 	for (reco::TrackCollection::const_iterator track=tC1->begin(); track!=tC1->end(); track++){
 	  i++;

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackMultiSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackMultiSelector.cc
@@ -45,7 +45,7 @@
             /// constructor
             explicit TrackMultiSelector( const edm::ParameterSet & cfg ) ;
             /// destructor
-            virtual ~TrackMultiSelector() ;
+            ~TrackMultiSelector() override ;
 
         private:
             typedef math::XYZPoint Point;
@@ -314,7 +314,7 @@ inline bool  TrackMultiSelector::testVtx ( const reco::Track &tk, const reco::Be
     using std::abs;
     double d0Err =abs(tk.d0Error()), dzErr = abs(tk.dzError());  // not fully sure they're > 0!
     if (points.empty()) {
-        Point spot = beamSpot.position();
+        const Point& spot = beamSpot.position();
         double dz = abs(tk.dz(spot)), d0 = abs(tk.dxy(spot));
         return ( dz < beamspotDZsigmas_*beamSpot.sigmaZ() ) && ( d0 < beamspotD0_ );
     }

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
@@ -75,7 +75,7 @@ namespace reco {
   class TrackerTrackHitFilter : public edm::stream::EDProducer<> {
   public:
     TrackerTrackHitFilter(const edm::ParameterSet &iConfig) ;
-    virtual void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
+    void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
     int checkHit(const edm::EventSetup &iSetup,const  DetId &detid,  const TrackingRecHit * hit);
     void produceFromTrajectory( const edm::EventSetup &iSetup, const Trajectory *itt, std::vector<TrackingRecHit *>&hits);
     void produceFromTrack( const edm::EventSetup &iSetup, const Track *itt, std::vector<TrackingRecHit *>&hits);
@@ -563,7 +563,7 @@ void TrackerTrackHitFilter::produceFromTrack(const edm::EventSetup &iSetup, cons
 	    DetId detid = hit->geographicalId();
 
 	    //check that the hit is a real hit and not a constraint
-	    if(hit->isValid() && hit==0 && detid.rawId()==0) continue;
+	    if(hit->isValid() && hit==nullptr && detid.rawId()==0) continue;
 
 	    int verdict=checkHit(iSetup,detid,hit);
 	    if (verdict == 0) {
@@ -600,7 +600,7 @@ void TrackerTrackHitFilter::produceFromTrajectory(const edm::EventSetup &iSetup,
   std::vector<TrajectoryMeasurement> tmColl =itt->measurements();
 
   //---OverlapBegin needed eventually for overlaps, but I must create them here in any case
-  const TrajectoryMeasurement* previousTM(0);
+  const TrajectoryMeasurement* previousTM(nullptr);
   DetId previousId(0);
   //int previousLayer(-1);
   ///---OverlapEnd
@@ -611,7 +611,7 @@ void TrackerTrackHitFilter::produceFromTrajectory(const edm::EventSetup &iSetup,
      TransientTrackingRecHit::ConstRecHitPointer hitpointer = itTrajMeas->recHit();
 
      //check that the hit is a real hit and not a constraint
-     if(hitpointer->isValid() && hitpointer->hit()==0){constrhits++; continue;}
+     if(hitpointer->isValid() && hitpointer->hit()==nullptr){constrhits++; continue;}
 
     const TrackingRecHit *hit=((*hitpointer).hit());
     DetId detid = hit->geographicalId();
@@ -643,7 +643,7 @@ void TrackerTrackHitFilter::produceFromTrajectory(const edm::EventSetup &iSetup,
 	  int subDet = detid.subdetId();
 	  //std::cout  << "  Check Subdet #" <<subDet << ", layer = " <<layer<<" stereo: "<< ((subDet > 2)?(SiStripDetId(detid).stereo()):2);
 
-	    if ( ( previousTM!=0 )&& (layer!=-1 )) {
+	    if ( ( previousTM!=nullptr )&& (layer!=-1 )) {
 	      //std::cout<<"A previous TM exists! "<<std::endl;
 	      for (std::vector<TrajectoryMeasurement>::const_iterator itmCompare =itTrajMeas-1;itmCompare >= tmColl.begin() &&  itmCompare > itTrajMeas - 4;--itmCompare){
 
@@ -756,7 +756,7 @@ bool TrackerTrackHitFilter::checkStoN(const edm::EventSetup &iSetup, const DetId
 	const SiStripCluster* cluster;
 	if (type == typeid(SiStripRecHit2D)) {
 	  const SiStripRecHit2D* hit = dynamic_cast<const SiStripRecHit2D*>(therechit);
-	  if (hit!=0) 	 cluster = &*(hit->cluster());
+	  if (hit!=nullptr) 	 cluster = &*(hit->cluster());
 	  else{
 	    edm::LogError("TrackerTrackHitFilter")<< "TrackerTrackHitFilter::checkStoN : Unknown valid tracker hit in subdet " << id.subdetId()<< "(detID="<<id.rawId()<<")\n ";
 	    keepthishit = false;
@@ -764,7 +764,7 @@ bool TrackerTrackHitFilter::checkStoN(const edm::EventSetup &iSetup, const DetId
 	}
 	else if (type == typeid(SiStripRecHit1D)) {
 	  const SiStripRecHit1D* hit = dynamic_cast<const SiStripRecHit1D*>(therechit);
-	  if (hit!=0) 	 cluster = &*(hit->cluster());
+	  if (hit!=nullptr) 	 cluster = &*(hit->cluster());
 	  else{
 	    edm::LogError("TrackerTrackHitFilter")<< "TrackerTrackHitFilter::checkStoN : Unknown valid tracker hit in subdet " << id.subdetId()<< "(detID="<<id.rawId()<<")\n ";
 	    keepthishit = false;
@@ -800,7 +800,7 @@ bool TrackerTrackHitFilter::checkStoN(const edm::EventSetup &iSetup, const DetId
 
       if(checkPXLQuality_){
       const SiPixelRecHit* pixelhit = dynamic_cast<const SiPixelRecHit*>(therechit);
-      if(pixelhit!=0){
+      if(pixelhit!=nullptr){
 	//std::cout << "ClusterCharge=" <<std::flush<<pixelhit->cluster()->charge() << std::flush;
        	float xyprob=pixelhit->clusterProbability(0);//x-y combined log_e probability of the pixel cluster
 	                                               //singl x- and y-prob not stored sicne CMSSW 3_9_0
@@ -835,7 +835,7 @@ bool TrackerTrackHitFilter::checkHitAngle(const TrajectoryMeasurement &meas){
 
   bool angle_ok=false;
   bool corrcharge_ok=true;
-  TrajectoryStateOnSurface tsos = meas.updatedState();
+  const TrajectoryStateOnSurface& tsos = meas.updatedState();
   /*
   edm::LogDebug("TrackerTrackHitFilter")<<"TSOS parameters: ";
   edm::LogDebug("TrackerTrackHitFilter") <<"Global momentum: "<<tsos.globalMomentum().x()<<"  "<<tsos.globalMomentum().y()<<"  "<<tsos.globalMomentum().z();
@@ -856,7 +856,7 @@ bool TrackerTrackHitFilter::checkHitAngle(const TrajectoryMeasurement &meas){
     if(angle_ok &&  PXLcorrClusChargeCut_>0.0){
       //
       //get the hit from the TM and check that it is in the pixel
-      TransientTrackingRecHit::ConstRecHitPointer hitpointer = meas.recHit();
+      const TransientTrackingRecHit::ConstRecHitPointer& hitpointer = meas.recHit();
       if(hitpointer->isValid()){
       const TrackingRecHit *hit=(*hitpointer).hit();
       if(GeomDetEnumerators::isTrackerPixel(theGeometry->geomDetSubDetector(hit->geographicalId().subdetId()))) {//do it only for pixel hits
@@ -897,14 +897,14 @@ bool TrackerTrackHitFilter::checkPXLCorrClustCharge(const TrajectoryMeasurement 
 
   bool corrcharge_ok=false;
   //get the hit from the TM and check that it is in the pixel
-  TransientTrackingRecHit::ConstRecHitPointer hitpointer = meas.recHit();
+  const TransientTrackingRecHit::ConstRecHitPointer& hitpointer = meas.recHit();
   if(!hitpointer->isValid()) return corrcharge_ok;
   const TrackingRecHit *hit=(*hitpointer).hit();
   if(GeomDetEnumerators::isTrackerStrip(theGeometry->geomDetSubDetector(hit->geographicalId().subdetId()))) {//SiStrip hit, skip
      return corrcharge_ok;
   }
 
-  TrajectoryStateOnSurface tsos = meas.updatedState();
+  const TrajectoryStateOnSurface& tsos = meas.updatedState();
   if(tsos.isValid()){
     float mom_x=tsos.localDirection().x();
     float mom_y=tsos.localDirection().y();

--- a/RecoTracker/GeometryESProducer/plugins/TrackerRecoGeometryESProducer.h
+++ b/RecoTracker/GeometryESProducer/plugins/TrackerRecoGeometryESProducer.h
@@ -11,7 +11,7 @@
 class  TrackerRecoGeometryESProducer: public edm::ESProducer{
  public:
   TrackerRecoGeometryESProducer(const edm::ParameterSet & p);
-  virtual ~TrackerRecoGeometryESProducer(); 
+  ~TrackerRecoGeometryESProducer() override; 
   std::shared_ptr<GeometricSearchTracker> produce(const TrackerRecoGeometryRecord &);
  private:
  std::shared_ptr<GeometricSearchTracker> _tracker;

--- a/RecoTracker/MeasurementDet/interface/ClusterFilterPayload.h
+++ b/RecoTracker/MeasurementDet/interface/ClusterFilterPayload.h
@@ -5,7 +5,7 @@
 
 class SiStripCluster;
 struct ClusterFilterPayload final : public MeasurementEstimator::OpaquePayload {
-  ~ClusterFilterPayload(){}
+  ~ClusterFilterPayload() override{}
 
   ClusterFilterPayload(unsigned int id, SiStripCluster const	* mono, SiStripCluster const	* stereo=nullptr) : detId(id), cluster{mono,stereo}{ tag=myTag;}
   unsigned int detId=0;

--- a/RecoTracker/MeasurementDet/interface/MeasurementTracker.h
+++ b/RecoTracker/MeasurementDet/interface/MeasurementTracker.h
@@ -30,14 +30,14 @@ public:
 
 
 
-  virtual ~MeasurementTracker();
+  ~MeasurementTracker() override;
 
   const TrackingGeometry* geomTracker() const { return theTrackerGeom;}
 
   const GeometricSearchTracker* geometricSearchTracker() const {return theGeometricSearchTracker;}
 
   /// MeasurementDetSystem interface
-  virtual MeasurementDetWithData idToDet(const DetId& id, const MeasurementTrackerEvent &data) const = 0;
+  MeasurementDetWithData idToDet(const DetId& id, const MeasurementTrackerEvent &data) const override = 0;
 
   /// Provide templates to be filled in
   virtual const StMeasurementConditionSet & stripDetConditions() const = 0;

--- a/RecoTracker/MeasurementDet/interface/StartingLayerFinder.h
+++ b/RecoTracker/MeasurementDet/interface/StartingLayerFinder.h
@@ -41,7 +41,7 @@ public:
     thePropagator(aPropagator),
     theMeasurementTracker(tracker),
     thePixelLayersValid(false),
-    theFirstPixelBarrelLayer(0),
+    theFirstPixelBarrelLayer(nullptr),
     theFirstNegPixelFwdLayer(0),
     theFirstPosPixelFwdLayer(0) { }
 

--- a/RecoTracker/MeasurementDet/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
@@ -45,7 +45,7 @@ public:
                  const MeasurementEstimator::OpaquePayload  & opay) const override;
 
 
-  virtual Chi2ChargeMeasurementEstimator* clone() const override {
+  Chi2ChargeMeasurementEstimator* clone() const override {
     return new Chi2ChargeMeasurementEstimator(*this);
   }
 private:
@@ -108,7 +108,7 @@ class  Chi2ChargeMeasurementEstimatorESProducer: public edm::ESProducer{
  public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   Chi2ChargeMeasurementEstimatorESProducer(const edm::ParameterSet & p);
-  virtual ~Chi2ChargeMeasurementEstimatorESProducer(); 
+  ~Chi2ChargeMeasurementEstimatorESProducer() override; 
   std::shared_ptr<Chi2MeasurementEstimatorBase> produce(const TrackingComponentsRecord &);
 
  private:

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
@@ -59,8 +59,8 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
 { 
 
   // ========= SiPixelQuality related tasks =============
-  const SiPixelQuality    *ptr_pixelQuality = 0;
-  const SiPixelFedCabling *ptr_pixelCabling = 0;
+  const SiPixelQuality    *ptr_pixelQuality = nullptr;
+  const SiPixelFedCabling *ptr_pixelCabling = nullptr;
   int   pixelQualityFlags = 0;
   int   pixelQualityDebugFlags = 0;
   edm::ESHandle<SiPixelQuality>	      pixelQuality;
@@ -88,7 +88,7 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
   }
   
   // ========= SiStripQuality related tasks =============
-  const SiStripQuality *ptr_stripQuality = 0;
+  const SiStripQuality *ptr_stripQuality = nullptr;
   int   stripQualityFlags = 0;
   int   stripQualityDebugFlags = 0;
   edm::ESHandle<SiStripQuality>	stripQuality;

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.h
@@ -10,7 +10,7 @@
 class  dso_hidden MeasurementTrackerESProducer: public edm::ESProducer{
  public:
   MeasurementTrackerESProducer(const edm::ParameterSet & p);
-  virtual ~MeasurementTrackerESProducer(); 
+  ~MeasurementTrackerESProducer() override; 
   std::shared_ptr<MeasurementTracker> produce(const CkfComponentsRecord &);
  private:
   std::shared_ptr<MeasurementTracker> _measurementTracker;

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc
@@ -117,34 +117,34 @@ void MeasurementTrackerImpl::initialize(const TrackerTopology* trackerTopology)
   bool subIsOT = false;
 
   //if the TkGeometry has the subDet vector filled, the theDetMap is filled, otherwise nothing should happen
-  if(theTrackerGeom->detsPXB().size()!=0) {
+  if(!theTrackerGeom->detsPXB().empty()) {
     subIsPixel = GeomDetEnumerators::isTrackerPixel(theTrackerGeom->geomDetSubDetector(theTrackerGeom->detsPXB().front()->geographicalId().subdetId()));
     addDets(theTrackerGeom->detsPXB(), subIsPixel, subIsOT);
   }
 
-  if(theTrackerGeom->detsPXF().size()!=0) {
+  if(!theTrackerGeom->detsPXF().empty()) {
     subIsPixel = GeomDetEnumerators::isTrackerPixel(theTrackerGeom->geomDetSubDetector(theTrackerGeom->detsPXF().front()->geographicalId().subdetId()));
     addDets(theTrackerGeom->detsPXF(), subIsPixel, subIsOT);
   }
 
   subIsOT = true;
 
-  if(theTrackerGeom->detsTIB().size()!=0) {
+  if(!theTrackerGeom->detsTIB().empty()) {
     subIsPixel = GeomDetEnumerators::isTrackerPixel(theTrackerGeom->geomDetSubDetector(theTrackerGeom->detsTIB().front()->geographicalId().subdetId()));
     addDets(theTrackerGeom->detsTIB(), subIsPixel, subIsOT);
   }
 
-  if(theTrackerGeom->detsTID().size()!=0) {
+  if(!theTrackerGeom->detsTID().empty()) {
     subIsPixel = GeomDetEnumerators::isTrackerPixel(theTrackerGeom->geomDetSubDetector(theTrackerGeom->detsTID().front()->geographicalId().subdetId()));
     addDets(theTrackerGeom->detsTID(), subIsPixel, subIsOT);
   }
 
-  if(theTrackerGeom->detsTOB().size()!=0) {
+  if(!theTrackerGeom->detsTOB().empty()) {
     subIsPixel = GeomDetEnumerators::isTrackerPixel(theTrackerGeom->geomDetSubDetector(theTrackerGeom->detsTOB().front()->geographicalId().subdetId()));
     addDets(theTrackerGeom->detsTOB(), subIsPixel, subIsOT);
   }
 
-  if(theTrackerGeom->detsTEC().size()!=0) { 
+  if(!theTrackerGeom->detsTEC().empty()) { 
     subIsPixel = GeomDetEnumerators::isTrackerPixel(theTrackerGeom->geomDetSubDetector(theTrackerGeom->detsTEC().front()->geographicalId().subdetId()));
     addDets(theTrackerGeom->detsTEC(), subIsPixel, subIsOT);
   }
@@ -249,10 +249,10 @@ void MeasurementTrackerImpl::addDets( const TrackingGeometry::DetContainer& dets
       const GluedGeomDet* gluedDet = dynamic_cast<const GluedGeomDet*>(*gd);
       const StackGeomDet* stackDet = dynamic_cast<const StackGeomDet*>(*gd);
 
-      if ((gluedDet == 0 && stackDet == 0) || (gluedDet != 0 && stackDet != 0)) {
+      if ((gluedDet == nullptr && stackDet == nullptr) || (gluedDet != nullptr && stackDet != nullptr)) {
         throw MeasurementDetException("MeasurementTracker ERROR: GeomDet neither DetUnit nor GluedDet nor StackDet");
       }
-      if(gluedDet != 0)
+      if(gluedDet != nullptr)
         addGluedDet(gluedDet);
       else
         addStackDet(stackDet);
@@ -315,7 +315,7 @@ void MeasurementTrackerImpl::initGluedDet( TkGluedMeasurementDet & det, const Tr
   const GluedGeomDet& gd = det.specificGeomDet();
   const MeasurementDet* monoDet = findDet( gd.monoDet()->geographicalId());
   const MeasurementDet* stereoDet = findDet( gd.stereoDet()->geographicalId());
-  if (monoDet == 0 || stereoDet == 0) {
+  if (monoDet == nullptr || stereoDet == nullptr) {
     edm::LogError("MeasurementDet") << "MeasurementTracker ERROR: GluedDet components not found as MeasurementDets ";
     throw MeasurementDetException("MeasurementTracker ERROR: GluedDet components not found as MeasurementDets");
   }
@@ -328,7 +328,7 @@ void MeasurementTrackerImpl::initStackDet( TkStackMeasurementDet & det)
   const StackGeomDet& gd = det.specificGeomDet();
   const MeasurementDet* lowerDet = findDet( gd.lowerDet()->geographicalId());
   const MeasurementDet* upperDet = findDet( gd.upperDet()->geographicalId());
-  if (lowerDet == 0 || upperDet == 0) {
+  if (lowerDet == nullptr || upperDet == nullptr) {
     edm::LogError("MeasurementDet") << "MeasurementTracker ERROR: StackDet components not found as MeasurementDets ";
     throw MeasurementDetException("MeasurementTracker ERROR: StackDet components not found as MeasurementDets");
   }
@@ -348,7 +348,7 @@ void MeasurementTrackerImpl::initializeStripStatus(const SiStripQuality *quality
   theStDetConditions.setMaskBad128StripBlocks((qualityFlags & MaskBad128StripBlocks) != 0);
   
   
-  if ((quality != 0) && (qualityFlags != 0))  {
+  if ((quality != nullptr) && (qualityFlags != 0))  {
     edm::LogInfo("MeasurementTracker") << "qualityFlags = " << qualityFlags;
     unsigned int on = 0, tot = 0; 
     unsigned int foff = 0, ftot = 0, aoff = 0, atot = 0; 
@@ -414,7 +414,7 @@ void MeasurementTrackerImpl::initializeStripStatus(const SiStripQuality *quality
 }
 
 void MeasurementTrackerImpl::initializePixelStatus(const SiPixelQuality *quality, const SiPixelFedCabling *pixelCabling, int qualityFlags, int qualityDebugFlags) {
-  if ((quality != 0) && (qualityFlags != 0))  {
+  if ((quality != nullptr) && (qualityFlags != 0))  {
     edm::LogInfo("MeasurementTracker") << "qualityFlags = " << qualityFlags;
     unsigned int on = 0, tot = 0, badrocs = 0; 
     for (std::vector<TkPixelMeasurementDet>::iterator i=thePixelDets.begin();

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.h
@@ -62,9 +62,9 @@ public:
                      const SiPixelFedCabling *pixelCabling,
                      int   pixelQualityFlags,
                      int   pixelQualityDebugFlags,
-		     const ClusterParameterEstimator<Phase2TrackerCluster1D>* phase2OTCPE = 0);
+		     const ClusterParameterEstimator<Phase2TrackerCluster1D>* phase2OTCPE = nullptr);
 
-  virtual ~MeasurementTrackerImpl();
+  ~MeasurementTrackerImpl() override;
  
   const TrackingGeometry* geomTracker() const { return theTrackerGeom;}
 
@@ -72,7 +72,7 @@ public:
 
   /// MeasurementDetSystem interface  (won't be overloaded anymore)
   MeasurementDetWithData 
-  idToDet(const DetId& id, const MeasurementTrackerEvent &data) const {
+  idToDet(const DetId& id, const MeasurementTrackerEvent &data) const override {
     return MeasurementDetWithData(*idToDetBare(id, data), data);
   }
 
@@ -93,7 +93,7 @@ public:
       //throw exception;
     }
     
-    return 0; //to avoid compile warning
+    return nullptr; //to avoid compile warning
   }
 
   typedef std::unordered_map<unsigned int,MeasurementDet*>   DetContainer;
@@ -105,9 +105,9 @@ public:
   const std::vector<TkGluedMeasurementDet>& gluedDets() const {return theGluedDets;}
   const std::vector<TkStackMeasurementDet>& stackDets() const {return theStackDets;}
 
-  virtual const StMeasurementConditionSet & stripDetConditions() const { return theStDetConditions; }
-  virtual const PxMeasurementConditionSet & pixelDetConditions() const { return thePxDetConditions; }
-  virtual const Phase2OTMeasurementConditionSet & phase2DetConditions() const { return thePhase2DetConditions; }
+  const StMeasurementConditionSet & stripDetConditions() const override { return theStDetConditions; }
+  const PxMeasurementConditionSet & pixelDetConditions() const override { return thePxDetConditions; }
+  const Phase2OTMeasurementConditionSet & phase2DetConditions() const override { return thePhase2DetConditions; }
 
  protected:
   const edm::ParameterSet& pset_;

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
@@ -84,7 +84,7 @@ void TkGluedMeasurementDet::init(const MeasurementDet* monoDet,
   theStereoDet = dynamic_cast<const TkStripMeasurementDet *>(stereoDet);
   theTopology = tTopo;
   
-  if ((theMonoDet == 0) || (theStereoDet == 0)) {
+  if ((theMonoDet == nullptr) || (theStereoDet == nullptr)) {
     throw MeasurementDetException("TkGluedMeasurementDet ERROR: Trying to glue a det which is not a TkStripMeasurementDet");
   }
 }

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.h
@@ -24,19 +24,19 @@ public:
 	    const MeasurementDet* stereoDet,
 	    const TrackerTopology* tTopo);
 
-  virtual RecHitContainer recHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & data) const;
+  RecHitContainer recHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & data) const override;
 
  // simple hits
-  virtual bool recHits(SimpleHitContainer & result,  
-		       const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator&, const MeasurementTrackerEvent & data) const;
+  bool recHits(SimpleHitContainer & result,  
+		       const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator&, const MeasurementTrackerEvent & data) const override;
 
   
 
  const GluedGeomDet& specificGeomDet() const {return static_cast<GluedGeomDet const&>(fastGeomDet());}
 
- virtual bool measurements( const TrajectoryStateOnSurface& stateOnThisDet,
+ bool measurements( const TrajectoryStateOnSurface& stateOnThisDet,
 			     const MeasurementEstimator& est, const MeasurementTrackerEvent & data,
-			    TempMeasurements & result) const;
+			    TempMeasurements & result) const override;
 
   const TkStripMeasurementDet* monoDet() const{ return theMonoDet;} 
   const TkStripMeasurementDet* stereoDet() const{ return theStereoDet;} 
@@ -45,10 +45,10 @@ public:
 
 
   /// return TRUE if both mono and stereo components are active
-  bool isActive(const MeasurementTrackerEvent & data) const {return monoDet()->isActive(data) && stereoDet()->isActive(data); }
+  bool isActive(const MeasurementTrackerEvent & data) const override {return monoDet()->isActive(data) && stereoDet()->isActive(data); }
  	  	 
   /// return TRUE if at least one of the mono and stereo components has badChannels
-  bool hasBadComponents( const TrajectoryStateOnSurface &tsos, const MeasurementTrackerEvent & data ) const {
+  bool hasBadComponents( const TrajectoryStateOnSurface &tsos, const MeasurementTrackerEvent & data ) const override {
     return (monoDet()->hasBadComponents(tsos,data) || stereoDet()->hasBadComponents(tsos,data));}
 
 private:
@@ -85,7 +85,7 @@ private:
     static bool filter() { return false;}   /// always fast as no estimator available here! 
     size_t size() const { return target_.size();}
 
-    static const MeasurementEstimator  & estimator() { static const MeasurementEstimator * dummy=0; return *dummy;}
+    static const MeasurementEstimator  & estimator() { static const MeasurementEstimator * dummy=nullptr; return *dummy;}
 
   private: 
     const GeomDet              * geomDet_;

--- a/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.cc
@@ -12,7 +12,7 @@ TkPhase2OTMeasurementDet::TkPhase2OTMeasurementDet( const GeomDet* gdet,
     MeasurementDet (gdet),
     theDetConditions(&conditions)
   {
-    if ( dynamic_cast<const PixelGeomDetUnit*>(gdet) == 0) {
+    if ( dynamic_cast<const PixelGeomDetUnit*>(gdet) == nullptr) {
       throw MeasurementDetException( "TkPhase2OTMeasurementDet constructed with a GeomDet which is not a PixelGeomDetUnit");
     }
   }
@@ -134,8 +134,8 @@ TkPhase2OTMeasurementDet::recHits( const TrajectoryStateOnSurface& ts, const Mea
   RecHitContainer result;
   if (isEmpty(data.phase2OTData())) return result;
   if (!isActive(data)) return result;
-  const Phase2TrackerCluster1D* begin=0;
-  if (0 != data.phase2OTData().handle()->data().size()) {
+  const Phase2TrackerCluster1D* begin=nullptr;
+  if (!data.phase2OTData().handle()->data().empty()) {
      begin = &(data.phase2OTData().handle()->data().front());
   }
   const detset & detSet = data.phase2OTData().detSet(index());

--- a/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.h
@@ -33,25 +33,25 @@ public:
   void setEmpty(Phase2OTMeasurementDetSet & data) { data.setEmpty(index());  }
   bool isEmpty(const Phase2OTMeasurementDetSet & data) const {return data.empty(index());}
 
-  virtual ~TkPhase2OTMeasurementDet() { }
+  ~TkPhase2OTMeasurementDet() override { }
 
-  virtual RecHitContainer recHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & dat ) const override;
-  virtual bool recHits( const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator&, const MeasurementTrackerEvent & data,
+  RecHitContainer recHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & dat ) const override;
+  bool recHits( const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator&, const MeasurementTrackerEvent & data,
 			RecHitContainer & result, std::vector<float> &) const override;
  
 
 
  // simple hits
-  virtual bool recHits(SimpleHitContainer & result,  
+  bool recHits(SimpleHitContainer & result,  
 		       const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator&, const MeasurementTrackerEvent & data) const override {
     assert("not implemented for Pixel yet"==nullptr);
   }
 
  
 
-  virtual bool measurements( const TrajectoryStateOnSurface& stateOnThisDet,
+  bool measurements( const TrajectoryStateOnSurface& stateOnThisDet,
 			    const MeasurementEstimator& est, const MeasurementTrackerEvent & dat,
-			    TempMeasurements & result) const;
+			    TempMeasurements & result) const override;
 
 
   const PixelGeomDetUnit& specificGeomDet() const {return static_cast<PixelGeomDetUnit const &>(fastGeomDet());}
@@ -66,9 +66,9 @@ public:
              This per-event flag is cleared by any call to 'update' or 'setEmpty'  */
   void setActiveThisEvent(Phase2OTMeasurementDetSet & data, bool active) const { data.setActiveThisEvent(index(), active); }
   /** \brief Is this module active in reconstruction? It must be both 'setActiveThisEvent' and 'setActive'. */
-  bool isActive(const MeasurementTrackerEvent & data) const { return data.phase2OTData().isActive(index()); }
+  bool isActive(const MeasurementTrackerEvent & data) const override { return data.phase2OTData().isActive(index()); }
 
-  bool hasBadComponents( const TrajectoryStateOnSurface &tsos, const MeasurementTrackerEvent & dat ) const ; 
+  bool hasBadComponents( const TrajectoryStateOnSurface &tsos, const MeasurementTrackerEvent & dat ) const override ; 
 
   //FIXME:just temporary solution for phase2!
   /** \brief Sets the list of bad ROCs, identified by the positions of their centers in the local coordinate frame*/

--- a/RecoTracker/MeasurementDet/plugins/TkStackMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkStackMeasurementDet.cc
@@ -16,7 +16,7 @@ void TkStackMeasurementDet::init(const MeasurementDet* lowerDet,
   theInnerDet = dynamic_cast<const TkPhase2OTMeasurementDet *>(lowerDet);
   theOuterDet = dynamic_cast<const TkPhase2OTMeasurementDet *>(upperDet);
 
-  if ((theInnerDet == 0) || (theOuterDet == 0)) {
+  if ((theInnerDet == nullptr) || (theOuterDet == nullptr)) {
     throw MeasurementDetException("TkStackMeasurementDet ERROR: Trying to glue a det which is not a TkPhase2OTMeasurementDet");
   }
 }

--- a/RecoTracker/MeasurementDet/plugins/TkStackMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkStackMeasurementDet.h
@@ -19,22 +19,22 @@ class TkStackMeasurementDet GCC11_FINAL : public MeasurementDet {
   void init(const MeasurementDet* lowerDet,
 	    const MeasurementDet* upperDet);
 
-  virtual RecHitContainer recHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & data) const;
+  RecHitContainer recHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & data) const override;
 
   const StackGeomDet& specificGeomDet() const {return static_cast<StackGeomDet const&>(fastGeomDet());}
 
-  virtual bool measurements( const TrajectoryStateOnSurface& stateOnThisDet,
+  bool measurements( const TrajectoryStateOnSurface& stateOnThisDet,
 			     const MeasurementEstimator& est, const MeasurementTrackerEvent & data,
-			     TempMeasurements & result) const;
+			     TempMeasurements & result) const override;
 
   const TkPhase2OTMeasurementDet* lowerDet() const{ return theInnerDet;}
   const TkPhase2OTMeasurementDet* upperDet() const{ return theOuterDet;}
 
   /// return TRUE if both lower and upper components are active
-  bool isActive(const MeasurementTrackerEvent & data) const {return lowerDet()->isActive(data) && upperDet()->isActive(data); }
+  bool isActive(const MeasurementTrackerEvent & data) const override {return lowerDet()->isActive(data) && upperDet()->isActive(data); }
 
   /// return TRUE if at least one of the lower and upper components has badChannels
-  bool hasBadComponents( const TrajectoryStateOnSurface &tsos, const MeasurementTrackerEvent & data ) const {
+  bool hasBadComponents( const TrajectoryStateOnSurface &tsos, const MeasurementTrackerEvent & data ) const override {
     return (lowerDet()->hasBadComponents(tsos, data) || upperDet()->hasBadComponents(tsos, data));}
 
  private:

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
@@ -16,7 +16,7 @@
 TkStripMeasurementDet::TkStripMeasurementDet( const GeomDet* gdet, StMeasurementConditionSet & conditions ) : 
   MeasurementDet (gdet), index_(-1), theDetConditions(&conditions)
   {
-    if (dynamic_cast<const StripGeomDetUnit*>(gdet) == 0) {
+    if (dynamic_cast<const StripGeomDetUnit*>(gdet) == nullptr) {
       throw MeasurementDetException( "TkStripMeasurementDet constructed with a GeomDet which is not a StripGeomDetUnit");
     }
   }
@@ -216,7 +216,7 @@ TkStripMeasurementDet::simpleRecHits( const TrajectoryStateOnSurface& ts, const 
 
     const detset & detSet = data.stripData().detSet(index());
     unInitDynArray(AClusters::value_type,detSet.size(),clusters);
-    assert(clusters.size()==0);
+    assert(clusters.empty());
     for (auto const & ci : detSet) {
       if (isMasked(ci)) continue;
       if (accept(detSet.makeKeyOf(&ci), data.stripClustersToSkip()))

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
@@ -47,9 +47,9 @@ struct dso_hidden TkStripRecHitIter {
     : mdet(&imdet),tsos(&itsos),data(&idata), clusterI(ci), clusterE(ce) {}
   
   
-  const TkStripMeasurementDet * mdet = 0;
-  const TrajectoryStateOnSurface * tsos=0;
-  const MeasurementTrackerEvent * data=0;
+  const TkStripMeasurementDet * mdet = nullptr;
+  const TrajectoryStateOnSurface * tsos=nullptr;
+  const MeasurementTrackerEvent * data=nullptr;
   
   new_const_iterator clusterI;
   new_const_iterator clusterE;
@@ -96,7 +96,7 @@ public:
   
   typedef std::vector<SiStripCluster>::const_iterator const_iterator;
   
-  virtual ~TkStripMeasurementDet(){}
+  ~TkStripMeasurementDet() override{}
   
   TkStripMeasurementDet( const GeomDet* gdet, StMeasurementConditionSet & conditionSet );
 
@@ -117,17 +117,17 @@ public:
 
   
   /** \brief Is this module active in reconstruction? It must be both 'setActiveThisEvent' and 'setActive'. */
-  bool isActive(const MeasurementTrackerEvent & data) const { return data.stripData().isActive(index()); }
+  bool isActive(const MeasurementTrackerEvent & data) const override { return data.stripData().isActive(index()); }
   
   //TO BE IMPLEMENTED
-  bool hasBadComponents( const TrajectoryStateOnSurface &tsos, const MeasurementTrackerEvent & data ) const {return false;}
+  bool hasBadComponents( const TrajectoryStateOnSurface &tsos, const MeasurementTrackerEvent & data ) const override {return false;}
   
   
   std::tuple<TkStripRecHitIter,TkStripRecHitIter> hitRange(const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & data) const;
   void advance(TkStripRecHitIter & hi ) const;
   SiStripRecHit2D hit(TkStripRecHitIter const & hi ) const;
   
-  virtual RecHitContainer recHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & data) const;
+  RecHitContainer recHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & data) const override;
 
 
   bool empty(const MeasurementTrackerEvent & data) const;
@@ -136,17 +136,17 @@ public:
   bool simpleRecHits( const TrajectoryStateOnSurface& ts, const MeasurementEstimator& est, const MeasurementTrackerEvent & data, std::vector<SiStripRecHit2D> &result) const ;
   
   // simple hits
-  virtual bool recHits(SimpleHitContainer & result,  
-		       const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator&, const MeasurementTrackerEvent & data) const;
+  bool recHits(SimpleHitContainer & result,  
+		       const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator&, const MeasurementTrackerEvent & data) const override;
 
   // TTRH
-  virtual bool recHits( const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator& est, const MeasurementTrackerEvent & data,
-			RecHitContainer & result, std::vector<float> & diffs) const;
+  bool recHits( const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator& est, const MeasurementTrackerEvent & data,
+			RecHitContainer & result, std::vector<float> & diffs) const override;
   
   
-  virtual bool measurements( const TrajectoryStateOnSurface& stateOnThisDet,
+  bool measurements( const TrajectoryStateOnSurface& stateOnThisDet,
 			     const MeasurementEstimator& est, const MeasurementTrackerEvent & data,
-			     TempMeasurements & result) const;
+			     TempMeasurements & result) const override;
   
   const StripGeomDetUnit& specificGeomDet() const {return static_cast<StripGeomDetUnit const &>(fastGeomDet());}
   

--- a/RecoTracker/MeasurementDet/src/MeasurementTrackerEvent.cc
+++ b/RecoTracker/MeasurementDet/src/MeasurementTrackerEvent.cc
@@ -4,9 +4,9 @@
 MeasurementTrackerEvent::~MeasurementTrackerEvent() {
     if (theOwner) {
         //std::cout << "Deleting owned MT @" << this << " (strip data @ " << theStripData << ")" << std::endl;
-        delete theStripData; theStripData = 0; // also sets to zero since sometimes the FWK seems
-        delete thePixelData; thePixelData = 0; // to double-delete the same object (!!!)
-        delete thePhase2OTData; thePhase2OTData = 0; // to double-delete the same object (!!!)
+        delete theStripData; theStripData = nullptr; // also sets to zero since sometimes the FWK seems
+        delete thePixelData; thePixelData = nullptr; // to double-delete the same object (!!!)
+        delete thePhase2OTData; thePhase2OTData = nullptr; // to double-delete the same object (!!!)
     }
 }
 

--- a/RecoTracker/NuclearSeedGenerator/interface/NuclearSeedsEDProducer.h
+++ b/RecoTracker/NuclearSeedGenerator/interface/NuclearSeedsEDProducer.h
@@ -50,11 +50,11 @@ class NuclearSeedsEDProducer : public edm::stream::EDProducer<> {
 
    public:
       explicit NuclearSeedsEDProducer(const edm::ParameterSet&);
-      ~NuclearSeedsEDProducer();
+      ~NuclearSeedsEDProducer() override;
 
    private:
-      virtual void beginRun(edm::Run const& run, const edm::EventSetup&) override;
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      void beginRun(edm::Run const& run, const edm::EventSetup&) override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
 
       // ----------member data ---------------------------
       edm::ParameterSet conf_;

--- a/RecoTracker/NuclearSeedGenerator/interface/NuclearTrackCorrector.h
+++ b/RecoTracker/NuclearSeedGenerator/interface/NuclearTrackCorrector.h
@@ -24,7 +24,7 @@
 // system include files
 #include <memory>
 #include <string>
-#include <stdio.h>
+#include <cstdio>
 
 // user include files
 
@@ -82,11 +82,11 @@ public:
    public:
 
       explicit NuclearTrackCorrector(const edm::ParameterSet&);
-      ~NuclearTrackCorrector();
+      ~NuclearTrackCorrector() override;
 
    private:
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override ;
+      void produce(edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
 
       /// check if the trajectory has to be refitted and get the new trajectory
       bool newTrajNeeded(Trajectory& newtrajectory, const TrajectoryRef& trajRef, const reco::NuclearInteraction& ni);

--- a/RecoTracker/NuclearSeedGenerator/plugins/NuclearTrackCorrector.cc
+++ b/RecoTracker/NuclearSeedGenerator/plugins/NuclearTrackCorrector.cc
@@ -34,7 +34,7 @@ using namespace reco;
 
 NuclearTrackCorrector::NuclearTrackCorrector(const edm::ParameterSet& iConfig) :
 conf_(iConfig),
-theInitialState(0)
+theInitialState(nullptr)
 {
      str_Input_Trajectory           = iConfig.getParameter<std::string>     ("InputTrajectory");
      str_Input_NuclearInteraction   = iConfig.getParameter<std::string>     ("InputNuclearInteraction");
@@ -93,15 +93,15 @@ NuclearTrackCorrector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
   // Load Inputs
   // --------------------------------------------------------------------------------------------------
   edm::Handle< TrajectoryCollection > temp_m_TrajectoryCollection;
-  iEvent.getByLabel( str_Input_Trajectory.c_str(), temp_m_TrajectoryCollection );
+  iEvent.getByLabel( str_Input_Trajectory, temp_m_TrajectoryCollection );
   const TrajectoryCollection m_TrajectoryCollection = *(temp_m_TrajectoryCollection.product());
 
   edm::Handle< NuclearInteractionCollection > temp_m_NuclearInteractionCollection;
-  iEvent.getByLabel( str_Input_NuclearInteraction.c_str(), temp_m_NuclearInteractionCollection );
+  iEvent.getByLabel( str_Input_NuclearInteraction, temp_m_NuclearInteractionCollection );
   const NuclearInteractionCollection m_NuclearInteractionCollection = *(temp_m_NuclearInteractionCollection.product());
 
   edm::Handle< TrajTrackAssociationCollection > h_TrajToTrackCollection;
-  iEvent.getByLabel( str_Input_Trajectory.c_str(), h_TrajToTrackCollection );
+  iEvent.getByLabel( str_Input_Trajectory, h_TrajToTrackCollection );
   m_TrajToTrackCollection = h_TrajToTrackCollection.product();
 
 

--- a/RecoTracker/NuclearSeedGenerator/src/NuclearInteractionFinder.cc
+++ b/RecoTracker/NuclearSeedGenerator/src/NuclearInteractionFinder.cc
@@ -142,7 +142,7 @@ void NuclearInteractionFinder::definePrimaryHelix(std::vector<TrajectoryMeasurem
 std::vector<TrajectoryMeasurement>
 NuclearInteractionFinder::findCompatibleMeasurements(const TM& lastMeas, double rescale, const LayerMeasurements & layerMeasurements) const
 {
-  TSOS currentState = lastMeas.updatedState();
+  const TSOS& currentState = lastMeas.updatedState();
   LogDebug("NuclearSeedGenerator") << "currentState :" << currentState << "\n";
 
   TSOS newState = rescaleError(rescale, currentState);

--- a/RecoTracker/NuclearSeedGenerator/src/SeedFromNuclearInteraction.cc
+++ b/RecoTracker/NuclearSeedGenerator/src/SeedFromNuclearInteraction.cc
@@ -126,7 +126,7 @@ bool SeedFromNuclearInteraction::construct() {
    // loop on all hits in theHits
    KFUpdator                 theUpdator;
 
-   const TrackingRecHit* hit = 0;
+   const TrackingRecHit* hit = nullptr;
 
    LogDebug("NuclearSeedGenerator") << "Seed ** initial state " << freeTS_->cartesianError().matrix();
 

--- a/RecoTracker/SiTrackerMRHTools/interface/GenericProjectedRecHit2D.h
+++ b/RecoTracker/SiTrackerMRHTools/interface/GenericProjectedRecHit2D.h
@@ -13,44 +13,44 @@ public:
                      const TransientTrackingRecHit::ConstRecHitPointer originalHit,
                      const TrackingRecHitPropagator* propagator);
 
-  virtual AlgebraicSymMatrix parametersError() const {
+  AlgebraicSymMatrix parametersError() const override {
     return HelpertRecHit2DLocalPos().parError( localPositionError(), *det()); 
   }
 
   //virtual ~GenericProjectedRecHit2D(){delete theOriginalTransientHit;}
 
-  virtual AlgebraicVector parameters() const ;
+  AlgebraicVector parameters() const override ;
 
-  virtual LocalPoint localPosition() const {return theLp;}
+  LocalPoint localPosition() const override {return theLp;}
 
-  virtual LocalError localPositionError() const {return theLe;}  
+  LocalError localPositionError() const override {return theLe;}  
 
-  virtual AlgebraicMatrix projectionMatrix() const {return theProjectionMatrix;} 	
+  AlgebraicMatrix projectionMatrix() const override {return theProjectionMatrix;} 	
 
   virtual DetId geographicalId() const {return det() ? det()->geographicalId() : DetId();}
 
-  virtual int dimension() const {return theDimension;}
+  int dimension() const override {return theDimension;}
 
   //this hit lays on the original surface, NOT on the projection surface
-  virtual const TrackingRecHit * hit() const { return theOriginalTransientHit->hit(); }	
+  const TrackingRecHit * hit() const override { return theOriginalTransientHit->hit(); }	
 
-  virtual TrackingRecHit * cloneHit() const { return theOriginalTransientHit->cloneHit(); }	
+  TrackingRecHit * cloneHit() const override { return theOriginalTransientHit->cloneHit(); }	
 
   virtual bool isValid() const{return true;}
 
-  virtual std::vector<const TrackingRecHit*> recHits() const {
+  std::vector<const TrackingRecHit*> recHits() const override {
   	//return theOriginalTransientHit->hit()->recHits();
 	return std::vector<const TrackingRecHit*>();
   }
 
-  virtual std::vector<TrackingRecHit*> recHits() {
+  std::vector<TrackingRecHit*> recHits() override {
 	//should it do something different?
         return std::vector<TrackingRecHit*>();
   }
 
   const TrackingRecHitPropagator* propagator() const {return thePropagator;}
 
-  virtual bool canImproveWithTrack() const {return true;} 
+  bool canImproveWithTrack() const override {return true;} 
    
   const GeomDet* originalDet() const {return theOriginalDet;}
 
@@ -74,7 +74,7 @@ private:
   //const TrackingRecHit* theOriginalHit;
   int theDimension; 
 
-  virtual GenericProjectedRecHit2D* clone() const {
+  GenericProjectedRecHit2D* clone() const override {
     return new GenericProjectedRecHit2D(*this);
   }
 

--- a/RecoTracker/SiTrackerMRHTools/interface/GroupedDAFHitCollector.h
+++ b/RecoTracker/SiTrackerMRHTools/interface/GroupedDAFHitCollector.h
@@ -31,9 +31,9 @@ public:
 		theEstimator(est), thePropagator(propagator), theReversePropagator(reversePropagator), debug_(debug){}
 			
 
-	virtual ~GroupedDAFHitCollector(){}
+	~GroupedDAFHitCollector() override{}
 
-	virtual std::vector<TrajectoryMeasurement> recHits(const Trajectory&, 
+	std::vector<TrajectoryMeasurement> recHits(const Trajectory&, 
 							   const MeasurementTrackerEvent *theMT) const override;
 
 	const SiTrackerMultiRecHitUpdator* getUpdator() const {return theUpdator;}

--- a/RecoTracker/SiTrackerMRHTools/interface/MeasurementByLayerGrouper.h
+++ b/RecoTracker/SiTrackerMRHTools/interface/MeasurementByLayerGrouper.h
@@ -21,7 +21,7 @@ private:
 
 public:
 
-  explicit MeasurementByLayerGrouper(const GeometricSearchTracker* search = 0):theGeomSearch(search){};
+  explicit MeasurementByLayerGrouper(const GeometricSearchTracker* search = nullptr):theGeomSearch(search){};
 
   std::vector<std::pair<const DetLayer*, std::vector<TM> > > operator()(const std::vector<TM>&) const;
 

--- a/RecoTracker/SiTrackerMRHTools/interface/SimpleDAFHitCollector.h
+++ b/RecoTracker/SiTrackerMRHTools/interface/SimpleDAFHitCollector.h
@@ -26,7 +26,7 @@ class SimpleDAFHitCollector :public MultiRecHitCollector {
 }
 			
 
-	virtual ~SimpleDAFHitCollector(){}
+	~SimpleDAFHitCollector() override{}
 	
 	//given a trajectory it returns a collection
         //of SiTrackerMultiRecHits and InvalidTransientRecHits.
@@ -35,7 +35,7 @@ class SimpleDAFHitCollector :public MultiRecHitCollector {
         //If measurements are found a SiTrackerMultiRecHit is built.
 	//All the components will lay on the same detector  
 	
-	virtual std::vector<TrajectoryMeasurement> recHits(const Trajectory&, const MeasurementTrackerEvent *theMTE) const override;
+	std::vector<TrajectoryMeasurement> recHits(const Trajectory&, const MeasurementTrackerEvent *theMTE) const override;
 
 	const SiTrackerMultiRecHitUpdator* getUpdator() const {return theUpdator;}
 	const MeasurementEstimator* getEstimator() const {return theEstimator;}

--- a/RecoTracker/SiTrackerMRHTools/plugins/MultiRecHitCollectorESProducer.h
+++ b/RecoTracker/SiTrackerMRHTools/plugins/MultiRecHitCollectorESProducer.h
@@ -19,7 +19,7 @@
 class  MultiRecHitCollectorESProducer: public edm::ESProducer{
  public:
   MultiRecHitCollectorESProducer(const edm::ParameterSet& iConfig);
-  virtual ~MultiRecHitCollectorESProducer(); 
+  ~MultiRecHitCollectorESProducer() override; 
   std::shared_ptr<MultiRecHitCollector> produce(const MultiRecHitRecord &);
 
   // Set parameter set

--- a/RecoTracker/SiTrackerMRHTools/plugins/SiTrackerMultiRecHitUpdatorESProducer.h
+++ b/RecoTracker/SiTrackerMRHTools/plugins/SiTrackerMultiRecHitUpdatorESProducer.h
@@ -11,7 +11,7 @@
 class  SiTrackerMultiRecHitUpdatorESProducer: public edm::ESProducer{
  public:
   SiTrackerMultiRecHitUpdatorESProducer(const edm::ParameterSet & p);
-  virtual ~SiTrackerMultiRecHitUpdatorESProducer(); 
+  ~SiTrackerMultiRecHitUpdatorESProducer() override; 
   std::shared_ptr<SiTrackerMultiRecHitUpdator> produce(const MultiRecHitRecord &);
  private:
   std::shared_ptr<SiTrackerMultiRecHitUpdator> _updator;

--- a/RecoTracker/SiTrackerMRHTools/src/GroupedDAFHitCollector.cc
+++ b/RecoTracker/SiTrackerMRHTools/src/GroupedDAFHitCollector.cc
@@ -216,7 +216,7 @@ void GroupedDAFHitCollector::buildMultiRecHits(const vector<TrajectoryMeasuremen
 	if (result.size() == initial_size){
 		LogTrace("MultiRecHitCollector") << "no valid measuremnt or no valid TSOS in none of the groups";
 		//measgroup has been already checked for size != 0
-		if (measgroup.back().measurements().size() != 0){	
+		if (!measgroup.back().measurements().empty()){	
 			result.push_back(measgroup.back().measurements().back());
 		} 
 	}

--- a/RecoTracker/SiTrackerMRHTools/src/MeasurementByLayerGrouper.cc
+++ b/RecoTracker/SiTrackerMRHTools/src/MeasurementByLayerGrouper.cc
@@ -22,7 +22,7 @@ vector<pair<const DetLayer*, vector<TrajectoryMeasurement> > > MeasurementByLaye
 		do {ipart++;}
     		while(ipart != vtm.end() && 
 	  		getDetLayer(*start)==getDetLayer(*ipart) &&
-			getDetLayer(*start) != 0  //the returned pointer will be 0 in case
+			getDetLayer(*start) != nullptr  //the returned pointer will be 0 in case
                                                   //the measurement contains an invalid hit with no associated detid.
 						  //This kind of hits are at most one per layer.
 						  //this last condition avoids that 2 consecutive measurements of this kind
@@ -56,16 +56,16 @@ const DetLayer* MeasurementByLayerGrouper::getDetLayer(const TM& tm) const {
 	//returns 0 for the moment
 	//to be revisited
 	
-        if (tm.recHit()->det()==0){
+        if (tm.recHit()->det()==nullptr){
 	  LogDebug("MeasurementByLayerGrouper") <<"This hit has no geomdet associated skipping... ";
-		return 0;
+		return nullptr;
         }
 
 	//now the cases in which the detid is set
 
 	if (!theGeomSearch) {
 		throw cms::Exception("MeasurementByLayerGrouper") << "Impossible to retrieve the det layer because it's not set in the TM and the pointer to the GeometricSearchTracker is 0 ";
-		return 0;	
+		return nullptr;	
 	}
 
 	return theGeomSearch->detLayer(tm.recHit()->det()->geographicalId());

--- a/RecoTracker/SiTrackerMRHTools/src/SiTrackerMultiRecHitUpdator.cc
+++ b/RecoTracker/SiTrackerMRHTools/src/SiTrackerMultiRecHitUpdator.cc
@@ -87,7 +87,7 @@ TransientTrackingRecHit::RecHitPointer SiTrackerMultiRecHitUpdator::update( Tran
   }
   
   std::vector<TransientTrackingRecHit::RecHitPointer> updatedcomponents;
-  const GeomDet* geomdet = 0;
+  const GeomDet* geomdet = nullptr;
 
   //running on all over the MRH components 
   for (TransientTrackingRecHit::ConstRecHitContainer::const_iterator iter = tcomponents.begin(); iter != tcomponents.end(); iter++){

--- a/RecoTracker/SiTrackerMRHTools/src/SimpleDAFHitCollector.cc
+++ b/RecoTracker/SiTrackerMRHTools/src/SimpleDAFHitCollector.cc
@@ -31,7 +31,7 @@ vector<TrajectoryMeasurement> SimpleDAFHitCollector::recHits(const Trajectory& t
 
   //WARNING: At the moment the trajectories has the measurements 
   //with reversed sorting after the track smoothing
-  const vector<TrajectoryMeasurement> meas = traj.measurements();
+  const vector<TrajectoryMeasurement>& meas = traj.measurements();
   unsigned int hitcounter = 1;
 
   if (meas.empty()) return vector<TrajectoryMeasurement>();

--- a/RecoTracker/SingleTrackPattern/interface/CRackTrajectoryBuilder.h
+++ b/RecoTracker/SingleTrackPattern/interface/CRackTrajectoryBuilder.h
@@ -48,8 +48,8 @@
      const GeomDet* detPos1 = _tracker.idToDet(rh1->geographicalId());
      const GeomDet* detPos2 = _tracker.idToDet(rh2->geographicalId());
 
-     GlobalPoint gp1 = detPos1->position();
-     GlobalPoint gp2 = detPos2->position();
+     const GlobalPoint& gp1 = detPos1->position();
+     const GlobalPoint& gp2 = detPos2->position();
      
      if (gp1.y()>gp2.y())
        return true;
@@ -73,8 +73,8 @@
      const GeomDet* detPos1 = _tracker.idToDet(rh1->geographicalId());
      const GeomDet* detPos2 = _tracker.idToDet(rh2->geographicalId());
 
-     GlobalPoint gp1 = detPos1->position();
-     GlobalPoint gp2 = detPos2->position();
+     const GlobalPoint& gp1 = detPos1->position();
+     const GlobalPoint& gp2 = detPos2->position();
      
      if (gp1.y()<gp2.y())
        return true;

--- a/RecoTracker/SingleTrackPattern/interface/CosmicTrackFinder.h
+++ b/RecoTracker/SingleTrackPattern/interface/CosmicTrackFinder.h
@@ -72,9 +72,9 @@ namespace cms
 
     explicit CosmicTrackFinder(const edm::ParameterSet& conf);
 
-    virtual ~CosmicTrackFinder();
+    ~CosmicTrackFinder() override;
 
-    virtual void produce(edm::Event& e, const edm::EventSetup& c);
+    void produce(edm::Event& e, const edm::EventSetup& c) override;
 
   private:
     CosmicTrajectoryBuilder cosmicTrajectoryBuilder_;

--- a/RecoTracker/SingleTrackPattern/src/CRackTrajectoryBuilder.cc
+++ b/RecoTracker/SingleTrackPattern/src/CRackTrajectoryBuilder.cc
@@ -133,7 +133,7 @@ void CRackTrajectoryBuilder::run(const TrajectorySeedCollection &collseed,
     seed_plus = !seed_plus;
     vector<const TrackingRecHit*> allHitsOppsite = SortHits(collstereo,collrphi,collmatched,collpixel, *iseed, true);
     seed_plus = !seed_plus;
-    if (allHitsOppsite.size())
+    if (!allHitsOppsite.empty())
       {
 	//there are hits which are above the seed,
 	//cout << "Number of hits higher than seed " <<allHitsOppsite.size() << endl;	
@@ -549,7 +549,7 @@ CRackTrajectoryBuilder::startingTSOS(const TrajectorySeed& seed)const
 void CRackTrajectoryBuilder::AddHit(Trajectory &traj,
                                      const vector<const TrackingRecHit*>& _Hits, Propagator *currPropagator){
    vector<const TrackingRecHit*> Hits = _Hits;
-   if ( Hits.size() == 0 )
+   if ( Hits.empty() )
      return;
   
    if (debug_info) cout << "CRackTrajectoryBuilder::AddHit" << endl;
@@ -681,7 +681,7 @@ void CRackTrajectoryBuilder::AddHit(Trajectory &traj,
  	      trackHitCandidates.push_back(  make_pair(iHit, prSt) );
  	    }
  	  
- 	  if (!trackHitCandidates.size())
+ 	  if (trackHitCandidates.empty())
  	  break;
  
  	  if (debug_info) cout << Hits.size() << " (int) trackHitCandidates.begin() " << trackHitCandidates.size() << endl;
@@ -925,7 +925,7 @@ CRackTrajectoryBuilder::innerState( const Trajectory& traj) const
   }
 
   TrajectoryMeasurement firstMeas = fitres[0].lastMeasurement();
-  TSOS firstState = firstMeas.updatedState();
+  const TSOS& firstState = firstMeas.updatedState();
 
   //  cout << "FitTester: Fitted first state " << firstState << endl;
   //cout << "FitTester: chi2 = " << fitres[0].chiSquared() << endl;

--- a/RecoTracker/SingleTrackPattern/src/CosmicTrackFinder.cc
+++ b/RecoTracker/SingleTrackPattern/src/CosmicTrackFinder.cc
@@ -95,7 +95,7 @@ namespace cms
     es.get<TrackerDigiGeometryRecord>().get(tracker);
     edm::LogVerbatim("CosmicTrackFinder") << "========== Cosmic Track Finder Info ==========";
     edm::LogVerbatim("CosmicTrackFinder") << " Numbers of Seeds " << (*seed).size();
-    if((*seed).size()>0){
+    if(!(*seed).empty()){
 
       std::vector<Trajectory> trajoutput;
       
@@ -127,7 +127,7 @@ namespace cms
 
       edm::LogVerbatim("CosmicTrackFinder") << " Numbers of Temp Trajectories " << trajoutput.size();
       edm::LogVerbatim("CosmicTrackFinder") << "========== END Info ==========";
-      if(trajoutput.size()>0){
+      if(!trajoutput.empty()){
 
         // crazyness...
 	std::vector<Trajectory*> tmpTraj;

--- a/RecoTracker/SpecialSeedGenerators/interface/BeamHaloPairGenerator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/BeamHaloPairGenerator.h
@@ -16,10 +16,10 @@ class SeedingLayerSetsHits;
 class BeamHaloPairGenerator : public OrderedHitsGenerator {
 	public:
 	BeamHaloPairGenerator(const edm::ParameterSet& conf, edm::ConsumesCollector& iC);
-	virtual ~BeamHaloPairGenerator(){};
-	virtual const OrderedSeedingHits& run(const TrackingRegion& region, 
+	~BeamHaloPairGenerator() override{};
+	const OrderedSeedingHits& run(const TrackingRegion& region, 
 					      const edm::Event & ev, 
-					      const edm::EventSetup& es);
+					      const edm::EventSetup& es) override;
 	private:
 	edm::EDGetTokenT<SeedingLayerSetsHits> theSeedingLayerToken;
 	OrderedHitPairs hitPairs;

--- a/RecoTracker/SpecialSeedGenerators/interface/CRackSeedGenerator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CRackSeedGenerator.h
@@ -17,9 +17,9 @@ class CRackSeedGenerator : public edm::EDProducer
 
   explicit CRackSeedGenerator(const edm::ParameterSet& conf);
 
-  virtual ~CRackSeedGenerator();
+  ~CRackSeedGenerator() override;
 
-  virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
+  void produce(edm::Event& e, const edm::EventSetup& c) override;
 
  private:
   edm::ParameterSet conf_;

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicRegionalSeedGenerator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicRegionalSeedGenerator.h
@@ -52,9 +52,9 @@ class CosmicRegionalSeedGenerator : public TrackingRegionProducer {
  public:
   explicit CosmicRegionalSeedGenerator(const edm::ParameterSet& conf, edm::ConsumesCollector && iC);
 
-  virtual ~CosmicRegionalSeedGenerator() {}
+  ~CosmicRegionalSeedGenerator() override {}
   
-  virtual std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event& event, const edm::EventSetup& es) const override;
+  std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event& event, const edm::EventSetup& es) const override;
 
  private:
   edm::ParameterSet conf_;

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicSeedCreator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicSeedCreator.h
@@ -17,17 +17,17 @@ class CosmicSeedCreator final : public SeedCreator {
       maxseeds_ = extra.getParameter<int>("maxseeds");
     }
 
-  virtual ~CosmicSeedCreator(){}
+  ~CosmicSeedCreator() override{}
 
   // initialize the "event dependent state"
-  virtual void init(const TrackingRegion & region,
+  void init(const TrackingRegion & region,
 		    const edm::EventSetup& es,
-		    const SeedComparitor *filter);
+		    const SeedComparitor *filter) override;
 
   // make job 
   // fill seedCollection with the "TrajectorySeed"
-  virtual void makeSeed(TrajectorySeedCollection & seedCollection,
-			const SeedingHitSet & hits);
+  void makeSeed(TrajectorySeedCollection & seedCollection,
+			const SeedingHitSet & hits) override;
 
   
 private:

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicSeedGenerator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicSeedGenerator.h
@@ -26,9 +26,9 @@ class CosmicSeedGenerator : public edm::stream::EDProducer<>
 
   explicit CosmicSeedGenerator(const edm::ParameterSet& conf);
 
-  virtual ~CosmicSeedGenerator();
+  ~CosmicSeedGenerator() override;
 
-  virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
+  void produce(edm::Event& e, const edm::EventSetup& c) override;
 
  private:
   SeedGeneratorForCosmics  cosmic_seed;

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicTrackingRegion.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicTrackingRegion.h
@@ -26,7 +26,7 @@ class CosmicTrackingRegion : public TrackingRegionBase {
 public:
 
 
-  virtual ~CosmicTrackingRegion() { }
+  ~CosmicTrackingRegion() override { }
 
   /** constructor (symmetric eta and phi margins). <BR>
    * dir        - the direction around which region is constructed <BR>
@@ -92,12 +92,12 @@ public:
 	const edm::EventSetup& es,
 	const SeedingLayerSetsHits::SeedingLayer& layer) const override;
   
-  virtual HitRZCompatibility* checkRZ(
+  HitRZCompatibility* checkRZ(
       const DetLayer* layer,
       const Hit & outerHit,
       const edm::EventSetup& iSetup, 
-      const DetLayer* outerlayer=0,
-      float lr=0, float gz=0, float dr=0, float dz=0) const override {return 0; }
+      const DetLayer* outerlayer=nullptr,
+      float lr=0, float gz=0, float dr=0, float dz=0) const override {return nullptr; }
    
    CosmicTrackingRegion * clone() const override {     return new CosmicTrackingRegion(*this);  }
    

--- a/RecoTracker/SpecialSeedGenerators/interface/CtfSpecialSeedGenerator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CtfSpecialSeedGenerator.h
@@ -45,12 +45,12 @@ class CtfSpecialSeedGenerator : public edm::stream::EDProducer<>
 
   CtfSpecialSeedGenerator(const edm::ParameterSet& conf);
 
-  virtual ~CtfSpecialSeedGenerator();//{};
+  ~CtfSpecialSeedGenerator() override;//{};
 
-  virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;	
-  virtual void endRun(edm::Run const&, edm::EventSetup const&) override;	
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;	
+  void endRun(edm::Run const&, edm::EventSetup const&) override;	
 
-  virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
+  void produce(edm::Event& e, const edm::EventSetup& c) override;
 
  private:
   

--- a/RecoTracker/SpecialSeedGenerators/interface/GenericPairGenerator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/GenericPairGenerator.h
@@ -16,11 +16,11 @@ class SeedingLayerSetsHits;
 class GenericPairGenerator : public OrderedHitsGenerator {
 	public:
 	GenericPairGenerator(const edm::ParameterSet& conf, edm::ConsumesCollector& iC);
-	virtual ~GenericPairGenerator(){};
-	virtual const OrderedSeedingHits& run(const TrackingRegion& region, 
+	~GenericPairGenerator() override{};
+	const OrderedSeedingHits& run(const TrackingRegion& region, 
 					      const edm::Event & ev, 
-					      const edm::EventSetup& es);
-        void clear() { hitPairs.clear();}
+					      const edm::EventSetup& es) override;
+        void clear() override { hitPairs.clear();}
 	private:
 	edm::EDGetTokenT<SeedingLayerSetsHits> theSeedingLayerToken;
 	OrderedHitPairs hitPairs;

--- a/RecoTracker/SpecialSeedGenerators/interface/GenericTripletGenerator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/GenericTripletGenerator.h
@@ -15,11 +15,11 @@
 class GenericTripletGenerator : public OrderedHitsGenerator {
 	public:
 	GenericTripletGenerator(const edm::ParameterSet& conf, edm::ConsumesCollector& iC);
-	virtual ~GenericTripletGenerator(){};
-	virtual const OrderedSeedingHits& run(const TrackingRegion& region, 
+	~GenericTripletGenerator() override{};
+	const OrderedSeedingHits& run(const TrackingRegion& region, 
 					      const edm::Event & ev, 
-					      const edm::EventSetup& es);
-        void clear() {hitTriplets.clear();}
+					      const edm::EventSetup& es) override;
+        void clear() override {hitTriplets.clear();}
 	private:
 	std::pair<bool,float> qualityFilter(const OrderedHitTriplet& oht, 
 					    const std::map<float, OrderedHitTriplet>& map,

--- a/RecoTracker/SpecialSeedGenerators/interface/SimpleCosmicBONSeeder.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/SimpleCosmicBONSeeder.h
@@ -44,9 +44,9 @@ class SimpleCosmicBONSeeder : public edm::stream::EDProducer<>
 
   explicit SimpleCosmicBONSeeder(const edm::ParameterSet& conf);
 
-  virtual ~SimpleCosmicBONSeeder() {}
+  ~SimpleCosmicBONSeeder() override {}
 
-  virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
+  void produce(edm::Event& e, const edm::EventSetup& c) override;
 
   void init(const edm::EventSetup& c);
   bool triplets(const edm::Event &e , const edm::EventSetup& c);

--- a/RecoTracker/SpecialSeedGenerators/src/CtfSpecialSeedGenerator.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CtfSpecialSeedGenerator.cc
@@ -25,8 +25,8 @@ CtfSpecialSeedGenerator::CtfSpecialSeedGenerator(const edm::ParameterSet& conf):
   	useScintillatorsConstraint = conf_.getParameter<bool>("UseScintillatorsConstraint");
   	edm::LogVerbatim("CtfSpecialSeedGenerator") << "Constructing CtfSpecialSeedGenerator";
   	produces<TrajectorySeedCollection>();
-	theSeedBuilder =0; 
-	theRegionProducer =0;
+	theSeedBuilder =nullptr; 
+	theRegionProducer =nullptr;
 
 	edm::ParameterSet regfactoryPSet = conf_.getParameter<edm::ParameterSet>("RegionFactoryPSet");
   	std::string regfactoryName = regfactoryPSet.getParameter<std::string>("ComponentName");
@@ -42,11 +42,11 @@ CtfSpecialSeedGenerator::CtfSpecialSeedGenerator(const edm::ParameterSet& conf):
 }
 
 CtfSpecialSeedGenerator::~CtfSpecialSeedGenerator(){
-    if (theRegionProducer) { delete theRegionProducer; theRegionProducer = 0; }
+    if (theRegionProducer) { delete theRegionProducer; theRegionProducer = nullptr; }
 }
 
 void CtfSpecialSeedGenerator::endRun(edm::Run const&, edm::EventSetup const&){
-    if (theSeedBuilder)    { delete theSeedBuilder;    theSeedBuilder = 0; }
+    if (theSeedBuilder)    { delete theSeedBuilder;    theSeedBuilder = nullptr; }
 }
 
 void CtfSpecialSeedGenerator::beginRun(edm::Run const&, const edm::EventSetup& iSetup){

--- a/RecoTracker/SpecialSeedGenerators/src/MuonReSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/MuonReSeeder.cc
@@ -31,9 +31,9 @@
 class MuonReSeeder : public edm::stream::EDProducer<> {
     public:
       explicit MuonReSeeder(const edm::ParameterSet & iConfig);
-      virtual ~MuonReSeeder() { }
+      ~MuonReSeeder() override { }
 
-      virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+      void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
 
     private:
       /// Labels for input collections
@@ -92,7 +92,7 @@ MuonReSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
         if (traj.size() != 1) continue;
         edm::OwnVector<TrackingRecHit> seedHits;
         const std::vector<TrajectoryMeasurement> & tms = traj.front().measurements();
-        TrajectoryStateOnSurface tsos; const TrackingRecHit *hit  = 0;
+        TrajectoryStateOnSurface tsos; const TrackingRecHit *hit  = nullptr;
         bool fromInside = (insideOut_ == (traj.front().direction() == alongMomentum));
         if (debug_) {
             std::cout << "Considering muon of pt " << mu.pt() << ", eta = " << mu.eta() << ", phi = " << mu.phi() << std::endl;
@@ -119,7 +119,7 @@ MuonReSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
 	    int lay = tTopo->layer(hit->geographicalId());
             if (subdet != lastSubdet || lay != lastLayer) {
                 // I'm on a new layer
-                if (lastHit != 0 && taken == layersToKeep_) {
+                if (lastHit != nullptr && taken == layersToKeep_) {
                     // I've had enough layers, I can stop here
                     hit = lastHit;
                     break;

--- a/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
@@ -40,9 +40,9 @@
 class OutsideInMuonSeeder final : public edm::stream::EDProducer<> {
     public:
       explicit OutsideInMuonSeeder(const edm::ParameterSet & iConfig);
-      virtual ~OutsideInMuonSeeder() { }
+      ~OutsideInMuonSeeder() override { }
 
-      virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+      void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
 
     private:
       /// Labels for input collections
@@ -280,7 +280,7 @@ OutsideInMuonSeeder::doDebug(const reco::Track &tk) const {
     for (unsigned int i = 0; i < tk.recHitsSize(); ++i) {
         const TrackingRecHit *hit = &*tk.recHit(i);
         const GeomDet *det = geometry_->idToDet(hit->geographicalId());
-        if (det == 0) continue;
+        if (det == nullptr) continue;
         if (i != 0) tsos = pmuon_cloned->propagate(tsos, det->surface());
         if (!tsos.isValid()) continue;
         LogDebug("OutsideInMuonSeeder") << "  state " << i << " at x = " << tsos.globalPosition() << ", p = " << tsos.globalMomentum() << std::endl;

--- a/RecoTracker/SpecialSeedGenerators/src/SeedFromGenericPairOrTriplet.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SeedFromGenericPairOrTriplet.cc
@@ -86,16 +86,16 @@ TrajectorySeed* SeedFromGenericPairOrTriplet::seedFromTriplet(const SeedingHitSe
 			<< middle.x() << ", " 
                         << middle.y() << ", " 
                         << middle.z() << ")";
-		if (!qualityFilter(hits)) return 0;
+		if (!qualityFilter(hits)) return nullptr;
 		bool sdir = (seedDir == outsideIn);
                 SeedingHitSet newSet(sdir ? hits[1] : hits[0], sdir ? hits[2] : hits[1]); 
 		TrajectorySeed* seed = seedFromPair(newSet, dir, seedDir, charge);
 		return seed;
 						
 	}
-	GlobalPoint* firstPoint  = 0;
-	GlobalPoint* secondPoint = 0;
-	GlobalPoint* thirdPoint  = 0;
+	GlobalPoint* firstPoint  = nullptr;
+	GlobalPoint* secondPoint = nullptr;
+	GlobalPoint* thirdPoint  = nullptr;
 	int momentumSign         = 1;
 	//const TrackingRecHit* firstHit  = 0;
 	//const TrackingRecHit* secondHit = 0;
@@ -139,7 +139,7 @@ TrajectorySeed* SeedFromGenericPairOrTriplet::seedFromTriplet(const SeedingHitSe
                                                                        originalPar.charge(),
                                                                        &originalPar.magneticField());*/
         //FreeTrajectoryState* startingState = new FreeTrajectoryState(newPar, initialError(trHits[0]));//trHits[1]));
-	if (!qualityFilter(momentumSign*originalStartingState.momentum())) return 0;
+	if (!qualityFilter(momentumSign*originalStartingState.momentum())) return nullptr;
 	//TrajectorySeed* seed = buildSeed(startingState, trHits, dir);
 	TrajectorySeed* seed = buildSeed(momentumSign*originalStartingState.momentum(),originalStartingState.charge(), trHits, dir);
 	return seed;	
@@ -164,8 +164,8 @@ TrajectorySeed* SeedFromGenericPairOrTriplet::seedFromPair(const SeedingHitSet& 
                         << inner.perp()
                         << ", " << inner.phi()
                         << "," << inner.theta() <<")";
-	GlobalPoint* firstPoint  = 0;
-        GlobalPoint* secondPoint = 0;
+	GlobalPoint* firstPoint  = nullptr;
+        GlobalPoint* secondPoint = nullptr;
         int momentumSign         = 1;
         //const TrackingRecHit* firstHit  = 0;
         //const TrackingRecHit* secondHit = 0;
@@ -250,12 +250,12 @@ TrajectorySeed* SeedFromGenericPairOrTriplet::buildSeed(const GlobalVector& mome
 	const TrajectoryStateOnSurface propTSOS = propagator->propagate(startingState,*(transHit2->surface()));
 	if (!propTSOS.isValid()){
 		LogDebug("SeedFromGenericPairOrTriplet") << "first propagation failed";
-		return 0;
+		return nullptr;
 	}
 	TrajectoryStateOnSurface seedTSOS = updator.update(propTSOS, *transHit2);
 	if (!seedTSOS.isValid()){
 		LogDebug("SeedFromGenericPairOrTriplet") << "first update failed";
-                return 0;
+                return nullptr;
 	}	
 	LogDebug("SeedFromGenericPairOrTriplet") << "starting TSOS " << seedTSOS ;
 	seedTSOS.rescaleError(theErrorRescaling);

--- a/RecoTracker/SpecialSeedGenerators/src/SimpleCosmicBONSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SimpleCosmicBONSeeder.cc
@@ -490,7 +490,7 @@ bool SimpleCosmicBONSeeder::seeds(TrajectorySeedCollection &output, const edm::E
             continue;
         }
 
-        const Propagator * propagator = 0;  
+        const Propagator * propagator = nullptr;  
         if((outer.y()-inner.y())>0){
             if (seedVerbosity_ > 1)
                 std::cout << "Processing triplet " << it << ":  downgoing." << std::endl; 

--- a/RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h
+++ b/RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h
@@ -25,7 +25,7 @@ class GeometricSearchTracker: public DetLayerGeometry {
 			 const std::vector<ForwardDetLayer const*>& posTec,
 			 const TrackerTopology* tTopo) __attribute__ ((cold));
   
-  virtual ~GeometricSearchTracker() __attribute__ ((cold));
+  ~GeometricSearchTracker() override __attribute__ ((cold));
 
   std::vector<DetLayer const*> const & allLayers()     const {return theAllLayers;}  
 
@@ -49,7 +49,7 @@ class GeometricSearchTracker: public DetLayerGeometry {
 
   
   /// Give the DetId of a module, returns the pointer to the corresponding DetLayer
-  virtual const DetLayer* idToLayer(const DetId& detId) const;
+  const DetLayer* idToLayer(const DetId& detId) const override;
 
   /// obsolete method. Use idToLayer() instead.
   const DetLayer*   detLayer( const DetId& id) const {return idToLayer(id);};

--- a/RecoTracker/TkDetLayers/src/BladeShapeBuilderFromDet.cc
+++ b/RecoTracker/TkDetLayers/src/BladeShapeBuilderFromDet.cc
@@ -97,7 +97,7 @@ namespace {
     GlobalVector zAxis;
     
     GlobalVector planeXAxis    = plane.toGlobal( LocalVector( 1, 0, 0));
-    GlobalPoint  planePosition = plane.position();
+    const GlobalPoint&  planePosition = plane.position();
     
     if(planePosition.x()*planeXAxis.x()+planePosition.y()*planeXAxis.y() > 0.){
       yAxis = planeXAxis;

--- a/RecoTracker/TkDetLayers/src/BoundDiskSector.h
+++ b/RecoTracker/TkDetLayers/src/BoundDiskSector.h
@@ -9,7 +9,7 @@ class BoundDiskSector final : public Plane {
  public:
  
  
-  virtual ~BoundDiskSector() {}
+  ~BoundDiskSector() override {}
  
   BoundDiskSector( const PositionType& pos, 
 		   const RotationType& rot, 

--- a/RecoTracker/TkDetLayers/src/CompositeTECPetal.cc
+++ b/RecoTracker/TkDetLayers/src/CompositeTECPetal.cc
@@ -295,7 +295,7 @@ CompositeTECPetal::searchNeighbors( const TrajectoryStateOnSurface& tsos,
 				    vector<DetGroup>& result,
 				    bool checkClosest) const
 {
-  GlobalPoint gCrossingPos = crossing.position();
+  const GlobalPoint& gCrossingPos = crossing.position();
 
   
   int closestIndex = crossing.closestDetIndex(); 

--- a/RecoTracker/TkDetLayers/src/CompositeTECPetal.h
+++ b/RecoTracker/TkDetLayers/src/CompositeTECPetal.h
@@ -24,29 +24,29 @@ class CompositeTECPetal final : public GeometricSearchDet {
   CompositeTECPetal(std::vector<const TECWedge*>& innerWedges,
 		    std::vector<const TECWedge*>& outerWedges)  __attribute__ ((cold));
   
-  ~CompositeTECPetal()  __attribute__ ((cold));
+  ~CompositeTECPetal()  override __attribute__ ((cold));
 
   // GeometricSearchDet interface  
-  virtual const BoundSurface& surface() const final {return *theDiskSector;}
+  const BoundSurface& surface() const final {return *theDiskSector;}
   //Extension of the interface
   virtual const BoundDiskSector& specificSurface() const final {return *theDiskSector;}
 
 
   
   // GeometricSearchDet interface  
-  virtual const std::vector<const GeomDet*>& basicComponents() const {return theBasicComps;}
+  const std::vector<const GeomDet*>& basicComponents() const override {return theBasicComps;}
   
-  virtual const std::vector<const GeometricSearchDet*>& components() const __attribute__ ((cold)) {return theComps;}
+  const std::vector<const GeometricSearchDet*>& components() const override __attribute__ ((cold)) {return theComps;}
   
-  virtual std::pair<bool, TrajectoryStateOnSurface>
+  std::pair<bool, TrajectoryStateOnSurface>
     compatible( const TrajectoryStateOnSurface& ts, const Propagator&, 
-		const MeasurementEstimator&) const __attribute__((cold));
+		const MeasurementEstimator&) const override __attribute__((cold));
   
-  virtual void
+  void
     groupedCompatibleDetsV( const TrajectoryStateOnSurface& startingState,
 			    const Propagator& prop,
 			    const MeasurementEstimator& est,
-			    std::vector<DetGroup> & result) const __attribute__ ((hot));
+			    std::vector<DetGroup> & result) const override __attribute__ ((hot));
   
   
  private:

--- a/RecoTracker/TkDetLayers/src/CompositeTECWedge.cc
+++ b/RecoTracker/TkDetLayers/src/CompositeTECWedge.cc
@@ -228,7 +228,7 @@ void CompositeTECWedge::searchNeighbors( const TrajectoryStateOnSurface& tsos,
 					 vector<DetGroup>& result,
 					 bool checkClosest) const
 {
-  GlobalPoint gCrossingPos = crossing.position();
+  const GlobalPoint& gCrossingPos = crossing.position();
 
   const vector<const GeomDet*>& sWedge( subWedge( crossing.subLayerIndex()));
  

--- a/RecoTracker/TkDetLayers/src/CompositeTECWedge.h
+++ b/RecoTracker/TkDetLayers/src/CompositeTECWedge.h
@@ -16,22 +16,22 @@ class CompositeTECWedge final : public TECWedge{
   CompositeTECWedge(std::vector<const GeomDet*>& innerDets,
 		    std::vector<const GeomDet*>& outerDets)  __attribute__ ((cold));
 
-  ~CompositeTECWedge()  __attribute__ ((cold));
+  ~CompositeTECWedge()  override __attribute__ ((cold));
   
   // GeometricSearchDet interface
-  virtual const std::vector<const GeomDet*>& basicComponents() const {return theDets;}
+  const std::vector<const GeomDet*>& basicComponents() const override {return theDets;}
 
-  virtual const std::vector<const GeometricSearchDet*>& components() const __attribute__ ((cold));
+  const std::vector<const GeometricSearchDet*>& components() const override __attribute__ ((cold));
   
-  virtual std::pair<bool, TrajectoryStateOnSurface>
+  std::pair<bool, TrajectoryStateOnSurface>
   compatible( const TrajectoryStateOnSurface& ts, const Propagator&, 
-	      const MeasurementEstimator&) const __attribute__ ((cold));
+	      const MeasurementEstimator&) const override __attribute__ ((cold));
 
-  virtual void
+  void
   groupedCompatibleDetsV( const TrajectoryStateOnSurface& startingState,
 			 const Propagator& prop,
 			 const MeasurementEstimator& est,
-			 std::vector<DetGroup> & result) const __attribute__ ((hot));
+			 std::vector<DetGroup> & result) const override __attribute__ ((hot));
 
  private:
   // private methods for the implementation of groupedCompatibleDets()

--- a/RecoTracker/TkDetLayers/src/DiskSectorBounds.h
+++ b/RecoTracker/TkDetLayers/src/DiskSectorBounds.h
@@ -21,17 +21,17 @@ public:
      theOffset = theRmin +  0.5f*(theRmax-theRmin);
    }
    
-   virtual float length()    const { return theRmax-theRmin*std::cos(thePhiExtH);}
-   virtual float width()     const { return 2.f*theRmax*std::sin(thePhiExtH);}
-   virtual float thickness() const { return theZmax-theZmin;}
+   float length()    const override { return theRmax-theRmin*std::cos(thePhiExtH);}
+   float width()     const override { return 2.f*theRmax*std::sin(thePhiExtH);}
+   float thickness() const override { return theZmax-theZmin;}
  
    
    
-   virtual bool inside( const Local3DPoint& p) const;
+   bool inside( const Local3DPoint& p) const override;
      
-   virtual bool inside( const Local3DPoint& p, const LocalError& err, float scale) const;
+   bool inside( const Local3DPoint& p, const LocalError& err, float scale) const override;
  
-   virtual Bounds* clone() const { 
+   Bounds* clone() const override { 
      return new DiskSectorBounds(*this);
    }
  

--- a/RecoTracker/TkDetLayers/src/ForwardDiskSectorBuilderFromDet.cc
+++ b/RecoTracker/TkDetLayers/src/ForwardDiskSectorBuilderFromDet.cc
@@ -48,7 +48,7 @@ ForwardDiskSectorBuilderFromDet::computeBounds( const vector<const GeomDet*>& de
   for (vector<const GeomDet*>::const_iterator idet=dets.begin();
        idet != dets.end(); idet++) {
     vector<const GeomDet*> detUnits = (**idet).components();
-    if( detUnits.size() ){
+    if( !detUnits.empty() ){
       for (vector<const GeomDet*>::const_iterator detu=detUnits.begin();
 	   detu!=detUnits.end(); detu++) {
 	// edm::LogInfo(TkDetLayers) << " Builder: Position of detUnit :"<< (**detu).position() ;      

--- a/RecoTracker/TkDetLayers/src/GeometricSearchTracker.cc
+++ b/RecoTracker/TkDetLayers/src/GeometricSearchTracker.cc
@@ -130,5 +130,5 @@ GeometricSearchTracker::idToLayer(const DetId& id) const
     edm::LogError("TkDetLayers") << "ERROR:layer not found!" ;
     // throw(something);
   }
-  return 0; //just to avoid compile warnings
+  return nullptr; //just to avoid compile warnings
 }

--- a/RecoTracker/TkDetLayers/src/Phase1PixelBlade.cc
+++ b/RecoTracker/TkDetLayers/src/Phase1PixelBlade.cc
@@ -213,7 +213,7 @@ void Phase1PixelBlade::searchNeighbors( const TrajectoryStateOnSurface& tsos,
 				  vector<DetGroup>& result,
 				  bool checkClosest) const
 {
-  GlobalPoint gCrossingPos = crossing.position();
+  const GlobalPoint& gCrossingPos = crossing.position();
   const vector<const GeomDet*>& sBlade( subBlade( crossing.subLayerIndex()));
 
   int closestIndex = crossing.closestDetIndex();
@@ -333,7 +333,7 @@ Phase1PixelBlade::computeRadiusRanges(const std::vector<const GeomDet*> &current
   GlobalVector zAxis;
 
   GlobalVector planeXAxis    = tmpplane.toGlobal(LocalVector(1, 0, 0));
-  GlobalPoint  planePosition = tmpplane.position();
+  const GlobalPoint&  planePosition = tmpplane.position();
 
   if (planePosition.x() * planeXAxis.x()
      + planePosition.y() * planeXAxis.y() > 0.){

--- a/RecoTracker/TkDetLayers/src/Phase1PixelBlade.h
+++ b/RecoTracker/TkDetLayers/src/Phase1PixelBlade.h
@@ -19,24 +19,24 @@ class Phase1PixelBlade final : public GeometricSearchDet {
   Phase1PixelBlade(std::vector<const GeomDet*>& frontDets,
 		   std::vector<const GeomDet*>& backDets  ) __attribute__ ((cold));
 
-  ~Phase1PixelBlade() __attribute__ ((cold));
+  ~Phase1PixelBlade() override __attribute__ ((cold));
 
   // GeometricSearchDet interface
-  virtual const BoundSurface& surface() const {return *theDiskSector;}
+  const BoundSurface& surface() const override {return *theDiskSector;}
 
-  virtual const std::vector<const GeomDet*>& basicComponents() const {return theDets;}
+  const std::vector<const GeomDet*>& basicComponents() const override {return theDets;}
 
-  virtual const std::vector<const GeometricSearchDet*>& components() const  __attribute__ ((cold));
+  const std::vector<const GeometricSearchDet*>& components() const  override __attribute__ ((cold));
 
   std::pair<bool, TrajectoryStateOnSurface>
   compatible( const TrajectoryStateOnSurface& ts, const Propagator&,
-	      const MeasurementEstimator&) const  __attribute__ ((cold));
+	      const MeasurementEstimator&) const  override __attribute__ ((cold));
 
-  virtual void
+  void
   groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
 			  const Propagator& prop,
 			  const MeasurementEstimator& est,
-			  std::vector<DetGroup> & result) const  __attribute__ ((hot));
+			  std::vector<DetGroup> & result) const  override __attribute__ ((hot));
 
   //Extension of the interface
   virtual const BoundDiskSector& specificSurface() const {return *theDiskSector;}

--- a/RecoTracker/TkDetLayers/src/Phase2EndcapLayer.h
+++ b/RecoTracker/TkDetLayers/src/Phase2EndcapLayer.h
@@ -15,7 +15,7 @@
 class Phase2EndcapLayer final : public RingedForwardLayer {
  public:
   Phase2EndcapLayer(std::vector<const Phase2EndcapRing*>& rings, const bool isOT)  __attribute__ ((cold));
-  ~Phase2EndcapLayer()  __attribute__ ((cold));
+  ~Phase2EndcapLayer()  override __attribute__ ((cold));
 
   // Default implementations would not properly manage memory
   Phase2EndcapLayer( const Phase2EndcapLayer& ) = delete;
@@ -23,17 +23,17 @@ class Phase2EndcapLayer final : public RingedForwardLayer {
 
   // GeometricSearchDet interface
   
-  virtual const std::vector<const GeomDet*>& basicComponents() const {return theBasicComps;}
+  const std::vector<const GeomDet*>& basicComponents() const override {return theBasicComps;}
   
-  virtual const std::vector<const GeometricSearchDet*>& components() const __attribute__ ((cold));
+  const std::vector<const GeometricSearchDet*>& components() const override __attribute__ ((cold));
 
   void groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
 			       const Propagator& prop,
 			       const MeasurementEstimator& est,
-			       std::vector<DetGroup> & result) const __attribute__ ((hot));
+			       std::vector<DetGroup> & result) const override __attribute__ ((hot));
 
   // DetLayer interface
-  virtual SubDetector subDetector() const { if(isOuterTracker) return GeomDetEnumerators::subDetGeom[GeomDetEnumerators::P2OTEC];
+  SubDetector subDetector() const override { if(isOuterTracker) return GeomDetEnumerators::subDetGeom[GeomDetEnumerators::P2OTEC];
                                             else return GeomDetEnumerators::subDetGeom[GeomDetEnumerators::P2PXEC];}
 
 

--- a/RecoTracker/TkDetLayers/src/Phase2EndcapRing.cc
+++ b/RecoTracker/TkDetLayers/src/Phase2EndcapRing.cc
@@ -252,7 +252,7 @@ void Phase2EndcapRing::searchNeighbors( const TrajectoryStateOnSurface& tsos,
 				     vector<DetGroup>& brotherresult,
 				     bool checkClosest) const
 {
-  GlobalPoint gCrossingPos = crossing.position();
+  const GlobalPoint& gCrossingPos = crossing.position();
 
   const vector<const GeomDet*>& sLayer( subLayer( crossing.subLayerIndex()));
   // It assumes that what is ok for the front modules in the pt modules is ok also for the back module

--- a/RecoTracker/TkDetLayers/src/Phase2EndcapRing.h
+++ b/RecoTracker/TkDetLayers/src/Phase2EndcapRing.h
@@ -17,23 +17,23 @@ class Phase2EndcapRing final : public GeometricSearchDet {
 		 std::vector<const GeomDet*>& outerDets,
 		 const std::vector<const GeomDet*>& innerDetBrothers = std::vector<const GeomDet*>(),
 		 const std::vector<const GeomDet*>& outerDetBrothers = std::vector<const GeomDet*>());
-  ~Phase2EndcapRing();
+  ~Phase2EndcapRing() override;
   
   // GeometricSearchDet interface
-  virtual const BoundSurface& surface() const {return *theDisk;}
+  const BoundSurface& surface() const override {return *theDisk;}
   
-  virtual const std::vector<const GeomDet*>& basicComponents() const {return theDets;}
+  const std::vector<const GeomDet*>& basicComponents() const override {return theDets;}
   
-  virtual const std::vector<const GeometricSearchDet*>& components() const __attribute__ ((cold));
+  const std::vector<const GeometricSearchDet*>& components() const override __attribute__ ((cold));
 
-  virtual std::pair<bool, TrajectoryStateOnSurface>
+  std::pair<bool, TrajectoryStateOnSurface>
   compatible( const TrajectoryStateOnSurface&, const Propagator&, 
-		       const MeasurementEstimator&) const;
+		       const MeasurementEstimator&) const override;
 
   void groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
 			       const Propagator& prop,
 			       const MeasurementEstimator& est,
-			       std::vector<DetGroup> & result) const __attribute__ ((hot));
+			       std::vector<DetGroup> & result) const override __attribute__ ((hot));
   
  
   //Extension of interface

--- a/RecoTracker/TkDetLayers/src/Phase2OTBarrelLayerBuilder.cc
+++ b/RecoTracker/TkDetLayers/src/Phase2OTBarrelLayerBuilder.cc
@@ -41,7 +41,7 @@ Phase2OTBarrelLayer* Phase2OTBarrelLayerBuilder::build(const GeometricDet* aPhas
 
   double meanR = 0;
   for (unsigned int index=0; index!=theGeometricDetRods.size(); index++)   meanR+=theGeometricDetRods[index]->positionBounds().perp();
-  if (theGeometricDetRods.size()!=0)
+  if (!theGeometricDetRods.empty())
     meanR/=(double) theGeometricDetRods.size();
   
   for(unsigned int index=0; index!=theGeometricDetRods.size(); index++){    

--- a/RecoTracker/TkDetLayers/src/Phase2OTBarrelRod.cc
+++ b/RecoTracker/TkDetLayers/src/Phase2OTBarrelRod.cc
@@ -295,7 +295,7 @@ void Phase2OTBarrelRod::searchNeighbors( const TrajectoryStateOnSurface& tsos,
 			      vector<DetGroup>& brotherresult,
 			      bool checkClosest) const
 {
-  GlobalPoint gCrossingPos = crossing.position();
+  const GlobalPoint& gCrossingPos = crossing.position();
 
   const vector<const GeomDet*>& sRod( subRod( crossing.subLayerIndex()));
   const vector<const GeomDet*>& sBrotherRod( subRodBrothers( crossing.subLayerIndex()));

--- a/RecoTracker/TkDetLayers/src/Phase2OTBarrelRod.h
+++ b/RecoTracker/TkDetLayers/src/Phase2OTBarrelRod.h
@@ -21,23 +21,23 @@ class Phase2OTBarrelRod final : public DetRod {
 			std::vector<const GeomDet*>& outerDets,
 			std::vector<const GeomDet*>& innerDetBrothers,
 		    std::vector<const GeomDet*>& outerDetBrothers) __attribute__ ((cold));
-  ~Phase2OTBarrelRod() __attribute__ ((cold));
+  ~Phase2OTBarrelRod() override __attribute__ ((cold));
   
   // GeometricSearchDet interface
   
-  virtual const std::vector<const GeomDet*>& basicComponents() const {return theDets;}
+  const std::vector<const GeomDet*>& basicComponents() const override {return theDets;}
 
-  virtual const std::vector<const GeometricSearchDet*>& components() const __attribute__ ((cold));
+  const std::vector<const GeometricSearchDet*>& components() const override __attribute__ ((cold));
 
   
-  virtual std::pair<bool, TrajectoryStateOnSurface>
+  std::pair<bool, TrajectoryStateOnSurface>
   compatible( const TrajectoryStateOnSurface& ts, const Propagator&, 
-	      const MeasurementEstimator&) const  __attribute__ ((cold));
+	      const MeasurementEstimator&) const  override __attribute__ ((cold));
 
   void groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
 			       const Propagator& prop,
 			       const MeasurementEstimator& est,
-			       std::vector<DetGroup> & result) const __attribute__ ((hot));
+			       std::vector<DetGroup> & result) const override __attribute__ ((hot));
   
  
  private:

--- a/RecoTracker/TkDetLayers/src/Phase2OTtiltedBarrelLayer.h
+++ b/RecoTracker/TkDetLayers/src/Phase2OTtiltedBarrelLayer.h
@@ -22,7 +22,7 @@ class Phase2OTtiltedBarrelLayer final : public Phase2OTBarrelLayer {
                             std::vector<const Phase2EndcapRing*>& negRings,
                             std::vector<const Phase2EndcapRing*>& posRings);
   
-  ~Phase2OTtiltedBarrelLayer();
+  ~Phase2OTtiltedBarrelLayer() override;
   
   void groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
 			       const Propagator& prop,

--- a/RecoTracker/TkDetLayers/src/PixelBarrelLayerBuilder.cc
+++ b/RecoTracker/TkDetLayers/src/PixelBarrelLayerBuilder.cc
@@ -23,7 +23,7 @@ PixelBarrelLayer* PixelBarrelLayerBuilder::build(const GeometricDet* aPixelBarre
 
   double meanR = 0;
   for (unsigned int index=0; index!=theGeometricDetRods.size(); index++)   meanR+=theGeometricDetRods[index]->positionBounds().perp();
-  if (theGeometricDetRods.size()!=0)
+  if (!theGeometricDetRods.empty())
     meanR/=(double) theGeometricDetRods.size();
   
   for(unsigned int index=0; index!=theGeometricDetRods.size(); index++){    

--- a/RecoTracker/TkDetLayers/src/PixelBlade.cc
+++ b/RecoTracker/TkDetLayers/src/PixelBlade.cc
@@ -188,7 +188,7 @@ void PixelBlade::searchNeighbors( const TrajectoryStateOnSurface& tsos,
 				  vector<DetGroup>& result,
 				  bool checkClosest) const
 {
-  GlobalPoint gCrossingPos = crossing.position();
+  const GlobalPoint& gCrossingPos = crossing.position();
 
   const vector<const GeomDet*>& sBlade( subBlade( crossing.subLayerIndex()));
  

--- a/RecoTracker/TkDetLayers/src/PixelBlade.h
+++ b/RecoTracker/TkDetLayers/src/PixelBlade.h
@@ -18,24 +18,24 @@ class PixelBlade final : public GeometricSearchDet {
   PixelBlade(std::vector<const GeomDet*>& frontDets,
 	     std::vector<const GeomDet*>& backDets  ) __attribute__ ((cold));
 
-  ~PixelBlade() __attribute__ ((cold));
+  ~PixelBlade() override __attribute__ ((cold));
   
   // GeometricSearchDet interface
-  virtual const BoundSurface& surface() const {return *theDiskSector;}
+  const BoundSurface& surface() const override {return *theDiskSector;}
 
-  virtual const std::vector<const GeomDet*>& basicComponents() const {return theDets;}
+  const std::vector<const GeomDet*>& basicComponents() const override {return theDets;}
 
-  virtual const std::vector<const GeometricSearchDet*>& components() const __attribute__ ((cold));
+  const std::vector<const GeometricSearchDet*>& components() const override __attribute__ ((cold));
 
   std::pair<bool, TrajectoryStateOnSurface>
   compatible( const TrajectoryStateOnSurface& ts, const Propagator&, 
-	      const MeasurementEstimator&) const  __attribute__ ((cold));
+	      const MeasurementEstimator&) const  override __attribute__ ((cold));
   
-  virtual void 
+  void 
   groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
 			  const Propagator& prop,
 			  const MeasurementEstimator& est,
-			  std::vector<DetGroup> & result) const __attribute__ ((hot));
+			  std::vector<DetGroup> & result) const override __attribute__ ((hot));
   
   //Extension of the interface
   virtual const BoundDiskSector& specificSurface() const {return *theDiskSector;}

--- a/RecoTracker/TkDetLayers/src/PixelForwardLayer.h
+++ b/RecoTracker/TkDetLayers/src/PixelForwardLayer.h
@@ -15,21 +15,21 @@
 class PixelForwardLayer final : public ForwardDetLayer {
  public:
   PixelForwardLayer(std::vector<const PixelBlade*>& blades);
-  ~PixelForwardLayer();
+  ~PixelForwardLayer() override;
   
   // GeometricSearchDet interface
   
-  virtual const std::vector<const GeomDet*>& basicComponents() const {return theBasicComps;}
+  const std::vector<const GeomDet*>& basicComponents() const override {return theBasicComps;}
 
-  virtual const std::vector<const GeometricSearchDet*>& components() const __attribute__ ((cold)) {return theComps;}
+  const std::vector<const GeometricSearchDet*>& components() const override __attribute__ ((cold)) {return theComps;}
   
   void groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
 			       const Propagator& prop,
 			       const MeasurementEstimator& est,
-			       std::vector<DetGroup> & result) const __attribute__ ((hot));
+			       std::vector<DetGroup> & result) const override __attribute__ ((hot));
 
   // DetLayer interface
-  virtual SubDetector subDetector() const {return GeomDetEnumerators::subDetGeom[GeomDetEnumerators::PixelEndcap];}
+  SubDetector subDetector() const override {return GeomDetEnumerators::subDetGeom[GeomDetEnumerators::PixelEndcap];}
   
 
  private:  

--- a/RecoTracker/TkDetLayers/src/PixelForwardLayerPhase1.h
+++ b/RecoTracker/TkDetLayers/src/PixelForwardLayerPhase1.h
@@ -16,21 +16,21 @@
 class PixelForwardLayerPhase1 final : public ForwardDetLayer {
  public:
   PixelForwardLayerPhase1(std::vector<const Phase1PixelBlade*>& blades);
-  ~PixelForwardLayerPhase1();
+  ~PixelForwardLayerPhase1() override;
 
   // GeometricSearchDet interface
 
-  virtual const std::vector<const GeomDet*>& basicComponents() const {return theBasicComps;}
+  const std::vector<const GeomDet*>& basicComponents() const override {return theBasicComps;}
 
-  virtual const std::vector<const GeometricSearchDet*>& components() const __attribute__ ((cold)) {return theComps;}
+  const std::vector<const GeometricSearchDet*>& components() const override __attribute__ ((cold)) {return theComps;}
 
   void groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
 			       const Propagator& prop,
 			       const MeasurementEstimator& est,
-			       std::vector<DetGroup> & result) const __attribute__ ((hot));
+			       std::vector<DetGroup> & result) const override __attribute__ ((hot));
 
   // DetLayer interface
-  virtual SubDetector subDetector() const {return GeomDetEnumerators::subDetGeom[GeomDetEnumerators::P1PXEC];}
+  SubDetector subDetector() const override {return GeomDetEnumerators::subDetGeom[GeomDetEnumerators::P1PXEC];}
 
 
  private:

--- a/RecoTracker/TkDetLayers/src/PixelRod.h
+++ b/RecoTracker/TkDetLayers/src/PixelRod.h
@@ -14,27 +14,27 @@ class PixelRod final : public DetRodOneR{
     typedef PeriodicBinFinderInZ<float>   BinFinderType;
 
   PixelRod(std::vector<const GeomDet*>& theDets);
-  ~PixelRod();
+  ~PixelRod() override;
   
   // GeometricSearchDet interface
 
-  virtual const std::vector<const GeometricSearchDet*>& components() const __attribute__ ((cold));
+  const std::vector<const GeometricSearchDet*>& components() const override __attribute__ ((cold));
   
-  virtual std::pair<bool, TrajectoryStateOnSurface>
+  std::pair<bool, TrajectoryStateOnSurface>
   compatible( const TrajectoryStateOnSurface& ts, const Propagator&, 
-	      const MeasurementEstimator&) const;
+	      const MeasurementEstimator&) const override;
 
-  virtual void
+  void
   compatibleDetsV( const TrajectoryStateOnSurface& startingState,
 		  const Propagator& prop, 
 		  const MeasurementEstimator& est,
-		  std::vector<DetWithState> & result) const __attribute__ ((hot));
+		  std::vector<DetWithState> & result) const override __attribute__ ((hot));
 
-  virtual void  
+  void  
   groupedCompatibleDetsV( const TrajectoryStateOnSurface&,
 			 const Propagator&,
 			 const MeasurementEstimator&,
-			 std::vector<DetGroup> &) const;
+			 std::vector<DetGroup> &) const override;
 
 
  private:

--- a/RecoTracker/TkDetLayers/src/SimpleTECWedge.h
+++ b/RecoTracker/TkDetLayers/src/SimpleTECWedge.h
@@ -14,22 +14,22 @@ class SimpleTECWedge final : public TECWedge{
  public:
   SimpleTECWedge(const GeomDet* theDet) __attribute__ ((cold));
 
-  ~SimpleTECWedge() __attribute__ ((cold));
+  ~SimpleTECWedge() override __attribute__ ((cold));
   
   // GeometricSearchDet interface
-  virtual const std::vector<const GeomDet*>& basicComponents() const {return theDets;}
+  const std::vector<const GeomDet*>& basicComponents() const override {return theDets;}
 
-  virtual const std::vector<const GeometricSearchDet*>& components() const __attribute__ ((cold));
+  const std::vector<const GeometricSearchDet*>& components() const override __attribute__ ((cold));
   
-  virtual std::pair<bool, TrajectoryStateOnSurface>
+  std::pair<bool, TrajectoryStateOnSurface>
   compatible( const TrajectoryStateOnSurface& ts, const Propagator&, 
-	      const MeasurementEstimator&) const __attribute__ ((hot));
+	      const MeasurementEstimator&) const override __attribute__ ((hot));
 
-  virtual void 
+  void 
   groupedCompatibleDetsV( const TrajectoryStateOnSurface& startingState,
 			 const Propagator& prop,
 			 const MeasurementEstimator& est,
-                         std::vector<DetGroup> & result) const __attribute__ ((hot));
+                         std::vector<DetGroup> & result) const override __attribute__ ((hot));
 
  private:
   const GeomDet* theDet;

--- a/RecoTracker/TkDetLayers/src/TBLayer.h
+++ b/RecoTracker/TkDetLayers/src/TBLayer.h
@@ -21,22 +21,22 @@ class TBLayer: public BarrelDetLayer {
     theOuterComps(outer.begin(),outer.end()), me(ime){}
 
 
-  ~TBLayer() __attribute__ ((cold));
+  ~TBLayer() override __attribute__ ((cold));
 
   // GeometricSearchDet interface
   
-  virtual const std::vector<const GeomDet*>& basicComponents() const final {return theBasicComps;}
+  const std::vector<const GeomDet*>& basicComponents() const final {return theBasicComps;}
 
-  virtual const std::vector<const GeometricSearchDet*>& components() const final  __attribute__ ((cold)) {return theComps;}
+  const std::vector<const GeometricSearchDet*>& components() const final  __attribute__ ((cold)) {return theComps;}
   
   void groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
 			       const Propagator& prop,
 			       const MeasurementEstimator& est,
-			       std::vector<DetGroup> & result) const __attribute__ ((hot));
+			       std::vector<DetGroup> & result) const override __attribute__ ((hot));
 
 
   // DetLayer interface
-  virtual SubDetector subDetector() const final {return GeomDetEnumerators::subDetGeom[me];}
+  SubDetector subDetector() const final {return GeomDetEnumerators::subDetGeom[me];}
 
 
 protected:

--- a/RecoTracker/TkDetLayers/src/TBPLayer.cc
+++ b/RecoTracker/TkDetLayers/src/TBPLayer.cc
@@ -34,11 +34,11 @@ void TBPLayer::construct() {
   theInnerCylinder = cylinder( theInnerComps);
   theOuterCylinder = cylinder( theOuterComps);
 
-  if (theInnerComps.size())
+  if (!theInnerComps.empty())
     theInnerBinFinder = BinFinderType(theInnerComps.front()->position().phi(),
 				      theInnerComps.size());
 
-  if (theOuterComps.size())
+  if (!theOuterComps.empty())
     theOuterBinFinder = BinFinderType(theOuterComps.front()->position().phi(),
 				      theOuterComps.size());
   
@@ -132,7 +132,7 @@ void TBPLayer::searchNeighbors( const TrajectoryStateOnSurface& tsos,
 				bool checkClosest) const {
   using barrelUtil::overlap;
   
-  GlobalPoint gCrossingPos = crossing.position();
+  const GlobalPoint& gCrossingPos = crossing.position();
   auto gphi = gCrossingPos.barePhi();  
   
   const vector<const GeometricSearchDet*>& sLayer( subLayer( crossing.subLayerIndex()));

--- a/RecoTracker/TkDetLayers/src/TBPLayer.h
+++ b/RecoTracker/TkDetLayers/src/TBPLayer.h
@@ -31,7 +31,7 @@ class TBPLayer : public TBLayer {
     TBLayer(inner,outer, GeomDetEnumerators::P2OTB){construct();}
 
   
-  ~TBPLayer()  __attribute__ ((cold));
+  ~TBPLayer()  override __attribute__ ((cold));
 
   
   BoundCylinder* cylinder( const std::vector<const GeometricSearchDet*>& rods) const __attribute__ ((cold));
@@ -44,13 +44,13 @@ class TBPLayer : public TBLayer {
   void construct()  __attribute__ ((cold));
 
 
-  std::tuple<bool,int,int>  computeIndexes(GlobalPoint gInnerPoint, GlobalPoint gOuterPoint) const  __attribute__ ((hot));
+  std::tuple<bool,int,int>  computeIndexes(GlobalPoint gInnerPoint, GlobalPoint gOuterPoint) const  override __attribute__ ((hot));
   
 
 
   float computeWindowSize( const GeomDet* det, 
 			   const TrajectoryStateOnSurface& tsos, 
-			   const MeasurementEstimator& est) const __attribute__ ((hot));
+			   const MeasurementEstimator& est) const override __attribute__ ((hot));
   
   static float calculatePhiWindow( float Xmax, const GeomDet& det,
 			     const TrajectoryStateOnSurface& state) __attribute__ ((hot));
@@ -62,7 +62,7 @@ class TBPLayer : public TBLayer {
 			const SubLayerCrossing& crossing,
 			float window, 
 			std::vector<DetGroup>& result,
-			bool checkClosest) const __attribute__ ((hot));
+			bool checkClosest) const override __attribute__ ((hot));
 
 
   BinFinderType    theInnerBinFinder;

--- a/RecoTracker/TkDetLayers/src/TECLayer.cc
+++ b/RecoTracker/TkDetLayers/src/TECLayer.cc
@@ -264,7 +264,7 @@ void TECLayer::searchNeighbors( const TrajectoryStateOnSurface& tsos,
 				vector<DetGroup>& result,
 				bool checkClosest) const
 {
-  GlobalPoint gCrossingPos = crossing.position();
+  const GlobalPoint& gCrossingPos = crossing.position();
   auto gphi = gCrossingPos.barePhi();  
 
   const auto & sLayer( subLayer( crossing.subLayerIndex()));

--- a/RecoTracker/TkDetLayers/src/TECLayer.h
+++ b/RecoTracker/TkDetLayers/src/TECLayer.h
@@ -17,21 +17,21 @@ class TECLayer : public ForwardDetLayer  {
  public:
   TECLayer(std::vector<const TECPetal*>& innerPetals,
 	   std::vector<const TECPetal*>& outerPetals) __attribute__ ((cold));
-  ~TECLayer() __attribute__ ((cold));
+  ~TECLayer() override __attribute__ ((cold));
   
   // GeometricSearchDet interface
   
-  virtual const std::vector<const GeomDet*>& basicComponents() const {return theBasicComps;}
+  const std::vector<const GeomDet*>& basicComponents() const override {return theBasicComps;}
 
-  virtual const std::vector<const GeometricSearchDet*>& components() const __attribute__ ((cold)) {return theComps;}
+  const std::vector<const GeometricSearchDet*>& components() const override __attribute__ ((cold)) {return theComps;}
   
   void groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
 			       const Propagator& prop,
 			       const MeasurementEstimator& est,
-			       std::vector<DetGroup> & result) const __attribute__ ((hot));
+			       std::vector<DetGroup> & result) const override __attribute__ ((hot));
  
   // DetLayer interface
-  virtual SubDetector subDetector() const {return GeomDetEnumerators::subDetGeom[GeomDetEnumerators::TEC];}
+  SubDetector subDetector() const override {return GeomDetEnumerators::subDetGeom[GeomDetEnumerators::TEC];}
   
 
   

--- a/RecoTracker/TkDetLayers/src/TECWedge.h
+++ b/RecoTracker/TkDetLayers/src/TECWedge.h
@@ -16,7 +16,7 @@ class TECWedge : public GeometricSearchDet {
   TECWedge() : GeometricSearchDet(true){}
 
     // GeometricSearchDet interface
-  virtual const BoundSurface& surface() const  final {return *theDiskSector;}
+  const BoundSurface& surface() const  final {return *theDiskSector;}
 
   
   //Extension of the interface

--- a/RecoTracker/TkDetLayers/src/TIBLayer.cc
+++ b/RecoTracker/TkDetLayers/src/TIBLayer.cc
@@ -145,7 +145,7 @@ void TIBLayer::searchNeighbors( const TrajectoryStateOnSurface& tsos,
 				vector<DetGroup>& result,
 				bool checkClosest) const
 {
-  GlobalPoint gCrossingPos = crossing.position();
+  const GlobalPoint& gCrossingPos = crossing.position();
 
   const vector<const GeometricSearchDet*>& sLayer( subLayer( crossing.subLayerIndex()));
  

--- a/RecoTracker/TkDetLayers/src/TIBLayer.h
+++ b/RecoTracker/TkDetLayers/src/TIBLayer.h
@@ -16,12 +16,12 @@ class TIBLayer final : public TBLayer {
   TIBLayer(std::vector<const TIBRing*>& innerRings,
 	   std::vector<const TIBRing*>& outerRings) __attribute__ ((cold));
 
-  ~TIBLayer() __attribute__ ((cold));
+  ~TIBLayer() override __attribute__ ((cold));
 
  private:
   // private methods for the implementation of groupedCompatibleDets()
 
-  std::tuple<bool,int,int>  computeIndexes(GlobalPoint gInnerPoint, GlobalPoint gOuterPoint) const  __attribute__ ((hot));
+  std::tuple<bool,int,int>  computeIndexes(GlobalPoint gInnerPoint, GlobalPoint gOuterPoint) const  override __attribute__ ((hot));
 
 
   void searchNeighbors( const TrajectoryStateOnSurface& tsos,
@@ -30,11 +30,11 @@ class TIBLayer final : public TBLayer {
 			const SubLayerCrossing& crossing,
 			float window, 
 			std::vector<DetGroup>& result,
-			bool checkClosest) const __attribute__ ((hot));
+			bool checkClosest) const override __attribute__ ((hot));
 
   float computeWindowSize( const GeomDet* det, 
 			   const TrajectoryStateOnSurface& tsos, 
-			   const MeasurementEstimator& est) const  __attribute__ ((hot));
+			   const MeasurementEstimator& est) const  override __attribute__ ((hot));
 
   static bool overlap( const GlobalPoint& gpos, const GeometricSearchDet& ring, float window)   __attribute__ ((hot));
 

--- a/RecoTracker/TkDetLayers/src/TIBRing.h
+++ b/RecoTracker/TkDetLayers/src/TIBRing.h
@@ -13,26 +13,26 @@
 class TIBRing final : public GeometricSearchDet{
  public:
   TIBRing(std::vector<const GeomDet*>& theGeomDets) __attribute__ ((cold));
-  ~TIBRing() __attribute__ ((cold));
+  ~TIBRing() override __attribute__ ((cold));
   
   // GeometricSearchDet interface
-  virtual const BoundSurface& surface() const {return *theCylinder;}  
+  const BoundSurface& surface() const override {return *theCylinder;}  
 
-  virtual const std::vector<const GeomDet*>& basicComponents() const {return theDets;}
+  const std::vector<const GeomDet*>& basicComponents() const override {return theDets;}
   
-  virtual const std::vector<const GeometricSearchDet*>& components() const __attribute__ ((cold));
+  const std::vector<const GeometricSearchDet*>& components() const override __attribute__ ((cold));
 
 
-  virtual std::pair<bool, TrajectoryStateOnSurface>
+  std::pair<bool, TrajectoryStateOnSurface>
   compatible( const TrajectoryStateOnSurface& ts, const Propagator&, 
-	      const MeasurementEstimator&) const __attribute__ ((cold));
+	      const MeasurementEstimator&) const override __attribute__ ((cold));
 
   
-  virtual void 
+  void 
   groupedCompatibleDetsV( const TrajectoryStateOnSurface& startingState,
 			  const Propagator& prop,
 			  const MeasurementEstimator& est,
-			  std::vector<DetGroup> & result) const __attribute__ ((hot));
+			  std::vector<DetGroup> & result) const override __attribute__ ((hot));
 
  
   //--- Extension of the interface

--- a/RecoTracker/TkDetLayers/src/TIDLayer.h
+++ b/RecoTracker/TkDetLayers/src/TIDLayer.h
@@ -15,7 +15,7 @@
 class TIDLayer final : public RingedForwardLayer {
  public:
   TIDLayer(std::vector<const TIDRing*>& rings)  __attribute__ ((cold));
-  ~TIDLayer()  __attribute__ ((cold));
+  ~TIDLayer()  override __attribute__ ((cold));
 
   //default implementations would not manage memory correctly
   TIDLayer(const TIDLayer&) = delete;
@@ -23,17 +23,17 @@ class TIDLayer final : public RingedForwardLayer {
   
   // GeometricSearchDet interface
   
-  virtual const std::vector<const GeomDet*>& basicComponents() const {return theBasicComps;}
+  const std::vector<const GeomDet*>& basicComponents() const override {return theBasicComps;}
   
-  virtual const std::vector<const GeometricSearchDet*>& components() const __attribute__ ((cold));
+  const std::vector<const GeometricSearchDet*>& components() const override __attribute__ ((cold));
 
   void groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
 			       const Propagator& prop,
 			       const MeasurementEstimator& est,
-			       std::vector<DetGroup> & result) const __attribute__ ((hot));
+			       std::vector<DetGroup> & result) const override __attribute__ ((hot));
 
   // DetLayer interface
-  virtual SubDetector subDetector() const {return GeomDetEnumerators::subDetGeom[GeomDetEnumerators::TID];}
+  SubDetector subDetector() const override {return GeomDetEnumerators::subDetGeom[GeomDetEnumerators::TID];}
 
 
  private:

--- a/RecoTracker/TkDetLayers/src/TIDRing.cc
+++ b/RecoTracker/TkDetLayers/src/TIDRing.cc
@@ -181,7 +181,7 @@ void TIDRing::searchNeighbors( const TrajectoryStateOnSurface& tsos,
 				     vector<DetGroup>& result,
 				     bool checkClosest) const
 {
-  GlobalPoint gCrossingPos = crossing.position();
+  const GlobalPoint& gCrossingPos = crossing.position();
 
   const vector<const GeomDet*>& sLayer( subLayer( crossing.subLayerIndex()));
  

--- a/RecoTracker/TkDetLayers/src/TIDRing.h
+++ b/RecoTracker/TkDetLayers/src/TIDRing.h
@@ -15,23 +15,23 @@ class TIDRing final : public GeometricSearchDet {
  public:
   TIDRing(std::vector<const GeomDet*>& innerDets,
 	  std::vector<const GeomDet*>& outerDets);
-  ~TIDRing();
+  ~TIDRing() override;
   
   // GeometricSearchDet interface
-  virtual const BoundSurface& surface() const {return *theDisk;}
+  const BoundSurface& surface() const override {return *theDisk;}
   
-  virtual const std::vector<const GeomDet*>& basicComponents() const {return theDets;}
+  const std::vector<const GeomDet*>& basicComponents() const override {return theDets;}
   
-  virtual const std::vector<const GeometricSearchDet*>& components() const __attribute__ ((cold));
+  const std::vector<const GeometricSearchDet*>& components() const override __attribute__ ((cold));
 
-  virtual std::pair<bool, TrajectoryStateOnSurface>
+  std::pair<bool, TrajectoryStateOnSurface>
   compatible( const TrajectoryStateOnSurface&, const Propagator&, 
-		       const MeasurementEstimator&) const;
+		       const MeasurementEstimator&) const override;
 
   void groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
 			       const Propagator& prop,
 			       const MeasurementEstimator& est,
-			       std::vector<DetGroup> & result) const __attribute__ ((hot));
+			       std::vector<DetGroup> & result) const override __attribute__ ((hot));
   
  
   //Extension of interface

--- a/RecoTracker/TkDetLayers/src/TOBLayerBuilder.cc
+++ b/RecoTracker/TkDetLayers/src/TOBLayerBuilder.cc
@@ -31,7 +31,7 @@ TOBLayer* TOBLayerBuilder::build(const GeometricDet* aTOBLayer,
   //			  << positiveZrods[1]->positionBounds().perp() ;
 
   double positiveMeanR = 0;
-  if(positiveZrods.size()>0){
+  if(!positiveZrods.empty()){
     for(unsigned int index=0; index!=positiveZrods.size(); index++){
       positiveMeanR += positiveZrods[index]->positionBounds().perp();
     }
@@ -40,14 +40,14 @@ TOBLayer* TOBLayerBuilder::build(const GeometricDet* aTOBLayer,
 
 
   double negativeMeanR = 0;
-  if(negativeZrods.size()>0){
+  if(!negativeZrods.empty()){
     for(unsigned int index=0; index!=negativeZrods.size(); index++){
       negativeMeanR += negativeZrods[index]->positionBounds().perp();
     }
     negativeMeanR = negativeMeanR/negativeZrods.size();
   }
 
-  if(positiveZrods.size()>0 && negativeZrods.size()>0){
+  if(!positiveZrods.empty() && !negativeZrods.empty()){
     for(unsigned int index=0; index!=positiveZrods.size(); index++){
       if( positiveZrods[index]->positionBounds().phi() != negativeZrods[index]->positionBounds().phi()){
 	edm::LogError("TkDetLayers") << "ERROR:rods don't have the same phi. exit!";
@@ -64,27 +64,27 @@ TOBLayer* TOBLayerBuilder::build(const GeometricDet* aTOBLayer,
 						     theGeomDetGeometry)    );
     }
   } else{
-    if(positiveZrods.size()>0){
+    if(!positiveZrods.empty()){
       for(unsigned int index=0; index!=positiveZrods.size(); index++){
 	if(positiveZrods[index]->positionBounds().perp() < positiveMeanR)
-	  theInnerRods.push_back(myTOBRodBuilder.build(0,
+	  theInnerRods.push_back(myTOBRodBuilder.build(nullptr,
 						       positiveZrods[index],
 						       theGeomDetGeometry)    );       
 	if(positiveZrods[index]->positionBounds().perp() >= positiveMeanR)
-	  theOuterRods.push_back(myTOBRodBuilder.build(0,
+	  theOuterRods.push_back(myTOBRodBuilder.build(nullptr,
 						       positiveZrods[index],
 						       theGeomDetGeometry)    );       
       }
     }
-    if(negativeZrods.size()>0){
+    if(!negativeZrods.empty()){
       for(unsigned int index=0; index!=negativeZrods.size(); index++){
 	if(negativeZrods[index]->positionBounds().perp() < negativeMeanR)
 	  theInnerRods.push_back(myTOBRodBuilder.build(negativeZrods[index],
-						       0,
+						       nullptr,
 						       theGeomDetGeometry)    );       
 	if(negativeZrods[index]->positionBounds().perp() >= negativeMeanR)
 	  theOuterRods.push_back(myTOBRodBuilder.build(negativeZrods[index],
-						       0,
+						       nullptr,
 						       theGeomDetGeometry)    );
       }
     }

--- a/RecoTracker/TkDetLayers/src/TOBRod.cc
+++ b/RecoTracker/TkDetLayers/src/TOBRod.cc
@@ -233,7 +233,7 @@ void TOBRod::searchNeighbors( const TrajectoryStateOnSurface& tsos,
 			      vector<DetGroup>& result,
 			      bool checkClosest) const
 {
-  GlobalPoint gCrossingPos = crossing.position();
+  const GlobalPoint& gCrossingPos = crossing.position();
 
   const vector<const GeomDet*>& sRod( subRod( crossing.subLayerIndex()));
  

--- a/RecoTracker/TkDetLayers/src/TOBRod.h
+++ b/RecoTracker/TkDetLayers/src/TOBRod.h
@@ -19,23 +19,23 @@ class TOBRod final : public DetRod {
 
   TOBRod(std::vector<const GeomDet*>& innerDets,
 	 std::vector<const GeomDet*>& outerDets) __attribute__ ((cold));
-  ~TOBRod() __attribute__ ((cold));
+  ~TOBRod() override __attribute__ ((cold));
   
   // GeometricSearchDet interface
   
-  virtual const std::vector<const GeomDet*>& basicComponents() const {return theDets;}
+  const std::vector<const GeomDet*>& basicComponents() const override {return theDets;}
 
-  virtual const std::vector<const GeometricSearchDet*>& components() const __attribute__ ((cold));
+  const std::vector<const GeometricSearchDet*>& components() const override __attribute__ ((cold));
 
   
-  virtual std::pair<bool, TrajectoryStateOnSurface>
+  std::pair<bool, TrajectoryStateOnSurface>
   compatible( const TrajectoryStateOnSurface& ts, const Propagator&, 
-	      const MeasurementEstimator&) const  __attribute__ ((cold));
+	      const MeasurementEstimator&) const  override __attribute__ ((cold));
 
   void groupedCompatibleDetsV( const TrajectoryStateOnSurface& tsos,
 			       const Propagator& prop,
 			       const MeasurementEstimator& est,
-			       std::vector<DetGroup> & result) const __attribute__ ((hot));
+			       std::vector<DetGroup> & result) const override __attribute__ ((hot));
   
  
  private:

--- a/RecoTracker/TkDetLayers/src/TOBRodBuilder.cc
+++ b/RecoTracker/TkDetLayers/src/TOBRodBuilder.cc
@@ -9,9 +9,9 @@ TOBRod* TOBRodBuilder::build(const GeometricDet* negTOBRod,
 			     const TrackerGeometry* theGeomDetGeometry)
 {  
   vector<const GeometricDet*>  theNegativeGeometricDets;
-  if (negTOBRod != 0) theNegativeGeometricDets = negTOBRod->components();
+  if (negTOBRod != nullptr) theNegativeGeometricDets = negTOBRod->components();
   vector<const GeometricDet*>  thePositiveGeometricDets;
-  if (posTOBRod != 0) thePositiveGeometricDets = posTOBRod->components();
+  if (posTOBRod != nullptr) thePositiveGeometricDets = posTOBRod->components();
 
   vector<const GeometricDet*> allGeometricDets = theNegativeGeometricDets;
   allGeometricDets.insert(allGeometricDets.end(),thePositiveGeometricDets.begin(),

--- a/RecoTracker/TkHitPairs/interface/CombinedHitPairGenerator.h
+++ b/RecoTracker/TkHitPairs/interface/CombinedHitPairGenerator.h
@@ -26,11 +26,11 @@ public:
 
 public:
   CombinedHitPairGenerator(const edm::ParameterSet & cfg, edm::ConsumesCollector& iC);
-  virtual ~CombinedHitPairGenerator();
+  ~CombinedHitPairGenerator() override;
 
   /// form base class
-  virtual void hitPairs( const TrackingRegion& reg, 
-      OrderedHitPairs & result, const edm::Event& ev, const edm::EventSetup& es);
+  void hitPairs( const TrackingRegion& reg, 
+      OrderedHitPairs & result, const edm::Event& ev, const edm::EventSetup& es) override;
 
 private:
   CombinedHitPairGenerator(const CombinedHitPairGenerator & cb); 

--- a/RecoTracker/TkHitPairs/interface/CosmicLayerPairs.h
+++ b/RecoTracker/TkHitPairs/interface/CosmicLayerPairs.h
@@ -19,13 +19,13 @@ class TrackerTopology;
 class CosmicLayerPairs : public SeedLayerPairs{
 public:
   CosmicLayerPairs(std::string geometry):_geometry(geometry){};//:isFirstCall(true){};
-  ~CosmicLayerPairs();
+  ~CosmicLayerPairs() override;
   //  explicit PixelSeedLayerPairs(const edm::EventSetup& iSetup);
 
 
 
   //  virtual vector<LayerPair> operator()() const;
-  std::vector<SeedLayerPairs::LayerPair> operator()() ;
+  std::vector<SeedLayerPairs::LayerPair> operator()() override ;
   void init(const SiStripRecHit2DCollection &collstereo,
              const SiStripRecHit2DCollection &collrphi,
              const SiStripMatchedRecHit2DCollection &collmatched,

--- a/RecoTracker/TkHitPairs/interface/HitPairGenerator.h
+++ b/RecoTracker/TkHitPairs/interface/HitPairGenerator.h
@@ -23,15 +23,15 @@ public:
   explicit HitPairGenerator(unsigned int size=4000);
   HitPairGenerator(HitPairGenerator const & other) : localRA(other.localRA.mean()){}
 
-  virtual ~HitPairGenerator() { }
+  ~HitPairGenerator() override { }
 
-  virtual const OrderedHitPairs & run(
-    const TrackingRegion& region, const edm::Event & ev, const edm::EventSetup& es);
+  const OrderedHitPairs & run(
+    const TrackingRegion& region, const edm::Event & ev, const edm::EventSetup& es) override;
 
   virtual void hitPairs( const TrackingRegion& reg, OrderedHitPairs & prs, 
       const edm::Event & ev,  const edm::EventSetup& es) = 0;
 
-  virtual void clear() final;
+  void clear() final;
 
 private:
   OrderedHitPairs thePairs;

--- a/RecoTracker/TkHitPairs/interface/OrderedHitPairs.h
+++ b/RecoTracker/TkHitPairs/interface/OrderedHitPairs.h
@@ -8,11 +8,11 @@
 class OrderedHitPairs : public std::vector<OrderedHitPair>, public OrderedSeedingHits {
 public:
 
-  virtual ~OrderedHitPairs(){}
+  ~OrderedHitPairs() override{}
 
-  virtual unsigned int size() const { return std::vector<OrderedHitPair>::size(); }
+  unsigned int size() const override { return std::vector<OrderedHitPair>::size(); }
 
-  virtual const OrderedHitPair& operator[](unsigned int i) const { 
+  const OrderedHitPair& operator[](unsigned int i) const override { 
     return std::vector<OrderedHitPair>::operator[](i); 
   }
 

--- a/RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h
+++ b/RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h
@@ -24,7 +24,7 @@ public:
   public:
     HitWithPhi( const Hit & hit) : theHit(hit), thePhi(hit->globalPosition().barePhi()) {}
     HitWithPhi( const Hit & hit,float phi) : theHit(hit), thePhi(phi) {}
-    HitWithPhi( float phi) : theHit(0), thePhi(phi) {}
+    HitWithPhi( float phi) : theHit(nullptr), thePhi(phi) {}
     float phi() const {return thePhi;}
     Hit const & hit() const { return theHit;}
   private:

--- a/RecoTracker/TkHitPairs/plugins/HitPairEDProducer.cc
+++ b/RecoTracker/TkHitPairs/plugins/HitPairEDProducer.cc
@@ -20,11 +20,11 @@ namespace { class ImplBase; }
 class HitPairEDProducer: public edm::stream::EDProducer<> {
 public:
   HitPairEDProducer(const edm::ParameterSet& iConfig);
-  ~HitPairEDProducer() = default;
+  ~HitPairEDProducer() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
 private:
   edm::EDGetTokenT<SeedingLayerSetsHits> seedingLayerToken_;
@@ -105,7 +105,7 @@ namespace {
   template <typename T_SeedingHitSets, typename T_IntermediateHitDoublets>
   struct Impl: public ImplBase {
     Impl(const edm::ParameterSet& iConfig): ImplBase(iConfig) {}
-    ~Impl() = default;
+    ~Impl() override = default;
 
     void produces(edm::ProducerBase& producer) const override {
       T_SeedingHitSets::produces(producer);

--- a/RecoTracker/TkHitPairs/src/CosmicHitPairGeneratorFromLayerPair.cc
+++ b/RecoTracker/TkHitPairs/src/CosmicHitPairGeneratorFromLayerPair.cc
@@ -16,7 +16,7 @@ CosmicHitPairGeneratorFromLayerPair::CosmicHitPairGeneratorFromLayerPair(const L
 							     const LayerWithHits* outer, 
 									 //							     LayerCacheType* layerCache, 
 							     const edm::EventSetup& iSetup)
-  : TTRHbuilder(0),trackerGeometry(0),
+  : TTRHbuilder(nullptr),trackerGeometry(nullptr),
     //theLayerCache(*layerCache), 
     theOuterLayer(outer), theInnerLayer(inner)
 {

--- a/RecoTracker/TkHitPairs/src/HitPairGenerator.cc
+++ b/RecoTracker/TkHitPairs/src/HitPairGenerator.cc
@@ -5,7 +5,7 @@ HitPairGenerator::HitPairGenerator(unsigned int nSize) : localRA(nSize) {}
 const OrderedHitPairs & HitPairGenerator::run(
     const TrackingRegion& region, const edm::Event & ev, const edm::EventSetup& es)
 {
-  assert(thePairs.size()==0); assert(thePairs.capacity()==0);
+  assert(thePairs.empty()); assert(thePairs.capacity()==0);
   thePairs.reserve(localRA.upper());
   hitPairs(region, thePairs, ev, es);
   thePairs.shrink_to_fit();

--- a/RecoTracker/TkMSParametrization/interface/MSLayer.h
+++ b/RecoTracker/TkMSParametrization/interface/MSLayer.h
@@ -16,11 +16,11 @@ public:
   typedef PixelRecoRange<float> Range;
 
   struct DataX0 { 
-    DataX0(const MSLayersKeeper *al = 0) 
+    DataX0(const MSLayersKeeper *al = nullptr) 
       : hasX0(false), allLayers(al) { }
     DataX0(float ax0, float asX0D, float aCotTheta) 
       : hasX0(true), hasFSlope(false), x0(ax0), sumX0D(asX0D), 
-        cotTheta(aCotTheta), allLayers(0) { }
+        cotTheta(aCotTheta), allLayers(nullptr) { }
     void setForwardSumX0DSlope(float aSlope) 
         { hasFSlope= true; slopeSumX0D = aSlope; }
     bool hasX0, hasFSlope;
@@ -29,12 +29,12 @@ public:
   };
 
 public:
-  MSLayer(const DetLayer* layer, const DataX0& dataX0 = DataX0(0) ) dso_hidden;
+  MSLayer(const DetLayer* layer, const DataX0& dataX0 = DataX0(nullptr) ) dso_hidden;
   MSLayer() { }
 
   MSLayer(GeomDetEnumerators::Location part, float position, Range range, 
 	   float halfThickness = 0., 
-	   const DataX0& dataX0 = DataX0(0) ) dso_hidden;
+	   const DataX0& dataX0 = DataX0(nullptr) ) dso_hidden;
 
 
   // sequential number to be used in "maps"

--- a/RecoTracker/TkMSParametrization/src/MSLayersAtAngle.cc
+++ b/RecoTracker/TkMSParametrization/src/MSLayersAtAngle.cc
@@ -35,7 +35,7 @@ const MSLayer * MSLayersAtAngle::findLayer(const MSLayer & layer) const
 {
   vector<MSLayer>::const_iterator it =
      find(theLayers.begin(), theLayers.end(), layer);
-  return it==theLayers.end() ? 0 : &(*it);  
+  return it==theLayers.end() ? nullptr : &(*it);  
 }
 
 //------------------------------------------------------------------------------

--- a/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0AtEta.cc
+++ b/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0AtEta.cc
@@ -81,7 +81,7 @@ void MSLayersKeeperX0AtEta::init(const edm::EventSetup &iSetup)
       vector<MSLayer>::iterator it;
       for (it = candidates.begin(); it != candidates.end(); it++) {
         if (layersAtAngle.findLayer(*it)) continue;
-        const MSLayer * found = 0;
+        const MSLayer * found = nullptr;
         int bin = idxbin;
         while(!found) {
           bin--; if (bin < 0) break; 

--- a/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0AtEta.h
+++ b/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0AtEta.h
@@ -9,9 +9,9 @@ class MSLayersKeeperX0Averaged;
 class dso_hidden MSLayersKeeperX0AtEta final : public MSLayersKeeper {
 public:
   MSLayersKeeperX0AtEta() : isInitialised(false) { }
-  ~MSLayersKeeperX0AtEta() { }
-  void init(const edm::EventSetup &iSetup);
-  const MSLayersAtAngle & layers(float cotTheta) const;
+  ~MSLayersKeeperX0AtEta() override { }
+  void init(const edm::EventSetup &iSetup) override;
+  const MSLayersAtAngle & layers(float cotTheta) const override;
 
 private:
   float eta(int idxBin) const;

--- a/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0Averaged.h
+++ b/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0Averaged.h
@@ -6,11 +6,11 @@
 class dso_hidden MSLayersKeeperX0Averaged final : public MSLayersKeeper {
 public:
   MSLayersKeeperX0Averaged() : isInitialised(false) { }
-  virtual ~MSLayersKeeperX0Averaged() { }
-  virtual void init(const edm::EventSetup &iSetup);
-  virtual MSLayer layer(const DetLayer* layer) const
+  ~MSLayersKeeperX0Averaged() override { }
+  void init(const edm::EventSetup &iSetup) override;
+  MSLayer layer(const DetLayer* layer) const override
     {return *theLayersData.findLayer(MSLayer(layer)); }
-  virtual const MSLayersAtAngle & layers(float cotTheta) const 
+  const MSLayersAtAngle & layers(float cotTheta) const override 
     {return theLayersData;}
 
 private:

--- a/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0DetLayer.h
+++ b/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0DetLayer.h
@@ -7,11 +7,11 @@
 class dso_hidden MSLayersKeeperX0DetLayer final : public MSLayersKeeper {
 public:
   MSLayersKeeperX0DetLayer() : isInitialised(false) { }
-  virtual ~MSLayersKeeperX0DetLayer() { }
-  virtual void init(const edm::EventSetup &iSetup);
-  virtual MSLayer layer(const DetLayer* layer) const
+  ~MSLayersKeeperX0DetLayer() override { }
+  void init(const edm::EventSetup &iSetup) override;
+  MSLayer layer(const DetLayer* layer) const override
     {return *theLayersData.findLayer(MSLayer(layer)); }
-  virtual const MSLayersAtAngle & layers(float cotTheta) const
+  const MSLayersAtAngle & layers(float cotTheta) const override
     {return theLayersData;}
 
 private:

--- a/RecoTracker/TkMSParametrization/src/MultipleScatteringX0Data.h
+++ b/RecoTracker/TkMSParametrization/src/MultipleScatteringX0Data.h
@@ -20,11 +20,11 @@ class dso_hidden MultipleScatteringX0Data : public SumX0AtEtaDataProvider {
 
 public:
   MultipleScatteringX0Data();
-  virtual ~MultipleScatteringX0Data();
+  ~MultipleScatteringX0Data() override;
   int nBinsEta() const;
   float minEta() const;
   float maxEta() const;
-  virtual float sumX0atEta(float eta, float r) const;
+  float sumX0atEta(float eta, float r) const override;
 
 private:
   std::string fileName();

--- a/RecoTracker/TkNavigation/plugins/BeamHaloNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/plugins/BeamHaloNavigationSchool.cc
@@ -10,14 +10,14 @@ public:
   
   BeamHaloNavigationSchool(const GeometricSearchTracker* theTracker,
 			 const MagneticField* field);
-  ~BeamHaloNavigationSchool(){ cleanMemory();}
+  ~BeamHaloNavigationSchool() override{ cleanMemory();}
 
  protected:
   //addon to SimpleNavigationSchool
   void linkOtherEndLayers( SymmetricLayerFinder& symFinder);
   void addInward(const DetLayer * det, const FDLC& news);
   void addInward(const DetLayer * det, const ForwardDetLayer * newF);
-  void establishInverseRelations();
+  void establishInverseRelations() override;
   FDLC reachableFromHorizontal();
 };
 

--- a/RecoTracker/TkNavigation/plugins/CosmicNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/plugins/CosmicNavigationSchool.cc
@@ -16,7 +16,7 @@ class dso_hidden CosmicNavigationSchool : public SimpleNavigationSchool {
 public:
   CosmicNavigationSchool(const GeometricSearchTracker* theTracker,
 			 const MagneticField* field);
-  ~CosmicNavigationSchool(){ cleanMemory();}
+  ~CosmicNavigationSchool() override{ cleanMemory();}
 
   class CosmicNavigationSchoolConfiguration{
   public:
@@ -42,7 +42,7 @@ protected:
 private:
 
   //FakeDetLayer* theFakeDetLayer;
-  void linkBarrelLayers( SymmetricLayerFinder& symFinder);
+  void linkBarrelLayers( SymmetricLayerFinder& symFinder) override;
   //void linkForwardLayers( SymmetricLayerFinder& symFinder); 
   void establishInverseRelations( SymmetricLayerFinder& symFinder );
   void buildAdditionalBarrelLinks();
@@ -137,7 +137,7 @@ void CosmicNavigationSchool::build(const GeometricSearchTracker* theInputTracker
 
     //add TOB1->TOB1 inward link
     const std::vector< const BarrelDetLayer * > &  tobL = theInputTracker->tobLayers();
-    if (tobL.size()>=1){
+    if (!tobL.empty()){
       if (conf.allSelf){
 	LogDebug("CosmicNavigationSchool")<<" adding all TOB self search.";
 	for (auto lIt = tobL.begin(); lIt!=tobL.end(); ++lIt)
@@ -150,7 +150,7 @@ void CosmicNavigationSchool::build(const GeometricSearchTracker* theInputTracker
       }
     }
     const std::vector< const BarrelDetLayer * > &  tibL = theInputTracker->tibLayers();
-    if (tibL.size()>=1){
+    if (!tibL.empty()){
       if (conf.allSelf){
 	LogDebug("CosmicNavigationSchool")<<" adding all TIB self search.";
 	for (auto lIt = tibL.begin(); lIt!=tibL.end(); ++lIt)
@@ -163,7 +163,7 @@ void CosmicNavigationSchool::build(const GeometricSearchTracker* theInputTracker
       }
     }
     const std::vector< const BarrelDetLayer * > &  pxbL = theInputTracker->pixelBarrelLayers();
-    if (pxbL.size()>=1){
+    if (!pxbL.empty()){
       if (conf.allSelf){
 	LogDebug("CosmicNavigationSchool")<<" adding all PXB self search.";
         for (auto lIt = pxbL.begin(); lIt!=pxbL.end(); ++lIt)
@@ -320,7 +320,7 @@ public:
 				      const MagneticField* field,
 				      const CosmicNavigationSchoolConfiguration conf);
 
-  ~SkippingLayerCosmicNavigationSchool(){cleanMemory();};
+  ~SkippingLayerCosmicNavigationSchool() override{cleanMemory();};
 };
 
 
@@ -362,7 +362,7 @@ class dso_hidden SkippingLayerCosmicNavigationSchoolESProducer final : public ed
 }
 
 
-  ~SkippingLayerCosmicNavigationSchoolESProducer(){}
+  ~SkippingLayerCosmicNavigationSchoolESProducer() override{}
 
    typedef std::shared_ptr<NavigationSchool> ReturnType;
 

--- a/RecoTracker/TkNavigation/plugins/NavigationSchoolESProducer.cc
+++ b/RecoTracker/TkNavigation/plugins/NavigationSchoolESProducer.cc
@@ -18,7 +18,7 @@
 class dso_hidden NavigationSchoolESProducer final : public edm::ESProducer {
 public:
   NavigationSchoolESProducer(const edm::ParameterSet&);
-  ~NavigationSchoolESProducer();
+  ~NavigationSchoolESProducer() override;
   
   typedef std::shared_ptr<NavigationSchool> ReturnType;
 

--- a/RecoTracker/TkNavigation/plugins/SimpleBarrelNavigableLayer.cc
+++ b/RecoTracker/TkNavigation/plugins/SimpleBarrelNavigableLayer.cc
@@ -163,7 +163,7 @@ SimpleBarrelNavigableLayer::nextLayers( const FreeTrajectoryState& fts,
   LogDebug("SimpleBarrelNavigableLayer") << "goingIntoTheBarrel: " << goingIntoTheBarrel;
 
 
-  if unlikely(theSelfSearch && result.size()==0){
+  if unlikely(theSelfSearch && result.empty()){
     if (!goingIntoTheBarrel){     
       LogDebug("SimpleBarrelNavigableLayer")<<" state is not going toward the center of the barrel. not adding self search.";}
     else{

--- a/RecoTracker/TkNavigation/plugins/SimpleBarrelNavigableLayer.h
+++ b/RecoTracker/TkNavigation/plugins/SimpleBarrelNavigableLayer.h
@@ -23,29 +23,29 @@ public:
 
   
   // NavigableLayer interface
-  virtual std::vector<const DetLayer*> 
+  std::vector<const DetLayer*> 
   nextLayers( NavigationDirection direction) const override;
 
-  virtual std::vector<const DetLayer*> 
+  std::vector<const DetLayer*> 
   nextLayers( const FreeTrajectoryState& fts, 
 	      PropagationDirection timeDirection) const override;
 
-  virtual std::vector<const DetLayer*> 
+  std::vector<const DetLayer*> 
   compatibleLayers( NavigationDirection direction) const override;
 
-  virtual std::vector<const DetLayer*> 
+  std::vector<const DetLayer*> 
   compatibleLayers( const FreeTrajectoryState& fts, 
 		    PropagationDirection dir) const override {
     int counter=0;
     return SimpleNavigableLayer::compatibleLayers(fts,dir,counter);
   }
 
-  virtual void setAdditionalLink(const DetLayer*, NavigationDirection direction=insideOut) override;
+  void setAdditionalLink(const DetLayer*, NavigationDirection direction=insideOut) override;
 
-  virtual const DetLayer* detLayer() const override { return theDetLayer;}
-  virtual void   setDetLayer( const DetLayer* dl) override;
+  const DetLayer* detLayer() const override { return theDetLayer;}
+  void   setDetLayer( const DetLayer* dl) override;
   
-  virtual void setInwardLinks(const BDLC& theBarrelv, const FDLC& theForwardv,TkLayerLess sorter = TkLayerLess(outsideIn)) override;
+  void setInwardLinks(const BDLC& theBarrelv, const FDLC& theForwardv,TkLayerLess sorter = TkLayerLess(outsideIn)) override;
 
 private:
   const BarrelDetLayer*   theDetLayer;

--- a/RecoTracker/TkNavigation/plugins/SimpleForwardNavigableLayer.h
+++ b/RecoTracker/TkNavigation/plugins/SimpleForwardNavigableLayer.h
@@ -18,29 +18,29 @@ public:
 			       bool checkCrossingSide=true);
 
   // NavigableLayer interface
-  virtual std::vector<const DetLayer*> 
+  std::vector<const DetLayer*> 
   nextLayers( NavigationDirection direction) const override;
 
-  virtual std::vector<const DetLayer*> 
+  std::vector<const DetLayer*> 
   nextLayers( const FreeTrajectoryState& fts, 
 	      PropagationDirection timeDirection) const override;
 
-  virtual std::vector<const DetLayer*> 
+  std::vector<const DetLayer*> 
   compatibleLayers( NavigationDirection direction) const override;
 
-  virtual std::vector<const DetLayer*> 
+  std::vector<const DetLayer*> 
   compatibleLayers( const FreeTrajectoryState& fts, 
 		    PropagationDirection dir) const override {
     int counter=0;
     return SimpleNavigableLayer::compatibleLayers(fts,dir,counter);
   }
 
-  virtual void setAdditionalLink(const DetLayer*, NavigationDirection direction=insideOut) override;
+  void setAdditionalLink(const DetLayer*, NavigationDirection direction=insideOut) override;
 
-  virtual const DetLayer* detLayer() const override { return theDetLayer;} 
-  virtual void   setDetLayer( const DetLayer* dl) override;
+  const DetLayer* detLayer() const override { return theDetLayer;} 
+  void   setDetLayer( const DetLayer* dl) override;
 
-  virtual void setInwardLinks( const BDLC&, const FDLC&, TkLayerLess sorter = TkLayerLess(outsideIn)) override;
+  void setInwardLinks( const BDLC&, const FDLC&, TkLayerLess sorter = TkLayerLess(outsideIn)) override;
 
 private:
   const ForwardDetLayer*  theDetLayer;

--- a/RecoTracker/TkNavigation/plugins/SimpleNavigableLayer.h
+++ b/RecoTracker/TkNavigation/plugins/SimpleNavigableLayer.h
@@ -33,7 +33,7 @@ public:
   void setCheckCrossingSide(bool docheck) {theCheckCrossingSide = docheck;}
 
 
-  virtual std::vector< const DetLayer * > compatibleLayers (const FreeTrajectoryState &fts, 
+  std::vector< const DetLayer * > compatibleLayers (const FreeTrajectoryState &fts, 
 							    PropagationDirection timeDirection,
 							    int& counter) const  final;
   

--- a/RecoTracker/TkNavigation/plugins/SimpleNavigationSchool.h
+++ b/RecoTracker/TkNavigation/plugins/SimpleNavigationSchool.h
@@ -22,10 +22,10 @@ public:
   SimpleNavigationSchool(const GeometricSearchTracker* tracker,
 			 const MagneticField* field) : 
                          TkNavigationSchool(tracker,field) {init();}
-  ~SimpleNavigationSchool(){cleanMemory();}
+  ~SimpleNavigationSchool() override{cleanMemory();}
 
   // from base class
-  virtual StateType navigableLayers() override;
+  StateType navigableLayers() override;
 
 protected:
 

--- a/RecoTracker/TkNavigation/plugins/SymmetricLayerFinder.cc
+++ b/RecoTracker/TkNavigation/plugins/SymmetricLayerFinder.cc
@@ -23,7 +23,7 @@ SymmetricLayerFinder::SymmetricLayerFinder( const FDLC& flc)
   for ( FDLI i = leftLayers.begin(); i != leftLayers.end(); i++) {
    const  ForwardDetLayer* partner = mirrorPartner( *i, rightLayers);
     //if ( partner == 0) throw DetLogicError("Assymmetric forward layers in Tracker");
-    if ( partner == 0) throw cms::Exception("SymmetricLayerFinder", "Assymmetric forward layers in Tracker");
+    if ( partner == nullptr) throw cms::Exception("SymmetricLayerFinder", "Assymmetric forward layers in Tracker");
 
     foundPairs.push_back( make_pair( *i, partner));
   }
@@ -52,7 +52,7 @@ const ForwardDetLayer* SymmetricLayerFinder::mirrorPartner( const ForwardDetLaye
 
   ConstFDLI result =
     find_if( rightLayers.begin(), rightLayers.end(), mirrorImage);
-  if ( result == rightLayers.end()) return 0;
+  if ( result == rightLayers.end()) return nullptr;
   else return *result;
 }
 

--- a/RecoTracker/TkNavigation/plugins/TkMSParameterizationBuilder.cc
+++ b/RecoTracker/TkNavigation/plugins/TkMSParameterizationBuilder.cc
@@ -158,7 +158,7 @@ TkMSParameterizationBuilder::produce(TkMSParameterizationRecord const& iRecord) 
 	      }
 	      if (debug) std::cout << il << (it->isBarrel() ? " Barrel" : " Forward") << " layer " << it->seqNum() << " SubDet " << it->subDetector()<< std::endl;
 	      auto const & detWithState = it->compatibleDets(tsos,ANprop,estimator);
-	      if(!detWithState.size()) { 
+	      if(detWithState.empty()) { 
 		if(debug) std::cout << "no det on this layer" << it->seqNum() << std::endl; 
 		continue;
 	      }
@@ -235,7 +235,7 @@ TkMSParameterizationBuilder::produce(TkMSParameterizationRecord const& iRecord) 
 	    }
 	    
 	    auto const & detWithState = layer0->compatibleDets(tsos0,ANprop,estimator);
-	    if(!detWithState.size()) {
+	    if(detWithState.empty()) {
 	      if(debug) std::cout << "no det on first layer" << layer0->seqNum() << std::endl;
 	      continue;
 	    }

--- a/RecoTracker/TkSeedGenerator/interface/ClusterChecker.h
+++ b/RecoTracker/TkSeedGenerator/interface/ClusterChecker.h
@@ -32,7 +32,7 @@ class ClusterChecker {
   size_t tooManyClusters(const edm::Event & e) const ;
 
  private: 
-  ClusterChecker(); // This is only needed for StringCutObjectSelector
+  ClusterChecker() = delete; // This is only needed for StringCutObjectSelector
   bool doACheck_;
   edm::InputTag clusterCollectionInputTag_;
   edm::InputTag pixelClusterCollectionInputTag_;

--- a/RecoTracker/TkSeedGenerator/interface/MultiHitGenerator.h
+++ b/RecoTracker/TkSeedGenerator/interface/MultiHitGenerator.h
@@ -24,9 +24,9 @@ public:
   MultiHitGenerator( MultiHitGenerator const & other) : localRA(other.localRA.mean()){}
 
 
-  virtual ~MultiHitGenerator() { }
+  ~MultiHitGenerator() override { }
 
-  virtual const OrderedMultiHits & run(
+  const OrderedMultiHits & run(
     const TrackingRegion& region, const edm::Event & ev, const edm::EventSetup& es) final;
 
   // temporary interface, for bckwd compatibility
@@ -36,7 +36,7 @@ public:
   virtual void hitSets( const TrackingRegion& reg, OrderedMultiHits & prs,
       const edm::Event & ev,  const edm::EventSetup& es) = 0;
 
-  virtual void clear();
+  void clear() override;
 
 private:
   OrderedMultiHits theHitSets;

--- a/RecoTracker/TkSeedGenerator/interface/SeedCreatorFromRegionHitsEDProducerT.h
+++ b/RecoTracker/TkSeedGenerator/interface/SeedCreatorFromRegionHitsEDProducerT.h
@@ -21,11 +21,11 @@ class SeedCreatorFromRegionHitsEDProducerT: public edm::stream::EDProducer<> {
 public:
 
   SeedCreatorFromRegionHitsEDProducerT(const edm::ParameterSet& iConfig);
-  ~SeedCreatorFromRegionHitsEDProducerT() = default;
+  ~SeedCreatorFromRegionHitsEDProducerT() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
 private:
   edm::EDGetTokenT<RegionsSeedingHitSets> seedingHitSetsToken_;

--- a/RecoTracker/TkSeedGenerator/plugins/ClusterCheckerEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/ClusterCheckerEDProducer.cc
@@ -10,11 +10,11 @@ class ClusterCheckerEDProducer: public edm::stream::EDProducer<> {
 public:
 
   ClusterCheckerEDProducer(const edm::ParameterSet& iConfig);
-  ~ClusterCheckerEDProducer() = default;
+  ~ClusterCheckerEDProducer() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
 private:
   ClusterChecker theClusterCheck;

--- a/RecoTracker/TkSeedGenerator/plugins/CombinedMultiHitGenerator.h
+++ b/RecoTracker/TkSeedGenerator/plugins/CombinedMultiHitGenerator.h
@@ -29,13 +29,13 @@ public:
 
   CombinedMultiHitGenerator( const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
 
-  virtual ~CombinedMultiHitGenerator();
+  ~CombinedMultiHitGenerator() override;
 
   /// from base class
-  virtual void hitSets( const TrackingRegion& reg, OrderedMultiHits & result,
+  void hitSets( const TrackingRegion& reg, OrderedMultiHits & result,
       const edm::Event & ev,  const edm::EventSetup& es) override;
 
-  virtual void clear() override {
+  void clear() override {
     MultiHitGenerator::clear();
     theGenerator->clear();
   }

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitFromChi2EDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitFromChi2EDProducer.cc
@@ -17,11 +17,11 @@
 class MultiHitFromChi2EDProducer: public edm::stream::EDProducer<> {
 public:
   MultiHitFromChi2EDProducer(const edm::ParameterSet& iConfig);
-  ~MultiHitFromChi2EDProducer() = default;
+  ~MultiHitFromChi2EDProducer() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
 private:
   edm::EDGetTokenT<IntermediateHitDoublets> doubletToken_;

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
@@ -93,8 +93,8 @@ MultiHitGeneratorFromChi2::MultiHitGeneratorFromChi2(const edm::ParameterSet& cf
     useSimpleMF_ = true;
     mfName_ = cfg.getParameter<std::string>("SimpleMagneticField");
   }
-  filter = 0;
-  bfield = 0;
+  filter = nullptr;
+  bfield = nullptr;
   nomField = -1.;
 }
 
@@ -198,7 +198,7 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region, OrderedMul
                                         cacheHits& refittedHitStorage) {
   int size = thirdLayers.size();
   const RecHitsSortedInPhi * thirdHitMap[size];
-  vector<const DetLayer *> thirdLayerDetLayer(size,0);
+  vector<const DetLayer *> thirdLayerDetLayer(size,nullptr);
   for (int il=0; il<size; ++il) 
     {
       thirdHitMap[il] = &layerCache(thirdLayers[il], region, es);
@@ -665,7 +665,7 @@ void MultiHitGeneratorFromChi2::refit2Hits(HitOwnPtr & hit1,
 					   const TrackingRegion& region, float nomField, bool isDebug) {
 
   //these need to be sorted in R
-  GlobalPoint gp0 = region.origin();
+  const GlobalPoint& gp0 = region.origin();
   GlobalPoint gp1 = hit1->globalPosition();
   GlobalPoint gp2 = hit2->globalPosition();
 

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.h
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.h
@@ -33,7 +33,7 @@ typedef CombinedMultiHitGenerator::LayerCacheType       LayerCacheType;
 public:
   MultiHitGeneratorFromChi2(const edm::ParameterSet& cfg);
 
-  virtual ~MultiHitGeneratorFromChi2();
+  ~MultiHitGeneratorFromChi2() override;
 
   static void fillDescriptions(edm::ParameterSetDescription& desc);
   static const char *fillDescriptionsLabel() { return "multiHitFromChi2"; }
@@ -41,7 +41,7 @@ public:
 
   void initES(const edm::EventSetup& es) override; 
 
-  virtual void hitSets( const TrackingRegion& region, OrderedMultiHits & trs, 
+  void hitSets( const TrackingRegion& region, OrderedMultiHits & trs, 
                         const edm::Event & ev, const edm::EventSetup& es,
                         SeedingLayerSetsHits::SeedingLayerSet pairLayers,
                         std::vector<SeedingLayerSetsHits::SeedingLayer> thirdLayers) override;

--- a/RecoTracker/TkSeedGenerator/plugins/SeedCombiner.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedCombiner.cc
@@ -39,7 +39,7 @@ SeedCombiner::SeedCombiner(const edm::ParameterSet& cfg)
       for (unsigned int i=0;i<clusterRemovalInfos_.size();++i)
 	if (!(clusterRemovalInfos_[i]==edm::InputTag("")))
 	  clusterRemovalTokens_[i] = consumes<reco::ClusterRemovalInfo>(clusterRemovalInfos_[i]);
-      if (clusterRemovalInfos_.size()!=0 && clusterRemovalInfos_.size()==inputCollections_.size()) reKeing_=true;
+      if (!clusterRemovalInfos_.empty() && clusterRemovalInfos_.size()==inputCollections_.size()) reKeing_=true;
     }
 }
 

--- a/RecoTracker/TkSeedGenerator/plugins/SeedCombiner.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedCombiner.h
@@ -14,9 +14,9 @@ class dso_hidden SeedCombiner : public edm::stream::EDProducer<> {
 public:
 
   SeedCombiner(const edm::ParameterSet& cfg);
-  ~SeedCombiner();
+  ~SeedCombiner() override;
 
-  virtual void produce(edm::Event& ev, const edm::EventSetup& es) override;
+  void produce(edm::Event& ev, const edm::EventSetup& es) override;
 
 private:
   std::vector<edm::EDGetTokenT<TrajectorySeedCollection>> inputCollections_;

--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.cc
@@ -170,7 +170,7 @@ void SeedFromConsecutiveHitsCreator::buildSeed(
   TrajectoryStateOnSurface updatedState;
   edm::OwnVector<TrackingRecHit> seedHits;
   
-  const TrackingRecHit* hit = 0;
+  const TrackingRecHit* hit = nullptr;
   for ( unsigned int iHit = 0; iHit < hits.size(); iHit++) {
     hit = hits[iHit]->hit();
     TrajectoryStateOnSurface state = (iHit==0) ? 

--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.h
@@ -32,19 +32,19 @@ public:
       {}
 
   //dtor
-  virtual ~SeedFromConsecutiveHitsCreator();
+  ~SeedFromConsecutiveHitsCreator() override;
 
   static void fillDescriptions(edm::ParameterSetDescription& desc);
   static const char *fillDescriptionsLabel() { return "ConsecutiveHits"; }
 
   // initialize the "event dependent state"
-  virtual void init(const TrackingRegion & region,
+  void init(const TrackingRegion & region,
 	       const edm::EventSetup& es,
 	       const SeedComparitor *filter) final;
 
   // make job
   // fill seedCollection with the "TrajectorySeed"
-  virtual void makeSeed(TrajectorySeedCollection & seedCollection,
+  void makeSeed(TrajectorySeedCollection & seedCollection,
 			const SeedingHitSet & hits) final;
 
 

--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsStraightLineCreator.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsStraightLineCreator.h
@@ -11,12 +11,12 @@ public:
   SeedFromConsecutiveHitsStraightLineCreator( const edm::ParameterSet & cfg):
     SeedFromConsecutiveHitsCreator(cfg) { }
 
-  virtual ~SeedFromConsecutiveHitsStraightLineCreator(){}
+  ~SeedFromConsecutiveHitsStraightLineCreator() override{}
 
 private:
 
-  virtual bool initialKinematic(GlobalTrajectoryParameters & kine,
-				const SeedingHitSet & hits) const;
+  bool initialKinematic(GlobalTrajectoryParameters & kine,
+				const SeedingHitSet & hits) const override;
 
 
 };

--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsTripletOnlyCreator.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsTripletOnlyCreator.h
@@ -14,12 +14,12 @@ public:
   }
   static const char *fillDescriptionsLabel() { return "ConsecutiveHitsTripletOnly"; }
 
-  virtual ~SeedFromConsecutiveHitsTripletOnlyCreator(){}
+  ~SeedFromConsecutiveHitsTripletOnlyCreator() override{}
 
 private:
 
-  virtual bool initialKinematic(GlobalTrajectoryParameters & kine,
-				const SeedingHitSet & hits) const;
+  bool initialKinematic(GlobalTrajectoryParameters & kine,
+				const SeedingHitSet & hits) const override;
  
 
 };

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
@@ -142,7 +142,7 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
 
 	edm::ParameterSet seedCreatorPSet = theConfig.getParameter<edm::ParameterSet>("SeedCreatorPSet");
 	SeedFromConsecutiveHitsCreator seedCreator(seedCreatorPSet);
-	seedCreator.init(region, es, 0);
+	seedCreator.init(region, es, nullptr);
 	seedCreator.makeSeed(*result, SeedingHitSet(hits[0], hits[1], hits.size() >2 ? hits[2] : SeedingHitSet::nullPtr() ));
       }
     }

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.h
@@ -12,8 +12,8 @@ namespace edm { class Event; class EventSetup; }
 class dso_hidden SeedGeneratorFromProtoTracksEDProducer : public edm::stream::EDProducer<> {
 public:
   SeedGeneratorFromProtoTracksEDProducer(const edm::ParameterSet& cfg);
-  virtual ~SeedGeneratorFromProtoTracksEDProducer(){}
-  virtual void produce(edm::Event& ev, const edm::EventSetup& es) override;
+  ~SeedGeneratorFromProtoTracksEDProducer() override{}
+  void produce(edm::Event& ev, const edm::EventSetup& es) override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:

--- a/RecoTracker/TkSeedGenerator/src/SeedFromProtoTrack.cc
+++ b/RecoTracker/TkSeedGenerator/src/SeedFromProtoTrack.cc
@@ -32,7 +32,7 @@ SeedFromProtoTrack::SeedFromProtoTrack(const reco::Track & proto,
 SeedFromProtoTrack::SeedFromProtoTrack(const reco::Track & proto,  const edm::EventSetup& es)
   : theValid(true)
 {
-  const TrackingRecHit* hit = 0;
+  const TrackingRecHit* hit = nullptr;
   for (unsigned int iHit = 0, nHits = proto.recHitsSize(); iHit < nHits; ++iHit) {
     TrackingRecHitRef refHit = proto.recHit(iHit);
     hit = &(*refHit);
@@ -54,8 +54,8 @@ void SeedFromProtoTrack::init(const reco::Track & proto, const edm::EventSetup& 
   edm::ESHandle<MagneticField> field;
   es.get<IdealMagneticFieldRecord>().get(field);//fixme
 
-  reco::TrackBase::Point  vtx = proto.referencePoint();
-  reco::TrackBase::Vector mom = proto.momentum();
+  const reco::TrackBase::Point&  vtx = proto.referencePoint();
+  const reco::TrackBase::Vector& mom = proto.momentum();
   GlobalTrajectoryParameters gtp( 
       GlobalPoint(vtx.x(),vtx.y(),vtx.z()),
       GlobalVector(mom.x(),mom.y(),mom.z()),

--- a/RecoTracker/TkSeedingLayers/interface/OrderedMultiHits.h
+++ b/RecoTracker/TkSeedingLayers/interface/OrderedMultiHits.h
@@ -8,11 +8,11 @@
 class OrderedMultiHits : public std::vector<SeedingHitSet>, public OrderedSeedingHits {
 public:
 
-  virtual ~OrderedMultiHits(){}
+  ~OrderedMultiHits() override{}
 
-  virtual unsigned int size() const { return std::vector<SeedingHitSet>::size(); }
+  unsigned int size() const override { return std::vector<SeedingHitSet>::size(); }
 
-  virtual const SeedingHitSet & operator[](unsigned int i) const {
+  const SeedingHitSet & operator[](unsigned int i) const override {
     return std::vector<SeedingHitSet>::operator[](i);
   }
 

--- a/RecoTracker/TkSeedingLayers/plugins/CombinedSeedComparitor.cc
+++ b/RecoTracker/TkSeedingLayers/plugins/CombinedSeedComparitor.cc
@@ -8,12 +8,12 @@
 class CombinedSeedComparitor : public SeedComparitor {
     public:
         CombinedSeedComparitor(const edm::ParameterSet &cfg, edm::ConsumesCollector& iC) ;
-        virtual ~CombinedSeedComparitor() ; 
-        virtual void init(const edm::Event& ev, const edm::EventSetup& es) override ;
-        virtual bool compatible(const SeedingHitSet  &hits) const override ;
-        virtual bool compatible(const TrajectoryStateOnSurface &,  
+        ~CombinedSeedComparitor() override ; 
+        void init(const edm::Event& ev, const edm::EventSetup& es) override ;
+        bool compatible(const SeedingHitSet  &hits) const override ;
+        bool compatible(const TrajectoryStateOnSurface &,  
                 SeedingHitSet::ConstRecHitPointer hit) const override ;
-        virtual bool compatible(const SeedingHitSet  &hits, 
+        bool compatible(const SeedingHitSet  &hits, 
                 const GlobalTrajectoryParameters &helixStateAtVertex,
                 const FastHelix                  &helix) const override ;
 

--- a/RecoTracker/TkSeedingLayers/plugins/SeedingLayersEDProducer.cc
+++ b/RecoTracker/TkSeedingLayers/plugins/SeedingLayersEDProducer.cc
@@ -13,7 +13,7 @@
 class dso_hidden SeedingLayersEDProducer: public edm::stream::EDProducer<> {
 public:
   SeedingLayersEDProducer(const edm::ParameterSet& iConfig);
-  ~SeedingLayersEDProducer();
+  ~SeedingLayersEDProducer() override;
 
   void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 

--- a/RecoTracker/TkSeedingLayers/plugins/SimpleClusterProbabilitySeedComparitor.cc
+++ b/RecoTracker/TkSeedingLayers/plugins/SimpleClusterProbabilitySeedComparitor.cc
@@ -7,12 +7,12 @@
 class SimpleClusterProbabilitySeedComparitor : public SeedComparitor {
     public:
         SimpleClusterProbabilitySeedComparitor(const edm::ParameterSet &cfg, edm::ConsumesCollector& iC) ;
-        virtual ~SimpleClusterProbabilitySeedComparitor() ; 
-        virtual void init(const edm::Event& ev, const edm::EventSetup& es) override {}
-        virtual bool compatible(const SeedingHitSet  &hits) const override { return true; }
-        virtual bool compatible(const TrajectoryStateOnSurface &,
+        ~SimpleClusterProbabilitySeedComparitor() override ; 
+        void init(const edm::Event& ev, const edm::EventSetup& es) override {}
+        bool compatible(const SeedingHitSet  &hits) const override { return true; }
+        bool compatible(const TrajectoryStateOnSurface &,
                 SeedingHitSet::ConstRecHitPointer hit) const override ;
-        virtual bool compatible(const SeedingHitSet  &hits, 
+        bool compatible(const SeedingHitSet  &hits, 
                 const GlobalTrajectoryParameters &helixStateAtVertex,
                 const FastHelix                  &helix) const override { return true; }
 

--- a/RecoTracker/TkSeedingLayers/src/HitExtractorPIX.h
+++ b/RecoTracker/TkSeedingLayers/src/HitExtractorPIX.h
@@ -14,9 +14,9 @@ namespace ctfseeding {
   class HitExtractorPIX final : public HitExtractor {
   public:
     HitExtractorPIX( SeedingLayer::Side & side, int idLayer, const std::string & hitProducer, edm::ConsumesCollector& iC);
-    virtual ~HitExtractorPIX(){}
-    virtual HitExtractor::Hits hits(const TkTransientTrackingRecHitBuilder &ttrhBuilder, const edm::Event& , const edm::EventSetup& ) const override;
-    virtual HitExtractorPIX * clone() const override { return new HitExtractorPIX(*this); }
+    ~HitExtractorPIX() override{}
+    HitExtractor::Hits hits(const TkTransientTrackingRecHitBuilder &ttrhBuilder, const edm::Event& , const edm::EventSetup& ) const override;
+    HitExtractorPIX * clone() const override { return new HitExtractorPIX(*this); }
     
   private:
     typedef edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster> > SkipClustersCollection;

--- a/RecoTracker/TkSeedingLayers/src/HitExtractorSTRP.h
+++ b/RecoTracker/TkSeedingLayers/src/HitExtractorSTRP.h
@@ -25,10 +25,10 @@ public:
   typedef SiStripRecHit2D::ClusterRef SiStripClusterRef;
 
   HitExtractorSTRP(GeomDetEnumerators::SubDetector subdet, SeedingLayer::Side & side, int idLayer, float iminGoodCharge);
-  virtual ~HitExtractorSTRP(){}
+  ~HitExtractorSTRP() override{}
 
-  virtual HitExtractor::Hits hits( const TkTransientTrackingRecHitBuilder &ttrhBuilder, const edm::Event& , const edm::EventSetup&) const override;
-  virtual HitExtractorSTRP * clone() const override { return new HitExtractorSTRP(*this); }
+  HitExtractor::Hits hits( const TkTransientTrackingRecHitBuilder &ttrhBuilder, const edm::Event& , const edm::EventSetup&) const override;
+  HitExtractorSTRP * clone() const override { return new HitExtractorSTRP(*this); }
 
   void useMatchedHits( const edm::InputTag & m, edm::ConsumesCollector& iC) { hasMatchedHits = true; theMatchedHits = iC.consumes<SiStripMatchedRecHit2DCollection>(m); }
   void useRPhiHits(    const edm::InputTag & m, edm::ConsumesCollector& iC) { hasRPhiHits    = true; theRPhiHits = iC.consumes<SiStripRecHit2DCollection>(m); }

--- a/RecoTracker/TkSeedingLayers/src/SeedingLayer.cc
+++ b/RecoTracker/TkSeedingLayers/src/SeedingLayer.cc
@@ -32,7 +32,7 @@ public:
   const TkTransientTrackingRecHitBuilder * hitBuilder() const { return theTTRHBuilder; }
 
 private:
-  SeedingLayerImpl(const SeedingLayerImpl &);
+  SeedingLayerImpl(const SeedingLayerImpl &) = delete;
 
 private:
   std::string theName;

--- a/RecoTracker/TkSeedingLayers/src/SeedingLayerSetsBuilder.cc
+++ b/RecoTracker/TkSeedingLayers/src/SeedingLayerSetsBuilder.cc
@@ -199,7 +199,7 @@ SeedingLayerSetsBuilder::SeedingLayerSetsBuilder(const edm::ParameterSet & cfg, 
 //    str << std::endl;
 //  }
 //  std::cout << str.str() << std::endl;
-  if(layerNamesInSets.size() == 0)
+  if(layerNamesInSets.empty())
     theNumberOfLayersInSet = 0;
   else
     theNumberOfLayersInSet = layerNamesInSets[0].size();

--- a/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
@@ -38,18 +38,18 @@ public:
       const SeedingLayerSetsHits::SeedingLayer& layer) const override;
 
  
-  virtual HitRZCompatibility * checkRZ(const DetLayer* layer,  
+  HitRZCompatibility * checkRZ(const DetLayer* layer,  
 				       const Hit &  outerHit,
 				       const edm::EventSetup& iSetup,
-				       const DetLayer* outerlayer=0,
+				       const DetLayer* outerlayer=nullptr,
 				       float lr=0, float gz=0, float dr=0, float dz=0) const  override;
 
-  virtual GlobalTrackingRegion* clone() const override { 
+  GlobalTrackingRegion* clone() const override { 
     return new GlobalTrackingRegion(*this);
   }
 
-  virtual std::string name() const override { return "GlobalTrackingRegion"; }
-  virtual std::string print() const override;
+  std::string name() const override { return "GlobalTrackingRegion"; }
+  std::string print() const override;
 
 private:
   bool  thePrecise=false;

--- a/RecoTracker/TkTrackingRegions/interface/HitEtaCheck.h
+++ b/RecoTracker/TkTrackingRegions/interface/HitEtaCheck.h
@@ -24,18 +24,18 @@ public:
     isBarrel(inbarrel), 
     theRZ(HitRZConstraint(point, cotLeftLine, point, cotRightLine)) { }
 
-  virtual bool operator() (const float & r, const float & z) const {
+  bool operator() (const float & r, const float & z) const override {
     const auto & lineLeft = theRZ.lineLeft();
     const auto & lineRight = theRZ.lineRight();
     float cotHit = (lineLeft.origin().z()-z)/(lineLeft.origin().r()-r);
     return lineRight.cotLine() < cotHit && cotHit < lineLeft.cotLine();
   }
 
-  virtual Range range(const float & rORz) const {
+  Range range(const float & rORz) const override {
     return (isBarrel) ? 
         HitZCheck(theRZ).range(rORz) : HitRCheck(theRZ).range(rORz);
   }
-  virtual HitEtaCheck* clone() const { return new HitEtaCheck(*this); }
+  HitEtaCheck* clone() const override { return new HitEtaCheck(*this); }
 private:
   bool isBarrel;
   HitRZConstraint theRZ;

--- a/RecoTracker/TkTrackingRegions/interface/HitRCheck.h
+++ b/RecoTracker/TkTrackingRegions/interface/HitRCheck.h
@@ -17,12 +17,12 @@ public:
   HitRCheck(const HitRZConstraint & rz, Margin margin = Margin(0,0)) 
     :  HitRZCompatibility(me), theRZ(rz), theTolerance(margin) { } 
 
-  virtual bool operator() (const float & r, const float & z) const
+  bool operator() (const float & r, const float & z) const override
     { return range(z).inside(r); }
 
-  inline Range range(const float & z) const;
+  inline Range range(const float & z) const override;
 
-  virtual HitRCheck * clone() const { return new HitRCheck(*this); }
+  HitRCheck * clone() const override { return new HitRCheck(*this); }
 
   void setTolerance(const Margin & tolerance) { theTolerance = tolerance; }
 

--- a/RecoTracker/TkTrackingRegions/interface/HitZCheck.h
+++ b/RecoTracker/TkTrackingRegions/interface/HitZCheck.h
@@ -18,12 +18,12 @@ public:
   HitZCheck(const HitRZConstraint & rz, Margin margin = Margin(0,0))
     : HitRZCompatibility(me), theRZ(rz), theTolerance(margin) { }
 
-  virtual bool operator() (const float & r, const float & z) const
+  bool operator() (const float & r, const float & z) const override
     { return range(r).inside(z); }
 
-  inline Range range(const float & radius) const;
+  inline Range range(const float & radius) const override;
 
-  virtual HitZCheck * clone() const { return new HitZCheck(*this); }
+  HitZCheck * clone() const override { return new HitZCheck(*this); }
 
   void setTolerance(const Margin & tolerance) { theTolerance = tolerance; }
 

--- a/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
@@ -157,23 +157,23 @@ public:
   /// is precise error calculation switched on 
   bool  isPrecise() const { return thePrecise; }
 
-  virtual TrackingRegion::Hits hits(
+  TrackingRegion::Hits hits(
       const edm::EventSetup& es,
       const SeedingLayerSetsHits::SeedingLayer& layer) const override;
 
-  virtual HitRZCompatibility * checkRZ(const DetLayer* layer,  
+  HitRZCompatibility * checkRZ(const DetLayer* layer,  
 				       const Hit &  outerHit,
 				       const edm::EventSetup&iSetup,
 				       const DetLayer* outerlayer=nullptr,
 				       float lr=0, float gz=0, float dr=0, float dz=0) const override
   { return checkRZOld(layer,outerHit,iSetup, outerlayer); }
 
-  virtual RectangularEtaPhiTrackingRegion* clone() const override { 
+  RectangularEtaPhiTrackingRegion* clone() const override { 
     return new RectangularEtaPhiTrackingRegion(*this);
   }
 
-  virtual std::string name() const override { return "RectangularEtaPhiTrackingRegion"; }
-  virtual std::string print() const override;
+  std::string name() const override { return "RectangularEtaPhiTrackingRegion"; }
+  std::string print() const override;
 
 private:
   HitRZCompatibility* checkRZOld(

--- a/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
@@ -91,7 +91,7 @@ public:
   virtual HitRZCompatibility * checkRZ(const DetLayer* layer,  
 				       const Hit &  outerHit,
 				       const edm::EventSetup& iSetup,
-				       const DetLayer* outerlayer=0, 
+				       const DetLayer* outerlayer=nullptr, 
 				       float lr=0, float gz=0, float dr=0, float dz=0) const = 0;
 
 

--- a/RecoTracker/TkTrackingRegions/interface/TrackingRegionEDProducerT.h
+++ b/RecoTracker/TkTrackingRegions/interface/TrackingRegionEDProducerT.h
@@ -21,13 +21,13 @@ public:
     produces<ProductType>();
   }
 
-  ~TrackingRegionEDProducerT() = default;
+  ~TrackingRegionEDProducerT() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     T_TrackingRegionProducer::fillDescriptions(descriptions);
   }
 
-  virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
     auto regions = regionProducer_.regions(iEvent, iSetup);
     auto ret = std::make_unique<ProductType>();
     ret->reserve(regions.size());

--- a/RecoTracker/TkTrackingRegions/plugins/GlobalTrackingRegionProducer.h
+++ b/RecoTracker/TkTrackingRegions/plugins/GlobalTrackingRegionProducer.h
@@ -25,7 +25,7 @@ public:
     theOrigin = GlobalPoint(xPos,yPos,zPos);
   }   
 
-  virtual ~GlobalTrackingRegionProducer(){}
+  ~GlobalTrackingRegionProducer() override{}
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
@@ -46,7 +46,7 @@ public:
     descriptions.add("globalTrackingRegion", descRegion);
   }
 
-  virtual std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event&, const edm::EventSetup&) const override {
+  std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event&, const edm::EventSetup&) const override {
     std::vector<std::unique_ptr<TrackingRegion> > result;
     result.push_back( 
         std::make_unique<GlobalTrackingRegion>( thePtMin, theOrigin, theOriginRadius, theOriginHalfLength, thePrecise) );

--- a/RecoTracker/TkTrackingRegions/plugins/GlobalTrackingRegionProducerFromBeamSpot.h
+++ b/RecoTracker/TkTrackingRegions/plugins/GlobalTrackingRegionProducerFromBeamSpot.h
@@ -36,7 +36,7 @@ public:
 
   }
 
-  virtual ~GlobalTrackingRegionProducerFromBeamSpot(){}
+  ~GlobalTrackingRegionProducerFromBeamSpot() override{}
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     {
@@ -76,7 +76,7 @@ public:
     }
   }
 
-  virtual std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event&ev, const edm::EventSetup&) const override {
+  std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event&ev, const edm::EventSetup&) const override {
     std::vector<std::unique_ptr<TrackingRegion> > result;
     edm::Handle<reco::BeamSpot> bsHandle;
     ev.getByToken( token_beamSpot, bsHandle);

--- a/RecoTracker/TkTrackingRegions/plugins/GlobalTrackingRegionWithVerticesProducer.h
+++ b/RecoTracker/TkTrackingRegions/plugins/GlobalTrackingRegionWithVerticesProducer.h
@@ -39,7 +39,7 @@ public:
     token_vertex      = iC.consumes<reco::VertexCollection>(regionPSet.getParameter<edm::InputTag>("VertexCollection"));
   }   
 
-  virtual ~GlobalTrackingRegionWithVerticesProducer(){}
+  ~GlobalTrackingRegionWithVerticesProducer() override{}
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
@@ -65,7 +65,7 @@ public:
     descriptions.add("globalTrackingRegionWithVertices", descRegion);
   }
 
-  virtual std::vector<std::unique_ptr<TrackingRegion> > regions
+  std::vector<std::unique_ptr<TrackingRegion> > regions
     (const edm::Event& ev, const edm::EventSetup&) const override
   {
     std::vector<std::unique_ptr<TrackingRegion> > result;

--- a/RecoTracker/TkTrackingRegions/plugins/PointSeededTrackingRegionsProducer.h
+++ b/RecoTracker/TkTrackingRegions/plugins/PointSeededTrackingRegionsProducer.h
@@ -104,7 +104,7 @@ public:
     }
   }
   
-  virtual ~PointSeededTrackingRegionsProducer() {}
+  ~PointSeededTrackingRegionsProducer() override {}
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
@@ -148,7 +148,7 @@ public:
 
     
 
-  virtual std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event& e, const edm::EventSetup& es) const override
+  std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event& e, const edm::EventSetup& es) const override
   {
     std::vector<std::unique_ptr<TrackingRegion> > result;
 

--- a/RecoTracker/TkTrackingRegions/src/OuterDetCompatibility.cc
+++ b/RecoTracker/TkTrackingRegions/src/OuterDetCompatibility.cc
@@ -13,7 +13,7 @@ bool OuterDetCompatibility::operator() (const BoundPlane& plane) const
     if (!checkPhi(plane.phiSpan())) return false;
     if (!checkR(plane.rSpan())) return false;
   }
-  return 1;
+  return true;
 }
 
 

--- a/RecoTracker/TkTrackingRegions/src/OuterEstimator.h
+++ b/RecoTracker/TkTrackingRegions/src/OuterEstimator.h
@@ -35,7 +35,7 @@ public:
    : theDetCompatibility(detCompatibility), 
      theHitCompatibility (hitCompatibility) { }
   
-  ~OuterEstimator(){}
+  ~OuterEstimator() override{}
 
   std::pair<bool,double> estimate(
       const TrajectoryStateOnSurface& ts, 

--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -220,7 +220,7 @@ RectangularEtaPhiTrackingRegion::estimator(const ForwardDetLayer* layer,const ed
   // r prediction, skip if not intersection
   HitRCheck rPrediction(rzConstraint());
   Range hitRWindow = rPrediction.range(zLayer).intersection(detRWindow);
-  if (hitRWindow.empty()) return 0;
+  if (hitRWindow.empty()) return nullptr;
 
   // phi prediction
   OuterHitPhiPrediction phiPrediction = phiWindow(iSetup);

--- a/RecoTracker/TrackProducer/plugins/DAFTrackProducer.h
+++ b/RecoTracker/TrackProducer/plugins/DAFTrackProducer.h
@@ -22,7 +22,7 @@ public:
   explicit DAFTrackProducer(const edm::ParameterSet& iConfig);
 
   // Implementation of produce method
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
   DAFTrackProducerAlgorithm theAlgo;

--- a/RecoTracker/TrackProducer/plugins/ExtraFromSeeds.h
+++ b/RecoTracker/TrackProducer/plugins/ExtraFromSeeds.h
@@ -45,12 +45,12 @@
 class ExtraFromSeeds : public edm::global::EDProducer<> {
    public:
       explicit ExtraFromSeeds(const edm::ParameterSet&);
-      ~ExtraFromSeeds();
+      ~ExtraFromSeeds() override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+      void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   edm::EDGetTokenT<reco::TrackCollection> tracks_;
   typedef std::vector<unsigned int> ExtremeLight;

--- a/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
+++ b/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
@@ -41,9 +41,9 @@ template<class T>
 class FakeTrackProducer : public edm::stream::EDProducer<> {
     public:
       explicit FakeTrackProducer(const edm::ParameterSet & iConfig);
-      virtual ~FakeTrackProducer() { }
+      ~FakeTrackProducer() override { }
 
-      virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+      void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
     private:
       /// Labels for input collections
       edm::EDGetTokenT<std::vector<T>> src_;
@@ -99,7 +99,7 @@ FakeTrackProducer<T>::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
         //if (!selector_(mu)) continue;
         const PTrajectoryStateOnDet & pstate = getState(mu);
         const GeomDet *det = theGeometry->idToDet(DetId(pstate.detId()));
-        if (det == 0) { std::cerr << "ERROR:  bogus detid " << pstate.detId() << std::endl; continue; }
+        if (det == nullptr) { std::cerr << "ERROR:  bogus detid " << pstate.detId() << std::endl; continue; }
         TrajectoryStateOnSurface state = trajectoryStateTransform::transientState(pstate, & det->surface(), &*theMagField);
         GlobalPoint  gx = state.globalPosition();
         GlobalVector gp = state.globalMomentum();
@@ -114,7 +114,7 @@ FakeTrackProducer<T>::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
         const TrackingRecHit *hit1 = &*(hits.second-1);
         const GeomDet *det0 = theGeometry->idToDet(hit0->geographicalId());
         const GeomDet *det1 = theGeometry->idToDet(hit1->geographicalId());
-        if (det0 == 0 || det1 == 0) { std::cerr << "ERROR:  bogus detids at beginning or end of range" << std::endl; continue; }
+        if (det0 == nullptr || det1 == nullptr) { std::cerr << "ERROR:  bogus detids at beginning or end of range" << std::endl; continue; }
         GlobalPoint gx0 = det0->toGlobal(hit0->localPosition());
         GlobalPoint gx1 = det1->toGlobal(hit1->localPosition());
         reco::Track::Point x0(gx0.x(), gx0.y(), gx0.z());

--- a/RecoTracker/TrackProducer/plugins/GsfTrackProducer.h
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackProducer.h
@@ -17,7 +17,7 @@ public:
   explicit GsfTrackProducer(const edm::ParameterSet& iConfig);
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
   TrackProducerAlgorithm<reco::GsfTrack> theAlgo;

--- a/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.h
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.h
@@ -18,7 +18,7 @@ public:
   explicit GsfTrackRefitter(const edm::ParameterSet& iConfig);
 
   /// Implementation of produce method
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
   TrackProducerAlgorithm<reco::GsfTrack> theAlgo;

--- a/RecoTracker/TrackProducer/plugins/QualityFilter.cc
+++ b/RecoTracker/TrackProducer/plugins/QualityFilter.cc
@@ -11,10 +11,10 @@
 class dso_hidden QualityFilter final : public edm::stream::EDProducer<> {
  public:
   explicit QualityFilter(const edm::ParameterSet&);
-  ~QualityFilter();
+  ~QualityFilter() override;
   
  private:
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
   virtual void endJob() ;
   
   // ----------member data ---------------------------
@@ -80,8 +80,8 @@ QualityFilter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   
   unique_ptr<TrackCollection> selTracks(new TrackCollection);
-  unique_ptr<TrackingRecHitCollection> selHits(copyExtras_ ? new TrackingRecHitCollection() : 0);
-  unique_ptr<TrackExtraCollection> selTrackExtras(copyExtras_ ? new TrackExtraCollection() : 0);
+  unique_ptr<TrackingRecHitCollection> selHits(copyExtras_ ? new TrackingRecHitCollection() : nullptr);
+  unique_ptr<TrackExtraCollection> selTrackExtras(copyExtras_ ? new TrackExtraCollection() : nullptr);
   unique_ptr<vector<Trajectory> > outputTJ(new vector<Trajectory> );
   unique_ptr<TrajTrackAssociationCollection> trajTrackMap( new TrajTrackAssociationCollection() );
   

--- a/RecoTracker/TrackProducer/plugins/TrackProducer.h
+++ b/RecoTracker/TrackProducer/plugins/TrackProducer.h
@@ -20,7 +20,7 @@ public:
   explicit TrackProducer(const edm::ParameterSet& iConfig);
 
   /// Implementation of produce method
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
   /// Get Transient Tracks
   std::vector<reco::TransientTrack> getTransient(edm::Event&, const edm::EventSetup&);

--- a/RecoTracker/TrackProducer/plugins/TrackRefitter.h
+++ b/RecoTracker/TrackProducer/plugins/TrackRefitter.h
@@ -18,7 +18,7 @@ public:
   explicit TrackRefitter(const edm::ParameterSet& iConfig);
 
   /// Implementation of produce method
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
   TrackProducerAlgorithm<reco::Track> theAlgo;

--- a/RecoTracker/TrackProducer/src/DAFTrackProducerAlgorithm.cc
+++ b/RecoTracker/TrackProducer/src/DAFTrackProducerAlgorithm.cc
@@ -289,7 +289,7 @@ bool DAFTrackProducerAlgorithm::buildTrack (const Trajectory vtraj,
 int DAFTrackProducerAlgorithm::countingGoodHits(const Trajectory traj) const{
 
   int ngoodhits = 0;
-  Trajectory myTraj = traj;
+  const Trajectory& myTraj = traj;
   std::vector<TrajectoryMeasurement> vtm = traj.measurements();
 
   for (std::vector<TrajectoryMeasurement>::const_iterator tm = vtm.begin(); tm != vtm.end(); tm++){
@@ -427,7 +427,7 @@ int DAFTrackProducerAlgorithm::checkHits( Trajectory iInitTraj, const Trajectory
 
       TrajectoryMeasurement imeas = finalmeasurements.at(ihit);
       const TrackingRecHit* finalHit = imeas.recHit()->hit();
-      const TrackingRecHit* MaxWeightHit=0;
+      const TrackingRecHit* MaxWeightHit=nullptr;
       float maxweight = 0;
   
       const SiTrackerMultiRecHit* mrh = dynamic_cast<const SiTrackerMultiRecHit*>(finalHit);

--- a/RecoTracker/TrackProducer/src/GsfTrackProducerBase.cc
+++ b/RecoTracker/TrackProducer/src/GsfTrackProducerBase.cc
@@ -306,7 +306,7 @@ GsfTrackProducerBase::fillMode (reco::GsfTrack& track, const TrajectoryStateOnSu
   //
   // extract state at PCA and create momentum vector and covariance matrix
   //
-  FreeTrajectoryState fts = tscbl.trackStateAtPCA();
+  const FreeTrajectoryState& fts = tscbl.trackStateAtPCA();
   GlobalVector tscblMom = fts.momentum();
   reco::GsfTrack::Vector mom(tscblMom.x(),tscblMom.y(),tscblMom.z());
   reco::GsfTrack::CovarianceMatrixMode cov;

--- a/RecoTracker/TrackProducer/src/TrajectoryToResiduals.cc
+++ b/RecoTracker/TrackProducer/src/TrajectoryToResiduals.cc
@@ -21,7 +21,7 @@ reco::TrackResiduals trajectoryToResiduals (const Trajectory &trajectory)
      for (; forward ? i_fwd != i_end : i_bwd != i_rend; 
 	  ++i_fwd, ++i_bwd, ++i_residual) {
 	  const TrajectoryMeasurement *i = forward ? &*i_fwd : &*i_bwd;
-	  if (!i->recHit()->isValid()||i->recHit()->det()==0) 
+	  if (!i->recHit()->isValid()||i->recHit()->det()==nullptr) 
 	       continue;
 	  TrajectoryStateCombiner combine;
 	  if (!i->forwardPredictedState().isValid() || !i->backwardPredictedState().isValid())

--- a/RecoTracker/TransientTrackingRecHit/interface/TRecHit1DMomConstraint.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TRecHit1DMomConstraint.h
@@ -9,49 +9,49 @@
 class TRecHit1DMomConstraint final : public TransientTrackingRecHit {
  public:
 
-  virtual ~TRecHit1DMomConstraint() {}
+  ~TRecHit1DMomConstraint() override {}
 
-  virtual AlgebraicVector parameters() const override {
+  AlgebraicVector parameters() const override {
     AlgebraicVector result(1);
     result[0] = charge_/fabs(mom_);
     return result;
   }
   
-  virtual AlgebraicSymMatrix parametersError() const override {
+  AlgebraicSymMatrix parametersError() const override {
     AlgebraicSymMatrix m(1);
     m[0][0] = err_/(mom_*mom_);//parametersErrors are squared
     m[0][0] *= m[0][0];
     return m;
   }
 
-  virtual AlgebraicMatrix projectionMatrix() const override {
+  AlgebraicMatrix projectionMatrix() const override {
     AlgebraicMatrix theProjectionMatrix;
     theProjectionMatrix = AlgebraicMatrix( 1, 5, 0);
     theProjectionMatrix[0][0] = 1;
     return theProjectionMatrix;
   }
-  virtual int dimension() const override {return 1;}
+  int dimension() const override {return 1;}
 
-  virtual LocalPoint localPosition() const override {return LocalPoint(0,0,0);}
-  virtual LocalError localPositionError() const override {return LocalError(0,0,0);}
+  LocalPoint localPosition() const override {return LocalPoint(0,0,0);}
+  LocalError localPositionError() const override {return LocalError(0,0,0);}
 
   double mom() const {return mom_;}
   double err() const {return err_;}
   int charge() const {return charge_;}
 
 
-  virtual const TrackingRecHit * hit() const override {return 0;}//fixme return invalid
-  virtual TrackingRecHit * cloneHit() const override { return 0;}
+  const TrackingRecHit * hit() const override {return nullptr;}//fixme return invalid
+  TrackingRecHit * cloneHit() const override { return nullptr;}
 
-  virtual std::vector<const TrackingRecHit*> recHits() const override { return std::vector<const TrackingRecHit*>(); }
-  virtual std::vector<TrackingRecHit*> recHits() override { return std::vector<TrackingRecHit*>(); }
-  virtual bool sharesInput( const TrackingRecHit*, SharedInputType) const override { return false;}
+  std::vector<const TrackingRecHit*> recHits() const override { return std::vector<const TrackingRecHit*>(); }
+  std::vector<TrackingRecHit*> recHits() override { return std::vector<TrackingRecHit*>(); }
+  bool sharesInput( const TrackingRecHit*, SharedInputType) const override { return false;}
 
-  virtual bool canImproveWithTrack() const override {return false;}
+  bool canImproveWithTrack() const override {return false;}
 
   virtual RecHitPointer clone (const TrajectoryStateOnSurface& ts) const {return RecHitPointer(clone());}
 
-  virtual const GeomDetUnit* detUnit() const override {return 0;}
+  const GeomDetUnit* detUnit() const override {return nullptr;}
 
   static RecHitPointer build(const int charge,
 			     const double mom,
@@ -60,13 +60,13 @@ class TRecHit1DMomConstraint final : public TransientTrackingRecHit {
     return RecHitPointer( new TRecHit1DMomConstraint( charge, mom, err, surface));
   }
 
-  virtual const Surface * surface() const override {return surface_;}
+  const Surface * surface() const override {return surface_;}
 
-  virtual GlobalPoint globalPosition() const override { return GlobalPoint();  }
-  virtual GlobalError globalPositionError() const override { return GlobalError();}
-  virtual float errorGlobalR() const override { return 0;}
-  virtual float errorGlobalZ() const override { return 0; }
-  virtual float errorGlobalRPhi() const override { return 0; }
+  GlobalPoint globalPosition() const override { return GlobalPoint();  }
+  GlobalError globalPositionError() const override { return GlobalError();}
+  float errorGlobalR() const override { return 0;}
+  float errorGlobalZ() const override { return 0; }
+  float errorGlobalRPhi() const override { return 0; }
 
 
  private:
@@ -84,7 +84,7 @@ class TRecHit1DMomConstraint final : public TransientTrackingRecHit {
   TRecHit1DMomConstraint( const TRecHit1DMomConstraint& other ):
     charge_( other.charge() ), mom_( other.mom() ),err_( other.err() ), surface_((other.surface())) {}
   
-  virtual TRecHit1DMomConstraint * clone() const override {
+  TRecHit1DMomConstraint * clone() const override {
     return new TRecHit1DMomConstraint(*this);
   }
 

--- a/RecoTracker/TransientTrackingRecHit/interface/TRecHit2DPosConstraint.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TRecHit2DPosConstraint.h
@@ -9,9 +9,9 @@
 class TRecHit2DPosConstraint final : public TransientTrackingRecHit {
 public:
 
-  virtual ~TRecHit2DPosConstraint() {}
+  ~TRecHit2DPosConstraint() override {}
 
-  virtual AlgebraicVector parameters() const {
+  AlgebraicVector parameters() const override {
     AlgebraicVector result(2);
     LocalPoint lp = localPosition();
     result[0] = lp.x();
@@ -19,7 +19,7 @@ public:
     return result;
   }
   
-  virtual AlgebraicSymMatrix parametersError() const {
+  AlgebraicSymMatrix parametersError() const override {
     AlgebraicSymMatrix m(2);
     LocalError le( localPositionError());
     m[0][0] = le.xx();
@@ -28,43 +28,43 @@ public:
     return m;
   }
 
-  virtual AlgebraicMatrix projectionMatrix() const {
+  AlgebraicMatrix projectionMatrix() const override {
     AlgebraicMatrix theProjectionMatrix;
     theProjectionMatrix = AlgebraicMatrix( 2, 5, 0);
     theProjectionMatrix[0][3] = 1;
     theProjectionMatrix[1][4] = 1;
     return theProjectionMatrix;
   }
-  virtual int dimension() const {return 2;}
+  int dimension() const override {return 2;}
 
-  virtual LocalPoint localPosition() const {return pos_;}
-  virtual LocalError localPositionError() const {return err_;}
+  LocalPoint localPosition() const override {return pos_;}
+  LocalError localPositionError() const override {return err_;}
 
-  virtual const TrackingRecHit * hit() const {return 0;}//fixme return invalid
-  virtual TrackingRecHit * cloneHit() const { return 0;}
+  const TrackingRecHit * hit() const override {return nullptr;}//fixme return invalid
+  TrackingRecHit * cloneHit() const override { return nullptr;}
   
-  virtual std::vector<const TrackingRecHit*> recHits() const { return std::vector<const TrackingRecHit*>(); }
-  virtual std::vector<TrackingRecHit*> recHits() { return std::vector<TrackingRecHit*>(); }
-  virtual bool sharesInput( const TrackingRecHit*, SharedInputType) const { return false;}
+  std::vector<const TrackingRecHit*> recHits() const override { return std::vector<const TrackingRecHit*>(); }
+  std::vector<TrackingRecHit*> recHits() override { return std::vector<TrackingRecHit*>(); }
+  bool sharesInput( const TrackingRecHit*, SharedInputType) const override { return false;}
 
-  virtual bool canImproveWithTrack() const {return false;}
+  bool canImproveWithTrack() const override {return false;}
 
   virtual RecHitPointer clone (const TrajectoryStateOnSurface& ts) const {return RecHitPointer(clone());}
 
-  virtual const GeomDetUnit* detUnit() const {return 0;}
+  const GeomDetUnit* detUnit() const override {return nullptr;}
 
   static RecHitPointer build( const LocalPoint& pos, const LocalError& err,
 			      const Surface* surface) {
     return RecHitPointer( new TRecHit2DPosConstraint( pos, err, surface));
   }
 
-  virtual const Surface * surface() const {return &(*surface_);}
+  const Surface * surface() const override {return &(*surface_);}
 
-  virtual GlobalPoint globalPosition() const { return  surface()->toGlobal(localPosition());}
-  virtual GlobalError globalPositionError() const { return ErrorFrameTransformer().transform( localPositionError(), *surface() );}
-  virtual float errorGlobalR() const { return std::sqrt(globalPositionError().rerr(globalPosition()));}
-  virtual float errorGlobalZ() const { return std::sqrt(globalPositionError().czz()); }
-  virtual float errorGlobalRPhi() const { return globalPosition().perp()*sqrt(globalPositionError().phierr(globalPosition())); }
+  GlobalPoint globalPosition() const override { return  surface()->toGlobal(localPosition());}
+  GlobalError globalPositionError() const override { return ErrorFrameTransformer().transform( localPositionError(), *surface() );}
+  float errorGlobalR() const override { return std::sqrt(globalPositionError().rerr(globalPosition()));}
+  float errorGlobalZ() const override { return std::sqrt(globalPositionError().czz()); }
+  float errorGlobalRPhi() const override { return globalPosition().perp()*sqrt(globalPositionError().phierr(globalPosition())); }
 
 
 private:
@@ -80,7 +80,7 @@ private:
   TRecHit2DPosConstraint( const TRecHit2DPosConstraint& other ):
     pos_( other.localPosition() ),err_( other.localPositionError() ), surface_((other.surface())) {}
 
-  virtual TRecHit2DPosConstraint * clone() const {
+  TRecHit2DPosConstraint * clone() const override {
     return new TRecHit2DPosConstraint(*this);
   }
 

--- a/RecoTracker/TransientTrackingRecHit/interface/TRecHit5DParamConstraint.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TRecHit5DParamConstraint.h
@@ -17,46 +17,46 @@ private:
 
 public:
 
-  virtual ~TRecHit5DParamConstraint() {}
+  ~TRecHit5DParamConstraint() override {}
 
-  virtual int dimension() const { return 5; }
+  int dimension() const override { return 5; }
 
-  virtual AlgebraicMatrix projectionMatrix() const {
+  AlgebraicMatrix projectionMatrix() const override {
     AlgebraicMatrix projectionMatrix( 5, 5, 1 );
     return projectionMatrix;
   }
 
-  virtual AlgebraicVector parameters() const { return asHepVector( tsos_.localParameters().vector() ); }
+  AlgebraicVector parameters() const override { return asHepVector( tsos_.localParameters().vector() ); }
 
-  virtual AlgebraicSymMatrix parametersError() const { return asHepMatrix( tsos_.localError().matrix() ); }
+  AlgebraicSymMatrix parametersError() const override { return asHepMatrix( tsos_.localError().matrix() ); }
 
-  virtual LocalPoint localPosition() const { return tsos_.localPosition(); }
+  LocalPoint localPosition() const override { return tsos_.localPosition(); }
 
-  virtual LocalError localPositionError() const { return tsos_.localError().positionError(); }
+  LocalError localPositionError() const override { return tsos_.localError().positionError(); }
 
   virtual int charge() const { return tsos_.charge(); }
 
-  virtual bool canImproveWithTrack() const { return false; }
+  bool canImproveWithTrack() const override { return false; }
 
-  virtual const TrackingRecHit* hit() const { return 0; }
-  virtual TrackingRecHit * cloneHit() const { return 0;}
+  const TrackingRecHit* hit() const override { return nullptr; }
+  TrackingRecHit * cloneHit() const override { return nullptr;}
   
-  virtual std::vector<const TrackingRecHit*> recHits() const { return std::vector<const TrackingRecHit*>(); }
-  virtual std::vector<TrackingRecHit*> recHits() { return std::vector<TrackingRecHit*>(); }
-  virtual bool sharesInput( const TrackingRecHit*, SharedInputType) const { return false;}
+  std::vector<const TrackingRecHit*> recHits() const override { return std::vector<const TrackingRecHit*>(); }
+  std::vector<TrackingRecHit*> recHits() override { return std::vector<TrackingRecHit*>(); }
+  bool sharesInput( const TrackingRecHit*, SharedInputType) const override { return false;}
 
 
-  virtual const GeomDetUnit* detUnit() const { return 0; }
+  const GeomDetUnit* detUnit() const override { return nullptr; }
 
-  virtual const GeomDet* det() const { return 0; }
+  virtual const GeomDet* det() const { return nullptr; }
 
-  virtual const Surface* surface() const { return &tsos_.surface(); }
+  const Surface* surface() const override { return &tsos_.surface(); }
 
-  virtual GlobalPoint globalPosition() const { return  surface()->toGlobal(localPosition());}
-  virtual GlobalError globalPositionError() const { return ErrorFrameTransformer().transform( localPositionError(), *surface() );}
-  virtual float errorGlobalR() const { return std::sqrt(globalPositionError().rerr(globalPosition()));}
-  virtual float errorGlobalZ() const { return std::sqrt(globalPositionError().czz()); }
-  virtual float errorGlobalRPhi() const { return globalPosition().perp()*sqrt(globalPositionError().phierr(globalPosition())); }
+  GlobalPoint globalPosition() const override { return  surface()->toGlobal(localPosition());}
+  GlobalError globalPositionError() const override { return ErrorFrameTransformer().transform( localPositionError(), *surface() );}
+  float errorGlobalR() const override { return std::sqrt(globalPositionError().rerr(globalPosition()));}
+  float errorGlobalZ() const override { return std::sqrt(globalPositionError().czz()); }
+  float errorGlobalRPhi() const override { return globalPosition().perp()*sqrt(globalPositionError().phierr(globalPosition())); }
 
 
   virtual TransientTrackingRecHit::RecHitPointer clone( const TrajectoryStateOnSurface& tsos ) const {
@@ -72,7 +72,7 @@ private:
 
   const TrajectoryStateOnSurface tsos_;
   
-  virtual TRecHit5DParamConstraint* clone() const {
+  TRecHit5DParamConstraint* clone() const override {
     return new TRecHit5DParamConstraint( this->trajectoryState() );
   }
 

--- a/RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h
@@ -16,27 +16,27 @@ public:
   TkClonerImpl(const PixelClusterParameterEstimator * ipixelCPE,
 	       const StripClusterParameterEstimator * istripCPE,
 	       const SiStripRecHitMatcher           * iMatcher
-	       ): pixelCPE(ipixelCPE), stripCPE(istripCPE), theMatcher(iMatcher), phase2TrackerCPE(0){}
+	       ): pixelCPE(ipixelCPE), stripCPE(istripCPE), theMatcher(iMatcher), phase2TrackerCPE(nullptr){}
   TkClonerImpl(const PixelClusterParameterEstimator * ipixelCPE,
 	       const ClusterParameterEstimator<Phase2TrackerCluster1D> * iPhase2OTCPE
-	       ): pixelCPE(ipixelCPE), stripCPE(0), theMatcher(0), phase2TrackerCPE(iPhase2OTCPE){}
+	       ): pixelCPE(ipixelCPE), stripCPE(nullptr), theMatcher(nullptr), phase2TrackerCPE(iPhase2OTCPE){}
 
   using TkCloner::operator();
-  virtual std::unique_ptr<SiPixelRecHit> operator()(SiPixelRecHit const & hit, TrajectoryStateOnSurface const& tsos) const override;
-  virtual std::unique_ptr<SiStripRecHit2D> operator()(SiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const override;
-  virtual std::unique_ptr<SiStripRecHit1D> operator()(SiStripRecHit1D const & hit, TrajectoryStateOnSurface const& tsos) const override;
-  virtual std::unique_ptr<SiStripMatchedRecHit2D> operator()(SiStripMatchedRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const override;
-  virtual std::unique_ptr<ProjectedSiStripRecHit2D> operator()(ProjectedSiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const override;
-  virtual std::unique_ptr<Phase2TrackerRecHit1D> operator()(Phase2TrackerRecHit1D const & hit, TrajectoryStateOnSurface const& tsos) const override;
+  std::unique_ptr<SiPixelRecHit> operator()(SiPixelRecHit const & hit, TrajectoryStateOnSurface const& tsos) const override;
+  std::unique_ptr<SiStripRecHit2D> operator()(SiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const override;
+  std::unique_ptr<SiStripRecHit1D> operator()(SiStripRecHit1D const & hit, TrajectoryStateOnSurface const& tsos) const override;
+  std::unique_ptr<SiStripMatchedRecHit2D> operator()(SiStripMatchedRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const override;
+  std::unique_ptr<ProjectedSiStripRecHit2D> operator()(ProjectedSiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const override;
+  std::unique_ptr<Phase2TrackerRecHit1D> operator()(Phase2TrackerRecHit1D const & hit, TrajectoryStateOnSurface const& tsos) const override;
 
 
   using TkCloner::makeShared;
-  virtual TrackingRecHit::ConstRecHitPointer makeShared(SiPixelRecHit const & hit, TrajectoryStateOnSurface const& tsos) const override;
-  virtual TrackingRecHit::ConstRecHitPointer makeShared(SiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const override;
-  virtual TrackingRecHit::ConstRecHitPointer makeShared(SiStripRecHit1D const & hit, TrajectoryStateOnSurface const& tsos) const override;
-  virtual TrackingRecHit::ConstRecHitPointer makeShared(SiStripMatchedRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const override;
-  virtual TrackingRecHit::ConstRecHitPointer makeShared(ProjectedSiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const override;
-  virtual TrackingRecHit::ConstRecHitPointer makeShared(Phase2TrackerRecHit1D const & hit, TrajectoryStateOnSurface const& tsos) const override;
+  TrackingRecHit::ConstRecHitPointer makeShared(SiPixelRecHit const & hit, TrajectoryStateOnSurface const& tsos) const override;
+  TrackingRecHit::ConstRecHitPointer makeShared(SiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const override;
+  TrackingRecHit::ConstRecHitPointer makeShared(SiStripRecHit1D const & hit, TrajectoryStateOnSurface const& tsos) const override;
+  TrackingRecHit::ConstRecHitPointer makeShared(SiStripMatchedRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const override;
+  TrackingRecHit::ConstRecHitPointer makeShared(ProjectedSiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const override;
+  TrackingRecHit::ConstRecHitPointer makeShared(Phase2TrackerRecHit1D const & hit, TrajectoryStateOnSurface const& tsos) const override;
 
 
   // project either mono or stero hit...

--- a/RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h
@@ -27,7 +27,7 @@ class TkTransientTrackingRecHitBuilder final : public TransientTrackingRecHitBui
 				    const PixelClusterParameterEstimator * ,
 				    const ClusterParameterEstimator<Phase2TrackerCluster1D> * );
 
-  TransientTrackingRecHit::RecHitPointer build (const TrackingRecHit * p) const ;
+  TransientTrackingRecHit::RecHitPointer build (const TrackingRecHit * p) const override ;
 
 
   const PixelClusterParameterEstimator * pixelClusterParameterEstimator() const {return pixelCPE;}
@@ -38,7 +38,7 @@ class TkTransientTrackingRecHitBuilder final : public TransientTrackingRecHitBui
 
   // for the time being here...
   TkClonerImpl cloner() const { 
-    if(phase2OTCPE == 0)
+    if(phase2OTCPE == nullptr)
       return TkClonerImpl(pixelCPE,stripCPE,theMatcher);
     else
       return TkClonerImpl(pixelCPE,phase2OTCPE);

--- a/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
+++ b/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
@@ -46,21 +46,21 @@ TkTransientTrackingRecHitBuilderESProducer::produce(const TransientRecHitRecord 
   const SiStripRecHitMatcher           * mp ;
     
   if (sname == "Fake") {
-    sp = 0;
+    sp = nullptr;
   }else{
     iRecord.getRecord<TkStripCPERecord>().get( sname, se );     
     sp = se.product();
   }
   
   if (pname == "Fake") {
-    pp = 0;
+    pp = nullptr;
   }else{
     iRecord.getRecord<TkPixelCPERecord>().get( pname, pe );     
     pp = pe.product();
   }
   
   if (mname == "Fake") {
-    mp = 0;
+    mp = nullptr;
   }else{
     iRecord.getRecord<TkStripCPERecord>().get( mname, me );     
     mp = me.product();

--- a/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.h
+++ b/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.h
@@ -14,7 +14,7 @@
 class  TkTransientTrackingRecHitBuilderESProducer: public edm::ESProducer{
  public:
   TkTransientTrackingRecHitBuilderESProducer(const edm::ParameterSet & p);
-  virtual ~TkTransientTrackingRecHitBuilderESProducer(); 
+  ~TkTransientTrackingRecHitBuilderESProducer() override; 
   std::shared_ptr<TransientTrackingRecHitBuilder> produce(const TransientRecHitRecord &);
  private:
   std::shared_ptr<TransientTrackingRecHitBuilder> _builder;

--- a/RecoTracker/TransientTrackingRecHit/src/TkClonerImpl.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/TkClonerImpl.cc
@@ -169,7 +169,7 @@ std::unique_ptr<ProjectedSiStripRecHit2D> TkClonerImpl::operator()(ProjectedSiSt
 		       det.surface().toLocal( det.position()-GlobalPoint(0,0,0)));
 
   auto delta = gluedPlane.localZ( hitPlane.position());
-  LocalVector ldir = tkDir;
+  const LocalVector& ldir = tkDir;
   LocalPoint lhitPos = gluedPlane.toLocal( hitPlane.toGlobal(lv.first));
   LocalPoint projectedHitPos = lhitPos - ldir * delta/ldir.z();                  
 
@@ -208,7 +208,7 @@ std::unique_ptr<ProjectedSiStripRecHit2D> TkClonerImpl::project(SiStripMatchedRe
 
 
   auto delta = gluedPlane.localZ( hitPlane.position());
-  LocalVector ldir = tkDir;
+  const LocalVector& ldir = tkDir;
   LocalPoint lhitPos = gluedPlane.toLocal( hitPlane.toGlobal(lv.first));
   LocalPoint projectedHitPos = lhitPos - ldir * delta/ldir.z();                  
 

--- a/RecoTracker/TransientTrackingRecHit/src/TkTransientTrackingRecHitBuilder.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/TkTransientTrackingRecHitBuilder.cc
@@ -24,15 +24,15 @@ TkTransientTrackingRecHitBuilder::TkTransientTrackingRecHitBuilder( const Tracki
   stripCPE(sCPE),
   theMatcher(matcher),
   theComputeCoarseLocalPosition(computeCoarseLocalPositionFromDisk),
-  phase2OTCPE(0){}
+  phase2OTCPE(nullptr){}
 
 TkTransientTrackingRecHitBuilder::TkTransientTrackingRecHitBuilder (const TrackingGeometry* trackingGeometry, 
 				                                    const PixelClusterParameterEstimator * pCPE,
 				                                    const ClusterParameterEstimator<Phase2TrackerCluster1D> * ph2StripCPE):
   tGeometry_(trackingGeometry),
   pixelCPE(pCPE),
-  stripCPE(0),
-  theMatcher(0),
+  stripCPE(nullptr),
+  theMatcher(nullptr),
   theComputeCoarseLocalPosition(false),
   phase2OTCPE(ph2StripCPE){}
 


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this quickly to avoid conflicts to the extent possible]