### PR TITLE
Clang-tidy checks for RecoVZero

### DIFF
--- a/RecoVZero/VZeroFinding/plugins/VZeroProducer.cc
+++ b/RecoVZero/VZeroFinding/plugins/VZeroProducer.cc
@@ -76,7 +76,7 @@ void VZeroProducer::produce(Event& ev, const EventSetup& es)
   auto result = std::make_unique<reco::VZeroCollection>();
 
   // Check all combination of positives and negatives
-  if(positives.size() > 0 && negatives.size() > 0)
+  if(!positives.empty() && !negatives.empty())
     for(reco::track_iterator ipos = positives.begin();
                              ipos!= positives.end(); ipos++)
     for(reco::track_iterator ineg = negatives.begin();

--- a/RecoVZero/VZeroFinding/plugins/VZeroProducer.h
+++ b/RecoVZero/VZeroFinding/plugins/VZeroProducer.h
@@ -11,9 +11,9 @@ class VZeroProducer :  public edm::EDProducer {
 public:
   explicit VZeroProducer(const edm::ParameterSet& pset);
 
-  ~VZeroProducer();
+  ~VZeroProducer() override;
 
-  virtual void produce(edm::Event& ev, const edm::EventSetup& es);
+  void produce(edm::Event& ev, const edm::EventSetup& es) override;
 
 private:
 

--- a/RecoVZero/VZeroFinding/src/VZeroFinder.cc
+++ b/RecoVZero/VZeroFinding/src/VZeroFinder.cc
@@ -106,7 +106,7 @@ bool VZeroFinder::checkTrackPair(const reco::Track& posTrack,
     GlobalVector momentum = momenta.first + momenta.second;
     float impact = -1.;
 
-    if(vertices->size() > 0)
+    if(!vertices->empty())
     {
       // Impact parameter of the mother wrt vertices, choose smallest
       for(reco::VertexCollection::const_iterator


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this quickly to avoid conflicts to the extent possible]