### PR TITLE
Clang-tidy checks for RecoVertex

### DIFF
--- a/RecoVertex/AdaptiveVertexFinder/interface/AdaptiveVertexReconstructor.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/AdaptiveVertexReconstructor.h
@@ -21,7 +21,7 @@ public:
   AdaptiveVertexReconstructor( float primcut = 2.0, float seccut = 6.0,
                                float minweight = 0.5, bool smoothing = false );
 
-  ~AdaptiveVertexReconstructor();
+  ~AdaptiveVertexReconstructor() override;
 
   /**
    *  The ParameterSet should have the following defined:
@@ -32,17 +32,17 @@ public:
    */
   AdaptiveVertexReconstructor( const edm::ParameterSet & s );
 
-  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> & v ) const;
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> & v ) const override;
   
   std::vector<TransientVertex> 
-    vertices(const std::vector<reco::TransientTrack> &, const reco::BeamSpot & ) const; 
+    vertices(const std::vector<reco::TransientTrack> &, const reco::BeamSpot & ) const override; 
   
   std::vector<TransientVertex> 
     vertices(const std::vector<reco::TransientTrack> & primaries,
              const std::vector<reco::TransientTrack> & tracks, 
-             const reco::BeamSpot & ) const; 
+             const reco::BeamSpot & ) const override; 
 
-  virtual AdaptiveVertexReconstructor * clone() const {
+  AdaptiveVertexReconstructor * clone() const override {
     return new AdaptiveVertexReconstructor( * this );
   }
 

--- a/RecoVertex/AdaptiveVertexFinder/interface/TTHelpers.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/TTHelpers.h
@@ -12,7 +12,7 @@ inline reco::TransientTrack buildTT(edm::Handle<reco::TrackCollection> & tracks,
 }
 inline reco::TransientTrack buildTT(edm::Handle<edm::View<reco::Candidate> > & tracks, edm::ESHandle<TransientTrackBuilder> &trackbuilder, unsigned int k)
 {
-	if((*tracks)[k].bestTrack() == 0) return reco::TransientTrack();
+	if((*tracks)[k].bestTrack() == nullptr) return reco::TransientTrack();
         return trackbuilder->build(tracks->ptrAt(k));
 }
 }

--- a/RecoVertex/AdaptiveVertexFinder/plugins/DoubleVertexFilter.cc
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/DoubleVertexFilter.cc
@@ -17,7 +17,7 @@ class DoubleVertexFilter : public edm::global::EDProducer<> {
     public:
 	DoubleVertexFilter(const edm::ParameterSet &params);
 
-	virtual void produce(edm::StreamID, edm::Event &event, const edm::EventSetup &es) const override;
+	void produce(edm::StreamID, edm::Event &event, const edm::EventSetup &es) const override;
 
     private:
 	bool trackFilter(const reco::TrackRef &track) const;

--- a/RecoVertex/AdaptiveVertexFinder/plugins/VertexMerger.cc
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/VertexMerger.cc
@@ -24,7 +24,7 @@ class TemplatedVertexMerger : public edm::stream::EDProducer<> {
 	typedef std::vector<VTX> Product;
 	TemplatedVertexMerger(const edm::ParameterSet &params);
 
-	virtual void produce(edm::Event &event, const edm::EventSetup &es) override;
+	void produce(edm::Event &event, const edm::EventSetup &es) override;
 
     private:
 	bool trackFilter(const reco::TrackRef &track) const;

--- a/RecoVertex/AdaptiveVertexFinder/src/AdaptiveVertexReconstructor.cc
+++ b/RecoVertex/AdaptiveVertexFinder/src/AdaptiveVertexReconstructor.cc
@@ -51,7 +51,7 @@ TransientVertex AdaptiveVertexReconstructor::cleanUp ( const TransientVertex & o
       }
       origtrkiter++;
     }
-    if ( newrfs.size() ) ret.refittedTracks ( newrfs ); // copy refitted tracks
+    if ( !newrfs.empty() ) ret.refittedTracks ( newrfs ); // copy refitted tracks
   }
 
   if ( ret.refittedTracks().size() > ret.originalTracks().size() )
@@ -86,7 +86,7 @@ void AdaptiveVertexReconstructor::erase (
 
 AdaptiveVertexReconstructor::AdaptiveVertexReconstructor(
     float primcut, float seccut, float min_weight, bool smoothing ) :
-  thePrimaryFitter ( 0 ), theSecondaryFitter ( 0 ),
+  thePrimaryFitter ( nullptr ), theSecondaryFitter ( nullptr ),
        theMinWeight( min_weight ), theWeightThreshold ( 0.001 )
 {
   setupFitters ( primcut, 256., 0.25, seccut, 256., 0.25, smoothing );
@@ -132,7 +132,7 @@ void AdaptiveVertexReconstructor::setupFitters ( float primcut,
 }
 
 AdaptiveVertexReconstructor::AdaptiveVertexReconstructor( const edm::ParameterSet & m )
-  : thePrimaryFitter(0), theSecondaryFitter(0), theMinWeight(0.5), theWeightThreshold ( 0.001 )
+  : thePrimaryFitter(nullptr), theSecondaryFitter(nullptr), theMinWeight(0.5), theWeightThreshold ( 0.001 )
 {
   float primcut = 2.0;
   float seccut = 6.0;
@@ -207,7 +207,7 @@ vector<TransientVertex> AdaptiveVertexReconstructor::vertices (
            */
       ctr++;
       const AdaptiveVertexFitter * fitter = theSecondaryFitter;
-      if ( ret.size() == 0 )
+      if ( ret.empty() )
       {
         fitter = thePrimaryFitter;
       };
@@ -217,12 +217,12 @@ vector<TransientVertex> AdaptiveVertexReconstructor::vertices (
       copy(remainingtrks.begin(), remainingtrks.end(), back_inserter(fittrks));
 
       TransientVertex tmpvtx;
-      if ( (ret.size() == 0) && has_primaries )
+      if ( (ret.empty()) && has_primaries )
       {
         // add the primaries to the fitted tracks.
         copy ( primaries.begin(), primaries.end(), back_inserter(fittrks) );
       }
-      if ( (ret.size() == 0) && usespot )
+      if ( (ret.empty()) && usespot )
       {
         tmpvtx=fitter->vertex ( fittrks, s );
       } else {

--- a/RecoVertex/AdaptiveVertexFit/interface/AdaptiveVertexFitter.h
+++ b/RecoVertex/AdaptiveVertexFit/interface/AdaptiveVertexFitter.h
@@ -50,7 +50,7 @@ public:
 
   AdaptiveVertexFitter( const AdaptiveVertexFitter & original );
 
-  virtual ~AdaptiveVertexFitter();
+  ~AdaptiveVertexFitter() override;
 
  /**
   * Method returning the fitted vertex, from a container of reco::TransientTracks.
@@ -58,7 +58,7 @@ public:
   * No prior vertex position will be used in the vertex fit.
   * \return The fitted vertex
   */
-  virtual CachingVertex<5> vertex( const std::vector<reco::TransientTrack> & ) const;
+  CachingVertex<5> vertex( const std::vector<reco::TransientTrack> & ) const override;
 
  /**
   * Method returning the fitted vertex, from a container of VertexTracks.
@@ -68,46 +68,46 @@ public:
   * No prior vertex position will be used in the vertex fit.
   * \return The fitted vertex
   */
-  virtual CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack> & ) const;
+  CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack> & ) const override;
 
   /**
    *  Same as above, only now also with BeamSpot constraint.
    */
-  virtual CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack> &,
-     const reco::BeamSpot & spot ) const;
+  CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack> &,
+     const reco::BeamSpot & spot ) const override;
 
   /** Fit vertex out of a std::vector of reco::TransientTracks. Uses the specified
    * linearization point.
    */
-  virtual CachingVertex<5> vertex( const std::vector<reco::TransientTrack> &,
-                                const GlobalPoint& linPoint ) const;
+  CachingVertex<5> vertex( const std::vector<reco::TransientTrack> &,
+                                const GlobalPoint& linPoint ) const override;
 
   /** Fit vertex out of a set of reco::TransientTracks.
    *   Uses the position as both the linearization point AND as prior
    *   estimate of the vertex position. The error is used for the
    *   weight of the prior estimate.
    */
-  virtual CachingVertex<5> vertex( const std::vector<reco::TransientTrack> &,
+  CachingVertex<5> vertex( const std::vector<reco::TransientTrack> &,
                                 const GlobalPoint & priorPos,
-                                const GlobalError & priorError ) const;
+                                const GlobalError & priorError ) const override;
 
   /** Fit vertex out of a set of TransientTracks. 
    *  The specified BeamSpot will be used as priot, but NOT for the linearization.
    * The specified LinearizationPointFinder will be used to find the linearization point.
    */
-  virtual CachingVertex<5> vertex(const std::vector<reco::TransientTrack> & tracks,
-		const reco::BeamSpot& beamSpot) const;
+  CachingVertex<5> vertex(const std::vector<reco::TransientTrack> & tracks,
+		const reco::BeamSpot& beamSpot) const override;
 
 
   /**  Fit vertex out of a set of VertexTracks
    *   Uses the position and error for the prior estimate of the vertex.
    *   This position is not used to relinearize the tracks.
    */
-  virtual CachingVertex<5> vertex( const std::vector<RefCountedVertexTrack> &,
+  CachingVertex<5> vertex( const std::vector<RefCountedVertexTrack> &,
                                 const GlobalPoint & priorPos,
-                                const GlobalError & priorError ) const;
+                                const GlobalError & priorError ) const override;
 
-  AdaptiveVertexFitter * clone() const;
+  AdaptiveVertexFitter * clone() const override;
 
   /**
    *  Set the weight threshold

--- a/RecoVertex/AdaptiveVertexFit/src/AdaptiveVertexFitter.cc
+++ b/RecoVertex/AdaptiveVertexFit/src/AdaptiveVertexFitter.cc
@@ -193,7 +193,7 @@ AdaptiveVertexFitter::vertex(const vector<RefCountedVertexTrack> & tracks) const
 CachingVertex<5>
 AdaptiveVertexFitter::vertex(const vector<RefCountedVertexTrack> & tracks, const reco::BeamSpot & spot ) const
 {
-  if ( tracks.size() < 1 )
+  if ( tracks.empty() )
   {
     LogError("RecoVertex|AdaptiveVertexFitter")
       << "Supplied no tracks. Vertex is invalid.";
@@ -234,7 +234,7 @@ CachingVertex<5>
 AdaptiveVertexFitter::vertex(const vector<reco::TransientTrack> & unstracks,
 			       const reco::BeamSpot& beamSpot) const
 {
-  if ( unstracks.size() < 1 )
+  if ( unstracks.empty() )
   {
     LogError("RecoVertex|AdaptiveVertexFitter")
       << "Supplied no tracks. Vertex is invalid.";
@@ -271,7 +271,7 @@ CachingVertex<5> AdaptiveVertexFitter::vertex(const vector<reco::TransientTrack>
                   const GlobalError& priorError) const
 
 {
-  if ( tracks.size() < 1 )
+  if ( tracks.empty() )
   {
     LogError("RecoVertex|AdaptiveVertexFitter")
       << "Supplied no tracks. Vertex is invalid.";
@@ -292,7 +292,7 @@ CachingVertex<5> AdaptiveVertexFitter::vertex(
                   const GlobalPoint& priorPos,
                   const GlobalError& priorError) const
 {
-  if ( tracks.size() < 1 )
+  if ( tracks.empty() )
   {
     LogError("RecoVertex|AdaptiveVertexFitter")
       << "Supplied no tracks. Vertex is invalid.";
@@ -342,7 +342,7 @@ AdaptiveVertexFitter::reLinearizeTracks(
                                 const vector<RefCountedVertexTrack> & tracks,
                                 const CachingVertex<5> & vertex ) const
 {
-  VertexState seed = vertex.vertexState();
+  const VertexState& seed = vertex.vertexState();
   GlobalPoint linP = seed.position();
   vector<RefCountedLinearizedTrackState> lTracks;
   for(vector<RefCountedVertexTrack>::const_iterator i = tracks.begin();
@@ -394,7 +394,7 @@ AdaptiveVertexFitter::reWeightTracks(
                     const vector<RefCountedLinearizedTrackState> & lTracks,
                     const CachingVertex<5> & vertex ) const
 {
-  VertexState seed = vertex.vertexState();
+  const VertexState& seed = vertex.vertexState();
   // cout << "[AdaptiveVertexFitter] now reweight around " << seed.position() << endl;
   theNr++;
   // GlobalPoint pos = seed.position();

--- a/RecoVertex/BeamSpotProducer/interface/BSpdfsFcn.h
+++ b/RecoVertex/BeamSpotProducer/interface/BSpdfsFcn.h
@@ -33,8 +33,8 @@ class BSpdfsFcn : public ROOT::Minuit2::FCNBase {
 		fusepdfs = usepdfs;
 	}
 
-	virtual double operator() (const std::vector<double>&) const;
-	virtual double Up() const {return 1.;}
+	double operator() (const std::vector<double>&) const override;
+	double Up() const override {return 1.;}
 	
   private:
 

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotAnalyzer.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotAnalyzer.h
@@ -26,16 +26,16 @@ ________________________________________________________________**/
 class BeamSpotAnalyzer : public edm::EDAnalyzer {
  public:
   explicit BeamSpotAnalyzer(const edm::ParameterSet&);
-  ~BeamSpotAnalyzer();
+  ~BeamSpotAnalyzer() override;
 
  private:
-  virtual void beginJob() ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-									const edm::EventSetup& context) ;
-  virtual void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-								  const edm::EventSetup& c);
+  void beginJob() override ;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
+  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
+									const edm::EventSetup& context) override ;
+  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
+								  const edm::EventSetup& c) override;
 
   int    ftotalevents;
   int fitNLumi_;

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotFromDB.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotFromDB.h
@@ -25,12 +25,12 @@ ________________________________________________________________**/
 class BeamSpotFromDB : public edm::EDAnalyzer {
  public:
   explicit BeamSpotFromDB(const edm::ParameterSet&);
-  ~BeamSpotFromDB();
+  ~BeamSpotFromDB() override;
 
  private:
-  virtual void beginJob() ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  void beginJob() override ;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
 
 
 };

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotOnlineProducer.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotOnlineProducer.h
@@ -29,10 +29,10 @@ class BeamSpotOnlineProducer: public edm::stream::EDProducer<> {
 	/// constructor
 	explicit BeamSpotOnlineProducer(const edm::ParameterSet& iConf);
 	/// destructor
-	~BeamSpotOnlineProducer();
+	~BeamSpotOnlineProducer() override;
 	
 	/// produce a beam spot class
-	virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+	void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   private:
 

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotProducer.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotProducer.h
@@ -27,10 +27,10 @@ class BeamSpotProducer: public edm::stream::EDProducer<> {
 	/// constructor
 	explicit BeamSpotProducer(const edm::ParameterSet& iConf);
 	/// destructor
-	~BeamSpotProducer();
+	~BeamSpotProducer() override;
 	
 	/// produce a beam spot class
-	virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup);
+	void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   private:
 	

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2DB.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2DB.h
@@ -31,12 +31,12 @@ ________________________________________________________________**/
 class BeamSpotWrite2DB : public edm::EDAnalyzer {
  public:
   explicit BeamSpotWrite2DB(const edm::ParameterSet&);
-  ~BeamSpotWrite2DB();
+  ~BeamSpotWrite2DB() override;
 
  private:
-  virtual void beginJob() ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  void beginJob() override ;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
 
   
   std::ifstream fasciiFile;

--- a/RecoVertex/BeamSpotProducer/interface/FcnBeamSpotFitPV.h
+++ b/RecoVertex/BeamSpotProducer/interface/FcnBeamSpotFitPV.h
@@ -23,15 +23,15 @@ class FcnBeamSpotFitPV : public ROOT::Minuit2::FCNBase {
 public: 
   // constructor from vertex data
   FcnBeamSpotFitPV(const std::vector<BeamSpotFitPVData>& data);
-  ~FcnBeamSpotFitPV() {} 
+  ~FcnBeamSpotFitPV() override {} 
   // additional vertex selection using limits in x, y, z
   void setLimits (float xmin, float xmax,
 		  float ymin, float ymax,
 		  float zmin, float zmax);
   // deltaFcn for definition of the uncertainty
-  double Up() const {return errorDef_;} 
+  double Up() const override {return errorDef_;} 
   // -2lnL value based on vector of parameters
-  double operator() (const std::vector<double>&) const; 
+  double operator() (const std::vector<double>&) const override; 
   // vertex count used for the fit (after selection)
   unsigned int nrOfVerticesUsed () const;
 private: 

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotFakeConditions.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotFakeConditions.cc
@@ -26,7 +26,7 @@ class BeamSpotFakeConditions : public edm::ESProducer, public edm::EventSetupRec
 public:
 	typedef std::shared_ptr<BeamSpotObjects> ReturnType;
 	BeamSpotFakeConditions(const edm::ParameterSet &params);
-	virtual ~BeamSpotFakeConditions();
+	~BeamSpotFakeConditions() override;
 	ReturnType produce(const BeamSpotObjectsRcd &record);
 private:
 	void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &key,const edm::IOVSyncValue &syncValue,edm::ValidityInterval &oValidity) override;

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
@@ -58,7 +58,7 @@ BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup)
   reco::BeamSpot aSpot;
 
   bool fallBackToDB=false;
-  if (handleScaler->size()!=0){
+  if (!handleScaler->empty()){
     // get one element
     spotOnline = * ( handleScaler->begin() );
     

--- a/RecoVertex/BeamSpotProducer/src/BSFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/BSFitter.cc
@@ -107,12 +107,12 @@ BSFitter::~BSFitter()
 //______________________________________________________________________
 reco::BeamSpot BSFitter::Fit() {
 
-	return this->Fit(0);
+	return this->Fit(nullptr);
 
 }
 
 //______________________________________________________________________
-reco::BeamSpot BSFitter::Fit(double *inipar = 0) {
+reco::BeamSpot BSFitter::Fit(double *inipar = nullptr) {
 	fbeamtype = reco::BeamSpot::Unknown;
 	if ( ffit_variable == "z" ) {
 

--- a/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
@@ -38,7 +38,7 @@ void BeamFitter::updateBTime() {
 
 
 BeamFitter::BeamFitter(const edm::ParameterSet& iConfig,
-                       edm::ConsumesCollector &&iColl): fPVTree_(0)
+                       edm::ConsumesCollector &&iColl): fPVTree_(nullptr)
 {
 
   debug_             = iConfig.getParameter<edm::ParameterSet>("BeamFitter").getUntrackedParameter<bool>("Debug");
@@ -247,7 +247,7 @@ void BeamFitter::readEvent(const edm::Event& iEvent)
 
   //------ Beam Spot in current event
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-  const reco::BeamSpot *refBS =  0;
+  const reco::BeamSpot *refBS =  nullptr;
   if ( iEvent.getByToken(beamSpotToken_, recoBeamSpotHandle) )
       refBS = recoBeamSpotHandle.product();
   //-------
@@ -302,7 +302,7 @@ void BeamFitter::readEvent(const edm::Event& iEvent)
     falgo = true;
 
     if (! isMuon_ ) {
-      if (quality_.size()!=0) {
+      if (!quality_.empty()) {
           fquality = false;
           for (unsigned int i = 0; i<quality_.size();++i) {
               if(debug_) edm::LogInfo("BeamFitter") << "quality_[" << i << "] = " << track->qualityName(quality_[i]) << std::endl;
@@ -316,7 +316,7 @@ void BeamFitter::readEvent(const edm::Event& iEvent)
 
       // Track algorithm
 
-      if (algorithm_.size()!=0) {
+      if (!algorithm_.empty()) {
 	if (std::find(algorithm_.begin(),algorithm_.end(),track->algo())==algorithm_.end())
 	  falgo = false;
       }
@@ -742,7 +742,7 @@ void BeamFitter::write2DB(){
 }
 
 void BeamFitter::runAllFitter() {
-  if(fBSvector.size()!=0){
+  if(!fBSvector.empty()){
     BSFitter *myalgo = new BSFitter( fBSvector );
     fbeamspot = myalgo->Fit_d0phi();
 

--- a/RecoVertex/BeamSpotProducer/src/PVFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/PVFitter.cc
@@ -43,14 +43,14 @@ using namespace std ;
 
 PVFitter::PVFitter(const edm::ParameterSet& iConfig,
                    edm::ConsumesCollector &&iColl)
-  : ftree_(0)
+  : ftree_(nullptr)
 {
   initialize(iConfig, iColl);
 }
 
 PVFitter::PVFitter(const edm::ParameterSet& iConfig,
                    edm::ConsumesCollector &iColl)
-    :ftree_(0)
+    :ftree_(nullptr)
 {
   initialize(iConfig, iColl);
 }
@@ -166,7 +166,7 @@ void PVFitter::readEvent(const edm::Event& iEvent)
           pvData.posCorr[2] = pv->covariance(1,2)/pv->yError()/pv->zError();
           pvStore_.push_back(pvData);
 
-      if(ftree_ != 0){
+      if(ftree_ != nullptr){
         theBeamSpotTreeData_.run(iEvent.id().run());
         theBeamSpotTreeData_.lumi(iEvent.luminosityBlock());
         theBeamSpotTreeData_.bunchCrossing(bx);

--- a/RecoVertex/ConfigurableVertexReco/interface/AbstractConfFitter.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/AbstractConfFitter.h
@@ -23,21 +23,21 @@ class AbstractConfFitter : public VertexFitter<5>
 
     virtual void configure ( const edm::ParameterSet & ) = 0;
     virtual edm::ParameterSet defaults() const = 0;
-    virtual ~AbstractConfFitter();
-    AbstractConfFitter * clone() const = 0;
+    ~AbstractConfFitter() override;
+    AbstractConfFitter * clone() const override = 0;
 
-    CachingVertex<5> vertex ( const std::vector < reco::TransientTrack > & t ) const;
-    CachingVertex<5> vertex( const std::vector<RefCountedVertexTrack> & tracks) const;
+    CachingVertex<5> vertex ( const std::vector < reco::TransientTrack > & t ) const override;
+    CachingVertex<5> vertex( const std::vector<RefCountedVertexTrack> & tracks) const override;
     CachingVertex<5> vertex( const std::vector<RefCountedVertexTrack> & tracks,
-        const reco::BeamSpot & spot ) const;
+        const reco::BeamSpot & spot ) const override;
     CachingVertex<5> vertex( const std::vector<reco::TransientTrack> & tracks, 
-        const GlobalPoint& linPoint) const;
+        const GlobalPoint& linPoint) const override;
     CachingVertex<5> vertex( const std::vector<reco::TransientTrack> & tracks, 
-        const GlobalPoint& priorPos, const GlobalError& priorError) const;
+        const GlobalPoint& priorPos, const GlobalError& priorError) const override;
     CachingVertex<5> vertex( const std::vector<reco::TransientTrack> & tracks, 
-                          const reco::BeamSpot& beamSpot) const;
+                          const reco::BeamSpot& beamSpot) const override;
     CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack> & tracks, 
-      const GlobalPoint& priorPos, const GlobalError& priorError) const;
+      const GlobalPoint& priorPos, const GlobalError& priorError) const override;
  public:
     const VertexFitter<5> * theFitter;
 };

--- a/RecoVertex/ConfigurableVertexReco/interface/AbstractConfReconstructor.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/AbstractConfReconstructor.h
@@ -18,8 +18,8 @@ class AbstractConfReconstructor : public VertexReconstructor
      */
     virtual void configure ( const edm::ParameterSet & ) = 0;
     virtual edm::ParameterSet defaults() const = 0;
-    virtual ~AbstractConfReconstructor() {};
-    AbstractConfReconstructor * clone() const = 0;
+    ~AbstractConfReconstructor() override {};
+    AbstractConfReconstructor * clone() const override = 0;
 };
 
 #endif

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfigurableAdaptiveFitter.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfigurableAdaptiveFitter.h
@@ -17,11 +17,11 @@ class ConfigurableAdaptiveFitter : public AbstractConfFitter
      *  Tini:    The initial temparature. Default: 256
      */
     ConfigurableAdaptiveFitter ();
-    void configure ( const edm::ParameterSet & );
+    void configure ( const edm::ParameterSet & ) override;
     ConfigurableAdaptiveFitter ( const ConfigurableAdaptiveFitter & o );
-    ~ConfigurableAdaptiveFitter();
-    ConfigurableAdaptiveFitter * clone () const;
-    edm::ParameterSet defaults() const;
+    ~ConfigurableAdaptiveFitter() override;
+    ConfigurableAdaptiveFitter * clone () const override;
+    edm::ParameterSet defaults() const override;
 };
 
 #endif

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfigurableAdaptiveReconstructor.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfigurableAdaptiveReconstructor.h
@@ -11,20 +11,20 @@ class ConfigurableAdaptiveReconstructor : public AbstractConfReconstructor
 {
   public:
     ConfigurableAdaptiveReconstructor ();
-    void configure ( const edm::ParameterSet & );
+    void configure ( const edm::ParameterSet & ) override;
     ConfigurableAdaptiveReconstructor ( const ConfigurableAdaptiveReconstructor & o );
-    ~ConfigurableAdaptiveReconstructor();
-    ConfigurableAdaptiveReconstructor * clone () const;
+    ~ConfigurableAdaptiveReconstructor() override;
+    ConfigurableAdaptiveReconstructor * clone () const override;
     std::vector < TransientVertex > vertices ( 
-        const std::vector < reco::TransientTrack > & t ) const;
+        const std::vector < reco::TransientTrack > & t ) const override;
     std::vector < TransientVertex > vertices ( 
         const std::vector < reco::TransientTrack > & t,
-        const reco::BeamSpot & ) const;
+        const reco::BeamSpot & ) const override;
     std::vector < TransientVertex > vertices ( 
         const std::vector < reco::TransientTrack > & prims,
         const std::vector < reco::TransientTrack > & secs,
-        const reco::BeamSpot & ) const;
-    edm::ParameterSet defaults() const;
+        const reco::BeamSpot & ) const override;
+    edm::ParameterSet defaults() const override;
   private:
     const VertexReconstructor * theRector;
 };

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfigurableAnnealing.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfigurableAnnealing.h
@@ -13,19 +13,19 @@ class ConfigurableAnnealing : public AnnealingSchedule {
 
 public:
   ConfigurableAnnealing( const edm::ParameterSet & );
-  ~ConfigurableAnnealing();
+  ~ConfigurableAnnealing() override;
   ConfigurableAnnealing( const ConfigurableAnnealing & );
-  void anneal();
-  void resetAnnealing();
-  double phi ( double chi2 ) const;
-  double weight ( double chi2 ) const;
-  double cutoff() const;
-  double currentTemp() const;
-  double initialTemp() const;
-  bool isAnnealed() const;
-  void debug() const;
+  void anneal() override;
+  void resetAnnealing() override;
+  double phi ( double chi2 ) const override;
+  double weight ( double chi2 ) const override;
+  double cutoff() const override;
+  double currentTemp() const override;
+  double initialTemp() const override;
+  bool isAnnealed() const override;
+  void debug() const override;
 
-  ConfigurableAnnealing * clone() const;
+  ConfigurableAnnealing * clone() const override;
 
 private:
   AnnealingSchedule * theImpl;

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfigurableKalmanFitter.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfigurableKalmanFitter.h
@@ -11,11 +11,11 @@ class ConfigurableKalmanFitter : public AbstractConfFitter
 {
   public:
     ConfigurableKalmanFitter ();
-    void configure ( const edm::ParameterSet & );
+    void configure ( const edm::ParameterSet & ) override;
     ConfigurableKalmanFitter ( const ConfigurableKalmanFitter & o );
-    ~ConfigurableKalmanFitter();
-    ConfigurableKalmanFitter * clone () const;
-    edm::ParameterSet defaults() const;
+    ~ConfigurableKalmanFitter() override;
+    ConfigurableKalmanFitter * clone () const override;
+    edm::ParameterSet defaults() const override;
 
 };
 

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfigurableMultiVertexFitter.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfigurableMultiVertexFitter.h
@@ -22,19 +22,19 @@ class ConfigurableMultiVertexFitter : public AbstractConfReconstructor
      */
     ConfigurableMultiVertexFitter ();
     ConfigurableMultiVertexFitter ( const ConfigurableMultiVertexFitter & o );
-    ~ConfigurableMultiVertexFitter();
-    ConfigurableMultiVertexFitter * clone () const;
+    ~ConfigurableMultiVertexFitter() override;
+    ConfigurableMultiVertexFitter * clone () const override;
     std::vector < TransientVertex > vertices ( 
-        const std::vector < reco::TransientTrack > & t ) const;
+        const std::vector < reco::TransientTrack > & t ) const override;
     std::vector < TransientVertex > vertices ( 
         const std::vector < reco::TransientTrack > & t,
-        const reco::BeamSpot & s ) const;
+        const reco::BeamSpot & s ) const override;
     std::vector < TransientVertex > vertices ( 
         const std::vector < reco::TransientTrack > & prims,
         const std::vector < reco::TransientTrack > & secs,
-        const reco::BeamSpot & s ) const;
-    void configure ( const edm::ParameterSet & );
-    edm::ParameterSet defaults() const;
+        const reco::BeamSpot & s ) const override;
+    void configure ( const edm::ParameterSet & ) override;
+    edm::ParameterSet defaults() const override;
   private:
     const MultiVertexReconstructor * theRector;
     int theCheater;

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfigurableTrimmedKalmanFinder.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfigurableTrimmedKalmanFinder.h
@@ -11,20 +11,20 @@ class ConfigurableTrimmedKalmanFinder : public AbstractConfReconstructor
 {
   public:
     ConfigurableTrimmedKalmanFinder ();
-    void configure ( const edm::ParameterSet & );
+    void configure ( const edm::ParameterSet & ) override;
     ConfigurableTrimmedKalmanFinder ( const ConfigurableTrimmedKalmanFinder & o );
-    ~ConfigurableTrimmedKalmanFinder();
-    ConfigurableTrimmedKalmanFinder * clone () const;
+    ~ConfigurableTrimmedKalmanFinder() override;
+    ConfigurableTrimmedKalmanFinder * clone () const override;
     std::vector < TransientVertex > vertices ( 
-        const std::vector < reco::TransientTrack > & t ) const;
+        const std::vector < reco::TransientTrack > & t ) const override;
     std::vector < TransientVertex > vertices ( 
         const std::vector < reco::TransientTrack > & t,
-        const reco::BeamSpot & s ) const;
+        const reco::BeamSpot & s ) const override;
     std::vector < TransientVertex > vertices ( 
         const std::vector < reco::TransientTrack > & prims,
         const std::vector < reco::TransientTrack > & secs,
-        const reco::BeamSpot & s ) const;
-    edm::ParameterSet defaults() const;
+        const reco::BeamSpot & s ) const override;
+    edm::ParameterSet defaults() const override;
   private:
     const VertexReconstructor * theRector;
 };

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfigurableVertexFitter.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfigurableVertexFitter.h
@@ -22,22 +22,22 @@ class ConfigurableVertexFitter : public VertexFitter<5>
 
     ConfigurableVertexFitter ( const edm::ParameterSet & );
     ConfigurableVertexFitter ( const ConfigurableVertexFitter & o );
-    ~ConfigurableVertexFitter();
+    ~ConfigurableVertexFitter() override;
 
-    ConfigurableVertexFitter * clone () const;
+    ConfigurableVertexFitter * clone () const override;
 
-    CachingVertex<5> vertex ( const std::vector < reco::TransientTrack > & t ) const;
-    CachingVertex<5> vertex( const std::vector<RefCountedVertexTrack> & tracks) const;
+    CachingVertex<5> vertex ( const std::vector < reco::TransientTrack > & t ) const override;
+    CachingVertex<5> vertex( const std::vector<RefCountedVertexTrack> & tracks) const override;
     CachingVertex<5> vertex( const std::vector<RefCountedVertexTrack> & tracks,
-        const reco::BeamSpot & spot ) const;
+        const reco::BeamSpot & spot ) const override;
     CachingVertex<5> vertex( const std::vector<reco::TransientTrack> & tracks, 
-        const GlobalPoint& linPoint) const;
+        const GlobalPoint& linPoint) const override;
     CachingVertex<5> vertex( const std::vector<reco::TransientTrack> & tracks, 
-        const GlobalPoint& priorPos, const GlobalError& priorError) const;
+        const GlobalPoint& priorPos, const GlobalError& priorError) const override;
     CachingVertex<5> vertex( const std::vector<reco::TransientTrack> & tracks, 
-                          const reco::BeamSpot& beamSpot) const;
+                          const reco::BeamSpot& beamSpot) const override;
     CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack> & tracks, 
-      const GlobalPoint& priorPos, const GlobalError& priorError) const;
+      const GlobalPoint& priorPos, const GlobalError& priorError) const override;
 
   private:
     AbstractConfFitter * theFitter;

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfigurableVertexReconstructor.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfigurableVertexReconstructor.h
@@ -15,15 +15,15 @@ class ConfigurableVertexReconstructor : public VertexReconstructor
   public:
     ConfigurableVertexReconstructor ( const edm::ParameterSet & );
     ConfigurableVertexReconstructor ( const ConfigurableVertexReconstructor & o );
-    ~ConfigurableVertexReconstructor();
+    ~ConfigurableVertexReconstructor() override;
 
-    std::vector < TransientVertex > vertices ( const std::vector < reco::TransientTrack > & ) const;
+    std::vector < TransientVertex > vertices ( const std::vector < reco::TransientTrack > & ) const override;
     std::vector < TransientVertex > vertices ( const std::vector < reco::TransientTrack > &,
-        const reco::BeamSpot & ) const;
+        const reco::BeamSpot & ) const override;
     std::vector < TransientVertex > vertices ( const std::vector < reco::TransientTrack > &,
-        const std::vector < reco::TransientTrack > &, const reco::BeamSpot & ) const;
+        const std::vector < reco::TransientTrack > &, const reco::BeamSpot & ) const override;
 
-    ConfigurableVertexReconstructor * clone () const;
+    ConfigurableVertexReconstructor * clone () const override;
 
   private:
     AbstractConfReconstructor * theRector;

--- a/RecoVertex/ConfigurableVertexReco/interface/ReconstructorFromFitter.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ReconstructorFromFitter.h
@@ -14,14 +14,14 @@ class ReconstructorFromFitter : public AbstractConfReconstructor
   public:
   explicit ReconstructorFromFitter ( std::unique_ptr<AbstractConfFitter>&&  );
     ReconstructorFromFitter ( const ReconstructorFromFitter & o );
-    ~ReconstructorFromFitter();
-    void configure(const edm::ParameterSet&);
-    edm::ParameterSet defaults() const;
-    std::vector < TransientVertex > vertices ( const std::vector < reco::TransientTrack > & ) const;
+    ~ReconstructorFromFitter() override;
+    void configure(const edm::ParameterSet&) override;
+    edm::ParameterSet defaults() const override;
+    std::vector < TransientVertex > vertices ( const std::vector < reco::TransientTrack > & ) const override;
     std::vector < TransientVertex > vertices ( const std::vector < reco::TransientTrack > &,
-        const reco::BeamSpot & ) const;
+        const reco::BeamSpot & ) const override;
 
-    ReconstructorFromFitter * clone () const;
+    ReconstructorFromFitter * clone () const override;
 
   private:
     const AbstractConfFitter * theFitter;

--- a/RecoVertex/ConfigurableVertexReco/src/AbstractConfFitter.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/AbstractConfFitter.cc
@@ -4,7 +4,7 @@ AbstractConfFitter::AbstractConfFitter ( const VertexFitter<5> & f ) :
   theFitter ( f.clone() )
 {}
 
-AbstractConfFitter::AbstractConfFitter() : theFitter ( 0 )
+AbstractConfFitter::AbstractConfFitter() : theFitter ( nullptr )
 {}
 
 AbstractConfFitter::AbstractConfFitter ( const AbstractConfFitter & o ) :

--- a/RecoVertex/ConfigurableVertexReco/src/ConfigurableAdaptiveFitter.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ConfigurableAdaptiveFitter.cc
@@ -49,7 +49,7 @@ void ConfigurableAdaptiveFitter::configure(
   // GenericLinearizationPointFinder linpt ( kvf );
   KalmanVertexUpdator<5> updator;
   bool s=m.getParameter< bool >("smoothing");
-  VertexSmoother<5> * smoother=0;
+  VertexSmoother<5> * smoother=nullptr;
   if ( s )
   {
     smoother = new KalmanVertexSmoother ();

--- a/RecoVertex/ConfigurableVertexReco/src/ConfigurableAnnealing.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ConfigurableAnnealing.cc
@@ -7,7 +7,7 @@
 using namespace std;
 
 ConfigurableAnnealing::ConfigurableAnnealing ( const edm::ParameterSet & m ) :
-  theImpl( 0 )
+  theImpl( nullptr )
 {
   string type = m.getParameter<string>("annealing");
   // edm::LogWarning("ConfigurableAnnealing") << "below one code ist still here.";

--- a/RecoVertex/ConfigurableVertexReco/src/ConfigurableVertexFitter.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ConfigurableVertexFitter.cc
@@ -21,7 +21,7 @@ namespace {
 }
 
 ConfigurableVertexFitter::ConfigurableVertexFitter ( 
-    const edm::ParameterSet & p ) : theFitter ( 0 )
+    const edm::ParameterSet & p ) : theFitter ( nullptr )
 {
   string fitter=p.getParameter<string>("fitter");
   theFitter = VertexFitterManager::Instance().get ( fitter ).release();

--- a/RecoVertex/ConfigurableVertexReco/src/ConfigurableVertexReconstructor.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ConfigurableVertexReconstructor.cc
@@ -22,7 +22,7 @@ namespace {
 }
 
 ConfigurableVertexReconstructor::ConfigurableVertexReconstructor ( 
-    const edm::ParameterSet & p ) : theRector ( 0 )
+    const edm::ParameterSet & p ) : theRector ( nullptr )
 {
   string finder=p.getParameter<string>("finder");
   theRector = VertexRecoManager::Instance().get ( finder ).release();

--- a/RecoVertex/GaussianSumVertexFit/interface/AdaptiveGsfVertexFitter.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/AdaptiveGsfVertexFitter.h
@@ -27,7 +27,7 @@ public:
   AdaptiveGsfVertexFitter(const edm::ParameterSet& pSet,
 	const LinearizationPointFinder & linP = DefaultLinearizationPointFinder());
 
-  virtual ~AdaptiveGsfVertexFitter();
+  ~AdaptiveGsfVertexFitter() override;
 
   /**
    * Copy constructor
@@ -35,7 +35,7 @@ public:
 
   AdaptiveGsfVertexFitter(const AdaptiveGsfVertexFitter & original);
 
-  AdaptiveGsfVertexFitter * clone() const {
+  AdaptiveGsfVertexFitter * clone() const override {
     return new AdaptiveGsfVertexFitter(* this);
   }
 
@@ -43,16 +43,16 @@ public:
 
   /** Fit vertex out of a set of RecTracks
    */
-  virtual inline CachingVertex<5> 
-    vertex(const std::vector<reco::TransientTrack>  & tracks) const
+  inline CachingVertex<5> 
+    vertex(const std::vector<reco::TransientTrack>  & tracks) const override
   {
     return theFitter->vertex(tracks);
   }
 
   /** Fit vertex out of a set of VertexTracks
    */
-  virtual inline CachingVertex<5> 
-  vertex(const std::vector<RefCountedVertexTrack> & tracks) const
+  inline CachingVertex<5> 
+  vertex(const std::vector<RefCountedVertexTrack> & tracks) const override
   {
     return theFitter->vertex(tracks);
   }
@@ -60,9 +60,9 @@ public:
   /** Fit vertex out of a set of RecTracks. 
    *  Uses the specified linearization point.
    */
-  virtual inline CachingVertex<5> 
+  inline CachingVertex<5> 
     vertex(const std::vector<reco::TransientTrack>  & tracks, 
-	   const GlobalPoint& linPoint) const
+	   const GlobalPoint& linPoint) const override
   {
     return theFitter->vertex(tracks, linPoint);
   }
@@ -71,8 +71,8 @@ public:
    *  The specified BeamSpot will be used as priot, but NOT for the linearization.
    * The specified LinearizationPointFinder will be used to find the linearization point.
    */
-  virtual inline CachingVertex<5> 
-  vertex(const std::vector<reco::TransientTrack> & tracks, const reco::BeamSpot& beamSpot) const
+  inline CachingVertex<5> 
+  vertex(const std::vector<reco::TransientTrack> & tracks, const reco::BeamSpot& beamSpot) const override
   {
     return theFitter->vertex(tracks, beamSpot);
   }
@@ -83,17 +83,17 @@ public:
    *  estimate of the vertex position. The error is used for the 
    *  weight of the prior estimate.
    */
-  virtual inline CachingVertex<5> 
+  inline CachingVertex<5> 
   vertex(const std::vector<reco::TransientTrack> & tracks, 
 	 const GlobalPoint& priorPos,
-  	 const GlobalError& priorError) const
+  	 const GlobalError& priorError) const override
   {
     return theFitter->vertex(tracks, priorPos, priorError);
   }
 
-  virtual inline CachingVertex<5> 
+  inline CachingVertex<5> 
   vertex(const std::vector<RefCountedVertexTrack> & tracks,
-      const reco::BeamSpot & spot ) const
+      const reco::BeamSpot & spot ) const override
   {
     return theFitter->vertex(tracks, spot );
   }
@@ -102,10 +102,10 @@ public:
    *  Uses the specified point and error as the prior estimate of the vertex.
    *  This position is not used to relinearize the tracks.
    */
-  virtual inline CachingVertex<5> 
+  inline CachingVertex<5> 
   vertex(const std::vector<RefCountedVertexTrack> & tracks, 
 	 const GlobalPoint& priorPos,
-	 const GlobalError& priorError) const
+	 const GlobalError& priorError) const override
   {
     return theFitter->vertex(tracks, priorPos, priorError);
   }

--- a/RecoVertex/GaussianSumVertexFit/interface/BasicMultiVertexState.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/BasicMultiVertexState.h
@@ -21,7 +21,7 @@ public:
 
   /** Access methods
    */
-  virtual BasicMultiVertexState* clone() const
+  BasicMultiVertexState* clone() const override
   {
     return new BasicMultiVertexState(*this);
   }
@@ -29,72 +29,72 @@ public:
   /**
    * Mean position of the mixture (position of the collapsed state)
    */
-  GlobalPoint position() const;
+  GlobalPoint position() const override;
 
   /**
    * Mean time of the mixture (time of the collapsed state)
    */
-  double time() const;
+  double time() const override;
 
   /**
    * Mean covariance matrix of the mixture
    * (covariance matrix of the collapsed state)
    */
-  GlobalError error() const;
+  GlobalError error() const override;
 
   /**
    * Mean covariance matrix of the mixture
    * (covariance matrix of the collapsed state)
    */
-  double timeError() const;
+  double timeError() const override;
 
   /**
    * Mean covariance matrix of the mixture
    * (covariance matrix of the collapsed state)
    */
-  GlobalError error4D() const;
+  GlobalError error4D() const override;
 
   /**
    * Mean weight matrix (inverse of covariance) of the mixture
    * ( weight matrix of the collapsed state)
    */
-  GlobalWeight weight() const;
+  GlobalWeight weight() const override;
 
   /**
    * Mean weight matrix (inverse of covariance) of the mixture
    * ( weight matrix of the collapsed state)
    */
-  GlobalWeight weight4D() const;
+  GlobalWeight weight4D() const override;
 
   /**
    * Mean (weight*position) matrix of the mixture
    */
-  AlgebraicVector3 weightTimesPosition() const;
+  AlgebraicVector3 weightTimesPosition() const override;
 
   /**
    * Mean (weight*position) matrix of the mixture
    */
-  AlgebraicVector4 weightTimesPosition4D() const;
+  AlgebraicVector4 weightTimesPosition4D() const override;
 
   /**
    * The weight of this state. It will be the sum of the weights of the
    * individual components in the mixture.
    */
-  double weightInMixture() const;
+  double weightInMixture() const override;
 
   /**
    * Vector of individual components in the mixture.
    */
-  virtual std::vector<VertexState> components() const {
+  std::vector<VertexState> components() const override {
     return theComponents;
   }
 
   /**
    * The validity of the vertex
    */
-  bool isValid() const {return valid;}
+  bool isValid() const override {return valid;}
 
-  bool is4D() const { checkCombinedState(); return theCombinedState.is4D(); }
+  bool is4D() const override { checkCombinedState(); return theCombinedState.is4D(); }
 
 private:
 

--- a/RecoVertex/GaussianSumVertexFit/interface/GsfVertexFitter.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/GsfVertexFitter.h
@@ -32,7 +32,7 @@ public:
   GsfVertexFitter(const edm::ParameterSet& pSet,
 	const LinearizationPointFinder & linP = DefaultLinearizationPointFinder());
 
-  virtual ~GsfVertexFitter();
+  ~GsfVertexFitter() override;
 
   /**
    * Copy constructor
@@ -40,7 +40,7 @@ public:
 
   GsfVertexFitter(const GsfVertexFitter & original);
 
-  GsfVertexFitter * clone() const {
+  GsfVertexFitter * clone() const override {
     return new GsfVertexFitter(* this);
   }
 
@@ -48,16 +48,16 @@ public:
 
   /** Fit vertex out of a set of RecTracks
    */
-  virtual inline CachingVertex<5> 
-    vertex(const std::vector<reco::TransientTrack>  & tracks) const
+  inline CachingVertex<5> 
+    vertex(const std::vector<reco::TransientTrack>  & tracks) const override
   {
     return theSequentialFitter->vertex(tracks);
   }
 
   /** Fit vertex out of a set of VertexTracks
    */
-  virtual inline CachingVertex<5> 
-  vertex(const std::vector<RefCountedVertexTrack> & tracks) const
+  inline CachingVertex<5> 
+  vertex(const std::vector<RefCountedVertexTrack> & tracks) const override
   {
     return theSequentialFitter->vertex(tracks);
   }
@@ -65,9 +65,9 @@ public:
   /** Fit vertex out of a set of RecTracks. 
    *  Uses the specified linearization point.
    */
-  virtual inline CachingVertex<5> 
+  inline CachingVertex<5> 
     vertex(const std::vector<reco::TransientTrack>  & tracks, 
-	   const GlobalPoint& linPoint) const
+	   const GlobalPoint& linPoint) const override
   {
     return theSequentialFitter->vertex(tracks, linPoint);
   }
@@ -77,10 +77,10 @@ public:
    *  estimate of the vertex position. The error is used for the 
    *  weight of the prior estimate.
    */
-  virtual inline CachingVertex<5> 
+  inline CachingVertex<5> 
   vertex(const std::vector<reco::TransientTrack> & tracks, 
 	 const GlobalPoint& priorPos,
-  	 const GlobalError& priorError) const
+  	 const GlobalError& priorError) const override
   {
     return theSequentialFitter->vertex(tracks, priorPos, priorError);
   }
@@ -89,15 +89,15 @@ public:
    *  The specified BeamSpot will be used as priot, but NOT for the linearization.
    * The specified LinearizationPointFinder will be used to find the linearization point.
    */
-  virtual inline CachingVertex<5> 
-  vertex(const std::vector<reco::TransientTrack> & tracks, const reco::BeamSpot& beamSpot) const
+  inline CachingVertex<5> 
+  vertex(const std::vector<reco::TransientTrack> & tracks, const reco::BeamSpot& beamSpot) const override
   {
     return theSequentialFitter->vertex(tracks, beamSpot);
   }
 
-  virtual inline CachingVertex<5> 
+  inline CachingVertex<5> 
   vertex(const std::vector<RefCountedVertexTrack> & tracks,
-      const reco::BeamSpot & spot ) const
+      const reco::BeamSpot & spot ) const override
   {
     return theSequentialFitter->vertex(tracks, spot );
   }
@@ -106,10 +106,10 @@ public:
    *  Uses the specified point and error as the prior estimate of the vertex.
    *  This position is not used to relinearize the tracks.
    */
-  virtual inline CachingVertex<5> 
+  inline CachingVertex<5> 
   vertex(const std::vector<RefCountedVertexTrack> & tracks, 
 	 const GlobalPoint& priorPos,
-	 const GlobalError& priorError) const
+	 const GlobalError& priorError) const override
   {
     return theSequentialFitter->vertex(tracks, priorPos, priorError);
   }

--- a/RecoVertex/GaussianSumVertexFit/interface/GsfVertexSmoother.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/GsfVertexSmoother.h
@@ -32,7 +32,7 @@ public:
 
   GsfVertexSmoother(bool limit, const GsfVertexMerger * merger);
 
-  virtual ~GsfVertexSmoother() {}
+  ~GsfVertexSmoother() override {}
 
   /**
    *  Methode which will refit the tracks with the vertex constraint
@@ -41,7 +41,7 @@ public:
    *	last update.
    *  \return the final vertex estimate, with all the supplementary information
    */
-  virtual CachingVertex<5> smooth(const CachingVertex<5> & vertex) const;
+  CachingVertex<5> smooth(const CachingVertex<5> & vertex) const override;
 
   /**
    *  Access methods
@@ -53,7 +53,7 @@ public:
   /**
    * Clone method 
    */
-  virtual VertexSmoother<5> * clone() const 
+  VertexSmoother<5> * clone() const override 
   {
     return new GsfVertexSmoother(* this);
   }

--- a/RecoVertex/GaussianSumVertexFit/interface/GsfVertexTrackCompatibilityEstimator.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/GsfVertexTrackCompatibilityEstimator.h
@@ -31,7 +31,7 @@ public:
 
   GsfVertexTrackCompatibilityEstimator(){}
 
-  virtual ~GsfVertexTrackCompatibilityEstimator(){}
+  ~GsfVertexTrackCompatibilityEstimator() override{}
 
   /**
    * Track-to-vertex compatibility. 
@@ -41,17 +41,17 @@ public:
    * \return The chi**2.
    */
 
-  virtual BDpair estimate(const CachingVertex<5> & vrt, const RefCountedVertexTrack track,
-			  unsigned int hint=UINT_MAX) const;
+  BDpair estimate(const CachingVertex<5> & vrt, const RefCountedVertexTrack track,
+			  unsigned int hint=UINT_MAX) const override;
 
-  virtual BDpair estimate(const CachingVertex<5> & v, 
+  BDpair estimate(const CachingVertex<5> & v, 
 			  const RefCountedLinearizedTrackState track,
-			  unsigned int hint=UINT_MAX) const;
+			  unsigned int hint=UINT_MAX) const override;
 
-  virtual BDpair estimate(const reco::Vertex & vertex, 
-			 const reco::TransientTrack & track) const;
+  BDpair estimate(const reco::Vertex & vertex, 
+			 const reco::TransientTrack & track) const override;
 
-  virtual GsfVertexTrackCompatibilityEstimator * clone() const
+  GsfVertexTrackCompatibilityEstimator * clone() const override
   {
     return new GsfVertexTrackCompatibilityEstimator(* this);
   }

--- a/RecoVertex/GaussianSumVertexFit/interface/GsfVertexUpdator.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/GsfVertexUpdator.h
@@ -18,14 +18,14 @@ public:
   typedef CachingVertex<5>::RefCountedVertexTrack RefCountedVertexTrack;
   typedef VertexTrack<5>::RefCountedLinearizedTrackState RefCountedLinearizedTrackState;
 
-  GsfVertexUpdator(bool limit = false, const GsfVertexMerger * merger = 0);
+  GsfVertexUpdator(bool limit = false, const GsfVertexMerger * merger = nullptr);
 /**
  *  Method to add a track to an existing CachingVertex
  *  An invalid vertex is returned in case of problems during the update.
  */
 
    CachingVertex<5> add(const CachingVertex<5> & oldVertex,
-        const RefCountedVertexTrack track) const;
+        const RefCountedVertexTrack track) const override;
 
 /**
  *  Method removing already used VertexTrack from existing CachingVertex
@@ -33,13 +33,13 @@ public:
  */
 
    CachingVertex<5> remove(const CachingVertex<5> & oldVertex,
-        const RefCountedVertexTrack track) const;
+        const RefCountedVertexTrack track) const override;
 
 /**
  * Clone method
  */
 
-   VertexUpdator<5> * clone() const
+   VertexUpdator<5> * clone() const override
    {
     return new GsfVertexUpdator(* this);
    }

--- a/RecoVertex/GaussianSumVertexFit/interface/MultiPerigeeLTSFactory.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/MultiPerigeeLTSFactory.h
@@ -22,13 +22,13 @@ public:
   typedef ReferenceCountingPointer<LinearizedTrackState<5> > RefCountedLinearizedTrackState;
 
   RefCountedLinearizedTrackState
-    linearizedTrackState(const GlobalPoint & linP, const reco::TransientTrack & track) const;
+    linearizedTrackState(const GlobalPoint & linP, const reco::TransientTrack & track) const override;
 
   RefCountedLinearizedTrackState
     linearizedTrackState(const GlobalPoint & linP, const reco::TransientTrack & track,
-    	const TrajectoryStateOnSurface& tsos) const;
+    	const TrajectoryStateOnSurface& tsos) const override;
 
-  const MultiPerigeeLTSFactory * clone() const;
+  const MultiPerigeeLTSFactory * clone() const override;
 
 };
 

--- a/RecoVertex/GaussianSumVertexFit/interface/MultiRefittedTS.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/MultiRefittedTS.h
@@ -36,55 +36,55 @@ public:
   MultiRefittedTS(const std::vector<RefCountedRefittedTrackState> & prtsComp,
 	const GlobalPoint & referencePosition);
 
-  virtual ~MultiRefittedTS(){}
+  ~MultiRefittedTS() override{}
 
   /**
    * Returns a FreeTrajectoryState. It will be the FTS of the single, collapsed
    * state.
    */
 
-  virtual FreeTrajectoryState freeTrajectoryState() const;
+  FreeTrajectoryState freeTrajectoryState() const override;
 
   /**
    * Returns a multi-state TSOS at a given surface
    */
-  virtual TrajectoryStateOnSurface trajectoryStateOnSurface(
-  		const Surface & surface) const;
+  TrajectoryStateOnSurface trajectoryStateOnSurface(
+  		const Surface & surface) const override;
 
   /**
    * Returns a multi-state TSOS at a given surface, with a given propagator
    */
 
-  virtual TrajectoryStateOnSurface trajectoryStateOnSurface(
-		const Surface & surface, const Propagator & propagator) const;
+  TrajectoryStateOnSurface trajectoryStateOnSurface(
+		const Surface & surface, const Propagator & propagator) const override;
 
   /**
    *   Returns a new reco::Track, which can then be made persistent. The parameters are taken
    *    from FTS described above.
    */
 
-  virtual reco::TransientTrack transientTrack() const;
+  reco::TransientTrack transientTrack() const override;
 
   /**
    * Vector containing the refitted track parameters. Not possible yet for a
    * multi-state, throws an exception.
    */
 
-  virtual AlgebraicVectorN  parameters() const;
+  AlgebraicVectorN  parameters() const override;
 
   /**
    * The covariance matrix. Not possible yet for a
    * multi-state, throws an exception.
    */
 
-  virtual AlgebraicSymMatrixNN  covariance() const;
+  AlgebraicSymMatrixNN  covariance() const override;
 
   /**
    * Position at which the momentum is defined. Not possible yet for a
    * multi-state, throws an exception.
    */
 
-  virtual GlobalPoint position() const;
+  GlobalPoint position() const override;
 
   /**
    * Vector containing the parameters describing the momentum as the vertex.
@@ -92,11 +92,11 @@ public:
    * multi-state, throws an exception.
    */
 
-  virtual AlgebraicVectorM momentumVector() const;
+  AlgebraicVectorM momentumVector() const override;
 
-  virtual double weight() const;
+  double weight() const override;
 
-  virtual std::vector<ReferenceCountingPointer<RefittedTrackState<5> > > components() const
+  std::vector<ReferenceCountingPointer<RefittedTrackState<5> > > components() const override
   {
     return theComponents;
   }
@@ -109,8 +109,8 @@ public:
    * The current state is unchanged.
    */
 
-  virtual ReferenceCountingPointer<RefittedTrackState<5> > stateWithNewWeight
-  	(const double newWeight) const;
+  ReferenceCountingPointer<RefittedTrackState<5> > stateWithNewWeight
+  	(const double newWeight) const override;
 
 
 private:

--- a/RecoVertex/GaussianSumVertexFit/interface/PerigeeMultiLTS.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/PerigeeMultiLTS.h
@@ -28,16 +28,16 @@ public:
    * A new object of the same type is returned, without change to the existing one.
    */
 
-  virtual  RefCountedLinearizedTrackState stateWithNewLinearizationPoint
-  	(const GlobalPoint & newLP) const;
+   RefCountedLinearizedTrackState stateWithNewLinearizationPoint
+  	(const GlobalPoint & newLP) const override;
 
 
   /**
    * The point at which the track state has been linearized
    */
-  const GlobalPoint & linearizationPoint() const { return theLinPoint; }
+  const GlobalPoint & linearizationPoint() const override { return theLinPoint; }
 
-  virtual reco::TransientTrack track() const { return theTrack; }
+  reco::TransientTrack track() const override { return theTrack; }
 
   /**
    * Returns theoriginal (multi-state) TrajectoryStateOnSurface whith which
@@ -48,22 +48,22 @@ public:
   /** Method returning the constant term of the Taylor expansion
    *  of the measurement equation for the collapsed track state
    */
-  virtual const AlgebraicVectorN & constantTerm() const;
+  const AlgebraicVectorN & constantTerm() const override;
 
   /** Method returning the Position Jacobian from the Taylor expansion
    *  (Matrix A) for the collapsed track state
    */
-  virtual const AlgebraicMatrixN3 & positionJacobian() const;
+  const AlgebraicMatrixN3 & positionJacobian() const override;
 
   /** Method returning the Momentum Jacobian from the Taylor expansion
    *  (Matrix B) for the collapsed track state
    */
-  virtual const AlgebraicMatrixNM & momentumJacobian() const;
+  const AlgebraicMatrixNM & momentumJacobian() const override;
 
   /** Method returning the parameters of the Taylor expansion for
    *  the collapsed track state
    */
-  virtual const AlgebraicVectorN & parametersFromExpansion() const;
+  const AlgebraicVectorN & parametersFromExpansion() const override;
 
   /** Method returning the track state at the point of closest approach
    *  to the linearization point, in the transverse plane (a.k.a.
@@ -74,60 +74,60 @@ public:
   /** Method returning the parameters of the track state at the
    *  transverse impact point, for the collapsed track state
    */
-  AlgebraicVectorN predictedStateParameters() const;
+  AlgebraicVectorN predictedStateParameters() const override;
 
   /** Method returning the momentum part of the parameters of the track state
    *  at the linearization point, for the collapsed track state
    */
-  virtual AlgebraicVectorM predictedStateMomentumParameters() const;
+  AlgebraicVectorM predictedStateMomentumParameters() const override;
 
   /** Method returning the weight matrix of the track state at the
    *  transverse impact point, for the collapsed track state
    * The error variable is 0 in case of success.
    */
-  AlgebraicSymMatrixNN predictedStateWeight(int & error) const;
+  AlgebraicSymMatrixNN predictedStateWeight(int & error) const override;
 
   /** Method returning the covariance matrix of the track state at the
    *  transverse impact point, for the collapsed track state
    */
-  AlgebraicSymMatrixNN predictedStateError() const;
+  AlgebraicSymMatrixNN predictedStateError() const override;
 
   /** Method returning the momentum covariance matrix of the track state at the
    *  transverse impact point, for the collapsed track state
    */
-  AlgebraicSymMatrixMM predictedStateMomentumError() const;
+  AlgebraicSymMatrixMM predictedStateMomentumError() const override;
 
-  TrackCharge charge() const {return theCharge;}
+  TrackCharge charge() const override {return theCharge;}
 
-  bool hasError() const;
+  bool hasError() const override;
 
-  bool operator ==(LinearizedTrackState<5>& other)const;
+  bool operator ==(LinearizedTrackState<5>& other)const override;
 
   /** Creates the correct refitted state according to the results of the
    *  track refit.
    */
-  virtual RefCountedRefittedTrackState createRefittedTrackState(
+  RefCountedRefittedTrackState createRefittedTrackState(
   	const GlobalPoint & vertexPosition,
 	const AlgebraicVectorM & vectorParameters,
-	const AlgebraicSymMatrixOO & covarianceMatrix) const;
+	const AlgebraicSymMatrixOO & covarianceMatrix) const override;
 
-  virtual AlgebraicVector5 refittedParamFromEquation(
-	const RefCountedRefittedTrackState & theRefittedState) const;
+  AlgebraicVector5 refittedParamFromEquation(
+	const RefCountedRefittedTrackState & theRefittedState) const override;
 
-  virtual void inline checkParameters(AlgebraicVector5 & parameters) const;
+  void inline checkParameters(AlgebraicVector5 & parameters) const override;
   /**
    * The weight of this state. It will be the sum of the weights of the
    * individual components in the mixture.
    */
 
-  virtual double weightInMixture() const {return theTSOS.weight();}
+  double weightInMixture() const override {return theTSOS.weight();}
 
   /**
    * Vector of individual components in the mixture.
    */
 
-  virtual std::vector<ReferenceCountingPointer<LinearizedTrackState<5> > > components()
-  				const {return ltComp;}
+  std::vector<ReferenceCountingPointer<LinearizedTrackState<5> > > components()
+  				const override {return ltComp;}
 
 private:
 

--- a/RecoVertex/GaussianSumVertexFit/src/GsfVertexSmoother.cc
+++ b/RecoVertex/GaussianSumVertexFit/src/GsfVertexSmoother.cc
@@ -26,7 +26,7 @@ GsfVertexSmoother::smooth(const CachingVertex<5> & vertex) const
   CachingVertex<5> fitVertex(priorVertexPosition,priorVertexError,initialTracks,0);
   //In case prior vertex was used.
   if (vertex.hasPrior()) {
-    VertexState priorVertexState = vertex.priorVertexState();
+    const VertexState& priorVertexState = vertex.priorVertexState();
     fitVertex = CachingVertex<5>(priorVertexState, priorVertexState,
     		initialTracks,0);
   }

--- a/RecoVertex/GaussianSumVertexFit/src/PerigeeMultiLTS.cc
+++ b/RecoVertex/GaussianSumVertexFit/src/PerigeeMultiLTS.cc
@@ -124,7 +124,7 @@ bool PerigeeMultiLTS::operator ==(LinearizedTrackState<5>& other)const
 {
   const PerigeeMultiLTS* otherP =
   	dynamic_cast<const PerigeeMultiLTS*>(&other);
-  if (otherP == 0) {
+  if (otherP == nullptr) {
    throw VertexException("PerigeeMultiLTS: don't know how to compare myself to non-perigee track state");
   }
   return (otherP->track() == theTrack);

--- a/RecoVertex/GhostTrackFitter/interface/AnnealingGhostTrackFitter.h
+++ b/RecoVertex/GhostTrackFitter/interface/AnnealingGhostTrackFitter.h
@@ -20,24 +20,24 @@ class AnnealingGhostTrackFitter : public SequentialGhostTrackFitter {
 	AnnealingGhostTrackFitter(const AnnealingGhostTrackFitter &orig) :
 		annealing(orig.annealing->clone()),
 		firstStep(orig.firstStep) {}
-	~AnnealingGhostTrackFitter() {}
+	~AnnealingGhostTrackFitter() override {}
 
     private:
-	virtual FitterImpl *clone() const
+	FitterImpl *clone() const override
 	{ return new AnnealingGhostTrackFitter(*this); }
 
-	virtual bool stable(const GhostTrackPrediction &before,
-	                    const GhostTrackPrediction &after) const
+	bool stable(const GhostTrackPrediction &before,
+	                    const GhostTrackPrediction &after) const override
 	{
 		return SequentialGhostTrackFitter::stable(before, after) &&
 		       annealing->isAnnealed();
 	}
 
-	virtual void reset() { annealing->resetAnnealing(); firstStep = true; }
-	virtual void postFit(
+	void reset() override { annealing->resetAnnealing(); firstStep = true; }
+	void postFit(
 			const GhostTrackFitter::PredictionUpdater &updater,
 			const GhostTrackPrediction &pred,
-			std::vector<GhostTrackState> &states);
+			std::vector<GhostTrackState> &states) override;
 
 	std::auto_ptr<AnnealingSchedule>	annealing;
 	bool					firstStep;

--- a/RecoVertex/GhostTrackFitter/interface/BasicGhostTrackState.h
+++ b/RecoVertex/GhostTrackFitter/interface/BasicGhostTrackState.h
@@ -34,7 +34,7 @@ class BasicGhostTrackState : public ReferenceCountedInEvent {
 	typedef std::pair<GlobalPoint, GlobalError> Vertex;
 
 	BasicGhostTrackState() : lambda_(0.), weight_(1.) {}
-	virtual ~BasicGhostTrackState() {}
+	~BasicGhostTrackState() override {}
 
 	virtual GlobalPoint globalPosition() const = 0;
 	virtual GlobalError cartesianError() const = 0;

--- a/RecoVertex/GhostTrackFitter/interface/KalmanGhostTrackUpdater.h
+++ b/RecoVertex/GhostTrackFitter/interface/KalmanGhostTrackUpdater.h
@@ -10,19 +10,19 @@ class GhostTrackState;
 
 class KalmanGhostTrackUpdater : public GhostTrackFitter::PredictionUpdater {
     public:
-	virtual ~KalmanGhostTrackUpdater() {}
+	~KalmanGhostTrackUpdater() override {}
 
-	virtual KalmanGhostTrackUpdater *clone() const
+	KalmanGhostTrackUpdater *clone() const override
 	{ return new KalmanGhostTrackUpdater(*this); }
 
 	GhostTrackPrediction update(const GhostTrackPrediction &pred,
 	                            const GhostTrackState &state,
-	                            double &ndof, double &chi2) const;
+	                            double &ndof, double &chi2) const override;
 
 	void contribution(const GhostTrackPrediction &pred,
 	                  const GhostTrackState &state,
 	                  double &ndof, double &chi2,
-	                  bool withPredError = false) const;
+	                  bool withPredError = false) const override;
 };
 
 }

--- a/RecoVertex/GhostTrackFitter/interface/PositiveSideGhostTrackFitter.h
+++ b/RecoVertex/GhostTrackFitter/interface/PositiveSideGhostTrackFitter.h
@@ -19,7 +19,7 @@ class PositiveSideGhostTrackFitter : public GhostTrackFitter::FitterImpl {
 			const GlobalPoint &origin,
 			const GhostTrackFitter::FitterImpl &actualFitter) :
 		origin_(origin), actualFitter_(actualFitter.clone()) {}
-	~PositiveSideGhostTrackFitter() {}
+	~PositiveSideGhostTrackFitter() override {}
 
 	PositiveSideGhostTrackFitter(
 				const PositiveSideGhostTrackFitter &orig) :
@@ -30,10 +30,10 @@ class PositiveSideGhostTrackFitter : public GhostTrackFitter::FitterImpl {
 			const GhostTrackFitter::PredictionUpdater &updater,
 			const GhostTrackPrediction &prior,
 			std::vector<GhostTrackState> &states,
-			double &ndof, double &chi2);
+			double &ndof, double &chi2) override;
 
     private:
-	virtual FitterImpl *clone() const
+	FitterImpl *clone() const override
 	{ return new PositiveSideGhostTrackFitter(*this); }
 
 	GlobalPoint					origin_;

--- a/RecoVertex/GhostTrackFitter/interface/SequentialGhostTrackFitter.h
+++ b/RecoVertex/GhostTrackFitter/interface/SequentialGhostTrackFitter.h
@@ -13,13 +13,13 @@ class GhostTrackState;
 class SequentialGhostTrackFitter : public GhostTrackFitter::FitterImpl {
     public:
 	SequentialGhostTrackFitter();
-	~SequentialGhostTrackFitter() {}
+	~SequentialGhostTrackFitter() override {}
 
 	GhostTrackPrediction fit(
 			const GhostTrackFitter::PredictionUpdater &updater,
 			const GhostTrackPrediction &prior,
 			std::vector<GhostTrackState> &states,
-			double &ndof, double &chi2);
+			double &ndof, double &chi2) override;
 
     protected:
 	virtual bool stable(const GhostTrackPrediction &before,
@@ -31,7 +31,7 @@ class SequentialGhostTrackFitter : public GhostTrackFitter::FitterImpl {
 			std::vector<GhostTrackState> &states) {}
 
     private:
-	virtual FitterImpl *clone() const
+	FitterImpl *clone() const override
 	{ return new SequentialGhostTrackFitter(*this); }
 
 	unsigned int	maxIteration;

--- a/RecoVertex/GhostTrackFitter/interface/TrackGhostTrackState.h
+++ b/RecoVertex/GhostTrackFitter/interface/TrackGhostTrackState.h
@@ -23,27 +23,27 @@ class TrackGhostTrackState : public BasicGhostTrackState {
 	const TransientTrack &track() const { return track_; }
 	const TrajectoryStateOnSurface &tsos() const { return tsos_; }
 
-	bool isValid() const { return tsos_.isValid(); }
+	bool isValid() const override { return tsos_.isValid(); }
 
-	GlobalPoint globalPosition() const
+	GlobalPoint globalPosition() const override
 	{ return tsos_.globalPosition(); }
-	GlobalError cartesianError() const
+	GlobalError cartesianError() const override
 	{ return tsos_.cartesianError().position(); }
-	CovarianceMatrix cartesianCovariance() const
+	CovarianceMatrix cartesianCovariance() const override
 	{ return tsos_.cartesianError().matrix().Sub<CovarianceMatrix>(0, 0); }
 
-	void reset() { tsos_ = TrajectoryStateOnSurface(); }
+	void reset() override { tsos_ = TrajectoryStateOnSurface(); }
 	bool linearize(const GhostTrackPrediction &pred,
-	               bool initial, double lambda);
-	bool linearize(const GhostTrackPrediction &pred, double lambda);
+	               bool initial, double lambda) override;
+	bool linearize(const GhostTrackPrediction &pred, double lambda) override;
 
 	Vertex vertexStateOnGhostTrack(const GhostTrackPrediction &pred,
-	                               bool withMeasurementError) const;
+	                               bool withMeasurementError) const override;
 	Vertex vertexStateOnMeasurement(const GhostTrackPrediction &pred,
-	                                bool withGhostTrackError) const;
+	                                bool withGhostTrackError) const override;
 
     private:
-	BasicGhostTrackState *clone() const
+	BasicGhostTrackState *clone() const override
 	{ return new TrackGhostTrackState(*this); }
 
 	TrajectoryStateOnSurface	tsos_;

--- a/RecoVertex/GhostTrackFitter/interface/VertexGhostTrackState.h
+++ b/RecoVertex/GhostTrackFitter/interface/VertexGhostTrackState.h
@@ -18,17 +18,17 @@ class VertexGhostTrackState : public BasicGhostTrackState {
 	                      const CovarianceMatrix &cov) :
 		position_(pos), covariance_(cov) {}
 
-	GlobalPoint globalPosition() const { return position_; }
-	GlobalError cartesianError() const { return covariance_; }
-	CovarianceMatrix cartesianCovariance() const { return covariance_; }
+	GlobalPoint globalPosition() const override { return position_; }
+	GlobalError cartesianError() const override { return covariance_; }
+	CovarianceMatrix cartesianCovariance() const override { return covariance_; }
 
 	Vertex vertexStateOnGhostTrack(const GhostTrackPrediction &pred,
-	                               bool withMeasurementError) const;
+	                               bool withMeasurementError) const override;
 	Vertex vertexStateOnMeasurement(const GhostTrackPrediction &pred,
-	                                bool withGhostTrackError) const;
+	                                bool withGhostTrackError) const override;
 
     private:
-	BasicGhostTrackState *clone() const
+	BasicGhostTrackState *clone() const override
 	{ return new VertexGhostTrackState(*this); }
 
 	GlobalPoint		position_;

--- a/RecoVertex/GhostTrackFitter/src/GhostTrackPrediction.cc
+++ b/RecoVertex/GhostTrackFitter/src/GhostTrackPrediction.cc
@@ -144,7 +144,7 @@ GhostTrackPrediction::GhostTrackPrediction(const Track &track) :
 			    GlobalTrajectoryParameters(
 						       GlobalPoint(track.vx(), track.vy(), track.vz()),
 						       GlobalVector(track.px(), track.py(), track.pz()),
-						       0, 0))),
+						       0, nullptr))),
 	covariance_(convert(prediction_, track.covariance()))
 {
 }

--- a/RecoVertex/GhostTrackFitter/src/GhostTrackState.cc
+++ b/RecoVertex/GhostTrackFitter/src/GhostTrackState.cc
@@ -57,12 +57,12 @@ GhostTrackState::GhostTrackState(const VertexState &state) :
 
 bool GhostTrackState::isTrack() const
 {
-	return dynamic_cast<const TrackGhostTrackState*>(&data()) != 0;
+	return dynamic_cast<const TrackGhostTrackState*>(&data()) != nullptr;
 }
 
 bool GhostTrackState::isVertex() const
 {
-	return dynamic_cast<const VertexGhostTrackState*>(&data()) != 0;
+	return dynamic_cast<const VertexGhostTrackState*>(&data()) != nullptr;
 }
 
 static const TrackGhostTrackState *getTrack(const BasicGhostTrackState *basic)

--- a/RecoVertex/GhostTrackFitter/src/GhostTrackVertexFinder.cc
+++ b/RecoVertex/GhostTrackFitter/src/GhostTrackVertexFinder.cc
@@ -94,7 +94,7 @@ struct GhostTrackVertexFinder::FinderInfo {
 		primaryVertex(primaryVertex), pred(ghostTrack.prediction()),
 		prior(ghostTrack.prior()), states(ghostTrack.states()),
 		beamSpot(beamSpot), hasBeamSpot(hasBeamSpot),
-		hasPrimaries(hasPrimaries), field(0) {}
+		hasPrimaries(hasPrimaries), field(nullptr) {}
 
 	const CachingVertex<5>			&primaryVertex;
 	GhostTrackPrediction			pred;
@@ -178,7 +178,7 @@ static CachingVertex<5> vertexAtState(const TransientTrack &ghostTrack,
 
 	GlobalPoint point = vtxMean(pca1, err1, pca2, err2);
 
-	TransientTrack recTrack = state.track();
+	const TransientTrack& recTrack = state.track();
 
 	RefCountedLinearizedTrackState linState[2] = {
 		linTrackFactory.linearizedTrackState(point, ghostTrack),

--- a/RecoVertex/KalmanVertexFit/interface/KalmanSmoothedVertexChi2Estimator.h
+++ b/RecoVertex/KalmanVertexFit/interface/KalmanSmoothedVertexChi2Estimator.h
@@ -17,16 +17,16 @@ public:
 
   typedef typename std::pair<bool, double> BDpair;
 
-  virtual ~KalmanSmoothedVertexChi2Estimator() {}
+  ~KalmanSmoothedVertexChi2Estimator() override {}
 
   /**
    *  Methode which calculates the smoothed vertex chi**2.
    *  \param vertex is the final estimate of the vertex, with the refited tracks
    *  \return the smoothed vertex chi**2
    */
-  BDpair estimate(const CachingVertex<N> & vertex) const;
+  BDpair estimate(const CachingVertex<N> & vertex) const override;
    
-  KalmanSmoothedVertexChi2Estimator * clone() const 
+  KalmanSmoothedVertexChi2Estimator * clone() const override 
   {
    return new KalmanSmoothedVertexChi2Estimator(* this);
   }

--- a/RecoVertex/KalmanVertexFit/interface/KalmanTrackToTrackCovCalculator.h
+++ b/RecoVertex/KalmanVertexFit/interface/KalmanTrackToTrackCovCalculator.h
@@ -26,9 +26,9 @@ public:
    * \return The map containing the covariance matrices.
    */
 
- typename CachingVertex<N>::TrackToTrackMap operator() (const CachingVertex<N> & vertex) const;
+ typename CachingVertex<N>::TrackToTrackMap operator() (const CachingVertex<N> & vertex) const override;
  
- KalmanTrackToTrackCovCalculator * clone() const
+ KalmanTrackToTrackCovCalculator * clone() const override
  {
    return new KalmanTrackToTrackCovCalculator(* this);
  }

--- a/RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h
+++ b/RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h
@@ -39,12 +39,12 @@ public:
   KalmanVertexFitter(const KalmanVertexFitter & other ) :
     theSequentialFitter ( other.theSequentialFitter->clone() ) {}
 
-  virtual ~KalmanVertexFitter()
+  ~KalmanVertexFitter() override
   {
     delete theSequentialFitter;
   }
 
-  KalmanVertexFitter * clone() const
+  KalmanVertexFitter * clone() const override
   {
     return new KalmanVertexFitter(* this);
   }
@@ -55,23 +55,23 @@ public:
 
   /** Fit vertex out of a set of RecTracks
    */
-  virtual inline CachingVertex<5> 
-    vertex(const std::vector<reco::TransientTrack>  & tracks) const
+  inline CachingVertex<5> 
+    vertex(const std::vector<reco::TransientTrack>  & tracks) const override
   {
     return theSequentialFitter->vertex(tracks);
   }
 
   /** Fit vertex out of a set of VertexTracks
    */
-  virtual inline CachingVertex<5> 
-  vertex(const std::vector<RefCountedVertexTrack> & tracks) const
+  inline CachingVertex<5> 
+  vertex(const std::vector<RefCountedVertexTrack> & tracks) const override
   {
     return theSequentialFitter->vertex(tracks);
   }
   
-  virtual inline CachingVertex<5> 
+  inline CachingVertex<5> 
   vertex(const std::vector<RefCountedVertexTrack> & tracks,
-      const reco::BeamSpot & spot ) const
+      const reco::BeamSpot & spot ) const override
   {
     return theSequentialFitter->vertex(tracks, spot );
   }
@@ -80,9 +80,9 @@ public:
   /** Fit vertex out of a set of RecTracks. 
    *  Uses the specified linearization point.
    */
-  virtual inline CachingVertex<5> 
+  inline CachingVertex<5> 
     vertex(const std::vector<reco::TransientTrack>  & tracks, 
-	   const GlobalPoint& linPoint) const
+	   const GlobalPoint& linPoint) const override
   {
     return theSequentialFitter->vertex(tracks, linPoint);
   }
@@ -92,10 +92,10 @@ public:
    *  estimate of the vertex position. The error is used for the 
    *  weight of the prior estimate.
    */
-  virtual inline CachingVertex<5> 
+  inline CachingVertex<5> 
   vertex(const std::vector<reco::TransientTrack> & tracks, 
 	 const GlobalPoint& priorPos,
-  	 const GlobalError& priorError) const
+  	 const GlobalError& priorError) const override
   {
     return theSequentialFitter->vertex(tracks, priorPos, priorError);
   }
@@ -104,8 +104,8 @@ public:
    *  The specified BeamSpot will be used as priot, but NOT for the linearization.
    * The specified LinearizationPointFinder will be used to find the linearization point.
    */
-  virtual inline CachingVertex<5> 
-  vertex(const std::vector<reco::TransientTrack> & tracks, const reco::BeamSpot& beamSpot) const
+  inline CachingVertex<5> 
+  vertex(const std::vector<reco::TransientTrack> & tracks, const reco::BeamSpot& beamSpot) const override
   {
     return theSequentialFitter->vertex(tracks, beamSpot);
   }
@@ -116,10 +116,10 @@ public:
    *  Uses the specified point and error as the prior estimate of the vertex.
    *  This position is not used to relinearize the tracks.
    */
-  virtual inline CachingVertex<5> 
+  inline CachingVertex<5> 
   vertex(const std::vector<RefCountedVertexTrack> & tracks, 
 	 const GlobalPoint& priorPos,
-	 const GlobalError& priorError) const
+	 const GlobalError& priorError) const override
   {
     return theSequentialFitter->vertex(tracks, priorPos, priorError);
   }

--- a/RecoVertex/KalmanVertexFit/interface/KalmanVertexTrackCompatibilityEstimator.h
+++ b/RecoVertex/KalmanVertexFit/interface/KalmanVertexTrackCompatibilityEstimator.h
@@ -34,7 +34,7 @@ public:
 
   KalmanVertexTrackCompatibilityEstimator(){}
 
-  virtual ~KalmanVertexTrackCompatibilityEstimator(){}
+  ~KalmanVertexTrackCompatibilityEstimator() override{}
 
   /**
    * Track-to-vertex compatibility. 
@@ -44,17 +44,17 @@ public:
    * \return The chi**2.
    */
 
-  virtual BDpair estimate(const CachingVertex<N> & vrt, const RefCountedVertexTrack track,
-			  unsigned int hint=UINT_MAX) const;
+  BDpair estimate(const CachingVertex<N> & vrt, const RefCountedVertexTrack track,
+			  unsigned int hint=UINT_MAX) const override;
 
-  virtual BDpair estimate(const CachingVertex<N> & v, 
+  BDpair estimate(const CachingVertex<N> & v, 
 			  const RefCountedLinearizedTrackState track,
-			  unsigned int hint=UINT_MAX) const;
+			  unsigned int hint=UINT_MAX) const override;
 
-  virtual BDpair estimate(const reco::Vertex & vertex, 
-			 const reco::TransientTrack & track) const;
+  BDpair estimate(const reco::Vertex & vertex, 
+			 const reco::TransientTrack & track) const override;
 
-  virtual KalmanVertexTrackCompatibilityEstimator<N> * clone() const
+  KalmanVertexTrackCompatibilityEstimator<N> * clone() const override
   {
     return new KalmanVertexTrackCompatibilityEstimator(* this);
   }

--- a/RecoVertex/KalmanVertexFit/interface/KalmanVertexTrackUpdator.h
+++ b/RecoVertex/KalmanVertexFit/interface/KalmanVertexTrackUpdator.h
@@ -29,7 +29,7 @@ public:
 
   KalmanVertexTrackUpdator(){}
 
-  virtual ~KalmanVertexTrackUpdator(){}
+  ~KalmanVertexTrackUpdator() override{}
 
   /**
    *   Refit of the track with the vertex constraint.
@@ -40,14 +40,14 @@ public:
    */
 
   RefCountedVertexTrack update(const CachingVertex<N> & vertex,
-                               RefCountedVertexTrack track) const;
+                               RefCountedVertexTrack track) const override;
 
 
   /**
    *  Clone method
    */
 
-  KalmanVertexTrackUpdator<N> * clone() const
+  KalmanVertexTrackUpdator<N> * clone() const override
   {
     return new KalmanVertexTrackUpdator(*this);
   }

--- a/RecoVertex/KalmanVertexFit/interface/KalmanVertexUpdator.h
+++ b/RecoVertex/KalmanVertexFit/interface/KalmanVertexUpdator.h
@@ -23,7 +23,7 @@ public:
  */
 
    CachingVertex<N> add(const CachingVertex<N> & oldVertex,
-        const RefCountedVertexTrack track) const;
+        const RefCountedVertexTrack track) const override;
 
 /**
  *  Method removing already used VertexTrack from existing CachingVertex
@@ -31,13 +31,13 @@ public:
  */
 
    CachingVertex<N> remove(const CachingVertex<N> & oldVertex,
-        const RefCountedVertexTrack track) const;
+        const RefCountedVertexTrack track) const override;
 
 /**
  * Clone method
  */
 
-   VertexUpdator<N> * clone() const
+   VertexUpdator<N> * clone() const override
    {
     return new KalmanVertexUpdator(* this);
    }

--- a/RecoVertex/KalmanVertexFit/interface/SimpleVertexTree.h
+++ b/RecoVertex/KalmanVertexFit/interface/SimpleVertexTree.h
@@ -47,7 +47,7 @@ public:
    */
 
   SimpleVertexTree(const char * fitterName = "VertexFitter",
-  		   const MagneticField * magField = 0);
+  		   const MagneticField * magField = nullptr);
   virtual ~SimpleVertexTree();
 
   /**
@@ -56,11 +56,11 @@ public:
    * Timing information for the fit can also be provided.
    */
 
-  void fill(const TransientVertex & recv, const TrackingVertex *simv = 0, 
-  	    reco::RecoToSimCollection *recSimColl = 0,
+  void fill(const TransientVertex & recv, const TrackingVertex *simv = nullptr, 
+  	    reco::RecoToSimCollection *recSimColl = nullptr,
   	    const float &time = 0.);
 
-  void fill(const TransientVertex & recv, const TrackingVertex *simv = 0,
+  void fill(const TransientVertex & recv, const TrackingVertex *simv = nullptr,
   	    const float &time = 0.);
 
   /**

--- a/RecoVertex/KalmanVertexFit/interface/VertexFitterResult.h
+++ b/RecoVertex/KalmanVertexFit/interface/VertexFitterResult.h
@@ -28,16 +28,16 @@ public:
 //   typedef std::vector<const TkSimTrack*>	SimTrackCont;
   typedef std::vector<reco::TransientTrack>		TTrackCont;
 
-  VertexFitterResult(const int maxTracks = 100, const MagneticField* = 0);
+  VertexFitterResult(const int maxTracks = 100, const MagneticField* = nullptr);
   ~VertexFitterResult();
 
-  void fill(const TransientVertex & recv, const TrackingVertex * simv = 0, 
-  	    reco::RecoToSimCollection *recSimColl = 0,
+  void fill(const TransientVertex & recv, const TrackingVertex * simv = nullptr, 
+  	    reco::RecoToSimCollection *recSimColl = nullptr,
   	    const float &time = 0);
 
   void fill(const TransientVertex & recVertex, const TTrackCont & recTrackV,
-	    const TrackingVertex * simv = 0, 
-      	    reco::RecoToSimCollection *recSimColl = 0, const float &time = 0);
+	    const TrackingVertex * simv = nullptr, 
+      	    reco::RecoToSimCollection *recSimColl = nullptr, const float &time = 0);
 
 
   const float* simVertexPos() const {return simPos;}
@@ -57,27 +57,27 @@ public:
   const float* recTrackWeight() {return trackWeight;}
   const float* recParameters (const int i) const
   {
-    if ( i<0 || i>=5 )  return 0;
+    if ( i<0 || i>=5 )  return nullptr;
     return recPars[i];
   }
   const float* refParameters (const int i) const
   {
-    if ( i<0 || i>=5 )  return 0;
+    if ( i<0 || i>=5 )  return nullptr;
     return refPars[i];
   }
   const float* simParameters (const int i) const
   {
-    if ( i<0 || i>=5 )  return 0;
+    if ( i<0 || i>=5 )  return nullptr;
     return simPars[i];
   }
   const float* recErrors (const int i) const
   {
-    if ( i<0 || i>=5 )  return 0;
+    if ( i<0 || i>=5 )  return nullptr;
     return recErrs[i];
   }
   const float* refErrors (const int i) const
   {
-    if ( i<0 || i>=5 )  return 0;
+    if ( i<0 || i>=5 )  return nullptr;
     return refErrs[i];
   }
 

--- a/RecoVertex/KalmanVertexFit/plugins/KVFTest.h
+++ b/RecoVertex/KalmanVertexFit/plugins/KVFTest.h
@@ -37,12 +37,12 @@
 class KVFTest : public edm::EDAnalyzer {
 public:
   explicit KVFTest(const edm::ParameterSet&);
-  ~KVFTest();
+  ~KVFTest() override;
   
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  virtual void beginJob();
-  virtual void endJob();
+  void beginJob() override;
+  void endJob() override;
 
 private:
 

--- a/RecoVertex/KalmanVertexFit/plugins/KVFTrackUpdate.h
+++ b/RecoVertex/KalmanVertexFit/plugins/KVFTrackUpdate.h
@@ -20,12 +20,12 @@
 class KVFTrackUpdate : public edm::EDAnalyzer {
 public:
   explicit KVFTrackUpdate(const edm::ParameterSet&);
-  ~KVFTrackUpdate();
+  ~KVFTrackUpdate() override;
   
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  virtual void beginJob();
-  virtual void endJob();
+  void beginJob() override;
+  void endJob() override;
 
 private:
 

--- a/RecoVertex/KalmanVertexFit/src/KalmanVertexTrackCompatibilityEstimator.cc
+++ b/RecoVertex/KalmanVertexFit/src/KalmanVertexTrackCompatibilityEstimator.cc
@@ -15,7 +15,7 @@ KalmanVertexTrackCompatibilityEstimator<N>::estimate(const CachingVertex<N> & ve
 
   const std::vector<RefCountedVertexTrack> &tracks = vertex.tracksRef();
 
-  if ( tracks.size()==0)
+  if ( tracks.empty())
    return estimateNFittedTrack(vertex,tr);
 
   if (hint<tracks.size() ) {

--- a/RecoVertex/KalmanVertexFit/src/SimpleVertexTree.cc
+++ b/RecoVertex/KalmanVertexFit/src/SimpleVertexTree.cc
@@ -139,13 +139,13 @@ void SimpleVertexTree::fill(const TransientVertex & recv, const TrackingVertex *
 
 void SimpleVertexTree::fill(const TransientVertex & recv, const float &time) 
 {
-  result->fill(recv, 0, 0, time);
+  result->fill(recv, nullptr, nullptr, time);
   fill();
 }
 
 void SimpleVertexTree::fill(const TrackingVertex * simv) 
 {
-  result->fill(TransientVertex(), simv, 0);
+  result->fill(TransientVertex(), simv, nullptr);
   fill();
 }
 

--- a/RecoVertex/KalmanVertexFit/src/VertexFitterResult.cc
+++ b/RecoVertex/KalmanVertexFit/src/VertexFitterResult.cc
@@ -20,11 +20,11 @@ VertexFitterResult::VertexFitterResult(const int maxTracks, const MagneticField*
       refErrs[i] = new float[maxTracks];
     }
     else {
-      simPars[i] = 0;
-      recPars[i] = 0;
-      refPars[i] = 0;
-      recErrs[i] = 0;
-      refErrs[i] = 0;
+      simPars[i] = nullptr;
+      recPars[i] = nullptr;
+      refPars[i] = nullptr;
+      recErrs[i] = nullptr;
+      refErrs[i] = nullptr;
     }
   }
   trackWeight = new float[maxTracks];
@@ -87,7 +87,7 @@ void VertexFitterResult::fill(const TransientVertex & recVertex,
     tracks[1] = recVertex.originalTracks().size();
   }
 
-  if (simv!=0) {
+  if (simv!=nullptr) {
     simPos[0] = simv->position().x();
     simPos[1] = simv->position().y();
     simPos[2] = simv->position().z();
@@ -129,7 +129,7 @@ void VertexFitterResult::fill(const TransientVertex & recVertex,
     std::vector<std::pair<TrackingParticleRef, double> > simFound;
     try {
       const TrackTransientTrack* ttt = dynamic_cast<const TrackTransientTrack*>(recTrack->basicTransientTrack());
-      if ((ttt!=0) && (recSimColl!=0)) simFound = (*recSimColl)[ttt->trackBaseRef()];
+      if ((ttt!=nullptr) && (recSimColl!=nullptr)) simFound = (*recSimColl)[ttt->trackBaseRef()];
 //       if (recSimColl!=0) simFound = (*recSimColl)[recTrack->persistentTrackRef()];
 //      if (recSimColl!=0) simFound = (*recSimColl)[recTrack];
 
@@ -139,7 +139,7 @@ void VertexFitterResult::fill(const TransientVertex & recVertex,
 //       edm::LogError("TrackValidator") << e.what() << "\n";
     }
 
-    if(simFound.size() != 0) {
+    if(!simFound.empty()) {
       //OK, it was associated, so get the state on the same surface as the 'SimState'
       TrackingParticleRefVector::const_iterator simTrackI = 
 	find(simTrackV.begin(), simTrackV.end(), simFound[0].first);

--- a/RecoVertex/KinematicFit/interface/BackToBackKinematicConstraint.h
+++ b/RecoVertex/KinematicFit/interface/BackToBackKinematicConstraint.h
@@ -24,30 +24,30 @@ public:
 
  BackToBackKinematicConstraint() {}
  
- ~BackToBackKinematicConstraint() {}
+ ~BackToBackKinematicConstraint() override {}
 
 /**
  * Derivatives and value calculated at given expansion point
  * Vector should always be of size 14 (2 particles)
  */
-virtual std::pair<AlgebraicVector, AlgebraicVector> value(const AlgebraicVector& exPoint) const;
+std::pair<AlgebraicVector, AlgebraicVector> value(const AlgebraicVector& exPoint) const override;
 
-virtual std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const AlgebraicVector& exPoint) const;
+std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const AlgebraicVector& exPoint) const override;
 
 /**
  * Derivatives and values calculated at expansion point, taken
  * at current state of input particles. Number of input particles
  * should be always equal to 2
  */
-virtual std::pair<AlgebraicVector, AlgebraicVector> value(const std::vector<RefCountedKinematicParticle> &par) const;
+std::pair<AlgebraicVector, AlgebraicVector> value(const std::vector<RefCountedKinematicParticle> &par) const override;
 
-virtual std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const std::vector<RefCountedKinematicParticle> &par) const;
+std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const std::vector<RefCountedKinematicParticle> &par) const override;
 
-virtual AlgebraicVector deviations(int nStates) const;
+AlgebraicVector deviations(int nStates) const override;
 
-virtual int numberOfEquations() const;
+int numberOfEquations() const override;
 
-virtual KinematicConstraint * clone() const;
+KinematicConstraint * clone() const override;
 
 private:
 

--- a/RecoVertex/KinematicFit/interface/ColinearityKinematicConstraint.h
+++ b/RecoVertex/KinematicFit/interface/ColinearityKinematicConstraint.h
@@ -27,8 +27,8 @@ public:
  * equations at the point where the input
  * particles are defined.
  */
-virtual AlgebraicVector  value(const std::vector<KinematicState> &states,
-                        const GlobalPoint& point) const;
+AlgebraicVector  value(const std::vector<KinematicState> &states,
+                        const GlobalPoint& point) const override;
 
 
 /**
@@ -36,23 +36,23 @@ virtual AlgebraicVector  value(const std::vector<KinematicState> &states,
  * constraint equations w.r.t. 
  * particle parameters
  */
-virtual AlgebraicMatrix parametersDerivative(const std::vector<KinematicState> &states,
-                                      const GlobalPoint& point) const;
+AlgebraicMatrix parametersDerivative(const std::vector<KinematicState> &states,
+                                      const GlobalPoint& point) const override;
 
 /**
  * Returns a matrix of derivatives of
  * constraint equations w.r.t. 
  * vertex position
  */
-virtual AlgebraicMatrix positionDerivative(const std::vector<KinematicState> &states,
-                                    const GlobalPoint& point) const;
+AlgebraicMatrix positionDerivative(const std::vector<KinematicState> &states,
+                                    const GlobalPoint& point) const override;
 
 /**
  * Number of equations per track used for the fit
  */
-virtual int numberOfEquations() const {return size;}
+int numberOfEquations() const override {return size;}
  
-virtual ColinearityKinematicConstraint * clone()const
+ColinearityKinematicConstraint * clone()const override
   {return new ColinearityKinematicConstraint(*this);}
 
 private:

--- a/RecoVertex/KinematicFit/interface/CombinedKinematicConstraint.h
+++ b/RecoVertex/KinematicFit/interface/CombinedKinematicConstraint.h
@@ -21,7 +21,7 @@ class CombinedKinematicConstraint : public MultiTrackKinematicConstraint{
 	
 public:
 	CombinedKinematicConstraint(const std::vector<MultiTrackKinematicConstraint* > &constraintVector):constraints(constraintVector){
-		if(constraints.size()<1) throw VertexException("CombinedKinematicConstraint::<1 constraints passed.");
+		if(constraints.empty()) throw VertexException("CombinedKinematicConstraint::<1 constraints passed.");
 	}
 	
 	/**
@@ -29,28 +29,28 @@ public:
 	 * equations at the point where the input
 	 * particles are defined.
 	 */
-	virtual AlgebraicVector  value(const std::vector<KinematicState> &states, const GlobalPoint& point) const;
+	AlgebraicVector  value(const std::vector<KinematicState> &states, const GlobalPoint& point) const override;
 	
 	/**
 	 * Returns a matrix of derivatives of the combined
 	 * constraint equations w.r.t. 
 	 * particle parameters
 	 */
-	virtual AlgebraicMatrix parametersDerivative(const std::vector<KinematicState> &states, const GlobalPoint& point) const;
+	AlgebraicMatrix parametersDerivative(const std::vector<KinematicState> &states, const GlobalPoint& point) const override;
 	
 	/**
 	 * Returns a matrix of derivatives of
 	 * constraint equations w.r.t. 
 	 * vertex position
 	 */
-	virtual AlgebraicMatrix positionDerivative(const std::vector<KinematicState> &states, const GlobalPoint& point) const;
+	AlgebraicMatrix positionDerivative(const std::vector<KinematicState> &states, const GlobalPoint& point) const override;
 	
 	/**
 	 * Number of equations per track used for the combined fit
 	 */
-	virtual int numberOfEquations() const;
+	int numberOfEquations() const override;
 	
-	virtual CombinedKinematicConstraint * clone()const
+	CombinedKinematicConstraint * clone()const override
 	{
 		return new CombinedKinematicConstraint(*this);
 	}

--- a/RecoVertex/KinematicFit/interface/ConstrainedTreeBuilderT.h
+++ b/RecoVertex/KinematicFit/interface/ConstrainedTreeBuilderT.h
@@ -173,7 +173,7 @@ ConstrainedTreeBuilderT::buildTree(const std::vector<RefCountedKinematicParticle
  //newborn kinematic particle
   float chi2 = vertex->chiSquared();
   float ndf = vertex->degreesOfFreedom();
-  KinematicParticle * zp = 0;
+  KinematicParticle * zp = nullptr;
   RefCountedKinematicParticle virtualParticle = pFactory.particle(nState,chi2,ndf,zp);
 
   return buildRealTree(virtualParticle, vertex, rParticles);

--- a/RecoVertex/KinematicFit/interface/FourMomentumKinematicConstraint.h
+++ b/RecoVertex/KinematicFit/interface/FourMomentumKinematicConstraint.h
@@ -31,29 +31,29 @@ public:
  * Vector of values and  matrix of derivatives
  * calculated at given  7*NumberOfStates expansion point
  */  
-virtual std::pair<AlgebraicVector,AlgebraicVector> value(const AlgebraicVector& exPoint) const;
+std::pair<AlgebraicVector,AlgebraicVector> value(const AlgebraicVector& exPoint) const override;
  
-virtual std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const AlgebraicVector& exPoint) const;
+std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const AlgebraicVector& exPoint) const override;
 
 
 /**
  * Vector of values and matrix of derivatives calculated using 
  * current state as an expansion point
  */  
-virtual std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const std::vector<RefCountedKinematicParticle> &par) const;
+std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const std::vector<RefCountedKinematicParticle> &par) const override;
 
-virtual std::pair<AlgebraicVector, AlgebraicVector> value(const std::vector<RefCountedKinematicParticle> &par) const;
+std::pair<AlgebraicVector, AlgebraicVector> value(const std::vector<RefCountedKinematicParticle> &par) const override;
 
  
 /**
  * Returns number of constraint equations used for fitting. Method is relevant for proper NDF
  * calculations.
  */ 
-virtual int numberOfEquations() const;
+int numberOfEquations() const override;
 
-virtual AlgebraicVector deviations(int nStates) const;
+AlgebraicVector deviations(int nStates) const override;
 
-virtual FourMomentumKinematicConstraint * clone() const
+FourMomentumKinematicConstraint * clone() const override
  {return new FourMomentumKinematicConstraint(*this);}
 
 private:

--- a/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexFitter.h
+++ b/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexFitter.h
@@ -46,7 +46,7 @@ public:
  * vertex fit using LMS with Lagrange multipliers method.
  */  
  RefCountedKinematicTree fit(const std::vector<RefCountedKinematicParticle> &part) {
-   return fit(part, 0, 0);
+   return fit(part, nullptr, nullptr);
  }
 
 /**
@@ -54,7 +54,7 @@ public:
  */  
  RefCountedKinematicTree fit(const std::vector<RefCountedKinematicParticle> &part,
                             MultiTrackKinematicConstraint * cs) {
-   return fit(part, cs, 0);
+   return fit(part, cs, nullptr);
  };
     
 /**

--- a/RecoVertex/KinematicFit/interface/LagrangeChildUpdator.h
+++ b/RecoVertex/KinematicFit/interface/LagrangeChildUpdator.h
@@ -15,13 +15,13 @@ class LagrangeChildUpdator:public ChildUpdator
 public:
 
  LagrangeChildUpdator(){}
- ~LagrangeChildUpdator(){}
+ ~LagrangeChildUpdator() override{}
  
- RefCountedKinematicTree  update(RefCountedKinematicTree tree) const;
+ RefCountedKinematicTree  update(RefCountedKinematicTree tree) const override;
  
- std::vector<RefCountedKinematicTree>  update(const std::vector<RefCountedKinematicTree> & trees) const;
+ std::vector<RefCountedKinematicTree>  update(const std::vector<RefCountedKinematicTree> & trees) const override;
  
- LagrangeChildUpdator * clone() const
+ LagrangeChildUpdator * clone() const override
  {return new LagrangeChildUpdator(*this);}
  
 private:

--- a/RecoVertex/KinematicFit/interface/LagrangeParentParticleFitter.h
+++ b/RecoVertex/KinematicFit/interface/LagrangeParentParticleFitter.h
@@ -22,7 +22,7 @@ public:
 
  LagrangeParentParticleFitter();
 
- ~LagrangeParentParticleFitter(){}
+ ~LagrangeParentParticleFitter() override{}
 
   /**
    * Configuration through PSet: number of iterations(maxDistance) and
@@ -39,9 +39,9 @@ public:
  * constraints may not work with single tracks (back to back for ex.)
  */
  std::vector<RefCountedKinematicTree>  fit(const std::vector<RefCountedKinematicTree> & trees,
-                                             KinematicConstraint * cs)const;
+                                             KinematicConstraint * cs)const override;
 
- LagrangeParentParticleFitter * clone() const
+ LagrangeParentParticleFitter * clone() const override
  {return new LagrangeParentParticleFitter(*this);}
 
 private:

--- a/RecoVertex/KinematicFit/interface/MassKinematicConstraint.h
+++ b/RecoVertex/KinematicFit/interface/MassKinematicConstraint.h
@@ -29,28 +29,28 @@ public:
  * Vector of values and matrix of derivatives
  * calculated at given 7xNumberOfStates point
  */ 
-virtual std::pair<AlgebraicVector,AlgebraicVector> value(const AlgebraicVector& exPoint) const;
+std::pair<AlgebraicVector,AlgebraicVector> value(const AlgebraicVector& exPoint) const override;
 
-virtual std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const AlgebraicVector& exPoint) const;
+std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const AlgebraicVector& exPoint) const override;
 
 /**
  * Vector of values and  matrix of derivatives calculated 
  * using current state parameters as expansion point
  */
-virtual std::pair<AlgebraicVector, AlgebraicVector> value(const std::vector<RefCountedKinematicParticle> &par) const;
+std::pair<AlgebraicVector, AlgebraicVector> value(const std::vector<RefCountedKinematicParticle> &par) const override;
 
-virtual std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const std::vector<RefCountedKinematicParticle> &par) const;
+std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const std::vector<RefCountedKinematicParticle> &par) const override;
 
 /**
  * Returns number of constraint equations used
  * for fitting. Method is relevant for proper NDF
  * calculations.
  */ 
-virtual int numberOfEquations() const;
+int numberOfEquations() const override;
 
-virtual AlgebraicVector deviations(int nStates) const;
+AlgebraicVector deviations(int nStates) const override;
 
-virtual MassKinematicConstraint * clone() const
+MassKinematicConstraint * clone() const override
  {return new MassKinematicConstraint(*this);}
 
 private:

--- a/RecoVertex/KinematicFit/interface/MomentumKinematicConstraint.h
+++ b/RecoVertex/KinematicFit/interface/MomentumKinematicConstraint.h
@@ -29,27 +29,27 @@ MomentumKinematicConstraint(const AlgebraicVector& momentum,
  * Vector of values and  matrix of derivatives
  * calculated at given expansion 7xNumberOfStates point
  */ 
-virtual std::pair<AlgebraicVector,AlgebraicVector> value(const AlgebraicVector& exPoint) const;
+std::pair<AlgebraicVector,AlgebraicVector> value(const AlgebraicVector& exPoint) const override;
 
-virtual std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const AlgebraicVector& exPoint) const;
+std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const AlgebraicVector& exPoint) const override;
 
 /**
  * Vector of values and  matrix of derivatives calculated using current
  * state parameters as expansion point
  */
-virtual std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const std::vector<RefCountedKinematicParticle> &par) const;
+std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const std::vector<RefCountedKinematicParticle> &par) const override;
 
-virtual std::pair<AlgebraicVector, AlgebraicVector> value(const std::vector<RefCountedKinematicParticle> &par) const;
+std::pair<AlgebraicVector, AlgebraicVector> value(const std::vector<RefCountedKinematicParticle> &par) const override;
 
-virtual AlgebraicVector deviations(int nStates) const;
+AlgebraicVector deviations(int nStates) const override;
 
 /**
  * Returns number of constraint equations used  for fitting.
  * Method is relevant for proper NDF calculations.
  */ 
-virtual int numberOfEquations() const;
+int numberOfEquations() const override;
 
-virtual MomentumKinematicConstraint * clone() const
+MomentumKinematicConstraint * clone() const override
   {return new MomentumKinematicConstraint(*this);}
 
 private:

--- a/RecoVertex/KinematicFit/interface/MultiTrackMassKinematicConstraint.h
+++ b/RecoVertex/KinematicFit/interface/MultiTrackMassKinematicConstraint.h
@@ -29,8 +29,8 @@ public:
    * equations at the point where the input
    * particles are defined.
    */
-  virtual AlgebraicVector  value(const std::vector<KinematicState> &states,
-                          const GlobalPoint& point) const;
+  AlgebraicVector  value(const std::vector<KinematicState> &states,
+                          const GlobalPoint& point) const override;
 
 
   /**
@@ -38,23 +38,23 @@ public:
    * constraint equations w.r.t.
    * particle parameters
    */
-  virtual AlgebraicMatrix parametersDerivative(const std::vector<KinematicState> &states,
-                                	const GlobalPoint& point) const;
+  AlgebraicMatrix parametersDerivative(const std::vector<KinematicState> &states,
+                                	const GlobalPoint& point) const override;
 
   /**
    * Returns a matrix of derivatives of
    * constraint equations w.r.t.
    * vertex position
    */
-  virtual AlgebraicMatrix positionDerivative(const std::vector<KinematicState> &states,
-                                      const GlobalPoint& point) const;
+  AlgebraicMatrix positionDerivative(const std::vector<KinematicState> &states,
+                                      const GlobalPoint& point) const override;
 
   /**
    * Number of equations per track used for the fit
    */
-  virtual int numberOfEquations() const {return 1;}
+  int numberOfEquations() const override {return 1;}
 
-  virtual MultiTrackMassKinematicConstraint * clone() const
+  MultiTrackMassKinematicConstraint * clone() const override
   {return new MultiTrackMassKinematicConstraint(*this);}
 
 private:

--- a/RecoVertex/KinematicFit/interface/MultiTrackPointingKinematicConstraint.h
+++ b/RecoVertex/KinematicFit/interface/MultiTrackPointingKinematicConstraint.h
@@ -29,28 +29,28 @@ public:
 	 * equations at the point where the input
 	 * particles are defined.
 	 */
-	virtual AlgebraicVector value(const std::vector<KinematicState> &states, const GlobalPoint& point) const;
+	AlgebraicVector value(const std::vector<KinematicState> &states, const GlobalPoint& point) const override;
 	
 	/**
 	 * Returns a matrix of derivatives of
 	 * constraint equations w.r.t. 
 	 * particle parameters
 	 */
-	virtual AlgebraicMatrix parametersDerivative(const std::vector<KinematicState> &states, const GlobalPoint& point) const;
+	AlgebraicMatrix parametersDerivative(const std::vector<KinematicState> &states, const GlobalPoint& point) const override;
 	
 	/**
 	 * Returns a matrix of derivatives of
 	 * constraint equations w.r.t. 
 	 * vertex position
 	 */
-	virtual AlgebraicMatrix positionDerivative(const std::vector<KinematicState> &states, const GlobalPoint& point) const;
+	AlgebraicMatrix positionDerivative(const std::vector<KinematicState> &states, const GlobalPoint& point) const override;
 	
 	/**
 	 * Number of equations per track used for the fit
 	 */
-	virtual int numberOfEquations() const;
+	int numberOfEquations() const override;
 	
-	virtual MultiTrackPointingKinematicConstraint * clone()const
+	MultiTrackPointingKinematicConstraint * clone()const override
 	{
 		return new MultiTrackPointingKinematicConstraint(*this);
 	}

--- a/RecoVertex/KinematicFit/interface/MultiTrackVertexLinkKinematicConstraint.h
+++ b/RecoVertex/KinematicFit/interface/MultiTrackVertexLinkKinematicConstraint.h
@@ -25,28 +25,28 @@ public:
 	 * equations at the point where the input
 	 * particles are defined.
 	 */
-	virtual AlgebraicVector value(const std::vector<KinematicState> &states, const GlobalPoint& point) const;
+	AlgebraicVector value(const std::vector<KinematicState> &states, const GlobalPoint& point) const override;
 	
 	/**
 	 * Returns a matrix of derivatives of
 	 * constraint equations w.r.t. 
 	 * particle parameters
 	 */
-	virtual AlgebraicMatrix parametersDerivative(const std::vector<KinematicState> &states, const GlobalPoint& point) const;
+	AlgebraicMatrix parametersDerivative(const std::vector<KinematicState> &states, const GlobalPoint& point) const override;
 	
 	/**
 	 * Returns a matrix of derivatives of
 	 * constraint equations w.r.t. 
 	 * vertex position
 	 */
-	virtual AlgebraicMatrix positionDerivative(const std::vector<KinematicState> &states, const GlobalPoint& point) const;
+	AlgebraicMatrix positionDerivative(const std::vector<KinematicState> &states, const GlobalPoint& point) const override;
 	
 	/**
 	 * Number of equations per track used for the fit
 	 */
-	virtual int numberOfEquations() const;
+	int numberOfEquations() const override;
 	
-	virtual MultiTrackVertexLinkKinematicConstraint * clone()const
+	MultiTrackVertexLinkKinematicConstraint * clone()const override
 	{
 		return new MultiTrackVertexLinkKinematicConstraint(*this);
 	}

--- a/RecoVertex/KinematicFit/interface/PointingKinematicConstraint.h
+++ b/RecoVertex/KinematicFit/interface/PointingKinematicConstraint.h
@@ -29,28 +29,28 @@ class PointingKinematicConstraint : public KinematicConstraint
  * Vector of values and  matrix of derivatives
  * calculated at given expansion 7xNumberOfStates point
  */ 
- virtual std::pair<AlgebraicVector, AlgebraicVector> value(const AlgebraicVector& exPoint) const;
+ std::pair<AlgebraicVector, AlgebraicVector> value(const AlgebraicVector& exPoint) const override;
 
- virtual std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const AlgebraicVector& exPoint) const;
+ std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const AlgebraicVector& exPoint) const override;
 
 /**
  * Vector of values and  matrix of derivatives calculated using current
  * state parameters as expansion point
  */
- virtual std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const std::vector<RefCountedKinematicParticle> &par) const;
+ std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const std::vector<RefCountedKinematicParticle> &par) const override;
 
- virtual std::pair<AlgebraicVector, AlgebraicVector> value(const std::vector<RefCountedKinematicParticle> &par) const;
+ std::pair<AlgebraicVector, AlgebraicVector> value(const std::vector<RefCountedKinematicParticle> &par) const override;
 
- virtual AlgebraicVector deviations(int nStates) const;
+ AlgebraicVector deviations(int nStates) const override;
 
 /**
  * Returns number of constraint equations used
  * for fitting. Method is relevant for proper NDF
  * calculations.
  */ 
- virtual int numberOfEquations() const;
+ int numberOfEquations() const override;
 
- virtual PointingKinematicConstraint * clone() const
+ PointingKinematicConstraint * clone() const override
  {return new PointingKinematicConstraint(*this);}
  
  private:

--- a/RecoVertex/KinematicFit/interface/SimplePointingConstraint.h
+++ b/RecoVertex/KinematicFit/interface/SimplePointingConstraint.h
@@ -29,28 +29,28 @@ class SimplePointingConstraint : public KinematicConstraint
  * Vector of values and  matrix of derivatives
  * calculated at given expansion 7xNumberOfStates point
  */ 
- virtual std::pair<AlgebraicVector, AlgebraicVector> value(const AlgebraicVector& exPoint) const;
+ std::pair<AlgebraicVector, AlgebraicVector> value(const AlgebraicVector& exPoint) const override;
 
- virtual std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const AlgebraicVector& exPoint) const;
+ std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const AlgebraicVector& exPoint) const override;
 
 /**
  * Vector of values and  matrix of derivatives calculated using current
  * state parameters as expansion point
  */
- virtual std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const std::vector<RefCountedKinematicParticle> &par) const;
+ std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const std::vector<RefCountedKinematicParticle> &par) const override;
 
- virtual std::pair<AlgebraicVector, AlgebraicVector> value(const std::vector<RefCountedKinematicParticle> &par) const;
+ std::pair<AlgebraicVector, AlgebraicVector> value(const std::vector<RefCountedKinematicParticle> &par) const override;
 
- virtual AlgebraicVector deviations(int nStates) const;
+ AlgebraicVector deviations(int nStates) const override;
 
 /**
  * Returns number of constraint equations used
  * for fitting. Method is relevant for proper NDF
  * calculations.
  */ 
- virtual int numberOfEquations() const;
+ int numberOfEquations() const override;
 
- virtual SimplePointingConstraint * clone() const
+ SimplePointingConstraint * clone() const override
  {return new SimplePointingConstraint(*this);}
  
  private:

--- a/RecoVertex/KinematicFit/interface/SmartPointingConstraint.h
+++ b/RecoVertex/KinematicFit/interface/SmartPointingConstraint.h
@@ -29,28 +29,28 @@ class SmartPointingConstraint : public KinematicConstraint
  * Vector of values and  matrix of derivatives
  * calculated at given expansion 7xNumberOfStates point
  */ 
- virtual std::pair<AlgebraicVector, AlgebraicVector> value(const AlgebraicVector& exPoint) const;
+ std::pair<AlgebraicVector, AlgebraicVector> value(const AlgebraicVector& exPoint) const override;
 
- virtual std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const AlgebraicVector& exPoint) const;
+ std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const AlgebraicVector& exPoint) const override;
 
 /**
  * Vector of values and  matrix of derivatives calculated using current
  * state parameters as expansion point
  */
- virtual std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const std::vector<RefCountedKinematicParticle> &par) const;
+ std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const std::vector<RefCountedKinematicParticle> &par) const override;
 
- virtual std::pair<AlgebraicVector, AlgebraicVector> value(const std::vector<RefCountedKinematicParticle> &par) const;
+ std::pair<AlgebraicVector, AlgebraicVector> value(const std::vector<RefCountedKinematicParticle> &par) const override;
 
- virtual AlgebraicVector deviations(int nStates) const;
+ AlgebraicVector deviations(int nStates) const override;
 
 /**
  * Returns number of constraint equations used
  * for fitting. Method is relevant for proper NDF
  * calculations.
  */ 
- virtual int numberOfEquations() const;
+ int numberOfEquations() const override;
 
- virtual SmartPointingConstraint * clone() const
+ SmartPointingConstraint * clone() const override
  {return new SmartPointingConstraint(*this);}
  
  private:

--- a/RecoVertex/KinematicFit/interface/TwoTrackMassKinematicConstraint.h
+++ b/RecoVertex/KinematicFit/interface/TwoTrackMassKinematicConstraint.h
@@ -30,8 +30,8 @@ public:
  * equations at the point where the input
  * particles are defined.
  */
-virtual AlgebraicVector  value(const std::vector<KinematicState> &states,
-                        const GlobalPoint& point) const;
+AlgebraicVector  value(const std::vector<KinematicState> &states,
+                        const GlobalPoint& point) const override;
 
 
 /**
@@ -39,23 +39,23 @@ virtual AlgebraicVector  value(const std::vector<KinematicState> &states,
  * constraint equations w.r.t. 
  * particle parameters
  */
-virtual AlgebraicMatrix parametersDerivative(const std::vector<KinematicState> &states,
-                                      const GlobalPoint& point) const;
+AlgebraicMatrix parametersDerivative(const std::vector<KinematicState> &states,
+                                      const GlobalPoint& point) const override;
 
 /**
  * Returns a matrix of derivatives of
  * constraint equations w.r.t. 
  * vertex position
  */
-virtual AlgebraicMatrix positionDerivative(const std::vector<KinematicState> &states,
-                                    const GlobalPoint& point) const;
+AlgebraicMatrix positionDerivative(const std::vector<KinematicState> &states,
+                                    const GlobalPoint& point) const override;
 
 /**
  * Number of equations per track used for the fit
  */
-virtual int numberOfEquations() const;
+int numberOfEquations() const override;
  
-virtual TwoTrackMassKinematicConstraint * clone()const
+TwoTrackMassKinematicConstraint * clone()const override
 {return new TwoTrackMassKinematicConstraint(*this);}
 
 private:

--- a/RecoVertex/KinematicFit/interface/VertexKinematicConstraint.h
+++ b/RecoVertex/KinematicFit/interface/VertexKinematicConstraint.h
@@ -17,37 +17,37 @@ public:
 
 VertexKinematicConstraint();
  
-virtual ~VertexKinematicConstraint();
+~VertexKinematicConstraint() override;
 
 /**
  * Returns a vector of values of constraint
  * equations at the point where the input
  * particles are defined.
  */
-virtual AlgebraicVector  value(const std::vector<KinematicState> &states,
-                        const GlobalPoint& point) const;
+AlgebraicVector  value(const std::vector<KinematicState> &states,
+                        const GlobalPoint& point) const override;
 
 /**
  * Returns a matrix of derivatives of
  * constraint equations w.r.t. 
  * particle parameters
  */
-virtual AlgebraicMatrix parametersDerivative(const std::vector<KinematicState> &states,
-                                      const GlobalPoint& point) const;
+AlgebraicMatrix parametersDerivative(const std::vector<KinematicState> &states,
+                                      const GlobalPoint& point) const override;
 
 /**
  * Returns a matrix of derivatives of
  * constraint equations w.r.t. 
  * vertex position
  */
-virtual AlgebraicMatrix positionDerivative(const std::vector<KinematicState> &states,
-                                    const GlobalPoint& point) const;
+AlgebraicMatrix positionDerivative(const std::vector<KinematicState> &states,
+                                    const GlobalPoint& point) const override;
 /**
  * Number of equations per track used for the fit
  */
-virtual int numberOfEquations() const;
+int numberOfEquations() const override;
  
-virtual VertexKinematicConstraint * clone()const
+VertexKinematicConstraint * clone()const override
 {return new VertexKinematicConstraint(*this);}
 
 

--- a/RecoVertex/KinematicFit/interface/VertexKinematicConstraintT.h
+++ b/RecoVertex/KinematicFit/interface/VertexKinematicConstraintT.h
@@ -30,19 +30,19 @@ public:
 
 VertexKinematicConstraintT();
  
-virtual ~VertexKinematicConstraintT();
+~VertexKinematicConstraintT() override;
 
   // initialize the constraint so it can precompute common qualtities to the three next call
-  virtual void init(const std::vector<KinematicState>& states,
-		    const GlobalPoint& point,  const GlobalVector& mf);
+  void init(const std::vector<KinematicState>& states,
+		    const GlobalPoint& point,  const GlobalVector& mf) override;
 
 
 /**
  * Number of equations per track used for the fit
  */
-virtual int numberOfEquations() const;
+int numberOfEquations() const override;
  
-virtual VertexKinematicConstraintT * clone()const
+VertexKinematicConstraintT * clone()const override
 {return new VertexKinematicConstraintT(*this);}
 
 
@@ -52,21 +52,21 @@ private:
  * equations at the point where the input
  * particles are defined.
  */
- virtual void fillValue() const;
+ void fillValue() const override;
 
 /**
  * fills a matrix of derivatives of
  * constraint equations w.r.t. 
  * particle parameters
  */
- virtual void fillParametersDerivative() const;
+ void fillParametersDerivative() const override;
 
 /**
  * fills a matrix of derivatives of
  * constraint equations w.r.t. 
  * vertex position
  */
- virtual void fillPositionDerivative() const;
+ void fillPositionDerivative() const override;
 
 
 private:

--- a/RecoVertex/KinematicFit/plugins/KineExample.h
+++ b/RecoVertex/KinematicFit/plugins/KineExample.h
@@ -39,12 +39,12 @@
 class KineExample : public edm::EDAnalyzer {
 public:
   explicit KineExample(const edm::ParameterSet&);
-  ~KineExample();
+  ~KineExample() override;
   
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  virtual void beginRun(edm::Run const&, edm::EventSetup const&);
-  virtual void endJob();
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void endJob() override;
 
 private:
 

--- a/RecoVertex/KinematicFit/src/ConstrainedTreeBuilder.cc
+++ b/RecoVertex/KinematicFit/src/ConstrainedTreeBuilder.cc
@@ -116,7 +116,7 @@ RefCountedKinematicTree ConstrainedTreeBuilder::buildTree(const std::vector<RefC
  //newborn kinematic particle
   float chi2 = vertex->chiSquared();
   float ndf = vertex->degreesOfFreedom();
-  KinematicParticle * zp = 0;
+  KinematicParticle * zp = nullptr;
   RefCountedKinematicParticle virtualParticle = pFactory->particle(nState,chi2,ndf,zp);
 
   return buildTree(virtualParticle, vertex, rParticles);
@@ -137,7 +137,7 @@ RefCountedKinematicTree ConstrainedTreeBuilder::buildTree(const RefCountedKinema
 //adding final state
  for(std::vector<RefCountedKinematicParticle>::const_iterator il = particles.begin(); il != particles.end(); il++)
  {
-  if((*il)->previousParticle()->correspondingTree() != 0)
+  if((*il)->previousParticle()->correspondingTree() != nullptr)
   {
    KinematicTree * tree = (*il)->previousParticle()->correspondingTree();
    tree->movePointerToTheTop();

--- a/RecoVertex/KinematicFit/src/ConstrainedTreeBuilderT.cc
+++ b/RecoVertex/KinematicFit/src/ConstrainedTreeBuilderT.cc
@@ -19,7 +19,7 @@ RefCountedKinematicTree ConstrainedTreeBuilderT::buildRealTree(const RefCountedK
 //adding final state
  for(std::vector<RefCountedKinematicParticle>::const_iterator il = particles.begin(); il != particles.end(); il++)
  {
-  if((*il)->previousParticle()->correspondingTree() != 0)
+  if((*il)->previousParticle()->correspondingTree() != nullptr)
   {
    KinematicTree * tree = (*il)->previousParticle()->correspondingTree();
    tree->movePointerToTheTop();

--- a/RecoVertex/KinematicFit/src/FinalTreeBuilder.cc
+++ b/RecoVertex/KinematicFit/src/FinalTreeBuilder.cc
@@ -8,7 +8,7 @@
 FinalTreeBuilder::FinalTreeBuilder()
 {
  kvFactory = new KinematicVertexFactory();
- KinematicStatePropagator * ksp = 0;
+ KinematicStatePropagator * ksp = nullptr;
  pFactory = new VirtualKinematicParticleFactory(ksp);
 }
 
@@ -89,7 +89,7 @@ RefCountedKinematicTree FinalTreeBuilder::buildTree(const CachingVertex<6>& vtx,
  KinematicState nState(kPar, kEr, ch, field);
 
 //invalid previous particle and empty constraint:
- KinematicParticle * zp = 0;
+ KinematicParticle * zp = nullptr;
  RefCountedKinematicParticle pPart = ReferenceCountingPointer<KinematicParticle>(zp);
 
  float vChi = vtx.totalChiSquared();
@@ -119,7 +119,7 @@ RefCountedKinematicTree FinalTreeBuilder::buildTree(const CachingVertex<6>& vtx,
   KinematicState nState(lkPar,lkCov,lch, field);
   RefCountedKinematicParticle nPart = (*j)->refittedParticle(nState,vChi,vNdf);
   rrP.push_back(nPart);
-  if((*j)->correspondingTree() != 0)
+  if((*j)->correspondingTree() != nullptr)
   {
 
 //here are the particles having trees after them

--- a/RecoVertex/KinematicFit/src/InputSort.cc
+++ b/RecoVertex/KinematicFit/src/InputSort.cc
@@ -5,7 +5,7 @@
 std::pair<std::vector<RefCountedKinematicParticle>, std::vector<FreeTrajectoryState> > 
                     InputSort::sort(const std::vector<RefCountedKinematicParticle> &particles) const
 {
- if(particles.size()==0) throw VertexException("Sorting particles for vertex fitter::number of particles = 0");
+ if(particles.empty()) throw VertexException("Sorting particles for vertex fitter::number of particles = 0");
  std::vector<RefCountedKinematicParticle> sortedParticles;
  std::vector<FreeTrajectoryState> sortedStates;
 
@@ -13,7 +13,7 @@ std::pair<std::vector<RefCountedKinematicParticle>, std::vector<FreeTrajectorySt
 //correcting them for the top ones otherwise 
  for(std::vector<RefCountedKinematicParticle>::const_iterator i = particles.begin(); i != particles.end(); i++)
  {
-  if((*i)->correspondingTree() != 0)
+  if((*i)->correspondingTree() != nullptr)
   {
    sortedParticles.push_back((*i)->correspondingTree()->topParticle());
    sortedStates.push_back((*i)->correspondingTree()->topParticle()->currentState().freeTrajectoryState());
@@ -27,7 +27,7 @@ std::pair<std::vector<RefCountedKinematicParticle>, std::vector<FreeTrajectorySt
 
 std::vector<RefCountedKinematicParticle> InputSort::sort(const std::vector<RefCountedKinematicTree> &trees) const
 {
- if(trees.size() ==0) throw VertexException("Input Sort::Zero vector of trees passed"); 
+ if(trees.empty()) throw VertexException("Input Sort::Zero vector of trees passed"); 
  std::vector<RefCountedKinematicParticle> res;
  for(std::vector<RefCountedKinematicTree>::const_iterator i = trees.begin(); i!=trees.end(); i++)
  {

--- a/RecoVertex/KinematicFit/src/KinematicConstrainedVertexFitter.cc
+++ b/RecoVertex/KinematicFit/src/KinematicConstrainedVertexFitter.cc
@@ -67,7 +67,7 @@ RefCountedKinematicTree KinematicConstrainedVertexFitter::fit(const std::vector<
 // linearization point
 // (only compute it using the linearization point finder if no point was passed to the fit function):
  GlobalPoint linPoint;
- if (pt!=0) {
+ if (pt!=nullptr) {
    linPoint  = *pt;
  }
  else {

--- a/RecoVertex/KinematicFit/src/KinematicConstrainedVertexUpdator.cc
+++ b/RecoVertex/KinematicFit/src/KinematicConstrainedVertexUpdator.cc
@@ -49,7 +49,7 @@ KinematicConstrainedVertexUpdator::update(const AlgebraicVector& inPar,
 //additional constraints to apply 
   AlgebraicMatrix g;
   AlgebraicVector val;
-  if(cs == 0)
+  if(cs == nullptr)
   {
  
 //unconstrained vertex fitter case
@@ -150,7 +150,7 @@ KinematicConstrainedVertexUpdator::update(const AlgebraicVector& inPar,
 //this is ndf without significant prior
 //vertex so -3 factor exists here 
   float ndf = 2*vSize - 3;
-  if(cs != 0){ndf += cs->numberOfEquations();}
+  if(cs != nullptr){ndf += cs->numberOfEquations();}
  
 
 //making resulting vertex 

--- a/RecoVertex/KinematicFitPrimitives/interface/KinematicParticle.h
+++ b/RecoVertex/KinematicFitPrimitives/interface/KinematicParticle.h
@@ -34,7 +34,7 @@ public:
  */  
  KinematicParticle(){}
  
- virtual ~KinematicParticle();
+ ~KinematicParticle() override;
 							   
 /**
  * Comparison by contents operators
@@ -82,7 +82,7 @@ public:
  * implemented by used for every specific type of KinematicParticle
  */ 
  virtual ReferenceCountingPointer<KinematicParticle> refittedParticle(const KinematicState& state,
-                               float chi2, float ndf, KinematicConstraint * cons = 0) const = 0;
+                               float chi2, float ndf, KinematicConstraint * cons = nullptr) const = 0;
 			       
 /**
  * Method returning LinearizedTrackState of the particle needed for

--- a/RecoVertex/KinematicFitPrimitives/interface/KinematicParticleFactoryFromTransientTrack.h
+++ b/RecoVertex/KinematicFitPrimitives/interface/KinematicParticleFactoryFromTransientTrack.h
@@ -78,7 +78,7 @@ class KinematicParticleFactoryFromTransientTrack
  */ 
   RefCountedKinematicParticle particle(const KinematicState& kineState, float& chiSquared,
                  float& ndf, ReferenceCountingPointer<KinematicParticle> previousParticle,
-				         KinematicConstraint * lastConstraint = 0) const;
+				         KinematicConstraint * lastConstraint = nullptr) const;
 
 private:
   

--- a/RecoVertex/KinematicFitPrimitives/interface/KinematicRefittedTrackState.h
+++ b/RecoVertex/KinematicFitPrimitives/interface/KinematicRefittedTrackState.h
@@ -30,12 +30,12 @@ public:
 /**
  * Access to Kinematic perigee parameters
  */
- AlgebraicVector6 parameters() const;
+ AlgebraicVector6 parameters() const override;
   
 /**
  * Kinmatic perigee covariance
  */  
- AlgebraicSymMatrix66 covariance() const ;
+ AlgebraicSymMatrix66 covariance() const override ;
 
 /**
  * Access to Kinematic parameters
@@ -50,9 +50,9 @@ public:
 /**
  * FTS out of kinematic parameters
  */
- FreeTrajectoryState freeTrajectoryState() const;
+ FreeTrajectoryState freeTrajectoryState() const override;
  
- GlobalPoint position() const;
+ GlobalPoint position() const override;
 
 /**
  * Kinematic momentum vector
@@ -62,21 +62,21 @@ public:
 /**
  * Perigee momentum vector
  */
- AlgebraicVector4 momentumVector() const;
+ AlgebraicVector4 momentumVector() const override;
 
- TrajectoryStateOnSurface trajectoryStateOnSurface(const Surface & surface) const;
+ TrajectoryStateOnSurface trajectoryStateOnSurface(const Surface & surface) const override;
 
  TrajectoryStateOnSurface trajectoryStateOnSurface(const Surface & surface, 
-                                                   const Propagator & propagator) const;
+                                                   const Propagator & propagator) const override;
 						   
- virtual double weight() const;
+ double weight() const override;
 
- virtual ReferenceCountingPointer<RefittedTrackState<6> > stateWithNewWeight
-  	(const double newWeight) const;
+ ReferenceCountingPointer<RefittedTrackState<6> > stateWithNewWeight
+  	(const double newWeight) const override;
 
- virtual std::vector< ReferenceCountingPointer<RefittedTrackState<6> > > components() const;						   
+ std::vector< ReferenceCountingPointer<RefittedTrackState<6> > > components() const override;						   
 
- virtual reco::TransientTrack transientTrack() const;
+ reco::TransientTrack transientTrack() const override;
 
 
 private:

--- a/RecoVertex/KinematicFitPrimitives/interface/KinematicTree.h
+++ b/RecoVertex/KinematicFitPrimitives/interface/KinematicTree.h
@@ -44,7 +44,7 @@ class KinematicTree : public ReferenceCounted
  KinematicTree();
 
  
- virtual ~KinematicTree();
+ ~KinematicTree() override;
  
 /**
  * Access methods

--- a/RecoVertex/KinematicFitPrimitives/interface/KinematicVertex.h
+++ b/RecoVertex/KinematicFitPrimitives/interface/KinematicVertex.h
@@ -51,7 +51,7 @@ public:
  KinematicVertex(const CachingVertex<6>& vertex);
 
 
- virtual ~KinematicVertex();
+ ~KinematicVertex() override;
 
 /**
  * Comparison by contents operator

--- a/RecoVertex/KinematicFitPrimitives/interface/MultiTrackKinematicConstraintT.h
+++ b/RecoVertex/KinematicFitPrimitives/interface/MultiTrackKinematicConstraintT.h
@@ -56,7 +56,7 @@ public:
   typedef ROOT::Math::SMatrix<double, DIM,3> positionDerivativeType;
 
 
-  virtual ~MultiTrackKinematicConstraintT() {}
+  ~MultiTrackKinematicConstraintT() override {}
 
 
   /**

--- a/RecoVertex/KinematicFitPrimitives/interface/MultipleKinematicConstraint.h
+++ b/RecoVertex/KinematicFitPrimitives/interface/MultipleKinematicConstraint.h
@@ -25,20 +25,20 @@ public:
  * Vector of values and  matrix of derivatives
  * calculated at given 7xNumberOfStates linearization point
  */   
-  std::pair<AlgebraicVector,AlgebraicVector> value(const AlgebraicVector& exPoint) const;
+  std::pair<AlgebraicVector,AlgebraicVector> value(const AlgebraicVector& exPoint) const override;
  
-  std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const AlgebraicVector& exPoint) const;
+  std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const AlgebraicVector& exPoint) const override;
   
 /**
  * Vector of values and matrix of derivatives, 
  * calu=culated at linearization point of current
  * particle states
  */  
-  std::pair<AlgebraicVector, AlgebraicVector> value(const std::vector<RefCountedKinematicParticle> &par) const;
+  std::pair<AlgebraicVector, AlgebraicVector> value(const std::vector<RefCountedKinematicParticle> &par) const override;
 
-  std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const std::vector<RefCountedKinematicParticle> &par) const;
+  std::pair<AlgebraicMatrix, AlgebraicVector> derivative(const std::vector<RefCountedKinematicParticle> &par) const override;
 
-  int numberOfEquations() const;
+  int numberOfEquations() const override;
   
 /**
  * Method adding new constraint to the list of
@@ -46,12 +46,12 @@ public:
  */  
   void addConstraint(KinematicConstraint * newConst) const; 
 
-  AlgebraicVector deviations(int nStates) const;
+  AlgebraicVector deviations(int nStates) const override;
   
   bool isEmpty() const
   {return em;}
   
-  MultipleKinematicConstraint * clone() const
+  MultipleKinematicConstraint * clone() const override
   {return new MultipleKinematicConstraint(*this);}
   
 private:

--- a/RecoVertex/KinematicFitPrimitives/interface/ParticleKinematicLinearizedTrackState.h
+++ b/RecoVertex/KinematicFitPrimitives/interface/ParticleKinematicLinearizedTrackState.h
@@ -24,33 +24,33 @@ public:
   * Returns a new linearized state with respect to a new linearization point.
   * A new object of the same type is returned, without change to the existing one.
   */ 
- virtual ReferenceCountingPointer<LinearizedTrackState<6> > stateWithNewLinearizationPoint
-  	(const GlobalPoint & newLP) const; 
+ ReferenceCountingPointer<LinearizedTrackState<6> > stateWithNewLinearizationPoint
+  	(const GlobalPoint & newLP) const override; 
 	
  /**
   * The point at which the track state has been linearized
   */	
- const GlobalPoint & linearizationPoint() const { return theLinPoint; }
+ const GlobalPoint & linearizationPoint() const override { return theLinPoint; }
  
 
 /** Method returning the constant term of the Taylor expansion
  *  of measurement equation
  */
- const AlgebraicVector6 & constantTerm() const;
+ const AlgebraicVector6 & constantTerm() const override;
 
 /** Method returning the Position Jacobian from the Taylor expansion 
  *  (Matrix A)
  */
- virtual const AlgebraicMatrix63 & positionJacobian() const;
+ const AlgebraicMatrix63 & positionJacobian() const override;
 
 /** Method returning the Momentum Jacobian from the Taylor expansion 
  *  (Matrix B)
  */   
- virtual const AlgebraicMatrix64 & momentumJacobian() const;
+ const AlgebraicMatrix64 & momentumJacobian() const override;
 
 /** Method returning the parameters of the Taylor expansion
  */
- const AlgebraicVector6 & parametersFromExpansion() const;
+ const AlgebraicVector6 & parametersFromExpansion() const override;
 
 /** Method returning the track state at the point of closest approach 
  *  to the linearization point, in the transverse plane (a.k.a. 
@@ -60,60 +60,60 @@ public:
 /**
  * extended perigee predicted parameters
  */
- AlgebraicVector6 predictedStateParameters() const;
+ AlgebraicVector6 predictedStateParameters() const override;
     
 /**
  * returns predicted 4-momentum in extended perigee parametrization
  */  
- AlgebraicVectorM predictedStateMomentumParameters() const; 
+ AlgebraicVectorM predictedStateMomentumParameters() const override; 
 
 /**
  * 4x4 error matrix ofe xtended perigee mometum components
  */ 
- AlgebraicSymMatrix44 predictedStateMomentumError() const; 
+ AlgebraicSymMatrix44 predictedStateMomentumError() const override; 
 
 /**
  * Full predicted weight matrix
  */  
- AlgebraicSymMatrix66 predictedStateWeight(int & error) const;
+ AlgebraicSymMatrix66 predictedStateWeight(int & error) const override;
   
 /**
  * Full predicted error matrix
  */  
- AlgebraicSymMatrix66 predictedStateError() const; 
+ AlgebraicSymMatrix66 predictedStateError() const override; 
 
 // /** 
 //  * Method returning the impact point measurement     
 //  */      
 //  ImpactPointMeasurement impactPointMeasurement() const;
   
- TrackCharge charge() const;
+ TrackCharge charge() const override;
  
  RefCountedKinematicParticle particle() const;
    
- bool operator ==(LinearizedTrackState<6>& other)const;
+ bool operator ==(LinearizedTrackState<6>& other)const override;
  
- bool hasError() const;
+ bool hasError() const override;
  
  RefCountedRefittedTrackState createRefittedTrackState(
                      const GlobalPoint & vertexPosition, 
 		     const AlgebraicVectorM & vectorParameters,
-		     const AlgebraicSymMatrix77 & covarianceMatrix) const;
+		     const AlgebraicSymMatrix77 & covarianceMatrix) const override;
 		     
   /** Method returning the parameters of the Taylor expansion evaluated with the
    *  refitted state.
    */
-  virtual AlgebraicVectorN refittedParamFromEquation(
-	const RefCountedRefittedTrackState & theRefittedState) const;
+  AlgebraicVectorN refittedParamFromEquation(
+	const RefCountedRefittedTrackState & theRefittedState) const override;
 
-  virtual inline void checkParameters(AlgebraicVectorN & parameters) const;
+  inline void checkParameters(AlgebraicVectorN & parameters) const override;
 		     
- double weightInMixture() const;
+ double weightInMixture() const override;
 
  std::vector<ReferenceCountingPointer<LinearizedTrackState<6> > > components()
-  									const;
+  									const override;
  
- virtual reco::TransientTrack track() const;
+ reco::TransientTrack track() const override;
 
  
 private:

--- a/RecoVertex/KinematicFitPrimitives/interface/ParticleKinematicLinearizedTrackStateFactory.h
+++ b/RecoVertex/KinematicFitPrimitives/interface/ParticleKinematicLinearizedTrackStateFactory.h
@@ -22,14 +22,14 @@ public:
  RefCountedLinearizedTrackState linearizedTrackState(const GlobalPoint & linP,
                                      RefCountedKinematicParticle & prt) const;  
 
-  virtual RefCountedLinearizedTrackState
-    linearizedTrackState(const GlobalPoint & linP, const reco::TransientTrack & track) const;
+  RefCountedLinearizedTrackState
+    linearizedTrackState(const GlobalPoint & linP, const reco::TransientTrack & track) const override;
 
-  virtual RefCountedLinearizedTrackState
+  RefCountedLinearizedTrackState
     linearizedTrackState(const GlobalPoint & linP, const reco::TransientTrack & track,
-    	const TrajectoryStateOnSurface& tsos) const;
+    	const TrajectoryStateOnSurface& tsos) const override;
 
-  virtual const ParticleKinematicLinearizedTrackStateFactory * clone() const;
+  const ParticleKinematicLinearizedTrackStateFactory * clone() const override;
 
 };
 #endif

--- a/RecoVertex/KinematicFitPrimitives/interface/TrackKinematicStatePropagator.h
+++ b/RecoVertex/KinematicFitPrimitives/interface/TrackKinematicStatePropagator.h
@@ -21,23 +21,23 @@ public:
 
   TrackKinematicStatePropagator() {}
   
-  virtual ~TrackKinematicStatePropagator() {}
+  ~TrackKinematicStatePropagator() override {}
   
   
   /**
    * Propagation to the point of closest approach in
    * transverse plane to the given point
    */   
-  virtual KinematicState propagateToTheTransversePCA(const KinematicState& state, const GlobalPoint& referencePoint) const;
+  KinematicState propagateToTheTransversePCA(const KinematicState& state, const GlobalPoint& referencePoint) const override;
   
-  virtual bool willPropagateToTheTransversePCA(const KinematicState& state, const GlobalPoint& point) const;
+  bool willPropagateToTheTransversePCA(const KinematicState& state, const GlobalPoint& point) const override;
   
     
   /**
    * Clone method reimplemented from
    * abstract class
    */
-  virtual KinematicStatePropagator * clone() const
+  KinematicStatePropagator * clone() const override
   {return new TrackKinematicStatePropagator(*this);}
   
  private:

--- a/RecoVertex/KinematicFitPrimitives/interface/TransientTrackKinematicParticle.h
+++ b/RecoVertex/KinematicFitPrimitives/interface/TransientTrackKinematicParticle.h
@@ -28,9 +28,9 @@ public:
  TransientTrackKinematicParticle(const KinematicState& kineState,float& chiSquared,
                        float& degreesOfFr,KinematicConstraint * lastConstraint,
                    ReferenceCountingPointer<KinematicParticle> previousParticle,
-		   KinematicStatePropagator * pr,const reco::TransientTrack * initialTrack = 0);
+		   KinematicStatePropagator * pr,const reco::TransientTrack * initialTrack = nullptr);
 		   	
- virtual ~TransientTrackKinematicParticle();
+ ~TransientTrackKinematicParticle() override;
  					   
 /**
  * Comparison by contents operator
@@ -39,17 +39,17 @@ public:
  * compares the initial KinematicStates
  * Retunes true if they match.
  */ 
-  bool operator==(const KinematicParticle& other)const;
+  bool operator==(const KinematicParticle& other)const override;
 
-  bool operator==(const ReferenceCountingPointer<KinematicParticle>& other) const;
+  bool operator==(const ReferenceCountingPointer<KinematicParticle>& other) const override;
 
-  bool operator!=(const KinematicParticle& other)const;
+  bool operator!=(const KinematicParticle& other)const override;
   
 /**
  * Access to KinematicState of particle
  * at given point
  */ 
- KinematicState stateAtPoint(const GlobalPoint& point)const;
+ KinematicState stateAtPoint(const GlobalPoint& point)const override;
  
 /**
  * Access to initial TransientTrack (if any)
@@ -62,13 +62,13 @@ public:
  * RCP<TransientTrackKinematicParticle> is  returned.
  */ 
  ReferenceCountingPointer<KinematicParticle> refittedParticle(const KinematicState& state,
-                            float chi2, float ndf, KinematicConstraint * cons = 0)const;
+                            float chi2, float ndf, KinematicConstraint * cons = nullptr)const override;
 			    
 /**
  * Method returning LinearizedTrackState of the particle needed for
  * Kalman flter vertex fit. This implementation uses the ParticleLinearizedTrackStateFactory class.
  */					    
- RefCountedLinearizedTrackState particleLinearizedTrackState(const GlobalPoint& point)const; 
+ RefCountedLinearizedTrackState particleLinearizedTrackState(const GlobalPoint& point)const override; 
 
 
 private: 

--- a/RecoVertex/KinematicFitPrimitives/interface/VirtualKinematicParticle.h
+++ b/RecoVertex/KinematicFitPrimitives/interface/VirtualKinematicParticle.h
@@ -27,7 +27,7 @@ class VirtualKinematicParticle:public KinematicParticle
                      ReferenceCountingPointer<KinematicParticle> previousParticle,
 		                                   KinematicStatePropagator * pr);
  
- virtual ~VirtualKinematicParticle();
+ ~VirtualKinematicParticle() override;
  
 /**
  * Comparison by contents operator
@@ -36,17 +36,17 @@ class VirtualKinematicParticle:public KinematicParticle
  * compares the initial KinematicStates
  * Retunes true if they match.
  */ 
-  bool operator==(const KinematicParticle& other)const;
+  bool operator==(const KinematicParticle& other)const override;
 
-  bool operator==(const ReferenceCountingPointer<KinematicParticle>& other) const;
+  bool operator==(const ReferenceCountingPointer<KinematicParticle>& other) const override;
 
-  bool operator!=(const KinematicParticle& other)const;
+  bool operator!=(const KinematicParticle& other)const override;
 
 /**
  * Access to KinematicState of particle
  * at given point
  */ 
- KinematicState stateAtPoint(const GlobalPoint& point)const;
+ KinematicState stateAtPoint(const GlobalPoint& point)const override;
  
 /**
  * Method producing new particle with refitted parameters.
@@ -54,13 +54,13 @@ class VirtualKinematicParticle:public KinematicParticle
  * RCP<VirtualKinematicParticle> is  returned.
  */ 
  RefCountedKinematicParticle refittedParticle(const KinematicState& state,
-                               float chi2, float ndf, KinematicConstraint * cons = 0)const;
+                               float chi2, float ndf, KinematicConstraint * cons = nullptr)const override;
 			       
 /**
  * Method returning LinearizedTrackState of the particle needed for
  * Kalman flter vertex fit. This implementation uses the ParticleLinearizedTrackStateFactory class.
  */					    
- RefCountedLinearizedTrackState particleLinearizedTrackState(const GlobalPoint& point)const; 
+ RefCountedLinearizedTrackState particleLinearizedTrackState(const GlobalPoint& point)const override; 
 			        
  private:
  

--- a/RecoVertex/KinematicFitPrimitives/interface/VirtualKinematicParticleFactory.h
+++ b/RecoVertex/KinematicFitPrimitives/interface/VirtualKinematicParticleFactory.h
@@ -32,7 +32,7 @@ public:
  */
   RefCountedKinematicParticle particle(const KinematicState& kineState, float& chiSquared,
                  float& degreesOfFr, ReferenceCountingPointer<KinematicParticle> previousParticle,
-				           KinematicConstraint * lastConstraint = 0)const;
+				           KinematicConstraint * lastConstraint = nullptr)const;
 private:
   
  KinematicStatePropagator * propagator;

--- a/RecoVertex/KinematicFitPrimitives/src/KinematicParticleFactoryFromTransientTrack.cc
+++ b/RecoVertex/KinematicFitPrimitives/src/KinematicParticleFactoryFromTransientTrack.cc
@@ -6,7 +6,7 @@ KinematicParticleFactoryFromTransientTrack::KinematicParticleFactoryFromTransien
 
 KinematicParticleFactoryFromTransientTrack::KinematicParticleFactoryFromTransientTrack(KinematicStatePropagator * pr)
 {
- if(pr != 0)
+ if(pr != nullptr)
  {
   propagator = pr->clone();
  }else{
@@ -23,8 +23,8 @@ RefCountedKinematicParticle KinematicParticleFactoryFromTransientTrack::particle
 // cout<<"calling the state builder"<<endl;
  KinematicState initState = builder(initialTrack,massGuess, m_sigma);
  const reco::TransientTrack * track = &initialTrack;
- KinematicConstraint * lastConstraint = 0;
- ReferenceCountingPointer<KinematicParticle> previousParticle = 0;
+ KinematicConstraint * lastConstraint = nullptr;
+ ReferenceCountingPointer<KinematicParticle> previousParticle = nullptr;
  return ReferenceCountingPointer<KinematicParticle>(new TransientTrackKinematicParticle(initState,
                       chiSquared,degreesOfFr, lastConstraint, previousParticle, propagator, track));
 }
@@ -39,8 +39,8 @@ RefCountedKinematicParticle KinematicParticleFactoryFromTransientTrack::particle
 // cout<<"calling the state builder"<<endl;
  KinematicState initState = builder(freestate,massGuess, m_sigma);
  const reco::TransientTrack * track = &initialTrack;
- KinematicConstraint * lastConstraint = 0;
- ReferenceCountingPointer<KinematicParticle> previousParticle = 0;
+ KinematicConstraint * lastConstraint = nullptr;
+ ReferenceCountingPointer<KinematicParticle> previousParticle = nullptr;
  return ReferenceCountingPointer<KinematicParticle>(new TransientTrackKinematicParticle(initState,
                       chiSquared,degreesOfFr, lastConstraint, previousParticle, propagator, track));
 }
@@ -55,8 +55,8 @@ RefCountedKinematicParticle KinematicParticleFactoryFromTransientTrack::particle
 //  FreeTrajectoryState st(initialTrack.impactPointTSCP().theState());
  KinematicState initState = builder(initialTrack.impactPointTSCP().theState(), massGuess, m_sigma, expPoint); 
  const reco::TransientTrack * track = &initialTrack;
- KinematicConstraint * lastConstraint = 0;
- ReferenceCountingPointer<KinematicParticle> previousParticle = 0;
+ KinematicConstraint * lastConstraint = nullptr;
+ ReferenceCountingPointer<KinematicParticle> previousParticle = nullptr;
  return ReferenceCountingPointer<KinematicParticle>(new TransientTrackKinematicParticle(initState,
                                 chiSquared,degreesOfFr, lastConstraint, previousParticle, propagator, track));
 }
@@ -73,7 +73,7 @@ RefCountedKinematicParticle KinematicParticleFactoryFromTransientTrack::particle
 // FIXME
 //  if(previousParticle.isValid()){
    TransientTrackKinematicParticle * pr = dynamic_cast<TransientTrackKinematicParticle * >(prp);
-   if(pr == 0){
+   if(pr == nullptr){
     throw VertexException("KinematicParticleFactoryFromTransientTrack::Previous particle passed is not TransientTrack based!");
    }else{track  = pr->initialTransientTrack();}
 //  }else{track = 0;}

--- a/RecoVertex/KinematicFitPrimitives/src/KinematicTree.cc
+++ b/RecoVertex/KinematicFitPrimitives/src/KinematicTree.cc
@@ -3,7 +3,7 @@
 KinematicTree::KinematicTree()
 {
  empt = true;
- treeWalker = 0;
+ treeWalker = nullptr;
 }
 
  KinematicTree::~KinematicTree()

--- a/RecoVertex/KinematicFitPrimitives/src/KinematicVertex.cc
+++ b/RecoVertex/KinematicFitPrimitives/src/KinematicVertex.cc
@@ -14,8 +14,8 @@ KinematicVertex::KinematicVertex(const VertexState state, float totalChiSq,
 					                           
 {
  vl = true;
- tree = 0;
- pVertex = 0;
+ tree = nullptr;
+ pVertex = nullptr;
 }
 
 KinematicVertex::KinematicVertex(const CachingVertex<6>& vertex)                                              
@@ -26,8 +26,8 @@ KinematicVertex::KinematicVertex(const CachingVertex<6>& vertex)
  theState = VertexState(vertex.position(), vertex.error());
  theChiSquared = vertex.totalChiSquared();
  theNDF = vertex.degreesOfFreedom();
- tree = 0;
- pVertex = 0;
+ tree = nullptr;
+ pVertex = nullptr;
 }		 
 
 KinematicVertex::KinematicVertex(const VertexState state, 
@@ -37,7 +37,7 @@ KinematicVertex::KinematicVertex(const VertexState state,
 				    theChiSquared(totalChiSq),theNDF(degreesOfFr) , pVertex(prVertex)
 {
  vl = true;
- tree = 0;
+ tree = nullptr;
 }
 
 
@@ -112,7 +112,7 @@ VertexState KinematicVertex::vertexState() const
 KinematicVertex::operator reco::Vertex() 
 {
    //If the vertex is invalid, return an invalid TV !
-  if (!vertexIsValid() || tree==0) return reco::Vertex();
+  if (!vertexIsValid() || tree==nullptr) return reco::Vertex();
 
 //accessing the tree components, move pointer to top
   if (!tree->findDecayVertex(this)) return reco::Vertex();
@@ -127,14 +127,14 @@ KinematicVertex::operator reco::Vertex()
        i != daughters.end(); ++i) {
 
     const TransientTrackKinematicParticle * ttkp = dynamic_cast<const TransientTrackKinematicParticle * >(&(**i));
-    if(ttkp != 0) {
+    if(ttkp != nullptr) {
       const reco::TrackTransientTrack * ttt = dynamic_cast<const reco::TrackTransientTrack*>(ttkp->initialTransientTrack()->basicTransientTrack());
-      if ((ttt!=0) && (ttt->persistentTrackRef().isNonnull())) {
+      if ((ttt!=nullptr) && (ttt->persistentTrackRef().isNonnull())) {
 	reco::TrackRef tr = ttt->persistentTrackRef();
 	vertex.add(reco::TrackBaseRef(tr), ttkp->refittedTransientTrack().track(), 1.);
       } else {
 	const reco::GsfTransientTrack * ttt = dynamic_cast<const reco::GsfTransientTrack*>(ttkp->initialTransientTrack()->basicTransientTrack());
-	if ((ttt!=0) && (ttt->persistentTrackRef().isNonnull())) {
+	if ((ttt!=nullptr) && (ttt->persistentTrackRef().isNonnull())) {
 	  reco::GsfTrackRef tr = ttt->persistentTrackRef();
 	  vertex.add(reco::TrackBaseRef(tr), ttkp->refittedTransientTrack().track(), 1.);
 	}

--- a/RecoVertex/KinematicFitPrimitives/src/MultipleKinematicConstraint.cc
+++ b/RecoVertex/KinematicFitPrimitives/src/MultipleKinematicConstraint.cc
@@ -2,14 +2,14 @@
 
 void MultipleKinematicConstraint::addConstraint(KinematicConstraint * newConst) const
 {
- if(newConst == 0)throw VertexException("MultipleKinematicConstraint::zero constraint pointer passed");
+ if(newConst == nullptr)throw VertexException("MultipleKinematicConstraint::zero constraint pointer passed");
  cts.push_back(newConst);
  em = false;
 }
   
 std::pair<AlgebraicVector,AlgebraicVector> MultipleKinematicConstraint::value(const AlgebraicVector& exPoint) const
 {
- if(cts.size() == 0)throw VertexException("MultipleKinematicConstraint::value requested for empty constraint");
+ if(cts.empty())throw VertexException("MultipleKinematicConstraint::value requested for empty constraint");
  if(exPoint.num_row() ==0 ) throw VertexException("MultipleKinematicConstraint::value requested for zero Linearization point");
 
 //looking for total number of states, represented by this  point. 
@@ -38,11 +38,11 @@ std::pair<AlgebraicVector,AlgebraicVector> MultipleKinematicConstraint::value(co
  
 std::pair<AlgebraicMatrix, AlgebraicVector> MultipleKinematicConstraint::derivative(const AlgebraicVector& exPoint) const
 {
- if(cts.size() == 0) throw VertexException("MultipleKinematicConstraint::derivative requested for empty constraint");
+ if(cts.empty()) throw VertexException("MultipleKinematicConstraint::derivative requested for empty constraint");
  if(exPoint.num_row() ==0 ) throw VertexException("MultipleKinematicConstraint::value requested for zero Linearization point");
 
 //security check for extended cartesian parametrization 
- AlgebraicVector expansion = exPoint;
+ const AlgebraicVector& expansion = exPoint;
  int inSize = exPoint.num_row(); 
  if((inSize%7) !=0) throw VertexException("MultipleKinematicConstraint::linearization point has a wrong dimension");
 
@@ -69,7 +69,7 @@ std::pair<AlgebraicMatrix, AlgebraicVector> MultipleKinematicConstraint::derivat
 int MultipleKinematicConstraint::numberOfEquations() const
 {
  int ne = 0;
- if(cts.size() == 0) throw VertexException("MultipleKinematicConstraint::number of equations requested for empty constraint");
+ if(cts.empty()) throw VertexException("MultipleKinematicConstraint::number of equations requested for empty constraint");
  for(std::vector<KinematicConstraint *>::const_iterator i = cts.begin(); i != cts.end(); i++)
  {ne += (*i)->numberOfEquations();}
  return ne;
@@ -77,7 +77,7 @@ int MultipleKinematicConstraint::numberOfEquations() const
 
 std::pair<AlgebraicVector, AlgebraicVector> MultipleKinematicConstraint::value(const std::vector<RefCountedKinematicParticle> &par) const
 {
- if(cts.size() == 0) throw VertexException("MultipleKinematicConstraint::derivative requested for empty constraint");
+ if(cts.empty()) throw VertexException("MultipleKinematicConstraint::derivative requested for empty constraint");
  int nStates = par.size();
  AlgebraicVector param(7*nStates,0);
  int count = 1;
@@ -107,7 +107,7 @@ std::pair<AlgebraicVector, AlgebraicVector> MultipleKinematicConstraint::value(c
 
 std::pair<AlgebraicMatrix, AlgebraicVector> MultipleKinematicConstraint::derivative(const std::vector<RefCountedKinematicParticle> &par) const
 {
- if(cts.size() == 0) throw VertexException("MultipleKinematicConstraint::derivative requested for empty constraint");
+ if(cts.empty()) throw VertexException("MultipleKinematicConstraint::derivative requested for empty constraint");
  int nStates = par.size();
  AlgebraicVector param(7*nStates,0);
  
@@ -140,7 +140,7 @@ std::pair<AlgebraicMatrix, AlgebraicVector> MultipleKinematicConstraint::derivat
 AlgebraicVector MultipleKinematicConstraint::deviations(int nStates) const
 {
  AlgebraicVector dev(nStates*7,0);
- if(cts.size() == 0) throw VertexException("MultipleKinematicConstraint::deviations requested for empty constraint");
+ if(cts.empty()) throw VertexException("MultipleKinematicConstraint::deviations requested for empty constraint");
  for(std::vector<KinematicConstraint *>::const_iterator i = cts.begin(); i != cts.end(); i++)
  {
   AlgebraicVector dev_loc =(*i)->deviations(nStates);

--- a/RecoVertex/KinematicFitPrimitives/src/ParticleKinematicLinearizedTrackState.cc
+++ b/RecoVertex/KinematicFitPrimitives/src/ParticleKinematicLinearizedTrackState.cc
@@ -61,7 +61,7 @@ bool  ParticleKinematicLinearizedTrackState::operator ==(LinearizedTrackState<6>
 {
  const  ParticleKinematicLinearizedTrackState* otherP = 
   	dynamic_cast<const  ParticleKinematicLinearizedTrackState*>(&other);
-   if (otherP == 0) {
+   if (otherP == nullptr) {
    throw VertexException(" ParticleKinematicLinearizedTrackState:: don't know how to compare myself to non-kinematic track state");
   }
   return (*(otherP->particle()) == *part);}

--- a/RecoVertex/KinematicFitPrimitives/src/TrackKinematicStatePropagator.cc
+++ b/RecoVertex/KinematicFitPrimitives/src/TrackKinematicStatePropagator.cc
@@ -81,7 +81,7 @@ TrackKinematicStatePropagator::propagateToTheTransversePCACharged
   //making a free trajectory state and looking 
   //for helix barrel plane crossing  
   FreeTrajectoryState const & fState = state.freeTrajectoryState();		
-  GlobalPoint iP = referencePoint;					  
+  const GlobalPoint& iP = referencePoint;					  
   std::pair<HelixBarrelPlaneCrossingByCircle, BoundPlane::BoundPlanePointer> cros = planeCrossing(fState,iP);	   
   
   HelixBarrelPlaneCrossingByCircle planeCrossing = cros.first; 

--- a/RecoVertex/KinematicFitPrimitives/src/TransientTrackKinematicParticle.cc
+++ b/RecoVertex/KinematicFitPrimitives/src/TransientTrackKinematicParticle.cc
@@ -10,7 +10,7 @@ TransientTrackKinematicParticle::TransientTrackKinematicParticle
 	KinematicStatePropagator * pr, const TransientTrack * initialTrack)
 {
   theField = kineState.magneticField();
- if(previousParticle.get() == 0)
+ if(previousParticle.get() == nullptr)
  { 
   initState = kineState;
 }else{initState = previousParticle->initialState();}
@@ -20,13 +20,13 @@ TransientTrackKinematicParticle::TransientTrackKinematicParticle
  chi2 = chiSquared;
  ndf = degreesOfFr;
  lConstraint = lastConstraint;
- if(pr!=0)
+ if(pr!=nullptr)
  {
   propagator = pr->clone();
  }else{
   propagator = new TrackKinematicStatePropagator();
  }
- tree = 0;
+ tree = nullptr;
 } 
 
 TransientTrackKinematicParticle::~TransientTrackKinematicParticle()
@@ -39,7 +39,7 @@ bool TransientTrackKinematicParticle::operator==(const KinematicParticle& other)
 //first looking if this is an object of the same type
  const  KinematicParticle * lp = &other;
  const TransientTrackKinematicParticle * lPart = dynamic_cast<const TransientTrackKinematicParticle * >(lp);
- if(lPart != 0){
+ if(lPart != nullptr){
  
 //then comparing particle with their initial TransientTracks 
   if((initialTransientTrack())&&(lPart->initialTransientTrack()))

--- a/RecoVertex/KinematicFitPrimitives/src/VirtualKinematicParticle.cc
+++ b/RecoVertex/KinematicFitPrimitives/src/VirtualKinematicParticle.cc
@@ -8,7 +8,7 @@ VirtualKinematicParticle::VirtualKinematicParticle
 	 KinematicStatePropagator * pr)
 {
   theField = kineState.magneticField();
- if(previousParticle.get() == 0)
+ if(previousParticle.get() == nullptr)
  {
   initState = kineState;
  }else{initState = previousParticle->initialState();}
@@ -17,13 +17,13 @@ VirtualKinematicParticle::VirtualKinematicParticle
  chi2 = chiSquared;
  ndf = degreesOfFr;
  lConstraint = lastConstraint;
- if(pr != 0)
+ if(pr != nullptr)
  {
   propagator = pr->clone();
  }else{
   propagator = new TrackKinematicStatePropagator();
  }
- tree = 0;
+ tree = nullptr;
 }
 
 VirtualKinematicParticle::~VirtualKinematicParticle()
@@ -36,7 +36,7 @@ bool VirtualKinematicParticle::operator==(const KinematicParticle& other)const
 //first looking if this is an object of the same type
  const  KinematicParticle * lp = &other;
  const VirtualKinematicParticle * lPart = dynamic_cast<const VirtualKinematicParticle * >(lp);
- if(lPart != 0 && initialState() == lPart->initialState()) dc = true;
+ if(lPart != nullptr && initialState() == lPart->initialState()) dc = true;
  return dc;
 }
 

--- a/RecoVertex/KinematicFitPrimitives/src/VirtualKinematicParticleFactory.cc
+++ b/RecoVertex/KinematicFitPrimitives/src/VirtualKinematicParticleFactory.cc
@@ -6,7 +6,7 @@ VirtualKinematicParticleFactory::VirtualKinematicParticleFactory()
  
 VirtualKinematicParticleFactory::VirtualKinematicParticleFactory(KinematicStatePropagator * pr)
 {
- if(pr!=0)
+ if(pr!=nullptr)
  {
   propagator = pr->clone();
  }else{
@@ -18,11 +18,11 @@ RefCountedKinematicParticle VirtualKinematicParticleFactory::particle(const Kine
           float& chiSquared, float& degreesOfFr, ReferenceCountingPointer<KinematicParticle> previousParticle,
 			                	       KinematicConstraint * lastConstraint)const
 {
- if(previousParticle.get() != 0)
+ if(previousParticle.get() != nullptr)
  {
   KinematicParticle * prp = &(*previousParticle);
   VirtualKinematicParticle * pr = dynamic_cast<VirtualKinematicParticle * >(prp);
-  if(pr == 0){ throw VertexException("KinematicParticleFactoryFromTransientTrack::Previous particle passed is not TransientTrack based!");}
+  if(pr == nullptr){ throw VertexException("KinematicParticleFactoryFromTransientTrack::Previous particle passed is not TransientTrack based!");}
  } 
  return ReferenceCountingPointer<KinematicParticle>(new VirtualKinematicParticle(kineState, chiSquared, degreesOfFr, 
                                                                             lastConstraint, previousParticle, propagator));

--- a/RecoVertex/LinearizationPointFinders/interface/CrossingPtBasedLinearizationPointFinder.h
+++ b/RecoVertex/LinearizationPointFinders/interface/CrossingPtBasedLinearizationPointFinder.h
@@ -45,14 +45,14 @@ public:
   CrossingPtBasedLinearizationPointFinder(
       const CrossingPtBasedLinearizationPointFinder & );
 
-  ~CrossingPtBasedLinearizationPointFinder();
+  ~CrossingPtBasedLinearizationPointFinder() override;
 
 /** Method giving back the Initial Linearization Point.
  */
-  virtual GlobalPoint getLinearizationPoint(const std::vector<reco::TransientTrack> & ) const;
-  virtual GlobalPoint getLinearizationPoint(const std::vector<FreeTrajectoryState> & ) const;
+  GlobalPoint getLinearizationPoint(const std::vector<reco::TransientTrack> & ) const override;
+  GlobalPoint getLinearizationPoint(const std::vector<FreeTrajectoryState> & ) const override;
 
-  virtual CrossingPtBasedLinearizationPointFinder * clone() const {
+  CrossingPtBasedLinearizationPointFinder * clone() const override {
     return new CrossingPtBasedLinearizationPointFinder ( * this );
   };
 protected:

--- a/RecoVertex/LinearizationPointFinders/interface/FallbackLinearizationPointFinder.h
+++ b/RecoVertex/LinearizationPointFinders/interface/FallbackLinearizationPointFinder.h
@@ -14,10 +14,10 @@ class FallbackLinearizationPointFinder : public LinearizationPointFinder
 {
 public:
   FallbackLinearizationPointFinder ( const ModeFinder3d & m = HsmModeFinder3d() );
-  virtual GlobalPoint getLinearizationPoint(const std::vector<reco::TransientTrack> & ) const;
-  virtual GlobalPoint getLinearizationPoint(const std::vector<FreeTrajectoryState> & ) const;
+  GlobalPoint getLinearizationPoint(const std::vector<reco::TransientTrack> & ) const override;
+  GlobalPoint getLinearizationPoint(const std::vector<FreeTrajectoryState> & ) const override;
 
-  virtual FallbackLinearizationPointFinder * clone() const
+  FallbackLinearizationPointFinder * clone() const override
   {
     return new FallbackLinearizationPointFinder ( * this );
   };

--- a/RecoVertex/LinearizationPointFinders/interface/FsmwLinearizationPointFinder.h
+++ b/RecoVertex/LinearizationPointFinders/interface/FsmwLinearizationPointFinder.h
@@ -39,7 +39,7 @@ public:
       signed int n_pairs = 250, float weight_exp = -2., float fraction = .5,
       float cut=10, int no_weight_above = 10 );
 
-  virtual FsmwLinearizationPointFinder * clone() const;
+  FsmwLinearizationPointFinder * clone() const override;
 };
 
 #endif

--- a/RecoVertex/LinearizationPointFinders/interface/HSMLinearizationPointFinder.h
+++ b/RecoVertex/LinearizationPointFinders/interface/HSMLinearizationPointFinder.h
@@ -27,7 +27,7 @@ public:
   HSMLinearizationPointFinder( const RecTracksDistanceMatrix * m,
       const signed int n_pairs = -1 );
 
-  virtual HSMLinearizationPointFinder * clone() const;
+  HSMLinearizationPointFinder * clone() const override;
 };
 
 #endif

--- a/RecoVertex/LinearizationPointFinders/interface/LMSLinearizationPointFinder.h
+++ b/RecoVertex/LinearizationPointFinders/interface/LMSLinearizationPointFinder.h
@@ -27,7 +27,7 @@ public:
   LMSLinearizationPointFinder( const RecTracksDistanceMatrix * m,
       const signed int n_pairs = -1 );
 
-  virtual LMSLinearizationPointFinder * clone() const;
+  LMSLinearizationPointFinder * clone() const override;
 };
 
 #endif

--- a/RecoVertex/LinearizationPointFinders/interface/SMSLinearizationPointFinder.h
+++ b/RecoVertex/LinearizationPointFinders/interface/SMSLinearizationPointFinder.h
@@ -28,7 +28,7 @@ public:
   SMSLinearizationPointFinder( const RecTracksDistanceMatrix * m,
       signed int n_pairs = -1, const SMS & sms = SMS() );
 
-  virtual SMSLinearizationPointFinder * clone() const;
+  SMSLinearizationPointFinder * clone() const override;
 };
 
 #endif

--- a/RecoVertex/LinearizationPointFinders/interface/SubsetHSMLinearizationPointFinder.h
+++ b/RecoVertex/LinearizationPointFinders/interface/SubsetHSMLinearizationPointFinder.h
@@ -27,7 +27,7 @@ public:
   SubsetHSMLinearizationPointFinder( const RecTracksDistanceMatrix * m,
       const signed int n_pairs = -1 );
 
-  virtual SubsetHSMLinearizationPointFinder * clone() const;
+  SubsetHSMLinearizationPointFinder * clone() const override;
 };
 
 #endif

--- a/RecoVertex/LinearizationPointFinders/interface/ZeroLinearizationPointFinder.h
+++ b/RecoVertex/LinearizationPointFinders/interface/ZeroLinearizationPointFinder.h
@@ -10,10 +10,10 @@
 class ZeroLinearizationPointFinder : public LinearizationPointFinder
 {
 public:
-  virtual GlobalPoint getLinearizationPoint(const std::vector<reco::TransientTrack> & ) const;
-  virtual GlobalPoint getLinearizationPoint(const std::vector<FreeTrajectoryState> & ) const;
+  GlobalPoint getLinearizationPoint(const std::vector<reco::TransientTrack> & ) const override;
+  GlobalPoint getLinearizationPoint(const std::vector<FreeTrajectoryState> & ) const override;
 
-  virtual ZeroLinearizationPointFinder * clone() const
+  ZeroLinearizationPointFinder * clone() const override
   {
     return new ZeroLinearizationPointFinder ( * this );
   };

--- a/RecoVertex/LinearizationPointFinders/src/CrossingPtBasedLinearizationPointFinder.cc
+++ b/RecoVertex/LinearizationPointFinders/src/CrossingPtBasedLinearizationPointFinder.cc
@@ -105,7 +105,7 @@ void graphicsDebug ( const std::vector < PointAndDistance > & input )
 
 CrossingPtBasedLinearizationPointFinder::CrossingPtBasedLinearizationPointFinder(
     const ModeFinder3d & algo, const signed int n_pairs ) :
-        useMatrix ( false ) , theNPairs ( n_pairs ), theMatrix ( 0 ),
+        useMatrix ( false ) , theNPairs ( n_pairs ), theMatrix ( nullptr ),
         theAlgo ( algo.clone() )
 {}
 
@@ -175,7 +175,7 @@ GlobalPoint CrossingPtBasedLinearizationPointFinder::useAllTracks(
 	 } // If sth goes wrong, we just dont add. Who cares?
         }
     }
-    if (! vgp.size() )
+    if (vgp.empty() )
     {
         return FallbackLinearizationPointFinder().getLinearizationPoint ( tracks );
     }
@@ -200,7 +200,7 @@ GlobalPoint CrossingPtBasedLinearizationPointFinder::useFullMatrix(
             vgp.push_back ( v );
         }
     }
-    if (! vgp.size() )
+    if (vgp.empty() )
     {
         return FallbackLinearizationPointFinder().getLinearizationPoint ( tracks );
     }
@@ -331,7 +331,7 @@ GlobalPoint CrossingPtBasedLinearizationPointFinder::getLinearizationPoint(
                 }
             }
         }
-        if (! vgp.size() )
+        if (vgp.empty() )
         {
             // no crossing points? Fallback to a crossingpoint-less lin pt finder!
             return FallbackLinearizationPointFinder().getLinearizationPoint ( tracks );

--- a/RecoVertex/MultiVertexFit/interface/MultiVertexBSeeder.h
+++ b/RecoVertex/MultiVertexFit/interface/MultiVertexBSeeder.h
@@ -14,12 +14,12 @@ class MultiVertexBSeeder : public VertexReconstructor
 public:
   MultiVertexBSeeder ( double nsigma=50. );
   std::vector<TransientVertex> vertices(
-      const std::vector<reco::TransientTrack> &) const; 
+      const std::vector<reco::TransientTrack> &) const override; 
   std::vector<TransientVertex> vertices(
       const std::vector<reco::TransientTrack> &,
-      const reco::BeamSpot & ) const; 
+      const reco::BeamSpot & ) const override; 
 
-  MultiVertexBSeeder * clone() const;
+  MultiVertexBSeeder * clone() const override;
 
 private:
   double theNSigma;

--- a/RecoVertex/MultiVertexFit/interface/MultiVertexReconstructor.h
+++ b/RecoVertex/MultiVertexFit/interface/MultiVertexReconstructor.h
@@ -16,21 +16,21 @@ public:
                              const AnnealingSchedule & s = DefaultMVFAnnealing(),
                              float revive=-1. );
   MultiVertexReconstructor ( const MultiVertexReconstructor & );
-  ~MultiVertexReconstructor();
+  ~MultiVertexReconstructor() override;
 
   std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &,
-      const reco::BeamSpot & ) const; 
-  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &) const; 
+      const reco::BeamSpot & ) const override; 
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &) const override; 
   std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &,
       const std::vector < reco::TransientTrack > & primaries ) const;
 
   std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &,
       const std::vector < reco::TransientTrack > & primaries,
-      const reco::BeamSpot & spot ) const;
+      const reco::BeamSpot & spot ) const override;
 
   VertexReconstructor * reconstructor() const;
 
-  MultiVertexReconstructor * clone() const;
+  MultiVertexReconstructor * clone() const override;
 
 private:
   VertexReconstructor * theOldReconstructor;

--- a/RecoVertex/MultiVertexFit/src/MultiVertexBSeeder.cc
+++ b/RecoVertex/MultiVertexFit/src/MultiVertexBSeeder.cc
@@ -104,7 +104,7 @@ namespace {
      *  momentum = total momentum of all tracks
      *
      */
-    if ( trks.size() == 0 ) return GlobalTrajectoryParameters();
+    if ( trks.empty() ) return GlobalTrajectoryParameters();
 
     GlobalVector mom = computeJetDirection ( trks );
     GlobalPoint pos = computeJetOrigin ( trks );

--- a/RecoVertex/MultiVertexFit/src/MultiVertexFitter.cc
+++ b/RecoVertex/MultiVertexFit/src/MultiVertexFitter.cc
@@ -223,7 +223,7 @@ vector < CachingVertex<5> > MultiVertexFitter::vertices (
     const vector < TransientTrack > & primaries )
 {
   // FIXME if vtces.size < 1 return sth that includes the primaries
-  if ( vtces.size() < 1 )
+  if ( vtces.empty() )
   {
     return vector < CachingVertex<5> > ();
   };
@@ -255,7 +255,7 @@ vector < CachingVertex<5> > MultiVertexFitter::vertices (
   clear();
   createPrimaries ( primaries );
   // FIXME if initials size < 1 return sth that includes the primaries
-  if (  initials.size() < 1 ) return initials;
+  if (  initials.empty() ) return initials;
   for ( vector< CachingVertex<5> >::const_iterator vtx=initials.begin();
         vtx!=initials.end() ; ++vtx )
   {

--- a/RecoVertex/MultiVertexFit/src/MultiVertexReconstructor.cc
+++ b/RecoVertex/MultiVertexFit/src/MultiVertexReconstructor.cc
@@ -53,7 +53,7 @@ namespace {
       bundles.push_back ( tnws );
     };
 
-    if ( bundles.size() == 0 ) return bundles;
+    if ( bundles.empty() ) return bundles;
 
     // now add not-yet assigned tracks
     for ( set < reco::TransientTrack >::const_iterator i=st.begin(); 

--- a/RecoVertex/NuclearInteractionProducer/interface/NuclearInteractionEDProducer.h
+++ b/RecoVertex/NuclearInteractionProducer/interface/NuclearInteractionEDProducer.h
@@ -52,10 +52,10 @@ public:
       typedef edm::RefVector<TrajectorySeedCollection> TrajectorySeedRefVector;
 
       explicit NuclearInteractionEDProducer(const edm::ParameterSet&);
-      ~NuclearInteractionEDProducer();
+      ~NuclearInteractionEDProducer() override;
 
    private:
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
 
       static bool isInside( const reco::TrackRef& track, const TrajectorySeedRefVector& seeds);
       void findAdditionalSecondaryTracks( reco::NuclearInteraction& nucl,

--- a/RecoVertex/NuclearInteractionProducer/src/NuclearVertexBuilder.cc
+++ b/RecoVertex/NuclearInteractionProducer/src/NuclearVertexBuilder.cc
@@ -13,7 +13,7 @@ void NuclearVertexBuilder::build( const reco::TrackRef& primTrack, std::vector<r
      std::sort(secTracks.begin(),secTracks.end(),cmpTracks());
      checkEnergy(primTrack, secTracks);
 
-     if( secTracks.size() != 0) {
+     if( !secTracks.empty()) {
          if( FillVertexWithAdaptVtxFitter(primTrack, secTracks) ) return;
          else if( FillVertexWithCrossingPoint(primTrack, secTracks) ) return;
          else FillVertexWithLastPrimHit( primTrack, secTracks);
@@ -123,7 +123,7 @@ ClosestApproachInRPhi* NuclearVertexBuilder::closestApproach( const reco::TrackR
             bool status = theApproach->calculate(primTraj,secTraj);
             if( status ) { return theApproach; }
             else { 
-                   return NULL;
+                   return nullptr;
             }
 }
 

--- a/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ.h
@@ -51,7 +51,7 @@ struct vertex_t{
  DAClusterizerInZ(const edm::ParameterSet& conf);
 
   std::vector< std::vector<reco::TransientTrack> >
-    clusterize(const std::vector<reco::TransientTrack> & tracks)const;
+    clusterize(const std::vector<reco::TransientTrack> & tracks)const override;
 
 
   std::vector< TransientVertex >

--- a/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
@@ -169,7 +169,7 @@ public:
   
   
   std::vector<std::vector<reco::TransientTrack> >
-  clusterize(const std::vector<reco::TransientTrack> & tracks) const;
+  clusterize(const std::vector<reco::TransientTrack> & tracks) const override;
   
   
   std::vector<TransientVertex>

--- a/RecoVertex/PrimaryVertexProducer/interface/GapClusterizerInZ.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/GapClusterizerInZ.h
@@ -21,14 +21,14 @@ public:
   GapClusterizerInZ(const edm::ParameterSet& conf);
 
   std::vector< std::vector<reco::TransientTrack> >
-    clusterize(const std::vector<reco::TransientTrack> & tracks)const;
+    clusterize(const std::vector<reco::TransientTrack> & tracks)const override;
 
   float zSeparation() const;
 
   std::vector< TransientVertex >
     vertices(const std::vector<reco::TransientTrack> & tracks)const;
 
-  ~GapClusterizerInZ(){};
+  ~GapClusterizerInZ() override{};
   
 private:
   float zSep;

--- a/RecoVertex/PrimaryVertexProducer/interface/HITrackFilterForPVFinding.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/HITrackFilterForPVFinding.h
@@ -26,7 +26,7 @@ private:
     
 
   // override the select method
-  std::vector<reco::TransientTrack> select (const std::vector<reco::TransientTrack>& tracks) const{
+  std::vector<reco::TransientTrack> select (const std::vector<reco::TransientTrack>& tracks) const override{
     std::vector<reco::TransientTrack> seltks = TrackFilterForPVFinding::select(tracks);
     if (seltks.size()<NumTracksThreshold_){
       return tracks;

--- a/RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexProducerAlgorithm.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexProducerAlgorithm.h
@@ -59,11 +59,11 @@ class PrimaryVertexProducerAlgorithm : public VertexReconstructor {
 public:
 
   explicit PrimaryVertexProducerAlgorithm(const edm::ParameterSet&);
-  ~PrimaryVertexProducerAlgorithm();
+  ~PrimaryVertexProducerAlgorithm() override;
   
   // obsolete method
-  virtual std::vector<TransientVertex> 
-  vertices(const std::vector<reco::TransientTrack> & tracks) const;
+  std::vector<TransientVertex> 
+  vertices(const std::vector<reco::TransientTrack> & tracks) const override;
 
   virtual std::vector<TransientVertex> 
   vertices(const std::vector<reco::TransientTrack> & tracks, 
@@ -72,7 +72,7 @@ public:
 	   ) const;
   /** Clone method
    */ 
-  virtual PrimaryVertexProducerAlgorithm * clone() const {
+  PrimaryVertexProducerAlgorithm * clone() const override {
     return new PrimaryVertexProducerAlgorithm(*this);
   }
   

--- a/RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h
@@ -17,7 +17,7 @@ public:
 
   TrackFilterForPVFinding(const edm::ParameterSet& conf);
   bool operator() (const reco::TransientTrack & tracks)const;
-  std::vector<reco::TransientTrack> select (const std::vector<reco::TransientTrack>& tracks)const;
+  std::vector<reco::TransientTrack> select (const std::vector<reco::TransientTrack>& tracks)const override;
 
 private:
 

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ.cc
@@ -711,7 +711,7 @@ DAClusterizerInZ::clusterize(const vector<reco::TransientTrack> & tracks)
   vector< TransientVertex > pv=vertices(tracks);
 
   if(verbose_){ cout << "# DAClusterizerInZ::clusterize   pv.size="<<pv.size() << endl;  }
-  if (pv.size()==0){ return clusters;}
+  if (pv.empty()){ return clusters;}
 
 
   // fill into clusters and merge

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -285,7 +285,7 @@ bool DAClusterizerInZ_vect::merge(vertex_t & y, double & beta)const{
       critical.push_back( make_pair( std::fabs(y._z[k + 1] - y._z[k]), k) );
     }
   }
-  if (critical.size() == 0) return false;
+  if (critical.empty()) return false;
 
   std::stable_sort(critical.begin(), critical.end(), std::less<std::pair<double, unsigned int> >() );
 
@@ -436,7 +436,7 @@ DAClusterizerInZ_vect::split(const double beta,  track_t &tks, vertex_t & y, dou
       critical.push_back( make_pair(Tc, k));
     }
   }
-  if (critical.size()==0) return false;
+  if (critical.empty()) return false;
 
 
   std::stable_sort(critical.begin(), critical.end(), std::greater<std::pair<double, unsigned int> >() );
@@ -759,7 +759,7 @@ vector<vector<reco::TransientTrack> > DAClusterizerInZ_vect::clusterize(
     std::cout  << "# DAClusterizerInZ::clusterize   pv.size=" << pv.size()
 					     << endl;
   }
-  if (pv.size() == 0) {
+  if (pv.empty()) {
     return clusters;
   }
   

--- a/RecoVertex/TrimmedKalmanVertexFinder/interface/ConfigurableTrimmedVertexFinder.h
+++ b/RecoVertex/TrimmedKalmanVertexFinder/interface/ConfigurableTrimmedVertexFinder.h
@@ -49,14 +49,14 @@ public:
 				  const VertexUpdator<5> * vu, 
 				  const VertexTrackCompatibilityEstimator<5> * ve);
 
-  virtual ~ConfigurableTrimmedVertexFinder() {}
+  ~ConfigurableTrimmedVertexFinder() override {}
 
-  virtual std::vector<TransientVertex> 
-    vertices(const std::vector<reco::TransientTrack> & tracks) const;
+  std::vector<TransientVertex> 
+    vertices(const std::vector<reco::TransientTrack> & tracks) const override;
   
-  virtual std::vector<TransientVertex> 
+  std::vector<TransientVertex> 
     vertices(const std::vector<reco::TransientTrack> & tracks,
-        const reco::BeamSpot & spot ) const;
+        const reco::BeamSpot & spot ) const override;
 
   std::vector<TransientVertex> 
     vertices( const std::vector<reco::TransientTrack> & tracks,
@@ -90,7 +90,7 @@ public:
 
   /** Clone method
    */
-  virtual ConfigurableTrimmedVertexFinder * clone() const {
+  ConfigurableTrimmedVertexFinder * clone() const override {
     return new ConfigurableTrimmedVertexFinder(*this);
   }
 

--- a/RecoVertex/TrimmedKalmanVertexFinder/interface/KalmanTrimmedVertexFinder.h
+++ b/RecoVertex/TrimmedKalmanVertexFinder/interface/KalmanTrimmedVertexFinder.h
@@ -18,22 +18,22 @@ public:
   KalmanTrimmedVertexFinder();
   KalmanTrimmedVertexFinder(
     const KalmanTrimmedVertexFinder & other);
-  virtual ~KalmanTrimmedVertexFinder();
+  ~KalmanTrimmedVertexFinder() override;
 
   /** Clone method
    */
-  virtual KalmanTrimmedVertexFinder * clone() const {
+  KalmanTrimmedVertexFinder * clone() const override {
     return new KalmanTrimmedVertexFinder(*this);
   }
 
-  virtual inline std::vector<TransientVertex> 
-    vertices(const std::vector<reco::TransientTrack> & tracks) const { 
+  inline std::vector<TransientVertex> 
+    vertices(const std::vector<reco::TransientTrack> & tracks) const override { 
     return theFinder->vertices(tracks); 
   }
   
-  virtual inline std::vector<TransientVertex> 
+  inline std::vector<TransientVertex> 
     vertices(const std::vector<reco::TransientTrack> & tracks,
-        const reco::BeamSpot & s ) const { 
+        const reco::BeamSpot & s ) const override { 
     return theFinder->vertices(tracks,s); 
   }
 

--- a/RecoVertex/TrimmedKalmanVertexFinder/src/ConfigurableTrimmedVertexFinder.cc
+++ b/RecoVertex/TrimmedKalmanVertexFinder/src/ConfigurableTrimmedVertexFinder.cc
@@ -84,7 +84,7 @@ std::vector<TransientVertex> ConfigurableTrimmedVertexFinder::vertexCandidates(
 
   while (true) {
 
-    float tkCompCut = (cand.size() == 0 ? 
+    float tkCompCut = (cand.empty() ? 
 		       theTrackCompatibilityToPV 
 		       : theTrackCompatibilityToSV);
 
@@ -94,7 +94,7 @@ std::vector<TransientVertex> ConfigurableTrimmedVertexFinder::vertexCandidates(
     //	 << theClusterFinder.trackCompatibilityCut() << std::endl;
 
     std::vector<TransientVertex> newVertices;
-    if ( cand.size() == 0 && use_spot )
+    if ( cand.empty() && use_spot )
     {
       newVertices = theClusterFinder.vertices(remain, spot );
     } else {

--- a/RecoVertex/TrimmedKalmanVertexFinder/src/TrimmedVertexFinder.cc
+++ b/RecoVertex/TrimmedKalmanVertexFinder/src/TrimmedVertexFinder.cc
@@ -137,7 +137,7 @@ TrimmedVertexFinder::vertices(std::vector<TransientTrack> & tks,
     const PerigeeLinearizedTrackState* plts = 
       dynamic_cast<const PerigeeLinearizedTrackState*>
       ((**i).linearizedTrack().get());
-    if (plts == 0) {
+    if (plts == nullptr) {
       throw cms::Exception("TrimmedVertexFinder: can't take track from non-perigee track state");
     }
 

--- a/RecoVertex/TrimmedVertexFit/interface/TrimmedVertexFitter.h
+++ b/RecoVertex/TrimmedVertexFit/interface/TrimmedVertexFitter.h
@@ -19,32 +19,32 @@ public:
   TrimmedVertexFitter();
   TrimmedVertexFitter(const edm::ParameterSet & pSet);
 
-  virtual ~TrimmedVertexFitter(){}
+  ~TrimmedVertexFitter() override{}
 
-  virtual CachingVertex<5> vertex(const std::vector<reco::TransientTrack> & tracks) const;
+  CachingVertex<5> vertex(const std::vector<reco::TransientTrack> & tracks) const override;
 
-  virtual CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack> & tracks) const;
+  CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack> & tracks) const override;
   
-  virtual CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack> & tracks,
-      const reco::BeamSpot & spot ) const;
+  CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack> & tracks,
+      const reco::BeamSpot & spot ) const override;
 
-  virtual CachingVertex<5> vertex(const std::vector<reco::TransientTrack> & tracks,
-  			const GlobalPoint& linPoint) const;
+  CachingVertex<5> vertex(const std::vector<reco::TransientTrack> & tracks,
+  			const GlobalPoint& linPoint) const override;
 
-  virtual CachingVertex<5> vertex(const std::vector<reco::TransientTrack> & tracks,
+  CachingVertex<5> vertex(const std::vector<reco::TransientTrack> & tracks,
   			const GlobalPoint& priorPos,
-			const GlobalError& priorError) const;
+			const GlobalError& priorError) const override;
 
-  virtual CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack> & tracks,
+  CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack> & tracks,
 	 		const GlobalPoint& priorPos,
-			const GlobalError& priorError) const;
+			const GlobalError& priorError) const override;
 
-  virtual CachingVertex<5> vertex(const std::vector<reco::TransientTrack> & tracks,
-		const reco::BeamSpot& beamSpot) const;
+  CachingVertex<5> vertex(const std::vector<reco::TransientTrack> & tracks,
+		const reco::BeamSpot& beamSpot) const override;
 
 
    // Clone method
-  TrimmedVertexFitter * clone() const;
+  TrimmedVertexFitter * clone() const override;
 
 
   void setPtCut ( float cut );

--- a/RecoVertex/TrimmedVertexFit/src/TrimmedVertexFitter.cc
+++ b/RecoVertex/TrimmedVertexFit/src/TrimmedVertexFitter.cc
@@ -23,7 +23,7 @@ CachingVertex<5>
 TrimmedVertexFitter::vertex(const std::vector<reco::TransientTrack> & tracks) const
 {
   std::vector<TransientVertex> vtces = theRector.vertices ( tracks );
-  if (vtces.size() )
+  if (!vtces.empty() )
   {
     const TransientVertex & rv = *(vtces.begin());
     LinearizedTrackStateFactory lfac;

--- a/RecoVertex/V0Producer/src/V0Fitter.cc
+++ b/RecoVertex/V0Producer/src/V0Fitter.cc
@@ -91,7 +91,7 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
 
    edm::Handle<reco::TrackCollection> theTrackHandle;
    iEvent.getByToken(token_tracks, theTrackHandle);
-   if (!theTrackHandle->size()) return;
+   if (theTrackHandle->empty()) return;
    const reco::TrackCollection* theTrackCollection = theTrackHandle.product();   
 
    edm::Handle<reco::BeamSpot> theBeamSpotHandle;
@@ -240,8 +240,8 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
       }
 
       if (useRefTracks_ && theRefTracks.size() > 1) {
-         reco::TransientTrack* thePositiveRefTrack = 0;
-         reco::TransientTrack* theNegativeRefTrack = 0;
+         reco::TransientTrack* thePositiveRefTrack = nullptr;
+         reco::TransientTrack* theNegativeRefTrack = nullptr;
          for (std::vector<reco::TransientTrack>::iterator iTrack = theRefTracks.begin(); iTrack != theRefTracks.end(); ++iTrack) {
             if (iTrack->track().charge() > 0.) {
                thePositiveRefTrack = &*iTrack;
@@ -249,7 +249,7 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
                theNegativeRefTrack = &*iTrack;
             }
          }
-         if (thePositiveRefTrack == 0 || theNegativeRefTrack == 0) continue;
+         if (thePositiveRefTrack == nullptr || theNegativeRefTrack == nullptr) continue;
          trajPlus.reset(new TrajectoryStateClosestToPoint(thePositiveRefTrack->trajectoryStateClosestToPoint(vtxPos)));
          trajMins.reset(new TrajectoryStateClosestToPoint(theNegativeRefTrack->trajectoryStateClosestToPoint(vtxPos)));
       } else {
@@ -257,7 +257,7 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
          trajMins.reset(new TrajectoryStateClosestToPoint(negTransTkPtr->trajectoryStateClosestToPoint(vtxPos)));
       }
 
-      if (trajPlus.get() == 0 || trajMins.get() == 0 || !trajPlus->isValid() || !trajMins->isValid()) continue;
+      if (trajPlus.get() == nullptr || trajMins.get() == nullptr || !trajPlus->isValid() || !trajMins->isValid()) continue;
 
       GlobalVector positiveP(trajPlus->momentum());
       GlobalVector negativeP(trajMins->momentum());

--- a/RecoVertex/VertexPrimitives/interface/BasicSingleVertexState.h
+++ b/RecoVertex/VertexPrimitives/interface/BasicSingleVertexState.h
@@ -48,27 +48,27 @@ public:
 
   /** Access methods
    */
-  virtual BasicSingleVertexState* clone() const
+  BasicSingleVertexState* clone() const override
   {
     return new BasicSingleVertexState(*this);
   }
 
-  GlobalPoint position() const;
-  GlobalError error() const;
-  GlobalError error4D() const;
-  double time() const;
-  double timeError() const;
-  GlobalWeight weight() const;
-  GlobalWeight weight4D() const;
-  AlgebraicVector3 weightTimesPosition() const;
-  AlgebraicVector4 weightTimesPosition4D() const;
-  double weightInMixture() const;
+  GlobalPoint position() const override;
+  GlobalError error() const override;
+  GlobalError error4D() const override;
+  double time() const override;
+  double timeError() const override;
+  GlobalWeight weight() const override;
+  GlobalWeight weight4D() const override;
+  AlgebraicVector3 weightTimesPosition() const override;
+  AlgebraicVector4 weightTimesPosition4D() const override;
+  double weightInMixture() const override;
 
   /**
    * The validity of the vertex
    */
-  bool isValid() const {return valid;}
-  bool is4D() const { return vertexIs4D; }
+  bool isValid() const override {return valid;}
+  bool is4D() const override { return vertexIs4D; }
 
 private:
 

--- a/RecoVertex/VertexPrimitives/interface/BasicVertexState.h
+++ b/RecoVertex/VertexPrimitives/interface/BasicVertexState.h
@@ -35,7 +35,7 @@ private:
 
 public:
 
-  virtual ~BasicVertexState() {}
+  ~BasicVertexState() override {}
 
   virtual BasicVertexState* clone() const = 0;
 

--- a/RecoVertex/VertexPrimitives/interface/LinearizedTrackState.h
+++ b/RecoVertex/VertexPrimitives/interface/LinearizedTrackState.h
@@ -50,7 +50,7 @@ public:
 
   typedef ReferenceCountingPointer<RefittedTrackState<N> > RefCountedRefittedTrackState;
 
-  virtual ~LinearizedTrackState(){}
+  ~LinearizedTrackState() override{}
 
   /**
    * Returns a new linearized state with respect to a new linearization point.

--- a/RecoVertex/VertexPrimitives/interface/RefittedTrackState.h
+++ b/RecoVertex/VertexPrimitives/interface/RefittedTrackState.h
@@ -30,7 +30,7 @@ public:
 //   typedef ROOT::Math::SMatrix<double,N-2,3,ROOT::Math::MatRepStd<double,N-2,3> > AlgebraicMatrixM3;
   typedef ROOT::Math::SMatrix<double,N,N,ROOT::Math::MatRepSym<double,N> > AlgebraicSymMatrixNN;
 
-  virtual ~RefittedTrackState(){}
+  ~RefittedTrackState() override{}
 
   /**
    * Transformation into a FreeTrajectoryState

--- a/RecoVertex/VertexPrimitives/interface/VertexException.h
+++ b/RecoVertex/VertexPrimitives/interface/VertexException.h
@@ -13,8 +13,8 @@ class VertexException : public std::exception {
 public:
   VertexException() throw() {}
   VertexException( const std::string& message) throw() : theMessage(message) {}
-  virtual ~VertexException() throw() {}
-  virtual const char* what() const throw() { return theMessage.c_str();}
+  ~VertexException() throw() override {}
+  const char* what() const throw() override { return theMessage.c_str();}
 private:
   std::string theMessage;
 };

--- a/RecoVertex/VertexTools/interface/DeterministicAnnealing.h
+++ b/RecoVertex/VertexTools/interface/DeterministicAnnealing.h
@@ -18,25 +18,25 @@ public:
   DeterministicAnnealing( float cutoff = 3.0 );
   DeterministicAnnealing( const std::vector < float > & sched, float cutoff = 3.0 );
 
-  void anneal(); //< One annealing step. theT *= theRatio.
-  void resetAnnealing(); //< theT = theT0.
+  void anneal() override; //< One annealing step. theT *= theRatio.
+  void resetAnnealing() override; //< theT = theT0.
 
   /**
    *  phi ( chi2 ) = e^( -.5*chi2 / T )
    */
-  double phi ( double chi2 ) const;
+  double phi ( double chi2 ) const override;
 
   /**
    *  Returns phi(chi2) / ( phi(cutoff^2) + phi(chi2) ),
    */
-  double weight ( double chi2 ) const;
+  double weight ( double chi2 ) const override;
   
   /**
    * is it annealed yet?
    */
-  bool isAnnealed() const;
+  bool isAnnealed() const override;
 
-  void debug() const;
+  void debug() const override;
 
   /**
    *  Returns phi(chi2) / ( phi(cutoff^2) + sum_i { phi(chi2s[i]) } )
@@ -44,11 +44,11 @@ public:
   // double weight ( double chi2, const vector < double > & chi2s ) const;
 
 
-  double cutoff() const;
-  double currentTemp() const;
-  double initialTemp() const;
+  double cutoff() const override;
+  double currentTemp() const override;
+  double initialTemp() const override;
 
-  DeterministicAnnealing * clone() const
+  DeterministicAnnealing * clone() const override
   {
     return new DeterministicAnnealing ( * this );
   };

--- a/RecoVertex/VertexTools/interface/DummyTrackToTrackCovCalculator.h
+++ b/RecoVertex/VertexTools/interface/DummyTrackToTrackCovCalculator.h
@@ -13,8 +13,8 @@ class DummyTrackToTrackCovCalculator : public TrackToTrackCovCalculator<N> {
 
 public:
 
-  virtual typename CachingVertex<N>::TrackToTrackMap operator() (const CachingVertex<N> &) const;
-  virtual DummyTrackToTrackCovCalculator * clone() const;
+  typename CachingVertex<N>::TrackToTrackMap operator() (const CachingVertex<N> &) const override;
+  DummyTrackToTrackCovCalculator * clone() const override;
 
 };
 

--- a/RecoVertex/VertexTools/interface/DummyVertexSmoother.h
+++ b/RecoVertex/VertexTools/interface/DummyVertexSmoother.h
@@ -10,8 +10,8 @@
 template <unsigned int N>
 class DummyVertexSmoother : public VertexSmoother<N> {
 public:
-  CachingVertex<N> smooth(const CachingVertex<N> & ) const;
-  DummyVertexSmoother * clone() const;
+  CachingVertex<N> smooth(const CachingVertex<N> & ) const override;
+  DummyVertexSmoother * clone() const override;
 };
 
 #endif

--- a/RecoVertex/VertexTools/interface/DummyVertexTrackUpdator.h
+++ b/RecoVertex/VertexTools/interface/DummyVertexTrackUpdator.h
@@ -16,10 +16,10 @@ public:
   /**
    * Computes the constrained track parameters
    */
-  virtual typename CachingVertex<N>::RefCountedVertexTrack
+  typename CachingVertex<N>::RefCountedVertexTrack
 	update(const CachingVertex<N> & v, 
-	typename CachingVertex<N>::RefCountedVertexTrack t) const;
-  virtual DummyVertexTrackUpdator * clone() const;
+	typename CachingVertex<N>::RefCountedVertexTrack t) const override;
+  DummyVertexTrackUpdator * clone() const override;
 
 };
 

--- a/RecoVertex/VertexTools/interface/FsmwModeFinder3d.h
+++ b/RecoVertex/VertexTools/interface/FsmwModeFinder3d.h
@@ -26,8 +26,8 @@ public:
      */
     FsmwModeFinder3d( float fraction = .5, float weightExponent = -2.,
                       float cutoff=10 /* microns */, int no_weights_above = 10 );
-    virtual GlobalPoint operator()( const std::vector< PointAndDistance> & ) const;
-    virtual FsmwModeFinder3d* clone() const;
+    GlobalPoint operator()( const std::vector< PointAndDistance> & ) const override;
+    FsmwModeFinder3d* clone() const override;
 private:
     float theFraction;
     float theWeightExponent;

--- a/RecoVertex/VertexTools/interface/GeometricAnnealing.h
+++ b/RecoVertex/VertexTools/interface/GeometricAnnealing.h
@@ -18,31 +18,31 @@ public:
   GeometricAnnealing( const double cutoff=3.0, const double T=256.0,
      const double annealing_ratio=0.25 );
 
-  void anneal(); //< One annealing step. theT *= theRatio.
-  void resetAnnealing(); //< theT = theT0.
+  void anneal() override; //< One annealing step. theT *= theRatio.
+  void resetAnnealing() override; //< theT = theT0.
 
   /**
    *  phi ( chi2 ) = e^( -.5 * chi2 / T )
    */
-  double phi ( double chi2 ) const;
+  double phi ( double chi2 ) const override;
 
   /**
    *  Returns phi(chi2) / ( phi(cutoff^2) + phi(chi2) ),
    */
-  double weight ( double chi2 ) const;
+  double weight ( double chi2 ) const override;
 
-  double cutoff() const;
-  double currentTemp() const;
-  double initialTemp() const;
+  double cutoff() const override;
+  double currentTemp() const override;
+  double initialTemp() const override;
 
   /**
    * is it annealed yet?
    */
-  bool isAnnealed() const;
+  bool isAnnealed() const override;
 
-  void debug() const;
+  void debug() const override;
 
-  GeometricAnnealing * clone() const
+  GeometricAnnealing * clone() const override
   {
     return new GeometricAnnealing ( * this );
   };

--- a/RecoVertex/VertexTools/interface/HsmModeFinder3d.h
+++ b/RecoVertex/VertexTools/interface/HsmModeFinder3d.h
@@ -11,8 +11,8 @@
  */
 class HsmModeFinder3d : public ModeFinder3d {
 public:
-  virtual GlobalPoint operator () ( const std::vector< PointAndDistance> & ) const;
-  virtual HsmModeFinder3d * clone() const;
+  GlobalPoint operator () ( const std::vector< PointAndDistance> & ) const override;
+  HsmModeFinder3d * clone() const override;
 };
 
 #endif

--- a/RecoVertex/VertexTools/interface/LinearizedTrackStateFactory.h
+++ b/RecoVertex/VertexTools/interface/LinearizedTrackStateFactory.h
@@ -16,16 +16,16 @@ class LinearizedTrackStateFactory : public AbstractLTSFactory<5> {
 public:
 
   RefCountedLinearizedTrackState
-    linearizedTrackState(const GlobalPoint & linP, const reco::TransientTrack & track) const;
+    linearizedTrackState(const GlobalPoint & linP, const reco::TransientTrack & track) const override;
 
   RefCountedLinearizedTrackState
     linearizedTrackState(const GlobalPoint & linP, const reco::TransientTrack & track,
-    	const TrajectoryStateOnSurface& tsos) const;
+    	const TrajectoryStateOnSurface& tsos) const override;
 
   RefCountedLinearizedTrackState
     linearizedTrackState(LinearizedTrackState<5> * lts) const;
 
-  const LinearizedTrackStateFactory * clone() const;
+  const LinearizedTrackStateFactory * clone() const override;
 
 //   RefCountedLinearizedTrackState
 //     linearizedTrackState(const GlobalPoint & linP, RefCountedKinematicParticle & prt) const;

--- a/RecoVertex/VertexTools/interface/LmsModeFinder3d.h
+++ b/RecoVertex/VertexTools/interface/LmsModeFinder3d.h
@@ -7,8 +7,8 @@
  */
 class LmsModeFinder3d : public ModeFinder3d {
 public:
-  virtual GlobalPoint operator () ( const std::vector< PointAndDistance> & values ) const;
-  virtual LmsModeFinder3d * clone() const;
+  GlobalPoint operator () ( const std::vector< PointAndDistance> & values ) const override;
+  LmsModeFinder3d * clone() const override;
 };
 
 #endif

--- a/RecoVertex/VertexTools/interface/PerigeeLinearizedTrackState.h
+++ b/RecoVertex/VertexTools/interface/PerigeeLinearizedTrackState.h
@@ -47,37 +47,37 @@ public:
    * Returns a new linearized state with respect to a new linearization point.
    * A new object of the same type is returned, without change to the existing one.
    */
-  virtual  RefCountedLinearizedTrackState stateWithNewLinearizationPoint
-    (const GlobalPoint & newLP) const;
+   RefCountedLinearizedTrackState stateWithNewLinearizationPoint
+    (const GlobalPoint & newLP) const override;
 
 
   /**
    * The point at which the track state has been linearized
    */
-  const GlobalPoint & linearizationPoint() const { return theLinPoint; }
+  const GlobalPoint & linearizationPoint() const override { return theLinPoint; }
 
-  virtual reco::TransientTrack track() const { return theTrack; }
+  reco::TransientTrack track() const override { return theTrack; }
 
   const TrajectoryStateOnSurface state() const { return theTSOS; }
 
   /** Method returning the constant term of the Taylor expansion
    *  of the measurement equation
    */
-  const AlgebraicVector5 & constantTerm() const;
+  const AlgebraicVector5 & constantTerm() const override;
 
   /** Method returning the Position Jacobian from the Taylor expansion
    *  (Matrix A)
    */
-  const AlgebraicMatrix53 & positionJacobian() const;
+  const AlgebraicMatrix53 & positionJacobian() const override;
 
   /** Method returning the Momentum Jacobian from the Taylor expansion
    *  (Matrix B)
    */
-  const AlgebraicMatrix53 & momentumJacobian() const;
+  const AlgebraicMatrix53 & momentumJacobian() const override;
 
   /** Method returning the parameters of the Taylor expansion
    */
-  const AlgebraicVector5 & parametersFromExpansion() const;
+  const AlgebraicVector5 & parametersFromExpansion() const override;
 
   /** Method returning the track state at the point of closest approach
    *  to the linearization point, in the transverse plane (a.k.a.
@@ -88,60 +88,60 @@ public:
   /** Method returning the parameters of the track state at the
    *  transverse impact point.
    */
-  AlgebraicVector5 predictedStateParameters() const;
+  AlgebraicVector5 predictedStateParameters() const override;
 
   /** Method returning the momentum part of the parameters of the track state
    *  at the linearization point.
    */
-  virtual AlgebraicVector3 predictedStateMomentumParameters() const;
+  AlgebraicVector3 predictedStateMomentumParameters() const override;
 
   /** Method returning the weight matrix of the track state at the
    *  transverse impact point.
    * The error variable is 0 in case of success.
    */
-  AlgebraicSymMatrix55 predictedStateWeight(int & error) const;
+  AlgebraicSymMatrix55 predictedStateWeight(int & error) const override;
 
   /** Method returning the covariance matrix of the track state at the
    *  transverse impact point.
    */
-  AlgebraicSymMatrix55 predictedStateError() const;
+  AlgebraicSymMatrix55 predictedStateError() const override;
 
   /** Method returning the momentum covariance matrix of the track state at the
    *  transverse impact point.
    */
-  AlgebraicSymMatrix33 predictedStateMomentumError() const;
+  AlgebraicSymMatrix33 predictedStateMomentumError() const override;
 
 //   /** Method returning the impact point measurement
 //    */
 //   ImpactPointMeasurement impactPointMeasurement() const;
 
-  TrackCharge charge() const {return theCharge;}
+  TrackCharge charge() const override {return theCharge;}
 
-  bool hasError() const;
+  bool hasError() const override;
 
-  bool operator ==(LinearizedTrackState<5> & other)const;
+  bool operator ==(LinearizedTrackState<5> & other)const override;
 
   bool operator ==(ReferenceCountingPointer<LinearizedTrackState<5> >& other)const;
 
   /** Creates the correct refitted state according to the results of the
    *  track refit.
    */
-  virtual RefCountedRefittedTrackState createRefittedTrackState(
+  RefCountedRefittedTrackState createRefittedTrackState(
   	const GlobalPoint & vertexPosition,
 	const AlgebraicVector3 & vectorParameters,
-	const AlgebraicSymMatrix66 & covarianceMatrix) const;
+	const AlgebraicSymMatrix66 & covarianceMatrix) const override;
 
 
-  virtual AlgebraicVector5 refittedParamFromEquation(
-	const RefCountedRefittedTrackState & theRefittedState) const;
+  AlgebraicVector5 refittedParamFromEquation(
+	const RefCountedRefittedTrackState & theRefittedState) const override;
 
-  virtual double weightInMixture() const {return theTSOS.weight();}
+  double weightInMixture() const override {return theTSOS.weight();}
 
-  virtual void inline checkParameters(AlgebraicVector5 & parameters) const;
+  void inline checkParameters(AlgebraicVector5 & parameters) const override;
 
-  virtual std::vector<ReferenceCountingPointer<LinearizedTrackState<5> > > components() const;
+  std::vector<ReferenceCountingPointer<LinearizedTrackState<5> > > components() const override;
 
-  virtual bool isValid() const;
+  bool isValid() const override;
 
 private:
 

--- a/RecoVertex/VertexTools/interface/PerigeeRefittedTrackState.h
+++ b/RecoVertex/VertexTools/interface/PerigeeRefittedTrackState.h
@@ -26,27 +26,27 @@ public:
   			    const double aWeight = 1.) :
     theState(tscp), momentumAtVertex(aMomentumAtVertex), theWeight(aWeight) {}
 
- virtual ~PerigeeRefittedTrackState(){}
+ ~PerigeeRefittedTrackState() override{}
 
   /**
    * Transformation into a FreeTrajectoryState
    */
 
-  virtual FreeTrajectoryState freeTrajectoryState() const
+  FreeTrajectoryState freeTrajectoryState() const override
     {return theState.theState();}
 
   /**
    * Transformation into a TSOS at a given surface
    */
-  virtual TrajectoryStateOnSurface trajectoryStateOnSurface(
-  		const Surface & surface) const;
+  TrajectoryStateOnSurface trajectoryStateOnSurface(
+  		const Surface & surface) const override;
 
   /**
    * Transformation into a TSOS at a given surface, with a given propagator
    */
 
-  virtual TrajectoryStateOnSurface trajectoryStateOnSurface(
-		const Surface & surface, const Propagator & propagator) const;
+  TrajectoryStateOnSurface trajectoryStateOnSurface(
+		const Surface & surface, const Propagator & propagator) const override;
 
   /**
    * Vector containing the refitted track parameters. <br>
@@ -54,21 +54,21 @@ public:
    *  (signed) transverse , longitudinal impact parameter)
    */
 
-  virtual AlgebraicVector5 parameters() const
+  AlgebraicVector5 parameters() const override
     {return theState.perigeeParameters().vector();}
 
   /**
    * The covariance matrix
    */
 
-  virtual AlgebraicSymMatrix55  covariance() const
+  AlgebraicSymMatrix55  covariance() const override
     {return theState.perigeeError().covarianceMatrix();}
 
   /**
    * Position at which the momentum is defined.
    */
 
-  virtual GlobalPoint position() const
+  GlobalPoint position() const override
     {return theState.referencePoint();}
 
   /**
@@ -76,23 +76,23 @@ public:
    * These are (signed transverse curvature, theta, phi)
    */
 
-  virtual AlgebraicVector3 momentumVector() const;
+  AlgebraicVector3 momentumVector() const override;
 
   /**
    *   The weight of this component in a mixture
    */
-  virtual double weight() const {return theWeight;}
+  double weight() const override {return theWeight;}
 
   /**
    * Returns a new refitted state of the same type, but with another weight.
    * The current state is unchanged.
    */
-  virtual ReferenceCountingPointer<RefittedTrackState<5> > stateWithNewWeight
-  	(const double newWeight) const;
+  ReferenceCountingPointer<RefittedTrackState<5> > stateWithNewWeight
+  	(const double newWeight) const override;
 
-  virtual std::vector<ReferenceCountingPointer<RefittedTrackState<5> > > components() const;
+  std::vector<ReferenceCountingPointer<RefittedTrackState<5> > > components() const override;
 
-  virtual reco::TransientTrack transientTrack() const;
+  reco::TransientTrack transientTrack() const override;
 
 private:
 

--- a/RecoVertex/VertexTools/interface/SequentialVertexFitter.h
+++ b/RecoVertex/VertexTools/interface/SequentialVertexFitter.h
@@ -67,7 +67,7 @@ public:
   SequentialVertexFitter(const SequentialVertexFitter & original);
 
 
-  virtual ~SequentialVertexFitter();
+  ~SequentialVertexFitter() override;
 
 
   /**
@@ -93,7 +93,7 @@ public:
   * \param tracks The container of RecTracks to fit.
   * \return The fitted vertex
   */
-  virtual CachingVertex<N> vertex(const std::vector<reco::TransientTrack> & tracks) const;
+  CachingVertex<N> vertex(const std::vector<reco::TransientTrack> & tracks) const override;
 
  /**
   * Method returning the fitted vertex, from a container of VertexTracks.
@@ -104,25 +104,25 @@ public:
   * \param tracks The container of VertexTracks to fit.
   * \return The fitted vertex
   */
-  virtual CachingVertex<N> vertex(const std::vector<RefCountedVertexTrack> & tracks) const;
+  CachingVertex<N> vertex(const std::vector<RefCountedVertexTrack> & tracks) const override;
 
   /**
    * Same as above, only now also with BeamSpot!
    */
-  virtual CachingVertex<N> vertex(const std::vector<RefCountedVertexTrack> & tracks, const reco::BeamSpot & spot ) const;
+  CachingVertex<N> vertex(const std::vector<RefCountedVertexTrack> & tracks, const reco::BeamSpot & spot ) const override;
 
 
   /** Fit vertex out of a set of RecTracks. Uses the specified linearization point.
    */
-  virtual CachingVertex<N>  vertex(const std::vector<reco::TransientTrack> & tracks, 
-  		const GlobalPoint& linPoint) const;
+  CachingVertex<N>  vertex(const std::vector<reco::TransientTrack> & tracks, 
+  		const GlobalPoint& linPoint) const override;
 
   /** Fit vertex out of a set of TransientTracks. 
    *  The specified BeamSpot will be used as priot, but NOT for the linearization.
    * The specified LinearizationPointFinder will be used to find the linearization point.
    */
-  virtual CachingVertex<N> vertex(const std::vector<reco::TransientTrack> & tracks,
-		const reco::BeamSpot& beamSpot) const;
+  CachingVertex<N> vertex(const std::vector<reco::TransientTrack> & tracks,
+		const reco::BeamSpot& beamSpot) const override;
 
 
   /** Fit vertex out of a set of RecTracks. 
@@ -130,17 +130,17 @@ public:
    *   estimate of the vertex position. The error is used for the 
    *   weight of the prior estimate.
    */
-  virtual CachingVertex<N> vertex(const std::vector<reco::TransientTrack> & tracks, 
+  CachingVertex<N> vertex(const std::vector<reco::TransientTrack> & tracks, 
   		const GlobalPoint& priorPos,
-  		const GlobalError& priorError) const;
+  		const GlobalError& priorError) const override;
 
   /** Fit vertex out of a set of VertexTracks
    *   Uses the position and error for the prior estimate of the vertex.
    *   This position is not used to relinearize the tracks.
    */
-  virtual CachingVertex<N> vertex(const std::vector<RefCountedVertexTrack> & tracks, 
+  CachingVertex<N> vertex(const std::vector<RefCountedVertexTrack> & tracks, 
   		const GlobalPoint& priorPos,
-  		const GlobalError& priorError) const;
+  		const GlobalError& priorError) const override;
 
 
 
@@ -177,7 +177,7 @@ public:
   const edm::ParameterSet parameterSet() const 
   {return thePSet;}
 
-  SequentialVertexFitter * clone() const {
+  SequentialVertexFitter * clone() const override {
     return new SequentialVertexFitter(* this);
   }
 

--- a/RecoVertex/VertexTools/interface/SequentialVertexSmoother.h
+++ b/RecoVertex/VertexTools/interface/SequentialVertexSmoother.h
@@ -32,7 +32,7 @@ public:
 			   const VertexSmoothedChiSquaredEstimator<N> & vse, 
 			   const TrackToTrackCovCalculator<N> & covCalc);
 
-  virtual ~SequentialVertexSmoother();
+  ~SequentialVertexSmoother() override;
 
   /**
    *  Special copy constructor cloning the private data
@@ -49,7 +49,7 @@ public:
    *	last update.
    *  \return the final vertex estimate, with all the supplementary information
    */
-  virtual CachingVertex<N> smooth(const CachingVertex<N> & vertex) const;
+  CachingVertex<N> smooth(const CachingVertex<N> & vertex) const override;
 
   /**
    *  Access methods
@@ -64,7 +64,7 @@ public:
   /**
    * Clone method 
    */
-  virtual SequentialVertexSmoother<N> * clone() const 
+  SequentialVertexSmoother<N> * clone() const override 
   {
     return new SequentialVertexSmoother(* this);
   }

--- a/RecoVertex/VertexTools/interface/SmsModeFinder3d.h
+++ b/RecoVertex/VertexTools/interface/SmsModeFinder3d.h
@@ -9,8 +9,8 @@
 class SmsModeFinder3d : public ModeFinder3d {
 public:
   SmsModeFinder3d ( const SMS & algo = SMS() );
-  virtual GlobalPoint operator () ( const std::vector< PointAndDistance> & values ) const;
-  virtual SmsModeFinder3d * clone() const;
+  GlobalPoint operator () ( const std::vector< PointAndDistance> & values ) const override;
+  SmsModeFinder3d * clone() const override;
 private:
   SMS theAlgo;
 };

--- a/RecoVertex/VertexTools/interface/SubsetHsmModeFinder3d.h
+++ b/RecoVertex/VertexTools/interface/SubsetHsmModeFinder3d.h
@@ -13,8 +13,8 @@
  */
 class SubsetHsmModeFinder3d : public ModeFinder3d {
 public:
-  virtual GlobalPoint operator () ( const std::vector< PointAndDistance> & values ) const;
-  virtual SubsetHsmModeFinder3d * clone() const;
+  GlobalPoint operator () ( const std::vector< PointAndDistance> & values ) const override;
+  SubsetHsmModeFinder3d * clone() const override;
 };
 
 #endif

--- a/RecoVertex/VertexTools/interface/VertexDistance3D.h
+++ b/RecoVertex/VertexTools/interface/VertexDistance3D.h
@@ -25,11 +25,11 @@ public:
    * the vector connecting the vertices and the reference vector:
    * if the scalar product is greater than zero, the sign is +1, else -1
    */
-  virtual Measurement1D signedDistance(const reco::Vertex &primVtx , 
+  Measurement1D signedDistance(const reco::Vertex &primVtx , 
 				 const reco::Vertex &secVtx,
-				 const GlobalVector & momentum) const;
+				 const GlobalVector & momentum) const override;
 
-  virtual VertexDistance3D * clone() const
+  VertexDistance3D * clone() const override
   {
     return new VertexDistance3D(*this);
   }
@@ -39,15 +39,15 @@ public:
 private:
 
   AlgebraicSymMatrix33 theNullMatrix;
-  virtual Measurement1D distance(const GlobalPoint & vtx1Position, 
+  Measurement1D distance(const GlobalPoint & vtx1Position, 
 				 const GlobalError & vtx1PositionError, 
 				 const GlobalPoint & vtx2Position, 
-				 const GlobalError & vtx2PositionError) const;
+				 const GlobalError & vtx2PositionError) const override;
 
-  virtual float compatibility(const GlobalPoint & vtx1Position, 
+  float compatibility(const GlobalPoint & vtx1Position, 
 			      const GlobalError & vtx1PositionError, 
 			      const GlobalPoint & vtx2Position, 
-			      const GlobalError & vtx2PositionError) const;
+			      const GlobalError & vtx2PositionError) const override;
 };
 
 

--- a/RecoVertex/VertexTools/interface/VertexDistanceXY.h
+++ b/RecoVertex/VertexTools/interface/VertexDistanceXY.h
@@ -22,11 +22,11 @@ public:
    * the vector connecting the vertices and the reference vector:
    * if the scalar product is greater than zero, the sign is +1, else -1
    */
-  virtual Measurement1D signedDistance(const reco::Vertex &primVtx , 
+  Measurement1D signedDistance(const reco::Vertex &primVtx , 
 				 const reco::Vertex &secVtx,
-				 const GlobalVector & momentum) const;
+				 const GlobalVector & momentum) const override;
 
-  virtual VertexDistanceXY * clone() const
+  VertexDistanceXY * clone() const override
   {
     return new VertexDistanceXY(*this);
   }
@@ -39,15 +39,15 @@ private:
 
   AlgebraicSymMatrix22 theNullMatrix;
 
-  virtual Measurement1D distance(const GlobalPoint & vtx1Position, 
+  Measurement1D distance(const GlobalPoint & vtx1Position, 
 				 const GlobalError & vtx1PositionError, 
 				 const GlobalPoint & vtx2Position, 
-				 const GlobalError & vtx2PositionError) const;
+				 const GlobalError & vtx2PositionError) const override;
 
-  virtual float compatibility(const GlobalPoint & vtx1Position, 
+  float compatibility(const GlobalPoint & vtx1Position, 
 			      const GlobalError & vtx1PositionError, 
 			      const GlobalPoint & vtx2Position, 
-			      const GlobalError & vtx2PositionError) const;
+			      const GlobalError & vtx2PositionError) const override;
 };
 
 

--- a/RecoVertex/VertexTools/src/FsmwModeFinder3d.cc
+++ b/RecoVertex/VertexTools/src/FsmwModeFinder3d.cc
@@ -51,7 +51,7 @@ GlobalPoint FsmwModeFinder3d::operator() (
     std::vector < SimpleCluster > cresx = algo(vx).first;
     std::vector < SimpleCluster > cresy = algo(vy).first;
     std::vector < SimpleCluster > cresz = algo(vz).first;
-    assert ( cresx.size() && cresy.size() && cresz.size() );
+    assert ( !cresx.empty() && !cresy.empty() && !cresz.empty() );
 
     GlobalPoint ret ( cresx.begin()->position().value(),
                       cresy.begin()->position().value(),

--- a/RecoVertex/VertexTools/src/PerigeeLinearizedTrackState.cc
+++ b/RecoVertex/VertexTools/src/PerigeeLinearizedTrackState.cc
@@ -33,7 +33,7 @@ bool PerigeeLinearizedTrackState::operator ==(LinearizedTrackState<5> & other)co
 {
   const PerigeeLinearizedTrackState* otherP = 
   	dynamic_cast<const PerigeeLinearizedTrackState*>(&other);
-  if (otherP == 0) {
+  if (otherP == nullptr) {
    throw VertexException("PerigeeLinearizedTrackState: don't know how to compare myself to non-perigee track state");
   }
   return (otherP->track() == theTrack);
@@ -44,7 +44,7 @@ bool PerigeeLinearizedTrackState::operator ==(ReferenceCountingPointer<Linearize
 {
   const PerigeeLinearizedTrackState* otherP = 
   	dynamic_cast<const PerigeeLinearizedTrackState*>(other.get());
-  if (otherP == 0) {
+  if (otherP == nullptr) {
    throw VertexException("PerigeeLinearizedTrackState: don't know how to compare myself to non-perigee track state");
   }
   return (otherP->track() == theTrack);

--- a/RecoVertex/VertexTools/src/SequentialVertexSmoother.cc
+++ b/RecoVertex/VertexTools/src/SequentialVertexSmoother.cc
@@ -40,7 +40,7 @@ SequentialVertexSmoother<N>::smooth(const CachingVertex<N> & vertex) const
   // Track refit
 
   std::vector<RefCountedVertexTrack> newTracks;
-  if (theVertexTrackUpdator != 0) {
+  if (theVertexTrackUpdator != nullptr) {
     const std::vector<RefCountedVertexTrack>&  vOut=vertex.tracks();
     for(typename std::vector<RefCountedVertexTrack>::const_iterator i = vOut.begin();
   	  i != vOut.end();i++)
@@ -64,12 +64,12 @@ SequentialVertexSmoother<N>::smooth(const CachingVertex<N> & vertex) const
   // Smoothed chi2
 
   float smChi2 = vertex.totalChiSquared();
-  if (theVertexSmoothedChiSquaredEstimator != 0) {
+  if (theVertexSmoothedChiSquaredEstimator != nullptr) {
     std::pair<bool, double> result = theVertexSmoothedChiSquaredEstimator->estimate(interVertex);
     smChi2 = result.second;
   }
 
-  if (theTrackToTrackCovCalculator == 0) {
+  if (theTrackToTrackCovCalculator == nullptr) {
     if  (vertex.hasPrior()) {
       return CachingVertex<N>(vertex.priorVertexState(), vertex.vertexState(),
     		  newTracks, smChi2);

--- a/RecoVertex/VertexTools/src/SubsetHsmModeFinder3d.cc
+++ b/RecoVertex/VertexTools/src/SubsetHsmModeFinder3d.cc
@@ -20,7 +20,7 @@ namespace {
 GlobalPoint SubsetHsmModeFinder3d::operator() ( const std::vector< PointAndDistance> & values )
     const 
 {
-  if ( values.size() == 0 )
+  if ( values.empty() )
   {
     throw VertexException ("SubsetHsmModeFinder3d: no value given.");
   };


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this quickly to avoid conflicts to the extent possible]