### PR TITLE
Clang-tidy checks for IORawData

### DIFF
--- a/IORawData/CaloPatterns/interface/HcalPatternXMLParser.h
+++ b/IORawData/CaloPatterns/interface/HcalPatternXMLParser.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include <map>
 #include <memory>
-#include <stdint.h>
+#include <cstdint>
 
 class HcalPatternXMLParserImpl;
 

--- a/IORawData/CaloPatterns/src/HcalFiberPattern.cc
+++ b/IORawData/CaloPatterns/src/HcalFiberPattern.cc
@@ -4,7 +4,7 @@
 static inline int setIf(const std::string& name,const std::map<std::string, std::string>& params) {
   std::map<std::string, std::string>::const_iterator j=params.find(name);
   if (j==params.end()) throw cms::Exception("InvalidFormat") << "Missing parameter '" << name << "'";
-  else return strtol(j->second.c_str(),0,0);
+  else return strtol(j->second.c_str(),nullptr,0);
 } 
 
 HcalFiberPattern::HcalFiberPattern(const std::map<std::string, std::string>& params, const std::vector<uint32_t>& data) : pattern_(data) {

--- a/IORawData/CaloPatterns/src/HcalPatternSource.cc
+++ b/IORawData/CaloPatterns/src/HcalPatternSource.cc
@@ -102,7 +102,7 @@ void HcalPatternSource::loadPatternFile(const std::string& filename) {
   std::map<std::string,std::string> params;
   std::vector<uint32_t> data;
   FILE* f=fopen(filename.c_str(), "r");
-  if (f==0) return;
+  if (f==nullptr) return;
   else {
     char block[4096];
     while (!feof(f)) {

--- a/IORawData/CaloPatterns/src/HcalPatternSource.h
+++ b/IORawData/CaloPatterns/src/HcalPatternSource.h
@@ -12,7 +12,7 @@
 class HcalPatternSource : public edm::EDProducer {
 public:
   HcalPatternSource(const edm::ParameterSet & pset);
-  virtual void produce(edm::Event& e, const edm::EventSetup& c);
+  void produce(edm::Event& e, const edm::EventSetup& c) override;
 private:  
   void loadPatterns(const std::string& patspec);
   void loadPatternFile(const std::string& filename);

--- a/IORawData/CaloPatterns/src/HcalPatternXMLParser.cc
+++ b/IORawData/CaloPatterns/src/HcalPatternXMLParser.cc
@@ -14,10 +14,10 @@ public:
 };
 
 HcalPatternXMLParser::HcalPatternXMLParser() {
-  m_parser=0;
+  m_parser=nullptr;
 }
 HcalPatternXMLParser::~HcalPatternXMLParser() {
-  if (m_parser!=0) delete m_parser;
+  if (m_parser!=nullptr) delete m_parser;
 }
 
   /*
@@ -56,7 +56,7 @@ HcalPatternXMLParser::~HcalPatternXMLParser() {
       m_items.clear();
       m_parameters.clear();
     }
-    virtual ~ConfigurationDBHandler() {
+    ~ConfigurationDBHandler() override {
       XMLString::release(&xc_Parameter);
       XMLString::release(&xc_Data);
       XMLString::release(&xc_name);
@@ -64,13 +64,13 @@ HcalPatternXMLParser::~HcalPatternXMLParser() {
       XMLString::release(&xc_elements);
       XMLString::release(&xc_encoding);
     }
-    virtual void startElement (const XMLCh *const uri, const XMLCh *const localname, const XMLCh *const qname, const Attributes &attrs) override;
-    virtual void endElement (const XMLCh *const uri, const XMLCh *const localname, const XMLCh *const qname) override;
-    virtual void characters (const XMLCh *const chars, const XMLSize_t length) override;
-    virtual void ignorableWhitespace (const XMLCh *const chars, const XMLSize_t length) override;
+    void startElement (const XMLCh *const uri, const XMLCh *const localname, const XMLCh *const qname, const Attributes &attrs) override;
+    void endElement (const XMLCh *const uri, const XMLCh *const localname, const XMLCh *const qname) override;
+    void characters (const XMLCh *const chars, const XMLSize_t length) override;
+    void ignorableWhitespace (const XMLCh *const chars, const XMLSize_t length) override;
   private:
     inline bool cvt2String(const XMLCh* val, std::string& ou) {
-      if (val==0) return false;
+      if (val==nullptr) return false;
       char* tool=XMLString::transcode(val);
       ou=tool;
       XMLString::release(&tool);
@@ -151,7 +151,7 @@ void HcalPatternXMLParser::parse(const std::string& xmlDocument, std::map<std::s
     ConfigurationDBHandler handler(parameters,items,encoding);
     
     try {
-      if (m_parser==0) {
+      if (m_parser==nullptr) {
 	m_parser=new HcalPatternXMLParserImpl();
 	m_parser->parser=std::auto_ptr<xercesc::SAX2XMLReader>(xercesc::XMLReaderFactory::createXMLReader());
       }
@@ -175,6 +175,6 @@ void HcalPatternXMLParser::parse(const std::string& xmlDocument, std::map<std::s
 
   data.clear();
   for (std::vector<std::string>::const_iterator i=items.begin(); i!=items.end(); i++)
-    data.push_back(strtol(i->c_str(),0,formatting));
+    data.push_back(strtol(i->c_str(),nullptr,formatting));
 
 }

--- a/IORawData/CaloPatterns/src/HtrXmlPattern.cc
+++ b/IORawData/CaloPatterns/src/HtrXmlPattern.cc
@@ -12,7 +12,7 @@
 
 HtrXmlPattern::HtrXmlPattern(const edm::ParameterSet& iConfig)
 {
-  m_filled=0;
+  m_filled=false;
   m_fill_by_hand        = iConfig.getUntrackedParameter<bool>("fill_by_hand");
   m_hand_pattern_number = iConfig.getUntrackedParameter<int> ("hand_pattern_number");
   m_sets_to_show        = iConfig.getUntrackedParameter<int> ("sets_to_show");
@@ -54,7 +54,7 @@ void HtrXmlPattern::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 
    if (m_fill_by_hand) {
      do_hand_fill(readoutMap);
-     m_filled=1;
+     m_filled=true;
      return;
    }
   

--- a/IORawData/CaloPatterns/src/HtrXmlPattern.h
+++ b/IORawData/CaloPatterns/src/HtrXmlPattern.h
@@ -21,11 +21,11 @@
 class HtrXmlPattern : public edm::EDAnalyzer {
 public:
   explicit HtrXmlPattern(const edm::ParameterSet&);
-  ~HtrXmlPattern();
+  ~HtrXmlPattern() override;
 
 private:
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
   virtual void do_hand_fill(const HcalElectronicsMap*);
   HtrXmlPatternTool *m_tool;
   HtrXmlPatternToolParameters *m_toolparameters;

--- a/IORawData/CaloPatterns/src/HtrXmlPatternSet.cc
+++ b/IORawData/CaloPatterns/src/HtrXmlPatternSet.cc
@@ -1,5 +1,5 @@
 #include "HtrXmlPatternSet.h"
-#include <math.h>
+#include <cmath>
 #include <iostream>
 
 ChannelPattern::ChannelPattern() {
@@ -43,7 +43,7 @@ void ChannelPattern::Fill_by_hand(const HcalElectronicsMap *emap,int pattern_num
   iCrate=6 ; dcc9[iCrate]=728; dcc19[iCrate]=729;
   iCrate=13; dcc9[iCrate]=730; dcc19[iCrate]=731;
 
-  int *dcc=0;
+  int *dcc=nullptr;
   int spigot=-100;
   if (m_slot>=2 && m_slot<=8) {
     spigot=2*m_slot-m_tb-3;
@@ -207,7 +207,7 @@ CrateData::CrateData(int crate, int slotsActive[ChannelPattern::NUM_SLOTS]) {
   for (int slot=0; slot<ChannelPattern::NUM_SLOTS; slot++) {
     for (int tb=0;tb<2;tb++) {
       if (slotsActive[slot]) m_slotsDoubled[slot][tb] = new HalfHtrData(crate,slot,tb);
-      else                   m_slotsDoubled[slot][tb] = 0;
+      else                   m_slotsDoubled[slot][tb] = nullptr;
     }
   }
 }
@@ -222,13 +222,13 @@ CrateData::~CrateData() {
 
 HalfHtrData* CrateData::getHalfHtrData(int slot, int tb) {
   if ( slot>=0 && slot<ChannelPattern::NUM_SLOTS && (tb==0 || tb==1) ) return m_slotsDoubled[slot][tb];
-  else return 0;
+  else return nullptr;
 }
 
 HtrXmlPatternSet::HtrXmlPatternSet(int cratesActive[ChannelPattern::NUM_CRATES], int slotsActive[ChannelPattern::NUM_SLOTS]) {
   for (int crate=0; crate<ChannelPattern::NUM_CRATES; crate++) {
     if (cratesActive[crate]) m_crates[crate] = new CrateData(crate,slotsActive);
-    else                     m_crates[crate] = 0;
+    else                     m_crates[crate] = nullptr;
   }
 }
 
@@ -240,5 +240,5 @@ HtrXmlPatternSet::~HtrXmlPatternSet() {
 
 CrateData* HtrXmlPatternSet::getCrate(int crate) {
   if (crate>=0 && crate<ChannelPattern::NUM_CRATES) return m_crates[crate];
-  else return 0;
+  else return nullptr;
 }

--- a/IORawData/CaloPatterns/src/HtrXmlPatternSet.h
+++ b/IORawData/CaloPatterns/src/HtrXmlPatternSet.h
@@ -38,7 +38,7 @@ private:
 class HalfHtrData {
 public:
   HalfHtrData(int crate, int slot, int tb);
-  ChannelPattern* getPattern(int chan) { return (chan>=1 && chan<=24)?(&m_patterns[chan-1]):(0); }
+  ChannelPattern* getPattern(int chan) { return (chan>=1 && chan<=24)?(&m_patterns[chan-1]):(nullptr); }
   int getCrate() const { return m_crate; }
   int getSlot() const { return m_slot; }
   int getTB() const { return m_tb; }

--- a/IORawData/CaloPatterns/src/HtrXmlPatternTool.cc
+++ b/IORawData/CaloPatterns/src/HtrXmlPatternTool.cc
@@ -39,8 +39,8 @@ HtrXmlPatternTool::~HtrXmlPatternTool() {
 
 void HtrXmlPatternTool::Fill(const HcalElectronicsId HEID,HBHEDigiCollection::const_iterator data) {
   CrateData* cd=m_patternSet->getCrate(HEID.readoutVMECrateId());
-  HalfHtrData* hd=0;
-  ChannelPattern* cp=0;
+  HalfHtrData* hd=nullptr;
+  ChannelPattern* cp=nullptr;
 
   if (cd) {
     hd=cd->getHalfHtrData(HEID.htrSlot(),HEID.htrTopBottom());
@@ -64,8 +64,8 @@ void HtrXmlPatternTool::Fill(const HcalElectronicsId HEID,HBHEDigiCollection::co
 
 void HtrXmlPatternTool::Fill(const HcalElectronicsId HEID,HFDigiCollection::const_iterator data) {
   CrateData* cd=m_patternSet->getCrate(HEID.readoutVMECrateId());
-  HalfHtrData* hd=0;
-  ChannelPattern* cp=0;
+  HalfHtrData* hd=nullptr;
+  ChannelPattern* cp=nullptr;
 
   if (cd) {
     hd=cd->getHalfHtrData(HEID.htrSlot(),HEID.htrTopBottom());
@@ -89,8 +89,8 @@ void HtrXmlPatternTool::Fill(const HcalElectronicsId HEID,HFDigiCollection::cons
 
 void HtrXmlPatternTool::Fill(const HcalElectronicsId HEID,HODigiCollection::const_iterator data) {
   CrateData* cd=m_patternSet->getCrate(HEID.readoutVMECrateId());
-  HalfHtrData* hd=0;
-  ChannelPattern* cp=0;
+  HalfHtrData* hd=nullptr;
+  ChannelPattern* cp=nullptr;
 
   if (cd) {
     hd=cd->getHalfHtrData(HEID.htrSlot(),HEID.htrTopBottom());
@@ -118,7 +118,7 @@ void HtrXmlPatternTool::prepareDirs() {
 
 void HtrXmlPatternTool::writeXML() {
   std::cout << "Writing XML..." << std::endl;
-  std::ofstream* of=0;
+  std::ofstream* of=nullptr;
 
   if (m_params->m_XML_file_mode==1) {
     std::string name=m_params->m_output_directory+(m_params->m_file_tag)+"_all.xml";
@@ -133,7 +133,7 @@ void HtrXmlPatternTool::writeXML() {
 
   for (int crate=0; crate<ChannelPattern::NUM_CRATES; crate++) {
     CrateData* cd=m_patternSet->getCrate(crate);
-    if (cd==0) continue;
+    if (cd==nullptr) continue;
 
     if (m_params->m_XML_file_mode==2) {
       std::string name=m_params->m_output_directory+(m_params->m_file_tag);
@@ -152,7 +152,7 @@ void HtrXmlPatternTool::writeXML() {
     for (int slot=0; slot<ChannelPattern::NUM_SLOTS; slot++) {
       for (int tb=0; tb<=1; tb++) {
 	HalfHtrData* hd=cd->getHalfHtrData(slot,tb);
-	if (hd==0) continue;
+	if (hd==nullptr) continue;
 	for (int fiber=1; fiber<=8; fiber++) {
 
 	  if (m_params->m_XML_file_mode==3) {
@@ -171,7 +171,7 @@ void HtrXmlPatternTool::writeXML() {
 	  if (m_params->m_XML_file_mode==3) {
 	    of->close();
 	    delete of;
-	    of=0;
+	    of=nullptr;
 	  }
 
 	} //end fiber loop
@@ -182,7 +182,7 @@ void HtrXmlPatternTool::writeXML() {
       (*of) << "</CFGBrickSet>" << std::endl;
       of->close();
       delete of;
-      of=0;
+      of=nullptr;
     }
     
   } //end crate loop
@@ -191,7 +191,7 @@ void HtrXmlPatternTool::writeXML() {
     (*of) << "</CFGBrickSet>" << std::endl;
     of->close();
     delete of;
-    of=0;
+    of=nullptr;
   }
 }
 
@@ -208,26 +208,26 @@ void HtrXmlPatternTool::createHists() {
 
   for (int crate=0; crate<ChannelPattern::NUM_CRATES; crate++) {
     CrateData* cd=m_patternSet->getCrate(crate);
-    if (cd==0) continue;
+    if (cd==nullptr) continue;
     for (int slot=0; slot<ChannelPattern::NUM_SLOTS; slot++) {
       for (int tb=0; tb<=1; tb++) {
 	HalfHtrData* hd=cd->getHalfHtrData(slot,tb);
-	if (hd==0) continue;
+	if (hd==nullptr) continue;
 	for (int chan=1; chan<=24; chan++) {
 	  ChannelPattern* cp=hd->getPattern(chan);
 	  char hname[128];
 	  sprintf(hname,"Exact fC Cr%d,%d%s-%d",crate,slot,
 		  ((tb==1)?("t"):("b")),chan);
 	  TH1* hp=new TH1F(hname,hname,ChannelPattern::SAMPLES,-0.5,ChannelPattern::SAMPLES-0.5);
-	  hp->SetDirectory(0);
+	  hp->SetDirectory(nullptr);
 	  sprintf(hname,"Quantized fC Cr%d,%d%s-%d",crate,slot,
 		  ((tb==1)?("t"):("b")),chan);
 	  TH1* hq=new TH1F(hname,hname,ChannelPattern::SAMPLES,-0.5,ChannelPattern::SAMPLES-0.5);
-	  hp->SetDirectory(0);
+	  hp->SetDirectory(nullptr);
 	  sprintf(hname,"Encoded fC Cr%d,%d%s-%d",crate,slot,
 		  ((tb==1)?("t"):("b")),chan);
 	  TH1* ha=new TH1F(hname,hname,ChannelPattern::SAMPLES,-0.5,ChannelPattern::SAMPLES-0.5);
-	  ha->SetDirectory(0);
+	  ha->SetDirectory(nullptr);
 	  for (int i=0; i<ChannelPattern::SAMPLES; i++) {
 	    hp->Fill(i*1.0,(*cp)[i]);
 	    hq->Fill(i*1.0,cp->getQuantized(i));

--- a/IORawData/CaloPatterns/src/HtrXmlPatternWriter.cc
+++ b/IORawData/CaloPatterns/src/HtrXmlPatternWriter.cc
@@ -10,7 +10,7 @@ static const char* tabbing(int level) {
 
 HtrXmlPatternWriter::HtrXmlPatternWriter() {
   // set the timestamp!
-  time_t now1=time(0);
+  time_t now1=time(nullptr);
   struct tm* now=localtime(&now1);
 
   char buffer[1024];

--- a/IORawData/DTCommissioning/plugins/DTDDUFileReader.cc
+++ b/IORawData/DTCommissioning/plugins/DTDDUFileReader.cc
@@ -94,7 +94,7 @@ int DTDDUFileReader::fillRawData(Event& e,
       word = dmaUnpack(dataTag,nread);
       if ( nread<=0 ) {
 	cout<<"[DTDDUFileReader]: ERROR! no more words and failed to get the trailer"<<endl;
-	delete data; data=0;
+	delete data; data=nullptr;
 	return false;
       }
     }
@@ -104,7 +104,7 @@ int DTDDUFileReader::fillRawData(Event& e,
       dataTag = false;
       if ( nread<=0 ) {
 	cout<<"[DTDDUFileReader]: ERROR! failed to get the trailer"<<endl;
-	delete data; data=0;
+	delete data; data=nullptr;
 	return false;
       }
     }
@@ -170,7 +170,7 @@ int DTDDUFileReader::fillRawData(Event& e,
 
 void DTDDUFileReader::produce(Event&e, EventSetup const&es){
    edm::Handle<FEDRawDataCollection> rawdata;
-   FEDRawDataCollection *fedcoll = 0;
+   FEDRawDataCollection *fedcoll = nullptr;
    fillRawData(e,fedcoll);
    std::unique_ptr<FEDRawDataCollection> bare_product(fedcoll);
    e.put(std::move(bare_product));

--- a/IORawData/DTCommissioning/plugins/DTDDUFileReader.h
+++ b/IORawData/DTCommissioning/plugins/DTDDUFileReader.h
@@ -25,14 +25,14 @@ class DTDDUFileReader : public edm::EDProducer {
   DTDDUFileReader(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~DTDDUFileReader();
+  ~DTDDUFileReader() override;
 
   /// Generate and fill FED raw data for a full event
   virtual int fillRawData(edm::Event& e,
 //			  edm::Timestamp& tstamp, 
 			  FEDRawDataCollection*& data);
 
-  virtual void produce(edm::Event&, edm::EventSetup const&);
+  void produce(edm::Event&, edm::EventSetup const&) override;
 
   /// check for a 64 bits word to be a DDU header
   bool isHeader(uint64_t word, bool dataTag);

--- a/IORawData/DTCommissioning/plugins/DTNewROS8FileReader.cc
+++ b/IORawData/DTCommissioning/plugins/DTNewROS8FileReader.cc
@@ -168,13 +168,13 @@ int DTNewROS8FileReader::fillRawData(Event& e,
     if ( i == 1 ){
       cout << "[DTNewROS8FileReader]: END OF FILE REACHED. "
            << "No information read for the requested event" << endl;
-      delete data; data=0;
+      delete data; data=nullptr;
       return false;
     }    
     else {
       cout << "[DTNewROS8FileReader]: PROBLEM WITH EVENT INFORMATION ON THE FILE. "
            << "EVENT DATA READING FAILED  code= " << i << endl;
-      delete data; data=0;
+      delete data; data=nullptr;
       return false;
     }
 
@@ -186,7 +186,7 @@ int DTNewROS8FileReader::fillRawData(Event& e,
 void DTNewROS8FileReader::produce(Event&e, EventSetup const&es){
 
    edm::Handle<FEDRawDataCollection> rawdata;
-   FEDRawDataCollection *fedcoll = 0;
+   FEDRawDataCollection *fedcoll = nullptr;
    fillRawData(e,fedcoll);
    std::unique_ptr<FEDRawDataCollection> bare_product(fedcoll);
    e.put(std::move(bare_product));

--- a/IORawData/DTCommissioning/plugins/DTNewROS8FileReader.h
+++ b/IORawData/DTCommissioning/plugins/DTNewROS8FileReader.h
@@ -22,14 +22,14 @@ class DTNewROS8FileReader : public edm::EDProducer {
   DTNewROS8FileReader(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~DTNewROS8FileReader();
+  ~DTNewROS8FileReader() override;
 
   /// Generate and fill FED raw data for a full event
   virtual int fillRawData(edm::Event& e,
 //			  edm::Timestamp& tstamp, 
 			  FEDRawDataCollection*& data);
 
-  virtual void produce(edm::Event&, edm::EventSetup const&);
+  void produce(edm::Event&, edm::EventSetup const&) override;
 
   virtual bool checkEndOfFile();
 

--- a/IORawData/DTCommissioning/plugins/DTROS25FileReader.cc
+++ b/IORawData/DTCommissioning/plugins/DTROS25FileReader.cc
@@ -113,14 +113,14 @@ int DTROS25FileReader::fillRawData(Event& e,
 
     if ( i == 1 ){
       cout<<"[DTROS25FileReader]: ERROR! failed to get the trailer"<<endl;
-      delete data; data=0;
+      delete data; data=nullptr;
       return false;
     }    
     else {
       cout<<"[DTROS25FileReader]:"
 	  <<" ERROR! ROS data exceeding estimated event dimension. Event size = "
 	  <<eventData.size()<<endl;
-      delete data; data=0;
+      delete data; data=nullptr;
       return false;
     }
     
@@ -130,7 +130,7 @@ int DTROS25FileReader::fillRawData(Event& e,
 
 void DTROS25FileReader::produce(Event&e, EventSetup const&es){
    edm::Handle<FEDRawDataCollection> rawdata;
-   FEDRawDataCollection *fedcoll = 0;
+   FEDRawDataCollection *fedcoll = nullptr;
    fillRawData(e,fedcoll);
    std::unique_ptr<FEDRawDataCollection> bare_product(fedcoll);
    e.put(std::move(bare_product));

--- a/IORawData/DTCommissioning/plugins/DTROS25FileReader.h
+++ b/IORawData/DTCommissioning/plugins/DTROS25FileReader.h
@@ -26,14 +26,14 @@ class DTROS25FileReader : public edm::EDProducer {
   DTROS25FileReader(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~DTROS25FileReader();
+  ~DTROS25FileReader() override;
 
   /// Generate and fill FED raw data for a full event
   virtual int fillRawData(edm::Event& e,
 //			  edm::Timestamp& tstamp, 
 			  FEDRawDataCollection*& data);
 
-  virtual void produce(edm::Event&, edm::EventSetup const&);
+  void produce(edm::Event&, edm::EventSetup const&) override;
 
   /// check for a 32 bits word to be a ROS25 header
   bool isHeader(uint32_t word);

--- a/IORawData/DTCommissioning/plugins/DTROS8FileReader.cc
+++ b/IORawData/DTCommissioning/plugins/DTROS8FileReader.cc
@@ -131,13 +131,13 @@ int DTROS8FileReader::fillRawData(Event& e,
     if ( i == 1 ){
       cout << "[DTROS8FileReader]: END OF FILE REACHED. "
            << "No information read for the requested event" << endl;
-      delete data; data=0;
+      delete data; data=nullptr;
       return false;
     }    
     else {
       cout << "[DTROS8FileReader]: PROBLEM WITH EVENT INFORMATION ON THE FILE. "
            << "EVENT DATA READING FAILED  code= " << i << endl;
-      delete data; data=0;
+      delete data; data=nullptr;
       return false;
     }
 
@@ -147,7 +147,7 @@ int DTROS8FileReader::fillRawData(Event& e,
 
 void DTROS8FileReader::produce(Event&e, EventSetup const&es){
    edm::Handle<FEDRawDataCollection> rawdata;
-   FEDRawDataCollection *fedcoll = 0;
+   FEDRawDataCollection *fedcoll = nullptr;
    fillRawData(e,fedcoll);
    std::unique_ptr<FEDRawDataCollection> bare_product(fedcoll);
    e.put(std::move(bare_product));

--- a/IORawData/DTCommissioning/plugins/DTROS8FileReader.h
+++ b/IORawData/DTCommissioning/plugins/DTROS8FileReader.h
@@ -24,14 +24,14 @@ class DTROS8FileReader : public edm::EDProducer {
   DTROS8FileReader(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~DTROS8FileReader();
+  ~DTROS8FileReader() override;
 
   /// Generate and fill FED raw data for a full event
   virtual int fillRawData(edm::Event& e,
 //			  edm::Timestamp& tstamp, 
 			  FEDRawDataCollection*& data);
 
-  virtual void produce(edm::Event&, edm::EventSetup const&);
+  void produce(edm::Event&, edm::EventSetup const&) override;
 
   virtual bool checkEndOfFile();
 

--- a/IORawData/DTCommissioning/plugins/DTSpy.cc
+++ b/IORawData/DTCommissioning/plugins/DTSpy.cc
@@ -8,8 +8,8 @@
  */
 
 #include "DTSpy.h"
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 
 #define DTSPY_HEAD_SIZE 36
 #define DTSPY_MAX_MSG  512*1024

--- a/IORawData/DTCommissioning/plugins/DTSpyHelper.cc
+++ b/IORawData/DTCommissioning/plugins/DTSpyHelper.cc
@@ -1,12 +1,12 @@
 #include "DTSpyHelper.h"
-#include <errno.h>
+#include <cerrno>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-#include <string.h>
+#include <cstring>
 
 #ifdef __wasAPPLE__
 typedef int socklen_t;
@@ -186,7 +186,7 @@ DTCtcp::WaitData(int timeout)
     tv.tv_sec = timeout;
     tv.tv_usec = 0;
  
-     int retva = select (1,&rfds,0,&rfds,&tv);
+     int retva = select (1,&rfds,nullptr,&rfds,&tv);
      if (retva)
          if (FD_ISSET(0,&rfds)) return 1;
          else return -1;

--- a/IORawData/DTCommissioning/plugins/DTSpyHelper.h
+++ b/IORawData/DTCommissioning/plugins/DTSpyHelper.h
@@ -6,7 +6,7 @@
 #include <sys/socket.h>
 #include <netinet/tcp.h>
 #include <netinet/in.h>
-#include <stdio.h>
+#include <cstdio>
 #include <netdb.h>
 
 class DTtcpExcp

--- a/IORawData/DTCommissioning/plugins/DTSpyReader.cc
+++ b/IORawData/DTCommissioning/plugins/DTSpyReader.cc
@@ -23,7 +23,7 @@
 #include <iosfwd>
 #include <iostream>
 #include <algorithm>
-#include <stdio.h>
+#include <cstdio>
 
    
 using namespace std;
@@ -136,7 +136,7 @@ int DTSpyReader::fillRawData(Event& e,
 
 void DTSpyReader::produce(Event&e, EventSetup const&es){
    edm::Handle<FEDRawDataCollection> rawdata;
-   FEDRawDataCollection *fedcoll = 0;
+   FEDRawDataCollection *fedcoll = nullptr;
    fillRawData(e,fedcoll);
    std::unique_ptr<FEDRawDataCollection> bare_product(fedcoll);
    e.put(std::move(bare_product));

--- a/IORawData/DTCommissioning/plugins/DTSpyReader.h
+++ b/IORawData/DTCommissioning/plugins/DTSpyReader.h
@@ -27,14 +27,14 @@ class DTSpyReader : public edm::EDProducer {
   DTSpyReader(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~DTSpyReader();
+  ~DTSpyReader() override;
 
   /// Generate and fill FED raw data for a full event
   virtual int fillRawData(edm::Event& e,
 //			  edm::Timestamp& tstamp, 
 			  FEDRawDataCollection*& data);
 
-  virtual void produce(edm::Event&, edm::EventSetup const&);
+  void produce(edm::Event&, edm::EventSetup const&) override;
 
   /// check for a 64 bits word to be a DDU header
   bool isHeader(uint64_t word, bool dataTag);

--- a/IORawData/DTCommissioning/plugins/RawFile.cc
+++ b/IORawData/DTCommissioning/plugins/RawFile.cc
@@ -11,9 +11,9 @@
 
 using namespace std;
 
-RawFile::RawFile() : inputFile(0), xrootdFlag(false) {}
+RawFile::RawFile() : inputFile(nullptr), xrootdFlag(false) {}
 
-RawFile::RawFile(const char* path) : inputFile(0), xrootdFlag(false) {
+RawFile::RawFile(const char* path) : inputFile(nullptr), xrootdFlag(false) {
   open(path);
 }
 
@@ -27,7 +27,7 @@ RawFile* RawFile::open(const char* path) {
   //cout << " Prefix: " << prefix << endl;
 
   char* filename = prefix;
-  if (strlen(prefix)<strlen(path)) filename = strtok(0,":");
+  if (strlen(prefix)<strlen(path)) filename = strtok(nullptr,":");
   //cout << " Filename: " << filename << endl;
 
   if (strcmp(prefix,"root")==0) xrootdFlag = true;
@@ -58,7 +58,7 @@ int RawFile::close() {
   } else {
       flag = fclose(inputFile);
   }
-  inputFile = 0;
+  inputFile = nullptr;
   return flag;
 }
 
@@ -66,7 +66,7 @@ RawFile::~RawFile(){close();}
 
 FILE* RawFile::GetPointer(){ return inputFile;}
 
-bool RawFile::ok(){ return (inputFile!=0);}
+bool RawFile::ok(){ return (inputFile!=nullptr);}
 
 bool RawFile::fail(){ return !ok();}
 

--- a/IORawData/HcalTBInputService/plugins/HcalTBSource.h
+++ b/IORawData/HcalTBInputService/plugins/HcalTBSource.h
@@ -22,10 +22,10 @@ class CDFEventInfo;
 class HcalTBSource : public edm::ProducerSourceFromFiles {
 public:
 explicit HcalTBSource(const edm::ParameterSet & pset, edm::InputSourceDescription const& desc);
-virtual ~HcalTBSource();
+~HcalTBSource() override;
 private:
-  virtual bool setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time, edm::EventAuxiliary::ExperimentType&);
-  virtual void produce(edm::Event & e);
+  bool setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time, edm::EventAuxiliary::ExperimentType&) override;
+  void produce(edm::Event & e) override;
   void unpackSetup(const std::vector<std::string>& params);
   void openFile(const std::string& filename);
   TTree* m_tree;

--- a/IORawData/HcalTBInputService/plugins/HcalTBWriter.cc
+++ b/IORawData/HcalTBInputService/plugins/HcalTBWriter.cc
@@ -24,14 +24,14 @@ HcalTBWriter::HcalTBWriter(const edm::ParameterSet & pset) :
     blockToName_[num]=name;
   }
 
-  file_=0;
-  tree_=0;
-  eventInfo_=0;
+  file_=nullptr;
+  tree_=nullptr;
+  eventInfo_=nullptr;
 }
 
 void HcalTBWriter::endJob() {
   char buffer[1024];
-  if (file_!=0) {
+  if (file_!=nullptr) {
     file_->Write();
 
     ri_.setInfo("DAQSofwareRelease","UNKNOWN -- HcalTBWriter");
@@ -40,10 +40,10 @@ void HcalTBWriter::endJob() {
     ri_.store(file_);
 
     file_->Close();
-    file_=0;
-    tree_=0;
+    file_=nullptr;
+    tree_=nullptr;
     chunkMap_.clear();
-    eventInfo_=0;
+    eventInfo_=nullptr;
   }
 }
 
@@ -51,7 +51,7 @@ void HcalTBWriter::analyze(const edm::Event& e, const edm::EventSetup& es) {
   edm::Handle<FEDRawDataCollection> raw;
   e.getByToken(tok_raw_, raw);
 
-  if (file_==0) {
+  if (file_==nullptr) {
     char fname[4096];
     snprintf(fname,4096, namePattern_.c_str(),e.id().run());
     edm::LogInfo("HCAL") << "Opening " << fname << " for writing HCAL-format file.";

--- a/IORawData/HcalTBInputService/plugins/HcalTBWriter.h
+++ b/IORawData/HcalTBInputService/plugins/HcalTBWriter.h
@@ -25,8 +25,8 @@ class CDFEventInfo;
 class HcalTBWriter : public edm::EDAnalyzer {
 public:
   HcalTBWriter(const edm::ParameterSet & pset);
-  virtual void analyze(const edm::Event& e, const edm::EventSetup& es);
-  virtual void endJob();
+  void analyze(const edm::Event& e, const edm::EventSetup& es) override;
+  void endJob() override;
 private:
   std::string namePattern_;
   // chunk naming...

--- a/IORawData/HcalTBInputService/src/CDFChunk.h
+++ b/IORawData/HcalTBInputService/src/CDFChunk.h
@@ -9,7 +9,7 @@ public:
   CDFChunk();
   CDFChunk(const char* name);
   void adoptBuffer(ULong64_t* buffer, Int_t length) { fChunk=buffer; fChunkLength=length; fHeaderSize=2; fTrailerSize=1; }
-  void releaseBuffer() { fChunk=0; fChunkLength=0; }
+  void releaseBuffer() { fChunk=nullptr; fChunkLength=0; }
   void setChunkName(const char* name) { fChunkName=name; }
   inline ULong64_t* getData() { return fChunk; }
   inline Int_t getDataLength() const { return fChunkLength; }

--- a/IORawData/HcalTBInputService/src/CDFRunInfo.cc
+++ b/IORawData/HcalTBInputService/src/CDFRunInfo.cc
@@ -1,7 +1,7 @@
 #include <TMap.h>
 #include <TObjString.h>
 #include "IORawData/HcalTBInputService/src/CDFRunInfo.h"
-#include <stdlib.h>
+#include <cstdlib>
 
 const char* CDFRunInfo::RootVariableName = "CDFRunInfo";
 
@@ -14,19 +14,19 @@ CDFRunInfo::CDFRunInfo(TFile* file) {
 
 const char* CDFRunInfo::get(const char* key) const {
   std::map<std::string,std::string>::const_iterator i=m_mapData.find(key);
-  if (i==m_mapData.end()) return NULL;
+  if (i==m_mapData.end()) return nullptr;
   return i->second.c_str();
 }
 
 int CDFRunInfo::getInt(const char* key) const {
   const char* k=get(key);
-  if (k==NULL) return 0;
+  if (k==nullptr) return 0;
   return atoi(k);
 }
 
 double CDFRunInfo::getDouble(const char* key) const {
   const char* k=get(key);
-  if (k==NULL) return 0;
+  if (k==nullptr) return 0;
   return atof(k);
 }
 
@@ -49,13 +49,13 @@ void CDFRunInfo::setInfo(const char* key, const char* value) {
 
 bool CDFRunInfo::load(TFile* f) {
   m_mapData.clear();
-  if (f==NULL) return false;
+  if (f==nullptr) return false;
   TMap* pMap=(TMap*)f->Get(RootVariableName);
-  if (pMap==NULL) return false;
+  if (pMap==nullptr) return false;
   TIterator* i=pMap->MakeIterator();
   TObject* o;
 
-  while ((o=i->Next())!=NULL) {
+  while ((o=i->Next())!=nullptr) {
     std::string a(o->GetName());
     std::string b(pMap->GetValue(o)->GetName());
     m_mapData.insert(std::pair<std::string,std::string>(a,b));

--- a/IORawData/SiPixelInputSources/interface/PixelSLinkDataInputSource.h
+++ b/IORawData/SiPixelInputSources/interface/PixelSLinkDataInputSource.h
@@ -42,12 +42,12 @@ public:
   explicit PixelSLinkDataInputSource(const edm::ParameterSet& pset, 
 				     const edm::InputSourceDescription& desc);
 
-  virtual ~PixelSLinkDataInputSource();
+  ~PixelSLinkDataInputSource() override;
 
 private:
 
-  virtual bool setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time, edm::EventAuxiliary::ExperimentType&);
-  virtual void produce(edm::Event& event);
+  bool setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time, edm::EventAuxiliary::ExperimentType&) override;
+  void produce(edm::Event& event) override;
   uint32_t synchronizeEvents();
 
   int m_fedid;

--- a/IORawData/SiPixelInputSources/src/PixelSLinkDataInputSource.cc
+++ b/IORawData/SiPixelInputSources/src/PixelSLinkDataInputSource.cc
@@ -139,7 +139,7 @@ PixelSLinkDataInputSource::PixelSLinkDataInputSource(const edm::ParameterSet& ps
     
   edm::LogInfo("PixelSLinkDataInputSource") << " unsigned long int size = " << sizeof(unsigned long int) <<"\n unsigned long size = " << sizeof(unsigned long)<<"\n unsigned long long size = " << sizeof(unsigned long long) <<  "\n uint32_t size = " << sizeof(uint32_t) << "\n uint64_t size = " << sizeof(uint64_t) << std::endl;
 
-  bool exists = StorageFactory::get() -> check(currentfilename.c_str(), &size);
+  bool exists = StorageFactory::get() -> check(currentfilename, &size);
   
   edm::LogInfo("PixelSLinkDataInputSource") << "file size " << size << std::endl;
   
@@ -148,7 +148,7 @@ PixelSLinkDataInputSource::PixelSLinkDataInputSource(const edm::ParameterSet& ps
     return;
   }
   // now open the file stream:
-  storage =StorageFactory::get()->open(currentfilename.c_str());
+  storage =StorageFactory::get()->open(currentfilename);
   // (throw if storage is 0)
 
   // check run number by opening up data file...

--- a/SUSYBSMAnalysis/HSCP/plugins/HSCPDeDxInfoProducer.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/HSCPDeDxInfoProducer.cc
@@ -67,7 +67,7 @@ HSCPDeDxInfoProducer::~HSCPDeDxInfoProducer(){}
 // ------------ method called once each job just before starting event loop  ------------
 void  HSCPDeDxInfoProducer::beginRun(edm::Run const& run, const edm::EventSetup& iSetup)
 {
-   if(useCalibration && calibGains.size()==0){
+   if(useCalibration && calibGains.empty()){
       edm::ESHandle<TrackerGeometry> tkGeom;
       iSetup.get<TrackerDigiGeometryRecord>().get( tkGeom );
       m_off = tkGeom->offsetDU(GeomDetEnumerators::PixelBarrel); //index start at the first pixel

--- a/SUSYBSMAnalysis/HSCP/plugins/HSCPDeDxInfoProducer.h
+++ b/SUSYBSMAnalysis/HSCP/plugins/HSCPDeDxInfoProducer.h
@@ -33,11 +33,11 @@
 class HSCPDeDxInfoProducer : public edm::stream::EDProducer<> {
 public:
   explicit HSCPDeDxInfoProducer(const edm::ParameterSet&);
-  ~HSCPDeDxInfoProducer();
+  ~HSCPDeDxInfoProducer() override;
 
 private:
-  virtual void beginRun(edm::Run const& run, const edm::EventSetup&) override;
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void beginRun(edm::Run const& run, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
   void   makeCalibrationMap(const TrackerGeometry& tkGeom);
   void   processHit(const TrackingRecHit* recHit, float trackMomentum, float& cosine, susybsm::HSCPDeDxInfo& hscpDeDxInfo,  LocalPoint HitLocalPos);

--- a/SUSYBSMAnalysis/HSCP/plugins/HSCPHLTFilter.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/HSCPHLTFilter.cc
@@ -24,12 +24,12 @@ using namespace edm;
 class HSCPHLTFilter : public edm::EDFilter {
    public:
       explicit HSCPHLTFilter(const edm::ParameterSet&);
-      ~HSCPHLTFilter();
+      ~HSCPHLTFilter() override;
 
    private:
-      virtual void beginJob() override ;
-      virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override ;
+      void beginJob() override ;
+      bool filter(edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
       bool isDuplicate(unsigned int Run, unsigned int Event);
 
       bool IncreasedTreshold(const trigger::TriggerEvent& trEv, const edm::InputTag& InputPath, double NewThreshold, double etaCut, int NObjectAboveThreshold, bool averageThreshold);

--- a/SUSYBSMAnalysis/HSCP/plugins/HSCPTreeBuilder.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/HSCPTreeBuilder.cc
@@ -117,13 +117,13 @@ using namespace __gnu_cxx;
 class HSCPTreeBuilder : public edm::EDFilter {
 	public:
 		explicit HSCPTreeBuilder(const edm::ParameterSet&);
-		~HSCPTreeBuilder();
+		~HSCPTreeBuilder() override;
 
 
 	private:
-		virtual void beginJob() override ;
-		virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-		virtual void endJob() override ;
+		void beginJob() override ;
+		bool filter(edm::Event&, const edm::EventSetup&) override;
+		void endJob() override ;
                 int ClosestMuonIndex(reco::TrackRef track, std::vector<reco::MuonRef>);
 
 		const edm::EventSetup* iSetup_;

--- a/SUSYBSMAnalysis/HSCP/plugins/HSCPValidator.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/HSCPValidator.cc
@@ -516,7 +516,7 @@ void HSCPValidator::makeSimDigiPlotsECAL(const edm::Event& iEvent)
   // 3) Match to digis
   int numMatchedSimHitsEventEB = 0;
   int numMatchedDigisEventEB = 0;
-  const PCaloHitContainer* phitsEB=0;
+  const PCaloHitContainer* phitsEB=nullptr;
   phitsEB = ebSimHits.product();
   for(SimTrackContainer::const_iterator simTrack = simTracks->begin(); simTrack != simTracks->end(); ++simTrack)
   {
@@ -537,7 +537,7 @@ void HSCPValidator::makeSimDigiPlotsECAL(const edm::Event& iEvent)
         mySimHitsEB.push_back(*simHitItr);
       ++simHitItr;
     }
-    if(mySimHitsEB.size()==0)
+    if(mySimHitsEB.empty())
     {
       std::cout << "Could not find matching EB PCaloHits for SimTrack id: " << trackId << ".  Skipping this SimTrack" << std::endl;
       continue;
@@ -597,7 +597,7 @@ void HSCPValidator::makeSimDigiPlotsECAL(const edm::Event& iEvent)
   // EE next
   int numMatchedSimHitsEventEE = 0;
   int numMatchedDigisEventEE = 0;
-  const PCaloHitContainer* phitsEE=0;
+  const PCaloHitContainer* phitsEE=nullptr;
   phitsEE = eeSimHits.product();
   for(SimTrackContainer::const_iterator simTrack = simTracks->begin(); simTrack != simTracks->end(); ++simTrack)
   {
@@ -618,7 +618,7 @@ void HSCPValidator::makeSimDigiPlotsECAL(const edm::Event& iEvent)
         mySimHitsEE.push_back(*simHitItr);
       ++simHitItr;
     }
-    if(mySimHitsEE.size()==0)
+    if(mySimHitsEE.empty())
     {
       std::cout << "Could not find matching EE PCaloHits for SimTrack id: " << trackId << ".  Skipping this SimTrack" << std::endl;
       continue;

--- a/SUSYBSMAnalysis/HSCP/plugins/HSCPValidator.h
+++ b/SUSYBSMAnalysis/HSCP/plugins/HSCPValidator.h
@@ -44,13 +44,13 @@
 class HSCPValidator : public edm::EDAnalyzer {
    public:
       explicit HSCPValidator(const edm::ParameterSet&);
-      ~HSCPValidator();
+      ~HSCPValidator() override;
 
 
    private:
-      virtual void beginJob() ;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+      void beginJob() override ;
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
       std::string intToString(int num);
       void makeGenPlots(const edm::Event& iEvent);
       void makeSimTrackPlots(const edm::Event& iEvent);

--- a/SUSYBSMAnalysis/HSCP/plugins/HSCParticleProducer.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/HSCParticleProducer.cc
@@ -166,7 +166,7 @@ HSCParticleProducer::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
         i--;
      }
   }
-  bool filterResult = !Filter_ || (Filter_ && hscp->size()>=1);
+  bool filterResult = !Filter_ || (Filter_ && !hscp->empty());
 
 
 

--- a/SUSYBSMAnalysis/HSCP/plugins/HSCParticleProducer.h
+++ b/SUSYBSMAnalysis/HSCP/plugins/HSCParticleProducer.h
@@ -54,12 +54,12 @@
 class HSCParticleProducer : public edm::EDFilter {
   public:
     explicit HSCParticleProducer(const edm::ParameterSet&);
-    ~HSCParticleProducer();
+    ~HSCParticleProducer() override;
 
   private:
-    virtual void beginJob() ;
-    virtual bool filter(edm::Event&, const edm::EventSetup&);
-    virtual void endJob() ;
+    void beginJob() override ;
+    bool filter(edm::Event&, const edm::EventSetup&) override;
+    void endJob() override ;
 
     std::vector<susybsm::HSCParticle> getHSCPSeedCollection(edm::Handle<reco::TrackCollection>& trackCollectionHandle,  edm::Handle<reco::MuonCollection>& muonCollectionHandle, edm::Handle<reco::MuonCollection>& MTmuonCollectionHandle);
 

--- a/SUSYBSMAnalysis/HSCP/plugins/HSCParticleSelector.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/HSCParticleSelector.cc
@@ -16,12 +16,12 @@
 class HSCParticleSelector : public edm::EDFilter {
    public:
       explicit HSCParticleSelector(const edm::ParameterSet&);
-      ~HSCParticleSelector();
+      ~HSCParticleSelector() override;
 
    private:
-      virtual void beginJob() override ;
-      virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override ;
+      void beginJob() override ;
+      bool filter(edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
 
       edm::EDGetTokenT<susybsm::HSCParticleCollection> sourceToken_;
 
@@ -85,7 +85,7 @@ bool HSCParticleSelector::filter(edm::Event& iEvent, const edm::EventSetup& iSet
          }
       }
 
-      bool filterResult = !Filter_ || (Filter_ && output->size()>=1);
+      bool filterResult = !Filter_ || (Filter_ && !output->empty());
 
       iEvent.put(std::move(result));
 

--- a/SUSYBSMAnalysis/HSCP/plugins/MuonSegmentProducer.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/MuonSegmentProducer.cc
@@ -48,12 +48,12 @@
 class MuonSegmentProducer : public edm::EDProducer {
 public:
   explicit MuonSegmentProducer(const edm::ParameterSet&);
-  ~MuonSegmentProducer();
+  ~MuonSegmentProducer() override;
 
 private:
-  virtual void beginJob() ;
-  virtual void produce(edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  void beginJob() override ;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
 
   edm::EDGetTokenT< CSCSegmentCollection > m_cscSegmentToken;
   edm::EDGetTokenT< DTRecSegment4DCollection > m_dtSegmentToken;

--- a/SUSYBSMAnalysis/HSCP/plugins/SimHitShifter.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/SimHitShifter.cc
@@ -108,17 +108,17 @@
 class SimHitShifter : public edm::EDProducer {
    public:
       explicit SimHitShifter(const edm::ParameterSet&);
-      ~SimHitShifter();
+      ~SimHitShifter() override;
   //edm::ESHandle <RPCGeometry> rpcGeo;
-      virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
+      void beginRun(const edm::Run&, const edm::EventSetup&) override;
       std::map<int,float> shiftinfo;
 
 
    private:
       std::string ShiftFileName;
-      virtual void beginJob() override;
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override ;
+      void beginJob() override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
     
 };
 

--- a/SUSYBSMAnalysis/HSCP/plugins/Skim_HSCPFilter.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/Skim_HSCPFilter.cc
@@ -51,12 +51,12 @@
 class HSCPFilter : public edm::EDFilter {
    public:
       explicit HSCPFilter(const edm::ParameterSet&);
-      ~HSCPFilter();
+      ~HSCPFilter() override;
 
    private:
-      virtual void beginJob() override ;
-      virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override ;
+      void beginJob() override ;
+      bool filter(edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
       bool filterFlag;
 #ifdef THIS_IS_AN_EVENT_EXAMPLE
       edm::EDGetTokenT<ExampleData> pInToken;
@@ -141,7 +141,7 @@ HSCPFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
    if(!filterFlag) return true;
 
-   if(recoVertex.size()<1) return false;
+   if(recoVertex.empty()) return false;
 
    using reco::MuonCollection;
 

--- a/SUSYBSMAnalysis/HSCP/plugins/Skim_HighPtTrackEcalDetIdProducer.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/Skim_HighPtTrackEcalDetIdProducer.cc
@@ -57,7 +57,7 @@
 class HighPtTrackEcalDetIdProducer : public edm::EDProducer {
    public:
       explicit HighPtTrackEcalDetIdProducer(const edm::ParameterSet&);
-      ~HighPtTrackEcalDetIdProducer();
+      ~HighPtTrackEcalDetIdProducer() override;
       void beginRun(const edm::Run&, const edm::EventSetup&) override;
       void produce(edm::Event&, const edm::EventSetup&) override;
    private:
@@ -133,9 +133,9 @@ HighPtTrackEcalDetIdProducer::produce(edm::Event& iEvent, const edm::EventSetup&
        ++itTrack) {
         if(itTrack->pt()>ptcut_){
            TrackDetMatchInfo info = trackAssociator_.associate(iEvent, iSetup, *itTrack, parameters_, TrackDetectorAssociator::InsideOut);
-           if(info.crossedEcalIds.size()==0) break;
+           if(info.crossedEcalIds.empty()) break;
 
-           if(info.crossedEcalIds.size()>0){
+           if(!info.crossedEcalIds.empty()){
               DetId centerId = info.crossedEcalIds.front();
 
               const CaloSubdetectorTopology* topology = caloTopology_->getSubdetectorTopology(DetId::Ecal,centerId.subdetId());

--- a/SUSYBSMAnalysis/HSCP/plugins/Skim_MonoPhotonSkimmer.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/Skim_MonoPhotonSkimmer.cc
@@ -42,12 +42,12 @@
 class MonoPhotonSkimmer : public edm::EDFilter {
    public:
       explicit MonoPhotonSkimmer(const edm::ParameterSet&);
-      ~MonoPhotonSkimmer();
+      ~MonoPhotonSkimmer() override;
 
    private:
-      virtual void beginJob() override ;
-      virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override ;
+      void beginJob() override ;
+      bool filter(edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
 
       // ----------member data ---------------------------
       edm::EDGetTokenT<reco::PhotonCollection> _phoToken;

--- a/SUSYBSMAnalysis/HSCP/plugins/Skim_ProduceIsolationMap.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/Skim_ProduceIsolationMap.cc
@@ -71,8 +71,8 @@ using namespace edm;
 class ProduceIsolationMap : public edm::EDProducer {
    public:
       explicit ProduceIsolationMap(const edm::ParameterSet&);
-      ~ProduceIsolationMap();
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      ~ProduceIsolationMap() override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
    private:
       edm::EDGetTokenT<reco::TrackCollection> TKToken_;
       edm::EDGetTokenT<reco::TrackCollection> inputCollectionToken_;
@@ -144,8 +144,8 @@ ProduceIsolationMap::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       TrackDetMatchInfo info = trackAssociator_.associate(iEvent, iSetup, *itTrack, parameters_, TrackDetectorAssociator::InsideOut);
 
 
-      if(info.ecalRecHits.size()>0){IsolationInfoColl[TkIndex].Set_ECAL_Energy(info.coneEnergy(IsolationConeDR_, TrackDetMatchInfo::EcalRecHits));}
-      if(info.hcalRecHits.size()>0){IsolationInfoColl[TkIndex].Set_HCAL_Energy(info.coneEnergy(IsolationConeDR_, TrackDetMatchInfo::HcalRecHits));}
+      if(!info.ecalRecHits.empty()){IsolationInfoColl[TkIndex].Set_ECAL_Energy(info.coneEnergy(IsolationConeDR_, TrackDetMatchInfo::EcalRecHits));}
+      if(!info.hcalRecHits.empty()){IsolationInfoColl[TkIndex].Set_HCAL_Energy(info.coneEnergy(IsolationConeDR_, TrackDetMatchInfo::HcalRecHits));}
 //      if(info.hcalRecHits.size()>0){IsolationInfoColl[TkIndex].Set_HCAL_Energy(info.hcalConeEnergy());}
 //      if(info.ecalRecHits.size()>0){IsolationInfoColl[TkIndex].Set_ECAL_Energy(info.ecalConeEnergy());}
 

--- a/SUSYBSMAnalysis/HSCP/plugins/Skim_ReduceHcalRecHitCollectionProducer.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/Skim_ReduceHcalRecHitCollectionProducer.cc
@@ -65,8 +65,8 @@
 class ReduceHcalRecHitCollectionProducer : public edm::EDProducer {
    public:
       explicit ReduceHcalRecHitCollectionProducer(const edm::ParameterSet&);
-      ~ReduceHcalRecHitCollectionProducer();
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      ~ReduceHcalRecHitCollectionProducer() override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
    private:
       edm::EDGetTokenT<HBHERecHitCollection> recHitsToken_;
       std::string reducedHitsCollection_;
@@ -156,7 +156,7 @@ ReduceHcalRecHitCollectionProducer::produce(edm::Event& iEvent, const edm::Event
 
            TrackDetMatchInfo info = trackAssociator_.associate(iEvent, iSetup, *itTrack, parameters_, TrackDetectorAssociator::InsideOut);
 
-          if(info.crossedHcalIds.size()>0){
+          if(!info.crossedHcalIds.empty()){
              //loop through hits in the cone
              for(std::vector<const HBHERecHit*>::const_iterator hit = info.hcalRecHits.begin();
                  hit != info.hcalRecHits.end(); ++hit)

--- a/SUSYBSMAnalysis/HSCP/plugins/Skim_UpdatedMuonInnerTrackRef.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/Skim_UpdatedMuonInnerTrackRef.cc
@@ -19,12 +19,12 @@
 class UpdatedMuonInnerTrackRef : public edm::EDProducer {
    public:
       explicit UpdatedMuonInnerTrackRef(const edm::ParameterSet&);
-      ~UpdatedMuonInnerTrackRef();
+      ~UpdatedMuonInnerTrackRef() override;
 
    private:
-      virtual void beginJob() override ;
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override ;
+      void beginJob() override ;
+      void produce(edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
 
       reco::TrackRef findNewRef(reco::TrackRef oldTrackRef, edm::Handle<reco::TrackCollection>& newTrackCollection);
 

--- a/SUSYBSMAnalysis/HSCP/src/BetaCalculatorECAL.cc
+++ b/SUSYBSMAnalysis/HSCP/src/BetaCalculatorECAL.cc
@@ -148,7 +148,7 @@ void BetaCalculatorECAL::addInfoToCandidate(HSCParticle& candidate, edm::Handle<
      trackExitMapIt++;
    }
 
-   if(crossedRecHits.size() > 0)
+   if(!crossedRecHits.empty())
    {
      setCalo = true;
      sort(crossedRecHits.begin(),crossedRecHits.end(),EcalRecHitLess());
@@ -186,7 +186,7 @@ void BetaCalculatorECAL::addInfoToCandidate(HSCParticle& candidate, edm::Handle<
      }
    }
 
-   if(info.crossedHcalRecHits.size() > 0)
+   if(!info.crossedHcalRecHits.empty())
    {
      // HCAL (not ECAL) info
      result.hcalCrossedEnergy = info.crossedEnergy(TrackDetMatchInfo::HcalRecHits);

--- a/SUSYBSMAnalysis/HSCP/src/BetaCalculatorRPC.cc
+++ b/SUSYBSMAnalysis/HSCP/src/BetaCalculatorRPC.cc
@@ -105,7 +105,7 @@ void BetaCalculatorRPC::algo(const std::vector<susybsm::RPCHit4D>& uHSCPRPCRecHi
     betavalue = 1.;
   }
 
-  if(HSCPRPCRecHits.size()==0){
+  if(HSCPRPCRecHits.empty()){
     //std::cout<<"Inside BetaCalculatorRPC \t WARINNG EMPTY RPC4DRecHits CONTAINER!!!"<<std::endl;
     betavalue = 1.;
   }


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this quickly to avoid conflicts to the extent possible]