### PR TITLE
Clang-tidy checks for JetMETCorrections

### DIFF
--- a/JetMETCorrections/Algorithms/interface/JetCorrectorImplMakerBase.h
+++ b/JetMETCorrections/Algorithms/interface/JetCorrectorImplMakerBase.h
@@ -52,9 +52,9 @@ class JetCorrectorImplMakerBase
 									std::function<void(std::string const&)> levelCheck);
   
  private:
-  JetCorrectorImplMakerBase(const JetCorrectorImplMakerBase&); // stop default
+  JetCorrectorImplMakerBase(const JetCorrectorImplMakerBase&) = delete; // stop default
   
-  const JetCorrectorImplMakerBase& operator=(const JetCorrectorImplMakerBase&); // stop default
+  const JetCorrectorImplMakerBase& operator=(const JetCorrectorImplMakerBase&) = delete; // stop default
   
   // ---------- member data --------------------------------
   std::string level_;

--- a/JetMETCorrections/Algorithms/interface/L1FastjetCorrector.h
+++ b/JetMETCorrections/Algorithms/interface/L1FastjetCorrector.h
@@ -19,24 +19,24 @@ class L1FastjetCorrector : public JetCorrector
 public:
   // construction / destruction
   L1FastjetCorrector(const JetCorrectorParameters& fParam, const edm::ParameterSet& fConfig);
-  virtual ~L1FastjetCorrector();
+  ~L1FastjetCorrector() override;
   
 public:
   //member functions
   
   /// apply correction using Jet information only
-  virtual double correction(const LorentzVector& fJet) const;
+  double correction(const LorentzVector& fJet) const override;
   /// apply correction using Jet information only
-  virtual double correction(const reco::Jet& fJet) const;
+  double correction(const reco::Jet& fJet) const override;
   /// apply correction using all event information
-  virtual double correction(const reco::Jet& fJet,
+  double correction(const reco::Jet& fJet,
 			    const edm::Event& fEvent,
-			    const edm::EventSetup& fSetup) const;
+			    const edm::EventSetup& fSetup) const override;
   /// if correction needs event information
-  virtual bool eventRequired() const { return true; }
+  bool eventRequired() const override { return true; }
 
   //----- if correction needs a jet reference -------------
-  virtual bool refRequired() const { return false; }
+  bool refRequired() const override { return false; }
 
 private:
   // member data

--- a/JetMETCorrections/Algorithms/interface/L1FastjetCorrectorImpl.h
+++ b/JetMETCorrections/Algorithms/interface/L1FastjetCorrectorImpl.h
@@ -42,12 +42,12 @@ public:
   //member functions
   
   /// apply correction using Jet information only
-  virtual double correction(const LorentzVector& fJet) const;
+  double correction(const LorentzVector& fJet) const override;
   /// apply correction using Jet information only
-  virtual double correction(const reco::Jet& fJet) const;
+  double correction(const reco::Jet& fJet) const override;
 
   //----- if correction needs a jet reference -------------
-  virtual bool refRequired() const { return false; }
+  bool refRequired() const override { return false; }
 
 private:
   // member data

--- a/JetMETCorrections/Algorithms/interface/L1JPTOffsetCorrector.h
+++ b/JetMETCorrections/Algorithms/interface/L1JPTOffsetCorrector.h
@@ -21,21 +21,21 @@ class L1JPTOffsetCorrector : public JetCorrector
     L1JPTOffsetCorrector(const JetCorrectorParameters& fConfig, const edm::ParameterSet& fParameters);   
 
     //----- destructor ----------------------------------------
-    virtual ~L1JPTOffsetCorrector();
+    ~L1JPTOffsetCorrector() override;
 
     //----- apply correction using Jet information only -------
-    virtual double correction(const LorentzVector& fJet) const;
+    double correction(const LorentzVector& fJet) const override;
 
     //----- apply correction using Jet information only -------
-    virtual double correction(const reco::Jet& fJet) const;
+    double correction(const reco::Jet& fJet) const override;
 
     //----- apply correction using all event information
-    virtual double correction(const reco::Jet& fJet, 
+    double correction(const reco::Jet& fJet, 
                               const edm::Event& fEvent, 
-                              const edm::EventSetup& fSetup) const;
+                              const edm::EventSetup& fSetup) const override;
     //----- if correction needs event information -------------
-    virtual bool eventRequired() const {return true;} 
-    virtual bool refRequired() const {return false;}
+    bool eventRequired() const override {return true;} 
+    bool refRequired() const override {return false;}
 
   private:
     //----- member data ---------------------------------------

--- a/JetMETCorrections/Algorithms/interface/L1JPTOffsetCorrectorImpl.h
+++ b/JetMETCorrections/Algorithms/interface/L1JPTOffsetCorrectorImpl.h
@@ -44,13 +44,13 @@ class L1JPTOffsetCorrectorImpl : public reco::JetCorrectorImpl
 			   const reco::JetCorrector* offsetService);   
 
     //----- apply correction using Jet information only -------
-    virtual double correction(const LorentzVector& fJet) const override;
+    double correction(const LorentzVector& fJet) const override;
 
     //----- apply correction using Jet information only -------
-    virtual double correction(const reco::Jet& fJet) const override;
+    double correction(const reco::Jet& fJet) const override;
 
     //----- if correction needs event information -------------
-    virtual bool refRequired() const override {return false;}
+    bool refRequired() const override {return false;}
 
   private:
     //----- member data ---------------------------------------

--- a/JetMETCorrections/Algorithms/interface/L1OffsetCorrector.h
+++ b/JetMETCorrections/Algorithms/interface/L1OffsetCorrector.h
@@ -21,23 +21,23 @@ class L1OffsetCorrector : public JetCorrector
     L1OffsetCorrector(const JetCorrectorParameters& fConfig, const edm::ParameterSet& fParameters);   
 
     //----- destructor ----------------------------------------
-    virtual ~L1OffsetCorrector();
+    ~L1OffsetCorrector() override;
 
     //----- apply correction using Jet information only -------
-    virtual double correction(const LorentzVector& fJet) const;
+    double correction(const LorentzVector& fJet) const override;
 
     //----- apply correction using Jet information only -------
-    virtual double correction(const reco::Jet& fJet) const;
+    double correction(const reco::Jet& fJet) const override;
 
     //----- apply correction using all event information
-    virtual double correction(const reco::Jet& fJet, 
+    double correction(const reco::Jet& fJet, 
                               const edm::Event& fEvent, 
-                              const edm::EventSetup& fSetup) const;
+                              const edm::EventSetup& fSetup) const override;
     //----- if correction needs event information -------------
-    virtual bool eventRequired() const {return true;} 
+    bool eventRequired() const override {return true;} 
 
     //----- if correction needs a jet reference -------------
-    virtual bool refRequired() const { return false; }
+    bool refRequired() const override { return false; }
 
   private:
     //----- member data ---------------------------------------

--- a/JetMETCorrections/Algorithms/interface/L1OffsetCorrectorImpl.h
+++ b/JetMETCorrections/Algorithms/interface/L1OffsetCorrectorImpl.h
@@ -44,13 +44,13 @@ class L1OffsetCorrectorImpl : public reco::JetCorrectorImpl
     //----- destructor ----------------------------------------
 
     //----- apply correction using Jet information only -------
-    virtual double correction(const LorentzVector& fJet) const override;
+    double correction(const LorentzVector& fJet) const override;
 
     //----- apply correction using Jet information only -------
-    virtual double correction(const reco::Jet& fJet) const override;
+    double correction(const reco::Jet& fJet) const override;
 
     //----- if correction needs a jet reference -------------
-    virtual bool refRequired() const override { return false; } 
+    bool refRequired() const override { return false; } 
 
   private:
     //----- member data ---------------------------------------

--- a/JetMETCorrections/Algorithms/interface/L6SLBCorrector.h
+++ b/JetMETCorrections/Algorithms/interface/L6SLBCorrector.h
@@ -23,7 +23,7 @@ class L6SLBCorrector : public JetCorrector
   //
 public:
   L6SLBCorrector (const JetCorrectorParameters& fParam, const edm::ParameterSet& fConfig);
-  virtual ~L6SLBCorrector ();
+  ~L6SLBCorrector () override;
   
 
   //
@@ -31,20 +31,20 @@ public:
   //
 public:
   /// apply correction using Jet information only
-  virtual double correction (const LorentzVector& fJet) const;
+  double correction (const LorentzVector& fJet) const override;
   /// apply correction using Jet information only
-  virtual double correction (const reco::Jet& fJet) const;
+  double correction (const reco::Jet& fJet) const override;
   /// apply correction using all event information
-  virtual double correction (const reco::Jet& fJet,
+  double correction (const reco::Jet& fJet,
 			     const edm::RefToBase<reco::Jet>& refToRawJet,
 			     const edm::Event& fEvent, 
-			     const edm::EventSetup& fSetup) const;
+			     const edm::EventSetup& fSetup) const override;
   
   /// if correction needs event information
-  virtual bool eventRequired () const {return true;} 
+  bool eventRequired () const override {return true;} 
 
   //----- if correction needs a jet reference -------------
-  virtual bool refRequired () const {return true;} 
+  bool refRequired () const override {return true;} 
   
   //
   // private member functions

--- a/JetMETCorrections/Algorithms/interface/L6SLBCorrectorImpl.h
+++ b/JetMETCorrections/Algorithms/interface/L6SLBCorrectorImpl.h
@@ -55,15 +55,15 @@ public:
   //
 public:
   /// apply correction using Jet information only
-  virtual double correction (const LorentzVector& fJet) const override;
+  double correction (const LorentzVector& fJet) const override;
   /// apply correction using Jet information only
-  virtual double correction (const reco::Jet& fJet) const override;
+  double correction (const reco::Jet& fJet) const override;
   /// apply correction using all event information
-  virtual double correction (const reco::Jet& fJet,
+  double correction (const reco::Jet& fJet,
 			     const edm::RefToBase<reco::Jet>& refToRawJet) const override;
   
   //----- if correction needs a jet reference -------------
-  virtual bool refRequired () const override {return true;} 
+  bool refRequired () const override {return true;} 
   
   //
   // private member functions

--- a/JetMETCorrections/Algorithms/interface/LXXXCorrector.h
+++ b/JetMETCorrections/Algorithms/interface/LXXXCorrector.h
@@ -20,19 +20,19 @@ class LXXXCorrector : public JetCorrector
     LXXXCorrector(const JetCorrectorParameters& fConfig, const edm::ParameterSet& fParameters);   
 
     //----- destructor ----------------------------------------
-    virtual ~LXXXCorrector();
+    ~LXXXCorrector() override;
 
     //----- apply correction using Jet information only -------
-    virtual double correction(const LorentzVector& fJet) const;
+    double correction(const LorentzVector& fJet) const override;
 
     //----- apply correction using Jet information only -------
-    virtual double correction(const reco::Jet& fJet) const;
+    double correction(const reco::Jet& fJet) const override;
 
     //----- if correction needs event information -------------
-    virtual bool eventRequired() const {return false;} 
+    bool eventRequired() const override {return false;} 
 
     //----- if correction needs a jet reference -------------
-    virtual bool refRequired() const { return false; }
+    bool refRequired() const override { return false; }
 
   private:
     //----- member data ---------------------------------------

--- a/JetMETCorrections/Algorithms/interface/LXXXCorrectorImpl.h
+++ b/JetMETCorrections/Algorithms/interface/LXXXCorrectorImpl.h
@@ -36,13 +36,13 @@ class LXXXCorrectorImpl : public reco::JetCorrectorImpl
     LXXXCorrectorImpl(std::shared_ptr<FactorizedJetCorrectorCalculator const> calculator, unsigned int level);
 
     //----- apply correction using Jet information only -------
-    virtual double correction(const LorentzVector& fJet) const override;
+    double correction(const LorentzVector& fJet) const override;
 
     //----- apply correction using Jet information only -------
-    virtual double correction(const reco::Jet& fJet) const override;
+    double correction(const reco::Jet& fJet) const override;
 
     //----- if correction needs a jet reference -------------
-    virtual bool refRequired() const override { return false; }
+    bool refRequired() const override { return false; }
 
   private:
     //----- member data ---------------------------------------

--- a/JetMETCorrections/Algorithms/src/L1JPTOffsetCorrector.cc
+++ b/JetMETCorrections/Algorithms/src/L1JPTOffsetCorrector.cc
@@ -67,7 +67,7 @@ double L1JPTOffsetCorrector::correction(const reco::Jet& fJet,
 {
   double result = 1.;
   const reco::JPTJet& jptjet = dynamic_cast <const reco::JPTJet&> (fJet);
-  edm::RefToBase<reco::Jet> jptjetRef = jptjet.getCaloJetRef();
+  const edm::RefToBase<reco::Jet>& jptjetRef = jptjet.getCaloJetRef();
   reco::CaloJet const * rawcalojet = dynamic_cast<reco::CaloJet const *>( &* jptjetRef);   
   //------ access the offset correction service ----------------
   double offset = 1.0;

--- a/JetMETCorrections/Algorithms/src/L1JPTOffsetCorrectorImpl.cc
+++ b/JetMETCorrections/Algorithms/src/L1JPTOffsetCorrectorImpl.cc
@@ -88,7 +88,7 @@ double L1JPTOffsetCorrectorImpl::correction(const reco::Jet& fJet) const
 {
   double result = 1.;
   const reco::JPTJet& jptjet = dynamic_cast <const reco::JPTJet&> (fJet);
-  edm::RefToBase<reco::Jet> jptjetRef = jptjet.getCaloJetRef();
+  const edm::RefToBase<reco::Jet>& jptjetRef = jptjet.getCaloJetRef();
   reco::CaloJet const * rawcalojet = dynamic_cast<reco::CaloJet const *>( &* jptjetRef);   
   //------ access the offset correction service ----------------
   double offset = 1.0;

--- a/JetMETCorrections/Algorithms/src/L6SLBCorrector.cc
+++ b/JetMETCorrections/Algorithms/src/L6SLBCorrector.cc
@@ -32,7 +32,7 @@ L6SLBCorrector::L6SLBCorrector(const JetCorrectorParameters& fParam, const edm::
   : addMuonToJet_(fConfig.getParameter<bool>("addMuonToJet"))
   , srcBTagInfoElec_(fConfig.getParameter<edm::InputTag>("srcBTagInfoElectron"))
   , srcBTagInfoMuon_(fConfig.getParameter<edm::InputTag>("srcBTagInfoMuon"))
-  , corrector_(0)
+  , corrector_(nullptr)
 {
   vector<JetCorrectorParameters> vParam;
   vParam.push_back(fParam);
@@ -86,7 +86,7 @@ double L6SLBCorrector::correction(const reco::Jet& fJet,
   const reco::SoftLeptonTagInfo& sltMuon =
     (*muoninfos)[getBTagInfoIndex(refToRawJet,*muoninfos)];
   if (sltMuon.leptons()>0) {
-    edm::RefToBase<reco::Track> trackRef = sltMuon.lepton(0);
+    const edm::RefToBase<reco::Track>& trackRef = sltMuon.lepton(0);
     values.setLepPx(trackRef->px());
     values.setLepPy(trackRef->py());
     values.setLepPz(trackRef->pz());
@@ -99,7 +99,7 @@ double L6SLBCorrector::correction(const reco::Jet& fJet,
     const reco::SoftLeptonTagInfo& sltElec =
       (*elecinfos)[getBTagInfoIndex(refToRawJet,*elecinfos)];
     if (sltElec.leptons()>0) {
-      edm::RefToBase<reco::Track> trackRef = sltElec.lepton(0);
+      const edm::RefToBase<reco::Track>& trackRef = sltElec.lepton(0);
       values.setLepPx(trackRef->px());
       values.setLepPy(trackRef->py());
       values.setLepPz(trackRef->pz());

--- a/JetMETCorrections/Algorithms/src/L6SLBCorrectorImpl.cc
+++ b/JetMETCorrections/Algorithms/src/L6SLBCorrectorImpl.cc
@@ -115,7 +115,7 @@ double L6SLBCorrectorImpl::correction(const reco::Jet& fJet,
   const reco::SoftLeptonTagInfo& sltMuon =
     (*bTagInfoMuon_)[getBTagInfoIndex(refToRawJet,*bTagInfoMuon_)];
   if (sltMuon.leptons()>0) {
-    edm::RefToBase<reco::Track> trackRef = sltMuon.lepton(0);
+    const edm::RefToBase<reco::Track>& trackRef = sltMuon.lepton(0);
     values.setLepPx(trackRef->px());
     values.setLepPy(trackRef->py());
     values.setLepPz(trackRef->pz());
@@ -126,7 +126,7 @@ double L6SLBCorrectorImpl::correction(const reco::Jet& fJet,
     const reco::SoftLeptonTagInfo& sltElec =
       (*bTagInfoElec_)[getBTagInfoIndex(refToRawJet,*bTagInfoElec_)];
     if (sltElec.leptons()>0) {
-      edm::RefToBase<reco::Track> trackRef = sltElec.lepton(0);
+      const edm::RefToBase<reco::Track>& trackRef = sltElec.lepton(0);
       values.setLepPx(trackRef->px());
       values.setLepPy(trackRef->py());
       values.setLepPz(trackRef->pz());

--- a/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectionESProducer.h
+++ b/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectionESProducer.h
@@ -118,7 +118,7 @@ public:
     typedef FFTJetCorrectorParametersRcd<CT> ParentRecord;
 
     FFTJetCorrectionESProducer(const edm::ParameterSet&);
-    virtual ~FFTJetCorrectionESProducer() {}
+    ~FFTJetCorrectionESProducer() override {}
 
     ReturnType produce(const MyRecord&);
 

--- a/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectorDBReader.cc
+++ b/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectorDBReader.cc
@@ -46,14 +46,14 @@ class FFTJetCorrectorDBReader : public edm::EDAnalyzer
 {
 public:
     explicit FFTJetCorrectorDBReader(const edm::ParameterSet&);
-    virtual ~FFTJetCorrectorDBReader() {}
+    ~FFTJetCorrectorDBReader() override {}
 
 private:
-    FFTJetCorrectorDBReader();
-    FFTJetCorrectorDBReader(const FFTJetCorrectorDBReader&);
-    FFTJetCorrectorDBReader& operator=(const FFTJetCorrectorDBReader&);
+    FFTJetCorrectorDBReader() = delete;
+    FFTJetCorrectorDBReader(const FFTJetCorrectorDBReader&) = delete;
+    FFTJetCorrectorDBReader& operator=(const FFTJetCorrectorDBReader&) = delete;
 
-    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     std::string record;
     std::string outputFile;

--- a/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectorDBWriter.cc
+++ b/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectorDBWriter.cc
@@ -43,14 +43,14 @@ class FFTJetCorrectorDBWriter : public edm::EDAnalyzer
 {
 public:
     explicit FFTJetCorrectorDBWriter(const edm::ParameterSet&);
-    virtual ~FFTJetCorrectorDBWriter() {}
+    ~FFTJetCorrectorDBWriter() override {}
 
 private:
-    FFTJetCorrectorDBWriter();
-    FFTJetCorrectorDBWriter(const FFTJetCorrectorDBWriter&);
-    FFTJetCorrectorDBWriter& operator=(const FFTJetCorrectorDBWriter&);
+    FFTJetCorrectorDBWriter() = delete;
+    FFTJetCorrectorDBWriter(const FFTJetCorrectorDBWriter&) = delete;
+    FFTJetCorrectorDBWriter& operator=(const FFTJetCorrectorDBWriter&) = delete;
 
-    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     std::string inputFile;
     std::string record;

--- a/JetMETCorrections/FFTJetModules/plugins/FFTJetLookupTableESProducer.cc
+++ b/JetMETCorrections/FFTJetModules/plugins/FFTJetLookupTableESProducer.cc
@@ -117,7 +117,7 @@ public:
     typedef FFTJetCorrectorParametersRcd<CT> ParentRecord;
 
     FFTJetLookupTableESProducer(const edm::ParameterSet&);
-    virtual ~FFTJetLookupTableESProducer() {}
+    ~FFTJetLookupTableESProducer() override {}
 
     ReturnType produce(const MyRecord&);
 

--- a/JetMETCorrections/FFTJetObjects/interface/AbsFFTJetScaleCalculator.h
+++ b/JetMETCorrections/FFTJetObjects/interface/AbsFFTJetScaleCalculator.h
@@ -21,13 +21,13 @@ public:
     inline double scale(const Jet& jet, const Adjustable& current) const
     {
         const unsigned dim = buffer_.size();
-        double* buf = dim ? &buffer_[0] : static_cast<double*>(0);
+        double* buf = dim ? &buffer_[0] : static_cast<double*>(nullptr);
         this->map(jet, current, buf, dim);
         return (*functor)(buf, dim);
     }
 
 private:
-    AbsFFTJetScaleCalculator();
+    AbsFFTJetScaleCalculator() = delete;
 
     virtual void map(const Jet& jet,
                      const Adjustable& current,

--- a/JetMETCorrections/FFTJetObjects/interface/AbsFFTSpecificScaleCalculator.h
+++ b/JetMETCorrections/FFTJetObjects/interface/AbsFFTSpecificScaleCalculator.h
@@ -30,7 +30,7 @@ class FFTSpecificScaleCalculatorFactory :
 {
     typedef DefaultFFTJetObjectFactory<AbsFFTSpecificScaleCalculator> Base;
     friend class StaticFFTJetObjectFactory<FFTSpecificScaleCalculatorFactory>;
-    FFTSpecificScaleCalculatorFactory();
+    FFTSpecificScaleCalculatorFactory() = delete;
 };
 
 typedef StaticFFTJetObjectFactory<FFTSpecificScaleCalculatorFactory>

--- a/JetMETCorrections/FFTJetObjects/interface/FFTGenericScaleCalculator.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTGenericScaleCalculator.h
@@ -15,12 +15,12 @@ class FFTGenericScaleCalculator : public AbsFFTSpecificScaleCalculator
 public:
     FFTGenericScaleCalculator(const edm::ParameterSet& ps);
 
-    inline virtual ~FFTGenericScaleCalculator() {}
+    inline ~FFTGenericScaleCalculator() override {}
 
-    virtual void mapFFTJet(const reco::Jet& jet,
+    void mapFFTJet(const reco::Jet& jet,
                            const reco::FFTJet<float>& fftJet,
                            const math::XYZTLorentzVector& current,
-                           double* buf, unsigned dim) const;
+                           double* buf, unsigned dim) const override;
 private:
     inline double f_safeLog(const double x) const
     {

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetAdjusters.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetAdjusters.h
@@ -6,11 +6,11 @@
 template<class MyJet, class Adjustable>
 struct FFTSimpleScalingAdjuster : public AbsFFTJetAdjuster<MyJet, Adjustable>
 {
-    inline virtual ~FFTSimpleScalingAdjuster() {}
+    inline ~FFTSimpleScalingAdjuster() override {}
 
-    virtual void adjust(const MyJet& /* jet */, const Adjustable& in,
+    void adjust(const MyJet& /* jet */, const Adjustable& in,
                         const double* factors, const unsigned lenFactors,
-                        Adjustable* out) const
+                        Adjustable* out) const override
     {
         if (lenFactors != 1U)
             throw cms::Exception("FFTJetBadConfig")
@@ -26,11 +26,11 @@ struct FFTSimpleScalingAdjuster : public AbsFFTJetAdjuster<MyJet, Adjustable>
 template<class MyJet, class Adjustable>
 struct FFTUncertaintyAdjuster : public AbsFFTJetAdjuster<MyJet, Adjustable>
 {
-    inline virtual ~FFTUncertaintyAdjuster() {}
+    inline ~FFTUncertaintyAdjuster() override {}
 
-    virtual void adjust(const MyJet& /* jet */, const Adjustable& in,
+    void adjust(const MyJet& /* jet */, const Adjustable& in,
                         const double* factors, const unsigned lenFactors,
-                        Adjustable* out) const
+                        Adjustable* out) const override
     {
         if (lenFactors != 1U)
             throw cms::Exception("FFTJetBadConfig")
@@ -48,11 +48,11 @@ template<class MyJet, class Adjustable>
 struct FFTScalingAdjusterWithUncertainty : 
     public AbsFFTJetAdjuster<MyJet, Adjustable>
 {
-    inline virtual ~FFTScalingAdjusterWithUncertainty() {}
+    inline ~FFTScalingAdjusterWithUncertainty() override {}
 
-    virtual void adjust(const MyJet& /* jet */, const Adjustable& in,
+    void adjust(const MyJet& /* jet */, const Adjustable& in,
                         const double* factors, const unsigned lenFactors,
-                        Adjustable* out) const
+                        Adjustable* out) const override
     {
         if (lenFactors != 2U)
             throw cms::Exception("FFTJetBadConfig")

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorParametersLoader.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorParametersLoader.h
@@ -13,7 +13,7 @@ class FFTJetCorrectorParametersLoader :
 {
     typedef DefaultFFTJetRcdMapper<FFTJetCorrectorParameters> Base;
     friend class StaticFFTJetRcdMapper<FFTJetCorrectorParametersLoader>;
-    FFTJetCorrectorParametersLoader();
+    FFTJetCorrectorParametersLoader() = delete;
 };
         
 typedef StaticFFTJetRcdMapper<FFTJetCorrectorParametersLoader>

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorResult.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorResult.h
@@ -29,7 +29,7 @@ public:
     inline void setSigma(const double s) {sigma_ = s;}
 
 private:
-    FFTJetCorrectorResult();
+    FFTJetCorrectorResult() = delete;
 
     LorentzVector vec_;
     double scale_;

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorTransient.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorTransient.h
@@ -42,7 +42,7 @@ public:
     }
 
 private:
-    FFTJetCorrectorTransient();
+    FFTJetCorrectorTransient() = delete;
 
     LorentzVector vec_;
     double scale_;

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetObjectFactory.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetObjectFactory.h
@@ -20,8 +20,8 @@ struct AbsFFTJetObjectFactory
 template<class Base, class Derived>
 struct ConcreteFFTJetObjectFactory : public AbsFFTJetObjectFactory<Base>
 {
-    virtual ~ConcreteFFTJetObjectFactory() {}
-    inline Derived* create(const edm::ParameterSet& ps) const
+    ~ConcreteFFTJetObjectFactory() override {}
+    inline Derived* create(const edm::ParameterSet& ps) const override
         {return new Derived(ps);}
 };
 
@@ -54,8 +54,8 @@ struct DefaultFFTJetObjectFactory :
     }
 
 private:
-    DefaultFFTJetObjectFactory(const DefaultFFTJetObjectFactory&);
-    DefaultFFTJetObjectFactory& operator=(const DefaultFFTJetObjectFactory&);
+    DefaultFFTJetObjectFactory(const DefaultFFTJetObjectFactory&) = delete;
+    DefaultFFTJetObjectFactory& operator=(const DefaultFFTJetObjectFactory&) = delete;
 };
 
 //
@@ -82,7 +82,7 @@ public:
     }
 
 private:
-    StaticFFTJetObjectFactory();
+    StaticFFTJetObjectFactory() = delete;
 };
 
 #endif // JetMETCorrections_FFTJetObjects_FFTJetObjectFactory_h

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetRcdMapper.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetRcdMapper.h
@@ -33,15 +33,15 @@ struct AbsFFTJetRcdMapper
 template<class DataType, class RecordType>
 struct ConcreteFFTJetRcdMapper : public AbsFFTJetRcdMapper<DataType>
 {
-    virtual ~ConcreteFFTJetRcdMapper() {}
+    ~ConcreteFFTJetRcdMapper() override {}
 
     inline void load(const edm::EventSetup& iSetup,
-                      edm::ESHandle<DataType>& handle) const
+                      edm::ESHandle<DataType>& handle) const override
         {iSetup.get<RecordType>().get(handle);}
 
     inline void load(const edm::EventSetup& iSetup,
                      const std::string& label,
-                     edm::ESHandle<DataType>& handle) const
+                     edm::ESHandle<DataType>& handle) const override
         {iSetup.get<RecordType>().get(label, handle);}
 };
 
@@ -87,8 +87,8 @@ struct DefaultFFTJetRcdMapper :
     }
 
 private:
-    DefaultFFTJetRcdMapper(const DefaultFFTJetRcdMapper&);
-    DefaultFFTJetRcdMapper& operator=(const DefaultFFTJetRcdMapper&);
+    DefaultFFTJetRcdMapper(const DefaultFFTJetRcdMapper&) = delete;
+    DefaultFFTJetRcdMapper& operator=(const DefaultFFTJetRcdMapper&) = delete;
 };
 
 //
@@ -115,7 +115,7 @@ public:
     }
 
 private:
-    StaticFFTJetRcdMapper();
+    StaticFFTJetRcdMapper() = delete;
 };
 
 #endif // JetMETCorrections_FFTJetObjects_FFTJetRcdMapper_h

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetScaleCalculators.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetScaleCalculators.h
@@ -20,7 +20,7 @@ public:
 private:
     inline void map(const MyJet& jet,
                     const Adjustable& current,
-                    double* buf, const unsigned dim) const
+                    double* buf, const unsigned dim) const override
     {
         assert(buf);
         if (dim != 3)
@@ -49,12 +49,12 @@ public:
         const AbsFFTSpecificScaleCalculator* p)
         : AbsFFTJetScaleCalculator<MyJet, Adjustable>(f), calc_(p) {assert(p);}
 
-    inline virtual ~FFTSpecificScaleCalculator() {delete calc_;}
+    inline ~FFTSpecificScaleCalculator() override {delete calc_;}
 
 private:
     inline void map(const MyJet& jet,
                     const Adjustable& current,
-                    double* buf, const unsigned dim) const
+                    double* buf, const unsigned dim) const override
     {
         return calc_->mapFFTJet(jet, jet.getFFTSpecific(),
                                 current.vec(), buf, dim);

--- a/JetMETCorrections/FFTJetObjects/interface/L2AbsScaleCalculator.h
+++ b/JetMETCorrections/FFTJetObjects/interface/L2AbsScaleCalculator.h
@@ -16,12 +16,12 @@ public:
           m_zeroPtLog(ps.getParameter<double>("zeroPtLog")),
           m_takePtLog(ps.getParameter<bool>("takePtLog")) {}
 
-    inline virtual ~L2AbsScaleCalculator() {}
+    inline ~L2AbsScaleCalculator() override {}
 
-    inline virtual void mapFFTJet(const reco::Jet& /* jet */,
+    inline void mapFFTJet(const reco::Jet& /* jet */,
                                   const reco::FFTJet<float>& fftJet,
                                   const math::XYZTLorentzVector& current,
-                                  double* buf, const unsigned dim) const
+                                  double* buf, const unsigned dim) const override
     {
         if (dim != 2)
             throw cms::Exception("FFTJetBadConfig")

--- a/JetMETCorrections/FFTJetObjects/interface/L2RecoScaleCalculator.h
+++ b/JetMETCorrections/FFTJetObjects/interface/L2RecoScaleCalculator.h
@@ -13,12 +13,12 @@ public:
     inline explicit L2RecoScaleCalculator(const edm::ParameterSet& ps) 
         : m_radiusFactor(ps.getParameter<double>("radiusFactor")) {}
 
-    inline virtual ~L2RecoScaleCalculator() {}
+    inline ~L2RecoScaleCalculator() override {}
 
-    inline virtual void mapFFTJet(const reco::Jet& /* jet */,
+    inline void mapFFTJet(const reco::Jet& /* jet */,
                                   const reco::FFTJet<float>& fftJet,
                                   const math::XYZTLorentzVector& /* current */,
-                                  double* buf, const unsigned dim) const
+                                  double* buf, const unsigned dim) const override
     {
         if (dim != 1)
             throw cms::Exception("FFTJetBadConfig")

--- a/JetMETCorrections/FFTJetObjects/interface/L2ResScaleCalculator.h
+++ b/JetMETCorrections/FFTJetObjects/interface/L2ResScaleCalculator.h
@@ -13,12 +13,12 @@ public:
     inline explicit L2ResScaleCalculator(const edm::ParameterSet& ps) 
         : m_radiusFactor(ps.getParameter<double>("radiusFactor")) {}
 
-    inline virtual ~L2ResScaleCalculator() {}
+    inline ~L2ResScaleCalculator() override {}
 
-    inline virtual void mapFFTJet(const reco::Jet& /* jet */,
+    inline void mapFFTJet(const reco::Jet& /* jet */,
                                   const reco::FFTJet<float>& fftJet,
                                   const math::XYZTLorentzVector& current,
-                                  double* buf, const unsigned dim) const
+                                  double* buf, const unsigned dim) const override
     {
         if (dim != 2)
             throw cms::Exception("FFTJetBadConfig")

--- a/JetMETCorrections/InterpolationTables/interface/ArrayND.h
+++ b/JetMETCorrections/InterpolationTables/interface/ArrayND.h
@@ -1686,7 +1686,7 @@ namespace npstat {
     ArrayND<Numeric,StackLen,StackDim>::ArrayND(
         const ArrayND<Num2, Len2, Dim2>& slicedArray,
         const unsigned *fixedIndices, const unsigned nFixedIndices)
-        : data_(0), strides_(0), shape_(0),
+        : data_(0), strides_(nullptr), shape_(nullptr),
           len_(1UL), dim_(slicedArray.dim_ - nFixedIndices),
           shapeIsKnown_(true)
     {
@@ -2559,7 +2559,7 @@ namespace npstat {
     void ArrayND<Numeric,Len,Dim>::buildStrides()
     {
         assert(dim_);
-        if (strides_ == 0)
+        if (strides_ == nullptr)
             strides_ = makeBuffer(dim_, localStrides_, Dim);
         strides_[dim_ - 1] = 1UL;
         for (unsigned j=dim_ - 1; j>0; --j)
@@ -2568,7 +2568,7 @@ namespace npstat {
 
     template<typename Numeric, unsigned StackLen, unsigned StackDim>
     inline ArrayND<Numeric,StackLen,StackDim>::ArrayND()
-        : data_(0), strides_(0), shape_(0),
+        : data_(nullptr), strides_(nullptr), shape_(nullptr),
           len_(0UL), dim_(0U), shapeIsKnown_(false)
     {
         localData_[0] = Numeric();
@@ -2577,7 +2577,7 @@ namespace npstat {
 
     template<typename Numeric, unsigned Len, unsigned Dim>
     ArrayND<Numeric,Len,Dim>::ArrayND(const ArrayND& r)
-        : data_(0), strides_(0), shape_(0),
+        : data_(nullptr), strides_(nullptr), shape_(nullptr),
           len_(r.len_), dim_(r.dim_), shapeIsKnown_(r.shapeIsKnown_)
     {
         if (dim_)
@@ -2605,7 +2605,7 @@ namespace npstat {
     template<typename Numeric, unsigned Len, unsigned Dim>
     template <typename Num2, unsigned Len2, unsigned Dim2>
     ArrayND<Numeric,Len,Dim>::ArrayND(const ArrayND<Num2, Len2, Dim2>& r)
-        : data_(0), strides_(0), shape_(0),
+        : data_(0), strides_(nullptr), shape_(nullptr),
           len_(r.len_), dim_(r.dim_), shapeIsKnown_(r.shapeIsKnown_)
     {
         if (dim_)
@@ -2634,7 +2634,7 @@ namespace npstat {
     template<typename Num2, unsigned Len2, unsigned Dim2, class Functor>
     ArrayND<Numeric,Len,Dim>::ArrayND(const ArrayND<Num2, Len2, Dim2>& r,
                                       Functor f)
-        : data_(0), strides_(0), shape_(0),
+        : data_(0), strides_(nullptr), shape_(nullptr),
           len_(r.len_), dim_(r.dim_), shapeIsKnown_(r.shapeIsKnown_)
     {
         if (dim_)
@@ -2694,7 +2694,7 @@ namespace npstat {
     template <typename Num2, unsigned Len2, unsigned Dim2>
     ArrayND<Numeric,Len,Dim>::ArrayND(
         const ArrayND<Num2, Len2, Dim2>& r, const ArrayRange& range)
-        : data_(0), strides_(0), shape_(0),
+        : data_(0), strides_(nullptr), shape_(nullptr),
           len_(r.len_), dim_(r.dim_), shapeIsKnown_(r.shapeIsKnown_)
     {
         if (!range.isCompatible(r.shape_, r.dim_))
@@ -2743,7 +2743,7 @@ namespace npstat {
     ArrayND<Numeric,Len,Dim>::ArrayND(
         const ArrayND<Num2, Len2, Dim2>& r, const ArrayRange& range,
         Functor f)
-        : data_(0), strides_(0), shape_(0),
+        : data_(0), strides_(nullptr), shape_(nullptr),
           len_(r.len_), dim_(r.dim_), shapeIsKnown_(r.shapeIsKnown_)
     {
         if (!range.isCompatible(r.shape_, r.dim_))
@@ -2782,23 +2782,23 @@ namespace npstat {
 
     template<typename Numeric, unsigned Len, unsigned Dim>
     ArrayND<Numeric,Len,Dim>::ArrayND(const ArrayShape& sh)
-        : data_(0), strides_(0), shape_(0), len_(1UL), shapeIsKnown_(true)
+        : data_(nullptr), strides_(nullptr), shape_(nullptr), len_(1UL), shapeIsKnown_(true)
     {
         const unsigned sz = sh.size();
-        buildFromShapePtr(sz ? &sh[0] : 0, sz);
+        buildFromShapePtr(sz ? &sh[0] : nullptr, sz);
     }
 
     template<typename Numeric, unsigned Len, unsigned Dim>
     ArrayND<Numeric,Len,Dim>::ArrayND(const unsigned* sizes,
                                       const unsigned dim)
-        : data_(0), strides_(0), shape_(0), len_(1UL), shapeIsKnown_(true)
+        : data_(0), strides_(nullptr), shape_(nullptr), len_(1UL), shapeIsKnown_(true)
     {
         buildFromShapePtr(sizes, dim);
     }
 
     template<typename Numeric, unsigned Len, unsigned Dim>
     ArrayND<Numeric,Len,Dim>::ArrayND(const unsigned n0)
-        : data_(0), strides_(0), shape_(0), len_(1UL), shapeIsKnown_(true)
+        : data_(0), strides_(nullptr), shape_(nullptr), len_(1UL), shapeIsKnown_(true)
     {
         const unsigned dim = 1U;
         unsigned sizes[dim];
@@ -2809,7 +2809,7 @@ namespace npstat {
     template<typename Numeric, unsigned Len, unsigned Dim>
     ArrayND<Numeric,Len,Dim>::ArrayND(const unsigned n0,
                                       const unsigned n1)
-        : data_(0), strides_(0), shape_(0), len_(1UL), shapeIsKnown_(true)
+        : data_(0), strides_(nullptr), shape_(nullptr), len_(1UL), shapeIsKnown_(true)
     {
         const unsigned dim = 2U;
         unsigned sizes[dim];
@@ -2822,7 +2822,7 @@ namespace npstat {
     ArrayND<Numeric,Len,Dim>::ArrayND(const unsigned n0,
                                       const unsigned n1,
                                       const unsigned n2)
-        : data_(0), strides_(0), shape_(0), len_(1UL), shapeIsKnown_(true)
+        : data_(0), strides_(nullptr), shape_(nullptr), len_(1UL), shapeIsKnown_(true)
     {
         const unsigned dim = 3U;
         unsigned sizes[dim];
@@ -2837,7 +2837,7 @@ namespace npstat {
                                       const unsigned n1,
                                       const unsigned n2,
                                       const unsigned n3)
-        : data_(0), strides_(0), shape_(0), len_(1UL), shapeIsKnown_(true)
+        : data_(0), strides_(nullptr), shape_(nullptr), len_(1UL), shapeIsKnown_(true)
     {
         const unsigned dim = 4U;
         unsigned sizes[dim];
@@ -2854,7 +2854,7 @@ namespace npstat {
                                       const unsigned n2,
                                       const unsigned n3,
                                       const unsigned n4)
-        : data_(0), strides_(0), shape_(0), len_(1UL), shapeIsKnown_(true)
+        : data_(0), strides_(nullptr), shape_(nullptr), len_(1UL), shapeIsKnown_(true)
     {
         const unsigned dim = 5U;
         unsigned sizes[dim];
@@ -2873,7 +2873,7 @@ namespace npstat {
                                       const unsigned n3,
                                       const unsigned n4,
                                       const unsigned n5)
-        : data_(0), strides_(0), shape_(0), len_(1UL), shapeIsKnown_(true)
+        : data_(0), strides_(nullptr), shape_(nullptr), len_(1UL), shapeIsKnown_(true)
     {
         const unsigned dim = 6U;
         unsigned sizes[dim];
@@ -2894,7 +2894,7 @@ namespace npstat {
                                       const unsigned n4,
                                       const unsigned n5,
                                       const unsigned n6)
-        : data_(0), strides_(0), shape_(0), len_(1UL), shapeIsKnown_(true)
+        : data_(0), strides_(nullptr), shape_(nullptr), len_(1UL), shapeIsKnown_(true)
     {
         const unsigned dim = 7U;
         unsigned sizes[dim];
@@ -2917,7 +2917,7 @@ namespace npstat {
                                       const unsigned n5,
                                       const unsigned n6,
                                       const unsigned n7)
-        : data_(0), strides_(0), shape_(0), len_(1UL), shapeIsKnown_(true)
+        : data_(0), strides_(nullptr), shape_(nullptr), len_(1UL), shapeIsKnown_(true)
     {
         const unsigned dim = 8U;
         unsigned sizes[dim];
@@ -2942,7 +2942,7 @@ namespace npstat {
                                       const unsigned n6,
                                       const unsigned n7,
                                       const unsigned n8)
-        : data_(0), strides_(0), shape_(0), len_(1UL), shapeIsKnown_(true)
+        : data_(0), strides_(nullptr), shape_(nullptr), len_(1UL), shapeIsKnown_(true)
     {
         const unsigned dim = 9U;
         unsigned sizes[dim];
@@ -2969,7 +2969,7 @@ namespace npstat {
                                       const unsigned n7,
                                       const unsigned n8,
                                       const unsigned n9)
-        : data_(0), strides_(0), shape_(0), len_(1UL), shapeIsKnown_(true)
+        : data_(0), strides_(nullptr), shape_(nullptr), len_(1UL), shapeIsKnown_(true)
     {
         const unsigned dim = 10U;
         unsigned sizes[dim];
@@ -3020,7 +3020,7 @@ namespace npstat {
              typename Num2, unsigned Len2, unsigned Dim2>
     ArrayND<Numeric,Len,Dim>::ArrayND(const ArrayND<Num1, Len1, Dim1>& a1,
                                       const ArrayND<Num2, Len2, Dim2>& a2)
-        : data_(0), strides_(0), shape_(0),
+        : data_(0), strides_(nullptr), shape_(nullptr),
           len_(1UL), dim_(a1.dim_ + a2.dim_), shapeIsKnown_(true)
     {
         if (!(a1.shapeIsKnown_ && a2.shapeIsKnown_))
@@ -4787,8 +4787,8 @@ namespace npstat {
         destroyBuffer(shape_, localShape_);
         localData_[0] = Numeric();
         data_ = localData_;
-        strides_ = 0;
-        shape_ = 0;
+        strides_ = nullptr;
+        shape_ = nullptr;
         len_ = 0;
         dim_ = 0;
         shapeIsKnown_ = false;
@@ -4978,7 +4978,7 @@ namespace npstat {
         }
         else
             localData_[0] = static_cast<Numeric>(
-                f(static_cast<unsigned*>(0), 0U));
+                f(static_cast<unsigned*>(nullptr), 0U));
         return *this;
     }
 
@@ -5595,7 +5595,7 @@ namespace npstat {
         if (dim_ == 1 && r.dim_ == 1)
         {
             // Special case: the result is of 0 rank
-            ArrayND<Numeric,Len,Dim> result(static_cast<unsigned*>(0), 0U);
+            ArrayND<Numeric,Len,Dim> result(static_cast<unsigned*>(nullptr), 0U);
             Numeric sum = Numeric();
             const unsigned imax = shape_[0];
             for (unsigned i=0; i<imax; ++i)

--- a/JetMETCorrections/InterpolationTables/interface/ArrayNDScanner.h
+++ b/JetMETCorrections/InterpolationTables/interface/ArrayNDScanner.h
@@ -42,7 +42,7 @@ namespace npstat {
             {initialize(shape, lenShape);}
 
         inline explicit ArrayNDScanner(const std::vector<unsigned>& shape)
-            {initialize(shape.empty() ? static_cast<unsigned*>(0) : 
+            {initialize(shape.empty() ? static_cast<unsigned*>(nullptr) : 
                         &shape[0], shape.size());}
         //@}
 
@@ -76,7 +76,7 @@ namespace npstat {
             {state_ = state <= maxState_ ? state : maxState_;}
 
     private:
-        ArrayNDScanner();
+        ArrayNDScanner() = delete;
         
         void initialize(const unsigned* shape, unsigned lenShape);
 

--- a/JetMETCorrections/InterpolationTables/interface/CoordinateSelector.h
+++ b/JetMETCorrections/InterpolationTables/interface/CoordinateSelector.h
@@ -27,9 +27,9 @@ namespace npstat {
     public:
         inline explicit CoordinateSelector(const unsigned i) : index_(i) {}
 
-        inline virtual ~CoordinateSelector() {}
+        inline ~CoordinateSelector() override {}
 
-        inline double operator()(const double* point, const unsigned dim) const
+        inline double operator()(const double* point, const unsigned dim) const override
         {
             if (dim <= index_)
                 throw npstat::NpstatInvalidArgument(
@@ -37,11 +37,11 @@ namespace npstat {
                     "input array dimensionality is too small");
             return point[index_];
         }
-        inline unsigned minDim() const {return index_ + 1U;}
-        inline unsigned maxDim() const {return UINT_MAX;}
+        inline unsigned minDim() const override {return index_ + 1U;}
+        inline unsigned maxDim() const override {return UINT_MAX;}
 
     private:
-        CoordinateSelector();
+        CoordinateSelector() = delete;
         unsigned index_;
     };
 }

--- a/JetMETCorrections/InterpolationTables/interface/DualAxis.h
+++ b/JetMETCorrections/InterpolationTables/interface/DualAxis.h
@@ -32,7 +32,7 @@ namespace npstat {
             : a_(dummy_vec()), u_(u), uniform_(true) {}
 
         inline DualAxis(unsigned nCoords, double min, double max,
-                        const char* label=0)
+                        const char* label=nullptr)
             : a_(dummy_vec()), u_(nCoords, min, max, label), uniform_(true) {}
 
         inline explicit DualAxis(const std::vector<double>& coords,
@@ -95,10 +95,10 @@ namespace npstat {
         // constructed type.
         */
         inline const GridAxis* getGridAxis() const
-            {return uniform_ ? static_cast<const GridAxis*>(0) : &a_;}
+            {return uniform_ ? static_cast<const GridAxis*>(nullptr) : &a_;}
 
         inline const UniformAxis* getUniformAxis() const
-            {return uniform_ ? &u_ : static_cast<const UniformAxis*>(0);}
+            {return uniform_ ? &u_ : static_cast<const UniformAxis*>(nullptr);}
         //@}
 
         /** Modify the axis label */

--- a/JetMETCorrections/InterpolationTables/interface/DualHistoAxis.h
+++ b/JetMETCorrections/InterpolationTables/interface/DualHistoAxis.h
@@ -31,11 +31,11 @@ namespace npstat {
             : a_(dummy_vec()), u_(u), uniform_(true) {}
 
         inline DualHistoAxis(const std::vector<double>& binEdges,
-                             const char* label = 0)
+                             const char* label = nullptr)
             : a_(binEdges, label), u_(1U, 0.0, 1.0), uniform_(false) {}
 
         inline DualHistoAxis(unsigned nBins, double min, double max,
-                             const char* label = 0)
+                             const char* label = nullptr)
             : a_(dummy_vec()), u_(nBins, min, max, label), uniform_(true) {}
 
         // Inspectors
@@ -81,10 +81,10 @@ namespace npstat {
         // constructed type.
         */
         inline const NUHistoAxis* getNUHistoAxis() const
-            {return uniform_ ? static_cast<const NUHistoAxis*>(0) : &a_;}
+            {return uniform_ ? static_cast<const NUHistoAxis*>(nullptr) : &a_;}
 
         inline const HistoAxis* getHistoAxis() const
-            {return uniform_ ? &u_ : static_cast<const HistoAxis*>(0);}
+            {return uniform_ ? &u_ : static_cast<const HistoAxis*>(nullptr);}
         //@}
 
         /** Modify the axis label */

--- a/JetMETCorrections/InterpolationTables/interface/EquidistantSequence.h
+++ b/JetMETCorrections/InterpolationTables/interface/EquidistantSequence.h
@@ -27,7 +27,7 @@ namespace npstat {
         virtual ~EquidistantInLinearSpace() {}
 
     private:
-        EquidistantInLinearSpace();
+        EquidistantInLinearSpace() = delete;
     };
 
     /**
@@ -43,7 +43,7 @@ namespace npstat {
         virtual ~EquidistantInLogSpace() {}
 
     private:
-        EquidistantInLogSpace();
+        EquidistantInLogSpace() = delete;
     };
 }
 

--- a/JetMETCorrections/InterpolationTables/interface/HistoAxis.h
+++ b/JetMETCorrections/InterpolationTables/interface/HistoAxis.h
@@ -35,7 +35,7 @@ namespace npstat {
         // if the minimum parameter is larger than the maximum
         */
         HistoAxis(unsigned nBins, double min, double max,
-                  const char* label=0);
+                  const char* label=nullptr);
 
         //@{
         /** Examine axis properties */

--- a/JetMETCorrections/InterpolationTables/interface/HistoND.h
+++ b/JetMETCorrections/InterpolationTables/interface/HistoND.h
@@ -55,30 +55,30 @@ namespace npstat {
         };
 
         /** Main constructor for arbitrary-dimensional histograms */
-        explicit HistoND(const std::vector<Axis>& axes, const char* title=0,
-                         const char* accumulatedDataLabel=0);
+        explicit HistoND(const std::vector<Axis>& axes, const char* title=nullptr,
+                         const char* accumulatedDataLabel=nullptr);
 
         /** Convenience constructor for 1-d histograms */
-        explicit HistoND(const Axis& xAxis, const char* title=0,
-                         const char* accumulatedDataLabel=0);
+        explicit HistoND(const Axis& xAxis, const char* title=nullptr,
+                         const char* accumulatedDataLabel=nullptr);
 
         /** Convenience constructor for 2-d histograms */
         HistoND(const Axis& xAxis, const Axis& yAxis,
-                const char* title=0, const char* accumulatedDataLabel=0);
+                const char* title=nullptr, const char* accumulatedDataLabel=nullptr);
 
         /** Convenience constructor for 3-d histograms */
         HistoND(const Axis& xAxis, const Axis& yAxis, const Axis& zAxis,
-                const char* title=0, const char* accumulatedDataLabel=0);
+                const char* title=nullptr, const char* accumulatedDataLabel=nullptr);
 
         /** Convenience constructor for 4-d histograms */
         HistoND(const Axis& xAxis, const Axis& yAxis,
                 const Axis& zAxis, const Axis& tAxis,
-                const char* title=0, const char* accumulatedDataLabel=0);
+                const char* title=nullptr, const char* accumulatedDataLabel=nullptr);
 
         /** Convenience constructor for 5-d histograms */
         HistoND(const Axis& xAxis, const Axis& yAxis,
                 const Axis& zAxis, const Axis& tAxis, const Axis& vAxis,
-                const char* title=0, const char* accumulatedDataLabel=0);
+                const char* title=nullptr, const char* accumulatedDataLabel=nullptr);
 
         /**
         // Simple constructor for uniformly binned histograms without
@@ -86,7 +86,7 @@ namespace npstat {
         // both "shape" and "boundingBox" arguments must be the same.
         */
         HistoND(const ArrayShape& shape, const BoxND<double>& boundingBox,
-                const char* title=0, const char* accumulatedDataLabel=0);
+                const char* title=nullptr, const char* accumulatedDataLabel=nullptr);
 
         /**
         // Converting constructor. The functor will be applied to all bins
@@ -96,7 +96,7 @@ namespace npstat {
         */
         template <typename Num2, class Functor>
         HistoND(const HistoND<Num2,Axis>& h, const Functor& f,
-                const char* title=0, const char* accumulatedDataLabel=0);
+                const char* title=nullptr, const char* accumulatedDataLabel=nullptr);
 
         /**
         // A slicing constructor. The new histogram will be created by
@@ -107,7 +107,7 @@ namespace npstat {
         */
         template <typename Num2>
         HistoND(const HistoND<Num2,Axis>& h, const unsigned *indices,
-                unsigned nIndices, const char* title=0);
+                unsigned nIndices, const char* title=nullptr);
 
         /**
         // A constructor that inserts a new axis into a histogram
@@ -120,7 +120,7 @@ namespace npstat {
         */
         template <typename Num2>
         HistoND(const HistoND<Num2,Axis>& h, const Axis& newAxis,
-                unsigned newAxisNumber, const char* title=0);
+                unsigned newAxisNumber, const char* title=nullptr);
 
         /**
         // Create a rebinned histogram with the same axis coverage.
@@ -142,7 +142,7 @@ namespace npstat {
         template <typename Num2>
         HistoND(const HistoND<Num2,Axis>& h, RebinType rType,
                 const unsigned *newBinCounts, unsigned lenNewBinCounts, 
-                const double* shifts=0, const char* title=0);
+                const double* shifts=nullptr, const char* title=nullptr);
 
         /** Copy constructor */
         HistoND(const HistoND&);
@@ -843,7 +843,7 @@ namespace npstat {
         static HistoND* read(const gs::ClassId& id, std::istream& in);
 
     private:
-        HistoND();
+        HistoND() = delete;
 
         // Special constructor which speeds up the "transpose" operation.
         // Does not do full error checking (some of it is done in transpose).

--- a/JetMETCorrections/InterpolationTables/interface/LinInterpolatedTableND.h
+++ b/JetMETCorrections/InterpolationTables/interface/LinInterpolatedTableND.h
@@ -54,29 +54,29 @@ namespace npstat {
         LinInterpolatedTableND(
             const std::vector<Axis>& axes,
             const std::vector<std::pair<bool,bool> >& extrapolationType,
-            const char* functionLabel=0);
+            const char* functionLabel=nullptr);
 
         /** Convenience constructor for 1-d interpolators */
         LinInterpolatedTableND(const Axis& xAxis, bool leftX, bool rightX,
-                               const char* functionLabel=0);
+                               const char* functionLabel=nullptr);
 
         /** Convenience constructor for 2-d interpolators */
         LinInterpolatedTableND(const Axis& xAxis, bool leftX, bool rightX,
                                const Axis& yAxis, bool leftY, bool rightY,
-                               const char* functionLabel=0);
+                               const char* functionLabel=nullptr);
 
         /** Convenience constructor for 3-d interpolators */
         LinInterpolatedTableND(const Axis& xAxis, bool leftX, bool rightX,
                                const Axis& yAxis, bool leftY, bool rightY,
                                const Axis& zAxis, bool leftZ, bool rightZ,
-                               const char* functionLabel=0);
+                               const char* functionLabel=nullptr);
 
         /** Convenience constructor for 4-d interpolators */
         LinInterpolatedTableND(const Axis& xAxis, bool leftX, bool rightX,
                                const Axis& yAxis, bool leftY, bool rightY,
                                const Axis& zAxis, bool leftZ, bool rightZ,
                                const Axis& tAxis, bool leftT, bool rightT,
-                               const char* functionLabel=0);
+                               const char* functionLabel=nullptr);
 
         /** Convenience constructor for 5-d interpolators */
         LinInterpolatedTableND(const Axis& xAxis, bool leftX, bool rightX,
@@ -84,7 +84,7 @@ namespace npstat {
                                const Axis& zAxis, bool leftZ, bool rightZ,
                                const Axis& tAxis, bool leftT, bool rightT,
                                const Axis& vAxis, bool leftV, bool rightV,
-                               const char* functionLabel=0);
+                               const char* functionLabel=nullptr);
 
         /**
         // Converting copy constructor from interpolator
@@ -162,7 +162,7 @@ namespace npstat {
         CPP11_auto_ptr<LinInterpolatedTableND> invertWRTAxis(
             ConvertibleToUnsigned axisNumber, const Axis& replacementAxis,
             bool newAxisLeftLinear, bool newAxisRightLinear,
-            const char* functionLabel=0) const;
+            const char* functionLabel=nullptr) const;
 
         /**
         // This method inverts the ratio response.
@@ -191,7 +191,7 @@ namespace npstat {
             unsigned axisNumber, const Axis& replacementAxis,
             bool newAxisLeftLinear, bool newAxisRightLinear,
             Functor1 invg, Functor2 invh,
-            const char* functionLabel=0) const;
+            const char* functionLabel=nullptr) const;
 
         /** Comparison for equality */
         bool operator==(const LinInterpolatedTableND&) const;
@@ -212,7 +212,7 @@ namespace npstat {
             const gs::ClassId& id, std::istream& in);
 
     private:
-        LinInterpolatedTableND();
+        LinInterpolatedTableND() = delete;
 
         LinInterpolatedTableND(
             const ArrayND<Numeric>& data,

--- a/JetMETCorrections/InterpolationTables/interface/NUHistoAxis.h
+++ b/JetMETCorrections/InterpolationTables/interface/NUHistoAxis.h
@@ -32,7 +32,7 @@ namespace npstat {
         // coordinates will be sorted internally in the increasing order.
         // The number of bins will be less by 1 than the number of edges.
         */
-        NUHistoAxis(const std::vector<double>& binEdges, const char* label = 0);
+        NUHistoAxis(const std::vector<double>& binEdges, const char* label = nullptr);
 
         //@{
         /** Examine axis properties */
@@ -108,7 +108,7 @@ namespace npstat {
 
     private:
         NUHistoAxis(unsigned nBins, double min, double max,
-                    const char* label = 0);
+                    const char* label = nullptr);
 
         double min_;
         double max_;

--- a/JetMETCorrections/InterpolationTables/interface/NpstatException.h
+++ b/JetMETCorrections/InterpolationTables/interface/NpstatException.h
@@ -27,7 +27,7 @@ namespace npstat {
         inline explicit NpstatException(const char* description)
             : cms::Exception(description) {}
 
-        virtual ~NpstatException() throw() {}
+        ~NpstatException() throw() override {}
     };
 
     struct NpstatOutOfRange : public NpstatException
@@ -37,7 +37,7 @@ namespace npstat {
         inline explicit NpstatOutOfRange(const std::string& description)
             : NpstatException(description) {}
 
-        virtual ~NpstatOutOfRange() throw() {}
+        ~NpstatOutOfRange() throw() override {}
     };
 
     struct NpstatInvalidArgument : public NpstatException
@@ -47,7 +47,7 @@ namespace npstat {
         inline explicit NpstatInvalidArgument(const std::string& description)
             : NpstatException(description) {}
 
-        virtual ~NpstatInvalidArgument() throw() {}
+        ~NpstatInvalidArgument() throw() override {}
     };
 
     struct NpstatRuntimeError : public NpstatException
@@ -57,7 +57,7 @@ namespace npstat {
         inline explicit NpstatRuntimeError(const std::string& description)
             : NpstatException(description) {}
 
-        virtual ~NpstatRuntimeError() throw() {}
+        ~NpstatRuntimeError() throw() override {}
     };
 
     struct NpstatDomainError : public NpstatException
@@ -67,7 +67,7 @@ namespace npstat {
         inline explicit NpstatDomainError(const std::string& description)
             : NpstatException(description) {}
 
-        virtual ~NpstatDomainError() throw() {}
+        ~NpstatDomainError() throw() override {}
     };
 }
 

--- a/JetMETCorrections/InterpolationTables/interface/SimpleFunctors.h
+++ b/JetMETCorrections/InterpolationTables/interface/SimpleFunctors.h
@@ -63,7 +63,7 @@ namespace npstat {
     template <typename Result>
     struct Same : public Functor1<Result, Result>
     {
-        inline Result operator()(const Result& a) const {return a;}
+        inline Result operator()(const Result& a) const override {return a;}
     };
 
     /** A simple functor which returns a reference to its argument */
@@ -138,7 +138,7 @@ namespace npstat {
         inline Result operator()() const {return fcn_();}
 
     private:
-        FcnFunctor0();
+        FcnFunctor0() = delete;
         Result (*fcn_)();
     };
 
@@ -154,7 +154,7 @@ namespace npstat {
         inline Result operator()(const Arg1& a) const {return fcn_(a);}
 
     private:
-        FcnFunctor1();
+        FcnFunctor1() = delete;
         Result (*fcn_)(Arg1);
     };
 
@@ -171,7 +171,7 @@ namespace npstat {
             {return fcn_(x, y);}
 
     private:
-        FcnFunctor2();
+        FcnFunctor2() = delete;
         Result (*fcn_)(Arg1, Arg2);
     };
 
@@ -188,7 +188,7 @@ namespace npstat {
             {return fcn_(x, y, z);}
 
     private:
-        FcnFunctor3();
+        FcnFunctor3() = delete;
         Result (*fcn_)(Arg1, Arg2, Arg3);
     };
 
@@ -204,7 +204,7 @@ namespace npstat {
         inline Result operator()(const Container& c) const {return c[idx];}
 
     private:
-        Element1D();
+        Element1D() = delete;
         unsigned long idx;
     };
 
@@ -220,7 +220,7 @@ namespace npstat {
         inline Result operator()(const Container& c) const {return c.at(idx);}
 
     private:
-        Element1DAt();
+        Element1DAt() = delete;
         unsigned long idx;
     };
 
@@ -275,7 +275,7 @@ namespace npstat {
             {return left += w_*right;}
 
     private:
-        addmul_left();
+        addmul_left() = delete;
         double w_;
     };
 
@@ -292,7 +292,7 @@ namespace npstat {
             {return right += w_*left;}
 
     private:
-        addmul_right();
+        addmul_right() = delete;
         double w_;
     };
 

--- a/JetMETCorrections/InterpolationTables/interface/StorableHistoNDFunctor.h
+++ b/JetMETCorrections/InterpolationTables/interface/StorableHistoNDFunctor.h
@@ -65,11 +65,11 @@ namespace npstat {
               table_(tab.table_, Same<Num2>(), tab.title().c_str(),
                      tab.accumulatedDataLabel().c_str()), deg_(tab.deg_) {}
 
-        virtual ~StorableHistoNDFunctor() {}
+        ~StorableHistoNDFunctor() override {}
 
-        virtual unsigned minDim() const {return table_.dim();};
+        unsigned minDim() const override {return table_.dim();};
 
-        virtual double operator()(const double* point, unsigned dim) const;
+        double operator()(const double* point, unsigned dim) const override;
 
         /** Retrieve interpolation degree */
         inline unsigned interpolationDegree() const {return deg_;}
@@ -97,8 +97,8 @@ namespace npstat {
 
         //@{
         // Method related to "geners" I/O
-        virtual gs::ClassId classId() const {return gs::ClassId(*this);}
-        virtual bool write(std::ostream& of) const;
+        gs::ClassId classId() const override {return gs::ClassId(*this);}
+        bool write(std::ostream& of) const override;
         //@}
 
         // I/O methods needed for reading
@@ -108,7 +108,7 @@ namespace npstat {
             const gs::ClassId& id, std::istream& in);
 
     protected:
-        virtual bool isEqual(const StorableMultivariateFunctor& other) const
+        bool isEqual(const StorableMultivariateFunctor& other) const override
         {
             // Note the use of static_cast rather than dynamic_cast below.
             // static_cast works faster and it is guaranteed to succeed here.
@@ -119,7 +119,7 @@ namespace npstat {
         }
 
     private:
-        StorableHistoNDFunctor();
+        StorableHistoNDFunctor() = delete;
 
         Table table_;
         unsigned deg_;

--- a/JetMETCorrections/InterpolationTables/interface/StorableInterpolationFunctor.h
+++ b/JetMETCorrections/InterpolationTables/interface/StorableInterpolationFunctor.h
@@ -65,20 +65,20 @@ namespace npstat {
         inline StorableInterpolationFunctor(
             const std::vector<Axis>& axes,
             const std::vector<std::pair<bool,bool> >& interpolationType,
-            const char* functionLabel=0)
+            const char* functionLabel=nullptr)
             : StorableMultivariateFunctor(),
               table_(axes, interpolationType, functionLabel) {}
 
         inline StorableInterpolationFunctor(
             const Axis& xAxis, bool leftX, bool rightX,
-            const char* functionLabel=0)
+            const char* functionLabel=nullptr)
             : StorableMultivariateFunctor(),
               table_(xAxis, leftX, rightX, functionLabel) {}
 
         inline StorableInterpolationFunctor(
             const Axis& xAxis, bool leftX, bool rightX,
             const Axis& yAxis, bool leftY, bool rightY,
-            const char* functionLabel=0)
+            const char* functionLabel=nullptr)
             : StorableMultivariateFunctor(),
               table_(xAxis, leftX, rightX,
                      yAxis, leftY, rightY, functionLabel) {}
@@ -87,7 +87,7 @@ namespace npstat {
             const Axis& xAxis, bool leftX, bool rightX,
             const Axis& yAxis, bool leftY, bool rightY,
             const Axis& zAxis, bool leftZ, bool rightZ,
-            const char* functionLabel=0)
+            const char* functionLabel=nullptr)
             : StorableMultivariateFunctor(),
               table_(xAxis, leftX, rightX,
                      yAxis, leftY, rightY,
@@ -98,7 +98,7 @@ namespace npstat {
             const Axis& yAxis, bool leftY, bool rightY,
             const Axis& zAxis, bool leftZ, bool rightZ,
             const Axis& tAxis, bool leftT, bool rightT,
-            const char* functionLabel=0)
+            const char* functionLabel=nullptr)
             : StorableMultivariateFunctor(),
               table_(xAxis, leftX, rightX,
                      yAxis, leftY, rightY,
@@ -111,7 +111,7 @@ namespace npstat {
             const Axis& zAxis, bool leftZ, bool rightZ,
             const Axis& tAxis, bool leftT, bool rightT,
             const Axis& vAxis, bool leftV, bool rightV,
-            const char* functionLabel=0)
+            const char* functionLabel=nullptr)
             : StorableMultivariateFunctor(),
               table_(xAxis, leftX, rightX,
                      yAxis, leftY, rightY,
@@ -120,11 +120,11 @@ namespace npstat {
                      vAxis, leftV, rightV, functionLabel) {}
         //@}
 
-        virtual ~StorableInterpolationFunctor() {}
+        ~StorableInterpolationFunctor() override {}
 
-        virtual unsigned minDim() const {return table_.dim();};
+        unsigned minDim() const override {return table_.dim();};
 
-        virtual double operator()(const double* point, unsigned dim) const
+        double operator()(const double* point, unsigned dim) const override
             {return conv_(table_(point, dim));}
 
         //@{
@@ -144,8 +144,8 @@ namespace npstat {
 
         //@{
         // Method related to "geners" I/O
-        virtual gs::ClassId classId() const {return gs::ClassId(*this);}
-        virtual bool write(std::ostream& of) const;
+        gs::ClassId classId() const override {return gs::ClassId(*this);}
+        bool write(std::ostream& of) const override;
         //@}
 
         // I/O methods needed for reading
@@ -155,7 +155,7 @@ namespace npstat {
             const gs::ClassId& id, std::istream& in);
 
     protected:
-        virtual bool isEqual(const StorableMultivariateFunctor& other) const
+        bool isEqual(const StorableMultivariateFunctor& other) const override
         {
             // Note the use of static_cast rather than dynamic_cast below.
             // static_cast works faster and it is guaranteed to succeed here.
@@ -166,7 +166,7 @@ namespace npstat {
         }
 
     private:
-        StorableInterpolationFunctor();
+        StorableInterpolationFunctor() = delete;
 
         Table table_;
         Converter conv_;

--- a/JetMETCorrections/InterpolationTables/interface/StorableMultivariateFunctor.h
+++ b/JetMETCorrections/InterpolationTables/interface/StorableMultivariateFunctor.h
@@ -29,7 +29,7 @@ namespace npstat {
         inline explicit StorableMultivariateFunctor(const std::string& descr)
             : AbsMultivariateFunctor(), description_(descr) {}
 
-        inline virtual ~StorableMultivariateFunctor() {}
+        inline ~StorableMultivariateFunctor() override {}
 
         /** Retrieve the functor description */
         inline const std::string& description() const {return description_;}

--- a/JetMETCorrections/InterpolationTables/interface/StorableMultivariateFunctorReader.h
+++ b/JetMETCorrections/InterpolationTables/interface/StorableMultivariateFunctorReader.h
@@ -25,7 +25,7 @@ namespace npstat {
     {
         typedef gs::DefaultReader<StorableMultivariateFunctor> Base;
         friend class gs::StaticReader<StorableMultivariateFunctorReader>;
-        StorableMultivariateFunctorReader();
+        StorableMultivariateFunctorReader() = delete;
     };
         
     /** The reader factory for descendants of StorableMultivariateFunctor */

--- a/JetMETCorrections/InterpolationTables/interface/UniformAxis.h
+++ b/JetMETCorrections/InterpolationTables/interface/UniformAxis.h
@@ -29,7 +29,7 @@ namespace npstat {
     public:
         // The number of coordinates must be at least 2
         UniformAxis(unsigned nCoords, double min, double max,
-                    const char* label=0);
+                    const char* label=nullptr);
 
         // Basic accessors
         inline unsigned nCoords() const {return npt_;}

--- a/JetMETCorrections/InterpolationTables/interface/allocators.h
+++ b/JetMETCorrections/InterpolationTables/interface/allocators.h
@@ -22,7 +22,7 @@ namespace npstat {
     inline T* makeBuffer(unsigned sizeNeeded, T* stackBuffer,
                          unsigned sizeofStackBuffer)
     {
-        if (sizeNeeded > sizeofStackBuffer || stackBuffer == 0)
+        if (sizeNeeded > sizeofStackBuffer || stackBuffer == nullptr)
             return new T[sizeNeeded];
         else
             return stackBuffer;

--- a/JetMETCorrections/InterpolationTables/src/ArrayRange.cc
+++ b/JetMETCorrections/InterpolationTables/src/ArrayRange.cc
@@ -16,7 +16,7 @@ namespace npstat {
     bool ArrayRange::isCompatible(const ArrayShape& ishape) const
     {
         const unsigned imax = ishape.size();
-        return isCompatible(imax ? &ishape[0] : (unsigned*)0, imax);
+        return isCompatible(imax ? &ishape[0] : (unsigned*)nullptr, imax);
     }
 
     bool ArrayRange::isCompatible(const unsigned* ishape,

--- a/JetMETCorrections/InterpolationTables/src/StorableMultivariateFunctor.cc
+++ b/JetMETCorrections/InterpolationTables/src/StorableMultivariateFunctor.cc
@@ -15,7 +15,7 @@ namespace npstat {
             mesage += "\" is different from the object description string \"";
             mesage += description_;
             mesage += "\"";
-            throw npstat::NpstatRuntimeError(mesage.c_str());
+            throw npstat::NpstatRuntimeError(mesage);
         }
     }
 

--- a/JetMETCorrections/JetParton/interface/JetPartonCorrector.h
+++ b/JetMETCorrections/JetParton/interface/JetPartonCorrector.h
@@ -22,14 +22,14 @@ class JetPartonCorrector : public JetCorrector
 {
 public:  
   JetPartonCorrector(const edm::ParameterSet& fConfig); 
-  virtual ~JetPartonCorrector();
+  ~JetPartonCorrector() override;
   
-  virtual double   correction (const LorentzVector& fJet) const;
+  double   correction (const LorentzVector& fJet) const override;
    
   void setParameters(std::string aCalibrationType, double aJetFinderRadius, int aPartonMixture);
 
   /// if correction needs event information
-  virtual bool eventRequired () const {return false;}
+  bool eventRequired () const override {return false;}
   
 private:
 

--- a/JetMETCorrections/JetParton/src/JetPartonCorrector.cc
+++ b/JetMETCorrections/JetParton/src/JetPartonCorrector.cc
@@ -105,7 +105,7 @@ class   JetPartonCalibrationParameterSet{
   double eta(int ieta){return etavector[ieta];}
   int type(int ieta){return typevector[ieta];}
   const vector<double>& parameters(int ieta){return pars[ieta];}
-  bool valid(){return etavector.size();}
+  bool valid(){return !etavector.empty();}
   
  private:
   
@@ -127,7 +127,7 @@ JetPartonCalibrationParameterSet::JetPartonCalibrationParameterSet(string tag){
   //  if ( f1.isLocal() ){
     string line;
     while( std::getline( in, line) ){
-      if(!line.size() || line[0]=='#') continue;
+      if(line.empty() || line[0]=='#') continue;
       istringstream linestream(line);
       double par;
       int type;

--- a/JetMETCorrections/JetVertexAssociation/interface/JetVertexAssociation.h
+++ b/JetMETCorrections/JetVertexAssociation/interface/JetVertexAssociation.h
@@ -30,9 +30,9 @@ namespace cms{
 
    JetVertexAssociation (const edm::ParameterSet& ps);
 
-   ~JetVertexAssociation () {}
+   ~JetVertexAssociation () override {}
 
-   void produce(edm::Event& e, const edm::EventSetup& c);
+   void produce(edm::Event& e, const edm::EventSetup& c) override;
 
   private:
     typedef std::vector<double> ResultCollection1;

--- a/JetMETCorrections/JetVertexAssociation/src/JetVertexAssociation.cc
+++ b/JetMETCorrections/JetVertexAssociation/src/JetVertexAssociation.cc
@@ -84,7 +84,7 @@ namespace cms{
    double ptmax = -100.;
 
    VertexCollection::const_iterator vert = vertexes->begin ();
-   if(vertexes->size() > 0 )   {
+   if(!vertexes->empty() )   {
         for (; vert != vertexes->end (); vert++) {
 
                 SIGNAL_V_Z = vert->z();
@@ -108,7 +108,7 @@ namespace cms{
 
    CaloJetCollection::const_iterator jet = jets->begin ();
 
-   if(jets->size() > 0 )   {
+   if(!jets->empty() )   {
         for (; jet != jets->end (); jet++) {
 	     result = m_algo.Main(*jet, tracks, SIGNAL_V_Z, SIGNAL_V_Z_ERROR);
              result1->push_back(result.first);

--- a/JetMETCorrections/JetVertexAssociation/src/JetVertexMain.cc
+++ b/JetMETCorrections/JetVertexAssociation/src/JetVertexMain.cc
@@ -38,7 +38,7 @@ std::pair<double,bool> JetVertexMain::Main(const reco::CaloJet& jet, edm::Handle
 
   TrackCollection::const_iterator track = tracks->begin ();
 
-  if (tracks->size() > 0 )   { 
+  if (!tracks->empty() )   { 
    for (; track != tracks->end (); track++) {
      double Vertex_Z = track->vz();
      double Vertex_Z_Error = track->dzError();

--- a/JetMETCorrections/MCJet/bin/L2Correction.cc
+++ b/JetMETCorrections/MCJet/bin/L2Correction.cc
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <iomanip>
-#include <string.h>
+#include <cstring>
 #include <fstream>
 #include <cmath>
 #include <TFile.h>

--- a/JetMETCorrections/MCJet/bin/L3Correction.cc
+++ b/JetMETCorrections/MCJet/bin/L3Correction.cc
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <iomanip>
-#include <string.h>
+#include <cstring>
 #include <fstream>
 #include <cmath>
 #include <TFile.h>

--- a/JetMETCorrections/MCJet/bin/ReadTree.cc
+++ b/JetMETCorrections/MCJet/bin/ReadTree.cc
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <string.h>
+#include <cstring>
 #include <fstream>
 #include <cmath>
 #include <TFile.h>

--- a/JetMETCorrections/MCJet/bin/ResponseFitter.cc
+++ b/JetMETCorrections/MCJet/bin/ResponseFitter.cc
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <string.h>
+#include <cstring>
 #include <fstream>
 #include <cmath>
 #include <TFile.h>

--- a/JetMETCorrections/MCJet/bin/Utilities.h
+++ b/JetMETCorrections/MCJet/bin/Utilities.h
@@ -248,7 +248,7 @@ bool CommandLine::check()
     }
   }
   
-  if (_unknowns.size()>0) {
+  if (!_unknowns.empty()) {
     result = false;
     std::cout<<"\nCommandLine WARNING: "<<_unknowns.size()
 	<<" the followingparameters *must* be provided:"<<std::endl;

--- a/JetMETCorrections/MCJet/plugins/CaloMCTruthTreeProducer.cc
+++ b/JetMETCorrections/MCJet/plugins/CaloMCTruthTreeProducer.cc
@@ -50,12 +50,12 @@ void CaloMCTruthTreeProducer::beginJob()
 //////////////////////////////////////////////////////////////////////////////////////////
 void CaloMCTruthTreeProducer::endJob()
 {
-  if (file_ !=0)
+  if (file_ !=nullptr)
     {
       file_->cd();
       mcTruthTree_->Write();
     }
-  file_ = 0;
+  file_ = nullptr;
 }
 //////////////////////////////////////////////////////////////////////////////////////////
 void CaloMCTruthTreeProducer::analyze(edm::Event const& event, edm::EventSetup const& iSetup)
@@ -71,7 +71,7 @@ void CaloMCTruthTreeProducer::analyze(edm::Event const& event, edm::EventSetup c
   ptHat_ = hEventInfo->binningValues()[0];
   float rr;
   int njet(0);
-  if (jets->size()>0 && genjets->size()>0)
+  if (!jets->empty() && !genjets->empty())
     {
       for (i_genjet = genjets->begin(); i_genjet != genjets->end(); i_genjet++)
        {

--- a/JetMETCorrections/MCJet/plugins/CaloMCTruthTreeProducer.h
+++ b/JetMETCorrections/MCJet/plugins/CaloMCTruthTreeProducer.h
@@ -14,10 +14,10 @@ class CaloMCTruthTreeProducer : public edm::EDAnalyzer
 {
   public:
     explicit CaloMCTruthTreeProducer(edm::ParameterSet const& cfg);
-    virtual void beginJob();
-    virtual void analyze(edm::Event const& e, edm::EventSetup const& iSetup);
-    virtual void endJob();
-    ~CaloMCTruthTreeProducer();
+    void beginJob() override;
+    void analyze(edm::Event const& e, edm::EventSetup const& iSetup) override;
+    void endJob() override;
+    ~CaloMCTruthTreeProducer() override;
 
   private:
     std::string histogramFile_;

--- a/JetMETCorrections/MCJet/plugins/PFMCTruthTreeProducer.cc
+++ b/JetMETCorrections/MCJet/plugins/PFMCTruthTreeProducer.cc
@@ -55,12 +55,12 @@ void PFMCTruthTreeProducer::beginJob()
 //////////////////////////////////////////////////////////////////////////////////////////
 void PFMCTruthTreeProducer::endJob()
 {
-  if (file_ !=0)
+  if (file_ !=nullptr)
     {
       file_->cd();
       mcTruthTree_->Write();
     }
-  file_ = 0;
+  file_ = nullptr;
 }
 //////////////////////////////////////////////////////////////////////////////////////////
 void PFMCTruthTreeProducer::analyze(edm::Event const& event, edm::EventSetup const& iSetup)
@@ -76,7 +76,7 @@ void PFMCTruthTreeProducer::analyze(edm::Event const& event, edm::EventSetup con
   ptHat_ = hEventInfo->binningValues()[0];
   float rr;
   int njet(0);
-  if (jets->size()>0 && genjets->size()>0)
+  if (!jets->empty() && !genjets->empty())
     {
       for (i_genjet = genjets->begin(); i_genjet != genjets->end(); i_genjet++)
        {

--- a/JetMETCorrections/MCJet/plugins/PFMCTruthTreeProducer.h
+++ b/JetMETCorrections/MCJet/plugins/PFMCTruthTreeProducer.h
@@ -14,10 +14,10 @@ class PFMCTruthTreeProducer : public edm::EDAnalyzer
 {
   public:
     explicit PFMCTruthTreeProducer(edm::ParameterSet const& cfg);
-    virtual void beginJob();
-    virtual void analyze(edm::Event const& e, edm::EventSetup const& iSetup);
-    virtual void endJob();
-    ~PFMCTruthTreeProducer();
+    void beginJob() override;
+    void analyze(edm::Event const& e, edm::EventSetup const& iSetup) override;
+    void endJob() override;
+    ~PFMCTruthTreeProducer() override;
 
   private:
     std::string histogramFile_;

--- a/JetMETCorrections/Modules/interface/CorrectedJetProducer.h
+++ b/JetMETCorrections/Modules/interface/CorrectedJetProducer.h
@@ -30,8 +30,8 @@ namespace reco
   public:
     typedef std::vector<T> JetCollection;
     explicit CorrectedJetProducer (const edm::ParameterSet& fParameters);
-    virtual ~CorrectedJetProducer () {}
-    virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+    ~CorrectedJetProducer () override {}
+    void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   private:
     const edm::EDGetTokenT<JetCollection> mInput;
     const std::vector <edm::EDGetTokenT<reco::JetCorrector> > mCorrectorTokens;

--- a/JetMETCorrections/Modules/interface/JetCorrectionESChain.h
+++ b/JetMETCorrections/Modules/interface/JetCorrectionESChain.h
@@ -23,7 +23,7 @@ namespace edm {
 class JetCorrectionESChain : public edm::ESProducer {
 public:
   JetCorrectionESChain(edm::ParameterSet const& fParameters);
-  ~JetCorrectionESChain();
+  ~JetCorrectionESChain() override;
 
   std::shared_ptr<JetCorrector> produce(JetCorrectionsRecord const& );
 

--- a/JetMETCorrections/Modules/interface/JetCorrectionESProducer.h
+++ b/JetMETCorrections/Modules/interface/JetCorrectionESProducer.h
@@ -40,7 +40,7 @@ public:
     setWhatProduced(this, label);
   }
 
-  ~JetCorrectionESProducer() {}
+  ~JetCorrectionESProducer() override {}
 
   std::shared_ptr<JetCorrector> produce(JetCorrectionsRecord const& iRecord)
   {

--- a/JetMETCorrections/Modules/interface/JetCorrectionESSource.h
+++ b/JetMETCorrections/Modules/interface/JetCorrectionESSource.h
@@ -58,7 +58,7 @@ public:
     findingRecord<JetCorrectionsRecord>();
   }
 
-  ~JetCorrectionESSource() {}
+  ~JetCorrectionESSource() override {}
 
   std::shared_ptr<JetCorrector> produce(JetCorrectionsRecord const& iRecord) 
   {
@@ -77,7 +77,7 @@ public:
     return std::make_shared<Corrector>(*tmpJetCorPar, mParameterSet);
   }
 
-  void setIntervalFor(edm::eventsetup::EventSetupRecordKey const&, edm::IOVSyncValue const&, edm::ValidityInterval& fIOV)
+  void setIntervalFor(edm::eventsetup::EventSetupRecordKey const&, edm::IOVSyncValue const&, edm::ValidityInterval& fIOV) override
   {
     fIOV = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime()); // anytime
   }

--- a/JetMETCorrections/Modules/interface/JetCorrectionProducer.h
+++ b/JetMETCorrections/Modules/interface/JetCorrectionProducer.h
@@ -33,8 +33,8 @@ namespace cms
   public:
     typedef std::vector<T> JetCollection;
     explicit JetCorrectionProducer (const edm::ParameterSet& fParameters);
-    virtual ~JetCorrectionProducer () {}
-    virtual void produce(edm::Event&, const edm::EventSetup&);
+    ~JetCorrectionProducer () override {}
+    void produce(edm::Event&, const edm::EventSetup&) override;
   private:
     edm::EDGetTokenT<JetCollection> mInput;
     std::vector <std::string> mCorrectorNames;
@@ -53,7 +53,7 @@ namespace cms {
   JetCorrectionProducer<T>::JetCorrectionProducer(const edm::ParameterSet& fConfig)
     : mInput(consumes<JetCollection>(fConfig.getParameter <edm::InputTag> ("src")))
     , mCorrectorNames(fConfig.getParameter<std::vector<std::string> >("correctors"))
-    , mCorrectors(mCorrectorNames.size(), 0)
+    , mCorrectors(mCorrectorNames.size(), nullptr)
     , mCacheId (0)
     , mVerbose (fConfig.getUntrackedParameter <bool> ("verbose", false))
   {

--- a/JetMETCorrections/Modules/interface/JetResolutionESProducer.h
+++ b/JetMETCorrections/Modules/interface/JetResolutionESProducer.h
@@ -29,7 +29,7 @@ class JetResolutionESProducer : public edm::ESProducer
             setWhatProduced(this, m_label);
         }
 
-        ~JetResolutionESProducer() {}
+        ~JetResolutionESProducer() override {}
 
         std::shared_ptr<JME::JetResolution> produce(JetResolutionRcd const& iRecord) {
             
@@ -55,7 +55,7 @@ class JetResolutionScaleFactorESProducer : public edm::ESProducer
             setWhatProduced(this, m_label);
         }
 
-        ~JetResolutionScaleFactorESProducer() {}
+        ~JetResolutionScaleFactorESProducer() override {}
 
         std::shared_ptr<JME::JetResolutionScaleFactor> produce(JetResolutionScaleFactorRcd const& iRecord) {
             

--- a/JetMETCorrections/Modules/interface/QGLikelihoodESProducer.h
+++ b/JetMETCorrections/Modules/interface/QGLikelihoodESProducer.h
@@ -19,7 +19,7 @@
 class QGLikelihoodESProducer : public edm::ESProducer{
    public:
       QGLikelihoodESProducer(const edm::ParameterSet&);
-      ~QGLikelihoodESProducer(){};
+      ~QGLikelihoodESProducer() override{};
 
       std::shared_ptr<QGLikelihoodObject> produce(const QGLikelihoodRcd&);
       void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &, edm::ValidityInterval &);

--- a/JetMETCorrections/Modules/interface/QGLikelihoodSystematicsESProducer.h
+++ b/JetMETCorrections/Modules/interface/QGLikelihoodSystematicsESProducer.h
@@ -19,7 +19,7 @@
 class QGLikelihoodSystematicsESProducer : public edm::ESProducer{
    public:
       QGLikelihoodSystematicsESProducer(const edm::ParameterSet&);
-      ~QGLikelihoodSystematicsESProducer(){};
+      ~QGLikelihoodSystematicsESProducer() override{};
 
       std::shared_ptr<QGLikelihoodSystematicsObject> produce(const QGLikelihoodSystematicsRcd&);
       void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &, edm::ValidityInterval &);

--- a/JetMETCorrections/Modules/plugins/ChainedJetCorrectorProducer.cc
+++ b/JetMETCorrections/Modules/plugins/ChainedJetCorrectorProducer.cc
@@ -50,17 +50,17 @@ namespace {
     ChainedJetCorrectorImpl(std::vector<reco::JetCorrector const*> correctors):
       jetCorrectors_(std::move(correctors)) {}
 
-    virtual double correction (const LorentzVector& fJet) const override;
+    double correction (const LorentzVector& fJet) const override;
 
     /// apply correction using Jet information only
-    virtual double correction (const reco::Jet& fJet) const override;
+    double correction (const reco::Jet& fJet) const override;
 
     /// apply correction using Ref
-    virtual double correction (const reco::Jet& fJet,
+    double correction (const reco::Jet& fJet,
 			       const edm::RefToBase<reco::Jet>& fJetRef) const override ;
 
     /// if correction needs the jet reference
-    virtual bool refRequired () const override;
+    bool refRequired () const override;
   
   private:
     std::vector<reco::JetCorrector const*> jetCorrectors_;
@@ -124,7 +124,7 @@ class ChainedJetCorrectorProducer : public edm::stream::EDProducer<> {
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
       
       // ----------member data ---------------------------
   std::vector<edm::EDGetTokenT<reco::JetCorrector>> correctorTokens_;

--- a/JetMETCorrections/Modules/plugins/FactorizedJetCorrectorDemo.cc
+++ b/JetMETCorrections/Modules/plugins/FactorizedJetCorrectorDemo.cc
@@ -29,13 +29,13 @@
 class FactorizedJetCorrectorDemo : public edm::EDAnalyzer {
 public:
   explicit FactorizedJetCorrectorDemo(const edm::ParameterSet&);
-  ~FactorizedJetCorrectorDemo();
+  ~FactorizedJetCorrectorDemo() override;
   typedef reco::Particle::LorentzVector LorentzVector;
 
 private:
-  virtual void beginJob() override ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override ;
+  void beginJob() override ;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
 
   std::string mJetCorService,mPayloadName,mUncertaintyTag,mUncertaintyFile;
   std::vector<std::string> mLevels;

--- a/JetMETCorrections/Modules/plugins/JetCorrectorDBReader.cc
+++ b/JetMETCorrections/Modules/plugins/JetCorrectorDBReader.cc
@@ -38,13 +38,13 @@
 class JetCorrectorDBReader : public edm::EDAnalyzer {
 public:
   explicit JetCorrectorDBReader(const edm::ParameterSet&);
-  ~JetCorrectorDBReader();
+  ~JetCorrectorDBReader() override;
   
   
 private:
-  virtual void beginJob() override ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override ;
+  void beginJob() override ;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
  
   std::string mPayloadName,mGlobalTag;
   bool mCreateTextFile,mPrintScreen;

--- a/JetMETCorrections/Modules/plugins/JetCorrectorDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/JetCorrectorDBWriter.cc
@@ -19,10 +19,10 @@ class  JetCorrectorDBWriter : public edm::EDAnalyzer
 {
  public:
   JetCorrectorDBWriter(const edm::ParameterSet&);
-  virtual void beginJob() override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override {}
-  virtual void endJob() override {}
-  ~JetCorrectorDBWriter() {}
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override {}
+  void endJob() override {}
+  ~JetCorrectorDBWriter() override {}
 
  private:
   std::string era;
@@ -64,7 +64,7 @@ void JetCorrectorDBWriter::beginJob()
       // create the parameter object from file 
       std::vector<std::string> sections;
       JetCorrectorParametersCollection::getSections(fip.fullPath(), sections );
-      if ( sections.size() == 0 ) {
+      if ( sections.empty() ) {
 	payload->push_back( i, JetCorrectorParameters(fip.fullPath(),"") );
       }
       else {

--- a/JetMETCorrections/Modules/plugins/JetCorrectorDemo.cc
+++ b/JetMETCorrections/Modules/plugins/JetCorrectorDemo.cc
@@ -28,13 +28,13 @@
 class JetCorrectorDemo : public edm::EDAnalyzer {
 public:
   explicit JetCorrectorDemo(const edm::ParameterSet&);
-  ~JetCorrectorDemo();
+  ~JetCorrectorDemo() override;
   typedef reco::Particle::LorentzVector LorentzVector;
 
 private:
-  virtual void beginJob() override ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override ;
+  void beginJob() override ;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
 
   edm::EDGetTokenT<reco::JetCorrector> mJetCorrector;
   std::string mPayloadName,mUncertaintyTag,mUncertaintyFile;
@@ -81,7 +81,7 @@ void JetCorrectorDemo::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 {
   edm::Handle<reco::JetCorrector> corrector;
   iEvent.getByToken(mJetCorrector, corrector);
-  JetCorrectionUncertainty *jecUnc(0);
+  JetCorrectionUncertainty *jecUnc(nullptr);
   if (mUncertaintyTag != "")
     {
       if (mUseCondDB)

--- a/JetMETCorrections/Modules/plugins/JetCorrectorOnTheFly.cc
+++ b/JetMETCorrections/Modules/plugins/JetCorrectorOnTheFly.cc
@@ -29,13 +29,13 @@ template<class Jet>
 class JetCorrectorOnTheFly : public edm::EDAnalyzer {
 public:
   explicit JetCorrectorOnTheFly(const edm::ParameterSet&);
-  ~JetCorrectorOnTheFly();
+  ~JetCorrectorOnTheFly() override;
 
 private:
   typedef std::vector<Jet> JetCollection;
-  virtual void beginJob() override ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override ;
+  void beginJob() override ;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
 
   edm::Service<TFileService> fs;
   edm::EDGetTokenT<reco::JetCorrector> mJetCorrector;

--- a/JetMETCorrections/Modules/plugins/JetResolutionDBReader.cc
+++ b/JetMETCorrections/Modules/plugins/JetResolutionDBReader.cc
@@ -28,13 +28,13 @@
 class JetResolutionDBReader : public edm::EDAnalyzer {
     public:
         explicit JetResolutionDBReader(const edm::ParameterSet&);
-        ~JetResolutionDBReader();
+        ~JetResolutionDBReader() override;
 
 
     private:
-        virtual void beginJob() override ;
-        virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-        virtual void endJob() override ;
+        void beginJob() override ;
+        void analyze(const edm::Event&, const edm::EventSetup&) override;
+        void endJob() override ;
 
         std::string m_era;
         std::string m_label;
@@ -49,7 +49,7 @@ class JetResolutionScaleFactorDBReader : public edm::EDAnalyzer {
 
 
     private:
-        virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+        void analyze(const edm::Event&, const edm::EventSetup&) override;
 
         std::string m_era;
         std::string m_label;

--- a/JetMETCorrections/Modules/plugins/JetResolutionDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/JetResolutionDBWriter.cc
@@ -18,10 +18,10 @@ class JetResolutionDBWriter : public edm::EDAnalyzer
 {
  public:
   JetResolutionDBWriter(const edm::ParameterSet&);
-  virtual void beginJob() override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override {}
-  virtual void endJob() override {}
-  ~JetResolutionDBWriter() {}
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override {}
+  void endJob() override {}
+  ~JetResolutionDBWriter() override {}
 
  private:
   std::string m_record;

--- a/JetMETCorrections/Modules/plugins/JetResolutionDemo.cc
+++ b/JetMETCorrections/Modules/plugins/JetResolutionDemo.cc
@@ -25,11 +25,11 @@
 class JetResolutionDemo : public edm::EDAnalyzer {
     public:
         explicit JetResolutionDemo(const edm::ParameterSet&);
-        ~JetResolutionDemo();
+        ~JetResolutionDemo() override;
 
     private:
-        virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-        virtual void endJob() override;
+        void analyze(const edm::Event&, const edm::EventSetup&) override;
+        void endJob() override;
 
         edm::EDGetTokenT<std::vector<pat::Jet>> m_jets_token;
         edm::EDGetTokenT<double> m_rho_token;

--- a/JetMETCorrections/Modules/plugins/METCorrectorDBReader.cc
+++ b/JetMETCorrections/Modules/plugins/METCorrectorDBReader.cc
@@ -38,13 +38,13 @@ namespace{
 class METCorrectorDBReader : public edm::one::EDAnalyzer<> {
 public:
   explicit METCorrectorDBReader(const edm::ParameterSet&);
-  ~METCorrectorDBReader();
+  ~METCorrectorDBReader() override;
   
   
 private:
-  virtual void beginJob() override ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override ;
+  void beginJob() override ;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
  
   std::string mPayloadName,mGlobalTag;
   bool mCreateTextFile,mPrintScreen;

--- a/JetMETCorrections/Modules/plugins/METCorrectorDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/METCorrectorDBWriter.cc
@@ -19,10 +19,10 @@ class  METCorrectorDBWriter : public edm::one::EDAnalyzer<>
 {
  public:
   METCorrectorDBWriter(const edm::ParameterSet&);
-  virtual void beginJob() override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override {}
-  virtual void endJob() override {}
-  ~METCorrectorDBWriter() {}
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override {}
+  void endJob() override {}
+  ~METCorrectorDBWriter() override {}
 
  private:
   std::string era;
@@ -64,7 +64,7 @@ void METCorrectorDBWriter::beginJob()
       std::vector<std::string> sections;
       payload->getSections(fip.fullPath(), sections );
       //MEtXYcorrectParametersCollection::getSections(fip.fullPath(), sections );
-      if(sections.size() == 0){
+      if(sections.empty()){
         payload->push_back(ilev, MEtXYcorrectParameters(fip.fullPath(),"") );
       }else{
 	for ( std::vector<std::string>::const_iterator isectbegin = sections.begin(), isectend = sections.end(), isect = isectbegin;

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBReader.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBReader.cc
@@ -13,12 +13,12 @@
 class QGLikelihoodDBReader : public edm::EDAnalyzer{
 public:
   explicit QGLikelihoodDBReader(const edm::ParameterSet&);
-  ~QGLikelihoodDBReader(){};
+  ~QGLikelihoodDBReader() override{};
   
 private:
-  virtual void beginJob() override{};
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override{};
+  void beginJob() override{};
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override{};
  
   std::string mPayloadName;
   bool mCreateTextFile,mPrintScreen;

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -7,7 +7,7 @@
 #include "TKey.h"
 #include "TH1.h"
 #include <sstream>
-#include <stdlib.h>  
+#include <cstdlib>  
 #include <vector>
 #include <memory>
 #include <string>
@@ -24,10 +24,10 @@
 class  QGLikelihoodDBWriter : public edm::EDAnalyzer{
  public:
   QGLikelihoodDBWriter(const edm::ParameterSet&);
-  virtual void beginJob() override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override {}
-  virtual void endJob() override {}
-  ~QGLikelihoodDBWriter(){}
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override {}
+  void endJob() override {}
+  ~QGLikelihoodDBWriter() override{}
 
  private:
   bool getVectorFromFile(TFile*, std::vector<float>&, const TString&);

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodSystematicsDBReader.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodSystematicsDBReader.cc
@@ -13,12 +13,12 @@
 class QGLikelihoodSystematicsDBReader : public edm::EDAnalyzer{
 public:
   explicit QGLikelihoodSystematicsDBReader(const edm::ParameterSet&);
-  ~QGLikelihoodSystematicsDBReader(){};
+  ~QGLikelihoodSystematicsDBReader() override{};
   
 private:
-  virtual void beginJob() override{};
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override{};
+  void beginJob() override{};
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override{};
  
   std::string mPayloadName;
   bool mCreateTextFile,mPrintScreen;

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodSystematicsDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodSystematicsDBWriter.cc
@@ -18,10 +18,10 @@
 class  QGLikelihoodSystematicsDBWriter : public edm::EDAnalyzer{
  public:
   QGLikelihoodSystematicsDBWriter(const edm::ParameterSet&);
-  virtual void beginJob() override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override {}
-  virtual void endJob() override {}
-  ~QGLikelihoodSystematicsDBWriter() {}
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override {}
+  void endJob() override {}
+  ~QGLikelihoodSystematicsDBWriter() override {}
 
  private:
   std::string fileName;

--- a/JetMETCorrections/Objects/interface/ChainedJetCorrector.h
+++ b/JetMETCorrections/Objects/interface/ChainedJetCorrector.h
@@ -16,20 +16,20 @@ class ChainedJetCorrector : public JetCorrector
 {
 public:
   ChainedJetCorrector (){}
-  virtual ~ChainedJetCorrector () {}
+  ~ChainedJetCorrector () override {}
   
-  virtual double correction (const JetCorrector::LorentzVector& fJet) const;
-  virtual double correction (const reco::Jet& fJet) const;
-  virtual double correction (const reco::Jet& fJet,
+  double correction (const JetCorrector::LorentzVector& fJet) const override;
+  double correction (const reco::Jet& fJet) const override;
+  double correction (const reco::Jet& fJet,
 			     const edm::Event& fEvent,
-			     const edm::EventSetup& fSetup) const;
-  virtual double correction (const reco::Jet& fJet,
+			     const edm::EventSetup& fSetup) const override;
+  double correction (const reco::Jet& fJet,
 			     const edm::RefToBase<reco::Jet>& fJetRef,
 			     const edm::Event& fEvent,
-			     const edm::EventSetup& fSetup) const;
+			     const edm::EventSetup& fSetup) const override;
   
-  virtual bool eventRequired () const;
-  virtual bool refRequired () const;
+  bool eventRequired () const override;
+  bool refRequired () const override;
   
   void push_back (const JetCorrector* fCorrector) {mCorrectors.push_back (fCorrector);}
   void clear () {mCorrectors.clear ();}

--- a/JetMETCorrections/TauJet/interface/TauJetCorrector.h
+++ b/JetMETCorrections/TauJet/interface/TauJetCorrector.h
@@ -15,13 +15,13 @@ class TauJetCorrector: public JetCorrector
 public:  
 
   TauJetCorrector(const edm::ParameterSet& fParameters);
-  virtual ~TauJetCorrector();
-  virtual double  correction (const LorentzVector& fJet) const;
-  virtual double  correction(const reco::Jet&) const;
+  ~TauJetCorrector() override;
+  double  correction (const LorentzVector& fJet) const override;
+  double  correction(const reco::Jet&) const override;
 
   void setParameters(std::string, int);
   /// if correction needs event information
-  virtual bool eventRequired () const {return false;}
+  bool eventRequired () const override {return false;}
    
 private:
 

--- a/JetMETCorrections/TauJet/plugins/TauJetCorrectorExample.cc
+++ b/JetMETCorrections/TauJet/plugins/TauJetCorrectorExample.cc
@@ -61,13 +61,13 @@ Implementation:
 class TauJetCorrectorExample : public edm::EDAnalyzer {
 public:
   explicit TauJetCorrectorExample(const edm::ParameterSet&);
-  ~TauJetCorrectorExample();
+  ~TauJetCorrectorExample() override;
 
 
 private:
-  virtual void beginJob() override ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override ;
+  void beginJob() override ;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
 
   // ----------member data ---------------------------
 #ifdef THIS_IS_AN_EVENT_EXAMPLE

--- a/JetMETCorrections/TauJet/src/TauJetCorrector.cc
+++ b/JetMETCorrections/TauJet/src/TauJetCorrector.cc
@@ -57,7 +57,7 @@ public:
   double eta(int ieta){return etavector[ieta];}
   int type(int ieta){return typevector[ieta];}
   const vector<double>& parameters(int ieta){return pars[ieta];}
-  bool valid(){return etavector.size();}
+  bool valid(){return !etavector.empty();}
 
 private:
 
@@ -77,7 +77,7 @@ JetCalibrationParameterSetTauJet::JetCalibrationParameterSetTauJet(string tag){
     //cout << " Start to read file "<<file<<endl;
     string line;
     while( std::getline( in, line)){
-      if(!line.size() || line[0]=='#') continue;
+      if(line.empty() || line[0]=='#') continue;
       istringstream linestream(line);
       double par;
       int type;

--- a/JetMETCorrections/Type1MET/interface/CaloJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/CaloJetMETcorrInputProducerT.h
@@ -97,7 +97,7 @@ class CaloJetMETcorrInputProducerT final : public edm::global::EDProducer<>
     produces<CorrMETData>("type2");
     produces<CorrMETData>("offset");
   }
-  ~CaloJetMETcorrInputProducerT() {}
+  ~CaloJetMETcorrInputProducerT() override {}
 
  private:
 

--- a/JetMETCorrections/Type1MET/interface/JetCleanerForType1METT.h
+++ b/JetMETCorrections/Type1MET/interface/JetCleanerForType1METT.h
@@ -125,7 +125,7 @@ class JetCleanerForType1METT : public edm::stream::EDProducer<>
 
  private:
 
-  void produce(edm::Event& evt, const edm::EventSetup& es)
+  void produce(edm::Event& evt, const edm::EventSetup& es) override
   {
 
     edm::Handle<reco::JetCorrector> jetCorr;
@@ -162,8 +162,8 @@ class JetCleanerForType1METT : public edm::stream::EDProducer<>
 	for ( std::vector<reco::CandidatePtr>::const_iterator cand = cands.begin();
 	      cand != cands.end(); ++cand ) {
 	  const reco::PFCandidate *pfcand = dynamic_cast<const reco::PFCandidate *>(cand->get());
-	  const reco::Candidate *mu = (pfcand != 0 ? ( pfcand->muonRef().isNonnull() ? pfcand->muonRef().get() : 0) : cand->get());
-	  if ( mu != 0 && (*skipMuonSelection_)(*mu) ) {
+	  const reco::Candidate *mu = (pfcand != nullptr ? ( pfcand->muonRef().isNonnull() ? pfcand->muonRef().get() : nullptr) : cand->get());
+	  if ( mu != nullptr && (*skipMuonSelection_)(*mu) ) {
 	    reco::Candidate::LorentzVector muonP4 = (*cand)->p4();
 	    rawJetP4 -= muonP4;
 	  }

--- a/JetMETCorrections/Type1MET/interface/METCorrectionAlgorithm.h
+++ b/JetMETCorrections/Type1MET/interface/METCorrectionAlgorithm.h
@@ -57,7 +57,7 @@ class METCorrectionAlgorithm
   {
     type2BinningEntryType(const std::string& binCorrformula, const edm::ParameterSet& binCorrParameter, const vInputTag& srcUnclEnergySums, edm::ConsumesCollector & iConsumesCollector)
       : binLabel_(""),
-        binCorrFormula_(0)
+        binCorrFormula_(nullptr)
     {
       for (vInputTag::const_iterator inputTag = srcUnclEnergySums.begin(); inputTag != srcUnclEnergySums.end(); ++inputTag)
 	{
@@ -68,7 +68,7 @@ class METCorrectionAlgorithm
     }
     type2BinningEntryType(const edm::ParameterSet& cfg, const vInputTag& srcUnclEnergySums, edm::ConsumesCollector & iConsumesCollector)
       : binLabel_(cfg.getParameter<std::string>("binLabel")),
-        binCorrFormula_(0)
+        binCorrFormula_(nullptr)
     {
       for ( vInputTag::const_iterator srcUnclEnergySum = srcUnclEnergySums.begin();
 	    srcUnclEnergySum != srcUnclEnergySums.end(); ++srcUnclEnergySum )
@@ -80,7 +80,7 @@ class METCorrectionAlgorithm
 	  corrTokens_.push_back(iConsumesCollector.consumes<CorrMETData>(inputTag));
 	}
       
-      std::string binCorrFormula = cfg.getParameter<std::string>("binCorrFormula").data();
+      std::string binCorrFormula = cfg.getParameter<std::string>("binCorrFormula");
     
       edm::ParameterSet binCorrParameter = cfg.getParameter<edm::ParameterSet>("binCorrParameter");
 
@@ -94,7 +94,7 @@ class METCorrectionAlgorithm
       int numParameter = parNames.size();
       binCorrParameter_.resize(numParameter);    
       for ( int parIndex = 0; parIndex < numParameter; ++parIndex ) {
-        const std::string& parName = parNames[parIndex].data();
+        const std::string& parName = parNames[parIndex];
 
         double parValue = binCorrParameter.getParameter<double>(parName);
         binCorrParameter_[parIndex] = parValue;

--- a/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -80,7 +80,7 @@ class PFJetMETcorrInputProducerT : public edm::stream::EDProducer<>
   explicit PFJetMETcorrInputProducerT(const edm::ParameterSet& cfg)
     : moduleLabel_(cfg.getParameter<std::string>("@module_label")),
       offsetCorrLabel_(""),
-      skipMuonSelection_(0)
+      skipMuonSelection_(nullptr)
   {
     token_ = consumes<std::vector<T> >(cfg.getParameter<edm::InputTag>("src"));
 
@@ -127,7 +127,7 @@ class PFJetMETcorrInputProducerT : public edm::stream::EDProducer<>
       produces<CorrMETData>((*type2BinningEntry)->getInstanceLabel_full("offset"));
     }
   }
-  ~PFJetMETcorrInputProducerT()
+  ~PFJetMETcorrInputProducerT() override
   {
     delete skipMuonSelection_;
 
@@ -155,7 +155,7 @@ class PFJetMETcorrInputProducerT : public edm::stream::EDProducer<>
 
  private:
 
-  void produce(edm::Event& evt, const edm::EventSetup& es)
+  void produce(edm::Event& evt, const edm::EventSetup& es) override
   {
 
     std::unique_ptr<CorrMETData> type1Correction(new CorrMETData());
@@ -196,8 +196,8 @@ class PFJetMETcorrInputProducerT : public edm::stream::EDProducer<>
 	for ( std::vector<reco::CandidatePtr>::const_iterator cand = cands.begin();
 	      cand != cands.end(); ++cand ) {
           const reco::PFCandidate *pfcand = dynamic_cast<const reco::PFCandidate *>(cand->get());
-          const reco::Candidate *mu = (pfcand != 0 ? ( pfcand->muonRef().isNonnull() ? pfcand->muonRef().get() : 0) : cand->get());
-	  if ( mu != 0 && (*skipMuonSelection_)(*mu) ) {
+          const reco::Candidate *mu = (pfcand != nullptr ? ( pfcand->muonRef().isNonnull() ? pfcand->muonRef().get() : nullptr) : cand->get());
+	  if ( mu != nullptr && (*skipMuonSelection_)(*mu) ) {
 	    reco::Candidate::LorentzVector muonP4 = (*cand)->p4();
 	    rawJetP4 -= muonP4;
 	  }
@@ -291,7 +291,7 @@ class PFJetMETcorrInputProducerT : public edm::stream::EDProducer<>
   {
     type2BinningEntryType()
       : binLabel_(""),
-        binSelection_(0)
+        binSelection_(nullptr)
     {}
     type2BinningEntryType(const edm::ParameterSet& cfg)
       : binLabel_(cfg.getParameter<std::string>("binLabel")),

--- a/JetMETCorrections/Type1MET/plugins/CorrectedCaloMETProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/CorrectedCaloMETProducer.cc
@@ -38,7 +38,7 @@ public:
     produces<METCollection>("");
   }
 
-  ~CorrectedCaloMETProducer() { }
+  ~CorrectedCaloMETProducer() override { }
 
 private:
 

--- a/JetMETCorrections/Type1MET/plugins/CorrectedPFMETProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/CorrectedPFMETProducer.cc
@@ -42,7 +42,7 @@ public:
     produces<METCollection>("");
   }
 
-  ~CorrectedPFMETProducer() { }
+  ~CorrectedPFMETProducer() override { }
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;

--- a/JetMETCorrections/Type1MET/plugins/CorrectedPatMETProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/CorrectedPatMETProducer.cc
@@ -49,7 +49,7 @@ public:
     produces<patMETCollection>("");
   }
 
-  ~CorrectedPatMETProducer() { }
+  ~CorrectedPatMETProducer() override { }
 
 private:
 

--- a/JetMETCorrections/Type1MET/plugins/MultShiftMETcorrDBInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/MultShiftMETcorrDBInputProducer.h
@@ -34,7 +34,7 @@ class MultShiftMETcorrDBInputProducer : public edm::stream::EDProducer<>
  public:
 
   explicit MultShiftMETcorrDBInputProducer(const edm::ParameterSet&);
-  ~MultShiftMETcorrDBInputProducer();
+  ~MultShiftMETcorrDBInputProducer() override;
     
  private:
 

--- a/JetMETCorrections/Type1MET/plugins/MultShiftMETcorrInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/MultShiftMETcorrInputProducer.h
@@ -33,7 +33,7 @@ class MultShiftMETcorrInputProducer : public edm::stream::EDProducer<>
  public:
 
   explicit MultShiftMETcorrInputProducer(const edm::ParameterSet&);
-  ~MultShiftMETcorrInputProducer();
+  ~MultShiftMETcorrInputProducer() override;
     
  private:
 

--- a/JetMETCorrections/Type1MET/plugins/MuonMETcorrInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/MuonMETcorrInputProducer.h
@@ -29,11 +29,11 @@ class MuonMETcorrInputProducer : public edm::stream::EDProducer<>
  public:
 
   explicit MuonMETcorrInputProducer(const edm::ParameterSet&);
-  ~MuonMETcorrInputProducer();
+  ~MuonMETcorrInputProducer() override;
     
  private:
 
-  void produce(edm::Event&, const edm::EventSetup&);
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
   std::string moduleLabel_;
 

--- a/JetMETCorrections/Type1MET/plugins/PFCandMETcorrInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/PFCandMETcorrInputProducer.h
@@ -32,11 +32,11 @@ class PFCandMETcorrInputProducer : public edm::stream::EDProducer<>
  public:
 
   explicit PFCandMETcorrInputProducer(const edm::ParameterSet&);
-  ~PFCandMETcorrInputProducer();
+  ~PFCandMETcorrInputProducer() override;
     
  private:
 
-  void produce(edm::Event&, const edm::EventSetup&);
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
   std::string moduleLabel_;
 

--- a/JetMETCorrections/Type1MET/plugins/PFchsMETcorrInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/PFchsMETcorrInputProducer.h
@@ -34,11 +34,11 @@ class PFchsMETcorrInputProducer : public edm::stream::EDProducer<>
  public:
 
   explicit PFchsMETcorrInputProducer(const edm::ParameterSet&);
-  ~PFchsMETcorrInputProducer();
+  ~PFchsMETcorrInputProducer() override;
     
  private:
 
-  void produce(edm::Event&, const edm::EventSetup&);
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
   std::string moduleLabel_;
 

--- a/JetMETCorrections/Type1MET/plugins/ScaleCorrMETData.cc
+++ b/JetMETCorrections/Type1MET/plugins/ScaleCorrMETData.cc
@@ -18,7 +18,7 @@ class ScaleCorrMETData : public edm::stream::EDProducer<>
 {
 public:
   explicit ScaleCorrMETData(const edm::ParameterSet&);
-  ~ScaleCorrMETData() { }
+  ~ScaleCorrMETData() override { }
 
 private:
 

--- a/JetMETCorrections/Type1MET/plugins/SysShiftMETcorrInputProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/SysShiftMETcorrInputProducer.cc
@@ -11,8 +11,8 @@
 SysShiftMETcorrInputProducer::SysShiftMETcorrInputProducer(const edm::ParameterSet& cfg)
   : moduleLabel_(cfg.getParameter<std::string>("@module_label")),
     useNvtx(false),
-    corrPx_(0),
-    corrPy_(0)
+    corrPx_(nullptr),
+    corrPy_(nullptr)
 {
   token_ = consumes<edm::View<reco::MET> >(cfg.getParameter<edm::InputTag>("src"));
   

--- a/JetMETCorrections/Type1MET/plugins/SysShiftMETcorrInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/SysShiftMETcorrInputProducer.h
@@ -30,11 +30,11 @@ class SysShiftMETcorrInputProducer : public edm::stream::EDProducer<>
  public:
 
   explicit SysShiftMETcorrInputProducer(const edm::ParameterSet&);
-  ~SysShiftMETcorrInputProducer();
+  ~SysShiftMETcorrInputProducer() override;
     
  private:
 
-  void produce(edm::Event&, const edm::EventSetup&);
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
   std::string moduleLabel_;
 

--- a/JetMETCorrections/Type1MET/plugins/Type0PFMETcorrInputProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/Type0PFMETcorrInputProducer.cc
@@ -12,7 +12,7 @@
 
 Type0PFMETcorrInputProducer::Type0PFMETcorrInputProducer(const edm::ParameterSet& cfg)
   : moduleLabel_(cfg.getParameter<std::string>("@module_label")),
-    correction_(0)
+    correction_(nullptr)
 {
   pfCandidateToVertexAssociationsToken_ = consumes<PFCandToVertexAssMap>(cfg.getParameter<edm::InputTag>("srcPFCandidateToVertexAssociations"));
   hardScatterVertexToken_ = consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("srcHardScatterVertex"));

--- a/JetMETCorrections/Type1MET/plugins/Type0PFMETcorrInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/Type0PFMETcorrInputProducer.h
@@ -31,11 +31,11 @@ class Type0PFMETcorrInputProducer : public edm::stream::EDProducer<>
  public:
 
   explicit Type0PFMETcorrInputProducer(const edm::ParameterSet&);
-  ~Type0PFMETcorrInputProducer();
+  ~Type0PFMETcorrInputProducer() override;
     
  private:
 
-  void produce(edm::Event&, const edm::EventSetup&);
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
   std::string moduleLabel_;
 

--- a/JetMETCorrections/Type1MET/plugins/Type2CorrectionProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/Type2CorrectionProducer.cc
@@ -22,7 +22,7 @@ class Type2CorrectionProducer : public edm::stream::EDProducer<>
 {
 public:
   explicit Type2CorrectionProducer(const edm::ParameterSet&);
-  ~Type2CorrectionProducer() { }
+  ~Type2CorrectionProducer() override { }
 
 private:
 
@@ -33,7 +33,7 @@ private:
   {
     type2BinningEntryType(const std::string& binCorrformula, const edm::ParameterSet& binCorrParameter, const vInputTag& srcUnclEnergySums, edm::ConsumesCollector && iConsumesCollector)
       : binLabel_(""),
-        binCorrFormula_(0)
+        binCorrFormula_(nullptr)
     {
       for (vInputTag::const_iterator inputTag = srcUnclEnergySums.begin(); inputTag != srcUnclEnergySums.end(); ++inputTag)
 	{
@@ -44,7 +44,7 @@ private:
     }
     type2BinningEntryType(const edm::ParameterSet& cfg, const vInputTag& srcUnclEnergySums, edm::ConsumesCollector && iConsumesCollector)
       : binLabel_(cfg.getParameter<std::string>("binLabel")),
-        binCorrFormula_(0)
+        binCorrFormula_(nullptr)
     {
 
       for ( vInputTag::const_iterator srcUnclEnergySum = srcUnclEnergySums.begin();
@@ -57,7 +57,7 @@ private:
 	  corrTokens_.push_back(iConsumesCollector.consumes<CorrMETData>(inputTag));
 	}
       
-      std::string binCorrFormula = cfg.getParameter<std::string>("binCorrFormula").data();
+      std::string binCorrFormula = cfg.getParameter<std::string>("binCorrFormula");
     
       edm::ParameterSet binCorrParameter = cfg.getParameter<edm::ParameterSet>("binCorrParameter");
 
@@ -71,7 +71,7 @@ private:
       int numParameter = parNames.size();
       binCorrParameter_.resize(numParameter);    
       for ( int parIndex = 0; parIndex < numParameter; ++parIndex ) {
-        const std::string& parName = parNames[parIndex].data();
+        const std::string& parName = parNames[parIndex];
 
         double parValue = binCorrParameter.getParameter<double>(parName);
         binCorrParameter_[parIndex] = parValue;
@@ -126,7 +126,7 @@ Type2CorrectionProducer::Type2CorrectionProducer(const edm::ParameterSet& cfg)
     }
   else
     {
-      std::string type2CorrFormula = cfg.getParameter<std::string>("type2CorrFormula").data();
+      std::string type2CorrFormula = cfg.getParameter<std::string>("type2CorrFormula");
       edm::ParameterSet type2CorrParameter = cfg.getParameter<edm::ParameterSet>("type2CorrParameter");
       type2Binning_.push_back(new type2BinningEntryType(type2CorrFormula, type2CorrParameter, srcUnclEnergySums, consumesCollector()));
     }

--- a/JetMETCorrections/Type1MET/src/METCorrectionAlgorithm.cc
+++ b/JetMETCorrections/Type1MET/src/METCorrectionAlgorithm.cc
@@ -34,7 +34,7 @@ METCorrectionAlgorithm::METCorrectionAlgorithm(const edm::ParameterSet& cfg, edm
 	}
       else
 	{
-	  std::string type2CorrFormula = cfg.getParameter<std::string>("type2CorrFormula").data();
+	  std::string type2CorrFormula = cfg.getParameter<std::string>("type2CorrFormula");
 	  edm::ParameterSet type2CorrParameter = cfg.getParameter<edm::ParameterSet>("type2CorrParameter");
 	  type2Binning_.push_back(new type2BinningEntryType(type2CorrFormula, type2CorrParameter, srcUnclEnergySums, iConsumesCollector));
 	}
@@ -54,7 +54,7 @@ METCorrectionAlgorithm::METCorrectionAlgorithm(const edm::ParameterSet& cfg, edm
       if (applyType2Corrections_)
 	{
 	  if (cfg.exists("type2Binning")) throw cms::Exception("Invalid Arg") << "Currently, applyType0Corrections and type2Binning cannot be used together!";
-	  std::string type2CorrFormula = cfg.getParameter<std::string>("type2CorrFormula").data();
+	  std::string type2CorrFormula = cfg.getParameter<std::string>("type2CorrFormula");
 	  if (!(type2CorrFormula == "A")) throw cms::Exception("Invalid Arg") << "type2CorrFormula must be \"A\" if applyType0Corrections!";
 	  edm::ParameterSet type2CorrParameter = cfg.getParameter<edm::ParameterSet>("type2CorrParameter");
 	  type0Cuncl_ = type2CorrParameter.getParameter<double>("A");


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this quickly to avoid conflicts to the extent possible]