### PR TITLE
Clang-tidy checks for L1TriggerOffline

### DIFF
--- a/L1TriggerOffline/L1Analyzer/src/BSCTrigger.cc
+++ b/L1TriggerOffline/L1Analyzer/src/BSCTrigger.cc
@@ -44,12 +44,12 @@ Implementation:
 class BSCTrigger : public edm::EDProducer {
 public:
   explicit BSCTrigger(const edm::ParameterSet&);
-  ~BSCTrigger();
+  ~BSCTrigger() override;
 
 private:
-  virtual void beginJob() override ;
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override ;
+  void beginJob() override ;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
   int   getBSCNum(int id, float z);
   bool  isInner(int id);
   bool  isZplus(int id);


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this quickly to avoid conflicts to the extent possible]