### PR TITLE
Clang-tidy checks for RecoCTPPS

### DIFF
--- a/RecoCTPPS/PixelLocal/interface/CTPPSPixelClusterProducer.h
+++ b/RecoCTPPS/PixelLocal/interface/CTPPSPixelClusterProducer.h
@@ -41,9 +41,9 @@ class CTPPSPixelClusterProducer : public edm::stream::EDProducer<>
 public:
   explicit CTPPSPixelClusterProducer(const edm::ParameterSet& param);
  
-  ~CTPPSPixelClusterProducer();
+  ~CTPPSPixelClusterProducer() override;
 
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:

--- a/RecoCTPPS/PixelLocal/interface/CTPPSPixelGainCalibrationDBService.h
+++ b/RecoCTPPS/PixelLocal/interface/CTPPSPixelGainCalibrationDBService.h
@@ -29,9 +29,9 @@ class CTPPSPixelGainCalibrationDBService
       virtual void getDB(const edm::Event& e, const edm::EventSetup& c);
       const CTPPSPixelGainCalibrations* getCalibs() const {return pPixelGainCalibrations;}
    private:
-      CTPPSPixelGainCalibrationDBService(const CTPPSPixelGainCalibrationDBService&); 
+      CTPPSPixelGainCalibrationDBService(const CTPPSPixelGainCalibrationDBService&) = delete; 
       const CTPPSPixelGainCalibrations* pPixelGainCalibrations;
-      const CTPPSPixelGainCalibrationDBService& operator=(const CTPPSPixelGainCalibrationDBService&); 
+      const CTPPSPixelGainCalibrationDBService& operator=(const CTPPSPixelGainCalibrationDBService&) = delete; 
 };
 
 #endif

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
@@ -29,12 +29,12 @@ class CTPPSDiamondLocalTrackFitter : public edm::stream::EDProducer<>
 {
   public:
     explicit CTPPSDiamondLocalTrackFitter( const edm::ParameterSet& );
-    ~CTPPSDiamondLocalTrackFitter();
+    ~CTPPSDiamondLocalTrackFitter() override;
 
     static void fillDescriptions( edm::ConfigurationDescriptions& );
 
   private:
-    virtual void produce( edm::Event&, const edm::EventSetup& ) override;
+    void produce( edm::Event&, const edm::EventSetup& ) override;
 
     edm::EDGetTokenT< edm::DetSetVector<CTPPSDiamondRecHit> > recHitsToken_;
     CTPPSDiamondTrackRecognition trk_algo_45_;

--- a/RecoCTPPS/TotemRPLocal/plugins/TotemRPClusterProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/TotemRPClusterProducer.cc
@@ -31,9 +31,9 @@ class TotemRPClusterProducer : public edm::stream::EDProducer<>
   
     explicit TotemRPClusterProducer(const edm::ParameterSet& conf);
   
-    virtual ~TotemRPClusterProducer() {}
+    ~TotemRPClusterProducer() override {}
   
-    virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
+    void produce(edm::Event& e, const edm::EventSetup& c) override;
     static void fillDescriptions( edm::ConfigurationDescriptions& );
   
   private:
@@ -78,7 +78,7 @@ void TotemRPClusterProducer::produce(edm::Event& e, const edm::EventSetup& es)
   DetSetVector<TotemRPCluster> output;
   
   // run clusterisation
-  if (input->size())
+  if (!input->empty())
     run(*input, output);
 
   // save output to event

--- a/RecoCTPPS/TotemRPLocal/plugins/TotemRPRecHitProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/TotemRPRecHitProducer.cc
@@ -29,9 +29,9 @@ class TotemRPRecHitProducer : public edm::stream::EDProducer<>
   
     explicit TotemRPRecHitProducer(const edm::ParameterSet& conf);
   
-    virtual ~TotemRPRecHitProducer() {}
+    ~TotemRPRecHitProducer() override {}
   
-    virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
+    void produce(edm::Event& e, const edm::EventSetup& c) override;
     static void fillDescriptions( edm::ConfigurationDescriptions& );
   
   private:

--- a/RecoCTPPS/TotemRPLocal/src/TotemRPClusterProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemRPClusterProducerAlgorithm.cc
@@ -34,7 +34,7 @@ int TotemRPClusterProducerAlgorithm::buildClusters(unsigned int detId, const std
   strip_digi_set_.clear();
   strip_digi_set_.insert(digi.begin(), digi.end());
 
-  if (strip_digi_set_.size() == 0)
+  if (strip_digi_set_.empty())
     return 0;
     
   bool iter_beg=true;


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this quickly to avoid conflicts to the extent possible]