### PR TITLE
OnlineDQM : Tune L1T Muon QTs v3

### DIFF
--- a/DQM/L1TMonitorClient/data/L1TStage2BMTFQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2BMTFQualityTests.xml
@@ -9,28 +9,12 @@
     <PARAM name="error">0.98</PARAM>
     <PARAM name="warning">0.99</PARAM>
   </QTEST>
-
-  <QTEST name="BMTF_hwPtSpectrum">
-    <TYPE>Comp2RefKolmogorov</TYPE>	
-    <PARAM name="testparam">0</PARAM>
-    <PARAM name="error">0.01</PARAM>
-    <PARAM name="warning">0.30</PARAM>
-  </QTEST>
   
   <LINK name="*/L1TStage2BMTF/bmtf_hwPt">
       <TestName activate="true">BMTF_hwPtRange</TestName>
-      <TestName activate="true">BMTF_hwPtSpectrum</TestName>
   </LINK>
 
   <!-- BMTF WEDGE vs BX -->
-
-  <QTEST name="BMTF_WedgeBXSpectrum">
-    <TYPE>Comp2Ref2DChi2</TYPE>	
-    <PARAM name="testparam">0</PARAM>
-    <PARAM name="error">0.01</PARAM>
-    <PARAM name="warning">0.30</PARAM>
-    <PARAM name="minEntries">60</PARAM>
-  </QTEST>
 
   <QTEST name="BMTF_WedgeBXNoisyWedge">
     <TYPE>NoisyChannel</TYPE>	
@@ -41,7 +25,6 @@
   </QTEST>
   
   <LINK name="*/L1TStage2BMTF/bmtf_wedge_bx">
-      <TestName activate="true">BMTF_WedgeBXSpectrum</TestName>
       <TestName activate="true">BMTF_WedgeBXNoisyWedge</TestName>
   </LINK>
 

--- a/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
@@ -8,8 +8,8 @@
     <TYPE>ContentsXRange</TYPE>	
     <PARAM name="xmin">0</PARAM>
     <PARAM name="xmax">0</PARAM>
-    <PARAM name="error">0.30</PARAM>
-    <PARAM name="warning">0.50</PARAM>
+    <PARAM name="error">0.20</PARAM>
+    <PARAM name="warning">0.30</PARAM>
   </QTEST>
 
   <QTEST name="uGMT_MuonBXMeanAtBX0">
@@ -32,13 +32,6 @@
 
   <!-- uGMT Muon Eta -->
 
-  <QTEST name="uGMT_MuonEtaSpectrum">
-    <TYPE>Comp2RefKolmogorov</TYPE>	
-    <PARAM name="testparam">0</PARAM>
-    <PARAM name="error">0.30</PARAM>
-    <PARAM name="warning">0.70</PARAM>
-  </QTEST>
-
   <QTEST name="uGMT_MuonEtaMeanAt0">
     <TYPE>MeanWithinExpected</TYPE>
     <PARAM name="mean">0.0</PARAM>
@@ -53,7 +46,6 @@
   </QTEST>
   
   <LINK name="*/L1TStage2uGMT/ugmtMuonEta">
-      <TestName activate="true">uGMT_MuonEtaSpectrum</TestName>
       <TestName activate="true">uGMT_MuonEtaMeanAt0</TestName>
   </LINK>
 
@@ -67,32 +59,12 @@
     <PARAM name="warning">0.99</PARAM>
   </QTEST>
 
-  <QTEST name="uGMT_MuonPtSpectrum">
-    <TYPE>Comp2RefKolmogorov</TYPE>	
-    <PARAM name="testparam">0</PARAM>
-    <PARAM name="error">0.01</PARAM>
-    <PARAM name="warning">0.30</PARAM>
-  </QTEST>
-
   
   <LINK name="*/L1TStage2uGMT/ugmtMuonPt">
       <TestName activate="true">uGMT_MuonPtRange</TestName>
-      <TestName activate="true">uGMT_MuonPtSpectrum</TestName>
   </LINK>
 
   <!-- uGMT Muon Phi-Eta -->
-
-  <QTEST name="uGMT_MuonPhivsEtaSpectrum">
-    <TYPE>Comp2Ref2DChi2</TYPE>	
-    <PARAM name="testparam">0</PARAM>
-    <PARAM name="error">0.01</PARAM>
-    <PARAM name="warning">0.30</PARAM>
-    <PARAM name="minEntries">3100</PARAM>
-  </QTEST>
-  
-  <LINK name="*/L1TStage2uGMT/ugmtMuonPhivsEta">
-      <TestName activate="true">uGMT_MuonPhivsEtaSpectrum</TestName>
-  </LINK>
 
 
   <!-- uGMT BMTF Quality Tests -->
@@ -132,8 +104,8 @@
   <QTEST name="uGMT_BMTFhwPhiSpectrum">
     <TYPE>Comp2RefKolmogorov</TYPE>	
     <PARAM name="testparam">0</PARAM>
-    <PARAM name="error">0.30</PARAM>
-    <PARAM name="warning">0.70</PARAM>
+    <PARAM name="error">0.01</PARAM>
+    <PARAM name="warning">0.10</PARAM>
   </QTEST>
 
   
@@ -146,8 +118,8 @@
   <QTEST name="uGMT_BMTFhwEtaSpectrum">
     <TYPE>Comp2RefKolmogorov</TYPE>	
     <PARAM name="testparam">0</PARAM>
-    <PARAM name="error">0.30</PARAM>
-    <PARAM name="warning">0.70</PARAM>
+    <PARAM name="error">0.01</PARAM>
+    <PARAM name="warning">0.10</PARAM>
   </QTEST>
 
   <QTEST name="uGMT_BMTFhwEtaMeanAt0">
@@ -221,8 +193,8 @@
   <QTEST name="uGMT_OMTFhwPhiNegSpectrum">
     <TYPE>Comp2RefKolmogorov</TYPE>	
     <PARAM name="testparam">0</PARAM>
-    <PARAM name="error">0.30</PARAM>
-    <PARAM name="warning">0.70</PARAM>
+    <PARAM name="error">0.01</PARAM>
+    <PARAM name="warning">0.10</PARAM>
   </QTEST>
 
   
@@ -235,8 +207,8 @@
   <QTEST name="uGMT_OMTFhwPhiPosSpectrum" activate="true">
     <TYPE>Comp2RefKolmogorov</TYPE>	
     <PARAM name="testparam">0</PARAM>
-    <PARAM name="error">0.30</PARAM>
-    <PARAM name="warning">0.70</PARAM>
+    <PARAM name="error">0.01</PARAM>
+    <PARAM name="warning">0.10</PARAM>
   </QTEST>
 
   
@@ -249,8 +221,8 @@
   <QTEST name="uGMT_OMTFhwEtaSpectrum">
     <TYPE>Comp2RefKolmogorov</TYPE>	
     <PARAM name="testparam">0</PARAM>
-    <PARAM name="error">0.30</PARAM>
-    <PARAM name="warning">0.70</PARAM>
+    <PARAM name="error">0.01</PARAM>
+    <PARAM name="warning">0.04</PARAM>
   </QTEST>
 
   <QTEST name="uGMT_OMTFhwEtaMeanAt0">
@@ -281,17 +253,9 @@
     <PARAM name="error">0.98</PARAM>
     <PARAM name="warning">0.99</PARAM>
   </QTEST>
-
-  <QTEST name="uGMT_OMTFhwPtSpectrum">
-    <TYPE>Comp2RefKolmogorov</TYPE>	
-    <PARAM name="testparam">0</PARAM>
-    <PARAM name="error">0.30</PARAM>
-    <PARAM name="warning">0.70</PARAM>
-  </QTEST>
   
   <LINK name="*/L1TStage2uGMT/*/ugmtOMTFhwPt">
       <TestName activate="true">uGMT_OMTFhwPtRange</TestName>
-      <TestName activate="true">uGMT_OMTFhwPtSpectrum</TestName>
   </LINK>
 
   <!-- uGMT OMTF HW Sign -->
@@ -318,8 +282,8 @@
     <TYPE>ContentsXRange</TYPE>	
     <PARAM name="xmin">0</PARAM>
     <PARAM name="xmax">0</PARAM>
-    <PARAM name="error">0.30</PARAM>
-    <PARAM name="warning">0.50</PARAM>
+    <PARAM name="error">0.20</PARAM>
+    <PARAM name="warning">0.30</PARAM>
   </QTEST>
 
   <QTEST name="uGMT_EMTFBXMeanAtBX0">
@@ -328,8 +292,8 @@
     <PARAM name="useRMS">0</PARAM>
     <PARAM name="useSigma">0</PARAM>
     <PARAM name="useRange">1</PARAM>
-    <PARAM name="xmin">-0.05</PARAM>
-    <PARAM name="xmax">0.05</PARAM>
+    <PARAM name="xmin">-0.15</PARAM>
+    <PARAM name="xmax">0.15</PARAM>
     <PARAM name="error">0.95</PARAM>
     <PARAM name="warning">0.99</PARAM>
     <PARAM name="minEntries">20</PARAM>
@@ -344,10 +308,10 @@
   <!-- uGMT EMTF Muon Phi -->
 
   <QTEST name="uGMT_EMTFMuonPhiSpectrum">
-    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <TYPE>Comp2RefChi2</TYPE>	
     <PARAM name="testparam">0</PARAM>
-    <PARAM name="error">0.10</PARAM>
-    <PARAM name="warning">0.50</PARAM>
+    <PARAM name="error">0.01</PARAM>
+    <PARAM name="warning">0.10</PARAM>
   </QTEST>
 
   <QTEST name="uGMT_EMTFMuonPhiMeanAt0">

--- a/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
@@ -121,11 +121,6 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestHist = cms.string("L1T/L1TStage2BMTF/bmtf_wedge_bx"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
-                            cms.PSet(
-                                QualityTestName = cms.string("BMTF_WedgeBXSpectrum"),
-                                QualityTestHist = cms.string("L1T/L1TStage2BMTF/bmtf_wedge_bx"),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                ),
                             )
                         ),
                     cms.PSet(
@@ -193,16 +188,6 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("uGMT_MuonPtSpectrum"),
-                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonPt"),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                ),
-                            cms.PSet(
-                                QualityTestName = cms.string("uGMT_MuonPhivsEtaSpectrum"),
-                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonPhivsEta"),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                ),
-                            cms.PSet(
                                 QualityTestName = cms.string("uGMT_BMTFBXPeakAtBX0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFInput/ugmtBMTFBX"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
@@ -215,6 +200,11 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                             cms.PSet(
                                 QualityTestName = cms.string("uGMT_BMTFhwPhiSpectrum"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFInput/ugmtBMTFglbhwPhi"),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_BMTFhwEtaSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFInput/ugmtBMTFhwEta"),
                                 QualityTestSummaryEnabled = cms.uint32(0)
                                 ),
                             cms.PSet(
@@ -243,6 +233,16 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestSummaryEnabled = cms.uint32(0)
                                 ),
                             cms.PSet(
+                                QualityTestName = cms.string("uGMT_OMTFhwPhiNegSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFglbhwPhiNeg"),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_OMTFhwEtaSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFhwEta"),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            cms.PSet(
                                 QualityTestName = cms.string("uGMT_OMTFhwEtaMeanAt0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFhwEta"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
@@ -251,11 +251,6 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestName = cms.string("uGMT_OMTFhwPtRange"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFhwPt"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
-                                ),
-                            cms.PSet(
-                                QualityTestName = cms.string("uGMT_OMTFhwPtSpectrum"),
-                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFhwPt"),
-                                QualityTestSummaryEnabled = cms.uint32(0)
                                 ),
                             cms.PSet(
                                 QualityTestName = cms.string("uGMT_OMTFhwSignUniform"),
@@ -271,6 +266,11 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestName = cms.string("uGMT_EMTFBXMeanAtBX0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/EMTFInput/ugmtEMTFBX"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_EMTFMuonPhiSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonPhiEmtf"),
+                                QualityTestSummaryEnabled = cms.uint32(0)
                                 ),
                             cms.PSet(
                                 QualityTestName = cms.string("uGMT_EMTFMuonPhiMeanAt0"),
@@ -318,12 +318,12 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("zeroSupp_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("zeroSupp_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/zeroSuppression/AllEvts/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("zeroSupp_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("zeroSupp_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/zeroSuppression/FatEvts/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),


### PR DESCRIPTION
Description:

This PR includes the following changes:

- Reduce the threshold of the Kolmogorov Tests used in the L1T Muon QTs

- Fix the name of the uGMT Zero Suppression Mismatch Ratio  QTs in the L1T DQM Event Info Client

- Remove the QTs comparing the L1T Muon pT and 2D histograms versus the reference.