### PR TITLE
Remove unnecessary find()s, commented couts; tidy

### DIFF
--- a/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
@@ -51,7 +51,7 @@ class SiStripRecHitsValid : public DQMEDAnalyzer {
   
   SiStripRecHitsValid(const edm::ParameterSet& conf);
   
-  ~SiStripRecHitsValid();
+  ~SiStripRecHitsValid() override;
  
   struct TotalMEs{ // MEs for total detector Level
     MonitorElement*  meNumTotrphi;
@@ -126,8 +126,8 @@ class SiStripRecHitsValid : public DQMEDAnalyzer {
 
  protected:
 
-  virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
-  void bookHistograms(DQMStore::IBooker & ibooker,const edm::Run& run, const edm::EventSetup& es);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+  void bookHistograms(DQMStore::IBooker & ibooker,const edm::Run& run, const edm::EventSetup& es) override;
   void beginJob(const edm::EventSetup& es);
 
  private: 
@@ -198,10 +198,10 @@ class SiStripRecHitsValid : public DQMEDAnalyzer {
   
   MonitorElement* bookME1D(DQMStore::IBooker & ibooker,const char* ParameterSetLabel, const char* HistoName, const char* HistoTitle);
 
-  inline void fillME(MonitorElement* ME,float value1){if (ME!=0)ME->Fill(value1);}
-  inline void fillME(MonitorElement* ME,float value1,float value2){if (ME!=0)ME->Fill(value1,value2);}
-  inline void fillME(MonitorElement* ME,float value1,float value2,float value3){if (ME!=0)ME->Fill(value1,value2,value3);}
-  inline void fillME(MonitorElement* ME,float value1,float value2,float value3,float value4){if (ME!=0)ME->Fill(value1,value2,value3,value4);}
+  inline void fillME(MonitorElement* ME,float value1){if (ME!=nullptr)ME->Fill(value1);}
+  inline void fillME(MonitorElement* ME,float value1,float value2){if (ME!=nullptr)ME->Fill(value1,value2);}
+  inline void fillME(MonitorElement* ME,float value1,float value2,float value3){if (ME!=nullptr)ME->Fill(value1,value2,value3);}
+  inline void fillME(MonitorElement* ME,float value1,float value2,float value3,float value4){if (ME!=nullptr)ME->Fill(value1,value2,value3,value4);}
 
   edm::ParameterSet conf_;
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;

--- a/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
@@ -181,7 +181,6 @@ void SiStripRecHitsValid::beginJob(const edm::EventSetup& es){
 void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es) {
 
   LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();  
-  //cout  << " Run = " << e.id().run() << " Event = " << e.id().event() << endl;  
   
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
@@ -212,25 +211,22 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
   
   SiStripHistoId hidmanager;
   SiStripFolderOrganizer fold_organ;
-  // start loops over detectors with detected rechitsrphi
-  for (auto it = rechitsrphi->begin(), itEnd = rechitsrphi->end(); it != itEnd; ++it) {
-    DetId detid = (*it).detId();
+  for (auto const& theDetSet : *rechitsrphi) {
+    DetId detid = theDetSet.detId();
     uint32_t myid = detid.rawId();       
-    auto detsetIter = rechitsrphi->find(detid);
-    totrechitrphi += detsetIter->size();
+    totrechitrphi += theDetSet.size();
   
     std::string label = hidmanager.getSubdetid(myid,tTopo,true);
     std::map<std::string, LayerMEs>::iterator iLayerME  = LayerMEsMap.find(label);
     std::pair<std::string,int32_t> det_lay_pair = fold_organ.GetSubDetAndLayer(myid,tTopo,true);
 
-    totnumrechitrphi[det_lay_pair.first] = totnumrechitrphi[det_lay_pair.first] + detsetIter->size();
+    totnumrechitrphi[det_lay_pair.first] = totnumrechitrphi[det_lay_pair.first] + theDetSet.size();
     //loop over rechits-rphi in the same subdetector
     if(iLayerME != LayerMEsMap.end()){
-      for(auto iterrphi= detsetIter->begin(), iterEnd = detsetIter->end(); iterrphi != iterEnd; ++iterrphi){	
+      for(auto const& rechit : theDetSet){	
         const GeomDetUnit *  det = tracker.idToDetUnit(detid);
         const StripGeomDetUnit * stripdet=(const StripGeomDetUnit*)(det);
         const StripTopology &topol=(StripTopology&)stripdet->topology();
-        SiStripRecHit2D const rechit=*iterrphi;
         //analyze RecHits 
         rechitanalysis(rechit,topol,associate);
         // fill the result in a histogram
@@ -255,24 +251,22 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
   }
 
   // start loops over detectors with detected rechitsstereo
-  for (auto it = rechitsstereo->begin(), itEnd = rechitsstereo->end(); it != itEnd; ++it) {
-    DetId detid = (*it).detId();
+  for (auto const& theDetSet : *rechitsstereo) {
+    DetId detid = theDetSet.detId();
     uint32_t myid= detid.rawId();       
-    auto detsetIter = rechitsstereo->find(detid);
-    totrechitstereo += detsetIter->size();
+    totrechitstereo += theDetSet.size();
  
     std::string label = hidmanager.getSubdetid(myid,tTopo,true);
     std::map<std::string, StereoAndMatchedMEs>::iterator iStereoAndMatchedME  = StereoAndMatchedMEsMap.find(label);
     std::pair<std::string,int32_t> det_lay_pair = fold_organ.GetSubDetAndLayer(myid,tTopo,true);
    
-    totnumrechitstereo[det_lay_pair.first] = totnumrechitstereo[det_lay_pair.first] + detsetIter->size();
+    totnumrechitstereo[det_lay_pair.first] = totnumrechitstereo[det_lay_pair.first] + theDetSet.size();
     //loop over rechits-stereo in the same subdetector
     if(iStereoAndMatchedME != StereoAndMatchedMEsMap.end()){
-      for(auto iterstereo=detsetIter->begin(), iterEnd = detsetIter->end(); iterstereo!=iterEnd; ++iterstereo){
+      for (auto const& rechit : theDetSet) {
         const GeomDetUnit *  det = tracker.idToDetUnit(detid);
         const StripGeomDetUnit * stripdet=(const StripGeomDetUnit*)(det);
         const StripTopology &topol=(StripTopology&)stripdet->topology();
-        SiStripRecHit2D const rechit=*iterstereo;
         //analyze RecHits
         rechitanalysis(rechit,topol,associate);
         // fill the result in a histogram
@@ -297,21 +291,19 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
   }
 
   // start loops over detectors with detected rechitmatched
-  for (auto it = rechitsmatched->begin(), itEnd = rechitsmatched->end(); it != itEnd; ++it) {
-    DetId detid = (*it).detId();
+  for (auto const & theDetSet : *rechitsmatched) {
+    DetId detid = theDetSet.detId();
     uint32_t myid = detid.rawId();       
-    auto detsetIter = rechitsmatched->find(detid);
-    totrechitmatched += detsetIter->size();
+    totrechitmatched += theDetSet.size();
  
     std::string label = hidmanager.getSubdetid(myid,tTopo,true);
     std::map<std::string, StereoAndMatchedMEs>::iterator iStereoAndMatchedME  = StereoAndMatchedMEsMap.find(label);
     std::pair<std::string,int32_t> det_lay_pair = fold_organ.GetSubDetAndLayer(myid,tTopo,true);
    
-    totnumrechitmatched[det_lay_pair.first] = totnumrechitmatched[det_lay_pair.first] + detsetIter->size();
+    totnumrechitmatched[det_lay_pair.first] = totnumrechitmatched[det_lay_pair.first] + theDetSet.size();
     //loop over rechits-matched in the same subdetector
     if(iStereoAndMatchedME != StereoAndMatchedMEsMap.end()){
-      for(auto itermatched=detsetIter->begin(), iterEnd = detsetIter->end(); itermatched!=iterEnd; ++itermatched){
-        SiStripMatchedRecHit2D const rechit=*itermatched;
+      for (auto const& rechit : theDetSet) {
         const GluedGeomDet* gluedDet = (const GluedGeomDet*)tracker.idToDet(rechit.geographicalId());
         //analyze RecHits 
         rechitanalysis_matched(rechit, gluedDet, associate);
@@ -354,7 +346,7 @@ std::pair<LocalPoint,LocalVector> SiStripRecHitsValid::projectHit( const PSimHit
 								   const BoundPlane& plane) 
 {
   //  const StripGeomDetUnit* stripDet = dynamic_cast<const StripGeomDetUnit*>(hit.det());
-  //if (stripDet == 0) throw MeasurementDetException("HitMatcher hit is not on StripGeomDetUnit");
+  //if (stripDet == nullptr) throw MeasurementDetException("HitMatcher hit is not on StripGeomDetUnit");
   
   const StripTopology& topol = stripDet->specificTopology();
   GlobalPoint globalpos= stripDet->surface().toGlobal(hit.localPosition());
@@ -368,8 +360,6 @@ std::pair<LocalPoint,LocalVector> SiStripRecHitsValid::projectHit( const PSimHit
   double scale = -localHit.z() / dir.z();
   
   LocalPoint projectedPos = localHit + scale*dir;
-  
-  //  std::cout << "projectedPos " << projectedPos << std::endl;
   
   double selfAngle = topol.stripAngle( topol.strip( hit.localPosition()));
   
@@ -391,8 +381,8 @@ void SiStripRecHitsValid::rechitanalysis(SiStripRecHit2D const rechit,const Stri
   MeasurementError Merror = topol.measurementError(position,error);
   const auto & amplitudes=(rechit.cluster())->amplitudes();
   int totcharge=0;
-  for(size_t ia=0; ia<amplitudes.size();++ia){
-    totcharge+=amplitudes[ia];
+  for(auto ia : amplitudes){
+    totcharge += ia;
   }
   rechitpro.x = position.x();
   rechitpro.y = position.y();
@@ -410,7 +400,7 @@ void SiStripRecHitsValid::rechitanalysis(SiStripRecHit2D const rechit,const Stri
 
     float mindist = std::numeric_limits<float>::max();
     float dist = std::numeric_limits<float>::max();
-    PSimHit const * closest = NULL;
+    PSimHit const * closest = nullptr;
  
     for(auto const &m : matched){
       dist = fabs(rechitpro.x - m.localPosition().x());
@@ -440,12 +430,6 @@ void SiStripRecHitsValid::rechitanalysis(SiStripRecHit2D const rechit,const Stri
     int ierr; 
     R.invert(ierr); // if (ierr != 0) throw exception;
     float est = R.similarity(r);
-    // 	  std::cout << " ====== Chi2 test rphi hits ====== " << std::endl;
-    // 	  std::cout << "RecHit param. = " << rhparameters << std::endl;
-    // 	  std::cout << "RecHit errors = " << R << std::endl;
-    //	  std::cout << "SimHit param. = " << shparameters << std::endl;
-    //	  std::cout << " chi2  = " << est << std::endl;
-    //	  std::cout << "DEBUG BORIS,filling chi2rphi[i],i: " << i << std::endl;
     rechitpro.chi2 = est;
   }
 
@@ -493,8 +477,6 @@ void SiStripRecHitsValid::rechitanalysis_matched(SiStripMatchedRecHit2D const re
 	disty = rechitpro.y - hitPair.first.y();
 	dist2 = distx*distx+disty*disty;
 	dist = sqrt(dist2);
-	// std::cout << " Simhit position x = " << hitPair.first.x() 
-	//      << " y = " << hitPair.first.y() << " dist = " << dist << std::endl;
 	if(dist<mindist){
 	  mindist = dist;
 	  closestPair = hitPair;
@@ -507,8 +489,6 @@ void SiStripRecHitsValid::rechitanalysis_matched(SiStripMatchedRecHit2D const re
     rechitpro.event = closest->eventId().event();
     rechitpro.resx = rechitpro.x - closestPair.first.x();
     rechitpro.resy = rechitpro.y - closestPair.first.y();
-    //std::cout << " Closest position x = " << closestPair.first.x() 
-    //      << " y = " << closestPair.first.y() << " dist = " << dist << std::endl;
   
     //chi2test compare rechit errors with the simhit position ( using null matrix for the simhit). 
     //Can spot problems in the geometry better than a simple residual. (thanks to BorisM)
@@ -527,12 +507,6 @@ void SiStripRecHitsValid::rechitanalysis_matched(SiStripMatchedRecHit2D const re
     int ierr; 
     R.invert(ierr); // if (ierr != 0) throw exception;
     float est = R.similarity(r);
-    // 	  std::cout << " ====== Chi2 test rphi hits ====== " << std::endl;
-    // 	  std::cout << "RecHit param. = " << rhparameters << std::endl;
-    // 	  std::cout << "RecHit errors = " << R << std::endl;
-    //	  std::cout << "SimHit param. = " << shparameters << std::endl;
-    //	  std::cout << " chi2  = " << est << std::endl;
-    //	  std::cout << "DEBUG BORIS,filling chi2rphi[i],i: " << i << std::endl;
     rechitpro.chi2 = est;
   
 
@@ -562,13 +536,11 @@ void SiStripRecHitsValid::createMEs(DQMStore::IBooker & ibooker,const edm::Event
   folder_organizer.setSiStripFolderName(curfold);
   folder_organizer.setSiStripFolder();
 
-  // std::cout << "curfold " << curfold << std::endl;
-
   createTotalMEs(ibooker);
   // loop over detectors and book MEs
   edm::LogInfo("SiStripTkRecHits|SiStripRecHitsValid")<<"nr. of activeDets:  "<<activeDets.size();
   const std::string& tec = "TEC", tid = "TID", tob = "TOB", tib = "TIB";        
-  for(std::vector<uint32_t>::iterator detid_iterator=activeDets.begin(), detid_end=activeDets.end(); detid_iterator!=detid_end; ++detid_iterator){
+  for(auto detid_iterator=activeDets.begin(), detid_end=activeDets.end(); detid_iterator!=detid_end; ++detid_iterator){
     uint32_t detid = (*detid_iterator);
     // remove any eventual zero elements - there should be none, but just in case
     if(detid == 0) {
@@ -580,7 +552,6 @@ void SiStripRecHitsValid::createMEs(DQMStore::IBooker & ibooker,const edm::Event
     std::pair<std::string,int32_t> det_layer_pair = folder_organizer.GetSubDetAndLayer(detid,tTopo,true);
     SiStripHistoId hidmanager;
     std::string label = hidmanager.getSubdetid(detid,tTopo,true);
-    // std::cout << "label " << label << endl;
       
     if(LayerMEsMap.find(label)==LayerMEsMap.end()) {
 	
@@ -610,15 +581,11 @@ void SiStripRecHitsValid::createMEs(DQMStore::IBooker & ibooker,const edm::Event
 
       // book Layer MEs 
       folder_organizer.setLayerFolder(detid,tTopo,det_layer_pair.second,true);
-      // std::stringstream ss;
-      // folder_organizer.getLayerFolderName(ss, detid, tTopo, true); 
-      // std::cout << "Folder Name " << ss.str().c_str() << std::endl;
       createLayerMEs(ibooker,label);
     }
     // book sub-detector plots 
     if (SubDetMEsMap.find(det_layer_pair.first) == SubDetMEsMap.end()){
       auto sdet_pair = folder_organizer.getSubDetFolderAndTag(detid, tTopo);
-      // std::cout << "sdet_pair " << sdet_pair.first << " " << sdet_pair.second << std::endl;
       ibooker.setCurrentFolder(sdet_pair.first);
       createSubDetMEs(ibooker,det_layer_pair.first);        
     }
@@ -660,9 +627,6 @@ void SiStripRecHitsValid::createMEs(DQMStore::IBooker & ibooker,const edm::Event
       if(isStereo){
 	//book StereoAndMatched MEs 
 	folder_organizer.setLayerFolder(detid,tTopo,det_layer_pair.second,true);
-	// std::stringstream ss1;
-	// folder_organizer.getLayerFolderName(ss1, detid, tTopo, true);  
-	// std::cout << "Folder Name stereo " <<  ss1.str().c_str() << std::endl;
 	//Create the Monitor Elements only when we have a stereo module
 	createStereoAndMatchedMEs(ibooker,label);
       }
@@ -672,9 +636,9 @@ void SiStripRecHitsValid::createMEs(DQMStore::IBooker & ibooker,const edm::Event
 //------------------------------------------------------------------------------------------
 void SiStripRecHitsValid::createTotalMEs(DQMStore::IBooker & ibooker) 
 {
-  totalMEs.meNumTotrphi = 0;
-  totalMEs.meNumTotStereo = 0;
-  totalMEs.meNumTotMatched = 0;
+  totalMEs.meNumTotrphi = nullptr;
+  totalMEs.meNumTotStereo = nullptr;
+  totalMEs.meNumTotMatched = nullptr;
 
   //NumTotrphi
   if(switchNumTotrphi) {
@@ -699,60 +663,60 @@ void SiStripRecHitsValid::createLayerMEs(DQMStore::IBooker & ibooker,std::string
   SiStripHistoId hidmanager;
   LayerMEs layerMEs; 
 
-  layerMEs.meWclusrphi = 0;
-  layerMEs.meAdcrphi = 0;
-  layerMEs.mePosxrphi = 0;
-  layerMEs.meResolxrphi = 0;
-  layerMEs.meResrphi = 0;
-  layerMEs.mePullLFrphi = 0;
-  layerMEs.mePullMFrphi = 0;
-  layerMEs.meChi2rphi = 0;
-  layerMEs.meNsimHitrphi = 0;
+  layerMEs.meWclusrphi = nullptr;
+  layerMEs.meAdcrphi = nullptr;
+  layerMEs.mePosxrphi = nullptr;
+  layerMEs.meResolxrphi = nullptr;
+  layerMEs.meResrphi = nullptr;
+  layerMEs.mePullLFrphi = nullptr;
+  layerMEs.mePullMFrphi = nullptr;
+  layerMEs.meChi2rphi = nullptr;
+  layerMEs.meNsimHitrphi = nullptr;
 
   //Wclusrphi
   if(switchWclusrphi) {
     layerMEs.meWclusrphi = bookME1D(ibooker,"TH1Wclusrphi", hidmanager.createHistoLayer("Wclus_rphi","layer",label,"").c_str() ,"Cluster Width - Number of strips that belong to the RecHit cluster"); 
-    layerMEs.meWclusrphi->setAxisTitle(("Cluster Width [nr strips] in "+ label).c_str());
+    layerMEs.meWclusrphi->setAxisTitle("Cluster Width [nr strips] in "+ label);
   }
   //Adcrphi
   if(switchAdcrphi) {
     layerMEs.meAdcrphi = bookME1D(ibooker,"TH1Adcrphi", hidmanager.createHistoLayer("Adc_rphi","layer",label,"").c_str() ,"RecHit Cluster Charge");
-    layerMEs.meAdcrphi->setAxisTitle(("cluster charge [ADC] in " + label).c_str());
+    layerMEs.meAdcrphi->setAxisTitle("cluster charge [ADC] in " + label);
   }
   //Posxrphi
   if(switchPosxrphi) {
     layerMEs.mePosxrphi = bookME1D(ibooker,"TH1Posxrphi", hidmanager.createHistoLayer("Posx_rphi","layer",label,"").c_str() ,"RecHit x coord."); 
-    layerMEs.mePosxrphi->setAxisTitle(("x RecHit coord. (local frame) in " + label).c_str());
+    layerMEs.mePosxrphi->setAxisTitle("x RecHit coord. (local frame) in " + label);
   }
   //Resolxrphi
   if(switchResolxrphi) {
     layerMEs.meResolxrphi = bookME1D(ibooker,"TH1Resolxrphi", hidmanager.createHistoLayer("Resolx_rphi","layer",label,"").c_str() ,"RecHit resol(x) coord.");   //<resolor>~20micron  
-    layerMEs.meResolxrphi->setAxisTitle(("resol(x) RecHit coord. (local frame) in " + label).c_str());
+    layerMEs.meResolxrphi->setAxisTitle("resol(x) RecHit coord. (local frame) in " + label);
   }
   //Resrphi
   if(switchResrphi) {
     layerMEs.meResrphi = bookME1D(ibooker,"TH1Resrphi", hidmanager.createHistoLayer("Res_rphi","layer",label,"").c_str() ,"Residuals of the hit x coordinate"); 
-    layerMEs.meResrphi->setAxisTitle(("RecHit Res(x) in " + label).c_str());
+    layerMEs.meResrphi->setAxisTitle("RecHit Res(x) in " + label);
   }
   //PullLFrphi
   if(switchPullLFrphi) {
     layerMEs.mePullLFrphi = bookME1D(ibooker,"TH1PullLFrphi", hidmanager.createHistoLayer("Pull_LF_rphi","layer",label,"").c_str() ,"Pull distribution");  
-    layerMEs.mePullLFrphi->setAxisTitle(("Pull distribution (local frame) in " + label).c_str());
+    layerMEs.mePullLFrphi->setAxisTitle("Pull distribution (local frame) in " + label);
   }
   //PullMFrphi
   if(switchPullMFrphi) {
     layerMEs.mePullMFrphi = bookME1D(ibooker,"TH1PullMFrphi", hidmanager.createHistoLayer("Pull_MF_rphi","layer",label,"").c_str() ,"Pull distribution");  
-    layerMEs.mePullMFrphi->setAxisTitle(("Pull distribution (measurement frame) in " + label).c_str());
+    layerMEs.mePullMFrphi->setAxisTitle("Pull distribution (measurement frame) in " + label);
   }
   //Chi2rphi
   if(switchChi2rphi) {
     layerMEs.meChi2rphi = bookME1D(ibooker,"TH1Chi2rphi", hidmanager.createHistoLayer("Chi2_rphi","layer",label,"").c_str() ,"RecHit Chi2 test"); 
-    layerMEs.meChi2rphi->setAxisTitle(("RecHit Chi2 test in " + label).c_str()); 
+    layerMEs.meChi2rphi->setAxisTitle("RecHit Chi2 test in " + label); 
   }
   //NsimHitrphi
   if(switchNsimHitrphi) {
     layerMEs.meNsimHitrphi = bookME1D(ibooker,"TH1NsimHitrphi", hidmanager.createHistoLayer("NsimHit_rphi","layer",label,"").c_str() ,"No. of assoc. simHits"); 
-    layerMEs.meNsimHitrphi->setAxisTitle(("Number of assoc. simHits in " + label).c_str()); 
+    layerMEs.meNsimHitrphi->setAxisTitle("Number of assoc. simHits in " + label); 
   }
 
   LayerMEsMap[label]=layerMEs;
@@ -764,108 +728,108 @@ void SiStripRecHitsValid::createStereoAndMatchedMEs(DQMStore::IBooker & ibooker,
   SiStripHistoId hidmanager;
   StereoAndMatchedMEs stereoandmatchedMEs; 
 
-  stereoandmatchedMEs.meWclusStereo = 0;
-  stereoandmatchedMEs.meAdcStereo = 0;
-  stereoandmatchedMEs.mePosxStereo = 0;
-  stereoandmatchedMEs.meResolxStereo = 0;
-  stereoandmatchedMEs.meResStereo = 0;
-  stereoandmatchedMEs.mePullLFStereo = 0;
-  stereoandmatchedMEs.mePullMFStereo = 0;
-  stereoandmatchedMEs.meChi2Stereo = 0;
-  stereoandmatchedMEs.meNsimHitStereo = 0;
-  stereoandmatchedMEs.mePosxMatched = 0;
-  stereoandmatchedMEs.mePosyMatched = 0;
-  stereoandmatchedMEs.meResolxMatched = 0;
-  stereoandmatchedMEs.meResolyMatched = 0;
-  stereoandmatchedMEs.meResxMatched = 0;
-  stereoandmatchedMEs.meResyMatched = 0;
-  stereoandmatchedMEs.meChi2Matched = 0;
-  stereoandmatchedMEs.meNsimHitMatched = 0;
+  stereoandmatchedMEs.meWclusStereo = nullptr;
+  stereoandmatchedMEs.meAdcStereo = nullptr;
+  stereoandmatchedMEs.mePosxStereo = nullptr;
+  stereoandmatchedMEs.meResolxStereo = nullptr;
+  stereoandmatchedMEs.meResStereo = nullptr;
+  stereoandmatchedMEs.mePullLFStereo = nullptr;
+  stereoandmatchedMEs.mePullMFStereo = nullptr;
+  stereoandmatchedMEs.meChi2Stereo = nullptr;
+  stereoandmatchedMEs.meNsimHitStereo = nullptr;
+  stereoandmatchedMEs.mePosxMatched = nullptr;
+  stereoandmatchedMEs.mePosyMatched = nullptr;
+  stereoandmatchedMEs.meResolxMatched = nullptr;
+  stereoandmatchedMEs.meResolyMatched = nullptr;
+  stereoandmatchedMEs.meResxMatched = nullptr;
+  stereoandmatchedMEs.meResyMatched = nullptr;
+  stereoandmatchedMEs.meChi2Matched = nullptr;
+  stereoandmatchedMEs.meNsimHitMatched = nullptr;
 
   //WclusStereo
   if(switchWclusStereo) {
     stereoandmatchedMEs.meWclusStereo = bookME1D(ibooker,"TH1WclusStereo", hidmanager.createHistoLayer("Wclus_stereo","layer",label,"").c_str() ,"Cluster Width - Number of strips that belong to the RecHit cluster");  
-    stereoandmatchedMEs.meWclusStereo->setAxisTitle(("Cluster Width [nr strips] in stereo modules in "+ label).c_str());
+    stereoandmatchedMEs.meWclusStereo->setAxisTitle("Cluster Width [nr strips] in stereo modules in "+ label);
   }
   //AdcStereo
   if(switchAdcStereo) {
     stereoandmatchedMEs.meAdcStereo = bookME1D(ibooker,"TH1AdcStereo", hidmanager.createHistoLayer("Adc_stereo","layer",label,"").c_str() ,"RecHit Cluster Charge"); 
-    stereoandmatchedMEs.meAdcStereo->setAxisTitle(("cluster charge [ADC] in stereo modules in " + label).c_str());
+    stereoandmatchedMEs.meAdcStereo->setAxisTitle("cluster charge [ADC] in stereo modules in " + label);
   }
   //PosxStereo
   if(switchPosxStereo) {
     stereoandmatchedMEs.mePosxStereo = bookME1D(ibooker,"TH1PosxStereo", hidmanager.createHistoLayer("Posx_stereo","layer",label,"").c_str() ,"RecHit x coord."); 
-    stereoandmatchedMEs.mePosxStereo->setAxisTitle(("x RecHit coord. (local frame) in stereo modules in " + label).c_str());
+    stereoandmatchedMEs.mePosxStereo->setAxisTitle("x RecHit coord. (local frame) in stereo modules in " + label);
   }
   //ResolxStereo
   if(switchResolxStereo) {
     stereoandmatchedMEs.meResolxStereo = bookME1D(ibooker,"TH1ResolxStereo", hidmanager.createHistoLayer("Resolx_stereo","layer",label,"").c_str() ,"RecHit resol(x) coord.");  
-    stereoandmatchedMEs.meResolxStereo->setAxisTitle(("resol(x) RecHit coord. (local frame) in stereo modules in " + label).c_str());
+    stereoandmatchedMEs.meResolxStereo->setAxisTitle("resol(x) RecHit coord. (local frame) in stereo modules in " + label);
   }
   //ResStereo
   if(switchResStereo) {
     stereoandmatchedMEs.meResStereo = bookME1D(ibooker,"TH1ResStereo", hidmanager.createHistoLayer("Res_stereo","layer",label,"").c_str() ,"Residuals of the hit x coordinate"); 
-    stereoandmatchedMEs.meResStereo->setAxisTitle(("RecHit Res(x) in stereo modules in " + label).c_str());
+    stereoandmatchedMEs.meResStereo->setAxisTitle("RecHit Res(x) in stereo modules in " + label);
   }
   //PullLFStereo
   if(switchPullLFStereo) {
     stereoandmatchedMEs.mePullLFStereo = bookME1D(ibooker,"TH1PullLFStereo", hidmanager.createHistoLayer("Pull_LF_stereo","layer",label,"").c_str() ,"Pull distribution");  
-    stereoandmatchedMEs.mePullLFStereo->setAxisTitle(("Pull distribution (local frame) in stereo modules in " + label).c_str());
+    stereoandmatchedMEs.mePullLFStereo->setAxisTitle("Pull distribution (local frame) in stereo modules in " + label);
   }
   //PullMFStereo
   if(switchPullMFStereo) {
     stereoandmatchedMEs.mePullMFStereo = bookME1D(ibooker,"TH1PullMFStereo", hidmanager.createHistoLayer("Pull_MF_stereo","layer",label,"").c_str() ,"Pull distribution");  
-    stereoandmatchedMEs.mePullMFStereo->setAxisTitle(("Pull distribution (measurement frame) in stereo modules in " + label).c_str());
+    stereoandmatchedMEs.mePullMFStereo->setAxisTitle("Pull distribution (measurement frame) in stereo modules in " + label);
   }
   //Chi2Stereo
   if(switchChi2Stereo) {
     stereoandmatchedMEs.meChi2Stereo = bookME1D(ibooker,"TH1Chi2Stereo", hidmanager.createHistoLayer("Chi2_stereo","layer",label,"").c_str() ,"RecHit Chi2 test");  
-    stereoandmatchedMEs.meChi2Stereo->setAxisTitle(("RecHit Chi2 test in stereo modules in " + label).c_str()); 
+    stereoandmatchedMEs.meChi2Stereo->setAxisTitle("RecHit Chi2 test in stereo modules in " + label); 
   }
   //NsimHitStereo
   if(switchNsimHitStereo) {
     stereoandmatchedMEs.meNsimHitStereo = bookME1D(ibooker,"TH1NsimHitStereo", hidmanager.createHistoLayer("NsimHit_stereo","layer",label,"").c_str() ,"No. of assoc. simHits");  
-    stereoandmatchedMEs.meNsimHitStereo->setAxisTitle(("Number of assoc. simHits in stereo modules in " + label).c_str()); 
+    stereoandmatchedMEs.meNsimHitStereo->setAxisTitle("Number of assoc. simHits in stereo modules in " + label); 
   }
   //PosxMatched
   if(switchPosxMatched) {
     stereoandmatchedMEs.mePosxMatched = bookME1D(ibooker,"TH1PosxMatched", hidmanager.createHistoLayer("Posx_matched","layer",label,"").c_str() ,"RecHit x coord.");  
-    stereoandmatchedMEs.mePosxMatched->setAxisTitle(("x coord. matched RecHit (local frame) in " + label).c_str());
+    stereoandmatchedMEs.mePosxMatched->setAxisTitle("x coord. matched RecHit (local frame) in " + label);
   }
   //PosyMatched
   if(switchPosyMatched) {
     stereoandmatchedMEs.mePosyMatched = bookME1D(ibooker,"TH1PosyMatched", hidmanager.createHistoLayer("Posy_matched","layer",label,"").c_str() ,"RecHit y coord."); 
-    stereoandmatchedMEs.mePosyMatched->setAxisTitle(("y coord. matched RecHit (local frame) in " + label).c_str());
+    stereoandmatchedMEs.mePosyMatched->setAxisTitle("y coord. matched RecHit (local frame) in " + label);
   }
   //ResolxMatched
   if(switchResolxMatched) {
     stereoandmatchedMEs.meResolxMatched = bookME1D(ibooker,"TH1ResolxMatched", hidmanager.createHistoLayer("Resolx_matched","layer",label,"").c_str() ,"RecHit resol(x) coord.");  
-    stereoandmatchedMEs.meResolxMatched->setAxisTitle(("resol(x) coord. matched RecHit (local frame) in " + label).c_str());
+    stereoandmatchedMEs.meResolxMatched->setAxisTitle("resol(x) coord. matched RecHit (local frame) in " + label);
   }
   //ResolyMatched
   if(switchResolyMatched) {
     stereoandmatchedMEs.meResolyMatched = bookME1D(ibooker,"TH1ResolyMatched", hidmanager.createHistoLayer("Resoly_matched","layer",label,"").c_str() ,"RecHit resol(y) coord."); 
-    stereoandmatchedMEs.meResolyMatched->setAxisTitle(("resol(y) coord. matched RecHit (local frame) in " + label).c_str());
+    stereoandmatchedMEs.meResolyMatched->setAxisTitle("resol(y) coord. matched RecHit (local frame) in " + label);
   }
   //ResxMatched
   if(switchResxMatched) {
     stereoandmatchedMEs.meResxMatched = bookME1D(ibooker,"TH1ResxMatched", hidmanager.createHistoLayer("Resx_matched","layer",label,"").c_str() ,"Residuals of the hit x coord."); 
-    stereoandmatchedMEs.meResxMatched->setAxisTitle(("Res(x) in matched RecHit in " + label).c_str());
+    stereoandmatchedMEs.meResxMatched->setAxisTitle("Res(x) in matched RecHit in " + label);
   }
   //ResyMatched
   if(switchResyMatched) {
     stereoandmatchedMEs.meResyMatched = bookME1D(ibooker,"TH1ResyMatched", hidmanager.createHistoLayer("Resy_matched","layer",label,"").c_str() ,"Residuals of the hit y coord."); 
-    stereoandmatchedMEs.meResyMatched->setAxisTitle(("Res(y) in matched RecHit in " + label).c_str());
+    stereoandmatchedMEs.meResyMatched->setAxisTitle("Res(y) in matched RecHit in " + label);
   }
   //Chi2Matched
   if(switchChi2Matched) {
     stereoandmatchedMEs.meChi2Matched = bookME1D(ibooker,"TH1Chi2Matched", hidmanager.createHistoLayer("Chi2_matched","layer",label,"").c_str() ,"RecHit Chi2 test"); 
-    stereoandmatchedMEs.meChi2Matched->setAxisTitle(("Matched RecHit Chi2 test in " + label).c_str()); 
+    stereoandmatchedMEs.meChi2Matched->setAxisTitle("Matched RecHit Chi2 test in " + label); 
   }
   //NsimHitMatched
   if(switchNsimHitMatched) {
     stereoandmatchedMEs.meNsimHitMatched = bookME1D(ibooker,"TH1NsimHitMatched", hidmanager.createHistoLayer("NsimHit_matched","layer",label,"").c_str() ,"No. of assoc. simHits"); 
-    stereoandmatchedMEs.meNsimHitMatched->setAxisTitle(("Number of assoc. simHits in " + label).c_str()); 
+    stereoandmatchedMEs.meNsimHitMatched->setAxisTitle("Number of assoc. simHits in " + label); 
   }
 
   StereoAndMatchedMEsMap[label]=stereoandmatchedMEs;
@@ -875,70 +839,70 @@ void SiStripRecHitsValid::createStereoAndMatchedMEs(DQMStore::IBooker & ibooker,
 void SiStripRecHitsValid::createSubDetMEs(DQMStore::IBooker & ibooker,std::string label) {
 
   SubDetMEs subdetMEs;
-  subdetMEs.meNumrphi = 0;
-  subdetMEs.meBunchrphi = 0;
-  subdetMEs.meEventrphi = 0;
-  subdetMEs.meNumStereo = 0;
-  subdetMEs.meBunchStereo = 0;
-  subdetMEs.meEventStereo = 0;
-  subdetMEs.meNumMatched = 0;
-  subdetMEs.meBunchMatched = 0;
-  subdetMEs.meEventMatched = 0;
+  subdetMEs.meNumrphi = nullptr;
+  subdetMEs.meBunchrphi = nullptr;
+  subdetMEs.meEventrphi = nullptr;
+  subdetMEs.meNumStereo = nullptr;
+  subdetMEs.meBunchStereo = nullptr;
+  subdetMEs.meEventStereo = nullptr;
+  subdetMEs.meNumMatched = nullptr;
+  subdetMEs.meBunchMatched = nullptr;
+  subdetMEs.meEventMatched = nullptr;
 
   std::string HistoName;
   //Numrphi
   if (switchNumrphi){
     HistoName = "TH1Numrphi__" + label;
     subdetMEs.meNumrphi = bookME1D(ibooker,"TH1Numrphi",HistoName.c_str(),"Num of RecHits");
-    subdetMEs.meNumrphi->setAxisTitle(("Total number of RecHits in "+ label).c_str());
+    subdetMEs.meNumrphi->setAxisTitle("Total number of RecHits in "+ label);
   }  
   //Bunchrphi
   if(switchBunchrphi) {
     HistoName = "TH1Bunchrphi__" + label;
     subdetMEs.meBunchrphi = bookME1D(ibooker,"TH1Bunchrphi",HistoName.c_str(),"Bunch Crossing");
-    subdetMEs.meBunchrphi->setAxisTitle(("Bunch crossing in " + label).c_str()); 
+    subdetMEs.meBunchrphi->setAxisTitle("Bunch crossing in " + label); 
   }
   //Eventrphi
   if(switchEventrphi) {
     HistoName = "TH1Eventrphi__" + label;
     subdetMEs.meEventrphi = bookME1D(ibooker,"TH1Eventrphi",HistoName.c_str(),"Event (in-time bunch)");
-    subdetMEs.meEventrphi->setAxisTitle(("Event (in-time bunch) in " + label).c_str()); 
+    subdetMEs.meEventrphi->setAxisTitle("Event (in-time bunch) in " + label); 
   }
   //NumStereo
   if (switchNumStereo){
     HistoName = "TH1NumStereo__" + label;
     subdetMEs.meNumStereo = bookME1D(ibooker,"TH1NumStereo",HistoName.c_str(),"Num of RecHits in stereo modules");
-    subdetMEs.meNumStereo->setAxisTitle(("Total number of RecHits, stereo modules in "+ label).c_str());
+    subdetMEs.meNumStereo->setAxisTitle("Total number of RecHits, stereo modules in "+ label);
   }  
   //BunchStereo
   if(switchBunchStereo) {
     HistoName = "TH1BunchStereo__" + label;
     subdetMEs.meBunchStereo = bookME1D(ibooker,"TH1BunchStereo",HistoName.c_str(),"Bunch Crossing");
-    subdetMEs.meBunchStereo->setAxisTitle(("Bunch crossing, stereo modules in " + label).c_str()); 
+    subdetMEs.meBunchStereo->setAxisTitle("Bunch crossing, stereo modules in " + label); 
   }
   //EventStereo
   if(switchEventStereo) {
     HistoName = "TH1EventStereo__" + label;
     subdetMEs.meEventStereo = bookME1D(ibooker,"TH1EventStereo",HistoName.c_str(),"Event (in-time bunch)");
-    subdetMEs.meEventStereo->setAxisTitle(("Event (in-time bunch), stereo modules in " + label).c_str()); 
+    subdetMEs.meEventStereo->setAxisTitle("Event (in-time bunch), stereo modules in " + label); 
   }
   //NumMatched
   if (switchNumMatched){
     HistoName = "TH1NumMatched__" + label;
     subdetMEs.meNumMatched = bookME1D(ibooker,"TH1NumMatched",HistoName.c_str(),"Num of matched RecHits" );
-    subdetMEs.meNumMatched->setAxisTitle(("Total number of matched RecHits in "+ label).c_str());
+    subdetMEs.meNumMatched->setAxisTitle("Total number of matched RecHits in "+ label);
   }  
   //BunchMatched
   if(switchBunchMatched) {
     HistoName = "TH1BunchMatched__" + label;
     subdetMEs.meBunchMatched = bookME1D(ibooker,"TH1BunchMatched",HistoName.c_str(),"Bunch Crossing");
-    subdetMEs.meBunchMatched->setAxisTitle(("Bunch crossing, matched RecHits in " + label).c_str()); 
+    subdetMEs.meBunchMatched->setAxisTitle("Bunch crossing, matched RecHits in " + label); 
   }
   //EventMatched
   if(switchEventMatched) {
     HistoName = "TH1EventMatched__" + label;
     subdetMEs.meEventMatched = bookME1D(ibooker,"TH1EventMatched",HistoName.c_str(),"Event (in-time bunch)");
-    subdetMEs.meEventMatched->setAxisTitle(("Event (in-time bunch), matched RecHits in " + label).c_str()); 
+    subdetMEs.meEventMatched->setAxisTitle("Event (in-time bunch), matched RecHits in " + label); 
   }
 
   SubDetMEsMap[label]=subdetMEs;


### PR DESCRIPTION
Remove three instances of unnecessary use of find() to access a detSet inside an iteration over detSets.  Implement auto and range-based for() loops.  Implement clang-tidy modernizations.  Remove commented couts.  No change in results.