### PR TITLE
Fix compilation error due to DetUnitContainer(deprecated)

### DIFF
--- a/L1Trigger/L1TMuonEndCap/test/tools/MakeAngleLUT.cc
+++ b/L1Trigger/L1TMuonEndCap/test/tools/MakeAngleLUT.cc
@@ -152,7 +152,7 @@ void MakeAngleLUT::generateLUTs() {
   // ___________________________________________________________________________
   // CSC
 
-  for (CSCGeometry::DetUnitContainer::const_iterator it = geocsc.detUnits().begin(); it != geocsc.detUnits().end(); ++it) {
+  for (CSCGeometry::DetContainer::const_iterator it = geocsc.detUnits().begin(); it != geocsc.detUnits().end(); ++it) {
     const CSCLayer* layer = dynamic_cast<const CSCLayer*>(*it);  // like GeomDetUnit
     assert(layer != nullptr);
     const CSCChamber* chamber = layer->chamber();  // like GeomDet
@@ -208,7 +208,7 @@ void MakeAngleLUT::generateLUTs() {
   // ___________________________________________________________________________
   // RPC
 
-  for (RPCGeometry::DetUnitContainer::const_iterator it = georpc.detUnits().begin(); it != georpc.detUnits().end(); ++it) {
+  for (RPCGeometry::DetContainer::const_iterator it = georpc.detUnits().begin(); it != georpc.detUnits().end(); ++it) {
     const RPCRoll* roll = dynamic_cast<const RPCRoll*>(*it);  // like GeomDetUnit
     assert(roll != nullptr);
     //const RPCChamber* chamber = roll->chamber();  // like GeomDet
@@ -261,7 +261,7 @@ void MakeAngleLUT::generateLUTs() {
   // ___________________________________________________________________________
   // GEM
 
-  for (GEMGeometry::DetUnitContainer::const_iterator it = geogem.detUnits().begin(); it != geogem.detUnits().end(); ++it) {
+  for (GEMGeometry::DetContainer::const_iterator it = geogem.detUnits().begin(); it != geogem.detUnits().end(); ++it) {
     const GEMEtaPartition* roll = dynamic_cast<const GEMEtaPartition*>(*it);  // like GeomDetUnit
     assert(roll != nullptr);
     //const GEMChamber* chamber = roll->chamber();  // like GeomDet


### PR DESCRIPTION
Fix compilation error due to DetUnitContainer(deprecated) used in L1Trigger/L1TMuonEndCap/test/tools/MakeAngleLUT.cc

https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc630/CMSSW_9_4_X_2017-10-08-2300/L1Trigger/L1TMuonEndCap