### PR TITLE
MiniAOD: use all genParticles for patJets partonFlavour

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -374,7 +374,7 @@ def miniAOD_customizeMC(process):
     #Boosted taus 
     process.tauMatchBoosted.matched = "prunedGenParticles"
     process.tauGenJetsBoosted.GenParticles = "prunedGenParticles"
-    process.patJetPartons.particles = "prunedGenParticles"
+    process.patJetPartons.particles = "genParticles"
     process.patJetPartonMatch.matched = "prunedGenParticles"
     process.patJetPartonMatch.mcStatus = [ 3, 23 ]
     process.patJetGenJetMatch.matched = "slimmedGenJets"


### PR DESCRIPTION
This should implement Jet flavour in MiniAOD as agreed in the pat (i.e. use all genparticles for flavour stored by value)

@Andrej-CMS  @gpetruc @ahinzmann @amarini @ferencek 