### PR TITLE
Fix multiple comp warnings for unused variables

### DIFF
--- a/Calibration/Tools/src/HouseholderDecomposition.cc
+++ b/Calibration/Tools/src/HouseholderDecomposition.cc
@@ -40,7 +40,6 @@ std::vector<float> HouseholderDecomposition::runRegional(const std::vector<std::
   std::vector<float> totalSolution(Nchannels,1.);
   std::vector<float> iterSolution(Nchannels,1.);
   std::vector<std::vector<float> > myEventMatrix(eventMatrix);
-  const std::vector<float>& myEnergyVector(energyVector);
 
   // loop over nIter
   for (int iter=1;iter<=nIter;iter++) 

--- a/CondTools/SiStrip/plugins/SiStripBadChannelBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripBadChannelBuilder.cc
@@ -26,8 +26,6 @@ void SiStripBadChannelBuilder::algoAnalyze(const edm::Event & event, const edm::
 
   SiStripDetInfoFileReader reader(fp_.fullPath());
   
-  const std::vector<uint32_t>& DetIds = reader.getAllDetIds();
-  
   for(Parameters::iterator iBadComponent = BadComponentList_.begin(); iBadComponent != BadComponentList_.end(); ++iBadComponent ) {
     
     uint32_t BadModule_ = iBadComponent->getParameter<uint32_t>("BadModule");

--- a/CondTools/SiStrip/plugins/SiStripBadFiberBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripBadFiberBuilder.cc
@@ -27,8 +27,6 @@ void SiStripBadFiberBuilder::algoAnalyze(const edm::Event & event, const edm::Ev
 
   SiStripDetInfoFileReader reader(fp_.fullPath());
   
-  const std::vector<uint32_t>& DetIds = reader.getAllDetIds();
-
   std::stringstream ss;
   for(Parameters::iterator iBadComponent = BadComponentList_.begin(); iBadComponent != BadComponentList_.end(); ++iBadComponent ) {
     

--- a/DPGAnalysis/Skims/interface/MatchedProbeMaker.h
+++ b/DPGAnalysis/Skims/interface/MatchedProbeMaker.h
@@ -115,7 +115,6 @@ void MatchedProbeMaker<T>::produce(edm::Event& iEvent, const edm::EventSetup& iS
       for (unsigned j=0; j<Refs->size(); j++) {
 	//const edm::Ref< collection > RefRef = (*Refs)[j];
 	RefToBase<Candidate> RefRef(Refs, j);
-	const reco::CandidateBaseRef& refBaseRef( RefRef );
 	
 	if(overlap(*CandRef,*RefRef)) {
 	   ppass = true; 

--- a/DQM/BeamMonitor/plugins/BeamSpotProblemMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamSpotProblemMonitor.cc
@@ -334,7 +334,6 @@ void BeamSpotProblemMonitor::FillPlots(const LuminosityBlock& lumiSeg,int &lastl
     		          /* S.Dutta : Commenting out these variables are not used and giving error with "-Werror=unused-variable" option
     	                   float qtresult = BeamSpotQReport->getQTresult();
                            int qtstatus   = BeamSpotQReport->getStatus() ; // get QT status value (see table below) */
-               	           const std::string& qtmessage = BeamSpotQReport->getMessage() ; // get the whole QT result message
                       }
 
 

--- a/DQM/L1TMonitorClient/src/L1TEventInfoClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TEventInfoClient.cc
@@ -519,7 +519,6 @@ void L1TEventInfoClient::readQtResults(DQMStore::IBooker &ibooker, DQMStore::IGe
 
             if (qHist) {
                 const std::vector<QReport*> qtVec = qHist->getQReports();
-                const std::string& hName = qHist->getName();
 
                 if (m_verbose) {
 
@@ -639,7 +638,6 @@ void L1TEventInfoClient::readQtResults(DQMStore::IBooker &ibooker, DQMStore::IGe
 
             if (qHist) {
                 const std::vector<QReport*> qtVec = qHist->getQReports();
-                const std::string& hName = qHist->getName();
 
                 if (m_verbose) {
 

--- a/DQMOffline/Muon/src/MuonTestSummary.cc
+++ b/DQMOffline/Muon/src/MuonTestSummary.cc
@@ -498,7 +498,6 @@ void MuonTestSummary::doKinematicsTests(DQMStore::IGetter & igetter, string muon
 	LogTrace(metname) << "Chi2Report exists!!";
 	float qtresult = myQReport->getQTresult(); // get QT result value
 	int qtstatus = myQReport->getStatus() ; // get QT status value (see table below)
-	const std::string& qtmessage = myQReport->getMessage() ; // get the whole QT result message
 	LogTrace(metname) << "qtresult " <<qtresult << " qtstatus "<<qtstatus<<endl;
 	chi2TestSummaryMap->setBinContent(bin,1,qtresult);
       }
@@ -509,7 +508,6 @@ void MuonTestSummary::doKinematicsTests(DQMStore::IGetter & igetter, string muon
 	LogTrace(metname) << "Chi2Report Kolmogorov exists!!";
 	float qtresult = myQReportKolmo->getQTresult(); // get QT result value
 	int qtstatus = myQReportKolmo->getStatus() ; // get QT status value (see table below)
-	const std::string& qtmessage = myQReportKolmo->getMessage() ; // get the whole QT result message
 	LogTrace(metname) << "qtresult " <<qtresult<< " qtstatus "<<qtstatus<<endl;
 	KolmogorovTestSummaryMap->setBinContent(bin,1,qtresult);
       }
@@ -558,7 +556,6 @@ void MuonTestSummary::doKinematicsTests(DQMStore::IGetter & igetter, string muon
 	LogTrace(metname) << "EtaReport exists!!";
 	float qtresult = myQReport->getQTresult(); // get QT result value
 	int qtstatus = myQReport->getStatus() ; // get QT status value (see table below)
-	const std::string& qtmessage = myQReport->getMessage() ; // get the whole QT result message
 	LogTrace(metname) << "qtresult " <<qtresult << " qtstatus "<<qtstatus<<endl;
 	chi2TestSummaryMap->setBinContent(bin,2,qtresult);
       }
@@ -570,7 +567,6 @@ void MuonTestSummary::doKinematicsTests(DQMStore::IGetter & igetter, string muon
 	LogTrace(metname) << "EtaReport Kolmogorov exists!!";
 	float qtresult = myQReportKolmo->getQTresult(); // get QT result value
 	int qtstatus = myQReportKolmo->getStatus() ; // get QT status value (see table below)
-	const std::string& qtmessage = myQReportKolmo->getMessage() ; // get the whole QT result message
 	LogTrace(metname) << "qtresult " <<qtresult<< " qtstatus "<<qtstatus<<endl;
 	KolmogorovTestSummaryMap->setBinContent(bin,2,qtresult);
       }
@@ -619,7 +615,6 @@ void MuonTestSummary::doKinematicsTests(DQMStore::IGetter & igetter, string muon
 	LogTrace(metname) << "PhiReport exists!!";
 	float qtresult = myQReport->getQTresult(); // get QT result value
 	int qtstatus = myQReport->getStatus() ; // get QT status value (see table below)
-	const std::string& qtmessage = myQReport->getMessage() ; // get the whole QT result message
 	LogTrace(metname) << "qtresult " <<qtresult<< " qtstatus "<<qtstatus<<endl;
 	chi2TestSummaryMap->setBinContent(bin,3,qtresult);
      }
@@ -631,7 +626,6 @@ void MuonTestSummary::doKinematicsTests(DQMStore::IGetter & igetter, string muon
 	LogTrace(metname) << "PhiReport Kolmogorov exists!!";
 	float qtresult = myQReportKolmo->getQTresult(); // get QT result value
 	int qtstatus = myQReportKolmo->getStatus() ; // get QT status value (see table below)
-	const std::string& qtmessage = myQReportKolmo->getMessage() ; // get the whole QT result message
 	LogTrace(metname) << "qtresult " <<qtresult<< " qtstatus "<<qtstatus<<endl;
 	KolmogorovTestSummaryMap->setBinContent(bin,3,qtresult);
       }
@@ -657,7 +651,6 @@ void MuonTestSummary::doKinematicsTests(DQMStore::IGetter & igetter, string muon
 	LogTrace(metname) << "PtReport exists!!";
 	float qtresult = myQReport->getQTresult(); // get QT result value
 	int qtstatus = myQReport->getStatus() ; // get QT status value (see table below)
-	const std::string& qtmessage = myQReport->getMessage() ; // get the whole QT result message
 	LogTrace(metname) << "qtresult " <<qtresult<< " qtstatus "<<qtstatus<<endl;
 	chi2TestSummaryMap->setBinContent(bin,4,qtresult);
      }
@@ -669,7 +662,6 @@ void MuonTestSummary::doKinematicsTests(DQMStore::IGetter & igetter, string muon
 	LogTrace(metname) << "PtReport Kolmogorov exists!!";
 	float qtresult = myQReportKolmo->getQTresult(); // get QT result value
 	int qtstatus = myQReportKolmo->getStatus() ; // get QT status value (see table below)
-	const std::string& qtmessage = myQReportKolmo->getMessage() ; // get the whole QT result message
 	LogTrace(metname) << "qtresult " <<qtresult<< " qtstatus "<<qtstatus<<endl;
 	KolmogorovTestSummaryMap->setBinContent(bin,4,qtresult);
       }
@@ -694,7 +686,6 @@ void MuonTestSummary::doKinematicsTests(DQMStore::IGetter & igetter, string muon
 	LogTrace(metname) << "qReport exists!!";
 	float qtresult = myQReport->getQTresult(); // get QT result value
 	int qtstatus = myQReport->getStatus() ; // get QT status value (see table below)
-	const std::string& qtmessage = myQReport->getMessage() ; // get the whole QT result message
 	LogTrace(metname) << "qtresult " <<qtresult<< " qtstatus "<<qtstatus<<endl;
 	chi2TestSummaryMap->setBinContent(bin,5,qtresult);
      }
@@ -706,7 +697,6 @@ void MuonTestSummary::doKinematicsTests(DQMStore::IGetter & igetter, string muon
 	LogTrace(metname) << "qReport Kolmogorov exists!!";
 	float qtresult = myQReportKolmo->getQTresult(); // get QT result value
 	int qtstatus = myQReportKolmo->getStatus() ; // get QT status value (see table below)
-	const std::string& qtmessage = myQReportKolmo->getMessage() ; // get the whole QT result message
 	LogTrace(metname) << "qtresult " <<qtresult<< " qtstatus "<<qtstatus<<endl;
 	KolmogorovTestSummaryMap->setBinContent(bin,5,qtresult);
       }

--- a/HLTriggerOffline/JetMET/src/HLTJetMETValidation.cc
+++ b/HLTriggerOffline/JetMET/src/HLTJetMETValidation.cc
@@ -397,7 +397,6 @@ void HLTJetMETValidation::getHLTResults(const edm::TriggerResults& hltresults,
     HLTinit_=true;
     
     for (int itrig = 0; itrig != ntrigs; ++itrig){
-      const std::string& trigName = triggerNames.triggerName(itrig);
       // std::cout << "trigger " << itrig << ": " << trigName << std::endl; 
     }
   }

--- a/RecoTauTag/RecoTau/interface/RecoTauCrossCleaning.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauCrossCleaning.h
@@ -106,7 +106,6 @@ class FilterPFCandByParticleId {
       id_(particleId){};
     template<typename PFCandCompatiblePtrType>
       bool operator()(const PFCandCompatiblePtrType& ptr) const {
-        const PFCandidatePtr& pfptr(ptr);
         return ptr->particleId() == id_;
       }
   private:

--- a/RecoTracker/TrackProducer/src/DAFTrackProducerAlgorithm.cc
+++ b/RecoTracker/TrackProducer/src/DAFTrackProducerAlgorithm.cc
@@ -289,7 +289,6 @@ bool DAFTrackProducerAlgorithm::buildTrack (const Trajectory vtraj,
 int DAFTrackProducerAlgorithm::countingGoodHits(const Trajectory traj) const{
 
   int ngoodhits = 0;
-  const Trajectory& myTraj = traj;
   std::vector<TrajectoryMeasurement> vtm = traj.measurements();
 
   for (std::vector<TrajectoryMeasurement>::const_iterator tm = vtm.begin(); tm != vtm.end(); tm++){

--- a/RecoVertex/KinematicFitPrimitives/src/MultipleKinematicConstraint.cc
+++ b/RecoVertex/KinematicFitPrimitives/src/MultipleKinematicConstraint.cc
@@ -42,7 +42,6 @@ std::pair<AlgebraicMatrix, AlgebraicVector> MultipleKinematicConstraint::derivat
  if(exPoint.num_row() ==0 ) throw VertexException("MultipleKinematicConstraint::value requested for zero Linearization point");
 
 //security check for extended cartesian parametrization 
- const AlgebraicVector& expansion = exPoint;
  int inSize = exPoint.num_row(); 
  if((inSize%7) !=0) throw VertexException("MultipleKinematicConstraint::linearization point has a wrong dimension");
 


### PR DESCRIPTION
Removes all compilation warnings due to unused vars listed here:
https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/slc6_amd64_gcc630/www/sun/9.4-sun-11/CMSSW_9_4_X_2017-10-08-1100