### PR TITLE
Fix compilation warnings (ClassDef macro)

### DIFF
--- a/Calibration/HcalCalibAlgos/src/TCell.h
+++ b/Calibration/HcalCalibAlgos/src/TCell.h
@@ -30,7 +30,7 @@ public:
     void SetId(UInt_t i) { _id=i; }
     
     
-    ClassDef(TCell, 1);
+    ClassDefOverride(TCell, 1);
 };
 
 #endif	/* _TCELL_H */

--- a/IOPool/TFileAdaptor/interface/TStorageFactorySystem.h
+++ b/IOPool/TFileAdaptor/interface/TStorageFactorySystem.h
@@ -14,7 +14,7 @@ private:
   void *		GetDirPt(void) const { return fDirp; }
 
 public:
-  ClassDef(TStorageFactorySystem, 0); // ROOT System operating on CMS Storage.
+  ClassDefOverride(TStorageFactorySystem, 0); // ROOT System operating on CMS Storage.
 
   TStorageFactorySystem(const char *, Bool_t); // For compatibility with TXNetFile, we don't actually use the arguments
   TStorageFactorySystem(void);


### PR DESCRIPTION
Fixes comp warnings from here:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_aarch64_gcc700/CMSSW_9_4_X_2017-10-08-1100/Calibration/HcalCalibAlgos
and here:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_aarch64_gcc700/CMSSW_9_4_X_2017-10-08-1100/IOPool/TFileAdaptor