### PR TITLE
Clang-tidy checks for RecoLocalFastTime

### DIFF
--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/FTLSimpleRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/FTLSimpleRecHitAlgo.cc
@@ -10,14 +10,14 @@ class FTLSimpleRecHitAlgo : public FTLRecHitAlgoBase {
     calibration_( conf.getParameter<double>("calibrationConstant") ) { }
 
   /// Destructor
-  virtual ~FTLSimpleRecHitAlgo() { }
+  ~FTLSimpleRecHitAlgo() override { }
 
   /// get event and eventsetup information
-  virtual void getEvent(const edm::Event&) override final {}
-  virtual void getEventSetup(const edm::EventSetup&) override final {}
+  void getEvent(const edm::Event&) final {}
+  void getEventSetup(const edm::EventSetup&) final {}
 
   /// make the rec hit
-  virtual FTLRecHit makeRecHit(const FTLUncalibratedRecHit& uRecHit, uint32_t& flags ) const override final;
+  FTLRecHit makeRecHit(const FTLUncalibratedRecHit& uRecHit, uint32_t& flags ) const final;
 
  private:  
   double thresholdToKeep_, calibration_;

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/FTLSimpleUncalibRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/FTLSimpleUncalibRecHitAlgo.cc
@@ -17,14 +17,14 @@ class FTLSimpleUncalibRecHitAlgo : public FTLUncalibratedRecHitAlgoBase {
   }
 
   /// Destructor
-  virtual ~FTLSimpleUncalibRecHitAlgo() { }
+  ~FTLSimpleUncalibRecHitAlgo() override { }
 
   /// get event and eventsetup information
-  virtual void getEvent(const edm::Event&) override final {}
-  virtual void getEventSetup(const edm::EventSetup&) override final {}
+  void getEvent(const edm::Event&) final {}
+  void getEventSetup(const edm::EventSetup&) final {}
 
   /// make the rec hit
-  virtual FTLUncalibratedRecHit makeRecHit(const FTLDataFrame& dataFrame ) const override final;
+  FTLUncalibratedRecHit makeRecHit(const FTLDataFrame& dataFrame ) const final;
 
  private:  
   double adcLSB_, toaLSBToNS_, timeError_;

--- a/RecoLocalFastTime/FTLRecProducers/plugins/FTLRecHitProducer.cc
+++ b/RecoLocalFastTime/FTLRecProducers/plugins/FTLRecHitProducer.cc
@@ -15,8 +15,8 @@ class FTLRecHitProducer : public edm::stream::EDProducer<> {
   
  public:
   explicit FTLRecHitProducer(const edm::ParameterSet& ps);
-  ~FTLRecHitProducer();
-  virtual void produce(edm::Event& evt, const edm::EventSetup& es) override;
+  ~FTLRecHitProducer() override;
+  void produce(edm::Event& evt, const edm::EventSetup& es) override;
   
  private:
   

--- a/RecoLocalFastTime/FTLRecProducers/plugins/FTLUncalibratedRecHitProducer.cc
+++ b/RecoLocalFastTime/FTLRecProducers/plugins/FTLUncalibratedRecHitProducer.cc
@@ -15,8 +15,8 @@ class FTLUncalibratedRecHitProducer : public edm::stream::EDProducer<> {
   
  public:
   explicit FTLUncalibratedRecHitProducer(const edm::ParameterSet& ps);
-  ~FTLUncalibratedRecHitProducer();
-  virtual void produce(edm::Event& evt, const edm::EventSetup& es) override;
+  ~FTLUncalibratedRecHitProducer() override;
+  void produce(edm::Event& evt, const edm::EventSetup& es) override;
   
  private:
   


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this quickly to avoid conflicts to the extent possible]