### PR TITLE
Clang-tidy checks for RecoLocalMuon

### DIFF
--- a/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.cc
+++ b/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.cc
@@ -887,7 +887,7 @@ void CSCEfficiency::fillRechitsSegments_info(edm::Handle<CSCRecHit2DCollection> 
 	for(int iC=0;iC<NumCh;iC++){
 	  int numLayers = 0;
 	  for(int iL=0;iL<6;iL++){
-	    if(allRechits[iE][iS][iR][iC][iL].size()){
+	    if(!allRechits[iE][iS][iR][iC][iL].empty()){
 	      ++numLayers; 
 	    }
 	  }
@@ -1074,11 +1074,11 @@ bool CSCEfficiency::efficienciesPerChamber(CSCDetId & id, const CSCChamber* cscC
   }
 
   // Segments
-  bool firstCondition = allSegments[ec][st][rg][ch].size() ? true : false;
+  bool firstCondition = !allSegments[ec][st][rg][ch].empty() ? true : false;
   bool secondCondition = false;
   //---- ME1 is special as usual - ME1a and ME1b are actually one chamber
   if(secondRing>-1){
-    secondCondition = allSegments[ec][st][secondRing][ch].size() ? true : false;
+    secondCondition = !allSegments[ec][st][secondRing][ch].empty() ? true : false;
   }
   if(firstCondition || secondCondition){
     if(out){
@@ -1185,11 +1185,11 @@ bool CSCEfficiency::stripWire_Efficiencies(CSCDetId & id, FreeTrajectoryState &f
 	"size W = "<<allWG[id.endcap()-1][id.station()-1][id.ring()-1][id.chamber()-FirstCh][iLayer].size()<<std::endl;
 
     }
-    firstCondition = allStrips[ec][st][rg][ch][iLayer].size() ? true : false;
+    firstCondition = !allStrips[ec][st][rg][ch][iLayer].empty() ? true : false;
     //allSegments[ec][st][rg][ch].size() ? true : false;
     secondCondition = false;
     if(secondRing>-1){
-      secondCondition = allStrips[ec][st][secondRing][ch][iLayer].size() ? true : false;
+      secondCondition = !allStrips[ec][st][secondRing][ch][iLayer].empty() ? true : false;
     }
     if(firstCondition || secondCondition){
       ChHist[ec][st][rg][ch].EfficientStrips->Fill(iLayer+1);
@@ -1201,10 +1201,10 @@ bool CSCEfficiency::stripWire_Efficiencies(CSCDetId & id, FreeTrajectoryState &f
       }
     }
     // Wires
-    firstCondition = allWG[ec][st][rg][ch][iLayer].size() ? true : false;
+    firstCondition = !allWG[ec][st][rg][ch][iLayer].empty() ? true : false;
     secondCondition = false;
     if(secondRing>-1){
-      secondCondition = allWG[ec][st][secondRing][ch][iLayer].size() ? true : false;
+      secondCondition = !allWG[ec][st][secondRing][ch][iLayer].empty() ? true : false;
     }
     if(firstCondition || secondCondition){
       ChHist[ec][st][rg][ch].EfficientWireGroups->Fill(iLayer+1);
@@ -1250,11 +1250,11 @@ bool CSCEfficiency::recSimHitEfficiency(CSCDetId & id, FreeTrajectoryState &ftsC
   returnTypes(id, ec, st, rg, ch, secondRing);
   bool firstCondition, secondCondition;
   for(int iLayer=0; iLayer<6;iLayer++){
-    firstCondition = allSimhits[ec][st][rg][ch][iLayer].size() ? true : false;
+    firstCondition = !allSimhits[ec][st][rg][ch][iLayer].empty() ? true : false;
     secondCondition = false;
     int thisRing = rg;
     if(secondRing>-1){
-      secondCondition = allSimhits[ec][st][secondRing][ch][iLayer].size() ? true : false;
+      secondCondition = !allSimhits[ec][st][secondRing][ch][iLayer].empty() ? true : false;
       if(secondCondition){
 	thisRing = secondRing;
       }
@@ -1266,7 +1266,7 @@ bool CSCEfficiency::recSimHitEfficiency(CSCDetId & id, FreeTrajectoryState &ftsC
 	if(13 ==
 	   fabs(allSimhits[ec][st][thisRing][ch][iLayer][iSH].second)){
 	  ChHist[ec][st][rg][ch].SimSimhits->Fill(iLayer+1);
-	  if(allRechits[ec][st][thisRing][ch][iLayer].size()){
+	  if(!allRechits[ec][st][thisRing][ch][iLayer].empty()){
 	    ChHist[ec][st][rg][ch].SimRechits->Fill(iLayer+1);
 	  }
 	  break;
@@ -1302,11 +1302,11 @@ bool CSCEfficiency::recHitSegment_Efficiencies(CSCDetId & id, const CSCChamber* 
   // Rechits
   if(printalot) std::cout<<"RecHits eff"<<std::endl;
   for(int iLayer=0;iLayer<6;++iLayer){
-    firstCondition = allRechits[ec][st][rg][ch][iLayer].size() ? true : false;
+    firstCondition = !allRechits[ec][st][rg][ch][iLayer].empty() ? true : false;
     secondCondition = false;
     int thisRing = rg;
     if(secondRing>-1){
-      secondCondition = allRechits[ec][st][secondRing][ch][iLayer].size() ? true : false;
+      secondCondition = !allRechits[ec][st][secondRing][ch][iLayer].empty() ? true : false;
       if(secondCondition){
 	thisRing = secondRing;
       }
@@ -1336,12 +1336,12 @@ bool CSCEfficiency::recHitSegment_Efficiencies(CSCDetId & id, const CSCChamber* 
   GlobalVector globalDir;
   GlobalPoint globalPos;
  // Segments
-  firstCondition = allSegments[ec][st][rg][ch].size() ? true : false;
+  firstCondition = !allSegments[ec][st][rg][ch].empty() ? true : false;
   secondCondition = false;
   int secondSize = 0;
   int thisRing = rg;
   if(secondRing>-1){
-    secondCondition = allSegments[ec][st][secondRing][ch].size() ? true : false;
+    secondCondition = !allSegments[ec][st][secondRing][ch].empty() ? true : false;
     secondSize = allSegments[ec][st][secondRing][ch].size();
     if(secondCondition){
       thisRing = secondRing;
@@ -1368,10 +1368,10 @@ bool CSCEfficiency::recHitSegment_Efficiencies(CSCDetId & id, const CSCChamber* 
 	}
 	ChHist[ec][st][rg][ch].AllSingleHits->Fill(iLayer+1);
       }
-      firstCondition = allRechits[ec][st][rg][ch][iLayer].size() ? true : false;
+      firstCondition = !allRechits[ec][st][rg][ch][iLayer].empty() ? true : false;
       secondCondition = false;
       if(secondRing>-1){
-	secondCondition = allRechits[ec][st][secondRing][ch][iLayer].size() ? true : false;
+	secondCondition = !allRechits[ec][st][secondRing][ch][iLayer].empty() ? true : false;
       }
       float stripAngle = 99999.;
       std::vector<float> posXY(2);
@@ -1572,7 +1572,7 @@ bool CSCEfficiency::applyTrigger(edm::Handle<edm::TriggerResults> &hltR,
     }
   }
   else{
-    if(pointToTriggers.size()){
+    if(!pointToTriggers.empty()){
       if(printalot){
         std::cout<<"The following triggers will be required in the event: "<<std::endl;
         for(size_t imyT =0; imyT <pointToTriggers.size();++imyT){
@@ -1585,7 +1585,7 @@ bool CSCEfficiency::applyTrigger(edm::Handle<edm::TriggerResults> &hltR,
   }
 
   if (hltR.isValid()) {
-    if(!pointToTriggers.size()){
+    if(pointToTriggers.empty()){
       if(printalot){
         std::cout<<" No triggers specified in the configuration or all ignored - no trigger information will be considered"<<std::endl;
       }

--- a/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.h
+++ b/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.h
@@ -117,14 +117,14 @@ public:
   CSCEfficiency(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~CSCEfficiency();
+  ~CSCEfficiency() override;
 
  private:
-  virtual void beginJob() ;
+  void beginJob() override ;
   //---- analysis + filter
-  virtual bool filter(edm::Event & event, const edm::EventSetup& eventSetup);
+  bool filter(edm::Event & event, const edm::EventSetup& eventSetup) override;
 
-  virtual void endJob() ;
+  void endJob() override ;
 
   //---- (input) parameters
   //---- Root file name

--- a/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
@@ -19,7 +19,7 @@
 #include <vector>
 //#include <iostream>
 
-CSCHitFromStripOnly::CSCHitFromStripOnly( const edm::ParameterSet& ps ) : recoConditions_(0), calcped_(0), ganged_(0) {
+CSCHitFromStripOnly::CSCHitFromStripOnly( const edm::ParameterSet& ps ) : recoConditions_(nullptr), calcped_(nullptr), ganged_(false) {
   
   useCalib                   = ps.getParameter<bool>("CSCUseCalibrations");
   bool useStaticPedestals    = ps.getParameter<bool>("CSCUseStaticPedestals");
@@ -511,7 +511,7 @@ float CSCHitFromStripOnly::findHitOnStripPosition( const std::vector<CSCStripHit
   
   float strippos = -1.;
   
-  if ( data.size() < 1 ) return strippos;
+  if ( data.empty() ) return strippos;
   
   // biggestStrip is strip with largest pulse height
   // Use pointer subtraction

--- a/RecoLocalMuon/CSCRecHitD/src/CSCHitFromWireOnly.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCHitFromWireOnly.cc
@@ -18,7 +18,7 @@
 #include <iostream>
 
 
-CSCHitFromWireOnly::CSCHitFromWireOnly( const edm::ParameterSet& ps ) : recoConditions_(0){
+CSCHitFromWireOnly::CSCHitFromWireOnly( const edm::ParameterSet& ps ) : recoConditions_(nullptr){
   
   deltaT                 = ps.getParameter<int>("CSCWireClusterDeltaT");
   useReducedWireTime     = ps.getParameter<bool>("CSCUseReducedWireTimeWindow");

--- a/RecoLocalMuon/CSCRecHitD/src/CSCPedestalChoice.h
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCPedestalChoice.h
@@ -25,7 +25,7 @@ public:
 	* and CSCDetId + channel
 	*/
 	virtual float pedestal( const std::vector<float>& sca, 
-	   const CSCRecoConditions* cond=0, const CSCDetId id=0, int ichan=0 ) = 0;
+	   const CSCRecoConditions* cond=nullptr, const CSCDetId id=0, int ichan=0 ) = 0;
 private:
 	float defaultPed;
 };
@@ -40,9 +40,9 @@ private:
 class CSCDynamicPedestal2 : public CSCPedestalChoice {
 public:
 	CSCDynamicPedestal2(){}
-	~CSCDynamicPedestal2(){}
+	~CSCDynamicPedestal2() override{}
 	float pedestal( const std::vector<float>& sca, 
-	    const CSCRecoConditions*, const CSCDetId, int ){
+	    const CSCRecoConditions*, const CSCDetId, int ) override{
 		float ped = getDefault();
 		if ( !sca.empty() ){
 			ped = ( sca[0]+sca[1] )/2.;
@@ -61,9 +61,9 @@ public:
 class CSCDynamicPedestal1 : public CSCPedestalChoice {
 public:
 	CSCDynamicPedestal1(){}
-	~CSCDynamicPedestal1(){}
+	~CSCDynamicPedestal1() override{}
 	float pedestal( const std::vector<float>& sca,
-	    const CSCRecoConditions*, const CSCDetId, int ){
+	    const CSCRecoConditions*, const CSCDetId, int ) override{
 		float ped = getDefault();
 		if ( !sca.empty() ){
 			ped = sca[0];
@@ -82,9 +82,9 @@ public:
 class CSCStaticPedestal : public CSCPedestalChoice {
 public:
 	CSCStaticPedestal(){}
-	~CSCStaticPedestal(){}
+	~CSCStaticPedestal() override{}
 	float pedestal( const std::vector<float>& sca,
-	    const CSCRecoConditions* cond, const CSCDetId id, int ichan ){
+	    const CSCRecoConditions* cond, const CSCDetId id, int ichan ) override{
 		float ped = cond->pedestal(id, ichan );
 		return ped;
 	}

--- a/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDBuilder.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDBuilder.cc
@@ -27,7 +27,7 @@
 #include <iostream>
 #include <cassert>
 
-CSCRecHitDBuilder::CSCRecHitDBuilder( const edm::ParameterSet& ps ) : geom_(0) {
+CSCRecHitDBuilder::CSCRecHitDBuilder( const edm::ParameterSet& ps ) : geom_(nullptr) {
   
   // Receives ParameterSet percolated down from EDProducer	
 

--- a/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDProducer.h
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDProducer.h
@@ -31,9 +31,9 @@ class CSCRecHitDProducer : public edm::stream::EDProducer<> {
 
 public:
   explicit CSCRecHitDProducer( const edm::ParameterSet& ps );
-  ~CSCRecHitDProducer();
+  ~CSCRecHitDProducer() override;
 
-  virtual void produce( edm::Event&, const edm::EventSetup& );
+  void produce( edm::Event&, const edm::EventSetup& ) override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 

--- a/RecoLocalMuon/CSCRecHitD/src/CSCRecoBadChannelsAnalyzer.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCRecoBadChannelsAnalyzer.cc
@@ -39,8 +39,8 @@
         recoConditions_( new CSCRecoConditions( ps ) ) {
     }
 
-    virtual ~CSCRecoBadChannelsAnalyzer() { delete recoConditions_; }
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    ~CSCRecoBadChannelsAnalyzer() override { delete recoConditions_; }
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
     /// did we request reading bad channel info from db?
     bool readBadChannels() const { return readBadChannels_; }

--- a/RecoLocalMuon/CSCRecHitD/src/CSCXonStrip_MatchGatti.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCXonStrip_MatchGatti.cc
@@ -36,7 +36,7 @@
                                                                                                  
 
 CSCXonStrip_MatchGatti::CSCXonStrip_MatchGatti(const edm::ParameterSet& ps) :
-  recoConditions_( 0 )  {
+  recoConditions_( nullptr )  {
 
   useCalib                   = ps.getParameter<bool>("CSCUseCalibrations");
   xtalksOffset               = ps.getParameter<double>("CSCStripxtalksOffset");

--- a/RecoLocalMuon/CSCSegment/src/CSCCondSegFit.h
+++ b/RecoLocalMuon/CSCSegment/src/CSCCondSegFit.h
@@ -29,7 +29,7 @@ public:
     covToAnyNumberAll_ ( ps.getParameter<bool>("ForceCovarianceAll") ),
     covAnyNumber_ ( ps.getParameter<double>("Covariance") ) {}
 
-  ~CSCCondSegFit() {}
+  ~CSCCondSegFit() override {}
 
   // The fit - override base class version with this version
   // which passes in bool flags for up to two extra conditioning passes

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoDF.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoDF.cc
@@ -33,7 +33,7 @@
  *
  */
 CSCSegAlgoDF::CSCSegAlgoDF(const edm::ParameterSet& ps) 
-  : CSCSegmentAlgorithm(ps), myName("CSCSegAlgoDF"), sfit_(0) {
+  : CSCSegmentAlgorithm(ps), myName("CSCSegAlgoDF"), sfit_(nullptr) {
 	
   debug                  = ps.getUntrackedParameter<bool>("CSCSegmentDebug");
   minLayersApart         = ps.getParameter<int>("minLayersApart");
@@ -257,7 +257,7 @@ std::vector<CSCSegment> CSCSegAlgoDF::buildSegments(const ChamberHitContainer& _
                               sfit_->covarianceMatrix(), sfit_->chi2());
 	//	std::cout << "[CSCSegAlgoDF::buildSegments] about to delete sfit= = " << sfit_ << std::endl;
 	delete sfit_;
-        sfit_ = 0; // avoid possibility of attempting a second delete later
+        sfit_ = nullptr; // avoid possibility of attempting a second delete later
 
         segmentInChamber.push_back(temp); 
 	if (debug) dumpSegment( temp );
@@ -499,7 +499,7 @@ void CSCSegAlgoDF::compareProtoSegment(const CSCRecHit2D* h, int layer) {
 
   bool ok = addHit(h, layer);
 
-  CSCSegFit* newfit = 0;
+  CSCSegFit* newfit = nullptr;
   if ( ok ) {
     newfit = new CSCSegFit( theChamber, protoSegment );
     //    std::cout << "[CSCSegAlgoDF::compareProtoSegment] newfit = " << newfit << std::endl;
@@ -537,7 +537,7 @@ void CSCSegAlgoDF::flagHitsAsUsed(const ChamberHitContainer& rechitsInChamber) {
   // Don't reject hits marked as "nearby" for now.
   // So this is bypassed at all times for now !!!
   // Perhaps add back to speed up algorithm some more
-  if (closeHits.size() > 0) return;  
+  if (!closeHits.empty()) return;  
   for ( hi = closeHits.begin(); hi != closeHits.end(); ++hi ) {
     for ( iu = ib; iu != rechitsInChamber.end(); ++iu ) {
       if (*hi == *iu) usedHits[iu-ib] = true;

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoDF.h
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoDF.h
@@ -61,7 +61,7 @@ public:
   explicit CSCSegAlgoDF(const edm::ParameterSet& ps);
 
   /// Destructor
-  virtual ~CSCSegAlgoDF();
+  ~CSCSegAlgoDF() override;
 
   /**
    * Build track segments in this chamber (this is where the actual
@@ -72,7 +72,7 @@ public:
   /**
    * Here we must implement the algorithm
    */
-  std::vector<CSCSegment> run(const CSCChamber* aChamber, const ChamberHitContainer& rechits); 
+  std::vector<CSCSegment> run(const CSCChamber* aChamber, const ChamberHitContainer& rechits) override; 
 
 private:
 

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.cc
@@ -232,12 +232,12 @@ std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const CSCChamber* aChamber, 
 	aState.proto_segment = best_proto_segment[j];
 	best_proto_segment[j].clear();
 	//SKIP empty proto-segments
-	if(aState.proto_segment.size() == 0) continue;
+	if(aState.proto_segment.empty()) continue;
 	updateParameters(aState);
 	// Create an actual CSCSegment - retrieve all info from the fit
 	CSCSegment temp(aState.sfit->hits(), aState.sfit->intercept(),
 			aState.sfit->localdir(), aState.sfit->covarianceMatrix(), aState.sfit->chi2());
-	aState.sfit = 0;
+	aState.sfit = nullptr;
 	segments.push_back(temp);
 	//if the segment has 3 hits flag them as used in a particular way
 	if(aState.proto_segment.size() == 3){

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.h
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.h
@@ -65,7 +65,7 @@ public:
     /// Constructor
     explicit CSCSegAlgoRU(const edm::ParameterSet& ps);
     /// Destructor
-    virtual ~CSCSegAlgoRU() {};
+    ~CSCSegAlgoRU() override {};
 
     /**
      * Build track segments in this chamber (this is where the actual
@@ -78,7 +78,7 @@ public:
     /**
      * Here we must implement the algorithm
      */
-    std::vector<CSCSegment> run(const CSCChamber* aChamber, const ChamberHitContainer& rechits){ return buildSegments(aChamber, rechits); }
+    std::vector<CSCSegment> run(const CSCChamber* aChamber, const ChamberHitContainer& rechits) override{ return buildSegments(aChamber, rechits); }
 
 private:
     struct AlgoState {

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoSK.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoSK.cc
@@ -17,7 +17,7 @@
 #include <string>
 
 CSCSegAlgoSK::CSCSegAlgoSK(const edm::ParameterSet& ps) 
-  : CSCSegmentAlgorithm(ps), myName("CSCSegAlgoSK"), sfit_(0) {
+  : CSCSegmentAlgorithm(ps), myName("CSCSegAlgoSK"), sfit_(nullptr) {
 	
   debugInfo = ps.getUntrackedParameter<bool>("verboseInfo");
     
@@ -103,7 +103,7 @@ std::vector<CSCSegment> CSCSegAlgoSK::buildSegments(const ChamberHitContainer& u
   std::vector<CSCSegment> segments;
 
   // This is going to point to fits to hits, and its content will be used to create a CSCSegment
-  sfit_ = 0;
+  sfit_ = nullptr;
   
   ChamberHitContainerCIt ib = rechits.begin();
   ChamberHitContainerCIt ie = rechits.end();
@@ -173,7 +173,7 @@ std::vector<CSCSegment> CSCSegAlgoSK::buildSegments(const ChamberHitContainer& u
               CSCSegment temp(sfit_->hits(), sfit_->intercept(), 
 	  	        sfit_->localdir(), sfit_->covarianceMatrix(), sfit_->chi2() );
               delete sfit_;
-              sfit_ = 0;              
+              sfit_ = nullptr;              
               LogDebug("CSC") << "Found a segment !!!\n";
               if ( debugInfo ) dumpSegment( temp );
               segments.push_back(temp);	

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoSK.h
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoSK.h
@@ -60,7 +60,7 @@ public:
     /// Constructor
     explicit CSCSegAlgoSK(const edm::ParameterSet& ps);
     /// Destructor
-    virtual ~CSCSegAlgoSK() {};
+    ~CSCSegAlgoSK() override {};
 
     /**
      * Build track segments in this chamber (this is where the actual
@@ -71,7 +71,7 @@ public:
     /**
      * Here we must implement the algorithm
      */
-    std::vector<CSCSegment> run(const CSCChamber* aChamber, const ChamberHitContainer& rechits); 
+    std::vector<CSCSegment> run(const CSCChamber* aChamber, const ChamberHitContainer& rechits) override; 
 
 private:
 

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoST.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoST.cc
@@ -31,7 +31,7 @@
  *
  */
 CSCSegAlgoST::CSCSegAlgoST(const edm::ParameterSet& ps) : 
-  CSCSegmentAlgorithm(ps), myName_("CSCSegAlgoST"), ps_(ps),  showering_(0) {
+  CSCSegmentAlgorithm(ps), myName_("CSCSegAlgoST"), ps_(ps),  showering_(nullptr) {
 	
   debug                  = ps.getUntrackedParameter<bool>("CSCDebug");
   //  minLayersApart         = ps.getParameter<int>("minLayersApart");
@@ -831,7 +831,7 @@ std::vector<CSCSegment> CSCSegAlgoST::buildSegments(const ChamberHitContainer& r
   // Find out which station, ring and chamber we are in 
   // Used to choose station/ring dependant y-weight cuts
 
-  if( rechits.size() > 0 ) {
+  if( !rechits.empty() ) {
     thering = rechits[0]->cscDetId().ring();
     thestation = rechits[0]->cscDetId().station();
     //thecham = rechits[0]->cscDetId().chamber();
@@ -857,7 +857,7 @@ std::vector<CSCSegment> CSCSegAlgoST::buildSegments(const ChamberHitContainer& r
     //   n_layers_missed_tot += 1;
     // }
 
-    if( PAhits_onLayer[layer].size() > 0 ) {
+    if( !PAhits_onLayer[layer].empty() ) {
       n_layers_processed += 1;
     }
 

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoST.h
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoST.h
@@ -44,7 +44,7 @@ public:
   explicit CSCSegAlgoST(const edm::ParameterSet& ps);
 
   /// Destructor
-  virtual ~CSCSegAlgoST();
+  ~CSCSegAlgoST() override;
 
   /**
    * Build track segments in this chamber (this is where the actual
@@ -61,7 +61,7 @@ public:
   /**
    * Build segments for all desired groups of hits
    */
-  std::vector<CSCSegment> run(const CSCChamber* aChamber, const ChamberHitContainer& rechits); 
+  std::vector<CSCSegment> run(const CSCChamber* aChamber, const ChamberHitContainer& rechits) override; 
 
   /**
    * Build groups of rechits that are separated in x and y to save time on the segment finding

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoShowering.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoShowering.cc
@@ -24,7 +24,7 @@
 /* Constructor
  *
  */
-CSCSegAlgoShowering::CSCSegAlgoShowering(const edm::ParameterSet& ps) : sfit_(0) {
+CSCSegAlgoShowering::CSCSegAlgoShowering(const edm::ParameterSet& ps) : sfit_(nullptr) {
 //  debug                  = ps.getUntrackedParameter<bool>("CSCSegmentDebug");
   dRPhiFineMax           = ps.getParameter<double>("dRPhiFineMax");
   dPhiFineMax            = ps.getParameter<double>("dPhiFineMax");
@@ -235,7 +235,7 @@ CSCSegment CSCSegAlgoShowering::showerSeg( const CSCChamber* aChamber, const Cha
   CSCSegment temp(sfit_->hits(), sfit_->intercept(), 
   		  sfit_->localdir(), sfit_->covarianceMatrix(), theFlag );
   delete sfit_;
-  sfit_ = 0;
+  sfit_ = nullptr;
 
   return temp;
 } 

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoTC.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoTC.cc
@@ -24,7 +24,7 @@
 #include <string>
 
 CSCSegAlgoTC::CSCSegAlgoTC(const edm::ParameterSet& ps) 
-  : CSCSegmentAlgorithm(ps), sfit_(0), myName("CSCSegAlgoTC") {
+  : CSCSegmentAlgorithm(ps), sfit_(nullptr), myName("CSCSegAlgoTC") {
   
   debugInfo = ps.getUntrackedParameter<bool>("verboseInfo");
   
@@ -122,7 +122,7 @@ std::vector<CSCSegment> CSCSegAlgoTC::buildSegments(const ChamberHitContainer& u
   
   std::vector<CSCSegment> segments;
 
-  sfit_ = 0;
+  sfit_ = nullptr;
   
   ChamberHitContainerCIt ib = rechits.begin();
   ChamberHitContainerCIt ie = rechits.end();
@@ -204,7 +204,7 @@ std::vector<CSCSegment> CSCSegAlgoTC::buildSegments(const ChamberHitContainer& u
 
   // reset member variables  
   candidates.clear();
-  sfit_ = 0;
+  sfit_ = nullptr;
 
   //  edm::LogVerbatim("CSCSegment") << "[CSCSegAlgoTC::buildSegments] no. of segments returned = " << segments.size();
 

--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoTC.h
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoTC.h
@@ -49,7 +49,7 @@ class CSCSegAlgoTC : public CSCSegmentAlgorithm {
   /// Constructor
   explicit CSCSegAlgoTC(const edm::ParameterSet& ps);
   /// Destructor
-  virtual ~CSCSegAlgoTC() {};
+  ~CSCSegAlgoTC() override {};
   
   /**
    * Build track segments in this chamber (this is where the actual
@@ -60,7 +60,7 @@ class CSCSegAlgoTC : public CSCSegmentAlgorithm {
   /**
    * Here we must implement the algorithm
    */
-  std::vector<CSCSegment> run(const CSCChamber* aChamber, const ChamberHitContainer& rechits);
+  std::vector<CSCSegment> run(const CSCChamber* aChamber, const ChamberHitContainer& rechits) override;
   
  private:
   

--- a/RecoLocalMuon/CSCSegment/src/CSCSegmentBuilder.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegmentBuilder.cc
@@ -18,7 +18,7 @@
 #include <FWCore/Utilities/interface/Exception.h>
 #include <FWCore/MessageLogger/interface/MessageLogger.h> 
 
-CSCSegmentBuilder::CSCSegmentBuilder(const edm::ParameterSet& ps) : geom_(0) {
+CSCSegmentBuilder::CSCSegmentBuilder(const edm::ParameterSet& ps) : geom_(nullptr) {
     
     // The algo chosen for the segment building
     int chosenAlgo = ps.getParameter<int>("algo_type") - 1;

--- a/RecoLocalMuon/CSCSegment/src/CSCSegmentProducer.h
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegmentProducer.h
@@ -21,9 +21,9 @@ public:
     /// Constructor
     explicit CSCSegmentProducer(const edm::ParameterSet&);
     /// Destructor
-    ~CSCSegmentProducer();
+    ~CSCSegmentProducer() override;
     /// Produce the CSCSegment collection
-    virtual void produce(edm::Event&, const edm::EventSetup&) override;
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
     int iev; // events through

--- a/RecoLocalMuon/CSCValidation/src/CSCValHists.cc
+++ b/RecoLocalMuon/CSCValidation/src/CSCValHists.cc
@@ -24,7 +24,7 @@ using namespace std;
 
     std::map<std::string,std::pair<TH1*,string> >::const_iterator mapit;
     for (mapit = theMap.begin(); mapit != theMap.end(); mapit++){
-      std::string folder = (*mapit).second.second.c_str();
+      std::string folder = (*mapit).second.second;
       fit = find(theFolders.begin(), theFolders.end(), folder);
       if (fit == theFolders.end()){
         theFolders.push_back(folder);

--- a/RecoLocalMuon/CSCValidation/src/CSCValidation.cc
+++ b/RecoLocalMuon/CSCValidation/src/CSCValidation.cc
@@ -1493,14 +1493,14 @@ void CSCValidation::doEfficiencies(edm::Handle<CSCWireDigiCollection> wires, edm
   chamberTypes["ME3/2"] = 7.5;
   chamberTypes["ME4/1"] = 8.5;
 
-  if(theSeg.size()){
+  if(!theSeg.empty()){
     std::map <int , GlobalPoint> extrapolatedPoint;
     std::map <int , GlobalPoint>::iterator it;
     const CSCGeometry::ChamberContainer& ChamberContainer = cscGeom->chambers();
     // Pick which chamber with which segment to test
     for(size_t nCh=0;nCh<ChamberContainer.size();nCh++){
       const CSCChamber *cscchamber = ChamberContainer[nCh];
-      std::pair <CSCDetId, CSCSegment> * thisSegment = 0;
+      std::pair <CSCDetId, CSCSegment> * thisSegment = nullptr;
       for(size_t iSeg =0;iSeg<theSeg.size();++iSeg ){
         if(cscchamber->id().endcap() == theSeg[iSeg]->first.endcap()){ 
           if(1==cscchamber->id().station() || 3==cscchamber->id().station() ){
@@ -2408,7 +2408,7 @@ void CSCValidation::doGasGain(const CSCWireDigiCollection& wirecltn,
                  title=ss.str(); ss.str("");
                  x=location;
                  y=adc_3_3_sum;
-                 histos->fill2DHist(x,y,name.c_str(),title.c_str(),30,1.0,31.0,50,0.0,2000.0,"GasGain");
+                 histos->fill2DHist(x,y,name,title,30,1.0,31.0,50,0.0,2000.0,"GasGain");
 
                  /*
                    std::cout<<idchamber<<"   "<<id.station()<<" "<<id.ring()<<" "
@@ -2472,7 +2472,7 @@ void CSCValidation::doAFEBTiming(const CSCWireDigiCollection& wirecltn) {
              name=ss.str(); ss.str("");
              ss<<"Time Bin vs AFEB Occupancy ME"<<endcapstr<<id.station()<<"/"<<id.ring()<<"/"<< id.chamber();
              title=ss.str(); ss.str("");
-             histos->fill2DHist(x,y,name.c_str(),title.c_str(),42,1.,43.,16,0.,16.,"AFEBTiming");
+             histos->fill2DHist(x,y,name,title,42,1.,43.,16,0.,16.,"AFEBTiming");
 
              // Number of anode wire group time bin vs afeb for each CSC
              x=afeb;
@@ -2482,7 +2482,7 @@ void CSCValidation::doAFEBTiming(const CSCWireDigiCollection& wirecltn) {
              ss<<"Number of Time Bins vs AFEB ME"<<endcapstr<<id.station()<<"/"<<id.ring()<<"/"<< id.chamber();
              title=ss.str(); 
              ss.str("");
-             histos->fill2DHist(x,y,name.c_str(),title.c_str(),42,1.,43.,16,0.,16.,"AFEBTiming");
+             histos->fill2DHist(x,y,name,title,42,1.,43.,16,0.,16.,"AFEBTiming");
              
           }     // end of digis loop in layer
        } // end of wire collection loop
@@ -2543,7 +2543,7 @@ void CSCValidation::doCompTiming(const CSCComparatorDigiCollection& compars) {
              ss<<"Comparator Time Bin vs CFEB Occupancy ME"<<endcap<<
                  id.station()<<"/"<< id.ring()<<"/"<< id.chamber();             
              title=ss.str(); ss.str("");
-             histos->fill2DHist(x,y,name.c_str(),title.c_str(),5,1.,6.,16,0.,16.,"CompTiming");
+             histos->fill2DHist(x,y,name,title,5,1.,6.,16,0.,16.,"CompTiming");
 
          }     // end of digis loop in layer
        } // end of collection loop
@@ -2628,7 +2628,7 @@ void CSCValidation::doADCTiming(const CSCRecHit2DCollection& rechitcltn) {
       
                      cfeb=(centerStrip-1)/16+1;
                      x=cfeb; y=adc_3_3_wtbin;
-                     histos->fill2DHist(x,y,name.c_str(),title.c_str(),5,1.,6.,80,-8.,8.,"ADCTiming");                                     
+                     histos->fill2DHist(x,y,name,title,5,1.,6.,80,-8.,8.,"ADCTiming");                                     
                      } // end of if flag==0
                  } // end of if (adc_3_3_sum > 100.0)
             } // end of if if(m_strip.size()==3
@@ -2879,15 +2879,15 @@ void CSCValidation::doTimeMonitoring(edm::Handle<CSCRecHit2DCollection> recHits,
     unsigned long length =  fedData.size();
     
     if (length>=32){ ///if fed has data then unpack it
-      CSCDCCExaminer* examiner = NULL;
+      CSCDCCExaminer* examiner = nullptr;
       std::stringstream examiner_out, examiner_err;
       goodEvent = true;
       ///examine event for integrity
       //CSCDCCExaminer examiner;
       examiner = new CSCDCCExaminer();
-      if( examinerMask&0x40000 ) examiner->crcCFEB(1);
-      if( examinerMask&0x8000  ) examiner->crcTMB (1);
-      if( examinerMask&0x0400  ) examiner->crcALCT(1);
+      if( examinerMask&0x40000 ) examiner->crcCFEB(true);
+      if( examinerMask&0x8000  ) examiner->crcTMB (true);
+      if( examinerMask&0x0400  ) examiner->crcALCT(true);
       examiner->setMask(examinerMask);
       const short unsigned int *data = (short unsigned int *)fedData.data();
      
@@ -3012,7 +3012,7 @@ void CSCValidation::doTimeMonitoring(edm::Handle<CSCRecHit2DCollection> recHits,
   	  } // end CSCData loop
   	} // end ddu data loop
       } // end if goodEvent
-      if (examiner!=NULL) delete examiner;
+      if (examiner!=nullptr) delete examiner;
     }// end if non-zero fed data
   } // end DCC loop for NON-REFERENCE
 

--- a/RecoLocalMuon/CSCValidation/src/CSCValidation.h
+++ b/RecoLocalMuon/CSCValidation/src/CSCValidation.h
@@ -122,11 +122,11 @@ public:
   CSCValidation(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~CSCValidation();
+  ~CSCValidation() override;
 
   /// Perform the analysis
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup);
-  void endJob();
+  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
+  void endJob() override;
 
   // for noise module
   struct ltrh

--- a/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftAlgo.h
+++ b/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftAlgo.h
@@ -19,32 +19,32 @@ class DTLinearDriftAlgo : public DTRecHitBaseAlgo {
   DTLinearDriftAlgo(const edm::ParameterSet& config);
 
   /// Destructor
-  virtual ~DTLinearDriftAlgo();
+  ~DTLinearDriftAlgo() override;
 
   // Operations
 
   /// Pass the Event Setup to the algo at each event
-  virtual void setES(const edm::EventSetup& setup);
+  void setES(const edm::EventSetup& setup) override;
 
 
   /// First step in computation of Left/Right hits from a Digi.  
   /// The results are the local position (in DTLayer frame) of the
   /// Left and Right hit, and the error (which is common). Returns
   /// false on failure. The hit is assumed to be at the wire center.
-  virtual bool compute(const DTLayer* layer,
+  bool compute(const DTLayer* layer,
                        const DTDigi& digi,
                        LocalPoint& leftPoint,
                        LocalPoint& rightPoint,
-                       LocalError& error) const;
+                       LocalError& error) const override;
 
 
   /// Second step in hit position computation.
   /// It is the same as first step since the angular information is not used
   /// NOTE: Only position and error of the new hit are modified
-  virtual bool compute(const DTLayer* layer,
+  bool compute(const DTLayer* layer,
                        const DTRecHit1D& recHit1D,
                        const float& angle,
-                       DTRecHit1D& newHit1D) const;
+                       DTRecHit1D& newHit1D) const override;
 
 
   /// Third (and final) step in hits position computation.
@@ -52,11 +52,11 @@ class DTLinearDriftAlgo : public DTRecHitBaseAlgo {
   /// and can be used to correct the drift time for particle
   /// TOF and propagation of signal along the wire. 
   /// NOTE: Only position and error of the new hit are modified
-  virtual bool compute(const DTLayer* layer,
+  bool compute(const DTLayer* layer,
                        const DTRecHit1D& recHit1D,
                        const float& angle,
                        const GlobalPoint& globPos, 
-                       DTRecHit1D& newHit1D) const;
+                       DTRecHit1D& newHit1D) const override;
 
 
  private:

--- a/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.cc
+++ b/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.cc
@@ -25,8 +25,8 @@ using namespace edm;
 
 DTLinearDriftFromDBAlgo::DTLinearDriftFromDBAlgo(const ParameterSet& config) :
   DTRecHitBaseAlgo(config),
-  mTimeMap(0),
-  field(0),
+  mTimeMap(nullptr),
+  field(nullptr),
   nominalB(-1),
   minTime(config.getParameter<double>("minTime")),
   maxTime(config.getParameter<double>("maxTime")),

--- a/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.h
+++ b/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.h
@@ -21,32 +21,32 @@ class DTLinearDriftFromDBAlgo : public DTRecHitBaseAlgo {
   DTLinearDriftFromDBAlgo(const edm::ParameterSet& config);
 
   /// Destructor
-  virtual ~DTLinearDriftFromDBAlgo();
+  ~DTLinearDriftFromDBAlgo() override;
 
   // Operations
 
   /// Pass the Event Setup to the algo at each event
-  virtual void setES(const edm::EventSetup& setup);
+  void setES(const edm::EventSetup& setup) override;
 
 
   /// First step in computation of Left/Right hits from a Digi.  
   /// The results are the local position (in DTLayer frame) of the
   /// Left and Right hit, and the error (which is common). Returns
   /// false on failure. The hit is assumed to be at the wire center.
-  virtual bool compute(const DTLayer* layer,
+  bool compute(const DTLayer* layer,
                        const DTDigi& digi,
                        LocalPoint& leftPoint,
                        LocalPoint& rightPoint,
-                       LocalError& error) const;
+                       LocalError& error) const override;
 
 
   /// Second step in hit position computation.
   /// It is the same as first step since the angular information is not used
   /// NOTE: Only position and error of the new hit are modified
-  virtual bool compute(const DTLayer* layer,
+  bool compute(const DTLayer* layer,
                        const DTRecHit1D& recHit1D,
                        const float& angle,
-                       DTRecHit1D& newHit1D) const;
+                       DTRecHit1D& newHit1D) const override;
 
 
   /// Third (and final) step in hits position computation.
@@ -54,11 +54,11 @@ class DTLinearDriftFromDBAlgo : public DTRecHitBaseAlgo {
   /// and can be used to correct the drift time for particle
   /// TOF and propagation of signal along the wire. 
   /// NOTE: Only position and error of the new hit are modified
-  virtual bool compute(const DTLayer* layer,
+  bool compute(const DTLayer* layer,
                        const DTRecHit1D& recHit1D,
                        const float& angle,
                        const GlobalPoint& globPos, 
-                       DTRecHit1D& newHit1D) const;
+                       DTRecHit1D& newHit1D) const override;
 
 
  private:

--- a/RecoLocalMuon/DTRecHit/plugins/DTNoDriftAlgo.h
+++ b/RecoLocalMuon/DTRecHit/plugins/DTNoDriftAlgo.h
@@ -20,40 +20,40 @@ class DTNoDriftAlgo : public DTRecHitBaseAlgo {
   DTNoDriftAlgo(const edm::ParameterSet& config);
 
   /// Destructor
-  virtual ~DTNoDriftAlgo();
+  ~DTNoDriftAlgo() override;
 
   // Operations
 
   /// Pass the Event Setup to the algo at each event
-  virtual void setES(const edm::EventSetup& setup);
+  void setES(const edm::EventSetup& setup) override;
 
 
   /// MM: Override virtual function from DTRecHitBaseAlgo--> for the NoDrift
   /// algorithm only a maximum of one hit per wire is allowed! 
   /// Build all hits in the range associated to the layerId, at the 1st step.
-  virtual edm::OwnVector<DTRecHit1DPair> reconstruct(const DTLayer* layer,
+  edm::OwnVector<DTRecHit1DPair> reconstruct(const DTLayer* layer,
 						     const DTLayerId& layerId,
-						     const DTDigiCollection::Range& digiRange);
+						     const DTDigiCollection::Range& digiRange) override;
 
 
   /// First step in computation of Left/Right hits from a Digi.  
   /// The results are the local position (in DTLayer frame) of the
   /// Left and Right hit, and the error (which is common). Returns
   /// false on failure. The hit is assumed to be at the wire center.
-  virtual bool compute(const DTLayer* layer,
+  bool compute(const DTLayer* layer,
                        const DTDigi& digi,
                        LocalPoint& leftPoint,
                        LocalPoint& rightPoint,
-                       LocalError& error) const;
+                       LocalError& error) const override;
 
 
   /// Second step in hit position computation.
   /// It is the same as first step since the angular information is not used
   /// NOTE: Only position and error of the new hit are modified
-  virtual bool compute(const DTLayer* layer,
+  bool compute(const DTLayer* layer,
                        const DTRecHit1D& recHit1D,
                        const float& angle,
-                       DTRecHit1D& newHit1D) const;
+                       DTRecHit1D& newHit1D) const override;
 
 
   /// Third (and final) step in hits position computation.
@@ -61,11 +61,11 @@ class DTNoDriftAlgo : public DTRecHitBaseAlgo {
   /// and can be used to correct the drift time for particle
   /// TOF and propagation of signal along the wire. 
   /// NOTE: Only position and error of the new hit are modified
-  virtual bool compute(const DTLayer* layer,
+  bool compute(const DTLayer* layer,
                        const DTRecHit1D& recHit1D,
                        const float& angle,
                        const GlobalPoint& globPos, 
-                       DTRecHit1D& newHit1D) const;
+                       DTRecHit1D& newHit1D) const override;
 
 
  private:

--- a/RecoLocalMuon/DTRecHit/plugins/DTParametrizedDriftAlgo.h
+++ b/RecoLocalMuon/DTRecHit/plugins/DTParametrizedDriftAlgo.h
@@ -19,12 +19,12 @@ class DTParametrizedDriftAlgo : public DTRecHitBaseAlgo {
   DTParametrizedDriftAlgo(const edm::ParameterSet& config);
 
   /// Destructor
-  virtual ~DTParametrizedDriftAlgo();
+  ~DTParametrizedDriftAlgo() override;
 
   // Operations
 
   /// Pass the Event Setup to the algo at each event
-  virtual void setES(const edm::EventSetup& setup);
+  void setES(const edm::EventSetup& setup) override;
 
     
   /// First step in computation of Left/Right hits from a Digi.  
@@ -32,11 +32,11 @@ class DTParametrizedDriftAlgo : public DTRecHitBaseAlgo {
   /// Left and Right hit, and the error (which is common). 
   /// The center of the wire is assumed as hit coordinate along y.
   /// Returns false on failure. 
-  virtual bool compute(const DTLayer* layer,
+  bool compute(const DTLayer* layer,
                        const DTDigi& digi,
                        LocalPoint& leftPoint,
                        LocalPoint& rightPoint,
-                       LocalError& error) const;
+                       LocalError& error) const override;
 
 
   /// Second step.
@@ -46,10 +46,10 @@ class DTParametrizedDriftAlgo : public DTRecHitBaseAlgo {
   /// angle=atan(dir.x()/-dir.z()) . This can be used when a SL segment is
   /// built, so the impact angle is known but the position along wire is not.
   /// NOTE: Only position and error of the new hit are modified
-  virtual bool compute(const DTLayer* layer,
+  bool compute(const DTLayer* layer,
                        const DTRecHit1D& recHit1D,
                        const float& angle,
-		       DTRecHit1D& newHit1D) const;
+		       DTRecHit1D& newHit1D) const override;
 
 
   /// Third (and final) step in hits position computation.
@@ -59,11 +59,11 @@ class DTParametrizedDriftAlgo : public DTRecHitBaseAlgo {
   /// wire is available and can be used to correct the drift time for particle
   /// TOF and propagation of signal along the wire.
   /// NOTE: Only position and error of the new hit are modified
-  virtual bool compute(const DTLayer* layer,
+  bool compute(const DTLayer* layer,
                        const DTRecHit1D& recHit1D,
                        const float& angle,
                        const GlobalPoint& globPos, 
-                       DTRecHit1D& newHit1D) const;
+                       DTRecHit1D& newHit1D) const override;
 
 
  private:

--- a/RecoLocalMuon/DTRecHit/plugins/DTRecHitProducer.cc
+++ b/RecoLocalMuon/DTRecHit/plugins/DTRecHitProducer.cc
@@ -89,7 +89,7 @@ void DTRecHitProducer::produce(Event& event, const EventSetup& setup) {
     
     if(debug)
       cout << "Number of hits in this layer: " << recHits.size() << endl;
-    if(recHits.size() > 0) //FIXME: is it really needed?
+    if(!recHits.empty()) //FIXME: is it really needed?
       recHitCollection->put(layerId, recHits.begin(), recHits.end());
   }
 

--- a/RecoLocalMuon/DTRecHit/plugins/DTRecHitProducer.h
+++ b/RecoLocalMuon/DTRecHit/plugins/DTRecHitProducer.h
@@ -27,10 +27,10 @@ public:
   DTRecHitProducer(const edm::ParameterSet&);
 
   /// Destructor
-  virtual ~DTRecHitProducer();
+  ~DTRecHitProducer() override;
 
   /// The method which produces the rechits
-  virtual void produce(edm::Event& event, const edm::EventSetup& setup);
+  void produce(edm::Event& event, const edm::EventSetup& setup) override;
 
 private:
   // Switch on verbosity

--- a/RecoLocalMuon/DTRecHit/plugins/DTTime2DriftParametrization.cc
+++ b/RecoLocalMuon/DTRecHit/plugins/DTTime2DriftParametrization.cc
@@ -6,8 +6,8 @@
 
 #define THIS_CLASS DTTime2DriftParametrization
 
-#include <math.h>
-#include <stdio.h>
+#include <cmath>
+#include <cstdio>
 #include <algorithm>
 
 #include "DTTime2DriftParametrization.h"

--- a/RecoLocalMuon/DTSegment/src/DTClusterer.cc
+++ b/RecoLocalMuon/DTSegment/src/DTClusterer.cc
@@ -95,7 +95,7 @@ void DTClusterer::produce(edm::Event& event, const edm::EventSetup& setup) {
     if(debug) cout << "Number of 1D-RecHit pairs " << pairs.size() << endl;
     vector<DTSLRecCluster> clus=buildClusters(sl, pairs);
     if(debug) cout << "Number of clusters build " << clus.size() << endl;
-    if (clus.size() > 0 )
+    if (!clus.empty() )
       clusters->put(sl->id(), clus.begin(), clus.end());
   }
   event.put(std::move(clusters));

--- a/RecoLocalMuon/DTSegment/src/DTClusterer.h
+++ b/RecoLocalMuon/DTSegment/src/DTClusterer.h
@@ -45,10 +45,10 @@ class DTClusterer : public edm::EDProducer {
     DTClusterer(const edm::ParameterSet&) ;
 
     /* Destructor */ 
-    virtual ~DTClusterer() ;
+    ~DTClusterer() override ;
 
     /* Operations */ 
-    virtual void produce(edm::Event& event, const edm::EventSetup& setup);
+    void produce(edm::Event& event, const edm::EventSetup& setup) override;
 
   private:
     // build clusters from hits

--- a/RecoLocalMuon/DTSegment/src/DTCombinatorialExtendedPatternReco.cc
+++ b/RecoLocalMuon/DTSegment/src/DTCombinatorialExtendedPatternReco.cc
@@ -66,7 +66,7 @@ DTCombinatorialExtendedPatternReco::reconstruct(const DTSuperLayer* sl,
     
     DTSLRecSegment2D *segment = (**cand);
 
-    theUpdator->update(segment,0);
+    theUpdator->update(segment,false);
 
     result.push_back(segment);
 
@@ -302,7 +302,7 @@ DTCombinatorialExtendedPatternReco::buildBestSegment(std::vector<DTSegmentCand::
     hits.size()  << endl;
   if (hits.size()<3) {
     //cout << "buildBestSegment: hits " << hits.size()<< endl;
-    return 0; // a least 3 point
+    return nullptr; // a least 3 point
   }
 
   // hits with defined LR
@@ -364,7 +364,7 @@ DTCombinatorialExtendedPatternReco::buildBestSegment(std::vector<DTSegmentCand::
   if (bestCandIter != extendedCands.end()) {
     return (*bestCandIter);
   }
-  return 0;
+  return nullptr;
 }
 
 void
@@ -377,7 +377,7 @@ DTCombinatorialExtendedPatternReco::buildPointsCollection(vector<DTSegmentCand::
     cout << "DTCombinatorialExtendedPatternReco::buildPointsCollection " << endl;
     cout << "points: " << points.size() << " NOLR: " << pointsNoLR.size()<< endl;
   }
-  if (pointsNoLR.size()>0) { // still unassociated points!
+  if (!pointsNoLR.empty()) { // still unassociated points!
     std::shared_ptr<DTHitPairForFit> unassHit = pointsNoLR.front();
     // try with the right
     if(debug)
@@ -419,7 +419,7 @@ DTCombinatorialExtendedPatternReco::buildPointsCollection(vector<DTSegmentCand::
     }
 
     DTSegmentCand* newCand = new DTSegmentCand(pointsSet,sl);
-    if (theUpdator->fit(newCand,0,0)) candidates.push_back(newCand);
+    if (theUpdator->fit(newCand,false,false)) candidates.push_back(newCand);
     else delete newCand; // bad seg, too few hits
   }
 }
@@ -490,7 +490,7 @@ DTCombinatorialExtendedPatternReco::extendCandidates(vector<DTSegmentCand*>& can
       }
       // fit the segment
       if (debug) cout << "extended cands nHits: " << extendedCand->nHits() <<endl;
-      if (theUpdator->fit(extendedCand,0,0)) {
+      if (theUpdator->fit(extendedCand,false,false)) {
         // add to result
         result.push_back(extendedCand);
       } else {

--- a/RecoLocalMuon/DTSegment/src/DTCombinatorialExtendedPatternReco.h
+++ b/RecoLocalMuon/DTSegment/src/DTCombinatorialExtendedPatternReco.h
@@ -47,21 +47,21 @@ class DTCombinatorialExtendedPatternReco : private DTRecSegment2DBaseAlgo {
     DTCombinatorialExtendedPatternReco(const edm::ParameterSet& pset) ;
 
     /// Destructor
-    virtual ~DTCombinatorialExtendedPatternReco() ;
+    ~DTCombinatorialExtendedPatternReco() override ;
 
     /* Operations */
 
     /// this function is called in the producer
-    virtual edm::OwnVector<DTSLRecSegment2D>
+    edm::OwnVector<DTSLRecSegment2D>
       reconstruct(const DTSuperLayer* sl,
-                  const std::vector<DTRecHit1DPair>& hits);
+                  const std::vector<DTRecHit1DPair>& hits) override;
 
     /// return the algo name
-    virtual std::string algoName() const { return theAlgoName; }
+    std::string algoName() const override { return theAlgoName; }
 
     /// Through this function the EventSetup is percolated to the
     /// objs which request it
-    virtual void setES(const edm::EventSetup& setup);
+    void setES(const edm::EventSetup& setup) override;
 
     // pass clusters to algo
     void setClusters(const std::vector<DTSLRecCluster>& clusters);

--- a/RecoLocalMuon/DTSegment/src/DTCombinatorialPatternReco.cc
+++ b/RecoLocalMuon/DTSegment/src/DTCombinatorialPatternReco.cc
@@ -65,7 +65,7 @@ DTCombinatorialPatternReco::reconstruct(const DTSuperLayer* sl,
     
     DTSLRecSegment2D *segment = (**cand);
 
-    theUpdator->update(segment,0);
+    theUpdator->update(segment,false);
 
     result.push_back(segment);
 
@@ -314,7 +314,7 @@ DTCombinatorialPatternReco::buildBestSegment(std::vector<DTSegmentCand::AssPoint
                                              const DTSuperLayer* sl) {
   if (hits.size()<3) {
     //cout << "buildBestSegment: hits " << hits.size()<< endl;
-    return 0; // a least 3 point
+    return nullptr; // a least 3 point
   }
 
   // hits with defined LR
@@ -372,7 +372,7 @@ DTCombinatorialPatternReco::buildBestSegment(std::vector<DTSegmentCand::AssPoint
        if (bestCandIter != candidates.end()) {
          return (*bestCandIter);
        }
-       return 0;
+       return nullptr;
 }
 
 void
@@ -385,7 +385,7 @@ DTCombinatorialPatternReco::buildPointsCollection(vector<DTSegmentCand::AssPoint
     cout << "buildPointsCollection " << endl;
     cout << "points: " << points.size() << " NOLR: " << pointsNoLR.size()<< endl;
   }
-  if (pointsNoLR.size()>0) { // still unassociated points!
+  if (!pointsNoLR.empty()) { // still unassociated points!
     std::shared_ptr<DTHitPairForFit> unassHit = pointsNoLR.front();
     // try with the right
     if(debug)
@@ -427,7 +427,7 @@ DTCombinatorialPatternReco::buildPointsCollection(vector<DTSegmentCand::AssPoint
     }
 
     DTSegmentCand* newCand = new DTSegmentCand(pointsSet,sl);
-    if (theUpdator->fit(newCand,0,0)) candidates.push_back(newCand);
+    if (theUpdator->fit(newCand,false,false)) candidates.push_back(newCand);
     else delete newCand; // bad seg, too few hits
   }
 }

--- a/RecoLocalMuon/DTSegment/src/DTCombinatorialPatternReco.h
+++ b/RecoLocalMuon/DTSegment/src/DTCombinatorialPatternReco.h
@@ -46,21 +46,21 @@ class DTCombinatorialPatternReco : public DTRecSegment2DBaseAlgo {
     DTCombinatorialPatternReco(const edm::ParameterSet& pset) ;
 
     /// Destructor
-    virtual ~DTCombinatorialPatternReco() ;
+    ~DTCombinatorialPatternReco() override ;
 
     /* Operations */
 
     /// this function is called in the producer
-    virtual edm::OwnVector<DTSLRecSegment2D>
+    edm::OwnVector<DTSLRecSegment2D>
       reconstruct(const DTSuperLayer* sl,
-                  const std::vector<DTRecHit1DPair>& hits);
+                  const std::vector<DTRecHit1DPair>& hits) override;
 
     /// return the algo name
-    virtual std::string algoName() const { return theAlgoName; }
+    std::string algoName() const override { return theAlgoName; }
 
     /// Through this function the EventSetup is percolated to the
     /// objs which request it
-    virtual void setES(const edm::EventSetup& setup);
+    void setES(const edm::EventSetup& setup) override;
 
   protected:
 

--- a/RecoLocalMuon/DTSegment/src/DTCombinatorialPatternReco4D.cc
+++ b/RecoLocalMuon/DTSegment/src/DTCombinatorialPatternReco4D.cc
@@ -154,8 +154,8 @@ DTCombinatorialPatternReco4D::reconstruct() {
   bool hasZed = false;
 
   // has this chamber the Z-superlayer?
-  if (theSegments2DTheta.size()){
-    hasZed = theSegments2DTheta.size() > 0;
+  if (!theSegments2DTheta.empty()){
+    hasZed = !theSegments2DTheta.empty();
     if (debug) cout << "There are " << theSegments2DTheta.size() << " Theta cand" << endl;
   } else {
     if (debug) cout << "No Theta SL" << endl;
@@ -163,13 +163,13 @@ DTCombinatorialPatternReco4D::reconstruct() {
 
   // Now I want to build the concrete DTRecSegment4D.
   if(debug) cout<<"Building of the concrete DTRecSegment4D"<<endl;
-  if (resultPhi.size()) {
+  if (!resultPhi.empty()) {
     for (vector<DTSegmentCand*>::const_iterator phi=resultPhi.begin();
          phi!=resultPhi.end(); ++phi) {
 
       std::unique_ptr<DTChamberRecSegment2D> superPhi(**phi);
 
-      theUpdator->update(superPhi.get(),0);
+      theUpdator->update(superPhi.get(),false);
       if(debug) cout << "superPhi: " << *superPhi << endl;
 
       if (hasZed) {
@@ -201,12 +201,12 @@ DTCombinatorialPatternReco4D::reconstruct() {
           if (debug) cout << "Created a 4D seg " << *newSeg << endl;
 
           /// 4d segment: I have the pos along the wire => further update!
-	  theUpdator->update(newSeg,0,0);
+	  theUpdator->update(newSeg,false,false);
           if (debug) cout << "     seg updated " <<  *newSeg << endl;
 
 
 	  if(!applyT0corr && computeT0corr) theUpdator->calculateT0corr(newSeg);
-          if(applyT0corr) theUpdator->update(newSeg,true,0);
+          if(applyT0corr) theUpdator->update(newSeg,true,false);
 
           result.push_back(newSeg);
         }
@@ -219,7 +219,7 @@ DTCombinatorialPatternReco4D::reconstruct() {
 
        //update the segment with the t0 and possibly vdrift correction
         if(!applyT0corr && computeT0corr) theUpdator->calculateT0corr(newSeg);
- 	if(applyT0corr) theUpdator->update(newSeg,true,0);
+ 	if(applyT0corr) theUpdator->update(newSeg,true,false);
 
         result.push_back(newSeg);
       }
@@ -243,7 +243,7 @@ DTCombinatorialPatternReco4D::reconstruct() {
 		     *newSeg << endl;
 
         if(!applyT0corr && computeT0corr) theUpdator->calculateT0corr(newSeg);
- 	if(applyT0corr) theUpdator->update(newSeg,true,0);
+ 	if(applyT0corr) theUpdator->update(newSeg,true,false);
 
         result.push_back(newSeg);
       }
@@ -262,10 +262,10 @@ vector<DTSegmentCand*> DTCombinatorialPatternReco4D::buildPhiSuperSegmentsCandid
 
   DTSuperLayerId slId;
 
-  if(theHitsFromPhi1.size())
+  if(!theHitsFromPhi1.empty())
     slId = theHitsFromPhi1.front().wireId().superlayerId();
   else
-    if(theHitsFromPhi2.size())
+    if(!theHitsFromPhi2.empty())
       slId = theHitsFromPhi2.front().wireId().superlayerId();
     else{
       if(debug) cout<<"DTCombinatorialPatternReco4D::buildPhiSuperSegmentsCandidates: "

--- a/RecoLocalMuon/DTSegment/src/DTCombinatorialPatternReco4D.h
+++ b/RecoLocalMuon/DTSegment/src/DTCombinatorialPatternReco4D.h
@@ -45,18 +45,18 @@ class DTCombinatorialPatternReco4D : public DTRecSegment4DBaseAlgo {
   DTCombinatorialPatternReco4D(const edm::ParameterSet& pset) ;
   
   /// Destructor
-  virtual ~DTCombinatorialPatternReco4D();
+  ~DTCombinatorialPatternReco4D() override;
     
   /// Operations  
-  virtual edm::OwnVector<DTRecSegment4D> reconstruct();
+  edm::OwnVector<DTRecSegment4D> reconstruct() override;
     
-  virtual std::string algoName() const { return theAlgoName; }
+  std::string algoName() const override { return theAlgoName; }
 
-  virtual void setES(const edm::EventSetup& setup);
-  virtual void setDTRecHit1DContainer(edm::Handle<DTRecHitCollection> all1DHits);
-  virtual void setDTRecSegment2DContainer(edm::Handle<DTRecSegment2DCollection> all2DSegments);
-  virtual void setChamber(const DTChamberId &chId);
-  virtual bool wants2DSegments(){return !allDTRecHits;}
+  void setES(const edm::EventSetup& setup) override;
+  void setDTRecHit1DContainer(edm::Handle<DTRecHitCollection> all1DHits) override;
+  void setDTRecSegment2DContainer(edm::Handle<DTRecSegment2DCollection> all2DSegments) override;
+  void setChamber(const DTChamberId &chId) override;
+  bool wants2DSegments() override{return !allDTRecHits;}
 
  protected:
 

--- a/RecoLocalMuon/DTSegment/src/DTLinearFit.cc
+++ b/RecoLocalMuon/DTSegment/src/DTLinearFit.cc
@@ -78,7 +78,7 @@ void DTLinearFit::fitNpar( const int npar,
                            float& cminf,
                            float& vminf,
                            double& chi2fit,
-                           const bool debug=0) const { 
+                           const bool debug=false) const { 
 
   int nptfit=xfit.size();
   if (nptfit<npar) return;
@@ -226,7 +226,7 @@ void DTLinearFit::fit3par( const vector<float>& xfit,
                            float& bminf,
                            float& cminf,
                            double& chi2fit,
-                           const bool debug=0) const { 
+                           const bool debug=false) const { 
 
   float vminf;
   vector <double> tfit( nptfit, 0.);
@@ -245,8 +245,8 @@ void DTLinearFit::fit4Var( const vector<float>& xfit,
                            float& cminf,
                            float& vminf,
                            double& chi2fit,
-                           const bool vdrift_4parfit=0,
-                           const bool debug=0) const { 
+                           const bool vdrift_4parfit=false,
+                           const bool debug=false) const { 
 
   if (debug) cout << "Entering Fit4Var" << endl;
 

--- a/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco.cc
+++ b/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco.cc
@@ -71,7 +71,7 @@ DTMeantimerPatternReco::reconstruct(const DTSuperLayer* sl,
   while (cand<candidates.end()) {
     
     DTSLRecSegment2D *segment = (**cand);
-    theUpdator->update(segment,1);
+    theUpdator->update(segment,true);
 
     if (debug) cout<<"Reconstructed 2D segments "<<*segment<<endl;
     result.push_back(segment);
@@ -217,13 +217,13 @@ DTMeantimerPatternReco::addHits(DTSegmentCand* segCand, const vector<std::shared
     DTSegmentCand::AssPoint rhit(*hit, DTEnums::Right);
 
     segCand->add(lhit);
-    bool left_ok=(fitWithT0(segCand,0)?true:false);
+    bool left_ok=(fitWithT0(segCand,false)?true:false);
     chi2l=segCand->chi2();
     t0l=segCand->t0();
     segCand->removeHit(lhit);
 
     segCand->add(rhit);
-    bool right_ok=(fitWithT0(segCand,0)?true:false);
+    bool right_ok=(fitWithT0(segCand,false)?true:false);
     chi2r=segCand->chi2();
     t0r=segCand->t0();
     segCand->removeHit(rhit);
@@ -331,7 +331,7 @@ DTSegmentCand*
 DTMeantimerPatternReco::fitWithT0(DTSegmentCand* seg, const bool fitdebug)
 {
   // perform the 3 parameter fit on the segment candidate
-  theUpdator->fit(seg,1,fitdebug);
+  theUpdator->fit(seg,true,fitdebug);
   double chi2=seg->chi2();
 
   // Sanity check - drop segment candidates with a failed 3-par fit.

--- a/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco.h
+++ b/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco.h
@@ -49,21 +49,21 @@ class DTMeantimerPatternReco : public DTRecSegment2DBaseAlgo {
   DTMeantimerPatternReco(const edm::ParameterSet& pset) ;
 
   /// Destructor
-  virtual ~DTMeantimerPatternReco() ;
+  ~DTMeantimerPatternReco() override ;
 
   /* Operations */
 
   /// this function is called in the producer
-  virtual edm::OwnVector<DTSLRecSegment2D>
+  edm::OwnVector<DTSLRecSegment2D>
     reconstruct(const DTSuperLayer* sl,
-		const std::vector<DTRecHit1DPair>& hits);
+		const std::vector<DTRecHit1DPair>& hits) override;
 	
   /// return the algo name
-  virtual std::string algoName() const { return theAlgoName; }
+  std::string algoName() const override { return theAlgoName; }
     
   /// Through this function the EventSetup is percolated to the
   /// objs which request it
-  virtual void setES(const edm::EventSetup& setup);
+  void setES(const edm::EventSetup& setup) override;
 
  protected:
 

--- a/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco4D.cc
+++ b/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco4D.cc
@@ -155,8 +155,8 @@ DTMeantimerPatternReco4D::reconstruct(){
   bool hasZed=false;
 
   // has this chamber the Z-superlayer?
-  if (theSegments2DTheta.size()){
-    hasZed = theSegments2DTheta.size()>0;
+  if (!theSegments2DTheta.empty()){
+    hasZed = !theSegments2DTheta.empty();
     if (debug) cout << "There are " << theSegments2DTheta.size() << " Theta cand" << endl;
   } else {
     if (debug) cout << "No Theta candidates." << endl;
@@ -164,13 +164,13 @@ DTMeantimerPatternReco4D::reconstruct(){
 
   // Now I want to build the concrete DTRecSegment4D.
   if(debug) cout << "Building the concrete DTRecSegment4D" << endl;
-  if (resultPhi.size()) {
+  if (!resultPhi.empty()) {
     for (vector<DTSegmentCand*>::const_iterator phi=resultPhi.begin();
          phi!=resultPhi.end(); ++phi) {
 
       std::unique_ptr<DTChamberRecSegment2D> superPhi(**phi);
 
-      theUpdator->update(superPhi.get(),1);
+      theUpdator->update(superPhi.get(),true);
       if(debug) cout << "superPhi: " << *superPhi << endl;
 
       if (hasZed) {
@@ -199,12 +199,12 @@ DTMeantimerPatternReco4D::reconstruct(){
           DTRecSegment4D* newSeg = new DTRecSegment4D(*superPhi,*zed,posZInCh,dirZInCh);
 
           /// 4d segment: I have the pos along the wire => further update!
-          theUpdator->update(newSeg,0,1);
+          theUpdator->update(newSeg,false,true);
           if (debug) cout << "Created a 4D seg " << *newSeg << endl;
 
           //update the segment with the t0 and possibly vdrift correction
           if(!applyT0corr && computeT0corr) theUpdator->calculateT0corr(newSeg);
-          if(applyT0corr) theUpdator->update(newSeg,true,1);
+          if(applyT0corr) theUpdator->update(newSeg,true,true);
 
           result.push_back(newSeg);
         }
@@ -216,7 +216,7 @@ DTMeantimerPatternReco4D::reconstruct(){
 
         //update the segment with the t0 and possibly vdrift correction
         if(!applyT0corr && computeT0corr) theUpdator->calculateT0corr(newSeg);
-        if(applyT0corr) theUpdator->update(newSeg,true,1);
+        if(applyT0corr) theUpdator->update(newSeg,true,true);
 
         result.push_back(newSeg);
       }
@@ -239,7 +239,7 @@ DTMeantimerPatternReco4D::reconstruct(){
         if (debug) cout << "Created a 4D segment using only the 2D Theta segment" << endl;
 
         if(!applyT0corr && computeT0corr) theUpdator->calculateT0corr(newSeg);
-        if(applyT0corr) theUpdator->update(newSeg,true,1);
+        if(applyT0corr) theUpdator->update(newSeg,true,true);
 
         result.push_back(newSeg);
       }
@@ -258,10 +258,10 @@ vector<DTSegmentCand*> DTMeantimerPatternReco4D::buildPhiSuperSegmentsCandidates
 
   DTSuperLayerId slId;
 
-  if(theHitsFromPhi1.size())
+  if(!theHitsFromPhi1.empty())
     slId = theHitsFromPhi1.front().wireId().superlayerId();
   else
-    if(theHitsFromPhi2.size())
+    if(!theHitsFromPhi2.empty())
       slId = theHitsFromPhi2.front().wireId().superlayerId();
     else{
       if(debug) cout<<"DTMeantimerPatternReco4D::buildPhiSuperSegmentsCandidates: "

--- a/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco4D.h
+++ b/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco4D.h
@@ -45,18 +45,18 @@ class DTMeantimerPatternReco4D : public DTRecSegment4DBaseAlgo {
     DTMeantimerPatternReco4D(const edm::ParameterSet& pset) ;
 
     /// Destructor
-    virtual ~DTMeantimerPatternReco4D();
+    ~DTMeantimerPatternReco4D() override;
 
     /// Operations  
-    virtual edm::OwnVector<DTRecSegment4D> reconstruct();
+    edm::OwnVector<DTRecSegment4D> reconstruct() override;
 
-    virtual std::string algoName() const { return theAlgoName; }
+    std::string algoName() const override { return theAlgoName; }
 
-    virtual void setES(const edm::EventSetup& setup);
-    virtual void setDTRecHit1DContainer(edm::Handle<DTRecHitCollection> all1DHits);
-    virtual void setDTRecSegment2DContainer(edm::Handle<DTRecSegment2DCollection> all2DSegments);
-    virtual void setChamber(const DTChamberId &chId);
-    virtual bool wants2DSegments(){return !allDTRecHits;}
+    void setES(const edm::EventSetup& setup) override;
+    void setDTRecHit1DContainer(edm::Handle<DTRecHitCollection> all1DHits) override;
+    void setDTRecSegment2DContainer(edm::Handle<DTRecSegment2DCollection> all2DSegments) override;
+    void setChamber(const DTChamberId &chId) override;
+    bool wants2DSegments() override{return !allDTRecHits;}
 
   protected:
 

--- a/RecoLocalMuon/DTSegment/src/DTRecSegment2DExtendedProducer.cc
+++ b/RecoLocalMuon/DTSegment/src/DTRecSegment2DExtendedProducer.cc
@@ -111,7 +111,7 @@ void DTRecSegment2DExtendedProducer::produce(edm::Event& event, const
            ostream_iterator<DTSLRecSegment2D>(cout, "\n"));
     }
 
-    if (segs.size() > 0 )
+    if (!segs.empty() )
       segments->put(SLId, segs.begin(),segs.end());
   }
   event.put(std::move(segments));

--- a/RecoLocalMuon/DTSegment/src/DTRecSegment2DExtendedProducer.h
+++ b/RecoLocalMuon/DTSegment/src/DTRecSegment2DExtendedProducer.h
@@ -37,12 +37,12 @@ class DTRecSegment2DExtendedProducer : public edm::EDProducer {
   DTRecSegment2DExtendedProducer(const edm::ParameterSet&) ;
 
   /// Destructor
-  virtual ~DTRecSegment2DExtendedProducer() ;
+  ~DTRecSegment2DExtendedProducer() override ;
     
   // Operations
 
   /// The method which produces the 2D-segments
-  virtual void produce(edm::Event& event, const edm::EventSetup& setup);
+  void produce(edm::Event& event, const edm::EventSetup& setup) override;
 
  protected:
 

--- a/RecoLocalMuon/DTSegment/src/DTRecSegment2DProducer.cc
+++ b/RecoLocalMuon/DTSegment/src/DTRecSegment2DProducer.cc
@@ -104,7 +104,7 @@ void DTRecSegment2DProducer::produce(edm::Event& event, const
     OwnVector<DTSLRecSegment2D> segs = theAlgo->reconstruct(sl, pairs);
     if(debug) cout << "Number of Reconstructed segments: " << segs.size() << endl;
 
-    if (segs.size() > 0 )
+    if (!segs.empty() )
       segments->put(SLId, segs.begin(),segs.end());
   }
   event.put(std::move(segments));

--- a/RecoLocalMuon/DTSegment/src/DTRecSegment2DProducer.h
+++ b/RecoLocalMuon/DTSegment/src/DTRecSegment2DProducer.h
@@ -36,12 +36,12 @@ class DTRecSegment2DProducer : public edm::stream::EDProducer<> {
   DTRecSegment2DProducer(const edm::ParameterSet&) ;
 
   /// Destructor
-  virtual ~DTRecSegment2DProducer() ;
+  ~DTRecSegment2DProducer() override ;
     
   // Operations
 
   /// The method which produces the 2D-segments
-  virtual void produce(edm::Event& event, const edm::EventSetup& setup);
+  void produce(edm::Event& event, const edm::EventSetup& setup) override;
 
  protected:
 

--- a/RecoLocalMuon/DTSegment/src/DTRecSegment4DProducer.cc
+++ b/RecoLocalMuon/DTSegment/src/DTRecSegment4DProducer.cc
@@ -105,7 +105,7 @@ void DTRecSegment4DProducer::produce(Event& event, const EventSetup& setup){
            ostream_iterator<DTRecSegment4D>(cout, "\n"));
     }
 
-    if (segments4D.size() > 0 )
+    if (!segments4D.empty() )
       // convert the OwnVector into a Collection
       segments4DCollection->put(chId, segments4D.begin(),segments4D.end());
   }

--- a/RecoLocalMuon/DTSegment/src/DTRecSegment4DProducer.h
+++ b/RecoLocalMuon/DTSegment/src/DTRecSegment4DProducer.h
@@ -24,12 +24,12 @@ public:
   DTRecSegment4DProducer(const edm::ParameterSet&) ;
 
   /// Destructor
-  virtual ~DTRecSegment4DProducer();
+  ~DTRecSegment4DProducer() override;
 
   // Operations
 
   /// The method which produces the 4D rec segments
-  virtual void produce(edm::Event& event, const edm::EventSetup& setup);
+  void produce(edm::Event& event, const edm::EventSetup& setup) override;
   
 
 protected:

--- a/RecoLocalMuon/DTSegment/src/DTRefitAndCombineReco4D.cc
+++ b/RecoLocalMuon/DTSegment/src/DTRefitAndCombineReco4D.cc
@@ -96,15 +96,15 @@ DTRefitAndCombineReco4D::reconstruct(){
   bool hasZed=false;
 
   // has this chamber the Z-superlayer?
-  if (theSegments2DTheta.size()){
-    hasZed = theSegments2DTheta.size()>0;
+  if (!theSegments2DTheta.empty()){
+    hasZed = !theSegments2DTheta.empty();
     if (debug) cout << "There are " << theSegments2DTheta.size() << " Theta cand" << endl;
   } else {
     if (debug) cout << "No Theta SL" << endl;
   }
 
   // Now I want to build the concrete DTRecSegment4D.
-  if (resultPhi.size()) {
+  if (!resultPhi.empty()) {
     for (vector<DTChamberRecSegment2D>::const_iterator phi=resultPhi.begin();
          phi!=resultPhi.end(); ++phi) {
       
@@ -125,7 +125,7 @@ DTRefitAndCombineReco4D::reconstruct(){
 	  //<<
 
           /// 4d segment: I have the pos along the wire => further update!
-          theUpdator->update(newSeg,0,1);
+          theUpdator->update(newSeg,false,true);
           if (debug) cout << "Created a 4D seg " << endl;
 	  result.push_back(newSeg);
         }
@@ -186,7 +186,7 @@ vector<DTChamberRecSegment2D> DTRefitAndCombineReco4D::refitSuperSegments(){
       DTChamberRecSegment2D superPhi(chId,recHitsSeg2DPhi1); 
       
       // refit it!
-      theUpdator->fit(&superPhi,0,0);
+      theUpdator->fit(&superPhi,false,false);
       
       // cut on the chi^2
       if (superPhi.chi2() > theMaxChi2forPhi)

--- a/RecoLocalMuon/DTSegment/src/DTRefitAndCombineReco4D.h
+++ b/RecoLocalMuon/DTSegment/src/DTRefitAndCombineReco4D.h
@@ -44,20 +44,20 @@ class DTRefitAndCombineReco4D : public DTRecSegment4DBaseAlgo {
   DTRefitAndCombineReco4D(const edm::ParameterSet& pset) ;
   
   /// Destructor
-  virtual ~DTRefitAndCombineReco4D(){};
+  ~DTRefitAndCombineReco4D() override{};
     
   /// Operations  
-  virtual edm::OwnVector<DTRecSegment4D>
-    reconstruct();
+  edm::OwnVector<DTRecSegment4D>
+    reconstruct() override;
     
-  virtual std::string algoName() const { return theAlgoName; }
+  std::string algoName() const override { return theAlgoName; }
     
-  virtual void setES(const edm::EventSetup& setup);
+  void setES(const edm::EventSetup& setup) override;
 
-  virtual void setDTRecHit1DContainer(edm::Handle<DTRecHitCollection> all1DHits) {};
-  virtual void setDTRecSegment2DContainer(edm::Handle<DTRecSegment2DCollection> all2DSegments);
-  virtual void setChamber(const DTChamberId &chId);
-  virtual bool wants2DSegments(){return true;}
+  void setDTRecHit1DContainer(edm::Handle<DTRecHitCollection> all1DHits) override {};
+  void setDTRecSegment2DContainer(edm::Handle<DTRecSegment2DCollection> all2DSegments) override;
+  void setChamber(const DTChamberId &chId) override;
+  bool wants2DSegments() override{return true;}
 
  protected:
 

--- a/RecoLocalMuon/DTSegment/src/DTSegment4DT0Corrector.cc
+++ b/RecoLocalMuon/DTSegment/src/DTSegment4DT0Corrector.cc
@@ -80,9 +80,9 @@ void DTSegment4DT0Corrector::produce(Event& event, const EventSetup& setup){
 
       DTRecSegment4D *newSeg = tmpseg.clone();
 
-      if(newSeg == 0) continue;
+      if(newSeg == nullptr) continue;
 
-      theUpdator->update(newSeg,true,0);
+      theUpdator->update(newSeg,true,false);
       result.push_back(*newSeg);
 
     }

--- a/RecoLocalMuon/DTSegment/src/DTSegment4DT0Corrector.h
+++ b/RecoLocalMuon/DTSegment/src/DTSegment4DT0Corrector.h
@@ -24,12 +24,12 @@ class DTSegment4DT0Corrector: public edm::stream::EDProducer<> {
   DTSegment4DT0Corrector(const edm::ParameterSet&) ;
 
   /// Destructor
-  virtual ~DTSegment4DT0Corrector();
+  ~DTSegment4DT0Corrector() override;
 
   // Operations
 
   /// The method which produces the 4D rec segments corrected for t0 offset
-  virtual void produce(edm::Event& event, const edm::EventSetup& setup);
+  void produce(edm::Event& event, const edm::EventSetup& setup) override;
   
 
  protected:

--- a/RecoLocalMuon/DTSegment/src/DTSegmentCleaner.cc
+++ b/RecoLocalMuon/DTSegment/src/DTSegmentCleaner.cc
@@ -57,7 +57,7 @@ vector<DTSegmentCand*> DTSegmentCleaner::solveConflict(const std::vector<DTSegme
 
       DTSegmentCand::AssPointCont confHits=(*cand)->conflictingHitPairs(*(*cand2));
       
-      if (confHits.size()) {
+      if (!confHits.empty()) {
 	///treatment of LR ambiguity cases: 1 chooses the best chi2
 	///                                 2 chooses the smaller angle
 	///                                 3 keeps both candidates
@@ -66,7 +66,7 @@ vector<DTSegmentCand*> DTSegmentCleaner::solveConflict(const std::vector<DTSegme
 
 	  if(segmCleanerMode == 2) { // mode 2: choose on the basis of the angle
 
-	    DTSegmentCand* badCand = 0;
+	    DTSegmentCand* badCand = nullptr;
 	    if((*cand)->superLayer()->id().superlayer() != 2) { // we are in the phi view
 
 	      LocalVector dir1 = (*cand)->direction();

--- a/RecoLocalMuon/DTSegment/src/DTSegmentExtendedCand.h
+++ b/RecoLocalMuon/DTSegment/src/DTSegmentExtendedCand.h
@@ -37,7 +37,7 @@ class DTSegmentExtendedCand  : public DTSegmentCand {
                                                   }
 
 /* Destructor */ 
-    virtual ~DTSegmentExtendedCand() {}
+    ~DTSegmentExtendedCand() override {}
 
 /* Operations */ 
     void addClus(const DTSegmentExtendedCand::DTSLRecClusterForFit& clus) {
@@ -52,9 +52,9 @@ class DTSegmentExtendedCand  : public DTSegmentCand {
 
     bool isCompatible(const DTSegmentExtendedCand::DTSLRecClusterForFit& clus) ;
 
-    virtual unsigned int nHits() const ;
+    unsigned int nHits() const override ;
 
-    virtual bool good() const ;
+    bool good() const override ;
 
     struct DTSLRecClusterForFit {
       public: 

--- a/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.cc
+++ b/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.cc
@@ -106,7 +106,7 @@ void DTSegmentUpdator::update(DTRecSegment2D* seg, bool allow3par) const {
   GlobalVector dir = (theGeom->idToDet(seg->geographicalId()))->toGlobal(seg->localDirection());
 
   updateHits(seg,pos,dir);
-  fit(seg,allow3par,0);
+  fit(seg,allow3par,false);
 }
 
 void DTSegmentUpdator::fit(DTRecSegment4D* seg, bool allow3par)  const {
@@ -124,14 +124,14 @@ void DTSegmentUpdator::fit(DTRecSegment4D* seg, bool allow3par)  const {
   if(seg->hasPhi()) {
     if(seg->hasZed()) {
       if (fabs(seg->phiSegment()->t0())<intime_cut) {
-        fit(seg->phiSegment(),allow3par,1);
-        fit(seg->zSegment(),allow3par,1);      
+        fit(seg->phiSegment(),allow3par,true);
+        fit(seg->zSegment(),allow3par,true);      
       } else {
-        fit(seg->phiSegment(),allow3par,0);
-        fit(seg->zSegment(),allow3par,0);      
+        fit(seg->phiSegment(),allow3par,false);
+        fit(seg->zSegment(),allow3par,false);      
       }
-    } else fit(seg->phiSegment(),allow3par,0);
-  } else fit(seg->zSegment(),allow3par,0);
+    } else fit(seg->phiSegment(),allow3par,false);
+  } else fit(seg->zSegment(),allow3par,false);
  
   const DTChamber* theChamber = theGeom->chamber(seg->chamberId());
 

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegAlgoRR.cc
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegAlgoRR.cc
@@ -29,7 +29,7 @@
 /**
  *  Constructor
  */
-GEMCSCSegAlgoRR::GEMCSCSegAlgoRR(const edm::ParameterSet& ps) : GEMCSCSegmentAlgorithm(ps), myName("GEMCSCSegAlgoRR"), sfit_(0) 
+GEMCSCSegAlgoRR::GEMCSCSegAlgoRR(const edm::ParameterSet& ps) : GEMCSCSegmentAlgorithm(ps), myName("GEMCSCSegAlgoRR"), sfit_(nullptr) 
 {	 
   debug                     = ps.getUntrackedParameter<bool>("GEMCSCDebug");
   minHitsPerSegment         = ps.getParameter<unsigned int>("minHitsPerSegment");
@@ -190,7 +190,7 @@ std::vector<const TrackingRecHit*> GEMCSCSegAlgoRR::chainHitsToSegm(const CSCSeg
   const CSCChamber* cscChamber = cscLayer->chamber();
 
   // For non-empty GEM rechit vector
-  if(gemrechits.size()!=0)
+  if(!gemrechits.empty())
     {
       float Dphi_min_l1 = 999;
       float Dphi_min_l2 = 999;
@@ -268,13 +268,13 @@ std::vector<const TrackingRecHit*> GEMCSCSegAlgoRR::chainHitsToSegm(const CSCSeg
       // maxima given by the configuration of the algorithm
       bool phiRequirementOK_l1 = Dphi_min_l1 < dPhiChainBoxMax;
       bool thetaRequirementOK_l1 = Dtheta_min_l1 < dThetaChainBoxMax;
-      if(phiRequirementOK_l1 && thetaRequirementOK_l1 && gemrh_min_l1!=0) 
+      if(phiRequirementOK_l1 && thetaRequirementOK_l1 && gemrh_min_l1!=nullptr) 
 	{
 	  chainedRecHits.push_back(gemrh_min_l1->clone());  
 	}
       bool phiRequirementOK_l2 = Dphi_min_l2 < dPhiChainBoxMax;
       bool thetaRequirementOK_l2 = Dtheta_min_l2 < dThetaChainBoxMax;
-      if(phiRequirementOK_l2 && thetaRequirementOK_l2 && gemrh_min_l2!=0) 
+      if(phiRequirementOK_l2 && thetaRequirementOK_l2 && gemrh_min_l2!=nullptr) 
 	{
 	  chainedRecHits.push_back(gemrh_min_l2->clone());
 	}

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegAlgoRR.h
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegAlgoRR.h
@@ -32,13 +32,13 @@ public:
   explicit GEMCSCSegAlgoRR(const edm::ParameterSet& ps);
 
   /// Destructor
-  ~GEMCSCSegAlgoRR();
+  ~GEMCSCSegAlgoRR() override;
 
   /**
    * Build segments for all desired groups of hits
    */
   std::vector<GEMCSCSegment> run( const std::map<uint32_t, const CSCLayer*>& csclayermap, const std::map<uint32_t, const GEMEtaPartition*>& gemrollmap,
-				  const std::vector<const CSCSegment*>& cscsegments, const std::vector<const GEMRecHit*>& gemrechits);
+				  const std::vector<const CSCSegment*>& cscsegments, const std::vector<const GEMRecHit*>& gemrechits) override;
 private:
 
   /// Utility functions 

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentBuilder.cc
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentBuilder.cc
@@ -30,7 +30,7 @@
 #include <DataFormats/GEMRecHit/interface/GEMRecHitCollection.h>
 
 
-GEMCSCSegmentBuilder::GEMCSCSegmentBuilder(const edm::ParameterSet& ps) : gemgeom_(0), cscgeom_(0) 
+GEMCSCSegmentBuilder::GEMCSCSegmentBuilder(const edm::ParameterSet& ps) : gemgeom_(nullptr), cscgeom_(nullptr) 
 {
 
     // Algo name
@@ -57,7 +57,7 @@ void GEMCSCSegmentBuilder::LinkGEMRollsToCSCChamberIndex(const GEMGeometry* gemG
   for (TrackingGeometry::DetContainer::const_iterator it=gemGeo->dets().begin();it<gemGeo->dets().end();it++)
     {
       const GEMChamber* ch = dynamic_cast< const GEMChamber* >( *it );
-      if(ch != 0 )
+      if(ch != nullptr )
 	{
 	  std::vector< const GEMEtaPartition*> rolls = (ch->etaPartitions());
 	  for(std::vector<const GEMEtaPartition*>::const_iterator r = rolls.begin(); r != rolls.end(); ++r)

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentProducer.h
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentProducer.h
@@ -25,9 +25,9 @@ public:
     /// Constructor
     explicit GEMCSCSegmentProducer(const edm::ParameterSet&);
     /// Destructor
-    ~GEMCSCSegmentProducer();
+    ~GEMCSCSegmentProducer() override;
     /// Produce the GEM-CSCSegment collection
-    virtual void produce(edm::Event&, const edm::EventSetup&);
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
     int iev; // events through

--- a/RecoLocalMuon/GEMRecHit/src/GEMRecHitProducer.cc
+++ b/RecoLocalMuon/GEMRecHit/src/GEMRecHitProducer.cc
@@ -206,7 +206,7 @@ void GEMRecHitProducer::produce(Event& event, const EventSetup& setup) {
     OwnVector<GEMRecHit> recHits =
       theAlgo->reconstruct(*roll, gemId, range, mask);
     
-    if(recHits.size() > 0) //FIXME: is it really needed?
+    if(!recHits.empty()) //FIXME: is it really needed?
       recHitCollection->put(gemId, recHits.begin(), recHits.end());
   }
 

--- a/RecoLocalMuon/GEMRecHit/src/GEMRecHitProducer.h
+++ b/RecoLocalMuon/GEMRecHit/src/GEMRecHitProducer.h
@@ -11,7 +11,7 @@
 #include <memory>
 #include <fstream>
 #include <iostream>
-#include <stdint.h>
+#include <cstdint>
 #include <cstdlib>
 #include <bitset>
 #include <map>
@@ -44,13 +44,13 @@ public:
   GEMRecHitProducer(const edm::ParameterSet& config);
 
   /// Destructor
-  virtual ~GEMRecHitProducer();
+  ~GEMRecHitProducer() override;
 
   // Method that access the EventSetup for each run
-  virtual void beginRun(const edm::Run&, const edm::EventSetup& ) override;
+  void beginRun(const edm::Run&, const edm::EventSetup& ) override;
 
   /// The method which produces the rechits
-  virtual void produce(edm::Event& event, const edm::EventSetup& setup) override;
+  void produce(edm::Event& event, const edm::EventSetup& setup) override;
 
 private:
 

--- a/RecoLocalMuon/GEMRecHit/src/GEMRecHitStandardAlgo.h
+++ b/RecoLocalMuon/GEMRecHit/src/GEMRecHitStandardAlgo.h
@@ -17,26 +17,26 @@ class GEMRecHitStandardAlgo : public GEMRecHitBaseAlgo {
   GEMRecHitStandardAlgo(const edm::ParameterSet& config);
 
   /// Destructor
-  virtual ~GEMRecHitStandardAlgo();
+  ~GEMRecHitStandardAlgo() override;
 
   // Operations
 
   /// Pass the Event Setup to the algo at each event
-  virtual void setES(const edm::EventSetup& setup);
+  void setES(const edm::EventSetup& setup) override;
 
 
-  virtual bool compute(const GEMEtaPartition& roll,
+  bool compute(const GEMEtaPartition& roll,
                        const GEMCluster& cluster,
                        LocalPoint& point,
-                       LocalError& error) const;
+                       LocalError& error) const override;
 
 
-  virtual bool compute(const GEMEtaPartition& roll,
+  bool compute(const GEMEtaPartition& roll,
                        const GEMCluster& cluster,
                        const float& angle,
                        const GlobalPoint& globPos, 
                        LocalPoint& point,
-                       LocalError& error) const;
+                       LocalError& error) const override;
 };
 #endif
 

--- a/RecoLocalMuon/GEMRecHit/src/ME0RecHitProducer.cc
+++ b/RecoLocalMuon/GEMRecHit/src/ME0RecHitProducer.cc
@@ -71,7 +71,7 @@ void ME0RecHitProducer::produce(edm::Event& event, const edm::EventSetup& setup)
     edm::OwnVector<ME0RecHit> recHits =
       theAlgo->reconstruct(me0Id, range);
     
-    if(recHits.size() > 0)
+    if(!recHits.empty())
       recHitCollection->put(me0Id, recHits.begin(), recHits.end());
   }
 

--- a/RecoLocalMuon/GEMRecHit/src/ME0RecHitProducer.h
+++ b/RecoLocalMuon/GEMRecHit/src/ME0RecHitProducer.h
@@ -13,7 +13,7 @@
 #include <memory>
 #include <fstream>
 #include <iostream>
-#include <stdint.h>
+#include <cstdint>
 #include <cstdlib>
 #include <bitset>
 #include <map>
@@ -48,13 +48,13 @@ public:
   ME0RecHitProducer(const edm::ParameterSet& config);
 
   /// Destructor
-  virtual ~ME0RecHitProducer();
+  ~ME0RecHitProducer() override;
 
   // Method that access the EventSetup for each run
-  virtual void beginRun(const edm::Run&, const edm::EventSetup& ) override;
+  void beginRun(const edm::Run&, const edm::EventSetup& ) override;
 
   /// The method which produces the rechits
-  virtual void produce(edm::Event& event, const edm::EventSetup& setup) override;
+  void produce(edm::Event& event, const edm::EventSetup& setup) override;
 
 private:
 

--- a/RecoLocalMuon/GEMRecHit/src/ME0RecHitStandardAlgo.h
+++ b/RecoLocalMuon/GEMRecHit/src/ME0RecHitStandardAlgo.h
@@ -16,17 +16,17 @@ class ME0RecHitStandardAlgo : public ME0RecHitBaseAlgo {
   ME0RecHitStandardAlgo(const edm::ParameterSet& config);
 
   /// Destructor
-  virtual ~ME0RecHitStandardAlgo();
+  ~ME0RecHitStandardAlgo() override;
 
   // Operations
 
   /// Pass the Event Setup to the algo at each event
-  virtual void setES(const edm::EventSetup& setup);
+  void setES(const edm::EventSetup& setup) override;
 
 
-  virtual bool compute(const ME0DigiPreReco& digi,
+  bool compute(const ME0DigiPreReco& digi,
                        LocalPoint& point,
-                       LocalError& error) const;
+                       LocalError& error) const override;
 
 
 };

--- a/RecoLocalMuon/GEMSegment/plugins/GEMSegmentAlgorithm.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/GEMSegmentAlgorithm.cc
@@ -360,7 +360,7 @@ void GEMSegmentAlgorithm::buildSegments(const GEMEnsemble& ensemble, const Ensem
   for (auto rh=rechits.begin(); rh!=rechits.end(); ++rh){
     bx += (*rh)->BunchX();
   }
-  if(rechits.size() != 0) bx=bx*1.0/(rechits.size());
+  if(!rechits.empty()) bx=bx*1.0/(rechits.size());
 
   // Calculate the central value and uncertainty of the segment time
   // if we want to study impact of 2-3ns time resolution on GEM Segment 

--- a/RecoLocalMuon/GEMSegment/plugins/GEMSegmentAlgorithm.h
+++ b/RecoLocalMuon/GEMSegment/plugins/GEMSegmentAlgorithm.h
@@ -33,12 +33,12 @@ public:
   /// Constructor
   explicit GEMSegmentAlgorithm(const edm::ParameterSet& ps);
   /// Destructor
-  virtual ~GEMSegmentAlgorithm();
+  ~GEMSegmentAlgorithm() override;
 
   /**
    * Build segments for all desired groups of hits
    */
-  std::vector<GEMSegment> run(const GEMEnsemble& ensemble, const EnsembleHitContainer& rechits); 
+  std::vector<GEMSegment> run(const GEMEnsemble& ensemble, const EnsembleHitContainer& rechits) override; 
 
 private:
   /// Utility functions 

--- a/RecoLocalMuon/GEMSegment/plugins/GEMSegmentBuilder.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/GEMSegmentBuilder.cc
@@ -9,7 +9,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h" 
 
-GEMSegmentBuilder::GEMSegmentBuilder(const edm::ParameterSet& ps) : geom_(0) {
+GEMSegmentBuilder::GEMSegmentBuilder(const edm::ParameterSet& ps) : geom_(nullptr) {
   
   // Algo name
   algoName = ps.getParameter<std::string>("algo_name");

--- a/RecoLocalMuon/GEMSegment/plugins/GEMSegmentProducer.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/GEMSegmentProducer.cc
@@ -25,7 +25,7 @@ public:
   /// Constructor
   explicit GEMSegmentProducer(const edm::ParameterSet&);
   /// Destructor
-  virtual ~GEMSegmentProducer() {}
+  ~GEMSegmentProducer() override {}
   /// Produce the GEMSegment collection
   void produce(edm::Event&, const edm::EventSetup&) override;
 

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.cc
@@ -72,7 +72,7 @@ ME0SegAlgoRU::ME0SegAlgoRU(const edm::ParameterSet& ps)
 			<< "maxTOFDiff          = " <<stdParameters.maxTOFDiff       << "\n"
 			<< std::endl;
 
-	theChamber=0;
+	theChamber=nullptr;
 
 }
 
@@ -161,7 +161,7 @@ std::vector<ME0Segment> ME0SegAlgoRU::run(const ME0Chamber * chamber, const HitA
 		//displaced muons will not worry about it  later
 		//Iteration 2a: If we don't allow wide segments simply do displaced
 		// Or if we already found a segment simply skip to displaced
-		if(!allowWideSegments || segments.size()){
+		if(!allowWideSegments || !segments.empty()){
 			doDisplaced();
 			return segments;
 		}
@@ -422,7 +422,7 @@ bool ME0SegAlgoRU::hasHitOnLayer(const HitAndPositionPtrContainer& proto_segment
 }
 
 void ME0SegAlgoRU::compareProtoSegment(std::unique_ptr<MuonSegFit>& current_fit, HitAndPositionPtrContainer& current_proto_segment, const HitAndPosition& new_hit) const {
-	const HitAndPosition * old_hit = 0;
+	const HitAndPosition * old_hit = nullptr;
 	HitAndPositionPtrContainer new_proto_segment = current_proto_segment;
 
 	HitAndPositionPtrContainer::const_iterator it;
@@ -434,7 +434,7 @@ void ME0SegAlgoRU::compareProtoSegment(std::unique_ptr<MuonSegFit>& current_fit,
 			++it;
 		}
 	}
-	if(old_hit == 0) return;
+	if(old_hit == nullptr) return;
 	auto new_fit = addHit(new_proto_segment,new_hit);
 
 	//If on the same strip but different BX choose the closest

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.h
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.h
@@ -53,12 +53,12 @@ public:
 	/// Constructor
 	explicit ME0SegAlgoRU(const edm::ParameterSet& ps);
 	/// Destructor
-	virtual ~ME0SegAlgoRU() {};
+	~ME0SegAlgoRU() override {};
 
 	/**
 	 * Here we must implement the algorithm
 	 */
-	std::vector<ME0Segment> run(const ME0Chamber * chamber, const HitAndPositionContainer& rechits);
+	std::vector<ME0Segment> run(const ME0Chamber * chamber, const HitAndPositionContainer& rechits) override;
 
 private:
 

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithm.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithm.cc
@@ -335,7 +335,7 @@ void ME0SegmentAlgorithm::buildSegments(const ME0Chamber * chamber, const HitAnd
   for (auto rh=rechits.begin(); rh!=rechits.end(); ++rh){
     averageTime += (*rh)->rh->tof();
   }
-  if(rechits.size() != 0) averageTime=averageTime/(rechits.size());
+  if(!rechits.empty()) averageTime=averageTime/(rechits.size());
   float timeUncrt=0.;
   for (auto rh=rechits.begin(); rh!=rechits.end(); ++rh){
     timeUncrt += pow((*rh)->rh->tof()-averageTime,2);

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithm.h
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithm.h
@@ -32,12 +32,12 @@ public:
   /// Constructor
   explicit ME0SegmentAlgorithm(const edm::ParameterSet& ps);
   /// Destructor
-  virtual ~ME0SegmentAlgorithm();
+  ~ME0SegmentAlgorithm() override;
 
   /**
    * Build segments for all desired groups of hits
    */
-  std::vector<ME0Segment> run(const ME0Chamber * chamber, const HitAndPositionContainer& rechits);
+  std::vector<ME0Segment> run(const ME0Chamber * chamber, const HitAndPositionContainer& rechits) override;
 
 private:
   /// Utility functions 

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegmentBuilder.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegmentBuilder.cc
@@ -10,7 +10,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-ME0SegmentBuilder::ME0SegmentBuilder(const edm::ParameterSet& ps) : geom_(0) {
+ME0SegmentBuilder::ME0SegmentBuilder(const edm::ParameterSet& ps) : geom_(nullptr) {
 
   // Algo type (indexed)
   int chosenAlgo = ps.getParameter<int>("algo_type") - 1;
@@ -57,7 +57,7 @@ void ME0SegmentBuilder::build(const ME0RecHitCollection* recHits, ME0SegmentColl
       		  if (layer->id().layer()==iL)
       			  return layer;
       	  }
-      	  return 0;
+      	  return nullptr;
         };
         float z1 = getLayer(1)->position().z();
         float z6 = getLayer(6)->position().z();
@@ -72,7 +72,7 @@ void ME0SegmentBuilder::build(const ME0RecHitCollection* recHits, ME0SegmentColl
       LogDebug("ME0Segment|ME0") << "found " << segv.size() << " segments in chamber " << *chIt;
 
       // Add the segments to master collection
-      if(segv.size())
+      if(!segv.empty())
       oc.put(chId, segv.begin(), segv.end());
 
   }

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegmentProducer.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegmentProducer.cc
@@ -26,7 +26,7 @@ public:
   /// Constructor
   explicit ME0SegmentProducer(const edm::ParameterSet&);
   /// Destructor
-  virtual ~ME0SegmentProducer() {}
+  ~ME0SegmentProducer() override {}
   /// Produce the ME0Segment collection
   void produce(edm::Event&, const edm::EventSetup&) override;
 

--- a/RecoLocalMuon/RPCRecHit/interface/RPCPointProducer.h
+++ b/RecoLocalMuon/RPCRecHit/interface/RPCPointProducer.h
@@ -24,7 +24,7 @@ class RPCPointProducer : public edm::global::EDProducer<> {
       explicit RPCPointProducer(const edm::ParameterSet&);
 
    private:
-      virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+      void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
       const edm::EDGetTokenT<CSCSegmentCollection> cscSegments;
       const edm::EDGetTokenT<DTRecSegment4DCollection> dt4DSegments;

--- a/RecoLocalMuon/RPCRecHit/src/CSCObjectMap.cc
+++ b/RecoLocalMuon/RPCRecHit/src/CSCObjectMap.cc
@@ -17,7 +17,7 @@ CSCObjectMap::CSCObjectMap(MuonGeometryRecord const& record){
   record.get(cscGeo);
   
   for (TrackingGeometry::DetContainer::const_iterator it=rpcGeo->dets().begin();it<rpcGeo->dets().end();it++){
-    if(dynamic_cast< const RPCChamber* >( *it ) != 0 ){
+    if(dynamic_cast< const RPCChamber* >( *it ) != nullptr ){
       auto ch = dynamic_cast< const RPCChamber* >( *it ); 
       std::vector< const RPCRoll*> roles = (ch->rolls());
       for(std::vector<const RPCRoll*>::const_iterator r = roles.begin();r != roles.end(); ++r){

--- a/RecoLocalMuon/RPCRecHit/src/CSCObjectMapESProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/CSCObjectMapESProducer.cc
@@ -16,7 +16,7 @@ public:
     setWhatProduced(this);
   }
 
-  ~CSCObjectMapESProducer() {
+  ~CSCObjectMapESProducer() override {
   }
 
   std::shared_ptr<CSCObjectMap> produce(MuonGeometryRecord const& record) {

--- a/RecoLocalMuon/RPCRecHit/src/CSCSegtoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/CSCSegtoRPC.cc
@@ -100,7 +100,7 @@ CSCSegtoRPC::CSCSegtoRPC(const CSCSegmentCollection * allCSCSegments, const edm:
 
 	  if(rpcRing!=1&&rpcStation!=4){//They don't exist!
 	  
-	    assert(rollsForThisCSC.size()>=1);
+	    assert(!rollsForThisCSC.empty());
 
 	    if(debug) std::cout<<"CSC \t \t Loop over all the rolls asociated to this CSC"<<std::endl;	    
 	    for (std::set<RPCDetId>::iterator iteraRoll = rollsForThisCSC.begin();iteraRoll != rollsForThisCSC.end(); iteraRoll++){

--- a/RecoLocalMuon/RPCRecHit/src/DTObjectMap.cc
+++ b/RecoLocalMuon/RPCRecHit/src/DTObjectMap.cc
@@ -19,7 +19,7 @@ DTObjectMap::DTObjectMap(MuonGeometryRecord const& record)
   record.get(dtGeo);
   
   for (TrackingGeometry::DetContainer::const_iterator it=rpcGeo->dets().begin();it<rpcGeo->dets().end();it++){
-    if(dynamic_cast<const RPCChamber* >( *it ) != 0 ){
+    if(dynamic_cast<const RPCChamber* >( *it ) != nullptr ){
       auto ch = dynamic_cast<const RPCChamber* >( *it ); 
       std::vector< const RPCRoll*> roles = (ch->rolls());
       for(std::vector<const RPCRoll*>::const_iterator r = roles.begin();r != roles.end(); ++r){

--- a/RecoLocalMuon/RPCRecHit/src/DTObjectMapESProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/DTObjectMapESProducer.cc
@@ -16,7 +16,7 @@ public:
     setWhatProduced(this);
   }
 
-  ~DTObjectMapESProducer() {
+  ~DTObjectMapESProducer() override {
   }
 
   std::shared_ptr<DTObjectMap> produce(MuonGeometryRecord const& record) {

--- a/RecoLocalMuon/RPCRecHit/src/DTSegtoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/DTSegtoRPC.cc
@@ -152,7 +152,7 @@ DTSegtoRPC::DTSegtoRPC(const DTRecSegment4DCollection * all4DSegments, const edm
       
 	if(debug) std::cout<<"DT  \t \t Number of rolls for this DT = "<<rollsForThisDT.size()<<std::endl;
       
-	assert(rollsForThisDT.size()>=1);
+	assert(!rollsForThisDT.empty());
       
 	if(debug) std::cout<<"DT  \t \t Loop over all the rolls asociated to this DT"<<std::endl;
 	for (std::set<RPCDetId>::iterator iteraRoll = rollsForThisDT.begin();iteraRoll != rollsForThisDT.end(); iteraRoll++){
@@ -265,8 +265,8 @@ DTSegtoRPC::DTSegtoRPC(const DTRecSegment4DCollection * all4DSegments, const edm
 	    if(debug) std::cout<<"MB4 \t \t \t \t The Segment in MB4 is 2D?"<<std::endl;
 	    if(segment->dimension()==2){
 	      if(debug) std::cout<<"MB4 \t \t \t \t yes"<<std::endl;
-	      LocalVector segmentDirectionMB4=segmentDirection;
-	      LocalPoint segmentPositionMB4=segmentPosition;
+	      const LocalVector& segmentDirectionMB4=segmentDirection;
+	      const LocalPoint& segmentPositionMB4=segmentPosition;
 	    
 	      const BoundPlane& DTSurface4 = dtGeo->idToDet(DTId)->surface();
 	        
@@ -340,7 +340,7 @@ DTSegtoRPC::DTSegtoRPC(const DTRecSegment4DCollection * all4DSegments, const edm
 
 		    if(debug) std::cout<<"MB4 \t \t Number of rolls for this DT = "<<rollsForThisDT.size()<<std::endl;
 		    
-		    assert(rollsForThisDT.size()>=1);
+		    assert(!rollsForThisDT.empty());
 		        
 		    if(debug) std::cout<<"MB4  \t \t Loop over all the rolls asociated to this DT"<<std::endl;
 		    for (std::set<RPCDetId>::iterator iteraRoll=rollsForThisDT.begin();iteraRoll != rollsForThisDT.end(); iteraRoll++){

--- a/RecoLocalMuon/RPCRecHit/src/RPCRecHitProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRecHitProducer.cc
@@ -140,7 +140,7 @@ void RPCRecHitProducer::produce(Event& event, const EventSetup& setup) {
 
     // Get the GeomDet from the setup
     const RPCRoll* roll = rpcGeom->roll(rpcId);
-    if (roll == 0){
+    if (roll == nullptr){
       edm::LogError("BadDigiInput")<<"Failed to find RPCRoll for ID "<<rpcId;
       continue;
     }
@@ -168,7 +168,7 @@ void RPCRecHitProducer::produce(Event& event, const EventSetup& setup) {
     // Call the reconstruction algorithm    
     OwnVector<RPCRecHit> recHits = theAlgo->reconstruct(*roll, rpcId, range, mask);
     
-    if(recHits.size() > 0) //FIXME: is it really needed?
+    if(!recHits.empty()) //FIXME: is it really needed?
       recHitCollection->put(rpcId, recHits.begin(), recHits.end());
   }
 

--- a/RecoLocalMuon/RPCRecHit/src/RPCRecHitProducer.h
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRecHitProducer.h
@@ -23,13 +23,13 @@ public:
   RPCRecHitProducer(const edm::ParameterSet& config);
 
   /// Destructor
-  virtual ~RPCRecHitProducer() {};
+  ~RPCRecHitProducer() override {};
 
   // Method that access the EventSetup for each run
-  virtual void beginRun(const edm::Run&, const edm::EventSetup& ) override;
+  void beginRun(const edm::Run&, const edm::EventSetup& ) override;
 
   /// The method which produces the rechits
-  virtual void produce(edm::Event& event, const edm::EventSetup& setup) override;
+  void produce(edm::Event& event, const edm::EventSetup& setup) override;
 
 private:
   // The label to be used to retrieve RPC digis from the event

--- a/RecoLocalMuon/RPCRecHit/src/RPCRecHitStandardAlgo.h
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRecHitStandardAlgo.h
@@ -15,26 +15,26 @@ class RPCRecHitStandardAlgo : public RPCRecHitBaseAlgo {
   RPCRecHitStandardAlgo(const edm::ParameterSet& config):RPCRecHitBaseAlgo(config) {};
 
   /// Destructor
-  virtual ~RPCRecHitStandardAlgo() {};
+  ~RPCRecHitStandardAlgo() override {};
 
   /// Pass the Event Setup to the algo at each event
-  virtual void setES(const edm::EventSetup& setup) {};
+  void setES(const edm::EventSetup& setup) override {};
 
 
-  virtual bool compute(const RPCRoll& roll,
+  bool compute(const RPCRoll& roll,
                        const RPCCluster& cluster,
                        LocalPoint& point,
                        LocalError& error,
-                       float& time, float& timeErr) const;
+                       float& time, float& timeErr) const override;
 
 
-  virtual bool compute(const RPCRoll& roll,
+  bool compute(const RPCRoll& roll,
                        const RPCCluster& cluster,
                        const float& angle,
                        const GlobalPoint& globPos,
                        LocalPoint& point,
                        LocalError& error,
-                       float& time, float& timeErr) const;
+                       float& time, float& timeErr) const override;
 };
 #endif
 

--- a/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc
@@ -113,7 +113,7 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
              const GlobalPoint dcPoint = DTSurface.toGlobal(LocalPoint(0.,0.,0.));
 
              TrajectoryMeasurement tMt = trajectory->closestMeasurement(dcPoint);
-             TrajectoryStateOnSurface upd2 = (tMt).updatedState();
+             const TrajectoryStateOnSurface& upd2 = (tMt).updatedState();
              if(upd2.isValid())
              {
                 LocalPoint trajLP = upd2.localPosition();
@@ -162,7 +162,7 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
              const GlobalPoint dcPoint = CSCSurface.toGlobal(LocalPoint(0.,0.,0.));
 
              TrajectoryMeasurement tMt = trajectory->closestMeasurement(dcPoint);
-             TrajectoryStateOnSurface upd2 = (tMt).updatedState();
+             const TrajectoryStateOnSurface& upd2 = (tMt).updatedState();
 
              if(upd2.isValid() && cscid.station()!=4 && cscid.ring()!=1 )
              {
@@ -297,7 +297,7 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
               const GlobalPoint dcPoint = DTSurface.toGlobal(LocalPoint(0.,0.,0.));
 
               TrajectoryMeasurement tMt = trajectory->closestMeasurement(dcPoint);
-              TrajectoryStateOnSurface upd2 = (tMt).updatedState();
+              const TrajectoryStateOnSurface& upd2 = (tMt).updatedState();
               if(upd2.isValid())
               {
                  TrajectoryStateOnSurface ptss =  thePropagator->propagate(upd2, rpcGeo->idToDet(*rpcroll2)->surface());
@@ -349,7 +349,7 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
               const GlobalPoint dcPoint = CSCSurface.toGlobal(LocalPoint(0.,0.,0.));
 
               TrajectoryMeasurement tMt = trajectory->closestMeasurement(dcPoint);
-              TrajectoryStateOnSurface upd2 = (tMt).updatedState();
+              const TrajectoryStateOnSurface& upd2 = (tMt).updatedState();
               if(upd2.isValid())  
               {
                  TrajectoryStateOnSurface ptss =  thePropagator->propagate(upd2, rpcGeo->idToDet(*rpcroll2)->surface());


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this quickly to avoid conflicts to the extent possible]