### PR TITLE
Clang-tidy checks for RecoLocalTracker

### DIFF
--- a/RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h
+++ b/RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h
@@ -30,7 +30,7 @@ public:
 public:
 
     Phase2StripCPE(edm::ParameterSet & conf, const MagneticField &,const TrackerGeometry&);
-    LocalValues localParameters(const Phase2TrackerCluster1D & cluster, const GeomDetUnit & det) const;
+    LocalValues localParameters(const Phase2TrackerCluster1D & cluster, const GeomDetUnit & det) const override;
     LocalVector driftDirection(const Phase2TrackerGeomDetUnit & det) const;
 
 private:

--- a/RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPEGeometric.h
+++ b/RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPEGeometric.h
@@ -14,7 +14,7 @@ class Phase2StripCPEGeometric : public ClusterParameterEstimator<Phase2TrackerCl
 
     Phase2StripCPEGeometric() {};
     Phase2StripCPEGeometric(edm::ParameterSet & conf);
-    LocalValues localParameters(const Phase2TrackerCluster1D & cluster, const GeomDetUnit & det) const;
+    LocalValues localParameters(const Phase2TrackerCluster1D & cluster, const GeomDetUnit & det) const override;
 
 };
 

--- a/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2TrackerRecHits.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2TrackerRecHits.cc
@@ -32,8 +32,8 @@ class Phase2TrackerRecHits : public edm::global::EDProducer<> {
         public:
 
             explicit Phase2TrackerRecHits(const edm::ParameterSet& conf);
-            virtual ~Phase2TrackerRecHits() {};
-            void produce(edm::StreamID sid, edm::Event& event, const edm::EventSetup& eventSetup) const override     final;
+            ~Phase2TrackerRecHits() override {};
+            void produce(edm::StreamID sid, edm::Event& event, const edm::EventSetup& eventSetup) const     final;
 
         private:
 

--- a/RecoLocalTracker/SiPhase2Clusterizer/plugins/Phase2TrackerClusterizer.cc
+++ b/RecoLocalTracker/SiPhase2Clusterizer/plugins/Phase2TrackerClusterizer.cc
@@ -33,8 +33,8 @@ class Phase2TrackerClusterizer : public edm::stream::EDProducer<> {
 
     public:
         explicit Phase2TrackerClusterizer(const edm::ParameterSet& conf);
-        virtual ~Phase2TrackerClusterizer();
-        virtual void produce(edm::Event& event, const edm::EventSetup& eventSetup) override;
+        ~Phase2TrackerClusterizer() override;
+        void produce(edm::Event& event, const edm::EventSetup& eventSetup) override;
 
     private:
 #ifdef VERIFY_PH2_TK_CLUS

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
@@ -60,19 +60,19 @@ class dso_hidden PixelThresholdClusterizer final : public PixelClusterizerBase {
  public:
 
   PixelThresholdClusterizer(edm::ParameterSet const& conf);
-  ~PixelThresholdClusterizer();
+  ~PixelThresholdClusterizer() override;
 
   // Full I/O in DetSet
   void clusterizeDetUnit( const edm::DetSet<PixelDigi> & input,	
 				  const PixelGeomDetUnit * pixDet,
 				  const TrackerTopology* tTopo,
 				  const std::vector<short>& badChannels,
-				  edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) { clusterizeDetUnitT(input, pixDet, tTopo, badChannels, output); }
+				  edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) override { clusterizeDetUnitT(input, pixDet, tTopo, badChannels, output); }
   void clusterizeDetUnit( const edmNew::DetSet<SiPixelCluster> & input,
                           const PixelGeomDetUnit * pixDet,
                           const TrackerTopology* tTopo,
                           const std::vector<short>& badChannels,
-                          edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) { clusterizeDetUnitT(input, pixDet, tTopo, badChannels, output); }
+                          edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) override { clusterizeDetUnitT(input, pixDet, tTopo, badChannels, output); }
 
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
@@ -48,9 +48,9 @@
   //---------------------------------------------------------------------------
   SiPixelClusterProducer::SiPixelClusterProducer(edm::ParameterSet const& conf) 
     : 
-    theSiPixelGainCalibration_(0), 
+    theSiPixelGainCalibration_(nullptr), 
     clusterMode_( conf.getUntrackedParameter<std::string>("ClusterMode","PixelThresholdClusterizer") ),
-    clusterizer_(0),          // the default, in case we fail to make one
+    clusterizer_(nullptr),          // the default, in case we fail to make one
     readyToCluster_(false),   // since we obviously aren't
     maxTotalClusters_( conf.getParameter<int32_t>( "maxNumberOfClusters" ) ),
     payloadType_( conf.getParameter<std::string>( "payloadType" ) )

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
@@ -53,12 +53,12 @@
   public:
     //--- Constructor, virtual destructor (just in case)
     explicit SiPixelClusterProducer(const edm::ParameterSet& conf);
-    virtual ~SiPixelClusterProducer();
+    ~SiPixelClusterProducer() override;
 
     void setupClusterizer(const edm::ParameterSet& conf);
 
     //--- The top-level event method.
-    virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
+    void produce(edm::Event& e, const edm::EventSetup& c) override;
 
     //--- Execute the algorithm(s).
     template<typename T>

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -135,7 +135,7 @@ public:
    //--------------------------------------------------------------------------
    
    inline ReturnType getParameters(const SiPixelCluster & cl,
-                                   const GeomDetUnit    & det ) const
+                                   const GeomDetUnit    & det ) const override
    {
 #ifdef EDM_ML_DEBUG
       nRecHitsTotal_++ ;
@@ -163,7 +163,7 @@ public:
    //--------------------------------------------------------------------------
    inline ReturnType getParameters(const SiPixelCluster & cl,
                                    const GeomDetUnit    & det,
-                                   const LocalTrajectoryParameters & ltp ) const
+                                   const LocalTrajectoryParameters & ltp ) const override
    {
 #ifdef EDM_ML_DEBUG
       nRecHitsTotal_++ ;

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
@@ -84,15 +84,15 @@ public:
                    const TrackerGeometry&, const TrackerTopology&, const SiPixelLorentzAngle *,
                    const SiPixelGenErrorDBObject *, const SiPixelLorentzAngle *);
    
-   ~PixelCPEGeneric() {;}
+   ~PixelCPEGeneric() override {;}
    
    
    
 private:
-   ClusterParam * createClusterParam(const SiPixelCluster & cl) const;
+   ClusterParam * createClusterParam(const SiPixelCluster & cl) const override;
    
-   LocalPoint localPosition (DetParam const & theDetParam, ClusterParam & theClusterParam) const;
-   LocalError localError   (DetParam const & theDetParam, ClusterParam & theClusterParam) const;
+   LocalPoint localPosition (DetParam const & theDetParam, ClusterParam & theClusterParam) const override;
+   LocalError localError   (DetParam const & theDetParam, ClusterParam & theClusterParam) const override;
    
    //--------------------------------------------------------------------
    //  Methods.

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericESProducer.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericESProducer.h
@@ -10,7 +10,7 @@
 class  PixelCPEGenericESProducer: public edm::ESProducer{
  public:
   PixelCPEGenericESProducer(const edm::ParameterSet & p);
-  virtual ~PixelCPEGenericESProducer(); 
+  ~PixelCPEGenericESProducer() override; 
   std::shared_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord &);
  private:
   std::shared_ptr<PixelClusterParameterEstimator> cpe_;

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateReco.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateReco.h
@@ -59,18 +59,18 @@ public:
    PixelCPETemplateReco(edm::ParameterSet const& conf, const MagneticField *, const TrackerGeometry&, const TrackerTopology&,
                         const SiPixelLorentzAngle *, const SiPixelTemplateDBObject *);
    
-   ~PixelCPETemplateReco();
+   ~PixelCPETemplateReco() override;
    
 private:
-   ClusterParam * createClusterParam(const SiPixelCluster & cl) const;
+   ClusterParam * createClusterParam(const SiPixelCluster & cl) const override;
    
    // We only need to implement measurementPosition, since localPosition() from
    // PixelCPEBase will call it and do the transformation
    // Gavril : put it back
-   LocalPoint localPosition (DetParam const & theDetParam, ClusterParam & theClusterParam) const;
+   LocalPoint localPosition (DetParam const & theDetParam, ClusterParam & theClusterParam) const override;
    
    // However, we do need to implement localError().
-   LocalError localError   (DetParam const & theDetParam, ClusterParam & theClusterParam) const;
+   LocalError localError   (DetParam const & theDetParam, ClusterParam & theClusterParam) const override;
    
    // Template storage
    std::vector< SiPixelTemplateStore > thePixelTemp_;

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateRecoESProducer.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateRecoESProducer.h
@@ -10,7 +10,7 @@
 class  PixelCPETemplateRecoESProducer: public edm::ESProducer{
  public:
   PixelCPETemplateRecoESProducer(const edm::ParameterSet & p);
-  virtual ~PixelCPETemplateRecoESProducer(); 
+  ~PixelCPETemplateRecoESProducer() override; 
   std::shared_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord &);
  private:
   std::shared_ptr<PixelClusterParameterEstimator> cpe_;

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelRecHitConverter.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelRecHitConverter.h
@@ -64,7 +64,7 @@ namespace cms
   public:
     //--- Constructor, virtual destructor (just in case)
     explicit SiPixelRecHitConverter(const edm::ParameterSet& conf);
-    virtual ~SiPixelRecHitConverter();
+    ~SiPixelRecHitConverter() override;
 
     //--- Factory method to make CPE's depending on the ParameterSet
     //--- Not sure if we need to make more than one CPE to run concurrently
@@ -75,7 +75,7 @@ namespace cms
     //--- realistic use case...
 
     //--- The top-level event method.
-    virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
+    void produce(edm::Event& e, const edm::EventSetup& c) override;
 
     //--- Execute the position estimator algorithm(s).
     //--- New interface with DetSetVector

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -66,14 +66,14 @@ PixelCPEGenericESProducer::produce(const TkPixelCPERecord & iRecord){
 
   // add the new la width object
   ESHandle<SiPixelLorentzAngle> lorentzAngleWidth;
-  const SiPixelLorentzAngle * lorentzAngleWidthProduct = 0;
+  const SiPixelLorentzAngle * lorentzAngleWidthProduct = nullptr;
   if(useLAWidthFromDB_) { // use the width LA
     iRecord.getRecord<SiPixelLorentzAngleRcd>().get("forWidth",lorentzAngleWidth );
     lorentzAngleWidthProduct = lorentzAngleWidth.product();
-  } else { lorentzAngleWidthProduct = NULL;} // do not use it
+  } else { lorentzAngleWidthProduct = nullptr;} // do not use it
   //std::cout<<" la width "<<lorentzAngleWidthProduct<<std::endl; //dk
 
-  const SiPixelGenErrorDBObject * genErrorDBObjectProduct = 0;
+  const SiPixelGenErrorDBObject * genErrorDBObjectProduct = nullptr;
 
   // Errors take only from new GenError
   ESHandle<SiPixelGenErrorDBObject> genErrorDBObject;

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
@@ -48,13 +48,13 @@ PixelCPETemplateRecoESProducer::produce(const TkPixelCPERecord & iRecord){
   iRecord.getRecord<TrackerDigiGeometryRecord>().getRecord<TrackerTopologyRcd>().get(hTT);
 
   edm::ESHandle<SiPixelLorentzAngle> lorentzAngle;
-  const SiPixelLorentzAngle * lorentzAngleProduct = 0;
+  const SiPixelLorentzAngle * lorentzAngleProduct = nullptr;
   if(DoLorentz_) { //  LA correction from alignment 
     iRecord.getRecord<SiPixelLorentzAngleRcd>().get("fromAlignment",lorentzAngle);
     lorentzAngleProduct = lorentzAngle.product();
   } else { // Normal, deafult LA actually is NOT needed
     //iRecord.getRecord<SiPixelLorentzAngleRcd>().get(lorentzAngle);
-    lorentzAngleProduct=NULL;  // null is ok becuse LA is not use by templates in this mode
+    lorentzAngleProduct=nullptr;  // null is ok becuse LA is not use by templates in this mode
   }
 
   ESHandle<SiPixelTemplateDBObject> templateDBobject;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
@@ -460,7 +460,7 @@ PixelCPEBase::driftDirection(DetParam & theDetParam, LocalVector Bfield ) const 
    // Use LA from DB or from config
    float langle = 0.;
    if( !useLAOffsetFromConfig_ ) {  // get it from DB
-      if(lorentzAngle_ != NULL) {  // a real LA object
+      if(lorentzAngle_ != nullptr) {  // a real LA object
          langle = lorentzAngle_->getLorentzAngle(theDetParam.theDet->geographicalId().rawId());
          //cout<<" la "<<langle<<" "<< theDetParam.theDet->geographicalId().rawId() <<endl;
       } else { // no LA, unused
@@ -480,7 +480,7 @@ PixelCPEBase::driftDirection(DetParam & theDetParam, LocalVector Bfield ) const 
    // Compute the charge width, generic only
    if(theFlag_==0) {
       
-      if(useLAWidthFromDB_ && (lorentzAngleWidth_ != NULL) ) {
+      if(useLAWidthFromDB_ && (lorentzAngleWidth_ != nullptr) ) {
          // take it from a seperate, special LA DB object (forWidth)
          
          auto langleWidth = lorentzAngleWidth_->getLorentzAngle(theDetParam.theDet->geographicalId().rawId());

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -31,8 +31,8 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const & conf,
                                  const TrackerTopology& ttopo,
                                  const SiPixelLorentzAngle * lorentzAngle,
                                  const SiPixelGenErrorDBObject * genErrorDBObject,
-                                 const SiPixelLorentzAngle * lorentzAngleWidth=0)
-: PixelCPEBase(conf, mag, geom, ttopo, lorentzAngle, genErrorDBObject, 0,lorentzAngleWidth,0) {
+                                 const SiPixelLorentzAngle * lorentzAngleWidth=nullptr)
+: PixelCPEBase(conf, mag, geom, ttopo, lorentzAngle, genErrorDBObject, nullptr,lorentzAngleWidth,0) {
    
    if (theVerboseLevel > 0)
       LogDebug("PixelCPEGeneric")

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -46,7 +46,7 @@ PixelCPETemplateReco::PixelCPETemplateReco(edm::ParameterSet const & conf,
                                            const TrackerTopology& ttopo,
                                            const SiPixelLorentzAngle * lorentzAngle,
                                            const SiPixelTemplateDBObject * templateDBobject)
-: PixelCPEBase(conf, mag, geom, ttopo, lorentzAngle, 0, templateDBobject, 0,1)
+: PixelCPEBase(conf, mag, geom, ttopo, lorentzAngle, nullptr, templateDBobject, nullptr,1)
 {
    //cout << endl;
    //cout << "Constructing PixelCPETemplateReco::PixelCPETemplateReco(...)................................................." << endl;

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelGenError.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelGenError.cc
@@ -11,7 +11,7 @@
 //#include <stdlib.h>
 //#include <stdio.h>
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-#include <math.h>
+#include <cmath>
 #else
 #include <math.h>
 #endif

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -118,7 +118,7 @@ namespace {
       }
     
     
-    ~ClusterFiller() { printStat();}
+    ~ClusterFiller() override { printStat();}
     
     void fill(StripClusterizerAlgorithm::output_t::TSFastFiller & record) override;
     
@@ -201,12 +201,12 @@ class SiStripClusterizerFromRaw final : public edm::stream::EDProducer<>  {
       }
   
 
-  void beginRun( const edm::Run&, const edm::EventSetup& es) {
+  void beginRun( const edm::Run&, const edm::EventSetup& es) override {
     initialize(es);
   }
   
   
-  void produce(edm::Event& ev, const edm::EventSetup& es) {
+  void produce(edm::Event& ev, const edm::EventSetup& es) override {
     
     initialize(es);
     

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterToDigiProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterToDigiProducer.cc
@@ -109,7 +109,7 @@ process(const ClusterCollection& input, std::vector<DetDigiCollection>& output_b
       }
     }
     
-    if (detDigis.size()) 
+    if (!detDigis.empty()) 
       output_base.push_back(detDigis); 
   }
 }

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
@@ -15,7 +15,7 @@ class SiStripClusterizer : public edm::stream::EDProducer<>  {
 public:
 
   explicit SiStripClusterizer(const edm::ParameterSet& conf);
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
 

--- a/RecoLocalTracker/SiStripClusterizer/src/StripClusterizerAlgorithm.cc
+++ b/RecoLocalTracker/SiStripClusterizer/src/StripClusterizerAlgorithm.cc
@@ -57,7 +57,7 @@ initialize(const edm::EventSetup& es) {
     indices.resize(detIds.size());
     COUT << "good detIds " << detIds.size() << std::endl;
 
-    if (0==detIds.size()) return;
+    if (detIds.empty()) return;
 
     {
       connections.clear();

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/CrosstalkInversion.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/CrosstalkInversion.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 #include <cmath>
-#include <stdint.h>
+#include <cstdint>
 #include "RecoLocalTracker/SiStripRecHitConverter/interface/ErrorPropogationTypes.h"
 
 class SiStripCluster;

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
@@ -212,7 +212,7 @@ void SiStripRecHitMatcher::doubleMatch(MonoIterator monoRHiter, MonoIterator mon
     
    // in case of no track hypothesis assume a track from the origin through the center of the strip
     if(notk){
-      LocalPoint lcenterofstrip=secondHit.localPositionFast();
+      const LocalPoint& lcenterofstrip=secondHit.localPositionFast();
       GlobalPoint gcenterofstrip= partnerStripDetTrans.toGlobal(lcenterofstrip);
       GlobalVector gtrackdirection=gcenterofstrip-GlobalPoint(0,0,0);
       trdir=gluedDetInvTrans.toLocal(gtrackdirection);
@@ -255,7 +255,7 @@ void SiStripRecHitMatcher::doubleMatch(MonoIterator monoRHiter, MonoIterator mon
     
     // in case of no track hypothesis assume a track from the origin through the center of the strip
     if(notk){
-      LocalPoint lcenterofstrip=monoRH.localPositionFast();
+      const LocalPoint& lcenterofstrip=monoRH.localPositionFast();
       GlobalPoint gcenterofstrip= stripDetTrans.toGlobal(lcenterofstrip);
       GlobalVector gtrackdirection=gcenterofstrip-GlobalPoint(0,0,0);
       trdir=gluedDetInvTrans.toLocal(gtrackdirection);

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEfromTemplate.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEfromTemplate.h
@@ -14,7 +14,7 @@ class StripCPEfromTemplate : public StripCPE
   
 
   StripClusterParameterEstimator::LocalValues 
-    localParameters( const SiStripCluster&, const GeomDetUnit&, const LocalTrajectoryParameters&) const;
+    localParameters( const SiStripCluster&, const GeomDetUnit&, const LocalTrajectoryParameters&) const override;
 
   StripCPEfromTemplate( edm::ParameterSet & conf, 
 			  const MagneticField& mag, 

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEgeometric.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEgeometric.h
@@ -10,7 +10,7 @@ class StripCPEgeometric : public StripCPE
  public:
  
   StripClusterParameterEstimator::LocalValues 
-    localParameters( const SiStripCluster&, const GeomDetUnit&, const LocalTrajectoryParameters&) const;
+    localParameters( const SiStripCluster&, const GeomDetUnit&, const LocalTrajectoryParameters&) const override;
 
   StripCPEgeometric( edm::ParameterSet& conf, 
 		     const MagneticField& mag, 

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitConverter.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitConverter.h
@@ -11,7 +11,7 @@ class SiStripRecHitConverter : public edm::stream::EDProducer<>
  public:
   
   explicit SiStripRecHitConverter(const edm::ParameterSet&);
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  void produce(edm::Event&, const edm::EventSetup&) override;
   
  private:
   

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
@@ -329,6 +329,6 @@ bool SiStripRecHitConverterAlgorithm::
 useModule(const uint32_t id) const
 {
   const StripGeomDetUnit * stripdet=(const StripGeomDetUnit*)tracker->idToDetUnit(id);
-  if(stripdet==0) edm::LogWarning("SiStripRecHitConverter") << "Detid=" << id << " not found";
-  return stripdet!=0 && (!useQuality || quality->IsModuleUsable(id));
+  if(stripdet==nullptr) edm::LogWarning("SiStripRecHitConverter") << "Detid=" << id << " not found";
+  return stripdet!=nullptr && (!useQuality || quality->IsModuleUsable(id));
 }

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
@@ -122,7 +122,7 @@ SiStripRecHitMatcher::match( const SiStripRecHit2D *monoRH,
   StripPosition stripmono=StripPosition(topol.localPosition(RPHIpointini),topol.localPosition(RPHIpointend));
 
   if(trackdirection.mag2()<FLT_MIN){// in case of no track hypothesis assume a track from the origin through the center of the strip
-    LocalPoint lcenterofstrip=monoRH->localPositionFast();
+    const LocalPoint& lcenterofstrip=monoRH->localPositionFast();
     GlobalPoint gcenterofstrip=(stripdet->surface()).toGlobal(lcenterofstrip);
     GlobalVector gtrackdirection=gcenterofstrip-GlobalPoint(0,0,0);
     trackdirection=(gluedDet->surface()).toLocal(gtrackdirection);
@@ -285,7 +285,7 @@ SiStripRecHitMatcher::match(const SiStripRecHit2D *monoRH,
   StripPosition stripmono=StripPosition(topol.localPosition(RPHIpointini),topol.localPosition(RPHIpointend));
 
   if(trackdirection.mag2()<float(FLT_MIN)){// in case of no track hypothesis assume a track from the origin through the center of the strip
-    LocalPoint lcenterofstrip=monoRH->localPositionFast();
+    const LocalPoint& lcenterofstrip=monoRH->localPositionFast();
     GlobalPoint gcenterofstrip=(stripdet->surface()).toGlobal(lcenterofstrip);
     GlobalVector gtrackdirection=gcenterofstrip-GlobalPoint(0,0,0);
     trackdirection=(gluedDet->surface()).toLocal(gtrackdirection);

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripTemplateReco.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripTemplateReco.cc
@@ -15,7 +15,7 @@
 //
 //
 
-#include <math.h>
+#include <cmath>
 #include <algorithm>
 #include <vector>
 #include <utility>

--- a/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTemplate.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTemplate.cc
@@ -128,7 +128,7 @@ StripCPEfromTemplate::localParameters( const SiStripCluster& cluster,
       
       const StripGeomDetUnit* stripdet = (const StripGeomDetUnit*)(&det);
  
-      if ( (id  > -9999999) && !(stripdet == 0) )
+      if ( (id  > -9999999) && !(stripdet == nullptr) )
 	{
 	  // Variables needed by template reco
 	  float cotalpha = -9999999.9; 

--- a/RecoLocalTracker/SiStripZeroSuppression/interface/FastLinearCMNSubtractor.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/interface/FastLinearCMNSubtractor.h
@@ -8,8 +8,8 @@ class FastLinearCMNSubtractor : public SiStripCommonModeNoiseSubtractor {
 
  public:  
 
-  void subtract(const uint32_t&,const uint16_t&, std::vector<int16_t>&);
-  void subtract(const uint32_t&,const uint16_t&, std::vector<float>&);
+  void subtract(const uint32_t&,const uint16_t&, std::vector<int16_t>&) override;
+  void subtract(const uint32_t&,const uint16_t&, std::vector<float>&) override;
 
  private:
 

--- a/RecoLocalTracker/SiStripZeroSuppression/interface/IteratedMedianCMNSubtractor.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/interface/IteratedMedianCMNSubtractor.h
@@ -14,9 +14,9 @@ class IteratedMedianCMNSubtractor : public SiStripCommonModeNoiseSubtractor {
   
  public:
   
-  void init(const edm::EventSetup& es);
-  void subtract(const uint32_t&,const uint16_t&, std::vector<int16_t>&);
-  void subtract(const uint32_t&,const uint16_t&, std::vector<float>&);
+  void init(const edm::EventSetup& es) override;
+  void subtract(const uint32_t&,const uint16_t&, std::vector<int16_t>&) override;
+  void subtract(const uint32_t&,const uint16_t&, std::vector<float>&) override;
   
  private:
 

--- a/RecoLocalTracker/SiStripZeroSuppression/interface/MedianCMNSubtractor.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/interface/MedianCMNSubtractor.h
@@ -8,8 +8,8 @@ class MedianCMNSubtractor : public SiStripCommonModeNoiseSubtractor {
   
  public:
   
-  void subtract(const uint32_t&,const uint16_t&, std::vector<int16_t>&);
-  void subtract(const uint32_t&,const uint16_t&,std::vector<float>&);
+  void subtract(const uint32_t&,const uint16_t&, std::vector<int16_t>&) override;
+  void subtract(const uint32_t&,const uint16_t&,std::vector<float>&) override;
  
  private:
   

--- a/RecoLocalTracker/SiStripZeroSuppression/interface/PercentileCMNSubtractor.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/interface/PercentileCMNSubtractor.h
@@ -8,8 +8,8 @@ class PercentileCMNSubtractor : public SiStripCommonModeNoiseSubtractor {
   
  public:
   
-  void subtract(const uint32_t&,const uint16_t& firstAPV, std::vector<int16_t>&);
-  void subtract(const uint32_t&,const uint16_t& firstAPV, std::vector<float>&);
+  void subtract(const uint32_t&,const uint16_t& firstAPV, std::vector<int16_t>&) override;
+  void subtract(const uint32_t&,const uint16_t& firstAPV, std::vector<float>&) override;
   
  private:
   

--- a/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripAPVRestorer.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripAPVRestorer.h
@@ -20,7 +20,7 @@
 #include "RecoLocalTracker/SiStripZeroSuppression/interface/SiStripCommonModeNoiseSubtractor.h"
 
 #include <vector>
-#include <stdint.h>
+#include <cstdint>
 
 typedef std::map<uint16_t, int16_t> DigiMap;
 typedef std::map<uint16_t, std::vector < int16_t> > RawDigiMap;

--- a/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripCommonModeNoiseSubtractor.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripCommonModeNoiseSubtractor.h
@@ -4,7 +4,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include <vector>
 #include <algorithm>
-#include <stdint.h>
+#include <cstdint>
 
 class SiStripCommonModeNoiseSubtractor {
 

--- a/RecoLocalTracker/SiStripZeroSuppression/interface/TT6CMNSubtractor.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/interface/TT6CMNSubtractor.h
@@ -12,9 +12,9 @@ class TT6CMNSubtractor : public SiStripCommonModeNoiseSubtractor {
   
  public:
   
-  void init(const edm::EventSetup& es);
-  void subtract(const uint32_t&, const uint16_t&, std::vector<int16_t>&);
-  void subtract(const uint32_t&, const uint16_t&, std::vector<float>&);
+  void init(const edm::EventSetup& es) override;
+  void subtract(const uint32_t&, const uint16_t&, std::vector<int16_t>&) override;
+  void subtract(const uint32_t&, const uint16_t&, std::vector<float>&) override;
   
  private:
 

--- a/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripBaselineAnalyzer.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripBaselineAnalyzer.cc
@@ -76,13 +76,13 @@
 class SiStripBaselineAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
    public:
       explicit SiStripBaselineAnalyzer(const edm::ParameterSet&);
-      ~SiStripBaselineAnalyzer();
+      ~SiStripBaselineAnalyzer() override;
 
 
    private:
-      virtual void beginJob() override ;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override ;
+      void beginJob() override ;
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
       
 	  std::auto_ptr<SiStripPedestalsSubtractor>   subtractorPed_;
           edm::ESHandle<SiStripPedestals> pedestalsHandle;
@@ -264,7 +264,7 @@ SiStripBaselineAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& es)
 
 	  
       edm::DetSet<SiStripRawDigi>::const_iterator itRaw = itRawDigis->begin(); 
-      bool restAPV[6] = {0,0,0,0,0,0};
+      bool restAPV[6] = {false,false,false,false,false,false};
       int strip =0, totADC=0;
       int minAPVRes = 7, maxAPVRes = -1;
       for(;itRaw != itRawDigis->end(); ++itRaw, ++strip){

--- a/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripMeanCMExtractor.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripMeanCMExtractor.cc
@@ -53,12 +53,12 @@ typedef std::map<uint32_t, std::vector<float> > CMMap;
 class SiStripMeanCMExtractor : public edm::one::EDProducer<> {
    public:
       explicit SiStripMeanCMExtractor( const edm::ParameterSet&);
-      ~SiStripMeanCMExtractor();
+      ~SiStripMeanCMExtractor() override;
 
    private:
-      virtual void beginJob() override ;
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override ;
+      void beginJob() override ;
+      void produce(edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
       
 	  void init(const edm::EventSetup&);
 	  

--- a/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.cc
@@ -68,7 +68,7 @@ inline void SiStripZeroSuppression::StandardZeroSuppression(edm::Event& e){
     edm::Handle< edm::DetSetVector<SiStripRawDigi> > input;
     e.getByToken(*inputToken,input);
 
-      if (input->size())
+      if (!input->empty())
         processRaw(*inputTag, *input);
     
       e.put(std::make_unique<edm::DetSetVector<SiStripDigi>>(output_base), inputTag->instance());
@@ -126,7 +126,7 @@ processRaw(const edm::InputTag& inputTag, const edm::DetSetVector<SiStripRawDigi
 
       //here storing the output
       this->storeExtraOutput(rawDigis->id, nAPVflagged);
-      if (suppressedDigis.size() && (storeInZScollBadAPV || nAPVflagged ==0)) 
+      if (!suppressedDigis.empty() && (storeInZScollBadAPV || nAPVflagged ==0)) 
 	output_base.push_back(suppressedDigis); 
          
       if (produceRawDigis && nAPVflagged > 0){  
@@ -189,7 +189,7 @@ void SiStripZeroSuppression::storeBaseline(uint32_t id, const std::vector< std::
     
   }
   
-  if(baselineDetSet.size())
+  if(!baselineDetSet.empty())
     output_baseline.push_back(baselineDetSet);
   
 }
@@ -215,7 +215,7 @@ void SiStripZeroSuppression::storeBaselinePoints(uint32_t id){
       }    
 
     
-    if(baspointDetSet.size())
+    if(!baspointDetSet.empty())
     output_baseline_points.push_back(baspointDetSet);
   
 }
@@ -251,7 +251,7 @@ void SiStripZeroSuppression::storeCMN(uint32_t id, const std::vector< std::pair<
     apvNb++;
   }
    
-  if(apvDetSet.size())
+  if(!apvDetSet.empty())
     output_apvcm.push_back(apvDetSet);
   
 }
@@ -267,7 +267,7 @@ inline void SiStripZeroSuppression::MergeCollectionsZeroSuppression(edm::Event& 
 	
     std::cout << inputdigi->size() << " " << inputraw->size() << std::endl;
 	
-    if (inputraw->size()){
+    if (!inputraw->empty()){
 		
 		std::vector<edm::DetSet<SiStripDigi> > outputdigi; 
 		outputdigi.clear();
@@ -303,7 +303,7 @@ inline void SiStripZeroSuppression::MergeCollectionsZeroSuppression(edm::Event& 
 				std::vector<int16_t> processedRawDigis(rawDigis->size());
                                 algorithms->SuppressVirginRawData(*rawDigis, suppressedDigis);
 		  	   
-				if(suppressedDigis.size()){	  
+				if(!suppressedDigis.empty()){	  
 					std::cout << "looking for the detId with the new ZS in the collection of the zero suppressed data" << std::endl; 
 					std::vector<edm::DetSet<SiStripDigi> >::iterator zsModule = outputdigi.begin();
 					//std::vector<edm::DetSet<SiStripDigi> >::iterator LastLowerIdDigis = zsModule;
@@ -419,7 +419,7 @@ inline void SiStripZeroSuppression::CollectionMergedZeroSuppression(edm::Event& 
     std::vector<edm::DetSet<SiStripRawDigi> > outputraw;  
        
 	
-    if (inputraw->size())	
+    if (!inputraw->empty())	
       processRaw(*inputTag, *inputraw);
     
 	

--- a/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.h
@@ -19,7 +19,7 @@ class SiStripZeroSuppression : public edm::stream::EDProducer<>
  public:
   
   explicit SiStripZeroSuppression(const edm::ParameterSet&);  
-  virtual void produce(edm::Event& , const edm::EventSetup& );
+  void produce(edm::Event& , const edm::EventSetup& ) override;
   
  private:
 

--- a/RecoLocalTracker/SiStripZeroSuppression/src/IteratedMedianCMNSubtractor.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/IteratedMedianCMNSubtractor.cc
@@ -53,7 +53,7 @@ subtract_(const uint32_t& detId, const uint16_t& firstAPV, std::vector<T>& digis
     }
 
     // caluate offset for all good strips (first iteration)
-    if (subset.size() != 0)
+    if (!subset.empty())
       offset = pairMedian(subset);
 
     // for second, third... iterations, remove strips over threshold
@@ -68,7 +68,7 @@ subtract_(const uint32_t& detId, const uint16_t& firstAPV, std::vector<T>& digis
         else
           ++si;
       }
-      if ( subset.size() == 0 ) break;
+      if ( subset.empty() ) break;
       offset = pairMedian(subset);
     }        
 

--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripAPVRestorer.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripAPVRestorer.cc
@@ -318,7 +318,7 @@ void SiStripAPVRestorer::BaselineFollowerRestore(const uint16_t& APVn, const uin
     
   //============================= Find Flat Regions & Interpolating the baseline & subtracting the baseline  =================	
   
-  if(SmoothedMaps_.size()){
+  if(!SmoothedMaps_.empty()){
     std::map<uint16_t, DigiMap >::iterator itSmootedMap = SmoothedMaps_.find(APVn);	
     this->BaselineFollower(itSmootedMap->second, baseline, median);
   } else {

--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripRawProcessingFactory.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripRawProcessingFactory.cc
@@ -87,7 +87,7 @@ create_Suppressor(const edm::ParameterSet& conf) {
 std::auto_ptr<SiStripAPVRestorer> SiStripRawProcessingFactory::
 create_Restorer( const edm::ParameterSet& conf) {
   if(!conf.exists("APVRestoreMode")) {
-    return std::auto_ptr<SiStripAPVRestorer>( 0 );
+    return std::auto_ptr<SiStripAPVRestorer>( nullptr );
   } else {
     return std::auto_ptr<SiStripAPVRestorer> (new SiStripAPVRestorer(conf));
   }

--- a/RecoLocalTracker/SubCollectionProducers/interface/ClusterMultiplicityFilter.h
+++ b/RecoLocalTracker/SubCollectionProducers/interface/ClusterMultiplicityFilter.h
@@ -14,10 +14,10 @@
 class ClusterMultiplicityFilter : public edm::global::EDFilter<> {
    public:
       explicit ClusterMultiplicityFilter(const edm::ParameterSet&);
-      ~ClusterMultiplicityFilter();
+      ~ClusterMultiplicityFilter() override;
 
    private:
-      virtual bool filter(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+      bool filter(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
 
       const unsigned int maxNumberOfClusters_;
       const edm::InputTag clusterCollectionTag_;

--- a/RecoLocalTracker/SubCollectionProducers/interface/ClusterSummaryProducer.h
+++ b/RecoLocalTracker/SubCollectionProducers/interface/ClusterSummaryProducer.h
@@ -26,7 +26,7 @@
 #include <map>
 #include <vector>
 #include<iostream>
-#include <string.h>
+#include <cstring>
 // user include files
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -68,11 +68,11 @@ class ClusterSummary;
 class ClusterSummaryProducer : public edm::stream::EDProducer<> {
    public:
       explicit ClusterSummaryProducer(const edm::ParameterSet&);
-      ~ClusterSummaryProducer(){};
+      ~ClusterSummaryProducer() override{};
 
    private:
-      virtual void beginStream(edm::StreamID) override;
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      void beginStream(edm::StreamID) override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
       
 
       typedef std::pair<DetIdSelector,ClusterSummary::CMSTracker> ModuleSelection;

--- a/RecoLocalTracker/SubCollectionProducers/src/ClusterChargeMasker.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/ClusterChargeMasker.cc
@@ -25,7 +25,7 @@ namespace {
   class ClusterChargeMasker : public edm::stream::EDProducer<> {
   public:
     ClusterChargeMasker(const edm::ParameterSet& iConfig);
-    ~ClusterChargeMasker(){}
+    ~ClusterChargeMasker() override{}
     void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override ;
   private:
  

--- a/RecoLocalTracker/SubCollectionProducers/src/ClusterMultiplicityFilter.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/ClusterMultiplicityFilter.cc
@@ -37,7 +37,7 @@ bool ClusterMultiplicityFilter::filter(edm::StreamID iID, edm::Event& iEvent, ed
 
   bool result = true;
 
-  const edmNew::DetSetVector<SiStripCluster> *clusters = 0;
+  const edmNew::DetSetVector<SiStripCluster> *clusters = nullptr;
   edm::Handle<edmNew::DetSetVector<SiStripCluster> > clusterHandle;
   iEvent.getByToken(clusters_,clusterHandle);
   if( !clusterHandle.isValid() ) {

--- a/RecoLocalTracker/SubCollectionProducers/src/HITrackClusterRemover.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/HITrackClusterRemover.cc
@@ -44,7 +44,7 @@
 class HITrackClusterRemover : public edm::stream::EDProducer<> {
     public:
         HITrackClusterRemover(const edm::ParameterSet& iConfig) ;
-        ~HITrackClusterRemover() ;
+        ~HITrackClusterRemover() override ;
         void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override ;
     private:
         struct ParamBlock {
@@ -267,7 +267,7 @@ HITrackClusterRemover::cleanup(const edmNew::DetSetVector<T> &oldClusters, const
         if (outds.empty()) outds.abort(); // not write in an empty DSV
     }
 
-    if (oldRefs != 0) mergeOld(refs, *oldRefs);
+    if (oldRefs != nullptr) mergeOld(refs, *oldRefs);
     return output;
 }
 
@@ -461,7 +461,7 @@ HITrackClusterRemover::produce(Event& iEvent, const EventSetup& iSetup)
       iEvent.getByToken(tracks_,tracks);
 
       std::vector<Handle<edm::ValueMap<int> > > quals;
-      if ( overrideTrkQuals_.size() > 0) {
+      if ( !overrideTrkQuals_.empty()) {
 	quals.resize(1);
 	iEvent.getByToken(overrideTrkQuals_[0],quals[0]);
       }
@@ -469,7 +469,7 @@ HITrackClusterRemover::produce(Event& iEvent, const EventSetup& iSetup)
       for (const auto & track: *tracks) {
 	if (filterTracks_) {
 	  bool goodTk = true;
-	  if ( quals.size()!=0) {
+	  if ( !quals.empty()) {
 	    int qual=(*(quals[0])). get(it++);
 	    if ( qual < 0 ) {goodTk=false;}
 	    //note that this does not work for some trackquals (goodIterative  or undefQuality)
@@ -518,12 +518,12 @@ HITrackClusterRemover::produce(Event& iEvent, const EventSetup& iSetup)
 
     if (doPixel_ && clusterWasteSolution_) {
         OrphanHandle<edmNew::DetSetVector<SiPixelCluster> > newPixels =
-          iEvent.put(cleanup(*pixelClusters, pixels, cri->pixelIndices(), mergeOld_ ? &oldRemovalInfo->pixelIndices() : 0));
+          iEvent.put(cleanup(*pixelClusters, pixels, cri->pixelIndices(), mergeOld_ ? &oldRemovalInfo->pixelIndices() : nullptr));
 //DBG// std::cout << "HITrackClusterRemover: Wrote pixel " << newPixels.id() << " from " << pixelSourceProdID << std::endl;
         cri->setNewPixelClusters(newPixels);
     }
     if (doStrip_ && clusterWasteSolution_) {
-        OrphanHandle<edmNew::DetSetVector<SiStripCluster> > newStrips = iEvent.put(cleanup(*stripClusters, strips, cri->stripIndices(), mergeOld_ ? &oldRemovalInfo->stripIndices() : 0));
+        OrphanHandle<edmNew::DetSetVector<SiStripCluster> > newStrips = iEvent.put(cleanup(*stripClusters, strips, cri->stripIndices(), mergeOld_ ? &oldRemovalInfo->stripIndices() : nullptr));
 //DBG// std::cout << "HITrackClusterRemover: Wrote strip " << newStrips.id() << " from " << stripSourceProdID << std::endl;
         cri->setNewStripClusters(newStrips);
     }

--- a/RecoLocalTracker/SubCollectionProducers/src/HLTTrackClusterRemoverNew.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/HLTTrackClusterRemoverNew.cc
@@ -39,7 +39,7 @@
 class HLTTrackClusterRemoverNew final : public edm::stream::EDProducer<> {
     public:
         HLTTrackClusterRemoverNew(const edm::ParameterSet& iConfig) ;
-        ~HLTTrackClusterRemoverNew() ;
+        ~HLTTrackClusterRemoverNew() override ;
         void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override ;
     private:
         struct ParamBlock {
@@ -240,7 +240,7 @@ HLTTrackClusterRemoverNew::cleanup(const edmNew::DetSetVector<T> &oldClusters, c
     }
     //    double fraction = countNew  / (double) countOld;
     //    std::cout<<"fraction: "<<fraction<<std::endl;
-    if (oldRefs != 0) mergeOld(refs, *oldRefs);
+    if (oldRefs != nullptr) mergeOld(refs, *oldRefs);
     return output;
 }
 

--- a/RecoLocalTracker/SubCollectionProducers/src/JetCoreClusterSplitter.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/JetCoreClusterSplitter.cc
@@ -26,8 +26,8 @@
 class JetCoreClusterSplitter : public edm::stream::EDProducer<> {
  public:
   JetCoreClusterSplitter(const edm::ParameterSet& iConfig);
-  ~JetCoreClusterSplitter();
-  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup);
+  ~JetCoreClusterSplitter() override;
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
  private:
   bool split(const SiPixelCluster& aCluster,
@@ -214,7 +214,7 @@ bool JetCoreClusterSplitter::split(
           [](SiPixelCluster const & cl1,SiPixelCluster const & cl2) { return cl1.minPixelRow() < cl2.minPixelRow();});
   }
 
-  return (sp.size() > 0);
+  return (!sp.empty());
 }
 
 // order with fast algo and pick first and second instead?
@@ -500,7 +500,7 @@ std::vector<SiPixelCluster> JetCoreClusterSplitter::fittingSplit(
       }
     }
     if (verbose) std::cout << std::endl;
-    if (pixelsForCl[cl].size() > 0) {
+    if (!pixelsForCl[cl].empty()) {
       if (forceXError_ > 0) output.back().setSplitClusterErrorX(forceXError_);
       if (forceYError_ > 0) output.back().setSplitClusterErrorY(forceYError_);
     }

--- a/RecoLocalTracker/SubCollectionProducers/src/SeedClusterRemover.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/SeedClusterRemover.cc
@@ -41,7 +41,7 @@
 class SeedClusterRemover : public edm::stream::EDProducer<> {
     public:
         SeedClusterRemover(const edm::ParameterSet& iConfig) ;
-        ~SeedClusterRemover() ;
+        ~SeedClusterRemover() override ;
         void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override ;
     private:
         struct ParamBlock {
@@ -233,7 +233,7 @@ SeedClusterRemover::cleanup(const edmNew::DetSetVector<T> &oldClusters, const st
         if (outds.empty()) outds.abort(); // not write in an empty DSV
     }
 
-    if (oldRefs != 0) mergeOld(refs, *oldRefs);
+    if (oldRefs != nullptr) mergeOld(refs, *oldRefs);
     return output;
 }
 
@@ -417,13 +417,13 @@ SeedClusterRemover::produce(Event& iEvent, const EventSetup& iSetup)
     
     if (doPixel_ && clusterWasteSolution_) {
         OrphanHandle<edmNew::DetSetVector<SiPixelCluster> > newPixels =
-          iEvent.put(cleanup(*pixelClusters, pixels, cri->pixelIndices(), mergeOld_ ? &oldRemovalInfo->pixelIndices() : 0));
+          iEvent.put(cleanup(*pixelClusters, pixels, cri->pixelIndices(), mergeOld_ ? &oldRemovalInfo->pixelIndices() : nullptr));
 //DBG// std::cout << "SeedClusterRemover: Wrote pixel " << newPixels.id() << " from " << pixelSourceProdID << std::endl;
         cri->setNewPixelClusters(newPixels);
     }
     if (doStrip_ && clusterWasteSolution_) {
         OrphanHandle<edmNew::DetSetVector<SiStripCluster> > newStrips =
-          iEvent.put(cleanup(*stripClusters, strips, cri->stripIndices(), mergeOld_ ? &oldRemovalInfo->stripIndices() : 0));
+          iEvent.put(cleanup(*stripClusters, strips, cri->stripIndices(), mergeOld_ ? &oldRemovalInfo->stripIndices() : nullptr));
 //DBG// std::cout << "SeedClusterRemover: Wrote strip " << newStrips.id() << " from " << stripSourceProdID << std::endl;
         cri->setNewStripClusters(newStrips);
     }

--- a/RecoLocalTracker/SubCollectionProducers/src/SeedClusterRemoverPhase2.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/SeedClusterRemoverPhase2.cc
@@ -40,7 +40,7 @@ class SeedClusterRemoverPhase2 : public edm::stream::EDProducer<> {
 
   public:
     SeedClusterRemoverPhase2(const edm::ParameterSet& iConfig) ;
-    ~SeedClusterRemoverPhase2() ;
+    ~SeedClusterRemoverPhase2() override ;
     void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override ;
   private:
     bool doOuterTracker_, doPixel_;
@@ -163,7 +163,7 @@ SeedClusterRemoverPhase2::cleanup(const edmNew::DetSetVector<T> &oldClusters, co
         if (outds.empty()) outds.abort(); // not write in an empty DSV
     }
 
-    if (oldRefs != 0) mergeOld(refs, *oldRefs);
+    if (oldRefs != nullptr) mergeOld(refs, *oldRefs);
     return output;
 }
 
@@ -315,13 +315,13 @@ SeedClusterRemoverPhase2::produce(Event& iEvent, const EventSetup& iSetup)
     
     if (doPixel_ && clusterWasteSolution_) {
         OrphanHandle<edmNew::DetSetVector<SiPixelCluster> > newPixels =
-          iEvent.put(cleanup(*pixelClusters, pixels, cri->pixelIndices(), mergeOld_ ? &oldRemovalInfo->pixelIndices() : 0));
+          iEvent.put(cleanup(*pixelClusters, pixels, cri->pixelIndices(), mergeOld_ ? &oldRemovalInfo->pixelIndices() : nullptr));
         LogDebug("SeedClusterRemoverPhase2") << "SeedClusterRemoverPhase2: Wrote pixel " << newPixels.id() << " from " << pixelSourceProdID ;
         cri->setNewPixelClusters(newPixels);
     }
     if (doOuterTracker_ && clusterWasteSolution_) {
         OrphanHandle<edmNew::DetSetVector<Phase2TrackerCluster1D> > newOuterTrackers =
-          iEvent.put(cleanup(*phase2OTClusters, OTs, cri->stripIndices(), mergeOld_ ? &oldRemovalInfo->stripIndices() : 0));
+          iEvent.put(cleanup(*phase2OTClusters, OTs, cri->stripIndices(), mergeOld_ ? &oldRemovalInfo->stripIndices() : nullptr));
         LogDebug("SeedClusterRemoverPhase2") << "SeedClusterRemoverPhase2: Wrote strip " << newOuterTrackers.id() << " from " << outerTrackerSourceProdID;
         cri->setNewPhase2OTClusters(newOuterTrackers);
     }

--- a/RecoLocalTracker/SubCollectionProducers/src/TopBottomClusterInfoProducer.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/TopBottomClusterInfoProducer.cc
@@ -32,7 +32,7 @@
 class TopBottomClusterInfoProducer : public edm::global::EDProducer<> {
 public:
   TopBottomClusterInfoProducer(const edm::ParameterSet& iConfig) ;
-  ~TopBottomClusterInfoProducer() ;
+  ~TopBottomClusterInfoProducer() override ;
   void produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const override ;
   
 private:

--- a/RecoLocalTracker/SubCollectionProducers/src/TrackClusterRemover.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/TrackClusterRemover.cc
@@ -32,11 +32,11 @@ namespace {
   class TrackClusterRemover final : public edm::global::EDProducer<> {
   public:
     TrackClusterRemover(const edm::ParameterSet& iConfig) ;
-    ~TrackClusterRemover(){}
+    ~TrackClusterRemover() override{}
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   private:
     
-    virtual void produce(edm::StreamID, edm::Event& evt, const edm::EventSetup&) const override;
+    void produce(edm::StreamID, edm::Event& evt, const edm::EventSetup&) const override;
  
     using PixelMaskContainer    = edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster>>;
     using StripMaskContainer    = edm::ContainerMask<edmNew::DetSetVector<SiStripCluster>>;

--- a/RecoLocalTracker/SubCollectionProducers/src/TrackClusterRemoverPhase2.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/TrackClusterRemoverPhase2.cc
@@ -36,11 +36,11 @@ namespace {
   class TrackClusterRemoverPhase2 final : public edm::global::EDProducer<> {
   public:
     TrackClusterRemoverPhase2(const edm::ParameterSet& iConfig) ;
-    ~TrackClusterRemoverPhase2(){}
+    ~TrackClusterRemoverPhase2() override{}
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   private:
     
-    virtual void produce(edm::StreamID, edm::Event& evt, const edm::EventSetup&) const override;
+    void produce(edm::StreamID, edm::Event& evt, const edm::EventSetup&) const override;
  
     using PixelMaskContainer    = edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster>>;
     using Phase2OTMaskContainer = edm::ContainerMask<edmNew::DetSetVector<Phase2TrackerCluster1D>>;

--- a/RecoLocalTracker/SubCollectionProducers/src/TrackClusterSplitter.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/TrackClusterSplitter.cc
@@ -66,7 +66,7 @@ class TrackClusterSplitter : public edm::stream::EDProducer<>
 
 public:
   TrackClusterSplitter(const edm::ParameterSet& iConfig) ;
-  ~TrackClusterSplitter() ;
+  ~TrackClusterSplitter() override ;
   void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override ;
   
 private:
@@ -435,7 +435,7 @@ TrackClusterSplitter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
                 }  
 
 	      const TrackingRecHit *hit = *it_hit;
-	      if ( hit == 0 || !hit->isValid() )
+	      if ( hit == nullptr || !hit->isValid() )
 		continue;
 	      
 	      int subdet = hit->geographicalId().subdetId();
@@ -470,7 +470,7 @@ TrackClusterSplitter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	  for (; it_hit != ed_hit; ++it_hit) 
 	    {
 	      const TrackingRecHit *hit = *it_hit;
-	      if ( hit == 0 || !hit->isValid() ) 
+	      if ( hit == nullptr || !hit->isValid() ) 
 		continue;
 	      
 	      int subdet = hit->geographicalId().subdetId();
@@ -480,7 +480,7 @@ TrackClusterSplitter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	      
 	      const GeomDet *det = geometry_->idToDet( hit->geographicalId() );
 	      
-	      if ( det == 0 ) 
+	      if ( det == nullptr ) 
 		{
 		  edm::LogError("MissingDetId") << "DetIDs " << (int)(hit->geographicalId()) << " is not in geometry.\n";
 		  continue;
@@ -561,7 +561,7 @@ TrackClusterSplitter::splitClusters(const std::map<uint32_t, boost::sub_range<st
     {
       const GeomDet* det = geometry_->idToDet( DetId(p.first) );
       
-      if ( det == 0 ) 
+      if ( det == nullptr ) 
       	{ 
       	  edm::LogError("MissingDetId") << "DetIDs " << p.first << " is not in geometry.\n";
 	  continue;
@@ -749,7 +749,7 @@ void TrackClusterSplitter::splitCluster<SiStripCluster> (const SiStripClusterWit
 		  for (size_t j=0; j<trackAmp[i].size(); ++j ) 
 		    clusterAmp += (float)(trackAmp[i])[j];
 		  
-		  if ( clusterAmp > 0.0 && firstStrip[i] != 9999 && trackAmp[i].size() > 0  ) 
+		  if ( clusterAmp > 0.0 && firstStrip[i] != 9999 && !trackAmp[i].empty()  ) 
 		    { 
 		      // gavril :  I think this should work
 		      output.push_back( newCluster[i] );


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this quickly to avoid conflicts to the extent possible]