### PR TITLE
Clang-tidy checks for RecoLuminosity

### DIFF
--- a/RecoLuminosity/LumiProducer/interface/DataPipe.h
+++ b/RecoLuminosity/LumiProducer/interface/DataPipe.h
@@ -32,8 +32,8 @@ namespace lumi{
     float m_norm; //Lumi2DB specific
     bool m_nocheckingstablebeam; //Lumi2DB specific
   private:
-    DataPipe( const DataPipe& );
-    const DataPipe& operator=( const DataPipe& );
+    DataPipe( const DataPipe& ) = delete;
+    const DataPipe& operator=( const DataPipe& ) = delete;
   };//class DataPipe
 }//ns lumi
 #endif

--- a/RecoLuminosity/LumiProducer/interface/Exception.h
+++ b/RecoLuminosity/LumiProducer/interface/Exception.h
@@ -8,8 +8,8 @@ namespace lumi{
     Exception( const std::string& message,
 	       const std::string& methodname,
 	       const std::string& moduleName);
-    virtual ~Exception() throw(){}
-    virtual char const* what() const throw(){
+    ~Exception() throw() override{}
+    char const* what() const throw() override{
       return m_message.c_str();
     }
   private:
@@ -20,7 +20,7 @@ namespace lumi{
   public:
     nonCollisionException(const std::string& methodname,
 			 const std::string& moduleName);
-    virtual ~nonCollisionException() throw(){}
+    ~nonCollisionException() throw() override{}
   };
 
   class invalidDataException : public lumi::Exception{
@@ -28,7 +28,7 @@ namespace lumi{
     invalidDataException(const std::string& message,
 			 const std::string& methodname,
 			 const std::string& moduleName);
-    virtual ~invalidDataException() throw(){}
+    ~invalidDataException() throw() override{}
   };
 
   class noStableBeamException : public lumi::Exception{
@@ -36,7 +36,7 @@ namespace lumi{
     noStableBeamException(const std::string& message,
 			 const std::string& methodname,
 			 const std::string& moduleName);
-    virtual ~noStableBeamException() throw(){}
+    ~noStableBeamException() throw() override{}
   };
   
   class duplicateRunInDataTagException : public lumi::Exception{
@@ -44,7 +44,7 @@ namespace lumi{
     duplicateRunInDataTagException(const std::string& message,
 				       const std::string& methodname,
 				       const std::string& moduleName);
-    virtual ~duplicateRunInDataTagException() throw(){}
+    ~duplicateRunInDataTagException() throw() override{}
   };
 }//ns lumi
 #endif

--- a/RecoLuminosity/LumiProducer/interface/LumiRawDataStructures.h
+++ b/RecoLuminosity/LumiProducer/interface/LumiRawDataStructures.h
@@ -13,7 +13,7 @@
 
 // Changes
 // Namespace for the HCAL HLX
-#include <stdint.h>
+#include <cstdint>
 
 namespace HCAL_HLX{
 

--- a/RecoLuminosity/LumiProducer/interface/NormFunctor.h
+++ b/RecoLuminosity/LumiProducer/interface/NormFunctor.h
@@ -14,8 +14,8 @@ namespace lumi{
     std::map< std::string , float > m_coeffmap;
     std::map< unsigned int, float > m_afterglowmap;
   private:
-    NormFunctor(const NormFunctor&);
-    const NormFunctor& operator=(const NormFunctor&);
+    NormFunctor(const NormFunctor&) = delete;
+    const NormFunctor& operator=(const NormFunctor&) = delete;
   };
 }//ns lumi
 #endif

--- a/RecoLuminosity/LumiProducer/plugins/BunchSpacingProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/BunchSpacingProducer.cc
@@ -21,9 +21,9 @@ public:
 
   explicit BunchSpacingProducer(const edm::ParameterSet&);
 
-  ~BunchSpacingProducer();
+  ~BunchSpacingProducer() override;
 
-  virtual void produce(edm::Event&, const edm::EventSetup&) override final;
+  void produce(edm::Event&, const edm::EventSetup&) final;
 
   static void fillDescriptions( edm::ConfigurationDescriptions & ) ;
   

--- a/RecoLuminosity/LumiProducer/plugins/CMSRunSummary2DB.cc
+++ b/RecoLuminosity/LumiProducer/plugins/CMSRunSummary2DB.cc
@@ -40,11 +40,11 @@ namespace lumi{
   class CMSRunSummary2DB : public DataPipe{
   public:
     CMSRunSummary2DB( const std::string& dest);
-    virtual unsigned long long retrieveData( unsigned int runnumber ) override;
-    virtual const std::string dataType() const override;
-    virtual const std::string sourceType() const override;
+    unsigned long long retrieveData( unsigned int runnumber ) override;
+    const std::string dataType() const override;
+    const std::string sourceType() const override;
     unsigned int str2int(const std::string& s) const;
-    virtual ~CMSRunSummary2DB();
+    ~CMSRunSummary2DB() override;
   private:
     struct cmsrunsum{
       std::string l1key;
@@ -173,10 +173,10 @@ namespace lumi{
 	if(it->find("PHYS")==std::string::npos) continue;
 	amd=*it;
       }
-      if(amd.size()==0&&amodes.size()!=0){
+      if(amd.empty()&&!amodes.empty()){
 	amd=*(amodes.begin());
       }
-      if(amd.size()==0){
+      if(amd.empty()){
 	 amd=std::string("PROTPHYS");//last resort
       }
       //std::cout<<"amd "<<amd<<std::endl;
@@ -328,7 +328,7 @@ namespace lumi{
     runinfosession->transaction().commit();
     delete runinfosession;
     
-    if(csvsource.size()!=0){
+    if(!csvsource.empty()){
       parseFillCSV(csvsource,result);
     }else{
       result.fillscheme=std::string("");

--- a/RecoLuminosity/LumiProducer/plugins/CMSRunSummaryDummy2DB.cc
+++ b/RecoLuminosity/LumiProducer/plugins/CMSRunSummaryDummy2DB.cc
@@ -21,10 +21,10 @@ namespace lumi{
   class CMSRunSummaryDummy2DB : public DataPipe{
   public:
     CMSRunSummaryDummy2DB(const std::string& dest);
-    virtual unsigned long long retrieveData( unsigned int ) override;
-    virtual const std::string dataType() const override;
-    virtual const std::string sourceType() const override;
-    virtual ~CMSRunSummaryDummy2DB();
+    unsigned long long retrieveData( unsigned int ) override;
+    const std::string dataType() const override;
+    const std::string sourceType() const override;
+    ~CMSRunSummaryDummy2DB() override;
   };//cl CMSRunSummaryDummy2DB
   //
   //implementation

--- a/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.cc
@@ -95,7 +95,7 @@ DIPLumiProducer::produceSummary(const DIPLuminosityRcd&)
   }else{
     m_summaryresult=m_summarycache[currentls];
   }
-  if(m_summaryresult.get()==0){
+  if(m_summaryresult.get()==nullptr){
     return std::make_shared<DIPLumiSummary>();
   }
   return m_summaryresult;
@@ -127,7 +127,7 @@ DIPLumiProducer::produceDetail(const DIPLuminosityRcd&)
   }else{
     m_detailresult=m_detailcache[currentls];
   }
-  if(m_detailresult.get()==0){
+  if(m_detailresult.get()==nullptr){
     return std::make_shared<DIPLumiDetail>();
   }
   return m_detailresult;

--- a/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.h
+++ b/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.h
@@ -26,12 +26,12 @@ class DIPLumiProducer: public edm::ESProducer , public edm::EventSetupRecordInte
   ReturnSummaryType produceSummary(const DIPLuminosityRcd&);
   typedef std::shared_ptr<DIPLumiDetail> ReturnDetailType;
   ReturnDetailType produceDetail(const DIPLuminosityRcd&);
-  ~DIPLumiProducer();
+  ~DIPLumiProducer() override;
 
  protected:
-  virtual void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
                                const edm::IOVSyncValue&,
-                               edm::ValidityInterval& );  
+                               edm::ValidityInterval& ) override;  
  private:
   unsigned int maxavailableLSforRun(coral::ISchema& schema,const std::string&tablename,unsigned int runnumber);
  private:

--- a/RecoLuminosity/LumiProducer/plugins/HLTConf2DB.cc
+++ b/RecoLuminosity/LumiProducer/plugins/HLTConf2DB.cc
@@ -31,10 +31,10 @@ namespace lumi{
   class HLTConf2DB : public DataPipe{
   public:
     explicit HLTConf2DB( const std::string& dest);
-    virtual unsigned long long retrieveData( unsigned int ) override;
-    virtual const std::string dataType() const override;
-    virtual const std::string sourceType() const override;
-    virtual ~HLTConf2DB();
+    unsigned long long retrieveData( unsigned int ) override;
+    const std::string dataType() const override;
+    const std::string sourceType() const override;
+    ~HLTConf2DB() override;
   };//cl HLTConf2DB
   //
   //implementation

--- a/RecoLuminosity/LumiProducer/plugins/HLTConfDummy2DB.cc
+++ b/RecoLuminosity/LumiProducer/plugins/HLTConfDummy2DB.cc
@@ -24,10 +24,10 @@ namespace lumi{
   class HLTConfDummy2DB : public DataPipe{
   public:
     explicit HLTConfDummy2DB(const std::string& dest);
-    virtual unsigned long long retrieveData( unsigned int runnumber) override;
-    virtual const std::string dataType() const override;
-    virtual const std::string sourceType() const override;
-    virtual ~HLTConfDummy2DB();
+    unsigned long long retrieveData( unsigned int runnumber) override;
+    const std::string dataType() const override;
+    const std::string sourceType() const override;
+    ~HLTConfDummy2DB() override;
   };//cl HLTConfDummy2DB
   //
   //implementation

--- a/RecoLuminosity/LumiProducer/plugins/HLTDummy2DB.cc
+++ b/RecoLuminosity/LumiProducer/plugins/HLTDummy2DB.cc
@@ -22,10 +22,10 @@ namespace lumi{
   class HLTDummy2DB : public DataPipe{
   public:
     HLTDummy2DB( const std::string& dest);
-    virtual unsigned long long retrieveData( unsigned int ) override;
-    virtual const std::string dataType() const override;
-    virtual const std::string sourceType() const override;
-    virtual ~HLTDummy2DB();
+    unsigned long long retrieveData( unsigned int ) override;
+    const std::string dataType() const override;
+    const std::string sourceType() const override;
+    ~HLTDummy2DB() override;
   };//cl HLTDummy2DB
   //
   //implementation

--- a/RecoLuminosity/LumiProducer/plugins/HLTV32DB.cc
+++ b/RecoLuminosity/LumiProducer/plugins/HLTV32DB.cc
@@ -38,10 +38,10 @@ namespace lumi{
     const static unsigned int COMMITLSINTERVAL=500; //commit interval in LS
     
     explicit HLTV32DB(const std::string& dest);
-    virtual unsigned long long retrieveData( unsigned int ) override;
-    virtual const std::string dataType() const override;
-    virtual const std::string sourceType() const override;
-    virtual ~HLTV32DB();
+    unsigned long long retrieveData( unsigned int ) override;
+    const std::string dataType() const override;
+    const std::string sourceType() const override;
+    ~HLTV32DB() override;
     struct hltinfo{
       unsigned int cmsluminr;
       std::string pathname;
@@ -137,7 +137,7 @@ namespace lumi{
       }
     }
     delete qPsindex;
-    if(psindexmap.size()==0){
+    if(psindexmap.empty()){
       srcsession->transaction().commit();
       delete srcsession;
       throw lumi::Exception("no psindex data found","retrieveData","HLTV32DB");
@@ -359,7 +359,7 @@ namespace lumi{
     unsigned int& acceptcount=hltData["ACCEPTCOUNT"].data<unsigned int>();
     unsigned int& prescale=hltData["PRESCALE"].data<unsigned int>();
     hltlscount=0;
-    coral::IBulkOperation* hltInserter=0; 
+    coral::IBulkOperation* hltInserter=nullptr; 
     unsigned int comittedls=0;
     for(HltResult::iterator hltIt=hltItBeg;hltIt!=hltItEnd;++hltIt,++hltlscount){
       std::map<unsigned int,HLTV32DB::hltinfo>::const_iterator pathIt;
@@ -390,13 +390,13 @@ namespace lumi{
       ++comittedls;
       if(comittedls==commitintv){
 	std::cout<<"\t committing in LS chunck "<<comittedls<<std::endl; 
-	delete hltInserter; hltInserter=0;
+	delete hltInserter; hltInserter=nullptr;
 	lumisession->transaction().commit();
 	comittedls=0;
 	std::cout<<"\t committed "<<std::endl; 
       }else if( hltlscount==(totalcmsls-1) ){
 	std::cout<<"\t committing at the end"<<std::endl; 
-	delete hltInserter; hltInserter=0;
+	delete hltInserter; hltInserter=nullptr;
 	lumisession->transaction().commit();
 	std::cout<<"\t done"<<std::endl; 
       }
@@ -467,7 +467,7 @@ namespace lumi{
    std::cout<<"inserting lshlt data"<<std::endl;
 
    unsigned int hltlscount=0;
-   coral::IBulkOperation* hltInserter=0; 
+   coral::IBulkOperation* hltInserter=nullptr; 
    unsigned int comittedls=0;
    for(HltResult::iterator hltIt=hltItBeg;hltIt!=hltItEnd;++hltIt,++hltlscount){
      unsigned int cmslscount=hltlscount+1;
@@ -517,13 +517,13 @@ namespace lumi{
      ++comittedls;
      if(comittedls==commitintv){
        std::cout<<"\t committing in LS chunck "<<comittedls<<std::endl; 
-       delete hltInserter; hltInserter=0;
+       delete hltInserter; hltInserter=nullptr;
        lumisession->transaction().commit();
        comittedls=0;
        std::cout<<"\t committed "<<std::endl; 
      }else if( hltlscount==(totalcmsls-1) ){
        std::cout<<"\t committing at the end"<<std::endl; 
-       delete hltInserter; hltInserter=0;
+       delete hltInserter; hltInserter=nullptr;
        lumisession->transaction().commit();
        std::cout<<"\t done"<<std::endl; 
      }

--- a/RecoLuminosity/LumiProducer/plugins/Lumi2DB.cc
+++ b/RecoLuminosity/LumiProducer/plugins/Lumi2DB.cc
@@ -34,10 +34,10 @@ namespace lumi{
   public:
     const static unsigned int COMMITLSINTERVAL=500; //commit interval in LS,totalrow=nls*(1+nalgo)
     Lumi2DB(const std::string& dest);
-    virtual unsigned long long retrieveData( unsigned int ) override;
-    virtual const std::string dataType() const override;
-    virtual const std::string sourceType() const override;
-    virtual ~Lumi2DB();
+    unsigned long long retrieveData( unsigned int ) override;
+    const std::string dataType() const override;
+    const std::string sourceType() const override;
+    ~Lumi2DB() override;
   
     struct LumiSource{
       unsigned int run;
@@ -160,7 +160,7 @@ lumi::Lumi2DB::writeBeamIntensityOnly(
   std::string& lumiversion = inputData["lumiversion"].data<std::string>();
 
   lumi::Lumi2DB::LumiResult::const_iterator lumiIt;
-  coral::IBulkOperation* summaryUpdater=0;
+  coral::IBulkOperation* summaryUpdater=nullptr;
   unsigned int totallumils=std::distance(lumiBeg,lumiEnd);
   unsigned int lumiindx=0;
   unsigned int comittedls=0;
@@ -201,13 +201,13 @@ lumi::Lumi2DB::writeBeamIntensityOnly(
     if(comittedls==Lumi2DB::COMMITLSINTERVAL){
       std::cout<<"\t committing in LS chunck "<<comittedls<<std::endl; 
       delete summaryUpdater;
-      summaryUpdater=0;
+      summaryUpdater=nullptr;
       session->transaction().commit();
       comittedls=0;
       std::cout<<"\t committed "<<std::endl; 
     }else if( lumiindx==(totallumils-1) ){
       std::cout<<"\t committing at the end"<<std::endl; 
-      delete summaryUpdater; summaryUpdater=0;
+      delete summaryUpdater; summaryUpdater=nullptr;
       session->transaction().commit();
       std::cout<<"\t done"<<std::endl; 
     }
@@ -277,8 +277,8 @@ lumi::Lumi2DB::writeAllLumiData(
   std::string& algoname=detailData["ALGONAME"].data<std::string>();
     
   lumi::Lumi2DB::LumiResult::const_iterator lumiIt;
-  coral::IBulkOperation* summaryInserter=0;
-  coral::IBulkOperation* detailInserter=0;
+  coral::IBulkOperation* summaryInserter=nullptr;
+  coral::IBulkOperation* detailInserter=nullptr;
   //one loop for ids
   //nested transaction doesn't work with bulk inserter
   unsigned int totallumils=std::distance(lumiBeg,lumiEnd);
@@ -401,16 +401,16 @@ lumi::Lumi2DB::writeAllLumiData(
     if(comittedls==Lumi2DB::COMMITLSINTERVAL){
       std::cout<<"\t committing in LS chunck "<<comittedls<<std::endl; 
       delete summaryInserter;
-      summaryInserter=0;
+      summaryInserter=nullptr;
       delete detailInserter;
-      detailInserter=0;
+      detailInserter=nullptr;
       session->transaction().commit();
       comittedls=0;
       std::cout<<"\t committed "<<std::endl; 
     }else if( lumiindx==(totallumils-1) ){
       std::cout<<"\t committing at the end"<<std::endl; 
-      delete summaryInserter; summaryInserter=0;
-      delete detailInserter; detailInserter=0;
+      delete summaryInserter; summaryInserter=nullptr;
+      delete detailInserter; detailInserter=nullptr;
       session->transaction().commit();
       std::cout<<"\t done"<<std::endl; 
     }
@@ -480,7 +480,7 @@ lumi::Lumi2DB::writeAllLumiDataToSchema2(
   coral::Blob& bxlumiquality_occ2=summaryData["BXLUMIQUALITY_OCC2"].data<coral::Blob>();
 
   lumi::Lumi2DB::LumiResult::const_iterator lumiIt;
-  coral::IBulkOperation* summaryInserter=0;
+  coral::IBulkOperation* summaryInserter=nullptr;
 
   unsigned int totallumils=std::distance(lumiBeg,lumiEnd);
   unsigned int lumiindx=0;
@@ -635,13 +635,13 @@ lumi::Lumi2DB::writeAllLumiDataToSchema2(
     if(comittedls==Lumi2DB::COMMITLSINTERVAL){
       std::cout<<"\t committing in LS chunck "<<comittedls<<std::endl; 
       delete summaryInserter;
-      summaryInserter=0;
+      summaryInserter=nullptr;
       session->transaction().commit();
       comittedls=0;
       std::cout<<"\t committed "<<std::endl; 
     }else if( lumiindx==(totallumils-1) ){
       std::cout<<"\t committing at the end"<<std::endl; 
-      delete summaryInserter; summaryInserter=0;
+      delete summaryInserter; summaryInserter=nullptr;
       session->transaction().commit();
       std::cout<<"\t done"<<std::endl; 
     }
@@ -690,11 +690,11 @@ lumi::Lumi2DB::parseSourceString(lumi::Lumi2DB::LumiSource& result)const{
 
 void
 lumi::Lumi2DB::retrieveBeamIntensity(HCAL_HLX::DIP_COMBINED_DATA* dataPtr, Lumi2DB::beamData&b)const{
-   if(dataPtr==0){
+   if(dataPtr==nullptr){
       std::cout<<"HCAL_HLX::DIP_COMBINED_DATA* dataPtr=0"<<std::endl;
-      b.bxindex=0;
-      b.beamintensity_1=0;
-      b.beamintensity_2=0;
+      b.bxindex=nullptr;
+      b.beamintensity_1=nullptr;
+      b.beamintensity_2=nullptr;
       b.nlivebx=0;
    }else{
       b.bxindex=(short*)::malloc(sizeof(short)*lumi::N_BX);
@@ -803,7 +803,7 @@ lumi::Lumi2DB::retrieveData( unsigned int runnumber){
       beamData b;
       b.mode="N/A";
       b.energy=0.0;
-      this->retrieveBeamIntensity(0,b);
+      this->retrieveBeamIntensity(nullptr,b);
       dipmap.insert(std::make_pair(i,b));
     }
   }
@@ -847,7 +847,7 @@ lumi::Lumi2DB::retrieveData( unsigned int runnumber){
 	h.bxindex=(short*)malloc(sizeof(short)*h.nlivebx);
 	h.beamintensity_1=(float*)malloc(sizeof(float)*h.nlivebx);
 	h.beamintensity_2=(float*)malloc(sizeof(float)*h.nlivebx);
-	if(h.bxindex==0 || h.beamintensity_1==0 || h.beamintensity_2==0){
+	if(h.bxindex==nullptr || h.beamintensity_1==nullptr || h.beamintensity_2==nullptr){
 	  std::cout<<"malloc failed"<<std::endl;
 	}
 	//std::cout<<"h.bxindex size "<<sizeof(short)*h.nlivebx<<std::endl;
@@ -858,22 +858,22 @@ lumi::Lumi2DB::retrieveData( unsigned int runnumber){
 	std::memmove(h.beamintensity_1,beamIt->second.beamintensity_1,sizeof(float)*h.nlivebx);
 	std::memmove(h.beamintensity_2,beamIt->second.beamintensity_2,sizeof(float)*h.nlivebx);
 
-	::free(beamIt->second.bxindex);beamIt->second.bxindex=0;
-	::free(beamIt->second.beamintensity_1);beamIt->second.beamintensity_1=0;
-	::free(beamIt->second.beamintensity_2);beamIt->second.beamintensity_2=0;
+	::free(beamIt->second.bxindex);beamIt->second.bxindex=nullptr;
+	::free(beamIt->second.beamintensity_1);beamIt->second.beamintensity_1=nullptr;
+	::free(beamIt->second.beamintensity_2);beamIt->second.beamintensity_2=nullptr;
       }else{
 	//std::cout<<"h.nlivebx is zero"<<std::endl;
-	h.bxindex=0;
-	h.beamintensity_1=0;
-	h.beamintensity_2=0;
+	h.bxindex=nullptr;
+	h.beamintensity_1=nullptr;
+	h.beamintensity_2=nullptr;
       }
     }else{
       h.beammode="N/A";
       h.beamenergy=0.0;
       h.nlivebx=0;
-      h.bxindex=0;
-      h.beamintensity_1=0;
-      h.beamintensity_2=0;
+      h.bxindex=nullptr;
+      h.beamintensity_1=nullptr;
+      h.beamintensity_2=nullptr;
     }
     h.startorbit=lumiheader->startOrbit;
     h.numorbit=lumiheader->numOrbits;

--- a/RecoLuminosity/LumiProducer/plugins/LumiCalculator.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiCalculator.cc
@@ -35,16 +35,16 @@ class LumiCalculator : public edm::EDAnalyzer{
 public:
   
   explicit LumiCalculator(edm::ParameterSet const& pset);
-  virtual ~LumiCalculator();
+  ~LumiCalculator() override;
 
 private:  
-  virtual void beginJob() override;
-  virtual void beginRun(const edm::Run& run, const edm::EventSetup& c) override;
-  virtual void analyze(edm::Event const& e, edm::EventSetup const& c) override;
-  virtual void endLuminosityBlock(edm::LuminosityBlock const& lumiBlock, 
+  void beginJob() override;
+  void beginRun(const edm::Run& run, const edm::EventSetup& c) override;
+  void analyze(edm::Event const& e, edm::EventSetup const& c) override;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumiBlock, 
 				  edm::EventSetup const& c) override;
-  virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-  virtual void endJob() override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
+  void endJob() override;
   std::vector<std::string> splitpathstr(const std::string& strValue,const std::string separator);
   HLTConfigProvider hltConfig_;
   std::multimap<std::string,std::string> trgpathMmap_;//key:hltpath,value:l1bit
@@ -68,7 +68,7 @@ LumiCalculator::LumiCalculator(edm::ParameterSet const& pset):log_( new edm::Log
 // -----------------------------------------------------------------
 
 LumiCalculator::~LumiCalculator(){
-  delete log_; log_=0; 
+  delete log_; log_=nullptr; 
 }
 
 // -----------------------------------------------------------------
@@ -156,7 +156,7 @@ void LumiCalculator::beginRun(const edm::Run& run, const edm::EventSetup& c){
 	  continue;
 	}else{
 	  for(std::vector<std::string>::iterator i=seeds.begin();i!=seeds.end();++i){
-	    if(i->size()!=0 && showTrgInfo_)  *log_<<"\t\tseed: "<<*i<<"\n";
+	    if(!i->empty() && showTrgInfo_)  *log_<<"\t\tseed: "<<*i<<"\n";
 	    if(i==seeds.begin()){//for now we take the first one from OR
 		trgpathMmap_.insert(std::make_pair(hltname,*i));
 	    }
@@ -175,7 +175,7 @@ void LumiCalculator::beginRun(const edm::Run& run, const edm::EventSetup& c){
 	}else{
 	  for(std::vector<std::string>::iterator i=seeds.begin();
 	      i!=seeds.end();++i){
-	    if(i->size()!=0 && showTrgInfo_) *log_<<"\t\tseed: "<<*i<<"\n";
+	    if(!i->empty() && showTrgInfo_) *log_<<"\t\tseed: "<<*i<<"\n";
 	    if(i==seeds.begin()){//for now we take the first one 
 	      trgpathMmap_.insert(std::make_pair(hltname,*i));
 	    }

--- a/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.cc
@@ -218,7 +218,7 @@ LumiCorrectionSource::produceLumiCorrectionParam(const LumiCorrectionParamRcd&)
     return std::make_shared<LumiCorrectionParam>();
   }
   m_paramresult=m_paramcache[currentrun];
-  if(m_paramresult.get()==0){
+  if(m_paramresult.get()==nullptr){
     return std::make_shared<LumiCorrectionParam>();
   }
   return m_paramresult;

--- a/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.h
+++ b/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.h
@@ -27,11 +27,11 @@ class LumiCorrectionSource: public edm::ESProducer , public edm::EventSetupRecor
   LumiCorrectionSource(const edm::ParameterSet&);
   typedef std::shared_ptr<LumiCorrectionParam> ReturnParamType;
   ReturnParamType produceLumiCorrectionParam(const LumiCorrectionParamRcd&);
-  ~LumiCorrectionSource();
+  ~LumiCorrectionSource() override;
  protected:
-  virtual void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
+  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey&,
                                const edm::IOVSyncValue&,
-			       edm::ValidityInterval& );
+			       edm::ValidityInterval& ) override;
  private:
   std::string translateFrontierConnect(const std::string& connectStr);
   void reloadAuth();

--- a/RecoLuminosity/LumiProducer/plugins/LumiDummy2DB.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiDummy2DB.cc
@@ -27,10 +27,10 @@ namespace lumi{
   class LumiDummy2DB : public DataPipe{
   public:
     LumiDummy2DB(const std::string& dest);
-    virtual unsigned long long retrieveData( unsigned int ) override;
-    virtual const std::string dataType() const override;
-    virtual const std::string sourceType() const override;
-    virtual ~LumiDummy2DB();
+    unsigned long long retrieveData( unsigned int ) override;
+    const std::string dataType() const override;
+    const std::string sourceType() const override;
+    ~LumiDummy2DB() override;
   };//cl LumiDummy2DB
   //
   //implementation

--- a/RecoLuminosity/LumiProducer/plugins/LumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiProducer.cc
@@ -122,19 +122,19 @@ public:
 
   explicit LumiProducer(const edm::ParameterSet&);
 
-  ~LumiProducer();
+  ~LumiProducer() override;
   
 private:
   
-  virtual void produce(edm::Event&, const edm::EventSetup&) override final;
+  void produce(edm::Event&, const edm::EventSetup&) final;
 
-  virtual void beginRun(edm::Run const&, edm::EventSetup const &) override final;
+  void beginRun(edm::Run const&, edm::EventSetup const &) final;
 
-  virtual void beginLuminosityBlockProduce(edm::LuminosityBlock & iLBlock,
-				    edm::EventSetup const& iSetup) override final;
+  void beginLuminosityBlockProduce(edm::LuminosityBlock & iLBlock,
+				    edm::EventSetup const& iSetup) final;
  
-  virtual void endRun(edm::Run const&, edm::EventSetup const &) override final;
-  virtual void endRunProduce(edm::Run&, edm::EventSetup const &) override final;
+  void endRun(edm::Run const&, edm::EventSetup const &) final;
+  void endRunProduce(edm::Run&, edm::EventSetup const &) final;
 
   bool fillLumi(edm::LuminosityBlock & iLBlock);
   void fillRunCache(const coral::ISchema& schema,unsigned int runnumber);
@@ -779,7 +779,7 @@ LumiProducer::fillLSCache(unsigned int luminum){
 	unsigned int* hltaccepts=(unsigned int*)::malloc(hltacceptblob.size());
 	std::memmove(hltaccepts,hltacceptblob_StartAddress,hltacceptblob.size()); 	
 	unsigned int nhltaccepts = sizeof(hltaccepts)/sizeof(unsigned int);
-        if(nhltaccepts > 0 && m_runcache.HLTPathNames.size() == 0){
+        if(nhltaccepts > 0 && m_runcache.HLTPathNames.empty()){
           edm::LogWarning("CorruptOrMissingHLTData")<<"Got "<<nhltaccepts
 <<" hltaccepts, but the run chache is empty. hltdata will  not be written";
             break;

--- a/RecoLuminosity/LumiProducer/plugins/TRGDummy2DB.cc
+++ b/RecoLuminosity/LumiProducer/plugins/TRGDummy2DB.cc
@@ -25,10 +25,10 @@ namespace lumi{
   class TRGDummy2DB : public DataPipe{
   public:
     TRGDummy2DB(const std::string& dest);
-    virtual unsigned long long retrieveData( unsigned int ) override;
-    virtual const std::string dataType() const override;
-    virtual const std::string sourceType() const override;
-    virtual ~TRGDummy2DB();
+    unsigned long long retrieveData( unsigned int ) override;
+    const std::string dataType() const override;
+    const std::string sourceType() const override;
+    ~TRGDummy2DB() override;
   };//cl TRGDummy2DB
   //
   //implementation

--- a/RecoLuminosity/LumiProducer/plugins/TRGScalers2DB.cc
+++ b/RecoLuminosity/LumiProducer/plugins/TRGScalers2DB.cc
@@ -35,10 +35,10 @@ namespace lumi{
     const static unsigned int COMMITLSINTERVAL=150; //commit interval in LS, totalrow=nsl*192
     const static unsigned int COMMITLSTRGINTERVAL=550; //commit interval in LS of schema2
     explicit TRGScalers2DB(const std::string& dest);
-    virtual unsigned long long retrieveData( unsigned int runnumber) override;
-    virtual const std::string dataType() const override;
-    virtual const std::string sourceType() const override;
-    virtual ~TRGScalers2DB();													  
+    unsigned long long retrieveData( unsigned int runnumber) override;
+    const std::string dataType() const override;
+    const std::string sourceType() const override;
+    ~TRGScalers2DB() override;													  
 
     //per run information
     typedef std::vector<std::string> TriggerNameResult_Algo;
@@ -731,7 +731,7 @@ namespace lumi{
     unsigned int& prescale=trgData["PRESCALE"].data<unsigned int>();
                       
     trglscount=0;    
-    coral::IBulkOperation* trgInserter=0; 
+    coral::IBulkOperation* trgInserter=nullptr; 
     unsigned int comittedls=0;
     for(deadIt=deadtimesBeg;deadIt!=deadtimesEnd;++deadIt,++trglscount ){
       unsigned int cmslscount=trglscount+1;
@@ -784,13 +784,13 @@ namespace lumi{
       ++comittedls;
       if(comittedls==commitintv){
 	std::cout<<"\t committing in LS chunck "<<comittedls<<std::endl; 
-	delete trgInserter; trgInserter=0;
+	delete trgInserter; trgInserter=nullptr;
 	lumisession->transaction().commit();
 	comittedls=0;
 	std::cout<<"\t committed "<<std::endl; 
       }else if( trglscount==( totalcmsls-1) ){
 	std::cout<<"\t committing at the end"<<std::endl; 
-	delete trgInserter; trgInserter=0;
+	delete trgInserter; trgInserter=nullptr;
 	lumisession->transaction().commit();
 	std::cout<<"\t done"<<std::endl; 
       }
@@ -881,7 +881,7 @@ namespace lumi{
  
     unsigned int trglscount=0;   
     // trglscount=0;
-    coral::IBulkOperation* lstrgInserter=0; 
+    coral::IBulkOperation* lstrgInserter=nullptr; 
     unsigned int comittedls=0;
     for(deadIt=deadtimesBeg;deadIt!=deadtimesEnd;++deadIt,++trglscount ){
       unsigned int cmslscount=trglscount+1;
@@ -926,13 +926,13 @@ namespace lumi{
       ++comittedls;
       if(comittedls==commitintv){
 	std::cout<<"\t committing in LS chunck "<<comittedls<<std::endl; 
-	delete lstrgInserter; lstrgInserter=0;
+	delete lstrgInserter; lstrgInserter=nullptr;
 	lumisession->transaction().commit();
 	comittedls=0;
 	std::cout<<"\t committed "<<std::endl; 
       }else if( trglscount==( totalcmsls-1) ){
 	std::cout<<"\t committing at the end"<<std::endl; 
-	delete lstrgInserter; lstrgInserter=0;
+	delete lstrgInserter; lstrgInserter=nullptr;
 	lumisession->transaction().commit();
 	std::cout<<"\t done"<<std::endl; 
       }

--- a/RecoLuminosity/LumiProducer/plugins/TRGWBM2DB.cc
+++ b/RecoLuminosity/LumiProducer/plugins/TRGWBM2DB.cc
@@ -29,10 +29,10 @@ namespace lumi{
   public:
     const static unsigned int COMMITLSINTERVAL=20; //commit interval in LS,totalrow=nsl*192
     explicit TRGWBM2DB(const std::string& dest);
-    virtual unsigned long long retrieveData( unsigned int runnumber) override;
-    virtual const std::string dataType() const override;
-    virtual const std::string sourceType() const override;
-    virtual ~TRGWBM2DB();
+    unsigned long long retrieveData( unsigned int runnumber) override;
+    const std::string dataType() const override;
+    const std::string sourceType() const override;
+    ~TRGWBM2DB() override;
   private:
     std::string int2str(unsigned int t,unsigned int width);
     unsigned int str2int(const std::string& s);
@@ -519,7 +519,7 @@ namespace lumi{
       unsigned int& prescale=trgData["PRESCALE"].data<unsigned int>();
      
       trglscount=0;    
-      coral::IBulkOperation* trgInserter=0; 
+      coral::IBulkOperation* trgInserter=nullptr; 
       unsigned int comittedls=0; 
       for(deadIt=deadBeg;deadIt!=deadEnd;++deadIt,++trglscount ){
 	unsigned int cmslscount=trglscount+1;
@@ -587,13 +587,13 @@ namespace lumi{
 	++comittedls;
 	if(comittedls==TRGWBM2DB::COMMITLSINTERVAL){
 	  std::cout<<"\t committing in LS chunck "<<comittedls<<std::endl; 
-	  delete trgInserter; trgInserter=0;
+	  delete trgInserter; trgInserter=nullptr;
 	  lumisession->transaction().commit();
 	  comittedls=0;
 	  std::cout<<"\t committed "<<std::endl; 
 	}else if( trglscount==( totalcmsls-1) ){
 	  std::cout<<"\t committing at the end"<<std::endl; 
-	  delete trgInserter; trgInserter=0;
+	  delete trgInserter; trgInserter=nullptr;
 	  lumisession->transaction().commit();
 	  std::cout<<"\t done"<<std::endl; 
 	}

--- a/RecoLuminosity/LumiProducer/plugins/fPoly.cc
+++ b/RecoLuminosity/LumiProducer/plugins/fPoly.cc
@@ -6,10 +6,10 @@ namespace lumi{
   class fPoly:public NormFunctor{
   public:
     fPoly(){}
-    ~fPoly(){}
+    ~fPoly() override{}
     void initialize(const std::map< std::string , float >& coeffmap,
 		    const std::map< unsigned int, float >& afterglowmap);
-    virtual float getCorrection(float luminonorm,float intglumi,unsigned int nBXs)const override;
+    float getCorrection(float luminonorm,float intglumi,unsigned int nBXs)const override;
   };
 }//ns lumi
 

--- a/RecoLuminosity/LumiProducer/src/RevisionDML.cc
+++ b/RecoLuminosity/LumiProducer/src/RevisionDML.cc
@@ -203,7 +203,7 @@ lumi::RevisionDML::currentHFDataTagId(coral::ISchema& schema){
     }
   }
   delete qHandle;
-  if(alltagids.size()>0){
+  if(!alltagids.empty()){
     std::vector<unsigned long long>::iterator currentdatatagidIt=std::max_element(alltagids.begin(),alltagids.end());
     currentdatatagid=*currentdatatagidIt;
   }

--- a/RecoLuminosity/TCPReceiver/src/TCPReceiver.cc
+++ b/RecoLuminosity/TCPReceiver/src/TCPReceiver.cc
@@ -127,7 +127,7 @@ void SetupFDSets(fd_set& ReadFDs, fd_set& WriteFDs,
 	  
 	  SetupFDSets(fdsRead, fdsWrite, fdsExcept, -1, tcpSocket);
 	  
-	  if(select(tcpSocket+1, &fdsRead, 0, &fdsExcept, 0)> 0){
+	  if(select(tcpSocket+1, &fdsRead, nullptr, &fdsExcept, nullptr)> 0){
 	    
 	    if (FD_ISSET(tcpSocket, &fdsRead)) {
 	      
@@ -328,7 +328,7 @@ void SetupFDSets(fd_set& ReadFDs, fd_set& WriteFDs,
     localSection.hdr.sectionNumber = 120;
     
     timeval tvTemp;
-    gettimeofday(&tvTemp, NULL);
+    gettimeofday(&tvTemp, nullptr);
     localSection.hdr.timestamp = tvTemp.tv_sec;
     localSection.hdr.timestamp_micros = tvTemp.tv_usec;
 
@@ -398,7 +398,7 @@ void SetupFDSets(fd_set& ReadFDs, fd_set& WriteFDs,
 #endif
     int i, j, k;
 
-    srand(time(NULL));
+    srand(time(nullptr));
     localSection.hdr.runNumber     = 55; //(rand() % 100);
     localSection.hdr.startOrbit    = (rand() % 100);
     localSection.hdr.numOrbits     = (rand() % 100);


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this quickly to avoid conflicts to the extent possible]