### PR TITLE
Clang-tidy checks for RecoParticleFlow

### DIFF
--- a/RecoParticleFlow/Benchmark/interface/GenericBenchmark.h
+++ b/RecoParticleFlow/Benchmark/interface/GenericBenchmark.h
@@ -28,7 +28,7 @@ class GenericBenchmark{
   GenericBenchmark();
   virtual ~GenericBenchmark() noexcept(false);
 
-  void setup(DQMStore *DQM = NULL, 
+  void setup(DQMStore *DQM = nullptr, 
 	     bool PlotAgainstReco_=true, 
 	     float minDeltaEt = -100., float maxDeltaEt = 50., 
 	     float minDeltaPhi = -0.5, float maxDeltaPhi = 0.5,
@@ -159,7 +159,7 @@ void GenericBenchmark::fill(const C *RecoCollection,
       // generate histograms comparing the reco and truth candidate (truth = closest in delta-R)
       const reco::Candidate *particle = &(*RecoCollection)[i];
       
-      assert( particle!=NULL ); 
+      assert( particle!=nullptr ); 
       if( !accepted(particle, recPt_cut, 
 		    minEta_cut, maxEta_cut)) continue;
 
@@ -177,7 +177,7 @@ void GenericBenchmark::fill(const C *RecoCollection,
       
       const reco::Candidate *gen_particle = algo_->matchByDeltaR(particle,
 								 GenCollection);
-      if(gen_particle==NULL) continue; 
+      if(gen_particle==nullptr) continue; 
 
 
 

--- a/RecoParticleFlow/Benchmark/interface/PFBenchmarkAlgo.h
+++ b/RecoParticleFlow/Benchmark/interface/PFBenchmarkAlgo.h
@@ -126,7 +126,7 @@ private:
 template <typename T, typename U>
 double PFBenchmarkAlgo::deltaEt(const T *c1, const U *c2) {
 
-  if (c1 == NULL || c2 == NULL)
+  if (c1 == nullptr || c2 == nullptr)
     throw cms::Exception("Invalid Arg") << "attempted to calculate deltaEt for invalid Candidate(s)";
 
   return c1->et() - c2->et();
@@ -137,7 +137,7 @@ double PFBenchmarkAlgo::deltaEt(const T *c1, const U *c2) {
 template <typename T, typename U>
 double PFBenchmarkAlgo::deltaEta(const T *c1, const U *c2) {
 
-  if (c1 == NULL || c2 == NULL)
+  if (c1 == nullptr || c2 == nullptr)
     throw cms::Exception("Invalid Arg") << "attempted to calculate deltaEta for invalid Candidate(s)";
 
   return c1->eta() - c2->eta();
@@ -148,7 +148,7 @@ double PFBenchmarkAlgo::deltaEta(const T *c1, const U *c2) {
 template <typename T, typename U>
 double PFBenchmarkAlgo::deltaPhi(const T *c1, const U *c2) {
 
-  if (c1 == NULL || c2 == NULL)
+  if (c1 == nullptr || c2 == nullptr)
     throw cms::Exception("Invalid Arg") << "attempted to calculate deltaPhi for invalid Candidate(s)";
 
   
@@ -188,7 +188,7 @@ double PFBenchmarkAlgo::deltaPhi(const T *c1, const U *c2) {
 template <typename T, typename U>
 double PFBenchmarkAlgo::deltaR(const T *c1, const U *c2) {
 
-  if (c1 == NULL || c2 == NULL)
+  if (c1 == nullptr || c2 == nullptr)
     throw cms::Exception("Invalid Arg") << "attempted to calculate deltaR for invalid Candidate(s)";
 
   return sqrt(std::pow(deltaPhi(c1,c2),2) + std::pow(deltaEta(c1,c2),2));
@@ -206,7 +206,7 @@ const typename Collection::value_type *PFBenchmarkAlgo::matchByDeltaR(const T *c
   if (!candidates) throw cms::Exception("Invalid Arg") << "attempted to match to invalid Collection";
 
   double minDeltaR = 9999.;
-  const U *match = NULL;
+  const U *match = nullptr;
   
   // Loop Over the Candidates...
   for (unsigned int i = 0; i < candidates->size(); i++) {

--- a/RecoParticleFlow/Benchmark/interface/PFJetBenchmark.h
+++ b/RecoParticleFlow/Benchmark/interface/PFJetBenchmark.h
@@ -37,13 +37,13 @@ class PFJetBenchmark {
   void setup(
 	     std::string Filename,
 	     bool debug, 
-	     bool plotAgainstReco=0, 
-	     bool onlyTwoJets=1,
+	     bool plotAgainstReco=false, 
+	     bool onlyTwoJets=true,
 	     double deltaRMax=0.1,
              std::string benchmarkLabel_ = "ParticleFlow", 
 	     double recPt = -1, 
 	     double maxEta = -1,
-	     DQMStore * dbe_store = NULL
+	     DQMStore * dbe_store = nullptr
 	     );
   void process(const reco::PFJetCollection& , const reco::GenJetCollection& );
   void gettrue (const reco::GenJet* truth, double& true_ChargedHadEnergy, 

--- a/RecoParticleFlow/Benchmark/interface/PFMETBenchmark.h
+++ b/RecoParticleFlow/Benchmark/interface/PFMETBenchmark.h
@@ -39,9 +39,9 @@ class PFMETBenchmark {
   void setup(
 	     std::string Filename,
 	     bool debug, 
-	     bool plotAgainstReco=0, 
+	     bool plotAgainstReco=false, 
              std::string benchmarkLabel_ = "ParticleFlow", 
-	     DQMStore * dbe_store = NULL
+	     DQMStore * dbe_store = nullptr
 	     );
   void process(const reco::PFMETCollection& , 
 	       const reco::GenParticleCollection&, 

--- a/RecoParticleFlow/Benchmark/src/GenericBenchmark.cc
+++ b/RecoParticleFlow/Benchmark/src/GenericBenchmark.cc
@@ -374,7 +374,7 @@ void GenericBenchmark::fillHistos( const reco::Candidate* genParticle,
   {
     const reco::MET* met1=static_cast<const reco::MET*>(genParticle);
     const reco::MET* met2=static_cast<const reco::MET*>(recParticle);
-    if (met1!=NULL && met2!=NULL)
+    if (met1!=nullptr && met2!=nullptr)
     {
       //std::cout << "FL: met1.sumEt() = " << (*met1).sumEt() << std::endl;
       hTrueSumEt->Fill((*met1).sumEt());
@@ -400,7 +400,7 @@ void GenericBenchmark::fillHistos( const reco::Candidate* genParticle,
 
 void GenericBenchmark::write(std::string Filename) {
 
-  if (Filename.size() != 0 && file_)
+  if (!Filename.empty() && file_)
     file_->Write(Filename.c_str());
 
 }

--- a/RecoParticleFlow/Benchmark/src/PFJetBenchmark.cc
+++ b/RecoParticleFlow/Benchmark/src/PFJetBenchmark.cc
@@ -39,7 +39,7 @@
 using namespace reco;
 using namespace std;
 
-PFJetBenchmark::PFJetBenchmark() : file_(0), entry_(0) {}
+PFJetBenchmark::PFJetBenchmark() : file_(nullptr), entry_(0) {}
 
 PFJetBenchmark::~PFJetBenchmark() {
   if(file_) file_->Close();
@@ -47,9 +47,9 @@ PFJetBenchmark::~PFJetBenchmark() {
 
 void PFJetBenchmark::write() {
    // Store the DAQ Histograms 
-  if (outputFile_.size() != 0) {
+  if (!outputFile_.empty()) {
     if (dbe_)
-          dbe_->save(outputFile_.c_str());
+          dbe_->save(outputFile_);
     // use bare Root if no DQM (FWLite applications)
     else if (file_) {
        file_->Write(outputFile_.c_str());
@@ -79,7 +79,7 @@ void PFJetBenchmark::setup(
   outputFile_=Filename;
   recPt_cut = recPt;
   maxEta_cut= maxEta;
-  file_ = NULL;
+  file_ = nullptr;
   dbe_ = dbe_store;
   // print parameters
   cout<< "PFJetBenchmark Setup parameters =============================================="<<endl;
@@ -98,7 +98,7 @@ void PFJetBenchmark::setup(
   string path = "PFTask/Benchmarks/"+ benchmarkLabel_ + "/";
   if (plotAgainstReco) path += "Reco"; else path += "Gen";
   if (dbe_) {
-    dbe_->setCurrentFolder(path.c_str());
+    dbe_->setCurrentFolder(path);
   }
   else {
     file_ = new TFile(outputFile_.c_str(), "recreate");
@@ -395,7 +395,7 @@ void PFJetBenchmark::process(const reco::PFJetCollection& pfJets, const reco::Ge
 		  << std::endl;
 
 	// check overlapping PF jets
-	const reco::PFJet* pfoj = 0; 
+	const reco::PFJet* pfoj = nullptr; 
 	double dRo = 1E9;
 	for(unsigned j=0; j<pfJets.size(); j++) { 
 	  const reco::PFJet& pfo = pfJets[j];
@@ -407,7 +407,7 @@ void PFJetBenchmark::process(const reco::PFJetCollection& pfJets, const reco::Ge
 	
 	// Check overlapping Gen Jet 
 	math::XYZTLorentzVector overlappinGenJet(0.,0.,0.,0.);
-	const reco::GenJet* genoj = 0;
+	const reco::GenJet* genoj = nullptr;
 	double dRgo = 1E9;
 	for(unsigned j=0; j<genJets.size(); j++) { 
 	  const reco::GenJet* gjo = &(genJets[j]);

--- a/RecoParticleFlow/Benchmark/src/PFMETBenchmark.cc
+++ b/RecoParticleFlow/Benchmark/src/PFMETBenchmark.cc
@@ -27,7 +27,7 @@
 using namespace reco;
 using namespace std;
 
-PFMETBenchmark::PFMETBenchmark() : file_(0) {}
+PFMETBenchmark::PFMETBenchmark() : file_(nullptr) {}
 
 PFMETBenchmark::~PFMETBenchmark() {
   if(file_) file_->Close();
@@ -35,9 +35,9 @@ PFMETBenchmark::~PFMETBenchmark() {
 
 void PFMETBenchmark::write() {
    // Store the DAQ Histograms 
-  if (outputFile_.size() != 0) {
+  if (!outputFile_.empty()) {
     if (dbe_)
-          dbe_->save(outputFile_.c_str());
+          dbe_->save(outputFile_);
     // use bare Root if no DQM (FWLite applications)
     else if (file_) {
        file_->Write(outputFile_.c_str());
@@ -59,7 +59,7 @@ void PFMETBenchmark::setup(
   debug_ = debug; 
   plotAgainstReco_ = plotAgainstReco;
   outputFile_=Filename;
-  file_ = NULL;
+  file_ = nullptr;
   dbe_ = dbe_store;
   // print parameters
   //cout<< "PFMETBenchmark Setup parameters =============================================="<<endl;
@@ -74,7 +74,7 @@ void PFMETBenchmark::setup(
   string path = "PFTask/Benchmarks/"+ benchmarkLabel_ + "/";
   if (plotAgainstReco) path += "Reco"; else path += "Gen";
   if (dbe_) {
-    dbe_->setCurrentFolder(path.c_str());
+    dbe_->setCurrentFolder(path);
   }
   else {
     file_ = new TFile(outputFile_.c_str(), "recreate");

--- a/RecoParticleFlow/Benchmark/src/PFTauElecRejectionBenchmark.cc
+++ b/RecoParticleFlow/Benchmark/src/PFTauElecRejectionBenchmark.cc
@@ -21,7 +21,7 @@ using namespace std;
 
 class MonitorElement;
 
-PFTauElecRejectionBenchmark::PFTauElecRejectionBenchmark() : file_(0) {}
+PFTauElecRejectionBenchmark::PFTauElecRejectionBenchmark() : file_(nullptr) {}
 
 PFTauElecRejectionBenchmark::~PFTauElecRejectionBenchmark() {
   if(file_) file_->Close();
@@ -29,9 +29,9 @@ PFTauElecRejectionBenchmark::~PFTauElecRejectionBenchmark() {
 
 void PFTauElecRejectionBenchmark::write() {
    // Store the DAQ Histograms 
-  if (outputFile_.size() != 0) {
+  if (!outputFile_.empty()) {
     if (db_)
-          db_->save(outputFile_.c_str());
+          db_->save(outputFile_);
     // use bare Root if no DQM (FWLite applications)
     else if (file_) {
        file_->Write(outputFile_.c_str());
@@ -65,7 +65,7 @@ void PFTauElecRejectionBenchmark::setup(
   sGenMatchObjectLabel_ = sGenMatchObjectLabel;
   applyEcalCrackCut_= applyEcalCrackCut;
 
-  file_ = NULL;
+  file_ = nullptr;
   db_ = db_store;
 
   // print parameters
@@ -86,7 +86,7 @@ void PFTauElecRejectionBenchmark::setup(
   string path = "PFTask/Benchmarks/"+ benchmarkLabel_ + "/";
   path += "Gen";
   if (db_) {
-    db_->setCurrentFolder(path.c_str());
+    db_->setCurrentFolder(path);
   }
   else {
     file_ = new TFile(outputFile_.c_str(), "recreate");

--- a/RecoParticleFlow/Configuration/plugins/HepMCCopy.h
+++ b/RecoParticleFlow/Configuration/plugins/HepMCCopy.h
@@ -13,8 +13,8 @@ class HepMCCopy : public edm::EDProducer
  public:
 
   explicit HepMCCopy(edm::ParameterSet const & p);
-  virtual ~HepMCCopy() {}
-  virtual void produce(edm::Event & e, const edm::EventSetup & c) override;
+  ~HepMCCopy() override {}
+  void produce(edm::Event & e, const edm::EventSetup & c) override;
 
  private:
 

--- a/RecoParticleFlow/PFClusterShapeProducer/plugins/PFClusterShapeProducer.h
+++ b/RecoParticleFlow/PFClusterShapeProducer/plugins/PFClusterShapeProducer.h
@@ -36,9 +36,9 @@ class PFClusterShapeProducer : public edm::EDProducer
 
   explicit PFClusterShapeProducer(const edm::ParameterSet &);
 
-  ~PFClusterShapeProducer();
+  ~PFClusterShapeProducer() override;
 
-  virtual void produce(edm::Event & ev, const edm::EventSetup & es);
+  void produce(edm::Event & ev, const edm::EventSetup & es) override;
 
  private:
 

--- a/RecoParticleFlow/PFClusterShapeProducer/src/PFClusterShapeAlgo.cc
+++ b/RecoParticleFlow/PFClusterShapeProducer/src/PFClusterShapeAlgo.cc
@@ -148,7 +148,7 @@ const reco::PFRecHitFraction * PFClusterShapeAlgo::getFractionFromDetId(const De
 	  return &(*it); 
 	}
     }
-  return 0;
+  return nullptr;
 }
 
 

--- a/RecoParticleFlow/PFClusterTools/interface/CalibCompare.h
+++ b/RecoParticleFlow/PFClusterTools/interface/CalibCompare.h
@@ -40,8 +40,8 @@ public:
 
 private:
 
-	CalibCompare(const CalibCompare&);
-	void operator=(const CalibCompare&);
+	CalibCompare(const CalibCompare&) = delete;
+	void operator=(const CalibCompare&) = delete;
 //	double lowE_, highE_, lowEta_, highEta_, lowPhi_, highPhi_;
 //	unsigned divE_, divEta_, divPhi_;
 	bool withOffset_;

--- a/RecoParticleFlow/PFClusterTools/interface/CalibratableTest.h
+++ b/RecoParticleFlow/PFClusterTools/interface/CalibratableTest.h
@@ -57,7 +57,7 @@
 class CalibratableTest : public edm::one::EDAnalyzer<> {
 public:
 	explicit CalibratableTest(const edm::ParameterSet&);
-	~CalibratableTest();
+	~CalibratableTest() override;
 
 	/*
 	 * Returns the collection in the event matching the Handle.
@@ -69,9 +69,9 @@ private:
 	/* 
 	 * The usual EDAnalyzer methods
 	 */
-	virtual void beginJob() override;
-	virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-	virtual void endJob() override;
+	void beginJob() override;
+	void analyze(const edm::Event&, const edm::EventSetup&) override;
+	void endJob() override;
 
 	/*
 	 * Called for each particle in the event to fill the tree and

--- a/RecoParticleFlow/PFClusterTools/interface/DetectorElement.h
+++ b/RecoParticleFlow/PFClusterTools/interface/DetectorElement.h
@@ -74,7 +74,7 @@ private:
 	virtual double getCalibCore(double eta, double phi) const;
 	virtual void setCalibCore(double calib) noexcept(false);
 	
-	DetectorElement(const DetectorElement& de);
+	DetectorElement(const DetectorElement& de) = delete;
 	DetectorElementType myType;
 	double myCalib;
 

--- a/RecoParticleFlow/PFClusterTools/interface/Exercises3.h
+++ b/RecoParticleFlow/PFClusterTools/interface/Exercises3.h
@@ -48,8 +48,8 @@ public:
 
 private:
 	
-	Exercises3(const Exercises3&);
-	void operator=(const Exercises3&);
+	Exercises3(const Exercises3&) = delete;
+	void operator=(const Exercises3&) = delete;
 //	double lowE_, highE_, lowEta_, highEta_, lowPhi_, highPhi_;
 //	unsigned divE_, divEta_, divPhi_;
 	bool withOffset_;

--- a/RecoParticleFlow/PFClusterTools/interface/IO.h
+++ b/RecoParticleFlow/PFClusterTools/interface/IO.h
@@ -59,7 +59,7 @@ class IO {
   friend std::ostream& operator<<(std::ostream& out, IO& io);
 
   /// true if constructor went wrong
-  bool IsZombie() const {return !fAllLines.size();}
+  bool IsZombie() const {return fAllLines.empty();}
 
 #ifndef __CINT__
   /// reads a vector of T
@@ -108,8 +108,8 @@ template <class T>
 bool pftools::IO::GetOpt(const char* tag, const char* key, std::vector< T >& values) const {
   std::string data = GetLineData(tag,key);
  
-  std::istringstream in(data.c_str());  
-  while(1) {
+  std::istringstream in(data);  
+  while(true) {
     T tmp;
     in>>tmp;
     if(!in) break;
@@ -123,7 +123,7 @@ template <class T>
 bool pftools::IO::GetOpt(const char* tag, const char* key, T& value) const {
   std::string data = GetLineData(tag,key);
   
-  std::istringstream in(data.c_str());  
+  std::istringstream in(data);  
   in>>value;
   if(in.good()) return true;
   else return false;
@@ -139,7 +139,7 @@ bool pftools::IO::GetAllOpt(const char* tag, const char* key, T& value) {
   std::string data = GetNextLineData(tag, key);
   if(data.empty()) return false;
   
-  std::istringstream in(data.c_str());  
+  std::istringstream in(data);  
   in>>value;
   if(in) {
     return true;

--- a/RecoParticleFlow/PFClusterTools/interface/LinearCalibrator.h
+++ b/RecoParticleFlow/PFClusterTools/interface/LinearCalibrator.h
@@ -24,7 +24,7 @@ namespace pftools {
 class LinearCalibrator : public Calibrator {
 public:
 	LinearCalibrator();
-	virtual ~LinearCalibrator();
+	~LinearCalibrator() override;
 
 
 	/*
@@ -32,13 +32,13 @@ public:
 	 * the return type but this IS allowed with modern compilers.
 	 * See documentation in Calibrator.h
 	 */
-	LinearCalibrator* clone() const;
-	LinearCalibrator* create() const;
+	LinearCalibrator* clone() const override;
+	LinearCalibrator* create() const override;
 
 protected:
 	
-	virtual std::map<DetectorElementPtr, double>
-			getCalibrationCoefficientsCore() noexcept(false);
+	std::map<DetectorElementPtr, double>
+			getCalibrationCoefficientsCore() noexcept(false) override;
 
 
 	LinearCalibrator(const LinearCalibrator& lc);

--- a/RecoParticleFlow/PFClusterTools/interface/PFToolsException.h
+++ b/RecoParticleFlow/PFClusterTools/interface/PFToolsException.h
@@ -15,9 +15,9 @@ class PFToolsException : public std::exception {
 public:
 	PFToolsException(const std::string& aErrorDescription="");
 	
-	virtual ~PFToolsException() noexcept;
+	~PFToolsException() noexcept override;
 	
-	virtual const char* what() const noexcept;
+	const char* what() const noexcept override;
 	
 protected:
 	std::string myDescription;

--- a/RecoParticleFlow/PFClusterTools/plugins/CalibratableTest.cc
+++ b/RecoParticleFlow/PFClusterTools/plugins/CalibratableTest.cc
@@ -79,7 +79,7 @@ void CalibratableTest::analyze(const edm::Event& event,
 	PFClusterCollection clustersEcal = **clustersEcal_;
 	PFClusterCollection clustersHcal = **clustersHcal_;
 
-	if (sims.size() == 0) {
+	if (sims.empty()) {
 		std::cout << "\tNo sim particles found!" << std::endl;
 		thisEventPasses_ = false;
 	}
@@ -118,7 +118,7 @@ void CalibratableTest::analyze(const edm::Event& event,
 		if (debug_ > 3)
 			std::cout << "\t\tFound candidates near sim, found "
 					<< matchingCands.size()<< " of them.\n";
-		if (matchingCands.size() == 0)
+		if (matchingCands.empty())
 			thisParticlePasses_ = false;
 		for (std::vector<unsigned>::const_iterator mcIt = matchingCands.begin(); mcIt
 				!= matchingCands.end(); ++mcIt) {
@@ -156,7 +156,7 @@ std::vector<unsigned> CalibratableTest::findPrimarySimParticles(
 		if (particleId != 211)
 			continue;
 		//TODO: ...particularly interacting pions?
-		if (theSim.daughterIds().size() > 0)
+		if (!theSim.daughterIds().empty())
 			continue;
 		answers.push_back(index);
 		++index;

--- a/RecoParticleFlow/PFClusterTools/src/Exercises3.cc
+++ b/RecoParticleFlow/PFClusterTools/src/Exercises3.cc
@@ -184,7 +184,7 @@ void Exercises3::calibrateCalibratables(TChain& sourceTree,
 		CalibratorPtr c = sm->findCalibrator(pd->getEta(), pd->getPhi(),
 				pd->getTruthEnergy());
 		//std::cout << *pd << "\n";
-		if (c == 0) {
+		if (c == nullptr) {
 			std::cout << "Couldn't find calibrator for particle?!\n";
 			std::cout << "\t"<< *pd << "\n";
 

--- a/RecoParticleFlow/PFClusterTools/src/IO.cc
+++ b/RecoParticleFlow/PFClusterTools/src/IO.cc
@@ -95,7 +95,7 @@ string IO::GetLineData(const char* tag, const char* key) const {
   bool found = false;
   for(unsigned i=0; i<fAllLines.size(); i++) {
     if( !fnmatch(fAllLines[i].first.c_str(), tag, 0) ) { 
-      istringstream in(fAllLines[i].second.c_str());
+      istringstream in(fAllLines[i].second);
       string readkey; in>>readkey;
       
       if(readkey == key) {
@@ -126,7 +126,7 @@ string IO::GetNextLineData(const char* tag, const char* key)  {
   bool found = false;
   for(unsigned i=fCurline; i<fAllLines.size(); i++) {
     if( !fnmatch(fAllLines[i].first.c_str(), tag, 0) ) { 
-      istringstream in(fAllLines[i].second.c_str());
+      istringstream in(fAllLines[i].second);
       string readkey; in>>readkey;
       
       if(readkey == key) {
@@ -146,7 +146,7 @@ bool IO::GetOpt(const char* tag, const char* key, string& value) const {
   string data = GetLineData(tag,key);
   
   char cstr[sLinesize];
-  istringstream in(data.c_str());  
+  istringstream in(data);  
   in.get(cstr,sLinesize);
 
 

--- a/RecoParticleFlow/PFClusterTools/src/LinkByRecHit.cc
+++ b/RecoParticleFlow/PFClusterTools/src/LinkByRecHit.cc
@@ -522,8 +522,8 @@ LinkByRecHit::testHFEMAndHFHADByRecHit(const reco::PFCluster& clusterHFEM,
 				      const reco::PFCluster& clusterHFHAD,
 				      bool debug) {
   
-  auto posxyzEM = clusterHFEM.position();
-  auto posxyzHAD = clusterHFHAD.position();
+  const auto& posxyzEM = clusterHFEM.position();
+  const auto& posxyzHAD = clusterHFHAD.position();
 
   double dX = posxyzEM.X()-posxyzHAD.X();
   double dY = posxyzEM.Y()-posxyzHAD.Y();

--- a/RecoParticleFlow/PFClusterTools/src/PFClusterCalibration.cc
+++ b/RecoParticleFlow/PFClusterTools/src/PFClusterCalibration.cc
@@ -177,7 +177,7 @@ void PFClusterCalibration::setCorrections(const double& lowEP0,
 
 double PFClusterCalibration::getCalibratedEcalEnergy(const double& ecalE,
 		const double& hcalE, const double& eta, const double& phi) const {
-	const TF1* theFunction(0);
+	const TF1* theFunction(nullptr);
 
 	if (fabs(eta) < barrelEndcapEtaDiv_) {
 		//barrel
@@ -187,7 +187,7 @@ double PFClusterCalibration::getCalibratedEcalEnergy(const double& ecalE,
 		theFunction = &(namesAndFunctions_.find("ecalHcalEcalEndcap")->second);
 	}
 
-	assert(theFunction != 0);
+	assert(theFunction != nullptr);
 	double totalE(ecalE + hcalE);
 	double bCoeff = theFunction->Eval(totalE);
 	return ecalE * bCoeff;
@@ -195,7 +195,7 @@ double PFClusterCalibration::getCalibratedEcalEnergy(const double& ecalE,
 
 double PFClusterCalibration::getCalibratedHcalEnergy(const double& ecalE,
 		const double& hcalE, const double& eta, const double& phi) const {
-	const TF1* theFunction(0);
+	const TF1* theFunction(nullptr);
 
 	if (fabs(eta) < barrelEndcapEtaDiv_) {
 		//barrel
@@ -206,7 +206,7 @@ double PFClusterCalibration::getCalibratedHcalEnergy(const double& ecalE,
 	}
 
 	double totalE(ecalE + hcalE);
-	assert(theFunction != 0);
+	assert(theFunction != nullptr);
 	double cCoeff = theFunction->Eval(totalE);
 	return hcalE * cCoeff;
 }

--- a/RecoParticleFlow/PFClusterTools/src/PFEnergyCalibration.cc
+++ b/RecoParticleFlow/PFClusterTools/src/PFEnergyCalibration.cc
@@ -4,7 +4,7 @@
 #include "CondFormats/ESObjects/interface/ESEEIntercalibConstants.h"
 
 #include <TMath.h>
-#include <math.h>
+#include <cmath>
 #include <vector>
 #include <TF1.h>
 #include <map>
@@ -13,7 +13,7 @@
 
 using namespace std;
 
-PFEnergyCalibration::PFEnergyCalibration() : pfCalibrations(0), esEEInterCalib_(0)
+PFEnergyCalibration::PFEnergyCalibration() : pfCalibrations(nullptr), esEEInterCalib_(nullptr)
 {
   initializeCalibrationFunctions();
 }
@@ -876,19 +876,19 @@ PFEnergyCalibration::EcorrPS(double eEcal,double ePS1,double ePS2,double etaEcal
   // gives the good weights to each subdetector
   double gammaprime=Gamma(etaEcal)/9e-5;
 
-  if(outputPS1 == 0 && outputPS2 == 0 && esEEInterCalib_ != 0){
+  if(outputPS1 == 0 && outputPS2 == 0 && esEEInterCalib_ != nullptr){
     // both ES planes working
     // scaling factor accounting for data-mc                                                                                 
     outputPS1=gammaprime*ePS1 * esEEInterCalib_->getGammaLow0();
     outputPS2=gammaprime*Alpha(etaEcal)*ePS2 * esEEInterCalib_->getGammaLow3();
   }
-  else if(outputPS1 == 0 && outputPS2 == -1 && esEEInterCalib_ != 0){
+  else if(outputPS1 == 0 && outputPS2 == -1 && esEEInterCalib_ != nullptr){
     // ESP1 only working
     double corrTotES = gammaprime*ePS1 * esEEInterCalib_->getGammaLow0() * esEEInterCalib_->getGammaLow1();
     outputPS1 = gammaprime*ePS1 * esEEInterCalib_->getGammaLow0();
     outputPS2 = corrTotES - outputPS1;
   }
-  else if(outputPS1 == -1 && outputPS2 == 0 && esEEInterCalib_ != 0){
+  else if(outputPS1 == -1 && outputPS2 == 0 && esEEInterCalib_ != nullptr){
     // ESP2 only working
     double corrTotES = gammaprime*Alpha(etaEcal)*ePS2 * esEEInterCalib_->getGammaLow3() * esEEInterCalib_->getGammaLow2();
     outputPS2 = gammaprime*Alpha(etaEcal)*ePS2 * esEEInterCalib_->getGammaLow3();

--- a/RecoParticleFlow/PFClusterTools/src/PFEnergyCalibrationHF.cc
+++ b/RecoParticleFlow/PFClusterTools/src/PFEnergyCalibrationHF.cc
@@ -1,6 +1,6 @@
 #include "RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibrationHF.h"
 #include <TMath.h>
-#include <math.h>
+#include <cmath>
 #include <vector>
 #include <TF1.h>
 

--- a/RecoParticleFlow/PFClusterTools/src/PFEnergyResolution.cc
+++ b/RecoParticleFlow/PFClusterTools/src/PFEnergyResolution.cc
@@ -1,6 +1,6 @@
 #include "RecoParticleFlow/PFClusterTools/interface/PFEnergyResolution.h"
 #include <TMath.h>
-#include <math.h>
+#include <cmath>
 /*
 PFEnergyResolution::PFEnergyResolution(const edm::ParameterSet& parameters)
 {

--- a/RecoParticleFlow/PFClusterTools/src/SpaceManager.cc
+++ b/RecoParticleFlow/PFClusterTools/src/SpaceManager.cc
@@ -221,7 +221,7 @@ CalibratorPtr SpaceManager::createCalibrator(const Calibrator& toClone,
 	} else {
 		c = myAddressBook[s];
 	}
-	assert(c != 0);
+	assert(c != nullptr);
 	return c;
 
 }
@@ -344,7 +344,7 @@ double SpaceManager::interpolateCoefficient(DetectorElementPtr det,
 	if (diffEnergy > 0) {
 		//look to higher energy calibrators
 		CalibratorPtr adjC = findCalibrator(eta, phi, s->maxEnergy() + 0.1);
-		if (adjC != 0) {
+		if (adjC != nullptr) {
 			SpaceVoxelPtr adjS = inverseAddressBook_[adjC];
 			adjacentCoeff = calibrationCoeffs_[adjC][det];
 			adjacentEnergy = (adjS->minEnergy() + adjS->maxEnergy()) / 2.0;
@@ -352,7 +352,7 @@ double SpaceManager::interpolateCoefficient(DetectorElementPtr det,
 	} else {
 		//look to lower energy calibrations
 		CalibratorPtr adjC = findCalibrator(eta, phi, s->minEnergy() - 0.1);
-		if (adjC != 0) {
+		if (adjC != nullptr) {
 			SpaceVoxelPtr adjS = inverseAddressBook_[adjC];
 			adjacentCoeff = calibrationCoeffs_[adjC][det];
 			adjacentEnergy = (adjS->minEnergy() + adjS->maxEnergy()) / 2.0;

--- a/RecoParticleFlow/PFClusterTools/src/TreeUtility.cc
+++ b/RecoParticleFlow/PFClusterTools/src/TreeUtility.cc
@@ -70,7 +70,7 @@ void TreeUtility::dumpCaloDataToCSV(TChain& tree, std::string csvFilename, doubl
 		//Check vetos as usual
 		if (c.cands_num_ > 1)
 			veto = true;
-		 if(c.cluster_ecal_.size() == 0  && c.cluster_hcal_.size() == 0)
+		 if(c.cluster_ecal_.empty()  && c.cluster_hcal_.empty())
 		 	veto = true;
 		 if(!veto) {
 			if(frequencies.GetBinContent(static_cast<int>(floor(c.sim_energyEvent_)) + 1) < (3000) * g.Eval(c.sim_energyEvent_) ) {
@@ -158,7 +158,7 @@ unsigned TreeUtility::getParticleDepositsDirectly(TChain& sourceChain,
 			veto = true;
 
 		if (target == CLUSTER) {
-			if (c.cluster_ecal_.size() == 0  && c.cluster_hcal_.size() ==0)
+			if (c.cluster_ecal_.empty()  && c.cluster_hcal_.empty())
 				veto = true;
 			//			if (c.cluster_numEcal_ > 1|| c.cluster_numHcal_ > 1)
 			//				veto = true;
@@ -204,7 +204,7 @@ unsigned TreeUtility::getParticleDepositsDirectly(TChain& sourceChain,
 		}
 
 		else if (target == RECHIT) {
-			if (c.rechits_ecal_.size() == 0&& c.rechits_hcal_.size() == 0)
+			if (c.rechits_ecal_.empty()&& c.rechits_hcal_.empty())
 				veto = true;
 			Deposition decal(ecal, c.rechits_meanEcal_.eta_,
 					c.rechits_meanEcal_.phi_, c.rechits_meanEcal_.energy_
@@ -274,7 +274,7 @@ unsigned TreeUtility::convertCalibratablesToParticleDeposits(
 			veto = true;
 
 		if (target == CLUSTER) {
-			if (c.cluster_ecal_.size() == 0&& c.cluster_hcal_.size() ==0)
+			if (c.cluster_ecal_.empty()&& c.cluster_hcal_.empty())
 				veto = true;
 			//			if (c.cluster_numEcal_ > 1|| c.cluster_numHcal_ > 1)
 			//				veto = true;
@@ -320,7 +320,7 @@ unsigned TreeUtility::convertCalibratablesToParticleDeposits(
 		}
 
 		else if (target == RECHIT) {
-			if (c.rechits_ecal_.size() == 0&& c.rechits_hcal_.size() == 0)
+			if (c.rechits_ecal_.empty()&& c.rechits_hcal_.empty())
 				veto = true;
 			Deposition decal(ecal, c.rechits_meanEcal_.eta_,
 					c.rechits_meanEcal_.phi_, c.rechits_meanEcal_.energy_

--- a/RecoParticleFlow/PFClusterTools/src/Utils.cc
+++ b/RecoParticleFlow/PFClusterTools/src/Utils.cc
@@ -1,7 +1,7 @@
 #include "RecoParticleFlow/PFClusterTools/interface/Utils.h"
 
-#include <stdio.h>
-#include <math.h>
+#include <cstdio>
+#include <cmath>
 #include <regex.h>
 #include <glob.h>
 
@@ -17,7 +17,7 @@ bool Utils::StringMatch(const char* str, const char* pattern) {
   if( regcomp(&re, pattern, REG_EXTENDED|REG_NOSUB) != 0 )
     return false;
   
-  status = regexec(&re, str, (size_t)0, NULL, 0);
+  status = regexec(&re, str, (size_t)0, nullptr, 0);
   regfree(&re);
   
   if (status != 0)
@@ -28,7 +28,7 @@ bool Utils::StringMatch(const char* str, const char* pattern) {
 
 
 TCanvas* Utils::DivideCanvas( TCanvas *cv, int nPads ) {  
-  if( !cv ) return 0;
+  if( !cv ) return nullptr;
   
   if( nPads<=1 ) return cv;
   int sqnP = (unsigned int) (sqrt( nPads ));
@@ -48,7 +48,7 @@ vector<string>  Utils::Glob(const char* pattern) {
   glob_t globbuf;
 
   globbuf.gl_offs = 2;
-  glob(pattern, GLOB_TILDE|GLOB_BRACE|GLOB_MARK, NULL, &globbuf);
+  glob(pattern, GLOB_TILDE|GLOB_BRACE|GLOB_MARK, nullptr, &globbuf);
 
   vector<string> results;
   for(unsigned i=0; i<globbuf.gl_pathc; i++) {

--- a/RecoParticleFlow/PFProducer/interface/KDTreeLinkerTools.h
+++ b/RecoParticleFlow/PFProducer/interface/KDTreeLinkerTools.h
@@ -49,7 +49,7 @@ struct KDTreeNodeInfo
   
   public:
   KDTreeNodeInfo()
-    : ptr(0)
+    : ptr(nullptr)
   {}
   
   KDTreeNodeInfo(const reco::PFRecHit	*rhptr,
@@ -74,7 +74,7 @@ struct KDTreeNode
   
   public:
   KDTreeNode()
-    : left(0), right(0)
+    : left(nullptr), right(nullptr)
   {}
   
   void setAttributs(const KDTreeBox&		regionBox,

--- a/RecoParticleFlow/PFProducer/interface/PFAlgoTestBenchConversions.h
+++ b/RecoParticleFlow/PFProducer/interface/PFAlgoTestBenchConversions.h
@@ -23,16 +23,16 @@ class PFAlgoTestBenchConversions : public PFAlgo {
   PFAlgoTestBenchConversions() {}
 
   /// destructor
-  virtual ~PFAlgoTestBenchConversions() {}
+  ~PFAlgoTestBenchConversions() override {}
   
  
  protected:
 
   /// process one block. can be reimplemented in more sophisticated 
   /// algorithms
-  virtual void processBlock( const reco::PFBlockRef& blockref,
+  void processBlock( const reco::PFBlockRef& blockref,
                              std::list<reco::PFBlockRef>& hcalBlockRefs, 
-			     std::list<reco::PFBlockRef>& ecalBlockRefs );
+			     std::list<reco::PFBlockRef>& ecalBlockRefs ) override;
   
 
  private:

--- a/RecoParticleFlow/PFProducer/interface/PFAlgoTestBenchElectrons.h
+++ b/RecoParticleFlow/PFProducer/interface/PFAlgoTestBenchElectrons.h
@@ -23,16 +23,16 @@ class PFAlgoTestBenchElectrons : public PFAlgo {
   PFAlgoTestBenchElectrons() {}
 
   /// destructor
-  virtual ~PFAlgoTestBenchElectrons() {}
+  ~PFAlgoTestBenchElectrons() override {}
   
 
  protected:
 
   /// process one block. can be reimplemented in more sophisticated 
   /// algorithms
-  virtual void processBlock( const reco::PFBlockRef& blockref,
+  void processBlock( const reco::PFBlockRef& blockref,
                              std::list<reco::PFBlockRef>& hcalBlockRefs, 
-			     std::list<reco::PFBlockRef>& ecalBlockRefs );
+			     std::list<reco::PFBlockRef>& ecalBlockRefs ) override;
   
 
  private:

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h
@@ -80,7 +80,7 @@ class PFEGammaAlgo {
     float > KFValMap;  
     
   struct ProtoEGObject {
-    ProtoEGObject() : parentSC(NULL) {}
+    ProtoEGObject() : parentSC(nullptr) {}
     reco::PFBlockRef parentBlock;
     const PFSCElement* parentSC; // if ECAL driven
     reco::ElectronSeedRef electronSeed; // if there is one
@@ -167,7 +167,7 @@ class PFEGammaAlgo {
                           const reco::PFBlockRef&  blockRef,
                           std::vector< bool >&  active){
     RunPFEG(hoc,blockRef,active);
-    return (egCandidate_.size()>0);
+    return (!egCandidate_.empty());
   };
   
   //get PFCandidate collection

--- a/RecoParticleFlow/PFProducer/plugins/ChargedHadronPFTrackIsolationProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/ChargedHadronPFTrackIsolationProducer.cc
@@ -28,7 +28,7 @@ class ChargedHadronPFTrackIsolationProducer : public edm::global::EDProducer<>
 public:
 
   explicit ChargedHadronPFTrackIsolationProducer(const edm::ParameterSet& cfg);
-  ~ChargedHadronPFTrackIsolationProducer() {}
+  ~ChargedHadronPFTrackIsolationProducer() override {}
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 

--- a/RecoParticleFlow/PFProducer/plugins/EFilter.h
+++ b/RecoParticleFlow/PFProducer/plugins/EFilter.h
@@ -30,10 +30,10 @@ class FSimEvent;
 class EFilter : public edm::stream::EDFilter<> {
  public:
   explicit EFilter(const edm::ParameterSet&);
-  ~EFilter();
+  ~EFilter() override;
 
  private:
-  virtual bool filter(edm::Event&, const edm::EventSetup&) override;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
   
   // ----------member data ---------------------------
 /*   edm::ParameterSet  vertexGenerator_;  */

--- a/RecoParticleFlow/PFProducer/plugins/PFBlockProducer.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFBlockProducer.h
@@ -49,12 +49,12 @@ class PFBlockProducer : public edm::stream::EDProducer<> {
 
   explicit PFBlockProducer(const edm::ParameterSet&);
 
-  ~PFBlockProducer();
+  ~PFBlockProducer() override;
   
-  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, 
+  void beginLuminosityBlock(edm::LuminosityBlock const&, 
 				    edm::EventSetup const&) override;
 
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
  private:
   /// verbose ?

--- a/RecoParticleFlow/PFProducer/plugins/PFCandidateChecker.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFCandidateChecker.h
@@ -33,11 +33,11 @@ class PFCandidateChecker : public edm::stream::EDAnalyzer<> {
 
   explicit PFCandidateChecker(const edm::ParameterSet&);
 
-  ~PFCandidateChecker();
+  ~PFCandidateChecker() override;
   
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  virtual void beginRun(const edm::Run & r, const edm::EventSetup & c);
+  void beginRun(const edm::Run & r, const edm::EventSetup & c) override;
 
  private:
   

--- a/RecoParticleFlow/PFProducer/plugins/PFConcretePFCandidateProducer.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFConcretePFCandidateProducer.h
@@ -17,9 +17,9 @@
 class PFConcretePFCandidateProducer : public edm::stream::EDProducer<> {
  public:
   explicit PFConcretePFCandidateProducer(const edm::ParameterSet&);
-  ~PFConcretePFCandidateProducer();
+  ~PFConcretePFCandidateProducer() override;
   
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
  private:
 

--- a/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
@@ -377,7 +377,7 @@ PFEGammaProducer::produce(edm::Event& iEvent,
     
     pfeg_->RunPFEG(globalCache(),blockref,active);
 
-    if( pfeg_->getCandidates().size() ) {
+    if( !pfeg_->getCandidates().empty() ) {
       LOGDRESSED("PFEGammaProducer")
       << "Block with " << elements.size() 
       << " elements produced " 

--- a/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.h
@@ -51,7 +51,7 @@ This producer makes use of PFAlgo, the particle flow algorithm.
 class PFEGammaProducer : public edm::stream::EDProducer<edm::GlobalCache<pfEGHelpers::HeavyObjectCache> > {
  public:
   explicit PFEGammaProducer(const edm::ParameterSet&, const pfEGHelpers::HeavyObjectCache* );
-  ~PFEGammaProducer();
+  ~PFEGammaProducer() override;
   
   static std::unique_ptr<pfEGHelpers::HeavyObjectCache> 
     initializeGlobalCache( const edm::ParameterSet& conf ) {
@@ -61,8 +61,8 @@ class PFEGammaProducer : public edm::stream::EDProducer<edm::GlobalCache<pfEGHel
   static void globalEndJob(pfEGHelpers::HeavyObjectCache const* ) {
   }
 
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void beginRun(const edm::Run &, const edm::EventSetup &) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void beginRun(const edm::Run &, const edm::EventSetup &) override;
 
  private:  
 

--- a/RecoParticleFlow/PFProducer/plugins/PFElectronTranslator.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFElectronTranslator.cc
@@ -287,7 +287,7 @@ void PFElectronTranslator::createBasicCluster(const reco::PFBlockElement & PFBE,
 					      std::vector<const reco::PFCluster *> & pfClusters,
 					      const reco::PFCandidate & coCandidate) const
 {
-  reco::PFClusterRef myPFClusterRef= PFBE.clusterRef();
+  const reco::PFClusterRef& myPFClusterRef= PFBE.clusterRef();
   if(myPFClusterRef.isNull()) return;  
 
   const reco::PFCluster & myPFCluster (*myPFClusterRef);
@@ -309,7 +309,7 @@ void PFElectronTranslator::createBasicCluster(const reco::PFBlockElement & PFBE,
 
 void PFElectronTranslator::createPreshowerCluster(const reco::PFBlockElement & PFBE, reco::PreshowerClusterCollection& preshowerClusters,unsigned plane) const
 {
-  reco::PFClusterRef  myPFClusterRef= PFBE.clusterRef();
+  const reco::PFClusterRef&  myPFClusterRef= PFBE.clusterRef();
   preshowerClusters.push_back(reco::PreshowerCluster(myPFClusterRef->energy(),myPFClusterRef->position(),
 					       myPFClusterRef->hitsAndFractions(),plane));
 }
@@ -575,7 +575,7 @@ void PFElectronTranslator::createGsfElectronCoreRefs(const edm::OrphanHandle<rec
 
 void PFElectronTranslator::getAmbiguousGsfTracks(const reco::PFBlockElement & PFBE, std::vector<reco::GsfTrackRef>& tracks) const {
   const reco::PFBlockElementGsfTrack *  GsfEl =  dynamic_cast<const reco::PFBlockElementGsfTrack*>(&PFBE);
-  if(GsfEl==0) return;
+  if(GsfEl==nullptr) return;
   const std::vector<reco::GsfPFRecTrackRef>& ambPFRecTracks(GsfEl->GsftrackRefPF()->convBremGsfPFRecTrackRef());
   unsigned ntracks=ambPFRecTracks.size();
   for(unsigned it=0;it<ntracks;++it) {
@@ -624,7 +624,7 @@ void PFElectronTranslator::createGsfElectrons(const reco::PFCandidateCollection 
       }
 
       // isolation
-      if( isolationValues.size() != 0 ) {
+      if( !isolationValues.empty() ) {
       	reco::GsfElectron::PflowIsolationVariables myPFIso;
       	myPFIso.sumChargedHadronPt=(*isolationValues[0])[CandidatePtr_[iGSF]];
       	myPFIso.sumPhotonEt=(*isolationValues[1])[CandidatePtr_[iGSF]];

--- a/RecoParticleFlow/PFProducer/plugins/PFElectronTranslator.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFElectronTranslator.h
@@ -24,9 +24,9 @@ class PFElectronTranslator : public edm::stream::EDProducer<>
 {
  public:
   explicit PFElectronTranslator(const edm::ParameterSet&);
-  ~PFElectronTranslator();
+  ~PFElectronTranslator() override;
   
-  virtual void produce(edm::Event &, const edm::EventSetup&) override;
+  void produce(edm::Event &, const edm::EventSetup&) override;
 
   typedef std::vector< edm::Handle< edm::ValueMap<double> > > IsolationValueMaps;
 

--- a/RecoParticleFlow/PFProducer/plugins/PFPhotonTranslator.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFPhotonTranslator.cc
@@ -189,7 +189,7 @@ void PFPhotonTranslator::produce(edm::Event& iEvent,
 
 	//std::cout << "nDoubleLegConv="<<cand.photonExtraRef()->conversionRef().size()<<std::endl;
 
-	if (cand.photonExtraRef()->conversionRef().size()>0){
+	if (!cand.photonExtraRef()->conversionRef().empty()){
 
 	  pfConv_.push_back(reco::ConversionRefVector());
 
@@ -208,7 +208,7 @@ void PFPhotonTranslator::produce(edm::Event& iEvent,
 	
 	//std::cout << "nSingleLegConv=" <<singleLegConvColl.size() << std::endl;
 
-	if (singleLegConvColl.size()>0){
+	if (!singleLegConvColl.empty()){
 
 	  pfSingleLegConv_.push_back(std::vector<reco::TrackRef>());
 	  pfSingleLegConvMva_.push_back(std::vector<float>());
@@ -525,7 +525,7 @@ void PFPhotonTranslator::createBasicCluster(const reco::PFBlockElement & PFBE,
 					      std::vector<const reco::PFCluster *> & pfClusters,
 					      const reco::PFCandidate & coCandidate) const
 {
-  reco::PFClusterRef myPFClusterRef = PFBE.clusterRef();
+  const reco::PFClusterRef& myPFClusterRef = PFBE.clusterRef();
   if(myPFClusterRef.isNull()) return;  
 
   const reco::PFCluster & myPFCluster (*myPFClusterRef);
@@ -545,7 +545,7 @@ void PFPhotonTranslator::createBasicCluster(const reco::PFBlockElement & PFBE,
 
 void PFPhotonTranslator::createPreshowerCluster(const reco::PFBlockElement & PFBE, reco::PreshowerClusterCollection& preshowerClusters,unsigned plane) const
 {
-  reco::PFClusterRef  myPFClusterRef= PFBE.clusterRef();
+  const reco::PFClusterRef&  myPFClusterRef= PFBE.clusterRef();
   preshowerClusters.push_back(reco::PreshowerCluster(myPFClusterRef->energy(),myPFClusterRef->position(),
 					       myPFClusterRef->hitsAndFractions(),plane));
 }
@@ -715,7 +715,7 @@ void PFPhotonTranslator::createOneLegConversions(const edm::OrphanHandle<reco::S
 	    std::vector<reco::TrackRef> OneLegConvVector;
 	    OneLegConvVector.push_back(pfSingleLegConv_[conv1legPFCandidateIndex_[iphot]][iConv]);
 	    
-	    reco::CaloClusterPtrVector clu=scPtrVec;
+	    const reco::CaloClusterPtrVector& clu=scPtrVec;
 	    std::vector<reco::TrackRef> tr=OneLegConvVector;
 	    std::vector<math::XYZPointF>trackPositionAtEcalVec;
 	    std::vector<math::XYZPointF>innPointVec;
@@ -896,7 +896,7 @@ void PFPhotonTranslator::createPhotons(reco::VertexCollection &vertexCollection,
       reco::PhotonCoreRef PCref(reco::PhotonCoreRef(photonCoresHandle, iphot));
 
       math::XYZPoint vtx(0.,0.,0.);
-      if (vertexCollection.size()>0) vtx = vertexCollection.begin()->position();
+      if (!vertexCollection.empty()) vtx = vertexCollection.begin()->position();
       //std::cout << "vtx made" << std::endl;
 
       math::XYZVector direction =  PCref->parentSuperCluster()->position() - vtx;

--- a/RecoParticleFlow/PFProducer/plugins/PFPhotonTranslator.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFPhotonTranslator.h
@@ -61,9 +61,9 @@ class PFPhotonTranslator : public edm::stream::EDProducer<>
 {
  public:
   explicit PFPhotonTranslator(const edm::ParameterSet&);
-  ~PFPhotonTranslator();
+  ~PFPhotonTranslator() override;
   
-  virtual void produce(edm::Event &, const edm::EventSetup&) override;
+  void produce(edm::Event &, const edm::EventSetup&) override;
 
   typedef std::vector< edm::Handle< edm::ValueMap<double> > > IsolationValueMaps;
 

--- a/RecoParticleFlow/PFProducer/plugins/PFProducer.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFProducer.h
@@ -42,10 +42,10 @@ This producer makes use of PFAlgo, the particle flow algorithm.
 class PFProducer : public edm::stream::EDProducer<> {
  public:
   explicit PFProducer(const edm::ParameterSet&);
-  ~PFProducer();
+  ~PFProducer() override;
   
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void beginRun(const edm::Run &, const edm::EventSetup &) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void beginRun(const edm::Run &, const edm::EventSetup &) override;
 
  private:
   edm::EDGetTokenT<reco::PFBlockCollection>  inputTagBlocks_;

--- a/RecoParticleFlow/PFProducer/plugins/importers/EGPhotonImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/EGPhotonImporter.cc
@@ -79,7 +79,7 @@ importToBlock( const edm::Event& e,
   //now add the photons
   auto bphoton = photons->cbegin();
   auto ephoton = photons->cend();
-  reco::PFBlockElementSuperCluster* scbe = NULL;
+  reco::PFBlockElementSuperCluster* scbe = nullptr;
   reco::PhotonRef phoref;
   for( auto photon = bphoton; photon != ephoton; ++photon ) {
     if( _selector->passPhotonSelection(*photon) ) {

--- a/RecoParticleFlow/PFProducer/plugins/importers/SuperClusterImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/SuperClusterImporter.cc
@@ -82,7 +82,7 @@ importToBlock( const edm::Event& e,
   // add eb superclusters
   auto bsc = eb_scs->cbegin();
   auto esc = eb_scs->cend();
-  reco::PFBlockElementSuperCluster* scbe = NULL;
+  reco::PFBlockElementSuperCluster* scbe = nullptr;
   reco::SuperClusterRef scref;
   for( auto sc = bsc; sc != esc; ++sc ) {
     scref = reco::SuperClusterRef(eb_scs,std::distance(bsc,sc));

--- a/RecoParticleFlow/PFProducer/plugins/importers/TrackFromParentImporter.h
+++ b/RecoParticleFlow/PFProducer/plugins/importers/TrackFromParentImporter.h
@@ -60,7 +60,7 @@ namespace pflow {
       auto bpar = pfparents->cbegin();
       auto epar = pfparents->cend();
       edm::Ref<Collection> parentRef;
-      reco::PFBlockElement* trkElem = NULL;
+      reco::PFBlockElement* trkElem = nullptr;
       for( auto pfparent =  bpar; pfparent != epar; ++pfparent ) {
 	if( Adaptor::check_importable(*pfparent) ) {
 	  parentRef = edm::Ref<Collection>(pfparents,std::distance(bpar,pfparent));

--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerPSEcal.cc
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerPSEcal.cc
@@ -26,7 +26,7 @@ KDTreeLinkerPSEcal::~KDTreeLinkerPSEcal()
 void
 KDTreeLinkerPSEcal::insertTargetElt(reco::PFBlockElement	*psCluster)
 {
-  reco::PFClusterRef clusterref = psCluster->clusterRef();
+  const reco::PFClusterRef& clusterref = psCluster->clusterRef();
 
   // This test is more or less done in PFBlockAlgo.h. In others cases, it should be switch on.
   //   if (!((clusterref->layer() == PFLayer::PS1) || 
@@ -40,7 +40,7 @@ KDTreeLinkerPSEcal::insertTargetElt(reco::PFBlockElement	*psCluster)
 void
 KDTreeLinkerPSEcal::insertFieldClusterElt(reco::PFBlockElement	*ecalCluster)
 {
-  reco::PFClusterRef clusterref = ecalCluster->clusterRef();
+  const reco::PFClusterRef& clusterref = ecalCluster->clusterRef();
 
   if (clusterref->layer() != PFLayer::ECAL_ENDCAP)
     return;

--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerPSEcal.h
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerPSEcal.h
@@ -13,30 +13,30 @@ class KDTreeLinkerPSEcal : public KDTreeLinkerBase
 {
  public:
   KDTreeLinkerPSEcal();
-  ~KDTreeLinkerPSEcal();
+  ~KDTreeLinkerPSEcal() override;
   
   // With this method, we create the list of psCluster that we want to link.
-  void insertTargetElt(reco::PFBlockElement		*psCluster);
+  void insertTargetElt(reco::PFBlockElement		*psCluster) override;
 
   // Here, we create the list of ecalCluster that we want to link. From ecalCluster
   // and fraction, we will create a second list of rechits that will be used to
   // build the KDTree.
-  void insertFieldClusterElt(reco::PFBlockElement	*ecalCluster);  
+  void insertFieldClusterElt(reco::PFBlockElement	*ecalCluster) override;  
 
   // The KDTree building from rechits list.
-  void buildTree();
+  void buildTree() override;
   
   // Here we will iterate over all psCluster. For each one, we will search the closest
   // rechits in the KDTree, from rechits we will find the ecalClusters and after that
   // we will check the links between the psCluster and all closest ecalClusters.
-  void searchLinks();
+  void searchLinks() override;
   
   // Here, we will store all PS/ECAL founded links in the PFBlockElement class
   // of each psCluster in the PFmultilinks field.
-  void updatePFBlockEltWithLinks();
+  void updatePFBlockEltWithLinks() override;
   
   // Here we free all allocated structures.
-  void clear();
+  void clear() override;
   
 
  private:

--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackEcal.cc
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackEcal.cc
@@ -31,7 +31,7 @@ KDTreeLinkerTrackEcal::insertTargetElt(reco::PFBlockElement	*track)
 void
 KDTreeLinkerTrackEcal::insertFieldClusterElt(reco::PFBlockElement	*ecalCluster)
 {
-  reco::PFClusterRef clusterref = ecalCluster->clusterRef();
+  const reco::PFClusterRef& clusterref = ecalCluster->clusterRef();
 
   // This test is more or less done in PFBlockAlgo.h. In others cases, it should be switch on.
   //   if (!((clusterref->layer() == PFLayer::ECAL_ENDCAP) ||

--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackEcal.h
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackEcal.h
@@ -13,31 +13,31 @@ class KDTreeLinkerTrackEcal : public KDTreeLinkerBase
 {
  public:
   KDTreeLinkerTrackEcal();
-  ~KDTreeLinkerTrackEcal();
+  ~KDTreeLinkerTrackEcal() override;
   
   // With this method, we create the list of psCluster that we want to link.
-  void insertTargetElt(reco::PFBlockElement		*track);
+  void insertTargetElt(reco::PFBlockElement		*track) override;
 
   // Here, we create the list of ecalCluster that we want to link. From ecalCluster
   // and fraction, we will create a second list of rechits that will be used to
   // build the KDTree.
-  void insertFieldClusterElt(reco::PFBlockElement	*ecalCluster);  
+  void insertFieldClusterElt(reco::PFBlockElement	*ecalCluster) override;  
 
   // The KDTree building from rechits list.
-  void buildTree();
+  void buildTree() override;
   
   // Here we will iterate over all tracks. For each track intersection point with ECAL, 
   // we will search the closest rechits in the KDTree, from rechits we will find the 
   // ecalClusters and after that we will check the links between the track and 
   // all closest ecalClusters.  
-  void searchLinks();
+  void searchLinks() override;
     
   // Here, we will store all PS/ECAL founded links in the PFBlockElement class
   // of each psCluster in the PFmultilinks field.
-  void updatePFBlockEltWithLinks();
+  void updatePFBlockEltWithLinks() override;
   
   // Here we free all allocated structures.
-  void clear();
+  void clear() override;
  
  private:
   // Data used by the KDTree algorithm : sets of Tracks and ECAL clusters.

--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackHcal.cc
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackHcal.cc
@@ -34,7 +34,7 @@ KDTreeLinkerTrackHcal::insertTargetElt(reco::PFBlockElement	*track)
 void
 KDTreeLinkerTrackHcal::insertFieldClusterElt(reco::PFBlockElement	*hcalCluster)
 {
-  reco::PFClusterRef clusterref = hcalCluster->clusterRef();
+  const reco::PFClusterRef& clusterref = hcalCluster->clusterRef();
 
   // This test is more or less done in PFBlockAlgo.h. In others cases, it should be switch on.
   //   if (!((clusterref->layer() == PFLayer::HCAL_ENDCAP) ||

--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackHcal.h
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackHcal.h
@@ -13,31 +13,31 @@ class KDTreeLinkerTrackHcal : public KDTreeLinkerBase
 {
  public:
   KDTreeLinkerTrackHcal();
-  ~KDTreeLinkerTrackHcal();
+  ~KDTreeLinkerTrackHcal() override;
   
   // With this method, we create the list of psCluster that we want to link.
-  void insertTargetElt(reco::PFBlockElement		*track);
+  void insertTargetElt(reco::PFBlockElement		*track) override;
 
   // Here, we create the list of hcalCluster that we want to link. From hcalCluster
   // and fraction, we will create a second list of rechits that will be used to
   // build the KDTree.
-  void insertFieldClusterElt(reco::PFBlockElement	*hcalCluster);  
+  void insertFieldClusterElt(reco::PFBlockElement	*hcalCluster) override;  
 
   // The KDTree building from rechits list.
-  void buildTree();
+  void buildTree() override;
   
   // Here we will iterate over all tracks. For each track intersection point with HCAL, 
   // we will search the closest rechits in the KDTree, from rechits we will find the 
   // hcalClusters and after that we will check the links between the track and 
   // all closest hcalClusters.  
-  void searchLinks();
+  void searchLinks() override;
     
   // Here, we will store all PS/HCAL founded links in the PFBlockElement class
   // of each psCluster in the PFmultilinks field.
-  void updatePFBlockEltWithLinks();
+  void updatePFBlockEltWithLinks() override;
   
   // Here we free all allocated structures.
-  void clear();
+  void clear() override;
  
  private:
   // Data used by the KDTree algorithm : sets of Tracks and HCAL clusters.

--- a/RecoParticleFlow/PFProducer/plugins/linkers/ECALAndBREMLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/ECALAndBREMLinker.cc
@@ -28,8 +28,8 @@ double ECALAndBREMLinker::testLink
     const reco::PFBlockElement* elem2) const { 
   constexpr reco::PFTrajectoryPoint::LayerType ECALShowerMax =
     reco::PFTrajectoryPoint::ECALShowerMax;
-  const reco::PFBlockElementCluster *ecalelem(NULL);
-  const reco::PFBlockElementBrem    *bremelem(NULL);
+  const reco::PFBlockElementCluster *ecalelem(nullptr);
+  const reco::PFBlockElementBrem    *bremelem(nullptr);
   double dist(-1.0);
   if( elem1->type() < elem2->type() ) {
     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);

--- a/RecoParticleFlow/PFProducer/plugins/linkers/ECALAndECALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/ECALAndECALLinker.cc
@@ -45,8 +45,8 @@ testLink( const reco::PFBlockElement* elem1,
   const reco::PFBlockElementCluster* ecal2 = 
     static_cast<const reco::PFBlockElementCluster*>(elem2);
  
-  const reco::SuperClusterRef sc1 = ecal1->superClusterRef();
-  const reco::SuperClusterRef sc2 = ecal2->superClusterRef();
+  const reco::SuperClusterRef& sc1 = ecal1->superClusterRef();
+  const reco::SuperClusterRef& sc2 = ecal2->superClusterRef();
 
   const reco::PFClusterRef& clus1 = ecal1->clusterRef();
   const reco::PFClusterRef& clus2 = ecal2->clusterRef();

--- a/RecoParticleFlow/PFProducer/plugins/linkers/ECALAndHCALCaloJetLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/ECALAndHCALCaloJetLinker.cc
@@ -25,7 +25,7 @@ DEFINE_EDM_PLUGIN(BlockElementLinkerFactory,
 double ECALAndHCALCaloJetLinker::testLink
   ( const reco::PFBlockElement* elem1,
     const reco::PFBlockElement* elem2) const {  
-  const reco::PFBlockElementCluster *hcalelem(NULL), *ecalelem(NULL);
+  const reco::PFBlockElementCluster *hcalelem(nullptr), *ecalelem(nullptr);
   double dist(-1.0);
   if( elem1->type() < elem2->type() ) {
     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);

--- a/RecoParticleFlow/PFProducer/plugins/linkers/ECALAndHCALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/ECALAndHCALLinker.cc
@@ -25,7 +25,7 @@ DEFINE_EDM_PLUGIN(BlockElementLinkerFactory,
 double ECALAndHCALLinker::testLink
   ( const reco::PFBlockElement* elem1,
     const reco::PFBlockElement* elem2) const {  
-  const reco::PFBlockElementCluster *hcalelem(NULL), *ecalelem(NULL);
+  const reco::PFBlockElementCluster *hcalelem(nullptr), *ecalelem(nullptr);
   double dist(-1.0);
   if( elem1->type() < elem2->type() ) {
     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);

--- a/RecoParticleFlow/PFProducer/plugins/linkers/GSFAndBREMLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/GSFAndBREMLinker.cc
@@ -27,8 +27,8 @@ double GSFAndBREMLinker::testLink
   ( const reco::PFBlockElement* elem1,
     const reco::PFBlockElement* elem2) const {   
   double dist = -1.0;
-  const reco::PFBlockElementGsfTrack * gsfelem(NULL);
-  const reco::PFBlockElementBrem * bremelem(NULL);
+  const reco::PFBlockElementGsfTrack * gsfelem(nullptr);
+  const reco::PFBlockElementBrem * bremelem(nullptr);
   if( elem1->type() < elem2->type() ) {
     gsfelem = static_cast<const reco::PFBlockElementGsfTrack *>(elem1);
     bremelem = static_cast<const reco::PFBlockElementBrem *>(elem2);

--- a/RecoParticleFlow/PFProducer/plugins/linkers/GSFAndECALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/GSFAndECALLinker.cc
@@ -28,8 +28,8 @@ double GSFAndECALLinker::testLink
     const reco::PFBlockElement* elem2) const {  
   constexpr reco::PFTrajectoryPoint::LayerType ECALShowerMax =
     reco::PFTrajectoryPoint::ECALShowerMax;
-  const reco::PFBlockElementCluster  *ecalelem(NULL);
-  const reco::PFBlockElementGsfTrack *gsfelem(NULL);
+  const reco::PFBlockElementCluster  *ecalelem(nullptr);
+  const reco::PFBlockElementGsfTrack *gsfelem(nullptr);
   double dist(-1.0);
   if( elem1->type() < elem2->type() ) {
     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);

--- a/RecoParticleFlow/PFProducer/plugins/linkers/GSFAndHCALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/GSFAndHCALLinker.cc
@@ -28,8 +28,8 @@ double GSFAndHCALLinker::testLink
     const reco::PFBlockElement* elem2) const {  
   constexpr reco::PFTrajectoryPoint::LayerType HCALEnt =
     reco::PFTrajectoryPoint::HCALEntrance;
-  const reco::PFBlockElementCluster  *hcalelem(NULL);
-  const reco::PFBlockElementGsfTrack *gsfelem(NULL);
+  const reco::PFBlockElementCluster  *hcalelem(nullptr);
+  const reco::PFBlockElementGsfTrack *gsfelem(nullptr);
   double dist(-1.0);
   if( elem1->type() < elem2->type() ) {
     hcalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);

--- a/RecoParticleFlow/PFProducer/plugins/linkers/GSFAndHGCalLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/GSFAndHGCalLinker.cc
@@ -28,8 +28,8 @@ double GSFAndHGCalLinker::testLink
     const reco::PFBlockElement* elem2) const {  
   constexpr reco::PFTrajectoryPoint::LayerType ECALShowerMax =
     reco::PFTrajectoryPoint::ECALShowerMax;
-  const reco::PFBlockElementCluster  *hgcalelem(NULL);
-  const reco::PFBlockElementGsfTrack *gsfelem(NULL);
+  const reco::PFBlockElementCluster  *hgcalelem(nullptr);
+  const reco::PFBlockElementGsfTrack *gsfelem(nullptr);
   double dist(-1.0);
   if( elem1->type() > elem2->type() ) {
     hgcalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);

--- a/RecoParticleFlow/PFProducer/plugins/linkers/HCALAndBREMLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/HCALAndBREMLinker.cc
@@ -28,8 +28,8 @@ double HCALAndBREMLinker::testLink
     const reco::PFBlockElement* elem2) const { 
   constexpr reco::PFTrajectoryPoint::LayerType HCALEnt =
     reco::PFTrajectoryPoint::HCALEntrance;
-  const reco::PFBlockElementCluster *hcalelem(NULL);
-  const reco::PFBlockElementBrem    *bremelem(NULL);
+  const reco::PFBlockElementCluster *hcalelem(nullptr);
+  const reco::PFBlockElementBrem    *bremelem(nullptr);
   double dist(-1.0);
   if( elem1->type() < elem2->type() ) {
     hcalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);

--- a/RecoParticleFlow/PFProducer/plugins/linkers/HCALAndHOLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/HCALAndHOLinker.cc
@@ -25,7 +25,7 @@ DEFINE_EDM_PLUGIN(BlockElementLinkerFactory,
 double HCALAndHOLinker::testLink
   ( const reco::PFBlockElement* elem1,
     const reco::PFBlockElement* elem2) const {  
-  const reco::PFBlockElementCluster *hcalelem(NULL), *hoelem(NULL);
+  const reco::PFBlockElementCluster *hcalelem(nullptr), *hoelem(nullptr);
   double dist(-1.0);
   if( elem1->type() < elem2->type() ) {
     hcalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);

--- a/RecoParticleFlow/PFProducer/plugins/linkers/HFEMAndHFHADLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/HFEMAndHFHADLinker.cc
@@ -25,7 +25,7 @@ DEFINE_EDM_PLUGIN(BlockElementLinkerFactory,
 double HFEMAndHFHADLinker::testLink
   ( const reco::PFBlockElement* elem1,
     const reco::PFBlockElement* elem2) const {  
-  const reco::PFBlockElementCluster *hfemelem(NULL), *hfhadelem(NULL);
+  const reco::PFBlockElementCluster *hfemelem(nullptr), *hfhadelem(nullptr);
   if( elem1->type() < elem2->type() ) {
     hfemelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
     hfhadelem = static_cast<const reco::PFBlockElementCluster*>(elem2);

--- a/RecoParticleFlow/PFProducer/plugins/linkers/HGCalandBREMLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/HGCalandBREMLinker.cc
@@ -28,8 +28,8 @@ double HGCalAndBREMLinker::testLink
     const reco::PFBlockElement* elem2) const { 
   constexpr reco::PFTrajectoryPoint::LayerType ECALShowerMax =
     reco::PFTrajectoryPoint::ECALShowerMax;
-  const reco::PFBlockElementCluster *ecalelem(NULL);
-  const reco::PFBlockElementBrem    *bremelem(NULL);
+  const reco::PFBlockElementCluster *ecalelem(nullptr);
+  const reco::PFBlockElementBrem    *bremelem(nullptr);
   double dist(-1.0);
   if( elem1->type() > elem2->type() ) {
     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);

--- a/RecoParticleFlow/PFProducer/plugins/linkers/PreshowerAndECALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/PreshowerAndECALLinker.cc
@@ -32,11 +32,11 @@ linkPrefilter( const reco::PFBlockElement* elem1,
   case reco::PFBlockElement::PS1:
   case reco::PFBlockElement::PS2:
     result = ( elem1->isMultilinksValide() && 
-	       elem1->getMultilinks().size() > 0 );    
+	       !elem1->getMultilinks().empty() );    
     break;
   case reco::PFBlockElement::ECAL:
     result = ( elem2->isMultilinksValide() && 
-	       elem2->getMultilinks().size() > 0 );
+	       !elem2->getMultilinks().empty() );
     break;
   default:
     break;
@@ -47,7 +47,7 @@ linkPrefilter( const reco::PFBlockElement* elem1,
 double PreshowerAndECALLinker::
 testLink( const reco::PFBlockElement* elem1,
 	  const reco::PFBlockElement* elem2) const {  
-  const reco::PFBlockElementCluster *pselem(NULL), *ecalelem(NULL);
+  const reco::PFBlockElementCluster *pselem(nullptr), *ecalelem(nullptr);
   double dist(-1.0);
   if( elem1->type() < elem2->type() ) {
     pselem = static_cast<const reco::PFBlockElementCluster*>(elem1);

--- a/RecoParticleFlow/PFProducer/plugins/linkers/SCAndECALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/SCAndECALLinker.cc
@@ -29,8 +29,8 @@ double SCAndECALLinker::testLink
   ( const reco::PFBlockElement* elem1,
     const reco::PFBlockElement* elem2) const { 
   double dist = -1.0;  
-  const reco::PFBlockElementCluster* ecalelem(NULL);    
-  const reco::PFBlockElementSuperCluster* scelem(NULL); 
+  const reco::PFBlockElementCluster* ecalelem(nullptr);    
+  const reco::PFBlockElementSuperCluster* scelem(nullptr); 
   if( elem1->type() < elem2->type() ) {
     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
     scelem = static_cast<const reco::PFBlockElementSuperCluster*>(elem2);

--- a/RecoParticleFlow/PFProducer/plugins/linkers/SCAndHGCalLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/SCAndHGCalLinker.cc
@@ -29,8 +29,8 @@ double SCAndHGCalLinker::testLink
   ( const reco::PFBlockElement* elem1,
     const reco::PFBlockElement* elem2) const { 
   double dist = -1.0;  
-  const reco::PFBlockElementCluster* ecalelem(NULL);    
-  const reco::PFBlockElementSuperCluster* scelem(NULL); 
+  const reco::PFBlockElementCluster* ecalelem(nullptr);    
+  const reco::PFBlockElementSuperCluster* scelem(nullptr); 
   if( elem1->type() > elem2->type() ) {
     ecalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
     scelem = static_cast<const reco::PFBlockElementSuperCluster*>(elem2);

--- a/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndECALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndECALLinker.cc
@@ -31,10 +31,10 @@ linkPrefilter( const reco::PFBlockElement* elem1,
   bool result = false;
   switch( elem1->type() ){ 
   case reco::PFBlockElement::TRACK:
-    result = (elem1->isMultilinksValide() && elem1->getMultilinks().size() > 0);
+    result = (elem1->isMultilinksValide() && !elem1->getMultilinks().empty());
     break;
   case reco::PFBlockElement::ECAL:
-    result = (elem2->isMultilinksValide() && elem2->getMultilinks().size() > 0);
+    result = (elem2->isMultilinksValide() && !elem2->getMultilinks().empty());
   default:
     break;
   } 
@@ -46,8 +46,8 @@ testLink( const reco::PFBlockElement* elem1,
 	  const reco::PFBlockElement* elem2 ) const {  
   constexpr reco::PFTrajectoryPoint::LayerType ECALShowerMax =
     reco::PFTrajectoryPoint::ECALShowerMax;
-  const reco::PFBlockElementCluster *ecalelem(NULL);
-  const reco::PFBlockElementTrack   *tkelem(NULL);
+  const reco::PFBlockElementCluster *ecalelem(nullptr);
+  const reco::PFBlockElementTrack   *tkelem(nullptr);
   double dist(-1.0);
   if( elem1->type() < elem2->type() ) {
     tkelem = static_cast<const reco::PFBlockElementTrack*>(elem1);

--- a/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndGSFLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndGSFLinker.cc
@@ -30,8 +30,8 @@ double TrackAndGSFLinker::testLink
   constexpr reco::PFBlockElement::TrackType T_FROM_GAMMACONV =
     reco::PFBlockElement::T_FROM_GAMMACONV;
   double dist = -1.0;
-  const reco::PFBlockElementGsfTrack * gsfelem(NULL);
-  const reco::PFBlockElementTrack * tkelem(NULL);
+  const reco::PFBlockElementGsfTrack * gsfelem(nullptr);
+  const reco::PFBlockElementTrack * tkelem(nullptr);
   if( elem1->type() < elem2->type() ) {
     tkelem = static_cast<const reco::PFBlockElementTrack *>(elem1);
     gsfelem = static_cast<const reco::PFBlockElementGsfTrack *>(elem2);

--- a/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndHCALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndHCALLinker.cc
@@ -32,8 +32,8 @@ double TrackAndHCALLinker::testLink
     reco::PFTrajectoryPoint::HCALEntrance;
   constexpr reco::PFTrajectoryPoint::LayerType HCALExit =
     reco::PFTrajectoryPoint::HCALExit;
-  const reco::PFBlockElementCluster *hcalelem(NULL);
-  const reco::PFBlockElementTrack   *tkelem(NULL);
+  const reco::PFBlockElementCluster *hcalelem(nullptr);
+  const reco::PFBlockElementTrack   *tkelem(nullptr);
   double dist(-1.0);
   if( elem1->type() < elem2->type() ) {
     tkelem = static_cast<const reco::PFBlockElementTrack*>(elem1);

--- a/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndHOLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndHOLinker.cc
@@ -28,8 +28,8 @@ double TrackAndHOLinker::testLink
     const reco::PFBlockElement* elem2) const {  
   constexpr reco::PFTrajectoryPoint::LayerType HOLayer =
     reco::PFTrajectoryPoint::HOLayer;
-  const reco::PFBlockElementTrack   *tkelem(NULL);
-  const reco::PFBlockElementCluster *hoelem(NULL);
+  const reco::PFBlockElementTrack   *tkelem(nullptr);
+  const reco::PFBlockElementCluster *hoelem(nullptr);
   double dist(-1.0);
   if( elem1->type() < elem2->type() ) {
     tkelem = static_cast<const reco::PFBlockElementTrack*>(elem1);

--- a/RecoParticleFlow/PFProducer/src/KDTreeLinkerAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/KDTreeLinkerAlgo.cc
@@ -1,8 +1,8 @@
 #include "RecoParticleFlow/PFProducer/interface/KDTreeLinkerAlgo.h"
 
 KDTreeLinkerAlgo::KDTreeLinkerAlgo()
-  : root_ (0),
-    nodePool_(0),
+  : root_ (nullptr),
+    nodePool_(nullptr),
     nodePoolSize_(-1),
     nodePoolPos_(-1)
 {
@@ -17,7 +17,7 @@ void
 KDTreeLinkerAlgo::build(std::vector<KDTreeNodeInfo>	&eltList, 
 			const KDTreeBox			&region)
 {
-  if (eltList.size()) {
+  if (!eltList.empty()) {
     nodePoolSize_ = eltList.size() * 2 - 1;
     nodePool_ = new KDTreeNode[nodePoolSize_];
 
@@ -156,13 +156,13 @@ KDTreeLinkerAlgo::recSearch(const KDTreeNode		*current,
 			    std::vector<KDTreeNodeInfo>	&recHits)
 {
   // By construction, current can't be null
-  assert(current != 0);
+  assert(current != nullptr);
 
   // By Construction, a node can't have just 1 son.
-  assert (!(((current->left == 0) && (current->right != 0)) ||
-	    ((current->left != 0) && (current->right == 0))));
+  assert (!(((current->left == nullptr) && (current->right != nullptr)) ||
+	    ((current->left != nullptr) && (current->right == nullptr))));
     
-  if ((current->left == 0) && (current->right == 0)) {//leaf case
+  if ((current->left == nullptr) && (current->right == nullptr)) {//leaf case
   
     // If point inside the rectangle/area
     if ((current->rh.dim1 >= trackBox.dim1min) && (current->rh.dim1 <= trackBox.dim1max) &&
@@ -210,9 +210,9 @@ KDTreeLinkerAlgo::addSubtree(const KDTreeNode		*current,
 		   std::vector<KDTreeNodeInfo>	&recHits)
 {
   // By construction, current can't be null
-  assert(current != 0);
+  assert(current != nullptr);
 
-  if ((current->left == 0) && (current->right == 0)) // leaf
+  if ((current->left == nullptr) && (current->right == nullptr)) // leaf
     recHits.push_back(current->rh);
   else { // node
     addSubtree(current->left, recHits);
@@ -225,8 +225,8 @@ void
 KDTreeLinkerAlgo::clearTree()
 {
   delete[] nodePool_;
-  nodePool_ = 0;
-  root_ = 0;
+  nodePool_ = nullptr;
+  root_ = nullptr;
   nodePoolSize_ = -1;
   nodePoolPos_ = -1;
 }

--- a/RecoParticleFlow/PFProducer/src/PFAlgoTestBenchElectrons.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgoTestBenchElectrons.cc
@@ -18,7 +18,7 @@ void PFAlgoTestBenchElectrons::processBlock(const reco::PFBlockRef& blockref,
  
 
   const reco::PFBlock& block = *blockref;
-  PFBlock::LinkData linkData =  block.linkData();
+  const PFBlock::LinkData& linkData =  block.linkData();
   const edm::OwnVector< reco::PFBlockElement >&  elements = block.elements();
 
   std::vector<bool> active(elements.size(), true );

--- a/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
@@ -349,8 +349,8 @@ void PFBlockAlgo::buildElements(const edm::Event& evt) {
   }
 
   // list is now partitioned, so mark the boundaries so we can efficiently skip chunks  
-  unsigned current_type = ( elements_.size() ? elements_[0]->type() : 0 );
-  unsigned last_type = ( elements_.size() ? elements_.back()->type() : 0 );
+  unsigned current_type = ( !elements_.empty() ? elements_[0]->type() : 0 );
+  unsigned last_type = ( !elements_.empty() ? elements_.back()->type() : 0 );
   ranges_[current_type].first  = 0;
   ranges_[last_type].second = elements_.size()-1;
   for( size_t i = 0; i < elements_.size(); ++i ) {

--- a/RecoParticleFlow/PFProducer/src/PFCandConnector.cc
+++ b/RecoParticleFlow/PFProducer/src/PFCandConnector.cc
@@ -163,7 +163,7 @@ PFCandConnector::analyseNuclearWPrim(std::unique_ptr<PFCandidateCollection>& pfC
 
   // ------- look for the little friends -------- //
 
-  math::XYZTLorentzVectorD momentumPrim = primaryCand.p4();
+  const math::XYZTLorentzVectorD& momentumPrim = primaryCand.p4();
 
   math::XYZTLorentzVectorD momentumSec;
 

--- a/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
@@ -182,13 +182,13 @@ bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron & electron
   for (PFCandidate::ElementsInBlocks::const_iterator itrk = extraTracks.begin(); 
        itrk<extraTracks.end(); ++itrk) {
     const PFBlock& block = *(itrk->first);
-    PFBlock::LinkData linkData =  block.linkData();
+    const PFBlock::LinkData& linkData =  block.linkData();
     const PFBlockElement& pfele = block.elements()[itrk->second];
 
     if(debugSafeForJetMET) 
       cout << " My track element number " <<  itrk->second << endl;
     if(pfele.type()==reco::PFBlockElement::TRACK) {
-      reco::TrackRef trackref = pfele.trackRef();
+      const reco::TrackRef& trackref = pfele.trackRef();
 
       bool goodTrack = PFTrackAlgoTools::isGoodForEGM(trackref->algo());
       // iter0, iter1, iter2, iter3 = Algo < 3
@@ -215,7 +215,7 @@ bool PFEGammaFilters::isElectronSafeForJetMET(const reco::GsfElectron & electron
 				  hcalKfElems,
 				  reco::PFBlockElement::HCAL,
 				  reco::PFBlock::LINKTEST_ALL );
-	if(hcalKfElems.size() > 0) {
+	if(!hcalKfElems.empty()) {
 	  itrackHcalLinked++;
 	}
 	if(debugSafeForJetMET) 
@@ -321,7 +321,7 @@ bool PFEGammaFilters::isPhotonSafeForJetMET(const reco::Photon & photon, const r
     if(pfele.type()==reco::PFBlockElement::TRACK) {
 
      
-      reco::TrackRef trackref = pfele.trackRef();
+      const reco::TrackRef& trackref = pfele.trackRef();
       
       if(debugSafeForJetMET)
 	cout << "PFEGammaFilters::isPhotonSafeForJetMET photon track:pt " << trackref->pt() << " SingleLegSize " << pfcandextra->singleLegConvTrackRefMva().size() << endl;

--- a/RecoParticleFlow/PFProducer/src/PFElectronAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFElectronAlgo.cc
@@ -121,7 +121,7 @@ void PFElectronAlgo::RunPFElectron(const reco::PFBlockRef&  blockRef,
     // This function finds also the best estimation of the initial electron 4-momentum.
 
     SetCandidates(blockRef,associatedToGsf,associatedToBrems,associatedToEcal);
-    if (elCandidate_.size() > 0 ){
+    if (!elCandidate_.empty() ){
       isvalid_ = true;
       // when a pfelectron candidate is created all the elements associated to the
       // electron are locked. 
@@ -144,7 +144,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 
   const reco::PFBlock& block = *blockRef;
   const edm::OwnVector< reco::PFBlockElement >&  elements = block.elements();
-  PFBlock::LinkData linkData =  block.linkData();  
+  const PFBlock::LinkData& linkData =  block.linkData();  
   
   bool IsThereAGSFTrack = false;
   bool IsThereAGoodGSFTrack = false;
@@ -179,7 +179,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 				kfElems,
 				reco::PFBlockElement::TRACK,
 				reco::PFBlock::LINKTEST_ALL );
-      thisIsAMuon = kfElems.size() ? 
+      thisIsAMuon = !kfElems.empty() ? 
       PFMuonAlgo::isMuon(elements[kfElems.begin()->second]) : false;
       // Otherwise store index
       if ( !thisIsAMuon && active[iEle] ) { 
@@ -227,7 +227,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 				gsfElems ,
 				reco::PFBlockElement::GSF,
 				reco::PFBlock::LINKTEST_ALL );
-      if(gsfElems.size() == 0){
+      if(gsfElems.empty()){
 	// This means that the considered kf is *not* associated
 	// to any gsf track
 	std::multimap<double, unsigned int> ecalKfElems;
@@ -235,7 +235,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 				  ecalKfElems,
 				  reco::PFBlockElement::ECAL,
 				  reco::PFBlock::LINKTEST_ALL );
-	if(ecalKfElems.size() > 0) { 
+	if(!ecalKfElems.empty()) { 
 	  unsigned int ecalKf_index = ecalKfElems.begin()->second;
 	  if(localactive[ecalKf_index]==true) {
 	    // Check if this clusters is however well linked to a primary gsf track
@@ -255,7 +255,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 					ecalGsfElems,
 					reco::PFBlockElement::ECAL,
 					reco::PFBlock::LINKTEST_ALL );
-	      if(ecalGsfElems.size() > 0) {
+	      if(!ecalGsfElems.empty()) {
 		if (ecalGsfElems.begin()->second == ecalKf_index) {
 		  isGsfLinked = true;
 		}
@@ -266,7 +266,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 	      // of the tracking fifth step
 	      const reco::PFBlockElementTrack * kfEle =  
 		dynamic_cast<const reco::PFBlockElementTrack*>((&elements[(trackIs[iEle])])); 	
-	      reco::TrackRef refKf = kfEle->trackRef();
+	      const reco::TrackRef& refKf = kfEle->trackRef();
 	      
 	      int nexhits = refKf->hitPattern().numberOfLostHits(HitPattern::MISSING_INNER_HITS);
 	      
@@ -330,7 +330,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 				reco::PFBlockElement::TRACK,
 				reco::PFBlock::LINKTEST_ALL );
       std::multimap<double, unsigned int> ecalKfElems;
-      if (kfElems.size() > 0) {
+      if (!kfElems.empty()) {
 	// 19 Mar 2010 now a loop is needed because > 1 KF track could
 	// be associated to the same GSF track
 
@@ -367,7 +367,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 				reco::PFBlock::LINKTEST_ALL );    
       double ecalGsf_dist = CutGSFECAL;
       unsigned int ClosestEcalGsf_index = CutIndex;
-      if (ecalGsfElems.size() > 0) {	
+      if (!ecalGsfElems.empty()) {	
 	if(localactive[(ecalGsfElems.begin()->second)] == true) {
 	  // check energy compatibility for outer eta != ecal entrance, looping tracks
 	  bool compatibleEPout = true;
@@ -390,7 +390,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 				      reco::PFBlockElement::GSF,
 				      reco::PFBlock::LINKTEST_ALL);
 	    
-	    if(ecalOtherGsfElems.size()>0) {
+	    if(!ecalOtherGsfElems.empty()) {
 	      // get if it is closed to a conv brem gsf tracks
 	      const reco::PFBlockElementGsfTrack * gsfCheck  =  
 		dynamic_cast<const reco::PFBlockElementGsfTrack*>((&elements[ecalOtherGsfElems.begin()->second]));
@@ -406,7 +406,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 	}
       }
       // if any cluster is found with the gsf-ecal link, try with kf-ecal
-      else if(ecalKfElems.size() > 0) {
+      else if(!ecalKfElems.empty()) {
 	if(localactive[(ecalKfElems.begin()->second)] == true) {
 	  ClosestEcalGsf_index = ecalKfElems.begin()->second;	  
 	  ecalGsf_dist = block.dist(gsfIs[iEle],ClosestEcalGsf_index,
@@ -419,7 +419,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 				    ecalOtherGsfElems,
 				    reco::PFBlockElement::GSF,
 				    reco::PFBlock::LINKTEST_ALL);
-	  if(ecalOtherGsfElems.size() > 0) {
+	  if(!ecalOtherGsfElems.empty()) {
 	    const reco::PFBlockElementGsfTrack * gsfCheck  =  
 	      dynamic_cast<const reco::PFBlockElementGsfTrack*>((&elements[ecalOtherGsfElems.begin()->second]));
 
@@ -522,7 +522,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 				      ecalOtherGsfElems,
 				      reco::PFBlockElement::GSF,
 				      reco::PFBlock::LINKTEST_ALL);
-	    if (ecalOtherGsfElems.size() > 0) {
+	    if (!ecalOtherGsfElems.empty()) {
 	      const reco::PFBlockElementGsfTrack * gsfCheck  =  
 		dynamic_cast<const reco::PFBlockElementGsfTrack*>((&elements[ecalOtherGsfElems.begin()->second]));
 	      if(ecalOtherGsfElems.begin()->second != gsfIs[iEle] &&
@@ -589,7 +589,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 				      ecalOtherGsfElems,
 				      reco::PFBlockElement::GSF,
 				      reco::PFBlock::LINKTEST_ALL);
-	    if(ecalOtherGsfElems.size()) {
+	    if(!ecalOtherGsfElems.empty()) {
 	      if(ecalOtherGsfElems.begin()->second != gsfIs[iEle]) continue;
 	    } 
 	    
@@ -637,7 +637,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 
       // if any clusters have been associated to the gsf track	  
       // use the Ecal clusters associated to the latest brem and associate it to the gsf
-       if(GsfElemIndex.size() == 0){
+       if(GsfElemIndex.empty()){
 	if(latestBrem_index < CutIndex) {
 	  unsigned int ckey = cleanedEcalBremElems.count(latestBrem_index);
 	  if(ckey == 1) {
@@ -697,7 +697,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 					ecalConvElems,
 					reco::PFBlockElement::ECAL,
 					reco::PFBlock::LINKTEST_ALL );    
-	      if(ecalConvElems.size() > 0) {
+	      if(!ecalConvElems.empty()) {
 		// the ecal cluster is still active?
 		if(localactive[(ecalConvElems.begin()->second)] == true) {
 		  if (DebugSetLinksDetailed)
@@ -708,7 +708,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 					    ecalOtherGsfPrimElems,
 					    reco::PFBlockElement::GSF,
 					    reco::PFBlock::LINKTEST_ALL);
-		  if(ecalOtherGsfPrimElems.size()>0) {
+		  if(!ecalOtherGsfPrimElems.empty()) {
 		    unsigned int gsfprimcheck_index = ecalOtherGsfPrimElems.begin()->second;
 		    const reco::PFBlockElementGsfTrack * gsfCheck  =  
 		      dynamic_cast<const reco::PFBlockElementGsfTrack*>((&elements[gsfprimcheck_index]));
@@ -764,7 +764,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
       // 19 Mar 2010: add KF and ECAL elements from converted brem photons
       vector<unsigned int> convBremKFTrack;
       convBremKFTrack.clear();
-      if (kfElems.size() > 0) {
+      if (!kfElems.empty()) {
 	for(std::multimap<double, unsigned int>::iterator itkf = kfElems.begin();
 	    itkf != kfElems.end(); ++itkf) {
 	  const reco::PFBlockElementTrack * TrkEl  =  
@@ -779,9 +779,9 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 				      ecalConvElems,
 				      reco::PFBlockElement::ECAL,
 				      reco::PFBlock::LINKTEST_ALL );
-	    if(ecalConvElems.size() > 0) {
+	    if(!ecalConvElems.empty()) {
 	      // Further Cleaning: DANIELE This could be improved!
-	      TrackRef trkRef =   TrkEl->trackRef();
+	      const TrackRef& trkRef =   TrkEl->trackRef();
 	      // iter0, iter1, iter2, iter3 = Algo < 3
 	      bool isGoodTrack = PFTrackAlgoTools::isGoodForEGM(trkRef->algo());
 	      float secpin = trkRef->p();	
@@ -805,7 +805,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 	      bool isPoHE = false;
 
 	      float enehcalclust = -1;
-	      if(hcalConvElems.size() > 0) {
+	      if(!hcalConvElems.empty()) {
 		const reco::PFBlockElementCluster * clusthcal =  
 		  dynamic_cast<const reco::PFBlockElementCluster*>((&elements[(hcalConvElems.begin()->second)])); 
 		enehcalclust  =clusthcal->clusterRef()->energy();
@@ -869,7 +869,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 					  ecalOtherKFPrimElems,
 					  reco::PFBlockElement::TRACK,
 					  reco::PFBlock::LINKTEST_ALL);
-		if(ecalOtherKFPrimElems.size() > 0) {
+		if(!ecalOtherKFPrimElems.empty()) {
 		  
 		  // check that this ECAL clusters is the best associated to at least one of the  KF tracks
 		  // linked to the considered GSF track
@@ -943,7 +943,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
       }
  
       // 4May import EG supercluster
-      if(EcalIndex.size() > 0 && useEGammaSupercluster_) {
+      if(!EcalIndex.empty() && useEGammaSupercluster_) {
 	double sumEtEcalInTheCone  = 0.;
 	
 	// Position of the first cluster
@@ -998,7 +998,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 	  if(localactive[(trackIs[iTrack])]==true) {
 	    const reco::PFBlockElementTrack * kfEle =  
 	      dynamic_cast<const reco::PFBlockElementTrack*>((&elements[(trackIs[iTrack])])); 	
-	    reco::TrackRef trkref = kfEle->trackRef();
+	    const reco::TrackRef& trkref = kfEle->trackRef();
 	    if (trkref.isNonnull()) {
 	      double deta_trk =  trkref->eta() - RefGSF->etaMode();
 	      double dphi_trk =  trkref->phi() - RefGSF->phiMode();
@@ -1095,7 +1095,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 				      ecalFromSuperClusterElems,
 				      reco::PFBlockElement::ECAL,
 				      reco::PFBlock::LINKTEST_ALL);
-	    if(ecalFromSuperClusterElems.size() > 0) {
+	    if(!ecalFromSuperClusterElems.empty()) {
 	      for(std::multimap<double, unsigned int>::iterator itsc = ecalFromSuperClusterElems.begin();
 		  itsc != ecalFromSuperClusterElems.end(); ++itsc) {
 		if(localactive[itsc->second] == false) {
@@ -1107,7 +1107,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 					  ecalOtherKFPrimElems,
 					  reco::PFBlockElement::TRACK,
 					  reco::PFBlock::LINKTEST_ALL);
-		if(ecalOtherKFPrimElems.size() > 0) {
+		if(!ecalOtherKFPrimElems.empty()) {
 		  if(localactive[ecalOtherKFPrimElems.begin()->second] == true) {
 		    if (DebugSetLinksDetailed)
 		      cout << "**** PFElectronAlgo:: SUPERCLUSTER FOUND BUT FAILS KF VETO *** " << endl;
@@ -1267,7 +1267,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 	      // }
 	  }
 	  // if the closest ecal cluster has been link with the KF, check KF - HCAL link
-	  if(hcalGsfElems.size() == 0 && ClosestEcalWithKf == true) {
+	  if(hcalGsfElems.empty() && ClosestEcalWithKf == true) {
 	    std::multimap<double, unsigned int> hcalKfElems;
 	    block.associatedElements( KfGsf_index,linkData,
 				      hcalKfElems,
@@ -1297,7 +1297,7 @@ bool PFElectronAlgo::SetLinks(const reco::PFBlockRef&  blockRef,
 				    kfEtraElems,
 				    reco::PFBlockElement::TRACK,
 				    reco::PFBlock::LINKTEST_ALL );
-	  if(kfEtraElems.size() > 0) {
+	  if(!kfEtraElems.empty()) {
 	    for( std::multimap<double, unsigned int>::iterator it = kfEtraElems.begin();
 		 it != kfEtraElems.end();it++) {
 	      unsigned int index = it->second;
@@ -1426,7 +1426,7 @@ void PFElectronAlgo::SetIDOutputs(const reco::PFBlockRef&  blockRef,
 					const reco::Vertex & primaryVertex){
   //PFEnergyCalibration pfcalib_;  
   const reco::PFBlock& block = *blockRef;
-  PFBlock::LinkData linkData =  block.linkData();     
+  const PFBlock::LinkData& linkData =  block.linkData();     
   const edm::OwnVector< reco::PFBlockElement >&  elements = block.elements();
   bool DebugIDOutputs = false;
   if(DebugIDOutputs) cout << " ######## Enter in SetIDOutputs #########" << endl;
@@ -1753,7 +1753,7 @@ void PFElectronAlgo::SetIDOutputs(const reco::PFBlockRef&  blockRef,
 		//if(kfTk->trackType(reco::PFBlockElement::T_FROM_GAMMACONV)) continue;
 		
 		
-		reco::TrackRef trackref =  kfTk->trackRef();
+		const reco::TrackRef& trackref =  kfTk->trackRef();
 		bool goodTrack = PFTrackAlgoTools::isGoodForEGM(trackref->algo());
 		// iter0, iter1, iter2, iter3 = Algo < 3
 		// algo 4,5,6,7
@@ -1789,7 +1789,7 @@ void PFElectronAlgo::SetIDOutputs(const reco::PFBlockRef&  blockRef,
 					    hcalKfElems,
 					    reco::PFBlockElement::HCAL,
 					    reco::PFBlock::LINKTEST_ALL );
-		  if(hcalKfElems.size() > 0) {
+		  if(!hcalKfElems.empty()) {
 		    itrackHcalLinked++;
 		  }
 		}
@@ -1912,7 +1912,7 @@ void PFElectronAlgo::SetCandidates(const reco::PFBlockRef&  blockRef,
 					 AssMap& associatedToEcal_){
   
   const reco::PFBlock& block = *blockRef;
-  PFBlock::LinkData linkData =  block.linkData();     
+  const PFBlock::LinkData& linkData =  block.linkData();     
   const edm::OwnVector< reco::PFBlockElement >&  elements = block.elements();
   PFEnergyResolution pfresol_;
   //PFEnergyCalibration pfcalib_;
@@ -2301,7 +2301,7 @@ void PFElectronAlgo::SetCandidates(const reco::PFBlockRef&  blockRef,
 				  reco::PFBlock::LINKTEST_ALL );
 
 	double phiTrack = RefGSF->phiMode();
-	if(bremElems.size()>0) {
+	if(!bremElems.empty()) {
 	  unsigned int brem_index =  bremElems.begin()->second;
 	  const reco::PFBlockElementBrem * BremEl  =  
 	    dynamic_cast<const reco::PFBlockElementBrem*>((&elements[brem_index]));
@@ -2548,7 +2548,7 @@ void PFElectronAlgo::SetActive(const reco::PFBlockRef&  blockRef,
 				     AssMap& associatedToEcal_,
 				     std::vector<bool>& active){
   const reco::PFBlock& block = *blockRef;
-  PFBlock::LinkData linkData =  block.linkData();  
+  const PFBlock::LinkData& linkData =  block.linkData();  
    
   const edm::OwnVector< reco::PFBlockElement >&  elements = block.elements();
   
@@ -2559,7 +2559,7 @@ void PFElectronAlgo::SetActive(const reco::PFBlockRef&  blockRef,
     unsigned int gsf_index =  igsf->first;
     const reco::PFBlockElementGsfTrack * GsfEl  =  
       dynamic_cast<const reco::PFBlockElementGsfTrack*>((&elements[gsf_index]));
-    reco::GsfTrackRef RefGSF = GsfEl->GsftrackRef();
+    const reco::GsfTrackRef& RefGSF = GsfEl->GsftrackRef();
 
     // lock only the elements that pass the BDT cut
     bool bypassmva=false;
@@ -2585,7 +2585,7 @@ void PFElectronAlgo::SetActive(const reco::PFBlockRef&  blockRef,
 	unsigned int keyecalgsf = assogsf_index[ielegsf];
 
 	// added protection against fifth step
-	if(fifthStepKfTrack_.size() > 0) {
+	if(!fifthStepKfTrack_.empty()) {
 	  for(unsigned int itr = 0; itr < fifthStepKfTrack_.size(); itr++) {
 	    if(fifthStepKfTrack_[itr].first == keyecalgsf) {
 	      active[(fifthStepKfTrack_[itr].second)] = false;
@@ -2594,7 +2594,7 @@ void PFElectronAlgo::SetActive(const reco::PFBlockRef&  blockRef,
 	}
 
 	// added locking for conv gsf tracks and kf tracks
-	if(convGsfTrack_.size() > 0) {
+	if(!convGsfTrack_.empty()) {
 	  for(unsigned int iconv = 0; iconv < convGsfTrack_.size(); iconv++) {
 	    if(convGsfTrack_[iconv].first == keyecalgsf) {
 	      // lock the GSF track
@@ -2606,7 +2606,7 @@ void PFElectronAlgo::SetActive(const reco::PFBlockRef&  blockRef,
 					convKf,
 					reco::PFBlockElement::TRACK,
 					reco::PFBlock::LINKTEST_ALL );
-	      if(convKf.size() > 0) {
+	      if(!convKf.empty()) {
 		active[convKf.begin()->second] = false;
 	      }
 	    }
@@ -2638,7 +2638,7 @@ void PFElectronAlgo::SetActive(const reco::PFBlockRef&  blockRef,
 	    active[(assobrem_index[ibrem])] = false;
 
 	    // add protection against fifth step
-	    if(fifthStepKfTrack_.size() > 0) {
+	    if(!fifthStepKfTrack_.empty()) {
 	      for(unsigned int itr = 0; itr < fifthStepKfTrack_.size(); itr++) {
 		if(fifthStepKfTrack_[itr].first == keyecalbrem) {
 		  active[(fifthStepKfTrack_[itr].second)] = false;
@@ -2669,10 +2669,10 @@ bool PFElectronAlgo::isPrimaryTrack(const reco::PFBlockElementTrack& KfEl,
 				    const reco::PFBlockElementGsfTrack& GsfEl) {
   bool isPrimary = false;
   
-  GsfPFRecTrackRef gsfPfRef = GsfEl.GsftrackRefPF();
+  const GsfPFRecTrackRef& gsfPfRef = GsfEl.GsftrackRefPF();
   
   if(gsfPfRef.isNonnull()) {
-    PFRecTrackRef  kfPfRef = KfEl.trackRefPF();
+    const PFRecTrackRef&  kfPfRef = KfEl.trackRefPF();
     PFRecTrackRef  kfPfRef_fromGsf = (*gsfPfRef).kfPFRecTrackRef();
     if(kfPfRef.isNonnull() && kfPfRef_fromGsf.isNonnull()) {
       reco::TrackRef kfref= (*kfPfRef).trackRef();

--- a/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
@@ -501,9 +501,9 @@ PFMuonAlgo::isTightMuonPOG(const reco::MuonRef& muonRef) {
 bool 
 PFMuonAlgo::hasValidTrack(const reco::MuonRef& muonRef,bool loose) {
   if(loose)
-    return muonTracks(muonRef).size()>0;
+    return !muonTracks(muonRef).empty();
   else
-    return goodMuonTracks(muonRef).size()>0;
+    return !goodMuonTracks(muonRef).empty();
 
 }
 
@@ -749,7 +749,7 @@ bool PFMuonAlgo::reconstructMuon(reco::PFCandidate& candidate, const reco::MuonR
     else
       validTracks = muonTracks(muon);
 
-    if( validTracks.size() ==0)
+    if( validTracks.empty())
       return false;
 
 
@@ -914,7 +914,7 @@ void PFMuonAlgo::postClean(reco::PFCandidateCollection*  cands) {
   for(unsigned int i=0;i<muons.size();++i) {
     const PFCandidate& pfc = cands->at(muons[i]);
     double origin=0.0;
-    if(vertices_->size()>0&& vertices_->at(0).isValid() && ! vertices_->at(0).isFake())
+    if(!vertices_->empty()&& vertices_->at(0).isValid() && ! vertices_->at(0).isFake())
       origin = pfc.muonRef()->muonBestTrack()->dxy(vertices_->at(0).position());
 
     if( origin> cosmicRejDistance_) {
@@ -999,16 +999,16 @@ void PFMuonAlgo::addMissingMuons(edm::Handle<reco::MuonCollection> muons, reco::
   
     std::vector<reco::Muon::MuonTrackTypePair> tracks  = goodMuonTracks(muonRef,true);
     //If there is at least 1 track choice  try to change the track 
-    if(tracks.size()>0) {
+    if(!tracks.empty()) {
 
     //Find tracks that change dramatically MET or Pt
     std::vector<reco::Muon::MuonTrackTypePair> tracksThatChangeMET = tracksPointingAtMET(tracks);
     //From those tracks get the one with smallest MET 
-    if (tracksThatChangeMET.size()>0) {
+    if (!tracksThatChangeMET.empty()) {
       reco::Muon::MuonTrackTypePair bestTrackType = *std::min_element(tracksThatChangeMET.begin(),tracksThatChangeMET.end(),comparator);
 
       //Make sure it is not cosmic
-      if((vertices_->size()==0) ||bestTrackType.first->dz(vertices_->at(0).position())<cosmicRejDistance_){
+      if((vertices_->empty()) ||bestTrackType.first->dz(vertices_->at(0).position())<cosmicRejDistance_){
 	
 	//make a pfcandidate
 	int charge = bestTrackType.first->charge()>0 ? 1 : -1;
@@ -1081,7 +1081,7 @@ bool PFMuonAlgo::cleanMismeasured(reco::PFCandidate& pfc,unsigned int i ){
     //Find tracks that change dramatically MET or Pt
     std::vector<reco::Muon::MuonTrackTypePair> tracksThatChangeMET = tracksWithBetterMET(tracks,pfc);
     //From those tracks get the one with smallest MET 
-    if (tracksThatChangeMET.size()>0) {
+    if (!tracksThatChangeMET.empty()) {
       reco::Muon::MuonTrackTypePair bestTrackType = *std::min_element(tracksThatChangeMET.begin(),tracksThatChangeMET.end(),comparator);
       changeTrack(pfc,bestTrackType);
 
@@ -1205,7 +1205,7 @@ bool PFMuonAlgo::cleanPunchThroughAndFakes(reco::PFCandidate&pfc,reco::PFCandida
   if(fake1 || fake2||punchthrough) {
     // Find the block of the muon
     const PFCandidate::ElementsInBlocks& eleInBlocks = pfc.elementsInBlocks();
-    if ( eleInBlocks.size() ) { 
+    if ( !eleInBlocks.empty() ) { 
       PFBlockRef blockRefMuon = eleInBlocks[0].first;
       unsigned indexMuon = eleInBlocks[0].second;
       if (eleInBlocks.size()>1)
@@ -1217,7 +1217,7 @@ bool PFMuonAlgo::cleanPunchThroughAndFakes(reco::PFCandidate&pfc,reco::PFCandida
       for ( unsigned i = imu+1; i < cands->size(); ++i ) { 
 	const PFCandidate& pfcn = cands->at(i);
 	    const PFCandidate::ElementsInBlocks& ele = pfcn.elementsInBlocks();
-	    if ( !ele.size() ) { 
+	    if ( ele.empty() ) { 
 	      continue;
 	    }
 	    PFBlockRef blockRefHadron = ele[0].first;

--- a/RecoParticleFlow/PFProducer/src/PFPhotonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFPhotonAlgo.cc
@@ -176,7 +176,7 @@ void PFPhotonAlgo::RunPFPhoton(const reco::PFBlockRef&  blockRef,
     PFPhoR9_=sc->photonRef()->r9();
     E3x3_=PFPhoR9_*(sc->superClusterRef()->rawEnergy());
     // loop over the ECAL clusters linked to the iEle 
-    if( ! ecalAssoPFClusters.size() ) {
+    if( ecalAssoPFClusters.empty() ) {
       // This SC element has NO ECAL elements asigned... *SHOULD NOT HAPPEN*
       //std::cout<<" Found SC element with no ECAL assigned "<<std::endl;
       continue;
@@ -648,7 +648,7 @@ void PFPhotonAlgo::RunPFPhoton(const reco::PFBlockRef&  blockRef,
 		    sc
 		    );   
     
-    if(AddFromElectron_.size()>0)
+    if(!AddFromElectron_.empty())
       {	
 	//collect elements from early Conversions that are reconstructed as Electrons
 	
@@ -775,7 +775,7 @@ void PFPhotonAlgo::RunPFPhoton(const reco::PFBlockRef&  blockRef,
 					   photonEnergy_* photonDirection.Z(),
 					   photonEnergy_           );
 
-    if(sum_track_pt>(sumPtTrackIsoForPhoton_ + sumPtTrackIsoSlopeForPhoton_ * photonMomentum.pt()) && AddFromElectron_.size()==0)
+    if(sum_track_pt>(sumPtTrackIsoForPhoton_ + sumPtTrackIsoSlopeForPhoton_ * photonMomentum.pt()) && AddFromElectron_.empty())
       {
 	elemsToLock.resize(0);
 	continue;
@@ -1323,7 +1323,7 @@ bool PFPhotonAlgo::EvaluateSingleLegMVA(const reco::PFBlockRef& blockref, const 
   const reco::PFBlock& block = *blockref;  
   const edm::OwnVector< reco::PFBlockElement >& elements = block.elements();  
   //use this to store linkdata in the associatedElements function below  
-  PFBlock::LinkData linkData =  block.linkData();  
+  const PFBlock::LinkData& linkData =  block.linkData();  
   //calculate MVA Variables  
   chi2=elements[track_index].trackRef()->chi2()/elements[track_index].trackRef()->ndof();
   nlost=elements[track_index].trackRef()->hitPattern().numberOfLostHits(HitPattern::MISSING_INNER_HITS);
@@ -1343,13 +1343,13 @@ bool PFPhotonAlgo::EvaluateSingleLegMVA(const reco::PFBlockRef& blockref, const 
 			    hcalAssoTrack,  
 			    reco::PFBlockElement::HCAL,  
 			    reco::PFBlock::LINKTEST_ALL );  
-  if(ecalAssoTrack.size() > 0) {  
+  if(!ecalAssoTrack.empty()) {  
     for(std::multimap<double, unsigned int>::iterator itecal = ecalAssoTrack.begin();  
 	itecal != ecalAssoTrack.end(); ++itecal) {  
       linked_e=linked_e+elements[itecal->second].clusterRef()->energy();  
     }  
   }  
-  if(hcalAssoTrack.size() > 0) {  
+  if(!hcalAssoTrack.empty()) {  
     for(std::multimap<double, unsigned int>::iterator ithcal = hcalAssoTrack.begin();  
 	ithcal != hcalAssoTrack.end(); ++ithcal) {  
       linked_h=linked_h+elements[ithcal->second].clusterRef()->energy();  
@@ -1397,7 +1397,7 @@ void PFPhotonAlgo::EarlyConversion(
 	      
 	      if(ElecscRef.isNonnull()){
 		//finally see if it matches:
-		reco::SuperClusterRef PhotscRef=sc->superClusterRef();
+		const reco::SuperClusterRef& PhotscRef=sc->superClusterRef();
 		if(PhotscRef==ElecscRef)
 		  {
 		    match_ind.push_back(count);

--- a/RecoParticleFlow/PFProducer/src/Utils.cc
+++ b/RecoParticleFlow/PFProducer/src/Utils.cc
@@ -1,6 +1,6 @@
 #include "RecoParticleFlow/PFProducer/interface/Utils.h"
 
-#include <stdio.h>
+#include <cstdio>
 #include <regex.h>
 
 
@@ -13,7 +13,7 @@ bool Utils::stringMatch(const char* str, const char* pattern) {
   if( regcomp(&re, pattern, REG_EXTENDED|REG_NOSUB) != 0 )
     return false;
   
-  status = regexec(&re, str, (size_t)0, NULL, 0);
+  status = regexec(&re, str, (size_t)0, nullptr, 0);
   regfree(&re);
   
   if (status != 0)
@@ -27,7 +27,7 @@ vector<string>  Utils::myGlob(const char* pattern) {
   glob_t globbuf;
 
   globbuf.gl_offs = 2;
-  glob(pattern, GLOB_TILDE|GLOB_BRACE|GLOB_MARK, NULL, &globbuf);
+  glob(pattern, GLOB_TILDE|GLOB_BRACE|GLOB_MARK, nullptr, &globbuf);
 
   vector<string> results;
   for(unsigned i=0; i<globbuf.gl_pathc; i++) {

--- a/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
@@ -50,8 +50,8 @@ using namespace reco;
 
 ConvBremSeedProducer::ConvBremSeedProducer(const ParameterSet& iConfig):
   conf_(iConfig),
-  fieldMap_(0),
-  layerMap_(56, static_cast<const DetLayer*>(0)),
+  fieldMap_(nullptr),
+  layerMap_(56, static_cast<const DetLayer*>(nullptr)),
   negLayerOffset_(27)
 {
   produces<ConvBremSeedCollection>();
@@ -187,13 +187,13 @@ ConvBremSeedProducer::produce(Event& iEvent, const EventSetup& iSetup)
        AnalyticalPropagator alongProp(&mf, anyDirection);
        InsideBoundsMeasurementEstimator est;
        const DetLayer* tkLayer = detLayer(*cyliter,PP.Z());
-       if (&(*tkLayer)==0) continue;
+       if (&(*tkLayer)==nullptr) continue;
        TrajectoryStateOnSurface trajState = makeTrajectoryState( tkLayer, PP, &mf);
 	    
        std::vector<DetWithState> compat 
 	 = tkLayer->compatibleDets( trajState, alongProp, est);
        vector <long int> temp;
-       if (compat.size()==0) continue;
+       if (compat.empty()) continue;
 
        for (std::vector<DetWithState>::const_iterator i=compat.begin(); i!=compat.end(); i++) {
 	      
@@ -479,7 +479,7 @@ ConvBremSeedProducer::initializeLayerMap()
 			    << " pos " << i->surface().position();
     if (!i->sensitive()) continue;
 
-    if (cyl != 0) {
+    if (cyl != nullptr) {
 
       LogDebug("FastTracker") << " cylinder radius " << cyl->radius();
       bool found = false;

--- a/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.h
+++ b/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.h
@@ -49,12 +49,12 @@ class ConvBremSeedProducer : public edm::EDProducer {
  
  public:
   explicit ConvBremSeedProducer(const edm::ParameterSet&);
-  ~ConvBremSeedProducer();
+  ~ConvBremSeedProducer() override;
   
  private:
-  virtual void beginRun(const edm::Run&,const edm::EventSetup&) override;
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endRun(const edm::Run&,const edm::EventSetup&) override;
+  void beginRun(const edm::Run&,const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endRun(const edm::Run&,const edm::EventSetup&) override;
   void initializeLayerMap();
   std::vector<const DetLayer*>                theLayerMap;
   TrajectoryStateOnSurface makeTrajectoryState( const DetLayer* layer, 

--- a/RecoParticleFlow/PFSimProducer/plugins/EcalBarrelClusterFastTimer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/EcalBarrelClusterFastTimer.cc
@@ -37,9 +37,9 @@
 class EcalBarrelClusterFastTimer : public edm::global::EDProducer<> {
 public:    
   EcalBarrelClusterFastTimer(const edm::ParameterSet&);
-  ~EcalBarrelClusterFastTimer() { }
+  ~EcalBarrelClusterFastTimer() override { }
   
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   
 private:
   // inputs

--- a/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.cc
@@ -535,7 +535,7 @@ void PFSimParticleProducer::getSimIDs( const TrackHandle& trackh,
       
       reco::PFRecTrackRef ref( trackh,i );
       const reco::PFRecTrack& PFT   = *ref;
-      const reco::TrackRef trackref = PFT.trackRef();
+      const reco::TrackRef& trackref = PFT.trackRef();
 
 //       double Pt  = trackref->pt(); 
 //       double DPt = trackref->ptError();

--- a/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.h
+++ b/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.h
@@ -46,9 +46,9 @@ class PFSimParticleProducer : public edm::stream::EDProducer<> {
 
   explicit PFSimParticleProducer(const edm::ParameterSet&);
 
-  ~PFSimParticleProducer();
+  ~PFSimParticleProducer() override;
   
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
   typedef edm::Handle<reco::PFRecTrackCollection> TrackHandle;
   void getSimIDs( const TrackHandle& trackh,

--- a/RecoParticleFlow/PFSimProducer/plugins/TauHadronDecayFilter.h
+++ b/RecoParticleFlow/PFSimProducer/plugins/TauHadronDecayFilter.h
@@ -31,11 +31,11 @@ class FSimEvent;
 class TauHadronDecayFilter : public edm::EDFilter {
  public:
   explicit TauHadronDecayFilter(const edm::ParameterSet&);
-  ~TauHadronDecayFilter();
+  ~TauHadronDecayFilter() override;
 
  private:
-  virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
-  virtual bool filter(edm::Event&, const edm::EventSetup&) override;
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
   
   // ----------member data ---------------------------
   edm::ParameterSet  particleFilter_;

--- a/RecoParticleFlow/PFTracking/interface/ElectronSeedMerger.h
+++ b/RecoParticleFlow/PFTracking/interface/ElectronSeedMerger.h
@@ -14,10 +14,10 @@
 class ElectronSeedMerger : public edm::stream::EDProducer<> {
    public:
       explicit ElectronSeedMerger(const edm::ParameterSet&);
-      ~ElectronSeedMerger();
+      ~ElectronSeedMerger() override;
   
    private:
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
  
 
       edm::ParameterSet conf_;

--- a/RecoParticleFlow/PFTracking/interface/LightPFTrackProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/LightPFTrackProducer.h
@@ -17,14 +17,14 @@ public:
   explicit LightPFTrackProducer(const edm::ParameterSet&);
   
   ///Destructor
-  ~LightPFTrackProducer();
+  ~LightPFTrackProducer() override;
   
 private:
-  virtual void beginRun(const edm::Run&,const edm::EventSetup&) override ;
-  virtual void endRun(const edm::Run&,const edm::EventSetup&) override;
+  void beginRun(const edm::Run&,const edm::EventSetup&) override ;
+  void endRun(const edm::Run&,const edm::EventSetup&) override;
   
   ///Produce the PFRecTrack collection
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
   
   ///PFTrackTransformer
   PFTrackTransformer *pfTransformer_; 

--- a/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
@@ -62,14 +62,14 @@ class PFElecTkProducer final : public edm::stream::EDProducer<edm::GlobalCache<c
   }
 
      ///Destructor
-     ~PFElecTkProducer();
+     ~PFElecTkProducer() override;
 
    private:
-      virtual void beginRun(const edm::Run&,const edm::EventSetup&) override;
-      virtual void endRun(const edm::Run&,const edm::EventSetup&) override;
+      void beginRun(const edm::Run&,const edm::EventSetup&) override;
+      void endRun(const edm::Run&,const edm::EventSetup&) override;
 
       ///Produce the PFRecTrack collection
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
 
     
       int FindPfRef(const reco::PFRecTrackCollection & PfRTkColl, 

--- a/RecoParticleFlow/PFTracking/interface/PFNuclearProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFNuclearProducer.h
@@ -16,14 +16,14 @@ public:
   explicit PFNuclearProducer(const edm::ParameterSet&);
   
   ///Destructor
-  ~PFNuclearProducer();
+  ~PFNuclearProducer() override;
   
 private:
-  virtual void beginRun(const edm::Run&,const edm::EventSetup&) override;
-  virtual void endRun(const edm::Run&,const edm::EventSetup&) override;
+  void beginRun(const edm::Run&,const edm::EventSetup&) override;
+  void endRun(const edm::Run&,const edm::EventSetup&) override;
   
   ///Produce the PFRecTrack collection
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
   
   ///PFTrackTransformer
   PFTrackTransformer *pfTransformer_; 

--- a/RecoParticleFlow/PFTracking/interface/PFTrackProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFTrackProducer.h
@@ -32,11 +32,11 @@ public:
   explicit PFTrackProducer(const edm::ParameterSet&);
     
 private:
-  virtual void beginRun(const edm::Run&,const edm::EventSetup&) override;
-  virtual void endRun(const edm::Run&,const edm::EventSetup&) override;
+  void beginRun(const edm::Run&,const edm::EventSetup&) override;
+  void endRun(const edm::Run&,const edm::EventSetup&) override;
   
   ///Produce the PFRecTrack collection
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
   
   ///PFTrackTransformer
   std::unique_ptr<PFTrackTransformer> pfTransformer_; 

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.h
@@ -79,8 +79,8 @@ class GoodSeedProducer final : public edm::stream::EDProducer<edm::GlobalCache<g
   }
 
    private:
-      virtual void beginRun(const edm::Run & run,const edm::EventSetup&) override;
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      void beginRun(const edm::Run & run,const edm::EventSetup&) override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
  
       ///Find the bin in pt and eta
       int getBin(float,float);

--- a/RecoParticleFlow/PFTracking/plugins/LightPFTrackProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/LightPFTrackProducer.cc
@@ -12,7 +12,7 @@
 using namespace std;
 using namespace edm;
 LightPFTrackProducer::LightPFTrackProducer(const ParameterSet& iConfig):
-  pfTransformer_(0)
+  pfTransformer_(nullptr)
 {
   produces<reco::PFRecTrackCollection>();
 

--- a/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.cc
@@ -20,7 +20,7 @@ using namespace edm;
 
 
 PFConversionProducer::PFConversionProducer(const ParameterSet& iConfig):
-  pfTransformer_(0)
+  pfTransformer_(nullptr)
 {
   produces<reco::PFRecTrackCollection>();
   produces<reco::PFConversionCollection>();

--- a/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.h
@@ -18,14 +18,14 @@ public:
   explicit PFConversionProducer(const edm::ParameterSet&);
   
   ///Destructor
-  ~PFConversionProducer();
+  ~PFConversionProducer() override;
   
 private:
-  virtual void beginRun(const edm::Run&,const edm::EventSetup&) override;
-  virtual void endRun(const edm::Run&,const edm::EventSetup&) override;
+  void beginRun(const edm::Run&,const edm::EventSetup&) override;
+  void endRun(const edm::Run&,const edm::EventSetup&) override;
   
   ///Produce the PFRecTrack collection
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
   
   ///PFTrackTransformer
   PFTrackTransformer *pfTransformer_; 

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.cc
@@ -8,7 +8,7 @@
 using namespace std;
 using namespace edm;
 PFDisplacedTrackerVertexProducer::PFDisplacedTrackerVertexProducer(const ParameterSet& iConfig):
-  pfTransformer_(0)
+  pfTransformer_(nullptr)
 {
   produces<reco::PFRecTrackCollection>();
   produces<reco::PFDisplacedTrackerVertexCollection>();

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.h
@@ -16,14 +16,14 @@ public:
   explicit PFDisplacedTrackerVertexProducer(const edm::ParameterSet&);
   
   ///Destructor
-  ~PFDisplacedTrackerVertexProducer();
+  ~PFDisplacedTrackerVertexProducer() override;
   
 private:
-  virtual void beginRun(const edm::Run&,const edm::EventSetup&) override;
-  virtual void endRun(const edm::Run&,const edm::EventSetup&) override;
+  void beginRun(const edm::Run&,const edm::EventSetup&) override;
+  void endRun(const edm::Run&,const edm::EventSetup&) override;
   
   ///Produce the PFRecTrack collection
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
   
   ///PFTrackTransformer
   PFTrackTransformer *pfTransformer_; 

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.h
@@ -29,9 +29,9 @@ class PFDisplacedVertexCandidateProducer : public edm::stream::EDProducer<> {
 
   explicit PFDisplacedVertexCandidateProducer(const edm::ParameterSet&);
 
-  ~PFDisplacedVertexCandidateProducer();
+  ~PFDisplacedVertexCandidateProducer() override;
   
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
  private:
 

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.h
@@ -27,9 +27,9 @@ class PFDisplacedVertexProducer : public edm::stream::EDProducer<> {
 
   explicit PFDisplacedVertexProducer(const edm::ParameterSet&);
 
-  ~PFDisplacedVertexProducer();
+  ~PFDisplacedVertexProducer() override;
   
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
  private:
 

--- a/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
@@ -199,7 +199,7 @@ PFElecTkProducer::produce(Event& iEvent, const EventSetup& iSetup)
 	bool isEcalDriven = true;
 	bool isTrackerDriven = true;
 	
-	if (&(*trackRef->seedRef())==0) {
+	if (&(*trackRef->seedRef())==nullptr) {
 	  isEcalDriven = false;
 	  isTrackerDriven = false;
 	}
@@ -269,7 +269,7 @@ PFElecTkProducer::produce(Event& iEvent, const EventSetup& iSetup)
   
   
   unsigned int count_primary = 0;
-  if(selGsfPFRecTracks.size() > 0) {
+  if(!selGsfPFRecTracks.empty()) {
     for(unsigned int ipfgsf=0; ipfgsf<selGsfPFRecTracks.size();ipfgsf++) {
       
       vector<unsigned int> secondaries(0);
@@ -305,7 +305,7 @@ PFElecTkProducer::produce(Event& iEvent, const EventSetup& iSetup)
 	// A MODIFICATION HERE IMPLIES A MODIFICATION IN PFBLOCKALGO.CC/H
 	unsigned int primGsfIndex = selGsfPFRecTracks[ipfgsf].trackId();
 	vector<reco::GsfPFRecTrack> trueGsfPFRecTracks;
-	if(secondaries.size() > 0) {
+	if(!secondaries.empty()) {
 	  // loop on secondaries gsf tracks (from converted brems)
 	  for(unsigned int isecpfgsf=0; isecpfgsf<secondaries.size();isecpfgsf++) {
 	    
@@ -401,7 +401,7 @@ PFElecTkProducer::FindPfRef(const reco::PFRecTrackCollection  & PfRTkColl,
 			    bool otherColl){
 
 
-  if (&(*gsftk.seedRef())==0) return -1;
+  if (&(*gsftk.seedRef())==nullptr) return -1;
   auto const &  ElSeedFromRef=static_cast<ElectronSeed const&>( *(gsftk.extra()->seedRef()) );
   //CASE 1 ELECTRONSEED DOES NOT HAVE A REF TO THE CKFTRACK
   if (ElSeedFromRef.ctfTrack().isNull()){
@@ -482,7 +482,7 @@ PFElecTkProducer::FindPfRef(const reco::PFRecTrackCollection  & PfRTkColl,
 // -- method to apply gsf electron selection to EcalDriven seeds
 bool 
 PFElecTkProducer::applySelection(const reco::GsfTrack& gsftk) {
-  if (&(*gsftk.seedRef())==0) return false;
+  if (&(*gsftk.seedRef())==nullptr) return false;
   auto const& ElSeedFromRef=static_cast<ElectronSeed const&>( *(gsftk.extra()->seedRef()) );
 
   bool passCut = false;
@@ -515,7 +515,7 @@ PFElecTkProducer::resolveGsfTracks(const vector<reco::GsfPFRecTrack>  & GsfPFVec
 
   const reco::GsfTrackRef& nGsfTrack = GsfPFVec[ngsf].gsfTrackRef();
   
-  if (&(*nGsfTrack->seedRef())==0) return false;    
+  if (&(*nGsfTrack->seedRef())==nullptr) return false;    
   auto const& nElSeedFromRef=static_cast<ElectronSeed const&>( *(nGsfTrack->extra()->seedRef()) );
   
   /* // now gotten from cache below
@@ -571,7 +571,7 @@ PFElecTkProducer::resolveGsfTracks(const vector<reco::GsfPFRecTrack>  & GsfPFVec
         */
         float iPin = gsfInnerMomentumCache_[iGsfTrack.key()];
 
-	if (&(*iGsfTrack->seedRef())==0) continue;   
+	if (&(*iGsfTrack->seedRef())==nullptr) continue;   
 	auto const& iElSeedFromRef=static_cast<ElectronSeed const&>( *(iGsfTrack->extra()->seedRef()) );
 
 	float SCEnergy = -1.;
@@ -935,7 +935,7 @@ PFElecTkProducer::isSharingEcalEnergyWithEgSC(const reco::GsfPFRecTrack& nGsfPFR
 	}  
       } // END if anble preselection
     } // PFClusters Loop
-    if(vecPFClusters.size() > 0 ) {
+    if(!vecPFClusters.empty() ) {
       for(unsigned int pf = 0; pf < vecPFClusters.size(); pf++) {
 	bool isCommon = ClusterClusterMapping::overlap(vecPFClusters[pf],*scRef);
 	if(isCommon) {
@@ -1027,7 +1027,7 @@ PFElecTkProducer::isSharingEcalEnergyWithEgSC(const reco::GsfPFRecTrack& nGsfPFR
     }
 
 
-    if(nPFCluster.size() > 0 && iPFCluster.size() > 0) {
+    if(!nPFCluster.empty() && !iPFCluster.empty()) {
       for(unsigned int npf = 0; npf < nPFCluster.size(); npf++) {
 	for(unsigned int ipf = 0; ipf < iPFCluster.size(); ipf++) {
 	  bool isCommon = ClusterClusterMapping::overlap(nPFCluster[npf],iPFCluster[ipf]);

--- a/RecoParticleFlow/PFTracking/plugins/PFNuclearProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFNuclearProducer.cc
@@ -8,7 +8,7 @@
 using namespace std;
 using namespace edm;
 PFNuclearProducer::PFNuclearProducer(const ParameterSet& iConfig):
-  pfTransformer_(0)
+  pfTransformer_(nullptr)
 {
   produces<reco::PFRecTrackCollection>();
   produces<reco::PFNuclearInteractionCollection>();

--- a/RecoParticleFlow/PFTracking/plugins/PFV0Producer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFV0Producer.cc
@@ -13,7 +13,7 @@ using namespace std;
 using namespace edm;
 using namespace reco;
 PFV0Producer::PFV0Producer(const ParameterSet& iConfig):
-  pfTransformer_(0)
+  pfTransformer_(nullptr)
 {
 
   produces<reco::PFV0Collection>();

--- a/RecoParticleFlow/PFTracking/plugins/PFV0Producer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFV0Producer.h
@@ -18,14 +18,14 @@ public:
   explicit PFV0Producer(const edm::ParameterSet&);
   
   ///Destructor
-  ~PFV0Producer();
+  ~PFV0Producer() override;
   
 private:
-  virtual void beginRun(const edm::Run&,const edm::EventSetup&) override;
-  virtual void endRun(const edm::Run&,const edm::EventSetup&) override;
+  void beginRun(const edm::Run&,const edm::EventSetup&) override;
+  void endRun(const edm::Run&,const edm::EventSetup&) override;
   
   ///Produce the PFRecTrack collection
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
   ///PFTrackTransformer
   PFTrackTransformer *pfTransformer_; 

--- a/RecoParticleFlow/PFTracking/src/ConvBremPFTrackFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/ConvBremPFTrackFinder.cc
@@ -57,8 +57,8 @@ ConvBremPFTrackFinder::runConvBremFinder(const Handle<PFRecTrackCollection>& the
   
   
   
-  reco::GsfTrackRef refGsf =  gsfpfrectk.gsfTrackRef();
-  reco::PFRecTrackRef pfTrackRef = gsfpfrectk.kfPFRecTrackRef();
+  const reco::GsfTrackRef& refGsf =  gsfpfrectk.gsfTrackRef();
+  const reco::PFRecTrackRef& pfTrackRef = gsfpfrectk.kfPFRecTrackRef();
   vector<PFBrem> primPFBrem = gsfpfrectk.PFRecBrem();
  
   
@@ -324,7 +324,7 @@ ConvBremPFTrackFinder::runConvBremFinder(const Handle<PFRecTrackCollection>& the
 	Vertex dummy;
 	const Vertex *pv = &dummy;
 	edm::Ref<VertexCollection> pvRef;
-	if (primaryVertex->size() != 0) {
+	if (!primaryVertex->empty()) {
 	  pv = &*primaryVertex->begin();
 	  // we always use the first vertex (at the moment)
 	  pvRef = edm::Ref<VertexCollection>(primaryVertex, 0);

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -237,7 +237,7 @@ PFDisplacedVertexFinder::fitVertexFromSeed(const PFDisplacedVertexSeed& displace
   // ---- Prepare transient track list ----
 
   set < TrackBaseRef, PFDisplacedVertexSeed::Compare > const& tracksToFit = displacedVertexSeed.elements();
-  GlobalPoint seedPoint = displacedVertexSeed.seedPoint();
+  const GlobalPoint& seedPoint = displacedVertexSeed.seedPoint();
 
   vector<TransientTrack> transTracks;
   vector<TransientTrack> transTracksRaw;
@@ -692,8 +692,8 @@ PFDisplacedVertexFinder::rejectAndLabelVertex(PFDisplacedVertex& dv){
 bool 
 PFDisplacedVertexFinder::isCloseTo(const PFDisplacedVertexSeed& dv1, const PFDisplacedVertexSeed& dv2) const {
 
-  const GlobalPoint vP1 = dv1.seedPoint();
-  const GlobalPoint vP2 = dv2.seedPoint();
+  const GlobalPoint& vP1 = dv1.seedPoint();
+  const GlobalPoint& vP2 = dv2.seedPoint();
 
   double Delta_Long = getLongDiff(vP1, vP2);
   if (Delta_Long > longSize_) return false;

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexHelper.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexHelper.cc
@@ -50,7 +50,7 @@ PFDisplacedVertexHelper::isTrackSelected(const reco::Track& trk,
 
   bool isGoodTrack = false;
     
-  bool isHighPurity = trk.quality( trk.qualityByName(tracksSelector_.quality().data()) );
+  bool isHighPurity = trk.quality( trk.qualityByName(tracksSelector_.quality()) );
         
   double nChi2  = trk.normalizedChi2(); 
   double pt = trk.pt();

--- a/RecoParticleFlow/PFTracking/src/PFGeometry.cc
+++ b/RecoParticleFlow/PFTracking/src/PFGeometry.cc
@@ -6,7 +6,7 @@
 
 PFGeometry::PFGeometry()
 {
-  if (!innerRadius_.size()) {
+  if (innerRadius_.empty()) {
     // All distances are in cm
     // BeamPipe
     innerRadius_.push_back(2.5);

--- a/RecoParticleFlow/PFTracking/src/PFTrackTransformer.cc
+++ b/RecoParticleFlow/PFTracking/src/PFTrackTransformer.cc
@@ -87,7 +87,7 @@ PFTrackTransformer::addPoints( reco::PFRecTrack& pftrack,
   math::XYZTLorentzVector momClosest 
     = math::XYZTLorentzVector(track.px(), track.py(), 
 			      track.pz(), track.p());
-  math::XYZPoint posClosest = track.vertex();
+  const math::XYZPoint& posClosest = track.vertex();
   
   pftrack.addPoint(PFTrajectoryPoint(-1,PFTrajectoryPoint::ClosestApproach,
 				     posClosest,momClosest));
@@ -266,7 +266,7 @@ PFTrackTransformer::addPointsAndBrems( reco::GsfPFRecTrack& pftrack,
       math::XYZTLorentzVector momClosest 
 	= math::XYZTLorentzVector(p.x(), p.y(), 
 				  p.z(), ptot);
-      math::XYZPoint posClosest = track.vertex();
+      const math::XYZPoint& posClosest = track.vertex();
       pftrack.addPoint(PFTrajectoryPoint(-1,PFTrajectoryPoint::ClosestApproach,
 					 posClosest,momClosest));
       
@@ -609,7 +609,7 @@ PFTrackTransformer::addPointsAndBrems( reco::GsfPFRecTrack& pftrack,
   math::XYZTLorentzVector momClosest 
     = math::XYZTLorentzVector(InMom.x(), InMom.y(), 
 			      InMom.z(), ptot);
-  math::XYZPoint posClosest = track.vertex();
+  const math::XYZPoint& posClosest = track.vertex();
   pftrack.addPoint(PFTrajectoryPoint(-1,PFTrajectoryPoint::ClosestApproach,
 				     posClosest,momClosest));
   


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this quickly to avoid conflicts to the extent possible]