### PR TITLE
Clang-tidy checks for RecoPixelVertexing

### DIFF
--- a/RecoPixelVertexing/PixelLowPtUtilities/bin/PixelClusterShapeExtractor.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/bin/PixelClusterShapeExtractor.cc
@@ -377,7 +377,7 @@ void PixelClusterShapeExtractor::analyzeRecTracks
         const SiPixelRecHit* pixelRecHit =
           dynamic_cast<const SiPixelRecHit *>(recHit);
 
-        if(pixelRecHit != 0)
+        if(pixelRecHit != nullptr)
           processRec(*pixelRecHit, theClusterShape, ldir, *clusterShapeCache, hrpc);
       }
     }

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilterESProducer.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilterESProducer.h
@@ -41,7 +41,7 @@ class ClusterShapeHitFilterESProducer : public edm::ESProducer
 {
  public:
   ClusterShapeHitFilterESProducer(const edm::ParameterSet&);
-  ~ClusterShapeHitFilterESProducer();
+  ~ClusterShapeHitFilterESProducer() override;
 
   typedef std::unique_ptr<ClusterShapeHitFilter> ReturnType;
   ReturnType produce(const ClusterShapeHitFilter::Record &);

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrackFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrackFilter.h
@@ -26,8 +26,8 @@ class ClusterShapeTrackFilter : public PixelTrackFilterBase
 {
  public:
   ClusterShapeTrackFilter(const SiPixelClusterShapeCache *cache, double ptmin, double ptmax, const edm::EventSetup& es);
-  virtual ~ClusterShapeTrackFilter();
-  virtual bool operator() (const reco::Track*, const std::vector<const TrackingRecHit *> &hits) const override;
+  ~ClusterShapeTrackFilter() override;
+  bool operator() (const reco::Track*, const std::vector<const TrackingRecHit *> &hits) const override;
 
  private:
   float areaParallelogram(const Global2DVector & a,

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrajectoryFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrajectoryFilter.h
@@ -19,17 +19,17 @@ class ClusterShapeTrajectoryFilter : public TrajectoryFilter {
  public:
   ClusterShapeTrajectoryFilter(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC);
 
-  virtual ~ClusterShapeTrajectoryFilter();
+  ~ClusterShapeTrajectoryFilter() override;
 
   void setEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-  virtual bool qualityFilter(const TempTrajectory&) const override;
-  virtual bool qualityFilter(const Trajectory&) const override;
+  bool qualityFilter(const TempTrajectory&) const override;
+  bool qualityFilter(const Trajectory&) const override;
  
-  virtual bool toBeContinued(TempTrajectory&) const override;
-  virtual bool toBeContinued(Trajectory&) const override;
+  bool toBeContinued(TempTrajectory&) const override;
+  bool toBeContinued(Trajectory&) const override;
 
-  virtual std::string name() const override { return "ClusterShapeTrajectoryFilter"; }
+  std::string name() const override { return "ClusterShapeTrajectoryFilter"; }
 
  private:
   edm::EDGetTokenT<SiPixelClusterShapeCache> theCacheToken;

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/LowPtClusterShapeSeedComparitor.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/LowPtClusterShapeSeedComparitor.h
@@ -17,14 +17,14 @@ class LowPtClusterShapeSeedComparitor : public SeedComparitor
 {
  public:
   LowPtClusterShapeSeedComparitor(const edm::ParameterSet& ps, edm::ConsumesCollector& iC);
-  virtual ~LowPtClusterShapeSeedComparitor(){}
-  virtual void init(const edm::Event& e, const edm::EventSetup& es) ;
-  virtual bool compatible(const SeedingHitSet  &hits) const ;
-  virtual bool compatible(const TrajectoryStateOnSurface &,  
-                          SeedingHitSet::ConstRecHitPointer hit) const { return true; }
-  virtual bool compatible(const SeedingHitSet  &hits, 
+  ~LowPtClusterShapeSeedComparitor() override{}
+  void init(const edm::Event& e, const edm::EventSetup& es) override ;
+  bool compatible(const SeedingHitSet  &hits) const override ;
+  bool compatible(const TrajectoryStateOnSurface &,  
+                          SeedingHitSet::ConstRecHitPointer hit) const override { return true; }
+  bool compatible(const SeedingHitSet  &hits, 
                           const GlobalTrajectoryParameters &helixStateAtVertex,
-                          const FastHelix                  &helix) const { return true; }
+                          const FastHelix                  &helix) const override { return true; }
 
  private:
    /// something

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/PixelTripletLowPtGenerator.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/PixelTripletLowPtGenerator.h
@@ -27,9 +27,9 @@ class   PixelTripletLowPtGenerator :
  public:
    PixelTripletLowPtGenerator( const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
 
-  virtual ~PixelTripletLowPtGenerator();
+  ~PixelTripletLowPtGenerator() override;
 
-  virtual void hitTriplets( const TrackingRegion& region, OrderedHitTriplets & trs,
+  void hitTriplets( const TrackingRegion& region, OrderedHitTriplets & trs,
                             const edm::Event & ev, const edm::EventSetup& es,
                             const SeedingLayerSetsHits::SeedingLayerSet& pairLayers,
                             const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers) override;

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h
@@ -71,17 +71,17 @@ class StripSubClusterShapeTrajectoryFilter: public StripSubClusterShapeFilterBas
         StripSubClusterShapeTrajectoryFilter(const edm::ParameterSet &iConfig, edm::ConsumesCollector& iC):
             StripSubClusterShapeFilterBase(iConfig,iC) {}
 
-        virtual ~StripSubClusterShapeTrajectoryFilter() {}
+        ~StripSubClusterShapeTrajectoryFilter() override {}
 
-        virtual bool qualityFilter(const TempTrajectory&) const override;
-        virtual bool qualityFilter(const Trajectory&) const override;
+        bool qualityFilter(const TempTrajectory&) const override;
+        bool qualityFilter(const Trajectory&) const override;
 
-        virtual bool toBeContinued(TempTrajectory&) const override;
-        virtual bool toBeContinued(Trajectory&) const override;
+        bool toBeContinued(TempTrajectory&) const override;
+        bool toBeContinued(Trajectory&) const override;
 
-        virtual std::string name() const override { return "StripSubClusterShapeTrajectoryFilter"; }
+        std::string name() const override { return "StripSubClusterShapeTrajectoryFilter"; }
 
-        virtual void setEvent(const edm::Event & e, const edm::EventSetup & es) override {
+        void setEvent(const edm::Event & e, const edm::EventSetup & es) override {
             setEventBase(e,es);
         }
 
@@ -94,16 +94,16 @@ class StripSubClusterShapeSeedFilter: public StripSubClusterShapeFilterBase, pub
     public:
         StripSubClusterShapeSeedFilter(const edm::ParameterSet &iConfig, edm::ConsumesCollector& iC) ;
 
-        virtual ~StripSubClusterShapeSeedFilter() {}
+        ~StripSubClusterShapeSeedFilter() override {}
 
-        virtual void init(const edm::Event& ev, const edm::EventSetup& es) override {
+        void init(const edm::Event& ev, const edm::EventSetup& es) override {
             setEventBase(ev,es);
         }
         // implemented
-        virtual bool compatible(const TrajectoryStateOnSurface &tsos,  SeedingHitSet::ConstRecHitPointer hit) const override ;
+        bool compatible(const TrajectoryStateOnSurface &tsos,  SeedingHitSet::ConstRecHitPointer hit) const override ;
         // not implemented 
-        virtual bool compatible(const SeedingHitSet &hits) const override { return true; }
-        virtual bool compatible(const SeedingHitSet &hits, const GlobalTrajectoryParameters &helixStateAtVertex, const FastHelix &helix) const override ;
+        bool compatible(const SeedingHitSet &hits) const override { return true; }
+        bool compatible(const SeedingHitSet &hits, const GlobalTrajectoryParameters &helixStateAtVertex, const FastHelix &helix) const override ;
 
     protected:
         bool filterAtHelixStage_;

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/TrackCleaner.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/TrackCleaner.h
@@ -16,10 +16,10 @@ class TrackCleaner : public PixelTrackCleaner
 {
   public:
     explicit TrackCleaner(const TrackerTopology *tTopo);
-    virtual ~TrackCleaner();
+    ~TrackCleaner() override;
 
-    virtual TracksWithRecHits cleanTracks
-      (const TracksWithRecHits & tracksWithRecHits) const;
+    TracksWithRecHits cleanTracks
+      (const TracksWithRecHits & tracksWithRecHits) const override;
 
   private:
     bool areSame(const TrackingRecHit * a,

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/TrackFitter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/TrackFitter.h
@@ -21,7 +21,7 @@ public:
               const MagneticField *field, const TransientTrackingRecHitBuilder *ttrhBuilder):
     theES(es), theTracker(tracker), theField(field), theTTRecHitBuilder(ttrhBuilder)
   {}
-  virtual ~TrackFitter() { }
+  ~TrackFitter() override { }
 
   std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits, const TrackingRegion& region) const override;
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ValidHitPairFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ValidHitPairFilter.h
@@ -21,8 +21,8 @@ class ValidHitPairFilter : public PixelTrackFilterBase
 {
 public:
   ValidHitPairFilter(const edm::EventSetup& es);
-  virtual ~ValidHitPairFilter();
-  virtual bool operator()(const reco::Track * track,
+  ~ValidHitPairFilter() override;
+  bool operator()(const reco::Track * track,
                           const std::vector<const TrackingRecHit *>& recHits) const override;
 
 private:

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/ClusterShapeSeedComparitor.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/ClusterShapeSeedComparitor.cc
@@ -25,12 +25,12 @@
 class PixelClusterShapeSeedComparitor : public SeedComparitor {
     public:
         PixelClusterShapeSeedComparitor(const edm::ParameterSet &cfg, edm::ConsumesCollector& iC) ;
-        virtual ~PixelClusterShapeSeedComparitor() ; 
-        virtual void init(const edm::Event& ev, const edm::EventSetup& es) override ;
-        virtual bool compatible(const SeedingHitSet  &hits) const override { return true; }
-        virtual bool compatible(const TrajectoryStateOnSurface &,
+        ~PixelClusterShapeSeedComparitor() override ; 
+        void init(const edm::Event& ev, const edm::EventSetup& es) override ;
+        bool compatible(const SeedingHitSet  &hits) const override { return true; }
+        bool compatible(const TrajectoryStateOnSurface &,
                 SeedingHitSet::ConstRecHitPointer hit) const override ;
-        virtual bool compatible(const SeedingHitSet  &hits, 
+        bool compatible(const SeedingHitSet  &hits, 
                 const GlobalTrajectoryParameters &helixStateAtVertex,
                 const FastHelix                  &helix) const override ;
 
@@ -126,7 +126,7 @@ PixelClusterShapeSeedComparitor::compatibleHit(const TrackingRecHit &hit, const 
     if (hit.geographicalId().subdetId() <= 2) {
         if (!filterPixelHits_) return true;    
         const SiPixelRecHit *pixhit = dynamic_cast<const SiPixelRecHit *>(&hit);
-        if (pixhit == 0) throw cms::Exception("LogicError", "Found a valid hit on the pixel detector which is not a SiPixelRecHit\n");
+        if (pixhit == nullptr) throw cms::Exception("LogicError", "Found a valid hit on the pixel detector which is not a SiPixelRecHit\n");
         //printf("Cheching hi hit on detid %10d, local direction is x = %9.6f, y = %9.6f, z = %9.6f\n", hit.geographicalId().rawId(), direction.x(), direction.y(), direction.z());
         return filterHandle_->isCompatible(*pixhit, direction, *pixelClusterShapeCache_);
     } else {
@@ -134,16 +134,16 @@ PixelClusterShapeSeedComparitor::compatibleHit(const TrackingRecHit &hit, const 
         const std::type_info &tid = typeid(*&hit);
         if (tid == typeid(SiStripMatchedRecHit2D)) {
             const SiStripMatchedRecHit2D* matchedHit = dynamic_cast<const SiStripMatchedRecHit2D *>(&hit);
-            assert(matchedHit != 0);
+            assert(matchedHit != nullptr);
             return (filterHandle_->isCompatible(DetId(matchedHit->monoId()), matchedHit->monoCluster(), direction) &&
                     filterHandle_->isCompatible(DetId(matchedHit->stereoId()), matchedHit->stereoCluster(), direction));
         } else if (tid == typeid(SiStripRecHit2D)) {
             const SiStripRecHit2D* recHit = dynamic_cast<const SiStripRecHit2D *>(&hit);
-            assert(recHit != 0);
+            assert(recHit != nullptr);
             return filterHandle_->isCompatible(*recHit, direction);
         } else if (tid == typeid(ProjectedSiStripRecHit2D)) {
             const ProjectedSiStripRecHit2D* precHit = dynamic_cast<const ProjectedSiStripRecHit2D *>(&hit);
-            assert(precHit != 0);
+            assert(precHit != nullptr);
             return filterHandle_->isCompatible(precHit->originalHit(), direction);
         } else {
             //printf("Questo e' un %s, che ci fo?\n", tid.name());

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/ClusterShapeTrackFilterProducer.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/ClusterShapeTrackFilterProducer.cc
@@ -16,12 +16,12 @@
 class ClusterShapeTrackFilterProducer: public edm::global::EDProducer<> {
 public:
   explicit ClusterShapeTrackFilterProducer(const edm::ParameterSet& iConfig);
-  ~ClusterShapeTrackFilterProducer();
+  ~ClusterShapeTrackFilterProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+  void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
   edm::EDGetTokenT<SiPixelClusterShapeCache> clusterShapeCacheToken_;
   const double ptMin_;

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerClusters.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerClusters.cc
@@ -96,7 +96,7 @@ void PixelVertexProducerClusters::produce
 
   auto vertices = std::make_unique<reco::VertexCollection>();
 
-  if(thePixelHits->size() > 0)
+  if(!thePixelHits->empty())
   {
     vector<VertexHit> hits;
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerClusters.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerClusters.h
@@ -14,8 +14,8 @@ class PixelVertexProducerClusters : public edm::global::EDProducer<>
 {
 public:
   explicit PixelVertexProducerClusters(const edm::ParameterSet& ps);
-  ~PixelVertexProducerClusters();
-  virtual void produce(edm::StreamID, edm::Event& ev, const edm::EventSetup& es) const override;
+  ~PixelVertexProducerClusters() override;
+  void produce(edm::StreamID, edm::Event& ev, const edm::EventSetup& es) const override;
 
 private:
   edm::EDGetTokenT<SiPixelRecHitCollection> pixelToken_;

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerMedian.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerMedian.cc
@@ -74,7 +74,7 @@ void PixelVertexProducerMedian::produce
 
   auto vertices = std::make_unique<reco::VertexCollection>();
 
-  if(tracks.size() > 0)
+  if(!tracks.empty())
   {
   // Sort along vertex z position
   std::sort(tracks.begin(), tracks.end(), ComparePairs());

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerMedian.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/PixelVertexProducerMedian.h
@@ -10,8 +10,8 @@ class PixelVertexProducerMedian : public edm::EDProducer
 {
 public:
   explicit PixelVertexProducerMedian(const edm::ParameterSet& ps);
-  ~PixelVertexProducerMedian();
-  virtual void produce(edm::Event& ev, const edm::EventSetup& es);
+  ~PixelVertexProducerMedian() override;
+  void produce(edm::Event& ev, const edm::EventSetup& es) override;
  
 private:
   edm::ParameterSet theConfig;

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/SiPixelClusterShapeCacheProducer.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/SiPixelClusterShapeCacheProducer.cc
@@ -26,11 +26,11 @@
 class SiPixelClusterShapeCacheProducer: public edm::global::EDProducer<> {
 public:
   explicit SiPixelClusterShapeCacheProducer(const edm::ParameterSet& iConfig);
-  ~SiPixelClusterShapeCacheProducer();
+  ~SiPixelClusterShapeCacheProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const;
+  void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
 private:
   using InputCollection = edmNew::DetSetVector<SiPixelCluster>;

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/TrackCleanerESProducer.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/TrackCleanerESProducer.cc
@@ -10,7 +10,7 @@
 class TrackCleanerESProducer: public edm::ESProducer {
 public:
   TrackCleanerESProducer(const edm::ParameterSet& iConfig);
-  ~TrackCleanerESProducer() = default;
+  ~TrackCleanerESProducer() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/TrackFitterProducer.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/TrackFitterProducer.cc
@@ -23,12 +23,12 @@
 class TrackFitterProducer: public edm::global::EDProducer<> {
 public:
   explicit TrackFitterProducer(const edm::ParameterSet& iConfig);
-  ~TrackFitterProducer() {}
+  ~TrackFitterProducer() override {}
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+  void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
   std::string theTTRHBuilderName;
   edm::EDGetTokenT<reco::BeamSpot> theBeamSpotToken;

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/TrackListCombiner.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/TrackListCombiner.h
@@ -15,8 +15,8 @@ class TrackListCombiner : public edm::global::EDProducer<>
 {
 public:
   explicit TrackListCombiner(const edm::ParameterSet& ps);
-  ~TrackListCombiner();
-  virtual void produce(edm::StreamID, edm::Event& ev, const edm::EventSetup& es) const override;
+  ~TrackListCombiner() override;
+  void produce(edm::StreamID, edm::Event& ev, const edm::EventSetup& es) const override;
 
 private:
   struct Tags {

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/ValidHitPairFilterProducer.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/ValidHitPairFilterProducer.cc
@@ -13,12 +13,12 @@
 class ValidHitPairFilterProducer: public edm::global::EDProducer<> {
 public:
   explicit ValidHitPairFilterProducer(const edm::ParameterSet& iConfig);
-  ~ValidHitPairFilterProducer();
+  ~ValidHitPairFilterProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+  void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 };
 
 ValidHitPairFilterProducer::ValidHitPairFilterProducer(const edm::ParameterSet& iConfig) {

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeTrajectoryFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeTrajectoryFilter.cc
@@ -84,17 +84,17 @@ bool ClusterShapeTrajectoryFilter::toBeContinued
         const SiPixelRecHit* recHit =
            dynamic_cast<const SiPixelRecHit *>(tRecHit);
 
-        if(recHit != 0)
+        if(recHit != nullptr)
           return theFilter->isCompatible(*recHit, gdir, *theCache);
       }
       else if(GeomDetEnumerators::isTrackerStrip(ttRecHit->det()->subDetector()))
       { // strip
-        if(dynamic_cast<const SiStripMatchedRecHit2D *>(tRecHit)  != 0)
+        if(dynamic_cast<const SiStripMatchedRecHit2D *>(tRecHit)  != nullptr)
         { // glued
           const SiStripMatchedRecHit2D* recHit =
             dynamic_cast<const SiStripMatchedRecHit2D *>(tRecHit);
 
-          if(recHit != 0)
+          if(recHit != nullptr)
           { 
             return (theFilter->isCompatible(recHit->monoHit()  , gdir) &&
                     theFilter->isCompatible(recHit->stereoHit(), gdir));
@@ -102,12 +102,12 @@ bool ClusterShapeTrajectoryFilter::toBeContinued
         }
         else
         { // single
-          if(dynamic_cast<const SiStripRecHit2D *>(tRecHit) != 0)
+          if(dynamic_cast<const SiStripRecHit2D *>(tRecHit) != nullptr)
           { // normal
             const SiStripRecHit2D* recHit =
               dynamic_cast<const SiStripRecHit2D *>(tRecHit);
   
-            if(recHit != 0)
+            if(recHit != nullptr)
               return theFilter->isCompatible(*recHit, gdir);
           }
           else
@@ -115,7 +115,7 @@ bool ClusterShapeTrajectoryFilter::toBeContinued
             const ProjectedSiStripRecHit2D* recHit =
               dynamic_cast<const ProjectedSiStripRecHit2D *>(tRecHit);
  
-            if(recHit != 0)
+            if(recHit != nullptr)
               return theFilter->isCompatible(recHit->originalHit(), gdir);
           }
         }
@@ -131,7 +131,7 @@ bool ClusterShapeTrajectoryFilter::toBeContinued
   (TempTrajectory& trajectory) const 
 {
   assert(theCache);
-  TempTrajectory::DataContainer tms = trajectory.measurements();
+  const TempTrajectory::DataContainer& tms = trajectory.measurements();
 
   for(TempTrajectory::DataContainer::const_iterator
        tm = tms.rbegin(); tm!= tms.rend(); --tm)
@@ -155,7 +155,7 @@ bool ClusterShapeTrajectoryFilter::toBeContinued
         const SiPixelRecHit* recHit =
            dynamic_cast<const SiPixelRecHit *>(tRecHit);
 
-        if(recHit != 0)
+        if(recHit != nullptr)
           if(! theFilter->isCompatible(*recHit, gdir, *theCache))
           {
             LogTrace("TrajectFilter")
@@ -165,12 +165,12 @@ bool ClusterShapeTrajectoryFilter::toBeContinued
       }
       else if(GeomDetEnumerators::isTrackerStrip(ttRecHit->det()->subDetector()))
       { // strip
-        if(dynamic_cast<const SiStripMatchedRecHit2D *>(tRecHit)  != 0)
+        if(dynamic_cast<const SiStripMatchedRecHit2D *>(tRecHit)  != nullptr)
         { // glued
           const SiStripMatchedRecHit2D* recHit =
             dynamic_cast<const SiStripMatchedRecHit2D *>(tRecHit);
 
-          if(recHit != 0)
+          if(recHit != nullptr)
           { 
             if(! theFilter->isCompatible(recHit->monoHit(), gdir))
             {
@@ -189,12 +189,12 @@ bool ClusterShapeTrajectoryFilter::toBeContinued
         }
         else
         { // single
-          if(dynamic_cast<const SiStripRecHit2D *>(tRecHit) != 0)
+          if(dynamic_cast<const SiStripRecHit2D *>(tRecHit) != nullptr)
           { // normal
             const SiStripRecHit2D* recHit =
               dynamic_cast<const SiStripRecHit2D *>(tRecHit);
   
-            if(recHit != 0)
+            if(recHit != nullptr)
               if(! theFilter->isCompatible(*recHit, gdir))
               {
                 LogTrace("TrajectFilter")
@@ -207,7 +207,7 @@ bool ClusterShapeTrajectoryFilter::toBeContinued
             const ProjectedSiStripRecHit2D* recHit =
               dynamic_cast<const ProjectedSiStripRecHit2D *>(tRecHit);
  
-            if(recHit != 0)
+            if(recHit != nullptr)
               if(! theFilter->isCompatible(recHit->originalHit(), gdir))
               {
                 LogTrace("TrajectFilter")

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/LowPtClusterShapeSeedComparitor.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/LowPtClusterShapeSeedComparitor.cc
@@ -124,7 +124,7 @@ bool LowPtClusterShapeSeedComparitor::compatible(const SeedingHitSet &hits) cons
   assert(hits.size()==3);
 
   const ClusterShapeHitFilter * filter = theShapeFilter.product();
-  if(filter == 0)
+  if(filter == nullptr)
     throw cms::Exception("LogicError") << "LowPtClusterShapeSeedComparitor: init(EventSetup) method was not called";
 
    // Get global positions

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/PixelTripletLowPtGenerator.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/PixelTripletLowPtGenerator.cc
@@ -46,7 +46,7 @@ PixelTripletLowPtGenerator::~PixelTripletLowPtGenerator() {}
 void PixelTripletLowPtGenerator::getTracker
   (const edm::EventSetup& es)
 {
-  if(theTracker == 0)
+  if(theTracker == nullptr)
   {
     // Get tracker geometry
     edm::ESHandle<TrackerGeometry> tracker;
@@ -93,7 +93,7 @@ void PixelTripletLowPtGenerator::hitTriplets(
   OrderedHitPairs pairs; pairs.reserve(30000);
   thePairGenerator->hitPairs(region,pairs,ev,es, pairLayers);
 
-  if (pairs.size() == 0) return;
+  if (pairs.empty()) return;
 
   int size = thirdLayers.size();
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/StripSubClusterShapeTrajectoryFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/StripSubClusterShapeTrajectoryFilter.cc
@@ -185,7 +185,7 @@ bool StripSubClusterShapeFilterBase::testLastHit
 bool StripSubClusterShapeFilterBase::testLastHit
    (const TrackingRecHit *hit, const GlobalPoint &gpos, const GlobalVector &gdir, bool mustProject) const
 {
-   const TrackerSingleRecHit *stripHit = 0;
+   const TrackerSingleRecHit *stripHit = nullptr;
    if (typeid(*hit) == typeid(SiStripMatchedRecHit2D)) {
       const SiStripMatchedRecHit2D & mhit = static_cast<const SiStripMatchedRecHit2D &>(*hit);
       SiStripRecHit2D mono = mhit.monoHit();
@@ -195,7 +195,7 @@ bool StripSubClusterShapeFilterBase::testLastHit
       const ProjectedSiStripRecHit2D & mhit = static_cast<const ProjectedSiStripRecHit2D &>(*hit);
       const SiStripRecHit2D &orig = mhit.originalHit();
       return testLastHit(&orig,   gpos, gdir, true);
-   } else if ((stripHit = dynamic_cast<const TrackerSingleRecHit *>(hit)) != 0) {
+   } else if ((stripHit = dynamic_cast<const TrackerSingleRecHit *>(hit)) != nullptr) {
       DetId detId = hit->geographicalId();
 
       if (layerMask_[detId.subdetId()][0] == 0) {
@@ -265,7 +265,7 @@ bool StripSubClusterShapeFilterBase::testLastHit
       } 
 
       const StripGeomDetUnit* stripDetUnit = dynamic_cast<const StripGeomDetUnit *>(det);
-      if (det == 0) { edm::LogError("Strip not a StripGeomDetUnit?") << " on " << detId.rawId() << "\n"; return true; }
+      if (det == nullptr) { edm::LogError("Strip not a StripGeomDetUnit?") << " on " << detId.rawId() << "\n"; return true; }
 
       float MeVperADCStrip = 9.5665E-4; // conversion constant from ADC counts to MeV for the SiStrip detector
       float mip = 3.9 / ( MeVperADCStrip/stripDetUnit->surface().bounds().thickness() ); // 3.9 MeV/cm = ionization in silicon 
@@ -311,7 +311,7 @@ bool StripSubClusterShapeTrajectoryFilter::testLastHit(const TrajectoryMeasureme
 {
    const TrackingRecHit* hit = last.recHit()->hit();
    if (!last.updatedState().isValid()) return true;
-   if (hit == 0 || !hit->isValid()) return true;
+   if (hit == nullptr || !hit->isValid()) return true;
    if (hit->geographicalId().subdetId() < SiStripDetId::TIB) return true; // we look only at strips for now
    return testLastHit(hit, last.updatedState(), false);
 
@@ -359,7 +359,7 @@ bool StripSubClusterShapeSeedFilter::compatible
 {
    if (filterAtHelixStage_) return true;
    const TrackingRecHit* hit = thit->hit();
-   if (hit == 0 || !hit->isValid()) return true;
+   if (hit == nullptr || !hit->isValid()) return true;
    if (hit->geographicalId().subdetId() < SiStripDetId::TIB) return true; // we look only at strips for now
    return testLastHit(hit, tsos, false);
 }

--- a/RecoPixelVertexing/PixelTrackFitting/interface/KFBasedPixelFitter.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/KFBasedPixelFitter.h
@@ -25,7 +25,7 @@ public:
                      const TransientTrackingRecHitBuilder *ttrhBuilder,
                      const TrackerGeometry *tracker, const MagneticField *field,
                      const reco::BeamSpot *beamSpot);
-  virtual ~KFBasedPixelFitter() {}
+  ~KFBasedPixelFitter() override {}
 
   std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits, const TrackingRegion& region) const override;
 
@@ -35,27 +35,27 @@ private:
   class MyBeamSpotGeomDet final : public GeomDet {
     public:
     explicit MyBeamSpotGeomDet(const ReferenceCountingPointer<BoundPlane>& plane) :GeomDet(plane) { setDetId(0); }
-    virtual ~MyBeamSpotGeomDet() { }
-    virtual GeomDetEnumerators::SubDetector subDetector() const { return GeomDetEnumerators::invalidDet; }
-    virtual std::vector< const GeomDet*> components() const { return std::vector< const GeomDet*>(); }
+    ~MyBeamSpotGeomDet() override { }
+    GeomDetEnumerators::SubDetector subDetector() const override { return GeomDetEnumerators::invalidDet; }
+    std::vector< const GeomDet*> components() const override { return std::vector< const GeomDet*>(); }
   };
   class MyBeamSpotHit final :  public TValidTrackingRecHit {
     public:
     MyBeamSpotHit (const reco::BeamSpot &beamSpot, const GeomDet * geom);
-    virtual ~MyBeamSpotHit(){}
-    virtual LocalPoint localPosition() const { return localPosition_; }
-    virtual LocalError localPositionError() const { return localError_; }
-    virtual AlgebraicVector parameters() const;
-    virtual AlgebraicSymMatrix parametersError() const;
-    virtual int dimension() const { return 1; }
-    virtual AlgebraicMatrix projectionMatrix() const;
-    virtual std::vector<const TrackingRecHit*> recHits() const { return std::vector<const TrackingRecHit*>(); }
-    virtual std::vector<TrackingRecHit*> recHits() { return std::vector<TrackingRecHit*>(); }
-    virtual const TrackingRecHit * hit() const { return 0; }
+    ~MyBeamSpotHit() override{}
+    LocalPoint localPosition() const override { return localPosition_; }
+    LocalError localPositionError() const override { return localError_; }
+    AlgebraicVector parameters() const override;
+    AlgebraicSymMatrix parametersError() const override;
+    int dimension() const override { return 1; }
+    AlgebraicMatrix projectionMatrix() const override;
+    std::vector<const TrackingRecHit*> recHits() const override { return std::vector<const TrackingRecHit*>(); }
+    std::vector<TrackingRecHit*> recHits() override { return std::vector<TrackingRecHit*>(); }
+    const TrackingRecHit * hit() const override { return nullptr; }
     private:
     LocalPoint localPosition_;
     LocalError localError_;
-    virtual MyBeamSpotHit * clone() const { return new MyBeamSpotHit(*this); }
+    MyBeamSpotHit * clone() const override { return new MyBeamSpotHit(*this); }
   };
 
   const edm::EventSetup *theES;

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterBase.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterBase.h
@@ -21,7 +21,7 @@ public:
   virtual reco::Track* run(
       const edm::EventSetup& es,
       const std::vector<const TrackingRecHit *>& hits,
-      const TrackingRegion& region) const { return 0;}
+      const TrackingRegion& region) const { return nullptr;}
 
   virtual reco::Track* run(
       const edm::Event& ev,

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByConformalMappingAndLine.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByConformalMappingAndLine.h
@@ -13,8 +13,8 @@ class MagneticField;
 class PixelFitterByConformalMappingAndLine : public PixelFitterBase {
 public:
   explicit PixelFitterByConformalMappingAndLine(const edm::EventSetup *es, const TransientTrackingRecHitBuilder *ttrhBuilder, const TrackerGeometry *tracker, const MagneticField *field, double fixImpactParameter, bool useFixImpactParameter);
-  virtual ~PixelFitterByConformalMappingAndLine() { }
-  virtual std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits,
+  ~PixelFitterByConformalMappingAndLine() override { }
+  std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits,
                                            const TrackingRegion& region) const override;
 private:
   const edm::EventSetup *theES;

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
@@ -16,8 +16,8 @@ class PixelFitterByHelixProjections final : public PixelFitterBase {
 public:
   explicit PixelFitterByHelixProjections(const edm::EventSetup *es, const MagneticField *field,
                                          bool scaleErrorsForBPix1, float scaleFactor);
-  virtual ~PixelFitterByHelixProjections() {}
-  virtual std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits,
+  ~PixelFitterByHelixProjections() override {}
+  std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits,
                                            const TrackingRegion& region) const override;
 
 private:

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackCleanerBySharedHits.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackCleanerBySharedHits.h
@@ -19,7 +19,7 @@ class PixelTrackCleanerBySharedHits final : public PixelTrackCleaner {
 public:
   PixelTrackCleanerBySharedHits(bool useQuadrupletAlgo);
 
- ~PixelTrackCleanerBySharedHits();
+ ~PixelTrackCleanerBySharedHits() override;
 
   using TrackWithTTRHs = pixeltrackfitting::TrackWithTTRHs;
   using TracksWithTTRHs = pixeltrackfitting::TracksWithTTRHs;

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilterByKinematics.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilterByKinematics.h
@@ -9,8 +9,8 @@ class PixelTrackFilterByKinematics : public PixelTrackFilterBase {
 public:
   PixelTrackFilterByKinematics(double ptmin = 0.9, double tipmax = 0.1, double chi2max = 100.);
   PixelTrackFilterByKinematics(float optmin, float invPtTolerance, float tipmax, float tipmaxTolerance, float chi2max);
-  virtual ~PixelTrackFilterByKinematics();
-  virtual bool operator()(const reco::Track*, const PixelTrackFilterBase::Hits & hits) const override;
+  ~PixelTrackFilterByKinematics() override;
+  bool operator()(const reco::Track*, const PixelTrackFilterBase::Hits & hits) const override;
 private:
   float theoPtMin, theNSigmaInvPtTolerance; 
   float theTIPMax, theNSigmaTipMaxTolerance;

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/KFBasedPixelFitterProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/KFBasedPixelFitterProducer.cc
@@ -23,12 +23,12 @@
 class KFBasedPixelFitterProducer: public edm::global::EDProducer<> {
 public:
   explicit KFBasedPixelFitterProducer(const edm::ParameterSet& iConfig);
-  ~KFBasedPixelFitterProducer() {}
+  ~KFBasedPixelFitterProducer() override {}
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+  void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
   std::string thePropagatorLabel;
   std::string thePropagatorOppositeLabel;

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelFitterByConformalMappingAndLineProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelFitterByConformalMappingAndLineProducer.cc
@@ -31,7 +31,7 @@ public:
 
     produces<PixelFitter>();
   }
-  ~PixelFitterByConformalMappingAndLineProducer() {}
+  ~PixelFitterByConformalMappingAndLineProducer() override {}
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
@@ -43,7 +43,7 @@ public:
   }
 
 private:
-  virtual void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+  void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
   std::string theTTRHBuilderName;
   double theFixImpactParameter;

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelFitterByHelixProjectionsProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelFitterByHelixProjectionsProducer.cc
@@ -23,7 +23,7 @@ public:
     , thescaleFactor(iConfig.getParameter<double>("scaleFactor"))  {
     produces<PixelFitter>();
   }
-  ~PixelFitterByHelixProjectionsProducer() {}
+  ~PixelFitterByHelixProjectionsProducer() override {}
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
@@ -33,7 +33,7 @@ public:
   }
 
 private:
-  virtual void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+  void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
   const bool thescaleErrorsForBPix1;
   const float thescaleFactor;
 };

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackCleanerBySharedHitsESProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackCleanerBySharedHitsESProducer.cc
@@ -9,7 +9,7 @@
 class PixelTrackCleanerBySharedHitsESProducer: public edm::ESProducer {
 public:
   PixelTrackCleanerBySharedHitsESProducer(const edm::ParameterSet& iConfig);
-  ~PixelTrackCleanerBySharedHitsESProducer() = default;
+  ~PixelTrackCleanerBySharedHitsESProducer() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackFilterByKinematicsProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackFilterByKinematicsProducer.cc
@@ -14,12 +14,12 @@
 class PixelTrackFilterByKinematicsProducer: public edm::global::EDProducer<> {
 public:
   explicit PixelTrackFilterByKinematicsProducer(const edm::ParameterSet& iConfig);
-  ~PixelTrackFilterByKinematicsProducer();
+  ~PixelTrackFilterByKinematicsProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+  void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
   const float theoPtMin;
   const float theNSigmaInvPtTolerance;

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.h
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.h
@@ -13,11 +13,11 @@ class PixelTrackProducer :  public edm::stream::EDProducer<> {
 public:
   explicit PixelTrackProducer(const edm::ParameterSet& conf);
 
-  ~PixelTrackProducer();
+  ~PixelTrackProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  virtual void produce(edm::Event& ev, const edm::EventSetup& es) override;
+  void produce(edm::Event& ev, const edm::EventSetup& es) override;
 
 private:
   void store(edm::Event& ev, const pixeltrackfitting::TracksWithTTRHs& selectedTracks, const TrackerTopology& ttopo);

--- a/RecoPixelVertexing/PixelTrackFitting/src/ConformalMappingFit.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/ConformalMappingFit.cc
@@ -6,7 +6,7 @@ template <class T> T sqr( T t) {return t*t;}
 
 ConformalMappingFit::ConformalMappingFit(
   const std::vector<PointXY> & hits, const std::vector<float> & errRPhi2, const Rotation * rot)
-  : theRotation(rot), myRotation(rot==0)
+  : theRotation(rot), myRotation(rot==nullptr)
 {
   typedef ConformalMappingFit::MappedPoint<double> PointUV;
   int hits_size = hits.size();

--- a/RecoPixelVertexing/PixelTrackFitting/src/ConformalMappingFit.h
+++ b/RecoPixelVertexing/PixelTrackFitting/src/ConformalMappingFit.h
@@ -17,7 +17,7 @@ public:
   typedef Basic2DVector<double> PointXY;
 
   ConformalMappingFit( const std::vector<PointXY> & hits, const std::vector<float> & errRPhi2,
-      const Rotation * rotation = 0);
+      const Rotation * rotation = nullptr);
 
   ~ConformalMappingFit();
 

--- a/RecoPixelVertexing/PixelTrackFitting/src/KFBasedPixelFitter.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/KFBasedPixelFitter.cc
@@ -92,7 +92,7 @@ std::unique_ptr<reco::Track> KFBasedPixelFitter::run(const std::vector<const Tra
 
   float ptMin = region.ptMin();
 
-  const GlobalPoint vertexPos = region.origin();
+  const GlobalPoint& vertexPos = region.origin();
   GlobalError vertexErr( sqr(region.originRBound()), 0, sqr(region.originRBound()), 0, 0, sqr(region.originZBound()));
 
   std::vector<GlobalPoint> points(nhits);
@@ -146,7 +146,7 @@ std::unique_ptr<reco::Track> KFBasedPixelFitter::run(const std::vector<const Tra
   // Now update initial state track using information from hits.
   TrajectoryStateOnSurface outerState;
   DetId outerDetId = 0;
-  const TrackingRecHit* hit = 0;
+  const TrackingRecHit* hit = nullptr;
   for ( unsigned int iHit = 0; iHit < hits.size(); iHit++) {
     hit = hits[iHit];
     if (iHit==0) outerState = thePropagator->propagate(fts,theTracker->idToDet(hit->geographicalId())->surface());

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackBuilder.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackBuilder.cc
@@ -122,7 +122,7 @@ namespace {
     TSCPBuilderNoMaterial tscpBuilder;
     TrajectoryStateClosestToPoint tscp =
       tscpBuilder(*(state.freeState()), origin);
-    FreeTrajectoryState fs = tscp.theState();
+    const FreeTrajectoryState& fs = tscp.theState();
     LogTrace("")<<"CHECK-2 FTS: " << fs;
   }
 

--- a/RecoPixelVertexing/PixelTriplets/interface/ThirdHitRZPredictionBase.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/ThirdHitRZPredictionBase.h
@@ -21,7 +21,7 @@ public:
   typedef TkTrackingRegionsMargin<float> Margin;
 
   ThirdHitRZPredictionBase();
-  ThirdHitRZPredictionBase(float tolerance, const DetLayer* layer = 0);
+  ThirdHitRZPredictionBase(float tolerance, const DetLayer* layer = nullptr);
 
   const Range & detRange() const { return theDetRange; }
   const Range & detSize() const { return theDetSize; }

--- a/RecoPixelVertexing/PixelTriplets/plugins/MatchedHitRZCorrectionFromBending.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/MatchedHitRZCorrectionFromBending.cc
@@ -12,7 +12,7 @@
 
 MatchedHitRZCorrectionFromBending::
 MatchedHitRZCorrectionFromBending(DetId detId, const TrackerTopology *tTopo)
-  : rFixup(0), zFixup(0)
+  : rFixup(nullptr), zFixup(nullptr)
 {
   if (detId.subdetId() == SiStripDetId::TIB &&
       tTopo->tibIsDoubleSide(detId))
@@ -21,7 +21,7 @@ MatchedHitRZCorrectionFromBending(DetId detId, const TrackerTopology *tTopo)
 
 MatchedHitRZCorrectionFromBending::
     MatchedHitRZCorrectionFromBending(const DetLayer *layer, const TrackerTopology *tTopo)
-  : rFixup(0), zFixup(0)
+  : rFixup(nullptr), zFixup(nullptr)
 {
   if (layer->subDetector() == GeomDetEnumerators::TIB) {
     const GeometricSearchDet *tibLayer = layer;

--- a/RecoPixelVertexing/PixelTriplets/plugins/MatchedHitRZCorrectionFromBending.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/MatchedHitRZCorrectionFromBending.h
@@ -10,7 +10,7 @@ class TrackerTopology;
 
 class MatchedHitRZCorrectionFromBending {
   public:
-    MatchedHitRZCorrectionFromBending() : rFixup(0), zFixup(0) {}
+    MatchedHitRZCorrectionFromBending() : rFixup(nullptr), zFixup(nullptr) {}
     MatchedHitRZCorrectionFromBending(DetId detId, const TrackerTopology *tTopo );
     MatchedHitRZCorrectionFromBending(const DetLayer *layer, const TrackerTopology *tTopo);
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletEDProducer.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletEDProducer.cc
@@ -18,11 +18,11 @@
 class PixelQuadrupletEDProducer: public edm::stream::EDProducer<> {
 public:
   PixelQuadrupletEDProducer(const edm::ParameterSet& iConfig);
-  ~PixelQuadrupletEDProducer() = default;
+  ~PixelQuadrupletEDProducer() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
 private:
   edm::EDGetTokenT<IntermediateHitTriplets> tripletToken_;

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -93,7 +93,7 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region, Ordered
 
     int size = thirdLayers.size();
     const RecHitsSortedInPhi * thirdHitMap[size];
-    vector<const DetLayer *> thirdLayerDetLayer(size,0);
+    vector<const DetLayer *> thirdLayerDetLayer(size,nullptr);
     for (int il=0; il<size; ++il) 
     {
 	thirdHitMap[il] = &layerCache(thirdLayers[il], region, es);

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -106,7 +106,7 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region, Or
                                                 LayerCacheType& layerCache) {
   int size = thirdLayers.size();
   const RecHitsSortedInPhi * thirdHitMap[size];
-  vector<const DetLayer *> thirdLayerDetLayer(size,0);
+  vector<const DetLayer *> thirdLayerDetLayer(size,nullptr);
   for (int il=0; il<size; ++il) 
     {
       thirdHitMap[il] = &layerCache(thirdLayers[il], region, es);

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.cc
@@ -49,7 +49,7 @@ void PixelTripletNoTipGenerator::hitTriplets(
 //double errorXY = sqrt( sqr(bs.BeamWidthX()) + sqr(bs.BeamWidthY()) );
 //
 
-  GlobalPoint bsPoint = region.origin();
+  const GlobalPoint& bsPoint = region.origin();
   double errorXY = region.originRBound();
   GlobalVector shift =   bsPoint - GlobalPoint(0.,0.,0.);
 
@@ -57,7 +57,7 @@ void PixelTripletNoTipGenerator::hitTriplets(
   OrderedHitPairs::const_iterator ip;
   thePairGenerator->hitPairs(region,pairs,ev,es, pairLayers);
 
-  if (pairs.size() ==0) return;
+  if (pairs.empty()) return;
 
   int size = thirdLayers.size();
 

--- a/RecoPixelVertexing/PixelTriplets/src/CosmicHitTripletGeneratorFromLayerTriplet.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/CosmicHitTripletGeneratorFromLayerTriplet.cc
@@ -18,7 +18,7 @@ CosmicHitTripletGeneratorFromLayerTriplet::CosmicHitTripletGeneratorFromLayerTri
  const LayerWithHits* middle, 
  const LayerWithHits* outer,
  const edm::EventSetup& iSetup)
-  : TTRHbuilder(0),trackerGeometry(0),
+  : TTRHbuilder(nullptr),trackerGeometry(nullptr),
     //theLayerCache(*layerCache), 
     theOuterLayer(outer),theMiddleLayer(middle), theInnerLayer(inner)
 {

--- a/RecoPixelVertexing/PixelTriplets/src/HitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/HitQuadrupletGenerator.cc
@@ -5,7 +5,7 @@ HitQuadrupletGenerator::HitQuadrupletGenerator(unsigned int nSize): localRA(nSiz
 const OrderedHitSeeds & HitQuadrupletGenerator::run(
     const TrackingRegion& region, const edm::Event & ev, const edm::EventSetup& es)
 {
-  assert(theQuadruplets.size()==0);assert(theQuadruplets.capacity()==0);
+  assert(theQuadruplets.empty());assert(theQuadruplets.capacity()==0);
   theQuadruplets.reserve(localRA.upper());
   hitQuadruplets(region, theQuadruplets, ev, es);
   localRA.update(theQuadruplets.size());

--- a/RecoPixelVertexing/PixelTriplets/src/HitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/HitTripletGenerator.cc
@@ -5,7 +5,7 @@ HitTripletGenerator::HitTripletGenerator(unsigned int nSize) : localRA(nSize) {}
 const OrderedHitTriplets & HitTripletGenerator::run(
     const TrackingRegion& region, const edm::Event & ev, const edm::EventSetup& es)
 {
-  assert(theTriplets.size()==0);assert(theTriplets.capacity()==0);
+  assert(theTriplets.empty());assert(theTriplets.capacity()==0);
   theTriplets.reserve(localRA.upper());
   hitTriplets(region, theTriplets, ev, es);
   localRA.update(theTriplets.size());

--- a/RecoPixelVertexing/PixelVertexFinding/interface/Cluster1DCleaner.h
+++ b/RecoPixelVertexing/PixelVertexFinding/interface/Cluster1DCleaner.h
@@ -60,7 +60,7 @@ Cluster1DCleaner<T>::cleanCluster1Ds(const std::vector<Cluster1D<T> >& clust)
 {
     theCleanedCluster1Ds.clear();
     theDiscardedCluster1Ds.clear();
-    if (clust.size() == 0)
+    if (clust.empty())
         return;
     float oldPos = average(clust);
     for( typename std::vector < Cluster1D<T> >::const_iterator ic=clust.begin();

--- a/RecoPixelVertexing/PixelVertexFinding/interface/DivisiveClusterizer1D.h
+++ b/RecoPixelVertexing/PixelVertexFinding/interface/DivisiveClusterizer1D.h
@@ -33,11 +33,11 @@ public:
     DivisiveClusterizer1D( float zoffset = 5., int ntkmin = 5, bool useError = true,
                          float zsep = 0.05, bool wei = true );
 
-    ~DivisiveClusterizer1D();
+    ~DivisiveClusterizer1D() override;
 
     std::pair < std::vector < Cluster1D<T> >, std::vector < const T * > > operator()
-        ( const std::vector < Cluster1D<T> > & ) const;
-    virtual DivisiveClusterizer1D * clone() const;
+        ( const std::vector < Cluster1D<T> > & ) const override;
+    DivisiveClusterizer1D * clone() const override;
 
     void setBeamSpot(const math::XYZPoint & bs) {theMerger->setBeamSpot(bs); } 
 
@@ -240,7 +240,7 @@ void
 DivisiveClusterizer1D<T>::insertTracks( std::vector< Cluster1D<T> >&  clusou,
                                       std::vector< Cluster1D<T> >&  cludest) const
 {
-    if (clusou.size() == 0)
+    if (clusou.empty())
         return;
     for ( typename std::vector< Cluster1D<T> >::const_iterator iclu = clusou.begin();
             iclu != clusou.end(); iclu++)

--- a/RecoPixelVertexing/PixelVertexFinding/interface/PixelVertexProducer.h
+++ b/RecoPixelVertexing/PixelVertexFinding/interface/PixelVertexProducer.h
@@ -35,9 +35,9 @@ class DivisiveVertexFinder;
 class PixelVertexProducer : public edm::stream::EDProducer<> {
  public:
   explicit PixelVertexProducer(const edm::ParameterSet&);
-  ~PixelVertexProducer();
+  ~PixelVertexProducer() override;
 
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
  private:
   // ----------member data ---------------------------
   // Turn on debug printing if verbose_ > 0

--- a/RecoPixelVertexing/PixelVertexFinding/src/FastPrimaryVertexProducer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/FastPrimaryVertexProducer.cc
@@ -76,7 +76,7 @@ class FastPrimaryVertexProducer : public edm::global::EDProducer<> {
       explicit FastPrimaryVertexProducer(const edm::ParameterSet&);
 
    private:
-      virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+      void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
       edm::EDGetTokenT<SiPixelClusterCollectionNew> m_clusters;
       edm::EDGetTokenT<edm::View<reco::Jet> > m_jets;
       edm::EDGetTokenT<reco::BeamSpot> m_beamSpot;
@@ -124,7 +124,7 @@ FastPrimaryVertexProducer::produce(edm::StreamID, edm::Event& iEvent, const edm:
     if(it->pt() > 40 && fabs(it->eta()) < 1.6)
     {
       const CaloJet * ca = dynamic_cast<const CaloJet *>( &(*it));
-      if(ca ==0) abort();
+      if(ca ==nullptr) abort();
       selectedJets.push_back(*ca);
 //    std::cout << "Jet eta,phi,pt: "<< it->eta() << "," << it->phi() << "," << it->pt()   << std::endl;
     }
@@ -221,7 +221,7 @@ FastPrimaryVertexProducer::produce(edm::StreamID, edm::Event& iEvent, const edm:
 
 
   float res=0;
-  if(zProjections.size() > 0)
+  if(!zProjections.empty())
   {
      res=*(left+(right-left)/2);
 //     std::cout << "RES " << res << std::endl;

--- a/RecoPixelVertexing/PixelVertexFinding/src/FastPrimaryVertexWithWeightsProducer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/FastPrimaryVertexWithWeightsProducer.cc
@@ -20,7 +20,7 @@
 // system include files
 #include <memory>
 #include <vector>
-#include <math.h>
+#include <cmath>
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
@@ -59,7 +59,7 @@ class FastPrimaryVertexWithWeightsProducer : public edm::stream::EDProducer<> {
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void produce(edm::Event&, const edm::EventSetup&);
+      void produce(edm::Event&, const edm::EventSetup&) override;
 
 
 

--- a/RecoPixelVertexing/PixelVertexFinding/src/JetVertexChecker.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/JetVertexChecker.cc
@@ -47,12 +47,12 @@
 class JetVertexChecker : public edm::stream::EDFilter<> {
    public:
       explicit JetVertexChecker(const edm::ParameterSet&);
-      ~JetVertexChecker();
+      ~JetVertexChecker() override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual bool filter(edm::Event&, const edm::EventSetup&) override;
+      bool filter(edm::Event&, const edm::EventSetup&) override;
 
   // ----------member data ---------------------------
   const edm::EDGetTokenT<reco::JetTracksAssociationCollection> m_associator; 

--- a/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexCollectionTrimmer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexCollectionTrimmer.cc
@@ -40,12 +40,12 @@ Implementation:
 class PixelVertexCollectionTrimmer : public edm::stream::EDProducer<> {
 public:
   explicit PixelVertexCollectionTrimmer(const edm::ParameterSet&);
-  ~PixelVertexCollectionTrimmer();
+  ~PixelVertexCollectionTrimmer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
   edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
   unsigned int maxVtx_ ;

--- a/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexProducer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexProducer.cc
@@ -131,7 +131,7 @@ void PixelVertexProducer::produce(edm::Event& e, const edm::EventSetup& es) {
       edm::LogWarning("PixelVertexProducer") << "No beamspot found. Using returning vertexes with (0,0,Z) ";
     } 
   
-  if(!vertexes->size() && bsHandle.isValid()){
+  if(vertexes->empty() && bsHandle.isValid()){
     
     const reco::BeamSpot & bs = *bsHandle;
       
@@ -161,7 +161,7 @@ void PixelVertexProducer::produce(edm::Event& e, const edm::EventSetup& es) {
       }
   }
       
-  else if(!vertexes->size() && !bsHandle.isValid())
+  else if(vertexes->empty() && !bsHandle.isValid())
     {
       edm::LogWarning("PixelVertexProducer") << "No beamspot and no vertex found. No vertex returned.";
     }


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this quickly to avoid conflicts to the extent possible]