### PR TITLE
Clang-tidy checks for EventFilter

### DIFF
--- a/EventFilter/CSCRawToDigi/interface/CSCALCTHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCALCTHeader.h
@@ -178,7 +178,7 @@ class CSCALCTHeader {
       default:
 	edm::LogError("CSCALCTHeader|CSCRawToDigi")
           <<"check(): ALCT firmware version is bad/not defined!";
-        return 0;
+        return false;
       }
   }
  

--- a/EventFilter/CSCRawToDigi/interface/CSCALCTHeader2007.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCALCTHeader2007.h
@@ -10,7 +10,7 @@
 #include <vector>
 #include "DataFormats/CSCDigi/interface/CSCALCTDigi.h"
 #include <boost/dynamic_bitset.hpp>
-#include <string.h>
+#include <cstring>
 
 class CSCDMBHeader;
 

--- a/EventFilter/CSCRawToDigi/interface/CSCALCTTrailer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCALCTTrailer.h
@@ -5,7 +5,7 @@
   http://www.phys.ufl.edu/~madorsky/alctv/alct2000_spec.PDF
 */
 
-#include <string.h> // memcpy
+#include <cstring> // memcpy
 #ifndef LOCAL_UNPACK
 #include <atomic>
 #endif
@@ -125,7 +125,7 @@ public:
     default:
       edm::LogError("CSCALCTTrailer|CSCRawToDigi")
 	<<"couldn't check: ALCT firmware version is bad/not defined!";
-      return 0;
+      return false;
     }
   }
   

--- a/EventFilter/CSCRawToDigi/interface/CSCAnodeData2006.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCAnodeData2006.h
@@ -49,14 +49,14 @@ public:
   /// fill from a real datastream
   CSCAnodeData2006(const CSCALCTHeader &, const unsigned short *buf);
 
-  virtual unsigned short * data() {return theDataFrames;}
+  unsigned short * data() override {return theDataFrames;}
   /// the amount of the input binary buffer read, in 16-bit words
-  virtual unsigned short int sizeInWords() const {return nAFEBs_ * nTimeBins_ * 6 * 2;}
+  unsigned short int sizeInWords() const override {return nAFEBs_ * nTimeBins_ * 6 * 2;}
 
   /// input layer is from 1 to 6
-  virtual std::vector<CSCWireDigi> wireDigis(int layer) const;
+  std::vector<CSCWireDigi> wireDigis(int layer) const override;
 
-  virtual void add(const CSCWireDigi &, int layer);
+  void add(const CSCWireDigi &, int layer) override;
 
   static  void selfTest();
 

--- a/EventFilter/CSCRawToDigi/interface/CSCAnodeData2007.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCAnodeData2007.h
@@ -39,14 +39,14 @@ public:
   /// fill from a real datastream
   CSCAnodeData2007(const CSCALCTHeader &, const unsigned short *buf);
 
-  virtual unsigned short * data() {return theDataFrames;}
+  unsigned short * data() override {return theDataFrames;}
   /// the amount of the input binary buffer read, in 16-bit words
-  virtual unsigned short int sizeInWords() const {return sizeInWords2007_;}
+  unsigned short int sizeInWords() const override {return sizeInWords2007_;}
 
   /// input layer is from 1 to 6
-  virtual std::vector<CSCWireDigi> wireDigis(int layer) const;
+  std::vector<CSCWireDigi> wireDigis(int layer) const override;
   
-  virtual void add(const CSCWireDigi &, int layer);
+  void add(const CSCWireDigi &, int layer) override;
 
   static void selfTest();
 

--- a/EventFilter/CSCRawToDigi/interface/CSCCFEBTimeSlice.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCCFEBTimeSlice.h
@@ -32,7 +32,7 @@ struct CSCCFEBDataWord {
 };
 
 #include <iostream>
-#include <string.h> //for bzero
+#include <cstring> //for bzero
 
 struct CSCCFEBSCAControllerWord {
   /**

--- a/EventFilter/CSCRawToDigi/interface/CSCDCCEventData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDCCEventData.h
@@ -15,7 +15,7 @@ public:
   CSCDCCEventData(int sourceId, int nDDUs, int bx, int l1a);
   /// buf may need to stay pinned in memory as long
   /// as this data is used.  Not sure
-  explicit CSCDCCEventData(unsigned short *buf, CSCDCCExaminer* examiner=NULL);
+  explicit CSCDCCEventData(unsigned short *buf, CSCDCCExaminer* examiner=nullptr);
 
   ~CSCDCCEventData();
 
@@ -51,7 +51,7 @@ public:
 
 
 protected:
-  void unpack_data(unsigned short * buf, CSCDCCExaminer* examiner=NULL);
+  void unpack_data(unsigned short * buf, CSCDCCExaminer* examiner=nullptr);
   CSCDCCHeader theDCCHeader;
   // DDUData is unpacked and stored in this vector
   std::vector<CSCDDUEventData> theDDUData;

--- a/EventFilter/CSCRawToDigi/interface/CSCDCCExaminer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDCCExaminer.h
@@ -176,8 +176,8 @@ public:
 	const char* payloadName(int num) const { if(num>=0&&num<nPAYLOADS) return sDMBExpectedPayload[num]; else return ""; }
 	const char* statusName (int num) const { if(num>=0&&num<nSTATUSES) return sDMBEventStaus     [num]; else return ""; }
 
-	bool error  (int num) const { if(num>=0&&num<nERRORS)   return fSUM_ERROR  [num]; else return 0; }
-	bool warning(int num) const { if(num>=0&&num<nWARNINGS) return fSUM_WARNING[num]; else return 0; }
+	bool error  (int num) const { if(num>=0&&num<nERRORS)   return fSUM_ERROR  [num]; else return false; }
+	bool warning(int num) const { if(num>=0&&num<nWARNINGS) return fSUM_WARNING[num]; else return false; }
 
 	std::set<CSCIdType> chambersWithError  (int num) const { if(num>=0&&num<nERRORS)   return fCHAMB_ERR[num]; else return std::set<int>(); }
 	std::set<CSCIdType> chambersWithWarning(int num) const { if(num>=0&&num<nWARNINGS) return fCHAMB_WRN[num]; else return std::set<int>(); }

--- a/EventFilter/CSCRawToDigi/interface/CSCDCCTrailer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDCCTrailer.h
@@ -4,7 +4,7 @@
 #define CSCDCCTrailer_h
 
 #include <iostream>
-#include <string.h> // bzero
+#include <cstring> // bzero
 #include "DataFormats/CSCDigi/interface/CSCDCCStatusDigi.h"
 
 

--- a/EventFilter/CSCRawToDigi/interface/CSCDCCUnpacker.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDCCUnpacker.h
@@ -20,12 +20,12 @@ class CSCDCCUnpacker: public edm::stream::EDProducer<> {
   CSCDCCUnpacker(const edm::ParameterSet & pset);
   
   /// Destructor
-  virtual ~CSCDCCUnpacker();
+  ~CSCDCCUnpacker() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
   /// Produce digis out of raw data
-  void produce(edm::Event & e, const edm::EventSetup& c);
+  void produce(edm::Event & e, const edm::EventSetup& c) override;
   
   /// Visualization of raw data in FED-less events (Robert Harr and Alexander Sakharov)
   void visual_raw(int hl,int id, int run, int event, bool fedshort, bool fDump, short unsigned int* buf) const; 

--- a/EventFilter/CSCRawToDigi/interface/CSCDDUEventData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDDUEventData.h
@@ -23,7 +23,7 @@ public:
 
   // buf may need to stay pinned in memory as long
   // as this data is used.  Not sure
-  explicit CSCDDUEventData(unsigned short *buf, CSCDCCExaminer* examiner=NULL);
+  explicit CSCDDUEventData(unsigned short *buf, CSCDCCExaminer* examiner=nullptr);
 
   ~CSCDDUEventData();
 
@@ -69,7 +69,7 @@ public:
 
   /// a good test routine would be to unpack data, then pack it again.
 protected:
-  void unpack_data(unsigned short * buf, CSCDCCExaminer* examiner=NULL);
+  void unpack_data(unsigned short * buf, CSCDCCExaminer* examiner=nullptr);
   CSCDCCHeader theDCCHeader;
   CSCDDUHeader theDDUHeader;
   // CSCData is unpacked and stored in this vector

--- a/EventFilter/CSCRawToDigi/interface/CSCDDUTrailer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDDUTrailer.h
@@ -2,7 +2,7 @@
 #define CSCDDUTrailer_h
 
 #include <iostream>
-#include <string.h> // bzero
+#include <cstring> // bzero
 #include "DataFormats/CSCDigi/interface/CSCDDUStatusDigi.h"
 
 /** documented at  http://www.physics.ohio-state.edu/~cms/ddu/ddu2.html

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h
@@ -3,7 +3,7 @@
 
 #include <cassert>
 #include <iosfwd>
-#include <string.h> // bzero
+#include <cstring> // bzero
 #include "FWCore/Utilities/interface/Exception.h"
 #include "DataFormats/CSCDigi/interface/CSCDMBStatusDigi.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCVDMBHeaderFormat.h"

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBHeader2005.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBHeader2005.h
@@ -3,7 +3,7 @@
 
 #include <cassert>
 #include <iosfwd>
-#include <string.h> // bzero
+#include <cstring> // bzero
 #include "DataFormats/CSCDigi/interface/CSCDMBStatusDigi.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCVDMBHeaderFormat.h"
 
@@ -19,39 +19,39 @@ struct CSCDMBHeader2005: public CSCVDMBHeaderFormat  {
       memcpy(this, digi.header(), sizeInWords()*2);
     }
 */
-  virtual bool cfebAvailable(unsigned icfeb);
+  bool cfebAvailable(unsigned icfeb) override;
 
-  virtual void addCFEB(int icfeb);
-  virtual void addNCLCT();  
-  virtual void addNALCT();
-  virtual void setBXN(int bxn);
-  virtual void setL1A(int l1a);
-  virtual void setL1A24(int l1a);
-  virtual void setCrateAddress(int crate, int dmbId);
-  virtual void setdmbID(int newDMBID) {bits.dmb_id = newDMBID;}
-  virtual void setdmbVersion(unsigned int version) {}
+  void addCFEB(int icfeb) override;
+  void addNCLCT() override;  
+  void addNALCT() override;
+  void setBXN(int bxn) override;
+  void setL1A(int l1a) override;
+  void setL1A24(int l1a) override;
+  void setCrateAddress(int crate, int dmbId) override;
+  void setdmbID(int newDMBID) override {bits.dmb_id = newDMBID;}
+  void setdmbVersion(unsigned int version) override {}
 
-  virtual unsigned cfebActive() const {return bits.cfeb_active;} 
-  virtual unsigned crateID() const;
-  virtual unsigned dmbID() const;
-  virtual unsigned bxn() const;
-  virtual unsigned bxn12() const;
-  virtual unsigned l1a() const;
-  virtual unsigned l1a24() const;
-  virtual unsigned cfebAvailable() const;
-  virtual unsigned nalct() const;
-  virtual unsigned nclct() const;
-  virtual unsigned cfebMovlp() const;
-  virtual unsigned dmbCfebSync() const;
-  virtual unsigned activeDavMismatch() const;
-  virtual unsigned format_version() const;
+  unsigned cfebActive() const override {return bits.cfeb_active;} 
+  unsigned crateID() const override;
+  unsigned dmbID() const override;
+  unsigned bxn() const override;
+  unsigned bxn12() const override;
+  unsigned l1a() const override;
+  unsigned l1a24() const override;
+  unsigned cfebAvailable() const override;
+  unsigned nalct() const override;
+  unsigned nclct() const override;
+  unsigned cfebMovlp() const override;
+  unsigned dmbCfebSync() const override;
+  unsigned activeDavMismatch() const override;
+  unsigned format_version() const override;
 
-  unsigned sizeInWords() const;
+  unsigned sizeInWords() const override;
  
-  virtual bool check() const;
+  bool check() const override;
 
-  virtual unsigned short * data() {return (unsigned short *)(&bits);}
-  virtual unsigned short * data() const {return (unsigned short *)(&bits);}
+  unsigned short * data() override {return (unsigned short *)(&bits);}
+  unsigned short * data() const override {return (unsigned short *)(&bits);}
 
 
   //ostream & operator<<(ostream &, const CSCDMBHeader2005 &);

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBHeader2013.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBHeader2013.h
@@ -37,7 +37,7 @@
 
 #include <cassert>
 #include <iosfwd>
-#include <string.h> // bzero
+#include <cstring> // bzero
 #include "DataFormats/CSCDigi/interface/CSCDMBStatusDigi.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCVDMBHeaderFormat.h"
 
@@ -53,39 +53,39 @@ struct CSCDMBHeader2013: public CSCVDMBHeaderFormat  {
       memcpy(this, digi.header(), sizeInWords()*2);
     }
 */
-  virtual bool cfebAvailable(unsigned icfeb);
+  bool cfebAvailable(unsigned icfeb) override;
 
-  virtual void addCFEB(int icfeb);
-  virtual void addNCLCT();  
-  virtual void addNALCT();
-  virtual void setBXN(int bxn);
-  virtual void setL1A(int l1a);
-  virtual void setL1A24(int l1a);
-  virtual void setCrateAddress(int crate, int dmbId);
-  virtual void setdmbID(int newDMBID) { bits.dmb_id = newDMBID; }
-  virtual void setdmbVersion(unsigned int version) {bits.fmt_version = (version<4) ? version: 0;}
+  void addCFEB(int icfeb) override;
+  void addNCLCT() override;  
+  void addNALCT() override;
+  void setBXN(int bxn) override;
+  void setL1A(int l1a) override;
+  void setL1A24(int l1a) override;
+  void setCrateAddress(int crate, int dmbId) override;
+  void setdmbID(int newDMBID) override { bits.dmb_id = newDMBID; }
+  void setdmbVersion(unsigned int version) override {bits.fmt_version = (version<4) ? version: 0;}
 
-  virtual unsigned cfebActive() const { return bits.cfeb_clct_sent; } 
-  virtual unsigned crateID() const;
-  virtual unsigned dmbID() const;
-  virtual unsigned bxn() const;
-  virtual unsigned bxn12() const;
-  virtual unsigned l1a() const;
-  virtual unsigned l1a24() const;
-  virtual unsigned cfebAvailable() const;
-  virtual unsigned nalct() const;
-  virtual unsigned nclct() const;
-  virtual unsigned cfebMovlp() const;
-  virtual unsigned dmbCfebSync() const;
-  virtual unsigned activeDavMismatch() const;
-  virtual unsigned format_version() const;
+  unsigned cfebActive() const override { return bits.cfeb_clct_sent; } 
+  unsigned crateID() const override;
+  unsigned dmbID() const override;
+  unsigned bxn() const override;
+  unsigned bxn12() const override;
+  unsigned l1a() const override;
+  unsigned l1a24() const override;
+  unsigned cfebAvailable() const override;
+  unsigned nalct() const override;
+  unsigned nclct() const override;
+  unsigned cfebMovlp() const override;
+  unsigned dmbCfebSync() const override;
+  unsigned activeDavMismatch() const override;
+  unsigned format_version() const override;
 
-  unsigned sizeInWords() const;
+  unsigned sizeInWords() const override;
  
-  bool check() const;
+  bool check() const override;
 
-  virtual unsigned short * data() {return (unsigned short *)(&bits);}
-  virtual unsigned short * data() const { return (unsigned short *)(&bits);}
+  unsigned short * data() override {return (unsigned short *)(&bits);}
+  unsigned short * data() const override { return (unsigned short *)(&bits);}
 
 
   //ostream & operator<<(ostream &, const CSCDMBHeader &);

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer.h
@@ -3,7 +3,7 @@
 
 #include <cassert>
 #include <iosfwd>
-#include <string.h> // bzero
+#include <cstring> // bzero
 #include "FWCore/Utilities/interface/Exception.h"
 #include "DataFormats/CSCDigi/interface/CSCDMBStatusDigi.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCVDMBTrailerFormat.h"

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer2005.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer2005.h
@@ -26,7 +26,7 @@ struct CSCDMBTrailer2005: public CSCVDMBTrailerFormat {
     }
 */
   ///@@ NEEDS TO BE DONE
-  virtual void setEventInformation(const CSCDMBHeader & dmbHeader) 
+  void setEventInformation(const CSCDMBHeader & dmbHeader) override 
    {
       bits.dmb_id = dmbHeader.dmbID();
       bits.crate_id = dmbHeader.crateID();
@@ -34,49 +34,49 @@ struct CSCDMBTrailer2005: public CSCVDMBTrailerFormat {
       bits.dmb_bxn = dmbHeader.bxn();
    };
 
-  virtual unsigned crateID() const { return bits.crate_id; };
-  virtual unsigned dmbID() const { return bits.dmb_id; };
+  unsigned crateID() const override { return bits.crate_id; };
+  unsigned dmbID() const override { return bits.dmb_id; };
 
-  virtual unsigned dmb_l1a() const { return bits.dmb_l1a; };
-  virtual unsigned dmb_bxn() const { return bits.dmb_bxn; };
+  unsigned dmb_l1a() const override { return bits.dmb_l1a; };
+  unsigned dmb_bxn() const override { return bits.dmb_bxn; };
 
-  virtual unsigned alct_endtimeout() const { return bits.alct_endtimeout; };
-  virtual unsigned tmb_endtimeout() const { return bits.tmb_endtimeout; };
-  virtual unsigned cfeb_endtimeout() const { return bits.cfeb_endtimeout; };
+  unsigned alct_endtimeout() const override { return bits.alct_endtimeout; };
+  unsigned tmb_endtimeout() const override { return bits.tmb_endtimeout; };
+  unsigned cfeb_endtimeout() const override { return bits.cfeb_endtimeout; };
 
-  virtual unsigned alct_starttimeout() const { return bits.alct_starttimeout; };
-  virtual unsigned tmb_starttimeout() const { return bits.tmb_starttimeout; };
-  virtual unsigned cfeb_starttimeout() const { return bits.cfeb_starttimeout; };
+  unsigned alct_starttimeout() const override { return bits.alct_starttimeout; };
+  unsigned tmb_starttimeout() const override { return bits.tmb_starttimeout; };
+  unsigned cfeb_starttimeout() const override { return bits.cfeb_starttimeout; };
 
-  virtual unsigned cfeb_movlp() const { return bits.cfeb_movlp; };
-  virtual unsigned dmb_l1pipe() const { return bits.dmb_l1pipe; };
+  unsigned cfeb_movlp() const override { return bits.cfeb_movlp; };
+  unsigned dmb_l1pipe() const override { return bits.dmb_l1pipe; };
 
-  virtual unsigned alct_empty() const { return bits.alct_empty; };
-  virtual unsigned tmb_empty() const {return bits.tmb_empty; };
-  virtual unsigned cfeb_empty() const { return bits.cfeb_empty; };
+  unsigned alct_empty() const override { return bits.alct_empty; };
+  unsigned tmb_empty() const override {return bits.tmb_empty; };
+  unsigned cfeb_empty() const override { return bits.cfeb_empty; };
 
-  virtual unsigned alct_half() const { return bits.alct_half; };
-  virtual unsigned tmb_half() const {return bits.tmb_half; };
-  virtual unsigned cfeb_half() const { return bits.cfeb_half; };
+  unsigned alct_half() const override { return bits.alct_half; };
+  unsigned tmb_half() const override {return bits.tmb_half; };
+  unsigned cfeb_half() const override { return bits.cfeb_half; };
 
-  virtual unsigned alct_full() const { return bits.alct_full; };
-  virtual unsigned tmb_full() const {return bits.tmb_full; };
-  virtual unsigned cfeb_full() const { return bits.cfeb_full; };
+  unsigned alct_full() const override { return bits.alct_full; };
+  unsigned tmb_full() const override {return bits.tmb_full; };
+  unsigned cfeb_full() const override { return bits.cfeb_full; };
 
-  virtual unsigned crc22() const { return (bits.dmb_crc_1 | (bits.dmb_crc_2 << 11)); };
-  virtual unsigned crc_lo_parity() const { return bits.dmb_parity_1; };
-  virtual unsigned crc_hi_parity() const { return bits.dmb_parity_2; };
+  unsigned crc22() const override { return (bits.dmb_crc_1 | (bits.dmb_crc_2 << 11)); };
+  unsigned crc_lo_parity() const override { return bits.dmb_parity_1; };
+  unsigned crc_hi_parity() const override { return bits.dmb_parity_2; };
 
 
-  virtual unsigned short * data() {return (unsigned short *)(&bits);}
-  virtual unsigned short * data() const {return (unsigned short *)(&bits);}
+  unsigned short * data() override {return (unsigned short *)(&bits);}
+  unsigned short * data() const override {return (unsigned short *)(&bits);}
 
-  bool check() const {return bits.ddu_code_1 == 0xF && bits.ddu_code_2 == 0xF
+  bool check() const override {return bits.ddu_code_1 == 0xF && bits.ddu_code_2 == 0xF
                           && bits.ddu_code_3 == 0xF && bits.ddu_code_4 == 0xF
                           && bits.ddu_code_5 == 0xE && bits.ddu_code_6 == 0xE
                           && bits.ddu_code_7 == 0xE && bits.ddu_code_8 == 0xE;}
 
-  unsigned sizeInWords() const {return 8;}
+  unsigned sizeInWords() const override {return 8;}
 
   struct {
   unsigned dmb_l1a       : 8;

--- a/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer2013.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBTrailer2013.h
@@ -62,7 +62,7 @@ struct CSCDMBTrailer2013: public CSCVDMBTrailerFormat {
 */
 
   ///@@ NEEDS TO BE DONE
-  virtual void setEventInformation(const CSCDMBHeader & dmbHeader) 
+  void setEventInformation(const CSCDMBHeader & dmbHeader) override 
     {
 	bits.dmb_id = dmbHeader.dmbID();
         bits.crate_id = dmbHeader.crateID();
@@ -70,50 +70,50 @@ struct CSCDMBTrailer2013: public CSCVDMBTrailerFormat {
         bits.dmb_bxn = dmbHeader.bxn();
     };
 
-  virtual unsigned crateID() const { return bits.crate_id; };
-  virtual unsigned dmbID() const { return bits.dmb_id; };
+  unsigned crateID() const override { return bits.crate_id; };
+  unsigned dmbID() const override { return bits.dmb_id; };
 
-  virtual unsigned dmb_l1a() const { return bits.dmb_l1a; };
-  virtual unsigned dmb_bxn() const { return bits.dmb_bxn; };
+  unsigned dmb_l1a() const override { return bits.dmb_l1a; };
+  unsigned dmb_bxn() const override { return bits.dmb_bxn; };
 
-  virtual unsigned alct_endtimeout() const { return bits.alct_endtimeout; };
-  virtual unsigned tmb_endtimeout() const { return bits.tmb_endtimeout; };
-  virtual unsigned cfeb_endtimeout() const { return bits.cfeb_endtimeout; };
+  unsigned alct_endtimeout() const override { return bits.alct_endtimeout; };
+  unsigned tmb_endtimeout() const override { return bits.tmb_endtimeout; };
+  unsigned cfeb_endtimeout() const override { return bits.cfeb_endtimeout; };
 
-  virtual unsigned alct_starttimeout() const { return bits.alct_starttimeout; };
-  virtual unsigned tmb_starttimeout() const { return bits.tmb_starttimeout; };
-  virtual unsigned cfeb_starttimeout() const { return bits.cfeb_starttimeout; };
+  unsigned alct_starttimeout() const override { return bits.alct_starttimeout; };
+  unsigned tmb_starttimeout() const override { return bits.tmb_starttimeout; };
+  unsigned cfeb_starttimeout() const override { return bits.cfeb_starttimeout; };
 
-  virtual unsigned cfeb_movlp() const { return bits.cfeb_movlp; };
-  virtual unsigned dmb_l1pipe() const { return bits.dmb_l1pipe; };
+  unsigned cfeb_movlp() const override { return bits.cfeb_movlp; };
+  unsigned dmb_l1pipe() const override { return bits.dmb_l1pipe; };
 
   /// Empty bits don't exists in new format
-  virtual unsigned alct_empty() const { return 0; };
-  virtual unsigned tmb_empty() const { return 0 ; };
-  virtual unsigned cfeb_empty() const { return 0; };
+  unsigned alct_empty() const override { return 0; };
+  unsigned tmb_empty() const override { return 0 ; };
+  unsigned cfeb_empty() const override { return 0; };
 
 
-  virtual unsigned alct_half() const { return bits.alct_half; };
-  virtual unsigned tmb_half() const { return bits.tmb_half; };
-  virtual unsigned cfeb_half() const { return bits.cfeb_half; };
+  unsigned alct_half() const override { return bits.alct_half; };
+  unsigned tmb_half() const override { return bits.tmb_half; };
+  unsigned cfeb_half() const override { return bits.cfeb_half; };
 
-  virtual unsigned alct_full() const { return bits.alct_full; };
-  virtual unsigned tmb_full() const { return bits.tmb_full; };
-  virtual unsigned cfeb_full() const { return (bits.cfeb_full_lowo | (bits.cfeb_full_hiwo << 3)); };
+  unsigned alct_full() const override { return bits.alct_full; };
+  unsigned tmb_full() const override { return bits.tmb_full; };
+  unsigned cfeb_full() const override { return (bits.cfeb_full_lowo | (bits.cfeb_full_hiwo << 3)); };
   
-  virtual unsigned crc22() const { return (bits.dmb_crc_1 | (bits.dmb_crc_2 << 11)); };
-  virtual unsigned crc_lo_parity() const { return bits.dmb_parity_1; };
-  virtual unsigned crc_hi_parity() const { return bits.dmb_parity_2; };
+  unsigned crc22() const override { return (bits.dmb_crc_1 | (bits.dmb_crc_2 << 11)); };
+  unsigned crc_lo_parity() const override { return bits.dmb_parity_1; };
+  unsigned crc_hi_parity() const override { return bits.dmb_parity_2; };
  
-  virtual unsigned short * data() { return (unsigned short *)(&bits); }
-  virtual unsigned short * data() const { return (unsigned short *)(&bits); }
+  unsigned short * data() override { return (unsigned short *)(&bits); }
+  unsigned short * data() const override { return (unsigned short *)(&bits); }
 
-  bool check() const {return bits.ddu_code_1 == 0xF && bits.ddu_code_2 == 0xF
+  bool check() const override {return bits.ddu_code_1 == 0xF && bits.ddu_code_2 == 0xF
                           && bits.ddu_code_3 == 0xF && bits.ddu_code_4 == 0xF
                           && bits.ddu_code_5 == 0xE && bits.ddu_code_6 == 0xE
                           && bits.ddu_code_7 == 0xE && bits.ddu_code_8 == 0xE;}
 
-  unsigned sizeInWords() const { return 8; }
+  unsigned sizeInWords() const override { return 8; }
 
   struct {
   /// 1st Trailer word

--- a/EventFilter/CSCRawToDigi/interface/CSCDigiValidator.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDigiValidator.h
@@ -35,12 +35,12 @@ class CSCChamberMap;
 class CSCDigiValidator : public edm::EDFilter {
    public:
       explicit CSCDigiValidator(const edm::ParameterSet&);
-      ~CSCDigiValidator();
+      ~CSCDigiValidator() override;
 
    private:
-      virtual void beginJob() ;
-      virtual bool filter(edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+      void beginJob() override ;
+      bool filter(edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
       
       std::vector<CSCWireDigi> 
 	sanitizeWireDigis(std::vector<CSCWireDigi>::const_iterator,

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2006.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2006.h
@@ -8,50 +8,50 @@ struct CSCTMBHeader2006 : public CSCVTMBHeaderFormat {
   enum {NWORDS=27};
   CSCTMBHeader2006();
   explicit CSCTMBHeader2006(const unsigned short * buf);
-  virtual void setEventInformation(const CSCDMBHeader & dmbHeader);
+  void setEventInformation(const CSCDMBHeader & dmbHeader) override;
 
-  virtual uint16_t BXNCount() const {return bits.bxnCount;}
-  virtual uint16_t ALCTMatchTime() const {return bits.alctMatchTime;}
-  virtual uint16_t CLCTOnly() const {return bits.clctOnly;}
-  virtual uint16_t ALCTOnly() const {return bits.alctOnly;}
-  virtual uint16_t TMBMatch() const {return bits.tmbMatch;}
-  virtual uint16_t Bxn0Diff() const {return bits.bxn0Diff;}
-  virtual uint16_t Bxn1Diff() const {return bits.bxn1Diff;}
-  virtual uint16_t L1ANumber() const {return bits.l1aNumber;}
-  virtual uint16_t NTBins() const {return bits.nTBins;}
-  virtual uint16_t NCFEBs() const {return bits.nCFEBs;}
-  virtual void setNCFEBs(uint16_t ncfebs) {bits.nCFEBs = ncfebs & 0x1F;}
-  virtual uint16_t firmwareRevision() const {return bits.firmRevCode;}
-  virtual uint16_t syncError() const {return bits.syncError;}
-  virtual uint16_t syncErrorCLCT() const {return (bits.clct0_sync_err | bits.clct1_sync_err);}
-  virtual uint16_t syncErrorMPC0() const {return bits.MPC_Muon0_SyncErr_;}
-  virtual uint16_t syncErrorMPC1() const {return bits.MPC_Muon1_SyncErr_;}
+  uint16_t BXNCount() const override {return bits.bxnCount;}
+  uint16_t ALCTMatchTime() const override {return bits.alctMatchTime;}
+  uint16_t CLCTOnly() const override {return bits.clctOnly;}
+  uint16_t ALCTOnly() const override {return bits.alctOnly;}
+  uint16_t TMBMatch() const override {return bits.tmbMatch;}
+  uint16_t Bxn0Diff() const override {return bits.bxn0Diff;}
+  uint16_t Bxn1Diff() const override {return bits.bxn1Diff;}
+  uint16_t L1ANumber() const override {return bits.l1aNumber;}
+  uint16_t NTBins() const override {return bits.nTBins;}
+  uint16_t NCFEBs() const override {return bits.nCFEBs;}
+  void setNCFEBs(uint16_t ncfebs) override {bits.nCFEBs = ncfebs & 0x1F;}
+  uint16_t firmwareRevision() const override {return bits.firmRevCode;}
+  uint16_t syncError() const override {return bits.syncError;}
+  uint16_t syncErrorCLCT() const override {return (bits.clct0_sync_err | bits.clct1_sync_err);}
+  uint16_t syncErrorMPC0() const override {return bits.MPC_Muon0_SyncErr_;}
+  uint16_t syncErrorMPC1() const override {return bits.MPC_Muon1_SyncErr_;}
 
   ///returns CLCT digis
-  virtual std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer);
+  std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer) override;
   ///returns CorrelatedLCT digis
-  virtual std::vector<CSCCorrelatedLCTDigi> CorrelatedLCTDigis(uint32_t idlayer) const;
+  std::vector<CSCCorrelatedLCTDigi> CorrelatedLCTDigis(uint32_t idlayer) const override;
  
   /// in 16-bit words.  Add olne because we include beginning(b0c) and
   /// end (e0c) flags
-  unsigned short int sizeInWords() const {return NWORDS;}
+  unsigned short int sizeInWords() const override {return NWORDS;}
 
-  virtual unsigned short int NHeaderFrames() const {return bits.nHeaderFrames;}
+  unsigned short int NHeaderFrames() const override {return bits.nHeaderFrames;}
   /// returns the first data word
-  virtual unsigned short * data() {return (unsigned short *)(&bits);}
-  virtual bool check() const {return bits.e0bline==0x6e0b && NHeaderFrames()+1 == NWORDS;}
+  unsigned short * data() override {return (unsigned short *)(&bits);}
+  bool check() const override {return bits.e0bline==0x6e0b && NHeaderFrames()+1 == NWORDS;}
 
   /// for data packing
-  virtual void addCLCT0(const CSCCLCTDigi & digi);
-  virtual void addCLCT1(const CSCCLCTDigi & digi);
-  virtual void addALCT0(const CSCALCTDigi & digi);
-  virtual void addALCT1(const CSCALCTDigi & digi);
-  virtual void addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi);
-  virtual void addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi);
+  void addCLCT0(const CSCCLCTDigi & digi) override;
+  void addCLCT1(const CSCCLCTDigi & digi) override;
+  void addALCT0(const CSCALCTDigi & digi) override;
+  void addALCT1(const CSCALCTDigi & digi) override;
+  void addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi) override;
+  void addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi) override;
 
   void swapCLCTs(CSCCLCTDigi& digi1, CSCCLCTDigi& digi2);
 
-  virtual void print(std::ostream & os) const;
+  void print(std::ostream & os) const override;
     struct {
       unsigned b0cline:16;
       unsigned nTBins:5, dumpCFEBs:7, fifoMode:3, reserved_1:1;

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2007.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2007.h
@@ -8,54 +8,54 @@ struct CSCTMBHeader2007 : public CSCVTMBHeaderFormat {
   enum {NWORDS = 43};
   CSCTMBHeader2007();
   CSCTMBHeader2007(const unsigned short * buf);
-  virtual void setEventInformation(const CSCDMBHeader & dmbHeader);
+  void setEventInformation(const CSCDMBHeader & dmbHeader) override;
 
-  virtual uint16_t BXNCount() const {return bits.bxnCount;}
-  virtual uint16_t ALCTMatchTime() const {return bits.matchWin;}
-  virtual uint16_t CLCTOnly() const {return bits.clctOnly;}
-  virtual uint16_t ALCTOnly() const {return bits.alctOnly;}
-  virtual uint16_t TMBMatch() const {return bits.tmbMatch;}
-  virtual uint16_t Bxn0Diff() const {return 0;}
-  virtual uint16_t Bxn1Diff() const {return 0;}
-  virtual uint16_t L1ANumber() const {return bits.l1aNumber;}
-  virtual uint16_t NTBins() const {return bits.nTBins;}
-  virtual uint16_t NCFEBs() const {return bits.nCFEBs;}
-  virtual void setNCFEBs(uint16_t ncfebs) {bits.nCFEBs = ncfebs & 0x1F;}
-  virtual uint16_t firmwareRevision() const {return bits.firmRevCode;}
-  virtual uint16_t syncError() const {return bits.syncError;}
-  virtual uint16_t syncErrorCLCT() const {return (bits.clct0_sync_err | bits.clct1_sync_err);}
-  virtual uint16_t syncErrorMPC0() const {return bits.MPC_Muon0_SyncErr_;}
-  virtual uint16_t syncErrorMPC1() const {return bits.MPC_Muon1_SyncErr_;}
+  uint16_t BXNCount() const override {return bits.bxnCount;}
+  uint16_t ALCTMatchTime() const override {return bits.matchWin;}
+  uint16_t CLCTOnly() const override {return bits.clctOnly;}
+  uint16_t ALCTOnly() const override {return bits.alctOnly;}
+  uint16_t TMBMatch() const override {return bits.tmbMatch;}
+  uint16_t Bxn0Diff() const override {return 0;}
+  uint16_t Bxn1Diff() const override {return 0;}
+  uint16_t L1ANumber() const override {return bits.l1aNumber;}
+  uint16_t NTBins() const override {return bits.nTBins;}
+  uint16_t NCFEBs() const override {return bits.nCFEBs;}
+  void setNCFEBs(uint16_t ncfebs) override {bits.nCFEBs = ncfebs & 0x1F;}
+  uint16_t firmwareRevision() const override {return bits.firmRevCode;}
+  uint16_t syncError() const override {return bits.syncError;}
+  uint16_t syncErrorCLCT() const override {return (bits.clct0_sync_err | bits.clct1_sync_err);}
+  uint16_t syncErrorMPC0() const override {return bits.MPC_Muon0_SyncErr_;}
+  uint16_t syncErrorMPC1() const override {return bits.MPC_Muon1_SyncErr_;}
 
   ///returns CLCT digis
-  virtual std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer);
+  std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer) override;
   ///returns CorrelatedLCT digis
-  virtual std::vector<CSCCorrelatedLCTDigi> CorrelatedLCTDigis(uint32_t idlayer) const;
+  std::vector<CSCCorrelatedLCTDigi> CorrelatedLCTDigis(uint32_t idlayer) const override;
  
   
   /// in 16-bit words.  Add olne because we include beginning(b0c) and
   /// end (e0c) flags
-  unsigned short int sizeInWords() const     {return NWORDS;}
+  unsigned short int sizeInWords() const override     {return NWORDS;}
 
-  virtual unsigned short int NHeaderFrames() const {return bits.nHeaderFrames;}
+  unsigned short int NHeaderFrames() const override {return bits.nHeaderFrames;}
   /// returns the first data word
-  virtual unsigned short * data() {return (unsigned short *)(&bits);}
-  virtual bool check() const {return bits.e0bline==0x6e0b;}
+  unsigned short * data() override {return (unsigned short *)(&bits);}
+  bool check() const override {return bits.e0bline==0x6e0b;}
 
   /// Needed before data packing
   //void setChamberId(const CSCDetId & detId) {theChamberId = detId;}
 
   /// for data packing
-  virtual void addCLCT0(const CSCCLCTDigi & digi);
-  virtual void addCLCT1(const CSCCLCTDigi & digi);
-  virtual void addALCT0(const CSCALCTDigi & digi);
-  virtual void addALCT1(const CSCALCTDigi & digi);
-  virtual void addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi);
-  virtual void addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi);
+  void addCLCT0(const CSCCLCTDigi & digi) override;
+  void addCLCT1(const CSCCLCTDigi & digi) override;
+  void addALCT0(const CSCALCTDigi & digi) override;
+  void addALCT1(const CSCALCTDigi & digi) override;
+  void addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi) override;
+  void addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi) override;
 
   void swapCLCTs(CSCCLCTDigi& digi1, CSCCLCTDigi& digi2);
 
-  virtual void print(std::ostream & os) const;
+  void print(std::ostream & os) const override;
 
   struct {
     unsigned b0cline:16;

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2007_rev0x50c3.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2007_rev0x50c3.h
@@ -8,54 +8,54 @@ struct CSCTMBHeader2007_rev0x50c3 : public CSCVTMBHeaderFormat {
   enum {NWORDS = 43};
   CSCTMBHeader2007_rev0x50c3();
   CSCTMBHeader2007_rev0x50c3(const unsigned short * buf);
-  virtual void setEventInformation(const CSCDMBHeader & dmbHeader);
+  void setEventInformation(const CSCDMBHeader & dmbHeader) override;
 
-  virtual uint16_t BXNCount() const {return bits.bxnCount;}
-  virtual uint16_t ALCTMatchTime() const {return bits.matchWin;}
-  virtual uint16_t CLCTOnly() const {return bits.clctOnly;}
-  virtual uint16_t ALCTOnly() const {return bits.alctOnly;}
-  virtual uint16_t TMBMatch() const {return bits.tmbMatch;}
-  virtual uint16_t Bxn0Diff() const {return 0;}
-  virtual uint16_t Bxn1Diff() const {return 0;}
-  virtual uint16_t L1ANumber() const {return bits.l1aNumber;}
-  virtual uint16_t NTBins() const {return bits.nTBins;}
-  virtual uint16_t NCFEBs() const {return bits.nCFEBs;}
-  virtual void setNCFEBs(uint16_t ncfebs) {bits.nCFEBs = ncfebs & 0x1F;}
-  virtual uint16_t syncError() const {return bits.syncError;}
-  virtual uint16_t syncErrorCLCT() const {return bits.clct_sync_err;}
-  virtual uint16_t syncErrorMPC0() const {return bits.MPC_Muon0_SyncErr_;}
-  virtual uint16_t syncErrorMPC1() const {return bits.MPC_Muon1_SyncErr_;}
-  virtual uint16_t firmwareRevision() const {return bits.firmRevCode;}
+  uint16_t BXNCount() const override {return bits.bxnCount;}
+  uint16_t ALCTMatchTime() const override {return bits.matchWin;}
+  uint16_t CLCTOnly() const override {return bits.clctOnly;}
+  uint16_t ALCTOnly() const override {return bits.alctOnly;}
+  uint16_t TMBMatch() const override {return bits.tmbMatch;}
+  uint16_t Bxn0Diff() const override {return 0;}
+  uint16_t Bxn1Diff() const override {return 0;}
+  uint16_t L1ANumber() const override {return bits.l1aNumber;}
+  uint16_t NTBins() const override {return bits.nTBins;}
+  uint16_t NCFEBs() const override {return bits.nCFEBs;}
+  void setNCFEBs(uint16_t ncfebs) override {bits.nCFEBs = ncfebs & 0x1F;}
+  uint16_t syncError() const override {return bits.syncError;}
+  uint16_t syncErrorCLCT() const override {return bits.clct_sync_err;}
+  uint16_t syncErrorMPC0() const override {return bits.MPC_Muon0_SyncErr_;}
+  uint16_t syncErrorMPC1() const override {return bits.MPC_Muon1_SyncErr_;}
+  uint16_t firmwareRevision() const override {return bits.firmRevCode;}
 
   ///returns CLCT digis
-  virtual std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer);
+  std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer) override;
   ///returns CorrelatedLCT digis
-  virtual std::vector<CSCCorrelatedLCTDigi> CorrelatedLCTDigis(uint32_t idlayer) const;
+  std::vector<CSCCorrelatedLCTDigi> CorrelatedLCTDigis(uint32_t idlayer) const override;
  
   
   /// in 16-bit words.  Add olne because we include beginning(b0c) and
   /// end (e0c) flags
-  unsigned short int sizeInWords() const     {return NWORDS;}
+  unsigned short int sizeInWords() const override     {return NWORDS;}
 
-  virtual unsigned short int NHeaderFrames() const {return bits.nHeaderFrames;}
+  unsigned short int NHeaderFrames() const override {return bits.nHeaderFrames;}
   /// returns the first data word
-  virtual unsigned short * data() {return (unsigned short *)(&bits);}
-  virtual bool check() const {return bits.e0bline==0x6e0b;}
+  unsigned short * data() override {return (unsigned short *)(&bits);}
+  bool check() const override {return bits.e0bline==0x6e0b;}
 
   /// Needed before data packing
   //void setChamberId(const CSCDetId & detId) {theChamberId = detId;}
 
   /// for data packing
-  virtual void addCLCT0(const CSCCLCTDigi & digi);
-  virtual void addCLCT1(const CSCCLCTDigi & digi);
-  virtual void addALCT0(const CSCALCTDigi & digi);
-  virtual void addALCT1(const CSCALCTDigi & digi);
-  virtual void addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi);
-  virtual void addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi);
+  void addCLCT0(const CSCCLCTDigi & digi) override;
+  void addCLCT1(const CSCCLCTDigi & digi) override;
+  void addALCT0(const CSCALCTDigi & digi) override;
+  void addALCT1(const CSCALCTDigi & digi) override;
+  void addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi) override;
+  void addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi) override;
 
   void swapCLCTs(CSCCLCTDigi& digi1, CSCCLCTDigi& digi2);
 
-  virtual void print(std::ostream & os) const;
+  void print(std::ostream & os) const override;
 
   struct {
   // 0

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2013.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2013.h
@@ -8,54 +8,54 @@ struct CSCTMBHeader2013 : public CSCVTMBHeaderFormat {
   enum {NWORDS = 43};
   CSCTMBHeader2013();
   CSCTMBHeader2013(const unsigned short * buf);
-  virtual void setEventInformation(const CSCDMBHeader & dmbHeader);
+  void setEventInformation(const CSCDMBHeader & dmbHeader) override;
 
-  virtual uint16_t BXNCount() const {return bits.bxnCount;}
-  virtual uint16_t ALCTMatchTime() const {return bits.matchWin;}
-  virtual uint16_t CLCTOnly() const {return bits.clctOnly;}
-  virtual uint16_t ALCTOnly() const {return bits.alctOnly;}
-  virtual uint16_t TMBMatch() const {return bits.tmbMatch;}
-  virtual uint16_t Bxn0Diff() const {return 0;}
-  virtual uint16_t Bxn1Diff() const {return 0;}
-  virtual uint16_t L1ANumber() const {return bits.l1aNumber;}
-  virtual uint16_t NTBins() const {return bits.nTBins;}
-  virtual uint16_t NCFEBs() const {return bits.nCFEBs;}
-  virtual void setNCFEBs(uint16_t ncfebs) {bits.nCFEBs = ncfebs & 0x7F;}
-  virtual uint16_t firmwareRevision() const {return bits.firmRevCode;}
-  virtual uint16_t syncError() const {return bits.syncError;}
-  virtual uint16_t syncErrorCLCT() const {return bits.clct_sync_err;}
-  virtual uint16_t syncErrorMPC0() const {return bits.MPC_Muon0_SyncErr_;}
-  virtual uint16_t syncErrorMPC1() const {return bits.MPC_Muon1_SyncErr_;}
+  uint16_t BXNCount() const override {return bits.bxnCount;}
+  uint16_t ALCTMatchTime() const override {return bits.matchWin;}
+  uint16_t CLCTOnly() const override {return bits.clctOnly;}
+  uint16_t ALCTOnly() const override {return bits.alctOnly;}
+  uint16_t TMBMatch() const override {return bits.tmbMatch;}
+  uint16_t Bxn0Diff() const override {return 0;}
+  uint16_t Bxn1Diff() const override {return 0;}
+  uint16_t L1ANumber() const override {return bits.l1aNumber;}
+  uint16_t NTBins() const override {return bits.nTBins;}
+  uint16_t NCFEBs() const override {return bits.nCFEBs;}
+  void setNCFEBs(uint16_t ncfebs) override {bits.nCFEBs = ncfebs & 0x7F;}
+  uint16_t firmwareRevision() const override {return bits.firmRevCode;}
+  uint16_t syncError() const override {return bits.syncError;}
+  uint16_t syncErrorCLCT() const override {return bits.clct_sync_err;}
+  uint16_t syncErrorMPC0() const override {return bits.MPC_Muon0_SyncErr_;}
+  uint16_t syncErrorMPC1() const override {return bits.MPC_Muon1_SyncErr_;}
 
   ///returns CLCT digis
-  virtual std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer);
+  std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer) override;
   ///returns CorrelatedLCT digis
-  virtual std::vector<CSCCorrelatedLCTDigi> CorrelatedLCTDigis(uint32_t idlayer) const;
+  std::vector<CSCCorrelatedLCTDigi> CorrelatedLCTDigis(uint32_t idlayer) const override;
  
   
   /// in 16-bit words.  Add olne because we include beginning(b0c) and
   /// end (e0c) flags
-  unsigned short int sizeInWords() const     {return NWORDS;}
+  unsigned short int sizeInWords() const override     {return NWORDS;}
 
-  virtual unsigned short int NHeaderFrames() const {return bits.nHeaderFrames;}
+  unsigned short int NHeaderFrames() const override {return bits.nHeaderFrames;}
   /// returns the first data word
-  virtual unsigned short * data() {return (unsigned short *)(&bits);}
-  virtual bool check() const {return bits.e0bline==0x6e0b;}
+  unsigned short * data() override {return (unsigned short *)(&bits);}
+  bool check() const override {return bits.e0bline==0x6e0b;}
 
   /// Needed before data packing
   //void setChamberId(const CSCDetId & detId) {theChamberId = detId;}
 
   /// for data packing
-  virtual void addCLCT0(const CSCCLCTDigi & digi);
-  virtual void addCLCT1(const CSCCLCTDigi & digi);
-  virtual void addALCT0(const CSCALCTDigi & digi);
-  virtual void addALCT1(const CSCALCTDigi & digi);
-  virtual void addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi);
-  virtual void addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi);
+  void addCLCT0(const CSCCLCTDigi & digi) override;
+  void addCLCT1(const CSCCLCTDigi & digi) override;
+  void addALCT0(const CSCALCTDigi & digi) override;
+  void addALCT1(const CSCALCTDigi & digi) override;
+  void addCorrelatedLCT0(const CSCCorrelatedLCTDigi & digi) override;
+  void addCorrelatedLCT1(const CSCCorrelatedLCTDigi & digi) override;
 
   void swapCLCTs(CSCCLCTDigi& digi1, CSCCLCTDigi& digi2);
 
-  virtual void print(std::ostream & os) const;
+  void print(std::ostream & os) const override;
 
   struct {
   // 0

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBTrailer.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBTrailer.h
@@ -1,9 +1,9 @@
 #ifndef CSCTMBTrailer_h
 #define CSCTMBTrailer_h
 
-#include <string.h> // bzero
+#include <cstring> // bzero
 #include "DataFormats/CSCDigi/interface/CSCTMBStatusDigi.h"
-#include <stdint.h>
+#include <cstdint>
 
 /** Defined to begin at the 6E0C word 2006 format
 6E0C

--- a/EventFilter/CSCRawToDigi/interface/CSCVDMBHeaderFormat.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCVDMBHeaderFormat.h
@@ -3,7 +3,7 @@
 
 #include <cassert>
 #include <iosfwd>
-#include <string.h> // bzero
+#include <cstring> // bzero
 
 class CSCVDMBHeaderFormat  {
 public:

--- a/EventFilter/CSCRawToDigi/interface/CSCVDMBTrailerFormat.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCVDMBTrailerFormat.h
@@ -3,7 +3,7 @@
 
 #include <cassert>
 #include <iosfwd>
-#include <string.h> // bzero
+#include <cstring> // bzero
 
 class CSCDMBHeader;
 

--- a/EventFilter/CSCRawToDigi/interface/CSCViewDigi.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCViewDigi.h
@@ -36,13 +36,13 @@ Location: EventFilter/CSCRawToDigi/interface/CSCViewDigi.h
 class CSCViewDigi : public edm::EDAnalyzer {
    public:
       explicit CSCViewDigi(const edm::ParameterSet&);
-      ~CSCViewDigi();
+      ~CSCViewDigi() override;
 
 
    private:
 
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
 
       bool WiresDigiDump, AlctDigiDump, ClctDigiDump, CorrClctDigiDump;
       bool StripDigiDump, ComparatorDigiDump, RpcDigiDump, StatusDigiDump;

--- a/EventFilter/CSCRawToDigi/interface/DigiAnalyzer.h
+++ b/EventFilter/CSCRawToDigi/interface/DigiAnalyzer.h
@@ -27,7 +27,7 @@
 class DigiAnalyzer : public edm::EDAnalyzer {
 public:
   explicit DigiAnalyzer(edm::ParameterSet const& conf);
-  virtual void analyze(edm::Event const& e, edm::EventSetup const& iSetup);
+  void analyze(edm::Event const& e, edm::EventSetup const& iSetup) override;
 
 private:
 

--- a/EventFilter/CSCRawToDigi/plugins/CSCDCCUnpacker.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCDCCUnpacker.cc
@@ -252,21 +252,21 @@ void CSCDCCUnpacker::produce(edm::Event & e, const edm::EventSetup& c)
 
       if (length>=32)  ///if fed has data then unpack it
         {
-          CSCDCCExaminer* examiner = NULL;
+          CSCDCCExaminer* examiner = nullptr;
           goodEvent = true;
           if (useExaminer)  ///examine event for integrity
             {
               // CSCDCCExaminer examiner;
               examiner = new CSCDCCExaminer();
-              if ( examinerMask&0x40000 ) examiner->crcCFEB(1);
-              if ( examinerMask&0x8000  ) examiner->crcTMB (1);
-              if ( examinerMask&0x0400  ) examiner->crcALCT(1);
+              if ( examinerMask&0x40000 ) examiner->crcCFEB(true);
+              if ( examinerMask&0x8000  ) examiner->crcTMB (true);
+              if ( examinerMask&0x0400  ) examiner->crcALCT(true);
               examiner->setMask(examinerMask);
 
               /// If we have DCC or only DDU FED by checking FED ID set examiner to uswe DCC or DDU mode
               if ( isDDU_FED )
                 {
-                  if (examiner != NULL) examiner->modeDDU(true);
+                  if (examiner != nullptr) examiner->modeDDU(true);
                 }
 
               const short unsigned int *data = (short unsigned int *)fedData.data();
@@ -329,7 +329,7 @@ void CSCDCCUnpacker::produce(edm::Event & e, const edm::EventSetup& c)
 
 
               CSCDCCExaminer * ptrExaminer = examiner;
-              if (!useSelectiveUnpacking) ptrExaminer = NULL;
+              if (!useSelectiveUnpacking) ptrExaminer = nullptr;
 
 
 
@@ -571,7 +571,7 @@ void CSCDCCUnpacker::produce(edm::Event & e, const edm::EventSetup& c)
                         {
                           for ( icfeb = 0; icfeb < 7; ++icfeb )  ///loop over status digis
                             {
-                              if ( cscData[iCSC].cfebData(icfeb) != NULL )
+                              if ( cscData[iCSC].cfebData(icfeb) != nullptr )
                                 cfebStatusProduct->
                                 insertDigi(layer, cscData[iCSC].cfebData(icfeb)->statusDigi());
                             }
@@ -613,7 +613,7 @@ void CSCDCCUnpacker::produce(edm::Event & e, const edm::EventSetup& c)
                             }
 
 
-                          if (goodTMB && (cscData[iCSC].tmbHeader() != NULL))
+                          if (goodTMB && (cscData[iCSC].tmbHeader() != nullptr))
                             {
                               int nCFEBs = cscData[iCSC].tmbHeader()->NCFEBs();
                               for ( icfeb = 0; icfeb < nCFEBs; ++icfeb )
@@ -655,7 +655,7 @@ void CSCDCCUnpacker::produce(edm::Event & e, const edm::EventSetup& c)
               // dccStatusProduct->insertDigi(CSCDetId(1,1,1,1,1), CSCDCCStatusDigi(examiner->errors()));
               // if(instantiateDQM)  monitor->process(examiner, NULL);
             }
-          if (examiner!=NULL) delete examiner;
+          if (examiner!=nullptr) delete examiner;
         } // end of if fed has data
     } // end of loop over DCCs
   // put into the event
@@ -1436,7 +1436,7 @@ void CSCDCCUnpacker::visual_raw(int hl,int id, int run, int event,bool fedshort,
        */
       std::cout << "Line: " << "    " << alct_t1_coll[k] << " " << sign1 << " " << alct_common << " " <<
                 alct_common_wcnt1 << " " << alct_wcnt1_coll[k] << " " << alct_common_wcnt2 << " ";
-      if (alct_wcnt2_coll.size()>0)
+      if (!alct_wcnt2_coll.empty())
         {
           std::cout << alct_wcnt2_coll[k] << std::endl;
         }

--- a/EventFilter/CSCRawToDigi/src/CSCALCTHeader2006.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCALCTHeader2006.cc
@@ -67,7 +67,7 @@ std::vector<CSCALCTDigi> CSCALCTs2006::ALCTDigis() const
 void CSCALCTs2006::add(const std::vector<CSCALCTDigi> & digis)
 {
   //FIXME doesn't do any sorting
-  if(digis.size() > 0) addALCT0(digis[0]);
+  if(!digis.empty()) addALCT0(digis[0]);
   if(digis.size() > 1) addALCT1(digis[1]);
 }
 

--- a/EventFilter/CSCRawToDigi/src/CSCAnodeData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCAnodeData.cc
@@ -3,7 +3,7 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCAnodeData2006.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCAnodeData2007.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <string.h> // for bzero
+#include <cstring> // for bzero
 
 
 

--- a/EventFilter/CSCRawToDigi/src/CSCAnodeData2006.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCAnodeData2006.cc
@@ -1,7 +1,7 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCAnodeData2006.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCALCTHeader.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <string.h> // for bzero
+#include <cstring> // for bzero
 #include <iostream>
 
 CSCAnodeDataFrame2006::CSCAnodeDataFrame2006(unsigned chip, unsigned tbin, unsigned data)

--- a/EventFilter/CSCRawToDigi/src/CSCAnodeData2007.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCAnodeData2007.cc
@@ -1,7 +1,7 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCAnodeData2007.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCALCTHeader.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <string.h> // for bzero
+#include <cstring> // for bzero
 #include<iostream>
 
 CSCAnodeData2007::CSCAnodeData2007(const CSCALCTHeader & header)

--- a/EventFilter/CSCRawToDigi/src/CSCBadCFEBTimeSlice.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCBadCFEBTimeSlice.cc
@@ -1,5 +1,5 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCBadCFEBTimeSlice.h"
-#include<assert.h>
+#include<cassert>
 
 CSCBadCFEBWord & CSCBadCFEBTimeSlice::word(int i) 
 {

--- a/EventFilter/CSCRawToDigi/src/CSCCFEBData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCCFEBData.cc
@@ -91,7 +91,7 @@ void CSCCFEBData::add(const CSCStripDigi & digi, int layer)
       unsigned value = scaCounts[itime] & 0xFFF; // 12-bit
       // assume it's good, since we're working with simulation
       const CSCCFEBTimeSlice * slice = timeSlice(itime);
-      assert(slice != 0);
+      assert(slice != nullptr);
       slice->timeSample(layer, channel,fDCFEB)->adcCounts = value;
       /// =VB= Set CRC value for simulated data
       ((CSCCFEBTimeSlice *)slice)->setCRC();
@@ -106,7 +106,7 @@ const CSCCFEBTimeSlice * CSCCFEBData::timeSlice(unsigned i) const
   // give a NULL pointer if this is a bad slice
   if(!start.second) 
     {
-      result = 0;
+      result = nullptr;
     } 
   else 
     {
@@ -324,7 +324,7 @@ bool CSCCFEBData::check() const
   for(unsigned i = 0; i < theNumberOfSamples; ++i) 
     {
       const CSCCFEBTimeSlice * slice = timeSlice(i);
-      if(slice==0 || !timeSlice(i)->check()) result = false;
+      if(slice==nullptr || !timeSlice(i)->check()) result = false;
     }
   return result;
 }

--- a/EventFilter/CSCRawToDigi/src/CSCCFEBTimeSlice.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCCFEBTimeSlice.cc
@@ -1,7 +1,7 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCCFEBTimeSlice.h"
 #include <cassert>
 #include <iomanip>
-#include <stdint.h>
+#include <cstdint>
 
 // a Gray code is An ordering of 2n binary numbers such that
 // only one bit changes from one entry to the next

--- a/EventFilter/CSCRawToDigi/src/CSCCLCTData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCCLCTData.cc
@@ -17,7 +17,7 @@ std::atomic<bool> CSCCLCTData::debug {false};
 CSCCLCTData::CSCCLCTData(const CSCTMBHeader * tmbHeader)
     : ncfebs_(tmbHeader->NCFEBs()), ntbins_(tmbHeader->NTBins())
 {
-  if (tmbHeader != NULL)  theFirmwareVersion = tmbHeader->FirmwareVersion();
+  if (tmbHeader != nullptr)  theFirmwareVersion = tmbHeader->FirmwareVersion();
   else theFirmwareVersion = 2007;
   size_ = nlines();
   zero();

--- a/EventFilter/CSCRawToDigi/src/CSCChamberDataItr.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCChamberDataItr.cc
@@ -2,7 +2,7 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCDCCEventData.h"
 
 CSCChamberDataItr::CSCChamberDataItr(const char * buf) :
-  theDCCData(0),
+  theDCCData(nullptr),
   theCurrentDDU(0)
 {
   // first try if it's DCC data.
@@ -42,7 +42,7 @@ bool CSCChamberDataItr::next()
       else
 	{
 	  // the next DDU exists, so initialize an itr
-	  assert(theDCCData != 0);
+	  assert(theDCCData != nullptr);
 	  delete theDDUItr;
 	  theDDUItr = new CSCDDUDataItr( &(theDCCData->dduData()[theCurrentDDU]) );
 	}

--- a/EventFilter/CSCRawToDigi/src/CSCDCCExaminer.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDCCExaminer.cc
@@ -1817,7 +1817,7 @@ void CSCDCCExaminer::checkTriggerHeadersAndTrailers()
       ALCT_WordsSinceLastHeaderZeroSuppressed =0;
       ALCT_WordsSinceLastHeader = 0;
       ALCT_WordsExpected        = 0;
-      fALCT_Header = 0;
+      fALCT_Header = false;
     }
 
   if(fTMB_Header)

--- a/EventFilter/CSCRawToDigi/src/CSCDDUDataItr.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDDUDataItr.cc
@@ -6,7 +6,7 @@
 // theCurrentCSC starts at -1, since user is expected to next() before he dereferences
 // for the first time
 CSCDDUDataItr::CSCDDUDataItr() :
-  theDDUData(0),
+  theDDUData(nullptr),
   theCurrentCSC(-1),
   theNumberOfCSCs(0),
   theDataIsOwnedByMe(true)
@@ -14,7 +14,7 @@ CSCDDUDataItr::CSCDDUDataItr() :
 
 
 CSCDDUDataItr::CSCDDUDataItr(const char * buf) :
-  theDDUData(0),
+  theDDUData(nullptr),
   theCurrentCSC(-1),
   theNumberOfCSCs(0),
   theDataIsOwnedByMe(true)
@@ -53,7 +53,7 @@ CSCDDUDataItr::CSCDDUDataItr(const CSCDDUDataItr & i) :
 {
   if(theDataIsOwnedByMe) 
     {
-      if(i.theDDUData != 0) 
+      if(i.theDDUData != nullptr) 
 	{
 	  theDDUData = new CSCDDUEventData(*(i.theDDUData));
 	}
@@ -70,7 +70,7 @@ void CSCDDUDataItr::operator=(const CSCDDUDataItr & i)
   if(theDataIsOwnedByMe) 
     {
       delete theDDUData;
-      if(i.theDDUData != 0) 
+      if(i.theDDUData != nullptr) 
 	{
 	  theDDUData = new CSCDDUEventData(*(i.theDDUData));
 	}

--- a/EventFilter/CSCRawToDigi/src/CSCDDUEventData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDDUEventData.cc
@@ -206,7 +206,7 @@ void CSCDDUEventData::unpack_data(uint16_t *buf, CSCDCCExaminer* examiner)
   theData.clear();
   theData.reserve(theDDUHeader.ncsc());
 
-  if (examiner!= NULL) { // Use selective unpacking mode
+  if (examiner!= nullptr) { // Use selective unpacking mode
 
     if (debug) LogTrace ("CSCDDUEventData|CSCRawToDigi") << "selective unpacking starting";
 

--- a/EventFilter/CSCRawToDigi/src/CSCDDUHeader.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDDUHeader.cc
@@ -1,5 +1,5 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCDDUHeader.h"
-#include <string.h> // for bzero
+#include <cstring> // for bzero
 #include <iostream>
 
 CSCDDUHeader::CSCDDUHeader() 

--- a/EventFilter/CSCRawToDigi/src/CSCDMBHeader.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDMBHeader.cc
@@ -29,7 +29,7 @@ CSCDMBHeader::CSCDMBHeader(unsigned short * buf, uint16_t firmware_version)
 
 CSCDMBHeader2005 CSCDMBHeader::dmbHeader2005()   const {
   CSCDMBHeader2005 * result = dynamic_cast<CSCDMBHeader2005 *>(theHeaderFormat.get());
-  if(result == 0)
+  if(result == nullptr)
   {
     throw cms::Exception("Could not get 2005 DMB header format");
   }
@@ -39,7 +39,7 @@ CSCDMBHeader2005 CSCDMBHeader::dmbHeader2005()   const {
 
 CSCDMBHeader2013 CSCDMBHeader::dmbHeader2013()   const {
   CSCDMBHeader2013 * result = dynamic_cast<CSCDMBHeader2013 *>(theHeaderFormat.get());
-  if(result == 0)
+  if(result == nullptr)
   {
     throw cms::Exception("Could not get 2013 DMB header format");
   }

--- a/EventFilter/CSCRawToDigi/src/CSCDMBTrailer.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDMBTrailer.cc
@@ -29,7 +29,7 @@ CSCDMBTrailer::CSCDMBTrailer(unsigned short * buf, uint16_t firmware_version)
 
 CSCDMBTrailer2005 CSCDMBTrailer::dmbTrailer2005()   const {
   CSCDMBTrailer2005 * result = dynamic_cast<CSCDMBTrailer2005 *>(theTrailerFormat.get());
-  if(result == 0)
+  if(result == nullptr)
   {
     throw cms::Exception("Could not get 2005 DMB trailer format");
   }
@@ -39,7 +39,7 @@ CSCDMBTrailer2005 CSCDMBTrailer::dmbTrailer2005()   const {
 
 CSCDMBTrailer2013 CSCDMBTrailer::dmbTrailer2013()   const {
   CSCDMBTrailer2013 * result = dynamic_cast<CSCDMBTrailer2013 *>(theTrailerFormat.get());
-  if(result == 0)
+  if(result == nullptr)
   {
     throw cms::Exception("Could not get 2013 DMB trailer format");
   }

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToPattern.h
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToPattern.h
@@ -16,7 +16,7 @@
 class CSCDigiToPattern : public edm::EDAnalyzer {
 public:
   explicit CSCDigiToPattern(edm::ParameterSet const& conf);
-  virtual void analyze(edm::Event const& e, edm::EventSetup const& iSetup);
+  void analyze(edm::Event const& e, edm::EventSetup const& iSetup) override;
 
   //virtual void endJob();
 private:

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRawModule.h
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRawModule.h
@@ -32,10 +32,10 @@ class CSCDigiToRawModule : public edm::EDProducer {
   CSCDigiToRawModule(const edm::ParameterSet & pset);
 
   /// Destructor
-  virtual ~CSCDigiToRawModule();
+  ~CSCDigiToRawModule() override;
 
   // Operations
-  virtual void produce( edm::Event&, const edm::EventSetup& );
+  void produce( edm::Event&, const edm::EventSetup& ) override;
 
   // Fill parameters descriptions
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);

--- a/EventFilter/CSCRawToDigi/src/CSCEventData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCEventData.cc
@@ -17,20 +17,20 @@ std::atomic<bool> CSCEventData::debug{false};
 
 CSCEventData::CSCEventData(int chamberType, uint16_t format_version) :
     theDMBHeader(format_version),
-    theALCTHeader(0),
-    theAnodeData(0),
-    theALCTTrailer(0),
-    theTMBData(0),
+    theALCTHeader(nullptr),
+    theAnodeData(nullptr),
+    theALCTTrailer(nullptr),
+    theTMBData(nullptr),
     theDMBTrailer(format_version),
     theChamberType(chamberType),
-    alctZSErecovered(0),
+    alctZSErecovered(nullptr),
     zseEnable(0),
     theFormatVersion(format_version)
 {
 
   for (unsigned i = 0; i < MAX_CFEB; ++i)
     {
-      theCFEBData[i] = 0;
+      theCFEBData[i] = nullptr;
     }
 }
 
@@ -255,7 +255,7 @@ void CSCEventData::unpack_data(unsigned short * buf)
     {
       for (int icfeb = 0; icfeb < MAX_CFEB; ++icfeb)
         {
-          theCFEBData[icfeb] = 0;
+          theCFEBData[icfeb] = nullptr;
           int cfeb_available = theDMBHeader.cfebAvailable(icfeb);
           unsigned int cfebTimeout = theDMBTrailer.cfeb_starttimeout() | theDMBTrailer.cfeb_endtimeout();
           //cfeb_available cannot be trusted - need additional verification!
@@ -325,15 +325,15 @@ CSCEventData CSCEventData::operator=(const CSCEventData & data)
 void CSCEventData::init()
 {
   //dataPresent = 0;
-  theALCTHeader = 0;
-  theAnodeData = 0;
-  theALCTTrailer = 0;
-  theTMBData = 0;
+  theALCTHeader = nullptr;
+  theAnodeData = nullptr;
+  theALCTTrailer = nullptr;
+  theTMBData = nullptr;
   for (int icfeb = 0; icfeb < MAX_CFEB; ++icfeb)
     {
-      theCFEBData[icfeb] = 0;
+      theCFEBData[icfeb] = nullptr;
     }
-  alctZSErecovered=0;
+  alctZSErecovered=nullptr;
   zseEnable=0;
 }
 
@@ -344,18 +344,18 @@ void CSCEventData::copy(const CSCEventData & data)
   theFormatVersion = data.theFormatVersion;
   theDMBHeader  = data.theDMBHeader;
   theDMBTrailer = data.theDMBTrailer;
-  if (data.theALCTHeader != NULL)
+  if (data.theALCTHeader != nullptr)
     theALCTHeader  = new CSCALCTHeader(*(data.theALCTHeader));
-  if (data.theAnodeData != NULL)
+  if (data.theAnodeData != nullptr)
     theAnodeData   = new CSCAnodeData(*(data.theAnodeData));
-  if (data.theALCTTrailer != NULL)
+  if (data.theALCTTrailer != nullptr)
     theALCTTrailer = new CSCALCTTrailer(*(data.theALCTTrailer));
-  if (data.theTMBData != NULL)
+  if (data.theTMBData != nullptr)
     theTMBData     = new CSCTMBData(*(data.theTMBData));
   for (int icfeb = 0; icfeb < MAX_CFEB; ++icfeb)
     {
-      theCFEBData[icfeb] = 0;
-      if (data.theCFEBData[icfeb] != NULL)
+      theCFEBData[icfeb] = nullptr;
+      if (data.theCFEBData[icfeb] != nullptr)
         theCFEBData[icfeb] = new CSCCFEBData(*(data.theCFEBData[icfeb]));
     }
   size_  = data.size_;
@@ -403,7 +403,7 @@ std::vector<CSCStripDigi> CSCEventData::stripDigis(unsigned idlayer, unsigned ic
 {
   //  assert(ilayer > 0 && ilayer <= 6); // off because now idlayer is raw cscdetid
   std::vector<CSCStripDigi> result;
-  if (theCFEBData[icfeb] != NULL)
+  if (theCFEBData[icfeb] != nullptr)
     {
       std::vector<CSCStripDigi> newDigis = theCFEBData[icfeb]->digis(idlayer);
       result.insert(result.end(), newDigis.begin(), newDigis.end());
@@ -415,7 +415,7 @@ std::vector<CSCStripDigi> CSCEventData::stripDigis(unsigned idlayer, unsigned ic
 
 std::vector<CSCWireDigi> CSCEventData::wireDigis(unsigned ilayer) const
 {
-  if (theAnodeData == 0)
+  if (theAnodeData == nullptr)
     {
       return std::vector<CSCWireDigi>();
     }
@@ -482,13 +482,13 @@ CSCTMBData * CSCEventData::tmbData() const
 
 CSCTMBHeader * CSCEventData::tmbHeader() const
 {
-  if ((nclct() == 0)||(tmbData()==NULL)) throw cms::Exception("No CLCT header for this chamber");
+  if ((nclct() == 0)||(tmbData()==nullptr)) throw cms::Exception("No CLCT header for this chamber");
   return tmbData()->tmbHeader();
 }
 
 CSCCLCTData * CSCEventData::clctData() const
 {
-  if ((nclct() == 0)||(tmbData()==NULL)) throw cms::Exception("No CLCT data for this chamber");
+  if ((nclct() == 0)||(tmbData()==nullptr)) throw cms::Exception("No CLCT data for this chamber");
   return tmbData()->clctData();
 }
 
@@ -531,7 +531,7 @@ void CSCEventData::setEventInformation(int bxnum, int lvl1num)
 
 void CSCEventData::checkALCTClasses()
 {
-  if (theAnodeData == NULL)
+  if (theAnodeData == nullptr)
     {
       assert(theChamberType>0);
       theALCTHeader = new CSCALCTHeader(theChamberType);
@@ -551,7 +551,7 @@ void CSCEventData::checkTMBClasses()
   if ((theFormatVersion  == 2013) && ((theChamberType == 1) || (theChamberType == 2)) ) {
       nCFEBs = 7;
   }
-  if (theTMBData == NULL)
+  if (theTMBData == nullptr)
     {
       if (theFormatVersion  == 2013) { // Set to TMB format for Post-LS1 data
         theTMBData = new CSCTMBData(2013, 0x7a76, nCFEBs);
@@ -572,7 +572,7 @@ void CSCEventData::add(const CSCStripDigi & digi, int layer)
   unsigned cfeb = (digi.getStrip()-1)/16;
   bool sixteenSamples = false;
   if (digi.getADCCounts().size()==16) sixteenSamples = true;
-  if (theCFEBData[cfeb] == 0)
+  if (theCFEBData[cfeb] == nullptr)
     {
       bool isDCFEB = false;
       if (theDMBHeader.format_version() == 2) isDCFEB = true;
@@ -653,13 +653,13 @@ boost::dynamic_bitset<> CSCEventData::pack()
   // Container for CRC calculations
   std::vector<std::pair<unsigned int, unsigned short*> > crcvec;
 
-  if (theALCTHeader != NULL)
+  if (theALCTHeader != nullptr)
     {
       boost::dynamic_bitset<> alctHeader = theALCTHeader->pack();
       result = bitset_utilities::append(result, alctHeader);
       crcvec.push_back(std::make_pair(theALCTHeader->sizeInWords(), theALCTHeader->data()));
     }
-  if (theAnodeData != NULL)
+  if (theAnodeData != nullptr)
     {
       boost::dynamic_bitset<> anodeData = bitset_utilities::ushortToBitset (theAnodeData->sizeInWords()*16,
                                           theAnodeData->data());
@@ -667,7 +667,7 @@ boost::dynamic_bitset<> CSCEventData::pack()
       crcvec.push_back(std::make_pair(theAnodeData->sizeInWords(), theAnodeData->data()));
 
     }
-  if (theALCTTrailer != NULL)
+  if (theALCTTrailer != nullptr)
     {
       unsigned int crc = calcALCTcrc(crcvec);
       theALCTTrailer->setCRC(crc);
@@ -676,14 +676,14 @@ boost::dynamic_bitset<> CSCEventData::pack()
       result = bitset_utilities::append(result, alctTrailer);
 
     }
-  if (theTMBData != NULL)
+  if (theTMBData != nullptr)
     {
       result  = bitset_utilities::append(result, theTMBData->pack());
     }
 
   for (int icfeb = 0;  icfeb < MAX_CFEB;  ++icfeb)
     {
-      if (theCFEBData[icfeb] != NULL)
+      if (theCFEBData[icfeb] != nullptr)
         {
           boost::dynamic_bitset<> cfebData = bitset_utilities::ushortToBitset(theCFEBData[icfeb]->sizeInWords()*16,
                                              theCFEBData[icfeb]->data());
@@ -708,7 +708,7 @@ unsigned int CSCEventData::calcALCTcrc(std::vector< std::pair<unsigned int, unsi
       for (uint16_t j=0, w=0; j<vec[n].first; j++ )
         {
 	 
-          if (vec[n].second != NULL) { 
+          if (vec[n].second != nullptr) { 
           w = vec[n].second[j] & 0xffff;
           for (uint32_t i=15, t=0, ncrc=0; i<16; i--)
             {

--- a/EventFilter/CSCRawToDigi/src/CSCTMBBlockedCFEB.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBBlockedCFEB.cc
@@ -137,7 +137,7 @@ void CSCTMBBlockedCFEB::print() const
         {
           anyLayer=*layerIt;
           std::cout << " Layer: " << LayerCnt;
-          if (anyLayer.size() !=0)
+          if (!anyLayer.empty())
             {
               for (int i=0; i<(int)anyLayer.size(); i++)
                 {

--- a/EventFilter/CSCRawToDigi/src/CSCTMBData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBData.cc
@@ -19,17 +19,17 @@ std::atomic<bool> CSCTMBData::debug{false};
 #endif
 
 CSCTMBData::CSCTMBData() 
-  : theOriginalBuffer(0), 
+  : theOriginalBuffer(nullptr), 
     theB0CLine( 0 ),
     theE0FLine( 0 ),
     theTMBHeader(2007, 0x50c3),
     theCLCTData(&theTMBHeader),
     theTMBScopeIsPresent(false), 
-    theTMBScope(0),
+    theTMBScope(nullptr),
     theTMBMiniScopeIsPresent(false), 
-    theTMBMiniScope(0),
+    theTMBMiniScope(nullptr),
     theBlockedCFEBIsPresent(false),
-    theTMBBlockedCFEB(0),
+    theTMBBlockedCFEB(nullptr),
     theTMBTrailer(theTMBHeader.sizeInWords()+theCLCTData.sizeInWords(), 2007),
     size_( 0 ), 
     cWordCnt( 0 ),
@@ -40,17 +40,17 @@ CSCTMBData::CSCTMBData()
 }
 
 CSCTMBData::CSCTMBData(int firmwareVersion, int firmwareRevision, int cfebs)
-  : theOriginalBuffer(0),
+  : theOriginalBuffer(nullptr),
     theB0CLine( 0 ),
     theE0FLine( 0 ),
     theTMBHeader(firmwareVersion, firmwareRevision),
     theCLCTData(&theTMBHeader),
     theTMBScopeIsPresent(false),
-    theTMBScope(0),
+    theTMBScope(nullptr),
     theTMBMiniScopeIsPresent(false),
-    theTMBMiniScope(0),
+    theTMBMiniScope(nullptr),
     theBlockedCFEBIsPresent(false),
-    theTMBBlockedCFEB(0),
+    theTMBBlockedCFEB(nullptr),
     theTMBTrailer(theTMBHeader.sizeInWords()+theCLCTData.sizeInWords(), firmwareVersion),
     size_( 0 ),
     cWordCnt( 0 ),
@@ -69,11 +69,11 @@ CSCTMBData::CSCTMBData(unsigned short *buf)
     theTMBHeader(2007, 0x50c3),
     theCLCTData(&theTMBHeader),
     theTMBScopeIsPresent(false), 
-    theTMBScope(0), 
+    theTMBScope(nullptr), 
     theTMBMiniScopeIsPresent(false), 
-    theTMBMiniScope(0), 
+    theTMBMiniScope(nullptr), 
     theBlockedCFEBIsPresent(false),
-    theTMBBlockedCFEB(0),
+    theTMBBlockedCFEB(nullptr),
     theTMBTrailer(theTMBHeader.sizeInWords()+theCLCTData.sizeInWords(), 2007),
     theRPCDataIsPresent(false){
   size_ = UnpackTMB(buf);
@@ -97,21 +97,21 @@ CSCTMBData::CSCTMBData(const CSCTMBData& data):
     theTMBScope = new CSCTMBScope(*(data.theTMBScope));
   }
   else {
-    theTMBScope = 0;
+    theTMBScope = nullptr;
   }
   
   if (theTMBMiniScopeIsPresent) {
     theTMBMiniScope = new CSCTMBMiniScope(*(data.theTMBMiniScope));
   }
   else {
-    theTMBMiniScope = 0;
+    theTMBMiniScope = nullptr;
   }
   
   if (theBlockedCFEBIsPresent) {
      theTMBBlockedCFEB = new CSCTMBBlockedCFEB(*(data.theTMBBlockedCFEB));
   }
   else {
-    theTMBBlockedCFEB = 0;
+    theTMBBlockedCFEB = nullptr;
   }
   
 }
@@ -151,7 +151,7 @@ int CSCTMBData::TMBCRCcalc() {
     theTotalTMBData[i] = std::bitset<16>(theOriginalBuffer[line]);
     ++i;
   }
-  if ( theTotalTMBData.size() > 0 )   {
+  if ( !theTotalTMBData.empty() )   {
     std::bitset<22> CRC=calCRC22(theTotalTMBData);
     LogTrace("CSCTMBData|CSCRawToDigi") << " Test here " << CRC.to_ulong();
     return CRC.to_ulong();

--- a/EventFilter/CSCRawToDigi/src/CSCTMBHeader.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBHeader.cc
@@ -8,8 +8,8 @@
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <math.h>
-#include <string.h> // memcpy
+#include <cmath>
+#include <cstring> // memcpy
 
 #ifdef LOCAL_UNPACK
 bool CSCTMBHeader::debug = false;
@@ -142,7 +142,7 @@ void CSCTMBHeader::swapCLCTs(CSCCLCTDigi& digi1, CSCCLCTDigi& digi2)
 void CSCTMBHeader::add(const std::vector<CSCCLCTDigi> & digis)
 {
   // sort???
-  if(digis.size() > 0) { 
+  if(!digis.empty()) { 
 	addCLCT0(digis[0]); 
         
   }
@@ -152,7 +152,7 @@ void CSCTMBHeader::add(const std::vector<CSCCLCTDigi> & digis)
 void CSCTMBHeader::add(const std::vector<CSCCorrelatedLCTDigi> & digis)
 {
   // sort???
-  if(digis.size() > 0) addCorrelatedLCT0(digis[0]);
+  if(!digis.empty()) addCorrelatedLCT0(digis[0]);
   if(digis.size() > 1) addCorrelatedLCT1(digis[1]);
 }
 
@@ -160,7 +160,7 @@ void CSCTMBHeader::add(const std::vector<CSCCorrelatedLCTDigi> & digis)
 CSCTMBHeader2007 CSCTMBHeader::tmbHeader2007()   const
 {
   CSCTMBHeader2007 * result = dynamic_cast<CSCTMBHeader2007 *>(theHeaderFormat.get());
-  if(result == 0)
+  if(result == nullptr)
     {
       throw cms::Exception("Could not get 2007 TMB header format");
     }
@@ -170,7 +170,7 @@ CSCTMBHeader2007 CSCTMBHeader::tmbHeader2007()   const
 CSCTMBHeader2007_rev0x50c3 CSCTMBHeader::tmbHeader2007_rev0x50c3()   const
 {
   CSCTMBHeader2007_rev0x50c3 * result = dynamic_cast<CSCTMBHeader2007_rev0x50c3 *>(theHeaderFormat.get());
-  if(result == 0)
+  if(result == nullptr)
     {
       throw cms::Exception("Could not get 2007 rev0x50c3 TMB header format");
     }
@@ -180,7 +180,7 @@ CSCTMBHeader2007_rev0x50c3 CSCTMBHeader::tmbHeader2007_rev0x50c3()   const
 CSCTMBHeader2013 CSCTMBHeader::tmbHeader2013()   const
 {
   CSCTMBHeader2013 * result = dynamic_cast<CSCTMBHeader2013 *>(theHeaderFormat.get());
-  if(result == 0)
+  if(result == nullptr)
     {
       throw cms::Exception("Could not get 2013 TMB header format");
     }
@@ -191,7 +191,7 @@ CSCTMBHeader2013 CSCTMBHeader::tmbHeader2013()   const
 CSCTMBHeader2006 CSCTMBHeader::tmbHeader2006()   const
 {
   CSCTMBHeader2006 * result = dynamic_cast<CSCTMBHeader2006 *>(theHeaderFormat.get());
-  if(result == 0)
+  if(result == nullptr)
     {
       throw cms::Exception("Could not get 2006 TMB header format");
     }

--- a/EventFilter/CSCTFRawToDigi/interface/CSCTFAnalyzer.h
+++ b/EventFilter/CSCTFRawToDigi/interface/CSCTFAnalyzer.h
@@ -32,10 +32,10 @@ private:
 
 
 public:
-	void analyze(const edm::Event& e, const edm::EventSetup& c);
+	void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 	explicit CSCTFAnalyzer(const edm::ParameterSet &conf);
-	~CSCTFAnalyzer(void){ file->cd(); tree->Write(); file->Close(); }
+	~CSCTFAnalyzer(void) override{ file->cd(); tree->Write(); file->Close(); }
 };
 
 #endif

--- a/EventFilter/CSCTFRawToDigi/interface/CSCTFPacker.h
+++ b/EventFilter/CSCTFRawToDigi/interface/CSCTFPacker.h
@@ -35,10 +35,10 @@ private:
 	edm::EDGetTokenT<L1CSCTrackCollection> L1CSCTr_Tok;
 
 public:
-	virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
+	void produce(edm::Event& e, const edm::EventSetup& c) override;
 
 	explicit CSCTFPacker(const edm::ParameterSet &conf);
-	~CSCTFPacker(void);
+	~CSCTFPacker(void) override;
 };
 
 #endif

--- a/EventFilter/CSCTFRawToDigi/interface/CSCTFUnpacker.h
+++ b/EventFilter/CSCTFRawToDigi/interface/CSCTFUnpacker.h
@@ -39,10 +39,10 @@ private:
 	edm::EDGetTokenT<FEDRawDataCollection> Raw_token;
 
 public:
-	void produce(edm::Event& e, const edm::EventSetup& c);
+	void produce(edm::Event& e, const edm::EventSetup& c) override;
 
 	CSCTFUnpacker(const edm::ParameterSet& pset);
-	~CSCTFUnpacker(void);
+	~CSCTFUnpacker(void) override;
 };
 
 #endif

--- a/EventFilter/CSCTFRawToDigi/plugins/CSCTFAnalyzer.cc
+++ b/EventFilter/CSCTFRawToDigi/plugins/CSCTFAnalyzer.cc
@@ -3,7 +3,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <strings.h>
-#include <errno.h>
+#include <cerrno>
 #include <iostream>
 #include <iomanip>
 

--- a/EventFilter/CSCTFRawToDigi/plugins/CSCTFPacker.cc
+++ b/EventFilter/CSCTFRawToDigi/plugins/CSCTFPacker.cc
@@ -2,7 +2,7 @@
 #include "EventFilter/CSCTFRawToDigi/src/CSCTFEvent.h"
 
 #include <strings.h>
-#include <errno.h>
+#include <cerrno>
 #include <iostream>
 #include <cstdio>
 
@@ -36,8 +36,8 @@ CSCTFPacker::CSCTFPacker(const edm::ParameterSet &conf):edm::one::EDProducer<>()
 	// Swap: if(swapME1strips && me1b && !zplus) strip = 65 - strip; // 1-64 -> 64-1 :
 	swapME1strips = conf.getParameter<bool>("swapME1strips");
 
-	file = 0;
-	if( outputFile.length() && (file = fopen(outputFile.c_str(),"wt"))==NULL )
+	file = nullptr;
+	if( outputFile.length() && (file = fopen(outputFile.c_str(),"wt"))==nullptr )
 		throw cms::Exception("OutputFile ")<<"CSCTFPacker: cannot open output file (errno="<<errno<<"). Try outputFile=\"\"";
 
 	// BX window bounds in CMSSW:

--- a/EventFilter/CSCTFRawToDigi/plugins/CSCTFUnpacker.cc
+++ b/EventFilter/CSCTFRawToDigi/plugins/CSCTFUnpacker.cc
@@ -31,7 +31,7 @@
 //#include <iostream>
 #include <sstream>
 
-CSCTFUnpacker::CSCTFUnpacker(const edm::ParameterSet& pset):edm::stream::EDProducer<>(),mapping(0){
+CSCTFUnpacker::CSCTFUnpacker(const edm::ParameterSet& pset):edm::stream::EDProducer<>(),mapping(nullptr){
 	LogDebug("CSCTFUnpacker|ctor")<<"Started ...";
 
 	// Edges of the time window, which LCTs are put into (unlike tracks, which are always centred around 0):
@@ -136,7 +136,7 @@ void CSCTFUnpacker::produce(edm::Event& e, const edm::EventSetup& c){
 					for(unsigned int FPGA=0; FPGA<5; FPGA++)
 						for(unsigned int MPClink=0; MPClink<3; ++MPClink){
 							std::vector<CSCSP_MEblock> lct = sp->record(tbin).LCT(FPGA,MPClink);
-							if( lct.size()==0 ) continue;
+							if( lct.empty() ) continue;
 
 							status.link_status[lct[0].spInput()] |=
 								(1<<lct[0].receiver_status_frame1())|

--- a/EventFilter/CSCTFRawToDigi/src/CSCSPHeader.h
+++ b/EventFilter/CSCTFRawToDigi/src/CSCSPHeader.h
@@ -1,7 +1,7 @@
 #ifndef CSCSPHeader_h
 #define CSCSPHeader_h
 
-#include <string.h> // memcpy
+#include <cstring> // memcpy
 
 class CSCSPHeader {
 private:

--- a/EventFilter/CSCTFRawToDigi/src/CSCSPRecord.cc
+++ b/EventFilter/CSCTFRawToDigi/src/CSCSPRecord.cc
@@ -1,4 +1,4 @@
-#include <string.h>      // memcpy, bzero
+#include <cstring>      // memcpy, bzero
 #include "EventFilter/CSCTFRawToDigi/src/CSCSPRecord.h"
 #include "EventFilter/CSCTFRawToDigi/src/CSCSPHeader.h"
 

--- a/EventFilter/CSCTFRawToDigi/src/CSCTFEvent.cc
+++ b/EventFilter/CSCTFRawToDigi/src/CSCTFEvent.cc
@@ -1,6 +1,6 @@
 #include "EventFilter/CSCTFRawToDigi/src/CSCTFEvent.h"
 #include "EventFilter/CSCTFRawToDigi/src/CSCSPHeader.h"
-#include <string.h>
+#include <cstring>
 #include <stdexcept>
 
 unsigned int CSCTFEvent::unpack(const unsigned short *buf, unsigned int length) {

--- a/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelRawToDigi.h
+++ b/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelRawToDigi.h
@@ -26,10 +26,10 @@ public:
 
   explicit CTPPSPixelRawToDigi( const edm::ParameterSet& );
 
-  virtual ~CTPPSPixelRawToDigi();
+  ~CTPPSPixelRawToDigi() override;
 
   /// get data, convert to digis attach againe to Event
-  virtual void produce( edm::Event&, const edm::EventSetup& ) override;
+  void produce( edm::Event&, const edm::EventSetup& ) override;
 
 private:
 

--- a/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
@@ -12,7 +12,7 @@
 
 #include <vector>
 #include <cstddef>
-#include <stdint.h>
+#include <cstdint>
 
 #include "EventFilter/CTPPSRawToDigi/interface/VFATFrame.h" 
 
@@ -24,9 +24,9 @@ class DiamondVFATFrame : public VFATFrame
 {
   
   public:
-    DiamondVFATFrame(const word* inputData = NULL)
+    DiamondVFATFrame(const word* inputData = nullptr)
     {}
-    virtual ~DiamondVFATFrame() {}
+    ~DiamondVFATFrame() override {}
 
     /// get timing infromation
     uint32_t getLeadingEdgeTime() const

--- a/EventFilter/CTPPSRawToDigi/interface/SimpleVFATFrameCollection.h
+++ b/EventFilter/CTPPSRawToDigi/interface/SimpleVFATFrameCollection.h
@@ -25,25 +25,25 @@ class SimpleVFATFrameCollection : public VFATFrameCollection
 
     MapType data;
 
-    virtual value_type BeginIterator() const;
-    virtual value_type NextIterator(const value_type&) const;
-    virtual bool IsEndIterator(const value_type&) const;
+    value_type BeginIterator() const override;
+    value_type NextIterator(const value_type&) const override;
+    bool IsEndIterator(const value_type&) const override;
 
   public:
     SimpleVFATFrameCollection();
-    ~SimpleVFATFrameCollection();
+    ~SimpleVFATFrameCollection() override;
 
-    const VFATFrame* GetFrameByID(unsigned int ID) const;
-    const VFATFrame* GetFrameByIndex(TotemFramePosition index) const;
+    const VFATFrame* GetFrameByID(unsigned int ID) const override;
+    const VFATFrame* GetFrameByIndex(TotemFramePosition index) const override;
 
-    virtual unsigned int Size() const
+    unsigned int Size() const override
     {
       return data.size();
     }
 
-    virtual bool Empty() const
+    bool Empty() const override
     {
-      return (data.size() == 0);
+      return (data.empty());
     }
 
     void Insert(const TotemFramePosition &index, const VFATFrame &frame)

--- a/EventFilter/CTPPSRawToDigi/interface/VFATFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/VFATFrame.h
@@ -11,7 +11,7 @@
 
 #include <vector>
 #include <cstddef>
-#include <stdint.h>
+#include <cstdint>
 
 /**
  * Representation of VFAT frame plus extra info added by DAQ.
@@ -21,7 +21,7 @@ class VFATFrame
   public:
     typedef uint16_t word;
   public:
-    VFATFrame(const word* _data = NULL);
+    VFATFrame(const word* _data = nullptr);
 
     VFATFrame(const VFATFrame& copy)
     {
@@ -141,7 +141,7 @@ class VFATFrame
     /// Returns positive number if it was active, 0 otherwise.
     virtual bool channelActive(unsigned char channel) const
     {
-      return ( data[1 + (channel / 16)] & (1 << (channel % 16)) ) ? 1 : 0;
+      return ( data[1 + (channel / 16)] & (1 << (channel % 16)) ) ? true : false;
     }
 
     /// Returns list  of active channels.

--- a/EventFilter/CTPPSRawToDigi/interface/VFATFrameCollection.h
+++ b/EventFilter/CTPPSRawToDigi/interface/VFATFrameCollection.h
@@ -54,7 +54,7 @@ class VFATFrameCollection
 
       public:
         /// constructor, automatically sets the iterator to the beginning
-        Iterator(const VFATFrameCollection* c = NULL) : collection(c)
+        Iterator(const VFATFrameCollection* c = nullptr) : collection(c)
           { if (collection) value = collection->BeginIterator(); }
 
         /// returns the DAQ position of the current element

--- a/EventFilter/CTPPSRawToDigi/plugins/TotemTriggerRawToDigi.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/TotemTriggerRawToDigi.cc
@@ -28,9 +28,9 @@ class TotemTriggerRawToDigi : public edm::stream::EDProducer<>
 {
   public:
     explicit TotemTriggerRawToDigi(const edm::ParameterSet&);
-    ~TotemTriggerRawToDigi();
+    ~TotemTriggerRawToDigi() override;
 
-    virtual void produce(edm::Event&, const edm::EventSetup&) override;
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
   private:
     unsigned int fedId;

--- a/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
@@ -39,10 +39,10 @@ class TotemVFATRawToDigi : public edm::stream::EDProducer<>
 {
   public:
     explicit TotemVFATRawToDigi(const edm::ParameterSet&);
-    ~TotemVFATRawToDigi();
+    ~TotemVFATRawToDigi() override;
 
-    virtual void produce(edm::Event&, const edm::EventSetup&) override;
-    virtual void endStream() override;
+    void produce(edm::Event&, const edm::EventSetup&) override;
+    void endStream() override;
 
   private:
     std::string subSystemName;

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -57,7 +57,7 @@ void RawToDigiConverter::RunCommon(const VFATFrameCollection &input, const Totem
   {
     TotemVFATStatus st;
     st.setMissing(true);
-    records[p.first] = { &p.second, NULL,  st };
+    records[p.first] = { &p.second, nullptr,  st };
   }
 
   // event error message buffer
@@ -303,7 +303,7 @@ void RawToDigiConverter::PrintSummaries() const
   // print error summary
   if (printErrorSummary)
   {
-    if (errorSummary.size() > 0)
+    if (!errorSummary.empty())
     {
       stringstream ees;
       for (const auto &vit : errorSummary)
@@ -323,7 +323,7 @@ void RawToDigiConverter::PrintSummaries() const
   // print summary of unknown frames (found in data but not in the mapping)
   if (printUnknownFrameSummary)
   {
-    if (unknownSummary.size() > 0)
+    if (!unknownSummary.empty())
     {
       stringstream ees;
       for (const auto &it : unknownSummary)

--- a/EventFilter/CTPPSRawToDigi/src/SimpleVFATFrameCollection.cc
+++ b/EventFilter/CTPPSRawToDigi/src/SimpleVFATFrameCollection.cc
@@ -36,7 +36,7 @@ const VFATFrame* SimpleVFATFrameCollection::GetFrameByID(unsigned int ID) const
       if (it->second.checkFootprint() && it->second.checkCRC())
         return &(it->second);
 
-  return NULL;
+  return nullptr;
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -47,7 +47,7 @@ const VFATFrame* SimpleVFATFrameCollection::GetFrameByIndex(TotemFramePosition i
   if (it != data.end())
     return &(it->second);
   else
-    return NULL;
+    return nullptr;
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -55,7 +55,7 @@ const VFATFrame* SimpleVFATFrameCollection::GetFrameByIndex(TotemFramePosition i
 VFATFrameCollection::value_type SimpleVFATFrameCollection::BeginIterator() const
 {
   MapType::const_iterator it = data.begin();
-  return (it == data.end()) ? value_type(TotemFramePosition(), NULL) : value_type(it->first, &it->second);
+  return (it == data.end()) ? value_type(TotemFramePosition(), nullptr) : value_type(it->first, &it->second);
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -68,12 +68,12 @@ VFATFrameCollection::value_type SimpleVFATFrameCollection::NextIterator(const va
   MapType::const_iterator it = data.find(value.first);
   it++;
 
-  return (it == data.end()) ? value_type(TotemFramePosition(), NULL) : value_type(it->first, &it->second);
+  return (it == data.end()) ? value_type(TotemFramePosition(), nullptr) : value_type(it->first, &it->second);
 }
 
 //----------------------------------------------------------------------------------------------------
 
 bool SimpleVFATFrameCollection::IsEndIterator(const value_type &value) const
 {
-  return (value.second == NULL);
+  return (value.second == nullptr);
 }

--- a/EventFilter/CTPPSRawToDigi/src/VFATFrame.cc
+++ b/EventFilter/CTPPSRawToDigi/src/VFATFrame.cc
@@ -10,7 +10,7 @@
 
 #include "EventFilter/CTPPSRawToDigi/interface/VFATFrame.h"
 
-#include <stdio.h>
+#include <cstdio>
 #include <cstring>
 
 //----------------------------------------------------------------------------------------------------
@@ -101,16 +101,16 @@ VFATFrame::word VFATFrame::calculateCRC(VFATFrame::word crc_in, VFATFrame::word 
 {
   word v = 0x0001;
   word mask = 0x0001;    
-  bool d=0;
+  bool d=false;
   word crc_temp = crc_in;
   unsigned char datalen = 16;
 
   for (int i = 0; i < datalen; i++)
   {
     if (dato & v)
-      d = 1;
+      d = true;
     else
-      d = 0;
+      d = false;
       
     if ((crc_temp & mask)^d)
       crc_temp = crc_temp>>1 ^ 0x8408;

--- a/EventFilter/CTPPSRawToDigi/src/VFATFrameCollection.cc
+++ b/EventFilter/CTPPSRawToDigi/src/VFATFrameCollection.cc
@@ -14,7 +14,7 @@
 const VFATFrame* VFATFrameCollection::GetFrameByIndexID(TotemFramePosition index, unsigned int ID)
 {
   const VFATFrame* returnframe = GetFrameByIndex(index);
-  if (returnframe == NULL)
-    return NULL;
-  return (returnframe->getChipID() == (ID & 0xFFF)) ? returnframe : NULL;
+  if (returnframe == nullptr)
+    return nullptr;
+  return (returnframe->getChipID() == (ID & 0xFFF)) ? returnframe : nullptr;
 }

--- a/EventFilter/CastorRawToDigi/interface/CastorCORData.h
+++ b/EventFilter/CastorRawToDigi/interface/CastorCORData.h
@@ -17,7 +17,7 @@ class CastorCORData {
   static const int MAXIMUM_SAMPLES_PER_CHANNEL;// = 20;
   
   CastorCORData();
-  ~CastorCORData() { if (m_ownData!=0) delete [] m_ownData; }
+  ~CastorCORData() { if (m_ownData!=nullptr) delete [] m_ownData; }
   CastorCORData(int version_to_create);
   CastorCORData(const unsigned short* data, int length);
   CastorCORData(const CastorCORData&);

--- a/EventFilter/CastorRawToDigi/interface/CastorMergerData.h
+++ b/EventFilter/CastorRawToDigi/interface/CastorMergerData.h
@@ -15,7 +15,7 @@ class CastorMergerData {
  public:
   
   CastorMergerData();
-  ~CastorMergerData() { if (m_ownData!=0) delete [] m_ownData; }
+  ~CastorMergerData() { if (m_ownData!=nullptr) delete [] m_ownData; }
   CastorMergerData(int version_to_create);
   CastorMergerData(const unsigned short* data, int length);
   CastorMergerData(const CastorMergerData&);

--- a/EventFilter/CastorRawToDigi/plugins/CastorDigiToRaw.h
+++ b/EventFilter/CastorRawToDigi/plugins/CastorDigiToRaw.h
@@ -27,8 +27,8 @@ class CastorDigiToRaw : public edm::EDProducer
 {
 public:
   explicit CastorDigiToRaw(const edm::ParameterSet& ps);
-  virtual ~CastorDigiToRaw();
-  virtual void produce(edm::Event& e, const edm::EventSetup& c);
+  ~CastorDigiToRaw() override;
+  void produce(edm::Event& e, const edm::EventSetup& c) override;
 
 private:
   CastorPacker packer_;

--- a/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.h
+++ b/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.h
@@ -36,9 +36,9 @@ class CastorRawToDigi : public edm::stream::EDProducer<>
 {
 public:
   explicit CastorRawToDigi(const edm::ParameterSet& ps);
-  virtual ~CastorRawToDigi();
-  virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
-  virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  ~CastorRawToDigi() override;
+  void produce(edm::Event& e, const edm::EventSetup& c) override;
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
 
 private:
   edm::InputTag dataTag_;

--- a/EventFilter/CastorRawToDigi/src/CastorCORData.cc
+++ b/EventFilter/CastorRawToDigi/src/CastorCORData.cc
@@ -7,7 +7,7 @@
 #else
 #include "CastorCORData.h"
 #endif
-#include <string.h>
+#include <cstring>
 #include <iostream>
 #include <algorithm>
 #include <iomanip>
@@ -17,12 +17,12 @@ using namespace std;
 const int CastorCORData::CHANNELS_PER_SPIGOT         = 36;
 const int CastorCORData::MAXIMUM_SAMPLES_PER_CHANNEL = 20;
 
-CastorCORData::CastorCORData() : m_formatVersion(-2), m_rawLength(0), m_rawConst(0), m_ownData(0) { }
+CastorCORData::CastorCORData() : m_formatVersion(-2), m_rawLength(0), m_rawConst(nullptr), m_ownData(nullptr) { }
 CastorCORData::CastorCORData(const unsigned short* data, int length) {
   adoptData(data,length);
-  m_ownData=0;
+  m_ownData=nullptr;
 }
-CastorCORData::CastorCORData(const CastorCORData& hd) : m_formatVersion(hd.m_formatVersion), m_rawLength(hd.m_rawLength), m_rawConst(hd.m_rawConst), m_ownData(0) { }
+CastorCORData::CastorCORData(const CastorCORData& hd) : m_formatVersion(hd.m_formatVersion), m_rawLength(hd.m_rawLength), m_rawConst(hd.m_rawConst), m_ownData(nullptr) { }
 
 CastorCORData::CastorCORData(int version_to_create) : m_formatVersion(version_to_create) {
   allocate(version_to_create);
@@ -39,7 +39,7 @@ void CastorCORData::allocate(int version_to_create) {
 }
 
 CastorCORData& CastorCORData::operator=(const CastorCORData& hd) {
-  if (m_ownData==0) {
+  if (m_ownData==nullptr) {
     m_formatVersion=hd.m_formatVersion;
     m_rawLength=hd.m_rawLength;
     m_rawConst=hd.m_rawConst;
@@ -100,8 +100,8 @@ void CastorCORData::determineStaticLengths(int& headerWords, int& trailerWords, 
 void CastorCORData::unpack(unsigned char* daq_lengths, unsigned short* daq_samples,
 			 unsigned char* tp_lengths, unsigned short* tp_samples) const {
 
-  if (daq_lengths!=0) memset(daq_lengths,0,CHANNELS_PER_SPIGOT);
-  if (tp_lengths!=0) memset(tp_lengths,0,1);
+  if (daq_lengths!=nullptr) memset(daq_lengths,0,CHANNELS_PER_SPIGOT);
+  if (tp_lengths!=nullptr) memset(tp_lengths,0,1);
 
   int tp_words_total = 0;
   int daq_words_total = 0;
@@ -113,7 +113,7 @@ void CastorCORData::unpack(unsigned char* daq_lengths, unsigned short* daq_sampl
   int wordPtr;
   const unsigned short* tpBase=m_rawConst+headerLen;
   // process the trigger primitive words
-  if (tp_lengths!=0) {
+  if (tp_lengths!=nullptr) {
     for (wordPtr=0; wordPtr<tp_words_total; wordPtr++) {
        tp_samples[tp_lengths[0]]=tpBase[wordPtr];
        tp_lengths[0]++;
@@ -126,7 +126,7 @@ void CastorCORData::unpack(unsigned char* daq_lengths, unsigned short* daq_sampl
   int lastCapid=0;
   int ts,dv;
   int tsamples = daq_words_total/24;
-  if (daq_lengths!=0) {
+  if (daq_lengths!=nullptr) {
 	for ( ts = 0; ts < tsamples; ts++ ) {
 		for (int j=0; j<12 ; j++) {
 			dat = daqBase[(ts*12+j)*2]<<16 | daqBase[(ts*12+j)*2+1];
@@ -164,7 +164,7 @@ void CastorCORData::pack(unsigned char* daq_lengths, unsigned short* daq_samples
 
   // trigger words
   unsigned short* ptr=m_ownData+headerLen;
-  if (tp_samples!=0 && tp_lengths!=0) {
+  if (tp_samples!=nullptr && tp_lengths!=nullptr) {
       for (isample=0; isample<tp_lengths[0] && isample<12; isample++) {
 	ptr[tp_words_total]=tp_samples[isample];
 	tp_words_total++;

--- a/EventFilter/CastorRawToDigi/src/CastorCTDCHeader.cc
+++ b/EventFilter/CastorRawToDigi/src/CastorCTDCHeader.cc
@@ -5,8 +5,8 @@
 #include "EventFilter/CastorRawToDigi/interface/CastorMergerData.h"
 #include "EventFilter/CastorRawToDigi/interface/CastorCTDCHeader.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <string.h>
-#include <stdint.h>
+#include <cstring>
+#include <cstdint>
 
 const int CastorCTDCHeader::SPIGOT_COUNT = 2; // COR spigots - does not include merger pay load
 

--- a/EventFilter/CastorRawToDigi/src/CastorCollections.cc
+++ b/EventFilter/CastorRawToDigi/src/CastorCollections.cc
@@ -2,9 +2,9 @@
 
 
 CastorCollections::CastorCollections() {
-  castorCont=0;
-  tpCont=0;
-  calibCont=0;
+  castorCont=nullptr;
+  tpCont=nullptr;
+  calibCont=nullptr;
 }
 CastorCollections::~CastorCollections() {
  

--- a/EventFilter/CastorRawToDigi/src/CastorCtdcPacker.cc
+++ b/EventFilter/CastorRawToDigi/src/CastorCtdcPacker.cc
@@ -13,7 +13,7 @@ using namespace std;
 
 template <class Coll, class DetIdClass> 
 int process(const Coll* pt, const DetId& did, unsigned short* buffer, int& presamples) {
-  if (pt==0) return 0;
+  if (pt==nullptr) return 0;
   int size=0;
   typename Coll::const_iterator i=pt->find(DetIdClass(did));
   if (i!=pt->end()) {

--- a/EventFilter/CastorRawToDigi/src/CastorMergerData.cc
+++ b/EventFilter/CastorRawToDigi/src/CastorMergerData.cc
@@ -6,16 +6,16 @@
 #else
 #include "CastorMergerData.h"
 #endif
-#include <string.h>
-#include <stdio.h>
+#include <cstring>
+#include <cstdio>
 #include <algorithm>
 
-CastorMergerData::CastorMergerData() : m_formatVersion(-2), m_rawLength(0), m_rawConst(0), m_ownData(0) { }
+CastorMergerData::CastorMergerData() : m_formatVersion(-2), m_rawLength(0), m_rawConst(nullptr), m_ownData(nullptr) { }
 CastorMergerData::CastorMergerData(const unsigned short* data, int length) {
   adoptData(data,length);
-  m_ownData=0;
+  m_ownData=nullptr;
 }
-CastorMergerData::CastorMergerData(const CastorMergerData& hd) : m_formatVersion(hd.m_formatVersion), m_rawLength(hd.m_rawLength), m_rawConst(hd.m_rawConst), m_ownData(0) { }
+CastorMergerData::CastorMergerData(const CastorMergerData& hd) : m_formatVersion(hd.m_formatVersion), m_rawLength(hd.m_rawLength), m_rawConst(hd.m_rawConst), m_ownData(nullptr) { }
 
 CastorMergerData::CastorMergerData(int version_to_create) : m_formatVersion(version_to_create) {
   allocate(version_to_create);
@@ -32,7 +32,7 @@ void CastorMergerData::allocate(int version_to_create) {
 }
 
 CastorMergerData& CastorMergerData::operator=(const CastorMergerData& hd) {
-  if (m_ownData==0) {
+  if (m_ownData==nullptr) {
     m_formatVersion=hd.m_formatVersion;
     m_rawLength=hd.m_rawLength;
     m_rawConst=hd.m_rawConst;
@@ -67,7 +67,7 @@ bool CastorMergerData::check() const {
 void CastorMergerData::unpack(
 			 unsigned char* tp_lengths, unsigned short* tp_samples) const {
 
-  if (tp_lengths!=0) memset(tp_lengths,0,1);
+  if (tp_lengths!=nullptr) memset(tp_lengths,0,1);
 
   int tp_words_total,headerLen,trailerLen;
   determineSectionLengths(tp_words_total,headerLen,trailerLen);
@@ -75,7 +75,7 @@ void CastorMergerData::unpack(
   int wordPtr;
   const unsigned short* tpBase=m_rawConst+headerLen;
   // process the trigger primitive words
-  if (tp_lengths!=0) {
+  if (tp_lengths!=nullptr) {
     for (wordPtr=0; wordPtr<tp_words_total; wordPtr++) {
        tp_samples[tp_lengths[0]]=tpBase[wordPtr];
        tp_lengths[0]++;
@@ -106,7 +106,7 @@ void CastorMergerData::pack(
 
   // trigger words
   unsigned short* ptr=m_ownData+headerLen;
-  if (tp_samples!=0 && tp_lengths!=0) {
+  if (tp_samples!=nullptr && tp_lengths!=nullptr) {
       for (isample=0; isample<tp_lengths[0] && isample<12; isample++) {
 	ptr[tp_words_total]=tp_samples[isample];
 	tp_words_total++;

--- a/EventFilter/CastorRawToDigi/src/CastorPacker.cc
+++ b/EventFilter/CastorRawToDigi/src/CastorPacker.cc
@@ -9,7 +9,7 @@
 
 template <class Coll, class DetIdClass> 
 int process(const Coll* pt, const DetId& did, unsigned short* buffer, int& presamples) {
-  if (pt==0) return 0;
+  if (pt==nullptr) return 0;
   int size=0;
   typename Coll::const_iterator i=pt->find(DetIdClass(did));
   if (i!=pt->end()) {

--- a/EventFilter/CastorRawToDigi/src/CastorRawCollections.cc
+++ b/EventFilter/CastorRawToDigi/src/CastorRawCollections.cc
@@ -1,11 +1,11 @@
 #include "EventFilter/CastorRawToDigi/interface/CastorRawCollections.h"
 
 CastorRawCollections::CastorRawCollections() {
-  castorCont=0;
-  zdcCont=0;
-  tpCont=0;
-  calibCont=0;
-  ttp=0;
+  castorCont=nullptr;
+  zdcCont=nullptr;
+  tpCont=nullptr;
+  calibCont=nullptr;
+  ttp=nullptr;
 }
 CastorRawCollections::~CastorRawCollections() {
  

--- a/EventFilter/CastorRawToDigi/src/CastorUnpacker.cc
+++ b/EventFilter/CastorRawToDigi/src/CastorUnpacker.cc
@@ -118,7 +118,7 @@ void CastorUnpacker::unpack(const FEDRawData& raw, const CastorElectronicsMap& e
 
     }
     if ((htr.getFirmwareFlavor()&0xE0)==0x80) { // some kind of TTP data
-      if (colls.ttp!=0) {
+      if (colls.ttp!=nullptr) {
 	HcalTTPUnpacker ttpUnpack;
 	colls.ttp->push_back(HcalTTPDigi());
 	ttpUnpack.unpack(htr,colls.ttp->back());

--- a/EventFilter/CastorRawToDigi/src/ZdcUnpacker.cc
+++ b/EventFilter/CastorRawToDigi/src/ZdcUnpacker.cc
@@ -219,7 +219,7 @@ void ZdcUnpacker::unpack(const FEDRawData& raw, const CastorElectronicsMap& emap
 
 		}
 		if ((htr.getFirmwareFlavor()&0xE0)==0x80) { // some kind of TTP data
-			if (colls.ttp!=0) {
+			if (colls.ttp!=nullptr) {
 				HcalTTPUnpacker ttpUnpack;
 				colls.ttp->push_back(HcalTTPDigi());
 				ttpUnpack.unpack(htr,colls.ttp->back());

--- a/EventFilter/DTRawToDigi/plugins/DTDDUUnpacker.h
+++ b/EventFilter/DTRawToDigi/plugins/DTDDUUnpacker.h
@@ -22,15 +22,15 @@ class DTDDUUnpacker : public DTUnpacker {
   DTDDUUnpacker(const edm::ParameterSet& ps);
 
   /// Destructor
-  virtual ~DTDDUUnpacker();
+  ~DTDDUUnpacker() override;
 
   // Unpacking method
-  virtual void interpretRawData(const unsigned int* index, int datasize,
+  void interpretRawData(const unsigned int* index, int datasize,
 				int dduID,
 				edm::ESHandle<DTReadOutMapping>& mapping, 
 				std::unique_ptr<DTDigiCollection>& product,
 				std::unique_ptr<DTLocalTriggerCollection>& product2,
-				uint16_t rosList=0);
+				uint16_t rosList=0) override;
   
   inline const std::vector<DTROS25Data> & getROSsControlData() const {
     return ros25Unpacker->getROSsControlData();

--- a/EventFilter/DTRawToDigi/plugins/DTDigiToRaw.cc
+++ b/EventFilter/DTRawToDigi/plugins/DTDigiToRaw.cc
@@ -1,7 +1,7 @@
 #include <EventFilter/DTRawToDigi/plugins/DTDigiToRaw.h>
 #include <DataFormats/DTDigi/interface/DTDDUWords.h>
 
-#include <math.h>
+#include <cmath>
 #include <iostream>
 
 using namespace edm;

--- a/EventFilter/DTRawToDigi/plugins/DTDigiToRawModule.h
+++ b/EventFilter/DTRawToDigi/plugins/DTDigiToRawModule.h
@@ -14,10 +14,10 @@ public:
   DTDigiToRawModule(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~DTDigiToRawModule();
+  ~DTDigiToRawModule() override;
 
   // Operations
-  virtual void produce( edm::Event&, const edm::EventSetup& ) override;
+  void produce( edm::Event&, const edm::EventSetup& ) override;
 
 private:
   DTDigiToRaw * packer;

--- a/EventFilter/DTRawToDigi/plugins/DTROS25Unpacker.cc
+++ b/EventFilter/DTRawToDigi/plugins/DTROS25Unpacker.cc
@@ -19,7 +19,7 @@
 #include <CondFormats/DTObjects/interface/DTReadOutMapping.h>
 
 #include <iostream>
-#include <math.h>
+#include <cmath>
 
 using namespace std;
 using namespace edm;

--- a/EventFilter/DTRawToDigi/plugins/DTROS25Unpacker.h
+++ b/EventFilter/DTRawToDigi/plugins/DTROS25Unpacker.h
@@ -23,15 +23,15 @@ public:
   DTROS25Unpacker(const edm::ParameterSet& ps);
 
   /// Destructor
-  virtual ~DTROS25Unpacker();
+  ~DTROS25Unpacker() override;
 
   // Unpacking method
-  virtual void interpretRawData(const unsigned int* index, int datasize,
+  void interpretRawData(const unsigned int* index, int datasize,
 				int dduID,
 				edm::ESHandle<DTReadOutMapping>& mapping, 
 				std::unique_ptr<DTDigiCollection>& product,
 				std::unique_ptr<DTLocalTriggerCollection>& product2,
-				uint16_t rosList = 0);
+				uint16_t rosList = 0) override;
 
   inline const std::vector<DTROS25Data> & getROSsControlData() const {
     return controlDataFromAllROS;

--- a/EventFilter/DTRawToDigi/plugins/DTROS8Unpacker.h
+++ b/EventFilter/DTRawToDigi/plugins/DTROS8Unpacker.h
@@ -23,15 +23,15 @@ public:
   DTROS8Unpacker(const edm::ParameterSet& ps): pset(ps) {}
 
   /// Destructor
-  virtual ~DTROS8Unpacker() {}
+  ~DTROS8Unpacker() override {}
 
   // Unpacking method
-  virtual void interpretRawData(const unsigned int* index, int datasize,
+  void interpretRawData(const unsigned int* index, int datasize,
 				int dduID,
 				edm::ESHandle<DTReadOutMapping>& mapping, 
 				std::unique_ptr<DTDigiCollection>& product,
                                 std::unique_ptr<DTLocalTriggerCollection>& product2,
-				uint16_t rosList = 0);
+				uint16_t rosList = 0) override;
 
 private:
 

--- a/EventFilter/DTRawToDigi/plugins/DTUnpackingModule.cc
+++ b/EventFilter/DTRawToDigi/plugins/DTUnpackingModule.cc
@@ -37,7 +37,7 @@ using namespace std;
 #define SLINK_WORD_SIZE 8 
 
 
-DTUnpackingModule::DTUnpackingModule(const edm::ParameterSet& ps) : unpacker(0),dataType("") {
+DTUnpackingModule::DTUnpackingModule(const edm::ParameterSet& ps) : unpacker(nullptr),dataType("") {
 
   dataType = ps.getParameter<string>("dataType");
 

--- a/EventFilter/DTRawToDigi/plugins/DTUnpackingModule.h
+++ b/EventFilter/DTRawToDigi/plugins/DTUnpackingModule.h
@@ -21,7 +21,7 @@ class DTUnpackingModule: public edm::stream::EDProducer<> {
   DTUnpackingModule(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~DTUnpackingModule();
+  ~DTUnpackingModule() override;
     
   /// Call the Unpackers and create the digis 
   void produce(edm::Event & e, const edm::EventSetup& c) override;

--- a/EventFilter/DTTFRawToDigi/interface/DTTFFEDReader.h
+++ b/EventFilter/DTTFRawToDigi/interface/DTTFFEDReader.h
@@ -37,10 +37,10 @@ class DTTFFEDReader : public edm::stream::EDProducer<> {
   DTTFFEDReader(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~DTTFFEDReader();
+  ~DTTFFEDReader() override;
 
   /// Produce digis out of raw data
-  void produce(edm::Event & e, const edm::EventSetup& c);
+  void produce(edm::Event & e, const edm::EventSetup& c) override;
 
   /// Generate and fill FED raw data for a full event
   bool fillRawData(edm::Event& e,

--- a/EventFilter/DTTFRawToDigi/interface/DTTFFEDSim.h
+++ b/EventFilter/DTTFRawToDigi/interface/DTTFFEDSim.h
@@ -34,7 +34,7 @@ class DTTFFEDSim : public edm::stream::EDProducer<> {
   DTTFFEDSim(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~DTTFFEDSim();
+  ~DTTFFEDSim() override;
 
   /// Produce digis out of raw data
   void produce(edm::Event & e, const edm::EventSetup& c) override;

--- a/EventFilter/ESDigiToRaw/interface/ESDigiToRaw.h
+++ b/EventFilter/ESDigiToRaw/interface/ESDigiToRaw.h
@@ -20,7 +20,7 @@
 class ESDigiToRaw : public edm::global::EDProducer<> {
 public:
   ESDigiToRaw(const edm::ParameterSet& ps);
-  virtual ~ESDigiToRaw();
+  ~ESDigiToRaw() override;
   
   void produce(edm::StreamID, edm::Event& e, const edm::EventSetup& es) const override;
 

--- a/EventFilter/ESDigiToRaw/src/ESDataFormatterV1_1.h
+++ b/EventFilter/ESDigiToRaw/src/ESDataFormatterV1_1.h
@@ -30,9 +30,9 @@ class ESDataFormatterV1_1 : public ESDataFormatter {
   typedef ESDataFormatter::Word64 Word64;
 
   ESDataFormatterV1_1(const edm::ParameterSet& ps);
-  ~ESDataFormatterV1_1();
+  ~ESDataFormatterV1_1() override;
 
-  void DigiToRaw(int fedId, Digis & digis, FEDRawData& fedRawData, const Meta_Data & meta_data) const;
+  void DigiToRaw(int fedId, Digis & digis, FEDRawData& fedRawData, const Meta_Data & meta_data) const override;
 
 
   private :    

--- a/EventFilter/ESDigiToRaw/src/ESDataFormatterV4.h
+++ b/EventFilter/ESDigiToRaw/src/ESDataFormatterV4.h
@@ -31,10 +31,10 @@ class ESDataFormatterV4 : public ESDataFormatter {
   typedef ESDataFormatter::Word64 Word64;
 
   ESDataFormatterV4(const edm::ParameterSet& ps);
-  ~ESDataFormatterV4();
+  ~ESDataFormatterV4() override;
 
 
-  void DigiToRaw(int fedId, Digis & digis, FEDRawData& fedRawData, Meta_Data const & meta_data) const;
+  void DigiToRaw(int fedId, Digis & digis, FEDRawData& fedRawData, Meta_Data const & meta_data) const override;
 
 
   private :    

--- a/EventFilter/ESDigiToRaw/src/ESDigiToRaw.cc
+++ b/EventFilter/ESDigiToRaw/src/ESDigiToRaw.cc
@@ -11,7 +11,7 @@
 using namespace std;
 using namespace edm;
 
-ESDigiToRaw::ESDigiToRaw(const edm::ParameterSet& ps) : ESDataFormatter_(0),
+ESDigiToRaw::ESDigiToRaw(const edm::ParameterSet& ps) : ESDataFormatter_(nullptr),
   label_(ps.getParameter<string>("Label")),
   instanceName_(ps.getParameter<string>("InstanceES")),
   ESDigiToken_(consumes<ESDigiCollection>(edm::InputTag(label_, instanceName_))),

--- a/EventFilter/ESRawToDigi/interface/ESRawToDigi.h
+++ b/EventFilter/ESRawToDigi/interface/ESRawToDigi.h
@@ -16,11 +16,11 @@ class ESRawToDigi : public edm::stream::EDProducer<> {
  public:
   
   ESRawToDigi(const edm::ParameterSet& ps);
-  virtual ~ESRawToDigi();
+  ~ESRawToDigi() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
  
-  void produce(edm::Event& e, const edm::EventSetup& es);
+  void produce(edm::Event& e, const edm::EventSetup& es) override;
   
  private:
 

--- a/EventFilter/EcalDigiToRaw/interface/EcalDigiToRaw.h
+++ b/EventFilter/EcalDigiToRaw/interface/EcalDigiToRaw.h
@@ -50,11 +50,11 @@
 class EcalDigiToRaw : public edm::EDProducer {
    public:
        EcalDigiToRaw(const edm::ParameterSet& pset);
-       virtual ~EcalDigiToRaw();
+       ~EcalDigiToRaw() override;
 
-      void beginJob();
-      void produce(edm::Event& e, const edm::EventSetup& c);
-      void endJob() ;
+      void beginJob() override;
+      void produce(edm::Event& e, const edm::EventSetup& c) override;
+      void endJob() override ;
 
       typedef long long Word64;
       typedef unsigned int Word32;

--- a/EventFilter/EcalDigiToRaw/src/TowerBlockFormatter.cc
+++ b/EventFilter/EcalDigiToRaw/src/TowerBlockFormatter.cc
@@ -382,8 +382,8 @@ void TowerBlockFormatter::EndEvent(FEDRawDataCollection* productRawData) {
  FEDorder -> clear();
  delete FEDmap;
  delete FEDorder;
- FEDmap = 0;
- FEDorder = 0;
+ FEDmap = nullptr;
+ FEDorder = nullptr;
 
  debug_ = false;
 

--- a/EventFilter/EcalRawToDigi/interface/DCCDataBlockPrototype.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCDataBlockPrototype.h
@@ -16,11 +16,11 @@
 #include <vector>
 #include <map>
 #include <utility>
-#include <stdio.h>
+#include <cstdio>
 
 #include <FWCore/MessageLogger/interface/MessageLogger.h>
 #include "DCCRawDataDefinitions.h"
-#include <stdint.h>
+#include <cstdint>
 
 class EcalElectronicsMapper;
 class DCCDataUnpacker;

--- a/EventFilter/EcalRawToDigi/interface/DCCDataUnpacker.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCDataUnpacker.h
@@ -21,8 +21,8 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <stdio.h>                     
-#include <stdint.h>
+#include <cstdio>                     
+#include <cstdint>
 #include <atomic>
 
 //DATA DECODER

--- a/EventFilter/EcalRawToDigi/interface/DCCEBEventBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCEBEventBlock.h
@@ -28,11 +28,11 @@ class DCCEBEventBlock : public DCCEventBlock{
 
    DCCEBEventBlock( DCCDataUnpacker * u, EcalElectronicsMapper *m ,  bool hU, bool srpU, bool tccU, bool feU, bool memU, bool forceToKeepFRdata);
    
-   void unpack(const uint64_t * buffer, size_t bufferSize, unsigned int expFedId);
+   void unpack(const uint64_t * buffer, size_t bufferSize, unsigned int expFedId) override;
    
   protected :
   
-    int unpackTCCBlocks();
+    int unpackTCCBlocks() override;
    
 };
 

--- a/EventFilter/EcalRawToDigi/interface/DCCEBSRPBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCEBSRPBlock.h
@@ -17,7 +17,7 @@
 
 #include <iostream>
 #include <memory>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>
@@ -36,14 +36,14 @@ class DCCEBSRPBlock : public DCCSRPBlock{
 
     DCCEBSRPBlock( DCCDataUnpacker * u,EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack);
     
-    void updateCollectors();
+    void updateCollectors() override;
 	 
 	 
   protected :
   
-    void addSRFlagToCollection();
+    void addSRFlagToCollection() override;
 	 
-    bool checkSrpIdAndNumbSRFlags();
+    bool checkSrpIdAndNumbSRFlags() override;
     
     std::unique_ptr<EBSrFlagCollection>  * ebSrFlagsDigis_;
     

--- a/EventFilter/EcalRawToDigi/interface/DCCEBTCCBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCEBTCCBlock.h
@@ -39,13 +39,13 @@ class DCCEBTCCBlock : public DCCTCCBlock {
     */
     DCCEBTCCBlock( DCCDataUnpacker *  u, EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack);    
 	 
-    void updateCollectors();
+    void updateCollectors() override;
    
-    void addTriggerPrimitivesToCollection();
+    void addTriggerPrimitivesToCollection() override;
   
   protected :
 
-   bool checkTccIdAndNumbTTs();
+   bool checkTccIdAndNumbTTs() override;
 
 };
 

--- a/EventFilter/EcalRawToDigi/interface/DCCEEEventBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCEEEventBlock.h
@@ -27,11 +27,11 @@ class DCCEEEventBlock : public DCCEventBlock{
 
    DCCEEEventBlock( DCCDataUnpacker * u, EcalElectronicsMapper * m, bool hU, bool srpU, bool tccU, bool feU, bool memU, bool forceToKeepFRdata );
    
-   void unpack(const uint64_t * buffer, size_t bufferSize, unsigned int expFedId);
+   void unpack(const uint64_t * buffer, size_t bufferSize, unsigned int expFedId) override;
 	
   protected :
   
-   int unpackTCCBlocks();
+   int unpackTCCBlocks() override;
    
    
 };

--- a/EventFilter/EcalRawToDigi/interface/DCCEESRPBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCEESRPBlock.h
@@ -17,7 +17,7 @@
 
 #include <iostream>
 #include <memory>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>
@@ -36,13 +36,13 @@ class DCCEESRPBlock : public DCCSRPBlock{
 
     DCCEESRPBlock( DCCDataUnpacker * u,EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack);
     
-    void updateCollectors();
+    void updateCollectors() override;
 	 
   protected :
   
-    void addSRFlagToCollection(); 
+    void addSRFlagToCollection() override; 
     
-    bool checkSrpIdAndNumbSRFlags();
+    bool checkSrpIdAndNumbSRFlags() override;
 	 
     std::unique_ptr<EESrFlagCollection>  * eeSrFlagsDigis_;
 	 

--- a/EventFilter/EcalRawToDigi/interface/DCCEETCCBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCEETCCBlock.h
@@ -35,15 +35,15 @@ class DCCEETCCBlock : public DCCTCCBlock{
     */
     DCCEETCCBlock( DCCDataUnpacker * u, EcalElectronicsMapper * m, DCCEventBlock * e, bool unpacking );    
   
-    void updateCollectors();
+    void updateCollectors() override;
 	 
-    void addTriggerPrimitivesToCollection();
+    void addTriggerPrimitivesToCollection() override;
 	
-	unsigned int getLength();
+	unsigned int getLength() override;
   
   protected :
   
-    bool checkTccIdAndNumbTTs();
+    bool checkTccIdAndNumbTTs() override;
 
 
 };

--- a/EventFilter/EcalRawToDigi/interface/DCCFEBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCFEBlock.h
@@ -3,7 +3,7 @@
 
 #include <iostream>
 #include <memory>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>
@@ -25,19 +25,19 @@ class DCCFEBlock : public DCCDataBlockPrototype {
 
     DCCFEBlock(DCCDataUnpacker * u,EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack, bool forceToKeepFRdata);
     
-    virtual ~DCCFEBlock(){ delete [] xtalGains_;}
+    ~DCCFEBlock() override{ delete [] xtalGains_;}
 
     void zsFlag(bool zs){ zs_ = zs;}
 
     void enableFeIdChecks(){checkFeId_= true;}
 	 
-    virtual void updateCollectors();
+    void updateCollectors() override;
     
-    void display(std::ostream & o); 
+    void display(std::ostream & o) override; 
     using DCCDataBlockPrototype::unpack; 
     int unpack(const uint64_t** data, unsigned int * dwToEnd, bool zs, unsigned int expectedTowerID);
 
-    unsigned int getLength(){return blockLength_; }
+    unsigned int getLength() override{return blockLength_; }
     			
   protected :
 	 

--- a/EventFilter/EcalRawToDigi/interface/DCCMemBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCMemBlock.h
@@ -16,7 +16,7 @@
 
 #include <iostream>
 #include <memory>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>
@@ -37,11 +37,11 @@ class DCCMemBlock : public DCCDataBlockPrototype {
 
     DCCMemBlock( DCCDataUnpacker * u,EcalElectronicsMapper * m, DCCEventBlock * e);
 	 
-    virtual ~DCCMemBlock(){}
+    ~DCCMemBlock() override{}
 	 
-    void updateCollectors();
+    void updateCollectors() override;
     
-    void display(std::ostream & o); 
+    void display(std::ostream & o) override; 
     using DCCDataBlockPrototype::unpack; 
     int unpack(const uint64_t ** data, unsigned int * dwToEnd, unsigned int expectedTowerID);   
     			

--- a/EventFilter/EcalRawToDigi/interface/DCCSCBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCSCBlock.h
@@ -3,7 +3,7 @@
 
 #include <iostream>
 #include <memory>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>
@@ -27,13 +27,13 @@ class DCCSCBlock : public DCCFEBlock {
 
     DCCSCBlock(DCCDataUnpacker * u, EcalElectronicsMapper *m, DCCEventBlock * e, bool unpack, bool forceToKeepFRdata);
 	 
-    void updateCollectors();
+    void updateCollectors() override;
 	 
 	 
   protected :
 
-   int unpackXtalData(unsigned int stripID, unsigned int xtalID);
-   void fillEcalElectronicsError( std::unique_ptr<EcalElectronicsIdCollection> * );
+   int unpackXtalData(unsigned int stripID, unsigned int xtalID) override;
+   void fillEcalElectronicsError( std::unique_ptr<EcalElectronicsIdCollection> * ) override;
 	 
    EEDetId                                * pDetId_;
    EEDataFrame                            * pDFId_;

--- a/EventFilter/EcalRawToDigi/interface/DCCSRPBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCSRPBlock.h
@@ -17,7 +17,7 @@
 
 #include <iostream>
 #include <memory>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>
@@ -36,7 +36,7 @@ class DCCSRPBlock : public DCCDataBlockPrototype {
 
     DCCSRPBlock( DCCDataUnpacker * u,EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack);
 	 
-    void display(std::ostream & o); 
+    void display(std::ostream & o) override; 
     using DCCDataBlockPrototype::unpack;
     int unpack(const uint64_t ** data, unsigned int * dwToEnd, unsigned int numbFlags = SRP_NUMBFLAGS);     	 
 

--- a/EventFilter/EcalRawToDigi/interface/DCCTCCBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCTCCBlock.h
@@ -47,7 +47,7 @@ class DCCTCCBlock : public DCCDataBlockPrototype {
     using DCCDataBlockPrototype::unpack;
     int unpack(const uint64_t ** data, unsigned int * dwToEnd, short tccChId=0);
 	 
-    void display(std::ostream & o); 
+    void display(std::ostream & o) override; 
 	 
   
   protected :

--- a/EventFilter/EcalRawToDigi/interface/DCCTowerBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCTowerBlock.h
@@ -3,7 +3,7 @@
 
 #include <iostream>
 #include <memory>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>
@@ -27,12 +27,12 @@ class DCCTowerBlock : public DCCFEBlock {
 
     DCCTowerBlock(DCCDataUnpacker * u,EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack, bool forceToKeepFRdata );
     
-    void updateCollectors();
+    void updateCollectors() override;
 	 
   protected:
 	 
-    int unpackXtalData(unsigned int stripID, unsigned int xtalID);
-    void fillEcalElectronicsError( std::unique_ptr<EcalElectronicsIdCollection> * );
+    int unpackXtalData(unsigned int stripID, unsigned int xtalID) override;
+    void fillEcalElectronicsError( std::unique_ptr<EcalElectronicsIdCollection> * ) override;
 
     std::unique_ptr<EBDigiCollection>     * digis_;
     

--- a/EventFilter/EcalRawToDigi/interface/EcalDumpRaw.h
+++ b/EventFilter/EcalRawToDigi/interface/EcalDumpRaw.h
@@ -11,7 +11,7 @@
 #include <fstream>
 #include <sstream>
 #include <string>
-#include <inttypes.h>
+#include <cinttypes>
 //#include "pgras/PGUtilities/interface/PGHisto.h"
 
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
@@ -35,10 +35,10 @@ class EcalDumpRaw : public edm::stream::EDAnalyzer<>{
   //ctors
 public:
   explicit EcalDumpRaw(const edm::ParameterSet&);
-  ~EcalDumpRaw();
+  ~EcalDumpRaw() override;
 
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   void analyzeEB(const edm::Event&, const edm::EventSetup&) const;
   void analyzeEE(const edm::Event&, const edm::EventSetup&) const;

--- a/EventFilter/EcalRawToDigi/interface/MatacqProducer.h
+++ b/EventFilter/EcalRawToDigi/interface/MatacqProducer.h
@@ -11,7 +11,7 @@
 #    define _LARGEFILE64_SOURCE
 #  endif //_LARGEFILE64_SOURCE not defined
 #  define  _FILE_OFFSET_BITS 64 
-#  include <stdio.h>
+#  include <cstdio>
 #endif //USE_STORAGE_MANAGER defined
 
 
@@ -25,7 +25,7 @@
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 
 #include <string>
-#include <inttypes.h>
+#include <cinttypes>
 #include <fstream>
 #include <memory>
 
@@ -126,14 +126,14 @@ public:
 
   /** Destructor
    */
-  ~MatacqProducer();
+  ~MatacqProducer() override;
 
   /** Produces the EDM products
    * @param CMS event
    * @param eventSetup event conditions
    */
-  virtual void
-  produce(edm::Event& event, const edm::EventSetup& eventSetup);
+  void
+  produce(edm::Event& event, const edm::EventSetup& eventSetup) override;
 
 private:
   /** Add matacq digi to the event
@@ -151,7 +151,7 @@ private:
    * found.
    */
   bool
-  getMatacqFile(uint32_t runNumber, uint32_t orbitId, bool* fileChange =0);
+  getMatacqFile(uint32_t runNumber, uint32_t orbitId, bool* fileChange =nullptr);
 
   bool
   getMatacqEvent(uint32_t runNumber, int32_t orbitId,
@@ -176,7 +176,7 @@ private:
    * @param mess text to insert in the eventual error message.
    * @return true on success, false on failure
    */  
-  bool mseek(filepos_t offset, int whence = SEEK_SET, const char* mess = 0);
+  bool mseek(filepos_t offset, int whence = SEEK_SET, const char* mess = nullptr);
 
   bool mtell(filepos_t& pos);
   
@@ -188,7 +188,7 @@ private:
    * @param peek if true file position is restored after the data read
    * @return true on success, false on failure
    */
-  bool mread(char* buf, size_t n, const char* mess = 0, bool peek = false);
+  bool mread(char* buf, size_t n, const char* mess = nullptr, bool peek = false);
 
   bool mcheck(const std::string& name);
 

--- a/EventFilter/EcalRawToDigi/interface/MatacqRawEvent.h
+++ b/EventFilter/EcalRawToDigi/interface/MatacqRawEvent.h
@@ -3,7 +3,7 @@
 #ifndef MATACQRAWEVENT_H
 #define MATACQRAWEVENT_H
 
-#include <inttypes.h>
+#include <cinttypes>
 #include <vector>
 
 #if 0 //replace 1 by 0 to remove XDAQ dependency. In this case it is assumed the

--- a/EventFilter/EcalRawToDigi/plugins/EcalDumpRaw.cc
+++ b/EventFilter/EcalRawToDigi/plugins/EcalDumpRaw.cc
@@ -213,7 +213,7 @@ EcalDumpRaw::analyze(const edm::Event& event, const edm::EventSetup& es){
   ++iEvent_;
   eventId_ = event.id().event();
 
-  if(eventList_.size()!=0 && find(eventList_.begin(), eventList_.end(),
+  if(!eventList_.empty() && find(eventList_.begin(), eventList_.end(),
                                   eventId_) == eventList_.end()){
     cout << "Skipping event " << eventId_ << ".\n";
     return;
@@ -223,7 +223,7 @@ EcalDumpRaw::analyze(const edm::Event& event, const edm::EventSetup& es){
       (last_event_ > 0 && last_event_ < iEvent_)) return;
   timeval start;
   timeval stop;
-  gettimeofday(&start, 0);
+  gettimeofday(&start, nullptr);
 
   edm::Handle<FEDRawDataCollection> rawdata;
   event.getByToken(fedRawDataCollectionToken_, rawdata);
@@ -240,7 +240,7 @@ EcalDumpRaw::analyze(const edm::Event& event, const edm::EventSetup& es){
     event.getByToken(l1AcceptBunchCrossingCollectionToken_, l1aHist);
     if(!l1aHist.isValid()) {
       cout << "L1A history not found.\n";
-    } else if (l1aHist->size() == 0) {
+    } else if (l1aHist->empty()) {
       cout << "L1A history is empty.\n";
     } else{
       cout << "L1A history: \n";
@@ -444,7 +444,7 @@ EcalDumpRaw::analyze(const edm::Event& event, const edm::EventSetup& es){
 
 #endif
 
-  gettimeofday(&stop, 0);
+  gettimeofday(&stop, nullptr);
   //  double dt  = (stop.tv_sec-start.tv_sec)*1.e3
   //  + (stop.tv_usec-start.tv_usec)*1.e-3;
   //  histo_.fillD("hCodeTime", "Code execution time;Duration (ms);Event count",

--- a/EventFilter/EcalRawToDigi/plugins/EcalRawToDigi.cc
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRawToDigi.cc
@@ -65,9 +65,9 @@ EcalRawToDigi::EcalRawToDigi(edm::ParameterSet const& conf):
 
 
 
-  myMap_(0),
+  myMap_(nullptr),
   
-  theUnpacker_(0)
+  theUnpacker_(nullptr)
 
 {
   
@@ -102,7 +102,7 @@ EcalRawToDigi::EcalRawToDigi(edm::ParameterSet const& conf):
 
   //print the FEDs to unpack to the logger
   std::ostringstream loggerOutput_;
-  if(fedUnpackList_.size()!=0){
+  if(!fedUnpackList_.empty()){
     for (unsigned int i=0; i<fedUnpackList_.size(); i++) 
       loggerOutput_ << fedUnpackList_[i] << " ";
     edm::LogInfo("EcalRawToDigi") << "EcalRawToDigi will unpack FEDs ( " << loggerOutput_.str() << ")";

--- a/EventFilter/EcalRawToDigi/plugins/EcalRawToDigi.h
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRawToDigi.h
@@ -49,16 +49,16 @@ class EcalRawToDigi : public edm::stream::EDProducer<>{
   /**
    * Functions that are called by framework at each event
    */
-  virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
+  void produce(edm::Event& e, const edm::EventSetup& c) override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   // function called at start of each run
-  virtual void beginRun(const edm::Run& run, const edm::EventSetup& es) override;
+  void beginRun(const edm::Run& run, const edm::EventSetup& es) override;
   
   /**
    * Class destructor
    */
-  virtual ~EcalRawToDigi();
+  ~EcalRawToDigi() override;
 
  
   edm::ESWatcher<EcalMappingRcd> watcher_;

--- a/EventFilter/EcalRawToDigi/plugins/EcalRegionCablingESProducer.h
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRegionCablingESProducer.h
@@ -32,7 +32,7 @@
 class EcalRegionCablingESProducer : public edm::ESProducer {
 public:
       EcalRegionCablingESProducer(const edm::ParameterSet&);
-  ~EcalRegionCablingESProducer();
+  ~EcalRegionCablingESProducer() override;
 
   typedef std::shared_ptr<EcalRegionCabling> ReturnType;
 

--- a/EventFilter/EcalRawToDigi/src/DCCDataUnpacker.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCDataUnpacker.cc
@@ -59,7 +59,7 @@ uint16_t DCCDataUnpacker::getChannelStatus(const DetId& id) const
   // TODO: think on a better way how to cover this case
   const uint16_t NO_DATA = 11;
   
-  if (chdb_ == 0) {
+  if (chdb_ == nullptr) {
     edm::LogError("IncorrectMapping")
       << "ECAL channel status database do not initialized";
     return NO_DATA;

--- a/EventFilter/EcalRawToDigi/src/DCCFEBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCFEBlock.cc
@@ -1,7 +1,7 @@
 #include "EventFilter/EcalRawToDigi/interface/DCCFEBlock.h"
 #include "EventFilter/EcalRawToDigi/interface/DCCEventBlock.h"
 #include "EventFilter/EcalRawToDigi/interface/DCCDataUnpacker.h"
-#include <stdio.h>
+#include <cstdio>
 #include "EventFilter/EcalRawToDigi/interface/EcalElectronicsMapper.h"
 
 

--- a/EventFilter/EcalRawToDigi/src/DCCMemBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCMemBlock.cc
@@ -1,7 +1,7 @@
 #include "EventFilter/EcalRawToDigi/interface/DCCMemBlock.h"
 #include "EventFilter/EcalRawToDigi/interface/DCCEventBlock.h"
 #include "EventFilter/EcalRawToDigi/interface/DCCDataUnpacker.h"
-#include <stdio.h>
+#include <cstdio>
 #include "EventFilter/EcalRawToDigi/interface/EcalElectronicsMapper.h"
 
 

--- a/EventFilter/EcalRawToDigi/src/DCCSCBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCSCBlock.cc
@@ -1,7 +1,7 @@
 #include "EventFilter/EcalRawToDigi/interface/DCCSCBlock.h"
 #include "EventFilter/EcalRawToDigi/interface/DCCEventBlock.h"
 #include "EventFilter/EcalRawToDigi/interface/DCCDataUnpacker.h"
-#include <stdio.h>
+#include <cstdio>
 #include "EventFilter/EcalRawToDigi/interface/EcalElectronicsMapper.h"
 
 

--- a/EventFilter/EcalRawToDigi/src/DCCTowerBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCTowerBlock.cc
@@ -1,4 +1,4 @@
-#include <stdio.h>
+#include <cstdio>
 #include <algorithm>
 #include "EventFilter/EcalRawToDigi/interface/DCCTowerBlock.h"
 #include "EventFilter/EcalRawToDigi/interface/DCCEventBlock.h"

--- a/EventFilter/EcalRawToDigi/src/EcalElectronicsMapper.cc
+++ b/EventFilter/EcalRawToDigi/src/EcalElectronicsMapper.cc
@@ -9,7 +9,7 @@ EcalElectronicsMapper::EcalElectronicsMapper( unsigned int numbXtalTSamples, uns
 : pathToMapFile_(""),
 numbXtalTSamples_(numbXtalTSamples),
 numbTriggerTSamples_(numbTriggerTSamples),
-mappingBuilder_(0)
+mappingBuilder_(nullptr)
 {
   resetPointers();
   setupGhostMap();
@@ -25,13 +25,13 @@ void EcalElectronicsMapper::resetPointers(){
         for(unsigned int xtal=0; xtal<NUMB_XTAL;xtal++){
                     
              //Reset DFrames and xtalDetIds
-          xtalDetIds_[sm][fe][strip][xtal]=0;
+          xtalDetIds_[sm][fe][strip][xtal]=nullptr;
         }
       }
 
       //Reset SC Det Ids
       //scDetIds_[sm][fe]=0;
-      scEleIds_[sm][fe]=0;
+      scEleIds_[sm][fe]=nullptr;
       //srFlags_[sm][fe]=0;
     }
   }
@@ -40,9 +40,9 @@ void EcalElectronicsMapper::resetPointers(){
   //Reset TT det Ids
   for( unsigned int tccid=0; tccid < NUMB_TCC; tccid++){
     for(unsigned int tpg =0; tpg<NUMB_FE;tpg++){
-      ttDetIds_[tccid][tpg]=0;
-      ttTPIds_[tccid][tpg]=0;
-      ttEleIds_[tccid][tpg]=0;
+      ttDetIds_[tccid][tpg]=nullptr;
+      ttTPIds_[tccid][tpg]=nullptr;
+      ttEleIds_[tccid][tpg]=nullptr;
     }
   }
 
@@ -50,7 +50,7 @@ void EcalElectronicsMapper::resetPointers(){
   for (int tccid=0; tccid<NUMB_TCC; tccid++){
       for (int ttid=0; ttid<TCC_EB_NUMBTTS; ttid++){
           for (int ps=0; ps<NUMB_STRIP; ps++){
-              psInput_[tccid][ttid][ps]=0;
+              psInput_[tccid][ttid][ps]=nullptr;
           }}}
   
   // initialize TCC maps
@@ -282,7 +282,7 @@ bool EcalElectronicsMapper::makeMapFromVectors( std::vector<int>& orderedFedUnpa
 
   // in case as non standard set of DCCId:FedId pairs was provided
   if ( orderedFedUnpackList.size() == orderedDCCIdList.size() &&
-       orderedFedUnpackList.size() > 0)
+       !orderedFedUnpackList.empty())
     {
       edm::LogInfo("EcalElectronicsMapper") << "DCCIdList/FedUnpackList lists given. Being loaded.";
       
@@ -318,7 +318,7 @@ std::ostream &operator<< (std::ostream& o, const EcalElectronicsMapper &aMapper_
   //print class information
   o << "---------------------------------------------------------";
 
-  if(aMapper_.pathToMapFile_.size() < 1){
+  if(aMapper_.pathToMapFile_.empty()){
     o << "No correct input for DCC map has been given yet...";
   }
   else{

--- a/EventFilter/EcalRawToDigi/src/MatacqRawEvent.cc
+++ b/EventFilter/EcalRawToDigi/src/MatacqRawEvent.cc
@@ -9,7 +9,7 @@
  */
 
 #include <unistd.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <fstream>
 #include <vector>
 #include <iostream>

--- a/EventFilter/EcalTBRawToDigi/interface/EcalDCC07UnpackingModule.h
+++ b/EventFilter/EcalTBRawToDigi/interface/EcalDCC07UnpackingModule.h
@@ -29,16 +29,16 @@ class MatacqTBDataFormatter;
     EcalDCCTB07UnpackingModule(const edm::ParameterSet& pset);
 
     /// Destructor
-    virtual ~EcalDCCTB07UnpackingModule();
+    ~EcalDCCTB07UnpackingModule() override;
     
     /// Produce digis out of raw data
-    void produce(edm::Event & e, const edm::EventSetup& c);
+    void produce(edm::Event & e, const edm::EventSetup& c) override;
 
     // BeginJob
-    void beginJob();
+    void beginJob() override;
 
     // EndJob
-    void endJob(void);
+    void endJob(void) override;
 
   private:
 

--- a/EventFilter/EcalTBRawToDigi/interface/EcalDCCUnpackingModule.h
+++ b/EventFilter/EcalTBRawToDigi/interface/EcalDCCUnpackingModule.h
@@ -28,16 +28,16 @@ class MatacqTBDataFormatter;
     EcalDCCTBUnpackingModule(const edm::ParameterSet& pset);
 
     /// Destructor
-    virtual ~EcalDCCTBUnpackingModule();
+    ~EcalDCCTBUnpackingModule() override;
     
     /// Produce digis out of raw data
-    void produce(edm::Event & e, const edm::EventSetup& c);
+    void produce(edm::Event & e, const edm::EventSetup& c) override;
 
     // BeginJob
-    void beginJob();
+    void beginJob() override;
 
     // EndJob
-    void endJob(void);
+    void endJob(void) override;
 
   private:
 

--- a/EventFilter/EcalTBRawToDigi/src/DCCBlockPrototype.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCBlockPrototype.cc
@@ -3,7 +3,7 @@
 #include "DCCDataMapper.h"
 #include "ECALParserBlockException.h"
 
-#include <stdio.h>
+#include <cstdio>
 #include <sstream>
 
 

--- a/EventFilter/EcalTBRawToDigi/src/DCCBlockPrototype.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCBlockPrototype.h
@@ -13,7 +13,7 @@
 #include <set>
 #include <iostream>
 #include <iomanip>
-#include <stdint.h>
+#include <cstdint>
 
 class DCCTBDataParser;
 class DCCTBDataField;

--- a/EventFilter/EcalTBRawToDigi/src/DCCDataParser.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCDataParser.cc
@@ -7,7 +7,7 @@
 /* class constructor                            */
 /*----------------------------------------------*/
 DCCTBDataParser::DCCTBDataParser(const std::vector<uint32_t>& parserParameters, bool parseInternalData,bool debug):
-  buffer_(0),parseInternalData_(parseInternalData),debug_(debug), parameters(parserParameters){
+  buffer_(nullptr),parseInternalData_(parseInternalData),debug_(debug), parameters(parserParameters){
 	
   mapper_ = new DCCTBDataMapper(this);       //build a new data mapper
   resetErrorCounters();                    //restart error counters

--- a/EventFilter/EcalTBRawToDigi/src/DCCDataParser.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCDataParser.h
@@ -13,7 +13,7 @@
 #include <vector>
 #include <map>
 
-#include <stdio.h>                     //C
+#include <cstdio>                     //C
 
 #include "ECALParserException.h"      //DATA DECODER
 #include "DCCEventBlock.h"

--- a/EventFilter/EcalTBRawToDigi/src/DCCEventBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCEventBlock.cc
@@ -21,7 +21,7 @@ DCCTBEventBlock::DCCTBEventBlock(
 	uint32_t wordEventOffset 
 ) : 
 DCCTBBlockPrototype(parser,"DCCHEADER", buffer, numbBytes,wordsToEnd)
-,dccTrailerBlock_(0),srpBlock_(0),wordBufferOffset_(wordBufferOffset) {
+,dccTrailerBlock_(nullptr),srpBlock_(nullptr),wordBufferOffset_(wordBufferOffset) {
 	
 	
 	//Reset error counters ////
@@ -204,8 +204,8 @@ DCCTBEventBlock::~DCCTBEventBlock(){
 	for(it2=towerBlocks_.begin();it2!=towerBlocks_.end();it2++){ delete (*it2);}
 	towerBlocks_.clear();
 	
-	if(srpBlock_ !=        0 ) { delete srpBlock_;       }
-	if(dccTrailerBlock_ != 0 ) { delete dccTrailerBlock_;}
+	if(srpBlock_ !=        nullptr ) { delete srpBlock_;       }
+	if(dccTrailerBlock_ != nullptr ) { delete dccTrailerBlock_;}
 	
 }
 

--- a/EventFilter/EcalTBRawToDigi/src/DCCEventBlock.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCEventBlock.h
@@ -27,7 +27,7 @@ class DCCTBEventBlock : public DCCTBBlockPrototype {
 			uint32_t wordEventOffset = 0 
 		);
 		
-		~DCCTBEventBlock();
+		~DCCTBEventBlock() override;
 		
 		void dataCheck(); 
 		

--- a/EventFilter/EcalTBRawToDigi/src/DCCTowerBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCTowerBlock.cc
@@ -4,7 +4,7 @@
 #include "DCCXtalBlock.h"
 #include "DCCDataMapper.h"
 #include "ECALParserBlockException.h"
-#include <stdio.h>
+#include <cstdio>
 
 
 

--- a/EventFilter/EcalTBRawToDigi/src/DCCTowerBlock.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCTowerBlock.h
@@ -32,7 +32,7 @@ class DCCTBTowerBlock : public DCCTBBlockPrototype {
 			uint32_t expectedTowerID
 		);
 		
-		~DCCTBTowerBlock();
+		~DCCTBTowerBlock() override;
 		
 		void parseXtalData();
 		int towerID();

--- a/EventFilter/EcalTBRawToDigi/src/EcalDCC07UnpackingModule.cc
+++ b/EventFilter/EcalTBRawToDigi/src/EcalDCC07UnpackingModule.cc
@@ -58,14 +58,14 @@ EcalDCCTB07UnpackingModule::EcalDCCTB07UnpackingModule(const edm::ParameterSet& 
   std::vector<int> positionIDs = pset.getUntrackedParameter<std::vector<int> >("positionIDs", std::vector<int>());
 
   // check if vectors are filled
-  if ( ics.size() == 0 || towerIDs.size() == 0 || stripIDs.size() == 0 || channelIDs.size() == 0 ){
+  if ( ics.empty() || towerIDs.empty() || stripIDs.empty() || channelIDs.empty() ){
     edm::LogError("EcalDCCTB07UnpackingModule") << "Some of the mapping info is missing! Check config files! " <<
       " Size of IC vector is " << ics.size() <<
       " Size of Tower ID vector is " << towerIDs.size() <<
       " Size of Strip ID vector is " << stripIDs.size() <<
       " Size of Channel ID vector is " << channelIDs.size();
   }
-  if ( statusIDs.size() == 0 || ccuIDs.size() == 0 || positionIDs.size() == 0 ) {
+  if ( statusIDs.empty() || ccuIDs.empty() || positionIDs.empty() ) {
     edm::LogError("EcalDCCTB07UnpackingModule") << "Some of the mapping info is missing! Check config files! " <<
       " Size of status ID vector is " << statusIDs.size() <<
       " Size of ccu ID vector is " << ccuIDs.size() <<

--- a/EventFilter/EcalTBRawToDigi/src/EcalTB07DaqFormatter.cc
+++ b/EventFilter/EcalTBRawToDigi/src/EcalTB07DaqFormatter.cc
@@ -841,7 +841,7 @@ void EcalTB07DaqFormatter::DecodeMEM( DCCTBTowerBlock *  towerblock,  EcalPnDiod
   // if anything was wrong with mem_tt_id or mem_tt_size: you would have already exited
   // otherwise, if any problem with ch_gain or ch_id: must not produce digis for the pertaining Pn
 
-  if (!      (memgaincollection.size()==0 && memchidcollection.size()==0)          )
+  if (!      (memgaincollection.empty() && memchidcollection.empty())          )
     {
       for ( EcalElectronicsIdCollection::const_iterator idItr = memgaincollection.begin();
 	    idItr != memgaincollection.end();

--- a/EventFilter/EcalTBRawToDigi/src/EcalTBDaqFormatter.cc
+++ b/EventFilter/EcalTBRawToDigi/src/EcalTBDaqFormatter.cc
@@ -768,7 +768,7 @@ void EcalTBDaqFormatter::DecodeMEM( DCCTBTowerBlock *  towerblock,  EcalPnDiodeD
   // if anything was wrong with mem_tt_id or mem_tt_size: you would have already exited
   // otherwise, if any problem with ch_gain or ch_id: must not produce digis for the pertaining Pn
 
-  if (!      (memgaincollection.size()==0 && memchidcollection.size()==0)          )
+  if (!      (memgaincollection.empty() && memchidcollection.empty())          )
     {
       for ( EcalElectronicsIdCollection::const_iterator idItr = memgaincollection.begin();
 	    idItr != memgaincollection.end();

--- a/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.cc
+++ b/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.cc
@@ -9,7 +9,7 @@
  */
 
 #include <unistd.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <fstream>
 #include <vector>
 #include <iostream>

--- a/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.h
+++ b/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.h
@@ -3,7 +3,7 @@
 #ifndef MATACQTBRAWEVENT_H
 #define MATACQTBRAWEVENT_H
 
-#include <inttypes.h>
+#include <cinttypes>
 
 #if 0 //replace 1 by 0 to remove XDAQ dependency. In this case it is assumed
       //the machine is little endian.

--- a/EventFilter/FEDInterface/plugins/EvFFEDSelector.h
+++ b/EventFilter/FEDInterface/plugins/EvFFEDSelector.h
@@ -19,9 +19,9 @@ namespace evf {
   public:
 
     explicit EvFFEDSelector(edm::ParameterSet const &);
-    ~EvFFEDSelector() { }
+    ~EvFFEDSelector() override { }
 
-    void produce(edm::StreamID, edm::Event &, edm::EventSetup const &) const override final;
+    void produce(edm::StreamID, edm::Event &, edm::EventSetup const &) const final;
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   private:

--- a/EventFilter/GctRawToDigi/plugins/GctDigiToRaw.cc
+++ b/EventFilter/GctRawToDigi/plugins/GctDigiToRaw.cc
@@ -51,7 +51,7 @@ GctDigiToRaw::GctDigiToRaw(const edm::ParameterSet& iConfig) :
   produces<FEDRawDataCollection>();
   const edm::InputTag rctInputTag = iConfig.getParameter<edm::InputTag>("rctInputLabel");
   const edm::InputTag gctInputTag = iConfig.getParameter<edm::InputTag>("gctInputLabel");
-  const std::string gctInputLabelStr = gctInputTag.label();
+  const std::string& gctInputLabelStr = gctInputTag.label();
   tokenL1GctEmCand_isoEm_ = consumes<L1GctEmCandCollection>(edm::InputTag(gctInputLabelStr, "isoEm"));
   tokenL1GctEmCand_nonIsoEm_ = consumes<L1GctEmCandCollection>(edm::InputTag(gctInputLabelStr, "nonIsoEm"));
   tokenGctJetCand_cenJets_ = consumes<L1GctJetCandCollection>(edm::InputTag(gctInputLabelStr, "cenJets"));

--- a/EventFilter/GctRawToDigi/plugins/GctDigiToRaw.h
+++ b/EventFilter/GctRawToDigi/plugins/GctDigiToRaw.h
@@ -41,12 +41,12 @@
 class GctDigiToRaw : public edm::EDProducer {
  public:
   explicit GctDigiToRaw(const edm::ParameterSet&);
-  ~GctDigiToRaw();
+  ~GctDigiToRaw() override;
   
  private: // methods
-  virtual void beginJob();
-  virtual void produce(edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  void beginJob() override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
   
   void print(FEDRawData& data);
 

--- a/EventFilter/GctRawToDigi/plugins/GctRawToDigi.cc
+++ b/EventFilter/GctRawToDigi/plugins/GctRawToDigi.cc
@@ -43,8 +43,8 @@ GctRawToDigi::GctRawToDigi(const edm::ParameterSet& iConfig) :
   formatVersion_(iConfig.getParameter<unsigned>("unpackerVersion")),
   checkHeaders_(iConfig.getUntrackedParameter<bool>("checkHeaders",false)),
   verbose_(iConfig.getUntrackedParameter<bool>("verbose",false)),
-  formatTranslator_(0),
-  errors_(0),
+  formatTranslator_(nullptr),
+  errors_(nullptr),
   errorCounters_(MAX_ERR_CODE+1),  // initialise with the maximum error codes!
   unpackFailures_(0)
 {
@@ -335,7 +335,7 @@ void GctRawToDigi::addError(const unsigned code) {
   ++(errorCounters_.at(code));
   
   // store error in event if possible
-  if (errors_ != 0) {
+  if (errors_ != nullptr) {
     errors_->push_back(L1TriggerError(fedId_, code));
   }
   else LogDebug("GCT") << "Detected error (code=" << code << ") but no error collection available!";

--- a/EventFilter/GctRawToDigi/plugins/GctRawToDigi.h
+++ b/EventFilter/GctRawToDigi/plugins/GctRawToDigi.h
@@ -46,13 +46,13 @@ class GctRawToDigi : public edm::stream::EDProducer<>
 public:
 
   explicit GctRawToDigi(const edm::ParameterSet&);
-  ~GctRawToDigi();
+  ~GctRawToDigi() override;
 
    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
  
 private: // methods
 
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
   
   /// Unpacks the raw data
   /*! \param invalidDataFlag - if true, then won't attempt unpack but just output empty collecions. */

--- a/EventFilter/GctRawToDigi/plugins/L1GctInternJetProducer.h
+++ b/EventFilter/GctRawToDigi/plugins/L1GctInternJetProducer.h
@@ -29,12 +29,12 @@ class L1CaloGeometry ;
 class L1GctInternJetProducer : public edm::EDProducer {
    public:
       explicit L1GctInternJetProducer(const edm::ParameterSet&);
-      ~L1GctInternJetProducer();
+      ~L1GctInternJetProducer() override;
 
    private:
-      virtual void beginJob() ;
-      virtual void produce(edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+      void beginJob() override ;
+      void produce(edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
 
       math::PtEtaPhiMLorentzVector gctLorentzVector( const double& et,
 						     const L1GctCand& cand,

--- a/EventFilter/GctRawToDigi/src/GctBlockHeader.h
+++ b/EventFilter/GctRawToDigi/src/GctBlockHeader.h
@@ -11,7 +11,7 @@
 
 // C++ headers
 #include <ostream>
-#include <stdint.h>
+#include <cstdint>
 
 class GctBlockHeader
 {

--- a/EventFilter/GctRawToDigi/src/GctFormatTranslateBase.cc
+++ b/EventFilter/GctRawToDigi/src/GctFormatTranslateBase.cc
@@ -10,7 +10,7 @@ const std::string GctFormatTranslateBase::INVALID_BLOCK_HEADER_STR = "UNKNOWN/IN
 // PUBLIC METHODS
 
 GctFormatTranslateBase::GctFormatTranslateBase(bool hltMode, bool unpackSharedRegions):
-  m_collections(0),
+  m_collections(nullptr),
   m_hltMode(hltMode),
   m_unpackSharedRegions(unpackSharedRegions),
   m_srcCardRouting(),

--- a/EventFilter/GctRawToDigi/src/GctFormatTranslateMCLegacy.cc
+++ b/EventFilter/GctRawToDigi/src/GctFormatTranslateMCLegacy.cc
@@ -293,7 +293,7 @@ void GctFormatTranslateMCLegacy::writeRctEmCandBlocks(unsigned char * d, const L
 {
   // This method is one giant "temporary" hack for CMSSW_1_8_X and CMSSW_2_0_0.
 
-  if(rctEm->size() == 0 || rctEm->size()%144 != 0)  // Should be 18 crates * 2 types (iso/noniso) * 4 electrons = 144 for 1 bx.
+  if(rctEm->empty() || rctEm->size()%144 != 0)  // Should be 18 crates * 2 types (iso/noniso) * 4 electrons = 144 for 1 bx.
   {
     LogDebug("GCT") << "Block pack error: bad L1CaloEmCollection size detected!\n"
                     << "Aborting packing of RCT EM Cand data!";
@@ -378,7 +378,7 @@ void GctFormatTranslateMCLegacy::writeAllRctCaloRegionBlock(unsigned char * d, c
 {
   // This method is one giant "temporary" hack for CMSSW_1_8_X and CMSSW_2_0_0.
 
-  if(rctCalo->size() == 0 || rctCalo->size()%396 != 0)  // Should be 396 calo regions for 1 bx.
+  if(rctCalo->empty() || rctCalo->size()%396 != 0)  // Should be 396 calo regions for 1 bx.
   {
     LogDebug("GCT") << "Block pack error: bad L1CaloRegionCollection size detected!\n"
                     << "Aborting packing of RCT Calo Region data!";

--- a/EventFilter/GctRawToDigi/src/GctFormatTranslateMCLegacy.h
+++ b/EventFilter/GctRawToDigi/src/GctFormatTranslateMCLegacy.h
@@ -28,13 +28,13 @@ public:
    *  \param unpackSharedRegions - this is a commissioning option to unpack the shared RCT calo regions. */
   explicit GctFormatTranslateMCLegacy(bool hltMode = false, bool unpackSharedRegions = false);
   
-  virtual ~GctFormatTranslateMCLegacy(); ///< Destructor.
+  ~GctFormatTranslateMCLegacy() override; ///< Destructor.
 
   /// Generate a block header from four 8-bit values.
-  virtual GctBlockHeader generateBlockHeader(const unsigned char * data) const override;
+  GctBlockHeader generateBlockHeader(const unsigned char * data) const override;
   
   /// Get digis from the block - will return true if it succeeds, false otherwise.
-  virtual bool convertBlock(const unsigned char * d, const GctBlockHeader& hdr) override;
+  bool convertBlock(const unsigned char * d, const GctBlockHeader& hdr) override;
 
 
   /* ------------------------------ */
@@ -72,20 +72,20 @@ protected:
   /* PROTECTED METHODS */
 
   /* Static data member access methods */
-  virtual const BlockLengthMap& blockLengthMap() const override final { return m_blockLength; } ///< get the static block ID to block-length map.
+  const BlockLengthMap& blockLengthMap() const final { return m_blockLength; } ///< get the static block ID to block-length map.
   
-  virtual const BlockNameMap& blockNameMap() const override final { return m_blockName; }  ///< get the static block ID to blockname map.
+  const BlockNameMap& blockNameMap() const final { return m_blockName; }  ///< get the static block ID to blockname map.
   
-  virtual const BlkToRctCrateMap& rctEmCrateMap() const override final { return m_rctEmCrate; }  ///< get static the block ID to RCT crate map for electrons.
+  const BlkToRctCrateMap& rctEmCrateMap() const final { return m_rctEmCrate; }  ///< get static the block ID to RCT crate map for electrons.
  
-  virtual const BlkToRctCrateMap& rctJetCrateMap() const override final { return m_rctJetCrate; }  ///< get the static block ID to RCT crate map for jets
+  const BlkToRctCrateMap& rctJetCrateMap() const final { return m_rctJetCrate; }  ///< get the static block ID to RCT crate map for jets
 
-  virtual const BlockIdToEmCandIsoBoundMap& internEmIsoBounds() const override final { return m_internEmIsoBounds; }  ///< get the static intern EM cand isolated boundary map.
+  const BlockIdToEmCandIsoBoundMap& internEmIsoBounds() const final { return m_internEmIsoBounds; }  ///< get the static intern EM cand isolated boundary map.
 
 
   /* Other general methods */
   /// Returns a raw 32-bit header word generated from the blockId, number of time samples, bunch-crossing and event IDs.
-  virtual uint32_t generateRawHeader(const uint32_t blockId,
+  uint32_t generateRawHeader(const uint32_t blockId,
                                      const uint32_t nSamples,
                                      const uint32_t bxId,
                                      const uint32_t eventId) const override;

--- a/EventFilter/GctRawToDigi/src/GctFormatTranslateV35.h
+++ b/EventFilter/GctRawToDigi/src/GctFormatTranslateV35.h
@@ -25,13 +25,13 @@ public:
    *  \param unpackSharedRegions - this is a commissioning option to unpack the shared RCT calo regions. */
   explicit GctFormatTranslateV35(bool hltMode = false, bool unpackSharedRegions = false);
   
-  virtual ~GctFormatTranslateV35(); ///< Destructor.
+  ~GctFormatTranslateV35() override; ///< Destructor.
 
   /// Generate a block header from four 8-bit values.
-  virtual GctBlockHeader generateBlockHeader(const unsigned char * data) const override;
+  GctBlockHeader generateBlockHeader(const unsigned char * data) const override;
   
   /// Get digis from the block - will return true if it succeeds, false otherwise.
-  virtual bool convertBlock(const unsigned char * d, const GctBlockHeader& hdr) override;
+  bool convertBlock(const unsigned char * d, const GctBlockHeader& hdr) override;
 
 
   /* ------------------------------ */
@@ -46,20 +46,20 @@ protected:
   /* PROTECTED METHODS */
 
   /* Static data member access methods */
-  virtual const BlockLengthMap& blockLengthMap() const override final { return m_blockLength; } ///< get the static block ID to block-length map.
+  const BlockLengthMap& blockLengthMap() const final { return m_blockLength; } ///< get the static block ID to block-length map.
   
-  virtual const BlockNameMap& blockNameMap() const override final { return m_blockName; }  ///< get the static block ID to blockname map.
+  const BlockNameMap& blockNameMap() const final { return m_blockName; }  ///< get the static block ID to blockname map.
   
-  virtual const BlkToRctCrateMap& rctEmCrateMap() const override final { return m_rctEmCrate; }  ///< get static the block ID to RCT crate map for electrons.
+  const BlkToRctCrateMap& rctEmCrateMap() const final { return m_rctEmCrate; }  ///< get static the block ID to RCT crate map for electrons.
  
-  virtual const BlkToRctCrateMap& rctJetCrateMap() const override final { return m_rctJetCrate; }  ///< get the static block ID to RCT crate map for jets
+  const BlkToRctCrateMap& rctJetCrateMap() const final { return m_rctJetCrate; }  ///< get the static block ID to RCT crate map for jets
 
-  virtual const BlockIdToEmCandIsoBoundMap& internEmIsoBounds() const override final { return m_internEmIsoBounds; }  ///< get the static intern EM cand isolated boundary map.
+  const BlockIdToEmCandIsoBoundMap& internEmIsoBounds() const final { return m_internEmIsoBounds; }  ///< get the static intern EM cand isolated boundary map.
 
 
   /* Other general methods */
   /// Returns a raw 32-bit header word generated from the blockId, number of time samples, bunch-crossing and event IDs.
-  virtual uint32_t generateRawHeader(const uint32_t blockId,
+  uint32_t generateRawHeader(const uint32_t blockId,
                                      const uint32_t nSamples,
                                      const uint32_t bxId,
                                      const uint32_t eventId) const override;

--- a/EventFilter/GctRawToDigi/src/GctFormatTranslateV38.h
+++ b/EventFilter/GctRawToDigi/src/GctFormatTranslateV38.h
@@ -28,13 +28,13 @@ public:
                                  unsigned numberOfGctSamplesToUnpack=1,
                                  unsigned numberOfRctSamplesToUnpack=1);
   
-  virtual ~GctFormatTranslateV38(); ///< Destructor.
+  ~GctFormatTranslateV38() override; ///< Destructor.
 
   /// Generate a block header from four 8-bit values.
-  virtual GctBlockHeader generateBlockHeader(const unsigned char * data) const override;
+  GctBlockHeader generateBlockHeader(const unsigned char * data) const override;
   
   /// Get digis from the block - will return true if it succeeds, false otherwise.
-  virtual bool convertBlock(const unsigned char * d, const GctBlockHeader& hdr) override;
+  bool convertBlock(const unsigned char * d, const GctBlockHeader& hdr) override;
 
 
   /* ------------------------------ */
@@ -49,20 +49,20 @@ protected:
   /* PROTECTED METHODS */
 
   /* Static data member access methods */
-  virtual const BlockLengthMap& blockLengthMap() const override final { return m_blockLength; } ///< get the static block ID to block-length map.
+  const BlockLengthMap& blockLengthMap() const final { return m_blockLength; } ///< get the static block ID to block-length map.
   
-  virtual const BlockNameMap& blockNameMap() const override final { return m_blockName; }  ///< get the static block ID to blockname map.
+  const BlockNameMap& blockNameMap() const final { return m_blockName; }  ///< get the static block ID to blockname map.
   
-  virtual const BlkToRctCrateMap& rctEmCrateMap() const override final { return m_rctEmCrate; }  ///< get static the block ID to RCT crate map for electrons.
+  const BlkToRctCrateMap& rctEmCrateMap() const final { return m_rctEmCrate; }  ///< get static the block ID to RCT crate map for electrons.
  
-  virtual const BlkToRctCrateMap& rctJetCrateMap() const override final { return m_rctJetCrate; }  ///< get the static block ID to RCT crate map for jets
+  const BlkToRctCrateMap& rctJetCrateMap() const final { return m_rctJetCrate; }  ///< get the static block ID to RCT crate map for jets
 
-  virtual const BlockIdToEmCandIsoBoundMap& internEmIsoBounds() const override final { return m_internEmIsoBounds; }  ///< get the static intern EM cand isolated boundary map.
+  const BlockIdToEmCandIsoBoundMap& internEmIsoBounds() const final { return m_internEmIsoBounds; }  ///< get the static intern EM cand isolated boundary map.
 
 
   /* Other general methods */
   /// Returns a raw 32-bit header word generated from the blockId, number of time samples, bunch-crossing and event IDs.
-  virtual uint32_t generateRawHeader(const uint32_t blockId,
+  uint32_t generateRawHeader(const uint32_t blockId,
                                      const uint32_t nSamples,
                                      const uint32_t bxId,
                                      const uint32_t eventId) const override;

--- a/EventFilter/GctRawToDigi/src/GctUnpackCollections.h
+++ b/EventFilter/GctRawToDigi/src/GctUnpackCollections.h
@@ -59,8 +59,8 @@ public:
 
 private:
 
-  GctUnpackCollections(const GctUnpackCollections&); ///< Copy ctor - deliberately not implemented!
-  GctUnpackCollections& operator=(const GctUnpackCollections&); ///< Assignment op - deliberately not implemented!  
+  GctUnpackCollections(const GctUnpackCollections&) = delete; ///< Copy ctor - deliberately not implemented!
+  GctUnpackCollections& operator=(const GctUnpackCollections&) = delete; ///< Assignment op - deliberately not implemented!  
 
   edm::Event& m_event;  ///< The event the collections will be put into on destruction of the GctUnpackCollections instance.
 

--- a/EventFilter/HcalRawToDigi/interface/AMC13Header.h
+++ b/EventFilter/HcalRawToDigi/interface/AMC13Header.h
@@ -2,7 +2,7 @@
 #ifndef AMC13Header_H_included
 #define AMC13Header_H_included
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace hcal {
   /** \class AMC13Header

--- a/EventFilter/HcalRawToDigi/interface/HcalDTCHeader.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalDTCHeader.h
@@ -3,7 +3,7 @@
 #define HcalDTCHeader_H
 
 #include <iostream>
-#include <stdint.h>
+#include <cstdint>
 #include "DataFormats/HcalDigi/interface/HcalCalibrationEventTypes.h"
 class HcalHTRData;
 

--- a/EventFilter/HcalRawToDigi/interface/HcalHTRData.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalHTRData.h
@@ -2,7 +2,7 @@
 #ifndef HcalHTRData_H
 #define HcalHTRData_H
 
-#include <stdint.h>
+#include <cstdint>
 
 /**  \class HcalHTRData
  *
@@ -20,7 +20,7 @@ class HcalHTRData {
   static const int FORMAT_VERSION_COMPACT_DATA =  6;
   
   HcalHTRData();
-  ~HcalHTRData() { if (m_ownData!=0) delete [] m_ownData; }
+  ~HcalHTRData() { if (m_ownData!=nullptr) delete [] m_ownData; }
   HcalHTRData(int version_to_create);
   HcalHTRData(const unsigned short* data, int length);
   HcalHTRData(const HcalHTRData&);

--- a/EventFilter/HcalRawToDigi/interface/HcalLaserEventFilter2012.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalLaserEventFilter2012.h
@@ -41,15 +41,15 @@ class HcalLaserEventFiltProducer2012;
 class HcalLaserEventFilter2012 : public edm::EDFilter {
 public:
   explicit HcalLaserEventFilter2012(const edm::ParameterSet&);
-  ~HcalLaserEventFilter2012();
+  ~HcalLaserEventFilter2012() override;
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
   friend HcalLaserEventFiltProducer2012;
 
 private:
-  virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
   
   void readEventListFile(const std::string & eventFileName);
   void addEventString(const std::string & eventString);

--- a/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
@@ -2,7 +2,7 @@
 #ifndef HcalUHTRData_H
 #define HcalUHTRData_H
 
-#include <stdint.h>
+#include <cstdint>
 
 /**  \class HcalUHTRData
  *
@@ -21,7 +21,7 @@ class HcalUHTRData {
   static const int CHANNELS_PER_FIBER_MAX      = 8;
   
   HcalUHTRData();
-  ~HcalUHTRData() { if (m_ownData!=0) delete [] m_ownData; }
+  ~HcalUHTRData() { if (m_ownData!=nullptr) delete [] m_ownData; }
   HcalUHTRData(int version_to_create);
   HcalUHTRData(const uint64_t* data, int length_words);
   HcalUHTRData(const HcalUHTRData&);
@@ -39,7 +39,7 @@ class HcalUHTRData {
   
   class const_iterator {
   public:
-    const_iterator(const uint16_t* ptr, const uint16_t* limit=0);
+    const_iterator(const uint16_t* ptr, const uint16_t* limit=nullptr);
     
     bool isHeader() const { return ((*m_ptr)&0x8000)!=0; }
     int flavor() const { return ((*m_ptr)>>12)&0x7; }

--- a/EventFilter/HcalRawToDigi/plugins/HcalCalibFEDSelector.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalCalibFEDSelector.cc
@@ -17,13 +17,13 @@
 class HcalCalibFEDSelector : public edm::EDProducer {
 public:
   HcalCalibFEDSelector(const edm::ParameterSet&);
-  ~HcalCalibFEDSelector();
+  ~HcalCalibFEDSelector() override;
 
 
 private:
-  virtual void beginJob() override ;
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override ;
+  void beginJob() override ;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
 
   // ----------member data ---------------------------
   edm::EDGetTokenT<FEDRawDataCollection> tok_fed_;

--- a/EventFilter/HcalRawToDigi/plugins/HcalCalibTypeFilter.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalCalibTypeFilter.cc
@@ -45,12 +45,12 @@ Implementation:
 class HcalCalibTypeFilter : public edm::EDFilter {
 public:
   explicit HcalCalibTypeFilter(const edm::ParameterSet&);
-  virtual ~HcalCalibTypeFilter();
+  ~HcalCalibTypeFilter() override;
   
 private:
-  virtual void beginJob() override ;
-  virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override ;
+  void beginJob() override ;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
   
   // ----------member data ---------------------------
  

--- a/EventFilter/HcalRawToDigi/plugins/HcalDigiToRaw.h
+++ b/EventFilter/HcalRawToDigi/plugins/HcalDigiToRaw.h
@@ -28,8 +28,8 @@ class HcalDigiToRaw : public edm::global::EDProducer<>
 {
 public:
   explicit HcalDigiToRaw(const edm::ParameterSet& ps);
-  virtual ~HcalDigiToRaw();
-  virtual void produce(edm::StreamID id, edm::Event& e, const edm::EventSetup& c) const override;
+  ~HcalDigiToRaw() override;
+  void produce(edm::StreamID id, edm::Event& e, const edm::EventSetup& c) const override;
 private:
   HcalPacker packer_;
   const edm::InputTag hbheTag_, hoTag_, hfTag_, zdcTag_, calibTag_, trigTag_;

--- a/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
@@ -41,9 +41,9 @@ using namespace std;
 class HcalDigiToRawuHTR : public edm::global::EDProducer<> {
 public:
   explicit HcalDigiToRawuHTR(const edm::ParameterSet&);
-  ~HcalDigiToRawuHTR();
+  ~HcalDigiToRawuHTR() override;
 
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 

--- a/EventFilter/HcalRawToDigi/plugins/HcalEmptyEventFilter.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalEmptyEventFilter.cc
@@ -45,10 +45,10 @@ Implementation:
 class HcalEmptyEventFilter : public edm::EDFilter {
 public:
   explicit HcalEmptyEventFilter(const edm::ParameterSet&);
-  virtual ~HcalEmptyEventFilter();
+  ~HcalEmptyEventFilter() override;
   
 private:
-  virtual bool filter(edm::Event&, const edm::EventSetup&) override;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
   
   // ----------member data ---------------------------
 

--- a/EventFilter/HcalRawToDigi/plugins/HcalHistogramRawToDigi.h
+++ b/EventFilter/HcalRawToDigi/plugins/HcalHistogramRawToDigi.h
@@ -28,8 +28,8 @@ class HcalHistogramRawToDigi : public edm::EDProducer
 {
 public:
   explicit HcalHistogramRawToDigi(const edm::ParameterSet& ps);
-  virtual ~HcalHistogramRawToDigi();
-  virtual void produce(edm::Event& e, const edm::EventSetup& c);
+  ~HcalHistogramRawToDigi() override;
+  void produce(edm::Event& e, const edm::EventSetup& c) override;
 private:
   edm::EDGetTokenT<FEDRawDataCollection> tok_data_;
   HcalUnpacker unpacker_;

--- a/EventFilter/HcalRawToDigi/plugins/HcalLaserEventFiltProducer2012.h
+++ b/EventFilter/HcalRawToDigi/plugins/HcalLaserEventFiltProducer2012.h
@@ -10,13 +10,13 @@ class HcalLaserEventFiltProducer2012 : public edm::EDProducer {
 
  public:
   explicit HcalLaserEventFiltProducer2012(const edm::ParameterSet& iConfig);
-  virtual ~HcalLaserEventFiltProducer2012(){
+  ~HcalLaserEventFiltProducer2012() override{
     delete hcalLaserEventFilter2012;
 } 
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
  private:
-  virtual void endJob() override;
+  void endJob() override;
   HcalLaserEventFilter2012 *hcalLaserEventFilter2012;
 };
 

--- a/EventFilter/HcalRawToDigi/plugins/HcalLaserEventFilter2012.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalLaserEventFilter2012.cc
@@ -107,7 +107,7 @@ void HcalLaserEventFilter2012::readEventListFile(const string & eventFileName)
   unsigned int i;
   char * pch;
 
-  while (1) {
+  while (true) {
     bytes_read = gzread (file, buffer, LENGTH - 1);
     buffer[bytes_read] = '\0';
     i=0;
@@ -117,7 +117,7 @@ void HcalLaserEventFilter2012::readEventListFile(const string & eventFileName)
       ++i;
     } else b2+=pch;
   
-    while (pch != NULL)
+    while (pch != nullptr)
     {
       i+=strlen(pch)+1;
       if (i>b2.size()) b2= pch;
@@ -129,7 +129,7 @@ void HcalLaserEventFilter2012::readEventListFile(const string & eventFileName)
       } else if (i<LENGTH) {
 	addEventString(b2);
       } 
-      pch = strtok (NULL, "\n");
+      pch = strtok (nullptr, "\n");
     }
     if (bytes_read < LENGTH - 1) {
       if (gzeof (file)) break;

--- a/EventFilter/HcalRawToDigi/plugins/HcalLaserHBHEFilter2012.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalLaserHBHEFilter2012.cc
@@ -51,13 +51,13 @@
 class HcalLaserHBHEFilter2012 : public edm::EDFilter {
 public:
   explicit HcalLaserHBHEFilter2012(const edm::ParameterSet&);
-  ~HcalLaserHBHEFilter2012();
+  ~HcalLaserHBHEFilter2012() override;
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
 private:
-  virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
   
   // ----------member data ---------------------------
   bool verbose_;  // if set to true, then the run:LS:event for any event failing the cut will be printed out

--- a/EventFilter/HcalRawToDigi/plugins/HcalLaserHBHEHFFilter2012.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalLaserHBHEHFFilter2012.cc
@@ -51,13 +51,13 @@
 class HcalLaserHBHEHFFilter2012 : public edm::EDFilter {
 public:
   explicit HcalLaserHBHEHFFilter2012(const edm::ParameterSet&);
-  ~HcalLaserHBHEHFFilter2012();
+  ~HcalLaserHBHEHFFilter2012() override;
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
 private:
-  virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
   
   // ----------member data ---------------------------
   bool filterHBHE_; // Flag to activate laser filter for HBHE

--- a/EventFilter/HcalRawToDigi/plugins/HcalLaserHFFilter2012.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalLaserHFFilter2012.cc
@@ -52,13 +52,13 @@
 class HcalLaserHFFilter2012 : public edm::EDFilter {
 public:
   explicit HcalLaserHFFilter2012(const edm::ParameterSet&);
-  ~HcalLaserHFFilter2012();
+  ~HcalLaserHFFilter2012() override;
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
 private:
-  virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
   
   // ----------member data ---------------------------
   bool verbose_;  // if set to true, then the run:LS:event for any event failing the cut will be printed out

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
@@ -200,15 +200,15 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   auto ho_prod = std::make_unique<HODigiCollection>();
   auto htp_prod = std::make_unique<HcalTrigPrimDigiCollection>();
   auto hotp_prod = std::make_unique<HOTrigPrimDigiCollection>();
-  if (colls.qie10 == 0) {
+  if (colls.qie10 == nullptr) {
     colls.qie10 = new QIE10DigiCollection(); 
   }
   std::unique_ptr<QIE10DigiCollection> qie10_prod(colls.qie10);
-  if (colls.qie10ZDC == 0) {
+  if (colls.qie10ZDC == nullptr) {
     colls.qie10ZDC = new QIE10DigiCollection(); 
   }
   std::unique_ptr<QIE10DigiCollection> qie10ZDC_prod(colls.qie10ZDC);
-  if (colls.qie11 == 0) {
+  if (colls.qie11 == nullptr) {
     colls.qie11 = new QIE11DigiCollection(); 
   }
   std::unique_ptr<QIE11DigiCollection> qie11_prod(colls.qie11);
@@ -293,7 +293,7 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   e.put(std::move(report));
   /// umnio
   if (unpackUMNio_) {
-    if(colls.umnio != 0) {
+    if(colls.umnio != nullptr) {
       e.put(std::make_unique<HcalUMNioDigi>(umnio));
     }
 

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.h
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.h
@@ -30,9 +30,9 @@ class HcalRawToDigi : public edm::stream::EDProducer <>
 {
 public:
   explicit HcalRawToDigi(const edm::ParameterSet& ps);
-  virtual ~HcalRawToDigi();
+  ~HcalRawToDigi() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  virtual void produce(edm::Event& , const edm::EventSetup&) override;
+  void produce(edm::Event& , const edm::EventSetup&) override;
 private:
   edm::EDGetTokenT<FEDRawDataCollection> tok_data_;
   HcalUnpacker unpacker_;

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigiFake.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigiFake.cc
@@ -25,7 +25,7 @@ namespace raw_impl {
       //copy constructor
       o_coll = std::make_unique<T>(*(h_coll.product()));
     }
-    if(productName.size()) e.put(std::move(o_coll),productName);
+    if(!productName.empty()) e.put(std::move(o_coll),productName);
     else e.put(std::move(o_coll));
   }
 }
@@ -34,9 +34,9 @@ class HcalRawToDigiFake : public edm::global::EDProducer<>
 {
 public:
   explicit HcalRawToDigiFake(const edm::ParameterSet& ps);
-  virtual ~HcalRawToDigiFake();
+  ~HcalRawToDigiFake() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  virtual void produce(edm::StreamID id, edm::Event& e, const edm::EventSetup& c) const override;
+  void produce(edm::StreamID id, edm::Event& e, const edm::EventSetup& c) const override;
 private:
   //members
   edm::EDGetTokenT<QIE10DigiCollection> tok_QIE10DigiCollection_;

--- a/EventFilter/HcalRawToDigi/src/HcalDCCHeader.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalDCCHeader.cc
@@ -4,8 +4,8 @@
 #include "EventFilter/HcalRawToDigi/interface/HcalHTRData.h"
 #include "EventFilter/HcalRawToDigi/interface/HcalDCCHeader.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <string.h>
-#include <stdint.h>
+#include <cstring>
+#include <cstdint>
 
 const int HcalDCCHeader::SPIGOT_COUNT = 15;
 

--- a/EventFilter/HcalRawToDigi/src/HcalDTCHeader.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalDTCHeader.cc
@@ -3,8 +3,8 @@
  */
 #include "EventFilter/HcalRawToDigi/interface/HcalHTRData.h"
 #include "EventFilter/HcalRawToDigi/interface/HcalDTCHeader.h"
-#include <string.h>
-#include <stdint.h>
+#include <cstring>
+#include <cstdint>
 
 const int HcalDTCHeader::SLOT_COUNT = 12;
 const int HcalDTCHeader::MINIMUM_SLOT = 1;

--- a/EventFilter/HcalRawToDigi/src/HcalHTRData.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalHTRData.cc
@@ -9,15 +9,15 @@
 const int HcalHTRData::CHANNELS_PER_SPIGOT         = 24;
 const int HcalHTRData::MAXIMUM_SAMPLES_PER_CHANNEL = 20;
 #endif
-#include <string.h>
-#include <stdio.h>
+#include <cstring>
+#include <cstdio>
 
-HcalHTRData::HcalHTRData() : m_formatVersion(-2), m_rawLength(0), m_rawConst(0), m_ownData(0) { }
+HcalHTRData::HcalHTRData() : m_formatVersion(-2), m_rawLength(0), m_rawConst(nullptr), m_ownData(nullptr) { }
 HcalHTRData::HcalHTRData(const unsigned short* data, int length) {
   adoptData(data,length);
-  m_ownData=0;
+  m_ownData=nullptr;
 }
-HcalHTRData::HcalHTRData(const HcalHTRData& hd) : m_formatVersion(hd.m_formatVersion), m_rawLength(hd.m_rawLength), m_rawConst(hd.m_rawConst), m_ownData(0) { }
+HcalHTRData::HcalHTRData(const HcalHTRData& hd) : m_formatVersion(hd.m_formatVersion), m_rawLength(hd.m_rawLength), m_rawConst(hd.m_rawConst), m_ownData(nullptr) { }
 
 HcalHTRData::HcalHTRData(int version_to_create) : m_formatVersion(version_to_create) {
   allocate(version_to_create);
@@ -36,7 +36,7 @@ void HcalHTRData::allocate(int version_to_create) {
 }
 
 HcalHTRData& HcalHTRData::operator=(const HcalHTRData& hd) {
-  if (m_ownData==0) {
+  if (m_ownData==nullptr) {
     m_formatVersion=hd.m_formatVersion;
     m_rawLength=hd.m_rawLength;
     m_rawConst=hd.m_rawConst;
@@ -172,8 +172,8 @@ static const int channelDecoder[32] = { 0, 1, 2, 99, 3, 4, 5, 99,
 void HcalHTRData::unpack(unsigned char* daq_lengths, unsigned short* daq_samples,
 			 unsigned char* tp_lengths, unsigned short* tp_samples) const {
 
-  if (daq_lengths!=0) memset(daq_lengths,0,CHANNELS_PER_SPIGOT);
-  if (tp_lengths!=0) memset(tp_lengths,0,CHANNELS_PER_SPIGOT);
+  if (daq_lengths!=nullptr) memset(daq_lengths,0,CHANNELS_PER_SPIGOT);
+  if (tp_lengths!=nullptr) memset(tp_lengths,0,CHANNELS_PER_SPIGOT);
 
   // currently, the major differences between the versions are
   //  -1 : 6 word header, no zero suppression, trailer setup
@@ -186,7 +186,7 @@ void HcalHTRData::unpack(unsigned char* daq_lengths, unsigned short* daq_samples
   int wordPtr;
   const unsigned short* tpBase=m_rawConst+headerLen;
   // process the trigger primitive words
-  if (tp_lengths!=0) {
+  if (tp_lengths!=nullptr) {
     for (wordPtr=0; wordPtr<tp_words_total; wordPtr++) {
       int ichan=channelDecoder[tpBase[wordPtr]>>11];
       if (ichan>=24) continue;
@@ -199,7 +199,7 @@ void HcalHTRData::unpack(unsigned char* daq_lengths, unsigned short* daq_samples
   // process the DAQ words [ assumes that data from one channel will always be together ]
   int lastChan=-1;
   int lastCapid=0;
-  if (daq_lengths!=0) {
+  if (daq_lengths!=nullptr) {
     for (wordPtr=0; wordPtr<daq_words_total; wordPtr++) {
       int ichan=channelDecoder[daqBase[wordPtr]>>11];
       if (ichan>=24) continue;
@@ -233,7 +233,7 @@ void HcalHTRData::pack(unsigned char* daq_lengths, unsigned short* daq_samples,
 
   // trigger primitive words
   unsigned short* ptr=m_ownData+headerLen;
-  if (tp_samples!=0 && tp_lengths!=0) {
+  if (tp_samples!=nullptr && tp_lengths!=nullptr) {
     for (ichan=0; ichan<24; ichan++) {
       unsigned short chanid=((ichan%4)+(((ichan/4)+1)<<2))<<11;
       for (isample=0; isample<tp_lengths[ichan] && isample<MAXIMUM_SAMPLES_PER_CHANNEL; isample++) {

--- a/EventFilter/HcalRawToDigi/src/HcalPacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalPacker.cc
@@ -7,18 +7,18 @@
 #include "FWCore/Utilities/interface/CRC16.h"
 
 HcalPacker::Collections::Collections() {
-  hbhe=0;
-  hoCont=0;
-  hfCont=0;
-  tpCont=0;
-  zdcCont=0;
-  calibCont=0;
+  hbhe=nullptr;
+  hoCont=nullptr;
+  hfCont=nullptr;
+  tpCont=nullptr;
+  zdcCont=nullptr;
+  calibCont=nullptr;
 }
 
 template <class Coll, class DetIdClass> 
 int process(const Coll* pt, const DetId& did, unsigned short* buffer, int& presamples,bool& isUS, bool& isMP) {
   isUS=false; isMP=false;
-  if (pt==0) { return 0; }
+  if (pt==nullptr) { return 0; }
   int size=0;
   typename Coll::const_iterator i=pt->find(DetIdClass(did));
   if (i!=pt->end()) {
@@ -34,7 +34,7 @@ int process(const Coll* pt, const DetId& did, unsigned short* buffer, int& presa
 }
 
 static unsigned char processTrig(const HcalTrigPrimDigiCollection* pt, const HcalTrigTowerDetId& tid, unsigned short* buffer) {
-  if (pt==0) { return 0; }
+  if (pt==nullptr) { return 0; }
   int size=0;
   HcalTrigPrimDigiCollection::const_iterator i=pt->find(tid);
   bool any_nonzero=false;
@@ -146,7 +146,7 @@ void HcalPacker::pack(int fedid, int dccnumber,
     for (int slb=1; slb<=6; slb++) {
       for (int slbchan=0; slbchan<=3; slbchan++) {
 	int linear=(slb-1)*4+slbchan;
-	HcalTriggerPrimitiveSample idCvt(0,0,slb,slbchan);
+	HcalTriggerPrimitiveSample idCvt(0,false,slb,slbchan);
 	unsigned short chanid=idCvt.raw()&0xF800;
 	triglen[linear]=0;
 

--- a/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
@@ -1,5 +1,5 @@
 #include "EventFilter/HcalRawToDigi/interface/HcalUHTRData.h"
-#include <string.h>
+#include <cstring>
 
 static const int HEADER_LENGTH_16BIT=2*sizeof(uint64_t)/sizeof(uint16_t);
 
@@ -104,13 +104,13 @@ HcalUHTRData::const_iterator HcalUHTRData::end() const {
   return HcalUHTRData::const_iterator(m_raw16+(m_rawLength64-1)*sizeof(uint64_t)/sizeof(uint16_t),m_raw16+(m_rawLength64-1)*sizeof(uint64_t)/sizeof(uint16_t));
 }
 
-HcalUHTRData::HcalUHTRData() : m_formatVersion(-2), m_rawLength64(0), m_raw64(0), m_raw16(0), m_ownData(0) { }
+HcalUHTRData::HcalUHTRData() : m_formatVersion(-2), m_rawLength64(0), m_raw64(nullptr), m_raw16(nullptr), m_ownData(nullptr) { }
 
-HcalUHTRData::HcalUHTRData(const uint64_t* data, int length) : m_rawLength64(length),m_raw64(data),m_raw16((const uint16_t*)(data)),m_ownData(0) {
+HcalUHTRData::HcalUHTRData(const uint64_t* data, int length) : m_rawLength64(length),m_raw64(data),m_raw16((const uint16_t*)(data)),m_ownData(nullptr) {
   m_formatVersion=(m_raw16[6]>>12)&0xF;
 }
 
-HcalUHTRData::HcalUHTRData(const HcalUHTRData& hd) : m_formatVersion(hd.m_formatVersion), m_rawLength64(hd.m_rawLength64), m_raw64(hd.m_raw64), m_raw16(hd.m_raw16), m_ownData(0) { }
+HcalUHTRData::HcalUHTRData(const HcalUHTRData& hd) : m_formatVersion(hd.m_formatVersion), m_rawLength64(hd.m_rawLength64), m_raw64(hd.m_raw64), m_raw16(hd.m_raw16), m_ownData(nullptr) { }
 
 HcalUHTRData::HcalUHTRData(int version_to_create) : m_formatVersion(version_to_create) {
 
@@ -126,7 +126,7 @@ HcalUHTRData::HcalUHTRData(int version_to_create) : m_formatVersion(version_to_c
 }
 
 HcalUHTRData& HcalUHTRData::operator=(const HcalUHTRData& hd) {
-  if (m_ownData==0) {
+  if (m_ownData==nullptr) {
     m_formatVersion=hd.m_formatVersion;
     m_rawLength64=hd.m_rawLength64;
     m_raw64=hd.m_raw64;

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -289,7 +289,7 @@ void HcalUnpacker::unpackVME(const FEDRawData& raw, const HcalElectronicsMap& em
       continue;
     }
     if ((htr.getFirmwareFlavor()&0xE0)==0x80) { // some kind of TTP data
-      if (colls.ttp!=0) {
+      if (colls.ttp!=nullptr) {
 	HcalTTPUnpacker ttpUnpack;
 	colls.ttp->push_back(HcalTTPDigi());
 	ttpUnpack.unpack(htr,colls.ttp->back());
@@ -640,7 +640,7 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
               ns++;
           }
           // Check QEI11 container exists
-          if (colls.qie11 == 0) {
+          if (colls.qie11 == nullptr) {
               colls.qie11 = new QIE11DigiCollection(ns);
           }
           else if (colls.qie11->samples() != ns) {
@@ -682,7 +682,7 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
 	}
 
 	// Check QEI10 container exists
-	if (colls.qie10ZDC == 0) {
+	if (colls.qie10ZDC == nullptr) {
 	  colls.qie10ZDC = new QIE10DigiCollection(ns);
 	}
 	else if (colls.qie10ZDC->samples() != ns) {
@@ -691,7 +691,7 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
 	  return;
 	}
 	
-	if (colls.qie10 == 0) {
+	if (colls.qie10 == nullptr) {
 	  colls.qie10 = new QIE10DigiCollection(ns);
 	}
 	else if (colls.qie10->samples() != ns) {
@@ -816,17 +816,17 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
 }
 
 HcalUnpacker::Collections::Collections() {
-  hbheCont=0;
-  hoCont=0;
-  hfCont=0;
-  tpCont=0;
-  zdcCont=0;
-  calibCont=0;
-  ttp=0;
-  qie10=0;
-  qie10ZDC=0;
-  qie11=0;
-  umnio=0;
+  hbheCont=nullptr;
+  hoCont=nullptr;
+  hfCont=nullptr;
+  tpCont=nullptr;
+  zdcCont=nullptr;
+  calibCont=nullptr;
+  ttp=nullptr;
+  qie10=nullptr;
+  qie10ZDC=nullptr;
+  qie11=nullptr;
+  umnio=nullptr;
 }
 
 void HcalUnpacker::unpack(const FEDRawData& raw, const HcalElectronicsMap& emap, std::vector<HcalHistogramDigi>& histoDigis) {

--- a/EventFilter/L1GlobalTriggerRawToDigi/interface/ConditionDumperInEdm.h
+++ b/EventFilter/L1GlobalTriggerRawToDigi/interface/ConditionDumperInEdm.h
@@ -49,12 +49,12 @@ class ConditionDumperInEdm : public edm::one::EDProducer<edm::EndRunProducer,
                                                          edm::EndLuminosityBlockProducer> {
    public:
       explicit ConditionDumperInEdm(const edm::ParameterSet&);
-      ~ConditionDumperInEdm();
+      ~ConditionDumperInEdm() override;
 
    private:
-      virtual void endLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) override final;
-      virtual void endRunProduce(edm::Run& , const edm::EventSetup&) override final;
-      virtual void produce(edm::Event&, const edm::EventSetup&) override final;
+      void endLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) final;
+      void endRunProduce(edm::Run& , const edm::EventSetup&) final;
+      void produce(edm::Event&, const edm::EventSetup&) final;
 
   template <typename R, typename T>
   const T * get(const edm::EventSetup & setup) {

--- a/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GTDigiToRaw.h
+++ b/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GTDigiToRaw.h
@@ -51,15 +51,15 @@ public:
     explicit L1GTDigiToRaw(const edm::ParameterSet&);
 
     /// destructor
-    virtual ~L1GTDigiToRaw();
+    ~L1GTDigiToRaw() override;
 
 private:
 
     /// beginning of job stuff
-    virtual void beginJob();
+    void beginJob() override;
 
     /// loop over events
-    virtual void produce(edm::Event&, const edm::EventSetup&);
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
     /// block packers -------------
 
@@ -92,7 +92,7 @@ private:
     void packTrailer(unsigned char*, unsigned char*, int);
 
     /// end of job stuff
-    virtual void endJob();
+    void endJob() override;
 
 private:
 

--- a/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GTEvmDigiToRaw.h
+++ b/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GTEvmDigiToRaw.h
@@ -48,15 +48,15 @@ public:
     explicit L1GTEvmDigiToRaw(const edm::ParameterSet&);
 
     /// destructor
-    virtual ~L1GTEvmDigiToRaw();
+    ~L1GTEvmDigiToRaw() override;
 
 private:
 
     /// beginning of job stuff
-    virtual void beginJob();
+    void beginJob() override;
 
     /// loop over events
-    virtual void produce(edm::Event&, const edm::EventSetup&);
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
     /// block packers -------------
 
@@ -80,7 +80,7 @@ private:
     void packTrailer(unsigned char*, unsigned char*, int);
 
     /// end of job stuff
-    virtual void endJob();
+    void endJob() override;
 
 private:
 

--- a/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GlobalTriggerEvmRawToDigi.h
+++ b/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GlobalTriggerEvmRawToDigi.h
@@ -50,11 +50,11 @@ public:
     explicit L1GlobalTriggerEvmRawToDigi(const edm::ParameterSet&);
 
     /// destructor
-    virtual ~L1GlobalTriggerEvmRawToDigi();
+    ~L1GlobalTriggerEvmRawToDigi() override;
 
 private:
 
-    virtual void produce(edm::Event&, const edm::EventSetup&) override;
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
     /// block unpackers
 

--- a/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GlobalTriggerRawToDigi.h
+++ b/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GlobalTriggerRawToDigi.h
@@ -55,13 +55,13 @@ public:
     explicit L1GlobalTriggerRawToDigi(const edm::ParameterSet&);
 
     /// destructor
-    virtual ~L1GlobalTriggerRawToDigi();
+    ~L1GlobalTriggerRawToDigi() override;
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
 
-    virtual void produce(edm::Event&, const edm::EventSetup&) override;
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
     /// block unpackers
 

--- a/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GlobalTriggerRecordProducer.h
+++ b/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GlobalTriggerRecordProducer.h
@@ -43,11 +43,11 @@ public:
     explicit L1GlobalTriggerRecordProducer(const edm::ParameterSet&);
 
     /// destructor
-    virtual ~L1GlobalTriggerRecordProducer();
+    ~L1GlobalTriggerRecordProducer() override;
 
 private:
 
-    virtual void produce(edm::Event&, const edm::EventSetup&) override;
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
     

--- a/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GtTextToRaw.h
+++ b/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GtTextToRaw.h
@@ -42,12 +42,12 @@ public:
     explicit L1GtTextToRaw(const edm::ParameterSet&);
 
     /// destructor
-    virtual ~L1GtTextToRaw();
+    ~L1GtTextToRaw() override;
 
 private:
 
     /// beginning of job stuff
-    virtual void beginJob();
+    void beginJob() override;
 
     /// clean the text file, if needed
     virtual void cleanTextFile();
@@ -56,10 +56,10 @@ private:
     virtual int getDataSize();
 
     /// loop over events
-    virtual void produce(edm::Event&, const edm::EventSetup&);
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
     /// end of job stuff
-    virtual void endJob();
+    void endJob() override;
 
 private:
 

--- a/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GtTriggerMenuLiteProducer.h
+++ b/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GtTriggerMenuLiteProducer.h
@@ -48,7 +48,7 @@ public:
     explicit L1GtTriggerMenuLiteProducer(const edm::ParameterSet&);
 
     /// destructor
-    virtual ~L1GtTriggerMenuLiteProducer();
+    ~L1GtTriggerMenuLiteProducer() override;
 
 private:
 
@@ -56,12 +56,12 @@ private:
     /// and cache them to improve the speed
     void retrieveL1EventSetup(const edm::EventSetup&);
 
-    virtual void beginJob() override final;
-    void beginRunProduce(edm::Run&, const edm::EventSetup&) override final;
+    void beginJob() final;
+    void beginRunProduce(edm::Run&, const edm::EventSetup&) final;
 
-    virtual void produce(edm::Event&, const edm::EventSetup&) override final;
+    void produce(edm::Event&, const edm::EventSetup&) final;
 
-    virtual void endJob() override;
+    void endJob() override;
 
 private:
     

--- a/EventFilter/L1TRawToDigi/interface/AMC13Spec.h
+++ b/EventFilter/L1TRawToDigi/interface/AMC13Spec.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 #include <vector>
-#include <stdint.h>
+#include <cstdint>
 
 #include "AMCSpec.h"
 

--- a/EventFilter/L1TRawToDigi/interface/AMCSpec.h
+++ b/EventFilter/L1TRawToDigi/interface/AMCSpec.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 #include <vector>
-#include <stdint.h>
+#include <cstdint>
 
 namespace amc {
    static const unsigned int split_block_size = 0x1000;

--- a/EventFilter/L1TRawToDigi/interface/MP7FileReader.h
+++ b/EventFilter/L1TRawToDigi/interface/MP7FileReader.h
@@ -12,7 +12,7 @@
 #include <string>
 #include <fstream>
 #include <map>
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 // Boost Headers

--- a/EventFilter/L1TRawToDigi/plugins/AMC13DumpToRaw.cc
+++ b/EventFilter/L1TRawToDigi/plugins/AMC13DumpToRaw.cc
@@ -51,15 +51,15 @@ namespace l1t {
 class AMC13DumpToRaw : public edm::EDProducer {
 public:
   explicit AMC13DumpToRaw(const edm::ParameterSet&);
-  ~AMC13DumpToRaw();
+  ~AMC13DumpToRaw() override;
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
   
 private:
-  virtual void beginJob() override;
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override;
+  void beginJob() override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
   void readEvent(std::vector<uint32_t>& load32);
 

--- a/EventFilter/L1TRawToDigi/plugins/AMCDumpToRaw.cc
+++ b/EventFilter/L1TRawToDigi/plugins/AMCDumpToRaw.cc
@@ -51,15 +51,15 @@ namespace l1t {
 class AMCDumpToRaw : public edm::EDProducer {
 public:
   explicit AMCDumpToRaw(const edm::ParameterSet&);
-  ~AMCDumpToRaw();
+  ~AMCDumpToRaw() override;
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
   
 private:
-  virtual void beginJob() override;
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override;
+  void beginJob() override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
   void readEvent(std::vector<uint32_t>& load32);
 

--- a/EventFilter/L1TRawToDigi/plugins/L1TCaloTowersFilter.cc
+++ b/EventFilter/L1TRawToDigi/plugins/L1TCaloTowersFilter.cc
@@ -50,12 +50,12 @@ namespace l1t {
 class L1TCaloTowersFilter : public edm::EDFilter {
 public:
   explicit L1TCaloTowersFilter(const edm::ParameterSet&);
-  virtual ~L1TCaloTowersFilter();
+  ~L1TCaloTowersFilter() override;
   
 private:
-  virtual void beginJob() override ;
-  virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override ;
+  void beginJob() override ;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
   
   // ----------member data ---------------------------
   edm::EDGetTokenT<FEDRawDataCollection> fedData_;

--- a/EventFilter/L1TRawToDigi/plugins/L1TRawToDigi.cc
+++ b/EventFilter/L1TRawToDigi/plugins/L1TRawToDigi.cc
@@ -45,17 +45,17 @@ namespace l1t {
    class L1TRawToDigi : public edm::stream::EDProducer<> {
       public:
          explicit L1TRawToDigi(const edm::ParameterSet&);
-         ~L1TRawToDigi();
+         ~L1TRawToDigi() override;
 
          static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
       private:
-         virtual void produce(edm::Event&, const edm::EventSetup&) override;
+         void produce(edm::Event&, const edm::EventSetup&) override;
 
-         virtual void beginRun(edm::Run const&, edm::EventSetup const&) override {};
-         virtual void endRun(edm::Run const&, edm::EventSetup const&) override {};
-         virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {};
-         virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {};
+         void beginRun(edm::Run const&, edm::EventSetup const&) override {};
+         void endRun(edm::Run const&, edm::EventSetup const&) override {};
+         void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {};
+         void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {};
 
          // ----------member data ---------------------------
          edm::EDGetTokenT<FEDRawDataCollection> fedData_;

--- a/EventFilter/L1TRawToDigi/plugins/MP7BufferDumpToRaw.cc
+++ b/EventFilter/L1TRawToDigi/plugins/MP7BufferDumpToRaw.cc
@@ -57,15 +57,15 @@ namespace l1t {
 class MP7BufferDumpToRaw : public edm::EDProducer {
 public:
   explicit MP7BufferDumpToRaw(const edm::ParameterSet&);
-  ~MP7BufferDumpToRaw();
+  ~MP7BufferDumpToRaw() override;
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
   
 private:
-  virtual void beginJob() override;
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override;
+  void beginJob() override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
   std::vector<Block> getBlocks(int iAmc);
 

--- a/EventFilter/L1TRawToDigi/plugins/PackerFactory.cc
+++ b/EventFilter/L1TRawToDigi/plugins/PackerFactory.cc
@@ -12,7 +12,7 @@ namespace l1t {
    {
       auto unpacker = std::shared_ptr<Packer>(PackerFactoryT::get()->create("l1t::" + name));
 
-      if (unpacker.get() == 0) {
+      if (unpacker.get() == nullptr) {
          throw edm::Exception(edm::errors::Configuration, "NoSourceModule")
             << "Cannot find a packer named " << name;
       }

--- a/EventFilter/L1TRawToDigi/plugins/PackingSetupFactory.cc
+++ b/EventFilter/L1TRawToDigi/plugins/PackingSetupFactory.cc
@@ -12,7 +12,7 @@ namespace l1t {
    {
       auto helper = std::unique_ptr<PackingSetup>(PackingSetupFactoryT::get()->create("l1t::" + type));
 
-      if (helper.get() == 0)
+      if (helper.get() == nullptr)
          throw edm::Exception(edm::errors::Configuration, "NoSourceModule") << "cannot find packing setup " << type;
 
       return helper;

--- a/EventFilter/L1TRawToDigi/plugins/TMTFilter.cc
+++ b/EventFilter/L1TRawToDigi/plugins/TMTFilter.cc
@@ -47,12 +47,12 @@ Implementation:
 class TMTFilter : public edm::EDFilter {
 public:
   explicit TMTFilter(const edm::ParameterSet&);
-  virtual ~TMTFilter();
+  ~TMTFilter() override;
   
 private:
-  virtual void beginJob() override ;
-  virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override ;
+  void beginJob() override ;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
   
   // ----------member data ---------------------------
   edm::EDGetTokenT<FEDRawDataCollection> fedData_;

--- a/EventFilter/L1TRawToDigi/plugins/UnpackerFactory.cc
+++ b/EventFilter/L1TRawToDigi/plugins/UnpackerFactory.cc
@@ -21,7 +21,7 @@ namespace l1t {
    {
       auto unpacker = std::shared_ptr<Unpacker>(UnpackerFactoryT::get()->create("l1t::" + name));
 
-      if (unpacker.get() == 0) {
+      if (unpacker.get() == nullptr) {
          throw edm::Exception(edm::errors::Configuration, "NoSourceModule")
             << "Cannot find an unpacker named " << name;
       }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/CaloCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/CaloCollections.h
@@ -36,7 +36,7 @@ namespace l1t {
                caloEmCands_(new L1CaloEmCollection()),
                caloRegions_(new L1CaloRegionCollection()) {};
 
-            virtual ~CaloCollections();
+            ~CaloCollections() override;
 
             inline CaloTowerBxCollection* getTowers() { return towers_.get(); };
             inline EGammaBxCollection* getEGammas() { return egammas_.get(); };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/CaloSetup.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/CaloSetup.h
@@ -13,13 +13,13 @@ namespace l1t {
    namespace stage1 {
       class CaloSetup : public PackingSetup {
          public:
-            virtual ~CaloSetup() {};
-            virtual std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override;
-            virtual void fillDescription(edm::ParameterSetDescription& desc) override;
-            virtual PackerMap getPackers(int fed, unsigned int fw) override;
-            virtual void registerProducts(edm::stream::EDProducerBase& prod) override;
-            virtual std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override;
-            virtual UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
+            ~CaloSetup() override {};
+            std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override;
+            void fillDescription(edm::ParameterSetDescription& desc) override;
+            PackerMap getPackers(int fed, unsigned int fw) override;
+            void registerProducts(edm::stream::EDProducerBase& prod) override;
+            std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override;
+            UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/CaloSpareHFPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/CaloSpareHFPacker.h
@@ -7,7 +7,7 @@ namespace l1t {
   namespace stage1 {
     class CaloSpareHFPacker : public Packer {
       public:
-        virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+        Blocks pack(const edm::Event&, const PackerTokens*) override;
     };
   }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/CaloSpareHFUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/CaloSpareHFUnpacker.h
@@ -7,7 +7,7 @@ namespace l1t {
   namespace stage1 {
     class CaloSpareHFUnpacker : public Unpacker {
       public:
-        virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+        bool unpack(const Block& block, UnpackerCollections *coll) override;
     };
   }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/EtSumPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/EtSumPacker.h
@@ -7,7 +7,7 @@ namespace l1t {
    namespace stage1 {
       class EtSumPacker : public Packer {
          public:
-            virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+            Blocks pack(const edm::Event&, const PackerTokens*) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/EtSumUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/EtSumUnpacker.h
@@ -7,7 +7,7 @@ namespace l1t {
   namespace stage1 {
     class EtSumUnpacker : public Unpacker {
       public:
-        virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+        bool unpack(const Block& block, UnpackerCollections *coll) override;
     };
   }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/HFRingPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/HFRingPacker.h
@@ -7,7 +7,7 @@ namespace l1t {
   namespace stage1 {
     class HFRingPacker : public Packer {
       public:
-        virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+        Blocks pack(const edm::Event&, const PackerTokens*) override;
     };
   }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/HFRingUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/HFRingUnpacker.h
@@ -7,7 +7,7 @@ namespace l1t {
   namespace stage1 {
     class HFRingUnpacker : public Unpacker {
       public:
-        virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+        bool unpack(const Block& block, UnpackerCollections *coll) override;
     };
   }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/LegacyEtSumUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/LegacyEtSumUnpacker.h
@@ -8,7 +8,7 @@ namespace l1t {
       namespace legacy {
          class EtSumUnpacker : public Unpacker {
             public:
-               virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+               bool unpack(const Block& block, UnpackerCollections *coll) override;
          };
       }
    }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/LegacyHFRingUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/LegacyHFRingUnpacker.h
@@ -8,7 +8,7 @@ namespace l1t {
       namespace legacy {
          class HFRingUnpacker : public Unpacker {
             public:
-               virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+               bool unpack(const Block& block, UnpackerCollections *coll) override;
          };
       }
    }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/LegacyPhysCandUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/LegacyPhysCandUnpacker.h
@@ -8,32 +8,32 @@ namespace l1t {
       namespace legacy {
          class IsoEGammaUnpacker : public Unpacker {
             public:
-               virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+               bool unpack(const Block& block, UnpackerCollections *coll) override;
          };
 
          class NonIsoEGammaUnpacker : public Unpacker {
             public:
-               virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+               bool unpack(const Block& block, UnpackerCollections *coll) override;
          };
 
          class CentralJetUnpacker : public Unpacker {
             public:
-               virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+               bool unpack(const Block& block, UnpackerCollections *coll) override;
          };
 
          class ForwardJetUnpacker : public Unpacker {
             public:
-               virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+               bool unpack(const Block& block, UnpackerCollections *coll) override;
          };
 
          class TauUnpacker : public Unpacker {
             public:
-               virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+               bool unpack(const Block& block, UnpackerCollections *coll) override;
          };
 
          class IsoTauUnpacker : public Unpacker {
             public:
-               virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+               bool unpack(const Block& block, UnpackerCollections *coll) override;
          };
       }
    }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/MissEtPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/MissEtPacker.h
@@ -7,7 +7,7 @@ namespace l1t {
    namespace stage1 {
       class MissEtPacker : public Packer {
          public:
-            virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+            Blocks pack(const edm::Event&, const PackerTokens*) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/MissEtUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/MissEtUnpacker.h
@@ -7,7 +7,7 @@ namespace l1t {
   namespace stage1 {
     class MissEtUnpacker : public Unpacker {
       public:
-        virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+        bool unpack(const Block& block, UnpackerCollections *coll) override;
     };
   }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/MissHtPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/MissHtPacker.h
@@ -7,7 +7,7 @@ namespace l1t {
   namespace stage1 {
     class MissHtPacker : public Packer {
       public:
-        virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+        Blocks pack(const edm::Event&, const PackerTokens*) override;
     };
   }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/MissHtUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/MissHtUnpacker.h
@@ -7,7 +7,7 @@ namespace l1t {
   namespace stage1 {
     class MissHtUnpacker : public Unpacker {
       public:
-        virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+        bool unpack(const Block& block, UnpackerCollections *coll) override;
     };
   }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/PhysCandPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/PhysCandPacker.h
@@ -7,32 +7,32 @@ namespace l1t {
   namespace stage1 {
     class IsoEGammaPacker : public Packer {
       public:
-        virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+        Blocks pack(const edm::Event&, const PackerTokens*) override;
     };
 
     class NonIsoEGammaPacker : public Packer {
       public:
-        virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+        Blocks pack(const edm::Event&, const PackerTokens*) override;
     };
 
     class CentralJetPacker : public Packer {
       public:
-        virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+        Blocks pack(const edm::Event&, const PackerTokens*) override;
     };
 
     class ForwardJetPacker : public Packer {
       public:
-        virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+        Blocks pack(const edm::Event&, const PackerTokens*) override;
     };
 
     class TauPacker : public Packer {
       public:
-        virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+        Blocks pack(const edm::Event&, const PackerTokens*) override;
     };
 
     class IsoTauPacker : public Packer {
       public:
-        virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+        Blocks pack(const edm::Event&, const PackerTokens*) override;
     };
   }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/PhysCandUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/PhysCandUnpacker.h
@@ -7,62 +7,62 @@ namespace l1t {
   namespace stage1 {
     class IsoEGammaUnpackerLeft : public Unpacker {
       public:
-        virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+        bool unpack(const Block& block, UnpackerCollections *coll) override;
     };
 
     class NonIsoEGammaUnpackerLeft : public Unpacker {
       public:
-        virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+        bool unpack(const Block& block, UnpackerCollections *coll) override;
     };
 
     class CentralJetUnpackerLeft : public Unpacker {
       public:
-        virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+        bool unpack(const Block& block, UnpackerCollections *coll) override;
     };
 
     class ForwardJetUnpackerLeft : public Unpacker {
       public:
-        virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+        bool unpack(const Block& block, UnpackerCollections *coll) override;
     };
 
     class TauUnpackerLeft : public Unpacker {
        public:
-        virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+        bool unpack(const Block& block, UnpackerCollections *coll) override;
     };
 
     class IsoTauUnpackerLeft : public Unpacker {
        public:
-        virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+        bool unpack(const Block& block, UnpackerCollections *coll) override;
     };
 
     class IsoEGammaUnpackerRight : public Unpacker {
       public:
-        virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+        bool unpack(const Block& block, UnpackerCollections *coll) override;
     };
 
     class NonIsoEGammaUnpackerRight : public Unpacker {
       public:
-        virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+        bool unpack(const Block& block, UnpackerCollections *coll) override;
     };
 
     class CentralJetUnpackerRight : public Unpacker {
       public:
-        virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+        bool unpack(const Block& block, UnpackerCollections *coll) override;
     };
 
     class ForwardJetUnpackerRight : public Unpacker {
       public:
-        virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+        bool unpack(const Block& block, UnpackerCollections *coll) override;
     };
 
     class TauUnpackerRight : public Unpacker {
        public:
-        virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+        bool unpack(const Block& block, UnpackerCollections *coll) override;
     };
 
     class IsoTauUnpackerRight : public Unpacker {
        public:
-        virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+        bool unpack(const Block& block, UnpackerCollections *coll) override;
     };
 
   }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/PhysicsToBitConverter.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/PhysicsToBitConverter.h
@@ -1,20 +1,20 @@
 #ifndef _PHYSICSTOBITCONVERTER_h
 #define _PHYSICSTOBITCONVERTER_h
 
-#include <stdio.h>
+#include <cstdio>
 #include <string>
-#include <stdlib.h>
+#include <cstdlib>
 #include <iostream>
 #include <fstream>
 #include <stdexcept>
-#include <stdint.h>
+#include <cstdint>
 #include <iomanip>
 #include <sstream>
 #include <vector>
 #include <array>
 #include <bitset>
-#include <stdint.h>
-#include <math.h>
+#include <cstdint>
+#include <cmath>
 #include "rctDataBase.h"
 
 namespace l1t{

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/RCTEmRegionPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/RCTEmRegionPacker.h
@@ -7,7 +7,7 @@ namespace l1t {
   namespace stage1 {
     class RCTEmRegionPacker : public Packer {
       public:
-        virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+        Blocks pack(const edm::Event&, const PackerTokens*) override;
     };
   }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/RCTEmRegionUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/RCTEmRegionUnpacker.cc
@@ -38,7 +38,7 @@ namespace l1t {
          for (int bx=firstBX; bx<=lastBX; bx++){
 
             unsigned int crate;
-            bool even=0;
+            bool even=false;
 
             std::vector <uint32_t> uint;
             uint.reserve(6);
@@ -104,7 +104,7 @@ namespace l1t {
          for (int bx=firstBX; bx<=lastBX; bx++){
 
             unsigned int crate;
-            bool even=0;
+            bool even=false;
 
             PhysicsToBitConverter converter;
             rctDataBase database;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/RCTEmRegionUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/RCTEmRegionUnpacker.h
@@ -7,7 +7,7 @@ namespace l1t {
   namespace stage1 {
     class RCTEmRegionUnpacker : public Unpacker {
       public:
-        virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+        bool unpack(const Block& block, UnpackerCollections *coll) override;
       private:
         unsigned int counter_ = 0;
     };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/rctDataBase.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/rctDataBase.h
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <vector>
-#include <stdint.h>
+#include <cstdint>
 
 namespace l1t{
   class rctDataBase {

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFCollections.h
@@ -19,7 +19,7 @@ namespace l1t {
                inputMuonsTh_ (new L1MuDTChambThContainer)
             {};
 
-            virtual ~BMTFCollections();
+            ~BMTFCollections() override;
 
 						inline RegionalMuonCandBxCollection* getBMTFMuons() {return outputMuons_.get();};
 						inline L1MuDTChambPhContainer* getInMuonsPh() { return inputMuonsPh_.get(); };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerInputs.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerInputs.h
@@ -13,7 +13,7 @@ namespace l1t{
 		class BMTFUnpackerInputsOldQual : public Unpacker
 		{
 			public:
-				virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+				bool unpack(const Block& block, UnpackerCollections *coll) override;
 			private:
 				qualityHits linkAndQual_;
 				//std::map<int, qualityHits> linkAndQual_;
@@ -22,7 +22,7 @@ namespace l1t{
 		class BMTFUnpackerInputsNewQual : public Unpacker
 		{
 			public:
-				virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+				bool unpack(const Block& block, UnpackerCollections *coll) override;
 			private:
 				qualityHits linkAndQual_;
 				//std::map<int, qualityHits> linkAndQual_;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerOutput.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerOutput.h
@@ -8,7 +8,7 @@ namespace l1t{
 		class BMTFUnpackerOutput : public Unpacker
 		{
 			public:
-				virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+				bool unpack(const Block& block, UnpackerCollections *coll) override;
 		};
 	}
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloCollections.h
@@ -26,7 +26,7 @@ namespace l1t {
 		 mp_egammas_(new EGammaBxCollection()),
 	       mp_taus_(new TauBxCollection()) {};
 
-            virtual ~CaloCollections();
+            ~CaloCollections() override;
 
             inline CaloTowerBxCollection* getTowers() { return towers_.get(); };
             inline EGammaBxCollection* getEGammas() override { return egammas_.get(); };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloSetup.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloSetup.h
@@ -13,12 +13,12 @@ namespace l1t {
    namespace stage2 {
       class CaloSetup : public PackingSetup {
          public:
-            virtual std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override;
-            virtual void fillDescription(edm::ParameterSetDescription& desc) override;
-            virtual PackerMap getPackers(int fed, unsigned int fw) override;
-            virtual void registerProducts(edm::stream::EDProducerBase& prod) override;
-            virtual std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override;
-            virtual UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
+            std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override;
+            void fillDescription(edm::ParameterSetDescription& desc) override;
+            PackerMap getPackers(int fed, unsigned int fw) override;
+            void registerProducts(edm::stream::EDProducerBase& prod) override;
+            std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override;
+            UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloTowerPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloTowerPacker.h
@@ -7,7 +7,7 @@ namespace l1t {
    namespace stage2 {
       class CaloTowerPacker : public Packer {
          public:
-            virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+            Blocks pack(const edm::Event&, const PackerTokens*) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloTowerUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloTowerUnpacker.h
@@ -7,7 +7,7 @@ namespace l1t {
    namespace stage2 {
       class CaloTowerUnpacker : public Unpacker {
          public:
-            virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+            bool unpack(const Block& block, UnpackerCollections *coll) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EGammaPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EGammaPacker.h
@@ -8,7 +8,7 @@ namespace l1t {
       class EGammaPacker : public Packer {
          public:
 	    EGammaPacker(int b1, int b2) : b1_(b1), b2_(b2) {}
-            virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+            Blocks pack(const edm::Event&, const PackerTokens*) override;
 	    int b1_, b2_;
       };
 

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EGammaUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EGammaUnpacker.h
@@ -7,7 +7,7 @@ namespace l1t {
    namespace stage2 {
       class EGammaUnpacker : public Unpacker {
          public:
-            virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+            bool unpack(const Block& block, UnpackerCollections *coll) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockCounters.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockCounters.cc
@@ -13,7 +13,7 @@ namespace l1t {
       class CountersBlockUnpacker : public Unpacker { // "CountersBlockUnpacker" inherits from "Unpacker"
       public:
 	virtual int checkFormat(const Block& block);
-	virtual bool unpack(const Block& block, UnpackerCollections *coll) override; // Apparently it's always good to use override in C++
+	bool unpack(const Block& block, UnpackerCollections *coll) override; // Apparently it's always good to use override in C++
 	// virtual bool packBlock(const Block& block, UnpackerCollections *coll) override;
       };
       

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockHeaders.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockHeaders.cc
@@ -13,7 +13,7 @@ namespace l1t {
       class HeadersBlockUnpacker : public Unpacker { // "HeadersBlockUnpacker" inherits from "Unpacker"
       public:
 	virtual int  checkFormat(const Block& block);
-	virtual bool unpack(const Block& block, UnpackerCollections *coll) override; // Apparently it's always good to use override in C++
+	bool unpack(const Block& block, UnpackerCollections *coll) override; // Apparently it's always good to use override in C++
 	// virtual bool packBlock(const Block& block, UnpackerCollections *coll) override;
       };
       

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
@@ -13,7 +13,7 @@ namespace l1t {
       class MEBlockUnpacker : public Unpacker { // "MEBlockUnpacker" inherits from "Unpacker"
       public:
 	virtual int  checkFormat(const Block& block);
-	virtual bool unpack(const Block& block, UnpackerCollections *coll) override; // Apparently it's always good to use override in C++
+	bool unpack(const Block& block, UnpackerCollections *coll) override; // Apparently it's always good to use override in C++
 	// virtual bool packBlock(const Block& block, UnpackerCollections *coll) override;
       };
       

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
@@ -14,7 +14,7 @@ namespace l1t {
       public:
 	virtual int  checkFormat(const Block& block); 
 	// virtual bool checkFormat() override; // Return "false" if block format does not match expected format
-	virtual bool unpack(const Block& block, UnpackerCollections *coll) override; // Apparently it's always good to use override in C++
+	bool unpack(const Block& block, UnpackerCollections *coll) override; // Apparently it's always good to use override in C++
 	// virtual bool packBlock(const Block& block, UnpackerCollections *coll) override;
       };
       

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
@@ -13,7 +13,7 @@ namespace l1t {
       class SPBlockUnpacker : public Unpacker { // "SPBlockUnpacker" inherits from "Unpacker"
       public:
 	virtual int  checkFormat(const Block& block);
-	virtual bool unpack(const Block& block, UnpackerCollections *coll) override; // Apparently it's always good to use override in C++
+	bool unpack(const Block& block, UnpackerCollections *coll) override; // Apparently it's always good to use override in C++
 	// virtual bool packBlock(const Block& block, UnpackerCollections *coll) override;
       };
       
@@ -191,7 +191,7 @@ namespace l1t {
 	ImportSP( Track_, SP_, (res->at(iOut)).PtrEventHeader()->Endcap(), (res->at(iOut)).PtrEventHeader()->Sector() );
 	// Track_.ImportPtLUT( Track_.Mode(), Track_.Pt_LUT_addr() );  // Deprecated ... replace? - AWB 15.03.17
 
-	if ( (res->at(iOut)).PtrSPCollection()->size() > 0 )
+	if ( !(res->at(iOut)).PtrSPCollection()->empty() )
 	  if ( SP_.TBIN() == (res->at(iOut)).PtrSPCollection()->at( (res->at(iOut)).PtrSPCollection()->size() - 1 ).TBIN() )
 	    Track_.set_track_num( (res->at(iOut)).PtrSPCollection()->size() );
 	  else Track_.set_track_num( 0 );

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockTrailers.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockTrailers.cc
@@ -13,7 +13,7 @@ namespace l1t {
       class TrailersBlockUnpacker : public Unpacker { // "TrailersBlockUnpacker" inherits from "Unpacker"
       public:
 	virtual int  checkFormat(const Block& block);
-	virtual bool unpack(const Block& block, UnpackerCollections *coll) override; // Apparently it's always good to use override in C++
+	bool unpack(const Block& block, UnpackerCollections *coll) override; // Apparently it's always good to use override in C++
 	// virtual bool packBlock(const Block& block, UnpackerCollections *coll) override;
       };
       

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.h
@@ -26,7 +26,7 @@ namespace l1t {
 	EMTFLCTs_(new CSCCorrelatedLCTDigiCollection())
 	  {};
       
-      virtual ~EMTFCollections();
+      ~EMTFCollections() override;
       
       inline RegionalMuonCandBxCollection* getRegionalMuonCands() { return regionalMuonCands_.get(); }
       // How does this work?  I haven't even defined a "get()" function for the EMTFDaqOutCollection. - AWB 28.01.16

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.h
@@ -13,12 +13,12 @@ namespace l1t {
   namespace stage2 {
     class EMTFSetup : public PackingSetup {
     public:
-      virtual std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override;
-      virtual void fillDescription(edm::ParameterSetDescription& desc) override;
-      virtual PackerMap getPackers(int fed, unsigned int fw) override;
-      virtual void registerProducts(edm::stream::EDProducerBase& prod) override;
-      virtual std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override;
-      virtual UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
+      std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override;
+      void fillDescription(edm::ParameterSetDescription& desc) override;
+      PackerMap getPackers(int fed, unsigned int fw) override;
+      void registerProducts(edm::stream::EDProducerBase& prod) override;
+      std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override;
+      UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
     };
   }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumPacker.h
@@ -8,7 +8,7 @@ namespace l1t {
       class EtSumPacker : public Packer {
          public:
 	    EtSumPacker(int b1) : b1_(b1) {}
-            virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+            Blocks pack(const edm::Event&, const PackerTokens*) override;
             int b1_;
       };
       class GTEtSumPacker : public EtSumPacker {

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker.h
@@ -7,7 +7,7 @@ namespace l1t {
    namespace stage2 {
       class EtSumUnpacker : public Unpacker {
          public:
-            virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+            bool unpack(const Block& block, UnpackerCollections *coll) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.cc
@@ -13,7 +13,7 @@ namespace l1t {
          event_.put(std::move(regionalMuonCandsEMTF_), "EMTF");
          event_.put(std::move(muons_[0]), "Muon");
          for (int i=1; i<6; ++i) {
-            event_.put(std::move(muons_[i]), ("MuonCopy"+std::to_string(i)).c_str());
+            event_.put(std::move(muons_[i]), "MuonCopy"+std::to_string(i));
          }
          event_.put(std::move(imdMuonsBMTF_), "imdMuonsBMTF");
          event_.put(std::move(imdMuonsEMTFNeg_), "imdMuonsEMTFNeg");

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.h
@@ -31,7 +31,7 @@ namespace l1t {
                std::generate(muons_.begin(), muons_.end(), [&oFirstBx, &oLastBx]{ return std::make_unique<MuonBxCollection>(0, oFirstBx, oLastBx); });
             };
 
-            virtual ~GMTCollections();
+            ~GMTCollections() override;
 
             inline RegionalMuonCandBxCollection* getRegionalMuonCandsBMTF() { return regionalMuonCandsBMTF_.get(); };
             inline RegionalMuonCandBxCollection* getRegionalMuonCandsOMTF() { return regionalMuonCandsOMTF_.get(); };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
@@ -57,7 +57,7 @@ namespace l1t {
          prod.produces<RegionalMuonCandBxCollection>("EMTF");
          prod.produces<MuonBxCollection>("Muon");
          for (int i=1; i<6; ++i) {
-            prod.produces<MuonBxCollection>(("MuonCopy"+std::to_string(i)).c_str());
+            prod.produces<MuonBxCollection>("MuonCopy"+std::to_string(i));
          }
          prod.produces<MuonBxCollection>("imdMuonsBMTF");
          prod.produces<MuonBxCollection>("imdMuonsEMTFNeg");

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.h
@@ -13,12 +13,12 @@ namespace l1t {
    namespace stage2 {
       class GMTSetup : public PackingSetup {
          public:
-            virtual std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override;
-            virtual void fillDescription(edm::ParameterSetDescription& desc) override;
-            virtual PackerMap getPackers(int fed, unsigned int fw) override;
-            virtual void registerProducts(edm::stream::EDProducerBase& prod) override;
-            virtual std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override;
-            virtual UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
+            std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override;
+            void fillDescription(edm::ParameterSetDescription& desc) override;
+            PackerMap getPackers(int fed, unsigned int fw) override;
+            void registerProducts(edm::stream::EDProducerBase& prod) override;
+            std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override;
+            UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTCollections.h
@@ -27,7 +27,7 @@ namespace l1t {
 		 algBlk_(new GlobalAlgBlkBxCollection()),
 		 extBlk_(new GlobalExtBlkBxCollection())  {};
 
-            virtual ~GTCollections();
+            ~GTCollections() override;
             
 	    inline MuonBxCollection* getMuons(const unsigned int copy) override { return muons_.get(); };
 	    inline EGammaBxCollection* getEGammas() override { return egammas_.get(); };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.h
@@ -13,13 +13,13 @@ namespace l1t {
    namespace stage2 {
       class GTSetup : public PackingSetup {
          public:
-            virtual ~GTSetup() {};
-            virtual std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override;
-            virtual void fillDescription(edm::ParameterSetDescription& desc) override;
-            virtual PackerMap getPackers(int fed, unsigned int fw) override;
-            virtual void registerProducts(edm::stream::EDProducerBase& prod) override;
-            virtual std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override;
-            virtual UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
+            ~GTSetup() override {};
+            std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override;
+            void fillDescription(edm::ParameterSetDescription& desc) override;
+            PackerMap getPackers(int fed, unsigned int fw) override;
+            void registerProducts(edm::stream::EDProducerBase& prod) override;
+            std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override;
+            UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GlobalAlgBlkPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GlobalAlgBlkPacker.h
@@ -7,7 +7,7 @@ namespace l1t {
    namespace stage2 {
       class GlobalAlgBlkPacker : public Packer {
          public:
-            virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+            Blocks pack(const edm::Event&, const PackerTokens*) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GlobalAlgBlkUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GlobalAlgBlkUnpacker.h
@@ -7,7 +7,7 @@ namespace l1t {
    namespace stage2 {
       class GlobalAlgBlkUnpacker : public Unpacker {
          public:
-            virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+            bool unpack(const Block& block, UnpackerCollections *coll) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GlobalExtBlkPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GlobalExtBlkPacker.h
@@ -7,7 +7,7 @@ namespace l1t {
    namespace stage2 {
       class GlobalExtBlkPacker : public Packer {
          public:
-            virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+            Blocks pack(const edm::Event&, const PackerTokens*) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GlobalExtBlkUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GlobalExtBlkUnpacker.h
@@ -7,7 +7,7 @@ namespace l1t {
    namespace stage2 {
       class GlobalExtBlkUnpacker : public Unpacker {
          public:
-            virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+            bool unpack(const Block& block, UnpackerCollections *coll) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonPacker.h
@@ -7,7 +7,7 @@ namespace l1t {
    namespace stage2 {
       class IntermediateMuonPacker : public Packer {
          public:
-            virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+            Blocks pack(const edm::Event&, const PackerTokens*) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/JetPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/JetPacker.h
@@ -8,7 +8,7 @@ namespace l1t {
       class JetPacker : public Packer {
          public:
 	    JetPacker(int b1, int b2) : b1_(b1), b2_(b2) {}
-            virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+            Blocks pack(const edm::Event&, const PackerTokens*) override;
 	    int b1_, b2_;
       };
 

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/JetUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/JetUnpacker.h
@@ -7,7 +7,7 @@ namespace l1t {
    namespace stage2 {
       class JetUnpacker : public Unpacker {
          public:
-            virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+            bool unpack(const Block& block, UnpackerCollections *coll) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/L1TObjectCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/L1TObjectCollections.h
@@ -15,13 +15,13 @@ namespace l1t {
        public:
          L1TObjectCollections(edm::Event& e) :
            UnpackerCollections(e) { };
-	 virtual ~L1TObjectCollections() ;
+	 ~L1TObjectCollections() override ;
 
-         virtual MuonBxCollection* getMuons(const unsigned int copy) { return  0;}
-	 virtual EGammaBxCollection* getEGammas() { return 0;} //= 0;
-	 virtual EtSumBxCollection* getEtSums() { return 0;}
-	 virtual JetBxCollection* getJets() {return 0; }
-	 virtual TauBxCollection* getTaus() {return 0; }
+         virtual MuonBxCollection* getMuons(const unsigned int copy) { return  nullptr;}
+	 virtual EGammaBxCollection* getEGammas() { return nullptr;} //= 0;
+	 virtual EtSumBxCollection* getEtSums() { return nullptr;}
+	 virtual JetBxCollection* getJets() {return nullptr; }
+	 virtual TauBxCollection* getTaus() {return nullptr; }
 	 
       };
    }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MPUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MPUnpacker.h
@@ -7,7 +7,7 @@ namespace l1t {
    namespace stage2 {
       class MPUnpacker : public Unpacker {
          public:
-            virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+            bool unpack(const Block& block, UnpackerCollections *coll) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MPUnpacker_0x1001000b.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MPUnpacker_0x1001000b.h
@@ -8,7 +8,7 @@ namespace l1t {
     class MPUnpacker_0x1001000b : public Unpacker {
     public:
       enum { BLK_TOT_POS=123, BLK_X_POS=121, BLK_Y_POS=127, BLK_TOT_NEG=125, BLK_X_NEG=131, BLK_Y_NEG=129};
-      virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+      bool unpack(const Block& block, UnpackerCollections *coll) override;
     private:
       int etaSign(int blkId);
     };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MPUnpacker_0x10010010.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MPUnpacker_0x10010010.h
@@ -7,7 +7,7 @@ namespace l1t {
    namespace stage2 {
       class MPUnpacker_0x10010010 : public Unpacker {
          public:
-            virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+            bool unpack(const Block& block, UnpackerCollections *coll) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MPUnpacker_0x10010033.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MPUnpacker_0x10010033.h
@@ -7,7 +7,7 @@ namespace l1t {
    namespace stage2 {
       class MPUnpacker_0x10010033 : public Unpacker {
          public:
-            virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+            bool unpack(const Block& block, UnpackerCollections *coll) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonPacker.h
@@ -8,7 +8,7 @@ namespace l1t {
       class MuonPacker : public Packer {
          public:
 	    MuonPacker(unsigned b1) : b1_(b1) {}
-            virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+            Blocks pack(const edm::Event&, const PackerTokens*) override;
             unsigned b1_;
          private:
             typedef std::map<unsigned int, std::vector<uint32_t>> PayloadMap;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.h
@@ -5,7 +5,7 @@ namespace l1t {
    namespace stage2 {
       class RegionalMuonGMTPacker : public Packer {
          public:
-            virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+            Blocks pack(const edm::Event&, const PackerTokens*) override;
          private:
             typedef std::map<unsigned int, std::vector<uint32_t>> PayloadMap;
             void packTF(const edm::Event&, const edm::EDGetTokenT<RegionalMuonCandBxCollection>&, Blocks&, const std::vector<unsigned int>&);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/TauPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/TauPacker.h
@@ -8,7 +8,7 @@ namespace l1t {
       class TauPacker : public Packer {
          public:
 	    TauPacker(int b1, int b2) : b1_(b1), b2_(b2) {}
-            virtual Blocks pack(const edm::Event&, const PackerTokens*) override;
+            Blocks pack(const edm::Event&, const PackerTokens*) override;
 	    int b1_, b2_;
       };
 

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/TauUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/TauUnpacker.h
@@ -7,7 +7,7 @@ namespace l1t {
    namespace stage2 {
       class TauUnpacker : public Unpacker {
          public:
-            virtual bool unpack(const Block& block, UnpackerCollections *coll) override;
+            bool unpack(const Block& block, UnpackerCollections *coll) override;
       };
    }
 }

--- a/EventFilter/L1TRawToDigi/src/MP7FileReader.cc
+++ b/EventFilter/L1TRawToDigi/src/MP7FileReader.cc
@@ -49,7 +49,7 @@ MP7FileReader::MP7FileReader(const std::string& path) : valid_(false), path_(pat
 
     LogDebug("L1T") << "# buffers " << buffers_.size();
 
-    if (buffers_.size() > 0) {
+    if (!buffers_.empty()) {
       LogDebug("L1T") << "# links " << buffers_.at(0).size();
       if (buffers_.at(0).size()>0) {
 	LogDebug("L1T") << "# frames " << buffers_.at(0).link(0).size();
@@ -198,7 +198,7 @@ uint64_t MP7FileReader::validStrToUint64(const std::string& token) {
     }
 
     uint64_t value = (uint64_t) (what[1] == "1") << 32;
-    value += std::stoul(what[2].str(), 0x0, 16);
+    value += std::stoul(what[2].str(), nullptr, 16);
     return value;
 }
 

--- a/EventFilter/L1TXRawToDigi/plugins/L1TCaloLayer1RawToDigi.cc
+++ b/EventFilter/L1TXRawToDigi/plugins/L1TCaloLayer1RawToDigi.cc
@@ -69,14 +69,14 @@ using namespace edm;
 class L1TCaloLayer1RawToDigi : public stream::EDProducer<> {
 public:
   explicit L1TCaloLayer1RawToDigi(const ParameterSet&);
-  ~L1TCaloLayer1RawToDigi();
+  ~L1TCaloLayer1RawToDigi() override;
 
   static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void beginStream(StreamID) override;
-  virtual void produce(Event&, const EventSetup&) override;
-  virtual void endStream() override;
+  void beginStream(StreamID) override;
+  void produce(Event&, const EventSetup&) override;
+  void endStream() override;
 
   void makeECalTPGs(uint32_t lPhi, UCTCTP7RawData& ctp7Data, std::unique_ptr<EcalTrigPrimDigiCollection>& ecalTPGs);
 

--- a/EventFilter/L1TXRawToDigi/plugins/L1TTwinMuxRawToDigi.h
+++ b/EventFilter/L1TXRawToDigi/plugins/L1TTwinMuxRawToDigi.h
@@ -35,10 +35,10 @@ public:
   L1TTwinMuxRawToDigi( const edm::ParameterSet& pset );
 
   /// Destructor
-  virtual ~L1TTwinMuxRawToDigi();
+  ~L1TTwinMuxRawToDigi() override;
 
   /// Produce digis out of raw data
-  void produce( edm::Event & e, const edm::EventSetup& c );
+  void produce( edm::Event & e, const edm::EventSetup& c ) override;
 
   /// Generate and fill FED raw data for a full event
   bool fillRawData( edm::Event& e,

--- a/EventFilter/L1TXRawToDigi/plugins/UCTAMCRawData.h
+++ b/EventFilter/L1TXRawToDigi/plugins/UCTAMCRawData.h
@@ -50,8 +50,8 @@ private:
 
   // No copy constructor and equality operator are needed
   
-  UCTAMCRawData(const UCTAMCRawData&);
-  const UCTAMCRawData& operator=(const UCTAMCRawData& i);
+  UCTAMCRawData(const UCTAMCRawData&) = delete;
+  const UCTAMCRawData& operator=(const UCTAMCRawData& i) = delete;
   
   // RawData data
   

--- a/EventFilter/L1TXRawToDigi/plugins/UCTCTP7RawData.h
+++ b/EventFilter/L1TXRawToDigi/plugins/UCTCTP7RawData.h
@@ -11,7 +11,7 @@ public:
   enum CaloType {EBEE=0, HBHE, HF};
 
   UCTCTP7RawData(const uint32_t *d) : myDataPtr(d) {
-    if(myDataPtr != 0) {
+    if(myDataPtr != nullptr) {
       if(sof() != 0xA110CA7E) {
 	LogError("UCTCTP7RawData") << "Failed to see 0xA110CA7E at start - but continuing" << std::endl;
       }
@@ -338,8 +338,8 @@ private:
 
   // No copy constructor and equality operator are needed
   
-  UCTCTP7RawData(const UCTCTP7RawData&);
-  const UCTCTP7RawData& operator=(const UCTCTP7RawData& i);
+  UCTCTP7RawData(const UCTCTP7RawData&) = delete;
+  const UCTCTP7RawData& operator=(const UCTCTP7RawData& i) = delete;
   
   // RawData data
   

--- a/EventFilter/L1TXRawToDigi/plugins/UCTDAQRawData.h
+++ b/EventFilter/L1TXRawToDigi/plugins/UCTDAQRawData.h
@@ -1,7 +1,7 @@
 #ifndef UCTDAQRawData_hh
 #define UCTDAQRawData_hh
 
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include <iomanip>
 
@@ -13,7 +13,7 @@ class UCTDAQRawData {
 public:
 
   UCTDAQRawData(const uint64_t *d) : myDataPtr(d) {
-    if(d != 0) {
+    if(d != nullptr) {
       if((d[0] & 0x5000000000000000) != 0x5000000000000000) {
 	LogError("UCTDAQRawData") << "CDF Header does not seem to be correct" 
 		  << std::showbase << std::internal 
@@ -143,7 +143,7 @@ public:
       return (uint32_t *) &myDataPtr[skip];
     }
     LogError("UCTDAQRawData") << "UCTDAQRawData: Failed to fetch payload location for AMC = " << amc << "; Max AMC = " << nAMCs() << std::endl;
-    return 0x0;
+    return nullptr;
   }
 
   const uint64_t *amc13TrailerPtr() {
@@ -277,8 +277,8 @@ private:
 
   // No copy constructor and equality operator are needed
   
-  UCTDAQRawData(const UCTDAQRawData&);
-  const UCTDAQRawData& operator=(const UCTDAQRawData& i);
+  UCTDAQRawData(const UCTDAQRawData&) = delete;
+  const UCTDAQRawData& operator=(const UCTDAQRawData& i) = delete;
   
   // RawData data
   

--- a/EventFilter/LTCRawToDigi/src/LTCRawToDigi.cc
+++ b/EventFilter/LTCRawToDigi/src/LTCRawToDigi.cc
@@ -42,10 +42,10 @@
 class LTCRawToDigi : public edm::EDProducer {
    public:
       explicit LTCRawToDigi(const edm::ParameterSet&);
-      ~LTCRawToDigi();
+      ~LTCRawToDigi() override;
 
 
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
    private:
       // ----------member data ---------------------------
 };

--- a/EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDBuffer.h
+++ b/EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDBuffer.h
@@ -5,7 +5,7 @@
 #include "EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDDAQTrailer.h"
 #include "EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDHeader.h"
 #include "EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDChannel.h"
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 #include <map>
 

--- a/EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDChannel.h
+++ b/EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDChannel.h
@@ -4,7 +4,7 @@
 #include "EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDDAQHeader.h"
 #include "EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDDAQTrailer.h"
 #include "EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDBuffer.h"
-#include <stdint.h>
+#include <cstdint>
 
 namespace Phase2Tracker {
 

--- a/EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDHeader.h
+++ b/EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDHeader.h
@@ -3,7 +3,7 @@
 
 #include "EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDDAQHeader.h"
 #include "EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDDAQTrailer.h"
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 namespace Phase2Tracker {

--- a/EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDRawChannelUnpacker.h
+++ b/EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDRawChannelUnpacker.h
@@ -4,7 +4,7 @@
 #include "EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDDAQHeader.h"
 #include "EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDDAQTrailer.h"
 #include "EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDChannel.h"
-#include <stdint.h>
+#include <cstdint>
 
 namespace Phase2Tracker {
 

--- a/EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDZSChannelUnpacker.h
+++ b/EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDZSChannelUnpacker.h
@@ -4,7 +4,7 @@
 #include "EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDDAQHeader.h"
 #include "EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDDAQTrailer.h"
 #include "EventFilter/Phase2TrackerRawToDigi/interface/Phase2TrackerFEDChannel.h"
-#include <stdint.h>
+#include <cstdint>
 
 namespace Phase2Tracker {
 

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerCommissioningDigiProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerCommissioningDigiProducer.cc
@@ -36,7 +36,7 @@ void Phase2Tracker::Phase2TrackerCommissioningDigiProducer::produce( edm::Event&
     if(fed.size()!=0 && fedIndex >= Phase2Tracker::FED_ID_MIN && fedIndex <= Phase2Tracker::FED_ID_MAX)
     {
       // construct buffer
-      Phase2Tracker:: Phase2TrackerFEDBuffer* buffer = 0;
+      Phase2Tracker:: Phase2TrackerFEDBuffer* buffer = nullptr;
       buffer = new Phase2Tracker::Phase2TrackerFEDBuffer(fed.data(),fed.size());
 
       // fetch condition data

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerCommissioningDigiProducer.h
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerCommissioningDigiProducer.h
@@ -18,8 +18,8 @@ namespace Phase2Tracker {
     /// constructor
     Phase2TrackerCommissioningDigiProducer( const edm::ParameterSet& pset );
     /// default constructor
-    ~Phase2TrackerCommissioningDigiProducer();
-    void produce( edm::Event& event, const edm::EventSetup& es );
+    ~Phase2TrackerCommissioningDigiProducer() override;
+    void produce( edm::Event& event, const edm::EventSetup& es ) override;
     
   private:
     edm::EDGetTokenT<FEDRawDataCollection> token_;

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerDigiProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerDigiProducer.cc
@@ -24,7 +24,7 @@ namespace Phase2Tracker {
 
   Phase2TrackerDigiProducer::Phase2TrackerDigiProducer( const edm::ParameterSet& pset ) :
     runNumber_(0),
-    cabling_(0),
+    cabling_(nullptr),
     cacheId_(0)
   {
     // define product
@@ -70,7 +70,7 @@ namespace Phase2Tracker {
       if(fed.size()!=0)
       {
 	// construct buffer
-	Phase2Tracker:: Phase2TrackerFEDBuffer* buffer = 0;
+	Phase2Tracker:: Phase2TrackerFEDBuffer* buffer = nullptr;
 	buffer = new Phase2Tracker::Phase2TrackerFEDBuffer(fed.data(),fed.size());
 
         #ifdef EDM_ML_DEBUG

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerDigiProducer.h
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerDigiProducer.h
@@ -14,7 +14,7 @@
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "CondFormats/SiStripObjects/interface/Phase2TrackerCabling.h"
 #include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -27,11 +27,11 @@ namespace Phase2Tracker {
     /// constructor
     Phase2TrackerDigiProducer( const edm::ParameterSet& pset );
     /// default constructor
-    ~Phase2TrackerDigiProducer();
-    virtual void beginJob() override;
-    virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-    virtual void produce(edm::Event&, const edm::EventSetup&) override;
-    virtual void endJob() override;
+    ~Phase2TrackerDigiProducer() override;
+    void beginJob() override;
+    void beginRun(edm::Run const&, edm::EventSetup const&) override;
+    void produce(edm::Event&, const edm::EventSetup&) override;
+    void endJob() override;
 
   private:
     unsigned int runNumber_;

--- a/EventFilter/Phase2TrackerRawToDigi/src/Phase2TrackerFEDBuffer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/src/Phase2TrackerFEDBuffer.cc
@@ -78,7 +78,7 @@ namespace Phase2Tracker
             }
             else
             {
-              channels_.push_back(Phase2TrackerFEDChannel(NULL,0,0));
+              channels_.push_back(Phase2TrackerFEDChannel(nullptr,0,0));
             }
           }
         }
@@ -146,7 +146,7 @@ namespace Phase2Tracker
     else
     {
       // put a null pointer to indicate lack of condition data
-      condDataPointer_ = 0;
+      condDataPointer_ = nullptr;
       // check buffer size :
       if (bufferDiff != 0)
       {

--- a/EventFilter/Playback/interface/PlaybackRawDataProvider.h
+++ b/EventFilter/Playback/interface/PlaybackRawDataProvider.h
@@ -17,13 +17,13 @@ public:
   // construction/destruction
   //
   explicit PlaybackRawDataProvider(const edm::ParameterSet&);
-  virtual ~PlaybackRawDataProvider();
+  ~PlaybackRawDataProvider() override;
   
   // EDAnalyzer interface
-  virtual void beginJob();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob();
-  virtual void respondToCloseInputFile(edm::FileBlock const& fb);
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+  void respondToCloseInputFile(edm::FileBlock const& fb) override;
 
   // provide cached fed collection (and run/evt number, if needed!)
   virtual FEDRawDataCollection* getFEDRawData();

--- a/EventFilter/Playback/src/PlaybackRawDataProvider.cc
+++ b/EventFilter/Playback/src/PlaybackRawDataProvider.cc
@@ -21,7 +21,7 @@ using namespace edm;
 // initialize static data members
 ////////////////////////////////////////////////////////////////////////////////
 
-PlaybackRawDataProvider* PlaybackRawDataProvider::instance_=0;
+PlaybackRawDataProvider* PlaybackRawDataProvider::instance_=nullptr;
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -31,9 +31,9 @@ PlaybackRawDataProvider* PlaybackRawDataProvider::instance_=0;
 //______________________________________________________________________________
 PlaybackRawDataProvider::PlaybackRawDataProvider(const ParameterSet& iConfig)
   : queueSize_(0)
-  , eventQueue_(0)
-  , runNumber_(0)
-  , evtNumber_(0)
+  , eventQueue_(nullptr)
+  , runNumber_(nullptr)
+  , evtNumber_(nullptr)
   , count_(0)
   , writeIndex_(0)
   , readIndex_(0)
@@ -48,7 +48,7 @@ PlaybackRawDataProvider::PlaybackRawDataProvider(const ParameterSet& iConfig)
   runNumber_ =new unsigned int[queueSize_];
   evtNumber_ =new unsigned int[queueSize_];
   eventQueue_=new FEDRawDataCollection*[queueSize_];
-  for (unsigned int i=0;i<queueSize_;i++) eventQueue_[i]=0;
+  for (unsigned int i=0;i<queueSize_;i++) eventQueue_[i]=nullptr;
   edm::LogInfo("PbImpl") << "Created Concrete RawData Provider 0x"<< hex << (unsigned long) this << dec << endl;
   instance_=this;
 }
@@ -57,15 +57,15 @@ PlaybackRawDataProvider::PlaybackRawDataProvider(const ParameterSet& iConfig)
 //______________________________________________________________________________
 PlaybackRawDataProvider::~PlaybackRawDataProvider()
 {
-  if (0!=runNumber_) delete [] runNumber_;
-  if (0!=evtNumber_) delete [] evtNumber_;
-  if (0!=eventQueue_) {
+  if (nullptr!=runNumber_) delete [] runNumber_;
+  if (nullptr!=evtNumber_) delete [] evtNumber_;
+  if (nullptr!=eventQueue_) {
     for (unsigned int i=0;i<queueSize_;i++)
-      if (0!=eventQueue_[i]) delete eventQueue_[i];
+      if (nullptr!=eventQueue_[i]) delete eventQueue_[i];
     delete [] eventQueue_;
   }
   edm::LogInfo("PbImpl") << "Destroyed Concrete RawData Provider 0x"<< hex << (unsigned long) this << dec << endl;
-  instance_=0;
+  instance_=nullptr;
 
   destroying_=true;
   postReadSem();
@@ -102,7 +102,7 @@ void PlaybackRawDataProvider::analyze(const Event& iEvent,
   
   
   // copy the raw data collection into rawData_, retrievable via getFEDRawData()
-  assert(0==eventQueue_[writeIndex_]);
+  assert(nullptr==eventQueue_[writeIndex_]);
   eventQueue_[writeIndex_]=new FEDRawDataCollection();
   for (unsigned int i=0;i<(unsigned int)FEDNumbering::MAXFEDID+1;i++) {
     unsigned int fedSize=pRawData->FEDData(i).size();
@@ -145,13 +145,13 @@ void PlaybackRawDataProvider::respondToCloseInputFile(edm::FileBlock const& fb)
 //______________________________________________________________________________
 FEDRawDataCollection* PlaybackRawDataProvider::getFEDRawData()
 {
-  FEDRawDataCollection* result = 0;
+  FEDRawDataCollection* result = nullptr;
   waitReadSem();
   //do not read data if destructor is called
-  if (destroying_) return 0;
+  if (destroying_) return nullptr;
   lock();
   result = eventQueue_[readIndex_];
-  eventQueue_[readIndex_]=0;
+  eventQueue_[readIndex_]=nullptr;
   readIndex_=(readIndex_+1)%queueSize_;
   unlock();
   
@@ -165,16 +165,16 @@ FEDRawDataCollection* PlaybackRawDataProvider::getFEDRawData(unsigned int& runNu
 							     unsigned int& evtNumber)
 {
 
-  FEDRawDataCollection* result = 0;
+  FEDRawDataCollection* result = nullptr;
   waitReadSem();
   //do not read data if destructor is called
-  if (destroying_) return 0;
+  if (destroying_) return nullptr;
   lock();
   runNumber=runNumber_[readIndex_];
   evtNumber=evtNumber_[readIndex_];
   result=eventQueue_[readIndex_];
   //  assert(0!=result);
-  eventQueue_[readIndex_]=0;
+  eventQueue_[readIndex_]=nullptr;
   readIndex_=(readIndex_+1)%queueSize_;
 
   unlock();

--- a/EventFilter/RPCRawToDigi/interface/EventRecords.h
+++ b/EventFilter/RPCRawToDigi/interface/EventRecords.h
@@ -30,7 +30,7 @@ public:
 
   bool complete() const { return theValidBX && theValidLN && theValidCD; }
 
-  bool hasErrors() const { return (theErrors.size()>0); }
+  bool hasErrors() const { return (!theErrors.empty()); }
 
   bool samePartition(const EventRecords & r) const;
 

--- a/EventFilter/RPCRawToDigi/interface/RPCPackingModule.h
+++ b/EventFilter/RPCRawToDigi/interface/RPCPackingModule.h
@@ -30,10 +30,10 @@ public:
   explicit RPCPackingModule( const edm::ParameterSet& );
 
   /// dtor
-  virtual ~RPCPackingModule();
+  ~RPCPackingModule() override;
 
   /// get data, convert to raw event, attach again to Event
-  virtual void produce( edm::Event&, const edm::EventSetup& ) override;
+  void produce( edm::Event&, const edm::EventSetup& ) override;
 
   static std::vector<rpcrawtodigi::EventRecords> eventRecords(
       int fedId, int trigger_BX, const RPCDigiCollection* , const RPCRecordFormatter& ); 

--- a/EventFilter/RPCRawToDigi/plugins/RPCReadOutMappingWithFastSearch.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCReadOutMappingWithFastSearch.cc
@@ -20,7 +20,7 @@ bool RPCReadOutMappingWithFastSearch::lessMap::operator()(
 }
 
 RPCReadOutMappingWithFastSearch::RPCReadOutMappingWithFastSearch()
-   : theMapping(0)
+   : theMapping(nullptr)
 {}
 
 void RPCReadOutMappingWithFastSearch::init(const RPCReadOutMapping * arm)
@@ -77,6 +77,6 @@ RPCReadOutMapping::StripInDetUnit RPCReadOutMappingWithFastSearch::detUnitFrame(
 const LinkBoardSpec* RPCReadOutMappingWithFastSearch::location(const LinkBoardElectronicIndex & ele) const
 {
   LBMap::const_iterator inMap = theLBMap.find(ele);
-  return (inMap!= theLBMap.end()) ? inMap->second : 0;
+  return (inMap!= theLBMap.end()) ? inMap->second : nullptr;
 // return theMapping->location(ele);
 }

--- a/EventFilter/RPCRawToDigi/plugins/RPCReadOutMappingWithFastSearch.h
+++ b/EventFilter/RPCRawToDigi/plugins/RPCReadOutMappingWithFastSearch.h
@@ -8,15 +8,15 @@
 class RPCReadOutMappingWithFastSearch : public RPCReadOutMapping {
 public:
   RPCReadOutMappingWithFastSearch();
-  virtual ~RPCReadOutMappingWithFastSearch(){} 
+  ~RPCReadOutMappingWithFastSearch() override{} 
 
   /// takes ownership of map
   void init(const RPCReadOutMapping * arm);
 
-  virtual const LinkBoardSpec* location (const LinkBoardElectronicIndex & ele) const;
+  const LinkBoardSpec* location (const LinkBoardElectronicIndex & ele) const override;
 
-  virtual RPCReadOutMapping::StripInDetUnit detUnitFrame(
-      const LinkBoardSpec& location, const LinkBoardPackedStrip & lbstrip) const;
+  RPCReadOutMapping::StripInDetUnit detUnitFrame(
+      const LinkBoardSpec& location, const LinkBoardPackedStrip & lbstrip) const override;
 
 private:
   std::string theVersion;

--- a/EventFilter/RPCRawToDigi/plugins/RPCTwinMuxDigiToRaw.h
+++ b/EventFilter/RPCRawToDigi/plugins/RPCTwinMuxDigiToRaw.h
@@ -25,7 +25,7 @@ class RPCTwinMuxDigiToRaw
 {
 public:
     RPCTwinMuxDigiToRaw(edm::ParameterSet const & config);
-    ~RPCTwinMuxDigiToRaw();
+    ~RPCTwinMuxDigiToRaw() override;
 
     static void fillDescriptions(edm::ConfigurationDescriptions & descs);
 

--- a/EventFilter/RPCRawToDigi/plugins/RPCTwinMuxRawToDigi.h
+++ b/EventFilter/RPCRawToDigi/plugins/RPCTwinMuxRawToDigi.h
@@ -32,7 +32,7 @@ class RPCTwinMuxRawToDigi
 {
 public:
     RPCTwinMuxRawToDigi(edm::ParameterSet const & config);
-    ~RPCTwinMuxRawToDigi();
+    ~RPCTwinMuxRawToDigi() override;
 
     static void compute_crc_64bit(std::uint16_t & crc, std::uint64_t const & word);
 

--- a/EventFilter/RPCRawToDigi/plugins/RPCUnpackingModule.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCUnpackingModule.cc
@@ -42,7 +42,7 @@ RPCUnpackingModule::RPCUnpackingModule(const edm::ParameterSet& pset)
   : dataLabel_(pset.getParameter<edm::InputTag>("InputLabel")),
     doSynchro_(pset.getParameter<bool>("doSynchro")),
     eventCounter_(0),
-    theCabling(0)
+    theCabling(nullptr)
 {
   produces<RPCDigiCollection>();
   produces<RPCRawDataCounts>();
@@ -98,7 +98,7 @@ void RPCUnpackingModule::produce(Event & ev, const EventSetup& es)
 
     const FEDRawData & rawData = allFEDRawData->FEDData(fedId);
     RPCRecordFormatter interpreter = 
-        theCabling ? RPCRecordFormatter(fedId,&theReadoutMappingSearch) : RPCRecordFormatter(fedId,0);
+        theCabling ? RPCRecordFormatter(fedId,&theReadoutMappingSearch) : RPCRecordFormatter(fedId,nullptr);
     int triggerBX =0;
     int nWords = rawData.size()/sizeof(Word64);
     if (nWords==0) continue;

--- a/EventFilter/RPCRawToDigi/plugins/RPCUnpackingModule.h
+++ b/EventFilter/RPCRawToDigi/plugins/RPCUnpackingModule.h
@@ -24,7 +24,7 @@ public:
     RPCUnpackingModule(const edm::ParameterSet& pset);
     
     ///Destructor
-    virtual ~RPCUnpackingModule();
+    ~RPCUnpackingModule() override;
  
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 

--- a/EventFilter/RPCRawToDigi/src/RPCRecordFormatter.cc
+++ b/EventFilter/RPCRawToDigi/src/RPCRecordFormatter.cc
@@ -106,7 +106,7 @@ int RPCRecordFormatter::recordUnpack(
      if(counter) counter->addReadoutError(currentFED, ReadoutError(eleIndex,ReadoutError::EOD));
   }
 
-  if(readoutMapping == 0) return error.type();
+  if(readoutMapping == nullptr) return error.type();
   const LinkBoardSpec* linkBoard = readoutMapping->location(eleIndex);
   if (!linkBoard) {
     if (debug) LogDebug("")<<" ** PROBLEM ** Invalid Linkboard location, skip CD event, " 
@@ -121,7 +121,7 @@ int RPCRecordFormatter::recordUnpack(
 
 
   std::vector<int> packStrips = event.recordCD().packedStrips();
-  if (packStrips.size() ==0) {
+  if (packStrips.empty()) {
     error = ReadoutError(eleIndex,ReadoutError::EmptyPackedStrips);
     if(counter) counter->addReadoutError(currentFED, error);
     return error.type();

--- a/EventFilter/RawDataCollector/src/RawDataCollectorByLabel.h
+++ b/EventFilter/RawDataCollector/src/RawDataCollectorByLabel.h
@@ -19,9 +19,9 @@ public:
     RawDataCollectorByLabel(const edm::ParameterSet& pset);
     
     ///Destructor
-    virtual ~RawDataCollectorByLabel();
+    ~RawDataCollectorByLabel() override;
     
-    void produce(edm::Event & e, const edm::EventSetup& c); 
+    void produce(edm::Event & e, const edm::EventSetup& c) override; 
           
 private:
 

--- a/EventFilter/RawDataCollector/src/RawDataFEDSelector.cc
+++ b/EventFilter/RawDataCollector/src/RawDataFEDSelector.cc
@@ -20,7 +20,7 @@ std::unique_ptr<FEDRawDataCollection> RawDataFEDSelector::select(const Handle<FE
   auto selectedRawData = std::make_unique<FEDRawDataCollection>();
 
   // if vector of FED indexes is defined, loop over it
-  if (fedList.size()) {
+  if (!fedList.empty()) {
     vector<int>::const_iterator it = fedList.begin();
     vector<int>::const_iterator itEnd = fedList.end();
     for (;it != itEnd; ++it) {  

--- a/EventFilter/RawDataCollector/src/RawDataSelector.cc
+++ b/EventFilter/RawDataCollector/src/RawDataSelector.cc
@@ -25,11 +25,11 @@ public:
 
   explicit RawDataSelector(const edm::ParameterSet&);
 
-  ~RawDataSelector();
+  ~RawDataSelector() override;
 
 private:
 
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
   RawDataFEDSelector * selector; 
 

--- a/EventFilter/RctRawToDigi/plugins/RctRawToDigi.h
+++ b/EventFilter/RctRawToDigi/plugins/RctRawToDigi.h
@@ -42,14 +42,14 @@ class RctRawToDigi : public edm::stream::EDProducer<>
 public:
 
   explicit RctRawToDigi(const edm::ParameterSet&);
-  ~RctRawToDigi();
+  ~RctRawToDigi() override;
 
   //do we need this?
   //static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
  
 private: // methods
 
-  void produce(edm::Event&, const edm::EventSetup&);
+  void produce(edm::Event&, const edm::EventSetup&) override;
   
   /// Unpacks the raw data
   /*! \param invalidDataFlag - if true, then won't attempt unpack but just output empty collecions. */

--- a/EventFilter/RctRawToDigi/src/RctUnpackCollections.h
+++ b/EventFilter/RctRawToDigi/src/RctUnpackCollections.h
@@ -30,8 +30,8 @@ public:
 
 private:
 
-  RctUnpackCollections(const RctUnpackCollections&); ///< Copy ctor - deliberately not implemented!
-  RctUnpackCollections& operator=(const RctUnpackCollections&); ///< Assignment op - deliberately not implemented!  
+  RctUnpackCollections(const RctUnpackCollections&) = delete; ///< Copy ctor - deliberately not implemented!
+  RctUnpackCollections& operator=(const RctUnpackCollections&) = delete; ///< Assignment op - deliberately not implemented!  
 
   edm::Event& m_event;  ///< The event the collections will be put into on destruction of the RctUnpackCollections instance.
 

--- a/EventFilter/ScalersRawToDigi/src/ScalersRawToDigi.cc
+++ b/EventFilter/ScalersRawToDigi/src/ScalersRawToDigi.cc
@@ -41,10 +41,10 @@ class ScalersRawToDigi : public edm::stream::EDProducer<>
 {
   public:
     explicit ScalersRawToDigi(const edm::ParameterSet&);
-    ~ScalersRawToDigi();
+    ~ScalersRawToDigi() override;
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-    virtual void produce(edm::Event&, const edm::EventSetup&) override;
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
   private:
     edm::InputTag inputTag_;

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
@@ -24,7 +24,7 @@ using namespace std;
 SiPixelDigiToRaw::SiPixelDigiToRaw( const edm::ParameterSet& pset ) :
   frameReverter_(nullptr),
   config_(pset),
-  hCPU(0), hDigi(0)
+  hCPU(nullptr), hDigi(nullptr)
 {
 
   tPixelDigi = consumes<edm::DetSetVector<PixelDigi> >(config_.getParameter<edm::InputTag>("InputLabel")); 

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.h
@@ -27,14 +27,14 @@ public:
   explicit SiPixelDigiToRaw( const edm::ParameterSet& );
 
   /// dtor
-  virtual ~SiPixelDigiToRaw();
+  ~SiPixelDigiToRaw() override;
 
 
   /// dummy end of job 
-  virtual void endJob() override {}
+  void endJob() override {}
 
   /// get data, convert to raw event, attach again to Event
-  virtual void produce( edm::Event&, const edm::EventSetup& ) override;
+  void produce( edm::Event&, const edm::EventSetup& ) override;
 
 private:
 

--- a/EventFilter/SiStripChannelChargeFilter/interface/ClusterMTCCFilter.h
+++ b/EventFilter/SiStripChannelChargeFilter/interface/ClusterMTCCFilter.h
@@ -22,8 +22,8 @@ namespace cms
  class ClusterMTCCFilter : public edm::EDFilter {
   public:
     ClusterMTCCFilter(const edm::ParameterSet& ps);
-    virtual ~ClusterMTCCFilter() {}
-    virtual bool filter(edm::Event & e, edm::EventSetup const& c);
+    ~ClusterMTCCFilter() override {}
+    bool filter(edm::Event & e, edm::EventSetup const& c) override;
 
   private:
    std::string clusterProducer;

--- a/EventFilter/SiStripChannelChargeFilter/interface/MTCCHLTrigger.h
+++ b/EventFilter/SiStripChannelChargeFilter/interface/MTCCHLTrigger.h
@@ -13,9 +13,9 @@ namespace cms
  class MTCCHLTrigger : public edm::EDFilter {
   public:
     MTCCHLTrigger(const edm::ParameterSet& ps);
-    virtual ~MTCCHLTrigger() {}
+    ~MTCCHLTrigger() override {}
 
-    virtual bool filter(edm::Event & e, edm::EventSetup const& c);
+    bool filter(edm::Event & e, edm::EventSetup const& c) override;
 
   private:
    //   bool selOnClusterCharge;

--- a/EventFilter/SiStripChannelChargeFilter/interface/TECClusterFilter.h
+++ b/EventFilter/SiStripChannelChargeFilter/interface/TECClusterFilter.h
@@ -22,8 +22,8 @@ namespace cms
  class TECClusterFilter : public edm::EDFilter {
   public:
     TECClusterFilter(const edm::ParameterSet& ps);
-    virtual ~TECClusterFilter() {}
-    virtual bool filter(edm::Event & e, edm::EventSetup const& c);
+    ~TECClusterFilter() override {}
+    bool filter(edm::Event & e, edm::EventSetup const& c) override;
 
   private:
    std::string clusterProducer;

--- a/EventFilter/SiStripChannelChargeFilter/interface/TrackMTCCFilter.h
+++ b/EventFilter/SiStripChannelChargeFilter/interface/TrackMTCCFilter.h
@@ -19,8 +19,8 @@ namespace cms
  class TrackMTCCFilter : public edm::EDFilter {
   public:
     TrackMTCCFilter(const edm::ParameterSet& ps);
-    virtual ~TrackMTCCFilter() {}
-    virtual bool filter(edm::Event & e, edm::EventSetup const& c);
+    ~TrackMTCCFilter() override {}
+    bool filter(edm::Event & e, edm::EventSetup const& c) override;
 
   private:
    std::string TrackProducer;

--- a/EventFilter/SiStripChannelChargeFilter/src/ClusterMTCCFilter.cc
+++ b/EventFilter/SiStripChannelChargeFilter/src/ClusterMTCCFilter.cc
@@ -112,10 +112,10 @@ bool ClusterMTCCFilter::filter(edm::Event & e, edm::EventSetup const& c) {
 //  if( clusters_in_subcomponents[31].size()>0 ) nr_of_subcomps_with_clusters++; // TIB1
 //  if( clusters_in_subcomponents[32].size()>0 ) nr_of_subcomps_with_clusters++; // TIB2
 //  if( clusters_in_subcomponents[60].size()>0 ) nr_of_subcomps_with_clusters++; // TEC
-  if( clusters_in_subcomponents[31].size()>0 ||  clusters_in_subcomponents[32].size()>0 ) nr_of_subcomps_with_clusters++; // TIB1 || TIB2
-  if( clusters_in_subcomponents[33].size()>0 ) nr_of_subcomps_with_clusters++; // TIB3
-  if( clusters_in_subcomponents[51].size()>0 ) nr_of_subcomps_with_clusters++; // TOB1
-  if( clusters_in_subcomponents[52].size()>0 ) nr_of_subcomps_with_clusters++; // TOB2
+  if( !clusters_in_subcomponents[31].empty() ||  !clusters_in_subcomponents[32].empty() ) nr_of_subcomps_with_clusters++; // TIB1 || TIB2
+  if( !clusters_in_subcomponents[33].empty() ) nr_of_subcomps_with_clusters++; // TIB3
+  if( !clusters_in_subcomponents[51].empty() ) nr_of_subcomps_with_clusters++; // TOB1
+  if( !clusters_in_subcomponents[52].empty() ) nr_of_subcomps_with_clusters++; // TOB2
   if(
      nr_of_subcomps_with_clusters >= MinClustersDiffComponents // more than 'MinClustersDiffComponents' components have at least 1 cluster
      ) {

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
@@ -25,8 +25,8 @@ namespace sistrip {
       //construct from buffer
       //if allowBadBuffer is set to true then exceptions will not be thrown if the channel lengths do not make sense or the event format is not recognized
       FEDBuffer(const uint8_t* fedBuffer, const uint16_t fedBufferSize, const bool allowBadBuffer = false);
-      virtual ~FEDBuffer();
-      virtual void print(std::ostream& os) const;
+      ~FEDBuffer() override;
+      void print(std::ostream& os) const override;
       const FEDFEHeader* feHeader() const;
       //check that a FE unit is enabled, has a good majority address and, if in full debug mode, that it is present
       bool feGood(const uint8_t internalFEUnitNum) const;
@@ -68,7 +68,7 @@ namespace sistrip {
       bool checkFEPayloadsPresent() const;
   
       //print a summary of all checks
-      virtual std::string checkSummary() const;
+      std::string checkSummary() const override;
     private:
       uint8_t nFEUnitsPresent() const;
       void findChannels();
@@ -205,7 +205,7 @@ namespace sistrip {
   //FEDBSChannelUnpacker
 
   inline FEDBSChannelUnpacker::FEDBSChannelUnpacker()
-    : data_(NULL),
+    : data_(nullptr),
       oldWordOffset_(0), currentWordOffset_(0),
       currentBitOffset_(0), currentLocalBitOffset_(0),
       bitOffsetIncrement_(10),
@@ -347,7 +347,7 @@ namespace sistrip {
   //FEDZSChannelUnpacker
   
   inline FEDZSChannelUnpacker::FEDZSChannelUnpacker()
-    : data_(NULL),
+    : data_(nullptr),
       offsetIncrement_(1),
       valuesLeftInCluster_(0),
       channelPayloadOffset_(0),

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
@@ -440,26 +440,26 @@ namespace sistrip {
     {
     public:
       explicit FEDAPVErrorHeader(const uint8_t* headerBuffer);
-      virtual ~FEDAPVErrorHeader();
-      virtual size_t lengthInBytes() const;
-      virtual bool checkChannelStatusBits(const uint8_t internalFEDChannelNum) const;
-      virtual bool checkStatusBits(const uint8_t internalFEDChannelNum, const uint8_t apvNum) const;
-      virtual void print(std::ostream& os) const;
-      virtual FEDAPVErrorHeader* clone() const;
+      ~FEDAPVErrorHeader() override;
+      size_t lengthInBytes() const override;
+      bool checkChannelStatusBits(const uint8_t internalFEDChannelNum) const override;
+      bool checkStatusBits(const uint8_t internalFEDChannelNum, const uint8_t apvNum) const override;
+      void print(std::ostream& os) const override;
+      FEDAPVErrorHeader* clone() const override;
       //used by digi2Raw
-      virtual const uint8_t* data() const;
+      const uint8_t* data() const override;
       FEDAPVErrorHeader& setAPVStatusBit(const uint8_t internalFEDChannelNum, const uint8_t apvNum, const bool apvGood);
       FEDAPVErrorHeader& setAPVStatusBit(const uint8_t internalFEUnitNum, const uint8_t internalFEUnitChannelNum, const uint8_t apvNum, const bool apvGood);
       FEDAPVErrorHeader(const std::vector<bool>& apvsGood = std::vector<bool>(APVS_PER_FED,true));
       //Information which is not present in APVError mode is allowed to be set here so that the methods can be called on the base class without caring
       //if the values need to be set.
-      virtual void setChannelStatus(const uint8_t internalFEDChannelNum, const FEDChannelStatus status);
-      virtual void setFEUnitMajorityAddress(const uint8_t internalFEUnitNum, const uint8_t address);
-      virtual void setBEStatusRegister(const FEDBackendStatusRegister beStatusRegister);
-      virtual void setDAQRegister(const uint32_t daqRegister);
-      virtual void setDAQRegister2(const uint32_t daqRegister2);
-      virtual void set32BitReservedRegister(const uint8_t internalFEUnitNum, const uint32_t reservedRegister);
-      virtual void setFEUnitLength(const uint8_t internalFEUnitNum, const uint16_t length);
+      void setChannelStatus(const uint8_t internalFEDChannelNum, const FEDChannelStatus status) override;
+      void setFEUnitMajorityAddress(const uint8_t internalFEUnitNum, const uint8_t address) override;
+      void setBEStatusRegister(const FEDBackendStatusRegister beStatusRegister) override;
+      void setDAQRegister(const uint32_t daqRegister) override;
+      void setDAQRegister2(const uint32_t daqRegister2) override;
+      void set32BitReservedRegister(const uint8_t internalFEUnitNum, const uint32_t reservedRegister) override;
+      void setFEUnitLength(const uint8_t internalFEUnitNum, const uint16_t length) override;
     private:
       static const size_t APV_ERROR_HEADER_SIZE_IN_64BIT_WORDS = 3;
       static const size_t APV_ERROR_HEADER_SIZE_IN_BYTES = APV_ERROR_HEADER_SIZE_IN_64BIT_WORDS*8;
@@ -470,12 +470,12 @@ namespace sistrip {
     {
     public:
       explicit FEDFullDebugHeader(const uint8_t* headerBuffer);
-      virtual ~FEDFullDebugHeader();
-      virtual size_t lengthInBytes() const;
-      virtual bool checkChannelStatusBits(const uint8_t internalFEDChannelNum) const;
-      virtual bool checkStatusBits(const uint8_t internalFEDChannelNum, const uint8_t apvNum) const;
-      virtual void print(std::ostream& os) const;
-      virtual FEDFullDebugHeader* clone() const;
+      ~FEDFullDebugHeader() override;
+      size_t lengthInBytes() const override;
+      bool checkChannelStatusBits(const uint8_t internalFEDChannelNum) const override;
+      bool checkStatusBits(const uint8_t internalFEDChannelNum, const uint8_t apvNum) const override;
+      void print(std::ostream& os) const override;
+      FEDFullDebugHeader* clone() const override;
       
       uint8_t feUnitMajorityAddress(const uint8_t internalFEUnitNum) const;
       FEDBackendStatusRegister beStatusRegister() const;
@@ -503,14 +503,14 @@ namespace sistrip {
       bool apvAddressError(const uint8_t internalFEUnitNum, const uint8_t internalFEUnitChannelNum, const uint8_t apvNum) const;
       
       //used by digi2Raw
-      virtual const uint8_t* data() const;
-      virtual void setChannelStatus(const uint8_t internalFEDChannelNum, const FEDChannelStatus status);
-      virtual void setFEUnitMajorityAddress(const uint8_t internalFEUnitNum, const uint8_t address);
-      virtual void setBEStatusRegister(const FEDBackendStatusRegister beStatusRegister);
-      virtual void setDAQRegister(const uint32_t daqRegister);
-      virtual void setDAQRegister2(const uint32_t daqRegister2);
-      virtual void set32BitReservedRegister(const uint8_t internalFEUnitNum, const uint32_t reservedRegister);
-      virtual void setFEUnitLength(const uint8_t internalFEUnitNum, const uint16_t length);
+      const uint8_t* data() const override;
+      void setChannelStatus(const uint8_t internalFEDChannelNum, const FEDChannelStatus status) override;
+      void setFEUnitMajorityAddress(const uint8_t internalFEUnitNum, const uint8_t address) override;
+      void setBEStatusRegister(const FEDBackendStatusRegister beStatusRegister) override;
+      void setDAQRegister(const uint32_t daqRegister) override;
+      void setDAQRegister2(const uint32_t daqRegister2) override;
+      void set32BitReservedRegister(const uint8_t internalFEUnitNum, const uint32_t reservedRegister) override;
+      void setFEUnitLength(const uint8_t internalFEUnitNum, const uint16_t length) override;
       static uint32_t get32BitWordFrom(const uint8_t* startOfWord);
       const uint8_t* feWord(const uint8_t internalFEUnitNum) const;
       uint8_t* feWord(const uint8_t internalFEUnitNum);

--- a/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.cc
@@ -24,7 +24,7 @@ namespace sistrip {
   ExcludedFEDListProducer::ExcludedFEDListProducer( const edm::ParameterSet& pset ) 
     : runNumber_(0)
     , cacheId_(0)
-    , cabling_(0)
+    , cabling_(nullptr)
     , token_ ( consumes<FEDRawDataCollection>(pset.getParameter<edm::InputTag>("ProductLabel")) )
   {    
     produces<DetIdCollection>();

--- a/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.h
+++ b/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.h
@@ -28,7 +28,7 @@ namespace sistrip {
     /// constructor
     ExcludedFEDListProducer( const edm::ParameterSet& pset );
     /// default constructor
-    ~ExcludedFEDListProducer();
+    ~ExcludedFEDListProducer() override;
     void beginRun( const edm::Run & run, const edm::EventSetup & es) override;
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
     void produce( edm::Event& event, const edm::EventSetup& es ) override;

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.cc
@@ -40,7 +40,7 @@ namespace sistrip {
     copyBufferHeader_(pset.getParameter<bool>("CopyBufferHeader")),
     mode_( fedReadoutModeFromString(pset.getParameter<std::string>( "FedReadoutMode" ))),
     rawdigi_( false ),
-    digiToRaw_(0),
+    digiToRaw_(nullptr),
     eventCounter_(0),
     rawDataTag_(pset.getParameter<edm::InputTag>("RawDataTag"))
   {

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
@@ -30,12 +30,12 @@ namespace sistrip {
   public:
   
     DigiToRawModule( const edm::ParameterSet& );
-    ~DigiToRawModule();
+    ~DigiToRawModule() override;
   
     virtual void beginJob() {}
     virtual void endJob() {}
   
-    virtual void produce( edm::Event&, const edm::EventSetup& );
+    void produce( edm::Event&, const edm::EventSetup& ) override;
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
   
   private:

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiModule.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiModule.h
@@ -28,10 +28,10 @@ namespace sistrip {
   public:
     
     RawToDigiModule( const edm::ParameterSet& );
-    ~RawToDigiModule();
+    ~RawToDigiModule() override;
     
-    virtual void beginRun( const edm::Run&, const edm::EventSetup& ) override;
-    virtual void produce( edm::Event&, const edm::EventSetup& ) override;
+    void beginRun( const edm::Run&, const edm::EventSetup& ) override;
+    void produce( edm::Event&, const edm::EventSetup& ) override;
     
   private: 
     

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -863,7 +863,7 @@ namespace sistrip {
   void RawToDigiUnpacker::triggerFed( const FEDRawDataCollection& buffers, SiStripEventSummary& summary, const uint32_t& event ) {
   
     // Pointer to data (recast as 32-bit words) and number of 32-bit words
-    uint32_t* data_u32 = 0;
+    uint32_t* data_u32 = nullptr;
     uint32_t  size_u32 = 0;
   
     // Search mode
@@ -925,7 +925,7 @@ namespace sistrip {
       
     } else { 
       triggerFedId_ = 0; 
-      data_u32 = 0;
+      data_u32 = nullptr;
       size_u32 = 0;
     }
   
@@ -1129,7 +1129,7 @@ namespace sistrip {
     uint32_t daq2 = sistrip::invalid32_;
 
     if (fed.headerType() == sistrip::HEADER_TYPE_FULL_DEBUG) {
-      const sistrip::FEDFullDebugHeader* header = 0;
+      const sistrip::FEDFullDebugHeader* header = nullptr;
       header = dynamic_cast<const sistrip::FEDFullDebugHeader*>(fed.feHeader());
       daq1 = static_cast<uint32_t>( header->daqRegister() ); 
       daq2 = static_cast<uint32_t>( header->daqRegister2() ); 
@@ -1163,7 +1163,7 @@ namespace sistrip {
        << " Buffer contains " << buffer.size()
        << " bytes (NB: payload is byte-swapped)" << std::endl;
 
-    if ( 0 ) { 
+    if ( false ) { 
       uint32_t* buffer_u32 = reinterpret_cast<uint32_t*>( const_cast<unsigned char*>( buffer.data() ) );
       unsigned int empty = 0;
 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.h
@@ -71,7 +71,7 @@ namespace sistrip {
     void update( RawDigis& scope_mode, RawDigis& virgin_raw, RawDigis& proc_raw, Digis& zero_suppr, RawDigis& common_mode );
     
     /// private default constructor
-    RawToDigiUnpacker();
+    RawToDigiUnpacker() = delete;
     
     /// sets the SiStripEventSummary -> not yet implemented for FEDBuffer class
     void updateEventSummary( const sistrip::FEDBuffer&, SiStripEventSummary& );

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
@@ -1272,7 +1272,7 @@ namespace sistrip {
 
 
   FEDBufferBase::FEDBufferBase(const uint8_t* fedBuffer, const size_t fedBufferSize, const bool allowUnrecognizedFormat)
-    : channels_(FEDCH_PER_FED,FEDChannel(NULL,0,0)),
+    : channels_(FEDCH_PER_FED,FEDChannel(nullptr,0,0)),
       originalBuffer_(fedBuffer),
       bufferSize_(fedBufferSize)
   {
@@ -1284,7 +1284,7 @@ namespace sistrip {
       bufferSize_(fedBufferSize)
   {
     init(fedBuffer,fedBufferSize,allowUnrecognizedFormat);
-    if (fillChannelVector) channels_.assign(FEDCH_PER_FED,FEDChannel(NULL,0,0));
+    if (fillChannelVector) channels_.assign(FEDCH_PER_FED,FEDChannel(nullptr,0,0));
   }
   
   void FEDBufferBase::init(const uint8_t* fedBuffer, const size_t fedBufferSize, const bool allowUnrecognizedFormat)

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferGenerator.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferGenerator.cc
@@ -85,7 +85,7 @@ namespace sistrip {
     //vectors are guarenteed to be contiguous
     if (lengthInBytes()) return &data_[0];
     //return NULL if there is no data yet
-    else return NULL;
+    else return nullptr;
   }
   
   uint16_t FEDBufferPayload::getFELength(const uint8_t internalFEUnitNum) const

--- a/EventFilter/Utilities/interface/JsonMonitorable.h
+++ b/EventFilter/Utilities/interface/JsonMonitorable.h
@@ -214,7 +214,7 @@ public:
 	std::string toString() const override {
 		std::stringstream ss;
 		ss << "[";
-		if (histo_.size())
+		if (!histo_.empty())
 			for (unsigned int i = 0; i < histo_.size(); i++) {
 				ss << histo_[i];
 				if (i<histo_.size()-1) ss << ",";

--- a/EventFilter/Utilities/interface/MicroStateServiceClassic.h
+++ b/EventFilter/Utilities/interface/MicroStateServiceClassic.h
@@ -24,11 +24,11 @@ namespace evf{
     {
     public:
       MicroStateServiceClassic(const edm::ParameterSet&,edm::ActivityRegistry&);
-      ~MicroStateServiceClassic();
+      ~MicroStateServiceClassic() override;
       
-      std::string getMicroState1();
+      std::string getMicroState1() override;
       
-      std::string const &getMicroState2();
+      std::string const &getMicroState2() override;
 
       void postBeginJob();     
 
@@ -43,7 +43,7 @@ namespace evf{
       void preModule(const edm::ModuleDescription&);
       void postModule(const edm::ModuleDescription&);
 
-      void setMicroState(MicroStateService::Microstate m);
+      void setMicroState(MicroStateService::Microstate m) override;
       
     private:
 

--- a/EventFilter/Utilities/plugins/DaqFakeReader.cc
+++ b/EventFilter/Utilities/plugins/DaqFakeReader.cc
@@ -20,7 +20,7 @@
 
 #include <cmath>
 #include <sys/time.h>
-#include <string.h>
+#include <cstring>
 
 
 using namespace std;
@@ -94,7 +94,7 @@ int DaqFakeReader::fillRawData(Event& e,
 	       eID, *data, meansize, width);
 
       timeval now;
-      gettimeofday(&now,0);
+      gettimeofday(&now,nullptr);
       fillGTPFED(eID, *data,&now);
       //TODO: write fake TCDS FED filler
     }
@@ -104,7 +104,7 @@ int DaqFakeReader::fillRawData(Event& e,
 void DaqFakeReader::produce(Event&e, EventSetup const&es){
 
   edm::Handle<FEDRawDataCollection> rawdata;
-  FEDRawDataCollection *fedcoll = 0;
+  FEDRawDataCollection *fedcoll = nullptr;
   fillRawData(e,fedcoll);
   std::unique_ptr<FEDRawDataCollection> bare_product(fedcoll);
   e.put(std::move(bare_product));

--- a/EventFilter/Utilities/plugins/DaqFakeReader.h
+++ b/EventFilter/Utilities/plugins/DaqFakeReader.h
@@ -25,7 +25,7 @@ class DaqFakeReader : public edm::one::EDProducer<>
   // construction/destruction
   //
   DaqFakeReader(const edm::ParameterSet& pset);
-  virtual ~DaqFakeReader();
+  ~DaqFakeReader() override;
   
 
   //
@@ -36,7 +36,7 @@ class DaqFakeReader : public edm::one::EDProducer<>
   virtual int fillRawData(edm::Event& e,
 			  FEDRawDataCollection*& data);
 
-  virtual void produce(edm::Event&, edm::EventSetup const&);
+  void produce(edm::Event&, edm::EventSetup const&) override;
   
 private:
   //

--- a/EventFilter/Utilities/plugins/ExceptionGenerator.cc
+++ b/EventFilter/Utilities/plugins/ExceptionGenerator.cc
@@ -13,9 +13,9 @@
 
 #include "boost/tokenizer.hpp"
 
-#include <stdio.h>
+#include <cstdio>
 #include <sys/types.h>
-#include <signal.h>
+#include <csignal>
 
 using namespace std;
 
@@ -140,7 +140,7 @@ namespace evf{
   void ExceptionGenerator::beginRun(const edm::Run& r, const edm::EventSetup& iSetup)
   {
 
-    gettimeofday(&tv_start_,0);
+    gettimeofday(&tv_start_,nullptr);
   }
 
   void __attribute__((optimize("O0"))) ExceptionGenerator::analyze(const edm::Event & e, const edm::EventSetup& c)
@@ -149,7 +149,7 @@ namespace evf{
       unsigned int iterations = 0;
       if(actionRequired_) 
 	{
-	  int *pi = 0;//null-pointer used with actionId_ 8 and 12 to intentionally cause segfault
+	  int *pi = nullptr;//null-pointer used with actionId_ 8 and 12 to intentionally cause segfault
 	  int ind = 0; 
 	  int step = 1; 
 	  switch(actionId_)
@@ -173,7 +173,7 @@ namespace evf{
 	      throw qualifier_; 
 	      break;
 	    case 6:
-	      while(1){ind+=step; if(ind>1000000) step = -1; if(ind==0) step = 1;}
+	      while(true){ind+=step; if(ind>1000000) step = -1; if(ind==0) step = 1;}
 	      break;
 	    case 7:
 	      edm::LogError("TestErrorMessage") << qualifier_;
@@ -216,7 +216,7 @@ namespace evf{
 	    case 12:
 	      {
 		timeval tv_now;
-	        gettimeofday(&tv_now,0);
+	        gettimeofday(&tv_now,nullptr);
 		if ((unsigned)(tv_now.tv_sec-tv_start_.tv_sec)>intqualifier_)
 		  *pi=0;//intentionally caused segfault by assigning null pointer (this produces static-checker warning)
 	      }

--- a/EventFilter/Utilities/plugins/ExceptionGenerator.h
+++ b/EventFilter/Utilities/plugins/ExceptionGenerator.h
@@ -18,7 +18,7 @@ namespace evf{
       static const std::string menu[menu_items];
 						   
       explicit ExceptionGenerator( const edm::ParameterSet&);
-      ~ExceptionGenerator(){};
+      ~ExceptionGenerator() override{};
       void beginRun(const edm::Run& r, const edm::EventSetup& iSetup) override;
       void analyze(const edm::Event & e, const edm::EventSetup& c) override;
       void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;

--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
@@ -11,10 +11,10 @@
 
 #include <iostream>
 #include <sstream>
-#include <stdio.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cerrno>
+#include <cstring>
 #include <boost/filesystem/fstream.hpp>
 
 using namespace jsoncollector;
@@ -285,7 +285,7 @@ void RawEventFileWriterForBU::stop()
 {
   if (lumiOpen_>lumiClosed_)  endOfLS(lumiOpen_);
   edm::LogInfo("RawEventFileWriterForBU") << "Writing EOR file!";
-  if (destinationDir_.size() > 0)
+  if (!destinationDir_.empty())
     {
       // create EoR file
       if (run_==-1) makeRunPrefix(destinationDir_);

--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.h
@@ -9,7 +9,7 @@
 #include "EventFilter/Utilities/interface/FastMonitor.h"
 
 #include <fstream>
-#include <stdio.h>
+#include <cstdio>
 #include <sys/types.h>
 #include <sys/stat.h>
 

--- a/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
@@ -34,17 +34,17 @@ class RawEventOutputModuleForBU : public edm::one::OutputModule<edm::one::WatchR
 
  public:
   explicit RawEventOutputModuleForBU(edm::ParameterSet const& ps);  
-  ~RawEventOutputModuleForBU();
+  ~RawEventOutputModuleForBU() override;
 
  private:
-  virtual void write(edm::EventForOutput const& e) override;
-  virtual void beginRun(edm::RunForOutput const&) override;
-  virtual void endRun(edm::RunForOutput const&) override;
-  virtual void writeRun(const edm::RunForOutput&) override {}
-  virtual void writeLuminosityBlock(const edm::LuminosityBlockForOutput&) override {}
+  void write(edm::EventForOutput const& e) override;
+  void beginRun(edm::RunForOutput const&) override;
+  void endRun(edm::RunForOutput const&) override;
+  void writeRun(const edm::RunForOutput&) override {}
+  void writeLuminosityBlock(const edm::LuminosityBlockForOutput&) override {}
 
-  virtual void beginLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
-  virtual void endLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
+  void beginLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
+  void endLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
 
   std::auto_ptr<Consumer> templateConsumer_;
   std::string label_;
@@ -191,18 +191,18 @@ void RawEventOutputModuleForBU<Consumer>::beginLuminosityBlock(edm::LuminosityBl
   //edm::Service<evf::EvFDaqDirector>()->updateBuLock(ls.id().luminosityBlock()+1);
   if(!firstLumi_){
     timeval now;
-    ::gettimeofday(&now,0);
+    ::gettimeofday(&now,nullptr);
     //long long elapsedusec = (now.tv_sec - startOfLastLumi.tv_sec)*1000000+now.tv_usec-startOfLastLumi.tv_usec;
 /*     std::cout << "(now.tv_sec - startOfLastLumi.tv_sec) " << now.tv_sec <<"-" << startOfLastLumi.tv_sec */
 /* 	      <<" (now.tv_usec-startOfLastLumi.tv_usec) " << now.tv_usec << "-" << startOfLastLumi.tv_usec << std::endl; */
 /*     std::cout << "elapsedusec " << elapsedusec << "  totevents " << totevents << "  size (GB)" << writtensize  */
 /* 	      << "  rate " << (writtensize-writtenSizeLast)/elapsedusec << " MB/s" <<std::endl; */
     writtenSizeLast=writtensize;
-    ::gettimeofday(&startOfLastLumi,0);
+    ::gettimeofday(&startOfLastLumi,nullptr);
     //edm::Service<evf::EvFDaqDirector>()->writeLsStatisticsBU(ls.id().luminosityBlock(), totevents, totsize, elapsedusec);
   }
   else
-    ::gettimeofday(&startOfLastLumi,0);
+    ::gettimeofday(&startOfLastLumi,nullptr);
   totevents = 0;
   totsize = 0LL;
   firstLumi_ = false;

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -33,19 +33,19 @@ namespace evf {
     
   public:
     explicit RecoEventOutputModuleForFU(edm::ParameterSet const& ps);  
-    virtual ~RecoEventOutputModuleForFU();
+    ~RecoEventOutputModuleForFU() override;
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
     
   private:
     void initRun();
-    virtual void start() override;
-    virtual void stop() override;
-    virtual void doOutputHeader(InitMsgBuilder const& init_message) override;
-    virtual void doOutputEvent(EventMsgBuilder const& msg) override;
+    void start() override;
+    void stop() override;
+    void doOutputHeader(InitMsgBuilder const& init_message) override;
+    void doOutputEvent(EventMsgBuilder const& msg) override;
     //virtual void beginRun(edm::RunForOutput const&);
-    virtual void beginJob() override;
-    virtual void beginLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
-    virtual void endLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
+    void beginJob() override;
+    void beginLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
+    void endLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
 
   private:
     std::auto_ptr<Consumer> c_;
@@ -309,7 +309,7 @@ namespace evf {
         std::string deschecksum = edm::Service<evf::EvFDaqDirector>()->getMergedDatChecksumFilePath(ls.luminosityBlock(), stream_label_);
 
         struct stat istat;
-        FILE * cf = NULL;
+        FILE * cf = nullptr;
         uint32_t mergedAdler32=1;
         //get adler32 accumulated checksum for the merged file
         if (!stat(deschecksum.c_str(), &istat)) {

--- a/EventFilter/Utilities/src/DataPoint.cc
+++ b/EventFilter/Utilities/src/DataPoint.cc
@@ -10,7 +10,7 @@
 #include <tbb/concurrent_vector.h>
 
 #include <algorithm>
-#include <assert.h>
+#include <cassert>
 
 //max collected updates per lumi
 #define MAXUPDATES 0xffffffff
@@ -42,10 +42,10 @@ DataPoint::~DataPoint()
 
 void DataPoint::serialize(Json::Value& root) const
 {
-  if (source_.size()) {
+  if (!source_.empty()) {
     root[SOURCE] = source_;
   }
-  if (definition_.size()) {
+  if (!definition_.empty()) {
     root[DEFINITION] = definition_;
   }
   for (unsigned int i=0;i<data_.size();i++)
@@ -114,9 +114,9 @@ void DataPoint::makeStreamLumiMap(unsigned int size)
 void DataPoint::serialize(Json::Value& root, bool rootInit, std::string const&input) const
 {
   if (rootInit) {
-    if (source_.size())
+    if (!source_.empty())
       root[SOURCE] = source_;
-    if (definition_.size())
+    if (!definition_.empty())
       root[DEFINITION] = definition_;
   }
   root[DATA].append(input);

--- a/EventFilter/Utilities/src/DataPointDefinition.cc
+++ b/EventFilter/Utilities/src/DataPointDefinition.cc
@@ -51,7 +51,7 @@ void DataPointDefinition::serialize(Json::Value& root) const
     Json::Value currentDef;
     currentDef[PARAM_NAME] = varNames_[i];
     currentDef[OPERATION] = opNames_[i];
-    if (typeNames_[i].size()) //only if it was found
+    if (!typeNames_[i].empty()) //only if it was found
       currentDef[TYPE] = typeNames_[i];
     root[defaultGroup_].append(currentDef);
   }
@@ -71,7 +71,7 @@ void DataPointDefinition::deserialize(Json::Value& root)
 
 bool DataPointDefinition::isPopulated() const
 {
-  if (varNames_.size() > 0)
+  if (!varNames_.empty())
     return true;
   return false;
 }

--- a/EventFilter/Utilities/src/FastMonitor.cc
+++ b/EventFilter/Utilities/src/FastMonitor.cc
@@ -13,7 +13,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
-#include <assert.h>
+#include <cassert>
 #include <sys/types.h>
 #include <unistd.h>
 #include <boost/filesystem/fstream.hpp>

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -260,14 +260,14 @@ namespace evf{
        microstate_.emplace_back(&reservedMicroStateNames[mInvalid]);
 
        //for synchronization
-       streamCounterUpdating_.push_back(new std::atomic<bool>(0));
+       streamCounterUpdating_.push_back(new std::atomic<bool>(false));
 
        //path (mini) state
        encPath_.emplace_back(0);
        encPath_[i].update(static_cast<const void*>(&nopath_));
        eventCountForPathInit_.push_back(0);
        firstEventId_.push_back(0);
-       collectedPathList_.push_back(new std::atomic<bool>(0));
+       collectedPathList_.push_back(new std::atomic<bool>(false));
 
     }
     //for (unsigned int i=0;i<nThreads_;i++)
@@ -396,7 +396,7 @@ namespace evf{
   void FastMonitoringService::preGlobalBeginLumi(edm::GlobalContext const& gc)
   {
 	  timeval lumiStartTime;
-	  gettimeofday(&lumiStartTime, 0);
+	  gettimeofday(&lumiStartTime, nullptr);
 	  unsigned int newLumi = gc.luminosityBlockID().luminosityBlock();
 
           std::lock_guard<std::mutex> lock(fmt_.monlock_);
@@ -423,7 +423,7 @@ namespace evf{
           LogDebug("FastMonitoringService") << "Lumi ended. Writing JSON information. LUMI -: "
                                                 << lumi;
 	  timeval lumiStopTime;
-	  gettimeofday(&lumiStopTime, 0);
+	  gettimeofday(&lumiStopTime, nullptr);
 
           std::lock_guard<std::mutex> lock(fmt_.monlock_);
 
@@ -667,7 +667,7 @@ namespace evf{
   }
 
   void FastMonitoringService::startedLookingForFile() {
-	  gettimeofday(&fileLookStart_, 0);
+	  gettimeofday(&fileLookStart_, nullptr);
 	  /*
 	 std::cout << "Started looking for .raw file at: s=" << fileLookStart_.tv_sec << ": ms = "
 	 << fileLookStart_.tv_usec / 1000.0 << std::endl;
@@ -675,7 +675,7 @@ namespace evf{
   }
 
   void FastMonitoringService::stoppedLookingForFile(unsigned int lumi) {
-	  gettimeofday(&fileLookStop_, 0);
+	  gettimeofday(&fileLookStop_, nullptr);
 	  /*
 	 std::cout << "Stopped looking for .raw file at: s=" << fileLookStop_.tv_sec << ": ms = "
 	 << fileLookStop_.tv_usec / 1000.0 << std::endl;
@@ -734,7 +734,7 @@ namespace evf{
     }
     else {
       throw cms::Exception("FastMonitoringService") << "output module wants already deleted (or never reported by SOURCE) lumisection status for LUMI -: "<<lumi;
-      return 0;
+      return false;
     }
   }
 

--- a/EventFilter/Utilities/src/FileIO.cc
+++ b/EventFilter/Utilities/src/FileIO.cc
@@ -12,7 +12,7 @@
 #include <streambuf>
 #include <cstdlib>
 #include <dirent.h>
-#include <stdio.h>
+#include <cstdio>
 #include <sys/stat.h>
 #include <cstring>
 

--- a/EventFilter/Utilities/src/JSONSerializer.cc
+++ b/EventFilter/Utilities/src/JSONSerializer.cc
@@ -7,7 +7,7 @@
 
 #include "EventFilter/Utilities/interface/JSONSerializer.h"
 
-#include <assert.h>
+#include <cassert>
 
 using namespace jsoncollector;
 

--- a/EventFilter/Utilities/src/crc32c.cc
+++ b/EventFilter/Utilities/src/crc32c.cc
@@ -39,9 +39,9 @@
 
 
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdint.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
 #include <unistd.h>
 #include <pthread.h>
 


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this quickly to avoid conflicts to the extent possible]