### PR TITLE
Clang-tidy checks for FastSimDataFormats

### DIFF
--- a/FastSimDataFormats/L1GlobalMuonTrigger/interface/SimpleL1MuGMTCand.h
+++ b/FastSimDataFormats/L1GlobalMuonTrigger/interface/SimpleL1MuGMTCand.h
@@ -49,7 +49,7 @@ class SimpleL1MuGMTCand : public L1MuGMTExtendedCand {
 		      float pTValue);    
 
     /// destructor
-    virtual ~SimpleL1MuGMTCand();
+    ~SimpleL1MuGMTCand() override;
 
     /// reset muon candidate
     void reset();


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this quickly to avoid conflicts to the extent possible]