### PR TITLE
Clang-tidy checks for FastSimulation

### DIFF
--- a/FastSimulation/CTPPSFastGeometry/src/CTPPSToFDetector.cc
+++ b/FastSimulation/CTPPSFastGeometry/src/CTPPSToFDetector.cc
@@ -1,5 +1,5 @@
 #include "FastSimulation/CTPPSFastGeometry/interface/CTPPSToFDetector.h"
-#include <math.h>
+#include <cmath>
 
 
 CTPPSToFDetector::CTPPSToFDetector(int ncellx,int ncelly, std::vector<double>& cellw,double cellh,double pitchx,double pitchy,double pos, int res):

--- a/FastSimulation/CTPPSFastGeometry/src/CTPPSTrkDetector.cc
+++ b/FastSimulation/CTPPSFastGeometry/src/CTPPSTrkDetector.cc
@@ -1,5 +1,5 @@
 #include "FastSimulation/CTPPSFastGeometry/interface/CTPPSTrkDetector.h"
-#include <math.h>
+#include <cmath>
 CTPPSTrkDetector::CTPPSTrkDetector(double detw, double deth, double detin):
                 ppsDetectorWidth_(detw), ppsDetectorHeight_(deth), ppsDetectorPosition_(detin) {clear();}
 void CTPPSTrkDetector::AddHit(unsigned int detID,double x, double y, double z)

--- a/FastSimulation/CTPPSFastTrackingProducer/interface/CTPPSFastTrackingProducer.h
+++ b/FastSimulation/CTPPSFastTrackingProducer/interface/CTPPSFastTrackingProducer.h
@@ -37,11 +37,11 @@
 #include <fstream>
 #include <string>
 #include <cmath>
-#include <math.h>
+#include <cmath>
 #include <map>
 #include <vector>
 #include <utility>
-#include <math.h>
+#include <cmath>
 
 #include <TMatrixD.h>
 
@@ -63,13 +63,13 @@
 class CTPPSFastTrackingProducer : public edm::stream::EDProducer<> {
     public:
         explicit CTPPSFastTrackingProducer(const edm::ParameterSet&);
-        ~CTPPSFastTrackingProducer();
+        ~CTPPSFastTrackingProducer() override;
         typedef CLHEP::HepLorentzVector LorentzVector;
 
     private:
-        virtual void beginStream(edm::StreamID) override;
-        virtual void produce(edm::Event&, const edm::EventSetup&) override;
-        virtual void endStream() override;
+        void beginStream(edm::StreamID) override;
+        void produce(edm::Event&, const edm::EventSetup&) override;
+        void endStream() override;
         //this function will only be called once per event
         virtual void beginEvent(edm::Event& event, const edm::EventSetup& eventSetup);
         virtual void endEvent(edm::Event& event, const edm::EventSetup& eventSetup);

--- a/FastSimulation/CTPPSFastTrackingProducer/plugins/CTPPSFastTrackingProducer.cc
+++ b/FastSimulation/CTPPSFastTrackingProducer/plugins/CTPPSFastTrackingProducer.cc
@@ -224,9 +224,9 @@ bool CTPPSFastTrackingProducer::SearchTrack(int i,int j,int Direction,double& xi
     // Given 1 hit in Tracker1 and 1 hit in Tracker2 try to make a track with Hector
     double theta=0.;
     xi = 0; t=0; partP=0; pt=0; x0=0.;y0=0.;xt =0.;yt =0.;X1d=0.;Y1d=0.;X2d=0.;Y2d=0.; 
-    CTPPSTrkDetector* det1 = NULL;
-    CTPPSTrkDetector* det2 = NULL;
-    H_RecRPObject*  station = NULL;
+    CTPPSTrkDetector* det1 = nullptr;
+    CTPPSTrkDetector* det2 = nullptr;
+    H_RecRPObject*  station = nullptr;
     // Separate in forward and backward stations according to direction
     if (Direction>0) {
         det1=&(TrkStation_F->first);det2=&(TrkStation_F->second);
@@ -349,8 +349,8 @@ void CTPPSFastTrackingProducer::FastReco(int Direction,H_RecRPObject* station)
 {
     double theta = 0.;
     double xi,t,partP,pt,phi,x0,y0,thx,thy,xt,yt,X1d,Y1d,X2d,Y2d;
-    CTPPSTrkDetector* Trk1 = NULL;
-    CTPPSTrkDetector* Trk2 = NULL;
+    CTPPSTrkDetector* Trk1 = nullptr;
+    CTPPSTrkDetector* Trk2 = nullptr;
     double pos_tof = fToFInsertion*fBeamXRMS_ToF+fToFXOffset;
     int cellId = 0;
     std::vector<double> vToFCellWidth;

--- a/FastSimulation/CTPPSRecHitProducer/plugins/CTPPSRecHitProducer.cc
+++ b/FastSimulation/CTPPSRecHitProducer/plugins/CTPPSRecHitProducer.cc
@@ -29,7 +29,7 @@ Implementation:
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 /////
-#include <math.h>
+#include <cmath>
 
 #include "CLHEP/Random/RandGauss.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
@@ -68,12 +68,12 @@ class CTPPSToFDetector;
 class CTPPSRecHitProducer : public edm::stream::EDProducer<> {
     public:
         explicit CTPPSRecHitProducer(const edm::ParameterSet&);
-        ~CTPPSRecHitProducer();
+        ~CTPPSRecHitProducer() override;
 
     private:
-        virtual void beginStream(edm::StreamID) override;
-        virtual void produce(edm::Event&, const edm::EventSetup&) override;
-        virtual void endStream() override;
+        void beginStream(edm::StreamID) override;
+        void produce(edm::Event&, const edm::EventSetup&) override;
+        void endStream() override;
 
         // ----------member data ---------------------------
         typedef std::vector<PSimHit> PSimHitContainer;

--- a/FastSimulation/CTPPSSimHitProducer/plugins/CTPPSSimHitProducer.cc
+++ b/FastSimulation/CTPPSSimHitProducer/plugins/CTPPSSimHitProducer.cc
@@ -58,13 +58,13 @@ Implementation:
 class CTPPSSimHitProducer : public edm::stream::EDProducer<> {
     public:
         explicit CTPPSSimHitProducer(const edm::ParameterSet&);
-        ~CTPPSSimHitProducer();
+        ~CTPPSSimHitProducer() override;
         typedef CLHEP::HepLorentzVector LorentzVector;
 
     private:
-        virtual void beginStream(edm::StreamID) override;
-        virtual void produce(edm::Event&, const edm::EventSetup&) override;
-        virtual void endStream() override;
+        void beginStream(edm::StreamID) override;
+        void produce(edm::Event&, const edm::EventSetup&) override;
+        void endStream() override;
 
         edm::EDGetTokenT< edm::HepMCProduct > mcEventToken; // label of MC event
         edm::Handle< edm::HepMCProduct > EvtHandle ;
@@ -130,7 +130,7 @@ CTPPSSimHitProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
             if(pid!=2212) continue;
 
             HepMC::GenVertex* pv = (*i)->production_vertex();
-            HepMC::FourVector vertex = pv->position();
+            const HepMC::FourVector& vertex = pv->position();
             const HepMC::FourVector p((*i)->momentum());
             protonCTPPS.push_back(math::XYZTLorentzVector(p.x(),p.y(),p.z(),p.t()));
 

--- a/FastSimulation/CaloHitMakers/interface/EcalHitMaker.h
+++ b/FastSimulation/CaloHitMakers/interface/EcalHitMaker.h
@@ -38,7 +38,7 @@ class EcalHitMaker: public CaloHitMaker
 	       unsigned showertype,
 	       const RandomEngineAndDistribution* engine);
 
-  ~EcalHitMaker();
+  ~EcalHitMaker() override;
 
   // This is not part of the constructor but it has to be called very early
   void setTrackParameters(const XYZNormal& normal,
@@ -110,16 +110,16 @@ class EcalHitMaker: public CaloHitMaker
 
   bool addHitDepth(double r,double phi,double depth=-1);
    
-  bool addHit(double r,double phi,unsigned layer=0) ;
+  bool addHit(double r,double phi,unsigned layer=0) override ;
 
   unsigned fastInsideCell(const CLHEP::Hep2Vector & point,double & sp,bool debug=false) ;
 
-  inline void setSpotEnergy(double e) { spotEnergy=e;}
+  inline void setSpotEnergy(double e) override { spotEnergy=e;}
   
    /// get the map of the stored hits. Triggers the calculation of the grid if it has
   /// not been done. 
     
-  const std::map<CaloHitID,float>& getHits() ;
+  const std::map<CaloHitID,float>& getHits() override ;
  
   /// To retrieve the track
   const FSimTrack* getFSimTrack() const {return myTrack_;}

--- a/FastSimulation/CaloHitMakers/interface/HcalHitMaker.h
+++ b/FastSimulation/CaloHitMakers/interface/HcalHitMaker.h
@@ -22,19 +22,19 @@ class HcalHitMaker : public CaloHitMaker
   typedef ROOT::Math::Transform3DPJ Transform3D;
 
   HcalHitMaker(EcalHitMaker &, unsigned );
-  ~HcalHitMaker() {;}
+  ~HcalHitMaker() override {;}
   
   /// Set the spot energy
-  inline void setSpotEnergy(double e) { spotEnergy=e;} 
+  inline void setSpotEnergy(double e) override { spotEnergy=e;} 
   
   /// add the hit in the HCAL in local coordinates
-  bool addHit(double r,double phi,unsigned layer=0);
+  bool addHit(double r,double phi,unsigned layer=0) override;
   
   /// add the hit in the HCAL in global coordinates
   bool addHit(const XYZPoint & point ,unsigned layer=0);
 
   // get the hits
-  const std::map<CaloHitID,float>& getHits() { return hitMap_ ;} ;
+  const std::map<CaloHitID,float>& getHits() override { return hitMap_ ;} ;
 
   /// set the depth in X0 or Lambda0 units depending on showerType
   bool setDepth(double,bool inCm=false); 

--- a/FastSimulation/CaloHitMakers/interface/PreshowerHitMaker.h
+++ b/FastSimulation/CaloHitMakers/interface/PreshowerHitMaker.h
@@ -24,12 +24,12 @@ class PreshowerHitMaker : public CaloHitMaker
 		    const LandauFluctuationGenerator* aGenerator,
 	            const RandomEngineAndDistribution* engine);
 
-  ~PreshowerHitMaker() {;} 
+  ~PreshowerHitMaker() override {;} 
   
-  inline void setSpotEnergy(double e) { spotEnergy=e;} 
-  bool addHit(double r, double phi, unsigned layer=0);
+  inline void setSpotEnergy(double e) override { spotEnergy=e;} 
+  bool addHit(double r, double phi, unsigned layer=0) override;
 
-  const std::map<CaloHitID,float>& getHits() { return hitMap_ ;} ;
+  const std::map<CaloHitID,float>& getHits() override { return hitMap_ ;} ;
  // for tuning
   inline void setMipEnergy(double e1, double e2) { mip1_=e1 ; mip2_=e2;} 
   

--- a/FastSimulation/CaloHitMakers/src/CaloHitMaker.cc
+++ b/FastSimulation/CaloHitMakers/src/CaloHitMaker.cc
@@ -8,7 +8,7 @@
 typedef ROOT::Math::Plane3D::Point Point;
 
 CaloHitMaker::CaloHitMaker(const CaloGeometryHelper * theCalo,DetId::Detector basedet,int subdetn,int cal,unsigned sht)
-  :myCalorimeter(theCalo),theCaloProperties(NULL),base_(basedet),subdetn_(subdetn),onCal_(cal),showerType_(sht)
+  :myCalorimeter(theCalo),theCaloProperties(nullptr),base_(basedet),subdetn_(subdetn),onCal_(cal),showerType_(sht)
 {
   //  std::cout << " FamosCalorimeter " << basedet << " " << cal << std::endl;
   EMSHOWER=(sht==0);

--- a/FastSimulation/CaloHitMakers/src/EcalHitMaker.cc
+++ b/FastSimulation/CaloHitMakers/src/EcalHitMaker.cc
@@ -38,7 +38,7 @@ EcalHitMaker::EcalHitMaker(CaloGeometryHelper * theCalo,
   CaloHitMaker(theCalo,DetId::Ecal,((onEcal==1)?EcalBarrel:EcalEndcap),onEcal,showertype),
   EcalEntrance_(ecalentrance),
   onEcal_(onEcal),
-  myTrack_(NULL),
+  myTrack_(nullptr),
   random(engine)
 {
 #ifdef FAMOSDEBUG
@@ -79,7 +79,7 @@ EcalHitMaker::EcalHitMaker(CaloGeometryHelper * theCalo,
   central_=onEcal==1;
   ecalFirstSegment_=-1;
   
-  myCrystalWindowMap_ = 0; 
+  myCrystalWindowMap_ = nullptr; 
   // In some cases, a "dummy" grid, not based on a cell, can be built. The previous variables
   // should however be initialized. In such a case onEcal=0
   if(!onEcal) return;
@@ -125,7 +125,7 @@ EcalHitMaker::EcalHitMaker(CaloGeometryHelper * theCalo,
 
 EcalHitMaker::~EcalHitMaker()
 {
-  if (myCrystalWindowMap_ != 0)
+  if (myCrystalWindowMap_ != nullptr)
     {
       delete myCrystalWindowMap_;
     }

--- a/FastSimulation/CalorimeterProperties/interface/ECALBarrelProperties.h
+++ b/FastSimulation/CalorimeterProperties/interface/ECALBarrelProperties.h
@@ -22,19 +22,19 @@ class ECALBarrelProperties : public ECALProperties
 
   ECALBarrelProperties(const edm::ParameterSet& fastDet);
 
-  virtual ~ECALBarrelProperties() { }
+  ~ECALBarrelProperties() override { }
 
   /// Thickness (in cm): 23.0 for Standard ECAL
-  double thickness(double eta) const { return thickness_; }
+  double thickness(double eta) const override { return thickness_; }
 
   ///Photostatistics (photons/GeV) in the homegeneous material: 50E3  for Standard ECAL
-  inline double photoStatistics() const { return photoStatistics_; }
+  inline double photoStatistics() const override { return photoStatistics_; }
 
   ///Light Collection efficiency [Default : 3.0%]
-  inline double lightCollectionEfficiency() const { return lightColl_; }
+  inline double lightCollectionEfficiency() const override { return lightColl_; }
 
   ///Light Collection uniformity 0.003 for Standard ECAL
-  inline double lightCollectionUniformity() const {return lightCollUnif_;}
+  inline double lightCollectionUniformity() const override {return lightCollUnif_;}
 
 };
 

--- a/FastSimulation/CalorimeterProperties/interface/ECALEndcapProperties.h
+++ b/FastSimulation/CalorimeterProperties/interface/ECALEndcapProperties.h
@@ -23,19 +23,19 @@ class ECALEndcapProperties : public ECALProperties
 
   ECALEndcapProperties(const edm::ParameterSet& fastDet) ;
 
-  virtual ~ECALEndcapProperties() { }
+  ~ECALEndcapProperties() override { }
 
  /// Thickness (in cm): 22.0 for Standard ECAL
-  double thickness(double eta) const { return thickness_; }
+  double thickness(double eta) const override { return thickness_; }
 
   ///Photostatistics (photons/GeV) in the homegeneous material: 50E3  for Standard ECAL
-  inline double photoStatistics() const { return photoStatistics_; }
+  inline double photoStatistics() const override { return photoStatistics_; }
 
   ///Light Collection efficiency [Default : 3.0%]
-  inline double lightCollectionEfficiency() const { return lightColl_; }
+  inline double lightCollectionEfficiency() const override { return lightColl_; }
 
   ///Light Collection uniformity 0.003 for Standard ECAL
-  inline double lightCollectionUniformity() const {return lightCollUnif_;}
+  inline double lightCollectionUniformity() const override {return lightCollUnif_;}
 
 
 };

--- a/FastSimulation/CalorimeterProperties/interface/ECALProperties.h
+++ b/FastSimulation/CalorimeterProperties/interface/ECALProperties.h
@@ -19,21 +19,21 @@ class ECALProperties : public CalorimeterProperties
 
   ECALProperties() : scaleEnergy_(0.0212){ } 
 
-  virtual ~ECALProperties() {
+  ~ECALProperties() override {
   }
 
   /// Effective A: 170.87 for Standard ECAL
-  inline double theAeff() const { return Aeff_; }
+  inline double theAeff() const override { return Aeff_; }
 
   /// Effective Z: 68.36 for Standard ECAL
-  inline double theZeff() const { return Zeff_; }
+  inline double theZeff() const override { return Zeff_; }
 
   /// Density in g/cm3: 8.280 for Standard ECAL
-  inline double rho() const { return rho_; }
+  inline double rho() const override { return rho_; }
 
   /// Radiation length in cm
   //  inline double radLenIncm()  const { return radiationLengthIncm(); }: 0.89 for Standard ECAL
-  inline double radLenIncm()  const { return radLenIncm_; }
+  inline double radLenIncm()  const override { return radLenIncm_; }
 
   /// Radiation length in cm but static 
   // This is needed in Calorimetry/CrystalSegment. Patrick, if you don't like it, give
@@ -41,16 +41,16 @@ class ECALProperties : public CalorimeterProperties
   // static inline double radiationLengthIncm() { return 0.89; }
 
   /// Radiation length in g/cm^2: 7.37  for Standard ECAL
-  inline double radLenIngcm2() const { return radLenIngcm2_; }
+  inline double radLenIngcm2() const override { return radLenIngcm2_; }
 
   /// Moliere Radius in cm : 2.190 for Standard ECAL
-  inline   double moliereRadius() const { return moliereRadius_; }
+  inline   double moliereRadius() const override { return moliereRadius_; }
 
   /// Critical energy in GeV (2.66E-3*(x0*Z/A)^1.1): 8.74E-3 for Standard ECAL
-  inline double criticalEnergy() const { return criticalEnergy_; }
+  inline double criticalEnergy() const override { return criticalEnergy_; }
 
   ///Interaction length in cm: 18.5 for Standard ECAL
-  inline double interactionLength() const { return interactionLength_; }
+  inline double interactionLength() const override { return interactionLength_; }
 
   ///Sampling fraction Fs of the calorimeter. 0 for homogeneous one
   inline double theFs() const { return Fs_; }

--- a/FastSimulation/CalorimeterProperties/interface/HCALBarrelProperties.h
+++ b/FastSimulation/CalorimeterProperties/interface/HCALBarrelProperties.h
@@ -25,11 +25,11 @@ class HCALBarrelProperties : public HCALProperties
 
   HCALBarrelProperties(const edm::ParameterSet& fastDet):HCALProperties(fastDet) {; } 
 
-  virtual ~HCALBarrelProperties() { }
+  ~HCALBarrelProperties() override { }
 
   double getHcalDepth(double);
 
-  double thickness(const double eta) const { 
+  double thickness(const double eta) const override { 
     return HCALProperties::getHcalDepth(eta) * interactionLength();
   }
 

--- a/FastSimulation/CalorimeterProperties/interface/HCALEndcapProperties.h
+++ b/FastSimulation/CalorimeterProperties/interface/HCALEndcapProperties.h
@@ -21,11 +21,11 @@ class HCALEndcapProperties : public HCALProperties
 
   HCALEndcapProperties(const edm::ParameterSet& fastDet):HCALProperties(fastDet) {; } 
 
-  virtual ~HCALEndcapProperties() { }
+  ~HCALEndcapProperties() override { }
 
   double getHcalDepth(double);
 
-  double thickness(const double eta) const { 
+  double thickness(const double eta) const override { 
     return HCALProperties::getHcalDepth(eta) * interactionLength();
   }
 

--- a/FastSimulation/CalorimeterProperties/interface/HCALForwardProperties.h
+++ b/FastSimulation/CalorimeterProperties/interface/HCALForwardProperties.h
@@ -25,11 +25,11 @@ class HCALForwardProperties : public HCALProperties
 
   HCALForwardProperties(const edm::ParameterSet& fastDet):HCALProperties(fastDet) {; } 
 
-  virtual ~HCALForwardProperties() { }
+  ~HCALForwardProperties() override { }
 
   double getHcalDepth(double);
 
-  double thickness(double eta) const { 
+  double thickness(double eta) const override { 
     
     double feta = fabs(eta);
     if(feta > 3.0 && feta < 5.19)

--- a/FastSimulation/CalorimeterProperties/interface/HCALProperties.h
+++ b/FastSimulation/CalorimeterProperties/interface/HCALProperties.h
@@ -25,20 +25,20 @@ class HCALProperties : public CalorimeterProperties
 
   HCALProperties(const edm::ParameterSet& fastDet);
 
-  virtual ~HCALProperties() {
+  ~HCALProperties() override {
   }
 
   /// Effective A
-  inline double theAeff() const { return HCALAeff_; }
+  inline double theAeff() const override { return HCALAeff_; }
 
   /// Effective Z
-  inline double theZeff() const { return HCALZeff_; }
+  inline double theZeff() const override { return HCALZeff_; }
 
   /// Density in g/cm3
-  inline double rho() const { return HCALrho_; }
+  inline double rho() const override { return HCALrho_; }
 
   /// Radiation length in cm
-  inline double radLenIncm()  const { return radiationLengthIncm(); }
+  inline double radLenIncm()  const override { return radiationLengthIncm(); }
 
   /// Radiation length in cm but static 
   // This is needed in Calorimetry/CrystalSegment. 
@@ -47,17 +47,17 @@ class HCALProperties : public CalorimeterProperties
   inline double radiationLengthIncm() const { return HCALradiationLengthIncm_; }
  
   /// Radiation length in g/cm^2
-  inline double radLenIngcm2() const { return HCALradLenIngcm2_; }
+  inline double radLenIngcm2() const override { return HCALradLenIngcm2_; }
 
   /// Moliere Radius in cm (=7 A/Z in g/cm^2)
-  inline   double moliereRadius() const { return HCALmoliereRadius_; }
+  inline   double moliereRadius() const override { return HCALmoliereRadius_; }
   //inline double moliereRadius()  const { return 2.4; }
 
   /// Critical energy in GeV (2.66E-3*(x0*Z/A)^1.1)
-  inline double criticalEnergy() const { return HCALcriticalEnergy_; }
+  inline double criticalEnergy() const override { return HCALcriticalEnergy_; }
 
   ///Interaction length in cm
-  inline double interactionLength() const { return HCALinteractionLength_; }
+  inline double interactionLength() const override { return HCALinteractionLength_; }
 
   ///h/pi Warning ! This is a ad-hoc parameter. It has been tuned to get a good agreement on 1TeV electrons
   ///It might have nothing to do with reality

--- a/FastSimulation/CalorimeterProperties/interface/PreshowerLayer1Properties.h
+++ b/FastSimulation/CalorimeterProperties/interface/PreshowerLayer1Properties.h
@@ -23,19 +23,19 @@ class PreshowerLayer1Properties : public PreshowerProperties
 
   PreshowerLayer1Properties(const edm::ParameterSet& fastDet); 
 
-  ~PreshowerLayer1Properties() {
+  ~PreshowerLayer1Properties() override {
     ;
   }
   
   /// Fraction of energy collected on sensitive detectors
-  inline double sensitiveFraction() const { return 0.0036; }
+  inline double sensitiveFraction() const override { return 0.0036; }
 
   /// Number of Mips/GeV [Default : 41.7 Mips/GeV or 24 MeV/Mips]
-  inline double mipsPerGeV() const { return mips; }
+  inline double mipsPerGeV() const override { return mips; }
 
   /// Thickness in cm (Pretend it is all lead)
   /// Default : 1.02 cm at normal incidence
-  double thickness(double eta) const ;
+  double thickness(double eta) const override ;
 };
 
 #endif

--- a/FastSimulation/CalorimeterProperties/interface/PreshowerLayer2Properties.h
+++ b/FastSimulation/CalorimeterProperties/interface/PreshowerLayer2Properties.h
@@ -23,18 +23,18 @@ class PreshowerLayer2Properties : public PreshowerProperties
 
   PreshowerLayer2Properties(const edm::ParameterSet& fastDet);
 
-  ~PreshowerLayer2Properties() {
+  ~PreshowerLayer2Properties() override {
       ;}
 
   /// Fraction of energy collected on sensitive detectors
-  inline double sensitiveFraction() const { return 0.00515; }
+  inline double sensitiveFraction() const override { return 0.00515; }
 
   /// Number of Mips/GeV [Default : 59.5 Mips/GeV or 0.7*24 MeV/Mips]
-  inline double mipsPerGeV() const { return mips; }
+  inline double mipsPerGeV() const override { return mips; }
 
   /// Thickness in cm (pretend it's all lead)
   /// Default : 0.506 cm at normal incidence
-  double thickness(const double eta) const ;
+  double thickness(const double eta) const override ;
 
     /// properties of the material between ES and EE; there is about 12 cm between the two.
   inline double pseeIntLenIncm() const {return pseeInteractionLength_;}

--- a/FastSimulation/CalorimeterProperties/interface/PreshowerProperties.h
+++ b/FastSimulation/CalorimeterProperties/interface/PreshowerProperties.h
@@ -19,29 +19,29 @@ class PreshowerProperties : public CalorimeterProperties
 
   PreshowerProperties() {;} 
 
-  ~PreshowerProperties() {
+  ~PreshowerProperties() override {
     ;
   }
     
   /// Effective A
-  inline double theAeff() const { return 207.2; }
+  inline double theAeff() const override { return 207.2; }
   /// Effective Z
-  inline double theZeff() const { return 82.; }
+  inline double theZeff() const override { return 82.; }
   /// Density in g/cm3
-  inline double rho() const { return 11.350; }
+  inline double rho() const override { return 11.350; }
   /// Radiation length in cm
-  inline double radLenIncm() const { return 0.56; }
+  inline double radLenIncm() const override { return 0.56; }
   /// Radiation length in g/cm^2
-  inline double radLenIngcm2() const { return 6.370; }
+  inline double radLenIngcm2() const override { return 6.370; }
   /// Moliere Radius in cm
-  inline double moliereRadius() const { return 1.53; }
+  inline double moliereRadius() const override { return 1.53; }
   /// Electron critical energy in GeV 
-  inline double criticalEnergy() const { return 7.79E-3; }
+  inline double criticalEnergy() const override { return 7.79E-3; }
   /// Muon critical energy in GeV 
   //inline double muonCriticalEnergy() const { return 141.; }
 
   ///Interaction length in cm
-  inline double interactionLength() const { return 17.1; }
+  inline double interactionLength() const override { return 17.1; }
   
   /// Fraction of energy collected on sensitive detectors
   virtual double sensitiveFraction() const=0;

--- a/FastSimulation/CalorimeterProperties/src/Calorimeter.cc
+++ b/FastSimulation/CalorimeterProperties/src/Calorimeter.cc
@@ -20,33 +20,33 @@
 #include "Geometry/HcalTowerAlgo/interface/HcalHardcodeGeometryLoader.h"
 
 Calorimeter::Calorimeter():
-  myPreshowerLayer1Properties_(NULL),
-  myPreshowerLayer2Properties_(NULL),  
-  myECALBarrelProperties_     (NULL),  
-  myECALEndcapProperties_     (NULL),  
-  myHCALBarrelProperties_     (NULL),  
-  myHCALEndcapProperties_     (NULL),  
-  myHCALForwardProperties_    (NULL),
-  EcalBarrelGeometry_         (NULL),
-  EcalEndcapGeometry_         (NULL),
-  HcalGeometry_               (NULL),
-  PreshowerGeometry_          (NULL)
+  myPreshowerLayer1Properties_(nullptr),
+  myPreshowerLayer2Properties_(nullptr),  
+  myECALBarrelProperties_     (nullptr),  
+  myECALEndcapProperties_     (nullptr),  
+  myHCALBarrelProperties_     (nullptr),  
+  myHCALEndcapProperties_     (nullptr),  
+  myHCALForwardProperties_    (nullptr),
+  EcalBarrelGeometry_         (nullptr),
+  EcalEndcapGeometry_         (nullptr),
+  HcalGeometry_               (nullptr),
+  PreshowerGeometry_          (nullptr)
 {
 ;
 }
 
 Calorimeter::Calorimeter(const edm::ParameterSet& fastCalo):
-  myPreshowerLayer1Properties_(NULL),
-  myPreshowerLayer2Properties_(NULL),  
-  myECALBarrelProperties_     (NULL),  
-  myECALEndcapProperties_     (NULL),  
-  myHCALBarrelProperties_     (NULL),  
-  myHCALEndcapProperties_     (NULL),  
-  myHCALForwardProperties_    (NULL),
-  EcalBarrelGeometry_        (NULL),
-  EcalEndcapGeometry_          (NULL),
-  HcalGeometry_               (NULL),
-  PreshowerGeometry_          (NULL)  
+  myPreshowerLayer1Properties_(nullptr),
+  myPreshowerLayer2Properties_(nullptr),  
+  myECALBarrelProperties_     (nullptr),  
+  myECALEndcapProperties_     (nullptr),  
+  myHCALBarrelProperties_     (nullptr),  
+  myHCALEndcapProperties_     (nullptr),  
+  myHCALForwardProperties_    (nullptr),
+  EcalBarrelGeometry_        (nullptr),
+  EcalEndcapGeometry_          (nullptr),
+  HcalGeometry_               (nullptr),
+  PreshowerGeometry_          (nullptr)  
 {
   edm::ParameterSet fastDet = fastCalo.getParameter<edm::ParameterSet>("CalorimeterProperties");
   edm::ParameterSet fastDetHF = fastCalo.getParameter<edm::ParameterSet>("ForwardCalorimeterProperties");
@@ -80,7 +80,7 @@ Calorimeter::ecalProperties(int onEcal) const {
     else
       return myECALEndcapProperties_;
   } else
-    return NULL;
+    return nullptr;
 }
 
 const HCALProperties*
@@ -96,7 +96,7 @@ Calorimeter::hcalProperties(int onHcal) const {
 	edm::LogInfo("CalorimeterProperties") << " Calorimeter::hcalProperties : set myHCALForwardProperties" << std::endl;
       }
   } else
-    return NULL;
+    return nullptr;
 }
 
 const PreshowerLayer1Properties*
@@ -104,7 +104,7 @@ Calorimeter::layer1Properties(int onLayer1) const {
   if ( onLayer1 ) 
     return myPreshowerLayer1Properties_;
   else
-    return NULL;
+    return nullptr;
 }
 
 const PreshowerLayer2Properties*
@@ -112,7 +112,7 @@ Calorimeter::layer2Properties(int onLayer2) const {
   if ( onLayer2 ) 
     return myPreshowerLayer2Properties_;
   else
-    return NULL;
+    return nullptr;
 }
 
 void Calorimeter::setupGeometry(const CaloGeometry& pG)
@@ -139,7 +139,7 @@ const CaloSubdetectorGeometry * Calorimeter::getEcalGeometry(int subdetn) const
   if(subdetn==2) return EcalEndcapGeometry_;
   if(subdetn==3) return PreshowerGeometry_;
   edm::LogWarning("Calorimeter") << "Requested an invalid ECAL subdetector geometry: " << subdetn << std::endl;
-  return 0;
+  return nullptr;
 }
 
 const CaloSubdetectorTopology * Calorimeter::getEcalTopology(int subdetn) const
@@ -147,5 +147,5 @@ const CaloSubdetectorTopology * Calorimeter::getEcalTopology(int subdetn) const
   if(subdetn==1) return EcalBarrelTopology_;
   if(subdetn==2) return EcalEndcapTopology_;
   edm::LogWarning("Calorimeter") << "Requested an invalid ECAL subdetector topology: " << subdetn << std::endl;
-  return 0;
+  return nullptr;
 }

--- a/FastSimulation/Calorimetry/src/HCALResponse.cc
+++ b/FastSimulation/Calorimetry/src/HCALResponse.cc
@@ -11,7 +11,7 @@
 #include <iostream>
 #include <vector>
 #include <string>
-#include <math.h>
+#include <cmath>
 
 using namespace edm;
 

--- a/FastSimulation/Event/interface/FBaseSimEvent.h
+++ b/FastSimulation/Event/interface/FBaseSimEvent.h
@@ -126,7 +126,7 @@ public:
 
   /// Add a new track to the Event and to the various lists
   int addSimTrack(const RawParticle* p, int iv, int ig=-1, 
-		  const HepMC::GenVertex* ev=0);
+		  const HepMC::GenVertex* ev=nullptr);
 
   /// Add a new vertex to the Event and to the various lists
   int addSimVertex(const XYZTLorentzVector& decayVertex, int im=-1,

--- a/FastSimulation/Event/src/FBaseSimEvent.cc
+++ b/FastSimulation/Event/src/FBaseSimEvent.cc
@@ -610,7 +610,7 @@ FBaseSimEvent::printMCTruth(const HepMC::GenEvent& myGenEvent) {
     int partId = p->pdg_id();
     std::string name;
 
-    if ( pdt->particle(ParticleID(partId)) !=0 ) {
+    if ( pdt->particle(ParticleID(partId)) !=nullptr ) {
       name = (pdt->particle(ParticleID(partId)))->name();
     } else {
       name = "none";

--- a/FastSimulation/Event/src/FSimVertex.cc
+++ b/FastSimulation/Event/src/FSimVertex.cc
@@ -1,7 +1,7 @@
 #include "FastSimulation/Event/interface/FSimVertex.h"
 
   /// Default constructor
-FSimVertex::FSimVertex() : SimVertex(), mom_(0), id_(-1) {;}
+FSimVertex::FSimVertex() : SimVertex(), mom_(nullptr), id_(-1) {;}
   
   /// constructor from the embedded vertex index in the FBaseSimEvent
 FSimVertex::FSimVertex(const XYZTLorentzVector& v, int im, int id, FBaseSimEvent* mom) : 

--- a/FastSimulation/EventProducer/interface/FamosProducer.h
+++ b/FastSimulation/EventProducer/interface/FamosProducer.h
@@ -20,9 +20,9 @@ class FamosProducer : public edm::stream::EDProducer <>
  public:
 
   explicit FamosProducer(edm::ParameterSet const & p);
-  virtual ~FamosProducer();
-  virtual void beginRun(edm::Run const& run, const edm::EventSetup & es) override;
-  virtual void produce(edm::Event & e, const edm::EventSetup & c) override;
+  ~FamosProducer() override;
+  void beginRun(edm::Run const& run, const edm::EventSetup & es) override;
+  void produce(edm::Event & e, const edm::EventSetup & c) override;
 
  private:
 

--- a/FastSimulation/EventProducer/src/FamosManager.cc
+++ b/FastSimulation/EventProducer/src/FamosManager.cc
@@ -45,7 +45,7 @@ using namespace HepMC;
 
 FamosManager::FamosManager(edm::ParameterSet const & p)
     : iEvent(0),
-      myCalorimetry(0),
+      myCalorimetry(nullptr),
       m_pUseMagneticField(p.getParameter<bool>("UseMagneticField")),
       m_Tracking(p.getParameter<bool>("SimulateTracking")),
       m_Calorimetry(p.getParameter<bool>("SimulateCalorimetry")),
@@ -120,7 +120,7 @@ FamosManager::setupGeometryAndField(edm::Run const& run, const edm::EventSetup &
   } else { 
     myTrajectoryManager->initializeRecoGeometry(&(*theGeomSearchTracker),
 						&(*theTrackerInteractionGeometry),
-						0);
+						nullptr);
     bField000 = 4.0;
   }
   // The following should be on LogInfo

--- a/FastSimulation/ForwardDetectors/plugins/AcceptanceTableHelper.cc
+++ b/FastSimulation/ForwardDetectors/plugins/AcceptanceTableHelper.cc
@@ -11,7 +11,7 @@
 #include "FastSimulation/ForwardDetectors/plugins/AcceptanceTableHelper.h"
 
 #include <iostream>
-#include <math.h>
+#include <cmath>
 
 /** Read from root file <f> acceptance tables named <basename> and <basename>_hight */
 
@@ -20,11 +20,11 @@ void AcceptanceTableHelper::Init(TFile& f, const std::string basename)
   // ... read table for low t
   TH3F *h = (TH3F*)f.Get(basename.c_str());
 
-  if (h != NULL)
+  if (h != nullptr)
   {
     h_log10t_log10Xi_Phi = (TH3F*)h->Clone();
     std::cout << "Read ";
-    h_log10t_log10Xi_Phi->SetDirectory(0); // secure it from deleting if the file is eventually closed
+    h_log10t_log10Xi_Phi->SetDirectory(nullptr); // secure it from deleting if the file is eventually closed
     h_log10t_log10Xi_Phi->Print();
   } else {
     std::cout << "Warning: could not get acceptance table " << basename << std::endl;
@@ -34,10 +34,10 @@ void AcceptanceTableHelper::Init(TFile& f, const std::string basename)
   std::string name2 = basename+"_hight";
   h = (TH3F*)f.Get(name2.c_str());
 
-  if (h != NULL)
+  if (h != nullptr)
   {
     h_t_log10Xi_Phi = (TH3F*)h->Clone();
-    h_t_log10Xi_Phi->SetDirectory(0); // secure it from deleting if the file is eventually closed
+    h_t_log10Xi_Phi->SetDirectory(nullptr); // secure it from deleting if the file is eventually closed
     std::cout << "Read ";
     h_t_log10Xi_Phi->Print();
   } else {
@@ -54,7 +54,7 @@ float AcceptanceTableHelper::GetAcceptance(float t, float xi, float phi) {
 
   float acc = 0;
 
-  if ((h_log10t_log10Xi_Phi != NULL)				  // if table exists
+  if ((h_log10t_log10Xi_Phi != nullptr)				  // if table exists
        && (log10t < h_log10t_log10Xi_Phi->GetXaxis()->GetXmax())) // and t within table range
   {
   
@@ -63,7 +63,7 @@ float AcceptanceTableHelper::GetAcceptance(float t, float xi, float phi) {
     
     acc = h_log10t_log10Xi_Phi->GetBinContent(h_log10t_log10Xi_Phi->FindBin(log10t, log10Xi, phi));
 
-  } else if (h_t_log10Xi_Phi != NULL) { // if table exists for high t
+  } else if (h_t_log10Xi_Phi != nullptr) { // if table exists for high t
 
      acc = h_t_log10Xi_Phi->GetBinContent(h_t_log10Xi_Phi->FindBin(-t, log10Xi, phi));
   }

--- a/FastSimulation/ForwardDetectors/plugins/AcceptanceTableHelper.h
+++ b/FastSimulation/ForwardDetectors/plugins/AcceptanceTableHelper.h
@@ -29,7 +29,7 @@ class AcceptanceTableHelper
 public:
 
   /// Default constructor
-  AcceptanceTableHelper() : h_log10t_log10Xi_Phi(NULL),h_t_log10Xi_Phi(NULL) {;}
+  AcceptanceTableHelper() : h_log10t_log10Xi_Phi(nullptr),h_t_log10Xi_Phi(nullptr) {;}
   
   /// Delete acceptance histograms
   ~AcceptanceTableHelper() { 

--- a/FastSimulation/ForwardDetectors/plugins/CastorFastClusterProducer.h
+++ b/FastSimulation/ForwardDetectors/plugins/CastorFastClusterProducer.h
@@ -19,10 +19,10 @@
 class CastorFastClusterProducer : public edm::stream::EDProducer <>{
    public:
       explicit CastorFastClusterProducer(const edm::ParameterSet&);
-      ~CastorFastClusterProducer();
+      ~CastorFastClusterProducer() override;
 
    private:
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
       double make_noise();
       
       // ----------member data ---------------------------

--- a/FastSimulation/ForwardDetectors/plugins/CastorFastTowerProducer.h
+++ b/FastSimulation/ForwardDetectors/plugins/CastorFastTowerProducer.h
@@ -18,10 +18,10 @@
 class CastorFastTowerProducer : public edm::stream::EDProducer <> {
    public:
       explicit CastorFastTowerProducer(const edm::ParameterSet&);
-      ~CastorFastTowerProducer();
+      ~CastorFastTowerProducer() override;
 
    private:
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
       double make_noise();
       
       // ----------member data ---------------------------

--- a/FastSimulation/ForwardDetectors/plugins/FastSimDataFilter.h
+++ b/FastSimulation/ForwardDetectors/plugins/FastSimDataFilter.h
@@ -28,9 +28,9 @@ public:
 
   FastSimDataFilter(const edm::ParameterSet& pset);
 
-  virtual ~FastSimDataFilter();
+  ~FastSimDataFilter() override;
 
-  virtual bool filter(edm::Event&, const edm::EventSetup&);
+  bool filter(edm::Event&, const edm::EventSetup&) override;
   virtual void beginJob();
   virtual void endJob();
    

--- a/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.cc
+++ b/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.cc
@@ -107,7 +107,7 @@ void ProtonTaggerFilter::beginJob()
   std::cout << "Opening " << fullPath << std::endl;
   TFile f(fullPath.c_str());
 
-  if (f.Get("description") != NULL)
+  if (f.Get("description") != nullptr)
       std::cout << "Description found: " << f.Get("description")->GetTitle() << std::endl;
   
   std::cout << "Reading acceptance tables @#@#%@$%@$#%@%" << std::endl;
@@ -151,7 +151,7 @@ bool ProtonTaggerFilter::filter(edm::Event & iEvent, const edm::EventSetup & es)
   // ... get pileup event
 
   edm::Handle<edm::HepMCProduct> pileUpSource;
-  const HepMC::GenEvent* pileUpEvent = 0;
+  const HepMC::GenEvent* pileUpEvent = nullptr;
   bool isPileUp = true;
   
   bool isProduct = iEvent.getByLabel("famosPileUp", "PileUpEvents", pileUpSource);

--- a/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.h
+++ b/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.h
@@ -40,7 +40,7 @@ class ProtonTaggerFilter : public edm::stream::EDFilter <>
   explicit ProtonTaggerFilter(edm::ParameterSet const & p);
 
   /// empty destructor
-  virtual ~ProtonTaggerFilter();
+  ~ProtonTaggerFilter() override;
 
   /// startup function of the EDFilter
   virtual void beginJob();
@@ -49,7 +49,7 @@ class ProtonTaggerFilter : public edm::stream::EDFilter <>
   virtual void endJob();
 
   /// decide if the event is accepted by the proton taggers
-  virtual bool filter(edm::Event & e, const edm::EventSetup & c);
+  bool filter(edm::Event & e, const edm::EventSetup & c) override;
 
  private:
 

--- a/FastSimulation/MaterialEffects/interface/BremsstrahlungSimulator.h
+++ b/FastSimulation/MaterialEffects/interface/BremsstrahlungSimulator.h
@@ -32,7 +32,7 @@ class BremsstrahlungSimulator : public MaterialEffectsSimulator
 			  double photonFractECut);
 
   /// Default destructor
-  ~BremsstrahlungSimulator() {}
+  ~BremsstrahlungSimulator() override {}
 
  private:
   
@@ -49,7 +49,7 @@ class BremsstrahlungSimulator : public MaterialEffectsSimulator
   unsigned int poisson(double ymu, RandomEngineAndDistribution const*);
 
   /// Generate Bremsstrahlung photons
-  void compute(ParticlePropagator &Particle, RandomEngineAndDistribution const*);
+  void compute(ParticlePropagator &Particle, RandomEngineAndDistribution const*) override;
 
   /// Compute Brem photon energy and angles, if any.
   XYZTLorentzVector brem(ParticlePropagator& p, RandomEngineAndDistribution const*) const;

--- a/FastSimulation/MaterialEffects/interface/CMSDummyDeexcitation.h
+++ b/FastSimulation/MaterialEffects/interface/CMSDummyDeexcitation.h
@@ -21,15 +21,15 @@ class CMSDummyDeexcitation : public G4VPreCompoundModel
 { 
 public:
 
-  CMSDummyDeexcitation():G4VPreCompoundModel(0, "PRECO") {}; 
+  CMSDummyDeexcitation():G4VPreCompoundModel(nullptr, "PRECO") {}; 
 
-  virtual ~CMSDummyDeexcitation() {};
+  ~CMSDummyDeexcitation() override {};
 
-  virtual G4HadFinalState* ApplyYourself(const G4HadProjectile&, G4Nucleus&) { return 0; } 
+  G4HadFinalState* ApplyYourself(const G4HadProjectile&, G4Nucleus&) override { return nullptr; } 
 
-  virtual G4ReactionProductVector* DeExcite(G4Fragment&) { return new G4ReactionProductVector(); };
+  G4ReactionProductVector* DeExcite(G4Fragment&) override { return new G4ReactionProductVector(); };
 
-  virtual void DeExciteModelDescription(std::ostream&) const {}
+  void DeExciteModelDescription(std::ostream&) const override {}
 
 };
 #endif

--- a/FastSimulation/MaterialEffects/interface/EnergyLossSimulator.h
+++ b/FastSimulation/MaterialEffects/interface/EnergyLossSimulator.h
@@ -31,7 +31,7 @@ class EnergyLossSimulator : public MaterialEffectsSimulator
   EnergyLossSimulator(double A, double Z, double density, double radLen);
 
   /// Default Destructor
-  ~EnergyLossSimulator();
+  ~EnergyLossSimulator() override;
 
   /// Return most probable energy loss
   inline double mostLikelyLoss() const { return mostProbableLoss; }
@@ -44,7 +44,7 @@ class EnergyLossSimulator : public MaterialEffectsSimulator
   LandauFluctuationGenerator* theGenerator;
 
   /// The real dE/dx generation and particle update
-  void compute(ParticlePropagator &Particle, RandomEngineAndDistribution const*);
+  void compute(ParticlePropagator &Particle, RandomEngineAndDistribution const*) override;
 
   /// The most probable enery loss
   double mostProbableLoss;

--- a/FastSimulation/MaterialEffects/interface/MultipleScatteringSimulator.h
+++ b/FastSimulation/MaterialEffects/interface/MultipleScatteringSimulator.h
@@ -31,12 +31,12 @@ class MultipleScatteringSimulator : public MaterialEffectsSimulator
   MultipleScatteringSimulator(double A, double Z, double density, double radLen);
 
   /// Default Destructor
-  ~MultipleScatteringSimulator() {} ;
+  ~MultipleScatteringSimulator() override {} ;
 
  private:
 
   /// The real dE/dx generation and particle update
-  void compute(ParticlePropagator &Particle, RandomEngineAndDistribution const*);
+  void compute(ParticlePropagator &Particle, RandomEngineAndDistribution const*) override;
 
  private: 
   

--- a/FastSimulation/MaterialEffects/interface/MuonBremsstrahlungSimulator.h
+++ b/FastSimulation/MaterialEffects/interface/MuonBremsstrahlungSimulator.h
@@ -37,7 +37,7 @@ class MuonBremsstrahlungSimulator : public MaterialEffectsSimulator
                               double radLen,double photonEnergyCut,double photonFractECut); 
 
   /// Default destructor
-  ~MuonBremsstrahlungSimulator() {}
+  ~MuonBremsstrahlungSimulator() override {}
 
 
 // Returns the actual Muon brem Energy
@@ -67,7 +67,7 @@ class MuonBremsstrahlungSimulator : public MaterialEffectsSimulator
   unsigned int poisson(double ymu);
 
   /// Generate Bremsstrahlung photons
-  void compute(ParticlePropagator &Particle, RandomEngineAndDistribution const*);
+  void compute(ParticlePropagator &Particle, RandomEngineAndDistribution const*) override;
 
   /// Compute Brem photon energy and angles, if any.
   XYZTLorentzVector brem(ParticlePropagator& p, RandomEngineAndDistribution const*)const;

--- a/FastSimulation/MaterialEffects/interface/NuclearInteractionFTFSimulator.h
+++ b/FastSimulation/MaterialEffects/interface/NuclearInteractionFTFSimulator.h
@@ -46,12 +46,12 @@ public:
 				 double elimit, double eth);
 
   /// Default Destructor
-  ~NuclearInteractionFTFSimulator();
+  ~NuclearInteractionFTFSimulator() override;
 
 private:
 
   /// Generate a nuclear interaction according to the probability that it happens
-  void compute(ParticlePropagator& Particle, RandomEngineAndDistribution const*);
+  void compute(ParticlePropagator& Particle, RandomEngineAndDistribution const*) override;
 
   void saveDaughter(ParticlePropagator& Particle, const G4LorentzVector& lv, int pdgid);
 

--- a/FastSimulation/MaterialEffects/interface/NuclearInteractionSimulator.h
+++ b/FastSimulation/MaterialEffects/interface/NuclearInteractionSimulator.h
@@ -49,10 +49,10 @@ class NuclearInteractionSimulator : public MaterialEffectsSimulator
 			      double distCut);
 
   /// Default Destructor
-  ~NuclearInteractionSimulator();
+  ~NuclearInteractionSimulator() override;
 
   /// Save current nuclear interaction (for later use)
-  void save();
+  void save() override;
 
   /// Read former nuclear interaction (from previous run)
   bool read(std::string inputFile);
@@ -60,7 +60,7 @@ class NuclearInteractionSimulator : public MaterialEffectsSimulator
  private:
 
   /// Generate a nuclear interaction according to the probability that it happens
-  void compute(ParticlePropagator& Particle, RandomEngineAndDistribution const*);
+  void compute(ParticlePropagator& Particle, RandomEngineAndDistribution const*) override;
 
   /// Compute distance between secondary and primary
   double distanceToPrimary(const RawParticle& Particle,

--- a/FastSimulation/MaterialEffects/interface/PairProductionSimulator.h
+++ b/FastSimulation/MaterialEffects/interface/PairProductionSimulator.h
@@ -29,7 +29,7 @@ class PairProductionSimulator : public MaterialEffectsSimulator
   PairProductionSimulator(double photonEnergyCut);
 
   /// Default Destructor
-  ~PairProductionSimulator() {}
+  ~PairProductionSimulator() override {}
 
  private:
 
@@ -37,7 +37,7 @@ class PairProductionSimulator : public MaterialEffectsSimulator
   double photonEnergy;
 
   /// Generate an e+e- pair according to the probability that it happens
-  void compute(ParticlePropagator& Particle, RandomEngineAndDistribution const*);
+  void compute(ParticlePropagator& Particle, RandomEngineAndDistribution const*) override;
 
   /// A universal angular distribution - still from GEANT.
   double gbteth(double ener,double partm,double efrac, RandomEngineAndDistribution const*);

--- a/FastSimulation/MaterialEffects/src/MaterialEffects.cc
+++ b/FastSimulation/MaterialEffects/src/MaterialEffects.cc
@@ -24,10 +24,10 @@
 #include <string>
 
 MaterialEffects::MaterialEffects(const edm::ParameterSet& matEff)
-  : PairProduction(0), Bremsstrahlung(0),MuonBremsstrahlung(0),
-    MultipleScattering(0), EnergyLoss(0), 
-    NuclearInteraction(0),
-    pTmin(999.), use_hardcoded(1)
+  : PairProduction(nullptr), Bremsstrahlung(nullptr),MuonBremsstrahlung(nullptr),
+    MultipleScattering(nullptr), EnergyLoss(nullptr), 
+    NuclearInteraction(nullptr),
+    pTmin(999.), use_hardcoded(true)
 {
   // Set the minimal photon energy for a Brem from e+/-
 

--- a/FastSimulation/MaterialEffects/src/NuclearInteractionFTFSimulator.cc
+++ b/FastSimulation/MaterialEffects/src/NuclearInteractionFTFSimulator.cc
@@ -66,7 +66,7 @@
 #include "G4SystemOfUnits.hh"
 
 static std::once_flag initializeOnce;
-[[cms::thread_guard("initializeOnce")]] const G4ParticleDefinition* NuclearInteractionFTFSimulator::theG4Hadron[] = {0};
+[[cms::thread_guard("initializeOnce")]] const G4ParticleDefinition* NuclearInteractionFTFSimulator::theG4Hadron[] = {nullptr};
 [[cms::thread_guard("initializeOnce")]] int NuclearInteractionFTFSimulator::theId[] = {0};
 
 const double fact = 1.0/CLHEP::GeV;
@@ -231,7 +231,7 @@ NuclearInteractionFTFSimulator::NuclearInteractionFTFSimulator(
   intLengthElastic = intLengthInelastic = 0.0;
   currIdx = 0;
   index = 0;
-  currTrack = 0;
+  currTrack = nullptr;
   currParticle = theG4Hadron[0];
 
   // fill projectile particle definitions
@@ -258,7 +258,7 @@ void NuclearInteractionFTFSimulator::compute(ParticlePropagator& Particle,
 
   int thePid = Particle.pid(); 
   if(thePid != theId[currIdx]) {
-    currParticle = 0;
+    currParticle = nullptr;
     currIdx = 0;
     for(; currIdx<numHadrons; ++currIdx) {
       if(theId[currIdx] == thePid) {

--- a/FastSimulation/MaterialEffects/src/NuclearInteractionSimulator.cc
+++ b/FastSimulation/MaterialEffects/src/NuclearInteractionSimulator.cc
@@ -53,10 +53,10 @@ NuclearInteractionSimulator::NuclearInteractionSimulator(
 
   // Prepare the map of files
   // Loop over the particle names
-  TFile* aVFile=0;
-  std::vector<TTree*> aVTree(thePionEN.size(),static_cast<TTree*>(0));
-  std::vector<TBranch*> aVBranch(thePionEN.size(),static_cast<TBranch*>(0));
-  std::vector<NUEvent*> aVNUEvents(thePionEN.size(),static_cast<NUEvent*>(0));
+  TFile* aVFile=nullptr;
+  std::vector<TTree*> aVTree(thePionEN.size(),static_cast<TTree*>(nullptr));
+  std::vector<TBranch*> aVBranch(thePionEN.size(),static_cast<TBranch*>(nullptr));
+  std::vector<NUEvent*> aVNUEvents(thePionEN.size(),static_cast<NUEvent*>(nullptr));
   std::vector<unsigned> aVCurrentEntry(thePionEN.size(),static_cast<unsigned>(0));
   std::vector<unsigned> aVCurrentInteraction(thePionEN.size(),static_cast<unsigned>(0));
   std::vector<unsigned> aVNumberOfEntries(thePionEN.size(),static_cast<unsigned>(0));

--- a/FastSimulation/MaterialEffects/src/PetrukhinModel.cc
+++ b/FastSimulation/MaterialEffects/src/PetrukhinModel.cc
@@ -10,7 +10,7 @@
 #include <fstream>
 #include "TF1.h"
 #include "FastSimulation/MaterialEffects/interface/PetrukhinModel.h"
-#include <math.h>
+#include <cmath>
 using namespace std;
 
 //=====================================================================

--- a/FastSimulation/MuonSimHitProducer/interface/MuonSimHitProducer.h
+++ b/FastSimulation/MuonSimHitProducer/interface/MuonSimHitProducer.h
@@ -59,7 +59,7 @@ class MuonSimHitProducer : public edm::stream::EDProducer <> {
    public:
 
       explicit MuonSimHitProducer(const edm::ParameterSet&);
-      ~MuonSimHitProducer();
+      ~MuonSimHitProducer() override;
 
    private:
 
@@ -75,8 +75,8 @@ class MuonSimHitProducer : public edm::stream::EDProducer <> {
 
       MaterialEffects* theMaterialEffects;
   
-      virtual void beginRun(edm::Run const& run, const edm::EventSetup & es) override;
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      void beginRun(edm::Run const& run, const edm::EventSetup & es) override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
       void readParameters(const edm::ParameterSet&, 
 			  const edm::ParameterSet&,
 			  const edm::ParameterSet& );

--- a/FastSimulation/MuonSimHitProducer/src/MuonSimHitProducer.cc
+++ b/FastSimulation/MuonSimHitProducer/src/MuonSimHitProducer.cc
@@ -79,7 +79,7 @@
 //
 MuonSimHitProducer::MuonSimHitProducer(const edm::ParameterSet& iConfig):
   theEstimator(iConfig.getParameter<double>("Chi2EstimatorCut")),
-  propagatorWithoutMaterial(0)
+  propagatorWithoutMaterial(nullptr)
  {
 
   // Read relevant parameters
@@ -560,7 +560,7 @@ MuonSimHitProducer::readParameters(const edm::ParameterSet& fastMuons,
   //    std::cout << " The FAST tracking option is turned ON" << std::endl;
 
   // Material Effects
-  theMaterialEffects = 0;
+  theMaterialEffects = nullptr;
   if ( matEff.getParameter<bool>("PairProduction") || 
        matEff.getParameter<bool>("Bremsstrahlung") ||
        matEff.getParameter<bool>("MuonBremsstrahlung") ||
@@ -596,7 +596,7 @@ MuonSimHitProducer::applyMaterialEffects(TrajectoryStateOnSurface& tsosWithdEdx,
   XYZTLorentzVector position(gPos.x(),gPos.y(),gPos.z(),0.);
   XYZTLorentzVector momentum(gMom.x(),gMom.y(),gMom.z(),en);
   float charge = (float)(tsos.charge());
-  ParticlePropagator theMuon(momentum,position,charge,0);
+  ParticlePropagator theMuon(momentum,position,charge,nullptr);
   theMuon.setID(-(int)charge*13);
 
   // Recompute the energy loss to get the fluctuations

--- a/FastSimulation/Muons/plugins/FastTSGFromIOHit.h
+++ b/FastSimulation/Muons/plugins/FastTSGFromIOHit.h
@@ -29,7 +29,7 @@ public:
   FastTSGFromIOHit(const edm::ParameterSet &pset,edm::ConsumesCollector& iC);
 
   /// destructor
-  virtual ~FastTSGFromIOHit();
+  ~FastTSGFromIOHit() override;
 
   /// generate seed(s) for a track
     void  trackerSeeds(const TrackCand&, const TrackingRegion&, const TrackerTopology *tTopo, std::vector<TrajectorySeed>&) override;

--- a/FastSimulation/Muons/plugins/FastTSGFromL2Muon.h
+++ b/FastSimulation/Muons/plugins/FastTSGFromL2Muon.h
@@ -25,9 +25,9 @@ class FastTSGFromL2Muon : public edm::stream::EDProducer <> {
  public:
 
   FastTSGFromL2Muon(const edm::ParameterSet& cfg);
-  virtual ~FastTSGFromL2Muon();
-  virtual void beginRun(edm::Run const& run, edm::EventSetup const& es) override;
-  virtual void produce(edm::Event& ev, const edm::EventSetup& es) override;
+  ~FastTSGFromL2Muon() override;
+  void beginRun(edm::Run const& run, edm::EventSetup const& es) override;
+  void produce(edm::Event& ev, const edm::EventSetup& es) override;
   
  private:
 

--- a/FastSimulation/Muons/plugins/FastTSGFromPropagation.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromPropagation.cc
@@ -92,7 +92,7 @@ void FastTSGFromPropagation::trackerSeeds(const TrackCand& staMuon, const Tracki
 
      for (std::vector<const DetLayer*>::const_iterator inl = nls.begin();
          inl != nls.end(); inl++, ndesLayer++ ) {
-         if ( (*inl == 0) ) break;
+         if ( (*inl == nullptr) ) break;
 //         if ( (inl != nls.end()-1 ) && ( (*inl)->subDetector() == GeomDetEnumerators::TEC ) && ( (*(inl+1))->subDetector() == GeomDetEnumerators::TOB ) ) continue; 
          alltm = findMeasurements_new(*inl, staState);
          if ( (!alltm.empty()) ) {
@@ -123,7 +123,7 @@ void FastTSGFromPropagation::trackerSeeds(const TrackCand& staMuon, const Tracki
 	   FreeTrajectoryState simtrack_trackerstate;
 	   for( unsigned icomb = 0;icomb < recHitCombinations->size();++icomb){
 	       const auto & recHitCombination = (*recHitCombinations)[icomb];
-	       if(recHitCombination.size() ==0)
+	       if(recHitCombination.empty())
 	         continue;
 	       int32_t simTrackId = recHitCombination.back()->simTrackId(0);
 	       const SimTrack & simtrack = (*simTracks)[simTrackId];
@@ -187,7 +187,7 @@ void FastTSGFromPropagation::trackerSeeds(const TrackCand& staMuon, const Tracki
 
 	   for( unsigned icomb = 0;icomb < recHitCombinations->size();++icomb){
 	       const auto & recHitCombination = (*recHitCombinations)[icomb];
-	       if(recHitCombination.size() ==0)
+	       if(recHitCombination.empty())
 	         continue;
 	       int32_t simTrackId = recHitCombination.back()->simTrackId(0);
 	       const SimTrack & simtrack = (*simTracks)[simTrackId];
@@ -265,7 +265,7 @@ void FastTSGFromPropagation::trackerSeeds(const TrackCand& staMuon, const Tracki
      for (std::vector<const DetLayer*>::const_iterator inl = nls.begin();
          inl != nls.end(); inl++ ) {
 
-         if ( !result.empty() || *inl == 0 ) {
+         if ( !result.empty() || *inl == nullptr ) {
             break;
          }
          std::vector<DetLayer::DetWithState> compatDets = (*inl)->compatibleDets(staState, *propagator(), *estimator());

--- a/FastSimulation/Muons/plugins/FastTSGFromPropagation.h
+++ b/FastSimulation/Muons/plugins/FastTSGFromPropagation.h
@@ -55,17 +55,17 @@ class FastTSGFromPropagation : public TrackerSeedGenerator {
   FastTSGFromPropagation(const edm::ParameterSet& par, const MuonServiceProxy*,edm::ConsumesCollector& iC);
     
   /// destructor
-  virtual ~FastTSGFromPropagation();
+  ~FastTSGFromPropagation() override;
 
   /// generate seed(s) for a track
   void  trackerSeeds(const TrackCand&, const TrackingRegion&, 
-		     const TrackerTopology *tTopo, std::vector<TrajectorySeed>&);
+		     const TrackerTopology *tTopo, std::vector<TrajectorySeed>&) override;
     
   /// initialize
-  void init(const MuonServiceProxy*);
+  void init(const MuonServiceProxy*) override;
 
   /// set an event
-  void setEvent(const edm::Event&);
+  void setEvent(const edm::Event&) override;
 
 private:
   /// A mere copy (without memory leak) of an existing tracking method
@@ -124,7 +124,7 @@ private:
 
   struct isInvalid {
     bool operator()(const TrajectoryMeasurement& measurement) {
-      return ( ((measurement).recHit() == 0) || !((measurement).recHit()->isValid()) || !((measurement).updatedState().isValid()) ); 
+      return ( ((measurement).recHit() == nullptr) || !((measurement).recHit()->isValid()) || !((measurement).updatedState().isValid()) ); 
     }
   };
 

--- a/FastSimulation/Particle/src/RawParticle.cc
+++ b/FastSimulation/Particle/src/RawParticle.cc
@@ -95,7 +95,7 @@ RawParticle::init() {
   myCharge=0.;
   myMass=0.;
   //tab = ParticleTable::instance();
-  myInfo=0;
+  myInfo=nullptr;
 }
 
 void 

--- a/FastSimulation/ParticleDecay/plugins/TestPythiaDecays.cc
+++ b/FastSimulation/ParticleDecay/plugins/TestPythiaDecays.cc
@@ -48,13 +48,13 @@
 class TestPythiaDecays : public edm::stream::EDAnalyzer <> {
 public:
   explicit TestPythiaDecays(const edm::ParameterSet&);
-  ~TestPythiaDecays();
+  ~TestPythiaDecays() override;
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
   
 private:
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
   
   //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
   //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
@@ -319,7 +319,7 @@ TestPythiaDecays::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
        h_originVertexRho[pid]->Fill(originVertex.position().Rho());
        h_originVertexZ[pid]->Fill(std::fabs(originVertex.position().Z()));
      }
-     if(childMap[j].size() > 0){
+     if(!childMap[j].empty()){
        const SimTrack & child = simtracks->at(childMap[j][0]);
        const SimVertex & decayVertex = simvertices->at(child.vertIndex());
        h_decayVertexRho[pid]->Fill(decayVertex.position().Rho());
@@ -335,7 +335,7 @@ TestPythiaDecays::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
      const SimTrack & parent = simtracks->at(parentIndex);
      int pid = abs(parent.type());
      std::vector<size_t> & childIndices = it->second;
-     if(childIndices.size() == 0)
+     if(childIndices.empty())
        continue;
 
      if(std::find(pids.begin(),pids.end(),pid)==pids.end())

--- a/FastSimulation/ParticlePropagator/plugins/MagneticFieldMapESProducer.h
+++ b/FastSimulation/ParticlePropagator/plugins/MagneticFieldMapESProducer.h
@@ -10,7 +10,7 @@
 class  MagneticFieldMapESProducer: public edm::ESProducer{
  public:
   MagneticFieldMapESProducer(const edm::ParameterSet & p);
-  virtual ~MagneticFieldMapESProducer(); 
+  ~MagneticFieldMapESProducer() override; 
   std::shared_ptr<MagneticFieldMap> produce(const MagneticFieldMapRecord &);
  private:
   std::shared_ptr<MagneticFieldMap> _map;

--- a/FastSimulation/ParticlePropagator/src/ParticlePropagator.cc
+++ b/FastSimulation/ParticlePropagator/src/ParticlePropagator.cc
@@ -11,7 +11,7 @@
 #include "FastSimulation/Utilities/interface/RandomEngineAndDistribution.h"
 
 ParticlePropagator::ParticlePropagator() : 
-  BaseParticlePropagator(), random(0) {;}
+  BaseParticlePropagator(), random(nullptr) {;}
 
 ParticlePropagator::ParticlePropagator(const RawParticle& myPart,
 				       double RCyl, double ZCyl, 
@@ -42,7 +42,7 @@ ParticlePropagator::ParticlePropagator(const XYZTLorentzVector& mom,
 				       const MagneticFieldMap* aFieldMap) :
   BaseParticlePropagator(RawParticle(mom,vert),0.,0.,0.),
   theFieldMap(aFieldMap),
-  random(0)
+  random(nullptr)
 {
   setCharge(q);
   setMagneticField(fieldMap(X(),Y(),Z()));
@@ -54,7 +54,7 @@ ParticlePropagator::ParticlePropagator(const XYZTLorentzVector& mom,
   BaseParticlePropagator(
     RawParticle(mom,XYZTLorentzVector(vert.X(),vert.Y(),vert.Z(),0.0)),0.,0.,0.),
   theFieldMap(aFieldMap),
-  random(0)
+  random(nullptr)
 {
   setCharge(q);
   setMagneticField(fieldMap(X(),Y(),Z()));
@@ -135,7 +135,7 @@ ParticlePropagator::fieldMap(double xx,double yy, double zz) {
   // Arguments now passed in cm.
   //  return MagneticFieldMap::instance()->inTesla(GlobalPoint(xx/10.,yy/10.,zz/10.)).z();
   // Return a dummy value for neutral particles!
-  return charge() == 0.0 || theFieldMap == 0 ? 
+  return charge() == 0.0 || theFieldMap == nullptr ? 
     4. : theFieldMap->inTeslaZ(GlobalPoint(xx,yy,zz));
 }
 
@@ -144,7 +144,7 @@ ParticlePropagator::fieldMap(const TrackerLayer& layer, double coord, int succes
   // Arguments now passed in cm.
   //  return MagneticFieldMap::instance()->inTesla(GlobalPoint(xx/10.,yy/10.,zz/10.)).z();
   // Return a dummy value for neutral particles!
-  return charge() == 0.0 || theFieldMap == 0 ? 
+  return charge() == 0.0 || theFieldMap == nullptr ? 
     4. : theFieldMap->inTeslaZ(layer,coord,success);
 }
 

--- a/FastSimulation/ShowerDevelopment/interface/EMShower.h
+++ b/FastSimulation/ShowerDevelopment/interface/EMShower.h
@@ -39,8 +39,8 @@ class EMShower
            GammaFunctionGenerator* gamma,
 	   EMECALShowerParametrization* const myParam,
 	   std::vector<const RawParticle*>* const myPart,
-	   EcalHitMaker  * const myGrid=NULL,
-	   PreshowerHitMaker * const myPreshower=NULL,
+	   EcalHitMaker  * const myGrid=nullptr,
+	   PreshowerHitMaker * const myPreshower=nullptr,
 	   bool bFixedLength = false);
 
   virtual ~EMShower(){;}

--- a/FastSimulation/ShowerDevelopment/src/EMShower.cc
+++ b/FastSimulation/ShowerDevelopment/src/EMShower.cc
@@ -35,7 +35,7 @@ EMShower::EMShower(const RandomEngineAndDistribution* engine,
   //  myHistos = Histos::instance();
   //  myGammaGenerator = GammaFunctionGenerator::instance();
   stepsCalculated=false;
-  hasPreshower = myPresh!=NULL;
+  hasPreshower = myPresh!=nullptr;
   theECAL = myParam->ecalProperties();
   theHCAL = myParam->hcalProperties();
   theLayer1 = myParam->layer1Properties();
@@ -314,7 +314,7 @@ EMShower::compute() {
     bool gap = detector==5;
 
     // Temporary. Will be removed 
-    if ( theHCAL==NULL) hcal=false;
+    if ( theHCAL==nullptr) hcal=false;
 
     // Keep only ECAL for now
     if ( vfcal ) continue;
@@ -703,7 +703,7 @@ void EMShower::setIntervals(unsigned icomp,  RadialInterval& rad)
 
 void EMShower::setPreshower(PreshowerHitMaker * const myPresh)
 {
-  if(myPresh!=NULL)
+  if(myPresh!=nullptr)
     {
       thePreshower = myPresh;
       hasPreshower=true;

--- a/FastSimulation/ShowerDevelopment/src/HDRShower.cc
+++ b/FastSimulation/ShowerDevelopment/src/HDRShower.cc
@@ -105,7 +105,7 @@ bool HDRShower::setHit(float espot, float theta) {
 
   // Commented (F.B) to remove a warning. Not used anywhere ? 
   //  bool inHcal = !onEcal || d>depthECAL || !qstatus;
-  bool result = 0;
+  bool result = false;
   if( !onEcal || d>depthECAL || !qstatus) { // in HCAL (HF or HB, HE)
     d += depthGAP;
     bool setHDdepth = theHcalHitMaker->setDepth(d);

--- a/FastSimulation/TrackerSetup/interface/TrackerLayer.h
+++ b/FastSimulation/TrackerSetup/interface/TrackerLayer.h
@@ -33,10 +33,10 @@ public:
        theDisk = dynamic_cast<BoundDisk*>(theSurface);
        theDiskInnerRadius = theDisk->innerRadius();
        theDiskOuterRadius = theDisk->outerRadius();
-       theCylinder = 0;
+       theCylinder = nullptr;
      } else {
        theCylinder = dynamic_cast<BoundCylinder*>(theSurface);
-       theDisk = 0;
+       theDisk = nullptr;
        theDiskInnerRadius = 0.;
        theDiskOuterRadius = 0.;
      }
@@ -60,7 +60,7 @@ public:
      theDisk = dynamic_cast<BoundDisk*>(theSurface);
      theDiskInnerRadius = theDisk->innerRadius();
      theDiskOuterRadius = theDisk->outerRadius();
-     theCylinder = 0;
+     theCylinder = nullptr;
    }
 
   /// Is the layer sensitive ?

--- a/FastSimulation/TrackerSetup/plugins/TrackerInteractionGeometryESProducer.h
+++ b/FastSimulation/TrackerSetup/plugins/TrackerInteractionGeometryESProducer.h
@@ -11,7 +11,7 @@
 class  TrackerInteractionGeometryESProducer: public edm::ESProducer{
  public:
   TrackerInteractionGeometryESProducer(const edm::ParameterSet & p);
-  virtual ~TrackerInteractionGeometryESProducer(); 
+  ~TrackerInteractionGeometryESProducer() override; 
   std::shared_ptr<TrackerInteractionGeometry> produce(const TrackerInteractionGeometryRecord &);
  private:
   std::shared_ptr<TrackerInteractionGeometry> _tracker;

--- a/FastSimulation/TrackerSetup/src/TrackerInteractionGeometry.cc
+++ b/FastSimulation/TrackerSetup/src/TrackerInteractionGeometry.cc
@@ -762,7 +762,7 @@ TrackerInteractionGeometry::TrackerInteractionGeometry(const edm::ParameterSet& 
     theDisk = new BoundDisk(PTID3,theRotation2,TID3);
     theDisk->setMediumProperties(*_theMPInner3);
     if ( theDisk->mediumProperties().radLen() > 0. ) 
-      _theCylinders.push_back(TrackerLayer(theDisk,12,layerNr,
+      _theCylinders.push_back(TrackerLayer(theDisk,true,layerNr,
 					   minDim(layerNr),maxDim(layerNr),
 					   fudgeFactors(layerNr)));
     else

--- a/FastSimulation/Tracking/interface/SeedFinder.h
+++ b/FastSimulation/Tracking/interface/SeedFinder.h
@@ -90,7 +90,7 @@ public:
                 if (_selectorFunctionsByHits.size()>=NHits)
                 {
                     //are there any selector functions stored for NHits?
-                    if (_selectorFunctionsByHits[NHits-1].size()>0)
+                    if (!_selectorFunctionsByHits[NHits-1].empty())
                     {
                         //fill vector of Hits from node to root to be passed to the selector function
                         std::vector<const FastTrackerRecHit*> seedCandidateHitList(node->getDepth()+1);
@@ -168,7 +168,7 @@ public:
                             hitIndicesInTree,
                             false
                         );
-                        if (seedHits.size()>0)
+                        if (!seedHits.empty())
                         {
                             return seedHits;
                         }

--- a/FastSimulation/Tracking/interface/SeedingTree.h
+++ b/FastSimulation/Tracking/interface/SeedingTree.h
@@ -94,7 +94,7 @@ class SeedingNode
        
         inline const SeedingNode<DATA>* firstChild() const
         {
-            if (_children.size()>0)
+            if (!_children.empty())
             {
                 return _allNodes[_children[0]];
             }
@@ -176,7 +176,7 @@ class SeedingTree
                 _singleSet.insert(dataList[i]);
             }
 
-            if (dataList.size()==0)
+            if (dataList.empty())
             {
                 return false;
             }

--- a/FastSimulation/Tracking/interface/TrajectorySeedHitCandidate.h
+++ b/FastSimulation/Tracking/interface/TrajectorySeedHitCandidate.h
@@ -27,7 +27,7 @@ public:
   
   /// Default Constructor
   TrajectorySeedHitCandidate():
-    theHit(0),
+    theHit(nullptr),
     seedingLayer()
     
    {

--- a/FastSimulation/Tracking/plugins/ConversionTrackRefFix.h
+++ b/FastSimulation/Tracking/plugins/ConversionTrackRefFix.h
@@ -12,11 +12,11 @@ class ConversionTrackRefFix : public edm::stream::EDProducer<>
 {
  public:
   explicit ConversionTrackRefFix(const edm::ParameterSet&);
-  ~ConversionTrackRefFix();
+  ~ConversionTrackRefFix() override;
   
  private:
   
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
   edm::EDGetTokenT<reco::ConversionTrackCollection > conversionTracksToken;
   edm::EDGetTokenT<reco::TrackCollection > newTracksToken;
 };

--- a/FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.h
+++ b/FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.h
@@ -18,12 +18,12 @@
 class ElectronSeedTrackRefFix : public edm::stream::EDProducer<> {
 public:
   explicit ElectronSeedTrackRefFix(const edm::ParameterSet&);
-  ~ElectronSeedTrackRefFix();
+  ~ElectronSeedTrackRefFix() override;
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
 private:
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
     
   // ----------member data ---------------------------
   edm::EDGetTokenT<reco::TrackCollection > newTracksToken;

--- a/FastSimulation/Tracking/plugins/FastTrackerRecHitCombiner.cc
+++ b/FastSimulation/Tracking/plugins/FastTrackerRecHitCombiner.cc
@@ -25,15 +25,15 @@ class FastTrackerRecHitCombiner : public edm::stream::EDProducer<> {
     public:
 
     explicit FastTrackerRecHitCombiner(const edm::ParameterSet&);
-    ~FastTrackerRecHitCombiner(){;}
+    ~FastTrackerRecHitCombiner() override{;}
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
     private:
 
-    virtual void beginStream(edm::StreamID) override{;}
-    virtual void produce(edm::Event&, const edm::EventSetup&) override;
-    virtual void endStream() override{;}
+    void beginStream(edm::StreamID) override{;}
+    void produce(edm::Event&, const edm::EventSetup&) override;
+    void endStream() override{;}
 
     // ----------member data ---------------------------
     edm::EDGetTokenT<edm::PSimHitContainer> simHitsToken; 

--- a/FastSimulation/Tracking/plugins/FastTrackerRecHitMaskProducer.cc
+++ b/FastSimulation/Tracking/plugins/FastTrackerRecHitMaskProducer.cc
@@ -26,9 +26,9 @@ class FastTrackerRecHitMaskProducer : public edm::stream::EDProducer <>
 
     explicit FastTrackerRecHitMaskProducer(const edm::ParameterSet&);
 
-    virtual ~FastTrackerRecHitMaskProducer() {}
+    ~FastTrackerRecHitMaskProducer() override {}
 
-    virtual void produce(edm::Event&, const edm::EventSetup&) override;
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
 
     private:

--- a/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
+++ b/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
@@ -33,7 +33,7 @@
 using namespace pixeltrackfitting;
 
 PixelTracksProducer::PixelTracksProducer(const edm::ParameterSet& conf) : 
-  theRegionProducer(0)
+  theRegionProducer(nullptr)
 {  
 
   produces<reco::TrackCollection>();
@@ -91,7 +91,7 @@ PixelTracksProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   e.getByToken(seedProducerToken,theSeeds);
 
   // No seed -> output an empty track collection
-  if(theSeeds->size() == 0) {
+  if(theSeeds->empty()) {
     e.put(std::move(tracks));
     e.put(std::move(recHits));
     e.put(std::move(trackExtras));
@@ -118,7 +118,7 @@ PixelTracksProducer::produce(edm::Event& e, const edm::EventSetup& es) {
       edm::OwnVector<TrackingRecHit>::const_iterator theLastSeedingRecHit = theSeedingRecHitRange.second;
 
       // Loop over the rechits
-      std::vector<const TrackingRecHit*> TripletHits(3,static_cast<const TrackingRecHit*>(0));
+      std::vector<const TrackingRecHit*> TripletHits(3,static_cast<const TrackingRecHit*>(nullptr));
       for ( unsigned i=0; aSeedingRecHit!=theLastSeedingRecHit; ++i,++aSeedingRecHit )  
 	TripletHits[i] = &(*aSeedingRecHit);
       

--- a/FastSimulation/Tracking/plugins/PixelTracksProducer.h
+++ b/FastSimulation/Tracking/plugins/PixelTracksProducer.h
@@ -24,9 +24,9 @@ class PixelTracksProducer :  public edm::stream::EDProducer <> {
 public:
   explicit PixelTracksProducer(const edm::ParameterSet& conf);
 
-  ~PixelTracksProducer();
+  ~PixelTracksProducer() override;
 
-  virtual void produce(edm::Event& ev, const edm::EventSetup& es);
+  void produce(edm::Event& ev, const edm::EventSetup& es) override;
 
 private:
 

--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
@@ -37,12 +37,12 @@ class RecoTrackAccumulator : public DigiAccumulatorMixMod
 {
  public:
   explicit RecoTrackAccumulator(const edm::ParameterSet& conf, edm::stream::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
-  virtual ~RecoTrackAccumulator();
+  ~RecoTrackAccumulator() override;
   
-  virtual void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;
-  virtual void accumulate(edm::Event const& e, edm::EventSetup const& c) override;
-  virtual void accumulate(PileUpEventPrincipal const& e, edm::EventSetup const& c, edm::StreamID const&) override;
-  virtual void finalizeEvent(edm::Event& e, edm::EventSetup const& c) override;
+  void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;
+  void accumulate(edm::Event const& e, edm::EventSetup const& c) override;
+  void accumulate(PileUpEventPrincipal const& e, edm::EventSetup const& c, edm::StreamID const&) override;
+  void finalizeEvent(edm::Event& e, edm::EventSetup const& c) override;
 
   
  private:

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
@@ -45,7 +45,7 @@ public:
   
     explicit TrackCandidateProducer(const edm::ParameterSet& conf);
   
-    virtual void produce(edm::Event& e, const edm::EventSetup& es) override;
+    void produce(edm::Event& e, const edm::EventSetup& es) override;
   
 private:
 
@@ -163,8 +163,8 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
 	    }
 
 	    // prepare to skip seed hits
-	    const FastTrackerRecHit * lastHitToSkip = 0;
-	    if(selectedRecHits.size() > 0)
+	    const FastTrackerRecHit * lastHitToSkip = nullptr;
+	    if(!selectedRecHits.empty())
 	    {
 		lastHitToSkip = selectedRecHits.back();
 	    }
@@ -185,7 +185,7 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
 		{
 		    if(lastHitToSkip->sameId(selectedRecHit))
 		    {
-			lastHitToSkip=0;
+			lastHitToSkip=nullptr;
 		    }
 		    continue;
 		}
@@ -201,7 +201,7 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
 		//  always accept the first hit
 		//  also accept a hit if it is not on the layer of the previous hit
 		if( !  rejectOverlaps
-		    || selectedRecHits.size() == 0
+		    || selectedRecHits.empty()
 		    || ( TrackingLayer::createFromDetId(selectedRecHits.back()->geographicalId(),*trackerTopology.product())
 			 != TrackingLayer::createFromDetId(selectedRecHit->geographicalId(),*trackerTopology.product())))
 		{

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
@@ -80,7 +80,7 @@ private:
 public:
     TrajectorySeedProducer(const edm::ParameterSet& conf);
 
-    virtual void produce(edm::Event& e, const edm::EventSetup& es);
+    void produce(edm::Event& e, const edm::EventSetup& es) override;
 
 
 };
@@ -159,7 +159,7 @@ void TrajectorySeedProducer::produce(edm::Event& e, const edm::EventSetup& es)
     // input data
     edm::Handle<FastTrackerRecHitCombinationCollection> recHitCombinations;
     e.getByToken(recHitCombinationsToken, recHitCombinations);
-    const std::vector<bool> * hitMasks = 0;
+    const std::vector<bool> * hitMasks = nullptr;
     if (!hitMasksToken.isUninitialized())
     {
         edm::Handle<std::vector<bool> > hitMasksHandle;
@@ -175,7 +175,7 @@ void TrajectorySeedProducer::produce(edm::Event& e, const edm::EventSetup& es)
     e.getByToken(trackingRegionToken, hregions);
     const auto& regions = *hregions;
     // and make sure there is at least one region
-    if(regions.size() == 0)
+    if(regions.empty())
     {
         e.put(std::move(output));
         return;
@@ -231,7 +231,7 @@ void TrajectorySeedProducer::produce(edm::Event& e, const edm::EventSetup& es)
                 fastTrackingUtilities::setRecHitCombinationIndex(seedHits,icomb);
 
 		// create the seed
-                seedCreator->init(region,es,0);
+                seedCreator->init(region,es,nullptr);
                 seedCreator->makeSeed(
                     *output,
                     SeedingHitSet(

--- a/FastSimulation/Tracking/src/SeedFinderSelector.cc
+++ b/FastSimulation/Tracking/src/SeedFinderSelector.cc
@@ -19,9 +19,9 @@
 #include "DataFormats/TrackerRecHit2D/interface/FastTrackerRecHit.h"
 
 SeedFinderSelector::SeedFinderSelector(const edm::ParameterSet & cfg,edm::ConsumesCollector && consumesCollector)
-    : trackingRegion_(0)
-    , eventSetup_(0)
-    , measurementTracker_(0)
+    : trackingRegion_(nullptr)
+    , eventSetup_(nullptr)
+    , measurementTracker_(nullptr)
     , measurementTrackerLabel_(cfg.getParameter<std::string>("measurementTracker"))
 {
     if(cfg.exists("pixelTripletGeneratorFactory"))
@@ -89,7 +89,7 @@ bool SeedFinderSelector::pass(const std::vector<const FastTrackerRecHit *>& hits
     HitDoublets result(fhm,shm);
     HitPairGeneratorFromLayerPair::doublets(*trackingRegion_,*firstLayer,*secondLayer,fhm,shm,*eventSetup_,0,result);
     
-    if(result.size()==0)
+    if(result.empty())
     {
 	return false;
     }
@@ -111,13 +111,13 @@ bool SeedFinderSelector::pass(const std::vector<const FastTrackerRecHit *>& hits
 	{
 	    OrderedHitTriplets tripletresult;
 	    pixelTripletGenerator_->hitTriplets(*trackingRegion_,tripletresult,*eventSetup_,result,&thmp,thirdLayerDetLayer,1);
-	    return tripletresult.size()!=0;
+	    return !tripletresult.empty();
 	}
 	else if(multiHitGenerator_)
 	{
 	    OrderedMultiHits  tripletresult;
 	    multiHitGenerator_->hitTriplets(*trackingRegion_,tripletresult,*eventSetup_,result,&thmp,thirdLayerDetLayer,1);
-	    return tripletresult.size()!=0;
+	    return !tripletresult.empty();
 	}
 
     }

--- a/FastSimulation/TrackingRecHitProducer/interface/PixelTemplateSmearerBase.h
+++ b/FastSimulation/TrackingRecHitProducer/interface/PixelTemplateSmearerBase.h
@@ -87,8 +87,8 @@ class PixelTemplateSmearerBase:
 			              const edm::ParameterSet& config,
 			              edm::ConsumesCollector& consumesCollector );
 
-        virtual ~PixelTemplateSmearerBase();
-        virtual TrackingRecHitProductPtr process(TrackingRecHitProductPtr product) const;
+        ~PixelTemplateSmearerBase() override;
+        TrackingRecHitProductPtr process(TrackingRecHitProductPtr product) const override;
 
         //--- Process all unmerged hits. Calls smearHit() for each.
         TrackingRecHitProductPtr processUnmergedHits( 

--- a/FastSimulation/TrackingRecHitProducer/plugins/FastTrackerRecHitMatcher.cc
+++ b/FastSimulation/TrackingRecHitProducer/plugins/FastTrackerRecHitMatcher.cc
@@ -34,12 +34,12 @@ class FastTrackerRecHitMatcher : public edm::stream::EDProducer<>  {
     public:
 
     explicit FastTrackerRecHitMatcher(const edm::ParameterSet&);
-    ~FastTrackerRecHitMatcher(){;}
+    ~FastTrackerRecHitMatcher() override{;}
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
     private:
     
-    virtual void produce(edm::Event&, const edm::EventSetup&) override;
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
     // ---------- typedefs -----------------------------
     typedef std::pair<LocalPoint,LocalPoint>                   StripPosition; 
@@ -159,7 +159,7 @@ void FastTrackerRecHitMatcher::produce(edm::Event& iEvent, const edm::EventSetup
 		LocalVector gluedLocalSimTrackDir = gluedDet->surface().toLocal(globalSimTrackDir);
 		
 		// check whether next hit is partner
-		const FastSingleTrackerRecHit * partnerRecHit = 0;
+		const FastSingleTrackerRecHit * partnerRecHit = nullptr;
 		//      - there must be a next hit
 		if(simHitCounter + 1 < simHits->size()){
 		    const FastTrackerRecHitRef & nextRecHitRef = (*simHit2RecHitMap)[simHitCounter + 1];

--- a/FastSimulation/TrackingRecHitProducer/plugins/PixelBarrelTemplateSmearerPlugin.cc
+++ b/FastSimulation/TrackingRecHitProducer/plugins/PixelBarrelTemplateSmearerPlugin.cc
@@ -35,7 +35,7 @@ class PixelBarrelTemplateSmearerPlugin:
             const edm::ParameterSet& config,
             edm::ConsumesCollector& consumesCollector
         );
-        virtual ~PixelBarrelTemplateSmearerPlugin();
+        ~PixelBarrelTemplateSmearerPlugin() override;
 
     private:
         void initializeBarrel();

--- a/FastSimulation/TrackingRecHitProducer/plugins/PixelForwardTemplateSmearerPlugin.cc
+++ b/FastSimulation/TrackingRecHitProducer/plugins/PixelForwardTemplateSmearerPlugin.cc
@@ -51,7 +51,7 @@ class PixelForwardTemplateSmearerPlugin:
             const edm::ParameterSet& config,
             edm::ConsumesCollector& consumesCollector
           );
-          virtual ~PixelForwardTemplateSmearerPlugin();
+          ~PixelForwardTemplateSmearerPlugin() override;
 
     private:
         void initializeForward();

--- a/FastSimulation/TrackingRecHitProducer/plugins/TrackingRecHitNoSmearingPlugin.cc
+++ b/FastSimulation/TrackingRecHitProducer/plugins/TrackingRecHitNoSmearingPlugin.cc
@@ -45,7 +45,7 @@ class TrackingRecHitNoSmearingPlugin:
             }
         }
 
-        virtual TrackingRecHitProductPtr process(TrackingRecHitProductPtr product) const
+        TrackingRecHitProductPtr process(TrackingRecHitProductPtr product) const override
         {
             for (const std::pair<unsigned int,const PSimHit*>& simHitIdPair: product->getSimHitIdPairs())
             {

--- a/FastSimulation/TrackingRecHitProducer/plugins/TrackingRecHitProducer.cc
+++ b/FastSimulation/TrackingRecHitProducer/plugins/TrackingRecHitProducer.cc
@@ -50,15 +50,15 @@ class TrackingRecHitProducer:
     public:
         TrackingRecHitProducer(const edm::ParameterSet& config);
 
-        virtual void beginRun(edm::Run const&, const edm::EventSetup& eventSetup);
+        void beginRun(edm::Run const&, const edm::EventSetup& eventSetup) override;
 
-        virtual void beginStream(edm::StreamID id);
+        void beginStream(edm::StreamID id) override;
 
-        virtual void produce(edm::Event& event, const edm::EventSetup& eventSetup);
+        void produce(edm::Event& event, const edm::EventSetup& eventSetup) override;
 
-        virtual void endStream();
+        void endStream() override;
 
-        virtual ~TrackingRecHitProducer();
+        ~TrackingRecHitProducer() override;
 };
 
 

--- a/FastSimulation/TrackingRecHitProducer/plugins/TrackingRecHitStripGSPlugin.cc
+++ b/FastSimulation/TrackingRecHitProducer/plugins/TrackingRecHitStripGSPlugin.cc
@@ -53,7 +53,7 @@ class TrackingRecHitStripGSPlugin:
             }
         }
 
-        virtual TrackingRecHitProductPtr process(TrackingRecHitProductPtr product) const
+        TrackingRecHitProductPtr process(TrackingRecHitProductPtr product) const override
         {
             for (const std::pair<unsigned int,const PSimHit*>& simHitIdPair: product->getSimHitIdPairs())
             {

--- a/FastSimulation/TrackingRecHitProducer/src/PixelTemplateSmearerBase.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/PixelTemplateSmearerBase.cc
@@ -77,7 +77,7 @@ PixelTemplateSmearerBase::process(TrackingRecHitProductPtr product) const
 
     const GeomDet* geomDet = getTrackerGeometry().idToDetUnit(product->getDetId());
     const PixelGeomDetUnit * pixelGeomDet = dynamic_cast< const PixelGeomDetUnit* >( geomDet );
-    if (pixelGeomDet == 0)
+    if (pixelGeomDet == nullptr)
     {
         throw cms::Exception("FastSimulation/TrackingRecHitProducer") << "The GeomDetUnit is not a PixelGeomDetUnit.  This should never happen!";
     }
@@ -124,13 +124,13 @@ PixelTemplateSmearerBase::process(TrackingRecHitProductPtr product) const
                     if ( merged )
                     {
                         // First, check if the other guy (j) is in some merge group already
-                        if ( mergeGroupByHit[j] != 0 ) 
+                        if ( mergeGroupByHit[j] != nullptr ) 
                         {
-                            if (mergeGroupByHit[i] == 0 ) 
+                            if (mergeGroupByHit[i] == nullptr ) 
                             {
                                 mergeGroupByHit[i] = mergeGroupByHit[j];
                                 mergeGroupByHit[i]->group.push_back(simHitIdPairs[i]);
-                                mergeGroupByHit[i]->smearIt = 1;
+                                mergeGroupByHit[i]->smearIt = true;
                             }
                             else
                             {
@@ -139,7 +139,7 @@ PixelTemplateSmearerBase::process(TrackingRecHitProductPtr product) const
                                     for (auto hit_it = mergeGroupByHit[j]->group.begin(); hit_it != mergeGroupByHit[j]->group.end(); ++hit_it)
                                     {
                                         mergeGroupByHit[i]->group.push_back( *hit_it );
-                                        mergeGroupByHit[i]->smearIt = 1;
+                                        mergeGroupByHit[i]->smearIt = true;
                                     }
 
                                     // Step 2: iterate over all hits, replace mgbh[j] by mgbh[i] (so that nobody points to i)                               
@@ -152,8 +152,8 @@ PixelTemplateSmearerBase::process(TrackingRecHitProductPtr product) const
                                                 mergeGroupByHit[k] = mergeGroupByHit[i];
 					    }
                                     }
-                                    mgbhj->smearIt = 0;
-                                    mergeGroupByHit[i]->smearIt = 1;
+                                    mgbhj->smearIt = false;
+                                    mergeGroupByHit[i]->smearIt = true;
 
                                     //  Step 3 would have been to delete mgbh[j]... however, we'll do that at the end anyway.                              
                                     //  The key was to prevent mgbh[j] from being accessed further, and we have done that,                                 
@@ -166,7 +166,7 @@ PixelTemplateSmearerBase::process(TrackingRecHitProductPtr product) const
                         { 
                             // j is not merged.  Check if i is merged with another hit yet.
                             //
-                            if ( mergeGroupByHit[i] == 0 )
+                            if ( mergeGroupByHit[i] == nullptr )
                             {
                                 // This is the first time we realized i is merged with any
                                 // other hit.  Create a new merge group for i and j
@@ -178,11 +178,11 @@ PixelTemplateSmearerBase::process(TrackingRecHitProductPtr product) const
                                 // (simHits[i] is a const pointer to PSimHit).
                                 //std::cout << "ALICE: simHits" << simHits[i] << std::endl;
                                 mergeGroupByHit[i]->group.push_back( simHitIdPairs[i] );
-                                mergeGroupByHit[i]->smearIt = 1;
+                                mergeGroupByHit[i]->smearIt = true;
                             }
                             //--- Add hit j as well
                             mergeGroupByHit[i]->group.push_back( simHitIdPairs[j] );
-                            mergeGroupByHit[i]->smearIt = 1;
+                            mergeGroupByHit[i]->smearIt = true;
                             
                             mergeGroupByHit[j] = mergeGroupByHit[i];
 
@@ -198,7 +198,7 @@ PixelTemplateSmearerBase::process(TrackingRecHitProductPtr product) const
                 //    case, if mergeGroupByHit[i] is empty, then the hit is
                 //    unmerged.
                 //
-                if ( mergeGroupByHit[i] == 0 )
+                if ( mergeGroupByHit[i] == nullptr )
                 {
                     //--- Keep track of it.
                     listOfUnmergedHits.push_back( simHitIdPairs[i] );

--- a/FastSimulation/TrajectoryManager/interface/InsideBoundsMeasurementEstimator.h
+++ b/FastSimulation/TrajectoryManager/interface/InsideBoundsMeasurementEstimator.h
@@ -6,18 +6,18 @@
 class InsideBoundsMeasurementEstimator : public MeasurementEstimator {
 public:
 
-  virtual bool estimate( const TrajectoryStateOnSurface& ts, 
-			 const Plane& plane) const;
+  bool estimate( const TrajectoryStateOnSurface& ts, 
+			 const Plane& plane) const override;
 
   std::pair<bool,double> 
     estimate(const TrajectoryStateOnSurface& tsos,
-	     const TrackingRecHit& aRecHit) const; 
+	     const TrackingRecHit& aRecHit) const override; 
 
-  virtual Local2DVector 
+  Local2DVector 
   maximalLocalDisplacement( const TrajectoryStateOnSurface& ts,
-			    const Plane& plane) const;
+			    const Plane& plane) const override;
 
-  virtual MeasurementEstimator* clone() const {
+  MeasurementEstimator* clone() const override {
     return new InsideBoundsMeasurementEstimator( *this);
   }
 

--- a/FastSimulation/TrajectoryManager/interface/LocalMagneticField.h
+++ b/FastSimulation/TrajectoryManager/interface/LocalMagneticField.h
@@ -19,9 +19,9 @@ class LocalMagneticField : public MagneticField {
   ///Construct passing the Z field component in Tesla
   LocalMagneticField(double value);
 
-  virtual ~LocalMagneticField() {}
+  ~LocalMagneticField() override {}
 
-  GlobalVector inTesla (const GlobalPoint& gp) const;
+  GlobalVector inTesla (const GlobalPoint& gp) const override;
 
  private:
   GlobalVector theField;

--- a/FastSimulation/TrajectoryManager/src/TrajectoryManager.cc
+++ b/FastSimulation/TrajectoryManager/src/TrajectoryManager.cc
@@ -48,16 +48,16 @@ TrajectoryManager::TrajectoryManager(FSimEvent* aSimEvent,
 				     const edm::ParameterSet& simHits,
 				     const edm::ParameterSet& decays) :
   mySimEvent(aSimEvent), 
-  _theGeometry(0),
-  _theFieldMap(0),
-  theMaterialEffects(0), 
-  myDecayEngine(0), 
-  theGeomTracker(0),
-  theGeomSearchTracker(0),
-  theLayerMap(56, static_cast<const DetLayer*>(0)), // reserve space for layers here
+  _theGeometry(nullptr),
+  _theFieldMap(nullptr),
+  theMaterialEffects(nullptr), 
+  myDecayEngine(nullptr), 
+  theGeomTracker(nullptr),
+  theGeomSearchTracker(nullptr),
+  theLayerMap(56, static_cast<const DetLayer*>(nullptr)), // reserve space for layers here
   theNegLayerOffset(27),
   //  myHistos(0),
-  use_hardcoded(1)
+  use_hardcoded(true)
 
 {  
   //std::cout << "TrajectoryManager.cc 1 use_hardcoded = " << use_hardcoded << std::endl;
@@ -472,7 +472,7 @@ TrajectoryManager::updateWithDaughters(ParticlePropagator& PP, int fsimi, Random
 
     // Before-propagation and after-propagation momentum and vertex position
     XYZTLorentzVector momentumBefore = mySimEvent->track(fsimi).momentum();
-    XYZTLorentzVector momentumAfter = PP.momentum();
+    const XYZTLorentzVector& momentumAfter = PP.momentum();
     double magBefore = std::sqrt(momentumBefore.Vect().mag2());
     double magAfter = std::sqrt(momentumAfter.Vect().mag2());
     // Rotation to be applied
@@ -495,7 +495,7 @@ TrajectoryManager::updateWithDaughters(ParticlePropagator& PP, int fsimi, Random
     const DaughterParticleList& daughters =  myDecayEngine->particleDaughters(PP, &random->theEngine());
 
     // Update the FSimEvent with an end vertex and with the daughters
-    if ( daughters.size() ) { 
+    if ( !daughters.empty() ) { 
       double distMin = 1E99;
       int theClosestChargedDaughterId = -1;
       DaughterParticleIterator daughter = daughters.begin();
@@ -860,7 +860,7 @@ TrajectoryManager::initializeLayerMap()
 			     << " pos " << i->surface().position();
     if (!i->sensitive()) continue;
 
-    if (cyl != 0) {
+    if (cyl != nullptr) {
       LogDebug("FastTracking") << " cylinder radius " << cyl->radius();
       bool found = false;
       for (auto
@@ -908,7 +908,7 @@ TrajectoryManager::initializeLayerMap()
   for (auto nl=negForwardLayers.begin();
        nl != negForwardLayers.end(); ++nl) {
     for (int i=0; i<=theNegLayerOffset; i++) {
-      if (theLayerMap[i] == 0) continue;
+      if (theLayerMap[i] == nullptr) continue;
       if ( fabs( (**nl).surface().position().z() +theLayerMap[i]-> surface().position().z()) < zTolerance) {
 	theLayerMap[i+theNegLayerOffset] = *nl;
 	break;

--- a/FastSimulation/Utilities/interface/GammaNumericalGenerator.h
+++ b/FastSimulation/Utilities/interface/GammaNumericalGenerator.h
@@ -26,7 +26,7 @@ class GammaNumericalGenerator : public BaseNumericalRandomGenerator
   }
 
   /// Default destructor
-  virtual ~GammaNumericalGenerator() {}
+  ~GammaNumericalGenerator() override {}
 
   /// Random generator 
   double gamma(RandomEngineAndDistribution const* random) const { return generate(random); }
@@ -36,7 +36,7 @@ class GammaNumericalGenerator : public BaseNumericalRandomGenerator
   double gamma_lin(RandomEngineAndDistribution const* random) const {return generateLin(random);}
 
   /// The probability density function implementation
-  virtual double function(double x) { return ersatzt(x); }
+  double function(double x) override { return ersatzt(x); }
 
   inline bool isValid() const {return valid;}
 

--- a/FastSimulation/Utilities/interface/HistogramGenerator.h
+++ b/FastSimulation/Utilities/interface/HistogramGenerator.h
@@ -44,10 +44,10 @@ class HistogramGenerator : public BaseNumericalRandomGenerator
   }
 
   /// Default destructor
-  virtual ~HistogramGenerator() {}
+  ~HistogramGenerator() override {}
 
   /// The probability density function implementation
-  virtual double function(double x) { return ersatzt(x); }
+  double function(double x) override { return ersatzt(x); }
 
  private:
   /// Pointer to the histogram

--- a/FastSimulation/Utilities/interface/LandauFluctuationGenerator.h
+++ b/FastSimulation/Utilities/interface/LandauFluctuationGenerator.h
@@ -28,13 +28,13 @@ class LandauFluctuationGenerator : public BaseNumericalRandomGenerator
   }
 
   /// Default destructor
-  virtual ~LandauFluctuationGenerator() {}
+  ~LandauFluctuationGenerator() override {}
 
   /// Random generator of the dE/dX spread (Landau function)  
   double landau(RandomEngineAndDistribution const* random) const { return generate(random); }
   
   /// The probability density function implementation
-  virtual double function(double x) { return ersatzt(x); }
+  double function(double x) override { return ersatzt(x); }
 
  private:
 

--- a/FastSimulation/Utilities/src/Histos.cc
+++ b/FastSimulation/Utilities/src/Histos.cc
@@ -8,7 +8,7 @@
 
 #include <sstream>
 
-Histos* Histos::myself = 0;
+Histos* Histos::myself = nullptr;
 
 Histos::Histos() {}
 

--- a/FastSimulation/Utilities/src/Looses.cc
+++ b/FastSimulation/Utilities/src/Looses.cc
@@ -4,7 +4,7 @@
 #include <iomanip>
 #include <iostream>
 
-Looses* Looses::myself = 0;
+Looses* Looses::myself = nullptr;
 
 Looses::Looses() {}
 

--- a/FastSimulation/Validation/plugins/EmptySimHits.cc
+++ b/FastSimulation/Validation/plugins/EmptySimHits.cc
@@ -14,14 +14,14 @@
 class EmptySimHits : public edm::EDProducer {
 public:
   explicit EmptySimHits(const edm::ParameterSet&);
-  ~EmptySimHits(){};
+  ~EmptySimHits() override{};
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
 private:
-  virtual void beginJob() override {};
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override {};
+  void beginJob() override {};
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override {};
 
   std::vector<std::string> pCaloHitInstanceLabels;
   std::vector<std::string> pSimHitInstanceLabels;


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this quickly to avoid conflicts to the extent possible]