### PR TITLE
Special strip and pixel Clients to run Online on XeXe collisions

### DIFF
--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -149,7 +149,7 @@ process.hltTriggerTypeFilter = cms.EDFilter("HLTTriggerTypeFilter",
 )
 
 process.load('HLTrigger.HLTfilters.hltHighLevel_cfi')
-process.hltHighLevel.HLTPaths = cms.vstring( 'HLT_ZeroBias_*' , 'HLT_ZeroBias1_*' , 'HLT_PAZeroBias_*' , 'HLT_PAZeroBias1_*', 'HLT_PAL1MinimumBiasHF_OR_SinglePixelTrack_*', 'HLT*SingleMu*','HLT_HICentralityVeto*')
+process.hltHighLevel.HLTPaths = cms.vstring( 'HLT_ZeroBias_*' , 'HLT_ZeroBias1_*' , 'HLT_PAZeroBias_*' , 'HLT_PAZeroBias1_*', 'HLT_PAL1MinimumBiasHF_OR_SinglePixelTrack_*', 'HLT*SingleMu*','HLT_HICentralityVeto*','HLT_HIMinBias*')
 process.hltHighLevel.andOr = cms.bool(True)
 process.hltHighLevel.throw =  cms.bool(False)
 
@@ -168,8 +168,8 @@ else:
     process.Reco = cms.Sequence(process.siPixelDigis*process.siStripDigis*process.siStripZeroSuppression*process.siStripClusters*process.siPixelClusters)
 
 process.p = cms.Path(
-  #process.hltHighLevel #trigger selection
- process.Reco
+  process.hltHighLevel #trigger selection
+ *process.Reco
  *process.DQMmodules
  *process.siPixelPhase1OnlineDQM_source
  *process.siPixelPhase1OnlineDQM_harvesting

--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -1,8 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 #from Configuration.StandardSequences.Eras import eras
-
-process = cms.Process("PIXELDQMLIVE")
+#process = cms.Process("PIXELDQMLIVE", eras.Run2_2017)
 
 live=True  #set to false for lxplus offline testing
 offlineTesting=not live
@@ -114,7 +113,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.ecalPreshowerDigis.sourceTag = cms.InputTag("rawDataRepacker")
     process.gctDigis.inputLabel = cms.InputTag("rawDataRepacker")
     process.gtDigis.DaqGtInputTag = cms.InputTag("rawDataRepacker")
-    process.gtEvmDigis.EvmGtInputTag = cms.InputTag("rawDataRepacker")
+    #process.gtEvmDigis.EvmGtInputTag = cms.InputTag("rawDataRepacker")
     process.hcalDigis.InputLabel = cms.InputTag("rawDataRepacker")
     process.muonCSCDigis.InputObjects = cms.InputTag("rawDataRepacker")
     process.muonDTDigis.inputLabel = cms.InputTag("rawDataRepacker")
@@ -125,14 +124,14 @@ if (process.runType.getRunType() == process.runType.hi_run):
 
     #replace the effect of era in local reco
     process.siPixelDigis.UsePhase1=True
-    process.siPixelClusters.VCaltoElectronGain      = cms.int32(47)   # L2-4: 47 +- 4.7 
-    process.siPixelClusters.VCaltoElectronGain_L1   = cms.int32(50)   # L1:   49.6 +- 2.6 
-    process.siPixelClusters.VCaltoElectronOffset    = cms.int32(-60)  # L2-4: -60 +- 130 
-    process.siPixelClusters.VCaltoElectronOffset_L1 = cms.int32(-670) # L1:   -670 +- 220 
-    process.siPixelClusters.ChannelThreshold        = cms.int32(10) 
-    process.siPixelClusters.SeedThreshold           = cms.int32(1000) 
-    process.siPixelClusters.ClusterThreshold        = cms.int32(4000) 
-    process.siPixelClusters.ClusterThreshold_L1     = cms.int32(2000) 
+    process.siPixelClustersPreSplitting.VCaltoElectronGain      = cms.int32(47)   # L2-4: 47 +- 4.7 
+    process.siPixelClustersPreSplitting.VCaltoElectronGain_L1   = cms.int32(50)   # L1:   49.6 +- 2.6 
+    process.siPixelClustersPreSplitting.VCaltoElectronOffset    = cms.int32(-60)  # L2-4: -60 +- 130 
+    process.siPixelClustersPreSplitting.VCaltoElectronOffset_L1 = cms.int32(-670) # L1:   -670 +- 220 
+    process.siPixelClustersPreSplitting.ChannelThreshold        = cms.int32(10) 
+    process.siPixelClustersPreSplitting.SeedThreshold           = cms.int32(1000) 
+    process.siPixelClustersPreSplitting.ClusterThreshold        = cms.int32(4000) 
+    process.siPixelClustersPreSplitting.ClusterThreshold_L1     = cms.int32(2000) 
 
     
 # Phase1 DQM
@@ -175,7 +174,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.load("RecoLocalTracker.Configuration.RecoLocalTrackerHeavyIons_cff")
     process.SiPixelPhase1ClustersAnalyzer.pixelSrc = cms.InputTag("siPixelClustersPreSplitting")
 #    process.Reco = cms.Sequence(process.siPixelDigis*process.pixeltrackerlocalreco)
-    process.Reco =cms.Sequence(process.siPixelDigis*process.siStripDigis*process.siStripVRDigis*process.trackerlocalreco*process.pixeltrackerlocalreco) 
+    process.Reco =cms.Sequence(process.siPixelDigis*process.siStripDigis*process.siStripVRDigis*process.trackerlocalreco) 
 else:
     process.Reco = cms.Sequence(process.siPixelDigis*process.siStripDigis*process.siStripZeroSuppression*process.siStripClusters*process.siPixelClusters)
 

--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -122,6 +122,18 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.scalersRawToDigi.scalersInputTag = cms.InputTag("rawDataRepacker")
     process.siPixelDigis.InputLabel = cms.InputTag("rawDataRepacker")
     process.siStripDigis.ProductLabel = cms.InputTag("rawDataRepacker")
+
+    #replace the effect of era in local reco
+    process.siPixelDigis.UsePhase1=True
+    process.siPixelClusters.VCaltoElectronGain      = cms.int32(47)   # L2-4: 47 +- 4.7 
+    process.siPixelClusters.VCaltoElectronGain_L1   = cms.int32(50)   # L1:   49.6 +- 2.6 
+    process.siPixelClusters.VCaltoElectronOffset    = cms.int32(-60)  # L2-4: -60 +- 130 
+    process.siPixelClusters.VCaltoElectronOffset_L1 = cms.int32(-670) # L1:   -670 +- 220 
+    process.siPixelClusters.ChannelThreshold        = cms.int32(10) 
+    process.siPixelClusters.SeedThreshold           = cms.int32(1000) 
+    process.siPixelClusters.ClusterThreshold        = cms.int32(4000) 
+    process.siPixelClusters.ClusterThreshold_L1     = cms.int32(2000) 
+
     
 # Phase1 DQM
 process.load("DQM.SiPixelPhase1Config.SiPixelPhase1OnlineDQM_cff")

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -158,14 +158,14 @@ process.stripQTester = cms.EDAnalyzer("QualityTester",
     qtestOnEndRun = cms.untracked.bool(True)
 )
 
-process.trackingQTester = cms.EDAnalyzer("QualityTester",
-    qtList = cms.untracked.FileInPath('DQM/TrackingMonitorClient/data/tracking_qualitytest_config.xml'),
-    prescaleFactor = cms.untracked.int32(3),                               
-    getQualityTestsFromFile = cms.untracked.bool(True),
-    qtestOnEndLumi = cms.untracked.bool(True),
-    qtestOnEndRun = cms.untracked.bool(True)
-)
-
+#process.trackingQTester = cms.EDAnalyzer("QualityTester",
+#    qtList = cms.untracked.FileInPath('DQM/TrackingMonitorClient/data/tracking_qualitytest_config.xml'),
+#    prescaleFactor = cms.untracked.int32(3),                               
+#    getQualityTestsFromFile = cms.untracked.bool(True),
+#    qtestOnEndLumi = cms.untracked.bool(True),
+#    qtestOnEndRun = cms.untracked.bool(True)
+#)
+#
 
 #--------------------------
 # Service
@@ -213,7 +213,7 @@ process.hltHighLevel.throw =  cms.bool(False)
 # Scheduling
 #--------------------------
 process.SiStripSources_LocalReco = cms.Sequence(process.siStripFEDMonitor*process.SiStripMonitorDigi*process.SiStripMonitorClusterReal)
-process.DQMCommon                = cms.Sequence(process.stripQTester*process.trackingQTester*process.dqmEnv*process.dqmEnvTr*process.dqmSaver)
+process.DQMCommon                = cms.Sequence(process.stripQTester*process.dqmEnv*process.dqmEnvTr*process.dqmSaver)
 process.RecoForDQM_LocalReco     = cms.Sequence(process.siPixelDigis*process.siStripDigis*process.gtDigis*process.trackerlocalreco*process.gtEvmDigis)
 
 #--------------------------
@@ -258,12 +258,12 @@ if (process.runType.getRunType() == process.runType.cosmic_run or process.runTyp
     process.stripQTester.qtestOnEndLumi          = cms.untracked.bool(True)
     process.stripQTester.qtestOnEndRun           = cms.untracked.bool(True)
 
-    process.trackingQTester.qtList                  = cms.untracked.FileInPath('DQM/TrackingMonitorClient/data/tracking_qualitytest_config_cosmic.xml')
-    process.trackingQTester.prescaleFactor          = cms.untracked.int32(1)
-    process.trackingQTester.getQualityTestsFromFile = cms.untracked.bool(True)
-    process.trackingQTester.qtestOnEndLumi          = cms.untracked.bool(True)
-    process.trackingQTester.qtestOnEndRun           = cms.untracked.bool(True)                                                                    
-
+#process.trackingQTester.qtList                  = cms.untracked.FileInPath('DQM/TrackingMonitorClient/data/tracking_qualitytest_config_cosmic.xml')
+#process.trackingQTester.prescaleFactor          = cms.untracked.int32(1)
+#process.trackingQTester.getQualityTestsFromFile = cms.untracked.bool(True)
+#process.trackingQTester.qtestOnEndLumi          = cms.untracked.bool(True)
+#process.trackingQTester.qtestOnEndRun           = cms.untracked.bool(True)                                                                    
+#
     process.p = cms.Path(process.scalersRawToDigi*
                          process.APVPhases*
                          process.consecutiveHEs*
@@ -330,12 +330,12 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
         process.TrackingAnalyser.verbose = cms.untracked.bool(True)
     process.TrackingClient = cms.Sequence( process.TrackingAnalyser )
     
-    process.trackingQTester.qtList                  = cms.untracked.FileInPath('DQM/TrackingMonitorClient/data/tracking_qualitytest_config.xml')
-    process.trackingQTester.prescaleFactor          = cms.untracked.int32(1)
-    process.trackingQTester.getQualityTestsFromFile = cms.untracked.bool(True)
-    process.trackingQTester.qtestOnEndLumi          = cms.untracked.bool(True)
-    process.trackingQTester.qtestOnEndRun           = cms.untracked.bool(True)                                                                    
-
+#process.trackingQTester.qtList                  = cms.untracked.FileInPath('DQM/TrackingMonitorClient/data/tracking_qualitytest_config.xml')
+#process.trackingQTester.prescaleFactor          = cms.untracked.int32(1)
+#process.trackingQTester.getQualityTestsFromFile = cms.untracked.bool(True)
+#process.trackingQTester.qtestOnEndLumi          = cms.untracked.bool(True)
+#process.trackingQTester.qtestOnEndRun           = cms.untracked.bool(True)                                                                    
+#
     # Reco for pp collisions
 
     process.load('RecoTracker.IterativeTracking.InitialStepPreSplitting_cff')
@@ -532,11 +532,11 @@ if (process.runType.getRunType() == process.runType.hi_run):
                                      qtestOnEndRun = cms.untracked.bool(True)
                                      )
 
-    process.trackingQTester.qtList                  = cms.untracked.FileInPath('DQM/TrackingMonitorClient/data/tracking_qualitytest_config_heavyion.xml')
-    process.trackingQTester.prescaleFactor          = cms.untracked.int32(2)
-    process.trackingQTester.getQualityTestsFromFile = cms.untracked.bool(True)
-    process.trackingQTester.qtestOnEndLumi          = cms.untracked.bool(True)
-    process.trackingQTester.qtestOnEndRun           = cms.untracked.bool(True)
+    #process.trackingQTester.qtList                  = cms.untracked.FileInPath('DQM/TrackingMonitorClient/data/tracking_qualitytest_config_heavyion.xml')
+    #process.trackingQTester.prescaleFactor          = cms.untracked.int32(2)
+    #process.trackingQTester.getQualityTestsFromFile = cms.untracked.bool(True)
+    #process.trackingQTester.qtestOnEndLumi          = cms.untracked.bool(True)
+    #process.trackingQTester.qtestOnEndRun           = cms.untracked.bool(True)
 
 #    process.trackingQTester = cms.EDAnalyzer("QualityTester",
 #                                               qtList = cms.untracked.FileInPath('DQM/TrackingMonitorClient/data/tracking_qualitytest_config_heavyion.xml'),
@@ -577,7 +577,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.PixelLayerTriplets.FPix.HitProducer = cms.string('siPixelRecHitsPreSplitting')
 
     process.hiProtoTrackFilter.siPixelRecHits = "siPixelRecHitsPreSplitting"
-    process.hiPixel3ProtoTracks.RegionFactoryPSet.RegionPSet.siPixelRecHits = cms.InputTag("siPixelRecHitsPreSplitting")
+    #process.hiPixel3ProtoTracks.RegionFactoryPSet.RegionPSet.siPixelRecHits = cms.InputTag("siPixelRecHitsPreSplitting")
 
     process.hiFilter.clusterShapeCacheSrc = "siPixelClusterShapeCachePreSplitting"
 
@@ -596,12 +596,12 @@ if (process.runType.getRunType() == process.runType.hi_run):
                          process.RecoForDQM_LocalReco*
                          process.DQMCommon*
                          process.SiStripClients*
-                         process.SiStripSources_LocalReco*
-                         process.RecoForDQM_TrkReco*
-                         process.SiStripSources_TrkReco*
-                         process.multFilter*
-                         process.SiStripBaselineValidator*
-                         process.TrackingClient
+                         process.SiStripSources_LocalReco
+                         #process.RecoForDQM_TrkReco*
+                         #process.SiStripSources_TrkReco*
+                         #process.multFilter*
+                         #process.SiStripBaselineValidator*
+                         #process.TrackingClient
                          )
     
 


### PR DESCRIPTION
This PR is a first attempt to have running clients for Pixel and Strip dedicated to XeXe running.
For the time being the Online Tracking has been disabled (The HI community is interested mainly to low level quantities to be monitored Online). However I will try to include also the tracking and reiterate if needed.

These clients are no more crashing with the test runs, 304458 as an example.