### PR TITLE
Get rid of unused variables in reco particle flow pf tracking

### DIFF
--- a/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
@@ -199,7 +199,7 @@ PFElecTkProducer::produce(Event& iEvent, const EventSetup& iSetup)
 	bool isEcalDriven = true;
 	bool isTrackerDriven = true;
 	
-	if (&(*trackRef->seedRef())==0) {
+	if (&(*trackRef->seedRef())==nullptr) {
 	  isEcalDriven = false;
 	  isTrackerDriven = false;
 	}
@@ -269,7 +269,7 @@ PFElecTkProducer::produce(Event& iEvent, const EventSetup& iSetup)
   
   
   unsigned int count_primary = 0;
-  if(selGsfPFRecTracks.size() > 0) {
+  if(!selGsfPFRecTracks.empty()) {
     for(unsigned int ipfgsf=0; ipfgsf<selGsfPFRecTracks.size();ipfgsf++) {
       
       vector<unsigned int> secondaries(0);
@@ -305,7 +305,7 @@ PFElecTkProducer::produce(Event& iEvent, const EventSetup& iSetup)
 	// A MODIFICATION HERE IMPLIES A MODIFICATION IN PFBLOCKALGO.CC/H
 	unsigned int primGsfIndex = selGsfPFRecTracks[ipfgsf].trackId();
 	vector<reco::GsfPFRecTrack> trueGsfPFRecTracks;
-	if(secondaries.size() > 0) {
+	if(!secondaries.empty()) {
 	  // loop on secondaries gsf tracks (from converted brems)
 	  for(unsigned int isecpfgsf=0; isecpfgsf<secondaries.size();isecpfgsf++) {
 	    
@@ -401,7 +401,7 @@ PFElecTkProducer::FindPfRef(const reco::PFRecTrackCollection  & PfRTkColl,
 			    bool otherColl){
 
 
-  if (&(*gsftk.seedRef())==0) return -1;
+  if (&(*gsftk.seedRef())==nullptr) return -1;
   auto const &  ElSeedFromRef=static_cast<ElectronSeed const&>( *(gsftk.extra()->seedRef()) );
   //CASE 1 ELECTRONSEED DOES NOT HAVE A REF TO THE CKFTRACK
   if (ElSeedFromRef.ctfTrack().isNull()){
@@ -482,7 +482,7 @@ PFElecTkProducer::FindPfRef(const reco::PFRecTrackCollection  & PfRTkColl,
 // -- method to apply gsf electron selection to EcalDriven seeds
 bool 
 PFElecTkProducer::applySelection(const reco::GsfTrack& gsftk) {
-  if (&(*gsftk.seedRef())==0) return false;
+  if (&(*gsftk.seedRef())==nullptr) return false;
   auto const& ElSeedFromRef=static_cast<ElectronSeed const&>( *(gsftk.extra()->seedRef()) );
 
   bool passCut = false;
@@ -515,7 +515,7 @@ PFElecTkProducer::resolveGsfTracks(const vector<reco::GsfPFRecTrack>  & GsfPFVec
 
   const reco::GsfTrackRef& nGsfTrack = GsfPFVec[ngsf].gsfTrackRef();
   
-  if (&(*nGsfTrack->seedRef())==0) return false;    
+  if (&(*nGsfTrack->seedRef())==nullptr) return false;    
   auto const& nElSeedFromRef=static_cast<ElectronSeed const&>( *(nGsfTrack->extra()->seedRef()) );
   
   /* // now gotten from cache below
@@ -571,7 +571,7 @@ PFElecTkProducer::resolveGsfTracks(const vector<reco::GsfPFRecTrack>  & GsfPFVec
         */
         float iPin = gsfInnerMomentumCache_[iGsfTrack.key()];
 
-	if (&(*iGsfTrack->seedRef())==0) continue;   
+	if (&(*iGsfTrack->seedRef())==nullptr) continue;   
 	auto const& iElSeedFromRef=static_cast<ElectronSeed const&>( *(iGsfTrack->extra()->seedRef()) );
 
 	float SCEnergy = -1.;
@@ -932,7 +932,7 @@ PFElecTkProducer::isSharingEcalEnergyWithEgSC(const reco::GsfPFRecTrack& nGsfPFR
 	}  
       } // END if angle preselection
     } // PFClusters Loop
-    if(vecPFClusters.size() > 0 ) {
+    if(!vecPFClusters.empty() ) {
       for(unsigned int pf = 0; pf < vecPFClusters.size(); pf++) {
 	bool isCommon = ClusterClusterMapping::overlap(vecPFClusters[pf],*scRef);
 	if(isCommon) {
@@ -1016,7 +1016,7 @@ PFElecTkProducer::isSharingEcalEnergyWithEgSC(const reco::GsfPFRecTrack& nGsfPFR
     }
 
 
-    if(nPFCluster.size() > 0 && iPFCluster.size() > 0) {
+    if(!nPFCluster.empty() && !iPFCluster.empty()) {
       for(unsigned int npf = 0; npf < nPFCluster.size(); npf++) {
 	for(unsigned int ipf = 0; ipf < iPFCluster.size(); ipf++) {
 	  bool isCommon = ClusterClusterMapping::overlap(nPFCluster[npf],iPFCluster[ipf]);

--- a/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
@@ -993,7 +993,6 @@ PFElecTkProducer::isSharingEcalEnergyWithEgSC(const reco::GsfPFRecTrack& nGsfPFR
       // Apply loose preselection with the track
       // just to save cpu time, for this hard-coded
       if(ideta < 0.5 && fabs(idphi) < 1.0) {
-	bool foundILink = false;
 	double dist = iGsfPFRecTrack.extrapolatedPoint( reco::PFTrajectoryPoint::ECALShowerMax ).isValid() ?
 	  LinkByRecHit::testTrackAndClusterByRecHit(iGsfPFRecTrack , clust ) : -1.;
 	if(dist > 0.) {

--- a/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
@@ -903,7 +903,6 @@ PFElecTkProducer::isSharingEcalEnergyWithEgSC(const reco::GsfPFRecTrack& nGsfPFR
       // Angle preselection between the supercluster and pfclusters
       // this is needed just to save some cpu-time for this is hard-coded     
       if(deta < 0.5 && fabs(dphi) < 1.0) {
-	bool foundLink = false;
 	double distGsf = gsfPfTrack.extrapolatedPoint( reco::PFTrajectoryPoint::ECALShowerMax ).isValid() ?
 	  LinkByRecHit::testTrackAndClusterByRecHit(gsfPfTrack , clust ) : -1.;
 	// check if it touch the GsfTrack
@@ -913,10 +912,9 @@ PFElecTkProducer::isSharingEcalEnergyWithEgSC(const reco::GsfPFRecTrack& nGsfPFR
 	  else
 	    nEnergy += clust.energy();
 	  vecPFClusters.push_back(clust);
-	  foundLink = true;
 	}
 	// check if it touch the Brem-tangents
-	if(foundLink == false) {
+	else {
 	  vector<PFBrem> primPFBrem = gsfPfTrack.PFRecBrem();
 	  for(unsigned ipbrem = 0; ipbrem < primPFBrem.size(); ipbrem++) {
 	    if(primPFBrem[ipbrem].indTrajPoint() == 99) continue;
@@ -929,11 +927,10 @@ PFElecTkProducer::isSharingEcalEnergyWithEgSC(const reco::GsfPFRecTrack& nGsfPFR
 	      else
 		nEnergy += clust.energy();
 	      vecPFClusters.push_back(clust);
-	      foundLink = true;
 	    }
 	  }	
 	}  
-      } // END if anble preselection
+      } // END if angle preselection
     } // PFClusters Loop
     if(vecPFClusters.size() > 0 ) {
       for(unsigned int pf = 0; pf < vecPFClusters.size(); pf++) {
@@ -967,28 +964,24 @@ PFElecTkProducer::isSharingEcalEnergyWithEgSC(const reco::GsfPFRecTrack& nGsfPFR
       // Apply loose preselection with the track
       // just to save cpu time, for this hard-coded
       if(ndeta < 0.5 && fabs(ndphi) < 1.0) {
-	bool foundNLink = false;
 	
 	double distGsf = nGsfPFRecTrack.extrapolatedPoint( reco::PFTrajectoryPoint::ECALShowerMax ).isValid() ?
 	  LinkByRecHit::testTrackAndClusterByRecHit(nGsfPFRecTrack , clust ) : -1.;
 	if(distGsf > 0.) {
 	  nPFCluster.push_back(clust);
 	  nEnergy += clust.energy();
-	  foundNLink = true;
 	}
-	if(foundNLink == false) {
+	else {
 	  const vector<PFBrem>& primPFBrem = nGsfPFRecTrack.PFRecBrem();
 	  for(unsigned ipbrem = 0; ipbrem < primPFBrem.size(); ipbrem++) {
 	    if(primPFBrem[ipbrem].indTrajPoint() == 99) continue;
 	    const reco::PFRecTrack& pfBremTrack = primPFBrem[ipbrem];
-	    if(foundNLink == false) {
-	      double dist = pfBremTrack.extrapolatedPoint( reco::PFTrajectoryPoint::ECALShowerMax ).isValid() ?
+	    double dist = pfBremTrack.extrapolatedPoint( reco::PFTrajectoryPoint::ECALShowerMax ).isValid() ?
 		LinkByRecHit::testTrackAndClusterByRecHit(pfBremTrack , clust, true ) : -1.;
-	      if(dist > 0.) {
-		nPFCluster.push_back(clust);
-		nEnergy += clust.energy();
-		foundNLink = true;
-	      }
+	    if(dist > 0.) {
+	      nPFCluster.push_back(clust);
+	      nEnergy += clust.energy();
+	      break;
 	    }
 	  }
 	}
@@ -1006,20 +999,17 @@ PFElecTkProducer::isSharingEcalEnergyWithEgSC(const reco::GsfPFRecTrack& nGsfPFR
 	if(dist > 0.) {
 	  iPFCluster.push_back(clust);
 	  iEnergy += clust.energy();
-	  foundILink = true;
 	}
-	if(foundILink == false) {
+	else {
 	  vector<PFBrem> primPFBrem = iGsfPFRecTrack.PFRecBrem();
 	  for(unsigned ipbrem = 0; ipbrem < primPFBrem.size(); ipbrem++) {
 	    if(primPFBrem[ipbrem].indTrajPoint() == 99) continue;
 	    const reco::PFRecTrack& pfBremTrack = primPFBrem[ipbrem];
-	    if(foundILink == false) {
-	      double dist = LinkByRecHit::testTrackAndClusterByRecHit(pfBremTrack , clust, true );
-	      if(dist > 0.) {
-		iPFCluster.push_back(clust);
-		iEnergy += clust.energy();
-		foundILink = true;
-	      }
+	    double dist = LinkByRecHit::testTrackAndClusterByRecHit(pfBremTrack , clust, true );
+	    if(dist > 0.) {
+	      iPFCluster.push_back(clust);
+	      iEnergy += clust.energy();
+	      break;
 	    }
 	  }
 	}

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -236,7 +236,7 @@ PFDisplacedVertexFinder::fitVertexFromSeed(const PFDisplacedVertexSeed& displace
   // ---- Prepare transient track list ----
 
   set < TrackBaseRef, PFDisplacedVertexSeed::Compare > const& tracksToFit = displacedVertexSeed.elements();
-  GlobalPoint seedPoint = displacedVertexSeed.seedPoint();
+  const GlobalPoint& seedPoint = displacedVertexSeed.seedPoint();
 
   vector<TransientTrack> transTracks;
   vector<TransientTrack> transTracksRaw;
@@ -691,8 +691,8 @@ PFDisplacedVertexFinder::rejectAndLabelVertex(PFDisplacedVertex& dv){
 bool 
 PFDisplacedVertexFinder::isCloseTo(const PFDisplacedVertexSeed& dv1, const PFDisplacedVertexSeed& dv2) const {
 
-  const GlobalPoint vP1 = dv1.seedPoint();
-  const GlobalPoint vP2 = dv2.seedPoint();
+  const GlobalPoint& vP1 = dv1.seedPoint();
+  const GlobalPoint& vP2 = dv2.seedPoint();
 
   double Delta_Long = getLongDiff(vP1, vP2);
   if (Delta_Long > longSize_) return false;

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -179,7 +179,6 @@ PFDisplacedVertexFinder::findSeedsFromCandidate(const PFDisplacedVertexCandidate
       tempDisplacedVertexSeeds.push_back( PFDisplacedVertexSeed() );      
       idvc_current = tempDisplacedVertexSeeds.end();
       idvc_current--;
-      bNeedNewCandidate = false;
     }
 
 


### PR DESCRIPTION
This PR addresses a couple of issues spot by the static analyzer in the RecoParticleFlow/PFTracking package, where some bool variable was computed but never used in the code flow afterwards.

While doing so, I also cleaned a bit the touched code in the PFElecTkProducer.cc

The code should work exactly the same as before: therefore any difference in output with respect to the baseline release must be seen as a bug in this implementation.