### PR TITLE
Clang-tidy checks for L1TriggerConfig

### DIFF
--- a/L1TriggerConfig/DTTrackFinder/interface/DTPhiLutTester.h
+++ b/L1TriggerConfig/DTTrackFinder/interface/DTPhiLutTester.h
@@ -26,9 +26,9 @@ class DTPhiLutTester : public edm::EDAnalyzer {
 
   DTPhiLutTester(const edm::ParameterSet& ps);
 
-  ~DTPhiLutTester();
+  ~DTPhiLutTester() override;
   
-  virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
  private:
 

--- a/L1TriggerConfig/DTTrackFinder/interface/DTPtaLutTester.h
+++ b/L1TriggerConfig/DTTrackFinder/interface/DTPtaLutTester.h
@@ -26,9 +26,9 @@ class DTPtaLutTester : public edm::EDAnalyzer {
 
   DTPtaLutTester(const edm::ParameterSet& ps);
 
-  ~DTPtaLutTester();
+  ~DTPtaLutTester() override;
   
-  virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
  private:
 

--- a/L1TriggerConfig/DTTrackFinder/interface/DTQualPatternLutTester.h
+++ b/L1TriggerConfig/DTTrackFinder/interface/DTQualPatternLutTester.h
@@ -26,9 +26,9 @@ class DTQualPatternLutTester : public edm::EDAnalyzer {
 
   DTQualPatternLutTester(const edm::ParameterSet& ps);
 
-  ~DTQualPatternLutTester();
+  ~DTQualPatternLutTester() override;
   
-  virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
  private:
 

--- a/L1TriggerConfig/DTTrackFinder/interface/DTTFMasksTester.h
+++ b/L1TriggerConfig/DTTrackFinder/interface/DTTFMasksTester.h
@@ -26,9 +26,9 @@ class DTTFMasksTester : public edm::EDAnalyzer {
 
   DTTFMasksTester(const edm::ParameterSet& ps);
 
-  ~DTTFMasksTester();
+  ~DTTFMasksTester() override;
   
-  virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
  private:
 

--- a/L1TriggerConfig/DTTrackFinder/interface/DTTFParametersTester.h
+++ b/L1TriggerConfig/DTTrackFinder/interface/DTTFParametersTester.h
@@ -26,9 +26,9 @@ class DTTFParametersTester : public edm::EDAnalyzer {
 
   DTTFParametersTester(const edm::ParameterSet& ps);
 
-  ~DTTFParametersTester();
+  ~DTTFParametersTester() override;
   
-  virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
  private:
 

--- a/L1TriggerConfig/DTTrackFinder/interface/DTTrackFinderConfig.h
+++ b/L1TriggerConfig/DTTrackFinder/interface/DTTrackFinderConfig.h
@@ -42,7 +42,7 @@ class DTTrackFinderConfig : public edm::ESProducer {
 
   DTTrackFinderConfig(const edm::ParameterSet&);
 
-  ~DTTrackFinderConfig();
+  ~DTTrackFinderConfig() override;
   
   std::unique_ptr<L1MuDTExtLut> produceL1MuDTExtLut(const L1MuDTExtLutRcd&);
 

--- a/L1TriggerConfig/DTTrackFinder/src/DTEtaPatternLutOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTEtaPatternLutOnlineProd.cc
@@ -37,9 +37,9 @@ class DTEtaPatternLutOnlineProd :
 {
    public:
       DTEtaPatternLutOnlineProd(const edm::ParameterSet&);
-      ~DTEtaPatternLutOnlineProd();
+      ~DTEtaPatternLutOnlineProd() override;
 
-  virtual std::shared_ptr< L1MuDTEtaPatternLut > newObject(
+  std::shared_ptr< L1MuDTEtaPatternLut > newObject(
     const std::string& objectKey ) override ;
 
    private:

--- a/L1TriggerConfig/DTTrackFinder/src/DTExtLutOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTExtLutOnlineProd.cc
@@ -37,9 +37,9 @@ class DTExtLutOnlineProd :
 {
    public:
       DTExtLutOnlineProd(const edm::ParameterSet&);
-      ~DTExtLutOnlineProd();
+      ~DTExtLutOnlineProd() override;
 
-  virtual std::shared_ptr< L1MuDTExtLut > newObject(
+  std::shared_ptr< L1MuDTExtLut > newObject(
     const std::string& objectKey ) override ;
 
    private:

--- a/L1TriggerConfig/DTTrackFinder/src/DTPhiLutOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTPhiLutOnlineProd.cc
@@ -37,9 +37,9 @@ class DTPhiLutOnlineProd :
 {
    public:
       DTPhiLutOnlineProd(const edm::ParameterSet&);
-      ~DTPhiLutOnlineProd();
+      ~DTPhiLutOnlineProd() override;
 
-  virtual std::shared_ptr< L1MuDTPhiLut > newObject(
+  std::shared_ptr< L1MuDTPhiLut > newObject(
     const std::string& objectKey ) override ;
 
    private:

--- a/L1TriggerConfig/DTTrackFinder/src/DTPtaLutOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTPtaLutOnlineProd.cc
@@ -37,9 +37,9 @@ class DTPtaLutOnlineProd :
 {
    public:
       DTPtaLutOnlineProd(const edm::ParameterSet&);
-      ~DTPtaLutOnlineProd();
+      ~DTPtaLutOnlineProd() override;
 
-  virtual std::shared_ptr< L1MuDTPtaLut > newObject(
+  std::shared_ptr< L1MuDTPtaLut > newObject(
     const std::string& objectKey ) override ;
 
    private:

--- a/L1TriggerConfig/DTTrackFinder/src/DTQualPatternLutOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTQualPatternLutOnlineProd.cc
@@ -37,9 +37,9 @@ class DTQualPatternLutOnlineProd :
 {
    public:
       DTQualPatternLutOnlineProd(const edm::ParameterSet&);
-      ~DTQualPatternLutOnlineProd();
+      ~DTQualPatternLutOnlineProd() override;
 
-  virtual std::shared_ptr< L1MuDTQualPatternLut > newObject(
+  std::shared_ptr< L1MuDTQualPatternLut > newObject(
     const std::string& objectKey ) override ;
 
    private:

--- a/L1TriggerConfig/DTTrackFinder/src/DTTFMasksOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTTFMasksOnlineProd.cc
@@ -34,9 +34,9 @@ class DTTFMasksOnlineProd :
   public L1ConfigOnlineProdBase< L1MuDTTFMasksRcd, L1MuDTTFMasks > {
    public:
       DTTFMasksOnlineProd(const edm::ParameterSet&);
-      ~DTTFMasksOnlineProd();
+      ~DTTFMasksOnlineProd() override;
 
-      virtual std::shared_ptr< L1MuDTTFMasks > newObject(
+      std::shared_ptr< L1MuDTTFMasks > newObject(
         const std::string& objectKey ) override ;
 
    private:
@@ -119,12 +119,12 @@ DTTFMasksOnlineProd::newObject( const std::string& objectKey )
 					crateMask ) ;
          char* pEnd;
 	 crateMaskL[ icrate ] = std::strtol( crateMask.c_str(), &pEnd, 16 ) ;
-	 crateMaskR[ icrate ] = std::strtol( pEnd, (char **)NULL, 16 ) ;
+	 crateMaskR[ icrate ] = std::strtol( pEnd, (char **)nullptr, 16 ) ;
 
 	 crateMaskResults.fillVariable( crateMaskColumns[ icrate+6 ],
 					crateMask ) ;
 	 krateMaskL[ icrate ] = std::strtol( crateMask.c_str(), &pEnd, 16 ) ;
-	 krateMaskR[ icrate ] = std::strtol( pEnd, (char **)NULL, 16 ) ;
+	 krateMaskR[ icrate ] = std::strtol( pEnd, (char **)nullptr, 16 ) ;
 
 	 std::cout << "Crate " << icrate << " masks"
 		   << " L: " << std::hex << crateMaskL[ icrate ]

--- a/L1TriggerConfig/DTTrackFinder/src/DTTFParametersOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTTFParametersOnlineProd.cc
@@ -34,9 +34,9 @@ class DTTFParametersOnlineProd :
   public L1ConfigOnlineProdBase< L1MuDTTFParametersRcd, L1MuDTTFParameters > {
    public:
       DTTFParametersOnlineProd(const edm::ParameterSet&);
-      ~DTTFParametersOnlineProd();
+      ~DTTFParametersOnlineProd() override;
 
-      virtual std::shared_ptr< L1MuDTTFParameters > newObject(
+      std::shared_ptr< L1MuDTTFParameters > newObject(
         const std::string& objectKey ) override ;
 
    private:

--- a/L1TriggerConfig/DTTrackFinder/src/DTTFRSKeysOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTTFRSKeysOnlineProd.cc
@@ -31,9 +31,9 @@
 class DTTFRSKeysOnlineProd : public L1ObjectKeysOnlineProdBase {
    public:
       DTTFRSKeysOnlineProd(const edm::ParameterSet&);
-      ~DTTFRSKeysOnlineProd();
+      ~DTTFRSKeysOnlineProd() override;
 
-      virtual void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+      void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
    private:
       // ----------member data ---------------------------
 };

--- a/L1TriggerConfig/DTTrackFinder/src/DTTFTSCObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTTFTSCObjectKeysOnlineProd.cc
@@ -31,9 +31,9 @@
 class DTTFTSCObjectKeysOnlineProd : public L1ObjectKeysOnlineProdBase {
    public:
       DTTFTSCObjectKeysOnlineProd(const edm::ParameterSet&);
-      ~DTTFTSCObjectKeysOnlineProd();
+      ~DTTFTSCObjectKeysOnlineProd() override;
 
-      virtual void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+      void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
    private:
       // ----------member data ---------------------------
 };

--- a/L1TriggerConfig/GMTConfigProducers/interface/L1MuGMTParametersOnlineProducer.h
+++ b/L1TriggerConfig/GMTConfigProducers/interface/L1MuGMTParametersOnlineProducer.h
@@ -30,10 +30,10 @@
 class L1MuGMTParametersOnlineProducer : public L1ConfigOnlineProdBase<L1MuGMTParametersRcd, L1MuGMTParameters> {
 public:
   L1MuGMTParametersOnlineProducer(const edm::ParameterSet&);
-  ~L1MuGMTParametersOnlineProducer();
+  ~L1MuGMTParametersOnlineProducer() override;
   
   /// The method that actually implements the production of the parameter objects
-  virtual std::shared_ptr<L1MuGMTParameters> newObject( const std::string& objectKey );
+  std::shared_ptr<L1MuGMTParameters> newObject( const std::string& objectKey ) override;
  protected:
 
   void checkCMSSWVersion(const coral::AttributeList& configRecord);

--- a/L1TriggerConfig/GMTConfigProducers/interface/L1MuGMTParametersProducer.h
+++ b/L1TriggerConfig/GMTConfigProducers/interface/L1MuGMTParametersProducer.h
@@ -34,7 +34,7 @@
 class L1MuGMTParametersProducer : public edm::ESProducer {
 public:
   L1MuGMTParametersProducer(const edm::ParameterSet&);
-  ~L1MuGMTParametersProducer();
+  ~L1MuGMTParametersProducer() override;
   
   std::unique_ptr<L1MuGMTParameters> produceL1MuGMTParameters(const L1MuGMTParametersRcd&);
   std::unique_ptr<L1MuGMTChannelMask> produceL1MuGMTChannelMask(const L1MuGMTChannelMaskRcd&);

--- a/L1TriggerConfig/GMTConfigProducers/interface/RecordHelper.h
+++ b/L1TriggerConfig/GMTConfigProducers/interface/RecordHelper.h
@@ -66,7 +66,7 @@ template <class TOutput, class TCField, class TDBField> class FieldHandler : pub
   { }
 
   /** Actual data extraction. */
-  virtual void extractValue(const AttributeList& src, TOutput& dest) { 
+  void extractValue(const AttributeList& src, TOutput& dest) override { 
 #ifdef RECORDHELPER_DEBUG
     std::cout << "Parsing field " << this->getName() << " with type " << typeid(TCField).name() ;
 #endif
@@ -100,7 +100,7 @@ template <class TOutput, char FalseCharacter> class ASCIIBoolFieldHandler : publ
     {   }
 
    /** Extract value as char, then see compare it to '0' to get its truth value. */
-  virtual void extractValue(const AttributeList& src, TOutput& dest)
+  void extractValue(const AttributeList& src, TOutput& dest) override
   {
     char value = src[this->getColumnName()].template data<char>();
 #ifdef RECORDHELPER_DEBUG

--- a/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTChannelMaskOnlineProducer.cc
+++ b/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTChannelMaskOnlineProducer.cc
@@ -6,9 +6,9 @@ class L1MuGMTChannelMaskOnlineProducer : public L1ConfigOnlineProdBase< L1MuGMTC
    public:
       L1MuGMTChannelMaskOnlineProducer(const edm::ParameterSet& iConfig)
          : L1ConfigOnlineProdBase< L1MuGMTChannelMaskRcd, L1MuGMTChannelMask >( iConfig ) {}
-      ~L1MuGMTChannelMaskOnlineProducer() {}
+      ~L1MuGMTChannelMaskOnlineProducer() override {}
 
-      virtual std::shared_ptr< L1MuGMTChannelMask > newObject( const std::string& objectKey ) override ;
+      std::shared_ptr< L1MuGMTChannelMask > newObject( const std::string& objectKey ) override ;
    private:
 };
 

--- a/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTParametersKeysOnlineProd.cc
+++ b/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTParametersKeysOnlineProd.cc
@@ -24,9 +24,9 @@ class L1MuGMTParametersKeysOnlineProd : public L1ObjectKeysOnlineProdBase {
       {
 	LogDebug( "L1-O2O" ) << "L1MuGMTParametersKeysOnlineProd created"  << std::endl;
       }
-      ~L1MuGMTParametersKeysOnlineProd() {}
+      ~L1MuGMTParametersKeysOnlineProd() override {}
 
-      virtual void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+      void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
    private:
 };
 

--- a/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTRSKeysOnlineProd.cc
+++ b/L1TriggerConfig/GMTConfigProducers/src/L1MuGMTRSKeysOnlineProd.cc
@@ -19,9 +19,9 @@
 class L1MuGMTRSKeysOnlineProd : public L1ObjectKeysOnlineProdBase {
    public:
       L1MuGMTRSKeysOnlineProd(const edm::ParameterSet& iConfig) ;
-      ~L1MuGMTRSKeysOnlineProd() {}
+      ~L1MuGMTRSKeysOnlineProd() override {}
 
-      virtual void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+      void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
    private:
       bool m_enableL1MuGMTChannelMask ;
 };

--- a/L1TriggerConfig/GctConfigProducers/interface/L1GctConfigDump.h
+++ b/L1TriggerConfig/GctConfigProducers/interface/L1GctConfigDump.h
@@ -35,9 +35,9 @@ public:
     explicit L1GctConfigDump(const edm::ParameterSet&);
 
     // destructor
-    virtual ~L1GctConfigDump();
+    ~L1GctConfigDump() override;
 
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
     
 };
 

--- a/L1TriggerConfig/GctConfigProducers/interface/L1GctConfigProducers.h
+++ b/L1TriggerConfig/GctConfigProducers/interface/L1GctConfigProducers.h
@@ -49,7 +49,7 @@ class L1GctChannelMaskRcd;
 class L1GctConfigProducers : public edm::ESProducer {
  public:
   L1GctConfigProducers(const edm::ParameterSet&);
-  ~L1GctConfigProducers();
+  ~L1GctConfigProducers() override;
   
   typedef std::shared_ptr<L1GctJetFinderParams>          JfParamsReturnType;
   typedef std::shared_ptr<L1GctChannelMask>          ChanMaskReturnType;

--- a/L1TriggerConfig/GctConfigProducers/src/L1GctChannelMaskOnlineProd.cc
+++ b/L1TriggerConfig/GctConfigProducers/src/L1GctChannelMaskOnlineProd.cc
@@ -6,9 +6,9 @@ class L1GctChannelMaskOnlineProd : public L1ConfigOnlineProdBase< L1GctChannelMa
    public:
       L1GctChannelMaskOnlineProd(const edm::ParameterSet& iConfig)
          : L1ConfigOnlineProdBase< L1GctChannelMaskRcd, L1GctChannelMask >( iConfig ) {}
-      ~L1GctChannelMaskOnlineProd() {}
+      ~L1GctChannelMaskOnlineProd() override {}
 
-      virtual std::shared_ptr< L1GctChannelMask > newObject( const std::string& objectKey ) override ;
+      std::shared_ptr< L1GctChannelMask > newObject( const std::string& objectKey ) override ;
    private:
 };
 

--- a/L1TriggerConfig/GctConfigProducers/src/L1GctJetFinderParamsOnlineProd.cc
+++ b/L1TriggerConfig/GctConfigProducers/src/L1GctJetFinderParamsOnlineProd.cc
@@ -6,9 +6,9 @@ class L1GctJetFinderParamsOnlineProd : public L1ConfigOnlineProdBase< L1GctJetFi
    public:
       L1GctJetFinderParamsOnlineProd(const edm::ParameterSet& iConfig)
          : L1ConfigOnlineProdBase< L1GctJetFinderParamsRcd, L1GctJetFinderParams >( iConfig ) {}
-      ~L1GctJetFinderParamsOnlineProd() {}
+      ~L1GctJetFinderParamsOnlineProd() override {}
 
-      virtual std::shared_ptr< L1GctJetFinderParams > newObject( const std::string& objectKey ) override ;
+      std::shared_ptr< L1GctJetFinderParams > newObject( const std::string& objectKey ) override ;
    private:
 };
 

--- a/L1TriggerConfig/GctConfigProducers/src/L1GctRSObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/GctConfigProducers/src/L1GctRSObjectKeysOnlineProd.cc
@@ -4,9 +4,9 @@
 class L1GctRSObjectKeysOnlineProd : public L1ObjectKeysOnlineProdBase {
    public:
       L1GctRSObjectKeysOnlineProd(const edm::ParameterSet& iConfig) ;
-      ~L1GctRSObjectKeysOnlineProd() {}
+      ~L1GctRSObjectKeysOnlineProd() override {}
 
-      virtual void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+      void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
    private:
       bool m_enableL1GctChannelMask ;
 };

--- a/L1TriggerConfig/GctConfigProducers/src/L1GctTSCObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/GctConfigProducers/src/L1GctTSCObjectKeysOnlineProd.cc
@@ -5,9 +5,9 @@ class L1GctTSCObjectKeysOnlineProd : public L1ObjectKeysOnlineProdBase {
    public:
       L1GctTSCObjectKeysOnlineProd(const edm::ParameterSet& iConfig)
          : L1ObjectKeysOnlineProdBase( iConfig ) {}
-      ~L1GctTSCObjectKeysOnlineProd() {}
+      ~L1GctTSCObjectKeysOnlineProd() override {}
 
-      virtual void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+      void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
    private:
 };
 

--- a/L1TriggerConfig/L1CSCTPConfigProducers/src/L1CSCTriggerPrimitivesConfigProducer.h
+++ b/L1TriggerConfig/L1CSCTPConfigProducers/src/L1CSCTriggerPrimitivesConfigProducer.h
@@ -24,7 +24,7 @@ class CSCDBL1TPParametersRcd;
 class L1CSCTriggerPrimitivesConfigProducer : public edm::ESProducer {
  public:
   L1CSCTriggerPrimitivesConfigProducer(const edm::ParameterSet&);
-  ~L1CSCTriggerPrimitivesConfigProducer();
+  ~L1CSCTriggerPrimitivesConfigProducer() override;
 
   //typedef std::shared_ptr<L1CSCTriggerPrimitivesConfigProducer> ReturnType;
 

--- a/L1TriggerConfig/L1GeometryProducers/interface/L1CaloGeometryProd.h
+++ b/L1TriggerConfig/L1GeometryProducers/interface/L1CaloGeometryProd.h
@@ -33,7 +33,7 @@
 class L1CaloGeometryProd : public edm::ESProducer {
    public:
       L1CaloGeometryProd(const edm::ParameterSet&);
-      ~L1CaloGeometryProd();
+      ~L1CaloGeometryProd() override;
 
       typedef std::unique_ptr<L1CaloGeometry> ReturnType;
 

--- a/L1TriggerConfig/L1GeometryProducers/src/L1CaloGeometryDump.cc
+++ b/L1TriggerConfig/L1GeometryProducers/src/L1CaloGeometryDump.cc
@@ -43,13 +43,13 @@
 class L1CaloGeometryDump : public edm::EDAnalyzer {
    public:
       explicit L1CaloGeometryDump(const edm::ParameterSet&);
-      ~L1CaloGeometryDump();
+      ~L1CaloGeometryDump() override;
 
 
    private:
-      virtual void beginJob() override ;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override ;
+      void beginJob() override ;
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
 
       // ----------member data ---------------------------
 };

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtBoardMapsTester.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtBoardMapsTester.h
@@ -37,9 +37,9 @@ public:
     explicit L1GtBoardMapsTester(const edm::ParameterSet&);
 
     // destructor
-    virtual ~L1GtBoardMapsTester();
+    ~L1GtBoardMapsTester() override;
 
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 };
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtBoardMapsTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtBoardMapsTrivialProducer.h
@@ -40,7 +40,7 @@ public:
     L1GtBoardMapsTrivialProducer(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtBoardMapsTrivialProducer();
+    ~L1GtBoardMapsTrivialProducer() override;
 
 
     /// public methods

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersConfigOnlineProd.h
@@ -39,10 +39,10 @@ public:
     L1GtParametersConfigOnlineProd(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtParametersConfigOnlineProd();
+    ~L1GtParametersConfigOnlineProd() override;
 
     /// public methods
-    virtual std::shared_ptr<L1GtParameters> newObject(const std::string& objectKey);
+    std::shared_ptr<L1GtParameters> newObject(const std::string& objectKey) override;
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersTester.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersTester.h
@@ -41,9 +41,9 @@ public:
     explicit L1GtParametersTester(const edm::ParameterSet&);
 
     // destructor
-    virtual ~L1GtParametersTester();
+    ~L1GtParametersTester() override;
 
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 };
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersTrivialProducer.h
@@ -42,7 +42,7 @@ public:
     L1GtParametersTrivialProducer(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtParametersTrivialProducer();
+    ~L1GtParametersTrivialProducer() override;
 
 
     /// public methods

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsAlgoTrigConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsAlgoTrigConfigOnlineProd.h
@@ -39,10 +39,10 @@ public:
     L1GtPrescaleFactorsAlgoTrigConfigOnlineProd(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtPrescaleFactorsAlgoTrigConfigOnlineProd();
+    ~L1GtPrescaleFactorsAlgoTrigConfigOnlineProd() override;
 
     /// public methods
-    virtual std::shared_ptr<L1GtPrescaleFactors> newObject(const std::string& objectKey);
+    std::shared_ptr<L1GtPrescaleFactors> newObject(const std::string& objectKey) override;
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsAlgoTrigTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsAlgoTrigTrivialProducer.h
@@ -42,7 +42,7 @@ public:
     L1GtPrescaleFactorsAlgoTrigTrivialProducer(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtPrescaleFactorsAlgoTrigTrivialProducer();
+    ~L1GtPrescaleFactorsAlgoTrigTrivialProducer() override;
 
     /// public methods
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsAndMasksTester.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsAndMasksTester.h
@@ -38,32 +38,32 @@ public:
     explicit L1GtPrescaleFactorsAndMasksTester(const edm::ParameterSet&);
 
     // destructor
-    virtual ~L1GtPrescaleFactorsAndMasksTester();
+    ~L1GtPrescaleFactorsAndMasksTester() override;
 
 private:
 
     /// begin job
-    void beginJob();
+    void beginJob() override;
 
     /// begin run
-    void beginRun(const edm::Run&, const edm::EventSetup&);
+    void beginRun(const edm::Run&, const edm::EventSetup&) override;
 
     /// begin luminosity block
     void beginLuminosityBlock(const edm::LuminosityBlock&,
-            const edm::EventSetup&);
+            const edm::EventSetup&) override;
 
     /// analyze
-    void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     /// end luminosity block
     void
-    endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+    endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
 
     /// end run
-    void endRun(const edm::Run&, const edm::EventSetup&);
+    void endRun(const edm::Run&, const edm::EventSetup&) override;
 
     /// end job
-    void endJob();
+    void endJob() override;
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsTechTrigConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsTechTrigConfigOnlineProd.h
@@ -39,10 +39,10 @@ public:
     L1GtPrescaleFactorsTechTrigConfigOnlineProd(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtPrescaleFactorsTechTrigConfigOnlineProd();
+    ~L1GtPrescaleFactorsTechTrigConfigOnlineProd() override;
 
     /// public methods
-    virtual std::shared_ptr<L1GtPrescaleFactors> newObject(const std::string& objectKey);
+    std::shared_ptr<L1GtPrescaleFactors> newObject(const std::string& objectKey) override;
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsTechTrigTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsTechTrigTrivialProducer.h
@@ -42,7 +42,7 @@ public:
     L1GtPrescaleFactorsTechTrigTrivialProducer(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtPrescaleFactorsTechTrigTrivialProducer();
+    ~L1GtPrescaleFactorsTechTrigTrivialProducer() override;
 
     /// public methods
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPsbSetupConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPsbSetupConfigOnlineProd.h
@@ -42,10 +42,10 @@ public:
     L1GtPsbSetupConfigOnlineProd(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtPsbSetupConfigOnlineProd();
+    ~L1GtPsbSetupConfigOnlineProd() override;
 
     /// public methods
-    virtual std::shared_ptr<L1GtPsbSetup> newObject(const std::string& objectKey);
+    std::shared_ptr<L1GtPsbSetup> newObject(const std::string& objectKey) override;
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPsbSetupTester.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPsbSetupTester.h
@@ -37,9 +37,9 @@ public:
     explicit L1GtPsbSetupTester(const edm::ParameterSet&);
 
     // destructor
-    virtual ~L1GtPsbSetupTester();
+    ~L1GtPsbSetupTester() override;
 
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 };
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPsbSetupTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPsbSetupTrivialProducer.h
@@ -40,7 +40,7 @@ public:
     L1GtPsbSetupTrivialProducer(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtPsbSetupTrivialProducer();
+    ~L1GtPsbSetupTrivialProducer() override;
 
 
     /// public methods

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtRsObjectKeysOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtRsObjectKeysOnlineProd.h
@@ -31,10 +31,10 @@ public:
     L1GtRsObjectKeysOnlineProd(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtRsObjectKeysOnlineProd();
+    ~L1GtRsObjectKeysOnlineProd() override;
 
     /// public methods
-    virtual void fillObjectKeys(ReturnType pL1TriggerKey);
+    void fillObjectKeys(ReturnType pL1TriggerKey) override;
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtStableParametersTester.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtStableParametersTester.h
@@ -40,9 +40,9 @@ public:
     explicit L1GtStableParametersTester(const edm::ParameterSet&);
 
     // destructor
-    virtual ~L1GtStableParametersTester();
+    ~L1GtStableParametersTester() override;
 
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 };
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtStableParametersTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtStableParametersTrivialProducer.h
@@ -44,7 +44,7 @@ public:
     L1GtStableParametersTrivialProducer(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtStableParametersTrivialProducer();
+    ~L1GtStableParametersTrivialProducer() override;
 
     /// public methods
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskAlgoTrigConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskAlgoTrigConfigOnlineProd.h
@@ -39,10 +39,10 @@ public:
     L1GtTriggerMaskAlgoTrigConfigOnlineProd(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtTriggerMaskAlgoTrigConfigOnlineProd();
+    ~L1GtTriggerMaskAlgoTrigConfigOnlineProd() override;
 
     /// public methods
-    virtual std::shared_ptr<L1GtTriggerMask> newObject(const std::string& objectKey);
+    std::shared_ptr<L1GtTriggerMask> newObject(const std::string& objectKey) override;
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskAlgoTrigTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskAlgoTrigTrivialProducer.h
@@ -42,7 +42,7 @@ public:
     L1GtTriggerMaskAlgoTrigTrivialProducer(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtTriggerMaskAlgoTrigTrivialProducer();
+    ~L1GtTriggerMaskAlgoTrigTrivialProducer() override;
 
 
     /// public methods

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskTechTrigConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskTechTrigConfigOnlineProd.h
@@ -39,10 +39,10 @@ public:
     L1GtTriggerMaskTechTrigConfigOnlineProd(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtTriggerMaskTechTrigConfigOnlineProd();
+    ~L1GtTriggerMaskTechTrigConfigOnlineProd() override;
 
     /// public methods
-    virtual std::shared_ptr<L1GtTriggerMask> newObject(const std::string& objectKey);
+    std::shared_ptr<L1GtTriggerMask> newObject(const std::string& objectKey) override;
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskTechTrigTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskTechTrigTrivialProducer.h
@@ -42,7 +42,7 @@ public:
     L1GtTriggerMaskTechTrigTrivialProducer(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtTriggerMaskTechTrigTrivialProducer();
+    ~L1GtTriggerMaskTechTrigTrivialProducer() override;
 
 
     /// public methods

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskVetoAlgoTrigTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskVetoAlgoTrigTrivialProducer.h
@@ -42,7 +42,7 @@ public:
     L1GtTriggerMaskVetoAlgoTrigTrivialProducer(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtTriggerMaskVetoAlgoTrigTrivialProducer();
+    ~L1GtTriggerMaskVetoAlgoTrigTrivialProducer() override;
 
 
     /// public methods

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskVetoTechTrigConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskVetoTechTrigConfigOnlineProd.h
@@ -39,10 +39,10 @@ public:
     L1GtTriggerMaskVetoTechTrigConfigOnlineProd(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtTriggerMaskVetoTechTrigConfigOnlineProd();
+    ~L1GtTriggerMaskVetoTechTrigConfigOnlineProd() override;
 
     /// public methods
-    virtual std::shared_ptr<L1GtTriggerMask> newObject(const std::string& objectKey);
+    std::shared_ptr<L1GtTriggerMask> newObject(const std::string& objectKey) override;
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskVetoTechTrigTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMaskVetoTechTrigTrivialProducer.h
@@ -42,7 +42,7 @@ public:
     L1GtTriggerMaskVetoTechTrigTrivialProducer(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtTriggerMaskVetoTechTrigTrivialProducer();
+    ~L1GtTriggerMaskVetoTechTrigTrivialProducer() override;
 
 
     /// public methods

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuConfigOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuConfigOnlineProd.h
@@ -55,10 +55,10 @@ public:
     L1GtTriggerMenuConfigOnlineProd(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtTriggerMenuConfigOnlineProd();
+    ~L1GtTriggerMenuConfigOnlineProd() override;
 
     /// public methods
-    virtual std::shared_ptr<L1GtTriggerMenu> newObject(const std::string& objectKey);
+    std::shared_ptr<L1GtTriggerMenu> newObject(const std::string& objectKey) override;
 
     /// initialize the class (mainly reserve/resize)
     void init(const int numberConditionChips);

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuTester.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuTester.h
@@ -49,32 +49,32 @@ public:
     explicit L1GtTriggerMenuTester(const edm::ParameterSet&);
 
     // destructor
-    virtual ~L1GtTriggerMenuTester();
+    ~L1GtTriggerMenuTester() override;
 
 private:
 
     /// begin job
-    void beginJob();
+    void beginJob() override;
 
     /// begin run
-    void beginRun(const edm::Run&, const edm::EventSetup&);
+    void beginRun(const edm::Run&, const edm::EventSetup&) override;
 
     /// begin luminosity block
     void beginLuminosityBlock(const edm::LuminosityBlock&,
-            const edm::EventSetup&);
+            const edm::EventSetup&) override;
 
     /// analyze
-    void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     /// end luminosity block
     void
-    endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+    endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
 
     /// end run
-    void endRun(const edm::Run&, const edm::EventSetup&);
+    void endRun(const edm::Run&, const edm::EventSetup&) override;
 
     /// end job
-    void endJob();
+    void endJob() override;
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuXmlParser.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuXmlParser.h
@@ -59,7 +59,7 @@ public:
     L1GtTriggerMenuXmlParser();
 
     /// destructor
-    virtual ~L1GtTriggerMenuXmlParser();
+    ~L1GtTriggerMenuXmlParser() override;
 
 public:
 
@@ -343,7 +343,7 @@ private:
     XERCES_CPP_NAMESPACE::DOMNode* findXMLChild(
             XERCES_CPP_NAMESPACE::DOMNode* startChild,
             const std::string& tagName, bool beginOnly = false,
-            std::string* rest = 0);
+            std::string* rest = nullptr);
 
     /// get a named attribute for an xml node as string
     std::string getXMLAttribute(const XERCES_CPP_NAMESPACE::DOMNode* node,

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuXmlProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuXmlProducer.h
@@ -43,7 +43,7 @@ public:
     L1GtTriggerMenuXmlProducer(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtTriggerMenuXmlProducer();
+    ~L1GtTriggerMenuXmlProducer() override;
 
 
     /// public methods

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTscObjectKeysOnlineProd.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTscObjectKeysOnlineProd.h
@@ -31,10 +31,10 @@ public:
     L1GtTscObjectKeysOnlineProd(const edm::ParameterSet&);
 
     /// destructor
-    ~L1GtTscObjectKeysOnlineProd();
+    ~L1GtTscObjectKeysOnlineProd() override;
 
     /// public methods
-    virtual void fillObjectKeys(ReturnType pL1TriggerKey);
+    void fillObjectKeys(ReturnType pL1TriggerKey) override;
 
 private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtVhdlWriter.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtVhdlWriter.h
@@ -44,9 +44,9 @@ class L1GtVhdlWriter : public edm::EDAnalyzer
         explicit L1GtVhdlWriter(const edm::ParameterSet&);
 
         /// destructor
-        virtual ~L1GtVhdlWriter();
+        ~L1GtVhdlWriter() override;
 
-        virtual void analyze(const edm::Event&, const edm::EventSetup&);
+        void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     private:
 

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtVhdlWriterCore.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtVhdlWriterCore.h
@@ -48,7 +48,7 @@ class L1GtVhdlWriterCore : public L1GtVhdlDefinitions
         L1GtVhdlWriterCore(const std::string &templatesDirectory, const std::string &outputDirectory, const bool &debug);
 
         /// destructor
-        ~L1GtVhdlWriterCore();
+        ~L1GtVhdlWriterCore() override;
 
         /// returns all condition of the same class. Conditions belong to one class if they are matching
         /// in type (Type1s, Type2s..) category (CondMuon, CondCalo,)and are defined for the same object (Mu, fwdJet..)

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtVmeWriterCore.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtVmeWriterCore.h
@@ -41,7 +41,7 @@ public:
             const std::string& vmeXmlFile);
 
     /// destructor
-    virtual ~L1GtVmeWriterCore();
+    ~L1GtVmeWriterCore() override;
 
     void writeVME(const std::vector<ConditionMap> &conditionMap,
             const std::map<std::string,int>& cond2intMap, const L1GtVhdlTemplateFile& header,  const int spacesPerLevel=2);

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuTester.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuTester.cc
@@ -436,7 +436,7 @@ void L1GtTriggerMenuTester::printTriggerGroup(const std::string& trigGroupName,
             const std::vector<std::string> & hltPaths =
                     m_hltPathsForL1AlgorithmTrigger.at(bitNumber);
 
-            if (hltPaths.size() < 1) {
+            if (hltPaths.empty()) {
                 algoTriggerNotSeed.push_back(aAlias);
                 seedsHlt
                         = "<font color = \"red\">Not used as seed by any !HLT path</font>";
@@ -492,7 +492,7 @@ void L1GtTriggerMenuTester::printTriggerGroup(const std::string& trigGroupName,
                 << "\n Algorithm triggers from " << trigGroupName
                 << " not used as seeds by !HLT:" << std::endl;
 
-        if (algoTriggerNotSeed.size() != 0) {
+        if (!algoTriggerNotSeed.empty()) {
             for (std::vector<std::string>::const_iterator strIter =
                     algoTriggerNotSeed.begin(); strIter
                     != algoTriggerNotSeed.end(); ++strIter) {

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuXmlParser.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuXmlParser.cc
@@ -38,7 +38,7 @@
 
 // constructor
 L1GtTriggerMenuXmlParser::L1GtTriggerMenuXmlParser() :
-    L1GtXmlParserTags(), m_xmlErrHandler(0), m_triggerMenuInterface("NULL"),
+    L1GtXmlParserTags(), m_xmlErrHandler(nullptr), m_triggerMenuInterface("NULL"),
     m_triggerMenuName("NULL"), m_triggerMenuImplementation("NULL"), m_scaleDbKey("NULL")
 
 {
@@ -267,13 +267,13 @@ void L1GtTriggerMenuXmlParser::parseXmlFile(const std::string& defXmlFile,
     m_triggerMenuName.erase(m_triggerMenuName.begin() + xmlPos, m_triggerMenuName.end());
 
     // error handler for xml-parser
-    m_xmlErrHandler = 0;
+    m_xmlErrHandler = nullptr;
 
     XercesDOMParser* parser;
 
     LogTrace("L1GtTriggerMenuXmlParser") << "\nOpening XML-File: \n  " << defXmlFile << std::endl;
 
-    if ((parser = initXML(defXmlFile)) != 0) {
+    if ((parser = initXML(defXmlFile)) != nullptr) {
         workXML(parser);
     }
     cleanupXML(parser);
@@ -354,14 +354,14 @@ XERCES_CPP_NAMESPACE::XercesDOMParser* L1GtTriggerMenuXmlParser::initXML(const s
         << message << std::endl;
 
         XMLString::release(&message);
-        return 0;
+        return nullptr;
     }
 
     XercesDOMParser* parser = new XercesDOMParser();
     parser->setValidationScheme(XercesDOMParser::Val_Always);
     parser->setDoNamespaces(false); // we got no dtd
 
-    if (m_xmlErrHandler == 0) { // redundant check
+    if (m_xmlErrHandler == nullptr) { // redundant check
         m_xmlErrHandler = (ErrorHandler*) new HandlerBase();
     }
     else {
@@ -383,8 +383,8 @@ XERCES_CPP_NAMESPACE::XercesDOMParser* L1GtTriggerMenuXmlParser::initXML(const s
         XMLString::release(&message);
         delete parser;
         delete m_xmlErrHandler;
-        m_xmlErrHandler = 0;
-        return 0;
+        m_xmlErrHandler = nullptr;
+        return nullptr;
     }
     catch (const DOMException &toCatch) {
         char *message = XMLString::transcode(toCatch.msg);
@@ -396,8 +396,8 @@ XERCES_CPP_NAMESPACE::XercesDOMParser* L1GtTriggerMenuXmlParser::initXML(const s
         XMLString::release(&message);
         delete parser;
         delete m_xmlErrHandler;
-        m_xmlErrHandler = 0;
-        return 0;
+        m_xmlErrHandler = nullptr;
+        return nullptr;
     }
     catch (...) {
 
@@ -407,8 +407,8 @@ XERCES_CPP_NAMESPACE::XercesDOMParser* L1GtTriggerMenuXmlParser::initXML(const s
 
         delete parser;
         delete m_xmlErrHandler;
-        m_xmlErrHandler = 0;
-        return 0;
+        m_xmlErrHandler = nullptr;
+        return nullptr;
     }
 
     return parser;
@@ -421,11 +421,11 @@ XERCES_CPP_NAMESPACE::DOMNode* L1GtTriggerMenuXmlParser::findXMLChild(
 
     XERCES_CPP_NAMESPACE_USE
 
-    char* nodeName = 0;
+    char* nodeName = nullptr;
 
     DOMNode *n1 = startChild;
-    if (n1 == 0) {
-        return 0;
+    if (n1 == nullptr) {
+        return nullptr;
     }
 
     if ( !tagName.empty() ) {
@@ -437,7 +437,7 @@ XERCES_CPP_NAMESPACE::DOMNode* L1GtTriggerMenuXmlParser::findXMLChild(
 
                 XMLString::release(&nodeName);
                 n1 = n1->getNextSibling();
-                if (n1 == 0) {
+                if (n1 == nullptr) {
                     break;
                 }
 
@@ -449,13 +449,13 @@ XERCES_CPP_NAMESPACE::DOMNode* L1GtTriggerMenuXmlParser::findXMLChild(
             while (XMLString::compareNIString(nodeName, tagName.c_str(), tagName.length())) {
                 XMLString::release(&nodeName);
                 n1 = n1->getNextSibling();
-                if (n1 == 0) {
+                if (n1 == nullptr) {
                     break;
                 }
 
                 nodeName = XMLString::transcode(n1->getNodeName());
             }
-            if (n1 != 0 && rest != 0) {
+            if (n1 != nullptr && rest != nullptr) {
                 *rest = std::string(nodeName).substr(tagName.length(), strlen(nodeName) - tagName.length());
             }
         }
@@ -463,12 +463,12 @@ XERCES_CPP_NAMESPACE::DOMNode* L1GtTriggerMenuXmlParser::findXMLChild(
     else { // empty string given
         while (n1->getNodeType() != DOMNode::ELEMENT_NODE) {
             n1 = n1->getNextSibling();
-            if (n1 == 0) {
+            if (n1 == nullptr) {
                 break;
             }
 
         }
-        if (n1 != 0 && rest != 0) {
+        if (n1 != nullptr && rest != nullptr) {
             nodeName = XMLString::transcode(n1->getNodeName());
             *rest = std::string(nodeName);
         }
@@ -498,7 +498,7 @@ std::string L1GtTriggerMenuXmlParser::getXMLAttribute(const XERCES_CPP_NAMESPACE
 
     // get attributes list
     DOMNamedNodeMap* attributes = node->getAttributes();
-    if (attributes == 0) {
+    if (attributes == nullptr) {
         return ret;
     }
 
@@ -507,7 +507,7 @@ std::string L1GtTriggerMenuXmlParser::getXMLAttribute(const XERCES_CPP_NAMESPACE
     DOMNode* attribNode = attributes->getNamedItem(attrName);
 
     XMLString::release(&attrName);
-    if (attribNode == 0) {
+    if (attribNode == nullptr) {
         return ret;
     }
 
@@ -533,12 +533,12 @@ std::string L1GtTriggerMenuXmlParser::getXMLTextValue(XERCES_CPP_NAMESPACE::DOMN
     std::string ret;
 
     DOMNode* n1 = node;
-    if (n1 == 0) {
+    if (n1 == nullptr) {
         return ret;
     }
 
     const XMLCh* retXmlCh = n1->getTextContent();
-    if (retXmlCh == 0) {
+    if (retXmlCh == nullptr) {
         return ret;
     }
 
@@ -648,7 +648,7 @@ bool L1GtTriggerMenuXmlParser::hexString2UInt128(const std::string& hexString,
 bool L1GtTriggerMenuXmlParser::getXMLHexTextValue128(XERCES_CPP_NAMESPACE::DOMNode* node,
     boost::uint64_t& dstL, boost::uint64_t& dstH) {
 
-    if (node == 0) {
+    if (node == nullptr) {
 
         LogDebug("L1GtTriggerMenuXmlParser") << "node == 0 in " << __PRETTY_FUNCTION__ << std::endl;
 
@@ -716,7 +716,7 @@ bool L1GtTriggerMenuXmlParser::countConditionChildMaxBits(XERCES_CPP_NAMESPACE::
     XERCES_CPP_NAMESPACE_USE
 
     // should never happen...
-    if (node == 0) {
+    if (node == nullptr) {
 
         LogDebug("L1GtTriggerMenuXmlParser")
         << "node == 0 in " << __PRETTY_FUNCTION__ << std::endl;
@@ -726,7 +726,7 @@ bool L1GtTriggerMenuXmlParser::countConditionChildMaxBits(XERCES_CPP_NAMESPACE::
 
     DOMNode* n1 = findXMLChild(node->getFirstChild(), childName);
 
-    if (n1 == 0) {
+    if (n1 == nullptr) {
 
         LogDebug("L1GtTriggerMenuXmlParser") << "Child of condition not found ( " << childName
             << ")" << std::endl;
@@ -736,7 +736,7 @@ bool L1GtTriggerMenuXmlParser::countConditionChildMaxBits(XERCES_CPP_NAMESPACE::
 
     DOMNode* n2 = findXMLChild(n1->getFirstChild(), m_xmlTagValue);
 
-    if (n2 == 0) {
+    if (n2 == nullptr) {
 
         LogDebug("L1GtTriggerMenuXmlParser") << "No value tag found for child " << childName
             << " in " << __PRETTY_FUNCTION__ << std::endl;
@@ -837,7 +837,7 @@ bool L1GtTriggerMenuXmlParser::getConditionChildValues(XERCES_CPP_NAMESPACE::DOM
 
     XERCES_CPP_NAMESPACE_USE
 
-    if (node == 0) {
+    if (node == nullptr) {
 
         LogDebug("L1GtTriggerMenuXmlParser")
         << "node == 0 in " << __PRETTY_FUNCTION__
@@ -849,7 +849,7 @@ bool L1GtTriggerMenuXmlParser::getConditionChildValues(XERCES_CPP_NAMESPACE::DOM
     DOMNode* n1 = findXMLChild(node->getFirstChild(), childName);
 
     // if child not found
-    if (n1 == 0) {
+    if (n1 == nullptr) {
 
         LogDebug("L1GtTriggerMenuXmlParser") << "Child of condition not found ( " << childName
             << ")" << std::endl;
@@ -868,7 +868,7 @@ bool L1GtTriggerMenuXmlParser::getConditionChildValues(XERCES_CPP_NAMESPACE::DOM
     //
     n1 = findXMLChild(n1->getFirstChild(), m_xmlTagValue);
     for (unsigned int i = 0; i < num; i++) {
-        if (n1 == 0) {
+        if (n1 == nullptr) {
 
             LogDebug("L1GtTriggerMenuXmlParser") << "Not enough values in condition child ( "
                 << childName << ")" << std::endl;
@@ -901,13 +901,13 @@ void L1GtTriggerMenuXmlParser::cleanupXML(XERCES_CPP_NAMESPACE::XercesDOMParser*
 
     XERCES_CPP_NAMESPACE_USE
 
-    if (parser != 0) {
+    if (parser != nullptr) {
         delete parser;
     }
 
-    if (m_xmlErrHandler != 0) {
+    if (m_xmlErrHandler != nullptr) {
         delete m_xmlErrHandler;
-        m_xmlErrHandler = 0;
+        m_xmlErrHandler = nullptr;
     }
 
     cms::concurrency::xercesTerminate();
@@ -934,7 +934,7 @@ bool L1GtTriggerMenuXmlParser::parseVmeXML(XERCES_CPP_NAMESPACE::XercesDOMParser
     DOMDocument* doc = parser->getDocument();
     DOMNode* n1 = doc->getFirstChild();
 
-    if (n1 == 0) {
+    if (n1 == nullptr) {
 
         edm::LogError("L1GtTriggerMenuXmlParser") << "Error: Found no XML child" << std::endl;
 
@@ -943,7 +943,7 @@ bool L1GtTriggerMenuXmlParser::parseVmeXML(XERCES_CPP_NAMESPACE::XercesDOMParser
 
     // find "vme"-tag
     n1 = findXMLChild(n1, m_xmlTagVme);
-    if (n1 == 0) {
+    if (n1 == nullptr) {
 
         edm::LogError("L1GtTriggerMenuXmlParser") << "Error: No vme tag found." << std::endl;
         return false;
@@ -956,7 +956,7 @@ bool L1GtTriggerMenuXmlParser::parseVmeXML(XERCES_CPP_NAMESPACE::XercesDOMParser
     while (chipCounter < m_numberConditionChips) {
 
         n1 = findXMLChild(n1, m_xmlTagChip, true);
-        if (n1 == 0) {
+        if (n1 == nullptr) {
             // just break if no more chips found
             break;
         }
@@ -1025,7 +1025,7 @@ bool L1GtTriggerMenuXmlParser::insertConditionIntoMap(L1GtCondition& cond, const
 bool L1GtTriggerMenuXmlParser::insertAlgorithmIntoMap(const L1GtAlgorithm& alg) {
 
     std::string algName = alg.algoName();
-    std::string algAlias = alg.algoAlias();
+    const std::string& algAlias = alg.algoAlias();
     //LogTrace("L1GtTriggerMenuXmlParser")
     //<< "    Trying to insert algorithm \"" << algName << "\" in the algorithm map." ;
 
@@ -1293,7 +1293,7 @@ int L1GtTriggerMenuXmlParser::getGEqFlag(XERCES_CPP_NAMESPACE::DOMNode* node,
 
     XERCES_CPP_NAMESPACE_USE
 
-    if (node == 0) {
+    if (node == nullptr) {
 
         LogDebug("L1GtTriggerMenuXmlParser")
         << "node == 0 in " << __PRETTY_FUNCTION__
@@ -1306,9 +1306,9 @@ int L1GtTriggerMenuXmlParser::getGEqFlag(XERCES_CPP_NAMESPACE::DOMNode* node,
     DOMNode* n1 = node->getFirstChild();
     n1 = findXMLChild(n1, nodeName);
 
-    if (n1 != 0) {
+    if (n1 != nullptr) {
         n1 = findXMLChild(n1->getFirstChild(), m_xmlTagGEq);
-        if (n1 == 0) {
+        if (n1 == nullptr) {
 
             LogDebug("L1GtTriggerMenuXmlParser") << "No \"greater or equal\" tag found"
                 << std::endl;
@@ -1344,14 +1344,14 @@ bool L1GtTriggerMenuXmlParser::getMuonMipIsoBits(XERCES_CPP_NAMESPACE::DOMNode* 
 
     XERCES_CPP_NAMESPACE_USE
 
-    if (node == 0) {
+    if (node == nullptr) {
         return false;
     }
 
     // find ptLowThreshold child
     DOMNode* n1 = findXMLChild(node->getFirstChild(), m_xmlTagPtLowThreshold);
 
-    if (n1 == 0) {
+    if (n1 == nullptr) {
         return false;
     }
 
@@ -1360,14 +1360,14 @@ bool L1GtTriggerMenuXmlParser::getMuonMipIsoBits(XERCES_CPP_NAMESPACE::DOMNode* 
 
     for (unsigned int i = 0; i < num; i++) {
 
-        if (n1 == 0) {
+        if (n1 == nullptr) {
             return false;
         }
 
         // MIP bit
 
         DOMNode* bitnode = findXMLChild(n1->getFirstChild(), m_xmlTagEnableMip);
-        if (bitnode == 0) {
+        if (bitnode == nullptr) {
             return true;
         }
 
@@ -1385,7 +1385,7 @@ bool L1GtTriggerMenuXmlParser::getMuonMipIsoBits(XERCES_CPP_NAMESPACE::DOMNode* 
 
         // enable iso bit
         bitnode = findXMLChild(n1->getFirstChild(), m_xmlTagEnableIso);
-        if (bitnode == 0) {
+        if (bitnode == nullptr) {
             return true;
         }
 
@@ -1402,7 +1402,7 @@ bool L1GtTriggerMenuXmlParser::getMuonMipIsoBits(XERCES_CPP_NAMESPACE::DOMNode* 
 
         // request iso bit
         bitnode = findXMLChild(n1->getFirstChild(), m_xmlTagRequestIso);
-        if (bitnode == 0) {
+        if (bitnode == nullptr) {
             return true;
         }
 
@@ -2038,13 +2038,13 @@ bool L1GtTriggerMenuXmlParser::parseEnergySum(
 
         // get energyOverflow logical flag and fill into structure
         DOMNode* n1;
-        if ( (n1 = findXMLChild(node->getFirstChild(), m_xmlTagEtThreshold)) == 0) {
+        if ( (n1 = findXMLChild(node->getFirstChild(), m_xmlTagEtThreshold)) == nullptr) {
             edm::LogError("L1GtTriggerMenuXmlParser")
                 << "    Could not get energyOverflow for EnergySum condition (" << name << ")"
                 << std::endl;
             return false;
         }
-        if ( (n1 = findXMLChild(n1->getFirstChild(), m_xmlTagEnergyOverflow)) == 0) {
+        if ( (n1 = findXMLChild(n1->getFirstChild(), m_xmlTagEnergyOverflow)) == nullptr) {
             edm::LogError("L1GtTriggerMenuXmlParser")
                 << "    Could not get energyOverflow for EnergySum condition (" << name << ")"
                 << std::endl;
@@ -3017,7 +3017,7 @@ bool L1GtTriggerMenuXmlParser::parseCorrelation(
 
     std::string valString;
 
-    if (node1 == 0) {
+    if (node1 == nullptr) {
         edm::LogError("L1GtTriggerMenuXmlParser")
                 << "    Could not get deltaEta for correlation condition "
                 << name << ". " << std::endl;
@@ -3042,7 +3042,7 @@ bool L1GtTriggerMenuXmlParser::parseCorrelation(
 
    node1 = findXMLChild(node->getFirstChild(), m_xmlTagDeltaPhi);
 
-    if (node1 == 0) {
+    if (node1 == nullptr) {
         return false;
         edm::LogError("L1GtTriggerMenuXmlParser")
                 << "    Could not get deltaPhi for correlation condition "
@@ -3121,14 +3121,14 @@ bool L1GtTriggerMenuXmlParser::parseId(XERCES_CPP_NAMESPACE::XercesDOMParser* pa
     // we assume that the first child is m_xmlTagDef because it was checked in workXML
 
     DOMNode* headerNode = n1->getFirstChild();
-    if (headerNode == 0) {
+    if (headerNode == nullptr) {
         edm::LogError("L1GtTriggerMenuXmlParser") << "Error: No child of <" << m_xmlTagDef
                 << "> tag found." << std::endl;
         return false;
     }
 
     headerNode = findXMLChild(headerNode, m_xmlTagHeader);
-    if (headerNode == 0) {
+    if (headerNode == nullptr) {
 
         LogDebug("L1GtTriggerMenuXmlParser") << "\n  Warning: Could not find <" << m_xmlTagHeader
                 << "> tag" << "\n   - No header information." << std::endl;
@@ -3139,7 +3139,7 @@ bool L1GtTriggerMenuXmlParser::parseId(XERCES_CPP_NAMESPACE::XercesDOMParser* pa
 
         // find menu interface name
         idNode = findXMLChild(idNode, m_xmlTagMenuInterface);
-        if (idNode == 0) {
+        if (idNode == nullptr) {
 
             LogTrace("L1GtTriggerMenuXmlParser") << "\n  Warning: Could not find <"
                     << m_xmlTagMenuInterface << "> tag"
@@ -3168,7 +3168,7 @@ bool L1GtTriggerMenuXmlParser::parseId(XERCES_CPP_NAMESPACE::XercesDOMParser* pa
         idNode = headerNode->getFirstChild();
         idNode = findXMLChild(idNode, m_xmlTagMenuInterfaceDate);
 
-        if (idNode == 0) {
+        if (idNode == nullptr) {
 
             LogTrace("L1GtTriggerMenuXmlParser") << "\n  Warning: Could not find <"
                     << m_xmlTagMenuInterfaceDate << "> tag" << "\n   - No creation date."
@@ -3183,7 +3183,7 @@ bool L1GtTriggerMenuXmlParser::parseId(XERCES_CPP_NAMESPACE::XercesDOMParser* pa
         idNode = headerNode->getFirstChild();
         idNode = findXMLChild(idNode, m_xmlTagMenuInterfaceAuthor);
 
-        if (idNode == 0) {
+        if (idNode == nullptr) {
 
             LogTrace("L1GtTriggerMenuXmlParser") << "\n  Warning: Could not find <"
                     << m_xmlTagMenuInterfaceAuthor << "> tag" << "\n   - No creation author."
@@ -3198,7 +3198,7 @@ bool L1GtTriggerMenuXmlParser::parseId(XERCES_CPP_NAMESPACE::XercesDOMParser* pa
         idNode = headerNode->getFirstChild();
         idNode = findXMLChild(idNode, m_xmlTagMenuInterfaceDescription);
 
-        if (idNode == 0) {
+        if (idNode == nullptr) {
 
             LogTrace("L1GtTriggerMenuXmlParser") << "\n  Warning: Could not find <"
                     << m_xmlTagMenuInterfaceDescription << "> tag" << "\n   - No description."
@@ -3213,7 +3213,7 @@ bool L1GtTriggerMenuXmlParser::parseId(XERCES_CPP_NAMESPACE::XercesDOMParser* pa
         idNode = headerNode->getFirstChild();
         idNode = findXMLChild(idNode, m_xmlTagMenuDate);
 
-        if (idNode == 0) {
+        if (idNode == nullptr) {
 
             LogTrace("L1GtTriggerMenuXmlParser") << "\n  Warning: Could not find <"
                     << m_xmlTagMenuDate << "> tag" << "\n   - No creation date."
@@ -3228,7 +3228,7 @@ bool L1GtTriggerMenuXmlParser::parseId(XERCES_CPP_NAMESPACE::XercesDOMParser* pa
         idNode = headerNode->getFirstChild();
         idNode = findXMLChild(idNode, m_xmlTagMenuAuthor);
 
-        if (idNode == 0) {
+        if (idNode == nullptr) {
 
             LogTrace("L1GtTriggerMenuXmlParser") << "\n  Warning: Could not find <"
                     << m_xmlTagMenuAuthor << "> tag" << "\n   - No creation author."
@@ -3243,7 +3243,7 @@ bool L1GtTriggerMenuXmlParser::parseId(XERCES_CPP_NAMESPACE::XercesDOMParser* pa
         idNode = headerNode->getFirstChild();
         idNode = findXMLChild(idNode, m_xmlTagMenuDescription);
 
-        if (idNode == 0) {
+        if (idNode == nullptr) {
 
             LogTrace("L1GtTriggerMenuXmlParser") << "\n  Warning: Could not find <"
                     << m_xmlTagMenuDescription << "> tag" << "\n   - No description."
@@ -3259,7 +3259,7 @@ bool L1GtTriggerMenuXmlParser::parseId(XERCES_CPP_NAMESPACE::XercesDOMParser* pa
         idNode = headerNode->getFirstChild();
 
         idNode = findXMLChild(idNode, m_xmlTagMenuAlgImpl);
-        if (idNode == 0) {
+        if (idNode == nullptr) {
 
             m_algorithmImplementation = "";
             LogTrace("L1GtTriggerMenuXmlParser") << "\n  Warning: Could not find <"
@@ -3276,7 +3276,7 @@ bool L1GtTriggerMenuXmlParser::parseId(XERCES_CPP_NAMESPACE::XercesDOMParser* pa
         idNode = headerNode->getFirstChild();
 
         idNode = findXMLChild(idNode, m_xmlTagScaleDbKey);
-        if (idNode == 0) {
+        if (idNode == nullptr) {
 
             m_scaleDbKey = "NULL";
             LogTrace("L1GtTriggerMenuXmlParser") << "\n  Warning: Could not find <"
@@ -3436,7 +3436,7 @@ bool L1GtTriggerMenuXmlParser::parseConditions(XERCES_CPP_NAMESPACE::XercesDOMPa
     // we assume that the first child is m_xmlTagDef because it was checked in workXML
 
     DOMNode* chipNode = n1->getFirstChild();
-    if (chipNode == 0) {
+    if (chipNode == nullptr) {
 
         edm::LogError("L1GtTriggerMenuXmlParser") << "Error: No child of <" << m_xmlTagDef
             << "> tag found." << std::endl;
@@ -3448,7 +3448,7 @@ bool L1GtTriggerMenuXmlParser::parseConditions(XERCES_CPP_NAMESPACE::XercesDOMPa
 
     std::string chipName; // name of the actual chip
     chipNode = findXMLChild(chipNode, m_xmlTagChip, true, &chipName);
-    if (chipNode == 0) {
+    if (chipNode == nullptr) {
 
         edm::LogError("L1GtTriggerMenuXmlParser") << "  Error: Could not find <" << m_xmlTagChip
             << "> tag" << std::endl;
@@ -3462,7 +3462,7 @@ bool L1GtTriggerMenuXmlParser::parseConditions(XERCES_CPP_NAMESPACE::XercesDOMPa
         // find conditions
         DOMNode* conditionsNode = chipNode->getFirstChild();
         conditionsNode = findXMLChild(conditionsNode, m_xmlTagConditions);
-        if (conditionsNode == 0) {
+        if (conditionsNode == nullptr) {
 
             edm::LogError("L1GtTriggerMenuXmlParser") << "Error: No <" << m_xmlTagConditions
                 << "> child found in Chip " << chipName << std::endl;
@@ -3481,7 +3481,7 @@ bool L1GtTriggerMenuXmlParser::parseConditions(XERCES_CPP_NAMESPACE::XercesDOMPa
         DOMNode* conditionNameNode = conditionsNode->getFirstChild();
         std::string conditionNameNodeName;
         conditionNameNode = findXMLChild(conditionNameNode, "", true, &conditionNameNodeName);
-        while (conditionNameNode != 0) {
+        while (conditionNameNode != nullptr) {
 
             LogTrace("L1GtTriggerMenuXmlParser")
             << "\n    Found a condition with name: " << conditionNameNodeName
@@ -3498,7 +3498,7 @@ bool L1GtTriggerMenuXmlParser::parseConditions(XERCES_CPP_NAMESPACE::XercesDOMPa
         chipNode = findXMLChild(chipNode->getNextSibling(), m_xmlTagChip, true, &chipName);
         chipNr++;
 
-    } while (chipNode != 0 && chipNr < m_numberConditionChips);
+    } while (chipNode != nullptr && chipNr < m_numberConditionChips);
 
     return true;
 }
@@ -3519,7 +3519,7 @@ bool L1GtTriggerMenuXmlParser::workAlgorithm(XERCES_CPP_NAMESPACE::DOMNode* node
 
     XERCES_CPP_NAMESPACE_USE
 
-    if (node == 0) {
+    if (node == nullptr) {
         LogDebug("L1GtTriggerMenuXmlParser")
         << "    Node is 0 in " << __PRETTY_FUNCTION__
         << " can not parse the algorithm " << algName
@@ -3559,7 +3559,7 @@ bool L1GtTriggerMenuXmlParser::workAlgorithm(XERCES_CPP_NAMESPACE::DOMNode* node
     int outputPin = 0;
 
     pinNode = node->getFirstChild();
-    if ( (pinNode = findXMLChild(pinNode, m_xmlTagOutputPin) ) != 0) {
+    if ( (pinNode = findXMLChild(pinNode, m_xmlTagOutputPin) ) != nullptr) {
         pinString = getXMLAttribute(pinNode, m_xmlAttrNr);
 
         // convert pinString to integer
@@ -3576,7 +3576,7 @@ bool L1GtTriggerMenuXmlParser::workAlgorithm(XERCES_CPP_NAMESPACE::DOMNode* node
 
     }
 
-    if (pinNode == 0) {
+    if (pinNode == nullptr) {
         LogTrace("L1GtTriggerMenuXmlParser") << "    Warning: No pin number found for algorithm: "
             << algName << std::endl;
 
@@ -3642,7 +3642,7 @@ bool L1GtTriggerMenuXmlParser::parseAlgorithms(XERCES_CPP_NAMESPACE::XercesDOMPa
     DOMNode* node = doc->getFirstChild();
 
     DOMNode* chipNode = node->getFirstChild();
-    if (chipNode == 0) {
+    if (chipNode == nullptr) {
         edm::LogError("L1GtTriggerMenuXmlParser") << "  Error: No child found for " << m_xmlTagDef
             << std::endl;
         return false;
@@ -3651,7 +3651,7 @@ bool L1GtTriggerMenuXmlParser::parseAlgorithms(XERCES_CPP_NAMESPACE::XercesDOMPa
     // find first chip
     std::string chipName;
     chipNode = findXMLChild(chipNode, m_xmlTagChip, true, &chipName);
-    if (chipNode == 0) {
+    if (chipNode == nullptr) {
         edm::LogError("L1GtTriggerMenuXmlParser") << "  Error: Could not find <" << m_xmlTagChip
             << std::endl;
         return false;
@@ -3670,7 +3670,7 @@ bool L1GtTriggerMenuXmlParser::parseAlgorithms(XERCES_CPP_NAMESPACE::XercesDOMPa
         // find algorithms
         DOMNode* algNode = chipNode->getFirstChild();
         algNode = findXMLChild(algNode, m_xmlTagAlgorithms);
-        if (algNode == 0) {
+        if (algNode == nullptr) {
             edm::LogError("L1GtTriggerMenuXmlParser") << "    Error: No <" << m_xmlTagAlgorithms
                 << "> child found in chip " << chipName << std::endl;
             return false;
@@ -3681,7 +3681,7 @@ bool L1GtTriggerMenuXmlParser::parseAlgorithms(XERCES_CPP_NAMESPACE::XercesDOMPa
         std::string algNameNodeName;
         algNameNode = findXMLChild(algNameNode, "", true, &algNameNodeName);
 
-        while (algNameNode != 0) {
+        while (algNameNode != nullptr) {
             //LogTrace("L1GtTriggerMenuXmlParser")
             //<< "    Found an algorithm with name: " << algNameNodeName
             //<< std::endl;
@@ -3698,7 +3698,7 @@ bool L1GtTriggerMenuXmlParser::parseAlgorithms(XERCES_CPP_NAMESPACE::XercesDOMPa
         chipNode = findXMLChild(chipNode->getNextSibling(), m_xmlTagChip, true, &chipName);
         chipNr++;
 
-    } while (chipNode != 0 && chipNr < m_numberConditionChips);
+    } while (chipNode != nullptr && chipNr < m_numberConditionChips);
 
     return true;
 }
@@ -3718,7 +3718,7 @@ bool L1GtTriggerMenuXmlParser::workTechTrigger(XERCES_CPP_NAMESPACE::DOMNode* no
 
     XERCES_CPP_NAMESPACE_USE
 
-    if (node == 0) {
+    if (node == nullptr) {
         LogDebug("L1GtTriggerMenuXmlParser")
         << "    Node is 0 in " << __PRETTY_FUNCTION__
         << " can not parse the technical trigger " << algName
@@ -3739,7 +3739,7 @@ bool L1GtTriggerMenuXmlParser::workTechTrigger(XERCES_CPP_NAMESPACE::DOMNode* no
     int outputPin = 0;
 
     pinNode = node->getFirstChild();
-    if ( (pinNode = findXMLChild(pinNode, m_xmlTagOutputPin) ) != 0) {
+    if ( (pinNode = findXMLChild(pinNode, m_xmlTagOutputPin) ) != nullptr) {
         pinString = getXMLAttribute(pinNode, m_xmlAttrNr);
 
         // convert pinString to integer
@@ -3756,7 +3756,7 @@ bool L1GtTriggerMenuXmlParser::workTechTrigger(XERCES_CPP_NAMESPACE::DOMNode* no
 
     }
 
-    if (pinNode == 0) {
+    if (pinNode == nullptr) {
         LogTrace("L1GtTriggerMenuXmlParser")
             << "    Warning: No pin number found for technical trigger: "
             << algName << std::endl;
@@ -3813,14 +3813,14 @@ bool L1GtTriggerMenuXmlParser::parseTechTriggers(XERCES_CPP_NAMESPACE::XercesDOM
     DOMNode* node = doc->getFirstChild();
 
     DOMNode* algNode = node->getFirstChild();
-    if (algNode == 0) {
+    if (algNode == nullptr) {
         edm::LogError("L1GtTriggerMenuXmlParser")
                 << "  Error: No child found for " << m_xmlTagDef << std::endl;
         return false;
     }
 
     algNode = findXMLChild(algNode, m_xmlTagTechTriggers);
-    if (algNode == 0) {
+    if (algNode == nullptr) {
         edm::LogError("L1GtTriggerMenuXmlParser") << "    Error: No <"
                 << m_xmlTagTechTriggers << "> child found."
                 << std::endl;
@@ -3832,7 +3832,7 @@ bool L1GtTriggerMenuXmlParser::parseTechTriggers(XERCES_CPP_NAMESPACE::XercesDOM
     std::string algNameNodeName;
     algNameNode = findXMLChild(algNameNode, "", true, &algNameNodeName);
 
-    while (algNameNode != 0) {
+    while (algNameNode != nullptr) {
         //LogTrace("L1GtTriggerMenuXmlParser")
         //<< "    Found an technical trigger with name: " << algNameNodeName
         //<< std::endl;
@@ -3865,7 +3865,7 @@ bool L1GtTriggerMenuXmlParser::workXML(XERCES_CPP_NAMESPACE::XercesDOMParser* pa
     DOMDocument* doc = parser->getDocument();
     DOMNode* n1 = doc->getFirstChild();
 
-    if (n1 == 0) {
+    if (n1 == nullptr) {
 
         edm::LogError("L1GtTriggerMenuXmlParser") << "Error: Found no XML child" << std::endl;
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriterCore.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriterCore.cc
@@ -851,7 +851,7 @@ bool L1GtVhdlWriterCore::processAlgorithmMap(std::vector< std::map<int, std::str
             L1GtCondition const* cond = (chip.find(conditions.at(i)) == chip.end()) ? nullptr : chip.at(conditions.at(i));
 
             // check weather condition exists
-            if (cond!=NULL)
+            if (cond!=nullptr)
             {
                 newExpr << objType2Str_[(cond->objectType()).at(0)];
                 newExpr << "_" << condType2Str_[cond->condType()] << "(";
@@ -1811,7 +1811,7 @@ void L1GtVhdlWriterCore::initializeDeltaConditions()
 
         std::vector<L1GtObject> caloObjectsCp = caloObjects_;
 
-        while (caloObjectsCp.size()>0)
+        while (!caloObjectsCp.empty())
         {
             std::vector<L1GtObject>::iterator iter=caloObjectsCp.begin();
             L1GtObject firstPartner = (*iter);

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1CaloInputScaleTester.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1CaloInputScaleTester.h
@@ -27,13 +27,13 @@
 class L1CaloInputScaleTester : public edm::EDAnalyzer {
    public:
       explicit L1CaloInputScaleTester(const edm::ParameterSet&);
-      ~L1CaloInputScaleTester();
+      ~L1CaloInputScaleTester() override;
 
 
    private:
-      virtual void beginJob() ;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+      void beginJob() override ;
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
 
       // ----------member data ---------------------------
 };

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1CaloInputScalesGenerator.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1CaloInputScalesGenerator.h
@@ -27,13 +27,13 @@
 class L1CaloInputScalesGenerator : public edm::EDAnalyzer {
    public:
       explicit L1CaloInputScalesGenerator(const edm::ParameterSet&);
-      ~L1CaloInputScalesGenerator();
+      ~L1CaloInputScalesGenerator() override;
 
 
    private:
-      virtual void beginJob() ;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+      void beginJob() override ;
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
+      void endJob() override ;
 
       // ----------member data ---------------------------
 };

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1CaloInputScalesProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1CaloInputScalesProducer.h
@@ -36,7 +36,7 @@
 class L1CaloInputScalesProducer : public edm::ESProducer {
    public:
       L1CaloInputScalesProducer(const edm::ParameterSet&);
-      ~L1CaloInputScalesProducer();
+      ~L1CaloInputScalesProducer() override;
 
       //typedef std::shared_ptr<L1CaloInputScale> ReturnType;
 

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1MuGMTScalesProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1MuGMTScalesProducer.h
@@ -33,7 +33,7 @@
 class L1MuGMTScalesProducer : public edm::ESProducer {
 public:
   L1MuGMTScalesProducer(const edm::ParameterSet&);
-  ~L1MuGMTScalesProducer();
+  ~L1MuGMTScalesProducer() override;
   
   std::unique_ptr<L1MuGMTScales> produceL1MuGMTScales(const L1MuGMTScalesRcd&);
 

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1MuScalesTester.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1MuScalesTester.h
@@ -18,10 +18,10 @@ class L1MuScale;
 class L1MuScalesTester : public edm::EDAnalyzer {
    public:
       explicit L1MuScalesTester(const edm::ParameterSet&);
-      ~L1MuScalesTester();
+      ~L1MuScalesTester() override;
 
 
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
 
       void printScale(const L1MuScale*);
 

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerPtScaleOnlineProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerPtScaleOnlineProducer.h
@@ -33,9 +33,9 @@
 class L1MuTriggerPtScaleOnlineProducer : public L1ConfigOnlineProdBase<L1MuTriggerPtScaleRcd, L1MuTriggerPtScale> {
 public:
   L1MuTriggerPtScaleOnlineProducer(const edm::ParameterSet&);
-  ~L1MuTriggerPtScaleOnlineProducer();
+  ~L1MuTriggerPtScaleOnlineProducer() override;
   
-  std::shared_ptr<L1MuTriggerPtScale> newObject(const std::string& objectKey);
+  std::shared_ptr<L1MuTriggerPtScale> newObject(const std::string& objectKey) override;
 
 private:
   // ----------member data ---------------------------

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerPtScaleProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerPtScaleProducer.h
@@ -33,7 +33,7 @@
 class L1MuTriggerPtScaleProducer : public edm::ESProducer {
 public:
   L1MuTriggerPtScaleProducer(const edm::ParameterSet&);
-  ~L1MuTriggerPtScaleProducer();
+  ~L1MuTriggerPtScaleProducer() override;
   
   std::unique_ptr<L1MuTriggerPtScale> produceL1MuTriggerPtScale(const L1MuTriggerPtScaleRcd&);
 

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerScalesOnlineProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerScalesOnlineProducer.h
@@ -35,10 +35,10 @@
 class L1MuTriggerScalesOnlineProducer : public L1ConfigOnlineProdBase<L1MuTriggerScalesRcd, L1MuTriggerScales> {
 public:
   L1MuTriggerScalesOnlineProducer(const edm::ParameterSet&);
-  ~L1MuTriggerScalesOnlineProducer();
+  ~L1MuTriggerScalesOnlineProducer() override;
 
-  virtual std::shared_ptr<L1MuTriggerScales> newObject(
-	const std::string& objectKey ) ;
+  std::shared_ptr<L1MuTriggerScales> newObject(
+	const std::string& objectKey ) override ;
 
 private:
   // ----------member data ---------------------------

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerScalesProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1MuTriggerScalesProducer.h
@@ -33,7 +33,7 @@
 class L1MuTriggerScalesProducer : public edm::ESProducer {
 public:
   L1MuTriggerScalesProducer(const edm::ParameterSet&);
-  ~L1MuTriggerScalesProducer();
+  ~L1MuTriggerScalesProducer() override;
   
   std::unique_ptr<L1MuTriggerScales> produceL1MuTriggerScales(const L1MuTriggerScalesRcd&);
 

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1ScalesTester.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1ScalesTester.h
@@ -31,10 +31,10 @@
 class L1ScalesTester : public edm::EDAnalyzer {
    public:
       explicit L1ScalesTester(const edm::ParameterSet&);
-      ~L1ScalesTester();
+      ~L1ScalesTester() override;
 
 
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
    private:
       // ----------member data ---------------------------
 };

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1ScalesTrivialProducer.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1ScalesTrivialProducer.h
@@ -44,7 +44,7 @@
 class L1ScalesTrivialProducer : public edm::ESProducer {
 public:
   L1ScalesTrivialProducer(const edm::ParameterSet&);
-  ~L1ScalesTrivialProducer();
+  ~L1ScalesTrivialProducer() override;
   
   std::unique_ptr<L1CaloEtScale> produceEmScale(const L1EmEtScaleRcd&);
   std::unique_ptr<L1CaloEtScale> produceJetScale(const L1JetEtScaleRcd&);

--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloEcalScaleConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloEcalScaleConfigOnlineProd.cc
@@ -39,9 +39,9 @@ class L1CaloEcalScaleConfigOnlineProd :
   public L1ConfigOnlineProdBase< L1CaloEcalScaleRcd, L1CaloEcalScale > {
    public:
       L1CaloEcalScaleConfigOnlineProd(const edm::ParameterSet&);
-      ~L1CaloEcalScaleConfigOnlineProd();
+      ~L1CaloEcalScaleConfigOnlineProd() override;
 
-  virtual std::shared_ptr< L1CaloEcalScale > newObject(
+  std::shared_ptr< L1CaloEcalScale > newObject(
     const std::string& objectKey ) override ;
 
 
@@ -99,7 +99,7 @@ L1CaloEcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
      if(objectKey == "NULL" || objectKey == "")  // return default blank ecal scale	 
         return std::shared_ptr< L1CaloEcalScale >( ecalScale );
      if(objectKey == "IDENTITY"){  // return identity ecal scale  
-       ecalScale = 0;
+       ecalScale = nullptr;
        ecalScale = new L1CaloEcalScale(1);
        return std::shared_ptr< L1CaloEcalScale >( ecalScale);
      }

--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
@@ -41,11 +41,11 @@ class L1CaloHcalScaleConfigOnlineProd :
   public L1ConfigOnlineProdBase< L1CaloHcalScaleRcd, L1CaloHcalScale > {
    public:
       L1CaloHcalScaleConfigOnlineProd(const edm::ParameterSet& iConfig);
-      ~L1CaloHcalScaleConfigOnlineProd();
+      ~L1CaloHcalScaleConfigOnlineProd() override;
 
   std::shared_ptr< L1CaloHcalScale > produce(const L1CaloHcalScaleRcd& iRecord) override ;
 
-  virtual std::shared_ptr< L1CaloHcalScale > newObject(
+  std::shared_ptr< L1CaloHcalScale > newObject(
     const std::string& objectKey ) override ;
 
    private:
@@ -90,7 +90,7 @@ L1CaloHcalScaleConfigOnlineProd::~L1CaloHcalScaleConfigOnlineProd()
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 
-  if(caloTPG != 0)
+  if(caloTPG != nullptr)
     delete caloTPG;
 }
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1EmEtScaleOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1EmEtScaleOnlineProd.cc
@@ -34,9 +34,9 @@ class L1EmEtScaleOnlineProd :
   public L1ConfigOnlineProdBase< L1EmEtScaleRcd, L1CaloEtScale > {
    public:
       L1EmEtScaleOnlineProd(const edm::ParameterSet&);
-      ~L1EmEtScaleOnlineProd();
+      ~L1EmEtScaleOnlineProd() override;
 
-  virtual std::shared_ptr< L1CaloEtScale > newObject(
+  std::shared_ptr< L1CaloEtScale > newObject(
     const std::string& objectKey ) override ;
 
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1HfRingEtScaleOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1HfRingEtScaleOnlineProd.cc
@@ -34,9 +34,9 @@ class L1HfRingEtScaleOnlineProd :
   public L1ConfigOnlineProdBase< L1HfRingEtScaleRcd, L1CaloEtScale > {
    public:
       L1HfRingEtScaleOnlineProd(const edm::ParameterSet&);
-      ~L1HfRingEtScaleOnlineProd();
+      ~L1HfRingEtScaleOnlineProd() override;
 
-  virtual std::shared_ptr< L1CaloEtScale > newObject(
+  std::shared_ptr< L1CaloEtScale > newObject(
     const std::string& objectKey ) override ;
 
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1HtMissScaleOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1HtMissScaleOnlineProd.cc
@@ -34,9 +34,9 @@ class L1HtMissScaleOnlineProd :
   public L1ConfigOnlineProdBase< L1HtMissScaleRcd, L1CaloEtScale > {
    public:
       L1HtMissScaleOnlineProd(const edm::ParameterSet&);
-      ~L1HtMissScaleOnlineProd();
+      ~L1HtMissScaleOnlineProd() override;
 
-  virtual std::shared_ptr< L1CaloEtScale > newObject(
+  std::shared_ptr< L1CaloEtScale > newObject(
     const std::string& objectKey ) override ;
 
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1JetEtScaleOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1JetEtScaleOnlineProd.cc
@@ -34,9 +34,9 @@ class L1JetEtScaleOnlineProd :
   public L1ConfigOnlineProdBase< L1JetEtScaleRcd, L1CaloEtScale > {
    public:
       L1JetEtScaleOnlineProd(const edm::ParameterSet&);
-      ~L1JetEtScaleOnlineProd();
+      ~L1JetEtScaleOnlineProd() override;
 
-  virtual std::shared_ptr< L1CaloEtScale > newObject(
+  std::shared_ptr< L1CaloEtScale > newObject(
     const std::string& objectKey ) override ;
 
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerScaleKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1MuTriggerScaleKeysOnlineProd.cc
@@ -29,9 +29,9 @@ class L1MuTriggerScaleKeysOnlineProd : public L1ObjectKeysOnlineProdBase {
         }        
       }
 
-      ~L1MuTriggerScaleKeysOnlineProd() {}
+      ~L1MuTriggerScaleKeysOnlineProd() override {}
 
-      virtual void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+      void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
 
    private:    
     std::vector<std::string> m_objectTypes;

--- a/L1TriggerConfig/L1TConfigProducers/src/CaloParamsHelperO2O.h
+++ b/L1TriggerConfig/L1TConfigProducers/src/CaloParamsHelperO2O.h
@@ -58,7 +58,7 @@ namespace l1t {
     };
     ~CaloParamsHelperO2O() {}
 
-    bool isValidForStage1() {return 1; } 
+    bool isValidForStage1() {return true; } 
     bool isValidForStage2() {return (version_ >= 2); }
 
     L1CaloEtScale emScale() { return emScale_; }

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsObjectKeysOnlineProd.cc
@@ -6,10 +6,10 @@ class L1TCaloParamsObjectKeysOnlineProd : public L1ObjectKeysOnlineProdBaseExt {
 private:
 
 public:
-    virtual void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+    void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
 
     L1TCaloParamsObjectKeysOnlineProd(const edm::ParameterSet&);
-    ~L1TCaloParamsObjectKeysOnlineProd(void){}
+    ~L1TCaloParamsObjectKeysOnlineProd(void) override{}
 };
 
 L1TCaloParamsObjectKeysOnlineProd::L1TCaloParamsObjectKeysOnlineProd(const edm::ParameterSet& iConfig)

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
@@ -26,10 +26,10 @@ l1t::Mask>& );
     bool readCaloLayer2OnlineSettings(l1t::CaloParamsHelperO2O& paramsHelper, std::map<std::string, l1t::Parameter>& conf, std::map<std::string, 
 l1t::Mask>& );
 public:
-    virtual std::shared_ptr<l1t::CaloParams> newObject(const std::string& objectKey, const L1TCaloParamsO2ORcd& record) override ;
+    std::shared_ptr<l1t::CaloParams> newObject(const std::string& objectKey, const L1TCaloParamsO2ORcd& record) override ;
 
     L1TCaloParamsOnlineProd(const edm::ParameterSet&);
-    ~L1TCaloParamsOnlineProd(void){}
+    ~L1TCaloParamsOnlineProd(void) override{}
 };
 
 bool

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosObjectKeysOnlineProd.cc
@@ -6,10 +6,10 @@ class L1TGlobalPrescalesVetosObjectKeysOnlineProd : public L1ObjectKeysOnlinePro
 private:
 
 public:
-    virtual void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+    void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
 
     L1TGlobalPrescalesVetosObjectKeysOnlineProd(const edm::ParameterSet&);
-    ~L1TGlobalPrescalesVetosObjectKeysOnlineProd(void){}
+    ~L1TGlobalPrescalesVetosObjectKeysOnlineProd(void) override{}
 };
 
 L1TGlobalPrescalesVetosObjectKeysOnlineProd::L1TGlobalPrescalesVetosObjectKeysOnlineProd(const edm::ParameterSet& iConfig)

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosOnlineProd.cc
@@ -29,10 +29,10 @@ class L1TGlobalPrescalesVetosOnlineProd : public L1ConfigOnlineProdBaseExt<L1TGl
 private:
     int xmlModel;
 public:
-    virtual std::shared_ptr<L1TGlobalPrescalesVetos> newObject(const std::string& objectKey, const L1TGlobalPrescalesVetosO2ORcd& record) override ;
+    std::shared_ptr<L1TGlobalPrescalesVetos> newObject(const std::string& objectKey, const L1TGlobalPrescalesVetosO2ORcd& record) override ;
 
     L1TGlobalPrescalesVetosOnlineProd(const edm::ParameterSet&);
-    ~L1TGlobalPrescalesVetosOnlineProd(void){}
+    ~L1TGlobalPrescalesVetosOnlineProd(void) override{}
 };
 
 L1TGlobalPrescalesVetosOnlineProd::L1TGlobalPrescalesVetosOnlineProd(const edm::ParameterSet& iConfig) : L1ConfigOnlineProdBaseExt<L1TGlobalPrescalesVetosO2ORcd,L1TGlobalPrescalesVetos>(iConfig) {
@@ -361,7 +361,7 @@ if( xmlModel > 2016 ){
             first = 0;
             last = 3563;
         } else {
-            char *dash = 0;
+            char *dash = nullptr;
             first = strtoul(s2.data(), &dash, 0);
             while( *dash != '\0' && *dash != '-' ) ++dash;
             last  = (*dash != '\0' ? strtoul(++dash, &dash, 0) : first);

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelObjectKeysOnlineProd.cc
@@ -6,10 +6,10 @@ class L1TMuonBarrelObjectKeysOnlineProd : public L1ObjectKeysOnlineProdBaseExt {
 private:
 
 public:
-    virtual void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+    void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
 
     L1TMuonBarrelObjectKeysOnlineProd(const edm::ParameterSet&);
-    ~L1TMuonBarrelObjectKeysOnlineProd(void){}
+    ~L1TMuonBarrelObjectKeysOnlineProd(void) override{}
 };
 
 L1TMuonBarrelObjectKeysOnlineProd::L1TMuonBarrelObjectKeysOnlineProd(const edm::ParameterSet& iConfig)

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelParamsOnlineProd.cc
@@ -16,10 +16,10 @@ using namespace XERCES_CPP_NAMESPACE;
 class L1TMuonBarrelParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonBarrelParamsO2ORcd,L1TMuonBarrelParams> {
 private:
 public:
-    virtual std::shared_ptr<L1TMuonBarrelParams> newObject(const std::string& objectKey, const L1TMuonBarrelParamsO2ORcd& record) override ;
+    std::shared_ptr<L1TMuonBarrelParams> newObject(const std::string& objectKey, const L1TMuonBarrelParamsO2ORcd& record) override ;
 
     L1TMuonBarrelParamsOnlineProd(const edm::ParameterSet&);
-    ~L1TMuonBarrelParamsOnlineProd(void){}
+    ~L1TMuonBarrelParamsOnlineProd(void) override{}
 };
 
 L1TMuonBarrelParamsOnlineProd::L1TMuonBarrelParamsOnlineProd(const edm::ParameterSet& iConfig) : L1ConfigOnlineProdBaseExt<L1TMuonBarrelParamsO2ORcd,L1TMuonBarrelParams>(iConfig) {}

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndcapObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndcapObjectKeysOnlineProd.cc
@@ -6,10 +6,10 @@ class L1TMuonEndcapObjectKeysOnlineProd : public L1ObjectKeysOnlineProdBaseExt {
 private:
 
 public:
-    virtual void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+    void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
 
     L1TMuonEndcapObjectKeysOnlineProd(const edm::ParameterSet&);
-    ~L1TMuonEndcapObjectKeysOnlineProd(void){}
+    ~L1TMuonEndcapObjectKeysOnlineProd(void) override{}
 };
 
 L1TMuonEndcapObjectKeysOnlineProd::L1TMuonEndcapObjectKeysOnlineProd(const edm::ParameterSet& iConfig)

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndcapParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndcapParamsOnlineProd.cc
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <fstream>
-#include <time.h>
+#include <ctime>
 #include <string>
 #include <map>
 
@@ -16,10 +16,10 @@
 class L1TMuonEndcapParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonEndcapParamsO2ORcd,L1TMuonEndCapParams> {
 private:
 public:
-    virtual std::shared_ptr<L1TMuonEndCapParams> newObject(const std::string& objectKey, const L1TMuonEndcapParamsO2ORcd& record) override ;
+    std::shared_ptr<L1TMuonEndCapParams> newObject(const std::string& objectKey, const L1TMuonEndcapParamsO2ORcd& record) override ;
 
     L1TMuonEndcapParamsOnlineProd(const edm::ParameterSet&);
-    ~L1TMuonEndcapParamsOnlineProd(void){}
+    ~L1TMuonEndcapParamsOnlineProd(void) override{}
 };
 
 L1TMuonEndcapParamsOnlineProd::L1TMuonEndcapParamsOnlineProd(const edm::ParameterSet& iConfig) : L1ConfigOnlineProdBaseExt<L1TMuonEndcapParamsO2ORcd,L1TMuonEndCapParams>(iConfig){}

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndcapParamsOnlineProxy.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndcapParamsOnlineProxy.cc
@@ -15,7 +15,7 @@ public:
     std::shared_ptr<L1TMuonEndCapParams> produce(const L1TMuonEndcapParamsO2ORcd& record);
 
     L1TMuonEndcapParamsOnlineProxy(const edm::ParameterSet&);
-    ~L1TMuonEndcapParamsOnlineProxy(void){}
+    ~L1TMuonEndcapParamsOnlineProxy(void) override{}
 };
 
 L1TMuonEndcapParamsOnlineProxy::L1TMuonEndcapParamsOnlineProxy(const edm::ParameterSet& iConfig) : edm::ESProducer() {

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalObjectKeysOnlineProd.cc
@@ -6,10 +6,10 @@ class L1TMuonGlobalObjectKeysOnlineProd : public L1ObjectKeysOnlineProdBaseExt {
 private:
 
 public:
-    virtual void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+    void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
 
     L1TMuonGlobalObjectKeysOnlineProd(const edm::ParameterSet&);
-    ~L1TMuonGlobalObjectKeysOnlineProd(void){}
+    ~L1TMuonGlobalObjectKeysOnlineProd(void) override{}
 };
 
 L1TMuonGlobalObjectKeysOnlineProd::L1TMuonGlobalObjectKeysOnlineProd(const edm::ParameterSet& iConfig)

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalParamsOnlineProd.cc
@@ -15,10 +15,10 @@
 class L1TMuonGlobalParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonGlobalParamsO2ORcd,L1TMuonGlobalParams> {
 private:
 public:
-    virtual std::shared_ptr<L1TMuonGlobalParams> newObject(const std::string& objectKey, const L1TMuonGlobalParamsO2ORcd &record) override ;
+    std::shared_ptr<L1TMuonGlobalParams> newObject(const std::string& objectKey, const L1TMuonGlobalParamsO2ORcd &record) override ;
 
     L1TMuonGlobalParamsOnlineProd(const edm::ParameterSet&);
-    ~L1TMuonGlobalParamsOnlineProd(void){}
+    ~L1TMuonGlobalParamsOnlineProd(void) override{}
 };
 
 L1TMuonGlobalParamsOnlineProd::L1TMuonGlobalParamsOnlineProd(const edm::ParameterSet& iConfig) : L1ConfigOnlineProdBaseExt<L1TMuonGlobalParamsO2ORcd,L1TMuonGlobalParams>(iConfig) {}

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapObjectKeysOnlineProd.cc
@@ -6,10 +6,10 @@ class L1TMuonOverlapObjectKeysOnlineProd : public L1ObjectKeysOnlineProdBaseExt 
 private:
 
 public:
-    virtual void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+    void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
 
     L1TMuonOverlapObjectKeysOnlineProd(const edm::ParameterSet&);
-    ~L1TMuonOverlapObjectKeysOnlineProd(void){}
+    ~L1TMuonOverlapObjectKeysOnlineProd(void) override{}
 };
 
 L1TMuonOverlapObjectKeysOnlineProd::L1TMuonOverlapObjectKeysOnlineProd(const edm::ParameterSet& iConfig)

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProd.cc
@@ -10,10 +10,10 @@
 class L1TMuonOverlapParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonOverlapParamsO2ORcd,L1TMuonOverlapParams> {
 private:
 public:
-    virtual std::shared_ptr<L1TMuonOverlapParams> newObject(const std::string& objectKey, const L1TMuonOverlapParamsO2ORcd& record) override ;
+    std::shared_ptr<L1TMuonOverlapParams> newObject(const std::string& objectKey, const L1TMuonOverlapParamsO2ORcd& record) override ;
 
     L1TMuonOverlapParamsOnlineProd(const edm::ParameterSet&);
-    ~L1TMuonOverlapParamsOnlineProd(void){}
+    ~L1TMuonOverlapParamsOnlineProd(void) override{}
 };
 
 L1TMuonOverlapParamsOnlineProd::L1TMuonOverlapParamsOnlineProd(const edm::ParameterSet& iConfig) : L1ConfigOnlineProdBaseExt<L1TMuonOverlapParamsO2ORcd,L1TMuonOverlapParams>(iConfig) {}

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProxy.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProxy.cc
@@ -14,7 +14,7 @@ public:
     std::shared_ptr<L1TMuonOverlapParams> produce(const L1TMuonOverlapParamsO2ORcd& record);
 
     L1TMuonOverlapParamsOnlineProxy(const edm::ParameterSet&);
-    ~L1TMuonOverlapParamsOnlineProxy(void){}
+    ~L1TMuonOverlapParamsOnlineProxy(void) override{}
 };
 
 L1TMuonOverlapParamsOnlineProxy::L1TMuonOverlapParamsOnlineProxy(const edm::ParameterSet& iConfig) : edm::ESProducer() {

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TUtmTriggerMenuObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TUtmTriggerMenuObjectKeysOnlineProd.cc
@@ -6,10 +6,10 @@ class L1TUtmTriggerMenuObjectKeysOnlineProd : public L1ObjectKeysOnlineProdBaseE
 private:
 
 public:
-    virtual void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+    void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
 
     L1TUtmTriggerMenuObjectKeysOnlineProd(const edm::ParameterSet&);
-    ~L1TUtmTriggerMenuObjectKeysOnlineProd(void){}
+    ~L1TUtmTriggerMenuObjectKeysOnlineProd(void) override{}
 };
 
 L1TUtmTriggerMenuObjectKeysOnlineProd::L1TUtmTriggerMenuObjectKeysOnlineProd(const edm::ParameterSet& iConfig)

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TUtmTriggerMenuOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TUtmTriggerMenuOnlineProd.cc
@@ -20,10 +20,10 @@
 class L1TUtmTriggerMenuOnlineProd : public L1ConfigOnlineProdBaseExt<L1TUtmTriggerMenuO2ORcd,L1TUtmTriggerMenu> {
 private:
 public:
-    virtual std::shared_ptr<L1TUtmTriggerMenu> newObject(const std::string& objectKey, const L1TUtmTriggerMenuO2ORcd& record) override ;
+    std::shared_ptr<L1TUtmTriggerMenu> newObject(const std::string& objectKey, const L1TUtmTriggerMenuO2ORcd& record) override ;
 
     L1TUtmTriggerMenuOnlineProd(const edm::ParameterSet&);
-    ~L1TUtmTriggerMenuOnlineProd(void){}
+    ~L1TUtmTriggerMenuOnlineProd(void) override{}
 };
 
 L1TUtmTriggerMenuOnlineProd::L1TUtmTriggerMenuOnlineProd(const edm::ParameterSet& iConfig) : L1ConfigOnlineProdBaseExt<L1TUtmTriggerMenuO2ORcd,L1TUtmTriggerMenu>(iConfig) {}

--- a/L1TriggerConfig/L1TConfigProducers/src/OnlineDBqueryHelper.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/OnlineDBqueryHelper.cc
@@ -6,7 +6,7 @@ std::map<std::string,std::string> l1t::OnlineDBqueryHelper::fetch(
         const std::string              &key,
         l1t::OMDSReader                &m_omdsReader)
     {
-        if( queryColumns.size() == 0 || table.length() == 0 )
+        if( queryColumns.empty() || table.length() == 0 )
            return std::map<std::string,std::string>();
 
         l1t::OMDSReader::QueryResults queryResult =

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTChannelMaskOnlineProd.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTChannelMaskOnlineProd.cc
@@ -39,9 +39,9 @@ class L1RCTChannelMaskOnlineProd :
    public:
   L1RCTChannelMaskOnlineProd(const edm::ParameterSet& iConfig)
     : L1ConfigOnlineProdBase< L1RCTChannelMaskRcd, L1RCTChannelMask > (iConfig) {}
-  ~L1RCTChannelMaskOnlineProd() {}
+  ~L1RCTChannelMaskOnlineProd() override {}
   
-  virtual std::shared_ptr< L1RCTChannelMask > newObject(const std::string& objectKey ) override ;
+  std::shared_ptr< L1RCTChannelMask > newObject(const std::string& objectKey ) override ;
 
 
    private:

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTChannelMaskTester.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTChannelMaskTester.cc
@@ -43,9 +43,9 @@ class L1RCTChannelMaskTester: public edm::EDAnalyzer {
 public:
     explicit L1RCTChannelMaskTester(const edm::ParameterSet&) {
     }
-    virtual ~L1RCTChannelMaskTester() {
+    ~L1RCTChannelMaskTester() override {
     }
-    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 };
 
@@ -63,7 +63,7 @@ void L1RCTChannelMaskTester::analyze(const edm::Event& iEvent,
             edm::eventsetup::EventSetupRecordKey::TypeTag::findType(
                     "L1RCTNoisyChannelMaskRcd"));
 
-    if (evSetup.find(recordKey) == 0) {
+    if (evSetup.find(recordKey) == nullptr) {
         //record not found
         std::cout << "\nRecord \"" << "L1RCTNoisyChannelMaskRcd"
                 << "\" does not exist.\n" << std::endl;

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTOmdsFedVectorProducer.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTOmdsFedVectorProducer.cc
@@ -55,7 +55,7 @@
 class L1RCTOmdsFedVectorProducer : public edm::ESProducer {
 public:
   L1RCTOmdsFedVectorProducer(const edm::ParameterSet&);
-  ~L1RCTOmdsFedVectorProducer();
+  ~L1RCTOmdsFedVectorProducer() override;
   
   typedef std::shared_ptr<RunInfo> ReturnType;
   

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTParametersOnlineProd.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTParametersOnlineProd.cc
@@ -36,9 +36,9 @@ class L1RCTParametersOnlineProd :
   public L1ConfigOnlineProdBase< L1RCTParametersRcd, L1RCTParameters > {
    public:
       L1RCTParametersOnlineProd(const edm::ParameterSet&);
-      ~L1RCTParametersOnlineProd();
+      ~L1RCTParametersOnlineProd() override;
 
-  virtual std::shared_ptr< L1RCTParameters > newObject(
+  std::shared_ptr< L1RCTParameters > newObject(
     const std::string& objectKey ) override ;
 
   void fillScaleFactors(

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTParametersTester.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTParametersTester.cc
@@ -45,8 +45,8 @@ using std::endl;
 class L1RCTParametersTester : public edm::EDAnalyzer {
 public:
   explicit L1RCTParametersTester(const edm::ParameterSet&) {}
-  virtual  ~L1RCTParametersTester() {}
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;  
+   ~L1RCTParametersTester() override {}
+      void analyze(const edm::Event&, const edm::EventSetup&) override;  
 
 };
 

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCT_RSKeysOnlineProd.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCT_RSKeysOnlineProd.cc
@@ -23,7 +23,7 @@
 #include "CondTools/L1Trigger/interface/L1ObjectKeysOnlineProdBase.h"
 #include <sstream>
 #include "CoralBase/TimeStamp.h"
-#include <math.h>
+#include <cmath>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -34,9 +34,9 @@
 class L1RCT_RSKeysOnlineProd : public L1ObjectKeysOnlineProdBase {
 public: 
   L1RCT_RSKeysOnlineProd(const edm::ParameterSet& iConfig);
-  ~L1RCT_RSKeysOnlineProd() {}
+  ~L1RCT_RSKeysOnlineProd() override {}
 
-      virtual void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+      void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
    private:
       // ----------member data ---------------------------
        bool m_enableL1RCTChannelMask;

--- a/L1TriggerConfig/RCTConfigProducers/src/RCTConfigProducers.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/RCTConfigProducers.cc
@@ -40,7 +40,7 @@
 class RCTConfigProducers : public edm::ESProducer {
 public:
   RCTConfigProducers(const edm::ParameterSet&);
-  ~RCTConfigProducers();
+  ~RCTConfigProducers() override;
   
   //typedef std::shared_ptr<L1RCTParameters> ReturnType;
   //typedef edm::ESProducts< std::shared_ptr<L1RCTParameters>, std::shared_ptr<L1RCTChannelMask> > ReturnType;

--- a/L1TriggerConfig/RCTConfigProducers/src/RCTObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/RCTObjectKeysOnlineProd.cc
@@ -32,9 +32,9 @@
 class RCTObjectKeysOnlineProd : public L1ObjectKeysOnlineProdBase {
    public:
       RCTObjectKeysOnlineProd(const edm::ParameterSet&);
-      ~RCTObjectKeysOnlineProd();
+      ~RCTObjectKeysOnlineProd() override;
 
-      virtual void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+      void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
    private:
       // ----------member data ---------------------------
 };

--- a/L1TriggerConfig/RPCTriggerConfig/src/L1RPCBxOrConfigOnlineProd.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/L1RPCBxOrConfigOnlineProd.cc
@@ -29,9 +29,9 @@ class L1RPCBxOrConfigOnlineProd : public L1ConfigOnlineProdBase< L1RPCBxOrConfig
 							   L1RPCBxOrConfig > {
    public:
       L1RPCBxOrConfigOnlineProd(const edm::ParameterSet&);
-      ~L1RPCBxOrConfigOnlineProd();
+      ~L1RPCBxOrConfigOnlineProd() override;
 
-  virtual std::shared_ptr< L1RPCBxOrConfig > newObject(
+  std::shared_ptr< L1RPCBxOrConfig > newObject(
     const std::string& objectKey ) override ;
 
    private:

--- a/L1TriggerConfig/RPCTriggerConfig/src/L1RPCConeDefinitionOnlineProd.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/L1RPCConeDefinitionOnlineProd.cc
@@ -36,9 +36,9 @@ class L1RPCConeDefinitionOnlineProd : public L1ConfigOnlineProdBase<
   L1RPCConeDefinitionRcd, L1RPCConeDefinition > {
    public:
       L1RPCConeDefinitionOnlineProd(const edm::ParameterSet&);
-      ~L1RPCConeDefinitionOnlineProd();
+      ~L1RPCConeDefinitionOnlineProd() override;
 
-  virtual std::shared_ptr< L1RPCConeDefinition > newObject(
+  std::shared_ptr< L1RPCConeDefinition > newObject(
     const std::string& objectKey ) override ;
 
    private:

--- a/L1TriggerConfig/RPCTriggerConfig/src/L1RPCConeDefinitionProducer.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/L1RPCConeDefinitionProducer.cc
@@ -37,7 +37,7 @@
 class L1RPCConeDefinitionProducer : public edm::ESProducer {
    public:
       L1RPCConeDefinitionProducer(const edm::ParameterSet&);
-      ~L1RPCConeDefinitionProducer();
+      ~L1RPCConeDefinitionProducer() override;
 
       typedef std::shared_ptr<L1RPCConeDefinition> ReturnType;
 

--- a/L1TriggerConfig/RPCTriggerConfig/src/L1RPCHsbConfigOnlineProd.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/L1RPCHsbConfigOnlineProd.cc
@@ -29,9 +29,9 @@ class L1RPCHsbConfigOnlineProd : public L1ConfigOnlineProdBase< L1RPCHsbConfigRc
 							   L1RPCHsbConfig > {
    public:
       L1RPCHsbConfigOnlineProd(const edm::ParameterSet&);
-      ~L1RPCHsbConfigOnlineProd();
+      ~L1RPCHsbConfigOnlineProd() override;
 
-  virtual std::shared_ptr< L1RPCHsbConfig > newObject(
+  std::shared_ptr< L1RPCHsbConfig > newObject(
     const std::string& objectKey ) override ;
 
    private:

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCConfigOnlineProd.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCConfigOnlineProd.cc
@@ -36,9 +36,9 @@ class RPCConfigOnlineProd : public L1ConfigOnlineProdBase< L1RPCConfigRcd,
 							   L1RPCConfig > {
    public:
       RPCConfigOnlineProd(const edm::ParameterSet&);
-      ~RPCConfigOnlineProd();
+      ~RPCConfigOnlineProd() override;
 
-  virtual std::shared_ptr< L1RPCConfig > newObject(
+  std::shared_ptr< L1RPCConfig > newObject(
     const std::string& objectKey ) override ;
 
    private:

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCObjectKeysOnlineProd.cc
@@ -31,9 +31,9 @@
 class RPCObjectKeysOnlineProd : public L1ObjectKeysOnlineProdBase {
    public:
       RPCObjectKeysOnlineProd(const edm::ParameterSet&);
-      ~RPCObjectKeysOnlineProd();
+      ~RPCObjectKeysOnlineProd() override;
 
-      virtual void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
+      void fillObjectKeys( ReturnType pL1TriggerKey ) override ;
    private:
       // ----------member data ---------------------------
   bool m_enableL1RPCConfig ;

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerBxOrConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerBxOrConfig.cc
@@ -38,7 +38,7 @@
 class RPCTriggerBxOrConfig : public edm::ESProducer {
    public:
       RPCTriggerBxOrConfig(const edm::ParameterSet&);
-      ~RPCTriggerBxOrConfig();
+      ~RPCTriggerBxOrConfig() override;
 
       typedef std::unique_ptr<L1RPCBxOrConfig> ReturnType;
 

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerConfig.cc
@@ -42,7 +42,7 @@
 class RPCTriggerConfig : public edm::ESProducer {
    public:
       RPCTriggerConfig(const edm::ParameterSet&);
-      ~RPCTriggerConfig();
+      ~RPCTriggerConfig() override;
 
       typedef std::unique_ptr<L1RPCConfig> ReturnType;
 

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerHsbConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerHsbConfig.cc
@@ -38,7 +38,7 @@
 class RPCTriggerHsbConfig : public edm::ESProducer {
    public:
       RPCTriggerHsbConfig(const edm::ParameterSet&);
-      ~RPCTriggerHsbConfig();
+      ~RPCTriggerHsbConfig() override;
 
       typedef std::unique_ptr<L1RPCHsbConfig> ReturnType;
 

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerHwConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerHwConfig.cc
@@ -38,7 +38,7 @@
 class RPCTriggerHwConfig : public edm::ESProducer {
    public:
       RPCTriggerHwConfig(const edm::ParameterSet&);
-      ~RPCTriggerHwConfig();
+      ~RPCTriggerHwConfig() override;
 
       typedef std::unique_ptr<L1RPCHwConfig> ReturnType;
 

--- a/L1TriggerConfig/Utilities/src/L1KeyListWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1KeyListWriter.cc
@@ -17,10 +17,10 @@
 
 class L1KeyListWriter : public edm::EDAnalyzer {
 public:
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     explicit L1KeyListWriter(const edm::ParameterSet&) : edm::EDAnalyzer(){}
-    virtual ~L1KeyListWriter(void){}
+    ~L1KeyListWriter(void) override{}
 };
 
 void L1KeyListWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup){

--- a/L1TriggerConfig/Utilities/src/L1KeyWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1KeyWriter.cc
@@ -17,10 +17,10 @@
 
 class L1KeyWriter : public edm::EDAnalyzer {
 public:
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     explicit L1KeyWriter(const edm::ParameterSet&) : edm::EDAnalyzer(){}
-    virtual ~L1KeyWriter(void){}
+    ~L1KeyWriter(void) override{}
 };
 
 void L1KeyWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup){

--- a/L1TriggerConfig/Utilities/src/L1MenuReader.cc
+++ b/L1TriggerConfig/Utilities/src/L1MenuReader.cc
@@ -20,10 +20,10 @@ using namespace std;
 
 class L1MenuReader : public edm::EDAnalyzer {
 public:
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     explicit L1MenuReader(const edm::ParameterSet&) : edm::EDAnalyzer(){}
-    virtual ~L1MenuReader(void){}
+    ~L1MenuReader(void) override{}
 };
 
 void L1MenuReader::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup){

--- a/L1TriggerConfig/Utilities/src/L1MenuWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1MenuWriter.cc
@@ -20,12 +20,12 @@ class L1MenuWriter : public edm::EDAnalyzer {
 private:
     bool isO2Opayload;
 public:
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     explicit L1MenuWriter(const edm::ParameterSet& pset) : edm::EDAnalyzer(){
        isO2Opayload = pset.getUntrackedParameter<bool>("isO2Opayload",  false);
     }
-    virtual ~L1MenuWriter(void){}
+    ~L1MenuWriter(void) override{}
 };
 
 void L1MenuWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup){

--- a/L1TriggerConfig/Utilities/src/L1TCaloParamsUpdater.cc
+++ b/L1TriggerConfig/Utilities/src/L1TCaloParamsUpdater.cc
@@ -18,10 +18,10 @@
 
 class L1TCaloParamsUpdater : public edm::EDAnalyzer {
 public:
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     explicit L1TCaloParamsUpdater(const edm::ParameterSet&) : edm::EDAnalyzer(){}
-    virtual ~L1TCaloParamsUpdater(void){}
+    ~L1TCaloParamsUpdater(void) override{}
 };
 
 void L1TCaloParamsUpdater::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup){

--- a/L1TriggerConfig/Utilities/src/L1TCaloParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TCaloParamsViewer.cc
@@ -23,7 +23,7 @@ private:
     std::string hash(void *buf, size_t len) const ;
 
 public:
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     explicit L1TCaloParamsViewer(const edm::ParameterSet& pset) : edm::EDAnalyzer(){
        printPUSParams   = pset.getUntrackedParameter<bool>("printPUSParams",  false);
@@ -34,11 +34,11 @@ public:
        printEgIsoLUT    = pset.getUntrackedParameter<bool>("printEgIsoLUT",   false);
     }
 
-    virtual ~L1TCaloParamsViewer(void){}
+    ~L1TCaloParamsViewer(void) override{}
 };
 
 #include <openssl/sha.h>
-#include <math.h>
+#include <cmath>
 #include <iostream>
 using namespace std;
 
@@ -70,7 +70,7 @@ void L1TCaloParamsViewer::analyze(const edm::Event& iEvent, const edm::EventSetu
     evSetup.get<L1TCaloParamsRcd>().get( handle1 ) ;
     boost::shared_ptr<l1t::CaloParams> ptr(new l1t::CaloParams(*(handle1.product ())));
 
-    l1t::CaloParamsHelper *ptr1 = 0;
+    l1t::CaloParamsHelper *ptr1 = nullptr;
     ptr1 = (l1t::CaloParamsHelper*) (&(*ptr));
 
     edm::LogInfo("")<<"L1TCaloParamsViewer:";
@@ -99,7 +99,7 @@ void L1TCaloParamsViewer::analyze(const edm::Event& iEvent, const edm::EventSetu
         if( printPUSParams ) cout<<"   "<<ceil(2*pusParams[i])<<endl;
     }
 
-    if( ptr1->regionPUSParams().size() )
+    if( !ptr1->regionPUSParams().empty() )
         cout << hash(pusParams, sizeof(float)*ptr1->regionPUSParams().size()) << endl;
     else cout<<endl;
 
@@ -181,7 +181,7 @@ void L1TCaloParamsViewer::analyze(const edm::Event& iEvent, const edm::EventSetu
     float egPUSParams[ptr1->egPUSParams().size()];
     for(unsigned int i=0; i<ptr1->egPUSParams().size(); i++) egPUSParams[i] = ptr1->egPUSParams()[i];
 
-    if( ptr1->egPUSParams().size() )
+    if( !ptr1->egPUSParams().empty() )
        cout << hash( egPUSParams, sizeof(float)*ptr1->egPUSParams().size() ) << endl;
     else cout<<endl;
 
@@ -189,7 +189,7 @@ void L1TCaloParamsViewer::analyze(const edm::Event& iEvent, const edm::EventSetu
     double egCalibrationParams[ptr1->egCalibrationParams().size()];
     for(unsigned int i=0; i<ptr1->egCalibrationParams().size(); i++) egCalibrationParams[i] = ptr1->egCalibrationParams()[i];
 
-    if( ptr1->egCalibrationParams().size() )
+    if( !ptr1->egCalibrationParams().empty() )
        cout << hash( egCalibrationParams, sizeof(double)*ptr1->egCalibrationParams().size() ) << endl;
     else cout<<endl;
 
@@ -259,7 +259,7 @@ void L1TCaloParamsViewer::analyze(const edm::Event& iEvent, const edm::EventSetu
     float tauPUSParams[ptr1->tauPUSParams().size()];
     for(unsigned int i=0; i<ptr1->tauPUSParams().size(); i++) tauPUSParams[i] = ptr1->tauPUSParams()[i];
 
-    if( ptr1->tauPUSParams().size() )
+    if( !ptr1->tauPUSParams().empty() )
         cout << hash( tauPUSParams, sizeof(float)*ptr1->tauPUSParams().size()  ) << endl;
     else cout<<endl;
 
@@ -273,7 +273,7 @@ void L1TCaloParamsViewer::analyze(const edm::Event& iEvent, const edm::EventSetu
     float jetCalibrationParams[ptr1->jetCalibrationParams().size()]; // deliberately drop double precision
     for(unsigned int i=0; i<ptr1->jetCalibrationParams().size(); i++) jetCalibrationParams[i] = ptr1->jetCalibrationParams()[i];
 
-    if( ptr1->jetCalibrationParams().size() ){
+    if( !ptr1->jetCalibrationParams().empty() ){
         cout << hash( jetCalibrationParams, sizeof(float)*ptr1->jetCalibrationParams().size() ) << endl;
         if( printJetCalibPar )
             for(unsigned int i=0; i<ptr1->jetCalibrationParams().size(); i++)

--- a/L1TriggerConfig/Utilities/src/L1TCaloParamsWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TCaloParamsWriter.cc
@@ -19,12 +19,12 @@ class L1TCaloStage2ParamsWriter : public edm::EDAnalyzer {
 private:
     bool isO2Opayload;
 public:
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     explicit L1TCaloStage2ParamsWriter(const edm::ParameterSet& pset) : edm::EDAnalyzer(){
        isO2Opayload = pset.getUntrackedParameter<bool>("isO2Opayload",  false);
     }
-    virtual ~L1TCaloStage2ParamsWriter(void){}
+    ~L1TCaloStage2ParamsWriter(void) override{}
 };
 
 void L1TCaloStage2ParamsWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup){

--- a/L1TriggerConfig/Utilities/src/L1TGlobalPrescalesVetosViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TGlobalPrescalesVetosViewer.cc
@@ -19,7 +19,7 @@ private:
     std::string hash(void *buf, size_t len) const ;
 
 public:
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     explicit L1TGlobalPrescalesVetosViewer(const edm::ParameterSet& pset) : edm::EDAnalyzer(){
        prescale_table_verbosity = pset.getUntrackedParameter<int32_t>("prescale_table_verbosity", 0);
@@ -27,11 +27,11 @@ public:
        veto_verbosity           = pset.getUntrackedParameter<int32_t>("veto_verbosity",           0);
     }
 
-    virtual ~L1TGlobalPrescalesVetosViewer(void){}
+    ~L1TGlobalPrescalesVetosViewer(void) override{}
 };
 
 #include <openssl/sha.h>
-#include <math.h>
+#include <cmath>
 #include <iostream>
 using namespace std;
 
@@ -116,7 +116,7 @@ void L1TGlobalPrescalesVetosViewer::analyze(const edm::Event& iEvent, const edm:
             for(size_t i=0; i<it->second.size(); i++)
                 masks[ i ] = it->second[i];
             cout << "  bxmask_map_[" << it->first << "][" << it->second.size() << "] = ";
-            if( it->second.size() )
+            if( !it->second.empty() )
                 cout << hash( masks, sizeof(int)*it->second.size() ) << endl;
             else cout << 0 << endl;
         }
@@ -144,7 +144,7 @@ void L1TGlobalPrescalesVetosViewer::analyze(const edm::Event& iEvent, const edm:
     }
     cout << "  veto_[" << (ptr->veto_).size() << "]              = ";
     if( veto_verbosity == 0 ){
-        if( (ptr->veto_).size() ){
+        if( !(ptr->veto_).empty() ){
             cout << hash( veto_, sizeof(int)*(ptr->veto_).size() );
             if( veto_allZeros ) cout << " (all zeros)" << endl;
             else cout << endl;
@@ -155,14 +155,14 @@ void L1TGlobalPrescalesVetosViewer::analyze(const edm::Event& iEvent, const edm:
     int exp_ints_[ (ptr->exp_ints_).size() ];
     for(size_t i=0; i<(ptr->exp_ints_).size(); i++) exp_ints_[i] = (ptr->exp_ints_)[i];
     cout << "  exp_ints_[" << (ptr->exp_ints_).size() << "]            = ";
-    if( (ptr->exp_ints_).size() )
+    if( !(ptr->exp_ints_).empty() )
         cout << hash( exp_ints_, sizeof(int)*(ptr->exp_ints_).size() ) << endl;
     else cout << 0 << endl;
 
     int exp_doubles_[ (ptr->exp_doubles_).size() ];
     for(size_t i=0; i<(ptr->exp_doubles_).size(); i++) exp_ints_[i] = (ptr->exp_doubles_)[i];
     cout << "  exp_doubles_[" << (ptr->exp_doubles_).size() << "]         = ";
-    if( (ptr->exp_doubles_).size() )
+    if( !(ptr->exp_doubles_).empty() )
         cout << hash( exp_doubles_, sizeof(int)*(ptr->exp_doubles_).size() ) << endl;
     else cout << 0 << endl;
 }

--- a/L1TriggerConfig/Utilities/src/L1TGlobalPrescalesVetosWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TGlobalPrescalesVetosWriter.cc
@@ -19,12 +19,12 @@ class L1TGlobalPrescalesVetosWriter : public edm::EDAnalyzer {
 private:
     bool isO2Opayload;
 public:
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     explicit L1TGlobalPrescalesVetosWriter(const edm::ParameterSet &pset) : edm::EDAnalyzer(){
        isO2Opayload = pset.getUntrackedParameter<bool>("isO2Opayload",  false);
     }
-    virtual ~L1TGlobalPrescalesVetosWriter(void){}
+    ~L1TGlobalPrescalesVetosWriter(void) override{}
 };
 
 void L1TGlobalPrescalesVetosWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup){

--- a/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsWriter.cc
@@ -19,12 +19,12 @@ class L1TMuonBarrelParamsWriter : public edm::EDAnalyzer {
 private:
     bool isO2Opayload;
 public:
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     explicit L1TMuonBarrelParamsWriter(const edm::ParameterSet &pset) : edm::EDAnalyzer(){
        isO2Opayload = pset.getUntrackedParameter<bool>("isO2Opayload",  false);
     }
-    virtual ~L1TMuonBarrelParamsWriter(void){}
+    ~L1TMuonBarrelParamsWriter(void) override{}
 };
 
 void L1TMuonBarrelParamsWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup){

--- a/L1TriggerConfig/Utilities/src/L1TMuonEndcapViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonEndcapViewer.cc
@@ -22,10 +22,10 @@ using namespace std;
 
 class L1TMuonEndcapViewer: public edm::EDAnalyzer {
 public:
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     explicit L1TMuonEndcapViewer(const edm::ParameterSet&) : edm::EDAnalyzer(){}
-    virtual ~L1TMuonEndcapViewer(void){}
+    ~L1TMuonEndcapViewer(void) override{}
 };
 
 void L1TMuonEndcapViewer::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup){

--- a/L1TriggerConfig/Utilities/src/L1TMuonEndcapWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonEndcapWriter.cc
@@ -20,12 +20,12 @@ class L1TMuonEndcapWriter : public edm::EDAnalyzer {
 private:
     bool isO2Opayload;
 public:
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     explicit L1TMuonEndcapWriter(const edm::ParameterSet &pset) : edm::EDAnalyzer(){
        isO2Opayload = pset.getUntrackedParameter<bool>("isO2Opayload",  false);
     }
-    virtual ~L1TMuonEndcapWriter(void){}
+    ~L1TMuonEndcapWriter(void) override{}
 };
 
 void L1TMuonEndcapWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup){

--- a/L1TriggerConfig/Utilities/src/L1TMuonGlobalParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonGlobalParamsViewer.cc
@@ -25,17 +25,17 @@ private:
     std::string hash(void *buf, size_t len) const ;
     void printLUT(l1t::LUT* lut, const char *name) const ;
 public:
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 //    string hash(void *buf, size_t len) const ;
 
     explicit L1TMuonGlobalParamsViewer(const edm::ParameterSet& pset) : edm::EDAnalyzer(){
 //       printLayerMap   = pset.getUntrackedParameter<bool>("printLayerMap",  false);
     }
-    virtual ~L1TMuonGlobalParamsViewer(void){}
+    ~L1TMuonGlobalParamsViewer(void) override{}
 };
 
 #include <openssl/sha.h>
-#include <math.h>
+#include <cmath>
 #include <iostream>
 using namespace std;
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonGlobalParamsWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonGlobalParamsWriter.cc
@@ -19,12 +19,12 @@ class L1TMuonGlobalParamsWriter : public edm::EDAnalyzer {
 private:
     bool isO2Opayload;
 public:
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     explicit L1TMuonGlobalParamsWriter(const edm::ParameterSet &pset) : edm::EDAnalyzer(){
        isO2Opayload = pset.getUntrackedParameter<bool>("isO2Opayload",  false);
     }
-    virtual ~L1TMuonGlobalParamsWriter(void){}
+    ~L1TMuonGlobalParamsWriter(void) override{}
 };
 
 void L1TMuonGlobalParamsWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup){

--- a/L1TriggerConfig/Utilities/src/L1TMuonOverlapReader.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonOverlapReader.cc
@@ -22,18 +22,18 @@ class L1TMuonOverlapReader: public edm::EDAnalyzer {
 private:
     bool printLayerMap;
 public:
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
     string hash(void *buf, size_t len) const ;
 
     explicit L1TMuonOverlapReader(const edm::ParameterSet& pset) : edm::EDAnalyzer(){
        printLayerMap   = pset.getUntrackedParameter<bool>("printLayerMap",  false);
     }
-    virtual ~L1TMuonOverlapReader(void){}
+    ~L1TMuonOverlapReader(void) override{}
 };
 
 
 #include <openssl/sha.h>
-#include <math.h>
+#include <cmath>
 #include <iostream>
 using namespace std;
 
@@ -90,7 +90,7 @@ void L1TMuonOverlapReader::analyze(const edm::Event& iEvent, const edm::EventSet
     cout<<endl;
 
     const std::vector<L1TMuonOverlapParams::LayerMapNode> *lm = ptr1->layerMap();
-    if( lm->size() ){
+    if( !lm->empty() ){
         cout<<" layerMap() =              ["<<lm->size()<<"] ";
         L1TMuonOverlapParams::LayerMapNode *lm_ = new L1TMuonOverlapParams::LayerMapNode[ lm->size() ];
         for(unsigned int i=0; i<lm->size(); i++) lm_[i] = (*lm)[i];
@@ -111,7 +111,7 @@ void L1TMuonOverlapReader::analyze(const edm::Event& iEvent, const edm::EventSet
     }
 
     const std::vector<L1TMuonOverlapParams::RefLayerMapNode> *rlm = ptr1->refLayerMap();
-    if( rlm->size() ){
+    if( !rlm->empty() ){
         cout<<" refLayerMap() =           ["<<rlm->size()<<"] ";
         L1TMuonOverlapParams::RefLayerMapNode *rlm_ = new L1TMuonOverlapParams::RefLayerMapNode[ rlm->size() ];
         for(unsigned int i=0; i<rlm->size(); i++) rlm_[i] = (*rlm)[i];
@@ -122,7 +122,7 @@ void L1TMuonOverlapReader::analyze(const edm::Event& iEvent, const edm::EventSet
     }
 
     const std::vector<L1TMuonOverlapParams::RefHitNode> *rhn = ptr1->refHitMap();
-    if( rhn->size() ){
+    if( !rhn->empty() ){
         cout<<" refHitMap() =             ["<<rhn->size()<<"] ";
         L1TMuonOverlapParams::RefHitNode *rhn_ = new L1TMuonOverlapParams::RefHitNode[ rhn->size() ];
         for(unsigned int i=0; i<rhn->size(); i++) rhn_[i] = (*rhn)[i];
@@ -133,7 +133,7 @@ void L1TMuonOverlapReader::analyze(const edm::Event& iEvent, const edm::EventSet
     }
 
     const std::vector<int> *gpsm = ptr1->globalPhiStartMap();
-    if( gpsm->size() ){
+    if( !gpsm->empty() ){
         cout<<" globalPhiStartMap() =     ["<<gpsm->size()<<"] ";
         int gpsm_[gpsm->size()];
         for(unsigned int i=0; i<gpsm->size(); i++) gpsm_[i] = (*gpsm)[i];
@@ -143,7 +143,7 @@ void L1TMuonOverlapReader::analyze(const edm::Event& iEvent, const edm::EventSet
     }
 
     const std::vector<L1TMuonOverlapParams::LayerInputNode> *lim = ptr1->layerInputMap();
-    if( lim->size() ){
+    if( !lim->empty() ){
         cout<<" layerInputMap() =         ["<<lim->size()<<"] ";
         L1TMuonOverlapParams::LayerInputNode *lim_ = new L1TMuonOverlapParams::LayerInputNode[lim->size()];
         for(unsigned int i=0; i<lim->size(); i++) lim_[i] = (*lim)[i];
@@ -154,7 +154,7 @@ void L1TMuonOverlapReader::analyze(const edm::Event& iEvent, const edm::EventSet
     }
 
     const std::vector<int> *css = ptr1->connectedSectorsStart();
-    if( css->size() ){
+    if( !css->empty() ){
         cout<<" connectedSectorsStart() = ["<<css->size()<<"] ";
         int css_[css->size()];
         for(unsigned int i=0; i<css->size(); i++) css_[i] = (*css)[i];
@@ -164,7 +164,7 @@ void L1TMuonOverlapReader::analyze(const edm::Event& iEvent, const edm::EventSet
     }
 
     const std::vector<int> *cse = ptr1->connectedSectorsEnd();
-    if( cse->size() ){
+    if( !cse->empty() ){
         cout<<" connectedSectorsEnd() = ["<<cse->size()<<"] ";
         int cse_[cse->size()];
         for(unsigned int i=0; i<cse->size(); i++) cse_[i] = (*cse)[i];

--- a/L1TriggerConfig/Utilities/src/L1TMuonOverlapWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonOverlapWriter.cc
@@ -17,10 +17,10 @@
 
 class L1TMuonOverlapWriter : public edm::EDAnalyzer {
 public:
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     explicit L1TMuonOverlapWriter(const edm::ParameterSet&) : edm::EDAnalyzer(){}
-    virtual ~L1TMuonOverlapWriter(void){}
+    ~L1TMuonOverlapWriter(void) override{}
 };
 
 void L1TMuonOverlapWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup){

--- a/L1TriggerConfig/Utilities/src/L1TriggerKeyExtReader.cc
+++ b/L1TriggerConfig/Utilities/src/L1TriggerKeyExtReader.cc
@@ -12,11 +12,11 @@ class L1TriggerKeyExtReader : public edm::EDAnalyzer {
 private:
     std::string label;
 public:
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     explicit L1TriggerKeyExtReader(const edm::ParameterSet &pset) : edm::EDAnalyzer(),
         label( pset.getParameter< std::string >( "label" ) ) {}
-    virtual ~L1TriggerKeyExtReader(void){}
+    ~L1TriggerKeyExtReader(void) override{}
 };
 
 #include <iostream>

--- a/L1TriggerConfig/Utilities/src/L1TriggerKeyListExtReader.cc
+++ b/L1TriggerConfig/Utilities/src/L1TriggerKeyListExtReader.cc
@@ -12,11 +12,11 @@ class L1TriggerKeyListExtReader : public edm::EDAnalyzer {
 private:
 
 public:
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     explicit L1TriggerKeyListExtReader(const edm::ParameterSet&) : edm::EDAnalyzer(){
     }
-    virtual ~L1TriggerKeyListExtReader(void){}
+    ~L1TriggerKeyListExtReader(void) override{}
 };
 
 #include <iostream>


### PR DESCRIPTION
PR to apply clang-tidy checks to all files except those that are a part of open pull requests (as of an hour ago) and files in test directories [assuming tests are ok we'll merge this quickly to avoid conflicts to the extent possible]