### PR TITLE
HCALDQM: fix castorDigis.InputLabel for heavy ion run type

### DIFF
--- a/DQM/Integration/python/clients/hcal2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal2_dqm_sourceclient-live_cfg.py
@@ -102,6 +102,7 @@ rawTagUntracked	= cms.untracked.InputTag("rawDataCollector")
 if isHeavyIon:
 	rawTag			= cms.InputTag("rawDataRepacker")
 	rawTagUntracked	= cms.untracked.InputTag("rawDataRepacker")
+	process.castorDigis.InputLabel = rawTag
 
 #	set the tag for default unpacker
 process.hcalDigis.InputLabel = rawTag

--- a/DQM/Integration/python/clients/hcal2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal2_dqm_sourceclient-live_cfg.py
@@ -102,7 +102,6 @@ rawTagUntracked	= cms.untracked.InputTag("rawDataCollector")
 if isHeavyIon:
 	rawTag			= cms.InputTag("rawDataRepacker")
 	rawTagUntracked	= cms.untracked.InputTag("rawDataRepacker")
-	process.castorDigis.InputLabel = rawTag
 
 #	set the tag for default unpacker
 process.hcalDigis.InputLabel = rawTag

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -83,6 +83,7 @@ rawTagUntracked = cms.untracked.InputTag("rawDataCollector")
 if isHeavyIon:
 	rawTag = cms.InputTag("rawDataRepacker")
 	rawTagUntracked = cms.untracked.InputTag("rawDataRepacker")
+	process.castorDigis.InputLabel = rawTag
 
 process.emulTPDigis = \
 		process.simHcalTriggerPrimitiveDigis.clone()


### PR DESCRIPTION
Important fix for HCALDQM for the XeXe run: the InputLabel of process.castorDigis should be rawDataRepacker for heavy ion runs, not rawDataCollector. 