### PR TITLE
Fix Fireworks/* pkgs comp warnings after clang-tidy

### DIFF
--- a/Fireworks/Core/interface/CmsShowCommonPopup.h
+++ b/Fireworks/Core/interface/CmsShowCommonPopup.h
@@ -45,7 +45,7 @@ public:
    void setPaletteGUI();
 
    TGComboBox* getCombo() {return m_combo;}
-   ClassDef(CmsShowCommonPopup, 0);
+   ClassDefOverride(CmsShowCommonPopup, 0);
  
 private:
    CmsShowCommonPopup(const CmsShowCommonPopup&);

--- a/Fireworks/Core/interface/CmsShowEDI.h
+++ b/Fireworks/Core/interface/CmsShowEDI.h
@@ -86,7 +86,7 @@ public:
    void moveToLayer(Long_t);
    void show(FWDataCategories);
 
-   ClassDef(CmsShowEDI, 0);
+   ClassDefOverride(CmsShowEDI, 0);
 
 private:
    CmsShowEDI(const CmsShowEDI&);    // stop default

--- a/Fireworks/Core/interface/CmsShowMainFrame.h
+++ b/Fireworks/Core/interface/CmsShowMainFrame.h
@@ -104,7 +104,7 @@ public:
    void setSummaryViewWeight(float);
    float getSummaryViewWeight() const;
 
-   ClassDef(CmsShowMainFrame, 0);
+   ClassDefOverride(CmsShowMainFrame, 0);
 
 protected:
    FWCustomIconsButton* m_filterEnableBtn;

--- a/Fireworks/Core/interface/CmsShowModelPopup.h
+++ b/Fireworks/Core/interface/CmsShowModelPopup.h
@@ -76,7 +76,7 @@ public:
 
    void clicked();
 
-   ClassDef(CmsShowModelPopup, 0);
+   ClassDefOverride(CmsShowModelPopup, 0);
 
 private:
    CmsShowModelPopup(const CmsShowModelPopup&);    // stop default

--- a/Fireworks/Core/interface/CmsShowSearchFiles.h
+++ b/Fireworks/Core/interface/CmsShowSearchFiles.h
@@ -53,7 +53,7 @@ public:
    
    void hyperlinkClicked(const char*);
 
-   ClassDef(CmsShowSearchFiles, 0);
+   ClassDefOverride(CmsShowSearchFiles, 0);
 
 private:
    void sendToWebBrowser(std::string& iWebFile);

--- a/Fireworks/Core/interface/CmsShowViewPopup.h
+++ b/Fireworks/Core/interface/CmsShowViewPopup.h
@@ -100,7 +100,7 @@ public:
    sigc::signal<void> closed_;
 #endif
 
-   ClassDef(CmsShowViewPopup, 0);
+   ClassDefOverride(CmsShowViewPopup, 0);
 
 private:
    CmsShowViewPopup(const CmsShowViewPopup&);                  // stop default

--- a/Fireworks/Core/interface/FWGUIEventFilter.h
+++ b/Fireworks/Core/interface/FWGUIEventFilter.h
@@ -56,7 +56,7 @@ public:
    void setFrom(const FWConfiguration&);
    */
    Bool_t HandleKey(Event_t *event) override;
-   ClassDef(FWGUIEventFilter, 0);
+   ClassDefOverride(FWGUIEventFilter, 0);
    
 private:   
    static const int s_entryHeight = 21;

--- a/Fireworks/Core/interface/FWGUIEventSelector.h
+++ b/Fireworks/Core/interface/FWGUIEventSelector.h
@@ -48,7 +48,7 @@ private:
    TGComboBox*               m_combo;
    FWHLTValidator*           m_validator;
 
-   ClassDef(FWGUIEventSelector, 0); // Manager for EVE windows.
+   ClassDefOverride(FWGUIEventSelector, 0); // Manager for EVE windows.
 };
 
 #endif

--- a/Fireworks/Core/interface/FWGUISubviewArea.h
+++ b/Fireworks/Core/interface/FWGUISubviewArea.h
@@ -73,7 +73,7 @@ public:
 
    static FWGUISubviewArea* getToolBarFromWindow(TEveWindow*);
 
-   ClassDef(FWGUISubviewArea, 0);
+   ClassDefOverride(FWGUISubviewArea, 0);
 
 private:
    FWGUISubviewArea(const FWGUISubviewArea&);    // stop default

--- a/Fireworks/Core/interface/FWGeoTopNode.h
+++ b/Fireworks/Core/interface/FWGeoTopNode.h
@@ -113,7 +113,7 @@ private:
 #endif
 
    
-   ClassDef(FWGeoTopNode, 0);
+   ClassDefOverride(FWGeoTopNode, 0);
 };
 
 

--- a/Fireworks/Core/interface/FWInvMassDialog.h
+++ b/Fireworks/Core/interface/FWInvMassDialog.h
@@ -65,7 +65,7 @@ private:
 
    bool          m_firstLine;
 
-   ClassDef(FWInvMassDialog, 0);
+   ClassDefOverride(FWInvMassDialog, 0);
 };
 
 

--- a/Fireworks/Core/interface/FWPartialConfig.h
+++ b/Fireworks/Core/interface/FWPartialConfig.h
@@ -20,7 +20,7 @@ class FWPartialConfigGUI : public TGTransientFrame
   FWConfiguration m_origConfig;
   FWConfigurationManager* m_cfgMng;
 
-  ClassDef(FWPartialConfigGUI, 0);
+  ClassDefOverride(FWPartialConfigGUI, 0);
 };
 
 //---------------------------------------------------------------------
@@ -36,7 +36,7 @@ class FWPartialConfigLoadGUI : public FWPartialConfigGUI
  private:
   FWEventItemsManager* m_eiMng;
   const char* m_oldConfigName;
-  ClassDef(FWPartialConfigLoadGUI, 0);
+  ClassDefOverride(FWPartialConfigLoadGUI, 0);
 };
 
 
@@ -54,7 +54,7 @@ class FWPartialConfigSaveGUI : public FWPartialConfigGUI
   std::string m_outFileName;
   std::string m_currFileName;
 
-  ClassDef(FWPartialConfigSaveGUI, 0);
+  ClassDefOverride(FWPartialConfigSaveGUI, 0);
 };
 
 

--- a/Fireworks/Core/interface/FWTEventList.h
+++ b/Fireworks/Core/interface/FWTEventList.h
@@ -25,7 +25,7 @@ private:
    FWTEventList(const FWTEventList&); // stop default
    const FWTEventList& operator=(const FWTEventList&); // stop default
 
-   ClassDef(FWTEventList, 0);
+   ClassDefOverride(FWTEventList, 0);
 };
 
 #endif

--- a/Fireworks/Core/interface/FWTSelectorToEventList.h
+++ b/Fireworks/Core/interface/FWTSelectorToEventList.h
@@ -30,7 +30,7 @@ public:
    Bool_t GetOwnEventList() const   { return fOwnEvList; }
    void   SetOwnEventList(Bool_t o) { fOwnEvList = o; }
 
-   ClassDef(FWTSelectorToEventList, 0);
+   ClassDefOverride(FWTSelectorToEventList, 0);
 };
 
 #endif

--- a/Fireworks/Core/interface/FWTextProjected.h
+++ b/Fireworks/Core/interface/FWTextProjected.h
@@ -41,7 +41,7 @@ public:
    ~FWEveText() override {}
 
    TClass* ProjectedClass(const TEveProjection* p) const override  ;
-   ClassDef(FWEveText, 0); // Class for visualisation of text with FTGL font.
+   ClassDefOverride(FWEveText, 0); // Class for visualisation of text with FTGL font.
 };
 
 //==============================================================================
@@ -62,7 +62,7 @@ public:
    void UpdateProjection() override;
    TEveElement* GetProjectedAsElement() override { return this; }
 
-   ClassDef(FWEveTextProjected, 0); // Projected replica of a FWEveText.
+   ClassDefOverride(FWEveTextProjected, 0); // Projected replica of a FWEveText.
 };
 
 //______________________________________________________________________________
@@ -75,7 +75,7 @@ public:
 
    void DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
-   ClassDef(FWEveTextGL, 0); // GL renderer class for TEveText.
+   ClassDefOverride(FWEveTextGL, 0); // GL renderer class for TEveText.
 };
 
 

--- a/Fireworks/Core/interface/FWViewEnergyScaleEditor.h
+++ b/Fireworks/Core/interface/FWViewEnergyScaleEditor.h
@@ -47,7 +47,7 @@ public:
    // ---------- member functions ---------------------------
    void setEnabled(bool);
 
-   ClassDef(FWViewEnergyScaleEditor, 0);
+   ClassDefOverride(FWViewEnergyScaleEditor, 0);
 
 private:
    FWViewEnergyScaleEditor(const FWViewEnergyScaleEditor&); // stop default

--- a/Fireworks/Core/src/FWCollectionSummaryWidget.h
+++ b/Fireworks/Core/src/FWCollectionSummaryWidget.h
@@ -79,7 +79,7 @@ public:
    void stateClicked();
    void labelClicked();
    
-   ClassDef(FWCollectionSummaryWidget,0);
+   ClassDefOverride(FWCollectionSummaryWidget,0);
    
    void itemColorClicked(int iIndex, Int_t iRootX, Int_t iRootY);
    void modelSelected(Int_t iRow,Int_t iButton,Int_t iKeyMod, Int_t iGlobalX, Int_t iGlobalY);

--- a/Fireworks/Core/src/FWColorSelect.h
+++ b/Fireworks/Core/src/FWColorSelect.h
@@ -30,7 +30,7 @@ public:
 
    void ColorSelected(Color_t); // *SIGNAL*
 
-   ClassDef(FWColorFrame, 0);
+   ClassDefOverride(FWColorFrame, 0);
 
 };
 
@@ -65,7 +65,7 @@ public:
 
    void ColorChanged(Color_t); // *SIGNAL*
 
-   ClassDef(FWColorRow, 0);
+   ClassDefOverride(FWColorRow, 0);
 
 };
 
@@ -107,7 +107,7 @@ public:
    static Bool_t HasFreePalette();
    static void   EnableFreePalette();
 
-   ClassDef(FWColorPopup, 0);
+   ClassDefOverride(FWColorPopup, 0);
 };
 
 
@@ -135,7 +135,7 @@ public:
    const std::string& label() const { return fLabel; } 
    void ColorChosen(Color_t); // *SIGNAL*
 
-   ClassDef(FWColorSelect, 0);
+   ClassDefOverride(FWColorSelect, 0);
 
 };
 #endif

--- a/Fireworks/Core/src/FWCompactVerticalLayout.h
+++ b/Fireworks/Core/src/FWCompactVerticalLayout.h
@@ -38,7 +38,7 @@ public:
    // ---------- static member functions --------------------
    
    // ---------- member functions ---------------------------
-   ClassDef(FWCompactVerticalLayout,0)  // Vertical layout manager
+   ClassDefOverride(FWCompactVerticalLayout,0)  // Vertical layout manager
 
 private:
    FWCompactVerticalLayout(const FWCompactVerticalLayout&); // stop default

--- a/Fireworks/Core/src/FWEveDetectorGeo.h
+++ b/Fireworks/Core/src/FWEveDetectorGeo.h
@@ -36,7 +36,7 @@ private:
    int m_maxLevel;
    bool m_filterOff;
 
-   ClassDef(FWEveDetectorGeo, 0);
+   ClassDefOverride(FWEveDetectorGeo, 0);
 };
 
 #endif

--- a/Fireworks/Core/src/FWEveDigitSetScalableMarker.h
+++ b/Fireworks/Core/src/FWEveDigitSetScalableMarker.h
@@ -12,7 +12,7 @@ public:
    FWEveDigitSetScalableMarker() {}
    ~FWEveDigitSetScalableMarker() override {}
    
-   ClassDef( FWEveDigitSetScalableMarker, 0);
+   ClassDefOverride( FWEveDigitSetScalableMarker, 0);
 };
 
 //--------------------------------------------
@@ -24,7 +24,7 @@ public:
    
    void DirectDraw(TGLRnrCtx & rnrCtx) const override;
    
-   ClassDef(FWEveDigitSetScalableMarkerGL, 0);
+   ClassDefOverride(FWEveDigitSetScalableMarkerGL, 0);
 };
 
 

--- a/Fireworks/Core/src/FWEveOverlap.h
+++ b/Fireworks/Core/src/FWEveOverlap.h
@@ -25,7 +25,7 @@ private:
 #ifndef __CINT__
    bool paintChildNodesRecurse(FWGeometryTableManagerBase::Entries_i pIt, Int_t idx,  const TGeoHMatrix& mtx);
 #endif
-   ClassDef(FWEveOverlap, 0);
+   ClassDefOverride(FWEveOverlap, 0);
 };
 
 #endif

--- a/Fireworks/Core/src/FWGUIValidatingTextEntry.h
+++ b/Fireworks/Core/src/FWGUIValidatingTextEntry.h
@@ -55,7 +55,7 @@ public:
 
    void keyPressedInPopup(TGFrame*, UInt_t keysym, UInt_t mask);
  
-   ClassDef(FWGUIValidatingTextEntry, 0);
+   ClassDefOverride(FWGUIValidatingTextEntry, 0);
 
 private:
    FWGUIValidatingTextEntry(const FWGUIValidatingTextEntry&); // stop default

--- a/Fireworks/Core/src/FWGeoTopNodeGL.h
+++ b/Fireworks/Core/src/FWGeoTopNodeGL.h
@@ -24,7 +24,7 @@ public:
    Bool_t AlwaysSecondarySelect()   const override { return kTRUE; }
    void   ProcessSelection(TGLRnrCtx& rnrCtx, TGLSelectRecord& rec) override;
 
-   ClassDef(FWGeoTopNodeGL, 0); // GL renderer class for FWGeoTopNodeGL.
+   ClassDefOverride(FWGeoTopNodeGL, 0); // GL renderer class for FWGeoTopNodeGL.
 
 };
 #endif

--- a/Fireworks/Core/src/FWGeometryTableView.h
+++ b/Fireworks/Core/src/FWGeometryTableView.h
@@ -92,7 +92,7 @@ private:
 
 #endif  
 
-   ClassDef(FWGeometryTableView, 0);
+   ClassDefOverride(FWGeometryTableView, 0);
 };
 
 #endif

--- a/Fireworks/Core/src/FWNumberEntry.h
+++ b/Fireworks/Core/src/FWNumberEntry.h
@@ -32,7 +32,7 @@ public:
    virtual ULong64_t GetULong64Number();
    virtual void      SetULong64Number(ULong64_t n);
 
-   ClassDef(FWNumberEntryField, 0);
+   ClassDefOverride(FWNumberEntryField, 0);
 
 };
 #endif

--- a/Fireworks/Core/src/FWOverlapTableView.h
+++ b/Fireworks/Core/src/FWOverlapTableView.h
@@ -94,7 +94,7 @@ public:
 
    
 #endif
-   ClassDef(FWOverlapTableView, 0);
+   ClassDefOverride(FWOverlapTableView, 0);
 };
 
 

--- a/Fireworks/FWInterface/src/FWPathsPopup.h
+++ b/Fireworks/FWInterface/src/FWPathsPopup.h
@@ -61,7 +61,7 @@ private:
    FWGUIManager             *m_guiManager;
    
 
-   ClassDef(FWPathsPopup, 0);
+   ClassDefOverride(FWPathsPopup, 0);
 };
 
 #endif

--- a/Fireworks/TableWidget/interface/FWCheckedTextTableCellRenderer.h
+++ b/Fireworks/TableWidget/interface/FWCheckedTextTableCellRenderer.h
@@ -49,7 +49,7 @@ class FWCheckedTextTableCellRenderer : public FWTextTableCellRenderer, public TQ
 
       void checkBoxClicked(); //*SIGNAL*
 
-      ClassDef(FWCheckedTextTableCellRenderer,0);
+      ClassDefOverride(FWCheckedTextTableCellRenderer,0);
 
    private:
       //FWCheckedTextTableCellRenderer(const FWCheckedTextTableCellRenderer&); // stop default

--- a/Fireworks/TableWidget/interface/FWTableManagerBase.h
+++ b/Fireworks/TableWidget/interface/FWTableManagerBase.h
@@ -99,7 +99,7 @@ class FWTableManagerBase : public TQObject
       ///Classes which inherit from FWTableManagerBase must call this when how the data is shown (e.g. color) changes
       void visualPropertiesChanged(); //*SIGNAL*
       
-      ClassDef(FWTableManagerBase,0);
+      ClassDefOverride(FWTableManagerBase,0);
 
       /// The current sort order for the table.
       bool sortOrder(void) { return m_sortOrder; }

--- a/Fireworks/TableWidget/interface/FWTableWidget.h
+++ b/Fireworks/TableWidget/interface/FWTableWidget.h
@@ -78,7 +78,7 @@ public:
    void childrenEvent(Event_t *);
    void Clicked();
 
-   ClassDef(FWTableWidget,0);
+   ClassDefOverride(FWTableWidget,0);
 
    void forceLayout() { m_forceLayout = true; }
    void dataChanged();

--- a/Fireworks/TableWidget/src/FWTabularWidget.h
+++ b/Fireworks/TableWidget/src/FWTabularWidget.h
@@ -62,7 +62,7 @@ public:
    void dataChanged();
    void needToRedraw();
 
-   ClassDef(FWTabularWidget,0);
+   ClassDefOverride(FWTabularWidget,0);
    
    void setLineContext(GContext_t iContext);
    void setBackgroundAreaContext(GContext_t iContext);

--- a/Fireworks/Vertices/interface/TEveEllipsoid.h
+++ b/Fireworks/Vertices/interface/TEveEllipsoid.h
@@ -41,7 +41,7 @@ public:
 
    void SetScale(float x) {fEScale = x; }
 
-   ClassDef(TEveEllipsoid, 0); // Short description.
+   ClassDefOverride(TEveEllipsoid, 0); // Short description.
 };
 
 
@@ -73,7 +73,7 @@ public:
 
    TEveElement* GetProjectedAsElement() override { return this; }
 
-   ClassDef(TEveEllipsoidProjected, 0); // Projection of TEveEllipsoid.
+   ClassDefOverride(TEveEllipsoidProjected, 0); // Projection of TEveEllipsoid.
 };
 
 #endif

--- a/Fireworks/Vertices/interface/TEveEllipsoidGL.h
+++ b/Fireworks/Vertices/interface/TEveEllipsoidGL.h
@@ -34,7 +34,7 @@ public:
    void   DirectDraw(TGLRnrCtx & rnrCtx) const override;
 Bool_t IgnoreSizeForOfInterest() const override { return kTRUE; }
 
-  ClassDef(TEveEllipsoidGL, 0); // GL renderer class for TEveEllipsoid.
+  ClassDefOverride(TEveEllipsoidGL, 0); // GL renderer class for TEveEllipsoid.
 };
 
 
@@ -64,7 +64,7 @@ public:
    void   SetBBox() override;
 
    void   DirectDraw(TGLRnrCtx & rnrCtx) const override;
-   ClassDef(TEveEllipsoidProjectedGL, 0); // GL renderer class for TEveEllipsoid.
+   ClassDefOverride(TEveEllipsoidProjectedGL, 0); // GL renderer class for TEveEllipsoid.
 };
 
 #endif


### PR DESCRIPTION
Fix macro used for class definition in Fireworks/* pkgs