### PR TITLE
introduce semi-deterministic smearing for e/gamma objects

### DIFF
--- a/EgammaAnalysis/ElectronTools/plugins/CalibratedElectronProducersRun2.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/CalibratedElectronProducersRun2.cc
@@ -17,14 +17,16 @@
 #include "EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibratorRun2.h"
 
 #include <vector>
+#include <random>
+#include <TRandom2.h>
 
 template<typename T>
 class CalibratedElectronProducerRun2T: public edm::stream::EDProducer<>
 {
     public:
         explicit CalibratedElectronProducerRun2T( const edm::ParameterSet & ) ;
-        virtual ~CalibratedElectronProducerRun2T();
-        virtual void produce( edm::Event &, const edm::EventSetup & ) override ;
+        ~CalibratedElectronProducerRun2T() override;
+        void produce( edm::Event &, const edm::EventSetup & ) override ;
 
     private:
         edm::EDGetTokenT<edm::View<T> > theElectronToken;
@@ -33,6 +35,8 @@ class CalibratedElectronProducerRun2T: public edm::stream::EDProducer<>
 
         EpCombinationTool theEpCombinationTool;
         ElectronEnergyCalibratorRun2 theEnCorrectorRun2;
+        std::unique_ptr<TRandom> theSemiDeterministicRng;
+
 };
 
 template<typename T>
@@ -42,6 +46,10 @@ CalibratedElectronProducerRun2T<T>::CalibratedElectronProducerRun2T( const edm::
   theEpCombinationTool(),
   theEnCorrectorRun2(theEpCombinationTool, conf.getParameter<bool>("isMC"), conf.getParameter<bool>("isSynchronization"), conf.getParameter<std::string>("correctionFile"))
 {
+  if (conf.existsAs<bool>("semiDeterministic") && conf.getParameter<bool>("semiDeterministic")) {
+    theSemiDeterministicRng.reset(new TRandom2());
+    theEnCorrectorRun2.initPrivateRng(theSemiDeterministicRng.get());
+  }
   produces<std::vector<T> >();
 }
 
@@ -62,6 +70,17 @@ CalibratedElectronProducerRun2T<T>::produce( edm::Event & iEvent, const edm::Eve
 
     std::unique_ptr<std::vector<T> > out(new std::vector<T>());
     out->reserve(in->size());   
+
+    if (theSemiDeterministicRng && !in->empty()) { // no need to set a seed if in is empty
+        const auto & first = in->front();
+        std::seed_seq seeder = {int(iEvent.id().event()), int(iEvent.id().luminosityBlock()), int(iEvent.id().run()),
+          int(in->size()), int(std::numeric_limits<int>::max()*first.phi()/M_PI) & 0xFFF, int(first.pdgId())};
+        uint32_t seed = 0, tries = 10;
+        do {
+            seeder.generate(&seed,&seed+1); tries++;
+        } while (seed == 0 && tries < 10);
+        theSemiDeterministicRng->SetSeed(seed ? seed : iEvent.id().event());
+    }
 
     for (const T &ele : *in) {
         out->push_back(ele);


### PR DESCRIPTION
Extend [EGMSmearer](https://twiki.cern.ch/twiki/bin/view/CMS/EGMSmearer) to allow a semi-deterministic smearing dependent only on the event. 

Needed for reproducibility of NanoAOD on MC when running multithreaded.

Uses `std::seed_seq` hash together a bunch of info about the event; tested on 50k events that the random numbers look random.

@arizzi @emanueledimarco @peruzzim 
