### PR TITLE
Bug fix. Add 2 overrides to LHESource

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/LHESource.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.cc
@@ -17,6 +17,9 @@
 #include "FWCore/Utilities/interface/TypeID.h"
 
 #include "DataFormats/Common/interface/OrphanHandle.h"
+#include "DataFormats/Provenance/interface/LuminosityBlockAuxiliary.h"
+#include "DataFormats/Provenance/interface/RunAuxiliary.h"
+#include "DataFormats/Provenance/interface/Timestamp.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/LesHouches.h"
 #include "SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h"
@@ -32,21 +35,21 @@ using namespace lhef;
 
 LHESource::LHESource(const edm::ParameterSet &params,
                      const edm::InputSourceDescription &desc) :
-	ProducerSourceFromFiles(params, desc, false),
-	reader(new LHEReader(fileNames(), params.getUntrackedParameter<unsigned int>("skipEvents", 0))),
-	wasMerged(false),
-	lheProvenanceHelper_(edm::TypeID(typeid(LHEEventProduct)), edm::TypeID(typeid(LHERunInfoProduct)), productRegistryUpdate()),
-	phid_(),
-        runPrincipal_()
+  ProducerSourceFromFiles(params, desc, false),
+  reader(new LHEReader(fileNames(), params.getUntrackedParameter<unsigned int>("skipEvents", 0))),
+  wasMerged(false),
+  lheProvenanceHelper_(edm::TypeID(typeid(LHEEventProduct)), edm::TypeID(typeid(LHERunInfoProduct)), productRegistryUpdate()),
+  phid_(),
+  runPrincipal_()
 {
-        nextEvent();
-        lheProvenanceHelper_.lheAugment(runInfo.get());
-	// Initialize metadata, and save the process history ID for use every event.
-	phid_ = lheProvenanceHelper_.lheInit(processHistoryRegistryForUpdate());
+  nextEvent();
+  lheProvenanceHelper_.lheAugment(runInfo.get());
+  // Initialize metadata, and save the process history ID for use every event.
+  phid_ = lheProvenanceHelper_.lheInit(processHistoryRegistryForUpdate());
 
-        // These calls are not wanted, because the principals are used for putting the products.
-	//produces<LHEEventProduct>();
-	//produces<LHERunInfoProduct, edm::InRun>();
+  // These calls are not wanted, because the principals are used for putting the products.
+  //produces<LHEEventProduct>();
+  //produces<LHERunInfoProduct, edm::InRun>();
 }
 
 LHESource::~LHESource()
@@ -55,60 +58,60 @@ LHESource::~LHESource()
 
 void LHESource::endJob()
 {
-	reader.reset();
+  reader.reset();
 }
 
 void LHESource::nextEvent()
 {
-	if (partonLevel) {
-		return;
+  if (partonLevel) {
+    return;
+  }
+
+  bool newFileOpened;
+  do {
+    newFileOpened = false;
+    partonLevel = reader->next(&newFileOpened);
+  } while (newFileOpened && !partonLevel);
+
+  if (!partonLevel) {
+    return;
+  }
+
+  boost::shared_ptr<LHERunInfo> runInfoThis = partonLevel->getRunInfo();
+  if (runInfoThis != runInfoLast) {
+    runInfo = runInfoThis;
+    runInfoLast = runInfoThis;
+  }
+  if (runInfo) {
+    std::auto_ptr<LHERunInfoProduct> product(
+                                             new LHERunInfoProduct(*runInfo->getHEPRUP()));
+    std::for_each(runInfo->getHeaders().begin(),
+                  runInfo->getHeaders().end(),
+                  boost::bind(
+                              &LHERunInfoProduct::addHeader,
+                              product.get(), _1));
+    std::for_each(runInfo->getComments().begin(),
+                  runInfo->getComments().end(),
+                  boost::bind(&LHERunInfoProduct::addComment,
+                              product.get(), _1));
+
+    if (!runInfoProducts.empty()) {
+      if (runInfoProducts.front().mergeProduct(*product)) {
+        if (!wasMerged) {
+          runInfoProducts.pop_front();
+          runInfoProducts.push_front(product);
+          wasMerged = true;
         }
+      } else {
+        lheProvenanceHelper_.lheAugment(runInfo.get());
+        // Initialize metadata, and save the process history ID for use every event.
+        phid_ = lheProvenanceHelper_.lheInit(processHistoryRegistryForUpdate());
+        resetRunAuxiliary();
+      }
+    }
 
-	bool newFileOpened;
-	do {
-		newFileOpened = false;
-		partonLevel = reader->next(&newFileOpened);
-	} while (newFileOpened && !partonLevel);
-
-	if (!partonLevel) {
-		return;
-        }
-
-	boost::shared_ptr<LHERunInfo> runInfoThis = partonLevel->getRunInfo();
-	if (runInfoThis != runInfoLast) {
-		runInfo = runInfoThis;
-		runInfoLast = runInfoThis;
-	}
-	if (runInfo) {
-		std::auto_ptr<LHERunInfoProduct> product(
-				new LHERunInfoProduct(*runInfo->getHEPRUP()));
-		std::for_each(runInfo->getHeaders().begin(),
-		              runInfo->getHeaders().end(),
-		              boost::bind(
-		              	&LHERunInfoProduct::addHeader,
-		              	product.get(), _1));
-		std::for_each(runInfo->getComments().begin(),
-		              runInfo->getComments().end(),
-		              boost::bind(&LHERunInfoProduct::addComment,
-		              	product.get(), _1));
-
-		if (!runInfoProducts.empty()) {
-		  if (runInfoProducts.front().mergeProduct(*product)) {
-			if (!wasMerged) {
-				runInfoProducts.pop_front();
-				runInfoProducts.push_front(product);
-				wasMerged = true;
-			}
-		  } else {
-                    lheProvenanceHelper_.lheAugment(runInfo.get());
-                    // Initialize metadata, and save the process history ID for use every event.
-                    phid_ = lheProvenanceHelper_.lheInit(processHistoryRegistryForUpdate());
-		    resetRunAuxiliary();
-		  }
-		}
-
-		runInfo.reset();
-	}
+    runInfo.reset();
+  }
 }
 
 // This is the only way we can now access the run principal.
@@ -127,89 +130,109 @@ LHESource::readLuminosityBlock_(edm::LuminosityBlockPrincipal& lumiPrincipal) {
 
 void LHESource::beginRun(edm::Run&)
 {
-	if (runInfoLast) {
-		runInfo = runInfoLast;
+  if (runInfoLast) {
+    runInfo = runInfoLast;
 
-		std::unique_ptr<LHERunInfoProduct> product(
-				new LHERunInfoProduct(*runInfo->getHEPRUP()));
-		std::for_each(runInfo->getHeaders().begin(),
-		              runInfo->getHeaders().end(),
-		              boost::bind(
-		              	&LHERunInfoProduct::addHeader,
-		              	product.get(), _1));
-		std::for_each(runInfo->getComments().begin(),
-		              runInfo->getComments().end(),
-		              boost::bind(&LHERunInfoProduct::addComment,
-		              	product.get(), _1));
+    std::unique_ptr<LHERunInfoProduct> product(
+                                               new LHERunInfoProduct(*runInfo->getHEPRUP()));
+    std::for_each(runInfo->getHeaders().begin(),
+                  runInfo->getHeaders().end(),
+                  boost::bind(
+                              &LHERunInfoProduct::addHeader,
+                              product.get(), _1));
+    std::for_each(runInfo->getComments().begin(),
+                  runInfo->getComments().end(),
+                  boost::bind(&LHERunInfoProduct::addComment,
+                              product.get(), _1));
 
-		// keep a copy around in case of merging
-		runInfoProducts.push_back(new LHERunInfoProduct(*product));
-		wasMerged = false;
+    // keep a copy around in case of merging
+    runInfoProducts.push_back(new LHERunInfoProduct(*product));
+    wasMerged = false;
 
-                std::unique_ptr<edm::WrapperBase> rdp(new edm::Wrapper<LHERunInfoProduct>(std::move(product)));
-		runPrincipal_->put(lheProvenanceHelper_.runProductBranchDescription_, std::move(rdp));
+    std::unique_ptr<edm::WrapperBase> rdp(new edm::Wrapper<LHERunInfoProduct>(std::move(product)));
+    runPrincipal_->put(lheProvenanceHelper_.runProductBranchDescription_, std::move(rdp));
 
-		runInfo.reset();
-	}
+    runInfo.reset();
+  }
 }
 
 void LHESource::endRun(edm::Run&)
 {
-	if (!runInfoProducts.empty()) {
-		std::unique_ptr<LHERunInfoProduct> product(
-					runInfoProducts.pop_front().release());
-                std::unique_ptr<edm::WrapperBase> rdp(new edm::Wrapper<LHERunInfoProduct>(std::move(product)));
-		runPrincipal_->put(lheProvenanceHelper_.runProductBranchDescription_, std::move(rdp));
-	}
-	runPrincipal_ = nullptr;
+  if (!runInfoProducts.empty()) {
+    std::unique_ptr<LHERunInfoProduct> product(
+                                               runInfoProducts.pop_front().release());
+    std::unique_ptr<edm::WrapperBase> rdp(new edm::Wrapper<LHERunInfoProduct>(std::move(product)));
+    runPrincipal_->put(lheProvenanceHelper_.runProductBranchDescription_, std::move(rdp));
+  }
+  runPrincipal_ = nullptr;
 }
 
 bool LHESource::setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&, edm::EventAuxiliary::ExperimentType&)
 {
-	nextEvent();
-	if (!partonLevel) {
-                // We just finished an input file. See if there is another.
-                nextEvent();
-	        if (!partonLevel) {
-                        // No more input files.
-		        return false;
-                }
-        }
-        return true;
+  nextEvent();
+  if (!partonLevel) {
+    // We just finished an input file. See if there is another.
+    nextEvent();
+    if (!partonLevel) {
+      // No more input files.
+      return false;
+    }
+  }
+  return true;
 }
 
 void
 LHESource::readEvent_(edm::EventPrincipal& eventPrincipal) {
-	assert(eventCached() || processingMode() != RunsLumisAndEvents);
-	edm::EventAuxiliary aux(eventID(), processGUID(), edm::Timestamp(presentTime()), false);
-	aux.setProcessHistoryID(phid_);
-	eventPrincipal.fillEventPrincipal(aux, processHistoryRegistryForUpdate());
+  assert(eventCached() || processingMode() != RunsLumisAndEvents);
+  edm::EventAuxiliary aux(eventID(), processGUID(), edm::Timestamp(presentTime()), false);
+  aux.setProcessHistoryID(phid_);
+  eventPrincipal.fillEventPrincipal(aux, processHistoryRegistryForUpdate());
 
-	std::unique_ptr<LHEEventProduct> product(
-		     new LHEEventProduct(*partonLevel->getHEPEUP(),
-					 partonLevel->originalXWGTUP())
-		     );
-	if (partonLevel->getPDF()) {
-		product->setPDF(*partonLevel->getPDF());
-        }		
-	std::for_each(partonLevel->weights().begin(),
-		      partonLevel->weights().end(),
-		      boost::bind(&LHEEventProduct::addWeight,
-				  product.get(), _1));
-        product->setScales(partonLevel->scales());
-        product->setNpLO(partonLevel->npLO());
-        product->setNpNLO(partonLevel->npNLO());
-	std::for_each(partonLevel->getComments().begin(),
-	              partonLevel->getComments().end(),
-	              boost::bind(&LHEEventProduct::addComment,
-	                          product.get(), _1));
+  std::unique_ptr<LHEEventProduct> product(
+                                           new LHEEventProduct(*partonLevel->getHEPEUP(),
+                                                               partonLevel->originalXWGTUP())
+                                           );
+  if (partonLevel->getPDF()) {
+    product->setPDF(*partonLevel->getPDF());
+  }
+  std::for_each(partonLevel->weights().begin(),
+                partonLevel->weights().end(),
+                boost::bind(&LHEEventProduct::addWeight,
+                            product.get(), _1));
+  product->setScales(partonLevel->scales());
+  product->setNpLO(partonLevel->npLO());
+  product->setNpNLO(partonLevel->npNLO());
+  std::for_each(partonLevel->getComments().begin(),
+                partonLevel->getComments().end(),
+                boost::bind(&LHEEventProduct::addComment,
+                            product.get(), _1));
 
-	std::unique_ptr<edm::WrapperBase> edp(new edm::Wrapper<LHEEventProduct>(std::move(product)));
-	eventPrincipal.put(lheProvenanceHelper_.eventProductBranchDescription_, std::move(edp), lheProvenanceHelper_.eventProductProvenance_);
+  std::unique_ptr<edm::WrapperBase> edp(new edm::Wrapper<LHEEventProduct>(std::move(product)));
+  eventPrincipal.put(lheProvenanceHelper_.eventProductBranchDescription_, std::move(edp), lheProvenanceHelper_.eventProductProvenance_);
 
-	partonLevel.reset();
+  partonLevel.reset();
 
-	resetEventCached();
+  resetEventCached();
+}
+
+std::shared_ptr<edm::RunAuxiliary>
+LHESource::readRunAuxiliary_() {
+  edm::Timestamp ts = edm::Timestamp(presentTime());
+  resetNewRun();
+  auto aux = std::make_shared<edm::RunAuxiliary>(eventID().run(), ts, edm::Timestamp::invalidTimestamp());
+  aux->setProcessHistoryID(phid_);
+  return aux;
+}
+
+std::shared_ptr<edm::LuminosityBlockAuxiliary>
+LHESource::readLuminosityBlockAuxiliary_() {
+  if (processingMode() == Runs) return std::shared_ptr<edm::LuminosityBlockAuxiliary>();
+  edm::Timestamp ts = edm::Timestamp(presentTime());
+  resetNewLumi();
+  auto aux = std::make_shared<edm::LuminosityBlockAuxiliary>(eventID().run(), eventID().luminosityBlock(),
+                                                             ts, edm::Timestamp::invalidTimestamp());
+  aux->setProcessHistoryID(phid_);
+  return aux;
 }
 
 DEFINE_FWK_INPUT_SOURCE(LHESource);

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.h
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.h
@@ -13,51 +13,54 @@
 #include "SimDataFormats/GeneratorProducts/interface/LesHouches.h"
 
 namespace lhef {
-	class LHERunInfo;
-	class LHEEvent;
-	class LHEReader;
+  class LHERunInfo;
+  class LHEEvent;
+  class LHEReader;
 }
 
 namespace edm {
-	class EventPrincipal;
-	class LuminosityBlockPrincipal;
-	class ParameterSet;
-	class Run;
-	class RunPrincipal;
+  class EventPrincipal;
+  class LuminosityBlockAuxiliary;
+  class LuminosityBlockPrincipal;
+  class ParameterSet;
+  class Run;
+  class RunAuxiliary;
+  class RunPrincipal;
 }
 
 class LHERunInfoProduct;
 
- class LHESource : public edm::ProducerSourceFromFiles {
-    public:
-	explicit LHESource(const edm::ParameterSet &params,
-	                   const edm::InputSourceDescription &desc);
-	virtual ~LHESource();
+class LHESource : public edm::ProducerSourceFromFiles {
+public:
+  explicit LHESource(const edm::ParameterSet &params,
+                     const edm::InputSourceDescription &desc);
+  ~LHESource() override;
 
-    private:
-	virtual void endJob() override;
-	virtual void beginRun(edm::Run &run) override;
-	virtual void endRun(edm::Run &run) override;
- 	virtual bool setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&, edm::EventAuxiliary::ExperimentType&) override;
-	virtual void readRun_(edm::RunPrincipal& runPrincipal) override;
-	virtual void readLuminosityBlock_(edm::LuminosityBlockPrincipal& lumiPrincipal) override;
-	virtual void readEvent_(edm::EventPrincipal& eventPrincipal) override;
-        virtual void produce(edm::Event&) override {}
+private:
+  void endJob() override;
+  void beginRun(edm::Run &run) override;
+  void endRun(edm::Run &run) override;
+  bool setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&, edm::EventAuxiliary::ExperimentType&) override;
+  void readRun_(edm::RunPrincipal& runPrincipal) override;
+  void readLuminosityBlock_(edm::LuminosityBlockPrincipal& lumiPrincipal) override;
+  void readEvent_(edm::EventPrincipal& eventPrincipal) override;
+  void produce(edm::Event&) override {}
+  std::shared_ptr<edm::RunAuxiliary> readRunAuxiliary_() override;
+  std::shared_ptr<edm::LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
 
-	void nextEvent();
+  void nextEvent();
 
-	std::auto_ptr<lhef::LHEReader>		reader;
+  std::auto_ptr<lhef::LHEReader>		reader;
 
-	boost::shared_ptr<lhef::LHERunInfo>	runInfoLast;
-	boost::shared_ptr<lhef::LHERunInfo>	runInfo;
-	boost::shared_ptr<lhef::LHEEvent>	partonLevel;
+  boost::shared_ptr<lhef::LHERunInfo>	runInfoLast;
+  boost::shared_ptr<lhef::LHERunInfo>	runInfo;
+  boost::shared_ptr<lhef::LHEEvent>	partonLevel;
 
-	boost::ptr_deque<LHERunInfoProduct>	runInfoProducts;
-	bool					wasMerged;
-	edm::LHEProvenanceHelper		lheProvenanceHelper_;
-	edm::ProcessHistoryID			phid_;
-	edm::RunPrincipal*	                runPrincipal_;
+  boost::ptr_deque<LHERunInfoProduct>	runInfoProducts;
+  bool					wasMerged;
+  edm::LHEProvenanceHelper		lheProvenanceHelper_;
+  edm::ProcessHistoryID			phid_;
+  edm::RunPrincipal*	                runPrincipal_;
 };
 
 #endif // GeneratorInterface_LHEInterface_LHESource_h
-


### PR DESCRIPTION
Add readRunAuxiliary_ and readLuminosityBlockAuxiliary_
function overrides to LHESource. (also includes code-check
fixes and indentation fixes that remove inconsistencies and
tabs, but the only substantive changes are the 2 new functions).
Earlier changes in the Framework broke LHESource and the
addition of these two functions fixes the problem by setting
the ProcessHistoryID properly.