### PR TITLE
TableExaminer usage

### DIFF
--- a/DataFormats/Common/interface/Wrapper.h
+++ b/DataFormats/Common/interface/Wrapper.h
@@ -64,6 +64,8 @@ private:
                                   std::vector<unsigned long> const& iIndices,
                                   std::vector<void const*>& oPtr) const override;
 
+    std::shared_ptr<soa::TableExaminerBase> tableExaminer_() const override;
+
   private:
     // We wish to disallow copy construction and assignment.
     // We make the copy constructor and assignment operator private.
@@ -144,6 +146,21 @@ private:
     assert(wrappedNewProduct != nullptr);
     return detail::doIsProductEqual<T>()(obj, wrappedNewProduct->obj);
   }
+  
+  namespace soa {
+    template<class T>
+    struct MakeTableExaminer {
+      static std::shared_ptr<edm::soa::TableExaminerBase> make(void const*) {
+        return std::shared_ptr<edm::soa::TableExaminerBase>{};
+      }
+    };
+  }
+  template <typename T>
+  inline
+  std::shared_ptr<edm::soa::TableExaminerBase> Wrapper<T>::tableExaminer_() const {
+    return soa::MakeTableExaminer<T>::make(&obj);
+  }
+
 }
 
 #include "DataFormats/Common/interface/WrapperView.icc"

--- a/DataFormats/Common/interface/WrapperBase.h
+++ b/DataFormats/Common/interface/WrapperBase.h
@@ -13,8 +13,13 @@ WrapperBase: The base class of all things that will be inserted into the Event.
 
 #include <typeinfo>
 #include <vector>
+#include <memory>
 
 namespace edm {
+  namespace soa {
+    class TableExaminerBase;
+  }
+  
   class WrapperBase : public ViewTypeChecker {
   public:
     WrapperBase();
@@ -48,6 +53,9 @@ namespace edm {
     bool hasIsProductEqual() const {return hasIsProductEqual_();}
     bool isProductEqual(WrapperBase const* newProduct) const {return isProductEqual_(newProduct);}
 
+    std::shared_ptr<soa::TableExaminerBase> tableExaminer() const {
+      return tableExaminer_();
+    }
   private:
     virtual std::type_info const& dynamicTypeInfo_() const = 0;
 
@@ -73,6 +81,9 @@ namespace edm {
     virtual void do_fillPtrVector(std::type_info const& iToType,
                                   std::vector<unsigned long> const& iIndicies,
                                   std::vector<void const*>& oPtr) const = 0;
+    
+    virtual std::shared_ptr<soa::TableExaminerBase> tableExaminer_() const = 0;
+
   };
 }
 #endif

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -238,6 +238,6 @@ exception when running testMissingDictionaryChecking_cfg.py.
  <class name="edm::Wrapper<edm::soa::Table<edm::soa::Column<edmtest::kAnInt,int>, edm::soa::Column<edmtest::kAFloat,float>,edm::soa::Column<edmtest::kAString,std::string> > >" persistent="false"/>
 -->
  <class name="edm::soa::Table<edmtest::AnInt, edmtest::AFloat,edmtest::AString >"/>
- <class name="edm::Wrapper<edm::soa::Table<edmtest::AnInt, edmtest::AFloat,edmtest::AString > >" persistent="false"/>
+ <class name="edm::Wrapper<edm::soa::Table<edmtest::AnInt, edmtest::AFloat,edmtest::AString > >"/>
 
 </lcgdict>

--- a/FWCore/Integration/test/testTableTest_cfg.py
+++ b/FWCore/Integration/test/testTableTest_cfg.py
@@ -24,6 +24,13 @@ process.checkTable = cms.EDAnalyzer("edmtest::TableTestAnalyzer",
 process.eventContent = cms.EDAnalyzer("EventContentAnalyzer")
 
 process.p = cms.Path(process.checkTable, cms.Task(process.tableTest) )
+
+process.out = cms.OutputModule("edmtest::TableTestOutputModule",
+                               outputCommands = cms.untracked.vstring("drop *",
+                                                                      "keep *_tableTest_*_*"
+                                                                    ))
+process.o = cms.EndPath(process.out)
+
 #process.p = cms.Path(process.tableTest+process.eventContent+process.checkTable)
 
 #process.add_(cms.Service("Tracer", dumpPathsAndConsumes= cms.untracked.bool(True) ) )

--- a/FWCore/SOA/interface/Table.h
+++ b/FWCore/SOA/interface/Table.h
@@ -124,6 +124,9 @@
 #include "FWCore/SOA/interface/ColumnValues.h"
 #include "FWCore/SOA/interface/RowView.h"
 
+//The following is needed for edm::Wrapper
+#include "FWCore/SOA/interface/TableExaminer.h"
+
 // forward declarations
 
 namespace edm {
@@ -242,7 +245,7 @@ namespace soa {
     
     // Member data
     unsigned int m_size = 0;
-    std::array<void *, sizeof...(Args)> m_values = {{nullptr}};
+    std::array<void *, sizeof...(Args)> m_values = {{nullptr}}; //! keep ROOT from trying to store this
     
     template<typename U>
     void const* columnAddress() const {
@@ -445,8 +448,15 @@ namespace soa {
   template <typename TABLE, typename E>
   using RemoveColumn_t = typename RemoveColumn<TABLE,E>::type;
 
+  //This is used by edm::Wrapper
+  template< typename T> struct MakeTableExaminer;
+  
+  template<typename... Args>
+  struct MakeTableExaminer<Table<Args...>> {
+    static std::unique_ptr<TableExaminerBase> make(const Table<Args...>* iTable) {
+      return std::make_unique<TableExaminer<Table<Args...>> >(iTable);
+    }
+  };
 }
 }
-
-
 #endif


### PR DESCRIPTION
Allow generic access to edm::soa::Table via the Wrapper. This is needed for further development such as storage of Tables in EDM ROOT format.