### PR TITLE
Backport of bug fix. Add 2 overrides to LHESource

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/LHESource.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.cc
@@ -17,6 +17,9 @@
 #include "FWCore/Utilities/interface/TypeID.h"
 
 #include "DataFormats/Common/interface/OrphanHandle.h"
+#include "DataFormats/Provenance/interface/LuminosityBlockAuxiliary.h"
+#include "DataFormats/Provenance/interface/RunAuxiliary.h"
+#include "DataFormats/Provenance/interface/Timestamp.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/LesHouches.h"
 #include "SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h"
@@ -210,6 +213,26 @@ LHESource::readEvent_(edm::EventPrincipal& eventPrincipal) {
 	partonLevel.reset();
 
 	resetEventCached();
+}
+
+std::shared_ptr<edm::RunAuxiliary>
+LHESource::readRunAuxiliary_() {
+  edm::Timestamp ts = edm::Timestamp(presentTime());
+  resetNewRun();
+  auto aux = std::make_shared<edm::RunAuxiliary>(eventID().run(), ts, edm::Timestamp::invalidTimestamp());
+  aux->setProcessHistoryID(phid_);
+  return aux;
+}
+
+std::shared_ptr<edm::LuminosityBlockAuxiliary>
+LHESource::readLuminosityBlockAuxiliary_() {
+  if (processingMode() == Runs) return std::shared_ptr<edm::LuminosityBlockAuxiliary>();
+  edm::Timestamp ts = edm::Timestamp(presentTime());
+  resetNewLumi();
+  auto aux = std::make_shared<edm::LuminosityBlockAuxiliary>(eventID().run(), eventID().luminosityBlock(),
+                                                             ts, edm::Timestamp::invalidTimestamp());
+  aux->setProcessHistoryID(phid_);
+  return aux;
 }
 
 DEFINE_FWK_INPUT_SOURCE(LHESource);

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.h
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.h
@@ -20,9 +20,11 @@ namespace lhef {
 
 namespace edm {
 	class EventPrincipal;
+        class LuminosityBlockAuxiliary;
 	class LuminosityBlockPrincipal;
 	class ParameterSet;
 	class Run;
+        class RunAuxiliary;
 	class RunPrincipal;
 }
 
@@ -43,6 +45,8 @@ class LHERunInfoProduct;
 	virtual void readLuminosityBlock_(edm::LuminosityBlockPrincipal& lumiPrincipal) override;
 	virtual void readEvent_(edm::EventPrincipal& eventPrincipal) override;
         virtual void produce(edm::Event&) override {}
+        std::shared_ptr<edm::RunAuxiliary> readRunAuxiliary_() override;
+        std::shared_ptr<edm::LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
 
 	void nextEvent();
 


### PR DESCRIPTION
Add readRunAuxiliary_ and readLuminosityBlockAuxiliary_
function overrides to LHESource. Earlier changes in the
Framework broke LHESource and the addition of these two
functions fixes the problem by setting the ProcessHistoryID
properly.

Backport of PR #20883 