### PR TITLE
Add fillDescriptions to MeasurementTrackerEventProducer

### DIFF
--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.h
@@ -33,7 +33,6 @@ protected:
       void getInactiveStrips(const edm::Event& event,std::vector<uint32_t> & rawInactiveDetIds) const;
 
       std::string measurementTrackerLabel_;
-      const edm::ParameterSet& pset_;
       edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> thePixelClusterLabel;
       edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster>> theStripClusterLabel;
       edm::EDGetTokenT<edmNew::DetSetVector<Phase2TrackerCluster1D>> thePh2OTClusterLabel;
@@ -46,6 +45,7 @@ protected:
       std::vector<edm::EDGetTokenT<DetIdCollection>>      theInactiveStripDetectorLabels;
 
       bool selfUpdateSkipClusters_;
+      bool switchOffPixelsIfEmpty_;
       bool isPhase2;
 };
 

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.h
@@ -17,6 +17,8 @@ class dso_hidden MeasurementTrackerEventProducer final : public edm::stream::EDP
 public:
       explicit MeasurementTrackerEventProducer(const edm::ParameterSet &iConfig) ;
       ~MeasurementTrackerEventProducer() override {}
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 private:
       void produce(edm::Event&, const edm::EventSetup&) override;
 

--- a/RecoTracker/MeasurementDet/python/MeasurementTrackerEventProducer_cfi.py
+++ b/RecoTracker/MeasurementDet/python/MeasurementTrackerEventProducer_cfi.py
@@ -1,26 +1,17 @@
 import FWCore.ParameterSet.Config as cms
 
-MeasurementTrackerEvent = cms.EDProducer("MeasurementTrackerEventProducer",
-    measurementTracker = cms.string(''),
+from RecoTracker.MeasurementDet.measurementTrackerEventDefault_cfi import measurementTrackerEventDefault as _measurementTrackerEventDefault
 
-    skipClusters = cms.InputTag(""),
-
-    pixelClusterProducer = cms.string('siPixelClusters'),
-    stripClusterProducer = cms.string('siStripClusters'),
-
-    # One or more DetIdCollections of modules to mask on the fly for a given event
-    inactivePixelDetectorLabels = cms.VInputTag(cms.InputTag('siPixelDigis')),
-    badPixelFEDChannelCollectionLabels = cms.VInputTag(cms.InputTag('siPixelDigis')),
-    pixelCablingMapLabel = cms.string(''),
-    inactiveStripDetectorLabels = cms.VInputTag(cms.InputTag('siStripDigis')),
-    switchOffPixelsIfEmpty = cms.bool(True), # let's keep it like this, for cosmics                                    
+MeasurementTrackerEvent = _measurementTrackerEventDefault.clone(
+    badPixelFEDChannelCollectionLabels = ['siPixelDigis'],
 )
+
 # This customization will be removed once we have phase2 pixel digis
 # Need this line to stop error about missing siPixelDigis
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(MeasurementTrackerEvent, # FIXME
     inactivePixelDetectorLabels = [],
-    Phase2TrackerCluster1DProducer = cms.string('siPhase2Clusters'),
+    Phase2TrackerCluster1DProducer = 'siPhase2Clusters',
     stripClusterProducer = ''
 )
 


### PR DESCRIPTION
This PR addresses the "POG code review comments" of #20151, main changes:
* add `fillDescriptions` to `MeasurementTrackerEventProducer`
* replace `vector<unique_ptr<...>>` with `unordered_map`
  * I tested run 300811 comparing `vector`, `map`, and `unordered_map`, and `unordered_map` was faster than `map` and took less memory than either `map` or `vector` (although numbers are totally insignificant wrt. tracking total, or even a single iteration)
* some cleanup

Tested in CMSSW_9_4_X_2017-10-03-0000, no changes expected.

@VinInn