### PR TITLE
Aesthetic changes to off-track cluster histograms

### DIFF
--- a/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
+++ b/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
@@ -30,14 +30,14 @@ SiStripMonitorTrack = cms.EDAnalyzer(
                                   maxWidth = cms.double(200.0)
                                   ),
 
-    TH1nClustersOn = cms.PSet( Nbinx = cms.int32(150),
+    TH1nClustersOn = cms.PSet( Nbinx = cms.int32(50),
                              xmin  = cms.double(-0.5),
                              xmax  = cms.double(2999.5)
                              ),
 
-    TH1nClustersOff = cms.PSet( Nbinx = cms.int32(150),
+    TH1nClustersOff = cms.PSet( Nbinx = cms.int32(100),
                              xmin  = cms.double(-0.5),
-                             xmax  = cms.double(19999.5)
+                             xmax  = cms.double(100000.)
                              ),
 
     TH1ClusterGain = cms.PSet(

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -64,7 +64,7 @@ SiStripMonitorTrack::SiStripMonitorTrack(const edm::ParameterSet& conf):
 SiStripMonitorTrack::~SiStripMonitorTrack() {
   if (dcsStatus_) delete dcsStatus_;
   if (genTriggerEventFlag_) delete genTriggerEventFlag_;
-  
+
 }
 
 //------------------------------------------------------------------------
@@ -328,11 +328,11 @@ ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TIBTID =
     ibooker.book2D("ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TECP","TEC- [FECCrate=2] (OnTrack)",10,-0.5,9.5,22,0.5,22.5);
   ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TECP->setAxisTitle("FEC Ring",1);
   ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TECP->setAxisTitle("FEC Slot",2);
-  
+
   //----------------------------------------
   // for conting the number of clusters, for the mean S/N calculation
    //book control view plots
- 
+
   ClusterCount_OnTrack_FECCratevsFECSlot =
     ibooker.book2D("ClusterCount_OnTrack_FECCratevsFECSlot"," S/N (On track)",22,0.5,22.5,4,0.5,4.5);
   ClusterCount_OnTrack_FECCratevsFECSlot->setAxisTitle("FEC Slot",1);
@@ -362,10 +362,10 @@ ClusterCount_OnTrack_FECSlotVsFECRing_TIBTID =
     ibooker.book2D("ClusterCount_OnTrack_FECSlotVsFECRing_TECP","TEC- [FECCrate=2] (OnTrack)",10,-0.5,9.5,22,0.5,22.5);
   ClusterCount_OnTrack_FECSlotVsFECRing_TECP->setAxisTitle("FEC Ring",1);
   ClusterCount_OnTrack_FECSlotVsFECRing_TECP->setAxisTitle("FEC Slot",2);
-  
-  
-  
-  
+
+
+
+
 }
 
 //--------------------------------------------------------------------------------
@@ -642,6 +642,25 @@ void SiStripMonitorTrack::bookSubDetMEs(DQMStore::IBooker & ibooker , std::strin
   axisName = "Number of off-track clusters in " + name;
   theSubDetMEs.nClustersOffTrack = bookME1D(ibooker , "TH1nClustersOff", completeName.c_str());
   theSubDetMEs.nClustersOffTrack->setAxisTitle(axisName);
+
+  double xmaximum=0;
+  if(name.find("TIB") != std::string::npos){
+    xmaximum = 40000.0;
+    theSubDetMEs.nClustersOffTrack->setAxisRange(0.0,xmaximum, 1);
+  }
+  if(name.find("TOB") != std::string::npos){
+    xmaximum = 40000.0;
+    theSubDetMEs.nClustersOffTrack->setAxisRange(0.0,xmaximum, 1);
+  }
+  if(name.find("TID") != std::string::npos){
+    xmaximum = 10000.0;
+    theSubDetMEs.nClustersOffTrack->setAxisRange(0.0,xmaximum, 1);
+  }
+  if(name.find("TEC") != std::string::npos){
+    xmaximum = 40000.0;
+    theSubDetMEs.nClustersOffTrack->setAxisRange(0.0,xmaximum, 1);
+  }
+
   theSubDetMEs.nClustersOffTrack->getTH1()->StatOverflows(kTRUE);
 
   // Cluster Gain
@@ -1285,7 +1304,7 @@ bool SiStripMonitorTrack::fillControlViewHistos(const edm::Event& ev, const edm:
       }
 
 
-      std::vector<const FedChannelConnection *> getFedChanConnections; 
+      std::vector<const FedChannelConnection *> getFedChanConnections;
       getFedChanConnections = SiStripDetCabling_->getConnections(thedetid);
 
       //      SiStripFolderOrganizer folder_organizer;
@@ -1332,25 +1351,25 @@ bool SiStripMonitorTrack::fillControlViewHistos(const edm::Event& ev, const edm:
       } // end of looping over the fed chan connections
     } // end of looping over the rechits of the track
   } // end of looping over the tracks
-  
-  
-  
-  
+
+
+
+
   return true;
 }
 
 
 void SiStripMonitorTrack::return2DME(MonitorElement* input1, MonitorElement* input2, int binx, int biny, double value) {
 
-  if (input1->getBinContent(binx,biny)==0.) { 
-    input1->setBinContent(binx,biny,value); 
+  if (input1->getBinContent(binx,biny)==0.) {
+    input1->setBinContent(binx,biny,value);
     input2->setBinContent(binx,biny,1);
   }
-  else { 
+  else {
     double nentries = input2->getBinContent(binx,biny);
     double theMeanSoN = (input1->getBinContent(binx,biny)*nentries + value)/(nentries+1);
-    //input1->setBinContent(binx,biny,((input1->getBinContent(binx,biny)+value)/2.)); 
-    input1->setBinContent(binx,biny,  theMeanSoN ); 
+    //input1->setBinContent(binx,biny,((input1->getBinContent(binx,biny)+value)/2.));
+    input1->setBinContent(binx,biny,  theMeanSoN );
     input2->setBinContent(binx,biny, input2->getBinContent(binx,biny)+1 );
   }
 


### PR DESCRIPTION
Aesthetic changes to x-axis range and binning in 'total number of off-track clusters' histograms.

Files changed:
- DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc: shrink x-axis range to better fit distributions shown in DQM GUI.
- DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py: Default range needed extending (can only shrink x-axis of original root histograms).