### PR TITLE
reduce max errors/warnings selected for LogError skim per kind to at most 1 per LS

### DIFF
--- a/FWCore/Modules/python/logErrorFilter_cfi.py
+++ b/FWCore/Modules/python/logErrorFilter_cfi.py
@@ -13,8 +13,8 @@ logErrorSkimFilter = cms.EDFilter("LogErrorFilter",
                               atLeastOneError = cms.bool(True),
                               atLeastOneWarning = cms.bool(True),
                               useThresholdsPerKind = cms.bool(True),
-                              maxErrorKindsPerLumi = cms.uint32(3),    
-                              maxWarningKindsPerLumi = cms.uint32(3),    
+                              maxErrorKindsPerLumi = cms.uint32(1),    
+                              maxWarningKindsPerLumi = cms.uint32(1),    
                               avoidCategories = cms.vstring()
                               )
 


### PR DESCRIPTION
LogError is defined by LogErrorFilter and triggers selection of events with errors to be written in RAW-RECO format.
The LogErrorFilter is a stream module, which means that its thresholds are per stream. The old thresholds of 3 become e.g. 24 in 8-thread running, which is more than we ever needed for this.
This PR reduces it to 1 per thread.

This is loosely  connected with #20189 , which will increase the coverage of the LogError skim because the harvester will capture more messages.

