### PR TITLE
increase of pT threshold for photons to be considered for tau reconstruction and ID

### DIFF
--- a/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
@@ -80,12 +80,12 @@ hpsPFTauDiscriminationByLooseIsolation.Prediscriminants.preIso = cms.PSet(
 ## ByMediumIsolation
 hpsPFTauDiscriminationByMediumIsolation = hpsPFTauDiscriminationByLooseIsolation.clone()
 hpsPFTauDiscriminationByMediumIsolation.qualityCuts.isolationQualityCuts.minTrackPt = 0.8
-hpsPFTauDiscriminationByMediumIsolation.qualityCuts.isolationQualityCuts.minGammaEt = 0.8
+hpsPFTauDiscriminationByMediumIsolation.qualityCuts.isolationQualityCuts.minGammaEt = 1.0
 hpsPFTauDiscriminationByMediumIsolation.Prediscriminants.preIso.Producer = cms.InputTag("hpsPFTauDiscriminationByMediumChargedIsolation")
 ## ByTightIsolation
 hpsPFTauDiscriminationByTightIsolation = hpsPFTauDiscriminationByLooseIsolation.clone()
 hpsPFTauDiscriminationByTightIsolation.qualityCuts.isolationQualityCuts.minTrackPt = 0.5
-hpsPFTauDiscriminationByTightIsolation.qualityCuts.isolationQualityCuts.minGammaEt = 0.5
+hpsPFTauDiscriminationByTightIsolation.qualityCuts.isolationQualityCuts.minGammaEt = 1.0
 hpsPFTauDiscriminationByTightIsolation.Prediscriminants.preIso.Producer = cms.InputTag("hpsPFTauDiscriminationByTightChargedIsolation")
 ## ByLooseIsolationDBSumPtCorr
 hpsPFTauDiscriminationByLooseIsolationDBSumPtCorr = hpsPFTauDiscriminationByLooseIsolation.clone(
@@ -128,7 +128,7 @@ hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminati
     Prediscriminants = requireDecayMode.clone()
 )
 hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minTrackPt = 0.5
-hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minGammaEt = 0.5
+hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minGammaEt = 1.0
 ## ByMediumCombinedIsolationDBSumPtCorr
 hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminationByMediumIsolationDBSumPtCorr.clone(
     ApplyDiscriminationByTrackerIsolation = True,
@@ -140,7 +140,7 @@ hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminat
     Prediscriminants = requireDecayMode.clone()
 )
 hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minTrackPt = 0.5
-hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minGammaEt = 0.5
+hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minGammaEt = 1.0
 ## ByTightCombinedIsolationDBSumPtCorr
 hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminationByTightIsolationDBSumPtCorr.clone(
     ApplyDiscriminationByTrackerIsolation = True,
@@ -152,7 +152,7 @@ hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminati
     Prediscriminants = requireDecayMode.clone()
 )
 hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minTrackPt = 0.5
-hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minGammaEt = 0.5
+hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minGammaEt = 1.0
 ## ByLooseChargedIsolation
 hpsPFTauDiscriminationByLooseChargedIsolation = hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr.clone(
     ApplyDiscriminationByECALIsolation = False

--- a/RecoTauTag/RecoTau/python/HLTPFRecoTauQualityCuts_cfi.py
+++ b/RecoTauTag/RecoTau/python/HLTPFRecoTauQualityCuts_cfi.py
@@ -15,7 +15,7 @@ hltPFTauQualityCuts = cms.PSet(
         maxTransverseImpactParameter = cms.double(0.03), # Should in general be disabled at HLT (PV is sometimes missing)
         minTrackVertexWeight         = cms.double(-1),   # Should in general be disabled at HLT (PV is sometimes missing)
         minTrackHits                 = cms.uint32(3),    # total track hits
-        minGammaEt                   = cms.double(0.5),  # filter PFgammas below given Pt
+        minGammaEt                   = cms.double(1.0),  # filter PFgammas below given Pt
         useTracksInsteadOfPFHadrons  = cms.bool(False),  # if true, use generalTracks, instead of PFChargedHadrons
     ),
     isolationQualityCuts = cms.PSet(

--- a/RecoTauTag/RecoTau/python/PFRecoTauChargedHadronBuilderPlugins_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauChargedHadronBuilderPlugins_cfi.py
@@ -31,8 +31,8 @@ chargedPFCandidates = cms.PSet(
     dRmergePhotonWrtOther = cms.double(0.005),    
     minBlockElementMatchesPhoton = cms.int32(2),
     maxUnmatchedBlockElementsPhoton = cms.int32(1),
-    minMergeNeutralHadronEt = cms.double(0.),
-    minMergeGammaEt = cms.double(0.),
+    minMergeNeutralHadronEt = cms.double(1.0),
+    minMergeGammaEt = cms.double(1.0),
     minMergeChargedHadronPt = cms.double(100.)
 )
 
@@ -47,8 +47,8 @@ tracks = cms.PSet(
     qualityCuts = PFTauQualityCuts,
     dRmergeNeutralHadron = cms.double(0.10),
     dRmergePhoton = cms.double(0.05),
-    minMergeNeutralHadronEt = cms.double(0.),
-    minMergeGammaEt = cms.double(0.),
+    minMergeNeutralHadronEt = cms.double(1.0),
+    minMergeGammaEt = cms.double(1.0),
     minMergeChargedHadronPt = cms.double(100.)
 )
 

--- a/RecoTauTag/RecoTau/python/PFRecoTauQualityCuts_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauQualityCuts_cfi.py
@@ -14,7 +14,7 @@ PFTauQualityCuts = cms.PSet(
         minTrackVertexWeight         = cms.double(-1.),    # Tracks weight in vertex
         minTrackPixelHits            = cms.uint32(0),      # pixel-only hits
         minTrackHits                 = cms.uint32(3),      # total track hits
-        minGammaEt                   = cms.double(0.5),    # filter PFgammas below given Pt
+        minGammaEt                   = cms.double(1.0),    # filter PFgammas below given Pt
         #useTracksInsteadOfPFHadrons  = cms.bool(False),   # if true, use generalTracks, instead of PFChargedHadrons
         minNeutralHadronEt           = cms.double(30.)
     ),
@@ -36,7 +36,7 @@ PFTauQualityCuts = cms.PSet(
         minTrackVertexWeight         = cms.double(-1.),    # Tracks weight in vertex
         minTrackPixelHits            = cms.uint32(0),      # pixel-only hits
         minTrackHits                 = cms.uint32(3),      # total track hits
-        minGammaEt                   = cms.double(0.5)     # filter PFgammas below given Pt
+        minGammaEt                   = cms.double(1.0)     # filter PFgammas below given Pt
         #useTracksInsteadOfPFHadrons  = cms.bool(False),   # if true, use generalTracks, instead of PFChargedHadrons
     ),
     # The central definition of primary vertex source.

--- a/RecoTauTag/RecoTau/python/PFRecoTauTagInfoProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauTagInfoProducer_cfi.py
@@ -9,7 +9,7 @@ pfRecoTauTagInfoProducer = cms.EDProducer("PFRecoTauTagInfoProducer",
     ChargedHadrCand_tkminPt    = cms.double(0.5),  # charged PF objects
     tkminPt                    = cms.double(0.5),  # track (non-PF) objects
     NeutrHadrCand_HcalclusMinEt = cms.double(1.0),  # PF neutral hadrons (HCAL)
-    GammaCand_EcalclusMinEt     = cms.double(0.5),  # PF gamma candidates (ECAL)
+    GammaCand_EcalclusMinEt     = cms.double(1.0),  # PF gamma candidates (ECAL)
 
     # The size of the delta R cone used to collect objects from the jet
     ChargedHadrCand_AssociationCone   = cms.double(0.8),

--- a/RecoTauTag/RecoTau/python/RecoTauPiZeroBuilderPlugins_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauPiZeroBuilderPlugins_cfi.py
@@ -60,8 +60,8 @@ comboStrips = cms.PSet(
 modStrips = strips.clone(
     plugin = cms.string('RecoTauPiZeroStripPlugin2'),
     applyElecTrackQcuts = cms.bool(False),
-    minGammaEtStripSeed = cms.double(0.5),
-    minGammaEtStripAdd = cms.double(0.),
+    minGammaEtStripSeed = cms.double(1.0),
+    minGammaEtStripAdd = cms.double(1.0),
     minStripEt = cms.double(1.0),
     updateStripAfterEachDaughter = cms.bool(False),
     maxStripBuildIterations = cms.int32(-1)
@@ -70,24 +70,24 @@ modStrips = strips.clone(
 # Produce a "strips" of photons
 # with no track quality cuts applied to PFElectrons
 # and eta x phi size of strip increasing for low pT photons
-modStrips2 = strips.clone(                                                                                                                           
-    plugin = cms.string('RecoTauPiZeroStripPlugin3'),                                                                                                
-    applyElecTrackQcuts = cms.bool(False),                                                                                                           
-    minGammaEtStripSeed = cms.double(0.5),                                                                                                           
-    minGammaEtStripAdd = cms.double(0.),                                                                                                             
-    minStripEt = cms.double(0.5),                                                                                                                    
-    # CV: parametrization of strip size in eta and phi determined by Yuta Takahashi,                                                                 
-    #     chosen to contain 95% of photons from tau decays                                                                                           
-    stripEtaAssociationDistance = cms.PSet(                                                                                                          
-        function = cms.string("TMath::Min(0.15, TMath::Max(0.05, [0]*TMath::Power(pT, -[1])))"),                                                     
-        par0 = cms.double(1.97077e-01),                                                                                                              
-        par1 = cms.double(6.58701e-01)                                                                                                               
-    ),                                                                                                                                               
-    stripPhiAssociationDistance = cms.PSet(                                                                                                          
-        function = cms.string("TMath::Min(0.3, TMath::Max(0.05, [0]*TMath::Power(pT, -[1])))"),                                                      
-        par0 = cms.double(3.52476e-01),                                                                                                              
-        par1 = cms.double(7.07716e-01)                                                                                                               
-   ),                                                                                                                                                
-    updateStripAfterEachDaughter = cms.bool(False),                                                                                                  
-    maxStripBuildIterations = cms.int32(-1)                                                                                                          
+modStrips2 = strips.clone(
+    plugin = cms.string('RecoTauPiZeroStripPlugin3'),
+    applyElecTrackQcuts = cms.bool(False),
+    minGammaEtStripSeed = cms.double(1.0),
+    minGammaEtStripAdd = cms.double(1.0),
+    minStripEt = cms.double(1.0),
+    # CV: parametrization of strip size in eta and phi determined by Yuta Takahashi,
+    #     chosen to contain 95% of photons from tau decays
+    stripEtaAssociationDistance = cms.PSet(
+        function = cms.string("TMath::Min(0.15, TMath::Max(0.05, [0]*TMath::Power(pT, -[1])))"),
+        par0 = cms.double(1.97077e-01),
+        par1 = cms.double(6.58701e-01)
+    ),
+    stripPhiAssociationDistance = cms.PSet(
+        function = cms.string("TMath::Min(0.3, TMath::Max(0.05, [0]*TMath::Power(pT, -[1])))"),
+        par0 = cms.double(3.52476e-01),
+        par1 = cms.double(7.07716e-01)
+    ),
+    updateStripAfterEachDaughter = cms.bool(False),
+    maxStripBuildIterations = cms.int32(-1)
 )


### PR DESCRIPTION
Hi Slava, Andrea, 

this is a PR to mitigate discrepancies in the MC description of PF photons used for tau reconstruction and ID. To mitigate this issue the pT for PF photons to be considered for tau reconstruction and ID is raised from 0.5 to 1 GeV. The implementation and validation has been provided by @mbluj. I post his initial PR description below (*). These are pure changes on configuration level. We do expect changed in the validation plots (see below). Usual unit tests perform fine. We would like to have this still being part of the upcoming 94X production release! 

Thanx a lot!

Cheers,
Roger 

(*)
As title of the PR says, this is a set of modification of python cfi/cff files to increase Et threshold of PF-photons used in tau reconstruction and identification from 0.5 to 1GeV. The modification is expected to have the following effects:
   * momentum (and thus Pt) of reconstructed taus will be slightly smaller,
   * some, but rather small, migration from decay modes with pi0's to decay modes without pi0's (1p+pi0->1p and 3p+pi0->3p)
   * smaller values of photon related isolation sums, etc.

Expected changes are summarized in slides which can be found here: 
   * https://indico.cern.ch/event/671551/#8-performance-of-tau-recoid-wi
   * https://indico.cern.ch/event/671551/contributions/2752656/attachments/1538977/2412783/mbluj_TauId_GammaPtGt1GeV_11Oct2017.pdf