### PR TITLE
Patch to ignore events causing ECAL DQM Calibration application crashes.

### DIFF
--- a/DQM/EcalMonitorTasks/src/PNDiodeTask.cc
+++ b/DQM/EcalMonitorTasks/src/PNDiodeTask.cc
@@ -1,6 +1,7 @@
 #include "../interface/PNDiodeTask.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace ecaldqm {
 
@@ -59,7 +60,15 @@ namespace ecaldqm {
     }
 
     std::for_each(_ids.begin(), _ids.end(), [&](EcalElectronicsIdCollection::value_type const& id){
-        set->fill(EcalElectronicsId(id.dccId(), id.towerId(), 1, id.xtalId()));
+        try {
+          set->fill(EcalElectronicsId(id.dccId(), id.towerId(), 1, id.xtalId()));
+        }
+        catch(cms::Exception e) {
+          if (e.category() == "InvalidDetId") {
+            edm::LogWarning("EcalDQM") << "PNDiodeTask::runOnErrors : one of the ids in the electronics ID collection is unphysical in lumi number " << timestamp_.iLumi << ". Exception message: " << e.message();
+          }
+          else throw e;
+        }
       });
   }
 


### PR DESCRIPTION
Whenever unphysical detector ID values are introduced in the collection of PN Diode Digis with errors, DQM calls the corresponding constructor with unphysical parameters. This causes the DQM application to crash. This problem has been present for a few months at least, but its frequency has increased over the last few weeks.

This fix adds a try-catch block around the offending line in the DQM code so that such digis are ignored, but at least the calibration application does not crash; in addition, a detailed warning is written to the logs to help ECAL experts with more detailed troubleshooting.

Link to corresponding PR for CMSSW master: https://github.com/cms-sw/cmssw/pull/20902