### PR TITLE
adding good e/gamma flag to PackedCandidate for MiniAOD

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -556,6 +556,11 @@ namespace pat {
         qualityFlags_ = (qualityFlags_ & ~muonFlagsMask) | ((muonFlags << muonFlagsShift) & muonFlagsMask);
     }
 
+    void setGoodEgamma(bool isGoodEgamma = true) {
+        int16_t egFlags = (isGoodEgamma << egammaFlagsShift) & egammaFlagsMask;
+        qualityFlags_ = (qualityFlags_& ~egammaFlagsMask) | egFlags;
+    }
+
     /// PDG identifier                                                                    
     int pdgId() const override   { return pdgId_; }
     // set PDG identifier                                                                 
@@ -626,6 +631,7 @@ namespace pat {
     bool isPhoton() const override { return false; }
     bool isConvertedPhoton() const override { return false; }
     bool isJet() const override { return false; }
+    bool isGoodEgamma() const { return (qualityFlags_ & egammaFlagsMask) !=0; }
 
     // puppiweights
     void setPuppiWeight(float p, float p_nolep = 0.0);  /// Set both weights at once (with option for only full PUPPI)
@@ -761,7 +767,8 @@ namespace pat {
         assignmentQualityMask = 0x7, assignmentQualityShift = 0,
         trackHighPurityMask  = 0x8, trackHighPurityShift=3,
         lostInnerHitsMask = 0x30, lostInnerHitsShift=4,
-        muonFlagsMask = 0x0600, muonFlagsShift=9
+        muonFlagsMask = 0x0600, muonFlagsShift=9,
+	egammaFlagsMask = 0x0800, egammaFlagsShift=11
     };
     
     /// static to allow unit testing

--- a/DataFormats/PatCandidates/test/testPackedCandidate.cc
+++ b/DataFormats/PatCandidates/test/testPackedCandidate.cc
@@ -14,6 +14,7 @@ class testPackedCandidate : public CppUnit::TestFixture {
   CPPUNIT_TEST(testPackUnpack);
   CPPUNIT_TEST(testSimulateReadFromRoot);
   CPPUNIT_TEST(testPackUnpackTime);
+  CPPUNIT_TEST(testQualityFlags);
 
   CPPUNIT_TEST_SUITE_END();
 public:
@@ -26,6 +27,7 @@ public:
   void testSimulateReadFromRoot();
 
   void testPackUnpackTime();
+  void testQualityFlags();
 
 private:
 };
@@ -72,6 +74,7 @@ void testPackedCandidate::testCopyConstructor() {
 static bool tolerance(double iLHS, double iRHS, double fraction) {
   return std::abs(iLHS-iRHS) <= fraction*std::abs(iLHS+iRHS)/2.;
 }
+
 
 void 
 testPackedCandidate::testPackUnpack() {
@@ -270,3 +273,48 @@ void testPackedCandidate::testPackUnpackTime() {
   if (debug) std::cout << std::endl;
 }
 
+
+void testPackedCandidate::testQualityFlags() {
+
+  const std::vector<pat::PackedCandidate::PVAssociationQuality> pvAssocVals = { 
+    pat::PackedCandidate::NotReconstructedPrimary,pat::PackedCandidate::OtherDeltaZ,pat::PackedCandidate::CompatibilityBTag,pat::PackedCandidate::CompatibilityDz,pat::PackedCandidate::UsedInFitLoose,pat::PackedCandidate::UsedInFitTight
+  };
+  const std::vector<pat::PackedCandidate::LostInnerHits> lostHitsVals = {
+    pat::PackedCandidate::validHitInFirstPixelBarrelLayer,pat::PackedCandidate::noLostInnerHits,pat::PackedCandidate::oneLostInnerHit,pat::PackedCandidate::moreLostInnerHits
+  };
+  const std::vector<bool> trackQualVals = {false,true};
+  const std::vector<bool> glbMuonVals={false,true};
+  const std::vector<bool> staMuonVals={false,true};
+  const std::vector<bool> goodEGVals={false,true};
+  
+  pat::PackedCandidate cand;
+
+  for(auto pvAssoc : pvAssocVals){
+    for(auto lostHits : lostHitsVals){
+      for(auto trackQual : trackQualVals){
+	for(auto glbMuon : glbMuonVals){
+	  for(auto staMuon : staMuonVals){
+	    for(auto goodEGamma : goodEGVals){
+	      cand.setMuonID(staMuon,glbMuon);
+	      cand.setGoodEgamma(goodEGamma);
+	      cand.setAssociationQuality(pvAssoc);
+	      cand.setLostInnerHits(lostHits);
+	      cand.setTrackHighPurity(trackQual);
+	      
+	      CPPUNIT_ASSERT(lostHits==cand.lostInnerHits());
+	      CPPUNIT_ASSERT(goodEGamma==cand.isGoodEgamma());
+	      CPPUNIT_ASSERT(staMuon==cand.isStandAloneMuon());
+	      CPPUNIT_ASSERT(glbMuon==cand.isGlobalMuon());
+	      CPPUNIT_ASSERT(trackQual==cand.trackHighPurity());
+	      CPPUNIT_ASSERT(pvAssoc==cand.pvAssociationQuality());
+
+	    }
+	  }
+	}
+      }
+    }
+  }
+}
+	      
+	      
+	    

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -256,7 +256,7 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
             lostHits = ( nlost == 1 ? pat::PackedCandidate::oneLostInnerHit : pat::PackedCandidate::moreLostInnerHits);
           }
 
-
+	  
           outPtrP->push_back( pat::PackedCandidate(cand.polarP4(), vtx, ptTrk, etaAtVtx, phiAtVtx, cand.pdgId(), PVRefProd, PV.key()));
           outPtrP->back().setAssociationQuality(pat::PackedCandidate::PVAssociationQuality(qualityMap[quality]));
           outPtrP->back().setCovarianceVersion(covarianceVersion_);
@@ -299,11 +299,11 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
             PV = reco::VertexRef(PVs, 0);
             PVpos = PV->position();
           }
-
+	
           outPtrP->push_back( pat::PackedCandidate(cand.polarP4(), PVpos, cand.pt(), cand.eta(), cand.phi(), cand.pdgId(), PVRefProd, PV.key()));
           outPtrP->back().setAssociationQuality(pat::PackedCandidate::PVAssociationQuality(pat::PackedCandidate::UsedInFitTight));
         }
-
+    
 	// neutrals and isolated charged hadrons
 
         bool isIsolatedChargedHadron = false;
@@ -322,6 +322,10 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
 	  outPtrP->back().setHcalFraction(0);
 	}
 	
+	//specifically this is the PFLinker requirements to apply the e/gamma regression
+	if(cand.particleId() == reco::PFCandidate::e || (cand.particleId() == reco::PFCandidate::gamma && cand.mva_nothing_gamma()>0.)) { 
+	  outPtrP->back().setGoodEgamma();
+	}
        
         if (usePuppi_){
            reco::PFCandidateRef pkref( cands, ic );


### PR DESCRIPTION
Dear All,

This sets a flag in PackedCandidate to indicate whether candidate is a good e/gamma object or not. Here good means "gets E/gamma energy regresssions". All electrons are automatically good, the problem is for photons, theres no way at the miniAOD level to know if you should apply the regression to it or not short of trying to do a tight p4 match with the original photon which is error prone.

This small change will greatly help E/gamma and JetMET understand the effects of the regression on jets + met as well as making it a lot easier to apply new energy corrections. Given the ongoing issues with E/gamma energy regression corrections, its extremely useful to have a clean way to re apply them at the miniAOD level. 

As an aside, had this feature already been here, the regression PR would have already gone though as my bug was in trying to apply the regression on miniAOD packed candidates. 

I've already cleared this with XPOG. 

I have one more minor check to do in the morning 