### PR TITLE
Fix negative error cases

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
@@ -1,5 +1,5 @@
 //
-//  SiPixelTemplate.h (v10.00)
+//  SiPixelTemplate.h (v10.13)
 //
 //  Add goodness-of-fit info and spare entries to templates, version number in template header, more error checking
 //  Add correction for (Q_F-Q_L)/(Q_F+Q_L) bias
@@ -71,6 +71,12 @@
 //  V9.00 - Expand header to include multi and single dcol thresholds, LA biases, and (variable) Qbin definitions
 //  V9.01 - Protect against negative error squared
 //  V10.00 - Update to work with Phase 1 FPix.  Fix some code problems introduced by other maintainers.
+//  V10.01 - Fix initialization style as suggested by S. Krutelyov
+//  V10.10 - Add class variables and methods to correctly calculate the probabilities of single pixel clusters
+//  V10.11 - Allow subdetector ID=5 for FPix R2P2 [allows better internal labeling of templates]
+//  V10.12 - Enforce minimum signal size in pixel charge uncertainty calculation
+//  V10.13 - Update the variable size [SI_PIXEL_TEMPLATE_USE_BOOST] option so that it works with VI's enhancements
+
 
 
 // Created by Morris Swartz on 10/27/06.
@@ -203,13 +209,16 @@ struct SiPixelTemplateHeader {           //!< template header structure
 
 struct SiPixelTemplateStore { //!< template storage structure
    SiPixelTemplateHeader head;
+#ifndef SI_PIXEL_TEMPLATE_USE_BOOST
    float cotbetaY[60];
    float cotbetaX[5];
    float cotalphaX[29];
-#ifndef SI_PIXEL_TEMPLATE_USE_BOOST
    SiPixelTemplateEntry enty[60];     //!< 60 Barrel y templates spanning cluster lengths from 0px to +18px [28 entries for fpix]
    SiPixelTemplateEntry entx[5][29];  //!< 29 Barrel x templates spanning cluster lengths from -6px (-1.125Rad) to +6px (+1.125Rad) in each of 5 slices [3x29 for fpix]
 #else
+   float* cotbetaY;
+   float* cotbetaX;
+   float* cotalphaX;
    boost::multi_array<SiPixelTemplateEntry,1> enty;     //!< use 1d entry to store [60] barrel entries or [28] fpix entries
    boost::multi_array<SiPixelTemplateEntry,2> entx;     //!< use 2d entry to store [5][29] barrel entries or [3][29] fpix entries
 #endif
@@ -323,7 +332,7 @@ public:
    float pixmax() {return pixmax_;}         //!< maximum pixel charge
    float qscale() {return qscale_;}         //!< charge scaling factor
    float s50() {return s50_;}               //!< 1/2 of the pixel threshold signal in electrons
-   float ss50() {return ss50_;}               //!< 1/2 of the pixel threshold signal in electrons
+   float ss50() {return ss50_;}               //!< 1/2 of the single pixel per double column threshold in electrons
    float symax() {return symax_;}             //!< average pixel signal for y-projection of cluster
    float dyone() {return dyone_;}             //!< mean offset/correction for one pixel y-clusters
    float syone() {return syone_;}             //!< rms for one pixel y-clusters
@@ -515,6 +524,10 @@ public:
    float ysize() {return ysize_;}                                    //!< pixel y-size (microns)
    float zsize() {return zsize_;}                                    //!< pixel z-size or thickness (microns)
    float r_qMeas_qTrue() {return r_qMeas_qTrue_;}                    //!< ratio of measured to true cluster charge
+   float fracyone() {return fracyone_;}                              //!< The simulated fraction of single pixel y-clusters 
+   float fracxone() {return fracxone_;}                              //!< The simulated fraction of single pixel x-clusters 
+   float fracytwo() {return fracytwo_;}                              //!< The simulated fraction of single double-size pixel y-clusters 
+   float fracxtwo() {return fracxtwo_;}                              //!< The simulated fraction of single double-size pixel x-clusters 
    //  float yspare(int i) {assert(i>=0 && i<5); return pyspare[i];}    //!< vector of 5 spares interpolated in beta only
    //  float xspare(int i) {assert(i>=0 && i<10); return pxspare[i];}    //!< vector of 10 spares interpolated in alpha and beta
    
@@ -536,8 +549,8 @@ private:
    float qavg_;              //!< average cluster charge for this set of track angles
    float pixmax_;            //!< maximum pixel charge
    float qscale_;            //!< charge scaling factor
-   float s50_;               //!< 1/2 of the pixel threshold signal in adc units
-   float ss50_;              //!< 1/2 of the pixel threshold signal in adc units
+   float s50_;               //!< 1/2 of the pixel single col threshold signal in electrons
+   float ss50_;              //!< 1/2 of the pixel double col threshold signal in electrons
    float symax_;             //!< average pixel signal for y-projection of cluster
    float syparmax_;          //!< maximum pixel signal for parameterization of y uncertainties
    float dyone_;             //!< mean offset/correction for one pixel y-clusters
@@ -614,6 +627,10 @@ private:
    float nxbins_;            //!< number of bins in each dimension of the x-splitting template
    float r_qMeas_qTrue_;     //!< ratio of measured to true cluster charges
    float fbin_[3];           //!< The QBin definitions in Q_clus/Q_avg
+   float fracyone_;          //!< The simulated fraction of single pixel y-clusters 
+   float fracxone_;          //!< The simulated fraction of single pixel x-clusters 
+   float fracytwo_;          //!< The simulated fraction of single double-size pixel y-clusters 
+   float fracxtwo_;          //!< The simulated fraction of single double-size pixel x-clusters 
    boost::multi_array<float,2> temp2dy_; //!< 2d-primitive for spltting 3-d template
    boost::multi_array<float,2> temp2dx_; //!< 2d-primitive for spltting 3-d template
    

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
@@ -216,11 +216,16 @@ struct SiPixelTemplateStore { //!< template storage structure
    SiPixelTemplateEntry enty[60];     //!< 60 Barrel y templates spanning cluster lengths from 0px to +18px [28 entries for fpix]
    SiPixelTemplateEntry entx[5][29];  //!< 29 Barrel x templates spanning cluster lengths from -6px (-1.125Rad) to +6px (+1.125Rad) in each of 5 slices [3x29 for fpix]
 #else
-   float* cotbetaY;
-   float* cotbetaX;
-   float* cotalphaX;
+   float* cotbetaY=nullptr;
+   float* cotbetaX=nullptr;
+   float* cotalphaX=nullptr;
    boost::multi_array<SiPixelTemplateEntry,1> enty;     //!< use 1d entry to store [60] barrel entries or [28] fpix entries
    boost::multi_array<SiPixelTemplateEntry,2> entx;     //!< use 2d entry to store [5][29] barrel entries or [3][29] fpix entries
+   ~SiPixelTemplateStore() {  // deletes arrays created by pushfile method of SiPixelTemplate
+      if (cotbetaY!=nullptr) delete[] cotbetaY;
+      if (cotbetaX!=nullptr) delete[] cotbetaX;
+      if (cotalphaX!=nullptr) delete[] cotalphaX;
+   }
 #endif
 } ;
 

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
@@ -215,13 +215,14 @@ struct SiPixelTemplateStore { //!< template storage structure
    float cotalphaX[29];
    SiPixelTemplateEntry enty[60];     //!< 60 Barrel y templates spanning cluster lengths from 0px to +18px [28 entries for fpix]
    SiPixelTemplateEntry entx[5][29];  //!< 29 Barrel x templates spanning cluster lengths from -6px (-1.125Rad) to +6px (+1.125Rad) in each of 5 slices [3x29 for fpix]
+   void destroy() {};
 #else
    float* cotbetaY=nullptr;
    float* cotbetaX=nullptr;
    float* cotalphaX=nullptr;
    boost::multi_array<SiPixelTemplateEntry,1> enty;     //!< use 1d entry to store [60] barrel entries or [28] fpix entries
    boost::multi_array<SiPixelTemplateEntry,2> entx;     //!< use 2d entry to store [5][29] barrel entries or [3][29] fpix entries
-   ~SiPixelTemplateStore() {  // deletes arrays created by pushfile method of SiPixelTemplate
+   void destroy() {  // deletes arrays created by pushfile method of SiPixelTemplate
       if (cotbetaY!=nullptr) delete[] cotbetaY;
       if (cotbetaX!=nullptr) delete[] cotbetaX;
       if (cotalphaX!=nullptr) delete[] cotalphaX;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -46,7 +46,7 @@ PixelCPETemplateReco::PixelCPETemplateReco(edm::ParameterSet const & conf,
                                            const TrackerTopology& ttopo,
                                            const SiPixelLorentzAngle * lorentzAngle,
                                            const SiPixelTemplateDBObject * templateDBobject)
-: PixelCPEBase(conf, mag, geom, ttopo, lorentzAngle, 0, templateDBobject, 0,1)
+: PixelCPEBase(conf, mag, geom, ttopo, lorentzAngle, nullptr, templateDBobject, nullptr,1)
 {
    //cout << endl;
    //cout << "Constructing PixelCPETemplateReco::PixelCPETemplateReco(...)................................................." << endl;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -97,7 +97,7 @@ PixelCPETemplateReco::PixelCPETemplateReco(edm::ParameterSet const & conf,
 //-----------------------------------------------------------------------------
 PixelCPETemplateReco::~PixelCPETemplateReco()
 {
-   // &&& delete template store?
+   for(auto x : thePixelTemp_) x.destroy();
 }
 
 PixelCPEBase::ClusterParam* PixelCPETemplateReco::createClusterParam(const SiPixelCluster & cl) const

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelGenError.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelGenError.cc
@@ -679,7 +679,6 @@ int SiPixelGenError::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
    
    
    
-   ilow = ihigh = 0;
    auto xxratio = 0.f;
    
    {

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelGenError.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelGenError.cc
@@ -11,7 +11,7 @@
 //#include <stdlib.h>
 //#include <stdio.h>
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-#include <math.h>
+#include <cmath>
 #else
 #include <math.h>
 #endif

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
@@ -1,5 +1,5 @@
 //
-//  SiPixelTemplate.cc  Version 10.00
+//  SiPixelTemplate.cc  Version 10.13
 //
 //  Add goodness-of-fit info and spare entries to templates, version number in template header, more error checking
 //  Add correction for (Q_F-Q_L)/(Q_F+Q_L) bias
@@ -73,6 +73,12 @@
 //  V9.00 - Expand header to include multi and single dcol thresholds, LA biases, and (variable) Qbin definitions
 //  V9.01 - Protect against negative error squared
 //  V10.00 - Update to work with Phase 1 FPix.  Fix some code problems introduced by other maintainers.
+//  V10.01 - Fix initialization style as suggested by S. Krutelyov
+//  V10.10 - Add class variables and methods to be used to correctly calculate the probabilities of single pixel clusters
+//  V10.11 - Allow subdetector ID=5 for FPix R2P2 [allows better internal labeling of templates]
+//  V10.12 - Enforce minimum signal size in pixel charge uncertainty calculation
+//  V10.13 - Update the variable size [SI_PIXEL_TEMPLATE_USE_BOOST] option so that it works with VI's enhancements
+
 
 
 //  Created by Morris Swartz on 10/27/06.
@@ -86,7 +92,7 @@
 #endif
 #include <algorithm>
 #include <vector>
-//#include "boost/multi_array.hpp"
+#include "boost/multi_array.hpp"
 #include <iostream>
 #include <iomanip>
 #include <sstream>
@@ -213,6 +219,10 @@ bool SiPixelTemplate::pushfile(int filenum, std::vector< SiPixelTemplateStore > 
       
       // next, layout the 1-d/2-d structures needed to store template
       
+      theCurrentTemp.cotbetaY = new float[theCurrentTemp.head.NTy];
+      theCurrentTemp.cotbetaX = new float[theCurrentTemp.head.NTyx];
+      theCurrentTemp.cotalphaX = new float[theCurrentTemp.head.NTxx];
+
       theCurrentTemp.enty.resize(boost::extents[theCurrentTemp.head.NTy]);
       
       theCurrentTemp.entx.resize(boost::extents[theCurrentTemp.head.NTyx][theCurrentTemp.head.NTxx]);
@@ -629,6 +639,9 @@ bool SiPixelTemplate::pushfile(const SiPixelTemplateDBObject& dbobject, std::vec
 #ifdef SI_PIXEL_TEMPLATE_USE_BOOST
       
       // next, layout the 1-d/2-d structures needed to store template
+      theCurrentTemp.cotbetaY = new float[theCurrentTemp.head.NTy];
+      theCurrentTemp.cotbetaX = new float[theCurrentTemp.head.NTyx];
+      theCurrentTemp.cotalphaX = new float[theCurrentTemp.head.NTxx];
       theCurrentTemp.enty.resize(boost::extents[theCurrentTemp.head.NTy]);
       theCurrentTemp.entx.resize(boost::extents[theCurrentTemp.head.NTyx][theCurrentTemp.head.NTxx]);
       
@@ -1073,6 +1086,7 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
          case 2:
          case 3:
          case 4:
+         case 5:
             if(locBx*locBz < 0.f) {
                cota = -cotalpha;
                flip_x = true;
@@ -1219,12 +1233,15 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
          }
       }
       
-      //// Do the spares next
+      //// Single pixel cluster probabilities
       
       chi2yavgone_=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].chi2yavgone + yratio*thePixelTemp_[index_id_].enty[ihigh].chi2yavgone;
       chi2yminone_=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].chi2yminone + yratio*thePixelTemp_[index_id_].enty[ihigh].chi2yminone;
       chi2xavgone=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].chi2xavgone + yratio*thePixelTemp_[index_id_].enty[ihigh].chi2xavgone;
       chi2xminone=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].chi2xminone + yratio*thePixelTemp_[index_id_].enty[ihigh].chi2xminone;
+      
+      fracyone_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].fracyone + yratio*thePixelTemp_[index_id_].enty[ihigh].fracyone;
+      fracytwo_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].fracytwo + yratio*thePixelTemp_[index_id_].enty[ihigh].fracytwo;
       //       for(i=0; i<10; ++i) {
       //		    pyspare[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].yspare[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].yspare[i];
       //       }
@@ -1415,6 +1432,12 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
       
       chi2xminone_=((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xminone + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xminone);
       if(thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xminone != 0.f) {chi2xminone_=chi2xminone_/thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xminone*chi2xminone;}
+      
+      fracxone_ = (1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].fracxone + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].fracxone)
+   +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].fracxone + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].fracxone);
+      fracxtwo_ = (1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].fracxtwo + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].fracxtwo)
+   +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].fracxtwo + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].fracxtwo);
+   
       //       for(i=0; i<10; ++i) {
       //	      pxspare[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].xspare[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].xspare[i])
       //		          +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xspare[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xspare[i]);
@@ -1517,7 +1540,7 @@ void SiPixelTemplate::ysigma2(int fypix, int lypix, float sythr, float ysum[25],
    
    // Local variables
    int i;
-   float sigi, sigi2, sigi3, sigi4, symax, qscale;
+   float sigi, sigi2, sigi3, sigi4, symax, qscale, s25;
    
    // Make sure that input is OK
    
@@ -1539,6 +1562,7 @@ void SiPixelTemplate::ysigma2(int fypix, int lypix, float sythr, float ysum[25],
    // Define the maximum signal to use in the parameterization
    
    symax = symax_;
+   s25 = 0.5f*s50_;
    if(symax_ > syparmax_) {symax = syparmax_;}
    
    // Evaluate pixel-by-pixel uncertainties (weights) for the templ analysis
@@ -1553,6 +1577,7 @@ void SiPixelTemplate::ysigma2(int fypix, int lypix, float sythr, float ysum[25],
          if(ysum[i] < symax) {
             sigi = ysum[i];
             qscale = 1.f;
+            if(sigi < s25) sigi = s25;
          } else {
             sigi = symax;
             qscale = ysum[i]/symax;
@@ -1594,7 +1619,7 @@ void SiPixelTemplate::ysigma2(float qpixel, int index, float& ysig2)
    // Interpolate using quantities already stored in the private variables
    
    // Local variables
-   float sigi, sigi2, sigi3, sigi4, symax, qscale, err2;
+   float sigi, sigi2, sigi3, sigi4, symax, qscale, err2, s25;
    
    // Make sure that input is OK
    
@@ -1609,6 +1634,7 @@ void SiPixelTemplate::ysigma2(float qpixel, int index, float& ysig2)
    // Define the maximum signal to use in the parameterization
    
    symax = symax_;
+   s25 = 0.5f*s50_;
    if(symax_ > syparmax_) {symax = syparmax_;}
    
    // Evaluate pixel-by-pixel uncertainties (weights) for the templ analysis
@@ -1616,6 +1642,7 @@ void SiPixelTemplate::ysigma2(float qpixel, int index, float& ysig2)
 			if(qpixel < symax) {
             sigi = qpixel;
             qscale = 1.f;
+            if(sigi < s25) sigi = s25;
          } else {
             sigi = symax;
             qscale = qpixel/symax;
@@ -1660,7 +1687,7 @@ void SiPixelTemplate::xsigma2(int fxpix, int lxpix, float sxthr, float xsum[11],
    
    // Local variables
    int i;
-   float sigi, sigi2, sigi3, sigi4, yint, sxmax, x0, qscale;
+   float sigi, sigi2, sigi3, sigi4, yint, sxmax, x0, qscale, s25;
    
    // Make sure that input is OK
    
@@ -1682,6 +1709,7 @@ void SiPixelTemplate::xsigma2(int fxpix, int lxpix, float sxthr, float xsum[11],
    // Define the maximum signal to use in the parameterization
    
    sxmax = sxmax_;
+   s25 = 0.5f*s50_;
    if(sxmax_ > sxparmax_) {sxmax = sxparmax_;}
    
    // Evaluate pixel-by-pixel uncertainties (weights) for the templ analysis
@@ -1696,6 +1724,7 @@ void SiPixelTemplate::xsigma2(int fxpix, int lxpix, float sxthr, float xsum[11],
          if(xsum[i] < sxmax) {
             sigi = xsum[i];
             qscale = 1.f;
+            if(sigi < s25) sigi = s25;
          } else {
             sigi = sxmax;
             qscale = xsum[i]/sxmax;
@@ -2406,6 +2435,7 @@ int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
       case 2:
       case 3:
       case 4:
+      case 5:
          if(locBx*locBz < 0.f) {
             cota = -cotalpha;
             flip_x = true;
@@ -2630,9 +2660,7 @@ int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
    // Interpolate for a new set of track angles
    
    // Local variables
-   float locBx; //  lorywidth, lorxwidth;
-   // Local variables
-   locBx = 1.f;
+   float locBx = 1.f; //  lorywidth, lorxwidth;
    
    return SiPixelTemplate::qbin(id, cotalpha, cotbeta, locBz, locBx, qclus, pixmx, sigmay, deltay, sigmax, deltax,
                                 sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2); // , lorywidth, lorxwidth);
@@ -2687,9 +2715,9 @@ int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float qclus)
    // Interpolate for a new set of track angles
    
    // Local variables
-   float pixmx, sigmay, deltay, sigmax, deltax, sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2, locBz, locBx; //  lorywidth, lorxwidth;
+   float pixmx, sigmay, deltay, sigmax, deltax, sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2, locBz; //  lorywidth, lorxwidth;
    // Local variables
-   locBx = 1.f;
+   float locBx = 1.f;
    if(cotbeta < 0.f) {locBx = -1.f;}
    locBz = locBx;
    if(cotalpha < 0.f) {locBz = -locBx;}

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
@@ -2573,7 +2573,6 @@ int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
    
    
    
-   ilow = ihigh = 0;
    auto xxratio = 0.f;
    
    {


### PR DESCRIPTION
Followup from problem reported in https://hypernews.cern.ch/HyperNews/CMS/get/pixelOfflineSW/1332/1/2/1/1.html

The fix enforces a minimum charge for the charge error calculation to avoid cases of negative x-error computed by the template reconstruction.

More details about the changes are written at the beginning of the header file.

It was tested that it doesn't break limited matrix workflows.
Using templates from GlobalTag 92X_dataRun2_Prompt_v9 and 1000 events from /SingleMuon/Run2017E-PromptReco-v1/RECO, Run 304663 it was checked that it doesn't affect the pixel triplet resolutions.