### PR TITLE
Remove unused variables to fix warnings

### DIFF
--- a/ElectroWeakAnalysis/ZMuMu/plugins/MuTriggerAnalyzer.cc
+++ b/ElectroWeakAnalysis/ZMuMu/plugins/MuTriggerAnalyzer.cc
@@ -212,22 +212,12 @@ void MuTriggerAnalyzer::analyze (const Event & ev, const EventSetup &) {
       unsigned int nHighPtGlbMu = highPtGlbMuons.size();
       std::cout << "I've got " << nHighPtGlbMu << " nHighPtGlbMu" << std::endl;
       // unsigned int nHighPtStaMu = highPtStaMuons.size();
-
-	// stop the loop after 10 cicles....
-       	(nHighPtGlbMu> 10)?   nHighPtGlbMu=10 : 1;
-
-	if (nHighPtGlbMu>0 ){
-
-           for(unsigned int i =0 ; i < nHighPtGlbMu ; i++) {
-	    reco::Muon muon1 = highPtGlbMuons[i];
-	    const math::XYZTLorentzVector& mu1(muon1.p4());
-	    //      double pt1= muon1.pt();
-
-	    /* bool singleTrigFlag1 =*/ IsMuMatchedToHLTMu ( muon1,  HLTMuMatched ,maxDeltaR_, maxDPtRel_ );
-
-	  }
-
-	}
+      // stop the loop after 10 cicles....
+      if (nHighPtGlbMu> 10) nHighPtGlbMu=10;
+      
+      for(unsigned int i =0 ; i < nHighPtGlbMu ; i++) {
+	IsMuMatchedToHLTMu ( highPtGlbMuons[i],  HLTMuMatched ,maxDeltaR_, maxDPtRel_ );
+      }
 
 }
 


### PR DESCRIPTION
Fix warning from unused var and remove a local copy var and unused commented vars. IsMuMatchedToHLTMu method is getting some arguments by reference and filling histogram that is member of the class, justifying the for loop. 
Edit: ternary condition substituted with if condition as it was not doing what it supposed to, redundant if condition (before the last loop) removed