### PR TITLE
Generator Configs for relval rquest with 94X

### DIFF
--- a/Configuration/Generator/python/QCD_Pt_15to30_13TeV_TuneCUETP8M1_pythia8_cff.py
+++ b/Configuration/Generator/python/QCD_Pt_15to30_13TeV_TuneCUETP8M1_pythia8_cff.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(1.0),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(1.83741e+09),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 15  ',
+			'PhaseSpace:pTHatMax = 30  ',
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD pthat 15to30 GeV, 13 TeV, TuneCUETP8M1')
+)

--- a/Configuration/Generator/python/UndergroundCosmicMu_forTRK_cfi.py
+++ b/Configuration/Generator/python/UndergroundCosmicMu_forTRK_cfi.py
@@ -1,0 +1,45 @@
+import FWCore.ParameterSet.Config as cms
+from GeneratorInterface.GenFilters.CosmicGenFilterHelix_cff import * 
+
+generator = cms.EDProducer("CosMuoGenProducer",
+    ZCentrOfTarget = cms.double(0.0),
+    MinP = cms.double(4.0),
+    MinP_CMS = cms.double(-1.0), ##negative means MinP_CMS = MinP. Only change this if you know what you are doing!
+    MaxP = cms.double(3000.0),
+    MinTheta = cms.double(0.0),
+    MaxTheta = cms.double(75.),
+    MinPhi = cms.double(0.0),
+    MaxPhi = cms.double(360.0),
+    MinT0 = cms.double(-12.5),
+    MaxT0 = cms.double(12.5),
+    PlugVx = cms.double(0.0),
+    PlugVz = cms.double(-14000.0),                
+    MinEnu = cms.double(10.),                
+    MaxEnu = cms.double(10000.),                
+    NuProdAlt = cms.double(7.5e6),                       
+    AcptAllMu = cms.bool(False), 
+    ElossScaleFactor = cms.double(1.0),
+    RadiusOfTarget = cms.double(8000.0),
+    ZDistOfTarget = cms.double(15000.0),
+    TrackerOnly = cms.bool(False),
+    TIFOnly_constant = cms.bool(False),
+    TIFOnly_linear = cms.bool(False),
+    MTCCHalf = cms.bool(False),
+    Verbosity = cms.bool(False),
+    RhoAir = cms.double(0.001214),
+    RhoWall = cms.double(2.5),
+    RhoRock = cms.double(2.5),
+    RhoClay = cms.double(2.3),
+    RhoPlug = cms.double(2.5),
+    ClayWidth = cms.double(50000.),
+                           
+    MultiMuon = cms.bool(False),
+    # MultiMuon = cms.bool(True),
+    MultiMuonFileName = cms.string("CORSIKAmultiMuon.root"),
+    MultiMuonFileFirstEvent = cms.int32(1),
+    MultiMuonNmin = cms.int32(2),              
+)
+
+
+#Filter
+ProductionFilterSequence = cms.Sequence(generator*cosmicInTracker)


### PR DESCRIPTION
Greetings,
this PR is meant to add two fragments in view of the MC requests from the tracker with the next pre-release (preparation of V2 MC) 
Possibly the relval machinery will be used for these special requests, therefore I prepared the fragments which would be needed in a release for the relval requests.

Note that the two fragments in questions  are 
1) QCD pt15 to 30 strictly the same as  used in the V1 MC campaign , 
https://cms-pdmv.cern.ch/mcm/requests?prepid=BTV-RunIISummer17GS-00005&page=0&shown=127
https://raw.githubusercontent.com/cms-sw/genproductions/85ccec18763776e0613830cde524bc7a4c77bc49/python/ThirteenTeV/QCD_Pt_15to30_TuneCUETP8M1_13TeV_pythia8_cff.py

2) Cosmic fragment,  strictly the same the one as used in the V1 MC campaign : 
https://cms-pdmv.cern.ch/mcm/requests?prepid=TRK-RunIISummer17CosmicGS-00001&page=0&shown=127
https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/TRK-RunIISummer17CosmicGS-00001


