### PR TITLE
Enable packing/unpacking for Phase2 HCAL

### DIFF
--- a/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
@@ -158,35 +158,41 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
 
 es_prefer_hcalHardcode = cms.ESPrefer("HcalHardcodeCalibrations", "es_hardcode")
 
+_toGet = [
+    'GainWidths',
+    'MCParams',
+    'RecoParams',
+    'RespCorrs',
+    'QIEData',
+    'QIETypes',
+    'Gains',
+    'Pedestals',
+    'PedestalWidths',
+    'ChannelQuality',
+    'ZSThresholds',
+    'TimeCorrs',
+    'LUTCorrs',
+    'LutMetadata',
+    'L1TriggerObjects',
+    'PFCorrs',
+    'ElectronicsMap',
+    'FrontEndMap',
+    'CovarianceMatrices',
+    'SiPMParameters',
+    'SiPMCharacteristics',
+    'TPChannelParameters',
+    'TPParameters',
+    'FlagHFDigiTimeParams'
+]
+
+_toGet_noEmap = _toGet[:]
+_toGet_noEmap.remove('ElectronicsMap')
+
+
 from Configuration.Eras.Modifier_hcalHardcodeConditions_cff import hcalHardcodeConditions
 hcalHardcodeConditions.toModify( es_hardcode,
-	toGet = cms.untracked.vstring(
-		'GainWidths',
-		'MCParams',
-		'RecoParams',
-		'RespCorrs',
-		'QIEData',
-		'QIETypes',
-		'Gains',
-		'Pedestals',
-		'PedestalWidths',
-		'ChannelQuality',
-		'ZSThresholds',
-		'TimeCorrs',
-		'LUTCorrs',
-		'LutMetadata',
-		'L1TriggerObjects',
-		'PFCorrs',
-		'ElectronicsMap',
-		'FrontEndMap',
-		'CovarianceMatrices',
-		'SiPMParameters',
-		'SiPMCharacteristics',
-		'TPChannelParameters',
-		'TPParameters',
-		'FlagHFDigiTimeParams'
-	),
-	GainWidthsForTrigPrims = cms.bool(True) 
+    toGet = cms.untracked.vstring(_toGet),
+    GainWidthsForTrigPrims = cms.bool(True) 
 )
 
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
@@ -200,6 +206,9 @@ run2_HF_2017.toModify( es_hardcode, useHFUpgrade = cms.bool(True) )
 run2_HE_2017.toModify( es_hardcode, useHEUpgrade = cms.bool(True), HEreCalibCutoff = cms.double(100.0) )
 run2_HEPlan1_2017.toModify( es_hardcode, testHEPlan1 = cms.bool(True), useHEUpgrade = cms.bool(False), HEreCalibCutoff = cms.double(20.0) )
 run3_HB.toModify( es_hardcode, useHBUpgrade = cms.bool(True), HBreCalibCutoff = cms.double(100.0) )
+
+# now that we have an emap
+run3_HB.toModify( es_hardcode, toGet = cms.untracked.vstring(_toGet_noEmap) )
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify( es_hardcode, killHE = cms.bool(True) )

--- a/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
@@ -200,6 +200,7 @@ from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
 from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 
 run2_HCAL_2017.toModify( es_hardcode, useLayer0Weight = cms.bool(True) )
 run2_HF_2017.toModify( es_hardcode, useHFUpgrade = cms.bool(True) )
@@ -208,7 +209,7 @@ run2_HEPlan1_2017.toModify( es_hardcode, testHEPlan1 = cms.bool(True), useHEUpgr
 run3_HB.toModify( es_hardcode, useHBUpgrade = cms.bool(True), HBreCalibCutoff = cms.double(100.0) )
 
 # now that we have an emap
-run3_HB.toModify( es_hardcode, toGet = cms.untracked.vstring(_toGet_noEmap) )
+phase2_hcal.toModify( es_hardcode, toGet = cms.untracked.vstring(_toGet_noEmap) )
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify( es_hardcode, killHE = cms.bool(True) )

--- a/Configuration/Eras/python/Era_Phase2_cff.py
+++ b/Configuration/Eras/python/Era_Phase2_cff.py
@@ -16,9 +16,8 @@ from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 from Configuration.Eras.Modifier_hcalHardcodeConditions_cff import hcalHardcodeConditions
-from Configuration.Eras.Modifier_hcalSkipPacker_cff import hcalSkipPacker
 
 Phase2 = cms.ModifierChain(run2_common, run3_common, phase2_common, phase2_tracker, trackingPhase2PU140, phase2_ecal,
     run2_HE_2017, run2_HF_2017, run2_HCAL_2017, run3_HB, phase2_hcal, phase2_hgcal, phase2_muon, run3_GEM, stage2L1Trigger,
-    hcalHardcodeConditions, hcalSkipPacker,
+    hcalHardcodeConditions,
 )

--- a/Configuration/Eras/python/Era_Run3_cff.py
+++ b/Configuration/Eras/python/Era_Run3_cff.py
@@ -6,7 +6,6 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_hcalHardcodeConditions_cff import hcalHardcodeConditions
-from Configuration.Eras.Modifier_hcalSkipPacker_cff import hcalSkipPacker
 
-Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017]), run3_common, run3_GEM, run3_HB, hcalHardcodeConditions, hcalSkipPacker)
+Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017]), run3_common, run3_GEM, run3_HB, hcalHardcodeConditions)
 

--- a/Configuration/Eras/python/Era_Run3_cff.py
+++ b/Configuration/Eras/python/Era_Run3_cff.py
@@ -6,6 +6,7 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_hcalHardcodeConditions_cff import hcalHardcodeConditions
+from Configuration.Eras.Modifier_hcalSkipPacker_cff import hcalSkipPacker
 
-Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017]), run3_common, run3_GEM, run3_HB, hcalHardcodeConditions)
+Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017]), run3_common, run3_GEM, run3_HB, hcalHardcodeConditions, hcalSkipPacker)
 

--- a/RecoLocalCalo/HcalRecProducers/src/ZdcHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/ZdcHitReconstructor.cc
@@ -110,9 +110,12 @@ void ZdcHitReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSet
      e.getByToken(tok_input_hcal,digi);
      
      if(digi->empty()) {
-       e.getByToken(tok_input_castor,digi);
-       if(digi->empty()) 
+       edm::Handle<ZDCDigiCollection> digi_castor;
+       e.getByToken(tok_input_castor,digi_castor);
+       if(!digi_castor.isValid() || digi_castor->empty()) 
        	 edm::LogInfo("ZdcHitReconstructor") << "No ZDC info found in either castorDigis or hcalDigis." << std::endl;
+       if(digi_castor.isValid())
+         e.getByToken(tok_input_castor,digi);
      }
         
      // create empty output


### PR DESCRIPTION
With #20758, we have a Phase2 GT that contains a functioning emap with all the HB upgrade cells.

This means that we no longer have to skip packing/unpacking for HB in Phase2 workflows. Among other things, this will enable premixing to work for the Phase2 HB.

(These changes were also propagated to 2019/post-LS2, but had to be disabled because there isn't a 2019 GT queue yet.)