### PR TITLE
GT Updates with Pixel Local Reco conditions for V2 MC

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -40,19 +40,19 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '94X_dataRun2_HLTHI_frozen_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '94X_mc2017_design_IdealBS_v2',
+    'phase1_2017_design'       :  '94X_mc2017_design_IdealBS_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '94X_mc2017_realistic_v2',
+    'phase1_2017_realistic'    : '94X_mc2017_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '94X_mc2017cosmics_realistic_deco_v1',
+    'phase1_2017_cosmics'      : '94X_mc2017cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '94X_mc2017cosmics_realistic_peak_v1',
+    'phase1_2017_cosmics_peak' : '94X_mc2017cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '94X_upgrade2018_design_IdealBS_v2',
+    'phase1_2018_design'       : '94X_upgrade2018_design_IdealBS_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '94X_upgrade2018_realistic_v2',
+    'phase1_2018_realistic'    : '94X_upgrade2018_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '94X_upgrade2018cosmics_realistic_deco_v1',
+    'phase1_2018_cosmics'      :   '94X_upgrade2018cosmics_realistic_deco_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023


### PR DESCRIPTION
# Summary of changes in Global Tags 
 
## Upgrade 
 
   * **PhaseI 2018 cosmics scenario** : [94X_upgrade2018cosmics_realistic_deco_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018cosmics_realistic_deco_v3) as [94X_upgrade2018cosmics_realistic_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018cosmics_realistic_deco_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_upgrade2018cosmics_realistic_deco_v3/94X_upgrade2018cosmics_realistic_deco_v1): 
      * update of pixel local reco conditions for V2 MC : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3313.html

   * **PhaseI 2018 design scenario** : [94X_upgrade2018_design_IdealBS_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018_design_IdealBS_v4) as [94X_upgrade2018_design_IdealBS_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018_design_IdealBS_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_upgrade2018_design_IdealBS_v4/94X_upgrade2018_design_IdealBS_v2): 
      * update of pixel local reco conditions for V2 MC : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3313.html

   * **PhaseI 2018 realistic scenario** : [94X_upgrade2018_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018_realistic_v4) as [94X_upgrade2018_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_upgrade2018_realistic_v4/94X_upgrade2018_realistic_v2): 
      * update of pixel local reco conditions for V2 MC : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3313.html

## 2017_MC 
 
   * **PhaseI 2017 cosmics peak scenario** : [94X_mc2017cosmics_realistic_peak_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017cosmics_realistic_peak_v3) as [94X_mc2017cosmics_realistic_peak_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017cosmics_realistic_peak_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017cosmics_realistic_peak_v3/94X_mc2017cosmics_realistic_peak_v1): 
      * update of pixel local reco conditions for V2 MC : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3313.html

   * **PhaseI 2017 cosmics scenario** : [94X_mc2017cosmics_realistic_deco_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017cosmics_realistic_deco_v3) as [94X_mc2017cosmics_realistic_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017cosmics_realistic_deco_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017cosmics_realistic_deco_v3/94X_mc2017cosmics_realistic_deco_v1): 
      * update of pixel local reco conditions for V2 MC : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3313.html

   * **PhaseI 2017 design scenario** : [94X_mc2017_design_IdealBS_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017_design_IdealBS_v4) as [94X_mc2017_design_IdealBS_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017_design_IdealBS_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017_design_IdealBS_v4/94X_mc2017_design_IdealBS_v2): 
      * update of pixel local reco conditions for V2 MC : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3313.html

   * **PhaseI 2017 realistic scenario** : [94X_mc2017_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017_realistic_v4) as [94X_mc2017_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017_realistic_v4/94X_mc2017_realistic_v2): 
      * update of pixel local reco conditions for V2 MC : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3313.html