### PR TITLE
L1TOffline DQM - add efficiency flag to efficiency ME - 92x

### DIFF
--- a/DQMOffline/L1Trigger/src/L1TEfficiencyHarvesting.cc
+++ b/DQMOffline/L1Trigger/src/L1TEfficiencyHarvesting.cc
@@ -101,6 +101,7 @@ void L1TEfficiencyPlotHandler::book(DQMStore::IBooker &ibooker, DQMStore::IGette
   else if (is2D) {
     h_efficiency_ = ibooker.book2D(plotName_, den->getTH2F());
   }
+  h_efficiency_->setEfficiencyFlag();
 }
 
 void L1TEfficiencyPlotHandler::computeEfficiency(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter)


### PR DESCRIPTION
Add efficiency flag to L1T offline DQM efficiency ME to avoid plots being normalised in the GUI.