### PR TITLE
Moving to Clopper-Pearson uncertainties in efficiency histograms

### DIFF
--- a/HLTriggerOffline/Btag/src/HLTBTagHarvestingAnalyzer.cc
+++ b/HLTriggerOffline/Btag/src/HLTBTagHarvestingAnalyzer.cc
@@ -301,7 +301,8 @@ TH1F  HLTBTagHarvestingAnalyzer::calculateEfficiency1D(DQMStore::IBooker& ibooke
 		double e;
 		if(d!=0){
 			e=n/d;
-			err =  sqrt(e*(1-e)/d); //from binomial standard deviation
+			err = std::max(e - TEfficiency::ClopperPearson(d, n, 0.683, false), TEfficiency::ClopperPearson(d, n, 0.683, true) - e);
+			//err =  sqrt(e*(1-e)/d); //from binomial standard deviation
 		}
 		else{
 			e=0;


### PR DESCRIPTION
As decided at BTV@HLT meeting and inspired by https://github.com/cms-sw/cmssw/pull/9863/ we replace binomial uncertainties by Clopper-Pearson ones in efficiency histograms. Clopper-Perason uncertainties provide better description in low efficiency cases.