### PR TITLE
L1T online DQM uGMT zero suppression plot axis range change - 92x

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
@@ -71,7 +71,7 @@ l1tStage2uGMTZeroSupp = cms.EDAnalyzer(
                                       0x0007FC00,
                                       0x00000000),
     # no masks defined for caption IDs 0 and 4-11
-    maxFEDReadoutSize = cms.untracked.int32(9000),
+    maxFEDReadoutSize = cms.untracked.int32(10000),
     monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/zeroSuppression/AllEvts"),
     verbose = cms.untracked.bool(False),
 )


### PR DESCRIPTION
Increase readout size plot x axis to accommodate for larger read out sizes with the per-BX zero suppression.