### PR TITLE
Excluded gluons and quarks from Geant4 tracking

### DIFF
--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -155,7 +155,6 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
     ),
     Generator = cms.PSet(
         HectorEtaCut,
-        # string HepMCProductLabel = "generatorSmeared"
         HepMCProductLabel = cms.InputTag('generatorSmeared'),
         ApplyPCuts = cms.bool(True),
         ApplyPtransCut = cms.bool(False),
@@ -168,9 +167,13 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         LDecLenCut = cms.double(30.0), ## (cm) decay volume length
         ApplyPhiCuts = cms.bool(False),
         MinPhiCut = cms.double(-3.14159265359), ## (radians)
-        MaxPhiCut = cms.double(3.14159265359), ## according to CMS conventions
+        MaxPhiCut = cms.double(3.14159265359),  ## according to CMS conventions
         ApplyLumiMonitorCuts = cms.bool(False), ## primary for lumi monitors
-        Verbosity = cms.untracked.int32(0)
+        Verbosity = cms.untracked.int32(0),
+        PDGselection = cms.PSet(
+            PDGfilterSel = cms.bool(False),        ## filter out unwanted particles
+            PDGfilter = cms.vint32(21,1,2,3,4,5,6) ## list of unwanted particles (gluons and quarks)
+        )
     ),
     RunAction = cms.PSet(
         StopFile = cms.string('StopRun')

--- a/SimG4Core/Generators/interface/Generator.h
+++ b/SimG4Core/Generators/interface/Generator.h
@@ -33,9 +33,9 @@ public:
 private:
 
   bool particlePassesPrimaryCuts(const G4ThreeVector& p) const;
-  bool isExotic(HepMC::GenParticle* p) const;
-  bool isExoticNonDetectable(HepMC::GenParticle* p) const;
-  bool IsInTheFilterList(HepMC::GenParticle* p) const;
+  bool isExotic(int pdgcode) const;
+  bool isExoticNonDetectable(int pdgcode) const;
+  bool IsInTheFilterList(int pdgcode) const;
   void particleAssignDaughters(G4PrimaryParticle * p, HepMC::GenParticle * hp, 
 			       double length);
   void setGenId(G4PrimaryParticle* p, int id) const 

--- a/SimG4Core/Generators/interface/Generator.h
+++ b/SimG4Core/Generators/interface/Generator.h
@@ -35,6 +35,7 @@ private:
   bool particlePassesPrimaryCuts(const G4ThreeVector& p) const;
   bool isExotic(HepMC::GenParticle* p) const;
   bool isExoticNonDetectable(HepMC::GenParticle* p) const;
+  bool IsInTheFilterList(HepMC::GenParticle* p) const;
   void particleAssignDaughters(G4PrimaryParticle * p, HepMC::GenParticle * hp, 
 			       double length);
   void setGenId(G4PrimaryParticle* p, int id) const 


### PR DESCRIPTION
Enabled exclusion of gluons and quarks from Geant4 tracking. Normally this should not happens, if event generator providing correct HepMC status code, but unfortunately, this was observed for some XeXe generators. The problem is discussed at SIM meeting during December CMS week: https://indico.cern.ch/event/684826/contributions/2812929/attachments/1570329/2476913/FullSimDec.pdf 

Also std::abs is used in this class instead of fabs, clean-up of internal methods: pdg code is used instead of pointer, LogInfo and LogWarnings are revised and extended. 

Should not affect results.