### PR TITLE
[94x] Run2_HI modifier chain use stage2L1Trigger

### DIFF
--- a/Configuration/Eras/python/Era_Run2_HI_cff.py
+++ b/Configuration/Eras/python/Era_Run2_HI_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Modifier_run2_common_cff import run2_common
 from Configuration.Eras.Modifier_run2_HI_specific_cff import run2_HI_specific
-from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
+from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
 
-Run2_HI = cms.ModifierChain(run2_common, run2_HI_specific, stage1L1Trigger)
+Run2_HI = cms.ModifierChain(run2_common, run2_HI_specific, stage2L1Trigger_2017)
 

--- a/Configuration/Eras/python/Era_Run2_HI_cff.py
+++ b/Configuration/Eras/python/Era_Run2_HI_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Modifier_run2_common_cff import run2_common
 from Configuration.Eras.Modifier_run2_HI_specific_cff import run2_HI_specific
-from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 
-Run2_HI = cms.ModifierChain(run2_common, run2_HI_specific, stage2L1Trigger_2017)
+Run2_HI = cms.ModifierChain(run2_common, run2_HI_specific, stage2L1Trigger)
 


### PR DESCRIPTION
For Run2_HI modifier chain, use stage2L1Trigger_2017 instead of stage1L1Trigger.