### PR TITLE
DeepCSV/DeepCMVA discriminators

### DIFF
--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
@@ -54,12 +54,6 @@ _patJets = cms.EDProducer("PATJetProducer",
         cms.InputTag('pfDeepCSVJetTags:probc'),
         cms.InputTag('pfDeepCSVJetTags:probudsg'),
         cms.InputTag('pfDeepCSVJetTags:probbb'),
-        # DeepCMVA
-        # cms.InputTag('pfDeepCMVAJetTags:probb'),
-        # cms.InputTag('pfDeepCMVAJetTags:probc'),
-        # cms.InputTag('pfDeepCMVAJetTags:probudsg'),
-        # cms.InputTag('pfDeepCMVAJetTags:probbb'),
-        # cms.InputTag('pfDeepCMVAJetTags:probcc'),
     ),
     # clone tag infos ATTENTION: these take lots of space!
     # usually the discriminators from the default algos

--- a/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
@@ -171,3 +171,15 @@ supportedBtagDiscr = {
     # ChargeTagging
   , 'pfChargeBJetTags'                                      : [["pfImpactParameterTagInfos", "pfInclusiveSecondaryVertexFinderTagInfos", "softPFMuonsTagInfos", "softPFElectronsTagInfos"]]
   }
+
+
+#meta-taggers are simple arithmetic on top of other taggers, they are stored here
+#such that in case you want them re-run also the parent tagger is re-run as well
+supportedMetaDiscr = {
+   'pfDeepCSVDiscriminatorsJetTags:BvsAll' : ['pfDeepCSVJetTags:probudsg', 'pfDeepCSVJetTags:probb', 'pfDeepCSVJetTags:probc', 'pfDeepCSVJetTags:probbb'],
+   'pfDeepCSVDiscriminatorsJetTags:CvsB' : ['pfDeepCSVJetTags:probudsg', 'pfDeepCSVJetTags:probb', 'pfDeepCSVJetTags:probc', 'pfDeepCSVJetTags:probbb'],
+   'pfDeepCSVDiscriminatorsJetTags:CvsL' : ['pfDeepCSVJetTags:probudsg', 'pfDeepCSVJetTags:probb', 'pfDeepCSVJetTags:probc', 'pfDeepCSVJetTags:probbb'],
+   'pfDeepCMVADiscriminatorsJetTags:BvsAll' : ['pfDeepCMVAJetTags:probudsg', 'pfDeepCMVAJetTags:probb', 'pfDeepCMVAJetTags:probc', 'pfDeepCMVAJetTags:probbb'],   
+   'pfDeepCMVADiscriminatorsJetTags:CvsB' : ['pfDeepCMVAJetTags:probudsg', 'pfDeepCMVAJetTags:probb', 'pfDeepCMVAJetTags:probc', 'pfDeepCMVAJetTags:probbb'],   
+   'pfDeepCMVADiscriminatorsJetTags:CvsL' : ['pfDeepCMVAJetTags:probudsg', 'pfDeepCMVAJetTags:probb', 'pfDeepCMVAJetTags:probc', 'pfDeepCMVAJetTags:probbb'],   
+}

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -238,7 +238,7 @@ def miniAOD_customizeCommon(process):
 
     ## DeepCSV meta discriminators (simple arithmethic on output probabilities)
     process.load('RecoBTag.Combined.deepFlavour_cff')
-    task.add(process.pfDeepFlavourTask)
+    task.add(process.pfDeepCSVDiscriminatorsJetTags)
     process.patJets.discriminatorSources.extend([
             cms.InputTag('pfDeepCSVDiscriminatorsJetTags:BvsAll' ),
             cms.InputTag('pfDeepCSVDiscriminatorsJetTags:CvsB'   ),

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -236,16 +236,13 @@ def miniAOD_customizeCommon(process):
 
     process.patJets.userData.userFloats.src += [ cms.InputTag('QGTagger:qgLikelihood'), ]
 
-    ## DeepCSV/CMVA meta discriminators (simple arithmethic on output probabilities)
+    ## DeepCSV meta discriminators (simple arithmethic on output probabilities)
     process.load('RecoBTag.Combined.deepFlavour_cff')
     task.add(process.pfDeepFlavourTask)
     process.patJets.discriminatorSources.extend([
             cms.InputTag('pfDeepCSVDiscriminatorsJetTags:BvsAll' ),
             cms.InputTag('pfDeepCSVDiscriminatorsJetTags:CvsB'   ),
             cms.InputTag('pfDeepCSVDiscriminatorsJetTags:CvsL'   ),
-            cms.InputTag('pfDeepCMVADiscriminatorsJetTags:BvsAll'),
-            cms.InputTag('pfDeepCMVADiscriminatorsJetTags:CvsB'  ),
-            cms.InputTag('pfDeepCMVADiscriminatorsJetTags:CvsL'  )
             ])
 
     ## CaloJets

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -236,6 +236,18 @@ def miniAOD_customizeCommon(process):
 
     process.patJets.userData.userFloats.src += [ cms.InputTag('QGTagger:qgLikelihood'), ]
 
+    ## DeepCSV/CMVA meta discriminators (simple arithmethic on output probabilities)
+    process.load('RecoBTag.Combined.deepFlavour_cff')
+    task.add(process.pfDeepFlavourTask)
+    process.patJets.discriminatorSources.extend([
+            cms.InputTag('pfDeepCSVDiscriminatorsJetTags:BvsAll' ),
+            cms.InputTag('pfDeepCSVDiscriminatorsJetTags:CvsB'   ),
+            cms.InputTag('pfDeepCSVDiscriminatorsJetTags:CvsL'   ),
+            cms.InputTag('pfDeepCMVADiscriminatorsJetTags:BvsAll'),
+            cms.InputTag('pfDeepCMVADiscriminatorsJetTags:CvsB'  ),
+            cms.InputTag('pfDeepCMVADiscriminatorsJetTags:CvsL'  )
+            ])
+
     ## CaloJets
     process.caloJetMap = cms.EDProducer("RecoJetDeltaRValueMapProducer",
          src = process.patJets.jetSource,

--- a/PhysicsTools/PatAlgos/test/patTuple_updateJets_fromMiniAOD_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_updateJets_fromMiniAOD_cfg.py
@@ -23,7 +23,8 @@ updateJetCollection(
    process,
    jetSource = cms.InputTag('slimmedJets'),
    jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
-   btagDiscriminators = ['pfCombinedSecondaryVertexV2BJetTags'] ## to add discriminators
+   btagDiscriminators = ['pfCombinedSecondaryVertexV2BJetTags', 'pfDeepCSVDiscriminatorsJetTags:BvsAll', 'pfDeepCSVDiscriminatorsJetTags:CvsB', 'pfDeepCSVDiscriminatorsJetTags:CvsL'], ## to add discriminators,
+   btagPrefix = 'TEST',
 )
 process.updatedPatJets.userData.userFloats.src += ['oldJetMass']
 

--- a/RecoBTag/Combined/plugins/BTagProbabilityToDiscriminator.cc
+++ b/RecoBTag/Combined/plugins/BTagProbabilityToDiscriminator.cc
@@ -177,10 +177,6 @@ void BTagProbabilityToDiscriminator::produce(edm::Event &iEvent,
 // module  ------------
 void BTagProbabilityToDiscriminator::fillDescriptions(
     edm::ConfigurationDescriptions &descriptions) {
-  // The following says we do not know what parameters are allowed so do no
-  // validation
-  // Please change this to state exactly what you do use, even if it is no
-  // parameters
   edm::ParameterSetDescription desc;
   {
     edm::ParameterSetDescription vpsd1;

--- a/RecoBTag/Combined/plugins/BTagProbabilityToDiscriminator.cc
+++ b/RecoBTag/Combined/plugins/BTagProbabilityToDiscriminator.cc
@@ -162,7 +162,7 @@ void BTagProbabilityToDiscriminator::produce(edm::Event &iEvent,
       float denominator = !discrims_[disc_idx].denominator.empty() ? 0 : 1;
       for (auto &den : discrims_[disc_idx].denominator)
         denominator += (*tags[den])[key];
-      float new_value = (denominator != 0) ? numerator / denominator : -10.;
+      float new_value = (denominator != 0 && numerator > 0) ? numerator / denominator : -10.;
       (*output_tags[disc_idx])[key] = new_value;
     }
   }

--- a/RecoBTag/Combined/plugins/BTagProbabilityToDiscriminator.cc
+++ b/RecoBTag/Combined/plugins/BTagProbabilityToDiscriminator.cc
@@ -1,0 +1,170 @@
+// -*- C++ -*-
+//
+// Package:    RecoBTag/SecondaryVertex
+// Class:      BTagProbabilityToDiscriminator
+//
+/**
+ *
+ * Description: EDProducer that performs simple arithmetic on the multi-classifier probabilities to compute simple discriminators
+ *
+ * Implementation:
+ *    A collection of output discriminators is defined in a VPSet, each containing the output name, input probabilities and normalization (empty vInputTag if none) the output is computed as 
+ *         sum(INPUTS)/sum(normalizations)
+ */
+//
+// Original Author:  Mauro Verzetti (CERN)
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "FWCore/Framework/interface/makeRefToBaseProdFrom.h"
+#include "DataFormats/Common/interface/RefToBase.h"
+#include "DataFormats/BTauReco/interface/JetTag.h"
+
+//from lwtnn
+#include <fstream>
+#include <map>
+#include <set>
+#include <vector>
+#include <string>
+#include <iostream>
+
+#include <boost/algorithm/string.hpp>
+#include <unordered_map>
+using namespace std;
+using namespace reco;
+//
+// class declaration
+//
+
+class BTagProbabilityToDiscriminator : public edm::stream::EDProducer<> {
+public:
+	explicit BTagProbabilityToDiscriminator(const edm::ParameterSet&);
+	~BTagProbabilityToDiscriminator() {}
+
+	static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+private:
+	typedef std::vector<edm::InputTag> vInputTag;
+	typedef std::vector<std::string> vstring;
+	typedef std::vector<edm::ParameterSet> vPSet;
+	struct Discriminator {
+		std::string name; //needed?
+		vstring numerator;
+		vstring denominator;
+	};
+
+	virtual void beginStream(edm::StreamID) override {}
+	virtual void produce(edm::Event&, const edm::EventSetup&) override;
+	virtual void endStream() override {}
+
+	// ----------member data ---------------------------
+	std::vector<Discriminator> discrims_;
+	std::unordered_map<std::string, edm::EDGetTokenT<JetTagCollection> > jet_tags_; //caches jet tags to avoid repetitions
+};
+
+BTagProbabilityToDiscriminator::BTagProbabilityToDiscriminator(const edm::ParameterSet& iConfig)
+{
+	for(auto discriminator : iConfig.getParameter<vPSet>("discriminators")) {
+		Discriminator current;
+		current.name = discriminator.getParameter<std::string>("name");
+		produces<JetTagCollection>(current.name);
+
+		for(auto intag : discriminator.getParameter<vInputTag>("numerator")) {
+			if(jet_tags_.find(intag.encode()) == jet_tags_.end()) { //new probability
+				jet_tags_[intag.encode()] = consumes<JetTagCollection>(intag);				
+			}
+			current.numerator.push_back(intag.encode());
+		}
+
+		for(auto intag : discriminator.getParameter<vInputTag>("denominator")) {
+			if(jet_tags_.find(intag.encode()) == jet_tags_.end()) { //new probability
+				jet_tags_[intag.encode()] = consumes<JetTagCollection>(intag);				
+			}
+			current.denominator.push_back(intag.encode());
+		}
+		discrims_.push_back(current);
+	}
+
+	if(!jet_tags_.size()) {
+		throw cms::Exception("RuntimeError") << "The module BTagProbabilityToDiscriminator is run without any input probability to work on!" << std::endl;
+	}
+}
+
+void
+BTagProbabilityToDiscriminator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+	std::unordered_map<std::string, edm::Handle<JetTagCollection> > tags; //caches jet tags to avoid repetitions
+	size_t size = 0;
+	bool first = true;
+	for(auto entry : jet_tags_) {
+		edm::Handle<JetTagCollection> tmp;
+		iEvent.getByToken(entry.second, tmp);
+		tags[entry.first] = tmp; 
+		if(first)	size = tmp->size();		
+		else {
+			if(tmp->size() != size) {
+				throw cms::Exception("RuntimeError") << "The length of one of the input jet tag collections does not match " <<
+					"with the others, this is probably due to the probabilities belonging to different jet collections, which is forbidden!" << std::endl;
+			}
+		}
+		first = false;
+	}
+
+	// create the output collection
+	// which is a "map" RefToBase<Jet> --> float
+	vector< std::unique_ptr<JetTagCollection> > output_tags;
+	output_tags.reserve(discrims_.size());
+	for(size_t i=0; i<discrims_.size(); ++i) {
+		output_tags.push_back(
+			std::make_unique<JetTagCollection>(*(tags.begin()->second)) //clone from the first element, will change the content later on
+			);			
+	}
+
+	// loop over jets
+	for(size_t idx = 0; idx < output_tags[0]->size(); idx++) {
+		auto key = output_tags[0]->key(idx); //index access should be OK as well, but a bit less safe, probably WAY faster
+
+		//loop over new discriminators to produce
+		for(size_t disc_idx = 0; disc_idx < output_tags.size(); disc_idx++) {
+			float numerator = 0;
+			for(auto& num : discrims_[disc_idx].numerator) numerator += (*tags[num])[key];
+			float denominator = discrims_[disc_idx].denominator.size() ? 0 : 1;
+			for(auto& den : discrims_[disc_idx].denominator) denominator += (*tags[den])[key];
+			float new_value = (denominator != 0) ? numerator / denominator : -10.;
+			(*output_tags[disc_idx])[key] = new_value;
+		}
+	}
+
+	// put the output in the event
+	for(size_t i=0; i<output_tags.size(); ++i) {
+			iEvent.put(std::move(output_tags[i]), discrims_[i].name);
+	}
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+BTagProbabilityToDiscriminator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(BTagProbabilityToDiscriminator);

--- a/RecoBTag/Combined/plugins/BTagProbabilityToDiscriminator.cc
+++ b/RecoBTag/Combined/plugins/BTagProbabilityToDiscriminator.cc
@@ -53,7 +53,7 @@ using namespace reco;
 class BTagProbabilityToDiscriminator : public edm::stream::EDProducer<> {
 public:
 	explicit BTagProbabilityToDiscriminator(const edm::ParameterSet&);
-	~BTagProbabilityToDiscriminator() {}
+	~BTagProbabilityToDiscriminator() override {}
 
 	static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -68,9 +68,9 @@ private:
 		vstring denominator;
 	};
 
-	virtual void beginStream(edm::StreamID) override {}
-	virtual void produce(edm::Event&, const edm::EventSetup&) override;
-	virtual void endStream() override {}
+	void beginStream(edm::StreamID) override {}
+	void produce(edm::Event&, const edm::EventSetup&) override;
+	void endStream() override {}
 
 	// ----------member data ---------------------------
 	std::vector<Discriminator> discrims_;
@@ -100,7 +100,7 @@ BTagProbabilityToDiscriminator::BTagProbabilityToDiscriminator(const edm::Parame
 		discrims_.push_back(current);
 	}
 
-	if(!jet_tags_.size()) {
+	if(jet_tags_.empty()) {
 		throw cms::Exception("RuntimeError") << "The module BTagProbabilityToDiscriminator is run without any input probability to work on!" << std::endl;
 	}
 }
@@ -143,7 +143,7 @@ BTagProbabilityToDiscriminator::produce(edm::Event& iEvent, const edm::EventSetu
 		for(size_t disc_idx = 0; disc_idx < output_tags.size(); disc_idx++) {
 			float numerator = 0;
 			for(auto& num : discrims_[disc_idx].numerator) numerator += (*tags[num])[key];
-			float denominator = discrims_[disc_idx].denominator.size() ? 0 : 1;
+			float denominator = !discrims_[disc_idx].denominator.empty() ? 0 : 1;
 			for(auto& den : discrims_[disc_idx].denominator) denominator += (*tags[den])[key];
 			float new_value = (denominator != 0) ? numerator / denominator : -10.;
 			(*output_tags[disc_idx])[key] = new_value;

--- a/RecoBTag/Combined/plugins/BTagProbabilityToDiscriminator.cc
+++ b/RecoBTag/Combined/plugins/BTagProbabilityToDiscriminator.cc
@@ -5,17 +5,19 @@
 //
 /**
  *
- * Description: EDProducer that performs simple arithmetic on the multi-classifier probabilities to compute simple discriminators
+ * Description: EDProducer that performs simple arithmetic on the
+ * multi-classifier probabilities to compute simple discriminators
  *
  * Implementation:
- *    A collection of output discriminators is defined in a VPSet, each containing the output name, input probabilities and normalization (empty vInputTag if none) the output is computed as 
+ *    A collection of output discriminators is defined in a VPSet, each
+ * containing the output name, input probabilities and normalization (empty
+ * vInputTag if none) the output is computed as
  *         sum(INPUTS)/sum(normalizations)
  */
 //
 // Original Author:  Mauro Verzetti (CERN)
 //
 //
-
 
 // system include files
 #include <memory>
@@ -30,17 +32,17 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
-#include "FWCore/Framework/interface/makeRefToBaseProdFrom.h"
-#include "DataFormats/Common/interface/RefToBase.h"
 #include "DataFormats/BTauReco/interface/JetTag.h"
+#include "DataFormats/Common/interface/RefToBase.h"
+#include "FWCore/Framework/interface/makeRefToBaseProdFrom.h"
 
-//from lwtnn
+// from lwtnn
 #include <fstream>
+#include <iostream>
 #include <map>
 #include <set>
-#include <vector>
 #include <string>
-#include <iostream>
+#include <vector>
 
 #include <boost/algorithm/string.hpp>
 #include <unordered_map>
@@ -52,158 +54,188 @@ using namespace reco;
 
 class BTagProbabilityToDiscriminator : public edm::stream::EDProducer<> {
 public:
-	explicit BTagProbabilityToDiscriminator(const edm::ParameterSet&);
-	~BTagProbabilityToDiscriminator() override {}
+  explicit BTagProbabilityToDiscriminator(const edm::ParameterSet &);
+  ~BTagProbabilityToDiscriminator() override {}
 
-	static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
-	typedef std::vector<edm::InputTag> vInputTag;
-	typedef std::vector<std::string> vstring;
-	typedef std::vector<edm::ParameterSet> vPSet;
-	struct Discriminator {
-		std::string name; //needed?
-		vstring numerator;
-		vstring denominator;
-	};
+  typedef std::vector<edm::InputTag> vInputTag;
+  typedef std::vector<std::string> vstring;
+  typedef std::vector<edm::ParameterSet> vPSet;
+  struct Discriminator {
+    std::string name; // needed?
+    vstring numerator;
+    vstring denominator;
+  };
 
-	void beginStream(edm::StreamID) override {}
-	void produce(edm::Event&, const edm::EventSetup&) override;
-	void endStream() override {}
+  void beginStream(edm::StreamID) override {}
+  void produce(edm::Event &, const edm::EventSetup &) override;
+  void endStream() override {}
 
-	// ----------member data ---------------------------
-	std::vector<Discriminator> discrims_;
-	std::unordered_map<std::string, edm::EDGetTokenT<JetTagCollection> > jet_tags_; //caches jet tags to avoid repetitions
+  // ----------member data ---------------------------
+  std::vector<Discriminator> discrims_;
+  std::unordered_map<std::string, edm::EDGetTokenT<JetTagCollection>>
+      jet_tags_; // caches jet tags to avoid repetitions
 };
 
-BTagProbabilityToDiscriminator::BTagProbabilityToDiscriminator(const edm::ParameterSet& iConfig)
-{
-	for(auto discriminator : iConfig.getParameter<vPSet>("discriminators")) {
-		Discriminator current;
-		current.name = discriminator.getParameter<std::string>("name");
-		produces<JetTagCollection>(current.name);
+BTagProbabilityToDiscriminator::BTagProbabilityToDiscriminator(
+    const edm::ParameterSet &iConfig) {
+  for (auto discriminator : iConfig.getParameter<vPSet>("discriminators")) {
+    Discriminator current;
+    current.name = discriminator.getParameter<std::string>("name");
+    produces<JetTagCollection>(current.name);
 
-		for(auto intag : discriminator.getParameter<vInputTag>("numerator")) {
-			if(jet_tags_.find(intag.encode()) == jet_tags_.end()) { //new probability
-				jet_tags_[intag.encode()] = consumes<JetTagCollection>(intag);				
-			}
-			current.numerator.push_back(intag.encode());
-		}
+    for (auto intag : discriminator.getParameter<vInputTag>("numerator")) {
+      if (jet_tags_.find(intag.encode()) == jet_tags_.end()) { // new
+                                                               // probability
+        jet_tags_[intag.encode()] = consumes<JetTagCollection>(intag);
+      }
+      current.numerator.push_back(intag.encode());
+    }
 
-		for(auto intag : discriminator.getParameter<vInputTag>("denominator")) {
-			if(jet_tags_.find(intag.encode()) == jet_tags_.end()) { //new probability
-				jet_tags_[intag.encode()] = consumes<JetTagCollection>(intag);				
-			}
-			current.denominator.push_back(intag.encode());
-		}
-		discrims_.push_back(current);
-	}
+    for (auto intag : discriminator.getParameter<vInputTag>("denominator")) {
+      if (jet_tags_.find(intag.encode()) == jet_tags_.end()) { // new
+                                                               // probability
+        jet_tags_[intag.encode()] = consumes<JetTagCollection>(intag);
+      }
+      current.denominator.push_back(intag.encode());
+    }
+    discrims_.push_back(current);
+  }
 
-	if(jet_tags_.empty()) {
-		throw cms::Exception("RuntimeError") << "The module BTagProbabilityToDiscriminator is run without any input probability to work on!" << std::endl;
-	}
+  if (jet_tags_.empty()) {
+    throw cms::Exception("RuntimeError")
+        << "The module BTagProbabilityToDiscriminator is run without any input "
+           "probability to work on!"
+        << std::endl;
+  }
 }
 
-void
-BTagProbabilityToDiscriminator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-	std::unordered_map<std::string, edm::Handle<JetTagCollection> > tags; //caches jet tags to avoid repetitions
-	size_t size = 0;
-	bool first = true;
-	for(auto entry : jet_tags_) {
-		edm::Handle<JetTagCollection> tmp;
-		iEvent.getByToken(entry.second, tmp);
-		tags[entry.first] = tmp; 
-		if(first)	size = tmp->size();		
-		else {
-			if(tmp->size() != size) {
-				throw cms::Exception("RuntimeError") << "The length of one of the input jet tag collections does not match " <<
-					"with the others, this is probably due to the probabilities belonging to different jet collections, which is forbidden!" << std::endl;
-			}
-		}
-		first = false;
-	}
+void BTagProbabilityToDiscriminator::produce(edm::Event &iEvent,
+                                             const edm::EventSetup &iSetup) {
+  std::unordered_map<std::string, edm::Handle<JetTagCollection>>
+      tags; // caches jet tags to avoid repetitions
+  size_t size = 0;
+  bool first = true;
+  for (auto entry : jet_tags_) {
+    edm::Handle<JetTagCollection> tmp;
+    iEvent.getByToken(entry.second, tmp);
+    tags[entry.first] = tmp;
+    if (first)
+      size = tmp->size();
+    else {
+      if (tmp->size() != size) {
+        throw cms::Exception("RuntimeError")
+            << "The length of one of the input jet tag collections does not "
+               "match "
+            << "with the others, this is probably due to the probabilities "
+               "belonging to different jet collections, which is forbidden!"
+            << std::endl;
+      }
+    }
+    first = false;
+  }
 
-	// create the output collection
-	// which is a "map" RefToBase<Jet> --> float
-	vector< std::unique_ptr<JetTagCollection> > output_tags;
-	output_tags.reserve(discrims_.size());
-	for(size_t i=0; i<discrims_.size(); ++i) {
-		output_tags.push_back(
-			std::make_unique<JetTagCollection>(*(tags.begin()->second)) //clone from the first element, will change the content later on
-			);			
-	}
+  // create the output collection
+  // which is a "map" RefToBase<Jet> --> float
+  vector<std::unique_ptr<JetTagCollection>> output_tags;
+  output_tags.reserve(discrims_.size());
+  for (size_t i = 0; i < discrims_.size(); ++i) {
+    output_tags.push_back(std::make_unique<JetTagCollection>(
+        *(tags.begin()->second)) // clone from the first element, will change
+                                 // the content later on
+                          );
+  }
 
-	// loop over jets
-	for(size_t idx = 0; idx < output_tags[0]->size(); idx++) {
-		auto key = output_tags[0]->key(idx); //index access should be OK as well, but a bit less safe, probably WAY faster
+  // loop over jets
+  for (size_t idx = 0; idx < output_tags[0]->size(); idx++) {
+    auto key = output_tags[0]->key(idx); // index access should be OK as well,
+                                         // but a bit less safe, probably WAY
+                                         // faster
 
-		//loop over new discriminators to produce
-		for(size_t disc_idx = 0; disc_idx < output_tags.size(); disc_idx++) {
-			float numerator = 0;
-			for(auto& num : discrims_[disc_idx].numerator) numerator += (*tags[num])[key];
-			float denominator = !discrims_[disc_idx].denominator.empty() ? 0 : 1;
-			for(auto& den : discrims_[disc_idx].denominator) denominator += (*tags[den])[key];
-			float new_value = (denominator != 0) ? numerator / denominator : -10.;
-			(*output_tags[disc_idx])[key] = new_value;
-		}
-	}
+    // loop over new discriminators to produce
+    for (size_t disc_idx = 0; disc_idx < output_tags.size(); disc_idx++) {
+      float numerator = 0;
+      for (auto &num : discrims_[disc_idx].numerator)
+        numerator += (*tags[num])[key];
+      float denominator = !discrims_[disc_idx].denominator.empty() ? 0 : 1;
+      for (auto &den : discrims_[disc_idx].denominator)
+        denominator += (*tags[den])[key];
+      float new_value = (denominator != 0) ? numerator / denominator : -10.;
+      (*output_tags[disc_idx])[key] = new_value;
+    }
+  }
 
-	// put the output in the event
-	for(size_t i=0; i<output_tags.size(); ++i) {
-			iEvent.put(std::move(output_tags[i]), discrims_[i].name);
-	}
+  // put the output in the event
+  for (size_t i = 0; i < output_tags.size(); ++i) {
+    iEvent.put(std::move(output_tags[i]), discrims_[i].name);
+  }
 }
 
-// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-BTagProbabilityToDiscriminator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  //The following says we do not know what parameters are allowed so do no validation
-  // Please change this to state exactly what you do use, even if it is no parameters
-	edm::ParameterSetDescription desc;
+// ------------ method fills 'descriptions' with the allowed parameters for the
+// module  ------------
+void BTagProbabilityToDiscriminator::fillDescriptions(
+    edm::ConfigurationDescriptions &descriptions) {
+  // The following says we do not know what parameters are allowed so do no
+  // validation
+  // Please change this to state exactly what you do use, even if it is no
+  // parameters
+  edm::ParameterSetDescription desc;
   {
-		edm::ParameterSetDescription vpsd1;
+    edm::ParameterSetDescription vpsd1;
     vpsd1.add<std::vector<edm::InputTag>>("denominator", {});
-    vpsd1.add<std::vector<edm::InputTag>>("numerator", {
-				edm::InputTag("pfDeepCSVJetTags","probb"),
-					edm::InputTag("pfDeepCSVJetTags","probbb"),
-					});
+    vpsd1.add<std::vector<edm::InputTag>>(
+        "numerator",
+        {
+            edm::InputTag("pfDeepCSVJetTags", "probb"),
+            edm::InputTag("pfDeepCSVJetTags", "probbb"),
+        });
     vpsd1.add<std::string>("name", "BvsAll");
-		std::vector<edm::ParameterSet> temp1;
+    std::vector<edm::ParameterSet> temp1;
     temp1.reserve(3);
     {
-			edm::ParameterSet temp2;
+      edm::ParameterSet temp2;
       temp2.addParameter<std::vector<edm::InputTag>>("denominator", {});
-      temp2.addParameter<std::vector<edm::InputTag>>("numerator", {
-					edm::InputTag("pfDeepCSVJetTags","probb"),
-						edm::InputTag("pfDeepCSVJetTags","probbb"),
-						});
+      temp2.addParameter<std::vector<edm::InputTag>>(
+          "numerator",
+          {
+              edm::InputTag("pfDeepCSVJetTags", "probb"),
+              edm::InputTag("pfDeepCSVJetTags", "probbb"),
+          });
       temp2.addParameter<std::string>("name", "BvsAll");
       temp1.push_back(temp2);
     }
     {
-			edm::ParameterSet temp2;
-      temp2.addParameter<std::vector<edm::InputTag>>("denominator", {
-					edm::InputTag("pfDeepCSVJetTags","probc"),
-						edm::InputTag("pfDeepCSVJetTags","probb"),
-						edm::InputTag("pfDeepCSVJetTags","probbb"),
-						});
-      temp2.addParameter<std::vector<edm::InputTag>>("numerator", {
-					edm::InputTag("pfDeepCSVJetTags","probc"),
-						});
+      edm::ParameterSet temp2;
+      temp2.addParameter<std::vector<edm::InputTag>>(
+          "denominator",
+          {
+              edm::InputTag("pfDeepCSVJetTags", "probc"),
+              edm::InputTag("pfDeepCSVJetTags", "probb"),
+              edm::InputTag("pfDeepCSVJetTags", "probbb"),
+          });
+      temp2.addParameter<std::vector<edm::InputTag>>(
+          "numerator",
+          {
+              edm::InputTag("pfDeepCSVJetTags", "probc"),
+          });
       temp2.addParameter<std::string>("name", "CvsB");
       temp1.push_back(temp2);
     }
     {
-			edm::ParameterSet temp2;
-      temp2.addParameter<std::vector<edm::InputTag>>("denominator", {
-					edm::InputTag("pfDeepCSVJetTags","probudsg"),
-						edm::InputTag("pfDeepCSVJetTags","probc"),
-						});
-      temp2.addParameter<std::vector<edm::InputTag>>("numerator", {
-					edm::InputTag("pfDeepCSVJetTags","probc"),
-						});
+      edm::ParameterSet temp2;
+      temp2.addParameter<std::vector<edm::InputTag>>(
+          "denominator",
+          {
+              edm::InputTag("pfDeepCSVJetTags", "probudsg"),
+              edm::InputTag("pfDeepCSVJetTags", "probc"),
+          });
+      temp2.addParameter<std::vector<edm::InputTag>>(
+          "numerator",
+          {
+              edm::InputTag("pfDeepCSVJetTags", "probc"),
+          });
       temp2.addParameter<std::string>("name", "CvsL");
       temp1.push_back(temp2);
     }
@@ -212,5 +244,5 @@ BTagProbabilityToDiscriminator::fillDescriptions(edm::ConfigurationDescriptions&
   descriptions.addDefault(desc);
 }
 
-//define this as a plug-in
+// define this as a plug-in
 DEFINE_FWK_MODULE(BTagProbabilityToDiscriminator);

--- a/RecoBTag/Combined/plugins/BTagProbabilityToDiscriminator.cc
+++ b/RecoBTag/Combined/plugins/BTagProbabilityToDiscriminator.cc
@@ -161,8 +161,54 @@ void
 BTagProbabilityToDiscriminator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
-  edm::ParameterSetDescription desc;
-  desc.setUnknown();
+	edm::ParameterSetDescription desc;
+  {
+		edm::ParameterSetDescription vpsd1;
+    vpsd1.add<std::vector<edm::InputTag>>("denominator", {});
+    vpsd1.add<std::vector<edm::InputTag>>("numerator", {
+				edm::InputTag("pfDeepCSVJetTags","probb"),
+					edm::InputTag("pfDeepCSVJetTags","probbb"),
+					});
+    vpsd1.add<std::string>("name", "BvsAll");
+		std::vector<edm::ParameterSet> temp1;
+    temp1.reserve(3);
+    {
+			edm::ParameterSet temp2;
+      temp2.addParameter<std::vector<edm::InputTag>>("denominator", {});
+      temp2.addParameter<std::vector<edm::InputTag>>("numerator", {
+					edm::InputTag("pfDeepCSVJetTags","probb"),
+						edm::InputTag("pfDeepCSVJetTags","probbb"),
+						});
+      temp2.addParameter<std::string>("name", "BvsAll");
+      temp1.push_back(temp2);
+    }
+    {
+			edm::ParameterSet temp2;
+      temp2.addParameter<std::vector<edm::InputTag>>("denominator", {
+					edm::InputTag("pfDeepCSVJetTags","probc"),
+						edm::InputTag("pfDeepCSVJetTags","probb"),
+						edm::InputTag("pfDeepCSVJetTags","probbb"),
+						});
+      temp2.addParameter<std::vector<edm::InputTag>>("numerator", {
+					edm::InputTag("pfDeepCSVJetTags","probc"),
+						});
+      temp2.addParameter<std::string>("name", "CvsB");
+      temp1.push_back(temp2);
+    }
+    {
+			edm::ParameterSet temp2;
+      temp2.addParameter<std::vector<edm::InputTag>>("denominator", {
+					edm::InputTag("pfDeepCSVJetTags","probudsg"),
+						edm::InputTag("pfDeepCSVJetTags","probc"),
+						});
+      temp2.addParameter<std::vector<edm::InputTag>>("numerator", {
+					edm::InputTag("pfDeepCSVJetTags","probc"),
+						});
+      temp2.addParameter<std::string>("name", "CvsL");
+      temp1.push_back(temp2);
+    }
+    desc.addVPSet("discriminators", vpsd1, temp1);
+  }
   descriptions.addDefault(desc);
 }
 

--- a/RecoBTag/Combined/plugins/BuildFile.xml
+++ b/RecoBTag/Combined/plugins/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <library file="*.cc" name="RecoBTagCombinedPlugins">
-	<flags CXXFLAGS="-g"/>  
   <use   name="lwtnn"/>
   <use   name="boost"/>
   <use   name="classlib"/>

--- a/RecoBTag/Combined/plugins/BuildFile.xml
+++ b/RecoBTag/Combined/plugins/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <library file="*.cc" name="RecoBTagCombinedPlugins">
+	<flags CXXFLAGS="-g"/>  
   <use   name="lwtnn"/>
   <use   name="boost"/>
   <use   name="classlib"/>

--- a/RecoBTag/Combined/python/deepFlavour_cff.py
+++ b/RecoBTag/Combined/python/deepFlavour_cff.py
@@ -2,7 +2,9 @@ import FWCore.ParameterSet.Config as cms
 from RecoBTag.Combined.pfDeepCSVTagInfos_cfi import pfDeepCSVTagInfos
 from RecoBTag.Combined.pfDeepCMVATagInfos_cfi import pfDeepCMVATagInfos
 from RecoBTag.Combined.pfDeepCSVJetTags_cfi import pfDeepCSVJetTags 
+from RecoBTag.Combined.pfDeepCSVDiscriminatorsJetTags_cfi import pfDeepCSVDiscriminatorsJetTags
 from RecoBTag.Combined.pfDeepCMVAJetTags_cfi import pfDeepCMVAJetTags
+from RecoBTag.Combined.pfDeepCMVADiscriminatorsJetTags_cfi import pfDeepCMVADiscriminatorsJetTags
 
 ##
 ## Negative and positive taggers for light SF estimation
@@ -54,6 +56,8 @@ pfDeepFlavourTask = cms.Task(
     pfDeepCSVTagInfos,
     pfDeepCMVATagInfos, #SKIP for the moment
     pfDeepCSVJetTags
+    , pfDeepCSVDiscriminatorsJetTags
     , pfDeepCMVAJetTags
+    , pfDeepCMVADiscriminatorsJetTags
 )
 pfDeepFlavour = cms.Sequence(pfDeepFlavourTask)

--- a/RecoBTag/Combined/python/deepFlavour_cff.py
+++ b/RecoBTag/Combined/python/deepFlavour_cff.py
@@ -56,8 +56,6 @@ pfDeepFlavourTask = cms.Task(
     pfDeepCSVTagInfos,
     pfDeepCMVATagInfos, #SKIP for the moment
     pfDeepCSVJetTags
-    , pfDeepCSVDiscriminatorsJetTags
     , pfDeepCMVAJetTags
-    , pfDeepCMVADiscriminatorsJetTags
 )
 pfDeepFlavour = cms.Sequence(pfDeepFlavourTask)

--- a/RecoBTag/Combined/python/pfDeepCMVADiscriminatorsJetTags_cfi.py
+++ b/RecoBTag/Combined/python/pfDeepCMVADiscriminatorsJetTags_cfi.py
@@ -1,0 +1,36 @@
+import FWCore.ParameterSet.Config as cms
+
+pfDeepCMVADiscriminatorsJetTags = cms.EDProducer(
+   'BTagProbabilityToDiscriminator',
+   discriminators = cms.VPSet(
+      cms.PSet(
+         name = cms.string('BvsAll'),
+         numerator = cms.VInputTag(
+            cms.InputTag('pfDeepCMVAJetTags', 'probb'),
+            cms.InputTag('pfDeepCMVAJetTags', 'probbb'),
+            ),
+         denominator = cms.VInputTag(),
+         ),
+      cms.PSet(
+         name = cms.string('CvsB'),
+         numerator = cms.VInputTag(
+            cms.InputTag('pfDeepCMVAJetTags', 'probc'),
+            ),
+         denominator = cms.VInputTag(
+            cms.InputTag('pfDeepCMVAJetTags', 'probc'),
+            cms.InputTag('pfDeepCMVAJetTags', 'probb'),
+            cms.InputTag('pfDeepCMVAJetTags', 'probbb'),
+            ),
+         ),
+      cms.PSet(
+         name = cms.string('CvsL'),
+         numerator = cms.VInputTag(
+            cms.InputTag('pfDeepCMVAJetTags', 'probc'),
+            ),
+         denominator = cms.VInputTag(
+            cms.InputTag('pfDeepCMVAJetTags', 'probc'),
+            cms.InputTag('pfDeepCMVAJetTags', 'probudsg'),
+            ),
+         ),
+      )
+   )

--- a/RecoBTag/Combined/python/pfDeepCSVDiscriminatorsJetTags_cfi.py
+++ b/RecoBTag/Combined/python/pfDeepCSVDiscriminatorsJetTags_cfi.py
@@ -1,0 +1,36 @@
+import FWCore.ParameterSet.Config as cms
+
+pfDeepCSVDiscriminatorsJetTags = cms.EDProducer(
+   'BTagProbabilityToDiscriminator',
+   discriminators = cms.VPSet(
+      cms.PSet(
+         name = cms.string('BvsAll'),
+         numerator = cms.VInputTag(
+            cms.InputTag('pfDeepCSVJetTags', 'probb'),
+            cms.InputTag('pfDeepCSVJetTags', 'probbb'),
+            ),
+         denominator = cms.VInputTag(),
+         ),
+      cms.PSet(
+         name = cms.string('CvsB'),
+         numerator = cms.VInputTag(
+            cms.InputTag('pfDeepCSVJetTags', 'probc'),
+            ),
+         denominator = cms.VInputTag(
+            cms.InputTag('pfDeepCSVJetTags', 'probc'),
+            cms.InputTag('pfDeepCSVJetTags', 'probb'),
+            cms.InputTag('pfDeepCSVJetTags', 'probbb'),
+            ),
+         ),
+      cms.PSet(
+         name = cms.string('CvsL'),
+         numerator = cms.VInputTag(
+            cms.InputTag('pfDeepCSVJetTags', 'probc'),
+            ),
+         denominator = cms.VInputTag(
+            cms.InputTag('pfDeepCSVJetTags', 'probudsg'),
+            cms.InputTag('pfDeepCSVJetTags', 'probc'),
+            ),
+         ),
+      )
+   )


### PR DESCRIPTION
Introduced DeepCSV discriminator taggers as simple arithmetic over the input probabilities.

The PR introduces three new bDiscriminators to the miniAOD event content, containing the DeepCSV discriminators computed starting from the DeepCSV probabilities. Only the miniAOD content is expected to change.

The change is implemented modifying the RECO sequences, but given the modules are never called they should not be scheduled.