### PR TITLE
Remove link to empty library tcmalloc_minimal. 

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -26,7 +26,10 @@
   <use   name="boost"/>
   <use   name="boost_program_options"/>
   <use   name="boost_python"/>
-  <use   name="tcmalloc_minimal"/>
+  <!-- jemalloc is mostly tested on x86_64 in upstream -->
+  <architecture name=".*_amd64_.*">
+	 <use   name="jemalloc"/>
+  </architecture>
   <use   name="FWCore/Framework"/>
   <use   name="FWCore/MessageLogger"/>
   <use   name="FWCore/PluginManager"/>


### PR DESCRIPTION
This will allow the removal of google-pertools-toolfile from cmssw-tool-conf.