### PR TITLE
saving the collections of ECAL selective readout flags (SrFlags) matc…

### DIFF
--- a/HLTrigger/special/BuildFile.xml
+++ b/HLTrigger/special/BuildFile.xml
@@ -49,5 +49,6 @@
 <use   name="Geometry/EcalAlgo"/>
 <use   name="SimGeneral/HepPDTRecord"/>
 <use   name="TrackingTools/TransientTrack"/>
+<use   name="CalibCalorimetry/EcalTPGTools"/>
 
 <flags   EDM_PLUGIN="1"/>

--- a/HLTrigger/special/src/HLTRechitsToDigis.cc
+++ b/HLTrigger/special/src/HLTRechitsToDigis.cc
@@ -31,9 +31,15 @@
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
+#include "DataFormats/EcalDetId/interface/EcalDetIdCollections.h"
 
 #include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
 #include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
+
+// for srFlags management
+#include "CalibCalorimetry/EcalTPGTools/interface/EcalReadoutTools.h"
+#include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
+
 
 //
 // class declaration
@@ -55,14 +61,22 @@ private:
   edm::EDGetTokenT<EBDigiCollection> digisEBInToken_;
   edm::EDGetTokenT<EEDigiCollection> digisEEInToken_;
   edm::EDGetTokenT<EcalRecHitCollection> recHitsToken_;
-  
+  // tokens for srFlags 
+  edm::EDGetTokenT<EBSrFlagCollection> srFlagsEBInToken_;
+  edm::EDGetTokenT<EESrFlagCollection> srFlagsEEInToken_;
+
   // input tags
   edm::InputTag digisIn_;
   edm::InputTag recHits_;
+  // srFlags
+  edm::InputTag srFlagsIn_;
   
   // string for the produced digi collection
   std::string digisOut_;
   ecalRegion region_;
+  // string for the produced srFlags collection
+  std::string srFlagsOut_;
+
 };
 //
 
@@ -81,15 +95,24 @@ HLTRechitsToDigis::HLTRechitsToDigis(const edm::ParameterSet& iConfig)
   // hit collections to save digis for
   recHits_ = iConfig.getParameter<edm::InputTag> ("recHits");
 
+  // srFlags matched to digis to be saved
+  srFlagsIn_ = iConfig.getParameter<edm::InputTag> ("srFlagsIn");
+  srFlagsOut_ = iConfig.getParameter<std::string> ("srFlagsOut");
+
+
   // region specific tokens
   switch(region_) {
   case barrel:
     digisEBInToken_ = consumes<EBDigiCollection>(digisIn_);
     produces<EBDigiCollection>(digisOut_);  
+    srFlagsEBInToken_ = consumes<EBSrFlagCollection>(srFlagsIn_);
+    produces<EBSrFlagCollection>(srFlagsOut_);  
     break;
   case endcap:
     digisEEInToken_ = consumes<EEDigiCollection>(digisIn_);
     produces<EEDigiCollection>(digisOut_);  
+    srFlagsEEInToken_ = consumes<EESrFlagCollection>(srFlagsIn_);
+    produces<EESrFlagCollection>(srFlagsOut_);  
     break;    
   case invalidRegion:  
     break;
@@ -126,6 +149,15 @@ HLTRechitsToDigis::produce(edm::Event& iEvent, edm::EventSetup const& setup)  {
   // output collections
   std::unique_ptr<EBDigiCollection> outputEBDigiCollection( new EBDigiCollection );
   std::unique_ptr<EEDigiCollection> outputEEDigiCollection( new EEDigiCollection );
+
+  // handles for srFlags
+  Handle<EBSrFlagCollection> srFlagsEBHandle;
+  Handle<EESrFlagCollection> srFlagsEEHandle;
+  
+  // output collections
+  std::unique_ptr<EBSrFlagCollection> outputEBSrFlagCollection( new EBSrFlagCollection );
+  std::unique_ptr<EESrFlagCollection> outputEESrFlagCollection( new EESrFlagCollection );
+  EcalReadoutTools ecalReadOutTool(iEvent, setup);
   
   // calibrated rechits
   Handle<EcalRecHitCollection> recHitsHandle;
@@ -136,8 +168,12 @@ HLTRechitsToDigis::produce(edm::Event& iEvent, edm::EventSetup const& setup)  {
   case barrel: { 
     iEvent.getByToken(digisEBInToken_, digisEBHandle);
     const EBDigiCollection* digisEB = digisEBHandle.product();   
+
+    iEvent.getByToken(srFlagsEBInToken_, srFlagsEBHandle);
+    const EBSrFlagCollection* srFlagsEB = srFlagsEBHandle.product();   
     
     // loop over the collection of rechits and match to digis
+    // at the same time, create the new sfFlags collection from the original one, keeping only the flags matched to digis
     EcalRecHitCollection::const_iterator ituneEB;
     for (ituneEB = recHitsHandle->begin(); ituneEB != recHitsHandle->end(); ituneEB++) {
       EcalRecHit const &    hit = (*ituneEB);
@@ -145,17 +181,32 @@ HLTRechitsToDigis::produce(edm::Event& iEvent, edm::EventSetup const& setup)  {
       // protect against a digi not existing
       if( digiLookUp == digisEB->end()) continue;
       outputEBDigiCollection->push_back( digiLookUp->id(), digiLookUp->begin() );
+ 
+      // same matching for srFlags
+      // firstly, get the tower id                                                                                                                                          
+       const EcalTrigTowerDetId& ttId = ecalReadOutTool.readOutUnitOf( static_cast<EBDetId>(hit.id()) );
+      // avoid inserting the same tower twice in the output collection (all the digis in the same tower will have the same SR flag)
+      if (outputEBSrFlagCollection->find(ttId) != outputEBSrFlagCollection->end()) continue;
+      EBSrFlagCollection::const_iterator srFlagLookUp = srFlagsEB->find( ttId );
+      // protect against a srFlag not existing
+      if( srFlagLookUp == srFlagsEB->end()) continue;
+      outputEBSrFlagCollection->push_back( *srFlagLookUp );
     }
 
     // add the built collection to the event 
     iEvent.put(std::move(outputEBDigiCollection), digisOut_);     
+    iEvent.put(std::move(outputEBSrFlagCollection), srFlagsOut_);     
     break;      
   }    
   case endcap: {
     iEvent.getByToken(digisEEInToken_, digisEEHandle);
     const EEDigiCollection* digisEE = digisEEHandle.product();   
+
+    iEvent.getByToken(srFlagsEEInToken_, srFlagsEEHandle);
+    const EESrFlagCollection* srFlagsEE = srFlagsEEHandle.product();   
     
     // loop over the collection of rechits and match to digis
+    // at the same time, create the new sfFlags collection from the original one, keeping only the flags matched to digis
     EcalRecHitCollection::const_iterator ituneEE;
     for (ituneEE = recHitsHandle->begin(); ituneEE != recHitsHandle->end(); ituneEE++) {
       EcalRecHit const & hit = (*ituneEE);            
@@ -163,10 +214,21 @@ HLTRechitsToDigis::produce(edm::Event& iEvent, edm::EventSetup const& setup)  {
       // protect against a digi not existing for the saved rechit
       if(digiLookUp  == digisEE->end()) continue;
       outputEEDigiCollection->push_back( digiLookUp->id(), digiLookUp->begin() );              
+
+      // same matching for srFlags
+      // firstly, get the tower id
+      const EcalScDetId& scId = ecalReadOutTool.readOutUnitOf( static_cast<EEDetId>(hit.id()) );
+      // avoid inserting the same tower twice in the output collection (all the digis in the same tower will have the same SR flag)
+      if (outputEESrFlagCollection->find(scId) != outputEESrFlagCollection->end()) continue;
+      EESrFlagCollection::const_iterator srFlagLookUp = srFlagsEE->find( scId );
+      // protect against an srFlag not existing for the saved rechit
+      if(srFlagLookUp  == srFlagsEE->end()) continue;
+      outputEESrFlagCollection->push_back( *srFlagLookUp );              
     } // end loop over endcap rechits
 
     // add the built collection to the event     
     iEvent.put(std::move(outputEEDigiCollection), digisOut_);     
+    iEvent.put(std::move(outputEESrFlagCollection), srFlagsOut_);     
     break;
   }
   case invalidRegion: {
@@ -222,6 +284,10 @@ HLTRechitsToDigis::fillDescriptions(edm::ConfigurationDescriptions& descriptions
     ->setComment("Name for the collection of Digis saved by the module");
   desc.add<edm::InputTag>("recHits",edm::InputTag("hltAlCaPi0EBUncalibrator","pi0EcalRecHitsEB"))
     ->setComment("Collection of rechits to match Digis to");  
+  desc.add<edm::InputTag>("srFlagsIn",edm::InputTag("ecalDigis"))
+    ->setComment("The collection of either barrel or endcap srFlags which correspond to the rechit collection");
+  desc.add<std::string>("srFlagsOut","pi0EBSrFlags")
+    ->setComment("Name for the collection of SrFlags saved by the module");
   descriptions.add("hltFindMatchingECALDigisToRechits", desc);
 }
 


### PR DESCRIPTION
…hed to digis in the output

We are adding the collection of ECAL Selective Readout (SR) flags in the output of the pi0/eta stream.
These flags are needed to study the impact of the SR thresholds on the pi0/eta reconstruction from low energy photons.

The change affects

    HLTrigger/special/src/HLTRechitsToDigis.cc
    HLTrigger/special/BuildFile.xml
    (the HLT configuration for the pi0/eta stream paths will have to be modified as well adding some parameters)

The source file implements the producer that saves the digis collection in the stream output (only those digis matched to rechits used to build pi0/eta are saved). Similarly, the change we implemented takes the SrFlags collection and produce a new collections storing only the flags matched to digis that are finally kept in the stream output.

The BuildFile.xml must have a new line to include a header used by the source.

Tested from release CMSSW_9_2_12_patch1 running the (updated) HLT configuration on HLTPhysics dataset. The new collections are created and stored in the output dataset.
The event size changes by 2% from 1.96 kB/event to 1.99 kB/event

A similar pull request has been opened from 9_4_X release to master branch (see https://github.com/cms-sw/cmssw/pull/20973)