### PR TITLE
Adding "else" clause to jet tokens

### DIFF
--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -380,6 +380,9 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
 	}
       }
     }
+    else {
+	throw cms::Exception("Invalid Jet Inputs") <<"Did not specify appropriate inputs for VirtualJetProducer, Abort!\n";    
+    }
   }
   LogDebug("VirtualJetProducer") << "Got inputs\n";
   


### PR DESCRIPTION
In response to silent failure problem raised in #20977, add an "else" clause to fail immediately if there is a misconfiguration instead of silently giving an empty vector. 