### PR TITLE
GT Updates: 92X offline, relval, promptLike, and HLT_frozen GT updated to make the release self-consistent with the data taken with it 

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,7 +26,7 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '92X_dataRun2_v7',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '92X_dataRun2_relval_v7',
+    'run2_data_relval'  :   '92X_dataRun2_relval_v8',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
     'run2_data_promptlike' : '92X_dataRun2_PromptLike_v7',
 

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -22,18 +22,18 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '92X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '92X_dataRun2_v5',
+    'run1_data'         :   '92X_dataRun2_v7',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '92X_dataRun2_v5',
+    'run2_data'         :   '92X_dataRun2_v7',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '92X_dataRun2_relval_v6',
+    'run2_data_relval'  :   '92X_dataRun2_relval_v7',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '92X_dataRun2_PromptLike_v5',
+    'run2_data_promptlike' : '92X_dataRun2_PromptLike_v7',
 
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '92X_dataRun2_HLT_frozen_v6',
+    'run1_hlt'          :   '92X_dataRun2_HLT_frozen_v7',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '92X_dataRun2_HLT_frozen_v6',
+    'run2_hlt'          :   '92X_dataRun2_HLT_frozen_v7',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'   :   '92X_dataRun2_HLT_relval_v8',
     # GlobalTag for Run2 HLT for HI: it points to the online GT

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1575,7 +1575,7 @@ steps['ALCAEXP']={'-s':'ALCAOUTPUT:SiStripCalZeroBias+TkAlMinBias+DtCalib+Hotlin
 steps['ALCAEXPHI']=merge([{'-s':'ALCA:PromptCalibProd+PromptCalibProdSiStrip+PromptCalibProdSiStripGains+PromptCalibProdSiStripGainsAAG',
                   '--scenario':'HeavyIons'},steps['ALCAEXP']])
 steps['ALCAEXPTE']={'-s':'ALCA:PromptCalibProdEcalPedestals',
-                    '--conditions':'auto:run2_data',
+                    '--conditions':'auto:run2_data_relval',
                     '--datatier':'ALCARECO',
                     '--eventcontent':'ALCARECO',
                     '--triggerResultsProcess': 'RECO'}


### PR DESCRIPTION
# Summary of changes in Global Tags

## RunI data

   * **RunI HLT processing** : [92X_dataRun2_HLT_frozen_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_dataRun2_HLT_frozen_v6) as [92X_dataRun2_HLT_frozen_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_dataRun2_HLT_frozen_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/92X_dataRun2_HLT_frozen_v6/92X_dataRun2_HLT_frozen_v7):
      * SnapShot of 92X_dataRun2_HLT_Queue

   * **RunI Offline processing** : [92X_dataRun2_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_dataRun2_v5) as [92X_dataRun2_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_dataRun2_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/92X_dataRun2_v5/92X_dataRun2_v7):
      * Marchchereco Queue

## RunII data

   * **RunII Offline processing** : [92X_dataRun2_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_dataRun2_v5) as [92X_dataRun2_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_dataRun2_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/92X_dataRun2_v5/92X_dataRun2_v7):
      * Match Rereco Queue

   * **RunII Offline relval processing** : [92X_dataRun2_relval_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_dataRun2_relval_v6) as [92X_dataRun2_relval_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_dataRun2_relval_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/92X_dataRun2_relval_v6/92X_dataRun2_relval_v8):
      * Match Rereco Queue + correct L1menu

   * **RunII Prompt processing** : [92X_dataRun2_PromptLike_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_dataRun2_PromptLike_v5) as [92X_dataRun2_PromptLike_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_dataRun2_PromptLike_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/92X_dataRun2_PromptLike_v5/92X_dataRun2_PromptLike_v7):
      * SnapShot of 92X_dataRun2_Prompt_Queue

   * **RunI HLT processing** : [92X_dataRun2_HLT_frozen_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_dataRun2_HLT_frozen_v6) as [92X_dataRun2_HLT_frozen_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_dataRun2_HLT_frozen_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/92X_dataRun2_HLT_frozen_v6/92X_dataRun2_HLT_frozen_v7):
      * SnapShot of 92X_dataRun2_HLT_Queue