### PR TITLE
Stand-alone tracker rechits validation cfg, root macro

### DIFF
--- a/SimTracker/TrackerHitAssociation/test/TestAssoc_Phase0-1_cfg.py
+++ b/SimTracker/TrackerHitAssociation/test/TestAssoc_Phase0-1_cfg.py
@@ -3,9 +3,7 @@ import FWCore.ParameterSet.Config as cms
 import os 
 
 # Create a new CMS process
-process = cms.Process('Phase01TrackerRecHitTest')
-
-from Configuration.StandardSequences.Eras import eras  # wtf(2)
+from Configuration.StandardSequences.Eras import eras
 process = cms.Process('assocTest',eras.Run2_2017)
 
 # Import all the necessary files
@@ -16,7 +14,7 @@ process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 
-process.load('Configuration.EventContent.EventContent_cff')  # wtf(5)
+process.load('Configuration.EventContent.EventContent_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
 process.load('Configuration.StandardSequences.RawToDigi_cff')
 process.load('Configuration.StandardSequences.L1Reco_cff')
@@ -49,7 +47,7 @@ process.TFileService = cms.Service('TFileService',
     fileName = cms.string('file:Run2_Trk_rechits_validation.root')
 )
 
-process.mix.playback = True  # wtf (3)
+process.mix.playback = True
 process.mix.digitizers = cms.PSet()
 for a in process.aliases: delattr(process, a)
 
@@ -99,11 +97,11 @@ process.testassociator = cms.EDAnalyzer("TestAssociator",
 process.MessageLogger.cerr.FwkReport.reportEvery = 1
 
 # Number of events (-1 = all)
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(5) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 
 # Processes to run
 
-process.raw2digi_step = cms.Path(process.RawToDigi)  # wtf (3)
+process.raw2digi_step = cms.Path(process.RawToDigi)
 process.L1Reco_step = cms.Path(process.L1Reco)
 process.reconstruction_step = cms.Path(process.reconstruction)
 

--- a/SimTracker/TrackerHitAssociation/test/TestAssoc_Phase2_cfg.py
+++ b/SimTracker/TrackerHitAssociation/test/TestAssoc_Phase2_cfg.py
@@ -3,9 +3,7 @@ import FWCore.ParameterSet.Config as cms
 import os 
 
 # Create a new CMS process
-process = cms.Process('Phase2TrackerRecHitTest')
-
-from Configuration.StandardSequences.Eras import eras  # wtf(2)
+from Configuration.StandardSequences.Eras import eras
 process = cms.Process('assocTest',eras.Phase2)
 
 # Import all the necessary files
@@ -23,7 +21,7 @@ process.load('SLHCUpgradeSimulations.Geometry.fakeConditions_phase2TkTilted4025_
 
 process.load('Configuration.StandardSequences.MagneticField_cff')
 
-process.load('Configuration.EventContent.EventContent_cff')  # wtf(5)
+process.load('Configuration.EventContent.EventContent_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
 process.load('Configuration.StandardSequences.RawToDigi_cff')
 process.load('Configuration.StandardSequences.L1Reco_cff')
@@ -56,7 +54,7 @@ process.TFileService = cms.Service('TFileService',
     fileName = cms.string('file:phase2Trk_rechits_validation.root')
 )
 
-process.mix.playback = True  # wtf (3)
+process.mix.playback = True
 process.mix.digitizers = cms.PSet()
 for a in process.aliases: delattr(process, a)
 
@@ -117,7 +115,7 @@ phase2_tracker.toModify(process.testassociator,
 process.MessageLogger.cerr.FwkReport.reportEvery = 1
 
 # Number of events (-1 = all)
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(20) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 
 # Processes to run
 
@@ -126,4 +124,4 @@ process.rechits_step = cms.Path(process.siPixelRecHits*process.siPhase2Clusters*
 # process.validation_step = cms.Path(process.content*process.testassociator)
 process.validation_step = cms.Path(process.testassociator)
 
-process.schedule = cms.Schedule(process.rechits_step, process.validation_step)  # wtf
+process.schedule = cms.Schedule(process.rechits_step, process.validation_step)

--- a/Validation/TrackerRecHits/test/HistoCompare.C
+++ b/Validation/TrackerRecHits/test/HistoCompare.C
@@ -1,4 +1,11 @@
-#include <iostream.h>
+#include <iostream>     // std::cout
+#include <string>       // std::string
+#include <sstream>      // std::stringstream
+#include <fstream>      // std::filestream
+#include "TH1F.h"
+#include "TH2.h"
+#include "TProfile.h"
+#include "TText.h"
 
 class HistoCompare {
 
@@ -6,14 +13,12 @@ class HistoCompare {
 
   HistoCompare() { std::cout << "Initializing HistoCompare... " << std::endl; } ;
 
-  void PVCompute(TH1 * oldHisto , TH1 * newHisto , TText * te );
-  void PVCompute(TH2 * oldHisto , TH2 * newHisto , TText * te );
-  void PVCompute(TProfile * oldHisto , TProfile * newHisto , TText * te );
+  void PVCompute(TH1 * oldHisto , TH1 * newHisto , TText * te, const double x=0.6, const double y=0.7);
+  void PVCompute(TH2 * oldHisto , TH2 * newHisto , TText * te, const double x=0.2, const double y=0.7);
+  void PVCompute(TProfile * oldHisto , TProfile * newHisto , TText * te, const double x=0.2, const double y=0.7);
 
  private:
   
-  Double_t mypv;
-
   TH1 * myoldHisto1;
   TH1 * mynewHisto1;
 
@@ -27,7 +32,7 @@ class HistoCompare {
 
 };
 
-HistoCompare::PVCompute(TH1 * oldHisto , TH1 * newHisto , TText * te )
+void HistoCompare::PVCompute(TH1 * oldHisto , TH1 * newHisto , TText * te, const double x, const double y)
 {
 
   myoldHisto1 = oldHisto;
@@ -35,20 +40,19 @@ HistoCompare::PVCompute(TH1 * oldHisto , TH1 * newHisto , TText * te )
   myte = te;
 
   Double_t mypv = myoldHisto1->Chi2Test(mynewHisto1,"UUNORM");
-  //  Double_t mypv = myoldHisto1->Chi2Test(mynewHisto1,"OU");
-  std::strstream buf;
+  std::stringstream buf;
   std::string value;
   buf<<"PV="<<mypv<<std::endl;
   buf>>value;
   
-  myte->DrawTextNDC(0.2,0.7, value.c_str());
+  myte->DrawTextNDC(x, y, value.c_str());
 
   std::cout << "[OVAL] " << myoldHisto1->GetName() << " PV = " << mypv << std::endl;
   return;
 
 }
 
-HistoCompare::PVCompute(TH2 * oldHisto , TH2 * newHisto , TText * te )
+void HistoCompare::PVCompute(TH2 * oldHisto , TH2 * newHisto , TText * te, const double x, const double y)
 {
 
   myoldHisto2 = oldHisto;
@@ -56,13 +60,12 @@ HistoCompare::PVCompute(TH2 * oldHisto , TH2 * newHisto , TText * te )
   myte = te;
 
   Double_t mypv = myoldHisto2->Chi2Test(mynewHisto2,"UUNORM");
-  //  Double_t mypv = myoldHisto2->Chi2Test(mynewHisto2,"OU");
-  std::strstream buf;
+  std::stringstream buf;
   std::string value;
   buf<<"PV="<<mypv<<std::endl;
   buf>>value;
   
-  myte->DrawTextNDC(0.2,0.7, value.c_str());
+  myte->DrawTextNDC(x, y, value.c_str());
 
   std::cout << "[OVAL] " << myoldHisto2->GetName() << " PV = " << mypv << std::endl;
   return;
@@ -70,7 +73,7 @@ HistoCompare::PVCompute(TH2 * oldHisto , TH2 * newHisto , TText * te )
 }
 
 
-HistoCompare::PVCompute(TProfile * oldHisto , TProfile * newHisto , TText * te )
+void HistoCompare::PVCompute(TProfile * oldHisto , TProfile * newHisto , TText * te, const double x, const double y)
 {
 
   myoldProfile = oldHisto;
@@ -78,13 +81,12 @@ HistoCompare::PVCompute(TProfile * oldHisto , TProfile * newHisto , TText * te )
   myte = te;
 
   Double_t mypv = myoldProfile->Chi2Test(mynewProfile,"UUNORM");
-  //  Double_t mypv = myoldProfile->Chi2Test(mynewProfile,"OU");
-  std::strstream buf;
+  std::stringstream buf;
   std::string value;
   buf<<"PV="<<mypv<<std::endl;
   buf>>value;
   
-  myte->DrawTextNDC(0.2,0.7, value.c_str());
+  myte->DrawTextNDC(x, y, value.c_str());
 
   std::cout << "[OVAL] " << myoldProfile->GetName() << " PV = " << mypv << std::endl;
   return;

--- a/Validation/TrackerRecHits/test/RecHitsCompare.C
+++ b/Validation/TrackerRecHits/test/RecHitsCompare.C
@@ -1,0 +1,755 @@
+//
+// Overlay RecHits plots from a pair of DQM validation files
+//  Strips and Phase 0 or Phase 1 pixels
+// Loosely based on Validation/TrackerRecHits/test/SiStripRecHitsCompare.C
+//  Bill Ford  10 Oct 2017
+//
+#include "TStyle.h"
+#include "TROOT.h"
+#include "TH1F.h"
+#include "TCanvas.h"
+#include "TFile.h"
+#include "TText.h"
+
+#define _CRT_SECURE_NO_WARNINGS
+
+#include <iostream>
+using std::cout;
+using std::endl;
+
+#include <fstream>
+using std::ifstream;
+
+#include <cstring>
+
+#include "HistoCompare.C"
+
+// static const char* outfiletype = "pdf";
+static const char* outfiletype = "gif";
+
+void SetUpHistograms(TH1F* h1, TH1F* h2, float bincorr=1.0)
+{
+  float scale1 = -9999.9;
+  float scale2 = -9999.9;
+
+  if ( h1->Integral() != 0 && h2->Integral() != 0 ) {
+    if (bincorr > 0.0) {
+      scale1 = 1.0/(float)h1->Integral();
+    // In case the bin width is different between reference and new files:
+      scale2 = bincorr/(float)h2->Integral();
+//     scale2 = scale1;
+//     scale2 *= 1000.0/936.0;
+      h1->Sumw2();
+      h2->Sumw2();
+      h1->Scale(scale1);
+      h2->Scale(scale2);
+    } else {
+      h1->SetLineStyle(3);
+    }
+
+    h1->SetLineWidth(1);
+    h2->SetLineWidth(1);
+    h1->SetLineColor(4);
+    h2->SetLineColor(2);
+  }
+}  // -----------------------------------------------------------
+
+void TIBcompare(HistoCompare* myPV, TDirectory* rdir, TDirectory* sdir, const char* varname,
+		const char* historoot, const Int_t logy, const float bincorr = 1.0) {
+  TH1F* refplotsTIB[6];
+  TH1F* newplotsTIB[6];
+  char objname[80], histoname[80];
+  Int_t layer, plotidx;
+  TText* te = new TText;
+
+  plotidx = 0;
+  for (layer = 1; layer < 5; ++layer) {
+    sprintf(objname, "TIB/layer_%1d/%s_rphi__TIB__layer__%1d", layer, varname, layer);
+    rdir->GetObject(objname, refplotsTIB[plotidx]);
+    sdir->GetObject(objname, newplotsTIB[plotidx]);
+    plotidx++;
+  }
+  for (layer = 1; layer < 3; ++layer) {
+    sprintf(objname, "TIB/layer_%1d/%s_stereo__TIB__layer__%1d", layer, varname, layer);
+    rdir->GetObject(objname, refplotsTIB[plotidx]);
+    sdir->GetObject(objname, newplotsTIB[plotidx]);
+    plotidx++;
+  }
+
+  TCanvas* Strip_TIB = new TCanvas("Strip_TIB","Strip_TIB",1000,1000);
+  Strip_TIB->Divide(2,3);
+  for (Int_t i=0; i<6; ++i) {
+    if (refplotsTIB[i]->GetEntries() == 0 || newplotsTIB[i]->GetEntries() == 0) continue;
+    Strip_TIB->cd(i+1);
+    SetUpHistograms(refplotsTIB[i], newplotsTIB[i], bincorr);
+    refplotsTIB[i]->Draw();
+    newplotsTIB[i]->Draw("sames");
+    myPV->PVCompute(refplotsTIB[i], newplotsTIB[i], te);
+    gPad->SetLogy(logy);
+  }
+
+  sprintf(histoname, "%sTIBCompare.%s", historoot, outfiletype);  Strip_TIB->Print(histoname);
+
+}  // ------------------------------------------------------------------------
+
+void TOBcompare(HistoCompare* myPV, TDirectory* rdir, TDirectory* sdir, const char* varname,
+		const char* historoot, const Int_t logy, const float bincorr = 1.0) {
+  TH1F* refplotsTOB[8];
+  TH1F* newplotsTOB[8];
+  char objname[80], histoname[80];
+  Int_t layer, plotidx;
+  TText* te = new TText;
+
+  plotidx = 0;
+  for (layer = 1; layer < 7; ++layer) {
+    sprintf(objname, "TOB/layer_%1d/%s_rphi__TOB__layer__%1d", layer, varname, layer);
+    rdir->GetObject(objname, refplotsTOB[plotidx]);
+    sdir->GetObject(objname, newplotsTOB[plotidx]);
+    plotidx++;
+  }
+  for (layer = 1; layer < 3; ++layer) {
+    sprintf(objname, "TOB/layer_%1d/%s_stereo__TOB__layer__%1d", layer, varname, layer);
+    rdir->GetObject(objname, refplotsTOB[plotidx]);
+    sdir->GetObject(objname, newplotsTOB[plotidx]);
+    plotidx++;
+  }
+
+  TCanvas* Strip_TOB = new TCanvas("Strip_TOB","Strip_TOB",1000,1000);
+  Strip_TOB->Divide(3,3);
+  for (Int_t i=0; i<8; ++i) {
+    if (refplotsTOB[i]->GetEntries() == 0 || newplotsTOB[i]->GetEntries() == 0) continue;
+    Strip_TOB->cd(i+1);
+    SetUpHistograms(refplotsTOB[i],newplotsTOB[i], bincorr);
+    refplotsTOB[i]->Draw();
+    newplotsTOB[i]->Draw("sames");
+    myPV->PVCompute(refplotsTOB[i], newplotsTOB[i], te);
+    gPad->SetLogy(logy);
+  }
+
+  sprintf(histoname, "%sTOBCompare.%s", historoot, outfiletype);  Strip_TOB->Print(histoname);
+
+}  // ------------------------------------------------------------------------
+
+void TIDcompare(HistoCompare* myPV, TDirectory* rdir, TDirectory* sdir, const char* varname,
+		const char* historoot, const Int_t logy, const float bincorr = 1.0) {
+  TH1F* refplotsTID[5];
+  TH1F* newplotsTID[5];
+  char objname[80], histoname[80];
+  Int_t layer, plotidx;
+  TText* te = new TText;
+
+  plotidx = 0;
+  for (layer = 1; layer < 4; ++layer) {
+    sprintf(objname, "TID/MINUS/ring_%1d/%s_rphi__TID__MINUS__ring__%1d", layer, varname, layer);
+    rdir->GetObject(objname, refplotsTID[plotidx]);
+     sdir->GetObject(objname, newplotsTID[plotidx]);
+   plotidx++;
+  }
+  for (layer = 1; layer < 3; ++layer) {
+    sprintf(objname, "TID/MINUS/ring_%1d/%s_stereo__TID__MINUS__ring__%1d", layer, varname, layer);
+    rdir->GetObject(objname, refplotsTID[plotidx]);
+    sdir->GetObject(objname, newplotsTID[plotidx]);
+    plotidx++;
+  }
+
+  TCanvas* Strip_TID = new TCanvas("Strip_TID","Strip_TID",1000,1000);
+  Strip_TID->Divide(2,3);
+  for (Int_t i=0; i<5; ++i) {
+    if (refplotsTID[i]->GetEntries() == 0 || newplotsTID[i]->GetEntries() == 0) continue;
+    Strip_TID->cd(i+1);
+    SetUpHistograms(refplotsTID[i],newplotsTID[i], bincorr);
+    refplotsTID[i]->Draw();
+    newplotsTID[i]->Draw("sames");
+    myPV->PVCompute(refplotsTID[i], newplotsTID[i], te);
+    gPad->SetLogy(logy);
+  }
+
+  sprintf(histoname, "%sTIDCompare.%s", historoot, outfiletype);  Strip_TID->Print(histoname);
+
+}  // ------------------------------------------------------------------------
+
+void TECcompare(HistoCompare* myPV, TDirectory* rdir, TDirectory* sdir, const char* varname,
+		const char* historoot, const Int_t logy, const float bincorr = 1.0) {
+  TH1F* refplotsTEC[10];
+  TH1F* newplotsTEC[10];
+  char objname[80], histoname[80];
+  Int_t layer[3] = {1, 2, 5}, lidx, plotidx;
+  TText* te = new TText;
+
+  plotidx = 0;
+  for (lidx = 1; lidx < 8; ++lidx) {
+    sprintf(objname, "TEC/MINUS/ring_%1d/%s_rphi__TEC__MINUS__ring__%1d", lidx, varname, lidx);
+    rdir->GetObject(objname, refplotsTEC[plotidx]);
+    sdir->GetObject(objname, newplotsTEC[plotidx]);
+    plotidx++;
+  }
+  for (lidx = 1; lidx < 3; ++lidx) {
+    sprintf(objname, "TEC/MINUS/ring_%1d/%s_stereo__TEC__MINUS__ring__%1d",
+	    layer[lidx], varname, layer[lidx]);
+    rdir->GetObject(objname, refplotsTEC[plotidx]);
+    sdir->GetObject(objname, newplotsTEC[plotidx]);
+    plotidx++;
+  }
+
+  TCanvas* Strip_TEC = new TCanvas("Strip_TEC","Strip_TEC",1000,1000);
+  Strip_TEC->Divide(2,3);
+  for (Int_t i=0; i<5; ++i) {
+    if (refplotsTEC[i]->GetEntries() == 0 || newplotsTEC[i]->GetEntries() == 0) continue;
+    Strip_TEC->cd(i+1);
+    SetUpHistograms(refplotsTEC[i],newplotsTEC[i], bincorr);
+    refplotsTEC[i]->Draw();
+    newplotsTEC[i]->Draw("sames");
+    myPV->PVCompute(refplotsTEC[i], newplotsTEC[i], te);
+    gPad->SetLogy(logy);
+  }
+
+  sprintf(histoname, "%sTECCompare.%s", historoot, outfiletype);  Strip_TEC->Print(histoname);
+
+}  // ------------------------------------------------------------------------
+
+void BPIXcompare(HistoCompare* myPV, TDirectory* rdir, TDirectory* sdir, const char* varname, int layer, const char* historoot) {
+
+  TH1F* refplotsBPIX[11];
+  TH1F* newplotsBPIX[11];
+  char objname[80], histoname[80];
+  std::string dirroot("");
+  Int_t module, plotidx;
+  TText* te = new TText;
+
+  if (strstr(varname, "Pull")) dirroot = "Pulls";
+
+  plotidx = 0;
+  sprintf(objname, "recHit%sBPIX/RecHit_NsimHit_Layer%1d", "", layer);
+  rdir->GetObject(objname, refplotsBPIX[plotidx]);
+  sdir->GetObject(objname, newplotsBPIX[plotidx]);
+  plotidx++;
+  sprintf(objname, "recHit%sBPIX/RecHit_X%s_FlippedLadder_Layer%1d", dirroot.c_str(), varname, layer);
+  rdir->GetObject(objname, refplotsBPIX[plotidx]);
+  sdir->GetObject(objname, newplotsBPIX[plotidx]);
+  plotidx++;
+  sprintf(objname, "recHit%sBPIX/RecHit_X%s_UnFlippedLadder_Layer%1d", dirroot.c_str(), varname, layer);
+  rdir->GetObject(objname, refplotsBPIX[plotidx]);
+  sdir->GetObject(objname, newplotsBPIX[plotidx]);
+  plotidx++;
+  for (module = 0; module < 8; ++module) {
+    sprintf(objname, "recHit%sBPIX/RecHit_Y%s_Layer%1d_Module%1d", dirroot.c_str(), varname, layer, module+1);
+    rdir->GetObject(objname, refplotsBPIX[plotidx]);
+    sdir->GetObject(objname, newplotsBPIX[plotidx]);
+    plotidx++;
+  }
+  int nplots = plotidx;
+
+  TCanvas* Pixel = new TCanvas("Pixel", "Pixel", 1000, 1000);
+  Pixel->Divide(3,4);
+  for (Int_t i=0; i<nplots; ++i) {
+    if (refplotsBPIX[i]->GetEntries() == 0 || newplotsBPIX[i]->GetEntries() == 0) continue;
+    Pixel->cd(i+1);
+    SetUpHistograms(refplotsBPIX[i],newplotsBPIX[i]);
+    refplotsBPIX[i]->Draw();
+    newplotsBPIX[i]->Draw("sames");
+    myPV->PVCompute(refplotsBPIX[i], newplotsBPIX[i], te);
+  }
+  TPad *p1 = (TPad *)(Pixel->cd(1));  p1->SetLogy(1);
+  sprintf(histoname, "%sBPIX_Layer_%1dCompare.%s", historoot, layer, outfiletype);  Pixel->Print(histoname);
+
+}  // ------------------------------------------------------------------------
+
+void FPIXcompare(HistoCompare* myPV, TDirectory* rdir, TDirectory* sdir, const char* varname, int disk, const char* historoot) {
+
+  TH1F* refplotsFPIX[8];
+  TH1F* newplotsFPIX[8];
+  char objname[80], histoname[80];
+  std::string dirroot("");
+  Int_t plaquette, plotidx;
+  TText* te = new TText;
+
+  if (strstr(varname, "Pull")) dirroot = "Pulls";
+
+  plotidx = 0;
+  sprintf(objname, "recHit%sFPIX/RecHit_NsimHit_Disk%1d", "", disk);
+  rdir->GetObject(objname, refplotsFPIX[plotidx]);
+  sdir->GetObject(objname, newplotsFPIX[plotidx]);
+  plotidx++;
+  for (plaquette = 0; plaquette < 7; ++plaquette) {
+    sprintf(objname, "recHit%sFPIX/RecHit_Y%s_Disk%1d_Plaquette%1d", dirroot.c_str(), varname, disk, plaquette+1);
+    rdir->GetObject(objname, refplotsFPIX[plotidx]);
+    sdir->GetObject(objname, newplotsFPIX[plotidx]);
+    plotidx++;
+  }
+  int nplots = plotidx;
+
+  TCanvas* Pixel = new TCanvas("Pixel","Pixel",1000,1000);
+  Pixel->Divide(3,3);
+  for (Int_t i=0; i<nplots; ++i) {
+    if (refplotsFPIX[i]->GetEntries() == 0 || newplotsFPIX[i]->GetEntries() == 0) continue;
+    Pixel->cd(i+1);
+    SetUpHistograms(refplotsFPIX[i],newplotsFPIX[i]);
+    refplotsFPIX[i]->Draw();
+    newplotsFPIX[i]->Draw("sames");
+    myPV->PVCompute(refplotsFPIX[i], newplotsFPIX[i], te);
+  }
+
+  TPad *p1 = (TPad *)(Pixel->cd(1));  p1->SetLogy(1);
+  sprintf(histoname, "%sFPIX_Disk_%1dCompare.%s", historoot, disk, outfiletype);  Pixel->Print(histoname);
+
+}  // ------------------------------------------------------------------------
+
+void Phase1PIXcompare(HistoCompare* myPV, TDirectory* rdir, TDirectory* sdir, const Int_t side, const Int_t layerdisk) {
+
+  TH1F* refplots[6];
+  TH1F* newplots[6];
+  char objname[80], histoname[80];
+  std::string subdir(""), LayerDisk(""), Side("");
+  Int_t abslayerdisk, plotidx;
+  TText* te = new TText;
+  if (side == 0) {
+    subdir = "PXBarrel";
+    LayerDisk = "Layer";
+    abslayerdisk = layerdisk;
+    Side = "";
+  } else {
+    subdir = "PXForward";
+    LayerDisk = "Disk";
+    abslayerdisk = layerdisk > 0 ? layerdisk : -layerdisk;
+    Side = side > 0 ? "+" : "-";
+  }
+
+  plotidx = 0;
+  sprintf(objname, "%s/res_x_PX%s_%s%1d", subdir.c_str(), LayerDisk.c_str(), Side.c_str(), abslayerdisk);
+  rdir->GetObject(objname, refplots[plotidx]);
+  sdir->GetObject(objname, newplots[plotidx]);
+  plotidx++;
+  sprintf(objname, "%s/res_y_PX%s_%s%1d", subdir.c_str(), LayerDisk.c_str(), Side.c_str(), abslayerdisk);
+  rdir->GetObject(objname, refplots[plotidx]);
+  sdir->GetObject(objname, newplots[plotidx]);
+  plotidx++;
+  sprintf(objname, "%s/pull_x_PX%s_%s%1d", subdir.c_str(), LayerDisk.c_str(), Side.c_str(), abslayerdisk);
+  rdir->GetObject(objname, refplots[plotidx]);
+  sdir->GetObject(objname, newplots[plotidx]);
+  plotidx++;
+  sprintf(objname, "%s/pull_y_PX%s_%s%1d", subdir.c_str(), LayerDisk.c_str(), Side.c_str(), abslayerdisk);
+  rdir->GetObject(objname, refplots[plotidx]);
+  sdir->GetObject(objname, newplots[plotidx]);
+  plotidx++;
+  sprintf(objname, "%s/nsimhits_PX%s_%s%1d", subdir.c_str(), LayerDisk.c_str(), Side.c_str(), abslayerdisk);
+  rdir->GetObject(objname, refplots[plotidx]);
+  sdir->GetObject(objname, newplots[plotidx]);
+  plotidx++;
+  int nplots = plotidx;
+
+  TCanvas* Phase1Pix = new TCanvas("Phase1Pix", "Phase1Pix", 1000, 1000);
+  Phase1Pix->Divide(2,3);
+  for (Int_t i=0; i<nplots; ++i) {
+    if (refplots[i]->GetEntries() == 0 || newplots[i]->GetEntries() == 0) continue;
+    Phase1Pix->cd(i+1);
+    SetUpHistograms(refplots[i],newplots[i]);
+    refplots[i]->Draw();
+    newplots[i]->Draw("sames");
+    myPV->PVCompute(refplots[i], newplots[i], te);
+  }
+  TPad *p5 = (TPad *)(Phase1Pix->cd(5));  p5->SetLogy(1);
+  sprintf(histoname, "%s_%s_%s%1d_Compare.%s", subdir.c_str(), LayerDisk.c_str(), Side.c_str(), abslayerdisk, outfiletype);
+  Phase1Pix->Print(histoname);
+
+}  // ------------------------------------------------------------------------
+
+void RecHitsCompare(
+		    const char* rfilename = "DQM_V0001_R000000001__my__relVal__tracker.root",
+		    const char* sfilename = "DQM_V0001_R000000001__my__relVal__tracker.root"
+		    )
+{
+  //  color 2 = red  = sfile = new file
+  //  color 4 = blue = rfile = reference file
+
+  gROOT ->Reset();
+  // gROOT->ProcessLine(".L ../HistoCompare.C");
+
+  delete gROOT->GetListOfFiles()->FindObject(rfilename);
+  delete gROOT->GetListOfFiles()->FindObject(sfilename);;
+  TFile * rfile = new TFile(rfilename);
+  TFile * sfile = new TFile(sfilename);
+  TDirectory * rdir=gDirectory;
+  TDirectory * sdir=gDirectory;
+
+  HistoCompare * myPV = new HistoCompare();
+  TText* te = new TText();
+  char histoname[80];
+ 
+  // Strips
+
+  if (rfile->cd("DQMData/Run 1/SiStrip/Run summary/RecHitsValidation/StiffTrackingRecHits/MechanicalView")) {
+    rdir = gDirectory;
+    if (sfile->cd("DQMData/Run 1/SiStrip/Run summary/RecHitsValidation/StiffTrackingRecHits/MechanicalView")) {
+      sdir=gDirectory;
+
+      //=============================================================== 
+      // TIB
+
+      // rphi, stereo layers
+      TIBcompare(myPV, rdir, sdir, "Pull_LF", "PullLF", 0);
+      TIBcompare(myPV, rdir, sdir, "Pull_MF", "PullMF", 0);
+      TIBcompare(myPV, rdir, sdir, "Resolx",  "Resolx", 0);
+      TIBcompare(myPV, rdir, sdir, "Wclus", "Wclus", 0);
+      TIBcompare(myPV, rdir, sdir, "Adc", "Adc", 0);
+      TIBcompare(myPV, rdir, sdir, "Posx", "Pos", 0);
+      TIBcompare(myPV, rdir, sdir, "Res", "Res", 0);
+      TIBcompare(myPV, rdir, sdir, "Chi2", "Chi2", 0);
+      TIBcompare(myPV, rdir, sdir, "NsimHit", "NsimHit", 1, -1.0);
+ 
+      // matched layers
+      TH1F* matchedtib[16];
+      TH1F* newmatchedtib[16];
+
+      rdir->GetObject("TIB/layer_1/Posx_matched__TIB__layer__1",matchedtib[0]);
+      rdir->GetObject("TIB/layer_1/Posy_matched__TIB__layer__1",matchedtib[1]);
+      rdir->GetObject("TIB/layer_2/Posx_matched__TIB__layer__2",matchedtib[2]);
+      rdir->GetObject("TIB/layer_2/Posy_matched__TIB__layer__2",matchedtib[3]);
+      rdir->GetObject("TIB/layer_1/Resolx_matched__TIB__layer__1",matchedtib[4]);
+      rdir->GetObject("TIB/layer_1/Resoly_matched__TIB__layer__1",matchedtib[5]);
+      rdir->GetObject("TIB/layer_2/Resolx_matched__TIB__layer__2",matchedtib[6]);
+      rdir->GetObject("TIB/layer_2/Resoly_matched__TIB__layer__2",matchedtib[7]);
+      rdir->GetObject("TIB/layer_1/Resx_matched__TIB__layer__1",matchedtib[8]);
+      rdir->GetObject("TIB/layer_1/Resy_matched__TIB__layer__1",matchedtib[9]);
+      rdir->GetObject("TIB/layer_2/Resx_matched__TIB__layer__2",matchedtib[10]);
+      rdir->GetObject("TIB/layer_2/Resy_matched__TIB__layer__2",matchedtib[11]);
+      rdir->GetObject("TIB/layer_1/Chi2_matched__TIB__layer__1",matchedtib[12]);
+      rdir->GetObject("TIB/layer_2/Chi2_matched__TIB__layer__2",matchedtib[13]);
+      rdir->GetObject("TIB/layer_1/NsimHit_matched__TIB__layer__1",matchedtib[14]);
+      rdir->GetObject("TIB/layer_2/NsimHit_matched__TIB__layer__2",matchedtib[15]);
+
+      sdir->GetObject("TIB/layer_1/Posx_matched__TIB__layer__1",newmatchedtib[0]);
+      sdir->GetObject("TIB/layer_1/Posy_matched__TIB__layer__1",newmatchedtib[1]);
+      sdir->GetObject("TIB/layer_2/Posx_matched__TIB__layer__2",newmatchedtib[2]);
+      sdir->GetObject("TIB/layer_2/Posy_matched__TIB__layer__2",newmatchedtib[3]);
+      sdir->GetObject("TIB/layer_1/Resolx_matched__TIB__layer__1",newmatchedtib[4]);
+      sdir->GetObject("TIB/layer_1/Resoly_matched__TIB__layer__1",newmatchedtib[5]);
+      sdir->GetObject("TIB/layer_2/Resolx_matched__TIB__layer__2",newmatchedtib[6]);
+      sdir->GetObject("TIB/layer_2/Resoly_matched__TIB__layer__2",newmatchedtib[7]);
+      sdir->GetObject("TIB/layer_1/Resx_matched__TIB__layer__1",newmatchedtib[8]);
+      sdir->GetObject("TIB/layer_1/Resy_matched__TIB__layer__1",newmatchedtib[9]);
+      sdir->GetObject("TIB/layer_2/Resx_matched__TIB__layer__2",newmatchedtib[10]);
+      sdir->GetObject("TIB/layer_2/Resy_matched__TIB__layer__2",newmatchedtib[11]);
+      sdir->GetObject("TIB/layer_1/Chi2_matched__TIB__layer__1",newmatchedtib[12]);
+      sdir->GetObject("TIB/layer_2/Chi2_matched__TIB__layer__2",newmatchedtib[13]);
+      sdir->GetObject("TIB/layer_1/NsimHit_matched__TIB__layer__1",newmatchedtib[14]);
+      sdir->GetObject("TIB/layer_2/NsimHit_matched__TIB__layer__2",newmatchedtib[15]);
+
+      TCanvas* Strip_TIB_matched = new TCanvas("Strip_TIB_matched","Strip_TIB_matched",1000,1000);
+      Strip_TIB_matched->Divide(4,4);
+      for (Int_t i=0; i<16; ++i) {
+        if (matchedtib[i]->GetEntries() == 0 || newmatchedtib[i]->GetEntries() == 0) continue;
+        Strip_TIB_matched->cd(i+1);
+        if (i == 14 || i == 15) SetUpHistograms(matchedtib[i],newmatchedtib[i], -1.0);
+        else SetUpHistograms(matchedtib[i],newmatchedtib[i]);
+        matchedtib[i]->Draw();
+        newmatchedtib[i]->Draw("sames");
+        myPV->PVCompute(matchedtib[i] , newmatchedtib[i] , te );
+      }
+      // TPad *p15 = (TPad *)(Strip_TIB_matched->cd(15));  p15->SetLogy(1);
+      // TPad *p16 = (TPad *)(Strip_TIB_matched->cd(16));  p16->SetLogy(1);
+
+      sprintf(histoname, "MatchedTIBCompare.%s", outfiletype);  Strip_TIB_matched->Print(histoname);
+
+      //======================================================================================================
+      // TOB
+
+      // rphi, stereo layers
+      TOBcompare(myPV, rdir, sdir, "Pull_LF", "PullLF", 0);
+      TOBcompare(myPV, rdir, sdir, "Pull_MF", "PullMF", 0);
+      TOBcompare(myPV, rdir, sdir, "Resolx",  "Resolx", 0);
+      TOBcompare(myPV, rdir, sdir, "Wclus", "Wclus", 0);
+      TOBcompare(myPV, rdir, sdir, "Adc", "Adc", 0);
+      TOBcompare(myPV, rdir, sdir, "Posx", "Pos", 0);
+      TOBcompare(myPV, rdir, sdir, "Res", "Res", 0);
+      TOBcompare(myPV, rdir, sdir, "Chi2", "Chi2", 0);
+      TOBcompare(myPV, rdir, sdir, "NsimHit", "NsimHit", 1, -1.0);
+
+      // matched layers
+      TH1F* matchedtob[16];
+      TH1F* newmatchedtob[16];
+
+      rdir->GetObject("TOB/layer_1/Posx_matched__TOB__layer__1",matchedtob[0]);
+      rdir->GetObject("TOB/layer_1/Posy_matched__TOB__layer__1",matchedtob[1]);
+      rdir->GetObject("TOB/layer_2/Posx_matched__TOB__layer__2",matchedtob[2]);
+      rdir->GetObject("TOB/layer_2/Posy_matched__TOB__layer__2",matchedtob[3]);
+      rdir->GetObject("TOB/layer_1/Resolx_matched__TOB__layer__1",matchedtob[4]);
+      rdir->GetObject("TOB/layer_1/Resoly_matched__TOB__layer__1",matchedtob[5]);
+      rdir->GetObject("TOB/layer_2/Resolx_matched__TOB__layer__2",matchedtob[6]);
+      rdir->GetObject("TOB/layer_2/Resoly_matched__TOB__layer__2",matchedtob[7]);
+      rdir->GetObject("TOB/layer_1/Resx_matched__TOB__layer__1",matchedtob[8]);
+      rdir->GetObject("TOB/layer_1/Resy_matched__TOB__layer__1",matchedtob[9]);
+      rdir->GetObject("TOB/layer_2/Resx_matched__TOB__layer__2",matchedtob[10]);
+      rdir->GetObject("TOB/layer_2/Resy_matched__TOB__layer__2",matchedtob[11]);
+      rdir->GetObject("TOB/layer_1/Chi2_matched__TOB__layer__1",matchedtob[12]);
+      rdir->GetObject("TOB/layer_2/Chi2_matched__TOB__layer__2",matchedtob[13]);
+      rdir->GetObject("TOB/layer_1/NsimHit_matched__TOB__layer__1",matchedtob[14]);
+      rdir->GetObject("TOB/layer_2/NsimHit_matched__TOB__layer__2",matchedtob[15]);
+
+      sdir->GetObject("TOB/layer_1/Posx_matched__TOB__layer__1",newmatchedtob[0]);
+      sdir->GetObject("TOB/layer_1/Posy_matched__TOB__layer__1",newmatchedtob[1]);
+      sdir->GetObject("TOB/layer_2/Posx_matched__TOB__layer__2",newmatchedtob[2]);
+      sdir->GetObject("TOB/layer_2/Posy_matched__TOB__layer__2",newmatchedtob[3]);
+      sdir->GetObject("TOB/layer_1/Resolx_matched__TOB__layer__1",newmatchedtob[4]);
+      sdir->GetObject("TOB/layer_1/Resoly_matched__TOB__layer__1",newmatchedtob[5]);
+      sdir->GetObject("TOB/layer_2/Resolx_matched__TOB__layer__2",newmatchedtob[6]);
+      sdir->GetObject("TOB/layer_2/Resoly_matched__TOB__layer__2",newmatchedtob[7]);
+      sdir->GetObject("TOB/layer_1/Resx_matched__TOB__layer__1",newmatchedtob[8]);
+      sdir->GetObject("TOB/layer_1/Resy_matched__TOB__layer__1",newmatchedtob[9]);
+      sdir->GetObject("TOB/layer_2/Resx_matched__TOB__layer__2",newmatchedtob[10]);
+      sdir->GetObject("TOB/layer_2/Resy_matched__TOB__layer__2",newmatchedtob[11]);
+      sdir->GetObject("TOB/layer_1/Chi2_matched__TOB__layer__1",newmatchedtob[12]);
+      sdir->GetObject("TOB/layer_2/Chi2_matched__TOB__layer__2",newmatchedtob[13]);
+      sdir->GetObject("TOB/layer_1/NsimHit_matched__TOB__layer__1",newmatchedtob[14]);
+      sdir->GetObject("TOB/layer_2/NsimHit_matched__TOB__layer__2",newmatchedtob[15]);
+
+      TCanvas* Strip_TOB_matched = new TCanvas("Strip_TOB_matched","Strip_TOB_matched",1000,1000);
+      Strip_TOB_matched->Divide(4,4);
+      for (Int_t i=0; i<16; ++i) {
+        if (matchedtob[i]->GetEntries() == 0 || newmatchedtob[i]->GetEntries() == 0) continue;
+        Strip_TOB_matched->cd(i+1);
+        if (i == 14 || i == 15) SetUpHistograms(matchedtob[i],newmatchedtob[i], -1.0);
+        else SetUpHistograms(matchedtob[i],newmatchedtob[i]);
+        matchedtob[i]->Draw();
+        newmatchedtob[i]->Draw("sames");
+        myPV->PVCompute(matchedtob[i] , newmatchedtob[i] , te );
+      }
+      // TPad *p15 = (TPad *)(Strip_TOB_matched->cd(15));  p15->SetLogy(1);
+      // TPad *p16 = (TPad *)(Strip_TOB_matched->cd(16));  p16->SetLogy(1);
+ 
+      sprintf(histoname, "MatchedTOBCompare.%s", outfiletype);  Strip_TOB_matched->Print(histoname);
+
+      //=============================================================== 
+      // TID
+
+      // rphi, stereo layers
+      TIDcompare(myPV, rdir, sdir, "Pull_LF", "PullLF", 0);
+      TIDcompare(myPV, rdir, sdir, "Pull_MF", "PullMF", 0);
+      TIDcompare(myPV, rdir, sdir, "Resolx",  "Resolx", 0);
+      TIDcompare(myPV, rdir, sdir, "Wclus", "Wclus", 0);
+      TIDcompare(myPV, rdir, sdir, "Adc", "Adc", 0);
+      TIDcompare(myPV, rdir, sdir, "Posx", "Pos", 0);
+      TIDcompare(myPV, rdir, sdir, "Res", "Res", 0);
+      TIDcompare(myPV, rdir, sdir, "Chi2", "Chi2", 0);
+      TIDcompare(myPV, rdir, sdir, "NsimHit", "NsimHit", 1, -1.0);
+
+      // matched layers
+      TH1F* matchedtid[16];
+      TH1F* newmatchedtid[16];
+
+      rdir->GetObject("TID/MINUS/ring_1/Posx_matched__TID__MINUS__ring__1",matchedtid[0]);
+      rdir->GetObject("TID/MINUS/ring_1/Posy_matched__TID__MINUS__ring__1",matchedtid[1]);
+      rdir->GetObject("TID/MINUS/ring_2/Posx_matched__TID__MINUS__ring__2",matchedtid[2]);
+      rdir->GetObject("TID/MINUS/ring_2/Posy_matched__TID__MINUS__ring__2",matchedtid[3]);
+      rdir->GetObject("TID/MINUS/ring_1/Resolx_matched__TID__MINUS__ring__1",matchedtid[4]);
+      rdir->GetObject("TID/MINUS/ring_1/Resoly_matched__TID__MINUS__ring__1",matchedtid[5]);
+      rdir->GetObject("TID/MINUS/ring_2/Resolx_matched__TID__MINUS__ring__2",matchedtid[6]);
+      rdir->GetObject("TID/MINUS/ring_2/Resoly_matched__TID__MINUS__ring__2",matchedtid[7]);
+      rdir->GetObject("TID/MINUS/ring_1/Resx_matched__TID__MINUS__ring__1",matchedtid[8]);
+      rdir->GetObject("TID/MINUS/ring_1/Resy_matched__TID__MINUS__ring__1",matchedtid[9]);
+      rdir->GetObject("TID/MINUS/ring_2/Resx_matched__TID__MINUS__ring__2",matchedtid[10]);
+      rdir->GetObject("TID/MINUS/ring_2/Resy_matched__TID__MINUS__ring__2",matchedtid[11]);
+      rdir->GetObject("TID/MINUS/ring_1/Chi2_matched__TID__MINUS__ring__1",matchedtid[12]);
+      rdir->GetObject("TID/MINUS/ring_1/Chi2_matched__TID__MINUS__ring__1",matchedtid[13]);
+      rdir->GetObject("TID/MINUS/ring_2/NsimHit_matched__TID__MINUS__ring__2",matchedtid[14]);
+      rdir->GetObject("TID/MINUS/ring_2/NsimHit_matched__TID__MINUS__ring__2",matchedtid[15]);
+
+      sdir->GetObject("TID/MINUS/ring_1/Posx_matched__TID__MINUS__ring__1",newmatchedtid[0]);
+      sdir->GetObject("TID/MINUS/ring_1/Posy_matched__TID__MINUS__ring__1",newmatchedtid[1]);
+      sdir->GetObject("TID/MINUS/ring_2/Posx_matched__TID__MINUS__ring__2",newmatchedtid[2]);
+      sdir->GetObject("TID/MINUS/ring_2/Posy_matched__TID__MINUS__ring__2",newmatchedtid[3]);
+      sdir->GetObject("TID/MINUS/ring_1/Resolx_matched__TID__MINUS__ring__1",newmatchedtid[4]);
+      sdir->GetObject("TID/MINUS/ring_1/Resoly_matched__TID__MINUS__ring__1",newmatchedtid[5]);
+      sdir->GetObject("TID/MINUS/ring_2/Resolx_matched__TID__MINUS__ring__2",newmatchedtid[6]);
+      sdir->GetObject("TID/MINUS/ring_2/Resoly_matched__TID__MINUS__ring__2",newmatchedtid[7]);
+      sdir->GetObject("TID/MINUS/ring_1/Resx_matched__TID__MINUS__ring__1",newmatchedtid[8]);
+      sdir->GetObject("TID/MINUS/ring_1/Resy_matched__TID__MINUS__ring__1",newmatchedtid[9]);
+      sdir->GetObject("TID/MINUS/ring_2/Resx_matched__TID__MINUS__ring__2",newmatchedtid[10]);
+      sdir->GetObject("TID/MINUS/ring_2/Resy_matched__TID__MINUS__ring__2",newmatchedtid[11]);
+      sdir->GetObject("TID/MINUS/ring_1/Chi2_matched__TID__MINUS__ring__1",newmatchedtid[12]);
+      sdir->GetObject("TID/MINUS/ring_2/Chi2_matched__TID__MINUS__ring__2",newmatchedtid[13]);
+      sdir->GetObject("TID/MINUS/ring_1/NsimHit_matched__TID__MINUS__ring__1",newmatchedtid[14]);
+      sdir->GetObject("TID/MINUS/ring_2/NsimHit_matched__TID__MINUS__ring__2",newmatchedtid[15]);
+
+      TCanvas* Strip_TID_matched = new TCanvas("Strip_TID_matched","Strip_TID_matched",1000,1000);
+      Strip_TID_matched->Divide(4,4);
+      for (Int_t i=0; i<16; ++i) {
+        if (matchedtid[i]->GetEntries() == 0 || newmatchedtid[i]->GetEntries() == 0) continue;
+        Strip_TID_matched->cd(i+1);
+        if (i == 14 || i == 15) SetUpHistograms(matchedtid[i],newmatchedtid[i], -1.0);
+        else SetUpHistograms(matchedtid[i],newmatchedtid[i]);
+        matchedtid[i]->Draw();
+        newmatchedtid[i]->Draw("sames");
+        myPV->PVCompute(matchedtid[i] , newmatchedtid[i] , te );
+      }
+      // TPad *p15 = (TPad *)(Strip_TID_matched->cd(15));  p15->SetLogy(1);
+      // TPad *p16 = (TPad *)(Strip_TID_matched->cd(16));  p16->SetLogy(1);
+ 
+      sprintf(histoname, "MatchedTIDCompare.%s", outfiletype);  Strip_TID_matched->Print(histoname);
+
+      //======================================================================================================
+      // TEC
+
+      // rphi, stereo layers
+      TECcompare(myPV, rdir, sdir, "Pull_LF", "PullLF", 0);
+      TECcompare(myPV, rdir, sdir, "Pull_MF", "PullMF", 0);
+      TECcompare(myPV, rdir, sdir, "Resolx",  "Resolx", 0);
+      TECcompare(myPV, rdir, sdir, "Wclus", "Wclus", 0);
+      TECcompare(myPV, rdir, sdir, "Adc", "Adc", 0);
+      TECcompare(myPV, rdir, sdir, "Posx", "Pos", 0);
+      TECcompare(myPV, rdir, sdir, "Res", "Res", 0);
+      TECcompare(myPV, rdir, sdir, "Chi2", "Chi2", 0);
+      TECcompare(myPV, rdir, sdir, "NsimHit", "NsimHit", 1, -1.0);
+
+      // matched layers
+      TH1F* matchedtec[24];
+      TH1F* newmatchedtec[24];
+
+      rdir->GetObject("TEC/MINUS/ring_1/Posx_matched__TEC__MINUS__ring__1",matchedtec[0]);
+      rdir->GetObject("TEC/MINUS/ring_1/Posy_matched__TEC__MINUS__ring__1",matchedtec[1]);
+      rdir->GetObject("TEC/MINUS/ring_2/Posx_matched__TEC__MINUS__ring__2",matchedtec[2]);
+      rdir->GetObject("TEC/MINUS/ring_2/Posy_matched__TEC__MINUS__ring__2",matchedtec[3]);
+      rdir->GetObject("TEC/MINUS/ring_5/Posx_matched__TEC__MINUS__ring__5",matchedtec[4]);
+      rdir->GetObject("TEC/MINUS/ring_5/Posy_matched__TEC__MINUS__ring__5",matchedtec[5]);
+      rdir->GetObject("TEC/MINUS/ring_1/Resolx_matched__TEC__MINUS__ring__1",matchedtec[6]);
+      rdir->GetObject("TEC/MINUS/ring_1/Resoly_matched__TEC__MINUS__ring__1",matchedtec[7]);
+      rdir->GetObject("TEC/MINUS/ring_2/Resolx_matched__TEC__MINUS__ring__2",matchedtec[8]);
+      rdir->GetObject("TEC/MINUS/ring_2/Resoly_matched__TEC__MINUS__ring__2",matchedtec[9]);
+      rdir->GetObject("TEC/MINUS/ring_5/Resolx_matched__TEC__MINUS__ring__5",matchedtec[10]);
+      rdir->GetObject("TEC/MINUS/ring_5/Resoly_matched__TEC__MINUS__ring__5",matchedtec[11]);
+      rdir->GetObject("TEC/MINUS/ring_1/Resx_matched__TEC__MINUS__ring__1",matchedtec[12]);
+      rdir->GetObject("TEC/MINUS/ring_1/Resy_matched__TEC__MINUS__ring__1",matchedtec[13]);
+      rdir->GetObject("TEC/MINUS/ring_2/Resx_matched__TEC__MINUS__ring__2",matchedtec[14]);
+      rdir->GetObject("TEC/MINUS/ring_2/Resy_matched__TEC__MINUS__ring__2",matchedtec[15]);
+      rdir->GetObject("TEC/MINUS/ring_5/Resx_matched__TEC__MINUS__ring__5",matchedtec[16]);
+      rdir->GetObject("TEC/MINUS/ring_5/Resy_matched__TEC__MINUS__ring__5",matchedtec[17]);
+      rdir->GetObject("TEC/MINUS/ring_1/Chi2_matched__TEC__MINUS__ring__1",matchedtec[18]);
+      rdir->GetObject("TEC/MINUS/ring_2/Chi2_matched__TEC__MINUS__ring__2",matchedtec[19]);
+      rdir->GetObject("TEC/MINUS/ring_5/Chi2_matched__TEC__MINUS__ring__5",matchedtec[20]);
+      rdir->GetObject("TEC/MINUS/ring_1/NsimHit_matched__TEC__MINUS__ring__1",matchedtec[21]);
+      rdir->GetObject("TEC/MINUS/ring_2/NsimHit_matched__TEC__MINUS__ring__2",matchedtec[22]);
+      rdir->GetObject("TEC/MINUS/ring_5/NsimHit_matched__TEC__MINUS__ring__5",matchedtec[23]);
+
+      sdir->GetObject("TEC/MINUS/ring_1/Posx_matched__TEC__MINUS__ring__1",newmatchedtec[0]);
+      sdir->GetObject("TEC/MINUS/ring_1/Posy_matched__TEC__MINUS__ring__1",newmatchedtec[1]);
+      sdir->GetObject("TEC/MINUS/ring_2/Posx_matched__TEC__MINUS__ring__2",newmatchedtec[2]);
+      sdir->GetObject("TEC/MINUS/ring_2/Posy_matched__TEC__MINUS__ring__2",newmatchedtec[3]);
+      sdir->GetObject("TEC/MINUS/ring_5/Posx_matched__TEC__MINUS__ring__5",newmatchedtec[4]);
+      sdir->GetObject("TEC/MINUS/ring_5/Posy_matched__TEC__MINUS__ring__5",newmatchedtec[5]);
+      sdir->GetObject("TEC/MINUS/ring_1/Resolx_matched__TEC__MINUS__ring__1",newmatchedtec[6]);
+      sdir->GetObject("TEC/MINUS/ring_1/Resoly_matched__TEC__MINUS__ring__1",newmatchedtec[7]);
+      sdir->GetObject("TEC/MINUS/ring_2/Resolx_matched__TEC__MINUS__ring__2",newmatchedtec[8]);
+      sdir->GetObject("TEC/MINUS/ring_2/Resoly_matched__TEC__MINUS__ring__2",newmatchedtec[9]);
+      sdir->GetObject("TEC/MINUS/ring_5/Resolx_matched__TEC__MINUS__ring__5",newmatchedtec[10]);
+      sdir->GetObject("TEC/MINUS/ring_5/Resoly_matched__TEC__MINUS__ring__5",newmatchedtec[11]);
+      sdir->GetObject("TEC/MINUS/ring_1/Resx_matched__TEC__MINUS__ring__1",newmatchedtec[12]);
+      sdir->GetObject("TEC/MINUS/ring_1/Resy_matched__TEC__MINUS__ring__1",newmatchedtec[13]);
+      sdir->GetObject("TEC/MINUS/ring_2/Resx_matched__TEC__MINUS__ring__2",newmatchedtec[14]);
+      sdir->GetObject("TEC/MINUS/ring_2/Resy_matched__TEC__MINUS__ring__2",newmatchedtec[15]);
+      sdir->GetObject("TEC/MINUS/ring_5/Resx_matched__TEC__MINUS__ring__5",newmatchedtec[16]);
+      sdir->GetObject("TEC/MINUS/ring_5/Resy_matched__TEC__MINUS__ring__5",newmatchedtec[17]);
+      sdir->GetObject("TEC/MINUS/ring_1/Chi2_matched__TEC__MINUS__ring__1",newmatchedtec[18]);
+      sdir->GetObject("TEC/MINUS/ring_2/Chi2_matched__TEC__MINUS__ring__2",newmatchedtec[19]);
+      sdir->GetObject("TEC/MINUS/ring_5/Chi2_matched__TEC__MINUS__ring__5",newmatchedtec[20]);
+      sdir->GetObject("TEC/MINUS/ring_1/NsimHit_matched__TEC__MINUS__ring__1",newmatchedtec[21]);
+      sdir->GetObject("TEC/MINUS/ring_2/NsimHit_matched__TEC__MINUS__ring__2",newmatchedtec[22]);
+      sdir->GetObject("TEC/MINUS/ring_5/NsimHit_matched__TEC__MINUS__ring__5",newmatchedtec[23]);
+
+      TCanvas* Strip_TEC_matched = new TCanvas("Strip_TEC_matched","Strip_TEC_matched",1000,1000);
+      Strip_TEC_matched->Divide(5,5);
+      for (Int_t i=0; i<24; ++i) {
+        if (matchedtec[i]->GetEntries() == 0 || newmatchedtec[i]->GetEntries() == 0) continue;
+        Strip_TEC_matched->cd(i+1);
+        if (i == 21 || i == 22 || i == 23) SetUpHistograms(matchedtec[i],newmatchedtec[i], -1.0);
+        else SetUpHistograms(matchedtec[i],newmatchedtec[i]);
+        matchedtec[i]->Draw();
+        newmatchedtec[i]->Draw("sames");
+        myPV->PVCompute(matchedtec[i] , newmatchedtec[i] , te );
+      }
+      // TPad *p22 = (TPad *)(Strip_TEC_matched->cd(22));  p22->SetLogy(1);
+      // TPad *p23 = (TPad *)(Strip_TEC_matched->cd(23));  p23->SetLogy(1);
+      // TPad *p24 = (TPad *)(Strip_TEC_matched->cd(24));  p24->SetLogy(1);
+ 
+      sprintf(histoname, "MatchedTECCompare.%s", outfiletype);  Strip_TEC_matched->Print(histoname);
+    }
+  }
+
+  //===============================================================
+  // Phase 0 pixels 
+
+  if (rfile->cd("DQMData/Run 1/TrackerRecHitsV/Run summary/TrackerRecHits/Pixel")) {
+    rdir = gDirectory;
+    if (sfile->cd("DQMData/Run 1/TrackerRecHitsV/Run summary/TrackerRecHits/Pixel")) {
+      sdir = gDirectory;
+
+      // BPIX
+      for (int layer=1; layer<=3; ++layer) {
+	BPIXcompare(myPV, rdir, sdir, "Res", layer, "Res");
+	BPIXcompare(myPV, rdir, sdir, "Pull", layer, "Pull");
+      }
+
+      // FPIX
+      for (int disk=1; disk<=2; ++disk) {
+	FPIXcompare(myPV, rdir, sdir, "Res", disk, "Res");
+	FPIXcompare(myPV, rdir, sdir, "Pull", disk, "Pull");
+      }
+    }
+  }
+
+  //===============================================================
+  // Phase 1 pixels 
+
+  if (rfile->cd("DQMData/Run 1/PixelPhase1V/Run summary/RecHits")) {
+    rdir = gDirectory;
+    if (sfile->cd("DQMData/Run 1/PixelPhase1V/Run summary/RecHits")) {
+      sdir = gDirectory;
+
+      // BPIX by layer
+      for (int layer=1; layer<=4; ++layer) {
+	Phase1PIXcompare(myPV, rdir, sdir, 0, layer);
+      }
+
+      // FPIX by disk
+      for (int disk=1; disk<=3; ++disk) {
+	Phase1PIXcompare(myPV, rdir, sdir, 1, disk);
+	Phase1PIXcompare(myPV, rdir, sdir, -1, disk);
+      }
+
+      // Combined layers
+      TH1F* refplots[6];
+      TH1F* newplots[6];
+      Int_t plotidx = 0;
+      rdir->GetObject("res_x_PXBarrel", refplots[plotidx]);
+      sdir->GetObject("res_x_PXBarrel", newplots[plotidx]);
+      plotidx++;
+      rdir->GetObject("res_y_PXBarrel", refplots[plotidx]);
+      sdir->GetObject("res_y_PXBarrel", newplots[plotidx]);
+      plotidx++;
+      rdir->GetObject("res_x_PXForward", refplots[plotidx]);
+      sdir->GetObject("res_x_PXForward", newplots[plotidx]);
+      plotidx++;
+      rdir->GetObject("res_y_PXForward", refplots[plotidx]);
+      sdir->GetObject("res_y_PXForward", newplots[plotidx]);
+      plotidx++;
+      rdir->GetObject("rechiterror_x", refplots[plotidx]);
+      sdir->GetObject("rechiterror_x", newplots[plotidx]);
+      plotidx++;
+      rdir->GetObject("rechiterror_y", refplots[plotidx]);
+      sdir->GetObject("rechiterror_y", newplots[plotidx]);
+      plotidx++;
+      int nplots = plotidx;
+
+      TCanvas* Phase1Pix = new TCanvas("Phase1Pix", "Phase1Pix", 1000, 1000);
+      Phase1Pix->Divide(2,3);
+      for (Int_t i=0; i<nplots; ++i) {
+	if (refplots[i]->GetEntries() == 0 || newplots[i]->GetEntries() == 0) continue;
+	Phase1Pix->cd(i+1);
+	SetUpHistograms(refplots[i],newplots[i]);
+	refplots[i]->Draw();
+	newplots[i]->Draw("sames");
+	myPV->PVCompute(refplots[i], newplots[i], te);
+      }
+      sprintf(histoname, "PX_Compare.%s", outfiletype);
+      Phase1Pix->Print(histoname);
+    }
+  }
+}  // ------------------------------------------------------------------------

--- a/Validation/TrackerRecHits/test/RecHitsValid_cfg.py
+++ b/Validation/TrackerRecHits/test/RecHitsValid_cfg.py
@@ -1,0 +1,216 @@
+#
+# Stand-alone creation of RelVal-plot root file for Strips and Phase0 or Phase1 pixels
+# This is derived from Validation/TrackerRecHits/test/
+#    SiPixelRecHitsValid_cfg.py
+#    SiStripRecHitsValid_cfg.py
+# Commented sections support crossing frames with pileup
+#  Bill Ford 10 Oct 2017
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.StandardSequences.Eras import eras
+# process = cms.Process("RecHitsValid", eras.Run2_2016)
+process = cms.Process("RecHitsValid", eras.Run2_2017)
+
+process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+# (See /Configuration/AlCa/python/autoCond.py)
+# process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_realistic', '')
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.load("Configuration.StandardSequences.Services_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
+
+# process.load('Configuration.StandardSequences.DigiToRaw_cff')  # for remaking recHits
+
+process.load('Configuration.StandardSequences.RawToDigi_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load("Configuration.StandardSequences.Reconstruction_cff")
+
+process.load("Validation.TrackerRecHits.SiPixelRecHitsValid_cfi")
+process.load("Validation.SiPixelPhase1ConfigV.SiPixelPhase1OfflineDQM_harvestingV_cff")
+process.load("Validation.TrackerRecHits.SiStripRecHitsValid_cfi")
+
+process.pixRecHitsValid_step = cms.Sequence(process.pixRecHitsValid)
+process.stripRecHitsValid_step = cms.Sequence(process.stripRecHitsValid)
+process.pixPhase1RecHitsValid_step = cms.Sequence(process.SiPixelPhase1RecHitsAnalyzerV*process.SiPixelPhase1RecHitsHarvesterV)
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toReplaceWith(process.pixRecHitsValid_step, process.pixPhase1RecHitsValid_step)
+process.validation_step = cms.Sequence(process.pixRecHitsValid_step*process.stripRecHitsValid_step)
+
+process.load("DQMServices.Components.DQMFileSaver_cfi")
+process.dqmSaver.workflow = cms.untracked.string('/my/relVal/tracker')
+
+# No pileup
+process.load("SimGeneral.MixingModule.mixNoPU_cfi")
+
+# From-scratch pileup; needs DigiToRaw in path
+# process.load("SimGeneral.MixingModule.mixHighLumPU_cfi")
+# process.mix.input.fileNames = cms.untracked.vstring([
+#  '/store/relval/CMSSW_7_1_0_pre4/RelValProdMinBias_13/GEN-SIM-RAW/POSTLS171_V1-v2/00000/0275ACA6-3CAA-E311-9DAF-02163E00E62F.root',
+#  '/store/relval/CMSSW_7_1_0_pre4/RelValProdMinBias_13/GEN-SIM-RAW/POSTLS171_V1-v2/00000/54DD7A36-3DAA-E311-A92B-0025904B11C0.root',
+#  '/store/relval/CMSSW_7_1_0_pre4/RelValProdMinBias_13/GEN-SIM-RAW/POSTLS171_V1-v2/00000/D6560D41-36AA-E311-BF6E-02163E00EBBC.root'
+#   ])
+
+# For playback pileup mode
+#  TTbar_13/<tier>/PU25ns sample
+#  (from config found in DAS for above sample)
+#
+# process.load('SimGeneral.MixingModule.mix_POISSON_average_cfi')
+# process.mix.input.nbPileupEvents.averageNumber = cms.double(10.000000)
+# process.mix.bunchspace = cms.int32(25)
+# process.mix.minBunch = cms.int32(-8)  # -8
+# process.mix.maxBunch = cms.int32(3)  # 3
+# process.mix.input.fileNames = cms.untracked.vstring([
+#   '/store/relval/CMSSW_7_1_0_pre1/RelValMinBias_13/GEN-SIM/POSTLS170_V1-v1/00000/0C2DD921-1586-E311-9EA9-02163E00EA98.root',
+#   '/store/relval/CMSSW_7_1_0_pre1/RelValMinBias_13/GEN-SIM/POSTLS170_V1-v1/00000/42450CEB-1086-E311-B439-02163E00EB7E.root',
+#   '/store/relval/CMSSW_7_1_0_pre1/RelValMinBias_13/GEN-SIM/POSTLS170_V1-v1/00000/502D6922-0986-E311-828F-02163E00A10F.root',
+#   '/store/relval/CMSSW_7_1_0_pre1/RelValMinBias_13/GEN-SIM/POSTLS170_V1-v1/00000/7AA4094E-1986-E311-8F3E-003048D2BC06.root',
+#   '/store/relval/CMSSW_7_1_0_pre1/RelValMinBias_13/GEN-SIM/POSTLS170_V1-v1/00000/7AF1A921-0D86-E311-86D7-02163E00E6CC.root',
+#   '/store/relval/CMSSW_7_1_0_pre1/RelValMinBias_13/GEN-SIM/POSTLS170_V1-v1/00000/88A9162C-0C86-E311-A244-02163E009E82.root',
+#   '/store/relval/CMSSW_7_1_0_pre1/RelValMinBias_13/GEN-SIM/POSTLS170_V1-v1/00000/88CDC2A6-1186-E311-A9F5-02163E00E5C7.root',
+#   '/store/relval/CMSSW_7_1_0_pre1/RelValMinBias_13/GEN-SIM/POSTLS170_V1-v1/00000/96AC49A8-0F86-E311-BBB4-02163E00EA8B.root',
+#   '/store/relval/CMSSW_7_1_0_pre1/RelValMinBias_13/GEN-SIM/POSTLS170_V1-v1/00000/A4846C0D-0B86-E311-8B2E-003048FEB9EE.root',
+#   '/store/relval/CMSSW_7_1_0_pre1/RelValMinBias_13/GEN-SIM/POSTLS170_V1-v1/00000/BA98B978-0A86-E311-A451-02163E00E680.root',
+#   '/store/relval/CMSSW_7_1_0_pre1/RelValMinBias_13/GEN-SIM/POSTLS170_V1-v1/00000/C04929C2-0D86-E311-A247-003048FEADBC.root',
+#   '/store/relval/CMSSW_7_1_0_pre1/RelValMinBias_13/GEN-SIM/POSTLS170_V1-v1/00000/D0E99AF9-0E86-E311-8C6C-00304894528A.root',
+#   '/store/relval/CMSSW_7_1_0_pre1/RelValMinBias_13/GEN-SIM/POSTLS170_V1-v1/00000/DCC5CAB6-0786-E311-BBDF-00237DDBEBD0.root',
+#   '/store/relval/CMSSW_7_1_0_pre1/RelValMinBias_13/GEN-SIM/POSTLS170_V1-v1/00000/DEACF0AD-0B86-E311-9C27-0030489455E0.root',
+#   '/store/relval/CMSSW_7_1_0_pre1/RelValMinBias_13/GEN-SIM/POSTLS170_V1-v1/00000/ECC297E5-1286-E311-846F-001D09F241E6.root',
+#   '/store/relval/CMSSW_7_1_0_pre1/RelValMinBias_13/GEN-SIM/POSTLS170_V1-v1/00000/EEC1F7A5-3786-E311-80B3-BCAEC532970F.root'
+#
+#   ])
+# process.mix.playback = True
+# process.mix.digitizers = cms.PSet()
+# for a in process.aliases: delattr(process, a)
+
+#
+# Configure RecHits validator
+#
+# process.stripRecHitsValid.TH1Resolxrphi.xmax=cms.double(0.00002)
+# process.stripRecHitsValid.TH1ResolxStereo.xmax=cms.double(0.01)
+# process.stripRecHitsValid.TH1ResolxMatched.xmax=cms.double(0.01)
+# process.stripRecHitsValid.TH1ResolyMatched.xmax=cms.double(0.05)
+# process.stripRecHitsValid.TH1NumTotrphi.xmax=cms.double(100000.)
+# process.stripRecHitsValid.TH1NumTotStereo.xmax=cms.double(100000.)
+# process.stripRecHitsValid.TH1NumTotMatched.xmax=cms.double(100000.)
+# process.stripRecHitsValid.TH1Numrphi.xmax=cms.double(50000.)
+# process.stripRecHitsValid.TH1NumStereo.xmax=cms.double(50000.)
+# process.stripRecHitsValid.TH1NumMatched.xmax=cms.double(50000.)
+
+#
+# Configure associator
+#
+# process.pixRecHitsValid.associateHitbySimTrack = cms.bool(True)
+# process.stripRecHitsValid.associateHitbySimTrack = cms.bool(True)
+#
+# Read simHits from prompt collections
+process.pixRecHitsValid.ROUList = cms.vstring(
+    'TrackerHitsPixelBarrelLowTof', 
+    'TrackerHitsPixelBarrelHighTof', 
+    'TrackerHitsPixelEndcapLowTof', 
+    'TrackerHitsPixelEndcapHighTof'
+    )
+process.SiPixelPhase1RecHitsAnalyzerV.ROUList = cms.vstring(
+    'TrackerHitsPixelBarrelLowTof', 
+    'TrackerHitsPixelBarrelHighTof', 
+    'TrackerHitsPixelEndcapLowTof', 
+    'TrackerHitsPixelEndcapHighTof'
+    )
+process.stripRecHitsValid.ROUList = cms.vstring(
+    'TrackerHitsTIBLowTof', 
+    'TrackerHitsTIBHighTof', 
+    'TrackerHitsTIDLowTof', 
+    'TrackerHitsTIDHighTof', 
+    'TrackerHitsTOBLowTof', 
+    'TrackerHitsTOBHighTof', 
+    'TrackerHitsTECLowTof', 
+    'TrackerHitsTECHighTof'
+    )
+
+inputfiles=cms.untracked.vstring(
+# '/store/relval/CMSSW_9_4_0_pre1/RelValSingleMuPt100/GEN-SIM-DIGI-RAW/93X_mc2017_realistic_v3-v1/00000/409345CD-F79C-E711-8383-0CC47A4D76C8.root',
+# '/store/relval/CMSSW_9_4_0_pre1/RelValSingleMuPt100/GEN-SIM-DIGI-RAW/93X_mc2017_realistic_v3-v1/00000/9C783844-F79C-E711-96E3-0CC47A4D76AA.root',
+# '/store/relval/CMSSW_9_4_0_pre1/RelValSingleMuPt100/GEN-SIM-DIGI-RAW/93X_mc2017_realistic_v3-v1/00000/DC94E5C6-F79C-E711-B3EC-0CC47A4D7606.root'
+
+# '/store/relval/CMSSW_9_2_4/RelValSingleMuPt1000_UP15/GEN-SIM-DIGI-RAW-HLTDEBUG/91X_mcRun2_asymptotic_v3-v1/00000/2470004C-8D62-E711-817C-0CC47A78A4B8.root',
+# '/store/relval/CMSSW_9_2_4/RelValSingleMuPt1000_UP15/GEN-SIM-DIGI-RAW-HLTDEBUG/91X_mcRun2_asymptotic_v3-v1/00000/5A844742-8D62-E711-B923-0CC47A4C8E38.root'
+
+# '/store/relval/CMSSW_9_3_0_pre1/RelValQCD_Pt_3000_3500_13/GEN-SIM-DIGI-RAW-HLTDEBUG/92X_mcRun2_asymptotic_v2-v1/00000/3219D083-8C63-E711-8FB8-0CC47A4D7628.root',
+# '/store/relval/CMSSW_9_3_0_pre1/RelValQCD_Pt_3000_3500_13/GEN-SIM-DIGI-RAW-HLTDEBUG/92X_mcRun2_asymptotic_v2-v1/00000/487A39C6-8C63-E711-8FCB-0CC47A4D7698.root',
+# '/store/relval/CMSSW_9_3_0_pre1/RelValQCD_Pt_3000_3500_13/GEN-SIM-DIGI-RAW-HLTDEBUG/92X_mcRun2_asymptotic_v2-v1/00000/84519579-8D63-E711-86B0-0CC47A4C8EB6.root',
+# '/store/relval/CMSSW_9_3_0_pre1/RelValQCD_Pt_3000_3500_13/GEN-SIM-DIGI-RAW-HLTDEBUG/92X_mcRun2_asymptotic_v2-v1/00000/9EA8737B-8C63-E711-A46C-0025905B85CC.root',
+# '/store/relval/CMSSW_9_3_0_pre1/RelValQCD_Pt_3000_3500_13/GEN-SIM-DIGI-RAW-HLTDEBUG/92X_mcRun2_asymptotic_v2-v1/00000/F6CF72E4-8B63-E711-96DA-0025905A6068.root',
+# '/store/relval/CMSSW_9_3_0_pre1/RelValQCD_Pt_3000_3500_13/GEN-SIM-DIGI-RAW-HLTDEBUG/92X_mcRun2_asymptotic_v2-v1/00000/FC762B97-8C63-E711-8CEE-0CC47A7C353E.root'
+
+'/store/relval/CMSSW_9_4_0_pre1/RelValQCD_Pt_3000_3500_13/GEN-SIM-DIGI-RAW/93X_mc2017_realistic_v3-v1/00000/00D622D4-A79C-E711-8A41-0CC47A7C35D8.root',
+'/store/relval/CMSSW_9_4_0_pre1/RelValQCD_Pt_3000_3500_13/GEN-SIM-DIGI-RAW/93X_mc2017_realistic_v3-v1/00000/28D592D3-A79C-E711-BE47-0CC47A7C3458.root',
+'/store/relval/CMSSW_9_4_0_pre1/RelValQCD_Pt_3000_3500_13/GEN-SIM-DIGI-RAW/93X_mc2017_realistic_v3-v1/00000/2C0B8FD4-A79C-E711-BF8F-0CC47A4D761A.root',
+'/store/relval/CMSSW_9_4_0_pre1/RelValQCD_Pt_3000_3500_13/GEN-SIM-DIGI-RAW/93X_mc2017_realistic_v3-v1/00000/54C1ABAB-A89C-E711-BEDF-0025905A60BE.root',
+'/store/relval/CMSSW_9_4_0_pre1/RelValQCD_Pt_3000_3500_13/GEN-SIM-DIGI-RAW/93X_mc2017_realistic_v3-v1/00000/5C3C3FD7-A79C-E711-91A6-0CC47A7C35A8.root',
+'/store/relval/CMSSW_9_4_0_pre1/RelValQCD_Pt_3000_3500_13/GEN-SIM-DIGI-RAW/93X_mc2017_realistic_v3-v1/00000/7E1D18E2-A79C-E711-969D-0025905A610A.root',
+'/store/relval/CMSSW_9_4_0_pre1/RelValQCD_Pt_3000_3500_13/GEN-SIM-DIGI-RAW/93X_mc2017_realistic_v3-v1/00000/E2715BD7-A79C-E711-807F-0025905B859E.root',
+'/store/relval/CMSSW_9_4_0_pre1/RelValQCD_Pt_3000_3500_13/GEN-SIM-DIGI-RAW/93X_mc2017_realistic_v3-v1/00000/E2772BAB-A89C-E711-945D-0025905B857C.root',
+'/store/relval/CMSSW_9_4_0_pre1/RelValQCD_Pt_3000_3500_13/GEN-SIM-DIGI-RAW/93X_mc2017_realistic_v3-v1/00000/FE788BD4-A79C-E711-B5D3-0CC47A4C8F08.root'
+
+)
+secinputfiles=cms.untracked.vstring(
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = inputfiles,
+    secondaryFileNames = secinputfiles
+    , inputCommands=cms.untracked.vstring('keep *', 
+      'drop l1tEMTFHitExtras_simEmtfDigis_CSC_HLT',
+      'drop l1tEMTFHitExtras_simEmtfDigis_RPC_HLT',
+      'drop l1tEMTFTrackExtras_simEmtfDigis__HLT'
+    )
+)
+
+# # Input source
+# process.source = cms.Source("PoolSource",
+#     fileNames = cms.untracked.vstring('file:../10008.0_SingleMuPt100+SingleMuPt100_pythia8_2017_GenSimFullINPUT+DigiFull_2017+RecoFull_2017+ALCAFull_2017+HARVESTFull_2017/step2.root'),
+#     # fileNames = cms.untracked.vstring('file:../1321.0_SingleMuPt100_UP15+SingleMuPt100_UP15INPUT+DIGIUP15+RECOUP15+HARVESTUP15/step2.root'),
+#     secondaryFileNames = cms.untracked.vstring()
+# )
+
+process.options = cms.untracked.PSet(
+  # SkipEvent = cms.untracked.vstring('ProductNotFound')
+)
+
+# Insert this in path to see what products the event contains
+process.content = cms.EDAnalyzer("EventContentAnalyzer")
+
+# To enable debugging:
+# [scram b clean ;] scram b USER_CXXFLAGS="-DEDM_ML_DEBUG"
+
+# process.load("SimTracker.TrackerHitAssociation.test.messageLoggerDebug_cff")
+
+process.MessageLogger.cerr.FwkReport.reportEvery = 1
+
+# Number of events (-1 = all)
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
+
+process.p1 = cms.Path(
+    # process.content*
+    process.mix
+    # *process.DigiToRaw  # for remaking recHits
+    *process.RawToDigi
+    *process.L1Reco
+    *process.reconstruction
+    *process.validation_step
+    *process.dqmSaver
+    )
+
+# # customisation of the process.
+
+# # Automatic addition of the customisation function from SimGeneral.MixingModule.fullMixCustomize_cff
+# from SimGeneral.MixingModule.fullMixCustomize_cff import setCrossingFrameOn 
+
+# #call to customisation function setCrossingFrameOn imported from SimGeneral.MixingModule.fullMixCustomize_cff
+# process = setCrossingFrameOn(process)
+
+# # End of customisation functions
+


### PR DESCRIPTION
Changes to test directories only.  Add a cfg that produces a RelVal-format root file with RecHit validation histograms from strips, and from pixels whether phase0 or phase1.  Add also a root macro to compare histograms across pairs of root files.