### PR TITLE
PFDisplacedVertexFinder speedups

### DIFF
--- a/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexFinder.h
+++ b/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexFinder.h
@@ -140,10 +140,7 @@ class PFDisplacedVertexFinder {
 
   bool isCloseTo(const reco::PFDisplacedVertexSeed&, const reco::PFDisplacedVertexSeed&) const;
 
-  double getTransvDiff(const GlobalPoint&, const GlobalPoint&) const;
-  double getLongDiff(const GlobalPoint&, const GlobalPoint&) const;
   std::pair<float,float> getTransvLongDiff(const GlobalPoint&, const GlobalPoint&) const;
-  double getLongProj(const GlobalPoint&, const GlobalVector&) const;
 
   reco::PFDisplacedVertex::VertexTrackType getVertexTrackType(PFTrackHitFullInfo&) const;
 

--- a/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexFinder.h
+++ b/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexFinder.h
@@ -142,6 +142,7 @@ class PFDisplacedVertexFinder {
 
   double getTransvDiff(const GlobalPoint&, const GlobalPoint&) const;
   double getLongDiff(const GlobalPoint&, const GlobalPoint&) const;
+  std::pair<float,float> getTransvLongDiff(const GlobalPoint&, const GlobalPoint&) const;
   double getLongProj(const GlobalPoint&, const GlobalVector&) const;
 
   reco::PFDisplacedVertex::VertexTrackType getVertexTrackType(PFTrackHitFullInfo&) const;
@@ -160,8 +161,8 @@ class PFDisplacedVertexFinder {
 
   /// Algo parameters for the vertex finder
 
-  double transvSize_;
-  double longSize_;
+  float transvSize_;
+  float longSize_;
   double primaryVertexCut_;
   double tobCut_;
   double tecCut_;

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -167,10 +167,9 @@ PFDisplacedVertexFinder::findSeedsFromCandidate(const PFDisplacedVertexCandidate
 	break;
       }
       const GlobalPoint vertexPoint = (*idvc_current).seedPoint();
-      double Delta_Long = getLongDiff(vertexPoint, dcaPoint);
-      double Delta_Transv = getTransvDiff(vertexPoint, dcaPoint);
-      if (Delta_Long > longSize_) continue;
-      if (Delta_Transv > transvSize_) continue;
+      std::pair<float,float> diffs = getTransvLongDiff(vertexPoint,dcaPoint);
+      if (diffs.second > longSize_) continue;
+      if (diffs.first > transvSize_) continue;
       bNeedNewCandidate = false;
       break;
     }
@@ -694,10 +693,9 @@ PFDisplacedVertexFinder::isCloseTo(const PFDisplacedVertexSeed& dv1, const PFDis
   const GlobalPoint& vP1 = dv1.seedPoint();
   const GlobalPoint& vP2 = dv2.seedPoint();
 
-  double Delta_Long = getLongDiff(vP1, vP2);
-  if (Delta_Long > longSize_) return false;
-  double Delta_Transv = getTransvDiff(vP1, vP2);
-  if (Delta_Transv > transvSize_) return false;
+  std::pair<float,float> diffs = getTransvLongDiff(vP1,vP2);
+  if (diffs.second > longSize_) return false;
+  if (diffs.first > transvSize_) return false;
   //  if (Delta_Long < longSize_ && Delta_Transv < transvSize_) isCloseTo = true;
 
   return true;
@@ -731,6 +729,17 @@ PFDisplacedVertexFinder::getTransvDiff(const GlobalPoint& Ref, const GlobalPoint
   Basic3DVector<double>vRef(Ref);
   Basic3DVector<double>vToProject(ToProject);
   return fabs(vRef.cross(vToProject).mag()/vRef.mag());
+
+}
+
+std::pair<float,float>
+PFDisplacedVertexFinder::getTransvLongDiff(const GlobalPoint& Ref, const GlobalPoint& ToProject) const {
+
+  Basic3DVector<float>vRef(Ref);
+  Basic3DVector<float>vToProject(ToProject);
+  double oneOverMag = 1.0/vRef.mag();
+
+  return std::make_pair(fabs(vRef.cross(vToProject).mag()*oneOverMag),fabs((vRef.dot(vToProject)-vRef.mag2())*oneOverMag));
 
 }
 

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -737,7 +737,7 @@ PFDisplacedVertexFinder::getTransvLongDiff(const GlobalPoint& Ref, const GlobalP
 
   Basic3DVector<float>vRef(Ref);
   Basic3DVector<float>vToProject(ToProject);
-  float oneOverMag = 1.0/vRef.mag();
+  float oneOverMag = 1.0f/vRef.mag();
 
   return std::make_pair(fabs(vRef.cross(vToProject).mag()*oneOverMag),fabs((vRef.dot(vToProject)-vRef.mag2())*oneOverMag));
 

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -703,44 +703,15 @@ PFDisplacedVertexFinder::isCloseTo(const PFDisplacedVertexSeed& dv1, const PFDis
 }
 
 
-double  
-PFDisplacedVertexFinder::getLongDiff(const GlobalPoint& Ref, const GlobalPoint& ToProject) const {
-
-  Basic3DVector<double>vRef(Ref);
-  Basic3DVector<double>vToProject(ToProject);
-  return fabs((vRef.dot(vToProject)-vRef.mag2())/vRef.mag());
-
-}
-
-double  
-PFDisplacedVertexFinder::getLongProj(const GlobalPoint& Ref, const GlobalVector& ToProject) const {
-
-  Basic3DVector<double>vRef(Ref);
-  Basic3DVector<double>vToProject(ToProject);
-  return (vRef.dot(vToProject))/vRef.mag();
-
-
-}
-
-
-double  
-PFDisplacedVertexFinder::getTransvDiff(const GlobalPoint& Ref, const GlobalPoint& ToProject) const {
-
-  Basic3DVector<double>vRef(Ref);
-  Basic3DVector<double>vToProject(ToProject);
-  return fabs(vRef.cross(vToProject).mag()/vRef.mag());
-
-}
-
 std::pair<float,float>
 PFDisplacedVertexFinder::getTransvLongDiff(const GlobalPoint& Ref, const GlobalPoint& ToProject) const {
 
-  Basic3DVector<float>vRef(Ref);
-  Basic3DVector<float>vToProject(ToProject);
-  float oneOverMag = 1.0f/vRef.mag();
+  const auto & vRef = Ref.basicVector();
+  const auto & vToProject = ToProject.basicVector();
+  float vRefMag2 = vRef.mag2();
+  float oneOverMag = 1.0f/sqrt(vRefMag2);
 
-  return std::make_pair(fabs(vRef.cross(vToProject).mag()*oneOverMag),fabs((vRef.dot(vToProject)-vRef.mag2())*oneOverMag));
-
+  return std::make_pair(fabs(vRef.cross(vToProject).mag()*oneOverMag),fabs((vRef.dot(vToProject)-vRefMag2)*oneOverMag));
 }
 
 

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -737,7 +737,7 @@ PFDisplacedVertexFinder::getTransvLongDiff(const GlobalPoint& Ref, const GlobalP
 
   Basic3DVector<float>vRef(Ref);
   Basic3DVector<float>vToProject(ToProject);
-  double oneOverMag = 1.0/vRef.mag();
+  float oneOverMag = 1.0/vRef.mag();
 
   return std::make_pair(fabs(vRef.cross(vToProject).mag()*oneOverMag),fabs((vRef.dot(vToProject)-vRef.mag2())*oneOverMag));
 


### PR DESCRIPTION
merge two calculations and covert them to float (as the inputs are floats). Regression is possible, though I found the calculations agreed to 5 digits (changing by 1 in the 6th digit from time to time).