### PR TITLE
Fix flat vtx generator

### DIFF
--- a/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
@@ -50,7 +50,6 @@ private:
 private:
   double fMinX, fMinY, fMinZ, fMinT;
   double fMaxX, fMaxY, fMaxZ, fMaxT;
-  double fTimeOffset;
 };
 
 #endif

--- a/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
@@ -5,6 +5,12 @@
  * Generate event vertices according to a Flat distribution. 
  * Attention: All values are assumed to be cm!
  *
+ * Important note: flat independent distributions in Z and T are not correct for physics production
+ * In reality, if two flat beams interact the real distribution will not be flat with independent Z and T
+ * but Z and T will be correlated, as example in GaussEvtVtxGenerator.
+ * Can restore correlation in configuration via MinT += (MinZ - MaxZ)/2 and MaxT += (MaxZ - MinZ)/2
+ * in [ns] units (recall c_light = 29.98cm/ns)
+ *
  */
 
 #include "IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h"

--- a/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
@@ -48,8 +48,8 @@ private:
   /** Copy assignment operator */
   FlatEvtVtxGenerator&  operator = (const FlatEvtVtxGenerator & rhs ) = delete;
 private:
-  double fMinX, fMinY, fMinZ;
-  double fMaxX, fMaxY, fMaxZ;
+  double fMinX, fMinY, fMinZ, fMinT;
+  double fMaxX, fMaxY, fMaxZ, fMaxT;
   double fTimeOffset;
 };
 

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -35,6 +35,11 @@ GaussVtxSigmaZ4cmSmearingParameters = cms.PSet(
 )
 
 # Flat Smearing
+# Important note: flat independent distributions in Z and T are not correct for physics production
+# In reality, if two flat beams interact the real distribution will not be flat with independent Z and T
+# but Z and T will be correlated, as example in GaussEvtVtxGenerator.
+# Can restore correlation via MinT += (MinZ - MaxZ)/2 and MaxT += (MaxZ - MinZ)/2
+# in [ns] units (recall c_light = 29.98cm/ns)
 FlatVtxSmearingParameters = cms.PSet(
     MaxZ = cms.double(5.3),
     MaxX = cms.double(0.0015),
@@ -42,8 +47,8 @@ FlatVtxSmearingParameters = cms.PSet(
     MinX = cms.double(-0.0015),
     MinY = cms.double(-0.0015),
     MinZ = cms.double(-5.3),
-    MaxT = cms.double(0.0),
-    MinT = cms.double(0.0)
+    MaxT = cms.double(0.177),
+    MinT = cms.double(-0.177)
 )
 #############################################
 # Beta functions smearing (pp 7+7 TeV)

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -42,7 +42,9 @@ FlatVtxSmearingParameters = cms.PSet(
     MinX = cms.double(-0.0015),
     MinY = cms.double(-0.0015),
     MinZ = cms.double(-5.3),
-    TimeOffset = cms.double(0.0)
+    TimeOffset = cms.double(0.0),
+    MaxT = cms.double(0.0),
+    MinT = cms.double(0.0)
 )
 #############################################
 # Beta functions smearing (pp 7+7 TeV)

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -42,7 +42,6 @@ FlatVtxSmearingParameters = cms.PSet(
     MinX = cms.double(-0.0015),
     MinY = cms.double(-0.0015),
     MinZ = cms.double(-5.3),
-    TimeOffset = cms.double(0.0),
     MaxT = cms.double(0.0),
     MinT = cms.double(0.0)
 )

--- a/IOMC/EventVertexGenerators/src/FlatEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/FlatEvtVtxGenerator.cc
@@ -22,7 +22,6 @@ FlatEvtVtxGenerator::FlatEvtVtxGenerator(const edm::ParameterSet& p )
   fMaxZ = p.getParameter<double>("MaxZ")*cm;     
   fMinT = p.getParameter<double>("MinT")*ns*c_light;
   fMaxT = p.getParameter<double>("MaxT")*ns*c_light;
-  fTimeOffset = p.getParameter<double>("TimeOffset")*ns*c_light;
   
   if (fMinX > fMaxX) {
     throw cms::Exception("Configuration")
@@ -56,9 +55,9 @@ HepMC::FourVector FlatEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine)
   aX = CLHEP::RandFlat::shoot(engine, fMinX, fMaxX);
   aY = CLHEP::RandFlat::shoot(engine, fMinY, fMaxY);
   aZ = CLHEP::RandFlat::shoot(engine, fMinZ, fMaxZ);
-  aT = CLHEP::RandFlat::shoot(engine, fMinT-std::abs(fMaxZ-fMinZ), fMaxT+std::abs(fMaxZ-fMinZ));
+  aT = CLHEP::RandFlat::shoot(engine, fMinT, fMaxT);
 
-  return HepMC::FourVector(aX,aY,aZ,aT+fTimeOffset);
+  return HepMC::FourVector(aX,aY,aZ,aT);
 }
 
 void FlatEvtVtxGenerator::minX(double min) 

--- a/IOMC/EventVertexGenerators/src/FlatEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/FlatEvtVtxGenerator.cc
@@ -20,6 +20,8 @@ FlatEvtVtxGenerator::FlatEvtVtxGenerator(const edm::ParameterSet& p )
   fMaxX = p.getParameter<double>("MaxX")*cm;
   fMaxY = p.getParameter<double>("MaxY")*cm;
   fMaxZ = p.getParameter<double>("MaxZ")*cm;     
+  fMinT = p.getParameter<double>("MinT")*ns*c_light;
+  fMaxT = p.getParameter<double>("MaxT")*ns*c_light;
   fTimeOffset = p.getParameter<double>("TimeOffset")*ns*c_light;
   
   if (fMinX > fMaxX) {
@@ -37,6 +39,11 @@ FlatEvtVtxGenerator::FlatEvtVtxGenerator(const edm::ParameterSet& p )
       << "Error in FlatEvtVtxGenerator: "
       << "MinZ is greater than MaxZ";
   }
+  if (fMinT > fMaxT) {
+    throw cms::Exception("Configuration")
+      << "Error in FlatEvtVtxGenerator: "
+      << "MinT is greater than MaxT";
+  }
 }
 
 FlatEvtVtxGenerator::~FlatEvtVtxGenerator()
@@ -49,7 +56,7 @@ HepMC::FourVector FlatEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine)
   aX = CLHEP::RandFlat::shoot(engine, fMinX, fMaxX);
   aY = CLHEP::RandFlat::shoot(engine, fMinY, fMaxY);
   aZ = CLHEP::RandFlat::shoot(engine, fMinZ, fMaxZ);
-  aT = CLHEP::RandFlat::shoot(engine, fMinZ, fMaxZ);
+  aT = CLHEP::RandFlat::shoot(engine, fMinT-std::abs(fMaxZ-fMinZ), fMaxT+std::abs(fMaxZ-fMinZ));
 
   return HepMC::FourVector(aX,aY,aZ,aT+fTimeOffset);
 }


### PR DESCRIPTION
Fix the distribution of the time coordinate for FlatEvtVtxGenerator.
This PR makes the T value independent from the Z one, allowing the generation of events with displaced vertex in space and not in time, and also vice versa.