### PR TITLE
simple change to the merge configuration to allow the merging of NANOAOD

### DIFF
--- a/Configuration/DataProcessing/python/Merge.py
+++ b/Configuration/DataProcessing/python/Merge.py
@@ -38,7 +38,7 @@ def mergeProcess(*inputFiles, **options):
     outputLFN = options.get("output_lfn", None)
     dropDQM = options.get("drop_dqm", False)
     newDQMIO = options.get("newDQMIO", False)
-    
+    mergeNANO = options.get("mergeNANO", False)
     #  //
     # // build process
     #//
@@ -63,8 +63,11 @@ def mergeProcess(*inputFiles, **options):
     #//
     if newDQMIO:
         outMod = OutputModule("DQMRootOutputModule")
+    elif mergeNANO:
+        outMod = OutputModule("NanoAODOutputModule")
     else:
         outMod = OutputModule("PoolOutputModule")
+
     outMod.fileName = CfgTypes.untracked.string(outputFilename)
     if outputLFN != None:
         outMod.logicalFileName = CfgTypes.untracked.string(outputLFN)


### PR DESCRIPTION
The configuration for merging in central production is taken from DataProcessing and we need this change to allow for the nanoaod merging using NanoAODOutputModule.