### PR TITLE
Make the python __repr__ for VPSet (and other v) indenting consistent

### DIFF
--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -589,27 +589,25 @@ class _ValidatingParameterListBase(_ValidatingListBase,_ParameterTypeBase):
     def dumpPython(self, options=PrintOptions()):
         result = self.pythonTypeName()+"("
         n = len(self)
+        if hasattr(self, "_nPerLine"):
+            nPerLine = self._nPerLine
+        else:
+            nPerLine = 5
+        if n>nPerLine: options.indent()
         if n>=256:
             #wrap in a tuple since they don't have a size constraint
             result+=" ("
-        indented = False
         for i, v in enumerate(self):
             if i == 0:
-                if hasattr(self, "_nPerLine"):
-                    nPerLine = self._nPerLine
-                else:
-                    nPerLine = 5
+                if n>nPerLine: result += '\n'+options.indentation()
             else:
-                if not indented:
-                    indented = True
-                    options.indent()
                 result += ', '
                 if i % nPerLine == 0:
                     result += '\n'+options.indentation()
             result += self.pythonValueForItem(v,options)
-        if indented:
+        if n>nPerLine:
             options.unindent()
-        #result+=', '.join((self.pythonValueForItem(v,options) for v in iter(self)))
+            result += '\n'+options.indentation()
         if n>=256:
             result +=' ) '
         result += ')'


### PR DESCRIPTION
This pull request modifies the `dumpPython` method of the _ValidatingParameterListBase class to make the indentation consistent. Particularly in the case of a VPSet.

Before:

```python
cms.EDProducer("Dummy",
    vinputtag = cms.VInputTag(cms.InputTag("a"), cms.InputTag("b"), cms.InputTag("c"), cms.InputTag("d"), cms.InputTag("e"),
        cms.InputTag("f")),
    vint = cms.vint32(1, 2, 3, 4, 5,
        6, 7, 8, 9, 10,
        11, 12, 13, 14, 15),
    vintshort = cms.vint32(1),
    vpset = cms.VPSet(cms.PSet(
        a = cms.untracked.int32(1),
        b = cms.untracked.int32(2),
        c = cms.untracked.int32(3)
    ),
        cms.PSet(
            x = cms.untracked.int32(1),
            y = cms.untracked.int32(2),
            z = cms.untracked.int32(3)
        )),
    vstring = cms.vstring('a',
        'b',
        'c',
        'd',
        'e',
        'f',
        'g'),
    vstringshort = cms.vstring('a')
)
```

After:

```python
cms.EDProducer("Dummy",
    vinputtag = cms.VInputTag(
        cms.InputTag("a"), cms.InputTag("b"), cms.InputTag("c"), cms.InputTag("d"), cms.InputTag("e"),
        cms.InputTag("f")
    ),
    vint = cms.vint32(
        1, 2, 3, 4, 5,
        6, 7, 8, 9, 10,
        11, 12, 13, 14, 15
    ),
    vintshort = cms.vint32(1),
    vpset = cms.VPSet(
        cms.PSet(
            a = cms.untracked.int32(1),
            b = cms.untracked.int32(2),
            c = cms.untracked.int32(3)
        ),
        cms.PSet(
            x = cms.untracked.int32(1),
            y = cms.untracked.int32(2),
            z = cms.untracked.int32(3)
        )
    ),
    vstring = cms.vstring(
        'a',
        'b',
        'c',
        'd',
        'e',
        'f',
        'g'
    ),
    vstringshort = cms.vstring('a')
)
```