### PR TITLE
handle error returns from poll() in InitRootHandlers signal handler

### DIFF
--- a/FWCore/Services/plugins/CPU.cc
+++ b/FWCore/Services/plugins/CPU.cc
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <sys/time.h>
 #include <sys/resource.h>
-#include <stdio.h>
+#include <cstdio>
 #include <string>
 #include <fstream>
 #include <sstream>
@@ -30,7 +30,7 @@
 
 #ifdef __linux__
 #include <sched.h>
-#include <errno.h>
+#include <cerrno>
 #endif
 
 namespace edm {
@@ -39,11 +39,11 @@ namespace edm {
     class CPU : public CPUServiceBase {
     public:
       CPU(ParameterSet const&, ActivityRegistry&);
-      ~CPU();
+      ~CPU() override;
 
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
-      virtual bool cpuInfo(std::string &models, double &avgSpeed) override;
+      bool cpuInfo(std::string &models, double &avgSpeed) override;
 
     private:
       const bool reportCPUProperties_;

--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -343,7 +343,12 @@ namespace {
             int rc = poll(&poll_info, 1, ms_remaining);
             if (rc <= 0)
             {
-              rc = (rc == 0) ? -ETIMEDOUT : -errno;
+              if (rc < 0) {
+                if (errno == EINTR || errno == EAGAIN) { continue; }
+                rc = -errno;
+              } else {
+                rc = -ETIMEDOUT;
+              }
               if ((flags & O_NONBLOCK) != O_NONBLOCK)
               {
                 fcntl(fd, F_SETFL, flags);

--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -24,7 +24,7 @@
 #include <thread>
 #include <sys/wait.h>
 #include <sstream>
-#include <string.h>
+#include <cstring>
 #include <poll.h>
 #include <atomic>
 
@@ -73,7 +73,7 @@ namespace edm {
         ThreadTracker() : tbb::task_scheduler_observer() {
           observe(true);
         }
-        void on_scheduler_entry(bool) {
+        void on_scheduler_entry(bool) override {
           // ensure thread local has been allocated; not necessary on Linux with
           // the current cmsRun linkage, but could be an issue if the platform
           // or linkage leads to "lazy" allocation of the thread local.  By
@@ -89,7 +89,7 @@ namespace edm {
       };
 
       explicit InitRootHandlers(ParameterSet const& pset, ActivityRegistry& iReg);
-      virtual ~InitRootHandlers();
+      ~InitRootHandlers() override;
       
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
       static void stacktraceFromThread();
@@ -100,9 +100,9 @@ namespace edm {
       static std::atomic<std::size_t> nextModule_, doneModules_;
     private:
       static char *const *getPstackArgv();
-      virtual void enableWarnings_() override;
-      virtual void ignoreWarnings_() override;
-      virtual void willBeUsingThreads() override;
+      void enableWarnings_() override;
+      void ignoreWarnings_() override;
+      void willBeUsingThreads() override;
 
       void cachePidInfo();
       static void stacktraceHelperThread();
@@ -179,10 +179,10 @@ namespace {
   // Arrange to report the error location as furnished by Root
 
     std::string el_location = "@SUB=?";
-    if (location != 0) el_location = std::string("@SUB=")+std::string(location);
+    if (location != nullptr) el_location = std::string("@SUB=")+std::string(location);
 
     std::string el_message  = "?";
-    if (message != 0) el_message  = message;
+    if (message != nullptr) el_message  = message;
 
   // Try to create a meaningful id string using knowledge of ROOT error messages
   //
@@ -412,7 +412,7 @@ namespace {
       sigset_t sigset;
       sigemptyset(&sigset);
       sigaddset(&sigset, RESUME_SIGNAL);
-      pthread_sigmask(SIG_UNBLOCK, &sigset, 0);
+      pthread_sigmask(SIG_UNBLOCK, &sigset, nullptr);
 #endif
       // sleep interrrupts on a handled delivery of the resume signal
       sleep(InitRootHandlers::stackTracePause());
@@ -448,13 +448,13 @@ namespace {
         act.sa_sigaction = sig_pause_for_stacktrace;
         act.sa_flags = 0;
         sigemptyset(&act.sa_mask);
-        sigaction(PAUSE_SIGNAL, &act, NULL);
+        sigaction(PAUSE_SIGNAL, &act, nullptr);
 
         // unblock pause signal globally, resume is unblocked in the pause handler
         sigset_t pausesigset;
         sigemptyset(&pausesigset);
         sigaddset(&pausesigset, PAUSE_SIGNAL);
-        sigprocmask(SIG_UNBLOCK, &pausesigset, 0);
+        sigprocmask(SIG_UNBLOCK, &pausesigset, nullptr);
 
         // send a pause signal to all CMSSW/TBB threads other than self
         for (auto id : tids) {
@@ -466,7 +466,7 @@ namespace {
 #ifdef RESUME_SIGNAL
         // install the "resume" handler
         act.sa_sigaction = sig_resume_handler;
-        sigaction(RESUME_SIGNAL, &act, NULL);
+        sigaction(RESUME_SIGNAL, &act, nullptr);
 #endif
       }
 #endif

--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -340,13 +340,15 @@ namespace {
           int ms_remaining = std::chrono::duration_cast<std::chrono::milliseconds>(end_time-std::chrono::steady_clock::now()).count();
           if (ms_remaining > 0)
           {
-            if (poll(&poll_info, 1, ms_remaining) == 0)
+            int rc = poll(&poll_info, 1, ms_remaining);
+            if (rc <= 0)
             {
+              rc = (rc == 0) ? -ETIMEDOUT : -errno;
               if ((flags & O_NONBLOCK) != O_NONBLOCK)
               {
                 fcntl(fd, F_SETFL, flags);
               }
-              return -ETIMEDOUT;
+              return rc;
             }
           }
           else if (ms_remaining < 0)

--- a/FWCore/Services/plugins/LoadAllDictionaries.cc
+++ b/FWCore/Services/plugins/LoadAllDictionaries.cc
@@ -44,9 +44,9 @@ namespace edm {
       // ---------- member functions ---------------------------
       
     private:
-      LoadAllDictionaries(const LoadAllDictionaries&); // stop default
+      LoadAllDictionaries(const LoadAllDictionaries&) = delete; // stop default
       
-      const LoadAllDictionaries& operator=(const LoadAllDictionaries&); // stop default
+      const LoadAllDictionaries& operator=(const LoadAllDictionaries&) = delete; // stop default
       
       // ---------- member data --------------------------------
       

--- a/FWCore/Services/plugins/PrintLoadingPlugins.cc
+++ b/FWCore/Services/plugins/PrintLoadingPlugins.cc
@@ -49,9 +49,9 @@ public:
   
 private:
   
-  PrintLoadingPlugins(const PrintLoadingPlugins&); // stop default
+  PrintLoadingPlugins(const PrintLoadingPlugins&) = delete; // stop default
   
-  const PrintLoadingPlugins& operator=(const PrintLoadingPlugins&); // stop default
+  const PrintLoadingPlugins& operator=(const PrintLoadingPlugins&) = delete; // stop default
   
   // ---------- member data --------------------------------
   

--- a/FWCore/Services/plugins/SimpleMemoryCheck.cc
+++ b/FWCore/Services/plugins/SimpleMemoryCheck.cc
@@ -432,7 +432,7 @@ namespace edm {
 
     SimpleMemoryCheck::~SimpleMemoryCheck() {
 #ifdef LINUX
-      if(0 != smapsFile_) {
+      if(nullptr != smapsFile_) {
         fclose(smapsFile_);
       }
 #endif
@@ -463,7 +463,7 @@ namespace edm {
       if (monitorPssAndPrivate_) {
         std::ostringstream smapsNameOst;
         smapsNameOst <<"/proc/"<<getpid()<<"/smaps";
-        if((smapsFile_ =fopen(smapsNameOst.str().c_str(), "r"))==0) {
+        if((smapsFile_ =fopen(smapsNameOst.str().c_str(), "r"))==nullptr) {
           throw Exception(errors::Configuration) <<"Failed to open smaps file "<<smapsNameOst.str()<<std::endl;
         }
       }

--- a/FWCore/Services/src/SiteLocalConfigService.cc
+++ b/FWCore/Services/src/SiteLocalConfigService.cc
@@ -478,7 +478,7 @@ namespace edm {
 		if (statsDestList->getLength() > 0) {
 		  DOMElement *statsDest = static_cast<DOMElement *>(statsDestList->item(0));
 		  m_statisticsDestination = toString(statsDest->getAttribute(uStr("endpoint").ptr()));
-		  if (!m_statisticsDestination.size()) {
+		  if (m_statisticsDestination.empty()) {
 		    m_statisticsDestination = toString(statsDest->getAttribute(uStr("name").ptr()));
 		  }
 		  std::string tmpStatisticsInfo = toString(statsDest->getAttribute(uStr("info").ptr()));

--- a/FWCore/Services/src/SiteLocalConfigService.h
+++ b/FWCore/Services/src/SiteLocalConfigService.h
@@ -46,7 +46,7 @@ namespace edm {
 
             // implicit copy constructor
             // implicit assignment operator
-            ~SiteLocalConfigService();
+            ~SiteLocalConfigService() override;
 
             static void fillDescriptions(ConfigurationDescriptions& descriptions);
 

--- a/FWCore/Services/test/SiteLocalConfigServiceTester.cc
+++ b/FWCore/Services/test/SiteLocalConfigServiceTester.cc
@@ -24,7 +24,7 @@ namespace edmtest {
    public:
       SiteLocalConfigServiceTester(const edm::ParameterSet& iPSet);
       
-      void analyze(const edm::Event&, const edm::EventSetup&);
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
       
    private:
       std::string m_cacheHint;
@@ -96,7 +96,7 @@ void throwWrongValue(const char* iName, const T& iExpected, const T& iRetrieved)
 namespace {
    template <typename T>
    void testValue(const char* iName, const T& iExpected, const T* iRetrieved) {
-      if(0==iRetrieved) {
+      if(nullptr==iRetrieved) {
          throwNotSet(iName);
       } else if (*iRetrieved != iExpected) {
          throwWrongValue(iName, iExpected, *iRetrieved);
@@ -105,13 +105,13 @@ namespace {
 
    template <typename T>
    void checkNotSet(const char* iName, const T* iRetrieved) {
-      if(0!=iRetrieved) {
+      if(nullptr!=iRetrieved) {
          throw cms::Exception("TestFailure")<<"The value "<<iName<<" should not have been set but was set to "<<*iRetrieved;
       }
    }
 
    void checkNotSet(const char* iName, const std::vector<std::string>* iRetrieved) {
-      if(0!=iRetrieved) {
+      if(nullptr!=iRetrieved) {
          throw cms::Exception("TestFailure")<<"The value "<<iName<<" should not have been set but was set";
       }
    }
@@ -129,7 +129,7 @@ void SiteLocalConfigServiceTester::analyze(const edm::Event&, const edm::EventSe
       testValue("sourceReadHint",m_readHint,pConfig->sourceReadHint());
       testValue("sourceTTreeCacheSize",m_ttreeCacheSize,pConfig->sourceTTreeCacheSize());
       const std::vector<std::string>* protocols = pConfig->sourceNativeProtocols();
-      if(0==protocols) {
+      if(nullptr==protocols) {
          throwNotSet("sourceNativeProtocols");
       }
       if (protocols->size() != m_nativeProtocols.size()) {


### PR DESCRIPTION
In full_read(), if the call to poll() returned an error the read() on the fd would still be attempted.  Since the error return provides no guarantee that the read() would succeed, this could lead to the signal handler blocking on the read() indefinitely.  This patch treats any error return similar to a timeout, returning without attempting the read.

ref:
https://hypernews.cern.ch/HyperNews/CMS/get/edmFramework/3798/1/1/2.html
