### PR TITLE
[94X]  Few fixes and additions to SiStrip PI plugins  (backport of #20946)

### DIFF
--- a/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
+++ b/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
@@ -259,8 +259,6 @@ namespace SiStripPI {
     }
   }
 
-
-  
   // code is mutuated from CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics
 
   /*--------------------------------------------------------------------*/
@@ -269,15 +267,13 @@ namespace SiStripPI {
   {
    
     if (BC.BadApvs){
-      NBadComponent[i][0][2]+= ( (BC.BadApvs>>5)&0x1 )+ ( (BC.BadApvs>>4)&0x1 ) + ( (BC.BadApvs>>3)&0x1 ) + 
-	( (BC.BadApvs>>2)&0x1 )+ ( (BC.BadApvs>>1)&0x1 ) + ( (BC.BadApvs)&0x1 );
-      NBadComponent[i][component][2]+= ( (BC.BadApvs>>5)&0x1 )+ ( (BC.BadApvs>>4)&0x1 ) + ( (BC.BadApvs>>3)&0x1 ) + 
-	( (BC.BadApvs>>2)&0x1 )+ ( (BC.BadApvs>>1)&0x1 ) + ( (BC.BadApvs)&0x1 );
+      NBadComponent[i][0][2]+= std::bitset<16>(BC.BadApvs&0x3f).count(); 
+      NBadComponent[i][component][2]+= std::bitset<16>(BC.BadApvs&0x3f).count(); 
     }
 
     if (BC.BadFibers){ 
-      NBadComponent[i][0][1]+= ( (BC.BadFibers>>2)&0x1 )+ ( (BC.BadFibers>>1)&0x1 ) + ( (BC.BadFibers)&0x1 );
-      NBadComponent[i][component][1]+= ( (BC.BadFibers>>2)&0x1 )+ ( (BC.BadFibers>>1)&0x1 ) + ( (BC.BadFibers)&0x1 );
+      NBadComponent[i][0][1]+= std::bitset<4>(BC.BadFibers&0x7).count();
+      NBadComponent[i][component][1]+= std::bitset<4>(BC.BadFibers&0x7).count();
     }   
 
     if (BC.BadModule){

--- a/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
+++ b/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
@@ -6,6 +6,7 @@
 #include <string>
 #include "TH1.h"
 #include "TPaveText.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"   
 #include "CondFormats/SiStripObjects/interface/SiStripSummary.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h" 
 
@@ -257,6 +258,34 @@ namespace SiStripPI {
       
     }
   }
+
+
+  
+  // code is mutuated from CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics
+
+  /*--------------------------------------------------------------------*/
+  void setBadComponents(int i, int component, SiStripQuality::BadComponent& BC,int NBadComponent[4][19][4])
+  /*--------------------------------------------------------------------*/
+  {
+   
+    if (BC.BadApvs){
+      NBadComponent[i][0][2]+= ( (BC.BadApvs>>5)&0x1 )+ ( (BC.BadApvs>>4)&0x1 ) + ( (BC.BadApvs>>3)&0x1 ) + 
+	( (BC.BadApvs>>2)&0x1 )+ ( (BC.BadApvs>>1)&0x1 ) + ( (BC.BadApvs)&0x1 );
+      NBadComponent[i][component][2]+= ( (BC.BadApvs>>5)&0x1 )+ ( (BC.BadApvs>>4)&0x1 ) + ( (BC.BadApvs>>3)&0x1 ) + 
+	( (BC.BadApvs>>2)&0x1 )+ ( (BC.BadApvs>>1)&0x1 ) + ( (BC.BadApvs)&0x1 );
+    }
+
+    if (BC.BadFibers){ 
+      NBadComponent[i][0][1]+= ( (BC.BadFibers>>2)&0x1 )+ ( (BC.BadFibers>>1)&0x1 ) + ( (BC.BadFibers)&0x1 );
+      NBadComponent[i][component][1]+= ( (BC.BadFibers>>2)&0x1 )+ ( (BC.BadFibers>>1)&0x1 ) + ( (BC.BadFibers)&0x1 );
+    }   
+
+    if (BC.BadModule){
+      NBadComponent[i][0][0]++;
+      NBadComponent[i][component][0]++;
+    }
+  }
+
 };
 
 #endif

--- a/CondCore/SiStripPlugins/plugins/SiStripBackPlaneCorrection_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBackPlaneCorrection_PayloadInspector.cc
@@ -34,6 +34,35 @@
 namespace {
 
   /************************************************
+    1d histogram of SiStripBackPlaneCorrection of 1 IOV 
+  *************************************************/
+
+  // inherit from one of the predefined plot class: Histogram1D
+  class SiStripBackPlaneCorrectionValue : public cond::payloadInspector::Histogram1D<SiStripBackPlaneCorrection> {
+    
+  public:
+    SiStripBackPlaneCorrectionValue() : cond::payloadInspector::Histogram1D<SiStripBackPlaneCorrection>("SiStrip BackPlaneCorrection values",
+													"SiStrip BackPlaneCorrection values", 100,0.0,0.1){
+      Base::setSingleIov( true );
+    }
+    
+    bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override{
+      for ( auto const & iov: iovs) {
+	std::shared_ptr<SiStripBackPlaneCorrection> payload = Base::fetchPayload( std::get<1>(iov) );
+	if( payload.get() ){
+	  
+	  std::map<uint32_t,float> BPMap_ = payload->getBackPlaneCorrections();
+      
+	  for(const auto &element : BPMap_){
+	    fillWithValue(element.second);
+	  }
+	}// payload
+      }// iovs
+      return true;
+    }// fill
+  };
+
+  /************************************************
     TrackerMap of SiStrip BackPlane Correction
   *************************************************/
   class SiStripBackPlaneCorrection_TrackerMap : public cond::payloadInspector::PlotImage<SiStripBackPlaneCorrection> {
@@ -139,6 +168,7 @@ namespace {
 	}
       }
 
+      h1->GetYaxis()->SetRangeUser(0.,h1->GetMaximum()*1.30);
       h1->SetMarkerStyle(20);
       h1->SetMarkerSize(1);
       h1->Draw("HIST");
@@ -175,6 +205,7 @@ namespace {
 }
 
 PAYLOAD_INSPECTOR_MODULE( SiStripBackPlaneCorrection ){
+  PAYLOAD_INSPECTOR_CLASS( SiStripBackPlaneCorrectionValue );
   PAYLOAD_INSPECTOR_CLASS( SiStripBackPlaneCorrection_TrackerMap );
   PAYLOAD_INSPECTOR_CLASS( SiStripBackPlaneCorrectionByPartition );
 }

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -839,21 +839,12 @@ namespace {
       // store global info
 
       //k: 0=BadModule, 1=BadFiber, 2=BadApv, 3=BadStrips
-      int NTkBadComponent[4];
+      int NTkBadComponent[4] = {0};
 
       //legend: NBadComponent[i][j][k]= SubSystem i, layer/disk/wheel j, BadModule/Fiber/Apv k
       //     i: 0=TIB, 1=TID, 2=TOB, 3=TEC
       //     k: 0=BadModule, 1=BadFiber, 2=BadApv, 3=BadStrips
-      int NBadComponent[4][19][4];  
-
-      // initialize
-      for(int i=0;i<4;++i){
-	NTkBadComponent[i]=0;
-	for(int j=0;j<19;++j){
-	  for(int k=0;k<4;++k)
-	    NBadComponent[i][j][k]=0;
-	}
-      }
+      int NBadComponent[4][19][4] = {{{0}}};  
     
       std::vector<SiStripQuality::BadComponent> BC = siStripQuality_->getBadComponentList();
   
@@ -995,7 +986,7 @@ namespace {
       edm::LogInfo("SiStripBadStrip_PayloadInspector") << ss.str() << std::endl;
       //std::cout<<  ss.str() << std::endl;
 
-      TH2I *masterTable = new TH2I("table","",4,0.,4.,39,0.,39.);
+      auto masterTable = std::unique_ptr<TH2I>(new TH2I("table","",4,0.,4.,39,0.,39.));
       
       std::string labelsX[4]={"Bad Modules","Bad Fibers","Bad APVs","Bad Strips"};
       std::string labelsY[40]={"Tracker","TIB","TID","TOB","TEC","TIB Layer 1","TIB Layer 2","TIB Layer 3","TIB Layer 4","TID+ Disk 1","TID+ Disk 2","TID+ Disk 3","TID- Disk 1","TID- Disk 2","TID- Disk 3","TOB Layer 1","TOB Layer 2","TOB Layer 3","TOB Layer 4","TOB Layer 5","TOB Layer 6","TEC+ Disk 1","TEC+ Disk 2","TEC+ Disk 3","TEC+ Disk 4","TEC+ Disk 5","TEC+ Disk 6","TEC+ Disk 7","TEC+ Disk 8","TEC+ Disk 9","TEC- Disk 1","TEC- Disk 2","TEC- Disk 3","TEC- Disk 4","TEC- Disk 5","TEC- Disk 6","TEC- Disk 7","TEC- Disk 8","TEC- Disk 9"};
@@ -1018,16 +1009,16 @@ namespace {
       int layerIndex=0;
       for(int iY=39;iY>=1;iY--){
        	for(int iX=0;iX<=3;iX++){
-       	  if(iY==39){ 
-       	    masterTable->SetBinContent(iX+1,iY,NTkBadComponent[iX]);
-      	  } else if (iY>=35){
+       	  if(iY==39){
+	    masterTable->SetBinContent(iX+1,iY,NTkBadComponent[iX]);
+	  } else if (iY>=35){
 	    masterTable->SetBinContent(iX+1,iY,NBadComponent[(39-iY)-1][0][iX]);
-	  } else {      
+	  } else {
 	    if(iX==0) layerIndex++;
 	    //std::cout<<"iY:"<<iY << " cursor: "  <<cursor << " layerIndex: " << layerIndex << " layer check: "<< layerBoundaries[cursor] <<std::endl;
 	    masterTable->SetBinContent(iX+1,iY,NBadComponent[cursor][layerIndex][iX]);
 	  }
-       	}
+	}
 	if(layerIndex==layerBoundaries[cursor]){
 	  // bring on the subdet counter and reset the layer count
 	  cursor++;
@@ -1035,7 +1026,7 @@ namespace {
 	  boundaries.push_back(iY);
 	}
       }
-
+      
       TCanvas canv("canv","canv",800,800);
       canv.cd();
 

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -992,8 +992,8 @@ namespace {
 	ss << "\nTEC- Disk " << i-9 << " :\t\t"<<NBadComponent[3][i][0]<<"\t"<<NBadComponent[3][i][1]<<"\t"<<NBadComponent[3][i][2]<<"\t"<<NBadComponent[3][i][3];
       ss<< "\n";
 
-      //edm::LogInfo("SiStripBadStrip_PayloadInspector") << ss.str() << std::endl;
-      std::cout<<  ss.str() << std::endl;
+      edm::LogInfo("SiStripBadStrip_PayloadInspector") << ss.str() << std::endl;
+      //std::cout<<  ss.str() << std::endl;
 
       TH2I *masterTable = new TH2I("table","",4,0.,4.,39,0.,39.);
       

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -1063,6 +1063,11 @@ namespace {
 	i++;
       }
 
+      canv.cd();
+      TLatex title;
+      title.SetTextSize(0.027);
+      title.SetTextColor(kBlue);
+      title.DrawLatexNDC(0.12,0.97,("IOV: "+std::to_string(std::get<0>(iov))+"| "+std::get<1>(iov)).c_str()); 
       std::string fileName(m_imageFileName);
       canv.SaveAs(fileName.c_str());
 

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -6,6 +6,8 @@
   \date $Date: 2017/08/14 14:37:22 $
 */
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 #include "CondCore/Utilities/interface/PayloadInspectorModule.h"
 #include "CondCore/Utilities/interface/PayloadInspector.h"
 #include "CondCore/CondDB/interface/Time.h"
@@ -16,6 +18,8 @@
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h" 
 #include "CondFormats/SiStripObjects/interface/SiStripDetSummary.h"
 
+#include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"   
+
 // needed for the tracker map
 #include "CommonTools/TrackerMap/interface/TrackerMap.h"
 
@@ -25,6 +29,7 @@
 
 #include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
+
 
 #include <memory>
 #include <sstream>
@@ -642,20 +647,29 @@ namespace {
       h_LastBadStrips->SetMarkerStyle(21);
       h_LastBadStrips->SetMarkerSize(1);
       h_LastBadStrips->SetLineColor(kBlue);
+      h_LastBadStrips->SetFillColor(kBlue);
       h_LastBadStrips->SetLineStyle(9);
       h_LastBadStrips->SetMarkerColor(kBlue);
       h_LastBadStrips->GetYaxis()->SetRangeUser(0.,h_LastBadStrips->GetMaximum()*1.30);
       h_LastBadStrips->GetYaxis()->SetTitleOffset(1.7);
-      h_LastBadStrips->Draw("HISTsame");
+
+      h_LastBadStrips->SetBarWidth(0.45);
+      h_LastBadStrips->SetBarOffset(0.1);
+      h_LastBadStrips->Draw("bar2");
       h_LastBadStrips->Draw("TEXTsame");
 
       h_FirstBadStrips->SetMarkerStyle(20);
       h_FirstBadStrips->SetMarkerSize(1);
+      h_FirstBadStrips->SetFillColor(kRed);
       h_FirstBadStrips->SetLineColor(kRed);
       h_FirstBadStrips->SetLineStyle(1);
       h_FirstBadStrips->SetMarkerColor(kRed);
       h_FirstBadStrips->GetYaxis()->SetTitleOffset(1.7);
-      h_FirstBadStrips->Draw("HISTsame");
+
+      h_FirstBadStrips->SetBarWidth(0.4);
+      h_FirstBadStrips->SetBarOffset(0.55);
+
+      h_FirstBadStrips->Draw("bar2same");
       h_FirstBadStrips->Draw("TEXT45same");
       
       canvas.Update();
@@ -799,6 +813,236 @@ namespace {
     }
   };
 
+  /************************************************
+    Plot BadStrip Quality analysis 
+  *************************************************/
+
+  class SiStripBadStripQualityAnalysis : public cond::payloadInspector::PlotImage<SiStripBadStrip> {
+  public:
+    SiStripBadStripQualityAnalysis() : cond::payloadInspector::PlotImage<SiStripBadStrip>( "SiStrip BadStrip Quality Analysis" ),
+      m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXML(edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())}
+    {
+      setSingleIov( true );
+    }
+
+    bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override{
+      auto iov = iovs.front();
+      std::shared_ptr<SiStripBadStrip> payload = fetchPayload( std::get<1>(iov) );
+
+      SiStripQuality* siStripQuality_ = new SiStripQuality();
+      siStripQuality_->add(payload.get());
+      siStripQuality_->cleanUp();
+      siStripQuality_->fillBadComponents();
+
+      // store global info
+
+      //k: 0=BadModule, 1=BadFiber, 2=BadApv, 3=BadStrips
+      int NTkBadComponent[4];
+
+      //legend: NBadComponent[i][j][k]= SubSystem i, layer/disk/wheel j, BadModule/Fiber/Apv k
+      //     i: 0=TIB, 1=TID, 2=TOB, 3=TEC
+      //     k: 0=BadModule, 1=BadFiber, 2=BadApv, 3=BadStrips
+      int NBadComponent[4][19][4];  
+
+      // initialize
+      for(int i=0;i<4;++i){
+	NTkBadComponent[i]=0;
+	for(int j=0;j<19;++j){
+	  for(int k=0;k<4;++k)
+	    NBadComponent[i][j][k]=0;
+	}
+      }
+    
+      std::vector<SiStripQuality::BadComponent> BC = siStripQuality_->getBadComponentList();
+  
+      for (size_t i=0;i<BC.size();++i){
+	
+	//&&&&&&&&&&&&&
+	//Full Tk
+	//&&&&&&&&&&&&&
+	
+	if (BC[i].BadModule) 
+	  NTkBadComponent[0]++;
+	if (BC[i].BadFibers) 
+	  NTkBadComponent[1]+= ( (BC[i].BadFibers>>2)&0x1 )+ ( (BC[i].BadFibers>>1)&0x1 ) + ( (BC[i].BadFibers)&0x1 );
+	if (BC[i].BadApvs)
+	  NTkBadComponent[2]+= ( (BC[i].BadApvs>>5)&0x1 )+ ( (BC[i].BadApvs>>4)&0x1 ) + ( (BC[i].BadApvs>>3)&0x1 ) + 
+	    ( (BC[i].BadApvs>>2)&0x1 )+ ( (BC[i].BadApvs>>1)&0x1 ) + ( (BC[i].BadApvs)&0x1 );
+	
+	//&&&&&&&&&&&&&&&&&
+	//Single SubSyste
+	//&&&&&&&&&&&&&&&&&
+	int component;
+	DetId detectorId=DetId(BC[i].detid);
+	int subDet = detectorId.subdetId();
+	if ( subDet == StripSubdetector::TIB ){
+	  //&&&&&&&&&&&&&&&&&
+	  //TIB
+	  //&&&&&&&&&&&&&&&&&
+	  
+	  component=m_trackerTopo.tibLayer(BC[i].detid);
+	  SiStripPI::setBadComponents(0, component, BC[i],NBadComponent);         
+
+	} else if ( subDet == StripSubdetector::TID ) {
+	  //&&&&&&&&&&&&&&&&&
+	  //TID
+	  //&&&&&&&&&&&&&&&&&
+	  
+	  component=m_trackerTopo.tidSide(BC[i].detid)==2?m_trackerTopo.tidWheel(BC[i].detid):m_trackerTopo.tidWheel(BC[i].detid)+3;
+	  SiStripPI::setBadComponents(1, component, BC[i],NBadComponent);         
+	  
+	} else if ( subDet == StripSubdetector::TOB ) {
+	  //&&&&&&&&&&&&&&&&&
+	  //TOB
+	  //&&&&&&&&&&&&&&&&&
+	  
+	  component=m_trackerTopo.tobLayer(BC[i].detid);
+	  SiStripPI::setBadComponents(2, component, BC[i],NBadComponent);         
+
+	} else if ( subDet == StripSubdetector::TEC ) {
+	  //&&&&&&&&&&&&&&&&&
+	  //TEC
+	  //&&&&&&&&&&&&&&&&&
+	  
+	  component=m_trackerTopo.tecSide(BC[i].detid)==2?m_trackerTopo.tecWheel(BC[i].detid):m_trackerTopo.tecWheel(BC[i].detid)+9;
+	  SiStripPI::setBadComponents(3, component, BC[i],NBadComponent);         
+	}    
+      }
+
+      //&&&&&&&&&&&&&&&&&&
+      // Single Strip Info
+      //&&&&&&&&&&&&&&&&&&
+
+      edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
+      SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());
+
+      float percentage=0;
+      
+      SiStripQuality::RegistryIterator rbegin = siStripQuality_->getRegistryVectorBegin();
+      SiStripQuality::RegistryIterator rend   = siStripQuality_->getRegistryVectorEnd();
+  
+      for (SiStripBadStrip::RegistryIterator rp=rbegin; rp != rend; ++rp) {
+	uint32_t detid=rp->detid;
+	
+	int subdet=-999; int component=-999;
+	DetId detectorId=DetId(detid);
+	int subDet = detectorId.subdetId();
+	if ( subDet == StripSubdetector::TIB ){
+	  subdet=0;
+	  component=m_trackerTopo.tibLayer(detid);
+	} else if ( subDet == StripSubdetector::TID ) {
+	  subdet=1;
+	  component=m_trackerTopo.tidSide(detid)==2?m_trackerTopo.tidWheel(detid):m_trackerTopo.tidWheel(detid)+3;
+	} else if ( subDet == StripSubdetector::TOB ) {
+	  subdet=2;
+	  component=m_trackerTopo.tobLayer(detid);
+	} else if ( subDet == StripSubdetector::TEC ) {
+	  subdet=3;
+	  component=m_trackerTopo.tecSide(detid)==2?m_trackerTopo.tecWheel(detid):m_trackerTopo.tecWheel(detid)+9;
+	} 
+
+	SiStripQuality::Range sqrange = SiStripQuality::Range( siStripQuality_->getDataVectorBegin()+rp->ibegin , siStripQuality_->getDataVectorBegin()+rp->iend );
+        
+	percentage=0;
+	for(int it=0;it<sqrange.second-sqrange.first;it++){
+	  unsigned int range=siStripQuality_->decode( *(sqrange.first+it) ).range;
+	  NTkBadComponent[3]+=range;
+	  NBadComponent[subdet][0][3]+=range;
+	  NBadComponent[subdet][component][3]+=range;
+	  percentage+=range;
+	}
+	if(percentage!=0)
+	  percentage/=128.*reader->getNumberOfApvsAndStripLength(detid).first;
+	if(percentage>1)
+	  edm::LogError("SiStripBadStrip_PayloadInspector") << "PROBLEM detid " << detid << " value " << percentage<< std::endl;
+      }
+       
+      //&&&&&&&&&&&&&&&&&&
+      // printout
+      //&&&&&&&&&&&&&&&&&&
+      
+      std::stringstream ss;
+      ss.str("");
+      ss << "\n-----------------\nGlobal Info\n-----------------";
+      ss << "\nBadComponent \t   Modules \tFibers \tApvs\tStrips\n----------------------------------------------------------------";
+      ss << "\nTracker:\t\t"<<NTkBadComponent[0]<<"\t"<<NTkBadComponent[1]<<"\t"<<NTkBadComponent[2]<<"\t"<<NTkBadComponent[3];
+      ss<< "\n";
+      ss << "\nTIB:\t\t\t"<<NBadComponent[0][0][0]<<"\t"<<NBadComponent[0][0][1]<<"\t"<<NBadComponent[0][0][2]<<"\t"<<NBadComponent[0][0][3];
+      ss << "\nTID:\t\t\t"<<NBadComponent[1][0][0]<<"\t"<<NBadComponent[1][0][1]<<"\t"<<NBadComponent[1][0][2]<<"\t"<<NBadComponent[1][0][3];
+      ss << "\nTOB:\t\t\t"<<NBadComponent[2][0][0]<<"\t"<<NBadComponent[2][0][1]<<"\t"<<NBadComponent[2][0][2]<<"\t"<<NBadComponent[2][0][3];
+      ss << "\nTEC:\t\t\t"<<NBadComponent[3][0][0]<<"\t"<<NBadComponent[3][0][1]<<"\t"<<NBadComponent[3][0][2]<<"\t"<<NBadComponent[3][0][3];
+      ss << "\n";
+      
+      for (int i=1;i<5;++i)
+	ss << "\nTIB Layer " << i   << " :\t\t"<<NBadComponent[0][i][0]<<"\t"<<NBadComponent[0][i][1]<<"\t"<<NBadComponent[0][i][2]<<"\t"<<NBadComponent[0][i][3];
+      ss << "\n";
+      for (int i=1;i<4;++i)
+	ss << "\nTID+ Disk " << i   << " :\t\t"<<NBadComponent[1][i][0]<<"\t"<<NBadComponent[1][i][1]<<"\t"<<NBadComponent[1][i][2]<<"\t"<<NBadComponent[1][i][3];
+      for (int i=4;i<7;++i)
+	ss << "\nTID- Disk " << i-3 << " :\t\t"<<NBadComponent[1][i][0]<<"\t"<<NBadComponent[1][i][1]<<"\t"<<NBadComponent[1][i][2]<<"\t"<<NBadComponent[1][i][3];
+      ss << "\n";
+      for (int i=1;i<7;++i)
+	ss << "\nTOB Layer " << i   << " :\t\t"<<NBadComponent[2][i][0]<<"\t"<<NBadComponent[2][i][1]<<"\t"<<NBadComponent[2][i][2]<<"\t"<<NBadComponent[2][i][3];
+      ss << "\n";
+      for (int i=1;i<10;++i)
+	ss << "\nTEC+ Disk " << i   << " :\t\t"<<NBadComponent[3][i][0]<<"\t"<<NBadComponent[3][i][1]<<"\t"<<NBadComponent[3][i][2]<<"\t"<<NBadComponent[3][i][3];
+      for (int i=10;i<19;++i)
+	ss << "\nTEC- Disk " << i-9 << " :\t\t"<<NBadComponent[3][i][0]<<"\t"<<NBadComponent[3][i][1]<<"\t"<<NBadComponent[3][i][2]<<"\t"<<NBadComponent[3][i][3];
+      ss<< "\n";
+
+      //edm::LogInfo("SiStripQualityStatistics") << ss.str() << std::endl;
+      std::cout<<  ss.str() << std::endl;
+
+      TH2I *masterTable = new TH2I("table","",4,0.,4.,39,0.,39.);
+      
+      std::string labelsX[4]={"Modules","Fibers","APVs","Strips"};
+      std::string labelsY[40]={"Tracker","TIB","TID","TOB","TEC","TIB Layer 1","TIB Layer 2","TIB Layer 3","TIB Layer 4","TID+ Disk 1","TID+ Disk 2","TID+ Disk 3","TID- Disk 1","TID- Disk 2","TID- Disk 3","TOB Layer 1","TOB Layer 2","TOB Layer 3","TOB Layer 4","TOB Layer 5","TOB Layer 6","TEC+ Disk 1","TEC+ Disk 2","TEC+ Disk 3","TEC+ Disk 4","TEC+ Disk 5","TEC+ Disk 6","TEC+ Disk 7","TEC+ Disk 8","TEC+ Disk 9","TEC- Disk 1","TEC- Disk 2","TEC- Disk 3","TEC- Disk 4","TEC- Disk 5","TEC- Disk 6","TEC- Disk 7","TEC- Disk 8","TEC- Disk 9"};
+
+      for(int iX=0;iX<=3;iX++){
+	masterTable->GetXaxis()->SetBinLabel(iX+1,labelsX[iX].c_str());
+      }
+
+      for(int iY=39;iY>=1;iY--){
+	masterTable->GetYaxis()->SetBinLabel(iY,labelsY[39-iY].c_str());
+      }
+
+
+      for(int iY=39;iY>=1;iY--){
+       	for(int iX=0;iX<=3;iX++){
+       	  if(iY==39){ 
+       	    masterTable->SetBinContent(iX+1,iY,NTkBadComponent[iX]);
+      	  } else if (iY>=35){
+	    masterTable->SetBinContent(iX+1,iY,NBadComponent[(39-iY)-1][0][iX]);
+	  } 
+	  //else {
+	  //  masterTable->SetBinContent(iX+1,iY,NBadComponent[]);
+	  //}
+       	}
+      }
+
+      TCanvas canv("canv","canv",800,800);
+      canv.cd();
+
+      canv.SetTopMargin(0.05);
+      canv.SetBottomMargin(0.09);
+      canv.SetLeftMargin(0.18);
+      canv.SetRightMargin(0.05);
+
+      masterTable->SetStats(false);
+      canv.SetGrid();
+     
+      masterTable->Draw("text");
+
+      std::string fileName(m_imageFileName);
+      canv.SaveAs(fileName.c_str());
+
+      delete siStripQuality_;
+      delete reader;
+      return true;
+    }
+  private:
+    TrackerTopology m_trackerTopo;
+  };
 
 } // close namespace
 
@@ -815,4 +1059,5 @@ PAYLOAD_INSPECTOR_MODULE(SiStripBadStrip){
   PAYLOAD_INSPECTOR_CLASS(SiStripBadStripByRegion);
   PAYLOAD_INSPECTOR_CLASS(SiStripBadStripByRegionComparison);
   PAYLOAD_INSPECTOR_CLASS(SiStripBadStripFractionComparisonTrackerMap);
+  PAYLOAD_INSPECTOR_CLASS(SiStripBadStripQualityAnalysis);
 }

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -539,10 +539,9 @@ namespace {
       std::string lastIOVsince  = std::to_string(std::get<0>(lastiov));
       std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
       
+      // last payload
       std::vector<uint32_t> detid;
       last_payload->getDetIds(detid);
-
-      // last payload
 
       SiStripDetSummary summaryLastBadStrips{&m_trackerTopo};
       int totalLastBadStrips =0;
@@ -558,7 +557,10 @@ namespace {
       }
       std::map<unsigned int, SiStripDetSummary::Values> mapLastBadStrips = summaryLastBadStrips.getCounts();
 
-      // first payload
+      // first payload 
+      // needs to be cleared to avoid bias using only detIds of last payload
+      detid.clear();
+      first_payload->getDetIds(detid);
 
       SiStripDetSummary summaryFirstBadStrips{&m_trackerTopo};
       int totalFirstBadStrips =0;

--- a/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
@@ -34,6 +34,35 @@
 namespace {
 
   /************************************************
+    1d histogram of SiStripLorentzAngle of 1 IOV 
+  *************************************************/
+
+  // inherit from one of the predefined plot class: Histogram1D
+  class SiStripLorentzAngleValue : public cond::payloadInspector::Histogram1D<SiStripLorentzAngle> {
+    
+  public:
+    SiStripLorentzAngleValue() : cond::payloadInspector::Histogram1D<SiStripLorentzAngle>("SiStrip LorentzAngle values",
+											  "SiStrip LorentzAngle values", 100,0.0,0.05){
+      Base::setSingleIov( true );
+    }
+    
+    bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override{
+      for ( auto const & iov: iovs) {
+	std::shared_ptr<SiStripLorentzAngle> payload = Base::fetchPayload( std::get<1>(iov) );
+	if( payload.get() ){
+	  
+	  std::map<uint32_t,float> LAMap_ = payload->getLorentzAngles();
+      
+	  for(const auto &element : LAMap_){
+	    fillWithValue(element.second);
+	  }
+	}// payload
+      }// iovs
+      return true;
+    }// fill
+  };
+  
+  /************************************************
     TrackerMap of SiStrip Lorentz Angle
   *************************************************/
   class SiStripLorentzAngle_TrackerMap : public cond::payloadInspector::PlotImage<SiStripLorentzAngle> {
@@ -139,6 +168,7 @@ namespace {
 	}
       }
 
+      h1->GetYaxis()->SetRangeUser(0.,h1->GetMaximum()*1.30);
       h1->SetMarkerStyle(20);
       h1->SetMarkerSize(1);
       h1->Draw("HIST");
@@ -175,6 +205,7 @@ namespace {
 }
 
 PAYLOAD_INSPECTOR_MODULE( SiStripLorentzAngle ){
+  PAYLOAD_INSPECTOR_CLASS( SiStripLorentzAngleValue );
   PAYLOAD_INSPECTOR_CLASS( SiStripLorentzAngle_TrackerMap );
   PAYLOAD_INSPECTOR_CLASS( SiStripLorentzAngleByPartition );
 }

--- a/CondCore/SiStripPlugins/test/test.sh
+++ b/CondCore/SiStripPlugins/test/test.sh
@@ -46,3 +46,14 @@ cd $W_DIR;
     --db Prod \
     --test;
 
+######################
+# Test Bad components
+######################
+/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+    --plugin pluginSiStripBadStrip_PayloadInspector \
+    --plot plot_SiStripBadStripQualityAnalysis \
+    --tag  SiStripBadComponents_startupMC_for2017_v1_mc\
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;


### PR DESCRIPTION
backport of #20946 

Post-merge follow-up to https://github.com/cms-sw/cmssw/pull/20643. 

Fixed:
   * bug in the filling of the `SiBadStrips` comparison plot due to not identical `detIds` list size for first and last IOV.

Added: 
   * 1D plot of payload dump values for `SiStripLorentzAngle` and `SiStripBackplaneCorrection`
   * Bad Strips Quality Statistics analysis breakout plot.