### PR TITLE
adding cluster charge and size per FPix ring

### DIFF
--- a/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
+++ b/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
@@ -206,15 +206,16 @@ SiPixelPhase1ClustersReadoutNClusters = DefaultHistoReadout.clone(
                              .groupBy("PXForward/HalfCylinder").save(),
 
     Specification(PerReadout).groupBy("PXBarrel/Shell/Sector/DetId/Event").reduce("COUNT")
-                             .groupBy("PXBarrel/Shell/Sector/Lumisection").reduce("MEAN")
+                             .groupBy("PXBarrel/Shell/Sector/LumiBlock").reduce("MEAN")
                              .groupBy("PXBarrel/Shell/Sector", "EXTEND_X").save(),
     Specification(PerReadout).groupBy("PXForward/HalfCylinder/DetId/Event").reduce("COUNT")
-                             .groupBy("PXForward/HalfCylinder/Lumisection").reduce("MEAN")
+                             .groupBy("PXForward/HalfCylinder/LumiBlock").reduce("MEAN")
                              .groupBy("PXForward/HalfCylinder", "EXTEND_X").save(),
   )
 )
 
 SiPixelPhase1ClustersPixelToStripRatio = DefaultHistoDigiCluster.clone(
+  enabled = False,
   name = "cluster_ratio",
   title = "Pixel to Strip clusters ratio",
   
@@ -223,7 +224,7 @@ SiPixelPhase1ClustersPixelToStripRatio = DefaultHistoDigiCluster.clone(
   
   specs = VPSet(
     Specification().groupBy("PXAll").save(100, 0, 1), 
-    Specification().groupBy("PXAll/Lumisection")
+    Specification().groupBy("PXAll/LumiBlock")
                    .reduce("MEAN") 
                    .groupBy("PXAll", "EXTEND_X")
                    .save(),

--- a/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
@@ -105,12 +105,12 @@ SiPixelPhase1DigisNdigisPerFEDtrend = DefaultHisto.clone(
 SiPixelPhase1DigisEvents = DefaultHistoDigiCluster.clone(
   name = "eventrate",
   title = "Rate of Pixel Events",
-  xlabel = "Lumisection",
+  xlabel = "LumiBlock",
   ylabel = "#Events",
   dimensions = 0,
   specs = VPSet(
 
-    Specification().groupBy("Lumisection")
+    Specification().groupBy("LumiBlock")
                    .reduce("MEAN")
                    .groupBy("", "EXTEND_X").save(),
     Specification().groupBy("BX")

--- a/DQM/SiPixelPhase1RecHits/python/SiPixelPhase1RecHits_cfi.py
+++ b/DQM/SiPixelPhase1RecHits/python/SiPixelPhase1RecHits_cfi.py
@@ -92,14 +92,14 @@ SiPixelPhase1RecHitsProb = DefaultHistoTrack.clone(
         Specification().groupBy("PXForward/PXDisk").saveAll(),
         StandardSpecification2DProfile,
     
-        Specification().groupBy("PXBarrel/PXLayer/Lumisection")
+        Specification().groupBy("PXBarrel/LumiBlock")
                        .reduce("MEAN")
-                       .groupBy("PXBarrel/PXLayer", "EXTEND_X")
+                       .groupBy("PXBarrel", "EXTEND_X")
                        .save(),
 
-        Specification().groupBy("PXForward/PXDisk/Lumisection")
+        Specification().groupBy("PXForward/LumiBlock")
                        .reduce("MEAN")
-                       .groupBy("PXForward/PXDisk", "EXTEND_X")
+                       .groupBy("PXForward", "EXTEND_X")
                        .save(),
 
         Specification(PerLayer1D).groupBy("PXBarrel/Shell/PXLayer").save(),

--- a/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
+++ b/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
@@ -20,6 +20,39 @@ SiPixelPhase1TrackClustersOnTrackCharge = DefaultHistoTrack.clone(
          .groupBy("PXForward", "EXTEND_Y")
          .save(),
 
+    Specification().groupBy("PXForward/PXRing").save(),
+
+    Specification(PerModule).groupBy("PXForward/PXRing/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXRing","EXTEND_X")
+                   .save(),
+
+    Specification(IsOffline).groupBy("PXForward/PXRing/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXRing","EXTEND_X")
+                   .save(),
+
+
+    Specification(PerModule).groupBy("PXBarrel/PXLayer/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel/PXLayer", "EXTEND_X")
+                   .save(),
+
+    Specification(PerModule).groupBy("PXForward/PXDisk/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXDisk", "EXTEND_X")
+                   .save(),
+
+    Specification(IsOffline).groupBy("PXBarrel/PXLayer/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel/PXLayer", "EXTEND_X")
+                   .save(),
+
+    Specification(IsOffline).groupBy("PXForward/PXDisk/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXDisk", "EXTEND_X")
+                   .save(),
+
     Specification(OverlayCurvesForTiming).groupBy("PXForward/PXDisk/OnlineBlock") # per-layer with history for online
                    .groupBy("PXForward/PXDisk", "EXTEND_Y")
                    .save(),
@@ -37,7 +70,39 @@ SiPixelPhase1TrackClustersOnTrackSize = DefaultHistoTrack.clone(
 
   specs = VPSet(
         StandardSpecifications1D,    
-        StandardSpecification2DProfile
+        StandardSpecification2DProfile,
+
+        Specification().groupBy("PXForward/PXRing").save(),
+
+        Specification(PerModule).groupBy("PXForward/PXRing/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXRing","EXTEND_X")
+                   .save(),
+
+        Specification(IsOffline).groupBy("PXForward/PXRing/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXRing","EXTEND_X")
+                   .save(),
+
+        Specification(PerModule).groupBy("PXBarrel/PXLayer/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel/PXLayer", "EXTEND_X")
+                   .save(),
+
+        Specification(PerModule).groupBy("PXForward/PXDisk/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXDisk", "EXTEND_X")
+                   .save(),
+
+        Specification(IsOffline).groupBy("PXBarrel/PXLayer/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel/PXLayer", "EXTEND_X")
+                   .save(),
+
+        Specification(IsOffline).groupBy("PXForward/PXDisk/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXDisk", "EXTEND_X")
+                   .save()
   )
 )
 
@@ -53,12 +118,22 @@ SiPixelPhase1TrackClustersOnTrackShape = DefaultHistoTrack.clone(
     Specification().groupBy("PXForward/PXDisk").saveAll(),
     StandardSpecification2DProfile,
 
-    Specification().groupBy("PXBarrel/PXLayer/Lumisection")
+    Specification(PerModule).groupBy("PXBarrel/PXLayer/Lumisection")
                    .reduce("MEAN")
                    .groupBy("PXBarrel/PXLayer", "EXTEND_X")
                    .save(),
 
-    Specification().groupBy("PXForward/PXDisk/Lumisection")
+    Specification(PerModule).groupBy("PXForward/PXDisk/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXDisk", "EXTEND_X")
+                   .save(),
+
+    Specification(IsOffline).groupBy("PXBarrel/PXLayer/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel/PXLayer", "EXTEND_X")
+                   .save(),
+
+    Specification(IsOffline).groupBy("PXForward/PXDisk/LumiBlock")
                    .reduce("MEAN")
                    .groupBy("PXForward/PXDisk", "EXTEND_X")
                    .save(),
@@ -78,15 +153,7 @@ SiPixelPhase1TrackClustersOnTrackNClusters = DefaultHistoTrack.clone(
   dimensions = 0,
 
   specs = VPSet(
- #   Specification().groupBy("PXBarrel/PXLayer" + "/DetId/Event") 
- #                  .reduce("COUNT") 
- #                  .groupBy("PXBarrel/PXLayer")
- #                  .saveAll(),
- #   Specification().groupBy("PXForward/PXDisk" + "/DetId/Event") 
- #                  .reduce("COUNT") 
- #                  .groupBy("PXForward/PXDisk")
- #                  .saveAll(),
- #   #StandardSpecificationInclusive_Num,
+
     StandardSpecificationTrend_Num,
     StandardSpecification2DProfile_Num,
 
@@ -118,16 +185,30 @@ SiPixelPhase1TrackClustersOnTrackNClusters = DefaultHistoTrack.clone(
     Specification().groupBy("BX")
                    .groupBy("", "EXTEND_X").save(),
 
-    Specification().groupBy("PXBarrel/PXLayer/Event")
+    Specification(PerModule).groupBy("PXBarrel/PXLayer/Event")
                    .reduce("COUNT")
                    .groupBy("PXBarrel/PXLayer/Lumisection")
                    .reduce("MEAN")
                    .groupBy("PXBarrel/PXLayer","EXTEND_X")
                    .save(),
 
-    Specification().groupBy("PXForward/PXDisk/Event")
+    Specification(PerModule).groupBy("PXForward/PXDisk/Event")
                    .reduce("COUNT")
                    .groupBy("PXForward/PXDisk/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXDisk","EXTEND_X")
+                   .save(),
+
+    Specification(IsOffline).groupBy("PXBarrel/PXLayer/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel/PXLayer/LumiBlock")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel/PXLayer","EXTEND_X")
+                   .save(),
+
+    Specification(IsOffline).groupBy("PXForward/PXDisk/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXForward/PXDisk/LumiBlock")
                    .reduce("MEAN")
                    .groupBy("PXForward/PXDisk","EXTEND_X")
                    .save(),

--- a/DQM/SiPixelPhase1TrackResiduals/python/SiPixelPhase1TrackResiduals_cfi.py
+++ b/DQM/SiPixelPhase1TrackResiduals/python/SiPixelPhase1TrackResiduals_cfi.py
@@ -12,14 +12,13 @@ SiPixelPhase1TrackResidualsResidualsX = DefaultHistoTrack.clone(
     StandardSpecification2DProfile,
     Specification().groupBy("PXBarrel/PXLayer").saveAll(),
     Specification().groupBy("PXForward/PXDisk").saveAll(),
-    StandardSpecification2DProfile,
     
-    Specification().groupBy("PXBarrel/PXLayer/Lumisection")
+    Specification().groupBy("PXBarrel/PXLayer/LumiBlock")
                    .reduce("MEAN")
                    .groupBy("PXBarrel/PXLayer", "EXTEND_X")
                    .save(),
 
-    Specification().groupBy("PXForward/PXDisk/Lumisection")
+    Specification().groupBy("PXForward/PXDisk/LumiBlock")
                    .reduce("MEAN")
                    .groupBy("PXForward/PXDisk", "EXTEND_X")
                    .save(),


### PR DESCRIPTION
This PR add histograms of on track cluster charge and size for the two rings of FPix, useful to better monitor the radiation damage effect on the detector.

It also move all Offline lumisection trends in trends each 10 lumisection, reducing effectively by a factor 10 the binning of those profile plots. 