### PR TITLE
Start EndPaths at the same time as we start Paths

### DIFF
--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -63,6 +63,7 @@ namespace edm {
 
     // ---------- const member functions ---------------------
     ProductResolverIndexAndSkipBit indexFrom(EDGetToken, BranchType, TypeID const&) const;
+    ProductResolverIndexAndSkipBit uncheckedIndexFrom(EDGetToken) const;
 
     void itemsToGet(BranchType, std::vector<ProductResolverIndexAndSkipBit>&) const;
     void itemsMayGet(BranchType, std::vector<ProductResolverIndexAndSkipBit>&) const;

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -207,6 +207,7 @@ namespace edm {
     void registerProductsAndCallbacks(OutputModule const*, ProductRegistry const*) {}
     
     bool needToRunSelection() const;
+    std::vector<ProductResolverIndexAndSkipBit> productsUsedBySelection() const;
     bool prePrefetchSelection(StreamID id, EventPrincipal const&, ModuleCallingContext const*);
 
     /// Ask the OutputModule if we should end the current file.

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -206,6 +206,7 @@ namespace edm {
 
     void registerProductsAndCallbacks(OutputModule const*, ProductRegistry const*) {}
     
+    bool needToRunSelection() const;
     bool prePrefetchSelection(StreamID id, EventPrincipal const&, ModuleCallingContext const*);
 
     /// Ask the OutputModule if we should end the current file.

--- a/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
+++ b/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
@@ -68,6 +68,8 @@ namespace edm {
 
       bool wantEvent(EventForOutput const& e);
 
+      unsigned int numberOfTokens() const { return selectors_.size();}
+      EDGetToken token(unsigned int index) const {return selectors_[index].token();}
     private:
       selectors_t selectors_;
       bool wantAllEvents_;

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -226,6 +226,7 @@ namespace edm {
       void registerProductsAndCallbacks(OutputModuleBase const*, ProductRegistry const*) {}
 
       bool needToRunSelection() const;
+      std::vector<ProductResolverIndexAndSkipBit> productsUsedBySelection() const;
       bool prePrefetchSelection(StreamID id, EventPrincipal const&, ModuleCallingContext const*);
       
       // Do the end-of-file tasks; this is only called internally, after

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -225,6 +225,7 @@ namespace edm {
       
       void registerProductsAndCallbacks(OutputModuleBase const*, ProductRegistry const*) {}
 
+      bool needToRunSelection() const;
       bool prePrefetchSelection(StreamID id, EventPrincipal const&, ModuleCallingContext const*);
       
       // Do the end-of-file tasks; this is only called internally, after

--- a/FWCore/Framework/interface/limited/OutputModuleBase.h
+++ b/FWCore/Framework/interface/limited/OutputModuleBase.h
@@ -231,6 +231,7 @@ namespace edm {
       
       void registerProductsAndCallbacks(OutputModuleBase const*, ProductRegistry const*) {}
 
+      bool needToRunSelection() const;
       bool prePrefetchSelection(StreamID id, EventPrincipal const&, ModuleCallingContext const*);
       
       // Do the end-of-file tasks; this is only called internally, after

--- a/FWCore/Framework/interface/limited/OutputModuleBase.h
+++ b/FWCore/Framework/interface/limited/OutputModuleBase.h
@@ -232,6 +232,7 @@ namespace edm {
       void registerProductsAndCallbacks(OutputModuleBase const*, ProductRegistry const*) {}
 
       bool needToRunSelection() const;
+      std::vector<ProductResolverIndexAndSkipBit> productsUsedBySelection() const;
       bool prePrefetchSelection(StreamID id, EventPrincipal const&, ModuleCallingContext const*);
       
       // Do the end-of-file tasks; this is only called internally, after

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -218,6 +218,7 @@ namespace edm {
       void registerProductsAndCallbacks(OutputModuleBase const*, ProductRegistry const*) {}
 
       bool needToRunSelection() const;
+      std::vector<ProductResolverIndexAndSkipBit> productsUsedBySelection() const;
       bool prePrefetchSelection(StreamID id, EventPrincipal const&, ModuleCallingContext const*);
       
       // Do the end-of-file tasks; this is only called internally, after

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -217,6 +217,7 @@ namespace edm {
       
       void registerProductsAndCallbacks(OutputModuleBase const*, ProductRegistry const*) {}
 
+      bool needToRunSelection() const;
       bool prePrefetchSelection(StreamID id, EventPrincipal const&, ModuleCallingContext const*);
       
       // Do the end-of-file tasks; this is only called internally, after

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -219,6 +219,12 @@ EDConsumerBase::indexFrom(EDGetToken iToken, BranchType iBranch, TypeID const& i
   return ProductResolverIndexAndSkipBit(edm::ProductResolverIndexInvalid, false);
 }
 
+ProductResolverIndexAndSkipBit
+EDConsumerBase::uncheckedIndexFrom(EDGetToken iToken) const {
+  return m_tokenInfo.get<kLookupInfo>(iToken.index()).m_index;
+}
+
+
 void
 EDConsumerBase::itemsToGet(BranchType iBranch, std::vector<ProductResolverIndexAndSkipBit>& oIndices) const
 {

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -224,6 +224,10 @@ namespace edm {
     return result;
   }
   
+  bool OutputModule::needToRunSelection() const {
+    return !wantAllEvents_;
+  }
+
   bool OutputModule::prePrefetchSelection(StreamID id, EventPrincipal const& ep, ModuleCallingContext const* mcc) {
     if(wantAllEvents_) return true;
     auto& s = selectors_[id.value()];

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -227,6 +227,19 @@ namespace edm {
   bool OutputModule::needToRunSelection() const {
     return !wantAllEvents_;
   }
+  
+  std::vector<ProductResolverIndexAndSkipBit>
+  OutputModule::productsUsedBySelection() const {
+    std::vector<ProductResolverIndexAndSkipBit> returnValue;
+    auto const& s = selectors_[0];
+    auto const n = s.numberOfTokens();
+    returnValue.reserve(n);
+    
+    for(unsigned int i=0; i< n;++i) {
+      returnValue.emplace_back(uncheckedIndexFrom(s.token(i)));
+    }
+    return returnValue;
+  }
 
   bool OutputModule::prePrefetchSelection(StreamID id, EventPrincipal const& ep, ModuleCallingContext const* mcc) {
     if(wantAllEvents_) return true;

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -169,6 +169,11 @@ namespace edm{
                                          ModuleCallingContext const* mcc) {
     return true;
   }
+  template<typename T>
+  inline
+  void
+  WorkerT<T>::itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>&) const {}
+
 
   template<>
   inline
@@ -182,11 +187,18 @@ namespace edm{
                                                     ModuleCallingContext const* mcc) {
     return module_->prePrefetchSelection(id,ep,mcc);
   }
+  template<>
+  inline
+  void
+  WorkerT<OutputModule>::itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>& iItems) const {
+    iItems = module_->productsUsedBySelection();
+  }
 
   template<>
   inline
   bool
   WorkerT<edm::one::OutputModuleBase>::implNeedToRunSelection() const { return true;}
+
   template<>
   inline
   bool
@@ -194,6 +206,12 @@ namespace edm{
                                                                   EventPrincipal const& ep,
                                                                   ModuleCallingContext const* mcc) {
     return module_->prePrefetchSelection(id,ep,mcc);
+  }
+  template<>
+  inline
+  void
+  WorkerT<edm::one::OutputModuleBase>::itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>& iItems) const {
+    iItems = module_->productsUsedBySelection();
   }
 
   template<>
@@ -208,6 +226,12 @@ namespace edm{
                                                                      ModuleCallingContext const* mcc) {
     return module_->prePrefetchSelection(id,ep,mcc);
   }
+  template<>
+  inline
+  void
+  WorkerT<edm::global::OutputModuleBase>::itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>& iItems) const {
+    iItems = module_->productsUsedBySelection();
+  }
 
   template<>
   inline
@@ -220,6 +244,12 @@ namespace edm{
                                                                      EventPrincipal const& ep,
                                                                      ModuleCallingContext const* mcc) {
     return module_->prePrefetchSelection(id,ep,mcc);
+  }
+  template<>
+  inline
+  void
+  WorkerT<edm::limited::OutputModuleBase>::itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>& iItems) const {
+    iItems = module_->productsUsedBySelection();
   }
 
   template<typename T>

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -159,12 +159,21 @@ namespace edm{
   template<typename T>
   inline
   bool
+  WorkerT<T>::implNeedToRunSelection() const { return false;}
+
+  template<typename T>
+  inline
+  bool
   WorkerT<T>::implDoPrePrefetchSelection(StreamID id,
                                          EventPrincipal const& ep,
                                          ModuleCallingContext const* mcc) {
     return true;
   }
 
+  template<>
+  inline
+  bool
+  WorkerT<OutputModule>::implNeedToRunSelection() const { return true;}
   template<>
   inline
   bool
@@ -177,6 +186,10 @@ namespace edm{
   template<>
   inline
   bool
+  WorkerT<edm::one::OutputModuleBase>::implNeedToRunSelection() const { return true;}
+  template<>
+  inline
+  bool
   WorkerT<edm::one::OutputModuleBase>::implDoPrePrefetchSelection(StreamID id,
                                                                   EventPrincipal const& ep,
                                                                   ModuleCallingContext const* mcc) {
@@ -186,12 +199,20 @@ namespace edm{
   template<>
   inline
   bool
+  WorkerT<edm::global::OutputModuleBase>::implNeedToRunSelection() const { return true;}
+  template<>
+  inline
+  bool
   WorkerT<edm::global::OutputModuleBase>::implDoPrePrefetchSelection(StreamID id,
                                                                      EventPrincipal const& ep,
                                                                      ModuleCallingContext const* mcc) {
     return module_->prePrefetchSelection(id,ep,mcc);
   }
 
+  template<>
+  inline
+  bool
+  WorkerT<edm::limited::OutputModuleBase>::implNeedToRunSelection() const { return true;}
   template<>
   inline
   bool

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -83,6 +83,7 @@ namespace edm {
   private:
     bool implDo(EventPrincipal const& ep, EventSetup const& c,
                         ModuleCallingContext const* mcc) override;
+    bool implNeedToRunSelection() const final;
     bool implDoPrePrefetchSelection(StreamID id,
                                             EventPrincipal const& ep,
                                             ModuleCallingContext const* mcc) override;

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -83,6 +83,7 @@ namespace edm {
   private:
     bool implDo(EventPrincipal const& ep, EventSetup const& c,
                         ModuleCallingContext const* mcc) override;
+    void itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>&) const final;
     bool implNeedToRunSelection() const final;
     bool implDoPrePrefetchSelection(StreamID id,
                                             EventPrincipal const& ep,

--- a/FWCore/Framework/src/global/OutputModuleBase.cc
+++ b/FWCore/Framework/src/global/OutputModuleBase.cc
@@ -207,6 +207,10 @@ namespace edm {
       endJob();
     }
     
+    bool OutputModuleBase::needToRunSelection() const {
+      return !wantAllEvents_;
+    }
+
     bool OutputModuleBase::prePrefetchSelection(StreamID id, EventPrincipal const& ep, ModuleCallingContext const* mcc) {
       if(wantAllEvents_) return true;
       auto& s = selectors_[id.value()];

--- a/FWCore/Framework/src/global/OutputModuleBase.cc
+++ b/FWCore/Framework/src/global/OutputModuleBase.cc
@@ -211,6 +211,19 @@ namespace edm {
       return !wantAllEvents_;
     }
 
+    std::vector<ProductResolverIndexAndSkipBit>
+    OutputModuleBase::productsUsedBySelection() const {
+      std::vector<ProductResolverIndexAndSkipBit> returnValue;
+      auto const& s = selectors_[0];
+      auto const n = s.numberOfTokens();
+      returnValue.reserve(n);
+      
+      for(unsigned int i=0; i< n;++i) {
+        returnValue.emplace_back(uncheckedIndexFrom(s.token(i)));
+      }
+      return returnValue;
+    }
+    
     bool OutputModuleBase::prePrefetchSelection(StreamID id, EventPrincipal const& ep, ModuleCallingContext const* mcc) {
       if(wantAllEvents_) return true;
       auto& s = selectors_[id.value()];

--- a/FWCore/Framework/src/limited/OutputModuleBase.cc
+++ b/FWCore/Framework/src/limited/OutputModuleBase.cc
@@ -212,6 +212,19 @@ namespace edm {
       return !wantAllEvents_;
     }
 
+    std::vector<ProductResolverIndexAndSkipBit>
+    OutputModuleBase::productsUsedBySelection() const {
+      std::vector<ProductResolverIndexAndSkipBit> returnValue;
+      auto const& s = selectors_[0];
+      auto const n = s.numberOfTokens();
+      returnValue.reserve(n);
+      
+      for(unsigned int i=0; i< n;++i) {
+        returnValue.emplace_back(uncheckedIndexFrom(s.token(i)));
+      }
+      return returnValue;
+    }
+
     bool OutputModuleBase::prePrefetchSelection(StreamID id, EventPrincipal const& ep, ModuleCallingContext const* mcc) {
       if(wantAllEvents_) return true;
       auto& s = selectors_[id.value()];

--- a/FWCore/Framework/src/limited/OutputModuleBase.cc
+++ b/FWCore/Framework/src/limited/OutputModuleBase.cc
@@ -208,6 +208,10 @@ namespace edm {
       endJob();
     }
     
+    bool OutputModuleBase::needToRunSelection() const {
+      return !wantAllEvents_;
+    }
+
     bool OutputModuleBase::prePrefetchSelection(StreamID id, EventPrincipal const& ep, ModuleCallingContext const* mcc) {
       if(wantAllEvents_) return true;
       auto& s = selectors_[id.value()];

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -227,6 +227,19 @@ namespace edm {
       return !wantAllEvents_;
     }
 
+    std::vector<ProductResolverIndexAndSkipBit>
+    OutputModuleBase::productsUsedBySelection() const {
+      std::vector<ProductResolverIndexAndSkipBit> returnValue;
+      auto const& s = selectors_[0];
+      auto const n = s.numberOfTokens();
+      returnValue.reserve(n);
+      
+      for(unsigned int i=0; i< n;++i) {
+        returnValue.emplace_back(uncheckedIndexFrom(s.token(i)));
+      }
+      return returnValue;
+    }
+    
     bool OutputModuleBase::prePrefetchSelection(StreamID id, EventPrincipal const& ep, ModuleCallingContext const* mcc) {
       if(wantAllEvents_) return true;
       auto& s = selectors_[id.value()];

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -223,6 +223,10 @@ namespace edm {
       endJob();
     }
     
+    bool OutputModuleBase::needToRunSelection() const {
+      return !wantAllEvents_;
+    }
+
     bool OutputModuleBase::prePrefetchSelection(StreamID id, EventPrincipal const& ep, ModuleCallingContext const* mcc) {
       if(wantAllEvents_) return true;
       auto& s = selectors_[id.value()];

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -300,6 +300,17 @@ StreamContext: StreamID = 0 transition = Event
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
+++++++ starting: processing path 'e' : stream = 0
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
+    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+PathContext: pathName = e pathID = 0 (EndPath)
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
+    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+
 ++++++ starting: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -408,17 +419,6 @@ PathContext: pathName = p pathID = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++ starting: processing path 'e' : stream = 0
-StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-PathContext: pathName = e pathID = 0 (EndPath)
-    StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 8
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 10
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 11
@@ -476,6 +476,17 @@ StreamContext: StreamID = 0 transition = Event
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
+++++++ starting: processing path 'e' : stream = 0
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
+    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+PathContext: pathName = e pathID = 0 (EndPath)
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
+    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+
 ++++++ starting: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -584,17 +595,6 @@ PathContext: pathName = p pathID = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++ starting: processing path 'e' : stream = 0
-StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 2
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-PathContext: pathName = e pathID = 0 (EndPath)
-    StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 2
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 8
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 10
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 11
@@ -652,6 +652,17 @@ StreamContext: StreamID = 0 transition = Event
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
+++++++ starting: processing path 'e' : stream = 0
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+PathContext: pathName = e pathID = 0 (EndPath)
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+
 ++++++ starting: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -760,17 +771,6 @@ PathContext: pathName = p pathID = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++ starting: processing path 'e' : stream = 0
-StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 3
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-PathContext: pathName = e pathID = 0 (EndPath)
-    StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 3
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 8
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 10
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 11

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -195,6 +195,17 @@ StreamContext: StreamID = 0 transition = Event
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
+++++++ starting: processing path 'e' : stream = 0
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
+    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
+PathContext: pathName = e pathID = 0 (EndPath)
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
+    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
+
 ++++++ starting: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -279,17 +290,6 @@ PathContext: pathName = p pathID = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++ starting: processing path 'e' : stream = 0
-StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-PathContext: pathName = e pathID = 0 (EndPath)
-    StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 5
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 6
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 7
@@ -345,6 +345,17 @@ StreamContext: StreamID = 0 transition = Event
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
+++++++ starting: processing path 'e' : stream = 0
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
+    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
+PathContext: pathName = e pathID = 0 (EndPath)
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
+    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
+
 ++++++ starting: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -429,17 +440,6 @@ PathContext: pathName = p pathID = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++ starting: processing path 'e' : stream = 0
-StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 2
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-PathContext: pathName = e pathID = 0 (EndPath)
-    StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 2
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 5
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 6
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 7
@@ -495,6 +495,17 @@ StreamContext: StreamID = 0 transition = Event
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
+++++++ starting: processing path 'e' : stream = 0
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
+PathContext: pathName = e pathID = 0 (EndPath)
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
+
 ++++++ starting: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -579,17 +590,6 @@ PathContext: pathName = p pathID = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++ starting: processing path 'e' : stream = 0
-StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 3
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-PathContext: pathName = e pathID = 0 (EndPath)
-    StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 3
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 5
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 6
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 7

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -421,6 +421,7 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -430,6 +431,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -474,7 +476,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -519,7 +520,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -583,6 +583,7 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -592,6 +593,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -636,7 +638,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -681,7 +682,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -745,6 +745,7 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -754,6 +755,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -798,7 +800,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -843,7 +844,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -907,6 +907,7 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -916,6 +917,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -960,7 +962,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -1005,7 +1006,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -1203,6 +1203,7 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -1212,6 +1213,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -1256,7 +1258,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -1301,7 +1302,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -1365,6 +1365,7 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -1374,6 +1375,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -1418,7 +1420,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -1463,7 +1464,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -1527,6 +1527,7 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -1536,6 +1537,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -1580,7 +1582,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -1625,7 +1626,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -1689,6 +1689,7 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -1698,6 +1699,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -1742,7 +1744,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -1787,7 +1788,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -1985,6 +1985,7 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -1994,6 +1995,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -2038,7 +2040,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -2083,7 +2084,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -2147,6 +2147,7 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -2156,6 +2157,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -2200,7 +2202,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -2245,7 +2246,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -2577,6 +2577,7 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -2586,6 +2587,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -2630,7 +2632,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -2675,7 +2676,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -2739,6 +2739,7 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -2748,6 +2749,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -2792,7 +2794,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -2837,7 +2838,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -2901,6 +2901,7 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -2910,6 +2911,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -2954,7 +2956,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -2999,7 +3000,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -3063,6 +3063,7 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -3072,6 +3073,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -3116,7 +3118,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -3161,7 +3162,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -3359,6 +3359,7 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -3368,6 +3369,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -3412,7 +3414,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -3457,7 +3458,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -3521,6 +3521,7 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -3530,6 +3531,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -3574,7 +3576,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -3619,7 +3620,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -3683,6 +3683,7 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -3692,6 +3693,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -3736,7 +3738,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -3781,7 +3782,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -3845,6 +3845,7 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -3854,6 +3855,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -3898,7 +3900,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -3943,7 +3944,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -4141,6 +4141,7 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -4150,6 +4151,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -4194,7 +4196,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -4239,7 +4240,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -4303,6 +4303,7 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -4312,6 +4313,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -4356,7 +4358,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -4401,7 +4402,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -4733,6 +4733,7 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -4742,6 +4743,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -4786,7 +4788,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -4831,7 +4832,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -4895,6 +4895,7 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -4904,6 +4905,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -4948,7 +4950,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -4993,7 +4994,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -5057,6 +5057,7 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -5066,6 +5067,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -5110,7 +5112,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -5155,7 +5156,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -5219,6 +5219,7 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -5228,6 +5229,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -5272,7 +5274,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -5317,7 +5318,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -5515,6 +5515,7 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -5524,6 +5525,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -5568,7 +5570,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -5613,7 +5614,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -5677,6 +5677,7 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -5686,6 +5687,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -5730,7 +5732,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -5775,7 +5776,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -5839,6 +5839,7 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -5848,6 +5849,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -5892,7 +5894,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -5937,7 +5938,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -6001,6 +6001,7 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -6010,6 +6011,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -6054,7 +6056,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -6099,7 +6100,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -6297,6 +6297,7 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -6306,6 +6307,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -6350,7 +6352,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -6395,7 +6396,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
@@ -6459,6 +6459,7 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
@@ -6468,6 +6469,7 @@
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
@@ -6512,7 +6514,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
@@ -6557,7 +6558,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37


### PR DESCRIPTION
Starting EndPaths as the same time as Paths gives the framework more concurrent tasks to use.
If a module on the EndPath depends on the present process' TriggerResults, such as an OutputModule with a SelectEvents configuration, the regular data dependency system will guarantee the proper run order of the modules.