### PR TITLE
HCALDQM: Add plots for monitoring bad TDC values

### DIFF
--- a/DQM/HcalCommon/interface/ValueQuantity.h
+++ b/DQM/HcalCommon/interface/ValueQuantity.h
@@ -61,7 +61,7 @@ namespace hcaldqm
 			fDualAnodeAsymmetry = 46,
 			fTimingRatio = 47,
 			fQIE10fC_100000Coarse = 48,
-			nValueQuantityType = 49,
+			fBadTDC = 49,
 		};
 		const std::map<ValueQuantityType, std::string> name_value = {
 			{fN,"N"},
@@ -113,6 +113,7 @@ namespace hcaldqm
 			{fDualAnodeAsymmetry, "(q_{1}-q_{2})/(q_{1}+q_{2})"},
 			{fTimingRatio, "q_{SOI+1}/q_{SOI}"},
 			{fQIE10fC_100000Coarse,"fC (QIE10/11)"},
+			{fBadTDC, "TDC"},
 		};
 		const std::map<ValueQuantityType, double> min_value = {
 			{fN,-0.05},
@@ -164,6 +165,7 @@ namespace hcaldqm
 			{fDualAnodeAsymmetry,-1.},	
 			{fTimingRatio,0.},	
 			{fQIE10fC_100000Coarse,0},
+			{fBadTDC,49.5},
 		};
 		const std::map<ValueQuantityType, double> max_value = {
 			{fN,1000},
@@ -215,6 +217,7 @@ namespace hcaldqm
 			{fDualAnodeAsymmetry,1.},
 			{fTimingRatio,2.5},	
 			{fQIE10fC_100000Coarse,100000},
+			{fBadTDC,61.5},
 		};
 		const std::map<ValueQuantityType, int> nbins_value = {
 			{fN,200},
@@ -265,6 +268,7 @@ namespace hcaldqm
 			{fDualAnodeAsymmetry,40},
 			{fTimingRatio,50},
 			{fQIE10fC_100000Coarse,1000},
+			{fBadTDC,12}
 		};
 		class ValueQuantity : public Quantity
 		{

--- a/DQM/HcalCommon/interface/ValueQuantity.h
+++ b/DQM/HcalCommon/interface/ValueQuantity.h
@@ -277,24 +277,24 @@ namespace hcaldqm
 				ValueQuantity(ValueQuantityType type, bool isLog=false) :
 					Quantity(name_value.at(type), isLog), _type(type)
 				{}
-				virtual ~ValueQuantity() {}
+				~ValueQuantity() override {}
 
-				virtual ValueQuantity* makeCopy()
+				ValueQuantity* makeCopy() override
 				{return new ValueQuantity(_type, _isLog);}
 
 				//	get Value to be overriden
-				virtual int getValue(int x)
+				int getValue(int x) override
 				{return x;}
-				virtual double getValue(double x)
+				double getValue(double x) override
 				{return x;}
 
 				//	standard properties
-				virtual QuantityType type() {return fValueQuantity;}
-				virtual int nbins() {return nbins_value.at(_type);}
-				virtual double min() {return min_value.at(_type);}
-				virtual double max() {return max_value.at(_type);}
+				QuantityType type() override {return fValueQuantity;}
+				int nbins() override {return nbins_value.at(_type);}
+				double min() override {return min_value.at(_type);}
+				double max() override {return max_value.at(_type);}
 
-				virtual void setBits(TH1* o)
+				void setBits(TH1* o) override
 				{Quantity::setBits(o);setLS(o);}
 				virtual void setLS(TH1* o)
 				{
@@ -317,18 +317,18 @@ namespace hcaldqm
 				FlagQuantity(){}
 				FlagQuantity(std::vector<flag::Flag> const& flags) :
 					_flags(flags) {}
-				virtual ~FlagQuantity() {}
+				~FlagQuantity() override {}
 				
-				virtual FlagQuantity* makeCopy()
+				FlagQuantity* makeCopy() override
 				{return new FlagQuantity(_flags);}
 
-				virtual std::string name() {return "Flag";}
-				virtual int nbins() {return _flags.size();}
-				virtual double min() {return 0;}
-				virtual double max() {return _flags.size();}
-				virtual int getValue(int f) {return f;}
-				virtual uint32_t getBin(int f) {return f+1;}
-				virtual std::vector<std::string> getLabels()
+				std::string name() override {return "Flag";}
+				int nbins() override {return _flags.size();}
+				double min() override {return 0;}
+				double max() override {return _flags.size();}
+				int getValue(int f) override {return f;}
+				uint32_t getBin(int f) override {return f+1;}
+				std::vector<std::string> getLabels() override
 				{
 					std::vector<std::string> vnames;
 					for (std::vector<flag::Flag>::const_iterator
@@ -350,19 +350,19 @@ namespace hcaldqm
 				LumiSection(int n) : ValueQuantity(fLS), 
 					_n(n) 
 				{}
-				virtual ~LumiSection() {}
+				~LumiSection() override {}
 				
-				virtual LumiSection* makeCopy()
+				LumiSection* makeCopy() override
 				{return new LumiSection(_n);}
 
-				virtual std::string name() {return "LS";}
-				virtual int nbins() {return _n;}
-				virtual double min() {return 1;}
-				virtual double max() {return _n+1;}
-				virtual int getValue(int l) {return l;}
-				virtual uint32_t getBin(int l) 
+				std::string name() override {return "LS";}
+				int nbins() override {return _n;}
+				double min() override {return 1;}
+				double max() override {return _n+1;}
+				int getValue(int l) override {return l;}
+				uint32_t getBin(int l) override 
 				{return getValue(l);}
-				virtual void setMax(double x) {_n=x;}
+				void setMax(double x) override {_n=x;}
 
 			protected:
 				int _n;
@@ -375,13 +375,13 @@ namespace hcaldqm
 				RunNumber(std::vector<int> runs) :
 					_runs(runs) 
 				{}
-				virtual ~RunNumber() {}
+				~RunNumber() override {}
 
-				virtual std::string name() {return "Run";}
-				virtual int nbins() {return _runs.size();}
-				virtual double min() {return 0;}
-				virtual double max() {return _runs.size();}
-				virtual std::vector<std::string> getLabels()
+				std::string name() override {return "Run";}
+				int nbins() override {return _runs.size();}
+				double min() override {return 0;}
+				double max() override {return _runs.size();}
+				std::vector<std::string> getLabels() override
 				{
 					char name[10];
 					std::vector<std::string> labels;
@@ -392,7 +392,7 @@ namespace hcaldqm
 					}
 					return labels;
 				}
-				virtual int getValue(int run)
+				int getValue(int run) override
 				{
 					int ir = -1;
 					for (uint32_t i=0; i<_runs.size(); i++)
@@ -409,7 +409,7 @@ namespace hcaldqm
 					return ir;
 				}
 
-				virtual uint32_t getBin(int run)
+				uint32_t getBin(int run) override
 				{
 					return (this->getValue(run)+1);
 				}
@@ -425,12 +425,12 @@ namespace hcaldqm
 				EventNumber(int nevents) :
 					ValueQuantity(fN), _nevents(nevents)
 				{}
-				virtual ~EventNumber() {}
+				~EventNumber() override {}
 
-				virtual std::string name() {return "Event";}
-				virtual int nbins() {return _nevents;}
-				virtual double min() {return 0.5;}
-				virtual double max() {return _nevents+0.5;}
+				std::string name() override {return "Event";}
+				int nbins() override {return _nevents;}
+				double min() override {return 0.5;}
+				double max() override {return _nevents+0.5;}
 
 			protected:
 				int _nevents;
@@ -443,7 +443,7 @@ namespace hcaldqm
 				EventType(std::vector<uint32_t> const& vtypes):
 					ValueQuantity(fN)
 				{this->setup(vtypes);}
-				virtual ~EventType() {}
+				~EventType() override {}
 
 				virtual void setup(std::vector<uint32_t> const& vtypes)
 				{
@@ -451,26 +451,26 @@ namespace hcaldqm
 					for (uint32_t i=0; i<vtypes.size(); i++)
 						_types.insert(std::make_pair((uint32_t)vtypes[i], i));
 				}
-				virtual int getValue(int v)
+				int getValue(int v) override
 				{
 					return _types[(uint32_t)v];
 				}
-				virtual uint32_t getBin(int v)
+				uint32_t getBin(int v) override
 				{
 					return getValue(v)+1;
 				}
 
-				virtual int nbins() {return _types.size();}
-				virtual double min() {return 0;}
-				virtual double max() {return _types.size();}
-				virtual std::string name() {return "Event Type";}
+				int nbins() override {return _types.size();}
+				double min() override {return 0;}
+				double max() override {return _types.size();}
+				std::string name() override {return "Event Type";}
 
 			protected:
 				typedef boost::unordered_map<uint32_t, int> TypeMap;
 				TypeMap _types;
 
 			public:
-				virtual std::vector<std::string> getLabels()
+				std::vector<std::string> getLabels() override
 				{
 					std::vector<std::string> labels(_types.size());
 					std::cout << "SIZE = " << _types.size() << std::endl;
@@ -481,7 +481,7 @@ namespace hcaldqm
 					}
 					return labels;
 				}
-				virtual EventType* makeCopy()
+				EventType* makeCopy() override
 				{
 					std::vector<uint32_t> vtypes;
 					BOOST_FOREACH(TypeMap::value_type &p, _types)

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -164,6 +164,12 @@ class DigiTask : public hcaldqm::DQTask
 		hcaldqm::Container2D _cLETDCvsTS_SubdetPM;
 		hcaldqm::Container1D _cLETDCTime_SubdetPM;
 
+		// Bad TDC histograms
+		hcaldqm::Container1D _cBadTDCValues_SubdetPM;
+		hcaldqm::Container1D _cBadTDCvsBX_SubdetPM;
+		hcaldqm::Container1D _cBadTDCvsLS_SubdetPM;
+		hcaldqm::Container2D _cBadTDCCount_depth;
+
 		//	#events counters
 		MonitorElement *meNumEvents1LS; // to transfer the #events to harvesting
 		MonitorElement *meUnknownIds1LS;

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -30,18 +30,18 @@ class DigiTask : public hcaldqm::DQTask
 {
 	public:
 		DigiTask(edm::ParameterSet const&);
-		virtual ~DigiTask() {}
+		~DigiTask() override {}
 
-		virtual void bookHistograms(DQMStore::IBooker&,
-			edm::Run const&, edm::EventSetup const&);
-		virtual void beginLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&);
-		virtual void endLuminosityBlock(edm::LuminosityBlock const&,
-			edm::EventSetup const&);
+		void bookHistograms(DQMStore::IBooker&,
+			edm::Run const&, edm::EventSetup const&) override;
+		void beginLuminosityBlock(edm::LuminosityBlock const&,
+			edm::EventSetup const&) override;
+		void endLuminosityBlock(edm::LuminosityBlock const&,
+			edm::EventSetup const&) override;
 
 	protected:
-		virtual void _process(edm::Event const&, edm::EventSetup const&);
-		virtual void _resetMonitors(hcaldqm::UpdateFreq);
+		void _process(edm::Event const&, edm::EventSetup const&) override;
+		void _resetMonitors(hcaldqm::UpdateFreq) override;
 
 		edm::InputTag		_tagHBHE;
 		edm::InputTag		_tagHEP17;

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -165,10 +165,14 @@ class DigiTask : public hcaldqm::DQTask
 		hcaldqm::Container1D _cLETDCTime_SubdetPM;
 
 		// Bad TDC histograms
-		hcaldqm::Container1D _cBadTDCValues_SubdetPM;
-		hcaldqm::Container1D _cBadTDCvsBX_SubdetPM;
-		hcaldqm::Container1D _cBadTDCvsLS_SubdetPM;
+		hcaldqm::Container1D _cBadTDCValues_SubdetPM_HF;
+		hcaldqm::Container1D _cBadTDCvsBX_SubdetPM_HF;
+		hcaldqm::Container1D _cBadTDCvsLS_SubdetPM_HF;
 		hcaldqm::Container2D _cBadTDCCount_depth;
+
+		hcaldqm::Container1D _cBadTDCValues_SubdetPM_HEP17;
+		hcaldqm::Container1D _cBadTDCvsBX_SubdetPM_HEP17;
+		hcaldqm::Container1D _cBadTDCvsLS_SubdetPM_HEP17;
 
 		//	#events counters
 		MonitorElement *meNumEvents1LS; // to transfer the #events to harvesting

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -174,6 +174,23 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		hcaldqm::hashfunctions::fSubdetPM,
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+	_cBadTDCValues_SubdetPM.initialize(_name, "BadTDCValues", 
+		hcaldqm::hashfunctions::fSubdetPM,
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBadTDC),
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+	_cBadTDCvsBX_SubdetPM.initialize(_name, "BadTDCvsBX", 
+		hcaldqm::hashfunctions::fSubdetPM, 
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+	_cBadTDCvsLS_SubdetPM.initialize(_name, "BadTDCvsLS", 
+		hcaldqm::hashfunctions::fSubdetPM, 
+		new hcaldqm::quantity::LumiSection(_maxLS),
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+	_cBadTDCCount_depth.initialize(_name, "BadTDCCount", 
+		hcaldqm::hashfunctions::fdepth,
+		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
 
 	if (_ptype == fOnline || _ptype == fLocal) {
 		_cOccupancy_Crate.initialize(_name,
@@ -435,6 +452,10 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	_cLETDCvsADC_SubdetPM.book(ib, _emap, _filter_HF, _subsystem);
 	_cLETDCvsTS_SubdetPM.book(ib, _emap, _filter_HF, _subsystem);
 	_cLETDCTime_SubdetPM.book(ib, _emap, _filter_HF, _subsystem);
+	_cBadTDCValues_SubdetPM.book(ib, _emap, _filter_HF, _subsystem);
+	_cBadTDCvsBX_SubdetPM.book(ib, _emap, _filter_HF, _subsystem);
+	_cBadTDCvsLS_SubdetPM.book(ib, _emap, _filter_HF, _subsystem);
+	_cBadTDCCount_depth	.book(ib, _emap, _filter_HF, _subsystem);
 
 	//	BOOK HISTOGRAMS that are only for Online
 	_ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
@@ -1030,6 +1051,14 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 						double time = i*25. + (digi[i].le_tdc() / 2.);
 						_cLETDCTime_SubdetPM.fill(did, time);
 						_cLETDCTimevsADC_SubdetPM.fill(did, digi[i].adc(), time);
+					}
+
+					// Bad TDC values: 50-61 should never happen in QIE10 or QIE11, but we are seeing some in 2017 data.
+					if ((50 <= digi[i].le_tdc()) && (digi[i].le_tdc() <= 61)) {
+						_cBadTDCValues_SubdetPM.fill(did, digi[i].le_tdc());
+						_cBadTDCvsBX_SubdetPM.fill(did, bx);
+						_cBadTDCvsLS_SubdetPM.fill(did, _currentLS);
+						_cBadTDCCount_depth.fill(did);
 					}
 				}
 

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -186,7 +186,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		hcaldqm::hashfunctions::fSubdetPM, 
 		new hcaldqm::quantity::LumiSection(_maxLS),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
-	_cBadTDCCount_depth_HF.initialize(_name, "BadTDCCount", 
+	_cBadTDCCount_depth.initialize(_name, "BadTDCCount", 
 		hcaldqm::hashfunctions::fdepth,
 		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
 		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
@@ -203,11 +203,6 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		hcaldqm::hashfunctions::fSubdetPM, 
 		new hcaldqm::quantity::LumiSection(_maxLS),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
-	_cBadTDCCount_depth_HEP17.initialize(_name, "BadTDCCount", 
-		hcaldqm::hashfunctions::fdepth,
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-		new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
 
 	if (_ptype == fOnline || _ptype == fLocal) {
 		_cOccupancy_Crate.initialize(_name,
@@ -472,11 +467,10 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	_cBadTDCValues_SubdetPM_HF.book(ib, _emap, _filter_HF, _subsystem);
 	_cBadTDCvsBX_SubdetPM_HF.book(ib, _emap, _filter_HF, _subsystem);
 	_cBadTDCvsLS_SubdetPM_HF.book(ib, _emap, _filter_HF, _subsystem);
-	_cBadTDCCount_depth_HF	.book(ib, _emap, _filter_HF, _subsystem);
+	_cBadTDCCount_depth.book(ib, _emap, _filter_HF, _subsystem);
 	_cBadTDCValues_SubdetPM_HEP17.book(ib, _emap, _filter_HEP17, _subsystem);
 	_cBadTDCvsBX_SubdetPM_HEP17.book(ib, _emap, _filter_HEP17, _subsystem);
 	_cBadTDCvsLS_SubdetPM_HEP17.book(ib, _emap, _filter_HEP17, _subsystem);
-	_cBadTDCCount_depth_HEP17.book(ib, _emap, _filter_HEP17, _subsystem);
 
 	//	BOOK HISTOGRAMS that are only for Online
 	_ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);


### PR DESCRIPTION
Adds 4 plots for monitoring bad TDC values from the HF QIE10s and HEP17 QIE11s (values 50-61 are never supposed to happen, but have been observed in the 2017 data):

- TH1 of bad TDC values, SubdetPM (12*3=36 bins)
- TH1 of bad TDC count vs. BX, SubdetPM (3600*3=10,800 bins)
- TH1 of bad TDC count vs. LS, SubdetPM (4000*3=12,000 bins)
- TH2 of bad TDC count vs ieta vs iphi, depth (84\*64\*7=37,632 bins)
