### PR TITLE
Prompt-like GT updated with revert of AlCaReco trigger bits to Fix wf 2016H

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -28,7 +28,7 @@ autoCond = {
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '92X_dataRun2_relval_v8',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '92X_dataRun2_PromptLike_v7',
+    'run2_data_promptlike' : '92X_dataRun2_PromptLike_v8',
 
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '92X_dataRun2_HLT_frozen_v7',


### PR DESCRIPTION
This PR should fix the issue reported here https://github.com/cms-sw/cmssw/pull/21053#issuecomment-340117333
@davidlange6 
you don't need to revert the whole PR #20984 
just merge this one and it should fix the issue.

I have tested it using 

`runTheMatrix.py -l 136.77 --command='--conditions 92X_dataRun2_PromptLike_v8 -n 1'`

and it worked fine. 
The problem was the wrong AlCaRecoTriggerBits tag in prompt-like GT.
