### PR TITLE
Avoided uneeded run and luminosity block  calls

### DIFF
--- a/FWCore/Framework/interface/EDAnalyzer.h
+++ b/FWCore/Framework/interface/EDAnalyzer.h
@@ -44,6 +44,8 @@ namespace edm {
     
     static bool wantsGlobalRuns() {return true;}
     static bool wantsGlobalLuminosityBlocks() {return true;}
+    static bool wantsStreamRuns() {return false;}
+    static bool wantsStreamLuminosityBlocks() {return false;};
 
     void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func);
 

--- a/FWCore/Framework/interface/EDAnalyzer.h
+++ b/FWCore/Framework/interface/EDAnalyzer.h
@@ -41,6 +41,9 @@ namespace edm {
 
     // Warning: the returned moduleDescription will be invalid during construction
     ModuleDescription const& moduleDescription() const { return moduleDescription_; }
+    
+    static bool wantsGlobalRuns() {return true;}
+    static bool wantsGlobalLuminosityBlocks() {return true;}
 
     void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func);
 

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -52,6 +52,9 @@ namespace edm {
     // Warning: the returned moduleDescription will be invalid during construction
     ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+    static bool wantsGlobalRuns() {return true;}
+    static bool wantsGlobalLuminosityBlocks() {return true;}
+
   private:
     bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                  ActivityRegistry* act,

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -54,6 +54,8 @@ namespace edm {
 
     static bool wantsGlobalRuns() {return true;}
     static bool wantsGlobalLuminosityBlocks() {return true;}
+    static bool wantsStreamRuns() {return false;}
+    static bool wantsStreamLuminosityBlocks() {return false;};
 
   private:
     bool doEvent(EventPrincipal const& ep, EventSetup const& c,

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -50,6 +50,8 @@ namespace edm {
     
     static bool wantsGlobalRuns() {return true;}
     static bool wantsGlobalLuminosityBlocks() {return true;}
+    static bool wantsStreamRuns() {return false;}
+    static bool wantsStreamLuminosityBlocks() {return false;};
 
   private:
     bool doEvent(EventPrincipal const& ep, EventSetup const& c,

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -47,6 +47,9 @@ namespace edm {
 
     // Warning: the returned moduleDescription will be invalid during construction
     ModuleDescription const& moduleDescription() const { return moduleDescription_; }
+    
+    static bool wantsGlobalRuns() {return true;}
+    static bool wantsGlobalLuminosityBlocks() {return true;}
 
   private:
     bool doEvent(EventPrincipal const& ep, EventSetup const& c,

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -83,6 +83,8 @@ namespace edm {
 
     static bool wantsGlobalRuns() {return true;}
     static bool wantsGlobalLuminosityBlocks() {return true;}
+    static bool wantsStreamRuns() {return false;}
+    static bool wantsStreamLuminosityBlocks() {return false;};
 
     bool wantAllEvents() const {return wantAllEvents_;}
 

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -81,6 +81,9 @@ namespace edm {
     static const std::string& baseType();
     static void prevalidate(ConfigurationDescriptions& );
 
+    static bool wantsGlobalRuns() {return true;}
+    static bool wantsGlobalLuminosityBlocks() {return true;}
+
     bool wantAllEvents() const {return wantAllEvents_;}
 
     BranchIDLists const* branchIDLists();

--- a/FWCore/Framework/interface/global/EDAnalyzer.h
+++ b/FWCore/Framework/interface/global/EDAnalyzer.h
@@ -42,7 +42,13 @@ namespace edm {
       virtual ~EDAnalyzer() {}
 #endif
       // ---------- const member functions ---------------------
-      
+      bool wantsGlobalRuns() const final {
+        return WantsGlobalRunTransitions<T...>::value;
+      }
+      bool wantsGlobalLuminosityBlocks() const final {
+        return WantsGlobalLuminosityBlockTransitions<T...>::value;
+      }
+
       // ---------- static member functions --------------------
       
       // ---------- member functions ---------------------------

--- a/FWCore/Framework/interface/global/EDAnalyzer.h
+++ b/FWCore/Framework/interface/global/EDAnalyzer.h
@@ -49,6 +49,13 @@ namespace edm {
         return WantsGlobalLuminosityBlockTransitions<T...>::value;
       }
 
+      bool wantsStreamRuns() const final {
+        return WantsStreamRunTransitions<T...>::value;
+      }
+      bool wantsStreamLuminosityBlocks() const final {
+        return WantsStreamLuminosityBlockTransitions<T...>::value;
+      }
+
       // ---------- static member functions --------------------
       
       // ---------- member functions ---------------------------

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -61,6 +61,9 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+      virtual bool wantsGlobalRuns() const =0;
+      virtual bool wantsGlobalLuminosityBlocks() const =0;
+
     private:
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -63,6 +63,8 @@ namespace edm {
 
       virtual bool wantsGlobalRuns() const =0;
       virtual bool wantsGlobalLuminosityBlocks() const =0;
+      virtual bool wantsStreamRuns() const =0;
+      virtual bool wantsStreamLuminosityBlocks() const =0;
 
     private:
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,

--- a/FWCore/Framework/interface/global/EDFilter.h
+++ b/FWCore/Framework/interface/global/EDFilter.h
@@ -46,7 +46,13 @@ namespace edm {
       virtual ~EDFilter() = default;
 #endif
       // ---------- const member functions ---------------------
-      
+      bool wantsGlobalRuns() const final {
+        return WantsGlobalRunTransitions<T...>::value;
+      }
+      bool wantsGlobalLuminosityBlocks() const final {
+        return WantsGlobalLuminosityBlockTransitions<T...>::value;
+      }
+
       // ---------- static member functions --------------------
       
       // ---------- member functions ---------------------------

--- a/FWCore/Framework/interface/global/EDFilter.h
+++ b/FWCore/Framework/interface/global/EDFilter.h
@@ -53,6 +53,13 @@ namespace edm {
         return WantsGlobalLuminosityBlockTransitions<T...>::value;
       }
 
+      bool wantsStreamRuns() const final {
+        return WantsStreamRunTransitions<T...>::value;
+      }
+      bool wantsStreamLuminosityBlocks() const final {
+        return WantsStreamLuminosityBlockTransitions<T...>::value;
+      }
+
       // ---------- static member functions --------------------
       
       // ---------- member functions ---------------------------

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -65,6 +65,8 @@ namespace edm {
 
       virtual bool wantsGlobalRuns() const =0;
       virtual bool wantsGlobalLuminosityBlocks() const =0;
+      virtual bool wantsStreamRuns() const =0;
+      virtual bool wantsStreamLuminosityBlocks() const =0;
 
     private:
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -63,6 +63,9 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+      virtual bool wantsGlobalRuns() const =0;
+      virtual bool wantsGlobalLuminosityBlocks() const =0;
+
     private:
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,

--- a/FWCore/Framework/interface/global/EDProducer.h
+++ b/FWCore/Framework/interface/global/EDProducer.h
@@ -40,7 +40,13 @@ namespace edm {
       EDProducer() = default;
       
       // ---------- const member functions ---------------------
-      
+      bool wantsGlobalRuns() const final {
+        return WantsGlobalRunTransitions<T...>::value;
+      }
+      bool wantsGlobalLuminosityBlocks() const final {
+        return WantsGlobalLuminosityBlockTransitions<T...>::value;
+      }
+
       // ---------- static member functions --------------------
       
       // ---------- member functions ---------------------------

--- a/FWCore/Framework/interface/global/EDProducer.h
+++ b/FWCore/Framework/interface/global/EDProducer.h
@@ -47,6 +47,13 @@ namespace edm {
         return WantsGlobalLuminosityBlockTransitions<T...>::value;
       }
 
+      bool wantsStreamRuns() const final {
+        return WantsStreamRunTransitions<T...>::value;
+      }
+      bool wantsStreamLuminosityBlocks() const final {
+        return WantsStreamLuminosityBlockTransitions<T...>::value;
+      }
+
       // ---------- static member functions --------------------
       
       // ---------- member functions ---------------------------

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -66,6 +66,9 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+      virtual bool wantsGlobalRuns() const =0;
+      virtual bool wantsGlobalLuminosityBlocks() const =0;
+
     private:
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -68,6 +68,8 @@ namespace edm {
 
       virtual bool wantsGlobalRuns() const =0;
       virtual bool wantsGlobalLuminosityBlocks() const =0;
+      virtual bool wantsStreamRuns() const =0;
+      virtual bool wantsStreamLuminosityBlocks() const =0;
 
     private:
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,

--- a/FWCore/Framework/interface/global/OutputModule.h
+++ b/FWCore/Framework/interface/global/OutputModule.h
@@ -42,6 +42,12 @@ namespace edm {
 #endif
       
       // ---------- const member functions ---------------------
+      bool wantsStreamRuns() const final {
+        return WantsStreamRunTransitions<T...>::value;
+      }
+      bool wantsStreamLuminosityBlocks() const final {
+        return WantsStreamLuminosityBlockTransitions<T...>::value;
+      }
       
       // ---------- static member functions --------------------
       

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -100,6 +100,11 @@ namespace edm {
       const ModuleDescription& moduleDescription() const {
         return moduleDescription_;
       }
+      
+      //Output modules always need writeRun and writeLumi to be called
+      bool wantsGlobalRuns() const {return true;}
+      bool wantsGlobalLuminosityBlocks() const {return true;}
+
     protected:
       
       ModuleDescription const& description() const;

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -92,7 +92,7 @@ namespace edm {
       static void prevalidate(ConfigurationDescriptions& );
       
       bool wantAllEvents() const {return wantAllEvents_;}
-      
+
       BranchIDLists const* branchIDLists();
 
       ThinnedAssociationsHelper const* thinnedAssociationsHelper() const;
@@ -104,6 +104,9 @@ namespace edm {
       //Output modules always need writeRun and writeLumi to be called
       bool wantsGlobalRuns() const {return true;}
       bool wantsGlobalLuminosityBlocks() const {return true;}
+
+      virtual bool wantsStreamRuns() const =0;
+      virtual bool wantsStreamLuminosityBlocks() const =0;
 
     protected:
       

--- a/FWCore/Framework/interface/limited/EDAnalyzer.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzer.h
@@ -42,7 +42,13 @@ namespace edm {
       virtual ~EDAnalyzer() {}
 #endif
       // ---------- const member functions ---------------------
-      
+      bool wantsGlobalRuns() const final {
+        return WantsGlobalRunTransitions<T...>::value;
+      }
+      bool wantsGlobalLuminosityBlocks() const final {
+        return WantsGlobalLuminosityBlockTransitions<T...>::value;
+      }
+
       // ---------- static member functions --------------------
       
       // ---------- member functions ---------------------------

--- a/FWCore/Framework/interface/limited/EDAnalyzer.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzer.h
@@ -48,6 +48,12 @@ namespace edm {
       bool wantsGlobalLuminosityBlocks() const final {
         return WantsGlobalLuminosityBlockTransitions<T...>::value;
       }
+      bool wantsStreamRuns() const final {
+        return WantsStreamRunTransitions<T...>::value;
+      }
+      bool wantsStreamLuminosityBlocks() const final {
+        return WantsStreamLuminosityBlockTransitions<T...>::value;
+      }
 
       // ---------- static member functions --------------------
       

--- a/FWCore/Framework/interface/limited/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzerBase.h
@@ -64,6 +64,8 @@ namespace edm {
       
       virtual bool wantsGlobalRuns() const =0;
       virtual bool wantsGlobalLuminosityBlocks() const =0;
+      virtual bool wantsStreamRuns() const =0;
+      virtual bool wantsStreamLuminosityBlocks() const =0;
 
       unsigned int concurrencyLimit() const { return queue_.concurrencyLimit(); }
 

--- a/FWCore/Framework/interface/limited/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzerBase.h
@@ -62,6 +62,9 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
       
+      virtual bool wantsGlobalRuns() const =0;
+      virtual bool wantsGlobalLuminosityBlocks() const =0;
+
       unsigned int concurrencyLimit() const { return queue_.concurrencyLimit(); }
 
       LimitedTaskQueue& queue() {

--- a/FWCore/Framework/interface/limited/EDFilter.h
+++ b/FWCore/Framework/interface/limited/EDFilter.h
@@ -57,6 +57,12 @@ namespace edm {
       bool wantsGlobalLuminosityBlocks() const final {
         return WantsGlobalLuminosityBlockTransitions<T...>::value;
       }
+      bool wantsStreamRuns() const final {
+        return WantsStreamRunTransitions<T...>::value;
+      }
+      bool wantsStreamLuminosityBlocks() const final {
+        return WantsStreamLuminosityBlockTransitions<T...>::value;
+      }
 
       // ---------- static member functions --------------------
       

--- a/FWCore/Framework/interface/limited/EDFilter.h
+++ b/FWCore/Framework/interface/limited/EDFilter.h
@@ -51,7 +51,13 @@ namespace edm {
       virtual ~EDFilter() = default;
 #endif
       // ---------- const member functions ---------------------
-      
+      bool wantsGlobalRuns() const final {
+        return WantsGlobalRunTransitions<T...>::value;
+      }
+      bool wantsGlobalLuminosityBlocks() const final {
+        return WantsGlobalLuminosityBlockTransitions<T...>::value;
+      }
+
       // ---------- static member functions --------------------
       
       // ---------- member functions ---------------------------

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -64,6 +64,9 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+      virtual bool wantsGlobalRuns() const =0;
+      virtual bool wantsGlobalLuminosityBlocks() const =0;
+
       unsigned int concurrencyLimit() const { return queue_.concurrencyLimit(); }
 
       LimitedTaskQueue& queue() {

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -66,6 +66,8 @@ namespace edm {
 
       virtual bool wantsGlobalRuns() const =0;
       virtual bool wantsGlobalLuminosityBlocks() const =0;
+      virtual bool wantsStreamRuns() const =0;
+      virtual bool wantsStreamLuminosityBlocks() const =0;
 
       unsigned int concurrencyLimit() const { return queue_.concurrencyLimit(); }
 

--- a/FWCore/Framework/interface/limited/EDProducer.h
+++ b/FWCore/Framework/interface/limited/EDProducer.h
@@ -44,7 +44,13 @@ namespace edm {
       T>::Type(iPSet)... {}
       
       // ---------- const member functions ---------------------
-      
+      bool wantsGlobalRuns() const final {
+        return WantsGlobalRunTransitions<T...>::value;
+      }
+      bool wantsGlobalLuminosityBlocks() const final {
+        return WantsGlobalLuminosityBlockTransitions<T...>::value;
+      }
+
       // ---------- static member functions --------------------
       
       // ---------- member functions ---------------------------

--- a/FWCore/Framework/interface/limited/EDProducer.h
+++ b/FWCore/Framework/interface/limited/EDProducer.h
@@ -50,6 +50,12 @@ namespace edm {
       bool wantsGlobalLuminosityBlocks() const final {
         return WantsGlobalLuminosityBlockTransitions<T...>::value;
       }
+      bool wantsStreamRuns() const final {
+        return WantsStreamRunTransitions<T...>::value;
+      }
+      bool wantsStreamLuminosityBlocks() const final {
+        return WantsStreamLuminosityBlockTransitions<T...>::value;
+      }
 
       // ---------- static member functions --------------------
       

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -69,6 +69,8 @@ namespace edm {
       
       virtual bool wantsGlobalRuns() const =0;
       virtual bool wantsGlobalLuminosityBlocks() const =0;
+      virtual bool wantsStreamRuns() const =0;
+      virtual bool wantsStreamLuminosityBlocks() const =0;
 
       unsigned int concurrencyLimit() const { return queue_.concurrencyLimit(); }
 

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -67,6 +67,9 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
       
+      virtual bool wantsGlobalRuns() const =0;
+      virtual bool wantsGlobalLuminosityBlocks() const =0;
+
       unsigned int concurrencyLimit() const { return queue_.concurrencyLimit(); }
 
       LimitedTaskQueue& queue() {

--- a/FWCore/Framework/interface/limited/OutputModule.h
+++ b/FWCore/Framework/interface/limited/OutputModule.h
@@ -42,7 +42,13 @@ namespace edm {
 #endif
       
       // ---------- const member functions ---------------------
-      
+      bool wantsStreamRuns() const final {
+        return WantsStreamRunTransitions<T...>::value;
+      }
+      bool wantsStreamLuminosityBlocks() const final {
+        return WantsStreamLuminosityBlockTransitions<T...>::value;
+      }
+
       // ---------- static member functions --------------------
       
       // ---------- member functions ---------------------------

--- a/FWCore/Framework/interface/limited/OutputModuleBase.h
+++ b/FWCore/Framework/interface/limited/OutputModuleBase.h
@@ -102,6 +102,10 @@ namespace edm {
         return moduleDescription_;
       }
       
+      //Output modules always need writeRun and writeLumi to be called
+      bool wantsGlobalRuns() const {return true;}
+      bool wantsGlobalLuminosityBlocks() const {return true;}
+
       unsigned int concurrencyLimit() const { return queue_.concurrencyLimit(); }
 
       LimitedTaskQueue& queue() {

--- a/FWCore/Framework/interface/limited/OutputModuleBase.h
+++ b/FWCore/Framework/interface/limited/OutputModuleBase.h
@@ -105,6 +105,8 @@ namespace edm {
       //Output modules always need writeRun and writeLumi to be called
       bool wantsGlobalRuns() const {return true;}
       bool wantsGlobalLuminosityBlocks() const {return true;}
+      virtual bool wantsStreamRuns() const =0;
+      virtual bool wantsStreamLuminosityBlocks() const =0;
 
       unsigned int concurrencyLimit() const { return queue_.concurrencyLimit(); }
 

--- a/FWCore/Framework/interface/moduleAbilities.h
+++ b/FWCore/Framework/interface/moduleAbilities.h
@@ -111,6 +111,22 @@ namespace edm {
     typedef edm::module::Empty Type;
   };
 
+  template<typename... VArgs>
+  struct WantsGlobalRunTransitions {
+    static constexpr bool value = CheckAbility<module::Abilities::kRunCache,VArgs...>::kHasIt or
+    CheckAbility<module::Abilities::kRunSummaryCache,VArgs...>::kHasIt or
+    CheckAbility<module::Abilities::kBeginRunProducer,VArgs...>::kHasIt or
+    CheckAbility<module::Abilities::kEndRunProducer, VArgs...>::kHasIt;
+  };
+  
+  template<typename... VArgs>
+  struct WantsGlobalLuminosityBlockTransitions {
+    static constexpr bool value = CheckAbility<module::Abilities::kLuminosityBlockCache,VArgs...>::kHasIt or
+    CheckAbility<module::Abilities::kLuminosityBlockSummaryCache,VArgs...>::kHasIt or
+    CheckAbility<module::Abilities::kBeginLuminosityBlockProducer,VArgs...>::kHasIt or
+    CheckAbility<module::Abilities::kEndLuminosityBlockProducer, VArgs...>::kHasIt;
+  };
+
 }
 
 #endif

--- a/FWCore/Framework/interface/moduleAbilities.h
+++ b/FWCore/Framework/interface/moduleAbilities.h
@@ -127,6 +127,18 @@ namespace edm {
     CheckAbility<module::Abilities::kEndLuminosityBlockProducer, VArgs...>::kHasIt;
   };
 
+  template<typename... VArgs>
+  struct WantsStreamRunTransitions {
+    static constexpr bool value = CheckAbility<module::Abilities::kStreamCache,VArgs...>::kHasIt or
+    CheckAbility<module::Abilities::kRunSummaryCache,VArgs...>::kHasIt ;
+  };
+  
+  template<typename... VArgs>
+  struct WantsStreamLuminosityBlockTransitions {
+    static constexpr bool value = CheckAbility<module::Abilities::kStreamCache,VArgs...>::kHasIt or
+    CheckAbility<module::Abilities::kLuminosityBlockSummaryCache,VArgs...>::kHasIt;
+  };
+
 }
 
 #endif

--- a/FWCore/Framework/interface/one/EDAnalyzer.h
+++ b/FWCore/Framework/interface/one/EDAnalyzer.h
@@ -36,7 +36,13 @@ namespace edm {
 #endif
       
       // ---------- const member functions ---------------------
-      
+      bool wantsGlobalRuns() const final {
+        return WantsGlobalRunTransitions<T...>::value;
+      }
+      bool wantsGlobalLuminosityBlocks() const final {
+        return WantsGlobalLuminosityBlockTransitions<T...>::value;
+      }
+
       // ---------- static member functions --------------------
       
       // ---------- member functions ---------------------------

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -65,6 +65,8 @@ namespace edm {
 
       virtual bool wantsGlobalRuns() const =0;
       virtual bool wantsGlobalLuminosityBlocks() const =0;
+      bool wantsStreamRuns() const {return false;}
+      bool wantsStreamLuminosityBlocks() const {return false;};
 
       void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func);
 

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -63,6 +63,9 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+      virtual bool wantsGlobalRuns() const =0;
+      virtual bool wantsGlobalLuminosityBlocks() const =0;
+
       void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func);
 
     private:

--- a/FWCore/Framework/interface/one/EDFilter.h
+++ b/FWCore/Framework/interface/one/EDFilter.h
@@ -35,7 +35,13 @@ namespace edm {
       //virtual ~EDFilter();
       
       // ---------- const member functions ---------------------
-      
+      bool wantsGlobalRuns() const final {
+        return WantsGlobalRunTransitions<T...>::value;
+      }
+      bool wantsGlobalLuminosityBlocks() const final {
+        return WantsGlobalLuminosityBlockTransitions<T...>::value;
+      }
+
       // ---------- static member functions --------------------
       
       // ---------- member functions ---------------------------

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -63,6 +63,9 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+      virtual bool wantsGlobalRuns() const =0;
+      virtual bool wantsGlobalLuminosityBlocks() const =0;
+
     private:
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -65,6 +65,8 @@ namespace edm {
 
       virtual bool wantsGlobalRuns() const =0;
       virtual bool wantsGlobalLuminosityBlocks() const =0;
+      bool wantsStreamRuns() const {return false;}
+      bool wantsStreamLuminosityBlocks() const {return false;};
 
     private:
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,

--- a/FWCore/Framework/interface/one/EDProducer.h
+++ b/FWCore/Framework/interface/one/EDProducer.h
@@ -37,7 +37,13 @@ namespace edm {
       //
       
       // ---------- const member functions ---------------------
-      
+      bool wantsGlobalRuns() const final {
+        return WantsGlobalRunTransitions<T...>::value;
+      }
+      bool wantsGlobalLuminosityBlocks() const final {
+        return WantsGlobalLuminosityBlockTransitions<T...>::value;
+      }
+
       // ---------- static member functions --------------------
       
       // ---------- member functions ---------------------------

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -63,6 +63,9 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
+      virtual bool wantsGlobalRuns() const =0;
+      virtual bool wantsGlobalLuminosityBlocks() const =0;
+
     private:
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -65,6 +65,8 @@ namespace edm {
 
       virtual bool wantsGlobalRuns() const =0;
       virtual bool wantsGlobalLuminosityBlocks() const =0;
+      bool wantsStreamRuns() const {return false;}
+      bool wantsStreamLuminosityBlocks() const {return false;};
 
     private:
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -97,6 +97,8 @@ namespace edm {
       //Output modules always need writeRun and writeLumi to be called
       bool wantsGlobalRuns() const {return true;}
       bool wantsGlobalLuminosityBlocks() const {return true;}
+      bool wantsStreamRuns() const {return false;}
+      bool wantsStreamLuminosityBlocks() const {return false;};
 
       bool wantAllEvents() const {return wantAllEvents_;}
       

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -94,6 +94,10 @@ namespace edm {
       static const std::string& baseType();
       static void prevalidate(ConfigurationDescriptions& );
       
+      //Output modules always need writeRun and writeLumi to be called
+      bool wantsGlobalRuns() const {return true;}
+      bool wantsGlobalLuminosityBlocks() const {return true;}
+
       bool wantAllEvents() const {return wantAllEvents_;}
       
       BranchIDLists const* branchIDLists();

--- a/FWCore/Framework/interface/one/implementors.h
+++ b/FWCore/Framework/interface/one/implementors.h
@@ -60,8 +60,6 @@ namespace edm {
             RunWatcher& operator=(RunWatcher const&) = delete;
             ~RunWatcher() noexcept(false) override {};
             
-            bool wantsGlobalRuns() const override {return true;}
-
          private:
             void doBeginRun_(Run const& rp, EventSetup const& c) final;
             void doEndRun_(Run const& rp, EventSetup const& c) final;
@@ -79,8 +77,6 @@ namespace edm {
             LuminosityBlockWatcher& operator=(LuminosityBlockWatcher const&) = delete;
             ~LuminosityBlockWatcher() noexcept(false) override {};
             
-            bool wantsGlobalLuminosityBlocks() const override {return true;}
-
          private:
             void doBeginLuminosityBlock_(LuminosityBlock const& rp, EventSetup const& c) final;
             void doEndLuminosityBlock_(LuminosityBlock const& rp, EventSetup const& c) final;
@@ -97,7 +93,6 @@ namespace edm {
             BeginRunProducer& operator=(BeginRunProducer const&) = delete;
             ~BeginRunProducer() noexcept(false) override {};
             
-            bool wantsGlobalRuns() const override {return true;}
          private:
             void doBeginRunProduce_(Run& rp, EventSetup const& c) final;
 
@@ -112,8 +107,6 @@ namespace edm {
             EndRunProducer& operator=(EndRunProducer const&) = delete;
             ~EndRunProducer() noexcept(false) override {};
             
-            bool wantsGlobalRuns() const override {return true;}
-
          private:
             
             void doEndRunProduce_(Run& rp, EventSetup const& c) final;
@@ -129,8 +122,6 @@ namespace edm {
             BeginLuminosityBlockProducer& operator=(BeginLuminosityBlockProducer const&) = delete;
             ~BeginLuminosityBlockProducer() noexcept(false) override {};
 
-            bool wantsGlobalLuminosityBlocks() const override {return true;}
-
          private:
             void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) final;
 
@@ -145,8 +136,6 @@ namespace edm {
             EndLuminosityBlockProducer& operator=(EndLuminosityBlockProducer const&) = delete;
             ~EndLuminosityBlockProducer() noexcept(false) override {};
             
-            bool wantsGlobalLuminosityBlocks() const override {return true;}
-
          private:
             void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) final;
 

--- a/FWCore/Framework/interface/one/implementors.h
+++ b/FWCore/Framework/interface/one/implementors.h
@@ -60,6 +60,8 @@ namespace edm {
             RunWatcher& operator=(RunWatcher const&) = delete;
             ~RunWatcher() noexcept(false) override {};
             
+            bool wantsGlobalRuns() const override {return true;}
+
          private:
             void doBeginRun_(Run const& rp, EventSetup const& c) final;
             void doEndRun_(Run const& rp, EventSetup const& c) final;
@@ -77,6 +79,8 @@ namespace edm {
             LuminosityBlockWatcher& operator=(LuminosityBlockWatcher const&) = delete;
             ~LuminosityBlockWatcher() noexcept(false) override {};
             
+            bool wantsGlobalLuminosityBlocks() const override {return true;}
+
          private:
             void doBeginLuminosityBlock_(LuminosityBlock const& rp, EventSetup const& c) final;
             void doEndLuminosityBlock_(LuminosityBlock const& rp, EventSetup const& c) final;
@@ -93,6 +97,7 @@ namespace edm {
             BeginRunProducer& operator=(BeginRunProducer const&) = delete;
             ~BeginRunProducer() noexcept(false) override {};
             
+            bool wantsGlobalRuns() const override {return true;}
          private:
             void doBeginRunProduce_(Run& rp, EventSetup const& c) final;
 
@@ -107,6 +112,8 @@ namespace edm {
             EndRunProducer& operator=(EndRunProducer const&) = delete;
             ~EndRunProducer() noexcept(false) override {};
             
+            bool wantsGlobalRuns() const override {return true;}
+
          private:
             
             void doEndRunProduce_(Run& rp, EventSetup const& c) final;
@@ -121,7 +128,9 @@ namespace edm {
             BeginLuminosityBlockProducer( BeginLuminosityBlockProducer const&) = delete;
             BeginLuminosityBlockProducer& operator=(BeginLuminosityBlockProducer const&) = delete;
             ~BeginLuminosityBlockProducer() noexcept(false) override {};
-            
+
+            bool wantsGlobalLuminosityBlocks() const override {return true;}
+
          private:
             void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) final;
 
@@ -136,6 +145,8 @@ namespace edm {
             EndLuminosityBlockProducer& operator=(EndLuminosityBlockProducer const&) = delete;
             ~EndLuminosityBlockProducer() noexcept(false) override {};
             
+            bool wantsGlobalLuminosityBlocks() const override {return true;}
+
          private:
             void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) final;
 

--- a/FWCore/Framework/interface/one/moduleAbilities.h
+++ b/FWCore/Framework/interface/one/moduleAbilities.h
@@ -41,6 +41,21 @@ namespace edm {
       static constexpr module::Abilities kAbilities=module::Abilities::kOneWatchLuminosityBlocks;
       typedef module::Empty Type;
     };
+    
+    template<typename... VArgs>
+    struct WantsGlobalRunTransitions {
+      static constexpr bool value = CheckAbility<module::Abilities::kOneWatchRuns,VArgs...>::kHasIt or
+      CheckAbility<module::Abilities::kBeginRunProducer,VArgs...>::kHasIt or
+      CheckAbility<module::Abilities::kEndRunProducer, VArgs...>::kHasIt;
+    };
+    
+    template<typename... VArgs>
+    struct WantsGlobalLuminosityBlockTransitions {
+      static constexpr bool value = CheckAbility<module::Abilities::kOneWatchLuminosityBlocks,VArgs...>::kHasIt or
+      CheckAbility<module::Abilities::kBeginLuminosityBlockProducer,VArgs...>::kHasIt or
+      CheckAbility<module::Abilities::kEndLuminosityBlockProducer, VArgs...>::kHasIt;
+    };
+
   }
 }
 

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
@@ -68,7 +68,10 @@ namespace edm {
         T::prevalidate(descriptions);
       }
 
-      
+      bool wantsGlobalRuns() const final {
+        return T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache; }
+      bool wantsGlobalLuminosityBlocks() const final {return T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache;}
+
     private:
       typedef CallGlobal<T> MyGlobal;
       typedef CallGlobalRun<T> MyGlobalRun;

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -74,7 +74,9 @@ namespace edm {
       
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
-        
+      bool wantsStreamRuns() const {return true;}
+      bool wantsStreamLuminosityBlocks() const {return true;}
+
       std::string workerType() const { return "WorkerT<EDAnalyzerAdaptorBase>";}
       void
       registerProductsAndCallbacks(EDAnalyzerAdaptorBase const*, ProductRegistry* reg);

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -72,6 +72,9 @@ namespace edm {
       // ---------- member functions ---------------------------
       const ModuleDescription& moduleDescription() const { return moduleDescription_;}
       
+      virtual bool wantsGlobalRuns() const = 0;
+      virtual bool wantsGlobalLuminosityBlocks() const = 0;
+        
       std::string workerType() const { return "WorkerT<EDAnalyzerAdaptorBase>";}
       void
       registerProductsAndCallbacks(EDAnalyzerAdaptorBase const*, ProductRegistry* reg);

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
@@ -59,6 +59,16 @@ namespace edm {
         T::prevalidate(descriptions);
       }
 
+      bool wantsGlobalRuns() const final {
+        return T::HasAbility::kRunCache or
+        T::HasAbility::kRunSummaryCache or
+        T::HasAbility::kBeginRunProducer or
+        T::HasAbility::kEndRunProducer; }
+      bool wantsGlobalLuminosityBlocks() const final {return T::HasAbility::kLuminosityBlockCache or
+        T::HasAbility::kLuminosityBlockSummaryCache or
+        T::HasAbility::kBeginLuminosityBlockProducer or
+        T::HasAbility::kEndLuminosityBlockProducer;}
+
       
     private:
       typedef CallGlobal<T> MyGlobal;

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -73,6 +73,9 @@ namespace edm {
       // ---------- member functions ---------------------------
       const ModuleDescription& moduleDescription() const { return moduleDescription_;}
       
+      virtual bool wantsGlobalRuns() const = 0;
+      virtual bool wantsGlobalLuminosityBlocks() const = 0;
+
       void
       registerProductsAndCallbacks(ProducingModuleAdaptorBase const*, ProductRegistry* reg);
       

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -75,6 +75,8 @@ namespace edm {
       
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
+      bool wantsStreamRuns() const {return true;}
+      bool wantsStreamLuminosityBlocks() const {return true;}
 
       void
       registerProductsAndCallbacks(ProducingModuleAdaptorBase const*, ProductRegistry* reg);

--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -148,14 +148,6 @@ namespace edm {
       GlobalContext const* context_;
     };
 
-    static bool shouldRunWorker(Worker const* iWorker, RunPrincipal const*) {
-      return iWorker->wantsGlobalRuns();
-    }
-
-    static bool shouldRunWorker(Worker const* iWorker, LuminosityBlockPrincipal const*) {
-      return iWorker->wantsGlobalLuminosityBlocks();
-    }
-
     /// returns the action table
     ExceptionToActionTable const& actionTable() const {
       return workerManager_.actionTable();
@@ -242,9 +234,7 @@ namespace edm {
     //make sure the task doesn't get run until all workers have beens started
     WaitingTaskHolder holdForLoop(doneTask);
     for(auto& worker: boost::adaptors::reverse((allWorkers()))) {
-      if(shouldRunWorker(worker, static_cast<typename T::MyPrincipal const*>(nullptr))) {
-        worker->doWorkAsync<T>(doneTask,ep,es,StreamID::invalidStreamID(),parentContext,globalContext.get());
-      }
+      worker->doWorkAsync<T>(doneTask,ep,es,StreamID::invalidStreamID(),parentContext,globalContext.get());
     }
 
   }

--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -148,7 +148,14 @@ namespace edm {
       GlobalContext const* context_;
     };
 
-    
+    static bool shouldRunWorker(Worker const* iWorker, RunPrincipal const*) {
+      return iWorker->wantsGlobalRuns();
+    }
+
+    static bool shouldRunWorker(Worker const* iWorker, LuminosityBlockPrincipal const*) {
+      return iWorker->wantsGlobalLuminosityBlocks();
+    }
+
     /// returns the action table
     ExceptionToActionTable const& actionTable() const {
       return workerManager_.actionTable();
@@ -235,7 +242,9 @@ namespace edm {
     //make sure the task doesn't get run until all workers have beens started
     WaitingTaskHolder holdForLoop(doneTask);
     for(auto& worker: boost::adaptors::reverse((allWorkers()))) {
-      worker->doWorkAsync<T>(doneTask,ep,es,StreamID::invalidStreamID(),parentContext,globalContext.get());
+      if(shouldRunWorker(worker, static_cast<typename T::MyPrincipal const*>(nullptr))) {
+        worker->doWorkAsync<T>(doneTask,ep,es,StreamID::invalidStreamID(),parentContext,globalContext.get());
+      }
     }
 
   }

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -687,6 +687,10 @@ namespace edm {
                            StreamID streamID,
                            ParentContext const& parentContext,
                            typename T::Context const* context) {
+    if (not workerhelper::CallImpl<T>::wantsTransition(this)) {
+      return;
+    }
+
     waitingTasks_.add(task);
     if(T::isEvent_) {
       timesVisited_.fetch_add(1,std::memory_order_relaxed);

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -114,6 +114,9 @@ namespace edm {
     Worker(Worker const&) = delete; // Disallow copying and moving
     Worker& operator=(Worker const&) = delete; // Disallow copying and moving
 
+    virtual bool wantsGlobalRuns() const = 0;
+    virtual bool wantsGlobalLuminosityBlocks() const = 0;
+    
     template <typename T>
     bool doWork(typename T::MyPrincipal const&, EventSetup const& c,
                 StreamID stream,

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -139,6 +139,16 @@ namespace edm{
   }
 
   template<typename T>
+  bool WorkerT<T>::wantsStreamRuns() const {
+    return module_->wantsStreamRuns();
+  }
+  
+  template<typename T>
+  bool WorkerT<T>::wantsStreamLuminosityBlocks() const {
+    return module_->wantsStreamLuminosityBlocks();
+  }
+
+  template<typename T>
   inline
   bool
   WorkerT<T>::implDo(EventPrincipal const& ep, EventSetup const& c, ModuleCallingContext const* mcc) {

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -127,6 +127,17 @@ namespace edm{
   WorkerT<T>::~WorkerT() {
   }
 
+  
+  template<typename T>
+  bool WorkerT<T>::wantsGlobalRuns() const {
+    return module_->wantsGlobalRuns();
+  }
+  
+  template<typename T>
+  bool WorkerT<T>::wantsGlobalLuminosityBlocks() const {
+    return module_->wantsGlobalLuminosityBlocks();
+  }
+
   template<typename T>
   inline
   bool

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -43,6 +43,9 @@ namespace edm {
     }
     
     Types moduleType() const override;
+    
+    virtual bool wantsGlobalRuns() const final;
+    virtual bool wantsGlobalLuminosityBlocks() const final;
 
     void updateLookup(BranchType iBranchType,
                               ProductResolverIndexHelper const&) override;

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -44,8 +44,11 @@ namespace edm {
     
     Types moduleType() const override;
     
-    virtual bool wantsGlobalRuns() const final;
-    virtual bool wantsGlobalLuminosityBlocks() const final;
+    bool wantsGlobalRuns() const final;
+    bool wantsGlobalLuminosityBlocks() const final;
+    bool wantsStreamRuns() const final;
+    bool wantsStreamLuminosityBlocks() const final;
+
 
     void updateLookup(BranchType iBranchType,
                               ProductResolverIndexHelper const&) override;

--- a/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
@@ -74,42 +74,8 @@ ModuleCallingContext state = Running
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1000000
-++++++ starting: global begin run for module: label = 'one' id = 4
-GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-    GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-
-++++++ finished: global begin run for module: label = 'one' id = 4
-GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-    GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-
-++++++ starting: global begin run for module: label = 'result1' id = 5
-++++++ finished: global begin run for module: label = 'result1' id = 5
-++++++ starting: global begin run for module: label = 'result2' id = 6
-++++++ finished: global begin run for module: label = 'result2' id = 6
-++++++ starting: global begin run for module: label = 'result4' id = 7
-++++++ finished: global begin run for module: label = 'result4' id = 7
 ++++++ starting: global begin run for module: label = 'get' id = 3
 ++++++ finished: global begin run for module: label = 'get' id = 3
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin run for module: label = 'p' id = 2
-++++++ finished: global begin run for module: label = 'p' id = 2
 ++++ finished: global begin run 1 : time = 1000000
 ++++ starting: begin run: stream = 0 run = 1 time = 1000000
 ++++++ starting: begin run for module: stream = 0 label = 'result4' id = 7
@@ -148,42 +114,8 @@ ModuleCallingContext state = Running
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1000000
-++++++ starting: global begin lumi for module: label = 'one' id = 4
-GlobalContext: transition = BeginLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-    GlobalContext: transition = BeginLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-
-++++++ finished: global begin lumi for module: label = 'one' id = 4
-GlobalContext: transition = BeginLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-    GlobalContext: transition = BeginLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-
-++++++ starting: global begin lumi for module: label = 'result1' id = 5
-++++++ finished: global begin lumi for module: label = 'result1' id = 5
-++++++ starting: global begin lumi for module: label = 'result2' id = 6
-++++++ finished: global begin lumi for module: label = 'result2' id = 6
-++++++ starting: global begin lumi for module: label = 'result4' id = 7
-++++++ finished: global begin lumi for module: label = 'result4' id = 7
 ++++++ starting: global begin lumi for module: label = 'get' id = 3
 ++++++ finished: global begin lumi for module: label = 'get' id = 3
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin lumi for module: label = 'p' id = 2
-++++++ finished: global begin lumi for module: label = 'p' id = 2
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
 ++++++ starting: begin lumi for module: stream = 0 label = 'result4' id = 7
@@ -602,42 +534,8 @@ ModuleCallingContext state = Running
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1000000
-++++++ starting: global end lumi for module: label = 'one' id = 4
-GlobalContext: transition = EndLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-    GlobalContext: transition = EndLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-
-++++++ finished: global end lumi for module: label = 'one' id = 4
-GlobalContext: transition = EndLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-    GlobalContext: transition = EndLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-
-++++++ starting: global end lumi for module: label = 'result1' id = 5
-++++++ finished: global end lumi for module: label = 'result1' id = 5
-++++++ starting: global end lumi for module: label = 'result2' id = 6
-++++++ finished: global end lumi for module: label = 'result2' id = 6
-++++++ starting: global end lumi for module: label = 'result4' id = 7
-++++++ finished: global end lumi for module: label = 'result4' id = 7
 ++++++ starting: global end lumi for module: label = 'get' id = 3
 ++++++ finished: global end lumi for module: label = 'get' id = 3
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global end lumi for module: label = 'p' id = 2
-++++++ finished: global end lumi for module: label = 'p' id = 2
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: end run: stream = 0 run = 1 time = 1000030
 ++++++ starting: end run for module: stream = 0 label = 'result4' id = 7
@@ -674,42 +572,8 @@ ModuleCallingContext state = Running
 ++++++ finished: end run for module: stream = 0 label = 'get' id = 3
 ++++ finished: end run: stream = 0 run = 1 time = 1000030
 ++++ starting: global end run 1 : time = 1000030
-++++++ starting: global end run for module: label = 'one' id = 4
-GlobalContext: transition = EndRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
-    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-    GlobalContext: transition = EndRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
-    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-
-++++++ finished: global end run for module: label = 'one' id = 4
-GlobalContext: transition = EndRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
-    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-    GlobalContext: transition = EndRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
-    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-
-++++++ starting: global end run for module: label = 'result1' id = 5
-++++++ finished: global end run for module: label = 'result1' id = 5
-++++++ starting: global end run for module: label = 'result2' id = 6
-++++++ finished: global end run for module: label = 'result2' id = 6
-++++++ starting: global end run for module: label = 'result4' id = 7
-++++++ finished: global end run for module: label = 'result4' id = 7
 ++++++ starting: global end run for module: label = 'get' id = 3
 ++++++ finished: global end run for module: label = 'get' id = 3
-++++++ starting: global end run for module: label = 'TriggerResults' id = 1
-++++++ finished: global end run for module: label = 'TriggerResults' id = 1
-++++++ starting: global end run for module: label = 'p' id = 2
-++++++ finished: global end run for module: label = 'p' id = 2
 ++++ finished: global end run 1 : time = 1000030
 ++++ starting: end stream for module: stream = 0 label = 'get' id = 3
 ++++ finished: end stream for module: stream = 0 label = 'get' id = 3

--- a/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
@@ -78,12 +78,6 @@ ModuleCallingContext state = Running
 ++++++ finished: global begin run for module: label = 'get' id = 3
 ++++ finished: global begin run 1 : time = 1000000
 ++++ starting: begin run: stream = 0 run = 1 time = 1000000
-++++++ starting: begin run for module: stream = 0 label = 'result4' id = 7
-++++++ finished: begin run for module: stream = 0 label = 'result4' id = 7
-++++++ starting: begin run for module: stream = 0 label = 'result2' id = 6
-++++++ finished: begin run for module: stream = 0 label = 'result2' id = 6
-++++++ starting: begin run for module: stream = 0 label = 'result1' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'result1' id = 5
 ++++++ starting: begin run for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -108,8 +102,6 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 3
 ++++ finished: begin run: stream = 0 run = 1 time = 1000000
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -118,12 +110,6 @@ ModuleCallingContext state = Running
 ++++++ finished: global begin lumi for module: label = 'get' id = 3
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
-++++++ starting: begin lumi for module: stream = 0 label = 'result4' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'result4' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'result2' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'result2' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'result1' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'result1' id = 5
 ++++++ starting: begin lumi for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -148,8 +134,6 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
 ++++ starting: source event
 ++++ finished: source event
@@ -500,12 +484,6 @@ ModuleCallingContext state = Running
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 1000030
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
-++++++ starting: end lumi for module: stream = 0 label = 'result4' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'result4' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'result2' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'result2' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'result1' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'result1' id = 5
 ++++++ starting: end lumi for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -530,20 +508,12 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++++ starting: global end lumi for module: label = 'get' id = 3
 ++++++ finished: global end lumi for module: label = 'get' id = 3
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: end run: stream = 0 run = 1 time = 1000030
-++++++ starting: end run for module: stream = 0 label = 'result4' id = 7
-++++++ finished: end run for module: stream = 0 label = 'result4' id = 7
-++++++ starting: end run for module: stream = 0 label = 'result2' id = 6
-++++++ finished: end run for module: stream = 0 label = 'result2' id = 6
-++++++ starting: end run for module: stream = 0 label = 'result1' id = 5
-++++++ finished: end run for module: stream = 0 label = 'result1' id = 5
 ++++++ starting: end run for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
@@ -568,8 +538,6 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: end run for module: stream = 0 label = 'get' id = 3
-++++++ finished: end run for module: stream = 0 label = 'get' id = 3
 ++++ finished: end run: stream = 0 run = 1 time = 1000030
 ++++ starting: global end run 1 : time = 1000030
 ++++++ starting: global end run for module: label = 'get' id = 3

--- a/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
@@ -42,18 +42,10 @@
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1000000
-++++++ starting: global begin run for module: label = 'one' id = 3
-++++++ finished: global begin run for module: label = 'one' id = 3
 ++++++ starting: global begin run for module: label = 'getOne' id = 4
 ++++++ finished: global begin run for module: label = 'getOne' id = 4
-++++++ starting: global begin run for module: label = 'two' id = 5
-++++++ finished: global begin run for module: label = 'two' id = 5
 ++++++ starting: global begin run for module: label = 'getTwo' id = 6
 ++++++ finished: global begin run for module: label = 'getTwo' id = 6
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin run for module: label = 'p' id = 2
-++++++ finished: global begin run for module: label = 'p' id = 2
 ++++ finished: global begin run 1 : time = 1000000
 ++++ starting: begin run: stream = 0 run = 1 time = 1000000
 ++++++ starting: begin run for module: stream = 0 label = 'two' id = 5
@@ -68,18 +60,10 @@
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1000000
-++++++ starting: global begin lumi for module: label = 'one' id = 3
-++++++ finished: global begin lumi for module: label = 'one' id = 3
 ++++++ starting: global begin lumi for module: label = 'getOne' id = 4
 ++++++ finished: global begin lumi for module: label = 'getOne' id = 4
-++++++ starting: global begin lumi for module: label = 'two' id = 5
-++++++ finished: global begin lumi for module: label = 'two' id = 5
 ++++++ starting: global begin lumi for module: label = 'getTwo' id = 6
 ++++++ finished: global begin lumi for module: label = 'getTwo' id = 6
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin lumi for module: label = 'p' id = 2
-++++++ finished: global begin lumi for module: label = 'p' id = 2
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
 ++++++ starting: begin lumi for module: stream = 0 label = 'two' id = 5
@@ -186,18 +170,10 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'one' id = 3
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1000000
-++++++ starting: global end lumi for module: label = 'one' id = 3
-++++++ finished: global end lumi for module: label = 'one' id = 3
 ++++++ starting: global end lumi for module: label = 'getOne' id = 4
 ++++++ finished: global end lumi for module: label = 'getOne' id = 4
-++++++ starting: global end lumi for module: label = 'two' id = 5
-++++++ finished: global end lumi for module: label = 'two' id = 5
 ++++++ starting: global end lumi for module: label = 'getTwo' id = 6
 ++++++ finished: global end lumi for module: label = 'getTwo' id = 6
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global end lumi for module: label = 'p' id = 2
-++++++ finished: global end lumi for module: label = 'p' id = 2
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: end run: stream = 0 run = 1 time = 1000030
 ++++++ starting: end run for module: stream = 0 label = 'two' id = 5
@@ -210,18 +186,10 @@
 ++++++ finished: end run for module: stream = 0 label = 'one' id = 3
 ++++ finished: end run: stream = 0 run = 1 time = 1000030
 ++++ starting: global end run 1 : time = 1000030
-++++++ starting: global end run for module: label = 'one' id = 3
-++++++ finished: global end run for module: label = 'one' id = 3
 ++++++ starting: global end run for module: label = 'getOne' id = 4
 ++++++ finished: global end run for module: label = 'getOne' id = 4
-++++++ starting: global end run for module: label = 'two' id = 5
-++++++ finished: global end run for module: label = 'two' id = 5
 ++++++ starting: global end run for module: label = 'getTwo' id = 6
 ++++++ finished: global end run for module: label = 'getTwo' id = 6
-++++++ starting: global end run for module: label = 'TriggerResults' id = 1
-++++++ finished: global end run for module: label = 'TriggerResults' id = 1
-++++++ starting: global end run for module: label = 'p' id = 2
-++++++ finished: global end run for module: label = 'p' id = 2
 ++++ finished: global end run 1 : time = 1000030
 ++++ starting: end stream for module: stream = 0 label = 'one' id = 3
 ++++ finished: end stream for module: stream = 0 label = 'one' id = 3

--- a/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
@@ -50,10 +50,6 @@
 ++++ starting: begin run: stream = 0 run = 1 time = 1000000
 ++++++ starting: begin run for module: stream = 0 label = 'two' id = 5
 ++++++ finished: begin run for module: stream = 0 label = 'two' id = 5
-++++++ starting: begin run for module: stream = 0 label = 'getOne' id = 4
-++++++ finished: begin run for module: stream = 0 label = 'getOne' id = 4
-++++++ starting: begin run for module: stream = 0 label = 'getTwo' id = 6
-++++++ finished: begin run for module: stream = 0 label = 'getTwo' id = 6
 ++++++ starting: begin run for module: stream = 0 label = 'one' id = 3
 ++++++ finished: begin run for module: stream = 0 label = 'one' id = 3
 ++++ finished: begin run: stream = 0 run = 1 time = 1000000
@@ -68,10 +64,6 @@
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
 ++++++ starting: begin lumi for module: stream = 0 label = 'two' id = 5
 ++++++ finished: begin lumi for module: stream = 0 label = 'two' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'getOne' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'getOne' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'getTwo' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'getTwo' id = 6
 ++++++ starting: begin lumi for module: stream = 0 label = 'one' id = 3
 ++++++ finished: begin lumi for module: stream = 0 label = 'one' id = 3
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
@@ -162,10 +154,6 @@
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
 ++++++ starting: end lumi for module: stream = 0 label = 'two' id = 5
 ++++++ finished: end lumi for module: stream = 0 label = 'two' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'getOne' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'getOne' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'getTwo' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'getTwo' id = 6
 ++++++ starting: end lumi for module: stream = 0 label = 'one' id = 3
 ++++++ finished: end lumi for module: stream = 0 label = 'one' id = 3
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
@@ -178,10 +166,6 @@
 ++++ starting: end run: stream = 0 run = 1 time = 1000030
 ++++++ starting: end run for module: stream = 0 label = 'two' id = 5
 ++++++ finished: end run for module: stream = 0 label = 'two' id = 5
-++++++ starting: end run for module: stream = 0 label = 'getOne' id = 4
-++++++ finished: end run for module: stream = 0 label = 'getOne' id = 4
-++++++ starting: end run for module: stream = 0 label = 'getTwo' id = 6
-++++++ finished: end run for module: stream = 0 label = 'getTwo' id = 6
 ++++++ starting: end run for module: stream = 0 label = 'one' id = 3
 ++++++ finished: end run for module: stream = 0 label = 'one' id = 3
 ++++ finished: end run: stream = 0 run = 1 time = 1000030

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -176,18 +176,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
-++++++ starting: begin run for module: stream = 0 label = 'a1' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'a1' id = 5
-++++++ starting: begin run for module: stream = 0 label = 'a2' id = 6
-++++++ finished: begin run for module: stream = 0 label = 'a2' id = 6
-++++++ starting: begin run for module: stream = 0 label = 'a3' id = 7
-++++++ finished: begin run for module: stream = 0 label = 'a3' id = 7
-++++++ starting: begin run for module: stream = 0 label = 'intVectorProducer' id = 12
-++++++ finished: begin run for module: stream = 0 label = 'intVectorProducer' id = 12
 ++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 4
 ++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 4
-++++++ starting: begin run for module: stream = 0 label = 'out' id = 8
-++++++ finished: begin run for module: stream = 0 label = 'out' id = 8
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -280,18 +270,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
-++++++ starting: begin lumi for module: stream = 0 label = 'a1' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'a1' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'a2' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'a2' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'a3' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'a3' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 12
 ++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 4
 ++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 8
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -874,18 +854,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
-++++++ starting: end lumi for module: stream = 0 label = 'a1' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'a1' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'a2' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'a2' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'a3' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'a3' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'intVectorProducer' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'intVectorProducer' id = 12
 ++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 4
 ++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 8
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -976,18 +946,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
-++++++ starting: end run for module: stream = 0 label = 'a1' id = 5
-++++++ finished: end run for module: stream = 0 label = 'a1' id = 5
-++++++ starting: end run for module: stream = 0 label = 'a2' id = 6
-++++++ finished: end run for module: stream = 0 label = 'a2' id = 6
-++++++ starting: end run for module: stream = 0 label = 'a3' id = 7
-++++++ finished: end run for module: stream = 0 label = 'a3' id = 7
-++++++ starting: end run for module: stream = 0 label = 'intVectorProducer' id = 12
-++++++ finished: end run for module: stream = 0 label = 'intVectorProducer' id = 12
 ++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 4
 ++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 4
-++++++ starting: end run for module: stream = 0 label = 'out' id = 8
-++++++ finished: end run for module: stream = 0 label = 'out' id = 8
 ++++ finished: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -112,38 +112,8 @@ GlobalContext: transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
-++++++ starting: global begin run for module: label = 'intProducerA' id = 9
-GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-    GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-
-++++++ finished: global begin run for module: label = 'intProducerA' id = 9
-GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-    GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-
-++++++ starting: global begin run for module: label = 'intProducerB' id = 10
-++++++ finished: global begin run for module: label = 'intProducerB' id = 10
-++++++ starting: global begin run for module: label = 'intProducerU' id = 11
-++++++ finished: global begin run for module: label = 'intProducerU' id = 11
 ++++++ starting: global begin run for module: label = 'intVectorProducer' id = 12
 ++++++ finished: global begin run for module: label = 'intVectorProducer' id = 12
-++++++ starting: global begin run for module: label = 'intProducer' id = 4
-++++++ finished: global begin run for module: label = 'intProducer' id = 4
 ++++++ starting: global begin run for module: label = 'a1' id = 5
 ++++++ finished: global begin run for module: label = 'a1' id = 5
 ++++++ starting: global begin run for module: label = 'a2' id = 6
@@ -152,12 +122,6 @@ ModuleCallingContext state = Running
 ++++++ finished: global begin run for module: label = 'a3' id = 7
 ++++++ starting: global begin run for module: label = 'out' id = 8
 ++++++ finished: global begin run for module: label = 'out' id = 8
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin run for module: label = 'p' id = 2
-++++++ finished: global begin run for module: label = 'p' id = 2
-++++++ starting: global begin run for module: label = 'e' id = 3
-++++++ finished: global begin run for module: label = 'e' id = 3
 ++++ finished: global begin run 1 : time = 1
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
@@ -252,38 +216,8 @@ GlobalContext: transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
-++++++ starting: global begin lumi for module: label = 'intProducerA' id = 9
-GlobalContext: transition = BeginLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-    GlobalContext: transition = BeginLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-
-++++++ finished: global begin lumi for module: label = 'intProducerA' id = 9
-GlobalContext: transition = BeginLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-    GlobalContext: transition = BeginLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-
-++++++ starting: global begin lumi for module: label = 'intProducerB' id = 10
-++++++ finished: global begin lumi for module: label = 'intProducerB' id = 10
-++++++ starting: global begin lumi for module: label = 'intProducerU' id = 11
-++++++ finished: global begin lumi for module: label = 'intProducerU' id = 11
 ++++++ starting: global begin lumi for module: label = 'intVectorProducer' id = 12
 ++++++ finished: global begin lumi for module: label = 'intVectorProducer' id = 12
-++++++ starting: global begin lumi for module: label = 'intProducer' id = 4
-++++++ finished: global begin lumi for module: label = 'intProducer' id = 4
 ++++++ starting: global begin lumi for module: label = 'a1' id = 5
 ++++++ finished: global begin lumi for module: label = 'a1' id = 5
 ++++++ starting: global begin lumi for module: label = 'a2' id = 6
@@ -292,12 +226,6 @@ ModuleCallingContext state = Running
 ++++++ finished: global begin lumi for module: label = 'a3' id = 7
 ++++++ starting: global begin lumi for module: label = 'out' id = 8
 ++++++ finished: global begin lumi for module: label = 'out' id = 8
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin lumi for module: label = 'p' id = 2
-++++++ finished: global begin lumi for module: label = 'p' id = 2
-++++++ starting: global begin lumi for module: label = 'e' id = 3
-++++++ finished: global begin lumi for module: label = 'e' id = 3
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -984,38 +912,8 @@ GlobalContext: transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
-++++++ starting: global end lumi for module: label = 'intProducerA' id = 9
-GlobalContext: transition = EndLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-    GlobalContext: transition = EndLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-
-++++++ finished: global end lumi for module: label = 'intProducerA' id = 9
-GlobalContext: transition = EndLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-    GlobalContext: transition = EndLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-
-++++++ starting: global end lumi for module: label = 'intProducerB' id = 10
-++++++ finished: global end lumi for module: label = 'intProducerB' id = 10
-++++++ starting: global end lumi for module: label = 'intProducerU' id = 11
-++++++ finished: global end lumi for module: label = 'intProducerU' id = 11
 ++++++ starting: global end lumi for module: label = 'intVectorProducer' id = 12
 ++++++ finished: global end lumi for module: label = 'intVectorProducer' id = 12
-++++++ starting: global end lumi for module: label = 'intProducer' id = 4
-++++++ finished: global end lumi for module: label = 'intProducer' id = 4
 ++++++ starting: global end lumi for module: label = 'a1' id = 5
 ++++++ finished: global end lumi for module: label = 'a1' id = 5
 ++++++ starting: global end lumi for module: label = 'a2' id = 6
@@ -1024,12 +922,6 @@ ModuleCallingContext state = Running
 ++++++ finished: global end lumi for module: label = 'a3' id = 7
 ++++++ starting: global end lumi for module: label = 'out' id = 8
 ++++++ finished: global end lumi for module: label = 'out' id = 8
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global end lumi for module: label = 'p' id = 2
-++++++ finished: global end lumi for module: label = 'p' id = 2
-++++++ starting: global end lumi for module: label = 'e' id = 3
-++++++ finished: global end lumi for module: label = 'e' id = 3
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -1122,38 +1014,8 @@ GlobalContext: transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
-++++++ starting: global end run for module: label = 'intProducerA' id = 9
-GlobalContext: transition = EndRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-    GlobalContext: transition = EndRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-
-++++++ finished: global end run for module: label = 'intProducerA' id = 9
-GlobalContext: transition = EndRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-    GlobalContext: transition = EndRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
-
-++++++ starting: global end run for module: label = 'intProducerB' id = 10
-++++++ finished: global end run for module: label = 'intProducerB' id = 10
-++++++ starting: global end run for module: label = 'intProducerU' id = 11
-++++++ finished: global end run for module: label = 'intProducerU' id = 11
 ++++++ starting: global end run for module: label = 'intVectorProducer' id = 12
 ++++++ finished: global end run for module: label = 'intVectorProducer' id = 12
-++++++ starting: global end run for module: label = 'intProducer' id = 4
-++++++ finished: global end run for module: label = 'intProducer' id = 4
 ++++++ starting: global end run for module: label = 'a1' id = 5
 ++++++ finished: global end run for module: label = 'a1' id = 5
 ++++++ starting: global end run for module: label = 'a2' id = 6
@@ -1162,12 +1024,6 @@ ModuleCallingContext state = Running
 ++++++ finished: global end run for module: label = 'a3' id = 7
 ++++++ starting: global end run for module: label = 'out' id = 8
 ++++++ finished: global end run for module: label = 'out' id = 8
-++++++ starting: global end run for module: label = 'TriggerResults' id = 1
-++++++ finished: global end run for module: label = 'TriggerResults' id = 1
-++++++ starting: global end run for module: label = 'p' id = 2
-++++++ finished: global end run for module: label = 'p' id = 2
-++++++ starting: global end run for module: label = 'e' id = 3
-++++++ finished: global end run for module: label = 'e' id = 3
 ++++ finished: global end run 1 : time = 15000001
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -83,42 +83,10 @@ GlobalContext: transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: global begin run for module: label = 'intProducerU' id = 6
-++++++ finished: global begin run for module: label = 'intProducerU' id = 6
 ++++++ starting: global begin run for module: label = 'intVectorProducer' id = 7
 ++++++ finished: global begin run for module: label = 'intVectorProducer' id = 7
-++++++ starting: global begin run for module: label = 'intProducer' id = 4
-GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-    GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-
-++++++ finished: global begin run for module: label = 'intProducer' id = 4
-GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-    GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-
 ++++++ starting: global begin run for module: label = 'out' id = 5
 ++++++ finished: global begin run for module: label = 'out' id = 5
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin run for module: label = 'p' id = 2
-++++++ finished: global begin run for module: label = 'p' id = 2
-++++++ starting: global begin run for module: label = 'e' id = 3
-++++++ finished: global begin run for module: label = 'e' id = 3
 ++++ finished: global begin run 1 : time = 1
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
@@ -175,42 +143,10 @@ GlobalContext: transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: global begin lumi for module: label = 'intProducerU' id = 6
-++++++ finished: global begin lumi for module: label = 'intProducerU' id = 6
 ++++++ starting: global begin lumi for module: label = 'intVectorProducer' id = 7
 ++++++ finished: global begin lumi for module: label = 'intVectorProducer' id = 7
-++++++ starting: global begin lumi for module: label = 'intProducer' id = 4
-GlobalContext: transition = BeginLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-    GlobalContext: transition = BeginLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-
-++++++ finished: global begin lumi for module: label = 'intProducer' id = 4
-GlobalContext: transition = BeginLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-    GlobalContext: transition = BeginLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-
 ++++++ starting: global begin lumi for module: label = 'out' id = 5
 ++++++ finished: global begin lumi for module: label = 'out' id = 5
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin lumi for module: label = 'p' id = 2
-++++++ finished: global begin lumi for module: label = 'p' id = 2
-++++++ starting: global begin lumi for module: label = 'e' id = 3
-++++++ finished: global begin lumi for module: label = 'e' id = 3
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -757,42 +693,10 @@ GlobalContext: transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: global end lumi for module: label = 'intProducerU' id = 6
-++++++ finished: global end lumi for module: label = 'intProducerU' id = 6
 ++++++ starting: global end lumi for module: label = 'intVectorProducer' id = 7
 ++++++ finished: global end lumi for module: label = 'intVectorProducer' id = 7
-++++++ starting: global end lumi for module: label = 'intProducer' id = 4
-GlobalContext: transition = EndLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-    GlobalContext: transition = EndLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-
-++++++ finished: global end lumi for module: label = 'intProducer' id = 4
-GlobalContext: transition = EndLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-    GlobalContext: transition = EndLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-
 ++++++ starting: global end lumi for module: label = 'out' id = 5
 ++++++ finished: global end lumi for module: label = 'out' id = 5
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global end lumi for module: label = 'p' id = 2
-++++++ finished: global end lumi for module: label = 'p' id = 2
-++++++ starting: global end lumi for module: label = 'e' id = 3
-++++++ finished: global end lumi for module: label = 'e' id = 3
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -847,42 +751,10 @@ GlobalContext: transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: global end run for module: label = 'intProducerU' id = 6
-++++++ finished: global end run for module: label = 'intProducerU' id = 6
 ++++++ starting: global end run for module: label = 'intVectorProducer' id = 7
 ++++++ finished: global end run for module: label = 'intVectorProducer' id = 7
-++++++ starting: global end run for module: label = 'intProducer' id = 4
-GlobalContext: transition = EndRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-    GlobalContext: transition = EndRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-
-++++++ finished: global end run for module: label = 'intProducer' id = 4
-GlobalContext: transition = EndRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-    GlobalContext: transition = EndRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
-
 ++++++ starting: global end run for module: label = 'out' id = 5
 ++++++ finished: global end run for module: label = 'out' id = 5
-++++++ starting: global end run for module: label = 'TriggerResults' id = 1
-++++++ finished: global end run for module: label = 'TriggerResults' id = 1
-++++++ starting: global end run for module: label = 'p' id = 2
-++++++ finished: global end run for module: label = 'p' id = 2
-++++++ starting: global end run for module: label = 'e' id = 3
-++++++ finished: global end run for module: label = 'e' id = 3
 ++++ finished: global end run 1 : time = 15000001
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -99,8 +99,6 @@ StreamContext: StreamID = 0 transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: begin run for module: stream = 0 label = 'intVectorProducer' id = 7
-++++++ finished: begin run for module: stream = 0 label = 'intVectorProducer' id = 7
 ++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 6
 ++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 6
 ++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 4
@@ -127,8 +125,6 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: begin run for module: stream = 0 label = 'out' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'out' id = 5
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -159,8 +155,6 @@ StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 7
 ++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 6
 ++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 6
 ++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 4
@@ -187,8 +181,6 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 5
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -651,8 +643,6 @@ StreamContext: StreamID = 0 transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: end lumi for module: stream = 0 label = 'intVectorProducer' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'intVectorProducer' id = 7
 ++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 6
 ++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 6
 ++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 4
@@ -679,8 +669,6 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 5
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -709,8 +697,6 @@ StreamContext: StreamID = 0 transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: end run for module: stream = 0 label = 'intVectorProducer' id = 7
-++++++ finished: end run for module: stream = 0 label = 'intVectorProducer' id = 7
 ++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 6
 ++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 6
 ++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 4
@@ -737,8 +723,6 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: end run for module: stream = 0 label = 'out' id = 5
-++++++ finished: end run for module: stream = 0 label = 'out' id = 5
 ++++ finished: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -239,26 +239,10 @@
 ++++ starting: global begin run 1 : time = 1
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global begin run for module: label = 'get' id = 6
-++++++ finished: global begin run for module: label = 'get' id = 6
-++++++ starting: global begin run for module: label = 'putInt' id = 7
-++++++ finished: global begin run for module: label = 'putInt' id = 7
-++++++ starting: global begin run for module: label = 'putInt2' id = 8
-++++++ finished: global begin run for module: label = 'putInt2' id = 8
-++++++ starting: global begin run for module: label = 'putInt3' id = 9
-++++++ finished: global begin run for module: label = 'putInt3' id = 9
 ++++++ starting: global begin run for module: label = 'getInt' id = 10
 ++++++ finished: global begin run for module: label = 'getInt' id = 10
 ++++++ starting: global begin run for module: label = 'noPut' id = 11
 ++++++ finished: global begin run for module: label = 'noPut' id = 11
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin run for module: label = 'p1' id = 2
-++++++ finished: global begin run for module: label = 'p1' id = 2
-++++++ starting: global begin run for module: label = 'path1' id = 3
-++++++ finished: global begin run for module: label = 'path1' id = 3
-++++++ starting: global begin run for module: label = 'path2' id = 4
-++++++ finished: global begin run for module: label = 'path2' id = 4
 ++++ finished: global begin run 1 : time = 1
 ++++ starting: global begin run 1 : time = 1
 ++++ finished: global begin run 1 : time = 1
@@ -270,26 +254,12 @@
 ++++++ finished: global begin run for module: label = 'test' id = 32
 ++++++ starting: global begin run for module: label = 'testmerge' id = 33
 ++++++ finished: global begin run for module: label = 'testmerge' id = 33
-++++++ starting: global begin run for module: label = 'get' id = 34
-++++++ finished: global begin run for module: label = 'get' id = 34
 ++++++ starting: global begin run for module: label = 'getInt' id = 35
 ++++++ finished: global begin run for module: label = 'getInt' id = 35
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global begin run for module: label = 'out' id = 37
 ++++++ finished: global begin run for module: label = 'out' id = 37
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 25
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 25
-++++++ starting: global begin run for module: label = 'path1' id = 26
-++++++ finished: global begin run for module: label = 'path1' id = 26
-++++++ starting: global begin run for module: label = 'path2' id = 27
-++++++ finished: global begin run for module: label = 'path2' id = 27
-++++++ starting: global begin run for module: label = 'path3' id = 28
-++++++ finished: global begin run for module: label = 'path3' id = 28
-++++++ starting: global begin run for module: label = 'path4' id = 29
-++++++ finished: global begin run for module: label = 'path4' id = 29
-++++++ starting: global begin run for module: label = 'endPath1' id = 30
-++++++ finished: global begin run for module: label = 'endPath1' id = 30
 ++++ finished: global begin run 1 : time = 1
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 18
@@ -297,26 +267,12 @@
 ++++++ finished: global begin run for module: label = 'test' id = 19
 ++++++ starting: global begin run for module: label = 'testmerge' id = 20
 ++++++ finished: global begin run for module: label = 'testmerge' id = 20
-++++++ starting: global begin run for module: label = 'get' id = 21
-++++++ finished: global begin run for module: label = 'get' id = 21
 ++++++ starting: global begin run for module: label = 'getInt' id = 22
 ++++++ finished: global begin run for module: label = 'getInt' id = 22
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin run for module: label = 'out' id = 24
 ++++++ finished: global begin run for module: label = 'out' id = 24
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 12
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 12
-++++++ starting: global begin run for module: label = 'path1' id = 13
-++++++ finished: global begin run for module: label = 'path1' id = 13
-++++++ starting: global begin run for module: label = 'path2' id = 14
-++++++ finished: global begin run for module: label = 'path2' id = 14
-++++++ starting: global begin run for module: label = 'path3' id = 15
-++++++ finished: global begin run for module: label = 'path3' id = 15
-++++++ starting: global begin run for module: label = 'path4' id = 16
-++++++ finished: global begin run for module: label = 'path4' id = 16
-++++++ starting: global begin run for module: label = 'endPath1' id = 17
-++++++ finished: global begin run for module: label = 'endPath1' id = 17
 ++++ finished: global begin run 1 : time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
@@ -381,26 +337,10 @@
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global begin lumi for module: label = 'get' id = 6
-++++++ finished: global begin lumi for module: label = 'get' id = 6
-++++++ starting: global begin lumi for module: label = 'putInt' id = 7
-++++++ finished: global begin lumi for module: label = 'putInt' id = 7
-++++++ starting: global begin lumi for module: label = 'putInt2' id = 8
-++++++ finished: global begin lumi for module: label = 'putInt2' id = 8
-++++++ starting: global begin lumi for module: label = 'putInt3' id = 9
-++++++ finished: global begin lumi for module: label = 'putInt3' id = 9
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 10
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 10
 ++++++ starting: global begin lumi for module: label = 'noPut' id = 11
 ++++++ finished: global begin lumi for module: label = 'noPut' id = 11
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin lumi for module: label = 'p1' id = 2
-++++++ finished: global begin lumi for module: label = 'p1' id = 2
-++++++ starting: global begin lumi for module: label = 'path1' id = 3
-++++++ finished: global begin lumi for module: label = 'path1' id = 3
-++++++ starting: global begin lumi for module: label = 'path2' id = 4
-++++++ finished: global begin lumi for module: label = 'path2' id = 4
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
@@ -412,26 +352,12 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 32
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
-++++++ starting: global begin lumi for module: label = 'get' id = 34
-++++++ finished: global begin lumi for module: label = 'get' id = 34
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 35
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global begin lumi for module: label = 'out' id = 37
 ++++++ finished: global begin lumi for module: label = 'out' id = 37
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 25
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 25
-++++++ starting: global begin lumi for module: label = 'path1' id = 26
-++++++ finished: global begin lumi for module: label = 'path1' id = 26
-++++++ starting: global begin lumi for module: label = 'path2' id = 27
-++++++ finished: global begin lumi for module: label = 'path2' id = 27
-++++++ starting: global begin lumi for module: label = 'path3' id = 28
-++++++ finished: global begin lumi for module: label = 'path3' id = 28
-++++++ starting: global begin lumi for module: label = 'path4' id = 29
-++++++ finished: global begin lumi for module: label = 'path4' id = 29
-++++++ starting: global begin lumi for module: label = 'endPath1' id = 30
-++++++ finished: global begin lumi for module: label = 'endPath1' id = 30
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -439,26 +365,12 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 19
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
-++++++ starting: global begin lumi for module: label = 'get' id = 21
-++++++ finished: global begin lumi for module: label = 'get' id = 21
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 22
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin lumi for module: label = 'out' id = 24
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global begin lumi for module: label = 'path1' id = 13
-++++++ finished: global begin lumi for module: label = 'path1' id = 13
-++++++ starting: global begin lumi for module: label = 'path2' id = 14
-++++++ finished: global begin lumi for module: label = 'path2' id = 14
-++++++ starting: global begin lumi for module: label = 'path3' id = 15
-++++++ finished: global begin lumi for module: label = 'path3' id = 15
-++++++ starting: global begin lumi for module: label = 'path4' id = 16
-++++++ finished: global begin lumi for module: label = 'path4' id = 16
-++++++ starting: global begin lumi for module: label = 'endPath1' id = 17
-++++++ finished: global begin lumi for module: label = 'endPath1' id = 17
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
@@ -1223,26 +1135,10 @@
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global end lumi for module: label = 'get' id = 6
-++++++ finished: global end lumi for module: label = 'get' id = 6
-++++++ starting: global end lumi for module: label = 'putInt' id = 7
-++++++ finished: global end lumi for module: label = 'putInt' id = 7
-++++++ starting: global end lumi for module: label = 'putInt2' id = 8
-++++++ finished: global end lumi for module: label = 'putInt2' id = 8
-++++++ starting: global end lumi for module: label = 'putInt3' id = 9
-++++++ finished: global end lumi for module: label = 'putInt3' id = 9
 ++++++ starting: global end lumi for module: label = 'getInt' id = 10
 ++++++ finished: global end lumi for module: label = 'getInt' id = 10
 ++++++ starting: global end lumi for module: label = 'noPut' id = 11
 ++++++ finished: global end lumi for module: label = 'noPut' id = 11
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global end lumi for module: label = 'p1' id = 2
-++++++ finished: global end lumi for module: label = 'p1' id = 2
-++++++ starting: global end lumi for module: label = 'path1' id = 3
-++++++ finished: global end lumi for module: label = 'path1' id = 3
-++++++ starting: global end lumi for module: label = 'path2' id = 4
-++++++ finished: global end lumi for module: label = 'path2' id = 4
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
@@ -1254,26 +1150,12 @@
 ++++++ finished: global end lumi for module: label = 'test' id = 32
 ++++++ starting: global end lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 33
-++++++ starting: global end lumi for module: label = 'get' id = 34
-++++++ finished: global end lumi for module: label = 'get' id = 34
 ++++++ starting: global end lumi for module: label = 'getInt' id = 35
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global end lumi for module: label = 'out' id = 37
 ++++++ finished: global end lumi for module: label = 'out' id = 37
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 25
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 25
-++++++ starting: global end lumi for module: label = 'path1' id = 26
-++++++ finished: global end lumi for module: label = 'path1' id = 26
-++++++ starting: global end lumi for module: label = 'path2' id = 27
-++++++ finished: global end lumi for module: label = 'path2' id = 27
-++++++ starting: global end lumi for module: label = 'path3' id = 28
-++++++ finished: global end lumi for module: label = 'path3' id = 28
-++++++ starting: global end lumi for module: label = 'path4' id = 29
-++++++ finished: global end lumi for module: label = 'path4' id = 29
-++++++ starting: global end lumi for module: label = 'endPath1' id = 30
-++++++ finished: global end lumi for module: label = 'endPath1' id = 30
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -1281,26 +1163,12 @@
 ++++++ finished: global end lumi for module: label = 'test' id = 19
 ++++++ starting: global end lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
 ++++++ starting: global end lumi for module: label = 'getInt' id = 22
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global end lumi for module: label = 'path1' id = 13
-++++++ finished: global end lumi for module: label = 'path1' id = 13
-++++++ starting: global end lumi for module: label = 'path2' id = 14
-++++++ finished: global end lumi for module: label = 'path2' id = 14
-++++++ starting: global end lumi for module: label = 'path3' id = 15
-++++++ finished: global end lumi for module: label = 'path3' id = 15
-++++++ starting: global end lumi for module: label = 'path4' id = 16
-++++++ finished: global end lumi for module: label = 'path4' id = 16
-++++++ starting: global end lumi for module: label = 'endPath1' id = 17
-++++++ finished: global end lumi for module: label = 'endPath1' id = 17
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -1311,26 +1179,10 @@
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global begin lumi for module: label = 'get' id = 6
-++++++ finished: global begin lumi for module: label = 'get' id = 6
-++++++ starting: global begin lumi for module: label = 'putInt' id = 7
-++++++ finished: global begin lumi for module: label = 'putInt' id = 7
-++++++ starting: global begin lumi for module: label = 'putInt2' id = 8
-++++++ finished: global begin lumi for module: label = 'putInt2' id = 8
-++++++ starting: global begin lumi for module: label = 'putInt3' id = 9
-++++++ finished: global begin lumi for module: label = 'putInt3' id = 9
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 10
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 10
 ++++++ starting: global begin lumi for module: label = 'noPut' id = 11
 ++++++ finished: global begin lumi for module: label = 'noPut' id = 11
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin lumi for module: label = 'p1' id = 2
-++++++ finished: global begin lumi for module: label = 'p1' id = 2
-++++++ starting: global begin lumi for module: label = 'path1' id = 3
-++++++ finished: global begin lumi for module: label = 'path1' id = 3
-++++++ starting: global begin lumi for module: label = 'path2' id = 4
-++++++ finished: global begin lumi for module: label = 'path2' id = 4
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
@@ -1342,26 +1194,12 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 32
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
-++++++ starting: global begin lumi for module: label = 'get' id = 34
-++++++ finished: global begin lumi for module: label = 'get' id = 34
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 35
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global begin lumi for module: label = 'out' id = 37
 ++++++ finished: global begin lumi for module: label = 'out' id = 37
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 25
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 25
-++++++ starting: global begin lumi for module: label = 'path1' id = 26
-++++++ finished: global begin lumi for module: label = 'path1' id = 26
-++++++ starting: global begin lumi for module: label = 'path2' id = 27
-++++++ finished: global begin lumi for module: label = 'path2' id = 27
-++++++ starting: global begin lumi for module: label = 'path3' id = 28
-++++++ finished: global begin lumi for module: label = 'path3' id = 28
-++++++ starting: global begin lumi for module: label = 'path4' id = 29
-++++++ finished: global begin lumi for module: label = 'path4' id = 29
-++++++ starting: global begin lumi for module: label = 'endPath1' id = 30
-++++++ finished: global begin lumi for module: label = 'endPath1' id = 30
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -1369,26 +1207,12 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 19
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
-++++++ starting: global begin lumi for module: label = 'get' id = 21
-++++++ finished: global begin lumi for module: label = 'get' id = 21
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 22
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin lumi for module: label = 'out' id = 24
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global begin lumi for module: label = 'path1' id = 13
-++++++ finished: global begin lumi for module: label = 'path1' id = 13
-++++++ starting: global begin lumi for module: label = 'path2' id = 14
-++++++ finished: global begin lumi for module: label = 'path2' id = 14
-++++++ starting: global begin lumi for module: label = 'path3' id = 15
-++++++ finished: global begin lumi for module: label = 'path3' id = 15
-++++++ starting: global begin lumi for module: label = 'path4' id = 16
-++++++ finished: global begin lumi for module: label = 'path4' id = 16
-++++++ starting: global begin lumi for module: label = 'endPath1' id = 17
-++++++ finished: global begin lumi for module: label = 'endPath1' id = 17
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
@@ -2153,26 +1977,10 @@
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global end lumi for module: label = 'get' id = 6
-++++++ finished: global end lumi for module: label = 'get' id = 6
-++++++ starting: global end lumi for module: label = 'putInt' id = 7
-++++++ finished: global end lumi for module: label = 'putInt' id = 7
-++++++ starting: global end lumi for module: label = 'putInt2' id = 8
-++++++ finished: global end lumi for module: label = 'putInt2' id = 8
-++++++ starting: global end lumi for module: label = 'putInt3' id = 9
-++++++ finished: global end lumi for module: label = 'putInt3' id = 9
 ++++++ starting: global end lumi for module: label = 'getInt' id = 10
 ++++++ finished: global end lumi for module: label = 'getInt' id = 10
 ++++++ starting: global end lumi for module: label = 'noPut' id = 11
 ++++++ finished: global end lumi for module: label = 'noPut' id = 11
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global end lumi for module: label = 'p1' id = 2
-++++++ finished: global end lumi for module: label = 'p1' id = 2
-++++++ starting: global end lumi for module: label = 'path1' id = 3
-++++++ finished: global end lumi for module: label = 'path1' id = 3
-++++++ starting: global end lumi for module: label = 'path2' id = 4
-++++++ finished: global end lumi for module: label = 'path2' id = 4
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
@@ -2184,26 +1992,12 @@
 ++++++ finished: global end lumi for module: label = 'test' id = 32
 ++++++ starting: global end lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 33
-++++++ starting: global end lumi for module: label = 'get' id = 34
-++++++ finished: global end lumi for module: label = 'get' id = 34
 ++++++ starting: global end lumi for module: label = 'getInt' id = 35
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global end lumi for module: label = 'out' id = 37
 ++++++ finished: global end lumi for module: label = 'out' id = 37
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 25
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 25
-++++++ starting: global end lumi for module: label = 'path1' id = 26
-++++++ finished: global end lumi for module: label = 'path1' id = 26
-++++++ starting: global end lumi for module: label = 'path2' id = 27
-++++++ finished: global end lumi for module: label = 'path2' id = 27
-++++++ starting: global end lumi for module: label = 'path3' id = 28
-++++++ finished: global end lumi for module: label = 'path3' id = 28
-++++++ starting: global end lumi for module: label = 'path4' id = 29
-++++++ finished: global end lumi for module: label = 'path4' id = 29
-++++++ starting: global end lumi for module: label = 'endPath1' id = 30
-++++++ finished: global end lumi for module: label = 'endPath1' id = 30
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -2211,26 +2005,12 @@
 ++++++ finished: global end lumi for module: label = 'test' id = 19
 ++++++ starting: global end lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
 ++++++ starting: global end lumi for module: label = 'getInt' id = 22
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global end lumi for module: label = 'path1' id = 13
-++++++ finished: global end lumi for module: label = 'path1' id = 13
-++++++ starting: global end lumi for module: label = 'path2' id = 14
-++++++ finished: global end lumi for module: label = 'path2' id = 14
-++++++ starting: global end lumi for module: label = 'path3' id = 15
-++++++ finished: global end lumi for module: label = 'path3' id = 15
-++++++ starting: global end lumi for module: label = 'path4' id = 16
-++++++ finished: global end lumi for module: label = 'path4' id = 16
-++++++ starting: global end lumi for module: label = 'endPath1' id = 17
-++++++ finished: global end lumi for module: label = 'endPath1' id = 17
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -2241,26 +2021,10 @@
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global begin lumi for module: label = 'get' id = 6
-++++++ finished: global begin lumi for module: label = 'get' id = 6
-++++++ starting: global begin lumi for module: label = 'putInt' id = 7
-++++++ finished: global begin lumi for module: label = 'putInt' id = 7
-++++++ starting: global begin lumi for module: label = 'putInt2' id = 8
-++++++ finished: global begin lumi for module: label = 'putInt2' id = 8
-++++++ starting: global begin lumi for module: label = 'putInt3' id = 9
-++++++ finished: global begin lumi for module: label = 'putInt3' id = 9
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 10
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 10
 ++++++ starting: global begin lumi for module: label = 'noPut' id = 11
 ++++++ finished: global begin lumi for module: label = 'noPut' id = 11
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin lumi for module: label = 'p1' id = 2
-++++++ finished: global begin lumi for module: label = 'p1' id = 2
-++++++ starting: global begin lumi for module: label = 'path1' id = 3
-++++++ finished: global begin lumi for module: label = 'path1' id = 3
-++++++ starting: global begin lumi for module: label = 'path2' id = 4
-++++++ finished: global begin lumi for module: label = 'path2' id = 4
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
@@ -2272,26 +2036,12 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 32
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
-++++++ starting: global begin lumi for module: label = 'get' id = 34
-++++++ finished: global begin lumi for module: label = 'get' id = 34
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 35
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global begin lumi for module: label = 'out' id = 37
 ++++++ finished: global begin lumi for module: label = 'out' id = 37
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 25
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 25
-++++++ starting: global begin lumi for module: label = 'path1' id = 26
-++++++ finished: global begin lumi for module: label = 'path1' id = 26
-++++++ starting: global begin lumi for module: label = 'path2' id = 27
-++++++ finished: global begin lumi for module: label = 'path2' id = 27
-++++++ starting: global begin lumi for module: label = 'path3' id = 28
-++++++ finished: global begin lumi for module: label = 'path3' id = 28
-++++++ starting: global begin lumi for module: label = 'path4' id = 29
-++++++ finished: global begin lumi for module: label = 'path4' id = 29
-++++++ starting: global begin lumi for module: label = 'endPath1' id = 30
-++++++ finished: global begin lumi for module: label = 'endPath1' id = 30
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -2299,26 +2049,12 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 19
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
-++++++ starting: global begin lumi for module: label = 'get' id = 21
-++++++ finished: global begin lumi for module: label = 'get' id = 21
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 22
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin lumi for module: label = 'out' id = 24
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global begin lumi for module: label = 'path1' id = 13
-++++++ finished: global begin lumi for module: label = 'path1' id = 13
-++++++ starting: global begin lumi for module: label = 'path2' id = 14
-++++++ finished: global begin lumi for module: label = 'path2' id = 14
-++++++ starting: global begin lumi for module: label = 'path3' id = 15
-++++++ finished: global begin lumi for module: label = 'path3' id = 15
-++++++ starting: global begin lumi for module: label = 'path4' id = 16
-++++++ finished: global begin lumi for module: label = 'path4' id = 16
-++++++ starting: global begin lumi for module: label = 'endPath1' id = 17
-++++++ finished: global begin lumi for module: label = 'endPath1' id = 17
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
@@ -2759,26 +2495,10 @@
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global end lumi for module: label = 'get' id = 6
-++++++ finished: global end lumi for module: label = 'get' id = 6
-++++++ starting: global end lumi for module: label = 'putInt' id = 7
-++++++ finished: global end lumi for module: label = 'putInt' id = 7
-++++++ starting: global end lumi for module: label = 'putInt2' id = 8
-++++++ finished: global end lumi for module: label = 'putInt2' id = 8
-++++++ starting: global end lumi for module: label = 'putInt3' id = 9
-++++++ finished: global end lumi for module: label = 'putInt3' id = 9
 ++++++ starting: global end lumi for module: label = 'getInt' id = 10
 ++++++ finished: global end lumi for module: label = 'getInt' id = 10
 ++++++ starting: global end lumi for module: label = 'noPut' id = 11
 ++++++ finished: global end lumi for module: label = 'noPut' id = 11
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global end lumi for module: label = 'p1' id = 2
-++++++ finished: global end lumi for module: label = 'p1' id = 2
-++++++ starting: global end lumi for module: label = 'path1' id = 3
-++++++ finished: global end lumi for module: label = 'path1' id = 3
-++++++ starting: global end lumi for module: label = 'path2' id = 4
-++++++ finished: global end lumi for module: label = 'path2' id = 4
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
@@ -2790,26 +2510,12 @@
 ++++++ finished: global end lumi for module: label = 'test' id = 32
 ++++++ starting: global end lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 33
-++++++ starting: global end lumi for module: label = 'get' id = 34
-++++++ finished: global end lumi for module: label = 'get' id = 34
 ++++++ starting: global end lumi for module: label = 'getInt' id = 35
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global end lumi for module: label = 'out' id = 37
 ++++++ finished: global end lumi for module: label = 'out' id = 37
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 25
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 25
-++++++ starting: global end lumi for module: label = 'path1' id = 26
-++++++ finished: global end lumi for module: label = 'path1' id = 26
-++++++ starting: global end lumi for module: label = 'path2' id = 27
-++++++ finished: global end lumi for module: label = 'path2' id = 27
-++++++ starting: global end lumi for module: label = 'path3' id = 28
-++++++ finished: global end lumi for module: label = 'path3' id = 28
-++++++ starting: global end lumi for module: label = 'path4' id = 29
-++++++ finished: global end lumi for module: label = 'path4' id = 29
-++++++ starting: global end lumi for module: label = 'endPath1' id = 30
-++++++ finished: global end lumi for module: label = 'endPath1' id = 30
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -2817,26 +2523,12 @@
 ++++++ finished: global end lumi for module: label = 'test' id = 19
 ++++++ starting: global end lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
 ++++++ starting: global end lumi for module: label = 'getInt' id = 22
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global end lumi for module: label = 'path1' id = 13
-++++++ finished: global end lumi for module: label = 'path1' id = 13
-++++++ starting: global end lumi for module: label = 'path2' id = 14
-++++++ finished: global end lumi for module: label = 'path2' id = 14
-++++++ starting: global end lumi for module: label = 'path3' id = 15
-++++++ finished: global end lumi for module: label = 'path3' id = 15
-++++++ starting: global end lumi for module: label = 'path4' id = 16
-++++++ finished: global end lumi for module: label = 'path4' id = 16
-++++++ starting: global end lumi for module: label = 'endPath1' id = 17
-++++++ finished: global end lumi for module: label = 'endPath1' id = 17
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: end run: stream = 0 run = 1 time = 50000001
 ++++ finished: end run: stream = 0 run = 1 time = 50000001
@@ -2899,26 +2591,10 @@
 ++++ starting: global end run 1 : time = 0
 ++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global end run for module: label = 'get' id = 6
-++++++ finished: global end run for module: label = 'get' id = 6
-++++++ starting: global end run for module: label = 'putInt' id = 7
-++++++ finished: global end run for module: label = 'putInt' id = 7
-++++++ starting: global end run for module: label = 'putInt2' id = 8
-++++++ finished: global end run for module: label = 'putInt2' id = 8
-++++++ starting: global end run for module: label = 'putInt3' id = 9
-++++++ finished: global end run for module: label = 'putInt3' id = 9
 ++++++ starting: global end run for module: label = 'getInt' id = 10
 ++++++ finished: global end run for module: label = 'getInt' id = 10
 ++++++ starting: global end run for module: label = 'noPut' id = 11
 ++++++ finished: global end run for module: label = 'noPut' id = 11
-++++++ starting: global end run for module: label = 'TriggerResults' id = 1
-++++++ finished: global end run for module: label = 'TriggerResults' id = 1
-++++++ starting: global end run for module: label = 'p1' id = 2
-++++++ finished: global end run for module: label = 'p1' id = 2
-++++++ starting: global end run for module: label = 'path1' id = 3
-++++++ finished: global end run for module: label = 'path1' id = 3
-++++++ starting: global end run for module: label = 'path2' id = 4
-++++++ finished: global end run for module: label = 'path2' id = 4
 ++++ finished: global end run 1 : time = 0
 ++++ starting: global end run 1 : time = 0
 ++++ finished: global end run 1 : time = 0
@@ -2930,26 +2606,12 @@
 ++++++ finished: global end run for module: label = 'test' id = 32
 ++++++ starting: global end run for module: label = 'testmerge' id = 33
 ++++++ finished: global end run for module: label = 'testmerge' id = 33
-++++++ starting: global end run for module: label = 'get' id = 34
-++++++ finished: global end run for module: label = 'get' id = 34
 ++++++ starting: global end run for module: label = 'getInt' id = 35
 ++++++ finished: global end run for module: label = 'getInt' id = 35
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global end run for module: label = 'out' id = 37
 ++++++ finished: global end run for module: label = 'out' id = 37
-++++++ starting: global end run for module: label = 'TriggerResults' id = 25
-++++++ finished: global end run for module: label = 'TriggerResults' id = 25
-++++++ starting: global end run for module: label = 'path1' id = 26
-++++++ finished: global end run for module: label = 'path1' id = 26
-++++++ starting: global end run for module: label = 'path2' id = 27
-++++++ finished: global end run for module: label = 'path2' id = 27
-++++++ starting: global end run for module: label = 'path3' id = 28
-++++++ finished: global end run for module: label = 'path3' id = 28
-++++++ starting: global end run for module: label = 'path4' id = 29
-++++++ finished: global end run for module: label = 'path4' id = 29
-++++++ starting: global end run for module: label = 'endPath1' id = 30
-++++++ finished: global end run for module: label = 'endPath1' id = 30
 ++++ finished: global end run 1 : time = 0
 ++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 18
@@ -2957,26 +2619,12 @@
 ++++++ finished: global end run for module: label = 'test' id = 19
 ++++++ starting: global end run for module: label = 'testmerge' id = 20
 ++++++ finished: global end run for module: label = 'testmerge' id = 20
-++++++ starting: global end run for module: label = 'get' id = 21
-++++++ finished: global end run for module: label = 'get' id = 21
 ++++++ starting: global end run for module: label = 'getInt' id = 22
 ++++++ finished: global end run for module: label = 'getInt' id = 22
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end run for module: label = 'out' id = 24
 ++++++ finished: global end run for module: label = 'out' id = 24
-++++++ starting: global end run for module: label = 'TriggerResults' id = 12
-++++++ finished: global end run for module: label = 'TriggerResults' id = 12
-++++++ starting: global end run for module: label = 'path1' id = 13
-++++++ finished: global end run for module: label = 'path1' id = 13
-++++++ starting: global end run for module: label = 'path2' id = 14
-++++++ finished: global end run for module: label = 'path2' id = 14
-++++++ starting: global end run for module: label = 'path3' id = 15
-++++++ finished: global end run for module: label = 'path3' id = 15
-++++++ starting: global end run for module: label = 'path4' id = 16
-++++++ finished: global end run for module: label = 'path4' id = 16
-++++++ starting: global end run for module: label = 'endPath1' id = 17
-++++++ finished: global end run for module: label = 'endPath1' id = 17
 ++++ finished: global end run 1 : time = 0
 ++++ starting: source run
 ++++ finished: source run
@@ -2987,26 +2635,10 @@
 ++++ starting: global begin run 2 : time = 55000001
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global begin run for module: label = 'get' id = 6
-++++++ finished: global begin run for module: label = 'get' id = 6
-++++++ starting: global begin run for module: label = 'putInt' id = 7
-++++++ finished: global begin run for module: label = 'putInt' id = 7
-++++++ starting: global begin run for module: label = 'putInt2' id = 8
-++++++ finished: global begin run for module: label = 'putInt2' id = 8
-++++++ starting: global begin run for module: label = 'putInt3' id = 9
-++++++ finished: global begin run for module: label = 'putInt3' id = 9
 ++++++ starting: global begin run for module: label = 'getInt' id = 10
 ++++++ finished: global begin run for module: label = 'getInt' id = 10
 ++++++ starting: global begin run for module: label = 'noPut' id = 11
 ++++++ finished: global begin run for module: label = 'noPut' id = 11
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin run for module: label = 'p1' id = 2
-++++++ finished: global begin run for module: label = 'p1' id = 2
-++++++ starting: global begin run for module: label = 'path1' id = 3
-++++++ finished: global begin run for module: label = 'path1' id = 3
-++++++ starting: global begin run for module: label = 'path2' id = 4
-++++++ finished: global begin run for module: label = 'path2' id = 4
 ++++ finished: global begin run 2 : time = 55000001
 ++++ starting: global begin run 2 : time = 55000001
 ++++ finished: global begin run 2 : time = 55000001
@@ -3018,26 +2650,12 @@
 ++++++ finished: global begin run for module: label = 'test' id = 32
 ++++++ starting: global begin run for module: label = 'testmerge' id = 33
 ++++++ finished: global begin run for module: label = 'testmerge' id = 33
-++++++ starting: global begin run for module: label = 'get' id = 34
-++++++ finished: global begin run for module: label = 'get' id = 34
 ++++++ starting: global begin run for module: label = 'getInt' id = 35
 ++++++ finished: global begin run for module: label = 'getInt' id = 35
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global begin run for module: label = 'out' id = 37
 ++++++ finished: global begin run for module: label = 'out' id = 37
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 25
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 25
-++++++ starting: global begin run for module: label = 'path1' id = 26
-++++++ finished: global begin run for module: label = 'path1' id = 26
-++++++ starting: global begin run for module: label = 'path2' id = 27
-++++++ finished: global begin run for module: label = 'path2' id = 27
-++++++ starting: global begin run for module: label = 'path3' id = 28
-++++++ finished: global begin run for module: label = 'path3' id = 28
-++++++ starting: global begin run for module: label = 'path4' id = 29
-++++++ finished: global begin run for module: label = 'path4' id = 29
-++++++ starting: global begin run for module: label = 'endPath1' id = 30
-++++++ finished: global begin run for module: label = 'endPath1' id = 30
 ++++ finished: global begin run 2 : time = 55000001
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 18
@@ -3045,26 +2663,12 @@
 ++++++ finished: global begin run for module: label = 'test' id = 19
 ++++++ starting: global begin run for module: label = 'testmerge' id = 20
 ++++++ finished: global begin run for module: label = 'testmerge' id = 20
-++++++ starting: global begin run for module: label = 'get' id = 21
-++++++ finished: global begin run for module: label = 'get' id = 21
 ++++++ starting: global begin run for module: label = 'getInt' id = 22
 ++++++ finished: global begin run for module: label = 'getInt' id = 22
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin run for module: label = 'out' id = 24
 ++++++ finished: global begin run for module: label = 'out' id = 24
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 12
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 12
-++++++ starting: global begin run for module: label = 'path1' id = 13
-++++++ finished: global begin run for module: label = 'path1' id = 13
-++++++ starting: global begin run for module: label = 'path2' id = 14
-++++++ finished: global begin run for module: label = 'path2' id = 14
-++++++ starting: global begin run for module: label = 'path3' id = 15
-++++++ finished: global begin run for module: label = 'path3' id = 15
-++++++ starting: global begin run for module: label = 'path4' id = 16
-++++++ finished: global begin run for module: label = 'path4' id = 16
-++++++ starting: global begin run for module: label = 'endPath1' id = 17
-++++++ finished: global begin run for module: label = 'endPath1' id = 17
 ++++ finished: global begin run 2 : time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
@@ -3129,26 +2733,10 @@
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global begin lumi for module: label = 'get' id = 6
-++++++ finished: global begin lumi for module: label = 'get' id = 6
-++++++ starting: global begin lumi for module: label = 'putInt' id = 7
-++++++ finished: global begin lumi for module: label = 'putInt' id = 7
-++++++ starting: global begin lumi for module: label = 'putInt2' id = 8
-++++++ finished: global begin lumi for module: label = 'putInt2' id = 8
-++++++ starting: global begin lumi for module: label = 'putInt3' id = 9
-++++++ finished: global begin lumi for module: label = 'putInt3' id = 9
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 10
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 10
 ++++++ starting: global begin lumi for module: label = 'noPut' id = 11
 ++++++ finished: global begin lumi for module: label = 'noPut' id = 11
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin lumi for module: label = 'p1' id = 2
-++++++ finished: global begin lumi for module: label = 'p1' id = 2
-++++++ starting: global begin lumi for module: label = 'path1' id = 3
-++++++ finished: global begin lumi for module: label = 'path1' id = 3
-++++++ starting: global begin lumi for module: label = 'path2' id = 4
-++++++ finished: global begin lumi for module: label = 'path2' id = 4
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
@@ -3160,26 +2748,12 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 32
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
-++++++ starting: global begin lumi for module: label = 'get' id = 34
-++++++ finished: global begin lumi for module: label = 'get' id = 34
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 35
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global begin lumi for module: label = 'out' id = 37
 ++++++ finished: global begin lumi for module: label = 'out' id = 37
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 25
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 25
-++++++ starting: global begin lumi for module: label = 'path1' id = 26
-++++++ finished: global begin lumi for module: label = 'path1' id = 26
-++++++ starting: global begin lumi for module: label = 'path2' id = 27
-++++++ finished: global begin lumi for module: label = 'path2' id = 27
-++++++ starting: global begin lumi for module: label = 'path3' id = 28
-++++++ finished: global begin lumi for module: label = 'path3' id = 28
-++++++ starting: global begin lumi for module: label = 'path4' id = 29
-++++++ finished: global begin lumi for module: label = 'path4' id = 29
-++++++ starting: global begin lumi for module: label = 'endPath1' id = 30
-++++++ finished: global begin lumi for module: label = 'endPath1' id = 30
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -3187,26 +2761,12 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 19
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
-++++++ starting: global begin lumi for module: label = 'get' id = 21
-++++++ finished: global begin lumi for module: label = 'get' id = 21
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 22
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin lumi for module: label = 'out' id = 24
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global begin lumi for module: label = 'path1' id = 13
-++++++ finished: global begin lumi for module: label = 'path1' id = 13
-++++++ starting: global begin lumi for module: label = 'path2' id = 14
-++++++ finished: global begin lumi for module: label = 'path2' id = 14
-++++++ starting: global begin lumi for module: label = 'path3' id = 15
-++++++ finished: global begin lumi for module: label = 'path3' id = 15
-++++++ starting: global begin lumi for module: label = 'path4' id = 16
-++++++ finished: global begin lumi for module: label = 'path4' id = 16
-++++++ starting: global begin lumi for module: label = 'endPath1' id = 17
-++++++ finished: global begin lumi for module: label = 'endPath1' id = 17
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
@@ -3971,26 +3531,10 @@
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global end lumi for module: label = 'get' id = 6
-++++++ finished: global end lumi for module: label = 'get' id = 6
-++++++ starting: global end lumi for module: label = 'putInt' id = 7
-++++++ finished: global end lumi for module: label = 'putInt' id = 7
-++++++ starting: global end lumi for module: label = 'putInt2' id = 8
-++++++ finished: global end lumi for module: label = 'putInt2' id = 8
-++++++ starting: global end lumi for module: label = 'putInt3' id = 9
-++++++ finished: global end lumi for module: label = 'putInt3' id = 9
 ++++++ starting: global end lumi for module: label = 'getInt' id = 10
 ++++++ finished: global end lumi for module: label = 'getInt' id = 10
 ++++++ starting: global end lumi for module: label = 'noPut' id = 11
 ++++++ finished: global end lumi for module: label = 'noPut' id = 11
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global end lumi for module: label = 'p1' id = 2
-++++++ finished: global end lumi for module: label = 'p1' id = 2
-++++++ starting: global end lumi for module: label = 'path1' id = 3
-++++++ finished: global end lumi for module: label = 'path1' id = 3
-++++++ starting: global end lumi for module: label = 'path2' id = 4
-++++++ finished: global end lumi for module: label = 'path2' id = 4
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
@@ -4002,26 +3546,12 @@
 ++++++ finished: global end lumi for module: label = 'test' id = 32
 ++++++ starting: global end lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 33
-++++++ starting: global end lumi for module: label = 'get' id = 34
-++++++ finished: global end lumi for module: label = 'get' id = 34
 ++++++ starting: global end lumi for module: label = 'getInt' id = 35
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global end lumi for module: label = 'out' id = 37
 ++++++ finished: global end lumi for module: label = 'out' id = 37
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 25
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 25
-++++++ starting: global end lumi for module: label = 'path1' id = 26
-++++++ finished: global end lumi for module: label = 'path1' id = 26
-++++++ starting: global end lumi for module: label = 'path2' id = 27
-++++++ finished: global end lumi for module: label = 'path2' id = 27
-++++++ starting: global end lumi for module: label = 'path3' id = 28
-++++++ finished: global end lumi for module: label = 'path3' id = 28
-++++++ starting: global end lumi for module: label = 'path4' id = 29
-++++++ finished: global end lumi for module: label = 'path4' id = 29
-++++++ starting: global end lumi for module: label = 'endPath1' id = 30
-++++++ finished: global end lumi for module: label = 'endPath1' id = 30
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -4029,26 +3559,12 @@
 ++++++ finished: global end lumi for module: label = 'test' id = 19
 ++++++ starting: global end lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
 ++++++ starting: global end lumi for module: label = 'getInt' id = 22
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global end lumi for module: label = 'path1' id = 13
-++++++ finished: global end lumi for module: label = 'path1' id = 13
-++++++ starting: global end lumi for module: label = 'path2' id = 14
-++++++ finished: global end lumi for module: label = 'path2' id = 14
-++++++ starting: global end lumi for module: label = 'path3' id = 15
-++++++ finished: global end lumi for module: label = 'path3' id = 15
-++++++ starting: global end lumi for module: label = 'path4' id = 16
-++++++ finished: global end lumi for module: label = 'path4' id = 16
-++++++ starting: global end lumi for module: label = 'endPath1' id = 17
-++++++ finished: global end lumi for module: label = 'endPath1' id = 17
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -4059,26 +3575,10 @@
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global begin lumi for module: label = 'get' id = 6
-++++++ finished: global begin lumi for module: label = 'get' id = 6
-++++++ starting: global begin lumi for module: label = 'putInt' id = 7
-++++++ finished: global begin lumi for module: label = 'putInt' id = 7
-++++++ starting: global begin lumi for module: label = 'putInt2' id = 8
-++++++ finished: global begin lumi for module: label = 'putInt2' id = 8
-++++++ starting: global begin lumi for module: label = 'putInt3' id = 9
-++++++ finished: global begin lumi for module: label = 'putInt3' id = 9
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 10
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 10
 ++++++ starting: global begin lumi for module: label = 'noPut' id = 11
 ++++++ finished: global begin lumi for module: label = 'noPut' id = 11
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin lumi for module: label = 'p1' id = 2
-++++++ finished: global begin lumi for module: label = 'p1' id = 2
-++++++ starting: global begin lumi for module: label = 'path1' id = 3
-++++++ finished: global begin lumi for module: label = 'path1' id = 3
-++++++ starting: global begin lumi for module: label = 'path2' id = 4
-++++++ finished: global begin lumi for module: label = 'path2' id = 4
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
@@ -4090,26 +3590,12 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 32
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
-++++++ starting: global begin lumi for module: label = 'get' id = 34
-++++++ finished: global begin lumi for module: label = 'get' id = 34
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 35
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global begin lumi for module: label = 'out' id = 37
 ++++++ finished: global begin lumi for module: label = 'out' id = 37
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 25
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 25
-++++++ starting: global begin lumi for module: label = 'path1' id = 26
-++++++ finished: global begin lumi for module: label = 'path1' id = 26
-++++++ starting: global begin lumi for module: label = 'path2' id = 27
-++++++ finished: global begin lumi for module: label = 'path2' id = 27
-++++++ starting: global begin lumi for module: label = 'path3' id = 28
-++++++ finished: global begin lumi for module: label = 'path3' id = 28
-++++++ starting: global begin lumi for module: label = 'path4' id = 29
-++++++ finished: global begin lumi for module: label = 'path4' id = 29
-++++++ starting: global begin lumi for module: label = 'endPath1' id = 30
-++++++ finished: global begin lumi for module: label = 'endPath1' id = 30
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -4117,26 +3603,12 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 19
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
-++++++ starting: global begin lumi for module: label = 'get' id = 21
-++++++ finished: global begin lumi for module: label = 'get' id = 21
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 22
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin lumi for module: label = 'out' id = 24
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global begin lumi for module: label = 'path1' id = 13
-++++++ finished: global begin lumi for module: label = 'path1' id = 13
-++++++ starting: global begin lumi for module: label = 'path2' id = 14
-++++++ finished: global begin lumi for module: label = 'path2' id = 14
-++++++ starting: global begin lumi for module: label = 'path3' id = 15
-++++++ finished: global begin lumi for module: label = 'path3' id = 15
-++++++ starting: global begin lumi for module: label = 'path4' id = 16
-++++++ finished: global begin lumi for module: label = 'path4' id = 16
-++++++ starting: global begin lumi for module: label = 'endPath1' id = 17
-++++++ finished: global begin lumi for module: label = 'endPath1' id = 17
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
@@ -4901,26 +4373,10 @@
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global end lumi for module: label = 'get' id = 6
-++++++ finished: global end lumi for module: label = 'get' id = 6
-++++++ starting: global end lumi for module: label = 'putInt' id = 7
-++++++ finished: global end lumi for module: label = 'putInt' id = 7
-++++++ starting: global end lumi for module: label = 'putInt2' id = 8
-++++++ finished: global end lumi for module: label = 'putInt2' id = 8
-++++++ starting: global end lumi for module: label = 'putInt3' id = 9
-++++++ finished: global end lumi for module: label = 'putInt3' id = 9
 ++++++ starting: global end lumi for module: label = 'getInt' id = 10
 ++++++ finished: global end lumi for module: label = 'getInt' id = 10
 ++++++ starting: global end lumi for module: label = 'noPut' id = 11
 ++++++ finished: global end lumi for module: label = 'noPut' id = 11
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global end lumi for module: label = 'p1' id = 2
-++++++ finished: global end lumi for module: label = 'p1' id = 2
-++++++ starting: global end lumi for module: label = 'path1' id = 3
-++++++ finished: global end lumi for module: label = 'path1' id = 3
-++++++ starting: global end lumi for module: label = 'path2' id = 4
-++++++ finished: global end lumi for module: label = 'path2' id = 4
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
@@ -4932,26 +4388,12 @@
 ++++++ finished: global end lumi for module: label = 'test' id = 32
 ++++++ starting: global end lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 33
-++++++ starting: global end lumi for module: label = 'get' id = 34
-++++++ finished: global end lumi for module: label = 'get' id = 34
 ++++++ starting: global end lumi for module: label = 'getInt' id = 35
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global end lumi for module: label = 'out' id = 37
 ++++++ finished: global end lumi for module: label = 'out' id = 37
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 25
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 25
-++++++ starting: global end lumi for module: label = 'path1' id = 26
-++++++ finished: global end lumi for module: label = 'path1' id = 26
-++++++ starting: global end lumi for module: label = 'path2' id = 27
-++++++ finished: global end lumi for module: label = 'path2' id = 27
-++++++ starting: global end lumi for module: label = 'path3' id = 28
-++++++ finished: global end lumi for module: label = 'path3' id = 28
-++++++ starting: global end lumi for module: label = 'path4' id = 29
-++++++ finished: global end lumi for module: label = 'path4' id = 29
-++++++ starting: global end lumi for module: label = 'endPath1' id = 30
-++++++ finished: global end lumi for module: label = 'endPath1' id = 30
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -4959,26 +4401,12 @@
 ++++++ finished: global end lumi for module: label = 'test' id = 19
 ++++++ starting: global end lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
 ++++++ starting: global end lumi for module: label = 'getInt' id = 22
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global end lumi for module: label = 'path1' id = 13
-++++++ finished: global end lumi for module: label = 'path1' id = 13
-++++++ starting: global end lumi for module: label = 'path2' id = 14
-++++++ finished: global end lumi for module: label = 'path2' id = 14
-++++++ starting: global end lumi for module: label = 'path3' id = 15
-++++++ finished: global end lumi for module: label = 'path3' id = 15
-++++++ starting: global end lumi for module: label = 'path4' id = 16
-++++++ finished: global end lumi for module: label = 'path4' id = 16
-++++++ starting: global end lumi for module: label = 'endPath1' id = 17
-++++++ finished: global end lumi for module: label = 'endPath1' id = 17
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -4989,26 +4417,10 @@
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global begin lumi for module: label = 'get' id = 6
-++++++ finished: global begin lumi for module: label = 'get' id = 6
-++++++ starting: global begin lumi for module: label = 'putInt' id = 7
-++++++ finished: global begin lumi for module: label = 'putInt' id = 7
-++++++ starting: global begin lumi for module: label = 'putInt2' id = 8
-++++++ finished: global begin lumi for module: label = 'putInt2' id = 8
-++++++ starting: global begin lumi for module: label = 'putInt3' id = 9
-++++++ finished: global begin lumi for module: label = 'putInt3' id = 9
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 10
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 10
 ++++++ starting: global begin lumi for module: label = 'noPut' id = 11
 ++++++ finished: global begin lumi for module: label = 'noPut' id = 11
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin lumi for module: label = 'p1' id = 2
-++++++ finished: global begin lumi for module: label = 'p1' id = 2
-++++++ starting: global begin lumi for module: label = 'path1' id = 3
-++++++ finished: global begin lumi for module: label = 'path1' id = 3
-++++++ starting: global begin lumi for module: label = 'path2' id = 4
-++++++ finished: global begin lumi for module: label = 'path2' id = 4
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
@@ -5020,26 +4432,12 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 32
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
-++++++ starting: global begin lumi for module: label = 'get' id = 34
-++++++ finished: global begin lumi for module: label = 'get' id = 34
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 35
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global begin lumi for module: label = 'out' id = 37
 ++++++ finished: global begin lumi for module: label = 'out' id = 37
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 25
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 25
-++++++ starting: global begin lumi for module: label = 'path1' id = 26
-++++++ finished: global begin lumi for module: label = 'path1' id = 26
-++++++ starting: global begin lumi for module: label = 'path2' id = 27
-++++++ finished: global begin lumi for module: label = 'path2' id = 27
-++++++ starting: global begin lumi for module: label = 'path3' id = 28
-++++++ finished: global begin lumi for module: label = 'path3' id = 28
-++++++ starting: global begin lumi for module: label = 'path4' id = 29
-++++++ finished: global begin lumi for module: label = 'path4' id = 29
-++++++ starting: global begin lumi for module: label = 'endPath1' id = 30
-++++++ finished: global begin lumi for module: label = 'endPath1' id = 30
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -5047,26 +4445,12 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 19
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
-++++++ starting: global begin lumi for module: label = 'get' id = 21
-++++++ finished: global begin lumi for module: label = 'get' id = 21
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 22
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin lumi for module: label = 'out' id = 24
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global begin lumi for module: label = 'path1' id = 13
-++++++ finished: global begin lumi for module: label = 'path1' id = 13
-++++++ starting: global begin lumi for module: label = 'path2' id = 14
-++++++ finished: global begin lumi for module: label = 'path2' id = 14
-++++++ starting: global begin lumi for module: label = 'path3' id = 15
-++++++ finished: global begin lumi for module: label = 'path3' id = 15
-++++++ starting: global begin lumi for module: label = 'path4' id = 16
-++++++ finished: global begin lumi for module: label = 'path4' id = 16
-++++++ starting: global begin lumi for module: label = 'endPath1' id = 17
-++++++ finished: global begin lumi for module: label = 'endPath1' id = 17
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
@@ -5507,26 +4891,10 @@
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global end lumi for module: label = 'get' id = 6
-++++++ finished: global end lumi for module: label = 'get' id = 6
-++++++ starting: global end lumi for module: label = 'putInt' id = 7
-++++++ finished: global end lumi for module: label = 'putInt' id = 7
-++++++ starting: global end lumi for module: label = 'putInt2' id = 8
-++++++ finished: global end lumi for module: label = 'putInt2' id = 8
-++++++ starting: global end lumi for module: label = 'putInt3' id = 9
-++++++ finished: global end lumi for module: label = 'putInt3' id = 9
 ++++++ starting: global end lumi for module: label = 'getInt' id = 10
 ++++++ finished: global end lumi for module: label = 'getInt' id = 10
 ++++++ starting: global end lumi for module: label = 'noPut' id = 11
 ++++++ finished: global end lumi for module: label = 'noPut' id = 11
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global end lumi for module: label = 'p1' id = 2
-++++++ finished: global end lumi for module: label = 'p1' id = 2
-++++++ starting: global end lumi for module: label = 'path1' id = 3
-++++++ finished: global end lumi for module: label = 'path1' id = 3
-++++++ starting: global end lumi for module: label = 'path2' id = 4
-++++++ finished: global end lumi for module: label = 'path2' id = 4
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
@@ -5538,26 +4906,12 @@
 ++++++ finished: global end lumi for module: label = 'test' id = 32
 ++++++ starting: global end lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 33
-++++++ starting: global end lumi for module: label = 'get' id = 34
-++++++ finished: global end lumi for module: label = 'get' id = 34
 ++++++ starting: global end lumi for module: label = 'getInt' id = 35
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global end lumi for module: label = 'out' id = 37
 ++++++ finished: global end lumi for module: label = 'out' id = 37
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 25
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 25
-++++++ starting: global end lumi for module: label = 'path1' id = 26
-++++++ finished: global end lumi for module: label = 'path1' id = 26
-++++++ starting: global end lumi for module: label = 'path2' id = 27
-++++++ finished: global end lumi for module: label = 'path2' id = 27
-++++++ starting: global end lumi for module: label = 'path3' id = 28
-++++++ finished: global end lumi for module: label = 'path3' id = 28
-++++++ starting: global end lumi for module: label = 'path4' id = 29
-++++++ finished: global end lumi for module: label = 'path4' id = 29
-++++++ starting: global end lumi for module: label = 'endPath1' id = 30
-++++++ finished: global end lumi for module: label = 'endPath1' id = 30
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -5565,26 +4919,12 @@
 ++++++ finished: global end lumi for module: label = 'test' id = 19
 ++++++ starting: global end lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
 ++++++ starting: global end lumi for module: label = 'getInt' id = 22
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global end lumi for module: label = 'path1' id = 13
-++++++ finished: global end lumi for module: label = 'path1' id = 13
-++++++ starting: global end lumi for module: label = 'path2' id = 14
-++++++ finished: global end lumi for module: label = 'path2' id = 14
-++++++ starting: global end lumi for module: label = 'path3' id = 15
-++++++ finished: global end lumi for module: label = 'path3' id = 15
-++++++ starting: global end lumi for module: label = 'path4' id = 16
-++++++ finished: global end lumi for module: label = 'path4' id = 16
-++++++ starting: global end lumi for module: label = 'endPath1' id = 17
-++++++ finished: global end lumi for module: label = 'endPath1' id = 17
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: end run: stream = 0 run = 2 time = 100000001
 ++++ finished: end run: stream = 0 run = 2 time = 100000001
@@ -5647,26 +4987,10 @@
 ++++ starting: global end run 2 : time = 0
 ++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global end run for module: label = 'get' id = 6
-++++++ finished: global end run for module: label = 'get' id = 6
-++++++ starting: global end run for module: label = 'putInt' id = 7
-++++++ finished: global end run for module: label = 'putInt' id = 7
-++++++ starting: global end run for module: label = 'putInt2' id = 8
-++++++ finished: global end run for module: label = 'putInt2' id = 8
-++++++ starting: global end run for module: label = 'putInt3' id = 9
-++++++ finished: global end run for module: label = 'putInt3' id = 9
 ++++++ starting: global end run for module: label = 'getInt' id = 10
 ++++++ finished: global end run for module: label = 'getInt' id = 10
 ++++++ starting: global end run for module: label = 'noPut' id = 11
 ++++++ finished: global end run for module: label = 'noPut' id = 11
-++++++ starting: global end run for module: label = 'TriggerResults' id = 1
-++++++ finished: global end run for module: label = 'TriggerResults' id = 1
-++++++ starting: global end run for module: label = 'p1' id = 2
-++++++ finished: global end run for module: label = 'p1' id = 2
-++++++ starting: global end run for module: label = 'path1' id = 3
-++++++ finished: global end run for module: label = 'path1' id = 3
-++++++ starting: global end run for module: label = 'path2' id = 4
-++++++ finished: global end run for module: label = 'path2' id = 4
 ++++ finished: global end run 2 : time = 0
 ++++ starting: global end run 2 : time = 0
 ++++ finished: global end run 2 : time = 0
@@ -5678,26 +5002,12 @@
 ++++++ finished: global end run for module: label = 'test' id = 32
 ++++++ starting: global end run for module: label = 'testmerge' id = 33
 ++++++ finished: global end run for module: label = 'testmerge' id = 33
-++++++ starting: global end run for module: label = 'get' id = 34
-++++++ finished: global end run for module: label = 'get' id = 34
 ++++++ starting: global end run for module: label = 'getInt' id = 35
 ++++++ finished: global end run for module: label = 'getInt' id = 35
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global end run for module: label = 'out' id = 37
 ++++++ finished: global end run for module: label = 'out' id = 37
-++++++ starting: global end run for module: label = 'TriggerResults' id = 25
-++++++ finished: global end run for module: label = 'TriggerResults' id = 25
-++++++ starting: global end run for module: label = 'path1' id = 26
-++++++ finished: global end run for module: label = 'path1' id = 26
-++++++ starting: global end run for module: label = 'path2' id = 27
-++++++ finished: global end run for module: label = 'path2' id = 27
-++++++ starting: global end run for module: label = 'path3' id = 28
-++++++ finished: global end run for module: label = 'path3' id = 28
-++++++ starting: global end run for module: label = 'path4' id = 29
-++++++ finished: global end run for module: label = 'path4' id = 29
-++++++ starting: global end run for module: label = 'endPath1' id = 30
-++++++ finished: global end run for module: label = 'endPath1' id = 30
 ++++ finished: global end run 2 : time = 0
 ++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 18
@@ -5705,26 +5015,12 @@
 ++++++ finished: global end run for module: label = 'test' id = 19
 ++++++ starting: global end run for module: label = 'testmerge' id = 20
 ++++++ finished: global end run for module: label = 'testmerge' id = 20
-++++++ starting: global end run for module: label = 'get' id = 21
-++++++ finished: global end run for module: label = 'get' id = 21
 ++++++ starting: global end run for module: label = 'getInt' id = 22
 ++++++ finished: global end run for module: label = 'getInt' id = 22
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end run for module: label = 'out' id = 24
 ++++++ finished: global end run for module: label = 'out' id = 24
-++++++ starting: global end run for module: label = 'TriggerResults' id = 12
-++++++ finished: global end run for module: label = 'TriggerResults' id = 12
-++++++ starting: global end run for module: label = 'path1' id = 13
-++++++ finished: global end run for module: label = 'path1' id = 13
-++++++ starting: global end run for module: label = 'path2' id = 14
-++++++ finished: global end run for module: label = 'path2' id = 14
-++++++ starting: global end run for module: label = 'path3' id = 15
-++++++ finished: global end run for module: label = 'path3' id = 15
-++++++ starting: global end run for module: label = 'path4' id = 16
-++++++ finished: global end run for module: label = 'path4' id = 16
-++++++ starting: global end run for module: label = 'endPath1' id = 17
-++++++ finished: global end run for module: label = 'endPath1' id = 17
 ++++ finished: global end run 2 : time = 0
 ++++ starting: source run
 ++++ finished: source run
@@ -5735,26 +5031,10 @@
 ++++ starting: global begin run 3 : time = 105000001
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global begin run for module: label = 'get' id = 6
-++++++ finished: global begin run for module: label = 'get' id = 6
-++++++ starting: global begin run for module: label = 'putInt' id = 7
-++++++ finished: global begin run for module: label = 'putInt' id = 7
-++++++ starting: global begin run for module: label = 'putInt2' id = 8
-++++++ finished: global begin run for module: label = 'putInt2' id = 8
-++++++ starting: global begin run for module: label = 'putInt3' id = 9
-++++++ finished: global begin run for module: label = 'putInt3' id = 9
 ++++++ starting: global begin run for module: label = 'getInt' id = 10
 ++++++ finished: global begin run for module: label = 'getInt' id = 10
 ++++++ starting: global begin run for module: label = 'noPut' id = 11
 ++++++ finished: global begin run for module: label = 'noPut' id = 11
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin run for module: label = 'p1' id = 2
-++++++ finished: global begin run for module: label = 'p1' id = 2
-++++++ starting: global begin run for module: label = 'path1' id = 3
-++++++ finished: global begin run for module: label = 'path1' id = 3
-++++++ starting: global begin run for module: label = 'path2' id = 4
-++++++ finished: global begin run for module: label = 'path2' id = 4
 ++++ finished: global begin run 3 : time = 105000001
 ++++ starting: global begin run 3 : time = 105000001
 ++++ finished: global begin run 3 : time = 105000001
@@ -5766,26 +5046,12 @@
 ++++++ finished: global begin run for module: label = 'test' id = 32
 ++++++ starting: global begin run for module: label = 'testmerge' id = 33
 ++++++ finished: global begin run for module: label = 'testmerge' id = 33
-++++++ starting: global begin run for module: label = 'get' id = 34
-++++++ finished: global begin run for module: label = 'get' id = 34
 ++++++ starting: global begin run for module: label = 'getInt' id = 35
 ++++++ finished: global begin run for module: label = 'getInt' id = 35
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global begin run for module: label = 'out' id = 37
 ++++++ finished: global begin run for module: label = 'out' id = 37
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 25
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 25
-++++++ starting: global begin run for module: label = 'path1' id = 26
-++++++ finished: global begin run for module: label = 'path1' id = 26
-++++++ starting: global begin run for module: label = 'path2' id = 27
-++++++ finished: global begin run for module: label = 'path2' id = 27
-++++++ starting: global begin run for module: label = 'path3' id = 28
-++++++ finished: global begin run for module: label = 'path3' id = 28
-++++++ starting: global begin run for module: label = 'path4' id = 29
-++++++ finished: global begin run for module: label = 'path4' id = 29
-++++++ starting: global begin run for module: label = 'endPath1' id = 30
-++++++ finished: global begin run for module: label = 'endPath1' id = 30
 ++++ finished: global begin run 3 : time = 105000001
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 18
@@ -5793,26 +5059,12 @@
 ++++++ finished: global begin run for module: label = 'test' id = 19
 ++++++ starting: global begin run for module: label = 'testmerge' id = 20
 ++++++ finished: global begin run for module: label = 'testmerge' id = 20
-++++++ starting: global begin run for module: label = 'get' id = 21
-++++++ finished: global begin run for module: label = 'get' id = 21
 ++++++ starting: global begin run for module: label = 'getInt' id = 22
 ++++++ finished: global begin run for module: label = 'getInt' id = 22
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin run for module: label = 'out' id = 24
 ++++++ finished: global begin run for module: label = 'out' id = 24
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 12
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 12
-++++++ starting: global begin run for module: label = 'path1' id = 13
-++++++ finished: global begin run for module: label = 'path1' id = 13
-++++++ starting: global begin run for module: label = 'path2' id = 14
-++++++ finished: global begin run for module: label = 'path2' id = 14
-++++++ starting: global begin run for module: label = 'path3' id = 15
-++++++ finished: global begin run for module: label = 'path3' id = 15
-++++++ starting: global begin run for module: label = 'path4' id = 16
-++++++ finished: global begin run for module: label = 'path4' id = 16
-++++++ starting: global begin run for module: label = 'endPath1' id = 17
-++++++ finished: global begin run for module: label = 'endPath1' id = 17
 ++++ finished: global begin run 3 : time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
@@ -5877,26 +5129,10 @@
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global begin lumi for module: label = 'get' id = 6
-++++++ finished: global begin lumi for module: label = 'get' id = 6
-++++++ starting: global begin lumi for module: label = 'putInt' id = 7
-++++++ finished: global begin lumi for module: label = 'putInt' id = 7
-++++++ starting: global begin lumi for module: label = 'putInt2' id = 8
-++++++ finished: global begin lumi for module: label = 'putInt2' id = 8
-++++++ starting: global begin lumi for module: label = 'putInt3' id = 9
-++++++ finished: global begin lumi for module: label = 'putInt3' id = 9
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 10
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 10
 ++++++ starting: global begin lumi for module: label = 'noPut' id = 11
 ++++++ finished: global begin lumi for module: label = 'noPut' id = 11
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin lumi for module: label = 'p1' id = 2
-++++++ finished: global begin lumi for module: label = 'p1' id = 2
-++++++ starting: global begin lumi for module: label = 'path1' id = 3
-++++++ finished: global begin lumi for module: label = 'path1' id = 3
-++++++ starting: global begin lumi for module: label = 'path2' id = 4
-++++++ finished: global begin lumi for module: label = 'path2' id = 4
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
@@ -5908,26 +5144,12 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 32
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
-++++++ starting: global begin lumi for module: label = 'get' id = 34
-++++++ finished: global begin lumi for module: label = 'get' id = 34
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 35
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global begin lumi for module: label = 'out' id = 37
 ++++++ finished: global begin lumi for module: label = 'out' id = 37
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 25
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 25
-++++++ starting: global begin lumi for module: label = 'path1' id = 26
-++++++ finished: global begin lumi for module: label = 'path1' id = 26
-++++++ starting: global begin lumi for module: label = 'path2' id = 27
-++++++ finished: global begin lumi for module: label = 'path2' id = 27
-++++++ starting: global begin lumi for module: label = 'path3' id = 28
-++++++ finished: global begin lumi for module: label = 'path3' id = 28
-++++++ starting: global begin lumi for module: label = 'path4' id = 29
-++++++ finished: global begin lumi for module: label = 'path4' id = 29
-++++++ starting: global begin lumi for module: label = 'endPath1' id = 30
-++++++ finished: global begin lumi for module: label = 'endPath1' id = 30
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -5935,26 +5157,12 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 19
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
-++++++ starting: global begin lumi for module: label = 'get' id = 21
-++++++ finished: global begin lumi for module: label = 'get' id = 21
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 22
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin lumi for module: label = 'out' id = 24
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global begin lumi for module: label = 'path1' id = 13
-++++++ finished: global begin lumi for module: label = 'path1' id = 13
-++++++ starting: global begin lumi for module: label = 'path2' id = 14
-++++++ finished: global begin lumi for module: label = 'path2' id = 14
-++++++ starting: global begin lumi for module: label = 'path3' id = 15
-++++++ finished: global begin lumi for module: label = 'path3' id = 15
-++++++ starting: global begin lumi for module: label = 'path4' id = 16
-++++++ finished: global begin lumi for module: label = 'path4' id = 16
-++++++ starting: global begin lumi for module: label = 'endPath1' id = 17
-++++++ finished: global begin lumi for module: label = 'endPath1' id = 17
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
@@ -6719,26 +5927,10 @@
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global end lumi for module: label = 'get' id = 6
-++++++ finished: global end lumi for module: label = 'get' id = 6
-++++++ starting: global end lumi for module: label = 'putInt' id = 7
-++++++ finished: global end lumi for module: label = 'putInt' id = 7
-++++++ starting: global end lumi for module: label = 'putInt2' id = 8
-++++++ finished: global end lumi for module: label = 'putInt2' id = 8
-++++++ starting: global end lumi for module: label = 'putInt3' id = 9
-++++++ finished: global end lumi for module: label = 'putInt3' id = 9
 ++++++ starting: global end lumi for module: label = 'getInt' id = 10
 ++++++ finished: global end lumi for module: label = 'getInt' id = 10
 ++++++ starting: global end lumi for module: label = 'noPut' id = 11
 ++++++ finished: global end lumi for module: label = 'noPut' id = 11
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global end lumi for module: label = 'p1' id = 2
-++++++ finished: global end lumi for module: label = 'p1' id = 2
-++++++ starting: global end lumi for module: label = 'path1' id = 3
-++++++ finished: global end lumi for module: label = 'path1' id = 3
-++++++ starting: global end lumi for module: label = 'path2' id = 4
-++++++ finished: global end lumi for module: label = 'path2' id = 4
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
@@ -6750,26 +5942,12 @@
 ++++++ finished: global end lumi for module: label = 'test' id = 32
 ++++++ starting: global end lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 33
-++++++ starting: global end lumi for module: label = 'get' id = 34
-++++++ finished: global end lumi for module: label = 'get' id = 34
 ++++++ starting: global end lumi for module: label = 'getInt' id = 35
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global end lumi for module: label = 'out' id = 37
 ++++++ finished: global end lumi for module: label = 'out' id = 37
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 25
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 25
-++++++ starting: global end lumi for module: label = 'path1' id = 26
-++++++ finished: global end lumi for module: label = 'path1' id = 26
-++++++ starting: global end lumi for module: label = 'path2' id = 27
-++++++ finished: global end lumi for module: label = 'path2' id = 27
-++++++ starting: global end lumi for module: label = 'path3' id = 28
-++++++ finished: global end lumi for module: label = 'path3' id = 28
-++++++ starting: global end lumi for module: label = 'path4' id = 29
-++++++ finished: global end lumi for module: label = 'path4' id = 29
-++++++ starting: global end lumi for module: label = 'endPath1' id = 30
-++++++ finished: global end lumi for module: label = 'endPath1' id = 30
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -6777,26 +5955,12 @@
 ++++++ finished: global end lumi for module: label = 'test' id = 19
 ++++++ starting: global end lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
 ++++++ starting: global end lumi for module: label = 'getInt' id = 22
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global end lumi for module: label = 'path1' id = 13
-++++++ finished: global end lumi for module: label = 'path1' id = 13
-++++++ starting: global end lumi for module: label = 'path2' id = 14
-++++++ finished: global end lumi for module: label = 'path2' id = 14
-++++++ starting: global end lumi for module: label = 'path3' id = 15
-++++++ finished: global end lumi for module: label = 'path3' id = 15
-++++++ starting: global end lumi for module: label = 'path4' id = 16
-++++++ finished: global end lumi for module: label = 'path4' id = 16
-++++++ starting: global end lumi for module: label = 'endPath1' id = 17
-++++++ finished: global end lumi for module: label = 'endPath1' id = 17
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -6807,26 +5971,10 @@
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global begin lumi for module: label = 'get' id = 6
-++++++ finished: global begin lumi for module: label = 'get' id = 6
-++++++ starting: global begin lumi for module: label = 'putInt' id = 7
-++++++ finished: global begin lumi for module: label = 'putInt' id = 7
-++++++ starting: global begin lumi for module: label = 'putInt2' id = 8
-++++++ finished: global begin lumi for module: label = 'putInt2' id = 8
-++++++ starting: global begin lumi for module: label = 'putInt3' id = 9
-++++++ finished: global begin lumi for module: label = 'putInt3' id = 9
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 10
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 10
 ++++++ starting: global begin lumi for module: label = 'noPut' id = 11
 ++++++ finished: global begin lumi for module: label = 'noPut' id = 11
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin lumi for module: label = 'p1' id = 2
-++++++ finished: global begin lumi for module: label = 'p1' id = 2
-++++++ starting: global begin lumi for module: label = 'path1' id = 3
-++++++ finished: global begin lumi for module: label = 'path1' id = 3
-++++++ starting: global begin lumi for module: label = 'path2' id = 4
-++++++ finished: global begin lumi for module: label = 'path2' id = 4
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
@@ -6838,26 +5986,12 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 32
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
-++++++ starting: global begin lumi for module: label = 'get' id = 34
-++++++ finished: global begin lumi for module: label = 'get' id = 34
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 35
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global begin lumi for module: label = 'out' id = 37
 ++++++ finished: global begin lumi for module: label = 'out' id = 37
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 25
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 25
-++++++ starting: global begin lumi for module: label = 'path1' id = 26
-++++++ finished: global begin lumi for module: label = 'path1' id = 26
-++++++ starting: global begin lumi for module: label = 'path2' id = 27
-++++++ finished: global begin lumi for module: label = 'path2' id = 27
-++++++ starting: global begin lumi for module: label = 'path3' id = 28
-++++++ finished: global begin lumi for module: label = 'path3' id = 28
-++++++ starting: global begin lumi for module: label = 'path4' id = 29
-++++++ finished: global begin lumi for module: label = 'path4' id = 29
-++++++ starting: global begin lumi for module: label = 'endPath1' id = 30
-++++++ finished: global begin lumi for module: label = 'endPath1' id = 30
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -6865,26 +5999,12 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 19
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
-++++++ starting: global begin lumi for module: label = 'get' id = 21
-++++++ finished: global begin lumi for module: label = 'get' id = 21
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 22
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin lumi for module: label = 'out' id = 24
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global begin lumi for module: label = 'path1' id = 13
-++++++ finished: global begin lumi for module: label = 'path1' id = 13
-++++++ starting: global begin lumi for module: label = 'path2' id = 14
-++++++ finished: global begin lumi for module: label = 'path2' id = 14
-++++++ starting: global begin lumi for module: label = 'path3' id = 15
-++++++ finished: global begin lumi for module: label = 'path3' id = 15
-++++++ starting: global begin lumi for module: label = 'path4' id = 16
-++++++ finished: global begin lumi for module: label = 'path4' id = 16
-++++++ starting: global begin lumi for module: label = 'endPath1' id = 17
-++++++ finished: global begin lumi for module: label = 'endPath1' id = 17
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
@@ -7649,26 +6769,10 @@
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global end lumi for module: label = 'get' id = 6
-++++++ finished: global end lumi for module: label = 'get' id = 6
-++++++ starting: global end lumi for module: label = 'putInt' id = 7
-++++++ finished: global end lumi for module: label = 'putInt' id = 7
-++++++ starting: global end lumi for module: label = 'putInt2' id = 8
-++++++ finished: global end lumi for module: label = 'putInt2' id = 8
-++++++ starting: global end lumi for module: label = 'putInt3' id = 9
-++++++ finished: global end lumi for module: label = 'putInt3' id = 9
 ++++++ starting: global end lumi for module: label = 'getInt' id = 10
 ++++++ finished: global end lumi for module: label = 'getInt' id = 10
 ++++++ starting: global end lumi for module: label = 'noPut' id = 11
 ++++++ finished: global end lumi for module: label = 'noPut' id = 11
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global end lumi for module: label = 'p1' id = 2
-++++++ finished: global end lumi for module: label = 'p1' id = 2
-++++++ starting: global end lumi for module: label = 'path1' id = 3
-++++++ finished: global end lumi for module: label = 'path1' id = 3
-++++++ starting: global end lumi for module: label = 'path2' id = 4
-++++++ finished: global end lumi for module: label = 'path2' id = 4
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
@@ -7680,26 +6784,12 @@
 ++++++ finished: global end lumi for module: label = 'test' id = 32
 ++++++ starting: global end lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 33
-++++++ starting: global end lumi for module: label = 'get' id = 34
-++++++ finished: global end lumi for module: label = 'get' id = 34
 ++++++ starting: global end lumi for module: label = 'getInt' id = 35
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global end lumi for module: label = 'out' id = 37
 ++++++ finished: global end lumi for module: label = 'out' id = 37
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 25
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 25
-++++++ starting: global end lumi for module: label = 'path1' id = 26
-++++++ finished: global end lumi for module: label = 'path1' id = 26
-++++++ starting: global end lumi for module: label = 'path2' id = 27
-++++++ finished: global end lumi for module: label = 'path2' id = 27
-++++++ starting: global end lumi for module: label = 'path3' id = 28
-++++++ finished: global end lumi for module: label = 'path3' id = 28
-++++++ starting: global end lumi for module: label = 'path4' id = 29
-++++++ finished: global end lumi for module: label = 'path4' id = 29
-++++++ starting: global end lumi for module: label = 'endPath1' id = 30
-++++++ finished: global end lumi for module: label = 'endPath1' id = 30
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -7707,26 +6797,12 @@
 ++++++ finished: global end lumi for module: label = 'test' id = 19
 ++++++ starting: global end lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
 ++++++ starting: global end lumi for module: label = 'getInt' id = 22
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global end lumi for module: label = 'path1' id = 13
-++++++ finished: global end lumi for module: label = 'path1' id = 13
-++++++ starting: global end lumi for module: label = 'path2' id = 14
-++++++ finished: global end lumi for module: label = 'path2' id = 14
-++++++ starting: global end lumi for module: label = 'path3' id = 15
-++++++ finished: global end lumi for module: label = 'path3' id = 15
-++++++ starting: global end lumi for module: label = 'path4' id = 16
-++++++ finished: global end lumi for module: label = 'path4' id = 16
-++++++ starting: global end lumi for module: label = 'endPath1' id = 17
-++++++ finished: global end lumi for module: label = 'endPath1' id = 17
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -7737,26 +6813,10 @@
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global begin lumi for module: label = 'get' id = 6
-++++++ finished: global begin lumi for module: label = 'get' id = 6
-++++++ starting: global begin lumi for module: label = 'putInt' id = 7
-++++++ finished: global begin lumi for module: label = 'putInt' id = 7
-++++++ starting: global begin lumi for module: label = 'putInt2' id = 8
-++++++ finished: global begin lumi for module: label = 'putInt2' id = 8
-++++++ starting: global begin lumi for module: label = 'putInt3' id = 9
-++++++ finished: global begin lumi for module: label = 'putInt3' id = 9
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 10
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 10
 ++++++ starting: global begin lumi for module: label = 'noPut' id = 11
 ++++++ finished: global begin lumi for module: label = 'noPut' id = 11
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global begin lumi for module: label = 'p1' id = 2
-++++++ finished: global begin lumi for module: label = 'p1' id = 2
-++++++ starting: global begin lumi for module: label = 'path1' id = 3
-++++++ finished: global begin lumi for module: label = 'path1' id = 3
-++++++ starting: global begin lumi for module: label = 'path2' id = 4
-++++++ finished: global begin lumi for module: label = 'path2' id = 4
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
@@ -7768,26 +6828,12 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 32
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
-++++++ starting: global begin lumi for module: label = 'get' id = 34
-++++++ finished: global begin lumi for module: label = 'get' id = 34
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 35
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global begin lumi for module: label = 'out' id = 37
 ++++++ finished: global begin lumi for module: label = 'out' id = 37
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 25
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 25
-++++++ starting: global begin lumi for module: label = 'path1' id = 26
-++++++ finished: global begin lumi for module: label = 'path1' id = 26
-++++++ starting: global begin lumi for module: label = 'path2' id = 27
-++++++ finished: global begin lumi for module: label = 'path2' id = 27
-++++++ starting: global begin lumi for module: label = 'path3' id = 28
-++++++ finished: global begin lumi for module: label = 'path3' id = 28
-++++++ starting: global begin lumi for module: label = 'path4' id = 29
-++++++ finished: global begin lumi for module: label = 'path4' id = 29
-++++++ starting: global begin lumi for module: label = 'endPath1' id = 30
-++++++ finished: global begin lumi for module: label = 'endPath1' id = 30
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -7795,26 +6841,12 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 19
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
-++++++ starting: global begin lumi for module: label = 'get' id = 21
-++++++ finished: global begin lumi for module: label = 'get' id = 21
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 22
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin lumi for module: label = 'out' id = 24
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global begin lumi for module: label = 'path1' id = 13
-++++++ finished: global begin lumi for module: label = 'path1' id = 13
-++++++ starting: global begin lumi for module: label = 'path2' id = 14
-++++++ finished: global begin lumi for module: label = 'path2' id = 14
-++++++ starting: global begin lumi for module: label = 'path3' id = 15
-++++++ finished: global begin lumi for module: label = 'path3' id = 15
-++++++ starting: global begin lumi for module: label = 'path4' id = 16
-++++++ finished: global begin lumi for module: label = 'path4' id = 16
-++++++ starting: global begin lumi for module: label = 'endPath1' id = 17
-++++++ finished: global begin lumi for module: label = 'endPath1' id = 17
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
@@ -8255,26 +7287,10 @@
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global end lumi for module: label = 'get' id = 6
-++++++ finished: global end lumi for module: label = 'get' id = 6
-++++++ starting: global end lumi for module: label = 'putInt' id = 7
-++++++ finished: global end lumi for module: label = 'putInt' id = 7
-++++++ starting: global end lumi for module: label = 'putInt2' id = 8
-++++++ finished: global end lumi for module: label = 'putInt2' id = 8
-++++++ starting: global end lumi for module: label = 'putInt3' id = 9
-++++++ finished: global end lumi for module: label = 'putInt3' id = 9
 ++++++ starting: global end lumi for module: label = 'getInt' id = 10
 ++++++ finished: global end lumi for module: label = 'getInt' id = 10
 ++++++ starting: global end lumi for module: label = 'noPut' id = 11
 ++++++ finished: global end lumi for module: label = 'noPut' id = 11
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
-++++++ starting: global end lumi for module: label = 'p1' id = 2
-++++++ finished: global end lumi for module: label = 'p1' id = 2
-++++++ starting: global end lumi for module: label = 'path1' id = 3
-++++++ finished: global end lumi for module: label = 'path1' id = 3
-++++++ starting: global end lumi for module: label = 'path2' id = 4
-++++++ finished: global end lumi for module: label = 'path2' id = 4
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
@@ -8286,26 +7302,12 @@
 ++++++ finished: global end lumi for module: label = 'test' id = 32
 ++++++ starting: global end lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 33
-++++++ starting: global end lumi for module: label = 'get' id = 34
-++++++ finished: global end lumi for module: label = 'get' id = 34
 ++++++ starting: global end lumi for module: label = 'getInt' id = 35
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global end lumi for module: label = 'out' id = 37
 ++++++ finished: global end lumi for module: label = 'out' id = 37
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 25
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 25
-++++++ starting: global end lumi for module: label = 'path1' id = 26
-++++++ finished: global end lumi for module: label = 'path1' id = 26
-++++++ starting: global end lumi for module: label = 'path2' id = 27
-++++++ finished: global end lumi for module: label = 'path2' id = 27
-++++++ starting: global end lumi for module: label = 'path3' id = 28
-++++++ finished: global end lumi for module: label = 'path3' id = 28
-++++++ starting: global end lumi for module: label = 'path4' id = 29
-++++++ finished: global end lumi for module: label = 'path4' id = 29
-++++++ starting: global end lumi for module: label = 'endPath1' id = 30
-++++++ finished: global end lumi for module: label = 'endPath1' id = 30
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -8313,26 +7315,12 @@
 ++++++ finished: global end lumi for module: label = 'test' id = 19
 ++++++ starting: global end lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
 ++++++ starting: global end lumi for module: label = 'getInt' id = 22
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
-++++++ starting: global end lumi for module: label = 'path1' id = 13
-++++++ finished: global end lumi for module: label = 'path1' id = 13
-++++++ starting: global end lumi for module: label = 'path2' id = 14
-++++++ finished: global end lumi for module: label = 'path2' id = 14
-++++++ starting: global end lumi for module: label = 'path3' id = 15
-++++++ finished: global end lumi for module: label = 'path3' id = 15
-++++++ starting: global end lumi for module: label = 'path4' id = 16
-++++++ finished: global end lumi for module: label = 'path4' id = 16
-++++++ starting: global end lumi for module: label = 'endPath1' id = 17
-++++++ finished: global end lumi for module: label = 'endPath1' id = 17
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: end run: stream = 0 run = 3 time = 150000001
 ++++ finished: end run: stream = 0 run = 3 time = 150000001
@@ -8395,26 +7383,10 @@
 ++++ starting: global end run 3 : time = 0
 ++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 5
-++++++ starting: global end run for module: label = 'get' id = 6
-++++++ finished: global end run for module: label = 'get' id = 6
-++++++ starting: global end run for module: label = 'putInt' id = 7
-++++++ finished: global end run for module: label = 'putInt' id = 7
-++++++ starting: global end run for module: label = 'putInt2' id = 8
-++++++ finished: global end run for module: label = 'putInt2' id = 8
-++++++ starting: global end run for module: label = 'putInt3' id = 9
-++++++ finished: global end run for module: label = 'putInt3' id = 9
 ++++++ starting: global end run for module: label = 'getInt' id = 10
 ++++++ finished: global end run for module: label = 'getInt' id = 10
 ++++++ starting: global end run for module: label = 'noPut' id = 11
 ++++++ finished: global end run for module: label = 'noPut' id = 11
-++++++ starting: global end run for module: label = 'TriggerResults' id = 1
-++++++ finished: global end run for module: label = 'TriggerResults' id = 1
-++++++ starting: global end run for module: label = 'p1' id = 2
-++++++ finished: global end run for module: label = 'p1' id = 2
-++++++ starting: global end run for module: label = 'path1' id = 3
-++++++ finished: global end run for module: label = 'path1' id = 3
-++++++ starting: global end run for module: label = 'path2' id = 4
-++++++ finished: global end run for module: label = 'path2' id = 4
 ++++ finished: global end run 3 : time = 0
 ++++ starting: global end run 3 : time = 0
 ++++ finished: global end run 3 : time = 0
@@ -8426,26 +7398,12 @@
 ++++++ finished: global end run for module: label = 'test' id = 32
 ++++++ starting: global end run for module: label = 'testmerge' id = 33
 ++++++ finished: global end run for module: label = 'testmerge' id = 33
-++++++ starting: global end run for module: label = 'get' id = 34
-++++++ finished: global end run for module: label = 'get' id = 34
 ++++++ starting: global end run for module: label = 'getInt' id = 35
 ++++++ finished: global end run for module: label = 'getInt' id = 35
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 36
 ++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 36
 ++++++ starting: global end run for module: label = 'out' id = 37
 ++++++ finished: global end run for module: label = 'out' id = 37
-++++++ starting: global end run for module: label = 'TriggerResults' id = 25
-++++++ finished: global end run for module: label = 'TriggerResults' id = 25
-++++++ starting: global end run for module: label = 'path1' id = 26
-++++++ finished: global end run for module: label = 'path1' id = 26
-++++++ starting: global end run for module: label = 'path2' id = 27
-++++++ finished: global end run for module: label = 'path2' id = 27
-++++++ starting: global end run for module: label = 'path3' id = 28
-++++++ finished: global end run for module: label = 'path3' id = 28
-++++++ starting: global end run for module: label = 'path4' id = 29
-++++++ finished: global end run for module: label = 'path4' id = 29
-++++++ starting: global end run for module: label = 'endPath1' id = 30
-++++++ finished: global end run for module: label = 'endPath1' id = 30
 ++++ finished: global end run 3 : time = 0
 ++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 18
@@ -8453,26 +7411,12 @@
 ++++++ finished: global end run for module: label = 'test' id = 19
 ++++++ starting: global end run for module: label = 'testmerge' id = 20
 ++++++ finished: global end run for module: label = 'testmerge' id = 20
-++++++ starting: global end run for module: label = 'get' id = 21
-++++++ finished: global end run for module: label = 'get' id = 21
 ++++++ starting: global end run for module: label = 'getInt' id = 22
 ++++++ finished: global end run for module: label = 'getInt' id = 22
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end run for module: label = 'out' id = 24
 ++++++ finished: global end run for module: label = 'out' id = 24
-++++++ starting: global end run for module: label = 'TriggerResults' id = 12
-++++++ finished: global end run for module: label = 'TriggerResults' id = 12
-++++++ starting: global end run for module: label = 'path1' id = 13
-++++++ finished: global end run for module: label = 'path1' id = 13
-++++++ starting: global end run for module: label = 'path2' id = 14
-++++++ finished: global end run for module: label = 'path2' id = 14
-++++++ starting: global end run for module: label = 'path3' id = 15
-++++++ finished: global end run for module: label = 'path3' id = 15
-++++++ starting: global end run for module: label = 'path4' id = 16
-++++++ finished: global end run for module: label = 'path4' id = 16
-++++++ starting: global end run for module: label = 'endPath1' id = 17
-++++++ finished: global end run for module: label = 'endPath1' id = 17
 ++++ finished: global end run 3 : time = 0
 ++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -279,10 +279,6 @@
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
-++++++ starting: begin run for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: begin run for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 8
@@ -291,42 +287,16 @@
 ++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: begin run for module: stream = 0 label = 'get' id = 6
 ++++++ finished: begin run for module: stream = 0 label = 'get' id = 6
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
-++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: begin run for module: stream = 0 label = 'get' id = 34
 ++++++ finished: begin run for module: stream = 0 label = 'get' id = 34
-++++++ starting: begin run for module: stream = 0 label = 'test' id = 32
-++++++ finished: begin run for module: stream = 0 label = 'test' id = 32
-++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: begin run for module: stream = 0 label = 'out' id = 37
-++++++ finished: begin run for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
-++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: begin run for module: stream = 0 label = 'get' id = 21
 ++++++ finished: begin run for module: stream = 0 label = 'get' id = 21
-++++++ starting: begin run for module: stream = 0 label = 'test' id = 19
-++++++ finished: begin run for module: stream = 0 label = 'test' id = 19
-++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: begin run for module: stream = 0 label = 'out' id = 24
-++++++ finished: begin run for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -377,10 +347,6 @@
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
@@ -389,42 +355,16 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 32
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 32
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 37
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: source event
 ++++ finished: source event
@@ -1079,10 +1019,6 @@
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
@@ -1091,42 +1027,16 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 32
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 32
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 37
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
@@ -1219,10 +1129,6 @@
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
@@ -1231,42 +1137,16 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 32
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 32
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 37
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: source event
 ++++ finished: source event
@@ -1921,10 +1801,6 @@
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
@@ -1933,42 +1809,16 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 32
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 32
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 37
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
@@ -2061,10 +1911,6 @@
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
@@ -2073,42 +1919,16 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 32
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 32
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 37
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: source event
 ++++ finished: source event
@@ -2439,10 +2259,6 @@
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
@@ -2451,42 +2267,16 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 32
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 32
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 37
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
@@ -2535,10 +2325,6 @@
 ++++ starting: end run: stream = 0 run = 1 time = 0
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: end run: stream = 0 run = 1 time = 0
-++++++ starting: end run for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: end run for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 8
@@ -2547,42 +2333,16 @@
 ++++++ finished: end run for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: end run for module: stream = 0 label = 'get' id = 6
 ++++++ finished: end run for module: stream = 0 label = 'get' id = 6
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: end run: stream = 0 run = 1 time = 0
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: end run: stream = 0 run = 1 time = 0
-++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: end run for module: stream = 0 label = 'get' id = 34
 ++++++ finished: end run for module: stream = 0 label = 'get' id = 34
-++++++ starting: end run for module: stream = 0 label = 'test' id = 32
-++++++ finished: end run for module: stream = 0 label = 'test' id = 32
-++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: end run for module: stream = 0 label = 'out' id = 37
-++++++ finished: end run for module: stream = 0 label = 'out' id = 37
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: end run: stream = 0 run = 1 time = 0
-++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: end run for module: stream = 0 label = 'get' id = 21
 ++++++ finished: end run for module: stream = 0 label = 'get' id = 21
-++++++ starting: end run for module: stream = 0 label = 'test' id = 19
-++++++ finished: end run for module: stream = 0 label = 'test' id = 19
-++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: end run for module: stream = 0 label = 'out' id = 24
-++++++ finished: end run for module: stream = 0 label = 'out' id = 24
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: global end run 1 : time = 50000001
 ++++ finished: global end run 1 : time = 50000001
@@ -2675,10 +2435,6 @@
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
-++++++ starting: begin run for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: begin run for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 8
@@ -2687,42 +2443,16 @@
 ++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: begin run for module: stream = 0 label = 'get' id = 6
 ++++++ finished: begin run for module: stream = 0 label = 'get' id = 6
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
-++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: begin run for module: stream = 0 label = 'get' id = 34
 ++++++ finished: begin run for module: stream = 0 label = 'get' id = 34
-++++++ starting: begin run for module: stream = 0 label = 'test' id = 32
-++++++ finished: begin run for module: stream = 0 label = 'test' id = 32
-++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: begin run for module: stream = 0 label = 'out' id = 37
-++++++ finished: begin run for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
-++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: begin run for module: stream = 0 label = 'get' id = 21
 ++++++ finished: begin run for module: stream = 0 label = 'get' id = 21
-++++++ starting: begin run for module: stream = 0 label = 'test' id = 19
-++++++ finished: begin run for module: stream = 0 label = 'test' id = 19
-++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: begin run for module: stream = 0 label = 'out' id = 24
-++++++ finished: begin run for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -2773,10 +2503,6 @@
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
@@ -2785,42 +2511,16 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 32
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 32
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 37
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: source event
 ++++ finished: source event
@@ -3475,10 +3175,6 @@
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
@@ -3487,42 +3183,16 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 32
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 32
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 37
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
@@ -3615,10 +3285,6 @@
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
@@ -3627,42 +3293,16 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 32
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 32
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 37
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: source event
 ++++ finished: source event
@@ -4317,10 +3957,6 @@
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
@@ -4329,42 +3965,16 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 32
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 32
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 37
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
@@ -4457,10 +4067,6 @@
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
@@ -4469,42 +4075,16 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 32
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 32
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 37
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: source event
 ++++ finished: source event
@@ -4835,10 +4415,6 @@
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
@@ -4847,42 +4423,16 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 32
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 32
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 37
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
@@ -4931,10 +4481,6 @@
 ++++ starting: end run: stream = 0 run = 2 time = 0
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: end run: stream = 0 run = 2 time = 0
-++++++ starting: end run for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: end run for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 8
@@ -4943,42 +4489,16 @@
 ++++++ finished: end run for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: end run for module: stream = 0 label = 'get' id = 6
 ++++++ finished: end run for module: stream = 0 label = 'get' id = 6
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: end run: stream = 0 run = 2 time = 0
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: end run: stream = 0 run = 2 time = 0
-++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: end run for module: stream = 0 label = 'get' id = 34
 ++++++ finished: end run for module: stream = 0 label = 'get' id = 34
-++++++ starting: end run for module: stream = 0 label = 'test' id = 32
-++++++ finished: end run for module: stream = 0 label = 'test' id = 32
-++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: end run for module: stream = 0 label = 'out' id = 37
-++++++ finished: end run for module: stream = 0 label = 'out' id = 37
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: end run: stream = 0 run = 2 time = 0
-++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: end run for module: stream = 0 label = 'get' id = 21
 ++++++ finished: end run for module: stream = 0 label = 'get' id = 21
-++++++ starting: end run for module: stream = 0 label = 'test' id = 19
-++++++ finished: end run for module: stream = 0 label = 'test' id = 19
-++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: end run for module: stream = 0 label = 'out' id = 24
-++++++ finished: end run for module: stream = 0 label = 'out' id = 24
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: global end run 2 : time = 100000001
 ++++ finished: global end run 2 : time = 100000001
@@ -5071,10 +4591,6 @@
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
-++++++ starting: begin run for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: begin run for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 8
@@ -5083,42 +4599,16 @@
 ++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: begin run for module: stream = 0 label = 'get' id = 6
 ++++++ finished: begin run for module: stream = 0 label = 'get' id = 6
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
-++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: begin run for module: stream = 0 label = 'get' id = 34
 ++++++ finished: begin run for module: stream = 0 label = 'get' id = 34
-++++++ starting: begin run for module: stream = 0 label = 'test' id = 32
-++++++ finished: begin run for module: stream = 0 label = 'test' id = 32
-++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: begin run for module: stream = 0 label = 'out' id = 37
-++++++ finished: begin run for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
-++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: begin run for module: stream = 0 label = 'get' id = 21
 ++++++ finished: begin run for module: stream = 0 label = 'get' id = 21
-++++++ starting: begin run for module: stream = 0 label = 'test' id = 19
-++++++ finished: begin run for module: stream = 0 label = 'test' id = 19
-++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: begin run for module: stream = 0 label = 'out' id = 24
-++++++ finished: begin run for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -5169,10 +4659,6 @@
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
@@ -5181,42 +4667,16 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 32
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 32
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 37
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: source event
 ++++ finished: source event
@@ -5871,10 +5331,6 @@
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
@@ -5883,42 +5339,16 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 32
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 32
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 37
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
@@ -6011,10 +5441,6 @@
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
@@ -6023,42 +5449,16 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 32
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 32
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 37
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: source event
 ++++ finished: source event
@@ -6713,10 +6113,6 @@
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
@@ -6725,42 +6121,16 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 32
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 32
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 37
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
@@ -6853,10 +6223,6 @@
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
@@ -6865,42 +6231,16 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 32
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 32
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 37
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: source event
 ++++ finished: source event
@@ -7231,10 +6571,6 @@
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
@@ -7243,42 +6579,16 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 32
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 32
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 37
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
@@ -7327,10 +6637,6 @@
 ++++ starting: end run: stream = 0 run = 3 time = 0
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: end run: stream = 0 run = 3 time = 0
-++++++ starting: end run for module: stream = 0 label = 'noPut' id = 11
-++++++ finished: end run for module: stream = 0 label = 'noPut' id = 11
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 10
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 10
 ++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 9
 ++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 9
 ++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 8
@@ -7339,42 +6645,16 @@
 ++++++ finished: end run for module: stream = 0 label = 'putInt' id = 7
 ++++++ starting: end run for module: stream = 0 label = 'get' id = 6
 ++++++ finished: end run for module: stream = 0 label = 'get' id = 6
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: end run: stream = 0 run = 3 time = 0
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: end run: stream = 0 run = 3 time = 0
-++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: end run for module: stream = 0 label = 'get' id = 34
 ++++++ finished: end run for module: stream = 0 label = 'get' id = 34
-++++++ starting: end run for module: stream = 0 label = 'test' id = 32
-++++++ finished: end run for module: stream = 0 label = 'test' id = 32
-++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 33
-++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 33
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 35
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 35
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++ starting: end run for module: stream = 0 label = 'out' id = 37
-++++++ finished: end run for module: stream = 0 label = 'out' id = 37
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: end run: stream = 0 run = 3 time = 0
-++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: end run for module: stream = 0 label = 'get' id = 21
 ++++++ finished: end run for module: stream = 0 label = 'get' id = 21
-++++++ starting: end run for module: stream = 0 label = 'test' id = 19
-++++++ finished: end run for module: stream = 0 label = 'test' id = 19
-++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 20
-++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 22
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ starting: end run for module: stream = 0 label = 'out' id = 24
-++++++ finished: end run for module: stream = 0 label = 'out' id = 24
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: global end run 3 : time = 150000001
 ++++ finished: global end run 3 : time = 150000001


### PR DESCRIPTION
We determine if a particular module actually needs to be called for a given global or stream transition. If it does not need to be called, then we no longer make the call.