### PR TITLE
OnlineDQM : Tune L1T Muon QTs v4

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
@@ -81,7 +81,10 @@ l1tStage2uGMTZeroSuppFatEvts = l1tStage2uGMTZeroSupp.clone()
 l1tStage2uGMTZeroSuppFatEvts.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/zeroSuppression/FatEvts")
 
 # List of bins to ignore
-ignoreBins = [1]
+ignoreBins = {
+    'Bmtf' : [1],
+    'Emtf' : [1]
+    }
 
 # compares the unpacked BMTF output regional muon collection with the unpacked uGMT input regional muon collection from BMTF
 # only muons that do not match are filled in the histograms
@@ -93,7 +96,7 @@ l1tStage2BmtfOutVsuGMTIn = cms.EDAnalyzer(
     regionalMuonCollection1Title = cms.untracked.string("BMTF output data"),
     regionalMuonCollection2Title = cms.untracked.string("uGMT input data from BMTF"),
     summaryTitle = cms.untracked.string("Summary of comparison between BMTF output muons and uGMT input muons from BMTF"),
-    ignoreBin = cms.untracked.vint32(ignoreBins),
+    ignoreBin = cms.untracked.vint32(ignoreBins['Bmtf']),
     verbose = cms.untracked.bool(False),
 )
 
@@ -120,6 +123,7 @@ l1tStage2EmtfOutVsuGMTIn = cms.EDAnalyzer(
     regionalMuonCollection1Title = cms.untracked.string("EMTF output data"),
     regionalMuonCollection2Title = cms.untracked.string("uGMT input data from EMTF"),
     summaryTitle = cms.untracked.string("Summary of comparison between EMTF output muons and uGMT input muons from EMTF"),
+    ignoreBin = cms.untracked.vint32(ignoreBins['Emtf']),
     verbose = cms.untracked.bool(False),
 )
 

--- a/DQM/L1TMonitorClient/data/L1TStage2BMTFDEQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2BMTFDEQualityTests.xml
@@ -4,17 +4,17 @@
 
   <!-- Mismatch Summary QTest -->
 
-  <QTEST name="BMTFDE_MismatchRatioMax0p05">
+  <QTEST name="BMTFDE_MismatchRatioMax0p01">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
-    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="ymax">0.01</PARAM>
     <PARAM name="error">0.95</PARAM>
     <PARAM name="warning">0.99</PARAM>
     <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
   
   <LINK name="L1TEMU/L1TdeStage2BMTF/mismatchRatio">
-      <TestName activate="true">BMTFDE_MismatchRatioMax0p05</TestName>
+      <TestName activate="true">BMTFDE_MismatchRatioMax0p01</TestName>
   </LINK>
 
 </TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2EMTFDEQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2EMTFDEQualityTests.xml
@@ -4,17 +4,17 @@
 
   <!-- Mismatch Summary QTest -->
 
-  <QTEST name="EMTFDE_MismatchRatioMax0p05">
+  <QTEST name="EMTFDE_MismatchRatioMax0p01">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
-    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="ymax">0.01</PARAM>
     <PARAM name="error">0.95</PARAM>
     <PARAM name="warning">0.99</PARAM>
     <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
   
   <LINK name="L1TEMU/L1TdeStage2EMTF/mismatchRatio">
-      <TestName activate="true">EMTFDE_MismatchRatioMax0p05</TestName>
+      <TestName activate="true">EMTFDE_MismatchRatioMax0p01</TestName>
   </LINK>
 
 </TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2OMTFDEQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2OMTFDEQualityTests.xml
@@ -4,17 +4,17 @@
 
   <!-- Mismatch Summary QTest -->
 
-  <QTEST name="OMTFDE_MismatchRatioMax0p05">
+  <QTEST name="OMTFDE_MismatchRatioMax0p01">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
-    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="ymax">0.01</PARAM>
     <PARAM name="error">0.95</PARAM>
     <PARAM name="warning">0.99</PARAM>
     <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
   
   <LINK name="L1TEMU/L1TdeStage2OMTF/mismatchRatio">
-      <TestName activate="true">OMTFDE_MismatchRatioMax0p05</TestName>
+      <TestName activate="true">OMTFDE_MismatchRatioMax0p01</TestName>
   </LINK>
 
 </TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
@@ -175,8 +175,8 @@
     <PARAM name="useRMS">0</PARAM>
     <PARAM name="useSigma">0</PARAM>
     <PARAM name="useRange">1</PARAM>
-    <PARAM name="xmin">-0.05</PARAM>
-    <PARAM name="xmax">0.05</PARAM>
+    <PARAM name="xmin">-0.15</PARAM>
+    <PARAM name="xmax">0.15</PARAM>
     <PARAM name="error">0.95</PARAM>
     <PARAM name="warning">0.99</PARAM>
     <PARAM name="minEntries">20</PARAM>

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorEventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorEventInfoClient_cfi.py
@@ -93,7 +93,7 @@ l1tStage2EmulatorEventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemDisable  = cms.uint32(0),
                         QualityTests = cms.VPSet(
                             cms.PSet(
-                                QualityTestName = cms.string("BMTFDE_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("BMTFDE_MismatchRatioMax0p01"),
                                 QualityTestHist = cms.string("L1TEMU/L1TdeStage2BMTF/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
@@ -105,7 +105,7 @@ l1tStage2EmulatorEventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemDisable  = cms.uint32(0),
                         QualityTests = cms.VPSet(
                             cms.PSet(
-                                QualityTestName = cms.string("OMTFDE_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("OMTFDE_MismatchRatioMax0p01"),
                                 QualityTestHist = cms.string("L1TEMU/L1TdeStage2OMTF/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
@@ -117,7 +117,7 @@ l1tStage2EmulatorEventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemDisable  = cms.uint32(0),
                         QualityTests = cms.VPSet(
                             cms.PSet(
-                                QualityTestName = cms.string("EMTFDE_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("EMTFDE_MismatchRatioMax0p01"),
                                 QualityTestHist = cms.string("L1TEMU/L1TdeStage2EMTF/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),

--- a/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
@@ -93,13 +93,7 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemLabel = cms.string("Calo Layer2"),
                         HwValLabel = cms.string("Stage2CaloLayer2"),
                         SystemDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                ),
-                            )
+                        QualityTests = cms.VPSet()
                         ),
                     cms.PSet(
                         SystemLabel = cms.string("BMTF"),
@@ -112,11 +106,6 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("BMTF_hwPtSpectrum"),
-                                QualityTestHist = cms.string("L1T/L1TStage2BMTF/bmtf_hwPt"),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                ),
-                            cms.PSet(
                                 QualityTestName = cms.string("BMTF_WedgeBXNoisyWedge"),
                                 QualityTestHist = cms.string("L1T/L1TStage2BMTF/bmtf_wedge_bx"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
@@ -127,13 +116,7 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemLabel = cms.string("OMTF"),
                         HwValLabel = cms.string("Stage2OMTF"),
                         SystemDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                ),
-                            )
+                        QualityTests = cms.VPSet()
                         ),
                     cms.PSet(
                         SystemLabel = cms.string("EMTF"),
@@ -155,11 +138,6 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestHist = cms.string("L1T/L1TStage2EMTF/emtfTrackBX"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
-                            # cms.PSet(
-                            #     QualityTestName = cms.string("EMTF_TrackBXSpectrum"),
-                            #     QualityTestHist = cms.string("L1T/L1TStage2EMTF/emtfTrackBX"),
-                            #     QualityTestSummaryEnabled = cms.uint32(0)
-                            #     ),
                             )
                         ),
                     cms.PSet(
@@ -167,11 +145,11 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         HwValLabel = cms.string("Stage2uGMT"),
                         SystemDisable  = cms.uint32(0),
                         QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string("uGMT_MuonBXPeakAtBX0"),
-                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonBX"),
-                                QualityTestSummaryEnabled = cms.uint32(1)
-                                ),
+                            #cms.PSet(
+                            #    QualityTestName = cms.string("uGMT_MuonBXPeakAtBX0"),
+                            #    QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonBX"),
+                            #    QualityTestSummaryEnabled = cms.uint32(1)
+                            #    ),
                             cms.PSet(
                                 QualityTestName = cms.string("uGMT_MuonBXMeanAtBX0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonBX"),
@@ -187,11 +165,11 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonPt"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
-                            cms.PSet(
-                                QualityTestName = cms.string("uGMT_BMTFBXPeakAtBX0"),
-                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFInput/ugmtBMTFBX"),
-                                QualityTestSummaryEnabled = cms.uint32(1)
-                                ),
+                            #cms.PSet(
+                            #    QualityTestName = cms.string("uGMT_BMTFBXPeakAtBX0"),
+                            #    QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFInput/ugmtBMTFBX"),
+                            #    QualityTestSummaryEnabled = cms.uint32(1)
+                            #    ),
                             cms.PSet(
                                 QualityTestName = cms.string("uGMT_BMTFBXMeanAtBX0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFInput/ugmtBMTFBX"),
@@ -217,11 +195,11 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFInput/ugmtBMTFhwSign"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
-                            cms.PSet(
-                                QualityTestName = cms.string("uGMT_OMTFBXPeakAtBX0"),
-                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFBX"),
-                                QualityTestSummaryEnabled = cms.uint32(1)
-                                ),
+                            #cms.PSet(
+                            #    QualityTestName = cms.string("uGMT_OMTFBXPeakAtBX0"),
+                            #    QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFBX"),
+                            #    QualityTestSummaryEnabled = cms.uint32(1)
+                            #    ),
                             cms.PSet(
                                 QualityTestName = cms.string("uGMT_OMTFBXMeanAtBX0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFBX"),
@@ -257,11 +235,11 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFhwSign"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
-                            cms.PSet(
-                                QualityTestName = cms.string("uGMT_EMTFBXPeakAtBX0"),
-                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/EMTFInput/ugmtEMTFBX"),
-                                QualityTestSummaryEnabled = cms.uint32(1)
-                                ),
+                            #cms.PSet(
+                            #    QualityTestName = cms.string("uGMT_EMTFBXPeakAtBX0"),
+                            #    QualityTestHist = cms.string("L1T/L1TStage2uGMT/EMTFInput/ugmtEMTFBX"),
+                            #    QualityTestSummaryEnabled = cms.uint32(1)
+                            #    ),
                             cms.PSet(
                                 QualityTestName = cms.string("uGMT_EMTFBXMeanAtBX0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/EMTFInput/ugmtEMTFBX"),
@@ -287,11 +265,11 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
-                            cms.PSet(
-                                QualityTestName = cms.string("EMTFvsuGMT_MismatchRatioMax0"),
-                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/mismatchRatio"),
-                                QualityTestSummaryEnabled = cms.uint32(1)
-                                ),
+                            #cms.PSet(
+                            #    QualityTestName = cms.string("EMTFvsuGMT_MismatchRatioMax0"),
+                            #    QualityTestHist = cms.string("L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/mismatchRatio"),
+                            #    QualityTestSummaryEnabled = cms.uint32(1)
+                            #    ),
                             cms.PSet(
                                 QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/GMTMuonCopy1/mismatchRatio"),
@@ -333,14 +311,8 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemLabel = cms.string("uGT"),
                         HwValLabel = cms.string("Stage2uGT"),
                         SystemDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                ),
-                            )
-                        ),
+                        QualityTests = cms.VPSet()
+                        )
                     ),
 
     #
@@ -354,156 +326,72 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                     cms.PSet(
                         ObjectLabel = cms.string("TechTrig"),
                         ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
+                        QualityTests = cms.VPSet()
                         ),
                     cms.PSet(
                         ObjectLabel = cms.string("GtExternal"),
                         ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
+                        QualityTests = cms.VPSet()
                         ),
                     cms.PSet(
                         ObjectLabel = cms.string("HfRingEtSums"),
                         ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
+                        QualityTests = cms.VPSet()
                         ),
                     cms.PSet(
                         ObjectLabel = cms.string("HfBitCounts"),
                         ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
+                        QualityTests = cms.VPSet()
                         ),
                     cms.PSet(
                         ObjectLabel = cms.string("HTM"),
                         ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
+                        QualityTests = cms.VPSet()
                         ),
                     cms.PSet(
                         ObjectLabel = cms.string("HTT"),
                         ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
+                        QualityTests = cms.VPSet()
                         ),
                     cms.PSet(
                         ObjectLabel = cms.string("ETM"),
                         ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
+                        QualityTests = cms.VPSet()
                         ),
                     cms.PSet(
                         ObjectLabel = cms.string("ETT"),
                         ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
+                        QualityTests = cms.VPSet()
                         ),
                     cms.PSet(
                         ObjectLabel = cms.string("Tau"),
                         ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
+                        QualityTests = cms.VPSet()
                         ),
                     cms.PSet(
                         ObjectLabel = cms.string("ForJet"),
                         ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
+                        QualityTests = cms.VPSet()
                         ),
                     cms.PSet(
                         ObjectLabel = cms.string("CenJet"),
                         ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
+                        QualityTests = cms.VPSet()
                         ),
                     cms.PSet(
                         ObjectLabel = cms.string("IsoEG"),
                         ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
+                        QualityTests = cms.VPSet()
                         ),
                     cms.PSet(
                         ObjectLabel = cms.string("NoIsoEG"),
                         ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
+                        QualityTests = cms.VPSet()
                         ),
                     cms.PSet(
                         ObjectLabel = cms.string("Mu"),
                         ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
+                        QualityTests = cms.VPSet()
                         )
                     ),
     #

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
@@ -57,7 +57,7 @@ l1tStage2BmtfOutVsuGMTInRatioClient.monitorDir = cms.untracked.string(ugmtDqmDir
 l1tStage2BmtfOutVsuGMTInRatioClient.inputNum = cms.untracked.string(ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistNumStr)
 l1tStage2BmtfOutVsuGMTInRatioClient.inputDen = cms.untracked.string(ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistDenStr)
 l1tStage2BmtfOutVsuGMTInRatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between BMTF output muons and uGMT input muons from BMTF')
-l1tStage2BmtfOutVsuGMTInRatioClient.ignoreBin = cms.untracked.vint32(ignoreBins)
+l1tStage2BmtfOutVsuGMTInRatioClient.ignoreBin = cms.untracked.vint32(ignoreBins['Bmtf'])
 
 l1tStage2OmtfOutVsuGMTInRatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
 l1tStage2OmtfOutVsuGMTInRatioClient.monitorDir = cms.untracked.string(ugmtDqmDir+'/OMTFoutput_vs_uGMTinput')
@@ -70,6 +70,7 @@ l1tStage2EmtfOutVsuGMTInRatioClient.monitorDir = cms.untracked.string(ugmtDqmDir
 l1tStage2EmtfOutVsuGMTInRatioClient.inputNum = cms.untracked.string(ugmtDqmDir+'/EMTFoutput_vs_uGMTinput/'+errHistNumStr)
 l1tStage2EmtfOutVsuGMTInRatioClient.inputDen = cms.untracked.string(ugmtDqmDir+'/EMTFoutput_vs_uGMTinput/'+errHistDenStr)
 l1tStage2EmtfOutVsuGMTInRatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between EMTF output muons and uGMT input muons from EMTF')
+l1tStage2EmtfOutVsuGMTInRatioClient.ignoreBin = cms.untracked.vint32(ignoreBins['Emtf'])
 
 # zero suppression
 l1tStage2uGMTZeroSuppRatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()


### PR DESCRIPTION
Description:

This PR includes the following changes:

- Ignore BX range mismatch for EMTF to uGMT mismatch plot ( https://its.cern.ch/jira/browse/CMSLITDPG-340 )

- The xmin and xmax values of uGMT_OMTFBXMeanAtBX0 are set to 0.15, and several QTs for uGMT are disabled in the L1T summary map ( https://its.cern.ch/jira/browse/CMSLITDPG-345 )

- The maximally allowed muon TF data emulator mismatch is set the 1% ( https://its.cern.ch/jira/browse/CMSLITDPG-330 )

- The summary map report is cleaned up (remove the empty QTs)