### PR TITLE
island photons for XeXe collision era + HI pp reference run era and relval wf (92X)

### DIFF
--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_ppRef.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_ppRef.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+"""
+_ppEra_Run2_2017_ppRef_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run2_2017_ppRef_cff import Run2_2017_ppRef
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run2_2017_ppRef(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.addEI=True
+        self.isRepacked=True
+        self.eras=Run2_2017_ppRef
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_ppRef' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_ppRef' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_ppRef' ]
+    """
+    _ppEra_Run2_2017_ppRef_
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2
+
+    """

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -64,6 +64,10 @@ def customisePostEra_Run2_2017_pp_on_XeXe(process):
     customisePostEra_Run2_2017(process)
     return process
 
+def customisePostEra_Run2_2017_ppRef(process):
+    customisePostEra_Run2_2017(process)
+    return process
+
 ##############################################################################
 def customisePPData(process):
     #deprecated process= customiseCommon(process)

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -13,7 +13,7 @@ function runTest { echo $1 ; python $1 || die "Failure for configuration: $1" $?
 
 runTest "${LOCAL_TEST_DIR}/RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever"
 
-declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe")
+declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBias+SiStripCalMinBias "
@@ -22,7 +22,7 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "hcalnzsEra_Run2_25ns" "hcalnzsEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "cosmicsEra_Run2_2017" "hcalnzsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017")
+declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "hcalnzsEra_Run2_25ns" "hcalnzsEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "cosmicsEra_Run2_2017" "hcalnzsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2017")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
@@ -36,14 +36,14 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "HeavyIons" "HeavyIonsEra_Run2_HI" "AlCaLumiPixels" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017")
+declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "HeavyIons" "HeavyIonsEra_Run2_HI" "AlCaLumiPixels" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef" "ppEra_Run2_2017")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn=/store/whatever --global-tag GLOBALTAG --skims SiStripCalZeroBias,SiStripCalMinBias,PromptCalibProd"
      runTest "${LOCAL_TEST_DIR}/RunDQMHarvesting.py --scenario $scenario --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG"
 done
 
-declare -a arr=("ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe")
+declare -a arr=("ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017_pp_on_XeXe" "ppEra_Run2_2017_ppRef")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"

--- a/Configuration/Eras/python/Era_Run2_2017_ppRef_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_ppRef_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
+
+Run2_2017_ppRef = cms.ModifierChain(Run2_2017, ppRef_2017)

--- a/Configuration/Eras/python/Modifier_ppRef_2017_cff.py
+++ b/Configuration/Eras/python/Modifier_ppRef_2017_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+ppRef_2017 =  cms.Modifier()
+

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -410,6 +410,9 @@ workflows[150.1] = ['',['QCD_Pt_80_120_13_HI','DIGIHI2018','RECOHI2018','HARVEST
 workflows[150.2] = ['',['PhotonJets_Pt_10_13_HI','DIGIHI2018','RECOHI2018','HARVESTHI2018']]
 workflows[150.3] = ['',['ZEEMM_13_HI','DIGIHI2018','RECOHI2018','HARVESTHI2018']]
 
+### pp reference test ###
+workflows[149] = ['',['QCD_Pt_80_120_13_PPREF','DIGIPPREF2017','RECOPPREF2017','HARVESTPPREF2017']]
+
 ### pPb test ###
 workflows[280]= ['',['AMPT_PPb_5020GeV_MinimumBias','DIGI','RECO','HARVEST']]
 

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1545,7 +1545,7 @@ steps['RECOHI2017']=merge([hiDefaults2017,{'-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,VAL
 steps['RECOHI2015']=merge([hiDefaults2015,{'-s':'RAW2DIGI,L1Reco,RECO,VALIDATION,DQM'},step3Up2015Defaults])
 steps['RECOHI2011']=merge([hiDefaults2011,{'-s':'RAW2DIGI,L1Reco,RECO,VALIDATION,DQM'},step3Defaults])
 
-steps['RECOPPREF2017']=merge([ppRefDefaults2017,{'-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@miniAODDQM'},step3Up2015Defaults])
+steps['RECOPPREF2017']=merge([ppRefDefaults2017,step3Up2015Defaults])
 
 steps['RECOHID11St3']=merge([{
                               '--process':'ZStoRECO'},

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -682,18 +682,22 @@ hiDefaults2015=merge([hiAlca2015,{'--scenario':'HeavyIons','-n':2}])
 hiDefaults2017=merge([hiAlca2017,{'-n':2}])
 hiDefaults2018=merge([hiAlca2018,{'--scenario':'HeavyIons','-n':2}])
 
-
 steps['HydjetQ_B12_5020GeV_2011']=merge([{'-n':1,'--beamspot':'RealisticHI2011Collision'},hiDefaults2011,genS('Hydjet_Quenched_B12_5020GeV_cfi',U2000by1)])
 steps['HydjetQ_B12_5020GeV_2015']=merge([{'-n':1,'--beamspot':'RealisticHICollision2015'},hiDefaults2015,genS('Hydjet_Quenched_B12_5020GeV_cfi',U2000by1)])
 steps['HydjetQ_MinBias_XeXe_5442GeV_2017']=merge([{'-n':1},hiDefaults2017,gen2017('Hydjet_Quenched_MinBias_XeXe_5442GeV_cfi',U2000by1)])
 steps['HydjetQ_B12_5020GeV_2018']=merge([{'-n':1},hiDefaults2018,gen2017('Hydjet_Quenched_B12_5020GeV_cfi',U2000by1)])
-
 
 steps['QCD_Pt_80_120_13_HI']=merge([hiDefaults2018,gen2017('QCD_Pt_80_120_13TeV_TuneCUETP8M1_cfi',Kby(9,150))])
 steps['PhotonJets_Pt_10_13_HI']=merge([hiDefaults2018,gen2017('PhotonJet_Pt_10_13TeV_TuneCUETP8M1_cfi',Kby(9,150))])
 steps['ZMM_13_HI']=merge([hiDefaults2018,gen2017('ZMM_13TeV_TuneCUETP8M1_cfi',Kby(18,100))])
 steps['ZEEMM_13_HI']=merge([hiDefaults2018,gen2017('ZEEMM_13TeV_TuneCUETP8M1_cfi',Kby(18,300))])
 
+## pp reference tests
+
+ppRefAlca2017 = {'--conditions':'auto:phase1_2017_realistic', '--era':'Run2_2017_ppRef'}
+ppRefDefaults2017=merge([ppRefAlca2017,{'-n':2}])
+
+steps['QCD_Pt_80_120_13_PPREF']=merge([ppRefDefaults2017,gen2017('QCD_Pt_80_120_13TeV_TuneCUETP8M1_cfi',Kby(9,150))])
 
 #### fastsim section ####
 ##no forseen to do things in two steps GEN-SIM then FASTIM->end: maybe later
@@ -1090,6 +1094,7 @@ steps['DIGIHI2015']=merge([{'-s':'DIGI:pdigi_hi,L1,DIGI2RAW,HLT:HIon'}, hiDefaul
 steps['DIGIHI2011']=merge([{'-s':'DIGI:pdigi_hi,L1,DIGI2RAW,HLT:@fake'}, hiDefaults2011, {'--pileup':'HiMixNoPU'}, step2Defaults])
 steps['DIGIHIMIX']=merge([{'-s':'DIGI:pdigi_hi,L1,DIGI2RAW,HLT:HIon', '-n':2}, hiDefaults2015, {'--pileup':'HiMix'}, PUHI, step2Upg2015Defaults])
 
+steps['DIGIPPREF2017']=merge([{'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@fake2'}, ppRefDefaults2017, step2Upg2015Defaults])
 
 # PRE-MIXING : https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideSimulation#Pre_Mixing_Instructions
 premixUp2015Defaults = {
@@ -1540,6 +1545,8 @@ steps['RECOHI2017']=merge([hiDefaults2017,{'-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,VAL
 steps['RECOHI2015']=merge([hiDefaults2015,{'-s':'RAW2DIGI,L1Reco,RECO,VALIDATION,DQM'},step3Up2015Defaults])
 steps['RECOHI2011']=merge([hiDefaults2011,{'-s':'RAW2DIGI,L1Reco,RECO,VALIDATION,DQM'},step3Defaults])
 
+steps['RECOPPREF2017']=merge([ppRefDefaults2017,{'-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@miniAODDQM'},step3Up2015Defaults])
+
 steps['RECOHID11St3']=merge([{
                               '--process':'ZStoRECO'},
                              steps['RECOHID11']])
@@ -1778,6 +1785,12 @@ steps['HARVESTHI2015']=merge([hiDefaults2015,{'-s':'HARVESTING:validationHarvest
 steps['HARVESTHI2011']=merge([hiDefaults2011,{'-s':'HARVESTING:validationHarvesting+dqmHarvesting',
                                               '--mc':'',
                                               '--filetype':'DQM'}])
+
+steps['HARVESTPPREF2017']=merge([ppRefDefaults2017,{'-s':'HARVESTING:validationHarvesting+dqmHarvesting',
+                    '--mc':'',
+                    '--era' : 'Run2_2017_ppRef',
+                    '--filetype':'DQM'}])
+
 steps['HARVESTUP15']={
     # '-s':'HARVESTING:validationHarvesting+dqmHarvesting', # todo: remove UP from label
     '-s':'HARVESTING:@standardValidation+@standardDQMExtraHLT+@miniAODValidation+@miniAODDQM', # todo: remove UP from label

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -24,6 +24,7 @@ class Eras (object):
                  'Run2_2017_trackingPhase1QuadProp',
                  'Run2_2017_trackingLowPU',
                  'Run2_2017_pp_on_XeXe',
+                 'Run2_2017_ppRef',
                  'Run2_2018',
                  'Run3',
                  'Phase2C1',

--- a/RecoEcal/Configuration/python/RecoEcal_EventContent_cff.py
+++ b/RecoEcal/Configuration/python/RecoEcal_EventContent_cff.py
@@ -101,8 +101,9 @@ phase2_hgcal.toReplaceWith( RecoEcalAOD , _phase2_hgcal_RecoEcalAOD  )
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 #HI-specific products needed in pp scenario special configurations
-for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
+for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017, ppRef_2017]:
     for ec in [RecoEcalRECO.outputCommands, RecoEcalFEVT.outputCommands]:
         e.toModify( ec, func=lambda outputCommands: outputCommands.extend(['keep recoCaloClusters_islandBasicClusters_*_*'])
                     )

--- a/RecoEcal/Configuration/python/RecoEcal_cff.py
+++ b/RecoEcal/Configuration/python/RecoEcal_cff.py
@@ -25,9 +25,9 @@ from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 
-from RecoEcal.EgammaClusterProducers.islandBasicClusters_cfi import islandBasicClusters
+from RecoEcal.EgammaClusterProducers.islandClusteringSequence_cff import *
 
 _ecalClustersHI = ecalClusters.copy()
-_ecalClustersHI += islandBasicClusters
+_ecalClustersHI += islandClusteringSequence
 for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
     e.toReplaceWith(ecalClusters, _ecalClustersHI)

--- a/RecoEcal/Configuration/python/RecoEcal_cff.py
+++ b/RecoEcal/Configuration/python/RecoEcal_cff.py
@@ -24,18 +24,11 @@ ecalClusters = cms.Sequence(ecalClustersNoPFBox*particleFlowSuperClusteringSeque
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 
 from RecoEcal.EgammaClusterProducers.islandClusteringSequence_cff import *
 
 _ecalClustersHI = ecalClusters.copy()
 _ecalClustersHI += islandClusteringSequence
-for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
+for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017, ppRef_2017]:
     e.toReplaceWith(ecalClusters, _ecalClustersHI)
-
-from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
-
-from RecoEcal.EgammaClusterProducers.islandBasicClusters_cfi import islandBasicClusters
-
-_ecalClustersHI_ppRef = ecalClusters.copy()
-_ecalClustersHI_ppRef += islandBasicClusters
-ppRef_2017.toReplaceWith(ecalClusters, _ecalClustersHI_ppRef)

--- a/RecoEcal/Configuration/python/RecoEcal_cff.py
+++ b/RecoEcal/Configuration/python/RecoEcal_cff.py
@@ -31,3 +31,11 @@ _ecalClustersHI = ecalClusters.copy()
 _ecalClustersHI += islandClusteringSequence
 for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
     e.toReplaceWith(ecalClusters, _ecalClustersHI)
+
+from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
+
+from RecoEcal.EgammaClusterProducers.islandBasicClusters_cfi import islandBasicClusters
+
+_ecalClustersHI_ppRef = ecalClusters.copy()
+_ecalClustersHI_ppRef += islandBasicClusters
+ppRef_2017.toReplaceWith(ecalClusters, _ecalClustersHI_ppRef)

--- a/RecoEcal/EgammaClusterProducers/python/correctedIslandBarrelSuperClusters_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/correctedIslandBarrelSuperClusters_cfi.py
@@ -21,8 +21,9 @@ correctedIslandBarrelSuperClusters = cms.EDProducer("EgammaSCCorrectionMaker",
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 
 from RecoHI.HiEgammaAlgos.HiCorrectedIslandBarrelSuperClusters_cfi import correctedIslandBarrelSuperClusters as _hiCorrectedIslandBarrelSuperClusters
 
-for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
+for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017, ppRef_2017]:
     e.toReplaceWith(correctedIslandBarrelSuperClusters, _hiCorrectedIslandBarrelSuperClusters)

--- a/RecoEcal/EgammaClusterProducers/python/correctedIslandBarrelSuperClusters_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/correctedIslandBarrelSuperClusters_cfi.py
@@ -18,4 +18,11 @@ correctedIslandBarrelSuperClusters = cms.EDProducer("EgammaSCCorrectionMaker",
     recHitProducer = cms.InputTag("ecalRecHit","EcalRecHitsEB")
 )
 
+from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
+from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
+from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 
+from RecoHI.HiEgammaAlgos.HiCorrectedIslandBarrelSuperClusters_cfi import correctedIslandBarrelSuperClusters as _hiCorrectedIslandBarrelSuperClusters
+
+for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
+    e.toReplaceWith(correctedIslandBarrelSuperClusters, _hiCorrectedIslandBarrelSuperClusters)

--- a/RecoEcal/EgammaClusterProducers/python/correctedIslandEndcapSuperClusters_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/correctedIslandEndcapSuperClusters_cfi.py
@@ -21,8 +21,9 @@ correctedIslandEndcapSuperClusters = cms.EDProducer("EgammaSCCorrectionMaker",
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 
 from RecoHI.HiEgammaAlgos.HiCorrectedIslandEndcapSuperClusters_cfi import correctedIslandEndcapSuperClusters as _hiCorrectedIslandEndcapSuperClusters
 
-for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
+for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017, ppRef_2017]:
     e.toReplaceWith(correctedIslandEndcapSuperClusters, _hiCorrectedIslandEndcapSuperClusters)

--- a/RecoEcal/EgammaClusterProducers/python/correctedIslandEndcapSuperClusters_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/correctedIslandEndcapSuperClusters_cfi.py
@@ -18,4 +18,11 @@ correctedIslandEndcapSuperClusters = cms.EDProducer("EgammaSCCorrectionMaker",
     recHitProducer = cms.InputTag("ecalRecHit","EcalRecHitsEE")
 )
 
+from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
+from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
+from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 
+from RecoHI.HiEgammaAlgos.HiCorrectedIslandEndcapSuperClusters_cfi import correctedIslandEndcapSuperClusters as _hiCorrectedIslandEndcapSuperClusters
+
+for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
+    e.toReplaceWith(correctedIslandEndcapSuperClusters, _hiCorrectedIslandEndcapSuperClusters)

--- a/RecoEcal/EgammaClusterProducers/python/islandSuperClusters_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/islandSuperClusters_cfi.py
@@ -30,8 +30,9 @@ islandSuperClusters = cms.EDProducer("SuperClusterProducer",
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 
 from RecoHI.HiEgammaAlgos.HiIslandSuperClusters_cfi import islandSuperClusters as _hiIslandSuperClusters
 
-for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
+for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017, ppRef_2017]:
     e.toReplaceWith(islandSuperClusters, _hiIslandSuperClusters)

--- a/RecoEcal/EgammaClusterProducers/python/islandSuperClusters_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/islandSuperClusters_cfi.py
@@ -27,4 +27,11 @@ islandSuperClusters = cms.EDProducer("SuperClusterProducer",
                                  )                                 
 )
 
+from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
+from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
+from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 
+from RecoHI.HiEgammaAlgos.HiIslandSuperClusters_cfi import islandSuperClusters as _hiIslandSuperClusters
+
+for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
+    e.toReplaceWith(islandSuperClusters, _hiIslandSuperClusters)

--- a/RecoEgamma/Configuration/python/RecoEgamma_EventContent_cff.py
+++ b/RecoEgamma/Configuration/python/RecoEgamma_EventContent_cff.py
@@ -178,6 +178,8 @@ from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
     for ec in [RecoEgammaAOD.outputCommands, RecoEgammaRECO.outputCommands, RecoEgammaFEVT.outputCommands]:
         e.toModify( ec, func=lambda outputCommands: outputCommands.extend(['keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
-                                                                           'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*'
+                                                                           'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*',
+                                                                           'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppIsland_*_*',
+                                                                           'keep recoPhotons_islandPhotons_*_*'
                                                                            ])
                     )

--- a/RecoEgamma/Configuration/python/RecoEgamma_EventContent_cff.py
+++ b/RecoEgamma/Configuration/python/RecoEgamma_EventContent_cff.py
@@ -183,3 +183,10 @@ for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
                                                                            'keep recoPhotons_islandPhotons_*_*'
                                                                            ])
                     )
+
+from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
+for ec in [RecoEgammaAOD.outputCommands, RecoEgammaRECO.outputCommands, RecoEgammaFEVT.outputCommands]:
+    ppRef_2017.toModify( ec, func=lambda outputCommands: outputCommands.extend(['keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
+                                                                                'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*'
+                                                                               ])
+                         )

--- a/RecoEgamma/Configuration/python/RecoEgamma_EventContent_cff.py
+++ b/RecoEgamma/Configuration/python/RecoEgamma_EventContent_cff.py
@@ -174,8 +174,9 @@ phase2_hgcal.toModify( RecoEgammaAOD,  outputCommands = RecoEgammaAOD.outputComm
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 #HI-specific products needed in pp scenario special configurations
-for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
+for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017, ppRef_2017]:
     for ec in [RecoEgammaAOD.outputCommands, RecoEgammaRECO.outputCommands, RecoEgammaFEVT.outputCommands]:
         e.toModify( ec, func=lambda outputCommands: outputCommands.extend(['keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
                                                                            'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*',
@@ -183,10 +184,3 @@ for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
                                                                            'keep recoPhotons_islandPhotons_*_*'
                                                                            ])
                     )
-
-from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
-for ec in [RecoEgammaAOD.outputCommands, RecoEgammaRECO.outputCommands, RecoEgammaFEVT.outputCommands]:
-    ppRef_2017.toModify( ec, func=lambda outputCommands: outputCommands.extend(['keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
-                                                                                'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*'
-                                                                               ])
-                         )

--- a/RecoEgamma/Configuration/python/RecoEgamma_cff.py
+++ b/RecoEgamma/Configuration/python/RecoEgamma_cff.py
@@ -44,13 +44,13 @@ from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 #HI-specific algorithms needed in pp scenario special configurations 
-from RecoEcal.EgammaClusterProducers.islandBasicClusters_cfi import islandBasicClusters
 from RecoHI.HiEgammaAlgos.photonIsolationHIProducer_cfi import photonIsolationHIProducerpp
 from RecoHI.HiEgammaAlgos.photonIsolationHIProducer_cfi import photonIsolationHIProducerppGED
+from RecoHI.HiEgammaAlgos.photonIsolationHIProducer_cfi import photonIsolationHIProducerppIsland
 
 _egammaHighLevelRecoPostPF_HI = egammaHighLevelRecoPostPF.copy()
-_egammaHighLevelRecoPostPF_HI += islandBasicClusters
 _egammaHighLevelRecoPostPF_HI += photonIsolationHIProducerpp
 _egammaHighLevelRecoPostPF_HI += photonIsolationHIProducerppGED
+_egammaHighLevelRecoPostPF_HI += photonIsolationHIProducerppIsland
 for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
     e.toReplaceWith(egammaHighLevelRecoPostPF, _egammaHighLevelRecoPostPF_HI)

--- a/RecoEgamma/Configuration/python/RecoEgamma_cff.py
+++ b/RecoEgamma/Configuration/python/RecoEgamma_cff.py
@@ -43,6 +43,7 @@ egammarecoFull_woHFElectrons = cms.Sequence(egammareco*interestingEgammaIsoDetId
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 #HI-specific algorithms needed in pp scenario special configurations 
 from RecoHI.HiEgammaAlgos.photonIsolationHIProducer_cfi import photonIsolationHIProducerpp
 from RecoHI.HiEgammaAlgos.photonIsolationHIProducer_cfi import photonIsolationHIProducerppGED
@@ -52,12 +53,5 @@ _egammaHighLevelRecoPostPF_HI = egammaHighLevelRecoPostPF.copy()
 _egammaHighLevelRecoPostPF_HI += photonIsolationHIProducerpp
 _egammaHighLevelRecoPostPF_HI += photonIsolationHIProducerppGED
 _egammaHighLevelRecoPostPF_HI += photonIsolationHIProducerppIsland
-for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
+for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017, ppRef_2017]:
     e.toReplaceWith(egammaHighLevelRecoPostPF, _egammaHighLevelRecoPostPF_HI)
-
-from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
-
-_egammaHighLevelRecoPostPF_HI_ppRef = egammaHighLevelRecoPostPF.copy()
-_egammaHighLevelRecoPostPF_HI_ppRef += photonIsolationHIProducerpp
-_egammaHighLevelRecoPostPF_HI_ppRef += photonIsolationHIProducerppGED
-ppRef_2017.toReplaceWith(egammaHighLevelRecoPostPF, _egammaHighLevelRecoPostPF_HI_ppRef)

--- a/RecoEgamma/Configuration/python/RecoEgamma_cff.py
+++ b/RecoEgamma/Configuration/python/RecoEgamma_cff.py
@@ -54,3 +54,10 @@ _egammaHighLevelRecoPostPF_HI += photonIsolationHIProducerppGED
 _egammaHighLevelRecoPostPF_HI += photonIsolationHIProducerppIsland
 for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
     e.toReplaceWith(egammaHighLevelRecoPostPF, _egammaHighLevelRecoPostPF_HI)
+
+from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
+
+_egammaHighLevelRecoPostPF_HI_ppRef = egammaHighLevelRecoPostPF.copy()
+_egammaHighLevelRecoPostPF_HI_ppRef += photonIsolationHIProducerpp
+_egammaHighLevelRecoPostPF_HI_ppRef += photonIsolationHIProducerppGED
+ppRef_2017.toReplaceWith(egammaHighLevelRecoPostPF, _egammaHighLevelRecoPostPF_HI_ppRef)

--- a/RecoEgamma/EgammaPhotonProducers/python/photonCore_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/photonCore_cfi.py
@@ -16,7 +16,7 @@ photonCore = cms.EDProducer("PhotonCoreProducer",
 #    MVA_weights_location = cms.string('RecoEgamma/EgammaTools/data/TMVAnalysis_Likelihood.weights.txt')
 )
 
-photonCoreIsland = photonCore.clone(
+islandPhotonCore = photonCore.clone(
     scHybridBarrelProducer = "correctedIslandBarrelSuperClusters",
     scIslandEndcapProducer = "correctedIslandEndcapSuperClusters",
     minSCEt = 8.0

--- a/RecoEgamma/EgammaPhotonProducers/python/photonSequence_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/photonSequence_cff.py
@@ -10,9 +10,10 @@ from RecoEgamma.EgammaPhotonProducers.photons_cfi import *
 photonSequence = cms.Sequence( photonCore + photons )
 
 _photonSequenceWithIsland = photonSequence.copy()
-_photonSequenceWithIsland += ( photonCoreIsland + photonsIsland)
+_photonSequenceWithIsland += ( islandPhotonCore + islandPhotons )
 
+from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
+from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
-pp_on_XeXe_2017.toReplaceWith(
- photonSequence, _photonSequenceWithIsland
-)
+for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
+    e.toReplaceWith(photonSequence, _photonSequenceWithIsland)

--- a/RecoEgamma/EgammaPhotonProducers/python/photonSequence_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/photonSequence_cff.py
@@ -15,5 +15,6 @@ _photonSequenceWithIsland += ( islandPhotonCore + islandPhotons )
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
-for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
+from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
+for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017, ppRef_2017]:
     e.toReplaceWith(photonSequence, _photonSequenceWithIsland)

--- a/RecoEgamma/EgammaPhotonProducers/python/photons_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/photons_cfi.py
@@ -76,7 +76,7 @@ photons = cms.EDProducer("PhotonProducer",
 )
 
 
-photonsIsland = photons.clone(
+islandPhotons = photons.clone(
     photonCoreProducer = "islandPhotonCore",
     minSCEtBarrel = 5.0,
     minSCEtEndcap = 15.0,

--- a/RecoHI/HiEgammaAlgos/python/photonIsolationHIProducer_cfi.py
+++ b/RecoHI/HiEgammaAlgos/python/photonIsolationHIProducer_cfi.py
@@ -22,9 +22,13 @@ photonIsolationHIProducerppGED = photonIsolationHIProducerpp.clone(
 photonProducer=cms.InputTag("gedPhotons")
 )
 
+photonIsolationHIProducerppIsland = photonIsolationHIProducerpp.clone(
+photonProducer=cms.InputTag("islandPhotons")
+)
+
 from RecoEcal.EgammaClusterProducers.islandBasicClusters_cfi import *
 
 islandBasicClustersGED = islandBasicClusters.clone()
 photonIsolationHISequence = cms.Sequence(islandBasicClusters * photonIsolationHIProducerpp)
 photonIsolationHISequenceGED = cms.Sequence(islandBasicClustersGED * photonIsolationHIProducerppGED)
-
+photonIsolationHISequenceIsland = cms.Sequence(islandBasicClusters * photonIsolationHIProducerppIsland)


### PR DESCRIPTION
fixes the pp_on_XeXe_2017 era to run island photons and add them into event content
original 92X PR for pp_on_XeXe_2017 era : https://github.com/cms-sw/cmssw/pull/20760
adds "Run2_2017_ppRef" era to run customized reco for HI pp reference run
adds a corresponding relval wf (149)
runs and stores photonIsolationHIProducer objects using the era
backport of https://github.com/cms-sw/cmssw/pull/20929 and https://github.com/cms-sw/cmssw/pull/21122