### PR TITLE
Fix to save PS weights from Pythia8 in GenEventInfoProduct record

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -807,6 +807,15 @@ bool Pythia8Hadronizer::hadronize()
     nFSRveto += fEmissionVetoHook->getNFSRveto();  
   }
 
+  // fill shower weights
+  // http://home.thep.lu.se/~torbjorn/pythia82html/Variations.html
+  if( fMasterGen->info.nWeights() > 1 ){
+    for(int i = 0; i < fMasterGen->info.nWeights(); ++i) {
+      double wgt = fMasterGen->info.weight(i);
+      event()->weights().push_back(wgt);
+    }
+  }
+
   return true;
 
 }

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -99,7 +99,7 @@ class Pythia8Hadronizer : public Py8InterfaceBase {
     std::auto_ptr<Vincia::VinciaPlugin> fvincia;
 
     void doSetRandomEngine(CLHEP::HepRandomEngine* v) override { p8SetRandomEngine(v); }
-    virtual std::vector<std::string> const& doSharedResources() const override { return p8SharedResources; }
+    std::vector<std::string> const& doSharedResources() const override { return p8SharedResources; }
 
     /// Center-of-Mass energy
     double       comEnergy;
@@ -467,11 +467,11 @@ bool Pythia8Hadronizer::initializeForInternalPartons()
   if (useEvtGen) {
     edm::LogInfo("Pythia8Interface") << "Creating and initializing pythia8 EvtGen plugin";
 
-    evtgenDecays.reset(new EvtGenDecays(fMasterGen.get(), evtgenDecFile.c_str(), evtgenPdlFile.c_str()));
+    evtgenDecays.reset(new EvtGenDecays(fMasterGen.get(), evtgenDecFile, evtgenPdlFile));
 
     for (unsigned int i=0; i<evtgenUserFiles.size(); i++) {
       edm::FileInPath evtgenUserFile(evtgenUserFiles.at(i)); 
-      evtgenDecays->readDecayFile(evtgenUserFile.fullPath().c_str());
+      evtgenDecays->readDecayFile(evtgenUserFile.fullPath());
     }
 
   }
@@ -618,11 +618,11 @@ bool Pythia8Hadronizer::initializeForExternalPartons()
     edm::LogInfo("Pythia8Interface") << "Creating and initializing pythia8 EvtGen plugin";
 
     std::string evtgenpath(getenv("EVTGENDATA"));
-    evtgenDecays.reset(new EvtGenDecays(fMasterGen.get(), evtgenDecFile.c_str(), evtgenPdlFile.c_str()));
+    evtgenDecays.reset(new EvtGenDecays(fMasterGen.get(), evtgenDecFile, evtgenPdlFile));
 
     for (unsigned int i=0; i<evtgenUserFiles.size(); i++) {
       edm::FileInPath evtgenUserFile(evtgenUserFiles.at(i));
-      evtgenDecays->readDecayFile(evtgenUserFile.fullPath().c_str());
+      evtgenDecays->readDecayFile(evtgenUserFile.fullPath());
     }
 
   }
@@ -872,7 +872,7 @@ bool Pythia8Hadronizer::residualDecay()
 
 void Pythia8Hadronizer::finalizeEvent()
 {
-  bool lhe = lheEvent() != 0;
+  bool lhe = lheEvent() != nullptr;
 
   // now create the GenEventInfo product from the GenEvent and fill
   // the missing pieces


### PR DESCRIPTION
When using Powheg, it seems this piece of code got lost at some point. Not sure if this is the optimal solution but it is done this way in other parts of the class and works for me.

I let the experts to comment, perhaps a backport to 93X is needed if we want to use it for Moriond18 production.