### PR TITLE
[10.0.x] Miscellaneous updates in Alignment PV Validation 

### DIFF
--- a/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
+++ b/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
@@ -12,6 +12,7 @@ def getSequence(process, collection,
                 cosmicsZeroTesla = True,
                 momentumConstraint = None,
                 cosmicTrackSplitting = False,
+                isPVValidation = False,
                 use_d0cut = True):
     """This function returns a cms.Sequence containing as last element the
     module 'FinalTrackRefitter', which can be used as cms.InputTag for
@@ -42,6 +43,8 @@ def getSequence(process, collection,
                             to provide here the name of the constraint module.
     - `cosmicTrackSplitting`: If set to 'True' cosmic tracks are split before the
                               second track refitter.
+    - `isPVValidation`: If set to 'True' most of the selection cuts are overridden
+                        to allow unbiased selection of tracks for vertex refitting 
     - `use_d0cut`: If 'True' (default), apply a cut |d0| < 50.
     """
 
@@ -272,6 +275,25 @@ def getSequence(process, collection,
                                              "clone": True})]
         if isCosmics: mods = mods[1:] # skip high purity selector for cosmics
 
+    #############################
+    ## PV Validation cuts tune ##                 
+    #############################
+
+    if isPVValidation:
+        options["TrackSelector"]["HighPurity"].update({
+                "trackQualities": [],
+                "pMin": 0.
+                })
+        options["TrackSelector"]["Alignment"].update({
+                "pMin" :      0.,      
+                "ptMin" :     0.,       
+                "nHitMin2D" : 0,       
+                "nHitMin"   : 0,       
+                "d0Min" : -999999.0,
+                "d0Max" :  999999.0,
+                "dzMin" : -999999.0,
+                "dzMax" :  999999.0
+                })
 
     ################################
     ## apply momentum constraint? ##

--- a/Alignment/OfflineValidation/interface/PVValidationHelpers.h
+++ b/Alignment/OfflineValidation/interface/PVValidationHelpers.h
@@ -16,13 +16,13 @@ namespace PVValHelper {
   // helper logarithmic bin generator
 
   template <typename T, size_t N>
-  std::array<T, N+1> makeLogBins(const double min, const double max) {
-    const double minLog10 = std::log10(min);
-    const double maxLog10 = std::log10(max);
-    const double width = (maxLog10-minLog10)/N;
+  std::array<T, N+1> makeLogBins(const T min, const T max) {
+    const T minLog10 = std::log10(min);
+    const T maxLog10 = std::log10(max);
+    const T width = (maxLog10-minLog10)/N;
     std::array<T, N+1> ret;
     ret[0] = std::pow(10, minLog10);
-    const double mult = std::pow(10, width);
+    const T mult = std::pow(10, width);
     for ( size_t i=1; i<=N; ++i) {
       ret[i] = ret[i-1]*mult;
     }

--- a/Alignment/OfflineValidation/interface/PVValidationHelpers.h
+++ b/Alignment/OfflineValidation/interface/PVValidationHelpers.h
@@ -13,6 +13,22 @@
 
 namespace PVValHelper {
 
+  // helper logarithmic bin generator
+
+  template <typename T, size_t N>
+  std::array<T, N+1> makeLogBins(const double min, const double max) {
+    const double minLog10 = std::log10(min);
+    const double maxLog10 = std::log10(max);
+    const double width = (maxLog10-minLog10)/N;
+    std::array<T, N+1> ret;
+    ret[0] = std::pow(10, minLog10);
+    const double mult = std::pow(10, width);
+    for ( size_t i=1; i<=N; ++i) {
+      ret[i] = ret[i-1]*mult;
+    }
+    return ret;
+  }
+
   // helper data formats
 
   enum estimator 

--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -43,8 +43,8 @@
 #include <TSystem.h>
 #include <TTimeStamp.h>
 #include <TStopwatch.h>
-#include "Alignment/OfflineValidation/plugins/TkAlStyle.cc" 
-#include "CMS_lumi.C"
+//#include "Alignment/OfflineValidation/plugins/TkAlStyle.cc" 
+#include "Alignment/OfflineValidation/macros/CMS_lumi.C"
 
 /* 
    This is an auxilliary class to store the list of files
@@ -343,7 +343,7 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
     std::cout<<"FitPVResiduals::FitPVResiduals(): plot axis range will be automatically adjusted"<<std::endl;
   }
     
-  TkAlStyle::set(INTERNAL);	// set publication status
+  //TkAlStyle::set(INTERNAL);	// set publication status
 
   Int_t def_markers[9] = {kFullSquare,kFullCircle,kFullTriangleDown,kOpenSquare,kDot,kOpenCircle,kFullTriangleDown,kFullTriangleUp,kOpenTriangleDown};
   Int_t def_colors[9] = {kBlack,kRed,kBlue,kMagenta,kGreen,kCyan,kViolet,kOrange,kGreen+2};
@@ -517,8 +517,10 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
     if(gDirectory->GetListOfKeys()->Contains("etaMax")){
       gDirectory->GetObject("etaMax",theEtaHistos[i]);
       theEtaMax_[i]   = theEtaHistos[i]->GetBinContent(1)/theEtaHistos[i]->GetEntries();
+      std::cout<<"File n. "<<i<<" has theEtaMax["<<i<<"] = "<< theEtaMax_[i]<<std::endl;
     } else {
       theEtaMax_[i]   = 2.5;
+      std::cout<<"File n. "<<i<<" getting the default pseudo-rapidity range: "<< theEtaMax_[i]<<std::endl;
     }
     	
     if(gDirectory->GetListOfKeys()->Contains("nbins")){
@@ -1482,7 +1484,7 @@ void arrangeBiasCanvas(TCanvas *canv,TH1F* dxyPhiMeanTrend[100],TH1F* dzPhiMeanT
   canv->cd(4)->SetLeftMargin(0.18);
   canv->cd(4)->SetRightMargin(0.01);
   canv->cd(4)->SetTopMargin(0.06); 
-
+  
   TH1F *dBiasTrend[4][nFiles]; 
   
   for(Int_t i=0;i<nFiles;i++){
@@ -1500,6 +1502,11 @@ void arrangeBiasCanvas(TCanvas *canv,TH1F* dxyPhiMeanTrend[100],TH1F* dzPhiMeanT
     canv->cd(k+1);
     
     for(Int_t i=0; i<nFiles; i++){
+
+      if(TString(canv->GetName()).Contains("BareResiduals")){
+	dBiasTrend[k][i]->Scale(1./dBiasTrend[k][i]->GetSumOfWeights());
+      }
+
       if(dBiasTrend[k][i]->GetMaximum()>absmax[k]) absmax[k] = dBiasTrend[k][i]->GetMaximum();
       if(dBiasTrend[k][i]->GetMinimum()<absmin[k]) absmin[k] = dBiasTrend[k][i]->GetMinimum();
     }
@@ -1545,6 +1552,11 @@ void arrangeBiasCanvas(TCanvas *canv,TH1F* dxyPhiMeanTrend[100],TH1F* dzPhiMeanT
 	    } 
 	  }
 	}
+	
+	if(TString(canv->GetName()).Contains("BareResiduals") && (k==0 || k==2)){
+	  dBiasTrend[k][i]->GetXaxis()->SetRangeUser(-0.11,0.11);
+	}
+
 	dBiasTrend[k][i]->Draw("e1");
 	makeNewXAxis(dBiasTrend[k][i]);
 	Int_t nbins =  dBiasTrend[k][i]->GetNbinsX();
@@ -1572,9 +1584,15 @@ void arrangeBiasCanvas(TCanvas *canv,TH1F* dxyPhiMeanTrend[100],TH1F* dzPhiMeanT
 	theConst->Draw("PLsame");
 
       }
-      else { 
-	dBiasTrend[k][i]->Draw("e1sames");	
+      else {	       
+
+	if(TString(canv->GetName()).Contains("BareResiduals") && (k==0 || k==2)){
+	  dBiasTrend[k][i]->GetXaxis()->SetRangeUser(-0.11,0.11);
+	}
+
+	dBiasTrend[k][i]->Draw("e1sames");      
       }
+
       if(k==0){
 	lego->AddEntry(dBiasTrend[k][i],LegLabels[i]);
       } 
@@ -1775,7 +1793,7 @@ void arrangeCanvas(TCanvas *canv,TH1F* meanplots[100],TH1F* widthplots[100],Int_
 
 	widthplots[i]->Draw("e1");
 	if(TString(widthplots[i]->GetName()).Contains("pT")){
-	  widthplots[i]->Draw("HIST][same");
+	  //widthplots[i]->Draw("HIST][same");
 	  gPad->SetGridx();
 	  gPad->SetGridy();
 	} 
@@ -1783,7 +1801,7 @@ void arrangeCanvas(TCanvas *canv,TH1F* meanplots[100],TH1F* widthplots[100],Int_
       } else {
 	widthplots[i]->Draw("e1sames");
 	if(TString(widthplots[i]->GetName()).Contains("pT")){
-	  widthplots[i]->Draw("HIST][same");
+	  //widthplots[i]->Draw("HIST][same");
 	}
       }
     }
@@ -1836,7 +1854,7 @@ void arrangeCanvas2D(TCanvas *canv,TH2F* meanmaps[100],TH2F* widthmaps[100],Int_
     pt2[i]->SetTextFont(52);
     pt2[i]->SetTextAlign(12);
     // TText *text2 = pt2->AddText("run: "+theDate);
-    TText *text2 = pt2[i]->AddText(toTString(INTERNAL));
+    TText *text2 = pt2[i]->AddText("INTERNAL");
     text2->SetTextSize(0.06*extraOverCmsTextSize); 
     
     pt3[i] = new TPaveText(0.55,0.955,0.95,0.98,"NDC");
@@ -2879,7 +2897,7 @@ void  MakeNiceTrendPlotStyle(TH1 *hist,Int_t color,Int_t style)
   hist->GetXaxis()->SetLabelSize(.07);
   //hist->GetXaxis()->SetNdivisions(505);
   if(color!=8){
-    hist->SetMarkerSize(1.5);
+    hist->SetMarkerSize(1.0);
   } else {
     hist->SetLineWidth(3);
     hist->SetMarkerSize(0.0);    
@@ -3246,8 +3264,8 @@ void makeNewXAxis (TH1F *h)
     axmax = 8.5;
   } else if (myTitle.Contains("h_probe")){
     ndiv = 505;
-    axmin = h->GetXaxis()->GetXmin();
-    axmax = h->GetXaxis()->GetXmax();
+    axmin = h->GetXaxis()->GetBinCenter(h->GetXaxis()->GetFirst());
+    axmax = h->GetXaxis()->GetBinCenter(h->GetXaxis()->GetLast());
   } else  {
     std::cout<<"unrecognized variable for histogram title: "<<myTitle<<std::endl;
   }

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -80,7 +80,7 @@ PrimaryVertexValidation::PrimaryVertexValidation(const edm::ParameterSet& iConfi
   etaOfProbe_(iConfig.getUntrackedParameter<double>("probeEta",2.4)),
   nHitsOfProbe_(iConfig.getUntrackedParameter<double>("probeNHits",0.)),
   nBins_(iConfig.getUntrackedParameter<int>("numberOfBins",24)),
-  minPt_(iConfig.getUntrackedParameter<double>("minPt",0.5)),
+  minPt_(iConfig.getUntrackedParameter<double>("minPt",1.)),
   maxPt_(iConfig.getUntrackedParameter<double>("maxPt",20.)),
   debug_(iConfig.getParameter<bool>("Debug")),
   runControl_(iConfig.getUntrackedParameter<bool>("runControl",false))

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -302,6 +302,9 @@ PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::EventSetup
     h_etaMax->SetBinContent(1.,etaOfProbe_);
     h_nbins->SetBinContent(1.,nBins_);
     h_nLadders->SetBinContent(1.,nLadders_);
+    h_pTinfo->SetBinContent(1.,mypT_bins_.size());
+    h_pTinfo->SetBinContent(2.,minPt_);
+    h_pTinfo->SetBinContent(3.,maxPt_);
   }
 
   //=======================================================
@@ -1252,7 +1255,6 @@ void PrimaryVertexValidation::beginJob()
   }
   
   h_runFromEvent      = EventFeatures.make<TH1I>("h_runFromEvent","run number from config;;run number (from event)",1,-0.5,0.5);
-
   h_nTracks           = EventFeatures.make<TH1F>("h_nTracks","number of tracks per event;n_{tracks}/event;n_{events}",300,-0.5,299.5);	     
   h_nClus             = EventFeatures.make<TH1F>("h_nClus","number of track clusters;n_{clusters}/event;n_{events}",50,-0.5,49.5);	     
   h_nOfflineVertices  = EventFeatures.make<TH1F>("h_nOfflineVertices","number of offline reconstructed vertices;n_{vertices}/event;n_{events}",50,-0.5,49.5);  
@@ -1271,6 +1273,11 @@ void PrimaryVertexValidation::beginJob()
   h_BeamWidthY        = EventFeatures.make<TH1F>("h_BeamWidthY","y-coordinate beam width;#sigma_{Y}^{beam};n_{events}",100,0.,0.01);        
 
   h_etaMax            = EventFeatures.make<TH1F>("etaMax","etaMax",1,-0.5,0.5);
+  h_pTinfo            = EventFeatures.make<TH1F>("pTinfo","pTinfo",3,-1.5,1.5);
+  h_pTinfo->GetXaxis()->SetBinLabel(1,"n. bins");
+  h_pTinfo->GetXaxis()->SetBinLabel(2,"pT min");
+  h_pTinfo->GetXaxis()->SetBinLabel(3,"pT max");
+
   h_nbins             = EventFeatures.make<TH1F>("nbins","nbins",1,-0.5,0.5);
   h_nLadders          = EventFeatures.make<TH1F>("nladders","n. ladders",1,-0.5,0.5);
 

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -71,9 +71,9 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   ~PrimaryVertexValidation() override;
 
  private:
-  virtual void beginJob() override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override;
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
   bool isBFieldConsistentWithMode(const edm::EventSetup& iSetup) const;
   bool isHit2D(const TrackingRecHit &hit) const;
   bool hasFirstLayerPixelHits(const reco::TransientTrack& track);

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -269,6 +269,7 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   TH1F* h_etaMax;
   TH1F* h_nbins;
   TH1F* h_nLadders;
+  TH1F* h_pTinfo;
 
   // ---- directly histograms // ===> unbiased residuals
   

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -141,7 +141,14 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   double  etaOfProbe_;
   double  nHitsOfProbe_;
   bool    isPhase1_;
-  int nBins_;                 // actual number of histograms     
+ 
+  // actual number of histograms     
+  int nBins_;                
+
+  // limits of the pt binned plots range
+  const double minPt_;
+  const double maxPt_;
+ 
   std::vector<unsigned int> runControlNumbers_;
 
   bool debug_;
@@ -167,7 +174,9 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
   // pT binning as in paragraph 3.2 of CMS-PAS-TRK-10-005 (https://cds.cern.ch/record/1279383/files/TRK-10-005-pas.pdf)
 
   //                                      0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  24  25  26  27  28  29  30  31  32  33  34  35  36   37  38   39  40  41  42  43  44  45   46  47  48
-  const float mypT_bins_[nPtBins_+1] = {0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,2.0,2.1,2.2,2.3,2.4,2.5,2.6,2.7,2.8,2.9,3.0,3.1,3.2,3.3,3.4,3.5,3.6,3.7,3.8,3.9,4.0,4.1,4.25,4.5,4.75,5.0,5.5,6.0,7.0,8.0,9.0,11.0,14.0,20.}; 
+  //const float mypT_bins_[nPtBins_+1] = {0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,2.0,2.1,2.2,2.3,2.4,2.5,2.6,2.7,2.8,2.9,3.0,3.1,3.2,3.3,3.4,3.5,3.6,3.7,3.8,3.9,4.0,4.1,4.25,4.5,4.75,5.0,5.5,6.0,7.0,8.0,9.0,11.0,14.0,20.}; 
+
+  std::array<float,nPtBins_+1> mypT_bins_;  
 
   // event-related quantities
   int nTracks_;
@@ -549,6 +558,7 @@ class PrimaryVertexValidation : public edm::one::EDAnalyzer<edm::one::SharedReso
 
   TH1F* h_probeP_;
   TH1F* h_probePt_;
+  TH1F* h_probePtRebin_;
   TH1F* h_probeEta_;
   TH1F* h_probePhi_;
   TH1F* h_probeChi2_;

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
@@ -163,6 +163,7 @@ process.MessageLogger.statistics.append('cout')
 CommonTrackSelectionRefitting = """
 import Alignment.CommonAlignment.tools.trackselectionRefitting as trackselRefit
 process.seqTrackselRefit = trackselRefit.getSequence(process, '.oO[trackcollection]Oo.',
+                                                     isPVValidation=.oO[ispvvalidation]Oo., 
                                                      TTRHBuilder='.oO[ttrhbuilder]Oo.',
                                                      usePixelQualityFlag=.oO[usepixelqualityflag]Oo.,
                                                      openMassWindow=.oO[openmasswindow]Oo.,

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/genericValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/genericValidation.py
@@ -519,6 +519,7 @@ class GenericValidationData_CTSR(GenericValidationData):
             "istracksplitting": str(isinstance(self, TrackSplittingValidation)),
             "cosmics0T": str(self.cosmics0T),
             "use_d0cut": str(self.use_d0cut),
+            "ispvvalidation": str(self.isPVValidation) 
         })
 
         commands = []
@@ -534,6 +535,9 @@ class GenericValidationData_CTSR(GenericValidationData):
     @property
     def use_d0cut(self):
         return "Cosmics" not in self.general["trackcollection"]  #use it for collisions only
+    @property
+    def isPVValidation(self):
+        return False  # only for PV Validation sequence
     @property
     def TrackSelectionRefitting(self):
         return configTemplates.CommonTrackSelectionRefitting

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidation.py
@@ -49,6 +49,10 @@ class PrimaryVertexValidation(GenericValidationData_CTSR, ValidationWithPlots):
         return False
 
     @property
+    def isPVValidation(self):
+        return True
+
+    @property
     def ProcessName(self):
         return "PrimaryVertexValidation"
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidation.py
@@ -12,10 +12,10 @@ class PrimaryVertexValidation(GenericValidationData_CTSR, ValidationWithPlots):
     resultBaseName  = "PrimaryVertexValidation"
     outputBaseName  = "PrimaryVertexValidation"
     defaults = {
-                "pvvalidationreference": ("/store/caf/user/musich/Alignment/TkAlPrimaryVertexValidation/Reference/PrimaryVertexValidation_test_pvvalidation_upgrade2017_design_mc_48bins.root"),
-                "doBPix":"True",
-                "doFPix":"True"
-               }
+        "pvvalidationreference": ("/store/group/alca_trackeralign/validation/PVValidation/Reference/PrimaryVertexValidation_phaseIMC92X_upgrade2017_realistic.root"),
+        "doBPix":"True",
+        "doFPix":"True"
+        }
     mandatories = {"isda","ismc","runboundary","trackcollection","vertexcollection","lumilist","ptCut","etaCut","runControl","numberOfBins"}
     valType = "primaryvertex"
     def __init__(self, valName, alignment, config):

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidation.py
@@ -12,7 +12,8 @@ class PrimaryVertexValidation(GenericValidationData_CTSR, ValidationWithPlots):
     resultBaseName  = "PrimaryVertexValidation"
     outputBaseName  = "PrimaryVertexValidation"
     defaults = {
-        "pvvalidationreference": ("/store/group/alca_trackeralign/validation/PVValidation/Reference/PrimaryVertexValidation_phaseIMC92X_upgrade2017_realistic.root"),
+        # N.B.: the reference needs to be updated each time the format of the output is changed
+        "pvvalidationreference": ("/store/group/alca_trackeralign/validation/PVValidation/Reference/PrimaryVertexValidation_phaseIMC92X_upgrade2017_Ideal.root"),
         "doBPix":"True",
         "doFPix":"True"
         }

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
@@ -213,7 +213,7 @@ ls -lh .
 eos mkdir -p /store/caf/user/$USER/.oO[eosdir]Oo./plots/
 for RootOutputFile in $(ls *root )
 do
-    xrdcp -f ${RootOutputFile}  root://eoscms//eos/cms/store/caf/user/$USER/.oO[eosdir]Oo./
+    xrdcp -f ${RootOutputFile} root://eoscms//eos/cms/store/caf/user/$USER/.oO[eosdir]Oo./${RootOutputFile}
     rfcp ${RootOutputFile}  .oO[workingdir]Oo.
 done
 
@@ -227,12 +227,12 @@ root -b -q "FitPVResiduals.C(\\"${PWD}/${RootOutputFile}=${theLabel},${PWD}/PVVa
 
 mkdir -p .oO[plotsdir]Oo.
 for PngOutputFile in $(ls *png ); do
-    xrdcp -f ${PngOutputFile}  root://eoscms//eos/cms/store/caf/user/$USER/.oO[eosdir]Oo./plots/
+    xrdcp -f ${PngOutputFile}  root://eoscms//eos/cms/store/caf/user/$USER/.oO[eosdir]Oo./plots/${PngOutputFile}
     rfcp ${PngOutputFile}  .oO[plotsdir]Oo.
 done
 
 for PdfOutputFile in $(ls *pdf ); do
-    xrdcp -f ${PdfOutputFile}  root://eoscms//eos/cms/store/caf/user/$USER/.oO[eosdir]Oo./plots/
+    xrdcp -f ${PdfOutputFile}  root://eoscms//eos/cms/store/caf/user/$USER/.oO[eosdir]Oo./plots/${PdfOutputFile}
     rfcp ${PdfOutputFile}  .oO[plotsdir]Oo.
 done
 
@@ -300,12 +300,12 @@ rfcp .oO[plottingscriptpath]Oo. .
 root -x -b -q .oO[plottingscriptname]Oo.++
 
 for PdfOutputFile in $(ls *pdf ); do
-    xrdcp -f ${PdfOutputFile}  root://eoscms//eos/cms/store/caf/user/$USER/.oO[eosdir]Oo./plots/
+    xrdcp -f ${PdfOutputFile}  root://eoscms//eos/cms/store/caf/user/$USER/.oO[eosdir]Oo./plots/${PdfOutputFile}
     rfcp ${PdfOutputFile}  .oO[datadir]Oo./.oO[PlotsDirName]Oo.
 done
 
 for PngOutputFile in $(ls *png ); do
-    xrdcp -f ${PngOutputFile}  root://eoscms//eos/cms/store/caf/user/$USER/.oO[eosdir]Oo./plots/
+    xrdcp -f ${PngOutputFile}  root://eoscms//eos/cms/store/caf/user/$USER/.oO[eosdir]Oo./plots/${PngOutputFile}
     rfcp ${PngOutputFile}  .oO[datadir]Oo./.oO[PlotsDirName]Oo.
 done
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
@@ -1,16 +1,5 @@
 PrimaryVertexValidationTemplate="""
 
-process.HighPurityTrackSelector.trackQualities = cms.vstring()
-process.HighPurityTrackSelector.pMin     = cms.double(0.)
-process.AlignmentTrackSelector.pMin      = cms.double(0.)
-process.AlignmentTrackSelector.ptMin     = cms.double(0.)
-process.AlignmentTrackSelector.nHitMin2D = cms.uint32(0)
-process.AlignmentTrackSelector.nHitMin   = cms.double(0.)
-process.AlignmentTrackSelector.d0Min     = cms.double(-999999.0)
-process.AlignmentTrackSelector.d0Max     = cms.double(+999999.0)
-process.AlignmentTrackSelector.dzMin     = cms.double(-999999.0)
-process.AlignmentTrackSelector.dzMax     = cms.double(+999999.0)
-
 isDA = .oO[isda]Oo.
 isMC = .oO[ismc]Oo.
 

--- a/Alignment/OfflineValidation/test/testPVValidation_all_ini_one.ini
+++ b/Alignment/OfflineValidation/test/testPVValidation_all_ini_one.ini
@@ -16,7 +16,7 @@ datadir = /afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/data/commonValidation/r
 title= 2016 MC
 globaltag = auto:run2_mc
 color = kBlack
-style = kFullCircle
+style = kOpenCircle
 
 [alignment:2016_data]
 title= 2016 data
@@ -40,12 +40,14 @@ style = kOpenTriangleDown
 title= 2017 MC Ideal
 globaltag = auto:phase1_2017_design
 condition TrackerAlignmentRcd = frontier://FrontierProd/CMS_CONDITIONS,TrackerAlignment_Upgrade2017_design_v4
+## need beamspot as in the simulated sample
+condition BeamSpotObjectsRcd  = frontier://FrontierProd/CMS_CONDITIONS,Ideal_Centered_SLHC_v3                                                
 color = kCyan
 style = kOpenSquare
 
 [alignment:2017_data]
 title= 2017 Data
-globaltag = 
+globaltag = auto:run2_data_promptlike
 color = kBlack
 style = kFullCircle
 

--- a/Alignment/OfflineValidation/test/testPVValidation_all_ini_one.ini
+++ b/Alignment/OfflineValidation/test/testPVValidation_all_ini_one.ini
@@ -41,7 +41,7 @@ title= 2017 MC Ideal
 globaltag = auto:phase1_2017_design
 condition TrackerAlignmentRcd = frontier://FrontierProd/CMS_CONDITIONS,TrackerAlignment_Upgrade2017_design_v4
 ## need beamspot as in the simulated sample
-condition BeamSpotObjectsRcd  = frontier://FrontierProd/CMS_CONDITIONS,Ideal_Centered_SLHC_v3                                                
+condition BeamSpotObjectsRcd  = frontier://FrontierProd/CMS_CONDITIONS,BeamSpotObjects_Realistic25ns_13TeVCollisions_Early2017_v1_mc 
 color = kCyan
 style = kOpenSquare
 

--- a/Alignment/OfflineValidation/test/testPVValidation_all_ini_one.ini
+++ b/Alignment/OfflineValidation/test/testPVValidation_all_ini_one.ini
@@ -3,46 +3,51 @@
 # - one can override `jobmode` in the individual validation's section
 [general]
 jobmode = lxBatch, -q cmscaf1nd
-datadir	= /afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/data/commonValidation/results/$USER/PVValidationPhaseI_TEST
+datadir = /afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/data/commonValidation/results/$USER/PVValidationTest
 # if you want your root files stored in a subdirectory on eos, put it here:
 # eosdir = Test
 # if you want your logs to be stored somewhere else, put it here:
 # logdir = /afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/data/commonValidation/results/$USER/log
 
-
 ###############################################################################
 # configuration of several alignments
 
-[alignment:run2_mc]
+[alignment:2016_mc]
 title= 2016 MC
 globaltag = auto:run2_mc
 color = kBlack
 style = kFullCircle
 
-[alignment:run2_data]
+[alignment:2016_data]
 title= 2016 data
-globaltag = 80X_dataRun2_Prompt_v15_forTkAlNovCamp_singleIOV_v1
+globaltag = auto:run2_data
 color = kRed
 style = kFullSquare
 
-[alignment:upgrade2017_mc]
+[alignment:2017_mc]
 title= 2017 MC
 globaltag = auto:phase1_2017_realistic
 color = kBlue
 style = kFullTriangleDown
 
-[alignment:upgrade2017_mc_bpixonly]
+[alignment:2017_mc_bpixonly]
 title= 2017 MC BPix
 globaltag = auto:phase1_2017_realistic
 color = kMagenta
 style = kOpenTriangleDown
 
-[alignment:upgrade2017_pseudoAsymptotic]
-title= 2017 MC Asy
-globaltag = auto:phase1_2017_realistic
-condition TrackerAlignmentRcd = frontier://FrontierProd/CMS_CONDITIONS,TrackerAlignment_Upgrade2017_realisticStrips_pseudoAsymptoticPixels_v0
+[alignment:2017_mc_Ideal]
+title= 2017 MC Ideal
+globaltag = auto:phase1_2017_design
+condition TrackerAlignmentRcd = frontier://FrontierProd/CMS_CONDITIONS,TrackerAlignment_Upgrade2017_design_v4
 color = kCyan
 style = kOpenSquare
+
+[alignment:2017_data]
+title= 2017 Data
+globaltag = 
+color = kBlack
+style = kFullCircle
 
 ###############################################################################
 # plotting options
@@ -75,8 +80,8 @@ w_dzEtaNormMax = 1.8
 ###############################################################################
 # configuration of individual validations
 
-[primaryvertex:run2MC]
-maxevents = 100000
+[primaryvertex:phase0MC]
+maxevents = 10000
 dataset = /RelValTTbar_13/CMSSW_8_1_0_pre16-TkAlMinBias-81X_mcRun2_asymptotic_v11-v1/ALCARECO 
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices
@@ -90,41 +95,39 @@ etaCut = 2.5
 runControl = False
 
 [primaryvertex:phaseIMC]
-maxevents = 100000
-dataset = /RelValTTbar_13/CMSSW_8_1_0_pre16-TkAlMinBias-81X_upgrade2017_realistic_v22-v1/ALCARECO
+maxevents = 10000
+dataset =  /QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/RunIISummer17DRPremix-TkAlMinBias-92X_upgrade2017_realistic_v10-v1/ALCARECO
 trackcollection = ALCARECOTkAlMinBias
-### use Generic CPE for track refit
-ttrhbuilder = WithTrackAngle  
 vertexcollection = offlinePrimaryVertices
+### use Generic CPE for track refit
+### ttrhbuilder = WithTrackAngle  
 isda = True
 ismc = True
 numberOfBins = 48
 runboundary = 1
 lumilist = None
-ptCut = 3.
+ptCut  = 3.
 etaCut = 2.5
 runControl = False
 
 [primaryvertex:phaseIMC_BPixOnly]
-maxevents = 100000
-dataset = /RelValTTbar_13/CMSSW_8_1_0_pre16-TkAlMinBias-81X_upgrade2017_realistic_v22-v1/ALCARECO
+maxevents = 10000
+dataset =  /QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/RunIISummer17DRPremix-TkAlMinBias-92X_upgrade2017_realistic_v10-v1/ALCARECO
 trackcollection = ALCARECOTkAlMinBias
-### use Generic CPE for track refit
-ttrhbuilder = WithTrackAngle   
 vertexcollection = offlinePrimaryVertices
 isda = True
 ismc = True
 numberOfBins = 48
 runboundary = 1
 lumilist = None
-ptCut = 3.
+ptCut  = 3.
 etaCut = 2.5
 doBPix = True
 doFPix = False
 runControl = False
 
-[primaryvertex:run2data]
-maxevents = 100000
+[primaryvertex:run2016data]
+maxevents = 10000
 dataset = /HLTPhysics/Run2016H-TkAlMinBias-PromptReco-v2/ALCARECO
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices
@@ -137,12 +140,29 @@ ptCut  = 3.
 etaCut = 2.5
 runControl = True
 
+[primaryvertex:run2017data]
+maxevents = 10000
+dataset = /StreamExpressAlignment/Run2017C-TkAlMinBias-Express-v3/ALCARECO
+trackcollection = ALCARECOTkAlMinBias
+vertexcollection = offlinePrimaryVertices
+isda = True
+ismc = False
+numberOfBins = 48
+runboundary = 301461
+lumilist = /afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/DCSOnly/json_DCSONLY.txt
+ptCut  = 3.
+etaCut = 2.5
+runControl = True
+
 ###############################################################################
 # configure which validation to run on which alignment
 
 [validation]
-primaryvertex run2MC   : run2_mc 
-primaryvertex run2data : run2_data
-primaryvertex phaseIMC : upgrade2017_mc
-#primaryvertex phaseIMC : upgrade2017_pseudoAsymptotic
-primaryvertex phaseIMC_BPixOnly : upgrade2017_mc_bpixonly 
+primaryvertex phase0MC    : 2016_mc 
+primaryvertex run2016data : 2016_data
+primaryvertex phaseIMC    : 2017_mc
+primaryvertex run2017data : 2017_data
+primaryvertex phaseIMC_BPixOnly : 2017_mc_bpixonly
+primaryvertex phaseIMC    : 2017_mc_Ideal
+
+

--- a/Alignment/OfflineValidation/test/test_all_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_cfg.py
@@ -18,10 +18,6 @@ process.source = cms.Source("PoolSource",
                             duplicateCheckMode = cms.untracked.string('checkAllFilesOpened')
                             )
 
-process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.destinations = ['cout', 'cerr']
-process.MessageLogger.cerr.FwkReport.reportEvery = 1000
-
 runboundary = 1
 process.source.firstRun = cms.untracked.uint32(int(runboundary))
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
@@ -40,9 +36,24 @@ else:
 ###################################################################
 # Messages
 ###################################################################
-process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.destinations = ['cout', 'cerr']
-process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+process.load('FWCore.MessageService.MessageLogger_cfi')   
+process.MessageLogger.categories.append("PrimaryVertexValidation")  
+process.MessageLogger.categories.append("FilterOutLowPt")  
+process.MessageLogger.destinations = cms.untracked.vstring("cout")
+process.MessageLogger.cout = cms.untracked.PSet(
+    threshold = cms.untracked.string("INFO"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),                                                      
+    PrimaryVertexValidation = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    FilterOutLowPt          = cms.untracked.PSet( limit = cms.untracked.int32(-1))
+    )
+process.MessageLogger.statistics.append('cout') 
+
+# process.load("FWCore.MessageService.MessageLogger_cfi")
+# process.MessageLogger.destinations = ['cout', 'cerr']
+# process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 
 ####################################################################
 # Produce the Transient Track Record in the event
@@ -207,6 +218,8 @@ if isDA:
                                            isLightNtuple = cms.bool(True),
                                            askFirstLayerHit = cms.bool(False),
                                            probePt = cms.untracked.double(3.),
+                                           minPt   = cms.untracked.double(1.),
+                                           maxPt   = cms.untracked.double(30.),
                                            runControl = cms.untracked.bool(True),
                                            runControlNumber = cms.untracked.vuint32(int(runboundary)),
                                            
@@ -249,6 +262,8 @@ else:
                                            useTracksFromRecoVtx = cms.bool(False),
                                            askFirstLayerHit = cms.bool(False),
                                            probePt = cms.untracked.double(3.),
+                                           minPt   = cms.untracked.double(1.),
+                                           maxPt   = cms.untracked.double(30.),
                                            runControl = cms.untracked.bool(True),
                                            runControlNumber = cms.untracked.vuint32(int(runboundary)),
                                            

--- a/Alignment/OfflineValidation/test/test_all_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_cfg.py
@@ -51,10 +51,6 @@ process.MessageLogger.cout = cms.untracked.PSet(
     )
 process.MessageLogger.statistics.append('cout') 
 
-# process.load("FWCore.MessageService.MessageLogger_cfi")
-# process.MessageLogger.destinations = ['cout', 'cerr']
-# process.MessageLogger.cerr.FwkReport.reportEvery = 1000
-
 ####################################################################
 # Produce the Transient Track Record in the event
 ####################################################################
@@ -185,17 +181,29 @@ else:
 ####################################################################
 # Load and Configure TrackRefitter
 ####################################################################
-#import Alignment.CommonAlignment.tools.trackselectionRefitting as trackselRefit
-#process.seqTrackselRefit = trackselRefit.getSequence(process,'generalTracks')
-#process.seqTrackselRefit.TrackSelector.ptMin = cms.double(3)
+# process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
+# import RecoTracker.TrackProducer.TrackRefitters_cff
+# process.FinalTrackRefitter = RecoTracker.TrackProducer.TrackRefitter_cfi.TrackRefitter.clone()
+# process.FinalTrackRefitter.src = "generalTracks"
+# process.FinalTrackRefitter.TrajectoryInEvent = True
+# process.FinalTrackRefitter.NavigationSchool = ''
+# process.FinalTrackRefitter.TTRHBuilder = "WithAngleAndTemplate"
 
-process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
-import RecoTracker.TrackProducer.TrackRefitters_cff
-process.FinalTrackRefitter = RecoTracker.TrackProducer.TrackRefitter_cfi.TrackRefitter.clone()
-process.FinalTrackRefitter.src = "generalTracks"
-process.FinalTrackRefitter.TrajectoryInEvent = True
-process.FinalTrackRefitter.NavigationSchool = ''
-process.FinalTrackRefitter.TTRHBuilder = "WithAngleAndTemplate"
+####################################################################
+# Load and Configure Common Track Selection and refitting sequence
+####################################################################
+import Alignment.CommonAlignment.tools.trackselectionRefitting as trackselRefit
+process.seqTrackselRefit = trackselRefit.getSequence(process, 'generalTracks',
+                                                     isPVValidation=True, 
+                                                     TTRHBuilder='WithAngleAndTemplate',
+                                                     usePixelQualityFlag=True,
+                                                     openMassWindow=False,
+                                                     cosmicsDecoMode=True,
+                                                     cosmicsZeroTesla=False,
+                                                     momentumConstraint=None,
+                                                     cosmicTrackSplitting=False,
+                                                     use_d0cut=False,
+                                                     )
 
 ####################################################################
 # Output file
@@ -287,10 +295,11 @@ else:
 # Path
 ####################################################################
 process.p = cms.Path(process.goodvertexSkim*
-                     process.offlineBeamSpot*
-                     # in case common fit sequence is uses
-                     #process.seqTrackselRefit*
+                     #### in case of old-style single refit sequence
+                     #process.offlineBeamSpot*
                      # in case NavigatioSchool is set !='' 
                      #process.MeasurementTrackerEvent*
-                     process.FinalTrackRefitter*
+                     #process.FinalTrackRefitter*
+                     # in case common fit sequence is used
+                     process.seqTrackselRefit*
                      process.PVValidation)


### PR DESCRIPTION
 Greetings, 
this is the summary of the updates proposed in this PR:
   *  move specialized track selection (most hits/tracks selection cuts are open w.r.t. the rest of validation types) from the PV validation configuration file template to the common track selection and refitting sequence.
   * use configurable (log)-binning for pT-binned resolution and bias.
   * update plotting macros to check for consistent pT-binning among input files.
   * update example `ini` file using 2016 legacy data and 2017 MC with final pixel geometry.
   * updated reference file address with consistently updated binning  
   * update unit test to use the common track selection and refitting sequence
   * few graphical improvements on the output plots. 