### PR TITLE
L1T DQM - Fix for OMTF data to emulator check configuration - 94x

### DIFF
--- a/DQM/L1TMonitorClient/python/L1TStage2OMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2OMTFEmulatorClient_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
-from DQM.L1TMonitor.L1TdeStage2OMTF_cfi import ignoreBins
+from DQM.L1TMonitor.L1TdeStage2OMTF_cfi import ignoreBinsDeStage2Omtf
 
 # RegionalMuonCands
 l1tStage2OMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
@@ -11,7 +11,7 @@ l1tStage2OMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     ratioTitle = cms.untracked.string('Summary of mismatch rates between OMTF muons and OMTF emulator muons'),
     yAxisTitle = cms.untracked.string('# mismatch / # total'),
     binomialErr = cms.untracked.bool(True),
-    ignoreBin = cms.untracked.vint32(ignoreBins)
+    ignoreBin = cms.untracked.vint32(ignoreBinsDeStage2Omtf)
 )
 
 # sequences


### PR DESCRIPTION
Fixes a python error when running the L1TEMU online DQM configuration.
The problem was introduced with the changes in this commit [1] missing to also change the file in the current PR.

[1]
https://github.com/cms-sw/cmssw/commit/1e2154188e97871948a57403499b74e8ab77a72c