### PR TITLE
fix for asan build

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc
@@ -2294,7 +2294,7 @@ void CSCTriggerPrimitivesReader::drawALCTHistos() {
   TText t;
   t.SetTextFont(32);
   t.SetTextSize(0.025);
-  char pagenum[7], titl[50];
+  char pagenum[16], titl[50];
   TPaveLabel *title;
 
   int max_idh = plotME42 ? CSC_TYPES : CSC_TYPES-1;
@@ -2368,7 +2368,7 @@ void CSCTriggerPrimitivesReader::drawCLCTHistos() {
   TText t;
   t.SetTextFont(32);
   t.SetTextSize(0.025);
-  char pagenum[7], titl[50];
+  char pagenum[16], titl[50];
   TPaveLabel *title;
 
   ps->NewPage();
@@ -2537,7 +2537,7 @@ void CSCTriggerPrimitivesReader::drawLCTTMBHistos() {
   TText t;
   t.SetTextFont(32);
   t.SetTextSize(0.025);
-  char pagenum[7], titl[50];
+  char pagenum[16], titl[50];
   TPaveLabel *title;
 
   int max_idh = plotME42 ? CSC_TYPES : CSC_TYPES-1;
@@ -2634,7 +2634,7 @@ void CSCTriggerPrimitivesReader::drawLCTMPCHistos() {
   TText t;
   t.SetTextFont(32);
   t.SetTextSize(0.025);
-  char pagenum[7];
+  char pagenum[16];
   TPaveLabel *title;
 
   ps->NewPage();
@@ -2707,7 +2707,7 @@ void CSCTriggerPrimitivesReader::drawCompHistos() {
   TText t;
   t.SetTextFont(32);
   t.SetTextSize(0.025);
-  char pagenum[7];
+  char pagenum[16];
   TPaveLabel *title;
   Int_t nbins;
 
@@ -3045,7 +3045,7 @@ void CSCTriggerPrimitivesReader::drawResolHistos() {
   TText t;
   t.SetTextFont(32);
   t.SetTextSize(0.025);
-  char pagenum[7];
+  char pagenum[16];
   TPaveLabel *title;
 
   int max_idh = plotME42 ? CSC_TYPES : CSC_TYPES-1;
@@ -3422,7 +3422,7 @@ void CSCTriggerPrimitivesReader::drawEfficHistos() {
   TText t;
   t.SetTextFont(32);
   t.SetTextSize(0.025);
-  char pagenum[7];
+  char pagenum[16];
   TPaveLabel *title;
   char histtitle[60];
   


### PR DESCRIPTION
This PR fixes the build error we get with ASAN IBs
```
L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc: In member function 'void CSCTriggerPrimitivesReader::drawCompHistos()':
L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc:2696:6: error: '%d' directive output may be truncated writing between 1 and 10 bytes into a region of size 5 [-Werror=format-truncation=]
 void CSCTriggerPrimitivesReader::drawCompHistos() {
      ^~~~~~~~~~~~~~~~~~~~~~~~~~
L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc:2696:6: note: directive argument in the range [1, 2147483647]
L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc:2779:13: note: 'snprintf' output between 6 and 15 bytes into a destination of size 7
     snprintf(pagenum, sizeof(pagenum), "- %d -", page);  t.DrawText(0.9, 0.02, pagenum);
     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc:2696:6: error: '%d' directive output may be truncated writing between 1 and 10 bytes into a region of size 5 [-Werror=format-truncation=]
 void CSCTriggerPrimitivesReader::drawCompHistos() {
      ^~~~~~~~~~~~~~~~~~~~~~~~~~
L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc:2696:6: note: directive argument in the range [1, 2147483647]
L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc:2831:13: note: 'snprintf' output between 6 and 15 bytes into a destination of size 7
     snprintf(pagenum, sizeof(pagenum), "- %d -", page);  t.DrawText(0.9, 0.02, pagenum);
     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc:2696:6: error: '%d' directive output may be truncated writing between 1 and 10 bytes into a region of size 5 [-Werror=format-truncation=]
 void CSCTriggerPrimitivesReader::drawCompHistos() {
      ^~~~~~~~~~~~~~~~~~~~~~~~~~
L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc:2696:6: note: directive argument in the range [1, 2147483647]
L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc:2882:13: note: 'snprintf' output between 6 and 15 bytes into a destination of size 7
     snprintf(pagenum, sizeof(pagenum), "- %d -", page);  t.DrawText(0.9, 0.02, pagenum);
     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc:2696:6: error: '%d' directive output may be truncated writing between 1 and 10 bytes into a region of size 5 [-Werror=format-truncation=]
 void CSCTriggerPrimitivesReader::drawCompHistos() {
      ^~~~~~~~~~~~~~~~~~~~~~~~~~
L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc:2696:6: note: directive argument in the range [1, 2147483647]
L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc:2934:13: note: 'snprintf' output between 6 and 15 bytes into a destination of size 7
     snprintf(pagenum, sizeof(pagenum), "- %d -", page);  t.DrawText(0.9, 0.02, pagenum);
     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc:2696:6: error: '%d' directive output may be truncated writing between 1 and 10 bytes into a region of size 5 [-Werror=format-truncation=]
 void CSCTriggerPrimitivesReader::drawCompHistos() {
      ^~~~~~~~~~~~~~~~~~~~~~~~~~
L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc:2696:6: note: directive argument in the range [1, 2147483647]
L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc:2985:13: note: 'snprintf' output between 6 and 15 bytes into a destination of size 7
     snprintf(pagenum, sizeof(pagenum), "- %d -", page);  t.DrawText(0.9, 0.02, pagenum);
     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```