### PR TITLE
Pixel Validation - Tracking Particle code fix.

### DIFF
--- a/Validation/SiPixelPhase1TrackingParticleV/interface/SiPixelPhase1TrackingParticleV.h
+++ b/Validation/SiPixelPhase1TrackingParticleV/interface/SiPixelPhase1TrackingParticleV.h
@@ -42,7 +42,6 @@ class SiPixelPhase1TrackingParticleV : public SiPixelPhase1Base {
   private:
   edm::EDGetTokenT<TrackingParticleCollection> vec_TrackingParticle_Token_;
   std::vector<edm::EDGetTokenT<std::vector<PSimHit> > > simHitTokens_;
-  std::vector<std::pair<unsigned int, const PSimHit *>> trackIdToHitPtr_;
 };
 
 #endif

--- a/Validation/SiPixelPhase1TrackingParticleV/interface/SiPixelPhase1TrackingParticleV.h
+++ b/Validation/SiPixelPhase1TrackingParticleV/interface/SiPixelPhase1TrackingParticleV.h
@@ -37,7 +37,7 @@ class SiPixelPhase1TrackingParticleV : public SiPixelPhase1Base {
 
   public:
   explicit SiPixelPhase1TrackingParticleV(const edm::ParameterSet& conf);
-  void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   private:
   edm::EDGetTokenT<TrackingParticleCollection> vec_TrackingParticle_Token_;

--- a/Validation/SiPixelPhase1TrackingParticleV/src/SiPixelPhase1TrackingParticleV.cc
+++ b/Validation/SiPixelPhase1TrackingParticleV/src/SiPixelPhase1TrackingParticleV.cc
@@ -51,19 +51,19 @@ void SiPixelPhase1TrackingParticleV::analyze(const edm::Event& iEvent, const edm
   edm::Handle<TrackingParticleCollection>  TruthTrackContainer;
   iEvent.getByToken( vec_TrackingParticle_Token_, TruthTrackContainer );
   const TrackingParticleCollection *tPC   = TruthTrackContainer.product();
-  std::vector<std::pair<unsigned int, const PSimHit *>> trackIdToHitPtr_;
+  std::vector<std::pair<unsigned int, const PSimHit *>> trackIdToHitPtr;
 
   // A multimap linking SimTrack::trackId() to a pointer to PSimHit
   // Similar to TrackingTruthAccumulator
   for(const auto& simHitToken: simHitTokens_) {
     edm::Handle<std::vector<PSimHit> > hsimhits;
     iEvent.getByToken(simHitToken, hsimhits);
-    trackIdToHitPtr_.reserve(trackIdToHitPtr_.size()+hsimhits->size());
+    trackIdToHitPtr.reserve(trackIdToHitPtr.size()+hsimhits->size());
     for(const auto& simHit: *hsimhits) {
-      trackIdToHitPtr_.emplace_back(simHit.trackId(), &simHit);
+      trackIdToHitPtr.emplace_back(simHit.trackId(), &simHit);
     }
   }
-  std::stable_sort(trackIdToHitPtr_.begin(), trackIdToHitPtr_.end(), trackIdHitPairLessSort);
+  std::stable_sort(trackIdToHitPtr.begin(), trackIdToHitPtr.end(), trackIdHitPairLessSort);
 
 
   // Loop over TrackingParticle's
@@ -76,7 +76,7 @@ void SiPixelPhase1TrackingParticleV::analyze(const edm::Event& iEvent, const edm
 
     for(const SimTrack& simTrack: t->g4Tracks()) {
       // Logic is from TrackingTruthAccumulator
-      auto range = std::equal_range(trackIdToHitPtr_.begin(), trackIdToHitPtr_.end(), std::pair<unsigned int, const PSimHit *>(simTrack.trackId(), nullptr), trackIdHitPairLess);
+      auto range = std::equal_range(trackIdToHitPtr.begin(), trackIdToHitPtr.end(), std::pair<unsigned int, const PSimHit *>(simTrack.trackId(), nullptr), trackIdHitPairLess);
       if(range.first == range.second) continue;
 
       auto iHitPtr = range.first;

--- a/Validation/SiPixelPhase1TrackingParticleV/src/SiPixelPhase1TrackingParticleV.cc
+++ b/Validation/SiPixelPhase1TrackingParticleV/src/SiPixelPhase1TrackingParticleV.cc
@@ -51,6 +51,7 @@ void SiPixelPhase1TrackingParticleV::analyze(const edm::Event& iEvent, const edm
   edm::Handle<TrackingParticleCollection>  TruthTrackContainer;
   iEvent.getByToken( vec_TrackingParticle_Token_, TruthTrackContainer );
   const TrackingParticleCollection *tPC   = TruthTrackContainer.product();
+  std::vector<std::pair<unsigned int, const PSimHit *>> trackIdToHitPtr_;
 
   // A multimap linking SimTrack::trackId() to a pointer to PSimHit
   // Similar to TrackingTruthAccumulator


### PR DESCRIPTION
Resolved a long standing bug where trackIdToHitPtr_ in tracking particle pixel validation code would continue to contain stale pointers from old events without being cleared. Solution, removed as a member data and just have it as a local variable.

Problem cause detailed in issue #21079 