### PR TITLE
[10x] trivial fix in the filling of fit charge MPV vs sensor thickness

### DIFF
--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -1399,8 +1399,8 @@ void SiStripGainFromCalibTree::qualityMonitor() {
             if(FitMPV>0.) Gains->Fill(Gain);
 
             MPVs->Fill(FitMPV);
-            if(Thickness<0.04) MPVs320->Fill(Phi,FitMPV);
-            if(Thickness>0.04) MPVs500->Fill(Phi,FitMPV);
+            if(Thickness<0.04) MPVs320->Fill(FitMPV);
+            if(Thickness>0.04) MPVs500->Fill(FitMPV);
 
             MPVError->Fill(FitMPVErr);
             MPVErrorVsMPV->Fill(FitMPV,FitMPVErr);

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
@@ -271,8 +271,8 @@ SiStripGainsPCLHarvester::gainQualityMonitor(DQMStore::IBooker& ibooker_, const 
        if(FitMPV>0.) Gains->Fill(Gain);
  
        MPVs->Fill(FitMPV);
-       if(Thickness<0.04) MPVs320->Fill(Phi,FitMPV);
-       if(Thickness>0.04) MPVs500->Fill(Phi,FitMPV);
+       if(Thickness<0.04) MPVs320->Fill(FitMPV);
+       if(Thickness>0.04) MPVs500->Fill(FitMPV);
 
        MPVError->Fill(FitMPVErr);
        MPVErrorVsMPV->Fill(FitMPV,FitMPVErr);


### PR DESCRIPTION
Title says it all, the histograms are supposed to be 1D. 
Attention @dimattia 