### PR TITLE
fix typos in HLT validation directories

### DIFF
--- a/DQM/HLTEvF/python/HLTTrackingMonitoring_Client_cff.py
+++ b/DQM/HLTEvF/python/HLTTrackingMonitoring_Client_cff.py
@@ -17,9 +17,9 @@ trackingMonitorClientHLT = cms.Sequence(
 # EGM tracking
 trackingForElectronsEffFromHitPatternHLT = trackingEffFromHitPattern.clone()
 trackingForElectronsEffFromHitPatternHLT.subDirs = cms.untracked.vstring(
-   "HLT/EG/Tracking/GSF/HitEffFromHitPattern*",
-   "HLT/EG/Tracking/pixelTracks/HitEffFromHitPattern*",
-   "HLT/EG/Tracking/iter2Merged/HitEffFromHitPattern*"
+   "HLT/EGM/Tracking/GSF/HitEffFromHitPattern*",
+   "HLT/EGM/Tracking/pixelTracks/HitEffFromHitPattern*",
+   "HLT/EGM/Tracking/iter2Merged/HitEffFromHitPattern*"
 )
 
 # Sequence

--- a/HLTriggerOffline/Egamma/python/HLTmultiTrackValidatorGsfTracks_cff.py
+++ b/HLTriggerOffline/Egamma/python/HLTmultiTrackValidatorGsfTracks_cff.py
@@ -4,11 +4,11 @@ from Validation.RecoTrack.HLTmultiTrackValidator_cfi import *
 hltGsfTrackValidator = hltMultiTrackValidator.clone(
     label = [
         "hltEgammaGsfTracks",
-        "hltEgammaGsfTracksUnseeded",
+#        "hltEgammaGsfTracksUnseeded",
     ],
     label_tp_effic           = "trackingParticlesElectron",
     label_tp_effic_refvector = cms.bool(True), 
-    dirName                  = cms.string('HLT/EG/Tracking/ValidationWRTtp/'),
+    dirName                  = cms.string('HLT/EGM/Tracking/ValidationWRTtp/'),
     ## eta range driven by ECAL acceptance
     histoProducerAlgoBlock = dict(
         TpSelectorForEfficiencyVsEta  = dict(minRapidity=-3, maxRapidity=3),

--- a/HLTriggerOffline/Egamma/python/HLTpostProcessorGsfTracker_cfi.py
+++ b/HLTriggerOffline/Egamma/python/HLTpostProcessorGsfTracker_cfi.py
@@ -3,11 +3,11 @@ import FWCore.ParameterSet.Config as cms
 import Validation.RecoTrack.PostProcessorTracker_cfi as _PostProcessorTracker_cfi
 
 postProcessorHLTgsfTracking = _PostProcessorTracker_cfi.postProcessorTrack.clone(
-    subDirs = ["HLT/EG/Tracking/ValidationWRTtp/*"]
+    subDirs = ["HLT/EGM/Tracking/ValidationWRTtp/*"]
 )
 
 postProcessorHLTgsfTrackingSummary = _PostProcessorTracker_cfi.postProcessorTrackSummary.clone(
-    subDirs = ["HLT/EG/Tracking/ValidationWRTtp"]
+    subDirs = ["HLT/EGM/Tracking/ValidationWRTtp"]
 )
 
 postProcessorHLTgsfTrackingSequence = (

--- a/Validation/HcalRecHits/python/HLTHcalRecHitParam_cfi.py
+++ b/Validation/HcalRecHits/python/HLTHcalRecHitParam_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Validation.HcalRecHits.HcalRecHitParam_cfi import *
 
 hltHCALRecoAnalyzer = hcalRecoAnalyzer.clone()
-hltHCALRecoAnalyzer.TopFolderName             = cms.string('HLT/RecHits/Simulation')
+hltHCALRecoAnalyzer.TopFolderName             = cms.string('HLT/HCAL/RecHits/Simulation')
 hltHCALRecoAnalyzer.outputFile                = cms.untracked.string('')
 hltHCALRecoAnalyzer.HBHERecHitCollectionLabel = cms.untracked.InputTag("hltHbhereco")
 hltHCALRecoAnalyzer.HFRecHitCollectionLabel   = cms.untracked.InputTag("hltHfreco")


### PR DESCRIPTION
by mistake (they were typos)
few DQM directories under HLT were misspelled

this PR fixes the following
HLT/EG/Tracking --> HLT/EGM/Tracking
HLT/RecHits --> HLT/HCAL/RecHits