### PR TITLE
CT-PPS Pixel local track reconstruction patch

### DIFF
--- a/RecoCTPPS/PixelLocal/src/RPixDetClusterizer.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixDetClusterizer.cc
@@ -64,11 +64,11 @@ void RPixDetClusterizer::buildClusters(unsigned int detId, const std::vector<CTP
     if(!is_in){
 //calibrate digi and store the new ones
       electrons = calibrate(detId,adc,row,column,pcalibrations);
+      if(electrons < SeedADCThreshold_*ElectronADCGain_) electrons = SeedADCThreshold_*ElectronADCGain_;
       RPixCalibDigi calibDigi(row,column,adc,electrons);
       unsigned int index = column*maxRow + row;
       calib_rpix_digi_map_.insert(std::pair<unsigned int, RPixCalibDigi> (index, calibDigi));
-      if(calibDigi.electrons() > SeedADCThreshold_*ElectronADCGain_)
-	SeedVector_.push_back(calibDigi);
+      SeedVector_.push_back(calibDigi);
     }
   }
   if(verbosity_) edm::LogInfo("RPixDetClusterizer")<<" RPix set size = "<<calib_rpix_digi_map_.size();

--- a/RecoCTPPS/PixelLocal/src/RPixRoadFinder.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixRoadFinder.cc
@@ -87,7 +87,7 @@ void RPixRoadFinder::findPattern(){
 
 //look for points near wrt each other
 // starting algorithm
-  while( it_gh1 != temp_all_hits.end() && temp_all_hits.size() > minRoadSize_){
+  while( it_gh1 != temp_all_hits.end() && temp_all_hits.size() >= minRoadSize_){
     Road temp_road;
   
     it_gh2 = it_gh1;
@@ -110,7 +110,7 @@ void RPixRoadFinder::findPattern(){
 
     }
 
-    if(temp_road.size() > minRoadSize_ && temp_road.size() < maxRoadSize_ )patternVector_.push_back(temp_road);
+    if(temp_road.size() >= minRoadSize_ && temp_road.size() < maxRoadSize_ )patternVector_.push_back(temp_road);
    
   }
 // end of algorithm


### PR DESCRIPTION
we have just discovered a couple of issues in the reco code of the CTPPS pixels that is affecting our track efficiency. We have also found the reasons and prepared fixes.
It would be important if the fixes could already be put inside 940 and used for the re-reco… We know that the deadline is passed but if we could find a way to put these patches it would really be great in terms of our performances.
 
More in details, the modifications proposed are “minimal” and are shown in this comparison:
https://github.com/cms-sw/cmssw/compare/master...CTPPS:ctpps_pixeLocalTracks_patch1
 
The first bug is in RecoCTPPS/PixelLocal/src/RPixRoadFinder.cc : we observed it when reconstructing the tracks that use only 3 planes out of the 6.
The problem is at line 90 and 113 where the number of points found in the pattern is request to be greater than minRoadSize_ (currently set to 3)
instead of requesting greater or equal.
 
The second problem is something similar to what already discussed for the central pixel code last week between Danek and Andrea.
We have some pixels which show very low ADC values due to the non-uniform irradiation we are facing in CT-PPS.
Once calibrated, these pixels will show a negative charge and would be rejected.
Since the problem appears in the pixels where we have the maximum number of physics hits (and hence are also the most irradiated)
we would lose a large number of good tracks.
For this reason we included a small change in RecoCTPPS/PixelLocal/src/RPixDetClusterizer.cc
in order to save a fix charge in case the calibrated charge is below the threshold set from the python (variable already present in the merged version).
 
Please let us know what you think.