### PR TITLE
Modules will see end transition if they saw a begin transition 

### DIFF
--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -201,11 +201,11 @@ namespace edm {
 
     void doErrorStuff();
 
-    void beginRun(ProcessHistoryID const& phid, RunNumber_t run);
-    void endRun(ProcessHistoryID const& phid, RunNumber_t run, bool cleaningUpAfterException);
+    void beginRun(ProcessHistoryID const& phid, RunNumber_t run, bool& globalBeginSucceeded);
+    void endRun(ProcessHistoryID const& phid, RunNumber_t run, bool globalBeginSucceeded, bool cleaningUpAfterException);
 
-    void beginLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi);
-    void endLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi, bool cleaningUpAfterException);
+    void beginLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi, bool& globalBeginSucceeded);
+    void endLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi, bool globalBeginSucceeded, bool cleaningUpAfterException);
 
     std::pair<ProcessHistoryID,RunNumber_t> readRun();
     std::pair<ProcessHistoryID,RunNumber_t> readAndMergeRun();

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -931,7 +931,8 @@ namespace edm {
       << "This likely indicates a bug in an input module or corrupted input or both\n";
   }
   
-  void EventProcessor::beginRun(ProcessHistoryID const& phid, RunNumber_t run) {
+  void EventProcessor::beginRun(ProcessHistoryID const& phid, RunNumber_t run, bool& globalBeginSucceeded) {
+    globalBeginSucceeded = false;
     RunPrincipal& runPrincipal = principalCache_.runPrincipal(phid, run);
     {
       SendSourceTerminationSignalIfException sentry(actReg_.get());
@@ -972,6 +973,7 @@ namespace edm {
         std::rethrow_exception(* (globalWaitTask->exceptionPtr()) );
       }
     }
+    globalBeginSucceeded = true;
     FDEBUG(1) << "\tbeginRun " << run << "\n";
     if(looper_) {
       looper_->doBeginRun(runPrincipal, es, &processContext_);
@@ -1002,7 +1004,7 @@ namespace edm {
     }
   }
 
-  void EventProcessor::endRun(ProcessHistoryID const& phid, RunNumber_t run, bool cleaningUpAfterException) {
+  void EventProcessor::endRun(ProcessHistoryID const& phid, RunNumber_t run, bool globalBeginSucceeded, bool cleaningUpAfterException) {
     RunPrincipal& runPrincipal = principalCache_.runPrincipal(phid, run);
     runPrincipal.setAtEndTransition(true);
     //We need to reset failed items since they might
@@ -1026,7 +1028,7 @@ namespace edm {
       sentry.completedSuccessfully();
     }
     EventSetup const& es = esp_->eventSetup();
-    {
+    if(globalBeginSucceeded){
       //To wait, the ref count has to be 1+#streams
       auto streamLoopWaitTask = make_empty_waiting_task();
       streamLoopWaitTask->increment_ref_count();
@@ -1074,7 +1076,8 @@ namespace edm {
     }
   }
 
-  void EventProcessor::beginLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi) {
+  void EventProcessor::beginLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi, bool& globalBeginSucceeded) {
+    globalBeginSucceeded = false;
     LuminosityBlockPrincipal& lumiPrincipal = principalCache_.lumiPrincipal(phid, run, lumi);
     {
       SendSourceTerminationSignalIfException sentry(actReg_.get());
@@ -1113,6 +1116,7 @@ namespace edm {
         std::rethrow_exception(* (globalWaitTask->exceptionPtr()) );
       }
     }
+    globalBeginSucceeded=true;
     FDEBUG(1) << "\tbeginLumi " << run << "/" << lumi << "\n";
     if(looper_) {
       looper_->doBeginLuminosityBlock(lumiPrincipal, es, &processContext_);
@@ -1143,7 +1147,7 @@ namespace edm {
     }
   }
 
-  void EventProcessor::endLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi, bool cleaningUpAfterException) {
+  void EventProcessor::endLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi, bool globalBeginSucceeded, bool cleaningUpAfterException) {
     LuminosityBlockPrincipal& lumiPrincipal = principalCache_.lumiPrincipal(phid, run, lumi);
     lumiPrincipal.setAtEndTransition(true);
     //We need to reset failed items since they might
@@ -1168,7 +1172,7 @@ namespace edm {
       sentry.completedSuccessfully();
     }
     EventSetup const& es = esp_->eventSetup();
-    {
+    if(globalBeginSucceeded){
       //To wait, the ref count has to b 1+#streams
       auto streamLoopWaitTask = make_empty_waiting_task();
       streamLoopWaitTask->increment_ref_count();

--- a/FWCore/Framework/src/TransitionProcessors.icc
+++ b/FWCore/Framework/src/TransitionProcessors.icc
@@ -42,11 +42,10 @@ struct RunResources {
   
   ~RunResources() noexcept {
     try {
+      //If we skip empty runs, this would be called conditionally
+      ep_.endRun(processHistoryID(), run(), globalTransitionSucceeded_, cleaningUpAfterException_);
+      
       if(success_) {
-        //If we skip empty runs, this would be called conditionally
-        ep_.endRun(processHistoryID(), run(), cleaningUpAfterException_);
-      
-      
         ep_.writeRun(processHistoryID(), run());
       }
       ep_.deleteRunFromCache(processHistoryID(), run());
@@ -81,6 +80,7 @@ struct RunResources {
   edm::RunNumber_t run_;
   bool cleaningUpAfterException_ = true;
   bool success_ = false;
+  bool globalTransitionSucceeded_ = false;
 };
 
 struct LumiResources {
@@ -90,12 +90,10 @@ struct LumiResources {
   
   ~LumiResources() noexcept {
     try {
+      //If we skip empty lumis, this would be called conditionally
+      run_->ep_.endLumi(processHistoryID(), run(), lumi(), globalTransitionSucceeded_, cleaningUpAfterException_);
+      
       if (success_) {
-      
-        //If we skip empty lumis, this would be called conditionally
-        run_->ep_.endLumi(processHistoryID(), run(), lumi(), cleaningUpAfterException_);
-      
-      
         run_->ep_.writeLumi(processHistoryID(), run(), lumi());
       }
 
@@ -132,6 +130,7 @@ struct LumiResources {
   edm::LuminosityBlockNumber_t lumi_;
   bool cleaningUpAfterException_ = true;
   bool success_ = false;
+  bool globalTransitionSucceeded_ = false;
 };
 
 struct EventResources {
@@ -208,8 +207,8 @@ private:
       currentLumi_ = std::make_shared<LumiResources>(iRun,lumiID);
       auto id = iEP.readLuminosityBlock();
       assert((id >= 0) and (static_cast<unsigned int>(id) == lumiID));
-      iEP.beginLumi(currentLumi_->processHistoryID(), currentLumi_->run(), currentLumi_->lumi());
-      //only if we succeed at beginLumi should we run endLumi
+      iEP.beginLumi(currentLumi_->processHistoryID(), currentLumi_->run(), currentLumi_->lumi(), currentLumi_->globalTransitionSucceeded_);
+      //only if we succeed at beginLumi should we run writeLumi
       currentLumi_->succeeded();
     } else {
       //merge
@@ -269,8 +268,8 @@ private:
       }
       currentRun_ = std::make_shared<RunResources>(iEP,runID.first,runID.second);
       iEP.readRun();
-      iEP.beginRun(runID.first,runID.second);
-      //only if we succeed at beginRun should we run endRun
+      iEP.beginRun(runID.first,runID.second, currentRun_->globalTransitionSucceeded_);
+      //only if we succeed at beginRun should we run writeRun
       currentRun_->succeeded();
     } else {
       //merge

--- a/FWCore/Framework/test/MockEventProcessor.cc
+++ b/FWCore/Framework/test/MockEventProcessor.cc
@@ -205,22 +205,26 @@ namespace edm {
     output_ << "\tdoErrorStuff\n";
   }
 
-  void MockEventProcessor::beginRun(ProcessHistoryID const& phid, RunNumber_t run) {
+  void MockEventProcessor::beginRun(ProcessHistoryID const& phid, RunNumber_t run, bool& globalTransitionSucceeded) {
     output_ << "\tbeginRun " << run << "\n";
     throwIfNeeded();
+    globalTransitionSucceeded = true;
   }
 
-  void MockEventProcessor::endRun(ProcessHistoryID const& phid, RunNumber_t run, bool /*cleaningUpAfterException*/ ) {
-    output_ << "\tendRun " << run << "\n";
+  void MockEventProcessor::endRun(ProcessHistoryID const& phid, RunNumber_t run, bool globalTransitionSucceeded, bool /*cleaningUpAfterException*/ ) {
+    auto postfix = globalTransitionSucceeded? "\n" : " global failed\n";
+    output_ << "\tendRun " << run << postfix;
   }
 
-  void MockEventProcessor::beginLumi(ProcessHistoryID const&, RunNumber_t run, LuminosityBlockNumber_t lumi) {
+  void MockEventProcessor::beginLumi(ProcessHistoryID const&, RunNumber_t run, LuminosityBlockNumber_t lumi, bool& globalTransitionSucceeded) {
     output_ << "\tbeginLumi " << run << "/" << lumi << "\n";
     throwIfNeeded();
+    globalTransitionSucceeded = true;
   }
 
-  void MockEventProcessor::endLumi(ProcessHistoryID const&, RunNumber_t run, LuminosityBlockNumber_t lumi, bool /*cleaningUpAfterException*/) {
-    output_ << "\tendLumi " << run << "/" << lumi << "\n";
+  void MockEventProcessor::endLumi(ProcessHistoryID const&, RunNumber_t run, LuminosityBlockNumber_t lumi, bool globalTransitionSucceeded , bool /*cleaningUpAfterException*/) {
+    auto postfix = globalTransitionSucceeded? "\n" : " global failed\n";
+    output_ << "\tendLumi " << run << "/" << lumi << postfix;
   }
 
   std::pair<ProcessHistoryID,RunNumber_t> MockEventProcessor::readRun() {

--- a/FWCore/Framework/test/MockEventProcessor.h
+++ b/FWCore/Framework/test/MockEventProcessor.h
@@ -51,11 +51,11 @@ namespace edm {
 
     void doErrorStuff();
 
-    void beginRun(ProcessHistoryID const& phid, RunNumber_t run);
-    void endRun(ProcessHistoryID const& phid, RunNumber_t run, bool cleaningUpAfterException);
+    void beginRun(ProcessHistoryID const& phid, RunNumber_t run, bool& globalTransitionSucceeded);
+    void endRun(ProcessHistoryID const& phid, RunNumber_t run, bool globalTranstitionSucceeded, bool cleaningUpAfterException);
 
-    void beginLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi);
-    void endLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi, bool cleaningUpAfterException);
+    void beginLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi, bool& globalTransitionSucceeded);
+    void endLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi, bool globalTransitionSucceeded, bool cleaningUpAfterException);
 
     std::pair<ProcessHistoryID,RunNumber_t> readRun();
     std::pair<ProcessHistoryID,RunNumber_t> readAndMergeRun();

--- a/FWCore/Framework/test/test_earlyTerminationSignal.sh
+++ b/FWCore/Framework/test/test_earlyTerminationSignal.sh
@@ -12,3 +12,6 @@ echo "runnig cmsRun test_dependentPathsAndExceptions_cfg.py"
 
 echo "runnig cmsRun test_dependentRunDataAndException_cfg.py"
 (cmsRun ${LOCAL_TEST_DIR}/test_dependentRunDataAndException_cfg.py 2>&1 | grep -q "Intentional 'NotFound' exception for testing purposes") || die "dependent Run data and Exceptions failed" $?
+
+echo "runnig cmsRun test_exceptionAtGlobalBeginRun_cfg.py"
+(cmsRun ${LOCAL_TEST_DIR}/test_exceptionAtGlobalBeginRun_cfg.py 2>&1 | grep -q -v "An exception of category 'transitions' occurred") || die "exception at globalBeginRun failed" $?

--- a/FWCore/Framework/test/test_exceptionAtGlobalBeginRun_cfg.py
+++ b/FWCore/Framework/test/test_exceptionAtGlobalBeginRun_cfg.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("Test")
+
+process.source = cms.Source("EmptySource")
+
+process.fail = cms.EDProducer("edmtest::FailingInRunProducer")
+
+process.tstStream = cms.EDAnalyzer("edmtest::global::StreamIntAnalyzer", transitions=cms.int32(2))
+process.tstGlobal = cms.EDAnalyzer("edmtest::global::RunIntAnalyzer",
+                                   transitions=cms.int32(2),
+                                   cachevalue = cms.int32(0))
+
+process.p = cms.Path(process.fail+process.tstStream+process.tstGlobal)
+
+process.add_(cms.Service("Tracer"))
+
+process2 = cms.Process("Test2")
+process2.tstStreamSub = cms.EDAnalyzer("edmtest::global::StreamIntAnalyzer", transitions=cms.int32(2))
+process2.tstGlobalSub = cms.EDAnalyzer("edmtest::global::RunIntAnalyzer",
+                                   transitions=cms.int32(2),
+                                   cachevalue = cms.int32(0))
+process2.p2 = cms.Path(process2.tstStreamSub+process2.tstGlobalSub)
+process.addSubProcess(cms.SubProcess(process2))

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_21.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_21.txt
@@ -37,6 +37,7 @@ Machine parameters:  mode = NOMERGE
 	readLuminosityBlock 1
 	beginLumi 2/1
 	throwing
+	endLumi 2/1 global failed
 	deleteLumiFromCache 2/1
 	endRun 2
 	writeRun 2
@@ -83,6 +84,7 @@ Machine parameters:  mode = FULLMERGE
 	readLuminosityBlock 1
 	beginLumi 2/1
 	throwing
+	endLumi 2/1 global failed
 	deleteLumiFromCache 2/1
 	endRun 2
 	writeRun 2

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_22.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_22.txt
@@ -34,6 +34,7 @@ Machine parameters:  mode = NOMERGE
 	readRun 2
 	beginRun 2
 	throwing
+	endRun 2 global failed
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
@@ -74,6 +75,7 @@ Machine parameters:  mode = FULLMERGE
 	readRun 2
 	beginRun 2
 	throwing
+	endRun 2 global failed
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile


### PR DESCRIPTION
In the case where an exception occurs during a begin Run/LuminosityBlock transition we make sure that modules which saw that transition will also see the related end transition. This is accomplished by requiring all modules to see a transition once that transition has started. In this way we do not have to record which modules have seen which transitions (since it will be all or none).
If the exception happened during the global part of the transition, we do not then run the stream part of the transition in order to attempt to minimize the time to end the application.