### PR TITLE
Fixed Geant4 exception handling

### DIFF
--- a/SimG4Core/Application/interface/ExceptionHandler.h
+++ b/SimG4Core/Application/interface/ExceptionHandler.h
@@ -1,30 +1,36 @@
-#ifndef SimG4Core_ExceptionHandler_H
-#define SimG4Core_ExceptionHandler_H 
+// ------------------------------------------------------------
+//
+// Author: V.Ivanchenko - 01.11.2018 - old code re-written
+//
+// ------------------------------------------------------------
+//
+// Class description:
+//
+// Catch Geant4 exception and throw CMS exception allowing 
+// correctly abort problematic run or notify about a problem
+// ------------------------------------------------------------
+
+#ifndef SimG4Core_Application_ExceptionHandler_H
+#define SimG4Core_Application_ExceptionHandler_H 
 
 #include "G4VExceptionHandler.hh"
 #include "G4ExceptionSeverity.hh"
 
-class RunManager;
-class RunManagerMT;
- 
 class ExceptionHandler : public G4VExceptionHandler
 {
 public:
-    ExceptionHandler(RunManager * rm);
-    ExceptionHandler(RunManagerMT * rm);
-    ExceptionHandler() {} ;
-    ~ExceptionHandler() override;
-    int operator==(const ExceptionHandler & right) const { return (this == &right); }
-    int operator!=(const ExceptionHandler & right) const { return (this != &right); }
-    bool Notify(const char * exceptionOrigin, const char * exceptionCode,
-			G4ExceptionSeverity severity, const char * description) override;
+  explicit ExceptionHandler();
+  ~ExceptionHandler() override;
+
+  int operator==(const ExceptionHandler & right) const { return (this == &right); }
+  int operator!=(const ExceptionHandler & right) const { return (this != &right); }
+
+  bool Notify(const char * exceptionOrigin, const char * exceptionCode,
+              G4ExceptionSeverity severity, const char * description) override;
+
 private:
-    ExceptionHandler(const ExceptionHandler &) : G4VExceptionHandler() {}
-    ExceptionHandler& operator=(const ExceptionHandler &right) { return *this; }
-    RunManager * fRunManager;
-    RunManagerMT * fRunManagerMT;
-    //bool override;
-    //int verbose;
+  ExceptionHandler(const ExceptionHandler &) = delete;
+  ExceptionHandler& operator=(const ExceptionHandler &right) = delete;
 };
 
 #endif

--- a/SimG4Core/Application/interface/RunManager.h
+++ b/SimG4Core/Application/interface/RunManager.h
@@ -25,10 +25,6 @@ namespace edm {
   class HepMCProduct;
 }
 
-namespace CLHEP {
-  class HepJamesRandom;
-}
-
 namespace sim {
   class ChordFinderSetter;
 }

--- a/SimG4Core/Application/interface/RunManagerMT.h
+++ b/SimG4Core/Application/interface/RunManagerMT.h
@@ -13,10 +13,6 @@
 
 #include <memory>
 
-namespace CLHEP {
-  class HepJamesRandom;
-}
-
 namespace sim {
   class ChordFinderSetter;
 }

--- a/SimG4Core/Application/plugins/OscarProducer.cc
+++ b/SimG4Core/Application/plugins/OscarProducer.cc
@@ -161,56 +161,8 @@ void OscarProducer::produce(edm::Event & e, const edm::EventSetup & es)
   std::vector<SensitiveCaloDetector*>& sCalo =
     m_runManager->sensCaloDetectors();
 
-  try {
-
-    m_runManager->produce(e, es);
-
-    std::unique_ptr<edm::SimTrackContainer>
-      p1(new edm::SimTrackContainer);
-    std::unique_ptr<edm::SimVertexContainer>
-      p2(new edm::SimVertexContainer);
-    G4SimEvent * evt = m_runManager->simEvent();
-    evt->load(*p1);
-    evt->load(*p2);   
-
-    e.put(std::move(p1));
-    e.put(std::move(p2));
-
-    for (std::vector<SensitiveTkDetector*>::iterator it = sTk.begin(); 
-	 it != sTk.end(); ++it) {
-
-      std::vector<std::string> v = (*it)->getNames();
-      for (std::vector<std::string>::iterator in = v.begin(); 
-	   in!= v.end(); ++in) {
-
-	std::unique_ptr<edm::PSimHitContainer>
-	  product(new edm::PSimHitContainer);
-	(*it)->fillHits(*product,*in);
-	e.put(std::move(product),*in);
-      }
-    }
-    for (std::vector<SensitiveCaloDetector*>::iterator it = sCalo.begin(); 
-	 it != sCalo.end(); ++it) {
-
-      std::vector<std::string>  v = (*it)->getNames();
-
-      for (std::vector<std::string>::iterator in = v.begin(); 
-	   in!= v.end(); in++) {
-
-	std::unique_ptr<edm::PCaloHitContainer>
-	  product(new edm::PCaloHitContainer);
-	(*it)->fillHits(*product,*in);
-	e.put(std::move(product),*in);
-      }
-    }
-
-    for(Producers::iterator itProd = m_producers.begin();
-	itProd != m_producers.end(); ++itProd) {
-
-      (*itProd)->produce(e,es);
-    }
-
-  } catch ( const SimG4Exception& simg4ex ) {
+  try { m_runManager->produce(e, es); }
+  catch ( const SimG4Exception& simg4ex ) {
        
     edm::LogInfo("SimG4CoreApplication") << "SimG4Exception caght! " 
 					 << simg4ex.what();
@@ -220,6 +172,45 @@ void OscarProducer::produce(edm::Event & e, const edm::EventSetup & es)
       << "SimG4CoreApplication exception in generation of event "
       << e.id() << " in stream " << e.streamID() << " \n"
       << simg4ex.what();
+  }
+
+  std::unique_ptr<edm::SimTrackContainer>
+    p1(new edm::SimTrackContainer);
+  std::unique_ptr<edm::SimVertexContainer>
+    p2(new edm::SimVertexContainer);
+  G4SimEvent * evt = m_runManager->simEvent();
+  evt->load(*p1);
+  evt->load(*p2);   
+
+  e.put(std::move(p1));
+  e.put(std::move(p2));
+  
+  for (auto & tracker : sTk) {
+
+    std::vector<std::string> v = tracker->getNames();
+    for (auto & name : v) {
+
+      std::unique_ptr<edm::PSimHitContainer>
+	product(new edm::PSimHitContainer);
+      tracker->fillHits(*product,name);
+      e.put(std::move(product),name);
+    }
+  }
+  for (auto & calo : sCalo) {
+
+    std::vector<std::string> v = calo->getNames();
+
+    for (auto & name : v) {
+
+      std::unique_ptr<edm::PCaloHitContainer>
+	product(new edm::PCaloHitContainer);
+      calo->fillHits(*product,name);
+      e.put(std::move(product),name);
+    }
+  }
+
+  for(auto & prod :  m_producers) {
+    prod.get()->produce(e,es);
   }
 }
 

--- a/SimG4Core/Application/src/ExceptionHandler.cc
+++ b/SimG4Core/Application/src/ExceptionHandler.cc
@@ -1,109 +1,52 @@
 #include "SimG4Core/Application/interface/ExceptionHandler.h"
-#include "SimG4Core/Application/interface/RunManager.h"
-#include "SimG4Core/Application/interface/RunManagerMT.h"
-
 #include "SimG4Core/Notification/interface/SimG4Exception.h"
 
-#include "G4EventManager.hh"
-#include "G4StateManager.hh"
-#include "G4ios.hh"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-using std::cout;
-using std::endl;
-using std::string;
+#include <sstream>
 
-ExceptionHandler::ExceptionHandler(RunManager* rm) 
-  : fRunManager(rm),fRunManagerMT(nullptr)
+ExceptionHandler::ExceptionHandler() 
 {}
 
-ExceptionHandler::ExceptionHandler(RunManagerMT* rm) 
-  : fRunManager(nullptr),fRunManagerMT(rm)
+ExceptionHandler::~ExceptionHandler() 
 {}
-
-ExceptionHandler::~ExceptionHandler() {}
 
 bool ExceptionHandler::Notify(const char* exceptionOrigin,
 			      const char* exceptionCode,
 			      G4ExceptionSeverity severity,
 			      const char* description)
 {
-    cout << endl;
-    cout << "*** G4Exception : " << exceptionCode << " issued by " << exceptionOrigin << endl;
-    cout << "    " << description << endl;
-    bool abortionForCoreDump = false;
-    G4ApplicationState aps = G4StateManager::GetStateManager()->GetCurrentState();
-    switch(severity)
-    {
-    case FatalException:
-        if ( aps==G4State_EventProc && exceptionOrigin==string("G4HadronicProcess") )
-        {
-        cout << "*** Fatal exception *** " << endl;
-        throw SimG4Exception( "SimG4CoreApplication: Bug in G4HadronicProcess" ) ;
-        }
-        else
-        {
-        cout << "*** Fatal exception *** core dump ***" << endl;
-        abortionForCoreDump = true;
-        }
-/*
-	cout << "*** Fatal exception *** core dump ***" << endl;
-	abortionForCoreDump = true;
-*/
-	break;
-    case FatalErrorInArgument:
-	cout << "*** Fatal error in argument *** core dump ***" << endl;
-	abortionForCoreDump = true;
-	break;
-    case RunMustBeAborted:
-	if(aps==G4State_GeomClosed || aps==G4State_EventProc)
-	{
-	    cout << "*** Run must be aborted " << endl;
-	    if(fRunManager) { fRunManager->abortRun(false); }
-	    if(fRunManagerMT) { fRunManagerMT->abortRun(false); }
-	}
-	abortionForCoreDump = false;
-	break;
-    case EventMustBeAborted:
-	if(aps==G4State_EventProc)
-	{
-	    cout << "*** Event must be aborted " << endl;
-	    // if (override && exceptionCode == string("StuckTrack"))
-/*
-	    if (exceptionCode == string("StuckTrack"))
-	    {
-		//if (verbose > 1) cout << "*** overriden by user " << endl;
-		G4Track * t = G4EventManager::GetEventManager()->GetTrackingManager()->GetTrack();
-		//if (verbose > 1) 
-		    cout << " ERROR - G4Navigator::ComputeStep() " << endl 
-			 << " Track " << t->GetTrackID() << " stuck " 
-			 << " in volume " << t->GetVolume()->GetName()
-			 << " at point " << t->GetPosition()/mm << " mm "<< endl
-			 << " with direction: " << t->GetMomentumDirection()
-			 << " and distance to out " 
-			 << (t->GetVolume()->GetLogicalVolume()->GetSolid())
-			->DistanceToOut(t->GetPosition())/mm << " mm " << endl;
-		//if (verbose > 1) 
-		    cout << " Particle " << t->GetDynamicParticle()->GetDefinition()->GetParticleName()
-			 << " from parent ID " << t->GetParentID() << endl
-			 << " with " << t->GetKineticEnergy()/MeV << " MeV kinetic energy " 
-			 << " created in " << t->GetLogicalVolumeAtVertex()->GetName() << endl;
-		cout << " *** StuckTrack: track status set to fStopButAlive " << endl;
-		t->SetTrackStatus(fStopButAlive);
-	    }
-	    else
-*/
-		//fRunManager->abortEvent();
-		//RunManager::instance()->abortEvent() ;
-		throw SimG4Exception( "SimG4CoreApplication: G4Navigator:StuckTrack detected" ) ;
-	}
-	abortionForCoreDump = false;
-	break;
-    default:
-	cout << "*** This is just a warning message " << endl;
-	abortionForCoreDump = false;
-	break;
-    }
-    cout << endl;
-    return abortionForCoreDump;
+  static const G4String es_banner
+    = "\n-------- EEEE ------- G4Exception-START -------- EEEE -------\n";
+  static const G4String ee_banner
+    = "\n-------- EEEE -------- G4Exception-END --------- EEEE -------\n";
+  static const G4String ws_banner
+    = "\n-------- WWWW ------- G4Exception-START -------- WWWW -------\n";
+  static const G4String we_banner
+    = "\n-------- WWWW -------- G4Exception-END --------- WWWW -------\n";
+
+  std::stringstream message;
+  message << "*** G4Exception : " << exceptionCode << "\n"
+          << "      issued by : " << exceptionOrigin << "\n"
+          << description;
+
+  std::stringstream ss;
+  switch(severity) {
+
+  case FatalException:
+  case FatalErrorInArgument:
+  case RunMustBeAborted:
+  case EventMustBeAborted:
+    ss << es_banner << message.str() << ee_banner;
+    throw SimG4Exception(ss.str());
+    break;
+
+  case JustWarning:
+    edm::LogWarning("SimG4CoreApplication") 
+      << ws_banner << message.str() << "*** This is just a warning message. ***"
+      << we_banner;
+    break;
+  }
+  return false;
 }
 

--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -11,6 +11,8 @@
 #include "SimG4Core/Application/interface/ParametrisedEMPhysics.h"
 #include "SimG4Core/Application/interface/G4RegionReporter.h"
 #include "SimG4Core/Application/interface/CMSGDMLWriteStructure.h"
+#include "SimG4Core/Application/interface/ExceptionHandler.h"
+
 #include "SimG4Core/Geometry/interface/DDDWorld.h"
 #include "SimG4Core/Geometry/interface/G4LogicalVolumeToDDLogicalPartMap.h"
 #include "SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h"
@@ -141,6 +143,7 @@ RunManager::RunManager(edm::ParameterSet const & p, edm::ConsumesCollector&& iC)
 {    
   m_UIsession.reset(new CustomUIsession());
   m_kernel = new G4RunManagerKernel();
+  G4StateManager::GetStateManager()->SetExceptionHandler(new ExceptionHandler());
 
   m_check = p.getUntrackedParameter<bool>("CheckOverlap",false);
   m_WriteFile = p.getUntrackedParameter<std::string>("FileNameGDML","");

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -6,6 +6,7 @@
 #include "SimG4Core/Application/interface/G4SimEvent.h"
 #include "SimG4Core/Application/interface/ParametrisedEMPhysics.h"
 #include "SimG4Core/Application/interface/CustomUIsession.h"
+#include "SimG4Core/Application/interface/ExceptionHandler.h"
 
 #include "SimG4Core/Geometry/interface/DDDWorld.h"
 #include "SimG4Core/Geometry/interface/G4LogicalVolumeToDDLogicalPartMap.h"
@@ -78,6 +79,7 @@ RunManagerMT::RunManagerMT(edm::ParameterSet const & p):
   m_physicsList.reset(nullptr);
   m_world.reset(nullptr);
   m_kernel = new G4MTRunManagerKernel();
+  G4StateManager::GetStateManager()->SetExceptionHandler(new ExceptionHandler());
 
   m_check = p.getUntrackedParameter<bool>("CheckOverlap",false);
   m_WriteFile = p.getUntrackedParameter<std::string>("FileNameGDML","");

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -10,6 +10,7 @@
 #include "SimG4Core/Application/interface/CustomUIsession.h"
 #include "SimG4Core/Application/interface/CustomUIsessionThreadPrefix.h"
 #include "SimG4Core/Application/interface/CustomUIsessionToFile.h"
+#include "SimG4Core/Application/interface/ExceptionHandler.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -214,6 +215,9 @@ void RunManagerMTWorker::initializeThread(RunManagerMT& runManagerMaster, const 
   // Create worker run manager
   m_tls->kernel = G4WorkerRunManagerKernel::GetRunManagerKernel();
   if(!m_tls->kernel) { m_tls->kernel = new G4WorkerRunManagerKernel(); }
+
+  // Define G4 exception handler
+  G4StateManager::GetStateManager()->SetExceptionHandler(new ExceptionHandler());
 
   // Set the geometry for the worker, share from master
   DDDWorld::WorkerSetAsWorld(runManagerMaster.world().GetWorldVolumeForWorker());


### PR DESCRIPTION
Enable CMS exception handler (derived from G4VException) for handling of exceptions from Geant4. Forward any Geant4 exception to the CMS framework as fatal exception or as a warning.

Clean-up produce method of OscarProducer and OscarMTProducer.

Should not affect results of any WF.