### PR TITLE
Cosmics false alarm fix+2D super crystal binning fix (for CMSSW master)

### DIFF
--- a/DQM/EcalCommon/interface/MESetNonObject.h
+++ b/DQM/EcalCommon/interface/MESetNonObject.h
@@ -29,6 +29,8 @@ namespace ecaldqm
 
     double getBinContent(int, int = 0) const override;
 
+    double getFloatValue() const;
+
     double getBinError(int, int = 0) const override;
 
     double getBinEntries(int, int = 0) const override;

--- a/DQM/EcalCommon/src/MESetBinningUtils2.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils2.cc
@@ -726,11 +726,13 @@ namespace ecaldqm
         case kEB:
           xbin = 4 * ((iDCC - 9) % 18) + (isEBm ? towerid - 1 : 68 - towerid) % 4 + 1;
           ybin = (towerid - 1) / 4 * (isEBm ? -1 : 1) + (isEBm ? 18 : 17);
+          nbinsX = 72;
           break;
         case kSM:
         case kEBSM:
           xbin = (towerid - 1) / 4 + 1;
           ybin = (isEBm ? towerid - 1 : 68 - towerid) % 4 + 1;
+          nbinsX = 17;
           break;
         default:
           break;

--- a/DQM/EcalCommon/src/MESetNonObject.cc
+++ b/DQM/EcalCommon/src/MESetNonObject.cc
@@ -265,6 +265,13 @@ namespace ecaldqm
   }
 
   double
+  MESetNonObject::getFloatValue() const
+  {
+    if(kind_ == MonitorElement::DQM_KIND_REAL) return mes_[0]->getFloatValue();
+    else return 0.;
+  }
+
+  double
   MESetNonObject::getBinError(int _bin, int) const
   {
     if(!active_) return 0.;

--- a/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
@@ -17,6 +17,7 @@ ecalTrigPrimClient = cms.untracked.PSet(
         TTFlags4 = ecalTrigPrimTask.MEs.TTFlags4,
         TTMaskMapAll = ecalTrigPrimTask.MEs.TTMaskMapAll,
         TTFMismatch = ecalTrigPrimTask.MEs.TTFMismatch,
+        LHCStatusByLumi = ecalTrigPrimTask.MEs.LHCStatusByLumi,
         TPDigiThrAll = ecalOccupancyTask.MEs.TPDigiThrAll
     ),
     MEs = cms.untracked.PSet(

--- a/DQM/EcalMonitorTasks/BuildFile.xml
+++ b/DQM/EcalMonitorTasks/BuildFile.xml
@@ -7,6 +7,7 @@
 <use   name="DataFormats/EcalRecHit"/>
 <use   name="DataFormats/EgammaReco"/>
 <use   name="DataFormats/Math"/>
+<use   name="DataFormats/TCDS"/>
 <use   name="DataFormats/L1GlobalTrigger"/>
 <use   name="DataFormats/L1GlobalMuonTrigger"/>
 <use   name="FWCore/Framework"/>

--- a/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
+++ b/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
@@ -4,8 +4,12 @@
 #include "DQWorkerTask.h"
 
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
+#include "DataFormats/TCDS/interface/TCDSRecord.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "CondFormats/EcalObjects/interface/EcalTPGTowerStatus.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGStripStatus.h"
@@ -28,6 +32,8 @@ namespace ecaldqm {
     void runOnRealTPs(EcalTrigPrimDigiCollection const&);
     void runOnEmulTPs(EcalTrigPrimDigiCollection const&);
     template<typename DigiCollection> void runOnDigis(DigiCollection const&);
+
+    void setTokens(edm::ConsumesCollector&) override;
 
     enum Constants {
       nBXBins = 15
@@ -52,6 +58,10 @@ namespace ecaldqm {
 
     edm::ESHandle<EcalTPGTowerStatus> TTStatusRcd;
     edm::ESHandle<EcalTPGStripStatus> StripStatusRcd;
+
+    edm::InputTag lhcStatusInfoCollectionTag_;
+    edm::EDGetTokenT<TCDSRecord> lhcStatusInfoRecordToken_;
+    bool lhcStatusSet_;
 
   };
 

--- a/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
@@ -23,7 +23,8 @@ ecalTrigPrimTask = cms.untracked.PSet(
     params = cms.untracked.PSet(
         #    HLTMuonPath = cms.untracked.string('HLT_Mu5_v*'),
         #    HLTCaloPath = cms.untracked.string('HLT_SingleJet*'),
-        runOnEmul = cms.untracked.bool(True)
+        runOnEmul = cms.untracked.bool(True),
+        lhcStatusInfoCollectionTag = cms.untracked.InputTag("tcdsDigis","tcdsRecord")
     ),
     MEs = cms.untracked.PSet(
         LowIntMap = cms.untracked.PSet(
@@ -268,6 +269,13 @@ ecalTrigPrimTask = cms.untracked.PSet(
             btype = cms.untracked.string('User'),
             path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/%(prefix)sTTT Real vs Emulated TP Et%(suffix)s'),
             description = cms.untracked.string('Real data VS emulated TP Et (in-time)')
+        ),
+        LHCStatusByLumi = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/LHC status by lumi'),
+            kind = cms.untracked.string('REAL'),
+            otype = cms.untracked.string('None'),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('LHC Status in this lumisection. The convention for the value is the same as in the plot Info/LhcInfo/beamMode')
         )
     )
 )

--- a/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
@@ -1,5 +1,6 @@
 ### AUTO-GENERATED CMSRUN CONFIGURATION FOR ECAL DQM ###
 import FWCore.ParameterSet.Config as cms
+from EventFilter.Utilities.tcdsRawToDigi_cfi import * # To monitor LHC status, e.g. to mask trigger primitives quality alarm during Cosmics
 
 process = cms.Process("process")
 
@@ -92,6 +93,9 @@ process.GlobalTag.toGet = cms.VPSet(cms.PSet(
 
 process.preScaler.prescaleFactor = 1
 
+process.tcdsDigis = tcdsRawToDigi.clone()
+process.tcdsDigis.InputLabel = cms.InputTag("rawDataCollector")
+
 process.DQMStore.referenceFileName = "/dqmdata/dqm/reference/ecal_reference.root"
 
 process.dqmEnv.subSystemFolder = cms.untracked.string('Ecal')
@@ -122,7 +126,7 @@ process.hybridClusteringSequence = cms.Sequence(process.cleanedHybridSuperCluste
 
 ### Paths ###
 
-process.ecalMonitorPath = cms.Path(process.preScaler+process.ecalPreRecoSequence+process.ecalPhysicsFilter+process.ecalRecoSequence+process.ecalMonitorTask)
+process.ecalMonitorPath = cms.Path(process.preScaler+process.ecalPreRecoSequence+process.ecalPhysicsFilter+process.ecalRecoSequence+process.tcdsDigis+process.ecalMonitorTask)
 process.ecalClientPath = cms.Path(process.preScaler+process.ecalPreRecoSequence+process.ecalPhysicsFilter+process.ecalMonitorClient)
 
 process.dqmEndPath = cms.EndPath(process.dqmEnv)


### PR DESCRIPTION
(1) Fix for bug that led to incorrect bin numbers for all plots that were filled by supercrystal from Electronics ID.

(2) Restricted the masking of warmer-than-usual supermodules in the trigger primitives quality plot to collisions runs only. To do this,
--> The beam mode information is obtained from TCDS Digis copying the method used by central DQM for plots in Info/LHCInfo.
--> A DQM_KIND_REAL is filled in the trigger primitives task to store the LHC status mode by lumisection
--> This value is read by the trigger primitives client, and the check on average occupancy in a supermodule is performed only if this value is 11 (i.e. collisions)

This was done because over the last several months, we have increasingly seen "warm" towers during cosmics that trigger an alarm on anomalously high occupancies in a supermodule. The thresholds for setting off this alarm were tuned for collisions runs; such false alarms during cosmics runs lead to unnecessary confusion for the DQM shifter.

Please note that at this moment, there is another pending PR to master that does not interfere with this one: https://github.com/cms-sw/cmssw/pull/20902 , which I'm working on fixing.

Link to CMSSW_9_2_X backport: https://github.com/cms-sw/cmssw/pull/21114