### PR TITLE
Add emplace_back to edm::VecArray

### DIFF
--- a/FWCore/Utilities/interface/VecArray.h
+++ b/FWCore/Utilities/interface/VecArray.h
@@ -87,6 +87,21 @@ namespace edm {
       ++size_;
     }
 
+    // Throws if size()==N
+    template <typename ...Args>
+    void emplace_back(Args&&... args) {
+      if(size_ >= N)
+        throw std::length_error("emplace_back on already-full VecArray (N="+std::to_string(N)+")");
+      emplace_back_unchecked(std::forward<Args>(args)...);
+    }
+
+    // Undefined behaviour if size()==N
+    template <typename ...Args>
+    void emplace_back_unchecked(Args&&... args) {
+      data_[size_] = T(std::forward<Args>(args)...);
+      ++size_;
+    }
+
     // Undefined behaviour if size()==0
     void pop_back() {
       --size_;

--- a/FWCore/Utilities/test/vecarray.cppunit.cpp
+++ b/FWCore/Utilities/test/vecarray.cppunit.cpp
@@ -44,13 +44,13 @@ void testVecArray::test() {
   ++iter;
   CPPUNIT_ASSERT(iter == end);
 
-  array.push_back_unchecked(2);
+  array.emplace_back_unchecked(2);
   CPPUNIT_ASSERT(array.size() == 2);
   CPPUNIT_ASSERT(array.back() == 2);
   array.push_back(3);
   CPPUNIT_ASSERT(array.size() == 3);
   CPPUNIT_ASSERT(array.back() == 3);
-  array.push_back(4);
+  array.emplace_back(4);
   CPPUNIT_ASSERT(array.size() == 4);
   CPPUNIT_ASSERT(array.front() == 1);
   CPPUNIT_ASSERT(array.back() == 4);
@@ -58,6 +58,13 @@ void testVecArray::test() {
 
   try {
     array.push_back(5);
+    CPPUNIT_ASSERT(false);
+  } catch(std::length_error& e) {
+    CPPUNIT_ASSERT(true);
+  }
+
+  try {
+    array.emplace_back(5);
     CPPUNIT_ASSERT(false);
   } catch(std::length_error& e) {
     CPPUNIT_ASSERT(true);

--- a/FWCore/Utilities/test/vecarray.cppunit.cpp
+++ b/FWCore/Utilities/test/vecarray.cppunit.cpp
@@ -56,19 +56,8 @@ void testVecArray::test() {
   CPPUNIT_ASSERT(array.back() == 4);
   CPPUNIT_ASSERT(array[0] == 1 && array[1] == 2 && array[2] == 3 && array[3] == 4);
 
-  try {
-    array.push_back(5);
-    CPPUNIT_ASSERT(false);
-  } catch(std::length_error& e) {
-    CPPUNIT_ASSERT(true);
-  }
-
-  try {
-    array.emplace_back(5);
-    CPPUNIT_ASSERT(false);
-  } catch(std::length_error& e) {
-    CPPUNIT_ASSERT(true);
-  }
+  CPPUNIT_ASSERT_THROW(array.push_back(5), std::length_error);
+  CPPUNIT_ASSERT_THROW(array.emplace_back(5), std::length_error);
 
   auto ptr = array.data();
   CPPUNIT_ASSERT(ptr[0] == 1 && ptr[1] == 2 && ptr[2] == 3 && ptr[3] == 4);
@@ -111,12 +100,7 @@ void testVecArray::test() {
   CPPUNIT_ASSERT(array.size() == 2);
   array.pop_back();
   CPPUNIT_ASSERT(array.size() == 1);
-  try {
-    array.resize(6);
-    CPPUNIT_ASSERT(false);
-  } catch(std::length_error& e) {
-    CPPUNIT_ASSERT(true);
-  }
+  CPPUNIT_ASSERT_THROW(array.resize(6), std::length_error);
   CPPUNIT_ASSERT(array.size() == 1);
   array.resize(4);
   CPPUNIT_ASSERT(array.size() == 4);


### PR DESCRIPTION
This PR adds `emplace_back` to `edm::VecArray` mostly for syntactic sugar for the case that `VecArray` holds e.g. `std::pair` (i.e. one can avoid typing `std::make_pair(...)` or `std::pair<...>(...)` that are needed with the existing `push_back`). It should nevertheless be noted that this is not a "true" `emplace_back` like in `std::vector` since all elements of `VecArray::data_` are value-initialized in the constructor of `VecArray`. On the other hand, `VecArray` makes sense only for types that are cheap to construct and copy, so in practice there should be no (added) problems.


Tested in 9_4_0_pre3, no changes expected.