### PR TITLE
Fix for conddb dump command

### DIFF
--- a/CondCore/Utilities/python/cond2xml.py
+++ b/CondCore/Utilities/python/cond2xml.py
@@ -143,7 +143,7 @@ class CondXmlProcessor(object):
         	 codeFile.write(code)
     	 	 codeFile.close()
     
-    	cmd = "source /cvmfs/cms.cern.ch/cmsset_default.sh;"
+    	cmd = "source $CMS_PATH/cmsset_default.sh;"
     	cmd += "(cd %s ; scram b 2>&1 >build.log)" %tmpDir
         pipe = subprocess.Popen( cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT )
         out, err = pipe.communicate()


### PR DESCRIPTION
Fix for checkouts on cluster outside CERN: setup file sourced from CMS_PATH