### PR TITLE
[10.0.X] Update GT: Update all L1T tags

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,21 +24,21 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '94X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '94X_dataRun2_v3',
+    'run1_data'         :   '94X_dataRun2_v4',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '94X_dataRun2_v3',
+    'run2_data'         :   '94X_dataRun2_v4',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '94X_dataRun2_relval_v6',
+    'run2_data_relval'  :   '94X_dataRun2_relval_v7',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '94X_dataRun2_PromptLike_v6',
+    'run2_data_promptlike' : '94X_dataRun2_PromptLike_v8',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '94X_dataRun2_HLT_frozen_v4',
+    'run1_hlt'          :   '94X_dataRun2_HLT_frozen_v5',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '94X_dataRun2_HLT_frozen_v4',
+    'run2_hlt'          :   '94X_dataRun2_HLT_frozen_v5',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '94X_dataRun2_HLT_relval_v6',
+    'run2_hlt_relval'   :   '94X_dataRun2_HLT_relval_v7',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '94X_dataRun2_HLTHI_frozen_v3',
+    'run2_hlt_hi'       :   '94X_dataRun2_HLTHI_frozen_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '94X_mc2017_design_IdealBS_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -52,7 +52,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
     'phase1_2018_realistic'    : '94X_upgrade2018_realistic_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '94X_upgrade2018cosmics_realistic_deco_v6',
+    'phase1_2018_cosmics'      :   '94X_upgrade2018cosmics_realistic_deco_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,19 +10,19 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '94X_mcRun1_pA_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '94X_mcRun2_design_v0',
+    'run2_design'       :   '94X_mcRun2_design_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '94X_mcRun2_startup_v0',
+    'run2_mc_50ns'      :   '94X_mcRun2_startup_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '94X_mcRun2_asymptotic_v0',
+    'run2_mc'           :   '94X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
     'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '94X_mcRun2cosmics_startup_deco_v0',
+    'run2_mc_cosmics'   :   '94X_mcRun2cosmics_startup_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '93X_mcRun2_HeavyIon_v0',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '94X_mcRun2_pA_v0',
+    'run2_mc_pa'        :   '94X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '94X_dataRun2_v3',
     # GlobalTag for Run2 data reprocessing

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,39 +24,39 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '94X_mcRun2_pA_v0',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '94X_dataRun2_v2',
+    'run1_data'         :   '94X_dataRun2_v3',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '94X_dataRun2_v2',
+    'run2_data'         :   '94X_dataRun2_v3',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '94X_dataRun2_relval_v5',
+    'run2_data_relval'  :   '94X_dataRun2_relval_v6',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '94X_dataRun2_PromptLike_v5',
+    'run2_data_promptlike' : '94X_dataRun2_PromptLike_v6',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '94X_dataRun2_HLT_frozen_v3',
+    'run1_hlt'          :   '94X_dataRun2_HLT_frozen_v4',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '94X_dataRun2_HLT_frozen_v3',
+    'run2_hlt'          :   '94X_dataRun2_HLT_frozen_v4',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '94X_dataRun2_HLT_relval_v5',
+    'run2_hlt_relval'   :   '94X_dataRun2_HLT_relval_v6',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '94X_dataRun2_HLTHI_frozen_v2',
+    'run2_hlt_hi'       :   '94X_dataRun2_HLTHI_frozen_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '94X_mc2017_design_IdealBS_v5',
+    'phase1_2017_design'       :  '94X_mc2017_design_IdealBS_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '94X_mc2017_realistic_v5',
+    'phase1_2017_realistic'    : '94X_mc2017_realistic_v6',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '94X_mc2017cosmics_realistic_deco_v4',
+    'phase1_2017_cosmics'      : '94X_mc2017cosmics_realistic_deco_v5',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '94X_mc2017cosmics_realistic_peak_v4',
+    'phase1_2017_cosmics_peak' : '94X_mc2017cosmics_realistic_peak_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '94X_upgrade2018_design_IdealBS_v5',
+    'phase1_2018_design'       : '94X_upgrade2018_design_IdealBS_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '94X_upgrade2018_realistic_v5',
+    'phase1_2018_realistic'    : '94X_upgrade2018_realistic_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '94X_upgrade2018cosmics_realistic_deco_v4',
+    'phase1_2018_cosmics'      :   '94X_upgrade2018cosmics_realistic_deco_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '94X_upgrade2023_realistic_v2'
+    'phase2_realistic'         : '94X_upgrade2023_realistic_v3'
 }
 
 aliases = {

--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -83,9 +83,6 @@ process.l1tEmulatorMonitorPath = cms.Path(
 #process.load("L1Trigger.L1TGlobal.hackConditions_cff")
 process.load("L1Trigger.L1TGlobal.GlobalParameters_cff")
 
-# 2017 EMTF emulator uses payloads and forests from DB, but not yet in GT
-process.load("L1Trigger.L1TMuonEndCap.fakeEmtfParams_2017_MC_cff")
-
 # To get CaloTPGTranscoder
 process.load('SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff')
 process.HcalTPGCoderULUT.LUTGenerationMode = cms.bool(False)

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
@@ -263,9 +263,6 @@ from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 #from L1Trigger.L1TCalorimeter.hackConditions_cff import *
 from L1Trigger.L1TGlobal.GlobalParameters_cff import *
 
-# 2017 EMTF emulator uses payloads and forests from DB, but not yet in GT
-from L1Trigger.L1TMuonEndCap.fakeEmtfParams_2017_MC_cff import *
-
 from DQMOffline.L1Trigger.L1TStage2CaloLayer2Offline_cfi import *
 l1tStage2CaloLayer2OfflineDQMEmu.stage2CaloLayer2JetSource=cms.InputTag("valCaloStage2Layer2Digis")
 l1tStage2CaloLayer2OfflineDQMEmu.stage2CaloLayer2EtSumSource=cms.InputTag("valCaloStage2Layer2Digis")

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -54,7 +54,6 @@ from L1Trigger.L1TGlobal.GlobalParameters_cff import *
 
 # 2017 EMTF and TwinMux emulator use payloads from DB, not yet in GT,
 # soon to be removed when availble in GTs
-from L1Trigger.L1TMuonEndCap.fakeEmtfParams_2017_MC_cff import *
 from L1Trigger.L1TTwinMux.fakeTwinMuxParams_cff import *
 
 # Customisation for the phase2_hgcal era. Includes the HGCAL L1 trigger


### PR DESCRIPTION
# Summary of changes in Global Tags

## RunI data

   * **RunI HLT processing** : [94X_dataRun2_HLT_frozen_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_frozen_v3) as [94X_dataRun2_HLT_frozen_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_frozen_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_HLT_frozen_v3/94X_dataRun2_HLT_frozen_v4):
      * Add All L1Tag

   * **RunI Offline processing** : [94X_dataRun2_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_v2) as [94X_dataRun2_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_v2/94X_dataRun2_v3):
      * Add All L1 Tag

## RunII data

   * **RunII HLTHI processing** : [94X_dataRun2_HLTHI_frozen_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLTHI_frozen_v2) as [94X_dataRun2_HLTHI_frozen_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLTHI_frozen_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_HLTHI_frozen_v2/94X_dataRun2_HLTHI_frozen_v3):
      * Add All L1 Tag

   * **RunII HLT relval processing** : [94X_dataRun2_HLT_relval_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_relval_v5) as [94X_dataRun2_HLT_relval_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_relval_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_HLT_relval_v5/94X_dataRun2_HLT_relval_v6):
      * Add All L1 Tag

   * **RunII Offline processing** : [94X_dataRun2_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_v2) as [94X_dataRun2_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_v2/94X_dataRun2_v3):
      * Add All L1 Tag

   * **RunII Offline relval processing** : [94X_dataRun2_relval_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_relval_v5) as [94X_dataRun2_relval_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_relval_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_relval_v5/94X_dataRun2_relval_v6):
      * Add All L1 Tag

   * **RunII Prompt processing** : [94X_dataRun2_PromptLike_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_PromptLike_v5) as [94X_dataRun2_PromptLike_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_PromptLike_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_PromptLike_v5/94X_dataRun2_PromptLike_v6):
      * Add All L1 Tag

   * **RunI HLT processing** : [94X_dataRun2_HLT_frozen_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_frozen_v3) as [94X_dataRun2_HLT_frozen_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_frozen_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_HLT_frozen_v3/94X_dataRun2_HLT_frozen_v4):
      * Add All L1 Tag

## Upgrade

   * **PhaseII realistic scenario** : [94X_upgrade2023_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2023_realistic_v2) as [94X_upgrade2023_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2023_realistic_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_upgrade2023_realistic_v2/94X_upgrade2023_realistic_v3):
      * Add All L1 Tag

   * **PhaseI 2018 cosmics scenario** : [94X_upgrade2018cosmics_realistic_deco_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018cosmics_realistic_deco_v4) as [94X_upgrade2018cosmics_realistic_deco_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018cosmics_realistic_deco_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_upgrade2018cosmics_realistic_deco_v4/94X_upgrade2018cosmics_realistic_deco_v5):
      * Add All L1 Tag

   * **PhaseI 2018 design scenario** : [94X_upgrade2018_design_IdealBS_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018_design_IdealBS_v5) as [94X_upgrade2018_design_IdealBS_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018_design_IdealBS_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_upgrade2018_design_IdealBS_v5/94X_upgrade2018_design_IdealBS_v6):
      * Add All L1 Tag

   * **PhaseI 2018 realistic scenario** : [94X_upgrade2018_realistic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018_realistic_v5) as [94X_upgrade2018_realistic_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018_realistic_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_upgrade2018_realistic_v5/94X_upgrade2018_realistic_v6):
      * Add All L1 Tag

## 2017_MC

   * **PhaseI 2017 cosmics peak scenario** : [94X_mc2017cosmics_realistic_peak_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017cosmics_realistic_peak_v4) as [94X_mc2017cosmics_realistic_peak_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017cosmics_realistic_peak_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017cosmics_realistic_peak_v4/94X_mc2017cosmics_realistic_peak_v5):
      * Add All L1 Tag

   * **PhaseI 2017 cosmics scenario** : [94X_mc2017cosmics_realistic_deco_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017cosmics_realistic_deco_v4) as [94X_mc2017cosmics_realistic_deco_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017cosmics_realistic_deco_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017cosmics_realistic_deco_v4/94X_mc2017cosmics_realistic_deco_v5):
      * Add All L1 Tag

   * **PhaseI 2017 design scenario** : [94X_mc2017_design_IdealBS_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017_design_IdealBS_v5) as [94X_mc2017_design_IdealBS_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017_design_IdealBS_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017_design_IdealBS_v5/94X_mc2017_design_IdealBS_v6):
      * Add All L1 Tag

   * **PhaseI 2017 realistic scenario** : [94X_mc2017_realistic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017_realistic_v5) as [94X_mc2017_realistic_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017_realistic_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017_realistic_v5/94X_mc2017_realistic_v6):
      * Add All L1 Tag