### PR TITLE
ZCounting: Add electron channel.

### DIFF
--- a/DQMOffline/Lumi/BuildFile.xml
+++ b/DQMOffline/Lumi/BuildFile.xml
@@ -1,5 +1,8 @@
 <use name="FWCore/Framework"/>
 <use name="DataFormats/MuonReco"/>
+<use name="DataFormats/EgammaReco"/>
+<use name="DataFormats/EgammaCandidates"/>
+<use name="RecoEgamma/ElectronIdentification"/>
 <use name="DataFormats/HLTReco"/>
 <use name="TrackingTools/IPTools"/>
 <use name="boost"/>

--- a/DQMOffline/Lumi/interface/ElectronIdentifier.h
+++ b/DQMOffline/Lumi/interface/ElectronIdentifier.h
@@ -48,19 +48,14 @@ class ElectronIdentifier{
    public:
       ElectronIdentifier (const edm::ParameterSet& c);
       float dEtaInSeed(const reco::GsfElectronPtr& ele);
-      bool passID(const reco::GsfElectronPtr& ele);
+      bool passID(const reco::GsfElectronPtr& ele,edm::Handle<reco::BeamSpot> beamspot,edm::Handle<reco::ConversionCollection> conversions);
       float isolation(const reco::GsfElectronPtr& ele);
-      void loadEvent(const edm::Event& iEvent);
 
       void setID(std::string ID);
       void setRho(double rho);
-      void setBeamspot(edm::Handle<reco::BeamSpot> beamspot);
-      void setConversions(edm::Handle<reco::ConversionCollection> conversions);
    private:
      double rho_;
      int ID_;
-     edm::Handle<reco::BeamSpot> beamspot_;
-     edm::Handle<reco::ConversionCollection> conversions_;
      std::array<std::array<std::array<double,2>,3>,8> cuts_;
      // Effective area constants
      EffectiveAreas _effectiveAreas;

--- a/DQMOffline/Lumi/interface/ElectronIdentifier.h
+++ b/DQMOffline/Lumi/interface/ElectronIdentifier.h
@@ -24,7 +24,26 @@
 
 #include "RecoEgamma/EgammaTools/interface/EffectiveAreas.h"
 #include <DataFormats/BeamSpot/interface/BeamSpot.h>
-
+enum EleIDCutNames{
+   SIGMAIETA,
+   DETAINSEED,
+   DPHIIN,
+   HOVERE,
+   ISO,
+   ONEOVERE,
+   MISSINGHITS,
+   CONVERSION,
+};
+enum EleIDWorkingPoints{
+   VETO,
+   MEDIUM,
+   LOOSE,
+   TIGHT
+};
+enum EleIDEtaBins{
+   BARREL,
+   ENDCAP
+};
 class ElectronIdentifier{
    public:
       ElectronIdentifier (const edm::ParameterSet& c);
@@ -39,11 +58,10 @@ class ElectronIdentifier{
       void setConversions(edm::Handle<reco::ConversionCollection> conversions);
    private:
      double rho_;
-     std::string ID_;
+     int ID_;
      edm::Handle<reco::BeamSpot> beamspot_;
      edm::Handle<reco::ConversionCollection> conversions_;
-     std::map<std::string,std::map<std::string,std::map<std::string, double>>> cuts_;
-
+     std::array<std::array<std::array<double,2>,3>,8> cuts_;
      // Effective area constants
      EffectiveAreas _effectiveAreas;
 };

--- a/DQMOffline/Lumi/interface/ElectronIdentifier.h
+++ b/DQMOffline/Lumi/interface/ElectronIdentifier.h
@@ -1,0 +1,51 @@
+#ifndef DQMOFFLINE_LUMI_ELECTRONIDENTIFIER_H
+#define DQMOFFLINE_LUMI_ELECTRONIDENTIFIER_H
+
+#include "FWCore/Framework/interface/MakerMacros.h"      // definitions for declaring plug-in modules
+#include "FWCore/Framework/interface/Frameworkfwd.h"     // declaration of EDM types
+#include "FWCore/Framework/interface/EDAnalyzer.h"       // EDAnalyzer class
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"  // Parameters
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include <string>                                        // string class
+#include <TMath.h>
+#include <cassert>
+
+#include "DataFormats/EgammaCandidates/interface/ElectronFwd.h"
+#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/ConversionFwd.h"
+#include "DataFormats/EgammaCandidates/interface/Conversion.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+
+#include "PhysicsTools/SelectorUtils/interface/CutApplicatorBase.h"
+
+#include "RecoEgamma/EgammaTools/interface/EffectiveAreas.h"
+#include <DataFormats/BeamSpot/interface/BeamSpot.h>
+
+class ElectronIdentifier{
+   public:
+      ElectronIdentifier (const edm::ParameterSet& c);
+      float dEtaInSeed(const reco::GsfElectronPtr& ele);
+      bool passID(const reco::GsfElectronPtr& ele);
+      float isolation(const reco::GsfElectronPtr& ele);
+      void loadEvent(const edm::Event& iEvent);
+
+      void setID(std::string ID);
+      void setRho(double rho);
+      void setBeamspot(edm::Handle<reco::BeamSpot> beamspot);
+      void setConversions(edm::Handle<reco::ConversionCollection> conversions);
+   private:
+     double rho_;
+     std::string ID_;
+     edm::Handle<reco::BeamSpot> beamspot_;
+     edm::Handle<reco::ConversionCollection> conversions_;
+     std::map<std::string,std::map<std::string,std::map<std::string, double>>> cuts_;
+
+     // Effective area constants
+     EffectiveAreas _effectiveAreas;
+};
+
+#endif

--- a/DQMOffline/Lumi/interface/ElectronIdentifier.h
+++ b/DQMOffline/Lumi/interface/ElectronIdentifier.h
@@ -56,7 +56,7 @@ class ElectronIdentifier{
    private:
      double rho_;
      int ID_;
-     std::array<std::array<std::array<double,2>,3>,8> cuts_;
+     std::array<std::array<std::array<double,2>,4>,8> cuts_;
      // Effective area constants
      EffectiveAreas _effectiveAreas;
 };

--- a/DQMOffline/Lumi/plugins/ZCounting.cc
+++ b/DQMOffline/Lumi/plugins/ZCounting.cc
@@ -515,12 +515,10 @@ void ZCounting::analyzeElectrons(const edm::Event& iEvent, const edm::EventSetup
   // Get beamspot
   edm::Handle<reco::BeamSpot> beamspotHandle;
   iEvent.getByToken(fBeamspotToken, beamspotHandle);
-  EleID_.setBeamspot(beamspotHandle);
 
   // Conversions
   edm::Handle<reco::ConversionCollection> conversionsHandle;
   iEvent.getByToken(fConversionToken, conversionsHandle);
-  EleID_.setConversions(conversionsHandle);
 
 
   edm::Ptr<reco::GsfElectron> eleProbe;
@@ -529,7 +527,7 @@ void ZCounting::analyzeElectrons(const edm::Event& iEvent, const edm::EventSetup
   // Loop over Tags
   for (size_t itag = 0; itag < electrons->size(); ++itag){
     const auto el1 = electrons->ptrAt(itag);
-    if( not EleID_.passID(el1) ) continue;
+    if( not EleID_.passID(el1,beamspotHandle,conversionsHandle) ) continue;
 
     float pt1  = el1->pt();
     float eta1 = el1->eta();
@@ -594,7 +592,7 @@ void ZCounting::analyzeElectrons(const edm::Event& iEvent, const edm::EventSetup
 
       long ls = iEvent.luminosityBlock();
       bool probe_pass_trigger = isElectronTriggerObj(*fTrigger, TriggerTools::matchHLT(vProbe.Eta(), vProbe.Phi(), fTrigger->fRecords, *hTrgEvt));
-      bool probe_pass_id = eleProbe.isNonnull() and EleID_.passID(eleProbe);
+      bool probe_pass_id = eleProbe.isNonnull() and EleID_.passID(eleProbe,beamspotHandle,conversionsHandle);
 
       //// Fill for yields
       bool probe_is_forward = probe_abseta > ELE_ETA_CRACK_LOW;

--- a/DQMOffline/Lumi/plugins/ZCounting.cc
+++ b/DQMOffline/Lumi/plugins/ZCounting.cc
@@ -44,6 +44,9 @@ ZCounting::ZCounting(const edm::ParameterSet& iConfig):
   ELE_ETA_CUT_TAG(iConfig.getUntrackedParameter<double>("EtaCutEleTag")),
   ELE_ETA_CUT_PROBE(iConfig.getUntrackedParameter<double>("EtaCutEleProbe")),
 
+  ELE_MASS_CUT_LOW(iConfig.getUntrackedParameter<double>("MassCutEleLow")),
+  ELE_MASS_CUT_HIGH(iConfig.getUntrackedParameter<double>("MassCutEleHigh")),
+
   ELE_ID_WP( iConfig.getUntrackedParameter<std::string>("ElectronIDType","TIGHT")),
   EleID_(ElectronIdentifier(iConfig))
 {
@@ -583,9 +586,8 @@ void ZCounting::analyzeElectrons(const edm::Event& iEvent, const edm::EventSetup
 
       // Require good Z
       TLorentzVector vDilep = vTag + vProbe;
-      float MASS_LOW = 80.0;
-      float MASS_HIGH = 100.0;
-      if((vDilep.M()<MASS_LOW) || (vDilep.M()>MASS_HIGH)) continue;
+
+      if((vDilep.M()<ELE_MASS_CUT_LOW) || (vDilep.M()>ELE_MASS_CUT_HIGH)) continue;
       if(eleProbe.isNonnull() and (eleProbe->charge() != - el1->charge())) continue;
 
       // Good Z found!

--- a/DQMOffline/Lumi/plugins/ZCounting.cc
+++ b/DQMOffline/Lumi/plugins/ZCounting.cc
@@ -454,12 +454,12 @@ void ZCounting::analyzeElectrons(const edm::Event& iEvent, const edm::EventSetup
   const reco::VertexCollection *pvCol = hVertexProduct.product();
   int nvtx = 0;
 
-  for(reco::VertexCollection::const_iterator itVtx = pvCol->begin(); itVtx!=pvCol->end(); ++itVtx) {
-    if(itVtx->isFake())                             continue;
-    if(itVtx->tracksSize()     < VtxNTracksFitCut_) continue;
-    if(itVtx->ndof()           < VtxNdofCut_)       continue;
-    if(fabs(itVtx->z())        > VtxAbsZCut_)       continue;
-    if(itVtx->position().Rho() > VtxRhoCut_)        continue;
+  for(auto const & vtx : *pvCol) {
+    if(vtx.isFake())                             continue;
+    if(vtx.tracksSize()     < VtxNTracksFitCut_) continue;
+    if(vtx.ndof()           < VtxNdofCut_)       continue;
+    if(fabs(vtx.z())        > VtxAbsZCut_)       continue;
+    if(vtx.position().Rho() > VtxRhoCut_)        continue;
 
     nvtx++;
   }

--- a/DQMOffline/Lumi/plugins/ZCounting.cc
+++ b/DQMOffline/Lumi/plugins/ZCounting.cc
@@ -27,7 +27,25 @@ ZCounting::ZCounting(const edm::ParameterSet& iConfig):
   fHLTTag            (iConfig.getParameter<edm::InputTag>("TriggerResults")),
   fPVName            (iConfig.getUntrackedParameter<std::string>("edmPVName","offlinePrimaryVertices")),
   fMuonName          (iConfig.getUntrackedParameter<std::string>("edmName","muons")),
-  fTrackName         (iConfig.getUntrackedParameter<std::string>("edmTrackName","generalTracks"))
+  fTrackName         (iConfig.getUntrackedParameter<std::string>("edmTrackName","generalTracks")),
+
+  // Electron-specific Parameters
+  fElectronName( iConfig.getUntrackedParameter<std::string>("edmGsfEleName","gedGsfElectrons")),
+  fSCName( iConfig.getUntrackedParameter<std::string>("edmSCName","particleFlowEGamma")),
+
+  // Electron-specific Tags
+  fRhoTag( iConfig.getParameter<edm::InputTag>("rhoname") ),
+  fBeamspotTag(iConfig.getParameter<edm::InputTag>("beamspotName") ),
+  fConversionTag( iConfig.getParameter<edm::InputTag>("conversionsName")),
+
+  // Electron-specific Cuts
+  ELE_PT_CUT_TAG(iConfig.getUntrackedParameter<double>("PtCutEleTag")),
+  ELE_PT_CUT_PROBE(iConfig.getUntrackedParameter<double>("PtCutEleProbe")),
+  ELE_ETA_CUT_TAG(iConfig.getUntrackedParameter<double>("EtaCutEleTag")),
+  ELE_ETA_CUT_PROBE(iConfig.getUntrackedParameter<double>("EtaCutEleProbe")),
+
+  ELE_ID_WP( iConfig.getUntrackedParameter<std::string>("ElectronIDType","TIGHT")),
+  EleID_(ElectronIdentifier(iConfig))
 {
   edm::LogInfo("ZCounting") <<  "Constructor  ZCounting::ZCounting " << std::endl;
   
@@ -38,7 +56,14 @@ ZCounting::ZCounting(const edm::ParameterSet& iConfig):
   fMuonName_token  = consumes<reco::MuonCollection>(fMuonName);
   fTrackName_token = consumes<reco::TrackCollection>(fTrackName);
 
-  //Cuts
+  // Electron-specific parameters
+  fGsfElectronName_token  = consumes<edm::View<reco::GsfElectron>>(fElectronName);
+  fSCName_token           = consumes<edm::View<reco::SuperCluster>>(fSCName);
+  fRhoToken               = consumes<double>(fRhoTag);
+  fBeamspotToken          = consumes<reco::BeamSpot>(fBeamspotTag);
+  fConversionToken        = consumes<reco::ConversionCollection>(fConversionTag);
+
+  // Muon-specific Cuts
   IDTypestr_       = iConfig.getUntrackedParameter<std::string>("IDType");
   IsoTypestr_      = iConfig.getUntrackedParameter<std::string>("IsoType");
   IsoCut_          = iConfig.getUntrackedParameter<double>("IsoCut");
@@ -73,6 +98,8 @@ ZCounting::ZCounting(const edm::ParameterSet& iConfig):
   VtxNdofCut_       = iConfig.getUntrackedParameter<double>("VtxNdofMin");
   VtxAbsZCut_       = iConfig.getUntrackedParameter<double>("VtxAbsZMax");
   VtxRhoCut_        = iConfig.getUntrackedParameter<double>("VtxRhoMax");
+
+  EleID_.setID(ELE_ID_WP);
 }
 
 //
@@ -104,6 +131,8 @@ void ZCounting::bookHistograms(DQMStore::IBooker & ibooker_, edm::Run const &, e
   ibooker_.cd();
   ibooker_.setCurrentFolder("ZCounting/Histograms");
 
+
+  // Muon histograms
   h_mass_HLT_pass_central = ibooker_.book2D("h_mass_HLT_pass_central", "h_mass_HLT_pass_central", LumiBin_, LumiMin_, LumiMax_, MassBin_, MassMin_, MassMax_);
   h_mass_HLT_pass_forward = ibooker_.book2D("h_mass_HLT_pass_forward", "h_mass_HLT_pass_forward", LumiBin_, LumiMin_, LumiMax_, MassBin_, MassMin_, MassMax_);
   h_mass_HLT_fail_central = ibooker_.book2D("h_mass_HLT_fail_central", "h_mass_HLT_fail_central", LumiBin_, LumiMin_, LumiMax_, MassBin_, MassMin_, MassMax_);
@@ -124,6 +153,21 @@ void ZCounting::bookHistograms(DQMStore::IBooker & ibooker_, edm::Run const &, e
   h_yieldBB_Z             = ibooker_.book1D("h_yieldBB_Z", "h_yieldBB_Z", LumiBin_, LumiMin_, LumiMax_);
   h_yieldEE_Z             = ibooker_.book1D("h_yieldEE_Z", "h_yieldEE_Z", LumiBin_, LumiMin_, LumiMax_);
 
+
+  // Electron histograms
+  h_ee_mass_id_pass_central  = ibooker_.book2D("h_ee_mass_id_pass_central", "h_ee_mass_id_pass_central", LumiBin_, LumiMin_, LumiMax_, MassBin_, MassMin_, MassMax_);
+  h_ee_mass_id_fail_central  = ibooker_.book2D("h_ee_mass_id_fail_central", "h_ee_mass_id_fail_central", LumiBin_, LumiMin_, LumiMax_, MassBin_, MassMin_, MassMax_);
+  h_ee_mass_id_pass_forward  = ibooker_.book2D("h_ee_mass_id_pass_forward", "h_ee_mass_id_pass_forward", LumiBin_, LumiMin_, LumiMax_, MassBin_, MassMin_, MassMax_);
+  h_ee_mass_id_fail_forward  = ibooker_.book2D("h_ee_mass_id_fail_forward", "h_ee_mass_id_fail_forward", LumiBin_, LumiMin_, LumiMax_, MassBin_, MassMin_, MassMax_);
+
+  h_ee_mass_HLT_pass_central = ibooker_.book2D("h_ee_mass_HLT_pass_central", "h_ee_mass_HLT_pass_central", LumiBin_, LumiMin_, LumiMax_, MassBin_, MassMin_, MassMax_);
+  h_ee_mass_HLT_fail_central = ibooker_.book2D("h_ee_mass_HLT_fail_central", "h_ee_mass_HLT_fail_central", LumiBin_, LumiMin_, LumiMax_, MassBin_, MassMin_, MassMax_);
+  h_ee_mass_HLT_pass_forward = ibooker_.book2D("h_ee_mass_HLT_pass_forward", "h_ee_mass_HLT_pass_forward", LumiBin_, LumiMin_, LumiMax_, MassBin_, MassMin_, MassMax_);
+  h_ee_mass_HLT_fail_forward = ibooker_.book2D("h_ee_mass_HLT_fail_forward", "h_ee_mass_HLT_fail_forward", LumiBin_, LumiMin_, LumiMax_, MassBin_, MassMin_, MassMax_);
+
+  h_ee_yield_Z_ebeb       = ibooker_.book1D("h_ee_yield_Z_ebeb", "h_ee_yield_Z_ebeb", LumiBin_, LumiMin_, LumiMax_);
+  h_ee_yield_Z_ebee       = ibooker_.book1D("h_ee_yield_Z_ebee", "h_ee_yield_Z_ebee", LumiBin_, LumiMin_, LumiMax_);
+  h_ee_yield_Z_eeee       = ibooker_.book1D("h_ee_yield_Z_eeee", "h_ee_yield_Z_eeee", LumiBin_, LumiMin_, LumiMax_);
 }
 //
 // -------------------------------------- beginLuminosityBlock --------------------------------------------
@@ -141,7 +185,12 @@ void ZCounting::beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::E
 void ZCounting::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {// Fill event tree on the fly 
   edm::LogInfo("ZCounting") <<  "ZCounting::analyze" << std::endl;
+  analyzeMuons(iEvent, iSetup);
+  analyzeElectrons(iEvent, iSetup);
+}
 
+void ZCounting::analyzeMuons(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::LogInfo("ZCounting") <<  "ZCounting::analyzeMuons" << std::endl;
   //-------------------------------
   //--- Vertex 
   //-------------------------------
@@ -389,7 +438,225 @@ void ZCounting::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   }//End of tag loop
 
 }
+void ZCounting::analyzeElectrons(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::LogInfo("ZCounting") <<  "ZCounting::analyzeElectrons" << std::endl;
 
+  //-------------------------------
+  //--- Vertex
+  //-------------------------------
+  edm::Handle<reco::VertexCollection> hVertexProduct;
+  iEvent.getByToken(fPVName_token,hVertexProduct);
+  if(!hVertexProduct.isValid()) return;
+
+  const reco::VertexCollection *pvCol = hVertexProduct.product();
+  int nvtx = 0;
+
+  for(reco::VertexCollection::const_iterator itVtx = pvCol->begin(); itVtx!=pvCol->end(); ++itVtx) {
+    if(itVtx->isFake())                             continue;
+    if(itVtx->tracksSize()     < VtxNTracksFitCut_) continue;
+    if(itVtx->ndof()           < VtxNdofCut_)       continue;
+    if(fabs(itVtx->z())        > VtxAbsZCut_)       continue;
+    if(itVtx->position().Rho() > VtxRhoCut_)        continue;
+
+    nvtx++;
+  }
+
+  // Good vertex requirement
+  if(nvtx==0) return;
+
+  //-------------------------------
+  //--- Trigger
+  //-------------------------------
+  edm::Handle<edm::TriggerResults> hTrgRes;
+  iEvent.getByToken(fHLTTag_token,hTrgRes);
+  if(!hTrgRes.isValid()) return;
+
+  edm::Handle<trigger::TriggerEvent> hTrgEvt;
+  iEvent.getByToken(fHLTObjTag_token,hTrgEvt);
+
+
+  const edm::TriggerNames &triggerNames = iEvent.triggerNames(*hTrgRes);
+  Bool_t config_changed = false;
+  if(fTriggerNamesID != triggerNames.parameterSetID()) {
+    fTriggerNamesID = triggerNames.parameterSetID();
+    config_changed  = true;
+  }
+  if(config_changed) {
+    initHLT(*hTrgRes, triggerNames);
+  }
+
+  TriggerBits triggerBits;
+  for(unsigned int irec=0; irec<fTrigger->fRecords.size(); irec++) {
+    if(fTrigger->fRecords[irec].hltPathIndex == (unsigned int)-1) continue;
+    if(hTrgRes->accept(fTrigger->fRecords[irec].hltPathIndex)) {
+      triggerBits [fTrigger->fRecords[irec].baconTrigBit] = 1;
+    }
+  }
+
+  // Trigger requirement
+  if(!isElectronTrigger(*fTrigger, triggerBits)) return;
+
+  // Get Electrons
+  edm::Handle<edm::View<reco::GsfElectron> > electrons;
+  iEvent.getByToken(fGsfElectronName_token, electrons);
+
+  // Get SuperClusters
+  edm::Handle<edm::View<reco::SuperCluster> > superclusters;
+  iEvent.getByToken(fSCName_token, superclusters);
+
+  // Get Rho
+  edm::Handle<double> rhoHandle;
+  iEvent.getByToken(fRhoToken, rhoHandle);
+  EleID_.setRho(*rhoHandle);
+
+  // Get beamspot
+  edm::Handle<reco::BeamSpot> beamspotHandle;
+  iEvent.getByToken(fBeamspotToken, beamspotHandle);
+  EleID_.setBeamspot(beamspotHandle);
+
+  // Conversions
+  edm::Handle<reco::ConversionCollection> conversionsHandle;
+  iEvent.getByToken(fConversionToken, conversionsHandle);
+  EleID_.setConversions(conversionsHandle);
+
+  TLorentzVector vTag(0.,0.,0.,0.);
+  TLorentzVector vProbe(0.,0.,0.,0.);
+  TLorentzVector vDilep(0.,0.,0.,0.);
+  edm::Ptr<reco::GsfElectron> eleProbe;
+  enum { eEleEle2HLT=1, eEleEle1HLT1L1, eEleEle1HLT, eEleEleNoSel, eEleSC };  // event category enum
+
+  // Loop over Tags
+  for (size_t itag = 0; itag < electrons->size(); ++itag){
+    const auto el1 = electrons->ptrAt(itag);
+    if( not EleID_.passID(el1) ) continue;
+
+    float pt1  = el1->pt();
+    float eta1 = el1->eta();
+    float phi1 = el1->phi();
+
+    if(!isElectronTriggerObj(*fTrigger, TriggerTools::matchHLT(eta1, phi1, fTrigger->fRecords, *hTrgEvt))) continue;
+    vTag.SetPtEtaPhiM(pt1, eta1, phi1, ELECTRON_MASS);
+
+
+    // Tag selection: kinematic cuts, lepton selection and trigger matching
+    double tag_pt = vTag.Pt();
+    double tag_abseta = fabs(vTag.Eta());
+
+    bool tag_is_valid_tag = ele_tag_selection(tag_pt,tag_abseta);
+    bool tag_is_valid_probe = ele_probe_selection(tag_pt,tag_abseta);
+
+    if( not (tag_is_valid_tag or tag_is_valid_probe) ) continue;
+
+    // Loop over probes
+    for (size_t iprobe = 0; iprobe < superclusters->size(); ++iprobe){
+      // Initialize probe
+      const auto sc = superclusters->ptrAt(iprobe);
+      if(*sc == *(el1->superCluster())) {
+        continue;
+      }
+
+      // Find matching electron
+      for (size_t iele = 0; iele < electrons->size(); ++iele){
+        if(iele == itag) continue;
+        const auto ele = electrons->ptrAt(iele);
+        if(*sc == *(ele->superCluster())) {
+          eleProbe = ele;
+          break;
+        }
+      }
+
+      // Assign final probe 4-vector
+      if(eleProbe.isNonnull()){
+        vProbe.SetPtEtaPhiM( eleProbe->pt(), eleProbe->eta(), eleProbe->phi(), ELECTRON_MASS);
+      } else {
+        double pt = sc->energy() * TMath::Sqrt( 1 - pow(TMath::TanH(sc->eta()),2) );
+        vProbe.SetPtEtaPhiM( pt, sc->eta(), sc->phi(), ELECTRON_MASS);
+      }
+
+      // Probe Selection
+      double probe_pt = vProbe.Pt();
+      double probe_abseta = fabs(sc->eta());
+      bool probe_is_valid_probe = ele_probe_selection(probe_pt, probe_abseta);
+      if( !probe_is_valid_probe ) continue;
+
+      // Good Probe found!
+
+      // Require good Z
+      vDilep = vTag + vProbe;
+      float MASS_LOW = 80.0;
+      float MASS_HIGH = 100.0;
+      if((vDilep.M()<MASS_LOW) || (vDilep.M()>MASS_HIGH)) continue;
+      if(eleProbe.isNonnull() and (eleProbe->charge() != - el1->charge())) continue;
+
+      // Good Z found!
+
+      long ls = iEvent.luminosityBlock();
+      bool probe_pass_trigger = isElectronTriggerObj(*fTrigger, TriggerTools::matchHLT(vProbe.Eta(), vProbe.Phi(), fTrigger->fRecords, *hTrgEvt));
+      bool probe_pass_id = eleProbe.isNonnull() and EleID_.passID(eleProbe);
+
+      //// Fill for yields
+      bool probe_is_forward = probe_abseta > ELE_ETA_CRACK_LOW;
+      bool tag_is_forward = tag_abseta > ELE_ETA_CRACK_LOW;
+
+      if(probe_pass_id) {
+        if(probe_is_forward and tag_is_forward) {
+          h_ee_yield_Z_eeee -> Fill(ls);
+        } else if(!probe_is_forward and !tag_is_forward) {
+          h_ee_yield_Z_ebeb -> Fill(ls);
+        } else {
+          h_ee_yield_Z_ebee -> Fill(ls);
+        }
+      }
+
+      if(!tag_is_valid_tag) continue;
+
+      /// Fill for ID efficiency
+      if(probe_pass_id) {
+        if(probe_is_forward) {
+          h_ee_mass_id_pass_forward->Fill(ls, vDilep.M());
+        } else {
+          h_ee_mass_id_pass_central->Fill(ls, vDilep.M());
+        }
+      } else {
+          if(probe_is_forward) {
+            h_ee_mass_id_fail_forward->Fill(ls, vDilep.M());
+          } else {
+            h_ee_mass_id_fail_central->Fill(ls, vDilep.M());
+          }
+      }
+
+      /// Fill for HLT efficiency
+      if(probe_pass_id and probe_pass_trigger) {
+        if(probe_is_forward) {
+          h_ee_mass_HLT_pass_forward->Fill(ls, vDilep.M());
+        } else {
+          h_ee_mass_HLT_pass_central->Fill(ls, vDilep.M());
+        }
+      } else if (probe_pass_id) {
+        if(probe_is_forward) {
+          h_ee_mass_HLT_fail_forward->Fill(ls, vDilep.M());
+        } else {
+          h_ee_mass_HLT_fail_central->Fill(ls, vDilep.M());
+        }
+      }
+    } // End of probe loop
+  }//End of tag loop
+
+}
+bool ZCounting::ele_probe_selection(double pt, double abseta){
+  bool pass = true;
+  pass &= pt > ELE_PT_CUT_PROBE;
+  pass &= abseta < ELE_ETA_CUT_PROBE;
+  pass &= (abseta < ELE_ETA_CRACK_LOW) or (abseta > ELE_ETA_CRACK_HIGH);
+  return pass;
+}
+bool ZCounting::ele_tag_selection(double pt, double abseta){
+  bool pass = true;
+  pass &= pt > ELE_PT_CUT_TAG;
+  pass &= abseta < ELE_ETA_CUT_TAG;
+  pass &= (abseta < ELE_ETA_CRACK_LOW) or (abseta > ELE_ETA_CRACK_HIGH);
+  return pass;
+}
 //
 // -------------------------------------- endLuminosityBlock --------------------------------------------
 //
@@ -439,6 +706,7 @@ bool ZCounting::isMuonTriggerObj(const ZCountingTrigger::TTrigger &triggerMenu, 
 {
   return triggerMenu.passObj("HLT_IsoMu27_v*","hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07",hltMatchBits);
 }
+
 //--------------------------------------------------------------------------------------------------
 bool ZCounting::passMuonID(const reco::Muon& muon, const reco::Vertex& vtx, const MuonIDTypes &idType)
 {//Muon ID selection, using internal function "DataFormats/MuonReco/src/MuonSelectors.cc
@@ -459,4 +727,14 @@ bool ZCounting::passMuonIso(const reco::Muon& muon, const MuonIsoTypes &isoType,
     else                        return false;
 }
 
+//--------------------------------------------------------------------------------------------------
+bool ZCounting::isElectronTrigger(ZCountingTrigger::TTrigger triggerMenu, TriggerBits hltBits)
+{
+  return triggerMenu.pass("HLT_Ele35_WPTight_Gsf_v*",hltBits);
+}
+//--------------------------------------------------------------------------------------------------
+bool ZCounting::isElectronTriggerObj(ZCountingTrigger::TTrigger triggerMenu, TriggerObjects hltMatchBits)
+{
+  return triggerMenu.passObj("HLT_Ele35_WPTight_Gsf_v*","hltEle35noerWPTightGsfTrackIsoFilter",hltMatchBits);
+}
 DEFINE_FWK_MODULE(ZCounting);

--- a/DQMOffline/Lumi/plugins/ZCounting.cc
+++ b/DQMOffline/Lumi/plugins/ZCounting.cc
@@ -646,15 +646,15 @@ void ZCounting::analyzeElectrons(const edm::Event& iEvent, const edm::EventSetup
 
 bool ZCounting::ele_probe_selection(double pt, double abseta){
   if(pt < ELE_PT_CUT_PROBE) return false;
-  else if(abseta > ELE_ETA_CUT_PROBE) return false;
-  else if( (abseta > ELE_ETA_CRACK_LOW) and (abseta < ELE_ETA_CRACK_HIGH) ) return false;
-  else return true;
+  if(abseta > ELE_ETA_CUT_PROBE) return false;
+  if( (abseta > ELE_ETA_CRACK_LOW) and (abseta < ELE_ETA_CRACK_HIGH) ) return false;
+  return true;
 }
 bool ZCounting::ele_tag_selection(double pt, double abseta){
   if(pt < ELE_PT_CUT_TAG) return false;
-  else if(abseta > ELE_ETA_CUT_TAG) return false;
-  else if( (abseta > ELE_ETA_CRACK_LOW) and (abseta < ELE_ETA_CRACK_HIGH) ) return false;
-  else return true;
+  if(abseta > ELE_ETA_CUT_TAG) return false;
+  if( (abseta > ELE_ETA_CRACK_LOW) and (abseta < ELE_ETA_CRACK_HIGH) ) return false;
+  return true;
 }
 //
 // -------------------------------------- endLuminosityBlock --------------------------------------------

--- a/DQMOffline/Lumi/plugins/ZCounting.cc
+++ b/DQMOffline/Lumi/plugins/ZCounting.cc
@@ -569,7 +569,7 @@ void ZCounting::analyzeElectrons(const edm::Event& iEvent, const edm::EventSetup
       if(eleProbe.isNonnull()){
         vProbe.SetPtEtaPhiM( eleProbe->pt(), eleProbe->eta(), eleProbe->phi(), ELECTRON_MASS);
       } else {
-        double pt = sc->energy() * TMath::Sqrt( 1 - pow(TMath::TanH(sc->eta()),2) );
+        double pt = sc->energy() * sqrt( 1 - pow(tanh(sc->eta()),2) );
         vProbe.SetPtEtaPhiM( pt, sc->eta(), sc->phi(), ELECTRON_MASS);
       }
 

--- a/DQMOffline/Lumi/plugins/ZCounting.cc
+++ b/DQMOffline/Lumi/plugins/ZCounting.cc
@@ -643,19 +643,18 @@ void ZCounting::analyzeElectrons(const edm::Event& iEvent, const edm::EventSetup
   }//End of tag loop
 
 }
+
 bool ZCounting::ele_probe_selection(double pt, double abseta){
-  bool pass = true;
-  pass &= pt > ELE_PT_CUT_PROBE;
-  pass &= abseta < ELE_ETA_CUT_PROBE;
-  pass &= (abseta < ELE_ETA_CRACK_LOW) or (abseta > ELE_ETA_CRACK_HIGH);
-  return pass;
+  if(pt < ELE_PT_CUT_PROBE) return false;
+  else if(abseta > ELE_ETA_CUT_PROBE) return false;
+  else if( (abseta > ELE_ETA_CRACK_LOW) and (abseta < ELE_ETA_CRACK_HIGH) ) return false;
+  else return true;
 }
 bool ZCounting::ele_tag_selection(double pt, double abseta){
-  bool pass = true;
-  pass &= pt > ELE_PT_CUT_TAG;
-  pass &= abseta < ELE_ETA_CUT_TAG;
-  pass &= (abseta < ELE_ETA_CRACK_LOW) or (abseta > ELE_ETA_CRACK_HIGH);
-  return pass;
+  if(pt < ELE_PT_CUT_TAG) return false;
+  else if(abseta > ELE_ETA_CUT_TAG) return false;
+  else if( (abseta > ELE_ETA_CRACK_LOW) and (abseta < ELE_ETA_CRACK_HIGH) ) return false;
+  else return true;
 }
 //
 // -------------------------------------- endLuminosityBlock --------------------------------------------

--- a/DQMOffline/Lumi/plugins/ZCounting.cc
+++ b/DQMOffline/Lumi/plugins/ZCounting.cc
@@ -519,9 +519,7 @@ void ZCounting::analyzeElectrons(const edm::Event& iEvent, const edm::EventSetup
   iEvent.getByToken(fConversionToken, conversionsHandle);
   EleID_.setConversions(conversionsHandle);
 
-  TLorentzVector vTag(0.,0.,0.,0.);
-  TLorentzVector vProbe(0.,0.,0.,0.);
-  TLorentzVector vDilep(0.,0.,0.,0.);
+
   edm::Ptr<reco::GsfElectron> eleProbe;
   enum { eEleEle2HLT=1, eEleEle1HLT1L1, eEleEle1HLT, eEleEleNoSel, eEleSC };  // event category enum
 
@@ -535,6 +533,7 @@ void ZCounting::analyzeElectrons(const edm::Event& iEvent, const edm::EventSetup
     float phi1 = el1->phi();
 
     if(!isElectronTriggerObj(*fTrigger, TriggerTools::matchHLT(eta1, phi1, fTrigger->fRecords, *hTrgEvt))) continue;
+    TLorentzVector vTag(0.,0.,0.,0.);
     vTag.SetPtEtaPhiM(pt1, eta1, phi1, ELECTRON_MASS);
 
 
@@ -566,6 +565,7 @@ void ZCounting::analyzeElectrons(const edm::Event& iEvent, const edm::EventSetup
       }
 
       // Assign final probe 4-vector
+      TLorentzVector vProbe(0.,0.,0.,0.);
       if(eleProbe.isNonnull()){
         vProbe.SetPtEtaPhiM( eleProbe->pt(), eleProbe->eta(), eleProbe->phi(), ELECTRON_MASS);
       } else {
@@ -582,7 +582,7 @@ void ZCounting::analyzeElectrons(const edm::Event& iEvent, const edm::EventSetup
       // Good Probe found!
 
       // Require good Z
-      vDilep = vTag + vProbe;
+      TLorentzVector vDilep = vTag + vProbe;
       float MASS_LOW = 80.0;
       float MASS_HIGH = 100.0;
       if((vDilep.M()<MASS_LOW) || (vDilep.M()>MASS_HIGH)) continue;

--- a/DQMOffline/Lumi/plugins/ZCounting.cc
+++ b/DQMOffline/Lumi/plugins/ZCounting.cc
@@ -489,7 +489,7 @@ void ZCounting::analyzeElectrons(const edm::Event& iEvent, const edm::EventSetup
   for(unsigned int irec=0; irec<fTrigger->fRecords.size(); irec++) {
     if(fTrigger->fRecords[irec].hltPathIndex == (unsigned int)-1) continue;
     if(hTrgRes->accept(fTrigger->fRecords[irec].hltPathIndex)) {
-      triggerBits [fTrigger->fRecords[irec].baconTrigBit] = 1;
+      triggerBits [fTrigger->fRecords[irec].baconTrigBit] = true;
     }
   }
 

--- a/DQMOffline/Lumi/plugins/ZCounting.h
+++ b/DQMOffline/Lumi/plugins/ZCounting.h
@@ -148,6 +148,9 @@ private:
   const Double_t ELE_PT_CUT_PROBE;
   const Double_t ELE_ETA_CUT_TAG;
   const Double_t ELE_ETA_CUT_PROBE;
+  const Double_t ELE_MASS_CUT_LOW;
+  const Double_t ELE_MASS_CUT_HIGH;
+
   const std::string ELE_ID_WP;
   const Double_t ELE_ETA_CRACK_LOW = 1.4442;
   const Double_t ELE_ETA_CRACK_HIGH = 1.56;

--- a/DQMOffline/Lumi/plugins/ZCounting.h
+++ b/DQMOffline/Lumi/plugins/ZCounting.h
@@ -142,18 +142,18 @@ private:
   const double MUON_BOUND = 0.9;
 
 
-  const Double_t ELECTRON_MASS  = 0.000511;
+  const float ELECTRON_MASS  = 0.000511;
 
-  const Double_t ELE_PT_CUT_TAG;
-  const Double_t ELE_PT_CUT_PROBE;
-  const Double_t ELE_ETA_CUT_TAG;
-  const Double_t ELE_ETA_CUT_PROBE;
-  const Double_t ELE_MASS_CUT_LOW;
-  const Double_t ELE_MASS_CUT_HIGH;
+  const float ELE_PT_CUT_TAG;
+  const float ELE_PT_CUT_PROBE;
+  const float ELE_ETA_CUT_TAG;
+  const float ELE_ETA_CUT_PROBE;
+  const float ELE_MASS_CUT_LOW;
+  const float ELE_MASS_CUT_HIGH;
 
   const std::string ELE_ID_WP;
-  const Double_t ELE_ETA_CRACK_LOW = 1.4442;
-  const Double_t ELE_ETA_CRACK_HIGH = 1.56;
+  const float ELE_ETA_CRACK_LOW = 1.4442;
+  const float ELE_ETA_CRACK_HIGH = 1.56;
   // Electron-specific members
   ElectronIdentifier EleID_;
 

--- a/DQMOffline/Lumi/plugins/ZCounting.h
+++ b/DQMOffline/Lumi/plugins/ZCounting.h
@@ -25,6 +25,7 @@
 #include "DQMOffline/Lumi/interface/TriggerDefs.h"
 #include "DQMOffline/Lumi/interface/TTrigger.h"
 #include "DQMOffline/Lumi/interface/TriggerTools.h"
+#include "DQMOffline/Lumi/interface/ElectronIdentifier.h"
 
 class TFile;
 class TH1D;
@@ -58,10 +59,18 @@ protected:
 
 private:
   //other functions
+  void analyzeMuons(edm::Event const& e, edm::EventSetup const& eSetup);
+  void analyzeElectrons(edm::Event const& e, edm::EventSetup const& eSetup);
   bool isMuonTrigger(const ZCountingTrigger::TTrigger &triggerMenu, const TriggerBits &hltBits);
   bool isMuonTriggerObj(const ZCountingTrigger::TTrigger &triggerMenu, const TriggerObjects &hltMatchBits);
   bool passMuonID(const reco::Muon& muon, const reco::Vertex& vtx, const MuonIDTypes &idType);
   bool passMuonIso(const reco::Muon& muon, const MuonIsoTypes &isoType, const float isoCut);
+
+  // Electron-specific functions
+  bool isElectronTrigger(ZCountingTrigger::TTrigger triggerMenu, TriggerBits hltBits);
+  bool isElectronTriggerObj(ZCountingTrigger::TTrigger triggerMenu, TriggerObjects hltMatchBits);
+  bool ele_probe_selection(double pt, double abseta);
+  bool ele_tag_selection(double pt, double abseta);
 
   // initialization from HLT menu; needs to be called on every change in HLT menu
   void initHLT(const edm::TriggerResults&, const edm::TriggerNames&);
@@ -78,6 +87,25 @@ private:
   edm::EDGetTokenT<reco::MuonCollection> fMuonName_token;
   std::string fTrackName;
   edm::EDGetTokenT<reco::TrackCollection> fTrackName_token;
+
+  // Electrons
+  std::string fElectronName;
+  edm::EDGetTokenT<edm::View<reco::GsfElectron>> fGsfElectronName_token;
+  std::string fSCName;
+  edm::EDGetTokenT<edm::View<reco::SuperCluster>> fSCName_token;
+
+
+
+  edm::InputTag fRhoTag;
+  edm::EDGetTokenT<double> fRhoToken;
+
+  edm::InputTag fBeamspotTag;
+  edm::EDGetTokenT<reco::BeamSpot> fBeamspotToken;
+
+  edm::InputTag fConversionTag;
+  edm::EDGetTokenT<reco::ConversionCollection> fConversionToken;
+
+
 
   // bacon fillers
   std::unique_ptr<ZCountingTrigger::TTrigger> fTrigger;
@@ -113,7 +141,21 @@ private:
   const double MUON_MASS  = 0.105658369;
   const double MUON_BOUND = 0.9;
 
-  // Histograms
+
+  const Double_t ELECTRON_MASS  = 0.000511;
+
+  const Double_t ELE_PT_CUT_TAG;
+  const Double_t ELE_PT_CUT_PROBE;
+  const Double_t ELE_ETA_CUT_TAG;
+  const Double_t ELE_ETA_CUT_PROBE;
+  const std::string ELE_ID_WP;
+  const Double_t ELE_ETA_CRACK_LOW = 1.4442;
+  const Double_t ELE_ETA_CRACK_HIGH = 1.56;
+  // Electron-specific members
+  ElectronIdentifier EleID_;
+
+
+  // Muon Histograms
   MonitorElement* h_mass_HLT_pass_central;
   MonitorElement* h_mass_HLT_pass_forward;
   MonitorElement* h_mass_HLT_fail_central;
@@ -133,6 +175,22 @@ private:
   MonitorElement* h_yield_Z;
   MonitorElement* h_yieldBB_Z;
   MonitorElement* h_yieldEE_Z;
+
+  // Electron Histograms
+  MonitorElement* h_ee_mass_id_pass_central;
+  MonitorElement* h_ee_mass_id_fail_central;
+  MonitorElement* h_ee_mass_id_pass_forward;
+  MonitorElement* h_ee_mass_id_fail_forward;
+
+  MonitorElement* h_ee_mass_HLT_pass_central;
+  MonitorElement* h_ee_mass_HLT_fail_central;
+  MonitorElement* h_ee_mass_HLT_pass_forward;
+  MonitorElement* h_ee_mass_HLT_fail_forward;
+
+
+  MonitorElement * h_ee_yield_Z_ebeb;
+  MonitorElement * h_ee_yield_Z_ebee;
+  MonitorElement * h_ee_yield_Z_eeee;
 };
 
 

--- a/DQMOffline/Lumi/python/ZCounting_cff.py
+++ b/DQMOffline/Lumi/python/ZCounting_cff.py
@@ -7,6 +7,15 @@ zcounting = cms.EDAnalyzer('ZCounting',
                                  edmName       = cms.untracked.string('muons'),
                                  edmTrackName = cms.untracked.string('generalTracks'),
 
+                                 edmGsfEleName = cms.untracked.string('gedGsfElectrons'),
+                                 edmSCName = cms.untracked.string('particleFlowEGamma'),
+
+                                 effAreasConfigFile = cms.FileInPath("RecoEgamma/ElectronIdentification/data/Summer16/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_80X.txt"),
+
+                                 rhoname = cms.InputTag('fixedGridRhoFastjetAll'),
+                                 beamspotName = cms.InputTag('offlineBeamSpot'),
+                                 conversionsName = cms.InputTag('conversions'),
+
                                  IDType   = cms.untracked.string("Tight"),# Tight, Medium, Loose
                                  IsoType  = cms.untracked.string("NULL"),  # Tracker-based, PF-based
                                  IsoCut   = cms.untracked.double(0.),     # {0.05, 0.10} for Tracker-based, {0.15, 0.25} for PF-based
@@ -15,6 +24,13 @@ zcounting = cms.EDAnalyzer('ZCounting',
                                  PtCutL2  = cms.untracked.double(30.0),
                                  EtaCutL1 = cms.untracked.double(2.4),
                                  EtaCutL2 = cms.untracked.double(2.4),
+
+                                 PtCutEleTag = cms.untracked.double(40.0),
+                                 PtCutEleProbe = cms.untracked.double(35.0),
+                                 EtaCutEleTag = cms.untracked.double(2.5),
+                                 EtaCutEleProbe = cms.untracked.double(2.5),
+
+                                 ElectronIDType = cms.untracked.string("TIGHT"),
 
                                  MassBin  = cms.untracked.int32(50),
                                  MassMin  = cms.untracked.double(66.0),

--- a/DQMOffline/Lumi/python/ZCounting_cff.py
+++ b/DQMOffline/Lumi/python/ZCounting_cff.py
@@ -29,6 +29,8 @@ zcounting = cms.EDAnalyzer('ZCounting',
                                  PtCutEleProbe = cms.untracked.double(35.0),
                                  EtaCutEleTag = cms.untracked.double(2.5),
                                  EtaCutEleProbe = cms.untracked.double(2.5),
+                                 MassCutEleLow = cms.untracked.double(80.0),
+                                 MassCutEleHigh = cms.untracked.double(100.0),
 
                                  ElectronIDType = cms.untracked.string("TIGHT"),
 

--- a/DQMOffline/Lumi/src/ElectronIdentifier.cc
+++ b/DQMOffline/Lumi/src/ElectronIdentifier.cc
@@ -151,22 +151,16 @@ bool ElectronIdentifier::passID(const reco::GsfElectronPtr& ele,edm::Handle<reco
    if(ID_ == -1) throw;
    unsigned int region = fabs(ele->superCluster()->eta()) < 1.479 ? EleIDEtaBins::BARREL : EleIDEtaBins::BARREL;
 
-   bool pass = true;
+   if( ele->full5x5_sigmaIetaIeta()                     > cuts_[EleIDCutNames::SIGMAIETA][ID_][region]) return false;
+   if( dEtaInSeed(ele)                                  > cuts_[EleIDCutNames::DETAINSEED][ID_][region]) return false;
+   if( std::abs(ele->deltaPhiSuperClusterTrackAtVtx())  > cuts_[EleIDCutNames::DPHIIN][ID_][region]) return false;
+   if( ele->hadronicOverEm()                            > cuts_[EleIDCutNames::HOVERE][ID_][region]) return false;
+   if( isolation(ele)/ele->pt()                         > cuts_[EleIDCutNames::ISO][ID_][region]) return false;
+   if( std::abs(1.0 - ele->eSuperClusterOverP())/ele->ecalEnergy()  > cuts_[EleIDCutNames::ONEOVERE][ID_][region]) return false;
+   if( (ele->gsfTrack()->hitPattern().numberOfAllHits(reco::HitPattern::MISSING_INNER_HITS)) > cuts_[EleIDCutNames::MISSINGHITS][ID_][region]) return false;
+   if( ConversionTools::hasMatchedConversion(*ele,conversions,beamspot->position())) return false;
 
-   std::vector<bool> passes;
-   passes.push_back( ele->full5x5_sigmaIetaIeta()                     < cuts_[EleIDCutNames::SIGMAIETA][ID_][region]);
-   passes.push_back( dEtaInSeed(ele)                                  < cuts_[EleIDCutNames::DETAINSEED][ID_][region]);
-   passes.push_back( std::abs(ele->deltaPhiSuperClusterTrackAtVtx())  < cuts_[EleIDCutNames::DPHIIN][ID_][region]);
-   passes.push_back( ele->hadronicOverEm()                            < cuts_[EleIDCutNames::HOVERE][ID_][region]);
-   passes.push_back( isolation(ele)/ele->pt()                         < cuts_[EleIDCutNames::ISO][ID_][region]);
-   passes.push_back( std::abs(1.0 - ele->eSuperClusterOverP())/ele->ecalEnergy()  < cuts_[EleIDCutNames::ONEOVERE][ID_][region]);
-   passes.push_back( (ele->gsfTrack()->hitPattern().numberOfAllHits(reco::HitPattern::MISSING_INNER_HITS)) <= cuts_[EleIDCutNames::MISSINGHITS][ID_][region]);
-   passes.push_back( !ConversionTools::hasMatchedConversion(*ele,conversions,beamspot->position()));
-
-   for (auto const p:passes) {
-      pass &= p;
-   }
-   return pass;
+   return true;
 }
 
 

--- a/DQMOffline/Lumi/src/ElectronIdentifier.cc
+++ b/DQMOffline/Lumi/src/ElectronIdentifier.cc
@@ -1,0 +1,188 @@
+#include "DQMOffline/Lumi/interface/ElectronIdentifier.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "FWCore/Utilities/interface/RegexMatch.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonSelectors.h"
+
+#include "DataFormats/EgammaCandidates/interface/Electron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
+
+#include "DQMOffline/Lumi/interface/TTrigger.h"
+#include "DQMOffline/Lumi/interface/TriggerTools.h"
+
+#include <boost/foreach.hpp>
+#include <TLorentzVector.h>
+#include <TMath.h>
+#include <algorithm>
+
+ElectronIdentifier::ElectronIdentifier (const edm::ParameterSet& c) :
+   _effectiveAreas( (c.getParameter<edm::FileInPath>("effAreasConfigFile")).fullPath())
+
+{
+   rho_ = -1;
+   ID_ = "NULL";
+   cuts_["SIGMAIETA"]["VETO"]  ["BARREL"] = 0.0115;
+   cuts_["SIGMAIETA"]["LOOSE"] ["BARREL"] = 0.011;
+   cuts_["SIGMAIETA"]["MEDIUM"]["BARREL"] = 0.00998;
+   cuts_["SIGMAIETA"]["TIGHT"] ["BARREL"] = 0.00998;
+
+   cuts_["SIGMAIETA"]["VETO"]  ["ENDCAP"] = 0.037;
+   cuts_["SIGMAIETA"]["LOOSE"] ["ENDCAP"] = 0.0314;
+   cuts_["SIGMAIETA"]["MEDIUM"]["ENDCAP"] = 0.0298;
+   cuts_["SIGMAIETA"]["TIGHT"] ["ENDCAP"] = 0.0292;
+
+   cuts_["DETAINSEED"]["VETO"]  ["BARREL"] = 0.00749;
+   cuts_["DETAINSEED"]["LOOSE"] ["BARREL"] = 0.00477;
+   cuts_["DETAINSEED"]["MEDIUM"]["BARREL"] = 0.00311;
+   cuts_["DETAINSEED"]["TIGHT"] ["BARREL"] = 0.00308;
+
+   cuts_["DETAINSEED"]["VETO"]  ["ENDCAP"] = 0.00895;
+   cuts_["DETAINSEED"]["LOOSE"] ["ENDCAP"] = 0.00868;
+   cuts_["DETAINSEED"]["MEDIUM"]["ENDCAP"] = 0.00609;
+   cuts_["DETAINSEED"]["TIGHT"] ["ENDCAP"] = 0.00605;
+
+   cuts_["DPHIIN"]["VETO"]  ["BARREL"] = 0.228;
+   cuts_["DPHIIN"]["LOOSE"] ["BARREL"] = 	0.222;
+   cuts_["DPHIIN"]["MEDIUM"]["BARREL"] = 	0.103;
+   cuts_["DPHIIN"]["TIGHT"] ["BARREL"] = 	0.0816;
+
+   cuts_["DPHIIN"]["VETO"]  ["ENDCAP"] = 0.213;
+   cuts_["DPHIIN"]["LOOSE"] ["ENDCAP"] = 	0.213;
+   cuts_["DPHIIN"]["MEDIUM"]["ENDCAP"] = 	0.045;
+   cuts_["DPHIIN"]["TIGHT"] ["ENDCAP"] = 	0.0394;
+
+   cuts_["HOVERE"]["VETO"]  ["BARREL"] = 0.356;
+   cuts_["HOVERE"]["LOOSE"] ["BARREL"] = 	0.298;
+   cuts_["HOVERE"]["MEDIUM"]["BARREL"] = 0.253;
+   cuts_["HOVERE"]["TIGHT"] ["BARREL"] = 0.0414;
+
+   cuts_["HOVERE"]["VETO"]  ["ENDCAP"] = 0.211;
+   cuts_["HOVERE"]["LOOSE"] ["ENDCAP"] = 0.101;
+   cuts_["HOVERE"]["MEDIUM"]["ENDCAP"] = 0.0878;
+   cuts_["HOVERE"]["TIGHT"] ["ENDCAP"] = 0.0641;
+
+   cuts_["ISO"]["VETO"]  ["BARREL"] = 0.175;
+   cuts_["ISO"]["LOOSE"] ["BARREL"] = 0.0994;
+   cuts_["ISO"]["MEDIUM"]["BARREL"] = 	0.0695;
+   cuts_["ISO"]["TIGHT"] ["BARREL"] = 	0.0588;
+
+   cuts_["ISO"]["VETO"]  ["ENDCAP"] = 0.159;
+   cuts_["ISO"]["LOOSE"] ["ENDCAP"] = 	0.107;
+   cuts_["ISO"]["MEDIUM"]["ENDCAP"] = 	0.0821;
+   cuts_["ISO"]["TIGHT"] ["ENDCAP"] = 	0.0571;
+
+   cuts_["1OVERE"]["VETO"]  ["BARREL"] = 0.299;
+   cuts_["1OVERE"]["LOOSE"] ["BARREL"] = 0.241;
+   cuts_["1OVERE"]["MEDIUM"]["BARREL"] = 0.134;
+   cuts_["1OVERE"]["TIGHT"] ["BARREL"] = 0.0129;
+
+   cuts_["1OVERE"]["VETO"]  ["ENDCAP"] = 0.15;
+   cuts_["1OVERE"]["LOOSE"] ["ENDCAP"] = 0.14;
+   cuts_["1OVERE"]["MEDIUM"]["ENDCAP"] = 0.13;
+   cuts_["1OVERE"]["TIGHT"] ["ENDCAP"] = 0.0129;
+
+   cuts_["MISSINGHITS"]["VETO"]  ["BARREL"] = 2;
+   cuts_["MISSINGHITS"]["LOOSE"] ["BARREL"] = 1;
+   cuts_["MISSINGHITS"]["MEDIUM"]["BARREL"] = 1;
+   cuts_["MISSINGHITS"]["TIGHT"] ["BARREL"] = 1;
+
+   cuts_["MISSINGHITS"]["VETO"]  ["ENDCAP"] = 3;
+   cuts_["MISSINGHITS"]["LOOSE"] ["ENDCAP"] = 1;
+   cuts_["MISSINGHITS"]["MEDIUM"]["ENDCAP"] = 1;
+   cuts_["MISSINGHITS"]["TIGHT"] ["ENDCAP"] = 1;
+
+   cuts_["CONVERSION"]["VETO"]  ["BARREL"] = 1;
+   cuts_["CONVERSION"]["LOOSE"] ["BARREL"] = 1;
+   cuts_["CONVERSION"]["MEDIUM"]["BARREL"] = 1;
+   cuts_["CONVERSION"]["TIGHT"] ["BARREL"] = 1;
+
+   cuts_["CONVERSION"]["VETO"]  ["ENDCAP"] = 1;
+   cuts_["CONVERSION"]["LOOSE"] ["ENDCAP"] = 1;
+   cuts_["CONVERSION"]["MEDIUM"]["ENDCAP"] = 1;
+   cuts_["CONVERSION"]["TIGHT"] ["ENDCAP"] = 1;
+}
+
+void ElectronIdentifier::setRho(double rho) {
+   if(rho >= 0) {
+      rho_ = rho;
+   } else {
+      throw;
+   }
+}
+void ElectronIdentifier::setID(std::string ID) {
+   bool is_available = true;
+   for (auto const cutmap : cuts_) {
+      bool tmp = false;
+      for( auto const item : cutmap.second ){
+            tmp |= (item.first == ID);
+      }
+      is_available &= tmp;
+   }
+   if(is_available){
+      ID_ = ID;
+   } else {
+      throw;
+   }
+}
+void ElectronIdentifier::setBeamspot(edm::Handle<reco::BeamSpot> beamspot) {
+   beamspot_ = beamspot;
+}
+void ElectronIdentifier::setConversions(edm::Handle<reco::ConversionCollection> conversions) {
+   conversions_ = conversions;
+}
+void ElectronIdentifier::loadEvent(const edm::Event& iEvent){
+   //~ iEvent.getByToken(fRhoToken, rho);
+}
+float ElectronIdentifier::dEtaInSeed(const reco::GsfElectronPtr& ele){
+         return ele->superCluster().isNonnull() && ele->superCluster()->seed().isNonnull() ?
+         ele->deltaEtaSuperClusterTrackAtVtx() - ele->superCluster()->eta() + ele->superCluster()->seed()->eta() : std::numeric_limits<float>::max();
+      }
+float ElectronIdentifier::isolation(const reco::GsfElectronPtr& ele) {
+  if(rho_ < 0 ) {
+     throw;
+  }
+  const reco::GsfElectron::PflowIsolationVariables& pfIso = ele->pfIsolationVariables();
+  const float chad = pfIso.sumChargedHadronPt;
+  const float nhad = pfIso.sumNeutralHadronEt;
+  const float pho = pfIso.sumPhotonEt;
+  const float  eA = _effectiveAreas.getEffectiveArea( fabs(ele->superCluster()->eta()) );
+  const float iso = chad + std::max(0.0, nhad + pho - rho_*eA);
+
+  // Apply the cut and return the result
+  // Scale by pT if the relative isolation is requested but avoid division by 0
+  return iso;
+}
+
+
+bool ElectronIdentifier::passID(const reco::GsfElectronPtr& ele) {
+   if(ID_ == "NULL") throw;
+   std::string region = fabs(ele->superCluster()->eta()) < 1.479 ? "BARREL" : "ENDCAP";
+
+   bool pass = true;
+
+   std::vector<bool> passes;
+   passes.push_back( ele->full5x5_sigmaIetaIeta()                     < cuts_["SIGMAIETA"][ID_][region]);
+   passes.push_back( dEtaInSeed(ele)                                  < cuts_["DETAINSEED"][ID_][region]);
+   passes.push_back( std::abs(ele->deltaPhiSuperClusterTrackAtVtx())  < cuts_["DPHIIN"][ID_][region]);
+   passes.push_back( ele->hadronicOverEm()                            < cuts_["HOVERE"][ID_][region]);
+   passes.push_back( isolation(ele)/ele->pt()                         < cuts_["ISO"][ID_][region]);
+   passes.push_back( std::abs(1.0 - ele->eSuperClusterOverP())/ele->ecalEnergy()  < cuts_["1OVERE"][ID_][region]);
+   passes.push_back( (ele->gsfTrack()->hitPattern().numberOfAllHits(reco::HitPattern::MISSING_INNER_HITS)) <= cuts_["MISSINGHITS"][ID_][region]);
+   passes.push_back( !ConversionTools::hasMatchedConversion(*ele,conversions_,beamspot_->position()));
+
+   for (auto const p:passes) {
+      pass &= p;
+   }
+   return pass;
+}
+
+
+
+

--- a/DQMOffline/Lumi/src/ElectronIdentifier.cc
+++ b/DQMOffline/Lumi/src/ElectronIdentifier.cc
@@ -113,7 +113,10 @@ void ElectronIdentifier::setRho(double rho) {
    if(rho >= 0) {
       rho_ = rho;
    } else {
-      throw;
+      throw cms::Exception("ValueError")
+         << "Encountered invalid value for energy density rho.\n"
+         << "Value: " << rho << "\n"
+         << "Rho should be a real, positive number.\n";
    }
 }
 void ElectronIdentifier::setID(std::string ID) {

--- a/DQMOffline/Lumi/src/ElectronIdentifier.cc
+++ b/DQMOffline/Lumi/src/ElectronIdentifier.cc
@@ -126,15 +126,6 @@ void ElectronIdentifier::setID(std::string ID) {
    else if(ID=="VETO") ID_ = EleIDWorkingPoints::VETO;
    else throw;
 }
-void ElectronIdentifier::setBeamspot(edm::Handle<reco::BeamSpot> beamspot) {
-   beamspot_ = beamspot;
-}
-void ElectronIdentifier::setConversions(edm::Handle<reco::ConversionCollection> conversions) {
-   conversions_ = conversions;
-}
-void ElectronIdentifier::loadEvent(const edm::Event& iEvent){
-   //~ iEvent.getByToken(fRhoToken, rho);
-}
 float ElectronIdentifier::dEtaInSeed(const reco::GsfElectronPtr& ele){
          return ele->superCluster().isNonnull() && ele->superCluster()->seed().isNonnull() ?
          ele->deltaEtaSuperClusterTrackAtVtx() - ele->superCluster()->eta() + ele->superCluster()->seed()->eta() : std::numeric_limits<float>::max();
@@ -156,7 +147,7 @@ float ElectronIdentifier::isolation(const reco::GsfElectronPtr& ele) {
 }
 
 
-bool ElectronIdentifier::passID(const reco::GsfElectronPtr& ele) {
+bool ElectronIdentifier::passID(const reco::GsfElectronPtr& ele,edm::Handle<reco::BeamSpot> beamspot,edm::Handle<reco::ConversionCollection> conversions) {
    if(ID_ == -1) throw;
    unsigned int region = fabs(ele->superCluster()->eta()) < 1.479 ? EleIDEtaBins::BARREL : EleIDEtaBins::BARREL;
 
@@ -170,7 +161,7 @@ bool ElectronIdentifier::passID(const reco::GsfElectronPtr& ele) {
    passes.push_back( isolation(ele)/ele->pt()                         < cuts_[EleIDCutNames::ISO][ID_][region]);
    passes.push_back( std::abs(1.0 - ele->eSuperClusterOverP())/ele->ecalEnergy()  < cuts_[EleIDCutNames::ONEOVERE][ID_][region]);
    passes.push_back( (ele->gsfTrack()->hitPattern().numberOfAllHits(reco::HitPattern::MISSING_INNER_HITS)) <= cuts_[EleIDCutNames::MISSINGHITS][ID_][region]);
-   passes.push_back( !ConversionTools::hasMatchedConversion(*ele,conversions_,beamspot_->position()));
+   passes.push_back( !ConversionTools::hasMatchedConversion(*ele,conversions,beamspot->position()));
 
    for (auto const p:passes) {
       pass &= p;

--- a/DQMOffline/Lumi/src/ElectronIdentifier.cc
+++ b/DQMOffline/Lumi/src/ElectronIdentifier.cc
@@ -27,86 +27,86 @@ ElectronIdentifier::ElectronIdentifier (const edm::ParameterSet& c) :
 
 {
    rho_ = -1;
-   ID_ = "NULL";
-   cuts_["SIGMAIETA"]["VETO"]  ["BARREL"] = 0.0115;
-   cuts_["SIGMAIETA"]["LOOSE"] ["BARREL"] = 0.011;
-   cuts_["SIGMAIETA"]["MEDIUM"]["BARREL"] = 0.00998;
-   cuts_["SIGMAIETA"]["TIGHT"] ["BARREL"] = 0.00998;
+   ID_ = -1;
+   cuts_[EleIDCutNames::SIGMAIETA][EleIDWorkingPoints::VETO]  [EleIDEtaBins::BARREL] = 0.0115;
+   cuts_[EleIDCutNames::SIGMAIETA][EleIDWorkingPoints::LOOSE] [EleIDEtaBins::BARREL] = 0.011;
+   cuts_[EleIDCutNames::SIGMAIETA][EleIDWorkingPoints::MEDIUM][EleIDEtaBins::BARREL] = 0.00998;
+   cuts_[EleIDCutNames::SIGMAIETA][EleIDWorkingPoints::TIGHT] [EleIDEtaBins::BARREL] = 0.00998;
 
-   cuts_["SIGMAIETA"]["VETO"]  ["ENDCAP"] = 0.037;
-   cuts_["SIGMAIETA"]["LOOSE"] ["ENDCAP"] = 0.0314;
-   cuts_["SIGMAIETA"]["MEDIUM"]["ENDCAP"] = 0.0298;
-   cuts_["SIGMAIETA"]["TIGHT"] ["ENDCAP"] = 0.0292;
+   cuts_[EleIDCutNames::SIGMAIETA][EleIDWorkingPoints::VETO]  [EleIDEtaBins::ENDCAP] = 0.037;
+   cuts_[EleIDCutNames::SIGMAIETA][EleIDWorkingPoints::LOOSE] [EleIDEtaBins::ENDCAP] = 0.0314;
+   cuts_[EleIDCutNames::SIGMAIETA][EleIDWorkingPoints::MEDIUM][EleIDEtaBins::ENDCAP] = 0.0298;
+   cuts_[EleIDCutNames::SIGMAIETA][EleIDWorkingPoints::TIGHT] [EleIDEtaBins::ENDCAP] = 0.0292;
 
-   cuts_["DETAINSEED"]["VETO"]  ["BARREL"] = 0.00749;
-   cuts_["DETAINSEED"]["LOOSE"] ["BARREL"] = 0.00477;
-   cuts_["DETAINSEED"]["MEDIUM"]["BARREL"] = 0.00311;
-   cuts_["DETAINSEED"]["TIGHT"] ["BARREL"] = 0.00308;
+   cuts_[EleIDCutNames::DETAINSEED][EleIDWorkingPoints::VETO]  [EleIDEtaBins::BARREL] = 0.00749;
+   cuts_[EleIDCutNames::DETAINSEED][EleIDWorkingPoints::LOOSE] [EleIDEtaBins::BARREL] = 0.00477;
+   cuts_[EleIDCutNames::DETAINSEED][EleIDWorkingPoints::MEDIUM][EleIDEtaBins::BARREL] = 0.00311;
+   cuts_[EleIDCutNames::DETAINSEED][EleIDWorkingPoints::TIGHT] [EleIDEtaBins::BARREL] = 0.00308;
 
-   cuts_["DETAINSEED"]["VETO"]  ["ENDCAP"] = 0.00895;
-   cuts_["DETAINSEED"]["LOOSE"] ["ENDCAP"] = 0.00868;
-   cuts_["DETAINSEED"]["MEDIUM"]["ENDCAP"] = 0.00609;
-   cuts_["DETAINSEED"]["TIGHT"] ["ENDCAP"] = 0.00605;
+   cuts_[EleIDCutNames::DETAINSEED][EleIDWorkingPoints::VETO]  [EleIDEtaBins::ENDCAP] = 0.00895;
+   cuts_[EleIDCutNames::DETAINSEED][EleIDWorkingPoints::LOOSE] [EleIDEtaBins::ENDCAP] = 0.00868;
+   cuts_[EleIDCutNames::DETAINSEED][EleIDWorkingPoints::MEDIUM][EleIDEtaBins::ENDCAP] = 0.00609;
+   cuts_[EleIDCutNames::DETAINSEED][EleIDWorkingPoints::TIGHT] [EleIDEtaBins::ENDCAP] = 0.00605;
 
-   cuts_["DPHIIN"]["VETO"]  ["BARREL"] = 0.228;
-   cuts_["DPHIIN"]["LOOSE"] ["BARREL"] = 	0.222;
-   cuts_["DPHIIN"]["MEDIUM"]["BARREL"] = 	0.103;
-   cuts_["DPHIIN"]["TIGHT"] ["BARREL"] = 	0.0816;
+   cuts_[EleIDCutNames::DPHIIN][EleIDWorkingPoints::VETO]  [EleIDEtaBins::BARREL] = 0.228;
+   cuts_[EleIDCutNames::DPHIIN][EleIDWorkingPoints::LOOSE] [EleIDEtaBins::BARREL] = 0.222;
+   cuts_[EleIDCutNames::DPHIIN][EleIDWorkingPoints::MEDIUM][EleIDEtaBins::BARREL] = 0.103;
+   cuts_[EleIDCutNames::DPHIIN][EleIDWorkingPoints::TIGHT] [EleIDEtaBins::BARREL] = 0.0816;
 
-   cuts_["DPHIIN"]["VETO"]  ["ENDCAP"] = 0.213;
-   cuts_["DPHIIN"]["LOOSE"] ["ENDCAP"] = 	0.213;
-   cuts_["DPHIIN"]["MEDIUM"]["ENDCAP"] = 	0.045;
-   cuts_["DPHIIN"]["TIGHT"] ["ENDCAP"] = 	0.0394;
+   cuts_[EleIDCutNames::DPHIIN][EleIDWorkingPoints::VETO]  [EleIDEtaBins::ENDCAP] = 0.213;
+   cuts_[EleIDCutNames::DPHIIN][EleIDWorkingPoints::LOOSE] [EleIDEtaBins::ENDCAP] = 0.213;
+   cuts_[EleIDCutNames::DPHIIN][EleIDWorkingPoints::MEDIUM][EleIDEtaBins::ENDCAP] = 0.045;
+   cuts_[EleIDCutNames::DPHIIN][EleIDWorkingPoints::TIGHT] [EleIDEtaBins::ENDCAP] = 0.0394;
 
-   cuts_["HOVERE"]["VETO"]  ["BARREL"] = 0.356;
-   cuts_["HOVERE"]["LOOSE"] ["BARREL"] = 	0.298;
-   cuts_["HOVERE"]["MEDIUM"]["BARREL"] = 0.253;
-   cuts_["HOVERE"]["TIGHT"] ["BARREL"] = 0.0414;
+   cuts_[EleIDCutNames::HOVERE][EleIDWorkingPoints::VETO]  [EleIDEtaBins::BARREL] = 0.356;
+   cuts_[EleIDCutNames::HOVERE][EleIDWorkingPoints::LOOSE] [EleIDEtaBins::BARREL] = 	0.298;
+   cuts_[EleIDCutNames::HOVERE][EleIDWorkingPoints::MEDIUM][EleIDEtaBins::BARREL] = 0.253;
+   cuts_[EleIDCutNames::HOVERE][EleIDWorkingPoints::TIGHT] [EleIDEtaBins::BARREL] = 0.0414;
 
-   cuts_["HOVERE"]["VETO"]  ["ENDCAP"] = 0.211;
-   cuts_["HOVERE"]["LOOSE"] ["ENDCAP"] = 0.101;
-   cuts_["HOVERE"]["MEDIUM"]["ENDCAP"] = 0.0878;
-   cuts_["HOVERE"]["TIGHT"] ["ENDCAP"] = 0.0641;
+   cuts_[EleIDCutNames::HOVERE][EleIDWorkingPoints::VETO]  [EleIDEtaBins::ENDCAP] = 0.211;
+   cuts_[EleIDCutNames::HOVERE][EleIDWorkingPoints::LOOSE] [EleIDEtaBins::ENDCAP] = 0.101;
+   cuts_[EleIDCutNames::HOVERE][EleIDWorkingPoints::MEDIUM][EleIDEtaBins::ENDCAP] = 0.0878;
+   cuts_[EleIDCutNames::HOVERE][EleIDWorkingPoints::TIGHT] [EleIDEtaBins::ENDCAP] = 0.0641;
 
-   cuts_["ISO"]["VETO"]  ["BARREL"] = 0.175;
-   cuts_["ISO"]["LOOSE"] ["BARREL"] = 0.0994;
-   cuts_["ISO"]["MEDIUM"]["BARREL"] = 	0.0695;
-   cuts_["ISO"]["TIGHT"] ["BARREL"] = 	0.0588;
+   cuts_[EleIDCutNames::ISO][EleIDWorkingPoints::VETO]  [EleIDEtaBins::BARREL] = 0.175;
+   cuts_[EleIDCutNames::ISO][EleIDWorkingPoints::LOOSE] [EleIDEtaBins::BARREL] = 0.0994;
+   cuts_[EleIDCutNames::ISO][EleIDWorkingPoints::MEDIUM][EleIDEtaBins::BARREL] = 0.0695;
+   cuts_[EleIDCutNames::ISO][EleIDWorkingPoints::TIGHT] [EleIDEtaBins::BARREL] = 0.0588;
 
-   cuts_["ISO"]["VETO"]  ["ENDCAP"] = 0.159;
-   cuts_["ISO"]["LOOSE"] ["ENDCAP"] = 	0.107;
-   cuts_["ISO"]["MEDIUM"]["ENDCAP"] = 	0.0821;
-   cuts_["ISO"]["TIGHT"] ["ENDCAP"] = 	0.0571;
+   cuts_[EleIDCutNames::ISO][EleIDWorkingPoints::VETO]  [EleIDEtaBins::ENDCAP] = 0.159;
+   cuts_[EleIDCutNames::ISO][EleIDWorkingPoints::LOOSE] [EleIDEtaBins::ENDCAP] = 0.107;
+   cuts_[EleIDCutNames::ISO][EleIDWorkingPoints::MEDIUM][EleIDEtaBins::ENDCAP] = 0.0821;
+   cuts_[EleIDCutNames::ISO][EleIDWorkingPoints::TIGHT] [EleIDEtaBins::ENDCAP] = 0.0571;
 
-   cuts_["1OVERE"]["VETO"]  ["BARREL"] = 0.299;
-   cuts_["1OVERE"]["LOOSE"] ["BARREL"] = 0.241;
-   cuts_["1OVERE"]["MEDIUM"]["BARREL"] = 0.134;
-   cuts_["1OVERE"]["TIGHT"] ["BARREL"] = 0.0129;
+   cuts_[EleIDCutNames::ONEOVERE][EleIDWorkingPoints::VETO]  [EleIDEtaBins::BARREL] = 0.299;
+   cuts_[EleIDCutNames::ONEOVERE][EleIDWorkingPoints::LOOSE] [EleIDEtaBins::BARREL] = 0.241;
+   cuts_[EleIDCutNames::ONEOVERE][EleIDWorkingPoints::MEDIUM][EleIDEtaBins::BARREL] = 0.134;
+   cuts_[EleIDCutNames::ONEOVERE][EleIDWorkingPoints::TIGHT] [EleIDEtaBins::BARREL] = 0.0129;
 
-   cuts_["1OVERE"]["VETO"]  ["ENDCAP"] = 0.15;
-   cuts_["1OVERE"]["LOOSE"] ["ENDCAP"] = 0.14;
-   cuts_["1OVERE"]["MEDIUM"]["ENDCAP"] = 0.13;
-   cuts_["1OVERE"]["TIGHT"] ["ENDCAP"] = 0.0129;
+   cuts_[EleIDCutNames::ONEOVERE][EleIDWorkingPoints::VETO]  [EleIDEtaBins::ENDCAP] = 0.15;
+   cuts_[EleIDCutNames::ONEOVERE][EleIDWorkingPoints::LOOSE] [EleIDEtaBins::ENDCAP] = 0.14;
+   cuts_[EleIDCutNames::ONEOVERE][EleIDWorkingPoints::MEDIUM][EleIDEtaBins::ENDCAP] = 0.13;
+   cuts_[EleIDCutNames::ONEOVERE][EleIDWorkingPoints::TIGHT] [EleIDEtaBins::ENDCAP] = 0.0129;
 
-   cuts_["MISSINGHITS"]["VETO"]  ["BARREL"] = 2;
-   cuts_["MISSINGHITS"]["LOOSE"] ["BARREL"] = 1;
-   cuts_["MISSINGHITS"]["MEDIUM"]["BARREL"] = 1;
-   cuts_["MISSINGHITS"]["TIGHT"] ["BARREL"] = 1;
+   cuts_[EleIDCutNames::MISSINGHITS][EleIDWorkingPoints::VETO]  [EleIDEtaBins::BARREL] = 2;
+   cuts_[EleIDCutNames::MISSINGHITS][EleIDWorkingPoints::LOOSE] [EleIDEtaBins::BARREL] = 1;
+   cuts_[EleIDCutNames::MISSINGHITS][EleIDWorkingPoints::MEDIUM][EleIDEtaBins::BARREL] = 1;
+   cuts_[EleIDCutNames::MISSINGHITS][EleIDWorkingPoints::TIGHT] [EleIDEtaBins::BARREL] = 1;
 
-   cuts_["MISSINGHITS"]["VETO"]  ["ENDCAP"] = 3;
-   cuts_["MISSINGHITS"]["LOOSE"] ["ENDCAP"] = 1;
-   cuts_["MISSINGHITS"]["MEDIUM"]["ENDCAP"] = 1;
-   cuts_["MISSINGHITS"]["TIGHT"] ["ENDCAP"] = 1;
+   cuts_[EleIDCutNames::MISSINGHITS][EleIDWorkingPoints::VETO]  [EleIDEtaBins::ENDCAP] = 3;
+   cuts_[EleIDCutNames::MISSINGHITS][EleIDWorkingPoints::LOOSE] [EleIDEtaBins::ENDCAP] = 1;
+   cuts_[EleIDCutNames::MISSINGHITS][EleIDWorkingPoints::MEDIUM][EleIDEtaBins::ENDCAP] = 1;
+   cuts_[EleIDCutNames::MISSINGHITS][EleIDWorkingPoints::TIGHT] [EleIDEtaBins::ENDCAP] = 1;
 
-   cuts_["CONVERSION"]["VETO"]  ["BARREL"] = 1;
-   cuts_["CONVERSION"]["LOOSE"] ["BARREL"] = 1;
-   cuts_["CONVERSION"]["MEDIUM"]["BARREL"] = 1;
-   cuts_["CONVERSION"]["TIGHT"] ["BARREL"] = 1;
+   cuts_[EleIDCutNames::CONVERSION][EleIDWorkingPoints::VETO]  [EleIDEtaBins::BARREL] = 1;
+   cuts_[EleIDCutNames::CONVERSION][EleIDWorkingPoints::LOOSE] [EleIDEtaBins::BARREL] = 1;
+   cuts_[EleIDCutNames::CONVERSION][EleIDWorkingPoints::MEDIUM][EleIDEtaBins::BARREL] = 1;
+   cuts_[EleIDCutNames::CONVERSION][EleIDWorkingPoints::TIGHT] [EleIDEtaBins::BARREL] = 1;
 
-   cuts_["CONVERSION"]["VETO"]  ["ENDCAP"] = 1;
-   cuts_["CONVERSION"]["LOOSE"] ["ENDCAP"] = 1;
-   cuts_["CONVERSION"]["MEDIUM"]["ENDCAP"] = 1;
-   cuts_["CONVERSION"]["TIGHT"] ["ENDCAP"] = 1;
+   cuts_[EleIDCutNames::CONVERSION][EleIDWorkingPoints::VETO]  [EleIDEtaBins::ENDCAP] = 1;
+   cuts_[EleIDCutNames::CONVERSION][EleIDWorkingPoints::LOOSE] [EleIDEtaBins::ENDCAP] = 1;
+   cuts_[EleIDCutNames::CONVERSION][EleIDWorkingPoints::MEDIUM][EleIDEtaBins::ENDCAP] = 1;
+   cuts_[EleIDCutNames::CONVERSION][EleIDWorkingPoints::TIGHT] [EleIDEtaBins::ENDCAP] = 1;
 }
 
 void ElectronIdentifier::setRho(double rho) {
@@ -117,19 +117,11 @@ void ElectronIdentifier::setRho(double rho) {
    }
 }
 void ElectronIdentifier::setID(std::string ID) {
-   bool is_available = true;
-   for (auto const cutmap : cuts_) {
-      bool tmp = false;
-      for( auto const item : cutmap.second ){
-            tmp |= (item.first == ID);
-      }
-      is_available &= tmp;
-   }
-   if(is_available){
-      ID_ = ID;
-   } else {
-      throw;
-   }
+   if(ID=="TIGHT") ID_ = EleIDWorkingPoints::TIGHT;
+   else if(ID=="MEDIUM") ID_ = EleIDWorkingPoints::MEDIUM;
+   else if(ID=="LOOSE") ID_ = EleIDWorkingPoints::LOOSE;
+   else if(ID=="VETO") ID_ = EleIDWorkingPoints::VETO;
+   else throw;
 }
 void ElectronIdentifier::setBeamspot(edm::Handle<reco::BeamSpot> beamspot) {
    beamspot_ = beamspot;
@@ -162,19 +154,19 @@ float ElectronIdentifier::isolation(const reco::GsfElectronPtr& ele) {
 
 
 bool ElectronIdentifier::passID(const reco::GsfElectronPtr& ele) {
-   if(ID_ == "NULL") throw;
-   std::string region = fabs(ele->superCluster()->eta()) < 1.479 ? "BARREL" : "ENDCAP";
+   if(ID_ == -1) throw;
+   unsigned int region = fabs(ele->superCluster()->eta()) < 1.479 ? EleIDEtaBins::BARREL : EleIDEtaBins::BARREL;
 
    bool pass = true;
 
    std::vector<bool> passes;
-   passes.push_back( ele->full5x5_sigmaIetaIeta()                     < cuts_["SIGMAIETA"][ID_][region]);
-   passes.push_back( dEtaInSeed(ele)                                  < cuts_["DETAINSEED"][ID_][region]);
-   passes.push_back( std::abs(ele->deltaPhiSuperClusterTrackAtVtx())  < cuts_["DPHIIN"][ID_][region]);
-   passes.push_back( ele->hadronicOverEm()                            < cuts_["HOVERE"][ID_][region]);
-   passes.push_back( isolation(ele)/ele->pt()                         < cuts_["ISO"][ID_][region]);
-   passes.push_back( std::abs(1.0 - ele->eSuperClusterOverP())/ele->ecalEnergy()  < cuts_["1OVERE"][ID_][region]);
-   passes.push_back( (ele->gsfTrack()->hitPattern().numberOfAllHits(reco::HitPattern::MISSING_INNER_HITS)) <= cuts_["MISSINGHITS"][ID_][region]);
+   passes.push_back( ele->full5x5_sigmaIetaIeta()                     < cuts_[EleIDCutNames::SIGMAIETA][ID_][region]);
+   passes.push_back( dEtaInSeed(ele)                                  < cuts_[EleIDCutNames::DETAINSEED][ID_][region]);
+   passes.push_back( std::abs(ele->deltaPhiSuperClusterTrackAtVtx())  < cuts_[EleIDCutNames::DPHIIN][ID_][region]);
+   passes.push_back( ele->hadronicOverEm()                            < cuts_[EleIDCutNames::HOVERE][ID_][region]);
+   passes.push_back( isolation(ele)/ele->pt()                         < cuts_[EleIDCutNames::ISO][ID_][region]);
+   passes.push_back( std::abs(1.0 - ele->eSuperClusterOverP())/ele->ecalEnergy()  < cuts_[EleIDCutNames::ONEOVERE][ID_][region]);
+   passes.push_back( (ele->gsfTrack()->hitPattern().numberOfAllHits(reco::HitPattern::MISSING_INNER_HITS)) <= cuts_[EleIDCutNames::MISSINGHITS][ID_][region]);
    passes.push_back( !ConversionTools::hasMatchedConversion(*ele,conversions_,beamspot_->position()));
 
    for (auto const p:passes) {

--- a/DQMOffline/Lumi/src/TTrigger.cc
+++ b/DQMOffline/Lumi/src/TTrigger.cc
@@ -26,6 +26,10 @@ TTrigger::TTrigger() {
 
   fRecords.push_back(ZCountingTrigger::TriggerRecord("HLT_IsoMu27_v*",0));
   fRecords.back().objectMap.push_back(std::pair<std::string, int>("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07",0));    
+  fRecords.push_back(ZCountingTrigger::TriggerRecord("HLT_Ele35_WPTight_Gsf_v*",1));
+  fRecords.back().objectMap.push_back(std::pair<std::string, int>("hltEle35noerWPTightGsfTrackIsoFilter",0));
+  fRecords.push_back(ZCountingTrigger::TriggerRecord("HLT_Ele27_WPTight_Gsf_v*",2));
+  fRecords.back().objectMap.push_back(std::pair<std::string, int>("hltEle27WPTightGsfTrackIsoFilter",0));
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/DQMOffline/Lumi/test/ZCounting_cfg.py
+++ b/DQMOffline/Lumi/test/ZCounting_cfg.py
@@ -34,6 +34,7 @@ process.source = cms.Source("PoolSource",
 '/store/data/Run2017B/SingleMuon/RECO/PromptReco-v1/000/297/218/00000/14C84999-6457-E711-AAE4-02163E0136E0.root'
                                 )
                                 )
+
 process.source.inputCommands = cms.untracked.vstring("keep *",
                                                          "drop *_MEtoEDMConverter_*_*")
 
@@ -50,6 +51,15 @@ process.zcounting = cms.EDAnalyzer('ZCounting',
                                  edmName       = cms.untracked.string('muons'),
                                  edmTrackName = cms.untracked.string('generalTracks'),
 
+                                 edmGsfEleName = cms.untracked.string('gedGsfElectrons'),
+                                 edmSCName = cms.untracked.string('particleFlowEGamma'),
+
+                                 effAreasConfigFile = cms.FileInPath("RecoEgamma/ElectronIdentification/data/Summer16/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_80X.txt"),
+
+                                 rhoname = cms.InputTag('fixedGridRhoFastjetAll'),
+                                 beamspotName = cms.InputTag('offlineBeamSpot'),
+                                 conversionsName = cms.InputTag('conversions'),
+
                                  IDType   = cms.untracked.string("Tight"),# Tight, Medium, Loose
                                  IsoType  = cms.untracked.string("NULL"),  # Tracker-based, PF-based
                                  IsoCut   = cms.untracked.double(0.),     # {0.05, 0.10} for Tracker-based, {0.15, 0.25} for PF-based
@@ -58,6 +68,13 @@ process.zcounting = cms.EDAnalyzer('ZCounting',
                                  PtCutL2  = cms.untracked.double(30.0),
                                  EtaCutL1 = cms.untracked.double(2.4),
                                  EtaCutL2 = cms.untracked.double(2.4),
+
+                                 PtCutEleTag = cms.untracked.double(40.0),
+                                 PtCutEleProbe = cms.untracked.double(35.0),
+                                 EtaCutEleTag = cms.untracked.double(2.5),
+                                 EtaCutEleProbe = cms.untracked.double(2.5),
+
+                                 ElectronIDType = cms.untracked.string("TIGHT"),
 
                                  MassBin  = cms.untracked.int32(50),
                                  MassMin  = cms.untracked.double(66.0),

--- a/DQMOffline/Lumi/test/ZCounting_cfg.py
+++ b/DQMOffline/Lumi/test/ZCounting_cfg.py
@@ -73,6 +73,8 @@ process.zcounting = cms.EDAnalyzer('ZCounting',
                                  PtCutEleProbe = cms.untracked.double(35.0),
                                  EtaCutEleTag = cms.untracked.double(2.5),
                                  EtaCutEleProbe = cms.untracked.double(2.5),
+                                 MassCutEleLow = cms.untracked.double(80.0),
+                                 MassCutEleHigh = cms.untracked.double(100.0),
 
                                  ElectronIDType = cms.untracked.string("TIGHT"),
 


### PR DESCRIPTION
This is an extension of the existing Z->mumu counting to electrons. The muon code has been touched as little as possible. It was moved into a separate function in order to factorize the code.
Electron identification has to be implemented by hand since out-of-the-box VID code does not work on RECO tier.