### PR TITLE
Add method to return the significance of a track inside a Det

### DIFF
--- a/DataFormats/GeometrySurface/interface/Bounds.h
+++ b/DataFormats/GeometrySurface/interface/Bounds.h
@@ -65,6 +65,8 @@ public:
     return inside( Local3DPoint(p.x(), p.y(), 0), err, scale);
   }
 
+  virtual float howMuchInside(const Local3DPoint&, const LocalError&) const;
+
   virtual Bounds* clone() const = 0;
   
   std::pair<float,float> const & phiSpan() const { return m_span.phiSpan(); }

--- a/DataFormats/GeometrySurface/interface/Bounds.h
+++ b/DataFormats/GeometrySurface/interface/Bounds.h
@@ -65,7 +65,7 @@ public:
     return inside( Local3DPoint(p.x(), p.y(), 0), err, scale);
   }
 
-  virtual float howMuchInside(const Local3DPoint&, const LocalError&) const;
+  virtual float significanceInside(const Local3DPoint&, const LocalError&) const;
 
   virtual Bounds* clone() const = 0;
   

--- a/DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h
+++ b/DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h
@@ -55,7 +55,7 @@ public:
 
   bool inside( const Local2DPoint& p, const LocalError& err, float scale=1.f) const override;
 
-  float howMuchInside(const Local3DPoint&, const LocalError&) const override;
+  float significanceInside(const Local3DPoint&, const LocalError&) const override;
 
 
   // compatible of being inside or outside...

--- a/DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h
+++ b/DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h
@@ -55,7 +55,7 @@ public:
 
   bool inside( const Local2DPoint& p, const LocalError& err, float scale=1.f) const override;
 
-  float howMuchInside(const Local3DPoint&, const LocalError&) const;
+  float howMuchInside(const Local3DPoint&, const LocalError&) const override;
 
 
   // compatible of being inside or outside...

--- a/DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h
+++ b/DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h
@@ -55,6 +55,9 @@ public:
 
   virtual bool inside( const Local2DPoint& p, const LocalError& err, float scale=1.f) const;
 
+  float howMuchInside(const Local3DPoint&, const LocalError&) const;
+
+
   // compatible of being inside or outside...
  std::pair<bool,bool> inout( const Local3DPoint& p, const LocalError& err, float scale=1.f) const;
 

--- a/DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h
+++ b/DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h
@@ -51,7 +51,7 @@ public:
 
   bool inside( const Local2DPoint& p, const LocalError& err, float scale) const override;
 
-  float howMuchInside(const Local3DPoint&, const LocalError&) const override;
+  float significanceInside(const Local3DPoint&, const LocalError&) const override;
 
 
   /** returns the 4 parameters needed for construction, in the order

--- a/DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h
+++ b/DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h
@@ -51,7 +51,7 @@ public:
 
   bool inside( const Local2DPoint& p, const LocalError& err, float scale) const override;
 
-  float howMuchInside(const Local3DPoint&, const LocalError&) const;
+  float howMuchInside(const Local3DPoint&, const LocalError&) const override;
 
 
   /** returns the 4 parameters needed for construction, in the order

--- a/DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h
+++ b/DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h
@@ -51,6 +51,9 @@ public:
 
   virtual bool inside( const Local2DPoint& p, const LocalError& err, float scale) const;
 
+  float howMuchInside(const Local3DPoint&, const LocalError&) const;
+
+
   /** returns the 4 parameters needed for construction, in the order
    * ( half bottom edge, half top edge, half thickness, half apothem).
    * Beware! This order is different from the one in the constructor!

--- a/DataFormats/GeometrySurface/src/Bounds.cc
+++ b/DataFormats/GeometrySurface/src/Bounds.cc
@@ -1,0 +1,7 @@
+#include "DataFormats/GeometrySurface/interface/Bounds.h"
+#include "DataFormats/GeometrySurface/interface/GeomExceptions.h"
+
+float Bounds::howMuchInside(const Local3DPoint&, const LocalError&) const {
+    throw GeometryError("howMuchInside not implemented");
+}
+

--- a/DataFormats/GeometrySurface/src/Bounds.cc
+++ b/DataFormats/GeometrySurface/src/Bounds.cc
@@ -1,7 +1,7 @@
 #include "DataFormats/GeometrySurface/interface/Bounds.h"
 #include "DataFormats/GeometrySurface/interface/GeomExceptions.h"
 
-float Bounds::howMuchInside(const Local3DPoint&, const LocalError&) const {
+float Bounds::significanceInside(const Local3DPoint&, const LocalError&) const {
     throw GeometryError("howMuchInside not implemented");
 }
 

--- a/DataFormats/GeometrySurface/src/RectangularPlaneBounds.cc
+++ b/DataFormats/GeometrySurface/src/RectangularPlaneBounds.cc
@@ -25,7 +25,7 @@ bool RectangularPlaneBounds::inside( const Local2DPoint& p, const LocalError& er
       (std::abs(p.y()) < halfLength + std::sqrt(err.yy())*scale);
 }
 
-float RectangularPlaneBounds::howMuchInside(const Local3DPoint& p, const LocalError& err) const {
+float RectangularPlaneBounds::significanceInside(const Local3DPoint& p, const LocalError& err) const {
    return std::max((std::abs(p.x()) - halfWidth )/std::sqrt(err.xx()),
                    (std::abs(p.y()) - halfLength)/std::sqrt(err.yy())
                   );

--- a/DataFormats/GeometrySurface/src/RectangularPlaneBounds.cc
+++ b/DataFormats/GeometrySurface/src/RectangularPlaneBounds.cc
@@ -25,6 +25,12 @@ bool RectangularPlaneBounds::inside( const Local2DPoint& p, const LocalError& er
       (std::abs(p.y()) < halfLength + std::sqrt(err.yy())*scale);
 }
 
+float RectangularPlaneBounds::howMuchInside(const Local3DPoint& p, const LocalError& err) const {
+   return std::max((std::abs(p.x()) - halfWidth )/std::sqrt(err.xx()),
+                   (std::abs(p.y()) - halfLength)/std::sqrt(err.yy())
+                  );
+}
+
 
 std::pair<bool,bool> RectangularPlaneBounds::inout( const Local3DPoint& p, const LocalError& err, float scale) const {
   float xl = std::abs(p.x()) -  std::sqrt(err.xx())*scale;

--- a/DataFormats/GeometrySurface/src/TrapezoidalPlaneBounds.cc
+++ b/DataFormats/GeometrySurface/src/TrapezoidalPlaneBounds.cc
@@ -47,7 +47,7 @@ bool TrapezoidalPlaneBounds::inside( const Local2DPoint& p, const LocalError& er
 float TrapezoidalPlaneBounds::howMuchInside(const Local3DPoint& p, const LocalError& err) const {
    return std::max( 
                    (std::abs(p.y())-hapothem)/std::sqrt(err.yy()),
-                   (std::abs(p.x())-tan_a*std::abs(p.y()+offset))/std::sqrt(err.yy())
+                   (std::abs(p.x())-tan_a*std::abs(p.y()+offset))/std::sqrt(err.xx())
                   );
 }
 

--- a/DataFormats/GeometrySurface/src/TrapezoidalPlaneBounds.cc
+++ b/DataFormats/GeometrySurface/src/TrapezoidalPlaneBounds.cc
@@ -44,6 +44,15 @@ bool TrapezoidalPlaneBounds::inside( const Local2DPoint& p, const LocalError& er
   return Bounds::inside(p,err,scale);
 }
 
+float TrapezoidalPlaneBounds::howMuchInside(const Local3DPoint& p, const LocalError& err) const {
+   return std::max( 
+                   (std::abs(p.y())-hapothem)/std::sqrt(err.yy()),
+                   (std::abs(p.x())-tan_a*std::abs(p.y()+offset))/std::sqrt(err.yy())
+                  );
+}
+
+
+
 Bounds* TrapezoidalPlaneBounds::clone() const { 
   return new TrapezoidalPlaneBounds(*this);
 }

--- a/DataFormats/GeometrySurface/src/TrapezoidalPlaneBounds.cc
+++ b/DataFormats/GeometrySurface/src/TrapezoidalPlaneBounds.cc
@@ -44,7 +44,7 @@ bool TrapezoidalPlaneBounds::inside( const Local2DPoint& p, const LocalError& er
   return Bounds::inside(p,err,scale);
 }
 
-float TrapezoidalPlaneBounds::howMuchInside(const Local3DPoint& p, const LocalError& err) const {
+float TrapezoidalPlaneBounds::significanceInside(const Local3DPoint& p, const LocalError& err) const {
    return std::max( 
                    (std::abs(p.y())-hapothem)/std::sqrt(err.yy()),
                    (std::abs(p.x())-tan_a*std::abs(p.y()+offset))/std::sqrt(err.xx())

--- a/TrackingTools/MeasurementDet/src/LayerMeasurements.cc
+++ b/TrackingTools/MeasurementDet/src/LayerMeasurements.cc
@@ -187,7 +187,7 @@ void LayerMeasurements::addInvalidMeas( vector<TrajectoryMeasurement>& measVec,
   if (!measVec.empty()) {
     // invalidMeas on Det of most compatible hit
     auto const & ts = measVec.front().predictedState();
-    auto toll = measVec.front().recHitR().det()->surface().bounds().howMuchInside(ts.localPosition(),ts.localError().positionError());
+    auto toll = measVec.front().recHitR().det()->surface().bounds().significanceInside(ts.localPosition(),ts.localError().positionError());
     measVec.emplace_back(measVec.front().predictedState(), 
 			 std::make_shared<InvalidTrackingRecHit>(*measVec.front().recHitR().det(), TrackingRecHit::missing),
 			 toll,&layer);
@@ -195,7 +195,7 @@ void LayerMeasurements::addInvalidMeas( vector<TrajectoryMeasurement>& measVec,
   else if (!group.empty()) {
     // invalid state on first compatible Det
     auto const & ts = group.front().trajectoryState();
-    auto toll = group.front().det()->surface().bounds().howMuchInside(ts.localPosition(),ts.localError().positionError());
+    auto toll = group.front().det()->surface().bounds().significanceInside(ts.localPosition(),ts.localError().positionError());
       measVec.emplace_back(group.front().trajectoryState(), 
     			 std::make_shared<InvalidTrackingRecHit>(*group.front().det(), TrackingRecHit::missing), toll,&layer);
   }

--- a/TrackingTools/MeasurementDet/src/LayerMeasurements.cc
+++ b/TrackingTools/MeasurementDet/src/LayerMeasurements.cc
@@ -186,21 +186,17 @@ void LayerMeasurements::addInvalidMeas( vector<TrajectoryMeasurement>& measVec,
 {
   if (!measVec.empty()) {
     // invalidMeas on Det of most compatible hit
+    auto const & ts = measVec.front().predictedState();
+    auto toll = measVec.front().recHitR().det()->surface().bounds().howMuchInside(ts.localPosition(),ts.localError().positionError());
     measVec.emplace_back(measVec.front().predictedState(), 
-			 std::make_shared<InvalidTrackingRecHit>(*measVec.front().recHit()->det(), TrackingRecHit::missing),
-			 0.,&layer);
+			 std::make_shared<InvalidTrackingRecHit>(*measVec.front().recHitR().det(), TrackingRecHit::missing),
+			 toll,&layer);
   }
   else if (!group.empty()) {
     // invalid state on first compatible Det
     auto const & ts = group.front().trajectoryState();
-    if (ts.globalMomentum().perp2()<0.81f || 
-        group.front().det()->surface().bounds().inside(ts.localPosition(), 
-				   ts.localError().positionError(),-3))
+    auto toll = group.front().det()->surface().bounds().howMuchInside(ts.localPosition(),ts.localError().positionError());
       measVec.emplace_back(group.front().trajectoryState(), 
-    			 std::make_shared<InvalidTrackingRecHit>(*group.front().det(), TrackingRecHit::missing), 0.,&layer);
-    else
-      measVec.emplace_back(group.front().trajectoryState(),
-                         std::make_shared<InvalidTrackingRecHit>(*group.front().det(), TrackingRecHit::inactive), 0.,&layer);
-
+    			 std::make_shared<InvalidTrackingRecHit>(*group.front().det(), TrackingRecHit::missing), toll,&layer);
   }
 }

--- a/TrackingTools/MeasurementDet/src/LayerMeasurements.cc
+++ b/TrackingTools/MeasurementDet/src/LayerMeasurements.cc
@@ -192,7 +192,15 @@ void LayerMeasurements::addInvalidMeas( vector<TrajectoryMeasurement>& measVec,
   }
   else if (!group.empty()) {
     // invalid state on first compatible Det
-    measVec.emplace_back(group.front().trajectoryState(), 
-			 std::make_shared<InvalidTrackingRecHit>(*group.front().det(), TrackingRecHit::missing), 0.,&layer);
+    auto const & ts = group.front().trajectoryState();
+    if (ts.globalMomentum().perp2()<0.81f || 
+        group.front().det()->surface().bounds().inside(ts.localPosition(), 
+				   ts.localError().positionError(),-3))
+      measVec.emplace_back(group.front().trajectoryState(), 
+    			 std::make_shared<InvalidTrackingRecHit>(*group.front().det(), TrackingRecHit::missing), 0.,&layer);
+    else
+      measVec.emplace_back(group.front().trajectoryState(),
+                         std::make_shared<InvalidTrackingRecHit>(*group.front().det(), TrackingRecHit::inactive), 0.,&layer);
+
   }
 }


### PR DESCRIPTION
With this PR we add to ```Bounds```  a method that returns the significance of a track inside a Det
(negative if inside, positive if outside)
We add this information to "MIssingHIts" in place of the "estimator".

The idea is to later use this information to try to identify tracks that miss a Det because they pass between the gap among two of them: this has been seen occurring in particular in the Inner Pixel for both Phase1 and Phase2.

This PR just adds the capability, does not make any use of it.
No regression expected. It does recompile the universe.
Any future use of this information is expected to create regression: so we prefer to start from an IB
already including this basic mods that trigger major recompilation. 