### PR TITLE
Fix HGCal aging

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/aging.py
+++ b/SLHCUpgradeSimulations/Configuration/python/aging.py
@@ -61,9 +61,9 @@ def ageHF(process,turnon):
 
 def agedHGCal(process):
     from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import HGCal_setEndOfLifeNoise
-    HGCal_setEndOfLifeNoise(getHGCalDigitizer(process,'EE'))
-    HGCal_setEndOfLifeNoise(getHGCalDigitizer(process,'FH'))
-    HGCal_setEndOfLifeNoise(getHGCalDigitizer(process,'BH'))
+    for subdet in ['EE','FH','BH']:
+        hgcaldigi = getHGCalDigitizer(process,subdet)
+        if hgcaldigi is not None: HGCal_setEndOfLifeNoise(hgcaldigi)
     return process
 
 # needs lumi to set proper ZS thresholds (tbd)

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -169,6 +169,6 @@ endOfLifeNoises = [2400.0,2250.0,1750.0]
 def HGCal_setEndOfLifeNoise(digitizer):
     if( digitizer.digiCollection != "HGCDigisHEback" ):
         digitizer.digiCfg.noise_fC = cms.vdouble( [x*fC_per_ele for x in endOfLifeNoises] )
-        digitizer.digiCfg.chargeCollectionEfficiency = cms.double(endOfLifeCCEs)
+        digitizer.digiCfg.chargeCollectionEfficiency = cms.vdouble(endOfLifeCCEs)
     else: #use S/N of 7 for SiPM readout
-        digitizer.digiCfg.noise_MIP = cms.vdouble( 1.0/5.0 )
+        digitizer.digiCfg.noise_MIP = cms.double( 1.0/5.0 )


### PR DESCRIPTION
I noticed several python problems when trying to run an aging configuration that included HGCal. (It seems that this has never been run in production.)

This PR will be backported to 93X.