### PR TITLE
Fix compilation error in EvtGenInterface.cc

### DIFF
--- a/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.cc
+++ b/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.cc
@@ -305,7 +305,7 @@ void EvtGenInterface::init(){
   //Setup evtGen following instructions on http://evtgen.warwick.ac.uk/docs/external/ 
   bool convertPythiaCodes=fPSet->getUntrackedParameter<bool>("convertPythiaCodes",true); // Specify if we want to use Pythia 6 physics codes for decays
   std::string pythiaDir = getenv ("PYTHIA8DATA"); // Specify the pythia xml data directory to use the default PYTHIA8DATA location
-  if(pythiaDir==nullptr){ 
+  if(pythiaDir.empty()){
     edm::LogError("EvtGenInterface::~EvtGenInterface") << "EvtGenInterface::init() PYTHIA8DATA not defined. Terminating program "; 
     exit(0);
   }


### PR DESCRIPTION
Use `bool empty() const;` method from `std::string` to check if it's
empty.

This failed to compile in `CMSSW_10_0_ROOT6_X_2017-11-04-0900`.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>