### PR TITLE
Fix ASan + -O0 compilation in CondFormats/EcalObjects

### DIFF
--- a/CondFormats/EcalObjects/interface/EcalCondObjectContainer.h
+++ b/CondFormats/EcalObjects/interface/EcalCondObjectContainer.h
@@ -79,6 +79,7 @@ class EcalCondObjectContainer {
                                         // FIXME (add throw)
                                         return ee_.end();
                         }
+                        return ee_.end();
                 }
 
                 inline


### PR DESCRIPTION
While working on ASan + -O0 build I kept getting:

    CondFormats/EcalObjects/interface/EcalCondObjectContainer.h:82:17:
    error: control reaches end of non-void function [-Werror=return-type]

I don't see how this could be the case, but the following change should
be safe also and avoids this issue.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>