### PR TITLE
Fix Phase 1 Pixel Premixing

### DIFF
--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelMCDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelMCDigiWorker.cc
@@ -633,8 +633,10 @@ bool DataMixingSiPixelMCDigiWorker::PixelEfficiencies::matches(const DetId& deti
 	    } // end if
 	    //Make a new Digi:
 
-	    SPD.push_back( PixelDigi(i->first, i->second) );     
-
+	    // Don't put in digis that have been killed:
+	    if(i->second > 0.) {
+	      SPD.push_back( PixelDigi(i->first, i->second) );     
+	    }
 	  } // end pixel loop
 	  // push back vector here of one detID
 	  


### PR DESCRIPTION
Remove practice of putting dead pixel digis in with zero ADC counts.  Apparently the clustering filter in the Pixels no longer ignores them.