### PR TITLE
Puppi tune for upgrade

### DIFF
--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -86,6 +86,7 @@ from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(
     puppi,
     DeltaZCut = cms.double(0.1),
+    PtMaxNeutrals  = cms.double(-1.),
     algos = cms.VPSet( 
         cms.PSet( 
              etaMin = cms.vdouble(0.,  2.5),


### PR DESCRIPTION
The PtMaxNeutrals parameter protects against detector noise in data and was tuned for 2016+2017 data. It is not appropriate for Phase-2 simulation and leads to storing too many low weight neutral pileup particles in high-pT jets, particularly in the endcap.

While this change is too late for production, it would be useful to validate this change as an analysis recipe.

One round of jenkins tests including upgrade workflows would be useful. Then the PR can be closed again.