### PR TITLE
Change locations of DQM modules as requested in CMSLITDPG-318

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2CaloLayer2Emul_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2CaloLayer2Emul_cfi.py
@@ -5,6 +5,6 @@ l1tStage2CaloLayer2Emul = cms.EDAnalyzer("L1TStage2CaloLayer2",
                 stage2CaloLayer2EGammaSource = cms.InputTag("valCaloStage2Layer2Digis"),
                 stage2CaloLayer2TauSource = cms.InputTag("valCaloStage2Layer2Digis"),
                 stage2CaloLayer2EtSumSource = cms.InputTag("valCaloStage2Layer2Digis"),
-                monitorDir = cms.untracked.string("L1TEMU/L1TStage2CaloLayer2EMU")
+                monitorDir = cms.untracked.string("L1TEMU/L1TStage2CaloLayer2/L1TStage2CaloLayer2EMU")
 )
                                      

--- a/DQM/L1TMonitor/python/L1TdeStage2CaloLayer2_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2CaloLayer2_cfi.py
@@ -9,5 +9,5 @@ l1tdeStage2CaloLayer2 = cms.EDAnalyzer("L1TdeStage2CaloLayer2",
     calol2TauCollectionEmul = cms.InputTag("valCaloStage2Layer2Digis"),
     calol2EtSumCollectionData = cms.InputTag("caloStage2Digis", "EtSum"),
     calol2EtSumCollectionEmul = cms.InputTag("valCaloStage2Layer2Digis"),
-    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2CaloLayer2")
+    monitorDir = cms.untracked.string("L1TEMU/L1TStage2CaloLayer2/L1TdeStage2CaloLayer2")
 )

--- a/DQM/L1TMonitorClient/python/L1TStage2CaloLayer2DEClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2CaloLayer2DEClient_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 l1tStage2CaloLayer2DEClient = DQMEDHarvester("L1TStage2CaloLayer2DEClient",
-                  monitorDir = cms.untracked.string('L1TEMU/L1TStage2CaloLayer2DERatio'),
+                  monitorDir = cms.untracked.string('L1TEMU/L1TStage2CaloLayer2/L1TStage2CaloLayer2DERatio'),
                   inputDataDir = cms.untracked.string('L1T/L1TStage2CaloLayer2'),
                   inputEmulDir = cms.untracked.string('L1TEMU/L1TStage2CaloLayer2EMU')
 )

--- a/DQM/L1TMonitorClient/python/L1TStage2CaloLayer2DEClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2CaloLayer2DEClient_cfi.py
@@ -4,7 +4,7 @@ from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 l1tStage2CaloLayer2DEClient = DQMEDHarvester("L1TStage2CaloLayer2DEClient",
                   monitorDir = cms.untracked.string('L1TEMU/L1TStage2CaloLayer2/L1TStage2CaloLayer2DERatio'),
                   inputDataDir = cms.untracked.string('L1T/L1TStage2CaloLayer2'),
-                  inputEmulDir = cms.untracked.string('L1TEMU/L1TStage2CaloLayer2EMU')
+                  inputEmulDir = cms.untracked.string('L1TEMU/L1TStage2CaloLayer2/L1TStage2CaloLayer2EMU')
 )
 
 


### PR DESCRIPTION
Currently there are three CaloLayer2 directories under L1TEMU:
L1TStage2CaloLayer2DERatio, L1TStage2CaloLayer2EMU, and L1TdeStage2CaloLayer2
This PR was created in order to group them into one (L1TStage2CaloLayer2) directory.
A back-port to 92x will be available as well.

JIRA ticket:
https://its.cern.ch/jira/browse/CMSLITDPG-318