### PR TITLE
Muon selector function taking enum type

### DIFF
--- a/DataFormats/MuonReco/interface/Muon.h
+++ b/DataFormats/MuonReco/interface/Muon.h
@@ -212,6 +212,7 @@ namespace reco {
     };
     
     bool passed( unsigned int selection ) const { return (selectors_ & selection)==selection; }
+    bool passed( Selector selection ) const { return passed(static_cast<unsigned int>(selection)); }
     unsigned int selectors() const { return selectors_; }
     void setSelectors( unsigned int selectors ){ selectors_ = selectors; }
     void setSelector(Selector selector, bool passed){ 


### PR DESCRIPTION
Needed to call reco::Muon::passed from string parser using names defined in the reco::Muon::Selector enum.

@gpetruc @arizzi @emanueledimarco @drkovalskyi 