### PR TITLE
Removed unnecessary caching for consumes failures

### DIFF
--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -320,14 +320,6 @@ EDConsumerBase::registeredToConsume(ProductResolverIndex iIndex, bool skipCurren
       return true;
     }
   }
-  //TEMPORARY: Remember so we do not have to do this again
-  //non thread-safe
-  EDConsumerBase* nonConstThis = const_cast<EDConsumerBase*>(this);
-  nonConstThis->m_tokenInfo.emplace_back(TokenLookupInfo{TypeID{}, iIndex, skipCurrentProcess, iBranch},
-                                         true,
-                                         LabelPlacement{0,0,0},
-                                         PRODUCT_TYPE);
-
   return false;
 }
 
@@ -344,13 +336,6 @@ EDConsumerBase::registeredToConsumeMany(TypeID const& iType, BranchType iBranch)
       return true;
     }
   }
-  //TEMPORARY: Remember so we do not have to do this again
-  //non thread-safe
-  EDConsumerBase* nonConstThis = const_cast<EDConsumerBase*>(this);
-  nonConstThis->m_tokenInfo.emplace_back(TokenLookupInfo{iType,ProductResolverIndexInvalid, false, iBranch},
-                           true,
-                           LabelPlacement{0,0,0},
-                           PRODUCT_TYPE);
   return false;
   
 }


### PR DESCRIPTION
Removed the caching of requests which were not registered for consumes since now we trigger a fatal exception in that case.