### PR TITLE
remove empty entry from phase2 harvesting list

### DIFF
--- a/Validation/Configuration/python/autoValidation.py
+++ b/Validation/Configuration/python/autoValidation.py
@@ -15,4 +15,4 @@ autoValidation = { 'liteTracking' : ['prevalidationLiteTracking','validationLite
 _phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','JetMETOnlyValidation','bTagOnlyValidation','hcalOnlyValidation', 'HGCalValidation']
 autoValidation['phase2Validation'] = ['','','']
 for i in range(0,3):
-    autoValidation['phase2Validation'][i] = '+'.join([autoValidation[m][i] for m in _phase2_allowed])
+    autoValidation['phase2Validation'][i] = '+'.join(filter(None,[autoValidation[m][i] for m in _phase2_allowed]))


### PR DESCRIPTION
Step4 in Phase2 workflows was printing this message:
```
 is not a possible harvesting type. Available are [...]
```
where `[...]` was a very long list of all harvesting sequences. I found this was caused by the inclusion of an empty string in the phase2Validation lists, which is now fixed.