### PR TITLE
Fix L1TMuonEndCap warning regarding Phase 2 iRPC hits

### DIFF
--- a/L1Trigger/L1TMuonEndCap/src/EMTFSubsystemCollector.cc
+++ b/L1Trigger/L1TMuonEndCap/src/EMTFSubsystemCollector.cc
@@ -46,9 +46,10 @@ void EMTFSubsystemCollector::extractPrimitives(
     auto dend = (*chamber).second.second;
     for( ; digi != dend; ++digi ) {
       if ((*chamber).first.region() != 0) {  // 0 is barrel
-        if (!((*chamber).first.station() <= 2 && (*chamber).first.ring() == 3)) {  // do not include RE1/3, RE2/3
-          out.emplace_back((*chamber).first,digi->strip(),(*chamber).first.layer(),digi->bx());
-        }
+        if ((*chamber).first.station() <= 2 && (*chamber).first.ring() == 3)  continue;  // do not include RE1/3, RE2/3
+        if ((*chamber).first.station() >= 3 && (*chamber).first.ring() == 1)  continue;  // do not include RE3/1, RE4/1
+
+        out.emplace_back((*chamber).first,digi->strip(),(*chamber).first.layer(),digi->bx());
       }
     }
   }


### PR DESCRIPTION
This PR should fix #21201 reported by @kpedro88 .

The current L1 EMTF emulator is not designed to handle Phase 2 iRPC hits (RPC hits from RE3/1 and RE4/1). Using the hits will likely produce code crashes or simply bogus results. This PR simply removes the hits from entering the EMTF emulator. This is a temporary solution.

Further discussion can be found on the issue above (#21201). 

@abrinke1 , @kpedro88 please check/comment, thanks!