### PR TITLE
update offline DQM muon threshold for ppRef_2017 era

### DIFF
--- a/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cff.py
+++ b/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cff.py
@@ -183,13 +183,16 @@ hltMuonOfflineAnalyzers = cms.Sequence(
 )
 
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
+from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 for muAna in [globalAnalyzerTnP.targetParams, trackerAnalyzerTnP.targetParams, 
               tightAnalyzerTnP.targetParams, looseAnalyzerTnP.targetParams,
               globalAnalyzerRef.targetParams, trackerAnalyzerRef.targetParams, 
               tightAnalyzerRef.targetParams, looseAnalyzerRef.targetParams,]:
-    pA_2016.toModify(muAna, ptCut_Jpsi = cms.untracked.double( 5.0))
+    for e in [pA_2016, ppRef_2017]:
+	    e.toModify(muAna, ptCut_Jpsi = cms.untracked.double( 5.0))
 for muAna in [globalAnalyzerTnP.binParams, trackerAnalyzerTnP.binParams,
               tightAnalyzerTnP.binParams, looseAnalyzerTnP.binParams,
               globalAnalyzerRef.binParams, trackerAnalyzerRef.binParams,
               tightAnalyzerRef.binParams, looseAnalyzerRef.binParams]:
-    pA_2016.toModify(muAna, ptCoarse = cms.untracked.vdouble(0.,1.,2.,3.,4.,5.,7.,9.,12.,15.,20.,30.,40.))
+    for e in [pA_2016, ppRef_2017]:
+	    e.toModify(muAna, ptCoarse = cms.untracked.vdouble(0.,1.,2.,3.,4.,5.,7.,9.,12.,15.,20.,30.,40.))


### PR DESCRIPTION
update offline DQM muon threshold for ppRef_2017 era.
Will back port to 92X for prompt reco and 94X for rereco.