### PR TITLE
Fix PhysicsTools & Validation pkgs comp warnings after clang-tidy

### DIFF
--- a/PhysicsTools/ParallelAnalysis/interface/TrackTSelector.h
+++ b/PhysicsTools/ParallelAnalysis/interface/TrackTSelector.h
@@ -26,7 +26,7 @@ namespace examples {
     /// terminate processing
     void terminate( TList & ) override;
 
-    ClassDef(TrackTSelector,2)
+    ClassDefOverride(TrackTSelector,2)
   private:
     /// avoid copy constructor
     TrackTSelector( const TrackTSelector & );

--- a/PhysicsTools/RooStatsCms/interface/ExclusionBandPlot.h
+++ b/PhysicsTools/RooStatsCms/interface/ExclusionBandPlot.h
@@ -83,7 +83,7 @@ class ExclusionBandPlot : public StatisticalPlot {
 
 //For Cint/**/
 // #if (defined (STANDALONE) or defined (__CINT__) )
-ClassDef(ExclusionBandPlot,1)
+ClassDefOverride(ExclusionBandPlot,1)
 // #endif
  };
 

--- a/PhysicsTools/RooStatsCms/interface/LEPBandPlot.h
+++ b/PhysicsTools/RooStatsCms/interface/LEPBandPlot.h
@@ -110,7 +110,7 @@ class LEPBandPlot : public StatisticalPlot {
 
 //For Cint
 // #if (defined (STANDALONE) or defined (__CINT__) )
-ClassDef(LEPBandPlot,1)
+ClassDefOverride(LEPBandPlot,1)
 // #endif
  };
 

--- a/PhysicsTools/TagAndProbe/interface/RooCBExGaussShape.h
+++ b/PhysicsTools/TagAndProbe/interface/RooCBExGaussShape.h
@@ -30,7 +30,7 @@ public:
   inline ~RooCBExGaussShape() override{}
   Double_t evaluate() const override ;
   
-  ClassDef(RooCBExGaussShape,1)
+  ClassDefOverride(RooCBExGaussShape,1)
 
 protected:
 

--- a/PhysicsTools/TagAndProbe/interface/RooCMSShape.h
+++ b/PhysicsTools/TagAndProbe/interface/RooCMSShape.h
@@ -45,7 +45,7 @@ public:
   Double_t evaluate() const override ;
   
 
-  ClassDef(RooCMSShape,1);
+  ClassDefOverride(RooCMSShape,1);
 
 protected:
 

--- a/PhysicsTools/TagAndProbe/interface/ZGeneratorLineShape.h
+++ b/PhysicsTools/TagAndProbe/interface/ZGeneratorLineShape.h
@@ -20,7 +20,7 @@ public:
   ZGeneratorLineShape(const ZGeneratorLineShape& other, const char* name);
   inline TObject* clone(const char* newname) const override { return new ZGeneratorLineShape(*this,newname);}
   inline ~ZGeneratorLineShape() override{};
-  ClassDef(ZGeneratorLineShape,1)
+  ClassDefOverride(ZGeneratorLineShape,1)
     Double_t evaluate() const override;  
  protected:
   RooRealProxy m ;

--- a/Validation/RecoParticleFlow/interface/TH2Analyzer.h
+++ b/Validation/RecoParticleFlow/interface/TH2Analyzer.h
@@ -75,7 +75,7 @@ class TH2Analyzer : public TObject {
   TH1D*      meanXslice_;
 
   //std::vector< TH1D* > parameters_; // if we are not fitting with a gauss function
-  ClassDef(TH2Analyzer, 1);
+  ClassDefOverride(TH2Analyzer, 1);
 
 };
 


### PR DESCRIPTION
Fix comp warnings listed here:
https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/slc6_amd64_gcc630/www/tue/10.0-tue-11/CMSSW_10_0_X_2017-11-07-1100
in PhysicsTools/* and Validation/RecoParticleFlow	