### PR TITLE
Fix comp warnings in multiple pkgs

### DIFF
--- a/PhysicsTools/SelectorUtils/interface/CutApplicatorBase.h
+++ b/PhysicsTools/SelectorUtils/interface/CutApplicatorBase.h
@@ -59,7 +59,7 @@ class CutApplicatorBase : public candf::CandidateCut {
 #endif
     
   
-  result_type operator()(const argument_type&) const 
+  result_type operator()(const argument_type&) const override
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     final
 #endif


### PR DESCRIPTION
Fixes comp warnings here: 
https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/slc6_amd64_gcc630/www/tue/10.0-tue-11/CMSSW_10_0_X_2017-11-07-1100
in Reco* and 	PhysicsTools/SelectorUtils