### PR TITLE
Remove unused vars in multiple pkgs

### DIFF
--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EGammaAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2EGammaAlgorithmFirmwareImp1.cc
@@ -503,7 +503,6 @@ unsigned int l1t::Stage2Layer2EGammaAlgorithmFirmwareImp1::trimmingLutIndex(unsi
 unsigned int l1t::Stage2Layer2EGammaAlgorithmFirmwareImp1::returnShape(const l1t::CaloCluster& clus)
 /*****************************************************************/
 {
-  const l1t::CaloCluster& clusCopy = clus;
 
   unsigned int shape = 0;
   if( (clus.checkClusterFlag(CaloCluster::INCLUDE_N)) ) shape |= (0x1);

--- a/PhysicsTools/Utilities/src/LumiReWeighting.cc
+++ b/PhysicsTools/Utilities/src/LumiReWeighting.cc
@@ -157,9 +157,9 @@ double LumiReWeighting::weight( float npv ) {
 
 double LumiReWeighting::weight( const edm::EventBase &e ) {
 
-  FirstWarning_ = false; // in the previous statement, FirstWarning_ would've been turned to false if it were true, and would've remain false if not, false in both cases
   // get pileup summary information
 
+  e.processHistory(); // keep the function call
   Handle<std::vector< PileupSummaryInfo > >  PupInfo;
   e.getByLabel(pileupSumInfoTag_, PupInfo);
 
@@ -192,7 +192,7 @@ double LumiReWeighting::weightOOT( const edm::EventBase &e ) {
 
   //int Run = e.run();
   int LumiSection = e.luminosityBlock();
-  
+  e.processHistory(); // keep the function call
   // do some caching here, attempt to catch file boundaries
 
   if(LumiSection != OldLumiSection_)

--- a/PhysicsTools/Utilities/src/LumiReWeighting.cc
+++ b/PhysicsTools/Utilities/src/LumiReWeighting.cc
@@ -158,8 +158,11 @@ double LumiReWeighting::weight( float npv ) {
 double LumiReWeighting::weight( const edm::EventBase &e ) {
 
   // get pileup summary information
-
-  e.processHistory(); // keep the function call
+  if(FirstWarning_) {
+    e.processHistory(); // keep the function call
+    //    SetFirstFalse();
+    FirstWarning_ = false;
+  }
   Handle<std::vector< PileupSummaryInfo > >  PupInfo;
   e.getByLabel(pileupSumInfoTag_, PupInfo);
 
@@ -192,12 +195,12 @@ double LumiReWeighting::weightOOT( const edm::EventBase &e ) {
 
   //int Run = e.run();
   int LumiSection = e.luminosityBlock();
-  e.processHistory(); // keep the function call
   // do some caching here, attempt to catch file boundaries
 
-  if(LumiSection != OldLumiSection_)
+  if(LumiSection != OldLumiSection_){
+    e.processHistory(); // keep the function call
     OldLumiSection_ = LumiSection;
-
+  }
   // find the pileup summary information
 
   Handle<std::vector< PileupSummaryInfo > >  PupInfo;

--- a/PhysicsTools/Utilities/src/LumiReWeighting.cc
+++ b/PhysicsTools/Utilities/src/LumiReWeighting.cc
@@ -157,9 +157,8 @@ double LumiReWeighting::weight( float npv ) {
 
 double LumiReWeighting::weight( const edm::EventBase &e ) {
 
-  // get pileup summary information
   if(FirstWarning_) {
-    e.processHistory(); // keep the function call
+    e.processHistory();
     //    SetFirstFalse();
     FirstWarning_ = false;
   }

--- a/PhysicsTools/Utilities/src/LumiReWeighting.cc
+++ b/PhysicsTools/Utilities/src/LumiReWeighting.cc
@@ -157,21 +157,7 @@ double LumiReWeighting::weight( float npv ) {
 
 double LumiReWeighting::weight( const edm::EventBase &e ) {
 
-  // find provenance of event objects, just to check at the job beginning if there might be an issue  
-
-  if(FirstWarning_) {
-
-    const edm::ProcessHistory& PHist = e.processHistory();
-    edm::ProcessHistory::const_iterator PHist_iter = PHist.begin();
-
-    for(; PHist_iter<PHist.end() ;++PHist_iter) {
-      edm::ProcessConfiguration PConf = *(PHist_iter);
-
-    }
-    //    SetFirstFalse();
-    FirstWarning_ = false;
-  }
-
+  FirstWarning_ = false; // in the previous statement, FirstWarning_ would've been turned to false if it were true, and would've remain false if not, false in both cases
   // get pileup summary information
 
   Handle<std::vector< PileupSummaryInfo > >  PupInfo;
@@ -209,17 +195,8 @@ double LumiReWeighting::weightOOT( const edm::EventBase &e ) {
   
   // do some caching here, attempt to catch file boundaries
 
-  if(LumiSection != OldLumiSection_) {
-
-    const edm::ProcessHistory& PHist = e.processHistory();
-    edm::ProcessHistory::const_iterator PHist_iter = PHist.begin();
-
-    for(; PHist_iter<PHist.end() ;++PHist_iter) {
-      edm::ProcessConfiguration PConf = *(PHist_iter);
-
-    }
+  if(LumiSection != OldLumiSection_)
     OldLumiSection_ = LumiSection;
-  }
 
   // find the pileup summary information
 

--- a/PhysicsTools/Utilities/src/LumiReWeighting.cc
+++ b/PhysicsTools/Utilities/src/LumiReWeighting.cc
@@ -166,8 +166,6 @@ double LumiReWeighting::weight( const edm::EventBase &e ) {
 
     for(; PHist_iter<PHist.end() ;++PHist_iter) {
       edm::ProcessConfiguration PConf = *(PHist_iter);
-      const edm::ReleaseVersion& Release =  PConf.releaseVersion() ;
-      const std::string& Process =  PConf.processName();
 
     }
     //    SetFirstFalse();
@@ -218,8 +216,6 @@ double LumiReWeighting::weightOOT( const edm::EventBase &e ) {
 
     for(; PHist_iter<PHist.end() ;++PHist_iter) {
       edm::ProcessConfiguration PConf = *(PHist_iter);
-      const edm::ReleaseVersion& Release =  PConf.releaseVersion() ;
-      const std::string& Process =  PConf.processName();
 
     }
     OldLumiSection_ = LumiSection;

--- a/Validation/Geometry/src/MaterialBudgetAction.cc
+++ b/Validation/Geometry/src/MaterialBudgetAction.cc
@@ -157,7 +157,6 @@ void MaterialBudgetAction::update(const BeginOfRun* )
     int siz = partTable->size();
     for (int ii= 0; ii < siz; ii++) {
       G4ParticleDefinition * particle = partTable->GetParticle(ii);
-      const std::string& particleName = particle->GetParticleName();
       
       //--- All processes of this particle 
       G4ProcessManager * pmanager = particle->GetProcessManager();


### PR DESCRIPTION
Remove unused vars from three packages. Note that the changes here:
https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/Utilities/src/LumiReWeighting.cc#L169
and here
https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/Utilities/src/LumiReWeighting.cc#L221
are leaving the for loops without obvious purpose (from a glance) yet there was no comp warning for PConf being unused (not sure why), so I'll leave them (the loops) as they are. 