### PR TITLE
maxtracks parameter for offline validation

### DIFF
--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -304,6 +304,9 @@ private:
   //sum hists are fit at the end using fitResiduals()
   std::vector<TH1*> toFit_;
 
+  unsigned long long ntracks_;
+  const unsigned long long maxtracks_;
+
   TrackerValidationVariables avalidator_;
 };
 
@@ -386,6 +389,8 @@ TrackerOfflineValidation::TrackerOfflineValidation(const edm::ParameterSet& iCon
     useOverflowForRMS_(parSet_.getParameter<bool>("useOverflowForRMS")),
     dqmMode_(parSet_.getParameter<bool>("useInDqmMode")),
     moduleDirectory_(parSet_.getParameter<std::string>("moduleDirectoryInOutput")),
+    ntracks_(0),
+    maxtracks_(parSet_.getParameter<unsigned long long>("maxtracks")),
     avalidator_(iConfig, consumesCollector())
 {
 }
@@ -1005,6 +1010,9 @@ TrackerOfflineValidation::getHistStructFromMap(const DetId& detid)
 void
 TrackerOfflineValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
+  if (maxtracks_ > 0 && ntracks_ >= maxtracks_) return;  //don't do anything after hitting the max number of tracks
+                                                         //(could just rely on break below, but this way saves fillTrackQuantities)
+
   if (useOverflowForRMS_)TH1::StatOverflows(kTRUE);
   this->checkBookHists(iSetup); // check whether hists are booked and do so if not yet done
 
@@ -1015,6 +1023,7 @@ TrackerOfflineValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
        itT != vTrackstruct.end();
        ++itT) {
     
+    if (maxtracks_ > 0 && ntracks_++ >= maxtracks_) break; //exit the loop after hitting the max number of tracks
     // Fill 1D track histos
     static const int etaindex = this->GetIndex(vTrackHistos_,"h_tracketa");
     vTrackHistos_[etaindex]->Fill(itT->eta);

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidation.py
@@ -16,6 +16,7 @@ class OfflineValidation(GenericValidationData_CTSR, ParallelValidation, Validati
         "offlineModuleLevelHistsTransient": "False",
         "offlineModuleLevelProfiles": "True",
         "stripYResiduals": "False",
+        "maxtracks": "0",
         }
     deprecateddefaults = {
         "DMRMethod":"",

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
@@ -31,6 +31,7 @@ process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..trajectoryInput = 
 process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..moduleLevelHistsTransient = .oO[offlineModuleLevelHistsTransient]Oo.
 process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..moduleLevelProfiles = .oO[offlineModuleLevelProfiles]Oo.
 process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..stripYResiduals = .oO[stripYResiduals]Oo.
+process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..maxtracks = .oO[maxtracks]Oo.
 """
 
 OfflineValidationSequence = "process.seqTrackerOfflineValidation.oO[offlineValidationMode]Oo."

--- a/Alignment/OfflineValidation/python/TrackerOfflineValidation_cfi.py
+++ b/Alignment/OfflineValidation/python/TrackerOfflineValidation_cfi.py
@@ -9,11 +9,12 @@ TrackerOfflineValidation = cms.EDAnalyzer("TrackerOfflineValidation",
     moduleLevelHistsTransient = cms.bool(False),  # Do not switch on in DQM mode, TrackerOfflineValidationSummary needs it
     moduleLevelProfiles       = cms.bool(False),  # Do not switch on in DQM mode
     localCoorProfilesOn       = cms.bool(False),
-    stripYResiduals           = cms.bool(False),                                        
+    stripYResiduals           = cms.bool(False),
     useFwhm                   = cms.bool(True),
     useFit                    = cms.bool(False),  # Unused in DQM mode, where it has to be specified in TrackerOfflineValidationSummary
     useCombinedTrajectory     = cms.bool(False),
     useOverflowForRMS         = cms.bool(False),
+    maxtracks                 = cms.uint64(0),
     # Normalized X Residuals, normal local coordinates (Strip)
     TH1NormXResStripModules = cms.PSet(
         Nbinx = cms.int32(100), xmin = cms.double(-5.0), xmax = cms.double(5.0)
@@ -38,48 +39,48 @@ TrackerOfflineValidation = cms.EDAnalyzer("TrackerOfflineValidation",
     TH1NormYResStripModules = cms.PSet(
         Nbinx = cms.int32(100), xmin = cms.double(-5.0), xmax = cms.double(5.0)
     ),
-    # -> very broad distributions expected                                         
+    # -> very broad distributions expected
     TH1YResStripModules = cms.PSet(
         Nbinx = cms.int32(100), xmin = cms.double(-11.0), xmax = cms.double(11.0)
     ),
 
-    # Normalized X residuals normal local coordinates (Pixel)                                        
+    # Normalized X residuals normal local coordinates (Pixel)
     TH1NormXResPixelModules = cms.PSet(
         Nbinx = cms.int32(100), xmin = cms.double(-5.0), xmax = cms.double(5.0)
     ),
-    # X residuals normal local coordinates (Pixel)                                        
+    # X residuals normal local coordinates (Pixel)
     TH1XResPixelModules = cms.PSet(
         Nbinx = cms.int32(100), xmin = cms.double(-0.5), xmax = cms.double(0.5)
     ),
-    # Normalized X residuals native coordinates (Pixel)                                        
+    # Normalized X residuals native coordinates (Pixel)
     TH1NormXprimeResPixelModules = cms.PSet(
         Nbinx = cms.int32(100), xmin = cms.double(-5.0), xmax = cms.double(5.0)
     ),
-    # X residuals native coordinates (Pixel)                                        
+    # X residuals native coordinates (Pixel)
     TH1XprimeResPixelModules = cms.PSet(
         Nbinx = cms.int32(100), xmin = cms.double(-0.5), xmax = cms.double(0.5)
-    ),                                        
-    # Normalized Y residuals native coordinates (Pixel)                                         
+    ),
+    # Normalized Y residuals native coordinates (Pixel)
     TH1NormYResPixelModules = cms.PSet(
         Nbinx = cms.int32(100), xmin = cms.double(-5.0), xmax = cms.double(5.0)
     ),
-    # Y residuals native coordinates (Pixel)                                         
+    # Y residuals native coordinates (Pixel)
     TH1YResPixelModules = cms.PSet(
         Nbinx = cms.int32(100), xmin = cms.double(-0.5), xmax = cms.double(0.5)
     ),
-    # X Residuals vs reduced local coordinates (Strip)                      
+    # X Residuals vs reduced local coordinates (Strip)
     TProfileXResStripModules = cms.PSet(
         Nbinx = cms.int32(20), xmin = cms.double(-1.0), xmax = cms.double(1.0)
     ),
-    # X Residuals vs reduced local coordinates (Strip)                      
+    # X Residuals vs reduced local coordinates (Strip)
     TProfileYResStripModules = cms.PSet(
         Nbinx = cms.int32(20), xmin = cms.double(-1.0), xmax = cms.double(1.0)
     ),
-    # X Residuals vs reduced local coordinates (Pixel)                      
+    # X Residuals vs reduced local coordinates (Pixel)
     TProfileXResPixelModules = cms.PSet(
         Nbinx = cms.int32(20), xmin = cms.double(-1.0), xmax = cms.double(1.0)
     ),
-    # X Residuals vs reduced local coordinates (Pixel)                      
+    # X Residuals vs reduced local coordinates (Pixel)
     TProfileYResPixelModules = cms.PSet(
         Nbinx = cms.int32(20), xmin = cms.double(-1.0), xmax = cms.double(1.0)
     )


### PR DESCRIPTION
So that the validation can stop after a specified number of tracks, rather than just a number of events.  Because the DMR plots count the number of modules per bin, rather than the number of tracks per bin, the number of tracks has to be the same when comparing two geometries.

backport of #21223