### PR TITLE
Remove obsolete references to the online "connection string"

### DIFF
--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_TCCPattern.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_TCCPattern.py
@@ -23,8 +23,6 @@ process.eegeom = cms.ESSource("EmptyESSource",
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/xiezhen/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beam4.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beam4.py
@@ -23,8 +23,6 @@ process.eegeom = cms.ESSource("EmptyESSource",
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beam_zerotesla_v0.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beam_zerotesla_v0.py
@@ -23,12 +23,6 @@ process.eegeom = cms.ESSource("EmptyESSource",
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
-
-
-
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv0.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv0.py
@@ -23,8 +23,6 @@ process.eegeom = cms.ESSource("EmptyESSource",
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv0_MC.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv0_MC.py
@@ -23,8 +23,6 @@ process.eegeom = cms.ESSource("EmptyESSource",
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv1.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv1.py
@@ -23,8 +23,6 @@ process.eegeom = cms.ESSource("EmptyESSource",
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/xiezhen/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv2.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv2.py
@@ -23,12 +23,6 @@ process.eegeom = cms.ESSource("EmptyESSource",
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
-
-
-
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv2_MC_ideal.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv2_MC_ideal.py
@@ -23,8 +23,6 @@ process.eegeom = cms.ESSource("EmptyESSource",
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv2_MC_startup.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv2_MC_startup.py
@@ -23,7 +23,6 @@ process.eegeom = cms.ESSource("EmptyESSource",
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv3.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv3.py
@@ -23,12 +23,6 @@ process.eegeom = cms.ESSource("EmptyESSource",
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
-
-
-
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv3ForFG.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv3ForFG.py
@@ -23,12 +23,6 @@ process.eegeom = cms.ESSource("EmptyESSource",
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
-
-
-
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv3ForSFGVB.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv3ForSFGVB.py
@@ -23,12 +23,6 @@ process.eegeom = cms.ESSource("EmptyESSource",
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
-
-
-
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv3WithAPDGain10.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv3WithAPDGain10.py
@@ -23,12 +23,6 @@ process.eegeom = cms.ESSource("EmptyESSource",
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
-
-
-
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv4_128.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv4_128.py
@@ -23,8 +23,6 @@ process.eegeom = cms.ESSource("EmptyESSource",
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv4_128_MC_ideal.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv4_128_MC_ideal.py
@@ -24,8 +24,6 @@ process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 #process.CondDBCommon.connect = 'oracle://cms_orcoff_prep/CMS_COND_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv4_128_MC_startup.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv4_128_MC_startup.py
@@ -24,8 +24,6 @@ process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 #process.CondDBCommon.connect = 'oracle://cms_orcoff_prep/CMS_COND_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv4_MC_ideal.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv4_MC_ideal.py
@@ -24,8 +24,6 @@ process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 #process.CondDBCommon.connect = 'oracle://cms_orcoff_prep/CMS_COND_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv4_MC_startup.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv4_MC_startup.py
@@ -24,8 +24,6 @@ process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 #process.CondDBCommon.connect = 'oracle://cms_orcoff_prep/CMS_COND_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv5.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv5.py
@@ -25,8 +25,6 @@ process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL' ##P5 
 #process.CondDBCommon.connect = 'oracle://cms_orcoff_prod/CMS_COND_31X_ECAL' ##lxplus
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb' ###P5 stuff
 #process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb' ##lxplus
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv5_GT.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv5_GT.py
@@ -29,8 +29,6 @@ process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL' ##P5 
 #process.CondDBCommon.connect = 'oracle://cms_orcoff_prod/CMS_COND_31X_ECAL' ##lxplus
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb' ###P5 stuff
 #process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb' ##lxplus
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
 
 #########################
 process.source = cms.Source("EmptySource",

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv5_MC_startup.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv5_MC_startup.py
@@ -25,7 +25,6 @@ process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL' ##P5 
 #process.CondDBCommon.connect = 'oracle://cms_orcoff_prod/CMS_COND_31X_ECAL' ##lxplus
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb' ###P5 stuff
 #process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb' ##lxplus
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                              process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv5_ZS.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv5_ZS.py
@@ -25,8 +25,6 @@ process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL' ##P5 
 #process.CondDBCommon.connect = 'oracle://cms_orcoff_prod/CMS_COND_31X_ECAL' ##lxplus
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb' ###P5 stuff
 #process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb' ##lxplus
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv5_emul.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv5_emul.py
@@ -25,8 +25,6 @@ process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL' ##P5 
 #process.CondDBCommon.connect = 'oracle://cms_orcoff_prod/CMS_COND_31X_ECAL' ##lxplus
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb' ###P5 stuff
 #process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb' ##lxplus
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv6_transparency_spikekill_2016_script_270062.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv6_transparency_spikekill_2016_script_270062.py
@@ -42,8 +42,6 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'oracle://cms_orcon_adg/CMS_CONDITIONS' ##lxplus DBv2
 #process.CondDB.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb' ###P5 stuff
 process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb' ##lxplus
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDB,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_craft_v1.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_craft_v1.py
@@ -23,8 +23,6 @@ process.eegeom = cms.ESSource("EmptyESSource",
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/xiezhen/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_debug.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_debug.py
@@ -23,8 +23,6 @@ process.eegeom = cms.ESSource("EmptyESSource",
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_pascal.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_pascal.py
@@ -23,12 +23,6 @@ process.eegeom = cms.ESSource("EmptyESSource",
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_31X_ECAL'
 process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb'
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
-
-
-
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDBCommon,

--- a/CondTools/Ecal/python/produceTPGParameters_beamv6_transparency_spikekill_2016_script.py
+++ b/CondTools/Ecal/python/produceTPGParameters_beamv6_transparency_spikekill_2016_script.py
@@ -27,8 +27,6 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'oracle://cms_orcon_adg/CMS_CONDITIONS' ##lxplus DBv2
 #process.CondDB.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb' ###P5 stuff
 process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb' ##lxplus
-# process.GlobalTag.connect =cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG')
-
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                           process.CondDB,

--- a/CondTools/L1Trigger/test/validate-l1Key.py
+++ b/CondTools/L1Trigger/test/validate-l1Key.py
@@ -79,30 +79,23 @@ process.load('Configuration/EventContent/EventContent_cff')
 #process.GlobalTag.globaltag = 'GR10_H_V4::All'
 #process.GlobalTag.globaltag = 'GR10_H_V8::All'
 process.GlobalTag.globaltag = 'GR_H_V20::All'
-process.GlobalTag.connect = "frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_COND_31X_GLOBALTAG"
 
 process.GlobalTag.toGet = cms.VPSet()
 process.GlobalTag.toGet.append(
     cms.PSet(
-    record = cms.string('DTCCBConfigRcd'),
-    tag = cms.string('DT_config_V04'),
-    connect = cms.untracked.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_COND_31X_DT')
-    )
-    )
+        record = cms.string('DTCCBConfigRcd'),
+        tag = cms.string('DT_config_V04'),
+    ) )
 process.GlobalTag.toGet.append(
     cms.PSet(
-    record = cms.string('DTKeyedConfigListRcd'),
-    tag = cms.string('DT_keyedConfListIOV_V01'),
-    connect = cms.untracked.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_COND_31X_DT')
-    )
-    )
+        record = cms.string('DTKeyedConfigListRcd'),
+        tag = cms.string('DT_keyedConfListIOV_V01'),
+    ) )
 process.GlobalTag.toGet.append(
     cms.PSet(
-    record = cms.string('DTKeyedConfigContainerRcd'),
-    tag = cms.string('DT_keyedConfBricks_V01'),
-    connect = cms.untracked.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_COND_31X_DT')
-    )
-    )
+        record = cms.string('DTKeyedConfigContainerRcd'),
+        tag = cms.string('DT_keyedConfBricks_V01'),
+    ) )
 
 process.p = cms.Path(
     process.ecalDigis * process.hcalDigis 

--- a/DQM/BeamMonitor/test/44X_HI_beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/BeamMonitor/test/44X_HI_beam_dqm_sourceclient-live_cfg.py
@@ -74,10 +74,8 @@ process.load("DQM.Integration.test.FrontierCondition_GT_cfi")
 #import commands
 #from os import environ
 #environ["http_proxy"]="http://cmsproxy.cms:3128"
-#process.GlobalTag.connect = "frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_COND_31X_GLOBALTAG"
 #dasinfo = eval(commands.getoutput("wget -qO- 'http://vocms115.cern.ch:8304/tier0/express_config?run=&stream=Express'"))
 #process.GlobalTag.globaltag=dasinfo[0]['global_tag']
-#process.GlobalTag.pfnPrefix=cms.untracked.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/')
 #del environ["http_proxy"]
 
 #-----------------------

--- a/DQM/CSCMonitorModule/python/test/csc_dqm_sourceclient-file_cfg.py
+++ b/DQM/CSCMonitorModule/python/test/csc_dqm_sourceclient-file_cfg.py
@@ -103,14 +103,11 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 #from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
 #process.GlobalTag.connect = "sqlite_file:/nfshome0/malgeri/public/globtag/CRZT210_V1H.db"
 #process.GlobalTag.connect = "frontier://FrontierDev/CMS_COND_CSC"
-#process.GlobalTag.connect ="frontier://(proxyurl=http://localhost:3128)(serverurl=http://frontier1.cms:8000/FrontierOnProd)(serverurl=http://frontier2.cms:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_21X_GLOBALTAG"
 #process.GlobalTag.globaltag = "CRZT210_V1H::All"
 #process.GlobalTag.globaltag = 'CRAFT_V3P::All'
 #process.GlobalTag.globaltag = "CRAFT_30X::All"
 #process.es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
-#process.GlobalTag.connect ="frontier://(proxyurl=http://localhost:3128)(serverurl=http://frontier1.cms:8000/FrontierOnProd)(serverurl=http://frontier2.cms:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG"
 #process.GlobalTag.globaltag = "CRAFT_V17H::All"
-#process.GlobalTag.connect ="frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG"
 #process.GlobalTag.globaltag = 'GR09_31X_V1H::All' 
 process.GlobalTag.globaltag = 'GR10_P_V2::All' 
 process.es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')

--- a/DQM/CSCMonitorModule/python/test/csc_dqm_sourceclient-live_cfg.py
+++ b/DQM/CSCMonitorModule/python/test/csc_dqm_sourceclient-live_cfg.py
@@ -65,8 +65,7 @@ process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 #process.GlobalTag.connect = "sqlite_file:/nfshome0/malgeri/public/globtag/CRZT210_V1H.db"
-#process.GlobalTag.connect = "frontier://FrontierDev/CMS_COND_CSC"
-process.GlobalTag.connect ="frontier://(proxyurl=http://localhost:3128)(serverurl=http://frontier1.cms:8000/FrontierOnProd)(serverurl=http://frontier2.cms:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_21X_GLOBALTAG"
+#process.GlobalTag.connect = "frontier://FrontierProd/CMS_COND_21X_GLOBALTAG"
 #process.GlobalTag.globaltag = "CRZT210_V1H::All"
 process.GlobalTag.globaltag = 'CRAFT_V3P::All'
 process.es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')

--- a/DQM/CSCMonitorModule/python/test/csc_dqm_sourceclient-playback_cfg.py
+++ b/DQM/CSCMonitorModule/python/test/csc_dqm_sourceclient-playback_cfg.py
@@ -83,7 +83,6 @@ process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 #process.GlobalTag.connect = "sqlite_file:/nfshome0/malgeri/public/globtag/CRZT210_V1H.db"
 #process.GlobalTag.connect = "frontier://FrontierDev/CMS_COND_CSC"
-process.GlobalTag.connect ="frontier://(proxyurl=http://localhost:3128)(serverurl=http://frontier1.cms:8000/FrontierOnProd)(serverurl=http://frontier2.cms:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_21X_GLOBALTAG"
 process.GlobalTag.globaltag = "CRZT210_V1H::All"
 #process.GlobalTag.globaltag = 'CRAFT_V3P::All'
 process.es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')

--- a/DQM/CSCMonitorModule/python/test/csc_dqm_sourceclient-rawfile_cfg.py
+++ b/DQM/CSCMonitorModule/python/test/csc_dqm_sourceclient-rawfile_cfg.py
@@ -133,7 +133,6 @@ process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 #process.GlobalTag.connect = "sqlite_file:/nfshome0/malgeri/public/globtag/CRZT210_V1H.db"
 #process.GlobalTag.connect = "frontier://FrontierDev/CMS_COND_CSC"
-process.GlobalTag.connect ="frontier://(proxyurl=http://localhost:3128)(serverurl=http://frontier1.cms:8000/FrontierOnProd)(serverurl=http://frontier2.cms:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_21X_GLOBALTAG"
 process.GlobalTag.globaltag = "CRZT210_V1H::All"
 process.es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
 

--- a/DQM/CSCMonitorModule/python/test/csc_dqm_sourceclient_offline-file_cfg.py
+++ b/DQM/CSCMonitorModule/python/test/csc_dqm_sourceclient_offline-file_cfg.py
@@ -87,14 +87,11 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 #from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
 #process.GlobalTag.connect = "sqlite_file:/nfshome0/malgeri/public/globtag/CRZT210_V1H.db"
 #process.GlobalTag.connect = "frontier://FrontierDev/CMS_COND_CSC"
-#process.GlobalTag.connect ="frontier://(proxyurl=http://localhost:3128)(serverurl=http://frontier1.cms:8000/FrontierOnProd)(serverurl=http://frontier2.cms:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_21X_GLOBALTAG"
 #process.GlobalTag.globaltag = "CRZT210_V1H::All"
 #process.GlobalTag.globaltag = 'CRAFT_V3P::All'
 #process.GlobalTag.globaltag = "CRAFT_30X::All"
 #process.es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
-#process.GlobalTag.connect ="frontier://(proxyurl=http://localhost:3128)(serverurl=http://frontier1.cms:8000/FrontierOnProd)(serverurl=http://frontier2.cms:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG"
 #process.GlobalTag.globaltag = "CRAFT_V17H::All"
-#process.GlobalTag.connect ="frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG"
 #process.GlobalTag.globaltag = 'GR09_31X_V1H::All' 
 #process.GlobalTag.globaltag = 'GR09_31X_V1P::All' 
 process.GlobalTag.globaltag = 'GR10_P_V2::All' 

--- a/DQM/CSCMonitorModule/python/test/csc_hlt_dqm_sourceclient-file_cfg.py
+++ b/DQM/CSCMonitorModule/python/test/csc_hlt_dqm_sourceclient-file_cfg.py
@@ -32,7 +32,6 @@ process.source = cms.Source("PoolSource",
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 #process.GlobalTag.connect = "sqlite_file:/nfshome0/malgeri/public/globtag/CRZT210_V1H.db"
 #process.GlobalTag.connect = "frontier://FrontierDev/CMS_COND_CSC"
-#process.GlobalTag.connect ="frontier://(proxyurl=http://localhost:3128)(serverurl=http://frontier1.cms:8000/FrontierOnProd)(serverurl=http://frontier2.cms:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_21X_GLOBALTAG"
 process.GlobalTag.globaltag = "CRAFT_30X::All"
 process.es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
 

--- a/DQM/CSCMonitorModule/python/test/csc_hlt_dqm_sourceclient-playback_cfg.py
+++ b/DQM/CSCMonitorModule/python/test/csc_hlt_dqm_sourceclient-playback_cfg.py
@@ -57,7 +57,6 @@ process.dqmSaver.dirName = '.'
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 #process.GlobalTag.connect = "sqlite_file:/nfshome0/malgeri/public/globtag/CRZT210_V1H.db"
 #process.GlobalTag.connect = "frontier://FrontierDev/CMS_COND_CSC"
-process.GlobalTag.connect ="frontier://(proxyurl=http://localhost:3128)(serverurl=http://frontier1.cms:8000/FrontierOnProd)(serverurl=http://frontier2.cms:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_21X_GLOBALTAG"
 process.GlobalTag.globaltag = "CRZT210_V1H::All"
 process.es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
 

--- a/DQM/CSCMonitorModule/python/test/csc_hlt_dqm_sourceclient-rawfile_cfg.py
+++ b/DQM/CSCMonitorModule/python/test/csc_hlt_dqm_sourceclient-rawfile_cfg.py
@@ -62,7 +62,6 @@ process.source = cms.Source("DaqSource",
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 #process.GlobalTag.connect = "sqlite_file:/nfshome0/malgeri/public/globtag/CRZT210_V1H.db"
 #process.GlobalTag.connect = "frontier://FrontierDev/CMS_COND_CSC"
-process.GlobalTag.connect ="frontier://(proxyurl=http://localhost:3128)(serverurl=http://frontier1.cms:8000/FrontierOnProd)(serverurl=http://frontier2.cms:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_21X_GLOBALTAG"
 process.GlobalTag.globaltag = "CRZT210_V1H::All"
 process.es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
 

--- a/DQM/DTMonitorModule/python/test/dt_dqm_sourceclient-file_MiniDAQ_cfg.py
+++ b/DQM/DTMonitorModule/python/test/dt_dqm_sourceclient-file_MiniDAQ_cfg.py
@@ -41,7 +41,6 @@ process.dqmSaver.saveAtJobEnd = True
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load("DQM.DTMonitorModule.dt_dqm_sourceclient_common_cff")
 #---- for P5 (online) DB access
-process.GlobalTag.connect ="frontier://(proxyurl=http://localhost:3128)(serverurl=http://frontier1.cms:8000/FrontierOnProd)(serverurl=http://frontier2.cms:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_21X_GLOBALTAG"
 process.GlobalTag.globaltag = "CRAFT_V4H::All"
 #---- for offline DB
 #process.GlobalTag.globaltag = "CRAFT_V2P::All"

--- a/DQM/DTMonitorModule/python/test/hltdt_dqm_sourceclient-live_GlobalRun_cfg.py
+++ b/DQM/DTMonitorModule/python/test/hltdt_dqm_sourceclient-live_GlobalRun_cfg.py
@@ -49,7 +49,6 @@ physicsEventsFilter = cms.EDFilter("HLTTriggerTypeFilter",
 
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
 #---- for P5 (online) DB access
-process.GlobalTag.connect ="frontier://(proxyurl=http://localhost:3128)(serverurl=http://frontier1.cms:8000/FrontierOnProd)(serverurl=http://frontier2.cms:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG"
 process.GlobalTag.globaltag = "CRAFT_V17H::All"
 #---- for offline DB
 #process.GlobalTag.globaltag = "CRAFT_V2P::All"

--- a/DQM/DataScouting/test/HLTvsRECOstudies/hlt_data.py
+++ b/DQM/DataScouting/test/HLTvsRECOstudies/hlt_data.py
@@ -1068,7 +1068,6 @@ process.GlobalTag = cms.ESSource( "PoolDBESSource",
     ),
     toGet = cms.VPSet(
     ),
-    connect = cms.string( "frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG" ),
     globaltag = cms.string( "GR_H_V29::All" ),
     timetype = cms.string( "runnumber" ),
     RefreshEachRun = cms.untracked.bool( True )

--- a/DQM/EcalCommon/data/readEcalDQMStatus.py
+++ b/DQM/EcalCommon/data/readEcalDQMStatus.py
@@ -26,14 +26,12 @@ process.GlobalTag.toGet = cms.VPSet(
 #           tag = cms.string("EcalDQMChannelStatus_v1_express"),
 #           tag = cms.string("EcalDQMChannelStatus_v1_offline"),           
 #           connect = cms.untracked.string("sqlite_file:mask-ECAL.db")
-#           connect = cms.untracked.string("frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_COND_34X_ECAL")
           ),
   cms.PSet(record = cms.string("EcalDQMTowerStatusRcd"),
 #           tag = cms.string("EcalDQMTowerStatus_v1_hlt"),
 #           tag = cms.string("EcalDQMTowerStatus_v1_express"),
 #           tag = cms.string("EcalDQMTowerStatus_v1_offline"),
 #           connect = cms.untracked.string("sqlite_file:mask-ECAL.db")
-#           connect = cms.untracked.string("frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_COND_34X_ECAL")           
           )
 )
 

--- a/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
@@ -6,7 +6,6 @@ from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
 # It should be kept in synch with Express processing at Tier0: what the url
 # https://cmsweb.cern.ch/t0wmadatasvc/prod/express_config
 # would tell you.
-GlobalTag.connect = cms.string("frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierProd)(serverurl=http://localhost:8000/FrontierProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_CONDITIONS")
 GlobalTag.globaltag = "92X_dataRun2_Express_v7"
 
 # ===== auto -> Automatically get the GT string from current Tier0 configuration via a Tier0Das call.

--- a/DQM/TrigXMonitor/python/hlt_scaler_cfg.py
+++ b/DQM/TrigXMonitor/python/hlt_scaler_cfg.py
@@ -15,7 +15,6 @@ process.load("Geometry.MuonCommonData.muonIdealGeometryXML_cfi")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
-#process.GlobalTag.connect = "frontier://(proxyurl=http://localhost:3128)(serverurl=http://frontier1.cms:8000/FrontierOnProd)(serverurl=http://frontier2.cms:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_21X_GLOBALTAG"
 #process.GlobalTag.globaltag = 'CRZT210_V1H::All'
 #process.prefer("GlobalTag")
 

--- a/DQM/TrigXMonitorClient/python/test/hlt_scalerclient_cfg.py
+++ b/DQM/TrigXMonitorClient/python/test/hlt_scalerclient_cfg.py
@@ -33,7 +33,6 @@ process.load("Geometry.MuonCommonData.muonIdealGeometryXML_cfi")
 
 #process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
-#process.GlobalTag.connect = "frontier://(proxyurl=http://localhost:3128)(serverurl=http://frontier1.cms:8000/FrontierOnProd)(serverurl=http://frontier2.cms:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_21X_GLOBALTAG"
 #process.GlobalTag.globaltag = 'CRZT210_V1H::All'
 #process.prefer("GlobalTag")
 

--- a/L1Trigger/CSCTriggerPrimitives/test/csc_dqm_sourceclient-file_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/csc_dqm_sourceclient-file_cfg.py
@@ -100,14 +100,11 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 #from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
 #process.GlobalTag.connect = "sqlite_file:/nfshome0/malgeri/public/globtag/CRZT210_V1H.db"
 #process.GlobalTag.connect = "frontier://FrontierDev/CMS_COND_CSC"
-#process.GlobalTag.connect ="frontier://(proxyurl=http://localhost:3128)(serverurl=http://frontier1.cms:8000/FrontierOnProd)(serverurl=http://frontier2.cms:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_21X_GLOBALTAG"
 #process.GlobalTag.globaltag = "CRZT210_V1H::All"
 #process.GlobalTag.globaltag = 'CRAFT_V3P::All'
 #process.GlobalTag.globaltag = "CRAFT_30X::All"
 #process.es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
-#process.GlobalTag.connect ="frontier://(proxyurl=http://localhost:3128)(serverurl=http://frontier1.cms:8000/FrontierOnProd)(serverurl=http://frontier2.cms:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG"
 #process.GlobalTag.globaltag = "CRAFT_V17H::All"
-#process.GlobalTag.connect ="frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)/CMS_COND_31X_GLOBALTAG"
 #process.GlobalTag.globaltag = 'GR09_31X_V1H::All' 
 process.GlobalTag.globaltag = 'GR10_P_V2::All' 
 process.es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')

--- a/L1TriggerConfig/CSCTFConfigProducers/test/testEmulator.py
+++ b/L1TriggerConfig/CSCTFConfigProducers/test/testEmulator.py
@@ -29,8 +29,6 @@ process.load('Configuration/EventContent/EventContent_cff')
 # https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideFrontierConditions
 process.GlobalTag.globaltag = 'GR10_H_V4::All'
 
-process.GlobalTag.connect = "frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_COND_31X_GLOBALTAG"
-
 # Message Logger
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.MessageLogger.debugModules = ['*']

--- a/L1TriggerConfig/CSCTFConfigProducers/test/testEmulatorFromSQLite.py
+++ b/L1TriggerConfig/CSCTFConfigProducers/test/testEmulatorFromSQLite.py
@@ -38,8 +38,6 @@ process.load('Configuration/EventContent/EventContent_cff')
  
 process.GlobalTag.globaltag = 'GR10_H_V4::All'
 
-process.GlobalTag.connect = "frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_COND_31X_GLOBALTAG"
-
 ## process.GlobalTag.toGet.append(cms.PSet(record  = cms.string( "L1MuCSCTFConfigurationRcd" ),
 ##                                         tag     = cms.string("L1MuCSCTFConfiguration_IDEAL" ),
 ##                                         connect = cms.untracked.string( "sqlite_file:csctf.db")

--- a/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
+++ b/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
@@ -3,8 +3,6 @@ from CondCore.CondDB.CondDB_cfi import *
 '''Helper procedure that loads mva inputs from database'''
 
 CondDBTauConnection = CondDB.clone( connect = cms.string( 'frontier://FrontierProd/CMS_CONDITIONS' ) )
-if socket.getfqdn().find( '.cms' ) != -1:
-    CondDBTauConnection.connect = cms.string( 'frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_CONDITIONS' )
 
 loadRecoTauTagMVAsFromPrepDB = cms.ESSource( "PoolDBESSource",
                                              CondDBTauConnection,


### PR DESCRIPTION
Running cmsRun at Point 5 within the .cms network used to require a dedicated
connection string, of the form
`frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_CONDITIONS`

This is no longer necessary since
  - the frontier services at P5 now use the standard name 'FrontierProd' rather than 'FrontierOnProd'
  - the proxy and server settings are stored in the SITECONF