### PR TITLE
L1T offine DQM changes for pp reference run - part2

### DIFF
--- a/DQMOffline/L1Trigger/python/L1TEGammaDiff_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaDiff_cfi.py
@@ -77,13 +77,5 @@ allPlots_HI.extend(plots2D)
 
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 ppRef_2017.toModify(l1tEGammaEmuDiff,
-    plotCfgs=cms.untracked.VPSet(
-        cms.untracked.PSet(  # EMU comparison
-            dir1=cms.untracked.string("L1T/L1TEGamma"),
-            dir2=cms.untracked.string("L1TEMU/L1TEGamma"),
-            outputDir=cms.untracked.string(
-                "L1TEMU/L1TEGamma/Comparison"),
-            plots=cms.untracked.vstring(allPlots_HI)
-        ),
-    )
+    plotCfgs = {0:dict(plots = allPlots_HI)}
 )

--- a/DQMOffline/L1Trigger/python/L1TEGammaDiff_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaDiff_cfi.py
@@ -56,3 +56,34 @@ l1tEGammaEmuDiff = l1tDiffHarvesting.clone(
         ),
     )
 )
+
+# modifications for the pp reference run
+variables_HI = {
+    'electron': L1TEGammaOffline_cfi.electronEfficiencyThresholds_HI,
+}
+
+allEfficiencyPlots_HI = []
+add_plot = allEfficiencyPlots_HI.append
+for variable, thresholds in variables_HI.iteritems():
+    for plot in plots[variable]:
+        for threshold in thresholds:
+            plotName = '{0}_threshold_{1}'.format(plot, threshold)
+            add_plot(plotName)
+
+allPlots_HI = []
+allPlots_HI.extend(allEfficiencyPlots_HI)
+allPlots_HI.extend(resolution_plots)
+allPlots_HI.extend(plots2D)
+
+from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
+ppRef_2017.toModify(l1tEGammaEmuDiff,
+    plotCfgs=cms.untracked.VPSet(
+        cms.untracked.PSet(  # EMU comparison
+            dir1=cms.untracked.string("L1T/L1TEGamma"),
+            dir2=cms.untracked.string("L1TEMU/L1TEGamma"),
+            outputDir=cms.untracked.string(
+                "L1TEMU/L1TEGamma/Comparison"),
+            plots=cms.untracked.vstring(allPlots_HI)
+        ),
+    )
+)

--- a/DQMOffline/L1Trigger/python/L1TEGammaEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaEfficiency_cfi.py
@@ -92,21 +92,8 @@ for variable, thresholds in deepInspectionThresholds_HI.iteritems():
 
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 ppRef_2017.toModify(l1tEGammaEfficiency,
-    plotCfgs=cms.untracked.VPSet(
-        cms.untracked.PSet(
-            numeratorDir=cms.untracked.string("L1T/L1TEGamma/efficiency_raw"),
-            outputDir=cms.untracked.string("L1T/L1TEGamma"),
-            numeratorSuffix=cms.untracked.string("_Num"),
-            denominatorSuffix=cms.untracked.string("_Den"),
-            plots=cms.untracked.vstring(allEfficiencyPlots_HI)
-        ),
-        cms.untracked.PSet(
-            numeratorDir=cms.untracked.string(
-                "L1TEMU/L1TEGamma/efficiency_raw"),
-            outputDir=cms.untracked.string("L1TEMU/L1TEGamma"),
-            numeratorSuffix=cms.untracked.string("_Num"),
-            denominatorSuffix=cms.untracked.string("_Den"),
-            plots=cms.untracked.vstring(allEfficiencyPlots_HI)
-        ),
-    )
+    plotCfgs = {
+        0:dict(plots = allEfficiencyPlots_HI),
+        1:dict(plots = allEfficiencyPlots_HI)
+    }
 )

--- a/DQMOffline/L1Trigger/python/L1TEGammaEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaEfficiency_cfi.py
@@ -64,3 +64,49 @@ l1tEGammaEfficiency = l1tEfficiencyHarvesting.clone(
         ),
     )
 )
+
+# modifications for the pp reference run
+variables_HI = {
+    'electron': L1TEGammaOffline_cfi.electronEfficiencyThresholds_HI,
+    'photon': L1TEGammaOffline_cfi.photonEfficiencyThresholds_HI,
+}
+
+deepInspectionThresholds_HI = {
+    'electron': L1TEGammaOffline_cfi.deepInspectionElectronThresholds_HI,
+    'photon': [],
+}
+
+allEfficiencyPlots_HI = []
+add_plot = allEfficiencyPlots_HI.append
+for variable, thresholds in variables_HI.iteritems():
+    for plot in plots[variable]:
+        for threshold in thresholds:
+            plotName = '{0}_threshold_{1}'.format(plot, threshold)
+            add_plot(plotName)
+
+for variable, thresholds in deepInspectionThresholds_HI.iteritems():
+    for plot in deepInspectionPlots[variable]:
+        for threshold in thresholds:
+            plotName = '{0}_threshold_{1}'.format(plot, threshold)
+            add_plot(plotName)
+
+from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
+ppRef_2017.toModify(l1tEGammaEfficiency,
+    plotCfgs=cms.untracked.VPSet(
+        cms.untracked.PSet(
+            numeratorDir=cms.untracked.string("L1T/L1TEGamma/efficiency_raw"),
+            outputDir=cms.untracked.string("L1T/L1TEGamma"),
+            numeratorSuffix=cms.untracked.string("_Num"),
+            denominatorSuffix=cms.untracked.string("_Den"),
+            plots=cms.untracked.vstring(allEfficiencyPlots_HI)
+        ),
+        cms.untracked.PSet(
+            numeratorDir=cms.untracked.string(
+                "L1TEMU/L1TEGamma/efficiency_raw"),
+            outputDir=cms.untracked.string("L1TEMU/L1TEGamma"),
+            numeratorSuffix=cms.untracked.string("_Num"),
+            denominatorSuffix=cms.untracked.string("_Den"),
+            plots=cms.untracked.vstring(allEfficiencyPlots_HI)
+        ),
+    )
+)

--- a/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
@@ -44,14 +44,42 @@ l1tEGammaOfflineDQM = cms.EDAnalyzer(
     electronEfficiencyThresholds=cms.vdouble(electronEfficiencyThresholds),
     electronEfficiencyBins=cms.vdouble(electronEfficiencyBins),
     probeToL1Offset=cms.double(probeToL1Offset),
-    deepInspectionElectronThresholds=cms.vdouble([48, 50]),
+    deepInspectionElectronThresholds=cms.vdouble(deepInspectionElectronThresholds),
 
     photonEfficiencyThresholds=cms.vdouble(photonEfficiencyThresholds),
     photonEfficiencyBins=cms.vdouble(photonEfficiencyBins),
 )
 
+# modifications for the pp reference run
+electronEfficiencyThresholds_HI = [5, 10, 15, 21]
+deepInspectionElectronThresholds_HI = [15]
+
+electronEfficiencyBins_HI = []
+electronEfficiencyBins_HI.extend(list(xrange(1, 26, 1)))
+electronEfficiencyBins_HI.extend(list(xrange(26, 42, 2)))
+electronEfficiencyBins_HI.extend(list(xrange(42, 45, 3)))
+electronEfficiencyBins_HI.extend(list(xrange(45, 50, 5)))
+electronEfficiencyBins_HI.extend(list(xrange(50, 70, 10)))
+electronEfficiencyBins_HI.extend(list(xrange(70, 101, 30)))
+
+photonEfficiencyThresholds_HI = electronEfficiencyThresholds_HI
+photonEfficiencyBins_HI = electronEfficiencyBins_HI
+
+from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
+ppRef_2017.toModify(l1tEGammaOfflineDQM,
+    TriggerFilter=cms.InputTag('hltEle20WPLoose1GsfTrackIsoFilter', '', 'HLT'),
+    TriggerPath=cms.string('HLT_Ele20_WPLoose_Gsf_v4'),
+    electronEfficiencyThresholds=cms.vdouble(electronEfficiencyThresholds_HI),
+    electronEfficiencyBins=cms.vdouble(electronEfficiencyBins_HI),
+    deepInspectionElectronThresholds=cms.vdouble(deepInspectionElectronThresholds_HI),
+    photonEfficiencyThresholds=cms.vdouble(photonEfficiencyThresholds_HI),
+    photonEfficiencyBins=cms.vdouble(photonEfficiencyBins_HI)
+)
+
+# emulator module
 l1tEGammaOfflineDQMEmu = l1tEGammaOfflineDQM.clone(
     stage2CaloLayer2EGammaSource=cms.InputTag("simCaloStage2Digis"),
 
     histFolder=cms.string('L1TEMU/L1TEGamma'),
 )
+

--- a/DQMOffline/L1Trigger/python/L1TMuonDQMEfficiency_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TMuonDQMEfficiency_cff.py
@@ -35,14 +35,6 @@ l1tMuonDQMEfficiency = l1tEfficiencyHarvesting.clone(
 # modifications for the pp reference run
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 ppRef_2017.toModify(l1tMuonDQMEfficiency,
-    plotCfgs = cms.untracked.VPSet(
-        cms.untracked.PSet(
-            numeratorDir = cms.untracked.string("L1T/L1TMuon/numerators_and_denominators"),
-            outputDir = cms.untracked.string("L1T/L1TMuon"),
-            numeratorSuffix = cms.untracked.string("_Num"),
-            denominatorSuffix = cms.untracked.string("_Den"),
-            plots = cms.untracked.vstring(allEfficiencyPlots_HI)
-        )
-    )
+    plotCfgs = {0:dict(plots = allEfficiencyPlots_HI)}
 )
 

--- a/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Diff_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Diff_cfi.py
@@ -84,14 +84,6 @@ allPlots_HI.extend(plots2D)
 
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 ppRef_2017.toModify(l1tStage2CaloLayer2EmuDiff,
-    plotCfgs=cms.untracked.VPSet(
-        cms.untracked.PSet(  # EMU comparison
-            dir1=cms.untracked.string("L1T/L1TStage2CaloLayer2"),
-            dir2=cms.untracked.string("L1TEMU/L1TStage2CaloLayer2"),
-            outputDir=cms.untracked.string(
-                "L1TEMU/L1TStage2CaloLayer2/Comparison"),
-            plots=cms.untracked.vstring(allPlots_HI)
-        ),
-    )
+    plotCfgs = {0:dict(plots = allPlots_HI)}
 )
 

--- a/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Diff_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Diff_cfi.py
@@ -64,3 +64,34 @@ l1tStage2CaloLayer2EmuDiff = l1tDiffHarvesting.clone(
         ),
     )
 )
+
+# modifications for the pp reference run
+variables_HI = variables
+variables_HI['jet'] = L1TStep1.jetEfficiencyThresholds_HI
+
+allEfficiencyPlots_HI = []
+add_plot = allEfficiencyPlots_HI.append
+for variable, thresholds in variables_HI.iteritems():
+    for plot in plots[variable]:
+        for threshold in thresholds:
+            plotName = '{0}_threshold_{1}'.format(plot, threshold)
+            add_plot(plotName)
+
+allPlots_HI = []
+allPlots_HI.extend(allEfficiencyPlots_HI)
+allPlots_HI.extend(resolution_plots)
+allPlots_HI.extend(plots2D)
+
+from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
+ppRef_2017.toModify(l1tStage2CaloLayer2EmuDiff,
+    plotCfgs=cms.untracked.VPSet(
+        cms.untracked.PSet(  # EMU comparison
+            dir1=cms.untracked.string("L1T/L1TStage2CaloLayer2"),
+            dir2=cms.untracked.string("L1TEMU/L1TStage2CaloLayer2"),
+            outputDir=cms.untracked.string(
+                "L1TEMU/L1TStage2CaloLayer2/Comparison"),
+            plots=cms.untracked.vstring(allPlots_HI)
+        ),
+    )
+)
+

--- a/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Efficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Efficiency_cfi.py
@@ -46,3 +46,36 @@ l1tStage2CaloLayer2Efficiency = l1tEfficiencyHarvesting.clone(
         ),
     )
 )
+
+# modifications for the pp reference run
+variables_HI = variables
+variables_HI['jet'] = L1TStep1.jetEfficiencyThresholds_HI
+
+allEfficiencyPlots_HI = []
+add_plot = allEfficiencyPlots_HI.append
+for variable, thresholds in variables_HI.iteritems():
+    for plot in plots[variable]:
+        for threshold in thresholds:
+            plotName = '{0}_threshold_{1}'.format(plot, threshold)
+            add_plot(plotName)
+
+from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
+ppRef_2017.toModify(l1tStage2CaloLayer2Efficiency,
+    plotCfgs=cms.untracked.VPSet(
+        cms.untracked.PSet(
+            numeratorDir=cms.untracked.string("L1T/L1TStage2CaloLayer2/efficiency_raw"),
+            outputDir=cms.untracked.string("L1T/L1TStage2CaloLayer2"),
+            numeratorSuffix=cms.untracked.string("_Num"),
+            denominatorSuffix=cms.untracked.string("_Den"),
+            plots=cms.untracked.vstring(allEfficiencyPlots_HI)
+        ),
+        cms.untracked.PSet(
+            numeratorDir=cms.untracked.string("L1TEMU/L1TStage2CaloLayer2/efficiency_raw"),
+            outputDir=cms.untracked.string("L1TEMU/L1TStage2CaloLayer2"),
+            numeratorSuffix=cms.untracked.string("_Num"),
+            denominatorSuffix=cms.untracked.string("_Den"),
+            plots=cms.untracked.vstring(allEfficiencyPlots_HI)
+        ),
+    )
+)
+

--- a/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Efficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Efficiency_cfi.py
@@ -61,21 +61,9 @@ for variable, thresholds in variables_HI.iteritems():
 
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 ppRef_2017.toModify(l1tStage2CaloLayer2Efficiency,
-    plotCfgs=cms.untracked.VPSet(
-        cms.untracked.PSet(
-            numeratorDir=cms.untracked.string("L1T/L1TStage2CaloLayer2/efficiency_raw"),
-            outputDir=cms.untracked.string("L1T/L1TStage2CaloLayer2"),
-            numeratorSuffix=cms.untracked.string("_Num"),
-            denominatorSuffix=cms.untracked.string("_Den"),
-            plots=cms.untracked.vstring(allEfficiencyPlots_HI)
-        ),
-        cms.untracked.PSet(
-            numeratorDir=cms.untracked.string("L1TEMU/L1TStage2CaloLayer2/efficiency_raw"),
-            outputDir=cms.untracked.string("L1TEMU/L1TStage2CaloLayer2"),
-            numeratorSuffix=cms.untracked.string("_Num"),
-            denominatorSuffix=cms.untracked.string("_Den"),
-            plots=cms.untracked.vstring(allEfficiencyPlots_HI)
-        ),
-    )
+    plotCfgs = {
+        0:dict(plots = allEfficiencyPlots_HI),
+        1:dict(plots = allEfficiencyPlots_HI)
+    }
 )
 

--- a/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Offline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Offline_cfi.py
@@ -78,6 +78,25 @@ l1tStage2CaloLayer2OfflineDQM = cms.EDAnalyzer(
     recoMHTMaxEta=cms.double(2.5),
 )
 
+# modifications for the pp reference run
+jetEfficiencyThresholds_HI = [8, 16, 24, 44, 60, 80, 90]
+jetEfficiencyBins_HI = []
+jetEfficiencyBins_HI.extend(list(xrange(0, 60, 2)))
+jetEfficiencyBins_HI.extend(list(xrange(60, 90, 5)))
+jetEfficiencyBins_HI.extend(list(xrange(90, 120, 10)))
+jetEfficiencyBins_HI.extend(list(xrange(120, 180, 20)))
+jetEfficiencyBins_HI.extend(list(xrange(180, 300, 40)))
+jetEfficiencyBins_HI.extend(list(xrange(300, 401, 100)))
+
+from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
+ppRef_2017.toModify(l1tStage2CaloLayer2OfflineDQM,
+    TriggerFilter=cms.InputTag('hltEle20WPLoose1GsfTrackIsoFilter', '', 'HLT'),
+    TriggerPath=cms.string('HLT_Ele20_WPLoose_Gsf_v4'),
+    jetEfficiencyThresholds=cms.vdouble(jetEfficiencyThresholds_HI),
+    jetEfficiencyBins=cms.vdouble(jetEfficiencyBins_HI),
+)
+
+# emulator module
 l1tStage2CaloLayer2OfflineDQMEmu = l1tStage2CaloLayer2OfflineDQM.clone(
     stage2CaloLayer2JetSource=cms.InputTag("simCaloStage2Digis"),
     stage2CaloLayer2EtSumSource=cms.InputTag("simCaloStage2Digis"),


### PR DESCRIPTION
To make the L1T offline DQM work for the pp reference run the trigger paths used must be adapted for the pp reference run HLT menu.

Part 2: L1T EG and L1T Jets