### PR TITLE
Forward declaration of DoNotRecordParents needs to be a struct

### DIFF
--- a/FWCore/Framework/interface/ProductRegistryHelper.h
+++ b/FWCore/Framework/interface/ProductRegistryHelper.h
@@ -18,7 +18,7 @@ ProductRegistryHelper:
 namespace edm {
   class ModuleDescription;
   class ProductRegistry;
-  class DoNotRecordParents;
+  struct DoNotRecordParents;
   
   class ProductRegistryHelper {
   public:


### PR DESCRIPTION
clang gave a warning that the forward declaration was a class but
the actual declaration is a struct.