### PR TITLE
Removing ambiguous assertion from unit test TestCondFormatsJetMETObjectsJetCorrectorParameters

### DIFF
--- a/CondFormats/JetMETObjects/test/JetCorrectorParameters_t.cpp
+++ b/CondFormats/JetMETObjects/test/JetCorrectorParameters_t.cpp
@@ -160,7 +160,7 @@ void testJetCorrectorParameters::generateFiles() {
 
 void testJetCorrectorParameters::benchmarkBinIndex(bool is3D) {
     float oldCPU = 0, newCPU = 0, oldReal = 0, newReal = 0;
-    unsigned int ntests = (is3D) ? 1000 : 1000000;
+    unsigned int ntests = (is3D) ? 100000 : 1000000;
     if(is3D) fX = {5.0,50.0,100.0};
     else     fX = {5.0};
     setupCorrector(is3D);
@@ -197,7 +197,9 @@ void testJetCorrectorParameters::benchmarkBinIndex(bool is3D) {
          << "\tReal speedup = " << oldReal/newReal << endl;
 
     CPPUNIT_ASSERT(oldCPU/newCPU >= 1.0);
-    CPPUNIT_ASSERT(oldReal/newReal >= 1.0);
+    //CPPUNIT_ASSERT(oldReal/newReal >= 1.0); //this might fail not due to longer L1JetPar->binIndexN(fX) execution
+    if (oldReal/newReal >= 1.0)
+    cout << "newReal value increased oldReal, which might be due to system load" << endl;
 
     destroyCorrector();
 }


### PR DESCRIPTION
Substituting CPPUNIT_ASSERT(oldReal/newReal >= 1.0);
with simple printout as real time might not be calculated based only on function call execution time.
Also increasing iterations on line 163 from 1000 to 100000 