### PR TITLE
Solve static check issues and bugs for reco muon tracking tools

### DIFF
--- a/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
@@ -756,7 +756,7 @@ vector<Trajectory> GlobalMuonRefitter::transform(const reco::Track& newTrack,
 //  if(propDir == oppositeToMomentum && theRefitDirection == insideOut) propDir=alongMomentum;
 
   const TrajectoryStateOnSurface& tsosForDir = inner_is_first ? lastTSOS : firstTSOS;
-  propDir = (tsosForDir.globalPosition().basicVector().dot(tsosForDir.globalMomentum().basicVector())>0) ? alongMomentum : oppositeToMomentum;
+  PropagationDirection propDir = (tsosForDir.globalPosition().basicVector().dot(tsosForDir.globalMomentum().basicVector())>0) ? alongMomentum : oppositeToMomentum;
   LogTrace(theCategory) << "propDir based on firstTSOS x dot p is " << propDir
 			<< " (alongMomentum == " << alongMomentum << ", oppositeToMomentum == " << oppositeToMomentum << ")";
 

--- a/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
@@ -749,8 +749,6 @@ vector<Trajectory> GlobalMuonRefitter::transform(const reco::Track& newTrack,
   // This is the only way to get a TrajectorySeed with settable propagation direction
   PTrajectoryStateOnDet garbage1;
   edm::OwnVector<TrackingRecHit> garbage2;
-  PropagationDirection propDir = 
-    (firstTSOS.globalPosition().basicVector().dot(firstTSOS.globalMomentum().basicVector())>0) ? alongMomentum : oppositeToMomentum;
 
   // These lines cause the code to ignore completely what was set
   // above, and force propDir for tracks from collisions!

--- a/RecoMuon/TrackingTools/src/MuonErrorMatrix.cc
+++ b/RecoMuon/TrackingTools/src/MuonErrorMatrix.cc
@@ -64,8 +64,8 @@ MuonErrorMatrix::MuonErrorMatrix(const edm::ParameterSet & iConfig):theD(nullptr
       if (yBins.empty()){edm::LogError( theCategory)<<"NEta=0 and no entries in the vector. I will do aseg fault soon.";}
       NEta = yBins.size()-1;
       yBinsArray = &(yBins.front());
-      minPt = yBins.front();
-      maxPt = yBins.back();}
+      minEta = yBins.front();
+      maxEta = yBins.back();}
 
     NPhi = iConfig.getParameter<int>("NPhi");
     std::stringstream get(iConfig.getParameter<std::string>("minPhi"));

--- a/RecoMuon/TrackingTools/src/MuonErrorMatrix.cc
+++ b/RecoMuon/TrackingTools/src/MuonErrorMatrix.cc
@@ -92,8 +92,8 @@ MuonErrorMatrix::MuonErrorMatrix(const edm::ParameterSet & iConfig):theD(nullptr
     yBins = errorMatrixValuesPSet.getParameter<std::vector<double> >("yAxis");
     NEta = yBins.size()-1;
     yBinsArray = &(yBins.front());
-    minPt = yBins.front();
-    maxPt = yBins.back();
+    minEta = yBins.front();
+    maxEta = yBins.back();
 
     std::vector<double> zBins = errorMatrixValuesPSet.getParameter<std::vector<double> >("zAxis");
     NPhi=1;

--- a/RecoMuon/TrackingTools/src/MuonTrajectoryCleaner.cc
+++ b/RecoMuon/TrackingTools/src/MuonTrajectoryCleaner.cc
@@ -60,10 +60,6 @@ void MuonTrajectoryCleaner::clean(TrajectoryContainer& trajC, edm::Event& event,
 	} // end for( m2 ... )
       } // end for( m1 ... )
       
-
-      int nTotHits_i = (*iter)->measurements().size();
-      int nTotHits_j = (*jter)->measurements().size();
-
       // FIXME Set Boff/on via cfg!
       double chi2_dof_i = (*iter)->ndof() > 0 ? (*iter)->chiSquared()/(*iter)->ndof() : (*iter)->chiSquared()/1e-10;
       double chi2_dof_j = (*jter)->ndof() > 0 ? (*jter)->chiSquared()/(*jter)->ndof() : (*jter)->chiSquared()/1e-10;
@@ -72,11 +68,11 @@ void MuonTrajectoryCleaner::clean(TrajectoryContainer& trajC, edm::Event& event,
       LogTrace(metname) << " * trajC " << i 
 			<< " (pT="<<(*iter)->lastMeasurement().updatedState().globalMomentum().perp() 
 			<< " GeV) - chi2/nDOF = " << (*iter)->chiSquared() << "/" << (*iter)->ndof() << " = " << chi2_dof_i;
-      LogTrace(metname)	<< "     - valid RH = " << (*iter)->foundHits() << " / total RH = " <<  nTotHits_i;
+      LogTrace(metname)	<< "     - valid RH = " << (*iter)->foundHits() << " / total RH = " <<  (*iter)->measurements().size();
       LogTrace(metname)	<< " * trajC " << j 
 			<< " (pT="<<(*jter)->lastMeasurement().updatedState().globalMomentum().perp() 
 			<< " GeV) - chi2/nDOF = " << (*jter)->chiSquared() << "/" << (*jter)->ndof() << " = " << chi2_dof_j;
-      LogTrace(metname)	<< "     - valid RH = " << (*jter)->foundHits() << " / total RH = " <<  nTotHits_j;
+      LogTrace(metname)	<< "     - valid RH = " << (*jter)->foundHits() << " / total RH = " << (*jter)->measurements().size();
       LogTrace(metname)	<< " *** Shared RecHits: " << match; 
 
       int hit_diff =  (*iter)->foundHits() - (*jter)->foundHits() ;       


### PR DESCRIPTION
I hit the issues addressed here while looking at the output of the static analyzer triggered in a pull request review.

The fixes in RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc and RecoMuon/TrackingTools/src/MuonTrajectoryCleaner.cc are just cleaning and, they are uncontroversial. 

In RecoMuon/TrackingTools/src/MuonErrorMatrix.cc there was a real bug, instead: min/maxPt was assigned instead of min/maxEta in a couple of places. It looks like that these two places were not accessed with the standard configuration (and in fact there are no changes in reco outputs in jenkins) but they must be fixed anyhow.

@drkovalskyi @folguera 