### PR TITLE
Solve a possible bug found in RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc

### DIFF
--- a/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc
@@ -905,14 +905,14 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
            GlobalPoint refpoint = (*iseed)->globalPosition(); //starting from the one with smallest value of phi
            muonRecHitsThetaTemp.clear();
            muonRecHitsThetaTemp = findThetaCluster(muonCorrelatedHits.at(stat), refpoint);
+	   if (muonRecHitsThetaTemp.size() > 1) {
+	     float dtheta = fabs((float)muonRecHitsThetaTemp.back()->globalPosition().theta() - (float)muonRecHitsThetaTemp.front()->globalPosition().theta());
+	     if (dtheta > dthetamax) {
+	       dthetamax = dtheta;
+	       muonRecHitsThetaBest = muonRecHitsThetaTemp;
+	     }
+	   } //at least two hits
        }//loop over seeds
-       if (muonRecHitsThetaTemp.size() > 1) {
-         float dtheta = fabs((float)muonRecHitsThetaTemp.back()->globalPosition().theta() - (float)muonRecHitsThetaTemp.front()->globalPosition().theta());
-         if (dtheta > dthetamax) {
-           dthetamax = dtheta;
-           muonRecHitsThetaBest = muonRecHitsThetaTemp;
-         }
-       } //at least two hits
      }//not empty container2
 
      //fill deltaRs


### PR DESCRIPTION
I hit the issues addressed here while looking at the output of the static analyzer triggered in a pull request review.

Quite likely the static analyzer was able to spot a real bug in RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc

The muonRecHitsThetaBest was  previously always taken as the last recHitContainer encountered in the loop over muonCorrelatedHits, instead of the one with the largest dtheta (as the logic of the code suggests). This fix moves the assignment of muonRecHitsThetaBest following the check if (dtheta > dthetamax) inside the loop.
@drkovalskyi @folguera 