### PR TITLE
 ppEra_Run2_2017_ppRef has standard format (not repacked) [backport of #21255 ]

### DIFF
--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_ppRef.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_ppRef.py
@@ -21,7 +21,6 @@ class ppEra_Run2_2017_ppRef(pp):
         self.recoSeq=''
         self.cbSc='pp'
         self.addEI=True
-        self.isRepacked=True
         self.eras=Run2_2017_ppRef
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_ppRef' ]
         self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_ppRef' ]


### PR DESCRIPTION
drop isRepacked = True flag.
This should fix problems in
https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/1776/1/1/1/1/1/1/1/2/1/1/2/1/1/1.html
