### PR TITLE
Fix fastsim generalTracks for premixing case

### DIFF
--- a/FastSimulation/Configuration/python/DigiAliases_cff.py
+++ b/FastSimulation/Configuration/python/DigiAliases_cff.py
@@ -13,12 +13,14 @@ caloStage1LegacyFormatDigis = None
 gtDigis = None
 gmtDigis = None
 
-def loadDigiAliases(premix=False):
+loadDigiAliasesWasCalled = False
 
+def loadDigiAliases(premix=False):
     nopremix = not premix
 
-    global generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis
+    global generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis,loadDigiAliasesWasCalled
 
+    loadDigiAliasesWasCalled=True
     generalTracks = cms.EDAlias(
         **{"mix" if nopremix else "mixData" :
            cms.VPSet(

--- a/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
@@ -59,7 +59,10 @@ fastSim.toReplaceWith(generalTracksSequence,
         )
 )
 def _fastSimGeneralTracks(process):
-    if hasattr(process,"generalTracks") and isinstance(process.generalTracks,cms.EDAlias):
+    from FastSimulation.Configuration.DigiAliases_cff import loadDigiAliasesWasCalled
+    if loadDigiAliasesWasCalled:
+        from FastSimulation.Configuration.DigiAliases_cff import generalTracks
+        process.generalTracks = generalTracks
         return
     from Configuration.StandardSequences.Digi_cff import generalTracks
     process.generalTracks = generalTracks


### PR DESCRIPTION
The change to fastsim making futher use of eras did not properly
handle the case where premixing is being used.