### PR TITLE
[10.0.x] Update of SiStrip PI classes

### DIFF
--- a/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
+++ b/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
@@ -72,101 +72,59 @@ namespace SiStripPI {
     END_OF_REGIONS	
   };
 
-  // mapping to get the bin number
-  std::map<SiStripPI::TrackerRegion,unsigned int> EnumToBinMap{
-    {TrackerRegion::TIB1r,1 }, 
-    {TrackerRegion::TIB1s,2 },
-    {TrackerRegion::TIB2r,3 }, 
-    {TrackerRegion::TIB2s,4 },
-    {TrackerRegion::TIB3r,5 },
-    {TrackerRegion::TIB4r,6 },
-    {TrackerRegion::TOB1r,7 }, 
-    {TrackerRegion::TOB1s,8 },
-    {TrackerRegion::TOB2r,9 }, 
-    {TrackerRegion::TOB2s,10},
-    {TrackerRegion::TOB3r,11},
-    {TrackerRegion::TOB4r,12},
-    {TrackerRegion::TOB5r,13},
-    {TrackerRegion::TOB6r,14},
-    {TrackerRegion::TEC1r,15}, 
-    {TrackerRegion::TEC1s,16},
-    {TrackerRegion::TEC2r,17}, 
-    {TrackerRegion::TEC2s,18},
-    {TrackerRegion::TEC3r,19}, 
-    {TrackerRegion::TEC3s,20},
-    {TrackerRegion::TEC4r,21}, 
-    {TrackerRegion::TEC4s,22},
-    {TrackerRegion::TEC5r,23}, 
-    {TrackerRegion::TEC5s,24},
-    {TrackerRegion::TEC6r,25}, 
-    {TrackerRegion::TEC6s,26},
-    {TrackerRegion::TEC7r,27}, 
-    {TrackerRegion::TEC7s,28},
-    {TrackerRegion::TEC8r,29}, 
-    {TrackerRegion::TEC8s,30},
-    {TrackerRegion::TEC9r,31}, 
-    {TrackerRegion::TEC9s,32},
-    {TrackerRegion::TID1r,33}, 
-    {TrackerRegion::TID1s,34},
-    {TrackerRegion::TID2r,35}, 
-    {TrackerRegion::TID2s,36},
-    {TrackerRegion::TID3r,37}, 
-    {TrackerRegion::TID3s,38}
-  };
-
   /*--------------------------------------------------------------------*/
-  const char * regionType(int index)
+  std::pair<int,const char *> regionType(int index)
   /*--------------------------------------------------------------------*/
   {
     
     auto region = static_cast<std::underlying_type_t<SiStripPI::TrackerRegion> >(index);
 
     switch(region){
-    case SiStripPI::TIB1r: return "TIB L1 r-#varphi";
-    case SiStripPI::TIB1s: return "TIB L1 stereo";
-    case SiStripPI::TIB2r: return "TIB L2 r-#varphi";
-    case SiStripPI::TIB2s: return "TIB L2 stereo";
-    case SiStripPI::TIB3r: return "TIB L3";
-    case SiStripPI::TIB4r: return "TIB L4";
-    case SiStripPI::TOB1r: return "TOB L1 r-#varphi";
-    case SiStripPI::TOB1s: return "TOB L1 stereo";
-    case SiStripPI::TOB2r: return "TOB L2 r-#varphi";
-    case SiStripPI::TOB2s: return "TOB L2 stereo";
-    case SiStripPI::TOB3r: return "TOB L3 r-#varphi";
-    case SiStripPI::TOB4r: return "TOB L4";
-    case SiStripPI::TOB5r: return "TOB L5";
-    case SiStripPI::TOB6r: return "TOB L6";
-    case SiStripPI::TEC1r: return "TEC D1 r-#varphi";
-    case SiStripPI::TEC1s: return "TEC D1 stereo";
-    case SiStripPI::TEC2r: return "TEC D2 r-#varphi";
-    case SiStripPI::TEC2s: return "TEC D2 stereo";
-    case SiStripPI::TEC3r: return "TEC D3 r-#varphi";
-    case SiStripPI::TEC3s: return "TEC D3 stereo";
-    case SiStripPI::TEC4r: return "TEC D4 r-#varphi";
-    case SiStripPI::TEC4s: return "TEC D4 stereo";
-    case SiStripPI::TEC5r: return "TEC D5 r-#varphi";
-    case SiStripPI::TEC5s: return "TEC D5 stereo";
-    case SiStripPI::TEC6r: return "TEC D6 r-#varphi";
-    case SiStripPI::TEC6s: return "TEC D6 stereo";
-    case SiStripPI::TEC7r: return "TEC D7 r-#varphi";
-    case SiStripPI::TEC7s: return "TEC D7 stereo";
-    case SiStripPI::TEC8r: return "TEC D8 r-#varphi";
-    case SiStripPI::TEC8s: return "TEC D8 stereo";
-    case SiStripPI::TEC9r: return "TEC D9 r-#varphi";
-    case SiStripPI::TEC9s: return "TEC D9 stereo";
-    case SiStripPI::TID1r: return "TID D1 r-#varphi";
-    case SiStripPI::TID1s: return "TID D1 stereo";
-    case SiStripPI::TID2r: return "TID D2 r-#varphi";
-    case SiStripPI::TID2s: return "TID D2 stereo";
-    case SiStripPI::TID3r: return "TID D3 r-#varphi"; 
-    case SiStripPI::TID3s: return "TID D3 stereo";
-    case SiStripPI::END_OF_REGIONS : return "undefined";
-    default : return "should never be here";  
+    case SiStripPI::TIB1r: return std::make_pair(1 ,"TIB L1 r-#varphi");
+    case SiStripPI::TIB1s: return std::make_pair(2 ,"TIB L1 stereo");
+    case SiStripPI::TIB2r: return std::make_pair(3 ,"TIB L2 r-#varphi");
+    case SiStripPI::TIB2s: return std::make_pair(4 ,"TIB L2 stereo");
+    case SiStripPI::TIB3r: return std::make_pair(5 ,"TIB L3");
+    case SiStripPI::TIB4r: return std::make_pair(6 ,"TIB L4");
+    case SiStripPI::TOB1r: return std::make_pair(7 ,"TOB L1 r-#varphi");
+    case SiStripPI::TOB1s: return std::make_pair(8 ,"TOB L1 stereo");
+    case SiStripPI::TOB2r: return std::make_pair(9 ,"TOB L2 r-#varphi");
+    case SiStripPI::TOB2s: return std::make_pair(10,"TOB L2 stereo");
+    case SiStripPI::TOB3r: return std::make_pair(11,"TOB L3 r-#varphi");
+    case SiStripPI::TOB4r: return std::make_pair(12,"TOB L4");
+    case SiStripPI::TOB5r: return std::make_pair(13,"TOB L5");
+    case SiStripPI::TOB6r: return std::make_pair(14,"TOB L6");
+    case SiStripPI::TEC1r: return std::make_pair(15,"TEC D1 r-#varphi");
+    case SiStripPI::TEC1s: return std::make_pair(16,"TEC D1 stereo");
+    case SiStripPI::TEC2r: return std::make_pair(17,"TEC D2 r-#varphi");
+    case SiStripPI::TEC2s: return std::make_pair(18,"TEC D2 stereo");
+    case SiStripPI::TEC3r: return std::make_pair(19,"TEC D3 r-#varphi");
+    case SiStripPI::TEC3s: return std::make_pair(20,"TEC D3 stereo");
+    case SiStripPI::TEC4r: return std::make_pair(21,"TEC D4 r-#varphi");
+    case SiStripPI::TEC4s: return std::make_pair(22,"TEC D4 stereo");
+    case SiStripPI::TEC5r: return std::make_pair(23,"TEC D5 r-#varphi");
+    case SiStripPI::TEC5s: return std::make_pair(24,"TEC D5 stereo");
+    case SiStripPI::TEC6r: return std::make_pair(25,"TEC D6 r-#varphi");
+    case SiStripPI::TEC6s: return std::make_pair(26,"TEC D6 stereo");
+    case SiStripPI::TEC7r: return std::make_pair(27,"TEC D7 r-#varphi");
+    case SiStripPI::TEC7s: return std::make_pair(28,"TEC D7 stereo");
+    case SiStripPI::TEC8r: return std::make_pair(29,"TEC D8 r-#varphi");
+    case SiStripPI::TEC8s: return std::make_pair(30,"TEC D8 stereo");
+    case SiStripPI::TEC9r: return std::make_pair(31,"TEC D9 r-#varphi");
+    case SiStripPI::TEC9s: return std::make_pair(32,"TEC D9 stereo");
+    case SiStripPI::TID1r: return std::make_pair(33,"TID D1 r-#varphi");
+    case SiStripPI::TID1s: return std::make_pair(34,"TID D1 stereo");
+    case SiStripPI::TID2r: return std::make_pair(35,"TID D2 r-#varphi");
+    case SiStripPI::TID2s: return std::make_pair(36,"TID D2 stereo");
+    case SiStripPI::TID3r: return std::make_pair(37,"TID D3 r-#varphi"); 
+    case SiStripPI::TID3s: return std::make_pair(38,"TID D3 stereo");
+    case SiStripPI::END_OF_REGIONS : std::make_pair(-1,"undefined");
+    default : return std::make_pair(999,"should never be here");  
     }
   }
 
   /*--------------------------------------------------------------------*/
-  std::pair<float,float> getTheRange(std::map<uint32_t,float> values,const int nsigma)
+  std::pair<float,float> getTheRange(std::map<uint32_t,float> values,const float nsigma)
   /*--------------------------------------------------------------------*/
   {
     float sum = std::accumulate(std::begin(values), 
@@ -295,7 +253,7 @@ namespace SiStripPI {
       int layer  = (element.first)/10 - (element.first)/1000*100;
       int stereo = (element.first) - (layer*10) -(element.first)/1000*1000;
       
-      std::cout<<"key of the map:"<<element.first <<" ( region: "<<regionType(element.first) <<" ) "  
+      std::cout<<"key of the map:"<<element.first <<" ( region: "<<regionType(element.first).second <<" ) "  
 	       << detector<<" layer: "<<layer<<" stereo:"<<stereo
 	       <<"| count:"<<count<<" mean: "<<mean<<" rms: "<<rms<<std::endl;
       

--- a/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
+++ b/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
@@ -166,7 +166,7 @@ namespace SiStripPI {
   }
 
   /*--------------------------------------------------------------------*/
-  std::pair<float,float> getTheRange(std::map<uint32_t,float> values)
+  std::pair<float,float> getTheRange(std::map<uint32_t,float> values,const int nsigma)
   /*--------------------------------------------------------------------*/
   {
     float sum = std::accumulate(std::begin(values), 
@@ -187,7 +187,7 @@ namespace SiStripPI {
     
     float stdev = sqrt(accum / (values.size()-1)); 
     
-    return std::make_pair(m-2*stdev,m+2*stdev);
+    return std::make_pair(m-nsigma*stdev,m+nsigma*stdev);
     
   }
   

--- a/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
+++ b/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
@@ -6,6 +6,7 @@
 #include <string>
 #include "TH1.h"
 #include "TPaveText.h"
+#include "TStyle.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"   
 #include "CondFormats/SiStripObjects/interface/SiStripSummary.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h" 
@@ -69,6 +70,48 @@ namespace SiStripPI {
     TID2r = 4020, TID2s = 4021,
     TID3r = 4030, TID3s = 4031,
     END_OF_REGIONS	
+  };
+
+  // mapping to get the bin number
+  std::map<SiStripPI::TrackerRegion,unsigned int> binToEnumMap{
+    {TrackerRegion::TIB1r,1 }, 
+    {TrackerRegion::TIB1s,2 },
+    {TrackerRegion::TIB2r,3 }, 
+    {TrackerRegion::TIB2s,4 },
+    {TrackerRegion::TIB3r,5 },
+    {TrackerRegion::TIB4r,6 },
+    {TrackerRegion::TOB1r,7 }, 
+    {TrackerRegion::TOB1s,8 },
+    {TrackerRegion::TOB2r,9 }, 
+    {TrackerRegion::TOB2s,10},
+    {TrackerRegion::TOB3r,11},
+    {TrackerRegion::TOB4r,12},
+    {TrackerRegion::TOB5r,13},
+    {TrackerRegion::TOB6r,14},
+    {TrackerRegion::TEC1r,15}, 
+    {TrackerRegion::TEC1s,16},
+    {TrackerRegion::TEC2r,17}, 
+    {TrackerRegion::TEC2s,18},
+    {TrackerRegion::TEC3r,19}, 
+    {TrackerRegion::TEC3s,20},
+    {TrackerRegion::TEC4r,21}, 
+    {TrackerRegion::TEC4s,22},
+    {TrackerRegion::TEC5r,23}, 
+    {TrackerRegion::TEC5s,24},
+    {TrackerRegion::TEC6r,25}, 
+    {TrackerRegion::TEC6s,26},
+    {TrackerRegion::TEC7r,27}, 
+    {TrackerRegion::TEC7s,28},
+    {TrackerRegion::TEC8r,29}, 
+    {TrackerRegion::TEC8s,30},
+    {TrackerRegion::TEC9r,31}, 
+    {TrackerRegion::TEC9s,32},
+    {TrackerRegion::TID1r,33}, 
+    {TrackerRegion::TID1s,34},
+    {TrackerRegion::TID2r,35}, 
+    {TrackerRegion::TID2s,36},
+    {TrackerRegion::TID3r,37}, 
+    {TrackerRegion::TID3s,38}
   };
 
   /*--------------------------------------------------------------------*/
@@ -281,7 +324,128 @@ namespace SiStripPI {
       NBadComponent[i][component][0]++;
     }
   }
+  
+  enum palette {HALFGRAY,GRAY,BLUES,REDS,ANTIGRAY,FIRE,ANTIFIRE,LOGREDBLUE,LOGBLUERED,DEFAULT};
+
+  /*--------------------------------------------------------------------*/
+  void setPaletteStyle(SiStripPI::palette palette) 
+  /*--------------------------------------------------------------------*/
+  {
+  
+    TStyle *palettestyle = new TStyle("palettestyle","Style for P-TDR");
+  
+    const int NRGBs = 5;
+    const int NCont = 255;
+    
+    switch(palette){
+
+    case HALFGRAY:
+      {
+	double stops[NRGBs] = {0.00, 0.34, 0.61, 0.84, 1.00};
+	double red[NRGBs]   = {1.00, 0.91, 0.80, 0.67, 1.00};
+	double green[NRGBs] = {1.00, 0.91, 0.80, 0.67, 1.00};
+	double blue[NRGBs]  = {1.00, 0.91, 0.80, 0.67, 1.00};
+	TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);
+      }
+      break;
+
+    case GRAY:
+      {
+	double stops[NRGBs] = {0.00, 0.01, 0.05, 0.09, 0.1};
+	double red[NRGBs]   = {1.00, 0.84, 0.61, 0.34, 0.00};
+	double green[NRGBs] = {1.00, 0.84, 0.61, 0.34, 0.00};
+	double blue[NRGBs]  = {1.00, 0.84, 0.61, 0.34, 0.00};
+      	TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);
+      }
+      break;
+
+    case BLUES:
+      {
+	double stops[NRGBs] = {0.00, 0.34, 0.61, 0.84, 1.00};
+	double red[NRGBs]   = {1.00, 0.84, 0.61, 0.34, 0.00};
+	double green[NRGBs] = {1.00, 0.84, 0.61, 0.34, 0.00};
+	double blue[NRGBs]  = {1.00, 1.00, 1.00, 1.00, 1.00};
+	TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);
+	
+      }
+      break;
+      
+    case REDS:
+	{
+	  double stops[NRGBs] = {0.00, 0.34, 0.61, 0.84, 1.00};
+	  double red[NRGBs]   = {1.00, 1.00, 1.00, 1.00, 1.00};
+	  double green[NRGBs] = {1.00, 0.84, 0.61, 0.34, 0.00};
+	  double blue[NRGBs]  = {1.00, 0.84, 0.61, 0.34, 0.00};
+	  TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);	
+	}
+	break;
+      
+    case ANTIGRAY:
+      {
+	double stops[NRGBs] = {0.00, 0.34, 0.61, 0.84, 1.00};
+	double red[NRGBs]   = {0.00, 0.34, 0.61, 0.84, 1.00};
+	double green[NRGBs] = {0.00, 0.34, 0.61, 0.84, 1.00};
+	double blue[NRGBs]  = {0.00, 0.34, 0.61, 0.84, 1.00};
+	TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);		
+      }      
+      break;
+      
+    case FIRE:
+      {
+	double stops[NRGBs] = {0.00, 0.20, 0.80, 1.00};
+	double red[NRGBs]   = {1.00, 1.00, 1.00, 0.50};
+	double green[NRGBs] = {1.00, 1.00, 0.00, 0.00};
+	double blue[NRGBs]  = {0.20, 0.00, 0.00, 0.00};
+	TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);	
+      }
+      break;
+
+    case ANTIFIRE:
+      {
+	double stops[NRGBs] = {0.00, 0.20, 0.80, 1.00};
+	double red[NRGBs]   = {0.50, 1.00, 1.00, 1.00};
+	double green[NRGBs] = {0.00, 0.00, 1.00, 1.00};
+	double blue[NRGBs]  = {0.00, 0.00, 0.00, 0.20};
+	TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);		
+      }
+      break;
+
+    case LOGREDBLUE:
+      {
+	double stops[NRGBs] = {0.0001, 0.0010, 0.0100, 0.1000,  1.0000};
+	double red[NRGBs]   = {1.00,   0.75,   0.50,   0.25,    0.00};
+	double green[NRGBs] = {0.00,   0.00,   0.00,   0.00,    0.00};
+	double blue[NRGBs]  = {0.00,   0.25,   0.50,   0.75,    1.00};
+	TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);		
+      }
+      break;
+      
+    case LOGBLUERED:
+      {
+	double stops[NRGBs] = {0.0001, 0.0010, 0.0100, 0.1000,  1.0000};
+	double red[NRGBs]   = {0.00,   0.25,   0.50,   0.75,    1.00};
+	double green[NRGBs] = {0.00,   0.00,   0.00,   0.00,    0.00};
+	double blue[NRGBs]  = {1.00,   0.75,   0.50,   0.25,    0.00};
+	TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);			
+      } 
+      break;
+    
+    case DEFAULT:
+      {
+	double stops[NRGBs] = {0.00, 0.34, 0.61, 0.84, 1.00};
+	double red[NRGBs]   = {0.00, 0.00, 0.87, 1.00, 0.51};
+	double green[NRGBs] = {0.00, 0.81, 1.00, 0.20, 0.00};
+	double blue[NRGBs]  = {0.51, 1.00, 0.12, 0.00, 0.00};
+	TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);	
+      }
+      break;
+    default:
+      std::cout<<"should nevere be here" << std::endl;
+      break;
+    }
+    
+    palettestyle->SetNumberContours(NCont);
+  }
 
 };
-
 #endif

--- a/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
+++ b/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
@@ -73,7 +73,7 @@ namespace SiStripPI {
   };
 
   // mapping to get the bin number
-  std::map<SiStripPI::TrackerRegion,unsigned int> binToEnumMap{
+  std::map<SiStripPI::TrackerRegion,unsigned int> EnumToBinMap{
     {TrackerRegion::TIB1r,1 }, 
     {TrackerRegion::TIB1s,2 },
     {TrackerRegion::TIB2r,3 }, 

--- a/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
@@ -1419,8 +1419,8 @@ namespace {
       TCanvas canvas("Payload comparison by Tracker Region","payload comparison by Tracker Region",1800,800); 
       canvas.Divide(2,1);
       
-      auto h2first = std::unique_ptr<TH2F>(new TH2F("byRegion1","SiStrip APV Gain average by region;; average SiStrip Gain",38,1.,39.,100.,0.,2.));
-      auto h2last  = std::unique_ptr<TH2F>(new TH2F("byRegion2","SiStrip APV Gain average by region;; average SiStrip Gain",38,1.,39.,100.,0.,2.));
+      auto h2first = std::unique_ptr<TH2F>(new TH2F("byRegion1","SiStrip APV Gain values by region;; average SiStrip Gain",38,1.,39.,100.,0.,2.));
+      auto h2last  = std::unique_ptr<TH2F>(new TH2F("byRegion2","SiStrip APV Gain values by region;; average SiStrip Gain",38,1.,39.,100.,0.,2.));
 
       auto h2ratio  = std::unique_ptr<TH2F>(new TH2F("byRegionRatio",
 						     Form("SiStrip APV Gains ratio by region;; Gains ratio IOV: %s/ IOV %s",lastIOVsince.c_str(),firstIOVsince.c_str())
@@ -1432,7 +1432,7 @@ namespace {
 
       canvas.cd(1)->SetBottomMargin(0.18);
       canvas.cd(1)->SetLeftMargin(0.12);
-      canvas.cd(1)->SetRightMargin(0.08);
+      canvas.cd(1)->SetRightMargin(0.05);
       canvas.Modified();
 
       std::vector<int> boundaries;
@@ -1467,20 +1467,26 @@ namespace {
       h2first->SetLineColor(kRed);
       h2first->SetFillColor(kRed);
 
+      h2first->SetMarkerStyle(20);
+      h2last->SetMarkerStyle(21);
+
+      h2first->SetMarkerColor(kRed);
+      h2last->SetMarkerColor(kBlue);
+
       canvas.cd(1);
       h2first->Draw("BOX");
       h2last->Draw("BOXsame");
       
       TLegend legend = TLegend(0.70,0.8,0.95,0.9);
       legend.SetHeader("Gain Comparison","C"); // option "C" allows to center the header
-      legend.AddEntry(h2first.get(),("IOV: "+std::to_string(std::get<0>(firstiov))).c_str(),"PL");
-      legend.AddEntry(h2last.get() ,("IOV: "+std::to_string(std::get<0>(lastiov))).c_str(),"PL");
+      legend.AddEntry(h2first.get(),("IOV: "+std::to_string(std::get<0>(firstiov))).c_str(),"F");
+      legend.AddEntry(h2last.get() ,("IOV: "+std::to_string(std::get<0>(lastiov))).c_str(),"F");
       legend.Draw("same");
 
       canvas.cd(2);
       canvas.cd(2)->SetBottomMargin(0.18);
       canvas.cd(2)->SetLeftMargin(0.12);
-      canvas.cd(2)->SetRightMargin(0.14);
+      canvas.cd(2)->SetRightMargin(0.12);
 
       h2ratio->Draw("COLZ");
       auto hpfx_tmp = (TProfile*)(h2ratio->ProfileX("_pfx",1,-1,"o"));

--- a/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
@@ -1320,7 +1320,7 @@ namespace {
       hratio->SetTitle("");
       hratio->SetMinimum(0.55);  // Define Y ..
       hratio->SetMaximum(1.55);  // .. range
-      hratio->SetStats(0);       // No statistics on lower plot
+      hratio->SetStats(false);       // No statistics on lower plot
       hratio->Divide(h_lastGains.get());
       hratio->SetMarkerStyle(20);
       hratio->Draw("ep");       // Draw the ratio plot

--- a/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
@@ -1440,17 +1440,23 @@ namespace {
       std::string currentDetector;
 
       for (const auto &element : lastmap){
-	auto region = getTheRegion(element.first.first);
-      	h2last->Fill(SiStripPI::EnumToBinMap[region],element.second);
-	h2last->GetXaxis()->SetBinLabel(SiStripPI::EnumToBinMap[region],SiStripPI::regionType(region));
-	h2ratio->Fill(SiStripPI::EnumToBinMap[region],element.second/firstmap[element.first]);
-	h2ratio->GetXaxis()->SetBinLabel(SiStripPI::EnumToBinMap[region],SiStripPI::regionType(region));
+	auto region = this->getTheRegion(element.first.first);
+	auto bin   = SiStripPI::regionType(region).first;
+	auto label = SiStripPI::regionType(region).second;
+
+      	h2last->Fill(bin,element.second);
+	h2last->GetXaxis()->SetBinLabel(bin,label);
+	h2ratio->Fill(bin,element.second/firstmap[element.first]);
+	h2ratio->GetXaxis()->SetBinLabel(bin,label);
       }
 
       for (const auto &element : firstmap){
-	auto region = getTheRegion(element.first.first);
-	h2first->Fill(SiStripPI::EnumToBinMap[region],element.second);
-	h2first->GetXaxis()->SetBinLabel(SiStripPI::EnumToBinMap[region],SiStripPI::regionType(region));
+	auto region = this->getTheRegion(element.first.first);
+	auto bin   = SiStripPI::regionType(region).first;
+	auto label = SiStripPI::regionType(region).second;
+
+	h2first->Fill(bin,element.second);
+	h2first->GetXaxis()->SetBinLabel(bin,label);
       }
       
       h2first->GetXaxis()->LabelsOption("v");
@@ -1477,7 +1483,7 @@ namespace {
       canvas.cd(2)->SetRightMargin(0.14);
 
       h2ratio->Draw("COLZ");
-      TProfile *hpfx_tmp = (TProfile*) h2ratio->ProfileX("_pfx",1,-1,"o");
+      auto hpfx_tmp = (TProfile*)(h2ratio->ProfileX("_pfx",1,-1,"o"));
       hpfx_tmp->SetStats(kFALSE);
       hpfx_tmp->SetMarkerColor(kRed);
       hpfx_tmp->SetLineColor(kRed);
@@ -1628,7 +1634,7 @@ namespace {
 
 	hlast->SetBinContent(iBin,mean);	
 	hlast->SetBinError(iBin,mean/10000.);
-	hlast->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first));
+	hlast->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first).second);
 	hlast->GetXaxis()->LabelsOption("v");
 	
 	if(detector!=currentDetector) {
@@ -1647,7 +1653,7 @@ namespace {
 
 	hfirst->SetBinContent(iBin,mean);
 	hfirst->SetBinError(iBin,mean/10000.);
-	hfirst->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first));
+	hfirst->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first).second);
 	hfirst->GetXaxis()->LabelsOption("v");	
       }
 
@@ -1765,7 +1771,7 @@ namespace {
 	  }
 
 	h1->SetBinContent(iBin,mean);
-	h1->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first));
+	h1->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first).second);
 	h1->GetXaxis()->LabelsOption("v");
 	
 	if(detector!=currentDetector) {

--- a/CondCore/SiStripPlugins/plugins/SiStripBackPlaneCorrection_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBackPlaneCorrection_PayloadInspector.cc
@@ -159,7 +159,7 @@ namespace {
 	  }
 
 	h1->SetBinContent(iBin,mean);
-	h1->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first));
+	h1->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first).second);
 	h1->GetXaxis()->LabelsOption("v");
 	
 	if(detector!=currentDetector) {

--- a/CondCore/SiStripPlugins/plugins/SiStripBackPlaneCorrection_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBackPlaneCorrection_PayloadInspector.cc
@@ -97,9 +97,9 @@ namespace {
     Plot SiStrip BackPlane Correction averages by partition 
   *************************************************/
 
-  class SiStripBackPlaneCorrectionByPartition : public cond::payloadInspector::PlotImage<SiStripBackPlaneCorrection> {
+  class SiStripBackPlaneCorrectionByRegion : public cond::payloadInspector::PlotImage<SiStripBackPlaneCorrection> {
   public:
-    SiStripBackPlaneCorrectionByPartition() : cond::payloadInspector::PlotImage<SiStripBackPlaneCorrection>( "SiStripBackPlaneCorrection By Partition" ),
+    SiStripBackPlaneCorrectionByRegion() : cond::payloadInspector::PlotImage<SiStripBackPlaneCorrection>( "SiStripBackPlaneCorrection By Region" ),
       m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXML(edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())}
     {
       setSingleIov( true );
@@ -122,7 +122,7 @@ namespace {
       
       TCanvas canvas("Partion summary","partition summary",1200,1000); 
       canvas.cd();
-      auto h1 = std::unique_ptr<TH1F>(new TH1F("byPartition","SiStrip Backplane correction average by partition;; average SiStrip BackPlane Correction",map.size(),0.,map.size()));
+      auto h1 = std::unique_ptr<TH1F>(new TH1F("byRegion","SiStrip Backplane correction average by partition;; average SiStrip BackPlane Correction",map.size(),0.,map.size()));
       h1->SetStats(false);
       canvas.SetBottomMargin(0.18);
       canvas.SetLeftMargin(0.17);
@@ -207,5 +207,5 @@ namespace {
 PAYLOAD_INSPECTOR_MODULE( SiStripBackPlaneCorrection ){
   PAYLOAD_INSPECTOR_CLASS( SiStripBackPlaneCorrectionValue );
   PAYLOAD_INSPECTOR_CLASS( SiStripBackPlaneCorrection_TrackerMap );
-  PAYLOAD_INSPECTOR_CLASS( SiStripBackPlaneCorrectionByPartition );
+  PAYLOAD_INSPECTOR_CLASS( SiStripBackPlaneCorrectionByRegion );
 }

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -460,7 +460,7 @@ namespace {
 	  }
 
 	h_BadStrips->SetBinContent(iBin,countBadStrips);
-	h_BadStrips->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first));
+	h_BadStrips->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first).second);
 	h_BadStrips->GetXaxis()->LabelsOption("v");
 
 	if(detector!=currentDetector) {
@@ -621,7 +621,7 @@ namespace {
 	  }
 
 	h_LastBadStrips->SetBinContent(iBin,countBadStrips);
-	h_LastBadStrips->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first));
+	h_LastBadStrips->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first).second);
 	h_LastBadStrips->GetXaxis()->LabelsOption("v");
 
 	if(detector!=currentDetector) {
@@ -638,7 +638,7 @@ namespace {
 	int countBadStrips = (element.second.mean);
 
 	h_FirstBadStrips->SetBinContent(iBin,countBadStrips);
-	h_FirstBadStrips->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first));
+	h_FirstBadStrips->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first).second);
 	h_FirstBadStrips->GetXaxis()->LabelsOption("v");
 
       }

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -421,7 +421,7 @@ namespace {
 
       //=========================
       
-      TCanvas canvas("BadStrip Partion summary","SiStripBadStrip region summary",1200,1000); 
+      TCanvas canvas("BadStrip Region summary","SiStripBadStrip region summary",1200,1000); 
       canvas.cd();
       auto h_BadStrips = std::unique_ptr<TH1F>(new TH1F("BadStripsbyRegion","SiStrip Bad Strip summary by region;; n. bad strips",mapBadStrips.size(),0.,mapBadStrips.size()));
       h_BadStrips->SetStats(false);

--- a/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
@@ -281,11 +281,11 @@ namespace {
 	  }
 
 	h_HV->SetBinContent(iBin,countHV);
-	h_HV->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(index));
+	h_HV->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(index).second);
 	h_HV->GetXaxis()->LabelsOption("v");
 
 	h_LV->SetBinContent(iBin,countLV);
-	h_LV->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(index));
+	h_LV->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(index).second);
 	h_LV->GetXaxis()->LabelsOption("v");
 
 	if(detector!=currentDetector) {

--- a/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
@@ -159,7 +159,7 @@ namespace {
 	  }
 
 	h1->SetBinContent(iBin,mean);
-	h1->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first));
+	h1->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first).second);
 	h1->GetXaxis()->LabelsOption("v");
 	
 	if(detector!=currentDetector) {

--- a/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
@@ -97,9 +97,9 @@ namespace {
     Plot Lorentz Angle averages by partition 
   *************************************************/
 
-  class SiStripLorentzAngleByPartition : public cond::payloadInspector::PlotImage<SiStripLorentzAngle> {
+  class SiStripLorentzAngleByRegion : public cond::payloadInspector::PlotImage<SiStripLorentzAngle> {
   public:
-    SiStripLorentzAngleByPartition() : cond::payloadInspector::PlotImage<SiStripLorentzAngle>( "SiStripLorentzAngle By Partition" ),
+    SiStripLorentzAngleByRegion() : cond::payloadInspector::PlotImage<SiStripLorentzAngle>( "SiStripLorentzAngle By Region" ),
       m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXML(edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())}
     {
       setSingleIov( true );
@@ -122,7 +122,7 @@ namespace {
       
       TCanvas canvas("Partion summary","partition summary",1200,1000); 
       canvas.cd();
-      auto h1 = std::unique_ptr<TH1F>(new TH1F("byPartition","SiStrip LA average by partition;; average SiStrip Lorentz Angle [rad]",map.size(),0.,map.size()));
+      auto h1 = std::unique_ptr<TH1F>(new TH1F("byRegion","SiStrip LA average by partition;; average SiStrip Lorentz Angle [rad]",map.size(),0.,map.size()));
       h1->SetStats(false);
       canvas.SetBottomMargin(0.18);
       canvas.SetLeftMargin(0.17);
@@ -207,5 +207,5 @@ namespace {
 PAYLOAD_INSPECTOR_MODULE( SiStripLorentzAngle ){
   PAYLOAD_INSPECTOR_CLASS( SiStripLorentzAngleValue );
   PAYLOAD_INSPECTOR_CLASS( SiStripLorentzAngle_TrackerMap );
-  PAYLOAD_INSPECTOR_CLASS( SiStripLorentzAngleByPartition );
+  PAYLOAD_INSPECTOR_CLASS( SiStripLorentzAngleByRegion );
 }

--- a/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
@@ -338,7 +338,7 @@ namespace {
 	  }
 
 	h1->SetBinContent(iBin,mean);
-	h1->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first));
+	h1->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first).second);
 	h1->GetXaxis()->LabelsOption("v");
 	
 	if(detector!=currentDetector) {

--- a/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
@@ -205,7 +205,7 @@ namespace {
 	tmap->fill(item.first,item.second);
       }
 
-      auto range = SiStripPI::getTheRange(info_per_detid);
+      auto range = SiStripPI::getTheRange(info_per_detid,2);
       
       //=========================
       
@@ -229,9 +229,9 @@ namespace {
   SiStrip Noise Tracker Summaries 
   *************************************************/
   
-   template<SiStripPI::estimator est> class SiStripNoiseByPartition : public cond::payloadInspector::PlotImage<SiStripNoises> {
+   template<SiStripPI::estimator est> class SiStripNoiseByRegion : public cond::payloadInspector::PlotImage<SiStripNoises> {
   public:
-     SiStripNoiseByPartition() : cond::payloadInspector::PlotImage<SiStripNoises>( "SiStrip Noise "+estimatorType(est)+" by Partition" ),
+     SiStripNoiseByRegion() : cond::payloadInspector::PlotImage<SiStripNoises>( "SiStrip Noise "+estimatorType(est)+" by Region" ),
       m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXML(edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())}
     {
       setSingleIov( true );
@@ -295,7 +295,7 @@ namespace {
       
       TCanvas canvas("Partion summary","partition summary",1200,1000); 
       canvas.cd();
-      auto h1 = std::unique_ptr<TH1F>(new TH1F("byPartition",Form("Average by partition of %s SiStrip Noise per module;;average SiStrip Noise %s [ADC counts]",estimatorType(est).c_str(),estimatorType(est).c_str()),map.size(),0.,map.size()));
+      auto h1 = std::unique_ptr<TH1F>(new TH1F("byRegion",Form("Average by partition of %s SiStrip Noise per module;;average SiStrip Noise %s [ADC counts]",estimatorType(est).c_str(),estimatorType(est).c_str()),map.size(),0.,map.size()));
       h1->SetStats(false);
       canvas.SetBottomMargin(0.18);
       canvas.SetLeftMargin(0.17);
@@ -381,10 +381,10 @@ namespace {
     TrackerTopology m_trackerTopo;
   };
 
-  typedef SiStripNoiseByPartition<SiStripPI::mean> SiStripNoiseMeanByPartition;
-  typedef SiStripNoiseByPartition<SiStripPI::min>  SiStripNoiseMinByPartition;
-  typedef SiStripNoiseByPartition<SiStripPI::max>  SiStripNoiseMaxByPartition;
-  typedef SiStripNoiseByPartition<SiStripPI::rms>  SiStripNoiseRMSByPartition;
+  typedef SiStripNoiseByRegion<SiStripPI::mean> SiStripNoiseMeanByRegion;
+  typedef SiStripNoiseByRegion<SiStripPI::min>  SiStripNoiseMinByRegion;
+  typedef SiStripNoiseByRegion<SiStripPI::max>  SiStripNoiseMaxByRegion;
+  typedef SiStripNoiseByRegion<SiStripPI::rms>  SiStripNoiseRMSByRegion;
 
   /************************************************
     Noise linearity
@@ -638,10 +638,10 @@ PAYLOAD_INSPECTOR_MODULE(SiStripNoises){
   PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMax_TrackerMap);
   PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMean_TrackerMap);
   PAYLOAD_INSPECTOR_CLASS(SiStripNoiseRMS_TrackerMap);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMeanByPartition);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMinByPartition);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMaxByPartition);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseRMSByPartition);
+  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMeanByRegion);
+  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMinByRegion);
+  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMaxByRegion);
+  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseRMSByRegion);
   PAYLOAD_INSPECTOR_CLASS(SiStripNoiseLinearity);
   PAYLOAD_INSPECTOR_CLASS(TIBNoiseHistory);
   PAYLOAD_INSPECTOR_CLASS(TOBNoiseHistory);

--- a/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
@@ -211,9 +211,9 @@ namespace {
     Tracker Map of SiStrip Pedestals Summaries
   *************************************************/
 
-  template<SiStripPI::estimator est> class SiStripPedestalsByPartition : public cond::payloadInspector::PlotImage<SiStripPedestals> {
+  template<SiStripPI::estimator est> class SiStripPedestalsByRegion : public cond::payloadInspector::PlotImage<SiStripPedestals> {
   public:
-     SiStripPedestalsByPartition() : cond::payloadInspector::PlotImage<SiStripPedestals>( "SiStrip Pedestals "+estimatorType(est)+" by Partition" ),
+     SiStripPedestalsByRegion() : cond::payloadInspector::PlotImage<SiStripPedestals>( "SiStrip Pedestals "+estimatorType(est)+" by Region" ),
       m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXML(edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())}
     {
       setSingleIov( true );
@@ -271,7 +271,7 @@ namespace {
       
       TCanvas canvas("Partion summary","partition summary",1200,1000); 
       canvas.cd();
-      auto h1 = std::unique_ptr<TH1F>(new TH1F("byPartition",Form("Average by partition of %s SiStrip Pedestals per module;;average SiStrip Pedestals %s [ADC counts]",estimatorType(est).c_str(),estimatorType(est).c_str()),map.size(),0.,map.size()));
+      auto h1 = std::unique_ptr<TH1F>(new TH1F("byRegion",Form("Average by partition of %s SiStrip Pedestals per module;;average SiStrip Pedestals %s [ADC counts]",estimatorType(est).c_str(),estimatorType(est).c_str()),map.size(),0.,map.size()));
       h1->SetStats(false);
       canvas.SetBottomMargin(0.18);
       canvas.SetLeftMargin(0.17);
@@ -358,10 +358,10 @@ namespace {
   };
 
 
-  typedef SiStripPedestalsByPartition<SiStripPI::mean> SiStripPedestalsMeanByPartition;
-  typedef SiStripPedestalsByPartition<SiStripPI::min>  SiStripPedestalsMinByPartition;
-  typedef SiStripPedestalsByPartition<SiStripPI::max>  SiStripPedestalsMaxByPartition;
-  typedef SiStripPedestalsByPartition<SiStripPI::rms>  SiStripPedestalsRMSByPartition;
+  typedef SiStripPedestalsByRegion<SiStripPI::mean> SiStripPedestalsMeanByRegion;
+  typedef SiStripPedestalsByRegion<SiStripPI::min>  SiStripPedestalsMinByRegion;
+  typedef SiStripPedestalsByRegion<SiStripPI::max>  SiStripPedestalsMaxByRegion;
+  typedef SiStripPedestalsByRegion<SiStripPI::rms>  SiStripPedestalsRMSByRegion;
 
 } // close namespace
 
@@ -372,8 +372,8 @@ PAYLOAD_INSPECTOR_MODULE(SiStripPedestals){
   PAYLOAD_INSPECTOR_CLASS(SiStripPedestalsMax_TrackerMap);
   PAYLOAD_INSPECTOR_CLASS(SiStripPedestalsMean_TrackerMap);
   PAYLOAD_INSPECTOR_CLASS(SiStripPedestalsRMS_TrackerMap);
-  PAYLOAD_INSPECTOR_CLASS(SiStripPedestalsMeanByPartition);
-  PAYLOAD_INSPECTOR_CLASS(SiStripPedestalsMinByPartition);
-  PAYLOAD_INSPECTOR_CLASS(SiStripPedestalsMaxByPartition);
-  PAYLOAD_INSPECTOR_CLASS(SiStripPedestalsRMSByPartition);
+  PAYLOAD_INSPECTOR_CLASS(SiStripPedestalsMeanByRegion);
+  PAYLOAD_INSPECTOR_CLASS(SiStripPedestalsMinByRegion);
+  PAYLOAD_INSPECTOR_CLASS(SiStripPedestalsMaxByRegion);
+  PAYLOAD_INSPECTOR_CLASS(SiStripPedestalsRMSByRegion);
 }

--- a/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
@@ -314,7 +314,7 @@ namespace {
 	  }
 
 	h1->SetBinContent(iBin,mean);
-	h1->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first));
+	h1->GetXaxis()->SetBinLabel(iBin,SiStripPI::regionType(element.first).second);
 	h1->GetXaxis()->LabelsOption("v");
 	
 	if(detector!=currentDetector) {

--- a/CondCore/SiStripPlugins/test/test.sh
+++ b/CondCore/SiStripPlugins/test/test.sh
@@ -15,7 +15,7 @@ cd $W_DIR;
 ####################
 /afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
     --plugin pluginSiStripApvGain_PayloadInspector \
-    --plot plot_SiStripApvGainsByPartition \
+    --plot plot_SiStripApvGainsByRegion \
     --tag SiStripApvGain_FromParticles_GR10_v1_express \
     --time_type Run \
     --iovs '{"start_iov": "286042", "end_iov": "286042"}' \
@@ -27,7 +27,7 @@ cd $W_DIR;
 ######################
 /afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
     --plugin pluginSiStripLorentzAngle_PayloadInspector \
-    --plot plot_SiStripLorentzAngleByPartition \
+    --plot plot_SiStripLorentzAngleByRegion \
     --tag  SiStripLorentzAngleDeco_GR10_v1_prompt \
     --time_type Run \
     --iovs '{"start_iov": "1", "end_iov": "1"}' \
@@ -39,7 +39,7 @@ cd $W_DIR;
 ######################
 /afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
     --plugin pluginSiStripBackPlaneCorrection_PayloadInspector \
-    --plot plot_SiStripBackPlaneCorrectionByPartition \
+    --plot plot_SiStripBackPlaneCorrectionByRegion \
     --tag SiStripBackPlaneCorrection_deco_GR10_v1_express \
     --time_type Run \
     --iovs '{"start_iov": "153690", "end_iov": "153690"}' \

--- a/CondCore/SiStripPlugins/test/testGains.sh
+++ b/CondCore/SiStripPlugins/test/testGains.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Save current working dir so img can be outputted there later
+W_DIR=$(pwd);
+# Set SCRAM architecture var
+SCRAM_ARCH=slc6_amd64_gcc630;
+export SCRAM_ARCH;
+source /afs/cern.ch/cms/cmsset_default.sh;
+eval `scram run -sh`;
+# Go back to original working directory
+cd $W_DIR;
+# Run get payload data script
+
+mkdir $W_DIR/results
+
+####################
+# Test Gains
+####################
+/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+    --plugin pluginSiStripApvGain_PayloadInspector \
+    --plot plot_SiStripApvGainsByRegionComparator \
+    --tag SiStripApvGainAfterAbortGap_PCL_v0_prompt \
+    --time_type Run \
+    --iovs '{"start_iov": "302393", "end_iov": "305114"}' \
+    --db Prep \
+    --test;
+
+mv *.png $W_DIR/results/G2_update.png
+
+/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+    --plugin pluginSiStripApvGain_PayloadInspector \
+    --plot plot_SiStripApvGainsByRegionComparator \
+    --tag SiStripApvGain_GR10_v1_hlt \
+    --time_type Run \
+    --iovs '{"start_iov": "302322", "end_iov": "306054"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/results/G1_updated.png

--- a/CondCore/SiStripPlugins/test/testGainsPayloadInspector.sh
+++ b/CondCore/SiStripPlugins/test/testGainsPayloadInspector.sh
@@ -46,7 +46,7 @@ mv *.png $W_DIR/plots/G2_MaxDeviatonRatio_update.png
     --plot plot_SiStripApvGainsRatioComparatorByRegion \
     --tag SiStripApvGainAfterAbortGap_PCL_v0_prompt \
     --time_type Run \
-    --iovs '{"start_iov": "302393", "end_iov": "305114"}' \
+    --iovs '{"start_iov": "280000", "end_iov": "305114"}' \
     --db Prep \
     --test;
 

--- a/CondCore/SiStripPlugins/test/testGainsPayloadInspector.sh
+++ b/CondCore/SiStripPlugins/test/testGainsPayloadInspector.sh
@@ -28,7 +28,29 @@ mkdir $W_DIR/plots
     --db Prep \
     --test;
 
-mv *.png $W_DIR/plots/G2_update.png
+mv *.png $W_DIR/plots/G2_Value_update.png
+
+/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+    --plugin pluginSiStripApvGain_PayloadInspector \
+    --plot plot_SiStripApvGainsMaxDeviationRatio2sigmaTrackerMap \
+    --tag SiStripApvGainAfterAbortGap_PCL_v0_prompt \
+    --time_type Run \
+    --iovs '{"start_iov": "302393", "end_iov": "305114"}' \
+    --db Prep \
+    --test;
+
+mv *.png $W_DIR/plots/G2_MaxDeviatonRatio_update.png
+
+/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+    --plugin pluginSiStripApvGain_PayloadInspector \
+    --plot plot_SiStripApvGainsRatioComparatorByRegion \
+    --tag SiStripApvGainAfterAbortGap_PCL_v0_prompt \
+    --time_type Run \
+    --iovs '{"start_iov": "302393", "end_iov": "305114"}' \
+    --db Prep \
+    --test;
+
+mv *.png $W_DIR/plots/G2_Ratio_update.png
 
 /afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
     --plugin pluginSiStripApvGain_PayloadInspector \
@@ -39,4 +61,4 @@ mv *.png $W_DIR/plots/G2_update.png
     --db Prod \
     --test;
 
-mv *.png $W_DIR/plots/G1_updated.png
+mv *.png $W_DIR/plots/G1_Value_update.png

--- a/CondCore/SiStripPlugins/test/testGainsPayloadInspector.sh
+++ b/CondCore/SiStripPlugins/test/testGainsPayloadInspector.sh
@@ -10,29 +10,33 @@ eval `scram run -sh`;
 cd $W_DIR;
 # Run get payload data script
 
-mkdir $W_DIR/results
+if [ -d $W_DIR/plots ]; then
+    rm -fr $W_DIR/plots
+fi
+
+mkdir $W_DIR/plots
 
 ####################
 # Test Gains
 ####################
 /afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
     --plugin pluginSiStripApvGain_PayloadInspector \
-    --plot plot_SiStripApvGainsByRegionComparator \
+    --plot plot_SiStripApvGainsValuesComparator \
     --tag SiStripApvGainAfterAbortGap_PCL_v0_prompt \
     --time_type Run \
     --iovs '{"start_iov": "302393", "end_iov": "305114"}' \
     --db Prep \
     --test;
 
-mv *.png $W_DIR/results/G2_update.png
+mv *.png $W_DIR/plots/G2_update.png
 
 /afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
     --plugin pluginSiStripApvGain_PayloadInspector \
-    --plot plot_SiStripApvGainsByRegionComparator \
+    --plot plot_SiStripApvGainsValuesComparator \
     --tag SiStripApvGain_GR10_v1_hlt \
     --time_type Run \
     --iovs '{"start_iov": "302322", "end_iov": "306054"}' \
     --db Prod \
     --test;
 
-mv *.png $W_DIR/results/G1_updated.png
+mv *.png $W_DIR/plots/G1_updated.png

--- a/CondCore/SiStripPlugins/test/testNoisePayloadInspector.sh
+++ b/CondCore/SiStripPlugins/test/testNoisePayloadInspector.sh
@@ -50,14 +50,14 @@ do
 
     /afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
 	--plugin pluginSiStripNoises_PayloadInspector \
-	--plot plot_SiStripNoise${i}ByPartition \
+	--plot plot_SiStripNoise${i}ByRegion \
 	--tag SiStripNoise_v2_prompt \
 	--time_type Run \
 	--iovs '{"start_iov": "303420", "end_iov": "303420"}' \
 	--db Prod \
 	--test;
 
-    mv *.png $W_DIR/results/SiStripNoises${i}ByPartition.png
+    mv *.png $W_DIR/results/SiStripNoises${i}ByRegion.png
 
 done
 

--- a/CondCore/SiStripPlugins/test/testNoisePayloadInspector.sh
+++ b/CondCore/SiStripPlugins/test/testNoisePayloadInspector.sh
@@ -26,8 +26,7 @@ estimators=(Mean Min Max RMS)
 
 mkdir -p $W_DIR/results
 
-if [ -f *.png ]
-then    
+if [ -f *.png ]; then    
     rm *.png
 fi
 

--- a/CondCore/SiStripPlugins/test/testPedestalsPayloadInspector.sh
+++ b/CondCore/SiStripPlugins/test/testPedestalsPayloadInspector.sh
@@ -50,14 +50,14 @@ do
 
     /afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
 	--plugin pluginSiStripPedestals_PayloadInspector \
-	--plot plot_SiStripPedestals${i}ByPartition \
+	--plot plot_SiStripPedestals${i}ByRegion \
 	--tag SiStripPedestals_v2_prompt \
 	--time_type Run \
 	--iovs '{"start_iov": "303420", "end_iov": "303420"}' \
 	--db Prod \
 	--test;
 
-    mv *.png $W_DIR/results/SiStripPedestals${i}ByPartition.png
+    mv *.png $W_DIR/results/SiStripPedestals${i}ByRegion.png
 
 done
 

--- a/CondCore/SiStripPlugins/test/testPedestalsPayloadInspector.sh
+++ b/CondCore/SiStripPlugins/test/testPedestalsPayloadInspector.sh
@@ -26,8 +26,7 @@ estimators=(Mean Min Max RMS)
 
 mkdir -p $W_DIR/results
 
-if [ -f *.png ]
-then    
+if [ -f *.png ]; then    
     rm *.png
 fi
 

--- a/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
+++ b/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
@@ -38,11 +38,11 @@ int main(int argc, char** argv) {
   histo1.process( connectionString, tag, runTimeType, start, start );
   std::cout <<histo1.data()<<std::endl;
 
-  SiStripApvGainsRatioWithPreviousIOVTrackerMap histo2;
+  SiStripApvGainsAvgDeviationRatio1sigmaTrackerMap histo2;
   histo2.process( connectionString, tag, runTimeType, end, end );
   std::cout <<histo2.data()<<std::endl;
 
-  SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMap histo3;
+  SiStripApvGainsMaxDeviationRatio1sigmaTrackerMap histo3;
   histo3.process( connectionString, tag, runTimeType, end, end );
   std::cout <<histo3.data()<<std::endl;
 


### PR DESCRIPTION
Features added:
   * Implement different levels of saturation for the `TrackerMaps` via class templates;
   * Add plot of integral gain distribution comparison; 
   * Add 2D plots of gain ratios;  
   * Correct nomenclature; rename everywhere "partition" to more appropriate "region";

Bug-fixes: 
   * Fixed buggy logic in filling the `TrackerMap` of the maximum deviation of the ratio; 
   * Fixed off-by-one bin filling in  `SiStripApvAbsolute*` plots;