### PR TITLE
[10.0.X] Add Payload Inspector for AlCaRecoTriggerBits

### DIFF
--- a/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
+++ b/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
@@ -70,8 +70,8 @@ namespace {
 	  if(br!=output.size()-1) y-=pitch;
 	}
 
-	TLine *line = new TLine(gPad->GetUxmin(),y-(pitch/2.),gPad->GetUxmax(),y-(pitch/2.));
-	line->Draw();
+	TLine line = TLine(gPad->GetUxmin(),y-(pitch/2.),gPad->GetUxmax(),y-(pitch/2.));
+	line.Draw("same");
 
 	//std::cout << std::endl;
       }
@@ -176,12 +176,6 @@ namespace {
 	    count++;
 	    output[count]+=missing_in_last_paths[iPath];
 	  }
-
-	  /* old logic
-	  output[count]+=missing_in_last_paths[iPath];
-	  output[count]+=";";
-	  if(output[count].length()>30) count++;
-	  */
 	}
 	
 	for (unsigned int br=0; br<output.size();br++){
@@ -191,7 +185,7 @@ namespace {
 	//std::cout << " |||||| not in last";
 	//std::cout << std::endl;
 
-	TLine *line = new TLine(gPad->GetUxmin(),y-0.008,gPad->GetUxmax(),y-0.008);
+	TLine *line = new TLine (gPad->GetUxmin(),y-0.008,gPad->GetUxmax(),y-0.008);
 	line->Draw();
 
       }
@@ -216,12 +210,6 @@ namespace {
 	    count++;
 	    output[count]+=missing_in_first_paths[iPath];
 	  }
-
-	  /* old logic
-	  output[count]+=missing_in_first_paths[iPath];
-	  output[count]+=";";
-	  if(output[count].length()>30) count++;
-	  */
 	}
 
 	for (unsigned int br=0; br<output.size();br++){
@@ -271,12 +259,6 @@ namespace {
 		count++;
 		output[count]+=not_in_last[iPath];
 	      }
-
-	      /* old logic
-      	      output[count]+= not_in_last[iPath];
-      	      output[count]+="; ";
-      	      if(output[count].length()>60) count++;
-	      */
       	    }
 
       	    for (unsigned int br=0; br<output.size();br++){
@@ -296,12 +278,6 @@ namespace {
 		count++;
 		output[count]+=not_in_first[jPath];
 	      }
-
-	      /* old logic
-      	      output[count1]+= not_in_first[jPath];
-      	      output[count1]+=";";
-      	      if(output[count1].length()>60) count1++;
-	      */
       	    }
 
       	    for (unsigned int br=0; br<output.size();br++){
@@ -310,6 +286,7 @@ namespace {
 
 	    // decrease the y position to the maximum of the two lists
 	    y-=std::max(count,count1)*pitch;
+
       	    TLine *line3 = new TLine(gPad->GetUxmin(),y-0.008,gPad->GetUxmax(),y-0.008);
       	    line3->Draw();
 	    

--- a/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
+++ b/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
@@ -38,6 +38,8 @@ namespace {
       std::vector<float> y_x1,y_x2,y_line;
       std::vector<std::string>   s_x1,s_x2,s_x3;
 
+      // starting table at y=1.0 (top of the canvas)
+      // first column is at 0.02, second column at 0.32 NDC
       y = 1.0; x1 = 0.02; x2 = x1+0.30;
 	
       y -= pitch; 
@@ -50,23 +52,26 @@ namespace {
       y_line.push_back(y);
 
       for(const auto &element : triggerMap){
-	//std::cout<< element.first << " : " ;
 
 	y -= pitch; 
 	y_x1.push_back(y);
 	s_x1.push_back(element.first);
 
-	std::map<int,std::string> output;
-	int count=0;
+	std::vector<std::string> output;
+	std::string toAppend=""; 
 	const std::vector<std::string> paths = payload->decompose(element.second);
 	for (unsigned int iPath = 0; iPath < paths.size(); ++iPath) {
-	  if((output[count]+paths[iPath]).length()<60){
-	    output[count]+=paths[iPath];
-	    output[count]+=";";
+	  // if the line to be added has less than 60 chars append to current 
+	  if((toAppend+paths[iPath]).length()<60){
+	    toAppend+=paths[iPath]+";";
 	  } else {
-	    count++;
-	    output[count]+=paths[iPath];
+	    // else if the line exceeds 60 chars, dump in the vector and resume from scratch
+	    output.push_back(toAppend);
+	    toAppend.clear();
+	    toAppend+=paths[iPath]+";";
 	  }
+	  // if it's the last, dump it
+	  if(iPath==paths.size()-1) output.push_back(toAppend);
 	}
       	
 	for (unsigned int br=0; br<output.size();br++){
@@ -77,7 +82,6 @@ namespace {
 
 	y_line.push_back(y-(pitch/2.));
        
-	//std::cout << std::endl;
       }
 
       TCanvas canvas("AlCaRecoTriggerBits","AlCaRecoTriggerBits",2000,std::max(y_x1.size(),y_x2.size())*40); 
@@ -103,7 +107,6 @@ namespace {
       TLine lines[y_line.size()];
       unsigned int iL=0;
       for (const auto & line : y_line){
-	//std::cout<<1-(1-line)*factor<<std::endl;
 	lines[iL] = TLine(gPad->GetUxmin(),1-(1-line)*factor,gPad->GetUxmax(),1-(1-line)*factor);
 	lines[iL].SetLineWidth(1);
 	lines[iL].SetLineStyle(9);
@@ -192,25 +195,26 @@ namespace {
 
       // print the ones missing in the last key
       for(const auto& key : not_in_last_keys ) {
-	//std::cout<< key ;
 	y -= pitch;  
 	y_x1.push_back(y);
 	s_x1.push_back(key);
 
 	const std::vector<std::string> missing_in_last_paths = first_payload->decompose(first_triggerMap.at(key));
 	
-	std::map<int,std::string> output;
-	int count=0;
+	std::vector<std::string> output;
+	std::string toAppend=""; 
 	for (unsigned int iPath = 0; iPath < missing_in_last_paths.size(); ++iPath) {
-	  //std::cout << missing_in_last_paths[iPath] << " ; " ;
-
-	  if((output[count]+missing_in_last_paths[iPath]).length()<60){
-	    output[count]+=missing_in_last_paths[iPath];
-	    output[count]+=";";
+	  // if the line to be added has less than 60 chars append to current 
+	  if((toAppend+missing_in_last_paths[iPath]).length()<60){
+	    toAppend+=missing_in_last_paths[iPath]+";";
 	  } else {
-	    count++;
-	    output[count]+=missing_in_last_paths[iPath];
+	    // else if the line exceeds 60 chars, dump in the vector and resume from scratch
+	    output.push_back(toAppend);
+	    toAppend.clear();
+	    toAppend+=missing_in_last_paths[iPath]+";";
 	  }
+	  // if it's the last, dump it
+	  if(iPath==missing_in_last_paths.size()-1) output.push_back(toAppend);
 	}
 	
 	for (unsigned int br=0; br<output.size();br++){
@@ -218,35 +222,31 @@ namespace {
 	  s_x2.push_back("#color[2]{"+output[br]+"}");
 	  if(br!=output.size()-1) y -=pitch;
 	}
-	//std::cout << " |||||| not in last";
-	//std::cout << std::endl;
-
 	y_line.push_back(y-0.008);
 
       }
       
-
       // print the ones missing in the first key
       for(const auto& key : not_in_first_keys ) {
-	//std::cout<< key ;
 	y -= pitch;  
 	y_x1.push_back(y);
 	s_x1.push_back(key);
 	const std::vector<std::string> missing_in_first_paths = last_payload->decompose(last_triggerMap.at(key));
 
-	//std::cout << " not in first ||||||";
-	std::map<int,std::string> output;
-	int count=0;
+	std::vector<std::string> output;
+	std::string toAppend=""; 
 	for (unsigned int iPath = 0; iPath < missing_in_first_paths.size(); ++iPath) {
-	  //std::cout << missing_in_first_paths[iPath] << " ; " ;
-
-	  if((output[count]+missing_in_first_paths[iPath]).length()<60){
-	    output[count]+=missing_in_first_paths[iPath];
-	    output[count]+=";";
+	  // if the line to be added has less than 60 chars append to current 
+	  if((toAppend+missing_in_first_paths[iPath]).length()<60){
+	    toAppend+=missing_in_first_paths[iPath]+";";
 	  } else {
-	    count++;
-	    output[count]+=missing_in_first_paths[iPath];
+	    // else if the line exceeds 60 chars, dump in the vector and resume from scratch
+	    output.push_back(toAppend);
+	    toAppend.clear();
+	    toAppend+=missing_in_first_paths[iPath]+";";
 	  }
+	  // if it's the last, dump it
+	  if(iPath==missing_in_first_paths.size()-1) output.push_back(toAppend);
 	}
 
 	for (unsigned int br=0; br<output.size();br++){
@@ -254,8 +254,6 @@ namespace {
 	  s_x3.push_back("#color[4]{"+output[br]+"}");
 	  if(br!=output.size()-1) y -= pitch;
 	}
-	//std::cout << std::endl;
-	
 	y_line.push_back(y-0.008);
 	
       }
@@ -281,56 +279,62 @@ namespace {
 
       	  if(!not_in_last.empty() || !not_in_first.empty()) {
 
-      	    //std::cout<< element.first << " : "  ;
       	    y -= pitch;  
 	    y_x1.push_back(y);
 	    s_x1.push_back(element.first);
     
-      	    std::map<int,std::string> output; 
-      	    int count(0);
-      	    for (unsigned int iPath = 0; iPath < not_in_last.size(); ++iPath) {
-      	      //std::cout << not_in_last[iPath] << " ; " ;
-	      
-	      if((output[count]+not_in_last[iPath]).length()<60){
-		output[count]+=not_in_last[iPath];
-		output[count]+=";";
+	    std::vector<std::string> output;
+	    std::string toAppend=""; 
+	    for (unsigned int iPath = 0; iPath < not_in_last.size(); ++iPath) {
+	      // if the line to be added has less than 60 chars append to current 
+	      if((toAppend+not_in_last[iPath]).length()<60){
+		toAppend+=not_in_last[iPath]+";";
 	      } else {
-		count++;
-		output[count]+=not_in_last[iPath];
+		// else if the line exceeds 60 chars, dump in the vector and resume from scratch
+		output.push_back(toAppend);
+		toAppend.clear();
+		toAppend+=not_in_last[iPath]+";";
 	      }
-      	    }
+	      // if it's the last and not empty, dump it
+	      if(toAppend.length()>0 && iPath==not_in_last.size()-1) output.push_back(toAppend);
+	    }
 
-      	    for (unsigned int br=0; br<output.size();br++){
+	    unsigned int count = output.size();
+
+      	    for (unsigned int br=0; br<count;br++){
 	      y_x2.push_back(y-(br*pitch));
 	      s_x2.push_back("#color[6]{"+output[br]+"}");
       	    }  
-      	    //std::cout << " ||||||";
 	    
-      	    output.clear();
-      	    int count1=0;
-      	    for (unsigned int jPath = 0; jPath < not_in_first.size(); ++jPath) {
-      	      //std::cout << not_in_first[jPath] << " ; " ;
-
-	      if((output[count]+not_in_first[jPath]).length()<60){
-		output[count]+=not_in_first[jPath];
-		output[count]+=";";
+	    // clear vector and string
+	    toAppend.clear();
+	    output.clear();
+	    for (unsigned int jPath = 0; jPath < not_in_first.size(); ++jPath) {
+	      // if the line to be added has less than 60 chars append to current 
+	      if((toAppend+not_in_first[jPath]).length()<60){
+		toAppend+=not_in_first[jPath]+";";
 	      } else {
-		count++;
-		output[count]+=not_in_first[jPath];
+		// else if the line exceeds 60 chars, dump in the vector and resume from scratch
+		output.push_back(toAppend);
+		toAppend.clear();
+		toAppend+=not_in_first[jPath]+";";
 	      }
-      	    }
-
-      	    for (unsigned int br=0; br<output.size();br++){  
+	      // if it's the last and not empty, dump it
+	      if(toAppend.length()>0 && jPath==not_in_first.size()-1) output.push_back(toAppend);
+	    }
+	    
+	    unsigned int count1 = output.size();
+		    
+      	    for (unsigned int br=0; br<count1;br++){  
 	      y_x3.push_back(y-(br*pitch));
 	      s_x3.push_back("#color[8]{"+output[br]+"}");
       	    }
 
 	    // decrease the y position to the maximum of the two lists
-	    y-=std::max(count,count1)*pitch;
+	    y-=(std::max(count,count1)-1)*pitch;
+	    //y-=count*pitch;
 	    y_line.push_back(y-0.008);
 	    
-      	    //std::cout << std::endl;
- 
       	  } // close if there is at least a difference 
       	} // if there is a common key
       }//loop on the keys
@@ -341,6 +345,7 @@ namespace {
       // Draw the columns titles
       l.SetTextAlign(12);
 
+      // rescale the width of the table row to fit into the canvas
       float newpitch = 1/(std::max(y_x1.size(),y_x2.size())*1.65);
       float factor  = newpitch/pitch;
       l.SetTextSize(newpitch-0.002);
@@ -363,7 +368,6 @@ namespace {
       TLine lines[y_line.size()];
       unsigned int iL=0;
       for (const auto & line : y_line){
-	//std::cout<<1-(1-line)*factor<<std::endl;
 	lines[iL] = TLine(gPad->GetUxmin(),1-(1-line)*factor,gPad->GetUxmax(),1-(1-line)*factor);
 	lines[iL].SetLineWidth(1);
 	lines[iL].SetLineStyle(9);

--- a/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
+++ b/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
@@ -27,15 +27,12 @@ namespace {
 
       std::string IOVsince  = std::to_string(std::get<0>(iov));
 
-      
       // Get map of strings to concatenated list of names of HLT paths:
       typedef std::map<std::string, std::string> TriggerMap;
       const TriggerMap &triggerMap = payload->m_alcarecoToTrig;
 
       unsigned int mapsize = triggerMap.size();
       float pitch = 1./(mapsize*1.20);
-
-      //std::cout<<"map size:" << mapsize << " pitch:" << pitch << "ratio: " << 1000./mapsize << std::endl;
 
       TCanvas canvas("AlCaRecoTriggerBits","AlCaRecoTriggerBits",2000,40*mapsize); 
 
@@ -140,10 +137,11 @@ namespace {
       std::set_difference(last_keys.begin(),last_keys.end(),first_keys.begin(),first_keys.end(), 
 			  std::inserter(not_in_first_keys, not_in_first_keys.begin()));
 
-      TCanvas canvas1("AlCaRecoTriggerBits0","AlCaRecoTriggerBits0",2000,1000); 
+      TCanvas canvas("AlCaRecoTriggerBits","AlCaRecoTriggerBits",2500,std::max(f_mapsize,l_mapsize)*40); 
+      float pitch = 0.013;
 
       TLatex l;
-      l.SetTextSize(0.018);
+      l.SetTextSize(0.012);
 
       // Draw the columns titles
       l.SetTextAlign(12);
@@ -151,33 +149,44 @@ namespace {
       float y, x1, x2, x3;
       y  = 1.0; 
       x1 = 0.02; 
-      x2 = x1+0.15; 
-      x3 = x2+0.35;
+      x2 = x1+0.20; 
+      x3 = x2+0.30;
 
-      y -= 0.017; 
+      y -= pitch; 
       l.DrawLatexNDC(x1, y,"#scale[1.2]{Key}"); 
       l.DrawLatexNDC(x2, y,("#scale[1.2]{in IOV: "+firstIOVsince+"}").c_str()); 
       l.DrawLatexNDC(x3, y,("#scale[1.2]{in IOV: "+lastIOVsince+"}").c_str()); 
-      y -= 0.005;
+      y -= pitch/3;
 
       // print the ones missing in the last key
       for(const auto& key : not_in_last_keys ) {
 	//std::cout<< key ;
-	y -= 0.017; l.DrawLatexNDC(x1, y,key.c_str()); 
+	y -= pitch; l.DrawLatexNDC(x1, y,key.c_str()); 
 	const std::vector<std::string> missing_in_last_paths = first_payload->decompose(first_triggerMap.at(key));
 	
 	std::map<int,std::string> output;
 	int count=0;
 	for (unsigned int iPath = 0; iPath < missing_in_last_paths.size(); ++iPath) {
 	  //std::cout << missing_in_last_paths[iPath] << " ; " ;
+
+	  if((output[count]+missing_in_last_paths[iPath]).length()<60){
+	    output[count]+=missing_in_last_paths[iPath];
+	    output[count]+=";";
+	  } else {
+	    count++;
+	    output[count]+=missing_in_last_paths[iPath];
+	  }
+
+	  /* old logic
 	  output[count]+=missing_in_last_paths[iPath];
 	  output[count]+=";";
-	  if(output[count].length()>60) count++;
+	  if(output[count].length()>30) count++;
+	  */
 	}
 	
 	for (unsigned int br=0; br<output.size();br++){
 	  l.DrawLatexNDC(x2,y,("#color[2]{"+output[br]+"}").c_str());  
-	  if(br!=output.size()-1) y -=0.017;
+	  if(br!=output.size()-1) y -=pitch;
 	}
 	//std::cout << " |||||| not in last";
 	//std::cout << std::endl;
@@ -191,7 +200,7 @@ namespace {
       // print the ones missing in the first key
       for(const auto& key : not_in_first_keys ) {
 	//std::cout<< key ;
-	y -= 0.017; l.DrawLatexNDC(x1, y,key.c_str()); 
+	y -= pitch; l.DrawLatexNDC(x1, y,key.c_str()); 
 	const std::vector<std::string> missing_in_first_paths = last_payload->decompose(last_triggerMap.at(key));
 
 	//std::cout << " not in first ||||||";
@@ -199,14 +208,25 @@ namespace {
 	int count=0;
 	for (unsigned int iPath = 0; iPath < missing_in_first_paths.size(); ++iPath) {
 	  //std::cout << missing_in_first_paths[iPath] << " ; " ;
+
+	  if((output[count]+missing_in_first_paths[iPath]).length()<60){
+	    output[count]+=missing_in_first_paths[iPath];
+	    output[count]+=";";
+	  } else {
+	    count++;
+	    output[count]+=missing_in_first_paths[iPath];
+	  }
+
+	  /* old logic
 	  output[count]+=missing_in_first_paths[iPath];
 	  output[count]+=";";
-	  if(output[count].length()>60) count++;
+	  if(output[count].length()>30) count++;
+	  */
 	}
 
 	for (unsigned int br=0; br<output.size();br++){
 	  l.DrawLatexNDC(x3,y,("#color[4]{"+output[br]+"}").c_str());  	    
-	  if(br!=output.size()-1) y -= 0.017;
+	  if(br!=output.size()-1) y -= pitch;
 	}
 	//std::cout << std::endl;
 	
@@ -237,19 +257,30 @@ namespace {
       	  if(not_in_last.size()!=0 || not_in_first.size()!=0) {
 
       	    //std::cout<< element.first << " : "  ;
-      	    y -= 0.017; l.DrawLatexNDC(x1, y, element.first.c_str()); 
+      	    y -= pitch; l.DrawLatexNDC(x1, y, element.first.c_str()); 
 	    
       	    std::map<int,std::string> output; 
       	    int count(0);
       	    for (unsigned int iPath = 0; iPath < not_in_last.size(); ++iPath) {
       	      //std::cout << not_in_last[iPath] << " ; " ;
+	      
+	      if((output[count]+not_in_last[iPath]).length()<60){
+		output[count]+=not_in_last[iPath];
+		output[count]+=";";
+	      } else {
+		count++;
+		output[count]+=not_in_last[iPath];
+	      }
+
+	      /* old logic
       	      output[count]+= not_in_last[iPath];
       	      output[count]+="; ";
       	      if(output[count].length()>60) count++;
+	      */
       	    }
 
       	    for (unsigned int br=0; br<output.size();br++){
-      	      l.DrawLatexNDC(x2,y-(br*0.017),("#color[6]{"+output[br]+"}").c_str());
+      	      l.DrawLatexNDC(x2,y-(br*pitch),("#color[6]{"+output[br]+"}").c_str());
       	    }  
       	    //std::cout << " ||||||";
 	    
@@ -257,22 +288,31 @@ namespace {
       	    int count1=0;
       	    for (unsigned int jPath = 0; jPath < not_in_first.size(); ++jPath) {
       	      //std::cout << not_in_first[jPath] << " ; " ;
+
+	      if((output[count]+not_in_first[jPath]).length()<60){
+		output[count]+=not_in_first[jPath];
+		output[count]+=";";
+	      } else {
+		count++;
+		output[count]+=not_in_first[jPath];
+	      }
+
+	      /* old logic
       	      output[count1]+= not_in_first[jPath];
       	      output[count1]+=";";
       	      if(output[count1].length()>60) count1++;
+	      */
       	    }
 
       	    for (unsigned int br=0; br<output.size();br++){
-      	      l.DrawLatexNDC(x3,y-(br*0.017),("#color[8]{"+output[br]+"}").c_str());  	    
+      	      l.DrawLatexNDC(x3,y-(br*pitch),("#color[8]{"+output[br]+"}").c_str());  	    
       	    }
 
-	    y-=std::max(count,count1)*0.017;
+	    // decrease the y position to the maximum of the two lists
+	    y-=std::max(count,count1)*pitch;
       	    TLine *line3 = new TLine(gPad->GetUxmin(),y-0.008,gPad->GetUxmax(),y-0.008);
       	    line3->Draw();
 	    
-	    // decrease the y position to the maximum of the two lists
-
-
       	    //std::cout << std::endl;
  
       	  } // close if there is at least a difference 
@@ -282,7 +322,7 @@ namespace {
 
       //canvas.SetCanvasSize(2000,(1-y)*1000);
       std::string fileName(m_imageFileName);
-      canvas1.SaveAs(fileName.c_str());
+      canvas.SaveAs(fileName.c_str());
       return true;
     }
   };

--- a/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
+++ b/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
@@ -54,7 +54,7 @@ namespace {
 
 	y -= pitch; 
 	y_x1.push_back(y);
-	s_x1.push_back(element.first.c_str());
+	s_x1.push_back(element.first);
 
 	std::map<int,std::string> output;
 	int count=0;

--- a/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
+++ b/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
@@ -1,0 +1,237 @@
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "CondFormats/HLTObjects/interface/AlCaRecoTriggerBits.h"
+
+#include <memory>
+#include <sstream>
+#include <iostream>
+#include "TCanvas.h"
+#include "TLatex.h"
+
+namespace {
+  
+  /************************************************
+    Display AlCaRecoTriggerBits mapping
+  *************************************************/
+  class AlCaRecoTriggerBits_Display: public cond::payloadInspector::PlotImage<AlCaRecoTriggerBits> {
+  public:
+    AlCaRecoTriggerBits_Display() : cond::payloadInspector::PlotImage<AlCaRecoTriggerBits>( "Table of AlCaRecoTriggerBits" ){
+      setSingleIov( true );
+    }
+
+    bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override{
+      auto iov = iovs.front();
+      std::shared_ptr<AlCaRecoTriggerBits> payload = fetchPayload( std::get<1>(iov) );
+
+      TCanvas canvas("AlCaRecoTriggerBits","AlCaRecoTriggerBits",2000,1000); 
+      
+      // Get map of strings to concatenated list of names of HLT paths:
+      typedef std::map<std::string, std::string> TriggerMap;
+      const TriggerMap &triggerMap = payload->m_alcarecoToTrig;
+
+      TLatex l;
+      l.SetTextSize(0.015);
+
+      // Draw the columns titles
+      l.SetTextAlign(12);
+
+      float y, x1, x2;
+      y = 1.0; x1 = 0.02; x2 = x1+0.15;
+	
+      int mapsize=triggerMap.size();
+
+      for(const auto &element : triggerMap){
+	//std::cout<< element.first << " : " ;
+
+	y -= 1./(mapsize+1); l.DrawLatex(x1, y, element.first.c_str()); 
+
+	std::string output;
+	const std::vector<std::string> paths = payload->decompose(element.second);
+	for (unsigned int iPath = 0; iPath < paths.size(); ++iPath) {
+	  //std::cout << paths[iPath] << " ; " ;
+	  output+=paths[iPath];
+	  output+="; ";
+	}
+      	
+	l.DrawLatex(x2,y,output.c_str());  
+	//std::cout << std::endl;
+      }
+
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+      return true;
+    }
+  };
+
+  /************************************************
+    Compare AlCaRecoTriggerBits mapping
+  *************************************************/
+  class AlCaRecoTriggerBits_Compare: public cond::payloadInspector::PlotImage<AlCaRecoTriggerBits> {
+  public:
+    AlCaRecoTriggerBits_Compare() : cond::payloadInspector::PlotImage<AlCaRecoTriggerBits>( "Table of AlCaRecoTriggerBits" ){
+      setSingleIov( false );
+    }
+
+    bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override{
+
+      std::vector<std::tuple<cond::Time_t,cond::Hash> > sorted_iovs = iovs;
+      
+      // make absolute sure the IOVs are sortd by since
+      std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const &t1, auto const &t2) {
+	  return std::get<0>(t1) < std::get<0>(t2);
+	});
+      
+      auto firstiov  = sorted_iovs.front();
+      auto lastiov   = sorted_iovs.back();
+      
+      std::shared_ptr<AlCaRecoTriggerBits> last_payload  = fetchPayload( std::get<1>(lastiov) );
+      std::shared_ptr<AlCaRecoTriggerBits> first_payload = fetchPayload( std::get<1>(firstiov) );
+      
+      std::string lastIOVsince  = std::to_string(std::get<0>(lastiov));
+      std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
+      
+      // Get map of strings to concatenated list of names of HLT paths:
+      typedef std::map<std::string, std::string> TriggerMap;
+      const TriggerMap &first_triggerMap = first_payload->m_alcarecoToTrig;
+      const TriggerMap &last_triggerMap  = last_payload->m_alcarecoToTrig;
+
+      std::vector<std::string> first_keys, not_in_first_keys;
+      std::vector<std::string> last_keys, not_in_last_keys;
+
+      // fill the vector of first keys
+      for (const auto& element : first_triggerMap){
+	first_keys.push_back(element.first);
+      }
+
+      // fill the vector of last keys
+      for (const auto& element : last_triggerMap){
+	last_keys.push_back(element.first);
+      }
+
+      // find the elements not in common
+      std::set_difference(first_keys.begin(),first_keys.end(),last_keys.begin(),last_keys.end(), 
+			  std::inserter(not_in_last_keys, not_in_last_keys.begin()));
+      
+      std::set_difference(last_keys.begin(),last_keys.end(),first_keys.begin(),first_keys.end(), 
+			  std::inserter(not_in_first_keys, not_in_first_keys.begin()));
+
+      TCanvas canvas1("AlCaRecoTriggerBits0","AlCaRecoTriggerBits0",2000,1000); 
+
+      TLatex l;
+      l.SetTextSize(0.018);
+
+      // Draw the columns titles
+      l.SetTextAlign(12);
+
+      float y, x1, x2, x3;
+      y  = 1.0; 
+      x1 = 0.02; 
+      x2 = x1+0.15; 
+      x3 = x2+0.25;
+
+      y -= 0.017; 
+      l.DrawLatexNDC(x1, y,"#scale[1.2]{Key}"); 
+      l.DrawLatexNDC(x2, y,("#scale[1.2]{in IOV: "+firstIOVsince+"}").c_str()); 
+      l.DrawLatexNDC(x3, y,("#scale[1.2]{in IOV: "+lastIOVsince+"}").c_str()); 
+      y -= 0.005;
+
+      // print the ones missing in the last key
+      for(const auto& key : not_in_last_keys ) {
+	//std::cout<< key ;
+	y -= 0.017; l.DrawLatexNDC(x1, y,key.c_str()); 
+	const std::vector<std::string> missing_in_last_paths = first_payload->decompose(first_triggerMap.at(key));
+	
+	std::string output;
+	for (unsigned int iPath = 0; iPath < missing_in_last_paths.size(); ++iPath) {
+	  std::cout << missing_in_last_paths[iPath] << " ; " ;
+	  output+=missing_in_last_paths[iPath];
+	  output+=";";
+	}
+	
+	l.DrawLatexNDC(x2,y,("#color[2]{"+output+"}").c_str());  
+	//std::cout << " |||||| not in last";
+	//std::cout << std::endl;
+      }
+
+      // print the ones missing in the first key
+      for(const auto& key : not_in_first_keys ) {
+	//std::cout<< key ;
+	y -= 0.017; l.DrawLatexNDC(x1, y,key.c_str()); 
+	const std::vector<std::string> missing_in_first_paths = last_payload->decompose(last_triggerMap.at(key));
+
+	//std::cout << " not in first ||||||";
+	std::string output;
+	for (unsigned int iPath = 0; iPath < missing_in_first_paths.size(); ++iPath) {
+	  //std::cout << missing_in_first_paths[iPath] << " ; " ;
+	  output+=missing_in_first_paths[iPath];
+	  output+=";";
+	}
+
+	l.DrawLatexNDC(x3,y,("#color[4]{"+output+"}").c_str());  	    
+	//std::cout << std::endl;
+      }
+
+      for(const auto &element : first_triggerMap){
+
+	if(last_triggerMap.find(element.first)!=last_triggerMap.end()){
+
+	  auto lastElement = last_triggerMap.find(element.first);
+	
+	  std::string output;
+	  const std::vector<std::string> first_paths = first_payload->decompose(element.second);
+	  const std::vector<std::string> last_paths  = last_payload->decompose(lastElement->second);
+
+	  std::vector<std::string> not_in_first;
+	  std::vector<std::string> not_in_last;
+
+	  std::set_difference(first_paths.begin(),first_paths.end(),last_paths.begin(),last_paths.end(), 
+			      std::inserter(not_in_last, not_in_last.begin()));
+
+	  std::set_difference(last_paths.begin(),last_paths.end(),first_paths.begin(),first_paths.end(), 
+	  		      std::inserter(not_in_first, not_in_first.begin()));
+
+	  if(not_in_last.size()!=0 || not_in_first.size()!=0) {
+
+	    //std::cout<< element.first << " : "  ;
+	    y -= 0.017; l.DrawLatexNDC(x1, y, element.first.c_str()); 
+	    
+	    std::string output;
+	    for (unsigned int iPath = 0; iPath < not_in_last.size(); ++iPath) {
+	      //std::cout << not_in_last[iPath] << " ; " ;
+	      output+= not_in_last[iPath];
+	      output+="; ";
+	    }
+
+	    l.DrawLatexNDC(x2,y,("#color[2]{"+output+"}").c_str());  
+	    //std::cout << " ||||||";
+	    
+	    output.clear();
+	    for (unsigned int jPath = 0; jPath < not_in_first.size(); ++jPath) {
+	      //std::cout << not_in_first[jPath] << " ; " ;
+	      output+= not_in_first[jPath];
+	      output+=";";
+	    }
+
+	    l.DrawLatexNDC(x3,y,("#color[4]{"+output+"}").c_str());  	    
+	    //std::cout << std::endl;
+ 
+	  } // close if there is at least a difference 
+	} // if there is a common key
+      } // loop on the keys
+
+      //canvas.SetCanvasSize(2000,(1-y)*1000);
+      std::string fileName(m_imageFileName);
+      canvas1.SaveAs(fileName.c_str());
+      return true;
+    }
+  };
+
+
+}
+
+
+PAYLOAD_INSPECTOR_MODULE( AlCaRecoTriggerBits ){
+  PAYLOAD_INSPECTOR_CLASS( AlCaRecoTriggerBits_Display );
+  PAYLOAD_INSPECTOR_CLASS( AlCaRecoTriggerBits_Compare );
+}

--- a/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
+++ b/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
@@ -8,6 +8,7 @@
 #include <iostream>
 #include "TCanvas.h"
 #include "TLatex.h"
+#include "TLine.h"
 
 namespace {
   
@@ -128,7 +129,7 @@ namespace {
       y  = 1.0; 
       x1 = 0.02; 
       x2 = x1+0.15; 
-      x3 = x2+0.25;
+      x3 = x2+0.35;
 
       y -= 0.017; 
       l.DrawLatexNDC(x1, y,"#scale[1.2]{Key}"); 
@@ -142,17 +143,27 @@ namespace {
 	y -= 0.017; l.DrawLatexNDC(x1, y,key.c_str()); 
 	const std::vector<std::string> missing_in_last_paths = first_payload->decompose(first_triggerMap.at(key));
 	
-	std::string output;
+	std::map<int,std::string> output;
+	int count=0;
 	for (unsigned int iPath = 0; iPath < missing_in_last_paths.size(); ++iPath) {
-	  std::cout << missing_in_last_paths[iPath] << " ; " ;
-	  output+=missing_in_last_paths[iPath];
-	  output+=";";
+	  //std::cout << missing_in_last_paths[iPath] << " ; " ;
+	  output[count]+=missing_in_last_paths[iPath];
+	  output[count]+=";";
+	  if(output[count].length()>60) count++;
 	}
 	
-	l.DrawLatexNDC(x2,y,("#color[2]{"+output+"}").c_str());  
+	for (unsigned int br=0; br<output.size();br++){
+	  l.DrawLatexNDC(x2,y,("#color[2]{"+output[br]+"}").c_str());  
+	  if(br!=output.size()-1) y -=0.017;
+	}
 	//std::cout << " |||||| not in last";
 	//std::cout << std::endl;
+
+	TLine *line = new TLine(gPad->GetUxmin(),y-0.008,gPad->GetUxmax(),y-0.008);
+	line->Draw();
+
       }
+      
 
       // print the ones missing in the first key
       for(const auto& key : not_in_first_keys ) {
@@ -161,64 +172,86 @@ namespace {
 	const std::vector<std::string> missing_in_first_paths = last_payload->decompose(last_triggerMap.at(key));
 
 	//std::cout << " not in first ||||||";
-	std::string output;
+	std::map<int,std::string> output;
+	int count=0;
 	for (unsigned int iPath = 0; iPath < missing_in_first_paths.size(); ++iPath) {
 	  //std::cout << missing_in_first_paths[iPath] << " ; " ;
-	  output+=missing_in_first_paths[iPath];
-	  output+=";";
+	  output[count]+=missing_in_first_paths[iPath];
+	  output[count]+=";";
+	  if(output[count].length()>60) count++;
 	}
 
-	l.DrawLatexNDC(x3,y,("#color[4]{"+output+"}").c_str());  	    
+	for (unsigned int br=0; br<output.size();br++){
+	  l.DrawLatexNDC(x3,y,("#color[4]{"+output[br]+"}").c_str());  	    
+	  if(br!=output.size()-1) y -= 0.017;
+	}
 	//std::cout << std::endl;
+	
+	TLine *line2 = new TLine(gPad->GetUxmin(),y-0.008,gPad->GetUxmax(),y-0.008);
+	line2->Draw();
+      
       }
 
       for(const auto &element : first_triggerMap){
 
-	if(last_triggerMap.find(element.first)!=last_triggerMap.end()){
+      	if(last_triggerMap.find(element.first)!=last_triggerMap.end()){
 
-	  auto lastElement = last_triggerMap.find(element.first);
+      	  auto lastElement = last_triggerMap.find(element.first);
 	
-	  std::string output;
-	  const std::vector<std::string> first_paths = first_payload->decompose(element.second);
-	  const std::vector<std::string> last_paths  = last_payload->decompose(lastElement->second);
+      	  std::string output;
+      	  const std::vector<std::string> first_paths = first_payload->decompose(element.second);
+      	  const std::vector<std::string> last_paths  = last_payload->decompose(lastElement->second);
 
-	  std::vector<std::string> not_in_first;
-	  std::vector<std::string> not_in_last;
+      	  std::vector<std::string> not_in_first;
+      	  std::vector<std::string> not_in_last;
 
-	  std::set_difference(first_paths.begin(),first_paths.end(),last_paths.begin(),last_paths.end(), 
-			      std::inserter(not_in_last, not_in_last.begin()));
+      	  std::set_difference(first_paths.begin(),first_paths.end(),last_paths.begin(),last_paths.end(), 
+      			      std::inserter(not_in_last, not_in_last.begin()));
 
-	  std::set_difference(last_paths.begin(),last_paths.end(),first_paths.begin(),first_paths.end(), 
-	  		      std::inserter(not_in_first, not_in_first.begin()));
+      	  std::set_difference(last_paths.begin(),last_paths.end(),first_paths.begin(),first_paths.end(), 
+      	  		      std::inserter(not_in_first, not_in_first.begin()));
 
-	  if(not_in_last.size()!=0 || not_in_first.size()!=0) {
+      	  if(not_in_last.size()!=0 || not_in_first.size()!=0) {
 
-	    //std::cout<< element.first << " : "  ;
-	    y -= 0.017; l.DrawLatexNDC(x1, y, element.first.c_str()); 
+      	    //std::cout<< element.first << " : "  ;
+      	    y -= 0.017; l.DrawLatexNDC(x1, y, element.first.c_str()); 
 	    
-	    std::string output;
-	    for (unsigned int iPath = 0; iPath < not_in_last.size(); ++iPath) {
-	      //std::cout << not_in_last[iPath] << " ; " ;
-	      output+= not_in_last[iPath];
-	      output+="; ";
-	    }
+      	    std::map<int,std::string> output; 
+      	    int count(0);
+      	    for (unsigned int iPath = 0; iPath < not_in_last.size(); ++iPath) {
+      	      //std::cout << not_in_last[iPath] << " ; " ;
+      	      output[count]+= not_in_last[iPath];
+      	      output[count]+="; ";
+      	      if(output[count].length()>60) count++;
+      	    }
 
-	    l.DrawLatexNDC(x2,y,("#color[2]{"+output+"}").c_str());  
-	    //std::cout << " ||||||";
+      	    for (unsigned int br=0; br<output.size();br++){
+      	      l.DrawLatexNDC(x2,y-(br*0.017),("#color[6]{"+output[br]+"}").c_str());
+      	    }  
+      	    //std::cout << " ||||||";
 	    
-	    output.clear();
-	    for (unsigned int jPath = 0; jPath < not_in_first.size(); ++jPath) {
-	      //std::cout << not_in_first[jPath] << " ; " ;
-	      output+= not_in_first[jPath];
-	      output+=";";
-	    }
+      	    output.clear();
+      	    count=0;
+      	    for (unsigned int jPath = 0; jPath < not_in_first.size(); ++jPath) {
+      	      //std::cout << not_in_first[jPath] << " ; " ;
+      	      output[count]+= not_in_first[jPath];
+      	      output[count]+=";";
+      	      if(output[count].length()>60) count++;
+      	    }
 
-	    l.DrawLatexNDC(x3,y,("#color[4]{"+output+"}").c_str());  	    
-	    //std::cout << std::endl;
+      	    for (unsigned int br=0; br<output.size();br++){
+      	      l.DrawLatexNDC(x3,y-(br*0.017),("#color[8]{"+output[br]+"}").c_str());  	    
+      	    }
+
+      	    TLine *line3 = new TLine(gPad->GetUxmin(),y-0.008,gPad->GetUxmax(),y-0.008);
+      	    line3->Draw();
+
+      	    //std::cout << std::endl;
  
-	  } // close if there is at least a difference 
-	} // if there is a common key
-      } // loop on the keys
+      	  } // close if there is at least a difference 
+      	} // if there is a common key
+      }
+      //loop on the keys
 
       //canvas.SetCanvasSize(2000,(1-y)*1000);
       std::string fileName(m_imageFileName);

--- a/CondCore/HLTPlugins/plugins/BuildFile.xml
+++ b/CondCore/HLTPlugins/plugins/BuildFile.xml
@@ -1,0 +1,8 @@
+<flags CXX_FLAGS="-Wno-unused-variable"/>
+
+<library file="AlCaRecoTriggerBits_PayloadInspector.cc" name="AlCaRecoTriggerBits_PayloadInspector">
+  <use   name="CondCore/Utilities"/>
+  <use   name="CondCore/CondDB"/>
+  <use   name="CondFormats/Common"/>
+  <use   name="boost_python"/>
+</library>

--- a/CondCore/HLTPlugins/plugins/BuildFile.xml
+++ b/CondCore/HLTPlugins/plugins/BuildFile.xml
@@ -1,5 +1,3 @@
-<flags CXX_FLAGS="-Wno-unused-variable"/>
-
 <library file="AlCaRecoTriggerBits_PayloadInspector.cc" name="AlCaRecoTriggerBits_PayloadInspector">
   <use   name="CondCore/Utilities"/>
   <use   name="CondCore/CondDB"/>

--- a/CondCore/HLTPlugins/test/test.sh
+++ b/CondCore/HLTPlugins/test/test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Save current working dir so img can be outputted there later
+W_DIR=$(pwd);
+# Set SCRAM architecture var
+SCRAM_ARCH=slc6_amd64_gcc630;
+export SCRAM_ARCH;
+source /afs/cern.ch/cms/cmsset_default.sh;
+eval `scram run -sh`;
+# Go back to original working directory
+cd $W_DIR;
+# Run get payload data script
+
+####################
+# Test Gains
+####################
+/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+    --plugin pluginAlCaRecoTriggerBits_PayloadInspector \
+    --plot plot_AlCaRecoTriggerBits_Compare \
+    --tag AlCaRecoTriggerBits_TrackerDQM_v2_express \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "284123"}' \
+    --db Prod \
+    --test;

--- a/CondCore/HLTPlugins/test/test.sh
+++ b/CondCore/HLTPlugins/test/test.sh
@@ -10,14 +10,32 @@ eval `scram run -sh`;
 cd $W_DIR;
 # Run get payload data script
 
+mkdir -p $W_DIR/plots
+
 ####################
-# Test Gains
+# Test display 
+####################
+/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+    --plugin pluginAlCaRecoTriggerBits_PayloadInspector \
+    --plot plot_AlCaRecoTriggerBits_Display \
+    --tag AlCaRecoHLTpaths8e29_1e31_v7_hlt \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/plots/AlCaRecoTriggerBits_Display.png
+
+####################
+# Test compare
 ####################
 /afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
     --plugin pluginAlCaRecoTriggerBits_PayloadInspector \
     --plot plot_AlCaRecoTriggerBits_Compare \
-    --tag AlCaRecoTriggerBits_TrackerDQM_v2_express \
+    --tag AlCaRecoHLTpaths8e29_1e31_v7_hlt \
     --time_type Run \
-    --iovs '{"start_iov": "1", "end_iov": "284123"}' \
+    --iovs '{"start_iov": "270000", "end_iov": "304820"}' \
     --db Prod \
     --test;
+
+mv *.png $W_DIR/plots/AlCaRecoTriggerBits_Compare.png


### PR DESCRIPTION
Adds Payload Inspector for `AlCaRecoTriggerBits` payloads to be displayed in [cmsDbBrowser](https://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/Prod):
   * payload dump for a single IOV;
   * payload difference between two IOVs;
 