### PR TITLE
Include PSet which is referenced via refToPSet_

### DIFF
--- a/RecoTracker/CkfPattern/python/CkfTrajectoryBuilder_cfi.py
+++ b/RecoTracker/CkfPattern/python/CkfTrajectoryBuilder_cfi.py
@@ -1,5 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
+#to resolve the refToPSet_
+from TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff import CkfBaseTrajectoryFilter_block
+
 CkfTrajectoryBuilder = cms.PSet(
     ComponentType = cms.string('CkfTrajectoryBuilder'),
     propagatorAlong = cms.string('PropagatorWithMaterial'),

--- a/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilder_cfi.py
+++ b/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilder_cfi.py
@@ -1,5 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
+#to resolve the refToPSet_
+from TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff import CkfBaseTrajectoryFilter_block
+
 GroupedCkfTrajectoryBuilder = cms.PSet(
     ComponentType = cms.string('GroupedCkfTrajectoryBuilder'),
     bestHitOnly = cms.bool(True),

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -106,6 +106,8 @@ jetCoreRegionalStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimat
 
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
+#need to also load the refToPSet_ used by GroupedCkfTrajectoryBuilder
+CkfBaseTrajectoryFilter_block = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.CkfBaseTrajectoryFilter_block
 jetCoreRegionalStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
     trajectoryFilter = cms.PSet(refToPSet_ = cms.string('jetCoreRegionalStepTrajectoryFilter')),


### PR DESCRIPTION
In order to help avoid the case where the PSet CkfBaseTrajectoryFilter_block
is added to a module configuration via a refToPSet_ but is not itself
added to the Process we now import that PSet into the cfi files
which reference it.
The missing reference error happened when the fastsim configuration
was changed to more fully utilize eras. This broke the configurations
used to generate pileup for fastsim (since only part of the RECO
sequence is used).