### PR TITLE
Adding hiCentrality and hiClusterCompatibility for XeXe re-reco

### DIFF
--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -125,6 +125,14 @@ highlevelreco = cms.Sequence(egammaHighLevelRecoPrePF*
                              cosmicDCTracksSeq
                              )
 
+# XeXe data with pp reco
+from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+from RecoHI.HiCentralityAlgos.HiCentrality_cfi import hiCentrality
+from RecoHI.HiCentralityAlgos.HiClusterCompatibility_cfi import hiClusterCompatibility
+_highlevelreco_HI = highlevelreco.copy()
+_highlevelreco_HI += hiCentrality
+_highlevelreco_HI += hiClusterCompatibility
+pp_on_XeXe_2017.toReplaceWith(highlevelreco, _highlevelreco_HI)
 
 from FWCore.Modules.logErrorHarvester_cfi import *
 

--- a/RecoHI/HiCentralityAlgos/python/HiCentrality_cfi.py
+++ b/RecoHI/HiCentralityAlgos/python/HiCentrality_cfi.py
@@ -33,3 +33,10 @@ hiCentrality = cms.EDProducer("CentralityProducer",
                            lowGainZDC = cms.bool(True),
 
                             )
+
+from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+pp_on_XeXe_2017.toModify(hiCentrality,
+                         producePixelTracks = False,
+                         srcTracks = cms.InputTag("generalTracks"),
+                         srcVertex = cms.InputTag("offlinePrimaryVertices")
+                         )

--- a/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
@@ -145,6 +145,12 @@ for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017]:
     e.toModify( RecoJetsAOD.outputCommands, 
                 func=lambda outputCommands: outputCommands.extend(['keep *_towerMaker_*_*'])
                 )
+for ec in [RecoJetsAOD.outputCommands, RecoJetsRECO.outputCommands, RecoJetsFEVT.outputCommands]:
+    pp_on_XeXe_2017.toModify( ec,
+                              func=lambda outputCommands: outputCommands.extend(['keep recoCentrality*_hiCentrality_*_*',
+                                                                                 'keep recoClusterCompatibility*_hiClusterCompatibility_*_*'
+                                                                                 ])
+                              )
 
 #HI-specific products: needed in AOD, propagate to more inclusive tiers as well
 for ec in [RecoJetsAOD.outputCommands, RecoJetsRECO.outputCommands, RecoJetsFEVT.outputCommands]:


### PR DESCRIPTION
Backport of #21210 
Produce and keep the hiCentrality and hiClusterCompatibility objects
To be used for XeXe re-reco