### PR TITLE
Fix range-based loop for runControlNumbers_

### DIFF
--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -1229,8 +1229,8 @@ void PrimaryVertexValidation::beginJob()
 
   h_runFromConfig     = EventFeatures.make<TH1I>("h_runFromConfig","run number from config;;run number (from configuration)",
 						 runControlNumbers_.size(),0.,runControlNumbers_.size());
-  for(const auto & r : runControlNumbers_){
-    h_runFromConfig->SetBinContent(r+1,runControlNumbers_[r]);
+  for(const auto r : runControlNumbers_){
+    h_runFromConfig->SetBinContent(r+1, r);
   }
   
   h_runFromEvent      = EventFeatures.make<TH1I>("h_runFromEvent","run number from config;;run number (from event)",1,-0.5,0.5);


### PR DESCRIPTION
Resolves issue: https://github.com/cms-sw/cmssw/issues/21283

We are iterating over `runControlNumbers_` (`std::vector<unsigned int>`)
and using those values again to access `runControlNumbers_`. In
particular failing unit test we had 1 run thus
`runControlNumbers_.size()` was 1. Then we tried to access
`runControlNumbers_[1]` which was out-of-bounds.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>