### PR TITLE
Dropbox json update for the ECAL Pedestals PCL for allowing to write in production tag

### DIFF
--- a/CondFormats/Common/test/EcalPedestal_prod.json
+++ b/CondFormats/Common/test/EcalPedestal_prod.json
@@ -1,7 +1,8 @@
 {
     "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
-        "EcalPedestals_PCL_byRun_v0_express": {}
+        "EcalPedestals_prompt": {},
+        "EcalPedestals_express": {}
     }, 
     "inputTag": "EcalPedestals_pcl", 
     "since": null, 


### PR DESCRIPTION
This is to keep the `CondFormats/Common` updated so that one can retrieve the last payload in the Dropbox tag which controls the writing of payloads from PCL workflows.
The change made here is to put ECAL Pedestals PCL workflow write in production tag consumed by express and prompt wfs.
The tag has been updated already. https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3365.html