### PR TITLE
Cure (innocuous) dead assignments in reco met filters and producers

### DIFF
--- a/RecoMET/METFilters/plugins/EEBadScFilter.cc
+++ b/RecoMET/METFilters/plugins/EEBadScFilter.cc
@@ -166,9 +166,6 @@ bool EEBadScFilter::filter(edm::StreamID, edm::Event & iEvent, const edm::EventS
 
   int ix,iy,iz;
 
-  ix=0,iy=0,iz=0;
-
-
   // loop over the list of bad SCs (defined in the python file)
 
   for (std::vector<int>::const_iterator scit = badsc_.begin(); scit != badsc_.end(); ++ scit) {

--- a/RecoMET/METFilters/plugins/EcalBadCalibFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalBadCalibFilter.cc
@@ -128,16 +128,13 @@ bool EcalBadCalibFilter::filter(edm::StreamID, edm::Event & iEvent, const edm::E
     // print some debug info
     if (debug_) {
       
-      int ix,iy,iz;
-      ix=0,iy=0,iz=0;
-      
       // ref: DataFormats/EcalDetId/interface/EcalSubdetector.h
       // EcalBarrel
       if (ecaldet.subdetId()==1) {
 	EBDetId ebdet(ecalit);
-	ix=ebdet.ieta();
-	iy=ebdet.iphi();
-	iz=ebdet.zside();
+	int ix=ebdet.ieta();
+	int iy=ebdet.iphi();
+	int iz=ebdet.zside();
 	
 	edm::LogInfo("EcalBadCalibFilter") << "DetId=" <<  ecaldet.rawId();
 	edm::LogInfo("EcalBadCalibFilter") << "ieta=" << ix << " iphi=" << iy << " iz=" << iz;
@@ -145,11 +142,11 @@ bool EcalBadCalibFilter::filter(edm::StreamID, edm::Event & iEvent, const edm::E
       }
 
       // EcalEndcap
-      if (ecaldet.subdetId()==2) {
+      else if (ecaldet.subdetId()==2) {
 	EEDetId eedet(ecalit);
-	ix=eedet.ix();
-	iy=eedet.iy();
-	iz=eedet.zside();
+	int ix=eedet.ix();
+	int iy=eedet.iy();
+	int iz=eedet.zside();
 
 	edm::LogInfo("EcalBadCalibFilter") << "DetId=" <<  ecaldet.rawId();
 	edm::LogInfo("EcalBadCalibFilter") << "ix=" << ix << " iy=" << iy << " iz=" << iz;

--- a/RecoMET/METProducers/src/MuonTCMETValueMapProducer.cc
+++ b/RecoMET/METProducers/src/MuonTCMETValueMapProducer.cc
@@ -273,7 +273,7 @@ bool MuonTCMETValueMapProducer::isGoodCaloMuon( const reco::Muon* muon, const un
 //____________________________________________________________________________||
 bool MuonTCMETValueMapProducer::isGoodTrack( const reco::Muon* muon )
 {
-  double d0    = -999;
+  double d0;
 
   const reco::TrackRef siTrack = muon->innerTrack();
   if (!siTrack.isNonnull())
@@ -286,8 +286,6 @@ bool MuonTCMETValueMapProducer::isGoodTrack( const reco::Muon* muon )
       const Point pvtx = Point(vertices_->begin()->x(),
 			       vertices_->begin()->y(), 
 			       vertices_->begin()->z());
-            
-      d0 = -1 * siTrack->dxy( pvtx );
             
       double dz = siTrack->dz( pvtx );
             


### PR DESCRIPTION
A few dead asignments were signalled by the static analyzer in
- RecoMET/METFilters/plugins/EEBadScFilter.cc
- RecoMET/METFilters/plugins/EcalBadCalibFilter.cc
- RecoMET/METProducers/src/MuonTCMETValueMapProducer.cc

They are all innocuous, but they are fixed here anyhow in order to clean up the code.

No effect at all is expected on outputs and filter results
