### PR TITLE
Small fixes for phase 1 geometry and further automation of APE tool

### DIFF
--- a/Alignment/APEEstimation/macros/DrawIteration.C
+++ b/Alignment/APEEstimation/macros/DrawIteration.C
@@ -207,23 +207,23 @@ DrawIteration::ExtremeValues DrawIteration::getGraphs(const std::string xOrY, un
       int iValue(0);
       for(std::vector<double>::const_iterator i_value = (*i_sectorValue).second.begin(); i_value != (*i_sectorValue).second.end(); ++i_value, ++iValue){
         double valueApe(std::sqrt(*i_value));
-	// Prevent method for non-analyzed sectors with default value sqrt(99.)
-	if(valueApe>9.){
-	  unregardedSector = true;
-	  break;
-	}
-	// Scale APE to have values in mum instead of cm
-	valueApe = valueApe*10000.;
-	if(valueApe<minimumApe)minimumApe = valueApe;
-	if(valueApe>maximumApe)maximumApe = valueApe;
-	graphApe->SetPoint(iValue,static_cast<double>(iValue),valueApe);
-	
-	const double correction(valueApe - lastCorrection);
-	//const double correction(correction2>0 ? std::sqrt(correction2) : -std::sqrt(-correction2));
-	if(std::fabs(correction)>maxAbsCorrection)maxAbsCorrection = correction;
-	graphCorrection->SetPoint(iValue,static_cast<double>(iValue),correction);
-	// For next iteration subtract value of this one
-	lastCorrection = valueApe;
+  // Prevent method for non-analyzed sectors with default value sqrt(99.)
+  if(valueApe>9.){
+    unregardedSector = true;
+    break;
+  }
+  // Scale APE to have values in mum instead of cm
+  valueApe = valueApe*10000.;
+  if(valueApe<minimumApe)minimumApe = valueApe;
+  if(valueApe>maximumApe)maximumApe = valueApe;
+  graphApe->SetPoint(iValue,static_cast<double>(iValue),valueApe);
+  
+  const double correction(valueApe - lastCorrection);
+  //const double correction(correction2>0 ? std::sqrt(correction2) : -std::sqrt(-correction2));
+  if(std::fabs(correction)>maxAbsCorrection)maxAbsCorrection = correction;
+  graphCorrection->SetPoint(iValue,static_cast<double>(iValue),correction);
+  // For next iteration subtract value of this one
+  lastCorrection = valueApe;
       }
       if(unregardedSector)continue;
       (*v_graphApe).push_back(graphApe);
@@ -390,11 +390,15 @@ std::vector<std::string> DrawIteration::pixelHist(){
   v_name.push_back("BpixLayer2In");
   v_name.push_back("BpixLayer3Out");
   v_name.push_back("BpixLayer3In");
+  v_name.push_back("BpixLayer4Out");
+  v_name.push_back("BpixLayer4In");
   
   v_name.push_back("FpixMinusLayer1");
   v_name.push_back("FpixMinusLayer2");
+  v_name.push_back("FpixMinusLayer3");
   v_name.push_back("FpixPlusLayer1");
   v_name.push_back("FpixPlusLayer2");
+  v_name.push_back("FpixPlusLayer3");
   
   return v_name;
 }
@@ -665,8 +669,8 @@ void DrawIteration::drawFinals(const std::string& xOrY){
       std::vector<Input*>::const_iterator i_input;
       for(i_input = v_input_.begin(); i_input != v_input_.end(); ++i_input, ++iInput){
         sectorValues = &(*i_input)->sectorValues;
-	TH1* hist(0);
-	TString& legendEntry = (*i_input)->legendEntry;
+  TH1* hist(0);
+  TString& legendEntry = (*i_input)->legendEntry;
         bool hasEntry = this->createResultHist(hist, *i_resultHist, xOrY, *sectorValues, iInput);
         if(hasEntry)v_hist.push_back(std::make_pair(hist, legendEntry));
         else hist->Delete();
@@ -678,72 +682,80 @@ void DrawIteration::drawFinals(const std::string& xOrY){
       std::vector<std::pair<TH1*, TString> >::iterator i_hist;
       unsigned int iHist(1);
       for(i_hist = v_hist.begin(); i_hist != v_hist.end(); ++i_hist, ++iHist){
-		  TH1* hist((*i_hist).first);
-		  if(iHist==1){
-			  hist->Draw("e0");
-		  }
-		  else{
-			  hist->SetLineColor(iHist);
-			  hist->SetMarkerColor(iHist);
-			  hist->Draw("e0same");
-		  }
-	  }
+      TH1* hist((*i_hist).first);
+      if(iHist==1){
+        hist->Draw("e0");
+      }
+      else{
+        hist->SetLineColor(iHist);
+        hist->SetMarkerColor(iHist);
+        hist->Draw("e0same");
+      }
+    }
       
       TH1* systHist(0);
       if(systematics_){
-	const std::vector<std::string>& v_name(*i_resultHist);
-	
-	bool pixel(false);
-	bool tob(false);
+  const std::vector<std::string>& v_name(*i_resultHist);
+  
+  bool pixel(false);
+  bool tob(false);
         std::vector<std::string>::const_iterator i_name;
         for(i_name=v_name.begin(); i_name!=v_name.end(); ++i_name){
-	  const TString name((*i_name).c_str());
-	  if(name.BeginsWith("Bpix") || name.BeginsWith("Fpix")){
-	    pixel = true;
-	    break;
-	  }
-	  if(name.BeginsWith("Tob")){
-	    tob = true;
-	    break;
-	  }
-	}
-	if(pixel || tob)systHist = new TH1F("systematics", "sytematics", v_name.size(), 0, v_name.size());
-	if(pixel){
-	  if(xOrY=="x"){
-	    systHist->SetBinContent(1, 10.);
-	    systHist->SetBinContent(2, 10.);
-	    systHist->SetBinContent(3, 10.);
-	    systHist->SetBinContent(4, 10.);
-	    systHist->SetBinContent(5, 10.);
-	    systHist->SetBinContent(6, 10.);
-	    systHist->SetBinContent(9, 5.);
-	  }
-	  else if(xOrY=="y"){
-	    systHist->SetBinContent(1, 15.);
-	    systHist->SetBinContent(2, 15.);
-	    systHist->SetBinContent(3, 15.);
-	    systHist->SetBinContent(4, 20.);
-	    systHist->SetBinContent(5, 15.);
-	    systHist->SetBinContent(6, 15.);
-	    systHist->SetBinContent(9, 5.);
-	  }
-	}
-	if(tob){
-	  systHist->SetBinContent(1, 15.);
-	  systHist->SetBinContent(2, 15.);
-	  systHist->SetBinContent(3, 10.);
-	  systHist->SetBinContent(4, 10.);
-	  systHist->SetBinContent(5, 10.);
-	  systHist->SetBinContent(6, 10.);
-	  systHist->SetBinContent(7, 15.);
-	  systHist->SetBinContent(8, 10.);
-	}
+    const TString name((*i_name).c_str());
+    if(name.BeginsWith("Bpix") || name.BeginsWith("Fpix")){
+      pixel = true;
+      break;
+    }
+    if(name.BeginsWith("Tob")){
+      tob = true;
+      break;
+    }
+  }
+  if(pixel || tob)systHist = new TH1F("systematics", "sytematics", v_name.size(), 0, v_name.size());
+  if(pixel){
+    if(xOrY=="x"){
+      systHist->SetBinContent(1, 10.);
+      systHist->SetBinContent(2, 10.);
+      systHist->SetBinContent(3, 10.);
+      systHist->SetBinContent(4, 10.);
+      systHist->SetBinContent(5, 10.);
+      systHist->SetBinContent(6, 10.);
+      systHist->SetBinContent(7, 10.);
+      systHist->SetBinContent(8, 10.);
+      systHist->SetBinContent(9, 10.);
+      systHist->SetBinContent(10, 10.);
+      systHist->SetBinContent(13, 5.);
+    }
+    else if(xOrY=="y"){
+      systHist->SetBinContent(1, 15.);
+      systHist->SetBinContent(2, 15.);
+      systHist->SetBinContent(3, 15.);
+      systHist->SetBinContent(4, 20.);
+      systHist->SetBinContent(5, 15.);
+      systHist->SetBinContent(6, 15.);
+      systHist->SetBinContent(7, 15.);
+      systHist->SetBinContent(8, 15.);
+      systHist->SetBinContent(9, 15.);
+      systHist->SetBinContent(10, 15.);
+      systHist->SetBinContent(13, 5.);
+    }
+  }
+  if(tob){
+    systHist->SetBinContent(1, 15.);
+    systHist->SetBinContent(2, 15.);
+    systHist->SetBinContent(3, 10.);
+    systHist->SetBinContent(4, 10.);
+    systHist->SetBinContent(5, 10.);
+    systHist->SetBinContent(6, 10.);
+    systHist->SetBinContent(7, 15.);
+    systHist->SetBinContent(8, 10.);
+  }
       }
       
       if(systHist){
         systHist->SetFillColor(1);
-	systHist->SetFillStyle(3004);
-	systHist->Draw("same");
+  systHist->SetFillStyle(3004);
+  systHist->Draw("same");
       }
       
       canvas->Modified();
@@ -759,9 +771,9 @@ void DrawIteration::drawFinals(const std::string& xOrY){
       
       if(v_hist.size()>1){
         for(i_hist = v_hist.begin(), iHist = 1; i_hist != v_hist.end(); ++i_hist, ++iHist){
-	  legend->AddEntry((*i_hist).first, (*i_hist).second, "lp");
-	}
-	legend->Draw("same");
+    legend->AddEntry((*i_hist).first, (*i_hist).second, "lp");
+  }
+  legend->Draw("same");
       }
       
       canvas->Modified();
@@ -874,12 +886,3 @@ void DrawIteration::outputDirectory(const TString& outpath){
   delete outpath_;
   outpath_ = new TString(outpath);
 }
-
-
-
-
-
-
-
-
-

--- a/Alignment/APEEstimation/macros/DrawIteration.C
+++ b/Alignment/APEEstimation/macros/DrawIteration.C
@@ -112,13 +112,13 @@ DrawIteration::SectorValues DrawIteration::getSectorValues(TFile* file){
   SectorValues sectorValues;
   
   // Trees containing the iterative APE values and the sector names
-  TTree* nameTree(0);
+  TTree* nameTree(nullptr);
   file->GetObject("nameTree", nameTree);
   if(!nameTree)std::cout<<"\n\tTTree with names of sectors not found in file!\n";
-  TTree* treeX(0);
+  TTree* treeX(nullptr);
   file->GetObject("iterTreeX", treeX);
   if(!treeX)std::cout<<"\n\tTTree with iteration x values of APE not found in file!\n";
-  TTree* treeY(0);
+  TTree* treeY(nullptr);
   file->GetObject("iterTreeY", treeY);
   if(!treeY)std::cout<<"\n\tTTree with iteration y values of APE not found in file!\n";
   
@@ -130,11 +130,11 @@ DrawIteration::SectorValues DrawIteration::getSectorValues(TFile* file){
   for(unsigned int iSector(1); sectorBool; ++iSector){
     std::stringstream sectorName, fullSectorName;
     sectorName << "Ape_Sector_" << iSector;
-    TBranch* branchName(0);
+    TBranch* branchName(nullptr);
     branchName = nameTree->GetBranch(sectorName.str().c_str());
-    TBranch* branchX(0);
+    TBranch* branchX(nullptr);
     branchX = treeX->GetBranch(sectorName.str().c_str());
-    TBranch* branchY(0);
+    TBranch* branchY(nullptr);
     branchY = treeY->GetBranch(sectorName.str().c_str());
     //std::cout<<"\n\tHere we are: "<<sectorName.str().c_str()<<" "<<branchX<<"\n";
     
@@ -149,7 +149,7 @@ DrawIteration::SectorValues DrawIteration::getSectorValues(TFile* file){
   }
   
   for(std::map<unsigned int, TBranch*>::const_iterator i_branch = m_branchName.begin(); i_branch != m_branchName.end(); ++i_branch){
-    std::string* value(0);
+    std::string* value(nullptr);
     i_branch->second->SetAddress(&value);
     i_branch->second->GetEntry(0);
     sectorValues.m_sectorName[i_branch->first] = value;
@@ -178,9 +178,9 @@ DrawIteration::ExtremeValues DrawIteration::getGraphs(const std::string xOrY, un
   double minimumApe(999.), maximumApe(-999.);
   double maxAbsCorrection(-999.);
   
-  std::map<unsigned int, std::vector<double> >* m_sectorValue(0);
-  std::vector<TGraph*>* v_graphApe(0);
-  std::vector<TGraph*>* v_graphCorrection(0);
+  std::map<unsigned int, std::vector<double> >* m_sectorValue(nullptr);
+  std::vector<TGraph*>* v_graphApe(nullptr);
+  std::vector<TGraph*>* v_graphCorrection(nullptr);
   
   if(xOrY=="x"){
     m_sectorValue = &sectorValues_.m_sectorValueX;
@@ -198,8 +198,8 @@ DrawIteration::ExtremeValues DrawIteration::getGraphs(const std::string xOrY, un
   
   for(std::map<unsigned int, std::vector<double> >::const_iterator i_sectorValue = m_sectorValue->begin(); i_sectorValue != m_sectorValue->end(); ++i_sectorValue){
     if((*i_sectorValue).first >= iSectorLow && (*i_sectorValue).first<= iSectorHigh){
-      TGraph* graphApe(0);
-      TGraph* graphCorrection(0);
+      TGraph* graphApe(nullptr);
+      TGraph* graphCorrection(nullptr);
       graphApe = new TGraph(sectorValues_.m_sectorValueX[1].size());
       graphCorrection = new TGraph(sectorValues_.m_sectorValueX[1].size());
       double lastCorrection(0.);
@@ -238,8 +238,8 @@ DrawIteration::ExtremeValues DrawIteration::getGraphs(const std::string xOrY, un
 
 void DrawIteration::drawCorrections(const std::string& xOrY, const ExtremeValues& extremeValues, const std::string& sectorInterval){
   
-  std::vector<TGraph*>* v_graphApe(0);
-  std::vector<TGraph*>* v_graphCorrection(0);
+  std::vector<TGraph*>* v_graphApe(nullptr);
+  std::vector<TGraph*>* v_graphCorrection(nullptr);
   if(xOrY=="x"){
     v_graphApe = &v_graphApeX_;
     v_graphCorrection = &v_graphCorrectionX_;
@@ -254,7 +254,7 @@ void DrawIteration::drawCorrections(const std::string& xOrY, const ExtremeValues
   
   if(v_graphApe->size()==0 || v_graphCorrection->size()==0)return;
   
-  TCanvas* canvas(0);
+  TCanvas* canvas(nullptr);
   canvas = new TCanvas("canvas");
   bool firstGraph(true);
   for(std::vector<TGraph*>::const_iterator i_graph = v_graphApe->begin(); i_graph != v_graphApe->end(); ++i_graph){
@@ -651,15 +651,15 @@ void DrawIteration::drawFinals(const std::string& xOrY){
   std::vector<std::vector<std::string> >::const_iterator i_resultHist;
   for(i_resultHist=v_resultHist_.begin(); i_resultHist!=v_resultHist_.end(); ++i_resultHist, ++iCanvas){
     //std::cout<<"New canvas\n";
-    TCanvas* canvas(0);
+    TCanvas* canvas(nullptr);
     canvas = new TCanvas("canvas","canvas",gStyle->GetCanvasDefW()*i_resultHist->size()/10.,gStyle->GetCanvasDefH());
     std::vector<std::pair<TH1*, TString> > v_hist;
     
-    SectorValues* sectorValues(0);
+    SectorValues* sectorValues(nullptr);
     if(!overlayMode_){
       unsigned int iInput(1);
       sectorValues = &sectorValues_;
-      TH1* hist(0);
+      TH1* hist(nullptr);
       bool hasEntry = this->createResultHist(hist, *i_resultHist, xOrY, *sectorValues, iInput);
       if(hasEntry)v_hist.push_back(std::make_pair(hist, ""));
       else hist->Delete();
@@ -669,8 +669,8 @@ void DrawIteration::drawFinals(const std::string& xOrY){
       std::vector<Input*>::const_iterator i_input;
       for(i_input = v_input_.begin(); i_input != v_input_.end(); ++i_input, ++iInput){
         sectorValues = &(*i_input)->sectorValues;
-  TH1* hist(0);
-  TString& legendEntry = (*i_input)->legendEntry;
+        TH1* hist(nullptr);
+        TString& legendEntry = (*i_input)->legendEntry;
         bool hasEntry = this->createResultHist(hist, *i_resultHist, xOrY, *sectorValues, iInput);
         if(hasEntry)v_hist.push_back(std::make_pair(hist, legendEntry));
         else hist->Delete();
@@ -693,7 +693,7 @@ void DrawIteration::drawFinals(const std::string& xOrY){
       }
     }
       
-      TH1* systHist(0);
+      TH1* systHist(nullptr);
       if(systematics_){
   const std::vector<std::string>& v_name(*i_resultHist);
   
@@ -761,7 +761,7 @@ void DrawIteration::drawFinals(const std::string& xOrY){
       canvas->Modified();
       canvas->Update();
       
-      TLegend* legend(0);
+      TLegend* legend(nullptr);
       legend = new TLegend(0.2,0.65,0.5,0.85);
       legend->SetFillColor(0);
       legend->SetFillStyle(0);
@@ -779,7 +779,7 @@ void DrawIteration::drawFinals(const std::string& xOrY){
       canvas->Modified();
       canvas->Update();
       
-      TLatex* cmsText(0);
+      TLatex* cmsText(nullptr);
       if(cmsText_!=""){
         cmsText = new TLatex(0.55,0.96,cmsText_);
         cmsText->SetNDC();
@@ -818,7 +818,7 @@ bool DrawIteration::createResultHist(TH1*& hist, const std::vector<std::string>&
   const TString title("Results;;#sigma_{align,"+xOrY+"}  [#mum]");
   hist = new TH1F(ss_name.str().c_str(), title, v_name.size(), 0, v_name.size());
   
-  std::map<unsigned int, std::vector<double> >* m_sectorValue(0);
+  std::map<unsigned int, std::vector<double> >* m_sectorValue(nullptr);
   if(xOrY=="x"){
     m_sectorValue = &sectorValues.m_sectorValueX;
   }

--- a/Alignment/APEEstimation/macros/commandsDrawIteration.C
+++ b/Alignment/APEEstimation/macros/commandsDrawIteration.C
@@ -26,8 +26,8 @@ drawIteration1.drawIteration(39,48);
 drawIteration1.drawIteration(49,68);
 
 
-gROOT->ProcessLine("DrawIteration drawIteration2(15)");
-drawIteration2.yAxisFixed(true);
+//gROOT->ProcessLine("DrawIteration drawIteration2(15)");
+//drawIteration2.yAxisFixed(true);
 
 
 //~ drawIteration2.drawIteration(1,8);
@@ -49,7 +49,7 @@ drawIteration1.drawResult();
 
 //drawIteration2.addSystematics();
 //drawIteration2.addCmsText("CMS Preliminary");
-drawIteration2.drawResult();
+//drawIteration2.drawResult();
 
 gROOT->ProcessLine(".q");
 

--- a/Alignment/APEEstimation/macros/commandsDrawIteration.C
+++ b/Alignment/APEEstimation/macros/commandsDrawIteration.C
@@ -18,24 +18,24 @@ gROOT->ProcessLine("DrawIteration drawIteration1(14)");
 drawIteration1.yAxisFixed(true);
 
 //drawIteration1.drawIteration();
-drawIteration1.drawIteration(1,6);
-drawIteration1.drawIteration(7,10);
-drawIteration1.drawIteration(11,22);
-drawIteration1.drawIteration(23,34);
-drawIteration1.drawIteration(35,44);
-drawIteration1.drawIteration(45,64);
+drawIteration1.drawIteration(1,8);
+drawIteration1.drawIteration(9,14);
+drawIteration1.drawIteration(15,26);
+drawIteration1.drawIteration(27,38);
+drawIteration1.drawIteration(39,48);
+drawIteration1.drawIteration(49,68);
 
 
 gROOT->ProcessLine("DrawIteration drawIteration2(15)");
 drawIteration2.yAxisFixed(true);
 
-drawIteration2.drawIteration(1,6);
-drawIteration2.drawIteration(7,10);
-drawIteration2.drawIteration(11,22);
-drawIteration2.drawIteration(23,34);
-drawIteration2.drawIteration(35,44);
-drawIteration2.drawIteration(45,64);
 
+//~ drawIteration2.drawIteration(1,8);
+//~ drawIteration2.drawIteration(9,14);
+//~ drawIteration2.drawIteration(15,26);
+//~ drawIteration2.drawIteration(27,38);
+//~ drawIteration2.drawIteration(39,48);
+//~ drawIteration2.drawIteration(49,68);
 
 
 gStyle->SetPadLeftMargin(0.15);

--- a/Alignment/APEEstimation/test/SkimProducer/skimProducer_cfg.py
+++ b/Alignment/APEEstimation/test/SkimProducer/skimProducer_cfg.py
@@ -118,8 +118,9 @@ if isZmumu50: process.load("Alignment.APEEstimation.samples.DYToMuMu_M-50_Tune4C
 
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-#~ process.GlobalTag = GlobalTag(process.GlobalTag, 'GR_P_V56', '')
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_design', '')
+
 print "Using global tag "+process.GlobalTag.globaltag._value
 
 process.load("Configuration.StandardSequences.Services_cff")

--- a/Alignment/APEEstimation/test/SkimProducer/skimProducer_cfg.py
+++ b/Alignment/APEEstimation/test/SkimProducer/skimProducer_cfg.py
@@ -10,7 +10,6 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 import sys
 options = VarParsing.VarParsing ('standard')
 options.register('sample', 'data1', VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.string, "Input sample")
-options.register('atCern', True, VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.bool, "At DESY or at CERN")
 options.register('useTrackList', False, VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.bool, "Use list of preselected tracks")
 options.register('isTest', False, VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.bool, "Test run")
 
@@ -24,7 +23,6 @@ if( hasattr(sys, "argv") ):
                 setattr(options,val[0], val[1])
 
 print "Input sample: ", options.sample
-print "At CERN: ", options.atCern
 print "Use list of preselected tracks: ", options.useTrackList
 print "Test run: ", options.isTest
 
@@ -118,8 +116,8 @@ if isZmumu20: process.load("Alignment.APEEstimation.samples.Mc_TkAlMuonIsolated_
 if isZmumu50: process.load("Alignment.APEEstimation.samples.DYToMuMu_M-50_Tune4C_13TeV-pythia8_Spring14dr-TkAlMuonIsolated-castor_PU_S14_POSTLS170_V6-v1_ALCARECO_cff")
 
 
-process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
-from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
 #~ process.GlobalTag = GlobalTag(process.GlobalTag, 'GR_P_V56', '')
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
 print "Using global tag "+process.GlobalTag.globaltag._value
@@ -127,7 +125,6 @@ print "Using global tag "+process.GlobalTag.globaltag._value
 process.load("Configuration.StandardSequences.Services_cff")
 process.load("Configuration.Geometry.GeometryRecoDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
-process.load("CondCore.CondDB.CondDB_cfi")
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 
 
@@ -220,47 +217,7 @@ process.out = cms.OutputModule("PoolOutputModule",
 process.load("Alignment.APEEstimation.PrivateSkim_EventContent_cff")
 process.out.outputCommands.extend(process.ApeSkimEventContent.outputCommands)
 
-#if isData1:
-#  if options.atCern:
-#    process.out.fileName = 'root://eoscms//eos/cms/store/caf/user/ajkumar/data/DoubleMu/Run2011A_May10ReReco/apeSkim.root?svcClass=cmscafuser&stageHost=castorcms'
-#  else:
-#    process.out.fileName = '/scratch/hh/current/cms/user/ajkumar/data/alcareco/data/apeSkim.root'
-#elif isData2:
-#  if options.atCern:
-#    #process.out.fileName = 'root://eoscms//eos/cms/store/caf/user/ajkumar/data/DoubleMu/Run2011A_PromptV4/apeSkim.root?svcClass=cmscafuser&stageHost=castorcms'
-#    process.out.fileName = 'apeSkim.root'
-#  else:
-#    process.out.fileName = '/scratch/hh/current/cms/user/ajkumar/data/alcareco/data/apeSkim.root'
-#if isQcd:
-#  if options.atCern:
-#    process.out.fileName = 'root://eoscms//eos/cms/store/caf/user/ajkumar/mc/Summer11/qcd/apeSkim.root?svcClass=cmscafuser&stageHost=castorcms'
-#  else:
-#    process.out.fileName = '/scratch/hh/current/cms/user/ajkumar/data/alcareco/qcd/apeSkim.root'
-#elif isWlnu:
-#  if options.atCern:
-#    process.out.fileName = 'root://eoscms//eos/cms/store/caf/user/ajkumar/mc/Summer11/wlnu/apeSkim.root?svcClass=cmscafuser&stageHost=castorcms'
-#  else:
-#    process.out.fileName = '/scratch/hh/current/cms/user/ajkumar/data/alcareco/wlnu/apeSkim.root'
-#elif isZmumu:
-#  if options.atCern:
-#    process.out.fileName = ''
-#  else:
-#    process.out.fileName = '/scratch/hh/current/cms/user/ajkumar/data/alcareco/zmumu/apeSkim.root'
-#elif isZtautau:
-#  if options.atCern:
-#    process.out.fileName = ''
-#  else:
-#    process.out.fileName = '/scratch/hh/current/cms/user/ajkumar/data/alcareco/ztautau/apeSkim.root'
-#elif isZmumu10:
-#  if options.atCern:
-#    process.out.fileName = 'root://eoscms//eos/cms/store/caf/user/ajkumar/mc/Summer11/zmumu10/apeSkim.root?svcClass=cmscafuser&stageHost=castorcms'
-#  else:
-#    process.out.fileName = ''
-#elif isZmumu20:
-#  if options.atCern:
-#    process.out.fileName = 'root://eoscms//eos/cms/store/caf/user/ajkumar/mc/Summer11/zmumu20/apeSkim.root?svcClass=cmscafuser&stageHost=castorcms'
-#  else:
-#    process.out.fileName = ''
+
 if options.isTest:
   process.out.fileName = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/test_apeSkim.root'
 

--- a/Alignment/APEEstimation/test/SkimProducer/skimProducer_cfg.py
+++ b/Alignment/APEEstimation/test/SkimProducer/skimProducer_cfg.py
@@ -113,23 +113,31 @@ if isData3: process.load("Alignment.APEEstimation.samples.Data_TkAlMuonIsolated_
 if isData4: process.load("Alignment.APEEstimation.samples.Data_TkAlMuonIsolated_22Jan2013D_v1_cff")
 if isQcd: process.load("Alignment.APEEstimation.samples.Mc_TkAlMuonIsolated_Summer12_qcd_cff")
 if isWlnu: process.load("Alignment.APEEstimation.samples.Mc_WJetsToLNu_74XTest_cff")
-if isZmumu: process.load("Alignment.APEEstimation.samples.Mc_TkAlZMuMu_PhaseI_Fall16_81X_DY_cff")
+if isZmumu10: process.load("Alignment.APEEstimation.samples.Mc_TkAlMuonIsolated_Summer12_zmumu10_cff")
 if isZmumu20: process.load("Alignment.APEEstimation.samples.Mc_TkAlMuonIsolated_Summer12_zmumu20_cff")
 if isZmumu50: process.load("Alignment.APEEstimation.samples.DYToMuMu_M-50_Tune4C_13TeV-pythia8_Spring14dr-TkAlMuonIsolated-castor_PU_S14_POSTLS170_V6-v1_ALCARECO_cff")
 
 
-process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
 from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
-#~ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_design', '')
+#~ process.GlobalTag = GlobalTag(process.GlobalTag, 'GR_P_V56', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
 print "Using global tag "+process.GlobalTag.globaltag._value
 
 process.load("Configuration.StandardSequences.Services_cff")
 process.load("Configuration.Geometry.GeometryRecoDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
-process.load("CondCore.DBCommon.CondDBCommon_cfi")
+process.load("CondCore.CondDB.CondDB_cfi")
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 
+
+process.GlobalTag.toGet = cms.VPSet(
+    cms.PSet(
+        record = cms.string("SiPixelTemplateDBObjectRcd"),
+        tag = cms.string("SiPixelTemplateDBObject_38T_v3_mc"),
+        connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
+    )
+) 
 
 ##
 ## Number of Events (should be after input file)
@@ -154,15 +162,14 @@ if options.useTrackList:
     process.TriggerSelectionSequence *= process.TrackList
 
 import Alignment.CommonAlignment.tools.trackselectionRefitting as trackselRefit
-#~ process.seqTrackselRefit = trackselRefit.getSequence(process, 'ALCARECOTkAlMuonIsolated')
-process.seqTrackselRefit = trackselRefit.getSequence(process, 'ALCARECOTkAlZMuMu')
+process.seqTrackselRefit = trackselRefit.getSequence(process, 'ALCARECOTkAlMuonIsolated')
+#~ process.seqTrackselRefit = trackselRefit.getSequence(process, 'ALCARECOTkAlZMuMu')
 
 ##
 ## Path
 ##
 process.path = cms.Path(
     process.offlineBeamSpot*
-    process.seqTrackselRefit*
     process.MuSkim
 )
 
@@ -184,8 +191,7 @@ EventSelection = cms.PSet(
 ##
 process.out = cms.OutputModule("PoolOutputModule",
     ## Parameters directly for PoolOutputModule
-    #~ fileName = cms.untracked.string('Data_TkAlMuonIsolated_DoubleMuon_Run2015B_PromptReco1.root'),
-    fileName = cms.untracked.string('MC_TkAlZMuMu_PhaseI_Fall16_81X_DY.root'),
+    fileName = cms.untracked.string('Data_TkAlMuonIsolated_DoubleMuon_Run2015B_PromptReco1.root'),
     #logicalFileName = cms.untracked.string(''),
     #catalog = cms.untracked.string(''),
     # Maximus size per file before a new one is created
@@ -214,6 +220,47 @@ process.out = cms.OutputModule("PoolOutputModule",
 process.load("Alignment.APEEstimation.PrivateSkim_EventContent_cff")
 process.out.outputCommands.extend(process.ApeSkimEventContent.outputCommands)
 
+#if isData1:
+#  if options.atCern:
+#    process.out.fileName = 'root://eoscms//eos/cms/store/caf/user/ajkumar/data/DoubleMu/Run2011A_May10ReReco/apeSkim.root?svcClass=cmscafuser&stageHost=castorcms'
+#  else:
+#    process.out.fileName = '/scratch/hh/current/cms/user/ajkumar/data/alcareco/data/apeSkim.root'
+#elif isData2:
+#  if options.atCern:
+#    #process.out.fileName = 'root://eoscms//eos/cms/store/caf/user/ajkumar/data/DoubleMu/Run2011A_PromptV4/apeSkim.root?svcClass=cmscafuser&stageHost=castorcms'
+#    process.out.fileName = 'apeSkim.root'
+#  else:
+#    process.out.fileName = '/scratch/hh/current/cms/user/ajkumar/data/alcareco/data/apeSkim.root'
+#if isQcd:
+#  if options.atCern:
+#    process.out.fileName = 'root://eoscms//eos/cms/store/caf/user/ajkumar/mc/Summer11/qcd/apeSkim.root?svcClass=cmscafuser&stageHost=castorcms'
+#  else:
+#    process.out.fileName = '/scratch/hh/current/cms/user/ajkumar/data/alcareco/qcd/apeSkim.root'
+#elif isWlnu:
+#  if options.atCern:
+#    process.out.fileName = 'root://eoscms//eos/cms/store/caf/user/ajkumar/mc/Summer11/wlnu/apeSkim.root?svcClass=cmscafuser&stageHost=castorcms'
+#  else:
+#    process.out.fileName = '/scratch/hh/current/cms/user/ajkumar/data/alcareco/wlnu/apeSkim.root'
+#elif isZmumu:
+#  if options.atCern:
+#    process.out.fileName = ''
+#  else:
+#    process.out.fileName = '/scratch/hh/current/cms/user/ajkumar/data/alcareco/zmumu/apeSkim.root'
+#elif isZtautau:
+#  if options.atCern:
+#    process.out.fileName = ''
+#  else:
+#    process.out.fileName = '/scratch/hh/current/cms/user/ajkumar/data/alcareco/ztautau/apeSkim.root'
+#elif isZmumu10:
+#  if options.atCern:
+#    process.out.fileName = 'root://eoscms//eos/cms/store/caf/user/ajkumar/mc/Summer11/zmumu10/apeSkim.root?svcClass=cmscafuser&stageHost=castorcms'
+#  else:
+#    process.out.fileName = ''
+#elif isZmumu20:
+#  if options.atCern:
+#    process.out.fileName = 'root://eoscms//eos/cms/store/caf/user/ajkumar/mc/Summer11/zmumu20/apeSkim.root?svcClass=cmscafuser&stageHost=castorcms'
+#  else:
+#    process.out.fileName = ''
 if options.isTest:
   process.out.fileName = os.environ['CMSSW_BASE'] + '/src/Alignment/APEEstimation/hists/test_apeSkim.root'
 
@@ -225,7 +272,3 @@ if options.isTest:
 ## Outpath
 ##
 process.outpath = cms.EndPath(process.out)
-
-
-
-

--- a/Alignment/APEEstimation/test/SkimProducer/skimProducer_cfg.py
+++ b/Alignment/APEEstimation/test/SkimProducer/skimProducer_cfg.py
@@ -158,6 +158,7 @@ process.seqTrackselRefit = trackselRefit.getSequence(process, 'ALCARECOTkAlMuonI
 ##
 process.path = cms.Path(
     process.offlineBeamSpot*
+    process.seqTrackselRefit*
     process.MuSkim
 )
 

--- a/Alignment/APEEstimation/test/SkimProducer/skimProducer_cfg.py
+++ b/Alignment/APEEstimation/test/SkimProducer/skimProducer_cfg.py
@@ -127,15 +127,6 @@ process.load("Configuration.Geometry.GeometryRecoDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 
-
-process.GlobalTag.toGet = cms.VPSet(
-    cms.PSet(
-        record = cms.string("SiPixelTemplateDBObjectRcd"),
-        tag = cms.string("SiPixelTemplateDBObject_38T_v3_mc"),
-        connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
-    )
-) 
-
 ##
 ## Number of Events (should be after input file)
 ##

--- a/Alignment/APEEstimation/test/cfgTemplate/batchSubmitTemplate.tcsh
+++ b/Alignment/APEEstimation/test/cfgTemplate/batchSubmitTemplate.tcsh
@@ -21,7 +21,7 @@ xrdcp _THE_INPUTBASE__THE_NUMBER_.root reco.root
 cmsRun $CMSSW_BASE/src/Alignment/APEEstimation/test/cfgTemplate/apeEstimator_cfg.py_THE_COMMANDS_
 
 
-
+rm -- "$0"
 
 
 

--- a/Alignment/APEEstimation/test/cfgTemplateData/manual_run10Iterations.bash
+++ b/Alignment/APEEstimation/test/cfgTemplateData/manual_run10Iterations.bash
@@ -17,4 +17,3 @@ bash ../startStep1.bash
 sleep 15m
 bash ../createStep2.bash 10
 bash ../startStep2.bash
-        

--- a/Alignment/APEEstimation/test/cfgTemplateData/manual_run10Iterations.bash
+++ b/Alignment/APEEstimation/test/cfgTemplateData/manual_run10Iterations.bash
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+COUNTER="0"
+
+# if data samples are larger switch to longer sleep times
+while [ $COUNTER -lt 10 ]; do
+        bash ../createStep1.bash $COUNTER
+        bash ../startStep1.bash
+        sleep 15m
+        bash ../createStep2.bash $COUNTER
+        bash ../startStep2.bash
+        let COUNTER=COUNTER+1
+done
+
+bash ../createStep1.bash 10 True
+bash ../startStep1.bash
+sleep 15m
+bash ../createStep2.bash 10
+bash ../startStep2.bash
+        

--- a/Alignment/APEEstimation/test/cfgTemplateData/manual_run15Iterations.bash
+++ b/Alignment/APEEstimation/test/cfgTemplateData/manual_run15Iterations.bash
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+COUNTER="0"
+
+# if data samples are larger switch to longer sleep times
+while [ $COUNTER -lt 15 ]; do
+        bash ../createStep1.bash $COUNTER
+        bash ../startStep1.bash
+        sleep 15m 
+        bash ../createStep2.bash $COUNTER
+        bash ../startStep2.bash
+        let COUNTER=COUNTER+1
+done
+
+bash ../createStep1.bash 15 True
+bash ../startStep1.bash
+sleep 15m
+bash ../createStep2.bash 15
+bash ../startStep2.bash
+        

--- a/Alignment/APEEstimation/test/cfgTemplateData/manual_run15Iterations.bash
+++ b/Alignment/APEEstimation/test/cfgTemplateData/manual_run15Iterations.bash
@@ -17,4 +17,3 @@ bash ../startStep1.bash
 sleep 15m
 bash ../createStep2.bash 15
 bash ../startStep2.bash
-        

--- a/Alignment/APEEstimation/test/cfgTemplateData/run10Iterations.bash
+++ b/Alignment/APEEstimation/test/cfgTemplateData/run10Iterations.bash
@@ -2,19 +2,58 @@
 
 COUNTER="0"
 
+nf=$(cat ../createStep1.bash | awk '/nFiles/{i++}i==2' | cut -d= -f 2)
+echo "$nf files to be sent to job queue"
+
+do_files_exist(){
+    fsExist=true 
+    for ((index=1;index<=$1;index++))
+    do
+        if [ -e "error${index}.txt" ]; then
+          :
+        else
+          fsExist=false
+        fi
+    done
+    
+}
+
+
 # if data samples are larger switch to longer sleep times
+rm error* output*
 while [ $COUNTER -lt 10 ]; do
-	bash ../createStep1.bash $COUNTER
-	bash ../startStep1.bash
-	sleep 15m
-	bash ../createStep2.bash $COUNTER
-	bash ../startStep2.bash
-	let COUNTER=COUNTER+1
+        bash ../createStep1.bash $COUNTER
+        bash ../startStep1.bash
+        
+        while : 
+        do
+                fsExist=false
+                sleep 1m
+                do_files_exist $nf
+                if [ $fsExist = true ];  then
+                        break
+                fi
+        done 
+        sleep 1m
+        bash ../createStep2.bash $COUNTER
+        bash ../startStep2.bash
+        let COUNTER=COUNTER+1
+        rm error* output*
 done
 
 bash ../createStep1.bash 10 True
 bash ../startStep1.bash
-sleep 15m
+
+while : 
+do
+        sleep 1m
+        do_files_exist $nf
+        if [ $fsExist = true ]; then
+                break
+        fi
+done 
+
+sleep 1m
 bash ../createStep2.bash 10
 bash ../startStep2.bash
-	
+        

--- a/Alignment/APEEstimation/test/cfgTemplateData/run10Iterations.bash
+++ b/Alignment/APEEstimation/test/cfgTemplateData/run10Iterations.bash
@@ -56,4 +56,3 @@ done
 sleep 1m
 bash ../createStep2.bash 10
 bash ../startStep2.bash
-        

--- a/Alignment/APEEstimation/test/cfgTemplateData/run15Iterations.bash
+++ b/Alignment/APEEstimation/test/cfgTemplateData/run15Iterations.bash
@@ -2,19 +2,58 @@
 
 COUNTER="0"
 
+nf=$(cat ../createStep1.bash | awk '/nFiles/{i++}i==2' | cut -d= -f 2)
+echo "$nf files to be sent to job queue"
+
+do_files_exist(){
+    fsExist=true 
+    for ((index=1;index<=$1;index++))
+    do
+        if [ -e "error${index}.txt" ]; then
+          :
+        else
+          fsExist=false
+        fi
+    done
+    
+}
+
+
 # if data samples are larger switch to longer sleep times
+rm error* output*
 while [ $COUNTER -lt 15 ]; do
-	bash ../createStep1.bash $COUNTER
-	bash ../startStep1.bash
-	sleep 15m 
-	bash ../createStep2.bash $COUNTER
-	bash ../startStep2.bash
-	let COUNTER=COUNTER+1
+        bash ../createStep1.bash $COUNTER
+        bash ../startStep1.bash
+        
+        while : 
+        do
+                fsExist=false
+                sleep 1m
+                do_files_exist $nf
+                if [ $fsExist = true ];  then
+                        break
+                fi
+        done 
+        sleep 1m
+        bash ../createStep2.bash $COUNTER
+        bash ../startStep2.bash
+        let COUNTER=COUNTER+1
+        rm error* output*
 done
 
 bash ../createStep1.bash 15 True
 bash ../startStep1.bash
-sleep 15m
+
+while : 
+do
+        sleep 1m
+        do_files_exist $nf
+        if [ $fsExist = true ]; then
+                break
+        fi
+done 
+
+sleep 1m
 bash ../createStep2.bash 15
 bash ../startStep2.bash
-	
+        

--- a/Alignment/APEEstimation/test/cfgTemplateData/run15Iterations.bash
+++ b/Alignment/APEEstimation/test/cfgTemplateData/run15Iterations.bash
@@ -56,4 +56,3 @@ done
 sleep 1m
 bash ../createStep2.bash 15
 bash ../startStep2.bash
-        


### PR DESCRIPTION
backport of #20889

This includes some small fixes, which up until now I had to manually include in each now CMSSW environment that I set up.

Parts of the APE tool still had the phase 0 geometry included. Changes were made to
Alignment/APEEstimation/macros/DrawIteration.C and
Alignment/APEEstimation/macros/commandsDrawIteration.C
to use phase 1 geometry.

- This only affects the plotting tools

Other changes include a small automation of the APE determination workflow in the following files:
Alignment/APEEstimation/cfgTemplatesData/run15Iterations.bash
Alignment/APEEstimation/cfgTemplatesData/run10Iterations.bash
Alignment/APEEstimation/cfgTemplates/batchSubmitTemplate.tcsh

- Before, one had to manually specify a sleeping time between iterations, waiting for batch jobs to finish
- Now, as soon as all batch jobs of an iteration have finished, the sleeping is ended
The old workflow is kept in the following files for now:

Alignment/APEEstimation/cfgTemplatesData/manual_run15Iterations.bash
Alignment/APEEstimation/cfgTemplatesData/manual_run10Iterations.bash

Finally, the deprecated use of ​CondCore.​DBCommon.CondDBCommon_cfi was removed from
Alignment/APEEstimation/test/SkimProducer/skimProducer_cfg.py.