### PR TITLE
Revert accidentally committed changes in CalibTracker/SiStripDCS [94X]

### DIFF
--- a/CalibTracker/SiStripDCS/interface/SiStripDetVOffBuilder.h
+++ b/CalibTracker/SiStripDCS/interface/SiStripDetVOffBuilder.h
@@ -22,7 +22,6 @@
 #include "CondFormats/Common/interface/TimeConversions.h"
 //#include "DataFormats/Provenance/interface/Timestamp.h"
 
-class TrackerTopology;
 
 #include <fstream>
 #include <iostream>
@@ -47,7 +46,7 @@ class SiStripDetVOffBuilder
   /** Default constructor. */
   SiStripDetVOffBuilder(const edm::ParameterSet&,const edm::ActivityRegistry&);
   /** Build the SiStripDetVOff object for transfer. */
-  void BuildDetVOffObj(const TrackerTopology* trackerTopo);
+  void BuildDetVOffObj();
   /** Return modules Off vector of objects. */
   std::vector< std::pair<SiStripDetVOff*,cond::Time_t> > getModulesVOff() {
     reduction(deltaTmin_, maxIOVlength_);

--- a/CalibTracker/SiStripDCS/plugins/SiStripDetVOffHandler.cc
+++ b/CalibTracker/SiStripDCS/plugins/SiStripDetVOffHandler.cc
@@ -72,13 +72,10 @@ void SiStripDetVOffHandler::analyze(const edm::Event& evt, const edm::EventSetup
   }
   condDbSession.transaction().commit();
 
-  edm::ESHandle<TrackerTopology> tTopo;
-  evtSetup.get<TrackerTopologyRcd>().get(tTopo);
-
   // build the object!
   newPayloads.clear();
   modHVBuilder->setLastSiStripDetVOff( lastPayload.get(), lastIov );
-  modHVBuilder->BuildDetVOffObj(tTopo.product());
+  modHVBuilder->BuildDetVOffObj();
   newPayloads = modHVBuilder->getModulesVOff();
   edm::LogInfo("SiStripDetVOffHandler") << "[SiStripDetVOffHandler::" << __func__ << "] "
       << "Finished building " << newPayloads.size() << " new payloads.";

--- a/CalibTracker/SiStripDCS/src/SiStripDetVOffBuilder.cc
+++ b/CalibTracker/SiStripDCS/src/SiStripDetVOffBuilder.cc
@@ -1,7 +1,6 @@
 #include "CalibTracker/SiStripDCS/interface/SiStripDetVOffBuilder.h"
 #include "boost/foreach.hpp"
 #include <sys/stat.h>
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 // constructor
 SiStripDetVOffBuilder::SiStripDetVOffBuilder(const edm::ParameterSet& pset, const edm::ActivityRegistry&) : 
@@ -88,7 +87,7 @@ void SiStripDetVOffBuilder::printPar(std::stringstream& ss, const std::vector<in
   }
 }
 
-void SiStripDetVOffBuilder::BuildDetVOffObj(const TrackerTopology* trackerTopo)
+void SiStripDetVOffBuilder::BuildDetVOffObj()
 {
   // vectors for storing output from DB or text file
   TimesAndValues timesAndValues;


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmssw/pull/21302 for CMSSW_9_4_X.
This reverts commit 58452370ce43291c8f8feab96307b2d786a8f0be, which was not needed and broke the SiStrip DCS O2O in CMSSW_9_4_0.

CC: @hqucms @boudoul 