### PR TITLE
keep islandPhoton related collections via HI eras

### DIFF
--- a/RecoEcal/Configuration/python/RecoEcal_EventContent_cff.py
+++ b/RecoEcal/Configuration/python/RecoEcal_EventContent_cff.py
@@ -104,6 +104,11 @@ from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 #HI-specific products needed in pp scenario special configurations
 for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017, ppRef_2017]:
+    for ec in [RecoEcalAOD.outputCommands, RecoEcalRECO.outputCommands, RecoEcalFEVT.outputCommands]:
+        e.toModify( ec, func=lambda outputCommands: outputCommands.extend(['keep recoSuperClusters_correctedIslandBarrelSuperClusters_*_*',
+                                                                           'keep recoSuperClusters_correctedIslandEndcapSuperClusters_*_*'
+                                                                           ])
+                    )
     for ec in [RecoEcalRECO.outputCommands, RecoEcalFEVT.outputCommands]:
         e.toModify( ec, func=lambda outputCommands: outputCommands.extend(['keep recoCaloClusters_islandBasicClusters_*_*'])
                     )

--- a/RecoEgamma/Configuration/python/RecoEgamma_EventContent_cff.py
+++ b/RecoEgamma/Configuration/python/RecoEgamma_EventContent_cff.py
@@ -186,6 +186,7 @@ for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017, ppRef_2017]:
         e.toModify( ec, func=lambda outputCommands: outputCommands.extend(['keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
                                                                            'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*',
                                                                            'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppIsland_*_*',
+                                                                           'keep recoPhotonCores_islandPhotonCore_*_*',
                                                                            'keep recoPhotons_islandPhotons_*_*'
                                                                            ])
                     )


### PR DESCRIPTION
stores PhotonCore and corrected SuperCluster collections corresponding to islandPhotons.
This PR is for HI-related eras, in particular pp_on_XeXe_2017, ppRef_2017.
These collections are necessary for  SC information and their addition was omitted in the previous PR https://github.com/cms-sw/cmssw/pull/21122