### PR TITLE
Post event transition cache must be atomic

### DIFF
--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -312,7 +312,7 @@ namespace edm {
     PreallocationConfiguration                    preallocations_;
     
     bool                                          asyncStopRequestedWhileProcessingEvents_;
-    InputSource::ItemType                         nextItemTypeFromProcessingEvents_;
+    std::atomic<InputSource::ItemType>            nextItemTypeFromProcessingEvents_;
     StatusCode                                    asyncStopStatusCodeFromProcessingEvents_;
     bool firstEventInBlock_=true;
     

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1432,7 +1432,7 @@ namespace edm {
     if(deferredExceptionPtrIsSet_) {
       std::rethrow_exception(deferredExceptionPtr_);
     }
-    return nextItemTypeFromProcessingEvents_;
+    return nextItemTypeFromProcessingEvents_.load();
   }
 
   void EventProcessor::readEvent(unsigned int iStreamIndex) {


### PR DESCRIPTION
The transition which occurs right after the last event in a block is cached in order to be transferred to the main thread. This cached value needs to be atomic to force synchronization of the memory.