### PR TITLE
Make the HLT vertex filters robust to L3Muon duplicates

### DIFF
--- a/HLTrigger/btau/src/HLTmumutkFilter.cc
+++ b/HLTrigger/btau/src/HLTmumutkFilter.cc
@@ -136,12 +136,18 @@ bool HLTmumutkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetu
     bool track3Matched = false;
     for (auto cand=mucands->begin(); cand!=mucands->end(); cand++) {
       reco::TrackRef tkRef = cand->get<reco::TrackRef>();
-      if     (tkRef == vertextkRef1 && iFoundRefs==0 && !track1Matched) {mucand1 = cand; iFoundRefs++; track1Matched = true;}
-      else if(tkRef == vertextkRef1 && iFoundRefs==1 && !track1Matched) {mucand2 = cand; iFoundRefs++; track1Matched = true;}
-      if     (tkRef == vertextkRef2 && iFoundRefs==0 && !track2Matched) {mucand1 = cand; iFoundRefs++; track2Matched = true;}
-      else if(tkRef == vertextkRef2 && iFoundRefs==1 && !track2Matched) {mucand2 = cand; iFoundRefs++; track2Matched = true;}
-      if     (tkRef == vertextkRef3 && iFoundRefs==0 && !track3Matched) {mucand1 = cand; iFoundRefs++; track3Matched = true;}
-      else if(tkRef == vertextkRef3 && iFoundRefs==1 && !track3Matched) {mucand2 = cand; iFoundRefs++; track3Matched = true;}
+      if (!track1Matched) {
+	if     (tkRef == vertextkRef1 && iFoundRefs==0) {mucand1 = cand; iFoundRefs++; track1Matched = true;}
+	else if(tkRef == vertextkRef1 && iFoundRefs==1) {mucand2 = cand; iFoundRefs++; track1Matched = true;}
+      }
+      if (!track2Matched) {
+	if     (tkRef == vertextkRef2 && iFoundRefs==0) {mucand1 = cand; iFoundRefs++; track2Matched = true;}
+	else if(tkRef == vertextkRef2 && iFoundRefs==1) {mucand2 = cand; iFoundRefs++; track2Matched = true;}
+      }
+      if (!track3Matched) {
+	if     (tkRef == vertextkRef3 && iFoundRefs==0) {mucand1 = cand; iFoundRefs++; track3Matched = true;}
+	else if(tkRef == vertextkRef3 && iFoundRefs==1) {mucand2 = cand; iFoundRefs++; track3Matched = true;}
+      }
     }
     if(iFoundRefs < 2) throw cms::Exception("BadLogic") << "HLTmumutkFilterr: ERROR: the vertex must have "
                                                     << " at least two muons by definition."  << std::endl;
@@ -149,11 +155,11 @@ bool HLTmumutkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetu
     int iTrkFoundRefs = 0;
     for (auto cand=trkcands->begin(); cand!=trkcands->end(); cand++) {
       reco::TrackRef tkRef = cand->get<reco::TrackRef>();
-      if     (tkRef == vertextkRef1 && iTrkFoundRefs==0 && !track1Matched) {tkcand = cand; iTrkFoundRefs++; track1Matched = true;}
-      if     (tkRef == vertextkRef2 && iTrkFoundRefs==0 && !track2Matched) {tkcand = cand; iTrkFoundRefs++; track2Matched = true;}
-      if     (tkRef == vertextkRef3 && iTrkFoundRefs==0 && !track3Matched) {tkcand = cand; iTrkFoundRefs++; track3Matched = true;}
+      if     (tkRef == vertextkRef1 && iTrkFoundRefs==0 && !track1Matched) {tkcand = cand; iTrkFoundRefs++; track1Matched = true; break;}
+      if     (tkRef == vertextkRef2 && iTrkFoundRefs==0 && !track2Matched) {tkcand = cand; iTrkFoundRefs++; track2Matched = true; break;}
+      if     (tkRef == vertextkRef3 && iTrkFoundRefs==0 && !track3Matched) {tkcand = cand; iTrkFoundRefs++; track3Matched = true; break;}
     }
-    if(iTrkFoundRefs < 1) throw cms::Exception("BadLogic") << "HLTmumutkFilterr: ERROR: the vertex must have "
+    if(iTrkFoundRefs == 0) throw cms::Exception("BadLogic") << "HLTmumutkFilterr: ERROR: the vertex must have "
                                                  << " at least one track by definition."  << std::endl;
 
     // calculate three-track transverse momentum

--- a/HLTrigger/btau/src/HLTmumutkFilter.cc
+++ b/HLTrigger/btau/src/HLTmumutkFilter.cc
@@ -131,35 +131,30 @@ bool HLTmumutkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetu
     reco::RecoChargedCandidateCollection::const_iterator tkcand ;    
 
     int iFoundRefs = 0;
-    bool threeMuons = false;
+    bool track1Matched = false;
+    bool track2Matched = false;
+    bool track3Matched = false;
     for (auto cand=mucands->begin(); cand!=mucands->end(); cand++) {
       reco::TrackRef tkRef = cand->get<reco::TrackRef>();
-      if     (tkRef == vertextkRef1 && iFoundRefs==0) {mucand1 = cand; iFoundRefs++;}
-      else if(tkRef == vertextkRef1 && iFoundRefs==1) {mucand2 = cand; iFoundRefs++;}
-      else if(tkRef == vertextkRef1 && iFoundRefs==2) {threeMuons = true;}
-      if     (tkRef == vertextkRef2 && iFoundRefs==0) {mucand1 = cand; iFoundRefs++;}
-      else if(tkRef == vertextkRef2 && iFoundRefs==1) {mucand2 = cand; iFoundRefs++;}
-      else if(tkRef == vertextkRef2 && iFoundRefs==2) {threeMuons = true;}
-      if     (tkRef == vertextkRef3 && iFoundRefs==0) {mucand1 = cand; iFoundRefs++;}
-      else if(tkRef == vertextkRef3 && iFoundRefs==1) {mucand2 = cand; iFoundRefs++;}
-      else if(tkRef == vertextkRef3 && iFoundRefs==2) {threeMuons = true;}
+      if     (tkRef == vertextkRef1 && iFoundRefs==0 && !track1Matched) {mucand1 = cand; iFoundRefs++; track1Matched = true;}
+      else if(tkRef == vertextkRef1 && iFoundRefs==1 && !track1Matched) {mucand2 = cand; iFoundRefs++; track1Matched = true;}
+      if     (tkRef == vertextkRef2 && iFoundRefs==0 && !track2Matched) {mucand1 = cand; iFoundRefs++; track2Matched = true;}
+      else if(tkRef == vertextkRef2 && iFoundRefs==1 && !track2Matched) {mucand2 = cand; iFoundRefs++; track2Matched = true;}
+      if     (tkRef == vertextkRef3 && iFoundRefs==0 && !track3Matched) {mucand1 = cand; iFoundRefs++; track3Matched = true;}
+      else if(tkRef == vertextkRef3 && iFoundRefs==1 && !track3Matched) {mucand2 = cand; iFoundRefs++; track3Matched = true;}
     }
-    if(threeMuons) throw cms::Exception("BadLogic") << "HLTmumutkFilterr: ERROR: the vertex must have "
-                                                    << " exactly two muons by definition."  << std::endl;
+    if(iFoundRefs < 2) throw cms::Exception("BadLogic") << "HLTmumutkFilterr: ERROR: the vertex must have "
+                                                    << " at least two muons by definition."  << std::endl;
 
-    bool twoTrks = false;
     int iTrkFoundRefs = 0;
     for (auto cand=trkcands->begin(); cand!=trkcands->end(); cand++) {
       reco::TrackRef tkRef = cand->get<reco::TrackRef>();
-      if     (tkRef == vertextkRef1 && iTrkFoundRefs==0) {tkcand = cand; iTrkFoundRefs++;}
-      else if(tkRef == vertextkRef1 && iTrkFoundRefs==1) {twoTrks = true;}
-      if     (tkRef == vertextkRef2 && iTrkFoundRefs==0) {tkcand = cand; iTrkFoundRefs++;}
-      else if(tkRef == vertextkRef2 && iTrkFoundRefs==1) {twoTrks = true;}
-      if     (tkRef == vertextkRef3 && iTrkFoundRefs==0) {tkcand = cand; iTrkFoundRefs++;}
-      else if(tkRef == vertextkRef3 && iTrkFoundRefs==1) {twoTrks = true;}
+      if     (tkRef == vertextkRef1 && iTrkFoundRefs==0 && !track1Matched) {tkcand = cand; iTrkFoundRefs++; track1Matched = true;}
+      if     (tkRef == vertextkRef2 && iTrkFoundRefs==0 && !track2Matched) {tkcand = cand; iTrkFoundRefs++; track2Matched = true;}
+      if     (tkRef == vertextkRef3 && iTrkFoundRefs==0 && !track3Matched) {tkcand = cand; iTrkFoundRefs++; track3Matched = true;}
     }
-    if(twoTrks) throw cms::Exception("BadLogic") << "HLTmumutkFilterr: ERROR: the vertex must have "
-                                                 << " exactly one track by definition."  << std::endl;
+    if(iTrkFoundRefs < 1) throw cms::Exception("BadLogic") << "HLTmumutkFilterr: ERROR: the vertex must have "
+                                                 << " at least one track by definition."  << std::endl;
 
     // calculate three-track transverse momentum
     math::XYZVector pperp(mucand1->px() + mucand2->px() + tkcand->px(),

--- a/HLTrigger/btau/src/HLTmumutktkFilter.cc
+++ b/HLTrigger/btau/src/HLTmumutktkFilter.cc
@@ -134,8 +134,8 @@ bool HLTmumutktkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
         if (tkRef == iVec) {mucandVec.push_back(cand); break;}
       }
     }
-    if(mucandVec.size()!= 2) throw cms::Exception("BadLogic") << "HLTmumutktkFilterr: ERROR: the vertex must have "
-                                                              << " exactly two muons by definition."  << std::endl;
+    if(mucandVec.size() < 2) throw cms::Exception("BadLogic") << "HLTmumutktkFilterr: ERROR: the vertex must have "
+                                                              << " at least two muons by definition."  << std::endl;
 
     for (auto cand=trkcands->begin(); cand!=trkcands->end(); cand++) {
       reco::TrackRef tkRef = cand->get<reco::TrackRef>();
@@ -143,8 +143,8 @@ bool HLTmumutktkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
         if (tkRef == iVec) {trkcandVec.push_back(cand); break;}
       }
     }
-    if(trkcandVec.size()!= 2 ) throw cms::Exception("BadLogic") << "HLTmumutktkFilterr: ERROR: the vertex must have "
-                                                                << " exactly two tracks by definition."  << std::endl;
+    if(trkcandVec.size() < 2 ) throw cms::Exception("BadLogic") << "HLTmumutktkFilterr: ERROR: the vertex must have "
+                                                                << " at least two tracks by definition."  << std::endl;
 
     // calculate four-track transverse momentum
     math::XYZVector pperp(mucandVec.at(0)->px() + mucandVec.at(1)->px() + trkcandVec.at(0)->px() + trkcandVec.at(1)->px(),


### PR DESCRIPTION
Two HLT filters, used in some BPH HLT paths, has been updated to be robust to the presence of duplicates in the L3Muon collection.

The changes affect the part of the code that selects the 2 muons and 1 (2) track(s) matched with the three (four) tracks used to build the vertex.
They include:
- veto to the selection of two identical muons
- reduction of the exception message to the cases in which not enough matching muons/tracks are found
