### PR TITLE
Fix for 136.7802 relval fail (revert to the old config in the cff)

### DIFF
--- a/DQMOffline/Trigger/python/B2GMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/B2GMonitoring_cff.py
@@ -139,10 +139,10 @@ AK8PFJet420_TrimMass30_PromptMonitoring.FolderName = cms.string('HLT/B2G/AK8PFJe
 AK8PFJet420_TrimMass30_PromptMonitoring.ptcut = cms.double(420)
 AK8PFJet420_TrimMass30_PromptMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJet420_TrimMass30_v*")
 
-b2gMonitorHLT = cms.Sequence(
+b2gHLTDQMSourceExtra = cms.Sequence(
 )
 
-b2gHLTDQMSourceExtra = cms.Sequence(
+b2gMonitorHLT = cms.Sequence(
     PFHT1050_Mjjmonitoring +
     PFHT1050_Softdropmonitoring +
 


### PR DESCRIPTION
Fix for this relval fail:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc630/CMSSW_10_0_X_2017-11-15-1100/pyRelValMatrixLogs/run/136.7802_RunHLTPhy2017B_AODextra+RunHLTPhy2017B_AODextra+DQMHLTonAODextra_2017+HARVESTDQMHLTonAOD_2017/step2_RunHLTPhy2017B_AODextra+RunHLTPhy2017B_AODextra+DQMHLTonAODextra_2017+HARVESTDQMHLTonAOD_2017.log
as mentioned here the https://github.com/cms-sw/cmssw/pull/21231 the PR broke relval so reverting this config to the previous state fixes it. If you want to keep your new config please fix the ordering mentioned in the log file on cmssdt as I have no idea what is this sequencing all about