### PR TITLE
Fix for 136.7802 relval fail (revert to the old config in the cff)

### DIFF
--- a/DQMOffline/Trigger/python/B2GMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/B2GMonitoring_cff.py
@@ -158,10 +158,10 @@ b2gDimuonHLTOfflineDQM.preselection.trigger.select = cms.vstring(['HLT_Mu37_TkMu
 
 
 
-b2gMonitorHLT = cms.Sequence(
+b2gHLTDQMSourceExtra = cms.Sequence(
 )
 
-b2gHLTDQMSourceExtra = cms.Sequence(
+b2gMonitorHLT = cms.Sequence(
     PFHT1050_Mjjmonitoring +
     PFHT1050_Softdropmonitoring +
 


### PR DESCRIPTION
Reverting this config to fix relval 136.7802 as it's described at the bottom here it brakes the relval 
https://github.com/cms-sw/cmssw/pull/21231
If you want to keep your new config please consult this:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc630/CMSSW_10_0_X_2017-11-15-1100/pyRelValMatrixLogs/run/136.7802_RunHLTPhy2017B_AODextra+RunHLTPhy2017B_AODextra+DQMHLTonAODextra_2017+HARVESTDQMHLTonAOD_2017/step2_RunHLTPhy2017B_AODextra+RunHLTPhy2017B_AODextra+DQMHLTonAODextra_2017+HARVESTDQMHLTonAOD_2017.log
and provide the ordering (sequencing) as required as I have no idea about what is that sequencing. 