### PR TITLE
L1T online and offline DQM configuration upgrades - 94x

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -34,6 +34,21 @@ process.dqmEndPath = cms.EndPath(process.dqmEnv * process.dqmSaver)
 
 process.load("Configuration.StandardSequences.RawToDigi_Data_cff")    
 
+# remove unneeded unpackers
+process.RawToDigi.remove(process.ecalPreshowerDigis)
+process.RawToDigi.remove(process.muonCSCDigis)
+process.RawToDigi.remove(process.muonDTDigis)
+process.RawToDigi.remove(process.muonRPCDigis)
+process.RawToDigi.remove(process.siPixelDigis)
+process.RawToDigi.remove(process.siStripDigis)
+process.RawToDigi.remove(process.castorDigis)
+process.RawToDigi.remove(process.scalersRawToDigi)
+process.RawToDigi.remove(process.tcdsDigis)
+process.RawToDigi.remove(process.totemTriggerRawToDigi)
+process.RawToDigi.remove(process.totemRPRawToDigi)
+process.RawToDigi.remove(process.ctppsDiamondRawToDigi)
+process.RawToDigi.remove(process.ctppsPixelDigis)
+
 process.rawToDigiPath = cms.Path(process.RawToDigi)
 
 #--------------------------------------------------

--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -123,7 +123,6 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.bmtfDigis.InputLabel = cms.InputTag("rawDataRepacker")
     process.emtfStage2Digis.InputLabel = cms.InputTag("rawDataRepacker")
     process.gmtStage2Digis.InputLabel = cms.InputTag("rawDataRepacker")
-    process.l1tCaloLayer1Digis.fedRawDataLabel = cms.InputTag("rawDataRepacker")
     process.caloStage1Digis.InputLabel = cms.InputTag("rawDataRepacker")
     process.caloStage2Digis.InputLabel = cms.InputTag("rawDataRepacker")
     process.gtStage2Digis.InputLabel = cms.InputTag("rawDataRepacker")

--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -57,7 +57,6 @@ process.selfFatEventFilter = cms.EDFilter("HLTL1NumberFilter",
 process.load("DQM.L1TMonitor.L1TStage2_cff")
 
 process.l1tMonitorPath = cms.Path(
-    process.l1tStage2Unpack +
     process.l1tStage2OnlineDQM +
     process.hltFatEventFilter +
 #    process.selfFatEventFilter +

--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -21,6 +21,8 @@ if 'es_prefer_GlobalTag' in process.__dict__:
 #process.load("DQM.Integration.config.fileinputsource_cfi")
 #process.load("DQM.Integration.config.FrontierCondition_GT_Offline_cfi") 
 
+# required for EMTF emulator
+process.load('Configuration.StandardSequences.MagneticField_cff')
 # Required to load EcalMappingRecord
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 

--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -127,7 +127,6 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.bmtfDigis.InputLabel = cms.InputTag("rawDataRepacker")
     process.emtfStage2Digis.InputLabel = cms.InputTag("rawDataRepacker")
     process.gmtStage2Digis.InputLabel = cms.InputTag("rawDataRepacker")
-    process.l1tCaloLayer1Digis.fedRawDataLabel = cms.InputTag("rawDataRepacker")
     process.caloStage1Digis.InputLabel = cms.InputTag("rawDataRepacker")
     process.caloStage2Digis.InputLabel = cms.InputTag("rawDataRepacker")
     process.simHcalTriggerPrimitiveDigis.InputTagFEDRaw = cms.InputTag("rawDataRepacker")

--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -45,6 +45,22 @@ process.dqmEndPath = cms.EndPath(
 
 process.load("Configuration.StandardSequences.RawToDigi_Data_cff")    
 
+# remove unneeded unpackers
+process.RawToDigi.remove(process.ecalDigis)
+process.RawToDigi.remove(process.ecalPreshowerDigis)
+process.RawToDigi.remove(process.hcalDigis)
+process.RawToDigi.remove(process.muonCSCDigis)
+process.RawToDigi.remove(process.muonDTDigis)
+process.RawToDigi.remove(process.siPixelDigis)
+process.RawToDigi.remove(process.siStripDigis)
+process.RawToDigi.remove(process.castorDigis)
+process.RawToDigi.remove(process.scalersRawToDigi)
+process.RawToDigi.remove(process.tcdsDigis)
+process.RawToDigi.remove(process.totemTriggerRawToDigi)
+process.RawToDigi.remove(process.totemRPRawToDigi)
+process.RawToDigi.remove(process.ctppsDiamondRawToDigi)
+process.RawToDigi.remove(process.ctppsPixelDigis)
+
 process.rawToDigiPath = cms.Path(process.RawToDigi)
 
 #--------------------------------------------------

--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -66,12 +66,10 @@ process.selfFatEventFilter = cms.EDFilter("HLTL1NumberFilter",
 process.load("DQM.L1TMonitor.L1TStage2Emulator_cff")
 
 process.l1tEmulatorMonitorPath = cms.Path(
-    process.l1tStage2Unpack  +
     process.Stage2L1HardwareValidation +
     process.l1tStage2EmulatorOnlineDQM +
     process.hltFatEventFilter +
 #    process.selfFatEventFilter +
-    process.l1tStage2UnpackValidationEvents  +
     process.Stage2L1HardwareValidationForValidationEvents +
     process.l1tStage2EmulatorOnlineDQMValidationEvents
     )

--- a/DQM/L1TMonitor/python/L1TStage2CaloLayer1_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2CaloLayer1_cfi.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 l1tStage2CaloLayer1 = cms.EDAnalyzer("L1TStage2CaloLayer1",
-    ecalTPSourceRecd = cms.InputTag("l1tCaloLayer1Digis"),
-    hcalTPSourceRecd = cms.InputTag("l1tCaloLayer1Digis"),
+    ecalTPSourceRecd = cms.InputTag("caloLayer1Digis"),
+    hcalTPSourceRecd = cms.InputTag("caloLayer1Digis"),
     ecalTPSourceSent = cms.InputTag("ecalDigis","EcalTriggerPrimitives"),
     hcalTPSourceSent = cms.InputTag("hcalDigis"),
     fedRawDataLabel  = cms.InputTag("rawDataCollector"),

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -1,44 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 #-------------------------------------------------
-# Stage2 Unpacker Modules
-# TODO: This needs to be setup as a StandardSequence.
-
-# CaloLayer1
-from EventFilter.L1TRawToDigi.caloLayer1Digis_cfi import *
-
-# CaloLayer2
-from EventFilter.L1TRawToDigi.caloStage2Digis_cfi import *
-
-# BMTF 
-from EventFilter.L1TRawToDigi.bmtfDigis_cfi import *
-
-# OMTF
-from EventFilter.L1TRawToDigi.omtfStage2Digis_cfi import *
-
-# EMTF
-from EventFilter.L1TRawToDigi.emtfStage2Digis_cfi import *
-
-# uGMT
-from EventFilter.L1TRawToDigi.gmtStage2Digis_cfi import *
-
-# uGT
-from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import *
-
-l1tStage2Unpack = cms.Sequence(
-    caloLayer1Digis +
-    bmtfDigis  +
-    omtfStage2Digis +
-    emtfStage2Digis +
-    gmtStage2Digis +
-    gtStage2Digis
-)
-
-l1tStage2UnpackValidationEvents = cms.Sequence(
-    caloStage2Digis
-)
-
-#-------------------------------------------------
 # Stage2 Emulator Modules (TODO: Move to L1Trigger.HardwareValidation.L1Stage2HardwareValidation_cff)
 
 # CaloLayer1

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -27,6 +27,7 @@ from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import *
 
 l1tStage2Unpack = cms.Sequence(
     l1tCaloLayer1Digis +
+    omtfStage2Digis +
     emtfStage2Digis +
     gmtStage2Digis
 )
@@ -34,7 +35,6 @@ l1tStage2Unpack = cms.Sequence(
 l1tStage2UnpackValidationEvents = cms.Sequence(
     caloStage2Digis +
     bmtfDigis  +
-    omtfStage2Digis +
     gtStage2Digis
 )
 
@@ -100,6 +100,7 @@ valGtStage2Digis.AlgorithmTriggersUnprescaled = cms.bool(False)
 
 Stage2L1HardwareValidation = cms.Sequence(
     valCaloStage2Layer1Digis +
+    valOmtfDigis +
     valEmtfStage2Digis +
     valGmtCaloSumDigis +
     valGmtStage2Digis
@@ -108,7 +109,6 @@ Stage2L1HardwareValidation = cms.Sequence(
 Stage2L1HardwareValidationForValidationEvents = cms.Sequence(
     valCaloStage2Layer2Digis +
     valBmtfDigis +
-    valOmtfDigis +
     valGtStage2Digis
 )
 
@@ -143,6 +143,7 @@ from DQM.L1TMonitor.L1TStage2uGTEmul_cfi import *
 
 # sequence to run for every event
 l1tStage2EmulatorOnlineDQM = cms.Sequence(
+    l1tdeStage2Omtf +
     l1tdeStage2EmtfOnlineDQMSeq +
     l1tStage2uGMTEmulatorOnlineDQMSeq
 )
@@ -155,7 +156,6 @@ l1tStage2EmulatorOnlineDQMValidationEvents = cms.Sequence(
     l1tdeStage2CaloLayer2 +
     l1tStage2CaloLayer2 + l1tStage2CaloLayer2Emul +
     l1tdeStage2Bmtf +
-    l1tdeStage2Omtf +
     l1tStage2uGtEmul
 )
 

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -27,6 +27,7 @@ from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import *
 
 l1tStage2Unpack = cms.Sequence(
     l1tCaloLayer1Digis +
+    bmtfDigis  +
     omtfStage2Digis +
     emtfStage2Digis +
     gmtStage2Digis
@@ -34,7 +35,6 @@ l1tStage2Unpack = cms.Sequence(
 
 l1tStage2UnpackValidationEvents = cms.Sequence(
     caloStage2Digis +
-    bmtfDigis  +
     gtStage2Digis
 )
 
@@ -100,6 +100,7 @@ valGtStage2Digis.AlgorithmTriggersUnprescaled = cms.bool(False)
 
 Stage2L1HardwareValidation = cms.Sequence(
     valCaloStage2Layer1Digis +
+    valBmtfDigis +
     valOmtfDigis +
     valEmtfStage2Digis +
     valGmtCaloSumDigis +
@@ -108,7 +109,6 @@ Stage2L1HardwareValidation = cms.Sequence(
 
 Stage2L1HardwareValidationForValidationEvents = cms.Sequence(
     valCaloStage2Layer2Digis +
-    valBmtfDigis +
     valGtStage2Digis
 )
 
@@ -143,6 +143,7 @@ from DQM.L1TMonitor.L1TStage2uGTEmul_cfi import *
 
 # sequence to run for every event
 l1tStage2EmulatorOnlineDQM = cms.Sequence(
+    l1tdeStage2Bmtf +
     l1tdeStage2Omtf +
     l1tdeStage2EmtfOnlineDQMSeq +
     l1tStage2uGMTEmulatorOnlineDQMSeq
@@ -155,7 +156,6 @@ l1tStage2EmulatorOnlineDQMValidationEvents = cms.Sequence(
     # to be able to divide them in the MonitorClient
     l1tdeStage2CaloLayer2 +
     l1tStage2CaloLayer2 + l1tStage2CaloLayer2Emul +
-    l1tdeStage2Bmtf +
     l1tStage2uGtEmul
 )
 

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -30,12 +30,12 @@ l1tStage2Unpack = cms.Sequence(
     bmtfDigis  +
     omtfStage2Digis +
     emtfStage2Digis +
-    gmtStage2Digis
+    gmtStage2Digis +
+    gtStage2Digis
 )
 
 l1tStage2UnpackValidationEvents = cms.Sequence(
-    caloStage2Digis +
-    gtStage2Digis
+    caloStage2Digis
 )
 
 #-------------------------------------------------
@@ -90,11 +90,11 @@ from L1Trigger.L1TGlobal.simGtExtFakeProd_cfi import simGtExtFakeProd
 
 valGtStage2Digis = simGtStage2Digis.clone()
 valGtStage2Digis.ExtInputTag = cms.InputTag("simGtExtFakeProd")
-valGtStage2Digis.MuonInputTag = cms.InputTag("gmtStage2Digis", "Muon")
-valGtStage2Digis.EGammaInputTag = cms.InputTag("caloStage2Digis", "EGamma")
-valGtStage2Digis.TauInputTag = cms.InputTag("caloStage2Digis", "Tau")
-valGtStage2Digis.JetInputTag = cms.InputTag("caloStage2Digis", "Jet")
-valGtStage2Digis.EtSumInputTag = cms.InputTag("caloStage2Digis", "EtSum")
+valGtStage2Digis.MuonInputTag = cms.InputTag("gtStage2Digis", "Muon")
+valGtStage2Digis.EGammaInputTag = cms.InputTag("gtStage2Digis", "EGamma")
+valGtStage2Digis.TauInputTag = cms.InputTag("gtStage2Digis", "Tau")
+valGtStage2Digis.JetInputTag = cms.InputTag("gtStage2Digis", "Jet")
+valGtStage2Digis.EtSumInputTag = cms.InputTag("gtStage2Digis", "EtSum")
 valGtStage2Digis.AlgorithmTriggersUnmasked = cms.bool(False)
 valGtStage2Digis.AlgorithmTriggersUnprescaled = cms.bool(False)
 
@@ -104,12 +104,12 @@ Stage2L1HardwareValidation = cms.Sequence(
     valOmtfDigis +
     valEmtfStage2Digis +
     valGmtCaloSumDigis +
-    valGmtStage2Digis
+    valGmtStage2Digis +
+    valGtStage2Digis
 )
 
 Stage2L1HardwareValidationForValidationEvents = cms.Sequence(
-    valCaloStage2Layer2Digis +
-    valGtStage2Digis
+    valCaloStage2Layer2Digis
 )
 
 #-------------------------------------------------
@@ -146,7 +146,8 @@ l1tStage2EmulatorOnlineDQM = cms.Sequence(
     l1tdeStage2Bmtf +
     l1tdeStage2Omtf +
     l1tdeStage2EmtfOnlineDQMSeq +
-    l1tStage2uGMTEmulatorOnlineDQMSeq
+    l1tStage2uGMTEmulatorOnlineDQMSeq +
+    l1tStage2uGtEmul
 )
 
 # sequence to run only for validation events
@@ -155,7 +156,7 @@ l1tStage2EmulatorOnlineDQMValidationEvents = cms.Sequence(
     # We process both layer2 and layer2emu in same sourceclient
     # to be able to divide them in the MonitorClient
     l1tdeStage2CaloLayer2 +
-    l1tStage2CaloLayer2 + l1tStage2CaloLayer2Emul +
-    l1tStage2uGtEmul
+    l1tStage2CaloLayer2 +
+    l1tStage2CaloLayer2Emul
 )
 

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -27,6 +27,7 @@ from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import *
 
 l1tStage2Unpack = cms.Sequence(
     l1tCaloLayer1Digis +
+    emtfStage2Digis +
     gmtStage2Digis
 )
 
@@ -34,7 +35,6 @@ l1tStage2UnpackValidationEvents = cms.Sequence(
     caloStage2Digis +
     bmtfDigis  +
     omtfStage2Digis +
-    emtfStage2Digis +
     gtStage2Digis
 )
 
@@ -100,6 +100,7 @@ valGtStage2Digis.AlgorithmTriggersUnprescaled = cms.bool(False)
 
 Stage2L1HardwareValidation = cms.Sequence(
     valCaloStage2Layer1Digis +
+    valEmtfStage2Digis +
     valGmtCaloSumDigis +
     valGmtStage2Digis
 )
@@ -107,7 +108,6 @@ Stage2L1HardwareValidation = cms.Sequence(
 Stage2L1HardwareValidationForValidationEvents = cms.Sequence(
     valCaloStage2Layer2Digis +
     valBmtfDigis +
-    valEmtfStage2Digis +
     valOmtfDigis +
     valGtStage2Digis
 )
@@ -143,6 +143,7 @@ from DQM.L1TMonitor.L1TStage2uGTEmul_cfi import *
 
 # sequence to run for every event
 l1tStage2EmulatorOnlineDQM = cms.Sequence(
+    l1tdeStage2EmtfOnlineDQMSeq +
     l1tStage2uGMTEmulatorOnlineDQMSeq
 )
 
@@ -155,8 +156,6 @@ l1tStage2EmulatorOnlineDQMValidationEvents = cms.Sequence(
     l1tStage2CaloLayer2 + l1tStage2CaloLayer2Emul +
     l1tdeStage2Bmtf +
     l1tdeStage2Omtf +
-    l1tdeStage2Emtf +
-    l1tdeStage2EmtfComp +
     l1tStage2uGtEmul
 )
 

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -5,7 +5,7 @@ import FWCore.ParameterSet.Config as cms
 # TODO: This needs to be setup as a StandardSequence.
 
 # CaloLayer1
-from EventFilter.L1TXRawToDigi.caloLayer1Stage2Digis_cfi import *
+from EventFilter.L1TRawToDigi.caloLayer1Digis_cfi import *
 
 # CaloLayer2
 from EventFilter.L1TRawToDigi.caloStage2Digis_cfi import *
@@ -26,7 +26,7 @@ from EventFilter.L1TRawToDigi.gmtStage2Digis_cfi import *
 from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import *
 
 l1tStage2Unpack = cms.Sequence(
-    l1tCaloLayer1Digis +
+    caloLayer1Digis +
     bmtfDigis  +
     omtfStage2Digis +
     emtfStage2Digis +
@@ -44,8 +44,8 @@ l1tStage2UnpackValidationEvents = cms.Sequence(
 # CaloLayer1
 from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Digis_cfi import simCaloStage2Layer1Digis
 valCaloStage2Layer1Digis = simCaloStage2Layer1Digis.clone()
-valCaloStage2Layer1Digis.ecalToken = cms.InputTag("l1tCaloLayer1Digis")
-valCaloStage2Layer1Digis.hcalToken = cms.InputTag("l1tCaloLayer1Digis")
+valCaloStage2Layer1Digis.ecalToken = cms.InputTag("caloLayer1Digis")
+valCaloStage2Layer1Digis.hcalToken = cms.InputTag("caloLayer1Digis")
 valCaloStage2Layer1Digis.unpackEcalMask = cms.bool(True)
 valCaloStage2Layer1Digis.unpackHcalMask = cms.bool(True)
 

--- a/DQM/L1TMonitor/python/L1TStage2_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2_cff.py
@@ -1,41 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 #-------------------------------------------------
-# Stage2 Unpacker Modules
-# TODO: This needs to be setup as a StandardSequence.
-
-# CaloLayer1
-from EventFilter.L1TRawToDigi.caloLayer1Digis_cfi import *
-
-# CaloLayer2
-from EventFilter.L1TRawToDigi.caloStage2Digis_cfi import *
-
-# BMTF 
-from EventFilter.L1TRawToDigi.bmtfDigis_cfi import *
-
-# OMTF
-from EventFilter.L1TRawToDigi.omtfStage2Digis_cfi import *
-
-# EMTF
-from EventFilter.L1TRawToDigi.emtfStage2Digis_cfi import *
-
-# uGMT
-from EventFilter.L1TRawToDigi.gmtStage2Digis_cfi import *
-
-# uGT
-from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import *
-
-l1tStage2Unpack = cms.Sequence(
-    caloLayer1Digis +
-    caloStage2Digis +
-    bmtfDigis  +
-    omtfStage2Digis +
-    emtfStage2Digis +
-    gmtStage2Digis +
-    gtStage2Digis
-)
-
-#-------------------------------------------------
 # DQM Modules
 
 # CaloLayer1

--- a/DQM/L1TMonitor/python/L1TStage2_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2_cff.py
@@ -5,7 +5,7 @@ import FWCore.ParameterSet.Config as cms
 # TODO: This needs to be setup as a StandardSequence.
 
 # CaloLayer1
-from EventFilter.L1TXRawToDigi.caloLayer1Stage2Digis_cfi import *
+from EventFilter.L1TRawToDigi.caloLayer1Digis_cfi import *
 
 # CaloLayer2
 from EventFilter.L1TRawToDigi.caloStage2Digis_cfi import *
@@ -26,7 +26,7 @@ from EventFilter.L1TRawToDigi.gmtStage2Digis_cfi import *
 from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import *
 
 l1tStage2Unpack = cms.Sequence(
-    l1tCaloLayer1Digis +
+    caloLayer1Digis +
     caloStage2Digis +
     bmtfDigis  +
     omtfStage2Digis +
@@ -71,7 +71,7 @@ from DQM.L1TMonitor.L1TStage2uGT_cfi import *
 
 # sequence to run for every event
 l1tStage2OnlineDQM = cms.Sequence(
-    l1tStage2CaloLayer1  +
+    l1tStage2CaloLayer1 +
     l1tStage2CaloLayer2 +
     l1tStage2Bmtf +
     l1tStage2Omtf +

--- a/DQM/L1TMonitor/python/L1TdeStage2BMTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2BMTF_cfi.py
@@ -1,5 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
+# List of bins to ignore
+ignoreBinsDeStage2Bmtf = [1]
+
 # compares the unpacked BMTF regional muon collection to the emulated BMTF regional muon collection
 # only muons that do not match are filled in the histograms
 l1tdeStage2Bmtf = cms.EDAnalyzer(
@@ -10,6 +13,7 @@ l1tdeStage2Bmtf = cms.EDAnalyzer(
     regionalMuonCollection1Title = cms.untracked.string("BMTF data"),
     regionalMuonCollection2Title = cms.untracked.string("BMTF emulator"),
     summaryTitle = cms.untracked.string("Summary of comparison between BMTF muons and BMTF emulator muons"),
+    ignoreBin = cms.untracked.vint32(ignoreBinsDeStage2Bmtf),
     verbose = cms.untracked.bool(False),
 )
 

--- a/DQM/L1TMonitor/python/L1TdeStage2EMTF_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2EMTF_cff.py
@@ -2,6 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.L1TMonitor.L1TdeStage2EMTF_cfi import *
 
+# List of bins to ignore
+ignoreBinsDeStage2Emtf = [1]
+
 # compares the unpacked EMTF regional muon collection to the emulated EMTF regional muon collection
 # only muons that do not match are filled in the histograms
 l1tdeStage2EmtfComp = cms.EDAnalyzer(
@@ -13,6 +16,7 @@ l1tdeStage2EmtfComp = cms.EDAnalyzer(
     regionalMuonCollection2Title = cms.untracked.string("EMTF emulator"),
     summaryTitle = cms.untracked.string("Summary of comparison between EMTF muons and EMTF emulator muons"),
     ignoreBadTrackAddress = cms.untracked.bool(True),
+    ignoreBin = cms.untracked.vint32(ignoreBinsDeStage2Emtf),
     verbose = cms.untracked.bool(False),
 )
 

--- a/DQM/L1TMonitor/python/L1TdeStage2EMTF_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2EMTF_cff.py
@@ -16,3 +16,9 @@ l1tdeStage2EmtfComp = cms.EDAnalyzer(
     verbose = cms.untracked.bool(False),
 )
 
+# sequences
+l1tdeStage2EmtfOnlineDQMSeq = cms.Sequence(
+    l1tdeStage2Emtf +
+    l1tdeStage2EmtfComp
+)
+

--- a/DQM/L1TMonitorClient/python/L1TStage2BMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2BMTFEmulatorClient_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+from DQM.L1TMonitor.L1TdeStage2BMTF_cfi import ignoreBinsDeStage2Bmtf
 
 # RegionalMuonCands
 l1tStage2BMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
@@ -9,7 +10,8 @@ l1tStage2BMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     ratioName = cms.untracked.string('mismatchRatio'),
     ratioTitle = cms.untracked.string('Summary of mismatch rates between BMTF muons and BMTF emulator muons'),
     yAxisTitle = cms.untracked.string('# mismatch / # total'),
-    binomialErr = cms.untracked.bool(True)
+    binomialErr = cms.untracked.bool(True),
+    ignoreBin = cms.untracked.vint32(ignoreBinsDeStage2Bmtf)
 )
 
 # sequences

--- a/DQM/L1TMonitorClient/python/L1TStage2EMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EMTFEmulatorClient_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+from DQM.L1TMonitor.L1TdeStage2EMTF_cff import ignoreBinsDeStage2Emtf
 
 # RegionalMuonCands
 l1tStage2EMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
@@ -9,7 +10,8 @@ l1tStage2EMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     ratioName = cms.untracked.string('mismatchRatio'),
     ratioTitle = cms.untracked.string('Summary of mismatch rates between EMTF muons and EMTF emulator muons'),
     yAxisTitle = cms.untracked.string('# mismatch / # total'),
-    binomialErr = cms.untracked.bool(True)
+    binomialErr = cms.untracked.bool(True),
+    ignoreBin = cms.untracked.vint32(ignoreBinsDeStage2Emtf)
 )
 
 # sequences

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
@@ -144,6 +144,7 @@ l1TriggerOffline = cms.Sequence(
 )
 
 #
+from L1Trigger.Configuration.ValL1Emulator_cff import *
 
 l1TriggerEmulatorOnline = cms.Sequence(
                                 l1Stage1HwValEmulatorMonitor
@@ -255,7 +256,12 @@ l1TriggerStage1Clients.remove(l1tTestsSummary)
 l1EmulatorMonitorClient.remove(l1EmulatorErrorFlagClient)
 #l1EmulatorMonitorClient.remove(l1EmulatorEventInfoClient)
 
+
+
+
+##############################################################################
 #stage2 
+##############################################################################
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 
 #from L1Trigger.L1TGlobal.hackConditions_cff import *
@@ -269,25 +275,17 @@ from L1Trigger.L1TMuonEndCap.fakeEmtfParams_2017_MC_cff import *
 from DQMOffline.L1Trigger.L1TStage2CaloLayer2Offline_cfi import *
 l1tStage2CaloLayer2OfflineDQMEmu.stage2CaloLayer2JetSource=cms.InputTag("valCaloStage2Layer2Digis")
 l1tStage2CaloLayer2OfflineDQMEmu.stage2CaloLayer2EtSumSource=cms.InputTag("valCaloStage2Layer2Digis")
+
 from DQMOffline.L1Trigger.L1TEGammaOffline_cfi import *
 l1tEGammaOfflineDQMEmu.stage2CaloLayer2EGammaSource=cms.InputTag("valCaloStage2Layer2Digis")
 
 from DQMOffline.L1Trigger.L1TTauOffline_cfi import *
-l1tTauOfflineDQMEmu.stage2CaloLayer2TaySource=cms.InputTag("valCaloStage2Layer2Digis")
+l1tTauOfflineDQMEmu.stage2CaloLayer2TauSource=cms.InputTag("valCaloStage2Layer2Digis")
+
 from DQMOffline.L1Trigger.L1TMuonDQMOffline_cfi import *
 
 from DQM.L1TMonitor.L1TStage2_cff import *
 from DQMOffline.L1Trigger.L1TriggerDqmOffline_SecondStep_cff import *
-
-stage2UnpackPath = cms.Sequence(
-     l1tCaloLayer1Digis +
-     caloStage2Digis +
-     bmtfDigis  +
-#     BMTFStage2Digis +
-     emtfStage2Digis +
-     gmtStage2Digis +
-     gtStage2Digis
-)
 
 ##Stage 2 Emulator
 
@@ -308,29 +306,22 @@ l1tStage2EmulatorMonitorClient = cms.Sequence(
 #
 # define sequences
 #
-
 Stage2l1TriggerOnline = cms.Sequence(
-                               stage2UnpackPath
-                                * l1tStage2OnlineDQM
+                                l1tStage2OnlineDQM
                                 * dqmEnvL1T
                                )
 # Do not include the uGT online DQM module in the offline sequence
 # since the large 2D histograms cause crashes at the T0.
 l1tStage2OnlineDQM.remove(l1tStage2uGt)
 
-
-
 Stage2l1TriggerOffline = cms.Sequence(
                                 Stage2l1TriggerOnline *
                                 dqmEnvL1TriggerReco *
                                 l1tStage2CaloLayer2OfflineDQM *
                                 l1tEGammaOfflineDQM *
-                                l1tTauOfflineDQM
-
+                                l1tTauOfflineDQM *
+                                l1tMuonDQMOffline
                                 )
-
-#
-from L1Trigger.Configuration.ValL1Emulator_cff import *
 
 Stage2l1TriggerEmulatorOnline = cms.Sequence(
                                  valHcalTriggerPrimitiveDigis +
@@ -338,6 +329,9 @@ Stage2l1TriggerEmulatorOnline = cms.Sequence(
                                  l1tStage2EmulatorOnlineDQM +
                                  dqmEnvL1TEMU
                                 )
+# Do not include the uGT emulation online DQM module in the offline
+# sequence since the large 2D histograms cause crashes at the T0.
+l1tStage2EmulatorOnlineDQM.remove(l1tStage2uGtEmul)
 
 Stage2l1TriggerEmulatorOffline = cms.Sequence(
                                 Stage2l1TriggerEmulatorOnline +
@@ -346,15 +340,11 @@ Stage2l1TriggerEmulatorOffline = cms.Sequence(
                                 l1tTauOfflineDQMEmu
                                 )
 
-#
 
 # DQM Offline Step 1 sequence
 Stage2l1TriggerDqmOffline = cms.Sequence(
                                 Stage2l1TriggerOffline
- #                               * l1tRate_Offline
-  #                              * l1tSync_Offline
                                 * Stage2l1TriggerEmulatorOffline
-                                * l1tMuonDQMOffline
                                 )
 
 # DQM Offline Step 2 sequence                                 


### PR DESCRIPTION
backport of #21334 

L1T online and offline DQM improvements.

- Move the TF emulators and the uGT emulator before the fat event filter to have better statistics for the comparisons. This means the modules are then also ran in the offline DQM.
- Ignore BX range mismatches for BMTF and EMTF data to emulator comparison in the summary.
- Remove the old unpacker for CaloLayer1 and use the rawToDigi standard sequence instead.
- Remove unneeded unpackers from the online DQM clients.
- Add the ESProducer for the ideal magnetic field to the online client because it is needed by the EMTF emulator.
