### PR TITLE
Fix indexes related to {s,l,c}_suffix

### DIFF
--- a/Validation/MuonGEMDigis/plugins/MuonGEMDigisHarvestor.cc
+++ b/Validation/MuonGEMDigis/plugins/MuonGEMDigisHarvestor.cc
@@ -46,7 +46,6 @@
 #include "Validation/MuonGEMDigis/plugins/MuonGEMDigisHarvestor.h"
 #include "Validation/MuonGEMHits/interface/GEMDetLabel.h"
 
-using namespace GEMDetLabel;
 MuonGEMDigisHarvestor::MuonGEMDigisHarvestor(const edm::ParameterSet& ps)
 {
   dbe_path_ = ps.getParameter<std::string>("dbePath");
@@ -162,8 +161,10 @@ MuonGEMDigisHarvestor::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& 
   }
   */
 
+  using namespace GEMDetLabel;
+
   // detailPlots
-  for( int i = 0 ; i < 3 ; i++) {
+  for( unsigned int i = 0 ; i < s_suffix.size() ; i++) {
     TString eta_label = TString(dbe_path_)+"track_eta"+s_suffix[i];
     TString phi_label;
     if ( ig.get(eta_label.Data()) != nullptr ) {
@@ -171,7 +172,7 @@ MuonGEMDigisHarvestor::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& 
       gem_trk_eta[i]->Sumw2();
     }
     else LogDebug("MuonGEMDigisHarvestor")<<"Can not found track_eta";
-    for ( int k=0 ; k <3 ; k++) {
+    for ( unsigned int k=0 ; k < c_suffix.size() ; k++) {
       phi_label = TString(dbe_path_.c_str())+"track_phi"+s_suffix[i]+c_suffix[k];
       if ( ig.get(phi_label.Data()) !=nullptr ) {
         gem_trk_phi[i][k] = (TH1F*)ig.get(phi_label.Data())->getTH1F()->Clone();
@@ -181,7 +182,7 @@ MuonGEMDigisHarvestor::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& 
     }
 
     if ( ig.get(eta_label.Data()) != nullptr && ig.get(phi_label.Data()) !=nullptr ) {
-      for( int j = 0; j < 4 ; j++) { 
+      for( unsigned int j = 0; j < l_suffix.size() ; j++) { 
         TString suffix = TString( s_suffix[i] )+TString( l_suffix[j]);
         TString eta_label = TString(dbe_path_)+"dg_sh_eta"+suffix;
         if( ig.get(eta_label.Data()) !=nullptr ) {
@@ -192,7 +193,7 @@ MuonGEMDigisHarvestor::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& 
         ProcessBooking( ibooker, ig, "dg_eta", suffix, gem_trk_eta[i], sh_eta[i][j]); 
         ProcessBooking( ibooker, ig, "pad_eta", suffix, gem_trk_eta[i], sh_eta[i][j]); 
         ProcessBooking( ibooker, ig, "copad_eta", suffix, gem_trk_eta[i], sh_eta[i][j]); 
-        for ( int k= 0 ; k< 3 ; k++) {
+        for ( unsigned int k = 0 ; k < c_suffix.size() ; k++) {
           suffix = TString( s_suffix[i])+TString( l_suffix[j]) +TString(c_suffix[k]);
           TString phi_label = TString(dbe_path_)+"dg_sh_phi"+suffix;
           if( ig.get(phi_label.Data()) !=nullptr ) {

--- a/Validation/MuonGEMRecHits/plugins/MuonGEMRecHitsHarvestor.cc
+++ b/Validation/MuonGEMRecHits/plugins/MuonGEMRecHitsHarvestor.cc
@@ -44,6 +44,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include "Validation/MuonGEMRecHits/plugins/MuonGEMRecHitsHarvestor.h"
+#include "Validation/MuonGEMHits/interface/GEMDetLabel.h"
 
 
 MuonGEMRecHitsHarvestor::MuonGEMRecHitsHarvestor(const edm::ParameterSet& ps)
@@ -116,18 +117,16 @@ void
 MuonGEMRecHitsHarvestor::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& ig)
 {
   ig.setCurrentFolder(dbe_path_);
+
+  using namespace GEMDetLabel;
  
-  const char* l_suffix[4] = {"_l1","_l2","_l1or2","_l1and2"};
-  const char* s_suffix[2] = {"_st1","_st2"};   
-  const char* c_suffix[3] = {"_even","_odd","_all"};   
+  TH1F* gem_trk_eta[s_suffix.size()];
+  TH1F* gem_trk_phi[s_suffix.size()][c_suffix.size()];  
 
-  TH1F* gem_trk_eta[2];
-  TH1F* gem_trk_phi[2][2];  
-
-  TH1F* sh_eta[2][4];
-  TH1F* sh_phi[2][4][3];
+  TH1F* sh_eta[s_suffix.size()][l_suffix.size()];
+  TH1F* sh_phi[s_suffix.size()][l_suffix.size()][c_suffix.size()];
   
-  for( int i = 0 ; i < 2 ; i++) {
+  for( unsigned int i = 0 ; i < s_suffix.size() ; i++) {
     TString eta_label = TString(dbe_path_)+"track_eta"+s_suffix[i];
     TString phi_label;
     if ( ig.get(eta_label.Data()) != nullptr ) {
@@ -135,7 +134,7 @@ MuonGEMRecHitsHarvestor::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter
       gem_trk_eta[i]->Sumw2();
     }
     else std::cout<<"Can not found track_eta"<<std::endl;
-    for ( int k=0 ; k <3 ; k++) {
+    for ( unsigned int k=0 ; k < c_suffix.size() ; k++) {
       phi_label = TString(dbe_path_.c_str())+"track_phi"+s_suffix[i]+c_suffix[k];
       if ( ig.get(phi_label.Data()) !=nullptr ) {
         gem_trk_phi[i][k] = (TH1F*)ig.get(phi_label.Data())->getTH1F()->Clone();
@@ -145,7 +144,7 @@ MuonGEMRecHitsHarvestor::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter
     }
     
     if ( ig.get(eta_label.Data()) != nullptr && ig.get(phi_label.Data()) !=nullptr ) {
-      for( int j = 0; j < 4 ; j++) { 
+      for( unsigned int j = 0; j < l_suffix.size() ; j++) { 
         TString suffix = TString( s_suffix[i] )+TString( l_suffix[j]);
         TString eta_label = TString(dbe_path_)+"rh_sh_eta"+suffix;
         if( ig.get(eta_label.Data()) !=nullptr ) {
@@ -154,7 +153,7 @@ MuonGEMRecHitsHarvestor::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter
         }
         else std::cout<<"Can not found eta histogram : "<<eta_label<<std::endl;
         ProcessBooking( ibooker, ig, "rh_eta", suffix, gem_trk_eta[i], sh_eta[i][j]); 
-        for ( int k= 0 ; k< 3 ; k++) {
+        for ( unsigned int k= 0 ; k < c_suffix.size() ; k++) {
           suffix = TString( s_suffix[i])+TString( l_suffix[j]) +TString(c_suffix[k]);
           TString phi_label = TString(dbe_path_)+"rh_sh_phi"+suffix;
           if( ig.get(phi_label.Data()) !=nullptr ) {

--- a/Validation/MuonGEMRecHits/src/GEMRecHitTrackMatch.cc
+++ b/Validation/MuonGEMRecHits/src/GEMRecHitTrackMatch.cc
@@ -1,4 +1,5 @@
 #include "Validation/MuonGEMRecHits/interface/GEMRecHitTrackMatch.h"
+#include "Validation/MuonGEMHits/interface/GEMDetLabel.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
@@ -36,17 +37,16 @@ void GEMRecHitTrackMatch::bookHistograms(DQMStore::IBooker& ibooker, edm::Run co
   edm::LogInfo("GEMRecHitTrackMatch")<<"ibooker set current folder\n";
     
   const float PI=TMath::Pi();
-  const char* l_suffix[4] = {"_l1","_l2","_l1or2","_l1and2"};
-  const char* s_suffix[2] = {"_st1","_st2"};
-  const char* c_suffix[3] = {"_even","_odd","_all"};
+
+  using namespace GEMDetLabel;
 
   nstation = geom.regions()[0]->stations().size(); 
   for( unsigned int j=0 ; j<nstation ; j++) {
-      string track_eta_name  = string("track_eta")+s_suffix[j];
+      string track_eta_name  = string("track_eta")+s_suffix.at(j);
       string track_eta_title = string("track_eta")+";SimTrack |#eta|;# of tracks";
       track_eta[j] = ibooker.book1D(track_eta_name.c_str(), track_eta_title.c_str(),140,minEta_,maxEta_);
 
-      for ( unsigned int k = 0 ; k<3 ; k++) {
+      for ( unsigned int k = 0 ; k < c_suffix.size() ; k++) {
           string suffix = string(s_suffix[j])+ string(c_suffix[k]);
           string track_phi_name  = string("track_phi")+suffix;
           string track_phi_title = string("track_phi")+suffix+";SimTrack #phi;# of tracks";
@@ -54,7 +54,7 @@ void GEMRecHitTrackMatch::bookHistograms(DQMStore::IBooker& ibooker, edm::Run co
       }
 
 
-      for( unsigned int i=0 ; i< 4; i++) {
+      for( unsigned int i=0 ; i < l_suffix.size(); i++) {
          string suffix = string(s_suffix[j])+string(l_suffix[i]);
          string rh_eta_name = string("rh_eta")+suffix;
          string rh_eta_title = rh_eta_name+"; tracks |#eta|; # of tracks";
@@ -64,7 +64,7 @@ void GEMRecHitTrackMatch::bookHistograms(DQMStore::IBooker& ibooker, edm::Run co
          string rh_sh_eta_title = rh_sh_eta_name+"; tracks |#eta|; # of tracks";
          rh_sh_eta[i][j] = ibooker.book1D( rh_sh_eta_name.c_str(), rh_sh_eta_title.c_str(), 140, minEta_, maxEta_) ;
 
-         for ( unsigned int k = 0 ; k<3 ; k++) {
+         for ( unsigned int k = 0 ; k < c_suffix.size() ; k++) {
           suffix = string(s_suffix[j])+string(l_suffix[i])+ string(c_suffix[k]);
           string rh_phi_name = string("rh_phi")+suffix;
           string rh_phi_title = rh_phi_name+"; tracks #phi; # of tracks";


### PR DESCRIPTION
The following resolves two bugs reported in one issue:
https://github.com/cms-sw/cmssw/issues/21287

One could consider this as a continuation of pull request:
https://github.com/cms-sw/cmssw/pull/17717

Instead of definiting in multiple places `{s,l,c}_suffix` we now use it
from the central location:
`Validation/MuonGEMHits/interface/GEMDetLabel.h`

In `GEMRecHitTrackMatch.cc` we have to use `s_suffix.at(j)` instead of
`s_suffix.at[j]` as I don't know if `nstation` could be out of bounds.

In `MuonGEMRecHitsHarvestor.cc` we change how `em_trk_eta`,
`gem_trk_phi`, `sh_eta`, and `sh_phi` are defined.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>