### PR TITLE
Reduce LogWarning for non-existing tau discriminators during pat::Tau candidate creation

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.h
@@ -55,7 +55,8 @@ namespace pat {
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
     private:
-      
+      bool firstOccurence_; // used to print LogWarnings only at first occurnece in the event loop
+
       // configurables
       edm::EDGetTokenT<edm::View<reco::BaseTau> > baseTauToken_;
       edm::EDGetTokenT<PFTauTIPAssociationByRef> tauTransverseImpactParameterToken_;


### PR DESCRIPTION
The change is purely technical and minimal as can be seen from the commits. It follows an issue raised by Slava (*).

Cheers,
Roger

(*)
 https://github.com/cms-sw/cmssw/pull/21022/files#diff-c7c5c83df6323f1a53a05655cd079d3fR319