### PR TITLE
Fix GenParticles2HepMCConverter to run on herwig samples

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -113,7 +113,7 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
     genCandToHepMCMap[p] = hepmc_particle;
 
     // Find incident proton pair
-    if ( p->pdgId() == 2212 and std::abs(p->eta()) > 100 and std::abs(p->pz()) > 1000 ) {
+    if ( p->mother() == nullptr and std::abs(p->eta()) > 5 and std::abs(p->pz()) > 1000 ) {
       if ( !parton1 and p->pz() > 0 ) {
         parton1 = p;
         hepmc_parton1 = hepmc_particle;
@@ -132,7 +132,7 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
   hepmc_event->add_vertex(vertex2);
   vertex1->add_particle_in(hepmc_parton1);
   vertex2->add_particle_in(hepmc_parton2);
-  hepmc_event->set_beam_particles(hepmc_parton1, hepmc_parton2);
+  //hepmc_event->set_beam_particles(hepmc_parton1, hepmc_parton2);
 
   // Prepare vertex list
   typedef std::map<const reco::Candidate*, HepMC::GenVertex*> ParticleToVertexMap;

--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -93,7 +93,9 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
 
   // Prepare list of HepMC::GenParticles
   std::map<const reco::Candidate*, HepMC::GenParticle*> genCandToHepMCMap;
+  HepMC::GenParticle* hepmc_parton1 = nullptr, * hepmc_parton2 = nullptr;
   std::vector<HepMC::GenParticle*> hepmc_particles;
+  const reco::Candidate* parton1 = nullptr, * parton2 = nullptr;
   for ( unsigned int i=0, n=genParticlesHandle->size(); i<n; ++i )
   {
     const reco::Candidate* p = &genParticlesHandle->at(i);
@@ -109,27 +111,38 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
 
     hepmc_particles.push_back(hepmc_particle);
     genCandToHepMCMap[p] = hepmc_particle;
+
+    // Find incident proton pair
+    if ( p->pdgId() == 2212 and std::abs(p->eta()) > 100 and std::abs(p->pz()) > 1000 ) {
+      if ( !parton1 and p->pz() > 0 ) {
+        parton1 = p;
+        hepmc_parton1 = hepmc_particle;
+      }
+      else if ( !parton2 and p->pz() < 0 ) {
+        parton2 = p;
+        hepmc_parton2 = hepmc_particle;
+      }
+    }
   }
 
   // Put incident beam particles : proton -> parton vertex
-  const reco::Candidate* parton1 = genParticlesHandle->at(0).daughter(0);
-  const reco::Candidate* parton2 = genParticlesHandle->at(1).daughter(0);
   HepMC::GenVertex* vertex1 = new HepMC::GenVertex(FourVector(parton1->vertex()));
   HepMC::GenVertex* vertex2 = new HepMC::GenVertex(FourVector(parton2->vertex()));
   hepmc_event->add_vertex(vertex1);
   hepmc_event->add_vertex(vertex2);
-  vertex1->add_particle_in(hepmc_particles[0]);
-  vertex2->add_particle_in(hepmc_particles[1]);
-  hepmc_event->set_beam_particles(hepmc_particles[0], hepmc_particles[1]);
+  vertex1->add_particle_in(hepmc_parton1);
+  vertex2->add_particle_in(hepmc_parton2);
+  hepmc_event->set_beam_particles(hepmc_parton1, hepmc_parton2);
 
   // Prepare vertex list
   typedef std::map<const reco::Candidate*, HepMC::GenVertex*> ParticleToVertexMap;
   ParticleToVertexMap particleToVertexMap;
   particleToVertexMap[parton1] = vertex1;
   particleToVertexMap[parton2] = vertex2;
-  for ( unsigned int i=2, n=genParticlesHandle->size(); i<n; ++i )
+  for ( unsigned int i=0, n=genParticlesHandle->size(); i<n; ++i )
   {
     const reco::Candidate* p = &genParticlesHandle->at(i);
+    if ( p == parton1 or p == parton2 ) continue;
 
     // Connect mother-daughters for the other cases
     for ( unsigned int j=0, nMothers=p->numberOfMothers(); j<nMothers; ++j )

--- a/GeneratorInterface/RivetInterface/plugins/MergedGenParticleProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/MergedGenParticleProducer.cc
@@ -133,13 +133,14 @@ void MergedGenParticleProducer::produce(edm::Event& event, const edm::EventSetup
 
 bool MergedGenParticleProducer::isPhotonFromPrunedHadron(const pat::PackedGenParticle& pk) const
 {
-  HepPDT::ParticleID motherid(pk.mother(0)->pdgId());
-  return
-    ( pk.pdgId() == 22 // We care about photons for lepton dressing here
-      and pk.statusFlags().isDirectHadronDecayProduct() // Gen status flag seems correct
-      // Catch cases where miniaod mother is not compatible with the status flag
-      and not (motherid.isHadron() and pk.mother(0)->status() == 2)
-    );
+  if (pk.pdgId() == 22 and pk.statusFlags().isDirectHadronDecayProduct()) {
+    // no mother
+    if (pk.numberOfMothers() == 0) return true;
+    // miniaod mother not compatible with the status flag
+    HepPDT::ParticleID motherid(pk.mother(0)->pdgId());
+    if (not (motherid.isHadron() and pk.mother(0)->status() == 2)) return true;
+  }
+  return false;
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"


### PR DESCRIPTION
The GenParticles2HepMCConverter was written assuming the first two particles in the event record are incident protons. This is is not true for Herwig samples and can introduce crash while invoking RivetAnalysis in the ParticleLevelProducer.

For an example, GenParticles list from a 80X TTbar herwig sample appears like below:
```
[ParticleListDrawer] analysing particle collection prunedGenParticles
 idx  |    ID -       Name |Stat|  Mo1  Mo2  Da1  Da2 |nMo nDa|    pt       eta     phi   |     px         py         pz        m     |
    0 |     6 -          t | 11 |   42   59   15   15 |  2  1 | 103.091     -2.071 -2.243 |    -64.186    -80.671   -402.211  171.651 |
    1 |    -6 -       tbar | 11 |   42   59   16   16 |  2  1 |  99.332     -0.731  1.018 |     52.164     84.533    -79.272  172.378 |
    2 |    21 -          g | 11 |   42   59   19   19 |  2  1 |  12.628     -0.514 -0.311 |     12.023     -3.862     -6.782   -0.000 |
    3 |  2212 -         p+ |  4 |   -1   -1    4    8 |  0  5 |   0.000  29256.000  0.000 |      0.000      0.000   6500.000    0.938 |
    4 |    82 -   rndmflav | 11 |    3    3   27   27 |  1  1 |   0.000     60.618 -0.000 |      0.000     -0.000   6405.248    0.931 |
    5 |    21 -          g | 11 |    3    3   28   29 |  1  2 |   0.957      6.455  0.459 |      0.858      0.424    304.341    0.000 |
```

With this PR, GenParticles2HepMCConverter searches for protons with large |eta| and |pz| to assign incident particles and the first vertices in the HepMC.

This will not affect the standard production.
NanoAOD was crashing to process herwig samples, and this PR solves the problem.

@intrepid42 @gpetruc 