### PR TITLE
Small corrections to the calo to uGT comparison plots

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2uGTCaloLayer2Comp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGTCaloLayer2Comp.h
@@ -192,11 +192,11 @@ class L1TStage2uGTCaloLayer2Comp : public DQMEDAnalyzer {
     JETBADETA,      // no. jets with bad eta
     JETBADPHI,      // no. jets with bad phi
     EGBADET,        // no. egs with bad Et
-    EGBADPHI,       // no. egs with bad eta
     EGBADETA,       // no. egs with bad phi
+    EGBADPHI,       // no. egs with bad eta
     TAUBADET,       // no. tau with bad Et
-    TAUBADPHI,      // no. tau with bad phi
     TAUBADETA,      // no. tau with bad eta
+    TAUBADPHI,      // no. tau with bad phi
     BADSUM          // no. sums with any disagreement
   };
 

--- a/DQM/L1TMonitor/src/L1TStage2uGTCaloLayer2Comp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGTCaloLayer2Comp.cc
@@ -43,7 +43,7 @@ void L1TStage2uGTCaloLayer2Comp::bookHistograms(
 
   comparisonNum->setBinLabel(EVENTBAD, "# bad evts");
   comparisonNum->setBinLabel(EVENTBADJETCOL, "# evts w/ bad jet col size");
-  comparisonNum->setBinLabel(EVENTBADEGCOL, "# evts w/ bad et col size");
+  comparisonNum->setBinLabel(EVENTBADEGCOL, "# evts w/ bad eg col size");
   comparisonNum->setBinLabel(EVENTBADTAUCOL, "# evts w/ bad tau col size");
   comparisonNum->setBinLabel(EVENTBADSUMCOL, "# evts w/ bad sum col size");
   comparisonNum->setBinLabel(JETBADET, "# jets bad Et");


### PR DESCRIPTION
In   (Top) / L1T / L1TStage2uGT / calol2ouput_vs_uGTinput
Ordering changed to : Et-eta-phi, to have the same order as for the muons in  (Top) / L1T / L1TStage2uGMT / uGMToutput_vs_uGTinput  for all collections. 
 
The third bin's label "# evts w/ bad et col size"=> "eg col size".
