### PR TITLE
Pr100x RPCTwinMux in L1TRawToDigi Sequence 

### DIFF
--- a/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
+++ b/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
@@ -67,7 +67,7 @@ def unpack_stage2():
     from EventFilter.L1TRawToDigi.gmtStage2Digis_cfi import gmtStage2Digis
     from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import gtStage2Digis
     from EventFilter.L1TXRawToDigi.twinMuxStage2Digis_cfi import twinMuxStage2Digis
-    L1TRawToDigi_Stage2 = cms.Sequence(twinMuxStage2Digis * bmtfDigis + omtfStage2Digis + emtfStage2Digis + caloLayer1Digis + caloStage2Digis + gmtStage2Digis + gtStage2Digis)
+    L1TRawToDigi_Stage2 = cms.Sequence(RPCTwinMuxRawToDigi + twinMuxStage2Digis * bmtfDigis + omtfStage2Digis + emtfStage2Digis + caloLayer1Digis + caloStage2Digis + gmtStage2Digis + gtStage2Digis)
     
 #
 # Legacy Trigger:


### PR DESCRIPTION
Fix: put dropped RPCTwinMux unpacker back into L1T unpacker sequence.

This unpacker is already in the L1REPACK:Full step relevant for HLT tests
and workflows. However, it was removed from the L1TRawToDigi sequence 
unintentionally.  It should be there.