### PR TITLE
Code added to Produce SiStrip trends of number of channel errors per …

### DIFF
--- a/DQM/SiStripMonitorHardware/interface/FEDErrors.hh
+++ b/DQM/SiStripMonitorHardware/interface/FEDErrors.hh
@@ -2,7 +2,7 @@
 //
 // Package:    DQM/SiStripMonitorHardware
 // Class:      FEDErrors
-// 
+//
 /**\class FEDErrors DQM/SiStripMonitorHardware/interface/FEDErrors.hh
 
  Description: class summarising FED errors
@@ -33,7 +33,7 @@ class TrackerTopology;
 class FEDErrors {
 
 public:
-  
+
   struct FEDCounters {
     unsigned int nFEDErrors;
     unsigned int nDAQProblems;
@@ -58,8 +58,8 @@ public:
   };
 
   struct FECounters {
-    unsigned int nFEOverflows; 
-    unsigned int nFEBadMajorityAddresses; 
+    unsigned int nFEOverflows;
+    unsigned int nFEBadMajorityAddresses;
     unsigned int nFEMissing;
   };
 
@@ -121,7 +121,7 @@ public:
   struct EventProperties {
     long long deltaBX;
   };
-    
+
   FEDErrors();
 
   ~FEDErrors();
@@ -132,7 +132,7 @@ public:
 
   void initialiseFED(const unsigned int aFedID,
 		     const SiStripFedCabling* aCabling,
-                     const TrackerTopology* tTopo,  
+                     const TrackerTopology* tTopo,
 		     bool initVars = true);
 
   //return false if no data, with or without cabled channels.
@@ -186,7 +186,9 @@ public:
 			  TkHistoMap *aTkMapPointer,
 			  MonitorElement *aFedIdVsApvId,
 			  unsigned int & aNBadChannels,
-			  unsigned int & aNBadActiveChannels);
+			  unsigned int & aNBadActiveChannels,
+        unsigned int & aNBadChannels_perFEDID
+      );
 
   void fillEventProperties(long long dbx);
 
@@ -195,7 +197,7 @@ public:
   const bool failMonitoringFEDCheck();
 
   const bool anyDAQProblems();
-  
+
   const bool anyFEDErrors();
 
   const bool anyFEProblems();
@@ -213,7 +215,7 @@ public:
   FEDLevelErrors & getFEDLevelErrors();
 
   EventProperties & getEventProperties();
-  
+
   std::vector<FELevelErrors> & getFELevelErrors();
 
   std::vector<ChannelLevelErrors> & getChannelLevelErrors();
@@ -245,7 +247,7 @@ public:
 
 
 protected:
-  
+
 private:
 
   void incrementLumiErrors(const bool hasError,
@@ -265,7 +267,7 @@ private:
   std::vector<unsigned short> nChInModule_;
 
   std::vector<unsigned short> subDetId_;
-  
+
   FECounters feCounter_;
   FEDLevelErrors fedErrors_;
   ChannelCounters lChCounter_;

--- a/DQM/SiStripMonitorHardware/interface/FEDHistograms.hh
+++ b/DQM/SiStripMonitorHardware/interface/FEDHistograms.hh
@@ -2,7 +2,7 @@
 //
 // Package:    DQM/SiStripMonitorHardware
 // Class:      FEDHistograms
-// 
+//
 /**\class FEDHistograms DQM/SiStripMonitorHardware/interface/FEDHistograms.hh
 
  Description: DQM source application to produce data integrety histograms for SiStrip data
@@ -31,38 +31,40 @@
 class FEDHistograms: public HistogramBase {
 
 public:
-  
+
   FEDHistograms();
 
   ~FEDHistograms() override;
-  
+
   //initialise histograms
   void initialise(const edm::ParameterSet& iConfig,
 		  std::ostringstream* pDebugStream
 		  ) override;
 
-  void fillCountersHistograms(const FEDErrors::FEDCounters & aFedLevelCounters, 
+  void fillCountersHistograms(const FEDErrors::FEDCounters & aFedLevelCounters,
 			      const FEDErrors::ChannelCounters & aChLevelCounters,
 			      const unsigned int aMaxSize,
 			      const double aTime);
 
   void fillFEDHistograms(FEDErrors & aFedError,
 			 const unsigned int aEvtSize,
-			 bool lFullDebug
+			 bool lFullDebug,
+       const double aLumiSection,
+       unsigned int & NumBadChannels_perFEDID
 			 );
 
   void fillFEHistograms(const unsigned int aFedId,
 			const FEDErrors::FELevelErrors & aFeLevelErrors,
-			const FEDErrors::EventProperties & aEventProp 
+			const FEDErrors::EventProperties & aEventProp
 			);
 
-  void fillChannelsHistograms(const unsigned int aFedId, 
-			      const FEDErrors::ChannelLevelErrors & aChErr, 
+  void fillChannelsHistograms(const unsigned int aFedId,
+			      const FEDErrors::ChannelLevelErrors & aChErr,
 			      bool fullDebug
 			      );
 
-  void fillAPVsHistograms(const unsigned int aFedId, 
-			  const FEDErrors::APVLevelErrors & aAPVErr, 
+  void fillAPVsHistograms(const unsigned int aFedId,
+			  const FEDErrors::APVLevelErrors & aAPVErr,
 			  bool fullDebug
 			  );
 
@@ -95,7 +97,7 @@ public:
   MonitorElement *getFedvsAPVpointer();
 
 protected:
-  
+
 private:
 
   //counting histograms (histogram of number of problems per event)
@@ -103,18 +105,19 @@ private:
   HistogramConfig fedEventSize_;
   HistogramConfig fedMaxEventSizevsTime_;
 
-  HistogramConfig nFEDErrors_, 
-    nFEDDAQProblems_, 
-    nFEDsWithFEProblems_, 
-    nFEDCorruptBuffers_, 
+  HistogramConfig nFEDErrors_,
+    nFEDDAQProblems_,
+    nFEDsWithFEProblems_,
+    nFEDCorruptBuffers_,
     nBadChannelStatusBits_,
     nBadActiveChannelStatusBits_,
     nUnconnectedChannels_,
-    nFEDsWithFEOverflows_, 
-    nFEDsWithFEBadMajorityAddresses_, 
+    nFEDsWithFEOverflows_,
+    nFEDsWithFEBadMajorityAddresses_,
     nFEDsWithMissingFEs_;
 
   HistogramConfig nFEDErrorsvsTime_;
+  HistogramConfig fedErrorsVsIdVsLumi_;
   HistogramConfig nFEDCorruptBuffersvsTime_;
   HistogramConfig nFEDsWithFEProblemsvsTime_;
 
@@ -137,22 +140,22 @@ private:
   HistogramConfig nOutOfSyncvsTime_;
 
   //top level histograms
-  HistogramConfig anyFEDErrors_, 
-    anyDAQProblems_, 
-    corruptBuffers_, 
-    invalidBuffers_, 
-    badIDs_, 
-    badChannelStatusBits_, 
+  HistogramConfig anyFEDErrors_,
+    anyDAQProblems_,
+    corruptBuffers_,
+    invalidBuffers_,
+    badIDs_,
+    badChannelStatusBits_,
     badActiveChannelStatusBits_,
-    badDAQCRCs_, 
-    badFEDCRCs_, 
-    badDAQPacket_, 
-    dataMissing_, 
-    dataPresent_, 
-    feOverflows_, 
+    badDAQCRCs_,
+    badFEDCRCs_,
+    badDAQPacket_,
+    dataMissing_,
+    dataPresent_,
+    feOverflows_,
     badMajorityAddresses_,
     badMajorityInPartition_,
-    feMissing_, 
+    feMissing_,
     anyFEProblems_,
     fedIdVsApvId_;
 
@@ -174,32 +177,32 @@ private:
   HistogramConfig medianAPV0_;
   HistogramConfig medianAPV1_;
 
-  HistogramConfig feOverflowDetailed_, 
-    badMajorityAddressDetailed_, 
+  HistogramConfig feOverflowDetailed_,
+    badMajorityAddressDetailed_,
     feMissingDetailed_;
 
-  HistogramConfig badStatusBitsDetailed_, 
-    apvErrorDetailed_, 
-    apvAddressErrorDetailed_, 
-    unlockedDetailed_, 
+  HistogramConfig badStatusBitsDetailed_,
+    apvErrorDetailed_,
+    apvAddressErrorDetailed_,
+    unlockedDetailed_,
     outOfSyncDetailed_;
-  
+
   //FED level histograms
-  std::map<unsigned int,MonitorElement*> feOverflowDetailedMap_, 
-    badMajorityAddressDetailedMap_, 
+  std::map<unsigned int,MonitorElement*> feOverflowDetailedMap_,
+    badMajorityAddressDetailedMap_,
     feMissingDetailedMap_;
 
-  std::map<unsigned int,MonitorElement*> badStatusBitsDetailedMap_, 
-    apvErrorDetailedMap_, 
-    apvAddressErrorDetailedMap_, 
-    unlockedDetailedMap_, 
+  std::map<unsigned int,MonitorElement*> badStatusBitsDetailedMap_,
+    apvErrorDetailedMap_,
+    apvAddressErrorDetailedMap_,
+    unlockedDetailedMap_,
     outOfSyncDetailedMap_;
 
 
   HistogramConfig fedErrorsVsId_;
 
   //has individual FED histogram been booked? (index is FedId)
-  std::vector<bool> histosBooked_, 
+  std::vector<bool> histosBooked_,
     debugHistosBooked_;
 
   HistogramConfig tkMapConfig_;

--- a/DQM/SiStripMonitorHardware/interface/HistogramBase.hh
+++ b/DQM/SiStripMonitorHardware/interface/HistogramBase.hh
@@ -2,7 +2,7 @@
 //
 // Package:    DQM/SiStripMonitorHardware
 // Class:      HistogramBase
-// 
+//
 /**\class HistogramBase DQM/SiStripMonitorHardware/interface/HistogramBase.hh
 
  Description: DQM source application to produce data integrety histograms for SiStrip data
@@ -28,18 +28,20 @@
 class HistogramBase {
 
 public:
-  
+
   struct HistogramConfig {
+    HistogramConfig() : globalswitchon(true) {}
     MonitorElement* monitorEle;
     bool enabled;
     unsigned int nBins;
     double min;
     double max;
+    bool globalswitchon;
   };
-  
+
 
   virtual ~HistogramBase(){};
-  
+
   //initialise histograms
   //make it pure abstract: implementation in derived class.
   virtual void initialise(const edm::ParameterSet& iConfig,
@@ -47,23 +49,28 @@ public:
 			  ) = 0;
 
   //fill a histogram if the pointer is not NULL (ie if it has been booked)
-  static void fillHistogram(HistogramConfig & histogram, 
+  static void fillHistogram(HistogramConfig & histogram,
 			    double value,
 			    double weight=1.
 			    );
 
   //fill a histogram if the pointer is not NULL (ie if it has been booked)
-  static void fillHistogram(MonitorElement* histogram, 
+  static void fillHistogram(MonitorElement* histogram,
 			    double value,
 			    double weight=1.
 			    );
- 
+  //fill a 2D profile trend histogram if the pointer is not NULL (ie if it has been booked)
+  static void fillHistogram2D(HistogramConfig & histogram,
+          double value,
+          double trendVar,
+          double weight=1.
+          );
   //fill tkHistoMap of percentage of bad channels per module
   static void fillTkHistoMap(TkHistoMap *aMap,
 			     uint32_t & detid,
 			     float value
 			     );
- 
+
   //if one of more histo map, return name and pointer
   virtual bool tkHistoMapEnabled(unsigned int aIndex=0) = 0;
 
@@ -71,17 +78,17 @@ public:
 
   //load the config for a histogram from PSet called <configName>HistogramConfig (writes a debug message to stream if pointer is non-NULL)
   void getConfigForHistogram(HistogramConfig & aConfig,
-			     const std::string& configName, 
+			     const std::string& configName,
 			     const edm::ParameterSet& psetContainingConfigPSet,
 			     std::ostringstream* pDebugStream
 			     );
 
   //book an individual hiostogram if enabled in config
   void bookHistogram(DQMStore::IBooker & , HistogramConfig & aConfig,
-		     const std::string& name, 
+		     const std::string& name,
 		     const std::string& title,
-		     const unsigned int nBins, 
-		     const double min, 
+		     const unsigned int nBins,
+		     const double min,
 		     const double max,
 		     const std::string& xAxisTitle
 		     );
@@ -89,23 +96,23 @@ public:
   //book an individual hiostogram if enabled in config
   void bookHistogram(DQMStore::IBooker & , HistogramConfig & aConfig,
 		     MonitorElement* & aHist,
-		     const std::string& name, 
+		     const std::string& name,
 		     const std::string& title,
-		     const unsigned int nBins, 
-		     const double min, 
+		     const unsigned int nBins,
+		     const double min,
 		     const double max,
 		     const std::string& xAxisTitle
 		     );
 
   //book an individual hiostogram if enabled in config
   void book2DHistogram(DQMStore::IBooker & , HistogramConfig & aConfig,
-		       const std::string& name, 
+		       const std::string& name,
 		       const std::string& title,
-		       const unsigned int nBins, 
-		       const double min, 
+		       const unsigned int nBins,
+		       const double min,
 		       const double max,
-		       const unsigned int nBinsY, 
-		       const double minY, 
+		       const unsigned int nBinsY,
+		       const double minY,
 		       const double maxY,
 		       const std::string& xAxisTitle,
 		       const std::string& yAxisTitle
@@ -114,13 +121,13 @@ public:
   //book an individual hiostogram if enabled in config
   void book2DHistogram(DQMStore::IBooker & , HistogramConfig & aConfig,
 		       MonitorElement* & aHist,
-		       const std::string& name, 
+		       const std::string& name,
 		       const std::string& title,
-		       const unsigned int nBins, 
-		       const double min, 
+		       const unsigned int nBins,
+		       const double min,
 		       const double max,
-		       const unsigned int nBinsY, 
-		       const double minY, 
+		       const unsigned int nBinsY,
+		       const double minY,
 		       const double maxY,
 		       const std::string& xAxisTitle,
 		       const std::string& yAxisTitle
@@ -128,18 +135,18 @@ public:
 
   //same but using binning from config
   void bookHistogram(DQMStore::IBooker & , HistogramConfig & aConfig,
-		     const std::string& name, 
-		     const std::string& title, 
+		     const std::string& name,
+		     const std::string& title,
 		     const std::string& xAxisTitle
 		     );
 
   void bookProfile(DQMStore::IBooker & , HistogramConfig & aConfig,
 		   const std::string& name,
 		   const std::string& title,
-		   const unsigned int nBins, 
-		   const double min, 
+		   const unsigned int nBins,
+		   const double min,
 		   const double max,
-		   const double minY, 
+		   const double minY,
 		   const double maxY,
 		   const std::string& xAxisTitle,
 		   const std::string& yAxisTitle
@@ -148,14 +155,35 @@ public:
   void bookProfile(DQMStore::IBooker & , HistogramConfig & aConfig,
 		   const std::string& name,
 		   const std::string& title,
-		   const double minY, 
+		   const double minY,
 		   const double maxY,
 		   const std::string& xAxisTitle,
 		   const std::string& yAxisTitle
 		   );
+  void bookProfile2D(DQMStore::IBooker & , HistogramConfig & aConfig,
+       const std::string& name,
+       const std::string& title,
+       const unsigned int nBinsx,
+       const double xmin,
+       const double xmax,
+        const unsigned int nBinsy,
+       const double ymin,
+       const double ymax,
+       const std::string& xAxisTitle,
+       const std::string& yAxisTitle
+       );
 
+    void bookProfile2D(DQMStore::IBooker & , HistogramConfig & aConfig,
+        const std::string& name,
+        const std::string& title,
+        const unsigned int nBinsy,
+        const double ymin,
+        const double ymax,
+        const std::string& xAxisTitle,
+        const std::string& yAxisTitle
+        );
 protected:
-  
+
   DQMStore* dqm_;
 
 private:

--- a/DQM/SiStripMonitorHardware/python/siStripFEDMonitor_cfi.py
+++ b/DQM/SiStripMonitorHardware/python/siStripFEDMonitor_cfi.py
@@ -4,22 +4,22 @@ siStripFEDMonitor = cms.EDAnalyzer("SiStripFEDMonitorPlugin",
   #Raw data collection
   RawDataTag = cms.untracked.InputTag('rawDataCollector'),
   #Folder in DQM Store to write global histograms to
-  TopFolderName       = cms.untracked.string('SiStrip'),                                 
+  TopFolderName       = cms.untracked.string('SiStrip'),
 #  HistogramFolderName = cms.untracked.string('SiStrip/ReadoutView/FedSummary'),
   HistogramFolderName = cms.untracked.string('ReadoutView'),
   #Fill all detailed histograms at FED level even if they will be empty (so that files can be merged)
   FillAllDetailedHistograms = cms.untracked.bool(False),
   #do histos vs time with time=event number. Default time = orbit number (s).
   FillWithEventNumber = cms.untracked.bool(False),
-  #Whether to dump buffer info and raw data if any error is found: 
+  #Whether to dump buffer info and raw data if any error is found:
   #1=errors, 2=minimum info, 3=full debug with printing of the data buffer of each FED per event.
   PrintDebugMessages = cms.untracked.uint32(1),
-  FullDebugMode = cms.untracked.bool(False),                                   
+  FullDebugMode = cms.untracked.bool(False),
   #Histogram configuration
   #lumi histogram
-  ErrorFractionByLumiBlockHistogramConfig = cms.untracked.PSet( Enabled = cms.untracked.bool(False) ),          
+  ErrorFractionByLumiBlockHistogramConfig = cms.untracked.PSet( Enabled = cms.untracked.bool(False) ),
   #Global/summary histograms
-  FedEventSizeHistogramConfig = cms.untracked.PSet( Enabled = cms.untracked.bool(True) ),                
+  FedEventSizeHistogramConfig = cms.untracked.PSet( Enabled = cms.untracked.bool(True) ),
   DataPresentHistogramConfig = cms.untracked.PSet( Enabled = cms.untracked.bool(True) ),
   AnyFEDErrorsHistogramConfig = cms.untracked.PSet( Enabled = cms.untracked.bool(True) ),
   AnyDAQProblemsHistogramConfig = cms.untracked.PSet( Enabled = cms.untracked.bool(True) ),
@@ -55,7 +55,7 @@ siStripFEDMonitor = cms.EDAnalyzer("SiStripFEDMonitorPlugin",
     NBins = cms.untracked.uint32(256),
     Min = cms.untracked.double(0),
     Max = cms.untracked.double(1024)
-    ),        
+    ),
   #Sub sets of DAQ problems
   DataMissingHistogramConfig = cms.untracked.PSet( Enabled = cms.untracked.bool(True) ),
   BadIDsHistogramConfig = cms.untracked.PSet( Enabled = cms.untracked.bool(True) ),
@@ -201,6 +201,13 @@ siStripFEDMonitor = cms.EDAnalyzer("SiStripFEDMonitorPlugin",
     Min = cms.untracked.double(0),
     Max = cms.untracked.double(3600)
   ),
+  fedErrorsVsIdVsLumiHistogramConfig = cms.untracked.PSet(
+     Enabled = cms.untracked.bool(True),
+     NBins = cms.untracked.uint32(250),
+     Min = cms.untracked.double(0),
+     Max = cms.untracked.double(5000),
+     globalswitchon = cms.untracked.bool(False)
+ ),
   nFEDCorruptBuffersvsTimeHistogramConfig = cms.untracked.PSet(
     Enabled = cms.untracked.bool(True),
     NBins = cms.untracked.uint32(600),
@@ -247,12 +254,12 @@ siStripFEDMonitor = cms.EDAnalyzer("SiStripFEDMonitorPlugin",
     Enabled = cms.untracked.bool(True),
     NBins = cms.untracked.uint32(600),
     Min = cms.untracked.double(0),
-    Max = cms.untracked.double(3600)                
-  ),                             
+    Max = cms.untracked.double(3600)
+  ),
   FedIdVsApvIdHistogramConfig = cms.untracked.PSet(
     Enabled = cms.untracked.bool(True)
   ),
   FedErrorsVsIdHistogramConfig = cms.untracked.PSet(
     Enabled = cms.untracked.bool(True)
-  )                             
+  )
  )

--- a/DQM/SiStripMonitorHardware/src/FEDErrors.cc
+++ b/DQM/SiStripMonitorHardware/src/FEDErrors.cc
@@ -26,7 +26,7 @@ FEDErrors::~FEDErrors()
 void FEDErrors::initialiseLumiBlock() {
   lumiErr_.nTotal.clear();
   lumiErr_.nErrors.clear();
-  //6 subdetectors: 
+  //6 subdetectors:
   //TECB,TECF,TIB,TIDB,TIDF,TOB
   lumiErr_.nTotal.resize(6,0);
   lumiErr_.nErrors.resize(6,0);
@@ -61,8 +61,8 @@ void FEDErrors::initialiseEvent() {
   lChCounter_.nAPVError = 0;
   lChCounter_.nAPVAddressError = 0;
 
-  feCounter_.nFEOverflows = 0; 
-  feCounter_.nFEBadMajorityAddresses = 0; 
+  feCounter_.nFEOverflows = 0;
+  feCounter_.nFEBadMajorityAddresses = 0;
   feCounter_.nFEMissing = 0;
 
   fedErrors_.HasCabledChannels = false;
@@ -113,10 +113,10 @@ void FEDErrors::initialiseFED(const unsigned int aFedID,
     detid_.resize(sistrip::FEDCH_PER_FED,0);
     nChInModule_.resize(sistrip::FEDCH_PER_FED,0);
 
-    for (unsigned int iCh = 0; 
-	 iCh < sistrip::FEDCH_PER_FED; 
+    for (unsigned int iCh = 0;
+	 iCh < sistrip::FEDCH_PER_FED;
 	 iCh++) {
-    
+
       const FedChannelConnection & lConnection = aCabling->fedConnection(fedID_,iCh);
       connected_[iCh] = lConnection.isConnected();
       detid_[iCh] = lConnection.detId();
@@ -124,7 +124,7 @@ void FEDErrors::initialiseFED(const unsigned int aFedID,
 
       unsigned short lFeNumber = static_cast<unsigned int>(iCh/sistrip::FEDCH_PER_FEUNIT);
       unsigned int lDetid = detid_[iCh];
-    
+
       if (lDetid && lDetid != sistrip::invalid32_ && connected_[iCh]) {
 	unsigned int lSubid = 6;
 	// 3=TIB, 4=TID, 5=TOB, 6=TEC (TECB here)
@@ -135,7 +135,7 @@ void FEDErrors::initialiseFED(const unsigned int aFedID,
 
 	case 4:
 	  {
-	    
+
 	    if (tTopo->tidSide(lDetid) == 2) lSubid = 4; //TIDF
 	    else lSubid = 3; //TIDB
 	    break;
@@ -147,7 +147,7 @@ void FEDErrors::initialiseFED(const unsigned int aFedID,
 
 	case 6:
 	  {
-	    
+
 	    if (tTopo->tecSide(lDetid) == 2) lSubid = 1; //TECF
 	    else lSubid = 0; //TECB
 	    break;
@@ -160,15 +160,15 @@ void FEDErrors::initialiseFED(const unsigned int aFedID,
 	}
 	subDetId_[lFeNumber] = lSubid;
 	//if (iCh%12==0) std::cout << fedID_ << " " << lFeNumber << " " << subDetId_[lFeNumber] << std::endl;
-	
+
       }
     }
 
 
-    feCounter_.nFEOverflows = 0; 
-    feCounter_.nFEBadMajorityAddresses = 0; 
+    feCounter_.nFEOverflows = 0;
+    feCounter_.nFEBadMajorityAddresses = 0;
     feCounter_.nFEMissing = 0;
-    
+
     fedErrors_.HasCabledChannels = false;
     fedErrors_.DataPresent = false;
     fedErrors_.DataMissing = false;
@@ -183,13 +183,13 @@ void FEDErrors::initialiseFED(const unsigned int aFedID,
     fedErrors_.FEsBadMajorityAddress = false;
     fedErrors_.BadChannelStatusBit = false;
     fedErrors_.BadActiveChannelStatusBit = false;
-    
+
     feErrors_.clear();
-    
+
     chErrorsDetailed_.clear();
-    
+
     apvErrors_.clear();
-    
+
     chErrors_.clear();
   }
 }
@@ -198,8 +198,8 @@ bool FEDErrors::checkDataPresent(const FEDRawData& aFedData)
 {
 
   if (!aFedData.size() || !aFedData.data()) {
-    for (unsigned int iCh = 0; 
-	 iCh < sistrip::FEDCH_PER_FED; 
+    for (unsigned int iCh = 0;
+	 iCh < sistrip::FEDCH_PER_FED;
 	 iCh++) {
       if (connected_[iCh]){
 	fedErrors_.HasCabledChannels = true;
@@ -212,8 +212,8 @@ bool FEDErrors::checkDataPresent(const FEDRawData& aFedData)
     return false;
   } else {
     fedErrors_.DataPresent = true;
-    for (unsigned int iCh = 0; 
-	 iCh < sistrip::FEDCH_PER_FED; 
+    for (unsigned int iCh = 0;
+	 iCh < sistrip::FEDCH_PER_FED;
 	 iCh++) {
       if (connected_[iCh]){
 	fedErrors_.HasCabledChannels = true;
@@ -260,7 +260,7 @@ bool FEDErrors::fillFatalFEDErrors(const FEDRawData& aFedData,
   if (!bufferBase->checkSourceIDs() || !bufferBase->checkNoUnexpectedSourceID()) {
     fedErrors_.BadIDs = true;
     return false;
-  } 
+  }
   //if so then do DAQ header/trailer checks
   //if these fail then buffer may be incomplete and checking contents doesn't make sense
   else if (!bufferBase->doDAQHeaderAndTrailerChecks()) {
@@ -271,8 +271,8 @@ bool FEDErrors::fillFatalFEDErrors(const FEDRawData& aFedData,
 
   //now do checks on header
   //check that tracker special header is consistent
-  if ( !(bufferBase->checkBufferFormat() && 
-	 bufferBase->checkHeaderType() && 
+  if ( !(bufferBase->checkBufferFormat() &&
+	 bufferBase->checkHeaderType() &&
 	 bufferBase->checkReadoutMode()) ) {
     failUnpackerFEDCheck_ = true;
     fedErrors_.InvalidBuffers = true;
@@ -281,7 +281,7 @@ bool FEDErrors::fillFatalFEDErrors(const FEDRawData& aFedData,
   }
 
   //FE unit overflows
-  if (!bufferBase->checkNoFEOverflows()) { 
+  if (!bufferBase->checkNoFEOverflows()) {
     failUnpackerFEDCheck_ = true;
     fedErrors_.FEsOverflow = true;
     //do not return false if debug printout of the buffer done below...
@@ -289,7 +289,7 @@ bool FEDErrors::fillFatalFEDErrors(const FEDRawData& aFedData,
   }
 
   return true;
-  
+
 }
 
 bool FEDErrors::fillCorruptBuffer(const sistrip::FEDBuffer* aBuffer)
@@ -319,7 +319,7 @@ float FEDErrors::fillNonFatalFEDErrors(const sistrip::FEDBuffer* aBuffer,
       lIsConnected = lConnection.isConnected();
     }
     else lIsConnected = connected_[iCh];
-      
+
     if (!lIsConnected) continue;
     lTotChans++;
     if (!aBuffer->channelGood(iCh)) lBadChans++;
@@ -329,7 +329,7 @@ float FEDErrors::fillNonFatalFEDErrors(const sistrip::FEDBuffer* aBuffer,
 }
 
 
-bool FEDErrors::fillFEDErrors(const FEDRawData& aFedData, 
+bool FEDErrors::fillFEDErrors(const FEDRawData& aFedData,
 			      bool & aFullDebug,
 			      const unsigned int aPrintDebug,
 			      unsigned int & aCounterMonitoring,
@@ -358,8 +358,8 @@ bool FEDErrors::fillFEDErrors(const FEDRawData& aFedData,
 
     bool lCorruptCheck = fillCorruptBuffer(buffer.get());
     if (aPrintDebug>1 && !lCorruptCheck) {
-      edm::LogWarning("SiStripMonitorHardware") 
-	<< "CorruptBuffer check failed for FED " << fedID_ 
+      edm::LogWarning("SiStripMonitorHardware")
+	<< "CorruptBuffer check failed for FED " << fedID_
 	<< std::endl
 	<< " -- buffer->checkChannelLengthsMatchBufferLength() = " << buffer->checkChannelLengthsMatchBufferLength()
 	<< std::endl
@@ -372,9 +372,9 @@ bool FEDErrors::fillFEDErrors(const FEDRawData& aFedData,
     //corruptBuffer concerns the payload: header info should still be reliable...
     //so analyze FE and channels to fill histograms.
 
-    //fe check... 
+    //fe check...
     fillFEErrors(buffer.get(),aDoFEMaj,aFeMajFrac);
-    
+
     //channel checks
     fillChannelErrors(buffer.get(),
 		      aFullDebug,
@@ -388,7 +388,7 @@ bool FEDErrors::fillFEDErrors(const FEDRawData& aFedData,
 
   }
 
-   
+
   if (printDebug() && aPrintDebug>2) {
     const sistrip::FEDBufferBase* debugBuffer = nullptr;
 
@@ -400,7 +400,7 @@ bool FEDErrors::fillFEDErrors(const FEDRawData& aFedData,
       if (!lChVec.empty()) {
 	std::sort(lChVec.begin(),lChVec.end());
         debugStream << "[FEDErrors] Cabled channels which had errors: ";
-	
+
         for (unsigned int iBadCh(0); iBadCh < lChVec.size(); iBadCh++) {
           print(lChVec[iBadCh],debugStream);
         }
@@ -418,7 +418,7 @@ bool FEDErrors::fillFEDErrors(const FEDRawData& aFedData,
       edm::LogVerbatim("SiStripMonitorHardware") << debugStream.str();
     }
   }
- 
+
   return !(anyFEDErrors());
 }
 
@@ -430,10 +430,10 @@ bool FEDErrors::fillFEErrors(const sistrip::FEDBuffer* aBuffer,
   bool foundBadMajority = false;
   bool foundMissing = false;
   for (unsigned int iFE = 0; iFE < sistrip::FEUNITS_PER_FED; iFE++) {
-    
+
     FEDErrors::FELevelErrors lFeErr;
     lFeErr.FeID = iFE;
-    lFeErr.SubDetID = subDetId_[iFE]; 
+    lFeErr.SubDetID = subDetId_[iFE];
     lFeErr.Overflow = false;
     lFeErr.Missing = false;
     lFeErr.BadMajorityAddress = false;
@@ -469,10 +469,10 @@ bool FEDErrors::fillFEErrors(const sistrip::FEDBuffer* aBuffer,
       //}
       continue;
     }
-    //two independent checks for the majority address of a FE: 
-    //first is done inside the FED, 
+    //two independent checks for the majority address of a FE:
+    //first is done inside the FED,
     //second is comparing explicitely the FE majAddress with the APVe address.
-    //!aBuffer->checkFEUnitAPVAddresses(): for all FE's.... 
+    //!aBuffer->checkFEUnitAPVAddresses(): for all FE's....
     //want to do it only for this FE... do it directly with the time difference.
     if (aBuffer->majorityAddressErrorForFEUnit(iFE)){
       lFeErr.BadMajorityAddress = true;
@@ -490,14 +490,14 @@ bool FEDErrors::fillFEErrors(const sistrip::FEDBuffer* aBuffer,
     // 	std::cout << "FED " << fedID_ << ", iFE = " << iFE << std::endl
     // 		<< " -- aBuffer->apveAddress() = " << static_cast<unsigned int>(aBuffer->apveAddress())
     // // 		<< ", debugHeader = " << debugHeader
-    // // 		<< ", header->feGood(iFE) = " << aBuffer->feGood(iFE) 
+    // // 		<< ", header->feGood(iFE) = " << aBuffer->feGood(iFE)
     //  		<< ", debugHeader->feUnitMajorityAddress(iFE) " << static_cast<unsigned int>(debugHeader->feUnitMajorityAddress(iFE))
     //  		<< std::endl
     //  		<< " -- timeLoc(feUnitMajAddr) = "
     //  		<< static_cast<unsigned int>(sistrip::FEDAddressConversion::timeLocation(debugHeader->feUnitMajorityAddress(iFE)))
     //  		<< ", timeLoc(apveAddr) = "
-    //  		<< static_cast<unsigned int>(sistrip::FEDAddressConversion::timeLocation(aBuffer->apveAddress())) 
-    // // 		<< ", aBuffer->checkFEUnitAPVAddresses() = " 
+    //  		<< static_cast<unsigned int>(sistrip::FEDAddressConversion::timeLocation(aBuffer->apveAddress()))
+    // // 		<< ", aBuffer->checkFEUnitAPVAddresses() = "
     // // 		<< aBuffer->checkFEUnitAPVAddresses()
     //  		<< std::endl;
     // 	std::cout << "My checks = "
@@ -511,7 +511,7 @@ bool FEDErrors::fillFEErrors(const sistrip::FEDBuffer* aBuffer,
     // 	//   std::cout << "aBuffer->checkFEUnitAPVAddresses() = " << aBuffer->checkFEUnitAPVAddresses() << std::endl;
     //   }
     // }
-      
+
     lFeErr.Apve = aBuffer->apveAddress();
 
     if (debugHeader){
@@ -537,13 +537,13 @@ bool FEDErrors::fillFEErrors(const sistrip::FEDBuffer* aBuffer,
 	//FEDAddressConversion::timeLocation(const uint8_t aPipelineAddress)
       }
     }
-     
+
     if (foundBadMajority || lFeErr.TimeDifference != 0){
       addBadFE(lFeErr);
 
 
  //      LogDebug("SiStripMonitorHardware") << " -- Problem found with FE maj address :" << std::endl
-// 					 << " --- FED = " << fedID_ 
+// 					 << " --- FED = " << fedID_
 // 					 << ", iFE = " << iFE << std::endl
 // 					 << " --- aBuffer->apveAddress() = " << static_cast<unsigned int>(aBuffer->apveAddress())
 // 					 << std::endl
@@ -552,7 +552,7 @@ bool FEDErrors::fillFEErrors(const sistrip::FEDBuffer* aBuffer,
 // 					 << static_cast<unsigned int>(sistrip::FEDAddressConversion::timeLocation(debugHeader->feUnitMajorityAddress(iFE)))<< std::endl
 // 					 << " --- timeLoc(apveAddr) = "
 // 					 << static_cast<unsigned int>(sistrip::FEDAddressConversion::timeLocation(aBuffer->apveAddress())) << std::endl
-// 					 << " --- aBuffer->checkFEUnitAPVAddresses() = " 
+// 					 << " --- aBuffer->checkFEUnitAPVAddresses() = "
 // 					 << aBuffer->checkFEUnitAPVAddresses()
 // 					 << std::endl;
 
@@ -564,7 +564,7 @@ bool FEDErrors::fillFEErrors(const sistrip::FEDBuffer* aBuffer,
   return !(foundOverflow || foundMissing || foundBadMajority);
 }
 
-bool FEDErrors::fillChannelErrors(const sistrip::FEDBuffer* aBuffer, 
+bool FEDErrors::fillChannelErrors(const sistrip::FEDBuffer* aBuffer,
 				  bool & aFullDebug,
 				  const unsigned int aPrintDebug,
 				  unsigned int & aCounterMonitoring,
@@ -583,10 +583,10 @@ bool FEDErrors::fillChannelErrors(const sistrip::FEDBuffer* aBuffer,
 
   bool lMedValid = aBuffer->readoutMode() == sistrip::READOUT_MODE_ZERO_SUPPRESSED;
 
-  //this method is not called if there was anyFEDerrors(), 
+  //this method is not called if there was anyFEDerrors(),
   //so only corruptBuffer+FE check are useful.
   bool lPassedMonitoringFEDcheck = !fedErrors_.CorruptBuffer;
-  
+
   for (unsigned int iCh = 0; iCh < sistrip::FEDCH_PER_FED; iCh++) {//loop on channels
 
     bool lFailUnpackerChannelCheck = (!aBuffer->channelGood(iCh) && connected_[iCh]) || failUnpackerFEDCheck_;
@@ -624,12 +624,12 @@ bool FEDErrors::fillChannelErrors(const sistrip::FEDBuffer* aBuffer,
 
 	if (debugHeader) {
 	  lStatus = debugHeader->getChannelStatus(iCh);
-	  apvBad[0] = 
-	    !(lStatus & sistrip::CHANNEL_STATUS_LOCKED) || 
+	  apvBad[0] =
+	    !(lStatus & sistrip::CHANNEL_STATUS_LOCKED) ||
 	    !(lStatus & sistrip::CHANNEL_STATUS_IN_SYNC) ||
 	    !(lStatus & sistrip::CHANNEL_STATUS_APV0_ADDRESS_GOOD) ||
 	    !(lStatus & sistrip::CHANNEL_STATUS_APV0_NO_ERROR_BIT);
-	  apvBad[1] = 
+	  apvBad[1] =
 	    !(lStatus & sistrip::CHANNEL_STATUS_LOCKED) ||
 	    !(lStatus & sistrip::CHANNEL_STATUS_IN_SYNC) ||
 	    !(lStatus & sistrip::CHANNEL_STATUS_APV1_ADDRESS_GOOD) ||
@@ -660,9 +660,9 @@ bool FEDErrors::fillChannelErrors(const sistrip::FEDBuffer* aBuffer,
 
 	//std::ostringstream lMode;
 	//lMode << aBuffer->readoutMode();
-	
+
 	bool lFirst = true;
-	
+
 	for (unsigned int iAPV = 0; iAPV < 2; iAPV++) {//loop on APVs
 
 	  FEDErrors::APVLevelErrors lAPVErr;
@@ -695,7 +695,7 @@ bool FEDErrors::fillChannelErrors(const sistrip::FEDBuffer* aBuffer,
 	  }
 
 	  if ( lAPVErr.APVStatusBit ||
-	       lAPVErr.APVError || 
+	       lAPVErr.APVError ||
 	       lAPVErr.APVAddressError
 	       ) addBadAPV(lAPVErr, lFirst);
 	}//loop on APVs
@@ -707,16 +707,16 @@ bool FEDErrors::fillChannelErrors(const sistrip::FEDBuffer* aBuffer,
     if (lFailUnpackerChannelCheck != lFailMonitoringChannelCheck && connected_[iCh]){
       if (aPrintDebug>1) {
 	std::ostringstream debugStream;
-	debugStream << "[FEDErrors] ------ WARNING: FED " << fedID_ << ", channel " << iCh 
-		    << ", isConnected = " << connected_[iCh] << std::endl 
+	debugStream << "[FEDErrors] ------ WARNING: FED " << fedID_ << ", channel " << iCh
+		    << ", isConnected = " << connected_[iCh] << std::endl
 		    << "[FEDErrors] --------- Monitoring Channel check " ;
 	if (lFailMonitoringChannelCheck) debugStream << "failed." << std::endl;
 	else debugStream << "passed." << std::endl ;
 	debugStream << "[FEDErrors] --------- Unpacker Channel check " ;
 	if (lFailUnpackerChannelCheck) debugStream << "failed." << std::endl;
 	else debugStream << "passed." << std::endl;
-	debugStream << "[FEDErrors] --------- fegood = " 
-		    << aBuffer->feGood(static_cast<unsigned int>(iCh/sistrip::FEDCH_PER_FEUNIT)) 
+	debugStream << "[FEDErrors] --------- fegood = "
+		    << aBuffer->feGood(static_cast<unsigned int>(iCh/sistrip::FEDCH_PER_FEUNIT))
 		    << std::endl
 		    << "[FEDErrors] --------- unpacker FED check = " << failUnpackerFEDCheck_ << std::endl;
 	edm::LogError("SiStripMonitorHardware") << debugStream.str();
@@ -729,7 +729,7 @@ bool FEDErrors::fillChannelErrors(const sistrip::FEDBuffer* aBuffer,
     if (lMedValid && !foundError && lPassedMonitoringFEDcheck && aDoMeds) {
       //get CM values
       const sistrip::FEDChannel & lChannel = aBuffer->channel(iCh);
- 
+
       HistogramBase::fillHistogram(aMedianHist0,
 				   lChannel.cmMedian(0));
       HistogramBase::fillHistogram(aMedianHist1,
@@ -746,7 +746,8 @@ void FEDErrors::fillBadChannelList(const bool doTkHistoMap,
 				   TkHistoMap *aTkMapPointer,
 				   MonitorElement *aFedIdVsApvId,
 				   unsigned int & aNBadChannels,
-				   unsigned int & aNBadActiveChannels)
+				   unsigned int & aNBadActiveChannels,
+           unsigned int & aNBadChannels_perFEDID)
 {
 
   uint32_t lPrevId = 0;
@@ -755,10 +756,10 @@ void FEDErrors::fillBadChannelList(const bool doTkHistoMap,
   bool hasBeenProcessed = false;
   bool lFailFED = failMonitoringFEDCheck();
 
-  for (unsigned int iCh = 0; 
-       iCh < sistrip::FEDCH_PER_FED; 
+  for (unsigned int iCh = 0;
+       iCh < sistrip::FEDCH_PER_FED;
        iCh++) {//loop on channels
-    
+
     if (!connected_[iCh]) continue;
     if (!detid_[iCh] || detid_[iCh] == sistrip::invalid32_) continue;
 
@@ -768,7 +769,7 @@ void FEDErrors::fillBadChannelList(const bool doTkHistoMap,
     }
 
     unsigned int feNumber = static_cast<unsigned int>(iCh/sistrip::FEDCH_PER_FEUNIT);
-	
+
     bool isBadFE = false;
     bool isMissingFE = false;
     //feErrors vector of FE 0 - 7, each FE has channels 0 -11, 12 .. - ,... - 96
@@ -800,13 +801,13 @@ void FEDErrors::fillBadChannelList(const bool doTkHistoMap,
 	if (apvErrors_[badApv].IsActive) isActiveChan = true;
       }
       if (apvErrors_[badApv].APVID == 2 * iCh ) isBadApv1 = true;
-      if (apvErrors_[badApv].APVID == 2 * iCh + 1 ) 
+      if (apvErrors_[badApv].APVID == 2 * iCh + 1 )
 	{
 	  isBadApv2 = true;
 	  break;
 	}
     }
-    
+
 
     if (detid_[iCh] == lPrevId){
       if (hasBeenProcessed) hasBeenProcessed = false;
@@ -830,10 +831,11 @@ void FEDErrors::fillBadChannelList(const bool doTkHistoMap,
     if ( lHasErr ) {
       nBad++;
       aNBadChannels++;
+      aNBadChannels_perFEDID = aNBadChannels_perFEDID+1;
       //define as active channel if channel locked AND not from an unlocked FE.
       if ((isBadChan && isActiveChan) || lFailFED || (isBadFE && !isMissingFE)) aNBadActiveChannels++;
-      if ( isBadApv1 || lFailFED || isBadFE ) HistogramBase::fillHistogram ( aFedIdVsApvId , 2 * iCh , fedID_ ) ; 
-      if ( isBadApv2 || lFailFED || isBadFE ) HistogramBase::fillHistogram ( aFedIdVsApvId , 2 * iCh + 1 , fedID_ ) ; 
+      if ( isBadApv1 || lFailFED || isBadFE ) HistogramBase::fillHistogram ( aFedIdVsApvId , 2 * iCh , fedID_ ) ;
+      if ( isBadApv2 || lFailFED || isBadFE ) HistogramBase::fillHistogram ( aFedIdVsApvId , 2 * iCh + 1 , fedID_ ) ;
     }
 
 
@@ -860,9 +862,9 @@ void FEDErrors::incrementLumiErrors(const bool hasError,
 				    const unsigned int aSubDet){
   if (lumiErr_.nTotal.empty()) return;
   if (aSubDet >= lumiErr_.nTotal.size()) {
-    edm::LogError("SiStripMonitorHardware") << " -- FED " << fedID_ 
+    edm::LogError("SiStripMonitorHardware") << " -- FED " << fedID_
 					    << ", invalid subdetid : " << aSubDet
-					    << ", size of lumiErr : " 
+					    << ", size of lumiErr : "
 					    << lumiErr_.nTotal.size()
 					    << std::endl;
   }
@@ -888,7 +890,7 @@ void FEDErrors::processDet(const uint32_t aPrevId,
 
   //tkHistoMap takes a uint & as argument
   uint32_t lDetid = aPrevId;
-  if (aPrevTot != 0 && doTkHistoMap && aTkMapPointer) 
+  if (aPrevTot != 0 && doTkHistoMap && aTkMapPointer)
     HistogramBase::fillTkHistoMap(aTkMapPointer,lDetid,static_cast<float>(nBad)/aPrevTot);
 
   nBad=0;
@@ -897,7 +899,7 @@ void FEDErrors::processDet(const uint32_t aPrevId,
 
 const bool FEDErrors::failMonitoringFEDCheck()
 {
-  return ( anyFEDErrors() || 
+  return ( anyFEDErrors() ||
 	   fedErrors_.CorruptBuffer
 	   );
 }
@@ -926,12 +928,12 @@ const bool FEDErrors::anyFEDErrors()
 
 const bool FEDErrors::anyFEProblems()
 {
-  return ( fedErrors_.FEsOverflow || 
-	   fedErrors_.FEsMissing || 
+  return ( fedErrors_.FEsOverflow ||
+	   fedErrors_.FEsMissing ||
 	   fedErrors_.FEsBadMajorityAddress
 	   );
 }
- 
+
 const bool FEDErrors::printDebug()
 {
   return ( anyFEDErrors()  ||
@@ -966,12 +968,12 @@ FEDErrors::FEDLevelErrors & FEDErrors::getFEDLevelErrors()
 {
   return fedErrors_;
 }
-  
+
 FEDErrors::EventProperties & FEDErrors::getEventProperties()
 {
   return eventProp_;
 }
-  
+
 std::vector<FEDErrors::FELevelErrors> & FEDErrors::getFELevelErrors()
 {
   return feErrors_;
@@ -1083,7 +1085,7 @@ void FEDErrors::incrementFEDCounters()
 
 void FEDErrors::incrementChannelCounters(const FEDErrors::ChannelLevelErrors & aChannel)
 {
-  if (aChannel.Unlocked && aChannel.Connected) lChCounter_.nUnlocked++; 
+  if (aChannel.Unlocked && aChannel.Connected) lChCounter_.nUnlocked++;
   if (aChannel.OutOfSync && aChannel.Connected) lChCounter_.nOutOfSync++;
   if (!aChannel.Connected) lChCounter_.nNotConnected++;
 }
@@ -1091,9 +1093,9 @@ void FEDErrors::incrementChannelCounters(const FEDErrors::ChannelLevelErrors & a
 void FEDErrors::incrementAPVCounters(const FEDErrors::APVLevelErrors & aAPV)
 {
   if (aAPV.Connected && aAPV.IsActive){
-    if (aAPV.APVStatusBit) lChCounter_.nAPVStatusBit++; 
-    if (aAPV.APVAddressError) lChCounter_.nAPVAddressError++; 
-    if (aAPV.APVError) lChCounter_.nAPVError++; 
+    if (aAPV.APVStatusBit) lChCounter_.nAPVStatusBit++;
+    if (aAPV.APVAddressError) lChCounter_.nAPVAddressError++;
+    if (aAPV.APVError) lChCounter_.nAPVError++;
   }
 }
 
@@ -1130,10 +1132,10 @@ void FEDErrors::print(const FEDErrors::FEDCounters & aFEDCounter, std::ostream &
       << "[FEDErrors]======== nTotalBadChannels = " << aFEDCounter.nTotalBadChannels << std::endl
       << "[FEDErrors]======== nTotalBadActiveChannels = " << aFEDCounter.nTotalBadActiveChannels << std::endl
       << "[FEDErrors]============================================" << std::endl;
-    
+
 
 }
-  
+
 void FEDErrors::print(const FEDErrors::FECounters & aFECounter, std::ostream & aOs)
 {
 
@@ -1145,7 +1147,7 @@ void FEDErrors::print(const FEDErrors::FECounters & aFECounter, std::ostream & a
       << "[FEDErrors]======== nFEBadMajorityAddresses = " << aFECounter.nFEBadMajorityAddresses << std::endl
       << "[FEDErrors]======== nFEMissing = " << aFECounter.nFEMissing << std::endl
       << "[FEDErrors]============================================" << std::endl;
-    
+
 
 }
 
@@ -1219,5 +1221,3 @@ void FEDErrors::print(const FEDErrors::APVLevelErrors & aErr, std::ostream & aOs
       << "[FEDErrors]============ APVAddressError = " << aErr.APVAddressError << std::endl
       << "[FEDErrors]=================================================" << std::endl;
 }
-
-

--- a/DQM/SiStripMonitorHardware/src/FEDHistograms.cc
+++ b/DQM/SiStripMonitorHardware/src/FEDHistograms.cc
@@ -252,9 +252,7 @@ void FEDHistograms::fillFEDHistograms(FEDErrors & aFedErr,
   }
 
   double numChannelLevelErrors = 0;
-	std::cout << "Global switch = " << fedErrorsVsIdVsLumi_.globalswitchon << std::endl;
   if(fedErrorsVsIdVsLumi_.globalswitchon){
-		std::cout << "Lumi Section = " << aLumiSection << " lFedId = " << lFedId << " channel level errors = " << lChVec.size() << std::endl;
 		numChannelLevelErrors = double(lChVec.size());
 		fillHistogram2D(fedErrorsVsIdVsLumi_,aLumiSection,lFedId,numChannelLevelErrors);
   }

--- a/DQM/SiStripMonitorHardware/src/FEDHistograms.cc
+++ b/DQM/SiStripMonitorHardware/src/FEDHistograms.cc
@@ -13,12 +13,12 @@ FEDHistograms::FEDHistograms()
 FEDHistograms::~FEDHistograms()
 {
 }
-  
+
 void FEDHistograms::initialise(const edm::ParameterSet& iConfig,
 			       std::ostringstream* pDebugStream
 			       )
 {
-  
+
   getConfigForHistogram(fedEventSize_,"FedEventSize",iConfig,pDebugStream);
   getConfigForHistogram(fedMaxEventSizevsTime_,"FedMaxEventSizevsTime",iConfig,pDebugStream);
 
@@ -29,7 +29,7 @@ void FEDHistograms::initialise(const edm::ParameterSet& iConfig,
   getConfigForHistogram(corruptBuffers_,"CorruptBuffers",iConfig,pDebugStream);
   getConfigForHistogram(badChannelStatusBits_,"BadChannelStatusBits",iConfig,pDebugStream);
   getConfigForHistogram(badActiveChannelStatusBits_,"BadActiveChannelStatusBits",iConfig,pDebugStream);
-  
+
   getConfigForHistogram(feOverflows_,"FEOverflows",iConfig,pDebugStream);
   getConfigForHistogram(feMissing_,"FEMissing",iConfig,pDebugStream);
   getConfigForHistogram(badMajorityAddresses_,"BadMajorityAddresses",iConfig,pDebugStream);
@@ -45,7 +45,7 @@ void FEDHistograms::initialise(const edm::ParameterSet& iConfig,
   getConfigForHistogram(invalidBuffers_,"InvalidBuffers",iConfig,pDebugStream);
   getConfigForHistogram(badDAQCRCs_,"BadDAQCRCs",iConfig,pDebugStream);
   getConfigForHistogram(badFEDCRCs_,"BadFEDCRCs",iConfig,pDebugStream);
-  
+
   getConfigForHistogram(feOverflowDetailed_,"FEOverflowsDetailed",iConfig,pDebugStream);
   getConfigForHistogram(feMissingDetailed_,"FEMissingDetailed",iConfig,pDebugStream);
   getConfigForHistogram(badMajorityAddressDetailed_,"BadMajorityAddressesDetailed",iConfig,pDebugStream);
@@ -54,7 +54,7 @@ void FEDHistograms::initialise(const edm::ParameterSet& iConfig,
   getConfigForHistogram(apvAddressErrorDetailed_,"APVAddressErrorBitsDetailed",iConfig,pDebugStream);
   getConfigForHistogram(unlockedDetailed_,"UnlockedBitsDetailed",iConfig,pDebugStream);
   getConfigForHistogram(outOfSyncDetailed_,"OOSBitsDetailed",iConfig,pDebugStream);
-  
+
   getConfigForHistogram(nFEDErrors_,"nFEDErrors",iConfig,pDebugStream);
   getConfigForHistogram(nFEDDAQProblems_,"nFEDDAQProblems",iConfig,pDebugStream);
   getConfigForHistogram(nFEDsWithFEProblems_,"nFEDsWithFEProblems",iConfig,pDebugStream);
@@ -66,6 +66,7 @@ void FEDHistograms::initialise(const edm::ParameterSet& iConfig,
   getConfigForHistogram(nFEDsWithFEBadMajorityAddresses_,"nFEDsWithFEBadMajorityAddresses",iConfig,pDebugStream);
 
   getConfigForHistogram(nFEDErrorsvsTime_,"nFEDErrorsvsTime",iConfig,pDebugStream);
+  getConfigForHistogram(fedErrorsVsIdVsLumi_,"fedErrorsVsIdVsLumi",iConfig,pDebugStream);
   getConfigForHistogram(nFEDCorruptBuffersvsTime_,"nFEDCorruptBuffersvsTime",iConfig,pDebugStream);
   getConfigForHistogram(nFEDsWithFEProblemsvsTime_,"nFEDsWithFEProblemsvsTime",iConfig,pDebugStream);
 
@@ -111,8 +112,8 @@ void FEDHistograms::initialise(const edm::ParameterSet& iConfig,
   getConfigForHistogram(fedErrorsVsId_,"FedErrorsVsId",iConfig,pDebugStream);
 }
 
-void FEDHistograms::fillCountersHistograms(const FEDErrors::FEDCounters & fedLevelCounters, 
-					   const FEDErrors::ChannelCounters & chLevelCounters, 
+void FEDHistograms::fillCountersHistograms(const FEDErrors::FEDCounters & fedLevelCounters,
+					   const FEDErrors::ChannelCounters & chLevelCounters,
 					   const unsigned int aMaxSize,
 					   const double aTime )
 {
@@ -139,7 +140,7 @@ void FEDHistograms::fillCountersHistograms(const FEDErrors::FEDCounters & fedLev
 
   fillHistogram(nTotalBadChannelsvsTime_,aTime,fedLevelCounters.nTotalBadChannels);
   fillHistogram(nTotalBadActiveChannelsvsTime_,aTime,fedLevelCounters.nTotalBadActiveChannels);
-  
+
   fillHistogram(nAPVStatusBit_,chLevelCounters.nAPVStatusBit);
   fillHistogram(nAPVError_,chLevelCounters.nAPVError);
   fillHistogram(nAPVAddressError_,chLevelCounters.nAPVAddressError);
@@ -154,9 +155,12 @@ void FEDHistograms::fillCountersHistograms(const FEDErrors::FEDCounters & fedLev
 
 }
 
-void FEDHistograms::fillFEDHistograms(FEDErrors & aFedErr, 
+void FEDHistograms::fillFEDHistograms(FEDErrors & aFedErr,
 				      const unsigned int aEvtSize,
-				      bool lFullDebug)
+				      bool lFullDebug,
+              const double aLumiSection,
+							unsigned int & NumBadChannels_perFEDID
+            )
 {
   const FEDErrors::FEDLevelErrors & lFedLevelErrors = aFedErr.getFEDLevelErrors();
   const unsigned int lFedId = aFedErr.fedID();
@@ -169,7 +173,7 @@ void FEDHistograms::fillFEDHistograms(FEDErrors & aFedErr,
     fillHistogram(dataMissing_,lFedId);
     fillHistogram(fedErrorsVsId_,lFedId,1);
   }
-  
+
   if (lFedLevelErrors.InvalidBuffers) {
     fillHistogram(invalidBuffers_,lFedId);
     fillHistogram(fedErrorsVsId_,lFedId,2);
@@ -232,7 +236,7 @@ void FEDHistograms::fillFEDHistograms(FEDErrors & aFedErr,
   }
 
   std::vector<FEDErrors::FELevelErrors> & lFeVec = aFedErr.getFELevelErrors();
-  
+
   for (unsigned int iFe(0); iFe<lFeVec.size(); iFe++){
     fillFEHistograms(lFedId,lFeVec[iFe],aFedErr.getEventProperties());
   }
@@ -247,13 +251,21 @@ void FEDHistograms::fillFEDHistograms(FEDErrors & aFedErr,
     fillAPVsHistograms(lFedId,lAPVVec[iApv],lFullDebug);
   }
 
+  double numChannelLevelErrors = 0;
+	std::cout << "Global switch = " << fedErrorsVsIdVsLumi_.globalswitchon << std::endl;
+  if(fedErrorsVsIdVsLumi_.globalswitchon){
+		std::cout << "Lumi Section = " << aLumiSection << " lFedId = " << lFedId << " channel level errors = " << lChVec.size() << std::endl;
+		numChannelLevelErrors = double(lChVec.size());
+		fillHistogram2D(fedErrorsVsIdVsLumi_,aLumiSection,lFedId,numChannelLevelErrors);
+  }
+
 
 }
 
 
 
 //fill a histogram if the pointer is not NULL (ie if it has been booked)
-void FEDHistograms::fillFEHistograms(const unsigned int aFedId, 
+void FEDHistograms::fillFEHistograms(const unsigned int aFedId,
 				     const FEDErrors::FELevelErrors & aFeLevelErrors, const FEDErrors::EventProperties & aEventProp )
 {
   const unsigned short lFeId = aFeLevelErrors.FeID;
@@ -261,52 +273,52 @@ void FEDHistograms::fillFEHistograms(const unsigned int aFedId,
   if ( (feOverflowDetailed_.enabled && aFeLevelErrors.Overflow) ||
        (badMajorityAddressDetailed_.enabled && aFeLevelErrors.BadMajorityAddress) ||
        (feMissingDetailed_.enabled && aFeLevelErrors.Missing)
-       ) 
+       )
     bookFEDHistograms(aFedId);
-  */  
+  */
   if (aFeLevelErrors.Overflow) fillHistogram(feOverflowDetailedMap_[aFedId],lFeId);
   else if (aFeLevelErrors.Missing) fillHistogram(feMissingDetailedMap_[aFedId],lFeId);
   else if (aFeLevelErrors.BadMajorityAddress) fillHistogram(badMajorityAddressDetailedMap_[aFedId],lFeId);
-  
+
 
   if (aFeLevelErrors.TimeDifference != 0) {
-    if (aFeLevelErrors.SubDetID == 2 || aFeLevelErrors.SubDetID == 3 || aFeLevelErrors.SubDetID == 4) 
+    if (aFeLevelErrors.SubDetID == 2 || aFeLevelErrors.SubDetID == 3 || aFeLevelErrors.SubDetID == 4)
       fillHistogram(feTimeDiffTIB_,aFeLevelErrors.TimeDifference);
-    else if (aFeLevelErrors.SubDetID == 5) 
+    else if (aFeLevelErrors.SubDetID == 5)
       fillHistogram(feTimeDiffTOB_,aFeLevelErrors.TimeDifference);
-    else if (aFeLevelErrors.SubDetID == 0) 
+    else if (aFeLevelErrors.SubDetID == 0)
       fillHistogram(feTimeDiffTECB_,aFeLevelErrors.TimeDifference);
-    else if (aFeLevelErrors.SubDetID == 1) 
+    else if (aFeLevelErrors.SubDetID == 1)
       fillHistogram(feTimeDiffTECF_,aFeLevelErrors.TimeDifference);
     fillHistogram(feTimeDiffvsDBX_,aEventProp.deltaBX,aFeLevelErrors.TimeDifference < 0 ? aFeLevelErrors.TimeDifference+192 : aFeLevelErrors.TimeDifference  );
     fillHistogram(apveAddress_,aFeLevelErrors.Apve);
-    fillHistogram(feMajAddress_,aFeLevelErrors.FeMaj);  
+    fillHistogram(feMajAddress_,aFeLevelErrors.FeMaj);
   }
 }
 
 //fill a histogram if the pointer is not NULL (ie if it has been booked)
-void FEDHistograms::fillChannelsHistograms(const unsigned int aFedId, 
-					   const FEDErrors::ChannelLevelErrors & aChErr, 
+void FEDHistograms::fillChannelsHistograms(const unsigned int aFedId,
+					   const FEDErrors::ChannelLevelErrors & aChErr,
 					   bool fullDebug)
 {
   unsigned int lChId = aChErr.ChannelID;
   /*
   if ( (unlockedDetailed_.enabled && aChErr.Unlocked) ||
        (outOfSyncDetailed_.enabled && aChErr.OutOfSync)
-       ) 
+       )
     bookFEDHistograms(aFedId,fullDebug);
   */
   if (aChErr.Unlocked) {
     fillHistogram(unlockedDetailedMap_[aFedId],lChId);
   }
   if (aChErr.OutOfSync) {
-    fillHistogram(outOfSyncDetailedMap_[aFedId],lChId);    
+    fillHistogram(outOfSyncDetailedMap_[aFedId],lChId);
   }
 }
 
 
-void FEDHistograms::fillAPVsHistograms(const unsigned int aFedId, 
-				       const FEDErrors::APVLevelErrors & aAPVErr, 
+void FEDHistograms::fillAPVsHistograms(const unsigned int aFedId,
+				       const FEDErrors::APVLevelErrors & aAPVErr,
 				       bool fullDebug)
 {
   unsigned int lChId = aAPVErr.APVID;
@@ -589,7 +601,7 @@ void FEDHistograms::bookTopLevelHistograms(DQMStore::IBooker & ibooker , std::st
 		"Number of buffers with any FE unit problems",
 		siStripFedIdMax-siStripFedIdMin+1,
 		siStripFedIdMin-0.5,siStripFedIdMax+0.5,"FED-ID");
-  
+
   bookHistogram(ibooker , feOverflows_,"FEOverflows",
 		"Number of buffers with one or more FE overflow",
 		siStripFedIdMax-siStripFedIdMin+1,
@@ -609,7 +621,7 @@ void FEDHistograms::bookTopLevelHistograms(DQMStore::IBooker & ibooker , std::st
 		"Number of buffers with one or more FE unit payload missing",
 		siStripFedIdMax-siStripFedIdMin+1,
 		siStripFedIdMin-0.5,siStripFedIdMax+0.5,"FED-ID");
-  
+
 
   ibooker.setCurrentFolder(lBaseDir+"/Fiber");
 
@@ -655,11 +667,11 @@ void FEDHistograms::bookTopLevelHistograms(DQMStore::IBooker & ibooker , std::st
   bookHistogram(ibooker , medianAPV0_,"MedianAPV0",
 		"Median APV0",
 		"medianAPV0");
-  
+
   bookHistogram(ibooker , medianAPV1_,"MedianAPV1",
 		"Median APV1",
 		"MedianAPV1");
-  
+
   bookHistogram(ibooker , nAPVStatusBit_,
 		"nAPVStatusBit",
 		"Number of APVs with APVStatusBit error per event",
@@ -707,6 +719,18 @@ void FEDHistograms::bookTopLevelHistograms(DQMStore::IBooker & ibooker , std::st
 	      );
 
   ibooker.setCurrentFolder(lBaseDir+"/Trends/FED");
+
+  if(fedErrorsVsIdVsLumi_.globalswitchon){
+    bookProfile2D( ibooker , fedErrorsVsIdVsLumi_,
+          "fedErrorsVsIdVsLumi",
+          "Total number of errors per FED ID per lumi section",
+          440,//# FED IDS
+          49.5,// Lowest FED ID
+          489.5,// Highest FED ID
+          "Lumi. Section",
+          "FED ID"
+          );
+        }
 
   bookProfile( ibooker , nFEDErrorsvsTime_,
 	      "nFEDErrorsvsTime",
@@ -895,7 +919,7 @@ void FEDHistograms::bookAllFEDHistograms(DQMStore::IBooker & ibooker , bool full
   const unsigned int siStripFedIdMin = FEDNumbering::MINSiStripFEDID;
   const unsigned int siStripFedIdMax = FEDNumbering::MAXSiStripFEDID;
   //book them
-  for (unsigned int iFed = siStripFedIdMin; iFed <= siStripFedIdMax; iFed++) 
+  for (unsigned int iFed = siStripFedIdMin; iFed <= siStripFedIdMax; iFed++)
     bookFEDHistograms(ibooker , iFed, fullDebugMode);
 }
 

--- a/DQM/SiStripMonitorHardware/src/HistogramBase.cc
+++ b/DQM/SiStripMonitorHardware/src/HistogramBase.cc
@@ -6,8 +6,8 @@
 
 
 
-void HistogramBase::fillHistogram(HistogramConfig & histogram, 
-				  double value, 
+void HistogramBase::fillHistogram(HistogramConfig & histogram,
+				  double value,
 				  double weight)
 {
   if (histogram.monitorEle) histogram.monitorEle->Fill(value,weight);
@@ -15,12 +15,20 @@ void HistogramBase::fillHistogram(HistogramConfig & histogram,
 
 
 void HistogramBase::fillHistogram(MonitorElement* histogram,
-				  double value, 
+				  double value,
 				  double weight)
 {
   if (histogram) histogram->Fill(value,weight);
 }
 
+void HistogramBase::fillHistogram2D(HistogramConfig & histogram,
+					double trendVar,
+				  double value,
+				  double weight
+				)
+{
+  if (histogram.monitorEle) histogram.monitorEle->Fill(trendVar,value,weight);
+}
 
 void HistogramBase::fillTkHistoMap(TkHistoMap* aMap,
 				   uint32_t & detid,
@@ -31,8 +39,8 @@ void HistogramBase::fillTkHistoMap(TkHistoMap* aMap,
 
 
 void HistogramBase::getConfigForHistogram(HistogramConfig & aConfig,
-					  const std::string& configName, 
-					  const edm::ParameterSet& psetContainingConfigPSet, 
+					  const std::string& configName,
+					  const edm::ParameterSet& psetContainingConfigPSet,
 					  std::ostringstream* pDebugStream
 					  )
 {
@@ -48,6 +56,9 @@ void HistogramBase::getConfigForHistogram(HistogramConfig & aConfig,
 
   if (psetContainingConfigPSet.exists(psetName)) {
     const edm::ParameterSet& pset = psetContainingConfigPSet.getUntrackedParameter<edm::ParameterSet>(psetName);
+		if(configName.find("fedErrorsVsIdVsLumi") != std::string::npos){
+			aConfig.globalswitchon = pset.getUntrackedParameter<bool>("globalswitchon");
+		}
     aConfig.enabled = (pset.exists("Enabled") ? pset.getUntrackedParameter<bool>("Enabled") : true);
     if (aConfig.enabled) {
       aConfig.nBins = (pset.exists("NBins") ? pset.getUntrackedParameter<unsigned int>("NBins") : 600);
@@ -80,15 +91,15 @@ void HistogramBase::getConfigForHistogram(HistogramConfig & aConfig,
       aConfig.nBins = (pset.exists("NBins") ? pset.getUntrackedParameter<unsigned int>("NBins") : 600);
       aConfig.min = (pset.exists("Min") ? pset.getUntrackedParameter<double>("Min") : 0);
       aConfig.max = (pset.exists("Max") ? pset.getUntrackedParameter<double>("Max") : 3600);
-    } 
-  
+    }
+
 }
 
 void HistogramBase::bookHistogram(DQMStore::IBooker & ibooker , HistogramConfig & aConfig,
-				  const std::string& name, 
+				  const std::string& name,
 				  const std::string& title,
-				  const unsigned int nBins, 
-				  const double min, 
+				  const unsigned int nBins,
+				  const double min,
 				  const double max,
 				  const std::string& xAxisTitle
 				  )
@@ -105,10 +116,10 @@ void HistogramBase::bookHistogram(DQMStore::IBooker & ibooker , HistogramConfig 
 
 void HistogramBase::bookHistogram(DQMStore::IBooker & ibooker , HistogramConfig & aConfig,
 				  MonitorElement* & aHist,
-				  const std::string& name, 
+				  const std::string& name,
 				  const std::string& title,
-				  const unsigned int nBins, 
-				  const double min, 
+				  const unsigned int nBins,
+				  const double min,
 				  const double max,
 				  const std::string& xAxisTitle
 				  )
@@ -124,23 +135,23 @@ void HistogramBase::bookHistogram(DQMStore::IBooker & ibooker , HistogramConfig 
 }
 
 void HistogramBase::bookHistogram(DQMStore::IBooker & ibooker , HistogramConfig & aConfig,
-				  const std::string& name, 
-				  const std::string& title, 
+				  const std::string& name,
+				  const std::string& title,
 				  const std::string& xAxisTitle
 				  )
 {
   return bookHistogram(ibooker , aConfig,name,title,aConfig.nBins,aConfig.min,aConfig.max,xAxisTitle);
-  
+
 }
 
 void HistogramBase::book2DHistogram(DQMStore::IBooker & ibooker , HistogramConfig & aConfig,
-				    const std::string& name, 
+				    const std::string& name,
 				    const std::string& title,
-				    const unsigned int nBins, 
-				    const double min, 
+				    const unsigned int nBins,
+				    const double min,
 				    const double max,
-				    const unsigned int nBinsY, 
-				    const double minY, 
+				    const unsigned int nBinsY,
+				    const double minY,
 				    const double maxY,
 				    const std::string& xAxisTitle,
 				    const std::string& yAxisTitle
@@ -158,13 +169,13 @@ void HistogramBase::book2DHistogram(DQMStore::IBooker & ibooker , HistogramConfi
 
 void HistogramBase::book2DHistogram(DQMStore::IBooker & ibooker , HistogramConfig & aConfig,
 				    MonitorElement* & aHist,
-				    const std::string& name, 
+				    const std::string& name,
 				    const std::string& title,
-				    const unsigned int nBins, 
-				    const double min, 
+				    const unsigned int nBins,
+				    const double min,
 				    const double max,
-				    const unsigned int nBinsY, 
-				    const double minY, 
+				    const unsigned int nBinsY,
+				    const double minY,
 				    const double maxY,
 				    const std::string& xAxisTitle,
 				    const std::string& yAxisTitle
@@ -183,16 +194,16 @@ void HistogramBase::book2DHistogram(DQMStore::IBooker & ibooker , HistogramConfi
 void HistogramBase::bookProfile(DQMStore::IBooker & ibooker , HistogramConfig & aConfig,
 				const std::string& name,
 				const std::string& title,
-				const unsigned int nBins, 
-				const double min, 
+				const unsigned int nBins,
+				const double min,
 				const double max,
-				const double minY, 
+				const double minY,
 				const double maxY,
 				const std::string& xAxisTitle,
 				const std::string& yAxisTitle
 				)
 {
-  
+
   if (aConfig.enabled) {
     aConfig.monitorEle = ibooker.bookProfile(name,
 					   title,
@@ -202,7 +213,7 @@ void HistogramBase::bookProfile(DQMStore::IBooker & ibooker , HistogramConfig & 
 					   minY,
 					   maxY
 					   );
-    
+
     aConfig.monitorEle->setAxisTitle(xAxisTitle,1);
     aConfig.monitorEle->setAxisTitle(yAxisTitle,2);
   } else {
@@ -213,13 +224,13 @@ void HistogramBase::bookProfile(DQMStore::IBooker & ibooker , HistogramConfig & 
 void HistogramBase::bookProfile(DQMStore::IBooker & ibooker , HistogramConfig & aConfig,
 				const std::string& name,
 				const std::string& title,
-				const double minY, 
+				const double minY,
 				const double maxY,
 				const std::string& xAxisTitle,
 				const std::string& yAxisTitle
 				)
 {
-  
+
   bookProfile(ibooker , aConfig,
 	      name,
 	      title,
@@ -234,4 +245,68 @@ void HistogramBase::bookProfile(DQMStore::IBooker & ibooker , HistogramConfig & 
   //automatically set the axis range: will accomodate new values keeping the same number of bins.
   if (aConfig.monitorEle) aConfig.monitorEle->getTProfile()->SetCanExtend(TH1::kAllAxes);
 }
- 
+
+// New method to book trend plots of 2D histograms.
+// Uses ibooker methods:
+// https://github.com/cms-sw/cmssw/blob/4297d2489bfac27c8fc19d37d58b5264f424ecfe/DQMServices/Core/src/DQMStore.cc#L1500
+void HistogramBase::bookProfile2D(DQMStore::IBooker & ibooker , HistogramConfig & aConfig,
+			const std::string& name,
+			const std::string& title,
+			const unsigned int nBinsx,
+			const double xmin,
+			const double xmax,
+			const unsigned int nBinsy,
+			const double ymin,
+			const double ymax,
+			const std::string& xAxisTitle,
+			const std::string& yAxisTitle
+			)
+{
+
+ if (aConfig.enabled) {
+	 aConfig.monitorEle = ibooker.bookProfile2D(name,
+					 title,
+					 nBinsx,
+					 xmin,
+					 xmax,
+					 nBinsy,
+					 ymin,
+					 ymax,
+					 0,
+					 0
+					 );
+
+	 aConfig.monitorEle->setAxisTitle(xAxisTitle,1);
+	 aConfig.monitorEle->setAxisTitle(yAxisTitle,2);
+ } else {
+	 aConfig.monitorEle = nullptr;
+ }
+}
+
+
+void HistogramBase::bookProfile2D(DQMStore::IBooker & ibooker , HistogramConfig & aConfig,
+			const std::string& name,
+			const std::string& title,
+			const unsigned int nBinsy,
+			const double ymin,
+			const double ymax,
+			const std::string& xAxisTitle,
+			const std::string& yAxisTitle
+			)
+{
+
+ bookProfile2D(ibooker , aConfig,
+			name,
+			title,
+			aConfig.nBins,
+			aConfig.min,
+			aConfig.max,
+			nBinsy,
+			ymin,
+			ymax,
+			xAxisTitle,
+			yAxisTitle);
+
+ //automatically set the axis range: will accomodate new values keeping the same number of bins.
+ if (aConfig.monitorEle && aConfig.monitorEle->kind() == MonitorElement::DQM_KIND_TPROFILE2D) aConfig.monitorEle->getTProfile2D()->SetCanExtend(TH1::kAllAxes);
+}

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDMonitor.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDMonitor.cc
@@ -2,7 +2,7 @@
 //
 // Package:    DQM/SiStripMonitorHardware
 // Class:      SiStripFEDMonitorPlugin
-// 
+//
 /**\class SiStripFEDMonitorPlugin SiStripFEDMonitor.cc DQM/SiStripMonitorHardware/plugins/SiStripFEDMonitor.cc
 
  Description: DQM source application to produce data integrety histograms for SiStrip data
@@ -15,7 +15,7 @@
 //   ---- 2009/04/21 : histogram management put in separate class
 //                     struct helper to simplify arguments of functions
 //   ---- 2009/04/22 : add TkHistoMap with % of bad channels per module
-//   ---- 2009/04/27 : create FEDErrors class 
+//   ---- 2009/04/27 : create FEDErrors class
 
 #include <sstream>
 #include <memory>
@@ -65,9 +65,9 @@ class SiStripFEDMonitorPlugin : public DQMEDAnalyzer
   ~SiStripFEDMonitorPlugin() override;
  private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
+  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
 				    const edm::EventSetup& context) override;
-  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
+  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
 				  const edm::EventSetup& context) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
@@ -85,7 +85,7 @@ class SiStripFEDMonitorPlugin : public DQMEDAnalyzer
   edm::InputTag rawDataTag_;
   edm::EDGetTokenT<FEDRawDataCollection> rawDataToken_;
   edm::EDGetTokenT<EventWithHistory> heToken_;
-  
+
   //histogram helper class
   FEDHistograms fedHists_;
   //folder name for histograms in DQMStore
@@ -133,7 +133,7 @@ SiStripFEDMonitorPlugin::SiStripFEDMonitorPlugin(const edm::ParameterSet& iConfi
 {
   std::string subFolderName = iConfig.getUntrackedParameter<std::string>("HistogramFolderName","ReadoutView");
   folderName_ = topFolderName_ + "/" + subFolderName;
-	      
+
 
   rawDataToken_ = consumes<FEDRawDataCollection>(rawDataTag_);
   heToken_      = consumes<EventWithHistory>(edm::InputTag("consecutiveHEs") );
@@ -148,10 +148,10 @@ SiStripFEDMonitorPlugin::SiStripFEDMonitorPlugin(const edm::ParameterSet& iConfi
 		<< "[SiStripFEDMonitorPlugin]\tFillWithEventNumber?" << (fillWithEvtNum_ ? "yes" : "no") << std::endl
                 << "[SiStripFEDMonitorPlugin]\tPrintDebugMessages? " << (printDebug_ ? "yes" : "no") << std::endl;
   }
-  
+
   //don;t generate debug mesages if debug is disabled
   std::ostringstream* pDebugStream = (printDebug_>1 ? &debugStream : nullptr);
-  
+
   fedHists_.initialise(iConfig,pDebugStream);
 
   doTkHistoMap_ = fedHists_.tkHistoMapEnabled();
@@ -178,7 +178,7 @@ SiStripFEDMonitorPlugin::~SiStripFEDMonitorPlugin()
 
 // ------------ method called to for each event  ------------
 void
-SiStripFEDMonitorPlugin::analyze(const edm::Event& iEvent, 
+SiStripFEDMonitorPlugin::analyze(const edm::Event& iEvent,
 				 const edm::EventSetup& iSetup)
 {
   //Retrieve tracker topology from geometry
@@ -188,12 +188,12 @@ SiStripFEDMonitorPlugin::analyze(const edm::Event& iEvent,
 
   //update cabling
   updateCabling(iSetup);
-  
+
   //get raw data
   edm::Handle<FEDRawDataCollection> rawDataCollectionHandle;
   iEvent.getByToken(rawDataToken_,rawDataCollectionHandle);
   const FEDRawDataCollection& rawDataCollection = *rawDataCollectionHandle;
-  
+
   fedErrors_.initialiseEvent();
 
   //add the deltaBX value if the product exist
@@ -231,24 +231,27 @@ SiStripFEDMonitorPlugin::analyze(const edm::Event& iEvent,
   maxFedBufferSize_ = 0;
 
   //loop over siStrip FED IDs
-  for (unsigned int fedId = FEDNumbering::MINSiStripFEDID; 
-       fedId <= FEDNumbering::MAXSiStripFEDID; 
+  for (unsigned int fedId = FEDNumbering::MINSiStripFEDID;
+       fedId <= FEDNumbering::MAXSiStripFEDID;
        fedId++) {//loop over FED IDs
+    unsigned int lNBadChannels_perFEDID = 0;
     const FEDRawData& fedData = rawDataCollection.FEDData(fedId);
 
     //create an object to fill all errors
     fedErrors_.initialiseFED(fedId,cabling_,tTopo);
- 
+
+    double aLumiSection = iEvent.orbitNumber()/262144.0;
+
     //Do detailed check
     //first check if data exists
     bool lDataExist = fedErrors_.checkDataPresent(fedData);
     if (!lDataExist) {
-      fedHists_.fillFEDHistograms(fedErrors_,0,fullDebugMode_);
+      fedHists_.fillFEDHistograms(fedErrors_,0,fullDebugMode_,aLumiSection, lNBadChannels_perFEDID);
       continue;
     }
 
 
- 
+
     //check for problems and fill detailed histograms
     fedErrors_.fillFEDErrors(fedData,
 			     fullDebugMode_,
@@ -272,19 +275,19 @@ SiStripFEDMonitorPlugin::analyze(const edm::Event& iEvent,
     }
     //std::cout << " -- " << fedId << " " << lSize << std::endl;
 
-    fedHists_.fillFEDHistograms(fedErrors_,lSize,fullDebugMode_);
+    //fedHists_.fillFEDHistograms(fedErrors_,lSize,fullDebugMode_);
 
     bool lFailMonitoringFEDcheck = fedErrors_.failMonitoringFEDCheck();
     if (lFailMonitoringFEDcheck) lNTotBadFeds++;
 
 
-    //sanity check: if something changed in the unpacking code 
+    //sanity check: if something changed in the unpacking code
     //but wasn't propagated here
     //print only the summary, and more info if printDebug>1
     if (lFailMonitoringFEDcheck != lFailUnpackerFEDcheck) {
       if (printDebug_>1) {
 	std::ostringstream debugStream;
-	debugStream << " --- WARNING: FED " << fedId << std::endl 
+	debugStream << " --- WARNING: FED " << fedId << std::endl
 		    << " ------ Monitoring FED check " ;
 	if (lFailMonitoringFEDcheck) debugStream << "failed." << std::endl;
 	else debugStream << "passed." << std::endl ;
@@ -300,7 +303,7 @@ SiStripFEDMonitorPlugin::analyze(const edm::Event& iEvent,
 
 
     //Fill TkHistoMap:
-    //add an entry for all channels (good = 0), 
+    //add an entry for all channels (good = 0),
     //so that tkHistoMap knows which channels should be there.
     if (doTkHistoMap_ && !fedHists_.tkHistoMapPointer()) {
       edm::LogWarning("SiStripMonitorHardware") << " -- Fedid " << fedId
@@ -311,7 +314,10 @@ SiStripFEDMonitorPlugin::analyze(const edm::Event& iEvent,
 				  fedHists_.tkHistoMapPointer(),
 				  fedHists_.getFedvsAPVpointer(),
 				  lNTotBadChannels,
-				  lNTotBadActiveChannels);
+				  lNTotBadActiveChannels,
+          lNBadChannels_perFEDID
+        );
+    fedHists_.fillFEDHistograms(fedErrors_,lSize,fullDebugMode_,aLumiSection, lNBadChannels_perFEDID);
   }//loop over FED IDs
 
 
@@ -333,11 +339,11 @@ SiStripFEDMonitorPlugin::analyze(const edm::Event& iEvent,
 
   if ((lNTotBadFeds> 0 || lNTotBadChannels>0) && printDebug_>1) {
     std::ostringstream debugStream;
-    debugStream << "[SiStripFEDMonitorPlugin] --- Total number of bad feds = " 
+    debugStream << "[SiStripFEDMonitorPlugin] --- Total number of bad feds = "
 		<< lNTotBadFeds << std::endl
-		<< "[SiStripFEDMonitorPlugin] --- Total number of bad channels = " 
+		<< "[SiStripFEDMonitorPlugin] --- Total number of bad channels = "
 		<< lNTotBadChannels << std::endl
-		<< "[SiStripFEDMonitorPlugin] --- Total number of bad active channels = " 
+		<< "[SiStripFEDMonitorPlugin] --- Total number of bad active channels = "
 		<< lNTotBadActiveChannels << std::endl;
     edm::LogInfo("SiStripMonitorHardware") << debugStream.str();
   }
@@ -345,16 +351,16 @@ SiStripFEDMonitorPlugin::analyze(const edm::Event& iEvent,
   if ((lNFEDMonitoring > 0 || lNFEDUnpacker > 0 || lNChannelMonitoring > 0 || lNChannelUnpacker > 0) && printDebug_) {
     std::ostringstream debugStream;
     debugStream
-      << "[SiStripFEDMonitorPlugin]-------------------------------------------------------------------------" << std::endl 
-      << "[SiStripFEDMonitorPlugin]-------------------------------------------------------------------------" << std::endl 
-      << "[SiStripFEDMonitorPlugin]-- Summary of differences between unpacker and monitoring at FED level : " << std::endl 
-      << "[SiStripFEDMonitorPlugin] ---- Number of times monitoring fails but not unpacking = " << lNFEDMonitoring << std::endl 
+      << "[SiStripFEDMonitorPlugin]-------------------------------------------------------------------------" << std::endl
+      << "[SiStripFEDMonitorPlugin]-------------------------------------------------------------------------" << std::endl
+      << "[SiStripFEDMonitorPlugin]-- Summary of differences between unpacker and monitoring at FED level : " << std::endl
+      << "[SiStripFEDMonitorPlugin] ---- Number of times monitoring fails but not unpacking = " << lNFEDMonitoring << std::endl
       << "[SiStripFEDMonitorPlugin] ---- Number of times unpacking fails but not monitoring = " << lNFEDUnpacker << std::endl
-      << "[SiStripFEDMonitorPlugin]-------------------------------------------------------------------------" << std::endl 
-      << "[SiStripFEDMonitorPlugin]-- Summary of differences between unpacker and monitoring at Channel level : " << std::endl 
-      << "[SiStripFEDMonitorPlugin] ---- Number of times monitoring fails but not unpacking = " << lNChannelMonitoring << std::endl 
+      << "[SiStripFEDMonitorPlugin]-------------------------------------------------------------------------" << std::endl
+      << "[SiStripFEDMonitorPlugin]-- Summary of differences between unpacker and monitoring at Channel level : " << std::endl
+      << "[SiStripFEDMonitorPlugin] ---- Number of times monitoring fails but not unpacking = " << lNChannelMonitoring << std::endl
       << "[SiStripFEDMonitorPlugin] ---- Number of times unpacking fails but not monitoring = " << lNChannelUnpacker << std::endl
-      << "[SiStripFEDMonitorPlugin]-------------------------------------------------------------------------" << std::endl 
+      << "[SiStripFEDMonitorPlugin]-------------------------------------------------------------------------" << std::endl
       << "[SiStripFEDMonitorPlugin]-------------------------------------------------------------------------" << std::endl ;
     edm::LogError("SiStripMonitorHardware") << debugStream.str();
 
@@ -373,7 +379,7 @@ SiStripFEDMonitorPlugin::analyze(const edm::Event& iEvent,
         maxFedBufferSize_,
         eventNumber);
   } else {
-    double aTime = iEvent.orbitNumber()/11223.;    
+    double aTime = iEvent.orbitNumber()/11223.;
     fedHists_.fillCountersHistograms(
         fedErrors_.getFEDErrorsCounters(),
         fedErrors_.getChannelErrorsCounters(),
@@ -394,13 +400,13 @@ bool SiStripFEDMonitorPlugin::pairComparison(const std::pair<unsigned int, unsig
 void SiStripFEDMonitorPlugin::getMajority(const std::vector<std::pair<unsigned int,unsigned int> > & aFeMajVec,
 					  unsigned int & aMajorityCounter,
 					  std::vector<unsigned int> & afedIds) {
-  
-  
+
+
   unsigned int lMajAddress = 0;
   std::vector<std::pair<unsigned int,unsigned int> >::const_iterator lIter = aFeMajVec.begin();
   unsigned int lMajAddr = (*lIter).second;
   unsigned int lCounter = 0;
-  
+
   //std::cout << " --- First element: addr = " << lMajAddr << " counter = " << lCounter << std::endl;
   unsigned int iele=0;
   //bool foundMaj = false;
@@ -426,7 +432,7 @@ void SiStripFEDMonitorPlugin::getMajority(const std::vector<std::pair<unsigned i
       --iele;
     }
   }
-  // AV Bug here? The check has to be done regardless foundMaj == false or true 
+  // AV Bug here? The check has to be done regardless foundMaj == false or true
   //  if (!foundMaj) {
     if (lCounter > aMajorityCounter) {
       //std::cout << " ------ >Majority: " << std::endl;
@@ -435,7 +441,7 @@ void SiStripFEDMonitorPlugin::getMajority(const std::vector<std::pair<unsigned i
     }
     //  }
   //std::cout << " -- found majority value for " << aMajorityCounter << " elements out of " << aFeMajVec.size() << "." << std::endl;
-  //get list of feds with address different from majority in partition:      
+  //get list of feds with address different from majority in partition:
   lIter = aFeMajVec.begin();
   afedIds.reserve(135);
   for ( ; lIter != aFeMajVec.end(); ++lIter ) {
@@ -465,8 +471,8 @@ void SiStripFEDMonitorPlugin::bookHistograms(DQMStore::IBooker & ibooker , const
   if (fillAllDetailedHistograms_) fedHists_.bookAllFEDHistograms(ibooker , fullDebugMode_ );
 }
 
-void 
-SiStripFEDMonitorPlugin::beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
+void
+SiStripFEDMonitorPlugin::beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
 					      const edm::EventSetup& context)
 {
 
@@ -475,8 +481,8 @@ SiStripFEDMonitorPlugin::beginLuminosityBlock(const edm::LuminosityBlock& lumiSe
 }
 
 
-void 
-SiStripFEDMonitorPlugin::endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
+void
+SiStripFEDMonitorPlugin::endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
 					    const edm::EventSetup& context)
 {
   fedHists_.fillLumiHistograms(fedErrors_.getLumiErrors());


### PR DESCRIPTION
…fed id per LS

Plots added to SiStripMonitorHardware FEDHistograms package and filled in SiStripFEDMonitor.cc. Plot is TProfile2D so added classes to HistogramBase to get and fill such histrograms. Added argument to FEDErrors fillBadChannelList method to count channel errors per fed id (previously only cumulative numbers available). 

Modified packages beneath.
	modified:   DQM/SiStripMonitorHardware/interface/FEDErrors.hh
	modified:   DQM/SiStripMonitorHardware/interface/FEDHistograms.hh
	modified:   DQM/SiStripMonitorHardware/interface/HistogramBase.hh
	modified:   DQM/SiStripMonitorHardware/python/siStripFEDMonitor_cfi.py
	modified:   DQM/SiStripMonitorHardware/src/FEDErrors.cc
	modified:   DQM/SiStripMonitorHardware/src/FEDHistograms.cc
	modified:   DQM/SiStripMonitorHardware/src/HistogramBase.cc
	modified:   DQM/SiStripMonitorHardware/src/SiStripFEDMonitor.cc