### PR TITLE
Fixed initialisation of Geant4 run managers

### DIFF
--- a/SimG4Core/Application/interface/RunManager.h
+++ b/SimG4Core/Application/interface/RunManager.h
@@ -131,10 +131,8 @@ private:
   bool m_RestorePhysicsTables;
   int m_EvtMgrVerbosity;
   bool m_check;
-  edm::ParameterSet m_pGeometry;
   edm::ParameterSet m_pField;
   edm::ParameterSet m_pGenerator;   
-  edm::ParameterSet m_pVertexGenerator;
   edm::ParameterSet m_pPhysics; 
   edm::ParameterSet m_pRunAction;      
   edm::ParameterSet m_pEventAction;

--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -145,6 +145,10 @@ RunManager::RunManager(edm::ParameterSet const & p, edm::ConsumesCollector&& iC)
   m_kernel = new G4RunManagerKernel();
   G4StateManager::GetStateManager()->SetExceptionHandler(new ExceptionHandler());
 
+  m_physicsList.reset(nullptr);
+  m_prodCuts.reset(nullptr);
+  m_attach = nullptr;
+
   m_check = p.getUntrackedParameter<bool>("CheckOverlap",false);
   m_WriteFile = p.getUntrackedParameter<std::string>("FileNameGDML","");
   m_FieldFile = p.getUntrackedParameter<std::string>("FileNameField","");

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -78,6 +78,13 @@ RunManagerMT::RunManagerMT(edm::ParameterSet const & p):
   m_UIsession.reset(new CustomUIsession());
   m_physicsList.reset(nullptr);
   m_world.reset(nullptr);
+
+  m_runInterface.reset(nullptr);
+  m_prodCuts.reset(nullptr);
+  m_chordFinderSetter.reset(nullptr);
+  m_userRunAction = nullptr;
+  m_currentRun = nullptr;
+
   m_kernel = new G4MTRunManagerKernel();
   G4StateManager::GetStateManager()->SetExceptionHandler(new ExceptionHandler());
 

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -148,6 +148,7 @@ RunManagerMTWorker::RunManagerMTWorker(const edm::ParameterSet& iConfig, edm::Co
   m_p(iConfig)
 {
   initializeTLS();
+  m_simEvent.reset(nullptr);
   m_sVerbose.reset(nullptr);
   std::vector<edm::ParameterSet> watchers = 
     iConfig.getParameter<std::vector<edm::ParameterSet> >("Watchers");


### PR DESCRIPTION
Initialized all members in Geant4 RunManagers - few members were not initialized in constructors. This addresses issue #21359.

Should not affect any result.