### PR TITLE
OnlineDQM : Remove unneeded histograms from uGMT

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2uGMT.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGMT.h
@@ -139,9 +139,6 @@ class L1TStage2uGMT : public DQMEDAnalyzer {
   MonitorElement* ugmtMuonPhiBmtf;
   MonitorElement* ugmtMuonPhiOmtf;
   MonitorElement* ugmtMuonPhiEmtf;
-  MonitorElement* ugmtMuonPhiAtVtxBmtf;
-  MonitorElement* ugmtMuonPhiAtVtxOmtf;
-  MonitorElement* ugmtMuonPhiAtVtxEmtf;
   MonitorElement* ugmtMuonDEtavsPtBmtf;
   MonitorElement* ugmtMuonDPhivsPtBmtf;
   MonitorElement* ugmtMuonDEtavsPtOmtf;
@@ -152,16 +149,12 @@ class L1TStage2uGMT : public DQMEDAnalyzer {
   MonitorElement* ugmtMuonPtvsEta;
   MonitorElement* ugmtMuonPtvsPhi;
   MonitorElement* ugmtMuonPhivsEta;
-  MonitorElement* ugmtMuonPtvsEtaAtVtx;
-  MonitorElement* ugmtMuonPtvsPhiAtVtx;
   MonitorElement* ugmtMuonPhiAtVtxvsEtaAtVtx;
 
   MonitorElement* ugmtMuonBXvsLink;
   MonitorElement* ugmtMuonBXvshwPt;
   MonitorElement* ugmtMuonBXvshwEta;
   MonitorElement* ugmtMuonBXvshwPhi;
-  MonitorElement* ugmtMuonBXvshwEtaAtVtx;
-  MonitorElement* ugmtMuonBXvshwPhiAtVtx;
   MonitorElement* ugmtMuonBXvshwCharge;
   MonitorElement* ugmtMuonBXvshwChargeValid;
   MonitorElement* ugmtMuonBXvshwQual;

--- a/DQM/L1TMonitor/interface/L1TStage2uGMTMuon.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGMTMuon.h
@@ -34,6 +34,7 @@ class L1TStage2uGMTMuon : public DQMEDAnalyzer {
   std::string monitorDir;
   std::string titlePrefix;
   bool verbose;
+  bool makeMuonAtVtxPlots;
 
   MonitorElement* ugmtMuonBX;
   MonitorElement* ugmtnMuons;

--- a/DQM/L1TMonitor/src/L1TStage2uGMT.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGMT.cc
@@ -253,14 +253,14 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   ibooker.setCurrentFolder(monitorDir);
 
   if (!emul) {
-    ugmtBMTFBXvsProcessor = ibooker.book2D("ugmtBMTFBXvsProcessor", "uGMT BMTF Input BX vs Processor", 12, -0.5, 11.5, 5, -2.5, 2.5);
+    ugmtBMTFBXvsProcessor = ibooker.book2D("ugmtBXvsProcessorBMTF", "uGMT BMTF Input BX vs Processor", 12, -0.5, 11.5, 5, -2.5, 2.5);
     ugmtBMTFBXvsProcessor->setAxisTitle("Wedge", 1);
     for (int bin = 1; bin <= 12; ++bin) {
       ugmtBMTFBXvsProcessor->setBinLabel(bin, std::to_string(bin), 1);
     }
     ugmtBMTFBXvsProcessor->setAxisTitle("BX", 2);
 
-    ugmtOMTFBXvsProcessor = ibooker.book2D("ugmtOMTFBXvsProcessor", "uGMT OMTF Input BX vs Processor", 12, -0.5, 11.5, 5, -2.5, 2.5);
+    ugmtOMTFBXvsProcessor = ibooker.book2D("ugmtBXvsProcessorOMTF", "uGMT OMTF Input BX vs Processor", 12, -0.5, 11.5, 5, -2.5, 2.5);
     ugmtOMTFBXvsProcessor->setAxisTitle("Sector (Detector Side)", 1);
     for (int bin = 1; bin <= 6; ++bin) {
       ugmtOMTFBXvsProcessor->setBinLabel(bin, std::to_string(7 - bin) + " (-)", 1);
@@ -268,7 +268,7 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
     }
     ugmtOMTFBXvsProcessor->setAxisTitle("BX", 2);
 
-    ugmtEMTFBXvsProcessor = ibooker.book2D("ugmtEMTFBXvsProcessor", "uGMT EMTF Input BX vs Processor", 12, -0.5, 11.5, 5, -2.5, 2.5);
+    ugmtEMTFBXvsProcessor = ibooker.book2D("ugmtBXvsProcessorEMTF", "uGMT EMTF Input BX vs Processor", 12, -0.5, 11.5, 5, -2.5, 2.5);
     ugmtEMTFBXvsProcessor->setAxisTitle("Sector (Detector Side)", 1);
     for (int bin = 1; bin <= 6; ++bin) {
       ugmtEMTFBXvsProcessor->setBinLabel(bin, std::to_string(7 - bin) + " (-)", 1);
@@ -344,15 +344,6 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   ugmtMuonPhiEmtf = ibooker.book1D("ugmtMuonPhiEmtf", "uGMT Muon #phi for EMTF Inputs", 126, -3.15, 3.15);
   ugmtMuonPhiEmtf->setAxisTitle("#phi", 1);
 
-  ugmtMuonPhiAtVtxBmtf = ibooker.book1D("ugmtMuonPhiAtVtxBmtf", "uGMT Muon #phi at vertex for BMTF Inputs", 126, -3.15, 3.15);
-  ugmtMuonPhiAtVtxBmtf->setAxisTitle("#phi at vertex", 1);
-
-  ugmtMuonPhiAtVtxOmtf = ibooker.book1D("ugmtMuonPhiAtVtxOmtf", "uGMT Muon #phi at vertex for OMTF Inputs", 126, -3.15, 3.15);
-  ugmtMuonPhiAtVtxOmtf->setAxisTitle("#phi at vertex", 1);
-
-  ugmtMuonPhiAtVtxEmtf = ibooker.book1D("ugmtMuonPhiAtVtxEmtf", "uGMT Muon #phi at vertex for EMTF Inputs", 126, -3.15, 3.15);
-  ugmtMuonPhiAtVtxEmtf->setAxisTitle("#phi at vertex", 1);
-
   const float dPhiScale = 4*phiScale_;
   const float dEtaScale = etaScale_;
   ugmtMuonDEtavsPtBmtf = ibooker.book2D("ugmtMuonDEtavsPtBmtf", "uGMT Muon from BMTF #eta_{at vertex} - #eta_{at muon system} vs p_{T}", 32, 0, 64, 31, -15.5*dEtaScale, 15.5*dEtaScale);
@@ -391,14 +382,6 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   ugmtMuonPhivsEta->setAxisTitle("#eta", 1);
   ugmtMuonPhivsEta->setAxisTitle("#phi", 2);
 
-  ugmtMuonPtvsEtaAtVtx = ibooker.book2D("ugmtMuonPtvsEtaAtVtx", "uGMT Muon p_{T} vs #eta at vertex", 100, -2.5, 2.5, 256, -0.5, 255.5);
-  ugmtMuonPtvsEtaAtVtx->setAxisTitle("#eta at vertex", 1);
-  ugmtMuonPtvsEtaAtVtx->setAxisTitle("p_{T} [GeV]", 2);
-
-  ugmtMuonPtvsPhiAtVtx = ibooker.book2D("ugmtMuonPtvsPhiAtVtx", "uGMT Muon p_{T} vs #phi at vertex", 64, -3.2, 3.2, 256, -0.5, 255.5);
-  ugmtMuonPtvsPhiAtVtx->setAxisTitle("#phi at vertex", 1);
-  ugmtMuonPtvsPhiAtVtx->setAxisTitle("p_{T} [GeV]", 2);
-
   ugmtMuonPhiAtVtxvsEtaAtVtx = ibooker.book2D("ugmtMuonPhiAtVtxvsEtaAtVtx", "uGMT Muon #phi at vertex vs #eta at vertex", 100, -2.5, 2.5, 64, -3.2, 3.2);
   ugmtMuonPhiAtVtxvsEtaAtVtx->setAxisTitle("#eta at vertex", 1);
   ugmtMuonPhiAtVtxvsEtaAtVtx->setAxisTitle("#phi at vertex", 2);
@@ -418,14 +401,6 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   ugmtMuonBXvshwPhi = ibooker.book2D("ugmtMuonBXvshwPhi", "uGMT Muon BX vs #phi", 116, -2.5, 577.5, 5, -2.5, 2.5);
   ugmtMuonBXvshwPhi->setAxisTitle("Hardware #phi", 1);
   ugmtMuonBXvshwPhi->setAxisTitle("BX", 2);
-
-  ugmtMuonBXvshwEtaAtVtx = ibooker.book2D("ugmtMuonBXvshwEtaAtVtx", "uGMT Muon BX vs #eta at vertex", 93, -232.5, 232.5, 5, -2.5, 2.5);
-  ugmtMuonBXvshwEtaAtVtx->setAxisTitle("Hardware #eta at vertex", 1);
-  ugmtMuonBXvshwEtaAtVtx->setAxisTitle("BX", 2);
-
-  ugmtMuonBXvshwPhiAtVtx = ibooker.book2D("ugmtMuonBXvshwPhiAtVtx", "uGMT Muon BX vs #phi at vertex", 116, -2.5, 577.5, 5, -2.5, 2.5);
-  ugmtMuonBXvshwPhiAtVtx->setAxisTitle("Hardware #phi at vertex", 1);
-  ugmtMuonBXvshwPhiAtVtx->setAxisTitle("BX", 2);
 
   ugmtMuonBXvshwCharge = ibooker.book2D("ugmtMuonBXvshwCharge", "uGMT Muon BX vs Charge", 2, -0.5, 1.5, 5, -2.5, 2.5);
   ugmtMuonBXvshwCharge->setAxisTitle("Hardware Charge", 1);
@@ -782,17 +757,14 @@ void L1TStage2uGMT::analyze(const edm::Event& e, const edm::EventSetup& c) {
       l1t::tftype tfType{getTfOrigin(tfMuonIndex)};
       if (tfType == l1t::emtf_pos || tfType == l1t::emtf_neg) {
         ugmtMuonPhiEmtf->Fill(Muon->phi());
-        ugmtMuonPhiAtVtxEmtf->Fill(Muon->phiAtVtx());
         ugmtMuonDEtavsPtEmtf->Fill(Muon->pt(), Muon->hwDEtaExtra()*etaScale_);
         ugmtMuonDPhivsPtEmtf->Fill(Muon->pt(), Muon->hwDPhiExtra()*phiScale_);
       } else if (tfType == l1t::omtf_pos || tfType == l1t::omtf_neg) {
         ugmtMuonPhiOmtf->Fill(Muon->phi());
-        ugmtMuonPhiAtVtxOmtf->Fill(Muon->phiAtVtx());
         ugmtMuonDEtavsPtOmtf->Fill(Muon->pt(), Muon->hwDEtaExtra()*etaScale_);
         ugmtMuonDPhivsPtOmtf->Fill(Muon->pt(), Muon->hwDPhiExtra()*phiScale_);
       } else if (tfType == l1t::bmtf) {
         ugmtMuonPhiBmtf->Fill(Muon->phi());
-        ugmtMuonPhiAtVtxBmtf->Fill(Muon->phiAtVtx());
         ugmtMuonDEtavsPtBmtf->Fill(Muon->pt(), Muon->hwDEtaExtra()*etaScale_);
         ugmtMuonDPhivsPtBmtf->Fill(Muon->pt(), Muon->hwDPhiExtra()*phiScale_);
       }
@@ -801,16 +773,12 @@ void L1TStage2uGMT::analyze(const edm::Event& e, const edm::EventSetup& c) {
       ugmtMuonPtvsPhi->Fill(Muon->phi(), Muon->pt());
       ugmtMuonPhivsEta->Fill(Muon->eta(), Muon->phi());
 
-      ugmtMuonPtvsEtaAtVtx->Fill(Muon->etaAtVtx(), Muon->pt());
-      ugmtMuonPtvsPhiAtVtx->Fill(Muon->phiAtVtx(), Muon->pt());
       ugmtMuonPhiAtVtxvsEtaAtVtx->Fill(Muon->etaAtVtx(), Muon->phiAtVtx());
 
       ugmtMuonBXvsLink->Fill(int(Muon->tfMuonIndex()/3.) + 36, itBX);
       ugmtMuonBXvshwPt->Fill(Muon->hwPt(), itBX);
       ugmtMuonBXvshwEta->Fill(Muon->hwEta(), itBX);
       ugmtMuonBXvshwPhi->Fill(Muon->hwPhi(), itBX);
-      ugmtMuonBXvshwEtaAtVtx->Fill(Muon->hwEtaAtVtx(), itBX);
-      ugmtMuonBXvshwPhiAtVtx->Fill(Muon->hwPhiAtVtx(), itBX);
       ugmtMuonBXvshwCharge->Fill(Muon->hwCharge(), itBX);
       ugmtMuonBXvshwChargeValid->Fill(Muon->hwChargeValid(), itBX);
       ugmtMuonBXvshwQual->Fill(Muon->hwQual(), itBX);

--- a/DQM/L1TMonitor/src/L1TStage2uGMTMuon.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGMTMuon.cc
@@ -5,7 +5,8 @@ L1TStage2uGMTMuon::L1TStage2uGMTMuon(const edm::ParameterSet& ps)
     : ugmtMuonToken(consumes<l1t::MuonBxCollection>(ps.getParameter<edm::InputTag>("muonProducer"))),
       monitorDir(ps.getUntrackedParameter<std::string>("monitorDir")),
       titlePrefix(ps.getUntrackedParameter<std::string>("titlePrefix")),
-      verbose(ps.getUntrackedParameter<bool>("verbose"))
+      verbose(ps.getUntrackedParameter<bool>("verbose")),
+      makeMuonAtVtxPlots(ps.getUntrackedParameter<bool>("makeMuonAtVtxPlots"))
 {
 }
 
@@ -17,6 +18,7 @@ void L1TStage2uGMTMuon::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.addUntracked<std::string>("monitorDir", "")->setComment("Target directory in the DQM file. Will be created if not existing.");
   desc.addUntracked<std::string>("titlePrefix", "")->setComment("Prefix text for the histogram titles.");
   desc.addUntracked<bool>("verbose", false);
+  desc.addUntracked<bool>("makeMuonAtVtxPlots", false);
   descriptions.add("l1tStage2uGMTMuon", desc);
 }
 
@@ -44,12 +46,6 @@ void L1TStage2uGMTMuon::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   ugmtMuonhwPhi = ibooker.book1D("ugmtMuonhwPhi", (titlePrefix+"#phi").c_str(), 576, -0.5, 575.5);
   ugmtMuonhwPhi->setAxisTitle("Hardware Phi", 1);
 
-  ugmtMuonhwEtaAtVtx = ibooker.book1D("ugmtMuonhwEtaAtVtx", (titlePrefix+"#eta at vertex").c_str(), 461, -230.5, 230.5);
-  ugmtMuonhwEtaAtVtx->setAxisTitle("Hardware Eta at Vertex", 1);
-
-  ugmtMuonhwPhiAtVtx = ibooker.book1D("ugmtMuonhwPhiAtVtx", (titlePrefix+"#phi at vertex").c_str(), 576, -0.5, 575.5);
-  ugmtMuonhwPhiAtVtx->setAxisTitle("Hardware Phi at Vertex", 1);
-
   ugmtMuonhwCharge = ibooker.book1D("ugmtMuonhwCharge", (titlePrefix+"Charge").c_str(), 2, -0.5, 1.5);
   ugmtMuonhwCharge->setAxisTitle("Hardware Charge", 1);
 
@@ -68,12 +64,6 @@ void L1TStage2uGMTMuon::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   ugmtMuonPhi = ibooker.book1D("ugmtMuonPhi", (titlePrefix+"#phi").c_str(), 126, -3.15, 3.15);
   ugmtMuonPhi->setAxisTitle("#phi", 1);
 
-  ugmtMuonEtaAtVtx = ibooker.book1D("ugmtMuonEtaAtVtx", (titlePrefix+"#eta at vertex").c_str(), 100, -2.5, 2.5);
-  ugmtMuonEtaAtVtx->setAxisTitle("#eta at Vertex", 1);
-
-  ugmtMuonPhiAtVtx = ibooker.book1D("ugmtMuonPhiAtVtx", (titlePrefix+"#phi at vertex").c_str(), 126, -3.15, 3.15);
-  ugmtMuonPhiAtVtx->setAxisTitle("#phi at Vertex", 1);
-
   ugmtMuonCharge = ibooker.book1D("ugmtMuonCharge", (titlePrefix+"Charge").c_str(), 3, -1.5, 1.5);
   ugmtMuonCharge->setAxisTitle("Charge", 1);
 
@@ -89,18 +79,6 @@ void L1TStage2uGMTMuon::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   ugmtMuonPhivsEta->setAxisTitle("#eta", 1);
   ugmtMuonPhivsEta->setAxisTitle("#phi", 2);
 
-  ugmtMuonPtvsEtaAtVtx = ibooker.book2D("ugmtMuonPtvsEtaAtVtx", (titlePrefix+"p_{T} vs #eta at vertex").c_str(), 100, -2.5, 2.5, 256, -0.5, 255.5);
-  ugmtMuonPtvsEtaAtVtx->setAxisTitle("#eta at Vertex", 1);
-  ugmtMuonPtvsEtaAtVtx->setAxisTitle("p_{T} [GeV]", 2);
-
-  ugmtMuonPtvsPhiAtVtx = ibooker.book2D("ugmtMuonPtvsPhiAtVtx", (titlePrefix+"p_{T} vs #phi at vertex").c_str(), 64, -3.2, 3.2, 256, -0.5, 255.5);
-  ugmtMuonPtvsPhiAtVtx->setAxisTitle("#phi", 1);
-  ugmtMuonPtvsPhiAtVtx->setAxisTitle("p_{T} [GeV]", 2);
-
-  ugmtMuonPhiAtVtxvsEtaAtVtx = ibooker.book2D("ugmtMuonPhiAtVtxvsEtaAtVtx", (titlePrefix+"#phi_{vtx} vs #eta_{vtx}").c_str(), 100, -2.5, 2.5, 64, -3.2, 3.2);
-  ugmtMuonPhiAtVtxvsEtaAtVtx->setAxisTitle("#eta at Vertex", 1);
-  ugmtMuonPhiAtVtxvsEtaAtVtx->setAxisTitle("#phi at Vertex", 2);
-
   ugmtMuonBXvshwPt = ibooker.book2D("ugmtMuonBXvshwPt", (titlePrefix+"BX vs p_{T}").c_str(), 256, -0.5, 511.5, 5, -2.5, 2.5);
   ugmtMuonBXvshwPt->setAxisTitle("Hardware p_{T}", 1);
   ugmtMuonBXvshwPt->setAxisTitle("BX", 2);
@@ -113,14 +91,6 @@ void L1TStage2uGMTMuon::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   ugmtMuonBXvshwPhi->setAxisTitle("Hardware #phi", 1);
   ugmtMuonBXvshwPhi->setAxisTitle("BX", 2);
 
-  ugmtMuonBXvshwEtaAtVtx = ibooker.book2D("ugmtMuonBXvshwEtaAtVtx", (titlePrefix+"BX vs #eta at vertex").c_str(), 93, -232.5, 232.5, 5, -2.5, 2.5);
-  ugmtMuonBXvshwEtaAtVtx->setAxisTitle("Hardware #eta at Vertex", 1);
-  ugmtMuonBXvshwEtaAtVtx->setAxisTitle("BX", 2);
-
-  ugmtMuonBXvshwPhiAtVtx = ibooker.book2D("ugmtMuonBXvshwPhiAtVtx", (titlePrefix+"BX vs #phi at vertex").c_str(), 116, -2.5, 577.5, 5, -2.5, 2.5);
-  ugmtMuonBXvshwPhiAtVtx->setAxisTitle("Hardware #phi at Vertex", 1);
-  ugmtMuonBXvshwPhiAtVtx->setAxisTitle("BX", 2);
-
   ugmtMuonBXvshwCharge = ibooker.book2D("ugmtMuonBXvshwCharge", (titlePrefix+"BX vs Charge").c_str(), 2, -0.5, 1.5, 5, -2.5, 2.5);
   ugmtMuonBXvshwCharge->setAxisTitle("Hardware Charge", 1);
   ugmtMuonBXvshwCharge->setAxisTitle("BX", 2);
@@ -132,6 +102,40 @@ void L1TStage2uGMTMuon::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   ugmtMuonBXvshwQual = ibooker.book2D("ugmtMuonBXvshwQual", (titlePrefix+"BX vs Quality").c_str(), 16, -0.5, 15.5, 5, -2.5, 2.5);
   ugmtMuonBXvshwQual->setAxisTitle("Quality", 1);
   ugmtMuonBXvshwQual->setAxisTitle("BX", 2);
+
+  if (makeMuonAtVtxPlots) {
+    ugmtMuonhwEtaAtVtx = ibooker.book1D("ugmtMuonhwEtaAtVtx", (titlePrefix+"#eta at vertex").c_str(), 461, -230.5, 230.5);
+    ugmtMuonhwEtaAtVtx->setAxisTitle("Hardware Eta at Vertex", 1);
+
+    ugmtMuonhwPhiAtVtx = ibooker.book1D("ugmtMuonhwPhiAtVtx", (titlePrefix+"#phi at vertex").c_str(), 576, -0.5, 575.5);
+    ugmtMuonhwPhiAtVtx->setAxisTitle("Hardware Phi at Vertex", 1);
+
+    ugmtMuonEtaAtVtx = ibooker.book1D("ugmtMuonEtaAtVtx", (titlePrefix+"#eta at vertex").c_str(), 100, -2.5, 2.5);
+    ugmtMuonEtaAtVtx->setAxisTitle("#eta at Vertex", 1);
+
+    ugmtMuonPhiAtVtx = ibooker.book1D("ugmtMuonPhiAtVtx", (titlePrefix+"#phi at vertex").c_str(), 126, -3.15, 3.15);
+    ugmtMuonPhiAtVtx->setAxisTitle("#phi at Vertex", 1);
+
+    ugmtMuonPtvsEtaAtVtx = ibooker.book2D("ugmtMuonPtvsEtaAtVtx", (titlePrefix+"p_{T} vs #eta at vertex").c_str(), 100, -2.5, 2.5, 256, -0.5, 255.5);
+    ugmtMuonPtvsEtaAtVtx->setAxisTitle("#eta at Vertex", 1);
+    ugmtMuonPtvsEtaAtVtx->setAxisTitle("p_{T} [GeV]", 2);
+
+    ugmtMuonPhiAtVtxvsEtaAtVtx = ibooker.book2D("ugmtMuonPhiAtVtxvsEtaAtVtx", (titlePrefix+"#phi_{vtx} vs #eta_{vtx}").c_str(), 100, -2.5, 2.5, 64, -3.2, 3.2);
+    ugmtMuonPhiAtVtxvsEtaAtVtx->setAxisTitle("#eta at Vertex", 1);
+    ugmtMuonPhiAtVtxvsEtaAtVtx->setAxisTitle("#phi at Vertex", 2);
+
+    ugmtMuonPtvsPhiAtVtx = ibooker.book2D("ugmtMuonPtvsPhiAtVtx", (titlePrefix+"p_{T} vs #phi at vertex").c_str(), 64, -3.2, 3.2, 256, -0.5, 255.5);
+    ugmtMuonPtvsPhiAtVtx->setAxisTitle("#phi at Vertex", 1);
+    ugmtMuonPtvsPhiAtVtx->setAxisTitle("p_{T} [GeV]", 2);
+
+    ugmtMuonBXvshwEtaAtVtx = ibooker.book2D("ugmtMuonBXvshwEtaAtVtx", (titlePrefix+"BX vs #eta at vertex").c_str(), 93, -232.5, 232.5, 5, -2.5, 2.5);
+    ugmtMuonBXvshwEtaAtVtx->setAxisTitle("Hardware #eta at Vertex", 1);
+    ugmtMuonBXvshwEtaAtVtx->setAxisTitle("BX", 2);
+
+    ugmtMuonBXvshwPhiAtVtx = ibooker.book2D("ugmtMuonBXvshwPhiAtVtx", (titlePrefix+"BX vs #phi at vertex").c_str(), 116, -2.5, 577.5, 5, -2.5, 2.5);
+    ugmtMuonBXvshwPhiAtVtx->setAxisTitle("Hardware #phi at Vertex", 1);
+    ugmtMuonBXvshwPhiAtVtx->setAxisTitle("BX", 2);
+  }
 }
 
 void L1TStage2uGMTMuon::analyze(const edm::Event& e, const edm::EventSetup& c) {
@@ -150,8 +154,6 @@ void L1TStage2uGMTMuon::analyze(const edm::Event& e, const edm::EventSetup& c) {
       ugmtMuonhwPt->Fill(Muon->hwPt());
       ugmtMuonhwEta->Fill(Muon->hwEta());
       ugmtMuonhwPhi->Fill(Muon->hwPhi());
-      ugmtMuonhwEtaAtVtx->Fill(Muon->hwEtaAtVtx());
-      ugmtMuonhwPhiAtVtx->Fill(Muon->hwPhiAtVtx());
       ugmtMuonhwCharge->Fill(Muon->hwCharge());
       ugmtMuonhwChargeValid->Fill(Muon->hwChargeValid());
       ugmtMuonhwQual->Fill(Muon->hwQual());
@@ -159,25 +161,30 @@ void L1TStage2uGMTMuon::analyze(const edm::Event& e, const edm::EventSetup& c) {
       ugmtMuonPt->Fill(Muon->pt());
       ugmtMuonEta->Fill(Muon->eta());
       ugmtMuonPhi->Fill(Muon->phi());
-      ugmtMuonEtaAtVtx->Fill(Muon->etaAtVtx());
-      ugmtMuonPhiAtVtx->Fill(Muon->phiAtVtx());
       ugmtMuonCharge->Fill(Muon->charge());
 
       ugmtMuonPtvsEta->Fill(Muon->eta(), Muon->pt());
       ugmtMuonPtvsPhi->Fill(Muon->phi(), Muon->pt());
       ugmtMuonPhivsEta->Fill(Muon->eta(), Muon->phi());
-      ugmtMuonPtvsEtaAtVtx->Fill(Muon->etaAtVtx(), Muon->pt());
-      ugmtMuonPtvsPhiAtVtx->Fill(Muon->phiAtVtx(), Muon->pt());
-      ugmtMuonPhiAtVtxvsEtaAtVtx->Fill(Muon->etaAtVtx(), Muon->phiAtVtx());
 
       ugmtMuonBXvshwPt->Fill(Muon->hwPt(), itBX);
       ugmtMuonBXvshwEta->Fill(Muon->hwEta(), itBX);
       ugmtMuonBXvshwPhi->Fill(Muon->hwPhi(), itBX);
-      ugmtMuonBXvshwEtaAtVtx->Fill(Muon->hwEtaAtVtx(), itBX);
-      ugmtMuonBXvshwPhiAtVtx->Fill(Muon->hwPhiAtVtx(), itBX);
       ugmtMuonBXvshwCharge->Fill(Muon->hwCharge(), itBX);
       ugmtMuonBXvshwChargeValid->Fill(Muon->hwChargeValid(), itBX);
       ugmtMuonBXvshwQual->Fill(Muon->hwQual(), itBX);
+
+      if (makeMuonAtVtxPlots) {
+        ugmtMuonhwEtaAtVtx->Fill(Muon->hwEtaAtVtx());
+        ugmtMuonhwPhiAtVtx->Fill(Muon->hwPhiAtVtx());
+        ugmtMuonEtaAtVtx->Fill(Muon->etaAtVtx());
+        ugmtMuonPhiAtVtx->Fill(Muon->phiAtVtx());
+        ugmtMuonPtvsEtaAtVtx->Fill(Muon->etaAtVtx(), Muon->pt());
+        ugmtMuonPtvsPhiAtVtx->Fill(Muon->phiAtVtx(), Muon->pt());
+        ugmtMuonPhiAtVtxvsEtaAtVtx->Fill(Muon->etaAtVtx(), Muon->phiAtVtx());
+        ugmtMuonBXvshwEtaAtVtx->Fill(Muon->hwEtaAtVtx(), itBX);
+        ugmtMuonBXvshwPhiAtVtx->Fill(Muon->hwPhiAtVtx(), itBX);
+      }
     }
   }
 }


### PR DESCRIPTION
Solves the JIRA Ticket:  https://its.cern.ch/jira/browse/CMSLITDPG-322

Description:

- Remove some muon AtVtx plots and rename the BXvsProcessor plots used in the uGMT L1T Online DQM workspace.

- Add a boolean flag to create or not the muon AtVtx plots for the Intermediate muons in the uGMT L1T Online DQM workspace.

