### PR TITLE
GT Updates : PhaseII GT updated with the new Jet Energy Corrections

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -54,7 +54,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '93X_upgrade2023_realistic_v2'
+    'phase2_realistic'         : '93X_upgrade2023_realistic_v3'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -54,7 +54,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '93X_upgrade2023_realistic_v4'
+    'phase2_realistic'         : '93X_upgrade2023_realistic_v5'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -54,7 +54,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '93X_upgrade2023_realistic_v3'
+    'phase2_realistic'         : '93X_upgrade2023_realistic_v4'
 }
 
 aliases = {


### PR DESCRIPTION
# Summary of changes in Global Tags 

## Upgrade

   * **PhaseII 2023 realistic scenario** : [93X_upgrade2023_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_upgrade2023_realistic_v2) as [93X_upgrade2023_realistic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_upgrade2023_realistic_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/93X_upgrade2023_realistic_v5/93X_upgrade2023_realistic_v2): 
      * update of Jet Energy Corrections mentioned here : https://github.com/cms-sw/cmssw/pull/21370#issuecomment-346689916