### PR TITLE
Added ProductID include to AssociationMapHelpers.h

### DIFF
--- a/DataFormats/Common/interface/AssociationMapHelpers.h
+++ b/DataFormats/Common/interface/AssociationMapHelpers.h
@@ -8,6 +8,7 @@
  *
  *
  */
+#include "DataFormats/Provenance/interface/ProductID.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
 #include <utility>


### PR DESCRIPTION
We try to construct a ProductID from this header, so we also
need to include the header that defines ProductID to make this
header standalone.