### PR TITLE
Added include for size_t to ContainerMask.h

### DIFF
--- a/DataFormats/Common/interface/ContainerMask.h
+++ b/DataFormats/Common/interface/ContainerMask.h
@@ -22,6 +22,7 @@
 // system include files
 #include <vector>
 #include <cassert>
+#include <cstddef>
 #include <algorithm>
 
 // user include files


### PR DESCRIPTION
We use size_t in this header but never include a header that defines
size_t. Let's just include <cstddef> to make this header standalone.