### PR TITLE
Added include for size_t to ContainerMaskTraits.h

### DIFF
--- a/DataFormats/Common/interface/ContainerMaskTraits.h
+++ b/DataFormats/Common/interface/ContainerMaskTraits.h
@@ -19,6 +19,7 @@
 //
 
 // system include files
+#include <cstddef>
 
 // user include files
 


### PR DESCRIPTION
We use size_t in this header, also we need the corresponding include
to make this header standalone.