### PR TITLE
Added missing vector include to WrapperDetail.h

### DIFF
--- a/DataFormats/Common/interface/WrapperDetail.h
+++ b/DataFormats/Common/interface/WrapperDetail.h
@@ -9,6 +9,7 @@ WrapperDetail: Metafunction support for compile-time selection of code.
 
 #include <typeinfo>
 #include <type_traits>
+#include <vector>
 
 namespace edm {
 


### PR DESCRIPTION
We use std::vector in this header, also we need to include <vector>
to make this header standalone.