### PR TITLE
Added missing includes to IDbSchema.h

### DIFF
--- a/CondCore/CondDB/src/IDbSchema.h
+++ b/CondCore/CondDB/src/IDbSchema.h
@@ -4,6 +4,10 @@
 //
 #include <boost/date_time/posix_time/posix_time.hpp>
 
+#include "CondFormats/Common/interface/Time.h"
+#include "CondCore/CondDB/interface/Types.h"
+#include "CondCore/CondDB/interface/Binary.h"
+
 namespace cond {
 
   namespace persistency {


### PR DESCRIPTION
We reference cond::TimeType, cond::SynchronizationType, cond::Binary
in this header but don't include the headers defining these declarations.

As some of the types are typedef'd which is ugly to forward declare, I
think just including the headers is the best way to make this header standalone.