### PR TITLE
Added include to cstddef to InsertContainerItem.hh

### DIFF
--- a/Alignment/Geners/interface/InsertContainerItem.hh
+++ b/Alignment/Geners/interface/InsertContainerItem.hh
@@ -1,6 +1,8 @@
 #ifndef GENERS_INSERTCONTAINERITEM_HH_
 #define GENERS_INSERTCONTAINERITEM_HH_
 
+#include <cstddef>
+
 namespace gs {
     template <typename T>
     struct InsertContainerItem


### PR DESCRIPTION
This header references std::size_t, but doesn't include the
associated `<cstddef>` header, making it impossible to parse
this header on its own.