### PR TITLE
Added include to functional to AlignmentSorter.h

### DIFF
--- a/CondFormats/Alignment/interface/AlignmentSorter.h
+++ b/CondFormats/Alignment/interface/AlignmentSorter.h
@@ -1,6 +1,8 @@
 #ifndef __CondFormats_Alignment_AlignmentSorter_h
 #define __CondFormats_Alignment_AlignmentSorter_h
 
+#include <functional>
+
 ///
 /// A struct to sort Alignments and AlignmentErrorsExtended by increasing DetId
 ///


### PR DESCRIPTION
This header referenced std::binary_function but didn't include
the associated `<functional>` header, making it impossible to
parse this header on its own.