### PR TITLE
Added include to CharBuffer.hh to RPBufferReference.hh

### DIFF
--- a/Alignment/Geners/interface/RPBufferReference.hh
+++ b/Alignment/Geners/interface/RPBufferReference.hh
@@ -2,6 +2,7 @@
 #define GENERS_RPBUFFERREFERENCE_HH_
 
 #include "Alignment/Geners/interface/AbsReference.hh"
+#include "Alignment/Geners/interface/CharBuffer.hh"
 #include "Alignment/Geners/interface/streamposIO.hh"
 
 namespace gs {


### PR DESCRIPTION
This header references CharBuffer::restore, so it also needs
to include the CharBuffer header to be parsable on its own.