### PR TITLE
Added include to AbsArchive.hh to RPFooterReference.hh

### DIFF
--- a/Alignment/Geners/interface/RPFooterReference.hh
+++ b/Alignment/Geners/interface/RPFooterReference.hh
@@ -1,6 +1,7 @@
 #ifndef GENERS_RPFOOTERREFERENCE_HH_
 #define GENERS_RPFOOTERREFERENCE_HH_
 
+#include "Alignment/Geners/interface/AbsArchive.hh"
 #include "Alignment/Geners/interface/AbsReference.hh"
 #include "Alignment/Geners/interface/GenericIO.hh"
 


### PR DESCRIPTION
In this file we access a member of AbsArchive here:
```C++
*offset = archive().catalogEntry(itemId)->offset();
                   ^
```

This means we need to include the header containing the AbsArchive
definition to make this header parsable on its own.