### PR TITLE
Added include to EcalRecHit.h to EcalRecHitComparison.h

### DIFF
--- a/DataFormats/EcalRecHit/interface/EcalRecHitComparison.h
+++ b/DataFormats/EcalRecHit/interface/EcalRecHitComparison.h
@@ -1,6 +1,8 @@
 #ifndef EcalRecHitComparison_H
 #define EcalRecHitComparison_H
 
+#include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
+
 //ordering capability mandatory for lazy getter framework
 // Comparison operators
 inline bool operator<( const EcalRecHit& one, const EcalRecHit& other) {


### PR DESCRIPTION
We reference EcalRecHit in this header, so we also need to include
EcalRecHit.h to make this header parsable on its own.