### PR TITLE
Added include for cmath to MuenMETCorrectionData

### DIFF
--- a/DataFormats/MuonReco/interface/MuonMETCorrectionData.h
+++ b/DataFormats/MuonReco/interface/MuonMETCorrectionData.h
@@ -1,6 +1,7 @@
 #ifndef MuonReco_MuonMETCorrectionData_h
 #define MuonReco_MuonMETCorrectionData_h
 
+#include <cmath>
 
 namespace reco {
   class MuonMETCorrectionData {


### PR DESCRIPTION
We use `sqrt` in this header, so we also need to include `cmath`.