### PR TITLE
Added include for vector to MuonShower.h

### DIFF
--- a/DataFormats/MuonReco/interface/MuonShower.h
+++ b/DataFormats/MuonReco/interface/MuonShower.h
@@ -1,6 +1,8 @@
 #ifndef MuonReco_MuonShower_h
 #define MuonReco_MuonShower_h
 
+#include <vector>
+
 namespace reco {
     struct MuonShower {
 


### PR DESCRIPTION
We use vector in this header, so we also should include `vector`.