### PR TITLE
Added include for SelectorStack.h to ExpressionCondition.h

### DIFF
--- a/CommonTools/Utils/src/ExpressionCondition.h
+++ b/CommonTools/Utils/src/ExpressionCondition.h
@@ -12,6 +12,7 @@
  */
 #include "CommonTools/Utils/src/ExpressionBase.h"
 #include "CommonTools/Utils/src/SelectorBase.h"
+#include "CommonTools/Utils/src/SelectorStack.h"
 #include "CommonTools/Utils/src/ExpressionStack.h"
 
 namespace reco {


### PR DESCRIPTION
We use SelectorStack in this header, so we also need to include
the header where this decl is defined to make it parsable on its
own.