### PR TITLE
Fix for large number of efficiency_strings in HLT harvesting (9_4_X)

### DIFF
--- a/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from HLTriggerOffline.Exotica.hltExoticaPostProcessor_cfi import *
 
 # Build the standard strings to the DQM
-def efficiency_string(objtype,plot_type,triggerpath):
+def make_efficiency_string(objtype, plot_type, triggerpath):
     # --- IMPORTANT: Add here a elif if you are introduce a new collection
     #                (see EVTColContainer::getTypeString) 
     if objtype == "Mu" :
@@ -56,150 +56,55 @@ def efficiency_string(objtype,plot_type,triggerpath):
     return "Eff_%s_%s '%s' %s_%s %s" % (input_type,triggerpath,
 		    all_titles,input_type,triggerpath,input_type)
 
-# Adding the reco objects
-def add_reco_strings(strings):
-    reco_strings = []
-    for entry in strings:
-        reco_strings.append(entry
-                            .replace("Generated", "Reconstructed")
-                            .replace("Gen", "Reco")
-                            .replace("gen", "rec"))
-    strings.extend(reco_strings)
-
-
 plot_types = ["TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4", "EffEta", "EffPhi", "EffDxy"]
 #--- IMPORTANT: Update this collection whenever you introduce a new object
 #               in the code (from EVTColContainer::getTypeString)
 obj_types  = ["Mu","refittedStandAloneMuons","Track","Ele","Photon","PFTau","PFJet","MET","PFMET","PFMHT","GenMET","CaloJet"
              ,"CaloMET","CaloMHT","l1MET"]
-#--- IMPORTANT: Trigger are extracted from the hltExoticaValidator_cfi.py module
-triggers = [ ] 
-efficiency_strings = []
 
-# Extract the triggers used in the hltExoticaValidator, for each path
+#--- IMPORTANT: Trigger are extracted from the hltExoticaValidator_cfi.py module
 from HLTriggerOffline.Exotica.hltExoticaValidator_cfi import hltExoticaValidator as _config
-triggers = set([])
-for an in _config.analysis:
-	s = _config.__getattribute__(an)
-	vstr = s.__getattribute__("hltPathsToCheck")
-	map(lambda x: triggers.add(x.replace("_v","")),vstr)
-triggers = list(triggers)
 #------------------------------------------------------------
 
-# Generating the list with all the efficiencies
-for type in plot_types:
-	for obj in obj_types:
-		for trig in triggers:
-			efficiency_strings.append(efficiency_string(obj,type,trig))
-#for item in efficiency_strings:
-#    print item
+def make_postprocessor(analysis_name):
+    postprocessor = hltExoticaPostProcessor.clone()
+    postprocessor.subDirs = ["HLT/Exotica/" + analysis_name]
+    efficiency_strings = [] # List of plots to look for. This is quite a bit larger than the number of plots that will be made.
+    for plot_type in plot_types:
+        for object_type in obj_types:
+            for trigger in [x.replace("_v", "") for x in _config.__getattribute__(analysis_name).hltPathsToCheck]:
+                this_efficiency_string = make_efficiency_string(object_type, plot_type, trigger)
+                efficiency_strings.append(this_efficiency_string)
+                efficiency_strings.append(this_efficiency_string.replace("Generated", "Reconstructed").replace("Gen", "Reco").replace("gen", "rec"))
+    postprocessor.efficiencyProfile = efficiency_strings
+    return postprocessor
 
-add_reco_strings(efficiency_strings)
-
-#--- IMPORTANT: Here you have to add the analyses one by one.
-hltExoticaPostLowPtTrimuon = hltExoticaPostProcessor.clone()
-hltExoticaPostLowPtTrimuon.subDirs = ['HLT/Exotica/LowPtTrimuon']
-hltExoticaPostLowPtTrimuon.efficiencyProfile = efficiency_strings
-
-hltExoticaPostHighPtDimuon = hltExoticaPostProcessor.clone()
-hltExoticaPostHighPtDimuon.subDirs = ['HLT/Exotica/HighPtDimuon']
-hltExoticaPostHighPtDimuon.efficiencyProfile = efficiency_strings
-
-hltExoticaPostHighPtDielectron = hltExoticaPostProcessor.clone()
-hltExoticaPostHighPtDielectron.subDirs = ['HLT/Exotica/HighPtDielectron']
-hltExoticaPostHighPtDielectron.efficiencyProfile = efficiency_strings
-
-hltExoticaPostHighPtElectron = hltExoticaPostProcessor.clone()
-hltExoticaPostHighPtElectron.subDirs = ['HLT/Exotica/HighPtElectron']
-hltExoticaPostHighPtElectron.efficiencyProfile = efficiency_strings
-
-hltExoticaPostLowPtElectron = hltExoticaPostProcessor.clone()
-hltExoticaPostLowPtElectron.subDirs = ['HLT/Exotica/LowPtElectron']
-hltExoticaPostLowPtElectron.efficiencyProfile = efficiency_strings
-
-hltExoticaPostLowPtDimuon = hltExoticaPostProcessor.clone()
-hltExoticaPostLowPtDimuon.subDirs = ['HLT/Exotica/LowPtDimuon']
-hltExoticaPostLowPtDimuon.efficiencyProfile = efficiency_strings
-
-hltExoticaPostLowPtDielectron = hltExoticaPostProcessor.clone()
-hltExoticaPostLowPtDielectron.subDirs = ['HLT/Exotica/LowPtDielectron']
-hltExoticaPostLowPtDielectron.efficiencyProfile = efficiency_strings
-
-hltExoticaPostHighPtPhoton = hltExoticaPostProcessor.clone()
-hltExoticaPostHighPtPhoton.subDirs = ['HLT/Exotica/HighPtPhoton']
-hltExoticaPostHighPtPhoton.efficiencyProfile = efficiency_strings
-
-hltExoticaPostDiPhoton = hltExoticaPostProcessor.clone()
-hltExoticaPostDiPhoton.subDirs = ['HLT/Exotica/DiPhoton']
-hltExoticaPostDiPhoton.efficiencyProfile = efficiency_strings
-
-hltExoticaPostSingleMuon = hltExoticaPostProcessor.clone()
-hltExoticaPostSingleMuon.subDirs = ['HLT/Exotica/SingleMuon']
-hltExoticaPostSingleMuon.efficiencyProfile = efficiency_strings
-
-hltExoticaPostPFHT = hltExoticaPostProcessor.clone()
-hltExoticaPostPFHT.subDirs = ['HLT/Exotica/PFHT']
-hltExoticaPostPFHT.efficiencyProfile = efficiency_strings
-
-hltExoticaPostCaloHT = hltExoticaPostProcessor.clone()
-hltExoticaPostCaloHT.subDirs = ['HLT/Exotica/CaloHT']
-hltExoticaPostCaloHT.efficiencyProfile = efficiency_strings
-
-hltExoticaPostJetNoBptx = hltExoticaPostProcessor.clone()
-hltExoticaPostJetNoBptx.subDirs = ['HLT/Exotica/JetNoBptx']
-hltExoticaPostJetNoBptx.efficiencyProfile = efficiency_strings
-
-hltExoticaPostMuonNoBptx = hltExoticaPostProcessor.clone()
-hltExoticaPostMuonNoBptx.subDirs = ['HLT/Exotica/MuonNoBptx']
-hltExoticaPostMuonNoBptx.efficiencyProfile = efficiency_strings
-
-hltExoticaPostDisplacedMuEG = hltExoticaPostProcessor.clone()
-hltExoticaPostDisplacedMuEG.subDirs = ['HLT/Exotica/DisplacedMuEG']
-hltExoticaPostDisplacedMuEG.efficiencyProfile = efficiency_strings
-
-hltExoticaPostDisplacedDimuon = hltExoticaPostProcessor.clone()
-hltExoticaPostDisplacedDimuon.subDirs = ['HLT/Exotica/DisplacedDimuon']
-hltExoticaPostDisplacedDimuon.efficiencyProfile = efficiency_strings
-
-hltExoticaPostMonojet = hltExoticaPostProcessor.clone()
-hltExoticaPostMonojet.subDirs = ['HLT/Exotica/Monojet']
-hltExoticaPostMonojet.efficiencyProfile = efficiency_strings
-
-hltExoticaPostMonojetBackup = hltExoticaPostProcessor.clone()
-hltExoticaPostMonojetBackup.subDirs = ['HLT/Exotica/MonojetBackup']
-hltExoticaPostMonojetBackup.efficiencyProfile = efficiency_strings
-
-hltExoticaPostPureMET = hltExoticaPostProcessor.clone()
-hltExoticaPostPureMET.subDirs = ['HLT/Exotica/PureMET']
-hltExoticaPostPureMET.efficiencyProfile = efficiency_strings
-
-hltExoticaPostMETplusTrack = hltExoticaPostProcessor.clone()
-hltExoticaPostMETplusTrack.subDirs = ['HLT/Exotica/METplusTrack']
-hltExoticaPostMETplusTrack.efficiencyProfile = efficiency_strings
-
-hltExoticaEleMu = hltExoticaPostProcessor.clone()
-hltExoticaEleMu.subDirs = ['HLT/Exotica/EleMu']
-hltExoticaEleMu.efficiencyProfile = efficiency_strings
-
-hltExoticaPhotonMET = hltExoticaPostProcessor.clone()
-hltExoticaPhotonMET.subDirs = ['HLT/Exotica/PhotonMET']
-hltExoticaPhotonMET.efficiencyProfile = efficiency_strings
-
-hltExoticaHTDisplacedJets = hltExoticaPostProcessor.clone()
-hltExoticaHTDisplacedJets.subDirs = ['HLT/Exotica/HTDisplacedJets']
-hltExoticaHTDisplacedJets.efficiencyProfile = efficiency_strings
-
-hltExoticaDSTJets = hltExoticaPostProcessor.clone()
-hltExoticaDSTJets.subDirs = ['HLT/Exotica/DSTJets']
-hltExoticaDSTJets.efficiencyProfile = efficiency_strings
-
-hltExoticaDSTMuons = hltExoticaPostProcessor.clone()
-hltExoticaDSTMuons.subDirs = ['HLT/Exotica/DSTMuons']
-hltExoticaDSTMuons.efficiencyProfile = efficiency_strings
-
-hltExoticaTracklessJets = hltExoticaPostProcessor.clone()
-hltExoticaTracklessJets.subDirs = ['HLT/Exotica/TracklessJets']
-hltExoticaTracklessJets.efficiencyProfile = efficiency_strings
+hltExoticaPostLowPtTrimuon = make_postprocessor("LowPtTrimuon")
+hltExoticaPostHighPtDimuon = make_postprocessor("HighPtDimuon")
+hltExoticaPostHighPtDielectron = make_postprocessor("HighPtDielectron")
+hltExoticaPostHighPtElectron = make_postprocessor("HighPtElectron")
+#hltExoticaPostLowPtElectron = make_postprocessor("LowPtElectron")
+hltExoticaPostLowPtDimuon = make_postprocessor("LowPtDimuon")
+hltExoticaPostLowPtDielectron = make_postprocessor("LowPtDielectron")
+hltExoticaPostHighPtPhoton = make_postprocessor("HighPtPhoton")
+hltExoticaPostDiPhoton = make_postprocessor("DiPhoton")
+hltExoticaPostSingleMuon = make_postprocessor("SingleMuon")
+hltExoticaPostPFHT = make_postprocessor("PFHT")
+hltExoticaPostCaloHT = make_postprocessor("CaloHT")
+hltExoticaPostJetNoBptx = make_postprocessor("JetNoBptx")
+hltExoticaPostMuonNoBptx = make_postprocessor("MuonNoBptx")
+hltExoticaPostDisplacedMuEG = make_postprocessor("DisplacedMuEG")
+hltExoticaPostDisplacedDimuon = make_postprocessor("DisplacedDimuon")
+hltExoticaPostMonojet = make_postprocessor("Monojet")
+hltExoticaPostMonojetBackup = make_postprocessor("MonojetBackup")
+hltExoticaPostPureMET = make_postprocessor("PureMET")
+hltExoticaPostMETplusTrack = make_postprocessor("METplusTrack")
+hltExoticaEleMu = make_postprocessor("EleMu")
+hltExoticaPhotonMET = make_postprocessor("PhotonMET")
+hltExoticaHTDisplacedJets = make_postprocessor("HTDisplacedJets")
+hltExoticaDSTJets = make_postprocessor("DSTJets")
+hltExoticaDSTMuons = make_postprocessor("DSTMuons")
+hltExoticaTracklessJets = make_postprocessor("TracklessJets")
 
 hltExoticaPostProcessors = cms.Sequence(
     # Tri-lepton paths
@@ -211,7 +116,7 @@ hltExoticaPostProcessors = cms.Sequence(
     hltExoticaPostLowPtDielectron +
     # Single Lepton paths
     hltExoticaPostHighPtElectron +
-    hltExoticaPostLowPtElectron +
+    #hltExoticaPostLowPtElectron +
     # Photon paths
     hltExoticaPostHighPtPhoton +
     hltExoticaPostDiPhoton +
@@ -237,3 +142,8 @@ hltExoticaPostProcessors = cms.Sequence(
     hltExoticaDSTJets +
     hltExoticaDSTMuons 
     )
+
+
+    #for analysis in _config.analyses:
+#    hltExoticaPostProcessors *= analysis_postprocessors[analysis]
+

--- a/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
@@ -56,55 +56,63 @@ def make_efficiency_string(objtype, plot_type, triggerpath):
     return "Eff_%s_%s '%s' %s_%s %s" % (input_type,triggerpath,
 		    all_titles,input_type,triggerpath,input_type)
 
-plot_types = ["TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4", "EffEta", "EffPhi", "EffDxy"]
-#--- IMPORTANT: Update this collection whenever you introduce a new object
-#               in the code (from EVTColContainer::getTypeString)
-obj_types  = ["Mu","refittedStandAloneMuons","Track","Ele","Photon","PFTau","PFJet","MET","PFMET","PFMHT","GenMET","CaloJet"
-             ,"CaloMET","CaloMHT","l1MET"]
 
 #--- IMPORTANT: Trigger are extracted from the hltExoticaValidator_cfi.py module
 from HLTriggerOffline.Exotica.hltExoticaValidator_cfi import hltExoticaValidator as _config
 #------------------------------------------------------------
-
-def make_postprocessor(analysis_name):
+#--- IMPORTANT: Update this collection whenever you introduce a new object
+#               in the code (from EVTColContainer::getTypeString)
+def make_exo_postprocessor(analysis_name, plot_types=["TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4", "EffEta", "EffPhi", "EffDxy"], object_types=["Mu","refittedStandAloneMuons","Track","Ele","Photon","PFTau","PFJet","MET","PFMET","PFMHT","GenMET","CaloJet","CaloMET","CaloMHT","l1MET"], extra_str_templates=[]):
     postprocessor = hltExoticaPostProcessor.clone()
     postprocessor.subDirs = ["HLT/Exotica/" + analysis_name]
     efficiency_strings = [] # List of plots to look for. This is quite a bit larger than the number of plots that will be made.
+
+    # Higgs and SMP postprocessors use this string, but exo does not, for now.
+    #efficiency_summary_string = "EffSummaryPaths_" + analysis_name + "_gen ' Efficiency of paths used in " + analysis_name + " ; trigger path ' SummaryPaths_" + analysis_name + "_gen_passingHLT SummaryPaths_" + analysis_name + "_gen"
+    #efficiency_strings.append(efficiency_summary_string)
+    #efficiency_strings.append(efficiency_summary_string.replace("Generated", "Reconstructed").replace("Gen", "Reco").replace("gen", "rec"))
+
     for plot_type in plot_types:
-        for object_type in obj_types:
+        for object_type in object_types:
             for trigger in [x.replace("_v", "") for x in _config.__getattribute__(analysis_name).hltPathsToCheck]:
                 this_efficiency_string = make_efficiency_string(object_type, plot_type, trigger)
                 efficiency_strings.append(this_efficiency_string)
                 efficiency_strings.append(this_efficiency_string.replace("Generated", "Reconstructed").replace("Gen", "Reco").replace("gen", "rec"))
+
+                for str_template in extra_str_templates:
+                    this_extra_string = str_template.replace("@AN@", analysis_name).replace("@TRIGGER@", trigger)
+                    efficiency_strings.append(this_extra_string)
+                    efficiency_strings.append(this_extra_stringreplace("Generated", "Reconstructed").replace("Gen", "Reco").replace("gen", "rec"))
+
     postprocessor.efficiencyProfile = efficiency_strings
     return postprocessor
 
-hltExoticaPostLowPtTrimuon = make_postprocessor("LowPtTrimuon")
-hltExoticaPostHighPtDimuon = make_postprocessor("HighPtDimuon")
-hltExoticaPostHighPtDielectron = make_postprocessor("HighPtDielectron")
-hltExoticaPostHighPtElectron = make_postprocessor("HighPtElectron")
-#hltExoticaPostLowPtElectron = make_postprocessor("LowPtElectron")
-hltExoticaPostLowPtDimuon = make_postprocessor("LowPtDimuon")
-hltExoticaPostLowPtDielectron = make_postprocessor("LowPtDielectron")
-hltExoticaPostHighPtPhoton = make_postprocessor("HighPtPhoton")
-hltExoticaPostDiPhoton = make_postprocessor("DiPhoton")
-hltExoticaPostSingleMuon = make_postprocessor("SingleMuon")
-hltExoticaPostPFHT = make_postprocessor("PFHT")
-hltExoticaPostCaloHT = make_postprocessor("CaloHT")
-hltExoticaPostJetNoBptx = make_postprocessor("JetNoBptx")
-hltExoticaPostMuonNoBptx = make_postprocessor("MuonNoBptx")
-hltExoticaPostDisplacedMuEG = make_postprocessor("DisplacedMuEG")
-hltExoticaPostDisplacedDimuon = make_postprocessor("DisplacedDimuon")
-hltExoticaPostMonojet = make_postprocessor("Monojet")
-hltExoticaPostMonojetBackup = make_postprocessor("MonojetBackup")
-hltExoticaPostPureMET = make_postprocessor("PureMET")
-hltExoticaPostMETplusTrack = make_postprocessor("METplusTrack")
-hltExoticaEleMu = make_postprocessor("EleMu")
-hltExoticaPhotonMET = make_postprocessor("PhotonMET")
-hltExoticaHTDisplacedJets = make_postprocessor("HTDisplacedJets")
-hltExoticaDSTJets = make_postprocessor("DSTJets")
-hltExoticaDSTMuons = make_postprocessor("DSTMuons")
-hltExoticaTracklessJets = make_postprocessor("TracklessJets")
+hltExoticaPostLowPtTrimuon = make_exo_postprocessor("LowPtTrimuon")
+hltExoticaPostHighPtDimuon = make_exo_postprocessor("HighPtDimuon")
+hltExoticaPostHighPtDielectron = make_exo_postprocessor("HighPtDielectron")
+hltExoticaPostHighPtElectron = make_exo_postprocessor("HighPtElectron")
+#hltExoticaPostLowPtElectron = make_exo_postprocessor("LowPtElectron")
+hltExoticaPostLowPtDimuon = make_exo_postprocessor("LowPtDimuon")
+hltExoticaPostLowPtDielectron = make_exo_postprocessor("LowPtDielectron")
+hltExoticaPostHighPtPhoton = make_exo_postprocessor("HighPtPhoton")
+hltExoticaPostDiPhoton = make_exo_postprocessor("DiPhoton")
+hltExoticaPostSingleMuon = make_exo_postprocessor("SingleMuon")
+hltExoticaPostPFHT = make_exo_postprocessor("PFHT")
+hltExoticaPostCaloHT = make_exo_postprocessor("CaloHT")
+hltExoticaPostJetNoBptx = make_exo_postprocessor("JetNoBptx")
+hltExoticaPostMuonNoBptx = make_exo_postprocessor("MuonNoBptx")
+hltExoticaPostDisplacedMuEG = make_exo_postprocessor("DisplacedMuEG")
+hltExoticaPostDisplacedDimuon = make_exo_postprocessor("DisplacedDimuon")
+hltExoticaPostMonojet = make_exo_postprocessor("Monojet")
+hltExoticaPostMonojetBackup = make_exo_postprocessor("MonojetBackup")
+hltExoticaPostPureMET = make_exo_postprocessor("PureMET")
+hltExoticaPostMETplusTrack = make_exo_postprocessor("METplusTrack")
+hltExoticaEleMu = make_exo_postprocessor("EleMu")
+hltExoticaPhotonMET = make_exo_postprocessor("PhotonMET")
+hltExoticaHTDisplacedJets = make_exo_postprocessor("HTDisplacedJets")
+hltExoticaDSTJets = make_exo_postprocessor("DSTJets")
+hltExoticaDSTMuons = make_exo_postprocessor("DSTMuons")
+hltExoticaTracklessJets = make_exo_postprocessor("TracklessJets")
 
 hltExoticaPostProcessors = cms.Sequence(
     # Tri-lepton paths

--- a/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
@@ -80,10 +80,9 @@ def make_exo_postprocessor(analysis_name, plot_types=["TurnOn1", "TurnOn2", "Tur
                 efficiency_strings.append(this_efficiency_string.replace("Generated", "Reconstructed").replace("Gen", "Reco").replace("gen", "rec"))
 
                 for str_template in extra_str_templates:
-                    this_extra_string = str_template.replace("@AN@", analysis_name).replace("@TRIGGER@", trigger)
+                    this_extra_string = str_template.replace("@ANALYSIS@", analysis_name).replace("@TRIGGER@", trigger)
                     efficiency_strings.append(this_extra_string)
                     efficiency_strings.append(this_extra_stringreplace("Generated", "Reconstructed").replace("Gen", "Reco").replace("gen", "rec"))
-
     postprocessor.efficiencyProfile = efficiency_strings
     return postprocessor
 
@@ -91,7 +90,7 @@ hltExoticaPostLowPtTrimuon = make_exo_postprocessor("LowPtTrimuon")
 hltExoticaPostHighPtDimuon = make_exo_postprocessor("HighPtDimuon")
 hltExoticaPostHighPtDielectron = make_exo_postprocessor("HighPtDielectron")
 hltExoticaPostHighPtElectron = make_exo_postprocessor("HighPtElectron")
-#hltExoticaPostLowPtElectron = make_exo_postprocessor("LowPtElectron")
+hltExoticaPostLowPtElectron = make_exo_postprocessor("LowPtElectron")
 hltExoticaPostLowPtDimuon = make_exo_postprocessor("LowPtDimuon")
 hltExoticaPostLowPtDielectron = make_exo_postprocessor("LowPtDielectron")
 hltExoticaPostHighPtPhoton = make_exo_postprocessor("HighPtPhoton")
@@ -124,7 +123,7 @@ hltExoticaPostProcessors = cms.Sequence(
     hltExoticaPostLowPtDielectron +
     # Single Lepton paths
     hltExoticaPostHighPtElectron +
-    #hltExoticaPostLowPtElectron +
+    hltExoticaPostLowPtElectron +
     # Photon paths
     hltExoticaPostHighPtPhoton +
     hltExoticaPostDiPhoton +

--- a/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
@@ -50,7 +50,7 @@ hltExoticaValidator = cms.EDAnalyzer(
     # -- The name of the analysis. This is the name that
     # appears in Run summary/Exotica/ANALYSIS_NAME
 
-    analysis       = cms.vstring(
+    analyses       = cms.vstring(
         "LowPtTrimuon",
         "HighPtDimuon",
         "HighPtDielectron",

--- a/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
@@ -20,7 +20,7 @@ from HLTriggerOffline.Exotica.analyses.hltExoticaHighPtDielectron_cff  import Hi
 from HLTriggerOffline.Exotica.analyses.hltExoticaLowPtDimuon_cff       import LowPtDimuonPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaLowPtDielectron_cff   import LowPtDielectronPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaHighPtElectron_cff    import HighPtElectronPSet
-#from HLTriggerOffline.Exotica.analyses.hltExoticaLowPtElectron_cff     import LowPtElectronPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaLowPtElectron_cff     import LowPtElectronPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaHighPtPhoton_cff      import HighPtPhotonPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaDiPhoton_cff          import DiPhotonPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaPFHT_cff              import PFHTPSet
@@ -57,7 +57,7 @@ hltExoticaValidator = cms.EDAnalyzer(
         "LowPtDimuon",
         "LowPtDielectron",
         "HighPtElectron",
-        #"LowPtElectron",
+        "LowPtElectron",
         "HighPtPhoton",
         "DiPhoton",
         "SingleMuon",
@@ -210,7 +210,7 @@ hltExoticaValidator = cms.EDAnalyzer(
     LowPtDimuon      = LowPtDimuonPSet,
     LowPtDielectron  = LowPtDielectronPSet,
     HighPtElectron   = HighPtElectronPSet,
-    #LowPtElectron    = LowPtElectronPSet,
+    LowPtElectron    = LowPtElectronPSet,
     HighPtPhoton     = HighPtPhotonPSet,                                 
     DiPhoton         = DiPhotonPSet,                                 
     SingleMuon       = SingleMuonPSet,

--- a/HLTriggerOffline/Exotica/src/HLTExoticaValidator.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaValidator.cc
@@ -21,7 +21,7 @@
 // Constructor
 HLTExoticaValidator::HLTExoticaValidator(const edm::ParameterSet& pset) :
     _pset(pset),
-    _analysisnames(pset.getParameter<std::vector<std::string> >("analysis")),
+    _analysisnames(pset.getParameter<std::vector<std::string> >("analyses")),
     _collections(nullptr)
 {
 

--- a/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
@@ -179,7 +179,7 @@ if NminOneCuts:
     for iCut in range(0,len(NminOneCuts)):
         if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
             X4b_plot_types.append(NminOneCutNames[iCut])
-hltHiggsPostX4b = make_higgs_postprocessor("X4b", plot_types=X4b_plot_types, object_types=["Jet"])
+hltHiggsPostX4b = make_higgs_postprocessor("X4b", plot_types=X4b_plot_types, object_types=["Jet"], extra_str_templates=[truevtx_string_template])
 
 #Specific plots for WH -> ev + bb
 hltHiggsPostWHToENuBB = make_higgs_postprocessor("WHToENuBB", extra_str_templates=[truevtx_string_template, TTHbbej_HtDist_template])
@@ -192,7 +192,7 @@ if NminOneCuts:
     for iCut in range(0,len(NminOneCuts)):
         if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
             MSSMHbb_plot_types.append(NminOneCutNames[iCut])
-hltHiggsPostMSSMHbb = make_higgs_postprocessor("MSSMHbb", plot_types=MSSMHbb_plot_types, object_types=["Jet"])
+hltHiggsPostMSSMHbb = make_higgs_postprocessor("MSSMHbb", plot_types=MSSMHbb_plot_types, object_types=["Jet"], extra_str_templates=[truevtx_string_template])
 
 #Specific plots for MSSMHbbmu
 MSSMHbbmu_plot_types = ["EffEta", "EffPhi", "TurnOn1"]
@@ -201,7 +201,7 @@ if NminOneCuts:
     for iCut in range(0,len(NminOneCuts)):
         if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
             MSSMHbbmu_plot_types.append(NminOneCutNames[iCut])
-hltHiggsPostMSSMHbbmu = make_higgs_postprocessor("MSSMHbbmu", plot_types=MSSMHbbmu_plot_types, object_types=["Jet"])
+hltHiggsPostMSSMHbbmu = make_higgs_postprocessor("MSSMHbbmu", plot_types=MSSMHbbmu_plot_types, object_types=["Jet"], extra_str_templates=[truevtx_string_template])
 
 hltHiggsPostProcessors = cms.Sequence(
         hltHiggsPostHWW+

--- a/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
@@ -106,7 +106,7 @@ def make_higgs_postprocessor(analysis_name, plot_types=["TurnOn1", "TurnOn2", "E
                 efficiency_strings.append(this_efficiency_string.replace("Generated", "Reconstructed").replace("Gen", "Reco").replace("gen", "rec"))
 
                 for str_template in extra_str_templates:
-                    this_extra_string = str_template.replace("@AN@", analysis_name).replace("@TRIGGER@", trigger)
+                    this_extra_string = str_template.replace("@ANALYSIS@", analysis_name).replace("@TRIGGER@", trigger)
                     efficiency_strings.append(this_extra_string)
                     efficiency_strings.append(this_extra_string.replace("Generated", "Reconstructed").replace("Gen", "Reco").replace("gen", "rec"))
 
@@ -126,7 +126,7 @@ hltHiggsPostH2tau = make_higgs_postprocessor("H2tau", extra_str_templates=[truev
 hltHiggsPostHtaunu = make_higgs_postprocessor("Htaunu", extra_str_templates=[truevtx_string_template])
 hltHiggsPostVBFHToInv = make_higgs_postprocessor("VBFHToInv", extra_str_templates=[truevtx_string_template])
 
-TTHbbej_HtDist_template = "Eff_HtDist_@ANALYSIS@_gen_@TRIGGER ' Efficiency of @TRIGGER vs sum pT of jets ; sum pT of jets ' HtDist_@ANALYSIS@_gen_@TRIGGER HtDist_@ANALYSIS@_gen"
+TTHbbej_HtDist_template = "Eff_HtDist_@ANALYSIS@_gen_@TRIGGER@ ' Efficiency of @TRIGGER@ vs sum pT of jets ; sum pT of jets ' HtDist_@ANALYSIS@_gen_@TRIGGER@ HtDist_@ANALYSIS@_gen"
 hltHiggsPostTTHbbej = make_higgs_postprocessor("TTHbbej", extra_str_templates=[truevtx_string_template, TTHbbej_HtDist_template])
 hltHiggsPostAHttH = make_higgs_postprocessor("AHttH", extra_str_templates=[truevtx_string_template, TTHbbej_HtDist_template])
 
@@ -141,7 +141,7 @@ if NminOneCuts:
             if( NminOneCutNames[iCut] == "EffmaxCSV" ):
                 VBFHbb_2btag_plot_types.pop()
             VBFHbb_2btag_plot_types.append(NminOneCutNames[iCut])
-hltHiggsPostVBFHbb_2btag = make_higgs_postprocessor("VBFHbb_2btag", object_types=["Jet"], plot_types=VBFHbb_2btag_plot_types)
+hltHiggsPostVBFHbb_2btag = make_higgs_postprocessor("VBFHbb_2btag", object_types=["Jet"], plot_types=VBFHbb_2btag_plot_types, extra_str_templates=[truevtx_string_template])
 
 #Specific plots for VBFHbb_1btag  
 #dEtaqq, mqq, dPhibb, CVS1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
@@ -153,7 +153,7 @@ if NminOneCuts:
             if( NminOneCutNames[iCut] == "EffmaxCSV" ):
                 VBFHbb_1btag_plot_types.pop()
             VBFHbb_1btag_plot_types.append(NminOneCutNames[iCut])
-hltHiggsPostVBFHbb_1btag = make_higgs_postprocessor("VBFHbb_1btag", plot_types=VBFHbb_1btag_plot_types, object_types=["Jet"])
+hltHiggsPostVBFHbb_1btag = make_higgs_postprocessor("VBFHbb_1btag", plot_types=VBFHbb_1btag_plot_types, object_types=["Jet"], extra_str_templates=[truevtx_string_template])
 
 #Specific plots for VBFHbb_0btag  
 #dEtaqq, mqq, dPhibb, CVS1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
@@ -165,7 +165,7 @@ if NminOneCuts:
             if( NminOneCutNames[iCut] == "EffmaxCSV" ):
                 VBFHbb_0btag_plot_types.pop()
             VBFHbb_0btag_plot_types.append(NminOneCutNames[iCut])
-hltHiggsPostVBFHbb_0btag = make_higgs_postprocessor("VBFHbb_0btag", plot_types=VBFHbb_0btag_plot_types, object_types=["Jet"])
+hltHiggsPostVBFHbb_0btag = make_higgs_postprocessor("VBFHbb_0btag", plot_types=VBFHbb_0btag_plot_types, object_types=["Jet"], extra_str_templates=[truevtx_string_template])
 
 
 #Specific plots for ZnnHbb
@@ -175,7 +175,7 @@ if NminOneCuts:
     for iCut in range(0,len(NminOneCuts)):
         if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
             ZnnHbb_plot_types.append(NminOneCutNames[iCut])
-hltHiggsPostZnnHbb = make_higgs_postprocessor("ZnnHbb", plot_types=["EffEta", "EffPhi", "TurnOn1"], object_types=["Jet", "PFMet"])
+hltHiggsPostZnnHbb = make_higgs_postprocessor("ZnnHbb", plot_types=ZnnHbb_plot_types, object_types=["Jet", "PFMET"], extra_str_templates=[truevtx_string_template])
 
 #Specific plots for X4b
 #Jet plots

--- a/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from HLTriggerOffline.Higgs.hltHiggsPostProcessor_cfi import *
 
 # Build the standard strings to the DQM
-def efficiency_string(objtype,plot_type,triggerpath):
+def make_efficiency_string(objtype,plot_type,triggerpath):
     # --- IMPORTANT: Add here a elif if you are introduce a new collection
     #                (see EVTColContainer::getTypeString) 
     if objtype == "Mu":
@@ -81,312 +81,148 @@ def efficiency_string(objtype,plot_type,triggerpath):
     return "Eff_%s_%s '%s' %s_%s %s" % (input_type,triggerpath,
             all_titles,input_type,triggerpath,input_type)
 
-# Adding the reco objects
-def get_reco_strings(strings):
-    reco_strings = []
-    for entry in strings:
-        reco_strings.append(entry
-                            .replace("Generated", "Reconstructed")
-                            .replace("Gen", "Reco")
-                            .replace("gen", "rec"))
-    return reco_strings
 
-
-plot_types = ["TurnOn1", "TurnOn2", "EffEta", "EffPhi"]
+#plot_types = ["TurnOn1", "TurnOn2", "EffEta", "EffPhi"]
 #--- IMPORTANT: Update this collection whenever you introduce a new object
 #               in the code (from EVTColContainer::getTypeString)
-obj_types  = ["Mu","Ele","Photon","MET","PFMET","PFTau","Jet"]
+#obj_types  = ["Mu","Ele","Photon","MET","PFMET","PFTau","Jet"]
 #--- IMPORTANT: Trigger are extracted from the hltHiggsValidator_cfi.py module
-triggers = [] 
-efficiency_strings = []
 
-# Extract the triggers used in the hltHiggsValidator 
 from HLTriggerOffline.Higgs.hltHiggsValidator_cfi import hltHiggsValidator as _config
-triggers = set([])
-for an in _config.analysis:
-    s = _config.__getattribute__(an)
-    vstr = s.__getattribute__("hltPathsToCheck")
-    map(lambda x: triggers.add(x.replace("_v","")),vstr)
-triggers = list(triggers)
+def make_higgs_postprocessor(analysis_name, plot_types=["TurnOn1", "TurnOn2", "EffEta", "EffPhi"], object_types=["Mu","Ele","Photon","MET","PFMET","PFTau","Jet"], extra_str_templates=[]):
+    postprocessor = hltHiggsPostProcessor.clone()
+    postprocessor.subDirs = ["HLT/Higgs/" + analysis_name]
+    efficiency_strings = [] # List of plots to look for. This is quite a bit larger than the number of plots that will be made.
 
-#------------------------------------------------------------
+    efficiency_summary_string = "EffSummaryPaths_" + analysis_name + "_gen ' Efficiency of paths used in " + analysis_name + " ; trigger path ' SummaryPaths_" + analysis_name + "_gen_passingHLT SummaryPaths_" + analysis_name + "_gen"
+    efficiency_strings.append(efficiency_summary_string)
+    efficiency_strings.append(efficiency_summary_string.replace("Generated", "Reconstructed").replace("Gen", "Reco").replace("gen", "rec"))
 
-# Generating the list with all the efficiencies
-for type in plot_types:
-    for obj in obj_types:
-        for trig in triggers:
-            efficiency_strings.append(efficiency_string(obj,type,trig))
+    for plot_type in plot_types:
+        for object_type in object_types:
+            for trigger in [x.replace("_v", "") for x in _config.__getattribute__(analysis_name).hltPathsToCheck]:
+                this_efficiency_string = make_efficiency_string(object_type, plot_type, trigger)
+                efficiency_strings.append(this_efficiency_string)
+                efficiency_strings.append(this_efficiency_string.replace("Generated", "Reconstructed").replace("Gen", "Reco").replace("gen", "rec"))
 
+                for str_template in extra_str_templates:
+                    this_extra_string = str_template.replace("@AN@", analysis_name).replace("@TRIGGER@", trigger)
+                    efficiency_strings.append(this_extra_string)
+                    efficiency_strings.append(this_extra_string.replace("Generated", "Reconstructed").replace("Gen", "Reco").replace("gen", "rec"))
 
-#add the summary plots
-efficiency_summary_strings = []
-for an in _config.analysis:
-    efficiency_summary_strings.append("EffSummaryPaths_"+an+"_gen ' Efficiency of paths used in "+an+" ; trigger path ' SummaryPaths_"+an+"_gen_passingHLT SummaryPaths_"+an+"_gen")
-    for trig in triggers:
-        efficiency_summary_strings.append("Eff_trueVtxDist_"+an+"_gen_"+trig+" ' Efficiency of "+trig+" vs nb of interactions ; nb events passing each path ' trueVtxDist_"+an+"_gen_"+trig+" trueVtxDist_"+an+"_gen")
+    postprocessor.efficiencyProfile = efficiency_strings
+    return postprocessor
 
-efficiency_strings.extend(efficiency_summary_strings)
-efficiency_strings.extend(get_reco_strings(efficiency_strings))
+truevtx_string_template = "Eff_trueVtxDist_@ANALYSIS@_gen_@TRIGGER@ ' Efficiency of @TRIGGER@ vs nb of interactions ; nb events passing each path ' trueVtxDist_@ANALYSIS@_gen_@TRIGGER@ trueVtxDist_@ANALYSIS@_gen"
+hltHiggsPostHWW = make_higgs_postprocessor("HWW", extra_str_templates=[truevtx_string_template])
+hltHiggsPostHZZControlPaths = make_higgs_postprocessor("HZZControlPaths", extra_str_templates=[truevtx_string_template])
+hltHiggsPostHZZ = make_higgs_postprocessor("HZZ", extra_str_templates=[truevtx_string_template])
+hltHiggsPostHgg = make_higgs_postprocessor("Hgg", extra_str_templates=[truevtx_string_template])
+#hltHiggsPostHggControlPaths = make_higgs_postprocessor("HggControlPaths", extra_str_templates=[truevtx_string_template])
+hltHiggsPostMuonJet = make_higgs_postprocessor("MuonJet", extra_str_templates=[truevtx_string_template])
+hltHiggsPostDoubleHinTaus = make_higgs_postprocessor("DoubleHinTaus", extra_str_templates=[truevtx_string_template])
+hltHiggsPostHiggsDalitz = make_higgs_postprocessor("HiggsDalitz", extra_str_templates=[truevtx_string_template])
+hltHiggsPostH2tau = make_higgs_postprocessor("H2tau", extra_str_templates=[truevtx_string_template])
+hltHiggsPostHtaunu = make_higgs_postprocessor("Htaunu", extra_str_templates=[truevtx_string_template])
+hltHiggsPostVBFHToInv = make_higgs_postprocessor("VBFHToInv", extra_str_templates=[truevtx_string_template])
 
-hltHiggsPostHWW = hltHiggsPostProcessor.clone()
-hltHiggsPostHWW.subDirs = ['HLT/Higgs/HWW']
-hltHiggsPostHWW.efficiencyProfile = efficiency_strings
-
-hltHiggsPostHZZControlPaths = hltHiggsPostProcessor.clone()
-hltHiggsPostHZZControlPaths.subDirs = ['HLT/Higgs/HZZControlPaths']
-hltHiggsPostHZZControlPaths.efficiencyProfile = efficiency_strings
-
-hltHiggsPostHZZ = hltHiggsPostProcessor.clone()
-hltHiggsPostHZZ.subDirs = ['HLT/Higgs/HZZ']
-hltHiggsPostHZZ.efficiencyProfile = efficiency_strings
-
-hltHiggsPostHgg = hltHiggsPostProcessor.clone()
-hltHiggsPostHgg.subDirs = ['HLT/Higgs/Hgg']
-hltHiggsPostHgg.efficiencyProfile = efficiency_strings
-
-hltHiggsPostHggControlPaths = hltHiggsPostProcessor.clone()
-hltHiggsPostHggControlPaths.subDirs = ['HLT/Higgs/HggControlPaths']
-hltHiggsPostHggControlPaths.efficiencyProfile = efficiency_strings
-
-hltHiggsPostMuonJet = hltHiggsPostProcessor.clone()
-hltHiggsPostMuonJet.subDirs = ['HLT/Higgs/MuonJet']
-hltHiggsPostMuonJet.efficiencyProfile = efficiency_strings
-
-hltHiggsPostDoubleHinTaus = hltHiggsPostProcessor.clone()
-hltHiggsPostDoubleHinTaus.subDirs = ['HLT/Higgs/DoubleHinTaus']
-hltHiggsPostDoubleHinTaus.efficiencyProfile = efficiency_strings
-
-hltHiggsPostHiggsDalitz = hltHiggsPostProcessor.clone()
-hltHiggsPostHiggsDalitz.subDirs = ['HLT/Higgs/HiggsDalitz']
-hltHiggsPostHiggsDalitz.efficiencyProfile = efficiency_strings
-
-hltHiggsPostH2tau = hltHiggsPostProcessor.clone()
-hltHiggsPostH2tau.subDirs = ['HLT/Higgs/H2tau']
-hltHiggsPostH2tau.efficiencyProfile = efficiency_strings
-
-hltHiggsPostHtaunu = hltHiggsPostProcessor.clone()
-hltHiggsPostHtaunu.subDirs = ['HLT/Higgs/Htaunu']
-hltHiggsPostHtaunu.efficiencyProfile = efficiency_strings
-
-hltHiggsPostVBFHToInv = hltHiggsPostProcessor.clone()
-hltHiggsPostVBFHToInv.subDirs = ['HLT/Higgs/VBFHToInv']
-hltHiggsPostVBFHToInv.efficiencyProfile = efficiency_strings
-
-
-efficiency_strings_TTHbbej = []
-#add the summary plots
-for an in _config.analysis:
-    for trig in triggers:
-        efficiency_strings_TTHbbej.append("Eff_HtDist_"+an+"_gen_"+trig+" ' Efficiency of "+trig+" vs sum pT of jets ; sum pT of jets ' HtDist_"+an+"_gen_"+trig+" HtDist_"+an+"_gen")
-
-efficiency_strings_TTHbbej.extend(get_reco_strings(efficiency_strings_TTHbbej))
-efficiency_strings_TTHbbej.extend(efficiency_strings)
-
-hltHiggsPostTTHbbej = hltHiggsPostProcessor.clone()
-hltHiggsPostTTHbbej.subDirs = ['HLT/Higgs/TTHbbej']
-hltHiggsPostTTHbbej.efficiencyProfile = efficiency_strings_TTHbbej
-
-hltHiggsPostAHttH = hltHiggsPostProcessor.clone()
-hltHiggsPostAHttH.subDirs = ['HLT/Higgs/AHttH']
-hltHiggsPostAHttH.efficiencyProfile = efficiency_strings
+TTHbbej_HtDist_template = "Eff_HtDist_@ANALYSIS@_gen_@TRIGGER ' Efficiency of @TRIGGER vs sum pT of jets ; sum pT of jets ' HtDist_@ANALYSIS@_gen_@TRIGGER HtDist_@ANALYSIS@_gen"
+hltHiggsPostTTHbbej = make_higgs_postprocessor("TTHbbej", extra_str_templates=[truevtx_string_template, TTHbbej_HtDist_template])
+hltHiggsPostAHttH = make_higgs_postprocessor("AHttH", extra_str_templates=[truevtx_string_template, TTHbbej_HtDist_template])
 
 #Specific plots for VBFHbb_2btag  
 #dEtaqq, mqq, dPhibb, CVS1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
 NminOneCutNames = ("EffdEtaqq", "Effmqq", "EffdPhibb", "EffCSV1", "EffCSV2", "EffCSV3",  "EffmaxCSV", "", "", "TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4")
-plot_types = []
+VBFHbb_2btag_plot_types = []
 NminOneCuts =_config.VBFHbb_2btag.NminOneCuts
 if NminOneCuts: 
     for iCut in range(0,len(NminOneCuts)):
         if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
             if( NminOneCutNames[iCut] == "EffmaxCSV" ):
-                plot_types.pop()
-            plot_types.append(NminOneCutNames[iCut])
-
-efficiency_strings = []
-for type in plot_types:
-    for obj in ["Jet"]:
-        for trig in triggers:
-            efficiency_strings.append(efficiency_string(obj,type,trig))
-
-efficiency_strings = get_reco_strings(efficiency_strings)
-efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
-
-hltHiggsPostVBFHbb2btag = hltHiggsPostProcessor.clone()
-hltHiggsPostVBFHbb2btag.subDirs = ['HLT/Higgs/VBFHbb_2btag']
-hltHiggsPostVBFHbb2btag.efficiencyProfile = efficiency_strings
+                VBFHbb_2btag_plot_types.pop()
+            VBFHbb_2btag_plot_types.append(NminOneCutNames[iCut])
+hltHiggsPostVBFHbb_2btag = make_higgs_postprocessor("VBFHbb_2btag", object_types=["Jet"], plot_types=VBFHbb_2btag_plot_types)
 
 #Specific plots for VBFHbb_1btag  
 #dEtaqq, mqq, dPhibb, CVS1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
-plot_types = []
+VBFHbb_1btag_plot_types = []
 NminOneCuts = _config.VBFHbb_1btag.NminOneCuts
 if NminOneCuts: 
     for iCut in range(0,len(NminOneCuts)):
         if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
             if( NminOneCutNames[iCut] == "EffmaxCSV" ):
-                plot_types.pop()
-            plot_types.append(NminOneCutNames[iCut])
-                       
-efficiency_strings = []
-for type in plot_types:
-    for obj in ["Jet"]:
-        for trig in triggers:
-            efficiency_strings.append(efficiency_string(obj,type,trig))
-
-efficiency_strings = get_reco_strings(efficiency_strings)
-efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
-    
-hltHiggsPostVBFHbb1btag = hltHiggsPostProcessor.clone()
-hltHiggsPostVBFHbb1btag.subDirs = ['HLT/Higgs/VBFHbb_1btag']
-hltHiggsPostVBFHbb1btag.efficiencyProfile = efficiency_strings
+                VBFHbb_1btag_plot_types.pop()
+            VBFHbb_1btag_plot_types.append(NminOneCutNames[iCut])
+hltHiggsPostVBFHbb_1btag = make_higgs_postprocessor("VBFHbb_1btag", plot_types=VBFHbb_1btag_plot_types, object_types=["Jet"])
 
 #Specific plots for VBFHbb_0btag  
 #dEtaqq, mqq, dPhibb, CVS1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
-plot_types = []
+VBFHbb_0btag_plot_types = []
 NminOneCuts = _config.VBFHbb_0btag.NminOneCuts
 if NminOneCuts: 
     for iCut in range(0,len(NminOneCuts)):
         if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
             if( NminOneCutNames[iCut] == "EffmaxCSV" ):
-                plot_types.pop()
-            plot_types.append(NminOneCutNames[iCut])
-
-efficiency_strings = []
-for type in plot_types:
-    for obj in ["Jet"]:
-        for trig in triggers:
-            efficiency_strings.append(efficiency_string(obj,type,trig))
-
-efficiency_strings = get_reco_strings(efficiency_strings)
-efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
-
-hltHiggsPostVBFHbb0btag = hltHiggsPostProcessor.clone()
-hltHiggsPostVBFHbb0btag.subDirs = ['HLT/Higgs/VBFHbb_0btag']
-hltHiggsPostVBFHbb0btag.efficiencyProfile = efficiency_strings
+                VBFHbb_0btag_plot_types.pop()
+            VBFHbb_0btag_plot_types.append(NminOneCutNames[iCut])
+hltHiggsPostVBFHbb_0btag = make_higgs_postprocessor("VBFHbb_0btag", plot_types=VBFHbb_0btag_plot_types, object_types=["Jet"])
 
 
 #Specific plots for ZnnHbb
-#Jet plots
-plot_types = ["EffEta", "EffPhi"]
+ZnnHbb_plot_types = ["EffEta", "EffPhi", "TurnOn1"]
 NminOneCuts = _config.ZnnHbb.NminOneCuts
 if NminOneCuts: 
     for iCut in range(0,len(NminOneCuts)):
         if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
-            plot_types.append(NminOneCutNames[iCut])
-    
-efficiency_strings = []
-for type in plot_types:
-    for obj in ["Jet"]:
-        for trig in triggers:
-            efficiency_strings.append(efficiency_string(obj,type,trig))
-        
-efficiency_strings = get_reco_strings(efficiency_strings)
-
-#PFMET plots
-plot_types = ["TurnOn1", "EffPhi"]
-efficiency_strings2 = []
-for type in plot_types:
-    for obj in ["PFMET"]:
-        for trig in triggers:
-            efficiency_strings2.append(efficiency_string(obj,type,trig))
-
-efficiency_strings2 = get_reco_strings(efficiency_strings2)
-efficiency_strings += efficiency_strings2
-efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
-    
-hltHiggsPostZnnHbb = hltHiggsPostProcessor.clone()
-hltHiggsPostZnnHbb.subDirs = ['HLT/Higgs/ZnnHbb']
-hltHiggsPostZnnHbb.efficiencyProfile = efficiency_strings
-
+            ZnnHbb_plot_types.append(NminOneCutNames[iCut])
+hltHiggsPostZnnHbb = make_higgs_postprocessor("ZnnHbb", plot_types=["EffEta", "EffPhi", "TurnOn1"], object_types=["Jet", "PFMet"])
 
 #Specific plots for X4b
 #Jet plots
+X4b_plot_types = ["EffEta", "EffPhi", "TurnOn1"]
 NminOneCuts = _config.X4b.NminOneCuts
 if NminOneCuts: 
     for iCut in range(0,len(NminOneCuts)):
         if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
-            plot_types.append(NminOneCutNames[iCut])
-
-efficiency_strings = []
-for type in plot_types:
-    for obj in ["Jet"]:
-        for trig in triggers:
-            efficiency_strings.append(efficiency_string(obj,type,trig))
-        
-efficiency_strings = get_reco_strings(efficiency_strings)
-efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
-
-hltHiggsPostX4b = hltHiggsPostProcessor.clone()
-hltHiggsPostX4b.subDirs = ['HLT/Higgs/X4b']
-hltHiggsPostX4b.efficiencyProfile = efficiency_strings
+            X4b_plot_types.append(NminOneCutNames[iCut])
+hltHiggsPostX4b = make_higgs_postprocessor("X4b", plot_types=X4b_plot_types, object_types=["Jet"])
 
 #Specific plots for WH -> ev + bb
-efficiency_strings_WHToENuBB = list(efficiency_strings_TTHbbej)
-#add the summary plots
-for an in _config.analysis:
-    for trig in triggers:
-        efficiency_strings_WHToENuBB.append("Eff_HtDist_"+an+"_gen_"+trig+" ' Efficiency of "+trig+" vs sum pT of jets ; sum pT of jets ' HtDist_"+an+"_gen_"+trig+" HtDist_"+an+"_gen")
-
-efficiency_strings_WHToENuBB.extend(get_reco_strings(efficiency_strings_WHToENuBB))
-
-hltHiggsPostWHToENuBB = hltHiggsPostProcessor.clone()
-hltHiggsPostWHToENuBB.subDirs = ['HLT/Higgs/WHToENuBB']
-hltHiggsPostWHToENuBB.efficiencyProfile = efficiency_strings_WHToENuBB
+hltHiggsPostWHToENuBB = make_higgs_postprocessor("WHToENuBB", extra_str_templates=[truevtx_string_template, TTHbbej_HtDist_template])
 
 #Specific plots for MSSMHbb 
 #Jet plots
+MSSMHbb_plot_types = ["EffEta", "EffPhi", "TurnOn1"]
 NminOneCuts = _config.MSSMHbb.NminOneCuts
 if NminOneCuts:
     for iCut in range(0,len(NminOneCuts)):
         if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
-            plot_types.append(NminOneCutNames[iCut])
-
-efficiency_strings = []
-for type in plot_types:
-    for obj in ["Jet"]:
-        for trig in triggers:
-            efficiency_strings.append(efficiency_string(obj,type,trig))
-
-efficiency_strings = get_reco_strings(efficiency_strings)
-efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
-
-hltHiggsPostMSSMHbb = hltHiggsPostProcessor.clone()
-hltHiggsPostMSSMHbb.subDirs = ['HLT/Higgs/MSSMHbb']
-hltHiggsPostMSSMHbb.efficiencyProfile = efficiency_strings
+            MSSMHbb_plot_types.append(NminOneCutNames[iCut])
+hltHiggsPostMSSMHbb = make_higgs_postprocessor("MSSMHbb", plot_types=MSSMHbb_plot_types, object_types=["Jet"])
 
 #Specific plots for MSSMHbbmu
+MSSMHbbmu_plot_types = ["EffEta", "EffPhi", "TurnOn1"]
 NminOneCuts = _config.MSSMHbbmu.NminOneCuts
 if NminOneCuts:
     for iCut in range(0,len(NminOneCuts)):
         if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
-            plot_types.append(NminOneCutNames[iCut])
-
-efficiency_strings = []
-for type in plot_types:
-    for obj in ["Jet"]:
-        for trig in triggers:
-            efficiency_strings.append(efficiency_string(obj,type,trig))
-
-efficiency_strings = get_reco_strings(efficiency_strings)
-efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
-hltHiggsPostMSSMHbbmu = hltHiggsPostProcessor.clone()
-hltHiggsPostMSSMHbbmu.subDirs = ['HLT/Higgs/MSSMHbbmu']
-hltHiggsPostMSSMHbbmu.efficiencyProfile = efficiency_strings
-
+            MSSMHbbmu_plot_types.append(NminOneCutNames[iCut])
+hltHiggsPostMSSMHbbmu = make_higgs_postprocessor("MSSMHbbmu", plot_types=MSSMHbbmu_plot_types, object_types=["Jet"])
 
 hltHiggsPostProcessors = cms.Sequence(
         hltHiggsPostHWW+
         hltHiggsPostHZZ+
-	hltHiggsPostHZZControlPaths+
+        hltHiggsPostHZZControlPaths+
         hltHiggsPostHgg+
-        hltHiggsPostHggControlPaths+
+        #hltHiggsPostHggControlPaths+
         hltHiggsPostMuonJet+
         hltHiggsPostHtaunu+
         hltHiggsPostH2tau+
         hltHiggsPostTTHbbej+
         hltHiggsPostAHttH+
-        hltHiggsPostVBFHbb0btag+
-        hltHiggsPostVBFHbb1btag+
-        hltHiggsPostVBFHbb2btag+
+        hltHiggsPostVBFHbb_0btag+
+        hltHiggsPostVBFHbb_1btag+
+        hltHiggsPostVBFHbb_2btag+
         hltHiggsPostZnnHbb+
         hltHiggsPostDoubleHinTaus+
         hltHiggsPostHiggsDalitz+

--- a/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
@@ -81,13 +81,7 @@ def make_efficiency_string(objtype,plot_type,triggerpath):
     return "Eff_%s_%s '%s' %s_%s %s" % (input_type,triggerpath,
             all_titles,input_type,triggerpath,input_type)
 
-
-#plot_types = ["TurnOn1", "TurnOn2", "EffEta", "EffPhi"]
-#--- IMPORTANT: Update this collection whenever you introduce a new object
-#               in the code (from EVTColContainer::getTypeString)
-#obj_types  = ["Mu","Ele","Photon","MET","PFMET","PFTau","Jet"]
 #--- IMPORTANT: Trigger are extracted from the hltHiggsValidator_cfi.py module
-
 from HLTriggerOffline.Higgs.hltHiggsValidator_cfi import hltHiggsValidator as _config
 def make_higgs_postprocessor(analysis_name, plot_types=["TurnOn1", "TurnOn2", "EffEta", "EffPhi"], object_types=["Mu","Ele","Photon","MET","PFMET","PFTau","Jet"], extra_str_templates=[]):
     postprocessor = hltHiggsPostProcessor.clone()

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         
     hltProcessName = cms.string("HLT"),
-    analysis       = cms.vstring("HWW", "HZZ", "HZZControlPaths", "MuonJet", "Hgg", "Htaunu", "H2tau", "VBFHbb_0btag", "VBFHbb_1btag", "VBFHbb_2btag",  "ZnnHbb","DoubleHinTaus","HiggsDalitz","X4b","TTHbbej","AHttH","WHToENuBB","MSSMHbb","MSSMHbbmu","VBFHToInv"),
+    analyses       = cms.vstring("HWW", "HZZ", "HZZControlPaths", "MuonJet", "Hgg", "Htaunu", "H2tau", "VBFHbb_0btag", "VBFHbb_1btag", "VBFHbb_2btag",  "ZnnHbb","DoubleHinTaus","HiggsDalitz","X4b","TTHbbej","AHttH","WHToENuBB","MSSMHbb","MSSMHbbmu","VBFHToInv"),
     histDirectory  = cms.string("HLT/Higgs"),
     
     # -- The instance name of the reco::GenParticles collection 

--- a/HLTriggerOffline/Higgs/src/HLTHiggsValidator.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsValidator.cc
@@ -23,7 +23,7 @@
 // Constructor
 HLTHiggsValidator::HLTHiggsValidator(const edm::ParameterSet& pset) :
         _pset(pset),
-    _analysisnames(pset.getParameter<std::vector<std::string> >("analysis")),
+    _analysisnames(pset.getParameter<std::vector<std::string> >("analyses")),
     _collections(nullptr)
 {
     _collections = new EVTColContainer;

--- a/HLTriggerOffline/SMP/python/hltSMPPostProcessors_cff.py
+++ b/HLTriggerOffline/SMP/python/hltSMPPostProcessors_cff.py
@@ -63,7 +63,7 @@ def make_smp_postprocessor(analysis_name, plot_types=["TurnOn1", "TurnOn2", "Eff
                 efficiency_strings.append(this_efficiency_string.replace("Generated", "Reconstructed").replace("Gen", "Reco").replace("gen", "rec"))
 
                 for str_template in extra_str_templates:
-                    this_extra_string = str_template.replace("@AN@", analysis_name).replace("@TRIGGER@", trigger)
+                    this_extra_string = str_template.replace("@ANALYSIS@", analysis_name).replace("@TRIGGER@", trigger)
                     efficiency_strings.append(this_extra_string)
                     efficiency_strings.append(this_extra_string.replace("Generated", "Reconstructed").replace("Gen", "Reco").replace("gen", "rec"))
 

--- a/HLTriggerOffline/SMP/python/hltSMPPostProcessors_cff.py
+++ b/HLTriggerOffline/SMP/python/hltSMPPostProcessors_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from HLTriggerOffline.SMP.hltSMPPostProcessor_cfi import *
 
 # Build the standard strings to the DQM
-def efficiency_string(objtype,plot_type,triggerpath):
+def make_efficiency_string(objtype,plot_type,triggerpath):
     # --- IMPORTANT: Add here a elif if you are introduce a new collection
     #                (see EVTColContainer::getTypeString) 
     if objtype == "Mu" :
@@ -45,63 +45,46 @@ def efficiency_string(objtype,plot_type,triggerpath):
     return "Eff_%s_%s '%s' %s_%s %s" % (input_type,triggerpath,
                 all_titles,input_type,triggerpath,input_type)
 
-# Adding the reco objects
-def add_reco_strings(strings):
-    reco_strings = []
-    for entry in strings:
-        reco_strings.append(entry
-                            .replace("Generated", "Reconstructed")
-                            .replace("Gen", "Reco")
-                            .replace("gen", "rec"))
-    strings.extend(reco_strings)
+from HLTriggerOffline.SMP.hltSMPValidator_cfi import hltSMPValidator as _config
+def make_smp_postprocessor(analysis_name, plot_types=["TurnOn1", "TurnOn2", "EffEta", "EffPhi"], object_types=["Mu","Ele","Photon","MET","PFMET","PFTau","Jet"], extra_str_templates=[]):
+    postprocessor = hltSMPPostProcessor.clone()
+    postprocessor.subDirs = ["HLT/SMP/" + analysis_name]
+    efficiency_strings = [] # List of plots to look for. This is quite a bit larger than the number of plots that will be made.
+
+    efficiency_summary_string = "EffSummaryPaths_" + analysis_name + "_gen ' Efficiency of paths used in " + analysis_name + " ; trigger path ' SummaryPaths_" + analysis_name + "_gen_passingHLT SummaryPaths_" + analysis_name + "_gen"
+    efficiency_strings.append(efficiency_summary_string)
+    efficiency_strings.append(efficiency_summary_string.replace("Generated", "Reconstructed").replace("Gen", "Reco").replace("gen", "rec"))
+
+    for plot_type in plot_types:
+        for object_type in object_types:
+            for trigger in [x.replace("_v", "") for x in _config.__getattribute__(analysis_name).hltPathsToCheck]:
+                this_efficiency_string = make_efficiency_string(object_type, plot_type, trigger)
+                efficiency_strings.append(this_efficiency_string)
+                efficiency_strings.append(this_efficiency_string.replace("Generated", "Reconstructed").replace("Gen", "Reco").replace("gen", "rec"))
+
+                for str_template in extra_str_templates:
+                    this_extra_string = str_template.replace("@AN@", analysis_name).replace("@TRIGGER@", trigger)
+                    efficiency_strings.append(this_extra_string)
+                    efficiency_strings.append(this_extra_string.replace("Generated", "Reconstructed").replace("Gen", "Reco").replace("gen", "rec"))
+
+    postprocessor.efficiencyProfile = efficiency_strings
+    return postprocessor
 
 
 plot_types = ["TurnOn1", "TurnOn2", "EffEta", "EffPhi"]
 #--- IMPORTANT: Update this collection whenever you introduce a new object
 #               in the code (from EVTColContainer::getTypeString)
-obj_types  = ["Mu","Ele","Photon","MET","PFTau"]
-#--- IMPORTANT: Trigger are extracted from the hltSMPValidator_cfi.py module
-triggers = [ ] 
-efficiency_strings = []
-
-# Extract the triggers used in the hltSMPValidator 
-from HLTriggerOffline.SMP.hltSMPValidator_cfi import hltSMPValidator as _config
-triggers = set([])
-for an in _config.analysis:
-  s = _config.__getattribute__(an)
-  vstr = s.__getattribute__("hltPathsToCheck")
-  map(lambda x: triggers.add(x.replace("_v","")),vstr)
-triggers = list(triggers)
-#------------------------------------------------------------
-
-# Generating the list with all the efficiencies
-for type in plot_types:
-    for obj in obj_types:
-        for trig in triggers:
-            efficiency_strings.append(efficiency_string(obj,type,trig))
+object_types  = ["Mu","Ele","Photon","MET","PFTau"]
+truevtx_string_template = "Eff_trueVtxDist_@ANALYSIS@_gen_@TRIGGER@ ' Efficiency of @TRIGGER@ vs nb of interactions ; nb events passing each path ' trueVtxDist_@ANALYSIS@_gen_@TRIGGER@ trueVtxDist_@ANALYSIS@_gen"
 
 
-#add the summary plots
-for an in _config.analysis:
-    efficiency_strings.append("EffSummaryPaths_"+an+"_gen ' Efficiency of paths used in "+an+" ; trigger path ' SummaryPaths_"+an+"_gen_passingHLT SummaryPaths_"+an+"_gen")
-    for trig in triggers:
-        efficiency_strings.append("Eff_trueVtxDist_"+an+"_gen_"+trig+" ' Efficiency of "+trig+" vs nb of interactions ; nb events passing each path ' trueVtxDist_"+an+"_gen_"+trig+" trueVtxDist_"+an+"_gen")
-
-add_reco_strings(efficiency_strings)
-
-
-
-hltSMPPostSingleEle = hltSMPPostProcessor.clone()
-hltSMPPostSingleEle.subDirs = ['HLT/SMP/SingleEle']
-hltSMPPostSingleEle.efficiencyProfile = efficiency_strings
+hltSMPPostSingleEle = make_smp_postprocessor("SingleEle", plot_types=plot_types, object_types=object_types, extra_str_templates=[truevtx_string_template])
+#hltSMPPostSingleMu = make_smp_postprocessor("SingleMu", plot_types=plot_types, object_types=object_types, extra_str_templates=[truevtx_string_template])
+hltSMPPostSinglePhoton = make_smp_postprocessor("SinglePhoton", plot_types=plot_types, object_types=object_types, extra_str_templates=[truevtx_string_template])
 
 # hltSMPPostSingleMu = hltSMPPostProcessor.clone()
 # hltSMPPostSingleMu.subDirs = ['HLT/SMP/SingleMu']
 # hltSMPPostSingleMu.efficiencyProfile = efficiency_strings
-
-hltSMPPostSinglePhoton = hltSMPPostProcessor.clone()
-hltSMPPostSinglePhoton.subDirs = ['HLT/SMP/SinglePhoton']
-hltSMPPostSinglePhoton.efficiencyProfile = efficiency_strings
 
 hltSMPPostProcessors = cms.Sequence(
     hltSMPPostSingleEle+

--- a/HLTriggerOffline/SMP/python/hltSMPValidator_cfi.py
+++ b/HLTriggerOffline/SMP/python/hltSMPValidator_cfi.py
@@ -5,7 +5,7 @@ hltSMPValidator = cms.EDAnalyzer("HLTHiggsValidator",
 		
     hltProcessName = cms.string("HLT"),
     histDirectory  = cms.string("HLT/SMP"),
-    analysis       = cms.vstring("SinglePhoton","SingleEle"),
+    analyses       = cms.vstring("SinglePhoton","SingleEle"),
     
     # -- The instance name of the reco::GenParticles collection
     genParticleLabel = cms.string("genParticles"),


### PR DESCRIPTION
This is the 9_4_X version of https://github.com/cms-sw/cmssw/pull/21387.

Following up on https://github.com/cms-sw/cmssw/pull/21239, this PR reduces the large number of efficiency strings generated by the HLT harvesting configurations (Exotica, Higgs, and SMP). The large number corresponds to:
[all analyses] * [all triggers] * [all object types] * [all plot types]

I reduced the strings by only using the actual analysis-trigger combinations, rather than compiling all of the triggers into a single giant list. I also moved the creation of the postprocessors to functions, e.g. `make_exo_postprocessor()`.

For Exotica and SMP, the changes were relatively trivial, but hltHiggsPostProcessors_cff.py was much more involved... the lists used in the `for` loops were repeated re-initialized and appended to at random points in the code, making it very difficult to figure out what was going on. I ran some runTheMatrix tests to make sure I didn't accidentally remove any plots, but this might merit more scrutiny. Feedback would be welcome, if anyone has a suggestion for how to do this systematically. 