### PR TITLE
Replace fastSim.isChosen() with toModify/toReplaceWith/makeProcessModifier

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -107,11 +107,10 @@ from PhysicsTools.NanoAOD.NanoAODEDMEventContent_cff import *
 from FastSimulation.Configuration.EventContent_cff import FASTPUEventContent
 import FastSimulation.Configuration.EventContent_cff as fastSimEC
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    RecoLocalTrackerRECO.outputCommands = fastSimEC.RecoLocalTracker.outputCommands
-    RecoLocalTrackerFEVT.outputCommands = fastSimEC.RecoLocalTracker.outputCommands
-    SimG4CoreRAW = fastSimEC.SimRAW
-    SimG4CoreRECO = fastSimEC.SimRECO
+fastSim.toModify(RecoLocalTrackerRECO, outputCommands = fastSimEC.RecoLocalTracker.outputCommands)
+fastSim.toModify(RecoLocalTrackerFEVT, outputCommands = fastSimEC.RecoLocalTracker.outputCommands)
+fastSim.toReplaceWith(SimG4CoreRAW, fastSimEC.SimRAW)
+fastSim.toReplaceWith(SimG4CoreRECO, fastSimEC.SimRECO)
 
 #
 #
@@ -526,8 +525,7 @@ PREMIXEventContent.outputCommands.append('keep PixelDigiSimLinkedmDetSetVector_s
 PREMIXEventContent.outputCommands.append('keep StripDigiSimLinkedmDetSetVector_simMuonCSCDigis_*_*')
 PREMIXEventContent.outputCommands.append('keep RPCDigiSimLinkedmDetSetVector_*_*_*')
 PREMIXEventContent.outputCommands.append('keep DTLayerIdDTDigiSimLinkMuonDigiCollection_*_*_*')
-if fastSim.isChosen():
-    PREMIXEventContent.outputCommands.extend(fastSimEC.extraPremixContent)
+fastSim.toModify(PREMIXEventContent, outputCommands = PREMIXEventContent.outputCommands+fastSimEC.extraPremixContent)
 
 from Configuration.Eras.Modifier_hcalSkipPacker_cff import hcalSkipPacker
 hcalSkipPacker.toModify(PREMIXEventContent.outputCommands,
@@ -544,8 +542,7 @@ PREMIXRAWEventContent.outputCommands.append('keep *_*_MuonCSCStripDigiSimLinks_*
 PREMIXRAWEventContent.outputCommands.append('keep *_*_MuonCSCWireDigiSimLinks_*')
 PREMIXRAWEventContent.outputCommands.append('keep *_*_RPCDigiSimLink_*')
 PREMIXRAWEventContent.outputCommands.append('keep DTLayerIdDTDigiSimLinkMuonDigiCollection_*_*_*')
-if fastSim.isChosen():
-    PREMIXEventContent.outputCommands.extend(fastSimEC.extraPremixContent)
+fastSim.toModify(PREMIXEventContent, outputCommands = PREMIXEventContent.outputCommands+fastSimEC.extraPremixContent)
 
 REPACKRAWSIMEventContent.outputCommands.extend(REPACKRAWEventContent.outputCommands)
 REPACKRAWSIMEventContent.outputCommands.extend(SimG4CoreRAW.outputCommands)
@@ -841,11 +838,10 @@ RAWAODSIMEventContent.outputCommands.extend(SimG4CoreHLTAODSIM.outputCommands)
 
 # in fastsim, normal digis are edaliases of simdigis
 # drop the simdigis to avoid complaints from the outputmodule related to duplicated branches
-if fastSim.isChosen():
-    for _entry in [FEVTDEBUGHLTEventContent,FEVTDEBUGEventContent,RECOSIMEventContent,AODSIMEventContent,RAWAODSIMEventContent]:
-        fastSimEC.dropSimDigis(_entry.outputCommands)
-    for _entry in [MINIAODEventContent, MINIAODSIMEventContent]:
-        fastSimEC.dropPatTrigger(_entry.outputCommands)
+for _entry in [FEVTDEBUGHLTEventContent,FEVTDEBUGEventContent,RECOSIMEventContent,AODSIMEventContent,RAWAODSIMEventContent]:
+    fastSim.toModify(_entry, outputCommands = _entry.outputCommands + fastSimEC.dropSimDigis)
+for _entry in [MINIAODEventContent, MINIAODSIMEventContent]:
+    fastSim.toModify(_entry, outputCommands = _entry.outputCommands + fastSimEC.dropPatTrigger)
 
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
+++ b/Configuration/StandardSequences/python/DataMixerPreMix_cff.py
@@ -64,9 +64,9 @@ from SimGeneral.PileupInformation.AddPileupSummaryPreMixed_cfi import *
 pdatamix = cms.Sequence(mixData+postDMDigi+addPileupInfo)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
+def _fastSimDigis(process):
     # pretend these digis have been through digi2raw and raw2digi, by using the approprate aliases
     # use an alias to make the mixed track collection available under the usual label
     from FastSimulation.Configuration.DigiAliases_cff import loadDigiAliases
-    loadDigiAliases(premix = True)
-    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis
+    loadDigiAliases(process, premix=True)
+modifyDataMixerPreMix_fastSimDigis = fastSim.makeProcessModifier(_fastSimDigis)

--- a/Configuration/StandardSequences/python/DigiToRawPreMixing_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRawPreMixing_cff.py
@@ -40,6 +40,4 @@ from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([rpcpacker]))
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen() :
-    for _entry in [siPixelRawData,SiStripDigiToRaw,castorRawData]:
-        DigiToRaw.remove(_entry)
+fastSim.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([siPixelRawData,SiStripDigiToRaw,castorRawData]))

--- a/Configuration/StandardSequences/python/DigiToRaw_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_cff.py
@@ -39,6 +39,4 @@ from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([rpcpacker]))
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen() :
-    for _entry in [siPixelRawData,SiStripDigiToRaw,castorRawData]:
-        DigiToRaw.remove(_entry)
+fastSim.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([siPixelRawData,SiStripDigiToRaw,castorRawData]))

--- a/Configuration/StandardSequences/python/Digi_PreMix_cff.py
+++ b/Configuration/StandardSequences/python/Digi_PreMix_cff.py
@@ -24,10 +24,9 @@ pdigi.remove(simEcalPreshowerDigis)
 hcalDigiSequence.remove(simHcalTriggerPrimitiveDigis)
 hcalDigiSequence.remove(simHcalTTPDigis)
 
-from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    # no need for the aliases for usual mixing
-    del generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis
+# no need for the aliases for usual mixing
+import FastSimulation.Configuration.DigiAliases_cff as _fastSim_DigiAliases_cff
+_fastSim_DigiAliases_cff._enableDigiAliases = False
 #else:
 #no need for this hack running at Nebraska
 ##hack - our code is too fast at large scale - lets slow it down and idle for 15 seconds

--- a/Configuration/StandardSequences/python/Digi_cff.py
+++ b/Configuration/StandardSequences/python/Digi_cff.py
@@ -41,12 +41,14 @@ pdigi_hi=cms.Sequence(pdigi+heavyIon)
 pdigi_hi_nogen=cms.Sequence(pdigi_nogen+heavyIon)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
+def _fastSimDigis(process):
+    import FastSimulation.Configuration.DigiAliases_cff as DigiAliases
+
     # pretend these digis have been through digi2raw and raw2digi, by using the approprate aliases
     # use an alias to make the mixed track collection available under the usual label
     from FastSimulation.Configuration.DigiAliases_cff import loadDigiAliases
-    loadDigiAliases(premix = False)
-    from FastSimulation.Configuration.DigiAliases_cff import generalTracks,ecalPreshowerDigis,ecalDigis,hcalDigis,muonDTDigis,muonCSCDigis,muonRPCDigis
+    loadDigiAliases(process)
+modifyDigi_fastSimDigis = fastSim.makeProcessModifier(_fastSimDigis)
 
 #phase 2 common mods
 def _modifyEnableHcalHardcode( theProcess ):

--- a/Configuration/StandardSequences/python/SimL1EmulatorPreMix_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorPreMix_cff.py
@@ -9,10 +9,9 @@ SimL1Emulator.remove(SimL1TGlobal)
 
 # make trigger digis available under with the raw2digi names
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
+def _fastSimTriggerDigis(process):
     # pretend these digis have been through digi2raw and to the HLT internal raw2digi, by using the approprate aliases
     # consider moving these mods to the HLT configuration
     from FastSimulation.Configuration.DigiAliases_cff import loadTriggerDigiAliases
-    loadTriggerDigiAliases()
-    from FastSimulation.Configuration.DigiAliases_cff import gtDigis,gmtDigis,gctDigis,caloStage1LegacyFormatDigis
-    
+    loadTriggerDigiAliases(process)
+modifySimL1EmulatorPreMix_fastSimTriggerDigis = fastSim.makeProcessModifier(_fastSimTriggerDigis)

--- a/Configuration/StandardSequences/python/SimL1Emulator_cff.py
+++ b/Configuration/StandardSequences/python/SimL1Emulator_cff.py
@@ -4,10 +4,9 @@ from L1Trigger.Configuration.SimL1Emulator_cff import *
 
 # make trigger digis available under with the raw2digi names
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
+def _fastSimTriggerDigis(process):
     # pretend these digis have been through digi2raw and to the HLT internal raw2digi, by using the approprate aliases
     # consider moving these mods to the HLT configuration
     from FastSimulation.Configuration.DigiAliases_cff import loadTriggerDigiAliases
-    loadTriggerDigiAliases()
-    from FastSimulation.Configuration.DigiAliases_cff import gtDigis,gmtDigis,gctDigis,caloStage1LegacyFormatDigis
-    
+    loadTriggerDigiAliases(process)
+modifySimL1Emulator_fastSimTriggerDigis = fastSim.makeProcessModifier(_fastSimTriggerDigis)

--- a/FastSimulation/Configuration/python/EventContent_cff.py
+++ b/FastSimulation/Configuration/python/EventContent_cff.py
@@ -1,13 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
-def dropPatTrigger(outputCommands):
-    print 'dropping patTrigger'
-    outputCommands.append("drop *_*patTrigger*_*_*")
-    outputCommands.append("drop *_*PatTrigger*_*_*")
+dropPatTrigger = [
+    "drop *_*patTrigger*_*_*",
+    "drop *_*PatTrigger*_*_*"
+]
 
-def dropSimDigis(outputCommands):
-    outputCommands.append("drop *_sim*Digis*_*_*")
-    outputCommands.append("drop *_gmtDigis*_*_*")
+dropSimDigis = [
+    "drop *_sim*Digis*_*_*",
+    "drop *_gmtDigis*_*_*"
+]
  
 extraPremixContent = ['keep *_mix_generalTracks_*']
 

--- a/HLTriggerOffline/Btag/python/HltBtagValidation_cff.py
+++ b/HLTriggerOffline/Btag/python/HltBtagValidation_cff.py
@@ -78,8 +78,7 @@ hltbtagValidationSequence = cms.Sequence(
 
 # fastsim customs
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    HltVertexValidationVertices.SimVertexCollection = cms.InputTag("famosSimHits")
+fastSim.toModify(HltVertexValidationVertices, SimVertexCollection = "famosSimHits")
     # are these customs actually needed?
     #HltVertexValidationVertices.HLTPathNames =cms.vstring(
     #'HLT_PFMET120_NoiseCleaned_BTagCSV07_v',

--- a/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
@@ -44,13 +44,14 @@ from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 
 # fastsim customs
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    hltpostvalidation.remove(postProcessorHLTtrackingSequence)
-    hltpostvalidation.remove(postProcessorHLTvertexing)
-    hltpostvalidation.remove(postProcessorHLTgsfTrackingSequence)
-    hltpostvalidation.remove(postProcessorHLTmuonTrackingSequence)
-    # remove this:     +hltvalidationqt ?
-    # remove this:    +hltExoticaPostProcessors ?
+fastSim.toReplaceWith(hltpostvalidation, hltpostvalidation.copyAndExclude([
+    postProcessorHLTtrackingSequence,
+    postProcessorHLTvertexing,
+    postProcessorHLTgsfTrackingSequence,
+    postProcessorHLTmuonTrackingSequence
+    # remove this:    hltvalidationqt ?
+    # remove this:    hltExoticaPostProcessors ?
+]))
     
 hltpostvalidation_preprod = cms.Sequence( 
     postProcessorHLTtrackingSequence

--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -75,11 +75,12 @@ hltvalidation = cms.Sequence(
 # remove the dependent modules for now
 # probably it would be rather easy to add or fake these collections
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    hltassociation.remove(hltMultiTrackValidation)
-    hltassociation.remove(hltMultiPVValidation)
-    hltassociation.remove(hltMultiTrackValidationGsfTracks)
-    hltassociation.remove(hltMultiTrackValidationMuonTracks)
+fastSim.toReplaceWith(hltassociation, hltassociation.copyAndExclude([
+    hltMultiTrackValidation,
+    hltMultiPVValidation,
+    hltMultiTrackValidationGsfTracks,
+    hltMultiTrackValidationMuonTracks,
+]))
 
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 pp_on_XeXe_2017.toReplaceWith(hltvalidation, hltvalidation.copyAndExclude([HiggsValidationSequence]))

--- a/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
@@ -59,13 +59,8 @@ fastSim.toReplaceWith(generalTracksSequence,
         )
 )
 def _fastSimGeneralTracks(process):
-    from FastSimulation.Configuration.DigiAliases_cff import loadDigiAliasesWasCalled
-    if loadDigiAliasesWasCalled:
-        from FastSimulation.Configuration.DigiAliases_cff import generalTracks
-        process.generalTracks = generalTracks
-        return
-    from Configuration.StandardSequences.Digi_cff import generalTracks
-    process.generalTracks = generalTracks
+    from FastSimulation.Configuration.DigiAliases_cff import loadGeneralTracksAlias
+    loadGeneralTracksAlias(process)
 modifyMergeTrackCollections_fastSimGeneralTracks = fastSim.makeProcessModifier( _fastSimGeneralTracks )
 
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi

--- a/SimCalorimetry/Configuration/python/SimCalorimetry_cff.py
+++ b/SimCalorimetry/Configuration/python/SimCalorimetry_cff.py
@@ -7,5 +7,4 @@ calDigi = cms.Sequence(ecalDigiSequence+hcalDigiSequence+castorDigiSequence)
 
 # fastsim has no castor model
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    calDigi.remove(castorDigiSequence)
+fastSim.toReplaceWith(calDigi, calDigi.copyAndExclude([castorDigiSequence]))

--- a/SimGeneral/DataMixingModule/python/mixOne_simraw_on_sim_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_simraw_on_sim_cfi.py
@@ -258,11 +258,12 @@ mixData.doEE = cms.bool(True)
 mixData.doES = cms.bool(True)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
+from FastSimulation.Tracking.recoTrackAccumulator_cfi import recoTrackAccumulator as _recoTrackAccumulator
+fastSim.toModify(mixData,
     # from signal: mix tracks not strip or pixel digis
-    mixData.TrackerMergeType = "tracks"
-    import FastSimulation.Tracking.recoTrackAccumulator_cfi
-    mixData.tracker = FastSimulation.Tracking.recoTrackAccumulator_cfi.recoTrackAccumulator.clone()
-    mixData.tracker.pileUpTracks = cms.InputTag("mix","generalTracks")
-    mixData.hitsProducer = "famosSimHits"
-
+    TrackerMergeType = "tracks",
+    tracker = _recoTrackAccumulator.clone(
+        pileUpTracks = "mix:generalTracks"
+    ),
+    hitsProducer = "famosSimHits"
+)

--- a/SimGeneral/MixingModule/python/caloTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/caloTruthProducer_cfi.py
@@ -31,5 +31,4 @@ caloParticles = cms.PSet(
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    caloParticles = cms.PSet() # don't allow this to run in fastsim
+fastSim.toReplaceWith(caloParticles, cms.PSet()) # don't allow this to run in fastsim

--- a/SimGeneral/MixingModule/python/digi_MixPreMix_cfi.py
+++ b/SimGeneral/MixingModule/python/digi_MixPreMix_cfi.py
@@ -32,12 +32,13 @@ theDigitizersMixPreMix.strip.FedAlgorithm = cms.int32(5) # special ZS mode: acce
 theDigitizersMixPreMix.pixel.AddPixelInefficiency = cms.bool(False) # will be added in DataMixer    
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
+fastSim.toModify(theDigitizersMixPreMix,
     # fastsim does not model castor
-    delattr(theDigitizersMixPreMix,"castor")
+    castor = None,
     # fastsim does not digitize pixel and strip hits
-    delattr(theDigitizersMixPreMix,"pixel")
-    delattr(theDigitizersMixPreMix,"strip")
+    pixel = None,
+    strip = None
+)
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify( theDigitizersMixPreMix, castor = None )

--- a/SimGeneral/MixingModule/python/digitizers_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizers_cfi.py
@@ -37,13 +37,14 @@ theDigitizers = cms.PSet(
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
+fastSim.toModify(theDigitizers,
     # fastsim does not model castor
-    delattr(theDigitizers,"castor")
+    castor = None,
     # fastsim does not digitize pixel and strip hits
-    delattr(theDigitizers,"pixel")
-    delattr(theDigitizers,"strip")
-    setattr(theDigitizers,"tracks",recoTrackAccumulator)
+    pixel = None,
+    strip = None,
+    tracks = recoTrackAccumulator
+)
 
 
 from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchebackDigitizer, hgchefrontDigitizer 

--- a/SimGeneral/MixingModule/python/ecalDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/ecalDigitizer_cfi.py
@@ -22,8 +22,7 @@ ecalDigitizer = cms.PSet(
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    ecalDigitizer.hitsProducer = cms.string("famosSimHits")
+fastSim.toModify(ecalDigitizer, hitsProducer = "famosSimHits")
     
 ecalDigitizer.doEB = cms.bool(True)
 ecalDigitizer.doEE = cms.bool(True)

--- a/SimGeneral/MixingModule/python/mixObjects_cfi.py
+++ b/SimGeneral/MixingModule/python/mixObjects_cfi.py
@@ -51,17 +51,16 @@ mixSimHits = cms.PSet(
 
 # fastsim customs
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    mixSimHits.input = cms.VInputTag(
-        cms.InputTag("MuonSimHits","MuonCSCHits"), 
-        cms.InputTag("MuonSimHits","MuonDTHits"), 
-        cms.InputTag("MuonSimHits","MuonRPCHits"), 
-        cms.InputTag("famosSimHits","TrackerHits"))
-    mixSimHits.subdets = cms.vstring(
-        'MuonCSCHits', 
-        'MuonDTHits', 
-        'MuonRPCHits', 
-        'TrackerHits')
+fastSim.toModify(mixSimHits,
+    input = ["MuonSimHits:MuonCSCHits", 
+             "MuonSimHits:MuonDTHits", 
+             "MuonSimHits:MuonRPCHits", 
+             "famosSimHits:TrackerHits"],
+    subdets = ['MuonCSCHits', 
+               'MuonDTHits', 
+               'MuonRPCHits', 
+               'TrackerHits']
+)
 
 mixCaloHits = cms.PSet(
     input = cms.VInputTag(  # note that this list needs to be in the same order as the subdets
@@ -89,17 +88,16 @@ mixCaloHits = cms.PSet(
 )
 
 # fastsim customs
-if fastSim.isChosen():
-    mixCaloHits.input = cms.VInputTag(
-        cms.InputTag("famosSimHits","EcalHitsEB"), 
-        cms.InputTag("famosSimHits","EcalHitsEE"), 
-        cms.InputTag("famosSimHits","EcalHitsES"), 
-        cms.InputTag("famosSimHits","HcalHits"))
-    mixCaloHits.subdets = cms.vstring(
-        'EcalHitsEB', 
-        'EcalHitsEE', 
-        'EcalHitsES', 
-        'HcalHits')
+fastSim.toModify(mixCaloHits,
+    input = ["famosSimHits:EcalHitsEB",
+             "famosSimHits:EcalHitsEE",
+             "famosSimHits:EcalHitsES",
+             "famosSimHits:HcalHits"],
+    subdets = ['EcalHitsEB',
+               'EcalHitsEE',
+               'EcalHitsES',
+               'HcalHits']
+)
 
 
 mixSimTracks = cms.PSet(
@@ -114,9 +112,8 @@ mixSimVertices = cms.PSet(
 )
 
 # fastsim customs
-if fastSim.isChosen():
-    mixSimTracks.input = cms.VInputTag(cms.InputTag("famosSimHits"))
-    mixSimVertices.input = cms.VInputTag(cms.InputTag("famosSimHits"))
+fastSim.toModify(mixSimTracks, input = ["famosSimHits"])
+fastSim.toModify(mixSimVertices, input = ["famosSimHits"])
     
 mixHepMCProducts = cms.PSet(
     makeCrossingFrame = cms.untracked.bool(True),
@@ -149,11 +146,7 @@ theMixObjects = cms.PSet(
 )
 
 # fastsim customs
-if fastSim.isChosen():
-    theMixObjects = cms.PSet(
-        theMixObjects,
-        mixRecoTracks = cms.PSet(mixReconstructedTracks)
-        )
+fastSim.toModify(theMixObjects, mixRecoTracks = cms.PSet(mixReconstructedTracks))
     
 mixPCFSimHits = cms.PSet(
     input = cms.VInputTag(cms.InputTag("CFWriter","g4SimHitsBSCHits"), cms.InputTag("CFWriter","g4SimHitsBCM1FHits"), cms.InputTag("CFWriter","g4SimHitsPLTHits"), cms.InputTag("CFWriter","g4SimHitsFP420SI"), cms.InputTag("CFWriter","g4SimHitsMuonCSCHits"), cms.InputTag("CFWriter","g4SimHitsMuonDTHits"), cms.InputTag("CFWriter","g4SimHitsMuonRPCHits"), 

--- a/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
@@ -38,18 +38,19 @@ trackingParticles = cms.PSet(
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
+fastSim.toModify(trackingParticles,
     # for unknown reasons, fastsim needs this flag on
-    trackingParticles.allowDifferentSimHitProcesses = True
+    allowDifferentSimHitProcesses = True,
     # fastsim labels for simhits, simtracks, simvertices
-    trackingParticles.simHitCollections = cms.PSet(
+    simHitCollections = cms.PSet(
         muon = cms.VInputTag( cms.InputTag('MuonSimHits','MuonDTHits'),
                               cms.InputTag('MuonSimHits','MuonCSCHits'),
                               cms.InputTag('MuonSimHits','MuonRPCHits') ),
         trackerAndPixel = cms.VInputTag( cms.InputTag('famosSimHits','TrackerHits') )
-        )
-    trackingParticles.simTrackCollection = cms.InputTag('famosSimHits')
-    trackingParticles.simVertexCollection = cms.InputTag('famosSimHits')
+    ),
+    simTrackCollection = 'famosSimHits',
+    simVertexCollection = 'famosSimHits'
+)
 
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 run2_GEM_2017.toModify(trackingParticles, simHitCollections = dict(

--- a/SimGeneral/TrackingAnalysis/python/simHitTPAssociation_cfi.py
+++ b/SimGeneral/TrackingAnalysis/python/simHitTPAssociation_cfi.py
@@ -23,9 +23,9 @@ from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(simHitTPAssocProducer, simHitSrc = ["g4SimHits:TrackerHitsPixelBarrelLowTof", "g4SimHits:TrackerHitsPixelEndcapLowTof"])
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    simHitTPAssocProducer.simHitSrc = cms.VInputTag(cms.InputTag('famosSimHits','TrackerHits'),
-                                                    cms.InputTag("MuonSimHits","MuonCSCHits"),
-                                                    cms.InputTag("MuonSimHits","MuonDTHits"),
-                                                    cms.InputTag("MuonSimHits","MuonRPCHits"))
-
+fastSim.toModify(simHitTPAssocProducer,
+    simHitSrc = ["famosSimHits:TrackerHits",
+                 "MuonSimHits:MuonCSCHits",
+                 "MuonSimHits:MuonDTHits",
+                 "MuonSimHits:MuonRPCHits"]
+)

--- a/SimMuon/CSCDigitizer/python/muonCSCDigis_cfi.py
+++ b/SimMuon/CSCDigitizer/python/muonCSCDigis_cfi.py
@@ -89,5 +89,4 @@ run2_common.toModify( simMuonCSCDigis.strips, bunchTimingOffsets=[0.0, 37.53, 37
 run2_common.toModify( simMuonCSCDigis.wires, bunchTimingOffsets=[0.0, 22.88, 22.55, 29.28, 30.0, 30.0, 30.5, 31.0, 29.5, 29.1, 29.88] )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    simMuonCSCDigis.InputCollection = 'MuonSimHitsMuonCSCHits'
+fastSim.toModify(simMuonCSCDigis, InputCollection = 'MuonSimHitsMuonCSCHits')

--- a/SimMuon/DTDigitizer/python/muonDTDigis_cfi.py
+++ b/SimMuon/DTDigitizer/python/muonDTDigis_cfi.py
@@ -38,7 +38,6 @@ simMuonDTDigis = cms.EDProducer("DTDigitizer",
 
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    simMuonDTDigis.InputCollection = 'MuonSimHitsMuonDTHits'
+fastSim.toModify(simMuonDTDigis, InputCollection = 'MuonSimHitsMuonDTHits')
     
 

--- a/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
+++ b/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
@@ -96,19 +96,17 @@ muonAssociatorByHitsCommonParameters = cms.PSet(
 
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-#if True:
-    obj = muonAssociatorByHitsCommonParameters
-    obj.simtracksTag = "famosSimHits"
-    obj.DTsimhitsTag  = "MuonSimHits:MuonDTHits"
-    obj.CSCsimHitsTag = "MuonSimHits:MuonCSCHits"
-    obj.RPCsimhitsTag = "MuonSimHits:MuonRPCHits"
-    obj.simtracksXFTag = "mix:famosSimHits"
-    obj.DTsimhitsXFTag  = "mix:MuonSimHitsMuonDTHits"
-    obj.CSCsimHitsXFTag = "mix:MuonSimHitsMuonCSCHits"
-    obj.RPCsimhitsXFTag = "mix:MuonSimHitsMuonRPCHits"
-    obj.ROUList = ['famosSimHitsTrackerHits']
-
+fastSim.toModify(muonAssociatorByHitsCommonParameters,
+    simtracksTag = "famosSimHits",
+    DTsimhitsTag  = "MuonSimHits:MuonDTHits",
+    CSCsimHitsTag = "MuonSimHits:MuonCSCHits",
+    RPCsimhitsTag = "MuonSimHits:MuonRPCHits",
+    simtracksXFTag = "mix:famosSimHits",
+    DTsimhitsXFTag  = "mix:MuonSimHitsMuonDTHits",
+    CSCsimHitsXFTag = "mix:MuonSimHitsMuonCSCHits",
+    RPCsimhitsXFTag = "mix:MuonSimHitsMuonRPCHits",
+    ROUList = ['famosSimHitsTrackerHits']
+)
   
 muonAssociatorByHits = cms.EDProducer("MuonAssociatorEDProducer",
     # COMMON CONFIGURATION

--- a/SimMuon/MCTruth/python/NewMuonAssociatorByHits_cfi.py
+++ b/SimMuon/MCTruth/python/NewMuonAssociatorByHits_cfi.py
@@ -96,19 +96,17 @@ NewMuonAssociatorByHitsCommonParameters = cms.PSet(
 
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-#if True:
-    obj = NewMuonAssociatorByHitsCommonParameters
-    obj.simtracksTag = "famosSimHits"
-    obj.DTsimhitsTag  = "MuonSimHits:MuonDTHits"
-    obj.CSCsimHitsTag = "MuonSimHits:MuonCSCHits"
-    obj.RPCsimhitsTag = "MuonSimHits:MuonRPCHits"
-    obj.simtracksXFTag = "mix:famosSimHits"
-    obj.DTsimhitsXFTag  = "mix:MuonSimHitsMuonDTHits"
-    obj.CSCsimHitsXFTag = "mix:MuonSimHitsMuonCSCHits"
-    obj.RPCsimhitsXFTag = "mix:MuonSimHitsMuonRPCHits"
-    obj.ROUList = ['famosSimHitsTrackerHits']
-
+fastSim.toModify(NewMuonAssociatorByHitsCommonParameters,
+    simtracksTag = "famosSimHits",
+    DTsimhitsTag  = "MuonSimHits:MuonDTHits",
+    CSCsimHitsTag = "MuonSimHits:MuonCSCHits",
+    RPCsimhitsTag = "MuonSimHits:MuonRPCHits",
+    simtracksXFTag = "mix:famosSimHits",
+    DTsimhitsXFTag  = "mix:MuonSimHitsMuonDTHits",
+    CSCsimHitsXFTag = "mix:MuonSimHitsMuonCSCHits",
+    RPCsimhitsXFTag = "mix:MuonSimHitsMuonRPCHits",
+    ROUList = ['famosSimHitsTrackerHits']
+)
   
 NewMuonAssociatorByHits = cms.EDProducer("MuonAssociatorEDProducer",
     # COMMON CONFIGURATION

--- a/SimTracker/TrackAssociatorProducers/python/quickTrackAssociatorByHits_cfi.py
+++ b/SimTracker/TrackAssociatorProducers/python/quickTrackAssociatorByHits_cfi.py
@@ -17,10 +17,11 @@ quickTrackAssociatorByHits = cms.EDProducer("QuickTrackAssociatorByHitsProducer"
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    quickTrackAssociatorByHits.associateStrip = False
-    quickTrackAssociatorByHits.associatePixel = False
-    quickTrackAssociatorByHits.useClusterTPAssociation = False
+fastSim.toModify(quickTrackAssociatorByHits,
+    associateStrip = False,
+    associatePixel = False,
+    useClusterTPAssociation = False
+)
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify( 

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -99,17 +99,13 @@ globalValidation = cms.Sequence(   trackerHitsValidation
 
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
+fastSim.toReplaceWith(globalValidation, globalValidation.copyAndExclude([
     # fastsim has no tracker digis and different tracker rechit and simhit structure => skipp
-    globalValidation.remove(trackerHitsValidation)
-    globalValidation.remove(trackerDigisValidation)
-    globalValidation.remove(trackerRecHitsValidation)
-    globalValidation.remove(trackingRecHitsValid)
-    # globalValidation.remove(mixCollectionValidation) # can be put back, once mixing is migrated to fastsim era
+    trackerHitsValidation, trackerDigisValidation, trackerRecHitsValidation, trackingRecHitsValid,
     # the following depends on crossing frame of ecal simhits, which is a bit hard to implement in the fastsim workflow
     # besides: is this cross frame doing something, or is it a relic from the past?
-    globalValidation.remove(ecalDigisValidationSequence)
-    globalValidation.remove(ecalRecHitsValidationSequence)
+    ecalDigisValidationSequence, ecalRecHitsValidationSequence
+]))
 
 #lite tracking validator to be used in the Validation matrix
 #lite validation

--- a/Validation/DTRecHits/python/DTRecHitQualityAll_cfi.py
+++ b/Validation/DTRecHits/python/DTRecHitQualityAll_cfi.py
@@ -53,9 +53,7 @@ dtLocalRecoValidation = cms.Sequence(rechivalidation*seg2dvalidation*seg2dsuperp
 dtLocalRecoValidation_no2D = cms.Sequence(rechivalidation*seg2dsuperphivalidation*seg4dvalidation)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    rechivalidation.simHitLabel = cms.untracked.InputTag("MuonSimHits","MuonDTHits")
-    seg2dvalidation.simHitLabel = cms.untracked.InputTag("MuonSimHits","MuonDTHits")
-    seg2dsuperphivalidation.simHitLabel = cms.untracked.InputTag("MuonSimHits","MuonDTHits")
-    seg4dvalidation.simHitLabel = cms.untracked.InputTag("MuonSimHits","MuonDTHits")
-    
+fastSim.toModify(rechivalidation, simHitLabel = "MuonSimHits:MuonDTHits")
+fastSim.toModify(seg2dvalidation, simHitLabel = "MuonSimHits:MuonDTHits")
+fastSim.toModify(seg2dsuperphivalidation, simHitLabel = "MuonSimHits:MuonDTHits")
+fastSim.toModify(seg4dvalidation, simHitLabel = "MuonSimHits:MuonDTHits")

--- a/Validation/DTRecHits/python/DTRecHitQuality_cfi.py
+++ b/Validation/DTRecHits/python/DTRecHitQuality_cfi.py
@@ -53,8 +53,7 @@ dtLocalRecoValidation = cms.Sequence(rechivalidation*seg2dvalidation*seg2dsuperp
 dtLocalRecoValidation_no2D = cms.Sequence(rechivalidation*seg2dsuperphivalidation*seg4dvalidation)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    rechivalidation.simHitLabel = cms.untracked.InputTag("MuonSimHits","MuonDTHits")
-    seg2dvalidation.simHitLabel = cms.untracked.InputTag("MuonSimHits","MuonDTHits")
-    seg2dsuperphivalidation.simHitLabel = cms.untracked.InputTag("MuonSimHits","MuonDTHits")
-    seg4dvalidation.simHitLabel = cms.untracked.InputTag("MuonSimHits","MuonDTHits")
+fastSim.toModify(rechivalidation, simHitLabel = "MuonSimHits:MuonDTHits")
+fastSim.toModify(seg2dvalidation, simHitLabel = "MuonSimHits:MuonDTHits")
+fastSim.toModify(seg2dsuperphivalidation, simHitLabel = "MuonSimHits:MuonDTHits")
+fastSim.toModify(seg4dvalidation, simHitLabel = "MuonSimHits:MuonDTHits")

--- a/Validation/EcalDigis/python/ecalDigisValidation_cfi.py
+++ b/Validation/EcalDigis/python/ecalDigisValidation_cfi.py
@@ -11,7 +11,4 @@ ecalDigisValidation = cms.EDAnalyzer("EcalDigisValidation",
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    ecalDigisValidation.moduleLabelG4 = cms.string('famosSimHits')
-
-
+fastSim.toModify(ecalDigisValidation, moduleLabelG4 = 'famosSimHits')

--- a/Validation/EcalDigis/python/ecalSelectiveReadoutValidation_cfi.py
+++ b/Validation/EcalDigis/python/ecalSelectiveReadoutValidation_cfi.py
@@ -86,5 +86,5 @@ ecalSelectiveReadoutValidation = cms.EDAnalyzer("EcalSelectiveReadoutValidation"
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify(ecalSelectiveReadoutValidation,
     EbSimHitCollection = "famosSimHits:EcalHitsEB",
-    EeSimHitCollection = "famosSimHits;EcalHitsEE"
+    EeSimHitCollection = "famosSimHits:EcalHitsEE"
 )

--- a/Validation/EcalDigis/python/ecalSelectiveReadoutValidation_cfi.py
+++ b/Validation/EcalDigis/python/ecalSelectiveReadoutValidation_cfi.py
@@ -84,6 +84,7 @@ ecalSelectiveReadoutValidation = cms.EDAnalyzer("EcalSelectiveReadoutValidation"
 
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    ecalSelectiveReadoutValidation.EbSimHitCollection = cms.InputTag("famosSimHits","EcalHitsEB")
-    ecalSelectiveReadoutValidation.EeSimHitCollection = cms.InputTag("famosSimHits","EcalHitsEE")
+fastSim.toModify(ecalSelectiveReadoutValidation,
+    EbSimHitCollection = "famosSimHits:EcalHitsEB",
+    EeSimHitCollection = "famosSimHits;EcalHitsEE"
+)

--- a/Validation/EcalHits/python/ecalSimHitsValidation_cfi.py
+++ b/Validation/EcalHits/python/ecalSimHitsValidation_cfi.py
@@ -11,5 +11,4 @@ ecalSimHitsValidation = cms.EDAnalyzer("EcalSimHitsValidation",
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    ecalSimHitsValidation.moduleLabelG4 = cms.string("famosSimHits")
+fastSim.toModify(ecalSimHitsValidation, moduleLabelG4 = "famosSimHits")

--- a/Validation/EcalRecHits/python/ecalRecHitsValidation_cfi.py
+++ b/Validation/EcalRecHits/python/ecalRecHitsValidation_cfi.py
@@ -13,5 +13,4 @@ ecalRecHitsValidation = cms.EDAnalyzer("EcalRecHitsValidation",
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    ecalRecHitsValidation.hitsProducer = "famosSimHits"
+fastSim.toModify(ecalRecHitsValidation, hitsProducer = "famosSimHits")

--- a/Validation/HcalDigis/python/HcalDigisParam_cfi.py
+++ b/Validation/HcalDigis/python/HcalDigisParam_cfi.py
@@ -17,8 +17,7 @@ hcaldigisAnalyzer = cms.EDAnalyzer("HcalDigisValidation",
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    hcaldigisAnalyzer.simHits = cms.untracked.InputTag("famosSimHits","HcalHits")
+fastSim.toModify(hcaldigisAnalyzer, simHits = "famosSimHits:HcalHits")
 
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify(hcaldigisAnalyzer,

--- a/Validation/HcalRecHits/python/hcalRecHitsValidationSequence_cff.py
+++ b/Validation/HcalRecHits/python/hcalRecHitsValidationSequence_cff.py
@@ -11,8 +11,7 @@ hcalRecHitsValidationSequence = cms.Sequence(NoiseRatesValidation*RecHitsValidat
 
 # fastsim hasn't got the right noise collection for the moment => no noise validation
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    hcalRecHitsValidationSequence.remove(NoiseRatesValidation)
+fastSim.toReplaceWith(hcalRecHitsValidationSequence, hcalRecHitsValidationSequence.copyAndExclude([NoiseRatesValidation]))
 
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 _phase2_hcalRecHitsValidationSequence = hcalRecHitsValidationSequence.copyAndExclude([NoiseRatesValidation])

--- a/Validation/MuonCSCDigis/python/cscDigiValidation_cfi.py
+++ b/Validation/MuonCSCDigis/python/cscDigiValidation_cfi.py
@@ -12,7 +12,4 @@ cscDigiValidation = cms.EDAnalyzer("CSCDigiValidation",
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    cscDigiValidation.simHitsTag = cms.InputTag("mix", "MuonSimHitsMuonCSCHits")
-
-
+fastSim.toModify(cscDigiValidation, simHitsTag = "mix:MuonSimHitsMuonCSCHits")

--- a/Validation/MuonDTDigis/python/dtDigiValidation_cfi.py
+++ b/Validation/MuonDTDigis/python/dtDigiValidation_cfi.py
@@ -12,5 +12,4 @@ muondtdigianalyzer = cms.EDAnalyzer("MuonDTDigis",
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    muondtdigianalyzer.SimHitLabel = cms.InputTag("MuonSimHits","MuonDTHits")
+fastSim.toModify(muondtdigianalyzer, SimHitLabel = "MuonSimHits:MuonDTHits")

--- a/Validation/MuonHits/python/muonHitsValidation_cfi.py
+++ b/Validation/MuonHits/python/muonHitsValidation_cfi.py
@@ -17,8 +17,8 @@ validSimHit = cms.EDAnalyzer("MuonSimHitsValidAnalyzer",
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    validSimHit.DTHitsSrc = cms.InputTag("MuonSimHits","MuonDTHits")
-    validSimHit.CSCHitsSrc = cms.InputTag("MuonSimHits","MuonCSCHits")
-    validSimHit.RPCHitsSrc = cms.InputTag("MuonSimHits","MuonRPCHits")
-    
+fastSim.toModify(validSimHit,
+    DTHitsSrc = "MuonSimHits:MuonDTHits",
+    CSCHitsSrc = "MuonSimHits:MuonCSCHits",
+    RPCHitsSrc = "MuonSimHits:MuonRPCHits"
+)

--- a/Validation/MuonIdentification/python/muonIdVal_cfi.py
+++ b/Validation/MuonIdentification/python/muonIdVal_cfi.py
@@ -22,5 +22,4 @@ muonIdVal = cms.EDAnalyzer("MuonIdVal",
 
 # fastsim has no cosmic muon veto in place
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    muonIdVal.makeCosmicCompatibilityPlots = False
+fastSim.toModify(muonIdVal, makeCosmicCompatibilityPlots = False)

--- a/Validation/MuonRPCDigis/python/validationMuonRPCDigis_cfi.py
+++ b/Validation/MuonRPCDigis/python/validationMuonRPCDigis_cfi.py
@@ -12,6 +12,4 @@ validationMuonRPCDigis = cms.EDAnalyzer("RPCDigiValid",
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    validationMuonRPCDigis.simHitTag = cms.untracked.InputTag("MuonSimHits","MuonRPCHits")
-    
+fastSim.toModify(validationMuonRPCDigis, simHitTag = "MuonSimHits:MuonRPCHits")

--- a/Validation/RPCRecHits/python/rpcRecHitValidation_cfi.py
+++ b/Validation/RPCRecHits/python/rpcRecHitValidation_cfi.py
@@ -12,6 +12,5 @@ rpcRecHitV = cms.EDAnalyzer("RPCRecHitValid",
 rpcRecHitValidation_step = cms.Sequence(rpcRecHitV)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    rpcRecHitV.simHit = cms.InputTag("MuonSimHits","MuonRPCHits")
+fastSim.toModify(rpcRecHitV, simHit = "MuonSimHits:MuonRPCHits")
 

--- a/Validation/RecoEgamma/python/photonPostProcessor_cff.py
+++ b/Validation/RecoEgamma/python/photonPostProcessor_cff.py
@@ -30,7 +30,5 @@ photonPostProcessor = cms.Sequence(photonPostprocessing*pfPhotonPostprocessing*c
 #photonPostProcessor = cms.Sequence(photonPostprocessing*conversionPostprocessing)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    photonPostprocessing.fastsim = cms.bool(True)
-    oldpfPhotonPostprocessing.fastsim = cms.bool(True)
-    
+fastSim.toModify(photonPostprocessing, fastSim = True)
+fastSim.toModify(oldpfPhotonPostprocessing, fastSim = True)

--- a/Validation/RecoEgamma/python/photonValidator_cfi.py
+++ b/Validation/RecoEgamma/python/photonValidator_cfi.py
@@ -140,6 +140,5 @@ photonValidation = cms.EDAnalyzer("PhotonValidator",
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    photonValidation.fastSim = True
+fastSim.toModify(photonValidation, fastSim = True)
 

--- a/Validation/RecoEgamma/python/tkConvValidator_cfi.py
+++ b/Validation/RecoEgamma/python/tkConvValidator_cfi.py
@@ -138,5 +138,4 @@ tkConversionValidation = cms.EDAnalyzer("TkConvValidator",
 
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    tkConversionValidation.simTracks = cms.InputTag("famosSimHits")
+fastSim.toModify(tkConversionValidation, simTracks = "famosSimHits")

--- a/Validation/RecoMuon/python/NewAssociators_cff.py
+++ b/Validation/RecoMuon/python/NewAssociators_cff.py
@@ -227,9 +227,8 @@ NewMuonAssociationHLT_seq = cms.Sequence(
 
 # fastsim has no hlt specific dt hit collection
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    _DTrechitTag = SimMuon.MCTruth.NewMuonAssociatorByHits_cfi.NewMuonAssociatorByHits.DTrechitTag
-    NEWtpToL3TkMuonAssociation.DTrechitTag = _DTrechitTag
-    NEWtpToL2MuonAssociation.DTrechitTag = _DTrechitTag
-    NEWtpToL2UpdMuonAssociation.DTrechitTag = _DTrechitTag
-    NEWtpToL3MuonAssociation.DTrechitTag = _DTrechitTag
+_DTrechitTag = SimMuon.MCTruth.NewMuonAssociatorByHits_cfi.NewMuonAssociatorByHits.DTrechitTag
+fastSim.toModify(NEWtpToL3TkMuonAssociation, DTrechitTag = _DTrechitTag)
+fastSim.toModify(NEWtpToL2MuonAssociation, DTrechitTag = _DTrechitTag)
+fastSim.toModify(NEWtpToL2UpdMuonAssociation, DTrechitTag = _DTrechitTag)
+fastSim.toModify(NEWtpToL3MuonAssociation, DTrechitTag = _DTrechitTag)

--- a/Validation/RecoMuon/python/NewMuonValidation_cff.py
+++ b/Validation/RecoMuon/python/NewMuonValidation_cff.py
@@ -217,8 +217,7 @@ NEWrecoMuonValidation = cms.Sequence(
 
 # no displaced muons in fastsim
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    NEWrecoMuonValidation = cms.Sequence(NEWmuonValidation_seq + NEWmuonValidationTEV_seq + NEWmuonValidationRefit_seq)
+fastSim.toReplaceWith(NEWrecoMuonValidation, cms.Sequence(NEWmuonValidation_seq + NEWmuonValidationTEV_seq + NEWmuonValidationRefit_seq))
 
 # sequence for cosmic muons
 NEWrecoCosmicMuonValidation = cms.Sequence(

--- a/Validation/RecoMuon/python/associators_cff.py
+++ b/Validation/RecoMuon/python/associators_cff.py
@@ -409,10 +409,8 @@ muonAssociationHLT_seq = cms.Sequence(
 
 # fastsim has no hlt specific dt hit collection
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    _DTrechitTag = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.DTrechitTag
-    tpToL3TkMuonAssociation.DTrechitTag = _DTrechitTag
-    tpToL2MuonAssociation.DTrechitTag = _DTrechitTag
-    tpToL2UpdMuonAssociation.DTrechitTag = _DTrechitTag
-    tpToL3MuonAssociation.DTrechitTag = _DTrechitTag
-
+_DTrechitTag = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.DTrechitTag
+fastSim.toModify(tpToL3TkMuonAssociation, DTrechitTag = _DTrechitTag)
+fastSim.toModify(tpToL2MuonAssociation, DTrechitTag = _DTrechitTag)
+fastSim.toModify(tpToL2UpdMuonAssociation, DTrechitTag = _DTrechitTag)
+fastSim.toModify(tpToL3MuonAssociation, DTrechitTag = _DTrechitTag)

--- a/Validation/RecoMuon/python/muonValidation_cff.py
+++ b/Validation/RecoMuon/python/muonValidation_cff.py
@@ -451,8 +451,7 @@ recoMuonValidation = cms.Sequence(
 
 # no displaces in fastsim
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    recoMuonValidation = cms.Sequence(muonValidation_seq + muonValidationTEV_seq + muonValidationRefit_seq)
+fastSim.toReplaceWith(recoMuonValidation, cms.Sequence(muonValidation_seq + muonValidationTEV_seq + muonValidationRefit_seq))
 
 # sequence for cosmic muons
 recoCosmicMuonValidation = cms.Sequence(

--- a/Validation/RecoTrack/python/MultiTrackValidator_cfi.py
+++ b/Validation/RecoTrack/python/MultiTrackValidator_cfi.py
@@ -101,6 +101,5 @@ multiTrackValidator = cms.EDAnalyzer(
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    multiTrackValidator.sim = [cms.InputTag('famosSimHits','TrackerHits')]
+fastSim.toModify(multiTrackValidator, sim = ['famosSimHits:TrackerHits'])
     

--- a/Validation/RecoTrack/python/TrackingParticleSelectionForEfficiency_cfi.py
+++ b/Validation/RecoTrack/python/TrackingParticleSelectionForEfficiency_cfi.py
@@ -23,5 +23,5 @@ phase1Pixel.toModify(TrackingParticleSelectionForEfficiency, _modifyForPhase1)
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(TrackingParticleSelectionForEfficiency, minRapidityTP = -4.5, maxRapidityTP = 4.5)
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    TrackingParticleSelectionForEfficiency.stableOnlyTP = True
+fastSim.toModify(TrackingParticleSelectionForEfficiency, stableOnlyTP = True)
+    

--- a/Validation/RecoTrack/python/TrackingParticleSelectionsForEfficiency_cff.py
+++ b/Validation/RecoTrack/python/TrackingParticleSelectionsForEfficiency_cff.py
@@ -18,8 +18,7 @@ generalTpSelectorBlock = cms.PSet(
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-if fastSim.isChosen():
-    generalTpSelectorBlock.stableOnly = True
+fastSim.toModify(generalTpSelectorBlock, stableOnly = True)
 
 TpSelectorForEfficiencyVsEtaBlock = generalTpSelectorBlock.clone()
 TpSelectorForEfficiencyVsPhiBlock = generalTpSelectorBlock.clone()


### PR DESCRIPTION
This PR is an attempt to get rid of the (disallowed) `Modifier.isChosen()` for FastSim customizations. Mostly it was a matter of using `toModify()` or `toReplaceWith()`, but the "digi aliases" required `ProcessModifier` plus two hacks to be able to track whether the job is classical mixing, premixing step1, or premixing step2 (from "which `_cff` files have been loaded").

I also catched two typos in the FastSim customization in `Validation/RecoEgamma/python/photonPostProcessor_cff.py`.

Tested in 10_0_0_pre1, no changes expected (except possibly from the `photonPostProcessor_cff.py` fix).

@Dr15Jones 