### PR TITLE
[10X] [L1T] [DQM] LogError -> LogWarning for invalid collections (issue CMSLITDPG-305)

### DIFF
--- a/DQMOffline/L1Trigger/python/L1TEGammaEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaEfficiency_cfi.py
@@ -54,6 +54,11 @@ l1tEGammaEfficiency = l1tEfficiencyHarvesting.clone(
             denominatorSuffix=cms.untracked.string("_Den"),
             plots=cms.untracked.vstring(allEfficiencyPlots)
         ),
+    )
+)
+
+l1tEGammaEmuEfficiency = l1tEfficiencyHarvesting.clone(
+    plotCfgs=cms.untracked.VPSet(
         cms.untracked.PSet(
             numeratorDir=cms.untracked.string(
                 "L1TEMU/L1TEGamma/efficiency_raw"),
@@ -94,6 +99,10 @@ from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 ppRef_2017.toModify(l1tEGammaEfficiency,
     plotCfgs = {
         0:dict(plots = allEfficiencyPlots_HI),
-        1:dict(plots = allEfficiencyPlots_HI)
+    }
+)
+ppRef_2017.toModify(l1tEGammaEmuEfficiency,
+    plotCfgs = {
+        0:dict(plots = allEfficiencyPlots_HI),
     }
 )

--- a/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Efficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Efficiency_cfi.py
@@ -37,6 +37,11 @@ l1tStage2CaloLayer2Efficiency = l1tEfficiencyHarvesting.clone(
             denominatorSuffix=cms.untracked.string("_Den"),
             plots=cms.untracked.vstring(allEfficiencyPlots)
         ),
+    )
+)
+
+l1tStage2CaloLayer2EmuEfficiency = l1tEfficiencyHarvesting.clone(
+    plotCfgs=cms.untracked.VPSet(
         cms.untracked.PSet(
             numeratorDir=cms.untracked.string("L1TEMU/L1TStage2CaloLayer2/efficiency_raw"),
             outputDir=cms.untracked.string("L1TEMU/L1TStage2CaloLayer2"),
@@ -63,7 +68,10 @@ from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 ppRef_2017.toModify(l1tStage2CaloLayer2Efficiency,
     plotCfgs = {
         0:dict(plots = allEfficiencyPlots_HI),
-        1:dict(plots = allEfficiencyPlots_HI)
     }
 )
-
+ppRef_2017.toModify(l1tStage2CaloLayer2EmuEfficiency,
+    plotCfgs = {
+        0:dict(plots = allEfficiencyPlots_HI),
+    }
+)

--- a/DQMOffline/L1Trigger/python/L1TTauEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TTauEfficiency_cfi.py
@@ -34,8 +34,13 @@ l1tTauEfficiency = l1tEfficiencyHarvesting.clone(
             numeratorSuffix=cms.untracked.string("_Num"),
             denominatorSuffix=cms.untracked.string("_Den"),
             plots=cms.untracked.vstring(allEfficiencyPlots),
-            
+
         ),
+    )
+)
+
+l1tTauEmuEfficiency = l1tEfficiencyHarvesting.clone(
+    plotCfgs=cms.untracked.VPSet(
         cms.untracked.PSet(
             numeratorDir=cms.untracked.string(
                 "L1TEMU/L1TTau/efficiency_raw"),

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_SecondStep_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_SecondStep_cff.py
@@ -13,9 +13,11 @@ from DQMOffline.L1Trigger.L1TMuonDQMEfficiency_cff import *
 # l1tStage2CaloLayer2EmuDiff uses plots produced by
 # l1tStage2CaloLayer2Efficiency
 DQMHarvestL1Trigger = cms.Sequence(
-    l1tStage2CaloLayer2Efficiency * l1tStage2CaloLayer2EmuDiff *
-    l1tEGammaEfficiency * l1tEGammaEmuDiff *
-    l1tTauEfficiency * l1tTauEmuDiff *
+    l1tStage2CaloLayer2Efficiency *
+    # l1tStage2CaloLayer2EmuDiff *
+    l1tEGammaEfficiency *
+    # l1tEGammaEmuDiff *
+    l1tTauEfficiency *
+    # l1tTauEmuDiff *
     l1tMuonDQMEfficiency
 )
-

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_SecondStep_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_SecondStep_cff.py
@@ -14,10 +14,13 @@ from DQMOffline.L1Trigger.L1TMuonDQMEfficiency_cff import *
 # l1tStage2CaloLayer2Efficiency
 DQMHarvestL1Trigger = cms.Sequence(
     l1tStage2CaloLayer2Efficiency *
+    # l1tStage2CaloLayer2EmuEfficiency *
     # l1tStage2CaloLayer2EmuDiff *
     l1tEGammaEfficiency *
+    # l1tEGammaEmuEfficiency *
     # l1tEGammaEmuDiff *
     l1tTauEfficiency *
+    # l1tTauEfficiency *
     # l1tTauEmuDiff *
     l1tMuonDQMEfficiency
 )

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
@@ -152,7 +152,7 @@ l1TriggerEmulatorOnline = cms.Sequence(
                                 )
 
 l1TriggerEmulatorOffline = cms.Sequence(
-    l1TriggerEmulatorOnline 
+    l1TriggerEmulatorOnline
 )
 #
 
@@ -257,11 +257,10 @@ l1EmulatorMonitorClient.remove(l1EmulatorErrorFlagClient)
 #l1EmulatorMonitorClient.remove(l1EmulatorEventInfoClient)
 
 
-
-
 ##############################################################################
-#stage2 
+#stage2
 ##############################################################################
+
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 
 #from L1Trigger.L1TGlobal.hackConditions_cff import *
@@ -292,7 +291,7 @@ from DQM.L1TMonitorClient.L1TStage2MonitorClient_cff import *
 # L1T monitor client sequence (system clients and quality tests)
 l1TStage2EmulatorClients = cms.Sequence(
                         l1tStage2CaloLayer2DEClient
-                        # l1tStage2EmulatorEventInfoClient 
+                        # l1tStage2EmulatorEventInfoClient
                         )
 
 l1tStage2EmulatorMonitorClient = cms.Sequence(
@@ -331,10 +330,10 @@ Stage2l1TriggerEmulatorOnline = cms.Sequence(
 l1tStage2EmulatorOnlineDQM.remove(l1tStage2uGtEmul)
 
 Stage2l1TriggerEmulatorOffline = cms.Sequence(
-                                Stage2l1TriggerEmulatorOnline +
-                                l1tStage2CaloLayer2OfflineDQMEmu +
-                                l1tEGammaOfflineDQMEmu +
-                                l1tTauOfflineDQMEmu
+                                Stage2l1TriggerEmulatorOnline# +
+                                # l1tStage2CaloLayer2OfflineDQMEmu +
+                                # l1tEGammaOfflineDQMEmu +
+                                # l1tTauOfflineDQMEmu
                                 )
 
 
@@ -344,7 +343,7 @@ Stage2l1TriggerDqmOffline = cms.Sequence(
                                 * Stage2l1TriggerEmulatorOffline
                                 )
 
-# DQM Offline Step 2 sequence                                 
+# DQM Offline Step 2 sequence
 Stage2l1TriggerDqmOfflineClient = cms.Sequence(
                                 l1tStage2EmulatorMonitorClient *
                                 l1tStage2MonitorClient *

--- a/DQMOffline/L1Trigger/src/L1TDiffHarvesting.cc
+++ b/DQMOffline/L1Trigger/src/L1TDiffHarvesting.cc
@@ -71,7 +71,7 @@ void L1TDiffHarvesting::L1TDiffPlotHandler::loadHistograms(DQMStore::IGetter &ig
   h2_ = igetter.get(h2Name);
 
   if (!h1_ || !h2_) {
-    edm::LogError("L1TDiffHarvesting::L1TDiffPlotHandler::loadHistograms")
+    edm::LogWarning("L1TDiffHarvesting::L1TDiffPlotHandler::loadHistograms")
         << (!h1_ && !h2_ ? h1Name + " && " + h2Name : !h1_ ? h1Name : h2Name) << " not gettable. Quitting booking"
         << std::endl;
 
@@ -86,12 +86,12 @@ void L1TDiffHarvesting::L1TDiffPlotHandler::loadHistograms(DQMStore::IGetter &ig
 bool L1TDiffHarvesting::L1TDiffPlotHandler::isValid() const
 {
   if (histType1_ == MonitorElement::DQM_KIND_INVALID) {
-    edm::LogError("L1TDiffHarvesting::L1TDiffPlotHandler::isValid") << " Could not find a supported histogram type"
+    edm::LogWarning("L1TDiffHarvesting::L1TDiffPlotHandler::isValid") << " Could not find a supported histogram type"
         << std::endl;
     return false;
   }
   if (histType1_ != histType2_) {
-    edm::LogError("L1TDiffHarvesting::L1TDiffPlotHandler::isValid")
+    edm::LogWarning("L1TDiffHarvesting::L1TDiffPlotHandler::isValid")
         << " Histogram 1 and 2 have different histogram types" << std::endl;
     return false;
   }

--- a/DQMOffline/L1Trigger/src/L1TEGammaOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TEGammaOffline.cc
@@ -93,7 +93,7 @@ void L1TEGammaOffline::analyze(edm::Event const& e, edm::EventSetup const& eSetu
   edm::Handle < reco::VertexCollection > vertexHandle;
   e.getByToken(thePVCollection_, vertexHandle);
   if (!vertexHandle.isValid()) {
-    edm::LogError("L1TEGammaOffline") << "invalid collection: vertex " << std::endl;
+    edm::LogWarning("L1TEGammaOffline") << "invalid collection: vertex " << std::endl;
     return;
   }
 
@@ -114,7 +114,7 @@ void L1TEGammaOffline::fillElectrons(edm::Event const& e, const unsigned int nVe
   e.getByToken(theGsfElectronCollection_, gsfElectrons);
 
   if (!gsfElectrons.isValid()) {
-    edm::LogError("L1TEGammaOffline") << "invalid collection: GSF electrons " << std::endl;
+    edm::LogWarning("L1TEGammaOffline") << "invalid collection: GSF electrons " << std::endl;
     return;
   }
   if (gsfElectrons->empty()) {
@@ -122,7 +122,7 @@ void L1TEGammaOffline::fillElectrons(edm::Event const& e, const unsigned int nVe
     return;
   }
   if (!l1EGamma.isValid()) {
-    edm::LogError("L1TEGammaOffline") << "invalid collection: L1 EGamma " << std::endl;
+    edm::LogWarning("L1TEGammaOffline") << "invalid collection: L1 EGamma " << std::endl;
     return;
   }
   if (!findTagAndProbePair(gsfElectrons)) {
@@ -382,11 +382,11 @@ void L1TEGammaOffline::fillPhotons(edm::Event const& e, const unsigned int nVert
   e.getByToken(thePhotonCollection_, photons);
 
   if (!photons.isValid()) {
-    edm::LogError("L1TEGammaOffline") << "invalid collection: reco::Photons " << std::endl;
+    edm::LogWarning("L1TEGammaOffline") << "invalid collection: reco::Photons " << std::endl;
     return;
   }
   if (!l1EGamma.isValid()) {
-    //  edm::LogError("L1TEGammaOffline") << "invalid collection: L1 EGamma " << std::endl;
+     edm::LogWarning("L1TEGammaOffline") << "invalid collection: L1 EGamma " << std::endl;
     return;
   }
 

--- a/DQMOffline/L1Trigger/src/L1TEfficiencyHarvesting.cc
+++ b/DQMOffline/L1Trigger/src/L1TEfficiencyHarvesting.cc
@@ -51,7 +51,7 @@ void L1TEfficiencyPlotHandler::book(DQMStore::IBooker &ibooker, DQMStore::IGette
 
   if (!num || !den) {
 
-    edm::LogError("L1TEfficiencyPlotHandler")
+    edm::LogWarning("L1TEfficiencyPlotHandler")
         << (!num && !den ? numeratorName + " && " + denominatorName : !num ? numeratorName : denominatorName)
         << " not gettable. Quitting booking" << endl;
     return;
@@ -62,7 +62,7 @@ void L1TEfficiencyPlotHandler::book(DQMStore::IBooker &ibooker, DQMStore::IGette
 
   if (!numH || !denH) {
 
-    edm::LogError("L1TEfficiencyPlotHandler")
+    edm::LogWarning("L1TEfficiencyPlotHandler")
         << (!numH && !denH ? numeratorName + " && " + denominatorName : !num ? numeratorName : denominatorName)
         << " is not TH1F. Quitting booking" << endl;
 
@@ -71,7 +71,7 @@ void L1TEfficiencyPlotHandler::book(DQMStore::IBooker &ibooker, DQMStore::IGette
   }
 
   if (numH->GetNbinsX() != denH->GetNbinsX()) {
-    edm::LogError(
+    edm::LogWarning(
       "L1TEfficiencyPlotHandler") << " # X bins in " <<
       numeratorName << " and " << denominatorName <<
       " are different. Quitting booking" << endl;
@@ -86,7 +86,7 @@ void L1TEfficiencyPlotHandler::book(DQMStore::IBooker &ibooker, DQMStore::IGette
 
   if (is2D) {
     if (numH->GetNbinsY() != denH->GetNbinsY()) {
-      edm::LogError(
+      edm::LogWarning(
         "L1TEfficiencyPlotHandler") << " # Y bins in " << numeratorName <<
         " and " << denominatorName << " are different. Quitting booking" <<
         endl;

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -94,7 +94,7 @@ void L1TStage2CaloLayer2Offline::analyze(edm::Event const& e, edm::EventSetup co
   edm::Handle<reco::VertexCollection> vertexHandle;
   e.getByToken(thePVCollection_, vertexHandle);
   if (!vertexHandle.isValid()) {
-    edm::LogError("L1TStage2CaloLayer2Offline") << "invalid collection: vertex " << std::endl;
+    edm::LogWarning("L1TStage2CaloLayer2Offline") << "invalid collection: vertex " << std::endl;
     return;
   }
 
@@ -121,19 +121,19 @@ void L1TStage2CaloLayer2Offline::fillEnergySums(edm::Event const& e, const unsig
   e.getByToken(thecaloETMHFCollection_, caloETMHFs);
 
   if (!caloJets.isValid()) {
-    edm::LogError("L1TStage2CaloLayer2Offline") << "invalid collection: calo jets " << std::endl;
+    edm::LogWarning("L1TStage2CaloLayer2Offline") << "invalid collection: calo jets " << std::endl;
     return;
   }
   if (!caloMETs.isValid()) {
-    edm::LogError("L1TStage2CaloLayer2Offline") << "invalid collection: Offline E_{T}^{miss} " << std::endl;
+    edm::LogWarning("L1TStage2CaloLayer2Offline") << "invalid collection: Offline E_{T}^{miss} " << std::endl;
     return;
   }
   if (!caloETMHFs.isValid()) {
-    edm::LogError("L1TStage2CaloLayer2Offline") << "invalid collection: Offline E_{T}^{miss} (HF) " << std::endl;
+    edm::LogWarning("L1TStage2CaloLayer2Offline") << "invalid collection: Offline E_{T}^{miss} (HF) " << std::endl;
     return;
   }
   if (!l1EtSums.isValid()) {
-    //edm::LogError("L1TStage2CaloLayer2Offline") << "invalid collection: L1 ET sums " << std::endl;
+    edm::LogWarning("L1TStage2CaloLayer2Offline") << "invalid collection: L1 ET sums " << std::endl;
     return;
   }
 
@@ -290,11 +290,11 @@ void L1TStage2CaloLayer2Offline::fillJets(edm::Event const& e, const unsigned in
   e.getByToken(theCaloJetCollection_, caloJets);
 
   if (!caloJets.isValid()) {
-    edm::LogError("L1TStage2CaloLayer2Offline") << "invalid collection: calo jets " << std::endl;
+    edm::LogWarning("L1TStage2CaloLayer2Offline") << "invalid collection: calo jets " << std::endl;
     return;
   }
   if (!l1Jets.isValid()) {
-    //edm::LogError("L1TStage2CaloLayer2Offline") << "invalid collection: L1 jets " << std::endl;
+    edm::LogWarning("L1TStage2CaloLayer2Offline") << "invalid collection: L1 jets " << std::endl;
     return;
   }
 

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -331,7 +331,7 @@ void L1TStage2CaloLayer2Offline::fillJets(edm::Event const& e, const unsigned in
 //	}
 
   if (!foundMatch) {
-    edm::LogWarning("L1TStage2CaloLayer2Offline") << "Could not find a matching L1 Jet " << std::endl;
+    LogDebug("L1TStage2CaloLayer2Offline") << "Could not find a matching L1 Jet " << std::endl;
     return;
   }
 

--- a/DQMOffline/L1Trigger/src/L1TTauOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TTauOffline.cc
@@ -1,9 +1,9 @@
-/** 
+/**
  *  @file     L1TTauOffline.cc
  *  @authors  Olivier Davignon (University of Bristol), Cécile Caillol (University of Wisconsin - Madison)
- *  @date     24/05/2017  
- *  @version  1.1 
- *  
+ *  @date     24/05/2017
+ *  @version  1.1
+ *
  */
 
 #include "DQMOffline/L1Trigger/interface/L1TTauOffline.h"
@@ -28,8 +28,8 @@ using namespace std;
 
 TauL1TPair::TauL1TPair(const TauL1TPair& tauL1tPair) {
 
-  m_tau    = tauL1tPair.m_tau;			
-  m_regTau  = tauL1tPair.m_regTau;		
+  m_tau    = tauL1tPair.m_tau;
+  m_regTau  = tauL1tPair.m_regTau;
 
   m_eta     = tauL1tPair.m_eta;
   m_phi_bar = tauL1tPair.m_phi_bar;
@@ -97,23 +97,23 @@ void L1TTauOffline::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const &
 
   //book at beginRun
   bookTauHistos(ibooker);
- 
+
   for ( auto trigNamesIt = triggerPath_.begin() ; trigNamesIt!=triggerPath_.end() ; trigNamesIt++){
 
-    std::string tNameTmp = (*trigNamesIt); 
+    std::string tNameTmp = (*trigNamesIt);
     std::string tNamePattern = "";
     std::size_t found0 = tNameTmp.find("*");
     if(found0!=std::string::npos) tNamePattern = tNameTmp.substr(0,tNameTmp.size()-1);
     else tNamePattern = tNameTmp;
 
     int tIndex = -1;
-    
+
     for (unsigned ipath = 0; ipath < m_hltConfig.size(); ++ipath) {
-      
+
       std::string tmpName = m_hltConfig.triggerName(ipath);
-      
+
       std::size_t found=tmpName.find(tNamePattern);
-      if (found!=std::string::npos){  
+      if (found!=std::string::npos){
 	tIndex = int(ipath);
 	m_trigIndices.push_back(tIndex);
       }
@@ -143,8 +143,8 @@ void L1TTauOffline::analyze(edm::Event const& e, edm::EventSetup const& eSetup)
 
   if(!taus.isValid())
     {
-      //edm::LogError("L1TTauOffline") << "invalid collection: reco::PFTauCollection " << std::endl;
-      return; 
+      edm::LogWarning("L1TTauOffline") << "invalid collection: reco::PFTauCollection " << std::endl;
+      return;
     }
 
   edm::Handle<reco::MuonCollection> muons;
@@ -152,17 +152,17 @@ void L1TTauOffline::analyze(edm::Event const& e, edm::EventSetup const& eSetup)
 
   if(!muons.isValid())
     {
-      //edm::LogError("L1TTauOffline") << "invalid collection: reco::MuonCollection " << std::endl;
-      return; 
-    }    
+      edm::LogWarning("L1TTauOffline") << "invalid collection: reco::MuonCollection " << std::endl;
+      return;
+    }
 
   edm::Handle<reco::BeamSpot> beamSpot;
   e.getByToken(BsInputTag_, beamSpot);
 
   if(!beamSpot.isValid())
     {
-      //edm::LogError("L1TTauOffline") << "invalid collection: reco::BeamSpot " << std::endl;
-      return; 
+      edm::LogWarning("L1TTauOffline") << "invalid collection: reco::BeamSpot " << std::endl;
+      return;
     }
 
   edm::Handle<reco::VertexCollection> vertex;
@@ -170,46 +170,46 @@ void L1TTauOffline::analyze(edm::Event const& e, edm::EventSetup const& eSetup)
 
   if(!vertex.isValid())
     {
-      //edm::LogError("L1TTauOffline") << "invalid collection: reco::VertexCollection " << std::endl;
-      return; 
+      edm::LogWarning("L1TTauOffline") << "invalid collection: reco::VertexCollection " << std::endl;
+      return;
     }
 
-  edm::Handle<l1t::TauBxCollection> l1tCands;				
+  edm::Handle<l1t::TauBxCollection> l1tCands;
   e.getByToken(stage2CaloLayer2TauToken_,l1tCands);
-  
+
   if(!l1tCands.isValid())
     {
-      //edm::LogError("L1TTauOffline") << "invalid collection: l1t::TauBxCollection " << std::endl;
-      return;        
+      edm::LogWarning("L1TTauOffline") << "invalid collection: l1t::TauBxCollection " << std::endl;
+      return;
     }
-  
+
   edm::Handle<edm::TriggerResults> trigResults;
   e.getByToken(triggerResults_,trigResults);
 
   if(!trigResults.isValid())
     {
-      //edm::LogError("L1TTauOffline") << "invalid collection: edm::TriggerResults " << std::endl;
-      return;      
+      edm::LogWarning("L1TTauOffline") << "invalid collection: edm::TriggerResults " << std::endl;
+      return;
     }
-  
+
   edm::Handle<trigger::TriggerEvent> trigEvent;
   e.getByToken(triggerEvent_,trigEvent);
 
   if(!trigEvent.isValid())
     {
-      //edm::LogError("L1TTauOffline") << "invalid collection: trigger::TriggerEvent " << std::endl;
-      return;      
+      edm::LogWarning("L1TTauOffline") << "invalid collection: trigger::TriggerEvent " << std::endl;
+      return;
     }
 
   edm::Handle<reco::PFMETCollection> mets;
   e.getByToken(MetInputTag_, mets);
 
   if(!mets.isValid()) {
-    //edm::LogError("L1TTauOffline") << "invalid collection: reco::PFMETCollection " << std::endl;
+    edm::LogWarning("L1TTauOffline") << "invalid collection: reco::PFMETCollection " << std::endl;
     return;
   }
 
-  eSetup.get<IdealMagneticFieldRecord>().get(m_BField);									
+  eSetup.get<IdealMagneticFieldRecord>().get(m_BField);
   const reco::Vertex primaryVertex = getPrimaryVertex(vertex,beamSpot);
 
   getTightMuons(muons,mets,primaryVertex,trigEvent);
@@ -221,15 +221,15 @@ void L1TTauOffline::analyze(edm::Event const& e, edm::EventSetup const& eSetup)
 
   for (auto tau = l1tCands->begin(0); tau != l1tCands->end(0); ++tau) {
     l1tContainer.push_back(*tau);
-  } 
-     
+  }
+
   for(auto tauL1tPairsIt=m_TauL1tPairs.begin(); tauL1tPairsIt!=m_TauL1tPairs.end(); ++tauL1tPairsIt) {
 
     float eta = tauL1tPairsIt->eta();
     float phi = tauL1tPairsIt->phi();
     float pt  = tauL1tPairsIt->pt();
 
-    // unmatched gmt cands have l1tPt = -1.	
+    // unmatched gmt cands have l1tPt = -1.
     float l1tPt  = tauL1tPairsIt->l1tPt();
 
     int counter = 0;
@@ -424,22 +424,22 @@ void L1TTauOffline::bookTauHistos(DQMStore::IBooker & ibooker)
 }
 
 const reco::Vertex L1TTauOffline::getPrimaryVertex( edm::Handle<reco::VertexCollection> const& vertex, edm::Handle<reco::BeamSpot> const& beamSpot ) {
-  
+
   reco::Vertex::Point posVtx;
   reco::Vertex::Error errVtx;
-  
+
   bool hasPrimaryVertex = false;
 
   if (vertex.isValid())
     {
-      for (auto vertexIt=vertex->begin();vertexIt!=vertex->end();++vertexIt) 
+      for (auto vertexIt=vertex->begin();vertexIt!=vertex->end();++vertexIt)
 	{
-	  if (vertexIt->isValid() && 
-	      !vertexIt->isFake()) 
+	  if (vertexIt->isValid() &&
+	      !vertexIt->isFake())
 	    {
 	      posVtx = vertexIt->position();
 	      errVtx = vertexIt->error();
-	      hasPrimaryVertex = true;	      
+	      hasPrimaryVertex = true;
 	      break;
 	    }
 	}
@@ -453,7 +453,7 @@ const reco::Vertex L1TTauOffline::getPrimaryVertex( edm::Handle<reco::VertexColl
   }
 
   const reco::Vertex primaryVertex(posVtx,errVtx);
-  
+
   return primaryVertex;
 }
 
@@ -470,42 +470,42 @@ bool L1TTauOffline::matchHlt(edm::Handle<trigger::TriggerEvent> const& triggerEv
     const unsigned moduleIndex = m_hltConfig.size((*trigIndexIt))-2;
 
     const unsigned hltFilterIndex = triggerEvent->filterIndex(InputTag(moduleLabels[moduleIndex],"",trigProcess_));
-    
+
     if (hltFilterIndex < triggerEvent->sizeFilters()) {
       const Keys triggerKeys(triggerEvent->filterKeys(hltFilterIndex));
       const Vids triggerVids(triggerEvent->filterIds(hltFilterIndex));
-      
+
       const unsigned nTriggers = triggerVids.size();
       for (size_t iTrig = 0; iTrig < nTriggers; ++iTrig) {
         const TriggerObject trigObject = trigObjs[triggerKeys[iTrig]];
-	
+
         double dRtmp = deltaR((*muon),trigObject);
         if (dRtmp < matchDeltaR) matchDeltaR = dRtmp;
       }
     }
   }
-  
+
   return (matchDeltaR < m_MaxHltTauDR);
 
 }
 
-void L1TTauOffline::getTauL1tPairs(edm::Handle<l1t::TauBxCollection> const& l1tCands) {					
+void L1TTauOffline::getTauL1tPairs(edm::Handle<l1t::TauBxCollection> const& l1tCands) {
 
   m_TauL1tPairs.clear();
-  
+
   vector<l1t::Tau> l1tContainer;
   l1tContainer.reserve(l1tCands->size()+1);
-  
+
   for (auto tau = l1tCands->begin(0); tau != l1tCands->end(0); ++tau) {
     l1tContainer.push_back(*tau);
   }
-			
-  for (auto probeTauIt = m_ProbeTaus.begin(); probeTauIt!=m_ProbeTaus.end(); ++probeTauIt) {    
 
-    TauL1TPair pairBestCand((*probeTauIt),nullptr);    
-    
+  for (auto probeTauIt = m_ProbeTaus.begin(); probeTauIt!=m_ProbeTaus.end(); ++probeTauIt) {
+
+    TauL1TPair pairBestCand((*probeTauIt),nullptr);
+
     for(auto l1tIt =  l1tContainer.begin() ; l1tIt!=l1tContainer.end(); ++l1tIt) {
-      
+
       TauL1TPair pairTmpCand((*probeTauIt),&(*l1tIt));
 
       if (pairTmpCand.dR() < m_MaxL1tTauDR && pairTmpCand.l1tPt() > pairBestCand.l1tPt())
@@ -514,7 +514,7 @@ void L1TTauOffline::getTauL1tPairs(edm::Handle<l1t::TauBxCollection> const& l1tC
     }
 
     m_TauL1tPairs.push_back(pairBestCand);
-  
+
   }
 
 }
@@ -543,7 +543,7 @@ void L1TTauOffline::getTightMuons(edm::Handle<reco::MuonCollection> const& muons
       if (mt<30){
          m_TightMuons.push_back(&(*muonIt));
          foundTightMu=true;
-      } 
+      }
     }
   }
 }
@@ -556,32 +556,32 @@ void L1TTauOffline::getProbeTaus(const edm::Event & iEvent,edm::Handle<reco::PFT
   iEvent.getByToken(AntiMuInputTag_, antimu);
   if(!antimu.isValid())
     {
-      //edm::LogError("L1TTauOffline") << "invalid collection: reco::PFTauDiscriminator " << std::endl;
-      return;  
+      edm::LogWarning("L1TTauOffline") << "invalid collection: reco::PFTauDiscriminator " << std::endl;
+      return;
     }
 
   edm::Handle<reco::PFTauDiscriminator> dmf;
   iEvent.getByToken(DecayModeFindingInputTag_, dmf);
   if(!dmf.isValid())
     {
-      //edm::LogError("L1TTauOffline") << "invalid collection: reco::PFTauDiscriminator " << std::endl;
-      return;  
+      edm::LogWarning("L1TTauOffline") << "invalid collection: reco::PFTauDiscriminator " << std::endl;
+      return;
     }
 
   edm::Handle<reco::PFTauDiscriminator> antiele;
   iEvent.getByToken(AntiEleInputTag_, antiele);
   if(!antiele.isValid())
     {
-      //edm::LogError("L1TTauOffline") << "invalid collection: reco::PFTauDiscriminator " << std::endl;
-      return;  
+      edm::LogWarning("L1TTauOffline") << "invalid collection: reco::PFTauDiscriminator " << std::endl;
+      return;
     }
 
   edm::Handle<reco::PFTauDiscriminator> comb3T;
   iEvent.getByToken(comb3TInputTag_, comb3T);
   if(!comb3T.isValid())
     {
-      //edm::LogError("L1TTauOffline") << "invalid collection: reco::PFTauDiscriminator " << std::endl;
-      return;  
+      edm::LogWarning("L1TTauOffline") << "invalid collection: reco::PFTauDiscriminator " << std::endl;
+      return;
     }
 
   if (!m_TightMuons.empty()){

--- a/DQMOffline/L1Trigger/test/runDQMOffline_step1_L1TStage2CaloLayer2_cfg.py
+++ b/DQMOffline/L1Trigger/test/runDQMOffline_step1_L1TStage2CaloLayer2_cfg.py
@@ -109,6 +109,11 @@ process.dqmoffline_step = cms.Path(
     process.l1tTauOfflineDQM +
     process.l1tTauOfflineDQMEmu
 )
+if options.sample != 'TTJet':
+    process.dqmoffline_step.remove(process.l1tStage2CaloLayer2OfflineDQMEmu)
+    process.dqmoffline_step.remove(process.l1tEGammaOfflineDQMEmu)
+    process.dqmoffline_step.remove(process.l1tTauOfflineDQMEmu)
+
 process.DQMoutput_step = cms.EndPath(process.DQMoutput)
 # Schedule definition
 process.schedule = cms.Schedule(

--- a/DQMOffline/L1Trigger/test/runDQMOffline_step2_L1TStage2CaloLayer2_cfg.py
+++ b/DQMOffline/L1Trigger/test/runDQMOffline_step2_L1TStage2CaloLayer2_cfg.py
@@ -58,9 +58,15 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:mc', '')  # for MC
 # Path and EndPath definitions
 process.myHarvesting = cms.Path(process.DQMExampleStep2)
 process.myEff = cms.Path(
-    process.l1tStage2CaloLayer2Efficiency * process.l1tStage2CaloLayer2EmuDiff +
-    process. l1tEGammaEfficiency * process.l1tEGammaEmuDiff +
-    process. l1tTauEfficiency * process.l1tTauEmuDiff
+    process.l1tStage2CaloLayer2Efficiency *
+    process.l1tStage2CaloLayer2EmuEfficiency *
+    process.l1tStage2CaloLayer2EmuDiff +
+    process.l1tEGammaEfficiency *
+    process.l1tEGammaEmuEfficiency *
+    process.l1tEGammaEmuDiff +
+    process.l1tTauEfficiency *
+    process.l1tTauEmuEfficiency * 
+    process.l1tTauEmuDiff
 )
 process.myTest = cms.Path(process.DQMExample_qTester)
 process.dqmsave_step = cms.Path(process.dqmSaver)


### PR DESCRIPTION
### Overview
Fixing issue https://its.cern.ch/jira/browse/CMSLITDPG-305, changing all `edm::LogError` logs for invalid collections to `edm::LogWarning`

### Changed items
 - changed all `edm::LogError` messages for invalid collections to `edm::LogWarning`in L1T  DQM offline modules
 - split Emu and non-Emu L1T DQM offline into separate modules
 - **temporarily removed all Emu from the DQM offline** due to missing sources resulting in large quantities of error messages, needs to be re-enabled in a new PR

### Follow up
#### Discussion around Emu paths
From Nickolas Smith:

> One could start from caloLayer1Digis and run layer1+layer2 emulator on all events to get better stats for efficiencies than relying on fat events.

From @thomreis 

> I think for this PR it is easier to comment out the three emulator modules and change the configuration to set up a layer1+layer2 emulator chain in a separate PR afterwards.

This is now summarised in issue #21710
