### PR TITLE
GTUpdates : All GTs updated with HCAL Pedestals with effective label

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -54,7 +54,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '100X_upgrade2018cosmics_realistic_deco_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : '100X_postLS2_realistic_v1', # GT containing realistic conditions for postLS2
+    'phase1_2019_realistic'       : '100X_postLS2_realistic_v1', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
     'phase2_realistic'         : '94X_upgrade2023_realistic_v3'
 }
@@ -85,5 +85,5 @@ autoCond['hltonline']        = ( autoCond['run1_hlt'] )
 autoCond['upgradePLS1']      = ( autoCond['run2_mc'] )
 autoCond['upgradePLS150ns']  = ( autoCond['run2_mc_50ns'] )
 autoCond['upgrade2017']      = ( autoCond['phase1_2017_design'] )
-autoCond['upgrade2019']      = ( autoCond['phase1_2019_design'] )
+autoCond['upgrade2019']      = ( autoCond['phase1_2019_realistic'] )
 autoCond['upgradePLS3']      = ( autoCond['phase2_realistic'] )

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,59 +2,59 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '94X_mcRun1_design_v1',
+    'run1_design'       :   '100X_mcRun1_design_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '94X_mcRun1_realistic_v1',
+    'run1_mc'           :   '100X_mcRun1_realistic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '94X_mcRun1_HeavyIon_v1',
+    'run1_mc_hi'        :   '100X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '94X_mcRun1_pA_v1',
+    'run1_mc_pa'        :   '100X_mcRun1_pA_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '94X_mcRun2_design_v1',
+    'run2_design'       :   '100X_mcRun2_design_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '94X_mcRun2_startup_v1',
+    'run2_mc_50ns'      :   '100X_mcRun2_startup_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '94X_mcRun2_asymptotic_v1',
+    'run2_mc'           :   '100X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
     'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '94X_mcRun2cosmics_startup_deco_v1',
+    'run2_mc_cosmics'   :   '100X_mcRun2cosmics_startup_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '93X_mcRun2_HeavyIon_v0',
+    'run2_mc_hi'        :   '100X_mcRun2_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '94X_mcRun2_pA_v1',
+    'run2_mc_pa'        :   '100X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '94X_dataRun2_v4',
+    'run1_data'         :   '100X_dataRun2_v1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '94X_dataRun2_v4',
+    'run2_data'         :   '100X_dataRun2_v1',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '94X_dataRun2_relval_v7',
+    'run2_data_relval'  :   '100X_dataRun2_relval_v1',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '94X_dataRun2_PromptLike_v8',
+    'run2_data_promptlike' : '100X_dataRun2_PromptLike_v1',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '94X_dataRun2_HLT_frozen_v5',
+    'run1_hlt'          :   '100X_dataRun2_HLT_frozen_v1',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '94X_dataRun2_HLT_frozen_v5',
+    'run2_hlt'          :   '100X_dataRun2_HLT_frozen_v1',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '94X_dataRun2_HLT_relval_v7',
+    'run2_hlt_relval'   :   '100X_dataRun2_HLT_relval_v1',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '94X_dataRun2_HLTHI_frozen_v4',
+    'run2_hlt_hi'       :   '100X_dataRun2_HLTHI_frozen_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '94X_mc2017_design_IdealBS_v6',
+    'phase1_2017_design'       :  '100X_mc2017_design_IdealBS_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '94X_mc2017_realistic_v6',
+    'phase1_2017_realistic'    : '100X_mc2017_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '94X_mc2017cosmics_realistic_deco_v5',
+    'phase1_2017_cosmics'      : '100X_mc2017cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '94X_mc2017cosmics_realistic_peak_v5',
+    'phase1_2017_cosmics_peak' : '100X_mc2017cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '94X_upgrade2018_design_IdealBS_v6',
+    'phase1_2018_design'       : '100X_upgrade2018_design_IdealBS_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '94X_upgrade2018_realistic_v6',
+    'phase1_2018_realistic'    : '100X_upgrade2018_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '94X_upgrade2018cosmics_realistic_deco_v5',
+    'phase1_2018_cosmics'      :   '100X_upgrade2018cosmics_realistic_deco_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
+    'phase1_2019_design'       : '100X_postLS2_realistic_v1', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase2 2023
     'phase2_realistic'         : '94X_upgrade2023_realistic_v3'
 }


### PR DESCRIPTION
Motivation of separating the HCAL pedestals for HCAL SiPMs is given here : https://indico.cern.ch/event/680480/contributions/2787885/attachments/1556785/2448593/Dual_peds_S.A._Nov13_2017.pdf

# Summary of changes in Global Tags 
 
## RunI simulation 
 
   * **RunI Heavy Ions scenario** : [100X_mcRun1_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mcRun1_HeavyIon_v1) as [94X_mcRun1_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun1_HeavyIon_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mcRun1_HeavyIon_v1/94X_mcRun1_HeavyIon_v1): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html

   * **RunI Ideal scenario** : [100X_mcRun1_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mcRun1_design_v1) as [94X_mcRun1_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun1_design_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mcRun1_design_v1/94X_mcRun1_design_v1): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html

   * **RunI Proton-Lead scenario** : [100X_mcRun1_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mcRun1_pA_v1) as [94X_mcRun1_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun1_pA_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mcRun1_pA_v1/94X_mcRun1_pA_v1): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html

   * **RunI Realistic scenario** : [100X_mcRun1_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mcRun1_realistic_v1) as [94X_mcRun1_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun1_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mcRun1_realistic_v1/94X_mcRun1_realistic_v1): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html

## RunII simulation 
 
   * **RunII Asymptotic scenario** : [100X_mcRun2_asymptotic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mcRun2_asymptotic_v1) as [94X_mcRun2_asymptotic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2_asymptotic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mcRun2_asymptotic_v1/94X_mcRun2_asymptotic_v1): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html

   * **RunII CRAFT scenario** : [100X_mcRun2cosmics_startup_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mcRun2cosmics_startup_deco_v1) as [94X_mcRun2cosmics_startup_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2cosmics_startup_deco_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mcRun2cosmics_startup_deco_v1/94X_mcRun2cosmics_startup_deco_v1): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html

   * **RunII Heavy Ions scenario** : [100X_mcRun2_HeavyIon_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mcRun2_HeavyIon_v1) as [93X_mcRun2_HeavyIon_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/93X_mcRun2_HeavyIon_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mcRun2_HeavyIon_v1/93X_mcRun2_HeavyIon_v0): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html
      * Insertion of L1T TwinMux tags
      * Insertion of L1T BTMF parameter tags

   * **RunII Ideal scenario** : [100X_mcRun2_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mcRun2_design_v1) as [94X_mcRun2_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2_design_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mcRun2_design_v1/94X_mcRun2_design_v1): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html

   * **RunII Proton-Lead scenario** : [100X_mcRun2_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mcRun2_pA_v1) as [94X_mcRun2_pA_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2_pA_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mcRun2_pA_v1/94X_mcRun2_pA_v1): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html

   * **RunII Startup scenario** : [100X_mcRun2_startup_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mcRun2_startup_v1) as [94X_mcRun2_startup_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2_startup_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mcRun2_startup_v1/94X_mcRun2_startup_v1): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html

## RunI data 
 
   * **RunI HLT processing** : [100X_dataRun2_HLT_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_dataRun2_HLT_frozen_v1) as [94X_dataRun2_HLT_frozen_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_frozen_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_dataRun2_HLT_frozen_v1/94X_dataRun2_HLT_frozen_v5): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html

   * **RunI Offline processing** : [100X_dataRun2_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_dataRun2_v1) as [94X_dataRun2_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_dataRun2_v1/94X_dataRun2_v4): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html
      * Insertion of L1T EMTF Forest tag

## RunII data 
 
   * **RunII HLTHI processing** : [100X_dataRun2_HLTHI_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_dataRun2_HLTHI_frozen_v1) as [94X_dataRun2_HLTHI_frozen_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLTHI_frozen_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_dataRun2_HLTHI_frozen_v1/94X_dataRun2_HLTHI_frozen_v4): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html

   * **RunII HLT relval processing** : [100X_dataRun2_HLT_relval_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_dataRun2_HLT_relval_v1) as [94X_dataRun2_HLT_relval_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_relval_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_dataRun2_HLT_relval_v1/94X_dataRun2_HLT_relval_v7): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html

   * **RunII Offline processing** : [100X_dataRun2_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_dataRun2_v1) as [94X_dataRun2_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_dataRun2_v1/94X_dataRun2_v4): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html
      * Insertion of L1T EMTF Forest tag

   * **RunII Offline relval processing** : [100X_dataRun2_relval_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_dataRun2_relval_v1) as [94X_dataRun2_relval_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_relval_v7) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_dataRun2_relval_v1/94X_dataRun2_relval_v7): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html
      * update of other offline tags to bring this queue closer to offline dataRun2 queue

   * **RunII Prompt processing** : [100X_dataRun2_PromptLike_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_dataRun2_PromptLike_v1) as [94X_dataRun2_PromptLike_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_PromptLike_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_dataRun2_PromptLike_v1/94X_dataRun2_PromptLike_v8): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html

   * **RunI HLT processing** : [100X_dataRun2_HLT_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_dataRun2_HLT_frozen_v1) as [94X_dataRun2_HLT_frozen_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_frozen_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_dataRun2_HLT_frozen_v1/94X_dataRun2_HLT_frozen_v5): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html

## Upgrade 
 
   * **PhaseI 2018 cosmics scenario** : [100X_upgrade2018cosmics_realistic_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2018cosmics_realistic_deco_v1) as [94X_upgrade2018cosmics_realistic_deco_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018cosmics_realistic_deco_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_upgrade2018cosmics_realistic_deco_v1/94X_upgrade2018cosmics_realistic_deco_v5): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html
      * update of regular HCAL Pedestals
      * update of tracker misalignment scenario which is being used for MC V2

   * **PhaseI 2018 design scenario** : [100X_upgrade2018_design_IdealBS_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2018_design_IdealBS_v1) as [94X_upgrade2018_design_IdealBS_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018_design_IdealBS_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_upgrade2018_design_IdealBS_v1/94X_upgrade2018_design_IdealBS_v6): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html
      * update of regular HCAL Pedestals

   * **PhaseI 2018 realistic scenario** : [100X_upgrade2018_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_upgrade2018_realistic_v1) as [94X_upgrade2018_realistic_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018_realistic_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_upgrade2018_realistic_v1/94X_upgrade2018_realistic_v6): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html
      * update of regular HCAL Pedestals
      * update of tracker misalignment scenario which is being used for MC V2

   * **PostLS2 realistic scenario** : [100X_postLS2_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_postLS2_realistic_v1) as [DES19_70_V2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/DES19_70_V2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_postLS2_realistic_v1/DES19_70_V2): 
      * first GT for postLS2 scenario with an update of HCAL electronics map. All other conditions are same as 2018 realistic.

## 2017_MC

   * **PhaseI 2017 cosmics peak scenario** : [100X_mc2017cosmics_realistic_peak_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mc2017cosmics_realistic_peak_v1) as [94X_mc2017cosmics_realistic_peak_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017cosmics_realistic_peak_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mc2017cosmics_realistic_peak_v1/94X_mc2017cosmics_realistic_peak_v5): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html
      * update of tracker misalignment scenario which is being used for MC V2

   * **PhaseI 2017 cosmics scenario** : [100X_mc2017cosmics_realistic_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mc2017cosmics_realistic_deco_v1) as [94X_mc2017cosmics_realistic_deco_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017cosmics_realistic_deco_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mc2017cosmics_realistic_deco_v1/94X_mc2017cosmics_realistic_deco_v5): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html
      * update of tracker misalignment scenario which is being used for MC V2

   * **PhaseI 2017 design scenario** : [100X_mc2017_design_IdealBS_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mc2017_design_IdealBS_v1) as [94X_mc2017_design_IdealBS_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017_design_IdealBS_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mc2017_design_IdealBS_v1/94X_mc2017_design_IdealBS_v6): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html

   * **PhaseI 2017 realistic scenario** : [100X_mc2017_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/100X_mc2017_realistic_v1) as [94X_mc2017_realistic_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017_realistic_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/100X_mc2017_realistic_v1/94X_mc2017_realistic_v6): 
      * update of HCAL Pedestals with label effective : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/3360.html
      * update of regular HCAL Pedestals which are being used for MC V2
      * update of tracker misalignment scenario which is being used for MC V2