### PR TITLE
Include ForwardDetRod.h in RBorderFinder.h

### DIFF
--- a/RecoMuon/DetLayers/src/RBorderFinder.h
+++ b/RecoMuon/DetLayers/src/RBorderFinder.h
@@ -13,6 +13,7 @@
 
 #include <Utilities/General/interface/precomputed_value_sort.h>
 #include <Geometry/CommonDetUnit/interface/GeomDet.h>
+#include <TrackingTools/DetLayers/interface/ForwardDetRing.h>
 #include <TrackingTools/DetLayers/interface/simple_stat.h>
 #include <FWCore/Utilities/interface/Exception.h>
 


### PR DESCRIPTION
We reference ForwardDetRing in this header, so we also need to
include the associated header to make this header parsable
on its own.