### PR TITLE
Include DetRod.h in PhiBorderFinder.h

### DIFF
--- a/RecoMuon/DetLayers/src/PhiBorderFinder.h
+++ b/RecoMuon/DetLayers/src/PhiBorderFinder.h
@@ -17,6 +17,7 @@
 #include <DataFormats/GeometryVector/interface/Pi.h>
 #include <Utilities/General/interface/precomputed_value_sort.h>
 #include <TrackingTools/DetLayers/interface/simple_stat.h>
+#include <TrackingTools/DetLayers/interface/DetRod.h>
 #include <FWCore/Utilities/interface/Exception.h>
 
 // FIXME: remove this include


### PR DESCRIPTION
We reference DetRod in this header, so we also need to include
the relevant header to make this header parsable on its own.