### PR TITLE
Added missing include to BarrelUtil.h

### DIFF
--- a/RecoTracker/TkDetLayers/src/BarrelUtil.h
+++ b/RecoTracker/TkDetLayers/src/BarrelUtil.h
@@ -4,6 +4,7 @@
 
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
+#include "TrackingTools/DetLayers/interface/GeometricSearchDet.h"
 #include "TrackingTools/DetLayers/interface/MeasurementEstimator.h"
 #include "TrackingTools/DetLayers/interface/rangesIntersect.h"
 #include "TrackingTools/DetLayers/interface/PhiLess.h"


### PR DESCRIPTION
We use GeometricSearchDet in this header, so we also need to
include the associated header to make this header parsable on its
own.