### PR TITLE
Added missing include to TrajAnnealing

### DIFF
--- a/TrackingTools/PatternTools/interface/TrajAnnealing.h
+++ b/TrackingTools/PatternTools/interface/TrajAnnealing.h
@@ -1,6 +1,8 @@
 #ifndef TrackingTools_PatternTools_TrajAnnealing_h
 #define TrackingTools_PatternTools_TrajAnnealing_h
 
+#include "TrackingTools/PatternTools/interface/Trajectory.h"
+
 #include <vector>
 
 /**  This class allow to save all the traj info


### PR DESCRIPTION
This header references Trajectory but never includes the header
declaring this class. This patch adds the missing include to
make this header parsable on its own.