### PR TITLE
Added missing includes to NullPostProcessor

### DIFF
--- a/CommonTools/UtilAlgos/interface/NullPostProcessor.h
+++ b/CommonTools/UtilAlgos/interface/NullPostProcessor.h
@@ -5,6 +5,14 @@
  * \author Luca Lista, INFN
  */
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "DataFormats/Common/interface/OrphanHandle.h"
+
+namespace edm {
+  class EDFilter;
+  class Event;
+  class ParameterSet;
+}
+
 namespace helper {
 
   template<typename OutputCollection, typename EdmFilter=edm::EDFilter>


### PR DESCRIPTION
This file references Event, EDFilter, ParameterSet and OrphanHandle
but doesn't include the header declaring these classes. This patch
adds the missing includes and forward decls to make this header
parsable on its own.