### PR TITLE
Added missing includes to FwdPtrConversionFactory.h

### DIFF
--- a/CommonTools/UtilAlgos/interface/FwdPtrConversionFactory.h
+++ b/CommonTools/UtilAlgos/interface/FwdPtrConversionFactory.h
@@ -10,6 +10,10 @@
   \author   Salvatore Rappoccio
 */
 
+#include "DataFormats/Common/interface/FwdPtr.h"
+#include "DataFormats/Common/interface/RefToBaseVector.h"
+
+#include <functional>
 
 namespace edm {
   /// Factory class template for how to produce products


### PR DESCRIPTION
This file references std::unary_function, edm::FwdPtr and
edm::View but doesn't include any header for that provides
the necessary declarations. This patch adds these includes
to make this header parsable on its own.