### PR TITLE
Added missing include to DummySelector.h

### DIFF
--- a/CommonTools/UtilAlgos/interface/DummySelector.h
+++ b/CommonTools/UtilAlgos/interface/DummySelector.h
@@ -9,6 +9,8 @@
  *
  * \author Luca Lista, INFN
  */
+#include "CommonTools/UtilAlgos/interface/EventSetupInitTrait.h"
+
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 


### PR DESCRIPTION
This header references the EVENTSETUP_STD_INIT macro but never
includes the header defining this macro. This patch adds the
right include that defines this macro to make this header
parsable on its own.