### PR TITLE
Added missing include to AssociatedVariableCollectionSelector.h

### DIFF
--- a/CommonTools/UtilAlgos/interface/AssociatedVariableCollectionSelector.h
+++ b/CommonTools/UtilAlgos/interface/AssociatedVariableCollectionSelector.h
@@ -13,6 +13,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "CommonTools/UtilAlgos/interface/SelectionAdderTrait.h"
+#include "CommonTools/UtilAlgos/interface/SelectedOutputCollectionTrait.h"
 #include "CommonTools/UtilAlgos/interface/StoreContainerTrait.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
 #include "DataFormats/Common/interface/getRef.h"


### PR DESCRIPTION
We use SelectedOutputCollectionTrait in this header but never
include the associated header that contains the declaration of
SelectedOutputCollectionTrait. This patch adds the missing
include to make this file parsable on its own.