### PR TITLE
Include TrackCandidateCollection in TrackCandidateSeedAssociation.h

### DIFF
--- a/DataFormats/TrackCandidate/interface/TrackCandidateSeedAssociation.h
+++ b/DataFormats/TrackCandidate/interface/TrackCandidateSeedAssociation.h
@@ -5,7 +5,7 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/RefProd.h"
-#include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
+#include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include "DataFormats/Common/interface/AssociationMap.h"
 


### PR DESCRIPTION
We use TrackCandidateCollection in this header, but only include
TrackCandidate.h. This patch fixes the include to make this header
parsable on its own.