### PR TITLE
Added include for vector to SelectionUserVariables.h

### DIFF
--- a/Alignment/CommonAlignmentAlgorithm/interface/SelectionUserVariables.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/SelectionUserVariables.h
@@ -17,6 +17,8 @@
 
 #include "Alignment/CommonAlignment/interface/AlignmentUserVariables.h"
 
+#include <vector>
+
 class SelectionUserVariables : public AlignmentUserVariables 
 {
  public:


### PR DESCRIPTION
We use std::vector in this header, so we also need to include
the `vector` header to make this header parsable on its own.