### PR TITLE
Added missing forward decls to DDNodeSelector.h

### DIFF
--- a/DetectorDescription/Core/interface/DDNodeSelector.h
+++ b/DetectorDescription/Core/interface/DDNodeSelector.h
@@ -3,6 +3,9 @@
 
 #include <string>
 
+class DDCompactView;
+class DDGeoHistory;
+
 /** given a part selection std::string, a node selector calculates all expanded nodes in the geometry tree */
 class DDNodeSelector
 {


### PR DESCRIPTION
This header references DDCompactView and DDGeoHistory but doesn't
include any header containing the declarations of those two
classes. We forward declare them to make this file parsable on
its own.