### PR TITLE
Make AlignableDataIO.h/AlignableDataIOROOT.h standalone

### DIFF
--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignableDataIO.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignableDataIO.h
@@ -1,7 +1,10 @@
 #ifndef Alignment_CommonAlignmentAlgorithm_AlignableDataIO_H
 #define Alignment_CommonAlignmentAlgorithm_AlignableDataIO_H
 
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignableData.h"
+
+class Alignable;
 
 /// Abstract base class for IO of alignable positions/shifts.
 /// Derived concrete class must implement raw read/write methods 

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignableDataIORoot.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignableDataIORoot.h
@@ -7,6 +7,8 @@
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignableDataIO.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentIORootBase.h"
 
+class Alignable;
+
 /// concrete class for ROOT based IO of Alignable positions 
 
 class AlignableDataIORoot : public AlignmentIORootBase, public AlignableDataIO


### PR DESCRIPTION
Both headers reference Alignable but don't include any header that
contains the declaration of this. Let's just forward declare it
to fix this and make the header parsable on its own.

AlignableDataIO.h also references Alignables but never includes
any header declaring this class, so we also add the missing
include here.