### PR TITLE
Made simple_stat.h standalone

### DIFF
--- a/TrackingTools/DetLayers/interface/simple_stat.h
+++ b/TrackingTools/DetLayers/interface/simple_stat.h
@@ -1,3 +1,7 @@
+#ifndef TrackingTools_DetLayers_simple_stat_h
+#define TrackingTools_DetLayers_simple_stat_h
+
+#include <algorithm>
 #include <numeric>
 #include <cmath>
 
@@ -32,3 +36,5 @@ double stat_RMS( const CONT & cont) {
   }
   else return 0.;
 }
+
+#endif // TrackingTools_DetLayers_simple_stat_h


### PR DESCRIPTION
This header is lacking header guards and it uses std::max but
doesn't include the `algorithm` header. This path just adds
the missing guards and the right include to make this header
work with modules.