### PR TITLE
Added include for algorithm to get std::min

### DIFF
--- a/Utilities/BinningTools/interface/PeriodicBinFinderInPhi.h
+++ b/Utilities/BinningTools/interface/PeriodicBinFinderInPhi.h
@@ -3,6 +3,7 @@
 
 #include "Utilities/BinningTools/interface/BaseBinFinder.h"
 
+#include <algorithm>
 #include <cmath>
 
 /** Periodic Bin Finder around a circle for (almost) equidistant bins.


### PR DESCRIPTION
std::min is used in this header but we need to include the
`algorithm` header to get the declaration of std::min and
make this header parsable on its own.