### PR TITLE
Added include for PFTau3ProngSummaryFwd.h

### DIFF
--- a/DataFormats/TauReco/interface/PFTau3ProngSummaryAssociation.h
+++ b/DataFormats/TauReco/interface/PFTau3ProngSummaryAssociation.h
@@ -7,6 +7,7 @@
 #include "DataFormats/Common/interface/RefProd.h"
 #include "DataFormats/TauReco/interface/PFTau.h"
 #include "DataFormats/TauReco/interface/PFTauFwd.h"
+#include "DataFormats/TauReco/interface/PFTau3ProngSummaryFwd.h"
 
 namespace reco {
   // PPFTau3ProngSummary


### PR DESCRIPTION
In this header we reference reco::PFTau3ProngSummaryRef for which
we first need to include PFTau3ProngSummaryFwd.h to make this
header parsable on its own.