### PR TITLE
Refactored HcalRecHitFwd.h to HcalRecHitDefs.h

### DIFF
--- a/DataFormats/CastorReco/interface/CastorTower.h
+++ b/DataFormats/CastorReco/interface/CastorTower.h
@@ -18,7 +18,7 @@
 #include "DataFormats/Common/interface/SortedCollection.h"
 
 #include "DataFormats/HcalRecHit/interface/CastorRecHit.h"
-//#include "DataFormats/HcalRecHit/interface/HcalRecHitFwd.h"
+//#include "DataFormats/HcalRecHit/interface/HcalRecHitDefs.h"
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
 
 namespace reco {

--- a/DataFormats/HcalRecHit/interface/HcalRecHitDefs.h
+++ b/DataFormats/HcalRecHit/interface/HcalRecHitDefs.h
@@ -6,12 +6,12 @@
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/RefProd.h"
 
-class HBHERecHit;
-class HORecHit;
-class HFRecHit;
-class ZDCRecHit;
-class CastorRecHit;
-class HcalCalibRecHit;
+#include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
+#include "DataFormats/HcalRecHit/interface/HORecHit.h"
+#include "DataFormats/HcalRecHit/interface/HFRecHit.h"
+#include "DataFormats/HcalRecHit/interface/ZDCRecHit.h"
+#include "DataFormats/HcalRecHit/interface/CastorRecHit.h"
+#include "DataFormats/HcalRecHit/interface/HcalCalibRecHit.h"
 
 typedef edm::SortedCollection<HBHERecHit> HBHERecHitCollection;
 typedef edm::Ref<HBHERecHitCollection> HBHERecHitRef;

--- a/DataFormats/HcalRecHit/src/classes.h
+++ b/DataFormats/HcalRecHit/src/classes.h
@@ -7,7 +7,7 @@
 #include "DataFormats/HcalRecHit/interface/HBHEChannelInfo.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h" 
-#include "DataFormats/HcalRecHit/interface/HcalRecHitFwd.h" 
+#include "DataFormats/HcalRecHit/interface/HcalRecHitDefs.h" 
 #include "DataFormats/HcalRecHit/interface/HcalSourcePositionData.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h" 
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"

--- a/DataFormats/RecoCandidate/src/classes.h
+++ b/DataFormats/RecoCandidate/src/classes.h
@@ -22,7 +22,7 @@
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "DataFormats/RecoCandidate/interface/TrackCandidateAssociation.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h" 
-#include "DataFormats/HcalRecHit/interface/HcalRecHitFwd.h" 
+#include "DataFormats/HcalRecHit/interface/HcalRecHitDefs.h" 
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/Common/interface/RefProd.h" 
 #include "DataFormats/Common/interface/Wrapper.h"

--- a/RecoJets/JetProducers/interface/JetIDHelper.h
+++ b/RecoJets/JetProducers/interface/JetIDHelper.h
@@ -4,7 +4,7 @@
 #include <atomic>
 
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
-#include "DataFormats/HcalRecHit/interface/HcalRecHitFwd.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitDefs.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EcalDetId/interface/EcalDetIdCollections.h"
 

--- a/RecoMET/METAlgorithms/interface/EcalHaloAlgo.h
+++ b/RecoMET/METAlgorithms/interface/EcalHaloAlgo.h
@@ -38,7 +38,7 @@
 #include "DataFormats/EgammaCandidates/interface/ConversionFwd.h"
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
-#include "DataFormats/HcalRecHit/interface/HcalRecHitFwd.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitDefs.h"
 #include "DataFormats/METReco/interface/HaloClusterCandidateECAL.h"
 
 class EcalHaloAlgo

--- a/RecoMET/METAlgorithms/interface/HcalHaloAlgo.h
+++ b/RecoMET/METAlgorithms/interface/HcalHaloAlgo.h
@@ -27,7 +27,7 @@
 #include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
 #include "DataFormats/HcalRecHit/interface/HFRecHit.h"
 #include "DataFormats/HcalRecHit/interface/HORecHit.h"
-#include "DataFormats/HcalRecHit/interface/HcalRecHitFwd.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitDefs.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "DataFormats/CaloRecHit/interface/CaloRecHit.h"
 #include "DataFormats/CaloTowers/interface/CaloTower.h"

--- a/RecoMET/METProducers/interface/EcalHaloDataProducer.h
+++ b/RecoMET/METProducers/interface/EcalHaloDataProducer.h
@@ -54,7 +54,7 @@
 #include "DataFormats/EgammaCandidates/interface/ConversionFwd.h"
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
-#include "DataFormats/HcalRecHit/interface/HcalRecHitFwd.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitDefs.h"
 #include "DataFormats/HepMCCandidate/interface/PdfInfo.h" 
 #include "DataFormats/GeometrySurface/interface/Cylinder.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"


### PR DESCRIPTION
As discussed in PR #18805, the *Fwd.h files aren't working with
forward declarations (due to `Ref` needing a definition). This
PR brings the same change to the HcalRecHitFwd.h header.