### PR TITLE
[10.0.x] add plot of BS parameters in beamspot payload inspector

### DIFF
--- a/CondCore/BeamSpotPlugins/plugins/BeamSpot_PayloadInspector.cc
+++ b/CondCore/BeamSpotPlugins/plugins/BeamSpot_PayloadInspector.cc
@@ -6,8 +6,20 @@
 
 #include <memory>
 #include <sstream>
+#include "TCanvas.h"
+#include "TH2F.h"
 
 namespace {
+
+  enum parameters {X,
+		   Y,
+		   Z,
+		   sigmaX,
+		   sigmaY,
+		   sigmaZ,
+		   dxdz,
+		   dydz,    
+		   END_OF_TYPES};
 
   class BeamSpot_hx : public cond::payloadInspector::HistoryPlot<BeamSpotObjects,std::pair<double,double> > {
   public:
@@ -58,8 +70,107 @@ namespace {
     }
   };
 
+  /************************************************
+    Display of Beam Spot parameters
+  *************************************************/
+  class BeamSpotParameters : public cond::payloadInspector::PlotImage<BeamSpotObjects> {
+  public:
+    BeamSpotParameters() : cond::payloadInspector::PlotImage<BeamSpotObjects>( "Display of BeamSpot parameters" ){
+    setSingleIov( true );
+    }
+  
+    bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override{
+      auto iov = iovs.front();
+      std::shared_ptr<BeamSpotObjects> payload = fetchPayload( std::get<1>(iov) );
+      
+      TCanvas canvas("Beam Spot Parameters Summary","BeamSpot Parameters summary",1000,1000); 
+      canvas.cd();
 
-}
+      canvas.SetTopMargin(0.07);
+      canvas.SetBottomMargin(0.06);
+      canvas.SetLeftMargin(0.15);
+      canvas.SetRightMargin(0.03);
+      canvas.Modified();
+      canvas.SetGrid();
+
+      auto h2_BSParameters = std::unique_ptr<TH2F>(new TH2F("Parameters","BeamSpot parameters summary",2,0.0,2.0,8,0,8.));
+      h2_BSParameters->SetStats(false);
+      
+      std::function<double(parameters,bool)> cutFunctor = [&payload](parameters my_param,bool isError) {	
+	double ret(-999.);
+	if(!isError){
+	  switch(my_param){
+	  case X      : return payload->GetX();
+	  case Y      : return payload->GetY();	    
+	  case Z      : return payload->GetZ();	    
+	  case sigmaX : return payload->GetBeamWidthX(); 
+	  case sigmaY : return payload->GetBeamWidthY(); 
+	  case sigmaZ : return payload->GetSigmaZ(); 
+	  case dxdz   : return payload->Getdxdz();   
+	  case dydz   : return payload->Getdydz();   
+	  case END_OF_TYPES : return ret;
+	  default : return ret;
+	  }
+	} else {
+	  switch(my_param){
+	  case X      : return payload->GetXError();
+	  case Y      : return payload->GetYError();	    
+	  case Z      : return payload->GetZError();	    
+	  case sigmaX : return payload->GetBeamWidthXError(); 
+	  case sigmaY : return payload->GetBeamWidthYError(); 
+	  case sigmaZ : return payload->GetSigmaZError(); 
+	  case dxdz   : return payload->GetdxdzError();   
+	  case dydz   : return payload->GetdydzError();   
+	  case END_OF_TYPES : return ret;
+	  default : return ret;
+	  }
+	}
+      };
+
+      h2_BSParameters->GetXaxis()->SetBinLabel(1,"Value");
+      h2_BSParameters->GetXaxis()->SetBinLabel(2,"Error");
+
+      unsigned int yBin=8;
+      for(int foo = parameters::X; foo != parameters::END_OF_TYPES; foo++ ){
+	parameters param = static_cast<parameters>(foo);
+	std::string theLabel =  getStringFromTypeEnum(param);
+	h2_BSParameters->GetYaxis()->SetBinLabel(yBin,theLabel.c_str());
+	h2_BSParameters->SetBinContent(1,yBin,cutFunctor(param,false)); 
+	h2_BSParameters->SetBinContent(2,yBin,cutFunctor(param,true)); 
+	yBin--;
+      }
+      
+      h2_BSParameters->GetXaxis()->LabelsOption("h");
+      
+      h2_BSParameters->GetYaxis()->SetLabelSize(0.05);
+      h2_BSParameters->GetXaxis()->SetLabelSize(0.05);
+
+      h2_BSParameters->SetMarkerSize(1.5);
+      h2_BSParameters->Draw("TEXT");
+      
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }
+
+    /************************************************/
+    std::string getStringFromTypeEnum (const parameters &parameter){
+      switch(parameter){
+      case X      : return "X [cm]";
+      case Y      : return "Y [cm]";	    
+      case Z      : return "Z [cm]";	    
+      case sigmaX : return "#sigma_{X} [cm]"; 
+      case sigmaY : return "#sigma_{Y} [cm]"; 
+      case sigmaZ : return "#sigma_{Z} [cm]"; 
+      case dxdz   : return "#frac{dX}{dZ} [rad]";   
+      case dydz   : return "#frac{dY}{dZ} [rad]";   
+      default: return "should never be here";
+      }
+    }
+  };
+
+} // close namespace
 
 PAYLOAD_INSPECTOR_MODULE( BeamSpot ){
   PAYLOAD_INSPECTOR_CLASS( BeamSpot_hx );
@@ -67,4 +178,5 @@ PAYLOAD_INSPECTOR_MODULE( BeamSpot ){
   PAYLOAD_INSPECTOR_CLASS( BeamSpot_x );
   PAYLOAD_INSPECTOR_CLASS( BeamSpot_y );
   PAYLOAD_INSPECTOR_CLASS( BeamSpot_xy );
+  PAYLOAD_INSPECTOR_CLASS( BeamSpotParameters );
 }


### PR DESCRIPTION
Adds a synoptic view plot for the offline Beam Spot parameters in DB, in the same style as it is done for the online BS fit monitoring: 

![553ed977-9ccd-493a-8808-e1b8a602d99a](https://user-images.githubusercontent.com/5082376/33081571-f6019486-ceda-11e7-8d2a-59c0a22d5990.png)
