### PR TITLE
[10.0.x] Add dump plot of AlignPCLThreshold in the payload inspector

### DIFF
--- a/CondCore/PCLConfigPlugins/plugins/AlignPCLThresholds_PayloadInspector.cc
+++ b/CondCore/PCLConfigPlugins/plugins/AlignPCLThresholds_PayloadInspector.cc
@@ -13,12 +13,10 @@
 // the data format of the condition to be inspected
 #include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"
 
-// auxilliary functions
-
 #include <memory>
 #include <sstream>
 #include <iostream>
-#include <regex>
+#include <functional>
 
 // include ROOT 
 #include "TH2F.h"
@@ -26,11 +24,14 @@
 #include "TCanvas.h"
 #include "TLine.h"
 #include "TStyle.h"
-#include "TLatex.h"
-#include "TPave.h"
-#include "TPaveStats.h"
 
 namespace {
+
+  enum types {DELTA,
+	      SIG,
+	      MAXMOVE,
+	      MAXERR,
+	      END_OF_TYPES};
   
   /************************************************
     Display of AlignPCLThresholds
@@ -44,49 +45,58 @@ namespace {
     bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override{
       auto iov = iovs.front();
       std::shared_ptr<AlignPCLThresholds> payload = fetchPayload( std::get<1>(iov) );
-      AlignPCLThresholds::threshold_map m_thresholds = payload->getThreshold_Map();
+      auto alignables = payload->getAlignableList();
       
-      TCanvas canvas("Alignment PCL thresholds summary","Alignment PCL thresholds summary",1000,1000); 
+      TCanvas canvas("Alignment PCL thresholds summary","Alignment PCL thresholds summary",1500,800); 
       canvas.cd();
 
       canvas.SetTopMargin(0.07);
-      canvas.SetBottomMargin(0.25);
-      canvas.SetLeftMargin(0.18);
+      canvas.SetBottomMargin(0.06);
+      canvas.SetLeftMargin(0.11);
       canvas.SetRightMargin(0.05);
       canvas.Modified();
       canvas.SetGrid();
 
-      auto Thresholds = std::unique_ptr<TH2F>(new TH2F("Thresholds","Alignment parameter thresholds",m_thresholds.size(),0,m_thresholds.size(),24,0,24));
+      auto Thresholds = std::unique_ptr<TH2F>(new TH2F("Thresholds","Alignment parameter thresholds",alignables.size(),0,alignables.size(),24,0,24));
       Thresholds->SetStats(false);
+      
+      std::function<float(types,std::string,AlignPCLThresholds::coordType)> cutFunctor = [&payload](types my_type,std::string alignable,AlignPCLThresholds::coordType coord) {	
+	float ret(-999.);
+	switch(my_type){
+	case DELTA   : return payload->getCut(alignable,coord);
+	case SIG     : return payload->getSigCut(alignable,coord);
+	case MAXMOVE : return payload->getMaxMoveCut(alignable,coord);
+	case MAXERR  : return payload->getMaxErrorCut(alignable,coord);
+	case END_OF_TYPES : return ret;
+	default : return ret;
+	}
+      };
 
-      std::array<std::string,24> ylabels = {{"X","sig X","maxMove X","Error X","Y","sig Y","maxMove Y","Error Y","Z","sig Z","maxMove Z", "Error Z","#theta_{X}","sig #theta_{X}","maxMove #theta_{X}","Error #theta_{X}","#theta_{Y}","sig #theta_{Y}","maxMove #theta_{Y}","Error #theta_{Y}","#theta_{Z}","sig #theta_{Z}","maxMove #theta_{Z}","Error #theta_{Z}"}};
-
-      unsigned int xBin=0;
-      for(const auto &entry : m_thresholds){
+      unsigned int xBin=0;	    
+      for(const auto &alignable : alignables){
 	xBin++;
- 	Thresholds->GetXaxis()->SetBinLabel(xBin,(entry.first).c_str());
 
-	// fill the labels on y-axis
-	unsigned int yBin=25;
-	for (const std::string &text : ylabels ){
-	  yBin--;
-	  if(xBin==1){
-	    Thresholds->GetYaxis()->SetBinLabel(yBin,text.c_str());
-	  }
-	}
-
+	auto xLabel = replaceAll(replaceAll(alignable,"minus","(-)"),"plus","(+)");
+ 	Thresholds->GetXaxis()->SetBinLabel(xBin,(xLabel).c_str());
+	unsigned int yBin=24;
 	for(int foo = AlignPCLThresholds::X; foo != AlignPCLThresholds::extra_DOF; foo++ ){
-	  AlignPCLThresholds::coordType type = static_cast<AlignPCLThresholds::coordType>(foo);  
+	  AlignPCLThresholds::coordType coord = static_cast<AlignPCLThresholds::coordType>(foo);  
+	  for(int bar = types::DELTA; bar != types::END_OF_TYPES; bar++ ){
+	    types type = static_cast<types>(bar);
+	    std::string theLabel = getStringFromTypeEnum(type)+getStringFromCoordEnum(coord);
+	    if(xBin==1){
+	      Thresholds->GetYaxis()->SetBinLabel(yBin,theLabel.c_str());
+	    }
+ 
+	    Thresholds->SetBinContent(xBin,yBin,cutFunctor(type,alignable,coord)); 
 
-	  Thresholds->SetBinContent(xBin,24-(foo*4),payload->getCut(entry.first,type));
-	  Thresholds->SetBinContent(xBin,24-((foo*4)+1),payload->getSigCut(entry.first,type));
-	  Thresholds->SetBinContent(xBin,24-((foo*4)+2),payload->getMaxMoveCut(entry.first,type));
-	  Thresholds->SetBinContent(xBin,24-((foo*4)+3),payload->getMaxErrorCut(entry.first,type));
-	}
-	
-      }
+	    yBin--;
+	  }// loop on types
+	}// loop on coordinates
+      } // loop on alignables
 
-      Thresholds->GetXaxis()->LabelsOption("v");
+
+      Thresholds->GetXaxis()->LabelsOption("h");
       Thresholds->Draw("TEXT");
       
       std::string fileName(m_imageFileName);
@@ -95,18 +105,44 @@ namespace {
       return true;
     }
     
-    std::string getStringFromCoordEnum (const AlignPCLThresholds::coordType &type){
-      switch(type){
+    /************************************************/
+    std::string getStringFromCoordEnum (const AlignPCLThresholds::coordType &coord){
+      switch(coord){
       case AlignPCLThresholds::X : return "X";
       case AlignPCLThresholds::Y : return "Y";
-      case AlignPCLThresholds::Z : return "Y";
-      case AlignPCLThresholds::theta_X : return "theta_X";
-      case AlignPCLThresholds::theta_Y : return "theta_Y";
-      case AlignPCLThresholds::theta_Z : return "theta_Z";
+      case AlignPCLThresholds::Z : return "Z";
+      case AlignPCLThresholds::theta_X : return "#theta_{X}";
+      case AlignPCLThresholds::theta_Y : return "#theta_{Y}";
+      case AlignPCLThresholds::theta_Z : return "#theta_{Z}";
       default : return "should never be here";
       }
     }
-    
+
+    /************************************************/
+    std::string getStringFromTypeEnum (const types &type){
+      switch(type){
+      case types::DELTA   : return "#Delta";
+      case types::SIG     : return "#Delta/#sigma ";
+      case types::MAXMOVE : return "max. move ";
+      case types::MAXERR  : return "max. err ";
+      default: return "should never be here";
+      }
+    }
+
+    /************************************************/
+    std::string replaceAll(const std::string& str, const std::string& from, const std::string& to) {
+      std::string out(str);
+  
+      if(from.empty())
+        return out;
+      size_t start_pos = 0;
+      while((start_pos = out.find(from, start_pos)) != std::string::npos) {
+        out.replace(start_pos, from.length(), to);
+        start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
+      }
+      return out;
+    }
+   
   };
 } // close namespace
 

--- a/CondCore/PCLConfigPlugins/plugins/AlignPCLThresholds_PayloadInspector.cc
+++ b/CondCore/PCLConfigPlugins/plugins/AlignPCLThresholds_PayloadInspector.cc
@@ -1,0 +1,116 @@
+/*!
+  \file AlignPCLThresholds_PayloadInspector
+  \Payload Inspector Plugin for Alignment PCL thresholds
+  \author M. Musich
+  \version $Revision: 1.0 $
+  \date $Date: 2017/10/19 12:51:00 $
+*/
+
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+
+// the data format of the condition to be inspected
+#include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"
+
+// auxilliary functions
+
+#include <memory>
+#include <sstream>
+#include <iostream>
+#include <regex>
+
+// include ROOT 
+#include "TH2F.h"
+#include "TLegend.h"
+#include "TCanvas.h"
+#include "TLine.h"
+#include "TStyle.h"
+#include "TLatex.h"
+#include "TPave.h"
+#include "TPaveStats.h"
+
+namespace {
+  
+  /************************************************
+    Display of AlignPCLThresholds
+  *************************************************/
+  class AlignPCLThresholds_Display : public cond::payloadInspector::PlotImage<AlignPCLThresholds> {
+  public:
+    AlignPCLThresholds_Display() : cond::payloadInspector::PlotImage<AlignPCLThresholds>( "Display of threshold parameters for SiPixelAli PCL" ){
+    setSingleIov( true );
+    }
+  
+    bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override{
+      auto iov = iovs.front();
+      std::shared_ptr<AlignPCLThresholds> payload = fetchPayload( std::get<1>(iov) );
+      AlignPCLThresholds::threshold_map m_thresholds = payload->getThreshold_Map();
+      
+      TCanvas canvas("Alignment PCL thresholds summary","Alignment PCL thresholds summary",1000,1000); 
+      canvas.cd();
+
+      canvas.SetTopMargin(0.07);
+      canvas.SetBottomMargin(0.25);
+      canvas.SetLeftMargin(0.18);
+      canvas.SetRightMargin(0.05);
+      canvas.Modified();
+      canvas.SetGrid();
+
+      auto Thresholds = std::unique_ptr<TH2F>(new TH2F("Thresholds","Alignment parameter thresholds",m_thresholds.size(),0,m_thresholds.size(),24,0,24));
+      Thresholds->SetStats(false);
+
+      std::array<std::string,24> ylabels = {{"X","sig X","maxMove X","Error X","Y","sig Y","maxMove Y","Error Y","Z","sig Z","maxMove Z", "Error Z","#theta_{X}","sig #theta_{X}","maxMove #theta_{X}","Error #theta_{X}","#theta_{Y}","sig #theta_{Y}","maxMove #theta_{Y}","Error #theta_{Y}","#theta_{Z}","sig #theta_{Z}","maxMove #theta_{Z}","Error #theta_{Z}"}};
+
+      unsigned int xBin=0;
+      for(const auto &entry : m_thresholds){
+	xBin++;
+ 	Thresholds->GetXaxis()->SetBinLabel(xBin,(entry.first).c_str());
+
+	// fill the labels on y-axis
+	unsigned int yBin=25;
+	for (const std::string &text : ylabels ){
+	  yBin--;
+	  if(xBin==1){
+	    Thresholds->GetYaxis()->SetBinLabel(yBin,text.c_str());
+	  }
+	}
+
+	for(int foo = AlignPCLThresholds::X; foo != AlignPCLThresholds::extra_DOF; foo++ ){
+	  AlignPCLThresholds::coordType type = static_cast<AlignPCLThresholds::coordType>(foo);  
+
+	  Thresholds->SetBinContent(xBin,24-(foo*4),payload->getCut(entry.first,type));
+	  Thresholds->SetBinContent(xBin,24-((foo*4)+1),payload->getSigCut(entry.first,type));
+	  Thresholds->SetBinContent(xBin,24-((foo*4)+2),payload->getMaxMoveCut(entry.first,type));
+	  Thresholds->SetBinContent(xBin,24-((foo*4)+3),payload->getMaxErrorCut(entry.first,type));
+	}
+	
+      }
+
+      Thresholds->GetXaxis()->LabelsOption("v");
+      Thresholds->Draw("TEXT");
+      
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }
+    
+    std::string getStringFromCoordEnum (const AlignPCLThresholds::coordType &type){
+      switch(type){
+      case AlignPCLThresholds::X : return "X";
+      case AlignPCLThresholds::Y : return "Y";
+      case AlignPCLThresholds::Z : return "Y";
+      case AlignPCLThresholds::theta_X : return "theta_X";
+      case AlignPCLThresholds::theta_Y : return "theta_Y";
+      case AlignPCLThresholds::theta_Z : return "theta_Z";
+      default : return "should never be here";
+      }
+    }
+    
+  };
+} // close namespace
+
+// Register the classes as boost python plugin
+PAYLOAD_INSPECTOR_MODULE(AlignPCLThresholds){
+  PAYLOAD_INSPECTOR_CLASS(AlignPCLThresholds_Display);
+}

--- a/CondCore/PCLConfigPlugins/plugins/BuildFile.xml
+++ b/CondCore/PCLConfigPlugins/plugins/BuildFile.xml
@@ -1,0 +1,8 @@
+<flags CXX_FLAGS="-Wno-unused-variable"/>
+
+<library   file="AlignPCLThresholds_PayloadInspector.cc" name="AlignPCLThresholds_PayloadInspector">
+  <use   name="CondCore/Utilities"/>
+  <use   name="CondCore/CondDB"/>
+  <use   name="CondFormats/Common"/>
+  <use   name="boost_python"/>
+</library>

--- a/CondCore/PCLConfigPlugins/plugins/BuildFile.xml
+++ b/CondCore/PCLConfigPlugins/plugins/BuildFile.xml
@@ -1,5 +1,3 @@
-<flags CXX_FLAGS="-Wno-unused-variable"/>
-
 <library   file="AlignPCLThresholds_PayloadInspector.cc" name="AlignPCLThresholds_PayloadInspector">
   <use   name="CondCore/Utilities"/>
   <use   name="CondCore/CondDB"/>

--- a/CondCore/PCLConfigPlugins/test/test.sh
+++ b/CondCore/PCLConfigPlugins/test/test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Save current working dir so img can be outputted there later
+W_DIR=$(pwd);
+# Set SCRAM architecture var
+SCRAM_ARCH=slc6_amd64_gcc630;
+export SCRAM_ARCH;
+source /afs/cern.ch/cms/cmsset_default.sh;
+eval `scram run -sh`;
+# Go back to original working directory
+cd $W_DIR;
+# Run get payload data script
+
+####################
+# Test Gains
+####################
+/afs/cern.ch/user/c/condbpro/public/BROWSER_PI/getPayloadData.py \
+    --plugin pluginAlignPCLThresholds_PayloadInspector \
+    --plot plot_AlignPCLThresholds_Display \
+    --tag SiPixelAliThresholds_offline_v0 \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;


### PR DESCRIPTION
Adds a parameters diplay plot for the `AlignPCLThreshold` object type, storing the "trigger-update" thresholds for the `SiPixelAli` Prompt Calibration Loop workflow. 