### PR TITLE
[9.4.X] Update GT: Update all L1T tags (except L1TMuonEndCapForestRcd) + adding GT used for MC v2 production

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -28,7 +28,7 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '94X_dataRun2_v4',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '94X_dataRun2_relval_v8',
+    'run2_data_relval'  :   '94X_dataRun2_relval_v9',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
     'run2_data_promptlike' : '94X_dataRun2_PromptLike_v9',
     # GlobalTag for Run1 HLT: it points to the online GT

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,35 +10,35 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '94X_mcRun1_pA_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '94X_mcRun2_design_v1',
+    'run2_design'       :   '94X_mcRun2_design_v2',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '94X_mcRun2_startup_v1',
+    'run2_mc_50ns'      :   '94X_mcRun2_startup_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '94X_mcRun2_asymptotic_v1',
+    'run2_mc'           :   '94X_mcRun2_asymptotic_v2',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
     'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '94X_mcRun2cosmics_startup_deco_v1',
+    'run2_mc_cosmics'   :   '94X_mcRun2cosmics_startup_deco_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '93X_mcRun2_HeavyIon_v0',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '94X_mcRun2_pA_v1',
+    'run2_mc_pa'        :   '94X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '94X_dataRun2_v4',
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '94X_dataRun2_v4',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '94X_dataRun2_relval_v7',
+    'run2_data_relval'  :   '94X_dataRun2_relval_v8',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '94X_dataRun2_PromptLike_v8',
+    'run2_data_promptlike' : '94X_dataRun2_PromptLike_v9',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '94X_dataRun2_HLT_frozen_v5',
+    'run1_hlt'          :   '94X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '94X_dataRun2_HLT_frozen_v5',
+    'run2_hlt'          :   '94X_dataRun2_HLT_frozen_v6',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '94X_dataRun2_HLT_relval_v7',
+    'run2_hlt_relval'   :   '94X_dataRun2_HLT_relval_v8',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '94X_dataRun2_HLTHI_frozen_v4',
+    'run2_hlt_hi'       :   '94X_dataRun2_HLTHI_frozen_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '94X_mc2017_design_IdealBS_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -28,7 +28,7 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '94X_dataRun2_v4',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '94X_dataRun2_relval_v9',
+    'run2_data_relval'  :   '94X_dataRun2_relval_v10',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
     'run2_data_promptlike' : '94X_dataRun2_PromptLike_v9',
     # GlobalTag for Run1 HLT: it points to the online GT

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,53 +10,53 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   '94X_mcRun1_pA_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '94X_mcRun2_design_v0',
+    'run2_design'       :   '94X_mcRun2_design_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '94X_mcRun2_startup_v0',
+    'run2_mc_50ns'      :   '94X_mcRun2_startup_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '94X_mcRun2_asymptotic_v0',
+    'run2_mc'           :   '94X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
     'run2_mc_l1stage1'  :   '93X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '94X_mcRun2cosmics_startup_deco_v0',
+    'run2_mc_cosmics'   :   '94X_mcRun2cosmics_startup_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '93X_mcRun2_HeavyIon_v0',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '94X_mcRun2_pA_v0',
+    'run2_mc_pa'        :   '94X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '94X_dataRun2_v2',
+    'run1_data'         :   '94X_dataRun2_v4',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '94X_dataRun2_v2',
+    'run2_data'         :   '94X_dataRun2_v4',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '94X_dataRun2_relval_v5',
+    'run2_data_relval'  :   '94X_dataRun2_relval_v7',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '94X_dataRun2_PromptLike_v5',
+    'run2_data_promptlike' : '94X_dataRun2_PromptLike_v8',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '94X_dataRun2_HLT_frozen_v3',
+    'run1_hlt'          :   '94X_dataRun2_HLT_frozen_v5',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '94X_dataRun2_HLT_frozen_v3',
+    'run2_hlt'          :   '94X_dataRun2_HLT_frozen_v5',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '94X_dataRun2_HLT_relval_v5',
+    'run2_hlt_relval'   :   '94X_dataRun2_HLT_relval_v7',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '94X_dataRun2_HLTHI_frozen_v2',
+    'run2_hlt_hi'       :   '94X_dataRun2_HLTHI_frozen_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '94X_mc2017_design_IdealBS_v5',
+    'phase1_2017_design'       :  '94X_mc2017_design_IdealBS_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '94X_mc2017_realistic_v5',
+    'phase1_2017_realistic'    : '94X_mc2017_realistic_v10',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '94X_mc2017cosmics_realistic_deco_v4',
+    'phase1_2017_cosmics'      : '94X_mc2017cosmics_realistic_deco_v6',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '94X_mc2017cosmics_realistic_peak_v4',
+    'phase1_2017_cosmics_peak' : '94X_mc2017cosmics_realistic_peak_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '94X_upgrade2018_design_IdealBS_v5',
+    'phase1_2018_design'       : '94X_upgrade2018_design_IdealBS_v7',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '94X_upgrade2018_realistic_v5',
+    'phase1_2018_realistic'    : '94X_upgrade2018_realistic_v7',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '94X_upgrade2018cosmics_realistic_deco_v4',
+    'phase1_2018_cosmics'      :   '94X_upgrade2018cosmics_realistic_deco_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '94X_upgrade2023_realistic_v2'
+    'phase2_realistic'         : '94X_upgrade2023_realistic_v4'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -56,7 +56,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '94X_upgrade2023_realistic_v4'
+    'phase2_realistic'         : '94X_upgrade2023_realistic_v5'
 }
 
 aliases = {


### PR DESCRIPTION
# Summary of changes in Global Tags
This PR update all the GT with the latest  L1T TAGs, except the TAG L1TMuonEndCapForestRcd that is currently pointed by a static file.
Also the GT used for the MC v2 production (94X_mc2017_realistic_v10) is included.
## RunII simulation

   * **RunII Asymptotic scenario** : [94X_mcRun2_asymptotic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2_asymptotic_v2) as [94X_mcRun2_asymptotic_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2_asymptotic_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun2_asymptotic_v2/94X_mcRun2_asymptotic_v0):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

   * **RunII CRAFT scenario** : [94X_mcRun2cosmics_startup_deco_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2cosmics_startup_deco_v2) as [94X_mcRun2cosmics_startup_deco_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2cosmics_startup_deco_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun2cosmics_startup_deco_v2/94X_mcRun2cosmics_startup_deco_v0):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

   * **RunII Ideal scenario** : [94X_mcRun2_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2_design_v2) as [94X_mcRun2_design_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2_design_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun2_design_v2/94X_mcRun2_design_v0):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

   * **RunII Proton-Lead scenario** : [94X_mcRun2_pA_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2_pA_v2) as [94X_mcRun2_pA_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2_pA_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun2_pA_v2/94X_mcRun2_pA_v0):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

   * **RunII Startup scenario** : [94X_mcRun2_startup_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2_startup_v2) as [94X_mcRun2_startup_v0](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mcRun2_startup_v0) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mcRun2_startup_v2/94X_mcRun2_startup_v0):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

## RunI data

   * **RunI HLT processing** : [94X_dataRun2_HLT_frozen_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_frozen_v6) as [94X_dataRun2_HLT_frozen_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_frozen_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_HLT_frozen_v6/94X_dataRun2_HLT_frozen_v3):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

   * **RunI Offline processing** : [94X_dataRun2_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_v4) as [94X_dataRun2_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_v4/94X_dataRun2_v2):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

## RunII data

   * **RunII HLTHI processing** : [94X_dataRun2_HLTHI_frozen_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLTHI_frozen_v5) as [94X_dataRun2_HLTHI_frozen_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLTHI_frozen_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_HLTHI_frozen_v5/94X_dataRun2_HLTHI_frozen_v2):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

   * **RunII HLT relval processing** : [94X_dataRun2_HLT_relval_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_relval_v8) as [94X_dataRun2_HLT_relval_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_relval_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_HLT_relval_v8/94X_dataRun2_HLT_relval_v5):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

   * **RunII Offline processing** : [94X_dataRun2_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_v4) as [94X_dataRun2_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_v4/94X_dataRun2_v2):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

   * **RunII Offline relval processing** : [94X_dataRun2_relval_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_relval_v10) as [94X_dataRun2_relval_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_relval_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_relval_v10/94X_dataRun2_relval_v5):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

   * **RunII Prompt processing** : [94X_dataRun2_PromptLike_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_PromptLike_v9) as [94X_dataRun2_PromptLike_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_PromptLike_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_PromptLike_v9/94X_dataRun2_PromptLike_v5):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

   * **RunI HLT processing** : [94X_dataRun2_HLT_frozen_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_frozen_v6) as [94X_dataRun2_HLT_frozen_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_dataRun2_HLT_frozen_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_dataRun2_HLT_frozen_v6/94X_dataRun2_HLT_frozen_v3):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

## Upgrade

   * **PhaseII realistic scenario** : [94X_upgrade2023_realistic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2023_realistic_v5) as [94X_upgrade2023_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2023_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_upgrade2023_realistic_v5/94X_upgrade2023_realistic_v2):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

   * **PhaseI 2018 cosmics scenario** : [94X_upgrade2018cosmics_realistic_deco_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018cosmics_realistic_deco_v6) as [94X_upgrade2018cosmics_realistic_deco_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018cosmics_realistic_deco_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_upgrade2018cosmics_realistic_deco_v6/94X_upgrade2018cosmics_realistic_deco_v4):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

   * **PhaseI 2018 design scenario** : [94X_upgrade2018_design_IdealBS_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018_design_IdealBS_v7) as [94X_upgrade2018_design_IdealBS_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018_design_IdealBS_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_upgrade2018_design_IdealBS_v7/94X_upgrade2018_design_IdealBS_v5):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

   * **PhaseI 2018 realistic scenario** : [94X_upgrade2018_realistic_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018_realistic_v7) as [94X_upgrade2018_realistic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_upgrade2018_realistic_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_upgrade2018_realistic_v7/94X_upgrade2018_realistic_v5):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

## 2017_MC

   * **PhaseI 2017 cosmics peak scenario** : [94X_mc2017cosmics_realistic_peak_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017cosmics_realistic_peak_v6) as [94X_mc2017cosmics_realistic_peak_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017cosmics_realistic_peak_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017cosmics_realistic_peak_v6/94X_mc2017cosmics_realistic_peak_v4):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

   * **PhaseI 2017 cosmics scenario** : [94X_mc2017cosmics_realistic_deco_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017cosmics_realistic_deco_v6) as [94X_mc2017cosmics_realistic_deco_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017cosmics_realistic_deco_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017cosmics_realistic_deco_v6/94X_mc2017cosmics_realistic_deco_v4):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

   * **PhaseI 2017 design scenario** : [94X_mc2017_design_IdealBS_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017_design_IdealBS_v7) as [94X_mc2017_design_IdealBS_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017_design_IdealBS_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017_design_IdealBS_v7/94X_mc2017_design_IdealBS_v5):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd

   * **PhaseI 2017 realistic scenario** : [94X_mc2017_realistic_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017_realistic_v10) as [94X_mc2017_realistic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/94X_mc2017_realistic_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/94X_mc2017_realistic_v10/94X_mc2017_realistic_v5):
      * Add L1T TAG, but not L1TMuonEndcapParamsRcd