### PR TITLE
Migrate SiStripSubStructure (and TkDetMap, TkHistoMap) from tracker-sub-DetId to TrackerTopology

### DIFF
--- a/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.h
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.h
@@ -36,7 +36,6 @@
 
 //******** Single include for the TkMap *************
 #include "CommonTools/TrackerMap/interface/TrackerMap.h" 
-#include "DQM/SiStripCommon/interface/TkHistoMap.h" 
 //***************************************************
 
 #include <algorithm>

--- a/Alignment/OfflineValidation/test/testCompare_cfg.py
+++ b/Alignment/OfflineValidation/test/testCompare_cfg.py
@@ -23,12 +23,7 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 process.source = cms.Source("EmptySource")
 
-process.load("DQM.SiStripCommon.TkHistoMap_cfi")
-#process.TkDetMap = cms.Service("TkDetMap")
-#process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
-
-process.load("DQMServices.Core.DQMStore_cfg") 
-#process.DQMStore=cms.Service("DQMStore")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)

--- a/CalibFormats/SiStripObjects/src/SiStripDetCabling.cc
+++ b/CalibFormats/SiStripObjects/src/SiStripDetCabling.cc
@@ -6,7 +6,6 @@
 #include "FWCore/Utilities/interface/typelookup.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 #include <iostream>

--- a/CalibTracker/SiStripAPVAnalysis/src/SimplePedestalCalculator.cc
+++ b/CalibTracker/SiStripAPVAnalysis/src/SimplePedestalCalculator.cc
@@ -1,5 +1,4 @@
 #include "CalibTracker/SiStripAPVAnalysis/interface/SimplePedestalCalculator.h"
-#include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 
 #include <cmath>
 #include <numeric>

--- a/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
+++ b/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
@@ -33,7 +33,6 @@
 #include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
 #include "DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h"
 #include "DataFormats/SiStripCluster/interface/SiStripClusterCollection.h"
-#include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainCosmicCalculator.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainCosmicCalculator.cc
@@ -99,9 +99,8 @@ void SiStripGainCosmicCalculator::algoBeginJob(const edm::EventSetup& iSetup)
    siStripDetCabling->addActiveDetectorsRawIds(activeDets);
 //    SelectedDetIds = activeDets; // all active detector modules
    // use SiStripSubStructure for selecting certain regions
-   SiStripSubStructure substructure;
-   substructure.getTIBDetectors(activeDets, SelectedDetIds, 0, 0, 0, 0); // this adds rawDetIds to SelectedDetIds
-   substructure.getTOBDetectors(activeDets, SelectedDetIds, 0, 0, 0);    // this adds rawDetIds to SelectedDetIds
+   SiStripSubStructure::getTIBDetectors(activeDets, SelectedDetIds, tTopo, 0, 0, 0, 0); // this adds rawDetIds to SelectedDetIds
+   SiStripSubStructure::getTOBDetectors(activeDets, SelectedDetIds, tTopo, 0, 0, 0);    // this adds rawDetIds to SelectedDetIds
    // get tracker geometry and find nr. of apv pairs for each active detector 
    edm::ESHandle<TrackerGeometry> tkGeom; iSetup.get<TrackerDigiGeometryRecord>().get( tkGeom );     
    for(TrackerGeometry::DetContainer::const_iterator it = tkGeom->dets().begin(); it != tkGeom->dets().end(); it++){ // loop over detector modules

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -42,7 +42,6 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
-#include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackReco/interface/DeDxHit.h"

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
@@ -36,7 +36,6 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h" 
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
-#include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
@@ -11,7 +11,6 @@
 #include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiStripCluster/interface/SiStripClusterCollection.h"
-#include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"

--- a/CalibTracker/SiStripCommon/interface/ShallowGainCalibration.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowGainCalibration.h
@@ -46,7 +46,6 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
-#include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackReco/interface/DeDxHit.h"

--- a/CalibTracker/SiStripCommon/interface/TkDetMap.h
+++ b/CalibTracker/SiStripCommon/interface/TkDetMap.h
@@ -1,146 +1,161 @@
 #ifndef CalibTracker_SiStripCommon_TKHistoMap_h
 #define CalibTracker_SiStripCommon_TKHistoMap_h
 
-
-#include <map>
+#include <vector>
 #include <boost/cstdint.hpp>
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
-#include "DataFormats/SiStripDetId/interface/TIBDetId.h"
 
-class TkLayerMap{
+class TrackerTopology;
 
- public:
-
+class TkLayerMap
+{
+public:
   struct XYbin{
-    XYbin(const XYbin& in){ix=in.ix;iy=in.iy;x=in.x;y=in.y;}
-    XYbin(int16_t _ix=-999, int16_t _iy=-999, float _x=-999., float _y=-999.){ix=_ix;iy=_iy;x=_x;y=_y;}
+    XYbin(int16_t _ix=-999, int16_t _iy=-999, float _x=-999., float _y=-999.)
+      : ix(_ix), iy(_iy), x(_x), y(_y) {}
     int16_t ix,iy;
     float x,y;
   };
-  
-  enum  TkLayerEnum { INVALID=0,
-		      TIB_L1, //1
-		      TIB_L2,
-		      TIB_L3,
-		      TIB_L4,         
-		      TIDM_D1, //5
-		      TIDM_D2,
-		      TIDM_D3,
-		      TIDP_D1, //8
-		      TIDP_D2,
-		      TIDP_D3,
-		      TOB_L1, //11
-		      TOB_L2,
-		      TOB_L3, 
-		      TOB_L4,
-		      TOB_L5,
-		      TOB_L6,
-		      TECM_W1, //17
-		      TECM_W2,
-		      TECM_W3,
-		      TECM_W4,
-		      TECM_W5,
-		      TECM_W6,
-		      TECM_W7,
-		      TECM_W8,
-		      TECM_W9,
-		      TECP_W1, //26
-		      TECP_W2,
-		      TECP_W3,
-		      TECP_W4,
-		      TECP_W5,
-		      TECP_W6,
-		      TECP_W7,
-		      TECP_W8,
-		      TECP_W9 //34
-  };
 
-  
-  TkLayerMap(int in);
-  ~TkLayerMap(){
-    delete [] binToDet;
-  };
-  
-  const XYbin getXY(uint32_t detid, int layerEnumNb=0) const;
+  enum TkLayerEnum { INVALID=0,
+                     TIB_L1, TIB_L2, TIB_L3, TIB_L4, //1-4
+                     TIDM_D1, TIDM_D2, TIDM_D3, //5-7
+                     TIDP_D1, TIDP_D2, TIDP_D3, //8-10
+                     TOB_L1, TOB_L2, TOB_L3, TOB_L4, TOB_L5, TOB_L6, //11-16
+                     TECM_W1, TECM_W2, TECM_W3, TECM_W4, TECM_W5, TECM_W6, TECM_W7, TECM_W8, TECM_W9, //17-25
+                     TECP_W1, TECP_W2, TECP_W3, TECP_W4, TECP_W5, TECP_W6, TECP_W7, TECP_W8, TECP_W9, //26-34
+                     NUMLAYERS }; //35
 
-  int get_nchX( ) const {return nchX;}
-  int get_nchY( ) const {return nchY;}
-  double get_lowX( ) const {return lowX;}
-  double get_highX( ) const {return highX;}
-  double get_lowY( ) const {return lowY;}
-  double get_highY( ) const {return highY;}
+  TkLayerMap() {}
 
-  static const int16_t layerSearch(uint32_t detid);
+  TkLayerMap( int layer
+            , std::size_t nchX, double lowX, double highX
+            , std::size_t nchY, double lowY, double highY
+            , const TrackerTopology* tTopo, const std::vector<uint32_t>& tkDetIdList
+            , const std::vector<uint32_t>& singleExtString = {}
+            , const std::vector<uint32_t>& modulesInRingFront = {}
+            , const std::vector<uint32_t>& modulesInRingBack = {}
+            , const std::vector<uint32_t>& binForRing = {}
+            , uint32_t nstring_ext = 0, uint32_t nrod = 0
+            )
+    : layer_(layer)
+    , nchX_(nchX), lowX_(lowX), highX_(highX)
+    , nchY_(nchY), lowY_(lowY), highY_(highY)
+    , tTopo_(tTopo)
+    , singleExtStr_(singleExtString)
+    , modulesInRingFront_(modulesInRingFront), modulesInRingBack_(modulesInRingBack)
+    , binForRing_(binForRing)
+    , nStringExt_(nstring_ext), nRod_(nrod)
+    , binToDet_(std::vector<DetId>(std::size_t(nchX*nchY), 0))
+  {
+    initMap(tkDetIdList);
+  }
 
-  uint32_t getDetFromBin(int ix, int iy) const;
-  const uint32_t* getBinToDet() const {return binToDet;}
+  TkLayerMap( int layer
+            , std::size_t nchX, double lowX, double highX
+            , std::size_t nchY, double lowY, double highY
+            , const TrackerTopology* tTopo, const std::vector<uint32_t>& tkDetIdList
+            , std::vector<uint32_t>&& singleExtString = {}
+            , std::vector<uint32_t>&& modulesInRingFront = {}
+            , std::vector<uint32_t>&& modulesInRingBack = {}
+            , std::vector<uint32_t>&& binForRing = {}
+            , uint32_t nstring_ext = 0, uint32_t nrod = 0
+            )
+    : layer_(layer)
+    , nchX_(nchX), lowX_(lowX), highX_(highX)
+    , nchY_(nchY), lowY_(lowY), highY_(highY)
+    , tTopo_(tTopo)
+    , singleExtStr_(singleExtString)
+    , modulesInRingFront_(modulesInRingFront), modulesInRingBack_(modulesInRingBack)
+    , binForRing_(binForRing)
+    , nStringExt_(nstring_ext), nRod_(nrod)
+    , binToDet_(std::vector<DetId>(std::size_t(nchX*nchY), 0))
+  {
+    initMap(tkDetIdList);
+  }
 
- private:
+  void initMap(const std::vector<uint32_t>& tkDetIdList);
+private:
+  void initMap_TIB(const std::vector<uint32_t>& tkDetIdList);
+  void initMap_TOB(const std::vector<uint32_t>& tkDetIdList);
+  void initMap_TID(const std::vector<uint32_t>& tkDetIdList);
+  void initMap_TEC(const std::vector<uint32_t>& tkDetIdList);
 
-  XYbin getXY_TIB(uint32_t detid, int layerEnumNb=0) const;
-  XYbin getXY_TOB(uint32_t detid, int layerEnumNb=0) const;
-  XYbin getXY_TID(uint32_t detid, int layerEnumNb=0) const;
-  XYbin getXY_TEC(uint32_t detid, int layerEnumNb=0) const;
+  std::size_t bin(std::size_t ix, std::size_t iy) const { return (ix-1)+nchX_*(iy-1); }
 
-  void initialize(int layer);
+public:
+  static const int16_t layerSearch(DetId detid, const TrackerTopology* tTopo);
 
-  void createTIB(std::vector<uint32_t>& TkDetIdList, int layer);
-  void createTOB(std::vector<uint32_t>& TkDetIdList, int layer);
-  void createTID(std::vector<uint32_t>& TkDetIdList, int layer);
-  void createTEC(std::vector<uint32_t>& TkDetIdList, int layer);
+  std::size_t get_nchX() const { return nchX_; }
+  std::size_t get_nchY() const { return nchY_; }
+  double get_lowX() const { return lowX_; }
+  double get_highX() const { return highX_; }
+  double get_lowY() const { return lowY_; }
+  double get_highY() const { return highY_; }
+  const std::vector<DetId>& getBinToDet() const { return binToDet_; }
 
- private:
-  uint32_t get_Offset( TIBDetId ) const;
+  DetId getDetFromBin(int ix, int iy) const {
+    const auto idx = bin(ix, iy);
+    return ( idx < nchX_*nchY_ ) ? binToDet_[idx] : DetId(0);
+  }
 
-  uint32_t* binToDet;
+  const XYbin getXY(DetId detid, int layerEnumNb = TkLayerMap::INVALID) const;
+private:
+  XYbin getXY_TIB(DetId detid) const;
+  XYbin getXY_TOB(DetId detid) const;
+  XYbin getXY_TID(DetId detid) const;
+  XYbin getXY_TEC(DetId detid) const;
 
-  int layerEnumNb_; //In the enumerator sequence
-  int nchX;
-  int nchY;
-  double lowX,highX;
-  double lowY, highY;
+private:
+  int layer_; //In the enumerator sequence
+  std::size_t nchX_;
+  double lowX_, highX_;
+  std::size_t nchY_;
+  double lowY_, highY_;
+  const TrackerTopology* tTopo_;
 
-  std::vector<uint32_t> SingleExtString,ModulesInRingFront,ModulesInRingBack,BinForRing;
-  uint32_t Nstring_ext, Nrod, Offset;
+  std::vector<uint32_t> singleExtStr_; // for TIB
+  std::vector<uint32_t> modulesInRingFront_, modulesInRingBack_, binForRing_; // for TEC
+  uint32_t nStringExt_, nRod_;
 
+  std::vector<DetId> binToDet_;
 };
 
-class TkDetMap{
+class TkDetMap
+{
+public:
+  TkDetMap(const TrackerTopology* tTopo) : tTopo_(tTopo) { TkMap.resize(TkLayerMap::NUMLAYERS); } // maximal number of layers
 
- public:
-  TkDetMap();
-  TkDetMap(const edm::ParameterSet&,const edm::ActivityRegistry&);
-  ~TkDetMap();
+  // modifiers
+  void setLayerMap(int layer, const TkLayerMap& lyrMap ) { TkMap[layer] = lyrMap; }
+  void setLayerMap(int layer, TkLayerMap&& lyrMap ) { TkMap[layer] = lyrMap; }
 
-  const TkLayerMap::XYbin& getXY(uint32_t& , uint32_t& cached_detid , int16_t& cached_layer , TkLayerMap::XYbin& cached_XYbin) const;
-  std::string getLayerName(int& in) const;
-  int getLayerNum(const std::string& in) const;
-  void getSubDetLayerSide(int& in,SiStripDetId::SubDetector&,uint32_t& layer,uint32_t& side) const;
+  // conversion
+  static std::string getLayerName(int in);
+  static int getLayerNum(const std::string& in);
 
-  int16_t FindLayer(uint32_t& detid , uint32_t& cached_detid , int16_t& cached_layer , TkLayerMap::XYbin& cached_XYbin) const;
+  static void getSubDetLayerSide(int in, SiStripDetId::SubDetector&, uint32_t& layer, uint32_t& side);
 
+  DetId getDetFromBin(int layer, int ix, int iy) const
+  { return TkMap[layer].getDetFromBin(ix, iy); }
+  DetId getDetFromBin(const std::string& layerName, int ix, int iy) const
+  { return getDetFromBin(getLayerNum(layerName), ix, iy); }
+
+  std::vector<DetId> getDetsForLayer(int layer) const
+  { return TkMap[layer].getBinToDet(); } // const vector& -> vector conversion will copy
+
+  // getXY and findLayer with caching, getComponents (for TkHistoMap)
+  const TkLayerMap::XYbin& getXY(DetId detid,
+      DetId& cached_detid, int16_t& cached_layer, TkLayerMap::XYbin& cached_XYbin) const;
+  int16_t findLayer(DetId detid,
+      DetId& cached_detid, int16_t& cached_layer, TkLayerMap::XYbin& cached_XYbin) const;
   void getComponents(int layer,
-		     int& nchX,double& lowX,double& highX,
-		     int& nchY,double& lowY,double& highY) const;
- 
-  uint32_t getDetFromBin(int layer, int ix, int iy) const { return TkMap[layer]->getDetFromBin(ix,iy); }
-  uint32_t getDetFromBin(const std::string& layerName, int ix, int iy) const {return getDetFromBin(getLayerNum(layerName),ix,iy);}
-
-  void getDetsForLayer(int layer,std::vector<uint32_t>& output) const;
+		     int& nchX, double& lowX, double& highX,
+		     int& nchY, double& lowY, double& highY) const;
 
  private:
-
-  void doMe();
-
- private:
-  typedef std::vector<const TkLayerMap*> detmapType;
-  detmapType TkMap;
-  //uint32_t cached_detid;
-  //int16_t cached_layer;
-  //TkLayerMap::XYbin cached_XYbin;
+  std::vector<TkLayerMap> TkMap;
+  const TrackerTopology* tTopo_;
 };
-
 
 #endif

--- a/CalibTracker/SiStripCommon/plugins/SealModules.cc
+++ b/CalibTracker/SiStripCommon/plugins/SealModules.cc
@@ -12,9 +12,6 @@ DEFINE_FWK_MODULE(SiStripDetInfoFileWriter);
 #include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 DEFINE_FWK_SERVICE(SiStripDetInfoFileReader);
 
-#include "CalibTracker/SiStripCommon/interface/TkDetMap.h"
-DEFINE_FWK_SERVICE(TkDetMap);
-
 
 #include "CalibTracker/SiStripCommon/interface/ShallowTree.h"
 #include "CalibTracker/SiStripCommon/interface/ShallowEventDataProducer.h"

--- a/CalibTracker/SiStripCommon/plugins/TkDetMapESProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/TkDetMapESProducer.cc
@@ -149,7 +149,7 @@ namespace {
                 {}, modulesInRingFront, modulesInRingBack, { 0, 0, 0, 1, 3, 5, 8, 10 });
             break;
           case TkLayerMap::TECP_W9:
-            return TkLayerMap(layer, 8, 8., -16., 80, 0., 80., tTopo, tkDetIdList,
+            return TkLayerMap(layer, 8, 8., 16., 80, 0., 80., tTopo, tkDetIdList,
                 {}, modulesInRingFront, modulesInRingBack, { 0, 0, 0, 0, 1, 3, 6, 8 });
         }
     }

--- a/CalibTracker/SiStripCommon/plugins/TkDetMapESProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/TkDetMapESProducer.cc
@@ -1,0 +1,188 @@
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "CalibTracker/SiStripCommon/interface/TkDetMap.h"
+
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+class TrackerTopology;
+
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
+
+class TkDetMapESProducer : public edm::ESProducer
+{
+public:
+  TkDetMapESProducer(const edm::ParameterSet&);
+  virtual ~TkDetMapESProducer() {}
+
+  std::shared_ptr<TkDetMap> produce(const TrackerTopologyRcd&);
+};
+
+TkDetMapESProducer::TkDetMapESProducer(const edm::ParameterSet&)
+{
+  setWhatProduced(this);
+}
+
+namespace {
+  TkLayerMap makeTkLayerMap(int layer, const TrackerTopology* tTopo, const std::vector<uint32_t> tkDetIdList)
+  {
+    LogTrace("TkLayerMap") <<" TkLayerMap::constructor for layer " << layer;
+    uint32_t nStringExt, nRod;
+    std::vector<uint32_t> SingleExtString;
+    switch (layer) {
+      case TkLayerMap::TIB_L1: //TIBL1
+        nStringExt = 30;
+        SingleExtString.insert(SingleExtString.begin(),8,0);
+        SingleExtString.insert(SingleExtString.begin()+8,7,1);
+        SingleExtString.insert(SingleExtString.begin()+15,8,2);
+        SingleExtString.insert(SingleExtString.begin()+23,7,3);
+        return TkLayerMap(layer, 12, -6., 6., 2*(nStringExt+1), -1.*(nStringExt+1.), (nStringExt+1), tTopo, tkDetIdList,
+            SingleExtString, {}, {}, {}, nStringExt);
+        break;
+      case TkLayerMap::TIB_L2:
+        nStringExt = 38;
+        SingleExtString.insert(SingleExtString.begin(),10,0);
+        SingleExtString.insert(SingleExtString.begin()+10,9,1);
+        SingleExtString.insert(SingleExtString.begin()+19,10,2);
+        SingleExtString.insert(SingleExtString.begin()+29,9,3);
+        return TkLayerMap(layer, 12, -6., 6., 2*(nStringExt+1), -1.*(nStringExt+1.), (nStringExt+1), tTopo, tkDetIdList,
+            SingleExtString, {}, {}, {}, nStringExt);
+        break;
+      case TkLayerMap::TIB_L3:
+        nStringExt = 46;
+        SingleExtString.insert(SingleExtString.begin(),23,0);
+        SingleExtString.insert(SingleExtString.begin()+23,23,1);
+        return TkLayerMap(layer, 12, -6., 6., nStringExt, 0, nStringExt, tTopo, tkDetIdList,
+            SingleExtString, {}, {}, {}, nStringExt);
+        break;
+      case TkLayerMap::TIB_L4:
+        nStringExt = 56;
+        SingleExtString.insert(SingleExtString.begin(),14,0);
+        SingleExtString.insert(SingleExtString.begin()+14,14,1);
+        SingleExtString.insert(SingleExtString.begin()+28,14,2);
+        SingleExtString.insert(SingleExtString.begin()+42,14,3);
+        return TkLayerMap(layer, 12, -6., 6., nStringExt, 0, nStringExt, tTopo, tkDetIdList,
+            SingleExtString, {}, {}, {}, nStringExt);
+        break;
+      case TkLayerMap::TIDM_D1:  //TID
+      case TkLayerMap::TIDM_D2:  //TID
+      case TkLayerMap::TIDM_D3:  //TID
+        return TkLayerMap(layer, 7, -7., 0., 40, 0., 40., tTopo, tkDetIdList, {});
+        break;
+      case TkLayerMap::TIDP_D1:  //TID
+      case TkLayerMap::TIDP_D2:  //TID
+      case TkLayerMap::TIDP_D3:  //TID
+        return TkLayerMap(layer, 7, 0., 7., 40, 0., 40., tTopo, tkDetIdList, {});
+        break;
+      case TkLayerMap::TOB_L1:  //TOBL1
+        nRod = 42;
+        return TkLayerMap(layer, 12, -6., 6., 2*(nRod+1), -1.*(nRod+1.), (nRod+1.), tTopo, tkDetIdList,
+            {}, {}, {}, {}, 0, nRod);
+        break;
+      case TkLayerMap::TOB_L2:
+        nRod = 48;
+        return TkLayerMap(layer, 12, -6., 6., 2*(nRod+1), -1.*(nRod+1.), (nRod+1.), tTopo, tkDetIdList,
+            {}, {}, {}, {}, 0, nRod);
+        break;
+      case TkLayerMap::TOB_L3: //TOBL3
+        nRod = 54;
+        return TkLayerMap(layer, 12, -6., 6., nRod, 0., 1.*nRod, tTopo, tkDetIdList,
+            {}, {}, {}, {}, 0, nRod);
+        break;
+      case TkLayerMap::TOB_L4:
+        nRod = 60;
+        return TkLayerMap(layer, 12, -6., 6., nRod, 0., 1.*nRod, tTopo, tkDetIdList,
+            {}, {}, {}, {}, 0, nRod);
+        break;
+      case TkLayerMap::TOB_L5:
+        nRod = 66;
+        return TkLayerMap(layer, 12, -6., 6., nRod, 0., 1.*nRod, tTopo, tkDetIdList,
+            {}, {}, {}, {}, 0, nRod);
+        break;
+      case TkLayerMap::TOB_L6:
+        nRod = 74;
+        return TkLayerMap(layer, 12, -6., 6., nRod, 0., 1.*nRod, tTopo, tkDetIdList,
+            {}, {}, {}, {}, 0, nRod);
+        break;
+      default: //TEC
+        std::vector<uint32_t> modulesInRingFront = { 0, 2, 2, 3, 4, 2, 4, 5 };
+        std::vector<uint32_t> modulesInRingBack  = { 0, 1, 1, 2, 3, 3, 3, 5 };
+        switch (layer) {
+          case TkLayerMap::TECM_W1:
+          case TkLayerMap::TECM_W2:
+          case TkLayerMap::TECM_W3:
+            return TkLayerMap(layer, 16, -16., 0., 80, 0., 80., tTopo, tkDetIdList,
+                {}, modulesInRingFront, modulesInRingBack, { 0, 1, 4, 7, 9, 11, 14, 16 });
+            break;
+          case TkLayerMap::TECM_W4:
+          case TkLayerMap::TECM_W5:
+          case TkLayerMap::TECM_W6:
+            return TkLayerMap(layer, 13, -16., -3., 80, 0., 80., tTopo, tkDetIdList,
+                {}, modulesInRingFront, modulesInRingBack, { 0, 0, 1, 4, 6, 8, 11, 13 });
+            break;
+          case TkLayerMap::TECM_W7:
+          case TkLayerMap::TECM_W8:
+            return TkLayerMap(layer, 10, -16., -6., 80, 0., 80., tTopo, tkDetIdList,
+                {}, modulesInRingFront, modulesInRingBack, { 0, 0, 0, 1, 3, 5, 8, 10 });
+            break;
+          case TkLayerMap::TECM_W9:
+            return TkLayerMap(layer, 8, -16., -8., 80, 0., 80., tTopo, tkDetIdList,
+                {}, modulesInRingFront, modulesInRingBack, { 0, 0, 0, 0, 1, 3, 6, 8 });
+            break;
+          case TkLayerMap::TECP_W1:
+          case TkLayerMap::TECP_W2:
+          case TkLayerMap::TECP_W3:
+            return TkLayerMap(layer, 16, 0., 16., 80, 0., 80., tTopo, tkDetIdList,
+                {}, modulesInRingFront, modulesInRingBack, { 0, 1, 4, 7, 9, 11, 14, 16 });
+            break;
+          case TkLayerMap::TECP_W4:
+          case TkLayerMap::TECP_W5:
+          case TkLayerMap::TECP_W6:
+            return TkLayerMap(layer, 13, 3., 16., 80, 0., 80., tTopo, tkDetIdList,
+                {}, modulesInRingFront, modulesInRingBack, { 0, 0, 1, 4, 6, 8, 11, 13 });
+            break;
+          case TkLayerMap::TECP_W7:
+          case TkLayerMap::TECP_W8:
+            return TkLayerMap(layer, 10, 6., 16., 80, 0., 80., tTopo, tkDetIdList,
+                {}, modulesInRingFront, modulesInRingBack, { 0, 0, 0, 1, 3, 5, 8, 10 });
+            break;
+          case TkLayerMap::TECP_W9:
+            return TkLayerMap(layer, 8, 8., -16., 80, 0., 80., tTopo, tkDetIdList,
+                {}, modulesInRingFront, modulesInRingBack, { 0, 0, 0, 0, 1, 3, 6, 8 });
+        }
+    }
+    return TkLayerMap{};
+  }
+}
+
+std::shared_ptr<TkDetMap> TkDetMapESProducer::produce(const TrackerTopologyRcd& tTopoRcd)
+{
+  if ( ! edm::Service<SiStripDetInfoFileReader>().isAvailable() ) {
+    edm::LogError("TkLayerMap") <<
+      "\n------------------------------------------"
+      "\nUnAvailable Service SiStripDetInfoFileReader: please insert in the configuration file an instance like"
+      "\n\tprocess.SiStripDetInfoFileReader = cms.Service(\"SiStripDetInfoFileReader\")"
+      "\n------------------------------------------";
+  }
+  SiStripDetInfoFileReader* fr = edm::Service<SiStripDetInfoFileReader>().operator->();
+  const std::vector<uint32_t> TkDetIdList = fr->getAllDetIds();
+
+  edm::ESHandle<TrackerTopology> tTopoHandle;
+  tTopoRcd.get(tTopoHandle);
+  const TrackerTopology* tTopo = tTopoHandle.product();
+
+  auto tkDetMap = std::make_shared<TkDetMap>(tTopo);
+
+  LogTrace("TkDetMap") <<"TkDetMap::constructor ";
+  //Create TkLayerMap for each layer declared in the TkLayerEnum
+  for ( int layer=1 ; layer < TkLayerMap::NUMLAYERS; ++layer ) {
+    tkDetMap->setLayerMap(layer, makeTkLayerMap(layer, tTopo, TkDetIdList));
+  }
+
+  return tkDetMap;
+}
+
+#include "FWCore/Framework/interface/ModuleFactory.h"
+DEFINE_FWK_EVENTSETUP_MODULE(TkDetMapESProducer);

--- a/CalibTracker/SiStripCommon/plugins/TkDetMapESProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/TkDetMapESProducer.cc
@@ -15,7 +15,7 @@ class TkDetMapESProducer : public edm::ESProducer
 {
 public:
   TkDetMapESProducer(const edm::ParameterSet&);
-  virtual ~TkDetMapESProducer() {}
+  ~TkDetMapESProducer() override {}
 
   std::shared_ptr<TkDetMap> produce(const TrackerTopologyRcd&);
 };
@@ -167,7 +167,7 @@ std::shared_ptr<TkDetMap> TkDetMapESProducer::produce(const TrackerTopologyRcd& 
       "\n------------------------------------------";
   }
   SiStripDetInfoFileReader* fr = edm::Service<SiStripDetInfoFileReader>().operator->();
-  const std::vector<uint32_t> TkDetIdList = fr->getAllDetIds();
+  const std::vector<uint32_t>& TkDetIdList = fr->getAllDetIds();
 
   edm::ESHandle<TrackerTopology> tTopoHandle;
   tTopoRcd.get(tTopoHandle);

--- a/CalibTracker/SiStripCommon/python/TkDetMapESProducer_cfi.py
+++ b/CalibTracker/SiStripCommon/python/TkDetMapESProducer_cfi.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+TkDetMapESProducer = cms.ESProducer("TkDetMapESProducer")

--- a/CalibTracker/SiStripCommon/python/TkDetMap_cff.py
+++ b/CalibTracker/SiStripCommon/python/TkDetMap_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+from CalibTracker.SiStripCommon.TkDetMapESProducer_cfi import *

--- a/CalibTracker/SiStripCommon/src/ES_TkDetMap.cc
+++ b/CalibTracker/SiStripCommon/src/ES_TkDetMap.cc
@@ -1,0 +1,4 @@
+#include "CalibTracker/SiStripCommon/interface/TkDetMap.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(TkDetMap);

--- a/CalibTracker/SiStripCommon/src/TkDetMap.cc
+++ b/CalibTracker/SiStripCommon/src/TkDetMap.cc
@@ -437,10 +437,9 @@ void TkLayerMap::initialize(int layer){
 void TkLayerMap::createTIB(std::vector<uint32_t>& TkDetIdList,int layerEnumNb){
   
   std::vector<uint32_t> LayerDetIdList;
-  SiStripSubStructure siStripSubStructure;
   
   //extract  vector of module in the layer
-  siStripSubStructure.getTIBDetectors(TkDetIdList,LayerDetIdList,layerEnumNb,0,0,0);
+  SiStripSubStructure::getTIBDetectors(TkDetIdList,LayerDetIdList,nullptr,layerEnumNb,0,0,0);
 
   LogTrace("TkLayerMap") << "[TkLayerMap::createTIB12] layer " << layerEnumNb  << " number of dets " << LayerDetIdList.size() << " lowY " << lowY << " high " << highY << " Nstring " << Nstring_ext;
 
@@ -456,10 +455,9 @@ void TkLayerMap::createTIB(std::vector<uint32_t>& TkDetIdList,int layerEnumNb){
 void TkLayerMap::createTOB(std::vector<uint32_t>& TkDetIdList,int layerEnumNb){
   
   std::vector<uint32_t> LayerDetIdList;
-  SiStripSubStructure siStripSubStructure;
   
   //extract  vector of module in the layer
-  siStripSubStructure.getTOBDetectors(TkDetIdList,LayerDetIdList,layerEnumNb-10,0,0);
+  SiStripSubStructure::getTOBDetectors(TkDetIdList,LayerDetIdList,nullptr,layerEnumNb-10,0,0);
 
   LogTrace("TkLayerMap") << "[TkLayerMap::createTOB] layer " << layerEnumNb-10  << " number of dets " << LayerDetIdList.size() << " lowY " << lowY << " high " << highY << " Nstring " << Nstring_ext;
 
@@ -475,10 +473,9 @@ void TkLayerMap::createTOB(std::vector<uint32_t>& TkDetIdList,int layerEnumNb){
 void TkLayerMap::createTID(std::vector<uint32_t>& TkDetIdList,int layerEnumNb){
   
   std::vector<uint32_t> LayerDetIdList;
-  SiStripSubStructure siStripSubStructure;
   
   //extract  vector of module in the layer
-  siStripSubStructure.getTIDDetectors(TkDetIdList,LayerDetIdList,(layerEnumNb-TkLayerMap::TIDM_D1)/3+1,(layerEnumNb-TkLayerMap::TIDM_D1)%3+1,0,0);
+  SiStripSubStructure::getTIDDetectors(TkDetIdList,LayerDetIdList,nullptr,(layerEnumNb-TkLayerMap::TIDM_D1)/3+1,(layerEnumNb-TkLayerMap::TIDM_D1)%3+1,0,0);
 
   LogTrace("TkLayerMap") << "[TkLayerMap::createTID] layer side " << (layerEnumNb-TkLayerMap::TIDM_D1)/3+1 << " nb " << (layerEnumNb-TkLayerMap::TIDM_D1)%3+1  << " number of dets " << LayerDetIdList.size() << " lowY " << lowY << " high " << highY << " Nstring " << Nstring_ext;
   
@@ -494,10 +491,9 @@ void TkLayerMap::createTID(std::vector<uint32_t>& TkDetIdList,int layerEnumNb){
 void TkLayerMap::createTEC(std::vector<uint32_t>& TkDetIdList,int layerEnumNb){
   
   std::vector<uint32_t> LayerDetIdList;
-  SiStripSubStructure siStripSubStructure;
   
   //extract  vector of module in the layer
-  siStripSubStructure.getTECDetectors(TkDetIdList,LayerDetIdList,(layerEnumNb-TkLayerMap::TECM_W1)/9+1,(layerEnumNb-TkLayerMap::TECM_W1)%9+1,0,0);
+  SiStripSubStructure::getTECDetectors(TkDetIdList,LayerDetIdList,nullptr,(layerEnumNb-TkLayerMap::TECM_W1)/9+1,(layerEnumNb-TkLayerMap::TECM_W1)%9+1,0,0);
   
   LogTrace("TkLayerMap") << "[TkLayerMap::createTEC] layer side " << (layerEnumNb-TkLayerMap::TECM_W1)/9+1 << " " << (layerEnumNb-TkLayerMap::TECM_W1)%9+1  << " number of dets " << LayerDetIdList.size() << " lowY " << lowY << " high " << highY << " Nstring " << Nstring_ext;
 

--- a/CalibTracker/SiStripCommon/src/TkDetMap.cc
+++ b/CalibTracker/SiStripCommon/src/TkDetMap.cc
@@ -1,41 +1,19 @@
-#include "CalibTracker/SiStripCommon/interface/TkDetMap.h"
-#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
-#include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
-#include "DataFormats/SiStripDetId/interface/TIBDetId.h"
-#include "DataFormats/SiStripDetId/interface/TIDDetId.h"
-#include "DataFormats/SiStripDetId/interface/TOBDetId.h"
-#include "DataFormats/SiStripDetId/interface/TECDetId.h"
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
-#include <iostream>
-#include <cstring>
+#include "CalibTracker/SiStripCommon/interface/TkDetMap.h"
 
-TkLayerMap::TkLayerMap(int in):layerEnumNb_(in){
+// TkLayerMap
 
-  LogTrace("TkLayerMap") <<" TkLayerMap::constructor for layer " << in;
-
-  initialize(layerEnumNb_);
-
- if(!edm::Service<SiStripDetInfoFileReader>().isAvailable()){
-    edm::LogError("TkLayerMap") << 
-      "\n------------------------------------------"
-      "\nUnAvailable Service SiStripDetInfoFileReader: please insert in the configuration file an instance like"
-      "\n\tprocess.SiStripDetInfoFileReader = cms.Service(\"SiStripDetInfoFileReader\")"
-      "\n------------------------------------------";
-  }
- 
-  SiStripDetInfoFileReader * fr=edm::Service<SiStripDetInfoFileReader>().operator->();
-
-  std::vector<uint32_t> TkDetIdList=fr->getAllDetIds();
-  
-  switch (layerEnumNb_)
-    {
+void TkLayerMap::initMap(const std::vector<uint32_t>& TkDetIdList)
+{
+  switch(layer_) {
     case TkLayerMap::TIB_L1:
     case TkLayerMap::TIB_L2:
     case TkLayerMap::TIB_L3:
-    case TkLayerMap::TIB_L4:         
-      createTIB(TkDetIdList,layerEnumNb_);
+    case TkLayerMap::TIB_L4:
+      initMap_TIB(TkDetIdList);
       break;
     case TkLayerMap::TIDP_D1:
     case TkLayerMap::TIDP_D2:
@@ -43,7 +21,7 @@ TkLayerMap::TkLayerMap(int in):layerEnumNb_(in){
     case TkLayerMap::TIDM_D1:
     case TkLayerMap::TIDM_D2:
     case TkLayerMap::TIDM_D3:
-      createTID(TkDetIdList,layerEnumNb_); 
+      initMap_TID(TkDetIdList);
       break;
     case TkLayerMap::TOB_L1:
     case TkLayerMap::TOB_L2:
@@ -51,13 +29,13 @@ TkLayerMap::TkLayerMap(int in):layerEnumNb_(in){
     case TkLayerMap::TOB_L4:
     case TkLayerMap::TOB_L5:
     case TkLayerMap::TOB_L6:
-      createTOB(TkDetIdList,layerEnumNb_); 
+      initMap_TOB(TkDetIdList);
     break;
     case TkLayerMap::TECP_W1:
     case TkLayerMap::TECP_W2:
     case TkLayerMap::TECP_W3:
     case TkLayerMap::TECP_W4:
-    case TkLayerMap::TECP_W5: 
+    case TkLayerMap::TECP_W5:
     case TkLayerMap::TECP_W6:
     case TkLayerMap::TECP_W7:
     case TkLayerMap::TECP_W8:
@@ -66,646 +44,205 @@ TkLayerMap::TkLayerMap(int in):layerEnumNb_(in){
     case TkLayerMap::TECM_W2:
     case TkLayerMap::TECM_W3:
     case TkLayerMap::TECM_W4:
-    case TkLayerMap::TECM_W5: 
+    case TkLayerMap::TECM_W5:
     case TkLayerMap::TECM_W6:
     case TkLayerMap::TECM_W7:
     case TkLayerMap::TECM_W8:
     case TkLayerMap::TECM_W9:
-      createTEC(TkDetIdList,layerEnumNb_); 
+      initMap_TEC(TkDetIdList);
       break;
     default:
-      edm::LogError("TkLayerMap") <<" TkLayerMap::requested creation of a wrong layer Nb "<< layerEnumNb_; 
-    }
-}
-
-uint32_t TkLayerMap::getDetFromBin(int ix, int iy) const {
-  
-  int val=(ix-1)+nchX*(iy-1);
-  if(val>-1 && val < nchX*nchY)
-    return binToDet[val];
-  return 0;
-}
-
-const int16_t TkLayerMap::layerSearch(uint32_t detid) {
-  
-    //  switch((detid>>25)&0x7){
-  if(SiStripDetId(detid).subDetector()==SiStripDetId::TIB){
-    TIBDetId D(detid);
-    return TkLayerMap::TIB_L1  -1 +D.layerNumber();
-  } else if (SiStripDetId(detid).subDetector()==SiStripDetId::TID){
-    TIDDetId D(detid);
-    return TkLayerMap::TIDM_D1 -1 + (D.side() -1)*3 + D.wheel();
-  } else if (SiStripDetId(detid).subDetector()==SiStripDetId::TOB){
-    TOBDetId D(detid);
-    return TkLayerMap::TOB_L1  -1 +D.layerNumber();
-  } else if (SiStripDetId(detid).subDetector()==SiStripDetId::TEC){
-    TECDetId D(detid);
-    return TkLayerMap::TECM_W1 -1 + (D.side() -1)*9 + D.wheel();
+      edm::LogError("TkLayerMap") << " TkLayerMap::requested creation of a wrong layer Nb " << layer_;
   }
-  return 0;
 }
 
-
-void TkLayerMap::initialize(int layer){
-
-  switch (layer){
-  case TkLayerMap::TIB_L1: //TIBL1
-    
-    Nstring_ext=30;
-    SingleExtString.insert(SingleExtString.begin(),8,0);
-    SingleExtString.insert(SingleExtString.begin()+8,7,1);
-    SingleExtString.insert(SingleExtString.begin()+15,8,2);
-    SingleExtString.insert(SingleExtString.begin()+23,7,3);
-    nchX=12;
-    lowX=-6;
-    highX=6;
-    nchY=2*(Nstring_ext+1);
-    lowY=-1.*(Nstring_ext+1.);
-    highY=(Nstring_ext+1);
-    
-    break;
-  case TkLayerMap::TIB_L2:
-    
-    Nstring_ext=38;
-    SingleExtString.insert(SingleExtString.begin(),10,0);
-    SingleExtString.insert(SingleExtString.begin()+10,9,1);
-    SingleExtString.insert(SingleExtString.begin()+19,10,2);
-    SingleExtString.insert(SingleExtString.begin()+29,9,3);
-    nchX=12;
-    lowX=-6;
-    highX=6;
-    nchY=2*(Nstring_ext+1);
-    lowY=-1.*(Nstring_ext+1.);
-    highY=(Nstring_ext+1);
-
-    break;
-  case TkLayerMap::TIB_L3:
-
-    Nstring_ext=46; 
-    SingleExtString.insert(SingleExtString.begin(),23,0);
-    SingleExtString.insert(SingleExtString.begin()+23,23,1);
-    nchX=12;
-    lowX=-6;
-    highX=6;
-    nchY=Nstring_ext;
-    lowY=0;
-    highY=nchY;
-
-    break;
-  case TkLayerMap::TIB_L4:
-
-    Nstring_ext=56;
-    SingleExtString.insert(SingleExtString.begin(),14,0);
-    SingleExtString.insert(SingleExtString.begin()+14,14,1);
-    SingleExtString.insert(SingleExtString.begin()+28,14,2);
-    SingleExtString.insert(SingleExtString.begin()+42,14,3);
-    nchX=12;
-    lowX=-6.;
-    highX=6.;
-    nchY=Nstring_ext;
-    lowY=0.;
-    highY=nchY;
-
-    break;
-  case TkLayerMap::TIDM_D1:  //TID
-  case TkLayerMap::TIDM_D2:  //TID
-  case TkLayerMap::TIDM_D3:  //TID
-
-    nchX=7;
-    lowX=-7.;
-    highX=0.;
-    nchY=40;
-    lowY=0.0;
-    highY=1.*nchY;
-
-    break;
-  case TkLayerMap::TIDP_D1:  //TID
-  case TkLayerMap::TIDP_D2:  //TID
-  case TkLayerMap::TIDP_D3:  //TID
-    
-    nchX=7;
-    lowX=0.;
-    highX=7.;
-    nchY=40;
-    lowY=0.0;
-    highY=1.*nchY;
-
-    break;
-  case TkLayerMap::TOB_L1:  //TOBL1
-
-    Nrod=42;
-    nchX=12;
-    lowX=-6.;
-    highX=6.;
-    nchY=2*(Nrod+1);
-    lowY=-1.*(Nrod+1.);
-    highY=(Nrod+1.);
-
-    break;
-  case TkLayerMap::TOB_L2:
-    
-    Nrod=48;
-    nchX=12;
-    lowX=-6.;
-    highX=6.;
-    nchY=int(2.*(Nrod+1.));
-    lowY=-1.*(Nrod+1.);
-    highY=(Nrod+1.);
-    
-    break;
-  case TkLayerMap::TOB_L3: //TOBL3
-   
-    Nrod=54;
-    nchX=12;
-    lowX=-6.;
-    highX=6.;
-    nchY=Nrod;
-    lowY=0.;
-    highY=1.*Nrod;
-    
-    break;
-  case TkLayerMap::TOB_L4:
-    
-    Nrod=60;
-    nchX=12;
-    lowX=-6.;
-    highX=6.;
-    nchY=Nrod;
-    lowY=0.;
-    highY=1.*Nrod;
-
-    break;
-  case TkLayerMap::TOB_L5:
-    
-    Nrod=66;
-    nchX=12;
-    lowX=-6.;
-    highX=6.;
-    nchY=Nrod;
-    lowY=0.;
-    highY=1.*Nrod;
-
-    break;
-  case TkLayerMap::TOB_L6:
-    
-    Nrod=74;
-    nchX=12;
-    lowX=-6.;
-    highX=6.;
-    nchY=Nrod;
-    lowY=0.;
-    highY=1.*Nrod;
-
-    break;
-  default: //TEC
-    switch (layer){
-    case TkLayerMap::TECM_W1:
-    case TkLayerMap::TECM_W2:
-    case TkLayerMap::TECM_W3:
-      nchX=16;
-      lowX=-16.;
-      highX=0.;
-      nchY=80;
-      lowY=0.;
-      highY=1.*nchY;
-
-      BinForRing.push_back(0); //null value for component 0
-      BinForRing.push_back(1);
-      BinForRing.push_back(4);
-      BinForRing.push_back(7);
-      BinForRing.push_back(9);
-      BinForRing.push_back(11);
-      BinForRing.push_back(14);
-      BinForRing.push_back(16);
-      break;
-    case TkLayerMap::TECM_W4:
-    case TkLayerMap::TECM_W5: 
-    case TkLayerMap::TECM_W6:
-      nchX=13;
-      lowX=-16.;
-      highX=-3.;
-      nchY=80;
-      lowY=0.;
-      highY=1.*nchY;
-
-      BinForRing.push_back(0); //null value for component 0
-      BinForRing.push_back(0);
-      BinForRing.push_back(1);
-      BinForRing.push_back(4);
-      BinForRing.push_back(6);
-      BinForRing.push_back(8);
-      BinForRing.push_back(11);
-      BinForRing.push_back(13);
-      break;
-    case TkLayerMap::TECM_W7:
-    case TkLayerMap::TECM_W8:
-      nchX=10;
-      lowX=-16.;
-      highX=-6.;
-      nchY=80;
-      lowY=0.;
-      highY=1.*nchY;
-
-      BinForRing.push_back(0); //null value for component 0
-      BinForRing.push_back(0);
-      BinForRing.push_back(0);
-      BinForRing.push_back(1);
-      BinForRing.push_back(3);
-      BinForRing.push_back(5);
-      BinForRing.push_back(8);
-      BinForRing.push_back(10);
-      break;
-    case TkLayerMap::TECM_W9:
-      nchX=8;
-      lowX=-16.;
-      highX=-8.;
-      nchY=80;
-      lowY=0.;
-      highY=1.*nchY;
-
-      BinForRing.push_back(0); //null value for component 0
-      BinForRing.push_back(0);
-      BinForRing.push_back(0);
-      BinForRing.push_back(0);
-      BinForRing.push_back(1);
-      BinForRing.push_back(3);
-      BinForRing.push_back(6);
-      BinForRing.push_back(8);
-      break;
-    case TkLayerMap::TECP_W1:
-    case TkLayerMap::TECP_W2:
-    case TkLayerMap::TECP_W3:
-      nchX=16;
-      lowX=0.;
-      highX=16.;
-      nchY=80;
-      lowY=0.;
-      highY=1.*nchY;
-
-      BinForRing.push_back(0); //null value for component 0
-      BinForRing.push_back(1);
-      BinForRing.push_back(4);
-      BinForRing.push_back(7);
-      BinForRing.push_back(9);
-      BinForRing.push_back(11);
-      BinForRing.push_back(14);
-      BinForRing.push_back(16);
-      break;
-    case TkLayerMap::TECP_W4:
-    case TkLayerMap::TECP_W5: 
-    case TkLayerMap::TECP_W6:
-      nchX=13;
-      lowX=3.;
-      highX=16.;
-      nchY=80;
-      lowY=0.;
-      highY=1.*nchY;
-
-      BinForRing.push_back(0); //null value for component 0
-      BinForRing.push_back(0);
-      BinForRing.push_back(1);
-      BinForRing.push_back(4);
-      BinForRing.push_back(6);
-      BinForRing.push_back(8);
-      BinForRing.push_back(11);
-      BinForRing.push_back(13);
-      break;
-    case TkLayerMap::TECP_W7:
-    case TkLayerMap::TECP_W8:
-      nchX=10;
-      lowX=6.;
-      highX=16.;
-      nchY=80;
-      lowY=0.;
-      highY=1.*nchY;
-
-      BinForRing.push_back(0); //null value for component 0
-      BinForRing.push_back(0);
-      BinForRing.push_back(0);
-      BinForRing.push_back(1);
-      BinForRing.push_back(3);
-      BinForRing.push_back(5);
-      BinForRing.push_back(8);
-      BinForRing.push_back(10);
-      break;
-    case TkLayerMap::TECP_W9:
-      nchX=8;
-      lowX=8.;
-      highX=16.;
-      nchY=80;
-      lowY=0.;
-      highY=1.*nchY;
-
-      BinForRing.push_back(0); //null value for component 0
-      BinForRing.push_back(0);
-      BinForRing.push_back(0);
-      BinForRing.push_back(0);
-      BinForRing.push_back(1);
-      BinForRing.push_back(3);
-      BinForRing.push_back(6);
-      BinForRing.push_back(8);
-    }
-
-
-    ModulesInRingFront.push_back(0); //null value for component 0
-    ModulesInRingFront.push_back(2);
-    ModulesInRingFront.push_back(2);
-    ModulesInRingFront.push_back(3);
-    ModulesInRingFront.push_back(4);
-    ModulesInRingFront.push_back(2);
-    ModulesInRingFront.push_back(4);
-    ModulesInRingFront.push_back(5);
-
-    ModulesInRingBack.push_back(0); //null value for component 0
-    ModulesInRingBack.push_back(1);    
-    ModulesInRingBack.push_back(1);    
-    ModulesInRingBack.push_back(2);    
-    ModulesInRingBack.push_back(3);    
-    ModulesInRingBack.push_back(3);    
-    ModulesInRingBack.push_back(3);    
-    ModulesInRingBack.push_back(5);
-  }
-  
-  for (size_t i=0;i<SingleExtString.size();i++)
-    LogTrace("TkLayerMap") << "[initialize SingleExtString["<<i<<"] " << SingleExtString[i];
-
-  binToDet= new uint32_t[nchX*nchY];
-  for(size_t i=0;i<(size_t) nchX*nchY;++i)
-    binToDet[i]=0;
-}
- 
-void TkLayerMap::createTIB(std::vector<uint32_t>& TkDetIdList,int layerEnumNb){
-  
-  std::vector<uint32_t> LayerDetIdList;
-  
+void TkLayerMap::initMap_TIB(const std::vector<uint32_t>& TkDetIdList)
+{
   //extract  vector of module in the layer
-  SiStripSubStructure::getTIBDetectors(TkDetIdList,LayerDetIdList,nullptr,layerEnumNb,0,0,0);
-
-  LogTrace("TkLayerMap") << "[TkLayerMap::createTIB12] layer " << layerEnumNb  << " number of dets " << LayerDetIdList.size() << " lowY " << lowY << " high " << highY << " Nstring " << Nstring_ext;
-
-  XYbin xyb;
-
-  for(size_t j=0;j<LayerDetIdList.size();++j){
-    xyb=getXY_TIB(LayerDetIdList[j],layerEnumNb);
-    binToDet[(xyb.ix-1)+nchX*(xyb.iy-1)]=LayerDetIdList[j];
-    LogTrace("TkLayerMap") << "[TkLayerMap::createTIB] " << LayerDetIdList[j]<< " " << xyb.ix << " " << xyb.iy  << " " << xyb.x << " " << xyb.y ;
-  }
-}
-
-void TkLayerMap::createTOB(std::vector<uint32_t>& TkDetIdList,int layerEnumNb){
-  
   std::vector<uint32_t> LayerDetIdList;
-  
-  //extract  vector of module in the layer
-  SiStripSubStructure::getTOBDetectors(TkDetIdList,LayerDetIdList,nullptr,layerEnumNb-10,0,0);
+  SiStripSubStructure::getTIBDetectors(TkDetIdList, LayerDetIdList, tTopo_, layer_, 0, 0, 0);
 
-  LogTrace("TkLayerMap") << "[TkLayerMap::createTOB] layer " << layerEnumNb-10  << " number of dets " << LayerDetIdList.size() << " lowY " << lowY << " high " << highY << " Nstring " << Nstring_ext;
+  LogTrace("TkLayerMap") << "[TkLayerMap::createTIB12] layer " << layer_ << " number of dets " << LayerDetIdList.size() << " lowY " << lowY_ << " high " << highY_ << " Nstring " << nStringExt_;
 
-  XYbin xyb;
+  for ( uint32_t det : LayerDetIdList ) {
+    const auto xyb = getXY_TIB(det);
+    binToDet_[bin(xyb.ix, xyb.iy)] = det;
 
-  for(size_t j=0;j<LayerDetIdList.size();++j){
-    xyb=getXY_TOB(LayerDetIdList[j],layerEnumNb);
-    binToDet[(xyb.ix-1)+nchX*(xyb.iy-1)]=LayerDetIdList[j];
-    LogTrace("TkLayerMap") << "[TkLayerMap::createTOB] " << LayerDetIdList[j]<< " " << xyb.ix << " " << xyb.iy  << " " << xyb.x << " " << xyb.y ;
+    LogTrace("TkLayerMap") << "[TkLayerMap::createTIB] " << det << " " << xyb.ix << " " << xyb.iy << " " << xyb.x << " " << xyb.y;
   }
 }
 
-void TkLayerMap::createTID(std::vector<uint32_t>& TkDetIdList,int layerEnumNb){
-  
+void TkLayerMap::initMap_TOB(const std::vector<uint32_t>& TkDetIdList)
+{
+  //extract  vector of module in the layer
   std::vector<uint32_t> LayerDetIdList;
-  
-  //extract  vector of module in the layer
-  SiStripSubStructure::getTIDDetectors(TkDetIdList,LayerDetIdList,nullptr,(layerEnumNb-TkLayerMap::TIDM_D1)/3+1,(layerEnumNb-TkLayerMap::TIDM_D1)%3+1,0,0);
+  SiStripSubStructure::getTOBDetectors(TkDetIdList, LayerDetIdList, tTopo_, layer_-10, 0, 0);
 
-  LogTrace("TkLayerMap") << "[TkLayerMap::createTID] layer side " << (layerEnumNb-TkLayerMap::TIDM_D1)/3+1 << " nb " << (layerEnumNb-TkLayerMap::TIDM_D1)%3+1  << " number of dets " << LayerDetIdList.size() << " lowY " << lowY << " high " << highY << " Nstring " << Nstring_ext;
-  
-  XYbin xyb;
+  LogTrace("TkLayerMap") << "[TkLayerMap::createTOB] layer " << layer_-10  << " number of dets " << LayerDetIdList.size() << " lowY " << lowY_ << " high " << highY_ << " Nstring " << nStringExt_;
 
-  for(size_t j=0;j<LayerDetIdList.size();++j){
-    xyb=getXY_TID(LayerDetIdList[j],layerEnumNb);
-    binToDet[(xyb.ix-1)+nchX*(xyb.iy-1)]=LayerDetIdList[j];
-    LogTrace("TkLayerMap") << "[TkLayerMap::createTID] " << LayerDetIdList[j]<< " " << xyb.ix << " " << xyb.iy  << " " << xyb.x << " " << xyb.y ;
+  for ( uint32_t det : LayerDetIdList ) {
+    const auto xyb = getXY_TOB(det);
+    binToDet_[bin(xyb.ix, xyb.iy)] = det;
+
+    LogTrace("TkLayerMap") << "[TkLayerMap::createTOB] " << det << " " << xyb.ix << " " << xyb.iy << " " << xyb.x << " " << xyb.y;
   }
 }
 
-void TkLayerMap::createTEC(std::vector<uint32_t>& TkDetIdList,int layerEnumNb){
-  
+void TkLayerMap::initMap_TID(const std::vector<uint32_t>& TkDetIdList)
+{
+  //extract  vector of module in the layer
   std::vector<uint32_t> LayerDetIdList;
-  
-  //extract  vector of module in the layer
-  SiStripSubStructure::getTECDetectors(TkDetIdList,LayerDetIdList,nullptr,(layerEnumNb-TkLayerMap::TECM_W1)/9+1,(layerEnumNb-TkLayerMap::TECM_W1)%9+1,0,0);
-  
-  LogTrace("TkLayerMap") << "[TkLayerMap::createTEC] layer side " << (layerEnumNb-TkLayerMap::TECM_W1)/9+1 << " " << (layerEnumNb-TkLayerMap::TECM_W1)%9+1  << " number of dets " << LayerDetIdList.size() << " lowY " << lowY << " high " << highY << " Nstring " << Nstring_ext;
+  SiStripSubStructure::getTIDDetectors(TkDetIdList, LayerDetIdList, tTopo_, (layer_-TkLayerMap::TIDM_D1)/3+1, (layer_-TkLayerMap::TIDM_D1)%3+1, 0, 0);
 
-  XYbin xyb;
+  LogTrace("TkLayerMap") << "[TkLayerMap::createTID] layer side " << (layer_-TkLayerMap::TIDM_D1)/3+1 << " nb " << (layer_-TkLayerMap::TIDM_D1)%3+1  << " number of dets " << LayerDetIdList.size() << " lowY " << lowY_ << " high " << highY_ << " Nstring " << nStringExt_;
 
-  for(size_t j=0;j<LayerDetIdList.size();++j){
-    xyb=getXY_TEC(LayerDetIdList[j],layerEnumNb);
-    binToDet[(xyb.ix-1)+nchX*(xyb.iy-1)]=LayerDetIdList[j];
-    LogTrace("TkLayerMap") << "[TkLayerMap::createTEC] " << LayerDetIdList[j]<< " " << xyb.ix << " " << xyb.iy  << " " << xyb.x << " " << xyb.y ;
-    
+  for ( uint32_t det : LayerDetIdList ) {
+    const auto xyb = getXY_TID(det);
+    binToDet_[bin(xyb.ix, xyb.iy)] = det;
+
+    LogTrace("TkLayerMap") << "[TkLayerMap::createTID] " << det << " " << xyb.ix << " " << xyb.iy  << " " << xyb.x << " " << xyb.y ;
   }
 }
 
+void TkLayerMap::initMap_TEC(const std::vector<uint32_t>& TkDetIdList)
+{
+  //extract  vector of module in the layer
+  std::vector<uint32_t> LayerDetIdList;
+  SiStripSubStructure::getTECDetectors(TkDetIdList, LayerDetIdList, tTopo_, (layer_-TkLayerMap::TECM_W1)/9+1, (layer_-TkLayerMap::TECM_W1)%9+1, 0, 0);
 
-const TkLayerMap::XYbin TkLayerMap::getXY(uint32_t detid, int layerEnumNb) const {
-  LogTrace("TkLayerMap") << "[TkLayerMap::getXY] " << detid << " layer " << layerEnumNb; 
+  LogTrace("TkLayerMap") << "[TkLayerMap::createTEC] layer side " << (layer_-TkLayerMap::TECM_W1)/9+1 << " " << (layer_-TkLayerMap::TECM_W1)%9+1  << " number of dets " << LayerDetIdList.size() << " lowY " << lowY_ << " high " << highY_ << " Nstring " << nStringExt_;
 
-  if(!layerEnumNb)
-    layerEnumNb=layerSearch(detid);
+  for ( uint32_t det : LayerDetIdList ) {
+    const auto xyb = getXY_TEC(det);
+    binToDet_[bin(xyb.ix, xyb.iy)] = det;
 
-  if(layerEnumNb!=layerEnumNb_)
+    LogTrace("TkLayerMap") << "[TkLayerMap::createTEC] " << det << " " << xyb.ix << " " << xyb.iy  << " " << xyb.x << " " << xyb.y;
+  }
+}
+
+const int16_t TkLayerMap::layerSearch(DetId detid, const TrackerTopology* tTopo)
+{
+  switch (detid.subdetId()) {
+    case SiStripDetId::TIB:
+      return TkLayerMap::TIB_L1  -1 + tTopo->tibLayer(detid);
+    case SiStripDetId::TID:
+      return TkLayerMap::TIDM_D1 -1 + (tTopo->tidSide(detid)-1)*3 + tTopo->tidWheel(detid);
+    case SiStripDetId::TOB:
+      return TkLayerMap::TOB_L1  -1 + tTopo->tobLayer(detid);
+    case SiStripDetId::TEC:
+      return TkLayerMap::TECM_W1 -1 + (tTopo->tecSide(detid)-1)*9 + tTopo->tecWheel(detid);
+    default:
+      return 0;
+  }
+}
+
+const TkLayerMap::XYbin TkLayerMap::getXY(DetId detid, int layerEnumNb) const
+{
+  LogTrace("TkLayerMap") << "[TkLayerMap::getXY] " << detid.rawId() << " layer " << layerEnumNb;
+
+  if ( ! layerEnumNb ) layerEnumNb = layerSearch(detid, tTopo_);
+
+  if ( layerEnumNb != layer_ )
     throw cms::Exception("CorruptedData")
-      << "[TkLayerMap::getXY] Fill of DetId " << detid << " layerEnumNb " << layerEnumNb << " are requested to wrong TkLayerMap " << layerEnumNb_ << " \nPlease check the TkDetMap code"; 
- 
+      << "[TkLayerMap::getXY] Fill of DetId " << detid.rawId() << " layerEnumNb " << layerEnumNb << " are requested to wrong TkLayerMap " << layer_ << " \nPlease check the TkDetMap code";
 
-  if(layerEnumNb>=TkLayerMap::TIB_L1 && layerEnumNb<=TkLayerMap::TIB_L4)  
-    return getXY_TIB(detid,layerEnumNb);
-  else if(layerEnumNb>=TkLayerMap::TIDM_D1 && layerEnumNb<=TkLayerMap::TIDP_D3)  
-    return getXY_TID(detid,layerEnumNb); 
-  else if(layerEnumNb>=TkLayerMap::TOB_L1 && layerEnumNb<=TkLayerMap::TOB_L6)  
-    return getXY_TOB(detid,layerEnumNb); 
-  else 
-    return getXY_TEC(detid,layerEnumNb); 
-}
-
-uint32_t TkLayerMap::get_Offset( TIBDetId D ) const {
-  if(D.layerNumber()%2)
-    return D.isInternalString()?2:1;
+  if ( layerEnumNb >= TkLayerMap::TIB_L1 && layerEnumNb <= TkLayerMap::TIB_L4 )
+    return getXY_TIB(detid);
+  else if ( layerEnumNb >= TkLayerMap::TIDM_D1 && layerEnumNb <= TkLayerMap::TIDP_D3 )
+    return getXY_TID(detid);
+  else if ( layerEnumNb >= TkLayerMap::TOB_L1 && layerEnumNb <= TkLayerMap::TOB_L6 )
+    return getXY_TOB(detid);
   else
-    return D.isInternalString()?1:2;
+    return getXY_TEC(detid);
 }
 
-
-TkLayerMap::XYbin TkLayerMap::getXY_TIB(uint32_t detid, int layerEnumNb) const {  
-  if(!layerEnumNb)
-    layerEnumNb=layerSearch(detid);
-
-  TIBDetId D(detid);
-
+TkLayerMap::XYbin TkLayerMap::getXY_TIB(DetId detid) const
+{
   XYbin xyb;
-  xyb.ix=2*(D.isZMinusSide()?-1*D.moduleNumber()+3:D.moduleNumber()+2)+get_Offset(D);
-  xyb.iy=D.isInternalString()?D.stringNumber()+SingleExtString[D.stringNumber()]:D.stringNumber();
-  if(D.layerNumber()<3 && !D.isStereo())
-    xyb.iy+=Nstring_ext+2;
-  
-  xyb.x=lowX+xyb.ix-0.5;
-  xyb.y=lowY+xyb.iy-0.5;
-  return xyb;
+  xyb.ix = ( 2*( tTopo_->tibIsZMinusSide(detid) ?
+                  -1*tTopo_->tibModule(detid)+3 :
+                  tTopo_->tibModule(detid)+2 )
+           + ( tTopo_->tibLayer(detid) % 2 ?
+               ( tTopo_->tibIsInternalString(detid) ? 2 : 1 ) :
+               ( tTopo_->tibIsInternalString(detid) ? 1 : 2 ) ) );
+  xyb.iy = ( ( tTopo_->tibIsInternalString(detid) ?
+              tTopo_->tibString(detid)+singleExtStr_[tTopo_->tibString(detid)] :
+              tTopo_->tibString(detid) )
+           + ( ( tTopo_->tibLayer(detid) < 3 ) && ( ! tTopo_->tibIsStereo(detid) ) ?
+                nStringExt_+2 : 0 ) );
 
-}
+  xyb.x = lowX_+xyb.ix-0.5;
+  xyb.y = lowY_+xyb.iy-0.5;
 
-TkLayerMap::XYbin TkLayerMap::getXY_TOB(uint32_t detid, int layerEnumNb) const {  
-  if(!layerEnumNb)
-    layerEnumNb=layerSearch(detid);
-
-  TOBDetId D(detid);
-
-  XYbin xyb;
-  xyb.ix=D.isZMinusSide()?-1*D.moduleNumber()+7:D.moduleNumber()+6;
-  xyb.iy=D.rodNumber();  
-  if(D.layerNumber()<3 && !D.isStereo())
-    xyb.iy+=Nrod+2;
-
-  xyb.x=lowX+xyb.ix-0.5;
-  xyb.y=lowY+xyb.iy-0.5;
   return xyb;
 }
 
-TkLayerMap::XYbin TkLayerMap::getXY_TID(uint32_t detid, int layerEnumNb) const {  
-  if(!layerEnumNb)
-    layerEnumNb=layerSearch(detid);
-
-  TIDDetId D(detid);
-
+TkLayerMap::XYbin TkLayerMap::getXY_TOB(DetId detid) const
+{
   XYbin xyb;
+  xyb.ix = ( tTopo_->tobIsZMinusSide(detid) ?
+              -1*tTopo_->tobModule(detid)+7 :
+              tTopo_->tobModule(detid)+6 );
+  xyb.iy = ( tTopo_->tobRod(detid)
+           + ( tTopo_->tobLayer(detid) < 3 && ! tTopo_->tobIsStereo(detid) ?
+                nRod_+2 : 0 ) );
 
-  xyb.ix=D.isZMinusSide()?-3*D.ring()+10:3*D.ring()-2;
-  if(D.isStereo())
-    xyb.ix+=(D.isZMinusSide()?-1:1);
-  xyb.iy= int(2. * D.moduleNumber() - (D.isBackRing()?0.:1.));
+  xyb.x = lowX_+xyb.ix-0.5;
+  xyb.y = lowY_+xyb.iy-0.5;
 
-  xyb.x=lowX+xyb.ix-0.5;
-  xyb.y=lowY+xyb.iy-0.5;
   return xyb;
 }
 
-TkLayerMap::XYbin TkLayerMap::getXY_TEC(uint32_t detid, int layerEnumNb) const {  
-  if(!layerEnumNb)
-    layerEnumNb=layerSearch(detid);
-
-  TECDetId D(detid);
-
+TkLayerMap::XYbin TkLayerMap::getXY_TID(DetId detid) const
+{
   XYbin xyb;
+  xyb.ix = ( ( tTopo_->tidIsZMinusSide(detid) ?
+                -3*tTopo_->tidRing(detid)+10 :
+                3*tTopo_->tidRing(detid)-2 )
+           + ( tTopo_->tidIsStereo(detid) ?
+               ( tTopo_->tidIsZMinusSide(detid) ? -1 : 1 ) : 0 ) );
+  xyb.iy = 2*tTopo_->tidModule(detid) - ( tTopo_->tidIsBackRing(detid) ? 0 : 1 );
 
-  xyb.ix=D.isZMinusSide()?BinForRing[7]-BinForRing[D.ring()]+1:BinForRing[D.ring()]; //after the introduction of plus and minus histos, the BinForRing should have been changed. on the contrary we hack this part of the code 
-  if(D.isStereo())
-    xyb.ix+=(D.isZMinusSide()?-1:1);
+  xyb.x = lowX_+xyb.ix-0.5;
+  xyb.y = lowY_+xyb.iy-0.5;
 
-  if(D.isZMinusSide()){
-    xyb.iy= (D.petalNumber()-1)*(ModulesInRingFront[D.ring()]+ModulesInRingBack[D.ring()]) + ModulesInRingFront[D.ring()] - D.moduleNumber() +1;
-    if(D.isBackPetal())
-      xyb.iy+=ModulesInRingBack[D.ring()];
-  }else{ 
-    xyb.iy= (D.petalNumber()-1)*(ModulesInRingFront[D.ring()]+ModulesInRingBack[D.ring()])+D.moduleNumber();
-    if(D.isBackPetal())
-      xyb.iy+=ModulesInRingFront[D.ring()];
-  }
-
-  xyb.x=lowX+xyb.ix-0.5;
-  xyb.y=lowY+xyb.iy-0.5;
   return xyb;
 }
 
-//--------------------------------------
+TkLayerMap::XYbin TkLayerMap::getXY_TEC(DetId detid) const
+{
+  XYbin xyb;
+  xyb.ix = ( ( tTopo_->tecIsZMinusSide(detid) ?
+                binForRing_[7]-binForRing_[tTopo_->tecRing(detid)]+1 :
+                binForRing_[tTopo_->tecRing(detid)] )
+           + ( tTopo_->tecIsStereo(detid) ?
+               ( tTopo_->tecIsZMinusSide(detid) ? -1 : 1 ) : 0 ) );
 
-TkDetMap::TkDetMap(const edm::ParameterSet& p,const edm::ActivityRegistry& a){
-  doMe();
+  xyb.iy = ( (tTopo_->tecPetalNumber(detid)-1)*(modulesInRingFront_[tTopo_->tecRing(detid)] + modulesInRingBack_[tTopo_->tecRing(detid)])
+           + ( tTopo_->tecIsZMinusSide(detid) ?
+                  modulesInRingFront_[tTopo_->tecRing(detid)]-tTopo_->tecModule(detid)+1
+                + ( tTopo_->tecIsBackPetal(detid) ? modulesInRingBack_[tTopo_->tecRing(detid)] : 0 )
+              : tTopo_->tecModule(detid) + ( tTopo_->tecIsBackPetal(detid) ? modulesInRingFront_[tTopo_->tecRing(detid)] : 0 ) ) );
+
+  xyb.x = lowX_+xyb.ix-0.5;
+  xyb.y = lowY_+xyb.iy-0.5;
+
+  return xyb;
 }
 
-TkDetMap::TkDetMap(){
-  doMe();
-}
+// TkDetMap
 
-void TkDetMap::doMe() {
-  LogTrace("TkDetMap") <<"TkDetMap::constructor ";
-
-  TkMap.resize(35);
-  //Create TkLayerMap for each layer declared in the TkLayerEnum
-  for(int layer=1;layer<35;++layer){
-    TkMap[layer]=new TkLayerMap(layer);
-  }
-}
-
-TkDetMap::~TkDetMap(){
-  detmapType::iterator iter=TkMap.begin();
-  detmapType::iterator iterE=TkMap.end();
- 
-  for(;iter!=iterE;++iter)
-    delete (*iter);  
-}
-
-const TkLayerMap::XYbin& TkDetMap::getXY(uint32_t& detid , uint32_t& cached_detid , int16_t& cached_layer , TkLayerMap::XYbin& cached_XYbin) const {
-  LogTrace("TkDetMap") <<"[getXY] detid "<< detid << " cache " << cached_detid << " layer " << cached_layer << " XY " << cached_XYbin.ix << " " << cached_XYbin.iy  << " " << cached_XYbin.x << " " << cached_XYbin.y ;    
-  if(detid==cached_detid)
-    return cached_XYbin;
-
-  /*FIXME*/
-  //if (layer!=INVALID)
-  FindLayer(detid , cached_detid , cached_layer , cached_XYbin );
-  LogTrace("TkDetMap") <<"[getXY] detid "<< detid << " cache " << cached_detid << " layer " << cached_layer << " XY " << cached_XYbin.ix << " " << cached_XYbin.iy  << " " << cached_XYbin.x << " " << cached_XYbin.y ;    
-  return cached_XYbin;
-}
-
-int16_t TkDetMap::FindLayer(uint32_t& detid , uint32_t& cached_detid , int16_t& cached_layer , TkLayerMap::XYbin& cached_XYbin) const { 
-
-  if(detid==cached_detid)
-    return cached_layer;
-
-  cached_detid=detid;
-
-  int16_t layer=TkLayerMap::layerSearch(detid);
-  LogTrace("TkDetMap") <<"[FindLayer] detid "<< detid << " layer " << layer;
-  if(layer!=cached_layer){
-    cached_layer=layer;  
-  }
-  cached_XYbin=TkMap[cached_layer]->getXY(detid,layer);
-  LogTrace("TkDetMap") <<"[FindLayer] detid "<< detid << " cached_XYbin " << cached_XYbin.ix << " "<< cached_XYbin.iy;
-
-  return cached_layer;
-}
-
-
-
-void TkDetMap::getComponents(int layer,
-			     int& nchX,double& lowX,double& highX,
-			     int& nchY,double& lowY,double& highY) const {
-  nchX=TkMap[layer]->get_nchX();
-  lowX=TkMap[layer]->get_lowX();
-  highX=TkMap[layer]->get_highX();
-  nchY=TkMap[layer]->get_nchY();
-  lowY=TkMap[layer]->get_lowY();
-  highY=TkMap[layer]->get_highY();
-}
-
-void TkDetMap::getDetsForLayer(int layer,std::vector<uint32_t>& output) const {
-  output.clear();
-  size_t size_=TkMap[layer]->get_nchX()*TkMap[layer]->get_nchY();
-  output.resize(size_);
-  memcpy((void*)&output[0],(void*)TkMap[layer]->getBinToDet(),size_*sizeof(uint32_t));
-}
-
-std::string TkDetMap::getLayerName(int& in) const {
-  switch (in)
-    {
+std::string TkDetMap::getLayerName(int in)
+{
+  switch (in) {
     case TkLayerMap::TIB_L1:
       return "TIB_L1";
     case TkLayerMap::TIB_L2:
       return "TIB_L2";
     case TkLayerMap::TIB_L3:
       return "TIB_L3";
-    case TkLayerMap::TIB_L4:         
-      return "TIB_L4";         
+    case TkLayerMap::TIB_L4:
+      return "TIB_L4";
     case TkLayerMap::TIDP_D1:
       return "TIDP_D1";
     case TkLayerMap::TIDP_D2:
@@ -738,7 +275,7 @@ std::string TkDetMap::getLayerName(int& in) const {
       return "TECP_W3";
     case TkLayerMap::TECP_W4:
       return "TECP_W4";
-    case TkLayerMap::TECP_W5: 
+    case TkLayerMap::TECP_W5:
       return "TECP_W5";
     case TkLayerMap::TECP_W6:
       return "TECP_W6";
@@ -756,7 +293,7 @@ std::string TkDetMap::getLayerName(int& in) const {
       return "TECM_W3";
     case TkLayerMap::TECM_W4:
       return "TECM_W4";
-    case TkLayerMap::TECM_W5: 
+    case TkLayerMap::TECM_W5:
       return "TECM_W5";
     case TkLayerMap::TECM_W6:
       return "TECM_W6";
@@ -766,85 +303,86 @@ std::string TkDetMap::getLayerName(int& in) const {
       return "TECM_W8";
     case TkLayerMap::TECM_W9:
       return "TECM_W9";
-    }
+  }
   return "Invalid";
 }
 
-int TkDetMap::getLayerNum(const std::string& in) const {
-  if(in=="TIB_L1")
+int TkDetMap::getLayerNum(const std::string& in)
+{
+  if ( in == "TIB_L1" )
     return TkLayerMap::TIB_L1;
-  if(in=="TIB_L2")
+  if ( in == "TIB_L2" )
     return TkLayerMap::TIB_L2;
-  if(in=="TIB_L3")
+  if ( in == "TIB_L3" )
     return TkLayerMap::TIB_L3;
-  if(in=="TIB_L4")         
-    return TkLayerMap::TIB_L4;         
-  if(in=="TIDP_D1")
+  if ( in == "TIB_L4" )
+    return TkLayerMap::TIB_L4;
+  if ( in == "TIDP_D1" )
     return TkLayerMap::TIDP_D1;
-  if(in=="TIDP_D2")
+  if ( in == "TIDP_D2" )
     return TkLayerMap::TIDP_D2;
-  if(in=="TIDP_D3")
+  if ( in == "TIDP_D3" )
     return TkLayerMap::TIDP_D3;
-  if(in=="TIDM_D1")
+  if ( in == "TIDM_D1" )
     return TkLayerMap::TIDM_D1;
-  if(in=="TIDM_D2")
+  if ( in == "TIDM_D2" )
     return TkLayerMap::TIDM_D2;
-  if(in=="TIDM_D3")
+  if ( in == "TIDM_D3" )
     return TkLayerMap::TIDM_D3;
-  if(in=="TOB_L1")
+  if ( in == "TOB_L1" )
     return TkLayerMap::TOB_L1;
-  if(in=="TOB_L2")
+  if ( in == "TOB_L2" )
     return TkLayerMap::TOB_L2;
-  if(in=="TOB_L3")
+  if ( in == "TOB_L3" )
     return TkLayerMap::TOB_L3;
-  if(in=="TOB_L4")
+  if ( in == "TOB_L4" )
     return TkLayerMap::TOB_L4;
-  if(in=="TOB_L5")
+  if ( in == "TOB_L5" )
     return TkLayerMap::TOB_L5;
-  if(in=="TOB_L6")
+  if ( in == "TOB_L6" )
     return TkLayerMap::TOB_L6;
-  if(in=="TECP_W1")
+  if ( in == "TECP_W1" )
     return TkLayerMap::TECP_W1;
-  if(in=="TECP_W2")
+  if ( in == "TECP_W2" )
     return TkLayerMap::TECP_W2;
-  if(in=="TECP_W3")
+  if ( in == "TECP_W3" )
     return TkLayerMap::TECP_W3;
-  if(in=="TECP_W4")
+  if ( in == "TECP_W4" )
     return TkLayerMap::TECP_W4;
-  if(in=="TECP_W5")
-    return TkLayerMap::TECP_W5; 
-  if(in=="TECP_W6")
+  if ( in == "TECP_W5" )
+    return TkLayerMap::TECP_W5;
+  if ( in == "TECP_W6" )
     return TkLayerMap::TECP_W6;
-  if(in=="TECP_W7")
+  if ( in == "TECP_W7" )
     return TkLayerMap::TECP_W7;
-  if(in=="TECP_W8")
+  if ( in == "TECP_W8" )
     return TkLayerMap::TECP_W8;
-  if(in=="TECP_W9")
+  if ( in == "TECP_W9" )
     return TkLayerMap::TECP_W9;
-  if(in=="TECM_W1")
+  if ( in == "TECM_W1" )
     return TkLayerMap::TECM_W1;
-  if(in=="TECM_W2")
+  if ( in == "TECM_W2" )
     return TkLayerMap::TECM_W2;
-  if(in=="TECM_W3")
+  if ( in == "TECM_W3" )
     return TkLayerMap::TECM_W3;
-  if(in=="TECM_W4")
+  if ( in == "TECM_W4" )
     return TkLayerMap::TECM_W4;
-  if(in=="TECM_W5")
-    return TkLayerMap::TECM_W5; 
-  if(in=="TECM_W6")
+  if ( in == "TECM_W5" )
+    return TkLayerMap::TECM_W5;
+  if ( in == "TECM_W6" )
     return TkLayerMap::TECM_W6;
-  if(in=="TECM_W7")
+  if ( in == "TECM_W7" )
     return TkLayerMap::TECM_W7;
-  if(in=="TECM_W8")
+  if ( in == "TECM_W8" )
     return TkLayerMap::TECM_W8;
-  if(in=="TECM_W9")
+  if ( in == "TECM_W9" )
     return TkLayerMap::TECM_W9;
   return 0;
 }
 
-void TkDetMap::getSubDetLayerSide(int& in,SiStripDetId::SubDetector& subDet,uint32_t& layer,uint32_t& side) const {
-  switch (in)
-    {
+void TkDetMap::getSubDetLayerSide(int in, SiStripDetId::SubDetector& subDet, uint32_t& layer, uint32_t& side)
+{
+  switch (in) {
     case TkLayerMap::TIB_L1:
       subDet = SiStripDetId::TIB;
       layer = 1;
@@ -864,32 +402,32 @@ void TkDetMap::getSubDetLayerSide(int& in,SiStripDetId::SubDetector& subDet,uint
     case TkLayerMap::TIDP_D1:
       subDet = SiStripDetId::TID;
       layer = 1;
-      side=2;
+      side = 2;
       break;
     case TkLayerMap::TIDP_D2:
       subDet = SiStripDetId::TID;
       layer = 2;
-      side=2;
+      side = 2;
       break;
     case TkLayerMap::TIDP_D3:
       subDet = SiStripDetId::TID;
       layer = 3;
-      side=2;
+      side = 2;
       break;
     case TkLayerMap::TIDM_D1:
       subDet = SiStripDetId::TID;
       layer = 1;
-      side=1;
+      side = 1;
       break;
     case TkLayerMap::TIDM_D2:
       subDet = SiStripDetId::TID;
       layer = 2;
-      side=1;
+      side = 1;
       break;
     case TkLayerMap::TIDM_D3:
       subDet = SiStripDetId::TID;
       layer = 3;
-      side=1;
+      side = 1;
       break;
     case TkLayerMap::TOB_L1:
       subDet = SiStripDetId::TOB;
@@ -918,94 +456,136 @@ void TkDetMap::getSubDetLayerSide(int& in,SiStripDetId::SubDetector& subDet,uint
     case TkLayerMap::TECP_W1:
       subDet = SiStripDetId::TEC;
       layer = 1;
-      side=2;
+      side = 2;
       break;
     case TkLayerMap::TECP_W2:
       subDet = SiStripDetId::TEC;
       layer = 2;
-      side=2;
+      side = 2;
       break;
     case TkLayerMap::TECP_W3:
       subDet = SiStripDetId::TEC;
       layer = 3;
-      side=2;
+      side = 2;
       break;
     case TkLayerMap::TECP_W4:
       subDet = SiStripDetId::TEC;
       layer = 4;
-      side=2;
+      side = 2;
       break;
-    case TkLayerMap::TECP_W5: 
+    case TkLayerMap::TECP_W5:
       subDet = SiStripDetId::TEC;
       layer = 5;
-      side=2;
+      side = 2;
       break;
     case TkLayerMap::TECP_W6:
       subDet = SiStripDetId::TEC;
       layer = 6;
-      side=2;
+      side = 2;
       break;
     case TkLayerMap::TECP_W7:
       subDet = SiStripDetId::TEC;
       layer = 7;
-      side=2;
+      side = 2;
       break;
     case TkLayerMap::TECP_W8:
       subDet = SiStripDetId::TEC;
       layer = 8;
-      side=2;
+      side = 2;
       break;
     case TkLayerMap::TECP_W9:
       subDet = SiStripDetId::TEC;
       layer = 9;
-      side=2;
+      side = 2;
       break;
     case TkLayerMap::TECM_W1:
       subDet = SiStripDetId::TEC;
       layer = 1;
-      side=1;
+      side = 1;
       break;
     case TkLayerMap::TECM_W2:
       subDet = SiStripDetId::TEC;
       layer = 2;
-      side=1;
+      side = 1;
       break;
     case TkLayerMap::TECM_W3:
       subDet = SiStripDetId::TEC;
       layer = 3;
-      side=1;
+      side = 1;
       break;
     case TkLayerMap::TECM_W4:
       subDet = SiStripDetId::TEC;
       layer = 4;
-      side=1;
+      side = 1;
       break;
-    case TkLayerMap::TECM_W5: 
+    case TkLayerMap::TECM_W5:
       subDet = SiStripDetId::TEC;
       layer = 5;
-      side=1;
+      side = 1;
       break;
     case TkLayerMap::TECM_W6:
       subDet = SiStripDetId::TEC;
       layer = 6;
-      side=1;
+      side = 1;
       break;
     case TkLayerMap::TECM_W7:
       subDet = SiStripDetId::TEC;
       layer = 7;
-      side=1;
+      side = 1;
       break;
     case TkLayerMap::TECM_W8:
       subDet = SiStripDetId::TEC;
       layer = 8;
-      side=1;
+      side = 1;
       break;
     case TkLayerMap::TECM_W9:
       subDet = SiStripDetId::TEC;
       layer = 9;
-      side=1;
+      side = 1;
       break;
-    }
+  }
 }
 
-//  LocalWords:  TkLayerMap
+const TkLayerMap::XYbin& TkDetMap::getXY(DetId detid, DetId& cached_detid, int16_t& cached_layer, TkLayerMap::XYbin& cached_XYbin) const
+{
+  LogTrace("TkDetMap") << "[getXY] detid " << detid.rawId() << " cache " << cached_detid.rawId() << " layer " << cached_layer << " XY " << cached_XYbin.ix << " " << cached_XYbin.iy << " " << cached_XYbin.x << " " << cached_XYbin.y;
+  if ( detid == cached_detid )
+    return cached_XYbin;
+
+  /*FIXME*/
+  //if (layer!=INVALID)
+  findLayer(detid, cached_detid , cached_layer, cached_XYbin);
+  LogTrace("TkDetMap") << "[getXY] detid " << detid.rawId() << " cache " << cached_detid.rawId() << " layer " << cached_layer << " XY " << cached_XYbin.ix << " " << cached_XYbin.iy  << " " << cached_XYbin.x << " " << cached_XYbin.y;
+
+  return cached_XYbin;
+}
+
+int16_t TkDetMap::findLayer( DetId detid, DetId& cached_detid, int16_t& cached_layer, TkLayerMap::XYbin& cached_XYbin ) const
+{
+  if ( detid == cached_detid )
+    return cached_layer;
+
+  cached_detid = detid;
+
+  int16_t layer = TkLayerMap::layerSearch(detid, tTopo_);
+  LogTrace("TkDetMap") << "[findLayer] detid " << detid.rawId() << " layer " << layer;
+  if ( layer != cached_layer ) {
+    cached_layer=layer;
+  }
+  cached_XYbin = TkMap[cached_layer].getXY(detid, layer);
+  LogTrace("TkDetMap") << "[findLayer] detid " << detid.rawId() << " cached_XYbin " << cached_XYbin.ix << " " << cached_XYbin.iy;
+
+  return cached_layer;
+}
+
+void TkDetMap::getComponents(int layer,
+			     int& nchX,double& lowX,double& highX,
+			     int& nchY,double& lowY,double& highY) const
+{
+  nchX = TkMap[layer].get_nchX();
+  lowX = TkMap[layer].get_lowX();
+  highX = TkMap[layer].get_highX();
+  nchY = TkMap[layer].get_nchY();
+  lowY = TkMap[layer].get_lowY();
+  highY = TkMap[layer].get_highY();
+}

--- a/CalibTracker/SiStripDCS/plugins/SiStripDetVOffTkMapPlotter.cc
+++ b/CalibTracker/SiStripDCS/plugins/SiStripDetVOffTkMapPlotter.cc
@@ -9,6 +9,8 @@
 
 #include "CondCore/CondDB/interface/ConnectionPool.h"
 
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
 #include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 #include "CondFormats/SiStripObjects/interface/SiStripDetVOff.h"
 #include "CondFormats/Common/interface/Time.h"
@@ -86,9 +88,12 @@ void SiStripDetVOffTkMapPlotter::analyze(const edm::Event& evt, const edm::Event
       << "Make tkMap for IOV " << theIov << " (" << boost::posix_time::to_simple_string(cond::time::to_boost(theIov)) << ")";
   auto payload = condDbSession.fetchPayload<SiStripDetVOff>( (*iiov).payloadId );
 
+  edm::ESHandle<TkDetMap> tkDetMapHandle;
+  evtSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+  const TkDetMap* tkDetMap = tkDetMapHandle.product();
   TrackerMap lvmap,hvmap;
-  TkHistoMap lvhisto("LV_Status","LV_Status",-1);
-  TkHistoMap hvhisto("HV_Status","HV_Status",-1);
+  TkHistoMap lvhisto(tkDetMap, "LV_Status","LV_Status",-1);
+  TkHistoMap hvhisto(tkDetMap, "HV_Status","HV_Status",-1);
 
   auto detids = detidReader->getAllDetIds();
   for (auto id : detids){

--- a/CalibTracker/SiStripDCS/plugins/TkVoltageMapCreator.cc
+++ b/CalibTracker/SiStripDCS/plugins/TkVoltageMapCreator.cc
@@ -20,6 +20,8 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
 #include "DQM/SiStripCommon/interface/TkHistoMap.h" 
 #include "CommonTools/TrackerMap/interface/TrackerMap.h"
 
@@ -93,12 +95,16 @@ TkVoltageMapCreator::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
 }
 
 void 
-TkVoltageMapCreator::beginRun(const edm::Run& iRun, const edm::EventSetup&)
+TkVoltageMapCreator::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup)
 {
+  edm::ESHandle<TkDetMap> tkDetMapHandle;
+  iSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+  const TkDetMap* tkDetMap = tkDetMapHandle.product();
+
   TrackerMap lvmap,hvmap;
 
-  TkHistoMap lvhisto("LV_Status","LV_Status",-1);
-  TkHistoMap hvhisto("HV_Status","HV_Status",-1);
+  TkHistoMap lvhisto(tkDetMap, "LV_Status","LV_Status",-1);
+  TkHistoMap hvhisto(tkDetMap, "HV_Status","HV_Status",-1);
   
   std::ifstream lvdata(_lvfile.c_str());
   std::ifstream hvdata(_hvfile.c_str());

--- a/CalibTracker/SiStripDCS/test/Synchronization/SyncDCSO2O.h
+++ b/CalibTracker/SiStripDCS/test/Synchronization/SyncDCSO2O.h
@@ -29,7 +29,6 @@
 #include "DataFormats/Common/interface/DetSetNew.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
-#include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
 
 #include <vector>

--- a/CalibTracker/SiStripDCS/test/TkVoltageMapCreator_cfg.py
+++ b/CalibTracker/SiStripDCS/test/TkVoltageMapCreator_cfg.py
@@ -22,9 +22,11 @@ process.source = cms.Source("EmptySource",
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 
-process.TkDetMap = cms.Service("TkDetMap")
-process.load("DQMServices.Core.DQMStore_cfg")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
+# load TrackerTopology (needed for TkDetMap and TkHistoMap)
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
+process.trackerTopology = cms.ESProducer("TrackerTopologyEP")
 
 #This is where we configure the input and output files for the LV/HV TkMaps we want to create
 #LV/HVStatusFile is a file that contains a list of all the 15148 Tracker DetIDs and for each of them a number 0=OFF 1=ON

--- a/CalibTracker/SiStripDCS/test/dcs_tkMap_cfg.py
+++ b/CalibTracker/SiStripDCS/test/dcs_tkMap_cfg.py
@@ -17,9 +17,11 @@ process.source = cms.Source("EmptySource",
     firstRun = cms.untracked.uint32(1)
 )
 
-process.TkDetMap = cms.Service("TkDetMap")
-process.load("DQMServices.Core.DQMStore_cfg")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
+# load TrackerTopology (needed for TkDetMap and TkHistoMap)
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
+process.trackerTopology = cms.ESProducer("TrackerTopologyEP")
 
 process.load("CondCore.CondDB.CondDB_cfi")
 process.tkVoltageMap = cms.EDAnalyzer( "SiStripDetVOffTkMapPlotter",

--- a/CalibTracker/SiStripESProducers/python/fake/SiStripBadModuleConfigurableFakeESSource_cfi.py
+++ b/CalibTracker/SiStripESProducers/python/fake/SiStripBadModuleConfigurableFakeESSource_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 siStripBadModuleConfigurableFakeESSource = cms.ESSource("SiStripBadModuleConfigurableFakeESSource",
         appendToDataLabel = cms.string(''),
         printDebug = cms.untracked.bool(False),
-        file = cms.untracked.FileInPath('CalibTracker/SiStripCommon/data/SiStripDetInfo.dat'),
+        file = cms.FileInPath('CalibTracker/SiStripCommon/data/SiStripDetInfo.dat'),
         BadComponentList = cms.untracked.VPSet(
                 cms.PSet(
                 SubDet = cms.string('TIB'),  

--- a/CalibTracker/SiStripESProducers/test/fedBadChannelFromNoiseRun_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/fedBadChannelFromNoiseRun_cfg.py
@@ -38,9 +38,7 @@ process.siStripQualityESProducer.ReduceGranularity = cms.bool(False)
 process.siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
 
 #### Add these lines to produce a tracker map
-process.load("DQMServices.Core.DQMStore_cfg")
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 ####
 
 process.stat = cms.EDAnalyzer("SiStripQualityStatistics",

--- a/CalibTracker/SiStripESProducers/test/mergeBadChannel_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/mergeBadChannel_cfg.py
@@ -39,9 +39,7 @@ process.siStripQualityESProducer.ReduceGranularity = cms.bool(False)
 process.siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
 
 #### Add these lines to produce a tracker map
-process.load("DQMServices.Core.DQMStore_cfg")
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 ####
 
 process.stat = cms.EDAnalyzer("SiStripQualityStatistics",

--- a/CalibTracker/SiStripESProducers/test/python/SiStripBadComponentBuilder_byHand_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/SiStripBadComponentBuilder_byHand_cfg.py
@@ -138,9 +138,11 @@ process.siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
      )
 
 #### Add these lines to produce a tracker map
-process.load("DQMServices.Core.DQMStore_cfg")
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
+# load TrackerTopology (needed for TkDetMap and TkHistoMap)
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
+process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
 ####
 
 process.reader = cms.EDAnalyzer("SiStripQualityStatistics",

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
@@ -48,7 +48,6 @@
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 #include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
-#include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h" 

--- a/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
@@ -53,7 +53,6 @@
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
-#include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics.cc
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics.cc
@@ -35,14 +35,11 @@ SiStripQualityStatistics::SiStripQualityStatistics( const edm::ParameterSet& iCo
   fp_(iConfig.getUntrackedParameter<edm::FileInPath>("file",edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat"))),
   saveTkHistoMap_(iConfig.getUntrackedParameter<bool>("SaveTkHistoMap",true)),
   tkMap(nullptr),tkMapFullIOVs(nullptr)
-{  
+{
   reader = new SiStripDetInfoFileReader(fp_.fullPath());
 
   tkMapFullIOVs=new TrackerMap( "BadComponents" );
   tkhisto=nullptr;
-  if (TkMapFileName_!=""){
-    tkhisto   =new TkHistoMap("BadComp","BadComp",-1.); //here the baseline (the value of the empty,not assigned bins) is put to -1 (default is zero)
-  }
 }
 
 void SiStripQualityStatistics::endJob(){
@@ -65,6 +62,12 @@ void SiStripQualityStatistics::analyze( const edm::Event& e, const edm::EventSet
   edm::ESHandle<TrackerTopology> tTopoHandle;
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
+  if ( ( ! tkhisto ) && ( ! TkMapFileName_.empty() ) ) {
+    edm::ESHandle<TkDetMap> tkDetMapHandle;
+    iSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+    //here the baseline (the value of the empty,not assigned bins) is put to -1 (default is zero)
+    tkhisto = std::make_unique<TkHistoMap>(tkDetMapHandle.product(), "BadComp","BadComp",-1.);
+  }
 
   unsigned long long cacheID = iSetup.get<SiStripQualityRcd>().cacheIdentifier();
 

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics.h
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics.h
@@ -49,6 +49,6 @@ class SiStripQualityStatistics : public edm::EDAnalyzer {
 
   TrackerMap * tkMap, *tkMapFullIOVs;
   SiStripDetInfoFileReader* reader;
-  TkHistoMap* tkhisto;
+  std::unique_ptr<TkHistoMap> tkhisto;
 };
 #endif

--- a/CalibTracker/SiStripQuality/test/cfg/SiStripQualityStatistics_cfg.py
+++ b/CalibTracker/SiStripQuality/test/cfg/SiStripQualityStatistics_cfg.py
@@ -117,9 +117,7 @@ process.siStripQualityESProducer.UseEmptyRunInfo = cms.bool(False)
 #-------------------------------------------------
 # Services for the TkHistoMap
 #-------------------------------------------------
-process.load("DQMServices.Core.DQMStore_cfg")
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 #-------------------------------------------------
 
 # be sure that the dataLabel parameter matches with the label of the SiStripQuality object you want to explore

--- a/CalibTracker/SiStripQuality/test/cfg/StudyExample/SiStripQualityStatistics_Cabling_cfg.py
+++ b/CalibTracker/SiStripQuality/test/cfg/StudyExample/SiStripQualityStatistics_Cabling_cfg.py
@@ -78,9 +78,7 @@ process.siStripQualityESProducer.ReduceGranularity = cms.bool(False)
 #-------------------------------------------------
 # Services for the TkHistoMap
 #-------------------------------------------------
-process.load("DQMServices.Core.DQMStore_cfg")
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 
 process.stat = cms.EDAnalyzer("SiStripQualityStatistics",
                               dataLabel = cms.untracked.string(""),

--- a/CalibTracker/SiStripQuality/test/cfg/StudyExample/SiStripQualityStatistics_singleTag_cfg.py
+++ b/CalibTracker/SiStripQuality/test/cfg/StudyExample/SiStripQualityStatistics_singleTag_cfg.py
@@ -79,9 +79,7 @@ process.onlineSiStripQualityProducer = cms.ESProducer("SiStripQualityESProducer"
 #-------------------------------------------------
 # Services for the TkHistoMap
 #-------------------------------------------------
-process.load("DQMServices.Core.DQMStore_cfg")
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 
 process.stat = cms.EDAnalyzer("SiStripQualityStatistics",
                               dataLabel = cms.untracked.string(""),

--- a/CalibTracker/SiStripQuality/test/cfg/TrackHitPositions_cfg.py
+++ b/CalibTracker/SiStripQuality/test/cfg/TrackHitPositions_cfg.py
@@ -64,9 +64,7 @@ process.siStripQualityESProducer.UseEmptyRunInfo = cms.bool(False)
 #-------------------------------------------------
 # Services for the TkHistoMap
 #-------------------------------------------------
-process.load("DQMServices.Core.DQMStore_cfg")
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 #-------------------------------------------------
 process.stat = cms.EDAnalyzer("TrackHitPositions",
                               dataLabel = cms.untracked.string(""),

--- a/DPGAnalysis/SiStripTools/plugins/APVShotsAnalyzer.cc
+++ b/DPGAnalysis/SiStripTools/plugins/APVShotsAnalyzer.cc
@@ -120,7 +120,7 @@ private:
   TH1F** _subDetectorrun;
   TH1F** _fedrun;
 
-  TkHistoMap *tkhisto,*tkhisto2;
+  std::unique_ptr<TkHistoMap> tkhisto, tkhisto2;
 
   // DetCabling
   bool _useCabling;
@@ -217,8 +217,8 @@ APVShotsAnalyzer::APVShotsAnalyzer(const edm::ParameterSet& iConfig):
    _medianVsFED->GetXaxis()->SetTitle("fedId");_medianVsFED->GetYaxis()->SetTitle("Charge [ADC]");  _median->GetZaxis()->SetTitle("Shots");
  }
 
- tkhisto      =new TkHistoMap("ShotMultiplicity","ShotMultiplicity",-1);
- tkhisto2      =new TkHistoMap("StripMultiplicity","StripMultiplicity",-1);
+ tkhisto = nullptr;
+ tkhisto2 = nullptr;
 }
 
 
@@ -245,6 +245,15 @@ APVShotsAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
    if (_useCabling){
      //retrieve cabling
      updateDetCabling( iSetup );
+   }
+
+   if ( ! ( tkhisto && tkhisto2 ) ) {
+     edm::ESHandle<TkDetMap> tkDetMapHandle;
+     iSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+     const TkDetMap* tkDetMap = tkDetMapHandle.product();
+
+     tkhisto = std::make_unique<TkHistoMap>(tkDetMap, "ShotMultiplicity","ShotMultiplicity",-1);
+     tkhisto2 = std::make_unique<TkHistoMap>(tkDetMap, "StripMultiplicity","StripMultiplicity",-1);
    }
 
    _nevents++;

--- a/DPGAnalysis/SiStripTools/plugins/DetIdSelectorTest.cc
+++ b/DPGAnalysis/SiStripTools/plugins/DetIdSelectorTest.cc
@@ -70,7 +70,7 @@ private:
 
 
   std::vector<DetIdSelector> detidsels_;
-  TkHistoMap *tkhisto_;
+  std::unique_ptr<TkHistoMap> tkhisto_;
   TrackerMap tkmap_;
 
   
@@ -88,7 +88,7 @@ private:
 // constructors and destructor
 //
 DetIdSelectorTest::DetIdSelectorTest(const edm::ParameterSet& iConfig):
-  detidsels_(), tkhisto_(new TkHistoMap("SelectorTest","SelectorTest",-1)),tkmap_()
+  detidsels_(), tkhisto_(nullptr), tkmap_()
 {
    //now do what ever initialization is needed
 
@@ -123,6 +123,12 @@ void
 DetIdSelectorTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
    using namespace edm;
+
+   if ( ! tkhisto_ ) {
+     edm::ESHandle<TkDetMap> tkDetMapHandle;
+     iSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+     tkhisto_ = std::make_unique<TkHistoMap>(tkDetMapHandle.product(), "SelectorTest","SelectorTest",-1);
+   }
    
    {
      SiStripDetInfoFileReader * reader=edm::Service<SiStripDetInfoFileReader>().operator->();

--- a/DPGAnalysis/SiStripTools/test/APVShot_Selector_cfg.py
+++ b/DPGAnalysis/SiStripTools/test/APVShot_Selector_cfg.py
@@ -11,9 +11,7 @@ process = cms.Process('APVShotAnalyzer',eras.Run2_2016)
 
 #prepare options
 
-process.DQMStore=cms.Service("DQMStore")
-process.TkDetMap=cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 
 options = VarParsing.VarParsing("analysis")
 

--- a/DPGAnalysis/SiStripTools/test/apvshotanalyzer_cfg.py
+++ b/DPGAnalysis/SiStripTools/test/apvshotanalyzer_cfg.py
@@ -108,9 +108,7 @@ process.FrameHeader2Events = cms.EDFilter('EventWithHistoryEDFilter',
                                           )
 
 
-process.DQMStore=cms.Service("DQMStore")
-process.TkDetMap=cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 
 process.p0 = cms.Path(
    process.siStripDigis + process.siStripZeroSuppression +

--- a/DPGAnalysis/SiStripTools/test/detidselectortest_cfg.py
+++ b/DPGAnalysis/SiStripTools/test/detidselectortest_cfg.py
@@ -63,9 +63,7 @@ process.detidselectortest = cms.EDAnalyzer("DetIdSelectorTest",
 #process.detidselectortest.selections.extend(OccupancyPlotsStripWantedSubDets)
 #process.detidselectortest.selections.extend(OccupancyPlotsPixelWantedSubDets)
 
-process.DQMStore = cms.Service("DQMStore")
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 
 #process.Timing = cms.Service("Timing")
 

--- a/DPGAnalysis/SiStripTools/test/manyfederrors_cfg.py
+++ b/DPGAnalysis/SiStripTools/test/manyfederrors_cfg.py
@@ -206,9 +206,7 @@ process.seqNoTooManyErrors = cms.Sequence(~process.filterFEDBadModuleAllThr + ~p
                                           ~process.filterFEDBadModuleMidThr + ~process.filterFEDBadModuleLowThr)
 
 
-process.DQMStore=cms.Service("DQMStore")
-process.TkDetMap=cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 
 process.load("DQM.SiStripMonitorHardware.siStripFEDMonitor_Tier0_cff")
 

--- a/DQM/HLTEvF/test/hlt_dqm_sourceclient-file_cfg.py
+++ b/DQM/HLTEvF/test/hlt_dqm_sourceclient-file_cfg.py
@@ -20,8 +20,7 @@ process.GlobalTag.globaltag = 'GR09_E_V3T::All'
 process.prefer("GlobalTag")
 
 #SiStrip Local Reco
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
-process.TkDetMap = cms.Service("TkDetMap")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 
 process.GlobalTrackingGeometryESProducer = cms.ESProducer( "GlobalTrackingGeometryESProducer" )
 

--- a/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
@@ -23,8 +23,7 @@ process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.GlobalTrackingGeometryESProducer = cms.ESProducer( "GlobalTrackingGeometryESProducer" ) # for muon hlt dqm
 #SiStrip Local Reco
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
-process.TkDetMap = cms.Service("TkDetMap")
+process.load("CalibTracker.SiStripCommon.TkDetMap_cff")
 
 #---- for P5 (online) DB access
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")

--- a/DQM/Integration/python/clients/hltrates_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hltrates_dqm_sourceclient-live_cfg.py
@@ -40,8 +40,7 @@ process.dqmSaver.tag = "HLTRates"
 #process.load("Configuration.StandardSequences.MagneticField_cff")
 #process.GlobalTrackingGeometryESProducer = cms.ESProducer( "GlobalTrackingGeometryESProducer" ) # for muon hlt dqm
 #SiStrip Local Reco
-#process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
-#process.TkDetMap = cms.Service("TkDetMap")
+#process.load("CalibTracker.SiStripCommon.TkDetMap_cff")
 
 #---- for P5 (online) DB access
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
@@ -72,8 +71,7 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 #process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 #process.load('Configuration/StandardSequences/RawToDigi_Data_cff')
 
-#process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
-#process.TkDetMap = cms.Service("TkDetMap")
+#process.load("CalibTracker.SiStripCommon.TkDetMap_cff")
 
 ####### JMS Aug 16 2011 you do need to prescale
 process.hltPreTrigResRateMon = cms.EDFilter ("HLTPrescaler",

--- a/DQM/SiStripCommon/interface/TkHistoMap.h
+++ b/DQM/SiStripCommon/interface/TkHistoMap.h
@@ -15,46 +15,46 @@ class TkHistoMap{
   typedef std::vector<MonitorElement*> tkHistoMapVect;
 
  public:
-  TkHistoMap(DQMStore::IBooker & ibooker , std::string path, std::string MapName, float baseline=0, bool mechanicalView=false);
-  TkHistoMap(std::string path, std::string MapName, float baseline=0, bool mechanicalView=false);
+  TkHistoMap(DQMStore::IBooker & ibooker , const TkDetMap* tkDetMap, const std::string& path, const std::string& MapName, float baseline=0, bool mechanicalView=false);
+  TkHistoMap(const TkDetMap* tkDetMap, const std::string& path, const std::string& MapName, float baseline=0, bool mechanicalView=false);
   TkHistoMap();
   ~TkHistoMap(){};
 
   void loadServices();
 
-  void loadTkHistoMap(std::string path, std::string MapName, bool mechanicalView=false);
+  void loadTkHistoMap(const std::string& path, const std::string& MapName, bool mechanicalView=false);
 
   MonitorElement* getMap(short layerNumber){return tkHistoMap_[layerNumber];};
   std::vector<MonitorElement*>& getAllMaps(){return tkHistoMap_;};
 
-  float getValue(uint32_t& detid);
-  float getEntries(uint32_t& detid);
-  uint32_t getDetId(std::string title, int ix, int iy){return getDetId(getLayerNum(getLayerName(title)),ix,iy);}
-  uint32_t getDetId(int layer, int ix, int iy){return tkdetmap_->getDetFromBin(layer,ix,iy);}
-  uint32_t getDetId(MonitorElement*ME, int ix, int iy){return getDetId(ME->getTitle(),ix,iy);}
+  float getValue(DetId detid);
+  float getEntries(DetId detid);
+  DetId getDetId(const std::string& title, int ix, int iy){return getDetId(getLayerNum(getLayerName(title)),ix,iy);}
+  DetId getDetId(int layer, int ix, int iy){return tkdetmap_->getDetFromBin(layer,ix,iy);}
+  DetId getDetId(const MonitorElement* ME, int ix, int iy){return getDetId(ME->getTitle(),ix,iy);}
   std::string getLayerName(std::string title){return title.erase(0,MapName_.size()+1);}
-  uint16_t getLayerNum(std::string layerName){return tkdetmap_->getLayerNum(layerName);}
+  uint16_t getLayerNum(const std::string& layerName){return tkdetmap_->getLayerNum(layerName);}
 
-  void fillFromAscii(std::string filename);
-  void fill(uint32_t& detid,float value);
-  void setBinContent(uint32_t& detid,float value);
-  void add(uint32_t& detid,float value);
+  void fillFromAscii(const std::string& filename);
+  void fill(DetId detid,float value);
+  void setBinContent(DetId detid,float value);
+  void add(DetId detid,float value);
 
   void dumpInTkMap(TrackerMap* tkmap, bool dumpEntries=false); //dumpEntries==true? (dump entries) : (dump mean values)
-  void save(std::string filename);
-  void saveAsCanvas(std::string filename,std::string options="", std::string mode="RECREATE");
+  void save(const std::string& filename);
+  void saveAsCanvas(const std::string& filename, const std::string& options="", const std::string& mode="RECREATE");
 
  private:
 
   //fixme: keep single method
-  void createTkHistoMap(std::string& path, std::string& MapName, float& baseline, bool mechanicalView);
-  void createTkHistoMap(DQMStore::IBooker & ibooker , std::string& path, std::string& MapName, float& baseline, bool mechanicalView);
+  void createTkHistoMap(const std::string& path, const std::string& MapName, float baseline, bool mechanicalView);
+  void createTkHistoMap(DQMStore::IBooker & ibooker , const std::string& path, const std::string& MapName, float baseline, bool mechanicalView);
 
-  std::string folderDefinition(std::string& path, std::string& MapName, int layer , bool mechanicalView, std::string& fullName);
+  std::string folderDefinition(std::string path, const std::string& MapName, int layer , bool mechanicalView, std::string& fullName);
 
   DQMStore* dqmStore_;
-  TkDetMap* tkdetmap_;
-  uint32_t cached_detid;
+  const TkDetMap* tkdetmap_;
+  DetId cached_detid;
   int16_t cached_layer;
   TkLayerMap::XYbin cached_XYbin;
   std::vector<MonitorElement*> tkHistoMap_;

--- a/DQM/SiStripCommon/interface/TkHistoMap.h
+++ b/DQM/SiStripCommon/interface/TkHistoMap.h
@@ -15,9 +15,9 @@ class TkHistoMap{
   typedef std::vector<MonitorElement*> tkHistoMapVect;
 
  public:
-  TkHistoMap(DQMStore::IBooker & ibooker , const TkDetMap* tkDetMap, const std::string& path, const std::string& MapName, float baseline=0, bool mechanicalView=false);
+  TkHistoMap(const TkDetMap* tkDetMap, DQMStore::IBooker & ibooker, const std::string& path, const std::string& MapName, float baseline=0, bool mechanicalView=false);
   TkHistoMap(const TkDetMap* tkDetMap, const std::string& path, const std::string& MapName, float baseline=0, bool mechanicalView=false);
-  TkHistoMap();
+  TkHistoMap(const TkDetMap* tkDetMap);
   ~TkHistoMap(){};
 
   void loadServices();
@@ -25,6 +25,7 @@ class TkHistoMap{
   void loadTkHistoMap(const std::string& path, const std::string& MapName, bool mechanicalView=false);
 
   MonitorElement* getMap(short layerNumber){return tkHistoMap_[layerNumber];};
+  const std::vector<MonitorElement*>& getAllMaps() const {return tkHistoMap_;};
   std::vector<MonitorElement*>& getAllMaps(){return tkHistoMap_;};
 
   float getValue(DetId detid);

--- a/DQM/SiStripCommon/python/TkHistoMap_cff.py
+++ b/DQM/SiStripCommon/python/TkHistoMap_cff.py
@@ -1,0 +1,2 @@
+from CalibTracker.SiStripCommon.TkDetMap_cff import *
+from DQMServices.Core.DQMStore_cfg import *

--- a/DQM/SiStripCommon/python/TkHistoMap_cfi.py
+++ b/DQM/SiStripCommon/python/TkHistoMap_cfi.py
@@ -1,4 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-TkDetMap = cms.Service("TkDetMap");
-SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader");

--- a/DQM/SiStripCommon/src/TkHistoMap.cc
+++ b/DQM/SiStripCommon/src/TkHistoMap.cc
@@ -13,7 +13,7 @@ TkHistoMap::TkHistoMap():
 }
 
 
-TkHistoMap::TkHistoMap(std::string path, std::string MapName,float baseline, bool mechanicalView): 
+TkHistoMap::TkHistoMap(const TkDetMap* tkDetMap, const std::string& path, const std::string& MapName,float baseline, bool mechanicalView):
   HistoNumber(35),
   MapName_(MapName)
 {
@@ -21,10 +21,11 @@ TkHistoMap::TkHistoMap(std::string path, std::string MapName,float baseline, boo
   cached_layer=0;
   LogTrace("TkHistoMap") <<"TkHistoMap::constructor with parameters"; 
   loadServices();
+  tkdetmap_ = tkDetMap;
   createTkHistoMap(path,MapName_, baseline, mechanicalView);
 }
 
-TkHistoMap::TkHistoMap(DQMStore::IBooker & ibooker , std::string path, std::string MapName,float baseline, bool mechanicalView): 
+TkHistoMap::TkHistoMap(DQMStore::IBooker & ibooker, const TkDetMap* tkDetMap, const std::string& path, const std::string& MapName,float baseline, bool mechanicalView):
   HistoNumber(35),
   MapName_(MapName)
 {
@@ -32,6 +33,7 @@ TkHistoMap::TkHistoMap(DQMStore::IBooker & ibooker , std::string path, std::stri
   cached_layer=0;
   LogTrace("TkHistoMap") <<"TkHistoMap::constructor with parameters"; 
   loadServices();
+  tkdetmap_ = tkDetMap;
   createTkHistoMap(ibooker , path,MapName_, baseline, mechanicalView);
 }
 
@@ -44,21 +46,13 @@ void TkHistoMap::loadServices(){
       "\n------------------------------------------";
   }
   dqmStore_=edm::Service<DQMStore>().operator->();
-  if(!edm::Service<TkDetMap>().isAvailable()){
-    edm::LogError("TkHistoMap") << 
-      "\n------------------------------------------"
-      "\nUnAvailable Service TkHistoMap: please insert in the configuration file an instance like"
-      "\n\tprocess.TkDetMap = cms.Service(\"TkDetMap\")"
-      "\n------------------------------------------";
-  }
-  tkdetmap_=edm::Service<TkDetMap>().operator->();
 }
 
-void TkHistoMap::save(std::string filename){
+void TkHistoMap::save(const std::string& filename){
   dqmStore_->save(filename);
 }
 
-void TkHistoMap::loadTkHistoMap(std::string path, std::string MapName, bool mechanicalView){
+void TkHistoMap::loadTkHistoMap(const std::string& path, const std::string& MapName, bool mechanicalView){
   MapName_=MapName;
   std::string fullName, folder;
   tkHistoMap_.resize(HistoNumber);    
@@ -77,7 +71,7 @@ void TkHistoMap::loadTkHistoMap(std::string path, std::string MapName, bool mech
   }
 }
 
-void TkHistoMap::createTkHistoMap(std::string& path, std::string& MapName, float& baseline, bool mechanicalView){
+void TkHistoMap::createTkHistoMap(const std::string& path, const std::string& MapName, float baseline, bool mechanicalView){
   
   int nchX;
   int nchY;
@@ -108,7 +102,7 @@ void TkHistoMap::createTkHistoMap(std::string& path, std::string& MapName, float
   }
 }
 
-void TkHistoMap::createTkHistoMap(DQMStore::IBooker & ibooker , std::string& path, std::string& MapName, float& baseline, bool mechanicalView){
+void TkHistoMap::createTkHistoMap(DQMStore::IBooker & ibooker , const std::string& path, const std::string& MapName, float baseline, bool mechanicalView){
   
   int nchX;
   int nchY;
@@ -139,22 +133,21 @@ void TkHistoMap::createTkHistoMap(DQMStore::IBooker & ibooker , std::string& pat
   }
 }
 
-std::string TkHistoMap::folderDefinition(std::string& path, std::string& MapName, int layer , bool mechanicalView,std::string& fullName ){
+std::string TkHistoMap::folderDefinition(std::string folder, const std::string& MapName, int layer , bool mechanicalView,std::string& fullName ){
   
-  std::string folder=path;
-  std::string name=MapName+std::string("_");
-  fullName=name+tkdetmap_->getLayerName(layer);
+  std::string name = MapName+std::string("_");
+  fullName=name+TkDetMap::getLayerName(layer);
   //  std::cout << "[TkHistoMap::folderDefinition] fullName: " << fullName << std::endl;
 
   if(mechanicalView){
     std::stringstream ss;
 
     SiStripFolderOrganizer folderOrg;
-    folderOrg.setSiStripFolderName(path);
+    folderOrg.setSiStripFolderName(folder);
 
     SiStripDetId::SubDetector subDet;
     uint32_t subdetlayer = 0, side = 0;
-    tkdetmap_->getSubDetLayerSide(layer,subDet,subdetlayer,side);
+    TkDetMap::getSubDetLayerSide(layer,subDet,subdetlayer,side);
     folderOrg.getSubDetLayerFolderName(ss,subDet,subdetlayer,side);
     
     folder = ss.str();
@@ -165,7 +158,7 @@ std::string TkHistoMap::folderDefinition(std::string& path, std::string& MapName
 }
 
 #include <iostream>
-void TkHistoMap::fillFromAscii(std::string filename){
+void TkHistoMap::fillFromAscii(const std::string& filename){
   std::ifstream file;
   file.open(filename.c_str());
   float value;
@@ -177,11 +170,11 @@ void TkHistoMap::fillFromAscii(std::string filename){
   file.close();
 }
 
-void TkHistoMap::fill(uint32_t& detid,float value){
-  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer , cached_XYbin);
+void TkHistoMap::fill(DetId detid,float value){
+  int16_t layer=tkdetmap_->findLayer(detid , cached_detid , cached_layer , cached_XYbin);
   TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer , cached_XYbin);
 #ifdef debug_TkHistoMap
-  LogTrace("TkHistoMap") << "[TkHistoMap::fill] Fill detid " << detid << " Layer " << layer << " value " << value << " ix,iy "  << xybin.ix << " " << xybin.iy  << " " << xybin.x << " " << xybin.y << " " << tkHistoMap_[layer]->getTProfile2D()->GetName();
+  LogTrace("TkHistoMap") << "[TkHistoMap::fill] Fill detid " << detid.rawId() << " Layer " << layer << " value " << value << " ix,iy "  << xybin.ix << " " << xybin.iy  << " " << xybin.x << " " << xybin.y << " " << tkHistoMap_[layer]->getTProfile2D()->GetName();
 #endif
   tkHistoMap_[layer]->getTProfile2D()->Fill(xybin.x,xybin.y,value);
 
@@ -193,14 +186,14 @@ void TkHistoMap::fill(uint32_t& detid,float value){
 #endif
 }
 
-void TkHistoMap::setBinContent(uint32_t& detid,float value){
-  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer , cached_XYbin);
+void TkHistoMap::setBinContent(DetId detid,float value){
+  int16_t layer=tkdetmap_->findLayer(detid , cached_detid , cached_layer , cached_XYbin);
   TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer , cached_XYbin);
   tkHistoMap_[layer]->getTProfile2D()->SetBinEntries(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy),1);
   tkHistoMap_[layer]->getTProfile2D()->SetBinContent(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy),value);
 
 #ifdef debug_TkHistoMap
-  LogTrace("TkHistoMap") << "[TkHistoMap::setbincontent]  setBinContent detid " << detid << " Layer " << layer << " value " << value << " ix,iy "  << xybin.ix << " " << xybin.iy  << " " << xybin.x << " " << xybin.y << " " << tkHistoMap_[layer]->getTProfile2D()->GetName() << " bin " << tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy);
+  LogTrace("TkHistoMap") << "[TkHistoMap::setbincontent]  setBinContent detid " << detid.rawId() << " Layer " << layer << " value " << value << " ix,iy "  << xybin.ix << " " << xybin.iy  << " " << xybin.x << " " << xybin.y << " " << tkHistoMap_[layer]->getTProfile2D()->GetName() << " bin " << tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy);
 
   LogTrace("TkHistoMap") << "[TkHistoMap::setbincontent] " << tkHistoMap_[layer]->getTProfile2D()->GetBinContent(xybin.ix,xybin.iy);
   for(size_t ii=0;ii<4;ii++)
@@ -210,31 +203,30 @@ void TkHistoMap::setBinContent(uint32_t& detid,float value){
 #endif
 }
 
-void TkHistoMap::add(uint32_t& detid,float value){
+void TkHistoMap::add(DetId detid,float value){
 #ifdef debug_TkHistoMap
   LogTrace("TkHistoMap") << "[TkHistoMap::add]";
 #endif
-  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer , cached_XYbin);
+  int16_t layer=tkdetmap_->findLayer(detid , cached_detid , cached_layer , cached_XYbin);
   TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer , cached_XYbin);
   setBinContent(detid,tkHistoMap_[layer]->getTProfile2D()->GetBinContent(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy))+value);
   
 }
 
-float TkHistoMap::getValue(uint32_t& detid){
-  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer , cached_XYbin);
+float TkHistoMap::getValue(DetId detid){
+  int16_t layer=tkdetmap_->findLayer(detid , cached_detid , cached_layer , cached_XYbin);
   TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer , cached_XYbin);
   return tkHistoMap_[layer]->getTProfile2D()->GetBinContent(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy));
 }
-float TkHistoMap::getEntries(uint32_t& detid){
-  int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer , cached_XYbin);
+float TkHistoMap::getEntries(DetId detid){
+  int16_t layer=tkdetmap_->findLayer(detid , cached_detid , cached_layer , cached_XYbin);
   TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer , cached_XYbin);
   return tkHistoMap_[layer]->getTProfile2D()->GetBinEntries(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy));
 }
 
 void TkHistoMap::dumpInTkMap(TrackerMap* tkmap,bool dumpEntries){
   for(int layer=1;layer<HistoNumber;++layer){
-    std::vector<uint32_t> dets;
-    tkdetmap_->getDetsForLayer(layer,dets);
+    std::vector<DetId> dets = tkdetmap_->getDetsForLayer(layer);
     for(size_t i=0;i<dets.size();++i){
       if(dets[i]>0){
 	if(getEntries(dets[i])>0) {
@@ -249,7 +241,7 @@ void TkHistoMap::dumpInTkMap(TrackerMap* tkmap,bool dumpEntries){
 
 #include "TCanvas.h"
 #include "TFile.h"
-void TkHistoMap::saveAsCanvas(std::string filename,std::string options,std::string mode){
+void TkHistoMap::saveAsCanvas(const std::string& filename, const std::string& options, const std::string& mode){
   //  TCanvas C(MapName_,MapName_,200,10,900,700);
   TCanvas* CTIB=new TCanvas(std::string("Canvas_"+MapName_+"TIB").c_str(),std::string("Canvas_"+MapName_+"TIB").c_str());
   TCanvas* CTOB=new TCanvas(std::string("Canvas_"+MapName_+"TOB").c_str(),std::string("Canvas_"+MapName_+"TOB").c_str());

--- a/DQM/SiStripCommon/src/TkHistoMap.cc
+++ b/DQM/SiStripCommon/src/TkHistoMap.cc
@@ -3,13 +3,14 @@
 
 //#define debug_TkHistoMap
 
-TkHistoMap::TkHistoMap():
+TkHistoMap::TkHistoMap(const TkDetMap* tkDetMap):
   HistoNumber(35){
   cached_detid=0;
   cached_layer=0;
   
   LogTrace("TkHistoMap") <<"TkHistoMap::constructor without parameters"; 
   loadServices();
+  tkdetmap_ = tkDetMap;
 }
 
 
@@ -25,7 +26,7 @@ TkHistoMap::TkHistoMap(const TkDetMap* tkDetMap, const std::string& path, const 
   createTkHistoMap(path,MapName_, baseline, mechanicalView);
 }
 
-TkHistoMap::TkHistoMap(DQMStore::IBooker & ibooker, const TkDetMap* tkDetMap, const std::string& path, const std::string& MapName,float baseline, bool mechanicalView):
+TkHistoMap::TkHistoMap(const TkDetMap* tkDetMap, DQMStore::IBooker & ibooker, const std::string& path, const std::string& MapName,float baseline, bool mechanicalView):
   HistoNumber(35),
   MapName_(MapName)
 {

--- a/DQM/SiStripCommon/test/plugins/testTkHistoMap.cc
+++ b/DQM/SiStripCommon/test/plugins/testTkHistoMap.cc
@@ -193,11 +193,10 @@ void testTkHistoMap::analyze(const edm::Event& iEvent,
 
   //extract  vector of module in the layer
   /*
-    SiStripSubStructure siStripSubStructure;
-    siStripSubStructure.getTIBDetectors(fullTkDetIdList,TkDetIdList,0,0,0);
-    siStripSubStructure.getTOBDetectors(fullTkDetIdList,TkDetIdList,0,0,0);
-    siStripSubStructure.getTIDDetectors(fullTkDetIdList,TkDetIdList,0,0,0);
-    //siStripSubStructure.getTECDetectors(fullTkDetIdList,TkDetIdList,0,0,0);
+    SiStripSubStructure::getTIBDetectors(fullTkDetIdList,TkDetIdList,trackerTopology,0,0,0);
+    SiStripSubStructure::getTOBDetectors(fullTkDetIdList,TkDetIdList,trackerTopology,0,0,0);
+    SiStripSubStructure::getTIDDetectors(fullTkDetIdList,TkDetIdList,trackerTopology,0,0,0);
+    //SiStripSubStructure::getTECDetectors(fullTkDetIdList,TkDetIdList,trackerTopology,0,0,0);
   */
 
   tkhisto->fillFromAscii("test.txt");

--- a/DQM/SiStripCommon/test/plugins/testTkHistoMap.cc
+++ b/DQM/SiStripCommon/test/plugins/testTkHistoMap.cc
@@ -48,44 +48,40 @@ public:
 
 private:
   
-  void read();
-  void create(); 
+  void read(const TkDetMap* tkDetMap);
+  void create(const TkDetMap* tkDetMap);
 
   bool readFromFile;
-  TkHistoMap *tkhisto, *tkhistoBis, *tkhistoZ, *tkhistoPhi, *tkhistoR, *tkhistoCheck;
+  std::unique_ptr<TkHistoMap> tkhisto, tkhistoBis, tkhistoZ, tkhistoPhi, tkhistoR, tkhistoCheck;
 };
 
 //
 testTkHistoMap::testTkHistoMap ( const edm::ParameterSet& iConfig ):
   readFromFile(iConfig.getParameter<bool>("readFromFile"))
+{}
+
+
+void testTkHistoMap::create(const TkDetMap* tkDetMap)
 {
-  if(!readFromFile){
-    create();
-  }else{
-    read();
-  }
-}
-
-
-void testTkHistoMap::create(){
-  tkhisto      =new TkHistoMap("detId","detId",-1); 
-  tkhistoBis   =new TkHistoMap("detIdBis","detIdBis",0,1); //here the baseline (the value of the empty,not assigned bins) is put to -1 (default is zero)
-  tkhistoZ     =new TkHistoMap("Zmap","Zmap");
-  tkhistoPhi   =new TkHistoMap("Phi","Phi");
-  tkhistoR     =new TkHistoMap("Rmap","Rmap",-99.); //here the baseline (the value of the empty,not assigned bins) is put to -99 (default is zero)
-  tkhistoCheck =new TkHistoMap("check","check");           
+  tkhisto      = std::make_unique<TkHistoMap>(tkDetMap, "detId","detId",-1);
+  tkhistoBis   = std::make_unique<TkHistoMap>(tkDetMap, "detIdBis","detIdBis",0,1); //here the baseline (the value of the empty,not assigned bins) is put to -1 (default is zero)
+  tkhistoZ     = std::make_unique<TkHistoMap>(tkDetMap, "Zmap","Zmap");
+  tkhistoPhi   = std::make_unique<TkHistoMap>(tkDetMap, "Phi","Phi");
+  tkhistoR     = std::make_unique<TkHistoMap>(tkDetMap, "Rmap","Rmap",-99.); //here the baseline (the value of the empty,not assigned bins) is put to -99 (default is zero)
+  tkhistoCheck = std::make_unique<TkHistoMap>(tkDetMap, "check","check");
 }
 
 /*Check that is possible to load in tkhistomaps histograms already stored in a DQM root file (if the folder and name are know)*/
-void testTkHistoMap::read(){
+void testTkHistoMap::read(const TkDetMap* tkDetMap)
+{
   edm::Service<DQMStore>().operator->()->open("test.root");  
 
-  tkhisto      =new TkHistoMap();
-  tkhistoBis   =new TkHistoMap();
-  tkhistoZ     =new TkHistoMap();
-  tkhistoPhi   =new TkHistoMap();
-  tkhistoR     =new TkHistoMap();
-  tkhistoCheck =new TkHistoMap();
+  tkhisto      = std::make_unique<TkHistoMap>(tkDetMap);
+  tkhistoBis   = std::make_unique<TkHistoMap>(tkDetMap);
+  tkhistoZ     = std::make_unique<TkHistoMap>(tkDetMap);
+  tkhistoPhi   = std::make_unique<TkHistoMap>(tkDetMap);
+  tkhistoR     = std::make_unique<TkHistoMap>(tkDetMap);
+  tkhistoCheck = std::make_unique<TkHistoMap>(tkDetMap);
 
   tkhisto     ->loadTkHistoMap("detId","detId"); 	    
   tkhistoBis  ->loadTkHistoMap("detIdBis","detIdBis",1);  
@@ -176,7 +172,16 @@ void testTkHistoMap::endJob(void)
 // // ------------ method called to produce the data  ------------
 void testTkHistoMap::analyze(const edm::Event& iEvent, 
 				     const edm::EventSetup& iSetup )
-{   
+{
+  edm::ESHandle<TkDetMap> tkDetMapHandle;
+  iSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+  const TkDetMap* tkDetMap = tkDetMapHandle.product();
+  if(!readFromFile){
+    create(tkDetMap);
+  }else{
+    read(tkDetMap);
+  }
+
   if(readFromFile)
     return;
 

--- a/DQM/SiStripCommon/test/testTkHistoMap_cfg.py
+++ b/DQM/SiStripCommon/test/testTkHistoMap_cfg.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("test")
-process.load("DQMServices.Core.DQM_cfg")
 
 process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
 
@@ -24,9 +23,10 @@ process.maxEvents = cms.untracked.PSet(
 )
 process.source = cms.Source("EmptySource")
 
-process.TkDetMap = cms.Service("TkDetMap")
-
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
+# load TrackerTopology (needed for TkDetMap and TkHistoMap)
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
+process.trackerTopology = cms.ESProducer("TrackerTopologyEP")
 
 process.tester = cms.EDAnalyzer("testTkHistoMap",
                               readFromFile = cms.bool(False)

--- a/DQM/SiStripMonitorClient/interface/SiStripQualityChecker.h
+++ b/DQM/SiStripMonitorClient/interface/SiStripQualityChecker.h
@@ -79,7 +79,7 @@ class SiStripQualityChecker {
   int globalStatusFilling_;
   bool useGoodTracks_;
 
-  TkDetMap* tkDetMap_;
+  const TkDetMap* tkDetMap_;
  
   float cutoffTrackRate_;
   float cutoffChi2overDoF_;

--- a/DQM/SiStripMonitorClient/interface/SiStripTrackerMapCreator.h
+++ b/DQM/SiStripMonitorClient/interface/SiStripTrackerMapCreator.h
@@ -64,11 +64,11 @@ class SiStripTrackerMapCreator {
   bool ResidualsRMS_;
   std::string ssqLabel_;
   int   nDet;
-  TkDetMap* tkDetMap_;
+  const TkDetMap* tkDetMap_;
   const edm::EventSetup& eSetup_;
   edm::ESHandle< SiStripDetCabling > detcabling_;
   //  SiStripPsuDetIdMap psumap_;
-  uint32_t cached_detid;
+  DetId cached_detid;
   int16_t cached_layer;
   std::map<uint32_t, uint16_t> detflag_;
   TkLayerMap::XYbin cached_XYbin;

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfigP5_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfigP5_Cosmic_cff.py
@@ -44,5 +44,4 @@ SiStripAnalyserCosmic = cms.EDAnalyzer("SiStripAnalyser",
 # Track Efficiency Client
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
-
+from CalibTracker.SiStripCommon.TkDetMap_cff import *

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfigP5_HeavyIons_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfigP5_HeavyIons_cff.py
@@ -63,5 +63,4 @@ TrackEffClient.FolderName = 'Tracking/TrackParameters/TrackEfficiency'
 TrackEffClient.AlgoName   = 'CKFTk'
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
-
+from CalibTracker.SiStripCommon.TkDetMap_cff import *

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfigP5_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfigP5_cff.py
@@ -63,5 +63,4 @@ TrackEffClient.FolderName = 'Tracking/TrackParameters/TrackEfficiency'
 TrackEffClient.AlgoName   = 'CKFTk'
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
-
+from CalibTracker.SiStripCommon.TkDetMap_cff import *

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_Cosmic_cff.py
@@ -28,5 +28,4 @@ SiStripCosmicDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser)
 
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
-SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")
+from CalibTracker.SiStripCommon.TkDetMap_cff import *

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_HeavyIons_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_HeavyIons_cff.py
@@ -38,5 +38,4 @@ siStripQTesterHI = cms.EDAnalyzer("QualityTester",
 SiStripOfflineDQMClientHI = cms.Sequence(siStripQTesterHI*siStripOfflineAnalyser)
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
-SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")
+from CalibTracker.SiStripCommon.TkDetMap_cff import *

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_Tier0_cff.py
@@ -45,5 +45,4 @@ SiStripOfflineDQMClient = cms.Sequence(siStripQTester*siStripOfflineAnalyser)
 
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
-SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")
+from CalibTracker.SiStripCommon.TkDetMap_cff import *

--- a/DQM/SiStripMonitorClient/python/SiStripClientConfig_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripClientConfig_cff.py
@@ -82,5 +82,4 @@ SiStripOnlineDQMClient = cms.Sequence(onlineAnalyser)
 SiStripOfflineDQMClient = cms.Sequence(offlineAnalyser)
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
-
+from CalibTracker.SiStripCommon.TkDetMap_cff import *

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigP5_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigP5_cff.py
@@ -123,5 +123,4 @@ MonitorTrackResiduals_gentk.Mod_On                 = False
 #MonitorTrackResiduals_hi.Mod_On                 = False
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
-SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")
+from CalibTracker.SiStripCommon.TkDetMap_cff import *

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
@@ -102,8 +102,7 @@ dqmInfoSiStrip = cms.EDAnalyzer("DQMEventInfo",
 )
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
-SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")
+from CalibTracker.SiStripCommon.TkDetMap_cff import *
 
 # Event History Producer
 from DPGAnalysis.SiStripTools.eventwithhistoryproducerfroml1abc_cfi import *

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
@@ -124,8 +124,7 @@ dqmInfoSiStrip = cms.EDAnalyzer("DQMEventInfo",
 )
 
 # Services needed for TkHistoMap
-TkDetMap = cms.Service("TkDetMap")
-SiStripDetInfoFileReade = cms.Service("SiStripDetInfoFileReader")
+from CalibTracker.SiStripCommon.TkDetMap_cff import *
 
 # Event History Producer
 from  DPGAnalysis.SiStripTools.eventwithhistoryproducerfroml1abc_cfi import *

--- a/DQM/SiStripMonitorClient/src/SiStripQualityChecker.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripQualityChecker.cc
@@ -36,16 +36,6 @@ SiStripQualityChecker::SiStripQualityChecker(edm::ParameterSet const& ps):pSet_(
   SubDetFolderMap.insert(std::pair<std::string, std::string>("TIDF", "TID/PLUS"));
   SubDetFolderMap.insert(std::pair<std::string, std::string>("TIDB", "TID/MINUS"));
   badModuleList.clear();
-
-  if(!edm::Service<TkDetMap>().isAvailable()){
-    edm::LogError("TkHistoMap") <<
-      "\n------------------------------------------"
-      "\nUnAvailable Service TkHistoMap: please insert in the configuration file an instance like"
-      "\n\tprocess.TkDetMap = cms.Service(\"TkDetMap\")"
-      "\n------------------------------------------";
-  }
-  tkDetMap_=edm::Service<TkDetMap>().operator->();
-
 }
 //
 // --  Destructor
@@ -215,6 +205,10 @@ void SiStripQualityChecker::resetStatus() {
 //
 void SiStripQualityChecker::fillStatus(DQMStore* dqm_store, const edm::ESHandle< SiStripDetCabling >& cabling, const edm::EventSetup& eSetup) {
   if (!bookedStripStatus_) bookStatus(dqm_store);
+
+  edm::ESHandle<TkDetMap> tkMapHandle;
+  eSetup.get<TrackerTopologyRcd>().get(tkMapHandle);
+  tkDetMap_ = tkMapHandle.product();
 
   fillDummyStatus();
   fillDetectorStatus(dqm_store, cabling);

--- a/DQM/SiStripMonitorClient/src/SiStripTrackerMapCreator.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripTrackerMapCreator.cc
@@ -44,15 +44,10 @@ SiStripTrackerMapCreator::SiStripTrackerMapCreator(const edm::EventSetup& eSetup
   trackerMap_ = nullptr;
   stripTopLevelDir_="";
   eSetup_.get<SiStripDetCablingRcd>().get(detcabling_);
+  edm::ESHandle<TkDetMap> tkDetMapHandle;
+  eSetup_.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+  tkDetMap_ = tkDetMapHandle.product();
   //  psumap_.BuildMap("CalibTracker/SiStripDCS/data/StripPSUDetIDMap_FromJan132010.dat",false);
-  if(!edm::Service<TkDetMap>().isAvailable()){
-    edm::LogError("TkHistoMap") <<
-      "\n------------------------------------------"
-      "\nUnAvailable Service TkHistoMap: please insert in the configuration file an instance like"
-      "\n\tprocess.TkDetMap = cms.Service(\"TkDetMap\")"
-      "\n------------------------------------------";
-  }
-  tkDetMap_=edm::Service<TkDetMap>().operator->();
 }
 //
 // -- Destructor
@@ -497,11 +492,8 @@ void SiStripTrackerMapCreator::paintTkMapFromHistogram(DQMStore* dqm_store, Moni
   const std::string& name  = me->getName();
   std::string lname = name.substr(name.find("TkHMap_")+7);  
   lname = lname.substr(lname.find("_T")+1);
-  std::vector<uint32_t> layer_detids;
-  tkDetMap_->getDetsForLayer(tkDetMap_->getLayerNum(lname), layer_detids);
-  for (std::vector<uint32_t>::const_iterator idet = layer_detids.begin(); idet != layer_detids.end(); idet++) {
-    uint32_t det_id= (*idet);
-    if (det_id <= 0) continue;
+  for ( DetId det_id : tkDetMap_->getDetsForLayer(TkDetMap::getLayerNum(lname)) ) {
+    if (det_id.rawId() <= 0) continue;
     nDet++;
     const TkLayerMap::XYbin& xyval = tkDetMap_->getXY(det_id , cached_detid , cached_layer , cached_XYbin);
     float fval = 0.0;

--- a/DQM/SiStripMonitorClient/src/SiStripTrackerMapCreator.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripTrackerMapCreator.cc
@@ -676,15 +676,15 @@ void SiStripTrackerMapCreator::createInfoFile(std::vector<std::string> map_names
     }
     dqm_store->cd();
 
-    std::vector<TkHistoMap*> tkHMaps;
+    std::vector<TkHistoMap> tkHMaps;
 
     uint32_t nHists = map_names.size();
 
     for(uint32_t ih = 0; ih < nHists; ++ih) {
-      tkHMaps.push_back(new TkHistoMap());
+      tkHMaps.emplace_back(tkDetMap_);
       if(map_names.at(ih) != "QTestAlarm") {
         std::string tkhmap_name = "TkHMap_" + map_names.at(ih);
-        tkHMaps.at(ih)->loadTkHistoMap(dirname, tkhmap_name, true);
+        tkHMaps.at(ih).loadTkHistoMap(dirname, tkhmap_name, true);
       }
     } 
 
@@ -695,7 +695,7 @@ void SiStripTrackerMapCreator::createInfoFile(std::vector<std::string> map_names
           std::ostringstream comment;
           qtalarm_flag = getDetectorFlag(det_id);
         } else {
-          tkhmap_value[map_names.at(ih)] = tkHMaps.at(ih)->getValue(det_id);
+          tkhmap_value[map_names.at(ih)] = tkHMaps.at(ih).getValue(det_id);
         }
       }
       if(!tkinfo_tree) {
@@ -705,12 +705,6 @@ void SiStripTrackerMapCreator::createInfoFile(std::vector<std::string> map_names
         tkinfo_tree->Fill();
       }
     }
-
-    // delete pointers
-    for(uint32_t ih = 0; ih < nHists; ++ih) {
-      delete tkHMaps.at(ih);
-    }
-
   }
 
 }

--- a/DQM/SiStripMonitorClient/test/SiStripDQM_OfflineTkMap_Template_cfg_DB.py
+++ b/DQM/SiStripMonitorClient/test/SiStripDQM_OfflineTkMap_Template_cfg_DB.py
@@ -137,8 +137,7 @@ process.siStripOfflineAnalyser = cms.EDAnalyzer("SiStripOfflineDQM",
 )
 
 # Services needed for TkHistoMap / DetIdInfoFile
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("CalibTracker.SiStripCommon.TkDetMap_cff")
 process.TFileService = cms.Service('TFileService',
   fileName = cms.string(options.detIdInfoFile)
 )

--- a/DQM/SiStripMonitorClient/test/SiStripDQM_Offline_standalone_cfg.py
+++ b/DQM/SiStripMonitorClient/test/SiStripDQM_Offline_standalone_cfg.py
@@ -23,8 +23,8 @@ process.GlobalTag.globaltag = "GR09_P_V2::All"
 # DQM Environment
 process.load("DQMServices.Core.DQM_cfg")
 
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("CalibTracker.SiStripCommon.TkDetMap_cff")
+process.trackerTopology = cms.ESProducer("TrackerTopologyEP")
 
 # SiStrip Offline DQM Client
 # SiStrip Offline DQM Client

--- a/DQM/SiStripMonitorClient/test/mergeBadChannel_Template_cfg.py
+++ b/DQM/SiStripMonitorClient/test/mergeBadChannel_Template_cfg.py
@@ -77,16 +77,12 @@ process.siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
 process.siStripQualityESProducer.ReduceGranularity = cms.bool(False)
 process.siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
 
-process.load("DQMServices.Core.DQMStore_cfg")
-
 process.stat = cms.EDAnalyzer("SiStripQualityStatistics",
     TkMapFileName = cms.untracked.string('MergedBadComponentsTkMap.png'),
     dataLabel = cms.untracked.string('')
 )
 #### Add these lines to produce a tracker map
-process.load("DQMServices.Core.DQMStore_cfg")
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 
 
 process.p = cms.Path(process.stat)

--- a/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
+++ b/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
@@ -157,8 +157,8 @@ class SiStripMonitorCluster : public DQMEDAnalyzer {
   edm::ParameterSet Parameters;
 
   // TkHistoMap added
-  TkHistoMap* tkmapcluster;
-  TkHistoMap* tkmapclusterch;
+  std::unique_ptr<TkHistoMap> tkmapcluster;
+  std::unique_ptr<TkHistoMap> tkmapclusterch;
 
   int runNb, eventNb;
   int firstEvent;

--- a/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
+++ b/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
@@ -248,8 +248,6 @@ void SiStripMonitorCluster::createMEs(const edm::EventSetup& es , DQMStore::IBoo
     std::vector<uint32_t> activeDets;
     SiStripDetCabling_->addActiveDetectorsRawIds(activeDets);
 
-    SiStripSubStructure substructure;
-
     SiStripFolderOrganizer folder_organizer;
     folder_organizer.setSiStripFolderName(topFolderName_);
     folder_organizer.setSiStripFolder();
@@ -300,17 +298,17 @@ void SiStripMonitorCluster::createMEs(const edm::EventSetup& es , DQMStore::IBoo
         int32_t lnumber = det_layer_pair.second;
 	std::vector<uint32_t> layerDetIds;
         if (det_layer_pair.first == "TIB") {
-          substructure.getTIBDetectors(activeDets,layerDetIds,lnumber,0,0,0);
+          SiStripSubStructure::getTIBDetectors(activeDets,layerDetIds,tTopo,lnumber,0,0,0);
         } else if (det_layer_pair.first == "TOB") {
-          substructure.getTOBDetectors(activeDets,layerDetIds,lnumber,0,0);
+          SiStripSubStructure::getTOBDetectors(activeDets,layerDetIds,tTopo,lnumber,0,0);
         } else if (det_layer_pair.first == "TID" && lnumber > 0) {
-          substructure.getTIDDetectors(activeDets,layerDetIds,2,std::abs(lnumber),0,0);
+          SiStripSubStructure::getTIDDetectors(activeDets,layerDetIds,tTopo,2,std::abs(lnumber),0,0);
         } else if (det_layer_pair.first == "TID" && lnumber < 0) {
-          substructure.getTIDDetectors(activeDets,layerDetIds,1,std::abs(lnumber),0,0);
+          SiStripSubStructure::getTIDDetectors(activeDets,layerDetIds,tTopo,1,std::abs(lnumber),0,0);
         } else if (det_layer_pair.first == "TEC" && lnumber > 0) {
-          substructure.getTECDetectors(activeDets,layerDetIds,2,std::abs(lnumber),0,0,0,0);
+          SiStripSubStructure::getTECDetectors(activeDets,layerDetIds,tTopo,2,std::abs(lnumber),0,0,0,0);
         } else if (det_layer_pair.first == "TEC" && lnumber < 0) {
-          substructure.getTECDetectors(activeDets,layerDetIds,1,std::abs(lnumber),0,0,0,0);
+          SiStripSubStructure::getTECDetectors(activeDets,layerDetIds,tTopo,1,std::abs(lnumber),0,0,0,0);
         }
 	LayerDetMap[label] = layerDetIds;
 

--- a/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
+++ b/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
@@ -240,6 +240,9 @@ void SiStripMonitorCluster::createMEs(const edm::EventSetup& es , DQMStore::IBoo
     edm::ESHandle<TrackerTopology> tTopoHandle;
     es.get<TrackerTopologyRcd>().get(tTopoHandle);
     const TrackerTopology* const tTopo = tTopoHandle.product();
+    edm::ESHandle<TkDetMap> tkDetMapHandle;
+    es.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+    const TkDetMap* tkDetMap = tkDetMapHandle.product();
 
     // take from eventSetup the SiStripDetCabling object - here will use SiStripDetControl later on
     es.get<SiStripDetCablingRcd>().get(SiStripDetCabling_);
@@ -257,13 +260,13 @@ void SiStripMonitorCluster::createMEs(const edm::EventSetup& es , DQMStore::IBoo
     if (clustertkhistomapon) {
       //      std::cout << "[SiStripMonitorCluster::createMEs] topFolderName_: " << topFolderName_ << "     ";
       if ( (topFolderName_ == "SiStrip") or (std::string::npos != topFolderName_.find("HLT")) )
-	tkmapcluster = new TkHistoMap(ibooker , topFolderName_,"TkHMap_NumberOfCluster",0.,true);
-      else tkmapcluster = new TkHistoMap(ibooker , topFolderName_+"/TkHistoMap","TkHMap_NumberOfCluster",0.,false);
+	tkmapcluster = std::make_unique<TkHistoMap>(tkDetMap, ibooker, topFolderName_,"TkHMap_NumberOfCluster",0.,true);
+      else tkmapcluster = std::make_unique<TkHistoMap>(tkDetMap, ibooker, topFolderName_+"/TkHistoMap","TkHMap_NumberOfCluster",0.,false);
     }
     if (clusterchtkhistomapon) {
      if ( (topFolderName_ == "SiStrip") or (std::string::npos != topFolderName_.find("HLT")) )
-       tkmapclusterch = new TkHistoMap(ibooker , topFolderName_,"TkHMap_ClusterCharge",0.,true);
-     else tkmapclusterch = new TkHistoMap(ibooker , topFolderName_+"/TkHistoMap","TkHMap_ClusterCharge",0.,false);
+       tkmapclusterch = std::make_unique<TkHistoMap>(tkDetMap, ibooker, topFolderName_,"TkHMap_ClusterCharge",0.,true);
+     else tkmapclusterch = std::make_unique<TkHistoMap>(tkDetMap, ibooker, topFolderName_+"/TkHistoMap","TkHMap_ClusterCharge",0.,false);
     }
 
     // loop over detectors and book MEs

--- a/DQM/SiStripMonitorCluster/test/MonitorCluster_RealData_cfg.py
+++ b/DQM/SiStripMonitorCluster/test/MonitorCluster_RealData_cfg.py
@@ -56,14 +56,7 @@ process.load("RecoLocalTracker.Configuration.RecoLocalTracker_cff")
 #--------------------------
 # DQM Services
 #--------------------------
-process.DQMStore = cms.Service("DQMStore",
-    referenceFileName = cms.untracked.string(''),
-    verbose = cms.untracked.int32(0)
-)
-
-
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 
 #--------------------------
 # Producers

--- a/DQM/SiStripMonitorCluster/test/MonitorCluster_SimData_cfg.py
+++ b/DQM/SiStripMonitorCluster/test/MonitorCluster_SimData_cfg.py
@@ -56,13 +56,7 @@ process.load("RecoLocalTracker.Configuration.RecoLocalTracker_cff")
 #--------------------------
 # DQM Services
 #--------------------------
-process.DQMStore = cms.Service("DQMStore",
-    referenceFileName = cms.untracked.string(''),
-    verbose = cms.untracked.int32(0)
-)
-
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 
 #--------------------------
 # SiStrip MonitorCluster

--- a/DQM/SiStripMonitorDigi/interface/SiStripMonitorDigi.h
+++ b/DQM/SiStripMonitorDigi/interface/SiStripMonitorDigi.h
@@ -143,7 +143,7 @@ class SiStripMonitorDigi : public DQMEDAnalyzer {
   //Global MEs to monitor APV Shots properties
   MonitorElement *NApvShotsGlobal, *NApvShotsGlobalProf, *MedianChargeApvShotsGlobal, *NApvApvShotsGlobal, *StripMultiplicityApvShotsGlobal, *ShotsVsTimeApvShotsGlobal;
 
-  TkHistoMap* tkmapdigi, *tkmapNApvshots, *tkmapNstripApvshot, *tkmapMedianChargeApvshots;
+  std::unique_ptr<TkHistoMap> tkmapdigi, tkmapNApvshots, tkmapNstripApvshot, tkmapMedianChargeApvshots;
 
   int runNb, eventNb;
   int firstEvent;

--- a/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
+++ b/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
@@ -329,6 +329,9 @@ void SiStripMonitorDigi::createMEs(DQMStore::IBooker & ibooker , const edm::Even
     edm::ESHandle<TrackerTopology> tTopoHandle;
     es.get<TrackerTopologyRcd>().get(tTopoHandle);
     const TrackerTopology* const tTopo = tTopoHandle.product();
+    edm::ESHandle<TkDetMap> tkDetMapHandle;
+    es.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+    const TkDetMap* tkDetMap = tkDetMapHandle.product();
 
     // take from eventSetup the SiStripDetCabling object - here will use SiStripDetControl later on
     es.get<SiStripDetCablingRcd>().get(SiStripDetCabling_);
@@ -348,10 +351,10 @@ void SiStripMonitorDigi::createMEs(DQMStore::IBooker & ibooker , const edm::Even
 
     // Create TkHistoMap for Digi and APV shots properies
 
-    if (digitkhistomapon)      tkmapdigi                = new TkHistoMap(ibooker , topFolderName_,"TkHMap_NumberOfDigi",        0.0,true);
-    if (shotshistomapon)       tkmapNApvshots           = new TkHistoMap(ibooker , topFolderName_,"TkHMap_NApvShots",           0.0,true);
-    if (shotsstripshistomapon) tkmapNstripApvshot       = new TkHistoMap(ibooker , topFolderName_,"TkHMap_NStripApvShots",      0.0,true);
-    if (shotschargehistomapon) tkmapMedianChargeApvshots= new TkHistoMap(ibooker , topFolderName_,"TkHMap_MedianChargeApvShots",0.0,true);
+    if (digitkhistomapon)      tkmapdigi                = std::make_unique<TkHistoMap>(tkDetMap, ibooker , topFolderName_,"TkHMap_NumberOfDigi",        0.0,true);
+    if (shotshistomapon)       tkmapNApvshots           = std::make_unique<TkHistoMap>(tkDetMap, ibooker , topFolderName_,"TkHMap_NApvShots",           0.0,true);
+    if (shotsstripshistomapon) tkmapNstripApvshot       = std::make_unique<TkHistoMap>(tkDetMap, ibooker , topFolderName_,"TkHMap_NStripApvShots",      0.0,true);
+    if (shotschargehistomapon) tkmapMedianChargeApvshots= std::make_unique<TkHistoMap>(tkDetMap, ibooker , topFolderName_,"TkHMap_MedianChargeApvShots",0.0,true);
 
     std::vector<uint32_t> tibDetIds;
 
@@ -690,8 +693,8 @@ else{
 	const std::vector<APVShot>& shots = theShotFinder.getShots();
 	AddApvShotsToSubDet(shots,SubDetMEsMap[subdet_label].SubDetApvShots);
 	if (shotshistomapon) tkmapNApvshots->fill(detid,shots.size());
-	if (shotsstripshistomapon) FillApvShotsMap(tkmapNstripApvshot,shots,detid,1);
-	if (shotschargehistomapon) FillApvShotsMap(tkmapMedianChargeApvshots,shots,detid,2);
+	if (shotsstripshistomapon) FillApvShotsMap(tkmapNstripApvshot.get(),shots,detid,1);
+	if (shotschargehistomapon) FillApvShotsMap(tkmapMedianChargeApvshots.get(),shots,detid,2);
       }
 
       if(Mod_On_ && moduleswitchnumdigison && (local_modmes.NumberOfDigis != nullptr))

--- a/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
+++ b/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
@@ -338,8 +338,6 @@ void SiStripMonitorDigi::createMEs(DQMStore::IBooker & ibooker , const edm::Even
     activeDets.clear(); // just in case
     SiStripDetCabling_->addActiveDetectorsRawIds(activeDets);
 
-    SiStripSubStructure substructure;
-
     // remove any eventual zero elements - there should be none, but just in case
     for(std::vector<uint32_t>::iterator idets = activeDets.begin(); idets != activeDets.end(); idets++){
       if(*idets == 0) activeDets.erase(idets);
@@ -395,17 +393,17 @@ void SiStripMonitorDigi::createMEs(DQMStore::IBooker & ibooker , const edm::Even
         int32_t lnumber = det_layer_pair.second;
         std::vector<uint32_t> layerDetIds;
         if (det_layer_pair.first == "TIB") {
-          substructure.getTIBDetectors(activeDets,layerDetIds,lnumber,0,0,0);
+          SiStripSubStructure::getTIBDetectors(activeDets,layerDetIds,tTopo,lnumber,0,0,0);
         } else if (det_layer_pair.first == "TOB") {
-          substructure.getTOBDetectors(activeDets,layerDetIds,lnumber,0,0);
+          SiStripSubStructure::getTOBDetectors(activeDets,layerDetIds,tTopo,lnumber,0,0);
         } else if (det_layer_pair.first == "TID" && lnumber > 0) {
-          substructure.getTIDDetectors(activeDets,layerDetIds,2,abs(lnumber),0,0);
+          SiStripSubStructure::getTIDDetectors(activeDets,layerDetIds,tTopo,2,abs(lnumber),0,0);
         } else if (det_layer_pair.first == "TID" && lnumber < 0) {
-          substructure.getTIDDetectors(activeDets,layerDetIds,1,abs(lnumber),0,0);
+          SiStripSubStructure::getTIDDetectors(activeDets,layerDetIds,tTopo,1,abs(lnumber),0,0);
         } else if (det_layer_pair.first == "TEC" && lnumber > 0) {
-          substructure.getTECDetectors(activeDets,layerDetIds,2,abs(lnumber),0,0,0,0);
+          SiStripSubStructure::getTECDetectors(activeDets,layerDetIds,tTopo,2,abs(lnumber),0,0,0,0);
         } else if (det_layer_pair.first == "TEC" && lnumber < 0) {
-          substructure.getTECDetectors(activeDets,layerDetIds,1,abs(lnumber),0,0,0,0);
+          SiStripSubStructure::getTECDetectors(activeDets,layerDetIds,tTopo,1,abs(lnumber),0,0,0,0);
         }
 
         LayerDetMap[label] = layerDetIds;

--- a/DQM/SiStripMonitorDigi/test/SiStripMonitorDigi_RealData_cfg.py
+++ b/DQM/SiStripMonitorDigi/test/SiStripMonitorDigi_RealData_cfg.py
@@ -51,13 +51,7 @@ process.siStripDigis.ProductLabel = 'source'
 #--------------------------
 # DQM Services
 #--------------------------
-process.DQMStore = cms.Service("DQMStore",
-    referenceFileName = cms.untracked.string(''),
-    verbose = cms.untracked.int32(0)
-)
-
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 
 #--------------------------
 # SiStrip MonitorDigi

--- a/DQM/SiStripMonitorHardware/interface/CMHistograms.hh
+++ b/DQM/SiStripMonitorHardware/interface/CMHistograms.hh
@@ -52,7 +52,7 @@ public:
 
 
    //book the top level histograms
-  void bookTopLevelHistograms(DQMStore::IBooker &);
+  void bookTopLevelHistograms(DQMStore::IBooker &, const TkDetMap*);
 
   //book individual FED histograms or book all FED level histograms at once
   void bookFEDHistograms(DQMStore::IBooker & , unsigned int fedId);
@@ -75,7 +75,7 @@ private:
   bool doFed_[500];
 
   HistogramConfig tkMapConfig_;
-  TkHistoMap *tkmapCM_[4];
+  std::unique_ptr<TkHistoMap> tkmapCM_[4];
 
   HistogramConfig medianAPV1vsAPV0_;
   HistogramConfig medianAPV0minusAPV1_;

--- a/DQM/SiStripMonitorHardware/interface/FEDHistograms.hh
+++ b/DQM/SiStripMonitorHardware/interface/FEDHistograms.hh
@@ -77,7 +77,7 @@ public:
   bool cmHistosEnabled();
 
    //book the top level histograms
-  void bookTopLevelHistograms(DQMStore::IBooker & , std::string topFolderName = "SiStrip");
+  void bookTopLevelHistograms(DQMStore::IBooker &, const TkDetMap*, std::string topFolderName = "SiStrip");
 
   //book individual FED histograms or book all FED level histograms at once
   void bookFEDHistograms(DQMStore::IBooker & , unsigned int fedId,
@@ -203,7 +203,7 @@ private:
     debugHistosBooked_;
 
   HistogramConfig tkMapConfig_;
-  TkHistoMap *tkmapFED_;
+  std::unique_ptr<TkHistoMap> tkmapFED_;
 
   HistogramConfig lumiErrorFraction_;
 

--- a/DQM/SiStripMonitorHardware/interface/SPYHistograms.h
+++ b/DQM/SiStripMonitorHardware/interface/SPYHistograms.h
@@ -64,7 +64,7 @@ class SPYHistograms: public HistogramBase {
 		  ) override;
 
   //book the top level histograms
-  void bookTopLevelHistograms(DQMStore::IBooker &);
+  void bookTopLevelHistograms(DQMStore::IBooker &, const TkDetMap*);
 
   //book individual FED histograms or book all FED level histograms at once
   void bookFEDHistograms(DQMStore::IBooker & , const unsigned int fedId,

--- a/DQM/SiStripMonitorHardware/python/test/testBuildTrackerMap_cfg.py
+++ b/DQM/SiStripMonitorHardware/python/test/testBuildTrackerMap_cfg.py
@@ -55,11 +55,10 @@ process.GlobalTag.globaltag = "CRAFT0831X_V1::All"
 #process.GlobalTag.globaltag = "GR09_31X_V1P::All"
 process.es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
 
-process.DQMStore = cms.Service("DQMStore")
-
 #needed to produce tkHistoMap
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
+# load TrackerTopology (needed for TkDetMap and TkHistoMap)
+process.trackerTopology = cms.ESProducer("TrackerTopologyEP")
 
 process.load('DQM.SiStripMonitorHardware.siStripBuildTrackerMap_cfi')
 process.siStripBuildTrackerMap.InputFileName = '/home/magnan/SOFTWARE/CMS/data/FED/CMAnalysis/69797/CM_69797.root'

--- a/DQM/SiStripMonitorHardware/python/test/testSiStripCMMonitor_cfg.py
+++ b/DQM/SiStripMonitorHardware/python/test/testSiStripCMMonitor_cfg.py
@@ -76,11 +76,8 @@ process.MessageLogger = cms.Service(
     )
 
 
-process.DQMStore = cms.Service("DQMStore")
-
 #needed to produce tkHistoMap
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 
 # Conditions (Global Tag is used here):
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")

--- a/DQM/SiStripMonitorHardware/python/test/testSiStripFEDMonitor_cfg.py
+++ b/DQM/SiStripMonitorHardware/python/test/testSiStripFEDMonitor_cfg.py
@@ -77,11 +77,10 @@ process.MessageLogger = cms.Service(
 
     )
 
-process.DQMStore = cms.Service("DQMStore")
-
 #needed to produce tkHistoMap
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
+# load TrackerTopology (needed for TkDetMap and TkHistoMap)
+process.trackerTopology = cms.ESProducer("TrackerTopologyEP")
 
 # Conditions (Global Tag is used here):
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")

--- a/DQM/SiStripMonitorHardware/python/test/testSiStripShotFilter_cfg.py
+++ b/DQM/SiStripMonitorHardware/python/test/testSiStripShotFilter_cfg.py
@@ -33,9 +33,7 @@ process.load("Configuration.StandardSequences.ReconstructionCosmics_cff")
 ##########################################################
 #needed to produce tkHistoMap+shot histos.
 #Can comment if commenting apvshotsanalyzer in main path
-process.DQMStore = cms.Service("DQMStore")
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 process.load("DPGAnalysis.SiStripTools.apvshotsanalyzer_cfi")
 process.TFileService = cms.Service("TFileService", 
                                    fileName = cms.string("Shot.root"),

--- a/DQM/SiStripMonitorHardware/src/BuildTrackerMap.cc
+++ b/DQM/SiStripMonitorHardware/src/BuildTrackerMap.cc
@@ -57,7 +57,7 @@ class BuildTrackerMapPlugin : public edm::EDAnalyzer
  public:
 
   explicit BuildTrackerMapPlugin(const edm::ParameterSet&);
-  ~BuildTrackerMapPlugin() override;
+  ~BuildTrackerMapPlugin() override {}
  private:
   void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
@@ -65,10 +65,11 @@ class BuildTrackerMapPlugin : public edm::EDAnalyzer
 
   void read(bool aMechView,
 	    std::string aFile,
-	    std::vector<TkHistoMap*> & aTkMapVec,
+            const TkDetMap* tkDetMap,
+	    std::vector<std::unique_ptr<TkHistoMap>> & aTkMapVec,
 	    std::vector<bool> & aValidVec);
-  void subtractMap(TkHistoMap*& aResult,
-		   TkHistoMap*& aSubtr);
+  void subtractMap(TkHistoMap* aResult,
+		   const TkHistoMap* aSubtr);
 
 
 
@@ -84,9 +85,9 @@ class BuildTrackerMapPlugin : public edm::EDAnalyzer
   bool doDiff_;
   std::string fileNameDiff_;
 
-  std::vector<TkHistoMap*> tkHistoMapVec_;
-  std::vector<TkHistoMap*> tkHistoMapVecDiff_;
-  
+  std::vector<std::unique_ptr<TkHistoMap>> tkHistoMapVec_;
+  std::vector<std::unique_ptr<TkHistoMap>> tkHistoMapVecDiff_;
+
   //name of the tkHistoMap to extract
   std::vector<std::string> tkHistoMapNameVec_;
   std::vector<double> minVal_;
@@ -118,8 +119,6 @@ BuildTrackerMapPlugin::BuildTrackerMapPlugin(const edm::ParameterSet& iConfig)
     pset_(iConfig.getParameter<edm::ParameterSet>("TkmapParameters"))
 {
 
-  read(mechanicalView_,fileName_,tkHistoMapVec_,isValidMap_);
-  if (doDiff_) read(mechanicalView_,fileNameDiff_,tkHistoMapVecDiff_,isValidMapDiff_);
 
 
 //   for (unsigned int i(0); i<34; i++){
@@ -136,14 +135,6 @@ BuildTrackerMapPlugin::BuildTrackerMapPlugin(const edm::ParameterSet& iConfig)
   
 }
 
-BuildTrackerMapPlugin::~BuildTrackerMapPlugin()
-{
-
-  tkHistoMapVec_.clear();
-  if (doDiff_) tkHistoMapVecDiff_.clear();
-}
-
-
 //
 // Member functions
 //
@@ -151,17 +142,17 @@ BuildTrackerMapPlugin::~BuildTrackerMapPlugin()
 /*Check that is possible to load in tkhistomaps histograms already stored in a DQM root file (if the folder and name are known)*/
 void BuildTrackerMapPlugin::read(bool aMechView,
 				 std::string aFile,
-				 std::vector<TkHistoMap*> & aTkMapVec,
-				 std::vector<bool> & aValidVec)
+                                 const TkDetMap* tkDetMap,
+				 std::vector<std::unique_ptr<TkHistoMap>>& aTkMapVec,
+				 std::vector<bool>& aValidVec)
 {
   
   DQMStore * lDqmStore = edm::Service<DQMStore>().operator->();
   lDqmStore->open(aFile);  
-  std::vector<TkHistoMap *> tkHistoMap;
 
   unsigned int nHists = tkHistoMapNameVec_.size();
-  tkHistoMap.resize(nHists,nullptr);
-  aValidVec.resize(nHists,true);
+  aTkMapVec.reserve(nHists);
+  aValidVec.reserve(nHists);
 
   std::string dirName = folderName_;
   if (dirName == "") {
@@ -178,11 +169,11 @@ void BuildTrackerMapPlugin::read(bool aMechView,
   unsigned int nTotTot = 0;
   for (unsigned int i(0); i<nHists; i++){
 
-    tkHistoMap[i] = new TkHistoMap();
+    std::unique_ptr<TkHistoMap> tkHistoMap{new TkHistoMap(tkDetMap)};
 
-    tkHistoMap[i]->loadTkHistoMap(dirName,tkHistoMapNameVec_.at(i),aMechView);
+    tkHistoMap->loadTkHistoMap(dirName,tkHistoMapNameVec_.at(i),aMechView);
     
-    std::vector<MonitorElement*>& lMaps = tkHistoMap[i]->getAllMaps();
+    std::vector<MonitorElement*>& lMaps = tkHistoMap->getAllMaps();
 
     std::cout << " -- map " << i << ", nHistos = " << lMaps.size() << std::endl;
     unsigned int nFail=0;
@@ -199,7 +190,7 @@ void BuildTrackerMapPlugin::read(bool aMechView,
     }
 
     if (nFail == nTot) aValidVec[i] = false;
-    aTkMapVec.push_back(tkHistoMap[i]);
+    aTkMapVec.emplace_back(std::move(tkHistoMap));
   }
 
   if (nFailTot < nTotTot) std::cout << " - " << nTotTot-nFailTot << "/" << nTotTot 
@@ -321,6 +312,14 @@ BuildTrackerMapPlugin::analyze(const edm::Event& iEvent,
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
 
+  if ( tkHistoMapVec_.empty() && ( ! tkHistoMapNameVec_.empty() ) ) {
+    edm::ESHandle<TkDetMap> tkDetMapHandle;
+    iSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+    const TkDetMap* tkDetMap = tkDetMapHandle.product();
+    read(mechanicalView_, fileName_, tkDetMap, tkHistoMapVec_, isValidMap_);
+    if (doDiff_) read(mechanicalView_, fileNameDiff_, tkDetMap, tkHistoMapVecDiff_, isValidMapDiff_);
+  }
+
   if (firstEvent) {
     for (unsigned int i(0); i<tkHistoMapNameVec_.size(); i++){
       tkmap_.push_back(new TrackerMap(pset_,&(*fedcabling),tTopo));
@@ -364,7 +363,7 @@ BuildTrackerMapPlugin::endJob()
       continue;
     }
 
-    subtractMap(tkHistoMapVec_.at(i),tkHistoMapVecDiff_.at(i));
+    subtractMap(tkHistoMapVec_.at(i).get(),tkHistoMapVecDiff_.at(i).get());
 
 
     //(pset_,pDD1); 
@@ -392,12 +391,11 @@ BuildTrackerMapPlugin::endJob()
 }
 
 
-void BuildTrackerMapPlugin::subtractMap(TkHistoMap *& aResult,
-					TkHistoMap *& aSubtr)
+void BuildTrackerMapPlugin::subtractMap(TkHistoMap* aResult, const TkHistoMap* aSubtr)
 {
   
   std::vector<MonitorElement*>& lMaps = aResult->getAllMaps();
-  std::vector<MonitorElement*>& lMapsDiff = aSubtr->getAllMaps();
+  const std::vector<MonitorElement*>& lMapsDiff = aSubtr->getAllMaps();
 
   assert(lMaps.size() == lMapsDiff.size());  
 

--- a/DQM/SiStripMonitorHardware/src/CMHistograms.cc
+++ b/DQM/SiStripMonitorHardware/src/CMHistograms.cc
@@ -89,7 +89,7 @@ void CMHistograms::fillHistograms(const std::vector<CMvalues>& aVec, float aTime
 }
 
 
-void CMHistograms::bookTopLevelHistograms(DQMStore::IBooker & ibooker)
+void CMHistograms::bookTopLevelHistograms(DQMStore::IBooker & ibooker, const TkDetMap* tkDetMap)
 {
   //book FED level histograms
   //get FED IDs
@@ -147,10 +147,10 @@ void CMHistograms::bookTopLevelHistograms(DQMStore::IBooker & ibooker)
     
   //book map after, as it creates a new folder...
   if (tkMapConfig_.enabled){
-    tkmapCM_[0] = new TkHistoMap("SiStrip/TkHisto","TkHMap_MeanCMAPV",0.,true);
-    tkmapCM_[1] = new TkHistoMap("SiStrip/TkHisto","TkHMap_RmsCMAPV",0.,true);
-    tkmapCM_[2] = new TkHistoMap("SiStrip/TkHisto","TkHMap_MeanCMAPV0minusAPV1",-500.,true);
-    tkmapCM_[3] = new TkHistoMap("SiStrip/TkHisto","TkHMap_RmsCMAPV0minusAPV1",-500.,true);
+    tkmapCM_[0] = std::make_unique<TkHistoMap>(tkDetMap, "SiStrip/TkHisto","TkHMap_MeanCMAPV",0.,true);
+    tkmapCM_[1] = std::make_unique<TkHistoMap>(tkDetMap, "SiStrip/TkHisto","TkHMap_RmsCMAPV",0.,true);
+    tkmapCM_[2] = std::make_unique<TkHistoMap>(tkDetMap, "SiStrip/TkHisto","TkHMap_MeanCMAPV0minusAPV1",-500.,true);
+    tkmapCM_[3] = std::make_unique<TkHistoMap>(tkDetMap, "SiStrip/TkHisto","TkHMap_RmsCMAPV0minusAPV1",-500.,true);
   }
   else {
     tkmapCM_[0] = nullptr;
@@ -251,5 +251,5 @@ bool CMHistograms::tkHistoMapEnabled(unsigned int aIndex){
 
 TkHistoMap * CMHistograms::tkHistoMapPointer(unsigned int aIndex){
   assert(aIndex < 4);
-  return tkmapCM_[aIndex];
+  return tkmapCM_[aIndex].get();
 }

--- a/DQM/SiStripMonitorHardware/src/FEDHistograms.cc
+++ b/DQM/SiStripMonitorHardware/src/FEDHistograms.cc
@@ -370,7 +370,7 @@ MonitorElement * FEDHistograms::getFedvsAPVpointer()
   return fedIdVsApvId_.monitorEle;
 }
 
-void FEDHistograms::bookTopLevelHistograms(DQMStore::IBooker & ibooker , std::string topFolderName)
+void FEDHistograms::bookTopLevelHistograms(DQMStore::IBooker & ibooker, const TkDetMap* tkDetMap, std::string topFolderName)
 {
   //get FED IDs
   const unsigned int siStripFedIdMin = FEDNumbering::MINSiStripFEDID;
@@ -807,7 +807,7 @@ void FEDHistograms::bookTopLevelHistograms(DQMStore::IBooker & ibooker , std::st
 
   //book map after, as it creates a new folder...
   if (tkMapConfig_.enabled){
-    tkmapFED_ = new TkHistoMap(topFolderName,"TkHMap_FractionOfBadChannels",0.,true);
+    tkmapFED_ = std::make_unique<TkHistoMap>(tkDetMap, topFolderName,"TkHMap_FractionOfBadChannels",0.,true);
   }
   else tkmapFED_ = nullptr;
 
@@ -904,5 +904,5 @@ bool FEDHistograms::tkHistoMapEnabled(unsigned int aIndex){
 }
 
 TkHistoMap * FEDHistograms::tkHistoMapPointer(unsigned int aIndex){
-  return tkmapFED_;
+  return tkmapFED_.get();
 }

--- a/DQM/SiStripMonitorHardware/src/SPYHistograms.cc
+++ b/DQM/SiStripMonitorHardware/src/SPYHistograms.cc
@@ -245,7 +245,7 @@ void SPYHistograms::fillDetailedHistograms(const Errors & aErr,
 }
 
 
-void SPYHistograms::bookTopLevelHistograms(DQMStore::IBooker & ibooker)
+void SPYHistograms::bookTopLevelHistograms(DQMStore::IBooker & ibooker, const TkDetMap*)
 {
   //get FED IDs
   const unsigned int siStripFedIdMin = sistrip::FED_ID_MIN;

--- a/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
@@ -180,7 +180,11 @@ void SiStripCMMonitorPlugin::bookHistograms(DQMStore::IBooker & ibooker , const 
 {
   ibooker.setCurrentFolder(folderName_);
 
-  cmHists_.bookTopLevelHistograms(ibooker);
+  edm::ESHandle<TkDetMap> tkDetMapHandle;
+  eSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+  const TkDetMap* tkDetMap = tkDetMapHandle.product();
+
+  cmHists_.bookTopLevelHistograms(ibooker, tkDetMap);
 
   if (fillAllDetailedHistograms_) cmHists_.bookAllFEDHistograms(ibooker);
 }

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDMonitor.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDMonitor.cc
@@ -461,7 +461,13 @@ void SiStripFEDMonitorPlugin::getMajority(const std::vector<std::pair<unsigned i
 void SiStripFEDMonitorPlugin::bookHistograms(DQMStore::IBooker & ibooker , const edm::Run & run, const edm::EventSetup & eSetup)
 {
   ibooker.setCurrentFolder(folderName_);
-  fedHists_.bookTopLevelHistograms(ibooker);
+
+  edm::ESHandle<TkDetMap> tkDetMapHandle;
+  eSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+  const TkDetMap* tkDetMap = tkDetMapHandle.product();
+
+  fedHists_.bookTopLevelHistograms(ibooker, tkDetMap);
+
   if (fillAllDetailedHistograms_) fedHists_.bookAllFEDHistograms(ibooker , fullDebugMode_ );
 }
 

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyMonitorModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyMonitorModule.cc
@@ -207,8 +207,12 @@ void SiStripSpyMonitorModule::bookHistograms(DQMStore::IBooker & ibooker , const
 				     << ibooker.pwd() 
 				     << std::endl;
   
+  edm::ESHandle<TkDetMap> tkDetMapHandle;
+  eSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+  const TkDetMap* tkDetMap = tkDetMapHandle.product();
+
   //this propagates dqm_ to the histoclass, must be called !
-  histManager_.bookTopLevelHistograms(ibooker);
+  histManager_.bookTopLevelHistograms(ibooker, tkDetMap);
   
   if (fillAllDetailedHistograms_) histManager_.bookAllFEDHistograms(ibooker);
 

--- a/DQM/SiStripMonitorHardware/test/buildTkMap_cfg.py
+++ b/DQM/SiStripMonitorHardware/test/buildTkMap_cfg.py
@@ -17,10 +17,9 @@ process.MessageLogger.debugModules = cms.untracked.vstring('*')
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.GlobalTag.globaltag = 'GR10_P_V4::All'
 
-process.DQMStore = cms.Service("DQMStore")
-
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
+# load TrackerTopology (needed for TkDetMap and TkHistoMap)
+process.trackerTopology = cms.ESProducer("TrackerTopologyEP")
 
 
 process.load('DQM.SiStripMonitorHardware.siStripBuildTrackerMap_cfi')

--- a/DQM/SiStripMonitorHardware/test/testSiStripFEDMonitor_cfg.py
+++ b/DQM/SiStripMonitorHardware/test/testSiStripFEDMonitor_cfg.py
@@ -73,11 +73,9 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1000)
     )
 
-process.DQMStore = cms.Service("DQMStore")
-
-#needed to produce tkHistoMap
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
+# load TrackerTopology (needed for TkDetMap and TkHistoMap)
+process.trackerTopology = cms.ESProducer("TrackerTopologyEP")
 
 # Conditions (Global Tag is used here):
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")

--- a/DQM/SiStripMonitorSummary/interface/SiStripBaseCondObjDQM.h
+++ b/DQM/SiStripMonitorSummary/interface/SiStripBaseCondObjDQM.h
@@ -14,7 +14,6 @@
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
-#include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 
 #include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
 #include "DQM/SiStripCommon/interface/SiStripHistoId.h"
@@ -64,7 +63,7 @@ class SiStripBaseCondObjDQM {
   
 
     std::vector<uint32_t> getCabledModules();
-    void selectModules(std::vector<uint32_t> & detIds_);
+    void selectModules(std::vector<uint32_t> & detIds_, const TrackerTopology* tTopo);
   
     //    virtual void fillTopSummaryMEs()=0;
  

--- a/DQM/SiStripMonitorSummary/interface/SiStripBaseCondObjDQM.h
+++ b/DQM/SiStripMonitorSummary/interface/SiStripBaseCondObjDQM.h
@@ -130,9 +130,9 @@ class SiStripBaseCondObjDQM {
     unsigned long long cacheID_memory;
     unsigned long long cacheID_current;
 
-    TkHistoMap* Tk_HM_;
-    TkHistoMap* Tk_HM_H;
-    TkHistoMap* Tk_HM_L;
+    std::unique_ptr<TkHistoMap> Tk_HM_;
+    std::unique_ptr<TkHistoMap> Tk_HM_H;
+    std::unique_ptr<TkHistoMap> Tk_HM_L;
     TrackerMap * tkMap;
   
  private:

--- a/DQM/SiStripMonitorSummary/src/SiStripApvGainsDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripApvGainsDQM.cc
@@ -10,8 +10,11 @@ SiStripApvGainsDQM::SiStripApvGainsDQM(const edm::EventSetup & eSetup,
                                        edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup,hPSet, fPSet){
 
   // Build the Histo_TkMap:
-  if(HistoMaps_On_ ) Tk_HM_ = new TkHistoMap("SiStrip/Histo_Map","MeanApvGain_TkMap",0.);
-
+  if ( HistoMaps_On_ ) {
+    edm::ESHandle<TkDetMap> tkDetMapHandle;
+    eSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+    Tk_HM_ = std::make_unique<TkHistoMap>(tkDetMapHandle.product(), "SiStrip/Histo_Map","MeanApvGain_TkMap",0.);
+  }
 }
 // -----
 

--- a/DQM/SiStripMonitorSummary/src/SiStripBackPlaneCorrectionDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripBackPlaneCorrectionDQM.cc
@@ -1,6 +1,7 @@
 #include "DQM/SiStripMonitorSummary/interface/SiStripBackPlaneCorrectionDQM.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
+#include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 #include "TCanvas.h"
 
 // -----
@@ -146,7 +147,6 @@ void SiStripBackPlaneCorrectionDQM::fillMEsForLayer( /*std::map<uint32_t, ModMEs
   }
 
   uint32_t selSubDetId_ =  ((selDetId_>>25)&0x7);
-  SiStripSubStructure substructure_;
   
   std::vector<uint32_t> sameLayerDetIds_;
   sameLayerDetIds_.clear();
@@ -167,20 +167,20 @@ void SiStripBackPlaneCorrectionDQM::fillMEsForLayer( /*std::map<uint32_t, ModMEs
    
     if(selSubDetId_==3){  //  TIB
       if(tTopo->tibIsInternalString(selDetId_)){
-	substructure_.getTIBDetectors(activeDetIds, sameLayerDetIds_, tTopo->tibLayer(selDetId_),0,1,tTopo->tibString(selDetId_));
+	SiStripSubStructure::getTIBDetectors(activeDetIds, sameLayerDetIds_, tTopo, tTopo->tibLayer(selDetId_),0,1,tTopo->tibString(selDetId_));
       }
       if(tTopo->tibIsExternalString(selDetId_)){
-	substructure_.getTIBDetectors(activeDetIds, sameLayerDetIds_, tTopo->tibLayer(selDetId_),0,2,tTopo->tibString(selDetId_));
+	SiStripSubStructure::getTIBDetectors(activeDetIds, sameLayerDetIds_, tTopo, tTopo->tibLayer(selDetId_),0,2,tTopo->tibString(selDetId_));
       } 
     }
     else if(selSubDetId_==4){  // TID
-      substructure_.getTIDDetectors(activeDetIds, sameLayerDetIds_, 0,0,0,0);
+      SiStripSubStructure::getTIDDetectors(activeDetIds, sameLayerDetIds_, tTopo, 0,0,0,0);
     }
     else if(selSubDetId_==5){  // TOB
-      substructure_.getTOBDetectors(activeDetIds, sameLayerDetIds_, tTopo->tobLayer(selDetId_),0,tTopo->tobRod(selDetId_));
+      SiStripSubStructure::getTOBDetectors(activeDetIds, sameLayerDetIds_, tTopo, tTopo->tobLayer(selDetId_),0,tTopo->tobRod(selDetId_));
     }
     else if(selSubDetId_==6){  // TEC
-      substructure_.getTECDetectors(activeDetIds, sameLayerDetIds_, 0,0,0,0,0,0);
+      SiStripSubStructure::getTECDetectors(activeDetIds, sameLayerDetIds_, tTopo, 0,0,0,0,0,0);
     }
  
     // -----

--- a/DQM/SiStripMonitorSummary/src/SiStripBackPlaneCorrectionDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripBackPlaneCorrectionDQM.cc
@@ -10,8 +10,11 @@ SiStripBackPlaneCorrectionDQM::SiStripBackPlaneCorrectionDQM(const edm::EventSet
 					       edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup, hPSet, fPSet){
 
   // Build the Histo_TkMap:
-  if(HistoMaps_On_ ) Tk_HM_ = new TkHistoMap("SiStrip/Histo_Map","BP_TkMap",0.);
-
+  if ( HistoMaps_On_ ) {
+    edm::ESHandle<TkDetMap> tkDetMapHandle;
+    eSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+    Tk_HM_ = std::make_unique<TkHistoMap>(tkDetMapHandle.product(), "SiStrip/Histo_Map","BP_TkMap",0.);
+  }
 }
 // -----
 

--- a/DQM/SiStripMonitorSummary/src/SiStripCablingDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripCablingDQM.cc
@@ -10,8 +10,11 @@ SiStripCablingDQM::SiStripCablingDQM(const edm::EventSetup & eSetup,
 				     edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup, hPSet, fPSet){
 
   // Build the Histo_TkMap:
-  if(HistoMaps_On_ ) Tk_HM_ = new TkHistoMap("SiStrip/Histo_Map","Cabling_TkMap",0.);
-
+  if ( HistoMaps_On_ ) {
+    edm::ESHandle<TkDetMap> tkDetMapHandle;
+    eSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+    Tk_HM_ = std::make_unique<TkHistoMap>(tkDetMapHandle.product(), "SiStrip/Histo_Map","Cabling_TkMap",0.);
+  }
 }
 // -----
 

--- a/DQM/SiStripMonitorSummary/src/SiStripClassToMonitorCondData.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripClassToMonitorCondData.cc
@@ -15,7 +15,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 
 #include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
 #include "DQM/SiStripCommon/interface/SiStripHistoId.h"

--- a/DQM/SiStripMonitorSummary/src/SiStripLorentzAngleDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripLorentzAngleDQM.cc
@@ -10,8 +10,11 @@ SiStripLorentzAngleDQM::SiStripLorentzAngleDQM(const edm::EventSetup & eSetup,
 					       edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup, hPSet, fPSet){
 
   // Build the Histo_TkMap:
-  if(HistoMaps_On_ ) Tk_HM_ = new TkHistoMap("SiStrip/Histo_Map","LA_TkMap",0.);
-
+  if ( HistoMaps_On_ ) {
+    edm::ESHandle<TkDetMap> tkDetMapHandle;
+    eSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+    Tk_HM_ = std::make_unique<TkHistoMap>(tkDetMapHandle.product(), "SiStrip/Histo_Map","LA_TkMap",0.);
+  }
 }
 // -----
 

--- a/DQM/SiStripMonitorSummary/src/SiStripLorentzAngleDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripLorentzAngleDQM.cc
@@ -1,6 +1,7 @@
 #include "DQM/SiStripMonitorSummary/interface/SiStripLorentzAngleDQM.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 #include "TCanvas.h"
 
 // -----
@@ -52,7 +53,7 @@ void SiStripLorentzAngleDQM::fillSummaryMEs(const std::vector<uint32_t> & select
 
   bool fillNext = true; 
   for(unsigned int i=0;i<selectedDetIds.size();i++){					    
-    int subDetId_ = ((selectedDetIds[i]>>25)&0x7);
+    int subDetId_ = DetId(selectedDetIds[i]).subdetId();
     if( subDetId_<3 ||subDetId_>6 ){ 
       edm::LogError("SiStripLorentzAngle")
 	<< "[SiStripLorentzAngle::fillSummaryMEs] WRONG INPUT : no such subdetector type : "
@@ -135,7 +136,7 @@ void SiStripLorentzAngleDQM::fillMEsForLayer( /*std::map<uint32_t, ModMEs> selME
 
   std::string hSummary_name; 
 
-  int subDetId_ = ((selDetId_>>25)&0x7);
+  int subDetId_ = DetId(selDetId_).subdetId();
   
   if( subDetId_<3 || subDetId_>6 ){ 
     edm::LogError("SiStripLorentzAngleDQM")
@@ -145,9 +146,6 @@ void SiStripLorentzAngleDQM::fillMEsForLayer( /*std::map<uint32_t, ModMEs> selME
     return;
   }
 
-  uint32_t selSubDetId_ =  ((selDetId_>>25)&0x7);
-  SiStripSubStructure substructure_;
-  
   std::vector<uint32_t> sameLayerDetIds_;
   sameLayerDetIds_.clear();
 
@@ -164,25 +162,27 @@ void SiStripLorentzAngleDQM::fillMEsForLayer( /*std::map<uint32_t, ModMEs> selME
   
     // -----   					   
     sameLayerDetIds_.clear();
-   
-    if(selSubDetId_==3){  //  TIB
-      if(tTopo->tibIsInternalString(selDetId_)){
-	substructure_.getTIBDetectors(activeDetIds, sameLayerDetIds_, tTopo->tibLayer(selDetId_),0,1,tTopo->tibString(selDetId_));
-      }
-      if(tTopo->tibIsExternalString(selDetId_)){
-	substructure_.getTIBDetectors(activeDetIds, sameLayerDetIds_, tTopo->tibLayer(selDetId_),0,2,tTopo->tibString(selDetId_));
-      } 
+
+    switch ( DetId(selDetId_).subdetId() ) {
+      case StripSubdetector::TIB:
+        if(tTopo->tibIsInternalString(selDetId_)){
+          SiStripSubStructure::getTIBDetectors(activeDetIds, sameLayerDetIds_, tTopo, tTopo->tibLayer(selDetId_),0,1,tTopo->tibString(selDetId_));
+        }
+        if(tTopo->tibIsExternalString(selDetId_)){
+          SiStripSubStructure::getTIBDetectors(activeDetIds, sameLayerDetIds_, tTopo, tTopo->tibLayer(selDetId_),0,2,tTopo->tibString(selDetId_));
+        }
+        break;
+      case StripSubdetector::TID:
+        SiStripSubStructure::getTIDDetectors(activeDetIds, sameLayerDetIds_, tTopo, 0,0,0,0);
+        break;
+      case StripSubdetector::TOB:
+        SiStripSubStructure::getTOBDetectors(activeDetIds, sameLayerDetIds_, tTopo, tTopo->tobLayer(selDetId_),0,tTopo->tobRod(selDetId_));
+        break;
+      case StripSubdetector::TEC:
+        SiStripSubStructure::getTECDetectors(activeDetIds, sameLayerDetIds_, tTopo, 0,0,0,0,0,0);
+        break;
     }
-    else if(selSubDetId_==4){  // TID
-      substructure_.getTIDDetectors(activeDetIds, sameLayerDetIds_, 0,0,0,0);
-    }
-    else if(selSubDetId_==5){  // TOB
-      substructure_.getTOBDetectors(activeDetIds, sameLayerDetIds_, tTopo->tobLayer(selDetId_),0,tTopo->tobRod(selDetId_));
-    }
-    else if(selSubDetId_==6){  // TEC
-      substructure_.getTECDetectors(activeDetIds, sameLayerDetIds_, 0,0,0,0,0,0);
-    }
- 
+
     // -----
 
     for(unsigned int i=0;i< sameLayerDetIds_.size(); i++){

--- a/DQM/SiStripMonitorSummary/src/SiStripMonitorCondData.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripMonitorCondData.cc
@@ -15,7 +15,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 
 #include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
 #include "DQM/SiStripCommon/interface/SiStripHistoId.h"

--- a/DQM/SiStripMonitorSummary/src/SiStripNoisesDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripNoisesDQM.cc
@@ -16,8 +16,11 @@ SiStripNoisesDQM::SiStripNoisesDQM(const edm::EventSetup & eSetup,
 
 
   // Build the Histo_TkMap:
-  if(HistoMaps_On_ ) Tk_HM_ = new TkHistoMap("SiStrip/Histo_Map","MeanNoise_TkMap",0.);
-
+  if ( HistoMaps_On_ ) {
+    edm::ESHandle<TkDetMap> tkDetMapHandle;
+    eSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+    Tk_HM_ = std::make_unique<TkHistoMap>(tkDetMapHandle.product(), "SiStrip/Histo_Map","MeanNoise_TkMap",0.);
+  }
 }
 // -----
 

--- a/DQM/SiStripMonitorSummary/src/SiStripPedestalsDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripPedestalsDQM.cc
@@ -9,7 +9,11 @@ SiStripPedestalsDQM::SiStripPedestalsDQM(const edm::EventSetup & eSetup,
                                          edm::ParameterSet const& fPSet):SiStripBaseCondObjDQM(eSetup, hPSet, fPSet){
 
   // Build the Histo_TkMap:
-  if(HistoMaps_On_ ) Tk_HM_ = new TkHistoMap("SiStrip/Histo_Map","MeanPed_TkMap",0.);
+  if ( HistoMaps_On_ ) {
+    edm::ESHandle<TkDetMap> tkDetMapHandle;
+    eSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+    Tk_HM_ = std::make_unique<TkHistoMap>(tkDetMapHandle.product(), "SiStrip/Histo_Map","MeanPed_TkMap",0.);
+  }
 }
 // -----
 

--- a/DQM/SiStripMonitorSummary/src/SiStripQualityDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripQualityDQM.cc
@@ -10,8 +10,11 @@ SiStripQualityDQM::SiStripQualityDQM(const edm::EventSetup & eSetup,
   qualityLabel_ = fPSet.getParameter<std::string>("StripQualityLabel");
 
   // Build the Histo_TkMap:
-  if(HistoMaps_On_ ) Tk_HM_ = new TkHistoMap("SiStrip/Histo_Map","Quality_TkMap",0.);
-
+  if ( HistoMaps_On_ ) {
+    edm::ESHandle<TkDetMap> tkDetMapHandle;
+    eSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+    Tk_HM_ = std::make_unique<TkHistoMap>(tkDetMapHandle.product(), "SiStrip/Histo_Map","Quality_TkMap",0.);
+  }
 }
 // -----
 

--- a/DQM/SiStripMonitorSummary/src/SiStripThresholdDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripThresholdDQM.cc
@@ -12,8 +12,11 @@ SiStripThresholdDQM::SiStripThresholdDQM(const edm::EventSetup & eSetup,
 
   // Build the Histo_TkMap:
   if(HistoMaps_On_ ){
-    if(WhichThreshold=="Low") Tk_HM_L = new TkHistoMap("SiStrip/Histo_Map","LowThresh_TkMap",0.);
-    if(WhichThreshold=="High") Tk_HM_H = new TkHistoMap("SiStrip/Histo_Map","HighThresh_TkMap",0.);
+    edm::ESHandle<TkDetMap> tkDetMapHandle;
+    eSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+    const TkDetMap* tkDetMap = tkDetMapHandle.product();
+    if(WhichThreshold=="Low") Tk_HM_L = std::make_unique<TkHistoMap>(tkDetMap, "SiStrip/Histo_Map","LowThresh_TkMap",0.);
+    if(WhichThreshold=="High") Tk_HM_H = std::make_unique<TkHistoMap>(tkDetMap, "SiStrip/Histo_Map","HighThresh_TkMap",0.);
   }
 }
 

--- a/DQM/SiStripMonitorSummary/test/DBReader_Quality_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/DBReader_Quality_cfg.py
@@ -6,10 +6,7 @@ process = cms.Process("CONDOBJMON")
 #-------------------------------------------------
 ###process.load("DQM.SiStripMonitorSummary.Tags21X_cff")
 
-process.load("DQM.SiStripCommon.TkHistoMap_cfi")
-
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 
 
 #-------------------------------------------------

--- a/DQM/SiStripMonitorSummary/test/DBReader_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/DBReader_cfg.py
@@ -2,10 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Reader")
 
-process.load("DQM.SiStripCommon.TkHistoMap_cfi")
-
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring(''),

--- a/DQM/SiStripMonitorSummary/test/DBReader_specifc_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/DBReader_specifc_cfg.py
@@ -4,7 +4,7 @@ process = cms.Process("Reader")
 
 process.load("DQM.SiStripCommon.TkHistoMap_cfi")
 
-process.TkDetMap = cms.Service("TkDetMap")
+process.load("CalibTracker.SiStripCommon.TkDetMapESProducer_cfi")
 process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 
 process.MessageLogger = cms.Service("MessageLogger",

--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -77,7 +77,7 @@ private:
   struct Det2MEs;
 
   //booking
-  void book(DQMStore::IBooker &, const TrackerTopology* tTopo);
+  void book(DQMStore::IBooker &, const TrackerTopology* tTopo, const TkDetMap* tkDetMap);
   void bookModMEs(DQMStore::IBooker &, const uint32_t );
   void bookLayerMEs(DQMStore::IBooker &, const uint32_t, std::string&);
   void bookRing(DQMStore::IBooker &, const uint32_t, std::string&);
@@ -166,10 +166,10 @@ private:
   std::string topFolderName_;
 
   //******* TkHistoMaps
-  TkHistoMap *tkhisto_StoNCorrOnTrack, *tkhisto_NumOnTrack, *tkhisto_NumOffTrack;
-  TkHistoMap *tkhisto_ClChPerCMfromOrigin, *tkhisto_ClChPerCMfromTrack;
-  TkHistoMap *tkhisto_NumMissingHits, *tkhisto_NumberInactiveHits, *tkhisto_NumberValidHits;
-  TkHistoMap *tkhisto_NoiseOnTrack, *tkhisto_NoiseOffTrack, *tkhisto_ClusterWidthOnTrack, *tkhisto_ClusterWidthOffTrack;
+  std::unique_ptr<TkHistoMap> tkhisto_StoNCorrOnTrack, tkhisto_NumOnTrack, tkhisto_NumOffTrack;
+  std::unique_ptr<TkHistoMap> tkhisto_ClChPerCMfromOrigin, tkhisto_ClChPerCMfromTrack;
+  std::unique_ptr<TkHistoMap> tkhisto_NumMissingHits, tkhisto_NumberInactiveHits, tkhisto_NumberValidHits;
+  std::unique_ptr<TkHistoMap> tkhisto_NoiseOnTrack, tkhisto_NoiseOffTrack, tkhisto_ClusterWidthOnTrack, tkhisto_ClusterWidthOffTrack;
   //******** TkHistoMaps
   int numTracks;
 

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -5,7 +5,6 @@
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 #include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
-#include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -85,8 +85,9 @@ void SiStripMonitorTrack::bookHistograms(DQMStore::IBooker & ibooker , const edm
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   es.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
-  book(ibooker , tTopo);
+  edm::ESHandle<TkDetMap> tkDetMapHandle;
+  es.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+  book(ibooker, tTopoHandle.product(), tkDetMapHandle.product());
 }
 
 // ------------ method called to produce the data  ------------
@@ -149,28 +150,27 @@ void SiStripMonitorTrack::analyze(const edm::Event& e, const edm::EventSetup& es
 }
 
 //------------------------------------------------------------------------
-void SiStripMonitorTrack::book(DQMStore::IBooker & ibooker , const TrackerTopology* tTopo)
+void SiStripMonitorTrack::book(DQMStore::IBooker& ibooker, const TrackerTopology* tTopo, const TkDetMap* tkDetMap)
 {
 
   SiStripFolderOrganizer folder_organizer;
   folder_organizer.setSiStripFolderName(topFolderName_);
   //******** TkHistoMaps
   if (TkHistoMap_On_) {
-    tkhisto_StoNCorrOnTrack = new TkHistoMap(ibooker , topFolderName_ ,"TkHMap_StoNCorrOnTrack",         0.0,true);
-    tkhisto_NumOnTrack      = new TkHistoMap(ibooker , topFolderName_, "TkHMap_NumberOfOnTrackCluster",  0.0,true);
-    tkhisto_NumOffTrack     = new TkHistoMap(ibooker , topFolderName_, "TkHMap_NumberOfOfffTrackCluster",0.0,true);
-    tkhisto_ClChPerCMfromTrack  = new TkHistoMap(ibooker , topFolderName_, "TkHMap_ChargePerCMfromTrack",0.0,true);
-    tkhisto_NumMissingHits      = new TkHistoMap(ibooker , topFolderName_, "TkHMap_NumberMissingHits",0.0,true);
-    tkhisto_NumberInactiveHits  = new TkHistoMap(ibooker , topFolderName_, "TkHMap_NumberInactiveHits",0.0,true);
-    tkhisto_NumberValidHits     = new TkHistoMap(ibooker , topFolderName_, "TkHMap_NumberValidHits",0.0,true);
-    tkhisto_NoiseOnTrack     = new TkHistoMap(ibooker , topFolderName_, "TkHMap_NoiseOnTrack",0.0,true);
-    tkhisto_NoiseOffTrack     = new TkHistoMap(ibooker , topFolderName_, "TkHMap_NoiseOffTrack",0.0,true);
-    tkhisto_ClusterWidthOnTrack     = new TkHistoMap(ibooker , topFolderName_, "TkHMap_ClusterWidthOnTrack",0.0,true);
-    tkhisto_ClusterWidthOffTrack     = new TkHistoMap(ibooker , topFolderName_, "TkHMap_ClusterWidthOffTrack",0.0,true);
-
+    tkhisto_StoNCorrOnTrack      = std::make_unique<TkHistoMap>(tkDetMap, ibooker, topFolderName_ ,"TkHMap_StoNCorrOnTrack",         0.0,true);
+    tkhisto_NumOnTrack           = std::make_unique<TkHistoMap>(tkDetMap, ibooker, topFolderName_, "TkHMap_NumberOfOnTrackCluster",  0.0,true);
+    tkhisto_NumOffTrack          = std::make_unique<TkHistoMap>(tkDetMap, ibooker, topFolderName_, "TkHMap_NumberOfOfffTrackCluster",0.0,true);
+    tkhisto_ClChPerCMfromTrack   = std::make_unique<TkHistoMap>(tkDetMap, ibooker, topFolderName_, "TkHMap_ChargePerCMfromTrack",0.0,true);
+    tkhisto_NumMissingHits       = std::make_unique<TkHistoMap>(tkDetMap, ibooker, topFolderName_, "TkHMap_NumberMissingHits",0.0,true);
+    tkhisto_NumberInactiveHits   = std::make_unique<TkHistoMap>(tkDetMap, ibooker, topFolderName_, "TkHMap_NumberInactiveHits",0.0,true);
+    tkhisto_NumberValidHits      = std::make_unique<TkHistoMap>(tkDetMap, ibooker, topFolderName_, "TkHMap_NumberValidHits",0.0,true);
+    tkhisto_NoiseOnTrack         = std::make_unique<TkHistoMap>(tkDetMap, ibooker, topFolderName_, "TkHMap_NoiseOnTrack",0.0,true);
+    tkhisto_NoiseOffTrack        = std::make_unique<TkHistoMap>(tkDetMap, ibooker, topFolderName_, "TkHMap_NoiseOffTrack",0.0,true);
+    tkhisto_ClusterWidthOnTrack  = std::make_unique<TkHistoMap>(tkDetMap, ibooker, topFolderName_, "TkHMap_ClusterWidthOnTrack",0.0,true);
+    tkhisto_ClusterWidthOffTrack = std::make_unique<TkHistoMap>(tkDetMap, ibooker, topFolderName_, "TkHMap_ClusterWidthOffTrack",0.0,true);
   }
   if (clchCMoriginTkHmap_On_)
-    tkhisto_ClChPerCMfromOrigin = new TkHistoMap(ibooker , topFolderName_, "TkHMap_ChargePerCMfromOrigin",0.0,true);
+    tkhisto_ClChPerCMfromOrigin = std::make_unique<TkHistoMap>(tkDetMap, ibooker , topFolderName_, "TkHMap_ChargePerCMfromOrigin",0.0,true);
   //******** TkHistoMaps
 
   std::vector<uint32_t> vdetId_;
@@ -1597,16 +1597,5 @@ bool SiStripMonitorTrack::clusterInfos(
     }
   }
   return true;
-  delete tkhisto_StoNCorrOnTrack;
-  delete tkhisto_NumOnTrack;
-  delete tkhisto_NumOffTrack;
-  delete tkhisto_ClChPerCMfromTrack;
-  delete tkhisto_NumMissingHits;
-  delete tkhisto_NumberInactiveHits;
-  delete tkhisto_NumberValidHits;
-  delete tkhisto_NoiseOnTrack;
-  delete tkhisto_NoiseOffTrack;
-  delete tkhisto_ClusterWidthOnTrack;
-  delete tkhisto_ClusterWidthOffTrack;
 }
 //--------------------------------------------------------------------------------

--- a/DQM/SiStripMonitorTrack/test/SiStripMonitorTrack_RealData_cfg.py
+++ b/DQM/SiStripMonitorTrack/test/SiStripMonitorTrack_RealData_cfg.py
@@ -27,7 +27,7 @@ process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 #-------------------------------------------------
 # TkDetMap for TkHistoMap
 #-------------------------------------------------
-process.TkDetMap = cms.Service("TkDetMap")
+process.load("CalibTracker.SiStripCommon.TkDetMapESProducer_cfi")
 process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
 
 #-------------------------------------------------

--- a/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc
+++ b/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc
@@ -41,7 +41,9 @@ void MonitorTrackResidualsBase<pixel_or_strip>::bookHistograms(DQMStore::IBooker
   std::string topFolderName_ = "SiStrip";
   SiStripFolderOrganizer folder_organizer;
   folder_organizer.setSiStripFolderName(topFolderName_);
-  tkhisto_ResidualsMean = std::unique_ptr<TkHistoMap>(new TkHistoMap(ibooker , topFolderName_ ,"TkHMap_ResidualsMean", 0.0,true)); 
+  edm::ESHandle<TkDetMap> tkDetMapHandle;
+  iSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
+  tkhisto_ResidualsMean = std::make_unique<TkHistoMap>(tkDetMapHandle.product(), ibooker , topFolderName_ ,"TkHMap_ResidualsMean", 0.0,true);
 }
 
 template<TrackerType pixel_or_strip>

--- a/DQM/TrackingMonitorClient/interface/TrackingQualityChecker.h
+++ b/DQM/TrackingMonitorClient/interface/TrackingQualityChecker.h
@@ -15,7 +15,6 @@
 #include <string>
 
 class MonitorElement;
-class TkDetMap;
 class TrackingDetCabling;
 
 class TrackingQualityChecker {

--- a/DQM/TrackingMonitorClient/src/TrackingQualityChecker.cc
+++ b/DQM/TrackingMonitorClient/src/TrackingQualityChecker.cc
@@ -5,8 +5,6 @@
 
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
 
-#include "CalibTracker/SiStripCommon/interface/TkDetMap.h"
-
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 #include "DQM/TrackingMonitorClient/interface/TrackingUtility.h"
@@ -27,14 +25,6 @@ TrackingQualityChecker::TrackingQualityChecker(edm::ParameterSet const& ps) :
 
   bookedTrackingGlobalStatus_ = false;
   bookedTrackingLSStatus_     = false;
-
-  if(!edm::Service<TkDetMap>().isAvailable()){
-    edm::LogError("TkHistoMap") <<
-      "\n------------------------------------------"
-      "\nUnAvailable Service TkHistoMap: please insert in the configuration file an instance like"
-      "\n\tprocess.TkDetMap = cms.Service(\"TkDetMap\")"
-      "\n------------------------------------------";
-  }
 
   TopFolderName_ = pSet_.getUntrackedParameter<std::string>("TopFolderName","Tracking");
 

--- a/DQMOffline/CalibTracker/test/SiStripQualityStatistics_full_cfg.py
+++ b/DQMOffline/CalibTracker/test/SiStripQualityStatistics_full_cfg.py
@@ -70,9 +70,11 @@ process.SiStripQualityESProducer = cms.ESProducer("SiStripQualityESProducer",
 )
 
 #### Add these lines to produce a tracker map
-#process.load("DQMServices.Core.DQMStore_cfg")
-#process.TkDetMap = cms.Service("TkDetMap")
-#process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+#process.load("DQM.SiStripCommon.TkHistoMap_cff")
+### load TrackerTopology (needed for TkDetMap and TkHistoMap)
+#process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
+#process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
+#process.trackerTopology = cms.ESProducer("TrackerTopologyEP")
 ####
 
 process.stat = cms.EDAnalyzer("SiStripQualityStatistics",

--- a/DQMOffline/CalibTracker/test/SiStripQualityStatistics_offline_cfg.py
+++ b/DQMOffline/CalibTracker/test/SiStripQualityStatistics_offline_cfg.py
@@ -43,9 +43,11 @@ process.SiStripQualityESProducer = cms.ESProducer("SiStripQualityESProducer",
 )
 
 #### Add these lines to produce a tracker map
-#process.load("DQMServices.Core.DQMStore_cfg")
-#process.TkDetMap = cms.Service("TkDetMap")
-#process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+#process.load("DQM.SiStripCommon.TkHistoMap_cff")
+### load TrackerTopology (needed for TkDetMap and TkHistoMap)
+#process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
+#process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
+#process.trackerTopology = cms.ESProducer("TrackerTopologyEP")
 ####
 
 process.stat = cms.EDAnalyzer("SiStripQualityStatistics",

--- a/DQMOffline/CalibTracker/test/template_DQMProfileConverter_cfg.py
+++ b/DQMOffline/CalibTracker/test/template_DQMProfileConverter_cfg.py
@@ -34,9 +34,11 @@ process.b = cms.ESSource("PoolDBESSource",
     connect = cms.string('oracle://cms_orcoff_prod/CMS_COND_21X_STRIP')
 )
 
-process.TkDetMap = cms.Service("TkDetMap")
-
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("CalibTracker.SiStripCommon.TkDetMap_cff")
+# load TrackerTopology (needed for TkDetMap and TkHistoMap)
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
+process.trackerTopology = cms.ESProducer("TrackerTopologyEP")
 
 process.sistripconn = cms.ESProducer("SiStripConnectivity")
 

--- a/DQMOffline/CalibTracker/test/template_SiStripQualityStatistics_offline_cfg.py
+++ b/DQMOffline/CalibTracker/test/template_SiStripQualityStatistics_offline_cfg.py
@@ -53,9 +53,11 @@ process.SiStripQualityESProducer = cms.ESProducer("SiStripQualityESProducer",
 )
 
 #### Add these lines to produce a tracker map
-process.load("DQMServices.Core.DQMStore_cfg")
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cfi")
+# load TrackerTopology (needed for TkDetMap and TkHistoMap)
+process.load("Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
+process.trackerTopology = cms.ESProducer("TrackerTopologyEP")
 ####
 
 process.stat = cms.EDAnalyzer("SiStripQualityStatistics",

--- a/DQMOffline/Trigger/test/triggerSequenceTest_cfg.py
+++ b/DQMOffline/Trigger/test/triggerSequenceTest_cfg.py
@@ -30,8 +30,7 @@ process.prefer("GlobalTag")
 
 # removed this because we don't want to do local reco
 #SiStrip Local Reco
-#process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
-#process.TkDetMap = cms.Service("TkDetMap")
+#process.load("CalibTracker.SiStripCommon.TkDetMap_cff")
 
 #process.GlobalTrackingGeometryESProducer = cms.ESProducer( "GlobalTrackingGeometryESProducer" )
 

--- a/DataFormats/SiStripDetId/BuildFile.xml
+++ b/DataFormats/SiStripDetId/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="DataFormats/DetId"/>
+<use   name="DataFormats/TrackerCommon"/>
 
 <export>
   <lib   name="1"/>

--- a/DataFormats/SiStripDetId/interface/SiStripSubStructure.h
+++ b/DataFormats/SiStripDetId/interface/SiStripSubStructure.h
@@ -19,7 +19,7 @@
 //
 
 #include <vector>
-#include <stdint.h>
+#include <cstdint>
 
 class TrackerTopology;
 

--- a/DataFormats/SiStripDetId/interface/SiStripSubStructure.h
+++ b/DataFormats/SiStripDetId/interface/SiStripSubStructure.h
@@ -4,7 +4,7 @@
 //
 // Package:     SiStripDetId
 // Class  :     SiStripSubStructure
-// 
+//
 /**\class SiStripSubStructure SiStripSubStructure.h DataFormats/SiStripDetId/interface/SiStripSubStructure.h
 
  Description: <Assign detector Ids to different substructures of the SiStripTracker: TOB, TIB, etc>
@@ -19,52 +19,43 @@
 //
 
 #include <vector>
-#include <cstdint>
+#include <stdint.h>
 
-class SiStripSubStructure
-{
+class TrackerTopology;
 
-   public:
-      SiStripSubStructure();
-      ~SiStripSubStructure();
+namespace SiStripSubStructure {
+  void getTIBDetectors(const std::vector<uint32_t> & inputDetRawIds, // INPUT
+                       std::vector<uint32_t> & tibDetRawIds,         // OUTPUT
+                       const TrackerTopology* trackerTopology,       // TrackerTopology
+                       uint32_t layer         = 0,                   // SELECTION: layer = 1..4, 0(ALL)
+                       uint32_t bkw_frw = 0,                         // bkw_frw = 1(TIB-), 2(TIB+) 0(ALL)
+                       uint32_t int_ext = 0,                         // int_ext = 1 (internal), 2(external), 0(ALL)
+                       uint32_t string        = 0);                  // string = 1..N, 0(ALL)
 
-      void getTIBDetectors(const std::vector<uint32_t> & inputDetRawIds, // INPUT
-                           std::vector<uint32_t> & tibDetRawIds,         // OUTPUT
-                           uint32_t layer         = 0,                   // SELECTION: layer = 1..4, 0(ALL)
-                           uint32_t bkw_frw = 0,                         // bkw_frw = 1(TIB-), 2(TIB+) 0(ALL)
-                           uint32_t int_ext = 0,                         // int_ext = 1 (internal), 2(external), 0(ALL)
-                           uint32_t string        = 0) const;            // string = 1..N, 0(ALL)
+  void getTIDDetectors(const std::vector<uint32_t> & inputDetRawIds, // INPUT
+                       std::vector<uint32_t> & tidDetRawIds,         // OUTPUT
+                       const TrackerTopology* trackerTopology,       // TrackerTopology
+                       uint32_t side        = 0,                     // SELECTION: side = 1(back), 2(front), 0(ALL)
+                       uint32_t wheel       = 0,                     // wheel = 1..3, 0(ALL)
+                       uint32_t ring        = 0,                     // ring  = 1..3, 0(ALL)
+                       uint32_t ster        = 0);                    // ster = 1(stereo), else (nonstereo), 0(ALL)
 
-      void getTIDDetectors(const std::vector<uint32_t> & inputDetRawIds, // INPUT
-                           std::vector<uint32_t> & tidDetRawIds,         // OUTPUT
-                           uint32_t side        = 0,                     // SELECTION: side = 1(back), 2(front), 0(ALL)
-                           uint32_t wheel       = 0,                     // wheel = 1..3, 0(ALL)
-                           uint32_t ring        = 0,                     // ring  = 1..3, 0(ALL)
-                           uint32_t ster        = 0) const;              // ster = 1(stereo), else (nonstereo), 0(ALL)
-
-      void getTOBDetectors(const std::vector<uint32_t> & inputDetRawIds, // INPUT
-                           std::vector<uint32_t> & tobDetRawIds,         // OUTPUT
-                           uint32_t layer      = 0,                      // SELECTION: layer = 1..6, 0(ALL)
-                           uint32_t bkw_frw    = 0,                      // bkw_frw = 1(TOB-) 2(TOB+) 0(everything)
-                           uint32_t rod        = 0) const;               // rod = 1..N, 0(ALL)
+  void getTOBDetectors(const std::vector<uint32_t> & inputDetRawIds, // INPUT
+                       std::vector<uint32_t> & tobDetRawIds,         // OUTPUT
+                       const TrackerTopology* trackerTopology,       // TrackerTopology
+                       uint32_t layer      = 0,                      // SELECTION: layer = 1..6, 0(ALL)
+                       uint32_t bkw_frw    = 0,                      // bkw_frw = 1(TOB-) 2(TOB+) 0(everything)
+                       uint32_t rod        = 0);                     // rod = 1..N, 0(ALL)
 
 
-      void getTECDetectors(const std::vector<uint32_t> & inputDetRawIds, // INPUT
-                           std::vector<uint32_t> & tecDetRawIds,         // OUTPUT
-                           uint32_t side          = 0,                   // SELECTION: side = 1(TEC-), 2(TEC+),  0(ALL)
-                           uint32_t wheel         = 0,                   // wheel = 1..9, 0(ALL)
-                           uint32_t petal_bkw_frw = 0,                   // petal_bkw_frw = 1(backward) 2(forward) 0(all)
-                           uint32_t petal         = 0,                   // petal = 1..8, 0(ALL)
-                           uint32_t ring          = 0,                   // ring = 1..7, 0(ALL)
-                           uint32_t ster          = 0) const;            // ster = 1(sterero), else(nonstereo), 0(ALL)
-
-   private:
-      SiStripSubStructure(const SiStripSubStructure&) = delete; // stop default
-
-      const SiStripSubStructure& operator=(const SiStripSubStructure&) = delete; // stop default
-
-      // ---------- member data --------------------------------
-
+  void getTECDetectors(const std::vector<uint32_t> & inputDetRawIds, // INPUT
+                       std::vector<uint32_t> & tecDetRawIds,         // OUTPUT
+                       const TrackerTopology* trackerTopology,       // TrackerTopology
+                       uint32_t side          = 0,                   // SELECTION: side = 1(TEC-), 2(TEC+),  0(ALL)
+                       uint32_t wheel         = 0,                   // wheel = 1..9, 0(ALL)
+                       uint32_t petal_bkw_frw = 0,                   // petal_bkw_frw = 1(backward) 2(forward) 0(all)
+                       uint32_t petal         = 0,                   // petal = 1..8, 0(ALL)
+                       uint32_t ring          = 0,                   // ring = 1..7, 0(ALL)
+                       uint32_t ster          = 0);                  // ster = 1(sterero), else(nonstereo), 0(ALL)
 };
-
 #endif

--- a/DataFormats/SiStripDetId/src/SiStripSubStructure.cc
+++ b/DataFormats/SiStripDetId/src/SiStripSubStructure.cc
@@ -9,6 +9,7 @@
 // Original Author:  dkcira
 //         Created:  Wed Jan 25 07:19:38 CET 2006
 //
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/SiStripDetId/interface/TIBDetId.h"
@@ -19,19 +20,15 @@
 
 using namespace std;
 
-SiStripSubStructure::SiStripSubStructure(){
-}
-
-SiStripSubStructure::~SiStripSubStructure(){
-}
-
 
 void SiStripSubStructure::getTIBDetectors(const std::vector<uint32_t> & inputDetRawIds,
                                           std::vector<uint32_t> & tibDetRawIds,
+                                          const TrackerTopology* tTopo,
                                           uint32_t requested_layer,
                                           uint32_t requested_bkw_frw,
                                           uint32_t requested_int_ext,
-                                          uint32_t requested_string) const{
+                                          uint32_t requested_string)
+{
  // loop over all input detectors
   for(vector<uint32_t>::const_iterator it = inputDetRawIds.begin(); it!=inputDetRawIds.end();it++){
     uint32_t therawid = (*it);                  // raw id of single detector
@@ -52,10 +49,12 @@ void SiStripSubStructure::getTIBDetectors(const std::vector<uint32_t> & inputDet
 
 void SiStripSubStructure::getTIDDetectors(const std::vector<uint32_t> & inputDetRawIds,
                                           std::vector<uint32_t> & tidDetRawIds,
+                                          const TrackerTopology* tTopo,
                                           uint32_t requested_side,
                                           uint32_t requested_wheel,
                                           uint32_t requested_ring,
-                                          uint32_t requested_ster) const{
+                                          uint32_t requested_ster)
+{
  // loop over all input detectors
   for(vector<uint32_t>::const_iterator it = inputDetRawIds.begin(); it!=inputDetRawIds.end();it++){
     uint32_t therawid = (*it);                  // raw id of single detector
@@ -76,9 +75,11 @@ void SiStripSubStructure::getTIDDetectors(const std::vector<uint32_t> & inputDet
 
 void SiStripSubStructure::getTOBDetectors(const std::vector<uint32_t> & inputDetRawIds,
                                           std::vector<uint32_t> & tobDetRawIds,
+                                          const TrackerTopology* tTopo,
                                           uint32_t requested_layer,
                                           uint32_t requested_bkw_frw,
-                                          uint32_t requested_rod) const{
+                                          uint32_t requested_rod)
+{
  // loop over all input detectors
   for(vector<uint32_t>::const_iterator it = inputDetRawIds.begin(); it!=inputDetRawIds.end();it++){
     uint32_t therawid = (*it);                  // raw id of single detector
@@ -98,12 +99,14 @@ void SiStripSubStructure::getTOBDetectors(const std::vector<uint32_t> & inputDet
 
 void SiStripSubStructure::getTECDetectors(const std::vector<uint32_t> & inputDetRawIds,
                                           std::vector<uint32_t> & tecDetRawIds,
+                                          const TrackerTopology* tTopo,
                                           uint32_t requested_side,
                                           uint32_t requested_wheel,
                                           uint32_t requested_petal_bkw_frw,
                                           uint32_t requested_petal,
                                           uint32_t requested_ring,
-                                          uint32_t requested_ster) const{ 
+                                          uint32_t requested_ster)
+{
  // loop over all input detectors
   for(vector<uint32_t>::const_iterator it = inputDetRawIds.begin(); it!=inputDetRawIds.end();it++){
     uint32_t therawid = (*it);                  // raw id of single detector

--- a/DataFormats/SiStripDetId/src/SiStripSubStructure.cc
+++ b/DataFormats/SiStripDetId/src/SiStripSubStructure.cc
@@ -10,120 +10,77 @@
 //         Created:  Wed Jan 25 07:19:38 CET 2006
 //
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
-#include "DataFormats/SiStripDetId/interface/TIBDetId.h"
-#include "DataFormats/SiStripDetId/interface/TIDDetId.h"
-#include "DataFormats/SiStripDetId/interface/TOBDetId.h"
-#include "DataFormats/SiStripDetId/interface/TECDetId.h"
+#include <algorithm>
+
 #include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 
-using namespace std;
-
-
-void SiStripSubStructure::getTIBDetectors(const std::vector<uint32_t> & inputDetRawIds,
-                                          std::vector<uint32_t> & tibDetRawIds,
+void SiStripSubStructure::getTIBDetectors(const std::vector<uint32_t> & inputDetRawIds, std::vector<uint32_t> & tibDetRawIds,
                                           const TrackerTopology* tTopo,
-                                          uint32_t requested_layer,
-                                          uint32_t requested_bkw_frw,
-                                          uint32_t requested_int_ext,
-                                          uint32_t requested_string)
+                                          uint32_t rq_layer, uint32_t rq_bkw_frw, uint32_t rq_int_ext, uint32_t rq_string)
 {
- // loop over all input detectors
-  for(vector<uint32_t>::const_iterator it = inputDetRawIds.begin(); it!=inputDetRawIds.end();it++){
-    uint32_t therawid = (*it);                  // raw id of single detector
-    TIBDetId potentialTIB = TIBDetId(therawid); // build TIBDetId, at this point is just DetId, but do not want to cast twice
-    if( potentialTIB.subdetId() ==  int (StripSubdetector::TIB) ){ // check if subdetector field is a TIB, both tested numbers are int
-      if( // check if TIB is from the ones requested
-         (    (potentialTIB.layer()==requested_layer) || requested_layer==0 )  // take everything if default value is 0
-         && ( ((potentialTIB.string()).at(0)==(requested_bkw_frw)) || requested_bkw_frw==0 )
-         && ( ((potentialTIB.string()).at(1)==(requested_int_ext)) || requested_int_ext==0 )
-         && ( ((potentialTIB.string()).at(2)==requested_string) || requested_string==0 )
-         ){
-        tibDetRawIds.push_back(therawid);       // add detector to list of selected TIBdets
-      }
-    }
-  }
+  std::copy_if(std::begin(inputDetRawIds), std::end(inputDetRawIds), std::back_inserter(tibDetRawIds),
+      [tTopo,rq_layer,rq_bkw_frw,rq_int_ext,rq_string] ( DetId det ) {
+        return ( ( StripSubdetector::TIB == det.subdetId() )
+                 // check if TIB is from the ones requested
+                 // take everything if default value is 0
+            &&  ( (rq_layer   == 0) || (rq_layer   == tTopo->tibLayer (det)) )
+            &&  ( (rq_bkw_frw == 0) || (rq_bkw_frw == tTopo->tibSide  (det)) )
+            &&  ( (rq_int_ext == 0) || (rq_int_ext == tTopo->tibOrder (det)) )
+            &&  ( (rq_string  == 0) || (rq_string  == tTopo->tibString(det)) )
+            );
+      });
+}
+
+void SiStripSubStructure::getTIDDetectors(const std::vector<uint32_t> & inputDetRawIds, std::vector<uint32_t> & tidDetRawIds,
+                                          const TrackerTopology* tTopo,
+                                          uint32_t rq_side, uint32_t rq_wheel, uint32_t rq_ring, uint32_t rq_ster)
+{
+  std::copy_if(std::begin(inputDetRawIds), std::end(inputDetRawIds), std::back_inserter(tidDetRawIds),
+      [tTopo,rq_side,rq_wheel,rq_ring,rq_ster] ( DetId det ) {
+        return ( ( StripSubdetector::TID == det.subdetId() )
+                 // check if TID is from the ones requested
+                 // take everything if default value is 0
+            &&  ( (rq_side  == 0) || (rq_side  == tTopo->tidSide  (det)) )
+            &&  ( (rq_wheel == 0) || (rq_wheel == tTopo->tidWheel (det)) )
+            &&  ( (rq_ring  == 0) || (rq_ring  == tTopo->tidRing  (det)) )
+            &&  ( (rq_ster  == 0) || (rq_ster  == tTopo->tidStereo(det)) )
+            );
+      });
+}
+
+void SiStripSubStructure::getTOBDetectors(const std::vector<uint32_t> & inputDetRawIds, std::vector<uint32_t> & tobDetRawIds,
+                                          const TrackerTopology* tTopo,
+                                          uint32_t rq_layer, uint32_t rq_bkw_frw, uint32_t rq_rod)
+{
+  std::copy_if(std::begin(inputDetRawIds), std::end(inputDetRawIds), std::back_inserter(tobDetRawIds),
+      [tTopo,rq_layer,rq_bkw_frw,rq_rod] ( DetId det ) {
+        return ( ( StripSubdetector::TOB == det.subdetId() )
+                 // check if TOB is from the ones requested
+                 // take everything if default value is 0
+            &&  ( (rq_layer   == 0) || (rq_layer   == tTopo->tobLayer (det)) )
+            &&  ( (rq_bkw_frw == 0) || (rq_bkw_frw == tTopo->tobSide  (det)) )
+            &&  ( (rq_rod     == 0) || (rq_rod     == tTopo->tobRod   (det)) )
+            );
+      });
 }
 
 
-void SiStripSubStructure::getTIDDetectors(const std::vector<uint32_t> & inputDetRawIds,
-                                          std::vector<uint32_t> & tidDetRawIds,
+void SiStripSubStructure::getTECDetectors(const std::vector<uint32_t> & inputDetRawIds, std::vector<uint32_t> & tecDetRawIds,
                                           const TrackerTopology* tTopo,
-                                          uint32_t requested_side,
-                                          uint32_t requested_wheel,
-                                          uint32_t requested_ring,
-                                          uint32_t requested_ster)
+                                          uint32_t rq_side, uint32_t rq_wheel, uint32_t rq_petal_bkw_frw, uint32_t rq_petal, uint32_t rq_ring, uint32_t rq_ster)
 {
- // loop over all input detectors
-  for(vector<uint32_t>::const_iterator it = inputDetRawIds.begin(); it!=inputDetRawIds.end();it++){
-    uint32_t therawid = (*it);                  // raw id of single detector
-    TIDDetId potentialTID = TIDDetId(therawid); // build TIDDetId, at this point is just DetId, but do not want to cast twice
-    if( potentialTID.subdetId() ==  int (StripSubdetector::TID) ){ // check if subdetector field is a TID, both tested numbers are int
-      if( // check if TID is from the ones requested
-         (    (potentialTID.side()==requested_side) || requested_side==0 )  // take everything if default value is 0
-         && ( (potentialTID.wheel()==requested_wheel) || requested_wheel==0 )
-         && ( (potentialTID.ring()==requested_ring) || requested_ring==0 )
-         && ( (potentialTID.stereo()==requested_ster) || requested_ster==0 )
-         ){
-        tidDetRawIds.push_back(therawid);       // add detector to list of selected TIDdets
-      }
-    }
-  }
+  std::copy_if(std::begin(inputDetRawIds), std::end(inputDetRawIds), std::back_inserter(tecDetRawIds),
+      [tTopo,rq_side,rq_wheel,rq_petal_bkw_frw,rq_petal,rq_ring,rq_ster] ( DetId det ) {
+        return ( ( StripSubdetector::TEC == det.subdetId() )
+                 // check if TEC is from the ones requested
+                 // take everything if default value is 0
+            &&  ( (rq_side          == 0) || (rq_side            == tTopo->tecSide       (det)) )
+            &&  ( (rq_wheel         == 0) || (rq_wheel           == tTopo->tecWheel      (det)) )
+            &&  ( (rq_petal_bkw_frw == 0) || (rq_petal_bkw_frw-1 == tTopo->tecOrder      (det)) )
+            &&  ( (rq_petal         == 0) || (rq_petal           == tTopo->tecPetalNumber(det)) )
+            &&  ( (rq_ring          == 0) || (rq_ring            == tTopo->tecRing       (det)) )
+            &&  ( (rq_ster          == 0) || (rq_ster            == tTopo->tecStereo     (det)) )
+            );
+      });
 }
-
-
-void SiStripSubStructure::getTOBDetectors(const std::vector<uint32_t> & inputDetRawIds,
-                                          std::vector<uint32_t> & tobDetRawIds,
-                                          const TrackerTopology* tTopo,
-                                          uint32_t requested_layer,
-                                          uint32_t requested_bkw_frw,
-                                          uint32_t requested_rod)
-{
- // loop over all input detectors
-  for(vector<uint32_t>::const_iterator it = inputDetRawIds.begin(); it!=inputDetRawIds.end();it++){
-    uint32_t therawid = (*it);                  // raw id of single detector
-    TOBDetId potentialTOB = TOBDetId(therawid); // build TOBDetId, at this point is just DetId, but do not want to cast twice
-    if( potentialTOB.subdetId() ==  int (StripSubdetector::TOB) ){ // check if subdetector field is a TOB, both tested numbers are int
-      if( // check if TOB is from the ones requested
-         (    (potentialTOB.layer()==requested_layer) || requested_layer==0 )  // take everything if default value is 0
-         && ( ((potentialTOB.rod()).at(0)==(requested_bkw_frw)) || requested_bkw_frw==0 )
-         && ( ((potentialTOB.rod()).at(1)==requested_rod) || requested_rod==0 )
-         ){
-        tobDetRawIds.push_back(therawid);       // add detector to list of selected TOBdets
-      }
-    }
-  }
-}
-
-
-void SiStripSubStructure::getTECDetectors(const std::vector<uint32_t> & inputDetRawIds,
-                                          std::vector<uint32_t> & tecDetRawIds,
-                                          const TrackerTopology* tTopo,
-                                          uint32_t requested_side,
-                                          uint32_t requested_wheel,
-                                          uint32_t requested_petal_bkw_frw,
-                                          uint32_t requested_petal,
-                                          uint32_t requested_ring,
-                                          uint32_t requested_ster)
-{
- // loop over all input detectors
-  for(vector<uint32_t>::const_iterator it = inputDetRawIds.begin(); it!=inputDetRawIds.end();it++){
-    uint32_t therawid = (*it);                  // raw id of single detector
-    TECDetId potentialTEC = TECDetId(therawid); // build TECDetId, at this point is just DetId, but do not want to cast twice
-    if( potentialTEC.subdetId() ==  int (StripSubdetector::TEC) ){ // check if subdetector field is a TEC, both tested numbers are int
-      if( // check if TEC is from the ones requested
-         (    (potentialTEC.side()==requested_side) || requested_side==0 )  // take everything if default value is 0
-         && ( (potentialTEC.wheel()==requested_wheel) || requested_wheel==0 )
-         && ( ((potentialTEC.petal()).at(0)==(requested_petal_bkw_frw-1)) || requested_petal_bkw_frw==0 )
-         && ( ((potentialTEC.petal()).at(1)==requested_petal) || requested_petal==0 )
-         && ( (potentialTEC.ring()==requested_ring) || requested_ring==0 )
-         && ( (potentialTEC.stereo()==requested_ster) || requested_ster==0 )
-         ){
-        tecDetRawIds.push_back(therawid);       // add detector to list of selected TECdets
-      }
-    }
-  }
-}
-
-

--- a/RecoLocalTracker/SiStripClusterizer/test/shotTest_withReClustering_cfg.py
+++ b/RecoLocalTracker/SiStripClusterizer/test/shotTest_withReClustering_cfg.py
@@ -23,20 +23,17 @@ process.source = cms.Source ( "PoolSource",
 #------------------------------------------
 # Load standard sequences.
 #------------------------------------------
-process.load('Configuration/StandardSequences/MagneticField_AutoFromDBCurrent_cff')
-process.load('Configuration/StandardSequences/GeometryIdeal_cff')
-
-
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
-process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
-process.load("Configuration/StandardSequences/Reconstruction_cff")
-process.load('Configuration/EventContent/EventContent_cff')
+process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.Reconstruction_cff")
 
 #------------------------------------------
 # Load ClusterToDigiProducer
 #------------------------------------------
-
 
 process.load('RecoLocalTracker.SiStripClusterizer.SiStripClusterToDigiProducer_cfi')
 
@@ -51,9 +48,7 @@ process.siStripClustersNew.Clusterizer.RemoveApvShots = cms.bool(True)
 # Load DQM 
 #------------------------------------------
 
-process.DQMStore = cms.Service("DQMStore")
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 
 process.load("DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi")
 
@@ -75,7 +70,7 @@ process.SiStripMonitorClusterNew.TH1ClusterDigiPos.moduleswitchon= cms.bool(True
 #------------------------------------------
 # Load apvshotanalyzer
 #------------------------------------------
-
+process.load("DPGAnalysis.SiStripTools.eventwithhistoryproducerfroml1abc_cfi")
 process.load("DPGAnalysis.SiStripTools.apvshotsanalyzer_cfi")
 process.apvshotsanalyzer.digiCollection.moduleLabel = "siStripClustersToDigis" 
 
@@ -92,6 +87,7 @@ process.skimming = cms.EDFilter("FilterOutScraping",
                                 )
 
 process.outpath = cms.EndPath(process.skimming+
+                              process.consecutiveHEs+
                               process.siStripDigis+
                               process.siStripZeroSuppression+
                               process.siStripClusters+

--- a/RecoLocalTracker/SiStripClusterizer/test/testClusterToDigi_cfg.py
+++ b/RecoLocalTracker/SiStripClusterizer/test/testClusterToDigi_cfg.py
@@ -18,15 +18,13 @@ process.source = cms.Source ( "PoolSource",
 #------------------------------------------
 # Load standard sequences.
 #------------------------------------------
-process.load('Configuration/StandardSequences/MagneticField_AutoFromDBCurrent_cff')
-process.load('Configuration/StandardSequences/GeometryIdeal_cff')
-
-
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
-process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
-process.load("Configuration/StandardSequences/Reconstruction_cff")
-process.load('Configuration/EventContent/EventContent_cff')
+process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.Reconstruction_cff")
 
 #------------------------------------------
 # Load ClusterToDigiProducer
@@ -55,9 +53,7 @@ process.recotrackout = cms.OutputModule("PoolOutputModule",
 # Load DQM 
 #------------------------------------------
 
-process.DQMStore = cms.Service("DQMStore")
-process.TkDetMap = cms.Service("TkDetMap")
-process.SiStripDetInfoFileReader = cms.Service("SiStripDetInfoFileReader")
+process.load("DQM.SiStripCommon.TkHistoMap_cff")
 
 process.load("DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi")
 

--- a/SUSYBSMAnalysis/HSCP/plugins/HSCPTreeBuilder.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/HSCPTreeBuilder.cc
@@ -55,7 +55,6 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
-#include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 

--- a/Validation/RecoTrack/src/SiStripTrackingRecHitsValid.cc
+++ b/Validation/RecoTrack/src/SiStripTrackingRecHitsValid.cc
@@ -1207,8 +1207,6 @@ void SiStripTrackingRecHitsValid::createMEs(DQMStore::IBooker & ibooker,const ed
   // get list of active detectors from SiStripDetCabling 
   std::vector<uint32_t> activeDets;
   SiStripDetCabling_->addActiveDetectorsRawIds(activeDets);
-    
-  SiStripSubStructure substructure;
 
   SiStripFolderOrganizer folder_organizer;
   // folder_organizer.setSiStripFolderName(topFolderName_);
@@ -1247,20 +1245,20 @@ void SiStripTrackingRecHitsValid::createMEs(DQMStore::IBooker & ibooker,const ed
       std::vector<uint32_t> layerDetIds;        
       if (lname == tec) { 
         if (lnumber > 0) {
-	  substructure.getTECDetectors(activeDets,layerDetIds,2,0,0,0,abs(lnumber),0);
+	  SiStripSubStructure::getTECDetectors(activeDets,layerDetIds,tTopo,2,0,0,0,abs(lnumber),0);
         } else if (lnumber < 0) {
-	  substructure.getTECDetectors(activeDets,layerDetIds,1,0,0,0,abs(lnumber),0);
+	  SiStripSubStructure::getTECDetectors(activeDets,layerDetIds,tTopo,1,0,0,0,abs(lnumber),0);
         }
       } else if (lname == tid) {
         if (lnumber > 0) {
-	  substructure.getTIDDetectors(activeDets,layerDetIds,2,0,abs(lnumber),0);
+	  SiStripSubStructure::getTIDDetectors(activeDets,layerDetIds,tTopo,2,0,abs(lnumber),0);
         } else if (lnumber < 0) {
-	  substructure.getTIDDetectors(activeDets,layerDetIds,1,0,abs(lnumber),0);
+	  SiStripSubStructure::getTIDDetectors(activeDets,layerDetIds,tTopo,1,0,abs(lnumber),0);
         }
       } else if (lname == tob) {
-	substructure.getTOBDetectors(activeDets,layerDetIds,lnumber,0,0);
+	SiStripSubStructure::getTOBDetectors(activeDets,layerDetIds,tTopo,lnumber,0,0);
       } else if (lname == tib) {
-	substructure.getTIBDetectors(activeDets,layerDetIds,lnumber,0,0,0);
+	SiStripSubStructure::getTIBDetectors(activeDets,layerDetIds,tTopo,lnumber,0,0,0);
       }
       LayerDetMap[label] = layerDetIds;
 
@@ -1284,25 +1282,25 @@ void SiStripTrackingRecHitsValid::createMEs(DQMStore::IBooker & ibooker,const ed
       const std::string& stereolname = det_layer_pair.first;
       if ( stereolname == tec && (tTopo->tecIsStereo(detid)) ) {
         if ( stereolnumber > 0 ) {
-          substructure.getTECDetectors(activeDets,stereoandmatchedDetIds,2,0,0,0,abs(stereolnumber),1);
+          SiStripSubStructure::getTECDetectors(activeDets,stereoandmatchedDetIds,tTopo,2,0,0,0,abs(stereolnumber),1);
           isStereo = true;
         } else if ( stereolnumber < 0 ) {
-          substructure.getTECDetectors(activeDets,stereoandmatchedDetIds,1,0,0,0,abs(stereolnumber),1);
+          SiStripSubStructure::getTECDetectors(activeDets,stereoandmatchedDetIds,tTopo,1,0,0,0,abs(stereolnumber),1);
           isStereo = true;
         }
       } else if ( stereolname == tid && (tTopo->tidIsStereo(detid)) ) {
         if ( stereolnumber > 0 ) {
-          substructure.getTIDDetectors(activeDets,stereoandmatchedDetIds,2,0,abs(stereolnumber),1);
+          SiStripSubStructure::getTIDDetectors(activeDets,stereoandmatchedDetIds,tTopo,2,0,abs(stereolnumber),1);
           isStereo = true;
         } else if ( stereolnumber < 0 ) {
-          substructure.getTIDDetectors(activeDets,stereoandmatchedDetIds,1,0,abs(stereolnumber),1);
+          SiStripSubStructure::getTIDDetectors(activeDets,stereoandmatchedDetIds,tTopo,1,0,abs(stereolnumber),1);
           isStereo = true;
         }
       } else if ( stereolname == tob && (tTopo->tobIsStereo(detid)) ) {
-        substructure.getTOBDetectors(activeDets,stereoandmatchedDetIds,stereolnumber,0,0);
+        SiStripSubStructure::getTOBDetectors(activeDets,stereoandmatchedDetIds,tTopo,stereolnumber,0,0);
         isStereo = true;
       } else if ( stereolname == tib && (tTopo->tibIsStereo(detid)) ) {
-        substructure.getTIBDetectors(activeDets,stereoandmatchedDetIds,stereolnumber,0,0,0);
+        SiStripSubStructure::getTIBDetectors(activeDets,stereoandmatchedDetIds,tTopo,stereolnumber,0,0,0);
         isStereo = true;
       }
 

--- a/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
@@ -527,8 +527,6 @@ void SiStripRecHitsValid::createMEs(DQMStore::IBooker & ibooker,const edm::Event
   // get list of active detectors from SiStripDetCabling 
   std::vector<uint32_t> activeDets;
   SiStripDetCabling_->addActiveDetectorsRawIds(activeDets);
-    
-  SiStripSubStructure substructure;
 
   SiStripFolderOrganizer folder_organizer;
   // folder_organizer.setSiStripFolderName(topFolderName_);
@@ -562,20 +560,20 @@ void SiStripRecHitsValid::createMEs(DQMStore::IBooker & ibooker,const edm::Event
       std::vector<uint32_t> layerDetIds;
       if (lname == tec) {
         if (lnumber > 0) {
-	  substructure.getTECDetectors(activeDets,layerDetIds,2,0,0,0,abs(lnumber),0);
+	  SiStripSubStructure::getTECDetectors(activeDets,layerDetIds,tTopo,2,0,0,0,abs(lnumber),0);
         } else if (lnumber < 0) {
-	  substructure.getTECDetectors(activeDets,layerDetIds,1,0,0,0,abs(lnumber),0);
+	  SiStripSubStructure::getTECDetectors(activeDets,layerDetIds,tTopo,1,0,0,0,abs(lnumber),0);
         }
       } else if (lname == tid) {
          if (lnumber > 0) {
-	   substructure.getTIDDetectors(activeDets,layerDetIds,2,0,abs(lnumber),0);
+	   SiStripSubStructure::getTIDDetectors(activeDets,layerDetIds,tTopo,2,0,abs(lnumber),0);
         } else if (lnumber < 0) {
-	  substructure.getTIDDetectors(activeDets,layerDetIds,1,0,abs(lnumber),0);
+	  SiStripSubStructure::getTIDDetectors(activeDets,layerDetIds,tTopo,1,0,abs(lnumber),0);
         }
       } else if (lname == tob) {
-	substructure.getTOBDetectors(activeDets,layerDetIds,lnumber,0,0);
+	SiStripSubStructure::getTOBDetectors(activeDets,layerDetIds,tTopo,lnumber,0,0);
       } else if (lname == tib) {
-	substructure.getTIBDetectors(activeDets,layerDetIds,lnumber,0,0,0);
+	SiStripSubStructure::getTIBDetectors(activeDets,layerDetIds,tTopo,lnumber,0,0,0);
       }  
       LayerDetMap[label] = layerDetIds;
 
@@ -600,25 +598,25 @@ void SiStripRecHitsValid::createMEs(DQMStore::IBooker & ibooker,const edm::Event
       const std::string& stereolname = det_layer_pair.first;
       if ( stereolname == tec && (tTopo->tecIsStereo(detid)) ) {
         if ( stereolnumber > 0 ) {
-          substructure.getTECDetectors(activeDets,stereoandmatchedDetIds,2,0,0,0,abs(stereolnumber),1);
+          SiStripSubStructure::getTECDetectors(activeDets,stereoandmatchedDetIds,tTopo,2,0,0,0,abs(stereolnumber),1);
 	  isStereo = true;
         } else if ( stereolnumber < 0 ) {
-	  substructure.getTECDetectors(activeDets,stereoandmatchedDetIds,1,0,0,0,abs(stereolnumber),1);
+	  SiStripSubStructure::getTECDetectors(activeDets,stereoandmatchedDetIds,tTopo,1,0,0,0,abs(stereolnumber),1);
 	  isStereo = true;
         }
       } else if ( stereolname == tid && (tTopo->tidIsStereo(detid)) ) {
         if ( stereolnumber > 0 ) {
-	  substructure.getTIDDetectors(activeDets,stereoandmatchedDetIds,2,0,abs(stereolnumber),1);
+	  SiStripSubStructure::getTIDDetectors(activeDets,stereoandmatchedDetIds,tTopo,2,0,abs(stereolnumber),1);
 	  isStereo = true;
         } else if ( stereolnumber < 0 ) {
-	  substructure.getTIDDetectors(activeDets,stereoandmatchedDetIds,1,0,abs(stereolnumber),1);
+	  SiStripSubStructure::getTIDDetectors(activeDets,stereoandmatchedDetIds,tTopo,1,0,abs(stereolnumber),1);
 	  isStereo = true;
         }
       } else if ( stereolname == tob && (tTopo->tobIsStereo(detid)) ) {
-	substructure.getTOBDetectors(activeDets,stereoandmatchedDetIds,stereolnumber,0,0);
+	SiStripSubStructure::getTOBDetectors(activeDets,stereoandmatchedDetIds,tTopo,stereolnumber,0,0);
 	isStereo = true;
       } else if ( stereolname == tib && (tTopo->tibIsStereo(detid)) ) {
-	substructure.getTIBDetectors(activeDets,stereoandmatchedDetIds,stereolnumber,0,0,0);
+	SiStripSubStructure::getTIBDetectors(activeDets,stereoandmatchedDetIds,tTopo,stereolnumber,0,0,0);
 	isStereo = true;
       } 
 


### PR DESCRIPTION
This pull request migrates SiStripSubstructure and the classes that use it (most notably: TkDetMap, and through that TkHistoMap) away from the specific strip tracker DetId classes (TIBDetId etc.), see https://twiki.cern.ch/twiki/bin/viewauth/CMS/SiStripLocalReco_notesSiStripSubDetIdToTrackerTopologyMigration for more context.

Summary of the changes:
- changed `SiStripSubStructure` from a class without data members to a namespace with methods (that also take a `const TrackerTopology*` argument)
- changed `TkDetMap` into an EventSetup product (it only needs a `TrackerTopology` from the EventSetup, so I put it into the `TrackerTopologyRcd`, following the advice in https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideEDMESWhichRecord#Data_built_from_data_in_one_Reco, but it also uses the `SiStripDetInfoFileReader` service to get the list of active detectors, so this may not be the ultimate solution, e.g. if this is migrated to the EventSetup as well at some point). I also updated the interface a bit (passing arguments by value for small types, const reference for big types, and non-const reference only if necessary for caching).
- take a `const TkDetMap*` argument in the `TkHistoMap` constructor, instead of loading it as a service (since I was going through all constructors, I also updated `TkHistoMap*` members to `std::unique_ptr<TkHistoMap>` for some plugins)
- adapted the configs that used to load the `TkDetMap` service. For those where the geometry is loaded from the global tag, this is straightforward, but there are some test/calibration/standalone cases where this is not done, so I added a few more lines there - I tried to run them to verify that they do not fail before getting the `TkDetMap` (changing global tags, config errors and input files for the outdated ones if necessary), but that is not a complete test, so please verify that everything is fine in case I edited a config file that is used in some workflow (I did not spot problems with `runTheMatrix.py -l limited -i all`, but that may leave some things uncovered).

CC @OlivierBondu @alesaggio @vidalm 
Tracked at https://github.com/cms-sw/cmssw/issues/19398